### PR TITLE
Fix for duplicate url check bug introduced by #19734 and support utf8…

### DIFF
--- a/administrator/components/com_redirect/tables/link.php
+++ b/administrator/components/com_redirect/tables/link.php
@@ -85,17 +85,20 @@ class RedirectTableLink extends JTable
 		// Check for existing name
 		$query = $db->getQuery(true)
 			->select($db->quoteName('id'))
+			->select($db->quoteName('old_url'))
 			->from('#__redirect_links')
-			->where($db->quoteName('old_url') . ' = ' . $db->quote(rawurlencode($this->old_url)));
+			->where($db->quoteName('old_url') . ' = ' . $db->quote($this->old_url));
 		$db->setQuery($query);
+		$urls = $db->loadAssocList();
 
-		$xid = (int) $db->loadResult();
-
-		if ($xid && $xid != (int) $this->id)
+		foreach ($urls AS $url)
 		{
-			$this->setError(JText::_('COM_REDIRECT_ERROR_DUPLICATE_OLD_URL'));
+			if ($url['old_url'] === $this->old_url && (int) $url['id'] != (int) $this->id)
+			{
+				$this->setError(JText::_('COM_REDIRECT_ERROR_DUPLICATE_OLD_URL'));
 
-			return false;
+				return false;
+			}
 		}
 
 		return true;

--- a/administrator/components/com_redirect/tables/link.php
+++ b/administrator/components/com_redirect/tables/link.php
@@ -91,7 +91,7 @@ class RedirectTableLink extends JTable
 		$db->setQuery($query);
 		$urls = $db->loadAssocList();
 
-		foreach ($urls AS $url)
+		foreach ($urls as $url)
 		{
 			if ($url['old_url'] === $this->old_url && (int) $url['id'] != (int) $this->id)
 			{


### PR DESCRIPTION
Fix for duplicate url check bug introduced by #19734 and support utf8 on old_urls.
Couldn't find a solution to handle this within mysql. So a simple foreach handles it perfectly fine.

@infograf768 can you please test?