### PR TITLE
Fix: Radio buttons don't trig OnChange event in beez3 template

### DIFF
--- a/templates/beez3/javascript/template.js
+++ b/templates/beez3/javascript/template.js
@@ -10,7 +10,7 @@
 {
 	$(document).ready(function()
 	{
-		$('*[rel=tooltip]').tooltip()
+		$('*[rel=tooltip]').tooltip();
 
 		// Turn radios into btn-group
 		$('.radio.btn-group label').addClass('btn');
@@ -30,6 +30,7 @@
 					label.addClass('active btn-success');
 				}
 				input.prop('checked', true);
+				input.trigger('change');
 			}
 		});
 		$(".btn-group input[checked=checked]").each(function()

--- a/templates/protostar/js/template.js
+++ b/templates/protostar/js/template.js
@@ -10,7 +10,7 @@
 {
 	$(document).ready(function()
 	{
-		$('*[rel=tooltip]').tooltip()
+		$('*[rel=tooltip]').tooltip();
 
 		// Turn radios into btn-group
 		$('.radio.btn-group label').addClass('btn');


### PR DESCRIPTION
The javascript code necessary for the radio buttons to work, has been duplicated and placed substantially unchanged among templates isis, protostar and beez3.
1. administrator/templates/isis/js/template.js
2. templates/protostar/js/template.js
3. templates/beez3/javascript/template.js

The original code suffered a bug which prevents the OnChange JavaScript event to be thrown.
Over time, the 'change' event trigger has been added to isis version [here](https://github.com/joomla/joomla-cms/commit/4c3824144bb723d69c1d278518a44070886166da#diff-6337832bd45e0f9af1521049cb78e03e) by @bembelimen and to protostar version [here](https://github.com/joomla/joomla-cms/commit/ae3dfdc7a3ee83e2dde30b309570aebcb462b341#diff-66c674d80734544d4f4d35463bea8cbe) by @Minei3oat and they hopefully can review and confirm this PR.

This PR ports the same fix to the beez3 template.

### Summary of Changes



### Testing Instructions
Put some HTML+JavaScript code to show the onchange event into an article. The following code is fine for that purpose.
_Tip: Note that you need to use Editor:none as back-end editor to actually add the code, otherwise javascript code could be stripped out during article save._
```
<div class="controls">
	<fieldset id="jform_offline" class="btn-group btn-group-yesno btn-group-reversed radio">
		<input type="radio" id="jform_offline0" name="jform[offline]" value="1"/>
		<label for="jform_offline0">Yes </label>
		<input type="radio" id="jform_offline1" name="jform[offline]" value="0" checked="checked"/>
		<label for="jform_offline1">No </label>
	</fieldset>
</div>

<script>
	jQuery('input[type=radio][name="jform[offline]"]').change(function () {
		alert('The value has changed. New value: ' + this.value);
	});
</script>
```

### Expected result
When I change the value to the radio button in the back-end, an alert should notify that the event has been raised.

### Actual result
While it works as expected for protostar template, it doesn't on beez3 template.
On beez3 template when user clicks on **the radio control** (the cue ball) the change event **is raised**, but when the user clicks on **the radio button label**, the value changes **without raising** the onchange event.
