### PR TITLE
Pass the configuration tmp_path to the archive package for extension installations

### DIFF
--- a/libraries/src/Installer/InstallerHelper.php
+++ b/libraries/src/Installer/InstallerHelper.php
@@ -132,7 +132,7 @@ abstract class InstallerHelper
 		// Do the unpacking of the archive
 		try
 		{
-			$archive = new Archive(array('tmp_path' => JFactory::getConfig()->get('tmp_path')));
+			$archive = new Archive(array('tmp_path' => \JFactory::getConfig()->get('tmp_path')));
 			$extract = $archive->extract($archivename, $extractdir);
 		}
 		catch (\Exception $e)

--- a/libraries/src/Installer/InstallerHelper.php
+++ b/libraries/src/Installer/InstallerHelper.php
@@ -132,7 +132,7 @@ abstract class InstallerHelper
 		// Do the unpacking of the archive
 		try
 		{
-			$archive = new Archive;
+			$archive = new Archive(array('tmp_path' => JFactory::getConfig()->get('tmp_path')));
 			$extract = $archive->extract($archivename, $extractdir);
 		}
 		catch (\Exception $e)


### PR DESCRIPTION
Pull Request for Issue #19503

### Summary of Changes

Pass the configuration tmp_path to the archive package for extension installations

### Testing Instructions

Make sure extension installation still works

### Expected result

extension installation uses the joomla temp folder

### Actual result

extension installation uses the system / server temp folder

### Documentation Changes Required

none