### PR TITLE
[CS] Round 3 Code Style fixes for Superfluous Whitespace

### DIFF
--- a/tests/unit/suites/libraries/cms/component/router/rules/stubs/MockJComponentRouterRulesMenuMenuObject.php
+++ b/tests/unit/suites/libraries/cms/component/router/rules/stubs/MockJComponentRouterRulesMenuMenuObject.php
@@ -112,7 +112,6 @@ class MockJComponentRouterRulesMenuMenuObject
 			'parent_id'    => '0',
 			'query'        => array('option' => 'com_content', 'view' => 'featured'));
 
-
 		$this->items[52] = (object) array(
 			'id'           => '52',
 			'menutype'     => 'testmenu',

--- a/tests/unit/suites/libraries/cms/plugin/JPluginHelperTest.php
+++ b/tests/unit/suites/libraries/cms/plugin/JPluginHelperTest.php
@@ -99,7 +99,7 @@ class JPluginHelperTest extends TestCaseDatabase
 			'plg_content_loadmodule should return loadmodule as the name'
 		);
 	}
-	
+
 	/**
 	 * Test JPluginHelper::getPlugin with a whole plugin group
 	 *

--- a/tests/unit/suites/libraries/cms/plugin/JPluginTest.php
+++ b/tests/unit/suites/libraries/cms/plugin/JPluginTest.php
@@ -47,7 +47,7 @@ class JPluginTest extends TestCase
 	protected function tearDown()
 	{
 		$this->restoreFactoryState();
-	
+
 		parent::tearDown();
 	}
 

--- a/tests/unit/suites/libraries/legacy/view/JViewLegacyTest.php
+++ b/tests/unit/suites/libraries/legacy/view/JViewLegacyTest.php
@@ -55,7 +55,7 @@ class JViewLegacyTest extends TestCase
 
 	/**
 	 * $_SERVER variable
-	 * 
+	 *
 	 * @var   array
 	 */
 	protected $server;


### PR DESCRIPTION
Pull Request for Issue found Superfluous Whitespace.

### Summary of Changes
Third and final round of fixes for Superfluous Whitespace
- Whitespace found at end of line
- Functions must not contain multiple empty lines in a row; found 2 empty lines

[Automatically fixed with Joomla code standards 2.0.0 PHPCS2-alpha2 fixers](https://github.com/joomla/coding-standards/releases/tag/2.0.0-alpha2)

None of the manual only fixes have been applied

### Testing Instructions
Merge by code review

### Expected result
code style has been applied as listed above, old code style testing on drone does not error.

### Actual result
code style had not been applied. [Autofixers from the Joomla code standards 2.0.0 PHPCS2 alpha2](https://github.com/joomla/coding-standards/releases/tag/2.0.0-alpha2) were used to implement fixable code style

### Documentation Changes Required
none