### PR TITLE
Fix parser error in plugin languagefilter on php5

### DIFF
--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -626,11 +626,8 @@ class PlgSystemLanguageFilter extends JPlugin
 					// Retrieves the Itemid from a login form.
 					$uri = new JUri($this->app->getUserState('users.login.form.return'));
 
-					// Workaround for php5 parse error T_PAAMAYIM_NEKUDOTAYIM
-					$app = $this->app;
-
 					// Get Itemid from SEF or home page
-					$query = $app::getRouter()->parse($uri);
+					$query = $this->app->getRouter()->parse($uri);
 
 					// Check, if the login form contains a menu item redirection.
 					if (!empty($query['Itemid']))

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -626,8 +626,11 @@ class PlgSystemLanguageFilter extends JPlugin
 					// Retrieves the Itemid from a login form.
 					$uri = new JUri($this->app->getUserState('users.login.form.return'));
 
+					// Workaround for php5 parse error T_PAAMAYIM_NEKUDOTAYIM
+					$app = $this->app;
+
 					// Get Itemid from SEF or home page
-					$query = $this->app::getRouter()->parse($uri);
+					$query = $app::getRouter()->parse($uri);
 
 					// Check, if the login form contains a menu item redirection.
 					if (!empty($query['Itemid']))


### PR DESCRIPTION
Pull Request for Issue #19267 .

### Summary of Changes
Add a workaround for php5


### Testing Instructions
Test Multilingual website on php5 or code review.


### Expected result
No error.


### Actual result
`Parse error: syntax error, unexpected '::' (T_PAAMAYIM_NEKUDOTAYIM) in plugins\system\languagefilter\languagefilter.php on line 630`


### Documentation Changes Required
No

  