### PR TITLE
[Protostar] Fix top nav dropdown disappearing in FF

### DIFF
--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -7403,6 +7403,14 @@ figcaption {
 .navigation .nav li li > a:focus + .nav-child {
 	display: block;
 }
+.navigation .nav > li:before {
+	position: absolute;
+	top: 100%;
+	right: 0;
+	left: 0;
+	height: 6px;
+	content: '';
+}
 .navigation .nav > li > .nav-child:before {
 	position: absolute;
 	top: -7px;

--- a/templates/protostar/less/template.less
+++ b/templates/protostar/less/template.less
@@ -355,6 +355,16 @@ figcaption {
 	.nav li li > a:focus + .nav-child {
 		display: block;
 	}
+	.nav > li {
+		&:before {
+		  position: absolute;
+		  top: 100%;
+		  right: 0;
+		  left: 0;
+		  height: 6px;
+		  content: '';
+		}
+	}
 	.nav > li > .nav-child {
 		&:before {
 		  position: absolute;


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Issue unique to Firefox. Unable to access nav dropdown in Protostar except via the pseudo element (arrow).

### Testing Instructions
Firstly test that problem exists as there is no open issue. Test in Firefox..

### Before
![nav1](https://user-images.githubusercontent.com/2803503/34957834-25da7868-fa27-11e7-9bd8-72dbeb308a1c.gif)

### After
![nav2](https://user-images.githubusercontent.com/2803503/34957852-37121078-fa27-11e7-8f62-92f564abce32.gif)

