### PR TITLE
Fix user profile plugin

### DIFF
--- a/plugins/user/profile/profile.php
+++ b/plugins/user/profile/profile.php
@@ -243,7 +243,7 @@ class PlgUserProfile extends JPlugin
 
 		// Add the registration fields to the form.
 		JForm::addFormPath(__DIR__ . '/profiles');
-		$form->loadFile('profile', false);
+		$form->loadFile('profile');
 
 		$fields = array(
 			'address1',


### PR DESCRIPTION
Pull Request for Issue #

### Summary of Changes
This PF fixes user profile field are optional on registration form even it is configured as a required field. This is an alternative for existing PRs #19614 and #19617. See https://github.com/joomla/joomla-cms/pull/19617#issuecomment-364481281 for the reason if the error if needed.


### Testing Instructions
1. Enable user profile plugin

2. Set address 1 field as required

3. Try to register for an account on your site

- Before patch: The address 1 field is displayed as optional field
- After patch: The address 1 field becomes a required field (as configured from the plugin)