### PR TITLE
[4.0] Remove language options on non multilingual site

### DIFF
--- a/administrator/components/com_banners/View/Banners/HtmlView.php
+++ b/administrator/components/com_banners/View/Banners/HtmlView.php
@@ -81,6 +81,13 @@ class HtmlView extends BaseHtmlView
 
 		$this->sidebar = \JHtmlSidebar::render();
 
+		// We do not need to filter by language when multilingual is disabled
+		if (!\JLanguageMultilang::isEnabled())
+		{
+			unset($this->activeFilters['language']);
+			$this->filterForm->removeField('language', 'filter');
+		}
+
 		return parent::display($tpl);
 	}
 

--- a/administrator/components/com_banners/forms/filter_banners.xml
+++ b/administrator/components/com_banners/forms/filter_banners.xml
@@ -82,8 +82,8 @@
 			<option value="impmade DESC">COM_BANNERS_HEADING_IMPRESSIONS_DESC</option>
 			<option value="clicks ASC">COM_BANNERS_HEADING_CLICKS_ASC</option>
 			<option value="clicks DESC">COM_BANNERS_HEADING_CLICKS_DESC</option>
-			<option value="a.language ASC">JGRID_HEADING_LANGUAGE_ASC</option>
-			<option value="a.language DESC">JGRID_HEADING_LANGUAGE_DESC</option>
+			<option value="a.language ASC" requires="multilanguage">JGRID_HEADING_LANGUAGE_ASC</option>
+			<option value="a.language DESC" requires="multilanguage">JGRID_HEADING_LANGUAGE_DESC</option>
 			<option value="a.id ASC">JGRID_HEADING_ID_ASC</option>
 			<option value="a.id DESC">JGRID_HEADING_ID_DESC</option>
 		</field>

--- a/administrator/components/com_banners/tmpl/banners/default.php
+++ b/administrator/components/com_banners/tmpl/banners/default.php
@@ -69,9 +69,11 @@ if ($saveOrder && !empty($this->items))
 								<th style="width:10%" class="nowrap hidden-sm-down text-center">
 									<?php echo JHtml::_('searchtools.sort', 'COM_BANNERS_HEADING_CLICKS', 'clicks', $listDirn, $listOrder); ?>
 								</th>
-								<th style="width:10%" class="nowrap hidden-sm-down text-center">
-									<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'a.language', $listDirn, $listOrder); ?>
-								</th>
+								<?php if (JLanguageMultilang::isEnabled()) : ?>
+									<th style="width:10%" class="nowrap hidden-sm-down text-center">
+										<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'a.language', $listDirn, $listOrder); ?>
+									</th>
+								<?php endif; ?>
 								<th style="width:5%" class="nowrap hidden-sm-down text-center">
 									<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>
 								</th>
@@ -156,9 +158,11 @@ if ($saveOrder && !empty($this->items))
 										<?php echo $item->clicks; ?> -
 										<?php echo sprintf('%.2f%%', $item->impmade ? 100 * $item->clicks / $item->impmade : 0); ?>
 									</td>
-									<td class="small nowrap hidden-sm-down text-center">
-										<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
-									</td>
+									<?php if (JLanguageMultilang::isEnabled()) : ?>
+										<td class="small nowrap hidden-sm-down text-center">
+											<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
+										</td>
+									<?php endif; ?>
 									<td class="hidden-sm-down text-center">
 										<?php echo $item->id; ?>
 									</td>

--- a/administrator/components/com_categories/View/Categories/HtmlView.php
+++ b/administrator/components/com_categories/View/Categories/HtmlView.php
@@ -106,6 +106,13 @@ class HtmlView extends BaseHtmlView
 		{
 			$this->addToolbar();
 			$this->sidebar = \JHtmlSidebar::render();
+
+			// We do not need to filter by language when multilingual is disabled
+			if (!\JLanguageMultilang::isEnabled())
+			{
+				unset($this->activeFilters['language']);
+				$this->filterForm->removeField('language', 'filter');
+			}
 		}
 		else
 		{

--- a/administrator/components/com_categories/forms/filter_categories.xml
+++ b/administrator/components/com_categories/forms/filter_categories.xml
@@ -76,8 +76,8 @@
 			<option value="a.title DESC">JGLOBAL_TITLE_DESC</option>
 			<option value="access_level ASC">JGRID_HEADING_ACCESS_ASC</option>
 			<option value="access_level DESC">JGRID_HEADING_ACCESS_DESC</option>
-			<option value="language_title ASC">JGRID_HEADING_LANGUAGE_ASC</option>
-			<option value="language_title DESC">JGRID_HEADING_LANGUAGE_DESC</option>
+			<option value="language_title ASC" requires="multilanguage">JGRID_HEADING_LANGUAGE_ASC</option>
+			<option value="language_title DESC" requires="multilanguage">JGRID_HEADING_LANGUAGE_DESC</option>
 			<option value="a.id ASC">JGRID_HEADING_ID_ASC</option>
 			<option value="a.id DESC">JGRID_HEADING_ID_DESC</option>
 		</field>

--- a/administrator/components/com_categories/tmpl/categories/default.php
+++ b/administrator/components/com_categories/tmpl/categories/default.php
@@ -121,9 +121,11 @@ if ($saveOrder && !empty($this->items))
 										<?php echo JHtml::_('searchtools.sort', 'COM_CATEGORY_HEADING_ASSOCIATION', 'association', $listDirn, $listOrder); ?>
 									</th>
 								<?php endif; ?>
-								<th style="width:10%" class="nowrap hidden-sm-down text-center">
-									<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'language_title', $listDirn, $listOrder); ?>
-								</th>
+								<?php if (JLanguageMultilang::isEnabled()) : ?>
+									<th style="width:10%" class="nowrap hidden-sm-down text-center">
+										<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'language_title', $listDirn, $listOrder); ?>
+									</th>
+								<?php endif; ?>	
 								<th style="width:5%" class="nowrap hidden-sm-down text-center">
 									<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>
 								</th>
@@ -253,9 +255,11 @@ if ($saveOrder && !empty($this->items))
 											<?php endif; ?>
 										</td>
 									<?php endif; ?>
-									<td class="small nowrap hidden-sm-down text-center">
-										<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
-									</td>
+									<?php if (JLanguageMultilang::isEnabled()) : ?>
+										<td class="small nowrap hidden-sm-down text-center">
+											<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
+										</td>
+									<?php endif; ?>
 									<td class="hidden-sm-down text-center">
 										<span title="<?php echo sprintf('%d-%d', $item->lft, $item->rgt); ?>">
 											<?php echo (int) $item->id; ?></span>

