### PR TITLE
Floats/Doubles Remove Decimal

### DIFF
--- a/libraries/fof/utils/array/array.php
+++ b/libraries/fof/utils/array/array.php
@@ -281,7 +281,7 @@ abstract class FOFUtilsArray
 			case 'FLOAT':
 			case 'DOUBLE':
 				// Only use the first floating point value
-				@preg_match('/-?[0-9]+(\.[0-9]+)?/', $result, $matches);
+				@preg_match('/-?\.?[0-9]+(\.[0-9]+)?/', $result, $matches);
 				$result = @(float) $matches[0];
 				break;
 


### PR DESCRIPTION
The float and double filter changes the value to an integer if there is no number prior to the decimal.
.0125 => 125
0.0125 => 0.0125

### Summary of Changes
Modified the RegExp to look for a leading decimal.


### Testing Instructions
Create a form with a float/double filtered text field, and pass a decimal value without a leading number.
Example: .0125


### Expected result
The value should remain a decimal like one of the following:
.0125
0.0125


### Actual result
The value gets converted to a whole number by removing the decimal and leading zeros.
Example: .0125 becomes 125