### PR TITLE
Correction for menu request params

### DIFF
--- a/administrator/components/com_menus/controllers/item.php
+++ b/administrator/components/com_menus/controllers/item.php
@@ -353,24 +353,26 @@ class MenusControllerItem extends JControllerForm
 
 		$data = $model->validate($form, $data);
 
+		// Preprocess request fields to ensure that we remove not set or empty request params
+		$request = $form->getGroup('request');
+
 		// Check for the special 'request' entry.
-		if ($data['type'] == 'component' && isset($data['request']) && is_array($data['request']) && !empty($data['request']))
+		if ($data['type'] == 'component' && !empty($request))
 		{
 			$removeArgs = array();
 
-			// Preprocess request fields to ensure that we remove not set or empty request params
-			$request = $form->getGroup('request');
-
-			if (!empty($request))
+			if (!isset($data['request']) || !is_array($data['request']))
 			{
-				foreach ($request as $field)
-				{
-					$fieldName = $field->getAttribute('name');
+				$data['request'] = array();
+			}
 
-					if (!isset($data['request'][$fieldName]) || $data['request'][$fieldName] == '')
-					{
-						$removeArgs[$fieldName] = '';
-					}
+			foreach ($request as $field)
+			{
+				$fieldName = $field->getAttribute('name');
+
+				if (!isset($data['request'][$fieldName]) || $data['request'][$fieldName] == '')
+				{
+					$removeArgs[$fieldName] = '';
 				}
 			}
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
The issue when menu has only a request with field type is list and multiple attribute. The first save time for one or multi option list is OK but the second time the menu can not clear the option list, it always loads the previous value.

### Testing Instructions
1. Modify `/components/com_content/views/featured/tmpl/default.xml` at line 10
2. Add a request group
```
<fields name="request">
		<fieldset name="request">
			<field
					name="custom"
					type="list"
					label="Custom IDs"
					multiple="true">
				<option value="1">ID 1</option>
				<option value="2">ID 2</option>
				<option value="3">ID 3</option>
			</field>
		</fieldset>
</fields>
```
3. Create a new menu item type is **Featured Articles** and choose some Custom IDs values -> Save
4. Clear Custom IDs values -> save

### Expected result
Custom IDs is empty.

### Actual result
Custom IDs is not empty.