### PR TITLE
[4.0] Deprecate WebApplication::getInstance

### DIFF
--- a/libraries/src/Application/WebApplication.php
+++ b/libraries/src/Application/WebApplication.php
@@ -101,8 +101,9 @@ abstract class WebApplication extends AbstractWebApplication implements Dispatch
 	 *
 	 * @return  WebApplication
 	 *
-	 * @since   11.3
-	 * @throws  \RuntimeException
+	 * @since       11.3
+	 * @throws      \RuntimeException
+	 * @deprecated  5.0 Use \Joomla\CMS\Factory::getContainer()->get($name) instead
 	 */
 	public static function getInstance($name = null)
 	{


### PR DESCRIPTION
Ongoing effort to phase out getInstance code. This pr deprecates `WebApplication::getInstance`.

I'm splitting #16918 into different pr's to be easier to review.