### PR TITLE
Correctly redirect after logging into the multilingual joomla with association enabled

### DIFF
--- a/components/com_users/views/login/tmpl/default_login.php
+++ b/components/com_users/views/login/tmpl/default_login.php
@@ -33,7 +33,7 @@ JHtml::_('behavior.formvalidator');
 	<?php if (($this->params->get('logindescription_show') == 1 && str_replace(' ', '', $this->params->get('login_description')) != '') || $this->params->get('login_image') != '') : ?>
 		</div>
 	<?php endif; ?>
-	<form action="<?php echo JRoute::_('index.php?option=com_users&task=user.login'); ?>" method="post" class="form-validate form-horizontal well">
+	<form action="<?php echo JRoute::_('index.php?option=com_users&view=login'); ?>" method="post" class="form-validate form-horizontal well">
 		<fieldset>
 			<?php foreach ($this->form->getFieldset('credentials') as $field) : ?>
 				<?php if (!$field->hidden) : ?>
@@ -76,6 +76,7 @@ JHtml::_('behavior.formvalidator');
 					</button>
 				</div>
 			</div>
+			<input type="hidden" name="task" value="user.login" />
 			<?php $return = $this->form->getValue('return', '', $this->params->get('login_redirect_url', $this->params->get('login_redirect_menuitem'))); ?>
 			<input type="hidden" name="return" value="<?php echo base64_encode($return); ?>" />
 			<?php echo JHtml::_('form.token'); ?>

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -639,9 +639,16 @@ class PlgSystemLanguageFilter extends JPlugin
 
 						if (!$Itemid && $this->mode_sef)
 						{
+							// Workaround to not use current active item id
+							$activeId = $this->app->input->get('Itemid');
+							$this->app->input->set('Itemid', null);
+
 							// Get Itemid from SEF or home page
 							$query  = $this->app->getRouter()->parse($uri);
 							$Itemid = isset($query['Itemid']) ? $query['Itemid'] : null;
+
+							// Restore active item id
+							$this->app->input->set('Itemid', $activeId);
 						}
 
 						if ($Itemid)
@@ -652,10 +659,10 @@ class PlgSystemLanguageFilter extends JPlugin
 							// The login form contains a menu item redirection. Try to get associations from that menu item.
 							$associations = MenusHelper::getAssociations($Itemid);
 						}
-						elseif ($active)
+						else
 						{
-							// Try to get associations from the active menu item.
-							$associations = MenusHelper::getAssociations($active->id);
+							// Return URL does not have any Itemid
+							$active = null;
 						}
 					}
 

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -646,33 +646,22 @@ class PlgSystemLanguageFilter extends JPlugin
 
 						if ($Itemid)
 						{
+							// Assign the active item from previous page to check for home page below
+							$active = $menu->getItem($Itemid);
+
 							// The login form contains a menu item redirection. Try to get associations from that menu item.
 							$associations = MenusHelper::getAssociations($Itemid);
 						}
 						elseif ($active)
 						{
+							// Try to get associations from the active menu item.
 							$associations = MenusHelper::getAssociations($active->id);
 						}
 					}
 
-					// Check, if the login form contains a menu item redirection.
-					if (!empty($Itemid))
+					// If any association set to the user preferred site language, redirect to that page.
+					if (isset($associations[$lang_code]) && $menu->getItem($associations[$lang_code]))
 					{
-						// If any association set to the user preferred site language, redirect to that page.
-						if (isset($associations[$lang_code]) && $menu->getItem($associations[$lang_code]))
-						{
-							$associationItemid = $associations[$lang_code];
-							$this->app->setUserState('users.login.form.return', 'index.php?Itemid=' . $associationItemid);
-							$foundAssociation = true;
-						}
-					}
-					elseif (isset($associations[$lang_code]) && $menu->getItem($associations[$lang_code]))
-					{
-						/**
-						 * The login form does not contain a menu item redirection.
-						 * The active menu item has associations.
-						 * We redirect to the user preferred site language associated page.
-						 */
 						$associationItemid = $associations[$lang_code];
 						$this->app->setUserState('users.login.form.return', 'index.php?Itemid=' . $associationItemid);
 						$foundAssociation = true;


### PR DESCRIPTION
Pull Request for Issue #19289 .

### Summary of Changes

Do not lose menu item id in form action login.

Revert a part of code introduced in #19099: The URL from `$active->params['login_redirect_url']` should not use association.

### Testing Instructions

#### Configuration.
1. Install multilingual joomla staging (with merged #19099) with (en-GB) as default for website and another language for a test user (ex. fr-FR).
2. Create/use categories with menu association (Categories in EN, Categories in FR)
   - Categories in EN `index.php?option=com_content&view=categories&id=0&Itemid=102&lang=en`
   - Categories in FR `index.php?option=com_content&view=categories&id=0&Itemid=104&lang=fr`
3. Create or use existed menu item for login view/form in com_users (/login-form) and set language en-GB
   No SEF address: `index.php?option=com_users&view=login&Itemid=106&lang=en`.

#### Test 1. **PR enables association when SEF is off**
1. Turn off SEF.
2. Set "Menu Item Login Redirect" to:
    * a menu item, ex "Categories in en_GB". (this should use menu item association)
    * Note: only internal URL should not use any association.
3. Go to login form from users component - use above login menu item.
   (index.php?option=com_users&view=login&Itemid=106&lang=en)
4. After login:
   Before PR you will go to ex `index.php?option=com_content&view=categories&id=0&Itemid=102&lang=en`.
   Association did not work.
   After PR you will go to ex `index.php?option=com_content&view=categories&id=0&Itemid=104&lang=fr`.
   Association works.
5. IMO when the SEF is OFF, before PR, the whole association does not work.

#### Test 2. **PR enables association when SEF is on**
1. Turn on SEF.
2. Set "Menu Item Login Redirect" to:
   * a menu item, ex "Categories in en_GB". (this should use menu item association)
     Note: only internal URL should not use any association.
3. Go to login form (ex `index.php/en/login-form`).
4. After login:
   Before PR you will go to ex `index.php/en/allcategories-en-gb`.
   Association did not work.
   After PR you will go to ex `index.php/fr/allcategories-fr-fr`.
   Association works.

#### Test 3. **Use redirection to preferred home page - issue mentioned by infograf768**
1. Do not use any login redirections in module mod_login.
2. Go to Home in EN (`index.php/en`)
3. Login by mod_login
4. You will be (before and after PR) redirected to user language preferred home page `index.php/fr`

#### Test 4. **Use association on active page**
1. Do not use any login redirections in module mod_login.
2. Go to Categories in EN (`index.php/en/allcategories-en-gb`)
3. Login by mod_login
4. You will be (before and after PR) redirected to `index.php/fr/allcategories-fr-fr`
5. You can set access to Registered to test association after log in too.
6. --- No menu item ---
7. Logout and go to `/index.php/en/component/content/categories` (no menu item)
8. Login and check redirection: before and after PR you stay on the same page.

#### Test 5. Use association on module with "Login Redirection Page"
1. Go to the module `mod_login` on backend and in configuration set option "Login Redirection Page" to menu item `Categories in EN`.
2. Go to front/home page and log in:
   * Before PR you will be redirected to `index.php/en/allcategories-en-gb` (association does not work)
   * After PR you will be redirected to `index.php/pl/allcategories-fr-fr` (association works)

#### Test 6. **Restricted article with "readmore" and enabled association on login page**
1. Follow the instruction at https://github.com/joomla/joomla-cms/pull/19295#issuecomment-357234851

### Expected result
Association works.

### Actual result
Association did not work in a few mentioned tests.