### PR TITLE
[CS] Code style Tabs must be used to indent lines; round 1

### DIFF
--- a/administrator/templates/hathor/cpanel.php
+++ b/administrator/templates/hathor/cpanel.php
@@ -91,7 +91,7 @@ else
 		<div class="title-ua">
 			<h1 class="title"><?php echo $this->params->get('showSiteName') ? $app->get('sitename') . ' ' . JText::_('JADMINISTRATION') : JText::_('JADMINISTRATION'); ?></h1>
 			<div id="skiplinkholder"><p><a id="skiplink" href="#skiptarget"><?php echo JText::_('TPL_HATHOR_SKIP_TO_MAIN_CONTENT'); ?></a></p></div>
-		  </div>
+		</div>
 	</div><!-- end header -->
 	<!-- Main Menu Navigation -->
 	<div id="nav">
@@ -113,7 +113,7 @@ else
 		<jdoc:include type="message" />
 		<!-- Sub Menu Navigation -->
 		<div id="no-submenu"></div>
-		   <div class="clr"></div>
+		<div class="clr"></div>
 		<!-- Beginning of Actual Content -->
 		<div id="element-box">
 			<p id="skiptargetholder"><a id="skiptarget" class="skip" tabindex="-1"></a></p>

--- a/administrator/templates/hathor/cpanel.php
+++ b/administrator/templates/hathor/cpanel.php
@@ -91,7 +91,7 @@ else
 		<div class="title-ua">
 			<h1 class="title"><?php echo $this->params->get('showSiteName') ? $app->get('sitename') . ' ' . JText::_('JADMINISTRATION') : JText::_('JADMINISTRATION'); ?></h1>
 			<div id="skiplinkholder"><p><a id="skiplink" href="#skiptarget"><?php echo JText::_('TPL_HATHOR_SKIP_TO_MAIN_CONTENT'); ?></a></p></div>
-      	</div>
+		  </div>
 	</div><!-- end header -->
 	<!-- Main Menu Navigation -->
 	<div id="nav">
@@ -113,7 +113,7 @@ else
 		<jdoc:include type="message" />
 		<!-- Sub Menu Navigation -->
 		<div id="no-submenu"></div>
-   		<div class="clr"></div>
+		   <div class="clr"></div>
 		<!-- Beginning of Actual Content -->
 		<div id="element-box">
 			<p id="skiptargetholder"><a id="skiptarget" class="skip" tabindex="-1"></a></p>

--- a/administrator/templates/hathor/html/com_admin/help/default.php
+++ b/administrator/templates/hathor/html/com_admin/help/default.php
@@ -29,7 +29,7 @@ jimport('joomla.language.help');
 				<ul class="subext">
 					<?php foreach ($this->toc as $k => $v):?>
 						<li>
-						    <?php $url = JHelp::createUrl('JHELP_'.strtoupper($k)); ?>
+							<?php $url = JHelp::createUrl('JHELP_'.strtoupper($k)); ?>
 							<?php echo JHtml::_('link', $url, $v, array('target' => 'helpFrame'));?>
 						</li>
 					<?php endforeach;?>

--- a/administrator/templates/hathor/html/com_categories/categories/default.php
+++ b/administrator/templates/hathor/html/com_categories/categories/default.php
@@ -104,22 +104,22 @@ $component = $jinput->get('extension');
 							<th width="1%" class="nowrap center hidden-phone">
 								<span class="icon-publish hasTooltip" aria-hidden="true" title="<?php echo JText::_('COM_CATEGORY_COUNT_PUBLISHED_ITEMS'); ?>"><span class="element-invisible"><?php echo JText::_('COM_CATEGORY_COUNT_PUBLISHED_ITEMS'); ?></span></span>
 							</th>
-						<?php endif;?>
+						<?php endif; ?>
 						<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_unpublished')) : ?>
 							<th width="1%" class="nowrap center hidden-phone">
 								<span class="icon-unpublish hasTooltip" aria-hidden="true" title="<?php echo JText::_('COM_CATEGORY_COUNT_UNPUBLISHED_ITEMS'); ?>"><span class="element-invisible"><?php echo JText::_('COM_CATEGORY_COUNT_UNPUBLISHED_ITEMS'); ?></span></span>
 							</th>
-						<?php endif;?>
+						<?php endif; ?>
 						<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_archived')) : ?>
 							<th width="1%" class="nowrap center hidden-phone">
 								<span class="icon-archive hasTooltip" aria-hidden="true" title="<?php echo JText::_('COM_CATEGORY_COUNT_ARCHIVED_ITEMS'); ?>"><span class="element-invisible"><?php echo JText::_('COM_CATEGORY_COUNT_ARCHIVED_ITEMS'); ?></span></span>
 							</th>
-						<?php endif;?>
+						<?php endif; ?>
 						<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_trashed')) : ?>
 							<th width="1%" class="nowrap center hidden-phone">
 								<span class="icon-trash hasTooltip" aria-hidden="true" title="<?php echo JText::_('COM_CATEGORY_COUNT_TRASHED_ITEMS'); ?>"><span class="element-invisible"><?php echo JText::_('COM_CATEGORY_COUNT_TRASHED_ITEMS'); ?></span></span>
 							</th>
-						<?php endif;?>
+						<?php endif; ?>
 						<th class="access-col">
 							<?php echo JHtml::_('grid.sort', 'JGRID_HEADING_ACCESS', 'access_level', $listDirn, $listOrder); ?>
 						</th>
@@ -179,35 +179,35 @@ $component = $jinput->get('extension');
 										<span><?php echo $this->pagination->orderDownIcon($i, $this->pagination->total, isset($this->ordering[$item->parent_id][$orderkey + 1]), 'categories.orderdown', 'JLIB_HTML_MOVE_DOWN', $ordering); ?></span>
 									<?php endif; ?>
 									<?php $disabled = $saveOrder ? '' : 'disabled="disabled"'; ?>
-									<input type="text" name="order[]" value="<?php echo $orderkey + 1; ?>" <?php echo $disabled ?> class="text-area-order" title="<?php echo $item->title; ?> order" />
+									<input type="text" name="order[]" value="<?php echo $orderkey + 1; ?>" <?php echo $disabled; ?> class="text-area-order" title="<?php echo $item->title; ?> order" />
 								<?php else : ?>
 									<?php echo $orderkey + 1; ?>
 								<?php endif; ?>
 							</td>
 							<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_published')) : ?>
 								<td class="center">
-									<a title="<?php echo JText::_('COM_CATEGORY_COUNT_PUBLISHED_ITEMS');?>" href="<?php echo JRoute::_('index.php?option=' . $component . '&filter[category_id]=' . (int) $item->id . '&filter[published]=1' . '&filter[level]=' . (int) $item->level);?>">
+									<a title="<?php echo JText::_('COM_CATEGORY_COUNT_PUBLISHED_ITEMS'); ?>" href="<?php echo JRoute::_('index.php?option=' . $component . '&filter[category_id]=' . (int) $item->id . '&filter[published]=1' . '&filter[level]=' . (int) $item->level); ?>">
 										<?php echo $item->count_published; ?></a>
 								</td>
-							<?php endif;?>
+							<?php endif; ?>
 							<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_unpublished')) : ?>
 								<td class="center">
-									<a title="<?php echo JText::_('COM_CATEGORY_COUNT_UNPUBLISHED_ITEMS');?>" href="<?php echo JRoute::_('index.php?option=' . $component . '&filter[category_id]=' . (int) $item->id . '&filter[published]=0' . '&filter[level]=' . (int) $item->level);?>">
+									<a title="<?php echo JText::_('COM_CATEGORY_COUNT_UNPUBLISHED_ITEMS'); ?>" href="<?php echo JRoute::_('index.php?option=' . $component . '&filter[category_id]=' . (int) $item->id . '&filter[published]=0' . '&filter[level]=' . (int) $item->level); ?>">
 										<?php echo $item->count_unpublished; ?></a>
 								</td>
-							<?php endif;?>
+							<?php endif; ?>
 							<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_archived')) : ?>
 								<td class="center">
-									<a title="<?php echo JText::_('COM_CATEGORY_COUNT_ARCHIVED_ITEMS');?>" href="<?php echo JRoute::_('index.php?option=' . $component . '&filter[category_id]=' . (int) $item->id . '&filter[published]=2' . '&filter[level]=' . (int) $item->level);?>">
+									<a title="<?php echo JText::_('COM_CATEGORY_COUNT_ARCHIVED_ITEMS'); ?>" href="<?php echo JRoute::_('index.php?option=' . $component . '&filter[category_id]=' . (int) $item->id . '&filter[published]=2' . '&filter[level]=' . (int) $item->level); ?>">
 										<?php echo $item->count_archived; ?></a>
 								</td>
-							<?php endif;?>
+							<?php endif; ?>
 							<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_trashed')) : ?>
 								<td class="center">
-									<a title="<?php echo JText::_('COM_CATEGORY_COUNT_TRASHED_ITEMS');?>" href="<?php echo JRoute::_('index.php?option=' . $component . '&filter[category_id]=' . (int) $item->id . '&filter[published]=-2' . '&filter[level]=' . (int) $item->level);?>">
+									<a title="<?php echo JText::_('COM_CATEGORY_COUNT_TRASHED_ITEMS'); ?>" href="<?php echo JRoute::_('index.php?option=' . $component . '&filter[category_id]=' . (int) $item->id . '&filter[published]=-2' . '&filter[level]=' . (int) $item->level); ?>">
 										<?php echo $item->count_trashed; ?></a>
 								</td>
-							<?php endif;?>
+							<?php endif; ?>
 							<td class="center">
 								<?php echo $this->escape($item->access_level); ?>
 							</td>

--- a/administrator/templates/hathor/html/com_contact/contact/edit.php
+++ b/administrator/templates/hathor/html/com_contact/contact/edit.php
@@ -86,7 +86,7 @@ $fieldSets = $this->form->getFieldsets();
 			<?php echo $this->form->getInput('misc'); ?>
 		</fieldset>
 	</div>
-    <div class="col options-section">
+	<div class="col options-section">
 		<?php echo  JHtml::_('sliders.start', 'contact-slider'); ?>
 			<?php echo JHtml::_('sliders.panel', JText::_('JGLOBAL_FIELDSET_PUBLISHING'), 'publishing-details'); ?>
 

--- a/administrator/templates/hathor/html/com_contact/contact/edit.php
+++ b/administrator/templates/hathor/html/com_contact/contact/edit.php
@@ -87,7 +87,7 @@ $fieldSets = $this->form->getFieldsets();
 		</fieldset>
 	</div>
 	<div class="col options-section">
-		<?php echo  JHtml::_('sliders.start', 'contact-slider'); ?>
+		<?php echo JHtml::_('sliders.start', 'contact-slider'); ?>
 			<?php echo JHtml::_('sliders.panel', JText::_('JGLOBAL_FIELDSET_PUBLISHING'), 'publishing-details'); ?>
 
 			<fieldset class="panelform">

