### PR TITLE
Update JHtml::calendar to support relative years limitation via minYear, maxYear attributes

### DIFF
--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -1037,6 +1037,8 @@ abstract class HTMLHelper
 		$hint         = isset($attribs['placeholder']) ? $attribs['placeholder'] : '';
 		$class        = isset($attribs['class']) ? $attribs['class'] : '';
 		$onchange     = isset($attribs['onChange']) ? $attribs['onChange'] : '';
+		$minYear      = isset($attribs['minYear']) ? $attribs['minYear'] : null;
+		$maxYear      = isset($attribs['maxYear']) ? $attribs['maxYear'] : null;
 
 		$showTime     = ($showTime) ? "1" : "0";
 		$todayBtn     = ($todayBtn) ? "1" : "0";
@@ -1081,6 +1083,8 @@ abstract class HTMLHelper
 			'localesPath'  => $localesPath,
 			'direction'    => $direction,
 			'onchange'     => $onchange,
+			'minYear'      => $minYear,
+			'maxYear'      => $maxYear,
 		);
 
 		return LayoutHelper::render('joomla.form.field.calendar', $data, null, null);


### PR DESCRIPTION
### Summary of Changes
JHtml::calendar helper method
unlilke the calendar form field via XML definition
does not support usage of minYear, maxYear (relative to current) year limitations


### Testing Instructions
```php
$attribs = array(
  'minYear'=>'-4',
  'maxYear'=>'4'
);
echo JHtml::_('calendar', $datevalue='',
  $fieldname='test', $elementid='test',
  $date_time_format='', $attribs);
```

### Expected result
Should limit year selection to 2014 to 2022

### Actual result
No such limitation


### Documentation Changes Required

