### PR TITLE
Encode value when an array

### DIFF
--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -87,6 +87,11 @@ class PlgSystemFields extends JPlugin
 		{
 			// Determine the value if it is available from the data
 			$value = key_exists($field->name, $fieldsData) ? $fieldsData[$field->name] : null;
+			
+			// JSON encode value for complex fields
+			if(is_array($value)) {
+				$value = json_encode($value);
+			}
 
 			// Setting the value for the field and the item
 			$model->setFieldValue($field->id, $item->id, $value);


### PR DESCRIPTION
This adjustment allows complex field types (types with more than one input) to store and retrieve data.

### Summary of Changes

Test value before save, if it's an array, json encode it

### Testing Instructions

Hard to say without installing a 3rd party custom field plugin

### Expected result

it should be transparent

### Actual result

transparent on my end

### Documentation Changes Required
none
