### PR TITLE
[4.0] Fix for: Copying a template is not possible

### DIFF
--- a/administrator/components/com_templates/Controller/TemplateController.php
+++ b/administrator/components/com_templates/Controller/TemplateController.php
@@ -10,10 +10,9 @@ namespace Joomla\Component\Templates\Administrator\Controller;
 
 defined('_JEXEC') or die;
 
-\JLoader::register('InstallerModelInstall', JPATH_ADMINISTRATOR . '/components/com_installer/models/install.php');
-
 use Joomla\CMS\MVC\Controller\BaseController;
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
+use Joomla\Component\Installer\Administrator\Model\InstallModel;
 
 /**
  * Template style controller class.
@@ -146,7 +145,7 @@ class TemplateController extends BaseController
 
 			// Call installation model
 			$this->input->set('install_directory', \JFactory::getConfig()->get('tmp_path') . '/' . $model->getState('tmp_prefix'));
-			$installModel = new \InstallerModelInstall;
+			$installModel = new InstallModel;
 			\JFactory::getLanguage()->load('com_installer');
 
 			if (!$installModel->install())


### PR DESCRIPTION
Pull Request for Issue # https://github.com/joomla/joomla-cms/issues/19419.

### Summary of Changes
Use namespace for loading InstallModel


### Testing Instructions

- Install  Joomla! 4

- Select  Extensions | Templates and select on the left Templates and click Cassiopeia Details and Files

- Click  the tool bar button Copy Template and choose a name and click on Copy Template


### Expected result

The template files are copied

### Actual result

You see an error. See https://github.com/joomla/joomla-cms/issues/19419

### Apply this patch

Apply this patch and the template is copied correctly. Only the message is transparent. But this error ist fixed in this PR: https://github.com/joomla/joomla-cms/pull/19413

### Documentation Changes Required
No
