### PR TITLE
Move custom buttons to the other buttons in TinyMCE

### DIFF
--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -575,7 +575,7 @@ class PlgEditorTinymce extends JPlugin
 		if ($custom_button)
 		{
 			$separator = strpos($custom_button, ',') !== false ? ',' : ' ';
-			$toolbar2  = array_merge($toolbar2, explode($separator, $custom_button));
+			$toolbar1  = array_merge($toolbar1, explode($separator, $custom_button));
 		}
 
 		// Drag and drop Images


### PR DESCRIPTION
### Summary of Changes
If you fill out a custom TinyMCE button field (in the TinyMCE plugin), it will be added after the editorx buttons.

![grafik](https://user-images.githubusercontent.com/1229869/36121870-d2bc2244-1047-11e8-864f-8eec955d75e6.png)

This PR moves the buttons beside the other buttons.

### Test instructions
Fill in a button name (e.g. codesample)

![grafik](https://user-images.githubusercontent.com/1229869/36123673-ba03000a-104d-11e8-90df-2f66728ed912.png)


### Expected result
![grafik](https://user-images.githubusercontent.com/1229869/36123720-da51f5be-104d-11e8-8645-b15085ae005b.png)

Button is next to the core buttons.


### Actual result
![grafik](https://user-images.githubusercontent.com/1229869/36123506-2e78abac-104d-11e8-96b9-1a4761a18cf5.png)

Buttons are in a new line at the end.
