### PR TITLE
[CS] Code Style fixes for administrator/components/com_templates/

### DIFF
--- a/administrator/components/com_templates/controllers/style.php
+++ b/administrator/components/com_templates/controllers/style.php
@@ -43,7 +43,7 @@ class TemplatesControllerStyle extends JControllerForm
 
 		$document = JFactory::getDocument();
 
-		if ($document->getType() == 'json')
+		if ($document->getType() === 'json')
 		{
 			$app   = JFactory::getApplication();
 			$lang  = JFactory::getLanguage();

--- a/administrator/components/com_templates/controllers/style.php
+++ b/administrator/components/com_templates/controllers/style.php
@@ -45,7 +45,6 @@ class TemplatesControllerStyle extends JControllerForm
 
 		if ($document->getType() == 'json')
 		{
-
 			$app   = JFactory::getApplication();
 			$lang  = JFactory::getLanguage();
 			$model = $this->getModel();
@@ -68,7 +67,6 @@ class TemplatesControllerStyle extends JControllerForm
 			// Access check.
 			if (!$this->allowSave($data, $key))
 			{
-
 				$app->enqueueMessage(JText::_('JLIB_APPLICATION_ERROR_SAVE_NOT_PERMITTED'), 'error');
 
 				return false;
@@ -153,7 +151,6 @@ class TemplatesControllerStyle extends JControllerForm
 			$this->postSaveHook($model, $validData);
 
 			return true;
-
 		}
 		else
 		{

--- a/administrator/components/com_templates/controllers/template.php
+++ b/administrator/components/com_templates/controllers/template.php
@@ -300,7 +300,7 @@ class TemplatesControllerTemplate extends JControllerLegacy
 				// Redirect back to the edit screen.
 				$url = 'index.php?option=com_templates&view=template&id=' . $model->getState('extension.id') . '&file=' . $fileName;
 				$this->setRedirect(JRoute::_($url, false));
-			break;
+				break;
 
 			default:
 
@@ -309,7 +309,7 @@ class TemplatesControllerTemplate extends JControllerLegacy
 				$id   = $app->input->get('id');
 				$url  = 'index.php?option=com_templates&view=template&id=' . $id . '&file=' . $file;
 				$this->setRedirect(JRoute::_($url, false));
-			break;
+				break;
 		}
 	}
 

--- a/administrator/components/com_templates/controllers/template.php
+++ b/administrator/components/com_templates/controllers/template.php
@@ -296,14 +296,12 @@ class TemplatesControllerTemplate extends JControllerLegacy
 		switch ($task)
 		{
 			case 'apply':
-
 				// Redirect back to the edit screen.
 				$url = 'index.php?option=com_templates&view=template&id=' . $model->getState('extension.id') . '&file=' . $fileName;
 				$this->setRedirect(JRoute::_($url, false));
 				break;
 
 			default:
-
 				// Redirect to the list screen.
 				$file = base64_encode('home');
 				$id   = $app->input->get('id');

--- a/administrator/components/com_templates/controllers/template.php
+++ b/administrator/components/com_templates/controllers/template.php
@@ -295,20 +295,20 @@ class TemplatesControllerTemplate extends JControllerLegacy
 		// Redirect the user based on the chosen task.
 		switch ($task)
 		{
-		case 'apply':
+			case 'apply':
 
-			// Redirect back to the edit screen.
-			$url = 'index.php?option=com_templates&view=template&id=' . $model->getState('extension.id') . '&file=' . $fileName;
-			$this->setRedirect(JRoute::_($url, false));
+				// Redirect back to the edit screen.
+				$url = 'index.php?option=com_templates&view=template&id=' . $model->getState('extension.id') . '&file=' . $fileName;
+				$this->setRedirect(JRoute::_($url, false));
 			break;
 
-		default:
+			default:
 
-			// Redirect to the list screen.
-			$file = base64_encode('home');
-			$id   = $app->input->get('id');
-			$url  = 'index.php?option=com_templates&view=template&id=' . $id . '&file=' . $file;
-			$this->setRedirect(JRoute::_($url, false));
+				// Redirect to the list screen.
+				$file = base64_encode('home');
+				$id   = $app->input->get('id');
+				$url  = 'index.php?option=com_templates&view=template&id=' . $id . '&file=' . $file;
+				$this->setRedirect(JRoute::_($url, false));
 			break;
 		}
 	}

--- a/administrator/components/com_templates/models/fields/templatelocation.php
+++ b/administrator/components/com_templates/models/fields/templatelocation.php
@@ -14,7 +14,7 @@ JLoader::register('TemplatesHelper', JPATH_ADMINISTRATOR . '/components/com_temp
 JFormHelper::loadFieldClass('list');
 
 /**
- * Template Location field. 
+ * Template Location field.
  *
  * @since  3.5
  */

--- a/administrator/components/com_templates/models/style.php
+++ b/administrator/components/com_templates/models/style.php
@@ -382,7 +382,7 @@ class TemplatesModelStyle extends JModelAdmin
 	 * @param   array   $config  Configuration array for model. Optional.
 	 *
 	 * @return  JTable  A database object
-	*/
+	 */
 	public function getTable($type = 'Style', $prefix = 'TemplatesTable', $config = array())
 	{
 		return JTable::getInstance($type, $prefix, $config);

--- a/administrator/components/com_templates/models/styles.php
+++ b/administrator/components/com_templates/models/styles.php
@@ -172,7 +172,8 @@ class TemplatesModelStyles extends JModelList
 					$db->quoteName('a.home') . ' IN (' . $menuItemLanguageSubQuery . ') OR ' .
 					// Custom template styles override (only if assigned to the selected menu item).
 					'(' . $db->quoteName('a.home') . ' = ' . $db->quote(0) . ' AND ' . $menuItemId . ' IN (' . $templateStylesMenuItemsSubQuery . '))' .
-				')');
+					')'
+				);
 			}
 		}
 

