### PR TITLE
template menu separator fix

### DIFF
--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -1974,7 +1974,6 @@ table th[class*="span"],
 	border-bottom: 1px solid #fff;
 }
 .dropdown-menu .menuitem-group {
-	height: 1px;
 	margin: 4px 1px;
 	overflow: hidden;
 	border-top: 1px solid #eee;
@@ -1983,7 +1982,7 @@ table th[class*="span"],
 	color: #555;
 	text-transform: capitalize;
 	font-size: 95%;
-	padding: 2px 0 24px;
+	padding: 3px 20px;
 }
 .dropdown-menu > li > a {
 	display: block;
@@ -8183,6 +8182,9 @@ body .navbar-fixed-top {
 		padding: 9px 9px 0 9px;
 	}
 }
+.navbar-search .search-query {
+	background: rgba(255,255,255,0.3);
+}
 @media (max-width: 979px) {
 	.navbar .nav {
 		font-size: 13px;
@@ -8206,10 +8208,6 @@ body .navbar-fixed-top {
 .nav-collapse .nav li a,
 .dropdown-menu a {
 	background-image: none;
-}
-.nav-collapse .dropdown-menu > li > span {
-	display: block;
-	padding: 3px 20px;
 }
 .nav-collapse .dropdown-menu > li img {
 	max-width: none;

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -1974,7 +1974,6 @@ table th[class*="span"],
 	border-bottom: 1px solid #fff;
 }
 .dropdown-menu .menuitem-group {
-	height: 1px;
 	margin: 4px 1px;
 	overflow: hidden;
 	border-top: 1px solid #eee;
@@ -1983,7 +1982,7 @@ table th[class*="span"],
 	color: #555;
 	text-transform: capitalize;
 	font-size: 95%;
-	padding: 2px 0 24px;
+	padding: 3px 20px;
 }
 .dropdown-menu > li > a {
 	display: block;
@@ -8183,6 +8182,9 @@ body .navbar-fixed-top {
 		padding: 9px 9px 0 9px;
 	}
 }
+.navbar-search .search-query {
+	background: rgba(255,255,255,0.3);
+}
 @media (max-width: 979px) {
 	.navbar .nav {
 		font-size: 13px;
@@ -8206,10 +8208,6 @@ body .navbar-fixed-top {
 .nav-collapse .nav li a,
 .dropdown-menu a {
 	background-image: none;
-}
-.nav-collapse .dropdown-menu > li > span {
-	display: block;
-	padding: 3px 20px;
 }
 .nav-collapse .dropdown-menu > li img {
 	max-width: none;

--- a/administrator/templates/isis/less/blocks/_navbar.less
+++ b/administrator/templates/isis/less/blocks/_navbar.less
@@ -182,11 +182,6 @@ body .navbar-fixed-top {
 	background-image: none;
 }
 
-.nav-collapse .dropdown-menu > li > span {
-	display: block;
-	padding: 3px 20px;
-}
-
 .nav-collapse .dropdown-menu > li {
 	img {
 		max-width: none;

--- a/media/jui/less/dropdowns.less
+++ b/media/jui/less/dropdowns.less
@@ -73,7 +73,6 @@
 
   // Labelled Separator (group label for menu items group) within the dropdown
   .menuitem-group {
-    height: 1px;
     margin: 4px 1px;
     overflow: hidden;
     border-top: 1px solid @grayLighter;
@@ -82,7 +81,7 @@
     color: @gray;
     text-transform: capitalize;
     font-size: 95%;
-    padding: 2px 0 24px;
+    padding: 3px 20px;
   }
 
   // Links within the dropdown menu

--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -2019,7 +2019,6 @@ table th[class*="span"],
 	border-bottom: 1px solid #fff;
 }
 .dropdown-menu .menuitem-group {
-	height: 1px;
 	margin: 4px 1px;
 	overflow: hidden;
 	border-top: 1px solid #eee;
@@ -2028,7 +2027,7 @@ table th[class*="span"],
 	color: #555;
 	text-transform: capitalize;
 	font-size: 95%;
-	padding: 2px 0 24px;
+	padding: 3px 20px;
 }
 .dropdown-menu > li > a {
 	display: block;


### PR DESCRIPTION
Pull Request for Issue #15093

### Summary of Changes
moved some css


### Testing Instructions
Go to the ISIS template options and set Collapse Administrator Menu to No and save

Now look at the drop down for the menu and you will see that SITE is misaligned


<img width="433" alt="screenshotr15-22-05" src="https://cloud.githubusercontent.com/assets/1296369/25091539/a6ae3f10-2381-11e7-8223-9c6ee1b0e339.png">


### Apply the PR and the Expected result
The separator is aligned correctly for both
 Collapse Administrator Menu to No and Yes

