### PR TITLE
[4.0] Load the component service provider as return value

### DIFF
--- a/administrator/components/com_content/services/provider.php
+++ b/administrator/components/com_content/services/provider.php
@@ -17,7 +17,11 @@ use Joomla\Component\Content\Site\Service\Category;
 use Joomla\DI\Container;
 use Joomla\DI\ServiceProviderInterface;
 
-
+/**
+ * The service provider.
+ *
+ * @since   __DEPLOY_VERSION__
+ */
 return new class implements ServiceProviderInterface
 {
 	/**

--- a/administrator/components/com_content/services/provider.php
+++ b/administrator/components/com_content/services/provider.php
@@ -18,9 +18,9 @@ use Joomla\DI\Container;
 use Joomla\DI\ServiceProviderInterface;
 
 /**
- * The service provider.
+ * The content service provider.
  *
- * @since   __DEPLOY_VERSION__
+ * @since  __DEPLOY_VERSION__
  */
 return new class implements ServiceProviderInterface
 {

--- a/administrator/components/com_content/services/provider.php
+++ b/administrator/components/com_content/services/provider.php
@@ -17,12 +17,8 @@ use Joomla\Component\Content\Site\Service\Category;
 use Joomla\DI\Container;
 use Joomla\DI\ServiceProviderInterface;
 
-/**
- * Content component loader.
- *
- * @since  __DEPLOY_VERSION__
- */
-class ContentComponentServiceProvider implements ServiceProviderInterface
+
+return new class implements ServiceProviderInterface
 {
 	/**
 	 * Registers the service provider with a DI container.
@@ -40,4 +36,4 @@ class ContentComponentServiceProvider implements ServiceProviderInterface
 		$container->set(DispatcherFactoryInterface::class, new DispatcherFactory('\\Joomla\\Component\\Content'));
 		$container->registerServiceProvider(new Component);
 	}
-}
+};

--- a/libraries/src/Extension/ExtensionManagerTrait.php
+++ b/libraries/src/Extension/ExtensionManagerTrait.php
@@ -68,25 +68,21 @@ trait ExtensionManagerTrait
 		}
 
 		// The container to get the services from
-		$container = new Container($this->getContainer());
-
-		// The class name to load
-		$className = ucfirst($extensionName) . ucfirst($type) . 'ServiceProvider';
+		$container = $this->getContainer()->createChild();
 
 		// The path of the loader file
 		$path = $extensionPath . '/services/provider.php';
 
-		if (!class_exists($className) && file_exists($path))
+		if (file_exists($path))
 		{
 			// Load the file
-			require_once $path;
-		}
+			$provider = require_once $path;
 
-		// Check if the extension supports the service provider interface
-		if (class_exists($className) && is_subclass_of($className, ServiceProviderInterface::class))
-		{
-			$extensionLoader = new $className;
-			$extensionLoader->register($container);
+			// Check if the extension supports the service provider interface
+			if ($provider instanceof ServiceProviderInterface)
+			{
+				$provider->register($container);
+			}
 		}
 
 		// Fallback to legacy


### PR DESCRIPTION
I don't like magic class name compiling as we do in the `ExtensionManagerTrait`. Sooner or later we will get into conflicts between front end and back end. Better to return the service provider from the file.