### PR TITLE
[4.0] Use the correct table name when creating a filter table

### DIFF
--- a/administrator/components/com_finder/Table/FilterTable.php
+++ b/administrator/components/com_finder/Table/FilterTable.php
@@ -254,7 +254,7 @@ class FilterTable extends Table
 		}
 
 		// Verify that the alias is unique
-		$table = new Filter($this->getDbo());
+		$table = new static($this->getDbo());
 
 		if ($table->load(array('alias' => $this->alias)) && ($table->filter_id != $this->filter_id || $this->filter_id == 0))
 		{


### PR DESCRIPTION
Its not possible to create a filter in smart search as the old table name is still used.