### PR TITLE
Corrected bug on empty subject of com_mailto

### DIFF
--- a/components/com_mailto/controller.php
+++ b/components/com_mailto/controller.php
@@ -110,7 +110,7 @@ class MailtoController extends JControllerLegacy
 		$sender          = $this->input->post->getString('sender', '');
 		$from            = $this->input->post->getString('from', '');
 		$subject_default = JText::sprintf('COM_MAILTO_SENT_BY', $sender);
-		$subject         = $this->input->post->getString('subject') !== "" ? $this->input->post->getString('subject') : $subject_default;
+		$subject         = $this->input->post->getString('subject', '') !== '' ? $this->input->post->getString('subject') : $subject_default;
 
 		// Check for a valid to address
 		$error = false;

--- a/components/com_mailto/controller.php
+++ b/components/com_mailto/controller.php
@@ -110,7 +110,7 @@ class MailtoController extends JControllerLegacy
 		$sender          = $this->input->post->getString('sender', '');
 		$from            = $this->input->post->getString('from', '');
 		$subject_default = JText::sprintf('COM_MAILTO_SENT_BY', $sender);
-		$subject         = $this->input->post->getString('subject', $subject_default);
+		$subject         = $this->input->post->getString('subject') !== "" ? $this->input->post->getString('subject') : $subject_default;
 
 		// Check for a valid to address
 		$error = false;


### PR DESCRIPTION
### Summary of Changes
Corrected the problem that if the subject is empty, the default subject text is never added.


### Testing Instructions
A com_mailto request without subject.


### Expected result
The default text to be taken.


### Actual result
Empty subject.


### Documentation Changes Required
Some changes are needed at: components\com_mailto\controller.php
