### PR TITLE
Replace the URL parameter "limitstart=0" with "start=0" if the SEF mode is on

### DIFF
--- a/libraries/src/Router/SiteRouter.php
+++ b/libraries/src/Router/SiteRouter.php
@@ -597,7 +597,9 @@ class SiteRouter extends Router
 			// Process the pagination support
 			if ($this->_mode == JROUTER_MODE_SEF)
 			{
-				if ($start = $uri->getVar('start'))
+				$start = $uri->getVar('start');
+
+				if ($start !== null)
 				{
 					$uri->delVar('start');
 					$vars['limitstart'] = $start;

--- a/libraries/src/Router/SiteRouter.php
+++ b/libraries/src/Router/SiteRouter.php
@@ -678,7 +678,9 @@ class SiteRouter extends Router
 
 			if ($this->_mode == JROUTER_MODE_SEF && $route)
 			{
-				if ($limitstart = $uri->getVar('limitstart'))
+				$limitstart = $uri->getVar('limitstart');
+
+				if ($limitstart !== null)
 				{
 					$uri->setVar('start', (int) $limitstart);
 					$uri->delVar('limitstart');

--- a/tests/unit/suites/libraries/cms/router/JRouterSiteTest.php
+++ b/tests/unit/suites/libraries/cms/router/JRouterSiteTest.php
@@ -1192,6 +1192,11 @@ class JRouterSiteTest extends TestCaseDatabase
 				'mode'     => JROUTER_MODE_SEF,
 				'expected' => 'test?start=42'
 			),
+			'limitstart_zero' => array(
+				'url'      => 'test?limitstart=0',
+				'mode'     => JROUTER_MODE_SEF,
+				'expected' => 'test?start=0'
+			),
 		);
 	}
 


### PR DESCRIPTION
### Summary of Changes
If SEF is on, then joomla replace almost every occurrence of parameter `limitstart` to `start` in pagination.
When parameter `limitstart` is empty or equal to `0` then it stay in URL.
This PR fix it. 

### Testing Instructions
1. Mode SEF is on. 
2. Mark a few articles as featured to get a few page of featured articles.
3. Go to featured view ex: `index.php/en/component/content/featured`
4. Go to the second page.
5. Check links for start/previous/first page:
   - before PR there is URL parameter `limitstart=0` or empty `limitstart=`
   - after PR the parameter has been replaced by `start=0`

### Expected result
No more `limitstart` parameter in URL when mode sef is on.

### Actual result
The parameter query `limitstart=0` stay in URL.

### Documentation Changes Required
No
