### PR TITLE
[CS] Code Style fixes for administrator/components,modules,templates

### DIFF
--- a/administrator/components/com_associations/helpers/associations.php
+++ b/administrator/components/com_associations/helpers/associations.php
@@ -285,6 +285,7 @@ class AssociationsHelper extends JHelperContent
 		}
 
 		JHtml::_('bootstrap.popover');
+
 		return JLayoutHelper::render('joomla.content.associations', $items);
 	}
 
@@ -467,7 +468,7 @@ class AssociationsHelper extends JHelperContent
 		}
 
 		// Get the extension specific helper method
-		$helper= self::getExtensionHelper($extensionName);
+		$helper = self::getExtensionHelper($extensionName);
 
 		if (method_exists($helper, 'allowEdit'))
 		{
@@ -495,7 +496,7 @@ class AssociationsHelper extends JHelperContent
 		}
 
 		// Get the extension specific helper method
-		$helper= self::getExtensionHelper($extensionName);
+		$helper = self::getExtensionHelper($extensionName);
 
 		if (method_exists($helper, 'allowAdd'))
 		{

--- a/administrator/components/com_associations/views/associations/view.html.php
+++ b/administrator/components/com_associations/views/associations/view.html.php
@@ -129,21 +129,25 @@ class AssociationsViewAssociations extends JViewLegacy
 					unset($this->activeFilters['state']);
 					$this->filterForm->removeField('state', 'filter');
 				}
+
 				if (empty($support['category']))
 				{
 					unset($this->activeFilters['category_id']);
 					$this->filterForm->removeField('category_id', 'filter');
 				}
+
 				if ($extensionName !== 'com_menus')
 				{
 					unset($this->activeFilters['menutype']);
 					$this->filterForm->removeField('menutype', 'filter');
 				}
+
 				if (empty($support['level']))
 				{
 					unset($this->activeFilters['level']);
 					$this->filterForm->removeField('level', 'filter');
 				}
+
 				if (empty($support['acl']))
 				{
 					unset($this->activeFilters['access']);
@@ -222,6 +226,7 @@ class AssociationsViewAssociations extends JViewLegacy
 				JToolbarHelper::custom('associations.purge', 'purge', 'purge', 'COM_ASSOCIATIONS_PURGE', false, false);
 				JToolbarHelper::custom('associations.clean', 'refresh', 'refresh', 'COM_ASSOCIATIONS_DELETE_ORPHANS', false, false);
 			}
+
 			JToolbarHelper::preferences('com_associations');
 		}
 

--- a/administrator/components/com_categories/models/fields/categoryedit.php
+++ b/administrator/components/com_categories/models/fields/categoryedit.php
@@ -174,6 +174,7 @@ class JFormFieldCategoryEdit extends JFormFieldList
 			{
 				$language = $db->quote($this->element['language']);
 			}
+
 			$query->where($db->quoteName('a.language') . ' IN (' . $language . ')');
 		}
 

--- a/administrator/components/com_contact/helpers/contact.php
+++ b/administrator/components/com_contact/helpers/contact.php
@@ -123,15 +123,19 @@ class ContactHelper extends JHelperContent
 		$db = JFactory::getDbo();
 		$parts     = explode('.', $extension);
 		$section   = null;
+
 		if (count($parts) > 1)
 		{
 			$section = $parts[1];
 		}
+
 		$join = $db->qn('#__contact_details') . ' AS c ON ct.content_item_id=c.id';
+
 		if ($section === 'category')
 		{
 			$join = $db->qn('#__categories') . ' AS c ON ct.content_item_id=c.id';
 		}
