### PR TITLE
Handle modified date in Document objects consistently

### DIFF
--- a/libraries/src/Document/Document.php
+++ b/libraries/src/Document/Document.php
@@ -10,6 +10,8 @@ namespace Joomla\CMS\Document;
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\CMS\Date\Date;
+
 /**
  * Document class, provides an easy interface to parse and display a document
  *
@@ -69,13 +71,14 @@ class Document
 	 * Document generator
 	 *
 	 * @var    string
+	 * @since  11.1
 	 */
 	public $_generator = 'Joomla! - Open Source Content Management';
 
 	/**
 	 * Document modified date
 	 *
-	 * @var    string
+	 * @var    string|Date
 	 * @since  11.1
 	 */
 	public $_mdate = '';
@@ -1035,14 +1038,27 @@ class Document
 	/**
 	 * Sets the document modified date
 	 *
-	 * @param   string  $date  The date to be set
+	 * @param   string|Date  $date  The date to be set
 	 *
 	 * @return  Document instance of $this to allow chaining
 	 *
 	 * @since   11.1
+	 * @throws  \InvalidArgumentException
 	 */
 	public function setModifiedDate($date)
 	{
+		if (!is_string($date) && !($date instanceof Date))
+		{
+			throw new \InvalidArgumentException(
+				sprintf(
+					'The $date parameter of %1$s must be a string or a %2$s instance, a %3$s was given.',
+					__METHOD__ . '()',
+					'Joomla\\CMS\\Date\\Date',
+					gettype($date) === 'object' ? (get_class($date) . ' instance') : gettype($date)
+				)
+			);
+		}
+
 		$this->_mdate = $date;
 
 		return $this;
@@ -1051,7 +1067,7 @@ class Document
 	/**
 	 * Returns the document modified date
 	 *
-	 * @return  string
+	 * @return  string|Date
 	 *
 	 * @since   11.1
 	 */
@@ -1252,6 +1268,11 @@ class Document
 
 		if ($mdate = $this->getModifiedDate())
 		{
+			if (!($mdate instanceof Date))
+			{
+				$mdate = new Date($mdate);
+			}
+
 			$app->modifiedDate = $mdate;
 		}
 


### PR DESCRIPTION
### Summary of Changes

The `Joomla\CMS\Document\Document` API supports setting a response's modified date, however this method is actually unused in core therefore nothing actually sets this to have found that it is broken.  The Document API takes this value as a string, however the property it sets in `Joomla\CMS\Application\WebApplication` is expected to be a `Joomla\CMS\Date\Date` object.  Using the current behavior, even if one were to call `$document->setModifiedDate('2017-12-31');` the value would never be set as a response header because the web application validates the property is a Date object before processing it.

This PR addresses the type mismatching by documenting the `$_mdate` property of the Document as supporting either a string or a Date object, converts the value to a Date object if it is a string before setting it to the application for use in the response headers, and changes the `setModifiedDate()` method to type check and throw an Exception if an invalid type is given.

### Testing Instructions

Code review as this code path is unused in core.