### PR TITLE
Ensure catid to be an integer array in search archived articles

### DIFF
--- a/components/com_content/models/archive.php
+++ b/components/com_content/models/archive.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Utilities\ArrayHelper;
+
 JLoader::register('ContentModelArticles', __DIR__ . '/articles.php');
 
 /**
@@ -83,8 +85,8 @@ class ContentModelArchive extends ContentModelArticles
 	{
 		$params           = $this->state->params;
 		$app              = JFactory::getApplication('site');
-		$catids           = $app->input->getVar('catid', array());
-		$catids           = array_values(array_diff($catids, array('')));
+		$catids           = ArrayHelper::toInteger($app->input->get('catid', array(), 'array'));
+		$catids           = array_values(array_diff($catids, array(0)));
 		$articleOrderDate = $params->get('order_date');
 
 		// Create a new query object.
@@ -125,7 +127,7 @@ class ContentModelArchive extends ContentModelArticles
 			$query->where($query->year($queryDate) . ' = ' . $year);
 		}
 
-		if (count($catids)>0)
+		if (count($catids) > 0)
 		{
 			$query->where('c.id IN (' . implode(', ', $catids) . ')');
 		}


### PR DESCRIPTION

### Summary of Changes
In searching archived articles, `catid` is expected to an array, however, it can be changed in the URL to be non-array which results in warnings. This PR ensures that `catid` be an (integer) array.


### Testing Instructions
Install `Test English (GB) Sample Data` demo.
Set `Search Engine Friendly URLs` to No.
On the front end, click `Archived Articles`.
In the browser's address bar, append `&catid=0` to the URL.
See warnings above the filter form.

### Expected result
No warnings.


### Actual result
`Warning: array_diff(): Argument #1 is not an array in C:\xampp\htdocs\joomla-cms-staging\components\com_content\models\archive.php on line 90`

`Warning: array_values() expects parameter 1 to be array, null given in C:\xampp\htdocs\joomla-cms-staging\components\com_content\models\archive.php on line 90`


### Documentation Changes Required
None

