### PR TITLE
Save default field values [com_fields]

### DIFF
--- a/administrator/components/com_fields/models/field.php
+++ b/administrator/components/com_fields/models/field.php
@@ -579,32 +579,25 @@ class FieldsModelField extends JModelAdmin
 		$needsInsert = false;
 		$needsUpdate = false;
 
-		if ($field->default_value == $value)
+		$oldValue = $this->getFieldValue($fieldId, $itemId);
+		$value    = (array) $value;
+
+		if ($oldValue === null)
 		{
-			$needsDelete = true;
+			// No records available, doing normal insert
+			$needsInsert = true;
+		}
+		elseif (count($value) == 1 && count((array) $oldValue) == 1)
+		{
+			// Only a single row value update can be done
+			$needsUpdate = true;
 		}
 		else
 		{
-			$oldValue = $this->getFieldValue($fieldId, $itemId);
-			$value    = (array) $value;
-
-			if ($oldValue === null)
-			{
-				// No records available, doing normal insert
-				$needsInsert = true;
-			}
-			elseif (count($value) == 1 && count((array) $oldValue) == 1)
-			{
-				// Only a single row value update can be done
-				$needsUpdate = true;
-			}
-			else
-			{
-				// Multiple values, we need to purge the data and do a new
-				// insert
-				$needsDelete = true;
-				$needsInsert = true;
-			}
+			// Multiple values, we need to purge the data and do a new
+			// insert
+			$needsDelete = true;
+			$needsInsert = true;
 		}
 
 		if ($needsDelete)


### PR DESCRIPTION
Pull Request for Issue #18546.

### Summary of Changes

Added saving of field values matching the default values.

### Testing Instructions

Set the default value for the field. In the article, select or enter the default value in the field. Save the article. Check preserved-whether the value and the correctness of its output at the front of the site.

### Expected result

In the website, nothing has changed, and a value equal to the default stored in the database in table #__fields_values.

### Actual result

In the website, nothing has changed, and a value equal to the default stored in the database in table #__fields_values.

### Documentation Changes Required

No