### PR TITLE
[4.0] Fix issue #18973 tinymce Illegal string offset error

### DIFF
--- a/plugins/editors-xtd/fields/fields.php
+++ b/plugins/editors-xtd/fields/fields.php
@@ -64,7 +64,12 @@ class PlgButtonFields extends JPlugin
 		$button->link    = $link;
 		$button->text    = JText::_('PLG_EDITORS-XTD_FIELDS_BUTTON_FIELD');
 		$button->name    = 'puzzle';
-		$button->options = "{handler: 'iframe', size: {x: 800, y: 500}}";
+		$button->options = array(
+			'height'     => '300px',
+			'width'      => '800px',
+			'bodyHeight' => '70',
+			'modalWidth' => '80',
+		);
 
 		return $button;
 	}


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This small PR fixes the issue #18973. The code at the below lines https://github.com/joomla/joomla-cms/blob/4.0-dev/plugins/editors/tinymce/tinymce.php#L755-L756 expects $options is an array but string is passed PlgButtonFields plugin and it causes the error

I just modified code to pass an array (like other editor-xtd plugins) to get the issue sorted

### Testing Instructions

1. Confirm the issue described at https://github.com/joomla/joomla-cms/issues/18973
2. Apply patch, confirm the warning messages gone
3. Click on Field button in TinyMCE plugin, make sure the popup opens and you can select the field

You might need to enable the plugin Button - Field if it is not enabled on your Joomla 4 installation