### PR TITLE
[4.0] Session Save Path error

### DIFF
--- a/administrator/components/com_config/Model/ApplicationModel.php
+++ b/administrator/components/com_config/Model/ApplicationModel.php
@@ -14,6 +14,8 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Access\Access as JAccess;
 use Joomla\CMS\Access\Rules as JAccessRules;
 use Joomla\CMS\Component\ComponentHelper;
+use Joomla\CMS\Filesystem\Folder;
+use Joomla\CMS\Filesystem\Path;
 use Joomla\CMS\MVC\Model\FormModel;
 use Joomla\CMS\Table\Asset;
 use Joomla\CMS\Table\Table;
@@ -300,6 +302,43 @@ class ApplicationModel extends FormModel
 				 * through normal garbage collection anyway or if not using the database handler someone can purge the
 				 * table on their own.  Either way, carry on Soldier!
 				 */
+			}
+		}
+
+		// Ensure custom session file path exists or try to create it if changed
+		if (!empty($data['session_filesystem_path']))
+		{
+			$currentPath = $prev['session_filesystem_path'] ?? null;
+
+			if ($currentPath)
+			{
+				$currentPath = Path::clean($currentPath);
+			}
+
+			$data['session_filesystem_path'] = Path::clean($data['session_filesystem_path']);
+
+			if ($currentPath !== $data['session_filesystem_path'])
+			{
+				if (!Folder::exists($data['session_filesystem_path']) && !Folder::create($data['session_filesystem_path']))
+				{
+					try
+					{
+						\JLog::add(
+							\JText::sprintf('COM_CONFIG_ERROR_CUSTOM_SESSION_FILESYSTEM_PATH_NOTWRITABLE_USING_DEFAULT', $data['session_filesystem_path']),
+							\JLog::WARNING,
+							'jerror'
+						);
+					}
+					catch (\RuntimeException $logException)
+					{
+						$app->enqueueMessage(
+							\JText::sprintf('COM_CONFIG_ERROR_CUSTOM_SESSION_FILESYSTEM_PATH_NOTWRITABLE_USING_DEFAULT', $data['session_filesystem_path']),
+							'warning'
+						);
+					}
+
+					$data['session_filesystem_path'] = $currentPath;
+				}
 			}
 		}
 

--- a/administrator/language/en-GB/en-GB.com_config.ini
+++ b/administrator/language/en-GB/en-GB.com_config.ini
@@ -19,6 +19,7 @@ COM_CONFIG_ERROR_CONFIG_EXTENSION_NOT_FOUND="The Global Configuration extension 
 COM_CONFIG_ERROR_CONFIGURATION_PHP_NOTUNWRITABLE="Could not make configuration.php unwritable."
 COM_CONFIG_ERROR_CONFIGURATION_PHP_NOTWRITABLE="Could not make configuration.php writable."
 COM_CONFIG_ERROR_CUSTOM_CACHE_PATH_NOTWRITABLE_USING_DEFAULT="The folder at %1$s is not writable and cannot be used for the cache, using the default %2$s instead."
+COM_CONFIG_ERROR_CUSTOM_SESSION_FILESYSTEM_PATH_NOTWRITABLE_USING_DEFAULT="The folder at %s is not writable and cannot be used to store session data, the default PHP path will be used instead."
 COM_CONFIG_ERROR_HELPREFRESH_ERROR_STORE="The new Help Sites list could not be saved."
 COM_CONFIG_ERROR_HELPREFRESH_FETCH="The current Help Sites list could not be fetched from the remote server."
 COM_CONFIG_ERROR_ROOT_ASSET_NOT_FOUND="The asset for global configuration could not be found. Permissions have not been saved."


### PR DESCRIPTION
Pull Request for Issue #19304

### Summary of Changes

If a custom path for session data stored in the filesystem is given, validate the path exists and attempt to create it if it does not exist.  If the path cannot be created, don't use it as the session path which effectively brings the site down.  Additionally, the path is cleaned while saving which helps to ensure the stored filepath is appropriate for the system (i.e. on Windows the right separator will be used).

### Testing Instructions

- Apply patch
- Try changing the session filesystem path to a custom path that doesn't exist on your filesystem
- If the path can be created, the path stored to the configuration file should be a cleaned path for your OS
- If the path cannot be created, you should get an error and the configuration will have the previous value of this field