### PR TITLE
[4.0] Error page fixes

### DIFF
--- a/administrator/templates/atum/error.php
+++ b/administrator/templates/atum/error.php
@@ -50,6 +50,7 @@ $scriptOptions = [
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
 	<meta charset="utf-8">
+	<base href="<?php echo JUri::root(); ?>">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<meta name="theme-color" content="#1c3d5c">
 	<title><?php echo $this->title; ?> <?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></title>
@@ -80,9 +81,9 @@ $scriptOptions = [
 <body class="admin <?php echo $option . ' view-' . $view . ' layout-' . $layout . ' task-' . $task . ' itemid-' . $itemid; ?>">
 
 	<noscript>
-		<div class="alert alert-danger" role="alert">
+		<joomla-alert type="danger" style="display:block; opacity:1;">
 			<?php echo Text::_('JGLOBAL_WARNJAVASCRIPT'); ?>
-		</div>
+		</joomla-alert>
 	</noscript>
 
 	<?php // Wrapper ?>

--- a/administrator/templates/atum/error.php
+++ b/administrator/templates/atum/error.php
@@ -59,12 +59,22 @@ $logoSm      = $this->baseurl . '/templates/' . $this->template . '/images/logo-
 		<link href="<?php echo $langCss; ?>" rel="stylesheet">
 	<?php endif; ?>
 
-	<script src="<?php echo Uri::root(); ?>media/vendor/joomla-custom-elements/polyfills/webcomponents-ce.min.js"></script>
-	<script src="<?php echo Uri::root(); ?>media/vendor/joomla-custom-elements/js/joomla-alert-es5.min.js"></script>
+	<?php // Web Components and Custom Elements are loaded based on the client capabilities ?>
+	<script type="application/json" class="joomla-script-options new">
+		{
+			"system.paths": {
+				"root":<?php echo json_encode(Uri::root(true)); ?>,
+				"rootFull":<?php echo json_encode(Uri::root()); ?>,
+				"base":"\/administrator"
+			},
+			"webcomponents":{
+				"joomla-alert":<?php echo json_encode(Uri::root() . 'media/vendor/joomla-custom-elements/js/joomla-alert.min.js'); ?>
+
+			}
+		}
+	</script>
+
 	<script src="<?php echo Uri::root(); ?>media/system/js/core.js"></script>
-	<script src="<?php echo Uri::root(); ?>media/vendor/jquery/js/jquery.min.js"></script>
-	<script src="<?php echo Uri::root(); ?>media/vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
-	<script src="<?php echo Uri::root(); ?>media/system/js/bootstrap-init.min.js"></script>
 	<script src="<?php echo 'templates/' . $this->template . '/js/template.js'; ?>"></script>
 </head>
 

--- a/administrator/templates/atum/error.php
+++ b/administrator/templates/atum/error.php
@@ -34,6 +34,17 @@ $sitename    = htmlspecialchars($app->get('sitename', ''), ENT_QUOTES, 'UTF-8');
 $hidden      = $app->input->get('hidemainmenu');
 $logoLg      = $this->baseurl . '/templates/' . $this->template . '/images/logo.svg';
 $logoSm      = $this->baseurl . '/templates/' . $this->template . '/images/logo-icon.svg';
+
+$scriptOptions = [
+	"system.paths" => [
+		'root'     => JUri::root(true),
+		'rootFull' => JUri::root(),
+		'base'     => JUri::base(true),
+	],
+	"webcomponents" => [
+		"joomla-alert" => Uri::root() . 'media/vendor/joomla-custom-elements/js/joomla-alert.min.js',
+	]
+];
 ?>
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
@@ -60,19 +71,7 @@ $logoSm      = $this->baseurl . '/templates/' . $this->template . '/images/logo-
 	<?php endif; ?>
 
 	<?php // Web Components and Custom Elements are loaded based on the client capabilities ?>
-	<script type="application/json" class="joomla-script-options new">
-		{
-			"system.paths": {
-				"root":<?php echo json_encode(Uri::root(true)); ?>,
-				"rootFull":<?php echo json_encode(Uri::root()); ?>,
-				"base":"\/administrator"
-			},
-			"webcomponents":{
-				"joomla-alert":<?php echo json_encode(Uri::root() . 'media/vendor/joomla-custom-elements/js/joomla-alert.min.js'); ?>
-
-			}
-		}
-	</script>
+	<script type="application/json" class="joomla-script-options new"><?php echo json_encode($scriptOptions); ?></script>
 
 	<script src="<?php echo Uri::root(); ?>media/system/js/core.js"></script>
 	<script src="<?php echo 'templates/' . $this->template . '/js/template.js'; ?>"></script>

--- a/templates/cassiopeia/error.php
+++ b/templates/cassiopeia/error.php
@@ -68,12 +68,22 @@ $container = $params->get('fluidContainer') ? 'container-fluid' : 'container';
 		<link href="<?php echo $langCss; ?>" rel="stylesheet">
 	<?php endif; ?>
 
-	<script src="<?php echo $this->baseurl; ?>/media/vendor/joomla-custom-elements/polyfills/webcomponents-ce.min.js"></script>
-	<script src="<?php echo $this->baseurl; ?>/media/vendor/joomla-custom-elements/js/joomla-alert-es5.min.js"></script>
+	<?php // Web Components and Custom Elements are loaded based on the client capabilities ?>
+	<script type="application/json" class="joomla-script-options new">
+		{
+			"system.paths": {
+				"root":<?php echo json_encode(Uri::root(true)); ?>,
+				"rootFull":<?php echo json_encode(Uri::root()); ?>,
+				"base":"\/"
+			},
+			"webcomponents":{
+				"joomla-alert":<?php echo json_encode(Uri::root() . 'media/vendor/joomla-custom-elements/js/joomla-alert.min.js'); ?>
+
+			}
+		}
+	</script>
+
 	<script src="<?php echo $this->baseurl; ?>/media/system/js/core.min.js"></script>
-	<script src="<?php echo $this->baseurl; ?>/media/vendor/jquery/js/jquery.min.js"></script>
-	<script src="<?php echo $this->baseurl; ?>/media/vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
-	<script src="<?php echo $this->baseurl; ?>/media/system/js/bootstrap-init.min.js"></script>
 	<script src="<?php echo $this->baseurl . '/templates/' . $this->template . '/js/template.js'; ?>"></script>
 </head>
 

--- a/templates/cassiopeia/error.php
+++ b/templates/cassiopeia/error.php
@@ -62,11 +62,12 @@ $scriptOptions = [
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
 	<meta charset="utf-8">
+	<base href="<?php echo JUri::root(); ?>">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<title><?php echo $this->title; ?> <?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></title>
 
 	<link href="<?php echo $this->baseurl . '/templates/' . $this->template . '/favicon.ico'; ?>" rel="shortcut icon" type="image/vnd.microsoft.icon">
-	<link href="<?php echo $this->baseurl; ?>/media/vendor/joomla-custom-elements/css/joomla-alert.min.css" rel="stylesheet">
+	<link href="<?php echo Uri::root(); ?>media/vendor/joomla-custom-elements/css/joomla-alert.min.css" rel="stylesheet">
 	<link href="<?php echo $this->baseurl . '/templates/' . $this->template . '/css/template' . ($this->direction === 'rtl' ? '-rtl' : '') . '.min.css'; ?>" rel="stylesheet">
 
 	<?php $userCss = $this->baseurl . '/templates/' . $this->template . '/css/user.css'; ?>
@@ -109,10 +110,16 @@ $scriptOptions = [
 				<span class="fa fa-bars"></span>
 			</button>
 			<div class="collapse navbar-collapse" id="navbar">
-				<?php echo $this->getBuffer('modules', 'menu', ['style' => 'none']); ?>
+				<?php echo $this->getBuffer('modules', 'menu'); ?>
 			</div>
 		</nav>
 	</header>
+
+	<noscript>
+		<joomla-alert type="danger" style="display:block; opacity:1;">
+			<?php echo Text::_('JGLOBAL_WARNJAVASCRIPT'); ?>
+		</joomla-alert>
+	</noscript>
 
 	<div class="container-main">
 

--- a/templates/cassiopeia/error.php
+++ b/templates/cassiopeia/error.php
@@ -46,6 +46,17 @@ else
 
 // Container
 $container = $params->get('fluidContainer') ? 'container-fluid' : 'container';
+
+$scriptOptions = [
+	"system.paths" => [
+		'root'     => JUri::root(true),
+		'rootFull' => JUri::root(),
+		'base'     => JUri::base(true),
+	],
+	"webcomponents" => [
+		"joomla-alert" => Uri::root() . 'media/vendor/joomla-custom-elements/js/joomla-alert.min.js',
+	]
+];
 ?>
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
@@ -69,19 +80,7 @@ $container = $params->get('fluidContainer') ? 'container-fluid' : 'container';
 	<?php endif; ?>
 
 	<?php // Web Components and Custom Elements are loaded based on the client capabilities ?>
-	<script type="application/json" class="joomla-script-options new">
-		{
-			"system.paths": {
-				"root":<?php echo json_encode(Uri::root(true)); ?>,
-				"rootFull":<?php echo json_encode(Uri::root()); ?>,
-				"base":"\/"
-			},
-			"webcomponents":{
-				"joomla-alert":<?php echo json_encode(Uri::root() . 'media/vendor/joomla-custom-elements/js/joomla-alert.min.js'); ?>
-
-			}
-		}
-	</script>
+	<script type="application/json" class="joomla-script-options new"><?php echo json_encode($scriptOptions); ?></script>
 
 	<script src="<?php echo $this->baseurl; ?>/media/system/js/core.min.js"></script>
 	<script src="<?php echo $this->baseurl . '/templates/' . $this->template . '/js/template.js'; ?>"></script>

--- a/templates/cassiopeia/error.php
+++ b/templates/cassiopeia/error.php
@@ -115,12 +115,6 @@ $scriptOptions = [
 		</nav>
 	</header>
 
-	<noscript>
-		<joomla-alert type="danger" style="display:block; opacity:1;">
-			<?php echo Text::_('JGLOBAL_WARNJAVASCRIPT'); ?>
-		</joomla-alert>
-	</noscript>
-
 	<div class="container-main">
 
 		<div class="container-component">

--- a/templates/cassiopeia/js/template.js
+++ b/templates/cassiopeia/js/template.js
@@ -41,13 +41,6 @@ Joomla = window.Joomla || {};
 		var target = event && event.target ? event.target : document;
 
 		/**
-		 * Bootstrap tooltips
-		 */
-		jQuery(target).find('*[rel=tooltip]').tooltip({
-			html: true
-		});
-
-		/**
 		 * Prevent clicks on buttons within a disabled fieldset
 		 */
 		var fieldsets = target.querySelectorAll('fieldset.btn-group');


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/pull/19218 .

### Summary of Changes
Web Components and custom Elements are ES6 by definition, forcing to ES5 will fail on **all** ES6 capable browsers (eg 96% of them), unless there is also a patch for allowing ES5 class to act as ES6. We are using Babel to transpile from ES6 to ES5 and there is a missing part that patches Classes for custom Elements to act as native ES6 code. This is what you'll get:
<img width="1256" alt="screen shot 2017-12-30 at 21 23 45" src="https://user-images.githubusercontent.com/3889375/34457117-d5d67014-eda7-11e7-84ac-d4058370717c.png">

Or open the codpen in chrome or safari: https://codepen.io/dgt41/pen/BJRrJN and check the console for errors!

BUT, because something went terribly wrong on the server we shouldn't deliver a crap experience. So let's load the CE the right way:
This is what we sent:
<img width="1127" alt="screen shot 2017-12-30 at 21 12 50" src="https://user-images.githubusercontent.com/3889375/34457129-2da5f512-eda8-11e7-8dff-866fa353a7ca.png">

and this is how it becomes once page loaded:
<img width="1063" alt="screen shot 2017-12-30 at 21 13 17" src="https://user-images.githubusercontent.com/3889375/34457134-496d1de8-eda8-11e7-9fca-23c07d9ff824.png">

### Testing Instructions

Try creating some errors back end and front end. Observe that the alert custom element (the script) is correctly loaded

### Expected result



### Actual result



### Documentation Changes Required
No


@wilsonge this one is for you