### PR TITLE
Category Modal - add notes

### DIFF
--- a/administrator/components/com_categories/views/categories/tmpl/modal.php
+++ b/administrator/components/com_categories/views/categories/tmpl/modal.php
@@ -113,8 +113,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 							<td>
 								<?php echo JLayoutHelper::render('joomla.html.treeprefix', array('level' => $item->level)); ?>
 								<a href="javascript:void(0)" onclick="if (window.parent) window.parent.<?php echo $this->escape($function); ?>('<?php echo $item->id; ?>', '<?php echo $this->escape(addslashes($item->title)); ?>', null, '<?php echo $this->escape(ContentHelperRoute::getCategoryRoute($item->id, $item->language)); ?>', '<?php echo $this->escape($lang); ?>', null);">
-									<?php echo $this->escape($item->title); ?>
-								</a>
+									<?php echo $this->escape($item->title); ?></a>
 								<span class="small" title="<?php echo $this->escape($item->path); ?>">
 									<?php if (empty($item->note)) : ?>
 										<?php echo JText::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->alias)); ?>

--- a/administrator/components/com_categories/views/categories/tmpl/modal.php
+++ b/administrator/components/com_categories/views/categories/tmpl/modal.php
@@ -115,6 +115,13 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 								<a href="javascript:void(0)" onclick="if (window.parent) window.parent.<?php echo $this->escape($function); ?>('<?php echo $item->id; ?>', '<?php echo $this->escape(addslashes($item->title)); ?>', null, '<?php echo $this->escape(ContentHelperRoute::getCategoryRoute($item->id, $item->language)); ?>', '<?php echo $this->escape($lang); ?>', null);">
 									<?php echo $this->escape($item->title); ?>
 								</a>
+								<span class="small" title="<?php echo $this->escape($item->path); ?>">
+									<?php if (empty($item->note)) : ?>
+										<?php echo JText::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->alias)); ?>
+									<?php else : ?>
+										<?php echo JText::sprintf('JGLOBAL_LIST_ALIAS_NOTE', $this->escape($item->alias), $this->escape($item->note)); ?>
+									<?php endif; ?>
+								</span>
 							</td>
 							<td class="small hidden-phone">
 								<?php echo $this->escape($item->access_level); ?>


### PR DESCRIPTION
If you add a note to a category then it is displayed in the category list but not displayed in the category modal (eg when you select a category for a blog menu item)

This PR adds the note, alias, and full path (on hover) to the modal to make it consistent with the list view

### Before
<img width="511" alt="screenshotr09-48-07" src="https://user-images.githubusercontent.com/1296369/34293922-486d7efc-e6fe-11e7-8610-5a723d84a4f4.png">

### After
<img width="501" alt="screenshotr09-51-59" src="https://user-images.githubusercontent.com/1296369/34293904-3cb1e634-e6fe-11e7-95b9-f20bee18f79a.png">
