### PR TITLE
[4.0] Fix content modules

### DIFF
--- a/modules/mod_articles_category/Helper/ArticlesCategoryHelper.php
+++ b/modules/mod_articles_category/Helper/ArticlesCategoryHelper.php
@@ -21,7 +21,7 @@ use Joomla\Component\Content\Site\Model\ArticlesModel;
 use Joomla\Component\Content\Site\Model\ArticleModel;
 use Joomla\Component\Content\Site\Model\CategoriesModel;
 
-\JLoader::register('\ContentHelperRoute', JPATH_SITE . '/components/com_content/helpers/route.php');
+\JLoader::register('ContentHelperRoute', JPATH_SITE . '/components/com_content/helpers/route.php');
 
 /**
  * Helper for mod_articles_category

--- a/modules/mod_articles_latest/Helper/ArticlesLatestHelper.php
+++ b/modules/mod_articles_latest/Helper/ArticlesLatestHelper.php
@@ -17,7 +17,7 @@ use Joomla\CMS\Access\Access;
 use Joomla\Utilities\ArrayHelper;
 use Joomla\Component\Content\Site\Model\ArticlesModel;
 
-\JLoader::register('\ContentHelperRoute', JPATH_SITE . '/components/com_content/helpers/route.php');
+\JLoader::register('ContentHelperRoute', JPATH_SITE . '/components/com_content/helpers/route.php');
 
 /**
  * Helper for mod_articles_latest

--- a/modules/mod_articles_news/Helper/ArticlesNewsHelper.php
+++ b/modules/mod_articles_news/Helper/ArticlesNewsHelper.php
@@ -17,7 +17,7 @@ use Joomla\CMS\Uri\Uri;
 use Joomla\CMS\Factory;
 use Joomla\Component\Content\Site\Model\ArticlesModel;
 
-\JLoader::register('\ContentHelperRoute', JPATH_SITE . '/components/com_content/helpers/route.php');
+\JLoader::register('ContentHelperRoute', JPATH_SITE . '/components/com_content/helpers/route.php');
 
 /**
  * Helper for mod_articles_news

--- a/modules/mod_articles_popular/Helper/ArticlesPopularHelper.php
+++ b/modules/mod_articles_popular/Helper/ArticlesPopularHelper.php
@@ -16,7 +16,7 @@ use Joomla\CMS\Access\Access;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\Component\Content\Site\Model\ArticlesModel;
 
-\JLoader::register('\ContentHelperRoute', JPATH_SITE . '/components/com_content/helpers/route.php');
+\JLoader::register('ContentHelperRoute', JPATH_SITE . '/components/com_content/helpers/route.php');
 
 /**
  * Helper for mod_articles_popular


### PR DESCRIPTION
Pull Request for Issue found while testing https://github.com/joomla/joomla-cms/pull/18888

### Summary of Changes
This properly registers the `ContentHelperRoute` in the module helper classes


### Testing Instructions
If you install the sample data you also get some modules added. When you now click the autor login link, you get an error page.



### Expected result
No error page


### Actual result
error page


### Documentation Changes Required
None
