### PR TITLE
Remove NONE value from category blog multiple tags filter

### DIFF
--- a/components/com_content/views/category/tmpl/blog.xml
+++ b/components/com_content/views/category/tmpl/blog.xml
@@ -31,9 +31,7 @@
 				label="JTAG"
 				description="JTAG_FIELD_SELECT_DESC"
 				multiple="true"
-				>
-				<option value="">JNONE</option>
-			</field>
+			/>
 		</fieldset>
 	</fields>
 


### PR DESCRIPTION
Pull Request for Issue #18785.

### Summary of Changes
With PR #18234, it is possible to select multiple tags. Therefore, it is no longer necessary to default to NONE value when no tags selected.


### Testing Instructions
- Create a Joomla article category blog menu
- Leave Tags field empty.
- Save


### Expected result
Editing a category menu should not alter its URL structure


### Actual result
Editing a category menu alters the URL structure (appends filter_tag[0]=) when no tags selected.


### Documentation Changes Required
None
