### PR TITLE
[4.0] Add a CLI command to run PHP session gc

### DIFF
--- a/libraries/src/Console/SessionGcCommand.php
+++ b/libraries/src/Console/SessionGcCommand.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Console;
+
+defined('JPATH_PLATFORM') or die;
+
+use Joomla\Console\AbstractCommand;
+use Joomla\Session\SessionInterface;
+
+/**
+ * Console command for performing session garbage collection
+ *
+ * @since  4.0.0
+ */
+class SessionGcCommand extends AbstractCommand
+{
+	/**
+	 * The session object.
+	 *
+	 * @var    SessionInterface
+	 * @since  4.0.0
+	 */
+	private $session;
+
+	/**
+	 * Instantiate the command.
+	 *
+	 * @param   SessionInterface  $session  The session object.
+	 *
+	 * @since   4.0.0
+	 */
+	public function __construct(SessionInterface $session)
+	{
+		$this->session = $session;
+
+		parent::__construct();
+	}
+
+	/**
+	 * Execute the command.
+	 *
+	 * @return  integer  The exit code for the command.
+	 *
+	 * @since   4.0.0
+	 */
+	public function execute(): int
+	{
+		$symfonyStyle = $this->createSymfonyStyle();
+
+		$symfonyStyle->title('Running Session Garbage Collection');
+
+		if ($this->session->gc() === false)
+		{
+			$symfonyStyle->error('Garbage collection was not completed. Either the operation failed or is not supported on your platform.');
+
+			return 1;
+		}
+
+		$symfonyStyle->success('Garbage collection completed.');
+
+		return 0;
+	}
+
+	/**
+	 * Initialise the command.
+	 *
+	 * @return  void
+	 *
+	 * @since   4.0.0
+	 */
+	protected function initialise()
+	{
+		$this->setName('session:gc');
+		$this->setDescription('Performs session garbage collection');
+		$this->setHelp(
+<<<EOF
+The <info>%command.name%</info> command runs PHP's garbage collection operation for session data
+
+<info>php %command.full_name%</info>
+EOF
+		);
+	}
+}

--- a/libraries/src/Factory.php
+++ b/libraries/src/Factory.php
@@ -500,6 +500,7 @@ abstract class Factory
 		$container = (new Container)
 			->registerServiceProvider(new \Joomla\CMS\Service\Provider\Application)
 			->registerServiceProvider(new \Joomla\CMS\Service\Provider\Authentication)
+			->registerServiceProvider(new \Joomla\CMS\Service\Provider\Console)
 			->registerServiceProvider(new \Joomla\CMS\Service\Provider\Database)
 			->registerServiceProvider(new \Joomla\CMS\Service\Provider\Dispatcher)
 			->registerServiceProvider(new \Joomla\CMS\Service\Provider\Document)

--- a/libraries/src/Service/Provider/Application.php
+++ b/libraries/src/Service/Provider/Application.php
@@ -11,6 +11,7 @@ namespace Joomla\CMS\Service\Provider;
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\CMS\Console\SessionGcCommand;
 use Joomla\Console\Application as BaseConsoleApplication;
 use Joomla\CMS\Application\AdministratorApplication;
 use Joomla\CMS\Application\ConsoleApplication;
@@ -18,6 +19,8 @@ use Joomla\CMS\Application\SiteApplication;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Log\Log;
 use Joomla\CMS\Session\Session;
+use Joomla\Console\Loader\ContainerLoader;
+use Joomla\Console\Loader\LoaderInterface;
 use Joomla\DI\Container;
 use Joomla\DI\ServiceProviderInterface;
 use Joomla\Session\Storage\RuntimeStorage;
@@ -97,12 +100,27 @@ class Application implements ServiceProviderInterface
 					$session = new Session(new RuntimeStorage);
 					$session->setDispatcher($dispatcher);
 
+					$app->setCommandLoader($container->get(LoaderInterface::class));
 					$app->setContainer($container);
 					$app->setDispatcher($dispatcher);
 					$app->setLogger($container->get(LoggerInterface::class));
 					$app->setSession($session);
 
 					return $app;
+				},
+				true
+			);
+
+		$container->alias(ContainerLoader::class, LoaderInterface::class)
+			->share(
+				LoaderInterface::class,
+				function (Container $container)
+				{
+					$mapping = [
+						'session:gc' => SessionGcCommand::class,
+					];
+
+					return new ContainerLoader($container, $mapping);
 				},
 				true
 			);

--- a/libraries/src/Service/Provider/Console.php
+++ b/libraries/src/Service/Provider/Console.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * @package     Joomla.Libraries
+ * @subpackage  Service
+ *
+ * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\CMS\Service\Provider;
+
+defined('JPATH_PLATFORM') or die;
+
+use Joomla\CMS\Console\SessionGcCommand;
+use Joomla\DI\Container;
+use Joomla\DI\ServiceProviderInterface;
+
+/**
+ * Service provider for the application's console services
+ *
+ * @since  4.0
+ */
+class Console implements ServiceProviderInterface
+{
+	/**
+	 * Registers the service provider with a DI container.
+	 *
+	 * @param   Container  $container  The DI container.
+	 *
+	 * @return  void
+	 *
+	 * @since   4.0
+	 */
+	public function register(Container $container)
+	{
+		$container->share(
+			SessionGcCommand::class,
+			function (Container $container)
+			{
+				return new SessionGcCommand($container->get('session'));
+			},
+			true
+		);
+	}
+}


### PR DESCRIPTION
### Summary of Changes

This is in essence the same thing as https://github.com/joomla/joomla-cms/pull/19548 but converted for 4.0 with the changes in the CLI runner and the session API in place.

This also defines a core service for lazy loading console commands so that command classes with dependencies don't have to arbitrarily be loaded at all times.

### Testing Instructions

With the patch applied, run `php cli/joomla.php session:gc` to trigger the command.  If running PHP 7.0 or the operation fails, you'll get an error message; otherwise you'll get a success message.  Note the PHP 7.0 error condition is because the Framework's default implementation of `SessionInterface::gc()` relies on PHP's `session_gc()` function, which is not available before PHP 7.1, and the function does not have a userland polyfill at this time.