### PR TITLE
[4.0] Setup eslint for es6

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+# A list of files to ignore from linting

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,10 +1,16 @@
 {
-	"extends": "airbnb-base",
-	"parser": "babel-eslint",
-	"env": {
-		"browser": true
-	},
-	"rules": {
-		"class-methods-use-this": "off"
-	}
+  // Extend the airbnb eslint config
+  "extends": "airbnb-base",
+  // ESLint will not look in parent folders for eslint configs
+  "root": true,
+  // An environment defines global variables that are predefined.
+  "env": {
+    "browser": true,
+    "es6": true,
+    "node": true
+  },
+  // Additional global variables your script accesses during execution
+  "globals": {
+    "Joomla": true
+  }
 }

--- a/build/build.php
+++ b/build/build.php
@@ -109,6 +109,8 @@ $doNotPackage = array(
 	'dev',
 	'.appveyor.yml',
 	'.drone.yml',
+	'.eslintignore',
+	'.eslint',
 	'.github',
 	'.gitignore',
 	'.hound.yml',

--- a/package.json
+++ b/package.json
@@ -8,10 +8,11 @@
     "url": "https://github.com/joomla/joomla-cms.git"
   },
   "scripts": {
-    "compile-js": "node build --compilejs",
-    "compile-sass": "node build --compilecss",
-    "update-dependencies": "node build --update",
-    "javascript-tests": "node node_modules/karma/bin/karma start karma.conf.js --single-run"
+    "build:js": "node build --compilejs",
+    "build:css": "node build --compilecss",
+    "lint:js": "node ./node_modules/eslint/bin/eslint.js --ext=.es6.js . || exit 0",
+    "test": "node node_modules/karma/bin/karma start karma.conf.js --single-run",
+    "update": "node build --update"
   },
   "dependencies": {
     "awesomplete": "1.1.2",
@@ -45,9 +46,8 @@
     "babelify": "^8.0.0",
     "browserify": "*",
     "eslint": "latest",
-    "eslint-config-airbnb": "latest",
-    "eslint-config-airbnb-base": "latest",
-    "eslint-plugin-import": "latest",
+    "eslint-config-airbnb-base": "^12.1.0",
+    "eslint-plugin-import": "^2.8.0",
     "fs": "0.0.1-security",
     "fs-extra": "^4.0.2",
     "ini": "latest",


### PR DESCRIPTION
Currently we are not checking the js codestyle at all. I was told that we are trying to use the airbnb codestyles. I checked media/system/core.js and it has 2300 cs errors (thats more than 2 per line) so its time to improve things here.

Airbnb code styles are widely accepted, more info: https://github.com/airbnb/javascript

This PR prepares js code style checks. 

### Changes

* Use airbnb eslint config
* Rename scripts

### Changes to scripts

* `npm run compile-js` is now `npm run build:js`
* `npm run compile-sass` is now `npm run build:css`
* Introduced new script `npm run lint:js` to check javascript cs (currently only for es6 and not used in ci so far)
* `npm run update-dependencies` is now `npm run update`

### Documentation changes 

Yes, we need to update code styles (which are outdated): https://developer.joomla.org/coding-standards/javascript.html (can be addopted from https://github.com/airbnb/javascript)




