### PR TITLE
Transition of Joomla's Wrapper from HTML4 to HTML5

### DIFF
--- a/components/com_wrapper/views/wrapper/tmpl/default.php
+++ b/components/com_wrapper/views/wrapper/tmpl/default.php
@@ -31,7 +31,7 @@ JHtml::_('script', 'com_wrapper/iframe-height.min.js', array('version' => 'auto'
 		style="width: <?php echo $this->escape($this->params->get('width')); ?>;
 		       height: <?php echo $this->escape($this->params->get('height')); ?>;
 		       overflow: <?php echo $this->escape($this->params->get('overflow')); ?>;
-		       border: <?php echo $this->escape($this->params->get('border', 1)); ?>;"
+		       border: <?php echo $this->escape($this->params->get('border')); ?>;"
 		<?php if ($this->escape($this->params->get('page_heading'))) : ?>
 			title="<?php echo $this->escape($this->params->get('page_heading')); ?>"
 		<?php else : ?>

--- a/components/com_wrapper/views/wrapper/tmpl/default.php
+++ b/components/com_wrapper/views/wrapper/tmpl/default.php
@@ -28,7 +28,10 @@ JHtml::_('script', 'com_wrapper/iframe-height.min.js', array('version' => 'auto'
 		id="blockrandom"
 		name="iframe"
 		src="<?php echo $this->escape($this->wrapper->url); ?>"
-		style="width: <?php echo $this->escape($this->params->get('width')); ?>; height: <?php echo $this->escape($this->params->get('height')); ?>; overflow: <?php echo $this->escape($this->params->get('overflow')); ?>; border: <?php echo $this->escape($this->params->get('border', 1)); ?>;"
+		style="width: <?php echo $this->escape($this->params->get('width')); ?>;
+		       height: <?php echo $this->escape($this->params->get('height')); ?>;
+		       overflow: <?php echo $this->escape($this->params->get('overflow')); ?>;
+		       border: <?php echo $this->escape($this->params->get('border', 1)); ?>;"
 		<?php if ($this->escape($this->params->get('page_heading'))) : ?>
 			title="<?php echo $this->escape($this->params->get('page_heading')); ?>"
 		<?php else : ?>

--- a/components/com_wrapper/views/wrapper/tmpl/default.php
+++ b/components/com_wrapper/views/wrapper/tmpl/default.php
@@ -28,10 +28,7 @@ JHtml::_('script', 'com_wrapper/iframe-height.min.js', array('version' => 'auto'
 		id="blockrandom"
 		name="iframe"
 		src="<?php echo $this->escape($this->wrapper->url); ?>"
-		width="<?php echo $this->escape($this->params->get('width')); ?>"
-		height="<?php echo $this->escape($this->params->get('height')); ?>"
-		scrolling="<?php echo $this->escape($this->params->get('scrolling')); ?>"
-		frameborder="<?php echo $this->escape($this->params->get('frameborder', 1)); ?>"
+		style="width <?php echo $this->escape($this->params->get('width')); ?>; height: <?php echo $this->escape($this->params->get('height')); ?>; overflow: <?php echo $this->escape($this->params->get('overflow')); ?>; border: <?php echo $this->escape($this->params->get('border', 1)); ?>;"
 		<?php if ($this->escape($this->params->get('page_heading'))) : ?>
 			title="<?php echo $this->escape($this->params->get('page_heading')); ?>"
 		<?php else : ?>

--- a/components/com_wrapper/views/wrapper/tmpl/default.php
+++ b/components/com_wrapper/views/wrapper/tmpl/default.php
@@ -28,7 +28,7 @@ JHtml::_('script', 'com_wrapper/iframe-height.min.js', array('version' => 'auto'
 		id="blockrandom"
 		name="iframe"
 		src="<?php echo $this->escape($this->wrapper->url); ?>"
-		style="width <?php echo $this->escape($this->params->get('width')); ?>; height: <?php echo $this->escape($this->params->get('height')); ?>; overflow: <?php echo $this->escape($this->params->get('overflow')); ?>; border: <?php echo $this->escape($this->params->get('border', 1)); ?>;"
+		style="width: <?php echo $this->escape($this->params->get('width')); ?>; height: <?php echo $this->escape($this->params->get('height')); ?>; overflow: <?php echo $this->escape($this->params->get('overflow')); ?>; border: <?php echo $this->escape($this->params->get('border', 1)); ?>;"
 		<?php if ($this->escape($this->params->get('page_heading'))) : ?>
 			title="<?php echo $this->escape($this->params->get('page_heading')); ?>"
 		<?php else : ?>

--- a/components/com_wrapper/views/wrapper/tmpl/default.xml
+++ b/components/com_wrapper/views/wrapper/tmpl/default.xml
@@ -88,15 +88,15 @@
 			</field>
 
 			<field 
-				name="frameborder"
+				name="border"
 				type="radio"
 				label="COM_WRAPPER_FIELD_FRAME_LABEL"
 				description="COM_WRAPPER_FIELD_FRAME_DESC"
 				class="btn-group btn-group-yesno"
-				default="1"
+				default="thin solid #D3D3D3"
 				>
-				<option value="1">JYES</option>
-				<option value="0">JNO</option>
+				<option value="thin solid #D3D3D3">JYES</option>
+				<option value="none">JNO</option>
 			</field>
 
 		</fieldset>

--- a/components/com_wrapper/views/wrapper/tmpl/default.xml
+++ b/components/com_wrapper/views/wrapper/tmpl/default.xml
@@ -29,14 +29,14 @@
 		<fieldset name="basic" label="COM_WRAPPER_FIELD_LABEL_SCROLLBARSPARAMS">
 
 			<field 
-				name="scrolling" 
+				name="overflow" 
 				type="list"
 				label="COM_WRAPPER_FIELD_SCROLLBARS_LABEL"
 				description="COM_WRAPPER_FIELD_SCROLLBARS_DESC"
 				default="auto"
 				>
-				<option value="no">JNO</option>
-				<option value="yes">JYES</option>
+				<option value="hidden">JNO</option>
+				<option value="scroll">JYES</option>
 				<option value="auto">COM_WRAPPER_FIELD_VALUE_AUTO</option>
 			</field>
 
@@ -51,10 +51,10 @@
 
 			<field 
 				name="height" 
-				type="number"
+				type="text"
 				label="COM_WRAPPER_FIELD_HEIGHT_LABEL"
 				description="COM_WRAPPER_FIELD_HEIGHT_DESC"
-				default="500"
+				default="500px"
 				size="5"
 			/>
 

--- a/modules/mod_wrapper/helper.php
+++ b/modules/mod_wrapper/helper.php
@@ -28,8 +28,8 @@ class ModWrapperHelper
 	public static function getParams(&$params)
 	{
 		$params->def('url', '');
-		$params->def('scrolling', 'auto');
-		$params->def('height', '200');
+		$params->def('overflow', 'auto');
+		$params->def('height', '200px');
 		$params->def('height_auto', '0');
 		$params->def('width', '100%');
 		$params->def('add', '1');

--- a/modules/mod_wrapper/mod_wrapper.php
+++ b/modules/mod_wrapper/mod_wrapper.php
@@ -19,9 +19,9 @@ $url             = htmlspecialchars($params->get('url'), ENT_COMPAT, 'UTF-8');
 $target          = htmlspecialchars($params->get('target'), ENT_COMPAT, 'UTF-8');
 $width           = htmlspecialchars($params->get('width'), ENT_COMPAT, 'UTF-8');
 $height          = htmlspecialchars($params->get('height'), ENT_COMPAT, 'UTF-8');
-$scroll          = htmlspecialchars($params->get('scrolling'), ENT_COMPAT, 'UTF-8');
+$overflow        = htmlspecialchars($params->get('overflow'), ENT_COMPAT, 'UTF-8');
 $moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
-$frameborder     = htmlspecialchars($params->get('frameborder'), ENT_COMPAT, 'UTF-8');
+$border          = htmlspecialchars($params->get('border'), ENT_COMPAT, 'UTF-8');
 $ititle          = $module->title;
 $id              = $module->id;
 

--- a/modules/mod_wrapper/mod_wrapper.xml
+++ b/modules/mod_wrapper/mod_wrapper.xml
@@ -91,10 +91,10 @@
 					label="MOD_WRAPPER_FIELD_FRAME_LABEL"
 					description="MOD_WRAPPER_FIELD_FRAME_DESC"
 					class="btn-group btn-group-yesno"
-					default="1"
+					default="thin solid #D3D3D3"
 					>
-					<option value="1">JYES</option>
-					<option value="0">JNO</option>
+					<option value="thin solid #D3D3D3">JYES</option>
+					<option value="none">JNO</option>
 				</field>
 
 				<field

--- a/modules/mod_wrapper/mod_wrapper.xml
+++ b/modules/mod_wrapper/mod_wrapper.xml
@@ -44,15 +44,15 @@
 				</field>
 
 				<field
-					name="scrolling"
+					name="overflow"
 					type="list"
 					label="MOD_WRAPPER_FIELD_SCROLL_LABEL"
 					description="MOD_WRAPPER_FIELD_SCROLL_DESC"
 					default="auto"
 					>
 					<option value="auto">MOD_WRAPPER_FIELD_VALUE_AUTO</option>
-					<option value="no">JNO</option>
-					<option value="yes">JYES</option>
+					<option value="hidden">JNO</option>
+					<option value="scroll">JYES</option>
 				</field>
 
 				<field
@@ -70,7 +70,7 @@
 					label="MOD_WRAPPER_FIELD_HEIGHT_LABEL"
 					description="MOD_WRAPPER_FIELD_HEIGHT_DESC"
 					size="5"
-					default="200"
+					default="200px"
 				/>
 
 				<field
@@ -86,7 +86,7 @@
 				</field>
 
 				<field
-					name="frameborder"
+					name="border"
 					type="radio"
 					label="MOD_WRAPPER_FIELD_FRAME_LABEL"
 					description="MOD_WRAPPER_FIELD_FRAME_DESC"

--- a/modules/mod_wrapper/tmpl/default.php
+++ b/modules/mod_wrapper/tmpl/default.php
@@ -15,7 +15,10 @@ JHtml::_('script', 'com_wrapper/iframe-height.min.js', array('version' => 'auto'
 	id="blockrandom-<?php echo $id; ?>"
 	name="<?php echo $target; ?>"
 	src="<?php echo $url; ?>"
-	style="width: <?php echo $width; ?>; height: <?php echo $height; ?>; overflow: <?php echo $overflow; ?>; border: <?php echo $border; ?>;"
+	style="width: <?php echo $width; ?>;
+	       height: <?php echo $height; ?>;
+	       overflow: <?php echo $overflow; ?>;
+	       border: <?php echo $border; ?>;"
 	title="<?php echo $ititle; ?>"
 	class="wrapper<?php echo $moduleclass_sfx; ?>" >
 	<?php echo JText::_('MOD_WRAPPER_NO_IFRAMES'); ?>

--- a/modules/mod_wrapper/tmpl/default.php
+++ b/modules/mod_wrapper/tmpl/default.php
@@ -15,10 +15,7 @@ JHtml::_('script', 'com_wrapper/iframe-height.min.js', array('version' => 'auto'
 	id="blockrandom-<?php echo $id; ?>"
 	name="<?php echo $target; ?>"
 	src="<?php echo $url; ?>"
-	width="<?php echo $width; ?>"
-	height="<?php echo $height; ?>"
-	scrolling="<?php echo $scroll; ?>"
-	frameborder="<?php echo $frameborder; ?>"
+	style="width: <?php echo $width; ?>; height: <?php echo $height; ?>; overflow: <?php echo $overflow; ?>; border: <?php echo $border; ?>;"
 	title="<?php echo $ititle; ?>"
 	class="wrapper<?php echo $moduleclass_sfx; ?>" >
 	<?php echo JText::_('MOD_WRAPPER_NO_IFRAMES'); ?>


### PR DESCRIPTION
### Summary of Changes

Made a transition in Joomla's IFRAME element from HTML4 to HTML5 standard

### Testing Instructions

Added wrapper modules on index.php and in menus (and/or submenus).
Using "px" or "%" in "height" field (required by HTML5 standard).

### Expected result

Working 100 %

### Actual result

Works like a charm, as seen @ [view-source:https://sflogistika.dobojcaffe.com/v2/](url) & [view-source:https://sflogistika.dobojcaffe.com/v2/index.php/video/srce-za-saobracajni](url)

### Documentation Changes Required

Need to modify 6 files to work without any problems or hiccups:

- modules/mod_wrapper/mod_wrapper.xml

- modules/mod_wrapper/mod_wrapper.php

- modules/mod_wrapper/helper.php

- modules/mod_wrapper/tmpl/default.php

- components/com_wrapper/views/wrapper/tmpl/default.xml

- components/com_wrapper/views/wrapper/tmpl/default.php