### PR TITLE
Fix plg_debug prettyPrintJSON when session variables contain HTML

### DIFF
--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -2013,8 +2013,12 @@ class PlgSystemDebug extends JPlugin
 		// In PHP 5.4.0 or later we have pretty print option.
 		if (version_compare(PHP_VERSION, '5.4', '>='))
 		{
-			$json = json_encode($json, JSON_PRETTY_PRINT);
+			$json = json_encode($json, JSON_UNESCAPED_SLASHES|JSON_PRETTY_PRINT);
 		}
+
+		// Escape HTML in session vars
+		$json = str_replace('<', '&lt;', $json);
+		$json = str_replace('>', '&gt;', $json);
 
 		// Add some colors
 		$json = preg_replace('#"([^"]+)":#', '<span class=\'black\'>"</span><span class=\'green\'>$1</span><span class=\'black\'>"</span>:', $json);

--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -2017,8 +2017,7 @@ class PlgSystemDebug extends JPlugin
 		}
 
 		// Escape HTML in session vars
-		$json = str_replace('<', '&lt;', $json);
-		$json = str_replace('>', '&gt;', $json);
+		$json = htmlentities($json);
 
 		// Add some colors
 		$json = preg_replace('#"([^"]+)":#', '<span class=\'black\'>"</span><span class=\'green\'>$1</span><span class=\'black\'>"</span>:', $json);


### PR DESCRIPTION
Issue occurred when Kunena had set a session variable of the form `<strong>Some text</strong>`.

`json_encode` was converting this to  `<strong>Some text<\/strong>` - which was then an unclosed `<strong>` tag which was disrupting the remainder of the debug output.

Pull Request for Issue #19311 .

### Summary of Changes

Added `JSON_UNESCAPED_SLASHES` to the json_encode so that closing HTML is not disrupted.

Escape any HTML in the JSON output by converting < and > to htmlentities.

### Testing Instructions

1. Create a session variable containing `<strong>Some text</strong>`.
2. View session output before and after this fix.

### Expected result

`"<strong>Some text</strong>"`.

### Documentation Changes Required

None