### PR TITLE
[a11y] Cache toolbar

### DIFF
--- a/administrator/components/com_cache/views/cache/view.html.php
+++ b/administrator/components/com_cache/views/cache/view.html.php
@@ -76,7 +76,7 @@ class CacheViewCache extends JViewLegacy
 		}
 
 		JToolbarHelper::custom('delete', 'delete.png', 'delete_f2.png', 'JTOOLBAR_DELETE', true);
-		JToolbarHelper::custom('deleteAll', 'delete.png', 'delete_f2.png', 'JTOOLBAR_DELETE_ALL', false);
+		JToolbarHelper::custom('deleteAll', 'remove.png', 'delete_f2.png', 'JTOOLBAR_DELETE_ALL', false);
 		JToolbarHelper::divider();
 
 		if (JFactory::getUser()->authorise('core.admin', 'com_cache'))


### PR DESCRIPTION
We use the icon name to populate the ID. This toolbar has the same icon for both buttons so we have two buttons with the same id which is an accessibility failure

This pr ensures every id attribute value is unique

Because the icon has multiple names we can simply use one of the alternative names as a quick and dirty fix.

There is no visual change