### PR TITLE
[4.0] Multilingual: Only display the articles field 'show_associations' when associations are set.

### DIFF
--- a/administrator/components/com_content/Field/AssocField.php
+++ b/administrator/components/com_content/Field/AssocField.php
@@ -3,8 +3,8 @@
  * @package     Joomla.Administrator
  * @subpackage  com_content
  *
- * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
- * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
 namespace Joomla\Component\Content\Administrator\Field;

--- a/administrator/components/com_content/Field/AssocField.php
+++ b/administrator/components/com_content/Field/AssocField.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\Component\Content\Administrator\Field;
+
+defined('_JEXEC') or die;
+
+use Joomla\CMS\Form\Field\ListField;
+use Joomla\CMS\Language\Associations;
+
+/**
+ * Form Field class for the Joomla Platform.
+ * Supports a generic list of options.
+ *
+ * @since  4.0
+ */
+class AssocField extends ListField
+{
+	/**
+	 * The form field type.
+	 *
+	 * @var    string
+	 * @since  4.0
+	 */
+	protected $type = 'Assoc';
+
+	/**
+	 * Method to attach a Form object to the field.
+	 *
+	 * @param   \SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
+	 * @param   mixed              $value    The form field value to validate.
+	 * @param   string             $group    The field name group control value. This acts as an array container for the field.
+	 *                                       For example if the field has name="foo" and the group value is set to "bar" then the
+	 *                                       full field name would end up being "bar[foo]".
+	 *
+	 * @return  boolean  True on success.
+	 *
+	 * @see     AssocField::setup()
+	 * @since   4.0
+	 */
+	public function setup(\SimpleXMLElement $element, $value, $group = null)
+	{
+		$return = parent::setup($element, $value, $group);
+
+		if (!Associations::isEnabled())
+		{
+			return false;
+		}
+
+		return $return;
+	}
+}
+

--- a/administrator/components/com_content/Field/AssocField.php
+++ b/administrator/components/com_content/Field/AssocField.php
@@ -1,6 +1,7 @@
 <?php
 /**
- * Joomla! Content Management System
+ * @package     Joomla.Administrator
+ * @subpackage  com_content
  *
  * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
@@ -14,8 +15,9 @@ use Joomla\CMS\Form\Field\ListField;
 use Joomla\CMS\Language\Associations;
 
 /**
- * Form Field class for the Joomla Platform.
+ * Assoc Field class.
  * Supports a generic list of options.
+ * Displays only when Associations are enabled.
  *
  * @since  4.0
  */
@@ -45,14 +47,11 @@ class AssocField extends ListField
 	 */
 	public function setup(\SimpleXMLElement $element, $value, $group = null)
 	{
-		$return = parent::setup($element, $value, $group);
-
 		if (!Associations::isEnabled())
 		{
 			return false;
 		}
 
-		return $return;
+		return parent::setup($element, $value, $group);
 	}
 }
-

--- a/administrator/components/com_content/forms/article.xml
+++ b/administrator/components/com_content/forms/article.xml
@@ -364,7 +364,7 @@
 
 			<field
 				name="show_associations"
-				type="list"
+				type="assoc"
 				label="JGLOBAL_SHOW_ASSOCIATIONS_LABEL"
 				useglobal="true"
 				>

