### PR TITLE
Add deprecate log message for the pathway name attribute

### DIFF
--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -554,7 +554,7 @@ class CMSApplication extends WebApplication
 		else
 		{
 			// Name should not be used
-			Log::add('Name attribute is deprecated, in the future fetch the pathway trough the respective application.', Log::WARNING, 'deprecated');
+			Log::add('Name attribute is deprecated, in the future fetch the pathway through the respective application.', Log::WARNING, 'deprecated');
 		}
 
 		try

--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -551,6 +551,11 @@ class CMSApplication extends WebApplication
 		{
 			$name = $this->getName();
 		}
+		else
+		{
+			// Name should not be used
+			Log::add('Name attribute is deprecated, in the future fetch the pathway trough the respective application.', Log::WARNING, 'deprecated');
+		}
 
 		try
 		{


### PR DESCRIPTION
Pull Request for pr comment https://github.com/joomla/joomla-cms/pull/19672#issuecomment-366229895 .

### Summary of Changes
Deprecates the name parameter for the pathway object in the application. There is currently only the `SitePathway` object and in Joomla , the pathway should be loaded trough the corresponding application as the app holds then the pathway object directly. See #19528 where the getInstance function got deprecated.

This pr is a preparation that we can remove the name attribute in version 4.