### PR TITLE
[3.9] Create a form validation rule to check if a value exists in the database

### DIFF
--- a/libraries/src/Form/Rule/ExistsRule.php
+++ b/libraries/src/Form/Rule/ExistsRule.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Form\Rule;
+
+defined('JPATH_PLATFORM') or die;
+
+use Joomla\CMS\Factory;
+use Joomla\CMS\Form\Form;
+use Joomla\CMS\Form\FormRule;
+use Joomla\Registry\Registry;
+
+/**
+ * Form rule class to determine if a value exists in a database table.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class ExistsRule extends FormRule
+{
+	/**
+	 * Method to test the username for uniqueness.
+	 *
+	 * @param   \SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
+	 * @param   mixed              $value    The form field value to validate.
+	 * @param   string             $group    The field name group control value. This acts as an array container for the field.
+	 *                                       For example if the field has name="foo" and the group value is set to "bar" then the
+	 *                                       full field name would end up being "bar[foo]".
+	 * @param   Registry           $input    An optional Registry object with the entire data set to validate against the entire form.
+	 * @param   Form               $form     The form object for which the field is being tested.
+	 *
+	 * @return  boolean  True if the value is valid, false otherwise.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function test(\SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
+	{
+		$value = trim($value);
+
+		$existsTable  = (string) $element['exists_table'];
+		$existsColumn = (string) $element['exists_column'];
+
+		// We cannot validate without a table name
+		if ($existsTable === '')
+		{
+			return true;
+		}
+
+		// Assume a default column name of `id`
+		if ($existsColumn === '')
+		{
+			$existsColumn = 'id';
+		}
+
+		$db = Factory::getDbo();
+
+		// Set and query the database.
+		$exists = $db->setQuery(
+			$db->getQuery(true)
+				->select('COUNT(*)')
+				->from($db->quoteName($existsTable))
+				->where($db->quoteName($existsColumn) . ' = ' . $db->quote($value))
+		)->loadResult();
+
+		return (int) $exists > 0;
+	}
+}


### PR DESCRIPTION
### Summary of Changes

It is a common scenario that you create form fields which reference data from a database table, however the form validation API doesn't easily offer a way to ensure the given value actually exists.  This PR creates a new validation rule for this purpose.

On a form field referencing data from another table, you can now use `validate="exists"` as a validation rule to trigger this behavior.  There are two XML attributes used by this validation rule:

- `exists_table` specifies the database table to check for the value in, i.e. `#__content`
- `exists_column` specifies the column in that table to check for the value in, usually this should be a primary key and the rule has a behavior defaulting to the `id` column if one isn't specified

### Testing Instructions

As an example with com_content, edit `administrator/components/com_content/models/forms/article.xml` and change the `created_by` field definition to the following:

```xml
<field 
	name="created_by" 
	type="user"
	label="COM_CONTENT_FIELD_CREATED_BY_LABEL" 
	description="COM_CONTENT_FIELD_CREATED_BY_DESC" 
	validate="exists"
	exists_table="#__users"
/>
```

Under normal operating conditions, everything should just keep working as you are only shown a list of users from the database in this field type.  But, by manipulating the DOM, you could change this value to anything you wanted really.  With the validation rule applied, if you've set this to a value that doesn't correspond to a user that exists in the database, then form validation should fail and the save operation should be blocked.

### Documentation Changes Required

Document the new form validator and its use.