### PR TITLE
Article and contact modal should not use addslashes

### DIFF
--- a/administrator/components/com_contact/views/contacts/tmpl/modal.php
+++ b/administrator/components/com_contact/views/contacts/tmpl/modal.php
@@ -120,7 +120,7 @@ if (!empty($editor))
 							<span class="<?php echo $iconStates[$this->escape($item->published)]; ?>" aria-hidden="true"></span>
 						</td>
 						<td>
-							<a class="select-link" href="javascript:void(0)" data-function="<?php echo $this->escape($onclick); ?>" data-id="<?php echo $item->id; ?>" data-title="<?php echo $this->escape(addslashes($item->name)); ?>" data-uri="<?php echo $this->escape(ContactHelperRoute::getContactRoute($item->id, $item->catid, $item->language)); ?>" data-language="<?php echo $this->escape($lang); ?>">
+							<a class="select-link" href="javascript:void(0)" data-function="<?php echo $this->escape($onclick); ?>" data-id="<?php echo $item->id; ?>" data-title="<?php echo $this->escape($item->name); ?>" data-uri="<?php echo $this->escape(ContactHelperRoute::getContactRoute($item->id, $item->catid, $item->language)); ?>" data-language="<?php echo $this->escape($lang); ?>">
 								<?php echo $this->escape($item->name); ?>
 							</a>
 							<?php echo $this->escape($item->name); ?></a>

--- a/administrator/components/com_content/views/articles/tmpl/modal.php
+++ b/administrator/components/com_content/views/articles/tmpl/modal.php
@@ -130,7 +130,7 @@ if (!empty($editor))
 						<td>
 							<?php $attribs = 'data-function="' . $this->escape($onclick) . '"'
 								. ' data-id="' . $item->id . '"'
-								. ' data-title="' . $this->escape(addslashes($item->title)) . '"'
+								. ' data-title="' . $this->escape($item->title) . '"'
 								. ' data-cat-id="' . $this->escape($item->catid) . '"'
 								. ' data-uri="' . $this->escape(ContentHelperRoute::getArticleRoute($item->id, $item->catid, $item->language)) . '"'
 								. ' data-language="' . $this->escape($lang) . '"';


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/19823

### Summary of Changes
Taking off useless addslashes


### Testing Instructions
- Create a new article with Title "L'association A & L'association B" 
- Edit another article , use ![image](https://user-images.githubusercontent.com/5349333/36937679-54748e9c-1f17-11e8-8ec1-7269a46c5b64.png) to insert the link of the newly created article.

Also create a contact whose name contains a single quote:   `L'idiot`
 Insert that contact in an article via the xtd Contact

### Expected result
`L'association A & L'association B`
`L'idiot`

### Actual result
`L\'association A & L\'association B`
`L\'idiot`

Patch and test again.

@jsubri 
@ggppdk 

