### PR TITLE
Menu items select field: no need to escape string value

### DIFF
--- a/administrator/components/com_menus/models/fields/modal/menu.php
+++ b/administrator/components/com_menus/models/fields/modal/menu.php
@@ -225,11 +225,11 @@ class JFormFieldModal_Menu extends JFormField
 		{
 			if ($this->element->option && (string) $this->element->option['value'] == '')
 			{
-				$title_holder = JText::_($this->element->option, true);
+				$title_holder = JText::_($this->element->option);
 			}
 			else
 			{
-				$title_holder = JText::_('COM_MENUS_SELECT_A_MENUITEM', true);
+				$title_holder = JText::_('COM_MENUS_SELECT_A_MENUITEM');
 			}
 		}
 
@@ -377,11 +377,11 @@ class JFormFieldModal_Menu extends JFormField
 		// Placeholder if option is present or not when clearing field
 		if ($this->element->option && (string) $this->element->option['value'] == '')
 		{
-			$title_holder = JText::_($this->element->option, true);
+			$title_holder = JText::_($this->element->option);
 		}
 		else
 		{
-			$title_holder = JText::_('COM_MENUS_SELECT_A_MENUITEM', true);
+			$title_holder = JText::_('COM_MENUS_SELECT_A_MENUITEM');
 		}
 
 		$html .= '<input type="hidden" id="' . $this->id . '_id" ' . $class . ' data-required="' . (int) $this->required . '" name="' . $this->name


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/17971

### Summary of Changes
The JText does not need to escape quotes
### Testing Instructions
Make a multilingual site (2 languages is enough)
Create some  menu items in both languages.
Modify in en-GB or the other language the string 
`COM_MENUS_ITEM_FIELD_ASSOCIATION_NO_VALUE` so include in the value a single quote.
In French, modify from
`COM_MENUS_ITEM_FIELD_ASSOCIATION_NO_VALUE="- Pas d’association -"`)
(French pack has now a typographic quote, therefore it has to be modified.)
To
`COM_MENUS_ITEM_FIELD_ASSOCIATION_NO_VALUE="- Pas d'association -"`

But it can be tested in English too by just adding a single quote in the string value.

### Before patch
Edit a menu item, association tab
The single quote in 
"- Pas d'association -"
will show as `- Pas d\'association -`

### After patch
The counterslash will not be there any more.

<img width="599" alt="screen shot 2018-03-04 at 12 15 21" src="https://user-images.githubusercontent.com/869724/36944931-d244e964-1fa5-11e8-89b6-e01e3c036364.png">


@izharaazmi 
@brianteeman 
