### PR TITLE
[4.0] Use the correct prefix for the fields path lookup in com_contact

### DIFF
--- a/administrator/components/com_contact/forms/contact.xml
+++ b/administrator/components/com_contact/forms/contact.xml
@@ -386,8 +386,7 @@
 
 	<fields name="params" label="JGLOBAL_FIELDSET_DISPLAY_OPTIONS">
 
-		<fieldset name="display" label="JGLOBAL_FIELDSET_DISPLAY_OPTIONS"
-			 addfieldpath="/administrator/components/com_fields/models/fields">
+		<fieldset name="display" label="JGLOBAL_FIELDSET_DISPLAY_OPTIONS">
 
 			<field
 				name="show_contact_category"
@@ -661,13 +660,14 @@
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-			
+
 			<field
 				name="show_user_custom_fields"
 				type="fieldgroups"
 				label="COM_CONTACT_FIELD_USER_CUSTOM_FIELDS_SHOW_LABEL"
 				multiple="true"
 				context="com_users.user"
+				addfieldprefix="Joomla\Component\Fields\Administrator\Field"
 				>
 				<option value="-1">JALL</option>
 			</field>

--- a/components/com_contact/tmpl/contact/default.xml
+++ b/components/com_contact/tmpl/contact/default.xml
@@ -14,7 +14,7 @@
 		<fieldset name="request"
 			addfieldprefix="Joomla\Component\Contact\Administrator\Field"
 		>
-			<field 
+			<field
 				name="id"
 				type="modal_contact"
 				label="COM_CONTACT_SELECT_CONTACT_LABEL"
@@ -33,9 +33,8 @@
 		<!-- Basic options. -->
 		<fieldset name="params"
 			label="COM_CONTACT_BASIC_OPTIONS_FIELDSET_LABEL"
-			addfieldpath="/administrator/components/com_fields/models/fields"
 		>
-			<field 
+			<field
 				name="presentation_style"
 				type="list"
 				label="COM_CONTACT_FIELD_PRESENTATION_LABEL"
@@ -46,7 +45,7 @@
 				<option value="plain">COM_CONTACT_FIELD_VALUE_PLAIN</option>
 			</field>
 
-			<field 
+			<field
 				name="show_contact_category"
 				type="list"
 				label="COM_CONTACT_FIELD_CONTACT_SHOW_CATEGORY_LABEL"
@@ -58,7 +57,7 @@
 				<option value="show_with_link">COM_CONTACT_FIELD_VALUE_WITH_LINK</option>
 			</field>
 
-			<field 
+			<field
 				name="show_contact_list"
 				type="list"
 				label="COM_CONTACT_FIELD_CONTACT_SHOW_LIST_LABEL"
@@ -91,7 +90,7 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field 
+			<field
 				name="show_name"
 				type="list"
 				label="COM_CONTACT_FIELD_PARAMS_NAME_LABEL"
@@ -103,7 +102,7 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field 
+			<field
 				name="show_position"
 				type="list"
 				label="COM_CONTACT_FIELD_PARAMS_CONTACT_POSITION_LABEL"
@@ -115,7 +114,7 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field 
+			<field
 				name="show_email"
 				type="list"
 				label="JGLOBAL_EMAIL"
@@ -139,7 +138,7 @@
 				<option value="0">JNO</option>
 			</field>
 
-			<field 
+			<field
 				name="show_street_address"
 				type="list"
 				label="COM_CONTACT_FIELD_PARAMS_STREET_ADDRESS_LABEL"
@@ -151,7 +150,7 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field 
+			<field
 				name="show_suburb"
 				type="list"
 				label="COM_CONTACT_FIELD_PARAMS_TOWN-SUBURB_LABEL"
@@ -163,7 +162,7 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field 
+			<field
 				name="show_state"
 				type="list"
 				label="COM_CONTACT_FIELD_PARAMS_STATE-COUNTY_LABEL"
@@ -175,7 +174,7 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field 
+			<field
 				name="show_postcode"
 				type="list"
 				label="COM_CONTACT_FIELD_PARAMS_POST-ZIP_CODE_LABEL"
@@ -187,7 +186,7 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field 
+			<field
 				name="show_country"
 				type="list"
 				label="COM_CONTACT_FIELD_PARAMS_COUNTRY_LABEL"
@@ -199,7 +198,7 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field 
+			<field
 				name="show_telephone"
 				type="list"
 				label="COM_CONTACT_FIELD_PARAMS_TELEPHONE_LABEL"
@@ -211,7 +210,7 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field 
+			<field
 				name="show_mobile"
 				type="list"
 				label="COM_CONTACT_FIELD_PARAMS_MOBILE_LABEL"
@@ -223,7 +222,7 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field 
+			<field
 				name="show_fax"
 				type="list"
 				label="COM_CONTACT_FIELD_PARAMS_FAX_LABEL"
@@ -235,7 +234,7 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field 
+			<field
 				name="show_webpage"
 				type="list"
 				label="COM_CONTACT_FIELD_PARAMS_WEBPAGE_LABEL"
