### PR TITLE
Fix undefined index: password_clear

### DIFF
--- a/plugins/system/remember/remember.php
+++ b/plugins/system/remember/remember.php
@@ -116,7 +116,7 @@ class PlgSystemRemember extends JPlugin
 		}
 
 		// Irrelevant, because password was not changed by user
-		if ($data['password_clear'] == '')
+		if (empty($data['password_clear']))
 		{
 			return true;
 		}


### PR DESCRIPTION
Pull Request for Issue #17827.

### Summary of Changes
Fix undefined index: password_clear

@schultz-it-solutions Please test.
@zero-24 Please consider for v3.8.6.

### Testing Instructions
Go to Users > Manage.
Under `Enabled` column, click button to enable/block a user.
See php error log file.


### Expected result
No notice.


### Actual result
`PHP Notice:  Undefined index: password_clear in \plugins\system\remember\remember.php on line 119`


### Documentation Changes Required
none
