### PR TITLE
Use jasmine done helper when using setTimeout in tests

### DIFF
--- a/tests/javascript/calendar/spec.js
+++ b/tests/javascript/calendar/spec.js
@@ -28,11 +28,12 @@ define(['jquery', 'testsRoot/calendar/spec-setup', 'jasmineJquery'], function ($
 			expect($('.js-calendar').css('display')).toEqual('none');
 		});
 
-		it('Should appear on button click', function () {
+		it('Should appear on button click', function (done) {
 			$('#jform_created_btn').trigger('click');
 
             setTimeout(function() {
                 expect($('.js-calendar').css('display')).toEqual('block');
+                done();
             }, 200)
 
 		});

--- a/tests/javascript/core/spec.js
+++ b/tests/javascript/core/spec.js
@@ -197,12 +197,13 @@ define(['jquery', 'testsRoot/core/spec-setup', 'jasmineJquery'], function ($) {
 			expect($messages[1]).toContainText('Error one');
 		});
 
-		it('removeMessages should remove all content from system-message-container', function () {
+		it('removeMessages should remove all content from system-message-container', function (done) {
 			Joomla.removeMessages();
 
 			// Alerts need some time for the close animation
 			setTimeout(function () {
 				expect($("#system-message-container")).toBeEmpty();
+				done();
 			}, 400);
 		});
 	});


### PR DESCRIPTION
### Summary of Changes

The current tests are useless (they dont fail) and make it hard to debug failing tests.

### Testing Instructions

1) change expectations so that the tests should fail i.e. instead of 
`expect($("#system-message-container")).toBeEmpty();` use `expect($("#system-message-container")).not.toBeEmpty();` in calendar/spec.js line 205
2) run tests => tests do not fail 
3) apply this patch and change expectation again
4) run tests => tests fail (as expected)

### Expected result

working tests

### Actual result

useless tests

### Documentation Changes Required

@astridx 
https://docs.joomla.org/JavaScript_Tests_for_Joomla4 (code sample also has the error)