### PR TITLE
[4.0] Fix FieldModel::getTable method

### DIFF
--- a/administrator/components/com_fields/Model/FieldModel.php
+++ b/administrator/components/com_fields/Model/FieldModel.php
@@ -401,7 +401,7 @@ class FieldModel extends AdminModel
 	 * @since   3.7.0
 	 * @throws  \Exception
 	 */
-	public function getTable($name = 'Field', $prefix = 'FieldsTable', $options = array())
+	public function getTable($name = '', $prefix = '', $options = array())
 	{
 		// Default to text type
 		$table       = parent::getTable($name, $prefix, $options);

--- a/administrator/components/com_fields/Table/Field.php
+++ b/administrator/components/com_fields/Table/Field.php
@@ -10,6 +10,11 @@ namespace Joomla\Component\Fields\Administrator\Table;
 
 defined('_JEXEC') or die;
 
+/**
+ * Field table
+ *
+ * @since  3.7.0
+ */
 class Field extends FieldTable
 {
 }

--- a/administrator/components/com_fields/Table/Field.php
+++ b/administrator/components/com_fields/Table/Field.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_fields
+ *
+ * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+namespace Joomla\Component\Fields\Administrator\Table;
+
+defined('_JEXEC') or die;
+
+class Field extends FieldTable
+{
+}


### PR DESCRIPTION
[4.0] [com_fields] Error when creating field

Pull Request for Issue #18920  .

### Summary of Changes

getTable method doesn't need name or prefix value to load the correct table class

### Testing Instructions

Attempting to create a field in a fresh install results in "Component\Fields\Administrator\Table\Field' not found"

### Expected result

Field is saved

### Actual result

Error: Component\Fields\Administrator\Table\Field' not found

### Documentation Changes Required

This restores normal function