### PR TITLE
Add primary key

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/3.8.12-2018-08-17.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.8.12-2018-08-17.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `#__finder_terms_common` ADD PRIMARY KEY (`term`,`language`);
+ALTER TABLE `#__utf8_conversion` ADD PRIMARY KEY (`converted`);

--- a/administrator/components/com_admin/sql/updates/postgresql/3.8.12-2018-08-17.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.8.12-2018-08-17.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "#__finder_terms_common" ADD PRIMARY KEY ("term","language");

--- a/administrator/components/com_admin/sql/updates/sqlazure/3.8.12-2018-08-17.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.8.12-2018-08-17.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "#__finder_terms_common" DROP CONSTRAINT "PK_#__finder_terms_common";
+ALTER TABLE "#__finder_terms_common" DROP CONSTRAINT "idx_word_lang";
+ALTER TABLE "#__finder_terms_common" ADD CONSTRAINT "PK_#__finder_terms_common" PRIMARY KEY ("term", "language");

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -1123,7 +1123,7 @@ CREATE TABLE IF NOT EXISTS `#__finder_terms` (
 CREATE TABLE IF NOT EXISTS `#__finder_terms_common` (
   `term` varchar(75) NOT NULL,
   `language` varchar(3) NOT NULL,
-  PRIMART KEY (`term`,`language`),
+  PRIMARY KEY (`term`,`language`),
   KEY `idx_lang` (`language`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_general_ci;
 

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -1123,7 +1123,7 @@ CREATE TABLE IF NOT EXISTS `#__finder_terms` (
 CREATE TABLE IF NOT EXISTS `#__finder_terms_common` (
   `term` varchar(75) NOT NULL,
   `language` varchar(3) NOT NULL,
-  KEY `idx_word_lang` (`term`,`language`),
+  PRIMART KEY (`term`,`language`),
   KEY `idx_lang` (`language`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_general_ci;
 
@@ -2084,7 +2084,8 @@ CREATE TABLE IF NOT EXISTS `#__user_usergroup_map` (
 --
 
 CREATE TABLE IF NOT EXISTS `#__utf8_conversion` (
-  `converted` tinyint(4) NOT NULL DEFAULT 0
+  `converted` tinyint(4) NOT NULL DEFAULT 0,
+  PRIMARY KEY (`converted`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
 
 --

--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -1088,9 +1088,9 @@ CREATE INDEX "#__finder_terms_idx_soundex_phrase" on "#__finder_terms" ("soundex
 
 CREATE TABLE "#__finder_terms_common" (
   "term" varchar(75) NOT NULL,
-  "language" varchar(3) DEFAULT '' NOT NULL
+  "language" varchar(3) DEFAULT '' NOT NULL,
+  PRIMARY KEY ("term", "language")
 );
-CREATE INDEX "#__finder_terms_common_idx_word_lang" on "#__finder_terms_common" ("term", "language");
 CREATE INDEX "#__finder_terms_common_idx_lang" on "#__finder_terms_common" ("language");
 
 --

--- a/installation/sql/sqlazure/joomla.sql
+++ b/installation/sql/sqlazure/joomla.sql
@@ -1669,18 +1669,13 @@ CREATE TABLE "#__finder_terms_common" (
   "language" nvarchar(3) NOT NULL,
  CONSTRAINT "PK_#__finder_terms_common" PRIMARY KEY CLUSTERED
 (
-  "term" ASC
+  "term" ASC,
+  "language" ASC
 )WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]
 ) ON [PRIMARY];
 
 CREATE NONCLUSTERED INDEX "idx_lang" ON "#__finder_terms_common"
 (
-  "language" ASC
-)WITH (STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, DROP_EXISTING = OFF, ONLINE = OFF);
-
-CREATE NONCLUSTERED INDEX "idx_word_lang" ON "#__finder_terms_common"
-(
-  "term" ASC,
   "language" ASC
 )WITH (STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, DROP_EXISTING = OFF, ONLINE = OFF);
 


### PR DESCRIPTION
Pull Request for Issue #19032.

### Summary of Changes
changed from KEY to PRIMARY KEY for the `#__finder_terms_common`
added the PRIMARY KEY for the `#__utf8_conversion`


### Testing Instructions
fresh install should work as before
with mysql group replication  should finish the installation
