### PR TITLE
[CS] Code Style fixes for unit tests

### DIFF
--- a/tests/unit/suites/database/driver/mysql/JDatabaseDriverMysqlTest.php
+++ b/tests/unit/suites/database/driver/mysql/JDatabaseDriverMysqlTest.php
@@ -281,7 +281,7 @@ class JDatabaseDriverMysqlTest extends TestCaseDatabaseMysql
 			self::$driver->getTableColumns('jos_dbtest')
 		);
 
-		/* not only type field */
+		// Not only type field
 		$id = new stdClass;
 		$id->Default    = null;
 		$id->Field      = 'id';
@@ -463,7 +463,7 @@ class JDatabaseDriverMysqlTest extends TestCaseDatabaseMysql
 		$this->assertEquals($objArr[2], self::$driver->loadNextObject());
 		$this->assertEquals($objArr[3], self::$driver->loadNextObject());
 
-		/* last call to free cursor, asserting that returns false */
+		// Last call to free cursor, asserting that returns false
 		$this->assertFalse(self::$driver->loadNextObject());
 	}
 
@@ -490,7 +490,7 @@ class JDatabaseDriverMysqlTest extends TestCaseDatabaseMysql
 		$this->assertEquals($objArr[2], self::$driver->loadNextObject());
 		$this->assertEquals($objArr[3], self::$driver->loadNextObject());
 
-		/* last call to free cursor, asserting that returns false */
+		// Last call to free cursor, asserting that returns false
 		$this->assertFalse(self::$driver->loadNextObject());
 	}
 
@@ -517,7 +517,7 @@ class JDatabaseDriverMysqlTest extends TestCaseDatabaseMysql
 		$this->assertEquals($objArr[2], self::$driver->loadNextObject());
 		$this->assertEquals($objArr[3], self::$driver->loadNextObject());
 
-		/* last call to free cursor, asserting that returns false */
+		// Last call to free cursor, asserting that returns false
 		$this->assertFalse(self::$driver->loadNextObject());
 	}
 
@@ -542,7 +542,8 @@ class JDatabaseDriverMysqlTest extends TestCaseDatabaseMysql
 		$this->assertEquals($rowArr[2], self::$driver->loadNextRow());
 		$this->assertEquals($rowArr[3], self::$driver->loadNextRow());
 
-		/* last call to free cursor, asserting that returns false */
+		// Last call to free cursor, asserting that returns false
+
 		$this->assertFalse(self::$driver->loadNextRow());
 	}
 
@@ -569,7 +570,7 @@ class JDatabaseDriverMysqlTest extends TestCaseDatabaseMysql
 		$this->assertEquals($rowArr[2], self::$driver->loadNextRow());
 		$this->assertEquals($rowArr[3], self::$driver->loadNextRow());
 
-		/* last call to free cursor, asserting that returns false */
+		// Last call to free cursor, asserting that returns false
 		$this->assertFalse(self::$driver->loadNextRow());
 	}
 
@@ -596,7 +597,7 @@ class JDatabaseDriverMysqlTest extends TestCaseDatabaseMysql
 		$this->assertEquals($rowArr[2], self::$driver->loadNextRow());
 		$this->assertEquals($rowArr[3], self::$driver->loadNextRow());
 
-		/* last call to free cursor, asserting that returns false */
+		// Last call to free cursor, asserting that returns false
 		$this->assertFalse(self::$driver->loadNextRow());
 	}
 
@@ -793,7 +794,7 @@ class JDatabaseDriverMysqlTest extends TestCaseDatabaseMysql
 
 		self::$driver->transactionCommit();
 
-		/* check if value is present */
+		// Check if value is present
 		$queryCheck = self::$driver->getQuery(true);
 		$queryCheck->select('*')
 			->from('#__dbtest')
@@ -821,20 +822,20 @@ class JDatabaseDriverMysqlTest extends TestCaseDatabaseMysql
 	{
 		self::$driver->transactionStart();
 
-		/* try to insert this tuple, inserted only when savepoint != null */
+		// Try to insert this tuple, inserted only when savepoint != null
 		$queryIns = self::$driver->getQuery(true);
 		$queryIns->insert('#__dbtest')
 			->columns('id, title, start_date, description')
 			->values("7, 'testRollback', '1970-01-01', 'testRollbackSp'");
 		self::$driver->setQuery($queryIns)->execute();
 
-		/* create savepoint only if is passed by data provider */
+		// Create savepoint only if is passed by data provider
 		if (!is_null($toSavepoint))
 		{
 			self::$driver->transactionStart((boolean) $toSavepoint);
 		}
 
-		/* try to insert this tuple, always rolled back */
+		// Try to insert this tuple, always rolled back
 		$queryIns = self::$driver->getQuery(true);
 		$queryIns->insert('#__dbtest')
 			->columns('id, title, start_date, description')
@@ -843,13 +844,14 @@ class JDatabaseDriverMysqlTest extends TestCaseDatabaseMysql
 
 		self::$driver->transactionRollback((boolean) $toSavepoint);
 
-		/* release savepoint and commit only if a savepoint exists */
+		// Release savepoint and commit only if a savepoint exists
 		if (!is_null($toSavepoint))
 		{
 			self::$driver->transactionCommit();
 		}
 
-		/* find how many rows have description='testRollbackSp' :
+		/*
+		 find how many rows have description='testRollbackSp' :
 		 *   - 0 if a savepoint doesn't exist
 		 *   - 1 if a savepoint exists
 		 */

--- a/tests/unit/suites/database/driver/mysql/JDatabaseDriverMysqlTest.php
+++ b/tests/unit/suites/database/driver/mysql/JDatabaseDriverMysqlTest.php
@@ -850,7 +850,7 @@ class JDatabaseDriverMysqlTest extends TestCaseDatabaseMysql
 		}
 
 		/*
-		 * find how many rows have description='testRollbackSp' :
+		 * Find how many rows have description='testRollbackSp' :
 		 *   - 0 if a savepoint doesn't exist
 		 *   - 1 if a savepoint exists
 		 */

--- a/tests/unit/suites/database/driver/mysql/JDatabaseDriverMysqlTest.php
+++ b/tests/unit/suites/database/driver/mysql/JDatabaseDriverMysqlTest.php
@@ -543,7 +543,6 @@ class JDatabaseDriverMysqlTest extends TestCaseDatabaseMysql
 		$this->assertEquals($rowArr[3], self::$driver->loadNextRow());
 
 		// Last call to free cursor, asserting that returns false
-
 		$this->assertFalse(self::$driver->loadNextRow());
 	}
 
@@ -851,7 +850,7 @@ class JDatabaseDriverMysqlTest extends TestCaseDatabaseMysql
 		}
 
 		/*
-		 find how many rows have description='testRollbackSp' :
+		 * find how many rows have description='testRollbackSp' :
 		 *   - 0 if a savepoint doesn't exist
 		 *   - 1 if a savepoint exists
 		 */

--- a/tests/unit/suites/database/driver/mysql/JDatabaseExporterMysqlTest.php
+++ b/tests/unit/suites/database/driver/mysql/JDatabaseExporterMysqlTest.php
@@ -64,27 +64,27 @@ class JDatabaseExporterMysqlTest extends TestCase
 			->method('getTableColumns')
 			->willReturn(
 				array(
-					'id' => (object) array(
-						'Field' => 'id',
-						'Type' => 'int(11) unsigned',
-						'Collation' => null,
-						'Null' => 'NO',
-						'Key' => 'PRI',
-						'Default' => '',
-						'Extra' => 'auto_increment',
-						'Privileges' => 'select,insert,update,references',
-						'Comment' => '',
+				'id' => (object) array(
+					'Field'      => 'id',
+					'Type'       => 'int(11) unsigned',
+					'Collation'  => null,
+					'Null'       => 'NO',
+					'Key'        => 'PRI',
+					'Default'    => '',
+					'Extra'      => 'auto_increment',
+					'Privileges' => 'select,insert,update,references',
+					'Comment'    => '',
 					),
-					'title' => (object) array(
-						'Field' => 'title',
-						'Type' => 'varchar(255)',
-						'Collation' => 'utf8_general_ci',
-						'Null' => 'NO',
-						'Key' => '',
-						'Default' => '',
-						'Extra' => '',
-						'Privileges' => 'select,insert,update,references',
-						'Comment' => '',
+				'title' => (object) array(
+					'Field'      => 'title',
+					'Type'       => 'varchar(255)',
+					'Collation'  => 'utf8_general_ci',
+					'Null'       => 'NO',
+					'Key'        => '',
+					'Default'    => '',
+					'Extra'      => '',
+					'Privileges' => 'select,insert,update,references',
+					'Comment'    => '',
 					),
 				)
 			);
@@ -95,19 +95,19 @@ class JDatabaseExporterMysqlTest extends TestCase
 			->willReturn(
 				array(
 				(object) array(
-					'Table' => 'jos_test',
-					'Non_unique' => '0',
-					'Key_name' => 'PRIMARY',
+					'Table'        => 'jos_test',
+					'Non_unique'   => '0',
+					'Key_name'     => 'PRIMARY',
 					'Seq_in_index' => '1',
-					'Column_name' => 'id',
-					'Collation' => 'A',
-					'Cardinality' => '2695',
-					'Sub_part' => '',
-					'Packed' => '',
-					'Null' => '',
-					'Index_type' => 'BTREE',
-					'Comment' => '',
-				)
+					'Column_name'  => 'id',
+					'Collation'    => 'A',
+					'Cardinality'  => '2695',
+					'Sub_part'     => '',
+					'Packed'       => '',
+					'Null'         => '',
+					'Index_type'   => 'BTREE',
+					'Comment'      => '',
+					)
 				)
 			);
 

--- a/tests/unit/suites/database/driver/mysql/JDatabaseImporterMysqlTest.php
+++ b/tests/unit/suites/database/driver/mysql/JDatabaseImporterMysqlTest.php
@@ -70,7 +70,8 @@ class JDatabaseImporterMysqlTest extends TestCase
 						'loadObjectList',
 						'quote',
 						'setQuery',
-					))
+				)
+			)
 			->setConstructorArgs(array())
 			->setMockClassName('')
 			->disableOriginalConstructor()
@@ -81,14 +82,14 @@ class JDatabaseImporterMysqlTest extends TestCase
 			->method('getPrefix')
 			->will(
 				$this->returnValue('jos_')
-		);
+			);
 
 		$this->dbo
 			->expects($this->any())
 			->method('getTableColumns')
 			->will(
-			$this->returnValue(
-				array(
+				$this->returnValue(
+					array(
 					'id' => (object) array(
 						'Field' => 'id',
 						'Type' => 'int(11) unsigned',
@@ -111,16 +112,16 @@ class JDatabaseImporterMysqlTest extends TestCase
 						'Privileges' => 'select,insert,update,references',
 						'Comment' => '',
 					),
+					)
 				)
-			)
-		);
+			);
 
 		$this->dbo
 			->expects($this->any())
 			->method('getTableKeys')
 			->will(
-			$this->returnValue(
-				array(
+				$this->returnValue(
+					array(
 					(object) array(
 						'Table' => 'jos_test',
 						'Non_unique' => '0',
@@ -135,45 +136,45 @@ class JDatabaseImporterMysqlTest extends TestCase
 						'Index_type' => 'BTREE',
 						'Comment' => '',
 					)
+					)
 				)
-			)
-		);
+			);
 
 		$this->dbo
 			->expects($this->any())
 			->method('quoteName')
 			->will(
-			$this->returnCallback(
-				array($this, 'callbackQuoteName')
-			)
-		);
+				$this->returnCallback(
+					array($this, 'callbackQuoteName')
+				)
+			);
 
 		$this->dbo
 			->expects($this->any())
 			->method('quote')
 			->will(
-			$this->returnCallback(
-				array($this, 'callbackQuote')
-			)
-		);
+				$this->returnCallback(
+					array($this, 'callbackQuote')
+				)
+			);
 
 		$this->dbo
 			->expects($this->any())
 			->method('setQuery')
 			->will(
-			$this->returnCallback(
-				array($this, 'callbackSetQuery')
-			)
-		);
+				$this->returnCallback(
+					array($this, 'callbackSetQuery')
+				)
+			);
 
 		$this->dbo
 			->expects($this->any())
 			->method('loadObjectList')
 			->will(
-			$this->returnCallback(
-				array($this, 'callbackLoadObjectList')
-			)
-		);
+				$this->returnCallback(
+					array($this, 'callbackLoadObjectList')
+				)
+			);
 	}
 
 	/**

--- a/tests/unit/suites/database/driver/mysql/JDatabaseImporterMysqlTest.php
+++ b/tests/unit/suites/database/driver/mysql/JDatabaseImporterMysqlTest.php
@@ -61,6 +61,7 @@ class JDatabaseImporterMysqlTest extends TestCase
 	protected function setUp()
 	{
 		$this->dbo = $this->getMockBuilder('JDatabaseDriverMysql')
+			->setMethods(array(
 						'getErrorNum',
 						'getPrefix',
 						'getTableColumns',
@@ -70,6 +71,10 @@ class JDatabaseImporterMysqlTest extends TestCase
 						'quote',
 						'setQuery',
 					))
+			->setConstructorArgs(array())
+			->setMockClassName('')
+			->disableOriginalConstructor()
+			->getMock();
 
 		$this->dbo
 			->expects($this->any())

--- a/tests/unit/suites/database/driver/mysql/JDatabaseImporterMysqlTest.php
+++ b/tests/unit/suites/database/driver/mysql/JDatabaseImporterMysqlTest.php
@@ -62,14 +62,14 @@ class JDatabaseImporterMysqlTest extends TestCase
 	{
 		$this->dbo = $this->getMockBuilder('JDatabaseDriverMysql')
 			->setMethods(array(
-						'getErrorNum',
-						'getPrefix',
-						'getTableColumns',
-						'getTableKeys',
-						'quoteName',
-						'loadObjectList',
-						'quote',
-						'setQuery',
+				'getErrorNum',
+				'getPrefix',
+				'getTableColumns',
+				'getTableKeys',
+				'quoteName',
+				'loadObjectList',
+				'quote',
+				'setQuery',
 				)
 			)
 			->setConstructorArgs(array())
@@ -91,27 +91,27 @@ class JDatabaseImporterMysqlTest extends TestCase
 				$this->returnValue(
 					array(
 					'id' => (object) array(
-						'Field' => 'id',
-						'Type' => 'int(11) unsigned',
-						'Collation' => null,
-						'Null' => 'NO',
-						'Key' => 'PRI',
-						'Default' => '',
-						'Extra' => 'auto_increment',
+						'Field'      => 'id',
+						'Type'       => 'int(11) unsigned',
+						'Collation'  => null,
+						'Null'       => 'NO',
+						'Key'        => 'PRI',
+						'Default'    => '',
+						'Extra'      => 'auto_increment',
 						'Privileges' => 'select,insert,update,references',
-						'Comment' => '',
-					),
+						'Comment'    => '',
+						),
 					'title' => (object) array(
-						'Field' => 'title',
-						'Type' => 'varchar(255)',
-						'Collation' => 'utf8_general_ci',
-						'Null' => 'NO',
-						'Key' => '',
-						'Default' => '',
-						'Extra' => '',
+						'Field'      => 'title',
+						'Type'       => 'varchar(255)',
+						'Collation'  => 'utf8_general_ci',
+						'Null'       => 'NO',
+						'Key'        => '',
+						'Default'    => '',
+						'Extra'      => '',
 						'Privileges' => 'select,insert,update,references',
-						'Comment' => '',
-					),
+						'Comment'    => '',
+						),
 					)
 				)
 			);
@@ -123,19 +123,19 @@ class JDatabaseImporterMysqlTest extends TestCase
 				$this->returnValue(
 					array(
 					(object) array(
-						'Table' => 'jos_test',
-						'Non_unique' => '0',
-						'Key_name' => 'PRIMARY',
+						'Table'        => 'jos_test',
+						'Non_unique'   => '0',
+						'Key_name'     => 'PRIMARY',
 						'Seq_in_index' => '1',
-						'Column_name' => 'id',
-						'Collation' => 'A',
-						'Cardinality' => '2695',
-						'Sub_part' => '',
-						'Packed' => '',
-						'Null' => '',
-						'Index_type' => 'BTREE',
-						'Comment' => '',
-					)
+						'Column_name'  => 'id',
+						'Collation'    => 'A',
+						'Cardinality'  => '2695',
+						'Sub_part'     => '',
+						'Packed'       => '',
+						'Null'         => '',
+						'Index_type'   => 'BTREE',
+						'Comment'      => '',
+						)
 					)
 				)
 			);

--- a/tests/unit/suites/database/driver/mysql/JDatabaseImporterMysqlTest.php
+++ b/tests/unit/suites/database/driver/mysql/JDatabaseImporterMysqlTest.php
@@ -61,7 +61,6 @@ class JDatabaseImporterMysqlTest extends TestCase
 	protected function setUp()
 	{
 		$this->dbo = $this->getMockBuilder('JDatabaseDriverMysql')
-					->setMethods(array(
 						'getErrorNum',
 						'getPrefix',
 						'getTableColumns',
@@ -71,10 +70,6 @@ class JDatabaseImporterMysqlTest extends TestCase
 						'quote',
 						'setQuery',
 					))
-					->setConstructorArgs(array())
-					->setMockClassName('')
-					->disableOriginalConstructor()
-					->getMock();
 
 		$this->dbo
 			->expects($this->any())

--- a/tests/unit/suites/database/driver/mysqli/JDatabaseDriverMysqliTest.php
+++ b/tests/unit/suites/database/driver/mysqli/JDatabaseDriverMysqliTest.php
@@ -283,7 +283,7 @@ class JDatabaseDriverMysqliTest extends TestCaseDatabaseMysqli
 			__LINE__
 		);
 
-		/* not only type field */
+		// Not only type field
 		$id = new stdClass;
 		$id->Default    = null;
 		$id->Field      = 'id';
