### PR TITLE
[4.0][Installer] Fix DB selection.

### DIFF
--- a/installation/forms/setup.xml
+++ b/installation/forms/setup.xml
@@ -76,9 +76,9 @@
 				id="db_type"
 				class="custom-select form-control"
 				label="INSTL_DATABASE_TYPE_DESC"
-				supported="mysqli,pdomysql,postgresql"
+				supported="mysql,postgresql"
 				required="true"
-				default="mysqli"
+				default="mysql"
 				filter="string"
 		/>
 		<field

--- a/installation/forms/setup.xml
+++ b/installation/forms/setup.xml
@@ -76,7 +76,7 @@
 				id="db_type"
 				class="custom-select form-control"
 				label="INSTL_DATABASE_TYPE_DESC"
-				supported="mysql,postgresql"
+				supported="mysql,mysqli,pgsql,postgresql"
 				required="true"
 				default="mysql"
 				filter="string"

--- a/installation/src/Model/DatabaseModel.php
+++ b/installation/src/Model/DatabaseModel.php
@@ -306,6 +306,8 @@ class DatabaseModel extends BaseInstallationModel
 		// Disable autoselect database before it's created.
 		$tmpSelect = true;
 
+		$options = (object) $options;
+
 		if (isset($options->db_select))
 		{
 			$tmpSelect = $options->db_select;
@@ -338,7 +340,7 @@ class DatabaseModel extends BaseInstallationModel
 			 * PDO MySQL: [1049] Unknown database 'database_name'
 			 * PostgreSQL: Error connecting to PGSQL database
 			 */
-			if ($type == 'pdomysql' && strpos($e->getMessage(), '[1049] Unknown database') === 42)
+			if ($type === 'pdomysql' && strpos($e->getMessage(), '[1049] Unknown database') === 42)
 			{
 				/*
 				 * Now we're really getting insane here; we're going to try building a new JDatabaseDriver instance without the database name
@@ -377,7 +379,7 @@ class DatabaseModel extends BaseInstallationModel
 					throw new \RuntimeException(\JText::sprintf('INSTL_DATABASE_COULD_NOT_CONNECT', $e->getMessage()), 500, $e);
 				}
 			}
-			elseif ($type == 'postgresql' && strpos($e->getMessage(), 'Error connecting to PGSQL database') === 42)
+			elseif ($type === 'postgresql' && strpos($e->getMessage(), 'Error connecting to PGSQL database') === 42)
 			{
 				throw new \RuntimeException(\JText::_('INSTL_DATABASE_COULD_NOT_CREATE_DATABASE'), 500, $e);
 			}


### PR DESCRIPTION
### Summary of Changes

Joomla 4 use framework DB package now, we must use `mysql` instead `pdomysql` as connection name in installer.

### Testing Instructions

Go to installer step2, the mysql type didn't show at the DB select list.

After this patch, you can select MySQL type.
