### PR TITLE
Proxy to a higher error handler if there is one available

### DIFF
--- a/plugins/system/redirect/redirect.php
+++ b/plugins/system/redirect/redirect.php
@@ -246,6 +246,14 @@ class PlgSystemRedirect extends JPlugin
 			}
 		}
 
-		JErrorPage::render($error);
+		// Proxy to the previous exception handler if available, otherwise just render the error page
+		if (self::$previousExceptionHandler)
+		{
+			call_user_func_array(self::$previousExceptionHandler, array($error));
+		}
+		else
+		{
+			JErrorPage::render($error);
+		}
 	}
 }


### PR DESCRIPTION
If there is an exception handler available then we should call it instead of immediately rendering the page - this is good practice - and required for compatibility with other 3rd party extensions that want to hook into the rendering process

In core: test that rendering of the page should continue to work