### PR TITLE
[com_content][Multilanguage] - fix link when layout and association

### DIFF
--- a/components/com_content/helpers/route.php
+++ b/components/com_content/helpers/route.php
@@ -78,6 +78,14 @@ abstract class ContentHelperRoute
 			{
 				$link .= '&lang=' . $language;
 			}
+
+			$jinput = JFactory::getApplication()->input;
+			$layout = $jinput->get('layout');
+
+			if ($layout !== '')
+			{
+				$link .= '&layout=' . $layout;
+			}
 		}
 
 		return $link;


### PR DESCRIPTION
### Summary of Changes
added the layout param in the link when needed


### Testing Instructions

- in a multilanguage site
- create a Category Blog menu item in all languages and associates those items
- create a Category List menu item in all languages and associates those items
- click on the Category Blog menu item (en-GB for example)
- click on a different flags (it-IT for example) on the module languages switcher


### Expected result
you are redirected to the associated Category Blog menu item (it-IT for example)


### Actual result
you are redirected to the associated Category List menu item (it-IT for example)

