### PR TITLE
[4.0] Fix build SEF URL for component view without own menu item

### DIFF
--- a/libraries/src/Router/SiteRouter.php
+++ b/libraries/src/Router/SiteRouter.php
@@ -479,7 +479,7 @@ class SiteRouter extends Router
 		$parts     = $crouter->build($query);
 		$tmp       = trim(implode('/', $parts));
 
-		$item = isset($query['Itemid']) ? $this->menu->getItem($query['Itemid']) : null;
+		$item = empty($query['Itemid']) ? null : $this->menu->getItem($query['Itemid']);
 
 		// Build the application route
 		if ($item !== null && $query['option'] === $item->component)

--- a/libraries/src/Router/SiteRouter.php
+++ b/libraries/src/Router/SiteRouter.php
@@ -465,9 +465,6 @@ class SiteRouter extends Router
 	 */
 	public function buildSefRoute(&$router, &$uri)
 	{
-		// Get the route
-		$route = $uri->getPath();
-
 		// Get the query data
 		$query = $uri->getQuery(true);
 
@@ -478,35 +475,29 @@ class SiteRouter extends Router
 
 		// Build the component route
 		$component = preg_replace('/[^A-Z0-9_\.-]/i', '', $query['option']);
-		$itemID    = !empty($query['Itemid']) ? $query['Itemid'] : null;
 		$crouter   = $this->getComponentRouter($component);
 		$parts     = $crouter->build($query);
 		$tmp       = trim(implode('/', $parts));
 
-		if (empty($query['Itemid']) && !empty($itemID))
-		{
-			$query['Itemid'] = $itemID;
-		}
+		$item = isset($query['Itemid']) ? $this->menu->getItem($query['Itemid']) : null;
 
 		// Build the application route
-		if (isset($query['Itemid']) && $item = $this->menu->getItem($query['Itemid']))
+		if ($item !== null && $query['option'] === $item->component)
 		{
-			if (is_object($item) && $query['option'] === $item->component)
+			if (!$item->home)
 			{
-				if (!$item->home)
-				{
-					$tmp = !empty($tmp) ? $item->route . '/' . $tmp : $item->route;
-				}
-
-				unset($query['Itemid']);
+				$tmp = $item->route . '/' . $tmp;
 			}
+
+			unset($query['Itemid']);
 		}
 		else
 		{
 			$tmp = 'component/' . substr($query['option'], 4) . '/' . $tmp;
 		}
 
-		$route .= '/' . $tmp;
+		// Get the route
+		$route = $uri->getPath() . '/' . $tmp;
 
 		// Unset unneeded query information
 		unset($query['option']);

--- a/libraries/src/Router/SiteRouter.php
+++ b/libraries/src/Router/SiteRouter.php
@@ -473,13 +473,14 @@ class SiteRouter extends Router
 			return;
 		}
 
+		// Get Menu Item
+		$item = empty($query['Itemid']) ? null : $this->menu->getItem($query['Itemid']);
+
 		// Build the component route
 		$component = preg_replace('/[^A-Z0-9_\.-]/i', '', $query['option']);
 		$crouter   = $this->getComponentRouter($component);
 		$parts     = $crouter->build($query);
 		$tmp       = trim(implode('/', $parts));
-
-		$item = empty($query['Itemid']) ? null : $this->menu->getItem($query['Itemid']);
 
 		// Build the application route
 		if ($item !== null && $query['option'] === $item->component)


### PR DESCRIPTION
Pull Request for Issue #18923

### Summary of Changes
1. Always add prefix `/component/[COMPONENT_NAME]/` if menu item component is not equal to `query[option]`.
2. Optimise code, remove a code that set again `$query['Itemid']`.
    I removed a way when the build rule can change menu route by changing value in `query['Itemid']`.
    This example describe old way that I removed.
```php
// Store Itemid in other variable
$itemID    = empty($query['Itemid']) ? null : $query['Itemid'];

$crouter   = $this->getComponentRouter($component);
// Now build rule can change query['Itemid']
$parts     = $crouter->build($query);

// Restore Itemid if deleted
if (empty($query['Itemid']) && $itemID)
{
	$query['Itemid'] = $itemID;
}

// After that we load menu item
$item = empty($query['Itemid']) ? null : $this->menu->getItem($query['Itemid']);
```

### Testing Instructions
See issue and code review.

### Expected result
SEF links is build in correct way.

Note:
IMO similar PR also can be applied to J.3.x