### PR TITLE
Adding a Honeypot Field Plugin to the Captcha Options

### DIFF
--- a/administrator/language/en-GB/en-GB.plg_captcha_honeypot.ini
+++ b/administrator/language/en-GB/en-GB.plg_captcha_honeypot.ini
@@ -1,0 +1,63 @@
+; Joomla! Project
+; Copyright (C) 2005 - 2017 Open Source Matters. All rights reserved.
+; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
+; Note : All ini files need to be saved as UTF-8
+
+PLG_CAPTCHA_RECAPTCHA_XML_DESCRIPTION="This CAPTCHA plugin uses the reCAPTCHA service to prevent spammers while it helps to digitize books, newspapers and old radio shows. To get a site and secret key for your domain, go to <a href="_QQ_"https://www.google.com/recaptcha"_QQ_" target="_QQ_"_blank"_QQ_">https://www.google.com/recaptcha</a>. To use this for new account registration, go to Options in the User Manager and select CAPTCHA - reCAPTCHA as the CAPTCHA."
+PLG_CAPTCHA_RECAPTCHA="CAPTCHA - reCAPTCHA"
+
+; Params
+PLG_RECAPTCHA_VERSION_1_WARNING_LABEL="You have selected Version 1.0. All new sites should be using Version 2.0. Since May 2016 version 1.0 has been deprecated and is only maintained to provide support for Global Site keys which are no longer available from Google. Version 1.0 will not work for new sites and continued functionality can not be guaranteed."
+PLG_RECAPTCHA_VERSION_LABEL="Version"
+PLG_RECAPTCHA_VERSION_DESC="Version 2.0 is the recommended version. Version 1.0 is required if using deprecated Global reCAPTCHA keys. It is no longer supported and will not work for new sites."
+; The following two strings are deprecated and will be removed with 4.0. They generate wrong plural detection in Crowdin.
+PLG_RECAPTCHA_VERSION_1="1.0"
+PLG_RECAPTCHA_VERSION_2="2.0"
+PLG_RECAPTCHA_VERSION_V1="1.0"
+PLG_RECAPTCHA_VERSION_V2="2.0"
+PLG_RECAPTCHA_PUBLIC_KEY_LABEL="Site Key"
+PLG_RECAPTCHA_PUBLIC_KEY_DESC="Used in the JavaScript code that is served to your users. See the plugin description for instructions on getting a site key."
+PLG_RECAPTCHA_PRIVATE_KEY_LABEL="Secret Key"
+PLG_RECAPTCHA_PRIVATE_KEY_DESC="Used in the communication between your server and the reCAPTCHA server. Be sure to keep it a secret. See the plugin description for instructions on getting a secret key."
+PLG_RECAPTCHA_THEME_LABEL="Theme"
+PLG_RECAPTCHA_THEME_DESC="Defines which theme to use for reCAPTCHA."
+PLG_RECAPTCHA_THEME_RED="Red"
+PLG_RECAPTCHA_THEME_WHITE="White"
+PLG_RECAPTCHA_THEME_BLACKGLASS="BlackGlass"
+PLG_RECAPTCHA_THEME_CLEAN="Clean"
+PLG_RECAPTCHA_THEME_LIGHT="Light"
+PLG_RECAPTCHA_THEME_DARK="Dark"
+PLG_RECAPTCHA_LANG_LABEL="Language"
+PLG_RECAPTCHA_LANG_DESC="Select the language for the reCAPTCHA. If default is set and the language file has a custom translation, it will be used."
+PLG_RECAPTCHA_SIZE_LABEL="Size"
+PLG_RECAPTCHA_SIZE_DESC="Select the size for the reCAPTCHA field."
+PLG_RECAPTCHA_THEME_NORMAL="Normal"
+PLG_RECAPTCHA_THEME_COMPACT="Compact"
+
+; Error messages
+PLG_RECAPTCHA_ERROR_NO_PRIVATE_KEY="reCAPTCHA plugin needs a secret key to be set in its parameters. Please contact a site administrator."
+PLG_RECAPTCHA_ERROR_NO_PUBLIC_KEY="reCAPTCHA plugin needs a site key to be set in its parameters. Please contact a site administrator."
+PLG_RECAPTCHA_ERROR_EMPTY_SOLUTION="Please complete the CAPTCHA."
+PLG_RECAPTCHA_ERROR_NO_IP="For security reasons, you must pass the remote IP address to reCAPTCHA."
+PLG_RECAPTCHA_ERROR_UNKNOWN="Unknown error."
+PLG_RECAPTCHA_ERROR_INVALID_SITE_PUBLIC_KEY="We weren't able to verify the site key."
+PLG_RECAPTCHA_ERROR_INVALID_SITE_PRIVATE_KEY="We weren't able to verify the secret key."
+PLG_RECAPTCHA_ERROR_INVALID_REQUEST_COOKIE="The challenge parameter of the verify script was incorrect."
+PLG_RECAPTCHA_ERROR_INCORRECT_CAPTCHA_SOL="The CAPTCHA was incorrect."
+PLG_RECAPTCHA_ERROR_VERIFY_PARAMS_INCORRECT="The parameters to verify were incorrect, make sure you are passing all the required parameters."
+PLG_RECAPTCHA_ERROR_INVALID_REFERRER="reCAPTCHA API keys are tied to a specific domain name for security reasons."
+PLG_RECAPTCHA_ERROR_RECAPTCHA_NOT_REACHABLE="Unable to contact the reCAPTCHA verify server."
+
+; Uncomment(remove the ";" from the beginning of the line) the following lines if reCAPTCHA is not available in your language
+; When uncommenting, do NOT translate PLG_RECAPTCHA_CUSTOM_LANG
+; As of 01/01/2012, the following languages do not need translation: en, nl, fr, de, pt, ru, es, tr
+;PLG_RECAPTCHA_CUSTOM_LANG="true"
+;PLG_RECAPTCHA_INSTRUCTIONS_VISUAL="Type the two words:"
+;PLG_RECAPTCHA_INSTRUCTIONS_AUDIO="Type what you hear:"
+;PLG_RECAPTCHA_PLAY_AGAIN="Play sound again"
+;PLG_RECAPTCHA_CANT_HEAR_THIS="Download sound as MP3"
+;PLG_RECAPTCHA_VISUAL_CHALLENGE="Get a visual challenge"
+;PLG_RECAPTCHA_AUDIO_CHALLENGE="Get an audio challenge"
+;PLG_RECAPTCHA_REFRESH_BTN="Get a new challenge"
+;PLG_RECAPTCHA_HELP_BTN="Help"
+;PLG_RECAPTCHA_INCORRECT_TRY_AGAIN="Incorrect. Try again."

