### PR TITLE
Fix PHP Warning for Session on PHP 7.2

### DIFF
--- a/libraries/src/Session/Session.php
+++ b/libraries/src/Session/Session.php
@@ -797,19 +797,9 @@ class Session implements \IteratorAggregate
 			return false;
 		}
 
-		// Keep session config
-		$cookie = session_get_cookie_params();
-
-		// Re-register the session store after a session has been destroyed, to avoid PHP bug
-		$this->_store->register();
-
-		// Restore config
-		session_set_cookie_params($cookie['lifetime'], $cookie['path'], $cookie['domain'], $cookie['secure'], true);
-
 		// Restart session with new id
 		$this->_handler->regenerate(true, null);
-		$this->_handler->start();
-
+		
 		return true;
 	}
 

--- a/libraries/src/Session/Session.php
+++ b/libraries/src/Session/Session.php
@@ -799,7 +799,7 @@ class Session implements \IteratorAggregate
 
 		// Restart session with new id
 		$this->_handler->regenerate(true, null);
-		
+
 		return true;
 	}
 


### PR DESCRIPTION
Pull Request for Issue #19127 .

### Summary of Changes
This is an attempt to fix issue #19127. If you login on a Joomla website runs on PHP 7.2, check error logs, you will see warning like below:

> [Thu Dec 28 22:04:15.331696 2017] [php7:warn] [pid 8128:tid 1900] [client ::1:65187] PHP Warning:  session_set_save_handler(): Cannot change save handler when session is active in D:\\www\\joomla\\libraries\\joomla\\session\\storage.php on line 106, referer: http://localhost/joomla/
> [Thu Dec 28 22:04:15.331696 2017] [php7:warn] [pid 8128:tid 1900] [client ::1:65187] PHP Warning:  session_set_cookie_params(): Cannot change session cookie parameters when session is active in D:\\www\\joomla\\libraries\\src\\Session\\Session.php on line 807, referer: http://localhost/joomla/

Honestly, I am unsure about quality of the fix. This fix is just simply removes codes base on warnings throws by PHP. 

I also remove **$this->_handler->start();** because after calling **$this->_handler->regenerate(true, null);**, session is already started, so I don't see the need for calling **$this->_handler->start();** again


### Testing Instructions
1. You need to have a Joomla website run on PHP 7.2
2. Login, then check error logs, confirm the warnings above
3. Apply patch, check and confirm the warnings not happen anymore
4. Try to login, logout, make sure it is still working as expected.

### Additional comments
I also tested on my own extension and confirm that session data still keep after logged in. I also checked data in database myself and see that new session id is generated. Not sure if I miss anything else.


