### PR TITLE
Inherit Itemid from current URL if option matches

### DIFF
--- a/libraries/src/Router/SiteRouter.php
+++ b/libraries/src/Router/SiteRouter.php
@@ -724,6 +724,14 @@ class SiteRouter extends Router
 					$uri->setVar('Itemid', $itemid);
 				}
 			}
+			else
+			{
+				// If option matches, inherit current Itemid
+				if ($this->getVar('option') === $uri->getVar('option') && ($itemid = $this->getVar('Itemid')))
+				{
+					$uri->setVar('Itemid', $itemid);
+				}
+			}
 		}
 		else
 		{


### PR DESCRIPTION
Pull Request for Issue #19497  .

### Summary of Changes
Due to #19099 URLs no longer inherit Itemid. They SHOULD if the option matches, otherwise that PR introduced a B/C change and all URLs should be passed to `JRoute::_()` without specifying `option` to keep this compatible (eg. `index.php?view=test` instead of `index.php?option=com_test&view=test`)


### Testing Instructions
See #19497 
