### PR TITLE
Add support for display docs and videos (same behaviour as J4) in the view used by media field

### DIFF
--- a/administrator/components/com_media/views/imageslist/tmpl/default.php
+++ b/administrator/components/com_media/views/imageslist/tmpl/default.php
@@ -47,8 +47,10 @@ else
 	);
 }
 ?>
-<?php if (count($this->images) > 0 || count($this->folders) > 0) : ?>
+<?php if (count($this->docs) > 0 || count($this->videos) > 0 || count($this->images) > 0 || count($this->folders) > 0) : ?>
+
 	<ul class="manager thumbnails thumbnails-media">
+
 		<?php for ($i = 0, $n = count($this->folders); $i < $n; $i++) :
 			$this->setFolder($i);
 			echo $this->loadTemplate('folder');
@@ -58,9 +60,23 @@ else
 			$this->setImage($i);
 			echo $this->loadTemplate('image');
 		endfor; ?>
+
+		<?php for ($i = 0, $n = count($this->videos); $i < $n; $i++) :
+			$this->setVideo($i);
+			echo $this->loadTemplate('video');
+		endfor; ?>
+
+		<?php for ($i = 0, $n = count($this->docs); $i < $n; $i++) :
+			$this->setDocument($i);
+			echo $this->loadTemplate('doc');
+		endfor; ?>
+
 	</ul>
+
 <?php else : ?>
+
 	<div id="media-noimages">
 		<div class="alert alert-info"><?php echo JText::_('COM_MEDIA_NO_IMAGES_FOUND'); ?></div>
 	</div>
+
 <?php endif; ?>

--- a/administrator/components/com_media/views/imageslist/tmpl/default_doc.php
+++ b/administrator/components/com_media/views/imageslist/tmpl/default_doc.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_media
+ *
+ * @copyright   Copyright (C) 2005 - 2018 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+use Joomla\Registry\Registry;
+
+$params     = new Registry;
+$dispatcher = JEventDispatcher::getInstance();
+$dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$this->_tmp_doc, &$params));
+?>
+
+<li class="imgOutline thumbnail height-80 width-80 center">
+	<a class="img-preview" href="javascript:ImageManager.populateFields('<?php echo $this->_tmp_doc->path_relative; ?>')" title="<?php echo $this->_tmp_doc->name; ?>" >
+		<div class="height-50">
+			<?php echo JHtml::_('image', $this->_tmp_doc->icon_32, $this->_tmp_doc->name, null, true, true) ? JHtml::_('image', $this->_tmp_doc->icon_32, $this->_tmp_doc->title, null, true) : JHtml::_('image', 'media/con_info.png', $this->_tmp_doc->name, null, true); ?>
+		</div>
+		<div class="small">
+			<?php echo JHtml::_('string.truncate', $this->_tmp_doc->name, 10, false); ?>
+		</div>
+	</a>
+</li>
+<?php
+$dispatcher->trigger('onContentAfterDisplay', array('com_media.file', &$this->_tmp_doc, &$params));

--- a/administrator/components/com_media/views/imageslist/tmpl/default_video.php
+++ b/administrator/components/com_media/views/imageslist/tmpl/default_video.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_media
+ *
+ * @copyright   Copyright (C) 2005 - 2018 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+use Joomla\Registry\Registry;
+
+$params     = new Registry;
+$dispatcher = JEventDispatcher::getInstance();
+$dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$this->_tmp_video, &$params));
+?>
+
+<li class="imgOutline thumbnail height-80 width-80 center">
+	<a class="img-preview" href="javascript:ImageManager.populateFields('<?php echo $this->_tmp_video->path_relative; ?>')" title="<?php echo $this->_tmp_video->name; ?>" >
+		<div class="height-50">
+			<?php echo JHtml::_('image', $this->_tmp_video->icon_32, $this->_tmp_video->title, null, true); ?>
+		</div>
+		<div class="small">
+			<?php echo JHtml::_('string.truncate', $this->_tmp_video->name, 10, false); ?>
+		</div>
+	</a>
+</li>
+<?php
+$dispatcher->trigger('onContentAfterDisplay', array('com_media.file', &$this->_tmp_video, &$params));

--- a/administrator/components/com_media/views/imageslist/view.html.php
+++ b/administrator/components/com_media/views/imageslist/view.html.php
@@ -30,13 +30,20 @@ class MediaViewImagesList extends JViewLegacy
 		// Do not allow cache
 		JFactory::getApplication()->allowCache(false);
 
