### PR TITLE
php 7.2 support count()

### DIFF
--- a/administrator/components/com_content/models/articles.php
+++ b/administrator/components/com_content/models/articles.php
@@ -275,7 +275,7 @@ class ContentModelArticles extends JModelList
 			: $categoryId;
 
 		// Case: Using both categories filter and by level filter
-		if (count($categoryId))
+		if (is_array($categoryId) && count($categoryId))
 		{
 			$categoryId = ArrayHelper::toInteger($categoryId);
 			$categoryTable = JTable::getInstance('Category', 'JTable');


### PR DESCRIPTION
Pull Request for Issue PHP 7.2 Support .

count() must now be an array or object.

### Summary of Changes

There must be 100+ files that must be changed, lets start first.

### Testing Instructions



### Expected result



### Actual result



### Documentation Changes Required

