### PR TITLE
Repair the update of database schema changes on postgreSQL

### DIFF
--- a/administrator/components/com_admin/sql/updates/postgresql/3.1.0.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.1.0.sql
@@ -1,6 +1,10 @@
 /* Changes to tables where data type conflicts exist with MySQL (mainly dealing with null values */
 ALTER TABLE "#__modules" ALTER COLUMN "content" SET DEFAULT '';
---ALTER TABLE "#__updates" ALTER COLUMN "data" SET DEFAULT '';
+--
+-- The following statement has to be disabled because it conflicts with
+-- a later change added with Joomla! 3.8.8 to repair the update of database schema changes
+--
+-- ALTER TABLE "#__updates" ALTER COLUMN "data" SET DEFAULT '';
 
 /* Tags database schema */
 

--- a/administrator/components/com_admin/sql/updates/postgresql/3.1.0.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.1.0.sql
@@ -1,6 +1,6 @@
 /* Changes to tables where data type conflicts exist with MySQL (mainly dealing with null values */
 ALTER TABLE "#__modules" ALTER COLUMN "content" SET DEFAULT '';
-ALTER TABLE "#__updates" ALTER COLUMN "data" SET DEFAULT '';
+--ALTER TABLE "#__updates" ALTER COLUMN "data" SET DEFAULT '';
 
 /* Tags database schema */
 

