### PR TITLE
Add support for non prefixed language files

### DIFF
--- a/administrator/components/com_languages/controllers/installed.php
+++ b/administrator/components/com_languages/controllers/installed.php
@@ -67,8 +67,14 @@ class LanguagesControllerInstalled extends JControllerLegacy
 		$cid   = $this->input->get('cid', '');
 		$model = $this->getModel('installed');
 
-		// Fetching the language name from the xx-XX.xml
+		// Fetching the language name from the xx-XX.xml or langmetadata.xml respectively.
 		$file = JPATH_ADMINISTRATOR . '/language/' . $cid . '/' . $cid . '.xml';
+
+		if (!is_file($file))
+		{
+			$file = JPATH_ADMINISTRATOR . '/language/' . $cid . '/langmetadata.xml';
+		}
+
 		$info = JInstaller::parseXMLInstallFile($file);
 		$languageName = $info['name'];
 

--- a/installation/model/languages.php
+++ b/installation/model/languages.php
@@ -313,7 +313,13 @@ class InstallationModelLanguages extends JModelBase
 
 		foreach ($langlist as $lang)
 		{
-			$file          = $path . '/' . $lang . '/' . $lang . '.xml';
+			$file = $path . '/' . $lang . '/' . $lang . '.xml';
+
+			if (!is_file($file))
+			{
+				$file = $path . '/' . $lang . '/langmetadata.xml';
+			}
+
 			$info          = JInstaller::parseXMLInstallFile($file);
 			$row           = new stdClass;
 			$row->language = $lang;

--- a/libraries/src/Installer/Adapter/LanguageAdapter.php
+++ b/libraries/src/Installer/Adapter/LanguageAdapter.php
@@ -313,8 +313,15 @@ class LanguageAdapter extends InstallerAdapter
 		// Create an unpublished content language.
 		if ((int) $clientId === 0)
 		{
+			$manifestfile = JPATH_SITE . '/language/' . $this->tag . '/' . $this->tag . '.xml';
+
+			if (!is_file($manifestfile))
+			{
+				$manifestfile = JPATH_SITE . '/language/' . $this->tag . '/langmetadata.xml';
+			}
+
 			// Load the site language manifest.
-			$siteLanguageManifest = LanguageHelper::parseXMLLanguageFile(JPATH_SITE . '/language/' . $this->tag . '/' . $this->tag . '.xml');
+			$siteLanguageManifest = LanguageHelper::parseXMLLanguageFile($manifestfile);
 
 			// Set the content language title as the language metadata name.
 			$contentLanguageTitle = $siteLanguageManifest['name'];
@@ -331,7 +338,14 @@ class LanguageAdapter extends InstallerAdapter
 			// Try to load a language string from the installation language var. Will be removed in 4.0.
 			if ($contentLanguageNativeTitle === $contentLanguageTitle)
 			{
-				if (file_exists(JPATH_INSTALLATION . '/language/' . $this->tag . '/' . $this->tag . '.xml'))
+				$manifestfile = JPATH_INSTALLATION . '/language/' . $this->tag . '/' . $this->tag . '.xml';
+
+				if (!is_file($manifestfile))
+				{
+					$manifestfile = JPATH_INSTALLATION . '/language/' . $this->tag . '/langmetadata.xml';
+				}
+
+				if (file_exists($manifestfile))
 				{
 					$installationLanguage = new Language($this->tag);
 					$installationLanguage->load('', JPATH_INSTALLATION);
@@ -831,6 +845,12 @@ class LanguageAdapter extends InstallerAdapter
 	{
 		$client = ApplicationHelper::getClientInfo($this->parent->extension->client_id);
 		$manifestPath = $client->path . '/language/' . $this->parent->extension->element . '/' . $this->parent->extension->element . '.xml';
+
+		if (!is_file($manifestPath))
+		{
+			$manifestPath = $client->path . '/language/' . $this->parent->extension->element . '/langmetadata.xml';
+		}
+
 		$this->parent->manifest = $this->parent->isManifest($manifestPath);
 		$this->parent->setPath('manifest', $manifestPath);
 		$manifest_details = Installer::parseXMLInstallFile($this->parent->getPath('manifest'));

--- a/libraries/src/Language/Language.php
+++ b/libraries/src/Language/Language.php
@@ -203,7 +203,7 @@ class Language
 			// Note: Manual indexing to enforce load order.
 			$paths[0] = JPATH_SITE . "/language/overrides/$lang.localise.php";
 			$paths[2] = JPATH_SITE . "/language/$lang/$lang.localise.php";
-			$paths[2] = JPATH_SITE . "/language/$lang/localise.php";
+			$paths[4] = JPATH_SITE . "/language/$lang/localise.php";
 		}
 
 		if (defined('JPATH_ADMINISTRATOR'))
@@ -211,7 +211,7 @@ class Language
 			// Note: Manual indexing to enforce load order.
 			$paths[1] = JPATH_ADMINISTRATOR . "/language/overrides/$lang.localise.php";
 			$paths[3] = JPATH_ADMINISTRATOR . "/language/$lang/$lang.localise.php";
-			$paths[3] = JPATH_ADMINISTRATOR . "/language/$lang/localise.php";
+			$paths[5] = JPATH_ADMINISTRATOR . "/language/$lang/localise.php";
 		}
 
 		ksort($paths);

--- a/libraries/src/Language/Language.php
+++ b/libraries/src/Language/Language.php
@@ -721,6 +721,7 @@ class Language
 		if ($internal)
 		{
 			$filenames[] = "$path/$lang.ini";
+			$filenames[] = "$path/joomla.ini";
 		}
 		else
 		{

--- a/libraries/src/Language/Language.php
+++ b/libraries/src/Language/Language.php
@@ -716,7 +716,7 @@ class Language
 
 		$internal = $extension == 'joomla' || $extension == '';
 
-		$filenames   = array();
+		$filenames = array();
 
 		if ($internal)
 		{

--- a/libraries/src/Language/Language.php
+++ b/libraries/src/Language/Language.php
@@ -203,6 +203,7 @@ class Language
 			// Note: Manual indexing to enforce load order.
 			$paths[0] = JPATH_SITE . "/language/overrides/$lang.localise.php";
 			$paths[2] = JPATH_SITE . "/language/$lang/$lang.localise.php";
+			$paths[2] = JPATH_SITE . "/language/$lang/localise.php";
 		}
 
 		if (defined('JPATH_ADMINISTRATOR'))
@@ -210,6 +211,7 @@ class Language
 			// Note: Manual indexing to enforce load order.
 			$paths[1] = JPATH_ADMINISTRATOR . "/language/overrides/$lang.localise.php";
 			$paths[3] = JPATH_ADMINISTRATOR . "/language/$lang/$lang.localise.php";
+			$paths[3] = JPATH_ADMINISTRATOR . "/language/$lang/localise.php";
 		}
 
 		ksort($paths);
@@ -713,43 +715,40 @@ class Language
 		$path = LanguageHelper::getLanguagePath($basePath, $lang);
 
 		$internal = $extension == 'joomla' || $extension == '';
-		$filename = $internal ? $lang : $lang . '.' . $extension;
-		$filename = "$path/$filename.ini";
 
-		if (isset($this->paths[$extension][$filename]) && !$reload)
+		$filenames   = array();
+
+		if ($internal)
 		{
-			// This file has already been tested for loading.
-			$result = $this->paths[$extension][$filename];
+			$filenames[] = "$path/$lang.ini";
 		}
 		else
 		{
-			// Load the language file
-			$result = $this->loadLanguage($filename, $extension);
+			// Try first with a language-prefixed filename.
+			$filenames[] = "$path/$lang.$extension.ini";
+			$filenames[] = "$path/$extension.ini";
+		}
 
-			// Check whether there was a problem with loading the file
-			if ($result === false && $default)
+		foreach ($filenames as $filename)
+		{
+			if (isset($this->paths[$extension][$filename]) && !$reload)
 			{
-				// No strings, so either file doesn't exist or the file is invalid
-				$oldFilename = $filename;
+				// This file has already been tested for loading.
+				$result = $this->paths[$extension][$filename];
+			}
+			else
+			{
+				// Load the language file
+				$result = $this->loadLanguage($filename, $extension);
+			}
 
-				// Check the standard file name
-				if (!$this->debug)
-				{
-					$path = LanguageHelper::getLanguagePath($basePath, $this->default);
-
-					$filename = $internal ? $this->default : $this->default . '.' . $extension;
-					$filename = "$path/$filename.ini";
-
-					// If the one we tried is different than the new name, try again
-					if ($oldFilename != $filename)
-					{
-						$result = $this->loadLanguage($filename, $extension, false);
-					}
-				}
+			if ($result)
+			{
+				return true;
 			}
 		}
 
-		return $result;
+		return false;
 	}
 
 	/**

--- a/libraries/src/Language/LanguageHelper.php
+++ b/libraries/src/Language/LanguageHelper.php
@@ -552,6 +552,12 @@ class LanguageHelper
 	public static function getMetadata($lang)
 	{
 		$file   = self::getLanguagePath(JPATH_BASE, $lang) . '/' . $lang . '.xml';
+
+		if (!is_file($file))
+		{
+			$file   = self::getLanguagePath(JPATH_BASE, $lang) . '/langmetadata.xml';
+		}
+
 		$result = null;
 
 		if (is_file($file))

--- a/libraries/src/Language/LanguageHelper.php
+++ b/libraries/src/Language/LanguageHelper.php
@@ -235,7 +235,7 @@ class LanguageHelper
 
 				if (!is_file($metafile))
 				{
-					$metafile   = self::getLanguagePath($clientPath, $language->element) . '/langmetadata.xml';
+					$metafile = self::getLanguagePath($clientPath, $language->element) . '/langmetadata.xml';
 				}
 
 				// Process the language metadata.
@@ -551,7 +551,7 @@ class LanguageHelper
 	 */
 	public static function getMetadata($lang)
 	{
-		$file   = self::getLanguagePath(JPATH_BASE, $lang) . '/' . $lang . '.xml';
+		$file = self::getLanguagePath(JPATH_BASE, $lang) . '/' . $lang . '.xml';
 
 		if (!is_file($file))
 		{

--- a/libraries/src/Language/LanguageHelper.php
+++ b/libraries/src/Language/LanguageHelper.php
@@ -233,6 +233,11 @@ class LanguageHelper
 				$clientPath = (int) $language->client_id === 0 ? JPATH_SITE : JPATH_ADMINISTRATOR;
 				$metafile   = self::getLanguagePath($clientPath, $language->element) . '/' . $language->element . '.xml';
 
+				if (!is_file($metafile))
+				{
+					$metafile   = self::getLanguagePath($clientPath, $language->element) . '/langmetadata.xml';
+				}
+
 				// Process the language metadata.
 				if ($processMetaData)
 				{
@@ -612,6 +617,11 @@ class LanguageHelper
 			{
 				$dirPathParts = pathinfo($directory);
 				$file         = $directory . '/' . $dirPathParts['filename'] . '.xml';
+
+				if (!is_file($file))
+				{
+					$file = $directory . '/langmetadata.xml';
+				}
 
 				if (!is_file($file))
 				{

--- a/libraries/src/Language/LanguageHelper.php
+++ b/libraries/src/Language/LanguageHelper.php
@@ -555,7 +555,7 @@ class LanguageHelper
 
 		if (!is_file($file))
 		{
-			$file   = self::getLanguagePath(JPATH_BASE, $lang) . '/langmetadata.xml';
+			$file = self::getLanguagePath(JPATH_BASE, $lang) . '/langmetadata.xml';
 		}
 
 		$result = null;


### PR DESCRIPTION
When I tried to use the GitHub integration of Crowdin, I faced the issue that Crowdin can't rename part of the translated filename. Eg it can't rename the source file `en-GB.com_weblinks.ini` to `de-DE.com_weblinks.ini`. It can however change the foldername easily, eg `/language/en-GB/` can be changed to `/language/de-DE/`.

That made me question the need for the language prefix.
Since we already have the language specific in the folderstructure, there is no technical reason to add it also to the filename.

### Summary of Changes
This PR changes the JLanguage logic so it first tries to load the file with prefix and if that fails it tries again with a non-prefixed filename.
This works for all files except the `en-GB.ini` (`.ini` doesn't make much sense) one and the ones in the override folder (we need the prefix here to differentiate the files).

This PR also removes some fallback code that tries to load the file from the default (en-GB) language. However since a few years we already do the same thing before even trying to load the real file. So those fallback strings are already loaded and that code did just load the same strings again.

### Testing Instructions
* Try renaming eg the language files from com_banners from de-DE.com_banners.ini to just com_banners.ini and see if the translation still works.
* Try removing the files and see that you get the english fallback strings.
* Make sure all untouched files still work (eg com_content) as before
* Test overrides (eg using Language Override Manager)

### Expected result
With this PR, everything should work as before, even when renaming the files.


### Actual result
Without this PR you get the english fallback strings when you rename a file.

### Points for Discussion
* Do we want to rename the en-GB.ini file? For Crowdin it doesn't matter, it can rename that one since it can replace the full filename.
* Do we want to deprecate the prefixed language files? If so, we need to communicate that early as it would impact language packs as well as every extension out there.
Personally I would certainly keep it for 4.0 but it may be something to be removed for 5.0 but I don't think it's worth the trouble. The code to keep it both ways is quite simple.

### Documentation Changes Required
Documentation regarding translations need to be adjusted.