### PR TITLE
[4.0] Enforced expected parameter type

### DIFF
--- a/administrator/components/com_templates/Controller/StyleController.php
+++ b/administrator/components/com_templates/Controller/StyleController.php
@@ -56,7 +56,7 @@ class StyleController extends FormController
 			$checkin = property_exists($table, 'checked_out');
 			$context = $this->option . '.edit.' . $this->context;
 
-			$item = $model->getItem($app->getTemplate('template')->id);
+			$item = $model->getItem($app->getTemplate(true)->id);
 
 			// Setting received params
 			$item->set('params', $data);

--- a/components/com_config/Controller/TemplatesController.php
+++ b/components/com_config/Controller/TemplatesController.php
@@ -94,7 +94,7 @@ class TemplatesController extends BaseController
 
 		// Set backend required params
 		$document->setType('json');
-		$this->input->set('id', $app->getTemplate('template')->id);
+		$this->input->set('id', $app->getTemplate(true)->id);
 
 		// Execute backend controller
 		$return = $controllerClass->save();


### PR DESCRIPTION
### Summary of Changes
The method getTemplate() implemented in CMSApplication, SiteApplication and AdministratorApplication wants a bool as unique parameter.
Currently there are a few occurrences where a string is passed instead, which incidentally assumes the intended value (true) when implicitly converted to bool:
(bool)'template' → true

### Testing Instructions
To be merged on code review.

[Fixed on staging](https://github.com/joomla/joomla-cms/pull/19573) too.