### PR TITLE
[bug] Featured article menu item does not respect Show Unauthorised Links menu item parameter

### DIFF
--- a/components/com_content/models/featured.php
+++ b/components/com_content/models/featured.php
@@ -51,7 +51,7 @@ class ContentModelFeatured extends ContentModelArticles
 		$limitstart = $input->getUInt('limitstart', 0);
 		$this->setState('list.start', $limitstart);
 
-		$params = $params = $this->state->params;
+		$params = $this->state->params;
 		$menuParams = new Registry;
 
 		if ($menu = $app->getMenu()->getActive())

--- a/components/com_content/models/featured.php
+++ b/components/com_content/models/featured.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Registry\Registry;
+
 JLoader::register('ContentModelArticles', __DIR__ . '/articles.php');
 
 /**
@@ -43,12 +45,25 @@ class ContentModelFeatured extends ContentModelArticles
 
 		$input = JFactory::getApplication()->input;
 		$user  = JFactory::getUser();
+		$app   = JFactory::getApplication('site');
 
 		// List state information
 		$limitstart = $input->getUInt('limitstart', 0);
 		$this->setState('list.start', $limitstart);
 
-		$params = $this->state->params;
+		$params = $params = $this->state->params;
+		$menuParams = new Registry;
+
+		if ($menu = $app->getMenu()->getActive())
+		{
+			$menuParams->loadString($menu->params);
+		}
+
+		$mergedParams = clone $menuParams;
+		$mergedParams->merge($params);
+
+		$this->setState('params', $mergedParams);
+
 		$limit = $params->get('num_leading_articles') + $params->get('num_intro_articles') + $params->get('num_links');
 		$this->setState('list.limit', $limit);
 		$this->setState('list.links', $params->get('num_links'));
@@ -63,6 +78,16 @@ class ContentModelFeatured extends ContentModelArticles
 		else
 		{
 			$this->setState('filter.published', array(0, 1, 2));
+		}
+
+		// Process show_noauth parameter
+		if (!$params->get('show_noauth'))
+		{
+			$this->setState('filter.access', true);
+		}
+		else
+		{
+			$this->setState('filter.access', false);
 		}
 
 		// Check for category selection


### PR DESCRIPTION
### Summary of Changes
Checking for the Show Unauthorised Links in the featured model

### Testing Instructions
Make sure that `Show Unauthorised Links` is set to No in the articles global Options
Create 2 articles set to featured in a category.
Make sure one of the article is set to Registered and has a Read More.
Make sure the article set to Registered `Show Unauthorised Links` option is set to No.
Create a Featured Menu item and make sure in the Options tab that `Show Unauthorised Links` is set to Yes.

### Expected result
The registered article displays with a register to read more when the menu item is used.

### Actual result
The registered article does not display with a register to read more when the menu item is used.

Note: the code used is similar to the one used in the category model