### PR TITLE
[bug] Multilingual: Show articles associations also displays the current item flag/langcode

### DIFF
--- a/components/com_content/views/category/tmpl/default_articles.php
+++ b/components/com_content/views/category/tmpl/default_articles.php
@@ -147,12 +147,12 @@ $tableClass = $this->params->get('show_headings') != 1 ? ' table-noheader' : '';
 						<?php $associations = ContentHelperAssociation::displayAssociations($article->id); ?>
 						<?php foreach ($associations as $association) : ?>
 							<?php if ($association['language']->lang_code != JFactory::getLanguage()->getTag()) : ?>
-								<?php if ($this->params->get('flags', 1)) : ?>
+								<?php if ($this->params->get('flags', 1) && $association['language']->image) : ?>
 									<?php $flag = JHtml::_('image', 'mod_languages/' . $association['language']->image . '.gif', $association['language']->title_native, array('title' => $association['language']->title_native), true); ?>
 									&nbsp;<a href="<?php echo JRoute::_($association['item']); ?>"><?php echo $flag; ?></a>&nbsp;
 								<?php else : ?>
 									<?php $class = 'label label-association label-' . $association['language']->sef; ?>
-									&nbsp;<a class="' . <?php echo $class; ?> . '" href="<?php echo JRoute::_($association['item']); ?>"><?php echo strtoupper($association['language']->sef); ?></a>&nbsp;
+									&nbsp;<a class="<?php echo $class; ?>" href="<?php echo JRoute::_($association['item']); ?>"><?php echo strtoupper($association['language']->sef); ?></a>&nbsp;
 								<?php endif; ?>
 							<?php endif; ?>
 						<?php endforeach; ?>

--- a/components/com_content/views/category/tmpl/default_articles.php
+++ b/components/com_content/views/category/tmpl/default_articles.php
@@ -146,12 +146,14 @@ $tableClass = $this->params->get('show_headings') != 1 ? ' table-noheader' : '';
 					<?php if (JLanguageAssociations::isEnabled() && $this->params->get('show_associations')) : ?>
 						<?php $associations = ContentHelperAssociation::displayAssociations($article->id); ?>
 						<?php foreach ($associations as $association) : ?>
-							<?php if ($this->params->get('flags', 1)) : ?>
-								<?php $flag = JHtml::_('image', 'mod_languages/' . $association['language']->image . '.gif', $association['language']->title_native, array('title' => $association['language']->title_native), true); ?>
-								&nbsp;<a href="<?php echo JRoute::_($association['item']); ?>"><?php echo $flag; ?></a>&nbsp;
-							<?php else : ?>
-								<?php $class = 'label label-association label-' . $association['language']->sef; ?>
-								&nbsp;<a class="' . <?php echo $class; ?> . '" href="<?php echo JRoute::_($association['item']); ?>"><?php echo strtoupper($association['language']->sef); ?></a>&nbsp;
+							<?php if ($association['language']->lang_code != JFactory::getLanguage()->getTag()) : ?>
+								<?php if ($this->params->get('flags', 1)) : ?>
+									<?php $flag = JHtml::_('image', 'mod_languages/' . $association['language']->image . '.gif', $association['language']->title_native, array('title' => $association['language']->title_native), true); ?>
+									&nbsp;<a href="<?php echo JRoute::_($association['item']); ?>"><?php echo $flag; ?></a>&nbsp;
+								<?php else : ?>
+									<?php $class = 'label label-association label-' . $association['language']->sef; ?>
+									&nbsp;<a class="' . <?php echo $class; ?> . '" href="<?php echo JRoute::_($association['item']); ?>"><?php echo strtoupper($association['language']->sef); ?></a>&nbsp;
+								<?php endif; ?>
 							<?php endif; ?>
 						<?php endforeach; ?>
 					<?php endif; ?>

--- a/layouts/joomla/content/info_block/associations.php
+++ b/layouts/joomla/content/info_block/associations.php
@@ -11,15 +11,18 @@ defined('JPATH_BASE') or die;
 ?>
 <?php if (!empty($displayData['item']->associations)) : ?>
 <?php $associations = $displayData['item']->associations; ?>
