### PR TITLE
Typo in comment

### DIFF
--- a/libraries/legacy/request/request.php
+++ b/libraries/legacy/request/request.php
@@ -272,7 +272,7 @@ class JRequest
 	}
 
 	/**
-	 * Cmd (Word and Integer0 filter
+	 * Cmd (Word and Integer) filter
 	 *
 	 * Fetches and returns a given filtered variable. The cmd
 	 * filter only allows the characters [A-Za-z0-9.-_]. This is


### PR DESCRIPTION
Simple typo where the author forget to press the shift key - can be merged on review