--- a/administrator/components/com_templates/models/template.php
+++ b/administrator/components/com_templates/models/template.php
@@ -441,6 +441,7 @@ class TemplatesModelTemplate extends JModelForm
 			catch (Exception $e)
 			{
 				$app->enqueueMessage(JText::_('COM_TEMPLATES_ERROR_SOURCE_FILE_NOT_FOUND'), 'error');
+
 				return;
 			}
 
@@ -885,6 +886,7 @@ class TemplatesModelTemplate extends JModelForm
 
 				return false;
 			}
+
 			// Check if the format is allowed and will be showed in the backend
 			$check = $this->checkFormat($type);
 
@@ -1423,14 +1425,14 @@ class TemplatesModelTemplate extends JModelForm
 	}
 
 	/**
- 	* Check if the extension is allowed and will be shown in the template manager
- 	*
-	* @param   string  $ext  The extension to check if it is allowed
- 	*
- 	* @return  boolean  true if the extension is allowed false otherwise
- 	*
- 	* @since   3.6.0
-	*/
+	 * Check if the extension is allowed and will be shown in the template manager
+	 *
+	 * @param   string  $ext  The extension to check if it is allowed
+	 *
+	 * @return  boolean  true if the extension is allowed false otherwise
+	 *
+	 * @since   3.6.0
+	 */
 	protected function checkFormat($ext)
 	{
 		if (!isset($this->allowedFormats))

--- a/administrator/components/com_templates/views/template/view.html.php
+++ b/administrator/components/com_templates/views/template/view.html.php
@@ -1,19 +1,19 @@
 <?php
 /**
-* @package     Joomla.Administrator
-* @subpackage  com_templates
-*
-* @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
-* @license     GNU General Public License version 2 or later; see LICENSE.txt
-*/
+ * @package     Joomla.Administrator
+ * @subpackage  com_templates
+ *
+ * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
 
 defined('_JEXEC') or die;
 
 /**
-* View to edit a template style.
-*
-* @since  1.6
-*/
+ * View to edit a template style.
+ *
+ * @since  1.6
+ */
 class TemplatesViewTemplate extends JViewLegacy
 {
 	/**


### PR DESCRIPTION
Pull Request for Issue code style fixes

### Summary of Changes
- Expected 1 newline after opening brace
- Blank line found at start of control structure
- Line indented incorrectly
- Whitespace found at end of line
- Expected intention before asterisk
- Closing parenthesis of a multi-line function call must be on a line by itself
- Please consider an empty line before the return statement;
- No blank line found after control structure
- Tabs must be used to indent lines; spaces are not allowed

[Automatically fixed with Joomla code standards 2.0.0 PHPCS2-alpha2 fixers](https://github.com/joomla/coding-standards/releases/tag/2.0.0-alpha2)

None of the manual only fixes have been applied

### Testing Instructions
Merge by code review

### Expected result
code style has been applied as listed above, old code style testing on drone does not error.

### Actual result
code style had not been applied. [Autofixers from the Joomla code standards 2.0.0 PHPCS2 alpha2](https://github.com/joomla/coding-standards/releases/tag/2.0.0-alpha2) were used to implement fixable code style

### Documentation Changes Required
none
