### PR TITLE
Don't check custom fields if section is unknown

### DIFF
--- a/administrator/components/com_fields/helpers/fields.php
+++ b/administrator/components/com_fields/helpers/fields.php
@@ -60,6 +60,10 @@ class FieldsHelper
 				{
 					$parts[1] = $section;
 				}
+				else
+				{
+					return null;
+				}
 			}
 		}
 


### PR DESCRIPTION
With custom fields, we check the section part of the context if it is valid. The component can then adjust the section as needed. That is useful if the context triggered in plugin events doesn't match the field context.
If the context is unknown we usually return `null` in that method.
See for example the one for com_content:
https://github.com/joomla/joomla-cms/blob/05fd1d9f12ea62960f1ea921663fa4877994e538/administrator/components/com_content/helpers/content.php#L228-L252

I would expect if I return `null`, then custom fields would stop processing as the context is unknown to the component. However it just runs with the original context.

### Summary of Changes
This PR changes the `FieldsHelper::extract` method so it returns `null` as well if the validate method returns `null`. This will stop the calling fields code.

### Testing Instructions
I'm not sure how it can be really tested. I have a failure in my extension in J4 due to this, but it is a quite specific setting.
I think it should be possible to run an `onContentPrepare` event with a context `com_content.foo` and debug if com_fields tries to lookup fields (should get a query at least).

The easier way is probably to just make sure custom fields still work in Content, Contact and 3rd parties.

### Documentation Changes Required
No

@laoneo What do you think?
As a background I got an issue with the current code when I try categories with sections (with https://github.com/joomla/joomla-cms/pull/17769 applied already) and an unknown context is passed.