### PR TITLE
[3.9] Deprecate New MVC classes

### DIFF
--- a/libraries/joomla/controller/base.php
+++ b/libraries/joomla/controller/base.php
@@ -14,7 +14,8 @@ use Joomla\Application\AbstractApplication;
 /**
  * Joomla Platform Base Controller Class
  *
- * @since  12.1
+ * @since       12.1
+ * @deprecated  5.0 Use the default MVC library
  */
 abstract class JControllerBase implements JController
 {

--- a/libraries/joomla/controller/controller.php
+++ b/libraries/joomla/controller/controller.php
@@ -14,7 +14,8 @@ defined('JPATH_PLATFORM') or die;
 /**
  * Joomla Platform Controller Interface
  *
- * @since  12.1
+ * @since       12.1
+ * @deprecated  5.0 Use the default MVC library
  */
 interface JController extends Serializable
 {

--- a/libraries/joomla/model/base.php
+++ b/libraries/joomla/model/base.php
@@ -14,7 +14,8 @@ use Joomla\Registry\Registry;
 /**
  * Joomla Platform Base Model Class
  *
- * @since  12.1
+ * @since       12.1
+ * @deprecated  5.0 Use the default MVC library
  */
 abstract class JModelBase implements JModel
 {

--- a/libraries/joomla/model/database.php
+++ b/libraries/joomla/model/database.php
@@ -14,7 +14,8 @@ use Joomla\Registry\Registry;
 /**
  * Joomla Platform Database Model Class
  *
- * @since  12.1
+ * @since       12.1
+ * @deprecated  5.0 Use the default MVC library
  */
 abstract class JModelDatabase extends JModelBase
 {

--- a/libraries/joomla/model/model.php
+++ b/libraries/joomla/model/model.php
@@ -14,7 +14,8 @@ use Joomla\Registry\Registry;
 /**
  * Joomla Platform Model Interface
  *
- * @since  12.1
+ * @since       12.1
+ * @deprecated  5.0 Use the default MVC library
  */
 interface JModel
 {

--- a/libraries/joomla/view/base.php
+++ b/libraries/joomla/view/base.php
@@ -12,7 +12,8 @@ defined('JPATH_PLATFORM') or die;
 /**
  * Joomla Platform Base View Class
  *
- * @since  12.1
+ * @since       12.1
+ * @deprecated  5.0 Use the default MVC library
  */
 abstract class JViewBase implements JView
 {

--- a/libraries/joomla/view/html.php
+++ b/libraries/joomla/view/html.php
@@ -14,7 +14,8 @@ jimport('joomla.filesystem.path');
 /**
  * Joomla Platform HTML View Class
  *
- * @since  12.1
+ * @since       12.1
+ * @deprecated  5.0 Use the default MVC library
  */
 abstract class JViewHtml extends JViewBase
 {

--- a/libraries/joomla/view/view.php
+++ b/libraries/joomla/view/view.php
@@ -12,7 +12,8 @@ defined('JPATH_PLATFORM') or die;
 /**
  * Joomla Platform View Interface
  *
- * @since  12.1
+ * @since       12.1
+ * @deprecated  5.0 Use the default MVC library
  */
 interface JView
 {


### PR DESCRIPTION
As discussed in #18526, the "New MVC" library should be deprecated for version 5 removal.