### PR TITLE
[com_finder] - fix update inner join syntax for postgres

### DIFF
--- a/administrator/components/com_finder/helpers/indexer/indexer.php
+++ b/administrator/components/com_finder/helpers/indexer/indexer.php
@@ -307,7 +307,9 @@ abstract class FinderIndexer
 			// Update the link counts for the terms.
 			$query->clear()
 				->update($db->quoteName('#__finder_terms', 't'))
-				->join('INNER', $db->quoteName('#__finder_links_terms' . dechex($i), 'm') . ' ON ' . $db->quoteName('m.term_id') . ' = ' . $db->quoteName('t.term_id'))
+				->join('INNER', $db->quoteName('#__finder_links_terms' . dechex($i), 'm') .
+					' ON ' . $db->quoteName('m.term_id') . ' = ' . $db->quoteName('t.term_id')
+				)
 				->set($db->quoteName('links') . ' = ' . $db->quoteName('links') . ' - 1')
 				->where($db->quoteName('m.link_id') . ' = ' . (int) $linkId);
 			$db->setQuery($query)->execute();

--- a/administrator/components/com_finder/helpers/indexer/indexer.php
+++ b/administrator/components/com_finder/helpers/indexer/indexer.php
@@ -306,10 +306,10 @@ abstract class FinderIndexer
 		{
 			// Update the link counts for the terms.
 			$query->clear()
-				->update($db->qn('#__finder_terms', 't'))
-				->join('INNER', $db->qn('#__finder_links_terms' . dechex($i), 'm') . ' ON ' . $db->qn('m.term_id') . ' = ' . $db->qn('t.term_id'))
-				->set($db->qn('links') . ' = ' . $db->qn('links') . ' - 1')
-				->where($db->qn('m.link_id') . ' = ' . (int) $linkId);
+				->update($db->quoteName('#__finder_terms', 't'))
+				->join('INNER', $db->quoteName('#__finder_links_terms' . dechex($i), 'm') . ' ON ' . $db->quoteName('m.term_id') . ' = ' . $db->quoteName('t.term_id'))
+				->set($db->quoteName('links') . ' = ' . $db->quoteName('links') . ' - 1')
+				->where($db->quoteName('m.link_id') . ' = ' . (int) $linkId);
 			$db->setQuery($query)->execute();
 
 			// Remove all records from the mapping tables.

--- a/administrator/components/com_finder/helpers/indexer/indexer.php
+++ b/administrator/components/com_finder/helpers/indexer/indexer.php
@@ -307,7 +307,7 @@ abstract class FinderIndexer
 			// Update the link counts for the terms.
 			$query->clear()
 				->update($db->qn('#__finder_terms', 't'))
-				->join('INNER', $db->qn('#__finder_links_terms' . dechex($i), 'm') . ' ON  ' . $db->qn('m.term_id') .' = '. $db->qn('t.term_id'))
+				->join('INNER', $db->qn('#__finder_links_terms' . dechex($i), 'm') . ' ON ' . $db->qn('m.term_id') . ' = ' . $db->qn('t.term_id'))
 				->set($db->qn('links') . ' = ' . $db->qn('links') . ' - 1')
 				->where($db->qn('m.link_id') . ' = ' . (int) $linkId);
 			$db->setQuery($query)->execute();

--- a/administrator/components/com_finder/helpers/indexer/indexer.php
+++ b/administrator/components/com_finder/helpers/indexer/indexer.php
@@ -306,10 +306,10 @@ abstract class FinderIndexer
 		{
 			// Update the link counts for the terms.
 			$query->clear()
-				->update($db->quoteName('#__finder_terms', 't'))
-				->join('INNER', $db->quoteName('#__finder_links_terms' . dechex($i), 'm') . ' ON m.term_id = t.term_id')
-				->set('t.links = t.links - 1')
-				->where($db->quoteName('m.link_id') . ' = ' . (int) $linkId);
+				->update($db->qn('#__finder_terms', 't'))
+				->join('INNER', $db->qn('#__finder_links_terms' . dechex($i), 'm') . ' ON  ' . $db->qn('m.term_id') .' = '. $db->qn('t.term_id'))
+				->set($db->qn('links') . ' = ' . $db->qn('links') . ' - 1')
+				->where($db->qn('m.link_id') . ' = ' . (int) $linkId);
 			$db->setQuery($query)->execute();
 
 			// Remove all records from the mapping tables.


### PR DESCRIPTION
### Summary of Changes
fix update join syntax for postgresql


### Testing Instructions

- with Content - Smart Search  plugin enabled
- index content
- unpublish/publish a category



### Expected result
no sql error


### Actual result
![screenshot from 2018-03-22 08-07-52](https://user-images.githubusercontent.com/181681/37756251-15e10502-2da9-11e8-82f3-d4d8ffc9ae45.png)




