### PR TITLE
Use urlencode() function for variable `return` in URL query string

### DIFF
--- a/administrator/components/com_menus/views/menus/tmpl/default.php
+++ b/administrator/components/com_menus/views/menus/tmpl/default.php
@@ -171,7 +171,8 @@ JFactory::getDocument()->addScriptDeclaration(implode("\n", $script));
 										<?php foreach ($this->modules[$item->menutype] as &$module) : ?>
 											<li>
 												<?php if ($user->authorise('core.edit', 'com_modules.module.' . (int) $module->id)) : ?>
-													<?php $link = JRoute::_('index.php?option=com_modules&task=module.edit&id=' . $module->id . '&return=' . $return . '&tmpl=component&layout=modal'); ?>
+													<?php $link = 'index.php?option=com_modules&task=module.edit&id=' . $module->id . '&tmpl=component&layout=modal&return=return'; ?>
+													<?php $link = str_replace('return=return', 'return=' . urlencode($return), JRoute::_($link)); ?>
 													<a href="#moduleEdit<?php echo $module->id; ?>Modal" role="button" class="button" data-toggle="modal" title="<?php echo JText::_('COM_MENUS_EDIT_MODULE_SETTINGS'); ?>">
 														<?php echo JText::sprintf('COM_MENUS_MODULE_ACCESS_POSITION', $this->escape($module->title), $this->escape($module->access_title), $this->escape($module->position)); ?></a>
 												<?php else : ?>
@@ -184,7 +185,8 @@ JFactory::getDocument()->addScriptDeclaration(implode("\n", $script));
 								 </div>
 								<?php foreach ($this->modules[$item->menutype] as &$module) : ?>
 									<?php if ($user->authorise('core.edit', 'com_modules.module.' . (int) $module->id)) : ?>
