### PR TITLE
Improve code to build pathway for ContentViewCategory

### DIFF
--- a/components/com_content/views/category/view.html.php
+++ b/components/com_content/views/category/view.html.php
@@ -286,9 +286,8 @@ class ContentViewCategory extends JViewCategory
 
 		// Build path from current category until we found matching category from active menu item or root category
 		$path     = array(array('title' => $this->category->title, 'link' => ''));
-		$category = $this->category;
-
-		// Add category link to pathway until the category in active menu item or root category is found
+		$category = $this->category;		
+		
 		while ($category && $category->id != $menuCategoryId && $category->id > 1)
 		{
 			$path[]   = array('title' => $category->title, 'link' => ContentHelperRoute::getCategoryRoute($category->id));

--- a/components/com_content/views/category/view.html.php
+++ b/components/com_content/views/category/view.html.php
@@ -286,8 +286,8 @@ class ContentViewCategory extends JViewCategory
 
 		// Build path from current category until we found matching category from active menu item or root category
 		$path     = array(array('title' => $this->category->title, 'link' => ''));
-		$category = $this->category;		
-		
+		$category = $this->category;
+
 		while ($category && $category->id != $menuCategoryId && $category->id > 1)
 		{
 			$path[]   = array('title' => $category->title, 'link' => ContentHelperRoute::getCategoryRoute($category->id));

--- a/components/com_content/views/category/view.html.php
+++ b/components/com_content/views/category/view.html.php
@@ -288,7 +288,7 @@ class ContentViewCategory extends JViewCategory
 		$path     = array(array('title' => $this->category->title, 'link' => ''));
 		$category = $this->category;
 
-		// Add category link to pathway until the the category meets the category in active menu or root category is found
+		// Add category link to pathway until the category in active menu item or root category is found
 		while ($category && $category->id != $menuCategoryId && $category->id > 1)
 		{
 			$path[]   = array('title' => $category->title, 'link' => ContentHelperRoute::getCategoryRoute($category->id));


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Our current code to build pathway to category looks quite complicated and not easy to understand (and by reading the code, I think it can be wrong in some case - for example, id is passed in active menu item but that menu item is not linked to categories or category view of com_content)

This PR improves that code, make it easier to understand and more accurate. The logic is that we add the path from current to category to the category which is setup in active menu item (or to root category if no category found from active menu item)

### Testing Instructions
1. Prefer to have one developer to review code

2. For human testing, apply patch, check and see that pathway is still generated correctly as before (it usually has the format Home -> Menu item -> [Category] -> [Sub-Category] -> Article


