### PR TITLE
Fix form data lost when user registration failed

### DIFF
--- a/components/com_users/views/registration/view.html.php
+++ b/components/com_users/views/registration/view.html.php
@@ -16,8 +16,6 @@ defined('_JEXEC') or die;
  */
 class UsersViewRegistration extends JViewLegacy
 {
-	protected $data;
-
 	protected $form;
 
 	protected $params;
@@ -38,7 +36,6 @@ class UsersViewRegistration extends JViewLegacy
 	public function display($tpl = null)
 	{
 		// Get the view data.
-		$this->data   = $this->get('Data');
 		$this->form   = $this->get('Form');
 		$this->state  = $this->get('State');
 		$this->params = $this->state->get('params');

--- a/components/com_users/views/registration/view.html.php
+++ b/components/com_users/views/registration/view.html.php
@@ -16,6 +16,8 @@ defined('_JEXEC') or die;
  */
 class UsersViewRegistration extends JViewLegacy
 {
+	protected $data;
+
 	protected $form;
 
 	protected $params;
@@ -37,6 +39,7 @@ class UsersViewRegistration extends JViewLegacy
 	{
 		// Get the view data.
 		$this->form   = $this->get('Form');
+		$this->data   = $this->get('Data');
 		$this->state  = $this->get('State');
 		$this->params = $this->state->get('params');
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
When someone register for an account and registration is failed for some reasons (for example, use an existing username or existing email), users will be redirected back to registration form with error messages explain the reason of errors. However, the data which he entered before is lost and he will have to re-enter again to register for an account. This PR fixes that issue


### Testing Instructions
1. Install Joomla

2. Try to register for an account, use an existing username

3. Before patch, you will be redirected back to register form. However, the data you entered before is cleared

4. After patch, you will be redirected back tor registration form, but the data you entered before is kept

### Technical explanation

For some reasons, the UsersViewRegistration class defines $data property (although I could not see it is used anywhere). When this line of code is called https://github.com/joomla/joomla-cms/blob/staging/components/com_users/views/registration/view.html.php#L41, the method getData of UsersModelRegistration is called. A form is created and cached without loading data from session https://github.com/joomla/joomla-cms/blob/staging/components/com_users/models/registration.php#L247

Later, when this command is called to get form object for view https://github.com/joomla/joomla-cms/blob/staging/components/com_users/views/registration/view.html.php#L42, the system uses the blank cached form and that's the reason form data is lost

As $data property is not used anywhere, I just remove it and remove$this->data   = $this->get('Data'); calls, it is now working as expected