--- a/administrator/components/com_contact/View/Contacts/HtmlView.php
+++ b/administrator/components/com_contact/View/Contacts/HtmlView.php
@@ -103,6 +103,13 @@ class HtmlView extends BaseHtmlView
 		{
 			$this->addToolbar();
 			$this->sidebar = \JHtmlSidebar::render();
+
+			// We do not need to filter by language when multilingual is disabled
+			if (!\JLanguageMultilang::isEnabled())
+			{
+				unset($this->activeFilters['language']);
+				$this->filterForm->removeField('language', 'filter');
+			}
 		}
 		else
 		{

--- a/administrator/components/com_contact/forms/filter_contacts.xml
+++ b/administrator/components/com_contact/forms/filter_contacts.xml
@@ -103,8 +103,8 @@
 				>
 				JASSOCIATIONS_DESC
 			</option>
-			<option value="language_title ASC">JGRID_HEADING_LANGUAGE_ASC</option>
-			<option value="language_title DESC">JGRID_HEADING_LANGUAGE_DESC</option>
+			<option value="language_title ASC" requires="multilanguage">JGRID_HEADING_LANGUAGE_ASC</option>
+			<option value="language_title DESC" requires="multilanguage">JGRID_HEADING_LANGUAGE_DESC</option>
 			<option value="a.id ASC">JGRID_HEADING_ID_ASC</option>
 			<option value="a.id DESC">JGRID_HEADING_ID_DESC</option>
 		</field>

--- a/administrator/components/com_contact/tmpl/contacts/default.php
+++ b/administrator/components/com_contact/tmpl/contacts/default.php
@@ -66,9 +66,11 @@ if ($saveOrder && !empty($this->items))
 									<?php echo JHtml::_('searchtools.sort', 'COM_CONTACT_HEADING_ASSOCIATION', 'association', $listDirn, $listOrder); ?>
 								</th>
 								<?php endif; ?>
-								<th style="width:10%" class="nowrap hidden-sm-down text-center">
-									<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'language_title', $listDirn, $listOrder); ?>
-								</th>
+								<?php if (JLanguageMultilang::isEnabled()) : ?>
+									<th style="width:10%" class="nowrap hidden-sm-down text-center">
+										<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'language_title', $listDirn, $listOrder); ?>
+									</th>
+								<?php endif; ?>
 								<th style="width:5%" class="nowrap hidden-sm-down text-center">
 									<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>
 								</th>
@@ -159,9 +161,11 @@ if ($saveOrder && !empty($this->items))
 									<?php endif; ?>
 								</td>
 								<?php endif; ?>
-								<td class="small hidden-sm-down text-center">
-									<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
-								</td>
+								<?php if (JLanguageMultilang::isEnabled()) : ?>
+									<td class="small hidden-sm-down text-center">
+										<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
+									</td>
+								<?php endif; ?>
 								<td class="hidden-sm-down text-center">
 									<?php echo $item->id; ?>
 								</td>

--- a/administrator/components/com_content/View/Articles/HtmlView.php
+++ b/administrator/components/com_content/View/Articles/HtmlView.php
@@ -118,7 +118,7 @@ class HtmlView extends BaseHtmlView
 			{
 				unset($this->activeFilters['language']);
 				$this->filterForm->removeField('language', 'filter');
-			}			
+			}
 		}
 		else
 		{

--- a/administrator/components/com_content/View/Articles/HtmlView.php
+++ b/administrator/components/com_content/View/Articles/HtmlView.php
@@ -112,7 +112,7 @@ class HtmlView extends BaseHtmlView
 		{
 			$this->addToolbar();
 			$this->sidebar = \JHtmlSidebar::render();
-	
+
 			// We do not need to filter by language when multilingual is disabled
 			if (!\JLanguageMultilang::isEnabled())
 			{

--- a/administrator/components/com_content/View/Articles/HtmlView.php
+++ b/administrator/components/com_content/View/Articles/HtmlView.php
@@ -112,6 +112,13 @@ class HtmlView extends BaseHtmlView
 		{
 			$this->addToolbar();
 			$this->sidebar = \JHtmlSidebar::render();
+			
+			// We do not need to filter by language when multilingual is disabled
+			if (!\JLanguageMultilang::isEnabled())
+			{
+				unset($this->activeFilters['language']);
+				$this->filterForm->removeField('language', 'filter');
+			}			
 		}
 		else
 		{

--- a/administrator/components/com_content/View/Articles/HtmlView.php
+++ b/administrator/components/com_content/View/Articles/HtmlView.php
@@ -112,7 +112,7 @@ class HtmlView extends BaseHtmlView
 		{
 			$this->addToolbar();
 			$this->sidebar = \JHtmlSidebar::render();
-			
+	
 			// We do not need to filter by language when multilingual is disabled
 			if (!\JLanguageMultilang::isEnabled())
 			{

--- a/administrator/components/com_content/View/Featured/HtmlView.php
+++ b/administrator/components/com_content/View/Featured/HtmlView.php
@@ -107,6 +107,13 @@ class HtmlView extends BaseHtmlView
 		$this->addToolbar();
 		$this->sidebar = \JHtmlSidebar::render();
 
+		// We do not need to filter by language when multilingual is disabled
+		if (!\JLanguageMultilang::isEnabled())
+		{
+			unset($this->activeFilters['language']);
+			$this->filterForm->removeField('language', 'filter');
+		}
+
 		return parent::display($tpl);
 	}
 

--- a/administrator/components/com_content/forms/filter_articles.xml
+++ b/administrator/components/com_content/forms/filter_articles.xml
@@ -101,8 +101,8 @@
 			<option value="association DESC" requires="associations">JASSOCIATIONS_DESC</option>
 			<option value="a.created_by ASC">JAUTHOR_ASC</option>
 			<option value="a.created_by DESC">JAUTHOR_DESC</option>
-			<option value="language ASC">JGRID_HEADING_LANGUAGE_ASC</option>
-			<option value="language DESC">JGRID_HEADING_LANGUAGE_DESC</option>
+			<option value="language ASC" requires="multilanguage">JGRID_HEADING_LANGUAGE_ASC</option>
+			<option value="language DESC" requires="multilanguage">JGRID_HEADING_LANGUAGE_DESC</option>
 			<option value="a.created ASC">JDATE_ASC</option>
 			<option value="a.created DESC">JDATE_DESC</option>
 			<option value="a.modified ASC">COM_CONTENT_MODIFIED_ASC</option>

--- a/administrator/components/com_content/forms/filter_featured.xml
+++ b/administrator/components/com_content/forms/filter_featured.xml
@@ -101,8 +101,8 @@
 			<option value="a.publish_up DESC">COM_CONTENT_PUBLISH_UP_DESC</option>
 			<option value="a.publish_down ASC">COM_CONTENT_PUBLISH_DOWN_ASC</option>
 			<option value="a.publish_down DESC">COM_CONTENT_PUBLISH_DOWN_DESC</option>
-			<option value="language ASC">JGRID_HEADING_LANGUAGE_ASC</option>
-			<option value="language DESC">JGRID_HEADING_LANGUAGE_DESC</option>
+			<option value="language ASC" requires="multilanguage">JGRID_HEADING_LANGUAGE_ASC</option>
+			<option value="language DESC" requires="multilanguage">JGRID_HEADING_LANGUAGE_DESC</option>
 			<option value="a.created ASC">JDATE_ASC</option>
 			<option value="a.created DESC">JDATE_DESC</option>
 			<option value="a.hits ASC">JGLOBAL_HITS_ASC</option>

--- a/administrator/components/com_content/tmpl/articles/default.php
+++ b/administrator/components/com_content/tmpl/articles/default.php
@@ -107,9 +107,11 @@ $featuredButton = (new ActionButton(['tip_title' => 'JGLOBAL_TOGGLE_FEATURED']))
 								<th style="width:10%" class="nowrap hidden-sm-down text-center">
 									<?php echo JHtml::_('searchtools.sort',  'JAUTHOR', 'a.created_by', $listDirn, $listOrder); ?>
 								</th>
-								<th style="width:10%" class="nowrap hidden-sm-down text-center">
-									<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'language', $listDirn, $listOrder); ?>
-								</th>
+								<?php if (JLanguageMultilang::isEnabled()) : ?>
+									<th style="width:10%" class="nowrap hidden-sm-down text-center">
+										<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'language', $listDirn, $listOrder); ?>
+									</th>
+								<?php endif; ?>
 								<th style="width:10%" class="nowrap hidden-sm-down text-center">
 									<?php echo JHtml::_('searchtools.sort', 'COM_CONTENT_HEADING_DATE_' . strtoupper($orderingColumn), 'a.' . $orderingColumn, $listDirn, $listOrder); ?>
 								</th>
@@ -224,9 +226,11 @@ $featuredButton = (new ActionButton(['tip_title' => 'JGLOBAL_TOGGLE_FEATURED']))
 										<?php endif; ?>
 									<?php endif; ?>
 								</td>
-								<td class="small hidden-sm-down text-center">
-									<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
-								</td>
+								<?php if (JLanguageMultilang::isEnabled()) : ?>
+									<td class="small hidden-sm-down text-center">
+										<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
+									</td>
+								<?php endif; ?>
 								<td class="nowrap small hidden-sm-down text-center">
 									<?php
 									$date = $item->{$orderingColumn};

--- a/administrator/components/com_content/tmpl/featured/default.php
+++ b/administrator/components/com_content/tmpl/featured/default.php
@@ -83,9 +83,11 @@ if ($saveOrder)
 								<th style="width:10%" class="nowrap hidden-sm-down text-center">
 									<?php echo JHtml::_('searchtools.sort', 'JAUTHOR', 'a.created_by', $listDirn, $listOrder); ?>
 								</th>
-								<th style="width:10%" class="nowrap hidden-sm-down text-center">
-									<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'language', $listDirn, $listOrder); ?>
-								</th>
+								<?php if (JLanguageMultilang::isEnabled()) : ?>
+									<th style="width:10%" class="nowrap hidden-sm-down text-center">
+										<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'language', $listDirn, $listOrder); ?>
+									</th>
+								<?php endif; ?>
 								<th style="width:10%" class="nowrap hidden-sm-down text-center">
 									<?php echo JHtml::_('searchtools.sort', 'COM_CONTENT_HEADING_DATE_' . strtoupper($orderingColumn), 'a.' . $orderingColumn, $listDirn, $listOrder); ?>
 								</th>
@@ -197,9 +199,11 @@ if ($saveOrder)
 										<?php endif; ?>
 									<?php endif; ?>
 								</td>
-								<td class="small hidden-sm-down text-center">
-									<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
-								</td>
+								<?php if (JLanguageMultilang::isEnabled()) : ?>
+									<td class="small hidden-sm-down text-center">
+										<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
+									</td>
+								<?php endif; ?>
 								<td class="nowrap small hidden-sm-down text-center">
 									<?php
 									$date = $item->{$orderingColumn};

--- a/administrator/components/com_fields/View/Fields/HtmlView.php
+++ b/administrator/components/com_fields/View/Fields/HtmlView.php
@@ -105,7 +105,7 @@ class HtmlView extends BaseHtmlView
 			{
 				unset($this->activeFilters['language']);
 				$this->filterForm->removeField('language', 'filter');
-			}	
+			}
 		}
 
 		\FieldsHelper::addSubmenu($this->state->get('filter.context'), 'fields');

