### PR TITLE
[CS] Code Style fixes for administrator/components/com_tags/

### DIFF
--- a/administrator/components/com_tags/tables/tag.php
+++ b/administrator/components/com_tags/tables/tag.php
@@ -141,6 +141,7 @@ class TagsTableTag extends JTableNested
 			$bad_characters = array("\"", '<', '>');
 			$this->metadesc = StringHelper::str_ireplace($bad_characters, '', $this->metadesc);
 		}
+
 		// Not Null sanity check
 		$date = JFactory::getDate();
 

--- a/administrator/components/com_tags/views/tag/view.html.php
+++ b/administrator/components/com_tags/views/tag/view.html.php
@@ -102,7 +102,7 @@ class TagsViewTag extends JViewLegacy
 			{
 				JToolbarHelper::apply('tag.apply');
 				JToolbarHelper::save('tag.save');
-	
+
 				if ($canDo->get('core.create'))
 				{
 					JToolbarHelper::save2new('tag.save2new');

--- a/administrator/components/com_tags/views/tags/view.html.php
+++ b/administrator/components/com_tags/views/tags/view.html.php
@@ -69,6 +69,7 @@ class TagsViewTags extends JViewLegacy
 		{
 			$this->addToolbar();
 		}
+
 		parent::display($tpl);
 	}
 


### PR DESCRIPTION
Pull Request for Issue code style fixes

### Summary of Changes
- No blank line found after control structure
- Whitespace found at end of line
[Automatically fixed with Joomla code standards 2.0.0 PHPCS2-alpha2 fixers](https://github.com/joomla/coding-standards/releases/tag/2.0.0-alpha2)

None of the manual only fixes have been applied

### Testing Instructions
Merge by code review

### Expected result
code style has been applied as listed above, old code style testing on drone does not error.

### Actual result
code style had not been applied. [Autofixers from the Joomla code standards 2.0.0 PHPCS2 alpha2](https://github.com/joomla/coding-standards/releases/tag/2.0.0-alpha2) were used to implement fixable code style

### Documentation Changes Required
none
