### PR TITLE
[4.0] Use scalar typehints and return types for new APIs and final classes in libraries

### DIFF
--- a/libraries/cms/html/draggablelist.php
+++ b/libraries/cms/html/draggablelist.php
@@ -40,7 +40,8 @@ abstract class JHtmlDraggablelist
 	 *
 	 * @throws  InvalidArgumentException
 	 */
-	public static function draggable($tableId = null, $formId = null, $sortDir = 'asc', $saveOrderingUrl = null, $redundant = null, $nestedList = false)
+	public static function draggable(string $tableId = '', string $formId = '', string $sortDir = 'asc', string $saveOrderingUrl = '',
+		$redundant = null, bool $nestedList = false)
 	{
 		// Only load once
 		if (isset(static::$loaded[__METHOD__]))
@@ -55,13 +56,13 @@ abstract class JHtmlDraggablelist
 		{
 			$doc->addScriptOptions(
 				'draggable-list',
-				array(
-					'id'         => '#' . $tableId . ' tbody',
-					'formId'     => $formId,
-					'direction'  => $sortDir,
-					'url'        => $saveOrderingUrl . '&' . JSession::getFormToken() . '=1',
-					'nested'     => $nestedList
-				)
+				[
+					'id'        => '#' . $tableId . ' tbody',
+					'formId'    => $formId,
+					'direction' => $sortDir,
+					'url'       => $saveOrderingUrl . '&' . JSession::getFormToken() . '=1',
+					'nested'    => $nestedList,
+				]
 			);
 		}
 

--- a/libraries/src/Application/AdministratorApplication.php
+++ b/libraries/src/Application/AdministratorApplication.php
@@ -475,7 +475,7 @@ class AdministratorApplication extends CMSApplication
 	 *
 	 * @since   4.0.0
 	 */
-	public function findOption()
+	public function findOption(): string
 	{
 		$app = \JFactory::getApplication();
 		$option = strtolower($app->input->get('option'));

--- a/libraries/src/Application/ConsoleApplication.php
+++ b/libraries/src/Application/ConsoleApplication.php
@@ -63,7 +63,7 @@ class ConsoleApplication extends Application implements DispatcherAwareInterface
 	 *                                            will be created based on the application's loadDispatcher() method.
 	 * @param   Container            $container   Dependency injection container.
 	 *
-	 * @since   11.1
+	 * @since   4.0.0
 	 */
 	public function __construct(Cli $input = null, Registry $config = null, DispatcherInterface $dispatcher = null, Container $container = null)
 	{

--- a/libraries/src/Application/ExtensionNamespaceMapper.php
+++ b/libraries/src/Application/ExtensionNamespaceMapper.php
@@ -15,7 +15,7 @@ use JLoader;
 /**
  * Trait for application classes which ensures the namespace mapper exists and includes it.
  *
- * @since  4.0
+ * @since  4.0.0
  */
 trait ExtensionNamespaceMapper
 {

--- a/libraries/src/Dispatcher/Dispatcher.php
+++ b/libraries/src/Dispatcher/Dispatcher.php
@@ -94,9 +94,9 @@ abstract class Dispatcher implements DispatcherInterface
 	/**
 	 * Load the language
 	 *
-	 * @since   4.0.0
-	 *
 	 * @return  void
+	 *
+	 * @since   4.0.0
 	 */
 	protected function loadLanguage()
 	{
@@ -108,9 +108,9 @@ abstract class Dispatcher implements DispatcherInterface
 	/**
 	 * Method to check component access permission
 	 *
-	 * @since   4.0.0
-	 *
 	 * @return  void
+	 *
+	 * @since   4.0.0
 	 */
 	protected function checkAccess()
 	{

--- a/libraries/src/Document/Factory.php
+++ b/libraries/src/Document/Factory.php
@@ -11,14 +11,14 @@ namespace Joomla\CMS\Document;
 defined('_JEXEC') or die;
 
 /**
- * Default factory for creating JDocument objects
+ * Default factory for creating Document objects
  *
  * @since  4.0.0
  */
 class Factory implements FactoryInterface
 {
 	/**
-	 * Creates a new JDocument object for the requested format.
+	 * Creates a new Document object for the requested format.
 	 *
 	 * @param   string  $type        The document type to instantiate
 	 * @param   array   $attributes  Array of attributes
@@ -66,7 +66,7 @@ class Factory implements FactoryInterface
 	/**
 	 * Creates a new renderer object.
 	 *
-	 * @param   Document  $document  The JDocument instance to attach to the renderer
+	 * @param   Document  $document  The Document instance to attach to the renderer
 	 * @param   string    $type      The renderer type to instantiate
 	 *
 	 * @return  RendererInterface

--- a/libraries/src/Document/FactoryInterface.php
+++ b/libraries/src/Document/FactoryInterface.php
@@ -11,14 +11,14 @@ namespace Joomla\CMS\Document;
 defined('_JEXEC') or die;
 
 /**
- * Interface defining a factory which can create JDocument objects
+ * Interface defining a factory which can create Document objects
  *
  * @since  4.0.0
  */
 interface FactoryInterface
 {
 	/**
-	 * Creates a new JDocument object for the requested format.
+	 * Creates a new Document object for the requested format.
 	 *
 	 * @param   string  $type        The document type to instantiate
 	 * @param   array   $attributes  Array of attributes
@@ -32,7 +32,7 @@ interface FactoryInterface
 	/**
 	 * Creates a new renderer object.
 	 *
-	 * @param   Document  $document  The JDocument instance to attach to the renderer
+	 * @param   Document  $document  The Document instance to attach to the renderer
 	 * @param   string    $type      The renderer type to instantiate
 	 *
 	 * @return  RendererInterface

--- a/libraries/src/Factory.php
+++ b/libraries/src/Factory.php
@@ -205,7 +205,7 @@ abstract class Factory
 	 *
 	 * @since   4.0
 	 */
-	public static function getContainer()
+	public static function getContainer(): Container
 	{
 		if (!self::$container)
 		{
@@ -512,7 +512,7 @@ abstract class Factory
 	 *
 	 * @since   4.0
 	 */
-	protected static function createContainer()
+	protected static function createContainer(): Container
 	{
 		$container = (new Container)
 			->registerServiceProvider(new \Joomla\CMS\Service\Provider\Application)

--- a/libraries/src/MVC/Factory/LegacyFactory.php
+++ b/libraries/src/MVC/Factory/LegacyFactory.php
@@ -23,7 +23,6 @@ use Joomla\CMS\Table\Table;
  */
 class LegacyFactory implements MVCFactoryInterface
 {
-
 	/**
 	 * Method to load and return a model object.
 	 *
@@ -36,7 +35,7 @@ class LegacyFactory implements MVCFactoryInterface
 	 * @since   4.0.0
 	 * @throws  \Exception
 	 */
-	public function createModel($name, $prefix = '', array $config = array())
+	public function createModel($name, $prefix = '', array $config = [])
 	{
 		// Clean the model name
 		$modelName = preg_replace('/[^A-Z0-9_]/i', '', $name);
@@ -58,7 +57,7 @@ class LegacyFactory implements MVCFactoryInterface
 	 * @since   4.0.0
 	 * @throws  \Exception
 	 */
-	public function createView($name, $prefix = '', $type = '', array $config = array())
+	public function createView($name, $prefix = '', $type = '', array $config = [])
 	{
 		// Clean the view name
 		$viewName = preg_replace('/[^A-Z0-9_]/i', '', $name);
@@ -101,7 +100,7 @@ class LegacyFactory implements MVCFactoryInterface
 	 * @since   4.0.0
 	 * @throws  \Exception
 	 */
-	public function createTable($name, $prefix = 'Table', array $config = array())
+	public function createTable($name, $prefix = 'Table', array $config = [])
 	{
 		// Clean the model name
 		$name = preg_replace('/[^A-Z0-9_]/i', '', $name);

--- a/libraries/src/MVC/Factory/MVCFactory.php
+++ b/libraries/src/MVC/Factory/MVCFactory.php
@@ -23,16 +23,18 @@ class MVCFactory implements MVCFactoryInterface
 	/**
 	 * The namespace to create the objects from.
 	 *
-	 * @var string
+	 * @var    string
+	 * @since  4.0.0
 	 */
-	private $namespace = null;
+	private $namespace;
 
 	/**
 	 * The application.
 	 *
-	 * @var CMSApplicationInterface
+	 * @var    CMSApplicationInterface
+	 * @since  4.0.0
 	 */
-	private $application = null;
+	private $application;
 
 	/**
 	 * The namespace must be like:
@@ -61,7 +63,7 @@ class MVCFactory implements MVCFactoryInterface
 	 * @since   4.0.0
 	 * @throws  \Exception
 	 */
-	public function createModel($name, $prefix = '', array $config = array())
+	public function createModel($name, $prefix = '', array $config = [])
 	{
 		// Clean the parameters
 		$name   = preg_replace('/[^A-Z0-9_]/i', '', $name);
@@ -90,7 +92,7 @@ class MVCFactory implements MVCFactoryInterface
 	 * @since   4.0.0
 	 * @throws  \Exception
 	 */
-	public function createView($name, $prefix = '', $type = '', array $config = array())
+	public function createView($name, $prefix = '', $type = '', array $config = [])
 	{
 		// Clean the parameters
 		$name   = preg_replace('/[^A-Z0-9_]/i', '', $name);
@@ -119,7 +121,7 @@ class MVCFactory implements MVCFactoryInterface
 	 * @since   4.0.0
 	 * @throws  \Exception
 	 */
-	public function createTable($name, $prefix = '', array $config = array())
+	public function createTable($name, $prefix = '', array $config = [])
 	{
 		// Clean the parameters
 		$name = preg_replace('/[^A-Z0-9_]/i', '', $name);
@@ -155,7 +157,7 @@ class MVCFactory implements MVCFactoryInterface
 	 *
 	 * @since   4.0.0
 	 */
-	private function getClassName($suffix, $prefix)
+	private function getClassName(string $suffix, string $prefix)
 	{
 		if (!$prefix)
 		{

--- a/libraries/src/MVC/Factory/MVCFactoryInterface.php
+++ b/libraries/src/MVC/Factory/MVCFactoryInterface.php
@@ -29,7 +29,7 @@ interface MVCFactoryInterface
 	 * @since   4.0.0
 	 * @throws  \Exception
 	 */
-	public function createModel($name, $prefix = '', array $config = array());
+	public function createModel($name, $prefix = '', array $config = []);
 
 	/**
 	 * Method to load and return a view object.
@@ -44,7 +44,7 @@ interface MVCFactoryInterface
 	 * @since   4.0.0
 	 * @throws  \Exception
 	 */
-	public function createView($name, $prefix = '', $type = '', array $config = array());
+	public function createView($name, $prefix = '', $type = '', array $config = []);
 
 	/**
 	 * Method to load and return a table object.
@@ -58,5 +58,5 @@ interface MVCFactoryInterface
 	 * @since   4.0.0
 	 * @throws  \Exception
 	 */
-	public function createTable($name, $prefix = '', array $config = array());
+	public function createTable($name, $prefix = '', array $config = []);
 }

--- a/libraries/src/Plugin/CMSPlugin.php
+++ b/libraries/src/Plugin/CMSPlugin.php
@@ -282,7 +282,7 @@ abstract class CMSPlugin implements DispatcherAwareInterface
 	 *
 	 * @since   4.0
 	 */
-	protected final function registerLegacyListener($methodName)
+	final protected function registerLegacyListener(string $methodName)
 	{
 		$this->getDispatcher()->addListener(
 			$methodName,
@@ -323,7 +323,7 @@ abstract class CMSPlugin implements DispatcherAwareInterface
 	 *
 	 * @since   4.0
 	 */
-	final protected function registerListener($methodName)
+	final protected function registerListener(string $methodName)
 	{
 		$this->getDispatcher()->addListener($methodName, [$this, $methodName]);
 	}

--- a/libraries/src/Session/Storage/JoomlaStorage.php
+++ b/libraries/src/Session/Storage/JoomlaStorage.php
@@ -10,6 +10,7 @@ namespace Joomla\CMS\Session\Storage;
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Input\Input;
 use Joomla\Registry\Registry;
 use Joomla\Session\Storage\NativeStorage;
 
@@ -39,7 +40,7 @@ class JoomlaStorage extends NativeStorage
 	/**
 	 * Input object
 	 *
-	 * @var    \JInput
+	 * @var    Input
 	 * @since  4.0
 	 */
 	private $input;
@@ -47,13 +48,13 @@ class JoomlaStorage extends NativeStorage
 	/**
 	 * Constructor
 	 *
-	 * @param   \JInput                   $input    Input object
+	 * @param   Input                     $input    Input object
 	 * @param   \SessionHandlerInterface  $handler  Session save handler
 	 * @param   array                     $options  Session options
 	 *
 	 * @since   4.0
 	 */
-	public function __construct(\JInput $input, \SessionHandlerInterface $handler = null, array $options = array())
+	public function __construct(Input $input, \SessionHandlerInterface $handler = null, array $options = [])
 	{
 		// Disable transparent sid support
 		ini_set('session.use_trans_sid', '0');
@@ -69,7 +70,7 @@ class JoomlaStorage extends NativeStorage
 		$this->input = $input;
 
 		// Register our function as shutdown method, so we can manipulate it
-		register_shutdown_function(array($this, 'close'));
+		register_shutdown_function([$this, 'close']);
 	}
 
 	/**

--- a/libraries/src/Version.php
+++ b/libraries/src/Version.php
@@ -125,7 +125,7 @@ final class Version
 	 *
 	 * @since   3.4.3
 	 */
-	public function isInDevelopmentState()
+	public function isInDevelopmentState(): bool
 	{
 		return strtolower(self::DEV_STATUS) !== 'stable';
 	}
@@ -140,7 +140,7 @@ final class Version
 	 * @link    https://secure.php.net/version_compare
 	 * @since   1.0
 	 */
-	public function isCompatible($minimum)
+	public function isCompatible(string $minimum): bool
 	{
 		return version_compare(JVERSION, $minimum, 'ge');
 	}
@@ -152,7 +152,7 @@ final class Version
 	 *
 	 * @since   1.0
 	 */
-	public function getHelpVersion()
+	public function getHelpVersion(): string
 	{
 		return '.' . self::MAJOR_VERSION . self::MINOR_VERSION;
 	}
@@ -164,7 +164,7 @@ final class Version
 	 *
 	 * @since   1.5
 	 */
-	public function getShortVersion()
+	public function getShortVersion(): string
 	{
 		$version = self::MAJOR_VERSION . '.' . self::MINOR_VERSION . '.' . self::PATCH_VERSION;
 
@@ -183,7 +183,7 @@ final class Version
 	 *
 	 * @since   1.5
 	 */
-	public function getLongVersion()
+	public function getLongVersion(): string
 	{
 		return self::PRODUCT . ' ' . $this->getShortVersion() . ' '
 			. self::DEV_STATUS . ' [ ' . self::CODENAME . ' ] ' . self::RELDATE . ' '
@@ -201,9 +201,9 @@ final class Version
 	 *
 	 * @since   1.0
 	 */
-	public function getUserAgent($component = null, $mask = false, $addVersion = true)
+	public function getUserAgent(string $component = '', bool $mask = false, bool $addVersion = true): string
 	{
-		if ($component === null)
+		if ($component === '')
 		{
 			$component = 'Framework';
 		}
@@ -225,7 +225,7 @@ final class Version
 	 *
 	 * @since   3.2
 	 */
-	public function generateMediaVersion()
+	public function generateMediaVersion(): string
 	{
 		return md5($this->getLongVersion() . \JFactory::getConfig()->get('secret') . (new \JDate)->toSql());
 	}
@@ -241,7 +241,7 @@ final class Version
 	 *
 	 * @since   3.2
 	 */
-	public function getMediaVersion()
+	public function getMediaVersion(): string
 	{
 		// Load the media version and cache it for future use
 		static $mediaVersion = null;
@@ -270,7 +270,7 @@ final class Version
 	 *
 	 * @since   3.2
 	 */
-	public function refreshMediaVersion()
+	public function refreshMediaVersion(): Version
 	{
 		return $this->setMediaVersion($this->generateMediaVersion());
 	}
@@ -284,7 +284,7 @@ final class Version
 	 *
 	 * @since   3.2
 	 */
-	public function setMediaVersion($mediaVersion)
+	public function setMediaVersion(string $mediaVersion): Version
 	{
 		// Do not allow empty media versions
 		if (!empty($mediaVersion))

--- a/tests/unit/suites/libraries/cms/version/JVersionTest.php
+++ b/tests/unit/suites/libraries/cms/version/JVersionTest.php
@@ -108,7 +108,7 @@ class JVersionTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function testGetUserAgent_maskFalse()
 	{
-		$this->assertNotContains('Mozilla/5.0 ', $this->object->getUserAgent(null, false, true));
+		$this->assertNotContains('Mozilla/5.0 ', $this->object->getUserAgent('', false, true));
 	}
 
 	/**
@@ -120,7 +120,7 @@ class JVersionTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function testGetUserAgent_maskTrue()
 	{
-		$this->assertContains('Mozilla/5.0 ', $this->object->getUserAgent(null, true, true));
+		$this->assertContains('Mozilla/5.0 ', $this->object->getUserAgent('', true, true));
 	}
 
 	/**
@@ -132,7 +132,7 @@ class JVersionTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function testGetUserAgent_ComponentNull()
 	{
-		$this->assertContains('Framework', $this->object->getUserAgent(null, false, true));
+		$this->assertContains('Framework', $this->object->getUserAgent('', false, true));
 	}
 
 	/**


### PR DESCRIPTION
### Summary of Changes

Makes use of PHP 7 typing features in classes/methods new to the 4.0 or classes/methods which are declared final and therefore B/C breaks are acceptable for these changes since final classes/methods cannot be extended.

### Testing Instructions

Code review
