### PR TITLE
Fix usage of jasmine jquery in async context

### DIFF
--- a/tests/javascript/validate/spec.js
+++ b/tests/javascript/validate/spec.js
@@ -9,11 +9,11 @@
  * @version     1.0.0
  */
 
-define(['jquery', 'testsRoot/validate/spec-setup', 'jasmineJquery'], function ($) {
+define(['jquery', 'testsRoot/validate/spec-setup', 'jasmineJquery'], ($) => {
 	var $element = $('#validatejs');
 
-	describe('Validate', function () {
-		beforeAll(function () {
+	describe('Validate', () => {
+		beforeAll(() => {
 			var ob = {
 				'JLIB_FORM_CONTAINS_INVALID_FIELDS': 'invalid',
 				'JLIB_FORM_FIELD_REQUIRED_VALUE': 'required',
@@ -34,72 +34,72 @@ define(['jquery', 'testsRoot/validate/spec-setup', 'jasmineJquery'], function ($
 			Joomla.JText._ = jtxtFn;
 		});
 
-		describe('The input fields in the form', function () {
-			it('with class \'required\' should have attributes aria-required = true', function () {
+		describe('The input fields in the form', () => {
+			it('with class \'required\' should have attributes aria-required = true', () => {
 				expect($element.find('#attach-to-form input')).toHaveAttr('aria-required', 'true');
 			});
 
-			it('with class \'required\' should have attributes required = required', function () {
+			it('with class \'required\' should have attributes required = required', () => {
 				expect($element.find('#attach-to-form input')).toHaveAttr('required');
 			});
 		});
 
-		describe('The textarea fields in the form', function () {
-			it('with class \'required\' should have attributes aria-required = true', function () {
+		describe('The textarea fields in the form', () => {
+			it('with class \'required\' should have attributes aria-required = true', () => {
 				expect($element.find('#attach-to-form textarea')).toHaveAttr('aria-required', 'true');
 			});
 
-			it('with class \'required\' should have attributes required = required', function () {
+			it('with class \'required\' should have attributes required = required', () => {
 				expect($element.find('#attach-to-form textarea')).toHaveAttr('required');
 			});
 		});
 
-		describe('The select fields in the form', function () {
-			it('with class \'required\' should have attributes aria-required = true', function () {
+		describe('The select fields in the form', () => {
+			it('with class \'required\' should have attributes aria-required = true', () => {
 				expect($element.find('#attach-to-form select')).toHaveAttr('aria-required', 'true');
 			});
 
-			it('with class \'required\' should have attributes required = required', function () {
+			it('with class \'required\' should have attributes required = required', () => {
 				expect($element.find('#attach-to-form select')).toHaveAttr('required');
 			});
 		});
 
-		describe('The fieldset fields in the form', function () {
-			it('with class \'required\' should have attributes aria-required = true', function () {
+		describe('The fieldset fields in the form', () => {
+			it('with class \'required\' should have attributes aria-required = true', () => {
 				expect($element.find('#attach-to-form fieldset')).toHaveAttr('aria-required', 'true');
 			});
 
-			it('with class \'required\' should have attributes required = required', function () {
+			it('with class \'required\' should have attributes required = required', () => {
 				expect($element.find('#attach-to-form fieldset')).toHaveAttr('required');
 			});
 		});
 
-		describe('validate method on #validate-disabled', function () {
+		describe('validate method on #validate-disabled', () => {
 			var res = document.formvalidator.validate($element.find('#validate-disabled').get(0));
 
-			it('should return true', function () {
+			it('should return true', () => {
 				expect(res).toEqual(true);
 			});
 
-			it('should remove class invalid from element', function () {
+			it('should remove class invalid from element', () => {
 				expect($element.find('#validate-disabled')).not.toHaveClass('invalid');
 			});
 
-			it('should have aria-invalid = false in element', function () {
+			it('should have aria-invalid = false in element', () => {
 				expect($element.find('#validate-disabled')).toHaveAttr('aria-invalid', 'false');
 			});
 
-			it('should remove class invalid from the label for element', function () {
+			it('should remove class invalid from the label for element', () => {
 				expect($element.find('#validate-test label[for=validate-disabled]')).not.toHaveClass('invalid');
 			});
 		});
 
 		// @TODO re add the 'validate method on #validate-required-unchecked' tests
 
-		describe('validate method on #validate-required-checked', function () {
+		describe('validate method on #validate-required-checked', () => {
 			var res = document.formvalidator.validate($element.find('#validate-required-checked').get(0));
 
-			it('should return true', function () {
+			it('should return true', () => {
 				expect(res).toEqual(true);
 			});
 		});
@@ -111,92 +111,96 @@ define(['jquery', 'testsRoot/validate/spec-setup', 'jasmineJquery'], function ($
 				expect(res).toEqual(true);
 			});
 
-			it('should remove class invalid from element', function () {
+			it('should remove class invalid from element', () => {
 				expect($element.find('#validate-numeric-number')).not.toHaveClass('invalid');
 			});
 
-			it('should have aria-invalid = false in element', function () {
+			it('should have aria-invalid = false in element', () => {
 				expect($element.find('#validate-numeric-number')).toHaveAttr('aria-invalid', 'false');
 			});
 
-			it('should remove class invalid from the label for element', function () {
+			it('should remove class invalid from the label for element', () => {
 				expect($element.find('#validate-numeric-number-lbl')).not.toHaveClass('invalid');
 			});
 		});
 
-		describe('validate method on #validate-numeric-nan', function () {
+		describe('validate method on #validate-numeric-nan', () => {
 			var elNan   = document.getElementById('validate-numeric-nan'),
 				res = document.formvalidator.validate(elNan);
 
-			it('should return false', function () {
+			it('should return false', () => {
 				expect(res).toEqual(false);
 			});
 
-			it('should add class invalid to element', function () {
-				setTimeout(function() {
-					expect(elNan).toHaveClass('invalid');
+			it('should add class invalid to element', (done) => {
+				setTimeout(() => {
+					expect(elNan.classList).toContain('invalid');
+					done();
 				}, 100)
 			});
 
-			it('should have aria-invalid = true in element', function () {
-				setTimeout(function() {
-					expect(elNan).toHaveAttr('aria-invalid', 'true');
+			it('should have aria-invalid = true in element', (done) => {
+				setTimeout(() => {
+					expect(elNan.getAttribute('aria-invalid')).toEqual('true');
+					done();
 				}, 100)
 			});
 
-			it('should add class invalid to the label for element', function () {
-				setTimeout(function() {
-					expect(document.querySelector('[for="validate-numeric-nan"]')).toHaveClass('invalid');
+			it('should add class invalid to the label for element', (done) => {
+				setTimeout(() => {
+					expect(document.querySelector('[for="validate-numeric-nan"]').classList).toContain('invalid');
+					done();
 				}, 100)
 			});
 		});
 
-		describe('validate method on #validate-no-options', function () {
+		describe('validate method on #validate-no-options', () => {
 			var res = document.formvalidator.validate($element.find('#validate-no-options').get(0));
 
-			it('should return true', function () {
+			it('should return true', () => {
 				expect(res).toEqual(true);
 			});
 
-			it('should remove class invalid from element', function () {
+			it('should remove class invalid from element', () => {
 				expect($element.find('#validate-no-options')).not.toHaveClass('invalid');
 			});
 
-			it('should have aria-invalid = false in element', function () {
+			it('should have aria-invalid = false in element', () => {
 				expect($element.find('#validate-no-options')).toHaveAttr('aria-invalid', 'false');
 			});
 		});
 
-		describe('isValid method on button click', function () {
-			beforeAll(function () {
+		describe('isValid method on button click', () => {
+			beforeAll(() => {
 				document.getElementById('button').click();
 			});
 
-			it('should call Joomla.JText._(\'JLIB_FORM_CONTAINS_INVALID_FIELDS\')', function () {
+			it('should call Joomla.JText._(\'JLIB_FORM_CONTAINS_INVALID_FIELDS\')', () => {
 				expect(Joomla.JText._).toHaveBeenCalledWith('JLIB_FORM_CONTAINS_INVALID_FIELDS');
 			});
 
-			it('should add class invalid to element #isvalid-numeric-nan', function () {
+			it('should add class invalid to element #isvalid-numeric-nan', () => {
 				expect(document.getElementById('isvalid-numeric-nan')).toHaveClass('invalid');
 			});
 
-			it('should have aria-invalid = true in element #isvalid-numeric-nan', function () {
+			it('should have aria-invalid = true in element #isvalid-numeric-nan', () => {
 				expect($element.find('#isvalid-numeric-nan')).toHaveAttr('aria-invalid', 'true');
 			});
 
-			it('should not add class invalid to element #isvalid-novalidate', function () {
+			it('should not add class invalid to element #isvalid-novalidate', () => {
 				expect($element.find('#isvalid-novalidate')).not.toHaveClass('invalid');
 			});
 		});
 
-		describe('Invalid element should become valid when passing the correct data', function () {
+		describe('Invalid element should become valid when passing the correct data', () => {
 
-			it('should remove class invalid from element #isvalid-numeric-nan after correcting value', function () {
+			it('should remove class invalid from element #isvalid-numeric-nan after correcting value', (done) => {
 				document.getElementById('isvalid-numeric-nan').setAttribute('value', 12345);
 				document.getElementById('button').click();
 
-				setTimeout(function() {
-					expect($element.find('#isvalid-numeric-nan')).not.toHaveClass('invalid');
+				setTimeout(() => {
+					expect($element.find('#isvalid-numeric-nan').classList).not.toContain('invalid');
+					done();
 				}, 100)
 			});
 		});


### PR DESCRIPTION
Our Javascript tests and our setup for automated testing is quite unstable right now. This should fix the random fails. 

+ Fix usage of jasmine-jquery in async context (use native js instead)
+ use es6 arrow functions in tests

### Testing Instructions
Let the javascript test running and check the results (see https://docs.joomla.org/Running_JavaScript_Tests_for_the_Joomla_CMS)

### Expected result
no failures

### Actual result
failes from time to time