### PR TITLE
[CS] "clone" is a statement not a function

### DIFF
--- a/administrator/components/com_content/views/article/tmpl/edit.php
+++ b/administrator/components/com_content/views/article/tmpl/edit.php
@@ -24,7 +24,7 @@ $this->hiddenFieldsets  = array('basic-limited');
 $this->ignore_fieldsets = array('jmetadata', 'item_associations');
 
 // Create shortcut to parameters.
-$params = clone($this->state->get('params'));
+$params = clone $this->state->get('params');
 $params->merge(new Registry($this->item->attribs));
 
 $app = JFactory::getApplication();


### PR DESCRIPTION
Pull Request for Issue "clone" is a statement not a function; no parentheses are required .

### Summary of Changes
- removed  parentheses from clone


### Testing Instructions
Code review should be sufficient 


### Expected result
no parentheses are required. 


### Actual result
parentheses removed  from clone


### Documentation Changes Required
none
