### PR TITLE
Make calendar output usable in other css-frameworks

### DIFF
--- a/media/system/css/fields/calendar-rtl.css
+++ b/media/system/css/fields/calendar-rtl.css
@@ -75,6 +75,7 @@ div.calendar-container table td.title { /* This holds the current "month, year" 
 	border: 0;
 	cursor : pointer;
 	font-size: 12px;
+	min-width: 38px;
 }
 
 .calendar-container table tbody td.day.wn {

--- a/media/system/css/fields/calendar-rtl.css
+++ b/media/system/css/fields/calendar-rtl.css
@@ -91,7 +91,7 @@ div.calendar-container table td.title { /* This holds the current "month, year" 
 .calendar-container table tbody td.today {
 	position: relative;
 	height: 100%;
-	width: 100%;
+	width: auto;
 	font-weight: bold;
 }
 .calendar-container table tbody td.today:after {

--- a/media/system/css/fields/calendar.css
+++ b/media/system/css/fields/calendar.css
@@ -75,6 +75,7 @@ div.calendar-container table td.title { /* This holds the current "month, year" 
 	border: 0;
 	cursor : pointer;
 	font-size: 12px;
+	min-width: 38px;
 }
 
 .calendar-container table tbody td.day.wn {

--- a/media/system/css/fields/calendar.css
+++ b/media/system/css/fields/calendar.css
@@ -91,7 +91,7 @@ div.calendar-container table td.title { /* This holds the current "month, year" 
 .calendar-container table tbody td.today {
 	position: relative;
 	height: 100%;
-	width: 100%;
+	width: auto;
 	font-weight: bold;
 }
 .calendar-container table tbody td.today:after {


### PR DESCRIPTION
### Summary of Changes
~~Make calendar button usable in other css-frameworks~~
**Edit:** 
Make calendar output usable in other css-frameworks
For testing instruction look at [this comment](https://github.com/joomla/joomla-cms/pull/19944#issuecomment-374542858)

### Documentation Changes Required
~~In BS3 the input-group can not handle the button tag, so it is now changed from a button tag before to an a tag.~~
**Edit:**
Other frameworks, such as Uikit, do not properly render the calendar design for active days. This PR fixes that.
