### PR TITLE
[4.0] html tests update

### DIFF
--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -424,14 +424,22 @@ abstract class HTMLHelper
 			$browser   = $navigator->getBrowser();
 			$major     = $navigator->getMajor();
 			$minor     = $navigator->getMinor();
+			$minExt    = '';
+
+			if (strlen($strip) > 4 && preg_match('#\.min$#', $strip))
+			{
+				$minExt    = '.min';
+				$strip = preg_replace('#\.min$#', '', $strip);
+
+			}
 
 			// Try to include files named filename.ext, filename_browser.ext, filename_browser_major.ext, filename_browser_major_minor.ext
 			// where major and minor are the browser version names
 			$potential = array(
-				$strip,
-				$strip . '_' . $browser,
-				$strip . '_' . $browser . '_' . $major,
-				$strip . '_' . $browser . '_' . $major . '_' . $minor,
+				$strip . $minExt,
+				$strip . '_' . $browser . $minExt,
+				$strip . '_' . $browser . '_' . $major . $minExt,
+				$strip . '_' . $browser . '_' . $major . '_' . $minor . $minExt,
 			);
 		}
 		else
@@ -699,14 +707,14 @@ abstract class HTMLHelper
 			$attribs                  = $argList[1] ?? array();
 			$options['relative']      = $argList[2] ?? false;
 			$options['pathOnly']      = $argList[3] ?? false;
-			$options['detectBrowser'] = $argList[4] ?? true;
+			$options['detectBrowser'] = $argList[4] ?? false;
 			$options['detectDebug']   = $argList[5] ?? true;
 		}
 		else
 		{
 			$options['relative']      = $options['relative'] ?? false;
 			$options['pathOnly']      = $options['pathOnly'] ?? false;
-			$options['detectBrowser'] = $options['detectBrowser'] ?? true;
+			$options['detectBrowser'] = $options['detectBrowser'] ?? false;
 			$options['detectDebug']   = $options['detectDebug'] ?? true;
 		}
 
@@ -772,7 +780,7 @@ abstract class HTMLHelper
 			$options['framework']     = $argList[1] ?? false;
 			$options['relative']      = $argList[2] ?? false;
 			$options['pathOnly']      = $argList[3] ?? false;
-			$options['detectBrowser'] = $argList[4] ?? true;
+			$options['detectBrowser'] = $argList[4] ?? false;
 			$options['detectDebug']   = $argList[5] ?? true;
 		}
 		else
@@ -780,7 +788,7 @@ abstract class HTMLHelper
 			$options['framework']     = $options['framework'] ?? false;
 			$options['relative']      = $options['relative'] ?? false;
 			$options['pathOnly']      = $options['pathOnly'] ?? false;
-			$options['detectBrowser'] = $options['detectBrowser'] ?? true;
+			$options['detectBrowser'] = $options['detectBrowser'] ?? false;
 			$options['detectDebug']   = $options['detectDebug'] ?? true;
 		}
 
@@ -830,7 +838,7 @@ abstract class HTMLHelper
 	 *                             Also passing a key = fullPolyfill and value= true we force the whole polyfill instead
 	 *                             of just the custom element. (Polyfills loaded as needed, no force load)
 	 * @param   array  $options    The relative, version, detect browser and detect debug options for the custom element
-	 *                             or web component. Files need to have a -es5(.min).js (or -es5(.min).html) for the non ES6
+	 *                             or web component. Files need to have a -es5(.min).js for the non ES6
 	 *                             Browsers.
 	 *
 	 * @since   4.0.0

