### PR TITLE
[CS] copyright tag comment indented incorrectly

### DIFF
--- a/libraries/src/Language/Stemmer/Porteren.php
+++ b/libraries/src/Language/Stemmer/Porteren.php
@@ -3,7 +3,7 @@
  * Joomla! Content Management System
  *
  * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
- * @copyright   Copyright (C) 2005 Richard Heyes (http://www.phpguru.org/). All rights reserved.
+ * @copyright  Copyright (C) 2005 Richard Heyes (http://www.phpguru.org/). All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
 


### PR DESCRIPTION
Pull Request for Issue copyright tag comment indented incorrectly reported in drone

### Summary of Changes
- copyright tag comment indented incorrectly
Fixes extra space introduced in fe0224208078651ff8859d94be3c3976e2ac5835

### Testing Instructions
Code review should be sufficient

### Expected result
unnecessary space indent has been removed

### Actual result
@copyright tag comment indented incorrectly but now is correctly indented

### Documentation Changes Required
none

//cc @wilsonge @rdeutz This fixes a drone CS report