### PR TITLE
[4.0] Fix filename not displaying properly in media manager.

### DIFF
--- a/plugins/filesystem/local/Adapter/LocalAdapter.php
+++ b/plugins/filesystem/local/Adapter/LocalAdapter.php
@@ -822,7 +822,7 @@ class LocalAdapter implements AdapterInterface
 	private function getFileName($path)
 	{
 		// Basename does not work here as it strips out certain characters like upper case umlaut u
-		$path = explode(DIRECTORY_SEPARATOR, $path);
+		$path = explode('/', $path);
 
 		// Return the last element
 		return array_pop($path);


### PR DESCRIPTION
###Issue

File and folder name not displaying properly.
The file path is showing in the place of the filename.

### Summary of Changes
Changes in:
<code>plugins/filesystem/local/Adapter/LocalAdapter.php</code> 


### Testing Instructions
Open media manager and check out.

### Expected result
![1](https://user-images.githubusercontent.com/30978328/34520937-0fb521c0-f0b1-11e7-97a4-96575af07306.PNG)



### Actual result

![2](https://user-images.githubusercontent.com/30978328/34520939-130fa1b0-f0b1-11e7-8cdc-9993b133d331.PNG)


### Documentation Changes Required