--- a/tests/unit/suites/libraries/cms/html/JHtmlTest.php
+++ b/tests/unit/suites/libraries/cms/html/JHtmlTest.php
@@ -580,7 +580,7 @@ class JHtmlTest extends TestCase
 	{
 		// These are some paths to pass to JHtml for testing purposes.
 		$urlpath = 'test' . uniqid() . '/';
-		$urlfilename = 'script' . uniqid() . '.js';
+		$urlfilename = 'script' . uniqid() . '.min.js';
 
 		// We generate a random template name so that we don't collide or hit anything.
 		$template = 'mytemplate' . uniqid();
@@ -685,7 +685,7 @@ class JHtmlTest extends TestCase
 		$extension = 'testextension' . uniqid();
 		$element = 'element' . uniqid();
 		$urlpath = 'path' . uniqid() . '/';
-		$urlfilename = 'script1.js';
+		$urlfilename = 'script1.min.js';
 
 		mkdir(JPATH_ROOT . '/media/' . $extension . '/' . $element . '/js/' . $urlpath, 0777, true);
 
@@ -769,12 +769,12 @@ class JHtmlTest extends TestCase
 
 		mkdir(JPATH_ROOT . '/media/system/js/' . $element . '/' . $urlpath, 0777, true);
 		file_put_contents(JPATH_ROOT . '/media/system/js/' . $element . '/' . $urlpath . $urlfilename, 'test');
-		file_put_contents(JPATH_ROOT . '/media/system/js/' . $element . '/' . $urlpath . 'script1_mybrowser.js', 'test');
-		file_put_contents(JPATH_ROOT . '/media/system/js/' . $element . '/' . $urlpath . 'script1_mybrowser_0.js', 'test');
-		file_put_contents(JPATH_ROOT . '/media/system/js/' . $element . '/' . $urlpath . 'script1_mybrowser_0_0.js', 'test');
+		file_put_contents(JPATH_ROOT . '/media/system/js/' . $element . '/' . $urlpath . 'script1_mybrowser.min.js', 'test');
+		file_put_contents(JPATH_ROOT . '/media/system/js/' . $element . '/' . $urlpath . 'script1_mybrowser_0.min.js', 'test');
+		file_put_contents(JPATH_ROOT . '/media/system/js/' . $element . '/' . $urlpath . 'script1_mybrowser_0_0.min.js', 'test');
 		JBrowser::getInstance()->setBrowser('mybrowser');
 
-		JHtml::script($extension . '/' . $element . '/' . $urlpath . $urlfilename, array('relative' => true));
+		JHtml::script($extension . '/' . $element . '/' . $urlpath . $urlfilename, array('relative' => true, 'detectBrowser' => true));
 
 		$this->assertArrayHasKey(
 			'/media/system/js/' . $element . '/' . $urlpath . $urlfilename,
@@ -783,18 +783,18 @@ class JHtmlTest extends TestCase
 		);
 
 		$this->assertArrayHasKey(
-			'/media/system/js/' . $element . '/' . $urlpath . 'script1_mybrowser.js',
+			'/media/system/js/' . $element . '/' . $urlpath . 'script1_mybrowser.min.js',
 			JFactory::$document->_scripts,
 			'Line:' . __LINE__ . ' JHtml::script failed when we should get it from the media directory'
 		);
 
 		$this->assertEquals(
-			JHtml::script($extension . '/' . $element . '/' . $urlpath . $urlfilename, array('relative' => true, 'pathOnly' => true)),
+			JHtml::script($extension . '/' . $element . '/' . $urlpath . $urlfilename, array('relative' => true, 'pathOnly' => true, 'detectBrowser' => true)),
 			array(
 				JUri::base(true) . '/media/system/js/' . $element . '/' . $urlpath . $urlfilename,
-				JUri::base(true) . '/media/system/js/' . $element . '/' . $urlpath . 'script1_mybrowser.js',
-				JUri::base(true) . '/media/system/js/' . $element . '/' . $urlpath . 'script1_mybrowser_0.js',
-				JUri::base(true) . '/media/system/js/' . $element . '/' . $urlpath . 'script1_mybrowser_0_0.js'
+				JUri::base(true) . '/media/system/js/' . $element . '/' . $urlpath . 'script1_mybrowser.min.js',
+				JUri::base(true) . '/media/system/js/' . $element . '/' . $urlpath . 'script1_mybrowser_0.min.js',
+				JUri::base(true) . '/media/system/js/' . $element . '/' . $urlpath . 'script1_mybrowser_0_0.min.js'
 			),
 			'Line:' . __LINE__ . ' JHtml::script failed in URL only mode when it should come from the media directory'
 		);
@@ -807,22 +807,22 @@ class JHtmlTest extends TestCase
 
 		JFactory::$document->_scripts = array();
 		unlink(JPATH_ROOT . '/media/system/js/' . $element . '/' . $urlpath . $urlfilename);
-		unlink(JPATH_ROOT . '/media/system/js/' . $element . '/' . $urlpath . 'script1_mybrowser.js');
-		unlink(JPATH_ROOT . '/media/system/js/' . $element . '/' . $urlpath . 'script1_mybrowser_0.js');
-		unlink(JPATH_ROOT . '/media/system/js/' . $element . '/' . $urlpath . 'script1_mybrowser_0_0.js');
+		unlink(JPATH_ROOT . '/media/system/js/' . $element . '/' . $urlpath . 'script1_mybrowser.min.js');
+		unlink(JPATH_ROOT . '/media/system/js/' . $element . '/' . $urlpath . 'script1_mybrowser_0.min.js');
+		unlink(JPATH_ROOT . '/media/system/js/' . $element . '/' . $urlpath . 'script1_mybrowser_0_0.min.js');
 		rmdir(JPATH_ROOT . '/media/system/js/' . $element . '/' . $urlpath);
 		rmdir(JPATH_ROOT . '/media/system/js/' . $element);
 
 		mkdir(JPATH_ROOT . '/media/system/js/' . $element . '/' . $urlpath, 0777, true);
 		file_put_contents(JPATH_ROOT . '/media/system/js/' . $element . '/' . $urlpath . $urlfilename, 'test');
-		file_put_contents(JPATH_ROOT . '/media/system/js/' . $element . '/' . $urlpath . 'script1-uncompressed.js', 'test');
+		file_put_contents(JPATH_ROOT . '/media/system/js/' . $element . '/' . $urlpath . 'script1.js', 'test');
 
 		JFactory::getConfig()->set('debug', 1);
 		JFactory::$document->_scripts = array();
 		JHtml::script($extension . '/' . $element . '/' . $urlpath . $urlfilename, array('relative' => true));
 
 		$this->assertArrayHasKey(
-			'/media/system/js/' . $element . '/' . $urlpath . 'script1-uncompressed.js',
+			'/media/system/js/' . $element . '/' . $urlpath . 'script1.js',
 			JFactory::$document->_scripts,
 			'Line:' . __LINE__ . ' JHtml::script failed when we should get it from the media directory'
 		);
@@ -835,7 +835,7 @@ class JHtmlTest extends TestCase
 
 		$this->assertEquals(
 			JHtml::script($extension . '/' . $element . '/' . $urlpath . $urlfilename, array('relative' => true, 'pathOnly' => true)),
-			JUri::base(true) . '/media/system/js/' . $element . '/' . $urlpath . 'script1-uncompressed.js',
+			JUri::base(true) . '/media/system/js/' . $element . '/' . $urlpath . 'script1.js',
 			'Line:' . __LINE__ . ' JHtml::script failed in URL only mode when it should come from the media directory'
 		);
 
@@ -850,14 +850,14 @@ class JHtmlTest extends TestCase
 		);
 
 		$this->assertArrayNotHasKey(
-			'/media/system/js/' . $element . '/' . $urlpath . 'script1-uncompressed.js',
+			'/media/system/js/' . $element . '/' . $urlpath . 'script1.js',
 			JFactory::$document->_scripts,
 			'Line:' . __LINE__ . ' JHtml::script failed when we should get it from the media directory'
 		);
 
 		$this->assertEquals(
 			JHtml::script($extension . '/' . $element . '/' . $urlpath . $urlfilename, array('relative' => true, 'pathOnly' => true)),
-			JUri::base(true) . '/media/system/js/' . $element . '/' . $urlpath . 'script1.js',
+			JUri::base(true) . '/media/system/js/' . $element . '/' . $urlpath . 'script1.min.js',
 			'Line:' . __LINE__ . ' JHtml::script failed in URL only mode when it should come from the media directory'
 		);
 
