### PR TITLE
Fix for ignoring layout attribute in MenuRouting

### DIFF
--- a/libraries/src/Component/Router/Rules/MenuRules.php
+++ b/libraries/src/Component/Router/Rules/MenuRules.php
@@ -239,7 +239,6 @@ class MenuRules implements RulesInterface
 						if (!isset($this->lookup[$language][$view . $layout][$item->query[$views[$view]->key]]) || $item->language !== '*')
 						{
 							$this->lookup[$language][$view . $layout][$item->query[$views[$view]->key]] = $item->id;
-							$this->lookup[$language][$view][$item->query[$views[$view]->key]] = $item->id;
 						}
 					}
 					else
@@ -252,7 +251,6 @@ class MenuRules implements RulesInterface
 						if (!isset($this->lookup[$language][$view . $layout]) || $item->language !== '*')
 						{
 							$this->lookup[$language][$view . $layout] = $item->id;
-							$this->lookup[$language][$view] = $item->id;
 						}
 					}
 				}


### PR DESCRIPTION
As far as I can tell it is save to remove these two lines. 
They are causing many routing issues!

Pull Request for Issue # .

###  Steps to reproduce the issue

Create two menu entries listing categorise with subcategories.
One is layout print one layout default.
index.php?option=com_content&view=categories&id=9
index.php?option=com_content&view=categories&layout=print&id=9

The router picks always the print layout item because
this entry was added last to the menu table.

This problem will afflict every component if
entries with same attributes but different layouts
exist.


### Expected result

