### PR TITLE
Remove PHP warning when logging out while editing the article  on php >= 7.1

### DIFF
--- a/libraries/legacy/error/error.php
+++ b/libraries/legacy/error/error.php
@@ -777,7 +777,7 @@ abstract class JError
 	{
 		JLog::add('JError::handleCallback() is deprecated.', JLog::WARNING, 'deprecated');
 
-		return call_user_func($options, $error);
+		return call_user_func_array($options, array(&$error));
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue #18476 .

### Summary of Changes

Function `call_user_func()` can not pass arguments by references.

Reference: http://php.net/manual/en/function.call-user-func.php

On php 7.1 and higher this is an issue that generates a PHP Warning.

`JError::handleCallback` expected a reference at the first argument.

To fix it, joomla has to use `call_user_func_array`, which can pass arguments by reference.

### Testing Instructions

1. Test on php 7.1 or higher
2. Login form module is set to display on all pages.
3. Be sure that plugin "System - Logout" is enabled.
4. Login as superadmin on frontend
5. Edit an article
6. Logout through the login module
7. Check error log.

### Expected result
No warning.


### Actual result
```
PHP Warning:  Parameter 1 to PlgSystemLogout::handleError() expected to be a reference, value given in ../libraries/legacy/error/error.php on line 780

PHP Stack trace:
PHP   1. {main}() .../index.php:0
PHP   2. Joomla\CMS\Application\SiteApplication->execute() .../index.php:49
PHP   3. Joomla\CMS\Application\SiteApplication->doExecute() .../libraries/src/Application/CMSApplication.php:267
PHP   4. Joomla\CMS\Application\SiteApplication->dispatch() .../libraries/src/Application/SiteApplication.php:233
PHP   5. Joomla\CMS\Component\ComponentHelper::renderComponent() .../libraries/src/Application/SiteApplication.php:194
PHP   6. Joomla\CMS\Component\ComponentHelper::executeComponent() .../libraries/src/Component/ComponentHelper.php:356
PHP   7. require_once() .../libraries/src/Component/ComponentHelper.php:381
PHP   8. ContentController->execute() .../components/com_content/content.php:43
PHP   9. ContentController->display() .../libraries/src/MVC/Controller/BaseController.php:710
PHP  10. JError::raiseError() .../components/com_content/controller.php:101
PHP  11. JError::raise() .../libraries/legacy/error/error.php:277
PHP  12. JError::throwError() .../libraries/legacy/error/error.php:202
PHP  13. JError::handleCallback() .../libraries/legacy/error/error.php:241
```