### PR TITLE
Don't have a metadataManager class property to avoid circular dependency problem when instantiating multiple applications

### DIFF
--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -64,14 +64,6 @@ class CMSApplication extends WebApplication
 	protected $_messageQueue = array();
 
 	/**
-	 * The session metadata manager
-	 *
-	 * @var    MetadataManager
-	 * @since  3.8.6
-	 */
-	protected $metadataManager = null;
-
-	/**
 	 * The name of the application.
 	 *
 	 * @var    array
@@ -115,8 +107,6 @@ class CMSApplication extends WebApplication
 	{
 		parent::__construct($input, $config, $client);
 
-		$this->metadataManager = new MetadataManager($this, \JFactory::getDbo());
-
 		// Load and set the dispatcher
 		$this->loadDispatcher();
 
@@ -158,7 +148,8 @@ class CMSApplication extends WebApplication
 	 */
 	public function checkSession()
 	{
-		$this->metadataManager->createRecordIfNonExisting(\JFactory::getSession(), \JFactory::getUser());
+		$metadataManager = new MetadataManager($this, \JFactory::getDbo());
+		$metadataManager->createRecordIfNonExisting(\JFactory::getSession(), \JFactory::getUser());
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue #19902

### Summary of Changes

Removes `CMSApplication::$metadataManager` due to the circular dependency problem that exists with instantiating multiple applications with this property, move instantiation into the application's `checkSession` method.

### Testing Instructions

Anywhere in an extension, add a `new JSite;` line.

Pre-patch, you should get the `Nesting level too deep - recursive dependency? in joomla/libraries/joomla/event/dispatcher.php on line 198` message.  Post-patch, you shouldn't.

### Documentation Changes Required

Technically breaking B/C by removing the property we added in this release since it's not private, otherwise no.