### PR TITLE
Display category title as page heading and page title when no menu item for com_content category

### DIFF
--- a/components/com_content/views/category/view.html.php
+++ b/components/com_content/views/category/view.html.php
@@ -184,12 +184,16 @@ class ContentViewCategory extends JViewCategory
 		// we need to get it from the menu item itself
 		$menu = $menus->getActive();
 
-		if ($menu)
+		if ($this->category->title)
+		{
+			$this->params->def('page_heading', $this->category->title);
+			$title =  $title ?: $this->category->title;
+		}
+		elseif ($menu)
 		{
 			$this->params->def('page_heading', $this->params->get('page_title', $menu->title));
+			$title = $title ?: $this->params->get('page_title', $menu->title);
 		}
-
-		$title = $this->params->get('page_title', '');
 
 		$id = (int) @$menu->query['id'];
 

--- a/components/com_content/views/category/view.html.php
+++ b/components/com_content/views/category/view.html.php
@@ -184,16 +184,20 @@ class ContentViewCategory extends JViewCategory
 		// we need to get it from the menu item itself
 		$menu = $menus->getActive();
 
-		if ($this->category->title && strpos($menu->link, 'view=categories&id='))
+		if ($menu
+			&& $menu->component == 'com_content'
+			&& isset($menu->query['view'], $menu->query['id'])
+			&& $menu->query['view'] == 'category'
+			&& $menu->query['id'] == $this->category->id)
 		{
-			$this->params->def('page_heading', $this->category->title);
-			$title = $title ?: $this->category->title;
-			$this->params->set('page_title', $title);
+			$this->params->def('page_heading', $this->params->get('page_title', $menu->title));
+			$title = $this->params->get('page_title', $menu->title);
 		}
 		else
 		{
-			$this->params->def('page_heading', $this->params->get('page_title', $menu->title));
-			$title = $title ?: $this->params->get('page_title', $menu->title);
+			$this->params->def('page_heading', $this->category->title);
+			$title = $this->category->title;
+			$this->params->set('page_title', $title);
 		}
 
 		$id = (int) @$menu->query['id'];

--- a/components/com_content/views/category/view.html.php
+++ b/components/com_content/views/category/view.html.php
@@ -184,12 +184,13 @@ class ContentViewCategory extends JViewCategory
 		// we need to get it from the menu item itself
 		$menu = $menus->getActive();
 
-		if ($this->category->title)
+		if ($this->category->title && strpos($menu->link, 'view=categories&id='))
 		{
 			$this->params->def('page_heading', $this->category->title);
-			$title =  $title ?: $this->category->title;
+			$title = $title ?: $this->category->title;
+			$this->params->set('page_title', $title);
 		}
-		elseif ($menu)
+		else
 		{
 			$this->params->def('page_heading', $this->params->get('page_title', $menu->title));
 			$title = $title ?: $this->params->get('page_title', $menu->title);


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/19192

### Summary of Changes
Patch similar to https://github.com/joomla/joomla-cms/pull/12167
Limited to com_content

### Steps to reproduce the issue
Create a menu item with the title "Categories" that lists all the categories, when accessing the menu, the page title in the browser shows "Categories" and if I click on any category the browser title does not change.

### Expected result
When accessing a category of the list, the title of the category should be displayed in the browser.

### Actual result
When accessing a category of the list it continues to show the menu title instead of the title of the category that has been selected .

### After patch
The category title will display
Example:
![screen shot 2017-12-28 at 10 06 35](https://user-images.githubusercontent.com/869724/34405997-e5b7c084-ebb6-11e7-8377-64a2a414d103.png)

### Documentation Changes Required
