### PR TITLE
Improve header handling in PageController cache

### DIFF
--- a/libraries/src/Cache/Controller/PageController.php
+++ b/libraries/src/Cache/Controller/PageController.php
@@ -207,7 +207,8 @@ class PageController extends CacheController
 		$app = \JFactory::getApplication();
 
 		// Send not modified header and exit gracefully
-		header('HTTP/1.x 304 Not Modified', true);
+		$app->setHeader('Status', 304, true);
+		$app->sendHeaders();
 		$app->close();
 	}
 
@@ -222,6 +223,6 @@ class PageController extends CacheController
 	 */
 	protected function _setEtag($etag)
 	{
-		\JFactory::getApplication()->setHeader('ETag', $etag, true);
+		\JFactory::getApplication()->setHeader('ETag', '"' . $etag . '"', true);
 	}
 }


### PR DESCRIPTION
Partial Pull Request for Issue #17192

### Summary of Changes

- Sets the 304 response header through our web application's API and sends all of the application's registered headers before exiting
- Quotes the value of the `ETag` header as should be done

### Testing Instructions

Primarily code review as personally I'm not sure how to trigger the circumstances which causes this code path to be triggered