### PR TITLE
[4.0] Clean up inline js #2

### DIFF
--- a/administrator/components/com_config/tmpl/component/default.php
+++ b/administrator/components/com_config/tmpl/component/default.php
@@ -12,25 +12,19 @@ defined('_JEXEC') or die;
 $app = JFactory::getApplication();
 $template = $app->getTemplate();
 
+JText::script('ERROR');
+JText::script('WARNING');
+JText::script('NOTICE');
+JText::script('MESSAGE');
+
 // Load the tooltip behavior.
 JHtml::_('behavior.formvalidator');
 JHtml::_('behavior.keepalive');
 JHtml::_('behavior.tabstate');
 JHtml::_('formbehavior.chosen', '.chzn-custom-value', null, array('disable_search_threshold' => 0));
 
-// Load JS message titles
-JText::script('ERROR');
-JText::script('WARNING');
-JText::script('NOTICE');
-JText::script('MESSAGE');
-
-JFactory::getDocument()->addScriptDeclaration(
-	'
-	// Select first tab
-	jQuery(document).ready(function() {
-		jQuery("#configTabs a:first").tab("show");
-	});'
-);
+// @TODO delete this when custom elements modal is merged
+JHtml::_('script', 'com_config/admin-application-default.min.js', ['relative' => true, 'version' => 'auto']);
 ?>
 
 <form action="<?php echo JRoute::_('index.php?option=com_config'); ?>" id="component-form" method="post" class="form-validate" name="adminForm" autocomplete="off" data-cancel-task="config.cancel.component">

--- a/media/com_config/js/admin-application-default.js
+++ b/media/com_config/js/admin-application-default.js
@@ -1,0 +1,10 @@
+/**
+ * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+// Select first tab
+// @TODO delete this file when custom elements modal is merged
+jQuery(document).ready(function() {
+	jQuery("#configTabs a:first").tab("show");
+});

--- a/media/com_config/js/admin-application-default.min.js
+++ b/media/com_config/js/admin-application-default.min.js
@@ -1,0 +1,1 @@
+jQuery(document).ready(function($){$("#configTabs a:first").tab("show");});


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
com_categories modal view. There is one instance of inline script in Field/CategoryField but this will be done in the PR that will refactor the modal field (not the greatest piece of code in the project)


### Testing Instructions

Try to edit the global configuration-> articles, if the first tab is selected then it's a pass!
![screen shot 2017-12-01 at 19 57 49](https://user-images.githubusercontent.com/3889375/33498569-2549d34e-d6d2-11e7-94ad-1e1a5e877905.png)

This js code (hack) will be removed once we move to the new modal!
### Expected result



### Actual result



### Documentation Changes Required
None