### PR TITLE
[4.0] Improve assets handling

### DIFF
--- a/libraries/cms/html/formbehavior.php
+++ b/libraries/cms/html/formbehavior.php
@@ -85,7 +85,7 @@ abstract class JHtmlFormbehavior
 		// Include jQuery
 		JHtml::_('jquery.framework');
 		JHtml::_('script', 'legacy/chosen.min.js', ['version' => 'auto', 'relative' => true]);
-		JHtml::_('stylesheet', 'legacy/chosen.css', false, true);
+		JHtml::_('stylesheet', 'legacy/chosen.min.css', ['version' => 'auto', 'relative' => true]);
 
 		// Options array to json options string
 		$options_str = json_encode($options, ($debug && defined('JSON_PRETTY_PRINT') ? JSON_PRETTY_PRINT : false));

--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -1379,7 +1379,7 @@ abstract class HTMLHelper
 	 */
 	protected static function convertToRelativePath($path)
 	{
-		$relativeFilePath = str_replace(JPATH_ROOT, '', $path);
+		$relativeFilePath = Uri::root(true) . str_replace(JPATH_ROOT, '', $path);
 
 		// On windows devices we need to replace "\" with "/" otherwise some browsers will not load the asset
 		return str_replace(DIRECTORY_SEPARATOR, '/', $relativeFilePath);

--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -10,16 +10,15 @@ namespace Joomla\CMS\HTML;
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Utilities\ArrayHelper;
 use Joomla\CMS\Environment\Browser;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Filesystem\File;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Log\Log;
+use Joomla\CMS\Filesystem\Path;
+use Joomla\CMS\Language\Text;
 use Joomla\CMS\Uri\Uri;
-use Joomla\Utilities\ArrayHelper;
-
-\JLoader::import('joomla.environment.browser');
-\JLoader::import('joomla.filesystem.file');
-\JLoader::import('joomla.filesystem.path');
 
 /**
  * Utility class for all HTML drawing classes
@@ -158,7 +157,7 @@ abstract class HTMLHelper
 
 		if (!class_exists($className))
 		{
-			$path = \JPath::find(static::$includePaths, strtolower($file) . '.php');
+			$path = Path::find(static::$includePaths, strtolower($file) . '.php');
 
 			if (!$path)
 			{
@@ -964,12 +963,12 @@ abstract class HTMLHelper
 		// If no format is given use the default locale based format.
 		if (!$format)
 		{
-			$format = \JText::_('DATE_FORMAT_LC1');
+			$format = Text::_('DATE_FORMAT_LC1');
 		}
 		// $format is an existing language key
 		elseif (Factory::getLanguage()->hasKey($format))
 		{
-			$format = \JText::_($format);
+			$format = Text::_($format);
 		}
 
 		if ($gregorian)
@@ -1057,7 +1056,7 @@ abstract class HTMLHelper
 	 *
 	 * @param   string   $title      The title of the tooltip (or combined '::' separated string).
 	 * @param   string   $content    The content to tooltip.
-	 * @param   boolean  $translate  If true will pass texts through JText.
+	 * @param   boolean  $translate  If true will pass texts through Text.
 	 * @param   boolean  $escape     If true will pass texts through htmlspecialchars.
 	 *
 	 * @return  string  The tooltip string
@@ -1078,11 +1077,11 @@ abstract class HTMLHelper
 				list($title, $content) = explode('::', $title, 2);
 			}
 
-			// Pass texts through JText if required.
+			// Pass texts through Text if required.
 			if ($translate)
 			{
-				$title = \JText::_($title);
-				$content = \JText::_($content);
+				$title = Text::_($title);
+				$content = Text::_($content);
 			}
 
 			// Use only the content if no title is given.
@@ -1255,7 +1254,7 @@ abstract class HTMLHelper
 		{
 			if (!empty($dir) && !in_array($dir, static::$includePaths))
 			{
-				array_unshift(static::$includePaths, \JPath::clean($dir));
+				array_unshift(static::$includePaths, Path::clean($dir));
 			}
 		}
 
@@ -1388,12 +1387,12 @@ abstract class HTMLHelper
 	/**
 	 * Method that takes two paths and checks if the files exist with different order
 	 *
-	 * @param  $first   string   the path of the minified file
-	 * @param  $second  string   the path of the non minified file
+	 * @param   string  $first   the path of the minified file
+	 * @param   string  $second  the path of the non minified file
 	 *
 	 * @return  string
 	 *
-	 * @since   __DEPLOY_VERSION__
+	 * @since  __DEPLOY_VERSION__
 	 */
 	private static function checkFileOrder($first, $second)
 	{

--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -399,243 +399,219 @@ abstract class HTMLHelper
 	 *
 	 * @return  array    files to be included.
 	 *
-	 * @see     JBrowser
+	 * @see     Browser
 	 * @since   1.6
 	 */
 	protected static function includeRelativeFiles($folder, $file, $relative, $detect_browser, $detect_debug)
 	{
-		// If http is present in filename just return it as an array
-		if (strpos($file, 'http') === 0 || strpos($file, '//') === 0)
+		// Set debug flag
+		$debugMode = false;
+
+		// Detect debug mode
+		if ($detect_debug && JDEBUG)
 		{
-			return array($file);
+			$debugMode = true;
 		}
 
-		// Extract extension and strip the file
-		$strip = \JFile::stripExt($file);
-		$ext   = \JFile::getExt($file);
-
-		// Prepare array of files
-		$includes = array();
-
-		// Detect browser and compute potential files
-		if ($detect_browser)
+		// If http is present in filename
+		if (strpos($file, 'http') === 0 || strpos($file, '//') === 0)
 		{
-			$navigator = Browser::getInstance();
-			$browser   = $navigator->getBrowser();
-			$major     = $navigator->getMajor();
-			$minor     = $navigator->getMinor();
-			$minExt    = '';
-
-			if (strlen($strip) > 4 && preg_match('#\.min$#', $strip))
-			{
-				$minExt    = '.min';
-				$strip = preg_replace('#\.min$#', '', $strip);
-
-			}
-
-			// Try to include files named filename.ext, filename_browser.ext, filename_browser_major.ext, filename_browser_major_minor.ext
-			// where major and minor are the browser version names
-			$potential = array(
-				$strip . $minExt,
-				$strip . '_' . $browser . $minExt,
-				$strip . '_' . $browser . '_' . $major . $minExt,
-				$strip . '_' . $browser . '_' . $major . '_' . $minor . $minExt,
-			);
+			$includes = [$file];
 		}
 		else
 		{
-			$potential = array($strip);
-		}
+			// Extract extension and strip the file
+			$strip = File::stripExt($file);
+			$ext   = pathinfo($file, PATHINFO_EXTENSION);
 
-		// If relative search in template directory or media directory
-		if ($relative)
-		{
-			// Get the template
-			$template = Factory::getApplication()->getTemplate();
+			// Prepare array of files
+			$includes = [];
 
-			// For each potential files
-			foreach ($potential as $strip)
+			// Detect browser and compute potential files
+			if ($detect_browser)
 			{
-				$files = array();
+				$navigator = Browser::getInstance();
+				$browser   = $navigator->getBrowser();
+				$major     = $navigator->getMajor();
+				$minor     = $navigator->getMinor();
+				$minExt    = '';
 
-				// Detect debug mode
-				if ($detect_debug && Factory::getConfig()->get('debug'))
+				if (strlen($strip) > 4 && preg_match('#\.min$#', $strip))
 				{
-					/*
-					 * Detect if we received a file in the format name.min.ext
-					 * If so, strip the .min part out, otherwise append -uncompressed
-					 */
-					if (strlen($strip) > 4 && preg_match('#\.min$#', $strip))
-					{
-						$files[] = preg_replace('#\.min$#', '.', $strip) . $ext;
-					}
-					else
-					{
-						$files[] = $strip . '-uncompressed.' . $ext;
-					}
+					$minExt    = '.min';
+					$strip = preg_replace('#\.min$#', '', $strip);
 				}
 
-				$files[] = $strip . '.' . $ext;
+				// Try to include files named filename.ext, filename_browser.ext, filename_browser_major.ext, filename_browser_major_minor.ext
+				// where major and minor are the browser version names
+				$potential = [
+					$strip . $minExt,
+					$strip . '_' . $browser . $minExt,
+					$strip . '_' . $browser . '_' . $major . $minExt,
+					$strip . '_' . $browser . '_' . $major . '_' . $minor . $minExt,
+				];
+			}
+			else
+			{
+				$potential = [$strip];
+			}
 
-				/*
-				 * Loop on 1 or 2 files and break on first found.
-				 * Add the content of the MD5SUM file located in the same folder to URL to ensure cache browser refresh
-				 * This MD5SUM file must represent the signature of the folder content
-				 */
-				foreach ($files as $file)
+			// If relative search in template directory or media directory
+			if ($relative)
+			{
+				// Get the template
+				$template = Factory::getApplication()->getTemplate();
+
+				// For each potential files
+				foreach ($potential as $strip)
 				{
-					// If the file is in the template folder
-					$path = JPATH_THEMES . "/$template/$folder/$file";
+					$files = [];
+					$files[] = $strip . '.' . $ext;
 
-					if (file_exists($path))
+					/**
+					 * Loop on 1 or 2 files and break on first found.
+					 * Add the content of the MD5SUM file located in the same folder to url to ensure cache browser refresh
+					 * This MD5SUM file must represent the signature of the folder content
+					 */
+					foreach ($files as $file)
 					{
-						$includes[] = Uri::base(true) . "/templates/$template/$folder/$file" . static::getMd5Version($path);
+						$found = static::addFileToBuffer(JPATH_THEMES . "/$template/$folder/$file", $ext, $debugMode);
 
-						break;
-					}
-					else
-					{
-						// If the file contains any /: it can be in a media extension subfolder
-						if (strpos($file, '/'))
+						if (!empty($found))
 						{
-							// Divide the file extracting the extension as the first part before /
-							list($extension, $file) = explode('/', $file, 2);
+							$includes[] = $found;
 
-							// If the file yet contains any /: it can be a plugin
+							break;
+						}
+						else
+						{
+							// If the file contains any /: it can be in a media extension subfolder
 							if (strpos($file, '/'))
 							{
-								// Divide the file extracting the element as the first part before /
-								list($element, $file) = explode('/', $file, 2);
+								// Divide the file extracting the extension as the first part before /
+								list($extension, $file) = explode('/', $file, 2);
 
-								// Try to deal with plugins group in the media folder
-								$path = JPATH_ROOT . "/media/$extension/$element/$folder/$file";
-
-								if (file_exists($path))
+								// If the file yet contains any /: it can be a plugin
+								if (strpos($file, '/'))
 								{
-									$includes[] = Uri::root(true) . "/media/$extension/$element/$folder/$file" . static::getMd5Version($path);
+									// Divide the file extracting the element as the first part before /
+									list($element, $file) = explode('/', $file, 2);
 
-									break;
+									// Try to deal with plugins group in the media folder
+									$found = static::addFileToBuffer(JPATH_ROOT . "/media/$extension/$element/$folder/$file", $ext, $debugMode);
+
+									if (!empty($found))
+									{
+										$includes[] = $found;
+
+										break;
+									}
+
+									// Try to deal with classical file in a media subfolder called element
+									$found = static::addFileToBuffer(JPATH_ROOT . "/media/$extension/$folder/$element/$file", $ext, $debugMode);
+
+									if (!empty($found))
+									{
+										$includes[] = $found;
+
+										break;
+									}
+
+									// Try to deal with system files in the template folder
+									$found = static::addFileToBuffer(JPATH_THEMES . "/$template/$folder/system/$element/$file", $ext, $debugMode);
+
+									if (!empty($found))
+									{
+										$includes[] = $found;
+
+										break;
+									}
+
+									// Try to deal with system files in the media folder
+									$found = static::addFileToBuffer(JPATH_ROOT . "/media/system/$folder/$element/$file", $ext, $debugMode);
+
+									if (!empty($found))
+									{
+										$includes[] = $found;
+
+										break;
+									}
 								}
-
-								// Try to deal with classical file in a media subfolder called element
-								$path = JPATH_ROOT . "/media/$extension/$folder/$element/$file";
-
-								if (file_exists($path))
+								else
 								{
-									$includes[] = Uri::root(true) . "/media/$extension/$folder/$element/$file" . static::getMd5Version($path);
+									// Try to deal with files in the extension's media folder
+									$found = static::addFileToBuffer(JPATH_ROOT . "/media/$extension/$folder/$file", $ext, $debugMode);
 
-									break;
-								}
+									if (!empty($found))
+									{
+										$includes[] = $found;
 
-								// Try to deal with system files in the template folder
-								$path = JPATH_THEMES . "/$template/$folder/system/$element/$file";
+										break;
+									}
 
-								if (file_exists($path))
-								{
-									$includes[] = Uri::root(true) . "/templates/$template/$folder/system/$element/$file" . static::getMd5Version($path);
+									// Try to deal with system files in the template folder
+									$found = static::addFileToBuffer(JPATH_THEMES . "/$template/$folder/system/$file", $ext, $debugMode);
 
-									break;
-								}
+									if (!empty($found))
+									{
+										$includes[] = $found;
 
-								// Try to deal with system files in the media folder
-								$path = JPATH_ROOT . "/media/system/$folder/$element/$file";
+										break;
+									}
 
-								if (file_exists($path))
-								{
-									$includes[] = Uri::root(true) . "/media/system/$folder/$element/$file" . static::getMd5Version($path);
+									// Try to deal with system files in the media folder
+									$found = static::addFileToBuffer(JPATH_ROOT . "/media/system/$folder/$file", $ext, $debugMode);
 
-									break;
+									if (!empty($found))
+									{
+										$includes[] = $found;
+
+										break;
+									}
 								}
 							}
 							else
 							{
-								// Try to deals in the extension media folder
-								$path = JPATH_ROOT . "/media/$extension/$folder/$file";
-
-								if (file_exists($path))
-								{
-									$includes[] = Uri::root(true) . "/media/$extension/$folder/$file" . static::getMd5Version($path);
-
-									break;
-								}
-
-								// Try to deal with system files in the template folder
-								$path = JPATH_THEMES . "/$template/$folder/system/$file";
-
-								if (file_exists($path))
-								{
-									$includes[] = Uri::root(true) . "/templates/$template/$folder/system/$file" . static::getMd5Version($path);
-
-									break;
-								}
-
 								// Try to deal with system files in the media folder
-								$path = JPATH_ROOT . "/media/system/$folder/$file";
+								$found = static::addFileToBuffer(JPATH_ROOT . "/media/system/$folder/$file", $ext, $debugMode);
 
-								if (file_exists($path))
+								if (!empty($found))
 								{
-									$includes[] = Uri::root(true) . "/media/system/$folder/$file" . static::getMd5Version($path);
+									$includes[] = $found;
 
 									break;
 								}
-							}
-						}
-						// Try to deal with system files in the media folder
-						else
-						{
-							$path = JPATH_ROOT . "/media/system/$folder/$file";
-
-							if (file_exists($path))
-							{
-								$includes[] = Uri::root(true) . "/media/system/$folder/$file" . static::getMd5Version($path);
-
-								break;
 							}
 						}
 					}
 				}
 			}
-		}
-		// If not relative and http is not present in filename
-		else
-		{
-			foreach ($potential as $strip)
+			else
 			{
-				$files = array();
-
-				// Detect debug mode
-				if ($detect_debug && Factory::getConfig()->get('debug'))
+				// If not relative and http is not present in filename
+				foreach ($potential as $strip)
 				{
-					/*
-					 * Detect if we received a file in the format name.min.ext
-					 * If so, strip the .min part out, otherwise append -uncompressed
+					$files = [];
+
+					$files[] = $strip . '.' . $ext;
+
+					/**
+					 * Loop on 1 or 2 files and break on first found.
+					 * Add the content of the MD5SUM file located in the same folder to url to ensure cache browser refresh
+					 * This MD5SUM file must represent the signature of the folder content
 					 */
-					if (strlen($strip) > 4 && preg_match('#\.min$#', $strip))
+					foreach ($files as $file)
 					{
-						$files[] = preg_replace('#\.min$#', '.', $strip) . $ext;
-					}
-					else
-					{
-						$files[] = $strip . '-uncompressed.' . $ext;
-					}
-				}
+						$path = JPATH_ROOT . "/$file";
 
-				$files[] = $strip . '.' . $ext;
+						$found = static::addFileToBuffer($path, $ext, $debugMode);
 
-				/*
-				 * Loop on 1 or 2 files and break on first found.
-				 * Add the content of the MD5SUM file located in the same folder to URL to ensure cache browser refresh
-				 * This MD5SUM file must represent the signature of the folder content
-				 */
-				foreach ($files as $file)
-				{
-					$path = JPATH_ROOT . "/$file";
+						if (!empty($found))
+						{
+							$includes[] = $found;
 
-					if (file_exists($path))
-					{
-						$includes[] = Uri::root(true) . "/$file" . static::getMd5Version($path);
-
-						break;
+							break;
+						}
 					}
 				}
 			}
@@ -643,6 +619,7 @@ abstract class HTMLHelper
 
 		return $includes;
 	}
+
 
 	/**
 	 * Write a `<img>` element
@@ -1345,4 +1322,92 @@ abstract class HTMLHelper
 
 		return '{' . implode(',', $elements) . '}';
 	}
+
+	/**
+	 * Method that searches if file exists in given path and returns the relative path. If a minified version exists it will be preferred.
+	 *
+	 * @param   string   $path       The actual path of the file
+	 * @param   string   $ext        The extension of the file
+	 * @param   boolean  $debugMode  Signifies if debug is enabled
+	 *
+	 * @return  string  The relative path of the file
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected static function addFileToBuffer($path = '', $ext = '', $debugMode = false)
+	{
+		if (!$debugMode)
+		{
+			// We are handling a name.min.ext file:
+			if (strrpos($path, '.min', '-4'))
+			{
+				$position        = strrpos($path, '.min', '-4');
+				$minifiedPath    = $path;
+				$nonMinifiedPath = str_replace('.min', '', $path, $position);
+
+				return self::checkFileOrder($nonMinifiedPath, $minifiedPath);
+			}
+
+			$minifiedPath = pathinfo($path, PATHINFO_DIRNAME) . '/' . pathinfo($path, PATHINFO_FILENAME) . '.min.' . $ext;
+
+			return self::checkFileOrder($path, $minifiedPath);
+		}
+
+		// We are handling a name.min.ext file:
+		if (strrpos($path, '.min', '-4'))
+		{
+			$position        = strrpos($path, '.min', '-4');
+			$minifiedPath    = $path;
+			$nonMinifiedPath = str_replace('.min', '', $path, $position);
+
+			return self::checkFileOrder($minifiedPath, $nonMinifiedPath);
+		}
+
+		$minifiedPath = pathinfo($path, PATHINFO_DIRNAME) . '/' . pathinfo($path, PATHINFO_FILENAME) . '.min.' . $ext;
+
+		return self::checkFileOrder($minifiedPath, $path);
+	}
+
+	/**
+	 * Method that takes a file path and converts it to a relative path
+	 *
+	 * @param   string  $path  The actual path of the file
+	 *
+	 * @return  string  The relative path of the file
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected static function convertToRelativePath($path)
+	{
+		$relativeFilePath = str_replace(JPATH_ROOT, '', $path);
+
+		// On windows devices we need to replace "\" with "/" otherwise some browsers will not load the asset
+		return str_replace(DIRECTORY_SEPARATOR, '/', $relativeFilePath);
+	}
+
+	/**
+	 * Method that takes two paths and checks if the files exist with different order
+	 *
+	 * @param  $first   string   the path of the minified file
+	 * @param  $second  string   the path of the non minified file
+	 *
+	 * @return  string
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	private static function checkFileOrder($first, $second)
+	{
+		if (is_file($second))
+		{
+			return static::convertToRelativePath($second);
+		}
+
+		if (is_file($first))
+		{
+			return static::convertToRelativePath($first);
+		}
+
+		return '';
+	}
 }
+


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/pull/19637 .

### Summary of Changes
This improves the way assets are handled. 
So it has a logic of first loonking for the minified and then the non minified version if in normal mode and if in debugging mode it reverses the order. 

In plain english even if you do `JHtml::_('script', 'my-awesome-script.js');` or 
`JHtml::_('script', 'my-awesome-script.min.js');` it doesn't matter! Joomla will pick the right one for you! 

### Testing Instructions
Apply patch, rename /media/system/js/core.min.js to  /media/system/js/x-core.min.js
core.js is loaded, revert the change
Enable debug mode
rename /media/system/js/core.js to  /media/system/js/x-core.js
core.min.js is loaded, revert the change
Test is successful!

### Expected result



### Actual result



### Documentation Changes Required
No

There is a change from enabling browser dependant script to be searched automatically to false, this is a performance improvement (checking for less files), but the functionality remains there, it just needs the right attribute to be passed in the JHtml::_()

This are the php changes to remove the minified version of assets, the rest will come when/if the rest of the affect scripts gets updated