### PR TITLE
[4.0] Button type button

### DIFF
--- a/layouts/joomla/form/field/contenthistory.php
+++ b/layouts/joomla/form/field/contenthistory.php
@@ -60,7 +60,7 @@ echo JHtml::_(
 );
 
 ?>
-<button onclick="jQuery('#versionsModal').modal('show')" class="btn btn-secondary" data-toggle="modal" title="<?php echo $label; ?>">
+<button type="button" onclick="jQuery('#versionsModal').modal('show')" class="btn btn-secondary" data-toggle="modal" title="<?php echo $label; ?>">
 	<span class="fa fa-code-fork" aria-hidden="true"></span>
 	<?php echo $label; ?>
 </button>


### PR DESCRIPTION
HTML5 default is for a button to be a submit - here it needs to be a button

To test on the front end click on the Versions button when editing an article

Before this PR the modal does not open
After this PR the modal will open

The error in the modal is a different issue
