### PR TITLE
Plain English cont.

### DIFF
--- a/administrator/language/en-GB/en-GB.plg_editors-xtd_article.ini
+++ b/administrator/language/en-GB/en-GB.plg_editors-xtd_article.ini
@@ -4,5 +4,5 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_ARTICLE_BUTTON_ARTICLE="Article"
-PLG_ARTICLE_XML_DESCRIPTION="Displays a button to make it possible to insert links to articles into an Article. Displays a popup allowing you to choose the article."
+PLG_ARTICLE_XML_DESCRIPTION="Displays a button to insert links to articles into an Article. Displays a popup allowing you to choose the article."
 PLG_EDITORS-XTD_ARTICLE="Button - Article"

--- a/administrator/language/en-GB/en-GB.plg_editors-xtd_article.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_editors-xtd_article.sys.ini
@@ -3,7 +3,7 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 
-PLG_ARTICLE_XML_DESCRIPTION="Displays a button to make it possible to insert links to articles into an Article. Displays a popup allowing you to choose the article."
+PLG_ARTICLE_XML_DESCRIPTION="Displays a button to insert links to articles into an Article. Displays a popup allowing you to choose the article."
 PLG_EDITORS-XTD_ARTICLE="Button - Article"
 
 

--- a/administrator/language/en-GB/en-GB.plg_editors-xtd_contact.ini
+++ b/administrator/language/en-GB/en-GB.plg_editors-xtd_contact.ini
@@ -5,4 +5,4 @@
 
 PLG_EDITORS-XTD_CONTACT="Button - Contact"
 PLG_EDITORS-XTD_CONTACT_BUTTON_CONTACT="Contact"
-PLG_EDITORS-XTD_CONTACT_XML_DESCRIPTION="Displays a button to make it possible to insert links to Contacts in an article. Displays a popup allowing you to choose the contact."
+PLG_EDITORS-XTD_CONTACT_XML_DESCRIPTION="Displays a button to insert links to Contacts in an article. Displays a popup allowing you to choose the contact."

--- a/administrator/language/en-GB/en-GB.plg_editors-xtd_contact.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_editors-xtd_contact.sys.ini
@@ -4,4 +4,4 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_EDITORS-XTD_CONTACT="Button - Contact"
-PLG_EDITORS-XTD_CONTACT_XML_DESCRIPTION="Displays a button to make it possible to insert links to Contacts in an article. Displays a popup allowing you to choose the contact."
+PLG_EDITORS-XTD_CONTACT_XML_DESCRIPTION="Displays a button to insert links to Contacts in an article. Displays a popup allowing you to choose the contact."

--- a/administrator/language/en-GB/en-GB.plg_editors-xtd_fields.ini
+++ b/administrator/language/en-GB/en-GB.plg_editors-xtd_fields.ini
@@ -5,4 +5,4 @@
 
 PLG_EDITORS-XTD_FIELDS="Button - Field"
 PLG_EDITORS-XTD_FIELDS_BUTTON_FIELD="Field"
-PLG_EDITORS-XTD_FIELDS_XML_DESCRIPTION="Displays a button to make it possible to insert a custom field into an editor area. Displays a popup allowing you to choose the field.<br/><strong>Warning!</strong>: the custom field will not be rendered if the <a href=\"index.php?option=com_plugins&view=plugins&filter[folder]=content\">Content - Fields</a> plugin is not enabled."
+PLG_EDITORS-XTD_FIELDS_XML_DESCRIPTION="Displays a button to insert a custom field into an editor area. Displays a popup allowing you to choose the field.<br/><strong>Warning!</strong>: the custom field will not be rendered if the <a href=\"index.php?option=com_plugins&view=plugins&filter[folder]=content\">Content - Fields</a> plugin is not enabled."

--- a/administrator/language/en-GB/en-GB.plg_editors-xtd_fields.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_editors-xtd_fields.sys.ini
@@ -4,4 +4,4 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_EDITORS-XTD_FIELDS="Button - Field"
-PLG_EDITORS-XTD_FIELDS_XML_DESCRIPTION="Displays a button to make it possible to insert a custom field into an editor area. Displays a popup allowing you to choose the field.<br/><strong>Warning!</strong>: the custom field will not be rendered if the <a href=\"index.php?option=com_plugins&view=plugins&filter[folder]=content\">Content - Fields</a> plugin is not enabled."
+PLG_EDITORS-XTD_FIELDS_XML_DESCRIPTION="Displays a button to insert a custom field into an editor area. Displays a popup allowing you to choose the field.<br/><strong>Warning!</strong>: the custom field will not be rendered if the <a href=\"index.php?option=com_plugins&view=plugins&filter[folder]=content\">Content - Fields</a> plugin is not enabled."

