### PR TITLE
[4.0] Ensure the CMSApplications do always have an identity

### DIFF
--- a/components/com_config/dispatcher.php
+++ b/components/com_config/dispatcher.php
@@ -9,6 +9,7 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Access\Exception\NotAllowed;
 use Joomla\CMS\Dispatcher\Dispatcher;
 
 /**

--- a/libraries/src/Application/AdministratorApplication.php
+++ b/libraries/src/Application/AdministratorApplication.php
@@ -481,12 +481,6 @@ class AdministratorApplication extends CMSApplication
 		$option = strtolower($app->input->get('option'));
 		$user = $app->getIdentity();
 
-		if (!$user)
-		{
-			$app->loadIdentity(\JFactory::getUser());
-			$user = $app->getIdentity();
-		}
-
 		if ($user->get('guest') || !$user->authorise('core.login.admin'))
 		{
 			$option = 'com_login';

--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -327,6 +327,12 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
 	 */
 	public function execute()
 	{
+		// Ensure the identity is loaded
+		if (!$this->getIdentity())
+		{
+			$this->loadIdentity(Factory::getUser());
+		}
+
 		$this->createExtensionNamespaceMap();
 
 		PluginHelper::importPlugin('system');
@@ -345,12 +351,6 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
 
 		// Mark beforeExecute in the profiler.
 		JDEBUG ? $this->profiler->mark('beforeExecute event dispatched') : null;
-
-		// Ensure the identity is loaded
-		if (!$this->getIdentity())
-		{
-			$this->loadIdentity(Factory::getUser());
-		}
 
 		// Perform application routines.
 		$this->doExecute();

--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -14,6 +14,7 @@ use Joomla\Application\Web\WebClient;
 use Joomla\CMS\Authentication\Authentication;
 use Joomla\CMS\Event\AbstractEvent;
 use Joomla\CMS\Event\BeforeExecuteEvent;
+use Joomla\CMS\Factory;
 use Joomla\CMS\Input\Input;
 use Joomla\CMS\Language\Language;
 use Joomla\CMS\Language\Text;
@@ -344,6 +345,12 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
 
 		// Mark beforeExecute in the profiler.
 		JDEBUG ? $this->profiler->mark('beforeExecute event dispatched') : null;
+
+		// Ensure the identity is loaded
+		if (!$this->getIdentity())
+		{
+			$this->loadIdentity(Factory::getUser());
+		}
 
 		// Perform application routines.
 		$this->doExecute();

--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -14,7 +14,6 @@ use Joomla\Application\Web\WebClient;
 use Joomla\CMS\Authentication\Authentication;
 use Joomla\CMS\Event\AbstractEvent;
 use Joomla\CMS\Event\BeforeExecuteEvent;
-use Joomla\CMS\Factory;
 use Joomla\CMS\Input\Input;
 use Joomla\CMS\Language\Language;
 use Joomla\CMS\Language\Text;
@@ -214,7 +213,7 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
 		// Ensure the identity is loaded
 		if (!$this->getIdentity())
 		{
-			$this->loadIdentity(Factory::getUser());
+			$this->loadIdentity($session->get('user'));
 		}
 	}
 

--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -14,7 +14,6 @@ use Joomla\Application\Web\WebClient;
 use Joomla\CMS\Authentication\Authentication;
 use Joomla\CMS\Event\AbstractEvent;
 use Joomla\CMS\Event\BeforeExecuteEvent;
-use Joomla\CMS\Factory;
 use Joomla\CMS\Input\Input;
 use Joomla\CMS\Language\Language;
 use Joomla\CMS\Language\Text;

--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -14,6 +14,7 @@ use Joomla\Application\Web\WebClient;
 use Joomla\CMS\Authentication\Authentication;
 use Joomla\CMS\Event\AbstractEvent;
 use Joomla\CMS\Event\BeforeExecuteEvent;
+use Joomla\CMS\Factory;
 use Joomla\CMS\Input\Input;
 use Joomla\CMS\Language\Language;
 use Joomla\CMS\Language\Text;
@@ -208,6 +209,12 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
 		if (($handler != 'database' && ($time % 2 || $session->isNew())) || ($handler == 'database' && $session->isNew()))
 		{
 			$this->checkSession();
+		}
+
+		// Ensure the identity is loaded
+		if (!$this->getIdentity())
+		{
+			$this->loadIdentity(Factory::getUser());
 		}
 	}
 

