### PR TITLE
[CS] Tabs must be used to indent lines; spaces are not allowed

### DIFF
--- a/plugins/system/sef/sef.php
+++ b/plugins/system/sef/sef.php
@@ -141,7 +141,7 @@ class PlgSystemSef extends JPlugin
 
 					foreach ($matches[0] as &$src)
 					{
-    						$src = preg_replace('#^(?!/|' . $protocols . '|\#|\')(.+)#', $base . '$1', $src);
+						$src = preg_replace('#^(?!/|' . $protocols . '|\#|\')(.+)#', $base . '$1', $src);
 					}
 
 					return ' srcset="' . implode($matches[0]) . '"';


### PR DESCRIPTION
Pull Request for Issue Tabs must be used to indent lines; spaces are not allowed

Drone Errors are allowing code style issues to be overlooked. This fixes one such code style issue.

### Summary of Changes

Tabs used to indent lines

### Testing Instructions
Code review is sufficient


### Expected result

Tabs used to indent lines

### Actual result

Tabs used to indent lines, no spaces

### Documentation Changes Required
none
