### PR TITLE
[CS] Round 2 Code Style fixes for Superfluous Whitespace

### DIFF
--- a/installation/model/database.php
+++ b/installation/model/database.php
@@ -177,7 +177,7 @@ class InstallationModelDatabase extends JModelBase
 		if ($shouldCheckLocalhost && !in_array($options->db_host, $localhost))
 		{
 			$remoteDbFileTestsPassed = JFactory::getSession()->get('remoteDbFileTestsPassed', false);
-			
+
 			// When all checks have been passed we don't need to do this here again.
 			if ($remoteDbFileTestsPassed === false)
 			{
@@ -238,7 +238,7 @@ class InstallationModelDatabase extends JModelBase
 				{
 					// Add the general message
 					JFactory::getApplication()->enqueueMessage($generalRemoteDatabaseMessage, 'warning');
-					
+
 					JFactory::getApplication()->enqueueMessage(
 						JText::sprintf(
 							'INSTL_DATABASE_HOST_IS_NOT_LOCALHOST_DELETE_FILE',

--- a/libraries/cms/html/adminlanguage.php
+++ b/libraries/cms/html/adminlanguage.php
@@ -45,9 +45,9 @@ abstract class JHtmlAdminLanguage
 			{
 				$languages[$tag] = $language['nativeName'];
 			}
-			
+
 			ksort($languages);
-			
+
 			static::$items = $languages;
 		}
 

--- a/libraries/cms/html/category.php
+++ b/libraries/cms/html/category.php
@@ -55,7 +55,7 @@ abstract class JHtmlCategory
 
 			// Filter on extension.
 			$query->where('extension = ' . $db->quote($extension));
-			
+
 			// Filter on user access level
 			$query->where('a.access IN (' . $groups . ')');
 
@@ -160,7 +160,7 @@ abstract class JHtmlCategory
 
 			// Filter on extension.
 			$query->where('extension = ' . $db->quote($extension));
-			
+
 			// Filter on user level.
 			$groups = implode(',', $user->getAuthorisedViewLevels());
 			$query->where('a.access IN (' . $groups . ')');

--- a/libraries/src/Form/Rule/UrlRule.php
+++ b/libraries/src/Form/Rule/UrlRule.php
@@ -56,7 +56,7 @@ class UrlRule extends FormRule
 		// Use the full list or optionally specify a list of permitted schemes.
 		if ($element['schemes'] == '')
 		{
-			$scheme = array('http', 'https', 'ftp', 'ftps', 'gopher', 'mailto', 'news', 'prospero', 'telnet', 'rlogin', 'sftp', 'tn3270', 'wais', 
+			$scheme = array('http', 'https', 'ftp', 'ftps', 'gopher', 'mailto', 'news', 'prospero', 'telnet', 'rlogin', 'sftp', 'tn3270', 'wais',
 				'mid', 'cid', 'nntp', 'tel', 'urn', 'ldap', 'file', 'fax', 'modem', 'git');
 		}
 		else

--- a/libraries/src/Toolbar/Button/ConfirmButton.php
+++ b/libraries/src/Toolbar/Button/ConfirmButton.php
@@ -99,7 +99,7 @@ class ConfirmButton extends ToolbarButton
 		{
 			$alert = "alert(Joomla.JText._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST'));";
 			$cmd   = "if (document.adminForm.boxchecked.value == 0) { " . $alert . " } else { " . $cmd . " }";
-			
+
 		}
 
 		return $cmd;

--- a/libraries/src/Toolbar/Button/ConfirmButton.php
+++ b/libraries/src/Toolbar/Button/ConfirmButton.php
@@ -99,7 +99,6 @@ class ConfirmButton extends ToolbarButton
 		{
 			$alert = "alert(Joomla.JText._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST'));";
 			$cmd   = "if (document.adminForm.boxchecked.value == 0) { " . $alert . " } else { " . $cmd . " }";
-
 		}
 
 		return $cmd;

--- a/plugins/content/fields/fields.php
+++ b/plugins/content/fields/fields.php
@@ -119,7 +119,6 @@ class PlgContentFields extends JPlugin
 			$layout  = !empty($explode[1]) ? trim($explode[1]) : 'render';
 			$output  = '';
 
-
 			if ($match[1] == 'field' && $id)
 			{
 				if (isset($fieldsById[$id]))

--- a/plugins/content/pagebreak/pagebreak.php
+++ b/plugins/content/pagebreak/pagebreak.php
@@ -80,7 +80,7 @@ class PlgContentPagebreak extends JPlugin
 			{
 				throw new Exception(JText::_('JERROR_PAGE_NOT_FOUND'), 404);
 			}
-			
+
 			return true;
 		}
 

--- a/plugins/system/log/log.php
+++ b/plugins/system/log/log.php
@@ -60,7 +60,7 @@ class PlgSystemLog extends JPlugin
 		{
 			JLog::add($errorlog['comment'], JLog::INFO, $errorlog['status']);
 		}
-		catch (Exception $e) 
+		catch (Exception $e)
 		{
 			// If the log file is unwriteable during login then we should not go to the error page
 			return;

--- a/plugins/system/sef/sef.php
+++ b/plugins/system/sef/sef.php
@@ -128,11 +128,11 @@ class PlgSystemSef extends JPlugin
 				$this->checkBuffer($buffer);
 			}
 		}
-		
-		if (strpos($buffer, 'srcset=') !== false) 
+
+		if (strpos($buffer, 'srcset=') !== false)
 		{
 			$regex = '#\s+srcset="([^"]+)"#m';
-			
+
 			$buffer = preg_replace_callback(
 				$regex,
 				function ($match) use ($base, $protocols)
@@ -147,7 +147,7 @@ class PlgSystemSef extends JPlugin
 					return ' srcset="' . implode($matches[0]) . '"';
 				},
 				$buffer
-			);	
+			);
 
 			$this->checkBuffer($buffer);
 		}

--- a/plugins/system/updatenotification/postinstall/updatecachetime.php
+++ b/plugins/system/updatenotification/postinstall/updatecachetime.php
@@ -40,7 +40,7 @@ function updatecachetime_postinstall_action()
 
 	// Sets the cachtimeout back to the default (6 hours)
 	$installer->params->set('cachetimeout', 6);
-	
+
 	// Save the new parameters back to com_installer
 	$table = JTable::getInstance('extension');
 	$table->load($installer->id);


### PR DESCRIPTION
Pull Request for Issue found Superfluous Whitespace.

### Summary of Changes
Second round of fixes for Superfluous Whitespace
- Whitespace found at end of line
- Functions must not contain multiple empty lines in a row; found 2 empty lines

[Automatically fixed with Joomla code standards 2.0.0 PHPCS2-alpha2 fixers](https://github.com/joomla/coding-standards/releases/tag/2.0.0-alpha2)

None of the manual only fixes have been applied

### Testing Instructions
Merge by code review

### Expected result
code style has been applied as listed above, old code style testing on drone does not error.

### Actual result
code style had not been applied. [Autofixers from the Joomla code standards 2.0.0 PHPCS2 alpha2](https://github.com/joomla/coding-standards/releases/tag/2.0.0-alpha2) were used to implement fixable code style

### Documentation Changes Required
none