### PR TITLE
Set active class in mod_articles_categories when SEF is off

### DIFF
--- a/modules/mod_articles_categories/tmpl/default_items.php
+++ b/modules/mod_articles_categories/tmpl/default_items.php
@@ -9,8 +9,13 @@
 
 defined('_JEXEC') or die;
 
+$input  = JFactory::getApplication()->input;
+$option = $input->getCmd('option');
+$view   = $input->getCmd('view');
+$id     = $input->getInt('id');
+
 foreach ($list as $item) : ?>
-	<li <?php if ($_SERVER['REQUEST_URI'] === JRoute::_(ContentHelperRoute::getCategoryRoute($item->id), false)) echo ' class="active"'; ?>> <?php $levelup = $item->level - $startLevel - 1; ?>
+	<li <?php if ($id == $item->id && $view == 'category' && $option == 'com_content') echo ' class="active"'; ?>> <?php $levelup = $item->level - $startLevel - 1; ?>
 		<h<?php echo $params->get('item_heading') + $levelup; ?>>
 		<a href="<?php echo JRoute::_(ContentHelperRoute::getCategoryRoute($item->id)); ?>">
 		<?php echo $item->title; ?>

--- a/modules/mod_articles_categories/tmpl/default_items.php
+++ b/modules/mod_articles_categories/tmpl/default_items.php
@@ -15,7 +15,7 @@ $view   = $input->getCmd('view');
 $id     = $input->getInt('id');
 
 foreach ($list as $item) : ?>
-	<li <?php if ($id == $item->id && $view == 'category' && $option == 'com_content') echo ' class="active"'; ?>> <?php $levelup = $item->level - $startLevel - 1; ?>
+	<li<?php if ($id == $item->id && $view == 'category' && $option == 'com_content') echo ' class="active"'; ?>> <?php $levelup = $item->level - $startLevel - 1; ?>
 		<h<?php echo $params->get('item_heading') + $levelup; ?>>
 		<a href="<?php echo JRoute::_(ContentHelperRoute::getCategoryRoute($item->id)); ?>">
 		<?php echo $item->title; ?>

--- a/modules/mod_articles_categories/tmpl/default_items.php
+++ b/modules/mod_articles_categories/tmpl/default_items.php
@@ -10,7 +10,7 @@
 defined('_JEXEC') or die;
 
 foreach ($list as $item) : ?>
-	<li <?php if ($_SERVER['REQUEST_URI'] === JRoute::_(ContentHelperRoute::getCategoryRoute($item->id))) echo ' class="active"'; ?>> <?php $levelup = $item->level - $startLevel - 1; ?>
+	<li <?php if ($_SERVER['REQUEST_URI'] === JRoute::_(ContentHelperRoute::getCategoryRoute($item->id), false)) echo ' class="active"'; ?>> <?php $levelup = $item->level - $startLevel - 1; ?>
 		<h<?php echo $params->get('item_heading') + $levelup; ?>>
 		<a href="<?php echo JRoute::_(ContentHelperRoute::getCategoryRoute($item->id)); ?>">
 		<?php echo $item->title; ?>


### PR DESCRIPTION
Pull Request for Issue #19194 .

### Summary of Changes
Do not replace `&` by `&amp;` in URL in `JRoute::_(...)` when comparing to `$_SERVER['REQUEST_URI']`

### Testing Instructions
Test issue #19194 


### Expected result
When SEF is off.
Active class will appear when we are on the category page.


### Actual result
When SEF is off active class in (`<li class="active">`) is missing.


### Documentation Changes Required
None
