### PR TITLE
[4.0] Store module namespace on installation

### DIFF
--- a/administrator/modules/mod_feed/mod_feed.xml
+++ b/administrator/modules/mod_feed/mod_feed.xml
@@ -9,6 +9,7 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
 	<description>MOD_FEED_XML_DESCRIPTION</description>
+	<namespace>Joomla\Module\Feed</namespace>
 	<files>
 		<filename module="mod_feed">mod_feed.php</filename>
 		<filename>helper.php</filename>

--- a/administrator/modules/mod_latest/mod_latest.xml
+++ b/administrator/modules/mod_latest/mod_latest.xml
@@ -9,6 +9,7 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
 	<description>MOD_LATEST_XML_DESCRIPTION</description>
+	<namespace>Joomla\Module\Latest</namespace>
 	<files>
 		<filename module="mod_latest">mod_latest.php</filename>
 		<filename>helper.php</filename>

--- a/administrator/modules/mod_logged/mod_logged.xml
+++ b/administrator/modules/mod_logged/mod_logged.xml
@@ -9,6 +9,7 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
 	<description>MOD_LOGGED_XML_DESCRIPTION</description>
+	<namespace>Joomla\Module\Logged</namespace>
 	<files>
 		<filename module="mod_logged">mod_logged.php</filename>
 		<folder>tmpl</folder>

--- a/administrator/modules/mod_login/mod_login.xml
+++ b/administrator/modules/mod_login/mod_login.xml
@@ -9,6 +9,7 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
 	<description>MOD_LOGIN_XML_DESCRIPTION</description>
+	<namespace>Joomla\Module\Login</namespace>
 	<files>
 		<filename module="mod_login">mod_login.php</filename>
 		<folder>tmpl</folder>

--- a/administrator/modules/mod_menu/mod_menu.xml
+++ b/administrator/modules/mod_menu/mod_menu.xml
@@ -9,6 +9,7 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
 	<description>MOD_MENU_XML_DESCRIPTION</description>
+	<namespace>Joomla\Module\Menu</namespace>
 	<files>
 		<filename module="mod_menu">mod_menu.php</filename>
 		<folder>preset</folder>

--- a/administrator/modules/mod_multilangstatus/mod_multilangstatus.xml
+++ b/administrator/modules/mod_multilangstatus/mod_multilangstatus.xml
@@ -9,7 +9,6 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
 	<description>MOD_MULTILANGSTATUS_XML_DESCRIPTION</description>
-
 	<files>
 		<filename module="mod_multilangstatus">mod_multilangstatus.php</filename>
 		<folder>tmpl</folder>

--- a/administrator/modules/mod_popular/mod_popular.xml
+++ b/administrator/modules/mod_popular/mod_popular.xml
@@ -9,6 +9,7 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
 	<description>MOD_POPULAR_XML_DESCRIPTION</description>
+	<namespace>Joomla\Module\Popular</namespace>
 	<files>
 		<filename module="mod_popular">mod_popular.php</filename>
 		<folder>tmpl</folder>

--- a/administrator/modules/mod_quickicon/mod_quickicon.xml
+++ b/administrator/modules/mod_quickicon/mod_quickicon.xml
@@ -9,6 +9,7 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
 	<description>MOD_QUICKICON_XML_DESCRIPTION</description>
+	<namespace>Joomla\Module\Quickicon</namespace>
 	<files>
 		<filename module="mod_quickicon">mod_quickicon.php</filename>
 		<folder>tmpl</folder>

--- a/administrator/modules/mod_sampledata/mod_sampledata.xml
+++ b/administrator/modules/mod_sampledata/mod_sampledata.xml
@@ -9,6 +9,7 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.8.0</version>
 	<description>MOD_SAMPLEDATA_XML_DESCRIPTION</description>
+	<namespace>Joomla\Module\Sampledata</namespace>
 	<files>
 		<filename module="mod_sampledata">mod_sampledata.php</filename>
 		<filename>helper.php</filename>

--- a/administrator/modules/mod_stats_admin/mod_stats_admin.xml
+++ b/administrator/modules/mod_stats_admin/mod_stats_admin.xml
@@ -9,6 +9,7 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
 	<description>MOD_STATS_XML_DESCRIPTION</description>
+	<namespace>Joomla\Module\StatsAdmin</namespace>
 	<files>
 		<filename module="mod_stats_admin">mod_stats_admin.php</filename>
 		<folder>tmpl</folder>

