### PR TITLE
[Regression] If the link does not have a view then add active menu item

### DIFF
--- a/libraries/src/Router/SiteRouter.php
+++ b/libraries/src/Router/SiteRouter.php
@@ -724,6 +724,15 @@ class SiteRouter extends Router
 					$uri->setVar('Itemid', $itemid);
 				}
 			}
+			elseif (!$uri->getVar('view') && !$uri->getVar('task'))
+			{
+				$itemid = $this->getVar('Itemid');
+
+				if ($itemid && $this->getVar('option') === $uri->getVar('option'))
+				{
+					$uri->setVar('Itemid', $itemid);
+				}
+			}
 		}
 		else
 		{


### PR DESCRIPTION
Pull Request for Issues #19499 and #19496

### Summary of Changes
Add active menu item to incomplete link, ex: `JRoute::_('index.php?option=com_kunena');`

This PR is a little similar to #19498 but prevents to add an active `Itemid` to full link like `JRoute::_('index.php?option=com_content&view=archive');` when there is no menu item for the archive view.

The full link will still not depend on the page it was generated on.

### Testing Instructions
See at issues #19499 and #19496.

### Expected result
Issues are fixed.
