### PR TITLE
Workaround for CodeMirror mode bug

### DIFF
--- a/plugins/editors/codemirror/layouts/editors/codemirror/init.php
+++ b/plugins/editors/codemirror/layouts/editors/codemirror/init.php
@@ -43,7 +43,7 @@ JFactory::getDocument()->addScriptDeclaration(
 				if (mode)
 				{
 					cm.autoLoadMode(editor, mode.mode);
-					editor.setOption('mode', mode.mime);
+					editor.setOption('mode', (mode.mime instanceof Array) ? mode.mime[0] : mode.mime);
 				}
 				else
 				{


### PR DESCRIPTION
The PHP mode in CodeMirror is wrongly defined
This results in the mode option being set wrong
Which gives us no syntax coloring for PHP
This fix works around the bug to set the right mode in php
Will also work for any other mode that is also wrongly defined as php is (if there is any)

Pull Request for Issue #19520 .

### Summary of Changes
Need to check if a value which is expected to be a string is, in fact, an array (which is a bug in CodeMirror). If it is, deal with it. 

### Testing Instructions
Use CodeMirror to edit a PHP file. 
By all means, test other types too.

### Expected result
Should have proper syntax coloring.


### Actual result
Before the patch: no syntax coloring for PHP.
After the patch: should have it.


### Documentation Changes Required
Nope
