### PR TITLE
Add additional check that $category is an array, getChildren() on null fix

### DIFF
--- a/components/com_content/router.php
+++ b/components/com_content/router.php
@@ -164,7 +164,7 @@ class ContentRouter extends JComponentRouterView
 		{
 			$category = JCategories::getInstance($this->getName())->get($query['id']);
 
-			if (is_array($category))
+			if ($category)
 			{
 				foreach ($category->getChildren() as $child)
 				{

--- a/components/com_content/router.php
+++ b/components/com_content/router.php
@@ -164,20 +164,23 @@ class ContentRouter extends JComponentRouterView
 		{
 			$category = JCategories::getInstance($this->getName())->get($query['id']);
 
-			foreach ($category->getChildren() as $child)
+			if (is_array($category))
 			{
-				if ($this->noIDs)
+				foreach ($category->getChildren() as $child)
 				{
-					if ($child->alias == $segment)
+					if ($this->noIDs)
 					{
-						return $child->id;
+						if ($child->alias == $segment)
+						{
+							return $child->id;
+						}
 					}
-				}
-				else
-				{
-					if ($child->id == (int) $segment)
+					else
 					{
-						return $child->id;
+						if ($child->id == (int) $segment)
+						{
+							return $child->id;
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Pull Request for Issue #18927 .

Add additional check that $category is an array, since null is return if the user cannot access the category and thus the foreach fails.

### Steps to reproduce the issue

Using Joomla 3.8.2 and default Protostar template...

Create a Category, set the Access level to Registered.
Create an Article and place it in the Category from above step.
Create a Menu Item to the Category (Category List), set the Access level to Registered.
Use the new Modern Router for com_content.
Optional: Set Remove IDs from URLs to Yes.
Visit frontend of your site and login.
Navigate to your test article.
Copy URL of the article that is in the registered access level category.
Logout of the frontend.
Visit the URL of the article you copied.
See error message 0 Call to a member function getChildren() on null.
Remain logged out and navigate to the URL of the Menu Item you created in step 3 above.
Get redirected to login page.

Apply fix, you are now redirected to a login page to login. Opposed to a call to member function error.