--- a/administrator/components/com_fields/View/Fields/HtmlView.php
+++ b/administrator/components/com_fields/View/Fields/HtmlView.php
@@ -99,6 +99,13 @@ class HtmlView extends BaseHtmlView
 		if ($this->getLayout() !== 'modal')
 		{
 			$this->addToolbar();
+
+			// We do not need to filter by language when multilingual is disabled
+			if (!\JLanguageMultilang::isEnabled())
+			{
+				unset($this->activeFilters['language']);
+				$this->filterForm->removeField('language', 'filter');
+			}	
 		}
 
 		\FieldsHelper::addSubmenu($this->state->get('filter.context'), 'fields');

--- a/administrator/components/com_fields/View/Groups/HtmlView.php
+++ b/administrator/components/com_fields/View/Groups/HtmlView.php
@@ -98,6 +98,13 @@ class HtmlView extends BaseHtmlView
 
 		$this->addToolbar();
 
+		// We do not need to filter by language when multilingual is disabled
+		if (!\JLanguageMultilang::isEnabled())
+		{
+			unset($this->activeFilters['language']);
+			$this->filterForm->removeField('language', 'filter');
+		}
+
 		\FieldsHelper::addSubmenu($this->state->get('filter.context'), 'groups');
 		$this->sidebar = \JHtmlSidebar::render();
 

--- a/administrator/components/com_fields/forms/filter_fields.xml
+++ b/administrator/components/com_fields/forms/filter_fields.xml
@@ -81,8 +81,8 @@
 			<option value="g.title DESC">COM_FIELDS_VIEW_FIELDS_SORT_GROUP_DESC</option>
 			<option value="a.access ASC">JGRID_HEADING_ACCESS_ASC</option>
 			<option value="a.access DESC">JGRID_HEADING_ACCESS_DESC</option>
-			<option value="a.language ASC">JGRID_HEADING_LANGUAGE_ASC</option>
-			<option value="a.language DESC">JGRID_HEADING_LANGUAGE_DESC</option>
+			<option value="a.language ASC" requires="multilanguage">JGRID_HEADING_LANGUAGE_ASC</option>
+			<option value="a.language DESC" requires="multilanguage">JGRID_HEADING_LANGUAGE_DESC</option>
 			<option value="a.id ASC">JGRID_HEADING_ID_ASC</option>
 			<option value="a.id DESC">JGRID_HEADING_ID_DESC</option>
 		</field>

--- a/administrator/components/com_fields/forms/filter_groups.xml
+++ b/administrator/components/com_fields/forms/filter_groups.xml
@@ -57,8 +57,8 @@
 			<option value="a.title DESC">JGLOBAL_TITLE_DESC</option>
 			<option value="a.access ASC">JGRID_HEADING_ACCESS_ASC</option>
 			<option value="a.access DESC">JGRID_HEADING_ACCESS_DESC</option>
-			<option value="a.language ASC">JGRID_HEADING_LANGUAGE_ASC</option>
-			<option value="a.language DESC">JGRID_HEADING_LANGUAGE_DESC</option>
+			<option value="a.language ASC" requires="multilanguage">JGRID_HEADING_LANGUAGE_ASC</option>
+			<option value="a.language DESC" requires="multilanguage">JGRID_HEADING_LANGUAGE_DESC</option>
 			<option value="a.id ASC">JGRID_HEADING_ID_ASC</option>
 			<option value="a.id DESC">JGRID_HEADING_ID_DESC</option>
 		</field>

--- a/administrator/components/com_fields/tmpl/fields/default.php
+++ b/administrator/components/com_fields/tmpl/fields/default.php
@@ -72,9 +72,11 @@ if ($saveOrder && !empty($this->items))
 								<th style="width:10%" class="nowrap hidden-sm-down text-center">
 									<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ACCESS', 'a.access', $listDirn, $listOrder); ?>
 								</th>
