### PR TITLE
Categories: Allow sorting by Associations

### DIFF
--- a/administrator/components/com_categories/models/categories.php
+++ b/administrator/components/com_categories/models/categories.php
@@ -47,6 +47,11 @@ class CategoriesModelCategories extends JModelList
 			);
 		}
 
+		if (JLanguageAssociations::isEnabled())
+		{
+			$config['filter_fields'][] = 'association';
+		}
+
 		parent::__construct($config);
 	}
 

--- a/administrator/components/com_categories/models/forms/filter_categories.xml
+++ b/administrator/components/com_categories/models/forms/filter_categories.xml
@@ -82,14 +82,14 @@
 			<option value="">JGLOBAL_SORT_BY</option>
 			<option value="a.lft ASC">JGRID_HEADING_ORDERING_ASC</option>
 			<option value="a.lft DESC">JGRID_HEADING_ORDERING_DESC</option>
-			<option value="association ASC" requires="associations">JASSOCIATIONS_ASC</option>
-			<option value="association DESC" requires="associations">JASSOCIATIONS_DESC</option>
 			<option value="a.published ASC">JSTATUS_ASC</option>
 			<option value="a.published DESC">JSTATUS_DESC</option>
 			<option value="a.title ASC">JGLOBAL_TITLE_ASC</option>
 			<option value="a.title DESC">JGLOBAL_TITLE_DESC</option>
 			<option value="access_level ASC">JGRID_HEADING_ACCESS_ASC</option>
 			<option value="access_level DESC">JGRID_HEADING_ACCESS_DESC</option>
+			<option value="association ASC" requires="associations">JASSOCIATIONS_ASC</option>
+			<option value="association DESC" requires="associations">JASSOCIATIONS_DESC</option>
 			<option value="language_title ASC">JGRID_HEADING_LANGUAGE_ASC</option>
 			<option value="language_title DESC">JGRID_HEADING_LANGUAGE_DESC</option>
 			<option value="a.id ASC">JGRID_HEADING_ID_ASC</option>

--- a/administrator/components/com_categories/models/forms/filter_categories.xml
+++ b/administrator/components/com_categories/models/forms/filter_categories.xml
@@ -82,6 +82,8 @@
 			<option value="">JGLOBAL_SORT_BY</option>
 			<option value="a.lft ASC">JGRID_HEADING_ORDERING_ASC</option>
 			<option value="a.lft DESC">JGRID_HEADING_ORDERING_DESC</option>
+			<option value="association ASC" requires="associations">JASSOCIATIONS_ASC</option>
+			<option value="association DESC" requires="associations">JASSOCIATIONS_DESC</option>
 			<option value="a.published ASC">JSTATUS_ASC</option>
 			<option value="a.published DESC">JSTATUS_DESC</option>
 			<option value="a.title ASC">JGLOBAL_TITLE_ASC</option>


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/19820

### Before patch
see issue

### Testing Instructions
Steps to reproduce the issue

Install a multilingual site, set the language filter plugin to use associations
Associate some categories
Go to Contents > Categories
Click on Association column header
or
Click Sort Table By dropdown


### After patch
<img width="708" alt="screen shot 2018-03-03 at 17 53 43" src="https://user-images.githubusercontent.com/869724/36936965-7e073b8e-1f0c-11e8-8907-c117c394fc09.png">

<img width="405" alt="screen shot 2018-03-03 at 17 59 21" src="https://user-images.githubusercontent.com/869724/36936985-b04876a8-1f0c-11e8-8062-4cfbac80c8e6.png">


@Quy 