### PR TITLE
[Regression] Fix undefined index: *

### DIFF
--- a/administrator/components/com_finder/helpers/indexer/helper.php
+++ b/administrator/components/com_finder/helpers/indexer/helper.php
@@ -329,7 +329,7 @@ class FinderIndexerHelper
 		}
 
 		// Check if the token is in the common array.
-		return in_array($token, $data[$lang], true);
+		return in_array($token, $data[$langCode], true);
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue #12450 .

### Summary of Changes
Use the right variable.


### Testing Instructions
Go to Components > Smart Search.
Click `Index` button.
Check php error log.


### Expected result
No notices/warnings.


### Actual result
```
PHP Notice:  Undefined index: * in \administrator\components\com_finder\helpers\indexer\helper.php on line 332
PHP Warning:  in_array() expects parameter 2 to be array, null given in \administrator\components\com_finder\helpers\indexer\helper.php on line 332
```

### Documentation Changes Required
none
