### PR TITLE
Modification to Joomla.loadOptions() so it actually merges option obj…

### DIFF
--- a/media/system/js/core.js
+++ b/media/system/js/core.js
@@ -230,21 +230,21 @@ Joomla.editors.instances = Joomla.editors.instances || {
 			Joomla.optionsStorage = options || {};
 		}
         // Merge with existing
-        else if ( options ) {
-            for (var p in options) {
-                if (options.hasOwnProperty(p)) {
-                    /**
-                     * If both existing and new options are objects, merge them with Joomla.extend().  But test for new
-                     * option being null, as null is an object, but we want to allow clearing of options with ...
-                     *
-                     * Joomla.loadOptions({'joomla.jtext': null});
-                     */
-                    if (options[p] !== null && typeof Joomla.optionsStorage[p] === 'object' && typeof options[p] === 'object') {
-                        Joomla.optionsStorage[p] = Joomla.extend(Joomla.optionsStorage[p], options[p]);
-                    } else {
-                        Joomla.optionsStorage[p] = options[p];
-                    }
-                }
+		else if ( options ) {
+			for (var p in options) {
+				if (options.hasOwnProperty(p)) {
+					/**
+					 * If both existing and new options are objects, merge them with Joomla.extend().  But test for new
+					 * option being null, as null is an object, but we want to allow clearing of options with ...
+					 *
+					 * Joomla.loadOptions({'joomla.jtext': null});
+					 */
+					if (options[p] !== null && typeof Joomla.optionsStorage[p] === 'object' && typeof options[p] === 'object') {
+						Joomla.optionsStorage[p] = Joomla.extend(Joomla.optionsStorage[p], options[p]);
+					} else {
+						Joomla.optionsStorage[p] = options[p];
+					}
+	            }
             }
         }
 	};

--- a/media/system/js/core.js
+++ b/media/system/js/core.js
@@ -229,7 +229,7 @@ Joomla.editors.instances = Joomla.editors.instances || {
 		if (!Joomla.optionsStorage) {
 			Joomla.optionsStorage = options || {};
 		}
-        // Merge with existing
+		// Merge with existing
 		else if ( options ) {
 			for (var p in options) {
 				if (options.hasOwnProperty(p)) {

--- a/media/system/js/core.js
+++ b/media/system/js/core.js
@@ -239,11 +239,9 @@ Joomla.editors.instances = Joomla.editors.instances || {
                      *
                      * Joomla.loadOptions({'joomla.jtext': null});
                      */
-                    if (options[p] !== null && typeof Joomla.optionsStorage[p] === 'object' && typeof options[p] === 'object')
-                    {
+                    if (options[p] !== null && typeof Joomla.optionsStorage[p] === 'object' && typeof options[p] === 'object') {
                         Joomla.optionsStorage[p] = Joomla.extend(Joomla.optionsStorage[p], options[p]);
-                    }
-                    else {
+                    } else {
                         Joomla.optionsStorage[p] = options[p];
                     }
                 }

--- a/media/system/js/core.js
+++ b/media/system/js/core.js
@@ -782,6 +782,13 @@ Joomla.editors.instances = Joomla.editors.instances || {
 	 * @return Object
 	 */
 	Joomla.extend = function (destination, source) {
+		/**
+		 * Technically null is an object, but trying to treat the destination as one in this context will error out.
+		 * So emulate jQuery.extend(), and treat a destination null as an empty object.
+ 		 */
+		if (destination === null) {
+			destination = {};
+		}
 		for (var p in source) {
 			if (source.hasOwnProperty(p)) {
 				destination[p] = source[p];

--- a/media/system/js/core.js
+++ b/media/system/js/core.js
@@ -229,14 +229,26 @@ Joomla.editors.instances = Joomla.editors.instances || {
 		if (!Joomla.optionsStorage) {
 			Joomla.optionsStorage = options || {};
 		}
-		// Merge with existing
-		else if ( options ) {
-			for (var p in options) {
-				if (options.hasOwnProperty(p)) {
-					Joomla.optionsStorage[p] = options[p];
-				}
-			}
-		}
+        // Merge with existing
+        else if ( options ) {
+            for (var p in options) {
+                if (options.hasOwnProperty(p)) {
+                    /**
+                     * If both existing and new options are objects, merge them with Joomla.extend().  But test for new
+                     * option being null, as null is an object, but we want to allow clearing of options with ...
+                     *
+                     * Joomla.loadOptions({'joomla.jtext': null});
+                     */
+                    if (options[p] !== null && typeof Joomla.optionsStorage[p] === 'object' && typeof options[p] === 'object')
+                    {
+                        Joomla.optionsStorage[p] = Joomla.extend(Joomla.optionsStorage[p], options[p]);
+                    }
+                    else {
+                        Joomla.optionsStorage[p] = options[p];
+                    }
+                }
+            }
+        }
 	};
 
 	/**


### PR DESCRIPTION
…ects.

Pull Request for Issue # .

### Summary of Changes

Tweak to Joomla.loadOptions() so it actually merges option objects, rather than replacing them.  The current code has a comment saying "Merge with existing", but as implemented it just replaces existing options with the new ones.

This change checks to see if existing and new options are objects (and not null), and if so, uses Joomla.extend() to merge the new one into the existing one.

The change is backward compatible with all current uses of Joomla.loadOptions in the CMS code, specifically by allowing a new option of 'null' to reset (as used by jtext).

### Testing Instructions

In Chrome, edit an article on the backend.  Open dev tools, and in the console look at Joomla.optionsStorage.  You'll see a bootstrap.tabs options object, with a single entry (myTab).

Run this in the console (without this change):

Joomla.loadOptions({'bootstrap.tabs': {'hughTab': {'active': "foo"}}})

... and you'll see that the bootstrap.tab options object has been replaced with the new one, with just 'hughTab'.

Try the same thing with the change, and you'll get a bootstrap.tabs options object with both myTab and hughTab, as the options got merged.

This change isn't of much interest to "out of box" behavior, but my extension does a lot of adding of DOM content (including objects with options) on the fly, where I need to make successive calls to addOptions, and have the options add to, not replace, existing options.

### Expected result

### Actual result

### Documentation Changes Required

Don't think so, as I think it just makes loadOptions behave how the internal comment says it does.
