### PR TITLE
Use original cased alias for deprecation logging

### DIFF
--- a/libraries/loader.php
+++ b/libraries/loader.php
@@ -378,21 +378,21 @@ abstract class JLoader
 	public static function registerAlias($alias, $original, $version = false)
 	{
 		// PHP is case insensitive so support all kind of alias combination
-		$alias = strtolower($alias);
+		$lowercasedAlias = strtolower($alias);
 
-		if (!isset(self::$classAliases[$alias]))
+		if (!isset(self::$classAliases[$lowercasedAlias]))
 		{
-			self::$classAliases[$alias] = $original;
+			self::$classAliases[$lowercasedAlias] = $original;
 
 			$original = self::stripFirstBackslash($original);
 
 			if (!isset(self::$classAliasesInverse[$original]))
 			{
-				self::$classAliasesInverse[$original] = array($alias);
+				self::$classAliasesInverse[$original] = array($lowercasedAlias);
 			}
 			else
 			{
-				self::$classAliasesInverse[$original][] = $alias;
+				self::$classAliasesInverse[$original][] = $lowercasedAlias;
 			}
 
 			// If given a version, log this alias as deprecated


### PR DESCRIPTION
### Summary of Changes

A side effect of using lowercased aliases in `JLoader` to cope with class aliasing issues, the log messages now also used the lowercased aliased name, and that just makes the log messages a little hard to read.  This PR changes `JLoader::registerAlias()` so that the lowercased alias is stored as a separate variable, making the original alias (with proper casing) available in the deprecation tracker.

### Testing Instructions

Code review, check deprecation logs (must have this enabled, options in log plugin) for class name casing.

### Expected result

`JCacheExceptionConnecting has been aliased to Joomla\CMS\Cache\Exception\CacheConnectingException and the former class name is deprecated. The alias will be removed in 5.0`

### Actual result

`jcacheexceptionconnecting has been aliased to Joomla\CMS\Cache\Exception\CacheConnectingException and the former class name is deprecated. The alias will be removed in 5.0`