### PR TITLE
Session table improvements

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/3.5.0-2015-07-01.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.5.0-2015-07-01.sql
@@ -1,2 +1,2 @@
-ALTER TABLE `#__session` MODIFY `session_id` varchar(191) NOT NULL DEFAULT '';
+-- ALTER TABLE `#__session` MODIFY `session_id` varchar(191) NOT NULL DEFAULT '';
 ALTER TABLE `#__user_keys` MODIFY `series` varchar(191) NOT NULL;

--- a/administrator/components/com_admin/sql/updates/mysql/3.8.6-2018-02-27.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.8.6-2018-02-27.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `#__session` MODIFY `session_id` varbinary(192) NOT NULL;
+ALTER TABLE `#__session` MODIFY `guest` tinyint(3) unsigned DEFAULT 1;
+ALTER TABLE `#__session` MODIFY `time` int(11) NOT NULL DEFAULT 0;

--- a/administrator/components/com_admin/sql/updates/postgresql/3.8.6-2018-02-27.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.8.6-2018-02-27.sql
@@ -1,0 +1,7 @@
+ALTER TABLE "#__session" ALTER COLUMN "session_id" DROP DEFAULT;
+ALTER TABLE "#__session" ALTER COLUMN "session_id" TYPE bytea USING "session_id"::bytea;
+ALTER TABLE "#__session" ALTER COLUMN "session_id" SET NOT NULL;
+ALTER TABLE "#__session" ALTER COLUMN "time" DROP DEFAULT,
+                         ALTER COLUMN "time" TYPE integer USING "time"::integer;
+ALTER TABLE "#__session" ALTER COLUMN "time" SET DEFAULT 0;
+ALTER TABLE "#__session" ALTER COLUMN "time" SET NOT NULL;

