### PR TITLE
Fix: Radio Buttons don't act like buttons

### DIFF
--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -5871,6 +5871,12 @@ hr.hr-condensed {
 .radio.btn-group input[type=radio] {
 	display: none;
 }
+.radio.btn-group > label {
+	-webkit-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+	user-select: none;
+}
 .radio.btn-group > label:first-of-type {
 	margin-left: 0;
 	-webkit-border-bottom-left-radius: 4px;

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -5871,6 +5871,12 @@ hr.hr-condensed {
 .radio.btn-group input[type=radio] {
 	display: none;
 }
+.radio.btn-group > label {
+	-webkit-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+	user-select: none;
+}
 .radio.btn-group > label:first-of-type {
 	margin-left: 0;
 	-webkit-border-bottom-left-radius: 4px;

--- a/media/jui/css/bootstrap-extended.css
+++ b/media/jui/css/bootstrap-extended.css
@@ -289,6 +289,12 @@ hr.hr-condensed {
 .radio.btn-group input[type=radio] {
 	display: none;
 }
+.radio.btn-group > label {
+	-webkit-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+	user-select: none;
+}
 .radio.btn-group > label:first-of-type {
 	margin-left: 0;
 	-webkit-border-bottom-left-radius: 4px;

--- a/media/jui/less/bootstrap-extended.less
+++ b/media/jui/less/bootstrap-extended.less
@@ -304,6 +304,12 @@ hr.hr-condensed {
 .radio.btn-group input[type=radio] {
     display: none;
 }
+.radio.btn-group > label {
+	-webkit-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+	user-select: none;
+}
 .radio.btn-group > label:first-of-type {
 	margin-left: 0;
 	-webkit-border-bottom-left-radius: 4px;

--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -6032,6 +6032,12 @@ hr.hr-condensed {
 .radio.btn-group input[type=radio] {
 	display: none;
 }
+.radio.btn-group > label {
+	-webkit-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+	user-select: none;
+}
 .radio.btn-group > label:first-of-type {
 	margin-left: 0;
 	-webkit-border-bottom-left-radius: 4px;


### PR DESCRIPTION
### Testing Instructions
Using the protostar template, visit any view in the Joomla front-end which contains a Radio Buttons element.
Module editing is fine for that purpose. See screenshot:

![immagine](https://user-images.githubusercontent.com/1609992/35594626-c2a45d0e-060b-11e8-9197-9e9dd754e3db.png)

### Expected result
Like any other button, the text inside the radio buttons should not be selectable.
Twitter Bootstrap makes the text inside Radio Buttons [not selectable](https://getbootstrap.com/docs/4.0/components/buttons/#checkbox-and-radio-buttons).

### Actual result
The text inside the radio buttons is selectable. See screenshot:
![immagine](https://user-images.githubusercontent.com/1609992/35594760-34295d94-060c-11e8-8de1-135cf476c07d.png)

The same goes for the isis template in the back-end: 
See screenshot:
![immagine](https://user-images.githubusercontent.com/1609992/35594808-5d55b988-060c-11e8-8b03-7aa3243b09fb.png)

