### PR TITLE
[CS] clone is a Statement Not Function

### DIFF
--- a/administrator/components/com_fields/libraries/fieldslistplugin.php
+++ b/administrator/components/com_fields/libraries/fieldslistplugin.php
@@ -65,7 +65,7 @@ class FieldsListPlugin extends FieldsPlugin
 		$data = array();
 
 		// Fetch the options from the plugin
-		$params = clone($this->params);
+		$params = clone $this->params;
 		$params->merge($field->fieldparams);
 
 		foreach ($params->get('options', array()) as $option)


### PR DESCRIPTION
Pull Request for Issue clone is a Statement Not Function.

### Summary of Changes
- `clone` is a Statement Not a Function; brackets are not required

### Testing Instructions
Code review should be sufficient

### Expected result
unnecessary brackets have been removed

### Actual result
unnecessary brackets had been used but have now been removed

### Documentation Changes Required
none