### PR TITLE
Do not add default or active Itemid to every link without own menu item

### DIFF
--- a/libraries/src/Component/Router/Rules/MenuRules.php
+++ b/libraries/src/Component/Router/Rules/MenuRules.php
@@ -156,8 +156,8 @@ class MenuRules implements RulesInterface
 			}
 		}
 
-		// If there is no option in query then add the default item id
-		if (!isset($query['option']))
+		// If there is no view and task in query then add the default item id
+		if (!isset($query['view']) && !isset($query['task']))
 		{
 			// If not found, return language specific home link
 			$default = $this->router->menu->getDefault($language);

--- a/libraries/src/Component/Router/Rules/MenuRules.php
+++ b/libraries/src/Component/Router/Rules/MenuRules.php
@@ -156,20 +156,16 @@ class MenuRules implements RulesInterface
 			}
 		}
 
-		// Check if the active menuitem matches the requested language
-		if ($active && $active->component === 'com_' . $this->router->getName()
-			&& ($language === '*' || in_array($active->language, array('*', $language)) || !\JLanguageMultilang::isEnabled()))
+		// If there is no option in query then add the default item id
+		if (!isset($query['option']))
 		{
-			$query['Itemid'] = $active->id;
-			return;
-		}
+			// If not found, return language specific home link
+			$default = $this->router->menu->getDefault($language);
 
-		// If not found, return language specific home link
-		$default = $this->router->menu->getDefault($language);
-
-		if (!empty($default->id))
-		{
-			$query['Itemid'] = $default->id;
+			if (!empty($default->id))
+			{
+				$query['Itemid'] = $default->id;
+			}
 		}
 	}
 

--- a/libraries/src/Router/SiteRouter.php
+++ b/libraries/src/Router/SiteRouter.php
@@ -707,25 +707,13 @@ class SiteRouter extends Router
 
 		if ($itemid === null)
 		{
-			if ($option = $uri->getVar('option'))
+			if (!$uri->getVar('option'))
 			{
-				$item = $this->menu->getItem($this->getVar('Itemid'));
+				$option = $this->getVar('option');
 
-				if ($item !== null && $item->component === $option)
-				{
-					$uri->setVar('Itemid', $item->id);
-				}
-			}
-			else
-			{
-				if ($option = $this->getVar('option'))
+				if ($option)
 				{
 					$uri->setVar('option', $option);
-				}
-
-				if ($itemid = $this->getVar('Itemid'))
-				{
-					$uri->setVar('Itemid', $itemid);
 				}
 			}
 		}

--- a/modules/mod_login/tmpl/default.php
+++ b/modules/mod_login/tmpl/default.php
@@ -15,7 +15,7 @@ JHtml::_('behavior.keepalive');
 JHtml::_('bootstrap.tooltip');
 
 ?>
-<form action="<?php echo JRoute::_('index.php', true, $params->get('usesecure')); ?>" method="post" id="login-form" class="form-inline">
+<form action="<?php echo JRoute::_('index.php?option=com_users&task=user.login', true, $params->get('usesecure')); ?>" method="post" id="login-form" class="form-inline">
 	<?php if ($params->get('pretext')) : ?>
 		<div class="pretext">
 			<p><?php echo $params->get('pretext'); ?></p>
@@ -111,8 +111,6 @@ JHtml::_('bootstrap.tooltip');
 					<?php echo JText::_('MOD_LOGIN_FORGOT_YOUR_PASSWORD'); ?></a>
 				</li>
 			</ul>
