### PR TITLE
[com_fields] Normalize the request data to make sure there is a value for every field

### DIFF
--- a/administrator/components/com_fields/models/field.php
+++ b/administrator/components/com_fields/models/field.php
@@ -589,8 +589,9 @@ class FieldsModelField extends JModelAdmin
 		}
 		elseif (count($value) == 1 && count((array) $oldValue) == 1)
 		{
-			// Only a single row value update can be done
-			$needsUpdate = true;
+			// Only a single row value update can be done when not empty
+			$needsUpdate = !empty($value[0]);
+			$needsDelete = empty($value[0]);
 		}
 		else
 		{

--- a/libraries/src/MVC/Controller/FormController.php
+++ b/libraries/src/MVC/Controller/FormController.php
@@ -10,6 +10,8 @@ namespace Joomla\CMS\MVC\Controller;
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\CMS\Form\Form;
+
 /**
  * Controller tailored to suit most form-based admin operations.
  *
@@ -694,6 +696,9 @@ class FormController extends BaseController
 			return false;
 		}
 
+		// Make sure the data array is in the form we need it
+		$data = $this->normalizeRequestData($form, $data);
+
 		// Test whether the data is valid.
 		$validData = $model->validate($form, $data);
 
@@ -912,5 +917,51 @@ class FormController extends BaseController
 
 		$this->setRedirect($redirectUrl);
 		$this->redirect();
+	}
+
+	/**
+	 * Ensures that there is an entry in the data array for every field
+	 * from the form. Groups will be respected too.
+	 * This is needed for checkboxes and radio fields as when no value is selected
+	 * then the data array contains no entry.
+	 *
+	 * @param   Form   $form  The form
+	 * @param   array  $data  The data
+	 *
+	 * @return  array
+	 *
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private function normalizeRequestData(Form $form, array $data)
+	{
+		// Loop over all fields
+		foreach ($form->getFieldset() as $field)
+		{
+			//Make sure the data array has an entry when there is no group
+			if (!$field->group && !key_exists($field->fieldname, $data))
+			{
+				$data[$field->fieldname] = false;
+			}
+
+			// If the field has no group, we are done here
+			if (!$field->group)
+			{
+				continue;
+			}
+
+			// Ensure there is always an array for the group
+			if (!key_exists($field->group, $data))
+			{
+				$data[$field->group] = array();
+			}
+
+			//Make sure the data group array has an entry
+			if (!key_exists($field->fieldname, $data[$field->group]))
+			{
+				$data[$field->group][$field->fieldname] = false;
+			}
+		}
+
+		return $data;
 	}
 }

--- a/libraries/src/MVC/Controller/FormController.php
+++ b/libraries/src/MVC/Controller/FormController.php
@@ -932,7 +932,7 @@ class FormController extends BaseController
 	 *
 	 * @since  __DEPLOY_VERSION__
 	 */
-	private function normaliseRequestData(Form $form, array $data)
+	protected function normaliseRequestData(Form $form, array $data)
 	{
 		// Loop over all fields
 		foreach ($form->getFieldset() as $field)

--- a/libraries/src/MVC/Controller/FormController.php
+++ b/libraries/src/MVC/Controller/FormController.php
@@ -697,7 +697,7 @@ class FormController extends BaseController
 		}
 
 		// Make sure the data array is in the form we need it
-		$data = $this->normalizeRequestData($form, $data);
+		$data = $this->normaliseRequestData($form, $data);
 
 		// Test whether the data is valid.
 		$validData = $model->validate($form, $data);
@@ -932,7 +932,7 @@ class FormController extends BaseController
 	 *
 	 * @since  __DEPLOY_VERSION__
 	 */
-	private function normalizeRequestData(Form $form, array $data)
+	private function normaliseRequestData(Form $form, array $data)
 	{
 		// Loop over all fields
 		foreach ($form->getFieldset() as $field)

--- a/libraries/src/MVC/Controller/FormController.php
+++ b/libraries/src/MVC/Controller/FormController.php
@@ -937,7 +937,7 @@ class FormController extends BaseController
 		// Loop over all fields
 		foreach ($form->getFieldset() as $field)
 		{
-			//Make sure the data array has an entry when there is no group
+			// Make sure the data array has an entry when there is no group
 			if (!$field->group && !key_exists($field->fieldname, $data))
 			{
 				$data[$field->fieldname] = false;
@@ -955,7 +955,7 @@ class FormController extends BaseController
 				$data[$field->group] = array();
 			}
 
-			//Make sure the data group array has an entry
+			// Make sure the data group array has an entry
 			if (!key_exists($field->fieldname, $data[$field->group]))
 			{
 				$data[$field->group][$field->fieldname] = false;

--- a/libraries/src/Table/Content.php
+++ b/libraries/src/Table/Content.php
@@ -142,12 +142,12 @@ class Content extends Table
 
 			if ($tagPos == 0)
 			{
-				$this->introtext = $array['articletext'];
-				$this->fulltext = '';
+				$array['introtext'] = $array['articletext'];
+				$array['fulltext']  = '';
 			}
 			else
 			{
-				list ($this->introtext, $this->fulltext) = preg_split($pattern, $array['articletext'], 2);
+				list ($array['introtext'], $array['fulltext']) = preg_split($pattern, $array['articletext'], 2);
 			}
 		}
 

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -45,7 +45,7 @@ class PlgSystemFields extends JPlugin
 	public function onContentAfterSave($context, $item, $isNew, $data = array())
 	{
 		// Check if data is an array and the item has an id
-		if (!is_array($data) || empty($item->id))
+		if (!is_array($data) || empty($item->id) || empty($data['com_fields']))
 		{
 			return true;
 		}
@@ -78,9 +78,6 @@ class PlgSystemFields extends JPlugin
 			return true;
 		}
 
-		// Get the fields data
-		$fieldsData = !empty($data['com_fields']) ? $data['com_fields'] : array();
-
 		// Loading the model
 		$model = JModelLegacy::getInstance('Field', 'FieldsModel', array('ignore_request' => true));
 
@@ -88,7 +85,7 @@ class PlgSystemFields extends JPlugin
 		foreach ($fields as $field)
 		{
 			// Determine the value if it is available from the data
-			$value = key_exists($field->name, $fieldsData) ? $fieldsData[$field->name] : null;
+			$value = key_exists($field->name, $data['com_fields']) ? $data['com_fields'][$field->name] : null;
 
 			// JSON encode value for complex fields
 			if (is_array($value) && (count($value, COUNT_NORMAL) !== count($value, COUNT_RECURSIVE) || !count(array_filter(array_keys($value), 'is_numeric'))))

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -85,7 +85,7 @@ class PlgSystemFields extends JPlugin
 		foreach ($fields as $field)
 		{
 			// Determine the value if it is available from the data
-			$value = key_exists($field->name, $data['com_fields']) ? $data['com_fields'][$field->name] : null;
+			$value = key_exists($field->name, $data['com_fields']) ? $data['com_fields'][$field->name] : $field->rawvalue;
 
 			// JSON encode value for complex fields
 			if (is_array($value) && (count($value, COUNT_NORMAL) !== count($value, COUNT_RECURSIVE) || !count(array_filter(array_keys($value), 'is_numeric'))))

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -84,8 +84,29 @@ class PlgSystemFields extends JPlugin
 		// Loop over the fields
 		foreach ($fields as $field)
 		{
-			// Determine the value if it is available from the data
-			$value = key_exists($field->name, $data['com_fields']) ? $data['com_fields'][$field->name] : $field->rawvalue;
+			// Determine the value if it is (un)available from the data
+			if (key_exists($field->name, $data['com_fields']))
+			{
+				if ($data['com_fields'][$field->name] === false)
+				{
+					$value = null;
+				}
+				else
+				{
+					$value = $data['com_fields'][$field->name];
+				}
+			}
+			// Field not available on form, use stored value
+			else
+			{
+				$value = $field->rawvalue;
+			}
+
+			// If no value set (empty) remove value fom database
+			if (empty($value))
+			{
+				$value = null;
+			}
 
 			// JSON encode value for complex fields
 			if (is_array($value) && (count($value, COUNT_NORMAL) !== count($value, COUNT_RECURSIVE) || !count(array_filter(array_keys($value), 'is_numeric'))))


### PR DESCRIPTION
Pull Request for Issues like #19735 and #17801 and for PRs #18188, #17837, #18207, #19742.

### Summary of Changes
Makes sure that there is always a value in the array of fields which get passed to the model for saving.

While doing this one, I think it would be safer to target it against 3.9 or even 4 and add a workaround like #18188 in the 3.8 series. What I didn't want to do is to add some special conditions to normalize the request data only for custom fields in the MVC library (yes we are doing that already for associations and tags). @mbabker any thoughts?

**NOTE:**
_Please test is with a lot of combinations and different components, core and 3rd party. I'm pretty sure there will be side effects._

### Testing Instructions
- Create custom user fields.
- Edit a user and fill any data in custom fields.
- Add the following code to the file /administrator/components/com_content/content.php after line 16: 
`JFactory::getUser($USER_ID)->save();`.
Replace the value $USER_ID with the user you have edited.

### Expected result
The user custom field data is still saved on the user.

### Actual result
The user custom fields data on the user are deleted.