### PR TITLE
ensure core_params are Registry object

### DIFF
--- a/components/com_tags/views/tag/view.html.php
+++ b/components/com_tags/views/tag/view.html.php
@@ -93,6 +93,7 @@ class TagsViewTag extends JViewLegacy
 
 				// For some plugins.
 				!empty($itemElement->core_body) ? $itemElement->text = $itemElement->core_body : $itemElement->text = null;
+				
 				if (is_string($itemElement->core_params))
 				{
 					$itemElement->core_params = new Registry($itemElement->core_params);

--- a/components/com_tags/views/tag/view.html.php
+++ b/components/com_tags/views/tag/view.html.php
@@ -91,11 +91,10 @@ class TagsViewTag extends JViewLegacy
 
 				// For some plugins.
 				!empty($itemElement->core_body)? $itemElement->text = $itemElement->core_body : $itemElement->text = null;
-				if(is_string($itemElement->core_params))
+				if (is_string($itemElement->core_params))
 				{
 					$itemElement->core_params = new Registry($itemElement->core_params);
 				}
-
 
 				$dispatcher = JEventDispatcher::getInstance();
 

--- a/components/com_tags/views/tag/view.html.php
+++ b/components/com_tags/views/tag/view.html.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Site
  * @subpackage  com_tags
  *
- * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @copyright   Copyright (C) 2005 - 2018 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
@@ -85,20 +85,21 @@ class TagsViewTag extends JViewLegacy
 
 		if ($items !== false)
 		{
+			JPluginHelper::importPlugin('content');
+
 			foreach ($items as $itemElement)
 			{
 				$itemElement->event = new stdClass;
 
 				// For some plugins.
-				!empty($itemElement->core_body)? $itemElement->text = $itemElement->core_body : $itemElement->text = null;
+				!empty($itemElement->core_body) ? $itemElement->text = $itemElement->core_body : $itemElement->text = null;
 				if (is_string($itemElement->core_params))
 				{
 					$itemElement->core_params = new Registry($itemElement->core_params);
-				}
+				}				
 
 				$dispatcher = JEventDispatcher::getInstance();
 
-				JPluginHelper::importPlugin('content');
 				$dispatcher->trigger('onContentPrepare', array ('com_tags.tag', &$itemElement, &$itemElement->core_params, 0));
 
 				$results = $dispatcher->trigger('onContentAfterTitle', array('com_tags.tag', &$itemElement, &$itemElement->core_params, 0));
@@ -115,6 +116,16 @@ class TagsViewTag extends JViewLegacy
 				{
 					$itemElement->core_body = $itemElement->text;
 				}
+			}
+		}
+
+		// Categories store the images differently so lets re-map it so the display is correct
+		if ($items && $items[0]->type_alias === 'com_content.category')
+		{
+			foreach ($items as $row)
+			{
+				$core_params = json_decode($row->core_params);
+				$row->core_images = json_encode(array('image_intro' => $core_params->image, 'image_intro_alt' => $core_params->image_alt));
 			}
 		}
 
@@ -135,17 +146,20 @@ class TagsViewTag extends JViewLegacy
 		$active       = $app->getMenu()->getActive();
 		$temp         = clone $this->params;
 
