### PR TITLE
Allow limiting calendar field to current year

### DIFF
--- a/layouts/joomla/form/field/calendar.php
+++ b/layouts/joomla/form/field/calendar.php
@@ -125,8 +125,8 @@ JHtml::_('stylesheet', 'system/fields/calendar' . $cssFileExt, array(), true);
 			data-show-others="<?php echo $filltable; ?>"
 			data-time-24="<?php echo $timeformat; ?>"
 			data-only-months-nav="<?php echo $singleheader; ?>"
-			<?php echo strlen($minYear) ? 'data-min-year="' . $minYear . '"' : ''; ?>
-			<?php echo strlen($maxYear) ? 'data-max-year="' . $maxYear . '"' : ''; ?>
+			<?php echo isset($minYear) && strlen($minYear) ? 'data-min-year="' . $minYear . '"' : ''; ?>
+			<?php echo isset($maxYear) && strlen($maxYear) ? 'data-max-year="' . $maxYear . '"' : ''; ?>
 			title="<?php echo JText::_('JLIB_HTML_BEHAVIOR_OPEN_CALENDAR'); ?>"
 		><span class="icon-calendar" aria-hidden="true"></span></button>
 		<?php if (!$readonly && !$disabled) : ?>

--- a/layouts/joomla/form/field/calendar.php
+++ b/layouts/joomla/form/field/calendar.php
@@ -125,8 +125,8 @@ JHtml::_('stylesheet', 'system/fields/calendar' . $cssFileExt, array(), true);
 			data-show-others="<?php echo $filltable; ?>"
 			data-time-24="<?php echo $timeformat; ?>"
 			data-only-months-nav="<?php echo $singleheader; ?>"
-			<?php echo !empty($minYear) ? 'data-min-year="' . $minYear . '"' : ''; ?>
-			<?php echo !empty($maxYear) ? 'data-max-year="' . $maxYear . '"' : ''; ?>
+			<?php echo strlen($minYear) ? 'data-min-year="' . $minYear . '"' : ''; ?>
+			<?php echo strlen($maxYear) ? 'data-max-year="' . $maxYear . '"' : ''; ?>
 			title="<?php echo JText::_('JLIB_HTML_BEHAVIOR_OPEN_CALENDAR'); ?>"
 		><span class="icon-calendar" aria-hidden="true"></span></button>
 		<?php if (!$readonly && !$disabled) : ?>

--- a/libraries/joomla/form/fields/calendar.php
+++ b/libraries/joomla/form/fields/calendar.php
@@ -169,8 +169,8 @@ class JFormFieldCalendar extends JFormField
 			$this->filltable    = (string) $this->element['filltable'] ? (string) $this->element['filltable'] : 'true';
 			$this->timeformat   = (int) $this->element['timeformat'] ? (int) $this->element['timeformat'] : 24;
 			$this->singleheader = (string) $this->element['singleheader'] ? (string) $this->element['singleheader'] : 'false';
-			$this->minyear      = (string) $this->element['minyear'] ? (string) $this->element['minyear'] : null;
-			$this->maxyear      = (string) $this->element['maxyear'] ? (string) $this->element['maxyear'] : null;
+			$this->minyear      = strlen((string) $this->element['minyear']) ? (string) $this->element['minyear'] : null;
+			$this->maxyear      = strlen((string) $this->element['maxyear']) ? (string) $this->element['maxyear'] : null;
 
 			if ($this->maxyear < 0 || $this->minyear > 0)
 			{


### PR DESCRIPTION
Pull Request for Issue #19831

@dgt41 , your opinion, i think this change matches documentation

### Summary of Changes
Minimum and Maximum (relative) year setting is not to added by the layout when its value is '0'
Change it so that it is, thus you can get
data-min-year="0"
data-max-year="0"

### Testing Instructions
Create a calendar field in XML that has attributes
minyear="0"
maxyear="0"


### Expected result
The selectable year in the calender is limited to current year


### Actual result
No limit


### Documentation Changes Required
None
