### PR TITLE
com_mailto remove unused params

### DIFF
--- a/components/com_mailto/mailto.xml
+++ b/components/com_mailto/mailto.xml
@@ -26,7 +26,4 @@
 			<language tag="en-GB">language/en-GB.com_mailto.sys.ini</language>
 		</languages>
 	</administration>
-	<params>
-		<param name="view" type="filelist" directory="/components/com_mailto/views" hide_none="1" hide_default="0" filter="." default="0" label="View Style" description="The view style for display" />
-	</params>
 </extension>


### PR DESCRIPTION
I was checking to see why we had an untranslated string and as far as i can tell this entire params section is not used

To test apply pr and make sure that the send to friend functionality works as before