-								<th style="width:10%" class="nowrap hidden-sm-down text-center">
-									<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'a.language', $listDirn, $listOrder); ?>
-								</th>
+								<?php if (JLanguageMultilang::isEnabled()) : ?>
+									<th style="width:10%" class="nowrap hidden-sm-down text-center">
+										<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'a.language', $listDirn, $listOrder); ?>
+									</th>
+								<?php endif; ?>
 								<th style="width:5%" class="nowrap hidden-sm-down text-center">
 									<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>
 								</th>
@@ -158,9 +160,11 @@ if ($saveOrder && !empty($this->items))
 									<td class="small hidden-sm-down text-center">
 										<?php echo $this->escape($item->access_level); ?>
 									</td>
-									<td class="small nowrap hidden-sm-down text-center">
-										<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
-									</td>
+									<?php if (JLanguageMultilang::isEnabled()) : ?>
+										<td class="small nowrap hidden-sm-down text-center">
+											<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
+										</td>
+									<?php endif; ?>
 									<td class="hidden-sm-down text-center">
 										<span><?php echo (int) $item->id; ?></span>
 									</td>

--- a/administrator/components/com_fields/tmpl/groups/default.php
+++ b/administrator/components/com_fields/tmpl/groups/default.php
@@ -71,9 +71,11 @@ if ($saveOrder && !empty($this->items))
 								<th style="width:10%" class="nowrap hidden-sm-down">
 									<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ACCESS', 'a.access', $listDirn, $listOrder); ?>
 								</th>
-								<th style="width:5%" class="nowrap hidden-sm-down">
-									<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'a.language', $listDirn, $listOrder); ?>
-								</th>
+								<?php if (JLanguageMultilang::isEnabled()) : ?>
+									<th style="width:5%" class="nowrap hidden-sm-down">
+										<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'a.language', $listDirn, $listOrder); ?>
+									</th>
+								<?php endif; ?>
 								<th style="width:1%" class="nowrap hidden-sm-down">
 									<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>
 								</th>
@@ -138,9 +140,11 @@ if ($saveOrder && !empty($this->items))
 									<td class="small hidden-sm-down">
 										<?php echo $this->escape($item->access_level); ?>
 									</td>
-									<td class="small nowrap hidden-sm-down">
-										<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
-									</td>
+									<?php if (JLanguageMultilang::isEnabled()) : ?>
+										<td class="small nowrap hidden-sm-down">
+											<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
+										</td>
+									<?php endif; ?>
 									<td class="text-center hidden-sm-down">
 										<span><?php echo (int) $item->id; ?></span>
 									</td>

--- a/administrator/components/com_languages/forms/filter_installed.xml
+++ b/administrator/components/com_languages/forms/filter_installed.xml
@@ -31,8 +31,8 @@
 			<option value="name DESC">COM_LANGUAGES_HEADING_LANGUAGE_DESC</option>
 			<option value="nativeName ASC">COM_LANGUAGES_HEADING_TITLE_NATIVE_ASC</option>
 			<option value="nativeName DESC">COM_LANGUAGES_HEADING_TITLE_NATIVE_DESC</option>
-			<option value="language ASC">COM_LANGUAGES_HEADING_LANG_TAG_ASC</option>
-			<option value="language DESC">COM_LANGUAGES_HEADING_LANG_TAG_DESC</option>
+			<option value="language ASC" requires="multilanguage">COM_LANGUAGES_HEADING_LANG_TAG_ASC</option>
+			<option value="language DESC" requires="multilanguage">COM_LANGUAGES_HEADING_LANG_TAG_DESC</option>
 			<option value="published ASC">COM_LANGUAGES_HEADING_DEFAULT_ASC</option>
 			<option value="published DESC">COM_LANGUAGES_HEADING_DEFAULT_DESC</option>
 			<option value="version ASC">COM_LANGUAGES_HEADING_VERSION_ASC</option>

--- a/administrator/components/com_menus/View/Items/HtmlView.php
+++ b/administrator/components/com_menus/View/Items/HtmlView.php
@@ -280,7 +280,7 @@ class HtmlView extends BaseHtmlView
 		{
 			$this->addToolbar();
 			$this->sidebar = \JHtmlSidebar::render();
-		
+
 			// We do not need to filter by language when multilingual is disabled
 			if (!\JLanguageMultilang::isEnabled())
 			{

--- a/administrator/components/com_menus/View/Items/HtmlView.php
+++ b/administrator/components/com_menus/View/Items/HtmlView.php
@@ -280,6 +280,13 @@ class HtmlView extends BaseHtmlView
 		{
 			$this->addToolbar();
 			$this->sidebar = \JHtmlSidebar::render();
+		
+			// We do not need to filter by language when multilingual is disabled
+			if (!\JLanguageMultilang::isEnabled())
+			{
+				unset($this->activeFilters['language']);
+				$this->filterForm->removeField('language', 'filter');
+			}
 		}
 		else
 		{

--- a/administrator/components/com_menus/View/Menus/HtmlView.php
+++ b/administrator/components/com_menus/View/Menus/HtmlView.php
@@ -107,6 +107,7 @@ class HtmlView extends BaseHtmlView
 
 		$this->addToolbar();
 		$this->sidebar = \JHtmlSidebar::render();
+		
 		parent::display($tpl);
 	}
 

--- a/administrator/components/com_menus/View/Menus/HtmlView.php
+++ b/administrator/components/com_menus/View/Menus/HtmlView.php
@@ -107,7 +107,7 @@ class HtmlView extends BaseHtmlView
 
 		$this->addToolbar();
 		$this->sidebar = \JHtmlSidebar::render();
-		
+
 		parent::display($tpl);
 	}
 

--- a/administrator/components/com_menus/forms/filter_items.xml
+++ b/administrator/components/com_menus/forms/filter_items.xml
@@ -95,8 +95,8 @@
 			<option value="a.access DESC">JGRID_HEADING_ACCESS_DESC</option>
 			<option value="association ASC" requires="associations">JASSOCIATIONS_ASC</option>
 			<option value="association DESC" requires="associations">JASSOCIATIONS_DESC</option>
-			<option value="language ASC">JGRID_HEADING_LANGUAGE_ASC</option>
-			<option value="language DESC">JGRID_HEADING_LANGUAGE_DESC</option>
+			<option value="language ASC" requires="multilanguage">JGRID_HEADING_LANGUAGE_ASC</option>
+			<option value="language DESC" requires="multilanguage">JGRID_HEADING_LANGUAGE_DESC</option>
 			<option value="a.id ASC">JGRID_HEADING_ID_ASC</option>
 			<option value="a.id DESC">JGRID_HEADING_ID_DESC</option>
 		</field>

--- a/administrator/components/com_menus/tmpl/items/default.php
+++ b/administrator/components/com_menus/tmpl/items/default.php
@@ -215,7 +215,7 @@ if ($menuType == '')
 									<?php echo $this->escape($item->menutype_title ?: ucwords($item->menutype)); ?>
 								</td>
 								<?php if (($this->state->get('filter.client_id') == 0) && (JLanguageMultilang::isEnabled())) : ?>
-								<td class="text-center hidden-sm-down">
+									<td class="text-center hidden-sm-down">
 										<?php if ($item->type == 'component') : ?>
 											<?php if ($item->language == '*' || $item->home == '0') : ?>
 												<?php echo JHtml::_('jgrid.isdefault', $item->home, $i, 'items.', ($item->language != '*' || !$item->home) && $canChange && !$item->protected); ?>

--- a/administrator/components/com_menus/tmpl/items/default.php
+++ b/administrator/components/com_menus/tmpl/items/default.php
@@ -87,7 +87,7 @@ if ($menuType == '')
 									<?php echo JHtml::_('searchtools.sort', 'COM_MENUS_HEADING_ASSOCIATION', 'association', $listDirn, $listOrder); ?>
 								</th>
 							<?php endif; ?>
-							<?php if ($this->state->get('filter.client_id') == 0) : ?>
+							<?php if (($this->state->get('filter.client_id') == 0) && (JLanguageMultilang::isEnabled())) : ?>
 								<th style="width:10%" class="nowrap hidden-sm-down text-center">
 									<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'language', $listDirn, $listOrder); ?>
 								</th>
