### PR TITLE
Fix count() in PHP 7.2

### DIFF
--- a/components/com_content/models/category.php
+++ b/components/com_content/models/category.php
@@ -454,7 +454,7 @@ class ContentModelCategory extends JModelList
 		}
 
 		// Order subcategories
-		if (count($this->_children))
+		if (is_array($this->_children) && count($this->_children) > 1)
 		{
 			$params = $this->getState()->get('params');
 

--- a/components/com_content/models/category.php
+++ b/components/com_content/models/category.php
@@ -454,7 +454,7 @@ class ContentModelCategory extends JModelList
 		}
 
 		// Order subcategories
-		if (is_array($this->_children) && count($this->_children) > 1)
+		if ($this->_children)
 		{
 			$params = $this->getState()->get('params');
 


### PR DESCRIPTION
This Pull Request improves PR #14982.

### Summary of Changes
Check for array to prevent count() warning.

The warning is due to `count(false)`.

### Testing Instructions
Install demo.
In the browser's address bar, enter `http://localhost/joomla-cms-staging/archived-articles/2011/1/archives`. (replace `http://localhost/joomla-cms-staging/` with your domain)
A 404 page is displayed.
Check PHP error log.


### Expected result
no warnings


### Actual result
`PHP Warning:  count(): Parameter must be an array or an object that implements Countable in \components\com_content\models\category.php on line 457`

### Documentation Changes Required
none