@@ -872,7 +872,7 @@ class JHtmlTest extends TestCase
 		);
 
 		$this->assertArrayNotHasKey(
-			'/media/system/js/' . $element . '/' . $urlpath . 'script1-uncompressed.js',
+			'/media/system/js/' . $element . '/' . $urlpath . 'script1.js',
 			JFactory::$document->_scripts,
 			'Line:' . __LINE__ . ' JHtml::script failed when we should get it from the media directory'
 		);
@@ -894,20 +894,20 @@ class JHtmlTest extends TestCase
 		);
 
 		$this->assertArrayNotHasKey(
-			'/media/system/js/' . $element . '/' . $urlpath . 'script1-uncompressed.js',
+			'/media/system/js/' . $element . '/' . $urlpath . 'script1.js',
 			JFactory::$document->_scripts,
 			'Line:' . __LINE__ . ' JHtml::script failed when we should get it from the media directory'
 		);
 
 		$this->assertEquals(
 			JHtml::script($extension . '/' . $element . '/' . $urlpath . $urlfilename, array('relative' => true, 'pathOnly' => true, 'detectDebug' => false)),
-			JUri::base(true) . '/media/system/js/' . $element . '/' . $urlpath . 'script1.js',
+			JUri::base(true) . '/media/system/js/' . $element . '/' . $urlpath . 'script1.min.js',
 			'Line:' . __LINE__ . ' JHtml::script failed in URL only mode when it should come from the media directory'
 		);
 
 		JFactory::$document->_scripts = array();
 		unlink(JPATH_ROOT . '/media/system/js/' . $element . '/' . $urlpath . $urlfilename);
