### PR TITLE
Use off deprecated methods

### DIFF
--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -301,7 +301,7 @@ abstract class JHtmlBehavior
 		$opt['onShow']    = isset($params['onShow']) ? '\\' . $params['onShow'] : null;
 		$opt['onHide']    = isset($params['onHide']) ? '\\' . $params['onHide'] : null;
 
-		$options = JHtml::getJSObject($opt);
+		$options = json_encode($opt);
 
 		// Include jQuery
 		JHtml::_('jquery.framework');
@@ -401,7 +401,7 @@ abstract class JHtmlBehavior
 			$opt['size']      = array('x' => '\\jQuery(window).width() - 80', 'y' => '\\jQuery(window).height() - 80');
 		}
 
-		$options = JHtml::getJSObject($opt);
+		$options = json_encode($opt);
 
 		// Attach modal behavior to document
 		$document
@@ -530,7 +530,7 @@ abstract class JHtmlBehavior
 		$opt['onClick']  = array_key_exists('onClick', $params) ? '\\' . $params['onClick']
 		: '\\function(node){  window.open(node.data.url, node.data.target != null ? node.data.target : \'_self\'); }';
 
-		$options = JHtml::getJSObject($opt);
+		$options = json_encode($opt);
 
 		// Setup root node
 		$rt['text']     = array_key_exists('text', $root) ? $root['text'] : 'Root';
@@ -540,7 +540,7 @@ abstract class JHtmlBehavior
 		$rt['icon']     = array_key_exists('icon', $root) ? $root['icon'] : null;
 		$rt['openicon'] = array_key_exists('openicon', $root) ? $root['openicon'] : null;
 		$rt['data']     = array_key_exists('data', $root) ? $root['data'] : null;
-		$rootNode = JHtml::getJSObject($rt);
+		$rootNode = json_encode($rt);
 
 		$treeName = array_key_exists('treeName', $params) ? $params['treeName'] : '';
 
@@ -849,13 +849,13 @@ abstract class JHtmlBehavior
 	 * @return  string  JavaScript object notation representation of the array
 	 *
 	 * @since       1.5
