### PR TITLE
[4.0] Deprecate CMSApplication::getInstance

### DIFF
--- a/administrator/components/com_finder/Controller/IndexerController.php
+++ b/administrator/components/com_finder/Controller/IndexerController.php
@@ -11,6 +11,7 @@ namespace Joomla\Component\Finder\Administrator\Controller;
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Application\CMSApplication;
+use Joomla\CMS\Application\SiteApplication;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\MVC\Controller\BaseController;
 use Joomla\CMS\Document\Document;
@@ -179,7 +180,7 @@ class IndexerController extends BaseController
 		$admin = clone Factory::getApplication();
 
 		// Get the site app.
-		$site = CMSApplication::getInstance('site');
+		$site = Factory::getContainer()->get(SiteApplication::class);
 
 		// Swap the app.
 		$app = Factory::getApplication();

--- a/components/com_config/Controller/ModulesController.php
+++ b/components/com_config/Controller/ModulesController.php
@@ -11,7 +11,9 @@ namespace Joomla\Component\Config\Site\Controller;
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Application\AdministratorApplication;
 use Joomla\CMS\Application\CMSApplication;
+use Joomla\CMS\Factory;
 use Joomla\CMS\MVC\Controller\BaseController;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
@@ -99,7 +101,7 @@ class ModulesController extends BaseController
 
 		\JLoader::register('ModulesDispatcher', JPATH_ADMINISTRATOR . '/components/com_modules/dispatcher.php');
 
-		$app = \Joomla\CMS\Application\CmsApplication::getInstance('administrator');
+		$app = Factory::getContainer()->get(AdministratorApplication::class);
 		$app->loadLanguage($this->app->getLanguage());
 		$dispatcher      = new \ModulesDispatcher($app, $this->input);
 

--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -472,8 +472,9 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
 	 *
 	 * @return  CmsApplication
 	 *
-	 * @since   3.2
-	 * @throws  \RuntimeException
+	 * @since       3.2
+	 * @throws      \RuntimeException
+	 * @deprecated  5.0 Use \Joomla\CMS\Factory::getContainer()->get($name) instead
 	 */
 	public static function getInstance($name = null, $prefix = '\JApplication', Container $container = null)
 	{

--- a/libraries/src/Pathway/SitePathway.php
+++ b/libraries/src/Pathway/SitePathway.php
@@ -10,7 +10,8 @@ namespace Joomla\CMS\Pathway;
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\CMS\Application\CMSApplication;
+use Joomla\CMS\Application\SiteApplication;
+use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Multilanguage;
 
 /**
@@ -27,11 +28,11 @@ class SitePathway extends Pathway
 	 *
 	 * @since   1.5
 	 */
-	public function __construct($options = array())
+	public function __construct($options = array(), SiteApplication $app = null)
 	{
 		$this->pathway = array();
 
-		$app  = CMSApplication::getInstance('site');
+		$app  = $app ?: Factory::getContainer()->get(SiteApplication::class);
 		$menu = $app->getMenu();
 		$lang = \JFactory::getLanguage();
 

--- a/libraries/src/Router/SiteRouter.php
+++ b/libraries/src/Router/SiteRouter.php
@@ -11,8 +11,10 @@ namespace Joomla\CMS\Router;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Application\CMSApplication;
+use Joomla\CMS\Application\SiteApplication;
 use Joomla\CMS\Component\Router\RouterInterface;
 use Joomla\CMS\Component\Router\RouterLegacy;
+use Joomla\CMS\Factory;
 use Joomla\CMS\Menu\AbstractMenu;
 use Joomla\Cms\Uri\Uri as JUri;
 use Joomla\String\StringHelper;
@@ -58,7 +60,7 @@ class SiteRouter extends Router
 	 */
 	public function __construct(CMSApplication $app = null, AbstractMenu $menu = null)
 	{
-		$this->app  = $app ?: CMSApplication::getInstance('site');
+		$this->app  = $app ?: Factory::getContainer()->get(SiteApplication::class);
 		$this->menu = $menu ?: $this->app->getMenu();
 
 		// Add core rules


### PR DESCRIPTION
Ongoing effort to phase out getInstance code. This pr deprecates `CMSApplication::getInstance`.

I'm splitting #16918 into different pr's to be easier to review.