### PR TITLE
Multiple editors don't inherit $params correctly

### DIFF
--- a/libraries/src/Editor/Editor.php
+++ b/libraries/src/Editor/Editor.php
@@ -538,7 +538,7 @@ class Editor extends \JObject
 		require_once $path;
 
 		// Get the plugin
-		$plugin = \JPluginHelper::getPlugin('editors', $this->_name);
+		$plugin = clone \JPluginHelper::getPlugin('editors', $this->_name);
 
 		// If no plugin is published we get an empty array and there not so much to do with it
 		if (empty($plugin))


### PR DESCRIPTION
### Summary of Changes
Because `PluginHelper::$plugins` is defined as `static`, `getPlugin()` returns a reference to the original `$plugin` object. When `_loadEditor()` is invoked it will load the `params` into the `Registry` and overwrite the original `$plugin->params` with the `Registry` object. Subsequent calls to `_loadEditor()` will try to load the modified `$plugin->params` and will lead to unexpected results:

First call:
```
object(Joomla\Registry\Registry)#417 (3) {
  ["data":protected]=>
  object(stdClass)#422 (11) {
    ["lineNumbers"]=>
    string(1) "1"
    ["lineWrapping"]=>
    string(1) "1"
    ["matchTags"]=>
    string(1) "1"
    ["matchBrackets"]=>
    string(1) "1"
    ["marker-gutter"]=>
    string(1) "1"
    ["autoCloseTags"]=>
    string(1) "1"
    ["autoCloseBrackets"]=>
    string(1) "1"
    ["autoFocus"]=>
    string(1) "1"
    ["theme"]=>
    string(7) "default"
    ["tabmode"]=>
    string(6) "indent"
    ["syntax"]=>
    string(3) "php"
  }
  ["initialized":protected]=>
  bool(true)
  ["separator"]=>
  string(1) "."
}
```
Second call:
```
object(Joomla\Registry\Registry)#423 (3) {
  ["data":protected]=>
  object(stdClass)#425 (4) {
    ["data"]=>
    object(stdClass)#426 (11) {
      ["lineNumbers"]=>
      string(1) "1"
      ["lineWrapping"]=>
      string(1) "1"
      ["matchTags"]=>
      string(1) "1"
      ["matchBrackets"]=>
      string(1) "1"
      ["marker-gutter"]=>
      string(1) "1"
      ["autoCloseTags"]=>
      string(1) "1"
      ["autoCloseBrackets"]=>
      string(1) "1"
      ["autoFocus"]=>
      string(1) "1"
      ["theme"]=>
      string(7) "default"
      ["tabmode"]=>
      string(6) "indent"
      ["syntax"]=>
      string(3) "php"
    }
    ["initialized"]=>
    bool(true)
    ["separator"]=>
    string(1) "."
    ["syntax"]=>
    string(10) "javascript"
  }
  ["initialized":protected]=>
  bool(true)
  ["separator"]=>
  string(1) "."
}
```
As you can see, `data` is now inside another `data` object.

### Testing Instructions
Let's say you want to display two CodeMirror editors - one for PHP, the other one for Javascript. For the sake of it, I'll make the code simple:

```php
$instance = new JEditor('codemirror');
echo $instance->display('first_editor', '<?php echo "test"; ?>', '100%', 300, 75, 20, $buttons = false, $id = null, $asset = null, $author = null, array('syntax' => 'php'));

$instance2 = new JEditor('codemirror');
echo $instance2->display('second_editor', 'var test;', '100%', 300, 75, 20, $buttons = false, $id = null, $asset = null, $author = null, array('syntax' => 'javascript'));
```


### Expected result
Two editors with different syntax highlighting - no other differences.


### Actual result
Two editors but the second editor grabbing incorrect plugin parameters (no line numbers, no gutters etc).


### Documentation Changes Required
Hopefully none?
