### PR TITLE
Radio Field - Allow boolean filter for radio button field

### DIFF
--- a/layouts/joomla/form/field/radio.php
+++ b/layouts/joomla/form/field/radio.php
@@ -64,7 +64,7 @@ $alt    = preg_replace('/[^a-zA-Z0-9_\-]/', '_', $name);
 		<?php foreach ($options as $i => $option) : ?>
 			<?php
 				// Initialize some option attributes.
-				$checked        = ((string) $option->value === $value) ? 'checked="checked"' : '';
+				$checked        = ((bool) $option->value === $value) ? 'checked="checked"' : '';
 				$disabled       = !empty($option->disable) ? 'disabled' : '';
 				$style          = $disabled ? 'style="pointer-events: none"' : '';
 				$option->class  = !empty($option->class) ? $option->class : '';

--- a/libraries/joomla/form/fields/radio.php
+++ b/libraries/joomla/form/fields/radio.php
@@ -66,7 +66,7 @@ class JFormFieldRadio extends JFormFieldList
 
 		$extraData = array(
 			'options' => $this->getOptions(),
-			'value'   => (string) $this->value,
+			'value'   => (bool) $this->value,
 		);
 
 		return array_merge($data, $extraData);


### PR DESCRIPTION
### Summary of Changes

This change allows the filter **boolean** for the standard radion button field (https://docs.joomla.org/Special:MyLanguage/Radio_form_field_type).

### Testing Instructions

Open the manifest file (XML) file of a plugin or module and add the following three fields in a fieldset:

```
<field name="radio1" type="radio" label="RADIO_1" class="btn-group btn-group-yesno" default="1" filter="uint">
    <option value="1">JYES</option>
    <option value="0">JNO</option>
</field>
<field name="radio2" type="radio" label="RADIO_2" class="btn-group btn-group-yesno" default="1" filter="bool">
    <option value="1">JYES</option>
    <option value="0">JNO</option>
</field>
<field name="radio3" type="radio" label="RADIO_3" class="btn-group btn-group-yesno" default="1">
    <option value="1">JYES</option>
    <option value="0">JNO</option>
</field>
```
1. uint filter - 2. boolean filter - 3. no filter

### Expected result

<img width="427" alt="screenshot 2018-02-22 21 52 31" src="https://user-images.githubusercontent.com/1976103/36563545-baf2ebf4-181a-11e8-9365-0bc97669f5a1.png">

### Actual result

<img width="423" alt="screenshot 2018-02-22 21 52 04" src="https://user-images.githubusercontent.com/1976103/36563552-c0507f30-181a-11e8-8d76-4126318176d7.png">

### Documentation Changes Required

No.