### PR TITLE
[CS] Code Style fixes for libraries\src\Application\WebApplication.php

### DIFF
--- a/libraries/src/Application/WebApplication.php
+++ b/libraries/src/Application/WebApplication.php
@@ -148,13 +148,13 @@ class WebApplication extends BaseApplication
 	);
 
 	/**
-         * A map of HTTP Response headers which may only send a single value, all others
-         * are considered to allow multiple
-         *
-         * @var    object
-         * @since  3.5.2
-         * @link   https://tools.ietf.org/html/rfc7230
-         */
+		 * A map of HTTP Response headers which may only send a single value, all others
+		 * are considered to allow multiple
+		 *
+		 * @var    object
+		 * @since  3.5.2
+		 * @link   https://tools.ietf.org/html/rfc7230
+		 */
 	private $singleValueResponseHeaders = array(
 		'status', // This is not a valid header name, but the representation used by Joomla to identify the HTTP Response Code
 		'Content-Length',

--- a/libraries/src/Application/WebApplication.php
+++ b/libraries/src/Application/WebApplication.php
@@ -148,13 +148,13 @@ class WebApplication extends BaseApplication
 	);
 
 	/**
-		 * A map of HTTP Response headers which may only send a single value, all others
-		 * are considered to allow multiple
-		 *
-		 * @var    object
-		 * @since  3.5.2
-		 * @link   https://tools.ietf.org/html/rfc7230
-		 */
+	 * A map of HTTP Response headers which may only send a single value, all others
+	 * are considered to allow multiple
+	 *
+	 * @var    object
+	 * @since  3.5.2
+	 * @link   https://tools.ietf.org/html/rfc7230
+	 */
 	private $singleValueResponseHeaders = array(
 		'status', // This is not a valid header name, but the representation used by Joomla to identify the HTTP Response Code
 		'Content-Length',


### PR DESCRIPTION
Pull Request for Issue spaces are not allowed.

### Summary of Changes
- Tabs must be used to indent lines; spaces are not allowed

[Automatically fixed with Joomla code standards 2.0.0 PHPCS2-alpha2 fixers](https://github.com/joomla/coding-standards/releases/tag/2.0.0-alpha2)

None of the manual only fixes have been applied

### Testing Instructions
Merge by code review

### Expected result
code style has been applied as listed above, old code style testing on drone does not error.

### Actual result
code style had not been applied. [Autofixers from the Joomla code standards 2.0.0 PHPCS2 alpha2](https://github.com/joomla/coding-standards/releases/tag/2.0.0-alpha2) were used to implement fixable code style

### Documentation Changes Required
none