### PR TITLE
Correcting finder feeds items date when language is not English

### DIFF
--- a/components/com_finder/views/search/view.feed.php
+++ b/components/com_finder/views/search/view.feed.php
@@ -84,7 +84,7 @@ class FinderViewSearch extends JViewLegacy
 			$item->title       = $result->title;
 			$item->link        = JRoute::_($result->route);
 			$item->description = $result->description;
-			// Use UNix date to cope for non-english languages
+			// Use Unix date to cope for non-english languages
 			$item->date        = (int) $result->start_date ? JHtml::_('date', $result->start_date, 'U') : $result->indexdate;
 
 			// Get the taxonomy data.

--- a/components/com_finder/views/search/view.feed.php
+++ b/components/com_finder/views/search/view.feed.php
@@ -84,7 +84,8 @@ class FinderViewSearch extends JViewLegacy
 			$item->title       = $result->title;
 			$item->link        = JRoute::_($result->route);
 			$item->description = $result->description;
-			$item->date        = (int) $result->start_date ? JHtml::_('date', $result->start_date, 'l d F Y') : $result->indexdate;
+			// Use UNix date to cope for non-english languages
+			$item->date        = (int) $result->start_date ? JHtml::_('date', $result->start_date, 'U') : $result->indexdate;
 
 			// Get the taxonomy data.
 			$taxonomy = $result->getTaxonomy();


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/10961
This PR is a redo of https://github.com/joomla/joomla-cms/pull/11557

This is correcting the fatal error (for a site in French or multilingual site and using French in frontend.
(The same error will also happen when using another language than English)
`Error: Call to undefined method Joomla\CMS\Document\FeedDocument::addHeadLink(): DateTime::__construct(): Failed to parse time string (jeudi 02 novembre 2017) at position 0 (j): The timezone could not be found in the database.`

### Summary of Changes
Using UNIX to be sure to get a date.

### Testing Instructions
Define a default time zone. I tested with Paris.
Choose a non English language as frontend language. French is a good example.
Index smartsearch.
Create a menu item to smart search , make sure Show Feed is set to yes.
<img width="480" alt="screen shot 2018-03-02 at 14 59 46" src="https://user-images.githubusercontent.com/869724/36902351-7da7a116-1e2a-11e8-8aa4-0dd21cd4b0bc.png">

Display that menu item in frontend and search for example for an article title.
Try to load the feed.

patch and try again.
