### PR TITLE
[com_fields] Normalise the request com_fields data

### DIFF
--- a/administrator/components/com_fields/models/field.php
+++ b/administrator/components/com_fields/models/field.php
@@ -589,8 +589,9 @@ class FieldsModelField extends JModelAdmin
 		}
 		elseif (count($value) == 1 && count((array) $oldValue) == 1)
 		{
-			// Only a single row value update can be done
-			$needsUpdate = true;
+			// Only a single row value update can be done when not empty
+			$needsUpdate = !empty($value[0]);
+			$needsDelete = empty($value[0]);
 		}
 		else
 		{

--- a/administrator/components/com_fields/models/field.php
+++ b/administrator/components/com_fields/models/field.php
@@ -590,8 +590,8 @@ class FieldsModelField extends JModelAdmin
 		elseif (count($value) == 1 && count((array) $oldValue) == 1)
 		{
 			// Only a single row value update can be done when not empty
-			$needsUpdate = !empty($value[0]);
-			$needsDelete = empty($value[0]);
+			$needsUpdate = is_array($value[0]) ? !count($value[0]) : !strlen($value[0]);
+			$needsDelete = !$needsUpdate;
 		}
 		else
 		{

--- a/administrator/components/com_fields/models/field.php
+++ b/administrator/components/com_fields/models/field.php
@@ -590,7 +590,7 @@ class FieldsModelField extends JModelAdmin
 		elseif (count($value) == 1 && count((array) $oldValue) == 1)
 		{
 			// Only a single row value update can be done when not empty
-			$needsUpdate = is_array($value[0]) ? !count($value[0]) : !strlen($value[0]);
+			$needsUpdate = is_array($value[0]) ? count($value[0]) : strlen($value[0]);
 			$needsDelete = !$needsUpdate;
 		}
 		else

--- a/components/com_users/controllers/profile.php
+++ b/components/com_users/controllers/profile.php
@@ -113,6 +113,14 @@ class UsersControllerProfile extends UsersController
 			return false;
 		}
 
+		// Send an object which can be modified through the plugin event
+		$objData = (object) $requestData;
+		$app->triggerEvent(
+			'onContentNormaliseRequestData',
+			array('com_users.user', $objData, $form)
+		);
+		$requestData = (array) $objData;
+
 		// Validate the posted data.
 		$data = $model->validate($form, $requestData);
 

--- a/libraries/src/MVC/Controller/FormController.php
+++ b/libraries/src/MVC/Controller/FormController.php
@@ -694,7 +694,7 @@ class FormController extends BaseController
 			return false;
 		}
 
-		// Send an object which can be modified trough the plugin event
+		// Send an object which can be modified through the plugin event
 		$objData = (object) $data;
 		$app->triggerEvent(
 			'onContentNormaliseRequestData',

--- a/libraries/src/MVC/Controller/FormController.php
+++ b/libraries/src/MVC/Controller/FormController.php
@@ -698,7 +698,7 @@ class FormController extends BaseController
 		$objData = (object) $data;
 		$app->triggerEvent(
 			'onContentNormaliseRequestData',
-			[$this->option . '.' . $this->context, $objData, $form]
+			array($this->option . '.' . $this->context, $objData, $form)
 		);
 		$data = (array) $objData;
 

--- a/libraries/src/MVC/Controller/FormController.php
+++ b/libraries/src/MVC/Controller/FormController.php
@@ -695,12 +695,12 @@ class FormController extends BaseController
 		}
 
 		// Send an object which can be modified trough the plugin event
-		$objData = (object)$data;
+		$objData = (object) $data;
 		$app->triggerEvent(
 			'onContentNormaliseRequestData',
 			[$this->option . '.' . $this->context, $objData, $form]
 		);
-		$data = (array)$objData;
+		$data = (array) $objData;
 
 		// Test whether the data is valid.
 		$validData = $model->validate($form, $data);

--- a/libraries/src/MVC/Controller/FormController.php
+++ b/libraries/src/MVC/Controller/FormController.php
@@ -694,6 +694,14 @@ class FormController extends BaseController
 			return false;
 		}
 
+		// Send an object which can be modified trough the plugin event
+		$objData = (object)$data;
+		$app->triggerEvent(
+			'onContentNormaliseRequestData',
+			[$this->option . '.' . $this->context, $objData, $form]
+		);
+		$data = (array)$objData;
+
 		// Test whether the data is valid.
 		$validData = $model->validate($form, $data);
 

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -135,7 +135,7 @@ class PlgSystemFields extends JPlugin
 				$value = $field->rawvalue;
 			}
 
-			// If no value set (empty) remove value fom database
+			// If no value set (empty) remove value from database
 			if (empty($value))
 			{
 				$value = null;

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -129,7 +129,7 @@ class PlgSystemFields extends JPlugin
 			}
 
 			// If no value set (empty) remove value from database
