### PR TITLE
mod_articles_news. Define $item_heading only if needed

### DIFF
--- a/modules/mod_articles_news/tmpl/_item.php
+++ b/modules/mod_articles_news/tmpl/_item.php
@@ -20,7 +20,6 @@ defined('_JEXEC') or die;
 		<?php echo $item->title; ?>
 	<?php endif; ?>
 	</<?php echo $item_heading; ?>>
-
 <?php endif; ?>
 
 <?php if (!$params->get('intro_only')) : ?>

--- a/modules/mod_articles_news/tmpl/_item.php
+++ b/modules/mod_articles_news/tmpl/_item.php
@@ -8,11 +8,10 @@
  */
 
 defined('_JEXEC') or die;
-
-$item_heading = $params->get('item_heading', 'h4');
 ?>
-<?php if ($params->get('item_title')) : ?>
 
+<?php if ($params->get('item_title')) : ?>
+	<?php $item_heading = $params->get('item_heading', 'h4'); ?>
 	<<?php echo $item_heading; ?> class="newsflash-title<?php echo $params->get('moduleclass_sfx'); ?>">
 	<?php if ($item->link !== '' && $params->get('link_titles')) : ?>
 		<a href="<?php echo $item->link; ?>">

--- a/modules/mod_articles_news/tmpl/_item.php
+++ b/modules/mod_articles_news/tmpl/_item.php
@@ -9,7 +9,6 @@
 
 defined('_JEXEC') or die;
 ?>
-
 <?php if ($params->get('item_title')) : ?>
 	<?php $item_heading = $params->get('item_heading', 'h4'); ?>
 	<<?php echo $item_heading; ?> class="newsflash-title<?php echo $params->get('moduleclass_sfx'); ?>">


### PR DESCRIPTION
### Summary of Changes
- Very small and pedantic optimization.
- Move definition of variable `$item_heading` inside `if` condition for `item_title` because not needed elsewhere in code.

### Testing Instructions
Code review or

- Create a module of type "Articles - Newsflash". Position, Title.
- Set option "Show Article Title" to YES.
- Check front-end display. You'll see the article title above any article with markup like this
```<h4 class="newsflash-title">Popular Tags</h4>```

- Apply patch. Check that nothing has changed and no warnings...