-	 * @deprecated  13.3 (Platform) & 4.0 (CMS) - Use JHtml::getJSObject() instead.
+	 * @deprecated  13.3 (Platform) & 4.0 (CMS) - Use json_encode() or \\Joomla\\Registry\\Registry::toString('json') instead.
 	 */
 	protected static function _getJSObject($array = array())
 	{
-		JLog::add('JHtmlBehavior::_getJSObject() is deprecated. JHtml::getJSObject() instead..', JLog::WARNING, 'deprecated');
+		JLog::add(__METHOD__ . " is deprecated. Use json_encode() or \\Joomla\\Registry\\Registry::toString('json') instead.", \JLog::WARNING, 'deprecated');
 
-		return JHtml::getJSObject($array);
+		return json_encode($array);
 	}
 
 	/**

--- a/libraries/cms/html/bootstrap.php
+++ b/libraries/cms/html/bootstrap.php
@@ -53,7 +53,7 @@ abstract class JHtmlBootstrap
 			// Setup options object
 			$opt['offset'] = isset($params['offset']) ? $params['offset'] : 10;
 
-			$options = JHtml::getJSObject($opt);
+			$options = json_encode($opt);
 
 			// Attach affix to document
 			JFactory::getDocument()->addScriptDeclaration(
@@ -155,7 +155,7 @@ abstract class JHtmlBootstrap
 			$opt['interval'] = isset($params['interval']) ? (int) $params['interval'] : 5000;
 			$opt['pause']    = isset($params['pause']) ? $params['pause'] : 'hover';
 
-			$options = JHtml::getJSObject($opt);
+			$options = json_encode($opt);
 
 			// Attach the carousel to document
 			JFactory::getDocument()->addScriptDeclaration(
@@ -266,7 +266,7 @@ abstract class JHtmlBootstrap
 			$opt['show']     = isset($params['show']) ? (boolean) $params['show'] : false;
 			$opt['remote']   = isset($params['remote']) ?  $params['remote'] : '';
 
-			$options = JHtml::getJSObject($opt);
+			$options = json_encode($opt);
 
 			// Attach the modal to document
 			JFactory::getDocument()->addScriptDeclaration(
@@ -362,7 +362,7 @@ abstract class JHtmlBootstrap
 		$opt['delay']     = isset($params['delay']) ? $params['delay'] : null;
 		$opt['container'] = isset($params['container']) ? $params['container'] : 'body';
 
-		$options = JHtml::getJSObject($opt);
+		$options = json_encode($opt);
 
 		// Attach the popover to the document
 		JFactory::getDocument()->addScriptDeclaration(
@@ -398,7 +398,7 @@ abstract class JHtmlBootstrap
 			// Setup options object
 			$opt['offset'] = isset($params['offset']) ? (int) $params['offset'] : 10;
 
-			$options = JHtml::getJSObject($opt);
+			$options = json_encode($opt);
 
 			// Attach ScrollSpy to document
 			JFactory::getDocument()->addScriptDeclaration(
@@ -459,7 +459,7 @@ abstract class JHtmlBootstrap
 			$onHide           = isset($params['onHide']) ? (string) $params['onHide'] : null;
 			$onHidden         = isset($params['onHidden']) ? (string) $params['onHidden'] : null;
 
-			$options = JHtml::getJSObject($opt);
+			$options = json_encode($opt);
 
 			// Build the script.
 			$script = array('$(' . json_encode($selector) . ').tooltip(' . $options . ')');
@@ -558,7 +558,7 @@ abstract class JHtmlBootstrap
 			$opt['updater']     = isset($params['updater']) ? (string) $params['updater'] : null;
 			$opt['highlighter'] = isset($params['highlighter']) ? (int) $params['highlighter'] : null;
 
-			$options = JHtml::getJSObject($opt);
+			$options = json_encode($opt);
 
 			// Attach typehead to document
 			JFactory::getDocument()->addScriptDeclaration(
@@ -609,7 +609,7 @@ abstract class JHtmlBootstrap
 			$onHide = isset($params['onHide']) ? (string) $params['onHide'] : null;
 			$onHidden = isset($params['onHidden']) ? (string) $params['onHidden'] : null;
 
-			$options = JHtml::getJSObject($opt);
+			$options = json_encode($opt);
 
 			$opt['active'] = isset($params['active']) ? (string) $params['active'] : '';
 

--- a/libraries/cms/html/sliders.php
+++ b/libraries/cms/html/sliders.php
@@ -111,7 +111,7 @@ abstract class JHtmlSliders
 			$opt['opacity'] = (isset($params['opacityTransition']) && $params['opacityTransition']) ? 'true' : 'false';
 			$opt['alwaysHide'] = (isset($params['allowAllClose']) && (!$params['allowAllClose'])) ? 'false' : 'true';
 
-			$options = JHtml::getJSObject($opt);
+			$options = json_encode($opt);
 
 			$js = "window.addEvent('domready', function(){ new Fx.Accordion($$('div#" . $group
 				. ".pane-sliders > .panel > h3.pane-toggler'), $$('div#" . $group . ".pane-sliders > .panel > div.pane-slider'), " . $options

--- a/libraries/cms/html/tabs.php
+++ b/libraries/cms/html/tabs.php
@@ -93,7 +93,7 @@ abstract class JHtmlTabs
 			// When use storage is set and value is false - By default we allow to use storage
 			$opt['useStorage'] = !(isset($params['useCookie']) && !$params['useCookie']);
 
-			$options = JHtml::getJSObject($opt);
+			$options = json_encode($opt);
 
 			$js = '	window.addEvent(\'domready\', function(){
 						$$(\'dl#' . $group . '.tabs\').each(function(tabs){

--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -1160,7 +1160,7 @@ abstract class HTMLHelper
 			}
 			else
 			{
-				$elements[] = $key . ': ' . static::getJSObject(is_object($v) ? get_object_vars($v) : $v);
+				$elements[] = $key . ': ' . json_encode(is_object($v) ? get_object_vars($v) : $v);
 			}
 		}
 

--- a/libraries/src/Layout/FileLayout.php
+++ b/libraries/src/Layout/FileLayout.php
@@ -77,7 +77,7 @@ class FileLayout extends BaseLayout
 		$this->setOptions($options);
 
 		// Main properties
-		$this->setLayout($layoutId);
+		$this->setLayoutId($layoutId);
 		$this->basePath = $basePath;
 
 		// Init Enviroment
@@ -470,7 +470,7 @@ class FileLayout extends BaseLayout
 		$this->options->set('component', $component);
 
 		// Refresh include paths
-		$this->refreshIncludePaths();
+		$this->clearIncludePaths();
 	}
 
 	/**
@@ -505,7 +505,7 @@ class FileLayout extends BaseLayout
 		$this->options->set('client', $client);
 
 		// Refresh include paths
-		$this->refreshIncludePaths();
+		$this->clearIncludePaths();
 	}
 
 	/**


### PR DESCRIPTION
From deprecated.php
This "Functions that are deleted when switching to version 4.0". Repeated many times.

Joomla\CMS\Layout\FileLayout::setLayout() is deprecated, use FileLayout::setLayoutId() instead.
Joomla\CMS\Layout\FileLayout::refreshIncludePaths() is deprecated, use FileLayout::clearIncludePaths() instead.

**Pull Request for Issue # .**
### Summary of Changes

Now using the recommended methods
### Testing Instructions

With a fresh 3.8.3 enabled log deprecated API logging
switch to site once
check log in administrator/logs/deprecated.php
Install patch

switch to site once
check log in administrator/logs/deprecated.php
### Expected result

No log entry from this file
### Actual result

2017-12-26T08:15:40+00:00 WARNING ::1 deprecated Joomla\CMS\Layout\FileLayout::setLayout() is deprecated, use FileLayout::setLayoutId() instead.
2017-12-26T08:15:40+00:00 WARNING ::1 deprecated Joomla\CMS\Layout\FileLayout::refreshIncludePaths() is deprecated, use FileLayout::clearIncludePaths() instead.
2017-12-26T08:15:40+00:00 WARNING ::1 deprecated Joomla\CMS\Layout\FileLayout::refreshIncludePaths() is deprecated, use FileLayout::clearIncludePaths() instead.
### Documentation Changes Required

No