### PR TITLE
Allow category selection in category search tool

### DIFF
--- a/administrator/components/com_categories/models/categories.php
+++ b/administrator/components/com_categories/models/categories.php
@@ -203,7 +203,7 @@ class CategoriesModelCategories extends JModelList
 
 		if (is_numeric($categoryId))
 		{
-			$categoryTable= JTable::getInstance('Category', 'JTable');
+			$categoryTable = JTable::getInstance('Category', 'JTable');
 			$categoryTable->load($categoryId);
 			$rgt = $categoryTable->rgt;
 			$lft = $categoryTable->lft;

--- a/administrator/components/com_categories/models/forms/filter_categories.xml
+++ b/administrator/components/com_categories/models/forms/filter_categories.xml
@@ -22,6 +22,18 @@
 		</field>
 
 		<field
+			name="category_id"
+			type="category"
+			label="JOPTION_FILTER_CATEGORY"
+			description="JOPTION_FILTER_CATEGORY_DESC"
+			extension="com_content"
+			onchange="this.form.submit();"
+			published="0,1,2"
+			>
+			<option value="">JOPTION_SELECT_CATEGORY</option>
+		</field>
+
+		<field
 			name="access"
 			type="accesslevel"
 			label="JOPTION_FILTER_ACCESS"

--- a/administrator/components/com_categories/views/categories/view.html.php
+++ b/administrator/components/com_categories/views/categories/view.html.php
@@ -201,15 +201,15 @@ class CategoriesViewCategories extends JViewLegacy
 			JToolbarHelper::archiveList('categories.archive');
 		}
 
-		if (JFactory::getUser()->authorise('core.admin'))
+		if ($user->authorise('core.admin'))
 		{
 			JToolbarHelper::checkin('categories.checkin');
 		}
 
 		// Add a batch button
-		if ($canDo->get('core.create')
-			&& $canDo->get('core.edit')
-			&& $canDo->get('core.edit.state'))
+		if ($user->authorise('core.create', $component)
+			&& $user->authorise('core.edit', $component)
+			&& $user->authorise('core.edit.state', $component))
 		{
 			$title = JText::_('JTOOLBAR_BATCH');
 


### PR DESCRIPTION
### Issue

An editor allowed to administrate some but not all categories might edit these categories, moreover he can create sub-categories for these categories and he can throw these categories and any sub-category created into trash. But he's never able to empty the trash since there is no such button in the toolbar.

This PR adds a "category selection" field to the search tools in Articles: Categories. Using this new field the editor is now able to empty the trash by first selecting the appropriate top-level category he's allowed to administrate and then by selecting the "trashed" status.

### Use Case

Within a sports club with many divisions we have one editor for each division. There is one top-level category for each division and the editor responsible for a division can administrate this top-level category such that he can add sub-categories when needed, create articles etc. Each editor is allowed to log in to the backend.

These editors can throw articles and categories into the trash and they can empty the trash holding old articles, but they are not able to empty the trash holding old categories.

### Testing Instructions

For testing my PR you need a current Joomla installation with the sample data installed.

#### Preparation

Create a new user group with the name "Park Site Authors", the parent user group is "Registered".

Set the following permissions for this new user group:

- in the global configuration: Administrator Login, Edit Own
- for articles: Administrative Access
- for the category "Park Site": Create, Delete, Edit, Edit State

Add this new user group to the access level "Special".

Finally create a new user with the name "Park Site Author", login "psauthor", password ..., mail ... and assign the user group "Park Site Authors" to this user (in doing so you might remove the default user group "Registered").

Note: the editors in the sports club have additional permissions beside those given above (like access to the media section), but these permissions do not interfere with the issue in this PR.

#### Status Quo

Log in as user "psauthor" and go to Articles: Categories. You should see that you can edit the "Park Site" category and all sub-categories of this category. In the toolbar you have the buttons "New", "Edit" and (on the right side) "Help".

Now create a new category (name it as you wish) and select the "Park Site" category as its parent category. Save & close this new category. Throw this category into the trash.

Now open the search tools and select the status "Trashed". After updating the screen you should see the category you threw into the trash immediately before. There is no way to empty the trash, you can only publish and archive the trashed category.

Log out and then log in as super user and empty the category trash.

#### Changes

First apply this PR.

Then log in again as user "psauthor" and go to Articles: Categories. You should see that you can edit the "Park Site" category and all sub-categories of this category. In the toolbar you have the buttons "New", "Edit" and (on the right side) "Help" (so far nothing has changed).

Now open the search tools. You should see an additional search tool "Select Category". Select the category "Park Site", after updating the screen you should see additional buttons in the toolbar: "Publish", "Unpublish", "Archive" and "Trash".

Repeat the test from above: create a new category with "Park Site" as parent category, then throw this category into the trash. Select the status "Trashed" in the search tools.

The toolbar has changed: instead of the button "Trash" you now see the botton "Empty Trash".

And after selecting the category in the trash, pressing the "Empty Trash" button and answering the question, whether the contents of the trash shall be deleted with "yes" the category will be deleted finally.

### A Final Note

If you think you've seen the changes I've made already before: this is true. I checked the code used in administrating articles and I found that more or less the same code can be used for administrating categories (some details differ...).