-		unlink(JPATH_ROOT . '/media/system/js/' . $element . '/' . $urlpath . 'script1-uncompressed.js');
+		unlink(JPATH_ROOT . '/media/system/js/' . $element . '/' . $urlpath . 'script1.js');
 		rmdir(JPATH_ROOT . '/media/system/js/' . $element . '/' . $urlpath);
 		rmdir(JPATH_ROOT . '/media/system/js/' . $element);
 	}
@@ -923,7 +923,7 @@ class JHtmlTest extends TestCase
 	{
 		// These are some paths to pass to JHtml for testing purposes.
 		$urlpath = 'test' . uniqid() . '/';
-		$urlfilename = 'style' . uniqid() . '.css';
+		$urlfilename = 'style' . uniqid() . '.min.css';
 
 		// We generate a random template name so that we don't collide or hit anything.
 		$template = 'mytemplate' . uniqid();
@@ -1026,7 +1026,7 @@ class JHtmlTest extends TestCase
 		$extension = 'testextension' . uniqid();
 		$element = 'element' . uniqid();
 		$urlpath = 'path' . uniqid() . '/';
-		$urlfilename = 'style1.css';
+		$urlfilename = 'style1.min.css';
 
 		mkdir(JPATH_ROOT . '/media/' . $extension . '/' . $element . '/css/' . $urlpath, 0777, true);
 		file_put_contents(JPATH_ROOT . '/media/' . $extension . '/' . $element . '/css/' . $urlpath . $urlfilename, 'test');
@@ -1118,12 +1118,12 @@ class JHtmlTest extends TestCase
 			mkdir(JPATH_ROOT . '/media/system/css/' . $element . '/' . $urlpath, 0777, true);
 		}
 		file_put_contents(JPATH_ROOT . '/media/system/css/' . $element . '/' . $urlpath . $urlfilename, 'test');
-		file_put_contents(JPATH_ROOT . '/media/system/css/' . $element . '/' . $urlpath . 'style1_mybrowser.css', 'test');
-		file_put_contents(JPATH_ROOT . '/media/system/css/' . $element . '/' . $urlpath . 'style1_mybrowser_0.css', 'test');
-		file_put_contents(JPATH_ROOT . '/media/system/css/' . $element . '/' . $urlpath . 'style1_mybrowser_0_0.css', 'test');
+		file_put_contents(JPATH_ROOT . '/media/system/css/' . $element . '/' . $urlpath . 'style1_mybrowser.min.css', 'test');
+		file_put_contents(JPATH_ROOT . '/media/system/css/' . $element . '/' . $urlpath . 'style1_mybrowser_0.min.css', 'test');
+		file_put_contents(JPATH_ROOT . '/media/system/css/' . $element . '/' . $urlpath . 'style1_mybrowser_0_0.min.css', 'test');
 		JBrowser::getInstance()->setBrowser('mybrowser');
 
