### PR TITLE
[4.0] Error in HTML markup because of not escape double quotation mark in the value of the attribut data-url

### DIFF
--- a/administrator/components/com_content/Field/Modal/ArticleField.php
+++ b/administrator/components/com_content/Field/Modal/ArticleField.php
@@ -93,7 +93,7 @@ class ArticleField extends FormField
 		}
 
 		$urlSelect = $linkArticles . '&amp;function=jSelectArticle_' . $this->id;
-		$urlEdit   = $linkArticle . '&amp;task=article.edit&amp;id=\' + document.getElementById("' . $this->id . '_id").value + \'';
+		$urlEdit   = $linkArticle . '&amp;task=article.edit&amp;id=\' + document.getElementById(&quot;' . $this->id . '_id&quot;).value + \'';
 		$urlNew    = $linkArticle . '&amp;task=article.add';
 
 		if ($value)


### PR DESCRIPTION

![menus edit item test administration](https://user-images.githubusercontent.com/9974686/35064703-339f1dbe-fbcb-11e7-8daf-692248d8693b.png)
Pull Request 

### Summary of Changes

We have error in our HTML markup in the backend, because we use double quotation mark, that is not escaped. You can find this, if you create an menu item of the type single article. 

If search for the ID ModalEditArticle_jform_request_id this looks like 

```
<div 
id="ModalEditArticle_jform_request_id" 
role="dialog" tabindex="-1" 
class="joomla-modal modal fade"
data-backdrop="static" 
data-keyboard="false" 

data-url="index.php?option=com_content&amp;view=article&amp;layout=modal&amp;tmpl=component&amp;d999480f48f1b6c1cb2ca1893c0c4d89=1&amp;task=article.edit&amp;id=' + document.getElementById("jform_request_id_id").value + '" 

data-iframe="&lt;iframe class=&quot;iframe&quot; src=&quot;index.php?option=com_content&amp;amp;view=article&amp;amp;layout=modal&amp;amp;tmpl=component&amp;amp;d999480f48f1b6c1cb2ca1893c0c4d89=1&amp;amp;task=article.edit&amp;amp;id=' + document.getElementById(&quot;jform_request_id_id&quot;).value + '&quot; name=&quot;Edit Article&quot; height=&quot;400px&quot; width=&quot;800px&quot;&gt;&lt;/iframe&gt;">
. . .
```
The attribute **data-url** is not valid because of the double quotation marks near _jform_request_id_id_

This PR escapes this characters.




### Testing Instructions
Code review



### Documentation Changes Required
No
