### PR TITLE
Improve code for setting category view layout

### DIFF
--- a/libraries/src/MVC/View/CategoryView.php
+++ b/libraries/src/MVC/View/CategoryView.php
@@ -209,17 +209,20 @@ class CategoryView extends HtmlView
 		// If it is the active menu item, then the view and category id will match
 		$active = $app->getMenu()->getActive();
 
-		if ((!$active) || ((strpos($active->link, 'view=category') === false) || (strpos($active->link, '&id=' . (string) $this->category->id) === false)))
+		if ($active
+			&& $active->component == $this->extension
+			&& isset($active->query['view'], $active->query['id'])
+			&& $active->query['view'] == 'category'
+			&& $active->query['id'] == $this->category->id)
 		{
-			if ($layout = $category->params->get('category_layout'))
+			if (isset($active->query['layout']))
 			{
-				$this->setLayout($layout);
+				$this->setLayout($active->query['layout']);
 			}
 		}
-		elseif (isset($active->query['layout']))
+		elseif ($layout = $category->params->get('category_layout'))
 		{
-			// We need to set the layout in case this is an alternative menu item (with an alternative layout)
-			$this->setLayout($active->query['layout']);
+			$this->setLayout($layout);
 		}
 
 		$this->category->tags = new \JHelperTags;


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Currently, we have code to set layout for category view base on active menu item and layout setting from the category itself. The logic is:

1. If the current active menu item is a direct menu link to the category being displayed, then use the layout from menu item

2. If the above condition is wrong, then the layout set up for the category will be used 

This PR keeps that same logic, but improves the code a bit to have more accurate + easier to read:

1. It compares component property of active menu item with the component of the view (original code ignore it)

2. Compare view and id directly instead of using **strpos** like in the original code

### Testing Instructions
1. Code review can be considered as successful test

2.  For human testing:

- Create a category, in Options tab, set Layout parameter to  **Blog**.
- Create a menu item to link to **List All Categories** menu option. Go to frontend, access to that menu item, all categories will be displayed. Click on the link to the category you created above, check and confirm articles are displayed using Blog layout.
- Now, create a new menu item to link to **Category List** menu option, choose the category you created in menu parameter
- Access to that menu item, check the articles displayed and confirm that it uses List layout (instead of Blog layout  like you set for the category when you create it)