### PR TITLE
Add method to set document head (meta) data

### DIFF
--- a/components/com_content/views/category/view.html.php
+++ b/components/com_content/views/category/view.html.php
@@ -212,16 +212,29 @@ class ContentViewCategory extends JViewCategory
 			$title = $this->category->title;
 		}
 
-		$this->params->set('page_title', $title);
+		$this->document->setTitle($title);
 
 		if ($this->category->metadesc)
 		{
-			$this->params->set('menu-meta_description', $this->category->metadesc);
+			$this->document->setDescription($this->category->metadesc);
+		}
+		elseif ($this->params->get('menu-meta_description'))
+		{
+			$this->document->setDescription($this->params->get('menu-meta_description'));
 		}
 
 		if ($this->category->metakey)
 		{
-			$this->params->set('keywords', $this->category->metakey);
+			$this->document->setMetadata('keywords', $this->category->metakey);
+		}
+		elseif ($this->params->get('menu-meta_keywords'))
+		{
+			$this->document->setMetadata('keywords', $this->params->get('menu-meta_keywords'));
+		}
+
+		if ($this->params->get('robots'))
+		{
+			$this->document->setMetadata('robots', $this->params->get('robots'));
 		}
 
 		if (!is_object($this->category->metadata))
@@ -229,14 +242,20 @@ class ContentViewCategory extends JViewCategory
 			$this->category->metadata = new Registry($this->category->metadata);
 		}
 
-		$mdata = $this->category->metadata->toArray();
-
-		if ($app->get('MetaAuthor') == '1' && $this->category->get('author', ''))
+		if (($app->get('MetaAuthor') == '1') && $this->category->get('author', ''))
 		{
-			$mdata['author'] = $this->category->get('author', '');
+			$this->document->setMetaData('author', $this->category->get('author', ''));
 		}
 
-		$this->params->set('metadata', $mdata);
+		$mdata = $this->category->metadata->toArray();
+
+		foreach ($mdata as $k => $v)
+		{
+			if ($v)
+			{
+				$this->document->setMetadata($k, $v);
+			}
+		}
 
 		return parent::display($tpl);
 	}

--- a/components/com_content/views/category/view.html.php
+++ b/components/com_content/views/category/view.html.php
@@ -212,29 +212,16 @@ class ContentViewCategory extends JViewCategory
 			$title = $this->category->title;
 		}
 
-		$this->document->setTitle($title);
+		$this->params->set('page_title', $title);
 
 		if ($this->category->metadesc)
 		{
-			$this->document->setDescription($this->category->metadesc);
-		}
-		elseif ($this->params->get('menu-meta_description'))
-		{
-			$this->document->setDescription($this->params->get('menu-meta_description'));
+			$this->params->set('menu-meta_description', $this->category->metadesc);
 		}
 
 		if ($this->category->metakey)
 		{
-			$this->document->setMetadata('keywords', $this->category->metakey);
-		}
-		elseif ($this->params->get('menu-meta_keywords'))
-		{
-			$this->document->setMetadata('keywords', $this->params->get('menu-meta_keywords'));
-		}
-
-		if ($this->params->get('robots'))
-		{
-			$this->document->setMetadata('robots', $this->params->get('robots'));
+			$this->params->set('keywords', $this->category->metakey);
 		}
 
 		if (!is_object($this->category->metadata))
@@ -242,20 +229,14 @@ class ContentViewCategory extends JViewCategory
 			$this->category->metadata = new Registry($this->category->metadata);
 		}
 
-		if (($app->get('MetaAuthor') == '1') && $this->category->get('author', ''))
-		{
-			$this->document->setMetaData('author', $this->category->get('author', ''));
-		}
-
 		$mdata = $this->category->metadata->toArray();
 
-		foreach ($mdata as $k => $v)
+		if ($app->get('MetaAuthor') == '1' && $this->category->get('author', ''))
 		{
-			if ($v)
-			{
-				$this->document->setMetadata($k, $v);
-			}
+			$mdata['author'] = $this->category->get('author', '');
 		}
+
+		$this->params->set('metadata', $mdata);
 
 		return parent::display($tpl);
 	}

--- a/libraries/src/MVC/View/CategoriesView.php
+++ b/libraries/src/MVC/View/CategoriesView.php
@@ -113,6 +113,6 @@ class CategoriesView extends HtmlView
 			$this->params->def('page_heading', \JText::_($this->pageHeading));
 		}
 
-		$this->setDocumentHeadData();
+		$this->setDocumentHeadData($this->params);
 	}
 }

--- a/libraries/src/MVC/View/CategoriesView.php
+++ b/libraries/src/MVC/View/CategoriesView.php
@@ -113,6 +113,6 @@ class CategoriesView extends HtmlView
 			$this->params->def('page_heading', \JText::_($this->pageHeading));
 		}
 
