### PR TITLE
Regression in createUri

### DIFF
--- a/components/com_content/views/archive/tmpl/default.php
+++ b/components/com_content/views/archive/tmpl/default.php
@@ -21,7 +21,7 @@ JHtml::_('behavior.caption');
 </h1>
 </div>
 <?php endif; ?>
-<form id="adminForm" action="<?php echo JRoute::_('index.php'); ?>" method="post" class="form-inline">
+<form id="adminForm" action="<?php echo JRoute::_('index.php?option=com_content&view=archive'); ?>" method="post" class="form-inline">
 	<fieldset class="filters">
 	<div class="filter-search">
 		<?php if ($this->params->get('filter_field') !== 'hide') : ?>
@@ -34,8 +34,6 @@ JHtml::_('behavior.caption');
 		<?php echo $this->form->limitField; ?>
 
 		<button type="submit" class="btn btn-primary" style="vertical-align: top;"><?php echo JText::_('JGLOBAL_FILTER_BUTTON'); ?></button>
-		<input type="hidden" name="view" value="archive" />
-		<input type="hidden" name="option" value="com_content" />
 		<input type="hidden" name="limitstart" value="0" />
 	</div>
 	<br />

--- a/libraries/src/Router/SiteRouter.php
+++ b/libraries/src/Router/SiteRouter.php
@@ -716,6 +716,13 @@ class SiteRouter extends Router
 				{
 					$uri->setVar('option', $option);
 				}
+
+				$itemid = $this->getVar('Itemid');
+
+				if ($itemid)
+				{
+					$uri->setVar('Itemid', $itemid);
+				}
 			}
 		}
 		else

--- a/tests/unit/suites/libraries/cms/router/JRouterSiteTest.php
+++ b/tests/unit/suites/libraries/cms/router/JRouterSiteTest.php
@@ -1265,6 +1265,18 @@ class JRouterSiteTest extends TestCaseDatabase
 				'preset'   => array('option' => 'com_test'),
 				'expected' => 'index.php?var1=value1&option=com_test'
 			),
+			// Check if a URL with no Itemid and no option, but globally set Itemid is added the Itemid
+			array(
+				'url'      => 'index.php?var1=value1',
+				'preset'   => array('Itemid' => '42'),
+				'expected' => 'index.php?var1=value1&Itemid=42'
+			),
+			// Check if a URL with no Itemid and no option, but with an option and a global Itemid available, which fits the option of the menu item gets the Itemid and option appended
+			array(
+				'url'      => 'index.php?var1=value1',
+				'preset'   => array('Itemid' => '42', 'option' => 'com_test'),
+				'expected' => 'index.php?var1=value1&option=com_test&Itemid=42'
+			),
 		);
 	}
 


### PR DESCRIPTION
Pull Request for Issue #19409

### Summary of Changes
1. This is a regression for #19099 at file `libraries/src/Router/SiteRouter.php`. 
   If a new URL does not have an `option`, nor `Itemid` then use global  `Itemid`. 
   Affects the relative URL, such as:
  `JRoute::_('&page=2');`
   `JRoute::_('index.php');`

2. Restore one unit test from 3.8.3 and add a new one.

3. Fix the form action link. This helps when we go to the archive view without any menu item like `index.php/component/content/archive`.


### Testing Instructions
**I updated the test instruction to facilitate testing.**

1. Install staging joomla with sample data "Test English (GB) Sample Data"
2. Archive 5 articles. In total should be more than 5.
3. Go to the archive view `index.php/archived-articles`
4. Change `Limit` field from `All` to 5.
5. Click on the second page, before PR you get error 404.
6. Apply patch and refresh `index.php/archived-articles`
7. As you have limit 5 you can go to the next page.
8. Second page works.
9. Change default template to `beez3` (`administrator/index.php?option=com_templates&view=styles`) and check second page again. It still works.
10. Unpublish menu item `Archived Articles` and go to `index.php/component/content/archive`, set limit to 5.
11. Go to second page, it still works.

### Expected result
Pagination works.

### Actual result
Pagination does not work,

### Documentation Changes Required
No