### PR TITLE
Add note docblocks to 3.9 about a behavior change in escape() methods in 4.0

### DIFF
--- a/libraries/joomla/view/html.php
+++ b/libraries/joomla/view/html.php
@@ -70,6 +70,8 @@ abstract class JViewHtml extends JViewBase
 	 *
 	 * @return  string  The escaped output.
 	 *
+	 * @note the ENT_COMPAT flag will be replaced by ENT_QUOTES in Joomla 4.0 to also escape single quotes
+	 *
 	 * @see     JView::escape()
 	 * @since   12.1
 	 */

--- a/libraries/src/Layout/BaseLayout.php
+++ b/libraries/src/Layout/BaseLayout.php
@@ -110,6 +110,8 @@ class BaseLayout implements LayoutInterface
 	 *
 	 * @return  string  The escaped output.
 	 *
+	 * @note the ENT_COMPAT flag will be replaced by ENT_QUOTES in Joomla 4.0 to also escape single quotes
+	 *
 	 * @since   3.0
 	 */
 	public function escape($output)

--- a/libraries/src/MVC/View/HtmlView.php
+++ b/libraries/src/MVC/View/HtmlView.php
@@ -376,6 +376,8 @@ class HtmlView extends \JObject
 	 *
 	 * @return  mixed  The escaped value.
 	 *
+	 * @note the ENT_COMPAT flag will be replaced by ENT_QUOTES in Joomla 4.0 to also escape single quotes
+	 *
 	 * @since   3.0
 	 */
 	public function escape($var)


### PR DESCRIPTION
See related 4.0 PR #19720 

### Summary of Changes
Add note docblocks for #19720 to 3.9