### PR TITLE
Custom admin menus: Translating menu items titles

### DIFF
--- a/administrator/components/com_menus/models/items.php
+++ b/administrator/components/com_menus/models/items.php
@@ -110,6 +110,12 @@ class MenusModelItems extends JModelList
 		$currentClientId = $app->getUserState($this->context . '.client_id', 0);
 		$clientId        = $app->input->getInt('client_id', $currentClientId);
 
+		// Load mod_menu.ini file when client is administrator
+		if ($clientId == 1)
+		{
+			JFactory::getLanguage()->load('mod_menu', JPATH_ADMINISTRATOR, null, false, true);
+		}
+
 		$currentMenuType = $app->getUserState($this->context . '.menutype', '');
 		$menuType        = $app->input->getString('menutype', $currentMenuType);
 


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/19898

### Summary of Changes
Load mod_menu.ini lang files when populating the manager

### Testing Instructions
Go to Menu Manager
Add a new Menu, type administrator, select one of the options predefined Joomla / predefined modern
Store the new menu.
Reopen it - you get the predefined Entries

### Expected result
The Language Keys (menu titles) from predefined xmls are translated


### Actual result
see screenshot![screen shot 2018-03-13 at 21 15 37](https://issues.joomla.org/uploads/1/9e7e124fd33b8a103c5845d9ca6c4abf.png)


### After patch
![screen shot 2018-03-14 at 10 01 14](https://user-images.githubusercontent.com/869724/37392581-cf4dbfc6-276e-11e8-826c-4b1723717eda.png)




### Documentation Changes Required
None

@chmst @ReLater 