### PR TITLE
[4.0] Deprecate Table::getInstance

### DIFF
--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -259,7 +259,8 @@ abstract class Table extends \JObject implements \JTableInterface, DispatcherAwa
 	 *
 	 * @return  Table|boolean   A Table object if found or boolean false on failure.
 	 *
-	 * @since   11.1
+	 * @since       11.1
+	 * @deprecated  5.0 Use the MvcFactory instead
 	 */
 	public static function getInstance($type, $prefix = 'JTable', $config = array())
 	{

--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -320,7 +320,7 @@ abstract class Table extends \JObject implements \JTableInterface, DispatcherAwa
 	 * @return  array  An array of filesystem paths to find Table classes in.
 	 *
 	 * @since       11.1
-	 * @deprecated  5.0 Should not be used anymore as tables are loaded trough the MvcFactory
+	 * @deprecated  5.0 Should not be used anymore as tables are loaded through the MvcFactory
 	 */
 	public static function addIncludePath($path = null)
 	{

--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -319,7 +319,8 @@ abstract class Table extends \JObject implements \JTableInterface, DispatcherAwa
 	 *
 	 * @return  array  An array of filesystem paths to find Table classes in.
 	 *
-	 * @since   11.1
+	 * @since       11.1
+	 * @deprecated  5.0 Should not be used anymore as tables are loaded trough the MvcFactory
 	 */
 	public static function addIncludePath($path = null)
 	{


### PR DESCRIPTION
Ongoing effort to phase out getInstance code. This pr deprecates Table::getInstance.

I'm splitting #16918 into different pr's to be easier to review.