### PR TITLE
[4.0] Fix Debug's Session output

### DIFF
--- a/media/plg_system_debug/css/debug.css
+++ b/media/plg_system_debug/css/debug.css
@@ -189,12 +189,8 @@ div#system-debug {
 	border: 0;
 	margin: 0;
 	padding: 0;
-	white-space: pre-wrap;       /* css-3 */
-	white-space: -moz-pre-wrap !important;  /* Mozilla, since 1999 */
-	white-space: -pre-wrap;      /* Opera 4-6 */
-	white-space: -o-pre-wrap;    /* Opera 7 */
-	white-space: -webkit-pre-wrap; /* Newer versions of Chrome/Safari*/
-	word-wrap: break-word;       /* Internet Explorer 5.5+ */
+	overflow-wrap: break-word;
+	white-space: pre-wrap;
 	word-break: break-word;
 }
 #dbg_container_session pre .blue

--- a/media/plg_system_debug/css/debug.css
+++ b/media/plg_system_debug/css/debug.css
@@ -189,6 +189,13 @@ div#system-debug {
 	border: 0;
 	margin: 0;
 	padding: 0;
+	white-space: pre-wrap;       /* css-3 */
+	white-space: -moz-pre-wrap !important;  /* Mozilla, since 1999 */
+	white-space: -pre-wrap;      /* Opera 4-6 */
+	white-space: -o-pre-wrap;    /* Opera 7 */
+	white-space: -webkit-pre-wrap; /* Newer versions of Chrome/Safari*/
+	word-wrap: break-word;       /* Internet Explorer 5.5+ */
+	word-break: break-word;
 }
 #dbg_container_session pre .blue
 {

--- a/media/system/css/debug.css
+++ b/media/system/css/debug.css
@@ -189,12 +189,8 @@ div#system-debug {
 	border: 0;
 	margin: 0;
 	padding: 0;
-	white-space: pre-wrap;       /* css-3 */
-	white-space: -moz-pre-wrap !important;  /* Mozilla, since 1999 */
-	white-space: -pre-wrap;      /* Opera 4-6 */
-	white-space: -o-pre-wrap;    /* Opera 7 */
-	white-space: -webkit-pre-wrap; /* Newer versions of Chrome/Safari*/
-	word-wrap: break-word;       /* Internet Explorer 5.5+ */
+	overflow-wrap: break-word;
+	white-space: pre-wrap;
 	word-break: break-word;
 }
 #dbg_container_session pre .blue

--- a/media/system/css/debug.css
+++ b/media/system/css/debug.css
@@ -189,6 +189,13 @@ div#system-debug {
 	border: 0;
 	margin: 0;
 	padding: 0;
+	white-space: pre-wrap;       /* css-3 */
+	white-space: -moz-pre-wrap !important;  /* Mozilla, since 1999 */
+	white-space: -pre-wrap;      /* Opera 4-6 */
+	white-space: -o-pre-wrap;    /* Opera 7 */
+	white-space: -webkit-pre-wrap; /* Newer versions of Chrome/Safari*/
+	word-wrap: break-word;       /* Internet Explorer 5.5+ */
+	word-break: break-word;
 }
 #dbg_container_session pre .blue
 {

--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -526,7 +526,7 @@ class PlgSystemDebug extends CMSPlugin
 
 		if (!is_array($session))
 		{
-			$html[] = $key . '<pre>' . $this->prettyPrintJSON($session) . '</pre>' . PHP_EOL;
+			$html[] = '<pre>' . $key . ': ' . $this->prettyPrintJSON($session) . '</pre>' . PHP_EOL;
 		}
 		else
 		{
@@ -563,22 +563,14 @@ class PlgSystemDebug extends CMSPlugin
 					$id++;
 
 					// Recurse...
-					$this->displaySession($sKey, $entries, $id);
+					$html[] = $this->displaySession($sKey, $entries, $id);
 
 					$html[] = '</div>';
 
 					continue;
 				}
 
-				if (is_array($entries))
-				{
-					$entries = implode($entries);
-				}
-
-				if (is_string($entries))
-				{
-					$html[] = $sKey . '<pre>' . $this->prettyPrintJSON($entries) . '</pre>' . PHP_EOL;
-				}
+				$html[] = '<pre>' . $sKey . ': ' . $this->prettyPrintJSON($entries) . '</pre>' . PHP_EOL;
 			}
 		}
 


### PR DESCRIPTION
### Summary of Changes

Fix non-output of session variables in debug output.

### Testing Instructions

Before application of this PR, open up the Session section of debug output and there will be no information except the main subheadings.

Apply this PR and session values will be shown.

### Documentation Changes Required

None.