### PR TITLE
[4.0] Change some menu icons

### DIFF
--- a/administrator/components/com_menus/presets/joomla.xml
+++ b/administrator/components/com_menus/presets/joomla.xml
@@ -193,12 +193,12 @@
 		type="component"
 		element="com_media"
 		link="index.php?option=com_media"
-		class="class:file-image-o"
+		class="class:image"
 	/>
 	<menuitem
 		title="MOD_MENU_COM_CONTENT"
 		type="heading"
-		class="class:file-text-o"
+		class="class:file-text"
 		>
 		<menuitem
 			title="MOD_MENU_COM_CONTENT_ARTICLE_MANAGER"

--- a/administrator/components/com_menus/presets/modern.xml
+++ b/administrator/components/com_menus/presets/modern.xml
@@ -193,12 +193,12 @@
 		type="component"
 		element="com_media"
 		link="index.php?option=com_media"
-		class="class:file-image-o"
+		class="class:image"
 	/>
 	<menuitem
 		title="MOD_MENU_COM_CONTENT"
 		type="heading"
-		class="class:file-text-o"
+		class="class:file-text"
 		>
 		<menuitem
 			title="MOD_MENU_COM_CONTENT_ARTICLE_MANAGER"


### PR DESCRIPTION
### Summary of Changes

The `com_media` and `com_content` icons were very similar and I found myself accidentally clicking on the wrong one about 90% of the time.

So this PR changes the icons

Left = Before
Right = After

![screeny](https://user-images.githubusercontent.com/2019801/33665055-816fab26-da8d-11e7-9f04-e81fff77558f.png)
