### PR TITLE
Protostar: missing some RTL code and order rtl classes load

### DIFF
--- a/templates/protostar/component.php
+++ b/templates/protostar/component.php
@@ -34,7 +34,7 @@ JHtmlBootstrap::loadCss($includeMaincss = false, $this->direction);
 	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
 	<jdoc:include type="head" />
 </head>
-<body class="contentpane modal">
+<body class="contentpane modal <?php echo ($this->direction == 'rtl' ? ' rtl' : ''); ?>">
 	<jdoc:include type="message" />
 	<jdoc:include type="component" />
 </body>

--- a/templates/protostar/component.php
+++ b/templates/protostar/component.php
@@ -34,7 +34,7 @@ JHtmlBootstrap::loadCss($includeMaincss = false, $this->direction);
 	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
 	<jdoc:include type="head" />
 </head>
-<body class="contentpane modal <?php echo ($this->direction == 'rtl' ? ' rtl' : ''); ?>">
+<body class="contentpane modal <?php echo ($this->direction === 'rtl' ? ' rtl' : ''); ?>">
 	<jdoc:include type="message" />
 	<jdoc:include type="component" />
 </body>

--- a/templates/protostar/component.php
+++ b/templates/protostar/component.php
@@ -34,7 +34,7 @@ JHtmlBootstrap::loadCss($includeMaincss = false, $this->direction);
 	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
 	<jdoc:include type="head" />
 </head>
-<body class="contentpane modal <?php echo ($this->direction === 'rtl' ? ' rtl' : ''); ?>">
+<body class="contentpane modal<?php echo $this->direction === 'rtl' ? ' rtl' : ''; ?>">
 	<jdoc:include type="message" />
 	<jdoc:include type="component" />
 </body>

--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -160,27 +160,6 @@ textarea {
 		page-break-after: avoid;
 	}
 }
-.rtl .navigation .nav-child {
-	left: auto;
-	right: 0;
-}
-.rtl .navigation .nav > li > .nav-child:before {
-	left: auto;
-	right: 12px;
-}
-.rtl .navigation .nav > li > .nav-child:after {
-	left: auto;
-	right: 13px;
-}
-.rtl .categories-list .collapse {
-	margin: 0 20px 0 0;
-}
-.rtl .modal-footer button {
-	float: left;
-}
-.rtl .finder-selects {
-	margin: 0 0 15px 15px;
-}
 .clearfix {
 	*zoom: 1;
 }
@@ -7735,4 +7714,25 @@ ul.manager .height-50 .icon-folder-2 {
 }
 .finder-selects {
 	margin: 0 15px 15px 0;
+}
+.rtl .navigation .nav-child {
+	left: auto;
+	right: 0;
+}
+.rtl .navigation .nav > li > .nav-child:before {
+	left: auto;
+	right: 12px;
+}
+.rtl .navigation .nav > li > .nav-child:after {
+	left: auto;
+	right: 13px;
+}
+.rtl .categories-list .collapse {
+	margin: 0 20px 0 0;
+}
+.rtl .modal-footer button {
+	float: left;
+}
+.rtl .finder-selects {
+	margin: 0 0 15px 15px;
 }

--- a/templates/protostar/error.php
+++ b/templates/protostar/error.php
@@ -103,6 +103,7 @@ else
 	. ($task ? ' task-' . $task : ' no-task')
 	. ($itemid ? ' itemid-' . $itemid : '')
 	. ($params->get('fluidContainer') ? ' fluid' : '');
+	echo ($this->direction == 'rtl' ? ' rtl' : '');
 ?>">
 	<!-- Body -->
 	<div class="body">

--- a/templates/protostar/error.php
+++ b/templates/protostar/error.php
@@ -102,8 +102,8 @@ else
 	. ($layout ? ' layout-' . $layout : ' no-layout')
 	. ($task ? ' task-' . $task : ' no-task')
 	. ($itemid ? ' itemid-' . $itemid : '')
-	. ($params->get('fluidContainer') ? ' fluid' : '');
-	echo ($this->direction == 'rtl' ? ' rtl' : '');
+	. ($params->get('fluidContainer') ? ' fluid' : '')
+	. ($this->direction === 'rtl' ? ' rtl' : '');
 ?>">
 	<!-- Body -->
 	<div class="body">

--- a/templates/protostar/index.php
+++ b/templates/protostar/index.php
@@ -137,8 +137,8 @@ else
 	. ($layout ? ' layout-' . $layout : ' no-layout')
 	. ($task ? ' task-' . $task : ' no-task')
 	. ($itemid ? ' itemid-' . $itemid : '')
-	. ($params->get('fluidContainer') ? ' fluid' : '');
-	echo ($this->direction === 'rtl' ? ' rtl' : '');
+	. ($params->get('fluidContainer') ? ' fluid' : '')
+	. ($this->direction === 'rtl' ? ' rtl' : '');
 ?>">
 	<!-- Body -->
 	<div class="body" id="top">

--- a/templates/protostar/less/template.less
+++ b/templates/protostar/less/template.less
@@ -3,7 +3,6 @@
 
 // Core variables and mixins
 @import "variables.less"; // Custom for this template
-@import "template_rtl.less"; // Specific for rtl
 @import "../../../media/jui/less/mixins.less";
 
 // Grid system and page structure
@@ -726,3 +725,5 @@ ul.manager .height-50 .icon-folder-2 {
 .finder-selects {
     margin: 0 15px 15px 0;
 }
+
+@import "template_rtl.less"; // Specific for rtl. Always load last.


### PR DESCRIPTION
Replaces https://github.com/joomla/joomla-cms/pull/13060

This PR adds the class `rtl` on body when the language is RTL in order to use any `.rtl .something` .
It is added in component.php as well as error.php. Code is similar to index.php. It allows adding specific `.rtl .something` in the rtl.less files.

It also changes the order of loading of the `.rtl .something` present in the template_rtl.less when they are saved into template.css by generatecss.php. 
This because these rtl classes should override their counterpart as set from various .less files when importing.

  