### PR TITLE
Do not add unnecessary parameters in the archive link

### DIFF
--- a/components/com_content/helpers/legacyrouter.php
+++ b/components/com_content/helpers/legacyrouter.php
@@ -84,10 +84,6 @@ class ContentRouterRulesLegacy implements JComponentRouterRulesInterface
 		{
 			$view = $query['view'];
 		}
-		elseif ($menuItemGiven)
-		{
-			$view = $menuItem->query['view'];
-		}
 		else
 		{
 			// We need to have a view in the query or it is an invalid URL

--- a/components/com_content/helpers/legacyrouter.php
+++ b/components/com_content/helpers/legacyrouter.php
@@ -249,6 +249,11 @@ class ContentRouterRulesLegacy implements JComponentRouterRulesInterface
 
 				unset($query['year']);
 			}
+
+			if (isset($query['month']) && empty($query['month']))
+			{
+				unset($query['month']);
+			}
 		}
 
 		if ($view == 'featured')


### PR DESCRIPTION
Pull Request to improve #19397

### Summary of Changes
1. Remove redundant `view` from SEF link generated by `mod_articles_archive`.
- before PR `index.php/en/archived-articles/2013/10?view=archive`
- after PR `index.php/en/archived-articles/2013/10`

2. Delete redundant segments `/0/0` from second and next pages, when no year, nor month have been selected.
- before PR `index.php/en/archived-articles/0/0?view=archive&start=5`
- after PR `index.php/en/archived-articles?start=5`

3. Allow to use short link to display the archive view for selected year.
- before PR `index.php/en/archived-articles/2011/0?view=archive` - works
- before PR `index.php/en/archived-articles/2011` - error 404 or display article with id 2011
- after PR `index.php/en/archived-articles/2011` - works

### Testing Instructions
1. Install the latest staging joomla with sample data "Test English (GB) Sample Data"
2. Archive at least 5 articles. In total should be more than 5.
3. Go to the archive view `index.php/archived-articles`
4. Change Limit field from All to 5.
5. Check above examples from summary.

### Expected result
Joomla generate and parse nicer links, old links still works.


### Actual result
Joomla adds redundant parameters and segments to SEF link.


### Documentation Changes Required
No

@Quy, @alikon please take a look