-										<?php $link = JRoute::_('index.php?option=com_modules&task=module.edit&id=' . $module->id . '&return=' . $return . '&tmpl=component&layout=modal'); ?>
+										<?php $link = 'index.php?option=com_modules&task=module.edit&id=' . $module->id . '&tmpl=component&layout=modal&return=return'; ?>
+										<?php $link = str_replace('return=return', 'return=' . urlencode($return), JRoute::_($link)); ?>
 										<?php echo JHtml::_(
 												'bootstrap.renderModal',
 												'moduleEdit' . $module->id . 'Modal',

--- a/administrator/templates/hathor/html/com_menus/menus/default.php
+++ b/administrator/templates/hathor/html/com_menus/menus/default.php
@@ -141,7 +141,8 @@ JFactory::getDocument()->addScriptDeclaration(implode("\n", $script));
 						?>
 						<li>
 							<?php if ($canEdit) : ?>
-								<?php $link = JRoute::_('index.php?option=com_modules&task=module.edit&id='.$module->id.'&return='.$return.'&tmpl=component&layout=modal'); ?>
+								<?php $link = 'index.php?option=com_modules&task=module.edit&id=' . $module->id . '&tmpl=component&layout=modal&return=return'; ?>
+								<?php $link = str_replace('return=return', 'return=' . urlencode($return), JRoute::_($link)); ?>
 								<a href="#module<?php echo $module->id; ?>Modal" role="button" class="button" data-toggle="modal" title="<?php echo JText::_('COM_MENUS_EDIT_MODULE_SETTINGS');?>">
 									<?php echo JText::sprintf('COM_MENUS_MODULE_ACCESS_POSITION', $this->escape($module->title), $this->escape($module->access_title), $this->escape($module->position)); ?></a>
 							<?php else : ?>
@@ -152,7 +153,8 @@ JFactory::getDocument()->addScriptDeclaration(implode("\n", $script));
 				</ul>
 					<?php foreach ($this->modules[$item->menutype] as &$module) : ?>
 						<?php if ($canEdit) : ?>
-							<?php $link = JRoute::_('index.php?option=com_modules&task=module.edit&id='.$module->id.'&return='.$return.'&tmpl=component&layout=modal'); ?>
+							<?php $link = 'index.php?option=com_modules&task=module.edit&id=' . $module->id . '&tmpl=component&layout=modal&return=return'; ?>
+							<?php $link = str_replace('return=return', 'return=' . urlencode($return), JRoute::_($link)); ?>
 							<?php echo JHtml::_(
 									'bootstrap.renderModal',
 									'module' . $module->id . 'Modal',

--- a/components/com_config/controller/modules/cancel.php
+++ b/components/com_config/controller/modules/cancel.php
@@ -41,9 +41,9 @@ class ConfigControllerModulesCancel extends ConfigControllerCanceladmin
 		// Get returnUri
 		$returnUri = $this->input->post->get('return', null, 'base64');
 
-		if (!empty($returnUri))
+		if ($returnUri)
 		{
-			$this->redirect = base64_decode(urldecode($returnUri));
+			$this->redirect = base64_decode($returnUri);
 		}
 		else
 		{

--- a/components/com_content/controllers/article.php
+++ b/components/com_content/controllers/article.php
@@ -263,7 +263,7 @@ class ContentControllerArticle extends JControllerForm
 	 * @param   integer  $recordId  The primary key id for the item.
 	 * @param   string   $urlVar    The name of the URL variable for the id.
 	 *
-	 * @return  string	The arguments to append to the redirect URL.
+	 * @return  string  The arguments to append to the redirect URL.
 	 *
 	 * @since   1.6
 	 */
@@ -296,7 +296,6 @@ class ContentControllerArticle extends JControllerForm
 		}
 
 		$itemId = $this->input->getInt('Itemid');
-		$return = $this->getReturnPage();
 		$catId  = $this->input->getInt('catid');
 
 		if ($itemId)
@@ -309,9 +308,12 @@ class ContentControllerArticle extends JControllerForm
 			$append .= '&catid=' . $catId;
 		}
 
+		$return = $this->getReturnPage();
+
 		if ($return)
 		{
-			$append .= '&return=' . base64_encode($return);
+			// Beacause of J3.x bug in Joomla\Uri\AbstractUri::buildQuery the return value has to be encoded twice
+			$append .= '&return=' . urlencode(urlencode(base64_encode($return)));
 		}
 
 		return $append;
@@ -334,10 +336,8 @@ class ContentControllerArticle extends JControllerForm
 		{
 			return JUri::base();
 		}
-		else
-		{
-			return base64_decode($return);
-		}
+
+		return base64_decode($return);
 	}
 
 	/**

--- a/components/com_content/helpers/icon.php
+++ b/components/com_content/helpers/icon.php
@@ -30,9 +30,7 @@ abstract class JHtmlIcon
 	 */
 	public static function create($category, $params, $attribs = array(), $legacy = false)
 	{
-		$uri = JUri::getInstance();
-
-		$url = 'index.php?option=com_content&task=article.add&return=' . base64_encode($uri) . '&a_id=0&catid=' . $category->id;
+		$url = 'index.php?option=com_content&task=article.add&a_id=0&catid=' . $category->id . '&return=return';
 
 		$text = JLayoutHelper::render('joomla.content.icons.create', array('params' => $params, 'legacy' => $legacy));
 
@@ -46,7 +44,11 @@ abstract class JHtmlIcon
 			$attribs['class'] = 'btn btn-primary';
 		}
 
-		$button = JHtml::_('link', JRoute::_($url), $text, $attribs);
+		$return = base64_encode(JUri::getInstance());
+
+		$url = str_replace('return=return', 'return=' . urlencode($return), JRoute::_($url));
+
+		$button = JHtml::_('link',  $url, $text, $attribs);
 
 		$output = '<span class="hasTooltip" title="' . JHtml::_('tooltipText', 'COM_CONTENT_CREATE_ARTICLE') . '">' . $button . '</span>';
 
