### PR TITLE
[4.0] Add a service provider for the PSR-3 LoggerInterface

### DIFF
--- a/installation/src/Service/Provider/Application.php
+++ b/installation/src/Service/Provider/Application.php
@@ -17,6 +17,7 @@ use Joomla\CMS\Installation\Application\InstallationApplication;
 use Joomla\CMS\Log\Log;
 use Joomla\DI\Container;
 use Joomla\DI\ServiceProviderInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * Application service provider
@@ -57,7 +58,7 @@ class Application implements ServiceProviderInterface
 				}
 
 				$app->setDispatcher($container->get('Joomla\Event\DispatcherInterface'));
-				$app->setLogger(Log::createDelegatedLogger());
+				$app->setLogger($container->get(LoggerInterface::class));
 				$app->setSession($container->get('Joomla\Session\SessionInterface'));
 
 				return $app;

--- a/libraries/src/Factory.php
+++ b/libraries/src/Factory.php
@@ -26,6 +26,7 @@ use Joomla\DI\Container;
 use Joomla\CMS\User\User;
 use Joomla\Registry\Registry;
 use PHPMailer\PHPMailer\Exception as phpmailerException;
+use Psr\Log\LoggerInterface;
 
 /**
  * Joomla Platform Factory class.
@@ -146,7 +147,7 @@ abstract class Factory
 			self::$application = CMSApplication::getInstance($id, $prefix, $container);
 
 			// Attach a delegated JLog object to the application
-			self::$application->setLogger(Log::createDelegatedLogger());
+			self::$application->setLogger($container->get(LoggerInterface::class));
 		}
 
 		return self::$application;
@@ -519,8 +520,9 @@ abstract class Factory
 			->registerServiceProvider(new \Joomla\CMS\Service\Provider\Authentication)
 			->registerServiceProvider(new \Joomla\CMS\Service\Provider\Database)
 			->registerServiceProvider(new \Joomla\CMS\Service\Provider\Dispatcher)
-			->registerServiceProvider(new \Joomla\CMS\Service\Provider\Form)
 			->registerServiceProvider(new \Joomla\CMS\Service\Provider\Document)
+			->registerServiceProvider(new \Joomla\CMS\Service\Provider\Form)
+			->registerServiceProvider(new \Joomla\CMS\Service\Provider\Logger)
 			->registerServiceProvider(new \Joomla\CMS\Service\Provider\Menu)
 			->registerServiceProvider(new \Joomla\CMS\Service\Provider\Session)
 			->registerServiceProvider(new \Joomla\CMS\Service\Provider\Toolbar);

--- a/libraries/src/Service/Provider/Application.php
+++ b/libraries/src/Service/Provider/Application.php
@@ -21,6 +21,7 @@ use Joomla\CMS\Session\Session;
 use Joomla\DI\Container;
 use Joomla\DI\ServiceProviderInterface;
 use Joomla\Session\Storage\RuntimeStorage;
+use Psr\Log\LoggerInterface;
 
 /**
  * Application service provider
@@ -54,7 +55,7 @@ class Application implements ServiceProviderInterface
 					}
 
 					$app->setDispatcher($container->get('Joomla\Event\DispatcherInterface'));
-					$app->setLogger(Log::createDelegatedLogger());
+					$app->setLogger($container->get(LoggerInterface::class));
 					$app->setSession($container->get('Joomla\Session\SessionInterface'));
 
 					return $app;
@@ -76,7 +77,7 @@ class Application implements ServiceProviderInterface
 					}
 
 					$app->setDispatcher($container->get('Joomla\Event\DispatcherInterface'));
-					$app->setLogger(Log::createDelegatedLogger());
+					$app->setLogger($container->get(LoggerInterface::class));
 					$app->setSession($container->get('Joomla\Session\SessionInterface'));
 
 					return $app;
@@ -98,7 +99,7 @@ class Application implements ServiceProviderInterface
 
 					$app->setContainer($container);
 					$app->setDispatcher($dispatcher);
-					$app->setLogger(Log::createDelegatedLogger());
+					$app->setLogger($container->get(LoggerInterface::class));
 					$app->setSession($session);
 
 					return $app;

--- a/libraries/src/Service/Provider/Logger.php
+++ b/libraries/src/Service/Provider/Logger.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * @package     Joomla.Libraries
+ * @subpackage  Service
+ *
+ * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\CMS\Service\Provider;
+
+defined('JPATH_PLATFORM') or die;
+
+use Joomla\CMS\Log\Log;
+use Joomla\DI\Container;
+use Joomla\DI\ServiceProviderInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Service provider for the application's PSR-3 logger dependency
+ *
+ * @since  4.0
+ */
+class Logger implements ServiceProviderInterface
+{
+	/**
+	 * Registers the service provider with a DI container.
+	 *
+	 * @param   Container  $container  The DI container.
+	 *
+	 * @return  void
+	 *
+	 * @since   4.0
+	 */
+	public function register(Container $container)
+	{
+		$container->alias('logger', LoggerInterface::class)
+			->share(
+				LoggerInterface::class,
+				function (Container $container)
+				{
+					return Log::createDelegatedLogger();
+				},
+				true
+			);
+	}
+}


### PR DESCRIPTION
### Summary of Changes

Adds a service provider to the DI container offering our delegating logger class as an implementation of the PSR-3 `LoggerInterface` and use it when building services.

### Testing Instructions

CMS still works as before, new logger service available via `Joomla\CMS\Factory::getContainer()->get('logger');` or `Joomla\CMS\Factory::getContainer()->get('Psr\Log\LoggerInterface');`

### Documentation Changes Required

If we're documenting core services somewhere, add this to the list.