### PR TITLE
plg_search_content. Use getter method to identify $serverType

### DIFF
--- a/plugins/search/content/content.php
+++ b/plugins/search/content/content.php
@@ -49,7 +49,7 @@ class PlgSearchContent extends JPlugin
 	public function onContentSearch($text, $phrase = '', $ordering = '', $areas = null)
 	{
 		$db         = JFactory::getDbo();
-		$serverType = $db->serverType;
+		$serverType = $db->getServerType();
 		$app        = JFactory::getApplication();
 		$user       = JFactory::getUser();
 		$groups     = implode(',', $user->getAuthorisedViewLevels());


### PR DESCRIPTION
### Summary of Changes
- `$db->serverType` is not reliably populated always. So, use `$db->getServerType()` instead.

### Testing Instructions
- Apply patch in current staging and see that nothing changes in com_search search results in frontend with activated plugin.

- See also comment of @mbabker https://github.com/joomla/joomla-cms/issues/19317#issuecomment-355795404

### Additional comment
**- At the latest in Joomla 4 the code must be changed accordingly.**