### PR TITLE
fix for com_fields values being erased in multiple use cases

### DIFF
--- a/administrator/components/com_contact/models/contact.php
+++ b/administrator/components/com_contact/models/contact.php
@@ -383,6 +383,10 @@ class ContactModelContact extends JModelAdmin
 	public function save($data)
 	{
 		$input = JFactory::getApplication()->input;
+		$form = $this->getForm($data, false);
+
+		JLoader::register('FieldsHelper', JPATH_ADMINISTRATOR . '/components/com_fields/helpers/fields.php');
+		$data = FieldsHelper::normaliseFieldsRequestData($form, $data);
 
 		JLoader::register('CategoriesHelper', JPATH_ADMINISTRATOR . '/components/com_categories/helpers/categories.php');
 

--- a/administrator/components/com_content/models/article.php
+++ b/administrator/components/com_content/models/article.php
@@ -629,6 +629,10 @@ class ContentModelArticle extends JModelAdmin
 	{
 		$input  = JFactory::getApplication()->input;
 		$filter = JFilterInput::getInstance();
+		$form = $this->getForm($data, false);
+
+		JLoader::register('FieldsHelper', JPATH_ADMINISTRATOR . '/components/com_fields/helpers/fields.php');
+		$data = FieldsHelper::normaliseFieldsRequestData($form, $data);
 
 		if (isset($data['metadata']) && isset($data['metadata']['author']))
 		{

--- a/administrator/components/com_fields/helpers/fields.php
+++ b/administrator/components/com_fields/helpers/fields.php
@@ -750,4 +750,44 @@ class FieldsHelper
 		self::$fieldCache  = null;
 		self::$fieldsCache = null;
 	}
+
+	/**
+	 * Ensures that there is an entry in the data array for every field on the form. Groups will be respected too.
+	 * This is needed for:
+	 * 	+ checkboxes and radio fields as when no value is selected then the data array contains no entry.
+	 * 	+ fields that are configured to not show on the form in order to retain those fields data
+	 *
+	 * @param   Form   $form  The form
+	 * @param   array  $data  The data
+	 *
+	 * @return  array
+	 *
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public function normaliseFieldsRequestData($form, array $data)
+	{
+		// Loop over all fields
+		foreach ($form->getFieldset() as $field)
+		{
+			// If the field has no group, we are done here
+			if (!$field->group == 'com_fields')
+			{
+				continue;
+			}
+
+			// Ensure there is always an array for the group
+			if (!key_exists($field->group, $data))
+			{
+				$data[$field->group] = array();
+			}
+
+			// Make sure the data group array has an entry
+			if (!key_exists($field->fieldname, $data[$field->group]))
+			{
+				$data[$field->group][$field->fieldname] = false;
+			}
+		}
+
+		return $data;
+	}
 }

--- a/administrator/components/com_fields/models/field.php
+++ b/administrator/components/com_fields/models/field.php
@@ -589,8 +589,9 @@ class FieldsModelField extends JModelAdmin
 		}
 		elseif (count($value) == 1 && count((array) $oldValue) == 1)
 		{
-			// Only a single row value update can be done
-			$needsUpdate = true;
+			// Only a single row value update can be done when not empty
+			$needsUpdate = !empty($value[0]);
+			$needsDelete = empty($value[0]);
 		}
 		else
 		{

--- a/administrator/components/com_users/models/user.php
+++ b/administrator/components/com_users/models/user.php
@@ -211,6 +211,10 @@ class UsersModelUser extends JModelAdmin
 	{
 		$pk   = (!empty($data['id'])) ? $data['id'] : (int) $this->getState('user.id');
 		$user = JUser::getInstance($pk);
+		$form = $this->getForm($data, false);
+
+		JLoader::register('FieldsHelper', JPATH_ADMINISTRATOR . '/components/com_fields/helpers/fields.php');
+		$data = FieldsHelper::normaliseFieldsRequestData($form, $data);
 
 		$my = JFactory::getUser();
 		$iAmSuperAdmin = $my->authorise('core.admin');

--- a/components/com_users/models/profile.php
+++ b/components/com_users/models/profile.php
@@ -299,6 +299,10 @@ class UsersModelProfile extends JModelForm
 		$userId = (!empty($data['id'])) ? $data['id'] : (int) $this->getState('user.id');
 
 		$user = new JUser($userId);
+		$form = $this->getForm($data, false);
+
+		JLoader::register('FieldsHelper', JPATH_ADMINISTRATOR . '/components/com_fields/helpers/fields.php');
+		$data = FieldsHelper::normaliseFieldsRequestData($form, $data);
 
 		// Prepare the data for the user object.
 		$data['email']    = JStringPunycode::emailToPunycode($data['email1']);

--- a/components/com_users/models/registration.php
+++ b/components/com_users/models/registration.php
@@ -410,6 +410,10 @@ class UsersModelRegistration extends JModelForm
 		// Initialise the table with JUser.
 		$user = new JUser;
 		$data = (array) $this->getData();
+		$form = $this->getForm($data, false);
+
+		JLoader::register('FieldsHelper', JPATH_ADMINISTRATOR . '/components/com_fields/helpers/fields.php');
+		$data = FieldsHelper::normaliseFieldsRequestData($form, $data);
 
 		// Merge in the registration data.
 		foreach ($temp as $k => $v)


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
After lot of discussion here: https://github.com/joomla/joomla-cms/pull/19753 we decided to take a different approach :) (bringing the required changes into the components model)


### Testing Instructions
1. use $user->save
2. use UserHelper function addUserToGroup / removeUserFromGroup
3. save on front-end article with fields that only display on administrator


### Expected result
1. user saved and field values retained
2. user group membership changed and field values retained
3. article saved and all field values retained

### Actual result
1. user saved but field values erased from #__fields_values
2. user group membership changed but field values erased from #__fields_values
3. article saved, but field values that are not displayed on the form erased from #__fields_values


### Documentation Changes Required
Fields with no values (empty) would be saved in #__fields_values.
Checkboxes with no value would NOT be saved (erased) in #__fields_values

After this change:
All fields with no values (empty) will NOT be saved (erased) from #__fields_values
