### PR TITLE
TinyMCE: uglify the inline XTD-btns script

### DIFF
--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -778,73 +778,59 @@ class PlgEditorTinymce extends JPlugin
 				$icon = 'none icon-' . $icon;
 
 				// Now we can built the script
-				$tempConstructor = '!(function(){';
+				$tempConstructor[] = '!(function(){';
 
 				// Get the modal width/height
 				if ($options && is_scalar($options))
 				{
-					$tempConstructor .= '
-				var getBtnOptions = new Function("return ' . addslashes($options) . '"),
-					btnOptions = getBtnOptions(),
-					modalWidth = btnOptions.size && btnOptions.size.x ?  btnOptions.size.x : null,
-					modalHeight = btnOptions.size && btnOptions.size.y ?  btnOptions.size.y : null;';
+					$tempConstructor[] = 'var getBtnOptions=new Function("return ' . addslashes($options) . '");';
+					$tempConstructor[] = 'var btnOptions=getBtnOptions();var modalWidth=btnOptions.size&&';
+					$tempConstructor[] = 'btnOptions.size.x?btnOptions.size.x:null;var modalHeight=btnOptions.size&&';
+					$tempConstructor[] = 'btnOptions.size.y?btnOptions.size.y:null;';
 				}
 				else
 				{
-					$tempConstructor .= '
-				var btnOptions = {}, modalWidth = null, modalHeight = null;';
+					$tempConstructor[] = 'var btnOptions={},modalWidth=null,modalHeight=null;';
 				}
 
-				$tempConstructor .= "
-				editor.addButton(\"" . $name . "\", {
-					text: \"" . $title . "\",
-					title: \"" . $title . "\",
-					icon: \"" . $icon . "\",
-					onclick: function () {";
+				// Now we can built the script
+				$tempConstructor[] = 'editor.addButton("' . $name . '",{';
+				$tempConstructor[] = 'text:"' . $title . '",';
+				$tempConstructor[] = 'title:"' . $title . '",';
+				$tempConstructor[] = 'icon:"' . $icon . '",';
+				$tempConstructor[] = 'onclick:function(){';
 
 				if ($href || $button->get('modal'))
 				{
-					$tempConstructor .= "
-							var modalOptions = {
-								title  : \"" . $title . "\",
-								url : '" . $href . "',
-								buttons: [{
-									text   : \"Close\",
-									onclick: \"close\"
-								}]
-							}
-							if(modalWidth){
-								modalOptions.width = modalWidth;
-							}
-							if(modalHeight){
-								modalOptions.height = modalHeight;
-							}
-							editor.windowManager.open(modalOptions);";
+					$tempConstructor[] = 'var modalOptions={';
+					$tempConstructor[] = 'title:"' . $title . '",';
+					$tempConstructor[] = 'url:"' . $href . '",';
+					$tempConstructor[] = 'buttons:[{text: "Close",onclick:"close"}]};';
+					$tempConstructor[] = 'modalOptions.width=parseInt(' . intval($options["width"]) . ', 10);';
+					$tempConstructor[] = 'modalOptions.height=parseInt(' . intval($options["height"]) . ', 10);';
+					$tempConstructor[] = 'if(modalWidth){modalOptions.width=modalWidth;} ';
+					$tempConstructor[] = 'if(modalHeight){modalOptions.height = modalHeight;} ';
+					$tempConstructor[] = 'editor.windowManager.open(modalOptions);';
 
 					if ($onclick && ($button->get('modal') || $href))
 					{
-						$tempConstructor .= "\r\n
-						" . $onclick . '
-							';
+						$tempConstructor[] = $onclick . ';';
 					}
 				}
 				else
 				{
-					$tempConstructor .= "\r\n
-						" . $onclick . '
-							';
+					$tempConstructor[] = $onclick . ';';
 				}
 
-				$tempConstructor .= '
-					}
-				});
-			})();';
+				$tempConstructor[] = '}';
+				$tempConstructor[] = '});';
+				$tempConstructor[] = '})();';
 
 				// The array with the toolbar buttons
 				$btnsNames[] = $name . ' | ';
 
 				// The array with code for each button
-				$tinyBtns[] = $tempConstructor;
+				$tinyBtns[] = implode($tempConstructor, '');
 			}
 		}
 

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -813,8 +813,6 @@ class PlgEditorTinymce extends JPlugin
 					$tempConstructor[] = '};';
 
 					// Set width/height
