### PR TITLE
[CS] Code Style fixes for Superfluous Whitespace

### DIFF
--- a/administrator/components/com_associations/models/fields/itemtype.php
+++ b/administrator/components/com_associations/models/fields/itemtype.php
@@ -26,7 +26,7 @@ class JFormFieldItemType extends JFormFieldGroupedList
 	 * @since  3.7.0
 	 */
 	protected $type = 'ItemType';
-	
+
 	/**
 	 * Method to get the field input markup.
 	 *

--- a/administrator/components/com_config/model/application.php
+++ b/administrator/components/com_config/model/application.php
@@ -659,7 +659,6 @@ class ConfigModelApplication extends ConfigModelForm
 			return false;
 		}
 
-
 		// All checks done.
 		$result = array(
 			'text'    => '',

--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -363,7 +363,6 @@ class JoomlaupdateModelDefault extends JModelLegacy
 			return false;
 		}
 
-
 		if (!$result || ($result->code != 200 && $result->code != 310))
 		{
 			return false;

--- a/administrator/components/com_joomlaupdate/restore.php
+++ b/administrator/components/com_joomlaupdate/restore.php
@@ -958,6 +958,7 @@ abstract class AKAbstractUnarchiver extends AKAbstractPart
 							}
 						}
 
+
 						break;
 
 					// Should I restore permissions?
@@ -4632,6 +4633,7 @@ class AKUnarchiverZIP extends AKUnarchiverJPA
 		}
 
 		debugMsg('*' . ftell($this->fp) . ' IS START OF ' . $this->fileHeader->file . ' (' . $this->fileHeader->compressed . ' bytes)');
+
 
 		// Decide filetype -- Check for directories
 		$this->fileHeader->type = 'file';

--- a/administrator/components/com_joomlaupdate/restore.php
+++ b/administrator/components/com_joomlaupdate/restore.php
@@ -958,7 +958,6 @@ abstract class AKAbstractUnarchiver extends AKAbstractPart
 							}
 						}
 
-
 						break;
 
 					// Should I restore permissions?
@@ -4633,7 +4632,6 @@ class AKUnarchiverZIP extends AKUnarchiverJPA
 		}
 
 		debugMsg('*' . ftell($this->fp) . ' IS START OF ' . $this->fileHeader->file . ' (' . $this->fileHeader->compressed . ' bytes)');
-
 
 		// Decide filetype -- Check for directories
 		$this->fileHeader->type = 'file';

--- a/components/com_config/model/templates.php
+++ b/components/com_config/model/templates.php
@@ -20,7 +20,7 @@ class ConfigModelTemplates extends ConfigModelForm
 	 * Method to auto-populate the model state.
 	 *
 	 * Note. Calling getState in this method will result in recursion.
-	 * 
+	 *
 	 * @return  null
 	 *
 	 * @since   3.2

--- a/components/com_content/helpers/query.php
+++ b/components/com_content/helpers/query.php
@@ -195,7 +195,7 @@ class ContentHelperQuery
 	 * @param   \Joomla\Registry\Registry  $params  An options object for the article.
 	 *
 	 * @return  array  A named array with "select" and "join" keys.
-	 * 
+	 *
 	 * @since   1.5
 	 */
 	public static function buildVotingQuery($params = null)

--- a/components/com_content/models/archive.php
+++ b/components/com_content/models/archive.php
@@ -194,7 +194,7 @@ class ContentModelArchive extends ContentModelArticles
 	 * Gets the archived articles years
 	 *
 	 * @return   array
-	 * 
+	 *
 	 * @since    3.6.0
 	 */
 	public function getYears()

--- a/components/com_content/views/category/view.feed.php
+++ b/components/com_content/views/category/view.feed.php
@@ -47,7 +47,7 @@ class ContentViewCategory extends JViewCategoryfeed
 			$item->description = '<p><img src="' . $image . '" /></p>';
 		}
 
-		$item->description .= ($params->get('feed_summary', 0) ? $item->introtext . $item->fulltext : $item->introtext);         
+		$item->description .= ($params->get('feed_summary', 0) ? $item->introtext . $item->fulltext : $item->introtext);
 
 		// Add readmore link to description if introtext is shown, show_readmore is true and fulltext exists
 		if (!$item->params->get('feed_summary', 0) && $item->params->get('feed_show_readmore', 0) && $item->fulltext)

--- a/components/com_content/views/featured/view.html.php
+++ b/components/com_content/views/featured/view.html.php
@@ -31,7 +31,7 @@ class ContentViewFeatured extends JViewLegacy
 	protected $link_items = array();
 
 	protected $columns = 1;
-	
+
 	/**
 	 * An instance of JDatabaseDriver.
 	 *

--- a/components/com_mailto/views/mailto/view.html.php
+++ b/components/com_mailto/views/mailto/view.html.php
@@ -11,7 +11,7 @@ defined('_JEXEC') or die;
 
 /**
  * Class for Mail.
- * 
+ *
  * @since  1.5
  */
 class MailtoViewMailto extends JViewLegacy

--- a/components/com_wrapper/views/wrapper/view.html.php
+++ b/components/com_wrapper/views/wrapper/view.html.php
@@ -11,7 +11,7 @@ defined('_JEXEC') or die;
 
 /**
  * Wrapper view class.
- * 
+ *
  * @since  1.5
  */
 class WrapperViewWrapper extends JViewLegacy


### PR DESCRIPTION
Pull Request for Issue found Superfluous Whitespace.

### Summary of Changes
- Whitespace found at end of line
- Functions must not contain multiple empty lines in a row; found 2 empty lines

[Automatically fixed with Joomla code standards 2.0.0 PHPCS2-alpha2 fixers](https://github.com/joomla/coding-standards/releases/tag/2.0.0-alpha2)

None of the manual only fixes have been applied

### Testing Instructions
Merge by code review

### Expected result
code style has been applied as listed above, old code style testing on drone does not error.

### Actual result
code style had not been applied. [Autofixers from the Joomla code standards 2.0.0 PHPCS2 alpha2](https://github.com/joomla/coding-standards/releases/tag/2.0.0-alpha2) were used to implement fixable code style

### Documentation Changes Required
none