### PR TITLE
Overrides do not find 3rd party plugins language files when files are in the plugin language folder

### DIFF
--- a/administrator/components/com_languages/models/strings.php
+++ b/administrator/components/com_languages/models/strings.php
@@ -74,7 +74,7 @@ class LanguagesModelStrings extends JModelLegacy
 		$files = array_merge($files, JFolder::files($base . '/templates', $language . '.*ini$', 3, true));
 
 		// Parse language directories of plugins.
-		$files = array_merge($files, JFolder::files(JPATH_PLUGINS, $language . '.*ini$', 3, true));
+		$files = array_merge($files, JFolder::files(JPATH_PLUGINS, $language . '.*ini$', 4, true));
 
 		// Parse all found ini files and add the strings to the database cache.
 		foreach ($files as $file)


### PR DESCRIPTION
Pull Request for Issue #19738

### Summary of Changes
The search for plugin languages files did not go deep enough


### Testing Instructions
See #19738


### After Patch
here for resourcerer
![screen shot 2018-02-19 at 17 28 07](https://user-images.githubusercontent.com/869724/36388152-3943774e-159b-11e8-855f-71d15891b988.png)

@toivo 