+
 		foreach ($items as $item)
 		{
 			$item->count_trashed = 0;

--- a/administrator/components/com_content/helpers/associations.php
+++ b/administrator/components/com_content/helpers/associations.php
@@ -141,7 +141,6 @@ class ContentAssociationsHelper extends AssociationExtensionHelper
 
 		if (in_array($typeName, $this->itemTypes))
 		{
-
 			switch ($typeName)
 			{
 				case 'article':

--- a/administrator/components/com_content/models/articles.php
+++ b/administrator/components/com_content/models/articles.php
@@ -235,6 +235,7 @@ class ContentModelArticles extends JModelList
 
 		// Filter by access level.
 		$access = $this->getState('filter.access');
+
 		if (is_numeric($access))
 		{
 			$query->where('a.access = ' . (int) $access);
@@ -356,6 +357,7 @@ class ContentModelArticles extends JModelList
 		{
 			$tagId = ArrayHelper::toInteger($tagId);
 			$tagId = implode(',', $tagId);
+
 			if (!empty($tagId))
 			{
 				$hasTag = true;

--- a/administrator/components/com_content/views/article/view.html.php
+++ b/administrator/components/com_content/views/article/view.html.php
@@ -57,7 +57,6 @@ class ContentViewArticle extends JViewLegacy
 	{
 		if ($this->getLayout() == 'pagebreak')
 		{
-
 			return parent::display($tpl);
 		}
 

--- a/administrator/components/com_fields/libraries/fieldsplugin.php
+++ b/administrator/components/com_fields/libraries/fieldsplugin.php
@@ -94,6 +94,7 @@ abstract class FieldsPlugin extends JPlugin
 
 		// Add to cache and return the data
 		$types_cache[$this->_type . $this->_name] = $types;
+
 		return $types;
 	}
 

--- a/administrator/components/com_fields/views/fields/tmpl/default_batch_body.php
+++ b/administrator/components/com_fields/views/fields/tmpl/default_batch_body.php
@@ -2,7 +2,7 @@
 /**
  * @package     Joomla.Administrator
  * @subpackage  com_fields
- * 
+ *
  * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */

--- a/administrator/components/com_fields/views/fields/tmpl/default_batch_footer.php
+++ b/administrator/components/com_fields/views/fields/tmpl/default_batch_footer.php
@@ -2,7 +2,7 @@
 /**
  * @package     Joomla.Administrator
  * @subpackage  com_fields
- * 
+ *
  * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */

--- a/administrator/components/com_fields/views/groups/tmpl/default_batch_footer.php
+++ b/administrator/components/com_fields/views/groups/tmpl/default_batch_footer.php
@@ -2,7 +2,7 @@
 /**
  * @package     Joomla.Administrator
  * @subpackage  com_fields
- * 
+ *
  * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */

--- a/administrator/components/com_installer/models/languages.php
+++ b/administrator/components/com_installer/models/languages.php
@@ -141,7 +141,7 @@ class InstallerModelLanguages extends JModelList
 
 			foreach ($extension->attributes() as $key => $value)
 			{
-				$language->$key =  (string) $value;
+				$language->$key = (string) $value;
 			}
 
 			if ($search)

--- a/administrator/modules/mod_stats_admin/helper.php
+++ b/administrator/modules/mod_stats_admin/helper.php
@@ -83,6 +83,7 @@ class ModStatsHelper
 			$query->select('COUNT(id) AS count_users')
 				->from('#__users');
 			$db->setQuery($query);
+
 			try
 			{
 				$users = $db->loadResult();
@@ -97,6 +98,7 @@ class ModStatsHelper
 				->from('#__content')
 				->where('state = 1');
 			$db->setQuery($query);
+
 			try
 			{
 				$items = $db->loadResult();

--- a/administrator/templates/hathor/html/layouts/joomla/edit/fieldset.php
+++ b/administrator/templates/hathor/html/layouts/joomla/edit/fieldset.php
@@ -50,7 +50,7 @@ if ($displayData->get('show_options', 1))
 	}
 	$html[] = '</ul>';
 	$html[] = '</fieldset>';
-	
+
 	echo implode('', $html);
 }
 else

--- a/administrator/templates/isis/html/layouts/joomla/pagination/link.php
+++ b/administrator/templates/isis/html/layouts/joomla/pagination/link.php
@@ -54,7 +54,7 @@ switch ((string) $item->text)
 
 	default:
 		$icon = null;
-		$aria = JText::sprintf('JLIB_HTML_GOTO_PAGE', $item->text);		
+		$aria = JText::sprintf('JLIB_HTML_GOTO_PAGE', $item->text);
 		break;
 }
 


### PR DESCRIPTION
Pull Request for Issue code style fixes
### Summary of Changes
- Please consider an empty line before the try/foreach statement
- Whitespace found at end of line
- Expected 1 space after "="; 2 found
- Expected 1 space before "="; 0 found
- Please consider an empty line before the return statement;
- Expected 1 newline after opening brace; 2 found
- Blank line found at start of control structure
- Please consider an empty line before the if statement;
- Line indented incorrectly;

[Automatically fixed with Joomla code standards 2.0.0 PHPCS2-alpha2 fixers](https://github.com/joomla/coding-standards/releases/tag/2.0.0-alpha2)

None of the manual only fixes have been applied

### Testing Instructions
Merge by code review

### Expected result
code style has been applied as listed above, old code style testing on drone does not error.

### Actual result
code style had not been applied. [Autofixers from the Joomla code standards 2.0.0 PHPCS2 alpha2](https://github.com/joomla/coding-standards/releases/tag/2.0.0-alpha2) were used to implement fixable code style

### Documentation Changes Required
none