### PR TITLE
[4.0] correct path to node_modules/karma/bin/karma start karma.conf.js --si…

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -22,7 +22,7 @@ module.exports = function (config) {
 			{pattern: 'media/system/js/legacy/*.js', included: false},
 			{pattern: 'media/system/js/fields/*.js', included: false},
 			{pattern: 'media/system/js/polyfills/webcomponents/webcomponents-ce.min.js', included: true},
-			{pattern: 'media/system/webcomponents/joomla-alert.min.js', included: true},
+			{pattern: 'media/vendor/joomla-custom-elements/js/joomla-alert.min.js', included: true},
 			{pattern: 'media/system/js/fields/calendar-locales/*.js', included: false},
 			{pattern: 'media/system/js/fields/calendar-locales/date/gregorian/*.js', included: false},
 			{pattern: 'tests/javascript/**/fixture.html', included: false},


### PR DESCRIPTION
### Summary of Changes
I have corrected the path to the file joomla-alert.min.js in the file karma.conf.js


### Testing Instructions
Run the tests via 
`node_modules/karma/bin/karma start karma.conf.js –single-run`



### Expected result
No warning


### Actual result
You see the warning message
`WARN [watcher]: Pattern "/var/www/html/JOOMLA/joomla4/joomla-cms/media/system/webcomponents/joomla-alert.min.js" does not match any file.`


### Documentation Changes Required
No
