### PR TITLE
[4.0] escaped some classes

### DIFF
--- a/administrator/components/com_fields/Plugin/FieldsPlugin.php
+++ b/administrator/components/com_fields/Plugin/FieldsPlugin.php
@@ -182,8 +182,8 @@ abstract class FieldsPlugin extends CMSPlugin
 
 		if ($field->default_value !== '')
 		{
-			$defaultNode = $node->appendChild(new DOMElement('default'));
-			$defaultNode->appendChild(new DOMCdataSection($field->default_value));
+			$defaultNode = $node->appendChild(new \DOMElement('default'));
+			$defaultNode->appendChild(new \DOMCdataSection($field->default_value));
 		}
 
 		// Combine the two params


### PR DESCRIPTION
unescaped classes causing issues saving default values in fields - maybe other stuff too.

Pull Request for Issue #19018  .

### Summary of Changes

Escaped some classnames

### Testing Instructions


1. Create a new field (I tried text, calendar, and one of my own field extensions)
2. type a default value
3. hit save
4. scratch your head (optional)

### Expected result

default saved

### Actual result

An error has occurred.
0 Class 'Joomla\Component\Fields\Administrator\Plugin\DOMElement' not found

### Documentation Changes Required

none