--- a/libraries/src/Schema/ChangeItem/PostgresqlChangeItem.php
+++ b/libraries/src/Schema/ChangeItem/PostgresqlChangeItem.php
@@ -40,20 +40,28 @@ class PostgresqlChangeItem extends ChangeItem
 	{
 		// Initialize fields in case we can't create a check query
 		$this->checkStatus = -1; // change status to skipped
+
 		$result = null;
+		$splitIntoWords = "~'[^']*'(*SKIP)(*F)|\s+~";
+		$splitIntoActions = "~'[^']*'(*SKIP)(*F)|,~";
 
 		// Remove any newlines
 		$this->updateQuery = str_replace("\n", '', $this->updateQuery);
+
+		// Remove trailing whitespace and semicolon
+		$this->updateQuery = rtrim($this->updateQuery, "; \t\n\r\0\x0B");
 
 		// Fix up extra spaces around () and in general
 		$find = array('#((\s*)\(\s*([^)\s]+)\s*)(\))#', '#(\s)(\s*)#');
 		$replace = array('($3)', '$1');
 		$updateQuery = preg_replace($find, $replace, $this->updateQuery);
-		$wordArray = explode(' ', $updateQuery);
+		$wordArray = preg_split($splitIntoWords, $updateQuery, null, PREG_SPLIT_NO_EMPTY);
+
+		$totalWords = count($wordArray);
 
 		// First, make sure we have an array of at least 6 elements
 		// if not, we can't make a check query for this one
-		if (count($wordArray) < 6)
+		if ($totalWords < 6)
 		{
 			// Done with method
 			return;
@@ -64,93 +72,171 @@ class PostgresqlChangeItem extends ChangeItem
 
 		if ($command === 'ALTER TABLE')
 		{
+			// Check only the last action
+			$actions = ltrim(substr($updateQuery, strpos($updateQuery, $wordArray[2]) + strlen($wordArray[2])));
+			$actions = preg_split($splitIntoActions, $actions);
+
+			// Get the last action
+			$lastActionArray = preg_split($splitIntoWords, end($actions), null, PREG_SPLIT_NO_EMPTY);
+
+			// Replace all actions by the last one
+			array_splice($wordArray, 3, count($wordArray), $lastActionArray);
+
+			$totalWords = count($wordArray);
+
 			$alterCommand = strtoupper($wordArray[3] . ' ' . $wordArray[4]);
 
 			if ($alterCommand === 'ADD COLUMN')
 			{
-				$result = 'SELECT column_name FROM information_schema.columns WHERE table_name='
-				. $this->fixQuote($wordArray[2]) . ' AND column_name=' . $this->fixQuote($wordArray[5]);
+				$result = 'SELECT column_name'
+					. ' FROM information_schema.columns'
+					. ' WHERE table_name='
+					. $this->fixQuote($wordArray[2])
+					. ' AND column_name=' . $this->fixQuote($wordArray[5]);
 
 				$this->queryType = 'ADD_COLUMN';
-				$this->msgElements = array($this->fixQuote($wordArray[2]), $this->fixQuote($wordArray[5]));
+				$this->msgElements = array(
+					$this->fixQuote($wordArray[2]),
+					$this->fixQuote($wordArray[5])
+				);
 			}
 			elseif ($alterCommand === 'DROP COLUMN')
 			{
-				$result = 'SELECT column_name FROM information_schema.columns WHERE table_name='
-				. $this->fixQuote($wordArray[2]) . ' AND column_name=' . $this->fixQuote($wordArray[5]);
+				$result = 'SELECT column_name'
+					. ' FROM information_schema.columns'
+					. ' WHERE table_name='
+					. $this->fixQuote($wordArray[2])
+					. ' AND column_name=' . $this->fixQuote($wordArray[5]);
 
 				$this->queryType = 'DROP_COLUMN';
 				$this->checkQueryExpected = 0;
-				$this->msgElements = array($this->fixQuote($wordArray[2]), $this->fixQuote($wordArray[5]));
+				$this->msgElements = array(
+					$this->fixQuote($wordArray[2]),
+					$this->fixQuote($wordArray[5])
+				);
 			}
 			elseif ($alterCommand === 'ALTER COLUMN')
 			{
-				if (strtoupper($wordArray[6]) === 'TYPE')
+				$alterAction = strtoupper($wordArray[6]);
+
+				if ($alterAction === 'TYPE')
 				{
 					$type = '';
 
-					for ($i = 7, $iMax = count($wordArray); $i < $iMax; $i++)
+					for ($i = 7; $i < $totalWords; $i++)
 					{
 						$type .= $wordArray[$i] . ' ';
 					}
 
+					if ($pos = stripos($type, 'USING'))
+					{
+						$type = substr($type, 0, $pos);
+					}
+
 					if ($pos = strpos($type, '('))
 					{
-						$type = substr($type, 0, $pos);
-					}
-
-					if ($pos = strpos($type, ';'))
-					{
-						$type = substr($type, 0, $pos);
-					}
-
-					$result = 'SELECT column_name, data_type FROM information_schema.columns WHERE table_name='
-						. $this->fixQuote($wordArray[2]) . ' AND column_name=' . $this->fixQuote($wordArray[5])
-						. ' AND data_type=' . $this->fixQuote($type);
-
-					$this->queryType = 'CHANGE_COLUMN_TYPE';
-					$this->msgElements = array($this->fixQuote($wordArray[2]), $this->fixQuote($wordArray[5]), $type);
-				}
-				elseif (strtoupper($wordArray[7] . ' ' . $wordArray[8]) === 'NOT NULL')
-				{
-					if (strtoupper($wordArray[6]) === 'SET')
-					{
-						// SET NOT NULL
-						$isNullable = $this->fixQuote('NO');
+						$datatype = substr($type, 0, $pos);
 					}
 					else
 					{
-						// DROP NOT NULL
-						$isNullable = $this->fixQuote('YES');
+						$datatype = substr($type, 0, -1);
 					}
 
-					$result = 'SELECT column_name, data_type, is_nullable FROM information_schema.columns WHERE table_name='
-						. $this->fixQuote($wordArray[2]) . ' AND column_name=' . $this->fixQuote($wordArray[5])
-						. ' AND is_nullable=' . $isNullable;
+					$result = 'SELECT column_name, data_type '
+						. 'FROM information_schema.columns WHERE table_name='
+						. $this->fixQuote($wordArray[2]) . ' AND column_name='
+						. $this->fixQuote($wordArray[5])
+						. ' AND data_type=' . $this->fixQuote($datatype);
+
+					if ($datatype === 'character varying')
+					{
+						$result .= ' AND character_maximum_length = ' . (int) substr($type, $pos + 1);
+					}
 
 					$this->queryType = 'CHANGE_COLUMN_TYPE';
-					$this->checkQueryExpected = 1;
-					$this->msgElements = array($this->fixQuote($wordArray[2]), $this->fixQuote($wordArray[5]), $isNullable);
+					$this->msgElements = array(
+						$this->fixQuote($wordArray[2]),
+						$this->fixQuote($wordArray[5]),
+						$type
+					);
 				}
-				elseif (strtoupper($wordArray[7]) === 'DEFAULT')
+				elseif ($alterAction === 'SET')
 				{
-					if (strtoupper($wordArray[6]) === 'SET')
-					{
-						$isNullDef = 'IS NOT NULL';
-					}
-					else
-					{
-						// DROP DEFAULT
-						$isNullDef = 'IS NULL';
-					}
+					$alterType = strtoupper($wordArray[7]);
 
-					$result = 'SELECT column_name, data_type, column_default FROM information_schema.columns WHERE table_name='
-						. $this->fixQuote($wordArray[2]) . ' AND column_name=' . $this->fixQuote($wordArray[5])
-						. ' AND column_default ' . $isNullDef;
+					if ($alterType === 'NOT' && strtoupper($wordArray[8]) === 'NULL')
+					{
+						$result = 'SELECT column_name, data_type, is_nullable'
+							. ' FROM information_schema.columns'
+							. ' WHERE table_name=' . $this->fixQuote($wordArray[2])
+							. ' AND column_name=' . $this->fixQuote($wordArray[5])
+							. ' AND is_nullable=' . $this->fixQuote('NO');
 
-					$this->queryType = 'CHANGE_COLUMN_TYPE';
-					$this->checkQueryExpected = 1;
-					$this->msgElements = array($this->fixQuote($wordArray[2]), $this->fixQuote($wordArray[5]), $isNullDef);
+						$this->queryType = 'CHANGE_COLUMN_TYPE';
+						$this->msgElements = array(
+							$this->fixQuote($wordArray[2]),
+							$this->fixQuote($wordArray[5]),
+							'NOT NULL'
+						);
+					}
+					elseif ($alterType === 'DEFAULT')
+					{
+						$result = 'SELECT column_name, data_type, is_nullable'
+							. ' FROM information_schema.columns'
+							. ' WHERE table_name=' . $this->fixQuote($wordArray[2])
+							. ' AND column_name=' . $this->fixQuote($wordArray[5])
+							. ' AND (CASE (position(' . $this->db->quote('::') . ' in column_default))'
+							. ' WHEN 0 THEN '
+							. ' column_default = ' . $this->db->quote($wordArray[8])
+							. ' ELSE '
+							. ' substring(column_default, 1, (position(' . $this->db->quote('::')
+							. ' in column_default) -1))  = ' . $this->db->quote($wordArray[8])
+							. ' END)';
+
+						$this->queryType = 'CHANGE_COLUMN_TYPE';
+						$this->msgElements = array(
+							$this->fixQuote($wordArray[2]),
+							$this->fixQuote($wordArray[5]),
+							'DEFAULT ' . $wordArray[8]
+						);
+					}
+				}
+				elseif ($alterAction === 'DROP')
+				{
+					$alterType = strtoupper($wordArray[7]);
+
+					if ($alterType === 'DEFAULT')
+					{
+						$result = 'SELECT column_name, data_type, is_nullable , column_default'
+							. ' FROM information_schema.columns'
+							. ' WHERE table_name=' . $this->fixQuote($wordArray[2])
+							. ' AND column_name=' . $this->fixQuote($wordArray[5])
+							. ' AND column_default IS NOT NULL';
+
+						$this->queryType = 'CHANGE_COLUMN_TYPE';
+						$this->checkQueryExpected = 0;
+						$this->msgElements = array(
+							$this->fixQuote($wordArray[2]),
+							$this->fixQuote($wordArray[5]),
+							'NOT DEFAULT'
+						);
+					}
+					elseif ($alterType === 'NOT' && strtoupper($wordArray[8]) === 'NULL')
+					{
+						$result = 'SELECT column_name, data_type, is_nullable , column_default'
+							. ' FROM information_schema.columns'
+							. ' WHERE table_name=' . $this->fixQuote($wordArray[2])
+							. ' AND column_name=' . $this->fixQuote($wordArray[5])
+							. ' AND is_nullable = ' . $this->fixQuote('NO');
+
+						$this->queryType = 'CHANGE_COLUMN_TYPE';
+						$this->checkQueryExpected = 0;
+						$this->msgElements = array(
+							$this->fixQuote($wordArray[2]),
+							$this->fixQuote($wordArray[5]),
+							'NULL'
+						);
+					}
 				}
 			}
 		}

--- a/libraries/src/Schema/ChangeItem/PostgresqlChangeItem.php
+++ b/libraries/src/Schema/ChangeItem/PostgresqlChangeItem.php
@@ -43,7 +43,7 @@ class PostgresqlChangeItem extends ChangeItem
 
 		$result = null;
 		$splitIntoWords = "~'[^']*'(*SKIP)(*F)|\s+~";
-		$splitIntoActions = "~'[^']*'(*SKIP)(*F)|,~";
+		$splitIntoActions = "~'[^']*'(*SKIP)(*F)|\([^)]*\)(*SKIP)(*F)|,~";
 
 		// Remove any newlines
 		$this->updateQuery = str_replace("\n", '', $this->updateQuery);
@@ -121,14 +121,9 @@ class PostgresqlChangeItem extends ChangeItem
 
 				if ($alterAction === 'TYPE')
 				{
-					$type = '';
+					$type = implode(' ', array_slice($wordArray, 7));
 
-					for ($i = 7; $i < $totalWords; $i++)
-					{
-						$type .= $wordArray[$i] . ' ';
-					}
-
-					if ($pos = stripos($type, 'USING'))
+					if ($pos = stripos($type, ' USING '))
 					{
 						$type = substr($type, 0, $pos);
 					}
@@ -139,7 +134,7 @@ class PostgresqlChangeItem extends ChangeItem
 					}
 					else
 					{
-						$datatype = substr($type, 0, -1);
+						$datatype = $type;
 					}
 
 					$result = 'SELECT column_name, data_type '

--- a/libraries/src/Schema/ChangeItem/PostgresqlChangeItem.php
+++ b/libraries/src/Schema/ChangeItem/PostgresqlChangeItem.php
@@ -80,9 +80,7 @@ class PostgresqlChangeItem extends ChangeItem
 			$lastActionArray = preg_split($splitIntoWords, end($actions), null, PREG_SPLIT_NO_EMPTY);
 
 			// Replace all actions by the last one
-			array_splice($wordArray, 3, count($wordArray), $lastActionArray);
-
-			$totalWords = count($wordArray);
+			array_splice($wordArray, 3, $totalWords, $lastActionArray);
 
 			$alterCommand = strtoupper($wordArray[3] . ' ' . $wordArray[4]);
 


### PR DESCRIPTION
Pull Request for Issue # #14331

### Summary of Changes
This PR is based on #17351, #18483 and is a replacement for #18483. 

After PR, joomla recognises correctly:
- `SET NOT NULL;`
- `SET DEFAULT '';`
- `DROP DEFAULT;` - does not work in #18483
- `DROP NOT NULL;` 
- `TYPE character varying(127)` - new stuff - allow to resize column
-  `... DROP DEFAULT, ... SET DEFAULT 0;` - only test the last action after comma

### Testing Instructions

[UPDATED]

1. Install joomla staging and go to backend to extension -> database.
2. Now you see an issue:
![j1](https://user-images.githubusercontent.com/9054379/36646291-195f81cc-1a76-11e8-8cff-a01e873bc556.png)

This issue should not happen because there is a fresh installation. 

The column has a definition at
https://github.com/joomla/joomla-cms/blob/73ca2926f898d88f8bcceb69423fe0a31e8a5abb/installation/sql/postgresql/joomla.sql#L1868
This means that the update query from 
https://github.com/joomla/joomla-cms/blob/c8b212151db8c1c7f8f1bdc222f8128dc8641dc2/administrator/components/com_admin/sql/updates/postgresql/3.1.0.sql#L3

is wrong and should be removed as I did in my PR.

3. After we click on the database fix, everything should be OK, but the query from:
https://github.com/joomla/joomla-cms/blob/73ca2926f898d88f8bcceb69423fe0a31e8a5abb/administrator/components/com_admin/sql/updates/postgresql/3.7.0-2017-03-03.sql#L3
is not visible by joomla (bug) and the query can not fix our database.

Now our database is different than the fresh from installation but joomla does not see any problems.

4. Apply this PR by com_patchtester
5. Go to extension -> database.
6. Now you see
![j2](https://user-images.githubusercontent.com/9054379/36646478-0bba2eee-1a78-11e8-810d-09a150e7f6a7.png)

7. After you click on the Fix button, the column `data` from `#__updates` will be repaired and will be equal to definition from
https://github.com/joomla/joomla-cms/blob/73ca2926f898d88f8bcceb69423fe0a31e8a5abb/installation/sql/postgresql/joomla.sql#L1868

8. The next tests are to check if each query starts with `ALTER TABLE ALTER COLUMN` is visible by joomla. I prepared 7 queries:

```sql
ALTER TABLE "#__newsfeeds" ALTER COLUMN "modified_by" DROP NOT NULL;
ALTER TABLE "#__newsfeeds" ALTER COLUMN "modified_by" DROP DEFAULT;
ALTER TABLE "#__newsfeeds" ALTER COLUMN "modified_by" TYPE bigint USING "modified_by"::bigint;

ALTER TABLE "#__contact_details" ALTER COLUMN "con_position" SET DEFAULT '';
ALTER TABLE "#__contact_details" ALTER COLUMN "mobile" DROP DEFAULT,
                                 ALTER COLUMN "mobile" SET DEFAULT 'new value';
ALTER TABLE "#__contact_details" ALTER COLUMN "address" SET NOT NULL;
ALTER TABLE "#__contact_details" ALTER COLUMN "alias" TYPE character varying(10) USING substr("alias", 1, 10);
```
After you put it at the bottom of
https://github.com/joomla/joomla-cms/blob/5bf0e5d688542530587b556e35b0e1be6df3b5ae/administrator/components/com_admin/sql/updates/postgresql/3.8.4-2018-01-16.sql#L1-L2

and refresh `extension -> database` page you should see a 7 issues:
![j3](https://user-images.githubusercontent.com/9054379/36646668-20e79a06-1a7b-11e8-981f-1c112132208b.png)

This means that every query is recognised by joomla. 

Then click on the Fix button.
Now everything is OK.

9. To revert all above changes, replace above code by:
```sql
ALTER TABLE "#__newsfeeds" ALTER COLUMN "modified_by" SET NOT NULL;
ALTER TABLE "#__newsfeeds" ALTER COLUMN "modified_by" SET DEFAULT 0;
ALTER TABLE "#__newsfeeds" ALTER COLUMN "modified_by" TYPE integer USING "modified_by"::integer;

ALTER TABLE "#__contact_details" ALTER COLUMN "con_position" DROP DEFAULT;
ALTER TABLE "#__contact_details" ALTER COLUMN "mobile" SET DEFAULT '';
ALTER TABLE "#__contact_details" ALTER COLUMN "address" DROP NOT NULL;
ALTER TABLE "#__contact_details" ALTER COLUMN "alias" TYPE character varying(255);
```

Then refresh `extension -> database` page we will see 7 issues:

![j4](https://user-images.githubusercontent.com/9054379/36646810-de3ead6e-1a7c-11e8-9ecd-5575ac82eeee.png)

this means that all queries have been recognised. 
Now click on the Fix button. All s OK.

10. Remove all custom changes from `administrator/components/com_admin/sql/updates/postgresql/3.8.4-2018-01-16.sql` and refresh `extension -> database`. All is OK.


### Expected result
All changes/issues are visible and can be fixed.


### Actual result
Joomla does not recognise a few above queries or recognises them incorrectly.
