### PR TITLE
[4.0] Fix missing filters (com_menus & com_associations)

### DIFF
--- a/administrator/components/com_associations/layouts/joomla/searchtools/default/bar.php
+++ b/administrator/components/com_associations/layouts/joomla/searchtools/default/bar.php
@@ -12,7 +12,7 @@ defined('JPATH_BASE') or die;
 $data = $displayData;
 
 ?>
-<?php if ($data['view'] instanceof \Joomla\Component\Associations\Administrator\View\Associations\Html) : ?>
+<?php if ($data['view'] instanceof \Joomla\Component\Associations\Administrator\View\Associations\HtmlView) : ?>
 	<?php $app = JFactory::getApplication(); ?>
 	<?php // We will get the component item type and language filters & remove it from the form filters. ?>
 	<?php if ($app->input->get('forcedItemType', '', 'string') == '') : ?>

--- a/administrator/components/com_menus/layouts/joomla/searchtools/default.php
+++ b/administrator/components/com_menus/layouts/joomla/searchtools/default.php
@@ -15,8 +15,8 @@ $data = $displayData;
 // Receive overridable options
 $data['options'] = !empty($data['options']) ? $data['options'] : array();
 
-if ($data['view'] instanceof \Joomla\Component\Menus\Administrator\View\Items\Html
-	|| $data['view'] instanceof \Joomla\Component\Menus\Administrator\View\Menus\Html)
+if ($data['view'] instanceof Joomla\Component\Menus\Administrator\View\Items\HtmlView
+	|| $data['view'] instanceof Joomla\Component\Menus\Administrator\View\Menus\HtmlView)
 {
 	// Client selector doesn't have to activate the filter bar.
 	unset($data['view']->activeFilters['client_id']);
@@ -47,7 +47,7 @@ $filtersClass = isset($data['view']->activeFilters) && $data['view']->activeFilt
 <div class="js-stools clearfix">
 	<div class="clearfix">
         <?php
-        if ($data['view'] instanceof \Joomla\Component\Menus\Administrator\View\Items\Html)
+        if ($data['view'] instanceof Joomla\Component\Menus\Administrator\View\Items\HtmlView)
         {
 	        // We will get the menutype filter & remove it from the form filters
 	        $menuTypeField = $data['view']->filterForm->getField('menutype');
@@ -69,7 +69,7 @@ $filtersClass = isset($data['view']->activeFilters) && $data['view']->activeFilt
             </div>
 	        <?php
         }
-        elseif ($data['view'] instanceof \Joomla\Component\Menus\Administrator\View\Menus\Html)
+        elseif ($data['view'] instanceof Joomla\Component\Menus\Administrator\View\Menus\HtmlView)
         {
 	        // Add the client selector before the form filters.
 	        $clientIdField = $data['view']->filterForm->getField('client_id');

--- a/administrator/components/com_menus/layouts/joomla/searchtools/default.php
+++ b/administrator/components/com_menus/layouts/joomla/searchtools/default.php
@@ -15,8 +15,8 @@ $data = $displayData;
 // Receive overridable options
 $data['options'] = !empty($data['options']) ? $data['options'] : array();
 
-if ($data['view'] instanceof Joomla\Component\Menus\Administrator\View\Items\HtmlView
-	|| $data['view'] instanceof Joomla\Component\Menus\Administrator\View\Menus\HtmlView)
+if ($data['view'] instanceof \Joomla\Component\Menus\Administrator\View\Items\HtmlView
+	|| $data['view'] instanceof \Joomla\Component\Menus\Administrator\View\Menus\HtmlView)
 {
 	// Client selector doesn't have to activate the filter bar.
 	unset($data['view']->activeFilters['client_id']);
@@ -47,7 +47,7 @@ $filtersClass = isset($data['view']->activeFilters) && $data['view']->activeFilt
 <div class="js-stools clearfix">
 	<div class="clearfix">
         <?php
-        if ($data['view'] instanceof Joomla\Component\Menus\Administrator\View\Items\HtmlView)
+        if ($data['view'] instanceof \Joomla\Component\Menus\Administrator\View\Items\HtmlView)
         {
 	        // We will get the menutype filter & remove it from the form filters
 	        $menuTypeField = $data['view']->filterForm->getField('menutype');
@@ -69,7 +69,7 @@ $filtersClass = isset($data['view']->activeFilters) && $data['view']->activeFilt
             </div>
 	        <?php
         }
-        elseif ($data['view'] instanceof Joomla\Component\Menus\Administrator\View\Menus\HtmlView)
+        elseif ($data['view'] instanceof \Joomla\Component\Menus\Administrator\View\Menus\HtmlView)
         {
 	        // Add the client selector before the form filters.
 	        $clientIdField = $data['view']->filterForm->getField('client_id');


### PR DESCRIPTION
Pull Request for Issue #18815 

### Summary of Changes

Fix the filters

### Testing Instructions

1.
- Go to `administrator/index.php?option=com_menus&view=menus`
- You should see a filter to switch between `Site` and `Administrator`

--------------------------------------

2.
- Go to `administrator/index.php?option=com_menus&view=items`
- You should see a filter to switch between `Site` and `Administrator`
- You should see a filter to select the menu type

--------------------------------------

3.
- Go to `administrator/index.php?option=com_associations`
- You should see a filter to for `Item type` and `Language`