+		$docs    = $this->get('documents');
+		$videos  = $this->get('videos');
 		$images  = $this->get('images');
 		$folders = $this->get('folders');
 		$state   = $this->get('state');
 
 		$this->baseURL = COM_MEDIA_BASEURL;
+
+		$this->docs    = &$docs;
+		$this->videos  = &$videos;
+		$this->videos  = &$videos;
 		$this->images  = &$images;
 		$this->folders = &$folders;
+
 		$this->state   = &$state;
 
 		parent::display($tpl);
@@ -81,6 +88,48 @@ class MediaViewImagesList extends JViewLegacy
 		else
 		{
 			$this->_tmp_img = new JObject;
+		}
+	}
+
+	/**
+	 * Set the active video
+	 *
+	 * @param   integer  $index  Image position
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function setVideo($index = 0)
+	{
+		if (isset($this->videos[$index]))
+		{
+			$this->_tmp_video = &$this->videos[$index];
+		}
+		else
+		{
+			$this->_tmp_video = new JObject;
+		}
+	}
+
+	/**
+	 * Set the active document
+	 *
+	 * @param   integer  $index  Image position
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function setDocument($index = 0)
+	{
+		if (isset($this->docs[$index]))
+		{
+			$this->_tmp_doc = &$this->docs[$index];
+		}
+		else
+		{
+			$this->_tmp_doc = new JObject;
 		}
 	}
 }

--- a/administrator/components/com_media/views/imageslist/view.html.php
+++ b/administrator/components/com_media/views/imageslist/view.html.php
@@ -40,7 +40,6 @@ class MediaViewImagesList extends JViewLegacy
 
 		$this->docs    = &$docs;
 		$this->videos  = &$videos;
-		$this->videos  = &$videos;
 		$this->images  = &$images;
 		$this->folders = &$folders;
 

--- a/administrator/components/com_media/views/imageslist/view.html.php
+++ b/administrator/components/com_media/views/imageslist/view.html.php
@@ -93,11 +93,11 @@ class MediaViewImagesList extends JViewLegacy
 	/**
 	 * Set the active video
 	 *
-	 * @param   integer  $index  Image position
+	 * @param   integer  $index  Video position
 	 *
 	 * @return  void
 	 *
-	 * @since   1.0
+	 * @since   __DEPLOY_VERSION__
 	 */
 	public function setVideo($index = 0)
 	{
@@ -114,11 +114,11 @@ class MediaViewImagesList extends JViewLegacy
 	/**
 	 * Set the active document
 	 *
-	 * @param   integer  $index  Image position
+	 * @param   integer  $index  Document position
 	 *
 	 * @return  void
 	 *
-	 * @since   1.0
+	 * @since   __DEPLOY_VERSION__
 	 */
 	public function setDocument($index = 0)
 	{

--- a/administrator/templates/isis/html/com_media/imageslist/default_doc.php
+++ b/administrator/templates/isis/html/com_media/imageslist/default_doc.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_media
+ *
+ * @copyright   Copyright (C) 2005 - 2018 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+use Joomla\Registry\Registry;
+
+$params     = new Registry;
+$dispatcher = JEventDispatcher::getInstance();
+$dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$this->_tmp_doc, &$params));
+?>
+
+<li class="imgOutline thumbnail height-80 width-80 center">
+	<a class="img-preview" href="javascript:ImageManager.populateFields('<?php echo $this->_tmp_doc->path_relative; ?>')" title="<?php echo $this->_tmp_doc->name; ?>" >
+		<div class="imgThumb">
+			<div class="imgThumbInside">
+			<?php echo JHtml::_('image', $this->_tmp_doc->icon_32, $this->_tmp_doc->name, null, true, true) ? JHtml::_('image', $this->_tmp_doc->icon_32, $this->_tmp_doc->title, null, true) : JHtml::_('image', 'media/con_info.png', $this->_tmp_doc->name, null, true); ?>
+			</div>
+		</div>
+		<div class="imgDetails small">
+			<?php echo JHtml::_('string.truncate', $this->_tmp_doc->name, 10, false); ?>
+		</div>
+	</a>
+</li>
+<?php
+$dispatcher->trigger('onContentAfterDisplay', array('com_media.file', &$this->_tmp_doc, &$params));