--- a/administrator/templates/hathor/html/com_installer/install/default_form.php
+++ b/administrator/templates/hathor/html/com_installer/install/default_form.php
@@ -110,14 +110,14 @@ JFactory::getDocument()->addStyleDeclaration(
 ?>
 <div id="installer-install" class="clearfix">
 	<form enctype="multipart/form-data" action="<?php echo JRoute::_('index.php?option=com_installer&view=install');?>" method="post" name="adminForm" id="adminForm">
-	<?php if (!empty( $this->sidebar)) : ?>
-		<div id="j-sidebar-container" class="span2">
-			<?php echo $this->sidebar; ?>
-		</div>
-		<div id="j-main-container" class="span10">
-	<?php else : ?>
-		<div id="j-main-container">
-	<?php endif;?>
+		<?php if (!empty( $this->sidebar)) : ?>
+			<div id="j-sidebar-container" class="span2">
+				<?php echo $this->sidebar; ?>
+			</div>
+			<div id="j-main-container" class="span10">
+		<?php else : ?>
+			<div id="j-main-container">
+		<?php endif;?>
 
 		<?php if ($this->showJedAndWebInstaller && !$this->showMessage) : ?>
 			<div class="alert j-jed-message" style="margin-bottom: 20px; line-height: 2em; color:#333333; clear:both;">
@@ -148,7 +148,6 @@ JFactory::getDocument()->addStyleDeclaration(
 			<?php if (!$tabs) : ?>
 				<?php JFactory::getApplication()->enqueueMessage(JText::_('COM_INSTALLER_NO_INSTALLATION_PLUGINS_FOUND'), 'warning'); ?>
 			<?php endif; ?>
-
 
 			<input type="hidden" name="type" value="" />
 			<input type="hidden" name="installtype" value="upload" />

--- a/administrator/templates/hathor/html/com_installer/install/default_form.php
+++ b/administrator/templates/hathor/html/com_installer/install/default_form.php
@@ -110,7 +110,7 @@ JFactory::getDocument()->addStyleDeclaration(
 ?>
 <div id="installer-install" class="clearfix">
 	<form enctype="multipart/form-data" action="<?php echo JRoute::_('index.php?option=com_installer&view=install');?>" method="post" name="adminForm" id="adminForm">
-		<?php if (!empty( $this->sidebar)) : ?>
+		<?php if (!empty($this->sidebar)) : ?>
 			<div id="j-sidebar-container" class="span2">
 				<?php echo $this->sidebar; ?>
 			</div>

--- a/administrator/templates/hathor/html/com_installer/install/default_form.php
+++ b/administrator/templates/hathor/html/com_installer/install/default_form.php
@@ -39,7 +39,7 @@ JFactory::getDocument()->addScriptDeclaration("
 		}
 		else
 		{
-		    JoomlaInstaller.showLoading();
+			JoomlaInstaller.showLoading();
 			form.installtype.value = 'folder';
 			form.submit();
 		}

--- a/administrator/templates/hathor/html/com_installer/install/default_form.php
+++ b/administrator/templates/hathor/html/com_installer/install/default_form.php
@@ -109,53 +109,53 @@ JFactory::getDocument()->addStyleDeclaration(
 );
 ?>
 <div id="installer-install" class="clearfix">
-    <form enctype="multipart/form-data" action="<?php echo JRoute::_('index.php?option=com_installer&view=install');?>" method="post" name="adminForm" id="adminForm">
-    <?php if (!empty( $this->sidebar)) : ?>
-        <div id="j-sidebar-container" class="span2">
-            <?php echo $this->sidebar; ?>
-        </div>
-        <div id="j-main-container" class="span10">
-    <?php else : ?>
-        <div id="j-main-container">
-    <?php endif;?>
+	<form enctype="multipart/form-data" action="<?php echo JRoute::_('index.php?option=com_installer&view=install');?>" method="post" name="adminForm" id="adminForm">
+	<?php if (!empty( $this->sidebar)) : ?>
+		<div id="j-sidebar-container" class="span2">
+			<?php echo $this->sidebar; ?>
+		</div>
+		<div id="j-main-container" class="span10">
+	<?php else : ?>
+		<div id="j-main-container">
+	<?php endif;?>
 
-        <?php if ($this->showJedAndWebInstaller && !$this->showMessage) : ?>
-            <div class="alert j-jed-message" style="margin-bottom: 20px; line-height: 2em; color:#333333; clear:both;">
-                <a href="index.php?option=com_config&view=component&component=com_installer&path=&return=<?php echo urlencode(base64_encode(JUri::getInstance())); ?>" class="close hasTooltip icon-options" data-dismiss="alert" title="<?php echo str_replace('"', '&quot;', JText::_('COM_INSTALLER_SHOW_JED_INFORMATION_TOOLTIP')); ?>"></a>
-                <p><?php echo JText::_('COM_INSTALLER_INSTALL_FROM_WEB_INFO'); ?>&nbsp;<?php echo JText::_('COM_INSTALLER_INSTALL_FROM_WEB_TOS'); ?></p>
-                <input class="btn" type="button" value="<?php echo JText::_('COM_INSTALLER_INSTALL_FROM_WEB_ADD_TAB'); ?>" onclick="Joomla.submitbuttonInstallWebInstaller()" />
-            </div>
-        <?php endif; ?>
+		<?php if ($this->showJedAndWebInstaller && !$this->showMessage) : ?>
+			<div class="alert j-jed-message" style="margin-bottom: 20px; line-height: 2em; color:#333333; clear:both;">
+				<a href="index.php?option=com_config&view=component&component=com_installer&path=&return=<?php echo urlencode(base64_encode(JUri::getInstance())); ?>" class="close hasTooltip icon-options" data-dismiss="alert" title="<?php echo str_replace('"', '&quot;', JText::_('COM_INSTALLER_SHOW_JED_INFORMATION_TOOLTIP')); ?>"></a>
+				<p><?php echo JText::_('COM_INSTALLER_INSTALL_FROM_WEB_INFO'); ?>&nbsp;<?php echo JText::_('COM_INSTALLER_INSTALL_FROM_WEB_TOS'); ?></p>
+				<input class="btn" type="button" value="<?php echo JText::_('COM_INSTALLER_INSTALL_FROM_WEB_ADD_TAB'); ?>" onclick="Joomla.submitbuttonInstallWebInstaller()" />
+			</div>
+		<?php endif; ?>
 
-        <?php if ($this->ftp) : ?>
-            <?php echo $this->loadTemplate('ftp'); ?>
-        <?php endif; ?>
-        <div class="width-70 fltlft">
+		<?php if ($this->ftp) : ?>
+			<?php echo $this->loadTemplate('ftp'); ?>
+		<?php endif; ?>
+		<div class="width-70 fltlft">
 
-            <?php $firstTab = JEventDispatcher::getInstance()->trigger('onInstallerViewBeforeFirstTab', array()); ?>
+			<?php $firstTab = JEventDispatcher::getInstance()->trigger('onInstallerViewBeforeFirstTab', array()); ?>
 
-            <?php // Show installation fieldsets ?>
-            <?php $tabs = JEventDispatcher::getInstance()->trigger('onInstallerAddInstallationTab', array()); ?>
-            <?php foreach ($tabs as $tab) : ?>
-                <fieldset class="uploadform">
-                    <?php echo $tab['content']; ?>
-                </fieldset>
-            <?php endforeach; ?>
+			<?php // Show installation fieldsets ?>
+			<?php $tabs = JEventDispatcher::getInstance()->trigger('onInstallerAddInstallationTab', array()); ?>
+			<?php foreach ($tabs as $tab) : ?>
+				<fieldset class="uploadform">
+					<?php echo $tab['content']; ?>
+				</fieldset>
+			<?php endforeach; ?>
 
-            <?php $lastTab = JEventDispatcher::getInstance()->trigger('onInstallerViewAfterLastTab', array()); ?>
+			<?php $lastTab = JEventDispatcher::getInstance()->trigger('onInstallerViewAfterLastTab', array()); ?>
 
-            <?php $tabs = array_merge($firstTab, $tabs, $lastTab); ?>
-            <?php if (!$tabs) : ?>
-                <?php JFactory::getApplication()->enqueueMessage(JText::_('COM_INSTALLER_NO_INSTALLATION_PLUGINS_FOUND'), 'warning'); ?>
-            <?php endif; ?>
+			<?php $tabs = array_merge($firstTab, $tabs, $lastTab); ?>
+			<?php if (!$tabs) : ?>
+				<?php JFactory::getApplication()->enqueueMessage(JText::_('COM_INSTALLER_NO_INSTALLATION_PLUGINS_FOUND'), 'warning'); ?>
+			<?php endif; ?>
 
 
-            <input type="hidden" name="type" value="" />
-            <input type="hidden" name="installtype" value="upload" />
-            <input type="hidden" name="task" value="install.install" />
-            <?php echo JHtml::_('form.token'); ?>
-        </div>
-    </div>
-    </form>
+			<input type="hidden" name="type" value="" />
+			<input type="hidden" name="installtype" value="upload" />
+			<input type="hidden" name="task" value="install.install" />
+			<?php echo JHtml::_('form.token'); ?>
+		</div>
+	</div>
+	</form>
 </div>
 <div id="loading"></div>

--- a/administrator/templates/hathor/html/com_installer/manage/default.php
+++ b/administrator/templates/hathor/html/com_installer/manage/default.php
@@ -61,9 +61,9 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 				<th class="width-10">
 					<?php echo JText::_('JDATE'); ?>
 				</th>
-                <th class="width-15 center">
-                	<?php echo JText::_('JAUTHOR'); ?>
-                </th>
+				<th class="width-15 center">
+					<?php echo JText::_('JAUTHOR'); ?>
+				</th>
 				<th>
 					<?php echo JHtml::_('grid.sort', 'COM_INSTALLER_HEADING_FOLDER', 'folder', $listDirn, $listOrder); ?>
 				</th>

--- a/administrator/templates/hathor/html/com_installer/manage/default_filter.php
+++ b/administrator/templates/hathor/html/com_installer/manage/default_filter.php
@@ -27,7 +27,7 @@ defined('_JEXEC') or die;
 				<?php echo JHtml::_('select.options', array('0' => JText::_('JSITE'), '1' => JText::_('JADMINISTRATOR')), 'value', 'text', $this->state->get('filter.client_id'), true);?>
 			</select>
 
-            <label class="selectlabel" for="filter_status">
+			<label class="selectlabel" for="filter_status">
 				<?php echo JText::_('COM_INSTALLER_VALUE_STATE_SELECT'); ?>
 			</label>
 			<select name="filter_status" id="filter_status">
@@ -35,7 +35,7 @@ defined('_JEXEC') or die;
 				<?php echo JHtml::_('select.options', InstallerHelper::getStateOptions(), 'value', 'text', $this->state->get('filter.status'), true);?>
 			</select>
 
-            <label class="selectlabel" for="filter_type">
+			<label class="selectlabel" for="filter_type">
 				<?php echo JText::_('COM_INSTALLER_VALUE_TYPE_SELECT'); ?>
 			</label>
 			<select name="filter_type" id="filter_type">

--- a/administrator/templates/hathor/html/com_installer/manage/default_filter.php
+++ b/administrator/templates/hathor/html/com_installer/manage/default_filter.php
@@ -24,31 +24,31 @@ defined('_JEXEC') or die;
 				<?php echo JText::_('COM_INSTALLER_VALUE_CLIENT_SELECT'); ?>
 			</label>
 			<select name="filter_client_id" id="filter_client_id">
-				<?php echo JHtml::_('select.options', array('0' => JText::_('JSITE'), '1' => JText::_('JADMINISTRATOR')), 'value', 'text', $this->state->get('filter.client_id'), true);?>
+				<?php echo JHtml::_('select.options', array('0' => JText::_('JSITE'), '1' => JText::_('JADMINISTRATOR')), 'value', 'text', $this->state->get('filter.client_id'), true); ?>
 			</select>
 
 			<label class="selectlabel" for="filter_status">
 				<?php echo JText::_('COM_INSTALLER_VALUE_STATE_SELECT'); ?>
 			</label>
 			<select name="filter_status" id="filter_status">
-				<option value=""><?php echo JText::_('JOPTION_SELECT_PUBLISHED');?></option>
-				<?php echo JHtml::_('select.options', InstallerHelper::getStateOptions(), 'value', 'text', $this->state->get('filter.status'), true);?>
+				<option value=""><?php echo JText::_('JOPTION_SELECT_PUBLISHED'); ?></option>
+				<?php echo JHtml::_('select.options', InstallerHelper::getStateOptions(), 'value', 'text', $this->state->get('filter.status'), true); ?>
 			</select>
 
 			<label class="selectlabel" for="filter_type">
 				<?php echo JText::_('COM_INSTALLER_VALUE_TYPE_SELECT'); ?>
 			</label>
 			<select name="filter_type" id="filter_type">
-				<option value=""><?php echo JText::_('COM_INSTALLER_VALUE_TYPE_SELECT');?></option>
-				<?php echo JHtml::_('select.options', InstallerHelper::getExtensionTypes(), 'value', 'text', $this->state->get('filter.type'), true);?>
+				<option value=""><?php echo JText::_('COM_INSTALLER_VALUE_TYPE_SELECT'); ?></option>
+				<?php echo JHtml::_('select.options', InstallerHelper::getExtensionTypes(), 'value', 'text', $this->state->get('filter.type'), true); ?>
 			</select>
 
 			<label class="selectlabel" for="filter_folder">
 				<?php echo JText::_('COM_INSTALLER_VALUE_FOLDER_SELECT'); ?>
 			</label>
 			<select name="filter_folder" id="filter_folder">
-				<option value=""><?php echo JText::_('COM_INSTALLER_VALUE_FOLDER_SELECT');?></option>
-				<?php echo JHtml::_('select.options', array_merge(InstallerHelper::getExtensionGroupes(), array('*' => JText::_('COM_INSTALLER_VALUE_FOLDER_NONAPPLICABLE'))), 'value', 'text', $this->state->get('filter.folder'), true);?>
+				<option value=""><?php echo JText::_('COM_INSTALLER_VALUE_FOLDER_SELECT'); ?></option>
+				<?php echo JHtml::_('select.options', array_merge(InstallerHelper::getExtensionGroupes(), array('*' => JText::_('COM_INSTALLER_VALUE_FOLDER_NONAPPLICABLE'))), 'value', 'text', $this->state->get('filter.folder'), true); ?>
 			</select>
 
 			<button type="submit" id="filter-go">

--- a/administrator/templates/hathor/html/com_languages/languages/default.php
+++ b/administrator/templates/hathor/html/com_languages/languages/default.php
@@ -31,7 +31,7 @@ $saveOrder = $listOrder == 'a.ordering';
 	<div id="j-main-container" class="span10">
 <?php else : ?>
 	<div id="j-main-container">
-<?php endif;?>
+<?php endif; ?>
 	<fieldset id="filter-bar">
 	<legend class="element-invisible"><?php echo JText::_('JSEARCH_FILTER_LABEL'); ?></legend>
 		<div class="filter-search">
@@ -46,8 +46,8 @@ $saveOrder = $listOrder == 'a.ordering';
 				<?php echo JText::_('JOPTION_SELECT_PUBLISHED'); ?>
 			</label>
 			<select name="filter_published" id="filter_published">
-				<option value=""><?php echo JText::_('JOPTION_SELECT_PUBLISHED');?></option>
-				<?php echo JHtml::_('select.options', JHtml::_('languages.publishedOptions'), 'value', 'text', $this->state->get('filter.published'), true);?>
+				<option value=""><?php echo JText::_('JOPTION_SELECT_PUBLISHED'); ?></option>
+				<?php echo JHtml::_('select.options', JHtml::_('languages.publishedOptions'), 'value', 'text', $this->state->get('filter.published'), true); ?>
 			</select>
 
 			<button type="submit" id="filter-go">
@@ -133,7 +133,7 @@ $saveOrder = $listOrder == 'a.ordering';
 					<?php endif; ?>
 				</td>
 				<td class="center">
-					<?php echo JHtml::_('jgrid.published', $item->published, $i, 'languages.', $canChange);?>
+					<?php echo JHtml::_('jgrid.published', $item->published, $i, 'languages.', $canChange); ?>
 				</td>
 				<td class="order">
 					<?php if ($canChange) : ?>
@@ -146,18 +146,18 @@ $saveOrder = $listOrder == 'a.ordering';
 								<span><?php echo $this->pagination->orderDownIcon($i, $this->pagination->total, true, 'languages.orderup', 'JLIB_HTML_MOVE_DOWN', $ordering); ?></span>
 							<?php endif; ?>
 						<?php endif; ?>
-						<?php $disabled = $saveOrder ?  '' : 'disabled="disabled"'; ?>
-						<input type="text" name="order[]" size="5" value="<?php echo $item->ordering;?>" <?php echo $disabled ?> class="text-area-order" />
+						<?php $disabled = $saveOrder ? '' : 'disabled="disabled"'; ?>
+						<input type="text" name="order[]" size="5" value="<?php echo $item->ordering; ?>" <?php echo $disabled; ?> class="text-area-order" />
 					<?php else : ?>
 						<?php echo $item->ordering; ?>
 					<?php endif; ?>
 				</td>
 				<td class="center">
 					<?php if ($item->home == '1') : ?>
-						<?php echo JText::_('JYES');?>
+						<?php echo JText::_('JYES'); ?>
 					<?php else:?>
-						<?php echo JText::_('JNO');?>
-					<?php endif;?>
+						<?php echo JText::_('JNO'); ?>
+					<?php endif; ?>
 				</td>
 				<td class="center">
 					<?php echo $this->escape($item->lang_id); ?>

--- a/administrator/templates/hathor/html/com_menus/item/edit.php
+++ b/administrator/templates/hathor/html/com_menus/item/edit.php
@@ -150,9 +150,9 @@ $clientId = $this->state->get('item.client_id', 0);
 				<li><?php echo $this->form->getLabel('id'); ?>
 				<?php echo $this->form->getInput('id'); ?></li>
 
-                <li><?php echo $this->form->getLabel('client_id'); ?>
+				<li><?php echo $this->form->getLabel('client_id'); ?>
 					<?php echo $this->form->getInput('client_id'); ?></li>
-            </ul>
+			</ul>
 
 	</fieldset>
 </div>

--- a/administrator/templates/hathor/html/com_menus/items/default.php
+++ b/administrator/templates/hathor/html/com_menus/items/default.php
@@ -23,11 +23,11 @@ $ordering  = ($listOrder == 'a.lft');
 $canOrder  = $user->authorise('core.edit.state', 'com_menus');
 $saveOrder = ($listOrder == 'a.lft' && $listDirn == 'asc');
 $menutypeid	= (int) $this->state->get('menutypeid');
-$assoc     = JLanguageAssociations::isEnabled() && $this->state->get('filter.client_id') == 0;;
+$assoc     = JLanguageAssociations::isEnabled() && $this->state->get('filter.client_id') == 0;
 ?>
 
 <?php // Set up the filter bar. ?>
-<form action="<?php echo JRoute::_('index.php?option=com_menus&view=items');?>" method="post" name="adminForm" id="adminForm">
+<form action="<?php echo JRoute::_('index.php?option=com_menus&view=items'); ?>" method="post" name="adminForm" id="adminForm">
 <?php if (!empty( $this->sidebar)) : ?>
 	<div id="j-sidebar-container" class="span2">
 		<?php echo $this->sidebar; ?>
@@ -35,7 +35,7 @@ $assoc     = JLanguageAssociations::isEnabled() && $this->state->get('filter.cli
 	<div id="j-main-container" class="span10">
 <?php else : ?>
 	<div id="j-main-container">
-<?php endif;?>
+<?php endif; ?>
 	<fieldset id="filter-bar">
 	<legend class="element-invisible"><?php echo JText::_('JSEARCH_FILTER_LABEL'); ?></legend>
 		<div class="filter-search">
@@ -49,39 +49,39 @@ $assoc     = JLanguageAssociations::isEnabled() && $this->state->get('filter.cli
 				<?php echo JText::_('TPL_HATHOR_COM_MENUS_MENU'); ?>
 			</label>
 			<select name="menutype" id="menutype">
-				<?php echo JHtml::_('select.options', JHtml::_('menu.menus'), 'value', 'text', $this->state->get('filter.menutype'));?>
+				<?php echo JHtml::_('select.options', JHtml::_('menu.menus'), 'value', 'text', $this->state->get('filter.menutype')); ?>
 			</select>
 
 			<label class="selectlabel" for="filter_level">
 				<?php echo JText::_('COM_MENUS_OPTION_SELECT_LEVEL'); ?>
 			</label>
 			<select name="filter_level" id="filter_level">
-				<option value=""><?php echo JText::_('COM_MENUS_OPTION_SELECT_LEVEL');?></option>
-				<?php echo JHtml::_('select.options', $this->f_levels, 'value', 'text', $this->state->get('filter.level'));?>
+				<option value=""><?php echo JText::_('COM_MENUS_OPTION_SELECT_LEVEL'); ?></option>
+				<?php echo JHtml::_('select.options', $this->f_levels, 'value', 'text', $this->state->get('filter.level')); ?>
 			</select>
 
 			<label class="selectlabel" for="filter_published">
 				<?php echo JText::_('JOPTION_SELECT_PUBLISHED'); ?>
 			</label>
 			<select name="filter[published]" id="filter_published">
-				<option value=""><?php echo JText::_('JOPTION_SELECT_PUBLISHED');?></option>
-				<?php echo JHtml::_('select.options', JHtml::_('jgrid.publishedOptions', array('archived' => false)), 'value', 'text', $this->state->get('filter.published'), true);?>
+				<option value=""><?php echo JText::_('JOPTION_SELECT_PUBLISHED'); ?></option>
+				<?php echo JHtml::_('select.options', JHtml::_('jgrid.publishedOptions', array('archived' => false)), 'value', 'text', $this->state->get('filter.published'), true); ?>
 			</select>
 
 			<label class="selectlabel" for="filter_access">
 				<?php echo JText::_('JOPTION_SELECT_ACCESS'); ?>
 			</label>
 			<select name="filter[access]" id="filter_access">
-				<option value=""><?php echo JText::_('JOPTION_SELECT_ACCESS');?></option>
-				<?php echo JHtml::_('select.options', JHtml::_('access.assetgroups'), 'value', 'text', $this->state->get('filter.access'));?>
+				<option value=""><?php echo JText::_('JOPTION_SELECT_ACCESS'); ?></option>
+				<?php echo JHtml::_('select.options', JHtml::_('access.assetgroups'), 'value', 'text', $this->state->get('filter.access')); ?>
 			</select>
 
 			<label class="selectlabel" for="filter_language">
 				<?php echo JText::_('JOPTION_SELECT_LANGUAGE'); ?>
 			</label>
 			<select name="filter[language]" id="filter_language">
-				<option value=""><?php echo JText::_('JOPTION_SELECT_LANGUAGE');?></option>
-				<?php echo JHtml::_('select.options', JHtml::_('contentlanguage.existing', true, true), 'value', 'text', $this->state->get('filter.language'));?>
+				<option value=""><?php echo JText::_('JOPTION_SELECT_LANGUAGE'); ?></option>
+				<?php echo JHtml::_('select.options', JHtml::_('contentlanguage.existing', true, true), 'value', 'text', $this->state->get('filter.language')); ?>
 			</select>
 
 			<button type="submit" id="filter-go">
@@ -123,7 +123,7 @@ $assoc     = JLanguageAssociations::isEnabled() && $this->state->get('filter.cli
 				<th class="width-5">
 					<?php echo JHtml::_('grid.sort', 'COM_MENUS_HEADING_ASSOCIATION', 'association', $listDirn, $listOrder); ?>
 				</th>
-				<?php endif;?>
+				<?php endif; ?>
 				<th class="language-col">
 					<?php echo JHtml::_('grid.sort', 'JGRID_HEADING_LANGUAGE', 'language', $listDirn, $listOrder); ?>
 				</th>
@@ -141,7 +141,7 @@ $assoc     = JLanguageAssociations::isEnabled() && $this->state->get('filter.cli
 			$canEdit    = $user->authorise('core.edit',       'com_menus.menu.' . $menutypeid);
 			$canCheckin = $user->authorise('core.manage',     'com_checkin') || $item->checked_out == $user->get('id')|| $item->checked_out == 0;
 			$canChange  = $user->authorise('core.edit.state', 'com_menus.menu.' . $menutypeid) && $canCheckin;
-			?>
+		?>
 			<tr class="row<?php echo $i % 2; ?>">
 				<td class="center">
 					<?php echo JHtml::_('grid.id', $i, $item->id); ?>
@@ -152,21 +152,21 @@ $assoc     = JLanguageAssociations::isEnabled() && $this->state->get('filter.cli
 						<?php echo JHtml::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, 'items.', $canCheckin); ?>
 					<?php endif; ?>
 					<?php if ($canEdit && !$item->protected) : ?>
-						<a href="<?php echo JRoute::_('index.php?option=com_menus&task=item.edit&id='.(int) $item->id);?>">
+						<a href="<?php echo JRoute::_('index.php?option=com_menus&task=item.edit&id='.(int) $item->id); ?>">
 							<?php echo $this->escape($item->title); ?></a>
 					<?php else : ?>
 						<?php echo $this->escape($item->title); ?>
 					<?php endif; ?>
-					<p class="smallsub" title="<?php echo $this->escape($item->path);?>">
+					<p class="smallsub" title="<?php echo $this->escape($item->path); ?>">
 						<?php echo str_repeat('<span class="gtr">|&mdash;</span>', $item->level - 1) ?>
 						<?php if ($item->type != 'url') : ?>
 							<?php if (empty($item->note)) : ?>
-								<?php echo JText::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->alias));?>
+								<?php echo JText::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->alias)); ?>
 							<?php else : ?>
-								<?php echo JText::sprintf('JGLOBAL_LIST_ALIAS_NOTE', $this->escape($item->alias), $this->escape($item->note));?>
+								<?php echo JText::sprintf('JGLOBAL_LIST_ALIAS_NOTE', $this->escape($item->alias), $this->escape($item->note)); ?>
 							<?php endif; ?>
 						<?php elseif ($item->type == 'url' && $item->note) : ?>
-							<?php echo JText::sprintf('JGLOBAL_LIST_NOTE', $this->escape($item->note));?>
+							<?php echo JText::sprintf('JGLOBAL_LIST_NOTE', $this->escape($item->note)); ?>
 						<?php endif; ?></p>
 				</td>
 				<td class="center">
@@ -179,9 +179,9 @@ $assoc     = JLanguageAssociations::isEnabled() && $this->state->get('filter.cli
 							<span><?php echo $this->pagination->orderDownIcon($i, $this->pagination->total, isset($this->ordering[$item->parent_id][$orderkey + 1]), 'items.orderdown', 'JLIB_HTML_MOVE_DOWN', $ordering); ?></span>
 						<?php endif; ?>
 						<?php $disabled = $saveOrder ?  '' : 'disabled="disabled"'; ?>
-						<input type="text" name="order[]" value="<?php echo $orderkey + 1;?>" <?php echo $disabled ?> class="text-area-order" title="<?php echo $item->title; ?> order" />
+						<input type="text" name="order[]" value="<?php echo $orderkey + 1; ?>" <?php echo $disabled ?> class="text-area-order" title="<?php echo $item->title; ?> order" />
 					<?php else : ?>
-						<?php echo $orderkey + 1;?>
+						<?php echo $orderkey + 1; ?>
 					<?php endif; ?>
 				</td>
 				<td class="center">
@@ -195,7 +195,7 @@ $assoc     = JLanguageAssociations::isEnabled() && $this->state->get('filter.cli
 				<td class="center">
 					<?php if ($item->type == 'component') : ?>
 						<?php if ($item->language == '*' || $item->home == '0'):?>
-							<?php echo JHtml::_('jgrid.isdefault', $item->home, $i, 'items.', ($item->language != '*' || !$item->home) && $canChange  && !$item->protected);?>
+							<?php echo JHtml::_('jgrid.isdefault', $item->home, $i, 'items.', ($item->language != '*' || !$item->home) && $canChange  && !$item->protected); ?>
 						<?php elseif ($canChange):?>
 							<a href="<?php echo JRoute::_('index.php?option=com_menus&task=items.unsetDefault&cid[]='.$item->id.'&'.JSession::getFormToken().'=1'); ?>">
 								<?php if ($item->language_image) : ?>
@@ -210,24 +210,22 @@ $assoc     = JLanguageAssociations::isEnabled() && $this->state->get('filter.cli
 							<?php else : ?>
 								<span class="label" title="<?php echo $item->language_title; ?>"><?php echo $item->language_sef; ?></span>
 							<?php endif; ?>
-						<?php endif;?>
+						<?php endif; ?>
 					<?php endif; ?>
 				</td>
 				<?php endif; ?>
-				<?php
-				if ($assoc):
-				?>
+				<?php if ($assoc) : ?>
 				<td class="center">
 					<?php if ($item->association):?>
-						<?php echo JHtml::_('MenusHtml.Menus.association', $item->id);?>
-					<?php endif;?>
+						<?php echo JHtml::_('MenusHtml.Menus.association', $item->id); ?>
+					<?php endif; ?>
 				</td>
-				<?php endif;?>
+				<?php endif; ?>
 				<td class="center">
 					<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
 				</td>
 				<td class="center">
-					<span title="<?php echo sprintf('%d-%d', $item->lft, $item->rgt);?>">
+					<span title="<?php echo sprintf('%d-%d', $item->lft, $item->rgt); ?>">
 						<?php echo (int) $item->id; ?></span>
 				</td>
 			</tr>
@@ -249,7 +247,7 @@ $assoc     = JLanguageAssociations::isEnabled() && $this->state->get('filter.cli
 			),
 			$this->loadTemplate('batch_body')
 		); ?>
-	<?php endif;?>
+	<?php endif; ?>
 
 	<input type="hidden" name="task" value="" />
 	<input type="hidden" name="boxchecked" value="0" />

--- a/administrator/templates/hathor/html/com_menus/items/default.php
+++ b/administrator/templates/hathor/html/com_menus/items/default.php
@@ -14,16 +14,16 @@ JHtml::addIncludePath(JPATH_COMPONENT.'/helpers/html');
 
 JHtml::_('behavior.multiselect');
 
-$user      = JFactory::getUser();
-$app       = JFactory::getApplication();
-$userId    = $user->get('id');
-$listOrder = $this->escape($this->state->get('list.ordering'));
-$listDirn  = $this->escape($this->state->get('list.direction'));
-$ordering  = ($listOrder == 'a.lft');
-$canOrder  = $user->authorise('core.edit.state', 'com_menus');
-$saveOrder = ($listOrder == 'a.lft' && $listDirn == 'asc');
-$menutypeid	= (int) $this->state->get('menutypeid');
-$assoc     = JLanguageAssociations::isEnabled() && $this->state->get('filter.client_id') == 0;
+$user       = JFactory::getUser();
+$app        = JFactory::getApplication();
+$userId     = $user->get('id');
+$listOrder  = $this->escape($this->state->get('list.ordering'));
+$listDirn   = $this->escape($this->state->get('list.direction'));
+$ordering   = ($listOrder == 'a.lft');
+$canOrder   = $user->authorise('core.edit.state', 'com_menus');
+$saveOrder  = ($listOrder == 'a.lft' && $listDirn == 'asc');
+$menutypeid = (int) $this->state->get('menutypeid');
+$assoc      = JLanguageAssociations::isEnabled() && $this->state->get('filter.client_id') == 0;
 ?>
 
 <?php // Set up the filter bar. ?>

--- a/administrator/templates/hathor/html/com_menus/items/default.php
+++ b/administrator/templates/hathor/html/com_menus/items/default.php
@@ -60,7 +60,7 @@ $assoc     = JLanguageAssociations::isEnabled() && $this->state->get('filter.cli
 				<?php echo JHtml::_('select.options', $this->f_levels, 'value', 'text', $this->state->get('filter.level'));?>
 			</select>
 
-            		<label class="selectlabel" for="filter_published">
+					<label class="selectlabel" for="filter_published">
 				<?php echo JText::_('JOPTION_SELECT_PUBLISHED'); ?>
 			</label>
 			<select name="filter[published]" id="filter_published">
@@ -68,7 +68,7 @@ $assoc     = JLanguageAssociations::isEnabled() && $this->state->get('filter.cli
 				<?php echo JHtml::_('select.options', JHtml::_('jgrid.publishedOptions', array('archived' => false)), 'value', 'text', $this->state->get('filter.published'), true);?>
 			</select>
 
-            		<label class="selectlabel" for="filter_access">
+					<label class="selectlabel" for="filter_access">
 				<?php echo JText::_('JOPTION_SELECT_ACCESS'); ?>
 			</label>
 			<select name="filter[access]" id="filter_access">

--- a/administrator/templates/hathor/html/com_menus/items/default.php
+++ b/administrator/templates/hathor/html/com_menus/items/default.php
@@ -60,7 +60,7 @@ $assoc     = JLanguageAssociations::isEnabled() && $this->state->get('filter.cli
 				<?php echo JHtml::_('select.options', $this->f_levels, 'value', 'text', $this->state->get('filter.level'));?>
 			</select>
 
-					<label class="selectlabel" for="filter_published">
+			<label class="selectlabel" for="filter_published">
 				<?php echo JText::_('JOPTION_SELECT_PUBLISHED'); ?>
 			</label>
 			<select name="filter[published]" id="filter_published">
@@ -68,7 +68,7 @@ $assoc     = JLanguageAssociations::isEnabled() && $this->state->get('filter.cli
 				<?php echo JHtml::_('select.options', JHtml::_('jgrid.publishedOptions', array('archived' => false)), 'value', 'text', $this->state->get('filter.published'), true);?>
 			</select>
 
-					<label class="selectlabel" for="filter_access">
+			<label class="selectlabel" for="filter_access">
 				<?php echo JText::_('JOPTION_SELECT_ACCESS'); ?>
 			</label>
 			<select name="filter[access]" id="filter_access">

--- a/administrator/templates/hathor/html/com_menus/items/default.php
+++ b/administrator/templates/hathor/html/com_menus/items/default.php
@@ -178,8 +178,8 @@ $assoc      = JLanguageAssociations::isEnabled() && $this->state->get('filter.cl
 							<span><?php echo $this->pagination->orderUpIcon($i, isset($this->ordering[$item->parent_id][$orderkey - 1]), 'items.orderup', 'JLIB_HTML_MOVE_UP', $ordering); ?></span>
 							<span><?php echo $this->pagination->orderDownIcon($i, $this->pagination->total, isset($this->ordering[$item->parent_id][$orderkey + 1]), 'items.orderdown', 'JLIB_HTML_MOVE_DOWN', $ordering); ?></span>
 						<?php endif; ?>
-						<?php $disabled = $saveOrder ?  '' : 'disabled="disabled"'; ?>
-						<input type="text" name="order[]" value="<?php echo $orderkey + 1; ?>" <?php echo $disabled ?> class="text-area-order" title="<?php echo $item->title; ?> order" />
+						<?php $disabled = $saveOrder ? '' : 'disabled="disabled"'; ?>
+						<input type="text" name="order[]" value="<?php echo $orderkey + 1; ?>" <?php echo $disabled; ?> class="text-area-order" title="<?php echo $item->title; ?> order" />
 					<?php else : ?>
 						<?php echo $orderkey + 1; ?>
 					<?php endif; ?>
@@ -195,7 +195,7 @@ $assoc      = JLanguageAssociations::isEnabled() && $this->state->get('filter.cl
 				<td class="center">
 					<?php if ($item->type == 'component') : ?>
 						<?php if ($item->language == '*' || $item->home == '0'):?>
-							<?php echo JHtml::_('jgrid.isdefault', $item->home, $i, 'items.', ($item->language != '*' || !$item->home) && $canChange  && !$item->protected); ?>
+							<?php echo JHtml::_('jgrid.isdefault', $item->home, $i, 'items.', ($item->language != '*' || !$item->home) && $canChange && !$item->protected); ?>
 						<?php elseif ($canChange):?>
 							<a href="<?php echo JRoute::_('index.php?option=com_menus&task=items.unsetDefault&cid[]='.$item->id.'&'.JSession::getFormToken().'=1'); ?>">
 								<?php if ($item->language_image) : ?>

--- a/administrator/templates/hathor/html/com_menus/menu/edit.php
+++ b/administrator/templates/hathor/html/com_menus/menu/edit.php
@@ -42,10 +42,10 @@ JFactory::getDocument()->addScriptDeclaration("
 				<?php echo $this->form->getInput('menutype'); ?></li>
 
 				<li><?php echo $this->form->getLabel('description'); ?>
-				 <?php echo $this->form->getInput('description'); ?></li>
+				<?php echo $this->form->getInput('description'); ?></li>
 
 				<li><?php echo $this->form->getLabel('client_id'); ?>
-				 <?php echo $this->form->getInput('client_id'); ?></li>				 
+				<?php echo $this->form->getInput('client_id'); ?></li>
 			</ul>
 	</fieldset>
 </div>

--- a/administrator/templates/hathor/html/com_menus/menu/edit.php
+++ b/administrator/templates/hathor/html/com_menus/menu/edit.php
@@ -42,10 +42,10 @@ JFactory::getDocument()->addScriptDeclaration("
 				<?php echo $this->form->getInput('menutype'); ?></li>
 
 				<li><?php echo $this->form->getLabel('description'); ?>
-			 	<?php echo $this->form->getInput('description'); ?></li>
+				 <?php echo $this->form->getInput('description'); ?></li>
 
 				<li><?php echo $this->form->getLabel('client_id'); ?>
-			 	<?php echo $this->form->getInput('client_id'); ?></li>				 
+				 <?php echo $this->form->getInput('client_id'); ?></li>				 
 			</ul>
 	</fieldset>
 </div>

--- a/administrator/templates/hathor/html/com_modules/modules/default.php
+++ b/administrator/templates/hathor/html/com_modules/modules/default.php
@@ -31,7 +31,7 @@ $saveOrder = $listOrder == 'ordering';
 	<div id="j-main-container" class="span10">
 <?php else : ?>
 	<div id="j-main-container">
-<?php endif;?>
+<?php endif; ?>
 	<fieldset id="filter-bar">
 	<legend class="element-invisible"><?php echo JText::_('JSEARCH_FILTER_LABEL'); ?></legend>
 		<div class="filter-search">
@@ -46,47 +46,47 @@ $saveOrder = $listOrder == 'ordering';
 				<?php echo JText::_('JGLOBAL_FILTER_CLIENT'); ?>
 			</label>
 			<select name="client_id" id="client_id">
-				<?php echo JHtml::_('select.options', ModulesHelper::getClientOptions(), 'value', 'text', $this->state->get('client_id'));?>
+				<?php echo JHtml::_('select.options', ModulesHelper::getClientOptions(), 'value', 'text', $this->state->get('client_id')); ?>
 			</select>
 
 			<label class="selectlabel" for="filter_state">
 				<?php echo JText::_('JOPTION_SELECT_PUBLISHED'); ?>
 			</label>
 			<select name="filter_state" id="filter_state">
-				<option value=""><?php echo JText::_('JOPTION_SELECT_PUBLISHED');?></option>
-				<?php echo JHtml::_('select.options', ModulesHelper::getStateOptions(), 'value', 'text', $this->state->get('filter.state'));?>
+				<option value=""><?php echo JText::_('JOPTION_SELECT_PUBLISHED'); ?></option>
+				<?php echo JHtml::_('select.options', ModulesHelper::getStateOptions(), 'value', 'text', $this->state->get('filter.state')); ?>
 			</select>
 
 			<label class="selectlabel" for="filter_position">
 				<?php echo JText::_('COM_MODULES_OPTION_SELECT_POSITION'); ?>
 			</label>
 			<select name="filter_position" id="filter_position">
-				<option value=""><?php echo JText::_('COM_MODULES_OPTION_SELECT_POSITION');?></option>
-				<?php echo JHtml::_('select.options', ModulesHelper::getPositions($this->state->get('client_id')), 'value', 'text', $this->state->get('filter.position'));?>
+				<option value=""><?php echo JText::_('COM_MODULES_OPTION_SELECT_POSITION'); ?></option>
+				<?php echo JHtml::_('select.options', ModulesHelper::getPositions($this->state->get('client_id')), 'value', 'text', $this->state->get('filter.position')); ?>
 			</select>
 
 			<label class="selectlabel" for="filter_module">
 				<?php echo JText::_('COM_MODULES_OPTION_SELECT_MODULE'); ?>
 			</label>
 			<select name="filter_module" id="filter_module">
-				<option value=""><?php echo JText::_('COM_MODULES_OPTION_SELECT_MODULE');?></option>
-				<?php echo JHtml::_('select.options', ModulesHelper::getModules($this->state->get('client_id')), 'value', 'text', $this->state->get('filter.module'));?>
+				<option value=""><?php echo JText::_('COM_MODULES_OPTION_SELECT_MODULE'); ?></option>
+				<?php echo JHtml::_('select.options', ModulesHelper::getModules($this->state->get('client_id')), 'value', 'text', $this->state->get('filter.module')); ?>
 			</select>
 
 			<label class="selectlabel" for="filter_access">
 				<?php echo JText::_('JOPTION_SELECT_ACCESS'); ?>
 			</label>
 			<select name="filter_access" id="filter_access">
-				<option value=""><?php echo JText::_('JOPTION_SELECT_ACCESS');?></option>
-				<?php echo JHtml::_('select.options', JHtml::_('access.assetgroups'), 'value', 'text', $this->state->get('filter.access'));?>
+				<option value=""><?php echo JText::_('JOPTION_SELECT_ACCESS'); ?></option>
+				<?php echo JHtml::_('select.options', JHtml::_('access.assetgroups'), 'value', 'text', $this->state->get('filter.access')); ?>
 			</select>
 
 			<label class="selectlabel" for="filter_language">
 				<?php echo JText::_('JOPTION_SELECT_LANGUAGE'); ?>
 			</label>
 			<select name="filter_language" id="filter_language">
-				<option value=""><?php echo JText::_('JOPTION_SELECT_LANGUAGE');?></option>
-				<?php echo JHtml::_('select.options', JHtml::_('contentlanguage.existing', true, true), 'value', 'text', $this->state->get('filter.language'));?>
+				<option value=""><?php echo JText::_('JOPTION_SELECT_LANGUAGE'); ?></option>
+				<?php echo JHtml::_('select.options', JHtml::_('contentlanguage.existing', true, true), 'value', 'text', $this->state->get('filter.language')); ?>
 			</select>
 
 			<button type="submit" id="filter-go">
@@ -159,7 +159,7 @@ $saveOrder = $listOrder == 'ordering';
 					<?php endif; ?>
 					<?php if (!empty($item->note)) : ?>
 					<p class="smallsub">
-						<?php echo JText::sprintf('JGLOBAL_LIST_NOTE', $this->escape($item->note));?></p>
+						<?php echo JText::sprintf('JGLOBAL_LIST_NOTE', $this->escape($item->note)); ?></p>
 					<?php endif; ?>
 				</td>
 				<td class="center">
@@ -188,13 +188,13 @@ $saveOrder = $listOrder == 'ordering';
 							<?php endif; ?>
 						<?php endif; ?>
 						<?php $disabled = $saveOrder ?  '' : 'disabled="disabled"'; ?>
-						<input type="text" name="order[]" value="<?php echo $item->ordering;?>" <?php echo $disabled ?> class="text-area-order" title="<?php echo $item->title; ?> order" />
+						<input type="text" name="order[]" value="<?php echo $item->ordering; ?>" <?php echo $disabled; ?> class="text-area-order" title="<?php echo $item->title; ?> order" />
 					<?php else : ?>
 						<?php echo $item->ordering; ?>
 					<?php endif; ?>
 				</td>
 				<td class="left">
-					<?php echo $item->name;?>
+					<?php echo $item->name; ?>
 				</td>
 				<td class="center">
 					<?php echo $item->pages; ?>
@@ -210,7 +210,7 @@ $saveOrder = $listOrder == 'ordering';
 						<?php echo JText::alt('JALL', 'language'); ?>
 					<?php else:?>
 						<?php echo $item->language_title ? JHtml::_('image', 'mod_languages/' . $item->language_image . '.gif', $item->language_title, array('title' => $item->language_title), true) . '&nbsp;' . $this->escape($item->language_title) : JText::_('JUNDEFINED'); ?>
-					<?php endif;?>
+					<?php endif; ?>
 				</td>
 				<td class="center">
 					<?php echo (int) $item->id; ?>

--- a/administrator/templates/hathor/html/com_newsfeeds/newsfeed/edit.php
+++ b/administrator/templates/hathor/html/com_newsfeeds/newsfeed/edit.php
@@ -41,7 +41,7 @@ JFactory::getDocument()->addScriptDeclaration("
 			<li><?php echo $this->form->getLabel('name'); ?>
 			<?php echo $this->form->getInput('name'); ?></li>
 
-			   <li><?php echo $this->form->getLabel('alias'); ?>
+			<li><?php echo $this->form->getLabel('alias'); ?>
 			<?php echo $this->form->getInput('alias'); ?></li>
 
 			<li><?php echo $this->form->getLabel('link'); ?>

--- a/administrator/templates/hathor/html/com_newsfeeds/newsfeed/edit.php
+++ b/administrator/templates/hathor/html/com_newsfeeds/newsfeed/edit.php
@@ -41,7 +41,7 @@ JFactory::getDocument()->addScriptDeclaration("
 			<li><?php echo $this->form->getLabel('name'); ?>
 			<?php echo $this->form->getInput('name'); ?></li>
 
-   			<li><?php echo $this->form->getLabel('alias'); ?>
+			   <li><?php echo $this->form->getLabel('alias'); ?>
 			<?php echo $this->form->getInput('alias'); ?></li>
 
 			<li><?php echo $this->form->getLabel('link'); ?>

--- a/administrator/templates/hathor/html/com_newsfeeds/newsfeeds/default.php
+++ b/administrator/templates/hathor/html/com_newsfeeds/newsfeeds/default.php
@@ -32,7 +32,7 @@ $assoc     = JLanguageAssociations::isEnabled();
 	<div id="j-main-container" class="span10">
 <?php else : ?>
 	<div id="j-main-container">
-<?php endif;?>
+<?php endif; ?>
 	<fieldset id="filter-bar">
 	<legend class="element-invisible"><?php echo JText::_('JSEARCH_FILTER_LABEL'); ?></legend>
 		<div class="filter-search">
@@ -47,40 +47,40 @@ $assoc     = JLanguageAssociations::isEnabled();
 				<?php echo JText::_('JOPTION_SELECT_PUBLISHED'); ?>
 			</label>
 			<select name="filter_published" id="filter_published">
-				<option value=""><?php echo JText::_('JOPTION_SELECT_PUBLISHED');?></option>
-				<?php echo JHtml::_('select.options', JHtml::_('jgrid.publishedOptions'), 'value', 'text', $this->state->get('filter.published'), true);?>
+				<option value=""><?php echo JText::_('JOPTION_SELECT_PUBLISHED'); ?></option>
+				<?php echo JHtml::_('select.options', JHtml::_('jgrid.publishedOptions'), 'value', 'text', $this->state->get('filter.published'), true); ?>
 			</select>
 
 			<label class="selectlabel" for="filter_category_id">
 				<?php echo JText::_('JOPTION_SELECT_CATEGORY'); ?>
 			</label>
 			<select name="filter_category_id" id="filter_category_id">
-				<option value=""><?php echo JText::_('JOPTION_SELECT_CATEGORY');?></option>
-				<?php echo JHtml::_('select.options', JHtml::_('category.options', 'com_newsfeeds'), 'value', 'text', $this->state->get('filter.category_id'));?>
+				<option value=""><?php echo JText::_('JOPTION_SELECT_CATEGORY'); ?></option>
+				<?php echo JHtml::_('select.options', JHtml::_('category.options', 'com_newsfeeds'), 'value', 'text', $this->state->get('filter.category_id')); ?>
 			</select>
 
 			<label class="selectlabel" for="filter_access">
 				<?php echo JText::_('JOPTION_SELECT_ACCESS'); ?>
 			</label>
 			<select name="filter_access" id="filter_access">
-				<option value=""><?php echo JText::_('JOPTION_SELECT_ACCESS');?></option>
-				<?php echo JHtml::_('select.options', JHtml::_('access.assetgroups'), 'value', 'text', $this->state->get('filter.access'));?>
+				<option value=""><?php echo JText::_('JOPTION_SELECT_ACCESS'); ?></option>
+				<?php echo JHtml::_('select.options', JHtml::_('access.assetgroups'), 'value', 'text', $this->state->get('filter.access')); ?>
 			</select>
 
 			<label class="selectlabel" for="filter_language">
 				<?php echo JText::_('JOPTION_SELECT_LANGUAGE'); ?>
 			</label>
 			<select name="filter_language" id="filter_language">
-				<option value=""><?php echo JText::_('JOPTION_SELECT_LANGUAGE');?></option>
-				<?php echo JHtml::_('select.options', JHtml::_('contentlanguage.existing', true, true), 'value', 'text', $this->state->get('filter.language'));?>
+				<option value=""><?php echo JText::_('JOPTION_SELECT_LANGUAGE'); ?></option>
+				<?php echo JHtml::_('select.options', JHtml::_('contentlanguage.existing', true, true), 'value', 'text', $this->state->get('filter.language')); ?>
 			</select>
 
 			<label class="selectlabel" for="filter_tag">
 				<?php echo JText::_('JOPTION_SELECT_TAG'); ?>
 			</label>
 			<select name="filter_tag" id="filter_tag">
-				<option value=""><?php echo JText::_('JOPTION_SELECT_TAG');?></option>
-				<?php echo JHtml::_('select.options', JHtml::_('tag.options', true, true), 'value', 'text', $this->state->get('filter.tag'));?>
+				<option value=""><?php echo JText::_('JOPTION_SELECT_TAG'); ?></option>
+				<?php echo JHtml::_('select.options', JHtml::_('tag.options', true, true), 'value', 'text', $this->state->get('filter.tag')); ?>
 			</select>
 
 			<button type="submit" id="filter-go">
@@ -123,7 +123,7 @@ $assoc     = JLanguageAssociations::isEnabled();
 					<th class="width-5">
 						<?php echo JHtml::_('grid.sort', 'COM_NEWSFEEDS_HEADING_ASSOCIATION', 'association', $listDirn, $listOrder); ?>
 					</th>
-				<?php endif;?>
+				<?php endif; ?>
 				<th class="width-5">
 					<?php echo JHtml::_('grid.sort', 'JGRID_HEADING_LANGUAGE', 'a.language', $listDirn, $listOrder); ?>
 				</th>
@@ -156,7 +156,7 @@ $assoc     = JLanguageAssociations::isEnabled();
 							<?php echo $this->escape($item->name); ?>
 					<?php endif; ?>
 					<p class="smallsub">
-						<?php echo JText::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->alias));?></p>
+						<?php echo JText::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->alias)); ?></p>
 				</td>
 				<td class="center">
 					<?php echo JHtml::_('jgrid.published', $item->published, $i, 'newsfeeds.', $canChange, 'cb', $item->publish_up, $item->publish_down); ?>
@@ -176,7 +176,7 @@ $assoc     = JLanguageAssociations::isEnabled();
 							<?php endif; ?>
 						<?php endif; ?>
 						<?php $disabled = $saveOrder ?  '' : 'disabled="disabled"'; ?>
-						<input type="text" name="order[]" size="5" value="<?php echo $item->ordering;?>" <?php echo $disabled ?> class="text-area-order" title="<?php echo $item->name; ?> order" />
+						<input type="text" name="order[]" size="5" value="<?php echo $item->ordering; ?>" <?php echo $disabled; ?> class="text-area-order" title="<?php echo $item->name; ?> order" />
 					<?php else : ?>
 						<?php echo $item->ordering; ?>
 					<?php endif; ?>
@@ -196,7 +196,7 @@ $assoc     = JLanguageAssociations::isEnabled();
 							<?php echo JHtml::_('newsfeed.association', $item->id); ?>
 						<?php endif; ?>
 					</td>
-				<?php endif;?>
+				<?php endif; ?>
 				<td class="center">
 					<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
 				</td>
@@ -221,7 +221,7 @@ $assoc     = JLanguageAssociations::isEnabled();
 			),
 			$this->loadTemplate('batch_body')
 		); ?>
-	<?php endif;?>
+	<?php endif; ?>
 
 	<?php echo $this->pagination->getListFooter(); ?>
 

--- a/administrator/templates/hathor/html/com_plugins/plugins/default.php
+++ b/administrator/templates/hathor/html/com_plugins/plugins/default.php
@@ -28,7 +28,7 @@ $saveOrder = $listOrder == 'ordering';
 	<div id="j-main-container" class="span10">
 <?php else : ?>
 	<div id="j-main-container">
-<?php endif;?>
+<?php endif; ?>
 	<fieldset id="filter-bar">
 	<legend class="element-invisible"><?php echo JText::_('JSEARCH_FILTER_LABEL'); ?></legend>
 		<div class="filter-search">
@@ -43,23 +43,23 @@ $saveOrder = $listOrder == 'ordering';
 				<?php echo JText::_('JOPTION_SELECT_PUBLISHED'); ?>
 			</label>
 			<select name="filter_enabled" id="filter_enabled">
-				<option value=""><?php echo JText::_('JOPTION_SELECT_PUBLISHED');?></option>
-				<?php echo JHtml::_('select.options', PluginsHelper::publishedOptions(), 'value', 'text', $this->state->get('filter.enabled'), true);?>
+				<option value=""><?php echo JText::_('JOPTION_SELECT_PUBLISHED'); ?></option>
+				<?php echo JHtml::_('select.options', PluginsHelper::publishedOptions(), 'value', 'text', $this->state->get('filter.enabled'), true); ?>
 			</select>
 
 			<label class="selectlabel" for="filter_folder">
 				<?php echo JText::_('COM_PLUGINS_OPTION_FOLDER'); ?>
 			</label>
 			<select name="filter_folder" id="filter_folder">
-				<option value=""><?php echo JText::_('COM_PLUGINS_OPTION_FOLDER');?></option>
-				<?php echo JHtml::_('select.options', PluginsHelper::folderOptions(), 'value', 'text', $this->state->get('filter.folder'));?>
+				<option value=""><?php echo JText::_('COM_PLUGINS_OPTION_FOLDER'); ?></option>
+				<?php echo JHtml::_('select.options', PluginsHelper::folderOptions(), 'value', 'text', $this->state->get('filter.folder')); ?>
 			</select>
 			<label class="selectlabel" for="filter_access">
 				<?php echo JText::_('JOPTION_SELECT_ACCESS'); ?>
 			</label>
 			<select name="filter_access" id="filter_access">
-				<option value=""><?php echo JText::_('JOPTION_SELECT_ACCESS');?></option>
-				<?php echo JHtml::_('select.options', JHtml::_('access.assetgroups'), 'value', 'text', $this->state->get('filter.access'));?>
+				<option value=""><?php echo JText::_('JOPTION_SELECT_ACCESS'); ?></option>
+				<?php echo JHtml::_('select.options', JHtml::_('access.assetgroups'), 'value', 'text', $this->state->get('filter.access')); ?>
 			</select>
 
 			<button type="submit" id="filter-go">
@@ -108,7 +108,7 @@ $saveOrder = $listOrder == 'ordering';
 			$canEdit    = $user->authorise('core.edit',       'com_plugins');
 			$canCheckin = $user->authorise('core.manage',     'com_checkin') || $item->checked_out == $user->get('id') || $item->checked_out == 0;
 			$canChange  = $user->authorise('core.edit.state', 'com_plugins') && $canCheckin;
-			?>
+		?>
 			<tr class="row<?php echo $i % 2; ?>">
 				<td class="center">
 					<?php echo JHtml::_('grid.id', $i, $item->extension_id); ?>
@@ -129,7 +129,7 @@ $saveOrder = $listOrder == 'ordering';
 				</td>
 				<td class="order">
 					<?php if ($canChange) : ?>
-						<?php if ($saveOrder) :?>
+						<?php if ($saveOrder) : ?>
 							<?php if ($listDirn == 'asc') : ?>
 								<span><?php echo $this->pagination->orderUpIcon($i, @$this->items[$i - 1]->folder == $item->folder, 'plugins.orderup', 'JLIB_HTML_MOVE_UP', $ordering); ?></span>
 								<span><?php echo $this->pagination->orderDownIcon($i, $this->pagination->total, @$this->items[$i + 1]->folder == $item->folder, 'plugins.orderdown', 'JLIB_HTML_MOVE_DOWN', $ordering); ?></span>
@@ -139,23 +139,23 @@ $saveOrder = $listOrder == 'ordering';
 							<?php endif; ?>
 						<?php endif; ?>
 						<?php $disabled = $saveOrder ?  '' : 'disabled="disabled"'; ?>
-						<input type="text" name="order[]" value="<?php echo $item->ordering;?>" <?php echo $disabled ?> class="text-area-order" title="<?php echo $item->name; ?> order" />
+						<input type="text" name="order[]" value="<?php echo $item->ordering; ?>" <?php echo $disabled ?> class="text-area-order" title="<?php echo $item->name; ?> order" />
 					<?php else : ?>
 						<?php echo $item->ordering; ?>
 					<?php endif; ?>
 				</td>
 
 				<td class="nowrap center">
-					<?php echo $this->escape($item->folder);?>
+					<?php echo $this->escape($item->folder); ?>
 				</td>
 				<td class="nowrap center">
-					<?php echo $this->escape($item->element);?>
+					<?php echo $this->escape($item->element); ?>
 				</td>
 				<td class="center">
 					<?php echo $this->escape($item->access_level); ?>
 				</td>
 				<td class="center">
-					<?php echo (int) $item->extension_id;?>
+					<?php echo (int) $item->extension_id; ?>
 				</td>
 			</tr>
 			<?php endforeach; ?>

--- a/administrator/templates/hathor/html/com_plugins/plugins/default.php
+++ b/administrator/templates/hathor/html/com_plugins/plugins/default.php
@@ -54,7 +54,7 @@ $saveOrder = $listOrder == 'ordering';
 				<option value=""><?php echo JText::_('COM_PLUGINS_OPTION_FOLDER');?></option>
 				<?php echo JHtml::_('select.options', PluginsHelper::folderOptions(), 'value', 'text', $this->state->get('filter.folder'));?>
 			</select>
-					<label class="selectlabel" for="filter_access">
+			<label class="selectlabel" for="filter_access">
 				<?php echo JText::_('JOPTION_SELECT_ACCESS'); ?>
 			</label>
 			<select name="filter_access" id="filter_access">
@@ -93,7 +93,7 @@ $saveOrder = $listOrder == 'ordering';
 				<th class="nowrap width-10">
 					<?php echo JHtml::_('grid.sort', 'COM_PLUGINS_ELEMENT_HEADING', 'element', $listDirn, $listOrder); ?>
 				</th>
-						<th class="title access-col">
+				<th class="title access-col">
 					<?php echo JHtml::_('grid.sort', 'JGRID_HEADING_ACCESS', 'access', $listDirn, $listOrder); ?>
 				</th>
 				<th class="nowrap id-col">

--- a/administrator/templates/hathor/html/com_plugins/plugins/default.php
+++ b/administrator/templates/hathor/html/com_plugins/plugins/default.php
@@ -54,7 +54,7 @@ $saveOrder = $listOrder == 'ordering';
 				<option value=""><?php echo JText::_('COM_PLUGINS_OPTION_FOLDER');?></option>
 				<?php echo JHtml::_('select.options', PluginsHelper::folderOptions(), 'value', 'text', $this->state->get('filter.folder'));?>
 			</select>
-            		<label class="selectlabel" for="filter_access">
+					<label class="selectlabel" for="filter_access">
 				<?php echo JText::_('JOPTION_SELECT_ACCESS'); ?>
 			</label>
 			<select name="filter_access" id="filter_access">
@@ -93,7 +93,7 @@ $saveOrder = $listOrder == 'ordering';
 				<th class="nowrap width-10">
 					<?php echo JHtml::_('grid.sort', 'COM_PLUGINS_ELEMENT_HEADING', 'element', $listDirn, $listOrder); ?>
 				</th>
-                		<th class="title access-col">
+						<th class="title access-col">
 					<?php echo JHtml::_('grid.sort', 'JGRID_HEADING_ACCESS', 'access', $listDirn, $listOrder); ?>
 				</th>
 				<th class="nowrap id-col">
@@ -151,7 +151,7 @@ $saveOrder = $listOrder == 'ordering';
 				<td class="nowrap center">
 					<?php echo $this->escape($item->element);?>
 				</td>
-                <td class="center">
+				<td class="center">
 					<?php echo $this->escape($item->access_level); ?>
 				</td>
 				<td class="center">

--- a/administrator/templates/hathor/html/com_plugins/plugins/default.php
+++ b/administrator/templates/hathor/html/com_plugins/plugins/default.php
@@ -139,7 +139,7 @@ $saveOrder = $listOrder == 'ordering';
 							<?php endif; ?>
 						<?php endif; ?>
 						<?php $disabled = $saveOrder ?  '' : 'disabled="disabled"'; ?>
-						<input type="text" name="order[]" value="<?php echo $item->ordering; ?>" <?php echo $disabled ?> class="text-area-order" title="<?php echo $item->name; ?> order" />
+						<input type="text" name="order[]" value="<?php echo $item->ordering; ?>" <?php echo $disabled; ?> class="text-area-order" title="<?php echo $item->name; ?> order" />
 					<?php else : ?>
 						<?php echo $item->ordering; ?>
 					<?php endif; ?>

--- a/administrator/templates/hathor/html/com_users/levels/default.php
+++ b/administrator/templates/hathor/html/com_users/levels/default.php
@@ -21,7 +21,7 @@ $canOrder  = $user->authorise('core.edit.state', 'com_users');
 $saveOrder = $listOrder == 'a.ordering';
 ?>
 
-<form action="<?php echo JRoute::_('index.php?option=com_users&view=levels');?>" method="post" id="adminForm" name="adminForm">
+<form action="<?php echo JRoute::_('index.php?option=com_users&view=levels'); ?>" method="post" id="adminForm" name="adminForm">
 <?php if (!empty( $this->sidebar)) : ?>
 	<div id="j-sidebar-container" class="span2">
 		<?php echo $this->sidebar; ?>
@@ -29,7 +29,7 @@ $saveOrder = $listOrder == 'a.ordering';
 	<div id="j-main-container" class="span10">
 <?php else : ?>
 	<div id="j-main-container">
-<?php endif;?>
+<?php endif; ?>
 	<fieldset id="filter-bar">
 	<legend class="element-invisible"><?php echo JText::_('COM_USERS_SEARCH_ACCESS_LEVELS'); ?></legend>
 		<div class="filter-search">
@@ -78,7 +78,7 @@ $saveOrder = $listOrder == 'a.ordering';
 				</td>
 				<td>
 					<?php if ($canEdit) : ?>
-					<a href="<?php echo JRoute::_('index.php?option=com_users&task=level.edit&id='.$item->id);?>">
+					<a href="<?php echo JRoute::_('index.php?option=com_users&task=level.edit&id='.$item->id); ?>">
 						<?php echo $this->escape($item->title); ?></a>
 					<?php else : ?>
 						<?php echo $this->escape($item->title); ?>
@@ -96,7 +96,7 @@ $saveOrder = $listOrder == 'a.ordering';
 							<?php endif; ?>
 						<?php endif; ?>
 						<?php $disabled = $saveOrder ?  '' : 'disabled="disabled"'; ?>
-						<input type="text" name="order[]" value="<?php echo $item->ordering;?>" <?php echo $disabled ?> class="text-area-order" title="<?php echo $item->title; ?> order" />
+						<input type="text" name="order[]" value="<?php echo $item->ordering; ?>" <?php echo $disabled; ?> class="text-area-order" title="<?php echo $item->title; ?> order" />
 					<?php else : ?>
 						<?php echo $item->ordering; ?>
 					<?php endif; ?>

--- a/administrator/templates/hathor/html/com_weblinks/weblinks/default.php
+++ b/administrator/templates/hathor/html/com_weblinks/weblinks/default.php
@@ -57,7 +57,7 @@ $saveOrder = $listOrder == 'a.ordering';
 				<?php echo JHtml::_('select.options', JHtml::_('category.options', 'com_weblinks'), 'value', 'text', $this->state->get('filter.category_id'));?>
 			</select>
 
-            		<label class="selectlabel" for="filter_access">
+					<label class="selectlabel" for="filter_access">
 				<?php echo JText::_('JOPTION_SELECT_ACCESS'); ?>
 			</label>
 			<select name="filter_access" id="filter_access">

--- a/administrator/templates/hathor/html/com_weblinks/weblinks/default.php
+++ b/administrator/templates/hathor/html/com_weblinks/weblinks/default.php
@@ -57,7 +57,7 @@ $saveOrder = $listOrder == 'a.ordering';
 				<?php echo JHtml::_('select.options', JHtml::_('category.options', 'com_weblinks'), 'value', 'text', $this->state->get('filter.category_id'));?>
 			</select>
 
-					<label class="selectlabel" for="filter_access">
+			<label class="selectlabel" for="filter_access">
 				<?php echo JText::_('JOPTION_SELECT_ACCESS'); ?>
 			</label>
 			<select name="filter_access" id="filter_access">

--- a/administrator/templates/hathor/html/com_weblinks/weblinks/default.php
+++ b/administrator/templates/hathor/html/com_weblinks/weblinks/default.php
@@ -30,7 +30,7 @@ $saveOrder = $listOrder == 'a.ordering';
 	<div id="j-main-container" class="span10">
 <?php else : ?>
 	<div id="j-main-container">
-<?php endif;?>
+<?php endif; ?>
 	<fieldset id="filter-bar">
 	<legend class="element-invisible"><?php echo JText::_('JSEARCH_FILTER_LABEL'); ?></legend>
 		<div class="filter-search">
@@ -45,40 +45,40 @@ $saveOrder = $listOrder == 'a.ordering';
 				<?php echo JText::_('JOPTION_SELECT_PUBLISHED'); ?>
 			</label>
 			<select name="filter_published" id="filter_published">
-				<option value=""><?php echo JText::_('JOPTION_SELECT_PUBLISHED');?></option>
-				<?php echo JHtml::_('select.options', JHtml::_('jgrid.publishedOptions'), 'value', 'text', $this->state->get('filter.state'), true);?>
+				<option value=""><?php echo JText::_('JOPTION_SELECT_PUBLISHED'); ?></option>
+				<?php echo JHtml::_('select.options', JHtml::_('jgrid.publishedOptions'), 'value', 'text', $this->state->get('filter.state'), true); ?>
 			</select>
 
 			<label class="selectlabel" for="filter_category_id">
 				<?php echo JText::_('JOPTION_SELECT_CATEGORY'); ?>
 			</label>
 			<select name="filter_category_id" id="filter_category_id">
-				<option value=""><?php echo JText::_('JOPTION_SELECT_CATEGORY');?></option>
-				<?php echo JHtml::_('select.options', JHtml::_('category.options', 'com_weblinks'), 'value', 'text', $this->state->get('filter.category_id'));?>
+				<option value=""><?php echo JText::_('JOPTION_SELECT_CATEGORY'); ?></option>
+				<?php echo JHtml::_('select.options', JHtml::_('category.options', 'com_weblinks'), 'value', 'text', $this->state->get('filter.category_id')); ?>
 			</select>
 
 			<label class="selectlabel" for="filter_access">
 				<?php echo JText::_('JOPTION_SELECT_ACCESS'); ?>
 			</label>
 			<select name="filter_access" id="filter_access">
-				<option value=""><?php echo JText::_('JOPTION_SELECT_ACCESS');?></option>
-				<?php echo JHtml::_('select.options', JHtml::_('access.assetgroups'), 'value', 'text', $this->state->get('filter.access'));?>
+				<option value=""><?php echo JText::_('JOPTION_SELECT_ACCESS'); ?></option>
+				<?php echo JHtml::_('select.options', JHtml::_('access.assetgroups'), 'value', 'text', $this->state->get('filter.access')); ?>
 			</select>
 
 			<label class="selectlabel" for="filter_language">
 				<?php echo JText::_('JOPTION_SELECT_LANGUAGE'); ?>
 			</label>
 			<select name="filter_language" id="filter_language">
-				<option value=""><?php echo JText::_('JOPTION_SELECT_LANGUAGE');?></option>
-				<?php echo JHtml::_('select.options', JHtml::_('contentlanguage.existing', true, true), 'value', 'text', $this->state->get('filter.language'));?>
+				<option value=""><?php echo JText::_('JOPTION_SELECT_LANGUAGE'); ?></option>
+				<?php echo JHtml::_('select.options', JHtml::_('contentlanguage.existing', true, true), 'value', 'text', $this->state->get('filter.language')); ?>
 			</select>
 
 			<label class="selectlabel" for="filter_tag">
 				<?php echo JText::_('JOPTION_SELECT_TAG'); ?>
 			</label>
 			<select name="filter_tag" id="filter_tag">
-				<option value=""><?php echo JText::_('JOPTION_SELECT_TAG');?></option>
-				<?php echo JHtml::_('select.options', JHtml::_('tag.options', true, true), 'value', 'text', $this->state->get('filter.tag'));?>
+				<option value=""><?php echo JText::_('JOPTION_SELECT_TAG'); ?></option>
+				<?php echo JHtml::_('select.options', JHtml::_('tag.options', true, true), 'value', 'text', $this->state->get('filter.tag')); ?>
 			</select>
 
 			<button type="submit" id="filter-go">
@@ -147,7 +147,7 @@ $saveOrder = $listOrder == 'a.ordering';
 							<?php echo $this->escape($item->title); ?>
 					<?php endif; ?>
 					<p class="smallsub">
-						<?php echo JText::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->alias));?></p>
+						<?php echo JText::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->alias)); ?></p>
 				</td>
 				<td class="center">
 					<?php echo JHtml::_('jgrid.published', $item->state, $i, 'weblinks.', $canChange, 'cb', $item->publish_up, $item->publish_down); ?>
@@ -166,8 +166,8 @@ $saveOrder = $listOrder == 'a.ordering';
 								<span><?php echo $this->pagination->orderDownIcon($i, $this->pagination->total, $item->catid == @$this->items[$i + 1]->catid, 'weblinks.orderup', 'JLIB_HTML_MOVE_DOWN', $ordering); ?></span>
 							<?php endif; ?>
 						<?php endif; ?>
-						<?php $disabled = $saveOrder ?  '' : 'disabled="disabled"'; ?>
-						<input type="text" name="order[]" value="<?php echo $item->ordering;?>" <?php echo $disabled ?> class="text-area-order" title="<?php echo $item->title; ?> order" />
+						<?php $disabled = $saveOrder ? '' : 'disabled="disabled"'; ?>
+						<input type="text" name="order[]" value="<?php echo $item->ordering; ?>" <?php echo $disabled; ?> class="text-area-order" title="<?php echo $item->title; ?> order" />
 					<?php else : ?>
 						<?php echo $item->ordering; ?>
 					<?php endif; ?>

--- a/administrator/templates/isis/html/com_media/medialist/thumbs_imgs.php
+++ b/administrator/templates/isis/html/com_media/medialist/thumbs_imgs.php
@@ -36,7 +36,7 @@ $dispatcher = JEventDispatcher::getInstance();
 			</label>
 		</div>
 
-		 <div class="imgPreview nowrap small">
+		<div class="imgPreview nowrap small">
 			<a href="<?php echo COM_MEDIA_BASEURL, '/', $img->path_relative; ?>" title="<?php echo $img->name; ?>" class="preview truncate">
 				<span class="icon-search" aria-hidden="true"></span><?php echo $img->name; ?>
 			</a>

--- a/administrator/templates/isis/html/com_media/medialist/thumbs_imgs.php
+++ b/administrator/templates/isis/html/com_media/medialist/thumbs_imgs.php
@@ -36,7 +36,7 @@ $dispatcher = JEventDispatcher::getInstance();
 			</label>
 		</div>
 
- 		<div class="imgPreview nowrap small">
+		 <div class="imgPreview nowrap small">
 			<a href="<?php echo COM_MEDIA_BASEURL, '/', $img->path_relative; ?>" title="<?php echo $img->name; ?>" class="preview truncate">
 				<span class="icon-search" aria-hidden="true"></span><?php echo $img->name; ?>
 			</a>

--- a/installation/view/languages/tmpl/default.php
+++ b/installation/view/languages/tmpl/default.php
@@ -69,8 +69,8 @@ $version = new JVersion;
 		<table class="table table-striped table-condensed">
 			<thead>
 					<tr>
-						<th width="1%" class="center">
-							&nbsp;
+						<th width="1%" class="center">&nbsp;
+							
 						</th>
 						<th>
 							<?php echo JText::_('INSTL_LANGUAGES_COLUMN_HEADER_LANGUAGE'); ?>
@@ -100,13 +100,13 @@ $version = new JVersion;
 							<?php echo $language->code; ?>
 						</td>
 						<td class="center">
-						<?php $minorVersion = $version::MAJOR_VERSION . '.' . $version::MINOR_VERSION; ?>
-						<?php // Display a Note if language pack version is not equal to Joomla version ?>
-						<?php if (strpos($language->version, $minorVersion) !== 0 || strpos($language->version, $currentShortVersion) !== 0) : ?>
-							<span class="label label-warning hasTooltip" title="<?php echo JText::_('JGLOBAL_LANGUAGE_VERSION_NOT_PLATFORM'); ?>"><?php echo $language->version; ?></span>
-						<?php else : ?>
-							<span class="label label-success"><?php echo $language->version; ?></span>
-						<?php endif; ?>
+							<?php $minorVersion = $version::MAJOR_VERSION . '.' . $version::MINOR_VERSION; ?>
+							<?php // Display a Note if language pack version is not equal to Joomla version ?>
+							<?php if (strpos($language->version, $minorVersion) !== 0 || strpos($language->version, $currentShortVersion) !== 0) : ?>
+								<span class="label label-warning hasTooltip" title="<?php echo JText::_('JGLOBAL_LANGUAGE_VERSION_NOT_PLATFORM'); ?>"><?php echo $language->version; ?></span>
+							<?php else : ?>
+								<span class="label label-success"><?php echo $language->version; ?></span>
+							<?php endif; ?>
 						</td>
 					</tr>
 				<?php endforeach; ?>

--- a/installation/view/languages/tmpl/default.php
+++ b/installation/view/languages/tmpl/default.php
@@ -98,7 +98,7 @@ $version = new JVersion;
 						</td>
 						<td>
 							<?php echo $language->code; ?>
-  						</td>
+						  </td>
 						<td class="center">
 						<?php $minorVersion = $version::MAJOR_VERSION . '.' . $version::MINOR_VERSION; ?>
 						<?php // Display a Note if language pack version is not equal to Joomla version ?>

--- a/installation/view/languages/tmpl/default.php
+++ b/installation/view/languages/tmpl/default.php
@@ -69,8 +69,8 @@ $version = new JVersion;
 		<table class="table table-striped table-condensed">
 			<thead>
 					<tr>
-						<th width="1%" class="center">
-							&nbsp;
+						<th width="1%" class="center">&nbsp;
+							
 						</th>
 						<th>
 							<?php echo JText::_('INSTL_LANGUAGES_COLUMN_HEADER_LANGUAGE'); ?>
@@ -98,7 +98,7 @@ $version = new JVersion;
 						</td>
 						<td>
 							<?php echo $language->code; ?>
-						  </td>
+						</td>
 						<td class="center">
 						<?php $minorVersion = $version::MAJOR_VERSION . '.' . $version::MINOR_VERSION; ?>
 						<?php // Display a Note if language pack version is not equal to Joomla version ?>

--- a/installation/view/languages/tmpl/default.php
+++ b/installation/view/languages/tmpl/default.php
@@ -69,8 +69,8 @@ $version = new JVersion;
 		<table class="table table-striped table-condensed">
 			<thead>
 					<tr>
-						<th width="1%" class="center">&nbsp;
-							
+						<th width="1%" class="center">
+							&nbsp;
 						</th>
 						<th>
 							<?php echo JText::_('INSTL_LANGUAGES_COLUMN_HEADER_LANGUAGE'); ?>

--- a/installation/view/summary/tmpl/default.php
+++ b/installation/view/summary/tmpl/default.php
@@ -370,9 +370,9 @@ $prev = $useftp ? 'ftp' : 'database';
 
 <script type="text/javascript">
 	jQuery('input[name="jform[summary_email]"]').each(function(index, el) {
-        jQuery(el).on('click', function() {
-            Install.toggle('email_passwords', 'summary_email', 1);
-        });
-        Install.toggle('email_passwords', 'summary_email', 1);
-    });
+		jQuery(el).on('click', function() {
+			Install.toggle('email_passwords', 'summary_email', 1);
+		});
+		Install.toggle('email_passwords', 'summary_email', 1);
+	});
 </script>


### PR DESCRIPTION
Pull Request for Issue Tabs must be used to indent lines; spaces are not allowed.

### Summary of Changes
- Tabs must be used to indent lines; spaces are not allowed

Working through Automatic fixers to remove cases where we have had rule exceptions

[Automatically fixed with Joomla code standards 2.0.0 PHPCS2-alpha2 fixers](https://github.com/joomla/coding-standards/releases/tag/2.0.0-alpha2)

None of the manual only fixes have been applied

### Testing Instructions
Merge by code review

### Expected result
code style has been applied as listed above, old code style testing on drone does not error.

### Actual result
code style had not been applied. [Autofixers from the Joomla code standards 2.0.0 PHPCS2 alpha2](https://github.com/joomla/coding-standards/releases/tag/2.0.0-alpha2) were used to implement fixable code style

### Documentation Changes Required
none