### PR TITLE
Profile plugin fields can be left empty when required on admin edit

### DIFF
--- a/plugins/user/profile/profile.php
+++ b/plugins/user/profile/profile.php
@@ -299,9 +299,14 @@ class PlgUserProfile extends JPlugin
 			// Case using the users manager in admin
 			if ($name === 'com_users.user')
 			{
+				// Toggle whether the field is required.
+				if ($this->params->get('profile-require_' . $field, 1) > 0)
+				{
+					$form->setFieldAttribute($field, 'required', ($this->params->get('profile-require_' . $field) == 2) ? 'required' : '', 'profile');
+				}
 				// Remove the field if it is disabled in registration and profile
-				if ($this->params->get('register-require_' . $field, 1) == 0
-					&& $this->params->get('profile-require_' . $field, 1) == 0)
+				elseif ($this->params->get('register-require_' . $field, 1) == 0
+				&& $this->params->get('profile-require_' . $field, 1) == 0)
 				{
 					$form->removeField($field, 'profile');
 				}

--- a/plugins/user/profile/profile.php
+++ b/plugins/user/profile/profile.php
@@ -306,7 +306,7 @@ class PlgUserProfile extends JPlugin
 				}
 				// Remove the field if it is disabled in registration and profile
 				elseif ($this->params->get('register-require_' . $field, 1) == 0
-				&& $this->params->get('profile-require_' . $field, 1) == 0)
+					&& $this->params->get('profile-require_' . $field, 1) == 0)
 				{
 					$form->removeField($field, 'profile');
 				}

--- a/plugins/user/profile/profile.php
+++ b/plugins/user/profile/profile.php
@@ -300,8 +300,7 @@ class PlgUserProfile extends JPlugin
 			if ($name === 'com_users.user')
 			{
 				// Toggle whether the field is required.
-				if ($this->params->get('profile-require_' . $field, 1) > 0
-					&& $this->params->get('register-require_' . $field, 1) > 0)
+				if ($this->params->get('profile-require_' . $field, 1) > 0)
 				{
 					$form->setFieldAttribute($field, 'required', ($this->params->get('profile-require_' . $field) == 2) ? 'required' : '', 'profile');
 				}

--- a/plugins/user/profile/profile.php
+++ b/plugins/user/profile/profile.php
@@ -300,7 +300,8 @@ class PlgUserProfile extends JPlugin
 			if ($name === 'com_users.user')
 			{
 				// Toggle whether the field is required.
-				if ($this->params->get('profile-require_' . $field, 1) > 0)
+				if ($this->params->get('profile-require_' . $field, 1) > 0
+					&& $this->params->get('register-require_' . $field, 1) > 0)
 				{
 					$form->setFieldAttribute($field, 'required', ($this->params->get('profile-require_' . $field) == 2) ? 'required' : '', 'profile');
 				}


### PR DESCRIPTION
## Steps to reproduce the issue
Enable profile plugin. set fields to required for site and admin edit. We used Phone, Company, and website in our test.

## Expected result
Profile plugin fields are required during admin edit.

## Actual result
Can save profile during admin edit when profile plugin fields are empty.

After this PR the fields set to required are marked with a * and have the class required

PR for #14805