@@ -469,7 +469,8 @@ class JDatabaseDriverMysqliTest extends TestCaseDatabaseMysqli
 		$this->assertEquals($objArr[2], self::$driver->loadNextObject());
 		$this->assertEquals($objArr[3], self::$driver->loadNextObject());
 
-		/* last call to free cursor, asserting that returns false */
+		// Last call to free cursor, asserting that returns false
+
 		$this->assertFalse(self::$driver->loadNextObject());
 	}
 
@@ -496,7 +497,7 @@ class JDatabaseDriverMysqliTest extends TestCaseDatabaseMysqli
 		$this->assertEquals($objArr[2], self::$driver->loadNextObject());
 		$this->assertEquals($objArr[3], self::$driver->loadNextObject());
 
-		/* last call to free cursor, asserting that returns false */
+		// Last call to free cursor, asserting that returns false
 		$this->assertFalse(self::$driver->loadNextObject());
 	}
 
@@ -523,7 +524,7 @@ class JDatabaseDriverMysqliTest extends TestCaseDatabaseMysqli
 		$this->assertEquals($objArr[2], self::$driver->loadNextObject());
 		$this->assertEquals($objArr[3], self::$driver->loadNextObject());
 
-		/* last call to free cursor, asserting that returns false */
+		// Last call to free cursor, asserting that returns false
 		$this->assertFalse(self::$driver->loadNextObject());
 	}
 
@@ -548,7 +549,7 @@ class JDatabaseDriverMysqliTest extends TestCaseDatabaseMysqli
 		$this->assertEquals($rowArr[2], self::$driver->loadNextRow());
 		$this->assertEquals($rowArr[3], self::$driver->loadNextRow());
 
-		/* last call to free cursor, asserting that returns false */
+		// Last call to free cursor, asserting that returns false
 		$this->assertFalse(self::$driver->loadNextRow());
 	}
 
@@ -575,7 +576,7 @@ class JDatabaseDriverMysqliTest extends TestCaseDatabaseMysqli
 		$this->assertEquals($rowArr[2], self::$driver->loadNextRow());
 		$this->assertEquals($rowArr[3], self::$driver->loadNextRow());
 
-		/* last call to free cursor, asserting that returns false */
+		// Last call to free cursor, asserting that returns false
 		$this->assertFalse(self::$driver->loadNextRow());
 	}
 
@@ -602,7 +603,8 @@ class JDatabaseDriverMysqliTest extends TestCaseDatabaseMysqli
 		$this->assertEquals($rowArr[2], self::$driver->loadNextRow());
 		$this->assertEquals($rowArr[3], self::$driver->loadNextRow());
 
-		/* last call to free cursor, asserting that returns false */
+		// Last call to free cursor, asserting that returns false
+
 		$this->assertFalse(self::$driver->loadNextRow());
 	}
 
@@ -849,7 +851,7 @@ class JDatabaseDriverMysqliTest extends TestCaseDatabaseMysqli
 
 		self::$driver->transactionCommit();
 
-		/* check if value is present */
+		// Check if value is present
 		$queryCheck = self::$driver->getQuery(true);
 		$queryCheck->select('*')
 			->from('#__dbtest')
@@ -877,20 +879,21 @@ class JDatabaseDriverMysqliTest extends TestCaseDatabaseMysqli
 	{
 		self::$driver->transactionStart();
 
-		/* try to insert this tuple, inserted only when savepoint != null */
+		// Try to insert this tuple, inserted only when savepoint != null
 		$queryIns = self::$driver->getQuery(true);
 		$queryIns->insert('#__dbtest')
 			->columns('id, title, start_date, description')
 			->values("7, 'testRollback', '1970-01-01', 'testRollbackSp'");
 		self::$driver->setQuery($queryIns)->execute();
 
-		/* create savepoint only if is passed by data provider */
+		// Create savepoint only if is passed by data provider
+
 		if (!is_null($toSavepoint))
 		{
 			self::$driver->transactionStart((boolean) $toSavepoint);
 		}
 
-		/* try to insert this tuple, always rolled back */
+		// Try to insert this tuple, always rolled back
 		$queryIns = self::$driver->getQuery(true);
 		$queryIns->insert('#__dbtest')
 			->columns('id, title, start_date, description')
@@ -899,13 +902,14 @@ class JDatabaseDriverMysqliTest extends TestCaseDatabaseMysqli
 
 		self::$driver->transactionRollback((boolean) $toSavepoint);
 
-		/* release savepoint and commit only if a savepoint exists */
+		// Release savepoint and commit only if a savepoint exists
 		if (!is_null($toSavepoint))
 		{
 			self::$driver->transactionCommit();
 		}
 
-		/* find how many rows have description='testRollbackSp' :
+		/*
+		 find how many rows have description='testRollbackSp' :
 		 *   - 0 if a savepoint doesn't exist
 		 *   - 1 if a savepoint exists
 		 */

--- a/tests/unit/suites/database/driver/mysqli/JDatabaseDriverMysqliTest.php
+++ b/tests/unit/suites/database/driver/mysqli/JDatabaseDriverMysqliTest.php
@@ -906,7 +906,7 @@ class JDatabaseDriverMysqliTest extends TestCaseDatabaseMysqli
 		}
 
 		/*
-		 * find how many rows have description='testRollbackSp' :
+		 * Find how many rows have description='testRollbackSp' :
 		 *   - 0 if a savepoint doesn't exist
 		 *   - 1 if a savepoint exists
 		 */

--- a/tests/unit/suites/database/driver/mysqli/JDatabaseDriverMysqliTest.php
+++ b/tests/unit/suites/database/driver/mysqli/JDatabaseDriverMysqliTest.php
@@ -470,7 +470,6 @@ class JDatabaseDriverMysqliTest extends TestCaseDatabaseMysqli
 		$this->assertEquals($objArr[3], self::$driver->loadNextObject());
 
 		// Last call to free cursor, asserting that returns false
-
 		$this->assertFalse(self::$driver->loadNextObject());
 	}
 
@@ -604,7 +603,6 @@ class JDatabaseDriverMysqliTest extends TestCaseDatabaseMysqli
 		$this->assertEquals($rowArr[3], self::$driver->loadNextRow());
 
 		// Last call to free cursor, asserting that returns false
-
 		$this->assertFalse(self::$driver->loadNextRow());
 	}
 
@@ -887,7 +885,6 @@ class JDatabaseDriverMysqliTest extends TestCaseDatabaseMysqli
 		self::$driver->setQuery($queryIns)->execute();
 
 		// Create savepoint only if is passed by data provider
-
 		if (!is_null($toSavepoint))
 		{
 			self::$driver->transactionStart((boolean) $toSavepoint);
@@ -909,7 +906,7 @@ class JDatabaseDriverMysqliTest extends TestCaseDatabaseMysqli
 		}
 
 		/*
-		 find how many rows have description='testRollbackSp' :
+		 * find how many rows have description='testRollbackSp' :
 		 *   - 0 if a savepoint doesn't exist
 		 *   - 1 if a savepoint exists
 		 */

--- a/tests/unit/suites/database/driver/mysqli/JDatabaseExporterMysqliTest.php
+++ b/tests/unit/suites/database/driver/mysqli/JDatabaseExporterMysqliTest.php
@@ -37,27 +37,27 @@ class JDatabaseExporterMysqliTest extends TestCase
 			->method('getTableColumns')
 			->willReturn(
 				array(
-					'id' => (object) array(
-						'Field' => 'id',
-						'Type' => 'int(11) unsigned',
-						'Collation' => null,
-						'Null' => 'NO',
-						'Key' => 'PRI',
-						'Default' => '',
-						'Extra' => 'auto_increment',
-						'Privileges' => 'select,insert,update,references',
-						'Comment' => '',
+				'id' => (object) array(
+					'Field'      => 'id',
+					'Type'       => 'int(11) unsigned',
+					'Collation'  => null,
+					'Null'       => 'NO',
+					'Key'        => 'PRI',
+					'Default'    => '',
+					'Extra'      => 'auto_increment',
+					'Privileges' => 'select,insert,update,references',
+					'Comment'    => '',
 					),
-					'title' => (object) array(
-						'Field' => 'title',
-						'Type' => 'varchar(255)',
-						'Collation' => 'utf8_general_ci',
-						'Null' => 'NO',
-						'Key' => '',
-						'Default' => '',
-						'Extra' => '',
-						'Privileges' => 'select,insert,update,references',
-						'Comment' => '',
+				'title' => (object) array(
+					'Field'      => 'title',
+					'Type'       => 'varchar(255)',
+					'Collation'  => 'utf8_general_ci',
+					'Null'       => 'NO',
+					'Key'        => '',
+					'Default'    => '',
+					'Extra'      => '',
+					'Privileges' => 'select,insert,update,references',
+					'Comment'    => '',
 					),
 				)
 			);
@@ -66,19 +66,19 @@ class JDatabaseExporterMysqliTest extends TestCase
 			->method('getTableKeys')
 			->willReturn(array(
 				(object) array(
-					'Table' => 'jos_test',
-					'Non_unique' => '0',
-					'Key_name' => 'PRIMARY',
+					'Table'        => 'jos_test',
+					'Non_unique'   => '0',
+					'Key_name'     => 'PRIMARY',
 					'Seq_in_index' => '1',
-					'Column_name' => 'id',
-					'Collation' => 'A',
-					'Cardinality' => '2695',
-					'Sub_part' => '',
-					'Packed' => '',
-					'Null' => '',
-					'Index_type' => 'BTREE',
-					'Comment' => '',
-				)
+					'Column_name'  => 'id',
+					'Collation'    => 'A',
+					'Cardinality'  => '2695',
+					'Sub_part'     => '',
+					'Packed'       => '',
+					'Null'         => '',
+					'Index_type'   => 'BTREE',
+					'Comment'      => '',
+					)
 				)
 			);
 

--- a/tests/unit/suites/database/driver/mysqli/JDatabaseExporterMysqliTest.php
+++ b/tests/unit/suites/database/driver/mysqli/JDatabaseExporterMysqliTest.php
@@ -79,7 +79,8 @@ class JDatabaseExporterMysqliTest extends TestCase
 					'Index_type' => 'BTREE',
 					'Comment' => '',
 				)
-			));
+				)
+			);
 
 		$this->dbo->expects($this->any())
 			->method('loadObjectList')

--- a/tests/unit/suites/database/driver/mysqli/JDatabaseImporterMysqliTest.php
+++ b/tests/unit/suites/database/driver/mysqli/JDatabaseImporterMysqliTest.php
@@ -47,7 +47,6 @@ class JDatabaseImporterMysqliTest extends \PHPUnit\Framework\TestCase
 	public function setup()
 	{
 		$this->dbo = $this->getMockBuilder('JDatabaseDriverMysqli')
-					->setMethods(array(
 						'getErrorNum',
 						'getPrefix',
 						'getTableColumns',
@@ -57,10 +56,6 @@ class JDatabaseImporterMysqliTest extends \PHPUnit\Framework\TestCase
 						'quote',
 						'setQuery',
 					))
-					->setConstructorArgs(array())
-					->setMockClassName('')
-					->disableOriginalConstructor()
-					->getMock();
 
 		$this->dbo->expects(
 			$this->any()

--- a/tests/unit/suites/database/driver/mysqli/JDatabaseImporterMysqliTest.php
+++ b/tests/unit/suites/database/driver/mysqli/JDatabaseImporterMysqliTest.php
@@ -56,7 +56,8 @@ class JDatabaseImporterMysqliTest extends \PHPUnit\Framework\TestCase
 						'loadObjectList',
 						'quote',
 						'setQuery',
-					))
+				)
+			)
 			->setConstructorArgs(array())
 			->setMockClassName('')
 			->disableOriginalConstructor()
