### PR TITLE
[3.9] Create a manager class for the session metadata handling

### DIFF
--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -11,6 +11,7 @@ namespace Joomla\CMS\Application;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Input\Input;
+use Joomla\CMS\Session\MetadataManager;
 use Joomla\Registry\Registry;
 
 /**
@@ -63,6 +64,14 @@ class CMSApplication extends WebApplication
 	protected $_messageQueue = array();
 
 	/**
+	 * The session metadata manager
+	 *
+	 * @var    MetadataManager
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $metadataManager = null;
+
+	/**
 	 * The name of the application.
 	 *
 	 * @var    array
@@ -105,6 +114,8 @@ class CMSApplication extends WebApplication
 	public function __construct(Input $input = null, Registry $config = null, \JApplicationWebClient $client = null)
 	{
 		parent::__construct($input, $config, $client);
+
+		$this->metadataManager = new MetadataManager($this, \JFactory::getDbo());
 
 		// Load and set the dispatcher
 		$this->loadDispatcher();
@@ -159,30 +170,13 @@ class CMSApplication extends WebApplication
 		// If the database session handler is not in use and the current time is a divisor of 5, purge session metadata after the response is sent
 		if ($handler !== 'database' && $time % 5 === 0)
 		{
+			$manager = $this->metadataManager;
+
 			$this->registerEvent(
 				'onAfterRespond',
-				function () use ($session, $time)
+				function () use ($session, $time, $manager)
 				{
-					// TODO: At some point we need to get away from having session data always in the db.
-					$db = \JFactory::getDbo();
-
-					$query = $db->getQuery(true)
-						->delete($db->quoteName('#__session'))
-						->where($db->quoteName('time') . ' < ' . $db->quote((int) ($time - $session->getExpire())));
-
-					$db->setQuery($query);
-
-					try
-					{
-						$db->execute();
-					}
-					catch (\JDatabaseExceptionExecuting $exception)
-					{
-						/*
-						 * The database API logs errors on failures so we don't need to add any error handling mechanisms here.
-						 * Since garbage collection does not result in a fatal error when run in the session API, we don't allow it here either.
-						 */
-					}
+					$manager->deletePriorTo((int) ($time - $session->getExpire()));
 				}
 			);
 		}
