### PR TITLE
[com_ajax] Change modules check

### DIFF
--- a/components/com_ajax/ajax.php
+++ b/components/com_ajax/ajax.php
@@ -46,14 +46,11 @@ if (!$format)
  */
 elseif ($input->get('module'))
 {
-	$module       = $input->get('module');
-	$moduleObject = JModuleHelper::getModule('mod_' . $module, null);
+	$module   = $input->get('module');
+	$table    = JTable::getInstance('extension');
+	$moduleId = $table->find(array('type' => 'module', 'element' => 'mod_' . $module));
 
-	/*
-	 * As JModuleHelper::isEnabled always returns true, we check
-	 * for an id other than 0 to see if it is published.
-	 */
-	if ($moduleObject->id != 0)
+	if ($moduleId && $table->load($moduleId) && $table->enabled)
 	{
 		$helperFile = JPATH_BASE . '/modules/mod_' . $module . '/helper.php';
 

--- a/libraries/src/Helper/ModuleHelper.php
+++ b/libraries/src/Helper/ModuleHelper.php
@@ -404,14 +404,8 @@ abstract class ModuleHelper
 		$query->where('(m.publish_up = ' . $db->quote($nullDate) . ' OR m.publish_up <= ' . $db->quote($now) . ')')
 			->where('(m.publish_down = ' . $db->quote($nullDate) . ' OR m.publish_down >= ' . $db->quote($now) . ')')
 			->where('m.access IN (' . $groups . ')')
-			->where('m.client_id = ' . $clientId);
-
-		// Filter by menu itemId
-		$option = $app->input->get('option', '');
-		if ($option !== 'com_ajax')
-		{
-			$query->where('(mm.menuid = ' . $Itemid . ' OR mm.menuid <= 0)');
-		}
+			->where('m.client_id = ' . $clientId)
+			->where('(mm.menuid = ' . $Itemid . ' OR mm.menuid <= 0)');
 
 		// Filter by language
 		if ($app->isClient('site') && $app->getLanguageFilter())

--- a/libraries/src/Helper/ModuleHelper.php
+++ b/libraries/src/Helper/ModuleHelper.php
@@ -404,8 +404,14 @@ abstract class ModuleHelper
 		$query->where('(m.publish_up = ' . $db->quote($nullDate) . ' OR m.publish_up <= ' . $db->quote($now) . ')')
 			->where('(m.publish_down = ' . $db->quote($nullDate) . ' OR m.publish_down >= ' . $db->quote($now) . ')')
 			->where('m.access IN (' . $groups . ')')
-			->where('m.client_id = ' . $clientId)
-			->where('(mm.menuid = ' . $Itemid . ' OR mm.menuid <= 0)');
+			->where('m.client_id = ' . $clientId);
+
+		// Filter by menu itemId
+		$option = $app->input->get('option', '');
+		if ($option !== 'com_ajax')
+		{
+			$query->where('(mm.menuid = ' . $Itemid . ' OR mm.menuid <= 0)');
+		}
 
 		// Filter by language
 		if ($app->isClient('site') && $app->getLanguageFilter())


### PR DESCRIPTION
### Summary of Changes
Change modules check to ignore the Menu Assignment menu in com_ajax


### Testing Instructions
* Install Joomla 3.8.5
* Download and install this test module [mod_ajaxtest.zip](https://github.com/joomla/joomla-cms/files/1777445/mod_ajaxtest.zip) (or you can use your module)
* Go to modules manager and then go to mod_ajaxtest settings 
* Сheck Module Assignment set No pages and save module
* Apply this path
* Return to the mod_ajaxtest settings and you will see a message about a successful request


### Expected result
The request will be successful regardless of the  Menu Assignment 


### Actual result
The request is executed with an error  
Module mod_ajaxtest is not published, you do not have access to it, or it's not assigned to the current menu item.

### What is it for
If you honestly bothered each time to pass the itemID when I need use com_ajax in modules, if the module is form is still quite tolerable (you can make a hidden field), then in all other cases you have to be wiser.

And if you need com_ajax in the module settings. For example, some kind of field, then you have to do a third-party file handler