@@ -67,18 +68,18 @@ class JDatabaseImporterMysqliTest extends \PHPUnit\Framework\TestCase
 		)
 			->method('getPrefix')
 			->will(
-			$this->returnValue(
-				'jos_'
-			)
-		);
+				$this->returnValue(
+					'jos_'
+				)
+			);
 
 		$this->dbo->expects(
 			$this->any()
 		)
 			->method('getTableColumns')
 			->will(
-			$this->returnValue(
-				array(
+				$this->returnValue(
+					array(
 					'id' => (object) array(
 						'Field' => 'id',
 						'Type' => 'int(11) unsigned',
@@ -101,17 +102,17 @@ class JDatabaseImporterMysqliTest extends \PHPUnit\Framework\TestCase
 						'Privileges' => 'select,insert,update,references',
 						'Comment' => '',
 					),
+					)
 				)
-			)
-		);
+			);
 
 		$this->dbo->expects(
 			$this->any()
 		)
 			->method('getTableKeys')
 			->will(
-			$this->returnValue(
-				array(
+				$this->returnValue(
+					array(
 					(object) array(
 						'Table' => 'jos_test',
 						'Non_unique' => '0',
@@ -126,49 +127,49 @@ class JDatabaseImporterMysqliTest extends \PHPUnit\Framework\TestCase
 						'Index_type' => 'BTREE',
 						'Comment' => '',
 					)
+					)
 				)
-			)
-		);
+			);
 
 		$this->dbo->expects(
 			$this->any()
 		)
 			->method('quoteName')
 			->will(
-			$this->returnCallback(
-				array($this, 'callbackQuoteName')
-			)
-		);
+				$this->returnCallback(
+					array($this, 'callbackQuoteName')
+				)
+			);
 
 		$this->dbo->expects(
 			$this->any()
 		)
 			->method('quote')
 			->will(
-			$this->returnCallback(
-				array($this, 'callbackQuote')
-			)
-		);
+				$this->returnCallback(
+					array($this, 'callbackQuote')
+				)
+			);
 
 		$this->dbo->expects(
 			$this->any()
 		)
 			->method('setQuery')
 			->will(
-			$this->returnCallback(
-				array($this, 'callbackSetQuery')
-			)
-		);
+				$this->returnCallback(
+					array($this, 'callbackSetQuery')
+				)
+			);
 
 		$this->dbo->expects(
 			$this->any()
 		)
 			->method('loadObjectList')
 			->will(
-			$this->returnCallback(
-				array($this, 'callbackLoadObjectList')
-			)
-		);
+				$this->returnCallback(
+					array($this, 'callbackLoadObjectList')
+				)
+			);
 	}
 
 	/**

--- a/tests/unit/suites/database/driver/mysqli/JDatabaseImporterMysqliTest.php
+++ b/tests/unit/suites/database/driver/mysqli/JDatabaseImporterMysqliTest.php
@@ -47,6 +47,7 @@ class JDatabaseImporterMysqliTest extends \PHPUnit\Framework\TestCase
 	public function setup()
 	{
 		$this->dbo = $this->getMockBuilder('JDatabaseDriverMysqli')
+			->setMethods(array(
 						'getErrorNum',
 						'getPrefix',
 						'getTableColumns',
@@ -56,6 +57,10 @@ class JDatabaseImporterMysqliTest extends \PHPUnit\Framework\TestCase
 						'quote',
 						'setQuery',
 					))
+			->setConstructorArgs(array())
+			->setMockClassName('')
+			->disableOriginalConstructor()
+			->getMock();
 
 		$this->dbo->expects(
 			$this->any()

--- a/tests/unit/suites/database/driver/mysqli/JDatabaseQueryMysqliTest.php
+++ b/tests/unit/suites/database/driver/mysqli/JDatabaseQueryMysqliTest.php
@@ -9,11 +9,11 @@
 
 /**
  * Test class for JDatabaseQueryMysqli.
-*
-* @package     Joomla.UnitTest
-* @subpackage  Database
-* @since       3.7.0
-*/
+ *
+ * @package     Joomla.UnitTest
+ * @subpackage  Database
+ * @since       3.7.0
+ */
 class JDatabaseQueryMysqliTest extends TestCase
 {
 	/**

--- a/tests/unit/suites/database/driver/pdomysql/JDatabaseDriverPdomysqlTest.php
+++ b/tests/unit/suites/database/driver/pdomysql/JDatabaseDriverPdomysqlTest.php
@@ -281,7 +281,6 @@ class JDatabaseDriverPdomysqlTest extends TestCaseDatabasePdomysql
 		);
 
 		// Not only type field
-
 		$id             = new stdClass;
 		$id->Default    = null;
 		$id->Field      = 'id';
@@ -802,7 +801,7 @@ class JDatabaseDriverPdomysqlTest extends TestCaseDatabasePdomysql
 		}
 
 		/*
-		 Find how many rows have description='testRollbackSp' :
+		 * Find how many rows have description='testRollbackSp' :
 		 *   - 0 if a savepoint doesn't exist
 		 *   - 1 if a savepoint exists
 		 */

--- a/tests/unit/suites/database/driver/pdomysql/JDatabaseDriverPdomysqlTest.php
+++ b/tests/unit/suites/database/driver/pdomysql/JDatabaseDriverPdomysqlTest.php
@@ -280,7 +280,8 @@ class JDatabaseDriverPdomysqlTest extends TestCaseDatabasePdomysql
 			__LINE__
 		);
 
-		/* Not only type field */
+		// Not only type field
+
 		$id             = new stdClass;
 		$id->Default    = null;
 		$id->Field      = 'id';
@@ -419,9 +420,10 @@ class JDatabaseDriverPdomysqlTest extends TestCaseDatabasePdomysql
 			$this->equalTo(
 				array(
 					'title' => 'Testing'
-				)),
-				__LINE__
-			);
+				)
+			),
+			__LINE__
+		);
 	}
 
 	/**
@@ -739,7 +741,7 @@ class JDatabaseDriverPdomysqlTest extends TestCaseDatabasePdomysql
 
 		self::$driver->transactionCommit();
 
-		/* Check if value is present */
+		// Check if value is present
 		$queryCheck = self::$driver->getQuery(true);
 		$queryCheck->select('*')
 			->from('#__dbtest')
@@ -771,20 +773,20 @@ class JDatabaseDriverPdomysqlTest extends TestCaseDatabasePdomysql
 	{
 		self::$driver->transactionStart();
 
-		/* Try to insert this tuple, inserted only when savepoint != null */
+		// Try to insert this tuple, inserted only when savepoint != null
 		$queryIns = self::$driver->getQuery(true);
 		$queryIns->insert('#__dbtest')
 			->columns('id, title, start_date, description')
 			->values("7, 'testRollback', '1970-01-01', 'testRollbackSp'");
 		self::$driver->setQuery($queryIns)->execute();
 
-		/* Create savepoint only if is passed by data provider */
+		// Create savepoint only if is passed by data provider
 		if (!is_null($toSavepoint))
 		{
 			self::$driver->transactionStart((boolean) $toSavepoint);
 		}
 
-		/* Try to insert this tuple, always rolled back */
+		// Try to insert this tuple, always rolled back
 		$queryIns = self::$driver->getQuery(true);
 		$queryIns->insert('#__dbtest')
 			->columns('id, title, start_date, description')
@@ -793,13 +795,14 @@ class JDatabaseDriverPdomysqlTest extends TestCaseDatabasePdomysql
 
 		self::$driver->transactionRollback((boolean) $toSavepoint);
 
-		/* Release savepoint and commit only if a savepoint exists */
+		// Release savepoint and commit only if a savepoint exists
 		if (!is_null($toSavepoint))
 		{
 			self::$driver->transactionCommit();
 		}
 
-		/* Find how many rows have description='testRollbackSp' :
+		/*
+		 Find how many rows have description='testRollbackSp' :
 		 *   - 0 if a savepoint doesn't exist
 		 *   - 1 if a savepoint exists
 		 */

--- a/tests/unit/suites/database/driver/pdomysql/JDatabaseExporterPdomysqlTest.php
+++ b/tests/unit/suites/database/driver/pdomysql/JDatabaseExporterPdomysqlTest.php
@@ -35,7 +35,6 @@ class JDatabaseExporterPdomysqlTest extends \PHPUnit\Framework\TestCase
 
 		// Set up the database object mock.
 		$this->dbo = $this->getMockBuilder('JDatabaseDriverPdomysql')
-					->setMethods(array(
 						'getErrorNum',
 						'getPrefix',
 						'getTableColumns',
@@ -44,10 +43,6 @@ class JDatabaseExporterPdomysqlTest extends \PHPUnit\Framework\TestCase
 						'loadObjectList',
 						'setQuery',
 					))
-					->setConstructorArgs(array())
-					->setMockClassName('')
-					->disableOriginalConstructor()
-					->getMock();
 
 		$this->dbo->expects(
 			$this->any()

--- a/tests/unit/suites/database/driver/pdomysql/JDatabaseExporterPdomysqlTest.php
+++ b/tests/unit/suites/database/driver/pdomysql/JDatabaseExporterPdomysqlTest.php
@@ -43,7 +43,8 @@ class JDatabaseExporterPdomysqlTest extends \PHPUnit\Framework\TestCase
 						'quoteName',
 						'loadObjectList',
 						'setQuery',
-					))
+				)
+			)
 			->setConstructorArgs(array())
 			->setMockClassName('')
 			->disableOriginalConstructor()
@@ -54,18 +55,18 @@ class JDatabaseExporterPdomysqlTest extends \PHPUnit\Framework\TestCase
 		)
 			->method('getPrefix')
 			->will(
-			$this->returnValue(
-				'jos_'
-			)
-		);
+				$this->returnValue(
+					'jos_'
+				)
+			);
 
 		$this->dbo->expects(
 			$this->any()
 		)
 			->method('getTableColumns')
 			->will(
-			$this->returnValue(
-				array(
+				$this->returnValue(
+					array(
 					(object) array(
 						'Field' => 'id',
 						'Type' => 'int(11) unsigned',
@@ -88,17 +89,17 @@ class JDatabaseExporterPdomysqlTest extends \PHPUnit\Framework\TestCase
 						'Privileges' => 'select,insert,update,references',
 						'Comment' => '',
 					),
+					)
 				)
-			)
-		);
+			);
 
 		$this->dbo->expects(
 			$this->any()
 		)
 			->method('getTableKeys')
 			->will(
-			$this->returnValue(
-				array(
+				$this->returnValue(
+					array(
 					(object) array(
 						'Table' => 'jos_test',
 						'Non_unique' => '0',
@@ -113,39 +114,39 @@ class JDatabaseExporterPdomysqlTest extends \PHPUnit\Framework\TestCase
 						'Index_type' => 'BTREE',
 						'Comment' => '',
 					)
+					)
 				)
-			)
-		);
+			);
 
 		$this->dbo->expects(
 			$this->any()
 		)
 			->method('quoteName')
 			->will(
-			$this->returnCallback(
-				array($this, 'callbackQuoteName')
-			)
-		);
+				$this->returnCallback(
+					array($this, 'callbackQuoteName')
+				)
+			);
 
 		$this->dbo->expects(
 			$this->any()
 		)
 			->method('setQuery')
 			->will(
-			$this->returnCallback(
-				array($this, 'callbackSetQuery')
-			)
-		);
+				$this->returnCallback(
+					array($this, 'callbackSetQuery')
+				)
+			);
 
 		$this->dbo->expects(
 			$this->any()
 		)
 			->method('loadObjectList')
 			->will(
-			$this->returnCallback(
-				array($this, 'callbackLoadObjectList')
-			)
-		);
+				$this->returnCallback(
+					array($this, 'callbackLoadObjectList')
+				)
+			);
 	}
 
 	/**

--- a/tests/unit/suites/database/driver/pdomysql/JDatabaseExporterPdomysqlTest.php
+++ b/tests/unit/suites/database/driver/pdomysql/JDatabaseExporterPdomysqlTest.php
@@ -35,6 +35,7 @@ class JDatabaseExporterPdomysqlTest extends \PHPUnit\Framework\TestCase
 
 		// Set up the database object mock.
 		$this->dbo = $this->getMockBuilder('JDatabaseDriverPdomysql')
+			->setMethods(array(
 						'getErrorNum',
 						'getPrefix',
 						'getTableColumns',
@@ -43,6 +44,10 @@ class JDatabaseExporterPdomysqlTest extends \PHPUnit\Framework\TestCase
 						'loadObjectList',
 						'setQuery',
 					))
+			->setConstructorArgs(array())
+			->setMockClassName('')
+			->disableOriginalConstructor()
+			->getMock();
 
 		$this->dbo->expects(
 			$this->any()

--- a/tests/unit/suites/database/driver/pdomysql/JDatabaseImporterPdomysqlTest.php
+++ b/tests/unit/suites/database/driver/pdomysql/JDatabaseImporterPdomysqlTest.php
@@ -65,7 +65,8 @@ class JDatabaseImporterPdomysqlTest extends \PHPUnit\Framework\TestCase
 						'loadObjectList',
 						'quote',
 						'setQuery',
-					))
+				)
+			)
 			->setConstructorArgs(array())
 			->setMockClassName('')
 			->disableOriginalConstructor()
@@ -76,18 +77,18 @@ class JDatabaseImporterPdomysqlTest extends \PHPUnit\Framework\TestCase
 		)
 			->method('getPrefix')
 			->will(
-			$this->returnValue(
-				'jos_'
-			)
-		);
+				$this->returnValue(
+					'jos_'
+				)
+			);
 
 		$this->dbo->expects(
 			$this->any()
 		)
 			->method('getTableColumns')
 			->will(
-			$this->returnValue(
-				array(
+				$this->returnValue(
+					array(
 					'id' => (object) array(
 						'Field' => 'id',
 						'Type' => 'int(11) unsigned',
@@ -110,17 +111,17 @@ class JDatabaseImporterPdomysqlTest extends \PHPUnit\Framework\TestCase
 						'Privileges' => 'select,insert,update,references',
 						'Comment' => '',
 					),
+					)
 				)
-			)
-		);
+			);
 
 		$this->dbo->expects(
 			$this->any()
 		)
 			->method('getTableKeys')
 			->will(
-			$this->returnValue(
-				array(
+				$this->returnValue(
+					array(
 					(object) array(
 						'Table' => 'jos_test',
 						'Non_unique' => '0',
@@ -135,49 +136,49 @@ class JDatabaseImporterPdomysqlTest extends \PHPUnit\Framework\TestCase
 						'Index_type' => 'BTREE',
 						'Comment' => '',
 					)
+					)
 				)
-			)
-		);
+			);
 
 		$this->dbo->expects(
 			$this->any()
 		)
 			->method('quoteName')
 			->will(
-			$this->returnCallback(
-				array($this, 'callbackQuoteName')
-			)
-		);
+				$this->returnCallback(
+					array($this, 'callbackQuoteName')
+				)
+			);
 
 		$this->dbo->expects(
 			$this->any()
 		)
 			->method('quote')
 			->will(
-			$this->returnCallback(
-				array($this, 'callbackQuote')
-			)
-		);
+				$this->returnCallback(
+					array($this, 'callbackQuote')
+				)
+			);
 
 		$this->dbo->expects(
 			$this->any()
 		)
 			->method('setQuery')
 			->will(
-			$this->returnCallback(
-				array($this, 'callbackSetQuery')
-			)
-		);
+				$this->returnCallback(
+					array($this, 'callbackSetQuery')
+				)
+			);
 
 		$this->dbo->expects(
 			$this->any()
 		)
 			->method('loadObjectList')
 			->will(
-			$this->returnCallback(
-				array($this, 'callbackLoadObjectList')
-			)
-		);
+				$this->returnCallback(
+					array($this, 'callbackLoadObjectList')
+				)
+			);
 	}
 
 	/**
@@ -798,7 +799,6 @@ class JDatabaseImporterPdomysqlTest extends \PHPUnit\Framework\TestCase
 				$this->identicalTo($instance),
 				'setDbo must return an object to support chaining.'
 			);
-
 		}
 		catch (PHPUnit_Framework_Error $e)
 		{

--- a/tests/unit/suites/database/driver/pdomysql/JDatabaseImporterPdomysqlTest.php
+++ b/tests/unit/suites/database/driver/pdomysql/JDatabaseImporterPdomysqlTest.php
@@ -56,6 +56,7 @@ class JDatabaseImporterPdomysqlTest extends \PHPUnit\Framework\TestCase
 
 		// Set up the database object mock.
 		$this->dbo = $this->getMockBuilder('JDatabaseDriverPdomysql')
+			->setMethods(array(
 						'getErrorNum',
 						'getPrefix',
 						'getTableColumns',
@@ -65,6 +66,10 @@ class JDatabaseImporterPdomysqlTest extends \PHPUnit\Framework\TestCase
 						'quote',
 						'setQuery',
 					))
+			->setConstructorArgs(array())
+			->setMockClassName('')
+			->disableOriginalConstructor()
+			->getMock();
 
 		$this->dbo->expects(
 			$this->any()

--- a/tests/unit/suites/database/driver/pdomysql/JDatabaseImporterPdomysqlTest.php
+++ b/tests/unit/suites/database/driver/pdomysql/JDatabaseImporterPdomysqlTest.php
@@ -56,7 +56,6 @@ class JDatabaseImporterPdomysqlTest extends \PHPUnit\Framework\TestCase
 
 		// Set up the database object mock.
 		$this->dbo = $this->getMockBuilder('JDatabaseDriverPdomysql')
-					->setMethods(array(
 						'getErrorNum',
 						'getPrefix',
 						'getTableColumns',
@@ -66,10 +65,6 @@ class JDatabaseImporterPdomysqlTest extends \PHPUnit\Framework\TestCase
 						'quote',
 						'setQuery',
 					))
-					->setConstructorArgs(array())
-					->setMockClassName('')
-					->disableOriginalConstructor()
-					->getMock();
 
 		$this->dbo->expects(
 			$this->any()

--- a/tests/unit/suites/database/driver/postgresql/JDatabaseDriverPostgresqlTest.php
+++ b/tests/unit/suites/database/driver/postgresql/JDatabaseDriverPostgresqlTest.php
@@ -25,10 +25,11 @@ class JDatabaseDriverPostgresqlTest extends TestCaseDatabasePostgresql
 	public function dataTestEscape()
 	{
 		return array(
-			/* ' will be escaped and become '' */
+			// ' will be escaped and become ''
 			array("'%_abc123", false, '\'\'%_abc123'),
 			array("'%_abc123", true, '\'\'\%\_abc123'),