--- a/administrator/modules/mod_version/mod_version.xml
+++ b/administrator/modules/mod_version/mod_version.xml
@@ -9,6 +9,7 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
 	<description>MOD_VERSION_XML_DESCRIPTION</description>
+	<namespace>Joomla\Module\Version</namespace>
 	<files>
 		<filename module="mod_version">mod_version.php</filename>
 		<folder>language</folder>

--- a/libraries/src/Installer/Adapter/ModuleAdapter.php
+++ b/libraries/src/Installer/Adapter/ModuleAdapter.php
@@ -138,6 +138,7 @@ class ModuleAdapter extends InstallerAdapter
 				$extension->set('state', -1);
 				$extension->set('manifest_cache', json_encode($manifest_details));
 				$extension->set('params', '{}');
+				$extension->set('namespace', $manifest_details['namespace']);
 				$results[] = clone $extension;
 			}
 		}
@@ -156,6 +157,7 @@ class ModuleAdapter extends InstallerAdapter
 				$extension->set('state', -1);
 				$extension->set('manifest_cache', json_encode($manifest_details));
 				$extension->set('params', '{}');
+				$extension->set('namespace', $manifest_details['namespace']);
 				$results[] = clone $extension;
 			}
 		}
@@ -420,6 +422,7 @@ class ModuleAdapter extends InstallerAdapter
 		$manifest_details = Installer::parseXMLInstallFile($this->parent->getPath('manifest'));
 		$this->parent->extension->manifest_cache = json_encode($manifest_details);
 		$this->parent->extension->name = $manifest_details['name'];
