### PR TITLE
Proper selection of menu item, for URLs that do not specify a layout, but menu items both with and without layout exist

### DIFF
--- a/libraries/src/Component/Router/Rules/MenuRules.php
+++ b/libraries/src/Component/Router/Rules/MenuRules.php
@@ -126,7 +126,7 @@ class MenuRules implements RulesInterface
 				$viewLayouts[] = $view;
 				$viewLayouts[] = $view . ':default';
 
-				foreach($viewLayouts as $viewLayout)
+				foreach ($viewLayouts as $viewLayout)
 				{
 					if (isset($this->lookup[$language][$viewLayout]))
 					{

--- a/libraries/src/Component/Router/Rules/MenuRules.php
+++ b/libraries/src/Component/Router/Rules/MenuRules.php
@@ -142,7 +142,7 @@ class MenuRules implements RulesInterface
 							if (isset($this->lookup[$language][$viewLayout][(int) $id]))
 							{
 								$query['Itemid'] = $this->lookup[$language][$viewLayout][(int) $id];
-	
+
 								return;
 							}
 						}

--- a/libraries/src/Component/Router/Rules/MenuRules.php
+++ b/libraries/src/Component/Router/Rules/MenuRules.php
@@ -116,44 +116,31 @@ class MenuRules implements RulesInterface
 		{
 			foreach ($needles as $view => $ids)
 			{
-				$viewLayout = $view . $layout;
+				$viewLayouts = $array(
+					$view . $layout,
+					$view,
+					$view . ':default'
+				);
 
-				if ($layout && isset($this->lookup[$language][$viewLayout]))
+				foreach($viewLayouts as $viewLayout)
 				{
-					if (is_bool($ids))
+					if (isset($this->lookup[$language][$viewLayout]))
 					{
-						$query['Itemid'] = $this->lookup[$language][$viewLayout];
-
-						return;
-					}
-
-					foreach ($ids as $id => $segment)
-					{
-						if (isset($this->lookup[$language][$viewLayout][(int) $id]))
+						if (is_bool($ids))
 						{
-							$query['Itemid'] = $this->lookup[$language][$viewLayout][(int) $id];
-
+							$query['Itemid'] = $this->lookup[$language][$viewLayout];
+	
 							return;
 						}
-					}
-				}
 
-				if (isset($this->lookup[$language][$view]))
-				{
-					if (is_bool($ids))
-					{
-						$query['Itemid'] = $this->lookup[$language][$view];
-
-						return;
-					}
-
-					foreach ($ids as $id => $segment)
-					{
-						if (isset($this->lookup[$language][$view][(int) $id]))
+						foreach ($ids as $id => $segment)
 						{
-							$query['Itemid'] = $this->lookup[$language][$view][(int) $id];
-
-							return;
+							if (isset($this->lookup[$language][$viewLayout][(int) $id]))
+							{
+								$query['Itemid'] = $this->lookup[$language][$viewLayout][(int) $id];
+	
+								return;
+							}
 						}
 					}
 				}
@@ -210,12 +197,7 @@ class MenuRules implements RulesInterface
 				{
 					$view = $item->query['view'];
 
-					$layout = '';
-
-					if (isset($item->query['layout']))
-					{
-						$layout = ':' . $item->query['layout'];
-					}
+					$layout = isset($item->query['layout']) && $item->query['layout'] !== 'default' ? ':' . $item->query['layout'] : '';
 
 					if ($views[$view]->key)
 					{
@@ -243,7 +225,7 @@ class MenuRules implements RulesInterface
 						if (!isset($this->lookup[$language][$view . $layout][$item->query[$views[$view]->key]]) || $item->language !== '*')
 						{
 							$this->lookup[$language][$view . $layout][$item->query[$views[$view]->key]] = $item->id;
-							$this->lookup[$language][$view][$item->query[$views[$view]->key]] = $item->id;
+							$this->lookup[$language][$view . ':default'][$item->query[$views[$view]->key]] = $item->id;
 						}
 					}
 					else
@@ -256,7 +238,7 @@ class MenuRules implements RulesInterface
 						if (!isset($this->lookup[$language][$view . $layout]) || $item->language !== '*')
 						{
 							$this->lookup[$language][$view . $layout] = $item->id;
-							$this->lookup[$language][$view] = $item->id;
+							$this->lookup[$language][$view . ':default'] = $item->id;
 						}
 					}
 				}

--- a/libraries/src/Component/Router/Rules/MenuRules.php
+++ b/libraries/src/Component/Router/Rules/MenuRules.php
@@ -116,11 +116,15 @@ class MenuRules implements RulesInterface
 		{
 			foreach ($needles as $view => $ids)
 			{
-				$viewLayouts = array(
-					$view . $layout,
-					$view,
-					$view . ':default'
-				);
+				$viewLayouts = array();
+
+				if ($layout)
+				{
+					$viewLayouts[] = $view . $layout;
+				}
+
+				$viewLayouts[] = $view;
+				$viewLayouts[] = $view . ':default';
 
 				foreach($viewLayouts as $viewLayout)
 				{
@@ -225,7 +229,12 @@ class MenuRules implements RulesInterface
 						if (!isset($this->lookup[$language][$view . $layout][$item->query[$views[$view]->key]]) || $item->language !== '*')
 						{
 							$this->lookup[$language][$view . $layout][$item->query[$views[$view]->key]] = $item->id;
-							$this->lookup[$language][$view . ':default'][$item->query[$views[$view]->key]] = $item->id;
+
+							// Also if it specifies layout, then also add it as last choice fallback
+							if ($layout)
+							{
+								$this->lookup[$language][$view . ':default'][$item->query[$views[$view]->key]] = $item->id;
+							}
 						}
 					}
 					else
@@ -238,7 +247,12 @@ class MenuRules implements RulesInterface
 						if (!isset($this->lookup[$language][$view . $layout]) || $item->language !== '*')
 						{
 							$this->lookup[$language][$view . $layout] = $item->id;
-							$this->lookup[$language][$view . ':default'] = $item->id;
+
+							// Also if it specifies layout, then also add it as last choice fallback
+							if ($layout)
+							{
+								$this->lookup[$language][$view . ':default'] = $item->id;
+							}
 						}
 					}
 				}

--- a/libraries/src/Component/Router/Rules/MenuRules.php
+++ b/libraries/src/Component/Router/Rules/MenuRules.php
@@ -116,7 +116,7 @@ class MenuRules implements RulesInterface
 		{
 			foreach ($needles as $view => $ids)
 			{
-				$viewLayouts = $array(
+				$viewLayouts = array(
 					$view . $layout,
 					$view,
 					$view . ':default'

--- a/tests/unit/suites/libraries/cms/component/router/rules/JComponentRouterRulesMenuTest.php
+++ b/tests/unit/suites/libraries/cms/component/router/rules/JComponentRouterRulesMenuTest.php
@@ -113,11 +113,10 @@ class JComponentRouterRulesMenuTest extends TestCaseDatabase
 		$this->assertInstanceOf('JComponentRouterView', $this->object->get('router'));
 		$this->assertEquals(array(
 			'*' => array(
-				'article' => array(1 => '52'),
-				'featured:default' => '47',
-				'categories:default' => array(14 => '48'),
-				'category:default' => array (20 => '49'),
-				'article:default' => array(1 => '52')),
+				'featured' => '47',
+				'categories' => array(14 => '48'),
+				'category' => array (20 => '49'),
+				'article' => array(1 => '52')),
 			), $this->object->get('lookup')
 		);
 	}
@@ -308,11 +307,10 @@ class JComponentRouterRulesMenuTest extends TestCaseDatabase
 	{
 		$this->assertEquals(array(
 			'*' => array(
-				'article' => array(1 => '52'),
-				'featured:default' => '47',
-				'categories:default' => array(14 => '48'),
-				'category:default' => array (20 => '49'),
-				'article:default' => array(1 => '52')),
+				'featured' => '47',
+				'categories' => array(14 => '48'),
+				'category' => array (20 => '49'),
+				'article' => array(1 => '52')),
 			), $this->object->get('lookup')
 		);
 

--- a/tests/unit/suites/libraries/cms/component/router/rules/JComponentRouterRulesMenuTest.php
+++ b/tests/unit/suites/libraries/cms/component/router/rules/JComponentRouterRulesMenuTest.php
@@ -113,7 +113,7 @@ class JComponentRouterRulesMenuTest extends TestCaseDatabase
 		$this->assertInstanceOf('JComponentRouterView', $this->object->get('router'));
 		$this->assertEquals(array(
 			'*' => array(
-				'article' => array(1 => '52')),
+				'article' => array(1 => '52'),
 				'featured:default' => '47',
 				'categories:default' => array(14 => '48'),
 				'category:default' => array (20 => '49'),
@@ -308,7 +308,7 @@ class JComponentRouterRulesMenuTest extends TestCaseDatabase
 	{
 		$this->assertEquals(array(
 			'*' => array(
-				'article' => array(1 => '52')),
+				'article' => array(1 => '52'),
 				'featured:default' => '47',
 				'categories:default' => array(14 => '48'),
 				'category:default' => array (20 => '49'),

--- a/tests/unit/suites/libraries/cms/component/router/rules/JComponentRouterRulesMenuTest.php
+++ b/tests/unit/suites/libraries/cms/component/router/rules/JComponentRouterRulesMenuTest.php
@@ -113,10 +113,11 @@ class JComponentRouterRulesMenuTest extends TestCaseDatabase
 		$this->assertInstanceOf('JComponentRouterView', $this->object->get('router'));
 		$this->assertEquals(array(
 			'*' => array(
-				'featured' => '47',
-				'categories' => array(14 => '48'),
-				'category' => array (20 => '49'),
 				'article' => array(1 => '52')),
+				'featured:default' => '47',
+				'categories:default' => array(14 => '48'),
+				'category:default' => array (20 => '49'),
+				'article:default' => array(1 => '52')),
 			), $this->object->get('lookup')
 		);
 	}
@@ -307,10 +308,11 @@ class JComponentRouterRulesMenuTest extends TestCaseDatabase
 	{
 		$this->assertEquals(array(
 			'*' => array(
-				'featured' => '47',
-				'categories' => array(14 => '48'),
-				'category' => array (20 => '49'),
 				'article' => array(1 => '52')),
+				'featured:default' => '47',
+				'categories:default' => array(14 => '48'),
+				'category:default' => array (20 => '49'),
+				'article:default' => array(1 => '52')),
 			), $this->object->get('lookup')
 		);
 


### PR DESCRIPTION
More complete alternative to Pull Request #19516 

### Summary of Changes
During building menu item lookup table
when a menu item that has a layout is encountered, **then 2 entries** are added to the lookup table:

- **[$view . $layout]** ....... (an exact match for URLs that specify layout variable
- **[$view]** .......................... (a "**fallback entry**" in the case of URL without layout variable)

but the above causes later added (to the lookup table) menu items for the specific $view,
that do not specify a 'layout' to be ignored, as the "**fallback entry**" is not overwritten

-----

PR #19516, suggests to remove the fallback entry, but then ... we have no fallback entry when needed
- this PR will add a distinct fallback **3rd** entry indexed via ... **[$view . ':default']** to be tried last

---

Order of checking the menu item lookup table

1. [$view . $layout] ....... **Same** as before this PR, created when a menu item with layout is encountered
2. [$view]  ......................... **Change**, this entry is now added ONLY by menu items without 'layout'
3. [$view . ':default'] ..... **New**, entry is added the first time that a menu item with layout is encountered 

NOTE:
**The lookup code is exactly to what it was before**, just the exact same code is moved inside a loop that iterates (in order) the above 3 cases ! Please see that is identical here:
https://github.com/ggppdk/joomla-cms/blob/30f86c8133dd226d7a8da908ba4baf6d2a3f403e/libraries/src/Component/Router/Rules/MenuRules.php#L131-L149

### Testing Instructions



### Expected result


### Actual result


### Documentation Changes Required
None
