### PR TITLE
Add possibility to save multiple values as JSON

### DIFF
--- a/libraries/joomla/form/fields/list.php
+++ b/libraries/joomla/form/fields/list.php
@@ -57,6 +57,12 @@ class JFormFieldList extends JFormField
 		// Get the field options.
 		$options = (array) $this->getOptions();
 
+		// Check if value is JSON
+		if ($this->multiple && is_string($this->value) && is_array(json_decode($this->value, true)))
+		{
+			$this->value = (array) json_decode($this->value);
+		}
+
 		// Create a read-only list (no name) with hidden input(s) to store the value(s).
 		if ((string) $this->readonly == '1' || (string) $this->readonly == 'true')
 		{


### PR DESCRIPTION
### Summary of Changes

This change add the possibility to save multiple values of FieldList as JSON.

### Testing Instructions

Create using JForm a list with multiple value enabled like:

```
    <field multiple="true" name="options" type="list" label="COM_TEST_FORM_LBL_OPTIONS" description="COM_TEST_FORM_DESC_OPTIONS" hint="COM_TEST_FORM_LBL_OPTIONS">
      <option value="0">COM_TEST_PRODUCTS_OPTIONS_0</option>
      <option value="1">COM_TEST_PRODUCTS_OPTIONS_1</option>
      <option value="2">COM_TEST_PRODUCTS_OPTIONS_2</option>
    </field>
```

Then add into save() function in models:

```
    $data['options'] = json_encode($data['options']);
```


### Expected result

You can save multiple values as JSON into database

