### PR TITLE
[4.0 dev] Error Class JFactory not found on frontend article editing

### DIFF
--- a/administrator/components/com_content/Service/HTML/Icon.php
+++ b/administrator/components/com_content/Service/HTML/Icon.php
@@ -17,7 +17,7 @@ use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
 use Joomla\Registry\Registry;
-
+use Joomla\CMS\Factory;
 /**
  * Content Component HTML Helper
  *
@@ -134,8 +134,8 @@ class Icon
 	 */
 	public function edit($article, $params, $attribs = array(), $legacy = false)
 	{
-		$user = JFactory::getUser();
-		$uri  = JUri::getInstance();
+		$user = Factory::getUser();
+		$uri  = Uri::getInstance();
 
 		// Ignore if in a popup window.
 		if ($params && $params->get('popup'))


### PR DESCRIPTION
After editing an article in frontend, error Class 'Joomla\Component\Content\Administrator\Service\HTML\JFactory' not found

Missing Factory declaration, JFactory and JUri classes are still called.

Pull Request for Issue # .

### Summary of Changes



### Testing Instructions



### Expected result



### Actual result



### Documentation Changes Required