-			/* ' and \ will be escaped: the first become '', the latter \\ */
+
+			// ' and \ will be escaped: the first become '', the latter \\
 			array("\'%_abc123", false, '\\\\\'\'%_abc123'),
 			array("\'%_abc123", true, '\\\\\'\'\%\_abc123'));
 	}
@@ -43,9 +44,10 @@ class JDatabaseDriverPostgresqlTest extends TestCaseDatabasePostgresql
 	public function dataTestGetEscaped()
 	{
 		return array(
-			/* ' will be escaped and become '' */
+			// ' will be escaped and become ''
 			array("'%_abc123", false), array("'%_abc123", true),
-			/* ' and \ will be escaped: the first become '', the latter \\ */
+
+			// ' and \ will be escaped: the first become '', the latter \\
 			array("\'%_abc123", false), array("\'%_abc123", true));
 	}
 
@@ -87,17 +89,22 @@ class JDatabaseDriverPostgresqlTest extends TestCaseDatabasePostgresql
 	public function dataTestReplacePrefix()
 	{
 		return array(
-			/* no prefix inside, no change */
+			// No prefix inside, no change
 			array('SELECT * FROM table', '#__', 'SELECT * FROM table'),
-			/* the prefix inside double quote has to be changed */
+
+			// The prefix inside double quote has to be changed
 			array('SELECT * FROM "#__table"', '#__', 'SELECT * FROM "jos_table"'),
-			/* the prefix inside single quote hasn't to be changed */
+
+			// The prefix inside single quote hasn't to be changed
 			array('SELECT * FROM \'#__table\'', '#__', 'SELECT * FROM \'#__table\''),
-			/* mixed quote case */
+
+			// Mixed quote case
 			array('SELECT * FROM \'#__table\', "#__tableSecond"', '#__', 'SELECT * FROM \'#__table\', "jos_tableSecond"'),
-			/* the prefix used in sequence name (single quote) has to be changed */
+
+			// The prefix used in sequence name (single quote) has to be changed
 			array('SELECT * FROM currval(\'#__table_id_seq\'::regclass)', '#__', 'SELECT * FROM currval(\'jos_table_id_seq\'::regclass)'),
-			/* using another prefix */
+
+			// Using another prefix
 			array('SELECT * FROM "#!-_table"', '#!-_', 'SELECT * FROM "jos_table"'));
 	}
 
@@ -111,24 +118,30 @@ class JDatabaseDriverPostgresqlTest extends TestCaseDatabasePostgresql
 	public function dataTestQuoteName()
 	{
 		return array(
-			/* test escape double quote */
+			// Test escape double quote
 			array('protected`title', null, '"protected`title"'),
 			array('protected"title', null, '"protected""title"'),
 			array('protected]title', null, '"protected]title"'),
-			/* no dot inside var */
+
+			// No dot inside var
 			array('jos_dbtest', null, '"jos_dbtest"'),
-			/* a dot inside var */
+
+			// A dot inside var
 			array('public.jos_dbtest', null, '"public"."jos_dbtest"'),
-			/* two dot inside var */
+
+			// Two dot inside var
 			array('joomla_ut.public.jos_dbtest', null, '"joomla_ut"."public"."jos_dbtest"'),
-			/* using an array */
+
+			// Using an array
 			array(array('joomla_ut', 'dbtest'), null, array('"joomla_ut"', '"dbtest"')),
-			/* using an array with dotted name */
+
+			// Using an array with dotted name
 			array(array('joomla_ut.dbtest', 'public.dbtest'), null, array('"joomla_ut"."dbtest"', '"public"."dbtest"')),
-			/* using an array with two dot in name */
+
+			// Using an array with two dot in name
 			array(array('joomla_ut.public.dbtest', 'public.dbtest.col'), null, array('"joomla_ut"."public"."dbtest"', '"public"."dbtest"."col"')),
 
-			/*** same tests with AS part ***/
+			// Same tests with AS part
 			array('jos_dbtest', 'test', '"jos_dbtest" AS "test"'),
 			array('public.jos_dbtest', 'tst', '"public"."jos_dbtest" AS "tst"'),
 			array('joomla_ut.public.jos_dbtest', 'tst', '"joomla_ut"."public"."jos_dbtest" AS "tst"'),
@@ -141,7 +154,8 @@ class JDatabaseDriverPostgresqlTest extends TestCaseDatabasePostgresql
 				array('joomla_ut.public.dbtest', 'public.dbtest.col'),
 				array('j_ut_p_db', 'pub_tst_col'),
 				array('"joomla_ut"."public"."dbtest" AS "j_ut_p_db"', '"public"."dbtest"."col" AS "pub_tst_col"')),
-			/* last test but with one null inside array */
+
+			// Last test but with one null inside array
 			array(
 				array('joomla_ut.public.dbtest', 'public.dbtest.col'),
 				array('j_ut_p_db', null),
@@ -304,7 +318,7 @@ class JDatabaseDriverPostgresqlTest extends TestCaseDatabasePostgresql
 
 		$this->assertEquals($tableCol, self::$driver->getTableColumns('jos_dbtest'));
 
-		/* not only type field */
+		// Not only type field
 		$id = new stdClass;
 		$id->column_name = 'id';
 		$id->Field = 'id';
@@ -503,8 +517,10 @@ class JDatabaseDriverPostgresqlTest extends TestCaseDatabasePostgresql
 		self::$driver->setQuery('TRUNCATE TABLE "jos_dbtest"');
 		self::$driver->execute();
 
-		/* increment the sequence automatically with INSERT INTO,
-		 * first insert to have a common starting point */
+		/*
+		 * increment the sequence automatically with INSERT INTO,
+		 * First insert to have a common starting point
+		 */
 		$query = self::$driver->getQuery(true);
 		$query->insert('jos_dbtest')
 			->columns('title,start_date,description')
@@ -512,13 +528,13 @@ class JDatabaseDriverPostgresqlTest extends TestCaseDatabasePostgresql
 		self::$driver->setQuery($query);
 		self::$driver->execute();
 
-		/* get the current sequence value */
+		// Get the current sequence value
 		$actualVal = self::$driver->getQuery(true);
 		$actualVal->select("currval('jos_dbtest_id_seq'::regclass)");
 		self::$driver->setQuery($actualVal);
 		$idActualVal = self::$driver->loadRow();
 
-		/* insert again, then call insertid() */
+		// Insert again, then call insertid()
 		$secondInsertQuery = self::$driver->getQuery(true);
 		$secondInsertQuery->insert('jos_dbtest')
 			->columns('title,start_date,description')
@@ -526,10 +542,10 @@ class JDatabaseDriverPostgresqlTest extends TestCaseDatabasePostgresql
 		self::$driver->setQuery($secondInsertQuery);
 		self::$driver->execute();
 
-		/* get insertid of last INSERT INTO */
+		// Get insertid of last INSERT INTO
 		$insertId = self::$driver->insertid();
 
-		/* check if first sequence val +1 is equal to last sequence val */
+		// Check if first sequence val +1 is equal to last sequence val
 		$this->assertEquals($idActualVal[0] + 1, $insertId);
 	}
 
@@ -666,7 +682,7 @@ class JDatabaseDriverPostgresqlTest extends TestCaseDatabasePostgresql
 		$this->assertEquals($objArr[2], self::$driver->loadNextObject());
 		$this->assertEquals($objArr[3], self::$driver->loadNextObject());
 
-		/* last call to free cursor, asserting that returns false */
+		// Last call to free cursor, asserting that returns false
 		$this->assertFalse(self::$driver->loadNextObject());
 	}
 
@@ -693,7 +709,7 @@ class JDatabaseDriverPostgresqlTest extends TestCaseDatabasePostgresql
 		$this->assertEquals($objArr[2], self::$driver->loadNextObject());
 		$this->assertEquals($objArr[3], self::$driver->loadNextObject());
 
-		/* last call to free cursor, asserting that returns false */
+		// Last call to free cursor, asserting that returns false
 		$this->assertFalse(self::$driver->loadNextObject());
 	}
 
@@ -720,7 +736,7 @@ class JDatabaseDriverPostgresqlTest extends TestCaseDatabasePostgresql
 		$this->assertEquals($objArr[2], self::$driver->loadNextObject());
 		$this->assertEquals($objArr[3], self::$driver->loadNextObject());
 
-		/* last call to free cursor, asserting that returns false */
+		// Last call to free cursor, asserting that returns false
 		$this->assertFalse(self::$driver->loadNextObject());
 	}
 
@@ -745,7 +761,7 @@ class JDatabaseDriverPostgresqlTest extends TestCaseDatabasePostgresql
 		$this->assertEquals($rowArr[2], self::$driver->loadNextRow());
 		$this->assertEquals($rowArr[3], self::$driver->loadNextRow());
 
-		/* last call to free cursor, asserting that returns false */
+		// Last call to free cursor, asserting that returns false
 		$this->assertFalse(self::$driver->loadNextRow());
 	}
 
@@ -772,7 +788,7 @@ class JDatabaseDriverPostgresqlTest extends TestCaseDatabasePostgresql
 		$this->assertEquals($rowArr[2], self::$driver->loadNextRow());
 		$this->assertEquals($rowArr[3], self::$driver->loadNextRow());
 
-		/* last call to free cursor, asserting that returns false */
+		// Last call to free cursor, asserting that returns false
 		$this->assertFalse(self::$driver->loadNextRow());
 	}
 
@@ -799,7 +815,7 @@ class JDatabaseDriverPostgresqlTest extends TestCaseDatabasePostgresql
 		$this->assertEquals($rowArr[2], self::$driver->loadNextRow());
 		$this->assertEquals($rowArr[3], self::$driver->loadNextRow());
 
-		/* last call to free cursor, asserting that returns false */
+		// Last call to free cursor, asserting that returns false
 		$this->assertFalse(self::$driver->loadNextRow());
 	}
 
@@ -985,7 +1001,7 @@ class JDatabaseDriverPostgresqlTest extends TestCaseDatabasePostgresql
 	 */
 	public function testSelect()
 	{
-		/* it's not possible to select a database, already done during connection, return true */
+		// It's not possible to select a database, already done during connection, return true
 		$this->assertTrue(self::$driver->select('database'));
 	}
 
@@ -1083,7 +1099,7 @@ class JDatabaseDriverPostgresqlTest extends TestCaseDatabasePostgresql
 
 		self::$driver->transactionCommit();
 
-		/* check if value is present */
+		// Check if value is present
 		$queryCheck = self::$driver->getQuery(true);
 		$queryCheck->select('*')
 			->from('#__dbtest')
