### PR TITLE
[4.0] Installation: email field is not a password field

### DIFF
--- a/installation/forms/setup.xml
+++ b/installation/forms/setup.xml
@@ -20,6 +20,15 @@
 		/>
 
 		<field
+				name="admin_user"
+				type="text"
+				id="admin_user"
+				class="form-control"
+				label="INSTL_ADMIN_USER_DESC"
+				required="true"
+		/>
+
+		<field
 				name="admin_email"
 				type="email"
 				id="admin_email"
@@ -30,12 +39,9 @@
 		/>
 
 		<field
-				name="admin_user"
+				name="dummy_input"
 				type="text"
-				id="admin_user"
-				class="form-control"
-				label="INSTL_ADMIN_USER_DESC"
-				required="true"
+				id="dummy_input"
 		/>
 
 		<field

--- a/installation/tmpl/setup/default.php
+++ b/installation/tmpl/setup/default.php
@@ -57,6 +57,8 @@ defined('_JEXEC') or die;
 					<?php echo $this->form->getLabel('admin_email'); ?>
 					<?php echo $this->form->getInput('admin_email'); ?>
 				</div>
+				<div style="display: none;"> 
+					<?php echo $this->form->getInput('dummy_input'); ?>
 				<div class="form-group">
 					<?php echo $this->form->getLabel('admin_password'); ?>
 					<?php echo $this->form->getInput('admin_password'); ?>


### PR DESCRIPTION
Pull Request for Issue #18793
### Summary of Changes
1. Added dummy field in installation/tmpl/setup/default.php to prevent email field autofill with password in Firefox browser.
2. Defined the field in installation/forms/setup.xml
3. Moved the adnin field in installation/forms/setup.xml to match the order in the default.php



### Testing Instructions
Download and unzip the Joomla 4 zip
Replace the  installation/tmpl/setup/default.php to prevent email field autofill with password  and installation/forms/setup.xml files
Run the install in Firefox browser


### Expected result
Clicking in the email field (page 2 of the install) displays a list of emails not passwords


### Actual result
Installing without the PR
Clicking in the email field (page 2 of the install) displays a list Passwords

Installing with the installation/tmpl/setup/default.php to prevent email field autofill with password  and installation/forms/setup.xml files
Clicking in the email field (page 2 of the install) displays a list of emails not passwords


### Documentation Changes Required
None