@@ -101,9 +103,6 @@ abstract class JHtmlIcon
 	 */
 	public static function edit($article, $params, $attribs = array(), $legacy = false)
 	{
-		$user = JFactory::getUser();
-		$uri  = JUri::getInstance();
-
 		// Ignore if in a popup window.
 		if ($params && $params->get('popup'))
 		{
@@ -120,7 +119,7 @@ abstract class JHtmlIcon
 		if (property_exists($article, 'checked_out')
 			&& property_exists($article, 'checked_out_time')
 			&& $article->checked_out > 0
-			&& $article->checked_out != $user->get('id'))
+			&& $article->checked_out != JFactory::getUser()->get('id'))
 		{
 			$checkoutUser = JFactory::getUser($article->checked_out);
 			$date         = JHtml::_('date', $article->checked_out_time);
@@ -129,26 +128,13 @@ abstract class JHtmlIcon
 
 			$text = JLayoutHelper::render('joomla.content.icons.edit_lock', array('tooltip' => $tooltip, 'legacy' => $legacy));
 
-			$output = JHtml::_('link', '#', $text, $attribs);
-
-			return $output;
-		}
-
-		$contentUrl = ContentHelperRoute::getArticleRoute($article->slug, $article->catid, $article->language);
-		$url        = $contentUrl . '&task=article.edit&a_id=' . $article->id . '&return=' . base64_encode($uri);
-
-		if ($article->state == 0)
-		{
-			$overlib = JText::_('JUNPUBLISHED');
-		}
-		else
-		{
-			$overlib = JText::_('JPUBLISHED');
+			return JHtml::_('link', '#', $text, $attribs);
 		}
 
 		$date   = JHtml::_('date', $article->created);
 		$author = $article->created_by_alias ?: $article->author;
 
+		$overlib  = JText::_($article->state == 0 ? 'JUNPUBLISHED' : 'JPUBLISHED');
 		$overlib .= '&lt;br /&gt;';
 		$overlib .= $date;
 		$overlib .= '&lt;br /&gt;';
@@ -156,10 +142,15 @@ abstract class JHtmlIcon
 
 		$text = JLayoutHelper::render('joomla.content.icons.edit', array('article' => $article, 'overlib' => $overlib, 'legacy' => $legacy));
 
-		$attribs['title']   = JText::_('JGLOBAL_EDIT_TITLE');
-		$output = JHtml::_('link', JRoute::_($url), $text, $attribs);
+		$attribs['title'] = JText::_('JGLOBAL_EDIT_TITLE');
 
-		return $output;
+		$return = base64_encode(JUri::getInstance());
+
+		$url = ContentHelperRoute::getArticleRoute($article->slug, $article->catid, $article->language)
+			. '&task=article.edit&a_id=' . $article->id . '&return=return';
+		$url = str_replace('return=return', 'return=' . urlencode($return), JRoute::_($url));
+
+		return JHtml::_('link', $url, $text, $attribs);
 	}
 
 	/**

--- a/components/com_content/views/article/view.html.php
+++ b/components/com_content/views/article/view.html.php
@@ -149,7 +149,11 @@ class ContentViewArticle extends JViewLegacy
 			if ($this->user->get('guest'))
 			{
 				$return = base64_encode(JUri::getInstance());
-				$login_url_with_return = JRoute::_('index.php?option=com_users&return=' . $return);
+
+				// Beacause of J3.x bug in Joomla\Uri\AbstractUri::buildQuery the return value has to be encoded later
+				$login_url_with_return = JRoute::_('index.php?option=com_users&view=login&return=return', false);
+				$login_url_with_return = str_replace('return=return', 'return=' . urlencode($return), $login_url_with_return);
+
 				$app->enqueueMessage(JText::_('JERROR_ALERTNOAUTHOR'), 'notice');
 				$app->redirect($login_url_with_return, 403);
 			}

--- a/components/com_users/controllers/user.php
+++ b/components/com_users/controllers/user.php
@@ -289,7 +289,10 @@ class UsersControllerUser extends UsersController
 		}
 
 		// Logout and redirect
-		$this->setRedirect('index.php?option=com_users&task=user.logout&' . JSession::getFormToken() . '=1&return=' . base64_encode($url));
+		$this->setRedirect(
+			'index.php?option=com_users&task=user.logout&'
+			. JSession::getFormToken() . '=1&return=' . urlencode(base64_encode($url))
+		);
 	}
 
 	/**

--- a/libraries/src/MVC/Controller/FormController.php
+++ b/libraries/src/MVC/Controller/FormController.php
@@ -480,7 +480,8 @@ class FormController extends BaseController
 
 		if ($return)
 		{
-			$append .= '&return=' . $return;
+			// Beacause of J3.x bug in Joomla\Uri\AbstractUri::buildQuery the return value has to be encoded twice
+			$append .= '&return=' . urlencode(urlencode($return));
 		}
 
 		return $append;


### PR DESCRIPTION
Pull Request for Issue #19130.

### Summary of Changes
Use `urlencode()` function for result of `base64_encode()` in URL query string.

For develop joomla website on URL like `http://localhost/~user/joomla`  function `base64_encode()` generates unsafe string in URL query.


### Testing Instructions
Test issue #19130

Additional:
1. Login as admin, go to some page (ex user login page) on front end and save/save and close/cancel module settings. After save + save and close/save and close/cancel you should back to previous page.

2. Go to category list and find the button "New" (add new article to category).
Click on link and then cancel, or save article. After you should back to category list.
Then try to edit some article from the category list. Save or cancel and back to category list.


### Expected result
The variable `return` is correct and you will be redirected to the previous page.

### Actual result
This is only visible on website that contains `~` in address.

The variable `return` is invalid and joomla redirects you to home page.

### Documentation Changes Required
None
