### PR TITLE
Defining typeAlias in AdminModel

### DIFF
--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -22,6 +22,14 @@ use Joomla\Utilities\ArrayHelper;
 abstract class AdminModel extends FormModel
 {
 	/**
+	 * The type alias for this content type (for example, 'com_content.article').
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public $typeAlias;
+
+	/**
 	 * The prefix to use with controller messages.
 	 *
 	 * @var    string


### PR DESCRIPTION
Currently, batch operations will generate PHP notices if the 3rd party model doesn't specify the `typeAlias` property for some reason.
This is because `\Joomla\CMS\MVC\Model\AdminModel` doesn't define the property itself.

### Summary of Changes
This PR adds the property definition to the class


### Testing Instructions
Test that batch operations still work.
Since core to my knowledge isn't affected, nothing should change here.
To test the appearance of the notices, you can try with my component ( (eg https://www.sermonspeaker.net/download/sermonspeaker-component/sermonspeaker-component-5-7-1.html)).

### Expected result
No notice


### Actual result
Notices with some 3rd party.


### Documentation Changes Required
None