### PR TITLE
Remove title attribute from icons of the Batch/Bulk Import buttons

### DIFF
--- a/administrator/components/com_redirect/layouts/toolbar/batch.php
+++ b/administrator/components/com_redirect/layouts/toolbar/batch.php
@@ -15,6 +15,6 @@ $title = $displayData['title'];
 
 ?>
 <button data-toggle="modal" onclick="{jQuery( '#collapseModal' ).modal('show'); return true;}" class="btn btn-small">
-	<span class="icon-checkbox-partial"  aria-hidden="true" title="<?php echo $title; ?>"></span>
+	<span class="icon-checkbox-partial" aria-hidden="true"></span>
 	<?php echo $title; ?>
 </button>

--- a/layouts/joomla/toolbar/batch.php
+++ b/layouts/joomla/toolbar/batch.php
@@ -16,6 +16,6 @@ JText::script('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST');
 $message = "alert(Joomla.JText._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST'));";
 ?>
 <button data-toggle="modal" onclick="if (document.adminForm.boxchecked.value==0){<?php echo $message; ?>}else{jQuery( '#collapseModal' ).modal('show'); return true;}" class="btn btn-small">
-	<span class="icon-checkbox-partial" aria-hidden="true" title="<?php echo $title; ?>"></span>
+	<span class="icon-checkbox-partial" aria-hidden="true"></span>
 	<?php echo $title; ?>
 </button>


### PR DESCRIPTION
### Summary of Changes
Remove the title attribute from the icons of `Batch` and `Bulk Import` buttons to make them consistent with the other buttons in the toolbar.


### Testing Instructions
Go to Contents > Articles
View page source or use a web developer inspector to see the markup of the `Batch` button.

Go to Components > Redirects
View page source or use a web developer inspector to see the markup of the `Bulk Import` button.

### Expected result
`<span class="icon-checkbox-partial" aria-hidden="true">`


### Actual result
`<span class="icon-checkbox-partial" aria-hidden="true" title="Batch">`
`<span class="icon-checkbox-partial"  aria-hidden="true" title="Bulk Import">`


### Documentation Changes Required
none
