### PR TITLE
Revert content archive routing

### DIFF
--- a/components/com_content/helpers/legacyrouter.php
+++ b/components/com_content/helpers/legacyrouter.php
@@ -237,7 +237,7 @@ class ContentRouterRulesLegacy implements JComponentRouterRulesInterface
 				}
 			}
 
-			if (isset($query['month']))
+			if (isset($query['year']) && isset($query['month']))
 			{
 				if ($menuItemGiven)
 				{
@@ -384,7 +384,7 @@ class ContentRouterRulesLegacy implements JComponentRouterRulesInterface
 		 * because the first segment will have the target category id prepended to it.  If the
 		 * last segment has a number prepended, it is an article, otherwise, it is a category.
 		 */
-		if ((!$advanced) && ($item->query['view'] !== 'archive'))
+		if (!$advanced)
 		{
 			$cat_id = (int) $segments[0];
 
@@ -403,16 +403,6 @@ class ContentRouterRulesLegacy implements JComponentRouterRulesInterface
 			}
 
 			return;
-		}
-
-		// Manage the archive view
-		if ($item->query['view'] == 'archive' && $count !== 1)
-		{
-			$vars['year']  = $count >= 2 ? $segments[$count - 2] : null;
-			$vars['month'] = $segments[$count - 1];
-			$vars['view']  = 'archive';
-
-			return;	
 		}
 
 		// We get the category id from the menu item and search from there
@@ -466,8 +456,18 @@ class ContentRouterRulesLegacy implements JComponentRouterRulesInterface
 					$cid = $segment;
 				}
 
-				$vars['id']   = $cid;
-				$vars['view'] = 'article';
+				$vars['id'] = $cid;
+
+				if ($item->query['view'] == 'archive' && $count != 1)
+				{
+					$vars['year'] = $count >= 2 ? $segments[$count - 2] : null;
+					$vars['month'] = $segments[$count - 1];
+					$vars['view'] = 'archive';
+				}
+				else
+				{
+					$vars['view'] = 'article';
+				}
 			}
 
 			$found = 0;

--- a/components/com_content/helpers/legacyrouter.php
+++ b/components/com_content/helpers/legacyrouter.php
@@ -225,34 +225,25 @@ class ContentRouterRulesLegacy implements JComponentRouterRulesInterface
 			if (!$menuItemGiven)
 			{
 				$segments[] = $view;
+				unset($query['view']);
 			}
 
-			unset($query['view']);
-
-			// If there is no year segment then do not add month segment
-			if (isset($query['year']) && $menuItemGiven)
+			if (isset($query['year']))
 			{
-				if ($query['year'])
+				if ($menuItemGiven)
 				{
 					$segments[] = $query['year'];
-
-					if (isset($query['month']))
-					{
-						if ($query['month'])
-						{
-							$segments[] = $query['month'];
-						}
-
-						unset($query['month']);
-					}
+					unset($query['year']);
 				}
-
-				unset($query['year']);
 			}
 
-			if (isset($query['month']) && empty($query['month']))
+			if (isset($query['month']))
 			{
-				unset($query['month']);
+				if ($menuItemGiven)
+				{
+					$segments[] = $query['month'];
+					unset($query['month']);
+				}
 			}
 		}
 
@@ -329,29 +320,10 @@ class ContentRouterRulesLegacy implements JComponentRouterRulesInterface
 		 * Standard routing for articles.  If we don't pick up an Itemid then we get the view from the segments
 		 * the first segment is the view and the last segment is the id of the article or category.
 		 */
-		if ($item === null)
+		if (!isset($item))
 		{
 			$vars['view'] = $segments[0];
 			$vars['id'] = $segments[$count - 1];
-
-			return;
-		}
-
-		// Manage the archive view
-		if ($item->query['view'] === 'archive')
-		{
-			$vars['view']  = 'archive';
-
-			if ($count >= 2)
-			{
-				$vars['year']  = $segments[$count - 2];
-				$vars['month'] = $segments[$count - 1];
-			}
-			else
-			{
-				$vars['year']  = $segments[$count - 1];
-				$vars['month'] = null;
-			}
 
 			return;
 		}
@@ -412,7 +384,7 @@ class ContentRouterRulesLegacy implements JComponentRouterRulesInterface
 		 * because the first segment will have the target category id prepended to it.  If the
 		 * last segment has a number prepended, it is an article, otherwise, it is a category.
 		 */
-		if ((!$advanced))
+		if ((!$advanced) && ($item->query['view'] !== 'archive'))
 		{
 			$cat_id = (int) $segments[0];
 
@@ -431,6 +403,16 @@ class ContentRouterRulesLegacy implements JComponentRouterRulesInterface
 			}
 
 			return;
+		}
+
+		// Manage the archive view
+		if ($item->query['view'] == 'archive' && $count !== 1)
+		{
+			$vars['year']  = $count >= 2 ? $segments[$count - 2] : null;
+			$vars['month'] = $segments[$count - 1];
+			$vars['view']  = 'archive';
+
+			return;	
 		}
 
 		// We get the category id from the menu item and search from there


### PR DESCRIPTION
### Summary of Changes

This is the simple reversion of two commits, my (#19447) and @alikon (#19397). 
If someone has more time then may try to fix it in a better way.

After merging #19512, the above PRs stop working and should also be reversed. 

Because of inheritance active menu item, the archive view has a conflict with article view.
Reverting the only one commit does not help.

Links like  `/archive/123-category/12-article` with segments after `/archive` - does not work in staging but it works in 3.8.3

### Testing Instructions
1. Install joomla staging (3.8.5-rc) with testing sample data.
2. Unpublish all menu items form com_content except one `archive` view and set home as featured view.
3. Archive a few articles
4. Go to `/archive` link
5. Now you should see a list of archived articles and its links like:
   - `/archive/75-sample-data-articles/joomla/extensions/modules/navigation-modules/61-breadcrumbs-module`
6. Click to one of them 
7. In 3.8.3 you will go to an **article**, in staging you stay in **archive view**, after PR you go to **article** as in 3.8.3.

### Expected result
Go to article.

### Actual result
Stay in archive view.

### Documentation Changes Required
No
