### PR TITLE
[4.0] Switch escape() methods to ENT_QUOTES to also cover single quotes

### DIFF
--- a/libraries/joomla/view/html.php
+++ b/libraries/joomla/view/html.php
@@ -75,7 +75,7 @@ abstract class JViewHtml extends JViewBase
 	public function escape($output)
 	{
 		// Escape the output.
-		return htmlspecialchars($output, ENT_COMPAT, 'UTF-8');
+		return htmlspecialchars($output, ENT_QUOTES, 'UTF-8');
 	}
 
 	/**

--- a/libraries/src/Layout/BaseLayout.php
+++ b/libraries/src/Layout/BaseLayout.php
@@ -114,7 +114,7 @@ class BaseLayout implements LayoutInterface
 	 */
 	public function escape($output)
 	{
-		return htmlspecialchars($output, ENT_COMPAT, 'UTF-8');
+		return htmlspecialchars($output, ENT_QUOTES, 'UTF-8');
 	}
 
 	/**

--- a/libraries/src/MVC/View/HtmlView.php
+++ b/libraries/src/MVC/View/HtmlView.php
@@ -197,7 +197,7 @@ class HtmlView extends AbstractView
 	 * Escapes a value for output in a view script.
 	 *
 	 * If escaping mechanism is htmlspecialchars, use
-	 * {@link $_encoding} setting.
+	 * {@link $_charset} setting.
 	 *
 	 * @param   mixed  $var  The output to escape.
 	 *
@@ -207,7 +207,7 @@ class HtmlView extends AbstractView
 	 */
 	public function escape($var)
 	{
-		return htmlspecialchars($var, ENT_COMPAT, $this->_charset);
+		return htmlspecialchars($var, ENT_QUOTES, $this->_charset);
 	}
 
 	/**


### PR DESCRIPTION
### Summary of Changes
In earlier versions, the escape method of JViewHtml, HtmlView and BaseLayout was using the ENT_COMPAT flag for escaping, which does not escape single quotes. This leads to potential XSS-issues in some situations and therefore should be changed in 4.0.

This is done with this PR.

### Testing Instructions
1. Add `echo $this->escape("'");` to a component template of your choice. 
2. Inspect the generated markup in the browser, see the plaintext output of the single quote
3. Apply this patch, refresh the page
4. Inspect markup again, see that the quote is now escaped


### Expected result
Single quotes are escaped


### Actual result
Single quotes aren't escaped.


### Documentation Changes Required
None
