### PR TITLE
Tweak build script for added flexibility

### DIFF
--- a/build/build.php
+++ b/build/build.php
@@ -23,12 +23,29 @@
 
 use Joomla\CMS\Version;
 
+const PHP_TAB = "\t";
+
+function usage($command)
+{
+	echo PHP_EOL;
+	echo 'Usage: php ' . $command . ' [options]' . PHP_EOL;
+	echo PHP_TAB . '[options]:'.PHP_EOL;
+	echo PHP_TAB . PHP_TAB . '--remote <remote>:' . PHP_TAB . 'The git remote reference to build from (ex: `tags/3.8.6`, `4.0-dev`), defaults to the most recent tag for the repository' . PHP_EOL;
+	echo PHP_TAB . PHP_TAB . '--exclude-zip:' . PHP_TAB . PHP_TAB . 'Exclude the generation of .zip packages' . PHP_EOL;
+	echo PHP_TAB . PHP_TAB . '--exclude-gzip:' . PHP_TAB . PHP_TAB . 'Exclude the generation of .tar.gz packages' . PHP_EOL;
+	echo PHP_TAB . PHP_TAB . '--exclude-bzip2:' . PHP_TAB . 'Exclude the generation of .tar.bz2 packages' . PHP_EOL;
+	echo PHP_TAB . PHP_TAB . '--help:' . PHP_TAB . PHP_TAB . PHP_TAB . 'Show this help output' . PHP_EOL;
+	echo PHP_EOL;
+}
+
 if (version_compare(PHP_VERSION, '5.4', '<'))
 {
 	echo "The build script requires PHP 5.4.\n";
 
 	exit(1);
 }
+
+$time = time();
 
 // Set path to git binary (e.g., /usr/local/git/bin/git or /usr/bin/git)
 ob_start();
@@ -38,24 +55,39 @@ $systemGit = trim(ob_get_clean());
 // Make sure file and folder permissions are set correctly
 umask(022);
 
-// Import the version class to set the version information
-define('JPATH_PLATFORM', 1);
-require_once dirname(__DIR__) . '/libraries/src/Version.php';
-
-// Set version information for the build
-$version     = Version::MAJOR_VERSION . '.' . Version::MINOR_VERSION;
-$release     = Version::PATCH_VERSION;
-$fullVersion = (new Version)->getShortVersion();
-
 // Shortcut the paths to the repository root and build folder
 $repo = dirname(__DIR__);
 $here = __DIR__;
 
 // Set paths for the build packages
 $tmp      = $here . '/tmp';
-$fullpath = $tmp . '/' . $fullVersion;
+$fullpath = $tmp . '/' . $time;
 
-echo "Start build for version $fullVersion.\n";
+// Parse input options
+$options = getopt('', ['help', 'remote::', 'exclude-zip', 'exclude-gzip', 'exclude-bzip2']);
+
+$remote       = isset($options['remote']) ? $options['remote'] : false;
+$excludeZip   = isset($options['exclude-zip']);
+$excludeGzip  = isset($options['exclude-gzip']);
+$excludeBzip2 = isset($options['exclude-bzip2']);
+$showHelp     = isset($options['help']);
+
+if ($showHelp)
+{
+	usage($argv[0]);
+	die;
+}
+
+// If not given a remote, assume we are looking for the latest local tag
+if (!$remote)
+{
+	chdir($repo);
+	$tagVersion = system($systemGit . ' describe --tags `' . $systemGit . ' rev-list --tags --max-count=1`', $tagVersion);
+	$remote = 'tags/' . $tagVersion;
+	chdir($here);
+}
+
+echo "Start build for remote $remote.\n";
 echo "Delete old release folder.\n";
 system('rm -rf ' . $tmp);
 mkdir($tmp);
@@ -63,14 +95,23 @@ mkdir($fullpath);
 
 echo "Copy the files from the git repository.\n";
 chdir($repo);
-system($systemGit . ' archive ' . $fullVersion . ' | tar -x -C ' . $fullpath);
+system($systemGit . ' archive ' . $remote . ' | tar -x -C ' . $fullpath);
+
+// Import the version class to set the version information
+define('JPATH_PLATFORM', 1);
+require_once $fullpath . '/libraries/src/Version.php';
+
+// Set version information for the build
+$version     = Version::MAJOR_VERSION . '.' . Version::MINOR_VERSION;
+$release     = Version::PATCH_VERSION;
+$fullVersion = (new Version)->getShortVersion();
 
 chdir($tmp);
 system('mkdir diffdocs');
 system('mkdir diffconvert');
 system('mkdir packages' . $version);
 
