### PR TITLE
Fix custom field values being lost when saving a record without (re)providing its custom field values

### DIFF
--- a/libraries/joomla/form/fields/checkbox.php
+++ b/libraries/joomla/form/fields/checkbox.php
@@ -20,6 +20,8 @@ defined('JPATH_PLATFORM') or die;
  */
 class JFormFieldCheckbox extends JFormField
 {
+	public $addFormPresence = true;
+
 	/**
 	 * The form field type.
 	 *

--- a/libraries/joomla/form/fields/checkboxes.php
+++ b/libraries/joomla/form/fields/checkboxes.php
@@ -21,6 +21,8 @@ JFormHelper::loadFieldClass('list');
  */
 class JFormFieldCheckboxes extends JFormFieldList
 {
+	public $addFormPresence = true;
+
 	/**
 	 * The form field type.
 	 *
@@ -106,6 +108,7 @@ class JFormFieldCheckboxes extends JFormFieldList
 	 */
 	protected function getInput()
 	{
+		echo "<pre>"; debug_print_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS); echo "</pre>";
 		if (empty($this->layout))
 		{
 			throw new UnexpectedValueException(sprintf('%s has no layout assigned.', $this->name));

--- a/libraries/joomla/form/fields/checkboxes.php
+++ b/libraries/joomla/form/fields/checkboxes.php
@@ -108,7 +108,6 @@ class JFormFieldCheckboxes extends JFormFieldList
 	 */
 	protected function getInput()
 	{
-		echo "<pre>"; debug_print_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS); echo "</pre>";
 		if (empty($this->layout))
 		{
 			throw new UnexpectedValueException(sprintf('%s has no layout assigned.', $this->name));

--- a/libraries/src/Form/FormField.php
+++ b/libraries/src/Form/FormField.php
@@ -963,9 +963,16 @@ abstract class FormField
 				json_encode(FormHelper::parseShowOnConditions($this->showon, $this->formControl, $this->group)) . '\'';
 			$options['showonEnabled'] = true;
 		}
+		
+		$input = $this->getInput();
+		if (!empty($this->addFormPresence) && strlen($input))
+		{
+			$fn = str_replace($this->formControl . '_', $this->formControl . '[_presence_][', $this->getId('', $this->fieldname)) . ']';
+			$input .= "\n" . '<input type="text" name="' . $fn . '" value="1" />';
+		}
 
 		$data = array(
-			'input'   => $this->getInput(),
+			'input'   => $input,
 			'label'   => $this->getLabel(),
 			'options' => $options,
 		);

--- a/libraries/src/Form/FormField.php
+++ b/libraries/src/Form/FormField.php
@@ -968,7 +968,7 @@ abstract class FormField
 		if (!empty($this->addFormPresence) && strlen($input))
 		{
 			$fn = str_replace($this->formControl . '_', $this->formControl . '[_presence_][', $this->getId('', $this->fieldname)) . ']';
-			$input .= "\n" . '<input type="text" name="' . $fn . '" value="1" />';
+			$input .= "\n" . '<input type="hidden" name="' . $fn . '" value="1" />';
 		}
 
 		$data = array(

--- a/libraries/src/MVC/Controller/FormController.php
+++ b/libraries/src/MVC/Controller/FormController.php
@@ -620,6 +620,7 @@ class FormController extends BaseController
 		$model = $this->getModel();
 		$table = $model->getTable();
 		$data  = $this->input->post->get('jform', array(), 'array');
+		$presence = $data['_presence_'];
 		$checkin = property_exists($table, $table->getColumnAlias('checked_out'));
 		$context = "$this->option.edit.$this->context";
 		$task = $this->getTask();
@@ -696,6 +697,13 @@ class FormController extends BaseController
 
 		// Test whether the data is valid.
 		$validData = $model->validate($form, $data);
+
+		/**
+		 * Validate field presence array, this is used by some fields together with canEditFieldValue ACL 
+		 * to decide if field's values should be emptied or if field values should be maintained
+		 */
+		\JArrayHelper::toInteger($presence);
+		$validData['_presence_'] = $presence;   // Pass presence information
 
 		// Check for validation errors.
 		if ($validData === false)

--- a/libraries/src/MVC/Controller/FormController.php
+++ b/libraries/src/MVC/Controller/FormController.php
@@ -701,7 +701,7 @@ class FormController extends BaseController
 		/**
 		 * Validate field presence array, this is used by some fields together with canEditFieldValue ACL 
 		 * to decide if field's values should be emptied or if field values should be maintained
-		 * Then passing the presence array information by setting it into the validated data array
+		 * then pass the presence array information by setting it into the validated data array
 		 */
 		\JArrayHelper::toInteger($presence);
 		$validData['_presence_'] = $presence;

--- a/libraries/src/MVC/Controller/FormController.php
+++ b/libraries/src/MVC/Controller/FormController.php
@@ -701,9 +701,10 @@ class FormController extends BaseController
 		/**
 		 * Validate field presence array, this is used by some fields together with canEditFieldValue ACL 
 		 * to decide if field's values should be emptied or if field values should be maintained
+		 * Then passing the presence array information by setting it into the validated data array
 		 */
 		\JArrayHelper::toInteger($presence);
-		$validData['_presence_'] = $presence;   // Pass presence information
+		$validData['_presence_'] = $presence;
 
 		// Check for validation errors.
 		if ($validData === false)

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -82,8 +82,6 @@ class PlgSystemFields extends JPlugin
 		$fieldsData = !empty($data['com_fields']) ? $data['com_fields'] : array();
 		$presence = !empty($data['_presence_']) ? $data['_presence_'] : array();
 
-		JFactory::getApplication()->enqueueMessage(print_r($presence, true), 'notice');
-
 		// Loading the model
 		$model = JModelLegacy::getInstance('Field', 'FieldsModel', array('ignore_request' => true));
 
@@ -100,8 +98,6 @@ class PlgSystemFields extends JPlugin
 			}
 
 			$presence_name = 'com_fields_' . str_replace('-', '_', $field->name);
-			JFactory::getApplication()->enqueueMessage(print_r($presence_name, true), 'notice');
-
 			$presentInForm = key_exists($presence_name, $presence);
 			$valuePosted = !is_null($value);
 

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -80,6 +80,9 @@ class PlgSystemFields extends JPlugin
 
 		// Get the fields data
 		$fieldsData = !empty($data['com_fields']) ? $data['com_fields'] : array();
+		$presence = !empty($data['_presence_']) ? $data['_presence_'] : array();
+
+		JFactory::getApplication()->enqueueMessage(print_r($presence, true), 'notice');
 
 		// Loading the model
 		$model = JModelLegacy::getInstance('Field', 'FieldsModel', array('ignore_request' => true));
@@ -96,8 +99,19 @@ class PlgSystemFields extends JPlugin
 				$value = json_encode($value);
 			}
 
-			// Setting the value for the field and the item
-			$model->setFieldValue($field->id, $item->id, $value);
+			$presence_name = 'com_fields_' . str_replace('-', '_', $field->name);
+			JFactory::getApplication()->enqueueMessage(print_r($presence_name, true), 'notice');
+
+			$presentInForm = key_exists($presence_name, $presence);
+			$valuePosted = !is_null($value);
+
+			// NOTE: canEdit field value is checked inside setFieldValue method, so need to check it here
+			// Even if field presence was tampered with it is OK if user has ACL privilege to edit field value !
+			if ($presentInForm || $valuePosted)
+			{
+				// Setting the value for the field and the item
+				$model->setFieldValue($field->id, $item->id, $value);
+			}
 		}
 
 		return true;


### PR DESCRIPTION
Pull Request for Issues like #19735 and #17801

Yet another alternative for PRs #18188, #17837, #18207, #19742
hopefully a more proper one

If you do not like something in this PR like the fieldnames used to detect field presence 
-- then please try to suggest a specific change (specific code !)

### Summary of Changes
Add into the forms an html input tag per field that needs it 
- to indicate if field was present in form but it did not submit any values

such fields are checkbox and checkboxes


### Testing Instructions
1. Add custom field to a user and save some values in them by editing and saving the user,
and execute the following custom code
```php
$user = JFactory::getUser($USER_ID);
$user->save();
```

2. Edit and save a user and ab article that have with checkboxes custom field,
then deselect all checkboxes and save the form

### Expected result
1. Custom field values are not lost

2. Form reloads showing none values selected in the checkboxes

### Actual result
1. Fails, custom field values are lost

2. Works

### Documentation Changes Required

?