### PR TITLE
Fix warning on JHtmlMenu::treerecurse method on PHP 7.2

### DIFF
--- a/libraries/cms/html/menu.php
+++ b/libraries/cms/html/menu.php
@@ -351,7 +351,7 @@ abstract class JHtmlMenu
 	 */
 	public static function treerecurse($id, $indent, $list, &$children, $maxlevel = 9999, $level = 0, $type = 1)
 	{
-		if ($level <= $maxlevel && @$children[$id])
+		if ($level <= $maxlevel && isset($children[$id]) && is_array($children[$id]))
 		{
 			if ($type)
 			{
@@ -379,8 +379,16 @@ abstract class JHtmlMenu
 
 				$list[$id]           = $v;
 				$list[$id]->treename = $indent . $txt;
-				$list[$id]->children = count(@$children[$id]);
-				$list                = static::treerecurse($id, $indent . $spacer, $list, $children, $maxlevel, $level + 1, $type);
+
+				if (isset($children[$id]) && is_array($children[$id]))
+				{
+					$list[$id]->children = count($children[$id]);
+					$list                = static::treerecurse($id, $indent . $spacer, $list, $children, $maxlevel, $level + 1, $type);
+				}
+				else
+				{
+					$list[$id]->children = 0;
+				}
 			}
 		}
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
When method JHtmlMenu::treerecurse is used on PHP 7.2, there are some warnings like this displayed:

> Warning: count(): Parameter must be an array or an object that implements Countable in D:\www\joomla\libraries\cms\html\menu.php on line 382

This PR just fixes it.

### Testing Instructions
1. You need to run your Joomla website on PHP 7.2 
2. Open the file templates/protostar/index.php, add this line of code: 

```php
echo JHtml::_('select.genericlist', JHtmlMenu::linkOptions(), 'link_option');
```

3. Access to frontend of the site, you will see many warning messages like this:

> Warning: count(): Parameter must be an array or an object that implements Countable in D:\www\joomla\libraries\cms\html\menu.php on line 382

4. Apply patch, the warnings are gone. You should see a dropdown contains menu items
