### PR TITLE
[Legacy routing] Fix wrong link to user profile

### DIFF
--- a/components/com_users/helpers/legacyrouter.php
+++ b/components/com_users/helpers/legacyrouter.php
@@ -187,23 +187,18 @@ class UsersRouterRulesLegacy implements JComponentRouterRulesInterface
 					}
 					break;
 
-				default:
 				case 'profile':
-					if (!empty($query['view']))
+					if ($profile)
 					{
-						$segments[] = $query['view'];
-					}
-
-					unset ($query['view']);
-
-					if ($query['Itemid'] = $profile)
-					{
-						unset ($query['view']);
+						$query['Itemid'] = $profile;
 					}
 					else
 					{
 						$query['Itemid'] = $default;
+						$segments[] = $query['view'];
 					}
+
+					unset ($query['view']);
 
 					// Only append the user id if not "me".
 					$user = JFactory::getUser();


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This PR fixes wrong link to user profile when there is a menu item created to link to user profile menu option. When we call JRoute::_('index.php?option=com_users&view=profile') to get link to user profile, instead of getting **/joomla/index.php/user-profile**, we actual get **/joomla/index.php/user-profile/profile** (**profile** at the end is name of the view, it is not needed)


### Testing Instructions

1. Create a menu item to link to user profile menu option of com_users, set alias to user-profile (you don't have to do that if you install Joomla with testing sample data)

2. Open the file templates/protostar/index.php, add the below command:

```php
echo JRoute::_('index.php?option=com_users&view=profile');
```
3. Before patch, you will see URL like this **/joomla/index.php/user-profile/profile** (note profile at the end, it is not needed)

4. After patch, correct URL is displayed **/joomla/index.php/user-profile** (it is the URL of menu item you create to link to user profile)

### Expected result
URL without profile at the end when a menu item to link to user profile menu option is available

### Actual result
URL still has profile at the end.

Ping @csthomas to have a look as you have experience with Joomla routing