### PR TITLE
In-menu-item modal modual editor fix

### DIFF
--- a/administrator/components/com_menus/views/item/tmpl/edit_modules.php
+++ b/administrator/components/com_menus/views/item/tmpl/edit_modules.php
@@ -17,29 +17,69 @@ foreach ($this->levels as $key => $value) {
 
 JFactory::getDocument()->addScriptDeclaration('
 	var viewLevels = ' . json_encode($allLevels) . ',
-		menuId = parseInt(' . $this->item->id . ');
+		menuId = parseInt(' . (int) $this->item->id . ');
 
-	jQuery(document).ready(function() {
-		jQuery(document).on("click", "input:radio[id^=\'jform_toggle_modules_assigned1\']", function (event) {
-			jQuery(".table tr.no").hide();
-		});
-		jQuery(document).on("click", "input:radio[id^=\'jform_toggle_modules_assigned0\']", function (event) {
-			jQuery(".table tr.no").show();
-		});
-		jQuery(document).on("click", "input:radio[id^=\'jform_toggle_modules_published1\']", function (event) {
-			jQuery(".table tr.unpublished").hide();
-		});
-		jQuery(document).on("click", "input:radio[id^=\'jform_toggle_modules_published0\']", function (event) {
-			jQuery(".table tr.unpublished").show();
-		});
+	jQuery(function($) {
+		var baseLink = "index.php?option=com_modules&amp;client_id=0&amp;task=module.edit&amp;tmpl=component&amp;view=module&amp;layout=modal&amp;id=",
+			iFrameAttr = "class=\"iframe jviewport-height70\"";
+
+		$(document)
+			.on("click", "input:radio[id^=\'jform_toggle_modules_assigned1\']", function (event) {
+				$(".table tr.no").hide();
+			})
+			.on("click", "input:radio[id^=\'jform_toggle_modules_assigned0\']", function (event) {
+				$(".table tr.no").show();
+			})
+			.on("click", "input:radio[id^=\'jform_toggle_modules_published1\']", function (event) {
+				$(".table tr.unpublished").hide();
+			})
+			.on("click", "input:radio[id^=\'jform_toggle_modules_published0\']", function (event) {
+				$(".table tr.unpublished").show();
+			})
+			.on("click", ".module-edit-link", function () {
+				var link = baseLink + $(this).data("moduleId"),
+					iFrame = $("<iframe src=\"" + link + "\" " + iFrameAttr + "></iframe>");
+
+				$("#moduleEditModal").modal()
+					.find(".modal-body").empty().prepend(iFrame);
+			})
+			.on("click", "#moduleEditModal .modal-footer .btn", function () {
+				var target = $(this).data("target");
+
+				if (target) {
+					$("#moduleEditModal iframe").contents().find(target).click();
+				}
+			});
 	});
 ');
+
 JFactory::getDocument()->addStyleDeclaration('
 ul.horizontal-buttons li {
   display: inline-block;
   padding-right: 10%;
 }
 ');
+
+// Set up the bootstrap modal that will be used for all module editors
+echo JHtml::_(
+	'bootstrap.renderModal',
+	'moduleEditModal',
+	array(
+		'title'       => JText::_('COM_MENUS_EDIT_MODULE_SETTINGS'),
+		'backdrop'    => 'static',
+		'keyboard'    => false,
+		'closeButton' => false,
+		'bodyHeight'  => '70',
+		'modalWidth'  => '80',
+		'footer'      => '<a type="button" class="btn" data-dismiss="modal" data-target="#closeBtn" aria-hidden="true">'
+				. JText::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</a>'
+				. '<button type="button" class="btn btn-primary" data-dismiss="modal" data-target="#saveBtn" aria-hidden="true">'
+				. JText::_('JSAVE') . '</button>'
+				. '<button type="button" class="btn btn-success" data-target="#applyBtn" aria-hidden="true">'
+				. JText::_('JAPPLY') . '</button>',
+	)
+);
+
 ?>
 <?php
 // Set main fields.
@@ -85,8 +125,12 @@ echo JLayoutHelper::render('joomla.menu.edit_modules', $this); ?>
 			<?php endif; ?>
 			<tr class="<?php echo $no; ?><?php echo $status; ?>row<?php echo $i % 2; ?>" id="tr-<?php echo $module->id; ?>" style="display:table-row">
 				<td id="<?php echo $module->id; ?>">
-					<?php $link = 'index.php?option=com_modules&amp;client_id=0&amp;task=module.edit&amp;id=' . $module->id . '&amp;tmpl=component&amp;view=module&amp;layout=modal'; ?>
-					<a href="#moduleEdit<?php echo $module->id; ?>Modal" role="button" class="btn btn-link" data-toggle="modal" title="<?php echo JText::_('COM_MENUS_EDIT_MODULE_SETTINGS'); ?>" id="title-<?php echo $module->id; ?>">
+					<a href="#moduleEditModal"
+						role="button"
+						class="btn btn-link module-edit-link"
+						title="<?php echo JText::_('COM_MENUS_EDIT_MODULE_SETTINGS'); ?>"
+						id="title-<?php echo $module->id; ?>"
+						data-module-id="<?php echo $module->id; ?>">
 						<?php echo $this->escape($module->title); ?></a>
 				</td>
 				<td id="access-<?php echo $module->id; ?>">
@@ -131,30 +175,6 @@ echo JLayoutHelper::render('joomla.menu.edit_modules', $this); ?>
 							</span>
 						<?php endif; ?>
 				</td>
-			<?php echo JHtml::_(
-					'bootstrap.renderModal',
-					'moduleEdit' . $module->id . 'Modal',
-					array(
-						'title'       => JText::_('COM_MENUS_EDIT_MODULE_SETTINGS'),
-						'backdrop'    => 'static',
-						'keyboard'    => false,
-						'closeButton' => false,
-						'url'         => $link,
-						'height'      => '400px',
-						'width'       => '800px',
-						'bodyHeight'  => '70',
-						'modalWidth'  => '80',
-						'footer'      => '<a type="button" class="btn" data-dismiss="modal" aria-hidden="true"'
-								. ' onclick="jQuery(\'#moduleEdit' . $module->id . 'Modal iframe\').contents().find(\'#closeBtn\').click();">'
-								. JText::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</a>'
-								. '<button type="button" class="btn btn-primary" aria-hidden="true"'
-								. ' onclick="jQuery(\'#moduleEdit' . $module->id . 'Modal iframe\').contents().find(\'#saveBtn\').click();">'
-								. JText::_('JSAVE') . '</button>'
-								. '<button type="button" class="btn btn-success" aria-hidden="true"'
-								. ' onclick="jQuery(\'#moduleEdit' . $module->id . 'Modal iframe\').contents().find(\'#applyBtn\').click();">'
-								. JText::_('JAPPLY') . '</button>',
-					)
-				); ?>
 			</tr>
 		<?php endforeach; ?>
 		</tbody>


### PR DESCRIPTION
Pull Request for Issue #18979 .

### Summary of Changes
Instead of one modal per module -> one generalized modal for ALL modules
Instead of specific js functions for each modal -> generalized js for ALL modals


### Testing Instructions
1. Have a lot of modules
2. Edit a menu item


### Expected result
Only one modal should be created and reused for all module editors.
Minimal, generalized js should be written to handle all modals.
More modules should not mean more js/html code.

### Actual result
Before this patch, it's possible to get out of memory error if you have enough modules.
After, should not be possible.

### Documentation Changes Required
Nope
