### PR TITLE
[CS] Code Style fixes for administrator/components/com_redirect/

### DIFF
--- a/administrator/components/com_redirect/models/link.php
+++ b/administrator/components/com_redirect/models/link.php
@@ -245,6 +245,7 @@ class RedirectModelLink extends JModelAdmin
 			{
 				$query->set($db->quoteName('comment') . ' = ' . $db->quote($comment));
 			}
+
 			$db->setQuery($query);
 
 			try

--- a/administrator/components/com_redirect/models/links.php
+++ b/administrator/components/com_redirect/models/links.php
@@ -193,7 +193,7 @@ class RedirectModelLinks extends JModelList
 	 *
 	 * @param   array  $batch_urls  Array of URLs to enter into the database
 	 *
-	 * @return bool
+	 * @return boolean
 	 */
 	public function batchProcess($batch_urls)
 	{

--- a/administrator/components/com_redirect/tables/link.php
+++ b/administrator/components/com_redirect/tables/link.php
@@ -47,6 +47,7 @@ class RedirectTableLink extends JTable
 
 			return false;
 		}
+
 		// Check for NOT NULL.
 		if (empty($this->referer))
 		{

--- a/administrator/components/com_redirect/views/links/view.html.php
+++ b/administrator/components/com_redirect/views/links/view.html.php
@@ -136,7 +136,7 @@ class RedirectViewLinks extends JViewLegacy
 				JToolbarHelper::unpublish('links.unpublish', 'JTOOLBAR_DISABLE', true);
 			}
 
-			if ($state->get('filter.state') != -1 )
+			if ($state->get('filter.state') != -1)
 			{
 				JToolbarHelper::divider();
 


### PR DESCRIPTION
Pull Request for Issue code style fixes

### Summary of Changes
- No blank line found before/after control structure
- Expected "boolean" but found "bool" for function return type
- Expected 0 spaces before closing bracket

[Automatically fixed with Joomla code standards 2.0.0 PHPCS2-alpha2 fixers](https://github.com/joomla/coding-standards/releases/tag/2.0.0-alpha2)

None of the manual only fixes have been applied

### Testing Instructions
Merge by code review

### Expected result
code style has been applied as listed above, old code style testing on drone does not error.

### Actual result
code style had not been applied. [Autofixers from the Joomla code standards 2.0.0 PHPCS2 alpha2](https://github.com/joomla/coding-standards/releases/tag/2.0.0-alpha2) were used to implement fixable code style

### Documentation Changes Required
none
