### PR TITLE
Fix illegal string offset

### DIFF
--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -679,7 +679,7 @@ abstract class HTMLHelper
 	public static function script($file, $options = array(), $attribs = array())
 	{
 		// B/C before 3.7.0
-		if (!is_array($options))
+		if (!is_array($attribs) || !is_array($options))
 		{
 			Log::add('The script method signature used has changed, use (file, options, attributes) instead.', Log::WARNING, 'deprecated');
 

--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -679,7 +679,7 @@ abstract class HTMLHelper
 	public static function script($file, $options = array(), $attribs = array())
 	{
 		// B/C before 3.7.0
-		if (!is_array($options) || !is_array($options))
+		if (!is_array($options))
 		{
 			Log::add('The script method signature used has changed, use (file, options, attributes) instead.', Log::WARNING, 'deprecated');
 

--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -607,7 +607,7 @@ abstract class HTMLHelper
 	public static function stylesheet($file, $options = array(), $attribs = array())
 	{
 		// B/C before 3.7.0
-		if (!is_array($attribs))
+		if (!is_array($attribs) || !is_array($options))
 		{
 			Log::add('The stylesheet method signature used has changed, use (file, options, attributes) instead.', Log::WARNING, 'deprecated');
 

--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -679,7 +679,7 @@ abstract class HTMLHelper
 	public static function script($file, $options = array(), $attribs = array())
 	{
 		// B/C before 3.7.0
-		if (!is_array($options))
+		if (!is_array($options) || !is_array($options))
 		{
 			Log::add('The script method signature used has changed, use (file, options, attributes) instead.', Log::WARNING, 'deprecated');
 


### PR DESCRIPTION
In legacy calls it is common to have the args as a string. So, if the first/second arg is not array, it should be proccessed as legacy.