-		$this->setDocumentHeadDatas();
+		$this->setDocumentHeadData();
 	}
 }

--- a/libraries/src/MVC/View/CategoriesView.php
+++ b/libraries/src/MVC/View/CategoriesView.php
@@ -8,6 +8,8 @@
 
 namespace Joomla\CMS\MVC\View;
 
+use Joomla\CMS\Factory;
+
 defined('JPATH_PLATFORM') or die;
 
 /**
@@ -56,7 +58,7 @@ class CategoriesView extends HtmlView
 		$items  = $this->get('Items');
 		$parent = $this->get('Parent');
 
-		$app = \JFactory::getApplication();
+		$app = Factory::getApplication();
 
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
@@ -66,14 +68,7 @@ class CategoriesView extends HtmlView
 			return false;
 		}
 
-		if ($items === false)
-		{
-			$app->enqueueMessage(\JText::_('JGLOBAL_CATEGORY_NOT_FOUND'), 'error');
-
-			return false;
-		}
-
-		if ($parent == false)
+		if ($items === false || $parent === false)
 		{
 			$app->enqueueMessage(\JText::_('JGLOBAL_CATEGORY_NOT_FOUND'), 'error');
 
@@ -106,11 +101,8 @@ class CategoriesView extends HtmlView
 	 */
 	protected function prepareDocument()
 	{
-		$app   = \JFactory::getApplication();
-		$menus = $app->getMenu();
-
 		// Because the application sets a default page title, we need to get it from the menu item itself
-		$menu = $menus->getActive();
+		$menu = Factory::getApplication()->getMenu()->getActive();
 
 		if ($menu)
 		{
@@ -121,36 +113,6 @@ class CategoriesView extends HtmlView
 			$this->params->def('page_heading', \JText::_($this->pageHeading));
 		}
 
-		$title = $this->params->get('page_title', '');
-
-		if (empty($title))
-		{
-			$title = $app->get('sitename');
-		}
-		elseif ($app->get('sitename_pagetitles', 0) == 1)
-		{
-			$title = \JText::sprintf('JPAGETITLE', $app->get('sitename'), $title);
-		}
-		elseif ($app->get('sitename_pagetitles', 0) == 2)
-		{
-			$title = \JText::sprintf('JPAGETITLE', $title, $app->get('sitename'));
-		}
-
-		$this->document->setTitle($title);
-
-		if ($this->params->get('menu-meta_description'))
-		{
-			$this->document->setDescription($this->params->get('menu-meta_description'));
-		}
-
-		if ($this->params->get('menu-meta_keywords'))
-		{
-			$this->document->setMetadata('keywords', $this->params->get('menu-meta_keywords'));
-		}
-
-		if ($this->params->get('robots'))
-		{
-			$this->document->setMetadata('robots', $this->params->get('robots'));
-		}
+		$this->setDocumentHeadDatas();
 	}
 }

--- a/libraries/src/MVC/View/CategoryView.php
+++ b/libraries/src/MVC/View/CategoryView.php
@@ -125,7 +125,7 @@ class CategoryView extends HtmlView
 		$children    = $this->get('Children');
 		$parent      = $this->get('Parent');
 
-		if ($category == false || $parent == false)
+		if ($category === false || $parent === false)
 		{
 			return \JError::raiseError(404, \JText::_('JGLOBAL_CATEGORY_NOT_FOUND'));
 		}

--- a/libraries/src/MVC/View/CategoryView.php
+++ b/libraries/src/MVC/View/CategoryView.php
@@ -260,7 +260,7 @@ class CategoryView extends HtmlView
 			$this->params->def('page_heading', \JText::_($this->defaultPageTitle));
 		}
 
