### PR TITLE
Front end menu items translated in error

### DIFF
--- a/administrator/components/com_menus/models/items.php
+++ b/administrator/components/com_menus/models/items.php
@@ -533,9 +533,9 @@ class MenusModelItems extends JModelList
 
 					// Translate component name
 					if ($client === 1)
-					{	
-					$item->title = JText::_($item->title);
-					}				
+					{
+						$item->title = JText::_($item->title);
+					}			
 				}
 			}
 

--- a/administrator/components/com_menus/models/items.php
+++ b/administrator/components/com_menus/models/items.php
@@ -535,7 +535,7 @@ class MenusModelItems extends JModelList
 					if ($client === 1)
 					{
 						$item->title = JText::_($item->title);
-					}			
+					}
 				}
 			}
 

--- a/administrator/components/com_menus/models/items.php
+++ b/administrator/components/com_menus/models/items.php
@@ -519,6 +519,7 @@ class MenusModelItems extends JModelList
 		{
 			$items = parent::getItems();
 			$lang  = JFactory::getLanguage();
+			$client = $this->state->get('filter.client_id');
 
 			if ($items)
 			{
@@ -531,7 +532,10 @@ class MenusModelItems extends JModelList
 					}
 
 					// Translate component name
+					if ($client === 1)
+					{	
 					$item->title = JText::_($item->title);
+					}				
 				}
 			}
 


### PR DESCRIPTION
Pull Request to fix #19800

PR #13606 introduced translatable admin menu item creation but the code didnt check if the menu item was for the frontend or the admin before doing the translation

### Test Instructions
1. Install any additional language eg italian
2. Create a menu item called "Sun"
3. On the list of all the menu items you will see it is displayed as "Dom" - the italian translation
4. Enable language debug
5. On the list of all the menu items you will see all your menu item titles are surrounded by ?? - to indicate no translation found -  except for "Dom" which has ** instead to show it has been translated
6. Apply this PR
7. Sun still says Sun
8. There are NO ?? or ** when in language debug mode
9. Bonus - check a custom admin menu item and you will see it can be translated
