### PR TITLE
Removed duplicated entry

### DIFF
--- a/libraries/classmap.php
+++ b/libraries/classmap.php
@@ -156,7 +156,6 @@ JLoader::registerAlias('JUcmContent',                       '\\Joomla\\CMS\\UCM\
 JLoader::registerAlias('JUcmType',                          '\\Joomla\\CMS\\UCM\\UCMType', '5.0');
 
 JLoader::registerAlias('JToolbar',                          '\\Joomla\\CMS\\Toolbar\\Toolbar', '5.0');
-JLoader::registerAlias('JToolBar',                          '\\Joomla\\CMS\\Toolbar\\Toolbar', '5.0');
 JLoader::registerAlias('JToolbarButton',                    '\\Joomla\\CMS\\Toolbar\\ToolbarButton', '5.0');
 JLoader::registerAlias('JToolbarButtonConfirm',             '\\Joomla\\CMS\\Toolbar\\Button\\ConfirmButton', '5.0');
 JLoader::registerAlias('JToolbarButtonCustom',              '\\Joomla\\CMS\\Toolbar\\Button\\CustomButton', '5.0');


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
I removed this line
JLoader::registerAlias('JToolBar', '\\Joomla\\CMS\\Toolbar\\Toolbar', '5.0');
because i assume that the above line (with a lowercase b) is the right one.
(JLoader::registerAlias('JToolbar', '\\Joomla\\CMS\\Toolbar\\Toolbar', '5.0');)

### Testing Instructions



### Expected result



### Actual result



### Documentation Changes Required

