### PR TITLE
[4.0] Use the namespace for the fieldgroups field in Contacts

### DIFF
--- a/administrator/components/com_contact/config.xml
+++ b/administrator/components/com_contact/config.xml
@@ -5,7 +5,6 @@
 		name="contact"
 		label="COM_CONTACT_FIELD_CONFIG_INDIVIDUAL_CONTACT_DISPLAY"
 		description="COM_CONTACT_FIELD_CONFIG_INDIVIDUAL_CONTACT_DESC"
-		addfieldpath="/administrator/components/com_fields/models/fields"
 		>
 
 		<field
@@ -243,7 +242,7 @@
 			label="COM_CONTACT_FIELD_PARAMS_WEBPAGE_LABEL"
 			default="1"
 			class="switcher"
-			showon="show_info:1"			
+			showon="show_info:1"
 			>
 			<option value="0">JHIDE</option>
 			<option value="1">JSHOW</option>
@@ -343,6 +342,7 @@
 			label="COM_CONTACT_FIELD_USER_CUSTOM_FIELDS_SHOW_LABEL"
 			multiple="true"
 			context="com_users.user"
+			addfieldprefix="Joomla\Component\Fields\Administrator\Field"
 			>
 			<option value="-1">JALL</option>
 		</field>


### PR DESCRIPTION
Pull Request for Issue #17213.

### Summary of Changes
The contacts configuration should use the addfieldprefix parameter to load the fields from com_fields.

### Testing Instructions
Open the contacts configuration and scroll down to the parameter _Show User Custom Fields_.

### Expected result
A multi select box is displayed.

### Actual result
An error is shown within the field.