### PR TITLE
mod_breadcrumbs. remove JHtml::bootstrap.tooltip

### DIFF
--- a/modules/mod_breadcrumbs/tmpl/default.php
+++ b/modules/mod_breadcrumbs/tmpl/default.php
@@ -8,8 +8,6 @@
  */
 
 defined('_JEXEC') or die;
-
-JHtml::_('bootstrap.tooltip');
 ?>
 
 <ul itemscope itemtype="https://schema.org/BreadcrumbList" class="breadcrumb<?php echo $moduleclass_sfx; ?>">


### PR DESCRIPTION
### Summary of Changes
- Removed `JHtml::_('bootstrap.tooltip');` because it's not needed in this file. There are no CSS classes like `hasTooltip` or attributes like `title`

### Test
Check Breadcrumbs module before and after patch. Nothing has changed.

Or code review.