+
 <dd class="association">
 	<?php echo JText::_('JASSOCIATIONS'); ?>
 	<?php foreach ($associations as $association) : ?>
-		<?php if ($displayData['item']->params->get('flags', 1) && $association['language']->image) : ?>
-			<?php $flag = JHtml::_('image', 'mod_languages/' . $association['language']->image . '.gif', $association['language']->title_native, array('title' => $association['language']->title_native), true); ?>
-			&nbsp;<a href="<?php echo JRoute::_($association['item']); ?>"><?php echo $flag; ?></a>&nbsp;
-		<?php else : ?>
-			<?php $class = 'label label-association label-' . $association['language']->sef; ?>
-			&nbsp;<a class="' . <?php echo $class; ?> . '" href="<?php echo JRoute::_($association['item']); ?>"><?php echo strtoupper($association['language']->sef); ?></a>&nbsp;
+		<?php if ($association['language']->lang_code != JFactory::getLanguage()->getTag()) : ?>
+			<?php if ($displayData['item']->params->get('flags', 1) && $association['language']->image) : ?>
+				<?php $flag = JHtml::_('image', 'mod_languages/' . $association['language']->image . '.gif', $association['language']->title_native, array('title' => $association['language']->title_native), true); ?>
+				&nbsp;<a href="<?php echo JRoute::_($association['item']); ?>"><?php echo $flag; ?></a>&nbsp;
+			<?php else : ?>
+				<?php $class = 'label label-association label-' . $association['language']->sef; ?>
+				&nbsp;<a class="' . <?php echo $class; ?> . '" href="<?php echo JRoute::_($association['item']); ?>"><?php echo strtoupper($association['language']->sef); ?></a>&nbsp;
+			<?php endif; ?>
 		<?php endif; ?>
 	<?php endforeach; ?>
 </dd>

--- a/layouts/joomla/content/info_block/associations.php
+++ b/layouts/joomla/content/info_block/associations.php
@@ -21,7 +21,7 @@ defined('JPATH_BASE') or die;
 				&nbsp;<a href="<?php echo JRoute::_($association['item']); ?>"><?php echo $flag; ?></a>&nbsp;
 			<?php else : ?>
 				<?php $class = 'label label-association label-' . $association['language']->sef; ?>
-				&nbsp;<a class="' . <?php echo $class; ?> . '" href="<?php echo JRoute::_($association['item']); ?>"><?php echo strtoupper($association['language']->sef); ?></a>&nbsp;
+				&nbsp;<a class="<?php echo $class; ?>" href="<?php echo JRoute::_($association['item']); ?>"><?php echo strtoupper($association['language']->sef); ?></a>&nbsp;
 			<?php endif; ?>
 		<?php endif; ?>
 	<?php endforeach; ?>


### PR DESCRIPTION
### Summary of Changes
Add conditional to display the associations for all associated articles except the current article

### Testing Instructions
Install a clean default multilingual site.
In the Articles general Options, make sure you Show Associations.
<img width="401" alt="screen shot 2017-12-07 at 11 11 14" src="https://user-images.githubusercontent.com/869724/33709974-6b699a96-db3f-11e7-857d-a31528bffc67.png">

In frontend display an article with associations, via an article menu item or a category blog or a featured articles menu item or a category list.

### Before patch

Both the associated flag and the item flag display next to `Also Available` in the infoblock or next to the article title in a category list.
<img width="435" alt="screen shot 2017-12-07 at 11 08 18" src="https://user-images.githubusercontent.com/869724/33710152-f4c0aa1e-db3f-11e7-9476-2f9231627829.png">
### After patch
Now displays what should be, i.e. only the associated article flag/lang_code
<img width="608" alt="screen shot 2017-12-07 at 11 18 26" src="https://user-images.githubusercontent.com/869724/33710288-642af49a-db40-11e7-92de-a36ddaf13b3b.png">

### Documentation Changes Required
None, this is a bug.
