### PR TITLE
Support for multiple download sources on update servers

### DIFF
--- a/administrator/components/com_installer/models/update.php
+++ b/administrator/components/com_installer/models/update.php
@@ -406,7 +406,7 @@ class InstallerModelUpdate extends JModelList
 		}
 
 		$url     = $update->downloadurl->_data;
-		$mirrors = $update->get('mirrors', array());
+		$sources = $update->get('downloadSources', array());
 
 		if ($extra_query = $update->get('extra_query'))
 		{
@@ -415,15 +415,18 @@ class InstallerModelUpdate extends JModelList
 		}
 
 		$mirror = 0;
-		while (!($p_file = JInstallerHelper::downloadPackage($url)) && isset($mirrors[$mirror]))
+
+		while (!($p_file = JInstallerHelper::downloadPackage($url)) && isset($sources[$mirror]))
 		{
-			$name = $mirrors[$mirror];
-			$url  = $update->$name->_data;
+			$name = $sources[$mirror];
+			$url  = $name->url;
+
 			if ($extra_query)
 			{
 				$url .= (strpos($url, '?') === false) ? '?' : '&amp;';
 				$url .= $extra_query;
 			}
+
 			$mirror++;
 		}
 

--- a/administrator/components/com_installer/models/update.php
+++ b/administrator/components/com_installer/models/update.php
@@ -405,7 +405,8 @@ class InstallerModelUpdate extends JModelList
 			return false;
 		}
 
-		$url = $update->downloadurl->_data;
+		$url     = $update->downloadurl->_data;
+		$mirrors = $update->get('mirrors', array());
 
 		if ($extra_query = $update->get('extra_query'))
 		{
@@ -413,7 +414,18 @@ class InstallerModelUpdate extends JModelList
 			$url .= $extra_query;
 		}
 
-		$p_file = JInstallerHelper::downloadPackage($url);
+		$mirror = 0;
+		while (!($p_file = JInstallerHelper::downloadPackage($url)) && isset($mirrors[$mirror]))
+		{
+			$name = $mirrors[$mirror];
+			$url  = $update->$name->_data;
+			if ($extra_query)
+			{
+				$url .= (strpos($url, '?') === false) ? '?' : '&amp;';
+				$url .= $extra_query;
+			}
+			$mirror++;
+		}
 
 		// Was the package downloaded?
 		if (!$p_file)