--- a/administrator/language/en-GB/en-GB.plg_captcha_honeypot.ini
+++ b/administrator/language/en-GB/en-GB.plg_captcha_honeypot.ini
@@ -3,61 +3,13 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 
-PLG_CAPTCHA_RECAPTCHA_XML_DESCRIPTION="This CAPTCHA plugin uses the reCAPTCHA service to prevent spammers while it helps to digitize books, newspapers and old radio shows. To get a site and secret key for your domain, go to <a href="_QQ_"https://www.google.com/recaptcha"_QQ_" target="_QQ_"_blank"_QQ_">https://www.google.com/recaptcha</a>. To use this for new account registration, go to Options in the User Manager and select CAPTCHA - reCAPTCHA as the CAPTCHA."
-PLG_CAPTCHA_RECAPTCHA="CAPTCHA - reCAPTCHA"
+PLG_CAPTCHA_HONEYPOT_XML_DESCRIPTION="This CAPTCHA plugin uses the honeypot functionality to prevent spam. If the hidden field is filled, the form cannot be sent."
+PLG_CAPTCHA_HONEYPOT="CAPTCHA - Honeypot"
 
 ; Params
-PLG_RECAPTCHA_VERSION_1_WARNING_LABEL="You have selected Version 1.0. All new sites should be using Version 2.0. Since May 2016 version 1.0 has been deprecated and is only maintained to provide support for Global Site keys which are no longer available from Google. Version 1.0 will not work for new sites and continued functionality can not be guaranteed."
-PLG_RECAPTCHA_VERSION_LABEL="Version"
-PLG_RECAPTCHA_VERSION_DESC="Version 2.0 is the recommended version. Version 1.0 is required if using deprecated Global reCAPTCHA keys. It is no longer supported and will not work for new sites."
-; The following two strings are deprecated and will be removed with 4.0. They generate wrong plural detection in Crowdin.
-PLG_RECAPTCHA_VERSION_1="1.0"
-PLG_RECAPTCHA_VERSION_2="2.0"
-PLG_RECAPTCHA_VERSION_V1="1.0"
-PLG_RECAPTCHA_VERSION_V2="2.0"
-PLG_RECAPTCHA_PUBLIC_KEY_LABEL="Site Key"
-PLG_RECAPTCHA_PUBLIC_KEY_DESC="Used in the JavaScript code that is served to your users. See the plugin description for instructions on getting a site key."
-PLG_RECAPTCHA_PRIVATE_KEY_LABEL="Secret Key"
-PLG_RECAPTCHA_PRIVATE_KEY_DESC="Used in the communication between your server and the reCAPTCHA server. Be sure to keep it a secret. See the plugin description for instructions on getting a secret key."
-PLG_RECAPTCHA_THEME_LABEL="Theme"
-PLG_RECAPTCHA_THEME_DESC="Defines which theme to use for reCAPTCHA."
-PLG_RECAPTCHA_THEME_RED="Red"
-PLG_RECAPTCHA_THEME_WHITE="White"
-PLG_RECAPTCHA_THEME_BLACKGLASS="BlackGlass"
-PLG_RECAPTCHA_THEME_CLEAN="Clean"
-PLG_RECAPTCHA_THEME_LIGHT="Light"
-PLG_RECAPTCHA_THEME_DARK="Dark"
-PLG_RECAPTCHA_LANG_LABEL="Language"
-PLG_RECAPTCHA_LANG_DESC="Select the language for the reCAPTCHA. If default is set and the language file has a custom translation, it will be used."
-PLG_RECAPTCHA_SIZE_LABEL="Size"
-PLG_RECAPTCHA_SIZE_DESC="Select the size for the reCAPTCHA field."
-PLG_RECAPTCHA_THEME_NORMAL="Normal"
-PLG_RECAPTCHA_THEME_COMPACT="Compact"
+PLG_CAPTCHA_HONEYPOT_FIELDNAME_LABEL="Honeypot field name"
+PLG_CAPTCHA_HONEYPOT_FIELDNAME_DESC="Enter the field name you wish to use to trap spambots"
 