-		$this->setDocumentHeadDatas();
+		$this->setDocumentHeadData();
 	}
 
 	/**

--- a/libraries/src/MVC/View/CategoryView.php
+++ b/libraries/src/MVC/View/CategoryView.php
@@ -260,7 +260,7 @@ class CategoryView extends HtmlView
 			$this->params->def('page_heading', \JText::_($this->defaultPageTitle));
 		}
 
-		$this->setDocumentHeadData();
+		$this->setDocumentHeadData($this->params);
 	}
 
 	/**

--- a/libraries/src/MVC/View/HtmlView.php
+++ b/libraries/src/MVC/View/HtmlView.php
@@ -858,7 +858,7 @@ class HtmlView extends \JObject
 	 */
 	public function setDocumentTitle($title)
 	{
-		$app = \JFactory::getApplication();
+		$app = Factory::getApplication();
 
 		// Check for empty title and add site name if param is set
 		if (empty($title))
@@ -890,25 +890,8 @@ class HtmlView extends \JObject
 		{
 			/* @var Registry $params */
 			$params = $this->params;
-			$app    = Factory::getApplication();
 
-			$title = $params->get('page_title');
-
-			// Check for empty title and add site name if param is set
-			if (empty($title))
-			{
-				$title = $app->get('sitename');
-			}
-			elseif ($app->get('sitename_pagetitles', 0) == 1)
-			{
-				$title = \JText::sprintf('JPAGETITLE', $app->get('sitename'), $title);
-			}
-			elseif ($app->get('sitename_pagetitles', 0) == 2)
-			{
-				$title = \JText::sprintf('JPAGETITLE', $title, $app->get('sitename'));
-			}
-
-			$this->document->setTitle($title);
+			$this->setDocumentTitle($params->get('page_title'));
 
 			if ($params->get('menu-meta_description'))
 			{

--- a/libraries/src/MVC/View/HtmlView.php
+++ b/libraries/src/MVC/View/HtmlView.php
@@ -884,7 +884,7 @@ class HtmlView extends \JObject
 	 *
 	 * @since __DEPLOY_VERSION__
 	 */
-	protected function setDocumentHeadDatas()
+	protected function setDocumentHeadData()
 	{
 		if (isset($this->params) && $this->params instanceof Registry)
 		{

--- a/libraries/src/MVC/View/HtmlView.php
+++ b/libraries/src/MVC/View/HtmlView.php
@@ -882,7 +882,7 @@ class HtmlView extends \JObject
 	 *
 	 * @return void
 	 *
-	 * @since 3.9.0
+	 * @since __DEPLOY_VERSION__
 	 */
 	protected function setDocumentHeadDatas()
 	{

--- a/libraries/src/MVC/View/HtmlView.php
+++ b/libraries/src/MVC/View/HtmlView.php
@@ -880,45 +880,41 @@ class HtmlView extends \JObject
 	/**
 	 * Method to add some document head data from view's $params property
 	 *
-	 * @return void
+	 * @param   Registry  $params  The view menu parameters
 	 *
-	 * @since __DEPLOY_VERSION__
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
 	 */
-	protected function setDocumentHeadData()
+	protected function setDocumentHeadData(Registry $params)
 	{
-		if (isset($this->params) && $this->params instanceof Registry)
+		$this->setDocumentTitle($params->get('page_title'));
+
+		if ($params->get('menu-meta_description'))
 		{
-			/* @var Registry $params */
-			$params = $this->params;
+			$this->document->setDescription($params->get('menu-meta_description'));
+		}
 
-			$this->setDocumentTitle($params->get('page_title'));
+		if ($params->get('menu-meta_keywords'))
+		{
+			$this->document->setMetadata('keywords', $params->get('menu-meta_keywords'));
+		}
 
-			if ($params->get('menu-meta_description'))
+		if ($params->get('robots'))
+		{
+			$this->document->setMetadata('robots', $params->get('robots'));
+		}
+
+		$metaData = $this->params->get('metadata');
+
+		if (is_array($metaData))
+		{
+			// Remove empty value
+			$metaData = array_filter($metaData);
+
+			foreach ($metaData as $k => $v)
 			{
-				$this->document->setDescription($params->get('menu-meta_description'));
-			}
-
-			if ($params->get('menu-meta_keywords'))
-			{
-				$this->document->setMetadata('keywords', $params->get('menu-meta_keywords'));
-			}
-
-			if ($params->get('robots'))
-			{
-				$this->document->setMetadata('robots', $params->get('robots'));
-			}
-
-			$metaData = $this->params->get('metadata');
-
-			if (is_array($metaData))
-			{
-				// Remove empty value
-				$metaData = array_filter($metaData);
-
-				foreach ($metaData as $k => $v)
-				{
-					$this->document->setMetadata($k, $v);
-				}
+				$this->document->setMetadata($k, $v);
 			}
 		}
 	}

--- a/libraries/src/MVC/View/HtmlView.php
+++ b/libraries/src/MVC/View/HtmlView.php
@@ -905,7 +905,7 @@ class HtmlView extends \JObject
 			$this->document->setMetadata('robots', $params->get('robots'));
 		}
 
-		$metaData = $this->params->get('metadata');
+		$metaData = $params->get('metadata');
 
 		if (is_array($metaData))
 		{


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
In view classes of a component, we usually have to set document head data like page title, description, meta keywords, meta description, robots...

Instead of writing that repeating code again and again in every view, this PR introduces a new method called setDocumentHeadDatas to do that work. Component view classes now only need to set necessary data to $params property of the view if needed and call setDocumentHeadDatas method to set these data for document

### Testing Instructions
Code review for now. If the concept is accepted, I will convert actual view classes (like category view) to use this new method and human testing will be needed at that time.

