### PR TITLE
[com_fields] Encode complex values to JSON

### DIFF
--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -91,7 +91,7 @@ class PlgSystemFields extends JPlugin
 			$value = key_exists($field->name, $fieldsData) ? $fieldsData[$field->name] : null;
 
 			// JSON encode value for complex fields
-			if (is_array($value) && count($value,COUNT_NORMAL) !== count($value,COUNT_RECURSIVE))
+			if (is_array($value) && count($value, COUNT_NORMAL) !== count($value, COUNT_RECURSIVE))
 			{
 				$value = json_encode($value);
 			}

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -91,7 +91,7 @@ class PlgSystemFields extends JPlugin
 			$value = key_exists($field->name, $fieldsData) ? $fieldsData[$field->name] : null;
 
 			// JSON encode value for complex fields
-			if (is_array($value))
+			if (is_array($value) && count($value,COUNT_NORMAL) !== count($value,COUNT_RECURSIVE))
 			{
 				$value = json_encode($value);
 			}

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -95,7 +95,7 @@ class PlgSystemFields extends JPlugin
 			{
 				$value = json_encode($value);
 			}
-			
+
 			// Setting the value for the field and the item
 			$model->setFieldValue($field->id, $item->id, $value);
 		}

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -91,7 +91,8 @@ class PlgSystemFields extends JPlugin
 			$value = key_exists($field->name, $fieldsData) ? $fieldsData[$field->name] : null;
 
 			// JSON encode value for complex fields
-			if(is_array($value)) {
+			if (is_array($value))
+			{
 				$value = json_encode($value);
 			}
 			

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -90,6 +90,11 @@ class PlgSystemFields extends JPlugin
 			// Determine the value if it is available from the data
 			$value = key_exists($field->name, $fieldsData) ? $fieldsData[$field->name] : null;
 
+			// JSON encode value for complex fields
+			if(is_array($value)) {
+				$value = json_encode($value);
+			}
+			
 			// Setting the value for the field and the item
 			$model->setFieldValue($field->id, $item->id, $value);
 		}


### PR DESCRIPTION
This adjustment allows complex field types (types with more than one input) to store and retrieve data.

I'll be submitting this on the 4.0-dev branch as well

### Summary of Changes

Test value before save, if it's a multidimensional array, json encode it

### Testing Instructions

Hard to say without installing a 3rd party custom field plugin

### Expected result

it should be transparent

### Actual result

transparent on my end

### Documentation Changes Required
none
