### PR TITLE
Don't hardcode class/method names into Exception messages

### DIFF
--- a/libraries/cms/html/select.php
+++ b/libraries/cms/html/select.php
@@ -159,7 +159,10 @@ abstract class JHtmlSelect
 	{
 		// Log deprecated message
 		JLog::add(
-			'JHtmlSelect::suggestionlist() is deprecated. Create the <datalist> tag directly instead.',
+			sprintf(
+				'%s() is deprecated. Create the <datalist> tag directly instead.',
+				__METHOD__
+			),
 			JLog::WARNING,
 			'deprecated'
 		);

--- a/libraries/cms/html/sortablelist.php
+++ b/libraries/cms/html/sortablelist.php
@@ -49,7 +49,7 @@ abstract class JHtmlSortablelist
 		// Note: $i is required but has to be an optional argument in the function call due to argument order
 		if ($saveOrderingUrl === null)
 		{
-			throw new InvalidArgumentException('$saveOrderingUrl is a required argument in JHtmlSortablelist::sortable');
+			throw new InvalidArgumentException(sprintf('$saveOrderingUrl is a required argument in %s()', __METHOD__));
 		}
 
 		$displayData = array(

--- a/libraries/joomla/filesystem/path.php
+++ b/libraries/joomla/filesystem/path.php
@@ -167,14 +167,27 @@ class JPath
 		if (strpos($path, '..') !== false)
 		{
 			// Don't translate
-			throw new Exception('JPath::check Use of relative paths not permitted', 20);
+			throw new Exception(
+				sprintf(
+					'%s() - Use of relative paths not permitted',
+					__METHOD__
+				),
+				20
+			);
 		}
 
 		$path = self::clean($path);
 
 		if ((JPATH_ROOT != '') && strpos($path, self::clean(JPATH_ROOT)) !== 0)
 		{
-			throw new Exception('JPath::check Snooping out of bounds @ ' . $path, 20);
+			throw new Exception(
+				sprintf(
+					'%1$s() - Snooping out of bounds @ %2$s',
+					__METHOD__,
+					$path
+				),
+				20
+			);
 		}
 
 		return $path;
@@ -195,7 +208,13 @@ class JPath
 	{
 		if (!is_string($path) && !empty($path))
 		{
-			throw new UnexpectedValueException('JPath::clean: $path is not a string.');
+			throw new UnexpectedValueException(
+				sprintf(
+					'%s() - $path is not a string',
+					__METHOD__
+				),
+				20
+			);
 		}
 
 		$path = trim($path);

--- a/libraries/src/Feed/Feed.php
+++ b/libraries/src/Feed/Feed.php
@@ -85,13 +85,25 @@ class Feed implements \ArrayAccess, \Countable
 		// Validate that any authors that are set are instances of JFeedPerson or null.
 		if (($name == 'author') && (!($value instanceof FeedPerson) || ($value === null)))
 		{
-			throw new \InvalidArgumentException('Feed "author" must be of type FeedPerson. ' . gettype($value) . 'given.');
+			throw new \InvalidArgumentException(
+				sprintf(
+					'%1$s "author" must be an instance of Joomla\\CMS\\Feed\\FeedPerson. %2$s given.',
+					get_class($this),
+					gettype($value) === 'object' ? get_class($value) : gettype($value)
+				)
+			);
 		}
 
 		// Disallow setting categories or contributors directly.
-		if (($name == 'categories') || ($name == 'contributors'))
+		if (in_array($name, array('categories', 'contributors')))
 		{
-			throw new \InvalidArgumentException('Cannot directly set Feed property "' . $name . '".');
+			throw new \InvalidArgumentException(
+				sprintf(
+					'Cannot directly set %1$s property "%2$s".',
+					get_class($this),
+					$name
+				)
+			);
 		}
 
 		$this->properties[$name] = $value;
@@ -231,7 +243,13 @@ class Feed implements \ArrayAccess, \Countable
 	{
 		if (!($value instanceof FeedEntry))
 		{
-			throw new \InvalidArgumentException('Cannot set value of type "' . gettype($value) . '".');
+			throw new \InvalidArgumentException(
+				sprintf(
+					'%1$s entries must be an instance of Joomla\\CMS\\Feed\\FeedPerson. %2$s given.',
+					get_class($this),
+					gettype($value) === 'object' ? get_class($value) : gettype($value)
+				)
+			);
 		}
 
 		$this->entries[$offset] = $value;

--- a/libraries/src/Feed/FeedEntry.php
+++ b/libraries/src/Feed/FeedEntry.php
@@ -80,19 +80,37 @@ class FeedEntry
 		// Validate that any authors that are set are instances of JFeedPerson or null.
 		if (($name == 'author') && (!($value instanceof FeedPerson) || ($value === null)))
 		{
-			throw new \InvalidArgumentException('FeedEntry "author" must be of type FeedPerson. ' . gettype($value) . 'given.');
+			throw new \InvalidArgumentException(
+				sprintf(
+					'%1$s "author" must be an instance of Joomla\\CMS\\Feed\\FeedPerson. %2$s given.',
+					get_class($this),
+					gettype($value) === 'object' ? get_class($value) : gettype($value)
+				)
+			);
 		}
 
 		// Validate that any sources that are set are instances of JFeed or null.
 		if (($name == 'source') && (!($value instanceof Feed) || ($value === null)))
 		{
-			throw new \InvalidArgumentException('FeedEntry "source" must be of type Feed. ' . gettype($value) . 'given.');
+			throw new \InvalidArgumentException(
+				sprintf(
+					'%1$s "source" must be an instance of Joomla\\CMS\\Feed\\Feed. %2$s given.',
+					get_class($this),
+					gettype($value) === 'object' ? get_class($value) : gettype($value)
+				)
+			);
 		}
 
 		// Disallow setting categories, contributors, or links directly.
-		if (($name == 'categories') || ($name == 'contributors') || ($name == 'links'))
+		if (in_array($name, array('categories', 'contributors', 'links')))
 		{
-			throw new \InvalidArgumentException('Cannot directly set FeedEntry property "' . $name . '".');
+			throw new \InvalidArgumentException(
+				sprintf(
+					'Cannot directly set %1$s property "%2$s".',
+					get_class($this),
+					$name
+				)
+			);
 		}
 
 		$this->properties[$name] = $value;

--- a/libraries/src/Form/Form.php
+++ b/libraries/src/Form/Form.php
@@ -2205,7 +2205,7 @@ class Form
 
 			if (empty($data))
 			{
-				throw new \InvalidArgumentException(sprintf('Form::getInstance(%s, *%s*)', $name, gettype($data)));
+				throw new \InvalidArgumentException(sprintf('%1$s(%2$s, *%3$s*)', __METHOD__, $name, gettype($data)));
 			}
 
 			// Instantiate the form.
@@ -2216,14 +2216,14 @@ class Form
 			{
 				if ($forms[$name]->load($data, $replace, $xpath) == false)
 				{
-					throw new \RuntimeException('JForm::getInstance could not load form');
+					throw new \RuntimeException(sprintf('%s() could not load form', __METHOD__));
 				}
 			}
 			else
 			{
 				if ($forms[$name]->loadFile($data, $replace, $xpath) == false)
 				{
-					throw new \RuntimeException('JForm::getInstance could not load file');
+					throw new \RuntimeException(sprintf('%s() could not load file', __METHOD__));
 				}
 			}
 		}

--- a/libraries/src/Helper/RouteHelper.php
+++ b/libraries/src/Helper/RouteHelper.php
@@ -241,7 +241,7 @@ class RouteHelper
 		// Note: $extension is required but has to be an optional argument in the function call due to argument order
 		if (empty($extension))
 		{
-			throw new \InvalidArgumentException('$extension is a required argument in RouteHelper::getCategoryRoute');
+			throw new \InvalidArgumentException(sprintf('$extension is a required argument in %s()', __METHOD__));
 		}
 
 		if ($catid instanceof \JCategoryNode)

--- a/libraries/src/Log/Logger/CallbackLogger.php
+++ b/libraries/src/Log/Logger/CallbackLogger.php
@@ -47,7 +47,7 @@ class CallbackLogger extends Logger
 		// Throw an exception if there is not a valid callback
 		if (!isset($this->options['callback']) || !is_callable($this->options['callback']))
 		{
-			throw new \RuntimeException('JLogLoggerCallback created without valid callback function.');
+			throw new \RuntimeException(sprintf('%s created without valid callback function.', get_class($this)));
 		}
 
 		$this->callback = $this->options['callback'];

--- a/libraries/src/Table/ContentType.php
+++ b/libraries/src/Table/ContentType.php
@@ -132,12 +132,12 @@ class ContentType extends Table
 		{
 			if (is_object($tableInfo->special) && isset($tableInfo->special->type) && isset($tableInfo->special->prefix))
 			{
-				$class = isset($tableInfo->special->class) ? $tableInfo->special->class : 'Joomla\\Cms\\Table\\Table';
+				$class = isset($tableInfo->special->class) ? $tableInfo->special->class : 'Joomla\\CMS\\Table\\Table';
 
-				if (!class_implements($class, 'Joomla\\Cms\\Table\\TableInterface'))
+				if (!class_implements($class, 'Joomla\\CMS\\Table\\TableInterface'))
 				{
 					// This isn't an instance of TableInterface. Abort.
-					throw new \RuntimeException('Class must be an instance of TableInterface');
+					throw new \RuntimeException('Class must be an instance of Joomla\\CMS\\Table\\TableInterface');
 				}
 
 				$result = $class::getInstance($tableInfo->special->type, $tableInfo->special->prefix);


### PR DESCRIPTION
### Summary of Changes

Generally, I would suggest we should not hardcode class and method names into Exception messages and instead dynamically resolve those at runtime through various available resources (i.e. `get_class($this)` or `__METHOD__`.  This PR changes Exception messages that do not have language keys to dynamically set these values over hardcoding them.  One of the benefits of this, especially with the namespacing efforts, is that the message text doesn't have to be changed as the class is renamed (the right name will always resolve).

As well, some minor improvements are made to a few messages to be more useful in debugging (primarily affects the Feed package).

### Testing Instructions

Code review