### PR TITLE
Fix illegal string offset in array

### DIFF
--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -606,13 +606,14 @@ abstract class HTMLHelper
 	 */
 	public static function stylesheet($file, $options = array(), $attribs = array())
 	{
+		$options = array();
+
 		// B/C before 3.7.0
 		if (!is_array($attribs))
 		{
 			Log::add('The stylesheet method signature used has changed, use (file, options, attributes) instead.', Log::WARNING, 'deprecated');
 
 			$argList = func_get_args();
-			$options = array();
 
 			// Old parameters.
 			$attribs                  = isset($argList[1]) ? $argList[1] : array();


### PR DESCRIPTION
Array does not exist, because it is defined in the condition block. If you pass NULL as the second arg (legacy), you will get the error.