### PR TITLE
fix 404 on github dokukmentation links

### DIFF
--- a/libraries/joomla/github/package/users.php
+++ b/libraries/joomla/github/package/users.php
@@ -12,7 +12,7 @@ defined('JPATH_PLATFORM') or die;
 /**
  * GitHub API References class for the Joomla Platform.
  *
- * @documentation https://developer.github.com/v3/repos/users
+ * @documentation https://developer.github.com/v3/users
  *
  * @since       12.3
  * @deprecated  4.0  Use the `joomla/github` package via Composer instead

--- a/libraries/joomla/github/package/users/emails.php
+++ b/libraries/joomla/github/package/users/emails.php
@@ -15,7 +15,7 @@ defined('JPATH_PLATFORM') or die;
  * Management of email addresses via the API requires that you are authenticated
  * through basic auth or OAuth with the user scope.
  *
- * @documentation https://developer.github.com/v3/repos/users/emails
+ * @documentation https://developer.github.com/v3/users/emails
  *
  * @since       12.3
  * @deprecated  4.0  Use the `joomla/github` package via Composer instead

--- a/libraries/joomla/github/package/users/followers.php
+++ b/libraries/joomla/github/package/users/followers.php
@@ -12,7 +12,7 @@ defined('JPATH_PLATFORM') or die;
 /**
  * GitHub API References class for the Joomla Platform.
  *
- * @documentation https://developer.github.com/v3/repos/users/followers
+ * @documentation https://developer.github.com/v3/users/followers
  *
  * @since       12.3
  * @deprecated  4.0  Use the `joomla/github` package via Composer instead

--- a/libraries/joomla/github/package/users/keys.php
+++ b/libraries/joomla/github/package/users/keys.php
@@ -12,7 +12,7 @@ defined('JPATH_PLATFORM') or die;
 /**
  * GitHub API References class for the Joomla Platform.
  *
- * @documentation https://developer.github.com/v3/repos/users/keys
+ * @documentation https://developer.github.com/v3/users/keys
  *
  * @since       12.3
  * @deprecated  4.0  Use the `joomla/github` package via Composer instead


### PR DESCRIPTION
### Summary of Changes

Some links in the inline doku for JGithub Point to 404 on github.com

### Testing Instructions

review as no production code is changed

### Expected result

no 404 links

### Actual result

404 links

### Additional comments

see here for the upstream PR:  https://github.com/joomla-framework/github-api/pull/42