### PR TITLE
[CS] New round of Code Style fixes for components/

### DIFF
--- a/components/com_contact/controllers/contact.php
+++ b/components/com_contact/controllers/contact.php
@@ -196,12 +196,13 @@ class ContactControllerContact extends JControllerForm
 		if (!empty($data['com_fields']) && $fields = FieldsHelper::getFields('com_contact.mail', $contact, true, $data['com_fields']))
 		{
 			$output = FieldsHelper::render(
-			'com_contact.mail',
-			'fields.render',
-			array(
-				'context' => 'com_contact.mail',
-				'item'    => $contact,
-				'fields'  => $fields)
+				'com_contact.mail',
+				'fields.render',
+				array(
+					'context' => 'com_contact.mail',
+					'item'    => $contact,
+					'fields'  => $fields,
+				)
 			);
 
 			if ($output)

--- a/components/com_contact/views/contact/view.html.php
+++ b/components/com_contact/views/contact/view.html.php
@@ -159,7 +159,7 @@ class ContactViewContact extends JViewLegacy
 		if ($item->params->get('show_street_address') || $item->params->get('show_suburb') || $item->params->get('show_state')
 			|| $item->params->get('show_postcode') || $item->params->get('show_country'))
 		{
-			if (!empty ($item->address) || !empty ($item->suburb) || !empty ($item->state) || !empty ($item->country) || !empty ($item->postcode))
+			if (!empty($item->address) || !empty($item->suburb) || !empty($item->state) || !empty($item->country) || !empty($item->postcode))
 			{
 				$item->params->set('address_check', 1);
 			}

--- a/components/com_content/models/articles.php
+++ b/components/com_content/models/articles.php
@@ -52,7 +52,7 @@ class ContentModelArticles extends JModelList
 				'images', 'a.images',
 				'urls', 'a.urls',
 				'filter_tag',
-				'tag'
+				'tag',
 			);
 		}
 
@@ -265,8 +265,10 @@ class ContentModelArticles extends JModelList
 
 		if (is_numeric($published) && $published == 2)
 		{
-			// If category is archived then article has to be published or archived.
-			// If categogy is published then article has to be archived.
+			/**
+			 * If category is archived then article has to be published or archived.
+			 * Or categogy is published then article has to be archived.
+			 */
 			$query->where('((c.published = 2 AND a.state > 0) OR (c.published = 1 AND a.state = 2))');
 		}
 		elseif (is_numeric($published))
@@ -298,8 +300,7 @@ class ContentModelArticles extends JModelList
 
 			case 'show':
 			default:
-				// Normally we do not discriminate
-				// between featured/unfeatured items.
+				// Normally we do not discriminate between featured/unfeatured items.
 				break;
 		}
 
@@ -575,9 +576,12 @@ class ContentModelArticles extends JModelList
 
 			$item->params = clone $this->getState('params');
 
-			/*For blogs, article params override menu item params only if menu param = 'use_article'
-			Otherwise, menu item params control the layout
-			If menu item is 'use_article' and there is no article param, use global*/
+			/**
+			 * For blogs, article params override menu item params only if menu param = 'use_article'
+			 *  Otherwise, menu item params control the layout
+			 * If menu item is 'use_article' and there is no article param, use global
+			 */
+			
 			if (($input->getString('layout') === 'blog') || ($input->getString('view') === 'featured')
 				|| ($this->getState('params')->get('layout_type') === 'blog'))
 			{
@@ -633,8 +637,10 @@ class ContentModelArticles extends JModelList
 					break;
 			}
 
