### PR TITLE
[com_fields] Handle tag items properly

### DIFF
--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -501,7 +501,7 @@ class PlgSystemFields extends JPlugin
 	private function prepareTagItem($item)
 	{
 		// Map core fields
-		$item->id       = $item->core_content_id;
+		$item->id       = $item->content_item_id;
 		$item->language = $item->core_language;
 
 		// Also handle the catid

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -320,6 +320,15 @@ class PlgSystemFields extends JPlugin
 
 		$context = $parts[0] . '.' . $parts[1];
 
+		// Convert tags
+		if ($context == 'com_tags.tag' && !empty($item->type_alias))
+		{
+			// Set the context
+			$context = $item->type_alias;
+
+			$item = $this->prepareTagItem($item);
+		}
+
 		if (is_string($params) || !$params)
 		{
 			$params = new Registry($params);
@@ -397,7 +406,18 @@ class PlgSystemFields extends JPlugin
 			return;
 		}
 
-		$fields = FieldsHelper::getFields($parts[0] . '.' . $parts[1], $item, true);
+		$context = $parts[0] . '.' . $parts[1];
+
+		// Convert tags
+		if ($context == 'com_tags.tag' && !empty($item->type_alias))
+		{
+			// Set the context
+			$context = $item->type_alias;
+
+			$item = $this->prepareTagItem($item);
+		}
+
+		$fields = FieldsHelper::getFields($context, $item, true);
 
 		// Adding the fields to the object
 		$item->jcfields = array();
@@ -467,5 +487,29 @@ class PlgSystemFields extends JPlugin
 		}
 
 		return true;
+	}
+
+	/**
+	 * Prepares a tag item to be ready for com_fields.
+	 *
+	 * @param   stdClass  $item  The item
+	 *
+	 * @return  object
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	private function prepareTagItem($item)
+	{
+		// Map core fields
+		$item->id       = $item->core_content_id;
+		$item->language = $item->core_language;
+
+		// Also handle the catid
+		if (!empty($item->core_catid))
+		{
+			$item->catid = $item->core_catid;
+		}
+
+		return $item;
 	}
 }


### PR DESCRIPTION
Pull Request for Issue #18992.

### Summary of Changes
Prepares an item in the tags view with the custom fields. It mapps the tag context to the propper one of the item which has the tag.

### Testing Instructions
- Create an article custom field.
- Create an article with a value of the custom field and give it a tag.
- Create a menu item "Tagged Items" and select the tag you gave the article, also set "Item Description" to Show as on the screenshot below
![image](https://user-images.githubusercontent.com/251072/33678643-a00d2f70-dabc-11e7-9c84-c85ee3f1d518.png)
- Open the menu on the front

### Expected result
The custom fields are shown on the item.

### Actual result
No custom fields are shown.