### PR TITLE
Regression: Isis RTL forgotten in 19417

### DIFF
--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -9733,6 +9733,10 @@ input[type="url"] {
 	background-color: rgba(0,0,0,0.5);
 	-webkit-box-shadow: 0 0 1px rgba(255,255,255,0.5);
 }
+.navbar .nav-user .dropdown-menu li span {
+	padding-left: 0;
+	padding-right: 10px;
+}
 .navbar .nav > .dropdown.open:after {
 	right: 10px;
 	width: 0;

--- a/administrator/templates/isis/less/template-rtl.less
+++ b/administrator/templates/isis/less/template-rtl.less
@@ -37,6 +37,10 @@
 			}
 		}
 	}
+	.nav-user .dropdown-menu li span {
+	padding-left: 0;
+	padding-right: 10px;
+	}
 	.nav > .dropdown.open:after {
 		right: 10px;
 		width: 0;


### PR DESCRIPTION
#19417 forgot to also correct RTL.

To test, set rtl in en-GB.xml to 1.
Before patch.

<img width="246" alt="screen shot 2018-01-21 at 16 20 40" src="https://user-images.githubusercontent.com/869724/35195673-6277ecfc-fec7-11e7-93ae-7a9c58a65c25.png">

After patch

<img width="197" alt="screen shot 2018-01-21 at 16 57 20" src="https://user-images.githubusercontent.com/869724/35195984-2c73c37e-fecc-11e7-8b9b-748c706ff815.png">
