### PR TITLE
[4.0] Split the configuration of the session service on a per-application basis, restructure session GC command

### DIFF
--- a/administrator/includes/app.php
+++ b/administrator/includes/app.php
@@ -39,7 +39,13 @@ JDEBUG ? JProfiler::getInstance('Application')->setStart($startTime, $startMem)-
 // Boot the DI container
 $container = \Joomla\CMS\Factory::getContainer();
 
-// Alias the session service keys to the web session service as that is the primary session backend for this application
+/*
+ * Alias the session service keys to the web session service as that is the primary session backend for this application
+ *
+ * In addition to aliasing "common" service keys, we also create aliases for the PHP classes to ensure autowiring objects
+ * is supported.  This includes aliases for aliased class names, and the keys for alised class names should be considered
+ * deprecated to be removed when the class name alias is removed as well.
+ */
 $container->alias('session.web', 'session.web.administrator')
 	->alias('session', 'session.web.administrator')
 	->alias('JSession', 'session.web.administrator')

--- a/administrator/includes/app.php
+++ b/administrator/includes/app.php
@@ -36,8 +36,19 @@ require_once JPATH_BASE . '/includes/framework.php';
 // Set profiler start time and memory usage and mark afterLoad in the profiler.
 JDEBUG ? JProfiler::getInstance('Application')->setStart($startTime, $startMem)->mark('afterLoad') : null;
 
+// Boot the DI container
+$container = \Joomla\CMS\Factory::getContainer();
+
+// Alias the session service keys to the web session service as that is the primary session backend for this application
+$container->alias('session.web', 'session.web.administrator')
+	->alias('session', 'session.web.administrator')
+	->alias('JSession', 'session.web.administrator')
+	->alias(\Joomla\CMS\Session\Session::class, 'session.web.administrator')
+	->alias(\Joomla\Session\Session::class, 'session.web.administrator')
+	->alias(\Joomla\Session\SessionInterface::class, 'session.web.administrator');
+
 // Instantiate the application.
-$app = \Joomla\CMS\Factory::getContainer()->get(\Joomla\CMS\Application\AdministratorApplication::class);
+$app = $container->get(\Joomla\CMS\Application\AdministratorApplication::class);
 
 // Set the application as global app
 \Joomla\CMS\Factory::$application = $app;

--- a/cli/joomla.php
+++ b/cli/joomla.php
@@ -34,6 +34,16 @@ if (!file_exists(JPATH_LIBRARIES . '/vendor/autoload.php') || !is_dir(JPATH_ROOT
 // Get the framework.
 require_once JPATH_BASE . '/includes/framework.php';
 
+// Boot the DI container
+$container = \Joomla\CMS\Factory::getContainer();
+
+// Alias the session service keys to the CLI session service as that is the primary session backend for this application
+$container->alias('session', 'session.cli')
+	->alias('JSession', 'session.cli')
+	->alias(\Joomla\CMS\Session\Session::class, 'session.cli')
+	->alias(\Joomla\Session\Session::class, 'session.cli')
+	->alias(\Joomla\Session\SessionInterface::class, 'session.cli');
+
 $app = \Joomla\CMS\Factory::getContainer()->get(\Joomla\Console\Application::class);
 \Joomla\CMS\Factory::$application = $app;
 $app->execute();

--- a/cli/joomla.php
+++ b/cli/joomla.php
@@ -37,7 +37,13 @@ require_once JPATH_BASE . '/includes/framework.php';
 // Boot the DI container
 $container = \Joomla\CMS\Factory::getContainer();
 
-// Alias the session service keys to the CLI session service as that is the primary session backend for this application
+/*
+ * Alias the session service keys to the CLI session service as that is the primary session backend for this application
+ *
+ * In addition to aliasing "common" service keys, we also create aliases for the PHP classes to ensure autowiring objects
+ * is supported.  This includes aliases for aliased class names, and the keys for alised class names should be considered
+ * deprecated to be removed when the class name alias is removed as well.
+ */
 $container->alias('session', 'session.cli')
 	->alias('JSession', 'session.cli')
 	->alias(\Joomla\CMS\Session\Session::class, 'session.cli')

--- a/composer.json
+++ b/composer.json
@@ -79,6 +79,7 @@
         "symfony/console": "3.4.*",
         "symfony/debug": "3.4.*",
         "symfony/ldap": "3.4.*",
+        "symfony/options-resolver": "3.4.*",
         "symfony/web-link": "3.4.*",
         "symfony/yaml": "3.4.*",
         "wamania/php-stemmer": "^1.2"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "81c9ca521a0712b07e07143b469e835a",
+    "content-hash": "5749677e2afdf181fc07ea6b394cbe40",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -3675,12 +3675,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-projects/joomla-browser.git",
-                "reference": "9020a33c3b14aadb86057eb25b61305e63a15e86"
+                "reference": "13c12ee493a4f5bad482dd601e86db52b2918714"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-projects/joomla-browser/zipball/9020a33c3b14aadb86057eb25b61305e63a15e86",
-                "reference": "9020a33c3b14aadb86057eb25b61305e63a15e86",
+                "url": "https://api.github.com/repos/joomla-projects/joomla-browser/zipball/13c12ee493a4f5bad482dd601e86db52b2918714",
+                "reference": "13c12ee493a4f5bad482dd601e86db52b2918714",
                 "shasum": ""
             },
             "require": {
@@ -3718,7 +3718,7 @@
                 "acceptance testing",
                 "joomla"
             ],
-            "time": "2018-05-15T13:46:14+00:00"
+            "time": "2018-08-06T11:31:54+00:00"
         },
         {
             "name": "joomla-projects/robo-joomla",
@@ -3861,12 +3861,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla/test-system.git",
-                "reference": "472c69aad1db7fbad67b07311ced5a21336366e1"
+                "reference": "0548840f05f4fcb0671f0ef1ff5acd978565ebb1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla/test-system/zipball/472c69aad1db7fbad67b07311ced5a21336366e1",
-                "reference": "472c69aad1db7fbad67b07311ced5a21336366e1",
+                "url": "https://api.github.com/repos/joomla/test-system/zipball/0548840f05f4fcb0671f0ef1ff5acd978565ebb1",
+                "reference": "0548840f05f4fcb0671f0ef1ff5acd978565ebb1",
                 "shasum": ""
             },
             "require": {
@@ -3887,7 +3887,7 @@
                 "cms",
                 "joomla"
             ],