--- a/administrator/templates/isis/html/com_media/imageslist/default_video.php
+++ b/administrator/templates/isis/html/com_media/imageslist/default_video.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_media
+ *
+ * @copyright   Copyright (C) 2005 - 2018 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+use Joomla\Registry\Registry;
+
+$params     = new Registry;
+$dispatcher = JEventDispatcher::getInstance();
+$dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$this->_tmp_video, &$params));
+?>
+
+<li class="imgOutline thumbnail height-80 width-80 center">
+	<a class="img-preview" href="javascript:ImageManager.populateFields('<?php echo $this->_tmp_video->path_relative; ?>')" title="<?php echo $this->_tmp_video->name; ?>" >
+		<div class="imgThumb">
+			<div class="imgThumbInside">
+			<?php echo JHtml::_('image', $this->_tmp_video->icon_32, $this->_tmp_video->title, null, true); ?>
+			</div>
+		</div>
+		<div class="imgDetails small">
+			<?php echo JHtml::_('string.truncate', $this->_tmp_video->name, 10, false); ?>
+		</div>
+	</a>
+</li>
+<?php
+$dispatcher->trigger('onContentAfterDisplay', array('com_media.file', &$this->_tmp_video, &$params));

--- a/templates/protostar/html/com_media/imageslist/default_doc.php
+++ b/templates/protostar/html/com_media/imageslist/default_doc.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_media
+ *
+ * @copyright   Copyright (C) 2005 - 2018 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+use Joomla\Registry\Registry;
+
+$params     = new Registry;
+$dispatcher = JEventDispatcher::getInstance();
+$dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$this->_tmp_doc, &$params));
+?>
+
+<li class="imgOutline thumbnail height-80 width-80 center">
+	<a class="img-preview" href="javascript:ImageManager.populateFields('<?php echo $this->_tmp_doc->path_relative; ?>')" title="<?php echo $this->_tmp_doc->name; ?>" >
+		<div class="imgThumb">
+			<div class="imgThumbInside">
+			<?php echo JHtml::_('image', $this->_tmp_doc->icon_32, $this->_tmp_doc->name, null, true, true) ? JHtml::_('image', $this->_tmp_doc->icon_32, $this->_tmp_doc->title, null, true) : JHtml::_('image', 'media/con_info.png', $this->_tmp_doc->name, null, true); ?>
+			</div>
+		</div>
+		<div class="imgDetails small">
+			<?php echo JHtml::_('string.truncate', $this->_tmp_doc->name, 10, false); ?>
+		</div>
+	</a>
+</li>
+<?php
+$dispatcher->trigger('onContentAfterDisplay', array('com_media.file', &$this->_tmp_doc, &$params));

--- a/templates/protostar/html/com_media/imageslist/default_video.php
+++ b/templates/protostar/html/com_media/imageslist/default_video.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_media
+ *
+ * @copyright   Copyright (C) 2005 - 2018 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+use Joomla\Registry\Registry;
+
+$params     = new Registry;
+$dispatcher = JEventDispatcher::getInstance();
+$dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$this->_tmp_video, &$params));
+?>
+
+<li class="imgOutline thumbnail height-80 width-80 center">
+	<a class="img-preview" href="javascript:ImageManager.populateFields('<?php echo $this->_tmp_video->path_relative; ?>')" title="<?php echo $this->_tmp_video->name; ?>" >
+		<div class="imgThumb">
+			<div class="imgThumbInside">
+			<?php echo JHtml::_('image', $this->_tmp_video->icon_32, $this->_tmp_video->title, null, true); ?>
+			</div>
+		</div>
+		<div class="imgDetails small">
+			<?php echo JHtml::_('string.truncate', $this->_tmp_video->name, 10, false); ?>
+		</div>
+	</a>
+</li>
+<?php
+$dispatcher->trigger('onContentAfterDisplay', array('com_media.file', &$this->_tmp_video, &$params));


### PR DESCRIPTION
Pull Request for Issues #10871 , #17475 , #19954

### Summary of Changes
Added template files for documents and videos to the **com_media** view (**imageslist**) used by media field
Added template overrides to backend **isis** template
Added template overrides to frontend **protostar** template


### Testing Instructions
1. (At Media Manager options)
Add `pdf,mp4,PDF,MP4` to Legal Extensions
Add `application/pdf,video/mp4` to Legal MIME types

2. Open an article and go to TAB `image and links`, click to select an image 

3. Upload a PDF file and an MP4 file, click on each of them so that they get selected and click "Insert"


### Expected result
The files are uploaded and shown and insertable


### Actual result
The files are uploaded but not shown / not insertable


### Documentation Changes Required

YES

