### PR TITLE
com_fields save error in case the subform is not multible

### DIFF
--- a/administrator/components/com_fields/libraries/fieldslistplugin.php
+++ b/administrator/components/com_fields/libraries/fieldslistplugin.php
@@ -68,8 +68,17 @@ class FieldsListPlugin extends FieldsPlugin
 		$params = clone $this->params;
 		$params->merge($field->fieldparams);
 
-		foreach ($params->get('options', array()) as $option)
+		$options = $params->get('options', array());
+
+		foreach ($options as $key => $option)
 		{
+			if (is_string($option))
+			{
+				$data[$option] = $key;
+
+				continue;
+			}
+
 			$op = (object) $option;
 			$data[$op->value] = $op->name;
 		}

--- a/administrator/components/com_fields/models/field.php
+++ b/administrator/components/com_fields/models/field.php
@@ -185,9 +185,17 @@ class FieldsModelField extends JModelAdmin
 			{
 				$names = array();
 
-				foreach ($newParams as $param)
+				// In the case where the subform is not multible this is just a stdClass
+				if (isset($newParams->value))
 				{
-					$names[] = $db->q($param['value']);
+					$names[] = $db->q($newParams->value);
+				}
+				else
+				{
+					foreach ($newParams as $param)
+					{
+						$names[] = $db->q($param['value']);
+					}
 				}
 
 				$query = $db->getQuery(true);

--- a/administrator/components/com_fields/models/field.php
+++ b/administrator/components/com_fields/models/field.php
@@ -185,7 +185,7 @@ class FieldsModelField extends JModelAdmin
 			{
 				$names = array();
 
-				// In the case where the subform is not multible this is just a stdClass
+				// In the case where the subform is not multiple this is just a stdClass
 				if (isset($newParams->value))
 				{
 					$names[] = $db->q($newParams->value);


### PR DESCRIPTION
### Summary of Changes

In the case that the subform used in side a fields plugin is not multible my xDebug cry's

### Testing Instructions

Change: https://github.com/joomla/joomla-cms/blob/staging/plugins/fields/checkboxes/params/checkboxes.xml#L12 to `multiple="false"`
&
Change: https://github.com/joomla/joomla-cms/blob/staging/plugins/fields/checkboxes/checkboxes.xml#L31 to `multiple="false"`

Try to save and make sure you changed the value fields before you hit save.

### Expected result

No error when using XDebug
![image](https://user-images.githubusercontent.com/2596554/35942780-2b1d0d94-0c57-11e8-9a58-0560ecb5b12e.png)


### Actual result

The point is that if we have a multibe subform the values come in this structure:
![image](https://user-images.githubusercontent.com/2596554/35942617-89dfe668-0c56-11e8-8401-1cf6915435c6.png)

If they are switched to not multible they come in this structure:
![image](https://user-images.githubusercontent.com/2596554/35942683-bb3dda9e-0c56-11e8-933e-616fdb4a0a88.png)

It is obvious that the current code can't work so here is a proposed fix.

cc @laoneo 