-            "time": "2018-05-15T13:20:55+00:00"
+            "time": "2018-07-28T21:13:03+00:00"
         },
         {
             "name": "joomla/test-unit",

--- a/includes/app.php
+++ b/includes/app.php
@@ -36,8 +36,19 @@ require_once JPATH_BASE . '/includes/framework.php';
 // Set profiler start time and memory usage and mark afterLoad in the profiler.
 JDEBUG ? JProfiler::getInstance('Application')->setStart($startTime, $startMem)->mark('afterLoad') : null;
 
-// Get the application.
-$app = \Joomla\CMS\Factory::getContainer()->get(\Joomla\CMS\Application\SiteApplication::class);
+// Boot the DI container
+$container = \Joomla\CMS\Factory::getContainer();
+
+// Alias the session service keys to the web session service as that is the primary session backend for this application
+$container->alias('session.web', 'session.web.site')
+	->alias('session', 'session.web.site')
+	->alias('JSession', 'session.web.site')
+	->alias(\Joomla\CMS\Session\Session::class, 'session.web.site')
+	->alias(\Joomla\Session\Session::class, 'session.web.site')
+	->alias(\Joomla\Session\SessionInterface::class, 'session.web.site');
+
+// Instantiate the application.
+$app = $container->get(\Joomla\CMS\Application\SiteApplication::class);
 
 // Set the application as global app
 \Joomla\CMS\Factory::$application = $app;

--- a/includes/app.php
+++ b/includes/app.php
@@ -39,7 +39,13 @@ JDEBUG ? JProfiler::getInstance('Application')->setStart($startTime, $startMem)-
 // Boot the DI container
 $container = \Joomla\CMS\Factory::getContainer();
 
-// Alias the session service keys to the web session service as that is the primary session backend for this application
+/*
+ * Alias the session service keys to the web session service as that is the primary session backend for this application
+ *
+ * In addition to aliasing "common" service keys, we also create aliases for the PHP classes to ensure autowiring objects
+ * is supported.  This includes aliases for aliased class names, and the keys for alised class names should be considered
+ * deprecated to be removed when the class name alias is removed as well.
+ */
 $container->alias('session.web', 'session.web.site')
 	->alias('session', 'session.web.site')
 	->alias('JSession', 'session.web.site')

--- a/installation/includes/app.php
+++ b/installation/includes/app.php
@@ -47,5 +47,13 @@ JLoader::registerAlias('JRouterInstallation', \Joomla\CMS\Installation\Router\In
 $container = \Joomla\CMS\Factory::getContainer();
 $container->registerServiceProvider(new \Joomla\CMS\Installation\Service\Provider\Application);
 
+// Alias the session service keys to the web session service as that is the primary session backend for this application
+$container->alias('session.web', 'session.web.installation')
+	->alias('session', 'session.web.installation')
+	->alias('JSession', 'session.web.installation')
+	->alias(\Joomla\CMS\Session\Session::class, 'session.web.installation')
+	->alias(\Joomla\Session\Session::class, 'session.web.installation')
+	->alias(\Joomla\Session\SessionInterface::class, 'session.web.installation');
+
 // Instantiate and execute the application
 $container->get(\Joomla\CMS\Installation\Application\InstallationApplication::class)->execute();

--- a/installation/includes/app.php
+++ b/installation/includes/app.php
@@ -47,7 +47,13 @@ JLoader::registerAlias('JRouterInstallation', \Joomla\CMS\Installation\Router\In
 $container = \Joomla\CMS\Factory::getContainer();
 $container->registerServiceProvider(new \Joomla\CMS\Installation\Service\Provider\Application);
 
-// Alias the session service keys to the web session service as that is the primary session backend for this application
+/*
+ * Alias the session service keys to the web session service as that is the primary session backend for this application
+ *
+ * In addition to aliasing "common" service keys, we also create aliases for the PHP classes to ensure autowiring objects
+ * is supported.  This includes aliases for aliased class names, and the keys for alised class names should be considered
+ * deprecated to be removed when the class name alias is removed as well.
+ */
 $container->alias('session.web', 'session.web.installation')
 	->alias('session', 'session.web.installation')
 	->alias('JSession', 'session.web.installation')

--- a/libraries/src/Service/Provider/Console.php
+++ b/libraries/src/Service/Provider/Console.php
@@ -38,7 +38,14 @@ class Console implements ServiceProviderInterface
 			SessionGcCommand::class,
 			function (Container $container)
 			{
-				return new SessionGcCommand($container->get('session'));
+				/*
+				 * The command will need the same session handler that web apps use to run correctly,
+				 * since this is based on an option we need to inject the container
+				 */
+				$command = new SessionGcCommand;
+				$command->setContainer($container);
+
+				return $command;
 			},
 			true
 		);

--- a/libraries/src/Service/Provider/Session.php
+++ b/libraries/src/Service/Provider/Session.php
@@ -206,12 +206,9 @@ class Session implements ServiceProviderInterface
 	 *
 	 * @since   4.0
 	 */
-	private function buildSession(
-		StorageInterface $storage,
-		CMSApplicationInterface $app,
-		DispatcherInterface $dispatcher,
-		array $options
-	): SessionInterface {
+	private function buildSession(StorageInterface $storage, CMSApplicationInterface $app, DispatcherInterface $dispatcher,
+		array $options): SessionInterface
+	{
 		$input = $app->input;
 
 		if (method_exists($app, 'afterSessionStart'))

--- a/libraries/src/Service/Provider/Session.php
+++ b/libraries/src/Service/Provider/Session.php
@@ -12,15 +12,25 @@ namespace Joomla\CMS\Service\Provider;
 defined('JPATH_PLATFORM') or die;
 
 use InvalidArgumentException;
+use Joomla\CMS\Application\AdministratorApplication;
 use Joomla\CMS\Application\ApplicationHelper;
+use Joomla\CMS\Application\CMSApplicationInterface;
+use Joomla\CMS\Application\ConsoleApplication;
+use Joomla\CMS\Application\SiteApplication;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Installation\Application\InstallationApplication;
 use Joomla\CMS\Session\Storage\JoomlaStorage;
 use Joomla\Database\DatabaseDriver;
 use Joomla\DI\Container;
 use Joomla\DI\ServiceProviderInterface;
+use Joomla\Event\DispatcherInterface;
+use Joomla\Registry\Registry;
 use Joomla\Session\Handler;
+use Joomla\Session\HandlerInterface;
 use Joomla\Session\SessionEvents;
+use Joomla\Session\SessionInterface;
 use Joomla\Session\Storage\RuntimeStorage;
+use Joomla\Session\StorageInterface;
 use Joomla\Session\Validator\AddressValidator;
 use Joomla\Session\Validator\ForwardedValidator;
 use Memcached;
@@ -45,174 +55,279 @@ class Session implements ServiceProviderInterface
 	 */
 	public function register(Container $container)
 	{
-		$container->alias('session', 'Joomla\Session\SessionInterface')
-			->alias('JSession', 'Joomla\Session\SessionInterface')
-			->alias('Joomla\Session\Session', 'Joomla\Session\SessionInterface')
-			->share(
-				'Joomla\Session\SessionInterface',
-				function (Container $container)
+		$container->share(
+			'session.web.administrator',
+			function (Container $container)
+			{
+				/** @var Registry $config */
+				$config = $container->get('config');
+				$app    = Factory::getApplication();
+
+				// Generate a session name.
+				$name = ApplicationHelper::getHash($config->get('session_name', AdministratorApplication::class));
+
+				// Calculate the session lifetime.
+				$lifetime = ($config->get('lifetime')) ? $config->get('lifetime') * 60 : 900;
+
+				// Initialize the options for the Session object.
+				$options = [
+					'name'   => $name,
+					'expire' => $lifetime,
+				];
+
+				if ($config->get('force_ssl') >= 1)
 				{
-					$config = $container->get('config');
-					$app    = Factory::getApplication();
+					$options['force_ssl'] = true;
+				}
 
-					// Generate a session name.
-					$name = ApplicationHelper::getHash($config->get('session_name', get_class($app)));
+				return $this->buildSession(
+					new JoomlaStorage($app->input, $this->buildSessionHandler($container, $config)),
+					$app,
+					$container->get(DispatcherInterface::class),
+					$options
+				);
+			},
+			true
+		);
 
-					// Calculate the session lifetime.
-					$lifetime = (($config->get('lifetime')) ? $config->get('lifetime') * 60 : 900);
+		$container->share(
+			'session.web.installation',
+			function (Container $container)
+			{
+				/** @var Registry $config */
+				$config = $container->get('config');
+				$app    = Factory::getApplication();
 
-					// Initialize the options for the Session object.
-					$options = array(
-						'name'   => $name,
-						'expire' => $lifetime
+				// Generate a session name.
+				$name = ApplicationHelper::getHash($config->get('session_name', InstallationApplication::class));
+
+				// Calculate the session lifetime.
+				$lifetime = ($config->get('lifetime')) ? $config->get('lifetime') * 60 : 900;
+
+				// Initialize the options for the Session object.
+				$options = [
+					'name'   => $name,
+					'expire' => $lifetime,
+				];
+
+				return $this->buildSession(
+					new JoomlaStorage($app->input, $this->buildSessionHandler($container, $config)),
+					$app,
+					$container->get(DispatcherInterface::class),
+					$options
+				);
+			},
+			true
+		);
+
+		$container->share(
+			'session.web.site',
+			function (Container $container)
+			{
+				/** @var Registry $config */
+				$config = $container->get('config');
+				$app    = Factory::getApplication();
+
+				// Generate a session name.
+				$name = ApplicationHelper::getHash($config->get('session_name', SiteApplication::class));
+
+				// Calculate the session lifetime.
+				$lifetime = ($config->get('lifetime')) ? $config->get('lifetime') * 60 : 900;
+
+				// Initialize the options for the Session object.
+				$options = [
+					'name'   => $name,
+					'expire' => $lifetime,
+				];
+
+				if ($config->get('force_ssl') == 2)
+				{
+					$options['force_ssl'] = true;
+				}
+
+				return $this->buildSession(
+					new JoomlaStorage($app->input, $this->buildSessionHandler($container, $config)),
+					$app,
+					$container->get(DispatcherInterface::class),
+					$options
+				);
+			},
+			true
+		);
+
+		$container->share(
+			'session.cli',
+			function (Container $container)
+			{
+				/** @var Registry $config */
+				$config = $container->get('config');
+				$app    = Factory::getApplication();
+
+				// Generate a session name.
+				$name = ApplicationHelper::getHash($config->get('session_name', ConsoleApplication::class));
+
+				// Calculate the session lifetime.
+				$lifetime = ($config->get('lifetime')) ? $config->get('lifetime') * 60 : 900;
+
+				// Initialize the options for the Session object.
+				$options = [
+					'name'   => $name,
+					'expire' => $lifetime,
+				];
+
+				// Unlike the web apps, we will only toggle the force SSL setting based on it being enabled and not based on client
+				if ($config->get('force_ssl') >= 1)
+				{
+					$options['force_ssl'] = true;
+				}
+
+				return $this->buildSession(new RuntimeStorage, $app, $container->get(DispatcherInterface::class), $options);
+			},
+			true
+		);
+	}
+
+	/**
+	 * Build the root session service
+	 *
+	 * @param   StorageInterface         $storage     The session storage engine.
+	 * @param   CMSApplicationInterface  $app         The application instance.
+	 * @param   DispatcherInterface      $dispatcher  The event dispatcher.
+	 * @param   array                    $options     The configured session options.
+	 *
+	 * @return  SessionInterface
+	 *
+	 * @since   4.0
+	 */
+	private function buildSession(
+		StorageInterface $storage,
+		CMSApplicationInterface $app,
+		DispatcherInterface $dispatcher,
+		array $options
+	): SessionInterface
+	{
+		$input = $app->input;
+
+		if (method_exists($app, 'afterSessionStart'))
+		{
+			$dispatcher->addListener(SessionEvents::START, [$app, 'afterSessionStart']);
+		}
+
+		$session = new \Joomla\CMS\Session\Session($storage, $dispatcher, $options);
+		$session->addValidator(new AddressValidator($input, $session));
+		$session->addValidator(new ForwardedValidator($input, $session));
+
+		return $session;
+	}
+
+	/**
+	 * Build the session's handler
+	 *
+	 * @param   Container  $container  The DI container.
+	 * @param   Registry   $config     The global configuration object.
+	 *
+	 * @return  HandlerInterface
+	 *
+	 * @since   4.0
+	 */
+	private function buildSessionHandler(Container $container, Registry $config): HandlerInterface
+	{
+		$handlerType = $config->get('session_handler', 'filesystem');
+
+		switch ($handlerType)
+		{
+			case 'apcu':
+				if (!Handler\ApcuHandler::isSupported())
+				{
+					throw new RuntimeException('APCu is not supported on this system.');
+				}
+
+				return new Handler\ApcuHandler;
+
+			case 'database':
+				return new Handler\DatabaseHandler($container->get(DatabaseDriver::class));
+
+			case 'filesystem':
+			case 'none':
+				// Try to use a custom configured path, fall back to the path in the PHP runtime configuration
+				$path = $config->get('session_filesystem_path', ini_get('session.save_path'));
+
+				// If we still have no path, as a last resort fall back to the system's temporary directory
+				if (empty($path))
+				{
+					$path = sys_get_temp_dir();
+				}
+
+				return new Handler\FilesystemHandler($path);
+
+			case 'memcached':
+				if (!Handler\MemcachedHandler::isSupported())
+				{
+					throw new RuntimeException('Memcached is not supported on this system.');
+				}
+
+				$host = $config->get('session_memcached_server_host', 'localhost');
+				$port = $config->get('session_memcached_server_port', 11211);
+
+				$memcached = new Memcached($config->get('session_memcached_server_id', 'joomla_cms'));
+				$memcached->addServer($host, $port);
+
+				ini_set('session.save_path', "$host:$port");
+				ini_set('session.save_handler', 'memcached');
+
+				return new Handler\MemcachedHandler($memcached, ['ttl' => $lifetime]);
+
+			case 'redis':
+				if (!Handler\RedisHandler::isSupported())
+				{
+					throw new RuntimeException('Redis is not supported on this system.');
+				}
+
+				$redis = new Redis;
+				$host  = $config->get('session_redis_server_host', '127.0.0.1');
+
+				// Use default port if connecting over a socket whatever the config value
+				$port = $host[0] === '/' ? $config->get('session_redis_server_port', 6379) : 6379;
+
+				if ($config->get('session_redis_persist', true))
+				{
+					$redis->pconnect(
+						$host,
+						$port
 					);
+				}
+				else
+				{
+					$redis->connect(
+						$host,
+						$port
+					);
+				}
 
-					if ($app->isClient('site') && $config->get('force_ssl') == 2)
-					{
-						$options['force_ssl'] = true;
-					}
+				if (!empty($config->get('session_redis_server_auth', '')))
+				{
+					$redis->auth($config->get('session_redis_server_auth', null));
+				}
 
-					if ($app->isClient('administrator') && $config->get('force_ssl') >= 1)
-					{
-						$options['force_ssl'] = true;
-					}
+				$db = (int) $config->get('session_redis_server_db', 0);
 
-					// Set up the storage handler
-					$handlerType = $config->get('session_handler', 'filesystem');
+				if ($db !== 0)
+				{
+					$redis->select($db);
+				}
 
-					switch ($handlerType)
-					{
-						case 'apcu':
-							if (!Handler\ApcuHandler::isSupported())
-							{
-								throw new RuntimeException('APCu is not supported on this system.');
-							}
+				return new Handler\RedisHandler($redis, ['ttl' => $lifetime]);
 
-							$handler = new Handler\ApcuHandler;
+			case 'wincache':
+				if (!Handler\WincacheHandler::isSupported())
+				{
+					throw new RuntimeException('Wincache is not supported on this system.');
+				}
 
-							break;
+				return new Handler\WincacheHandler;
 
-						case 'database':
-							$handler = new Handler\DatabaseHandler($container->get(DatabaseDriver::class));
-
-							break;
-
-						case 'filesystem':
-						case 'none':
-							// Try to use a custom configured path, fall back to the path in the PHP runtime configuration
-							$path = $config->get('session_filesystem_path', ini_get('session.save_path'));
-
-							// If we still have no path, as a last resort fall back to the system's temporary directory
-							if (empty($path))
-							{
-								$path = sys_get_temp_dir();
-							}
-
-							$handler = new Handler\FilesystemHandler($path);
-
-							break;
-
-						case 'memcached':
-							if (!Handler\MemcachedHandler::isSupported())
-							{
-								throw new RuntimeException('Memcached is not supported on this system.');
-							}
-
-							$host = $config->get('session_memcached_server_host', 'localhost');
-							$port = $config->get('session_memcached_server_port', 11211);
-
-							$memcached = new Memcached($config->get('session_memcached_server_id', 'joomla_cms'));
-							$memcached->addServer($host, $port);
-
-							$handler = new Handler\MemcachedHandler($memcached, ['ttl' => $lifetime]);
-
-							ini_set('session.save_path', "$host:$port");
-							ini_set('session.save_handler', 'memcached');
-
-							break;
-
-						case 'redis':
-							if (!Handler\RedisHandler::isSupported())
-							{
-								throw new RuntimeException('Redis is not supported on this system.');
-							}
-
-							$redis = new Redis;
-							$host = $config->get('session_redis_server_host', '127.0.0.1');
-
-							// Use default port if connecting over a socket whatever the config value
-							$port = $host[0] === '/' ? $config->get('session_redis_server_port', 6379) : 6379;
-
-							if ($config->get('session_redis_persist', true))
-							{
-								$redis->pconnect(
-									$host,
-									$port
-								);
-							}
-							else
-							{
-								$redis->connect(
-									$host,
-									$port
-								);
-							}
-
-							if (!empty($config->get('session_redis_server_auth', '')))
-							{
-								$redis->auth($config->get('session_redis_server_auth', null));
-							}
-
-							$db = (int) $config->get('session_redis_server_db', 0);
-
-							if ($db !== 0)
-							{
-								$redis->select($db);
-							}
-
-							$handler = new Handler\RedisHandler($redis, ['ttl' => $lifetime]);
-
-							break;
-
-						case 'wincache':
-							if (!Handler\WincacheHandler::isSupported())
-							{
-								throw new RuntimeException('Wincache is not supported on this system.');
-							}
-
-							$handler = new Handler\WincacheHandler;
-
-							break;
-
-						default:
-							throw new InvalidArgumentException(sprintf('The "%s" session handler is not recognised.', $handlerType));
-					}
-
-					$input = $app->input;
-
-					if ($app->isClient('cli'))
-					{
-						$storage = new RuntimeStorage;
-					}
-					else
-					{
-						$storage = new JoomlaStorage($input, $handler);
-					}
-
-					$dispatcher = $container->get('Joomla\Event\DispatcherInterface');
-
-					if (method_exists($app, 'afterSessionStart'))
-					{
-						$dispatcher->addListener(SessionEvents::START, array($app, 'afterSessionStart'));
-					}
-
-					$session = new \Joomla\CMS\Session\Session($storage, $dispatcher, $options);
-					$session->addValidator(new AddressValidator($input, $session));
-					$session->addValidator(new ForwardedValidator($input, $session));
-
-					return $session;
-				},
-				true
-			);
+			default:
+				throw new InvalidArgumentException(sprintf('The "%s" session handler is not recognised.', $handlerType));
+		}
 	}
 }

--- a/libraries/src/Service/Provider/Session.php
+++ b/libraries/src/Service/Provider/Session.php
@@ -11,7 +11,6 @@ namespace Joomla\CMS\Service\Provider;
 
 defined('JPATH_PLATFORM') or die;
 
-use InvalidArgumentException;
 use Joomla\CMS\Application\AdministratorApplication;
 use Joomla\CMS\Application\ApplicationHelper;
 use Joomla\CMS\Application\CMSApplicationInterface;
@@ -19,23 +18,18 @@ use Joomla\CMS\Application\ConsoleApplication;
 use Joomla\CMS\Application\SiteApplication;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Installation\Application\InstallationApplication;
+use Joomla\CMS\Session\SessionFactory;
 use Joomla\CMS\Session\Storage\JoomlaStorage;
-use Joomla\Database\DatabaseDriver;
 use Joomla\DI\Container;
 use Joomla\DI\ServiceProviderInterface;
 use Joomla\Event\DispatcherInterface;
 use Joomla\Registry\Registry;
-use Joomla\Session\Handler;
-use Joomla\Session\HandlerInterface;
 use Joomla\Session\SessionEvents;
 use Joomla\Session\SessionInterface;
 use Joomla\Session\Storage\RuntimeStorage;
 use Joomla\Session\StorageInterface;
 use Joomla\Session\Validator\AddressValidator;
 use Joomla\Session\Validator\ForwardedValidator;
-use Memcached;
-use Redis;
-use RuntimeException;
 
 /**
  * Service provider for the application's session dependency
@@ -81,7 +75,7 @@ class Session implements ServiceProviderInterface
 				}
 
 				return $this->buildSession(
-					new JoomlaStorage($app->input, $this->buildSessionHandler($container, $config)),
+					new JoomlaStorage($app->input, $container->get('session.factory')->createSessionHandler()),
 					$app,
 					$container->get(DispatcherInterface::class),
 					$options
@@ -111,7 +105,7 @@ class Session implements ServiceProviderInterface
 				];
 
 				return $this->buildSession(
-					new JoomlaStorage($app->input, $this->buildSessionHandler($container, $config)),
+					new JoomlaStorage($app->input, $container->get('session.factory')->createSessionHandler()),
 					$app,
 					$container->get(DispatcherInterface::class),
 					$options
@@ -146,7 +140,7 @@ class Session implements ServiceProviderInterface
 				}
 
 				return $this->buildSession(
-					new JoomlaStorage($app->input, $this->buildSessionHandler($container, $config)),
+					new JoomlaStorage($app->input, $container->get('session.factory')->createSessionHandler()),
 					$app,
 					$container->get(DispatcherInterface::class),
 					$options
@@ -185,6 +179,19 @@ class Session implements ServiceProviderInterface
 			},
 			true
 		);
+
+		$container->alias(SessionFactory::class, 'session.factory')
+			->share(
+				'session.factory',
+				function (Container $container)
+				{
+					$factory = new SessionFactory;
+					$factory->setContainer($container);
+
+					return $factory;
+				},
+				true
+			);
 	}
 
 	/**
@@ -218,116 +225,5 @@ class Session implements ServiceProviderInterface
 		$session->addValidator(new ForwardedValidator($input, $session));
 
 		return $session;
-	}
-
-	/**
-	 * Build the session's handler
-	 *
-	 * @param   Container  $container  The DI container.
-	 * @param   Registry   $config     The global configuration object.
-	 *
-	 * @return  HandlerInterface
-	 *
-	 * @since   4.0
-	 */
-	private function buildSessionHandler(Container $container, Registry $config): HandlerInterface
-	{
-		$handlerType = $config->get('session_handler', 'filesystem');
-
-		switch ($handlerType)
-		{
-			case 'apcu':
-				if (!Handler\ApcuHandler::isSupported())
-				{
-					throw new RuntimeException('APCu is not supported on this system.');
-				}
-
-				return new Handler\ApcuHandler;
-
-			case 'database':
-				return new Handler\DatabaseHandler($container->get(DatabaseDriver::class));
-
-			case 'filesystem':
-			case 'none':
-				// Try to use a custom configured path, fall back to the path in the PHP runtime configuration
-				$path = $config->get('session_filesystem_path', ini_get('session.save_path'));
-
-				// If we still have no path, as a last resort fall back to the system's temporary directory
-				if (empty($path))
-				{
-					$path = sys_get_temp_dir();
-				}
-
-				return new Handler\FilesystemHandler($path);
-
-			case 'memcached':
-				if (!Handler\MemcachedHandler::isSupported())
-				{
-					throw new RuntimeException('Memcached is not supported on this system.');
-				}
-
-				$host = $config->get('session_memcached_server_host', 'localhost');
-				$port = $config->get('session_memcached_server_port', 11211);
-
-				$memcached = new Memcached($config->get('session_memcached_server_id', 'joomla_cms'));
-				$memcached->addServer($host, $port);
-
-				ini_set('session.save_path', "$host:$port");
-				ini_set('session.save_handler', 'memcached');
-
-				return new Handler\MemcachedHandler($memcached, ['ttl' => $lifetime]);
-
-			case 'redis':
-				if (!Handler\RedisHandler::isSupported())
-				{
-					throw new RuntimeException('Redis is not supported on this system.');
-				}
-
-				$redis = new Redis;
-				$host  = $config->get('session_redis_server_host', '127.0.0.1');
-
-				// Use default port if connecting over a socket whatever the config value
-				$port = $host[0] === '/' ? $config->get('session_redis_server_port', 6379) : 6379;
-
-				if ($config->get('session_redis_persist', true))
-				{
-					$redis->pconnect(
-						$host,
-						$port
-					);
-				}
-				else
-				{
-					$redis->connect(
-						$host,
-						$port
-					);
-				}
-
-				if (!empty($config->get('session_redis_server_auth', '')))
-				{
-					$redis->auth($config->get('session_redis_server_auth', null));
-				}
-
-				$db = (int) $config->get('session_redis_server_db', 0);
-
-				if ($db !== 0)
-				{
-					$redis->select($db);
-				}
-
-				return new Handler\RedisHandler($redis, ['ttl' => $lifetime]);
-
-			case 'wincache':
-				if (!Handler\WincacheHandler::isSupported())
-				{
-					throw new RuntimeException('Wincache is not supported on this system.');
-				}
-
-				return new Handler\WincacheHandler;
-
-			default:
-				throw new InvalidArgumentException(sprintf('The "%s" session handler is not recognised.', $handlerType));
-		}
 	}
 }

--- a/libraries/src/Service/Provider/Session.php
+++ b/libraries/src/Service/Provider/Session.php
@@ -211,8 +211,7 @@ class Session implements ServiceProviderInterface
 		CMSApplicationInterface $app,
 		DispatcherInterface $dispatcher,
 		array $options
-	): SessionInterface
-	{
+	): SessionInterface {
 		$input = $app->input;
 
 		if (method_exists($app, 'afterSessionStart'))

--- a/libraries/src/Service/Provider/Session.php
+++ b/libraries/src/Service/Provider/Session.php
@@ -61,7 +61,7 @@ class Session implements ServiceProviderInterface
 				$name = ApplicationHelper::getHash($config->get('session_name', AdministratorApplication::class));
 
 				// Calculate the session lifetime.
-				$lifetime = ($config->get('lifetime')) ? $config->get('lifetime') * 60 : 900;
+				$lifetime = $config->get('lifetime') ? $config->get('lifetime') * 60 : 900;
 
 				// Initialize the options for the Session object.
 				$options = [
@@ -96,7 +96,7 @@ class Session implements ServiceProviderInterface
 				$name = ApplicationHelper::getHash($config->get('session_name', InstallationApplication::class));
 
 				// Calculate the session lifetime.
-				$lifetime = ($config->get('lifetime')) ? $config->get('lifetime') * 60 : 900;
+				$lifetime = $config->get('lifetime') ? $config->get('lifetime') * 60 : 900;
 
 				// Initialize the options for the Session object.
 				$options = [
@@ -126,7 +126,7 @@ class Session implements ServiceProviderInterface
 				$name = ApplicationHelper::getHash($config->get('session_name', SiteApplication::class));
 
 				// Calculate the session lifetime.
-				$lifetime = ($config->get('lifetime')) ? $config->get('lifetime') * 60 : 900;
+				$lifetime = $config->get('lifetime') ? $config->get('lifetime') * 60 : 900;
 
 				// Initialize the options for the Session object.
 				$options = [
@@ -161,7 +161,7 @@ class Session implements ServiceProviderInterface
 				$name = ApplicationHelper::getHash($config->get('session_name', ConsoleApplication::class));
 
 				// Calculate the session lifetime.
-				$lifetime = ($config->get('lifetime')) ? $config->get('lifetime') * 60 : 900;
+				$lifetime = $config->get('lifetime') ? $config->get('lifetime') * 60 : 900;
 
 				// Initialize the options for the Session object.
 				$options = [

--- a/libraries/src/Service/Provider/Session.php
+++ b/libraries/src/Service/Provider/Session.php
@@ -75,7 +75,7 @@ class Session implements ServiceProviderInterface
 				}
 
 				return $this->buildSession(
-					new JoomlaStorage($app->input, $container->get('session.factory')->createSessionHandler()),
+					new JoomlaStorage($app->input, $container->get('session.factory')->createSessionHandler($options)),
 					$app,
 					$container->get(DispatcherInterface::class),
 					$options
@@ -105,7 +105,7 @@ class Session implements ServiceProviderInterface
 				];
 
 				return $this->buildSession(
-					new JoomlaStorage($app->input, $container->get('session.factory')->createSessionHandler()),
+					new JoomlaStorage($app->input, $container->get('session.factory')->createSessionHandler($options)),
 					$app,
 					$container->get(DispatcherInterface::class),
 					$options
@@ -140,7 +140,7 @@ class Session implements ServiceProviderInterface
 				}
 
 				return $this->buildSession(
-					new JoomlaStorage($app->input, $container->get('session.factory')->createSessionHandler()),
+					new JoomlaStorage($app->input, $container->get('session.factory')->createSessionHandler($options)),
 					$app,
 					$container->get(DispatcherInterface::class),
 					$options

--- a/libraries/src/Session/SessionFactory.php
+++ b/libraries/src/Session/SessionFactory.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * @package     Joomla.Libraries
+ * @subpackage  Service
+ *
+ * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\CMS\Session;
+
+defined('JPATH_PLATFORM') or die;
+
+use InvalidArgumentException;
+use Joomla\Database\DatabaseInterface;
+use Joomla\DI\ContainerAwareInterface;
+use Joomla\DI\ContainerAwareTrait;
+use Joomla\Registry\Registry;
+use Joomla\Session\Handler;
+use Joomla\Session\HandlerInterface;
+use Memcached;
+use Redis;
+use RuntimeException;
+
+/**
+ * Factory for creating session API objects
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class SessionFactory implements ContainerAwareInterface
+{
+	use ContainerAwareTrait;
+
+	/**
+	 * Create a session handler based on the application configuration.
+	 *
+	 * @return  HandlerInterface
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function createSessionHandler(): HandlerInterface
+	{
+		/** @var Registry $config */
+		$config = $container->get('config');
+
+		$handlerType = $config->get('session_handler', 'filesystem');
+
+		switch ($handlerType)
+		{
+			case 'apcu':
+				if (!Handler\ApcuHandler::isSupported())
+				{
+					throw new RuntimeException('APCu is not supported on this system.');
+				}
+
+				return new Handler\ApcuHandler;
+
+			case 'database':
+				return new Handler\DatabaseHandler($this->getContainer()->get(DatabaseInterface::class));
+
+			case 'filesystem':
+			case 'none':
+				// Try to use a custom configured path, fall back to the path in the PHP runtime configuration
+				$path = $config->get('session_filesystem_path', ini_get('session.save_path'));
+
+				// If we still have no path, as a last resort fall back to the system's temporary directory
+				if (empty($path))
+				{
+					$path = sys_get_temp_dir();
+				}
+
+				return new Handler\FilesystemHandler($path);
+
+			case 'memcached':
+				if (!Handler\MemcachedHandler::isSupported())
+				{
+					throw new RuntimeException('Memcached is not supported on this system.');
+				}
+
+				$host = $config->get('session_memcached_server_host', 'localhost');
+				$port = $config->get('session_memcached_server_port', 11211);
+
+				$memcached = new Memcached($config->get('session_memcached_server_id', 'joomla_cms'));
+				$memcached->addServer($host, $port);
+
+				ini_set('session.save_path', "$host:$port");
+				ini_set('session.save_handler', 'memcached');
+
+				return new Handler\MemcachedHandler($memcached, ['ttl' => $lifetime]);
+
+			case 'redis':
+				if (!Handler\RedisHandler::isSupported())
+				{
+					throw new RuntimeException('Redis is not supported on this system.');
+				}
+
+				$redis = new Redis;
+				$host  = $config->get('session_redis_server_host', '127.0.0.1');
+
+				// Use default port if connecting over a socket whatever the config value
+				$port = $host[0] === '/' ? $config->get('session_redis_server_port', 6379) : 6379;
+
+				if ($config->get('session_redis_persist', true))
+				{
+					$redis->pconnect(
+						$host,
+						$port
+					);
+				}
+				else
+				{
+					$redis->connect(
+						$host,
+						$port
+					);
+				}
+
+				if (!empty($config->get('session_redis_server_auth', '')))
+				{
+					$redis->auth($config->get('session_redis_server_auth', null));
+				}
+
+				$db = (int) $config->get('session_redis_server_db', 0);
+
+				if ($db !== 0)
+				{
+					$redis->select($db);
+				}
+
+				return new Handler\RedisHandler($redis, ['ttl' => $lifetime]);
+
+			case 'wincache':
+				if (!Handler\WincacheHandler::isSupported())
+				{
+					throw new RuntimeException('Wincache is not supported on this system.');
+				}
+
+				return new Handler\WincacheHandler;
+
+			default:
+				throw new InvalidArgumentException(sprintf('The "%s" session handler is not recognised.', $handlerType));
+		}
+	}
+}

--- a/libraries/src/Session/SessionFactory.php
+++ b/libraries/src/Session/SessionFactory.php
@@ -41,7 +41,7 @@ class SessionFactory implements ContainerAwareInterface
 	public function createSessionHandler(): HandlerInterface
 	{
 		/** @var Registry $config */
-		$config = $container->get('config');
+		$config = $this->getContainer()->get('config');
 
 		$handlerType = $config->get('session_handler', 'filesystem');
 


### PR DESCRIPTION
### Summary of Changes

This is restructuring the definition of the core session service for 4.0.

Right now we have an issue where the session service is dependent on the application object for some checks and dependencies.  We can loosen that dependency by splitting the definition up on a per-application basis, which as of this PR only leaves the internal dependency in place to get the `Joomla\Input\Input` objects used in the session store (this can be addressed in a later PR much more easily now).

Additionally, this gives a little more flexibility to our `session:gc` command.  Right now there are technically different session stores/configurations for each of the core applications, primarily because of how the default `session_name` configuration value is set when shared sessions is not active.  So now the command can run garbage collection factoring in each application's configuration appropriately, especially as a `session_gc()` call in PHP requires an active session.

### Testing Instructions

This is predominantly code review, but all CMS operations should continue to function as normal too.