-; Error messages
-PLG_RECAPTCHA_ERROR_NO_PRIVATE_KEY="reCAPTCHA plugin needs a secret key to be set in its parameters. Please contact a site administrator."
-PLG_RECAPTCHA_ERROR_NO_PUBLIC_KEY="reCAPTCHA plugin needs a site key to be set in its parameters. Please contact a site administrator."
-PLG_RECAPTCHA_ERROR_EMPTY_SOLUTION="Please complete the CAPTCHA."
-PLG_RECAPTCHA_ERROR_NO_IP="For security reasons, you must pass the remote IP address to reCAPTCHA."
-PLG_RECAPTCHA_ERROR_UNKNOWN="Unknown error."
-PLG_RECAPTCHA_ERROR_INVALID_SITE_PUBLIC_KEY="We weren't able to verify the site key."
-PLG_RECAPTCHA_ERROR_INVALID_SITE_PRIVATE_KEY="We weren't able to verify the secret key."
-PLG_RECAPTCHA_ERROR_INVALID_REQUEST_COOKIE="The challenge parameter of the verify script was incorrect."
-PLG_RECAPTCHA_ERROR_INCORRECT_CAPTCHA_SOL="The CAPTCHA was incorrect."
-PLG_RECAPTCHA_ERROR_VERIFY_PARAMS_INCORRECT="The parameters to verify were incorrect, make sure you are passing all the required parameters."
-PLG_RECAPTCHA_ERROR_INVALID_REFERRER="reCAPTCHA API keys are tied to a specific domain name for security reasons."
-PLG_RECAPTCHA_ERROR_RECAPTCHA_NOT_REACHABLE="Unable to contact the reCAPTCHA verify server."
 
