### PR TITLE
Reserve other values for the download source tags

### DIFF
--- a/libraries/src/Updater/DownloadSource.php
+++ b/libraries/src/Updater/DownloadSource.php
@@ -18,6 +18,22 @@ defined('JPATH_PLATFORM') or die;
 class DownloadSource
 {
 	/**
+	 * Defines a BZIP2 download package
+	 *
+	 * @const  string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	const FORMAT_TAR_BZIP = 'bz2';
+
+	/**
+	 * Defines a TGZ download package
+	 *
+	 * @const  string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	const FORMAT_TAR_GZ = 'gz';
+
+	/**
 	 * Defines a ZIP download package
 	 *
 	 * @const  string
@@ -32,6 +48,22 @@ class DownloadSource
 	 * @since  3.8.3
 	 */
 	const TYPE_FULL = 'full';
+
+	/**
+	 * Defines a patch package download type
+	 *
+	 * @const  string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	const TYPE_PATCH = 'patch';
+
+	/**
+	 * Defines an upgrade package download type
+	 *
+	 * @const  string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	const TYPE_UPGRADE = 'upgrade';
 
 	/**
 	 * The download type


### PR DESCRIPTION
### Summary of Changes

This PR reserves additional values for future use in the new `<downloadsource>` tag's attributes.  Specifically, the `format` attribute will now support the same TAR package types that we distribute for core (.tar.gz and .tar.bz2) and the `type` attribute will support "patch" and "upgrade" download types.

### Testing Instructions

Code review only as no other code is aware of these attributes at the moment.

### Documentation Changes Required

N/A, we can document these as future support is integrated into the API but for now they'll just show up on the automated API documentation deployments.