### PR TITLE
[CS] Code Style fixes for libraries Object operator not indented correctly

### DIFF
--- a/libraries/src/Form/Field/FrontendlanguageField.php
+++ b/libraries/src/Form/Field/FrontendlanguageField.php
@@ -45,9 +45,9 @@ class FrontendlanguageField extends \JFormFieldList
 		$query = $db->getQuery(true);
 
 		$query->select('a.lang_code AS value, a.title AS text')
-				->from($db->quoteName('#__languages') . ' AS a')
-				->where('a.published = 1')
-				->order('a.title');
+            ->from($db->quoteName('#__languages') . ' AS a')
+            ->where('a.published = 1')
+            ->order('a.title');
 
 		// Select the language home pages.
 		$query->select('l.home, l.language')

--- a/libraries/src/Form/Field/FrontendlanguageField.php
+++ b/libraries/src/Form/Field/FrontendlanguageField.php
@@ -45,9 +45,9 @@ class FrontendlanguageField extends \JFormFieldList
 		$query = $db->getQuery(true);
 
 		$query->select('a.lang_code AS value, a.title AS text')
-            ->from($db->quoteName('#__languages') . ' AS a')
-            ->where('a.published = 1')
-            ->order('a.title');
+			->from($db->quoteName('#__languages') . ' AS a')
+			->where('a.published = 1')
+			->order('a.title');
 
 		// Select the language home pages.
 		$query->select('l.home, l.language')

--- a/libraries/src/Installer/Adapter/ComponentAdapter.php
+++ b/libraries/src/Installer/Adapter/ComponentAdapter.php
@@ -1177,8 +1177,8 @@ class ComponentAdapter extends InstallerAdapter
 		// to use the new component id.
 		$query = $db->getQuery(true)
 			->update('#__menu')
