### PR TITLE
Remove space indent exceptions

### DIFF
--- a/administrator/components/com_associations/models/fields/itemlanguage.php
+++ b/administrator/components/com_associations/models/fields/itemlanguage.php
@@ -80,7 +80,7 @@ class JFormFieldItemLanguage extends JFormFieldList
 				$itemId                    = (int) $associations[$language->lang_code]['id'];
 				$options[$langCode]->value = $language->lang_code . ':' . $itemId . ':edit';
 
-				 // Check if user does have permission to edit the associated item.
+				// Check if user does have permission to edit the associated item.
 				$canEdit = AssociationsHelper::allowEdit($extensionName, $typeName, $itemId);
 
 				// Check if item can be checked out

--- a/administrator/components/com_associations/views/associations/tmpl/modal.php
+++ b/administrator/components/com_associations/views/associations/tmpl/modal.php
@@ -46,8 +46,8 @@ $app->getDocument()->addScriptDeclaration(
 	});"
 );
 ?>
-<form action="<?php echo JRoute::_('index.php?option=com_associations&view=associations&layout=modal&tmpl=component&function=' . $function . '&' . JSession::getFormToken() . '=1');
- ?>" method="post" name="adminForm" id="adminForm">
+<form action="<?php echo JRoute::_('index.php?option=com_associations&view=associations&layout=modal&tmpl=component&function='
+. $function . '&' . JSession::getFormToken() . '=1'); ?>" method="post" name="adminForm" id="adminForm">
 
 <?php if (!empty( $this->sidebar)) : ?>
 	<div id="j-sidebar-container" class="span2">

--- a/administrator/components/com_menus/controllers/item.php
+++ b/administrator/components/com_menus/controllers/item.php
@@ -337,7 +337,7 @@ class MenusControllerItem extends JControllerForm
 				$segments = explode(':', $data['link']);
 				$protocol = strtolower($segments[0]);
 				$scheme = array('http', 'https', 'ftp', 'ftps', 'gopher', 'mailto', 'news', 'prospero', 'telnet', 'rlogin', 'tn3270', 'wais','mid', 'cid', 'nntp',
-					 'tel', 'urn', 'ldap', 'file', 'fax', 'modem', 'git', 'sms');
+						'tel', 'urn', 'ldap', 'file', 'fax', 'modem', 'git', 'sms');
 
 				if (!in_array($protocol, $scheme))
 				{

--- a/build/phpcs/Joomla/ruleset.xml
+++ b/build/phpcs/Joomla/ruleset.xml
@@ -82,12 +82,7 @@
 	<rule ref="Generic.PHP.DeprecatedFunctions" />
 	<rule ref="Generic.PHP.ForbiddenFunctions"/>
 	<rule ref="Generic.PHP.LowerCaseConstant" />
-	<rule ref="Generic.WhiteSpace.DisallowSpaceIndent">
-		<!-- These exceptions are temporary for now -->
-		<exclude-pattern type="relative">administrator/components/*</exclude-pattern>
-		<exclude-pattern type="relative">components/*</exclude-pattern>
-		<exclude-pattern type="relative">libraries/cms/*</exclude-pattern>
-	</rule>
+	<rule ref="Generic.WhiteSpace.DisallowSpaceIndent" />
 
 	<!-- Include some additional sniffs from the PEAR standard -->
 	<rule ref="PEAR.Classes.ClassDeclaration" />

--- a/components/com_content/content.php
+++ b/components/com_content/content.php
@@ -23,7 +23,7 @@ if ($checkCreateEdit)
 {
 	// Can create in any category (component permission) or at least in one category
 	$canCreateRecords = $user->authorise('core.create', 'com_content')
-	 || count($user->getAuthorisedCategories('com_content', 'core.create')) > 0;
+		|| count($user->getAuthorisedCategories('com_content', 'core.create')) > 0;
 
 	// Instead of checking edit on all records, we can use **same** check as the form editing view
 	$values = (array) JFactory::getApplication()->getUserState('com_content.edit.article.id');


### PR DESCRIPTION
Pull Request for Issue space indents are not allowed

### Summary of Changes
- remove space indent exceptions
- fix some cases where spaces indents have snuck in

### Testing Instructions
merge by code review
Drone should not error as all space indent exceptions should have been fixed
A few cases had to be fixed and are included in this PR.

No more spaces once this is merged.
(except in the few cases where we have larger full file/folder exceptions across the CMS libraries and tests, etc)

### Expected result
no drone CS errors

### Actual result
no drone CS errors

### Documentation Changes Required
none
