### PR TITLE
[4.0] Build.js support file watch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ node_modules/
 # We are ignoring this as a temporary measure until Node 8 and npm5 become the LTS release
 # and we can require it.
 package-lock.json
+yarn.lock
 
 # Removed in Joomla 4 #
 administrator/templates/isis

--- a/build.js
+++ b/build.js
@@ -20,6 +20,7 @@ Program
 	.option('--compilecss, --compilecss path', 'Compiles all the scss files to css')
 	.option('--compilecejs, --compilecejs path', 'Compiles/traspiles all the custom elements files')
 	.option('--compilecescss, --compilecescss path', 'Compiles/traspiles all the custom elements files')
+	.option('--watch, --watch path', 'Watch file changes and re-compile (Only work for compilecss and compilejs now).')
 	.option('--installer', 'Creates the language file for installer error page')
 	.on('--help', () => {
 		console.log(Chalk.cyan('\n  Version %s\n'), options.version);
@@ -56,12 +57,20 @@ if (Program.installer) {
 
 // Convert scss to css
 if (Program['compilecss']) {
-	css.css(options, Program.args[0])
+	if (Program['watch']) {
+		css.watch(options, null, true);
+	} else {
+		css.css(options, Program.args[0])
+	}
 }
 
 // Compress/transpile the javascript files
 if (Program['compilejs']) {
-	Js.js(options, Program.args[0])
+	if (Program['watch']) {
+		Js.watch(options, null, false);
+	} else {
+		Js.js(options, Program.args[0])
+	}
 }
 
 // Compress/transpile the Custom Elements files

--- a/build/build-modules-js/compilescss.js
+++ b/build/build-modules-js/compilescss.js
@@ -6,10 +6,17 @@ const Recurs = require("recursive-readdir");
 const Sass = require('node-sass');
 const UglyCss = require('uglifycss');
 const autoprefixer = require('autoprefixer');
-const postcss      = require('postcss');
+const postcss = require('postcss');
+const debounce = require('lodash.debounce');
 
 // Various variables
 const rootPath = __dirname.replace('/build/build-modules-js', '').replace('\\build\\build-modules-js', '');
+const watches = [
+	rootPath + '/' + 'templates/cassiopeia/scss',
+	rootPath + '/' + 'administrator/templates/atum/scss',
+	rootPath + '/' + 'media/plg_installer_webinstaller/scss',
+	rootPath + '/' + 'media',
+];
 
 compileFiles = (options, path) => {
 	let files = [], folders = [];
@@ -82,7 +89,6 @@ compileFiles = (options, path) => {
 							// Write the file
 							fs.writeFileSync(file.replace('.css', '.min.css'), UglyCss.processFiles([file], {expandVars: false }), {encoding: "utf8"});
 						}
-
 					},
 					(error) => {
 						console.error("something exploded", error);
@@ -93,6 +99,33 @@ compileFiles = (options, path) => {
 
 };
 
+watchFiles = function(options, folders, compileFirst = false) {
+	folders = folders || watches;
+
+	if (compileFirst) {
+		compileFiles(options);
+	}
+
+	folders.forEach((folder) => {
+		Recurs(folder, ['*.css', '*.map', '*.js', '*.svg', '*.png', '*.swf']).then(
+			(files) => {
+				files.forEach((file) => {
+						if (file.match(/.scss/)) {
+							fs.watchFile(file, () => {
+								console.log('File: ' + file + ' changed.');
+								debounce(() => compileFiles(options), 150)();
+							});
+						}
+					},
+					(error) => {
+						console.error("something exploded", error);
+					}
+				);
+			});
+	});
+
+	console.log('Now watching SASS files...');
+};
 
 sass = (options, path) => {
 	Promise.resolve()
@@ -107,3 +140,4 @@ sass = (options, path) => {
 };
 
 module.exports.css = sass;
+module.exports.watch = watchFiles;

--- a/package.json
+++ b/package.json
@@ -10,11 +10,14 @@
   "scripts": {
     "build:js": "node build --compilejs",
     "build:css": "node build --compilecss",
+    "watch:js": "node build --compilejs --watch",
+    "watch:css": "node build --compilecss --watch",
     "lint:js": "node ./node_modules/eslint/bin/eslint.js --ext=.es6.js . || exit 0",
     "test": "node node_modules/karma/bin/karma start karma.conf.js --single-run",
     "update": "node build --update"
   },
   "dependencies": {
+    "@claviska/jquery-minicolors": "2.2.6",
     "awesomplete": "1.1.2",
     "bootstrap": "4.0.0",
     "codemirror": "5.34.0",
@@ -30,8 +33,7 @@
     "jquery-ui-dist": "1.12.1",
     "mediaelement": "4.2.8",
     "punycode": "1.4.1",
-    "tinymce": "4.7.6",
-    "@claviska/jquery-minicolors": "2.2.6"
+    "tinymce": "4.7.6"
   },
   "devDependencies": {
     "@polymer/test-fixture": "latest",
@@ -60,6 +62,7 @@
     "karma-jasmine-ajax": "latest",
     "karma-requirejs": "latest",
     "karma-verbose-reporter": "latest",
+    "lodash.debounce": "^4.0.8",
     "node-sass": "^4.5.3",
     "path": "^0.12.7",
     "recursive-copy": "latest",


### PR DESCRIPTION
This PR attempts to add file watch to `compilecss` and `compilejs` that we can get rid of re-compile manually every time after code changed.

### Usage

Watch CSS

```
npm run watch:css
```

Watch JS

```
npm run watch:js
```

Watch both

```
node build --compilecss --compilejs --watch
```

-----

Just curious why we don't use Gulp?