@@ -1112,20 +1128,20 @@ class JDatabaseDriverPostgresqlTest extends TestCaseDatabasePostgresql
 	{
 		self::$driver->transactionStart();
 
-		/* try to insert this tuple, inserted only when savepoint != null */
+		// Try to insert this tuple, inserted only when savepoint != null
 		$queryIns = self::$driver->getQuery(true);
 		$queryIns->insert('#__dbtest')
 			->columns('id,title,start_date,description')
 			->values("7, 'testRollback','1970-01-01','testRollbackSp'");
 		self::$driver->setQuery($queryIns)->execute();
 
-		/* create savepoint only if is passed by data provider */
+		// Create savepoint only if is passed by data provider
 		if (!is_null($toSavepoint))
 		{
 			self::$driver->transactionStart((boolean) $toSavepoint);
 		}
 
-		/* try to insert this tuple, always rolled back */
+		// Try to insert this tuple, always rolled back
 		$queryIns = self::$driver->getQuery(true);
 		$queryIns->insert('#__dbtest')
 			->columns('id,title,start_date,description')
@@ -1134,13 +1150,14 @@ class JDatabaseDriverPostgresqlTest extends TestCaseDatabasePostgresql
 
 		self::$driver->transactionRollback((boolean) $toSavepoint);
 
-		/* release savepoint and commit only if a savepoint exists */
+		// Release savepoint and commit only if a savepoint exists
 		if (!is_null($toSavepoint))
 		{
 			self::$driver->transactionCommit();
 		}
 
-		/* find how many rows have description='testRollbackSp' :
+		/*
+		 find how many rows have description='testRollbackSp' :
 		 *   - 0 if a savepoint doesn't exist
 		 *   - 1 if a savepoint exists
 		 */
@@ -1172,7 +1189,7 @@ class JDatabaseDriverPostgresqlTest extends TestCaseDatabasePostgresql
 
 		self::$driver->setQuery($queryIns)->execute();
 
-		/* check if is present an exclusive lock, it means a transaction is running */
+		// Check if is present an exclusive lock, it means a transaction is running
 		$queryCheck = self::$driver->getQuery(true);
 		$queryCheck->select('*')
 			->from('pg_catalog.pg_locks')
@@ -1197,7 +1214,7 @@ class JDatabaseDriverPostgresqlTest extends TestCaseDatabasePostgresql
 		self::$driver->transactionRollback();
 		self::$driver->transactionStart();
 
-		/* release a nonexistent savepoint will throw an exception */
+		// Release a nonexistent savepoint will throw an exception
 		try
 		{
 			self::$driver->releaseTransactionSavepoint('pippo');
@@ -1222,23 +1239,24 @@ class JDatabaseDriverPostgresqlTest extends TestCaseDatabasePostgresql
 
 		self::$driver->renameTable('jos_dbtest', $newTableName);
 
-		/* check name change */
+		// Check name change
 		$tableList = self::$driver->getTableList();
 		$this->assertTrue(in_array($newTableName, $tableList));
 
-		/* check index change */
+		// Check index change
 		self::$driver->setQuery(
 			'SELECT relname
 							FROM pg_class
 							WHERE oid IN (
 								SELECT indexrelid
 								FROM pg_index, pg_class
-								WHERE pg_class.relname=\'' . $newTableName . '\' AND pg_class.oid=pg_index.indrelid );');
+								WHERE pg_class.relname=\'' . $newTableName . '\' AND pg_class.oid=pg_index.indrelid );'
+		);
 
 		$oldIndexes = self::$driver->loadColumn();
 		$this->assertEquals('bak_jos_dbtest_pkey', $oldIndexes[0]);
 
-		/* check sequence change */
+		// Check sequence change
 		self::$driver->setQuery(
 			'SELECT relname
 							FROM pg_class
@@ -1249,12 +1267,13 @@ class JDatabaseDriverPostgresqlTest extends TestCaseDatabasePostgresql
 								WHERE nspname NOT LIKE \'pg_%\'
 								AND nspname != \'information_schema\'
 							)
-							AND relname LIKE \'%' . $newTableName . '%\' ;');
+							AND relname LIKE \'%' . $newTableName . '%\' ;'
+		);
 
 		$oldSequences = self::$driver->loadColumn();
 		$this->assertEquals('bak_jos_dbtest_id_seq', $oldSequences[0]);
 
-		/* restore initial state */
+		// Restore initial state
 		self::$driver->renameTable($newTableName, 'jos_dbtest');
 	}
 

--- a/tests/unit/suites/database/driver/postgresql/JDatabaseDriverPostgresqlTest.php
+++ b/tests/unit/suites/database/driver/postgresql/JDatabaseDriverPostgresqlTest.php
@@ -1157,7 +1157,7 @@ class JDatabaseDriverPostgresqlTest extends TestCaseDatabasePostgresql
 		}
 
 		/*
-		 find how many rows have description='testRollbackSp' :
+		 * Find how many rows have description='testRollbackSp' :
 		 *   - 0 if a savepoint doesn't exist
 		 *   - 1 if a savepoint exists
 		 */

--- a/tests/unit/suites/database/driver/postgresql/JDatabaseExporterPostgresqlTest.php
+++ b/tests/unit/suites/database/driver/postgresql/JDatabaseExporterPostgresqlTest.php
@@ -88,7 +88,8 @@ class JDatabaseExporterPostgresqlTest extends TestCase
 					'isUnique' => 'TRUE',
 					'Query' => 'ALTER TABLE "jos_dbtest" ADD PRIMARY KEY (id)',
 				)
-			));
+				)
+			);
 
 		// Check if database is at least 9.1.0
 		$this->dbo->expects($this->any())
@@ -102,7 +103,8 @@ class JDatabaseExporterPostgresqlTest extends TestCase
 		}
 		else
 		{
-			/* Older version */
+			// Older version
+
 			$this->_ver9dot1 = false;
 			$start_val = null;
 		}
@@ -193,7 +195,8 @@ class JDatabaseExporterPostgresqlTest extends TestCase
 			->from('jos_test')
 			->withStructure(true);
 
-		/* Depending on which version is running, 9.1.0 or older */
+		// Depending on which version is running, 9.1.0 or older
+
 		$start_val = null;
 
 		if ($this->_ver9dot1)
@@ -258,7 +261,8 @@ class JDatabaseExporterPostgresqlTest extends TestCase
 			->from('jos_test')
 			->withStructure(true);
 
-		/* Depending on which version is running, 9.1.0 or older */
+		// Depending on which version is running, 9.1.0 or older
+
 		$start_val = null;
 
 		if ($this->_ver9dot1)
@@ -301,7 +305,8 @@ class JDatabaseExporterPostgresqlTest extends TestCase
 			->from('jos_test')
 			->withStructure(true);
 
-		/* Depending on which version is running, 9.1.0 or older */
+		// Depending on which version is running, 9.1.0 or older
+
 		$start_val = null;
 
 		if ($this->_ver9dot1)