-					$tempConstructor[] = 'modalOptions.width=parseInt(' . intval($options["width"]) . ', 10);';
-					$tempConstructor[] = 'modalOptions.height=parseInt(' . intval($options["height"]) . ', 10);';
 					$tempConstructor[] = 'if(modalWidth){modalOptions.width=modalWidth;}';
 					$tempConstructor[] = 'if(modalHeight){modalOptions.height = modalHeight;}';
 					$tempConstructor[] = 'editor.windowManager.open(modalOptions);';

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -794,36 +794,50 @@ class PlgEditorTinymce extends JPlugin
 				}
 
 				// Now we can built the script
+				// AddButton starts here
 				$tempConstructor[] = 'editor.addButton("' . $name . '",{';
 				$tempConstructor[] = 'text:"' . $title . '",';
 				$tempConstructor[] = 'title:"' . $title . '",';
 				$tempConstructor[] = 'icon:"' . $icon . '",';
+
+				// Onclick starts here
 				$tempConstructor[] = 'onclick:function(){';
 
 				if ($href || $button->get('modal'))
 				{
+					// TinyMCE standard modal options
 					$tempConstructor[] = 'var modalOptions={';
 					$tempConstructor[] = 'title:"' . $title . '",';
 					$tempConstructor[] = 'url:"' . $href . '",';
-					$tempConstructor[] = 'buttons:[{text: "Close",onclick:"close"}]};';
+					$tempConstructor[] = 'buttons:[{text: "Close",onclick:"close"}]';
+					$tempConstructor[] = '};';
+
+					// Set width/height
 					$tempConstructor[] = 'modalOptions.width=parseInt(' . intval($options["width"]) . ', 10);';
 					$tempConstructor[] = 'modalOptions.height=parseInt(' . intval($options["height"]) . ', 10);';
-					$tempConstructor[] = 'if(modalWidth){modalOptions.width=modalWidth;} ';
-					$tempConstructor[] = 'if(modalHeight){modalOptions.height = modalHeight;} ';
+					$tempConstructor[] = 'if(modalWidth){modalOptions.width=modalWidth;}';
+					$tempConstructor[] = 'if(modalHeight){modalOptions.height = modalHeight;}';
 					$tempConstructor[] = 'editor.windowManager.open(modalOptions);';
 
 					if ($onclick && ($button->get('modal') || $href))
 					{
+						// Adds callback for close button
 						$tempConstructor[] = $onclick . ';';
 					}
 				}
 				else
 				{
+					// Adds callback for the button, eg: readmore
 					$tempConstructor[] = $onclick . ';';
 				}
 
+				// Onclick ends here
 				$tempConstructor[] = '}';
+
+				// AddButton ends here
 				$tempConstructor[] = '});';
+
+				// IIFE ends here
 				$tempConstructor[] = '})();';
 
 				// The array with the toolbar buttons

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -783,10 +783,10 @@ class PlgEditorTinymce extends JPlugin
 				// Get the modal width/height
 				if ($options && is_scalar($options))
 				{
-					$tempConstructor[] = 'var getBtnOptions=new Function("return ' . addslashes($options) . '");';
-					$tempConstructor[] = 'var btnOptions=getBtnOptions();var modalWidth=btnOptions.size&&';
-					$tempConstructor[] = 'btnOptions.size.x?btnOptions.size.x:null;var modalHeight=btnOptions.size&&';
-					$tempConstructor[] = 'btnOptions.size.y?btnOptions.size.y:null;';
+					$tempConstructor[] = 'var getBtnOptions=new Function("return ' . addslashes($options) . '"),';
+					$tempConstructor[] = 'btnOptions=getBtnOptions(),';
+					$tempConstructor[] = 'modalWidth=btnOptions.size&&btnOptions.size.x?btnOptions.size.x:null,';
+					$tempConstructor[] = 'modalHeight=btnOptions.size&&btnOptions.size.y?btnOptions.size.y:null;';
 				}
 				else
 				{

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -777,6 +777,8 @@ class PlgEditorTinymce extends JPlugin
 				// We do some hack here to set the correct icon for 3PD buttons
 				$icon = 'none icon-' . $icon;
 
+				$tempConstructor = array();
+
 				// Now we can built the script
 				$tempConstructor[] = '!(function(){';
 


### PR DESCRIPTION
Pull Request for Issue #19719 .

### Summary of Changes
TinyMCE options are included in page HTML as inline JSON. This PR cleans up the script by building the script correctly making the resulting HTML smaller.

The history behind this mess:
When I added the xtd-button to tinymce, the editor was using an inline script for initialisation. Later on @Fedik did some great work for the customisation part and the inline script was converted to static file. So when this code was merged the tabs and returns was kept intensionally to output a prettified output. What we never did was to convert this code to be uglified as now it's passed in the JSON string (which by the way is also totally wrong).

### Testing Instructions
Apply patch and check if tiny works correctly


### Expected result



### Actual result



### Documentation Changes Required
No