### PR TITLE
Multilanguage: Correcting display of associated articles when they are Unpublished or when user has no access to them

### DIFF
--- a/components/com_content/helpers/association.php
+++ b/components/com_content/helpers/association.php
@@ -57,7 +57,7 @@ abstract class ContentHelperAssociation extends CategoryHelperAssociation
 						$query = $db->getQuery(true)
 							->select($db->qn('state'))
 							->from($db->qn('#__content'))
-							->where($db->qn('id') . ' = ' . (int)($assocId))
+							->where($db->qn('id') . ' = ' . (int) ($assocId))
 							->where('access IN (' . $groups . ')');
 						$db->setQuery($query);
 

--- a/components/com_content/helpers/association.php
+++ b/components/com_content/helpers/association.php
@@ -35,6 +35,8 @@ abstract class ContentHelperAssociation extends CategoryHelperAssociation
 		$jinput = JFactory::getApplication()->input;
 		$view   = $view === null ? $jinput->get('view') : $view;
 		$id     = empty($id) ? $jinput->getInt('id') : $id;
+		$user   = JFactory::getUser();
+		$groups = implode(',', $user->getAuthorisedViewLevels());
 
 		if ($view === 'article')
 		{
@@ -46,7 +48,26 @@ abstract class ContentHelperAssociation extends CategoryHelperAssociation
 
 				foreach ($associations as $tag => $item)
 				{
-					$return[$tag] = ContentHelperRoute::getArticleRoute($item->id, (int) $item->catid, $item->language);
+					if ($item->language != JFactory::getLanguage()->getTag())
+					{
+						$arrId   = explode(':', $item->id);
+						$assocId = $arrId[0];
+
+						$db    = JFactory::getDbo();
+						$query = $db->getQuery(true)
+							->select($db->qn('state'))
+							->from($db->qn('#__content'))
+							->where($db->qn('id') . ' = ' . (int)($assocId))
+							->where('access IN (' . $groups . ')');
+						$db->setQuery($query);
+
+						$result = (int) $db->loadResult();
+
+						if ($result > 0)
+						{
+							$return[$tag] = ContentHelperRoute::getArticleRoute($item->id, (int) $item->catid, $item->language);
+						}
+					}
 				}
 
 				return $return;

--- a/components/com_content/views/category/tmpl/default_articles.php
+++ b/components/com_content/views/category/tmpl/default_articles.php
@@ -146,14 +146,12 @@ $tableClass = $this->params->get('show_headings') != 1 ? ' table-noheader' : '';
 					<?php if (JLanguageAssociations::isEnabled() && $this->params->get('show_associations')) : ?>
 						<?php $associations = ContentHelperAssociation::displayAssociations($article->id); ?>
 						<?php foreach ($associations as $association) : ?>
-							<?php if ($association['language']->lang_code != JFactory::getLanguage()->getTag()) : ?>
-								<?php if ($this->params->get('flags', 1) && $association['language']->image) : ?>
-									<?php $flag = JHtml::_('image', 'mod_languages/' . $association['language']->image . '.gif', $association['language']->title_native, array('title' => $association['language']->title_native), true); ?>
-									&nbsp;<a href="<?php echo JRoute::_($association['item']); ?>"><?php echo $flag; ?></a>&nbsp;
-								<?php else : ?>
-									<?php $class = 'label label-association label-' . $association['language']->sef; ?>
-									&nbsp;<a class="<?php echo $class; ?>" href="<?php echo JRoute::_($association['item']); ?>"><?php echo strtoupper($association['language']->sef); ?></a>&nbsp;
-								<?php endif; ?>
+							<?php if ($this->params->get('flags', 1) && $association['language']->image) : ?>
+								<?php $flag = JHtml::_('image', 'mod_languages/' . $association['language']->image . '.gif', $association['language']->title_native, array('title' => $association['language']->title_native), true); ?>
+								&nbsp;<a href="<?php echo JRoute::_($association['item']); ?>"><?php echo $flag; ?></a>&nbsp;
+							<?php else : ?>
+								<?php $class = 'label label-association label-' . $association['language']->sef; ?>
+								&nbsp;<a class="<?php echo $class; ?>" href="<?php echo JRoute::_($association['item']); ?>"><?php echo strtoupper($association['language']->sef); ?></a>&nbsp;
 							<?php endif; ?>
 						<?php endforeach; ?>
 					<?php endif; ?>

--- a/layouts/joomla/content/info_block/associations.php
+++ b/layouts/joomla/content/info_block/associations.php
@@ -15,14 +15,12 @@ defined('JPATH_BASE') or die;
 <dd class="association">
 	<?php echo JText::_('JASSOCIATIONS'); ?>
 	<?php foreach ($associations as $association) : ?>
-		<?php if ($association['language']->lang_code != JFactory::getLanguage()->getTag()) : ?>
-			<?php if ($displayData['item']->params->get('flags', 1) && $association['language']->image) : ?>
-				<?php $flag = JHtml::_('image', 'mod_languages/' . $association['language']->image . '.gif', $association['language']->title_native, array('title' => $association['language']->title_native), true); ?>
-				&nbsp;<a href="<?php echo JRoute::_($association['item']); ?>"><?php echo $flag; ?></a>&nbsp;
-			<?php else : ?>
-				<?php $class = 'label label-association label-' . $association['language']->sef; ?>
-				&nbsp;<a class="<?php echo $class; ?>" href="<?php echo JRoute::_($association['item']); ?>"><?php echo strtoupper($association['language']->sef); ?></a>&nbsp;
-			<?php endif; ?>
+		<?php if ($displayData['item']->params->get('flags', 1) && $association['language']->image) : ?>
+			<?php $flag = JHtml::_('image', 'mod_languages/' . $association['language']->image . '.gif', $association['language']->title_native, array('title' => $association['language']->title_native), true); ?>
+			&nbsp;<a href="<?php echo JRoute::_($association['item']); ?>"><?php echo $flag; ?></a>&nbsp;
+		<?php else : ?>
+			<?php $class = 'label label-association label-' . $association['language']->sef; ?>
+			&nbsp;<a class="<?php echo $class; ?>" href="<?php echo JRoute::_($association['item']); ?>"><?php echo strtoupper($association['language']->sef); ?></a>&nbsp;
 		<?php endif; ?>
 	<?php endforeach; ?>
 </dd>


### PR DESCRIPTION
Pull Request for Issue #19279

### Summary of Changes
Filtering articles in content helper to prevent displaying an associated article when it is unpublished, trashed or when user has no access to it.
As we now filter there also to not display the flags for the current language, https://github.com/joomla/joomla-cms/pull/19009 is now useless and is reverted here.


### Testing Instructions
Install a clean multilingual site from staging. 2 languages are enough.
Set Articles Options to show Associations.

<img width="487" alt="screen shot 2018-01-06 at 17 56 20" src="https://user-images.githubusercontent.com/869724/34641900-02f96fca-f30b-11e7-904d-cb78644c51e6.png">

Add various articles in both languages  and set to their specific language category, to be displayed on the Home page through a blog or featured menu item.
Create a Category list menu item to display the same category.
Associate the articles.
Set some of them in one of the languages to unpublished or trashed.

Set some with access registered.
Set some to Unpublished

Display the language where the articles are simply Published and set to Public access

### Expected result in frontend
The small flag should not display in the info-block and in the category list to link to the associated respective articles 

### Actual result
The flag does display, and we get errors as explained in #19279

### Example
article en-GB is associated to article fr-FR
article fr-FR is set to registered
<img width="1036" alt="screen shot 2018-01-06 at 18 03 40" src="https://user-images.githubusercontent.com/869724/34641968-28c729bc-f30c-11e7-93cd-383091411443.png">
<img width="524" alt="screen shot 2018-01-06 at 18 04 06" src="https://user-images.githubusercontent.com/869724/34641974-30eceec4-f30c-11e7-9451-01685a3b2ac7.png">

Result in frontend:
<img width="986" alt="screen shot 2018-01-06 at 18 06 19" src="https://user-images.githubusercontent.com/869724/34641987-6df68a50-f30c-11e7-830b-3b1feaaf7fa9.png">
<img width="718" alt="screen shot 2018-01-06 at 18 06 46" src="https://user-images.githubusercontent.com/869724/34641990-749ad226-f30c-11e7-8b8e-2843598a9dec.png">

And when logged in as registered
<img width="766" alt="screen shot 2018-01-06 at 18 18 46" src="https://user-images.githubusercontent.com/869724/34642110-1cd01cd4-f30e-11e7-80ea-e3589ec8f5db.png">

<img width="770" alt="screen shot 2018-01-06 at 18 17 42" src="https://user-images.githubusercontent.com/869724/34642086-ee46502c-f30d-11e7-8f15-8bb8742e316c.png">

If the associated article is unpublished, the flag will not display either.

@Giuse69
@joomdonation 
@alikon 

