### PR TITLE
Debug plugin style

### DIFF
--- a/plugins/system/debug/debug.xml
+++ b/plugins/system/debug/debug.xml
@@ -134,7 +134,7 @@
 					label="PLG_DEBUG_FIELD_LOG_CATEGORY_MODE_LABEL"
 					description="PLG_DEBUG_FIELD_LOG_CATEGORY_MODE_DESC"
 					default="0"
-					class="btn-group btn-group btn-group-yesno btn-group-reversed"
+					class="btn-group btn-group-yesno btn-group-reversed"
 					>
 					<option value="0">PLG_DEBUG_FIELD_LOG_CATEGORY_MODE_INCLUDE</option>
 					<option value="1">PLG_DEBUG_FIELD_LOG_CATEGORY_MODE_EXCLUDE</option>

--- a/plugins/system/debug/debug.xml
+++ b/plugins/system/debug/debug.xml
@@ -134,7 +134,7 @@
 					label="PLG_DEBUG_FIELD_LOG_CATEGORY_MODE_LABEL"
 					description="PLG_DEBUG_FIELD_LOG_CATEGORY_MODE_DESC"
 					default="0"
-					class="btn-group btn-group-yesno"
+					class="btn-group btn-group btn-group-yesno btn-group-reversed"
 					>
 					<option value="0">PLG_DEBUG_FIELD_LOG_CATEGORY_MODE_INCLUDE</option>
 					<option value="1">PLG_DEBUG_FIELD_LOG_CATEGORY_MODE_EXCLUDE</option>


### PR DESCRIPTION
Wrong css on the buttons for Log Category Mode

It should be green for the positive action (include) and red for the negative action (exclude)

This simple PR ensures that is the case

### Before
<img width="327" alt="chrome_2018-02-26_18-55-15" src="https://user-images.githubusercontent.com/1296369/36689181-9c99a706-1b26-11e8-8f81-6419b02f63e0.png">

### After
<img width="345" alt="chrome_2018-02-26_18-54-27" src="https://user-images.githubusercontent.com/1296369/36689149-88c5077a-1b26-11e8-85b2-6984f8619dd4.png">
