### PR TITLE
[4.1] com_media modifications for front-end use

### DIFF
--- a/components/com_media/dispatcher.php
+++ b/components/com_media/dispatcher.php
@@ -76,7 +76,7 @@ class MediaDispatcher extends Dispatcher
 		// Access check
 		if (!$user->authorise('core.manage', 'com_media')
 			&& (!$asset || (!$user->authorise('core.edit', $asset)
-                        && !$user->authorise('core.create', 'com_media')
+			&& !$user->authorise('core.create', 'com_media')
 			&& !$user->authorise('core.create', $asset)
 			&& count($user->getAuthorisedCategories($asset, 'core.create')) == 0)
 			&& !($user->id == $author && $user->authorise('core.edit.own', $asset))))

--- a/components/com_media/dispatcher.php
+++ b/components/com_media/dispatcher.php
@@ -76,6 +76,7 @@ class MediaDispatcher extends Dispatcher
 		// Access check
 		if (!$user->authorise('core.manage', 'com_media')
 			&& (!$asset || (!$user->authorise('core.edit', $asset)
+                        && !$user->authorise('core.create', 'com_media')
 			&& !$user->authorise('core.create', $asset)
 			&& count($user->getAuthorisedCategories($asset, 'core.create')) == 0)
 			&& !($user->id == $author && $user->authorise('core.edit.own', $asset))))

--- a/plugins/fields/media/media.php
+++ b/plugins/fields/media/media.php
@@ -37,7 +37,7 @@ class PlgFieldsMedia extends \Joomla\Component\Fields\Administrator\Plugin\Field
 		}
 
 		$fieldNode->setAttribute('hide_default', 'true');
-		
+
 		if (JFactory::getApplication()->getIdentity()->authorise('core.create', 'com_media'))
 		{
 			$fieldNode->setAttribute('disabled', 'false');

--- a/plugins/fields/media/media.php
+++ b/plugins/fields/media/media.php
@@ -37,6 +37,7 @@ class PlgFieldsMedia extends \Joomla\Component\Fields\Administrator\Plugin\Field
 		}
 
 		$fieldNode->setAttribute('hide_default', 'true');
+		
 		if (JFactory::getApplication()->getIdentity()->authorise('core.create', 'com_media'))
 		{
 			$fieldNode->setAttribute('disabled', 'false');

--- a/plugins/fields/media/media.php
+++ b/plugins/fields/media/media.php
@@ -37,7 +37,7 @@ class PlgFieldsMedia extends \Joomla\Component\Fields\Administrator\Plugin\Field
 		}
 
 		$fieldNode->setAttribute('hide_default', 'true');
-		if(JFactory::getApplication()->getIdentity()->authorise('core.create','com_media'))
+		if (JFactory::getApplication()->getIdentity()->authorise('core.create', 'com_media'))
 		{
 			$fieldNode->setAttribute('disabled', 'false');
 		}

--- a/plugins/fields/media/media.php
+++ b/plugins/fields/media/media.php
@@ -37,6 +37,10 @@ class PlgFieldsMedia extends \Joomla\Component\Fields\Administrator\Plugin\Field
 		}
 
 		$fieldNode->setAttribute('hide_default', 'true');
+		if(JFactory::getApplication()->getIdentity()->authorise('core.create','com_media'))
+		{
+			$fieldNode->setAttribute('disabled', 'false');
+		}
 
 		return $fieldNode;
 	}


### PR DESCRIPTION
This small change allows media fields to be used in user profiles, where a user is not authorized for core.create in com_users - they can be authorized in com_media.  In conjunction with a filesystem plugin, a user can be granted access to com_media a limited area of the filesystem.  This change should not impact anything other than front-end media modals.

### Summary of Changes

allow core.create for com_media to open com_media

### Testing Instructions

Create a user custom field of type media as a regular user (registered group).  Editing your profile, the media field will have no button to open the media manager because the user has no access.

Apply this change, and allow "Regisered" user group "create" permissions.  The user is now given the "Select"

### Expected result
media custom fields usable

### Actual result
after change, users can use media fields


### Documentation Changes Required

