### PR TITLE
[4.0] Fix Subhead buttons does not display properly on scroll.

### DIFF
--- a/administrator/modules/mod_menu/tmpl/default.php
+++ b/administrator/modules/mod_menu/tmpl/default.php
@@ -10,9 +10,6 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Helper\ModuleHelper;
-use Joomla\CMS\HTML\HTMLHelper;
-
-HTMLHelper::_('script', 'mod_menu/admin-menu.min.js', ['version' => 'auto', 'relative' => true], ['defer' => true]);
 
 $doc       = \Joomla\CMS\Factory::getDocument();
 $direction = $doc->direction == 'rtl' ? 'float-right' : '';

--- a/administrator/templates/atum/index.php
+++ b/administrator/templates/atum/index.php
@@ -36,6 +36,7 @@ $logoSm      = $this->baseurl . '/templates/' . $this->template . '/images/logo-
 HTMLHelper::_('bootstrap.framework');
 HTMLHelper::_('script', 'media/vendor/flying-focus-a11y/js/flying-focus.min.js', ['version' => 'auto']);
 HTMLHelper::_('script', 'template.js', ['version' => 'auto', 'relative' => true], ['defer' => true]);
+HTMLHelper::_('script', 'mod_menu/admin-menu.min.js', ['version' => 'auto', 'relative' => true], ['defer' => true]);
 
 // Load template CSS file
 HTMLHelper::_('stylesheet', 'bootstrap.min.css', ['version' => 'auto', 'relative' => true]);

--- a/administrator/templates/atum/index.php
+++ b/administrator/templates/atum/index.php
@@ -36,7 +36,6 @@ $logoSm      = $this->baseurl . '/templates/' . $this->template . '/images/logo-
 HTMLHelper::_('bootstrap.framework');
 HTMLHelper::_('script', 'media/vendor/flying-focus-a11y/js/flying-focus.min.js', ['version' => 'auto']);
 HTMLHelper::_('script', 'template.js', ['version' => 'auto', 'relative' => true], ['defer' => true]);
-HTMLHelper::_('script', 'mod_menu/admin-menu.min.js', ['version' => 'auto', 'relative' => true], ['defer' => true]);
 
 // Load template CSS file
 HTMLHelper::_('stylesheet', 'bootstrap.min.css', ['version' => 'auto', 'relative' => true]);


### PR DESCRIPTION
### Issue

This issue present where <code>subhead button</code>is used. Subhead buttons do not display properly on a scroll. You can check any of them.

Like: Try to open page to write a new article then scroll down. 
You can check <code>save and cancel button</code>, not align properly. 

### Summary of Changes
Changes in :
<code>administrator/modules/mod_menu/tmpl/default.php</code>
and
<code>administrator/templates/atum/index.php</code>

Adding of javascript file changed from <code>default to index</code>


### Testing Instructions
 
Step1: Try to open page to write a new article then scroll down. 

### Expected result

Buttons Align properly

![aa](https://user-images.githubusercontent.com/30978328/34340631-c225650a-e9ad-11e7-904b-b3e1a9c88fbb.PNG)


### Actual result
Buttons not align properly.

![aaa](https://user-images.githubusercontent.com/30978328/34340633-c967e928-e9ad-11e7-87db-011a4a0eadba.PNG)


