### PR TITLE
[CS] Code Style fixes for Valid Logical Operators

### DIFF
--- a/components/com_contact/helpers/legacyrouter.php
+++ b/components/com_contact/helpers/legacyrouter.php
@@ -86,14 +86,14 @@ class ContactRouterRulesLegacy implements JComponentRouterRulesInterface
 		}
 
 		// Are we dealing with a contact that is attached to a menu item?
-		if (isset($view) && ($mView == $view) and isset($query['id']) and ($mId == (int) $query['id']))
+		if (isset($view) && ($mView == $view) && isset($query['id']) && ($mId == (int) $query['id']))
 		{
 			unset($query['view'], $query['catid'], $query['id']);
 
 			return;
 		}
 
-		if (isset($view) and ($view == 'category' or $view == 'contact'))
+		if (isset($view) && ($view == 'category' || $view == 'contact'))
 		{
 			if ($mId != (int) $query['id'] || $mView != $view)
 			{

--- a/libraries/src/Form/Rule/UrlRule.php
+++ b/libraries/src/Form/Rule/UrlRule.php
@@ -70,13 +70,13 @@ class UrlRule extends FormRule
 		 * returns False for seriously malformed URLs instead of an associative array.
 		 * @link https://secure.php.net/manual/en/function.parse-url.php
 		 */
-		if ($urlParts === false or !array_key_exists('scheme', $urlParts))
+		if ($urlParts === false || !array_key_exists('scheme', $urlParts))
 		{
 			/*
 			 * The function parse_url() returned false (seriously malformed URL) or no scheme
 			 * was found and the relative option is not set: in both cases the field is not valid.
 			 */
-			if ($urlParts === false or !$element['relative'])
+			if ($urlParts === false || !$element['relative'])
 			{
 				$element->addAttribute('message', \JText::sprintf('JLIB_FORM_VALIDATE_FIELD_URL_SCHEMA_MISSING', $value, implode(', ', $scheme)));
 

--- a/libraries/src/Language/Stemmer/Porteren.php
+++ b/libraries/src/Language/Stemmer/Porteren.php
@@ -95,13 +95,13 @@ class Porteren extends LanguageStemmer
 		if (substr($word, -1) == 's')
 		{
 				self::_replace($word, 'sses', 'ss')
-			or self::_replace($word, 'ies', 'i')
-			or self::_replace($word, 'ss', 'ss')
-			or self::_replace($word, 's', '');
+			|| self::_replace($word, 'ies', 'i')
+			|| self::_replace($word, 'ss', 'ss')
+			|| self::_replace($word, 's', '');
 		}
 
 		// Part b
-		if (substr($word, -2, 1) != 'e' or !self::_replace($word, 'eed', 'ee', 0))
+		if (substr($word, -2, 1) != 'e' || !self::_replace($word, 'eed', 'ee', 0))
 		{
 			// First rule
 			$v = self::$_regex_vowel;
@@ -109,17 +109,17 @@ class Porteren extends LanguageStemmer
 			// Check ing and ed
 			// Note use of && and OR, for precedence reasons
 			if (preg_match("#$v+#", substr($word, 0, -3)) && self::_replace($word, 'ing', '')
-				or preg_match("#$v+#", substr($word, 0, -2)) && self::_replace($word, 'ed', ''))
+				|| preg_match("#$v+#", substr($word, 0, -2)) && self::_replace($word, 'ed', ''))
 			{
 				// If one of above two test successful
-				if (!self::_replace($word, 'at', 'ate') and !self::_replace($word, 'bl', 'ble') and !self::_replace($word, 'iz', 'ize'))
+				if (!self::_replace($word, 'at', 'ate') && !self::_replace($word, 'bl', 'ble') && !self::_replace($word, 'iz', 'ize'))
 				{
 					// Double consonant ending
-					if (self::_doubleConsonant($word) and substr($word, -2) != 'll' and substr($word, -2) != 'ss' and substr($word, -2) != 'zz')
+					if (self::_doubleConsonant($word) && substr($word, -2) != 'll' && substr($word, -2) != 'ss' && substr($word, -2) != 'zz')
 					{
 						$word = substr($word, 0, -1);
 					}
-					elseif (self::_m($word) == 1 and self::_cvc($word))
+					elseif (self::_m($word) == 1 && self::_cvc($word))
 					{
 						$word .= 'e';
 					}
@@ -166,11 +166,11 @@ class Porteren extends LanguageStemmer
 		{
 			case 'a':
 					self::_replace($word, 'ational', 'ate', 0)
-				or self::_replace($word, 'tional', 'tion', 0);
+				|| self::_replace($word, 'tional', 'tion', 0);
 				break;
 			case 'c':
 					self::_replace($word, 'enci', 'ence', 0)
-				or self::_replace($word, 'anci', 'ance', 0);
+				|| self::_replace($word, 'anci', 'ance', 0);
 				break;
 			case 'e':
 				self::_replace($word, 'izer', 'ize', 0);
@@ -180,26 +180,26 @@ class Porteren extends LanguageStemmer
 				break;
 			case 'l':
 					self::_replace($word, 'entli', 'ent', 0)
-				or self::_replace($word, 'ousli', 'ous', 0)
-				or self::_replace($word, 'alli', 'al', 0)
-				or self::_replace($word, 'bli', 'ble', 0)
-				or self::_replace($word, 'eli', 'e', 0);
+				|| self::_replace($word, 'ousli', 'ous', 0)
+				|| self::_replace($word, 'alli', 'al', 0)
+				|| self::_replace($word, 'bli', 'ble', 0)
+				|| self::_replace($word, 'eli', 'e', 0);
 				break;
 			case 'o':
 					self::_replace($word, 'ization', 'ize', 0)
-				or self::_replace($word, 'ation', 'ate', 0)
-				or self::_replace($word, 'ator', 'ate', 0);
+				|| self::_replace($word, 'ation', 'ate', 0)
+				|| self::_replace($word, 'ator', 'ate', 0);
 				break;
 			case 's':
 					self::_replace($word, 'iveness', 'ive', 0)
-				or self::_replace($word, 'fulness', 'ful', 0)
-				or self::_replace($word, 'ousness', 'ous', 0)
-				or self::_replace($word, 'alism', 'al', 0);
+				|| self::_replace($word, 'fulness', 'ful', 0)
+				|| self::_replace($word, 'ousness', 'ous', 0)
+				|| self::_replace($word, 'alism', 'al', 0);
 				break;
 			case 't':
 					self::_replace($word, 'biliti', 'ble', 0)
-				or self::_replace($word, 'aliti', 'al', 0)
-				or self::_replace($word, 'iviti', 'ive', 0);
+				|| self::_replace($word, 'aliti', 'al', 0)
+				|| self::_replace($word, 'iviti', 'ive', 0);
 				break;
 		}
 
@@ -227,7 +227,7 @@ class Porteren extends LanguageStemmer
 				break;
 			case 't':
 					self::_replace($word, 'icate', 'ic', 0)
-				or self::_replace($word, 'iciti', 'ic', 0);
+				|| self::_replace($word, 'iciti', 'ic', 0);
 				break;
 			case 'u':
 				self::_replace($word, 'ful', '', 0);
@@ -261,7 +261,7 @@ class Porteren extends LanguageStemmer
 				break;
 			case 'c':
 					self::_replace($word, 'ance', '', 1)
-				or self::_replace($word, 'ence', '', 1);
+				|| self::_replace($word, 'ence', '', 1);
 				break;
 			case 'e':
 				self::_replace($word, 'er', '', 1);
@@ -271,16 +271,16 @@ class Porteren extends LanguageStemmer
 				break;
 			case 'l':
 					self::_replace($word, 'able', '', 1)
-				or self::_replace($word, 'ible', '', 1);
+				|| self::_replace($word, 'ible', '', 1);
 				break;
 			case 'n':
 					self::_replace($word, 'ant', '', 1)
-				or self::_replace($word, 'ement', '', 1)
-				or self::_replace($word, 'ment', '', 1)
-				or self::_replace($word, 'ent', '', 1);
+				|| self::_replace($word, 'ement', '', 1)
+				|| self::_replace($word, 'ment', '', 1)
+				|| self::_replace($word, 'ent', '', 1);
 				break;
 			case 'o':
-				if (substr($word, -4) == 'tion' or substr($word, -4) == 'sion')
+				if (substr($word, -4) == 'tion' || substr($word, -4) == 'sion')
 				{
 					self::_replace($word, 'ion', '', 1);
 				}
@@ -294,7 +294,7 @@ class Porteren extends LanguageStemmer
 				break;
 			case 't':
 					self::_replace($word, 'ate', '', 1)
-				or self::_replace($word, 'iti', '', 1);
+				|| self::_replace($word, 'iti', '', 1);
 				break;
 			case 'u':
 				self::_replace($word, 'ous', '', 1);
@@ -338,7 +338,7 @@ class Porteren extends LanguageStemmer
 		}
 
 		// Part b
-		if (self::_m($word) > 1 and self::_doubleConsonant($word) and substr($word, -1) == 'l')
+		if (self::_m($word) > 1 && self::_doubleConsonant($word) && substr($word, -1) == 'l')
 		{
 			$word = substr($word, 0, -1);
 		}
@@ -369,7 +369,7 @@ class Porteren extends LanguageStemmer
 		{
 			$substr = substr($str, 0, $len);
 
-			if (is_null($m) or self::_m($substr) > $m)
+			if (is_null($m) || self::_m($substr) > $m)
 			{
 				$str = $substr . $repl;
 			}
@@ -423,7 +423,7 @@ class Porteren extends LanguageStemmer
 	{
 		$c = self::$_regex_consonant;
 
-		return preg_match("#$c{2}$#", $str, $matches) and $matches[0]{0} == $matches[0]{1};
+		return preg_match("#$c{2}$#", $str, $matches) && $matches[0]{0} == $matches[0]{1};
 	}
 
 	/**
@@ -441,10 +441,10 @@ class Porteren extends LanguageStemmer
 		$v = self::$_regex_vowel;
 
 		$result = preg_match("#($c$v$c)$#", $str, $matches)
-			and strlen($matches[1]) == 3
-			and $matches[1]{2} != 'w'
-			and $matches[1]{2} != 'x'
-			and $matches[1]{2} != 'y';
+			&& strlen($matches[1]) == 3
+			&& $matches[1]{2} != 'w'
+			&& $matches[1]{2} != 'x'
+			&& $matches[1]{2} != 'y';
 
 		return $result;
 	}


### PR DESCRIPTION
Pull Request for Issue use Valid Logical Operators

### Summary of Changes
- Logical operator `and` not allowed; use `&&` instead
- Logical operator `or` not allowed; use `||` instead

[Automatically fixed with Joomla code standards 2.0.0 PHPCS2-alpha2 fixers](https://github.com/joomla/coding-standards/releases/tag/2.0.0-alpha2)

None of the manual only fixes have been applied

### Testing Instructions
Merge by code review

### Expected result
code style has been applied as listed above, old code style testing on drone does not error.

### Actual result
code style had not been applied. [Autofixers from the Joomla code standards 2.0.0 PHPCS2 alpha2](https://github.com/joomla/coding-standards/releases/tag/2.0.0-alpha2) were used to implement fixable code style

### Documentation Changes Required
none