### PR TITLE
Fix deleting Custom Field value from table when Field not set in object

### DIFF
--- a/libraries/src/User/UserHelper.php
+++ b/libraries/src/User/UserHelper.php
@@ -61,8 +61,16 @@ abstract class UserHelper
 			// Add the group data to the user object.
 			$user->groups[$title] = $groupId;
 
+			// Set task to avoid removing of saved Field data
+			$input = \JFactory::getApplication()->input;
+			$task = $input->getCmd('task');
+			$input->set('task', 'addUserToGroup');
+
 			// Store the user object.
 			$user->save();
+
+			// Restore task to initial setting
+			$input->set('task', $task);
 		}
 
 		// Set the group data for any preloaded user objects.
@@ -123,8 +131,16 @@ abstract class UserHelper
 			// Remove the user from the group.
 			unset($user->groups[$key]);
 
+			// Set task to avoid removing of saved Field data
+			$input = \JFactory::getApplication()->input;
+			$task = $input->getCmd('task');
+			$input->set('task', 'removeUserFromGroup');
+
 			// Store the user object.
 			$user->save();
+
+			// Restore task to initial setting
+			$input->set('task', $task);
 		}
 
 		// Set the group data for any preloaded user objects.

--- a/libraries/src/User/UserHelper.php
+++ b/libraries/src/User/UserHelper.php
@@ -61,16 +61,12 @@ abstract class UserHelper
 			// Add the group data to the user object.
 			$user->groups[$title] = $groupId;
 
-			// Set task to avoid removing of saved Field data
+			// Set helpertask to avoid removing of saved Field data
 			$input = \JFactory::getApplication()->input;
-			$task = $input->getCmd('task');
-			$input->set('task', 'addUserToGroup');
+			$input->set('helpertask', 'addUserToGroup');
 
 			// Store the user object.
 			$user->save();
-
-			// Restore task to initial setting
-			$input->set('task', $task);
 		}
 
 		// Set the group data for any preloaded user objects.
@@ -131,16 +127,12 @@ abstract class UserHelper
 			// Remove the user from the group.
 			unset($user->groups[$key]);
 
-			// Set task to avoid removing of saved Field data
+			// Set helpertask to avoid removing of saved Field data
 			$input = \JFactory::getApplication()->input;
-			$task = $input->getCmd('task');
-			$input->set('task', 'removeUserFromGroup');
+			$input->set('helpertask', 'removeUserFromGroup');
 
 			// Store the user object.
 			$user->save();
-
-			// Restore task to initial setting
-			$input->set('task', $task);
 		}
 
 		// Set the group data for any preloaded user objects.

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -73,7 +73,7 @@ class PlgSystemFields extends JPlugin
 		// Loading the fields
 		$fields = FieldsHelper::getFields($context, $item);
 
-		if (!$fields)
+		if (!$fields || empty($data['com_fields']))
 		{
 			return true;
 		}
@@ -96,12 +96,8 @@ class PlgSystemFields extends JPlugin
 				$value = json_encode($value);
 			}
 
-			// Do not set field value for fields that are not available in the object as this will erase the data for these fields
-			if (!is_null($value))
-			{
-				// Setting the value for the field and the item
-				$model->setFieldValue($field->id, $item->id, $value);
-			}
+			// Setting the value for the field and the item
+			$model->setFieldValue($field->id, $item->id, $value);
 		}
 
 		return true;

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -127,9 +127,10 @@ class PlgSystemFields extends JPlugin
 		$user = JFactory::getUser($userData['id']);
 
 		$task = JFactory::getApplication()->input->getCmd('task');
+		$helperTask = JFactory::getApplication()->input->getCmd('helpertask');
 
 		// Skip fields save when we activate a user or change user's group membership, because we will lose the saved data
-		if (in_array($task, array('activate', 'block', 'unblock', 'removeUserFromGroup', 'addUserToGroup')))
+		if (in_array($task, array('activate', 'block', 'unblock')) || in_array($helperTask, array('removeUserFromGroup', 'addUserToGroup')))
 		{
 			return true;
 		}

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -73,7 +73,7 @@ class PlgSystemFields extends JPlugin
 		// Loading the fields
 		$fields = FieldsHelper::getFields($context, $item);
 
-		if (!$fields || empty($data['com_fields']))
+		if (!$fields)
 		{
 			return true;
 		}
@@ -96,7 +96,6 @@ class PlgSystemFields extends JPlugin
 				$value = json_encode($value);
 			}
 
-			// Setting the value for the field and the item
 			$model->setFieldValue($field->id, $item->id, $value);
 		}
 
@@ -128,8 +127,8 @@ class PlgSystemFields extends JPlugin
 
 		$task = JFactory::getApplication()->input->getCmd('task');
 
-		// Skip fields save when we activate a user, because we will lose the saved data
-		if (in_array($task, array('activate', 'block', 'unblock')))
+		// Skip fields save when we activate a user or change user's group membership, because we will lose the saved data
+		if (in_array($task, array('activate', 'block', 'unblock', 'removeUserFromGroup', 'addUserToGroup')))
 		{
 			return true;
 		}

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -96,8 +96,12 @@ class PlgSystemFields extends JPlugin
 				$value = json_encode($value);
 			}
 
-			// Setting the value for the field and the item
-			$model->setFieldValue($field->id, $item->id, $value);
+			// Do not set field value for fields that are not available in the object as this will erase the data for these fields
+			if (!is_null($value))
+			{
+				// Setting the value for the field and the item
+				$model->setFieldValue($field->id, $item->id, $value);
+			}
 		}
 
 		return true;

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -96,6 +96,7 @@ class PlgSystemFields extends JPlugin
 				$value = json_encode($value);
 			}
 
+			// Setting the value for the field and the item
 			$model->setFieldValue($field->id, $item->id, $value);
 		}
 


### PR DESCRIPTION
Pull Request for Issue # https://issues.joomla.org/tracker/joomla-cms/19735

### Summary of Changes
When saving a user object that has NO custom fields attached in a specific context, the saved custom fields for that object will be erased. This will happen e.g. when a the function removeUserFromGroup or function addUserToGroup is called from a component to remove or add a user from a user group.


### Testing Instructions
1. add custom fields in com_user
2. add values to these fields to a user
 The values should show in the user profile
3. use a component (like rd-subscriptions or probably any membership component that uses the UserHelper function addUserToGroup / removeUserFromGroup) and 'remove' the user form a group


### Expected result
The filed values for this user should not be deleted


### Actual result

The field values for this user are deleted (from the #__fiels_values), because when calling the removeUserFromGroup / addUserToGroup the user object doe not have the set fields attached to the object and there for the value for these fields is set to NULL

### Documentation Changes Required
none.
