### PR TITLE
Com_redirect: Differentiating utf8 old_url

### DIFF
--- a/administrator/components/com_redirect/tables/link.php
+++ b/administrator/components/com_redirect/tables/link.php
@@ -86,7 +86,7 @@ class RedirectTableLink extends JTable
 		$query = $db->getQuery(true)
 			->select($db->quoteName('id'))
 			->from('#__redirect_links')
-			->where($db->quoteName('old_url') . ' = ' . $db->quote($this->old_url));
+			->where($db->quoteName('old_url') . ' = ' . $db->quote(rawurlencode($this->old_url)));
 		$db->setQuery($query);
 
 		$xid = (int) $db->loadResult();


### PR DESCRIPTION
Pull Request for Issue #19713

### Summary of Changes
When checking old_urls for duplicates, com_redirect does not make the difference between utf8 and ascii characters. By rawurlencode them, it solves the issue.

### Testing Instructions
See #19713 

an old  url of type http://mydomain.com/bogusurl will not be considered as different from http://mydomain.com/bøgusurl and therefore com_redirect considers it as duplicate.

After patch it does not any more and each can get a different new URL

![screen shot 2018-02-19 at 10 06 56](https://user-images.githubusercontent.com/869724/36369758-bbc442dc-155c-11e8-8101-8a6f183e3ad4.png)
