### PR TITLE
Create apcu-7.2.ini

### DIFF
--- a/build/travis/phpenv/apcu-7.2.ini
+++ b/build/travis/phpenv/apcu-7.2.ini
@@ -1,0 +1,2 @@
+apc.enabled=true
+apc.enable_cli=true


### PR DESCRIPTION
Pull Request for Issue Travis PHP 7.2 errors due to missing file .

### Summary of Changes
- Create apcu-7.2.ini

### Testing Instructions
code review


### Expected result
Travis PHP 7.2 does not error for missing apcu-7.2.ini file

### Actual result
Travis PHP 7.2 does not error for missing apcu-7.2.ini file


### Documentation Changes Required
none
