### PR TITLE
[4.0] Deprecate Menu::getInstance

### DIFF
--- a/libraries/src/Menu/AbstractMenu.php
+++ b/libraries/src/Menu/AbstractMenu.php
@@ -90,8 +90,9 @@ abstract class AbstractMenu
 	 *
 	 * @return  AbstractMenu  A menu object.
 	 *
-	 * @since   1.5
-	 * @throws  \Exception
+	 * @since       1.5
+	 * @throws      \Exception
+	 * @deprecated  5.0 Use the MenuFactoryInterface from the container instead
 	 */
 	public static function getInstance($client, $options = array())
 	{


### PR DESCRIPTION
Ongoing effort to phase out getInstance code. This pr deprecates AbstractMenu::getInstance.

I'm splitting #16918 into different pr's to be easier to review.