### PR TITLE
[4.0] Correct a bug in Registry.php

### DIFF
--- a/libraries/vendor/joomla/registry/src/Registry.php
+++ b/libraries/vendor/joomla/registry/src/Registry.php
@@ -508,11 +508,13 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 		switch (true)
 		{
 			case (is_object($node)):
-				$result = $node->{$nodes[$i]} = $value;
+				$result = $node->{$nodes[$i]};
+				$node->{$nodes[$i]} = $value;
 				break;
 
 			case (is_array($node)):
-				$result = $node[$nodes[$i]] = $value;
+				$result = $node[$nodes[$i]];
+				$node->{$nodes[$i]} = $value;
 				break;
 
 			default:


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
In class Registry, function set() is supposed to return the old value if exists, but actually return the newly set value.


### Testing Instructions
None


### Expected result
None


### Actual result
None


### Documentation Changes Required
None
