### PR TITLE
Enforced expected parameter type

### DIFF
--- a/administrator/components/com_templates/controllers/style.php
+++ b/administrator/components/com_templates/controllers/style.php
@@ -54,7 +54,7 @@ class TemplatesControllerStyle extends JControllerForm
 			$context = $this->option . '.edit.' . $this->context;
 			$task = $this->getTask();
 
-			$item = $model->getItem($app->getTemplate('template')->id);
+			$item = $model->getItem($app->getTemplate(true)->id);
 
 			// Setting received params
 			$item->set('params', $data);

--- a/components/com_config/controller/templates/display.php
+++ b/components/com_config/controller/templates/display.php
@@ -44,7 +44,7 @@ class ConfigControllerTemplatesDisplay extends ConfigControllerDisplay
 
 		// Set backend required params
 		$document->setType('json');
-		$this->input->set('id', $app->getTemplate('template')->id);
+		$this->input->set('id', $app->getTemplate(true)->id);
 
 		// Execute backend controller
 		$serviceData = json_decode($displayClass->display(), true);

--- a/components/com_config/controller/templates/save.php
+++ b/components/com_config/controller/templates/save.php
@@ -55,7 +55,7 @@ class ConfigControllerTemplatesSave extends JControllerBase
 
 		// Set backend required params
 		$document->setType('json');
-		$this->input->set('id', $app->getTemplate('template')->id);
+		$this->input->set('id', $app->getTemplate(true)->id);
 
 		// Execute backend controller
 		$return = $controllerClass->save();


### PR DESCRIPTION
### Summary of Changes
The method getTemplate() implemented in CMSApplication, SiteApplication and AdministratorApplication wants a bool as unique parameter.
Currently there are a few occurrences where a string is passed instead, which incidentally assumes the intended value (true) when implicitly converted to bool:
(bool)'template' → true

### Testing Instructions
To be merged on code review.

[Fixed on 4.0](https://github.com/joomla/joomla-cms/pull/19574) too.