### PR TITLE
JHtml image. Parameter $returnPath = -1 returns image path instead of image tag

### DIFF
--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -582,7 +582,7 @@ abstract class HTMLHelper
 		}
 
 		// If only path is required
-		if ($returnPath)
+		if ($returnPath === 1)
 		{
 			return $file;
 		}


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/19762#issuecomment-368095188

### Testing Instructions
See https://github.com/joomla/joomla-cms/issues/19762#issuecomment-368095188
- Apply patch
- Test again
