### PR TITLE
Decrease the frequency of session metadata cleanup and where in the request cycle it occurs

### DIFF
--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -150,6 +150,42 @@ class CMSApplication extends WebApplication
 			$session->set('registry', new Registry);
 			$session->set('user', new \JUser);
 		}
+
+		// Get the session handler from the configuration.
+		$handler = $this->get('session_handler', 'none');
+
+		$time = time();
+
+		// If the database session handler is not in use and the current time is a divisor of 5, purge session metadata after the response is sent
+		if ($handler !== 'database' && $time % 5 === 0)
+		{
+			$this->registerEvent(
+				'onAfterResponse',
+				function () use ($session, $time)
+				{
+					// TODO: At some point we need to get away from having session data always in the db.
+					$db = \JFactory::getDbo();
+
+					$query = $db->getQuery(true)
+						->delete($db->quoteName('#__session'))
+						->where($db->quoteName('time') . ' < ' . $db->quote((int) ($time - $session->getExpire())));
+
+					$db->setQuery($query);
+
+					try
+					{
+						$db->execute();
+					}
+					catch (\JDatabaseExceptionExecuting $exception)
+					{
+						/*
+						 * The database API logs errors on failures so we don't need to add any error handling mechanisms here.
+						 * Since garbage collection does not result in a fatal error when run in the session API, we don't allow it here either.
+						 */
+					}
+				}
+			);
+		}
 	}
 
 	/**
@@ -806,29 +842,16 @@ class CMSApplication extends WebApplication
 
 		$session->initialise($this->input, $this->dispatcher);
 
-		// TODO: At some point we need to get away from having session data always in the db.
-		$db = \JFactory::getDbo();
-
-		// Remove expired sessions from the database.
-		$time = time();
-
-		if ($time % 2)
-		{
-			// The modulus introduces a little entropy, making the flushing less accurate
-			// but fires the query less than half the time.
-			$query = $db->getQuery(true)
-				->delete($db->quoteName('#__session'))
-				->where($db->quoteName('time') . ' < ' . $db->quote((int) ($time - $session->getExpire())));
-
-			$db->setQuery($query);
-			$db->execute();
-		}
-
 		// Get the session handler from the configuration.
 		$handler = $this->get('session_handler', 'none');
 
-		if (($handler !== 'database' && ($time % 2 || $session->isNew()))
-			|| ($handler === 'database' && $session->isNew()))
+		/*
+		 * Check for extra session metadata when:
+		 *
+		 * 1) The database handler is in use and the session is new
+		 * 2) The database handler is not in use and the time is an even numbered second or the session is new
+		 */
+		if (($handler !== 'database' && (time() % 2 || $session->isNew())) || ($handler === 'database' && $session->isNew()))
 		{
 			$this->checkSession();
 		}


### PR DESCRIPTION
Pull Request for Issue #19146 .

### Summary of Changes

Presently, we write metadata about the session to the database regardless of the handler in use, and we purge expired metadata when a request happens on an even numbered second.  This results in a high number of `DELETE FROM #__session...` queries for no good reason.

This PR tries to make this cleanup operation less frequent AND defers it to the end of the request cycle versus the beginning of it.  To do so, an event listener is dynamically registered during the `onAfterSessionStart` event that checks if the request is occurring on a second that is a divisor of five and the session handler in use is NOT the database handler.  If these conditions are met, then the cleanup query will be run.

Practical changes:

- Expired session cleanup when the database handler is in use will be deferred to when PHP natively runs the session cleanup operation, this may result in some sessions living in the database longer than they do now but this will not cause a side effect of allowing an expired session to be resumed
- The metadata cleanup drops in frequency from once every 2 seconds to once every 5 seconds at a minimum (of course this is also dependent on your site's traffic, for higher traffic sites this can be a big deal)
- The metadata cleanup is deferred from the beginning of the request cycle to the end of it

### Testing Instructions

Sessions should continue to function as they presently do.  Note that the frequency of when expired sessions are purged from the database will be reliant on the PHP configuration now versus an arbitrary once every 2 second code check when the database handler is in use (this basically means the expired session won't be immediately removed, at worst this can affect the list of logged in users shown in various modules).  When a non-database session handler is in use (i.e. the "PHP" option using the filesystem), the session metadata is cleared from the database once every five seconds at a minimum (since this is now in a lambda function happening after the response is sent, you'll probably need to add a `JLog::add()` statement to actually verify the lambda is triggered as a poor man's `var_dump($foo);die;` won't really do much here).