### PR TITLE
Occasional problem of corrupted html

### DIFF
--- a/libraries/legacy/response/response.php
+++ b/libraries/legacy/response/response.php
@@ -242,18 +242,10 @@ class JResponse
 		// Ideal level
 		$level = 4;
 
-		/*
-		$size    = strlen($data);
-		$crc     = crc32($data);
-		$gzdata  = "\x1f\x8b\x08\x00\x00\x00\x00\x00";
-		$gzdata .= gzcompress($data, $level);
-		$gzdata  = substr($gzdata, 0, strlen($gzdata) - 4);
-		$gzdata .= pack("V",$crc) . pack("V", $size);
-		*/
-
 		$gzdata = gzencode($data, $level);
 
 		self::setHeader('Content-Encoding', $encoding);
+		self::setHeader('Vary', 'Accept-Encoding');
 
 		// Header will be removed at 4.0
 		if (defined('JVERSION') && JFactory::getConfig()->get('MetaVersion', 0))

--- a/libraries/src/Application/WebApplication.php
+++ b/libraries/src/Application/WebApplication.php
@@ -468,6 +468,7 @@ class WebApplication extends BaseApplication
 
 				// Set the encoding headers.
 				$this->setHeader('Content-Encoding', $encoding);
+				$this->setHeader('Vary', 'Accept-Encoding');
 
 				// Header will be removed at 4.0
 				if ($this->get('MetaVersion'))

--- a/tests/unit/suites/libraries/joomla/application/JApplicationWebTest.php
+++ b/tests/unit/suites/libraries/joomla/application/JApplicationWebTest.php
@@ -338,7 +338,8 @@ class JApplicationWebTest extends TestCase
 		// Ensure that the compression headers were set.
 		$this->assertEquals(
 			array(
-				0 => array('name' => 'Content-Encoding', 'value' => 'gzip')
+				0 => array('name' => 'Content-Encoding', 'value' => 'gzip'),
+				1 => array('name' => 'Vary', 'value' => 'Accept-Encoding')
 			),
 			TestReflection::getValue($this->class, 'response')->headers
 		);
@@ -386,7 +387,8 @@ class JApplicationWebTest extends TestCase
 		// Ensure that the compression headers were set.
 		$this->assertEquals(
 			array(
-				0 => array('name' => 'Content-Encoding', 'value' => 'deflate')
+				0 => array('name' => 'Content-Encoding', 'value' => 'deflate'),
+				1 => array('name' => 'Vary', 'value' => 'Accept-Encoding')
 			),
 			TestReflection::getValue($this->class, 'response')->headers
 		);


### PR DESCRIPTION
When the compression of the response is delegated to Apache with mod_deflate, two headers are set during the compression:
```
Content-Encoding: gzip
Vary: Accept-Encoding
```

Vary: Accept-Encoding is important to prevent proxies, intermediate caches, or CDNs from serving compressed resource to clients that does not support compression and vice versa.
"Vary: Accept-Encoding" header specifies that caches should only be used if the incoming request matches the "Accept-Encoding" information in the cache.

When the mod_deflate is disabled in the web server, and the compression is delegated to Joomla through Global Configuration → Server → Gzip Page Compression, in this case the header "Content-Encoding: gzip" is set, but "Vary: Accept-Encoding" no, which causes the problem mentioned above on modern networks.

### Testing Instructions
Disable mod_deflate in your web server and enable Joomla compression Global Configuration → Server → Gzip Page Compression.
Browse any page.
Check that the response headers include Vary: Accept-Encoding in addition to Content-Encoding: gzip

### Note
See https://github.com/joomla-framework/application/pull/79