### PR TITLE
Prevent compounding inputmode attribute

### DIFF
--- a/layouts/joomla/form/field/text.php
+++ b/layouts/joomla/form/field/text.php
@@ -71,7 +71,7 @@ $attributes = array(
 	$autocomplete,
 	$autofocus ? ' autofocus' : '',
 	$spellcheck ? '' : 'spellcheck="false"',
-	!empty($inputmode) ? 'inputmode="' . $inputmode . '"' : '',
+	!empty($inputmode) ? $inputmode : '',
 	!empty($pattern) ? 'pattern="' . $pattern . '"' : '',
 );
 ?>


### PR DESCRIPTION
Pull Request for Issue #19563.

### Summary of Changes
Fix `inputmode` name from being included in the `inputmode` value.

This change matches how `$maxLength` and `$dirname` are implemented in `\libraries\joomla\form\fields\text.php` and `\layouts\joomla\form\field\text.php`.

### Testing Instructions
In `\components\com_content\models\forms\article.xml` after line 37, add: `inputmode="numeric"`

Edit an article in the front end. 
View page source.
Find `inputmode` attribute.

### Expected result
`<input type="text" name="jform[title]" id="jform_title"  value="Joomla! Testing" class="inputbox required" size="30"       required aria-required="true"     inputmode="numeric"  />`


### Actual result
`<input type="text" name="jform[title]" id="jform_title"  value="Joomla! Testing" class="inputbox required" size="30"       required aria-required="true"    inputmode=" inputmode="numeric""  />`


### Documentation Changes Required
none