--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -327,12 +327,6 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
 	 */
 	public function execute()
 	{
-		// Ensure the identity is loaded
-		if (!$this->getIdentity())
-		{
-			$this->loadIdentity(Factory::getUser());
-		}
-
 		$this->createExtensionNamespaceMap();
 
 		PluginHelper::importPlugin('system');

--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -22,7 +22,6 @@ use Joomla\CMS\Pathway\Pathway;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Profiler\Profiler;
 use Joomla\CMS\Session\Session;
-use Joomla\CMS\User\User;
 use Joomla\DI\Container;
 use Joomla\DI\ContainerAwareInterface;
 use Joomla\DI\ContainerAwareTrait;
@@ -163,13 +162,9 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
 	 */
 	public function afterSessionStart(SessionEvent $event)
 	{
-		$session = $event->getSession();
+		parent::afterSessionStart($event);
 
-		if ($session->isNew())
-		{
-			$session->set('registry', new Registry);
-			$session->set('user', new User);
-		}
+		$session = $event->getSession();
 
 		// TODO: At some point we need to get away from having session data always in the db.
 		$db   = \JFactory::getDbo();
@@ -208,12 +203,6 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
 		if (($handler != 'database' && ($time % 2 || $session->isNew())) || ($handler == 'database' && $session->isNew()))
 		{
 			$this->checkSession();
-		}
-
-		// Ensure the identity is loaded
-		if (!$this->getIdentity())
-		{
-			$this->loadIdentity($session->get('user'));
 		}
 	}
 

--- a/libraries/src/Application/WebApplication.php
+++ b/libraries/src/Application/WebApplication.php
@@ -15,6 +15,7 @@ use Joomla\Application\Web\WebClient;
 use Joomla\CMS\Document\Document;
 use Joomla\CMS\Input\Input;
 use Joomla\CMS\Language\Language;
+use Joomla\CMS\User\User;
 use Joomla\CMS\Version;
 use Joomla\Event\DispatcherAwareInterface;
 use Joomla\Event\DispatcherAwareTrait;
@@ -316,7 +317,13 @@ abstract class WebApplication extends AbstractWebApplication implements Dispatch
 		if ($session->isNew())
 		{
 			$session->set('registry', new Registry);
-			$session->set('user', new \JUser);
+			$session->set('user', new User);
+		}
+
+		// Ensure the identity is loaded
+		if (!$this->getIdentity())
+		{
+			$this->loadIdentity($session->get('user'));
 		}
 	}
 

--- a/libraries/src/Application/WebApplication.php
+++ b/libraries/src/Application/WebApplication.php
@@ -318,6 +318,12 @@ abstract class WebApplication extends AbstractWebApplication implements Dispatch
 			$session->set('registry', new Registry);
 			$session->set('user', new \JUser);
 		}
+
+		// Ensure the identity is loaded
+		if (!$this->getIdentity())
+		{
+			$this->loadIdentity(Factory::getUser());
+		}
 	}
 
 	/**

--- a/libraries/src/Application/WebApplication.php
+++ b/libraries/src/Application/WebApplication.php
@@ -13,6 +13,7 @@ defined('JPATH_PLATFORM') or die;
 use Joomla\Application\AbstractWebApplication;
 use Joomla\Application\Web\WebClient;
 use Joomla\CMS\Document\Document;
+use Joomla\CMS\Factory;
 use Joomla\CMS\Input\Input;
 use Joomla\CMS\Language\Language;
 use Joomla\CMS\Version;

--- a/libraries/src/Application/WebApplication.php
+++ b/libraries/src/Application/WebApplication.php
@@ -13,7 +13,6 @@ defined('JPATH_PLATFORM') or die;
 use Joomla\Application\AbstractWebApplication;
 use Joomla\Application\Web\WebClient;
 use Joomla\CMS\Document\Document;
-use Joomla\CMS\Factory;
 use Joomla\CMS\Input\Input;
 use Joomla\CMS\Language\Language;
 use Joomla\CMS\Version;
@@ -318,12 +317,6 @@ abstract class WebApplication extends AbstractWebApplication implements Dispatch
 		{
 			$session->set('registry', new Registry);
 			$session->set('user', new \JUser);
-		}
-
-		// Ensure the identity is loaded
-		if (!$this->getIdentity())
-		{
-			$this->loadIdentity(Factory::getUser());
 		}
 	}
 


### PR DESCRIPTION
### Summary of Changes
The CMSApplications needs always an identity.

### Testing Instructions
- Create a "Site Configuration Options" menu item
- Open the menu item in the front end

### Expected result
- It opens normally when you are logged in and do have super admin permissions.
- It throws an no access exception when you are a guest.

### Actual result
The following error is thrown:

_Call to a member function authorise() on null_