### PR TITLE
Fix JRoute('&var=...') not adding current URL variables when current URL is the home page

### DIFF
--- a/libraries/src/Router/SiteRouter.php
+++ b/libraries/src/Router/SiteRouter.php
@@ -299,7 +299,7 @@ class SiteRouter extends Router
 			// If user not allowed to see default menu item then avoid notices
 			if (is_object($item))
 			{
-				// Set query variables of default menu item into the request, keeping existing request variables
+				// Set query variables of default menu item into the request, but keep existing request variables
 				$vars = array_merge($vars, $item->query);
 
 				// Get the itemid

--- a/libraries/src/Router/SiteRouter.php
+++ b/libraries/src/Router/SiteRouter.php
@@ -299,8 +299,8 @@ class SiteRouter extends Router
 			// If user not allowed to see default menu item then avoid notices
 			if (is_object($item))
 			{
-				// Set the information in the request
-				$vars = $item->query;
+				// Set query variables of default menu item into the request, keeping existing request variables
+				$vars = array_merge($vars, $item->query);
 
 				// Get the itemid
 				$vars['Itemid'] = $item->id;

--- a/tests/unit/suites/libraries/cms/router/JRouterSiteTest.php
+++ b/tests/unit/suites/libraries/cms/router/JRouterSiteTest.php
@@ -692,7 +692,7 @@ class JRouterSiteTest extends TestCaseDatabase
 				'url'          => '?testvar=testvalue',
 				'mode'         => JROUTER_MODE_RAW,
 				'appConfig'    => array(),
-				'expParseVars' => array('testvar' => 'testvalue'),
+				'expParseVars' => array('testvar' => 'testvalue', 'Itemid' => '45', 'option' => 'com_test3', 'view' => 'test3'),
 				'expObjVars'   => array('testvar' => 'testvalue', 'Itemid' => '45', 'option' => 'com_test3', 'view' => 'test3')
 			),
 			'abs-raw-path.ext-no_qs-no_sfx' => array(

--- a/tests/unit/suites/libraries/cms/router/JRouterSiteTest.php
+++ b/tests/unit/suites/libraries/cms/router/JRouterSiteTest.php
@@ -692,8 +692,8 @@ class JRouterSiteTest extends TestCaseDatabase
 				'url'          => '?testvar=testvalue',
 				'mode'         => JROUTER_MODE_RAW,
 				'appConfig'    => array(),
-				'expParseVars' => array('Itemid' => '45', 'option' => 'com_test3', 'view' => 'test3'),
-				'expObjVars'   => array('Itemid' => '45', 'option' => 'com_test3', 'view' => 'test3')
+				'expParseVars' => array('testvar' => 'testvalue'),
+				'expObjVars'   => array('testvar' => 'testvalue', 'Itemid' => '45', 'option' => 'com_test3', 'view' => 'test3')
 			),
 			'abs-raw-path.ext-no_qs-no_sfx' => array(
 				'url'          => '/test/path.json',


### PR DESCRIPTION
Pull Request for Issue #19579 

### Summary of Changes
Patch parseSefRoute(&$uri) method in SiteRouter
to add current URL variables when 
- current page is the home page
- and calling `JRoute('&var=...')`

### Testing Instructions
Create a paginated home page

Visit home page and in addressbar also add
`?hello=1&world=2`

e.g.  `localhost/joomla3xtext/en/?hello=1&world=2`

### Expected result
Look at the pagination (page) links, the should be

`localhost/joomla3xtext/en/?hello=1&world=2&start=5`
`localhost/joomla3xtext/en/?hello=1&world=2&start=10`

### Actual result
`localhost/joomla3xtext/en/?start=5`
`localhost/joomla3xtext/en/?start=10`


### Documentation Changes Required
None
