### PR TITLE
Protostar: missing some RTL code and order rtl classes load 

### DIFF
--- a/templates/protostar/component.php
+++ b/templates/protostar/component.php
@@ -34,7 +34,7 @@ JHtmlBootstrap::loadCss($includeMaincss = false, $this->direction);
 	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
 	<jdoc:include type="head" />
 </head>
-<body class="contentpane modal">
+<body class="contentpane modal <?php echo ($this->direction == 'rtl' ? ' rtl' : ''); ?>">
 	<jdoc:include type="message" />
 	<jdoc:include type="component" />
 </body>

--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -1454,11 +1454,6 @@ select:focus:invalid:focus {
 	-moz-border-radius: 0;
 	border-radius: 0;
 }
-.input-append .active,
-.input-prepend .active {
-	background-color: #a9dba9;
-	border-color: #46a546;
-}
 .input-prepend .add-on,
 .input-prepend .btn {
 	margin-right: -1px;
@@ -1561,6 +1556,10 @@ input.search-query {
 	-webkit-border-radius: 14px 0 0 14px;
 	-moz-border-radius: 14px 0 0 14px;
 	border-radius: 14px 0 0 14px;
+}
+.js-stools-field-filter .input-prepend,
+.js-stools-field-filter .input-append {
+	margin-bottom: 0;
 }
 .form-search input,
 .form-search textarea,
@@ -1683,6 +1682,14 @@ legend + .control-group {
 }
 .subform-repeatable-wrapper tr.ui-sortable-helper {
 	display: table;
+}
+@media (min-width: 980px) and (max-width: 1215px) {
+	.float-cols .control-label {
+		float: none;
+	}
+	.float-cols .controls {
+		margin-left: 0;
+	}
 }
 table {
 	max-width: 100%;
@@ -1989,6 +1996,17 @@ table th[class*="span"],
 	overflow: hidden;
 	background-color: #e5e5e5;
 	border-bottom: 1px solid #fff;
+}
+.dropdown-menu .menuitem-group {
+	margin: 4px 1px;
+	overflow: hidden;
+	border-top: 1px solid #eee;
+	border-bottom: 1px solid #eee;
+	background-color: #eee;
+	color: #555;
+	text-transform: capitalize;
+	font-size: 95%;
+	padding: 3px 20px;
 }
 .dropdown-menu > li > a {
 	display: block;
@@ -2829,6 +2847,7 @@ input[type="submit"].btn.btn-mini {
 	top: -2px;
 	right: -21px;
 	line-height: 18px;
+	cursor: pointer;
 }
 .alert-success {
 	background-color: #dff0d8;
@@ -4793,6 +4812,10 @@ a.badge:focus {
 	.dl-horizontal dd {
 		margin-left: 0;
 	}
+	.dropdown-menu .menuitem-group {
+		background-color: #10223e;
+		color: #eee;
+	}
 	.container {
 		width: auto;
 	}
@@ -6139,6 +6162,7 @@ fieldset.radio.btn-group {
 }
 input.invalid {
 	border: 1px solid #9d261d;
+	background: #f2dede;
 }
 select.chzn-done.invalid + .chzn-container.chzn-container-single > a.chzn-single,
 select.chzn-done.invalid + .chzn-container.chzn-container-multi > ul.chzn-choices {
@@ -7105,6 +7129,9 @@ div.modal.jviewport-width100 {
 .rtl .modal-footer button {
 	float: left;
 }
+.rtl .finder-selects {
+	margin: 0 0 15px 15px;
+}
 body {
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
@@ -7125,8 +7152,14 @@ body.site.fluid {
 }
 .site-title {
 	font-size: 40px;
+	font-size: calc(16px + 2.16vw);
 	line-height: 48px;
 	font-weight: bold;
+}
+@media (min-width: 1024px) {
+	.site-title {
+		font-size: 40px;
+	}
 }
 .brand {
 	color: #001a27;
@@ -7265,6 +7298,13 @@ p {
 .breadcrumb > li,
 .breadcrumb > .active {
 	color: #515151;
+}
+#login-form {
+	margin-top: 8px;
+}
+.add-on + #modlgn-username,
+.add-on + #modlgn-passwd {
+	width: 132px;
 }
 .img_caption .left {
 	float: left;
@@ -7560,6 +7600,12 @@ figcaption {
 		height: 0;
 		z-index: 100;
 	}
+	.nav-collapse .nav > li.active > a {
+		color: #fff;
+	}
+	.nav-collapse .nav > li.active > a:hover {
+		color: #555;
+	}
 }
 @media (min-width: 768px) and (max-width: 979px) {
 	#login-form .input-small {
@@ -7629,7 +7675,7 @@ code {
 .search span.highlight {
 	background-color: #FFFFCC;
 	font-weight: bold;
-	padding: 1px 4px;
+	padding: 1px 0;
 }
 dt.result-title {
 	word-wrap: break-word;
@@ -7643,6 +7689,17 @@ body.modal-open {
 }
 #users-profile-custom label {
 	display: inline;
+}
+.controls > .radio:first-child,
+.controls > .checkbox:first-child {
+	padding-top: 0;
+}
+.form-horizontal .controls > .radio:first-child,
+.form-horizontal .controls > .checkbox:first-child {
+	padding-top: 5px;
+}
+.form-horizontal .controls > .radio.btn-group:first-child {
+	padding-top: 0;
 }
 .field-media-wrapper .modal .modal-body {
 	padding: 5px 10px;
@@ -7675,4 +7732,7 @@ ul.manager .height-50 .icon-folder-2 {
 }
 .popover-content {
 	min-height: 33px;
+}
+.finder-selects {
+	margin: 0 15px 15px 0;
 }

--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -160,24 +160,6 @@ textarea {
 		page-break-after: avoid;
 	}
 }
-.rtl .navigation .nav-child {
-	left: auto;
-	right: 0;
-}
-.rtl .navigation .nav > li > .nav-child:before {
-	left: auto;
-	right: 12px;
-}
-.rtl .navigation .nav > li > .nav-child:after {
-	left: auto;
-	right: 13px;
-}
-.rtl .categories-list .collapse {
-	margin: 0 20px 0 0;
-}
-.rtl .modal-footer button {
-	float: left;
-}
 .clearfix {
 	*zoom: 1;
 }
@@ -7104,6 +7086,24 @@ div.modal.jviewport-width100 {
 }
 .icon-expired:before {
 	content: "\4b";
+}
+.rtl .navigation .nav-child {
+	left: auto;
+	right: 0;
+}
+.rtl .navigation .nav > li > .nav-child:before {
+	left: auto;
+	right: 12px;
+}
+.rtl .navigation .nav > li > .nav-child:after {
+	left: auto;
+	right: 13px;
+}
+.rtl .categories-list .collapse {
+	margin: 0 20px 0 0;
+}
+.rtl .modal-footer button {
+	float: left;
 }
 body {
 	-webkit-font-smoothing: antialiased;

--- a/templates/protostar/error.php
+++ b/templates/protostar/error.php
@@ -103,6 +103,7 @@ else
 	. ($task ? ' task-' . $task : ' no-task')
 	. ($itemid ? ' itemid-' . $itemid : '')
 	. ($params->get('fluidContainer') ? ' fluid' : '');
+	echo ($this->direction == 'rtl' ? ' rtl' : '');
 ?>">
 	<!-- Body -->
 	<div class="body">

--- a/templates/protostar/less/template.less
+++ b/templates/protostar/less/template.less
@@ -3,7 +3,6 @@
 
 // Core variables and mixins
 @import "variables.less"; // Custom for this template
-@import "template_rtl.less"; // Specific for rtl
 @import "../../../media/jui/less/mixins.less";
 
 // Grid system and page structure
@@ -85,6 +84,9 @@
 
 // Icon Font
 @import "icomoon.less";
+
+// RTL specific
+@import "template_rtl.less"; 
 
 /* Site Body Styles */
 body {
@@ -395,10 +397,10 @@ figcaption {
 .navigation .nav-child li > a:hover,
 .navigation .nav-child li > a:focus,
 .navigation .nav-child:hover > a {
-  text-decoration: none;
-  color: @dropdownLinkColorHover;
-  background-color: @dropdownLinkBackgroundHover;
-  #gradient > .vertical(@dropdownLinkBackgroundHover, darken(@dropdownLinkBackgroundHover, 5%));
+	text-decoration: none;
+	color: @dropdownLinkColorHover;
+	background-color: @dropdownLinkBackgroundHover;
+	#gradient > .vertical(@dropdownLinkBackgroundHover, darken(@dropdownLinkBackgroundHover, 5%));
 }
 
 // Category collapse
@@ -634,8 +636,8 @@ dd.result-text {
 
 /* Prevent scrolling on the parent window of a modal */
 body.modal-open {
-  overflow: hidden;
-  -ms-overflow-style: none;
+	overflow: hidden;
+	-ms-overflow-style: none;
 }
 
 /* Align fields for the profile display */
@@ -676,12 +678,12 @@ li {
 }
 
 ul.manager .height-50 .icon-folder-2 {
-    height: 35px;
-    width: 35px;
-    line-height: 35px;
-    font-size: 30px;
+	height: 35px;
+	width: 35px;
+	line-height: 35px;
+	font-size: 30px;
 }
 /* Popover minimum height - overwrite bootstrap default */
 .popover-content {
-    min-height: 33px;
+	min-height: 33px;
 }

--- a/templates/protostar/less/template_rtl.less
+++ b/templates/protostar/less/template_rtl.less
@@ -23,3 +23,8 @@
 .rtl .modal-footer button {
 	float: left;
 }
+
+// Finder selects
+.rtl .finder-selects {
+	margin: 0 0 15px 15px;
+}


### PR DESCRIPTION
Replaces https://github.com/joomla/joomla-cms/pull/13060

This PR adds the class `rtl` on body when the language is RTL in order to use any `.rtl .something` .
It is added in component.php as well as error.php. Code is similar to index.php. It allows adding specific `.rtl .something` in the rtl.less files.

It also changes the order of loading of the `.rtl .something` present in the template_rtl.less when they are saved into template.css by generatecss.php. 
This because these rtl classes should override their counterpart as set from various .less files when importing.