@@ -214,8 +214,8 @@ if ($menuType == '')
 								<td class="small hidden-sm-down text-center">
 									<?php echo $this->escape($item->menutype_title ?: ucwords($item->menutype)); ?>
 								</td>
-								<?php if ($this->state->get('filter.client_id') == 0) : ?>
-									<td class="text-center hidden-sm-down">
+								<?php if (($this->state->get('filter.client_id') == 0) && (JLanguageMultilang::isEnabled())) : ?>
+								<td class="text-center hidden-sm-down">
 										<?php if ($item->type == 'component') : ?>
 											<?php if ($item->language == '*' || $item->home == '0') : ?>
 												<?php echo JHtml::_('jgrid.isdefault', $item->home, $i, 'items.', ($item->language != '*' || !$item->home) && $canChange && !$item->protected); ?>

--- a/administrator/components/com_menus/tmpl/items/default.php
+++ b/administrator/components/com_menus/tmpl/items/default.php
@@ -214,7 +214,7 @@ if ($menuType == '')
 								<td class="small hidden-sm-down text-center">
 									<?php echo $this->escape($item->menutype_title ?: ucwords($item->menutype)); ?>
 								</td>
-								<?php if (($this->state->get('filter.client_id') == 0) && (JLanguageMultilang::isEnabled())) : ?>
+								<?php if ($this->state->get('filter.client_id') == 0) : ?>
 									<td class="text-center hidden-sm-down">
 										<?php if ($item->type == 'component') : ?>
 											<?php if ($item->language == '*' || $item->home == '0') : ?>
@@ -251,7 +251,7 @@ if ($menuType == '')
 										<?php endif; ?>
 									</td>
 								<?php endif; ?>
-								<?php if ($this->state->get('filter.client_id') == 0) : ?>
+								<?php if ($this->state->get('filter.client_id') == 0 && JLanguageMultilang::isEnabled()) : ?>
 									<td class="small hidden-sm-down text-center">
 										<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
 									</td>

--- a/administrator/components/com_modules/View/Modules/HtmlView.php
+++ b/administrator/components/com_modules/View/Modules/HtmlView.php
@@ -103,7 +103,7 @@ class HtmlView extends BaseHtmlView
 		if ($this->getLayout() !== 'modal')
 		{
 			$this->addToolbar();
-	
+
 			// We do not need to filter by language when multilingual is disabled
 			if (!\JLanguageMultilang::isEnabled())
 			{

--- a/administrator/components/com_modules/View/Modules/HtmlView.php
+++ b/administrator/components/com_modules/View/Modules/HtmlView.php
@@ -103,7 +103,7 @@ class HtmlView extends BaseHtmlView
 		if ($this->getLayout() !== 'modal')
 		{
 			$this->addToolbar();
-			
+	
 			// We do not need to filter by language when multilingual is disabled
 			if (!\JLanguageMultilang::isEnabled())
 			{

--- a/administrator/components/com_modules/View/Modules/HtmlView.php
+++ b/administrator/components/com_modules/View/Modules/HtmlView.php
@@ -103,6 +103,13 @@ class HtmlView extends BaseHtmlView
 		if ($this->getLayout() !== 'modal')
 		{
 			$this->addToolbar();
+			
+			// We do not need to filter by language when multilingual is disabled
+			if (!\JLanguageMultilang::isEnabled())
+			{
+				unset($this->activeFilters['language']);
+				$this->filterForm->removeField('language', 'filter');
+			}
 		}
 		// If in modal layout.
 		else

--- a/administrator/components/com_modules/forms/filter_modules.xml
+++ b/administrator/components/com_modules/forms/filter_modules.xml
@@ -89,8 +89,8 @@
 			<option value="pages DESC">COM_MODULES_HEADING_PAGES_DESC</option>
 			<option value="ag.title ASC">JGRID_HEADING_ACCESS_ASC</option>
 			<option value="ag.title DESC">JGRID_HEADING_ACCESS_DESC</option>
-			<option value="l.title ASC">JGRID_HEADING_LANGUAGE_ASC</option>
-			<option value="l.title DESC">JGRID_HEADING_LANGUAGE_DESC</option>
+			<option value="l.title ASC" requires="multilanguage">JGRID_HEADING_LANGUAGE_ASC</option>
+			<option value="l.title DESC" requires="multilanguage">JGRID_HEADING_LANGUAGE_DESC</option>
 			<option value="a.id ASC">JGRID_HEADING_ID_ASC</option>
 			<option value="a.id DESC">JGRID_HEADING_ID_DESC</option>
 		</field>

--- a/administrator/components/com_modules/tmpl/module/edit.php
+++ b/administrator/components/com_modules/tmpl/module/edit.php
@@ -150,8 +150,12 @@ $tmpl    = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=c
 						);
 
 						?>
-						<?php echo JLayoutHelper::render('joomla.edit.global', $this); ?>
-					</div>
+						<?php if ($this->item->client_id == 0) : ?>
+							<?php echo JLayoutHelper::render('joomla.edit.global', $this); ?>
+						<?php else : ?>
+							<?php echo JLayoutHelper::render('joomla.edit.admin_modules', $this); ?>
+						<?php endif; ?>
+ 					</div>
 				</div>
 			</div>
 		</div>

--- a/administrator/components/com_modules/tmpl/modules/default.php
+++ b/administrator/components/com_modules/tmpl/modules/default.php
@@ -57,7 +57,7 @@ $colSpan = $clientId === 1 ? 8 : 10;
 						<th style="width:10%" class="nowrap hidden-sm-down text-center">
 							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ACCESS', 'ag.title', $listDirn, $listOrder); ?>
 						</th>
-						<?php if ($clientId === 0) : ?>
+						<?php if (($clientId === 0) && (JLanguageMultilang::isEnabled())) : ?>
 						<th style="width:10%" class="nowrap hidden-sm-down text-center">
 							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'l.title', $listDirn, $listOrder); ?>
 						</th>
@@ -166,7 +166,7 @@ $colSpan = $clientId === 1 ? 8 : 10;
 						<td class="small hidden-sm-down text-center">
 							<?php echo $this->escape($item->access_level); ?>
 						</td>
-						<?php if ($clientId === 0) : ?>
+						<?php if (($clientId === 0) && (JLanguageMultilang::isEnabled())) : ?>
 						<td class="small hidden-sm-down text-center">
 							<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
 						</td>

--- a/administrator/components/com_newsfeeds/View/Newsfeeds/HtmlView.php
+++ b/administrator/components/com_newsfeeds/View/Newsfeeds/HtmlView.php
@@ -80,6 +80,13 @@ class HtmlView extends BaseHtmlView
 		{
 			$this->addToolbar();
 			$this->sidebar = \JHtmlSidebar::render();
+
+			// We do not need to filter by language when multilingual is disabled
+			if (!\JLanguageMultilang::isEnabled())
+			{
+				unset($this->activeFilters['language']);
+				$this->filterForm->removeField('language', 'filter');
+			}			
 		}
 		else
 		{

--- a/administrator/components/com_newsfeeds/View/Newsfeeds/HtmlView.php
+++ b/administrator/components/com_newsfeeds/View/Newsfeeds/HtmlView.php
@@ -86,7 +86,7 @@ class HtmlView extends BaseHtmlView
 			{
 				unset($this->activeFilters['language']);
 				$this->filterForm->removeField('language', 'filter');
-			}			
+			}
 		}
 		else
 		{

--- a/administrator/components/com_newsfeeds/forms/filter_newsfeeds.xml
+++ b/administrator/components/com_newsfeeds/forms/filter_newsfeeds.xml
@@ -103,8 +103,8 @@
 				>
 				JASSOCIATIONS_DESC
 			</option>
-			<option value="language_title ASC">JGRID_HEADING_LANGUAGE_ASC</option>
-			<option value="language_title DESC">JGRID_HEADING_LANGUAGE_DESC</option>
+			<option value="language_title ASC" requires="multilanguage">JGRID_HEADING_LANGUAGE_ASC</option>
+			<option value="language_title DESC" requires="multilanguage">JGRID_HEADING_LANGUAGE_DESC</option>
 			<option value="a.id ASC">JGRID_HEADING_ID_ASC</option>
 			<option value="a.id DESC">JGRID_HEADING_ID_DESC</option>
 		</field>

--- a/administrator/components/com_newsfeeds/tmpl/newsfeeds/default.php
+++ b/administrator/components/com_newsfeeds/tmpl/newsfeeds/default.php
@@ -69,9 +69,11 @@ if ($saveOrder && !empty($this->items))
 									<?php echo JHtml::_('searchtools.sort', 'COM_NEWSFEEDS_HEADING_ASSOCIATION', 'association', $listDirn, $listOrder); ?>
 								</th>
 								<?php endif; ?>
-								<th style="width:10%" class="nowrap hidden-sm-down text-center">
-									<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'language_title', $listDirn, $listOrder); ?>
-								</th>
+								<?php if (JLanguageMultilang::isEnabled()) : ?>
+									<th style="width:10%" class="nowrap hidden-sm-down text-center">
+										<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'language_title', $listDirn, $listOrder); ?>
+									</th>
+								<?php endif; ?>
 								<th style="width:5%" class="nowrap hidden-sm-down text-center">
 									<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>
 								</th>