-		JHtml::stylesheet($extension . '/' . $element . '/' . $urlpath . $urlfilename, array('relative' => true));
+		JHtml::stylesheet($extension . '/' . $element . '/' . $urlpath . $urlfilename, array('relative' => true, 'detectBrowser' => true, 'debug' => false));
 		$this->assertArrayHasKey(
 			'/media/system/css/' . $element . '/' . $urlpath . $urlfilename,
 			JFactory::$document->_styleSheets,
@@ -1131,18 +1131,18 @@ class JHtmlTest extends TestCase
 		);
 
 		$this->assertArrayHasKey(
-			'/media/system/css/' . $element . '/' . $urlpath . 'style1_mybrowser.css',
+			'/media/system/css/' . $element . '/' . $urlpath . 'style1_mybrowser.min.css',
 			JFactory::$document->_styleSheets,
 			'Line:' . __LINE__ . ' JHtml::stylesheet failed when we should get it from the media directory'
 		);
 
 		$this->assertEquals(
-			JHtml::stylesheet($extension . '/' . $element . '/' . $urlpath . $urlfilename, array('relative' => true, 'pathOnly' => true)),
+			JHtml::stylesheet($extension . '/' . $element . '/' . $urlpath . $urlfilename, array('relative' => true, 'pathOnly' => true, 'detectBrowser' => true)),
 			array(
 				JUri::base(true) . '/media/system/css/' . $element . '/' . $urlpath . $urlfilename,
-				JUri::base(true) . '/media/system/css/' . $element . '/' . $urlpath . 'style1_mybrowser.css',
-				JUri::base(true) . '/media/system/css/' . $element . '/' . $urlpath . 'style1_mybrowser_0.css',
-				JUri::base(true) . '/media/system/css/' . $element . '/' . $urlpath . 'style1_mybrowser_0_0.css'
+				JUri::base(true) . '/media/system/css/' . $element . '/' . $urlpath . 'style1_mybrowser.min.css',
+				JUri::base(true) . '/media/system/css/' . $element . '/' . $urlpath . 'style1_mybrowser_0.min.css',
+				JUri::base(true) . '/media/system/css/' . $element . '/' . $urlpath . 'style1_mybrowser_0_0.min.css'
 			),
 			'Line:' . __LINE__ . ' JHtml::stylesheet failed in URL only mode when it should come from the media directory'
 		);
@@ -1155,22 +1155,22 @@ class JHtmlTest extends TestCase
 
 		JFactory::$document->_styleSheets = array();
 		unlink(JPATH_ROOT . '/media/system/css/' . $element . '/' . $urlpath . $urlfilename);
-		unlink(JPATH_ROOT . '/media/system/css/' . $element . '/' . $urlpath . 'style1_mybrowser.css');
-		unlink(JPATH_ROOT . '/media/system/css/' . $element . '/' . $urlpath . 'style1_mybrowser_0.css');
-		unlink(JPATH_ROOT . '/media/system/css/' . $element . '/' . $urlpath . 'style1_mybrowser_0_0.css');
+		unlink(JPATH_ROOT . '/media/system/css/' . $element . '/' . $urlpath . 'style1_mybrowser.min.css');
+		unlink(JPATH_ROOT . '/media/system/css/' . $element . '/' . $urlpath . 'style1_mybrowser_0.min.css');
+		unlink(JPATH_ROOT . '/media/system/css/' . $element . '/' . $urlpath . 'style1_mybrowser_0_0.min.css');
 		rmdir(JPATH_ROOT . '/media/system/css/' . $element . '/' . $urlpath);
 		rmdir(JPATH_ROOT . '/media/system/css/' . $element);
 
 		mkdir(JPATH_ROOT . '/media/system/css/' . $element . '/' . $urlpath, 0777, true);
 		file_put_contents(JPATH_ROOT . '/media/system/css/' . $element . '/' . $urlpath . $urlfilename, 'test');
-		file_put_contents(JPATH_ROOT . '/media/system/css/' . $element . '/' . $urlpath . 'style1-uncompressed.css', 'test');
+		file_put_contents(JPATH_ROOT . '/media/system/css/' . $element . '/' . $urlpath . 'style1.css', 'test');
 
 		JFactory::getConfig()->set('debug', 1);
 		JFactory::$document->_styleSheets = array();
 		JHtml::stylesheet($extension . '/' . $element . '/' . $urlpath . $urlfilename, array('relative' => true));
 
 		$this->assertArrayHasKey(
-			'/media/system/css/' . $element . '/' . $urlpath . 'style1-uncompressed.css',
+			'/media/system/css/' . $element . '/' . $urlpath . 'style1.css',
 			JFactory::$document->_styleSheets,
 			'Line:' . __LINE__ . ' JHtml::stylesheet failed when we should get it from the media directory'
 		);