--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -251,9 +251,9 @@ class JoomlaupdateModelDefault extends JModelLegacy
 	{
 		$updateInfo = $this->getUpdateInformation();
 		$packageURL = $updateInfo['object']->downloadurl->_data;
-		$mirrors    = $updateInfo['object']->get('mirrors', array());
+		$sources    = $updateInfo['object']->get('downloadSources', array());
 		$headers    = get_headers($packageURL, 1);
-
+var_dump($sources);die;
 		// Follow the Location headers until the actual download URL is known
 		while (isset($headers['Location']))
 		{
@@ -281,10 +281,11 @@ class JoomlaupdateModelDefault extends JModelLegacy
 		{
 			// Not there, let's fetch it.
 			$mirror = 0;
-			while (!($download = $this->downloadPackage($packageURL, $target)) && isset($mirrors[$mirror]))
+
+			while (!($download = $this->downloadPackage($packageURL, $target)) && isset($sources[$mirror]))
 			{
-				$name       = $mirrors[$mirror];
-				$packageURL = $updateInfo['object']->$name->_data;
+				$name       = $sources[$mirror];
+				$packageURL = $name->url;
 				$mirror++;
 			}
 
@@ -298,10 +299,11 @@ class JoomlaupdateModelDefault extends JModelLegacy
 			if (empty($filesize))
 			{
 				$mirror = 0;
-				while (!($download = $this->downloadPackage($packageURL, $target)) && isset($mirrors[$mirror]))
+
+				while (!($download = $this->downloadPackage($packageURL, $target)) && isset($sources[$mirror]))
 				{
-					$name       = $mirrors[$mirror];
-					$packageURL = $updateInfo['object']->$name->_data;
+					$name       = $sources[$mirror];
+					$packageURL = $name->url;
 					$mirror++;
 				}
 

--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -253,7 +253,7 @@ class JoomlaupdateModelDefault extends JModelLegacy
 		$packageURL = $updateInfo['object']->downloadurl->_data;
 		$sources    = $updateInfo['object']->get('downloadSources', array());
 		$headers    = get_headers($packageURL, 1);
-var_dump($sources);die;
+
 		// Follow the Location headers until the actual download URL is known
 		while (isset($headers['Location']))
 		{

--- a/libraries/src/Updater/DownloadSource.php
+++ b/libraries/src/Updater/DownloadSource.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Updater;
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * Data object representing a download source given as part of an update's `<downloads>` element
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class DownloadSource
+{
+	/**
+	 * Defines a ZIP download package
+	 *
+	 * @const  string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	const FORMAT_ZIP = 'zip';
+
+	/**
+	 * Defines a full package download type
+	 *
+	 * @const  string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	const TYPE_FULL = 'full';
+
+	/**
+	 * The download type
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public $type = self::TYPE_FULL;
+
+	/**
+	 * The download file's format
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public $format = self::FORMAT_ZIP;
+
+	/**
+	 * The URL to retrieve the package from
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public $url;
+}

--- a/libraries/src/Updater/Update.php
+++ b/libraries/src/Updater/Update.php
@@ -100,7 +100,7 @@ class Update extends \JObject
 	/**
 	 * Update manifest `<downloadsource>` elements
 	 *
-	 * @var    \stdClass[]
+	 * @var    DownloadSource[]
 	 * @since  __DEPLOY_VERSION__
 	 */
 	protected $downloadSources = array();
@@ -272,7 +272,7 @@ class Update extends \JObject
 
 			// Handle the array of download sources
 			case 'DOWNLOADSOURCE':
-				$source = new \stdClass;
+				$source = new DownloadSource;
 
 				foreach ($attrs as $key => $data)
 				{

--- a/libraries/src/Updater/Update.php
+++ b/libraries/src/Updater/Update.php
@@ -90,6 +90,14 @@ class Update extends \JObject
 	protected $group;
 
 	/**
+	 * The mirrors name array
+	 *
+	 * @var    array
+	 * @since  11.1
+	 */
+	protected $mirrors = array();
+
+	/**
 	 * Update manifest `<downloads>` element
 	 *
 	 * @var    string
@@ -246,6 +254,13 @@ class Update extends \JObject
 	 */
 	public function _startElement($parser, $name, $attrs = array())
 	{
+		// Change name if is mirror
+		if ($name == 'DOWNLOADURL' && isset($this->currentUpdate->downloadurl))
+		{
+			$name            = 'MIRROR' . count($this->mirrors);
+			$this->mirrors[] = strtolower($name);
+		}
+
 		$this->stack[] = $name;
 		$tag           = $this->_getStackLocation();
 


### PR DESCRIPTION
### Summary of Changes

This is an enhancement of #18547 to introduce support for multiple download sources (AKA mirrors) to the update server library.  See the original PR for all the basics.

I have made a couple of core tweaks to the concept to allow us to be minimally disruptive to past releases while also enable us to expand the API and be able to implement other missing features in the update system.  In short:

- Introduces a new `<downloadsource>` tag to be used under the `<downloads>` tag, this is different than the original PR which tweaked the update library to support multiple `<downloadurl>` tags
    - In thinking about that implementation more, I started to worry that all currently released Joomla versions might not cope very well with having multiple `<downloadurl>` tags which would cause more issues in serving updates, so I think a new tag is going to be the absolute safest option
- Introduces a new PHP class acting as a data object to give a standardized PHP definition of the new `<downloadsource>` tag
    - This will also allow us to standardize and implement the additional attributes that are present on the tag but unused
- Conceptually doing a "soft" reservation on the tag attributes and defining standardized values allows us to revisit PRs like https://github.com/joomla/joomla-cms/pull/11497 and work on optimizing the packages served through the update component for the various update/install paths instead of always serving the largest of the packages we have (so the 3.8.1 to 3.8.2 update could receive the optimized 1.07 MB ZIP file instead of requiring the full 11.37 MB ZIP file, less bandwidth expense and a smaller number of files to process in the update cycle, everyone wins)

### Testing Instructions

With the patch applied, go into the update component, set the update channel to "Custom URL" and use the URL https://developer.joomla.org/test-update-server/list_sts.xml as your server.  Then try to update Joomla (this will use a nightly build, so it WILL undo the changes from this patch).  The update should work.

Note this server is purposefully provisioned so that it should fail on the first two download attempts, the first using the existing `<downloadurl>` tag and the second the first element of the new download sources array.  So a successful update purposefully only happens after a couple of failures to validate the fallback behavior works.

### Documentation Changes Required

The update server documentation should be expanded to document the new tag/options.