@@ -201,63 +195,7 @@ class CMSApplication extends WebApplication
 	 */
 	public function checkSession()
 	{
-		$db = \JFactory::getDbo();
-		$session = \JFactory::getSession();
-		$user = \JFactory::getUser();
-
-		$query = $db->getQuery(true)
-			->select($db->quoteName('session_id'))
-			->from($db->quoteName('#__session'))
-			->where($db->quoteName('session_id') . ' = ' . $db->quote($session->getId()));
-
-		$db->setQuery($query, 0, 1);
-		$exists = $db->loadResult();
-
-		// If the session record doesn't exist initialise it.
-		if (!$exists)
-		{
-			$query->clear();
-
-			$time = $session->isNew() ? time() : $session->get('session.timer.start');
-
-			$columns = array(
-				$db->quoteName('session_id'),
-				$db->quoteName('guest'),
-				$db->quoteName('time'),
-				$db->quoteName('userid'),
-				$db->quoteName('username'),
-			);
-
-			$values = array(
-				$db->quote($session->getId()),
-				(int) $user->guest,
-				$db->quote((int) $time),
-				(int) $user->id,
-				$db->quote($user->username),
-			);
-
-			if (!$this->get('shared_session', '0'))
-			{
-				$columns[] = $db->quoteName('client_id');
-				$values[] = (int) $this->getClientId();
-			}
-
-			$query->insert($db->quoteName('#__session'))
-				->columns($columns)
-				->values(implode(', ', $values));
-
-			$db->setQuery($query);
-
-			// If the insert failed, exit the application.
-			try
-			{
-				$db->execute();
-			}
-			catch (\RuntimeException $e)
-			{
-				throw new \RuntimeException(\JText::_('JERROR_SESSION_STARTUP'), $e->getCode(), $e);
-			}
-		}
+		$this->metadataManager->createRecordIfNonExisting(\JFactory::getSession(), \JFactory::getUser());
 	}
 
 	/**

--- a/libraries/src/Session/MetadataManager.php
+++ b/libraries/src/Session/MetadataManager.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  Copyright (C) 2005 - 2018 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Session;
+
+defined('JPATH_PLATFORM') or die;
+
+use Joomla\CMS\Application\CMSApplication;
+use Joomla\CMS\User\User;
+
+/**
+ * Manager for optional session metadata.
+ *
+ * @since  __DEPLOY_VERSION__
+ * @internal
+ */
+final class MetadataManager
+{
+	/**
+	 * Application object.
+	 *
+	 * @var    CMSApplication
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $app;
+
+	/**
+	 * Database driver.
+	 *
+	 * @var    \JDatabaseDriver
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $db;
+
+	/**
+	 * MetadataManager constructor.
+	 *
+	 * @param   CMSApplication    $app  Application object.
+	 * @param   \JDatabaseDriver  $db   Database driver.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function __construct(CMSApplication $app, \JDatabaseDriver $db)
+	{
+		$this->app = $app;
+		$this->db  = $db;
+	}
+
+	/**
+	 * Create the metadata record if it does not exist.
+	 *
+	 * @param   Session  $session  The session to create the metadata record for.
+	 * @param   User     $user     The user to associate with the record.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  \RuntimeException
+	 */
+	public function createRecordIfNonExisting(Session $session, User $user)
+	{
+		$query = $this->db->getQuery(true)
+			->select($this->db->quoteName('session_id'))
+			->from($this->db->quoteName('#__session'))
+			->where($this->db->quoteName('session_id') . ' = ' . $this->db->quote($session->getId()));
+
+		$this->db->setQuery($query, 0, 1);
+		$exists = $this->db->loadResult();
+
+		// If the session record doesn't exist initialise it.
+		if ($exists)
+		{
+			return;
+		}
+
+		$query->clear();
+
+		$time = $session->isNew() ? time() : $session->get('session.timer.start');
+
+		$columns = array(
+			$this->db->quoteName('session_id'),
+			$this->db->quoteName('guest'),
+			$this->db->quoteName('time'),
+			$this->db->quoteName('userid'),
+			$this->db->quoteName('username'),
+		);
+
+		$values = array(
+			$this->db->quote($session->getId()),
+			(int) $user->guest,
+			$this->db->quote((int) $time),
+			(int) $user->id,
+			$this->db->quote($user->username),
+		);
+
+		if (!$this->app->get('shared_session', '0'))
+		{
+			$columns[] = $this->db->quoteName('client_id');
+			$values[] = (int) $this->app->getClientId();
+		}
+
+		$query->insert($this->db->quoteName('#__session'))
+			->columns($columns)
+			->values(implode(', ', $values));
+
+		$this->db->setQuery($query);
+
+		try
+		{
+			$this->db->execute();
+		}
+		catch (\RuntimeException $e)
+		{
+			/*
+			 * Because of how our session handlers are structured, we must abort the request if this insert query fails,
+			 * especially in the case of the database handler which does not support "INSERT or UPDATE" logic. With the
+			 * change to the `joomla/session` Framework package in 4.0, where the required logic is implemented in the
+			 * handlers, we can change this catch block so that the error is gracefully handled and does not result
+			 * in a fatal error for the request.
+			 */
+			throw new \RuntimeException(\JText::_('JERROR_SESSION_STARTUP'), $e->getCode(), $e);
+		}
+	}
+
+	/**
+	 * Delete records with a timestamp prior to the given time.
+	 *
+	 * @param   integer  $time  The time records should be deleted if expired before.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function deletePriorTo($time)
+	{
+		$query = $this->db->getQuery(true)
+			->delete($this->db->quoteName('#__session'))
+			->where($this->db->quoteName('time') . ' < ' . $this->db->quote($time));
+
+		$this->db->setQuery($query);
+
+		try
+		{
+			$this->db->execute();
+		}
+		catch (\JDatabaseExceptionExecuting $exception)
+		{
+			/*
+			 * The database API logs errors on failures so we don't need to add any error handling mechanisms here.
+			 * Since garbage collection does not result in a fatal error when run in the session API, we don't allow it here either.
+			 */
+		}
+	}
+}


### PR DESCRIPTION
### Summary of Changes

In order to do things like be able to set up a cron job to run the session metadata purge operation (versus having it arbitrarily run on select HTTP requests based on very subjective criteria), we need to extract the processes performing CRUD operations on this data to a separate service class.  This PR accomplishes just that.

A new `MetadataManager` class is created which is now used for creating metadata records as needed and deleting selected records.  This class is purposefully declared final and annotated `@internal` as this should not be an extension integration point and its definition will change when merged to the 4.0 branch.  For now it is only used by the application class to do the same operations that are already happening, but as an example a new CLI script and global config option can be added so that users can turn off the cleanup operation in web requests and fully manage this in cron jobs.

### Testing Instructions

For now, nothing should change.  So, session metadata should still be written when a new session created, and the delete operation triggered based on the changed criteria of 3.8.4 (a second on a divisor of 5 when non-database handlers are in use).