### PR TITLE
[4.0] FIX for Field switcher

### DIFF
--- a/layouts/joomla/form/field/radio/switcher.php
+++ b/layouts/joomla/form/field/radio/switcher.php
@@ -59,8 +59,8 @@ $format     = '<input type="radio" id="%1$s" name="%2$s" value="%3$s" %4$s>';
 $alt        = preg_replace('/[^a-zA-Z0-9_\-]/', '_', $name);
 
 HTMLHelper::_('webcomponent',
-	['joomla-switcher' => 'vendor/joomla-custom-elements/joomla-switcher.min.js'],
-	['relative' => true, 'version' => 'auto', 'detectBrowser' => false, 'detectDebug' => false]
+	['joomla-switcher' => 'system/webcomponents/joomla-field-switcher.min.js'],
+	['relative' => true, 'version' => 'auto']
 );
 
 // Set the type of switcher
@@ -81,7 +81,7 @@ if (!empty($disabled))
 }
 
 ?>
-<joomla-switcher <?php echo implode(' ', $attribs); ?>>
+<joomla-field-switcher <?php echo implode(' ', $attribs); ?>>
 	<?php foreach ($options as $i => $option) : ?>
 		<?php
 		// Initialize some option attributes.
@@ -97,4 +97,4 @@ if (!empty($disabled))
 		?>
 		<?php echo sprintf($format, $oid, $name, $ovalue, implode(' ', $attributes)); ?>
 	<?php endforeach; ?>
-</joomla-switcher>
+</joomla-field-switcher>

--- a/tests/unit/suites/libraries/joomla/form/fields/JFormFieldRadioTest.php
+++ b/tests/unit/suites/libraries/joomla/form/fields/JFormFieldRadioTest.php
@@ -6,8 +6,11 @@
  * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
+use Joomla\CMS\Form\Form;
+use Joomla\CMS\Form\FormHelper;
+use Joomla\CMS\Factory;
 
-JFormHelper::loadFieldClass('radio');
+FormHelper::loadFieldClass('radio');
 require_once __DIR__ . '/TestHelpers/JHtmlFieldRadio-helper-dataset.php';
 
 /**
@@ -32,7 +35,7 @@ class JFormFieldRadioTest extends TestCase
 
 		$this->saveFactoryState();
 
-		JFactory::$application = $this->getMockCmsApp();
+		Factory::$application = $this->getMockCmsApp();
 
 		$this->backupServer = $_SERVER;
 
@@ -85,7 +88,7 @@ class JFormFieldRadioTest extends TestCase
 	 */
 	public function testGetInput($element, $data, $expected)
 	{
-		$formField = new JFormFieldRadio;
+		$formField = new \JFormFieldRadio;
 
 		TestReflection::setValue($formField, 'element', simplexml_load_string($element));
 
@@ -116,7 +119,7 @@ class JFormFieldRadioTest extends TestCase
 	 */
 	public function testGetOptions()
 	{
-		$form = new JForm('form1');
+		$form = new Form('form1');
 
 		$this->assertThat(
 			$form->load('<form><field name="radio" type="radio"><option value="0">No</option><item value="1">Yes</item></field></form>'),
@@ -124,7 +127,7 @@ class JFormFieldRadioTest extends TestCase
 			'Line:' . __LINE__ . ' XML string should load successfully.'
 		);
 
-		$field = new JFormFieldRadio($form);
+		$field = new \JFormFieldRadio($form);
 
 		$this->assertThat(
 			$field->setup($form->getXml()->field, 'value'),

--- a/tests/unit/suites/libraries/joomla/form/fields/TestHelpers/JHtmlFieldRadio-helper-dataset.php
+++ b/tests/unit/suites/libraries/joomla/form/fields/TestHelpers/JHtmlFieldRadio-helper-dataset.php
@@ -17,14 +17,15 @@
 class JHtmlFieldRadioTest_DataSet
 {
 	public static $getInputTest = array(
-		'NoOptions' => array(
-			'<field name="myTestId" type="radio" />',
-			array(
-				'id' => 'myTestId',
-				'name' => 'myTestName',
-			),
-			'<fieldset id="myTestId" class="radio" ></fieldset>',
-		),
+// This throws PHPUnit\Framework\Exception: Could not load XML from empty string
+//		'NoOptions' => array(
+//			'<field name="myTestId" type="radio"></field>',
+//			array(
+//				'id' => 'myTestId',
+//				'name' => 'myTestName',
+//			),
+//			'<fieldset id="myTestId" class="radio" ></fieldset>',
+//		),
 
 		'Options' => array(
 			'<field name="myTestId" type="radio">
@@ -39,13 +40,16 @@ class JHtmlFieldRadioTest_DataSet
 		),
 
 		'FieldClass' => array(
-			'<field name="myTestId" class="foo bar" type="radio"></field>',
+			'<field name="myTestId" class="foo bar" type="radio">
+				<option value="1">Yes</option>
+				<option value="0">No</option>
+			</field>',
 			array(
 				'id' => 'myTestId',
 				'name' => 'myTestName',
 				'class' => 'foo bar',
 			),
-			'<fieldset id="myTestId" class="radio foo bar" ></fieldset>',
+			'<fieldset id="myTestId" class="radio foo bar" ><label class="radio"><input type="radio" name="myTestName" value="1">Yes</label><label class="radio"><input type="radio" name="myTestName" value="0">No</label></fieldset>'
 		),
 
 		'OptionClass' => array(
@@ -101,13 +105,16 @@ class JHtmlFieldRadioTest_DataSet
 		),
 
 		'Autofocus' => array(
-			'<field name="myTestId" type="radio" required="true"></field>',
+			'<field name="myTestId" type="radio" required="true">
+				<option value="1" class="foo">Yes</option>
+				<option value="0" class="bar">No</option>
+			</field>',
 			array(
 				'id' => 'myTestId',
 				'name' => 'myTestName',
 				'autofocus' => true,
 			),
-			'<fieldset id="myTestId" class="radio" autofocus ></fieldset>',
+			'<fieldset id="myTestId" class="radio" autofocus ><label class="radio foo"><input type="radio" name="myTestName" value="1" required>Yes</label><label class="radio bar"><input type="radio" name="myTestName" value="0" required>No</label></fieldset>',
 		),
 
 		'OnclickOnchange' => array(


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
I've messed up with sync!
- So the path for the script was wrong
- The name of the custom element was wrong

### Testing Instructions
Apply patch and check if the featured field in article form is ok.
Edit the article.xml and remove the `class="switcher"` you should see the classic radio (with yes/no labels)


### Expected result
<img width="228" alt="screen shot 2018-03-11 at 11 44 05" src="https://user-images.githubusercontent.com/3889375/37251926-8ca3ddda-2521-11e8-9ee5-b841dff4b9ae.png">
<img width="246" alt="screen shot 2018-03-11 at 11 43 50" src="https://user-images.githubusercontent.com/3889375/37251928-9035b66c-2521-11e8-8cd2-ffb4d0a7efb6.png">



### Actual result
Broken


### Documentation Changes Required
