### PR TITLE
Move from protocol relative links to https for google fonts imports

### DIFF
--- a/plugins/editors/codemirror/fonts.json
+++ b/plugins/editors/codemirror/fonts.json
@@ -1,7 +1,7 @@
 {
 	"anonymous_pro": {
 		"name": "Anonymous Pro",
-		"url": "http:https://fonts.googleapis.com/css?family=Anonymous+Pro",
+		"url": "https://fonts.googleapis.com/css?family=Anonymous+Pro",
 		"css": "'Anonymous Pro', monospace"
 	},
 	"cousine": {

--- a/plugins/editors/codemirror/fonts.json
+++ b/plugins/editors/codemirror/fonts.json
@@ -1,97 +1,97 @@
 {
 	"anonymous_pro": {
 		"name": "Anonymous Pro",
-		"url": "http://fonts.googleapis.com/css?family=Anonymous+Pro",
+		"url": "http:https://fonts.googleapis.com/css?family=Anonymous+Pro",
 		"css": "'Anonymous Pro', monospace"
 	},
 	"cousine": {
 		"name": "Cousine",
-		"url": "//fonts.googleapis.com/css?family=Cousine",
+		"url": "https://fonts.googleapis.com/css?family=Cousine",
 		"css": "Cousine, monospace"
 	},
 	"cutive_mono": {
 		"name": "Cutive Mono",
-		"url": "//fonts.googleapis.com/css?family=Cutive+Mono",
+		"url": "https://fonts.googleapis.com/css?family=Cutive+Mono",
 		"css": "'Cutive Mono', monospace"
 	},
 	"droid_sans_mono": {
 		"name": "Droid Sans Mono",
-		"url": "//fonts.googleapis.com/css?family=Droid+Sans+Mono",
+		"url": "https://fonts.googleapis.com/css?family=Droid+Sans+Mono",
 		"css": "'Droid Sans Mono', monospace"
 	},
 	"fira_mono": {
 		"name": "Fira Mono",
-		"url": "//fonts.googleapis.com/css?family=Fira+Mono",
+		"url": "https://fonts.googleapis.com/css?family=Fira+Mono",
 		"css": "'Fira Mono', monospace"
 	},
 	"inconsolata": {
 		"name": "Inconsolata",
-		"url": "//fonts.googleapis.com/css?family=Inconsolata",
+		"url": "https://fonts.googleapis.com/css?family=Inconsolata",
 		"css": "Inconsolata, monospace"
 	},
 	"lekton": {
 		"name": "Lekton",
-		"url": "//fonts.googleapis.com/css?family=Lekton",
+		"url": "https://fonts.googleapis.com/css?family=Lekton",
 		"css": "Lekton, monospace"
 	},
 	"nova_mono": {
 		"name": "Nova Mono",
-		"url": "//fonts.googleapis.com/css?family=Nova+Mono",
+		"url": "https://fonts.googleapis.com/css?family=Nova+Mono",
 		"css": "'Nova Mono', monospace"
 	},
 	"overpass_mono": {
 		"name": "Overpass Mono",
-		"url": "//fonts.googleapis.com/css?family=Overpass+Mono",
+		"url": "https://fonts.googleapis.com/css?family=Overpass+Mono",
 		"css": "'Overpass Mono', monospace"
 	},
 	"oxygen_mono": {
 		"name": "Oxygen Mono",
-		"url": "//fonts.googleapis.com/css?family=Oxygen+Mono",
+		"url": "https://fonts.googleapis.com/css?family=Oxygen+Mono",
 		"css": "'Oxygen Mono', monospace"
 	},
 	"press_start_2p": {
 		"name": "Press Start 2P",
-		"url": "//fonts.googleapis.com/css?family=Press+Start+2P",
+		"url": "https://fonts.googleapis.com/css?family=Press+Start+2P",
 		"css": "'Press Start 2P', monospace"
 	},
 	"pt_mono": {
 		"name": "PT Mono",
-		"url": "//fonts.googleapis.com/css?family=PT+Mono",
+		"url": "https://fonts.googleapis.com/css?family=PT+Mono",
 		"css": "'PT Mono', monospace"
 	},
 	"roboto_mono": {
 		"name": "Roboto Mono",
-		"url": "//fonts.googleapis.com/css?family=Roboto+Mono",
+		"url": "https://fonts.googleapis.com/css?family=Roboto+Mono",
 		"css": "'Roboto Mono', monospace"
 	},
 	"rubik_mono_one": {
 		"name": "Rubik Mono One",
-		"url": "//fonts.googleapis.com/css?family=Rubik+Mono+One",
+		"url": "https://fonts.googleapis.com/css?family=Rubik+Mono+One",
 		"css": "'Rubik Mono One', monospace"
 	},
 	"share_tech_mono": {
 		"name": "Share Tech Mono",
-		"url": "//fonts.googleapis.com/css?family=Share+Tech+Mono",
+		"url": "https://fonts.googleapis.com/css?family=Share+Tech+Mono",
 		"css": "'Share Tech Mono', monospace"
 	},
 	"source_code_pro": {
 		"name": "Source Code Pro",
-		"url": "//fonts.googleapis.com/css?family=Source+Code+Pro",
+		"url": "https://fonts.googleapis.com/css?family=Source+Code+Pro",
 		"css": "'Source Code Pro', monospace"
 	},
 	"space_mono": {
 		"name": "Space Mono",
-		"url": "//fonts.googleapis.com/css?family=Space+Mono",
+		"url": "https://fonts.googleapis.com/css?family=Space+Mono",
 		"css": "'Space Mono', monospace"
 	},
 	"ubuntu_mono": {
 		"name": "Ubuntu Mono",
-		"url": "//fonts.googleapis.com/css?family=Ubuntu+Mono",
+		"url": "https://fonts.googleapis.com/css?family=Ubuntu+Mono",
 		"css": "'Ubuntu Mono', monospace"
 	},
 	"vt323": {
 		"name": "VT323",
-		"url": "//fonts.googleapis.com/css?family=VT323",
+		"url": "https://fonts.googleapis.com/css?family=VT323",
 		"css": "'VT323', monospace"
 	}
 }

--- a/templates/protostar/error.php
+++ b/templates/protostar/error.php
@@ -59,7 +59,7 @@ else
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<?php // Use of Google Font ?>
 	<?php if ($params->get('googleFont')) : ?>
-		<link href="//fonts.googleapis.com/css?family=<?php echo $params->get('googleFontName'); ?>" rel="stylesheet" />
+		<link href="https://fonts.googleapis.com/css?family=<?php echo $params->get('googleFontName'); ?>" rel="stylesheet" />
 		<style>
 			h1, h2, h3, h4, h5, h6, .site-title {
 				font-family: '<?php echo str_replace('+', ' ', $params->get('googleFontName')); ?>', sans-serif;

--- a/templates/protostar/index.php
+++ b/templates/protostar/index.php
@@ -52,7 +52,7 @@ JHtml::_('stylesheet', 'template.css', array('version' => 'auto', 'relative' => 
 // Use of Google Font
 if ($this->params->get('googleFont'))
 {
-	JHtml::_('stylesheet', '//fonts.googleapis.com/css?family=' . $this->params->get('googleFontName'));
+	JHtml::_('stylesheet', 'https://fonts.googleapis.com/css?family=' . $this->params->get('googleFontName'));
 	$this->addStyleDeclaration("
 	h1, h2, h3, h4, h5, h6, .site-title {
 		font-family: '" . str_replace('+', ' ', $this->params->get('googleFontName')) . "', sans-serif;

--- a/templates/protostar/offline.php
+++ b/templates/protostar/offline.php
@@ -35,7 +35,7 @@ JHtml::_('stylesheet', 'offline.css', array('version' => 'auto', 'relative' => t
 // Use of Google Font
 if ($this->params->get('googleFont'))
 {
-	JHtml::_('stylesheet', '//fonts.googleapis.com/css?family=' . $this->params->get('googleFontName'));
+	JHtml::_('stylesheet', 'https://fonts.googleapis.com/css?family=' . $this->params->get('googleFontName'));
 	$this->addStyleDeclaration("
 	h1, h2, h3, h4, h5, h6, .site-title {
 		font-family: '" . str_replace('+', ' ', $this->params->get('googleFontName')) . "', sans-serif;


### PR DESCRIPTION
### Summary of Changes

There is no advantage anymore to use protocol relative links over https.

### Testing Instructions

- install joomla
- see in the frontend source code
- notice the following entry in the head:
![image](https://user-images.githubusercontent.com/2596554/35575367-7ec2e8a0-05dc-11e8-8b5c-46c26b99670f.png)
- apply the patch
Confirm the link now points directly to https and not as protocol relative link.

### Expected result

Move from protocol relative links to https for google fonts imports

### Actual result

We use protocol relative links for google fonts (only that one)

### Documentation Changes Required

None.