### PR TITLE
helpTOC cli script

### DIFF
--- a/build/helpTOC.php
+++ b/build/helpTOC.php
@@ -40,9 +40,6 @@ ini_set('display_errors', 1);
 // Load the admin en-GB.ini language file to get the JHELP language keys
 Factory::getLanguage()->load('joomla', JPATH_ADMINISTRATOR, null, false, false);
 
-// Import namespaced classes
-use Joomla\CMS\Version;
-use Joomla\Registry\Registry;
 
 /**
  * Utility CLI to retrieve the list of help screens from the docs wiki and create an index for the admin help view.


### PR DESCRIPTION
The CLI script was importing the namespace classes twice and therefore producing a fatal error

### Testing Instructions
~ php helpTOC.php

Should be no errors and an updated toc.json created in administrator\help\en-GB\toc.json