### PR TITLE
Fix wrong namespace in OutputFilter loading

### DIFF
--- a/libraries/vendor/joomla/filter/src/OutputFilter.php
+++ b/libraries/vendor/joomla/filter/src/OutputFilter.php
@@ -8,7 +8,7 @@
 
 namespace Joomla\Filter;
 
-use Joomla\Language\Language;
+use Joomla\CMS\Language\Language;
 use Joomla\String\StringHelper;
 
 /**


### PR DESCRIPTION
### Summary of Changes
OutputFilter uses the wrong namespace for the language loading


### Testing Instructions
```
use Joomla\CMS\Filter\OutputFilter;
echo OutputFilter::stringUrlSafe('FooBar Test');
```

### Expected result
foobar-test



### Actual result
Exception

