### PR TITLE
[Regression] Menu item type url with rel attribute nofollow

### DIFF
--- a/modules/mod_menu/tmpl/default_url.php
+++ b/modules/mod_menu/tmpl/default_url.php
@@ -50,6 +50,7 @@ if ($item->browserNav == 1)
 {
 	$attributes['target'] = '_blank';
 	$attributes['rel'] = 'noopener noreferrer';
+
 	if ($item->anchor_rel == 'nofollow')
 	{
 		$attributes['rel'] = 'nofollow noopener noreferrer';

--- a/modules/mod_menu/tmpl/default_url.php
+++ b/modules/mod_menu/tmpl/default_url.php
@@ -50,7 +50,7 @@ if ($item->browserNav == 1)
 {
 	$attributes['target'] = '_blank';
 	$attributes['rel'] = 'noopener noreferrer';
-	if ($item->anchor_rel == 'nofollow'))
+	if ($item->anchor_rel == 'nofollow')
 	{
 		$attributes['rel'] = 'nofollow noopener noreferrer';
 	}

--- a/modules/mod_menu/tmpl/default_url.php
+++ b/modules/mod_menu/tmpl/default_url.php
@@ -50,6 +50,10 @@ if ($item->browserNav == 1)
 {
 	$attributes['target'] = '_blank';
 	$attributes['rel'] = 'noopener noreferrer';
+	if (isset($attributes['rel'] && $attributes['rel'] == 'nofollow'))
+	{
+		$attributes['rel'] = 'nofollow noopener noreferrer';
+	}
 }
 elseif ($item->browserNav == 2)
 {

--- a/modules/mod_menu/tmpl/default_url.php
+++ b/modules/mod_menu/tmpl/default_url.php
@@ -50,7 +50,7 @@ if ($item->browserNav == 1)
 {
 	$attributes['target'] = '_blank';
 	$attributes['rel'] = 'noopener noreferrer';
-	if (isset($attributes['rel'] && $attributes['rel'] == 'nofollow'))
+	if ($item->anchor_rel == 'nofollow'))
 	{
 		$attributes['rel'] = 'nofollow noopener noreferrer';
 	}

--- a/modules/mod_menu/tmpl/default_url.php
+++ b/modules/mod_menu/tmpl/default_url.php
@@ -53,7 +53,7 @@ if ($item->browserNav == 1)
 
 	if ($item->anchor_rel == 'nofollow')
 	{
-		$attributes['rel'] = 'nofollow noopener noreferrer';
+		$attributes['rel'] .= ' nofollow';
 	}
 }
 elseif ($item->browserNav == 2)


### PR DESCRIPTION
_Following PR #14881_

Previous PR (#14881) adding regression about menu item "url", when choosing "nofollow" for "Link Rel Attribute" and "New window with navigation" for "Target window", the value "nofollow" is not added, because of https://github.com/joomla/joomla-cms/blob/staging/modules/mod_menu/tmpl/default_url.php#L52 [https://github.com/joomla/joomla-cms/pull/14881/files#diff-c0c6261ed88c7b7315ee79638a3917abR44]

### Testing Instructions
#### Create a new menu item > Type : URL
- Target window : "new window with navigation"
- Link rel attribute : "nofollow"

Frontend > look at menu item, there is no "nofollow" in rel attribute

#### Apply patch
Frontend > look at menu item, this works