--- a/components/com_content/Model/ArticlesModel.php
+++ b/components/com_content/Model/ArticlesModel.php
@@ -252,7 +252,7 @@ class ArticlesModel extends ListModel
 		if (PluginHelper::isEnabled('content', 'vote'))
 		{
 			// Join on voting table
-			$query->select('COALESCE(NULLIF(ROUND(v.rating_sum  / v.rating_count, 0), 0), 0) AS rating, 
+			$query->select('COALESCE(NULLIF(ROUND(v.rating_sum  / v.rating_count, 0), 0), 0) AS rating,
 							COALESCE(NULLIF(v.rating_count, 0), 0) as rating_count')
 				->join('LEFT', '#__content_rating AS v ON a.id = v.content_id');
 		}
@@ -687,7 +687,7 @@ class ArticlesModel extends ListModel
 				$item->tags->getItemTags('com_content.article', $item->id);
 			}
 
-			if ($item->params->get('show_associations'))
+			if (\JLanguageAssociations::isEnabled() && $item->params->get('show_associations'))
 			{
 				$item->associations = \ContentHelperAssociation::displayAssociations($item->id);
 			}

--- a/components/com_content/View/Article/HtmlView.php
+++ b/components/com_content/View/Article/HtmlView.php
@@ -216,7 +216,7 @@ class HtmlView extends BaseHtmlView
 		$item->tags = new TagsHelper;
 		$item->tags->getItemTags('com_content.article', $this->item->id);
 
-		if ($item->params->get('show_associations'))
+		if (\JLanguageAssociations::isEnabled() && $item->params->get('show_associations'))
 		{
 			$item->associations = \ContentHelperAssociation::displayAssociations($item->id);
 		}

--- a/components/com_content/tmpl/article/default.xml
+++ b/components/com_content/tmpl/article/default.xml
@@ -32,7 +32,9 @@
 
 		<!-- Basic options. -->
 		<fieldset name="basic"
-			label="COM_CONTENT_ATTRIBS_ARTICLE_SETTINGS_LABEL">
+			label="COM_CONTENT_ATTRIBS_ARTICLE_SETTINGS_LABEL"
+			addfieldprefix="Joomla\Component\Content\Administrator\Field"
+		>
 
 		<field
 			name="show_title"
@@ -135,7 +137,7 @@
 
 		<field
 			name="show_associations"
-			type="list"
+			type="assoc"
 			label="JGLOBAL_SHOW_ASSOCIATIONS_LABEL"
 			useglobal="true"
 			class="chzn-color"

--- a/components/com_content/tmpl/category/blog.xml
+++ b/components/com_content/tmpl/category/blog.xml
@@ -323,7 +323,10 @@
 				</field>
 		</fieldset>
 
-		<fieldset name="article" label="COM_CONTENT_ATTRIBS_FIELDSET_LABEL">
+		<fieldset name="article"
+			label="COM_CONTENT_ATTRIBS_FIELDSET_LABEL"
+			addfieldprefix="Joomla\Component\Content\Administrator\Field"
+		>
 
 			<field
 				name="article_layout" type="componentlayout"
@@ -446,7 +449,7 @@
 
 			<field
 				name="show_associations"
-				type="list"
+				type="assoc"
 				label="JGLOBAL_SHOW_ASSOCIATIONS_LABEL"
 				useglobal="true"
 				class="chzn-color"

--- a/components/com_content/tmpl/category/default.xml
+++ b/components/com_content/tmpl/category/default.xml
@@ -362,7 +362,10 @@
 			</field>
 		</fieldset>
 
-		<fieldset name="article" label="COM_CONTENT_ATTRIBS_FIELDSET_LABEL">
+		<fieldset name="article"
+			label="COM_CONTENT_ATTRIBS_FIELDSET_LABEL"
+			addfieldprefix="Joomla\Component\Content\Administrator\Field"
+		>
 
 			<field
 				name="article_layout" type="componentlayout"
@@ -452,7 +455,7 @@
 
 			<field
 				name="show_associations"
-				type="list"
+				type="assoc"
 				label="JGLOBAL_SHOW_ASSOCIATIONS_LABEL"
 				useglobal="true"
 				class="chzn-color"

--- a/components/com_content/tmpl/featured/default.xml
+++ b/components/com_content/tmpl/featured/default.xml
@@ -162,7 +162,10 @@
 			</field>
 	</fieldset>
 
-	<fieldset name="article" label="COM_CONTENT_ATTRIBS_FIELDSET_LABEL">
+	<fieldset name="article"
+		label="COM_CONTENT_ATTRIBS_FIELDSET_LABEL"
+		addfieldprefix="Joomla\Component\Content\Administrator\Field"
+	>
 			<field 
 				name="show_title" 
 				type="list"
@@ -275,7 +278,7 @@
 
 			<field
 				name="show_associations"
-				type="list"
+				type="assoc"
 				label="JGLOBAL_SHOW_ASSOCIATIONS_LABEL"
 				useglobal="true"
 				class="chzn-color"


### PR DESCRIPTION
### Summary of Changes
Added new field type `AssocField` to display the field only when `Associations::isEnabled()` is enabled.

### Testing Instructions
Test creating a new article menu item, featured menu item, category list or blog menu item.
Test editing or creating an article.

In all cases look at the Options Tab.
### Before patch
Before patch, the field `show_associations` displays whatever the `Associations` settings in the languagefilter system plugin, and whether the plugin is enabled or not.
<img width="453" alt="screen shot 2017-12-10 at 10 55 52" src="https://user-images.githubusercontent.com/869724/33803807-d85cb574-dd98-11e7-8e44-0f8cc72a37ef.png">
### After patch
The field will not display when Associations are set to NO or the languagefilter is disabled.
<img width="464" alt="screen shot 2017-12-10 at 10 56 09" src="https://user-images.githubusercontent.com/869724/33803808-e0f9d96e-dd98-11e7-85ac-d7a4d1a444a6.png">

### Note
1. We can also create a new fieldtype to prevent showing the field in Articles Configuration as we would need there an override for the radio field type.
2. This PR also solves the issue when changing a site from multilingual to monolanguage and associations had been created. Before PR, if associations had been set and show associations implemented, the flag/lang_code would still show in the info-block of the articles concerned.
After patch no more.

### See discussion here
https://github.com/joomla/joomla-cms/pull/18972#issuecomment-349934131