@@ -1183,7 +1183,7 @@ class JHtmlTest extends TestCase
 
 		$this->assertEquals(
 			JHtml::stylesheet($extension . '/' . $element . '/' . $urlpath . $urlfilename, array('relative' => true, 'pathOnly' => true)),
-			JUri::base(true) . '/media/system/css/' . $element . '/' . $urlpath . 'style1-uncompressed.css',
+			JUri::base(true) . '/media/system/css/' . $element . '/' . $urlpath . 'style1.css',
 			'Line:' . __LINE__ . ' JHtml::stylesheet failed in URL only mode when it should come from the media directory'
 		);
 
@@ -1198,14 +1198,14 @@ class JHtmlTest extends TestCase
 		);
 
 		$this->assertArrayNotHasKey(
-			'/media/system/css/' . $element . '/' . $urlpath . 'style1-uncompressed.css',
+			'/media/system/css/' . $element . '/' . $urlpath . 'style1.css',
 			JFactory::$document->_styleSheets,
 			'Line:' . __LINE__ . ' JHtml::stylesheet failed when we should get it from the media directory'
 		);
 
 		$this->assertEquals(
 			JHtml::stylesheet($extension . '/' . $element . '/' . $urlpath . $urlfilename, array('relative' => true, 'pathOnly' => true)),
-			JUri::base(true) . '/media/system/css/' . $element . '/' . $urlpath . 'style1.css',
+			JUri::base(true) . '/media/system/css/' . $element . '/' . $urlpath . 'style1.min.css',
 			'Line:' . __LINE__ . ' JHtml::stylesheet failed in URL only mode when it should come from the media directory'
 		);
 
@@ -1220,7 +1220,7 @@ class JHtmlTest extends TestCase
 		);
 
 		$this->assertArrayNotHasKey(
-			'/media/system/css/' . $element . '/' . $urlpath . 'style1-uncompressed.css',
+			'/media/system/css/' . $element . '/' . $urlpath . 'style1.css',
 			JFactory::$document->_styleSheets,
 			'Line:' . __LINE__ . ' JHtml::stylesheet failed when we should get it from the media directory'
 		);
@@ -1242,20 +1242,20 @@ class JHtmlTest extends TestCase
 		);
 
 		$this->assertArrayNotHasKey(
-			'/media/system/css/' . $element . '/' . $urlpath . 'style1-uncompressed.css',
+			'/media/system/css/' . $element . '/' . $urlpath . 'style1.css',
 			JFactory::$document->_styleSheets,
 			'Line:' . __LINE__ . ' JHtml::stylesheet failed when we should get it from the media directory'
 		);
 
 		$this->assertEquals(
 			JHtml::stylesheet($extension . '/' . $element . '/' . $urlpath . $urlfilename, array('relative' => true, 'pathOnly' => true, 'detectDebug' => false)),
-			JUri::base(true) . '/media/system/css/' . $element . '/' . $urlpath . 'style1.css',
+			JUri::base(true) . '/media/system/css/' . $element . '/' . $urlpath . 'style1.min.css',
 			'Line:' . __LINE__ . ' JHtml::stylesheet failed in URL only mode when it should come from the media directory'
 		);
 
 		JFactory::$document->_styleSheets = array();
 		unlink(JPATH_ROOT . '/media/system/css/' . $element . '/' . $urlpath . $urlfilename);
-		unlink(JPATH_ROOT . '/media/system/css/' . $element . '/' . $urlpath . 'style1-uncompressed.css');
+		unlink(JPATH_ROOT . '/media/system/css/' . $element . '/' . $urlpath . 'style1.css');
 		rmdir(JPATH_ROOT . '/media/system/css/' . $element . '/' . $urlpath);
 		rmdir(JPATH_ROOT . '/media/system/css/' . $element);
 
@@ -1278,7 +1278,7 @@ class JHtmlTest extends TestCase
 				'options' => array(
 					'relative'      => true,
 					'pathOnly'      => false,
-					'detectBrowser' => true,
+					'detectBrowser' => false,
 					'detectDebug'   => true,
 				),
 			),


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
- We've already dropped the -uncompressed support for css/js, but the tests are still not reflecting that

- Also the `detectBrowser` in Joomla 4 has a default value `false` (for performance)


### Testing Instructions



### Expected result



### Actual result



### Documentation Changes Required
