### PR TITLE
com_redirect modal close button check in fix

### DIFF
--- a/administrator/components/com_redirect/views/links/tmpl/default.php
+++ b/administrator/components/com_redirect/views/links/tmpl/default.php
@@ -41,9 +41,9 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 					'footer'      => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true"'
 						. ' onclick="jQuery(\'#plugin' . $this->redirectPluginId . 'Modal iframe\').contents().find(\'#closeBtn\').click();">'
 						. JText::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>'
-						. '<button class="btn btn-primary" data-dismiss="modal" aria-hidden="true" onclick="jQuery(\'#plugin' . $this->redirectPluginId . 'Modal iframe\').contents().find(\'#saveBtn\').click();">'
+						. '<button type="button" class="btn btn-primary" data-dismiss="modal" aria-hidden="true" onclick="jQuery(\'#plugin' . $this->redirectPluginId . 'Modal iframe\').contents().find(\'#saveBtn\').click();">'
 						. JText::_("JSAVE") . '</button>'
-						. '<button class="btn btn-success" aria-hidden="true" onclick="jQuery(\'#plugin' . $this->redirectPluginId . 'Modal iframe\').contents().find(\'#applyBtn\').click(); return false;">'
+						. '<button type="button" class="btn btn-success" aria-hidden="true" onclick="jQuery(\'#plugin' . $this->redirectPluginId . 'Modal iframe\').contents().find(\'#applyBtn\').click(); return false;">'
 						. JText::_("JAPPLY") . '</button>'
 				)
 			); ?>
@@ -170,4 +170,3 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 		<?php echo JHtml::_('form.token'); ?>
 	</div>
 </form>
-

--- a/administrator/components/com_redirect/views/links/tmpl/default.php
+++ b/administrator/components/com_redirect/views/links/tmpl/default.php
@@ -29,8 +29,8 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 				'bootstrap.renderModal',
 				'plugin' . $this->redirectPluginId . 'Modal',
 				array(
-					'url'        => $link,
-					'title'      => JText::_('COM_REDIRECT_EDIT_PLUGIN_SETTINGS'),
+					'url'         => $link,
+					'title'       => JText::_('COM_REDIRECT_EDIT_PLUGIN_SETTINGS'),
 					'height'      => '400px',
 					'width'       => '800px',
 					'bodyHeight'  => '70',
@@ -38,8 +38,9 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 					'closeButton' => false,
 					'backdrop'    => 'static',
 					'keyboard'    => false,
-					'footer'     => '<button class="btn" data-dismiss="modal" aria-hidden="true">'
-						. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
+					'footer'      => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true"'
+						. ' onclick="jQuery(\'#plugin' . $this->redirectPluginId . 'Modal iframe\').contents().find(\'#closeBtn\').click();">'
+						. JText::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>'
 						. '<button class="btn btn-primary" data-dismiss="modal" aria-hidden="true" onclick="jQuery(\'#plugin' . $this->redirectPluginId . 'Modal iframe\').contents().find(\'#saveBtn\').click();">'
 						. JText::_("JSAVE") . '</button>'
 						. '<button class="btn btn-success" aria-hidden="true" onclick="jQuery(\'#plugin' . $this->redirectPluginId . 'Modal iframe\').contents().find(\'#applyBtn\').click(); return false;">'


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Changed the close button (footer) to execute the plugin.cancel task

### Testing Instructions

1. [tab 1]open com_redirect
2. [tab 2] open second tab with com_plugins and filter on 'redirect' plugin
3. in [tab 2] enable the redirect plugin and disable the collect urls > save the plugin
4. in [tab 1] in com_redirect click the 'Redirect System Plugin' link in the notice
5. clicking the [Close] button will close the modal

### Expected result

The plg_system_redirect should be checked in

### Actual result

The plg_system_redirect is NOT checked in.
in [tab 2] press ctrl-f5 and you can see that although the modal in tab 1 is closed, the plugin is not checked in correct.

### Documentation Changes Required
none.

### Note
this was previously fixed here: https://github.com/joomla/joomla-cms/pull/18292 but unfortunately reintroduced with normalize patch: https://github.com/joomla/joomla-cms/pull/18913