### PR TITLE
Proper loading of registration form to show required extra fields as required

### DIFF
--- a/components/com_users/models/registration.php
+++ b/components/com_users/models/registration.php
@@ -313,7 +313,7 @@ class UsersModelRegistration extends JModelForm
 	public function getForm($data = array(), $loadData = true)
 	{
 		// Get the form.
-		$form = $this->loadForm('com_users.registration', 'registration', array('control' => 'jform', 'load_data' => $loadData));
+		$form = $this->loadForm('com_users.registration', 'registration', array('control' => 'jform', 'load_data' => $loadData, 'form_instance_with_data' => $loadData));
 
 		if (empty($form))
 		{

--- a/components/com_users/models/registration.php
+++ b/components/com_users/models/registration.php
@@ -243,9 +243,6 @@ class UsersModelRegistration extends JModelForm
 			// Override the base user data with any data in the session.
 			$temp = (array) $app->getUserState('com_users.registration.data', array());
 
-			// Don't load the data in this getForm call, or we'll call ourself
-			$form = $this->getForm(array(), false);
-
 			foreach ($temp as $k => $v)
 			{
 				// Here we could have a grouped field, let's check it
@@ -255,14 +252,11 @@ class UsersModelRegistration extends JModelForm
 
 					foreach ($v as $key => $val)
 					{
-						if ($form->getField($key, $k) !== false)
-						{
-							$this->data->$k->$key = $val;
-						}
+						$this->data->$k->$key = $val;
 					}
 				}
 				// Only merge the field if it exists in the form.
-				elseif ($form->getField($k) !== false)
+				else
 				{
 					$this->data->$k = $v;
 				}
@@ -313,7 +307,7 @@ class UsersModelRegistration extends JModelForm
 	public function getForm($data = array(), $loadData = true)
 	{
 		// Get the form.
-		$form = $this->loadForm('com_users.registration', 'registration', array('control' => 'jform', 'load_data' => $loadData, 'form_instance_with_data' => $loadData));
+		$form = $this->loadForm('com_users.registration', 'registration', array('control' => 'jform', 'load_data' => $loadData));
 
 		if (empty($form))
 		{


### PR DESCRIPTION
Pull Request for Issue #19506, (better alternative to PR #19614)

This PR is fixing #19506 
while being able to reload form posted data when registration form reloads due to any error,
the above was fixed by #19145 but it caused issue #19506 

further more the order of calling
```php
$this->get('Data');
$this->get('Form');
```
is no longer important

### Summary of Changes
Remove form instances creation inside getData()


### Testing Instructions
1. Enable plugin "User - Profile" in plugin manager
2. Edit the plugin and enable some optional fields, set field Country to Required
3. Open registration form as guest and fill-in data in the form and right click on "input" of field "Name" and select "Inspect" (Chrome) or "Inspect Element" (Firefox), click Delete button on Keyboard to delete the selected `<input>`
4. Submit the form


### Expected result
1. Registration form loads showing Country Field **as required**
2. After form submits (with "Name" field having been deleted), you get an error that "Name field is required" and the form reloads **using the data that you have previously typed**

### Actual result
1. Country is shown as optional (broken by #19145)
2. This is working already properly with J3.8.5 / staging


### Documentation Changes Required
None



