### PR TITLE
[4.0] Make Debug respect groups hierarchy

### DIFF
--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -9,6 +9,7 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Access\Access;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\Database\DatabaseDriver;
 use Joomla\Database\Event\ConnectionEvent;
@@ -408,7 +409,7 @@ class PlgSystemDebug extends CMSPlugin
 
 		if (!empty($filterGroups))
 		{
-			$userGroups = JFactory::getUser()->get('groups');
+			$userGroups = Access::getGroupsByUser(JFactory::getUser()->get('id'));
 
 			if (!array_intersect($filterGroups, $userGroups))
 			{


### PR DESCRIPTION
If you e.g. select Public as a group to show debug, then it should be shown to all users.