### PR TITLE
Multilingual: Associated categories should display only when published

### DIFF
--- a/administrator/components/com_categories/helpers/categories.php
+++ b/administrator/components/com_categories/helpers/categories.php
@@ -111,11 +111,30 @@ class CategoriesHelper
 	public static function getAssociations($pk, $extension = 'com_content')
 	{
 		$langAssociations = JLanguageAssociations::getAssociations($extension, '#__categories', 'com_categories.item', $pk, 'id', 'alias', '');
-		$associations = array();
+		$associations     = array();
+		$user             = JFactory::getUser();
+		$groups           = implode(',', $user->getAuthorisedViewLevels());
 
 		foreach ($langAssociations as $langAssociation)
 		{
-			$associations[$langAssociation->language] = $langAssociation->id;
+			// Include only published categories with user access
+			$arrId    = explode(':', $langAssociation->id);
+			$assocId  = $arrId[0];
+
+			$db    = \JFactory::getDbo();
+
+			$query = $db->getQuery(true)
+				->select($db->qn('published'))
+				->from($db->qn('#__categories'))
+				->where('access IN (' . $groups . ')')
+				->where($db->qn('id') . ' = ' . (int)($assocId));
+
+			$result = (int) $db->setQuery($query)->loadResult();
+
+			if ($result === 1)
+			{
+				$associations[$langAssociation->language] = $langAssociation->id;
+			}
 		}
 
 		return $associations;

--- a/administrator/components/com_categories/helpers/categories.php
+++ b/administrator/components/com_categories/helpers/categories.php
@@ -127,7 +127,7 @@ class CategoriesHelper
 				->select($db->qn('published'))
 				->from($db->qn('#__categories'))
 				->where('access IN (' . $groups . ')')
-				->where($db->qn('id') . ' = ' . (int) ($assocId));
+				->where($db->qn('id') . ' = ' . (int) $assocId);
 
 			$result = (int) $db->setQuery($query)->loadResult();
 

--- a/administrator/components/com_categories/helpers/categories.php
+++ b/administrator/components/com_categories/helpers/categories.php
@@ -127,7 +127,7 @@ class CategoriesHelper
 				->select($db->qn('published'))
 				->from($db->qn('#__categories'))
 				->where('access IN (' . $groups . ')')
-				->where($db->qn('id') . ' = ' . (int)($assocId));
+				->where($db->qn('id') . ' = ' . (int) ($assocId));
 
 			$result = (int) $db->setQuery($query)->loadResult();
 


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/13359#issuecomment-361602857

### Summary of Changes
Make sure the associated category is published
patch is similar to what I did for articles.


### Testing Instructions
Associate a category to its equivalent in an other language.
Unpublish that equivalent.
Display the original category via  a menu item or a drilldown when displaying category link for an article.
Switch via the language switcher module to the associated category which is Unpublished.
Check the hreflang in source.

If you use 3.8.3, just patch and test again
Or test with staging or 3.8.5 (stable or RC)
then this PR.

### After patch
When the  associated category is Unpublished OR the user has no access to it, the switcher will redirect to the Home page for the said language. That is what we want.
Also the hreflang in source will not display anymore

