### PR TITLE
Fix filter by multiple categories

### DIFF
--- a/administrator/components/com_content/models/articles.php
+++ b/administrator/components/com_content/models/articles.php
@@ -379,7 +379,7 @@ class ContentModelArticles extends JModelList
 		$orderDirn = $this->state->get('list.direction', 'DESC');
 
 		$query->order($db->escape($orderCol) . ' ' . $db->escape($orderDirn));
-		$tmp = (string) ($query);
+
 		return $query;
 	}
 

--- a/administrator/components/com_content/models/articles.php
+++ b/administrator/components/com_content/models/articles.php
@@ -292,7 +292,7 @@ class ContentModelArticles extends JModelList
 					'c.rgt <= ' . (int) $categoryTable->rgt . ')';
 			}
 
-			$query->where(implode(' OR ', $subCatItemsWhere));
+			$query->where('(' . implode(' OR ', $subCatItemsWhere) . ')');
 		}
 
 		// Case: Using only the by level filter
@@ -379,7 +379,7 @@ class ContentModelArticles extends JModelList
 		$orderDirn = $this->state->get('list.direction', 'DESC');
 
 		$query->order($db->escape($orderCol) . ' ' . $db->escape($orderDirn));
-
+		$tmp = (string) ($query);
 		return $query;
 	}
 


### PR DESCRIPTION
Pull Request for Issue #19448 .

### Summary of Changes
The WHERE clause wasn't properly put into `( ... )` and thus the first catid wiltered properly and each successive one was put as a separate "OR" clause.


### Testing Instructions
Test articles filters in backend when filtering by multiple categories.


### Expected result
Additionally set filters (eg state) also work


### Actual result
They are ignored


### Documentation Changes Required
None
