### PR TITLE
Update tag.php

### DIFF
--- a/components/com_tags/models/tag.php
+++ b/components/com_tags/models/tag.php
@@ -262,15 +262,15 @@ class TagsModelTag extends JModelList
 		{
 			$this->item = false;
 
-			if (empty($id))
+			if (empty($pk))
 			{
-				$id = $this->getState('tag.id');
+				$pk = $this->getState('tag.id');
 			}
 
 			// Get a level row instance.
 			$table = JTable::getInstance('Tag', 'TagsTable');
 
-			$idsArray = explode(',', $id);
+			$idsArray = explode(',', $pk);
 
 			// Attempt to load the rows into an array.
 			foreach ($idsArray as $id)


### PR DESCRIPTION
There is a bug in getItem, the function parameter is called $pk, but in code it is using $id, so whenever the parameter  is passed it is not used in the function.

Pull Request for Issue # .

### Summary of Changes



### Testing Instructions



### Expected result



### Actual result



### Documentation Changes Required

