### PR TITLE
Removed text-output and enabled a disabled tick box for consistency

### DIFF
--- a/administrator/components/com_users/views/users/tmpl/default.php
+++ b/administrator/components/com_users/views/users/tmpl/default.php
@@ -123,14 +123,14 @@ $debugUsers = $this->state->get('params')->get('debugUsers', 1);
 							<?php echo $this->escape($item->username); ?>
 						</td>
 						<td class="center">
-							<?php if ($canChange) : ?>
-								<?php
-								$self = $loggeduser->id == $item->id;
+							<?php
+							$self = $loggeduser->id == $item->id;
+
+							if ($canChange) :
 								echo JHtml::_('jgrid.state', JHtmlUsers::blockStates($self), $item->block, $i, 'users.', !$self);
-								?>
-							<?php else : ?>
-								<?php echo JText::_($item->block ? 'JNO' : 'JYES'); ?>
-							<?php endif; ?>
+							else :
+								echo JHtml::_('jgrid.state', JHtmlUsers::blockStates($self), $item->block, $i, 'users.', false);
+							endif; ?>
 						</td>
 						<td class="center hidden-phone">
 							<?php


### PR DESCRIPTION
Pull Request for Issue #19765 .

### Summary of Changes
At present if the user cannot block/unblock users in the backend they are shown a Yes/No for the sate instead of a disabled icon. 

This resolved that by displaying the correct icon. 