-			if (empty($value))
+			if (is_array($value) ? !count($value) : !strlen($value))
 			{
 				$value = null;
 			}

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -120,14 +120,7 @@ class PlgSystemFields extends JPlugin
 			// Determine the value if it is (un)available from the data
 			if (key_exists($field->name, $data['com_fields']))
 			{
-				if ($data['com_fields'][$field->name] === false)
-				{
-					$value = null;
-				}
-				else
-				{
-					$value = $data['com_fields'][$field->name];
-				}
+				$value = $data['com_fields'][$field->name] === false ? null : $data['com_fields'][$field->name];
 			}
 			// Field not available on form, use stored value
 			else

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -53,13 +53,13 @@ class PlgSystemFields extends JPlugin
 		foreach ($form->getGroup('com_fields') as $field)
 		{
 			// Make sure the data object has an entry
-			if (isset($data->{$field->fieldname}))
+			if (isset($data->com_fields[$field->fieldname]))
 			{
 				continue;
 			}
 
 			// Set a default value for the field
-			$data->{$field->fieldname} = false;
+			$data->com_fields[$field->fieldname] = false;
 		}
 	}
 

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -9,6 +9,7 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Form\Form;
 use Joomla\Registry\Registry;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Multilanguage;
@@ -31,6 +32,38 @@ class PlgSystemFields extends JPlugin
 	protected $autoloadLanguage = true;
 
 	/**
+	 * Normalizes the request data.
+	 *
+	 * @param   string  $context  The context
+	 * @param   object  $data     The object
+	 * @param   Form    $form     The form
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function onContentNormaliseRequestData($context, $data, Form $form)
+	{
+		if (!FieldsHelper::extract($context, $data))
+		{
+			return true;
+		}
+
+		// Loop over all fields
+		foreach ($form->getGroup('com_fields') as $field)
+		{
+			// Make sure the data object has an entry
+			if (isset($data->{$field->fieldname}))
+			{
+				continue;
+			}
+
+			// Set a default value for the field
+			$data->{$field->fieldname} = false;
+		}
+	}
+
+	/**
 	 * The save event.
 	 *
 	 * @param   string   $context  The context
@@ -45,7 +78,7 @@ class PlgSystemFields extends JPlugin
 	public function onContentAfterSave($context, $item, $isNew, $data = array())
 	{
 		// Check if data is an array and the item has an id
-		if (!is_array($data) || empty($item->id))
+		if (!is_array($data) || empty($item->id) || empty($data['com_fields']))
 		{
 			return true;
 		}
@@ -78,17 +111,35 @@ class PlgSystemFields extends JPlugin
 			return true;
 		}
 
-		// Get the fields data
-		$fieldsData = !empty($data['com_fields']) ? $data['com_fields'] : array();
-
 		// Loading the model
 		$model = JModelLegacy::getInstance('Field', 'FieldsModel', array('ignore_request' => true));
 
 		// Loop over the fields
 		foreach ($fields as $field)
 		{
-			// Determine the value if it is available from the data
-			$value = key_exists($field->name, $fieldsData) ? $fieldsData[$field->name] : null;
+			// Determine the value if it is (un)available from the data
+			if (key_exists($field->name, $data['com_fields']))
+			{
+				if ($data['com_fields'][$field->name] === false)
+				{
+					$value = null;
+				}
+				else
+				{
+					$value = $data['com_fields'][$field->name];
+				}
+			}
+			// Field not available on form, use stored value
+			else
+			{
+				$value = $field->rawvalue;
+			}
+
+			// If no value set (empty) remove value fom database
+			if (empty($value))
+			{
+				$value = null;
+			}
 
 			// JSON encode value for complex fields
 			if (is_array($value) && (count($value, COUNT_NORMAL) !== count($value, COUNT_RECURSIVE) || !count(array_filter(array_keys($value), 'is_numeric'))))


### PR DESCRIPTION
Pull Request for Issues like #19735 and #17801 and for PRs #18188, #17837, #18207, #19742, #19753, #19850.

### Summary of Changes
As #19753 revealed that the request data should be normalised only for com_fields and we do not want to have extension specific code in the libraries. This pr adds a new event which sends the data for normalisation in the controller. Like that the fields plugin can then modify the data.

_Remark:_
I was unsure about the plugin name, any feedback is welcome.

### Testing Instructions
- Create custom user fields.
- Edit a user and fill any data in custom fields.
- Add the following code to the file /administrator/components/com_content/content.php after line 16: 
`JFactory::getUser($USER_ID)->save();`.
Replace the value $USER_ID with the user you have edited.

### Expected result
The user custom field data is still saved on the user.

### Actual result
The user custom fields data on the user are deleted.