### PR TITLE
[4.0] Remove pathway name attribute

### DIFF
--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -16,6 +16,7 @@ use Joomla\CMS\Event\AbstractEvent;
 use Joomla\CMS\Event\BeforeExecuteEvent;
 use Joomla\CMS\Input\Input;
 use Joomla\CMS\Language\Language;
+use Joomla\CMS\Language\Text;
 use Joomla\CMS\Menu\AbstractMenu;
 use Joomla\CMS\Pathway\Pathway;
 use Joomla\CMS\Plugin\PluginHelper;
@@ -598,7 +599,17 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
 	{
 		if (!$this->pathway)
 		{
-			$this->pathway = $this->getContainer()->get(ucfirst($this->getName()) . 'Pathway');
+			$resourceName = ucfirst($this->getName()) . 'Pathway';
+
+			if (!$this->getContainer()->has($resourceName))
+			{
+				throw new \RuntimeException(
+					Text::sprintf('JLIB_APPLICATION_ERROR_PATHWAY_LOAD', $this->getName()),
+					500
+				);
+			}
+
+			$this->pathway = $this->getContainer()->get($resourceName);
 		}
 
 		return $this->pathway;

--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -590,22 +590,15 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
 	/**
 	 * Returns the application Pathway object.
 	 *
-	 * @param   string  $name  The name of the application.
-	 *
 	 * @return  Pathway
 	 *
 	 * @since   3.2
 	 */
-	public function getPathway($name = null)
+	public function getPathway()
 	{
-		if (!isset($name))
-		{
-			$name = $this->getName();
-		}
-
 		if (!$this->pathway)
 		{
-			$this->pathway = $this->getContainer()->get(ucfirst($name) . 'Pathway');
+			$this->pathway = $this->getContainer()->get(ucfirst($this->getName()) . 'Pathway');
 		}
 
 		return $this->pathway;

--- a/libraries/src/Service/Provider/Pathway.php
+++ b/libraries/src/Service/Provider/Pathway.php
@@ -44,5 +44,17 @@ class Pathway implements ServiceProviderInterface
 				},
 				true
 			);
+
+		$container->alias('Pathway', \Joomla\CMS\Pathway\Pathway::class)
+			->alias('JPathway', \Joomla\CMS\Pathway\Pathway::class)
+			->alias('pathway', \Joomla\CMS\Pathway\Pathway::class)
+			->share(
+				\Joomla\CMS\Pathway\Pathway::class,
+				function (Container $container)
+				{
+					return new \Joomla\CMS\Pathway\Pathway;
+				},
+				true
+			);
 	}
 }

--- a/tests/unit/suites/libraries/cms/application/JApplicationAdministratorTest.php
+++ b/tests/unit/suites/libraries/cms/application/JApplicationAdministratorTest.php
@@ -200,7 +200,7 @@ class JApplicationAdministratorTest extends TestCaseDatabase
 	 *
 	 * @since   3.2
 	 *
-	 * @expectedException  RuntimeException
+	 * @expectedException  \Joomla\DI\Exception\KeyNotFoundException
 	 * @covers  JApplicationAdministrator::getPathway
 	 */
 	public function testGetPathway()

--- a/tests/unit/suites/libraries/cms/application/JApplicationAdministratorTest.php
+++ b/tests/unit/suites/libraries/cms/application/JApplicationAdministratorTest.php
@@ -200,7 +200,7 @@ class JApplicationAdministratorTest extends TestCaseDatabase
 	 *
 	 * @since   3.2
 	 *
-	 * @expectedException  \Joomla\DI\Exception\KeyNotFoundException
+	 * @expectedException  RuntimeException
 	 * @covers  JApplicationAdministrator::getPathway
 	 */
 	public function testGetPathway()

--- a/tests/unit/suites/libraries/cms/application/JApplicationCmsTest.php
+++ b/tests/unit/suites/libraries/cms/application/JApplicationCmsTest.php
@@ -106,7 +106,7 @@ class JApplicationCmsTest extends TestCaseDatabase
 		$config->set('session', false);
 
 		// Get a new JApplicationCmsInspector instance.
-		$this->class = new JApplicationCmsInspector($this->getMockInput(), $config);
+		$this->class = new JApplicationCmsInspector($this->getMockInput(), $config, null, JFactory::getContainer());
 		$this->class->setSession(JFactory::$session);
 		$this->class->setDispatcher($this->getMockDispatcher());
 

--- a/tests/unit/suites/libraries/cms/application/JApplicationCmsTest.php
+++ b/tests/unit/suites/libraries/cms/application/JApplicationCmsTest.php
@@ -106,6 +106,7 @@ class JApplicationCmsTest extends TestCaseDatabase
 		$config->set('session', false);
 
 		// Get a new JApplicationCmsInspector instance.
+		// @Todo mock the container properly
 		$this->class = new JApplicationCmsInspector($this->getMockInput(), $config, null, JFactory::getContainer());
 		$this->class->setSession(JFactory::$session);
 		$this->class->setDispatcher($this->getMockDispatcher());

--- a/tests/unit/suites/libraries/cms/application/JApplicationSiteTest.php
+++ b/tests/unit/suites/libraries/cms/application/JApplicationSiteTest.php
@@ -103,6 +103,7 @@ class JApplicationSiteTest extends TestCaseDatabase
 		$config->set('session', false);
 
 		// Get a new JApplicationSite instance.
+		// @Todo mock the container properly
 		$this->class = new JApplicationSite($this->getMockInput(), $config, null, JFactory::getContainer());
 		$this->class->setSession(JFactory::$session);
 		$this->class->setDispatcher($this->getMockDispatcher());

--- a/tests/unit/suites/libraries/cms/application/JApplicationSiteTest.php
+++ b/tests/unit/suites/libraries/cms/application/JApplicationSiteTest.php
@@ -103,7 +103,7 @@ class JApplicationSiteTest extends TestCaseDatabase
 		$config->set('session', false);
 
 		// Get a new JApplicationSite instance.
-		$this->class = new JApplicationSite($this->getMockInput(), $config);
+		$this->class = new JApplicationSite($this->getMockInput(), $config, null, JFactory::getContainer());
 		$this->class->setSession(JFactory::$session);
 		$this->class->setDispatcher($this->getMockDispatcher());
 		TestReflection::setValue('JApplicationCms', 'instances', array('site' => $this->class));


### PR DESCRIPTION
### Summary of Changes
As discussed in #19672 the name attribute for the getPathway function should be removed as the container is the store to manage the different pathway objects.

Additionally the unit tests get fixed.