### PR TITLE
In theory, you may not always be working with the default database.

### DIFF
--- a/administrator/components/com_banners/tables/banner.php
+++ b/administrator/components/com_banners/tables/banner.php
@@ -173,6 +173,8 @@ class BannersTableBanner extends JTable
 	 */
 	public function store($updateNulls = false)
 	{
+		$db = $this->getDbo();
+
 		if (empty($this->id))
 		{
 			$purchaseType = $this->purchase_type;
@@ -180,7 +182,7 @@ class BannersTableBanner extends JTable
 			if ($purchaseType < 0 && $this->cid)
 			{
 				/** @var BannersTableClient $client */
-				$client = JTable::getInstance('Client', 'BannersTable');
+				$client = JTable::getInstance('Client', 'BannersTable', array('dbo' => $db));
 				$client->load($this->cid);
 				$purchaseType = $client->purchase_type;
 			}
@@ -220,7 +222,7 @@ class BannersTableBanner extends JTable
 		{
 			// Get the old row
 			/** @var BannersTableBanner $oldrow */
-			$oldrow = JTable::getInstance('Banner', 'BannersTable');
+			$oldrow = JTable::getInstance('Banner', 'BannersTable', array('dbo' => $db));
 
 			if (!$oldrow->load($this->id) && $oldrow->getError())
 			{
@@ -229,7 +231,7 @@ class BannersTableBanner extends JTable
 
 			// Verify that the alias is unique
 			/** @var BannersTableBanner $table */
-			$table = JTable::getInstance('Banner', 'BannersTable');
+			$table = JTable::getInstance('Banner', 'BannersTable', array('dbo' => $db));
 
 			if ($table->load(array('alias' => $this->alias, 'catid' => $this->catid)) && ($table->id != $this->id || $this->id == 0))
 			{

--- a/administrator/components/com_contact/tables/contact.php
+++ b/administrator/components/com_contact/tables/contact.php
@@ -110,7 +110,7 @@ class ContactTableContact extends JTable
 		$this->webpage = JStringPunycode::urlToPunycode($this->webpage);
 
 		// Verify that the alias is unique
-		$table = JTable::getInstance('Contact', 'ContactTable');
+		$table = JTable::getInstance('Contact', 'ContactTable', array('dbo' => $this->_db));
 
 		if ($table->load(array('alias' => $this->alias, 'catid' => $this->catid)) && ($table->id != $this->id || $this->id == 0))
 		{

--- a/administrator/components/com_finder/tables/filter.php
+++ b/administrator/components/com_finder/tables/filter.php
@@ -240,7 +240,7 @@ class FinderTableFilter extends JTable
 		}
 
 		// Verify that the alias is unique
-		$table = JTable::getInstance('Filter', 'FinderTable');
+		$table = JTable::getInstance('Filter', 'FinderTable', array('dbo' => $this->_db));
 
 		if ($table->load(array('alias' => $this->alias)) && ($table->filter_id != $this->filter_id || $this->filter_id == 0))
 		{

--- a/administrator/components/com_newsfeeds/tables/newsfeed.php
+++ b/administrator/components/com_newsfeeds/tables/newsfeed.php
@@ -149,7 +149,7 @@ class NewsfeedsTableNewsfeed extends JTable
 		}
 
 		// Verify that the alias is unique
-		$table = JTable::getInstance('Newsfeed', 'NewsfeedsTable');
+		$table = JTable::getInstance('Newsfeed', 'NewsfeedsTable', array('dbo' => $this->_db));
 
 		if ($table->load(array('alias' => $this->alias, 'catid' => $this->catid)) && ($table->id != $this->id || $this->id == 0))
 		{

--- a/administrator/components/com_users/tables/note.php
+++ b/administrator/components/com_users/tables/note.php
@@ -52,7 +52,7 @@ class UsersTableNote extends JTable
 		if (!((int) $this->review_time))
 		{
 			// Null date.
-			$this->review_time = JFactory::getDbo()->getNullDate();
+			$this->review_time = $this->_db->getNullDate();
 		}
 
 		if (empty($this->id))

--- a/libraries/src/Table/Content.php
+++ b/libraries/src/Table/Content.php
@@ -294,7 +294,7 @@ class Content extends Table
 	protected function getDefaultAssetValues($component)
 	{
 		// Need to find the asset id by the name of the component.
-		$db = \JFactory::getDbo();
+		$db = $this->getDbo();
 		$query = $db->getQuery(true)
 			->select($db->quoteName('id'))
 			->from($db->quoteName('#__assets'))

--- a/libraries/src/Table/Menu.php
+++ b/libraries/src/Table/Menu.php
@@ -144,10 +144,10 @@ class Menu extends Nested
 	 */
 	public function store($updateNulls = false)
 	{
-		$db = \JFactory::getDbo();
+		$db = $this->getDbo();
 
 		// Verify that the alias is unique
-		$table = Table::getInstance('Menu', 'JTable', array('dbo' => $this->getDbo()));
+		$table = Table::getInstance('Menu', 'JTable', array('dbo' => $db));
 
 		$originalAlias = trim($this->alias);
 		$this->alias   = !$originalAlias ? $this->title : $originalAlias;
@@ -227,7 +227,7 @@ class Menu extends Nested
 			// The alias already exists. Enqueue an error message.
 			if ($error)
 			{
-				$menuTypeTable = Table::getInstance('MenuType', 'JTable', array('dbo' => $this->getDbo()));
+				$menuTypeTable = Table::getInstance('MenuType', 'JTable', array('dbo' => $db));
 				$menuTypeTable->load(array('menutype' => $table->menutype));
 				$this->setError(\JText::sprintf('JLIB_DATABASE_ERROR_MENU_UNIQUE_ALIAS', $this->alias, $table->title, $menuTypeTable->title));
 


### PR DESCRIPTION
So use the correct one.

Pull Request for Issue # .

### Summary of Changes
Us the table class' own db object to access the database. Because (and, yes, this is highly unusual) you could be working with some other database. After all, is that not the whole reason that that Table constructor takes a dbo as one of its arguments?

### Testing Instructions
There's no new feature here and, in almost all cases, the affected function is 'store'. So just save a banner, contact, filter, newsfeed, note, and menu. All should work normally. 


### Expected result
Normal


### Actual result
Normal


### Documentation Changes Required
No
