### PR TITLE
Fix no button in configuration of com_content for Votes and rating

### DIFF
--- a/administrator/components/com_content/config.xml
+++ b/administrator/components/com_content/config.xml
@@ -929,7 +929,7 @@
 
 		<field 
 			name="list_show_votes"
-			type="voteradio"
+			type="radio"
 			label="JGLOBAL_LIST_VOTES_LABEL"
 			description="JGLOBAL_LIST_VOTES_DESC"
 			class="btn-group btn-group-yesno"
@@ -941,7 +941,7 @@
 
 		<field 
 			name="list_show_ratings"
-			type="voteradio"
+			type="radio"
 			label="JGLOBAL_LIST_RATINGS_LABEL"
 			description="JGLOBAL_LIST_RATINGS_DESC"
 			class="btn-group btn-group-yesno"


### PR DESCRIPTION
### Summary of Changes

Type changed to <code>radio</code>
Btn-group class accepts radio type .
So, type changed to the radio.

### Testing Instructions

1.Open configuration settings of<code> com_content</code> Or <code>Articles</code>
2.Then open <code>list layout</code> tab.
3.Check on the bottom now control-group is not empty. 

If you have Debugger installed then you can easily see.

But without debugger just use browser inspect.


### Expected result
![screenshot from 2018-02-02 23-50-23](https://user-images.githubusercontent.com/30978328/35759836-18b23d3c-0874-11e8-9d02-ee81239a1190.png)



### Actual result

![screenshot from 2018-02-02 23-51-37](https://user-images.githubusercontent.com/30978328/35759837-1b7839f4-0874-11e8-9581-aceae33f7dfa.png)


### Documentation Changes Required