@@ -157,9 +159,11 @@ if ($saveOrder && !empty($this->items))
 									<?php endif; ?>
 								</td>
 								<?php endif; ?>
-								<td class="small hidden-sm-down text-center">
-									<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
-								</td>
+								<?php if (JLanguageMultilang::isEnabled()) : ?>
+									<td class="small hidden-sm-down text-center">
+										<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
+									</td>
+								<?php endif; ?>
 								<td class="hidden-sm-down text-center">
 									<?php echo (int) $item->id; ?>
 								</td>

--- a/administrator/components/com_tags/View/Tags/HtmlView.php
+++ b/administrator/components/com_tags/View/Tags/HtmlView.php
@@ -114,6 +114,13 @@ class HtmlView extends BaseHtmlView
 		if ($this->getLayout() !== 'modal')
 		{
 			$this->addToolbar();
+			
+			// We do not need to filter by language when multilingual is disabled
+			if (!\JLanguageMultilang::isEnabled())
+			{
+				unset($this->activeFilters['language']);
+				$this->filterForm->removeField('language', 'filter');
+			}
 		}
 
 		parent::display($tpl);

--- a/administrator/components/com_tags/View/Tags/HtmlView.php
+++ b/administrator/components/com_tags/View/Tags/HtmlView.php
@@ -114,7 +114,7 @@ class HtmlView extends BaseHtmlView
 		if ($this->getLayout() !== 'modal')
 		{
 			$this->addToolbar();
-			
+
 			// We do not need to filter by language when multilingual is disabled
 			if (!\JLanguageMultilang::isEnabled())
 			{

--- a/administrator/components/com_tags/forms/filter_tags.xml
+++ b/administrator/components/com_tags/forms/filter_tags.xml
@@ -64,8 +64,8 @@
 			<option value="a.title DESC">JGLOBAL_TITLE_DESC</option>
 			<option value="a.access ASC">JGRID_HEADING_ACCESS_ASC</option>
 			<option value="a.access DESC">JGRID_HEADING_ACCESS_DESC</option>
-			<option value="a.language ASC">JGRID_HEADING_LANGUAGE_ASC</option>
-			<option value="a.language DESC">JGRID_HEADING_LANGUAGE_DESC</option>
+			<option value="a.language ASC" requires="multilanguage">JGRID_HEADING_LANGUAGE_ASC</option>
+			<option value="a.language DESC" requires="multilanguage">JGRID_HEADING_LANGUAGE_DESC</option>
 			<option value="a.id ASC">JGRID_HEADING_ID_ASC</option>
 			<option value="a.id DESC">JGRID_HEADING_ID_DESC</option>
 		</field>

--- a/administrator/components/com_tags/tmpl/tags/default.php
+++ b/administrator/components/com_tags/tmpl/tags/default.php
@@ -240,7 +240,7 @@ if ($saveOrder && !empty($this->items))
 							<td class="small nowrap hidden-sm-down text-center">
 								<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
 							</td>
-							<?php endif; ?>
+						<?php endif; ?>
 						<td class="hidden-sm-down text-center">
 							<span title="<?php echo sprintf('%d-%d', $item->lft, $item->rgt); ?>">
 								<?php echo (int) $item->id; ?></span>

--- a/administrator/components/com_tags/tmpl/tags/default.php
+++ b/administrator/components/com_tags/tmpl/tags/default.php
@@ -108,9 +108,11 @@ if ($saveOrder && !empty($this->items))
 						<th style="width:10%" class="nowrap hidden-sm-down text-center">
 							<?php echo JHtml::_('searchtools.sort',  'JGRID_HEADING_ACCESS', 'a.access', $listDirn, $listOrder); ?>
 						</th>
-						<th style="width:10%" class="nowrap hidden-sm-down text-center">
-							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'a.language', $this->state->get('list.direction'), $this->state->get('list.ordering')); ?>
-						</th>
+						<?php if (JLanguageMultilang::isEnabled()) : ?>
+							<th style="width:10%" class="nowrap hidden-sm-down text-center">
+								<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'a.language', $this->state->get('list.direction'), $this->state->get('list.ordering')); ?>
+							</th>
+						<?php endif; ?>
 						<th style="width:5%" class="nowrap hidden-sm-down text-center">
 							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>
 						</th>
@@ -234,9 +236,11 @@ if ($saveOrder && !empty($this->items))
 						<td class="small hidden-sm-down text-center">
 							<?php echo $this->escape($item->access_title); ?>
 						</td>
-						<td class="small nowrap hidden-sm-down text-center">
-							<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
-						</td>
+						<?php if (JLanguageMultilang::isEnabled()) : ?>
+							<td class="small nowrap hidden-sm-down text-center">
+								<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
+							</td>
+							<?php endif; ?>
 						<td class="hidden-sm-down text-center">
 							<span title="<?php echo sprintf('%d-%d', $item->lft, $item->rgt); ?>">
 								<?php echo (int) $item->id; ?></span>

