### PR TITLE
[4.0] Fix pathway tests to match old behaviour

### DIFF
--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -104,10 +104,10 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
 	/**
 	 * The pathway object
 	 *
-	 * @var    Pathway
+	 * @var    Pathway[]
 	 * @since  __DEPLOY_VERSION__
 	 */
-	protected $pathway = null;
+	protected $pathway = [];
 
 	/**
 	 * Class constructor.
@@ -603,12 +603,19 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
 			$name = $this->getName();
 		}
 
-		if (!$this->pathway)
+		$name = strtolower($name);
+
+		if (!array_key_exists($name, $this->pathway))
 		{
-			$this->pathway = $this->getContainer()->get(ucfirst($name) . 'Pathway');
+			if (!$this->getContainer()->has(ucfirst($name) . 'Pathway'))
+			{
+				throw new \RuntimeException(\JText::sprintf('JLIB_APPLICATION_ERROR_PATHWAY_LOAD', $name), 500);
+			}
+
+			$this->pathway[$name] = $this->getContainer()->get(ucfirst($name) . 'Pathway');
 		}
 
-		return $this->pathway;
+		return $this->pathway[$name];
 	}
 
 	/**

--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -605,17 +605,17 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
 
 		$name = strtolower($name);
 
-		if (!array_key_exists($name, $this->pathway))
+		if (!array_key_exists($name . 'pathway', $this->pathway))
 		{
 			if (!$this->getContainer()->has(ucfirst($name) . 'Pathway'))
 			{
 				throw new \RuntimeException(\JText::sprintf('JLIB_APPLICATION_ERROR_PATHWAY_LOAD', $name), 500);
 			}
 
-			$this->pathway[$name] = $this->getContainer()->get(ucfirst($name) . 'Pathway');
+			$this->pathway[$name . 'pathway'] = $this->getContainer()->get(ucfirst($name) . 'Pathway');
 		}
 
-		return $this->pathway[$name];
+		return $this->pathway[$name . 'pathway'];
 	}
 
 	/**

--- a/libraries/src/Service/Provider/Pathway.php
+++ b/libraries/src/Service/Provider/Pathway.php
@@ -11,6 +11,7 @@ namespace Joomla\CMS\Service\Provider;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Application\SiteApplication;
+use Joomla\CMS\Pathway\Pathway as GlobalPathway;
 use Joomla\CMS\Pathway\SitePathway;
 use Joomla\DI\Container;
 use Joomla\DI\ServiceProviderInterface;
@@ -41,6 +42,18 @@ class Pathway implements ServiceProviderInterface
 				function (Container $container)
 				{
 					return new SitePathway($container->get(SiteApplication::class));
+				},
+				true
+			);
+
+		$container->alias('Pathway', GlobalPathway::class)
+			->alias('JPathway', GlobalPathway::class)
+			->alias('pathway', GlobalPathway::class)
+			->share(
+				GlobalPathway::class,
+				function (Container $container)
+				{
+					return new GlobalPathway;
 				},
 				true
 			);

--- a/tests/unit/suites/libraries/cms/application/JApplicationCmsTest.php
+++ b/tests/unit/suites/libraries/cms/application/JApplicationCmsTest.php
@@ -105,8 +105,12 @@ class JApplicationCmsTest extends TestCaseDatabase
 		$config = new Registry;
 		$config->set('session', false);
 
+		$container = new \Joomla\DI\Container;
+		$pathwayProvider = new \Joomla\CMS\Service\Provider\Pathway;
+		$pathwayProvider->register($container);
+
 		// Get a new JApplicationCmsInspector instance.
-		$this->class = new JApplicationCmsInspector($this->getMockInput(), $config);
+		$this->class = new JApplicationCmsInspector($this->getMockInput(), $config, null, $container);
 		$this->class->setSession(JFactory::$session);
 		$this->class->setDispatcher($this->getMockDispatcher());
 

--- a/tests/unit/suites/libraries/cms/application/JApplicationSiteTest.php
+++ b/tests/unit/suites/libraries/cms/application/JApplicationSiteTest.php
@@ -102,10 +102,16 @@ class JApplicationSiteTest extends TestCaseDatabase
 		$config = new Registry;
 		$config->set('session', false);
 
+		$container = new \Joomla\DI\Container;
+		$pathwayProvider = new \Joomla\CMS\Service\Provider\Pathway;
+		$pathwayProvider->register($container);
+
 		// Get a new JApplicationSite instance.
 		$this->class = new JApplicationSite($this->getMockInput(), $config);
 		$this->class->setSession(JFactory::$session);
 		$this->class->setDispatcher($this->getMockDispatcher());
+		$container->set('Joomla\CMS\Application\SiteApplication', $this->class);
+		$this->class->setContainer($container);
 		TestReflection::setValue('JApplicationCms', 'instances', array('site' => $this->class));
 
 		JFactory::$application = $this->class;


### PR DESCRIPTION
A slightly different approach to #19669 that stays a bit truer to the original 3.x code. @laoneo and @mbabker thoughts? I'm not so keen on the creating container for tests - I guess we should really inject a mock container and check it's `has` and `get` methods are called with the correct params. On the positive side much less `Factory::getContainer();` stuff...

This also allows you to use the `$name` param because with the `pathway` var in the application we were only going to use whatever it's first value was. Now we can have multiple pathways (although quite what an empty string array key does idk but it doesn't break the tests so i guess it's ok??)