### PR TITLE
Output_buffering check broken in sys information report

### DIFF
--- a/administrator/components/com_admin/models/sysinfo.php
+++ b/administrator/components/com_admin/models/sysinfo.php
@@ -239,8 +239,6 @@ class AdminModelSysInfo extends JModelLegacy
 			return $this->php_settings;
 		}
 
-		$outputBuffering = ini_get('output_buffering');
-
 		$this->php_settings = array(
 			'safe_mode'          => ini_get('safe_mode') == '1',
 			'display_errors'     => ini_get('display_errors') == '1',
@@ -248,7 +246,7 @@ class AdminModelSysInfo extends JModelLegacy
 			'file_uploads'       => ini_get('file_uploads') == '1',
 			'magic_quotes_gpc'   => ini_get('magic_quotes_gpc') == '1',
 			'register_globals'   => ini_get('register_globals') == '1',
-			'output_buffering'   => ($outputBuffering === 'On') ? true : is_numeric($outputBuffering),
+			'output_buffering'   => (int) ini_get('output_buffering') !== 0,
 			'open_basedir'       => ini_get('open_basedir'),
 			'session.save_path'  => ini_get('session.save_path'),
 			'session.auto_start' => ini_get('session.auto_start'),

--- a/installation/model/setup.php
+++ b/installation/model/setup.php
@@ -372,10 +372,9 @@ class InstallationModelSetup extends JModelBase
 		$settings[] = $setting;
 
 		// Check for output buffering.
-		$outputBuffering = ini_get('output_buffering');
 		$setting = new stdClass;
 		$setting->label = JText::_('INSTL_OUTPUT_BUFFERING');
-		$setting->state = ($outputBuffering === 'On') ? true : is_numeric($outputBuffering);
+		$setting->state = (int) ini_get('output_buffering') !== 0;
 		$setting->recommended = false;
 		$settings[] = $setting;
 


### PR DESCRIPTION
Pull Request for Issue #19784 .

### Summary of Changes

@ggppdk provided a better check than the merged one in https://github.com/joomla/joomla-cms/pull/19611

### Testing Instructions

- upload joomla to the server
- set `php_value output_buffering Off` via htaccess
- check the output_buffering values showed in the installer and in the backed.

### Expected result

Setting is off also after that patch.

@sandewt @Quy @ggppdk please test this one here again. Thanks.