### PR TITLE
[4.0] Cassiopeia - Use option for fluid or static layout

### DIFF
--- a/templates/cassiopeia/index.php
+++ b/templates/cassiopeia/index.php
@@ -84,6 +84,7 @@ $this->setMetaData('viewport', 'width=device-width, initial-scale=1');
 </head>
 
 <body class="site-grid site <?php echo $option
+	. ' ' . $container
 	. ' view-' . $view
 	. ($layout ? ' layout-' . $layout : ' no-layout')
 	. ($task ? ' task-' . $task : ' no-task')
@@ -116,7 +117,7 @@ $this->setMetaData('viewport', 'width=device-width, initial-scale=1');
 						<?php endif; ?>
 					</div>
 				<?php endif; ?>
-				
+
 			</nav>
 			<?php if ($this->countModules('banner')) : ?>
 			<div class="grid-child container-banner">
@@ -132,7 +133,7 @@ $this->setMetaData('viewport', 'width=device-width, initial-scale=1');
 			</div>
 		</header>
 	</div>
-	
+
 	<?php if ($this->countModules('top-a')) : ?>
 	<div class="grid-child container-top-a">
 		<jdoc:include type="modules" name="top-a" style="cardGrey" />


### PR DESCRIPTION
### Summary of Changes
Up to now the option for fluid or static layout is not used. In this PR I add the variable container to the body tag, so that the boostrap 4 class is used.


### Testing Instructions
Apply the patch and check in admin the template cassiopeia. Set the option for fluid layout to static. 


### Expected result
The layout will be static


### Actual result
The is no change. The layout is fluid, no matter what you choose.


### Documentation Changes Required
No
