### PR TITLE
[CS] Code Style fixes for plugins/

### DIFF
--- a/plugins/fields/sql/sql.php
+++ b/plugins/fields/sql/sql.php
@@ -68,6 +68,7 @@ class PlgFieldsSql extends FieldsListPlugin
 		if (!JAccess::getAssetRules(1)->allow('core.admin', JFactory::getUser()->getAuthorisedGroups()))
 		{
 			$item->setError(JText::_('PLG_FIELDS_SQL_CREATE_NOT_POSSIBLE'));
+
 			return false;
 		}
 

--- a/plugins/system/log/log.php
+++ b/plugins/system/log/log.php
@@ -56,6 +56,7 @@ class PlgSystemLog extends JPlugin
 		}
 
 		JLog::addLogger(array(), JLog::INFO);
+
 		try
 		{
 			JLog::add($errorlog['comment'], JLog::INFO, $errorlog['status']);

--- a/plugins/system/updatenotification/updatenotification.php
+++ b/plugins/system/updatenotification/updatenotification.php
@@ -192,11 +192,13 @@ class PlgSystemUpdatenotification extends JPlugin
 			return;
 		}
 
-		/* Load the appropriate language. We try to load English (UK), the current user's language and the forced
+		/*
+		 * Load the appropriate language. We try to load English (UK), the current user's language and the forced
 		 * language preference, in this order. This ensures that we'll never end up with untranslated strings in the
 		 * update email which would make Joomla! seem bad. So, please, if you don't fully understand what the
 		 * following code does DO NOT TOUCH IT. It makes the difference between a hobbyist CMS and a professional
-		 * solution! */
+		 * solution! 
+		 */
 		$jLanguage = JFactory::getLanguage();
 		$jLanguage->load('plg_system_updatenotification', JPATH_ADMINISTRATOR, 'en-GB', true, true);
 		$jLanguage->load('plg_system_updatenotification', JPATH_ADMINISTRATOR, null, true, false);

--- a/plugins/user/joomla/joomla.php
+++ b/plugins/user/joomla/joomla.php
@@ -117,6 +117,7 @@ class PlgUserJoomla extends JPlugin
 		if (strpos($this->app->get('mailfrom'), '@') === false)
 		{
 			$this->app->enqueueMessage(JText::_('JERROR_SENDING_EMAIL'), 'warning');
+
 			return;
 		}
 


### PR DESCRIPTION
Pull Request for Issue code style fixes

### Summary of Changes
- Please consider an empty line before the return statement;
- Please consider an empty line before the try statement;
- block comments start and end with `/*` and `*/` and no text

[Automatically fixed with Joomla code standards 2.0.0 PHPCS2-alpha2 fixers](https://github.com/joomla/coding-standards/releases/tag/2.0.0-alpha2)

None of the manual only fixes have been applied

### Testing Instructions
Merge by code review

### Expected result
code style has been applied as listed above, old code style testing on drone does not error.

### Actual result
code style had not been applied. [Autofixers from the Joomla code standards 2.0.0 PHPCS2 alpha2](https://github.com/joomla/coding-standards/releases/tag/2.0.0-alpha2) were used to implement fixable code style

### Documentation Changes Required
none