-; Uncomment(remove the ";" from the beginning of the line) the following lines if reCAPTCHA is not available in your language
-; When uncommenting, do NOT translate PLG_RECAPTCHA_CUSTOM_LANG
-; As of 01/01/2012, the following languages do not need translation: en, nl, fr, de, pt, ru, es, tr
-;PLG_RECAPTCHA_CUSTOM_LANG="true"
-;PLG_RECAPTCHA_INSTRUCTIONS_VISUAL="Type the two words:"
-;PLG_RECAPTCHA_INSTRUCTIONS_AUDIO="Type what you hear:"
-;PLG_RECAPTCHA_PLAY_AGAIN="Play sound again"
-;PLG_RECAPTCHA_CANT_HEAR_THIS="Download sound as MP3"
-;PLG_RECAPTCHA_VISUAL_CHALLENGE="Get a visual challenge"
-;PLG_RECAPTCHA_AUDIO_CHALLENGE="Get an audio challenge"
-;PLG_RECAPTCHA_REFRESH_BTN="Get a new challenge"
-;PLG_RECAPTCHA_HELP_BTN="Help"
-;PLG_RECAPTCHA_INCORRECT_TRY_AGAIN="Incorrect. Try again."
+; Error Message
+PLG_RECAPTCHA_ERROR_HONEYPOT="Spam detected."

--- a/administrator/language/en-GB/en-GB.plg_captcha_honeypot.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_captcha_honeypot.sys.ini
@@ -1,0 +1,7 @@
+; Joomla! Project
+; Copyright (C) 2005 - 2017 Open Source Matters. All rights reserved.
+; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
+; Note : All ini files need to be saved as UTF-8
+
+PLG_CAPTCHA_RECAPTCHA_XML_DESCRIPTION="This CAPTCHA plugin uses the reCAPTCHA service to prevent spammers while it helps to digitize books, newspapers and old radio shows. To get a site and secret key for your domain, go to https://www.google.com/recaptcha. To use this for new account registration, go to Options in the User Manager and select Captcha - reCaptcha as the Captcha."
+PLG_CAPTCHA_RECAPTCHA="Captcha - ReCaptcha"

--- a/administrator/language/en-GB/en-GB.plg_captcha_honeypot.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_captcha_honeypot.sys.ini
@@ -3,5 +3,5 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 
-PLG_CAPTCHA_RECAPTCHA_XML_DESCRIPTION="This CAPTCHA plugin uses the reCAPTCHA service to prevent spammers while it helps to digitize books, newspapers and old radio shows. To get a site and secret key for your domain, go to https://www.google.com/recaptcha. To use this for new account registration, go to Options in the User Manager and select Captcha - reCaptcha as the Captcha."
-PLG_CAPTCHA_RECAPTCHA="Captcha - ReCaptcha"
+PLG_CAPTCHA_HONEYPOT_XML_DESCRIPTION="This CAPTCHA plugin uses the honeypot functionality to prevent spam. If the hidden field is filled, the form cannot be sent."
+PLG_CAPTCHA_HONEYPOT="CAPTCHA - Honeypot"

--- a/plugins/captcha/honeypot/honeypot.php
+++ b/plugins/captcha/honeypot/honeypot.php
@@ -24,7 +24,7 @@ class PlgCaptchaHoneypot extends JPlugin
 	 *
 	 * @return  string  The HTML to be embedded in the form.
 	 *