--- a/administrator/language/en-GB/en-GB.plg_editors-xtd_image.ini
+++ b/administrator/language/en-GB/en-GB.plg_editors-xtd_image.ini
@@ -5,5 +5,5 @@
 
 PLG_EDITORS-XTD_IMAGE="Button - Image"
 PLG_IMAGE_BUTTON_IMAGE="Image"
-PLG_IMAGE_XML_DESCRIPTION="Displays a button to make it possible to insert images into an Article. Displays a popup allowing you to configure an image's properties and upload new image files."
+PLG_IMAGE_XML_DESCRIPTION="Displays a button to insert images into an Article. Displays a popup allowing you to configure an image's properties and upload new image files."
 

--- a/administrator/language/en-GB/en-GB.plg_editors-xtd_image.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_editors-xtd_image.sys.ini
@@ -4,5 +4,5 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_EDITORS-XTD_IMAGE="Button - Image"
-PLG_IMAGE_XML_DESCRIPTION="Displays a button to make it possible to insert images into an Article. Displays a popup allowing you to configure an image's properties and upload new image files."
+PLG_IMAGE_XML_DESCRIPTION="Displays a button to insert images into an Article. Displays a popup allowing you to configure an image's properties and upload new image files."
 

--- a/administrator/language/en-GB/en-GB.plg_editors-xtd_menu.ini
+++ b/administrator/language/en-GB/en-GB.plg_editors-xtd_menu.ini
@@ -5,4 +5,4 @@
 
 PLG_EDITORS-XTD_MENU="Button - Menu"
 PLG_EDITORS-XTD_MENU_BUTTON_MENU="Menu"
-PLG_EDITORS-XTD_MENU_XML_DESCRIPTION="Displays a button to make it possible to insert menu item links into an Article. Displays a popup allowing you to choose the menu item."
+PLG_EDITORS-XTD_MENU_XML_DESCRIPTION="Displays a button to insert menu item links into an Article. Displays a popup allowing you to choose the menu item."

--- a/administrator/language/en-GB/en-GB.plg_editors-xtd_menu.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_editors-xtd_menu.sys.ini
@@ -4,4 +4,4 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_EDITORS-XTD_MENU="Button - Menu"
-PLG_EDITORS-XTD_MENU_XML_DESCRIPTION="Displays a button to make it possible to insert menu item links into an Article. Displays a popup allowing you to choose the menu item."
+PLG_EDITORS-XTD_MENU_XML_DESCRIPTION="Displays a button to insert menu item links into an Article. Displays a popup allowing you to choose the menu item."

--- a/administrator/language/en-GB/en-GB.plg_editors-xtd_module.ini
+++ b/administrator/language/en-GB/en-GB.plg_editors-xtd_module.ini
@@ -5,4 +5,4 @@
 
 PLG_EDITORS-XTD_MODULE="Button - Module"
 PLG_MODULE_BUTTON_MODULE="Module"
-PLG_MODULE_XML_DESCRIPTION="Displays a button to make it possible to insert a module into an Article. Displays a popup allowing you to choose the module."
+PLG_MODULE_XML_DESCRIPTION="Displays a button to insert a module into an Article. Displays a popup allowing you to choose the module."

--- a/administrator/language/en-GB/en-GB.plg_editors-xtd_module.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_editors-xtd_module.sys.ini
@@ -4,4 +4,4 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_EDITORS-XTD_MODULE="Button - Module"
-PLG_MODULE_XML_DESCRIPTION="Displays a button to make it possible to insert a module into an Article. Displays a popup allowing you to choose the module."
+PLG_MODULE_XML_DESCRIPTION="Displays a button to insert a module into an Article. Displays a popup allowing you to choose the module."


### PR DESCRIPTION
The accessibility standard Web Content Accessibility Guidelines (WCAG) 2.0 Section 3 states https://www.w3.org/TR/WCAG20/#understandable

>### 3. Understandable
> Information and the operation of user interface must be understandable.

>#### Guideline 3.1 Readable
> Make text content readable and understandable.

> #### Success Criterion 3.1.5 Reading Level
> When text requires reading ability more advanced than the lower secondary education level after removal of proper names and titles, supplemental content, or a version that does not require reading ability more advanced than the lower secondary education level, is available.

To achieve this we should use "plain language" wherever possible

1. Word choice: use the simplest word that conveys your meaning.
http://plainlanguagenetwork.org/plain-language/what-is-plain-language/

2. Prefer the short word to the long.
https://www.plainlanguage.gov/guidelines/words/

This PR continues the work and removes the superfluous text " to make it possible"