### PR TITLE
[#18964] Tag filter in blog category with pagination selects wrong page on start of new user session

### DIFF
--- a/components/com_content/models/category.php
+++ b/components/com_content/models/category.php
@@ -158,7 +158,7 @@ class ContentModelCategory extends JModelList
 
 		$itemid = $app->input->get('id', 0, 'int') . ':' . $app->input->get('Itemid', 0, 'int');
 
-		$value = $this->getUserStateFromRequest('com_content.category.filter.' . $itemid . '.tag', 'filter_tag', 0, 'int');
+		$value = $this->getUserStateFromRequest('com_content.category.filter.' . $itemid . '.tag', 'filter_tag', 0, 'int', false);
 		$this->setState('filter.tag', $value);
 
 		// Optional filter text


### PR DESCRIPTION
[#18964] - Tag filter in blog category with pagination selects wrong page on start of new user session


The wrong page selection appears by very specific conditions for anonymous users when they have not yet assigned user session. Direct request to second or any later page for blog category opens each time first page of given blog category.

Especially annoying is this bug in case when is used page caching and external crawlers visit the site without keeping session variables. Then in some time are all pages of blog category filled by first page content.
Steps to reproduce the issue

    Create category e.g. 'News'
    Create tag e.g. 'Science'
    Create 4 articles for category 'News' with tag 'Science'
    Create new menu item 'Science' for blog category 'News' with assigned tag 'Science' and 2 articles in 1 column per page
    Disable any Joomla caching (global as well as page one).
    Now on frontend are available for menu item 'Science' two pages (each with 2 articles and pagination buttons), select second page (with start=2) and assign it as bookmark in the browser. In browser assign blank page as initial page, delete all cookies for given site and close browser.
    Open browser, click on prepared link for the second page of 'Science'.

Expected result

response is SECOND page of tagged blog category with pagination having more pages
Actual result

response is FIRST page of tagged blog category with pagination having more pages
Additional comments

Solution for issue #17711 #17711 is good but it did not cover solution for described bug.