@@ -247,7 +246,7 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field 
+			<field
 				name="show_image"
 				type="list"
 				label="COM_CONTACT_FIELD_PARAMS_IMAGE_LABEL"
@@ -259,7 +258,7 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field 
+			<field
 				name="allow_vcard"
 				type="list"
 				label="COM_CONTACT_FIELD_PARAMS_VCARD_LABEL"
@@ -281,7 +280,7 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field 
+			<field
 				name="show_articles"
 				type="list"
 				label="COM_CONTACT_FIELD_ARTICLES_SHOW_LABEL"
@@ -292,9 +291,9 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field 
-				name="articles_display_num" 
-				type="list" 
+			<field
+				name="articles_display_num"
+				type="list"
 				label="COM_CONTACT_FIELD_ARTICLES_DISPLAY_NUM_LABEL"
 				default=""
 				useglobal="true"
@@ -322,11 +321,12 @@
 				label="COM_CONTACT_FIELD_USER_CUSTOM_FIELDS_SHOW_LABEL"
 				multiple="true"
 				context="com_users.user"
+				addfieldprefix="Joomla\Component\Fields\Administrator\Field"
 				>
 				<option value="-1">JALL</option>
 			</field>
 
-			<field 
+			<field
 				name="show_links"
 				type="list"
 				label="COM_CONTACT_FIELD_SHOW_LINKS_LABEL"
@@ -337,7 +337,7 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field 
+			<field
 				name="linka_name"
 				type="text"
 				label="COM_CONTACT_FIELD_LINKA_NAME_LABEL"
@@ -345,7 +345,7 @@
 				useglobal="true"
 			/>
 
-			<field 
+			<field
 				name="linkb_name"
 				type="text"
 				label="COM_CONTACT_FIELD_LINKB_NAME_LABEL"
@@ -353,7 +353,7 @@
 				useglobal="true"
 			/>
 
-			<field 
+			<field
 				name="linkc_name"
 				type="text"
 				label="COM_CONTACT_FIELD_LINKC_NAME_LABEL"
@@ -361,7 +361,7 @@
 				useglobal="true"
 			/>
 
-			<field 
+			<field
 				name="linkd_name"
 				type="text"
 				label="COM_CONTACT_FIELD_LINKD_NAME_LABEL"
@@ -369,7 +369,7 @@
 				useglobal="true"
 			/>
 
-			<field 
+			<field
 				name="linke_name"
 				type="text"
 				label="COM_CONTACT_FIELD_LINKE_NAME_LABEL"
@@ -383,8 +383,8 @@
 			label="COM_CONTACT_MAIL_FIELDSET_LABEL"
 		>
 
-			<field 
-				name="show_email_form" 
+			<field
+				name="show_email_form"
 				type="list"
 				label="COM_CONTACT_FIELD_EMAIL_SHOW_FORM_LABEL"
 				useglobal="true"
@@ -394,7 +394,7 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field 
+			<field
 				name="show_email_copy"
 				type="list"
 				label="COM_CONTACT_FIELD_EMAIL_EMAIL_COPY_LABEL"
@@ -405,7 +405,7 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field 
+			<field
 				name="banned_email"
 				type="textarea"
 				label="COM_CONTACT_FIELD_CONFIG_BANNED_EMAIL_LABEL"
@@ -414,7 +414,7 @@
 				rows="3"
 			/>
 
-			<field 
+			<field
 				name="banned_subject"
 				type="textarea"
 				label="COM_CONTACT_FIELD_CONFIG_BANNED_SUBJECT_LABEL"
@@ -423,7 +423,7 @@
 				rows="3"
 			/>
 
-			<field 
+			<field
 				name="banned_text"
 				type="textarea"
 				label="COM_CONTACT_FIELD_CONFIG_BANNED_TEXT_LABEL"
@@ -432,7 +432,7 @@
 				rows="3"
 			/>
 
-			<field 
+			<field
 				name="validate_session"
 				type="list"
 				label="COM_CONTACT_FIELD_CONFIG_SESSION_CHECK_LABEL"
@@ -443,7 +443,7 @@
 				<option value="1">JYES</option>
 			</field>
 
-			<field 
+			<field
 				name="custom_reply"
 				type="list"
 				label="COM_CONTACT_FIELD_CONFIG_CUSTOM_REPLY_LABEL"
@@ -454,7 +454,7 @@
 				<option value="1">JYES</option>
 			</field>
 
-			<field 
+			<field
 				name="redirect"
 				type="text"
 				label="COM_CONTACT_FIELD_CONFIG_REDIRECT_LABEL"


### PR DESCRIPTION
### Summary of Changes
The custom field groups option is broken because the of an invalid path.

Note: PHPStorm removed the spaces at the end of the file automatically.

### Testing Instructions
- Create a user custom field group.
- Open the Contact configuration and scroll down to the "User Custom Fields"parameter.

### Expected result
A list of field groups is displayed.

### Actual result
The following error is shown:
_Warning: htmlspecialchars() expects parameter 1 to be string, array given_