+		// Convert item params to a Registry object
+		$item[0]->params = new Registry($item[0]->params);
+
 		// Check to see which parameters should take priority
 		if ($active)
 		{
 			$currentLink = $active->link;
 
-			// If the current view is the active item and an tag view for one tag, then the menu item params take priority
-			if (strpos($currentLink, 'view=tag') && (strpos($currentLink, '&id[0]=' . (string) $item[0]->id)))
+			// If the current view is the active item and a tag view for one tag, then the menu item params take priority
+			if (strpos($currentLink, 'view=tag') && strpos($currentLink, '&id[0]=' . (string) $item[0]->id))
 			{
-				// $item->params are the article params, $temp are the menu item params
+				// $item[0]->params are the tag params, $temp are the menu item params
 				// Merge so that the menu item params take priority
-				$this->params->merge($temp);
+				$item[0]->params->merge($temp);
 
 				// Load layout from active query (in case it is an alternative menu item)
 				if (isset($active->query['layout']))
@@ -155,14 +169,14 @@ class TagsViewTag extends JViewLegacy
 			}
 			else
 			{
-				// Current view is not tags, so the global params take priority since tags is not an item.
-				// Merge the menu item params with the global params so that the article params take priority
-				$temp->merge($this->state->params);
-				$this->params = $temp;
+				// Current menuitem is not a single tag view, so the tag params take priority.
+				// Merge the menu item params with the tag params so that the tag params take priority
+				$temp->merge($item[0]->params);
+				$item[0]->params = $temp;
 
 				// Check for alternative layouts (since we are not in a single-article menu item)
 				// Single-article menu item layout takes priority over alt layout for an article
-				if ($layout = $this->params->get('tags_layout'))
+				if ($layout = $item[0]->params->get('tag_layout'))
 				{
 					$this->setLayout($layout);
 				}
@@ -198,28 +212,28 @@ class TagsViewTag extends JViewLegacy
 	 */
 	protected function _prepareDocument()
 	{
-		$app   = JFactory::getApplication();
-		$menus = $app->getMenu();
-		$title = null;
-
-		// Generate the tags title to use for page title, page heading and show tags title option
+		$app              = JFactory::getApplication();
+		$menu             = $app->getMenu()->getActive();
 		$this->tags_title = $this->getTagsTitle();
+		$title            = '';
 
-		// Because the application sets a default page title,
-		// we need to get it from the menu item itself
-		$menu = $menus->getActive();
+		// Highest priority for "Browser Page Title".
+		if ($menu)
+		{
+			$title = $menu->params->get('page_title', '');
+		}
 
 		if ($this->tags_title)
 		{
 			$this->params->def('page_heading', $this->tags_title);
-			$title = $this->tags_title;
+			$title = $title ?: $this->tags_title;
 		}
 		elseif ($menu)
 		{
 			$this->params->def('page_heading', $this->params->get('page_title', $menu->title));
-			$title = $this->params->get('page_title', $menu->title);
+			$title = $title ?: $this->params->get('page_title', $menu->title);
 
-			if ($menu->query['option'] != 'com_tags')
+			if ($menu->query['option'] !== 'com_tags')
 			{
 				$this->params->set('page_subheading', $menu->title);
 			}

--- a/components/com_tags/views/tag/view.html.php
+++ b/components/com_tags/views/tag/view.html.php
@@ -91,6 +91,11 @@ class TagsViewTag extends JViewLegacy
 
 				// For some plugins.
 				!empty($itemElement->core_body)? $itemElement->text = $itemElement->core_body : $itemElement->text = null;
+				if(is_string($itemElement->core_params))
+				{
+					$itemElement->core_params = new Registry($itemElement->core_params);
+				}
+
 
 				$dispatcher = JEventDispatcher::getInstance();
 

--- a/htaccess.txt
+++ b/htaccess.txt
@@ -68,9 +68,6 @@ RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
 # If the requested path and file is not /index.php and the request
 # has not already been internally rewritten to the index.php script
 RewriteCond %{REQUEST_URI} !^/index\.php
-# the request is not for an image file
-RewriteCond %{REQUEST_URI} !\.jpg|\.png|\.gif$
-# and the requested path and file doesn't directly match a physical file
 RewriteCond %{REQUEST_FILENAME} !-f
 # and the requested path and file doesn't directly match a physical folder
 RewriteCond %{REQUEST_FILENAME} !-d

--- a/htaccess.txt
+++ b/htaccess.txt
@@ -68,6 +68,7 @@ RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
 # If the requested path and file is not /index.php and the request
 # has not already been internally rewritten to the index.php script
 RewriteCond %{REQUEST_URI} !^/index\.php
+# and the requested path and file doesn't directly match a physical file
 RewriteCond %{REQUEST_FILENAME} !-f
 # and the requested path and file doesn't directly match a physical folder
 RewriteCond %{REQUEST_FILENAME} !-d

--- a/htaccess.txt
+++ b/htaccess.txt
@@ -68,6 +68,8 @@ RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
 # If the requested path and file is not /index.php and the request
 # has not already been internally rewritten to the index.php script
 RewriteCond %{REQUEST_URI} !^/index\.php
+# the request is not for an image file
+RewriteCond %{REQUEST_URI} !\.jpg|\.png|\.gif$
 # and the requested path and file doesn't directly match a physical file
 RewriteCond %{REQUEST_FILENAME} !-f
 # and the requested path and file doesn't directly match a physical folder


### PR DESCRIPTION
Pull Request for Issue #19487 . 

### Summary of Changes
adds test for whether the core_params are a string, if they are converts them to a Registry object

Without this fix, a fatal error can occur in a content plugin that uses the parameters, as for example in the jw_disqus plugin as described in the issue tracker


### Testing Instructions
install jw_disqus plugin

create a menu item of type tags component compact tag list

add this code to components/com_tags/views/tag/view.html.php

if (is_string($itemElement->core_params))
{
		$itemElement->core_params = new Registry($itemElement->core_params);
}



### Expected result
Without the added code, this causes a fatal error in Joomla 3.8.5


### Actual result

With the added code, the page renders as it should

### Documentation Changes Required

None that I can see