--- a/administrator/components/com_templates/View/Style/HtmlView.php
+++ b/administrator/components/com_templates/View/Style/HtmlView.php
@@ -70,6 +70,12 @@ class HtmlView extends BaseHtmlView
 		{
 			throw new \JViewGenericdataexception(implode("\n", $errors), 500);
 		}
+		
+		if ((!\JLanguageMultilang::isEnabled()) && ($this->item->client_id == 0))
+		{
+			$this->form->setFieldAttribute('home', 'type', 'radio');
+			$this->form->setFieldAttribute('home', 'class', 'switcher');
+		}	
 
 		$this->addToolbar();
 

--- a/administrator/components/com_templates/View/Style/HtmlView.php
+++ b/administrator/components/com_templates/View/Style/HtmlView.php
@@ -70,12 +70,12 @@ class HtmlView extends BaseHtmlView
 		{
 			throw new \JViewGenericdataexception(implode("\n", $errors), 500);
 		}
-		
+
 		if ((!\JLanguageMultilang::isEnabled()) && ($this->item->client_id == 0))
 		{
 			$this->form->setFieldAttribute('home', 'type', 'radio');
 			$this->form->setFieldAttribute('home', 'class', 'switcher');
-		}	
+		}
 
 		$this->addToolbar();
 

