### PR TITLE
[4.0] Missing "info" lang string

### DIFF
--- a/administrator/language/en-GB/en-GB.ini
+++ b/administrator/language/en-GB/en-GB.ini
@@ -40,8 +40,9 @@ JH5="h5"
 JH6="h6"
 
 ERROR="Error"
-MESSAGE="Message"
+INFO="Info"
 NOTICE="Notice"
+MESSAGE="Message"
 WARNING="Warning"
 
 JADMINISTRATION="Administration"

--- a/language/en-GB/en-GB.ini
+++ b/language/en-GB/en-GB.ini
@@ -11,8 +11,9 @@ JERROR_PARSING_LANGUAGE_FILE="&#160;: error(s) in line(s) %s"
 
 
 ERROR="Error"
-MESSAGE="Message"
+INFO="Info"
 NOTICE="Notice"
+MESSAGE="Message"
 WARNING="Warning"
 
 J1="1"


### PR DESCRIPTION
As title says. For example when fixing database:
`$app->enqueueMessage(\JText::_('COM_INSTALLER_MSG_DATABASE_OK'), 'info');`

Test: enable debug language.
Can be merged on review.