### PR TITLE
Fix captcha not displayed when $class not set

### DIFF
--- a/plugins/captcha/recaptcha/recaptcha.php
+++ b/plugins/captcha/recaptcha/recaptcha.php
@@ -82,6 +82,11 @@ class PlgCaptchaRecaptcha extends JPlugin
 	 */
 	public function onDisplay($name = null, $id = 'dynamic_recaptcha_1', $class = '')
 	{
+		if ($class == '')
+		{
+			$class = 'class="required"';
+		}
+
 		if ($this->params->get('version', '1.0') === '1.0')
 		{
 			return '<div id="' . $id . '" ' . $class . '></div>';


### PR DESCRIPTION
Pull Request for Issue #18773.

### Summary of Changes
Per the docblock, the `$class` parameter expects `class="required"` to be passed since a `str_replace` will be performed on this parameter. This PR assigns a value to `$class` parameter when not set.


### Testing Instructions
Code review

This was provided in the issue, but I did not know how/where to insert it to test.
```
JPluginHelper::importPlugin('captcha');
$dispatcher = JDispatcher::getInstance();
$arr = $dispatcher->trigger('onInit', 'dynamic_recaptcha_1');
echo $arr[0];
```

### Expected result
`<div id="dynamic_recaptcha_1" class="g-recaptcha " data-sitekey="SITEKEY_TOKEN" data-theme="light" data-size="compact"></div>`


### Actual result
`<div id="dynamic_recaptcha_1" data-sitekey="SITEKEY_TOKEN" data-theme="light" data-size="compact"></div`


### Documentation Changes Required
none
