### PR TITLE
[4.0] Correct default value for $prefix parameter

### DIFF
--- a/administrator/components/com_fields/Model/FieldModel.php
+++ b/administrator/components/com_fields/Model/FieldModel.php
@@ -401,7 +401,7 @@ class FieldModel extends AdminModel
 	 * @since   3.7.0
 	 * @throws  \Exception
 	 */
-	public function getTable($name = 'Field', $prefix = 'FieldsTable', $options = array())
+	public function getTable($name = 'Field', $prefix = 'Administrator', $options = array())
 	{
 		// Default to text type
 		$table       = parent::getTable($name, $prefix, $options);


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
The default value for $prefix parameter in getTable method should be **Administrator** instead of **FieldsTable**. It helps prevent Joomla from having to execute some unnecessary code (see https://github.com/joomla/joomla-cms/blob/4.0-dev/libraries/src/MVC/Factory/MVCFactory.php#L128 for the logic)

### Testing Instructions
Could be merged on code review.