-			->set('component_id = ' . $db->quoteName($component_id))
-			->where('type = ' . $db->quoteName('component'))
+			->set('component_id = ' . $db->quote($component_id))
+			->where('type = ' . $db->quote('component'))
 			->where('('
 					. 'link LIKE ' . $db->quote('index.php?option=' . $option) . ' OR '
 					. 'link LIKE ' . $db->q($db->escape('index.php?option=' . $option . '&') . '%', false)

--- a/libraries/src/Installer/Adapter/ComponentAdapter.php
+++ b/libraries/src/Installer/Adapter/ComponentAdapter.php
@@ -1177,12 +1177,12 @@ class ComponentAdapter extends InstallerAdapter
 		// to use the new component id.
 		$query = $db->getQuery(true)
 			->update('#__menu')
-			->set('component_id = ' . $db->quote($component_id))
-			->where('type = ' . $db->quote('component'))
-			->where('(' .
-						'link LIKE ' . $db->quote('index.php?option=' . $option) . ' OR ' .
-						'link LIKE ' . $db->q($db->escape('index.php?option=' . $option . '&') . '%', false) .
-					')');
+			->set('component_id = ' . $db->quoteName($component_id))
+			->where('type = ' . $db->quoteName('component'))
+			->where('('
+					. 'link LIKE ' . $db->quote('index.php?option=' . $option) . ' OR '
+					. 'link LIKE ' . $db->q($db->escape('index.php?option=' . $option . '&') . '%', false)
+					. ')');
 
 		if (isset($clientId))
 		{

--- a/libraries/src/Installer/Adapter/ComponentAdapter.php
+++ b/libraries/src/Installer/Adapter/ComponentAdapter.php
@@ -1180,9 +1180,9 @@ class ComponentAdapter extends InstallerAdapter
 			->set('component_id = ' . $db->quote($component_id))
 			->where('type = ' . $db->quote('component'))
 			->where('('
-					. 'link LIKE ' . $db->quote('index.php?option=' . $option) . ' OR '
-					. 'link LIKE ' . $db->q($db->escape('index.php?option=' . $option . '&') . '%', false)
-					. ')');
+				. 'link LIKE ' . $db->quote('index.php?option=' . $option) . ' OR '
+				. 'link LIKE ' . $db->q($db->escape('index.php?option=' . $option . '&') . '%', false)
+				. ')');
 
 		if (isset($clientId))
 		{

--- a/libraries/src/Installer/Adapter/ComponentAdapter.php
+++ b/libraries/src/Installer/Adapter/ComponentAdapter.php
@@ -605,11 +605,11 @@ class ComponentAdapter extends InstallerAdapter
 			$db = $this->parent->getDbo();
 
 			$query = $db->getQuery(true)
-                ->select($db->qn('extension_id'))
-                ->from($db->qn('#__extensions'))
-                ->where($db->qn('name') . ' = ' . $db->q($this->extension->name))
-                ->where($db->qn('type') . ' = ' . $db->q($this->extension->type))
-                ->where($db->qn('element') . ' = ' . $db->q($this->extension->element));
+				->select($db->qn('extension_id'))
+				->from($db->qn('#__extensions'))
+				->where($db->qn('name') . ' = ' . $db->q($this->extension->name))
+				->where($db->qn('type') . ' = ' . $db->q($this->extension->type))
+				->where($db->qn('element') . ' = ' . $db->q($this->extension->element));
 
 			$db->setQuery($query);
 
@@ -803,8 +803,8 @@ class ComponentAdapter extends InstallerAdapter
 
 		// Remove the schema version
 		$query = $db->getQuery(true)
-            ->delete('#__schemas')
-            ->where('extension_id = ' . $id);
+			->delete('#__schemas')
+			->where('extension_id = ' . $id);
 		$db->setQuery($query);
 		$db->execute();
 
@@ -898,13 +898,13 @@ class ComponentAdapter extends InstallerAdapter
 
 		// If a component exists with this option in the table within the protected menutype 'main' then we don't need to add menus
 		$query = $db->getQuery(true)
-            ->select('m.id, e.extension_id')
-            ->from('#__menu AS m')
-            ->join('LEFT', '#__extensions AS e ON m.component_id = e.extension_id')
-            ->where('m.parent_id = 1')
-            ->where('m.client_id = 1')
-            ->where('m.menutype = ' . $db->quote('main'))
-            ->where('e.element = ' . $db->quote($option));
+			->select('m.id, e.extension_id')
+			->from('#__menu AS m')
+			->join('LEFT', '#__extensions AS e ON m.component_id = e.extension_id')
+			->where('m.parent_id = 1')
+			->where('m.client_id = 1')
+			->where('m.menutype = ' . $db->quote('main'))
+			->where('e.element = ' . $db->quote($option));
 
 		$db->setQuery($query);
 
@@ -1110,11 +1110,11 @@ class ComponentAdapter extends InstallerAdapter
 
 		// Get the ids of the menu items
 		$query = $db->getQuery(true)
-            ->select('id')
-            ->from('#__menu')
-            ->where($db->quoteName('client_id') . ' = 1')
-            ->where($db->quoteName('menutype') . ' = ' . $db->q('main'))
-            ->where($db->quoteName('component_id') . ' = ' . (int) $id);
+			->select('id')
+			->from('#__menu')
+			->where($db->quoteName('client_id') . ' = 1')
+			->where($db->quoteName('menutype') . ' = ' . $db->q('main'))
+			->where($db->quoteName('component_id') . ' = ' . (int) $id);
 
 		$db->setQuery($query);
 
@@ -1176,10 +1176,10 @@ class ComponentAdapter extends InstallerAdapter
 		// Update all menu items which contain 'index.php?option=com_extension' or 'index.php?option=com_extension&...'
 		// to use the new component id.
 		$query = $db->getQuery(true)
-            ->update('#__menu')
-            ->set('component_id = ' . $db->quote($component_id))
-            ->where('type = ' . $db->quote('component'))
-            ->where('(' .
+			->update('#__menu')
+			->set('component_id = ' . $db->quote($component_id))
+			->where('type = ' . $db->quote('component'))
+			->where('(' .
 						'link LIKE ' . $db->quote('index.php?option=' . $option) . ' OR ' .
 						'link LIKE ' . $db->q($db->escape('index.php?option=' . $option . '&') . '%', false) .
 					')');
@@ -1336,14 +1336,14 @@ class ComponentAdapter extends InstallerAdapter
 		{
 			// The menu item already exists. Delete it and retry instead of throwing an error.
 			$query = $db->getQuery(true)
-                ->select('id')
-                ->from('#__menu')
-                ->where('menutype = ' . $db->q($data['menutype']))
-                ->where('client_id = 1')
-                ->where('link = ' . $db->q($data['link']))
-                ->where('type = ' . $db->q($data['type']))
-                ->where('parent_id = ' . $db->q($data['parent_id']))
-                ->where('home = ' . $db->q($data['home']));
+				->select('id')
+				->from('#__menu')
+				->where('menutype = ' . $db->q($data['menutype']))
+				->where('client_id = 1')
+				->where('link = ' . $db->q($data['link']))
+				->where('type = ' . $db->q($data['type']))
+				->where('parent_id = ' . $db->q($data['parent_id']))
+				->where('home = ' . $db->q($data['home']));
 
 			$db->setQuery($query);
 			$menu_id = $db->loadResult();

--- a/libraries/src/Installer/Adapter/ComponentAdapter.php
+++ b/libraries/src/Installer/Adapter/ComponentAdapter.php
@@ -605,11 +605,11 @@ class ComponentAdapter extends InstallerAdapter
 			$db = $this->parent->getDbo();
 
 			$query = $db->getQuery(true)
-						->select($db->qn('extension_id'))
-						->from($db->qn('#__extensions'))
-						->where($db->qn('name') . ' = ' . $db->q($this->extension->name))
-						->where($db->qn('type') . ' = ' . $db->q($this->extension->type))
-						->where($db->qn('element') . ' = ' . $db->q($this->extension->element));
+                ->select($db->qn('extension_id'))
+                ->from($db->qn('#__extensions'))
+                ->where($db->qn('name') . ' = ' . $db->q($this->extension->name))
+                ->where($db->qn('type') . ' = ' . $db->q($this->extension->type))
+                ->where($db->qn('element') . ' = ' . $db->q($this->extension->element));
 
 			$db->setQuery($query);
 
@@ -803,8 +803,8 @@ class ComponentAdapter extends InstallerAdapter
 
 		// Remove the schema version
 		$query = $db->getQuery(true)
-					->delete('#__schemas')
-					->where('extension_id = ' . $id);
+            ->delete('#__schemas')
+            ->where('extension_id = ' . $id);
 		$db->setQuery($query);
 		$db->execute();
 
@@ -898,13 +898,13 @@ class ComponentAdapter extends InstallerAdapter
 
 		// If a component exists with this option in the table within the protected menutype 'main' then we don't need to add menus
 		$query = $db->getQuery(true)
-					->select('m.id, e.extension_id')
-					->from('#__menu AS m')
-					->join('LEFT', '#__extensions AS e ON m.component_id = e.extension_id')
-					->where('m.parent_id = 1')
-					->where('m.client_id = 1')
-					->where('m.menutype = ' . $db->quote('main'))
-					->where('e.element = ' . $db->quote($option));
+            ->select('m.id, e.extension_id')
+            ->from('#__menu AS m')
+            ->join('LEFT', '#__extensions AS e ON m.component_id = e.extension_id')
+            ->where('m.parent_id = 1')
+            ->where('m.client_id = 1')
+            ->where('m.menutype = ' . $db->quote('main'))
+            ->where('e.element = ' . $db->quote($option));
 
 		$db->setQuery($query);
 
@@ -1110,11 +1110,11 @@ class ComponentAdapter extends InstallerAdapter
 
 		// Get the ids of the menu items
 		$query = $db->getQuery(true)
-					->select('id')
-					->from('#__menu')
-					->where($db->quoteName('client_id') . ' = 1')
-					->where($db->quoteName('menutype') . ' = ' . $db->q('main'))
-					->where($db->quoteName('component_id') . ' = ' . (int) $id);
+            ->select('id')
+            ->from('#__menu')
+            ->where($db->quoteName('client_id') . ' = 1')
+            ->where($db->quoteName('menutype') . ' = ' . $db->q('main'))
+            ->where($db->quoteName('component_id') . ' = ' . (int) $id);
 
 		$db->setQuery($query);
 
@@ -1176,10 +1176,10 @@ class ComponentAdapter extends InstallerAdapter
 		// Update all menu items which contain 'index.php?option=com_extension' or 'index.php?option=com_extension&...'
 		// to use the new component id.
 		$query = $db->getQuery(true)
-					->update('#__menu')
-					->set('component_id = ' . $db->quote($component_id))
-					->where('type = ' . $db->quote('component'))
-					->where('(' .
+            ->update('#__menu')
+            ->set('component_id = ' . $db->quote($component_id))
+            ->where('type = ' . $db->quote('component'))
+            ->where('(' .
 						'link LIKE ' . $db->quote('index.php?option=' . $option) . ' OR ' .
 						'link LIKE ' . $db->q($db->escape('index.php?option=' . $option . '&') . '%', false) .
 					')');
@@ -1336,14 +1336,14 @@ class ComponentAdapter extends InstallerAdapter
 		{
 			// The menu item already exists. Delete it and retry instead of throwing an error.
 			$query = $db->getQuery(true)
-						->select('id')
-						->from('#__menu')
-						->where('menutype = ' . $db->q($data['menutype']))
-						->where('client_id = 1')
-						->where('link = ' . $db->q($data['link']))
-						->where('type = ' . $db->q($data['type']))
-						->where('parent_id = ' . $db->q($data['parent_id']))
-						->where('home = ' . $db->q($data['home']));
+                ->select('id')
+                ->from('#__menu')
+                ->where('menutype = ' . $db->q($data['menutype']))
+                ->where('client_id = 1')
+                ->where('link = ' . $db->q($data['link']))
+                ->where('type = ' . $db->q($data['type']))
+                ->where('parent_id = ' . $db->q($data['parent_id']))
+                ->where('home = ' . $db->q($data['home']));
 
 			$db->setQuery($query);
 			$menu_id = $db->loadResult();

--- a/libraries/src/Updater/UpdateAdapter.php
+++ b/libraries/src/Updater/UpdateAdapter.php
@@ -183,9 +183,9 @@ abstract class UpdateAdapter extends \JAdapterInstance
 
 		$db = $this->parent->getDbo();
 		$query = $db->getQuery(true)
-            ->select($db->qn('name'))
-            ->from($db->qn('#__update_sites'))
-            ->where($db->qn('update_site_id') . ' = ' . $db->q($updateSiteId));
+			->select($db->qn('name'))
+			->from($db->qn('#__update_sites'))
+			->where($db->qn('update_site_id') . ' = ' . $db->q($updateSiteId));
 		$db->setQuery($query);
 
 		$name = '';

--- a/libraries/src/Updater/UpdateAdapter.php
+++ b/libraries/src/Updater/UpdateAdapter.php
@@ -183,9 +183,9 @@ abstract class UpdateAdapter extends \JAdapterInstance
 
 		$db = $this->parent->getDbo();
 		$query = $db->getQuery(true)
-					->select($db->qn('name'))
-					->from($db->qn('#__update_sites'))
-					->where($db->qn('update_site_id') . ' = ' . $db->q($updateSiteId));
+            ->select($db->qn('name'))
+            ->from($db->qn('#__update_sites'))
+            ->where($db->qn('update_site_id') . ' = ' . $db->q($updateSiteId));
 		$db->setQuery($query);
 
 		$name = '';

--- a/libraries/src/User/UserHelper.php
+++ b/libraries/src/User/UserHelper.php
@@ -767,8 +767,8 @@ abstract class UserHelper
 
 		$db = \JFactory::getDbo();
 		$query = $db->getQuery(true)
-            ->delete('#__user_keys')
-            ->where($db->quoteName('time') . ' < ' . $db->quote($now));
+			->delete('#__user_keys')
+			->where($db->quoteName('time') . ' < ' . $db->quote($now));
 
 		return $db->setQuery($query)->execute();
 	}

--- a/libraries/src/User/UserHelper.php
+++ b/libraries/src/User/UserHelper.php
@@ -767,8 +767,8 @@ abstract class UserHelper
 
 		$db = \JFactory::getDbo();
 		$query = $db->getQuery(true)
-		->delete('#__user_keys')
-		->where($db->quoteName('time') . ' < ' . $db->quote($now));
+            ->delete('#__user_keys')
+            ->where($db->quoteName('time') . ' < ' . $db->quote($now));
 
 		return $db->setQuery($query)->execute();
 	}


### PR DESCRIPTION
Pull Request for Issue Object operator not indented correctly.

### Summary of Changes
- autofixed cases of Object operator not indented correctly

[Automatically fixed with Joomla code standards 2.0.0 PHPCS2-alpha2 fixers](https://github.com/joomla/coding-standards/releases/tag/2.0.0-alpha2)

None of the manual only fixes have been applied

### Testing Instructions
Merge by code review

### Expected result
code style has been applied as listed above, old code style testing on drone does not error.

### Actual result
code style had not been applied. [Autofixers from the Joomla code standards 2.0.0 PHPCS2 alpha2](https://github.com/joomla/coding-standards/releases/tag/2.0.0-alpha2) were used to implement fixable code style

### Documentation Changes Required
none
