### PR TITLE
[4.0] Fix for Bug after creating an override

### DIFF
--- a/libraries/src/Factory.php
+++ b/libraries/src/Factory.php
@@ -746,7 +746,7 @@ abstract class Factory
 	 * @see     \JStream
 	 * @since   11.1
 	 */
-	public static function getStream($use_prefix = true, $use_network = true, $ua = null, $uamask = false)
+	public static function getStream($use_prefix = true, $use_network = true, $ua = 'Joomla', $uamask = false)
 	{
 		\JLoader::import('joomla.filesystem.stream');
 


### PR DESCRIPTION
Pull Request for Issue # https://github.com/joomla/joomla-cms/issues/19475

### Summary of Changes
Set UA User agent to 'Joomla'


### Testing Instructions
1. Open Extensions->Templates-> Create overrides.
2. Try any option Module, Component, Layout. 
-> an error will occur.
3. Apply this patch and open Extensions->Templates-> Create overrides.
4. Try any option Module, Component, Layout. 
-> override is created.



### Expected result
Creates an override of the extension (folder+files)


### Actual result
Getting this error :
0 Argument 1 passed to Joomla\CMS\Version::getUserAgent() must be of the type string, null given, called in libraries/src/Factory.php on line 758

Folder is created, no files.


### Documentation Changes Required
No
