### PR TITLE
Merge Script Options recursive

### DIFF
--- a/libraries/src/Document/Document.php
+++ b/libraries/src/Document/Document.php
@@ -612,7 +612,7 @@ class Document
 
 		if ($merge && is_array($options))
 		{
-			$this->scriptOptions[$key] = array_merge($this->scriptOptions[$key], $options);
+			$this->scriptOptions[$key] = array_replace_recursive($this->scriptOptions[$key], $options);
 		}
 		else
 		{


### PR DESCRIPTION
### Summary of Changes
With the JDocument::addScriptOptions method it's possible to change script parameters like the TinyMCE plugin parameters from outside (like with a plugin). This functionality was implemented with the following PR: https://github.com/joomla/joomla-cms/pull/3072 and in the TinyMCE here: https://github.com/joomla/joomla-cms/pull/11157 (with examples)

The problem at the moment is, that the "new parameters" will only be merged on the first level, so for example for the TinyMCE you cannot change parameters of deeper level in an easy way.

### Testing Instructions

Add the following code into your template index file:

```
$options = [
    'foo' => [
        'bar' => [
			'bla' => 1,
		],
		'baz' => [
			'blub' => 2
		]
    ]
];

JFactory::getDocument()->addScriptOptions('Foobar', $options);

// Update the foo => bar => bla value
$options = [
	'foo' => [
        	'bar' => [
			'bla' => 2,
		]
	]
];

JFactory::getDocument()->addScriptOptions('Foobar', $options);
```

### Expected result
```
    "Foobar": {
        "foo": {
            "bar": {
                "bla": 2
            },
            "baz": {
                "blub": 2
            }
        }
    }
```

### Actual result
```
    "Foobar": {
        "foo": {
            "bar": {
                "bla": 2
            }
        }
    }
```

### More description
This example is very small, but e.g. the tinyMCE has somewhere about 50 parameters with a level of 3 or more. If you want to change one parameter in the depth, you have to rebuild the whole tree (or load the current tree, setup the variables  and then set again), which makes the "merge" a bit useless.

Perhaps @Fedik and @dgt41 could look over this functionality, because they worked with it.

