### PR TITLE
[CS] Code Style fixes for administrator/components/com_users/ 

### DIFF
--- a/administrator/components/com_users/helpers/html/users.php
+++ b/administrator/components/com_users/helpers/html/users.php
@@ -113,7 +113,7 @@ class JHtmlUsers
 	 * @return  string   The html for the rendered modal
 	 *
 	 * @since   3.4.1
-	*/
+	 */
 	public static function notesModal($count, $userId)
 	{
 		if (empty($count))

--- a/administrator/components/com_users/models/group.php
+++ b/administrator/components/com_users/models/group.php
@@ -255,6 +255,7 @@ class UsersModelGroup extends JModelAdmin
 				return false;
 			}
 		}
+
 		// Iterate the items to delete each one.
 		foreach ($pks as $i => $pk)
 		{

--- a/administrator/components/com_users/models/user.php
+++ b/administrator/components/com_users/models/user.php
@@ -113,7 +113,7 @@ class UsersModelUser extends JModelAdmin
 	public function getForm($data = array(), $loadData = true)
 	{
 		$pluginParams = new Registry;
-		
+
 		if (JPluginHelper::isEnabled('user', 'joomla'))
 		{
 			$plugin = JPluginHelper::getPlugin('user', 'joomla');

--- a/administrator/components/com_users/views/users/view.html.php
+++ b/administrator/components/com_users/views/users/view.html.php
@@ -39,14 +39,14 @@ class UsersViewUsers extends JViewLegacy
 	 * @since 1.6
 	 */
 	protected $state;
-	
+
 	/**
 	 * A JForm instance with filter fields.
 	 *
 	 * @var    JForm
 	 * @since  3.6.3
 	 */
-	 public $filterForm;
+	public $filterForm;
 
 	/**
 	 * An array with active filters.
@@ -55,22 +55,22 @@ class UsersViewUsers extends JViewLegacy
 	 * @since  3.6.3
 	 */
 	public $activeFilters;
-	
+
 	/**
 	 * An ACL object to verify user rights.
 	 *
 	 * @var    JObject
 	 * @since  3.6.3
 	 */
-	 protected $canDo;
-	
+	protected $canDo;
+
 	/**
 	 * An instance of JDatabaseDriver.
 	 *
 	 * @var    JDatabaseDriver
 	 * @since  3.6.3
 	 */
-	 protected $db;
+	protected $db;
 
 	/**
 	 * Display the view


### PR DESCRIPTION
Pull Request for Issue code style fixes
(Note: This is the last code style **autofixer** PR for administrator/components/)

### Summary of Changes
- Whitespace found at end of line
- Line indented incorrectly
- No blank line found after control structure
- Line indented incorrectly before asterisk

[Automatically fixed with Joomla code standards 2.0.0 PHPCS2-alpha2 fixers](https://github.com/joomla/coding-standards/releases/tag/2.0.0-alpha2)

None of the manual only fixes have been applied

### Testing Instructions
Merge by code review

### Expected result
code style has been applied as listed above, old code style testing on drone does not error.

### Actual result
code style had not been applied. [Autofixers from the Joomla code standards 2.0.0 PHPCS2 alpha2](https://github.com/joomla/coding-standards/releases/tag/2.0.0-alpha2) were used to implement fixable code style

### Documentation Changes Required
none
