### PR TITLE
fix undefined offset when batch copy parent menu

### DIFF
--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -279,11 +279,6 @@ abstract class AdminModel extends FormModel
 
 				if (is_array($result))
 				{
-					foreach ($result as $old => $new)
-					{
-						$contexts[$new] = $contexts[$old];
-					}
-
 					$pks = array_values($result);
 				}
 				else


### PR DESCRIPTION
Pull Request for Issue #19547.

### Summary of Changes
fix undefined offset when batch copy parent menu


### Testing Instructions
see #19547
all batch copy work as before

### Expected result
no notice in error.log



### Actual result
PHP Notice:  Undefined offset: 290 in \libraries\src\MVC\Model\AdminModel.php on line 284


