### PR TITLE
[4.0] Make switcher type detection more robust

### DIFF
--- a/layouts/joomla/form/field/radio/switcher.php
+++ b/layouts/joomla/form/field/radio/switcher.php
@@ -68,7 +68,7 @@ $type = '';
 
 if ($pos = strpos($class, 'switcher-'))
 {
-	$type = 'type="' . strtok(substr($class, $pos+9), ' ') . '"';
+	$type = 'type="' . strtok(substr($class, $pos + 9), ' ') . '"';
 }
 
 // Add the attributes of the fieldset in an array

--- a/layouts/joomla/form/field/radio/switcher.php
+++ b/layouts/joomla/form/field/radio/switcher.php
@@ -64,8 +64,12 @@ HTMLHelper::_('webcomponent',
 );
 
 // Set the type of switcher
-$type = str_replace('switcher switcher-', '', trim($class));
-$type = $type === 'switcher' ? '' : 'type="' . $type . '"';
+$type = '';
+
+if ($pos = strpos($class, 'switcher-'))
+{
+	$type = 'type="' . strtok(substr($class, $pos+9), ' ') . '"';
+}
 
 // Add the attributes of the fieldset in an array
 $attribs = [


### PR DESCRIPTION
Pull Request for Issue #19943 .

### Summary of Changes
Makes the "type" detection for the switcher more robust.
Currently, everything behind the class part "switcher-" becomes the "type" of the switcher. This PR changes it so only that class is taken into account and following additional classes are ignored.


### Testing Instructions
Adjust a radio field with class "switcher", eg https://github.com/joomla/joomla-cms/blob/4.0-dev/administrator/components/com_content/config.xml#L22.
* Add to the existing class a second one like `switcher-danger` making it `class="switcher switcher-danger"`. Then test the appearance in the com_content option page.
* Change that class attribute again to something like `class="switcher btn-group"` and check again.


### Expected result
First test should change the switcher to a red one instead of green.
Second test should change nothing (since no `switcher-foo` is defined). Your switcher should stay green.


### Actual result
First test works as expected and switcher gets red.
Second test changes the switcher to use no color at all.


### Documentation Changes Required
None
