### PR TITLE
[com_users] Fix display of custom field of value 0

### DIFF
--- a/components/com_users/views/profile/tmpl/default_custom.php
+++ b/components/com_users/views/profile/tmpl/default_custom.php
@@ -51,7 +51,7 @@ foreach ($tmp as $customField)
 						</dt>
 						<dd>
 							<?php if (key_exists($field->fieldname, $customFields)) : ?>
-								<?php echo $customFields[$field->fieldname]->value ?: JText::_('COM_USERS_PROFILE_VALUE_NOT_FOUND'); ?>
+								<?php echo strlen($customFields[$field->fieldname]->value) ? $customFields[$field->fieldname]->value : JText::_('COM_USERS_PROFILE_VALUE_NOT_FOUND'); ?>
 							<?php elseif (JHtml::isRegistered('users.' . $field->id)) : ?>
 								<?php echo JHtml::_('users.' . $field->id, $field->value); ?>
 							<?php elseif (JHtml::isRegistered('users.' . $field->fieldname)) : ?>


### PR DESCRIPTION
### Summary of Changes
Fix display of custom field of value `0` to display `0` and not `No Information Entered`.

More related PRs to come to fix this issue in Contacts.

### Testing Instructions
Under Users > Fields, create a text custom field.
Edit your account and edit this custom field with a value 0.
Log in on the frontend.
Click `Your Profile`.
Under the `Fields` section, view the custom field and its value.

### Expected result
`0`


### Actual result
`No Information Entered`


### Documentation Changes Required
None