-	 * @since  3.9
+	 * @since  _DEPLOY_VERSION_
 	 */
 	public function onDisplay()
 	{
@@ -41,7 +41,7 @@ class PlgCaptchaHoneypot extends JPlugin
 	 *
 	 * @return  True if the answer is correct, false otherwise
 	 *
-	 * @since  3.9
+	 * @since  _DEPLOY_VERSION_
 	 */
 	public function onCheckAnswer()
 	{

--- a/plugins/captcha/honeypot/honeypot.php
+++ b/plugins/captcha/honeypot/honeypot.php
@@ -1,0 +1,7 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: elisa
+ * Date: 03.01.18
+ * Time: 19:19
+ */

--- a/plugins/captcha/honeypot/honeypot.php
+++ b/plugins/captcha/honeypot/honeypot.php
@@ -24,7 +24,7 @@ class PlgCaptchaHoneypot extends JPlugin
 	 *
 	 * @return  string  The HTML to be embedded in the form.
 	 *
-	 * @since  2.5
+	 * @since  3.9
 	 */
 	public function onDisplay()
 	{
@@ -41,7 +41,7 @@ class PlgCaptchaHoneypot extends JPlugin
 	 *
 	 * @return  True if the answer is correct, false otherwise
 	 *
-	 * @since  2.5
+	 * @since  3.9
 	 */
 	public function onCheckAnswer()
 	{

--- a/plugins/captcha/honeypot/honeypot.php
+++ b/plugins/captcha/honeypot/honeypot.php
@@ -1,7 +1,65 @@
 <?php
 /**
- * Created by PhpStorm.
- * User: elisa
- * Date: 03.01.18
- * Time: 19:19
+ * @package     Joomla.Plugin
+ * @subpackage  Captcha
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
+
+defined('_JEXEC') or die;
+
+
+/**
+ * Honeypot Plugin.
+ */
+
+class PlgCaptchaHoneypot extends JPlugin
+{
+
+	/**
+	 * Displays the honeypot input field and adds style declaration to hide it
+	 *
+	 * @param   string  $this->params->get("fieldname")   The name of the field.
+	 *
+	 * @return  string  The HTML to be embedded in the form.
+	 *
+	 * @since  2.5
+	 */
+	public function onDisplay()
+	{
+		$doc = JFactory::getDocument();
+/*		$doc->addStyleDeclaration('body label[for="' . $this->params->get("fieldname")  . '"], body label[for="jform_captcha"], body label[for="jform_captcha"] + span.optional, body #' . $this->params->get("fieldname")  . ' {display: none;  visibility: hidden; }');*/
+		return '<input id="' . $this->params->get("fieldname")  . '" name="' . $this->params->get("fieldname")  . '" size="40" type="text" />';
+	}
+
+
+	/**
+	 * Verifies if the honeypot field is empty
+	 *
+	 * @param   string  $code  Answer provided by user.
+	 *
+	 * @return  True if the answer is correct, false otherwise
+	 *
+	 * @since  2.5
+	 */
+	public function onCheckAnswer()
+	{
+		$input      = JFactory::getApplication()->input;
+		$honeypot   = $this->params->get("fieldname");
+		$response   = $input->get($honeypot, '', 'string');
+		$spam       = ($response != '');
+
+		// Discard spam submissions
+		if ($spam)
+		{
+			$this->_subject->setError(JText::_('PLG_RECAPTCHA_ERROR_HONEYPOT'));
+
+			return false;
+		}
+
+		return true;
+
+	}
+
+}

--- a/plugins/captcha/honeypot/honeypot.php
+++ b/plugins/captcha/honeypot/honeypot.php
@@ -30,7 +30,7 @@ class PlgCaptchaHoneypot extends JPlugin
 	{
 		$doc = JFactory::getDocument();
 /*		$doc->addStyleDeclaration('body label[for="' . $this->params->get("fieldname")  . '"], body label[for="jform_captcha"], body label[for="jform_captcha"] + span.optional, body #' . $this->params->get("fieldname")  . ' {display: none;  visibility: hidden; }');*/
-		return '<input id="' . $this->params->get("fieldname")  . '" name="' . $this->params->get("fieldname")  . '" size="40" type="text" />';
+		return '<input id="' . $this->params->get("fieldname")  . '" name="' . $this->params->get("fieldname")  . '" size="40" type="text" autocomplete="false" autofill="off" />';
 	}
 
 

--- a/plugins/captcha/honeypot/honeypot.xml
+++ b/plugins/captcha/honeypot/honeypot.xml
@@ -22,11 +22,11 @@
 			<fieldset name="basic">
 
 				<field
-						name="fieldname"
-						label="PLG_CAPTCHA_HONEYPOT_FIELDNAME_LABEL"
-						description="PLG_CAPTCHA_HONEYPOT_FIELDNAME_DESC"
-						type="text"
-						default="repeatmail"
+					name="fieldname"
+					label="PLG_CAPTCHA_HONEYPOT_FIELDNAME_LABEL"
+					description="PLG_CAPTCHA_HONEYPOT_FIELDNAME_DESC"
+					type="text"
+					default="repeatmail"
 				/>
 			</fieldset>
 		</fields>

--- a/plugins/captcha/honeypot/honeypot.xml
+++ b/plugins/captcha/honeypot/honeypot.xml
@@ -23,9 +23,9 @@
 
 				<field
 					name="fieldname"
+					type="text"
 					label="PLG_CAPTCHA_HONEYPOT_FIELDNAME_LABEL"
 					description="PLG_CAPTCHA_HONEYPOT_FIELDNAME_DESC"
-					type="text"
 					default="repeatmail"
 				/>
 			</fieldset>

--- a/plugins/captcha/honeypot/honeypot.xml
+++ b/plugins/captcha/honeypot/honeypot.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<extension version="3.9" type="plugin" group="captcha" method="upgrade">
+	<name>plg_captcha_honeypot</name>
+	<version>3.9.0</version>
+	<creationDate>January 2018</creationDate>
+	<author>Joomla! Project</author>
+	<authorEmail>admin@joomla.org</authorEmail>
+	<authorUrl>www.joomla.org</authorUrl>
+	<copyright>Copyright (C) 2005 - 2017 Open Source Matters. All rights reserved.</copyright>
+	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
+	<description>PLG_CAPTCHA_HONEYPOT_XML_DESCRIPTION</description>
+
+	<files>
+		<filename plugin="honeypot">honeypot.php</filename>
+	</files>
+	<languages>
+		<language tag="en-GB">language/en-GB.plg_captcha_honeypot.ini</language>
+		<language tag="en-GB">language/en-GB.plg_captcha_honeypot.sys.ini</language>
+	</languages>
+	<config>
+		<fields name="params">
+			<fieldset name="basic">
+
+				<field
+						name="fieldname"
+						label="PLG_CAPTCHA_HONEYPOT_FIELDNAME_LABEL"
+						description="PLG_CAPTCHA_HONEYPOT_FIELDNAME_DESC"
+						type="text"
+						default="repeatmail"
+				/>
+			</fieldset>
+		</fields>
+	</config>
+</extension>


### PR DESCRIPTION
### Summary of Changes
Altough Honeypot is not really a "captcha" functionality I think it fits best in the captcha plugin group. This plugin creates a hidden field named "repeatmail". The field name can be changed by the user. If repeatmail is filled, the form can't be sent.

### Testing Instructions
Enable the Honeypot in the Captcha Options in your main configuration.
- Use the Contactform and send a mail -> everything should work as before
- Use element inspector to disable the StyleDeclaration that hides the field and fill the field, try to send the form, an error should appear.

### Documentation Changes Required
Yes, as it's a new feature

  