### PR TITLE
Re-instating display of login form when Home page is set to Registered and there is no Login Form

### DIFF
--- a/libraries/src/Application/SiteApplication.php
+++ b/libraries/src/Application/SiteApplication.php
@@ -98,7 +98,7 @@ final class SiteApplication extends CMSApplication
 				$menuId  = explode('Itemid=', $url);
 
 				// Do not use an Itemid if we are on the home page and we have no Login Form menu item
-				if (!empty($menuId[1]) && $home_item->id == $menuId[1])
+				if (!empty($menuId[1]) && $home_item->id == (int) $menuId[1])
 				{
 					$url = 'index.php?option=com_users&view=login';
 				}

--- a/libraries/src/Application/SiteApplication.php
+++ b/libraries/src/Application/SiteApplication.php
@@ -80,7 +80,10 @@ final class SiteApplication extends CMSApplication
 	protected function authorise($itemid)
 	{
 		$menus = $this->getMenu();
-		$user = \JFactory::getUser();
+		$user  = \JFactory::getUser();
+
+		// Get the home page menu item
+		$home_item = $menus->getDefault($this->getLanguage()->getTag());
 
 		if (!$menus->authorise($itemid))
 		{
@@ -91,14 +94,20 @@ final class SiteApplication extends CMSApplication
 
 				$url = \JRoute::_('index.php?option=com_users&view=login', false);
 
+				//Check for a menu Itemid
+				$menuId  = explode('Itemid=', $url);
+
+				// Do not use an Itemid if we are on the home page and we have no Login Form menu item
+				if (!empty($menuId[1]) && $home_item->id == $menuId[1])
+				{
+					$url = 'index.php?option=com_users&view=login';
+				}
+
 				$this->enqueueMessage(\JText::_('JGLOBAL_YOU_MUST_LOGIN_FIRST'));
 				$this->redirect($url);
 			}
 			else
 			{
-				// Get the home page menu item
-				$home_item = $menus->getDefault($this->getLanguage()->getTag());
-
 				// If we are already in the homepage raise an exception
 				if ($menus->getActive()->id == $home_item->id)
 				{

--- a/libraries/src/Application/SiteApplication.php
+++ b/libraries/src/Application/SiteApplication.php
@@ -100,7 +100,7 @@ final class SiteApplication extends CMSApplication
 				// Do not use an Itemid if we are on the home page and we have no Login Form menu item
 				if (!empty($menuId[1]) && $home_item->id == (int) $menuId[1])
 				{
-					$url = 'index.php?option=com_users&view=login';
+					$url = \JRoute::_('index.php?option=com_users&view=login&Itemid=', false);
 				}
 
 				$this->enqueueMessage(\JText::_('JGLOBAL_YOU_MUST_LOGIN_FIRST'));

--- a/libraries/src/Application/SiteApplication.php
+++ b/libraries/src/Application/SiteApplication.php
@@ -95,7 +95,7 @@ final class SiteApplication extends CMSApplication
 				$url = \JRoute::_('index.php?option=com_users&view=login', false);
 
 				//Check for a menu Itemid
-				$menuId  = explode('Itemid=', $url);
+				$menuId = explode('Itemid=', $url);
 
 				// Do not use an Itemid if we are on the home page and we have no Login Form menu item
 				if (!empty($menuId[1]) && $home_item->id == (int) $menuId[1])


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/15730

### Summary of Changes
Display the login form without an Itemid as it was before 3.7.0

### Testing Instructions
Set a Home page to Registered.
Load the Home page
Test SEF on and off
Test with an existing Login Form menu item or not.

### After patch
The login form will display whatever the situation

<img width="760" alt="screen shot 2018-02-04 at 11 11 44" src="https://user-images.githubusercontent.com/869724/35776414-3e735c94-099c-11e8-901a-860e4328cd29.png">