-		<input type="hidden" name="option" value="com_users" />
-		<input type="hidden" name="task" value="user.login" />
 		<input type="hidden" name="return" value="<?php echo $return; ?>" />
 		<?php echo JHtml::_('form.token'); ?>
 	</div>

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -597,7 +597,6 @@ class PlgSystemLanguageFilter extends JPlugin
 		{
 			if ($this->params->get('automatic_change', 1))
 			{
-				$assoc = JLanguageAssociations::isEnabled();
 				$lang_code = $user['language'];
 
 				// If no language is specified for this user, we set it to the site default language
@@ -617,10 +616,37 @@ class PlgSystemLanguageFilter extends JPlugin
 					$lang_code = $this->current_lang;
 				}
 
+				$foundAssociation = false;
+
+				$assoc = JLanguageAssociations::isEnabled();
+
+				// If association is enabled
+				if ($assoc)
+				{
+					// Retrieves the Itemid from a login form.
+					$uri = new JUri($this->app->getUserState('users.login.form.return'));
+
+					// Get Itemid from SEF or home page
+					$query = $this->app::getRouter()->parse($uri);
+
+					// Check, if the login form contains a menu item redirection.
+					if (!empty($query['Itemid']))
+					{
+						// Try to get associations from that menu item.
+						$associations = MenusHelper::getAssociations($query['Itemid']);
+
+						// If any association set to the user preferred site language, redirect to that page.
+						if (isset($associations[$lang_code]) && $menu->getItem($associations[$lang_code]))
+						{
+							$associationItemid = $associations[$lang_code];
+							$this->app->setUserState('users.login.form.return', 'index.php?Itemid=' . $associationItemid);
+							$foundAssociation = true;
+						}
+					}
+				}
+
 				// Try to get association from the current active menu item
 				$active = $menu->getActive();
-
-				$foundAssociation = false;
 
 				/**
 				 * Looking for associations.
@@ -629,33 +655,14 @@ class PlgSystemLanguageFilter extends JPlugin
 				 * In that case we use the redirect as defined in the menu item.
 				 *  Otherwise we redirect, when available, to the user preferred site language.
 				 */
-				if ($active && !$active->params['login_redirect_url'])
+				if (!$foundAssociation && $active && !$active->params['login_redirect_url'])
 				{
 					if ($assoc)
 					{
 						$associations = MenusHelper::getAssociations($active->id);
 					}
 
-					// Retrieves the Itemid from a login form.
-					$uri = new JUri($this->app->getUserState('users.login.form.return'));
-
-					if ($uri->getVar('Itemid'))
-					{
-						// The login form contains a menu item redirection. Try to get associations from that menu item.
-						// If any association set to the user preferred site language, redirect to that page.
-						if ($assoc)
-						{
-							$associations = MenusHelper::getAssociations($uri->getVar('Itemid'));
-						}
-
-						if (isset($associations[$lang_code]) && $menu->getItem($associations[$lang_code]))
-						{
-							$associationItemid = $associations[$lang_code];
-							$this->app->setUserState('users.login.form.return', 'index.php?Itemid=' . $associationItemid);
-							$foundAssociation = true;
-						}
-					}
-					elseif (isset($associations[$lang_code]) && $menu->getItem($associations[$lang_code]))
+					if (isset($associations[$lang_code]) && $menu->getItem($associations[$lang_code]))
 					{
 						/**
 						 * The login form does not contain a menu item redirection.

--- a/templates/beez3/html/mod_login/default.php
+++ b/templates/beez3/html/mod_login/default.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 
 JHtml::_('behavior.keepalive');
 ?>
-<form action="<?php echo JRoute::_('index.php', true, $params->get('usesecure')); ?>" method="post" id="login-form" >
+<form action="<?php echo JRoute::_('index.php?option=com_users&task=user.login', true, $params->get('usesecure')); ?>" method="post" id="login-form" >
 <?php if ($params->get('pretext')) : ?>
 	<div class="pretext">
 	<p><?php echo $params->get('pretext'); ?></p>
@@ -49,8 +49,6 @@ JHtml::_('behavior.keepalive');
 	</p>
 <?php endif; ?>
 <input type="submit" name="Submit" class="button" value="<?php echo JText::_('JLOGIN') ?>" />
-<input type="hidden" name="option" value="com_users" />
-<input type="hidden" name="task" value="user.login" />
 <input type="hidden" name="return" value="<?php echo $return; ?>" />
 <?php echo JHtml::_('form.token'); ?>
 <ul>

--- a/templates/protostar/offline.php
+++ b/templates/protostar/offline.php
@@ -116,7 +116,7 @@ else
 				<?php endif; ?>
 				</div>
 				<jdoc:include type="message" />
-				<form action="<?php echo JRoute::_('index.php', true); ?>" method="post" id="form-login">
+				<form action="<?php echo JRoute::_('index.php?option=com_users&task=user.login'); ?>" method="post" id="form-login">
 					<fieldset>
 						<label for="username"><?php echo JText::_('JGLOBAL_USERNAME'); ?></label>
 						<input name="username" id="username" type="text" title="<?php echo JText::_('JGLOBAL_USERNAME'); ?>" />
@@ -131,8 +131,6 @@ else
 
 						<input type="submit" name="Submit" class="btn btn-primary" value="<?php echo JText::_('JLOGIN'); ?>" />
 
-						<input type="hidden" name="option" value="com_users" />
-						<input type="hidden" name="task" value="user.login" />
 						<input type="hidden" name="return" value="<?php echo base64_encode(JUri::base()); ?>" />
 						<?php echo JHtml::_('form.token'); ?>
 					</fieldset>

--- a/templates/system/offline.php
+++ b/templates/system/offline.php
@@ -58,7 +58,7 @@ $twofactormethods = JAuthenticationHelper::getTwoFactorMethods();
 			<?php echo JText::_('JOFFLINE_MESSAGE'); ?>
 		</p>
 	<?php endif; ?>
-	<form action="<?php echo JRoute::_('index.php', true); ?>" method="post" id="form-login">
+	<form action="<?php echo JRoute::_('index.php?option=com_users&task=user.login'); ?>" method="post" id="form-login">
 	<fieldset class="input">
 		<p id="form-login-username">
 			<label for="username"><?php echo JText::_('JGLOBAL_USERNAME'); ?></label>
@@ -77,8 +77,6 @@ $twofactormethods = JAuthenticationHelper::getTwoFactorMethods();
 		<p id="submit-buton">
 			<input type="submit" name="Submit" class="button login" value="<?php echo JText::_('JLOGIN'); ?>" />
 		</p>
-		<input type="hidden" name="option" value="com_users" />
-		<input type="hidden" name="task" value="user.login" />
 		<input type="hidden" name="return" value="<?php echo base64_encode(JUri::base()); ?>" />
 		<?php echo JHtml::_('form.token'); ?>
 	</fieldset>

--- a/tests/unit/suites/libraries/cms/component/router/rules/JComponentRouterRulesMenuTest.php
+++ b/tests/unit/suites/libraries/cms/component/router/rules/JComponentRouterRulesMenuTest.php
@@ -164,13 +164,13 @@ class JComponentRouterRulesMenuTest extends TestCaseDatabase
 		$cases[] = array(array('option' => 'com_content', 'view' => 'article', 'id' => '42', 'catid' => '22', 'lang' => 'en-GB'),
 			array('option' => 'com_content', 'view' => 'article', 'id' => '42', 'catid' => '22', 'lang' => 'en-GB', 'Itemid' => '49'));
 
-		// Check non-existing menu link
+		// Check non-existing menu link with a key
 		$cases[] = array(array('option' => 'com_content', 'view' => 'categories', 'id' => '42'),
-			array('option' => 'com_content', 'view' => 'categories', 'id' => '42', 'Itemid' => '49'));
+			array('option' => 'com_content', 'view' => 'categories', 'id' => '42'));
 
-		// Check indirect link to a single view behind a nested view with a key and language
+		// Check non-existing menu link with a key and language
 		$cases[] = array(array('option' => 'com_content', 'view' => 'categories', 'id' => '42', 'lang' => 'en-GB'),
-			array('option' => 'com_content', 'view' => 'categories', 'id' => '42', 'lang' => 'en-GB', 'Itemid' => '49'));
+			array('option' => 'com_content', 'view' => 'categories', 'id' => '42', 'lang' => 'en-GB'));
 
 		// Check if a query with existing Itemid that is not the current active menu-item is not touched
 		$cases[] = array(array('option' => 'com_content', 'view' => 'categories', 'id' => '42', 'Itemid' => '99'),

--- a/tests/unit/suites/libraries/cms/router/JRouterSiteTest.php
+++ b/tests/unit/suites/libraries/cms/router/JRouterSiteTest.php
@@ -1265,24 +1265,6 @@ class JRouterSiteTest extends TestCaseDatabase
 				'preset'   => array('option' => 'com_test'),
 				'expected' => 'index.php?var1=value1&option=com_test'
 			),
-			// Check if a URL with no Itemid and no option, but globally set Itemid is added the Itemid
-			array(
-				'url'      => 'index.php?var1=value1',
-				'preset'   => array('Itemid' => '42'),
-				'expected' => 'index.php?var1=value1&Itemid=42'
-			),
-			// Check if a URL without an Itemid, but with an option set and a global Itemid available, which fits the option of the menu item gets the Itemid appended
-			array(
-				'url'      => 'index.php?var1=value&option=com_test',
-				'preset'   => array('Itemid' => '42'),
-				'expected' => 'index.php?var1=value&option=com_test&Itemid=42'
-			),
-			// Check if a URL without an Itemid, but with an option set and a global Itemid available, which does not fit the option of the menu item gets returned identically
-			array(
-				'url'      => 'index.php?var1=value&option=com_test3',
-				'preset'   => array('Itemid' => '42'),
-				'expected' => 'index.php?var1=value&option=com_test3'
-			),
 		);
 	}
 


### PR DESCRIPTION
Pull Request for Issue #15730

### Summary of Changes
This PR contains two parts.

1. Do not add default/home `Itemid` to a link that does not have any `Itemid` (If active is not available)
2. Do not add active `Itemid` (from previous page) to a link that does not have any `Itemid`.

### Testing Instructions
Test issue #15730.


### Expected result
Every links work. 

You may see more links like `index/component/...`. 
It would be good to create for them menu items to get better SEO. 
Before this patch mentioned links use various of menu items to point to the same article/category, etc. 

**Example**: When you are on article view with menu item and the category and parent categories (of this article) does not own menu item then link to category will be (after PR) `index.php/component/content/category/[id]-[alias]` instead of (before PR) `/alias-to-article/[id]-[category]` 


### Actual result
See above


### Documentation Changes Required
Note: `Itemid` in URL query won't be inherited from default/previous page as was before.
