### PR TITLE
Correct output_buffering check in 3.8.x

### DIFF
--- a/administrator/components/com_admin/models/sysinfo.php
+++ b/administrator/components/com_admin/models/sysinfo.php
@@ -246,7 +246,7 @@ class AdminModelSysInfo extends JModelLegacy
 			'file_uploads'       => ini_get('file_uploads') == '1',
 			'magic_quotes_gpc'   => ini_get('magic_quotes_gpc') == '1',
 			'register_globals'   => ini_get('register_globals') == '1',
-			'output_buffering'   => (is_numeric(ini_get('output_buffering'))) ? true : false,
+			'output_buffering'   => is_numeric(ini_get('output_buffering')),
 			'open_basedir'       => ini_get('open_basedir'),
 			'session.save_path'  => ini_get('session.save_path'),
 			'session.auto_start' => ini_get('session.auto_start'),

--- a/administrator/components/com_admin/models/sysinfo.php
+++ b/administrator/components/com_admin/models/sysinfo.php
@@ -246,7 +246,7 @@ class AdminModelSysInfo extends JModelLegacy
 			'file_uploads'       => ini_get('file_uploads') == '1',
 			'magic_quotes_gpc'   => ini_get('magic_quotes_gpc') == '1',
 			'register_globals'   => ini_get('register_globals') == '1',
-			'output_buffering'   => (bool) ini_get('output_buffering'),
+			'output_buffering'   => (is_numeric(ini_get('output_buffering'))) ? true : false,
 			'open_basedir'       => ini_get('open_basedir'),
 			'session.save_path'  => ini_get('session.save_path'),
 			'session.auto_start' => ini_get('session.auto_start'),

--- a/administrator/components/com_admin/models/sysinfo.php
+++ b/administrator/components/com_admin/models/sysinfo.php
@@ -239,6 +239,8 @@ class AdminModelSysInfo extends JModelLegacy
 			return $this->php_settings;
 		}
 
+		$outputBuffering = ini_get('output_buffering');
+
 		$this->php_settings = array(
 			'safe_mode'          => ini_get('safe_mode') == '1',
 			'display_errors'     => ini_get('display_errors') == '1',
@@ -246,7 +248,7 @@ class AdminModelSysInfo extends JModelLegacy
 			'file_uploads'       => ini_get('file_uploads') == '1',
 			'magic_quotes_gpc'   => ini_get('magic_quotes_gpc') == '1',
 			'register_globals'   => ini_get('register_globals') == '1',
-			'output_buffering'   => is_numeric(ini_get('output_buffering')),
+			'output_buffering'   => ($outputBuffering === 'On') ? true : is_numeric($outputBuffering),
 			'open_basedir'       => ini_get('open_basedir'),
 			'session.save_path'  => ini_get('session.save_path'),
 			'session.auto_start' => ini_get('session.auto_start'),

--- a/installation/model/setup.php
+++ b/installation/model/setup.php
@@ -374,7 +374,7 @@ class InstallationModelSetup extends JModelBase
 		// Check for output buffering.
 		$setting = new stdClass;
 		$setting->label = JText::_('INSTL_OUTPUT_BUFFERING');
-		$setting->state = (bool) ini_get('output_buffering');
+		$setting->state = (is_numeric(ini_get('output_buffering'))) ? true : false;
 		$setting->recommended = false;
 		$settings[] = $setting;
 

--- a/installation/model/setup.php
+++ b/installation/model/setup.php
@@ -372,9 +372,10 @@ class InstallationModelSetup extends JModelBase
 		$settings[] = $setting;
 
 		// Check for output buffering.
+		$outputBuffering = ini_get('output_buffering');
 		$setting = new stdClass;
 		$setting->label = JText::_('INSTL_OUTPUT_BUFFERING');
-		$setting->state = is_numeric(ini_get('output_buffering'));
+		$setting->state = ($outputBuffering === 'On') ? true : is_numeric($outputBuffering);
 		$setting->recommended = false;
 		$settings[] = $setting;
 

--- a/installation/model/setup.php
+++ b/installation/model/setup.php
@@ -374,7 +374,7 @@ class InstallationModelSetup extends JModelBase
 		// Check for output buffering.
 		$setting = new stdClass;
 		$setting->label = JText::_('INSTL_OUTPUT_BUFFERING');
-		$setting->state = (is_numeric(ini_get('output_buffering'))) ? true : false;
+		$setting->state = is_numeric(ini_get('output_buffering'));
 		$setting->recommended = false;
 		$settings[] = $setting;
 


### PR DESCRIPTION
Pull Request for Issue #19033

### Summary of Changes

In case `output_buffering` is set to `Off` we should show it set off currently we show it to be enabled.

### Testing Instructions

- upload joomla to the server
- set `php_value output_buffering Off` via htaccess
- check the output_buffering values showed in the installer and in the backed.

### Expected result

Showed as off

### Actual result

showed as on

### Documentation Changes Required

none