### PR TITLE
Fix fatal error in getCategoryId method in several router classes

### DIFF
--- a/components/com_contact/router.php
+++ b/components/com_contact/router.php
@@ -143,22 +143,25 @@ class ContactRouter extends JComponentRouterView
 	{
 		if (isset($query['id']))
 		{
-			$category = JCategories::getInstance($this->getName())->get($query['id']);
+			$category = JCategories::getInstance($this->getName(), array('access' => false))->get($query['id']);
 
-			foreach ($category->getChildren() as $child)
+			if ($category)
 			{
-				if ($this->noIDs)
+				foreach ($category->getChildren() as $child)
 				{
-					if ($child->alias == $segment)
+					if ($this->noIDs)
 					{
-						return $child->id;
+						if ($child->alias == $segment)
+						{
+							return $child->id;
+						}
 					}
-				}
-				else
-				{
-					if ($child->id == (int) $segment)
+					else
 					{
-						return $child->id;
+						if ($child->id == (int) $segment)
+						{
+							return $child->id;
+						}
 					}
 				}
 			}

--- a/components/com_content/router.php
+++ b/components/com_content/router.php
@@ -162,22 +162,25 @@ class ContentRouter extends JComponentRouterView
 	{
 		if (isset($query['id']))
 		{
-			$category = JCategories::getInstance($this->getName())->get($query['id']);
+			$category = JCategories::getInstance($this->getName(), array('access' => false))->get($query['id']);
 
-			foreach ($category->getChildren() as $child)
+			if ($category)
 			{
-				if ($this->noIDs)
+				foreach ($category->getChildren() as $child)
 				{
-					if ($child->alias == $segment)
+					if ($this->noIDs)
 					{
-						return $child->id;
+						if ($child->alias == $segment)
+						{
+							return $child->id;
+						}
 					}
-				}
-				else
-				{
-					if ($child->id == (int) $segment)
+					else
 					{
-						return $child->id;
+						if ($child->id == (int) $segment)
+						{
+							return $child->id;
+						}
 					}
 				}
 			}

--- a/components/com_newsfeeds/router.php
+++ b/components/com_newsfeeds/router.php
@@ -141,22 +141,25 @@ class NewsfeedsRouter extends JComponentRouterView
 	{
 		if (isset($query['id']))
 		{
-			$category = JCategories::getInstance($this->getName())->get($query['id']);
+			$category = JCategories::getInstance($this->getName(), array('access' => false))->get($query['id']);
 
-			foreach ($category->getChildren() as $child)
+			if ($category)
 			{
-				if ($this->noIDs)
+				foreach ($category->getChildren() as $child)
 				{
-					if ($child->alias === $segment)
+					if ($this->noIDs)
 					{
-						return $child->id;
+						if ($child->alias === $segment)
+						{
+							return $child->id;
+						}
 					}
-				}
-				else
-				{
-					if ($child->id == (int) $segment)
+					else
 					{
-						return $child->id;
+						if ($child->id == (int) $segment)
+						{
+							return $child->id;
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Pull Request for Issue #18927.

### Summary of Changes
This PR fixes **"Call to a member function getChildren() on null" Error** for modern routing when Joomla parses a SEF URL which is linked to a category which user doesn't have access to. See https://github.com/joomla/joomla-cms/issues/18927 for issue description

Technical, this PR does two things:

1. Add 'access' => false to JCategories::getInstance method calls so that access level is not checked when getting category

2. Add a check to make sure a valid category is returned before calling later code (avoid fatal error)

### Testing Instructions

1. Confirm the issue described at https://github.com/joomla/joomla-cms/issues/18927

2. Apply patch, confirm the issue is fixed

Ping @justinherrin for testing since he reported the issue.