-echo "Create list of changed files from git repository.\n";
+echo "Create list of changed files from git repository for version $fullVersion.\n";
 
 /*
  * Here we force add every top-level directory and file in our diff archive, even if they haven't changed.
@@ -154,9 +195,9 @@ for ($num = $release - 1; $num >= 0; $num--)
 {
 	echo "Create version $num update packages.\n";
 
-	// Here we get a list of all files that have changed between the two tags ($previousTag and $fullVersion) and save in diffdocs
+	// Here we get a list of all files that have changed between the two references ($previousTag and $remote) and save in diffdocs
 	$previousTag = $version . '.' . $num;
-	$command     = $systemGit . ' diff tags/' . $previousTag . ' tags/' . $fullVersion . ' --name-status > diffdocs/' . $version . '.' . $num;
+	$command     = $systemGit . ' diff tags/' . $previousTag . ' ' . $remote . ' --name-status > diffdocs/' . $version . '.' . $num;
 
 	system($command);
 
@@ -226,13 +267,24 @@ for ($num = $release - 1; $num >= 0; $num--)
 	}
 
 	$fromName = $num == 0 ? 'x' : $num;
-	// Create the diff archive packages using the file name list.
-	system('tar --create --bzip2 --no-recursion --directory ' . $fullVersion . ' --file packages' . $version . '/Joomla_' . $version . '.' . $fromName . '_to_' . $fullVersion . '-' . $packageStability . '-Patch_Package.tar.bz2 --files-from diffconvert/' . $version . '.' . $num . '> /dev/null');
-	system('tar --create --gzip  --no-recursion --directory ' . $fullVersion . ' --file packages' . $version . '/Joomla_' . $version . '.' . $fromName . '_to_' . $fullVersion . '-' . $packageStability . '-Patch_Package.tar.gz  --files-from diffconvert/' . $version . '.' . $num . '> /dev/null');
 
-	chdir($fullVersion);
-	system('zip ../packages' . $version . '/Joomla_' . $version . '.' . $fromName . '_to_' . $fullVersion . '-' . $packageStability . '-Patch_Package.zip -@ < ../diffconvert/' . $version . '.' . $num . '> /dev/null');
-	chdir('..');
+	// Create the diff archive packages using the file name list.
+	if (!$excludeBzip2)
+	{
+		system('tar --create --bzip2 --no-recursion --directory ' . $time . ' --file packages' . $version . '/Joomla_' . $version . '.' . $fromName . '_to_' . $fullVersion . '-' . $packageStability . '-Patch_Package.tar.bz2 --files-from diffconvert/' . $version . '.' . $num . '> /dev/null');
+	}
+
+	if (!$excludeGzip)
+	{
+		system('tar --create --gzip  --no-recursion --directory ' . $time . ' --file packages' . $version . '/Joomla_' . $version . '.' . $fromName . '_to_' . $fullVersion . '-' . $packageStability . '-Patch_Package.tar.gz  --files-from diffconvert/' . $version . '.' . $num . '> /dev/null');
+	}
+
+	if (!$excludeZip)
+	{
+		chdir($time);
+		system('zip ../packages' . $version . '/Joomla_' . $version . '.' . $fromName . '_to_' . $fullVersion . '-' . $packageStability . '-Patch_Package.zip -@ < ../diffconvert/' . $version . '.' . $num . '> /dev/null');
+		chdir('..');
+	}
 }
 
 // Delete the files and folders we exclude from the packages (tests, docs, build, etc.).
@@ -240,23 +292,32 @@ echo "Delete folders not included in packages.\n";
 
 foreach ($doNotPackage as $removeFile)
 {
-	system('rm -rf ' . $fullVersion . '/' . $removeFile);
+	system('rm -rf ' . $time . '/' . $removeFile);
 }
 
 // Recreate empty directories before creating new archives.
 system('mkdir packages_full' . $fullVersion);
 echo "Build full package files.\n";
-chdir($fullVersion);
+chdir($time);
 
 // The weblinks package manifest should not be present for new installs, temporarily move it
 system('mv administrator/manifests/packages/pkg_weblinks.xml ../pkg_weblinks.xml');
 
 // Create full archive packages.
-system('tar --create --bzip2 --file ../packages_full' . $fullVersion . '/Joomla_' . $fullVersion . '-' . $packageStability . '-Full_Package.tar.bz2 * > /dev/null');
+if (!$excludeBzip2)
+{
+	system('tar --create --bzip2 --file ../packages_full' . $fullVersion . '/Joomla_' . $fullVersion . '-' . $packageStability . '-Full_Package.tar.bz2 * > /dev/null');
+}
 
-system('tar --create --gzip --file ../packages_full' . $fullVersion . '/Joomla_' . $fullVersion . '-' . $packageStability . '-Full_Package.tar.gz * > /dev/null');
+if (!$excludeGzip)
+{
+	system('tar --create --gzip --file ../packages_full' . $fullVersion . '/Joomla_' . $fullVersion . '-' . $packageStability . '-Full_Package.tar.gz * > /dev/null');
+}
 
-system('zip -r ../packages_full' . $fullVersion . '/Joomla_' . $fullVersion . '-' . $packageStability . '-Full_Package.zip * > /dev/null');
+if (!$excludeZip)
+{
+	system('zip -r ../packages_full' . $fullVersion . '/Joomla_' . $fullVersion . '-' . $packageStability . '-Full_Package.zip * > /dev/null');
+}
 
 // Create full update file without the default logs directory, installation folder, or sample images.
 echo "Build full update package.\n";
@@ -271,10 +332,19 @@ system('rm images/powered_by.png');
 // Move the weblinks manifest back
 system('mv ../pkg_weblinks.xml administrator/manifests/packages/pkg_weblinks.xml');
 
-system('tar --create --bzip2 --file ../packages_full' . $fullVersion . '/Joomla_' . $fullVersion . '-' . $packageStability . '-Update_Package.tar.bz2 * > /dev/null');
+if (!$excludeBzip2)
+{
+	system('tar --create --bzip2 --file ../packages_full' . $fullVersion . '/Joomla_' . $fullVersion . '-' . $packageStability . '-Update_Package.tar.bz2 * > /dev/null');
+}
 
-system('tar --create --gzip --file ../packages_full' . $fullVersion . '/Joomla_' . $fullVersion . '-' . $packageStability . '-Update_Package.tar.gz * > /dev/null');
+if (!$excludeGzip)
+{
+	system('tar --create --gzip --file ../packages_full' . $fullVersion . '/Joomla_' . $fullVersion . '-' . $packageStability . '-Update_Package.tar.gz * > /dev/null');
+}
 
-system('zip -r ../packages_full' . $fullVersion . '/Joomla_' . $fullVersion . '-' . $packageStability . '-Update_Package.zip * > /dev/null');
+if (!$excludeZip)
+{
+	system('zip -r ../packages_full' . $fullVersion . '/Joomla_' . $fullVersion . '-' . $packageStability . '-Update_Package.zip * > /dev/null');
+}
 
 echo "Build of version $fullVersion complete!\n";


### PR DESCRIPTION
### Summary of Changes

The build/packaging script has a very rigid definition that makes it difficult-to-impossible to reuse it (in fact, the nightly builds have to use a customized variant to build from a working branch versus a git tag and exclude package types).  So, let's fix the build script.

```php
Usage: php build/build.php [options]
        [options]:
                --remote <remote>:      The git remote reference to build from (ex: `tags/3.8.6`, `4.0-dev`), defaults to a tag for the CMS version string
                --exclude-zip:          Exclude the generation of .zip packages
                --exclude-gzip:         Exclude the generation of .tar.gz packages
                --exclude-bzip2:        Exclude the generation of .tar.bz2 packages
                --help:                 Show this help output
```

The main option added here is the `--remote` option, the exclude options are for convenience.

### Testing Instructions

With the main CMS repo cloned and all tags, try different setups including these base commands:

- `php build/build.php --remote=tags/3.8.5` should build packages for 3.8.5
- `php build/build.php --remote=3.9-dev` should build packages for 3.9

### Expected result

Release packages can be built based on any valid git reference branch or tag

### Actual result

Release packages can only be built if there is a git tag for the active version string

### Documentation Changes Required

N/A, docs are contained within the script