### PR TITLE
Fix delete session meta data error

### DIFF
--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -160,7 +160,7 @@ class CMSApplication extends WebApplication
 		if ($handler !== 'database' && $time % 5 === 0)
 		{
 			$this->registerEvent(
-				'onAfterResponse',
+				'onAfterRespond',
 				function () use ($session, $time)
 				{
 					// TODO: At some point we need to get away from having session data always in the db.


### PR DESCRIPTION
Pull Request for Issue #19511 .

### Summary of Changes
There was a typo in the code causes session meta data never being deleted and causes wrong number of visitors displayed in Who's online module. This PR fixes that issue.

### Testing Instructions
Ping @hannes01, @central4all and @sandewt for testing as they have issue on their website. Please apply patch and confirm the issue sorted.