### PR TITLE
[CS] Code Style fixes for components/com_config and components/com_tags

### DIFF
--- a/components/com_config/controller/modules/display.php
+++ b/components/com_config/controller/modules/display.php
@@ -15,7 +15,7 @@ defined('_JEXEC') or die;
  * @package     Joomla.Site
  * @subpackage  com_config
  * @since       3.2
-*/
+ */
 class ConfigControllerModulesDisplay extends ConfigControllerDisplay
 {
 	/**

--- a/components/com_config/controller/modules/save.php
+++ b/components/com_config/controller/modules/save.php
@@ -15,7 +15,7 @@ defined('_JEXEC') or die;
  * @package     Joomla.Site
  * @subpackage  com_config
  * @since       3.2
-*/
+ */
 class ConfigControllerModulesSave extends JControllerBase
 {
 	/**

--- a/components/com_tags/router.php
+++ b/components/com_tags/router.php
@@ -163,7 +163,7 @@ class TagsRouter extends JComponentRouterBase
 	 * @return  string  The segment with founded id
 	 *
 	 * @since   3.7
-	*/
+	 */
 	protected function fixSegment($segment)
 	{
 		$db = JFactory::getDbo();


### PR DESCRIPTION
Pull Request for Issue DocBlock Alignments.

### Summary of Changes
- Fix docBlock Alignment

[Automatically fixed with Joomla code standards 2.0.0 PHPCS2-alpha2 fixers](https://github.com/joomla/coding-standards/releases/tag/2.0.0-alpha2)

None of the manual only fixes have been applied

### Testing Instructions
Merge by code review

### Expected result
code style has been applied as listed above, old code style testing on drone does not error.

### Actual result
code style had not been applied. [Autofixers from the Joomla code standards 2.0.0 PHPCS2 alpha2](https://github.com/joomla/coding-standards/releases/tag/2.0.0-alpha2) were used to implement fixable code style

### Documentation Changes Required
none