### PR TITLE
additional complex value test

### DIFF
--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -91,7 +91,7 @@ class PlgSystemFields extends JPlugin
 			$value = key_exists($field->name, $fieldsData) ? $fieldsData[$field->name] : null;
 
 			// JSON encode value for complex fields
-			if (is_array($value) && count($value, COUNT_NORMAL) !== count($value, COUNT_RECURSIVE))
+			if (is_array($value) && (count($value, COUNT_NORMAL) !== count($value, COUNT_RECURSIVE) || !count(array_filter(array_keys($value),'is_numeric'))))
 			{
 				$value = json_encode($value);
 			}

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -91,7 +91,7 @@ class PlgSystemFields extends JPlugin
 			$value = key_exists($field->name, $fieldsData) ? $fieldsData[$field->name] : null;
 
 			// JSON encode value for complex fields
-			if (is_array($value) && (count($value, COUNT_NORMAL) !== count($value, COUNT_RECURSIVE) || !count(array_filter(array_keys($value),'is_numeric'))))
+			if (is_array($value) && (count($value, COUNT_NORMAL) !== count($value, COUNT_RECURSIVE) || !count(array_filter(array_keys($value), 'is_numeric'))))
 			{
 				$value = json_encode($value);
 			}


### PR DESCRIPTION
in my test case, I neglected to test for a single dimension array with non-numeric keys (a complex field, with a simple dataset)  This test excluded the normal arrays (multiselects and checkboxes) while identifying complex datasets by examining the array keys.

The test is now an array which has a normal count that does not match the recursive count (multidimensional) OR an array with non-numeric keys.

Pull Request for Issue # .

### Summary of Changes

numeric key test added to complex value test

### Testing Instructions

email me for a test plugin michael at richeyweb.com

### Expected result

after this modification, non-repeating fields behave normally

### Actual result



### Documentation Changes Required

none