### PR TITLE
[Modern Routing] make a simpler loop in StandardRules::build

### DIFF
--- a/libraries/src/Component/Router/Rules/StandardRules.php
+++ b/libraries/src/Component/Router/Rules/StandardRules.php
@@ -241,65 +241,84 @@ class StandardRules implements RulesInterface
 		}
 
 		// Get the path from the view of the current URL and parse it to the menu item
-		$path   = array_reverse($this->router->getPath($query), true);
-		$found  = false;
-		$found2 = false;
+		$path  = array_reverse($this->router->getPath($query), true);
+		$found = false;
 
-		for ($i = 0, $j = count($path); $i < $j; $i++)
+		// Id of the last added segment
+		$last_id = 0;
+
+		foreach ($path as $element => $ids)
 		{
-			reset($path);
-			$view = key($path);
+			$view = $views[$element];
 
-			if ($found)
+			if ($found === false && $item && $item->query['view'] === $element)
 			{
-				$ids = array_shift($path);
-
-				if ($views[$view]->nestable)
+				if ($view->key)
 				{
+					// Get id from menu item
+					$last_id = (int) $item->query[$view->key];
+				}
+
+				if ($view->nestable)
+				{
+					$found = true;
+				}
+				elseif ($view->children)
+				{
+					$found = true;
+
+					continue;
+				}
+			}
+
+			if ($found === false)
+			{
+				// Jump to the next view
+				continue;
+			}
+
+			if ($ids)
+			{
+				if ($view->nestable)
+				{
+					$found2 = false;
+
 					foreach (array_reverse($ids, true) as $id => $segment)
 					{
 						if ($found2)
 						{
 							$segments[] = str_replace(':', '-', $segment);
+							$last_id    = (int) $id;
 						}
-						elseif ((int) $item->query[$views[$view]->key] == (int) $id)
+						elseif (($view->parent && !$view->parent->key) || $last_id === (int) $id)
 						{
 							$found2 = true;
 						}
 					}
 				}
-				elseif (is_bool($ids))
+				elseif ($ids === true)
 				{
-					$segments[] = $views[$view]->name;
+					$segments[] = $element;
+					$last_id    = 0;
 				}
 				else
 				{
-					$segments[] = str_replace(':', '-', array_shift($ids));
-				}
-			}
-			elseif ($item->query['view'] !== $view)
-			{
-				array_shift($path);
-			}
-			else
-			{
-				if (!$views[$view]->nestable)
-				{
-					array_shift($path);
-				}
-				else
-				{
-					$i--;
-					$found2 = false;
-				}
-
-				if (count($views[$view]->children))
-				{
-					$found = true;
+					$segments[] = str_replace(':', '-', current($ids));
+					$last_id    = (int) key($ids);
 				}
 			}
 
-			unset($query[$views[$view]->parent_key]);
+			if ($view->name === $query['view'])
+			{
+				// Remove key from query
+				unset($query[$view->key]);
+			}
+
+			if ($view->parent_key)
+			{
+				// Remove parent key from query
+				unset($query[$view->parent_key]);
+			}
 		}
 
 		if ($found)

--- a/libraries/src/Component/Router/Rules/StandardRules.php
+++ b/libraries/src/Component/Router/Rules/StandardRules.php
@@ -244,20 +244,14 @@ class StandardRules implements RulesInterface
 		$path  = array_reverse($this->router->getPath($query), true);
 		$found = false;
 
-		// Id of the last added segment
-		$last_id = 0;
-
 		foreach ($path as $element => $ids)
 		{
 			$view = $views[$element];
 
 			if ($found === false && $item && $item->query['view'] === $element)
 			{
-				if ($view->key)
-				{
-					// Get id from menu item
-					$last_id = (int) $item->query[$view->key];
-				}
+				// Id of the last added segment from menu item
+				$last_id = $view->key ? (int) $item->query[$view->key] : 0;
 
 				if ($view->nestable)
 				{
@@ -290,7 +284,7 @@ class StandardRules implements RulesInterface
 							$segments[] = str_replace(':', '-', $segment);
 							$last_id    = (int) $id;
 						}
-						elseif (($view->parent && !$view->parent->key) || $last_id === (int) $id)
+						elseif ($last_id === 0 || $last_id === (int) $id)
 						{
 							$found2 = true;
 						}

--- a/libraries/src/Component/Router/Rules/StandardRules.php
+++ b/libraries/src/Component/Router/Rules/StandardRules.php
@@ -302,12 +302,6 @@ class StandardRules implements RulesInterface
 				}
 			}
 
-			if ($view->name === $query['view'])
-			{
-				// Remove key from query
-				unset($query[$view->key]);
-			}
-
 			if ($view->parent_key)
 			{
 				// Remove parent key from query


### PR DESCRIPTION
### Summary of Changes
Replace the old complex loop with a simpler one.
Remove PHP notice.
Everything should work as before.

This PR adds a way to build correct URL for below structure:

```php
$featured = new JComponentRouterViewconfiguration('featured');
$this->registerView($featured);
//$categories = new JComponentRouterViewconfiguration('categories');
//$categories->setKey('id')->setParent($featured);
//$this->registerView($categories);
$category = new JComponentRouterViewconfiguration('category');
$category->setKey('id')->setParent($featured)->setNestable()->addLayout('blog');
$this->registerView($category);
$article = new JComponentRouterViewconfiguration('article');
$article->setKey('id')->setParent($category, 'catid');
$this->registerView($article);
$this->registerView(new JComponentRouterViewconfiguration('archive'));
//$this->registerView(new JComponentRouterViewconfiguration('featured'));
$form = new JComponentRouterViewconfiguration('form');
$form->setKey('a_id');
$this->registerView($form);
```

### Testing Instructions
Install Joomla with sample data testing.
After you replace php code in `com_content/router.php` as describer above:
 -  disable all menu items for categories and category view.
 - add a featured view to menu item if missing
 - Go to `index.php/component/content/categories/` and compare link to category view before and after patch.

### Expected result
No PHP notices.
Link to the top category view should be like 
`/featured-articles/14-sample-data-articles` 

### Actual result
There is a `PHP Notice: Undefined index id on line 265`.

### Documentation Changes Required
No