+		$this->parent->extension->namespace = $manifest_details['namespace'];
 
 		if ($this->parent->extension->store())
 		{
@@ -587,6 +590,9 @@ class ModuleAdapter extends InstallerAdapter
 			// Update name
 			$this->extension->name = $this->name;
 
+			// Update namespace
+			$this->extension->namespace = (string) $this->manifest->namespace;
+
 			// Update manifest
 			$this->extension->manifest_cache = $this->parent->generateManifestCache();
 
@@ -604,9 +610,10 @@ class ModuleAdapter extends InstallerAdapter
 		}
 		else
 		{
-			$this->extension->name    = $this->name;
-			$this->extension->type    = 'module';
-			$this->extension->element = $this->element;
+			$this->extension->name      = $this->name;
+			$this->extension->type      = 'module';
+			$this->extension->element   = $this->element;
+			$this->extension->namespace = (string) $this->manifest->namespace;
 
 			// There is no folder for modules
 			$this->extension->folder    = '';

--- a/modules/mod_articles_archive/mod_articles_archive.xml
+++ b/modules/mod_articles_archive/mod_articles_archive.xml
@@ -9,6 +9,7 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
 	<description>MOD_ARTICLES_ARCHIVE_XML_DESCRIPTION</description>
+	<namespace>Joomla\Module\ArticlesArchive</namespace>
 	<files>
 		<filename module="mod_articles_archive">mod_articles_archive.php</filename>
 		<folder>tmpl</folder>

--- a/modules/mod_articles_categories/mod_articles_categories.xml
+++ b/modules/mod_articles_categories/mod_articles_categories.xml
@@ -9,6 +9,7 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
 	<description>MOD_ARTICLES_CATEGORIES_XML_DESCRIPTION</description>
+	<namespace>Joomla\Module\ArticlesCategories</namespace>
 	<files>
 		<filename module="mod_articles_categories">mod_articles_categories.php</filename>
 		<folder>tmpl</folder>

--- a/modules/mod_articles_category/mod_articles_category.xml
+++ b/modules/mod_articles_category/mod_articles_category.xml
@@ -9,6 +9,7 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
 	<description>MOD_ARTICLES_CATEGORY_XML_DESCRIPTION</description>
+	<namespace>Joomla\Module\ArticlesCategory</namespace>
 	<files>
 		<filename module="mod_articles_category">mod_articles_category.php</filename>
 		<folder>tmpl</folder>

--- a/modules/mod_articles_latest/mod_articles_latest.xml
+++ b/modules/mod_articles_latest/mod_articles_latest.xml
@@ -9,6 +9,7 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
 	<description>MOD_LATEST_NEWS_XML_DESCRIPTION</description>
+	<namespace>Joomla\Module\ArticlesLatest</namespace>
 	<files>
 		<filename module="mod_articles_latest">mod_articles_latest.php</filename>
 		<folder>tmpl</folder>

--- a/modules/mod_articles_news/mod_articles_news.xml
+++ b/modules/mod_articles_news/mod_articles_news.xml
@@ -9,6 +9,7 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
 	<description>MOD_ARTICLES_NEWS_XML_DESCRIPTION</description>
+	<namespace>Joomla\Module\ArticlesNews</namespace>
 	<files>
 		<filename module="mod_articles_news">mod_articles_news.php</filename>
 		<folder>tmpl</folder>

--- a/modules/mod_articles_popular/mod_articles_popular.xml
+++ b/modules/mod_articles_popular/mod_articles_popular.xml
@@ -9,6 +9,7 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
 	<description>MOD_POPULAR_XML_DESCRIPTION</description>
+	<namespace>Joomla\Module\ArticlesPopular</namespace>
 	<files>
 		<filename module="mod_articles_popular">mod_articles_popular.php</filename>
 		<folder>tmpl</folder>

--- a/modules/mod_banners/mod_banners.xml
+++ b/modules/mod_banners/mod_banners.xml
@@ -9,6 +9,7 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
 	<description>MOD_BANNERS_XML_DESCRIPTION</description>
+	<namespace>Joomla\Module\Banners</namespace>
 	<files>
 		<filename module="mod_banners">mod_banners.php</filename>
 		<folder>tmpl</folder>

--- a/modules/mod_breadcrumbs/mod_breadcrumbs.xml
+++ b/modules/mod_breadcrumbs/mod_breadcrumbs.xml
@@ -9,6 +9,7 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
 	<description>MOD_BREADCRUMBS_XML_DESCRIPTION</description>
+	<namespace>Joomla\Module\Breadcrumbs</namespace>
 	<files>
 		<filename module="mod_breadcrumbs">mod_breadcrumbs.php</filename>
 		<folder>tmpl</folder>

--- a/modules/mod_feed/mod_feed.xml
+++ b/modules/mod_feed/mod_feed.xml
@@ -9,6 +9,7 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
 	<description>MOD_FEED_XML_DESCRIPTION</description>
+	<namespace>Joomla\Module\Feed</namespace>
 	<files>
 		<filename module="mod_feed">mod_feed.php</filename>
 		<folder>tmpl</folder>

--- a/modules/mod_finder/mod_finder.xml
+++ b/modules/mod_finder/mod_finder.xml
@@ -9,6 +9,7 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
 	<description>MOD_FINDER_XML_DESCRIPTION</description>
+	<namespace>Joomla\Module\Finder</namespace>
 	<files>
 		<filename module="mod_finder">mod_finder.php</filename>
 		<folder>tmpl</folder>

--- a/modules/mod_languages/mod_languages.xml
+++ b/modules/mod_languages/mod_languages.xml
@@ -9,6 +9,7 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.5.0</version>
 	<description>MOD_LANGUAGES_XML_DESCRIPTION</description>
+	<namespace>Joomla\Module\Languages</namespace>
 	<files>
 		<filename module="mod_languages">mod_languages.php</filename>
 		<folder>tmpl</folder>

--- a/modules/mod_login/mod_login.xml
+++ b/modules/mod_login/mod_login.xml
@@ -9,6 +9,7 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
 	<description>MOD_LOGIN_XML_DESCRIPTION</description>
+	<namespace>Joomla\Module\Login</namespace>
 	<files>
 		<filename module="mod_login">mod_login.php</filename>
 		<folder>tmpl</folder>

--- a/modules/mod_menu/mod_menu.xml
+++ b/modules/mod_menu/mod_menu.xml
@@ -9,6 +9,7 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
 	<description>MOD_MENU_XML_DESCRIPTION</description>
+	<namespace>Joomla\Module\Menu</namespace>
 	<files>
 		<filename module="mod_menu">mod_menu.php</filename>
 		<folder>tmpl</folder>

--- a/modules/mod_random_image/mod_random_image.xml
+++ b/modules/mod_random_image/mod_random_image.xml
@@ -9,6 +9,7 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
 	<description>MOD_RANDOM_IMAGE_XML_DESCRIPTION</description>
+	<namespace>Joomla\Module\RandomImage</namespace>
 	<files>
 		<filename module="mod_random_image">mod_random_image.php</filename>
 		<folder>tmpl</folder>

--- a/modules/mod_related_items/mod_related_items.xml
+++ b/modules/mod_related_items/mod_related_items.xml
@@ -9,6 +9,7 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
 	<description>MOD_RELATED_XML_DESCRIPTION</description>
+	<namespace>Joomla\Module\RelatedItems</namespace>
 	<files>
 		<filename module="mod_related_items">mod_related_items.php</filename>
 		<folder>tmpl</folder>

--- a/modules/mod_search/mod_search.xml
+++ b/modules/mod_search/mod_search.xml
@@ -9,6 +9,7 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
 	<description>MOD_SEARCH_XML_DESCRIPTION</description>
+	<namespace>Joomla\Module\Search</namespace>
 	<files>
 		<filename module="mod_search">mod_search.php</filename>
 		<folder>tmpl</folder>

--- a/modules/mod_stats/mod_stats.xml
+++ b/modules/mod_stats/mod_stats.xml
@@ -9,6 +9,7 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
 	<description>MOD_STATS_XML_DESCRIPTION</description>
+	<namespace>Joomla\Module\Stats</namespace>
 	<files>
 		<filename module="mod_stats">mod_stats.php</filename>
 		<folder>tmpl</folder>

--- a/modules/mod_syndicate/mod_syndicate.xml
+++ b/modules/mod_syndicate/mod_syndicate.xml
@@ -9,6 +9,7 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
 	<description>MOD_SYNDICATE_XML_DESCRIPTION</description>
+	<namespace>Joomla\Module\Syndicate</namespace>
 	<files>
 		<filename module="mod_syndicate">mod_syndicate.php</filename>
 		<folder>tmpl</folder>

--- a/modules/mod_tags_popular/mod_tags_popular.xml
+++ b/modules/mod_tags_popular/mod_tags_popular.xml
@@ -9,6 +9,7 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.1.0</version>
 	<description>MOD_TAGS_POPULAR_XML_DESCRIPTION</description>
+	<namespace>Joomla\Module\TagsPopular</namespace>
 	<files>
 		<filename module="mod_tags_popular">mod_tags_popular.php</filename>
 		<folder>tmpl</folder>

--- a/modules/mod_tags_similar/mod_tags_similar.xml
+++ b/modules/mod_tags_similar/mod_tags_similar.xml
@@ -9,6 +9,7 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.1.0</version>
 	<description>MOD_TAGS_SIMILAR_XML_DESCRIPTION</description>
+	<namespace>Joomla\Module\TagsSimilar</namespace>
 	<files>
 		<filename module="mod_tags_similar">mod_tags_similar.php</filename>
 		<folder>tmpl</folder>

--- a/modules/mod_users_latest/mod_users_latest.xml
+++ b/modules/mod_users_latest/mod_users_latest.xml
@@ -9,6 +9,7 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
 	<description>MOD_USERS_LATEST_XML_DESCRIPTION</description>
+	<namespace>Joomla\Module\UsersLatest</namespace>
 	<files>
 		<filename module="mod_users_latest">mod_users_latest.php</filename>
 		<folder>tmpl</folder>

--- a/modules/mod_whosonline/mod_whosonline.xml
+++ b/modules/mod_whosonline/mod_whosonline.xml
@@ -9,6 +9,7 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
 	<description>MOD_WHOSONLINE_XML_DESCRIPTION</description>
+	<namespace>Joomla\Module\Whosonline</namespace>
 	<files>
 		<filename module="mod_whosonline">mod_whosonline.php</filename>
 		<folder>tmpl</folder>

--- a/modules/mod_wrapper/mod_wrapper.xml
+++ b/modules/mod_wrapper/mod_wrapper.xml
@@ -9,6 +9,7 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
 	<description>MOD_WRAPPER_XML_DESCRIPTION</description>
+	<namespace>Joomla\Module\Wrapper</namespace>
 	<files>
 		<filename module="mod_wrapper">mod_wrapper.php</filename>
 		<folder>tmpl</folder>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This PR did two things:

1. Store namespace for module when modules are installed/updated

2. Update xml files to have correct namespace tag for namespaced modules

This PR is created so that @wilsonge can finish his PR https://github.com/joomla/joomla-cms/pull/18703/

### Testing Instructions
Can be merged by code review