### PR TITLE
Use https URLs for openstreetmap.org.

### DIFF
--- a/libraries/joomla/openstreetmap/oauth.php
+++ b/libraries/joomla/openstreetmap/oauth.php
@@ -40,14 +40,14 @@ class JOpenstreetmapOauth extends JOAuth1Client
 	{
 		$this->options = isset($options) ? $options : new Registry;
 
-		$this->options->def('accessTokenURL', 'http://www.openstreetmap.org/oauth/access_token');
-		$this->options->def('authoriseURL', 'http://www.openstreetmap.org/oauth/authorize');
-		$this->options->def('requestTokenURL', 'http://www.openstreetmap.org/oauth/request_token');
+		$this->options->def('accessTokenURL', 'https://www.openstreetmap.org/oauth/access_token');
+		$this->options->def('authoriseURL', 'https://www.openstreetmap.org/oauth/authorize');
+		$this->options->def('requestTokenURL', 'https://www.openstreetmap.org/oauth/request_token');
 
 		/*
-		$this->options->def('accessTokenURL', 'http://api06.dev.openstreetmap.org/oauth/access_token');
-		$this->options->def('authoriseURL', 'http://api06.dev.openstreetmap.org/oauth/authorize');
-		$this->options->def('requestTokenURL', 'http://api06.dev.openstreetmap.org/oauth/request_token');
+		$this->options->def('accessTokenURL', 'https://api06.dev.openstreetmap.org/oauth/access_token');
+		$this->options->def('authoriseURL', 'https://api06.dev.openstreetmap.org/oauth/authorize');
+		$this->options->def('requestTokenURL', 'https://api06.dev.openstreetmap.org/oauth/request_token');
 		*/
 
 		// Call the JOauth1Client constructor to setup the object.

--- a/libraries/joomla/openstreetmap/openstreetmap.php
+++ b/libraries/joomla/openstreetmap/openstreetmap.php
@@ -99,9 +99,9 @@ class JOpenstreetmap
 		$this->client  = isset($client) ? $client : new JHttp($this->options);
 
 		// Setup the default API url if not already set.
-		$this->options->def('api.url', 'http://api.openstreetmap.org/api/0.6/');
+		$this->options->def('api.url', 'https://api.openstreetmap.org/api/0.6/');
 
-		// $this->options->def('api.url', 'http://api06.dev.openstreetmap.org/api/0.6/');
+		// $this->options->def('api.url', 'https://api06.dev.openstreetmap.org/api/0.6/');
 	}
 
 	/**

--- a/tests/unit/suites/libraries/joomla/openstreetmap/JOpenstreetmapChangesetsTest.php
+++ b/tests/unit/suites/libraries/joomla/openstreetmap/JOpenstreetmapChangesetsTest.php
@@ -150,7 +150,7 @@ XML;
 		$returnData->code = 200;
 		$returnData->body = $this->sampleXml;
 
-		// 		$path = 'http://api.openstreetmap.org/api/0.6/changeset/create';
+		// 		$path = 'https://api.openstreetmap.org/api/0.6/changeset/create';
 		$path = 'changeset/create';
 
 		$this->client->expects($this->once())


### PR DESCRIPTION
### Summary of Changes

OpenStreetMap is [moving to https by default](https://github.com/openstreetmap/operations/issues/190) and all oauth calls made to the http endpoint after that [will fail](https://github.com/openstreetmap/openstreetmap-website/pull/1341#issuecomment-258439266). This simple PR converts all openstreetmap.org http calls to https. 

While I was at it, I converted all the other openstreetmap.org URLs to use https.

No related Joomla issue, no additional tests, no documentation changes.