### PR TITLE
plg_search_content. content.xml. Adapt default values

### DIFF
--- a/plugins/search/content/content.xml
+++ b/plugins/search/content/content.xml
@@ -34,7 +34,7 @@
 					label="PLG_SEARCH_CONTENT_FIELD_CONTENT_LABEL"
 					description="PLG_SEARCH_CONTENT_FIELD_CONTENT_DESC"
 					class="btn-group btn-group-yesno"
-					default="0"
+					default="1"
 					>
 					<option value="1">JYES</option>
 					<option value="0">JNO</option>
@@ -46,7 +46,7 @@
 					label="PLG_SEARCH_CONTENT_FIELD_ARCHIVED_LABEL"
 					description="PLG_SEARCH_CONTENT_FIELD_ARCHIVED_DESC"
 					class="btn-group btn-group-yesno"
-					default="0"
+					default="1"
 					>
 					<option value="1">JYES</option>
 					<option value="0">JNO</option>


### PR DESCRIPTION
### Testing Instructions: Code Review:

- Have a look at installation file joomla.sql, line 586 https://github.com/joomla/joomla-cms/blob/staging/installation/sql/mysql/joomla.sql#L586
==> `plg_search_content` is installed with default value `1` for parameters` search_content` and  `search_archived`

- Plugin file https://github.com/joomla/joomla-cms/blob/staging/plugins/search/content/content.php#L68-L69 uses default value `1`, too.

- So, the default value for both parameters in manifest xml should be `1`, too.