### PR TITLE
[4.0] Remove unused code tinymce

### DIFF
--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -419,60 +419,31 @@ class PlgEditorTinymce extends JPlugin
 
 		if (!empty($allButtons['template']))
 		{
-			// Note this check for the template_list.js file will be removed in Joomla 4.0
-			if (is_file(JPATH_ROOT . "/media/vendor/tinymce/templates/template_list.js"))
+			foreach (glob(JPATH_ROOT . '/media/vendor/tinymce/templates/*.html') as $filename)
 			{
-				// If using the legacy file we need to include and input the files the new way
-				$str = file_get_contents(JPATH_ROOT . "/media/vendor/tinymce/templates/template_list.js");
+				$filename = basename($filename, '.html');
 
-				// Find from one [ to the last ]
-				$matches = array();
-				preg_match_all('/\[.*\]/', $str, $matches);
-
-				// Set variables
-				foreach ($matches['0'] as $match)
+				if ($filename !== 'index')
 				{
-					$values = array();
-					preg_match_all('/\".*\"/', $match, $values);
-					$result       = trim($values['0']['0'], '"');
-					$final_result = explode(',', $result);
+					$lang        = JFactory::getLanguage();
+					$title       = $filename;
+					$description = ' ';
+
+					if ($lang->hasKey('PLG_TINY_TEMPLATE_' . strtoupper($filename) . '_TITLE'))
+					{
+						$title = JText::_('PLG_TINY_TEMPLATE_' . strtoupper($filename) . '_TITLE');
+					}
+
+					if ($lang->hasKey('PLG_TINY_TEMPLATE_' . strtoupper($filename) . '_DESC'))
+					{
+						$description = JText::_('PLG_TINY_TEMPLATE_' . strtoupper($filename) . '_DESC');
+					}
 
 					$templates[] = array(
-						'title' => trim($final_result['0'], ' " '),
-						'description' => trim($final_result['2'], ' " '),
-						'url' => JUri::root(true) . '/' . trim($final_result['1'], ' " '),
+						'title' => $title,
+						'description' => $description,
+						'url' => JUri::root(true) . '/media/vendor/tinymce/templates/' . $filename . '.html',
 					);
-				}
-
-			}
-			else
-			{
-				foreach (glob(JPATH_ROOT . '/media/vendor/tinymce/templates/*.html') as $filename)
-				{
-					$filename = basename($filename, '.html');
-
-					if ($filename !== 'index')
-					{
-						$lang        = JFactory::getLanguage();
-						$title       = $filename;
-						$description = ' ';
-
-						if ($lang->hasKey('PLG_TINY_TEMPLATE_' . strtoupper($filename) . '_TITLE'))
-						{
-							$title = JText::_('PLG_TINY_TEMPLATE_' . strtoupper($filename) . '_TITLE');
-						}
-
-						if ($lang->hasKey('PLG_TINY_TEMPLATE_' . strtoupper($filename) . '_DESC'))
-						{
-							$description = JText::_('PLG_TINY_TEMPLATE_' . strtoupper($filename) . '_DESC');
-						}
-
-						$templates[] = array(
-							'title' => $title,
-							'description' => $description,
-							'url' => JUri::root(true) . '/media/vendor/tinymce/templates/' . $filename . '.html',
-						);
-					}
 				}
 			}
 		}


### PR DESCRIPTION
This code block was marked for removal in J4 so removing it. Not sure how long it has been there but its not usable in a current install

## Testing instructions
Code Review and make sure the templates button in the editor still offers two templates

<img width="531" alt="screenshotr10-45-35" src="https://user-images.githubusercontent.com/1296369/34667485-1b1159d6-f461-11e7-8ca6-522d6d4336bb.png">
