### PR TITLE
[4.0] Fix wrong ConfigModel class

### DIFF
--- a/administrator/components/com_messages/Model/MessageModel.php
+++ b/administrator/components/com_messages/Model/MessageModel.php
@@ -311,7 +311,7 @@ class MessageModel extends AdminModel
 		}
 
 		// Load the recipient user configuration.
-		$model  = new Config(array('ignore_request' => true));
+		$model  = new ConfigModel(array('ignore_request' => true));
 		$model->setState('user.id', $table->user_id_to);
 		$config = $model->getItem();
 


### PR DESCRIPTION
### Summary of Changes
This PR fixs the broken model class



### Testing Instructions
Submit an article over the frontend while you're a non-Super User and have the message plugin active


### Expected result
Article saved, email sent

### Actual result
Exception, because the model class is wrong.
