### PR TITLE
[CS] tabs Code Style fixes for administrator/components

### DIFF
--- a/administrator/components/com_admin/views/sysinfo/view.html.php
+++ b/administrator/components/com_admin/views/sysinfo/view.html.php
@@ -92,7 +92,7 @@ class AdminViewSysinfo extends JViewLegacy
 	 *
 	 * @since   1.6
 	 * @note    Necessary for Hathor compatibility
-	  * @deprecated  4.0 To be removed with Hathor
+	 * @deprecated  4.0 To be removed with Hathor
 	 */
 	protected function _setSubMenu()
 	{

--- a/administrator/components/com_admin/views/sysinfo/view.html.php
+++ b/administrator/components/com_admin/views/sysinfo/view.html.php
@@ -92,7 +92,7 @@ class AdminViewSysinfo extends JViewLegacy
 	 *
 	 * @since   1.6
 	 * @note    Necessary for Hathor compatibility
- 	 * @deprecated  4.0 To be removed with Hathor
+	  * @deprecated  4.0 To be removed with Hathor
 	 */
 	protected function _setSubMenu()
 	{

--- a/administrator/components/com_associations/models/fields/modalassociation.php
+++ b/administrator/components/com_associations/models/fields/modalassociation.php
@@ -75,11 +75,11 @@ class JFormFieldModalAssociation extends JFormField
 
 		// Clear association button
 		$html[] = '<button'
-				. ' class="btn' . ($value ? '' : ' hidden') . '"'
-				. ' onclick="return Joomla.submitbutton(\'undo-association\');"'
-				. ' id="remove-assoc">'
-				. '<span class="icon-remove" aria-hidden="true"></span>' . JText::_('JCLEAR')
-				. '</button>';
+			. ' class="btn' . ($value ? '' : ' hidden') . '"'
+			. ' onclick="return Joomla.submitbutton(\'undo-association\');"'
+			. ' id="remove-assoc">'
+			. '<span class="icon-remove" aria-hidden="true"></span>' . JText::_('JCLEAR')
+			. '</button>';
 
 		$html[] = '<input type="hidden" id="' . $this->id . '_id" name="' . $this->name . '" value="' . $value . '" />';
 

--- a/administrator/components/com_associations/models/fields/modalassociation.php
+++ b/administrator/components/com_associations/models/fields/modalassociation.php
@@ -75,11 +75,11 @@ class JFormFieldModalAssociation extends JFormField
 
 		// Clear association button
 		$html[] = '<button'
- 				. ' class="btn' . ($value ? '' : ' hidden') . '"'
- 				. ' onclick="return Joomla.submitbutton(\'undo-association\');"'
- 				. ' id="remove-assoc">'
- 				. '<span class="icon-remove" aria-hidden="true"></span>' . JText::_('JCLEAR')
- 				. '</button>';
+				 . ' class="btn' . ($value ? '' : ' hidden') . '"'
+				 . ' onclick="return Joomla.submitbutton(\'undo-association\');"'
+				 . ' id="remove-assoc">'
+				 . '<span class="icon-remove" aria-hidden="true"></span>' . JText::_('JCLEAR')
+				 . '</button>';
 
 		$html[] = '<input type="hidden" id="' . $this->id . '_id" name="' . $this->name . '" value="' . $value . '" />';
 

--- a/administrator/components/com_associations/models/fields/modalassociation.php
+++ b/administrator/components/com_associations/models/fields/modalassociation.php
@@ -75,11 +75,11 @@ class JFormFieldModalAssociation extends JFormField
 
 		// Clear association button
 		$html[] = '<button'
-				 . ' class="btn' . ($value ? '' : ' hidden') . '"'
-				 . ' onclick="return Joomla.submitbutton(\'undo-association\');"'
-				 . ' id="remove-assoc">'
-				 . '<span class="icon-remove" aria-hidden="true"></span>' . JText::_('JCLEAR')
-				 . '</button>';
+				. ' class="btn' . ($value ? '' : ' hidden') . '"'
+				. ' onclick="return Joomla.submitbutton(\'undo-association\');"'
+				. ' id="remove-assoc">'
+				. '<span class="icon-remove" aria-hidden="true"></span>' . JText::_('JCLEAR')
+				. '</button>';
 
 		$html[] = '<input type="hidden" id="' . $this->id . '_id" name="' . $this->name . '" value="' . $value . '" />';
 

--- a/administrator/components/com_menus/views/menus/tmpl/default.php
+++ b/administrator/components/com_menus/views/menus/tmpl/default.php
@@ -176,7 +176,7 @@ JFactory::getDocument()->addScriptDeclaration(implode("\n", $script));
 														<?php echo JText::sprintf('COM_MENUS_MODULE_ACCESS_POSITION', $this->escape($module->title), $this->escape($module->access_title), $this->escape($module->position)); ?></a>
 												<?php else : ?>
 													<a href="#" class="disabled" disabled="disabled">
-													    <?php echo JText::sprintf('COM_MENUS_MODULE_ACCESS_POSITION', $this->escape($module->title), $this->escape($module->access_title), $this->escape($module->position)); ?></a>
+														<?php echo JText::sprintf('COM_MENUS_MODULE_ACCESS_POSITION', $this->escape($module->title), $this->escape($module->access_title), $this->escape($module->position)); ?></a>
 												<?php endif; ?>
 											</li>
 										<?php endforeach; ?>

--- a/administrator/components/com_templates/views/template/tmpl/default_modal_delete_body.php
+++ b/administrator/components/com_templates/views/template/tmpl/default_modal_delete_body.php
@@ -11,6 +11,6 @@ defined('_JEXEC') or die;
 ?>
 <div id="template-manager-delete" class="container-fluid">
 	<div class="row-fluid">
-        <p><?php echo JText::sprintf('COM_TEMPLATES_MODAL_FILE_DELETE', $this->fileName); ?></p>
+		<p><?php echo JText::sprintf('COM_TEMPLATES_MODAL_FILE_DELETE', $this->fileName); ?></p>
 	</div>
 </div>


### PR DESCRIPTION
Pull Request for Issue spaces are not allowed

### Summary of Changes
- Tabs must be used to indent lines; spaces are not allowed

[Automatically fixed with Joomla code standards 2.0.0 PHPCS2-alpha2 fixers](https://github.com/joomla/coding-standards/releases/tag/2.0.0-alpha2)

None of the manual only fixes have been applied

### Testing Instructions
Merge by code review

### Expected result
code style has been applied as listed above, old code style testing on drone does not error.

### Actual result
code style had not been applied. [Autofixers from the Joomla code standards 2.0.0 PHPCS2 alpha2](https://github.com/joomla/coding-standards/releases/tag/2.0.0-alpha2) were used to implement fixable code style

### Documentation Changes Required
none
