### PR TITLE
Hide global configuration and system information from non super users

### DIFF
--- a/administrator/modules/mod_menu/menu.php
+++ b/administrator/modules/mod_menu/menu.php
@@ -314,6 +314,19 @@ class JAdminCssMenu
 
 				list($assetName) = isset($query['context']) ? explode('.', $query['context'], 2) : array('com_fields');
 			}
+			elseif ($item->element == 'com_config' && !$user->authorise('core.admin'))
+			{
+				continue;
+			}
+			elseif ($item->element == 'com_admin')
+			{
+				parse_str($item->link, $query);
+
+				if (isset($query['view']) && $query['view'] == 'sysinfo' && !$user->authorise('core.admin'))
+				{
+					continue;
+				}
+			}
 
 			if ($assetName && !$user->authorise(($item->scope == 'edit') ? 'core.create' : 'core.manage', $assetName))
 			{

--- a/administrator/modules/mod_menu/menu.php
+++ b/administrator/modules/mod_menu/menu.php
@@ -83,7 +83,7 @@ class JAdminCssMenu
 		$this->enabled = $enabled;
 		$menutype      = $this->params->get('menutype', '*');
 
-		if ($menutype == '*')
+		if ($menutype === '*')
 		{
 			$name   = $this->params->get('preset', 'joomla');
 			$levels = MenuHelper::loadPreset($name);
@@ -256,7 +256,7 @@ class JAdminCssMenu
 			$item->icon  = isset($item->icon) ? $item->icon : '';
 
 			// Whether this scope can be displayed. Applies only to preset items. Db driven items should use un/published state.
-			if (($item->scope == 'help' && !$this->params->get('showhelp')) || ($item->scope == 'edit' && !$this->params->get('shownew')))
+			if (($item->scope === 'help' && !$this->params->get('showhelp')) || ($item->scope === 'edit' && !$this->params->get('shownew')))
 			{
 				continue;
 			}
@@ -282,7 +282,7 @@ class JAdminCssMenu
 			}
 
 			// Exclude Mass Mail if disabled in global configuration
-			if ($item->scope == 'massmail' && (JFactory::getApplication()->get('massmailoff', 0) == 1))
+			if ($item->scope === 'massmail' && (JFactory::getApplication()->get('massmailoff', 0) == 1))
 			{
 				continue;
 			}
@@ -290,12 +290,12 @@ class JAdminCssMenu
 			// Exclude item if the component is not authorised
 			$assetName = $item->element;
 
-			if ($item->element == 'com_categories')
+			if ($item->element === 'com_categories')
 			{
 				parse_str($item->link, $query);
 				$assetName = isset($query['extension']) ? $query['extension'] : 'com_content';
 			}
-			elseif ($item->element == 'com_fields')
+			elseif ($item->element === 'com_fields')
 			{
 				parse_str($item->link, $query);
 
@@ -314,27 +314,27 @@ class JAdminCssMenu
 
 				list($assetName) = isset($query['context']) ? explode('.', $query['context'], 2) : array('com_fields');
 			}
-			elseif ($item->element == 'com_config' && !$user->authorise('core.admin'))
+			elseif ($item->element === 'com_config' && !$user->authorise('core.admin'))
 			{
 				continue;
 			}
-			elseif ($item->element == 'com_admin')
+			elseif ($item->element === 'com_admin')
 			{
 				parse_str($item->link, $query);
 
-				if (isset($query['view']) && $query['view'] == 'sysinfo' && !$user->authorise('core.admin'))
+				if (isset($query['view']) && $query['view'] === 'sysinfo' && !$user->authorise('core.admin'))
 				{
 					continue;
 				}
 			}
 
-			if ($assetName && !$user->authorise(($item->scope == 'edit') ? 'core.create' : 'core.manage', $assetName))
+			if ($assetName && !$user->authorise(($item->scope === 'edit') ? 'core.create' : 'core.manage', $assetName))
 			{
 				continue;
 			}
 
 			// Exclude if link is invalid
-			if (!in_array($item->type, array('separator', 'heading', 'container')) && trim($item->link) == '')
+			if (!in_array($item->type, array('separator', 'heading', 'container')) && trim($item->link) === '')
 			{
 				continue;
 			}
@@ -343,7 +343,7 @@ class JAdminCssMenu
 			$item->submenu = $this->preprocess($item->submenu);
 
 			// Populate automatic children for container items
-			if ($item->type == 'container')
+			if ($item->type === 'container')
 			{
 				$exclude    = (array) $item->params->get('hideitems') ?: array();
 				$components = MenusHelper::getMenuItems('main', false, $exclude);
@@ -360,7 +360,7 @@ class JAdminCssMenu
 			}
 
 			// Remove repeated and edge positioned separators, It is important to put this check at the end of any logical filtering.
-			if ($item->type == 'separator')
+			if ($item->type === 'separator')
 			{
 				if ($noSeparator)
 				{
@@ -381,7 +381,7 @@ class JAdminCssMenu
 				$language->load($item->element . '.sys', JPATH_ADMINISTRATOR . '/components/' . $item->element, null, false, true);
 			}
 
-			if ($item->type == 'separator' && $item->params->get('text_separator') == 0)
+			if ($item->type === 'separator' && $item->params->get('text_separator') == 0)
 			{
 				$item->title = '';
 			}
@@ -415,11 +415,11 @@ class JAdminCssMenu
 		{
 			$class = $this->enabled ? $item->class : 'disabled';
 
-			if ($item->type == 'separator')
+			if ($item->type === 'separator')
 			{
 				$this->tree->addChild(new Node\Separator($item->title));
 			}
-			elseif ($item->type == 'heading')
+			elseif ($item->type === 'heading')
 			{
 				// We already excluded heading type menu item with no children.
 				$this->tree->addChild(new Node\Heading($item->title, $class, null, $item->icon), $this->enabled);
@@ -430,7 +430,7 @@ class JAdminCssMenu
 					$this->tree->getParent();
 				}
 			}
-			elseif ($item->type == 'url')
+			elseif ($item->type === 'url')
 			{
 				$cNode = new Node\Url($item->title, $item->link, $item->browserNav, $class, null, $item->icon);
 				$this->tree->addChild($cNode, $this->enabled);
@@ -441,7 +441,7 @@ class JAdminCssMenu
 					$this->tree->getParent();
 				}
 			}
-			elseif ($item->type == 'component')
+			elseif ($item->type === 'component')
 			{
 				$cNode = new Node\Component($item->title, $item->element, $item->link, $item->browserNav, $class, null, $item->icon);
 				$this->tree->addChild($cNode, $this->enabled);
@@ -452,7 +452,7 @@ class JAdminCssMenu
 					$this->tree->getParent();
 				}
 			}
-			elseif ($item->type == 'container')
+			elseif ($item->type === 'container')
 			{
 				// We already excluded container type menu item with no children.
 				$this->tree->addChild(new Node\Container($item->title, $item->class, null, $item->icon), $this->enabled);


### PR DESCRIPTION
Pull Request for Issue #19478.

### Summary of Changes
Only super users have access to `Global Configuration` and `System Information`. This PR hides these 2 menu items from administrators.

Use identical operators for minor performance improvement.


### Testing Instructions
Log in as an Administrator.
View `System` menu.


### Expected result
No `Global Configuration` and `System Information`


### Actual result
Displays `Global Configuration` and `System Information`


### Documentation Changes Required
none
