### PR TITLE
Fix #19500 Make a subform table layout to be more strict to rows container

### DIFF
--- a/layouts/joomla/form/field/subform/repeatable-table.php
+++ b/layouts/joomla/form/field/subform/repeatable-table.php
@@ -73,7 +73,7 @@ else
 		<div class="subform-repeatable"
 			data-bt-add="a.group-add" data-bt-remove="a.group-remove" data-bt-move="a.group-move"
 			data-repeatable-element="tr.subform-repeatable-group"
-			data-rows-container="tbody" data-minimum="<?php echo $min; ?>" data-maximum="<?php echo $max; ?>">
+			data-rows-container="tbody.subform-repeatable-container" data-minimum="<?php echo $min; ?>" data-maximum="<?php echo $max; ?>">
 
 		<table class="adminlist table table-striped table-bordered">
 			<thead>
@@ -90,7 +90,7 @@ else
 					<?php endif; ?>
 				</tr>
 			</thead>
-			<tbody>
+			<tbody class="subform-repeatable-container">
 			<?php
 			foreach ($forms as $k => $form) :
 				echo $this->sublayout($sublayout, array('form' => $form, 'basegroup' => $fieldname, 'group' => $fieldname . $k, 'buttons' => $buttons));


### PR DESCRIPTION
Pull Request for Issue #19500 .

### Summary of Changes
Make a subform table layout to be more strict to rows container


### Testing Instructions
for details please see #19500

XML for testing (can add this XML to any existing form ) :
```xml
<field name="datesselect" multiple="true" layout="joomla.form.field.subform.repeatable-table" type="subform" label="DATESSELECT" description="" hint="">
  <form><fieldset>
    <field name="init_date" class="inputbox" timeformat="12" filter="server_utc" showtime="false" singleheader="false" todaybutton="false" weeknumbers="false" filltable="false" type="calendar" label="INIT_DATE" description="" hint=""/>
    <field name="end_date" class="inputbox" timeformat="12" filter="server_utc" showtime="false" singleheader="false" todaybutton="false" weeknumbers="false" filltable="false" type="calendar" label="END_DATE" description="" hint=""/>
  </fieldset></form>
</field>
```