--- a/administrator/components/com_admin/sql/updates/sqlazure/3.8.6-2018-02-27.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.8.6-2018-02-27.sql
@@ -1,0 +1,15 @@
+sp_rename "#__session", "#__session_old";
+
+SELECT cast("session_id" AS varbinary) AS "session_id", "client_id", "guest", cast("time" AS int) AS "time", "data", "userid", "username"
+INTO "#__session"
+FROM "#__session_old";
+
+DROP TABLE "#__session_old";
+
+ALTER TABLE "#__session" ALTER COLUMN "session_id" varbinary(192) NOT NULL;
+ALTER TABLE "#__session" ADD CONSTRAINT "PK_#__session_session_id" PRIMARY KEY CLUSTERED ("session_id") ON [PRIMARY];
+ALTER TABLE "#__session" ALTER COLUMN "time" int NOT NULL;
+ALTER TABLE "#__session" ADD DEFAULT (0) FOR "time";
+
+CREATE NONCLUSTERED INDEX "time" ON "#__session" ("time");
+CREATE NONCLUSTERED INDEX "userid" ON "#__session" ("userid");

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -1687,10 +1687,10 @@ CREATE TABLE IF NOT EXISTS `#__schemas` (
 --
 
 CREATE TABLE IF NOT EXISTS `#__session` (
-  `session_id` varchar(191) NOT NULL DEFAULT '',
+  `session_id` varbinary(192) NOT NULL,
   `client_id` tinyint(3) unsigned DEFAULT NULL,
-  `guest` tinyint(4) unsigned DEFAULT 1,
-  `time` varchar(14) DEFAULT '',
+  `guest` tinyint(3) unsigned DEFAULT 1,
+  `time` int(11) NOT NULL DEFAULT 0,
   `data` mediumtext,
   `userid` int(11) DEFAULT 0,
   `username` varchar(150) DEFAULT '',

--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -1664,10 +1664,10 @@ CREATE TABLE "#__schemas" (
 --
 
 CREATE TABLE "#__session" (
-  "session_id" varchar(200) DEFAULT '' NOT NULL,
+  "session_id" bytea NOT NULL,
   "client_id" smallint DEFAULT NULL,
   "guest" smallint DEFAULT 1,
-  "time" varchar(14) DEFAULT '',
+  "time" integer DEFAULT 0 NOT NULL,
   "data" text,
   "userid" bigint DEFAULT 0,
   "username" varchar(150) DEFAULT '',

--- a/installation/sql/sqlazure/joomla.sql
+++ b/installation/sql/sqlazure/joomla.sql
@@ -2394,28 +2394,19 @@ CREATE TABLE "#__schemas" (
 --
 
 CREATE TABLE "#__session" (
-  "session_id" nvarchar(200) NOT NULL DEFAULT '',
+  "session_id" varbinary(192) NOT NULL,
   "client_id" tinyint DEFAULT NULL,
-  "guest" tinyint NULL DEFAULT 1,
-  "time" nvarchar(14) NULL DEFAULT '',
-  "data" nvarchar(max) NULL,
-  "userid" int NULL DEFAULT 0,
-  "username" nvarchar(150) NULL DEFAULT '',
- CONSTRAINT "PK_#__session_session_id" PRIMARY KEY CLUSTERED
-(
-  "session_id" ASC
-)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]
-) ON [PRIMARY];
+  "guest" tinyint DEFAULT 1,
+  "time" int NOT NULL DEFAULT 0,
+  "data" nvarchar(max),
+  "userid" int DEFAULT 0,
+  "username" nvarchar(150) DEFAULT '',
+  CONSTRAINT "PK_#__session_session_id" PRIMARY KEY CLUSTERED ("session_id") ON [PRIMARY]
+)
+ON [PRIMARY];
 
-CREATE NONCLUSTERED INDEX "time" ON "#__session"
-(
-  "time" ASC
-)WITH (STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, DROP_EXISTING = OFF, ONLINE = OFF);
-
-CREATE NONCLUSTERED INDEX "userid" ON "#__session"
-(
-  "userid" ASC
-)WITH (STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, DROP_EXISTING = OFF, ONLINE = OFF);
+CREATE NONCLUSTERED INDEX "time" ON "#__session" ("time");
+CREATE NONCLUSTERED INDEX "userid" ON "#__session" ("userid");
 
 --
 -- Table structure for table `#__tags`

--- a/libraries/joomla/session/storage/database.php
+++ b/libraries/joomla/session/storage/database.php
@@ -76,7 +76,7 @@ class JSessionStorageDatabase extends JSessionStorage
 			$query = $db->getQuery(true)
 				->update($db->quoteName('#__session'))
 				->set($db->quoteName('data') . ' = ' . $db->quote($data))
-				->set($db->quoteName('time') . ' = ' . $db->quote((int) time()))
+				->set($db->quoteName('time') . ' = ' . time())
 				->where($db->quoteName('session_id') . ' = ' . $db->quote($id));
 
 			// Try to update the session data in the database table.
@@ -148,7 +148,7 @@ class JSessionStorageDatabase extends JSessionStorage
 		{
 			$query = $db->getQuery(true)
 				->delete($db->quoteName('#__session'))
-				->where($db->quoteName('time') . ' < ' . $db->quote((int) $past));
+				->where($db->quoteName('time') . ' < ' . (int) $past);
 
 			// Remove expired sessions from the database.
 			$db->setQuery($query);

--- a/libraries/legacy/application/application.php
+++ b/libraries/legacy/application/application.php
@@ -1004,7 +1004,7 @@ class JApplication extends BaseApplication
 			// but fires the query less than half the time.
 			$query = $db->getQuery(true)
 				->delete($db->quoteName('#__session'))
-				->where($db->quoteName('time') . ' < ' . $db->quote((int) ($time - $session->getExpire())));
+				->where($db->quoteName('time') . ' < ' . (int) ($time - $session->getExpire()));
 
 			$db->setQuery($query);
 			$db->execute();
@@ -1055,7 +1055,7 @@ class JApplication extends BaseApplication
 			{
 				$query->insert($db->quoteName('#__session'))
 					->columns($db->quoteName('session_id') . ', ' . $db->quoteName('client_id') . ', ' . $db->quoteName('time'))
-					->values($db->quote($session->getId()) . ', ' . (int) $this->getClientId() . ', ' . $db->quote((int) time()));
+					->values($db->quote($session->getId()) . ', ' . (int) $this->getClientId() . ', ' . time());
 				$db->setQuery($query);
 			}
 			else
@@ -1067,7 +1067,7 @@ class JApplication extends BaseApplication
 					)
 					->values(
 						$db->quote($session->getId()) . ', ' . (int) $this->getClientId() . ', ' . (int) $user->get('guest') . ', ' .
-						$db->quote((int) $session->get('session.timer.start')) . ', ' . (int) $user->get('id') . ', ' . $db->quote($user->get('username'))
+						(int) $session->get('session.timer.start') . ', ' . (int) $user->get('id') . ', ' . $db->quote($user->get('username'))
 					);
 
 				$db->setQuery($query);

--- a/libraries/src/Session/MetadataManager.php
+++ b/libraries/src/Session/MetadataManager.php
@@ -94,7 +94,7 @@ final class MetadataManager
 		$values = array(
 			$this->db->quote($session->getId()),
 			(int) $user->guest,
-			$this->db->quote((int) $time),
+			(int) $time,
 			(int) $user->id,
 			$this->db->quote($user->username),
 		);
@@ -141,7 +141,7 @@ final class MetadataManager
 	{
 		$query = $this->db->getQuery(true)
 			->delete($this->db->quoteName('#__session'))
-			->where($this->db->quoteName('time') . ' < ' . $this->db->quote($time));
+			->where($this->db->quoteName('time') . ' < ' . (int) $time);
 
 		$this->db->setQuery($query);
 

--- a/libraries/src/Session/Session.php
+++ b/libraries/src/Session/Session.php
@@ -361,7 +361,7 @@ class Session implements \IteratorAggregate
 	/**
 	 * Get session id
 	 *
-	 * @return  string  The session name
+	 * @return  string  The session id
 	 *
 	 * @since   11.1
 	 */


### PR DESCRIPTION
### Summary of Changes
This PR provides an improvement in the performance of high-traffic sites.

1. Change type of column `session_id` from `varchar` to `varbinary`.
2. Change type of column `time` from `varchar` to `integer`.

**Why I changed `time` column to integer?**
Before this PR the value of `time` column is stored as text.  
Comparing text to text such as "a" <'b' can not use the index key.

When joomla deletes all expired sessions then need to scan whole table because the index (of `time` column) is useless.

Drawback of varchar:
* `varchar` type use language processing on comparison, it is slower
* `varchar` takes up to 4 bytes per character when it is loaded into RAM
* when we compare strings like '21' < '110' then the result returns false (instead true), see #13933

**Why I changed `session_id` column to varbinary?**
A good explanation is at https://github.com/symfony/http-foundation/blob/master/Session/Storage/Handler/PdoSessionHandler.php#L214

### Testing Instructions
1. Install joomla 3.8.6 or newer
2. Login and apply this PR 19708, for example by `com_patchtester`. ~~For PostgreSQL database you should apply additional PR #19707~~ - it is merged.
3. Go to backend -> extension -> manage -> database -> and click on fix button. 
4. Everything should go without errors. You should be still logged in.
5. Your session works as before. You can login/logout without any problems.

### Expected result
All works as before.