--- a/tests/unit/suites/database/driver/postgresql/JDatabaseImporterPostgresqlTest.php
+++ b/tests/unit/suites/database/driver/postgresql/JDatabaseImporterPostgresqlTest.php
@@ -32,7 +32,6 @@ class JDatabaseImporterPostgresqlTest extends \PHPUnit\Framework\TestCase
 	{
 		// Set up the database object mock.
 		$this->dbo = $this->getMockBuilder('JDatabaseDriverPostgresql')
-					->setMethods(array(
 						'getErrorNum',
 						'getPrefix',
 						'getTableColumns',
@@ -48,16 +47,10 @@ class JDatabaseImporterPostgresqlTest extends \PHPUnit\Framework\TestCase
 						'quote',
 						'setQuery',
 					))
-					->setConstructorArgs(array())
-					->setMockClassName('')
-					->disableOriginalConstructor()
-					->getMock();
 
 		$this->dbo->expects(
 			$this->any()
 		)
-		->method('getPrefix')
-		->will(
 			$this->returnValue(
 				'jos_'
 			)
@@ -66,8 +59,6 @@ class JDatabaseImporterPostgresqlTest extends \PHPUnit\Framework\TestCase
 		$this->dbo->expects(
 			$this->any()
 		)
-		->method('getTableColumns')
-		->will(
 			$this->returnValue(
 				array(
 					'id' => (object) array(
@@ -91,8 +82,6 @@ class JDatabaseImporterPostgresqlTest extends \PHPUnit\Framework\TestCase
 		$this->dbo->expects(
 			$this->any()
 		)
-		->method('getTableKeys')
-		->will(
 			$this->returnValue(
 				array(
 					(object) array(
@@ -115,8 +104,6 @@ class JDatabaseImporterPostgresqlTest extends \PHPUnit\Framework\TestCase
 		$this->dbo->expects(
 			$this->any()
 		)
-		->method('getVersion')
-		->will(
 			$this->returnValue(
 				'7.1.2'
 			)
@@ -135,8 +122,6 @@ class JDatabaseImporterPostgresqlTest extends \PHPUnit\Framework\TestCase
 		$this->dbo->expects(
 			$this->any()
 		)
-		->method('getTableSequences')
-		->will(
 			$this->returnValue(
 			array(
 					(object) array(
@@ -158,8 +143,6 @@ class JDatabaseImporterPostgresqlTest extends \PHPUnit\Framework\TestCase
 		$this->dbo->expects(
 			$this->any()
 		)
-		->method('quoteName')
-		->will(
 			$this->returnCallback(
 				array($this, 'callbackQuoteName')
 			)
@@ -168,8 +151,6 @@ class JDatabaseImporterPostgresqlTest extends \PHPUnit\Framework\TestCase
 		$this->dbo->expects(
 			$this->any()
 		)
-		->method('quote')
-		->will(
 			$this->returnCallback(
 				array($this, 'callbackQuote')
 			)
@@ -178,8 +159,6 @@ class JDatabaseImporterPostgresqlTest extends \PHPUnit\Framework\TestCase
 		$this->dbo->expects(
 			$this->any()
 		)
-		->method('setQuery')
-		->will(
 			$this->returnCallback(
 				array($this, 'callbackSetQuery')
 			)
@@ -188,8 +167,6 @@ class JDatabaseImporterPostgresqlTest extends \PHPUnit\Framework\TestCase
 		$this->dbo->expects(
 			$this->any()
 		)
-		->method('loadObjectList')
-		->will(
 			$this->returnCallback(
 				array($this, 'callbackLoadObjectList')
 			)

--- a/tests/unit/suites/database/driver/postgresql/JDatabaseImporterPostgresqlTest.php
+++ b/tests/unit/suites/database/driver/postgresql/JDatabaseImporterPostgresqlTest.php
@@ -32,6 +32,7 @@ class JDatabaseImporterPostgresqlTest extends \PHPUnit\Framework\TestCase
 	{
 		// Set up the database object mock.
 		$this->dbo = $this->getMockBuilder('JDatabaseDriverPostgresql')
+			->setMethods(array(
 						'getErrorNum',
 						'getPrefix',
 						'getTableColumns',
@@ -47,10 +48,16 @@ class JDatabaseImporterPostgresqlTest extends \PHPUnit\Framework\TestCase
 						'quote',
 						'setQuery',
 					))
+			->setConstructorArgs(array())
+			->setMockClassName('')
+			->disableOriginalConstructor()
+			->getMock();
 
 		$this->dbo->expects(
 			$this->any()
 		)
+			->method('getPrefix')
+			->will(
 			$this->returnValue(
 				'jos_'
 			)
@@ -59,6 +66,8 @@ class JDatabaseImporterPostgresqlTest extends \PHPUnit\Framework\TestCase
 		$this->dbo->expects(
 			$this->any()
 		)
+			->method('getTableColumns')
+			->will(
 			$this->returnValue(
 				array(
 					'id' => (object) array(
@@ -82,6 +91,8 @@ class JDatabaseImporterPostgresqlTest extends \PHPUnit\Framework\TestCase
 		$this->dbo->expects(
 			$this->any()
 		)
+			->method('getTableKeys')
+			->will(
 			$this->returnValue(
 				array(
 					(object) array(
@@ -104,6 +115,8 @@ class JDatabaseImporterPostgresqlTest extends \PHPUnit\Framework\TestCase
 		$this->dbo->expects(
 			$this->any()
 		)
+			->method('getVersion')
+			->will(
 			$this->returnValue(
 				'7.1.2'
 			)
@@ -122,6 +135,8 @@ class JDatabaseImporterPostgresqlTest extends \PHPUnit\Framework\TestCase
 		$this->dbo->expects(
 			$this->any()
 		)
+			->method('getTableSequences')
+			->will(
 			$this->returnValue(
 			array(
 					(object) array(
@@ -143,6 +158,8 @@ class JDatabaseImporterPostgresqlTest extends \PHPUnit\Framework\TestCase
 		$this->dbo->expects(
 			$this->any()
 		)
+			->method('quoteName')
+			->will(
 			$this->returnCallback(
 				array($this, 'callbackQuoteName')
 			)
@@ -151,6 +168,8 @@ class JDatabaseImporterPostgresqlTest extends \PHPUnit\Framework\TestCase
 		$this->dbo->expects(
 			$this->any()
 		)
+			->method('quote')
+			->will(
 			$this->returnCallback(
 				array($this, 'callbackQuote')
 			)
@@ -159,6 +178,8 @@ class JDatabaseImporterPostgresqlTest extends \PHPUnit\Framework\TestCase
 		$this->dbo->expects(
 			$this->any()
 		)
+			->method('setQuery')
+			->will(
 			$this->returnCallback(
 				array($this, 'callbackSetQuery')
 			)
@@ -167,6 +188,8 @@ class JDatabaseImporterPostgresqlTest extends \PHPUnit\Framework\TestCase
 		$this->dbo->expects(
 			$this->any()
 		)
+			->method('loadObjectList')
+			->will(
 			$this->returnCallback(
 				array($this, 'callbackLoadObjectList')
 			)

--- a/tests/unit/suites/database/driver/postgresql/JDatabaseImporterPostgresqlTest.php
+++ b/tests/unit/suites/database/driver/postgresql/JDatabaseImporterPostgresqlTest.php
@@ -47,7 +47,8 @@ class JDatabaseImporterPostgresqlTest extends \PHPUnit\Framework\TestCase
 						'loadObjectList',
 						'quote',
 						'setQuery',
-					))
+				)
+			)
 			->setConstructorArgs(array())
 			->setMockClassName('')
 			->disableOriginalConstructor()
@@ -58,18 +59,18 @@ class JDatabaseImporterPostgresqlTest extends \PHPUnit\Framework\TestCase
 		)
 			->method('getPrefix')
 			->will(
-			$this->returnValue(
-				'jos_'
-			)
-		);
+				$this->returnValue(
+					'jos_'
+				)
+			);
 
 		$this->dbo->expects(
 			$this->any()
 		)
 			->method('getTableColumns')
 			->will(
-			$this->returnValue(
-				array(
+				$this->returnValue(
+					array(
 					'id' => (object) array(
 						'Field' => 'id',
 						'Type' => 'integer',
@@ -84,17 +85,17 @@ class JDatabaseImporterPostgresqlTest extends \PHPUnit\Framework\TestCase
 						'Default' => 'NULL',
 						'Comments' => '',
 					),
+					)
 				)
-			)
-		);
+			);
 
 		$this->dbo->expects(
 			$this->any()
 		)
 			->method('getTableKeys')
 			->will(
-			$this->returnValue(
-				array(
+				$this->returnValue(
+					array(
 					(object) array(
 						'Index' => 'jos_dbtest_pkey',
 						'is_primary' => 'TRUE',
@@ -107,9 +108,9 @@ class JDatabaseImporterPostgresqlTest extends \PHPUnit\Framework\TestCase
 						'is_unique' => 'FALSE',
 						'Query' => 'CREATE INDEX jos_dbtest_idx_name ON jos_dbtest USING btree (name)',
 					)
+					)
 				)
-			)
-		);
+			);
 
 		// Check if database is at least 9.1.0
 		$this->dbo->expects(
@@ -117,10 +118,10 @@ class JDatabaseImporterPostgresqlTest extends \PHPUnit\Framework\TestCase
 		)
 			->method('getVersion')
 			->will(
-			$this->returnValue(
-				'7.1.2'
-			)
-		);
+				$this->returnValue(
+					'7.1.2'
+				)
+			);
 
 		if (version_compare($this->dbo->getVersion(), '9.1.0') >= 0)
 		{
@@ -128,7 +129,8 @@ class JDatabaseImporterPostgresqlTest extends \PHPUnit\Framework\TestCase
 		}
 		else
 		{
-			/* Older version */
+			// Older version
+
 			$start_val = null;
 		}
 
@@ -137,8 +139,8 @@ class JDatabaseImporterPostgresqlTest extends \PHPUnit\Framework\TestCase
 		)
 			->method('getTableSequences')
 			->will(
-			$this->returnValue(
-			array(
+				$this->returnValue(
+					array(
 					(object) array(
 						'Name' => 'jos_dbtest_id_seq',
 						'Schema' => 'public',
@@ -151,49 +153,49 @@ class JDatabaseImporterPostgresqlTest extends \PHPUnit\Framework\TestCase
 						'Increment' => '1',
 						'Cycle_option' => 'NO',
 					)
+					)
 				)
-			)
-		);
+			);
 
 		$this->dbo->expects(
 			$this->any()
 		)
 			->method('quoteName')
 			->will(
-			$this->returnCallback(
-				array($this, 'callbackQuoteName')
-			)
-		);
+				$this->returnCallback(
+					array($this, 'callbackQuoteName')
+				)
+			);
 
 		$this->dbo->expects(
 			$this->any()
 		)
 			->method('quote')
 			->will(
-			$this->returnCallback(
-				array($this, 'callbackQuote')
-			)
-		);
+				$this->returnCallback(
+					array($this, 'callbackQuote')
+				)
+			);
 
 		$this->dbo->expects(
 			$this->any()
 		)
 			->method('setQuery')
 			->will(
-			$this->returnCallback(
-				array($this, 'callbackSetQuery')
-			)
-		);
+				$this->returnCallback(
+					array($this, 'callbackSetQuery')
+				)
+			);
 
 		$this->dbo->expects(
 			$this->any()
 		)
 			->method('loadObjectList')
 			->will(
-			$this->returnCallback(
-				array($this, 'callbackLoadObjectList')
-			)
-		);
+				$this->returnCallback(
+					array($this, 'callbackLoadObjectList')
+				)
+			);
 	}
 
 	/**

--- a/tests/unit/suites/database/driver/postgresql/JDatabaseQueryPostgresqlTest.php
+++ b/tests/unit/suites/database/driver/postgresql/JDatabaseQueryPostgresqlTest.php
@@ -164,7 +164,6 @@ class JDatabaseQueryPostgresqlTest extends TestCase
 			->innerJoin('b ON b.id = a.id')
 			->where('b.id = 1')
 			->group('a.id')
-				->having('COUNT(a.id) > 3')
 			->order('a.id');
 
 		$this->assertEquals(

--- a/tests/unit/suites/database/driver/postgresql/JDatabaseQueryPostgresqlTest.php
+++ b/tests/unit/suites/database/driver/postgresql/JDatabaseQueryPostgresqlTest.php
@@ -164,6 +164,7 @@ class JDatabaseQueryPostgresqlTest extends TestCase
 			->innerJoin('b ON b.id = a.id')
 			->where('b.id = 1')
 			->group('a.id')
+			->having('COUNT(a.id) > 3')
 			->order('a.id');
 
 		$this->assertEquals(

--- a/tests/unit/suites/database/driver/sqlsrv/JDatabaseDriverSqlsrvTest.php
+++ b/tests/unit/suites/database/driver/sqlsrv/JDatabaseDriverSqlsrvTest.php
@@ -184,7 +184,7 @@ class JDatabaseDriverSqlsrvTest extends TestCaseDatabaseSqlsrv
 		$this->assertThat(
 			self::$driver->getVersion(),
 			$this->isType('string'),
-		'Line:' . __LINE__ . ' The getVersion method should return a string containing the driver version.'
+			'Line:' . __LINE__ . ' The getVersion method should return a string containing the driver version.'
 		);
 	}
 

--- a/tests/unit/suites/database/driver/sqlsrv/JDatabaseQuerySqlsrvTest.php
+++ b/tests/unit/suites/database/driver/sqlsrv/JDatabaseQuerySqlsrvTest.php
@@ -9,11 +9,11 @@
 
 /**
  * Test class for JDatabaseQuerySqlsrv.
-*
-* @package     Joomla.UnitTest
-* @subpackage  Database
-* @since       11.3
-*/
+ *
+ * @package     Joomla.UnitTest
+ * @subpackage  Database
+ * @since       11.3
+ */
 class JDatabaseQuerySqlsrvTest extends TestCase
 {
 	/**
@@ -331,13 +331,13 @@ class JDatabaseQuerySqlsrvTest extends TestCase
 		$this->_instance
 			->clear()
 			->select('DISTINCT + + + id'
-			. ", - +- +-a . [id_9]"
-			. ", - +- +-a. [id_9]"
-			. ", - +- +-a .[id_9]"
-			. ", - +- +-a.[id_9]"
-			. ", + - + ix"
-			. ", ++ ix"
-		);
+				. ", - +- +-a . [id_9]"
+				. ", - +- +-a. [id_9]"
+				. ", - +- +-a .[id_9]"
+				. ", - +- +-a.[id_9]"
+				. ", + - + ix"
+				. ", ++ ix"
+			);
 
 		$expected = array(
 			'DISTINCT +++ id',
@@ -359,10 +359,10 @@ class JDatabaseQuerySqlsrvTest extends TestCase
 		$this->_instance
 			->clear()
 			->select('DISTINCT - + + + [a] . id'
-			. ", [a] . [id_9]"
-			. ", c + /**/ + [a].[b]"
-			. ", [a].[b] + c"
-		);
+				. ", [a] . [id_9]"
+				. ", c + /**/ + [a].[b]"
+				. ", [a].[b] + c"
+			);
 
 		$expected = array(
 			'DISTINCT -+++ [a]. id AS [columnAlias0]',
@@ -381,8 +381,8 @@ class JDatabaseQuerySqlsrvTest extends TestCase
 		$this->_instance
 			->clear()
 			->select('DISTINCT +id'
-			. ", ''+a . id_9 'alias'"
-		);
+				. ", ''+a . id_9 'alias'"
+			);
 
 		$expected = array(
 			'DISTINCT + id',

--- a/tests/unit/suites/libraries/cms/application/JApplicationCmsTest.php
+++ b/tests/unit/suites/libraries/cms/application/JApplicationCmsTest.php
@@ -190,11 +190,6 @@ class JApplicationCmsTest extends TestCaseDatabase
 
 		// Build the mock object.
 		$mockClient = $this->getMockBuilder('JApplicationWebClient')
-					->setMethods(array('test'))
-					->setConstructorArgs(array())
-					->setMockClassName('')
-					->disableOriginalConstructor()
-					->getMock();
 
 		$inspector = new JApplicationCmsInspector($mockInput, $config, $mockClient);
 

--- a/tests/unit/suites/libraries/cms/application/JApplicationCmsTest.php
+++ b/tests/unit/suites/libraries/cms/application/JApplicationCmsTest.php
@@ -190,6 +190,11 @@ class JApplicationCmsTest extends TestCaseDatabase
 
 		// Build the mock object.
 		$mockClient = $this->getMockBuilder('JApplicationWebClient')
+			->setMethods(array('test'))
+			->setConstructorArgs(array())
+			->setMockClassName('')
+			->disableOriginalConstructor()
+			->getMock();
 
 		$inspector = new JApplicationCmsInspector($mockInput, $config, $mockClient);
 

--- a/tests/unit/suites/libraries/cms/helper/JHelperMediaTest.php
+++ b/tests/unit/suites/libraries/cms/helper/JHelperMediaTest.php
@@ -176,7 +176,7 @@ class JHelperMediaTest extends TestCaseDatabase
 	 */
 	public function testCanUpload($file, $expected)
 	{
-	    $canUpload = $this->object->canUpload($file);
+		$canUpload = $this->object->canUpload($file);
 		$this->assertEquals($canUpload, $expected);
 	}
 

--- a/tests/unit/suites/libraries/cms/html/JHtmlMenuTest.php
+++ b/tests/unit/suites/libraries/cms/html/JHtmlMenuTest.php
@@ -26,10 +26,10 @@ class JHtmlMenuTest extends TestCaseDatabase
 	 */
 	protected function setUp()
 	{
-        // Skipped because dataset that allows these test not to fail let other tests fail.
-	    $this->markTestSkipped('skipped RD 3.Feb 2017');
+		// Skipped because dataset that allows these test not to fail let other tests fail.
+		$this->markTestSkipped('skipped RD 3.Feb 2017');
 
-	    parent::setUp();
+		parent::setUp();
 
 		$this->saveFactoryState();
 

--- a/tests/unit/suites/libraries/cms/html/JHtmlTest.php
+++ b/tests/unit/suites/libraries/cms/html/JHtmlTest.php
@@ -178,8 +178,6 @@ class JHtmlTest extends TestCase
 	{
 		// Build the mock object.
 		$registered = $this->getMockBuilder('MyHtmlClass')
-					->setMethods(array('mockFunction'))
-					->getMock();
 
 		// Test that we can register the method
 		$this->assertTrue(
@@ -210,8 +208,6 @@ class JHtmlTest extends TestCase
 	{
 		// Build the mock object to Register a method so we can unregister it.
 		$registered = $this->getMockBuilder('MyHtmlClass')
-					->setMethods(array('mockFunction'))
-					->getMock();
 
 		JHtml::register('prefix.unregister.testfunction', array($registered, 'mockFunction'));
 
@@ -237,8 +233,6 @@ class JHtmlTest extends TestCase
 	{
 		// Build the mock object.
 		$registered = $this->getMockBuilder('MyHtmlClass')
-					->setMethods(array('mockFunction'))
-					->getMock();
 
 		// Test that we can register the method.
 		JHtml::register('prefix.isregistered.method', array($registered, 'mockFunction'));

--- a/tests/unit/suites/libraries/cms/html/JHtmlTest.php
+++ b/tests/unit/suites/libraries/cms/html/JHtmlTest.php
@@ -178,6 +178,8 @@ class JHtmlTest extends TestCase
 	{
 		// Build the mock object.
 		$registered = $this->getMockBuilder('MyHtmlClass')
+			->setMethods(array('mockFunction'))
+			->getMock();
 
 		// Test that we can register the method
 		$this->assertTrue(
@@ -208,6 +210,8 @@ class JHtmlTest extends TestCase
 	{
 		// Build the mock object to Register a method so we can unregister it.
 		$registered = $this->getMockBuilder('MyHtmlClass')
+			->setMethods(array('mockFunction'))
+			->getMock();
 
 		JHtml::register('prefix.unregister.testfunction', array($registered, 'mockFunction'));
 
@@ -233,6 +237,8 @@ class JHtmlTest extends TestCase
 	{
 		// Build the mock object.
 		$registered = $this->getMockBuilder('MyHtmlClass')
+			->setMethods(array('mockFunction'))
+			->getMock();
 
 		// Test that we can register the method.
 		JHtml::register('prefix.isregistered.method', array($registered, 'mockFunction'));

--- a/tests/unit/suites/libraries/cms/installer/JInstallerAdapterTest.php
+++ b/tests/unit/suites/libraries/cms/installer/JInstallerAdapterTest.php
@@ -93,6 +93,9 @@ class JInstallerAdapterTest extends TestCaseDatabase
 
 		// Set up a mock JTableExtension
 		$mockTableExtension = $this->getMockBuilder('JTableExtension')
+			->setMethods(array('find', 'load'))
+			->setConstructorArgs(array(self::$driver))
+			->getMock();
 
 		// A set of data for an extension
 		$type = 'plugin';
@@ -138,6 +141,9 @@ class JInstallerAdapterTest extends TestCaseDatabase
 
 		// Set up a mock JTableExtension
 		$mockTableExtension = $this->getMockBuilder('JTableExtension')
+			->setMethods(array('find', 'load'))
+			->setConstructorArgs(array($this->getMockDatabase()))
+			->getMock();
 
 		// A set of data for an extension
 		$type = 'plugin';
@@ -181,6 +187,9 @@ class JInstallerAdapterTest extends TestCaseDatabase
 
 		// Set up a mock JTableExtension
 		$mockTableExtension = $this->getMockBuilder('JTableExtension')
+			->setMethods(array('find', 'load'))
+			->setConstructorArgs(array($this->getMockDatabase()))
+			->getMock();
 
 		$type = 'plugin';
 		$element = 'plg_finder_content';
@@ -206,6 +215,8 @@ class JInstallerAdapterTest extends TestCaseDatabase
 	public function testCheckExtensionInFilesystem()
 	{
 		$mockInstaller = $this->getMockBuilder('JInstaller')
+			->setMethods(array('getPath', 'isOverwrite', 'isUpgrade', 'setOverwrite', 'setUpgrade'))
+			->getMock();
 
 		$mockInstaller->expects($this->once())
 			->method('getPath')
@@ -263,6 +274,8 @@ class JInstallerAdapterTest extends TestCaseDatabase
 	public function testsCheckExtensionInFilesystemInstallerRouteSetWhenFilesystemExistsWithExtensionIdSet()
 	{
 		$mockInstaller = $this->getMockBuilder('JInstaller')
+			->setMethods(array('getPath', 'isOverwrite', 'isUpgrade', 'setOverwrite', 'setUpgrade'))
+			->getMock();
 
 		$mockInstaller->expects($this->once())
 			->method('getPath')
@@ -304,6 +317,8 @@ class JInstallerAdapterTest extends TestCaseDatabase
 	public function testsCheckExtensionInFilesystemWithOverwriteSetFalse()
 	{
 		$mockInstaller = $this->getMockBuilder('JInstaller')
+			->setMethods(array('getPath', 'isOverwrite', 'isUpgrade'))
+			->getMock();
 
 		$mockInstaller->expects($this->any())
 			->method('getPath')
@@ -337,6 +352,8 @@ class JInstallerAdapterTest extends TestCaseDatabase
 	public function testDiscoverInstall()
 	{
 		$mockInstaller = $this->getMockBuilder('JInstaller')
+			->setMethods(array('abort'))
+			->getMock();
 
 		// For this test we to ensure abort is not called in JInstaller
 		$mockInstaller->expects($this->never())
@@ -364,6 +381,9 @@ class JInstallerAdapterTest extends TestCaseDatabase
 
 		// Set up a mock JTableExtension
 		$mockTableExtension = $this->getMockBuilder('JTableExtension')
+			->setMethods(array('find', 'load'))
+			->setConstructorArgs(array($this->getMockDatabase()))
+			->getMock();
 
 		$mockTableExtension->extension_id = 444;
 		TestReflection::setValue($object, 'extension', $mockTableExtension);
@@ -406,6 +426,8 @@ class JInstallerAdapterTest extends TestCaseDatabase
 	public function testDiscoverInstallWithNoDescription()
 	{
 		$mockInstaller = $this->getMockBuilder('JInstaller')
+			->setMethods(array('abort'))
+			->getMock();
 
 		// For this test we to ensure abort is not called in JInstaller
 		$mockInstaller->expects($this->never())
@@ -433,6 +455,9 @@ class JInstallerAdapterTest extends TestCaseDatabase
 
 		// Set up a mock JTableExtension
 		$mockTableExtension = $this->getMockBuilder('JTableExtension')
+			->setMethods(array('find', 'load'))
+			->setConstructorArgs(array($this->getMockDatabase()))
+			->getMock();
 		$mockTableExtension->extension_id = 444;
 		TestReflection::setValue($object, 'extension', $mockTableExtension);
 
@@ -493,6 +518,8 @@ class JInstallerAdapterTest extends TestCaseDatabase
 	public function testDiscoverInstallWithExceptionThrownInAdapterMethods($method)
 	{
 		$mockInstaller = $this->getMockBuilder('JInstaller')
+			->setMethods(array('abort'))
+			->getMock();
 
 		// For this test we to ensure abort is not called in JInstaller
 		$mockInstaller->expects($this->once())
@@ -789,6 +816,8 @@ class JInstallerAdapterTest extends TestCaseDatabase
 	public function testInstall()
 	{
 		$mockInstaller = $this->getMockBuilder('JInstaller')
+			->setMethods(array('abort'))
+			->getMock();
 
 		// For this test we to ensure abort is not called in JInstaller
 		$mockInstaller->expects($this->never())
@@ -821,6 +850,9 @@ class JInstallerAdapterTest extends TestCaseDatabase
 
 		// Set up a mock JTableExtension
 		$mockTableExtension = $this->getMockBuilder('JTableExtension')
+			->setMethods(array('find', 'load'))
+			->setConstructorArgs(array($this->getMockDatabase()))
+			->getMock();
 		$mockTableExtension->extension_id = 444;
 		TestReflection::setValue($object, 'extension', $mockTableExtension);
 
@@ -862,6 +894,8 @@ class JInstallerAdapterTest extends TestCaseDatabase
 	public function testInstallOnUpdateRoute()
 	{
 		$mockInstaller = $this->getMockBuilder('JInstaller')
+			->setMethods(array('abort'))
+			->getMock();
 
 		// For this test we to ensure abort is not called in JInstaller
 		$mockInstaller->expects($this->never())
@@ -895,6 +929,9 @@ class JInstallerAdapterTest extends TestCaseDatabase
 
 		// Set up a mock JTableExtension
 		$mockTableExtension = $this->getMockBuilder('JTableExtension')
+			->setMethods(array('find', 'load'))
+			->setConstructorArgs(array($this->getMockDatabase()))
+			->getMock();
 		$mockTableExtension->extension_id = 444;
 		TestReflection::setValue($object, 'extension', $mockTableExtension);
 		TestReflection::setValue($object, 'route', 'update');
@@ -941,6 +978,8 @@ class JInstallerAdapterTest extends TestCaseDatabase
 	public function testInstallAbortsWhenSetupUpdatesThrowsException()
 	{
 		$mockInstaller = $this->getMockBuilder('JInstaller')
+			->setMethods(array('abort'))
+			->getMock();
 
 		// For this test we to ensure abort is not called in JInstaller
 		$mockInstaller->expects($this->once())
@@ -974,6 +1013,9 @@ class JInstallerAdapterTest extends TestCaseDatabase
 
 		// Set up a mock JTableExtension
 		$mockTableExtension = $this->getMockBuilder('JTableExtension')
+			->setMethods(array('find', 'load'))
+			->setConstructorArgs(array($this->getMockDatabase()))
+			->getMock();
 		$mockTableExtension->extension_id = 444;
 		TestReflection::setValue($object, 'extension', $mockTableExtension);
 		TestReflection::setValue($object, 'route', 'update');
@@ -1014,6 +1056,8 @@ class JInstallerAdapterTest extends TestCaseDatabase
 	public function testInstallWithNoDescription()
 	{
 		$mockInstaller = $this->getMockBuilder('JInstaller')
+			->setMethods(array('abort'))
+			->getMock();
 
 		// For this test we to ensure abort is not called in JInstaller
 		$mockInstaller->expects($this->never())
@@ -1046,6 +1090,9 @@ class JInstallerAdapterTest extends TestCaseDatabase
 
 		// Set up a mock JTableExtension
 		$mockTableExtension = $this->getMockBuilder('JTableExtension')
+			->setMethods(array('find', 'load'))
+			->setConstructorArgs(array($this->getMockDatabase()))
+			->getMock();
 		$mockTableExtension->extension_id = 444;
 		TestReflection::setValue($object, 'extension', $mockTableExtension);
 
@@ -1110,6 +1157,8 @@ class JInstallerAdapterTest extends TestCaseDatabase
 	public function testInstallWithExceptionThrownInAdapterMethods($method)
 	{
 		$mockInstaller = $this->getMockBuilder('JInstaller')
+			->setMethods(array('abort'))
+			->getMock();
 
 		// For this test we to ensure abort is not called in JInstaller
 		$mockInstaller->expects($this->once())
@@ -1171,6 +1220,8 @@ class JInstallerAdapterTest extends TestCaseDatabase
 	public function testInstallWithExceptionThrownInFinaliseInstall()
 	{
 		$mockInstaller = $this->getMockBuilder('JInstaller')
+			->setMethods(array('abort'))
+			->getMock();
 
 		// For this test we to ensure abort is not called in JInstaller
 		$mockInstaller->expects($this->once())
@@ -1264,6 +1315,8 @@ class JInstallerAdapterTest extends TestCaseDatabase
 		$schema = simplexml_load_string('<extension><update><schemas><schemapath type="mysql">sql/updates/mysql</schemapath></schemas></update></extension>');
 
 		$mockInstaller = $this->getMockBuilder('JInstaller')
+			->setMethods(array('parseSchemaUpdates'))
+			->getMock();
 
 		$mockInstaller->expects($this->once())
 			->method('parseSchemaUpdates')
@@ -1284,6 +1337,9 @@ class JInstallerAdapterTest extends TestCaseDatabase
 
 		// Set up a mock JTableExtension
 		$mockTableExtension = $this->getMockBuilder('JTableExtension')
+			->setMethods(array('find', 'load'))
+			->setConstructorArgs(array($this->getMockDatabase()))
+			->getMock();
 		$mockTableExtension->extension_id = 444;
 		TestReflection::setValue($object, 'extension', $mockTableExtension);
 
@@ -1306,6 +1362,8 @@ class JInstallerAdapterTest extends TestCaseDatabase
 		$schema = simplexml_load_string('<extension><update><schemas><schemapath type="mysql">sql/updates/mysql</schemapath></schemas></update></extension>');
 
 		$mockInstaller = $this->getMockBuilder('JInstaller')
+			->setMethods(array('parseSchemaUpdates'))
+			->getMock();
 		$mockInstaller->expects($this->once())
 			->method('parseSchemaUpdates')
 			->with($schema->update->schemas, 444)
@@ -1325,6 +1383,9 @@ class JInstallerAdapterTest extends TestCaseDatabase
 
 		// Set up a mock JTableExtension
 		$mockTableExtension = $this->getMockBuilder('JTableExtension')
+			->setMethods(array('find', 'load'))
+			->setConstructorArgs(array($this->getMockDatabase()))
+			->getMock();
 		$mockTableExtension->extension_id = 444;
 		TestReflection::setValue($object, 'extension', $mockTableExtension);
 
@@ -1417,11 +1478,15 @@ class JInstallerAdapterTest extends TestCaseDatabase
 	public function testTriggerManifestScriptForMethodsTakingInstallerObjectOnly($method)
 	{
 		$mockInstaller = $this->getMockBuilder('JInstaller')
+			->setMethods(array('set'))
+			->getMock();
 
 		$mockDatabase = $this->getMockDatabase();
 		$object       = $this->getMockForAbstractClass('JInstallerAdapter', array($mockInstaller, $mockDatabase));
 
 		$mockScript   = $this->getMockBuilder('DummyScript')
+			->setMethods(array('preflight', 'postflight', 'install', 'uninstall', 'update'))
+			->getMock();
 
 		$mockScript->expects($this->once())
 			->method($method)
@@ -1459,11 +1524,15 @@ class JInstallerAdapterTest extends TestCaseDatabase
 	public function testTriggerManifestScriptForMethodsTakingInstallerObjectAndRoute($method)
 	{
 		$mockInstaller = $this->getMockBuilder('JInstaller')
+			->setMethods(array('set'))
+			->getMock();
 
 		$mockDatabase = $this->getMockDatabase();
 		$object       = $this->getMockForAbstractClass('JInstallerAdapter', array($mockInstaller, $mockDatabase));
 
 		$mockScript   = $this->getMockBuilder('DummyScript')
+			->setMethods(array('preflight', 'postflight', 'install', 'uninstall', 'update'))
+			->getMock();
 
 		$routeValue = 'update';
 		TestReflection::setValue($object, 'route', $routeValue);
@@ -1489,11 +1558,15 @@ class JInstallerAdapterTest extends TestCaseDatabase
 	public function testTriggerManifestScriptPreflightReturningFalseThrowsException()
 	{
 		$mockInstaller = $this->getMockBuilder('JInstaller')
+			->setMethods(array('set'))
+			->getMock();
 
 		$mockDatabase = $this->getMockDatabase();
 		$object       = $this->getMockForAbstractClass('JInstallerAdapter', array($mockInstaller, $mockDatabase));
 
 		$mockScript   = $this->getMockBuilder('DummyScript')
+			->setMethods(array('preflight', 'postflight', 'install', 'uninstall', 'update'))
+			->getMock();
 
 		$routeValue = 'update';
 		TestReflection::setValue($object, 'route', $routeValue);
@@ -1533,11 +1606,15 @@ class JInstallerAdapterTest extends TestCaseDatabase
 	public function testTriggerManifestScriptInstallOrUpdateReturningFalseThrowsException($method)
 	{
 		$mockInstaller = $this->getMockBuilder('JInstaller')
+			->setMethods(array('set'))
+			->getMock();
 
 		$mockDatabase = $this->getMockDatabase();
 		$object       = $this->getMockForAbstractClass('JInstallerAdapter', array($mockInstaller, $mockDatabase));
 
 		$mockScript   = $this->getMockBuilder('DummyScript')
+			->setMethods(array('preflight', 'postflight', 'install', 'uninstall', 'update'))
+			->getMock();
 
 		TestReflection::setValue($object, 'route', $method);
 
@@ -1559,11 +1636,15 @@ class JInstallerAdapterTest extends TestCaseDatabase
 	public function testTriggerManifestScriptUninstallReturningFalseDoesNotThrowAnException()
 	{
 		$mockInstaller = $this->getMockBuilder('JInstaller')
+			->setMethods(array('set'))
+			->getMock();
 
 		$mockDatabase = $this->getMockDatabase();
 		$object       = $this->getMockForAbstractClass('JInstallerAdapter', array($mockInstaller, $mockDatabase));
 
 		$mockScript   = $this->getMockBuilder('DummyScript')
+			->setMethods(array('preflight', 'postflight', 'install', 'uninstall', 'update'))
+			->getMock();
 
 		TestReflection::setValue($object, 'route', 'uninstall');
 
@@ -1587,11 +1668,15 @@ class JInstallerAdapterTest extends TestCaseDatabase
 	public function testTriggerManifestScriptPostflightReturningFalseDoesNotThrowAnException()
 	{
 		$mockInstaller = $this->getMockBuilder('JInstaller')
+			->setMethods(array('set'))
+			->getMock();
 
 		$mockDatabase = $this->getMockDatabase();
 		$object       = $this->getMockForAbstractClass('JInstallerAdapter', array($mockInstaller, $mockDatabase));
 
 		$mockScript   = $this->getMockBuilder('DummyScript')
+			->setMethods(array('preflight', 'postflight', 'install', 'uninstall', 'update'))
+			->getMock();
 
 		TestReflection::setValue($object, 'route', 'uninstall');
 
@@ -1615,6 +1700,8 @@ class JInstallerAdapterTest extends TestCaseDatabase
 	public function testUpdate()
 	{
 		$mockInstaller = $this->getMockBuilder('JInstaller')
+			->setMethods(array('setOverwrite', 'setUpgrade'))
+			->getMock();
 
 		$mockInstaller->expects($this->once())
 			->method('setUpgrade')

--- a/tests/unit/suites/libraries/cms/installer/JInstallerAdapterTest.php
+++ b/tests/unit/suites/libraries/cms/installer/JInstallerAdapterTest.php
@@ -93,9 +93,6 @@ class JInstallerAdapterTest extends TestCaseDatabase
 
 		// Set up a mock JTableExtension
 		$mockTableExtension = $this->getMockBuilder('JTableExtension')
-							->setMethods(array('find', 'load'))
-							->setConstructorArgs(array(self::$driver))
-							->getMock();
 
 		// A set of data for an extension
 		$type = 'plugin';
@@ -141,9 +138,6 @@ class JInstallerAdapterTest extends TestCaseDatabase
 
 		// Set up a mock JTableExtension
 		$mockTableExtension = $this->getMockBuilder('JTableExtension')
-							->setMethods(array('find', 'load'))
-							->setConstructorArgs(array($this->getMockDatabase()))
-							->getMock();
 
 		// A set of data for an extension
 		$type = 'plugin';
@@ -187,9 +181,6 @@ class JInstallerAdapterTest extends TestCaseDatabase
 
 		// Set up a mock JTableExtension
 		$mockTableExtension = $this->getMockBuilder('JTableExtension')
-							->setMethods(array('find', 'load'))
-							->setConstructorArgs(array($this->getMockDatabase()))
-							->getMock();
 
 		$type = 'plugin';
 		$element = 'plg_finder_content';
@@ -215,8 +206,6 @@ class JInstallerAdapterTest extends TestCaseDatabase
 	public function testCheckExtensionInFilesystem()
 	{
 		$mockInstaller = $this->getMockBuilder('JInstaller')
-						->setMethods(array('getPath', 'isOverwrite', 'isUpgrade', 'setOverwrite', 'setUpgrade'))
-						->getMock();
 
 		$mockInstaller->expects($this->once())
 			->method('getPath')
@@ -274,8 +263,6 @@ class JInstallerAdapterTest extends TestCaseDatabase
 	public function testsCheckExtensionInFilesystemInstallerRouteSetWhenFilesystemExistsWithExtensionIdSet()
 	{
 		$mockInstaller = $this->getMockBuilder('JInstaller')
-						->setMethods(array('getPath', 'isOverwrite', 'isUpgrade', 'setOverwrite', 'setUpgrade'))
-						->getMock();
 
 		$mockInstaller->expects($this->once())
 			->method('getPath')
@@ -317,8 +304,6 @@ class JInstallerAdapterTest extends TestCaseDatabase
 	public function testsCheckExtensionInFilesystemWithOverwriteSetFalse()
 	{
 		$mockInstaller = $this->getMockBuilder('JInstaller')
-						->setMethods(array('getPath', 'isOverwrite', 'isUpgrade'))
-						->getMock();
 
 		$mockInstaller->expects($this->any())
 			->method('getPath')
@@ -352,8 +337,6 @@ class JInstallerAdapterTest extends TestCaseDatabase
 	public function testDiscoverInstall()
 	{
 		$mockInstaller = $this->getMockBuilder('JInstaller')
-						->setMethods(array('abort'))
-						->getMock();
 
 		// For this test we to ensure abort is not called in JInstaller
 		$mockInstaller->expects($this->never())
@@ -381,9 +364,6 @@ class JInstallerAdapterTest extends TestCaseDatabase
 
 		// Set up a mock JTableExtension
 		$mockTableExtension = $this->getMockBuilder('JTableExtension')
-							->setMethods(array('find', 'load'))
-							->setConstructorArgs(array($this->getMockDatabase()))
-							->getMock();
 
 		$mockTableExtension->extension_id = 444;
 		TestReflection::setValue($object, 'extension', $mockTableExtension);
@@ -426,8 +406,6 @@ class JInstallerAdapterTest extends TestCaseDatabase
 	public function testDiscoverInstallWithNoDescription()
 	{
 		$mockInstaller = $this->getMockBuilder('JInstaller')
-						->setMethods(array('abort'))
-						->getMock();
 
 		// For this test we to ensure abort is not called in JInstaller
 		$mockInstaller->expects($this->never())
@@ -455,9 +433,6 @@ class JInstallerAdapterTest extends TestCaseDatabase
 
 		// Set up a mock JTableExtension
 		$mockTableExtension = $this->getMockBuilder('JTableExtension')
-							->setMethods(array('find', 'load'))
-							->setConstructorArgs(array($this->getMockDatabase()))
-							->getMock();
 		$mockTableExtension->extension_id = 444;
 		TestReflection::setValue($object, 'extension', $mockTableExtension);
 
@@ -518,8 +493,6 @@ class JInstallerAdapterTest extends TestCaseDatabase
 	public function testDiscoverInstallWithExceptionThrownInAdapterMethods($method)
 	{
 		$mockInstaller = $this->getMockBuilder('JInstaller')
-						->setMethods(array('abort'))
-						->getMock();
 
 		// For this test we to ensure abort is not called in JInstaller
 		$mockInstaller->expects($this->once())
@@ -816,8 +789,6 @@ class JInstallerAdapterTest extends TestCaseDatabase
 	public function testInstall()
 	{
 		$mockInstaller = $this->getMockBuilder('JInstaller')
-						->setMethods(array('abort'))
-						->getMock();
 
 		// For this test we to ensure abort is not called in JInstaller
 		$mockInstaller->expects($this->never())
@@ -850,9 +821,6 @@ class JInstallerAdapterTest extends TestCaseDatabase
 
 		// Set up a mock JTableExtension
 		$mockTableExtension = $this->getMockBuilder('JTableExtension')
-							->setMethods(array('find', 'load'))
-							->setConstructorArgs(array($this->getMockDatabase()))
-							->getMock();
 		$mockTableExtension->extension_id = 444;
 		TestReflection::setValue($object, 'extension', $mockTableExtension);
 
@@ -894,8 +862,6 @@ class JInstallerAdapterTest extends TestCaseDatabase
 	public function testInstallOnUpdateRoute()
 	{
 		$mockInstaller = $this->getMockBuilder('JInstaller')
-						->setMethods(array('abort'))
-						->getMock();
 
 		// For this test we to ensure abort is not called in JInstaller
 		$mockInstaller->expects($this->never())
@@ -929,9 +895,6 @@ class JInstallerAdapterTest extends TestCaseDatabase
 
 		// Set up a mock JTableExtension
 		$mockTableExtension = $this->getMockBuilder('JTableExtension')
-							->setMethods(array('find', 'load'))
-							->setConstructorArgs(array($this->getMockDatabase()))
-							->getMock();
 		$mockTableExtension->extension_id = 444;
 		TestReflection::setValue($object, 'extension', $mockTableExtension);
 		TestReflection::setValue($object, 'route', 'update');
@@ -978,8 +941,6 @@ class JInstallerAdapterTest extends TestCaseDatabase
 	public function testInstallAbortsWhenSetupUpdatesThrowsException()
 	{
 		$mockInstaller = $this->getMockBuilder('JInstaller')
-						->setMethods(array('abort'))
-						->getMock();
 
 		// For this test we to ensure abort is not called in JInstaller
 		$mockInstaller->expects($this->once())
@@ -1013,9 +974,6 @@ class JInstallerAdapterTest extends TestCaseDatabase
 
 		// Set up a mock JTableExtension
 		$mockTableExtension = $this->getMockBuilder('JTableExtension')
-							->setMethods(array('find', 'load'))
-							->setConstructorArgs(array($this->getMockDatabase()))
-							->getMock();
 		$mockTableExtension->extension_id = 444;
 		TestReflection::setValue($object, 'extension', $mockTableExtension);
 		TestReflection::setValue($object, 'route', 'update');
@@ -1056,8 +1014,6 @@ class JInstallerAdapterTest extends TestCaseDatabase
 	public function testInstallWithNoDescription()
 	{
 		$mockInstaller = $this->getMockBuilder('JInstaller')
-						->setMethods(array('abort'))
-						->getMock();
 
 		// For this test we to ensure abort is not called in JInstaller
 		$mockInstaller->expects($this->never())
@@ -1090,9 +1046,6 @@ class JInstallerAdapterTest extends TestCaseDatabase
 
 		// Set up a mock JTableExtension
 		$mockTableExtension = $this->getMockBuilder('JTableExtension')
-							->setMethods(array('find', 'load'))
-							->setConstructorArgs(array($this->getMockDatabase()))
-							->getMock();
 		$mockTableExtension->extension_id = 444;
 		TestReflection::setValue($object, 'extension', $mockTableExtension);
 
@@ -1157,8 +1110,6 @@ class JInstallerAdapterTest extends TestCaseDatabase
 	public function testInstallWithExceptionThrownInAdapterMethods($method)
 	{
 		$mockInstaller = $this->getMockBuilder('JInstaller')
-						->setMethods(array('abort'))
-						->getMock();
 
 		// For this test we to ensure abort is not called in JInstaller
 		$mockInstaller->expects($this->once())
@@ -1220,8 +1171,6 @@ class JInstallerAdapterTest extends TestCaseDatabase
 	public function testInstallWithExceptionThrownInFinaliseInstall()
 	{
 		$mockInstaller = $this->getMockBuilder('JInstaller')
-						->setMethods(array('abort'))
-						->getMock();
 
 		// For this test we to ensure abort is not called in JInstaller
 		$mockInstaller->expects($this->once())
@@ -1315,8 +1264,6 @@ class JInstallerAdapterTest extends TestCaseDatabase
 		$schema = simplexml_load_string('<extension><update><schemas><schemapath type="mysql">sql/updates/mysql</schemapath></schemas></update></extension>');
 
 		$mockInstaller = $this->getMockBuilder('JInstaller')
-						->setMethods(array('parseSchemaUpdates'))
-						->getMock();
 
 		$mockInstaller->expects($this->once())
 			->method('parseSchemaUpdates')
@@ -1337,9 +1284,6 @@ class JInstallerAdapterTest extends TestCaseDatabase
 
 		// Set up a mock JTableExtension
 		$mockTableExtension = $this->getMockBuilder('JTableExtension')
-							->setMethods(array('find', 'load'))
-							->setConstructorArgs(array($this->getMockDatabase()))
-							->getMock();
 		$mockTableExtension->extension_id = 444;
 		TestReflection::setValue($object, 'extension', $mockTableExtension);
 
@@ -1362,8 +1306,6 @@ class JInstallerAdapterTest extends TestCaseDatabase
 		$schema = simplexml_load_string('<extension><update><schemas><schemapath type="mysql">sql/updates/mysql</schemapath></schemas></update></extension>');
 
 		$mockInstaller = $this->getMockBuilder('JInstaller')
-						->setMethods(array('parseSchemaUpdates'))
-						->getMock();
 		$mockInstaller->expects($this->once())
 			->method('parseSchemaUpdates')
 			->with($schema->update->schemas, 444)
@@ -1383,9 +1325,6 @@ class JInstallerAdapterTest extends TestCaseDatabase
 
 		// Set up a mock JTableExtension
 		$mockTableExtension = $this->getMockBuilder('JTableExtension')
-							->setMethods(array('find', 'load'))
-							->setConstructorArgs(array($this->getMockDatabase()))
-							->getMock();
 		$mockTableExtension->extension_id = 444;
 		TestReflection::setValue($object, 'extension', $mockTableExtension);
 
@@ -1478,15 +1417,11 @@ class JInstallerAdapterTest extends TestCaseDatabase
 	public function testTriggerManifestScriptForMethodsTakingInstallerObjectOnly($method)
 	{
 		$mockInstaller = $this->getMockBuilder('JInstaller')
-						->setMethods(array('set'))
-						->getMock();
 
 		$mockDatabase = $this->getMockDatabase();
 		$object       = $this->getMockForAbstractClass('JInstallerAdapter', array($mockInstaller, $mockDatabase));
 
 		$mockScript   = $this->getMockBuilder('DummyScript')
-						->setMethods(array('preflight', 'postflight', 'install', 'uninstall', 'update'))
-						->getMock();
 
 		$mockScript->expects($this->once())
 			->method($method)
@@ -1524,15 +1459,11 @@ class JInstallerAdapterTest extends TestCaseDatabase
 	public function testTriggerManifestScriptForMethodsTakingInstallerObjectAndRoute($method)
 	{
 		$mockInstaller = $this->getMockBuilder('JInstaller')
-						->setMethods(array('set'))
-						->getMock();
 
 		$mockDatabase = $this->getMockDatabase();
 		$object       = $this->getMockForAbstractClass('JInstallerAdapter', array($mockInstaller, $mockDatabase));
 
 		$mockScript   = $this->getMockBuilder('DummyScript')
-						->setMethods(array('preflight', 'postflight', 'install', 'uninstall', 'update'))
-						->getMock();
 
 		$routeValue = 'update';
 		TestReflection::setValue($object, 'route', $routeValue);
@@ -1558,15 +1489,11 @@ class JInstallerAdapterTest extends TestCaseDatabase
 	public function testTriggerManifestScriptPreflightReturningFalseThrowsException()
 	{
 		$mockInstaller = $this->getMockBuilder('JInstaller')
-						->setMethods(array('set'))
-						->getMock();
 
 		$mockDatabase = $this->getMockDatabase();
 		$object       = $this->getMockForAbstractClass('JInstallerAdapter', array($mockInstaller, $mockDatabase));
 
 		$mockScript   = $this->getMockBuilder('DummyScript')
-						->setMethods(array('preflight', 'postflight', 'install', 'uninstall', 'update'))
-						->getMock();
 
 		$routeValue = 'update';
 		TestReflection::setValue($object, 'route', $routeValue);
@@ -1606,15 +1533,11 @@ class JInstallerAdapterTest extends TestCaseDatabase
 	public function testTriggerManifestScriptInstallOrUpdateReturningFalseThrowsException($method)
 	{
 		$mockInstaller = $this->getMockBuilder('JInstaller')
-						->setMethods(array('set'))
-						->getMock();
 
 		$mockDatabase = $this->getMockDatabase();
 		$object       = $this->getMockForAbstractClass('JInstallerAdapter', array($mockInstaller, $mockDatabase));
 
 		$mockScript   = $this->getMockBuilder('DummyScript')
-						->setMethods(array('preflight', 'postflight', 'install', 'uninstall', 'update'))
-						->getMock();
 
 		TestReflection::setValue($object, 'route', $method);
 
@@ -1636,15 +1559,11 @@ class JInstallerAdapterTest extends TestCaseDatabase
 	public function testTriggerManifestScriptUninstallReturningFalseDoesNotThrowAnException()
 	{
 		$mockInstaller = $this->getMockBuilder('JInstaller')
-						->setMethods(array('set'))
-						->getMock();
 
 		$mockDatabase = $this->getMockDatabase();
 		$object       = $this->getMockForAbstractClass('JInstallerAdapter', array($mockInstaller, $mockDatabase));
 
 		$mockScript   = $this->getMockBuilder('DummyScript')
-						->setMethods(array('preflight', 'postflight', 'install', 'uninstall', 'update'))
-						->getMock();
 
 		TestReflection::setValue($object, 'route', 'uninstall');
 
@@ -1668,15 +1587,11 @@ class JInstallerAdapterTest extends TestCaseDatabase
 	public function testTriggerManifestScriptPostflightReturningFalseDoesNotThrowAnException()
 	{
 		$mockInstaller = $this->getMockBuilder('JInstaller')
-						->setMethods(array('set'))
-						->getMock();
 
 		$mockDatabase = $this->getMockDatabase();
 		$object       = $this->getMockForAbstractClass('JInstallerAdapter', array($mockInstaller, $mockDatabase));
 
 		$mockScript   = $this->getMockBuilder('DummyScript')
-						->setMethods(array('preflight', 'postflight', 'install', 'uninstall', 'update'))
-						->getMock();
 
 		TestReflection::setValue($object, 'route', 'uninstall');
 
@@ -1700,8 +1615,6 @@ class JInstallerAdapterTest extends TestCaseDatabase
 	public function testUpdate()
 	{
 		$mockInstaller = $this->getMockBuilder('JInstaller')
-						->setMethods(array('setOverwrite', 'setUpgrade'))
-						->getMock();
 
 		$mockInstaller->expects($this->once())
 			->method('setUpgrade')

--- a/tests/unit/suites/libraries/cms/installer/JInstallerTest.php
+++ b/tests/unit/suites/libraries/cms/installer/JInstallerTest.php
@@ -196,6 +196,8 @@ class JInstallerTest extends TestCaseDatabase
 	{
 		// Build the mock object.
 		$adapterMock  = $this->getMockBuilder('test')
+			->setMethods(array('_rollback_testtype'))
+			->getMock();
 
 		$adapterMock->expects($this->once())
 			->method('_rollback_testtype')

--- a/tests/unit/suites/libraries/cms/installer/JInstallerTest.php
+++ b/tests/unit/suites/libraries/cms/installer/JInstallerTest.php
@@ -196,8 +196,6 @@ class JInstallerTest extends TestCaseDatabase
 	{
 		// Build the mock object.
 		$adapterMock  = $this->getMockBuilder('test')
-					->setMethods(array('_rollback_testtype'))
-					->getMock();
 
 		$adapterMock->expects($this->once())
 			->method('_rollback_testtype')

--- a/tests/unit/suites/libraries/cms/pagination/JPaginationObjectTest.php
+++ b/tests/unit/suites/libraries/cms/pagination/JPaginationObjectTest.php
@@ -53,11 +53,11 @@ class JPaginationObjectTest extends TestCase
 	 * This is a basic data driven test. It takes the data passed, runs the constructor
 	 * and make sure the appropriate values get setup.
 	 *
-     * @param   string   $text      The link text.
-     * @param   integer  $prefix    The prefix used for request variables.
-     * @param   integer  $base      The number of rows as a base offset.
-     * @param   string   $link      The link URL.
-     * @param   boolean  $active    Flag whether the object is the 'active' page
+	 * @param   string   $text      The link text.
+	 * @param   integer  $prefix    The prefix used for request variables.
+	 * @param   integer  $base      The number of rows as a base offset.
+	 * @param   string   $link      The link URL.
+	 * @param   boolean  $active    Flag whether the object is the 'active' page
 	 * @param   array    $expected  The expected results for the JPagination object
 	 *
 	 * @return  void


### PR DESCRIPTION
Pull Request for Issue code style issues.

### Summary of Changes
- Object operator not indented correctly
- Tabs must be used to indent lines; spaces are not allowed

[Automatically fixed with Joomla code standards 2.0.0 PHPCS2-alpha2 fixers](https://github.com/joomla/coding-standards/releases/tag/2.0.0-alpha2)

None of the manual only fixes have been applied

### Testing Instructions
Merge by code review

### Expected result
code style has been applied as listed above, old code style testing on drone does not error.

### Actual result
code style had not been applied. [Autofixers from the Joomla code standards 2.0.0 PHPCS2 alpha2](https://github.com/joomla/coding-standards/releases/tag/2.0.0-alpha2) were used to implement fixable code style

### Documentation Changes Required
none