### PR TITLE
Tag and bracket completion and matching bug

### DIFF
--- a/plugins/editors/codemirror/codemirror.php
+++ b/plugins/editors/codemirror/codemirror.php
@@ -245,7 +245,7 @@ class PlgEditorCodemirror extends JPlugin
 		}
 
 		// Special options for tagged modes (xml/html).
-		if (in_array($options->mode, array('xml', 'htmlmixed', 'htmlembedded', 'php')))
+		if (in_array($options->mode, array('xml', 'html', 'php')))
 		{
 			// Autogenerate closing tags (html/xml only).
 			$options->autoCloseTags = (boolean) $this->params->get('autoCloseTags', true);
@@ -255,7 +255,7 @@ class PlgEditorCodemirror extends JPlugin
 		}
 
 		// Special options for non-tagged modes.
-		if (!in_array($options->mode, array('xml', 'htmlmixed', 'htmlembedded')))
+		if (!in_array($options->mode, array('xml', 'html')))
 		{
 			// Autogenerate closing brackets.
 			$options->autoCloseBrackets = (boolean) $this->params->get('autoCloseBrackets', true);


### PR DESCRIPTION
This fixes a bug where the tag/bracket completion and matching settings are not applied. This bug was introduced in a recent change to this plugin which moved the mode selection logic from php to javascript. So it's my fault. 

Pull Request for Issue # .

### Summary of Changes
Stop expecting the mode to be something like 'htmlembbed' or 'htmlmixed' and just expect 'html'.


### Testing Instructions
Make sure the tag or bracket matching and completion options are turned on in the codemirror plugin. Use codemirror to write some html or maybe javascript or css. 


### Expected result
Your tags and brackets should be autocompleted and/or matched (when the cursor is on one, it's match should be highlighted). 


### Actual result
This was not working in html documents (articles, etc). 


### Documentation Changes Required
No, it's just a fix for a recently introduced bug. With any luck, no one will notice it ever happened.
