### PR TITLE
Fix undefined index: com_fields in contact form

### DIFF
--- a/components/com_contact/controllers/contact.php
+++ b/components/com_contact/controllers/contact.php
@@ -193,16 +193,17 @@ class ContactControllerContact extends JControllerForm
 			$body   = $prefix . "\n" . $name . ' <' . $email . '>' . "\r\n\r\n" . stripslashes($body);
 
 			// Load the custom fields
-			if ($data['com_fields'] && $fields = FieldsHelper::getFields('com_contact.mail', $contact, true, $data['com_fields']))
+			if (isset($data['com_fields']) && $fields = FieldsHelper::getFields('com_contact.mail', $contact, true, $data['com_fields']))
 			{
 				$output = FieldsHelper::render(
-							'com_contact.mail',
-							'fields.render',
-							array('context' => 'com_contact.mail', 'item' => $contact, 'fields' => $fields)
+					'com_contact.mail',
+					'fields.render',
+					array('context' => 'com_contact.mail', 'item' => $contact, 'fields' => $fields)
 				);
+
 				if ($output)
 				{
-					$body  .= "\r\n\r\n" . $output;
+					$body .= "\r\n\r\n" . $output;
 				}
 			}
 

--- a/components/com_contact/controllers/contact.php
+++ b/components/com_contact/controllers/contact.php
@@ -193,7 +193,7 @@ class ContactControllerContact extends JControllerForm
 			$body   = $prefix . "\n" . $name . ' <' . $email . '>' . "\r\n\r\n" . stripslashes($body);
 
 			// Load the custom fields
-			if (isset($data['com_fields']) && $fields = FieldsHelper::getFields('com_contact.mail', $contact, true, $data['com_fields']))
+			if (!empty($data['com_fields']) && $fields = FieldsHelper::getFields('com_contact.mail', $contact, true, $data['com_fields']))
 			{
 				$output = FieldsHelper::render(
 					'com_contact.mail',


### PR DESCRIPTION
Pull Request for Issue #19053 .

### Summary of Changes
Check that `$data['com_fields']` is set before appending custom fields if any to the email.


### Testing Instructions
No custom fields in the contact form.
Fill out contact form.
Submit form.
See php error log.


### Expected result
no errors


### Actual result
Undefined index: com_fields in \components\com_contact\controllers\contact.php on line 196


### Documentation Changes Required
none
