### PR TITLE
Enhanced stub generator

### DIFF
--- a/build/stubGenerator.php
+++ b/build/stubGenerator.php
@@ -60,23 +60,34 @@ class StubGenerator extends CliApplication
 	 */
 	public function doExecute()
 	{
-		// Get the aliased class names via Reflection as the property is protected
-		$refl = new ReflectionClass('JLoader');
-		$property = $refl->getProperty('classAliases');
-		$property->setAccessible(true);
-		$aliases = $property->getValue();
-
 		$file = "<?php\n";
 
 		// Loop the aliases to generate the stubs data
-		foreach ($aliases as $oldName => $newName)
+		foreach (JLoader::getDeprecatedAliases() as $alias)
 		{
+			$oldName           = $alias['old'];
+			$newName           = $alias['new'];
+			$deprecatedVersion = $alias['version'];
+
 			// Figure out if the alias is for a class or interface
 			$reflection = new ReflectionClass($newName);
-			$type = $reflection->isInterface() ? 'interface' : 'class';
-			$modifier = ($reflection->isAbstract() && !$reflection->isInterface()) ? 'abstract ' : '';
+			$type       = $reflection->isInterface() ? 'interface' : 'class';
+			$modifier   = (!$reflection->isInterface() && $reflection->isFinal()) ? 'final ' : '';
+			$modifier   = ($reflection->isAbstract() && !$reflection->isInterface()) ? $modifier . 'abstract ' : $modifier;
 
-			$file .= "$modifier$type $oldName extends $newName {}\n";
+			// If a deprecated version is available, write a stub class doc block with a deprecated tag
+			if ($deprecatedVersion !== false)
+			{
+				$file .= <<<PHP
+/**
+ * @deprecated $deprecatedVersion Use $newName instead.
+ */
+
+PHP;
+
+			}
+
+			$file .= "$modifier$type $oldName extends $newName {}\n\n";
 		}
 
 		// And save the file locally


### PR DESCRIPTION
### Summary of Changes

Enhances the classmap stub generator by:

- Reading the aliases out of `JLoader::getDeprecatedAliases()` which makes deprecation versions available
- If a deprecation version is available, a stub doc block stub is written with a `@deprecated` tag (improves IDE integration by flagging the class as deprecated
- Adds the "final" keyword to class declarations for final classes (another IDE integration improvement, IDEs will warn if you extend a final class and right now the generator doesn't account for this keyword which could make someone think the alias is extensible when it shouldn't be)

### Testing Instructions

Apply the patch, run `php build/stubGenerator.php` and review the generated `stubs.php` file.  In combination with #19050 you should see entries similar to this now:

![screen shot 2017-12-22 at 9 29 48 am](https://user-images.githubusercontent.com/368545/34303441-f8f745f4-e6fa-11e7-8146-07dba077e75e.png)