### PR TITLE
[4.0] Use the config from the container in installation app

### DIFF
--- a/installation/src/Service/Provider/Application.php
+++ b/installation/src/Service/Provider/Application.php
@@ -41,15 +41,7 @@ class Application implements ServiceProviderInterface
 			InstallationApplication::class,
 			function (Container $container)
 			{
-				$config = null;
-
-				// Load the global configuration file if available
-				if (file_exists(JPATH_CONFIGURATION . '/configuration.php'))
-				{
-					$config = Factory::getConfig();
-				}
-
-				$app = new InstallationApplication(null, $config, null, $container);
+				$app = new InstallationApplication(null, $container->get('config'), null, $container);
 
 				// The session service provider needs JFactory::$application, set it if still null
 				if (Factory::$application === null)

--- a/libraries/src/Service/Provider/Config.php
+++ b/libraries/src/Service/Provider/Config.php
@@ -39,7 +39,7 @@ class Config implements ServiceProviderInterface
 				{
 					if (!file_exists(JPATH_CONFIGURATION . '/configuration.php'))
 					{
-						return [];
+						return new Registry;
 					}
 
 					\JLoader::register('JConfig', JPATH_CONFIGURATION . '/configuration.php');


### PR DESCRIPTION
As with the introduction of a config service provider in #19658 the applications do get the config from the container. The installation app got forgotten, this pr fixes that.