### PR TITLE
Possible misprint in plugins/sampledata/blog/blog.php

### DIFF
--- a/plugins/sampledata/blog/blog.php
+++ b/plugins/sampledata/blog/blog.php
@@ -282,7 +282,7 @@ class PlgSampledataBlog extends JPlugin
 				return $response;
 			}
 
-			// Get ID from category we just added
+			// Get ID from article we just added
 			$ids[] = $articleModel->getItem()->id;
 		}
 


### PR DESCRIPTION
I think $ids array stores articles ids, because $articleModel->getItem()->id. Maybe copy-paste from line 159/line 206?
Also, this possible misprint can be found in  4.0 branch.

It is only possible misprint in comments, so it's no errors here.