--- a/components/com_config/tmpl/modules/default.php
+++ b/components/com_config/tmpl/modules/default.php
@@ -146,14 +146,17 @@ JFactory::getDocument()->addScriptDeclaration("
 						</div>
 					</div>
 
-					<div class="control-group">
-						<div class="control-label">
-							<?php echo $this->form->getLabel('language'); ?>
+					<?php if (\JLanguageMultilang::isEnabled()) : ?>
+						<div class="control-group">
+							<div class="control-label">
+								<?php echo $this->form->getLabel('language'); ?>
+							</div>
+							<div class="controls">
+								<?php echo $this->form->getInput('language'); ?>
+							</div>
 						</div>
-						<div class="controls">
-							<?php echo $this->form->getInput('language'); ?>
-						</div>
-					</div>
+					<?php endif; ?>
+					
 					<div class="control-group">
 						<div class="control-label">
 							<?php echo $this->form->getLabel('note'); ?>

--- a/components/com_config/tmpl/modules/default.php
+++ b/components/com_config/tmpl/modules/default.php
@@ -156,7 +156,7 @@ JFactory::getDocument()->addScriptDeclaration("
 							</div>
 						</div>
 					<?php endif; ?>
-					
+
 					<div class="control-group">
 						<div class="control-label">
 							<?php echo $this->form->getLabel('note'); ?>

--- a/components/com_contact/forms/filter_contacts.xml
+++ b/components/com_contact/forms/filter_contacts.xml
@@ -117,8 +117,8 @@
 				>
 				JASSOCIATIONS_DESC
 			</option>
-			<option value="language_title ASC">JGRID_HEADING_LANGUAGE_ASC</option>
-			<option value="language_title DESC">JGRID_HEADING_LANGUAGE_DESC</option>
+			<option value="language_title ASC" requires="multilanguage">JGRID_HEADING_LANGUAGE_ASC</option>
+			<option value="language_title DESC" requires="multilanguage">JGRID_HEADING_LANGUAGE_DESC</option>
 			<option value="a.id ASC">JGRID_HEADING_ID_ASC</option>
 			<option value="a.id DESC">JGRID_HEADING_ID_DESC</option>
 		</field>

--- a/components/com_content/forms/filter_articles.xml
+++ b/components/com_content/forms/filter_articles.xml
@@ -113,8 +113,8 @@
 			<option value="a.access DESC">JGRID_HEADING_ACCESS_DESC</option>
 			<option value="a.created_by ASC">JAUTHOR_ASC</option>
 			<option value="a.created_by DESC">JAUTHOR_DESC</option>
-			<option value="language ASC">JGRID_HEADING_LANGUAGE_ASC</option>
-			<option value="language DESC">JGRID_HEADING_LANGUAGE_DESC</option>
+			<option value="language ASC" requires="multilanguage">JGRID_HEADING_LANGUAGE_ASC</option>
+			<option value="language DESC" requires="multilanguage">JGRID_HEADING_LANGUAGE_DESC</option>
 			<option value="a.created ASC">JDATE_ASC</option>
 			<option value="a.created DESC">JDATE_DESC</option>
 			<option value="a.id ASC">JGRID_HEADING_ID_ASC</option>

--- a/components/com_content/tmpl/form/edit.php
+++ b/components/com_content/tmpl/form/edit.php
@@ -130,9 +130,11 @@ JFactory::getDocument()->addScriptDeclaration("
 				<?php endif; ?>
 			<?php echo JHtml::_('bootstrap.endTab'); ?>
 
-			<?php echo JHtml::_('bootstrap.addTab', $this->tab_name, 'language', JText::_('JFIELD_LANGUAGE_LABEL')); ?>
-				<?php echo $this->form->renderField('language'); ?>
-			<?php echo JHtml::_('bootstrap.endTab'); ?>
+			<?php if (\JLanguageMultilang::isEnabled()) : ?>
+				<?php echo JHtml::_('bootstrap.addTab', $this->tab_name, 'language', JText::_('JFIELD_LANGUAGE_LABEL')); ?>
+					<?php echo $this->form->renderField('language'); ?>
+				<?php echo JHtml::_('bootstrap.endTab'); ?>
+			<?php endif; ?>
 
 			<?php if ($params->get('show_publishing_options', 1) == 1) : ?>	
 				<?php echo JHtml::_('bootstrap.addTab', $this->tab_name, 'metadata', JText::_('COM_CONTENT_METADATA')); ?>

--- a/components/com_fields/forms/filter_fields.xml
+++ b/components/com_fields/forms/filter_fields.xml
@@ -82,8 +82,8 @@
 			<option value="category_title DESC">COM_FIELDS_FIELD_GROUP_LABEL</option>
 			<option value="a.access ASC">JGRID_HEADING_ACCESS_ASC</option>
 			<option value="a.access DESC">JGRID_HEADING_ACCESS_DESC</option>
-			<option value="language ASC">JGRID_HEADING_LANGUAGE_ASC</option>
-			<option value="language DESC">JGRID_HEADING_LANGUAGE_DESC</option>
+			<option value="language ASC" requires="multilanguage">JGRID_HEADING_LANGUAGE_ASC</option>
+			<option value="language DESC" requires="multilanguage">JGRID_HEADING_LANGUAGE_DESC</option>
 			<option value="a.id ASC">JGRID_HEADING_ID_ASC</option>
 			<option value="a.id DESC">JGRID_HEADING_ID_DESC</option>
 		</field>

--- a/components/com_menus/forms/filter_items.xml
+++ b/components/com_menus/forms/filter_items.xml
@@ -77,8 +77,8 @@
 				<option value="a.access DESC">JGRID_HEADING_ACCESS_DESC</option>
 				<option value="association ASC" requires="associations">JASSOCIATIONS_ASC</option>
 				<option value="association DESC" requires="associations">JASSOCIATIONS_DESC</option>
-				<option value="language ASC">JGRID_HEADING_LANGUAGE_ASC</option>
-				<option value="language DESC">JGRID_HEADING_LANGUAGE_DESC</option>
+				<option value="language ASC" requires="multilanguage">JGRID_HEADING_LANGUAGE_ASC</option>
+				<option value="language DESC" requires="multilanguage">JGRID_HEADING_LANGUAGE_DESC</option>
 				<option value="a.id ASC">JGRID_HEADING_ID_ASC</option>
 				<option value="a.id DESC">JGRID_HEADING_ID_DESC</option>
 			</field>

--- a/components/com_modules/forms/filter_modules.xml
+++ b/components/com_modules/forms/filter_modules.xml
@@ -62,8 +62,8 @@
 			<option value="pages DESC">COM_MODULES_HEADING_PAGES_DESC</option>
 			<option value="ag.title ASC">JGRID_HEADING_ACCESS_ASC</option>
 			<option value="ag.title DESC">JGRID_HEADING_ACCESS_DESC</option>
-			<option value="l.title ASC">JGRID_HEADING_LANGUAGE_ASC</option>
-			<option value="l.title DESC">JGRID_HEADING_LANGUAGE_DESC</option>
+			<option value="l.title ASC" requires="multilanguage">JGRID_HEADING_LANGUAGE_ASC</option>
+			<option value="l.title DESC" requires="multilanguage">JGRID_HEADING_LANGUAGE_DESC</option>
 			<option value="a.id ASC">JGRID_HEADING_ID_ASC</option>
 			<option value="a.id DESC">JGRID_HEADING_ID_DESC</option>
 		</field>

--- a/layouts/joomla/edit/admin_modules.php
+++ b/layouts/joomla/edit/admin_modules.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('JPATH_BASE') or die;
+
+$app       = JFactory::getApplication();
+$form      = $displayData->getForm();
+$input     = $app->input;
+
+$fields = $displayData->get('fields') ?: array(
+	array('parent', 'parent_id'),
+	array('published', 'state', 'enabled'),
+	array('category', 'catid'),
+	'featured',
+	'sticky',
+	'access',
+	'language',
+	'tags',
+	'note',
+	'version_note',
+);
+
+$hiddenFields = $displayData->get('hidden_fields') ?: array();
+
+if (!JModuleHelper::isAdminMultilang())
+{
+	$hiddenFields[] = 'language';
+	$form->setFieldAttribute('language', 'default', '*');
+}
+
+$html   = array();
+$html[] = '<fieldset class="form-vertical form-no-margin">';
+
+foreach ($fields as $field)
+{
+	foreach ((array) $field as $f)
+	{
+		if ($form->getField($f))
+		{
+			if (in_array($f, $hiddenFields))
+			{
+				$form->setFieldAttribute($f, 'type', 'hidden');
+			}
+
+			$html[] = $form->renderField($f);
+			break;
+		}
+	}
+}
+
+$html[] = '</fieldset>';
+
+echo implode('', $html);

--- a/layouts/joomla/edit/admin_modules.php
+++ b/layouts/joomla/edit/admin_modules.php
@@ -9,9 +9,9 @@
 
 defined('JPATH_BASE') or die;
 
-$app       = JFactory::getApplication();
-$form      = $displayData->getForm();
-$input     = $app->input;
+$app    = JFactory::getApplication();
+$form   = $displayData->getForm();
+$input  = $app->input;
 
 $fields = $displayData->get('fields') ?: array(
 	array('parent', 'parent_id'),

--- a/layouts/joomla/edit/global.php
+++ b/layouts/joomla/edit/global.php
@@ -43,6 +43,12 @@ if (!$saveHistory)
 	$hiddenFields[] = 'version_note';
 }
 
+if (!JLanguageMultilang::isEnabled())
+{
+	$hiddenFields[] = 'language';
+	$form->setFieldAttribute('language', 'default', '*');
+}
+
 $html   = array();
 $html[] = '<fieldset class="form-vertical form-no-margin">';
 

--- a/libraries/src/Language/Multilanguage.php
+++ b/libraries/src/Language/Multilanguage.php
@@ -23,7 +23,7 @@ class Multilanguage
  	* @var    boolean
  	* @since  __DEPLOY_VERSION__
  	*/
-	 public static $enabled = false;
+	public static $enabled = false;
 
 	/**
 	 * Method to determine if the language filter plugin is enabled.

--- a/libraries/src/Language/Multilanguage.php
+++ b/libraries/src/Language/Multilanguage.php
@@ -18,6 +18,14 @@ defined('JPATH_PLATFORM') or die;
 class Multilanguage
 {
 	/**
+	* Flag indicating multilanguage functionality is enabled.
+ 	*
+ 	* @var    boolean
+ 	* @since  __DEPLOY_VERSION__
+ 	*/
+	 public static $enabled = false;
+
+	/**
 	 * Method to determine if the language filter plugin is enabled.
 	 * This works for both site and administrator.
 	 *
@@ -30,8 +38,11 @@ class Multilanguage
 		// Flag to avoid doing multiple database queries.
 		static $tested = false;
 
-		// Status of language filter plugin.
-		static $enabled = false;
+		// Do not proceed with testing if the flag is true
+		if (static::$enabled)
+		{
+			return true;
+		}
 
 		// Get application object.
 		$app = \JFactory::getApplication();
@@ -39,9 +50,9 @@ class Multilanguage
 		// If being called from the frontend, we can avoid the database query.
 		if ($app->isClient('site'))
 		{
-			$enabled = $app->getLanguageFilter();
+			static::$enabled = $app->getLanguageFilter();
 
-			return $enabled;
+			return static::$enabled;
 		}
 
 		// If already tested, don't test again.
@@ -57,11 +68,11 @@ class Multilanguage
 				->where($db->quoteName('element') . ' = ' . $db->quote('languagefilter'));
 			$db->setQuery($query);
 
-			$enabled = $db->loadResult();
+			static::$enabled = $db->loadResult();
 			$tested = true;
 		}
 
-		return (bool) $enabled;
+		return (bool) static::$enabled;
 	}
 
 	/**


### PR DESCRIPTION
Replacement for #17765 

Currently we have a column for the language on all list views and a field to select the language on all edit views

This PR removes them when you are on a non multilingual site. This simplifies the UI and removes a useless field when creating content

### Parts
- [x] Lists
- [x] Forms
- [x] Filters 
- [x] Search tools

## After PR and non multilingual
<img width="704" alt="screenshotr10-20-00" src="https://user-images.githubusercontent.com/1296369/28110930-bae13ee4-66eb-11e7-8022-2ad898c8b92d.png">

<img width="345" alt="screenshotr10-20-55" src="https://user-images.githubusercontent.com/1296369/28110956-cf470332-66eb-11e7-850b-e956aa011e9c.png">

## Before PR and After PR and multilingual
<img width="716" alt="screenshotr10-22-36" src="https://user-images.githubusercontent.com/1296369/28111041-1449186c-66ec-11e7-9936-f0e1898bfa1c.png">
<img width="291" alt="screenshotr10-22-46" src="https://user-images.githubusercontent.com/1296369/28111042-14516e86-66ec-11e7-99cf-feecd02e95b6.png">

## Test instructions
You don't need to install multiple languages. It is enough to enable the System - Language Filter plugin.
When enabled you will have language columns, sorts and filters AND language fields on item creation
When not enabled you never see the language columns

## Thanks
