### PR TITLE
iframe accessibility

### DIFF
--- a/components/com_wrapper/views/wrapper/tmpl/default.php
+++ b/components/com_wrapper/views/wrapper/tmpl/default.php
@@ -32,6 +32,11 @@ JHtml::_('script', 'com_wrapper/iframe-height.min.js', array('version' => 'auto'
 		height="<?php echo $this->escape($this->params->get('height')); ?>"
 		scrolling="<?php echo $this->escape($this->params->get('scrolling')); ?>"
 		frameborder="<?php echo $this->escape($this->params->get('frameborder', 1)); ?>"
+		<?php if ($this->escape($this->params->get('page_heading'))) : ?>
+			title="<?php echo $this->escape($this->params->get('page_heading')); ?>"
+		<?php else : ?>
+			title="<?php echo $this->escape($this->params->get('page_title')); ?>"
+		<?php endif; ?>
 		class="wrapper<?php echo $this->pageclass_sfx; ?>">
 		<?php echo JText::_('COM_WRAPPER_NO_IFRAMES'); ?>
 	</iframe>

--- a/modules/mod_wrapper/mod_wrapper.php
+++ b/modules/mod_wrapper/mod_wrapper.php
@@ -22,5 +22,6 @@ $height          = htmlspecialchars($params->get('height'), ENT_COMPAT, 'UTF-8')
 $scroll          = htmlspecialchars($params->get('scrolling'), ENT_COMPAT, 'UTF-8');
 $moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
 $frameborder     = htmlspecialchars($params->get('frameborder'), ENT_COMPAT, 'UTF-8');
+$ititle          = $module->title;
 
 require JModuleHelper::getLayoutPath('mod_wrapper', $params->get('layout', 'default'));

--- a/modules/mod_wrapper/tmpl/default.php
+++ b/modules/mod_wrapper/tmpl/default.php
@@ -19,6 +19,7 @@ JHtml::_('script', 'com_wrapper/iframe-height.min.js', array('version' => 'auto'
 	height="<?php echo $height; ?>"
 	scrolling="<?php echo $scroll; ?>"
 	frameborder="<?php echo $frameborder; ?>"
+	title="<?php echo $ititle; ?>"
 	class="wrapper<?php echo $moduleclass_sfx; ?>" >
 	<?php echo JText::_('MOD_WRAPPER_NO_IFRAMES'); ?>
 </iframe>


### PR DESCRIPTION
every iframe should have a title attribute
This pr ensures that the com_wrapper and mod_wrapper have a title in the iframe link

for the module it simply uses the module title
for the component it uses the menu name or if set the page heading

### Testing Instructions
Create a menu item of type wrapper and a module of type wrapper
Check the generated source code for the iframe link and you will see no title attribute

Apply the PR and check the source again and the title attribute is set