-			// Compute the asset access permissions.
-			// Technically guest could edit an article, but lets not check that to improve performance a little.
+			/**
+			 * Compute the asset access permissions.
+			 * Technically guest could edit an article, but lets not check that to improve performance a little.
+			 */
 			if (!$guest)
 			{
 				$asset = 'com_content.article.' . $item->id;

--- a/components/com_content/models/articles.php
+++ b/components/com_content/models/articles.php
@@ -578,10 +578,9 @@ class ContentModelArticles extends JModelList
 
 			/**
 			 * For blogs, article params override menu item params only if menu param = 'use_article'
-			 *  Otherwise, menu item params control the layout
+			 * Otherwise, menu item params control the layout
 			 * If menu item is 'use_article' and there is no article param, use global
 			 */
-			
 			if (($input->getString('layout') === 'blog') || ($input->getString('view') === 'featured')
 				|| ($this->getState('params')->get('layout_type') === 'blog'))
 			{

--- a/components/com_content/models/category.php
+++ b/components/com_content/models/category.php
@@ -339,7 +339,7 @@ class ContentModelCategory extends JModelList
 	{
 		if (!is_object($this->_item))
 		{
-			if (isset( $this->state->params))
+			if (isset($this->state->params))
 			{
 				$params = $this->state->params;
 				$options = array();

--- a/components/com_content/views/article/view.html.php
+++ b/components/com_content/views/article/view.html.php
@@ -223,7 +223,7 @@ class ContentViewArticle extends JViewLegacy
 		$title   = null;
 
 		/**
-		.* Because the application sets a default page title,
+		 * Because the application sets a default page title,
 		 * we need to get it from the menu item itself
 		 */
 		$menu = $menus->getActive();

--- a/components/com_content/views/article/view.html.php
+++ b/components/com_content/views/article/view.html.php
@@ -139,7 +139,8 @@ class ContentViewArticle extends JViewLegacy
 			return;
 		}
 
-		/* Check for no 'access-view' and empty fulltext,
+		/*
+		 * Check for no 'access-view' and empty fulltext,
 		 * - Redirect guest users to login
 		 * - Deny access to logged users with 403 code
 		 * NOTE: we do not recheck for no access-view + show_noauth disabled ... since it was checked above
@@ -162,8 +163,10 @@ class ContentViewArticle extends JViewLegacy
 			}
 		}
 
-		// NOTE: The following code (usually) sets the text to contain the fulltext, but it is the
-		// responsibility of the layout to check 'access-view' and only use "introtext" for guests
+		/**
+		 * NOTE: The following code (usually) sets the text to contain the fulltext, but it is the
+		 * responsibility of the layout to check 'access-view' and only use "introtext" for guests
+		 */
 		if ($item->params->get('show_intro', '1') == '1')
 		{
 			$item->text = $item->introtext . ' ' . $item->fulltext;
@@ -186,7 +189,6 @@ class ContentViewArticle extends JViewLegacy
 		}
 
 		// Process the content plugins.
-
 		JPluginHelper::importPlugin('content');
 		$dispatcher->trigger('onContentPrepare', array ('com_content.article', &$item, &$item->params, $offset));
 
@@ -220,8 +222,10 @@ class ContentViewArticle extends JViewLegacy
 		$pathway = $app->getPathway();
 		$title   = null;
 
-		// Because the application sets a default page title,
-		// we need to get it from the menu item itself
+		/**
+		.* Because the application sets a default page title,
+		 * we need to get it from the menu item itself
+		 */
 		$menu = $menus->getActive();
 
 		if ($menu)

--- a/components/com_content/views/article/view.html.php
+++ b/components/com_content/views/article/view.html.php
@@ -139,7 +139,7 @@ class ContentViewArticle extends JViewLegacy
 			return;
 		}
 
-		/*
+		/**
 		 * Check for no 'access-view' and empty fulltext,
 		 * - Redirect guest users to login
 		 * - Deny access to logged users with 403 code

--- a/components/com_finder/models/search.php
+++ b/components/com_finder/models/search.php
@@ -1102,7 +1102,8 @@ class FinderModelSearch extends JModelList
 		$this->setState('list.start', $input->get('limitstart', 0, 'uint'));
 		$this->setState('list.limit', $input->get('limit', $app->get('list_limit', 20), 'uint'));
 
-		/* Load the sort ordering.
+		/*
+		 * Load the sort ordering.
 		 * Currently this is 'hard' coded via menu item parameter but may not satisfy a users need.
 		 * More flexibility was way more user friendly. So we allow the user to pass a custom value
 		 * from the pool of fields that are indexed like the 'title' field.
@@ -1135,7 +1136,8 @@ class FinderModelSearch extends JModelList
 				break;
 		}
 
-		/* Load the sort direction.
+		/*
+		 * Load the sort direction.
 		 * Currently this is 'hard' coded via menu item parameter but may not satisfy a users need.
 		 * More flexibility was way more user friendly. So we allow to be inverted.
 		 * Also, we allow this parameter to be passed in either case (lower/upper).

--- a/components/com_finder/models/search.php
+++ b/components/com_finder/models/search.php
@@ -1102,7 +1102,7 @@ class FinderModelSearch extends JModelList
 		$this->setState('list.start', $input->get('limitstart', 0, 'uint'));
 		$this->setState('list.limit', $input->get('limit', $app->get('list_limit', 20), 'uint'));
 
-		/*
+		/**
 		 * Load the sort ordering.
 		 * Currently this is 'hard' coded via menu item parameter but may not satisfy a users need.
 		 * More flexibility was way more user friendly. So we allow the user to pass a custom value
@@ -1136,7 +1136,7 @@ class FinderModelSearch extends JModelList
 				break;
 		}
 
-		/*
+		/**
 		 * Load the sort direction.
 		 * Currently this is 'hard' coded via menu item parameter but may not satisfy a users need.
 		 * More flexibility was way more user friendly. So we allow to be inverted.

--- a/components/com_mailto/controller.php
+++ b/components/com_mailto/controller.php
@@ -104,7 +104,7 @@ class MailtoController extends JControllerLegacy
 		/*
 		 * Free up memory
 		 */
-		unset ($headers, $fields);
+		unset($headers, $fields);
 
 		$email           = $this->input->post->getString('mailto', '');
 		$sender          = $this->input->post->getString('sender', '');

--- a/components/com_users/helpers/legacyrouter.php
+++ b/components/com_users/helpers/legacyrouter.php
@@ -150,7 +150,7 @@ class UsersRouterRulesLegacy implements JComponentRouterRulesInterface
 				case 'reset':
 					if ($query['Itemid'] = $reset)
 					{
-						unset ($query['view']);
+						unset($query['view']);
 					}
 					else
 					{
@@ -161,7 +161,7 @@ class UsersRouterRulesLegacy implements JComponentRouterRulesInterface
 				case 'resend':
 					if ($query['Itemid'] = $resend)
 					{
-						unset ($query['view']);
+						unset($query['view']);
 					}
 					else
 					{
@@ -172,7 +172,7 @@ class UsersRouterRulesLegacy implements JComponentRouterRulesInterface
 				case 'remind':
 					if ($query['Itemid'] = $remind)
 					{
-						unset ($query['view']);
+						unset($query['view']);
 					}
 					else
 					{
@@ -183,7 +183,7 @@ class UsersRouterRulesLegacy implements JComponentRouterRulesInterface
 				case 'login':
 					if ($query['Itemid'] = $login)
 					{
-						unset ($query['view']);
+						unset($query['view']);
 					}
 					else
 					{
@@ -194,7 +194,7 @@ class UsersRouterRulesLegacy implements JComponentRouterRulesInterface
 				case 'registration':
 					if ($query['Itemid'] = $registration)
 					{
-						unset ($query['view']);
+						unset($query['view']);
 					}
 					else
 					{
@@ -209,11 +209,11 @@ class UsersRouterRulesLegacy implements JComponentRouterRulesInterface
 						$segments[] = $query['view'];
 					}
 
-					unset ($query['view']);
+					unset($query['view']);
 
 					if ($query['Itemid'] = $profile)
 					{
-						unset ($query['view']);
+						unset($query['view']);
 					}
 					else
 					{
@@ -228,7 +228,7 @@ class UsersRouterRulesLegacy implements JComponentRouterRulesInterface
 						$segments[] = $query['user_id'];
 					}
 
-					unset ($query['user_id']);
+					unset($query['user_id']);
 
 					break;
 			}

--- a/components/com_users/models/profile.php
+++ b/components/com_users/models/profile.php
@@ -380,7 +380,7 @@ class UsersModelProfile extends JModelForm
 		JPluginHelper::importPlugin('user');
 
 		// Retrieve the user groups so they don't get overwritten
-		unset ($user->groups);
+		unset($user->groups);
 		$user->groups = JAccess::getGroupsByUser($user->id, false);
 
 		// Store the data.


### PR DESCRIPTION
Pull Request for Issue code style fixes

### Summary of Changes
- Space before opening parenthesis of function call prohibited
- Space after opening parenthesis of function call prohibited
- Block comment text must start on a new line
- Multi-line function call not indented correctly
- preference blockComment style over multiple single line comments
- arrays should end with a comma

[Automatically fixed with Joomla code standards 2.0.0 PHPCS2-alpha2 fixers](https://github.com/joomla/coding-standards/releases/tag/2.0.0-alpha2)

Some manual only fixes have been applied

### Testing Instructions
Merge by code review

### Expected result
code style has been applied as listed above, old code style testing on drone does not error.

### Actual result
code style had not been applied. [Autofixers from the Joomla code standards 2.0.0 PHPCS2 alpha2](https://github.com/joomla/coding-standards/releases/tag/2.0.0-alpha2) were used to implement fixable code style

### Documentation Changes Required
none