### PR TITLE
REGRESSION User profile plugin

### DIFF
--- a/components/com_users/views/registration/view.html.php
+++ b/components/com_users/views/registration/view.html.php
@@ -38,8 +38,8 @@ class UsersViewRegistration extends JViewLegacy
 	public function display($tpl = null)
 	{
 		// Get the view data.
-		$this->form   = $this->get('Form');
 		$this->data   = $this->get('Data');
+		$this->form   = $this->get('Form');
 		$this->state  = $this->get('State');
 		$this->params = $this->state->get('params');
 


### PR DESCRIPTION
Enable the User - Joomla plugin and set the first field to be required
Enable user registration
Try to register a user on the front end and you will see that field Address 1 is displayed as optional - it should be displayed as required.
Try to register without completing field Address 1 and it will fail saying that Address 1 is required

This has been a long standing recurring bug. This instance has come from
Fix form data lost when user registration failed #19145

Reverting that PR resolves this issue but then of course it means that the issue being fixed in #19145 had returned
