### PR TITLE
Fix undefined index: force_ssl in the front end

### DIFF
--- a/administrator/components/com_config/model/application.php
+++ b/administrator/components/com_config/model/application.php
@@ -120,7 +120,7 @@ class ConfigModelApplication extends ConfigModelForm
 		}
 
 		// Check if we can set the Force SSL option
-		if ((int) $data['force_ssl'] !== 0 && (int) $data['force_ssl'] !== (int) JFactory::getConfig()->get('force_ssl', '0'))
+		if (isset($data['force_ssl']) && (int) $data['force_ssl'] !== 0 && (int) $data['force_ssl'] !== (int) JFactory::getConfig()->get('force_ssl', '0'))
 		{
 			try
 			{


### PR DESCRIPTION
### Summary of Changes
Check that `$data['force_ssl']` is set.


### Testing Instructions
Create a menu item `Configuration Manager > Site Configuration Options`
Log in the front end.
Select the menu item in step 1.
Click `Save` button.
See php error log.


### Expected result
no warnings


### Actual result
`PHP Notice:  Undefined index: force_ssl in \administrator\components\com_config\model\application.php on line 123`


### Documentation Changes Required
none
