### PR TITLE
Using the current date as alias in system menu items if alias is empty.

### DIFF
--- a/libraries/src/Table/Menu.php
+++ b/libraries/src/Table/Menu.php
@@ -147,7 +147,10 @@ class Menu extends Nested
 		// Verify that the alias is unique
 		$table = Table::getInstance('Menu', 'JTable', array('dbo' => $this->getDbo()));
 
-		$originalAlias = trim($this->alias);
+		$aliasDate   = \JFactory::getDate()->format('Y-m-d-H-i-s');
+		$systemTypes = array('url', 'heading', 'alias', 'separator');
+
+		$originalAlias = (empty($this->alias) && in_array($this->type, $systemTypes)) ? $aliasDate : trim($this->alias);
 		$this->alias   = !$originalAlias ? $this->title : $originalAlias;
 		$this->alias   = ApplicationHelper::stringURLSafe(trim($this->alias), $this->language);
 


### PR DESCRIPTION
### Summary of Changes
Commit returns the old function of using the current date as alias in system menu items if alias is empty. 


### Testing Instructions
* Install Joomla 3.8.2
* Apply this path
* Create any system menu items (url, heading, alias,'separator)
**Leave the alias field empty.**

### Expected result
Alias of this menu item will look like this `2017-12-05-15-29-29`
