### PR TITLE
[#18724] [4.0] Offsets separated by white space(s) are deprecated, use a comma (,) instead

### DIFF
--- a/libraries/cms/html/bootstrap.php
+++ b/libraries/cms/html/bootstrap.php
@@ -256,7 +256,7 @@ abstract class JHtmlBootstrap
 		$opt['title']       = isset($params['title']) ? $params['title'] : null;
 		$opt['trigger']     = isset($params['trigger']) ? $params['trigger'] : 'hover focus';
 		$opt['constraints'] = isset($params['constraints']) ? $params['constraints'] : ['to' => 'scrollParent', 'attachment' => 'together', 'pin' => true];
-		$opt['offset']      = isset($params['offset']) ? $params['offset'] : '0 0';
+		$opt['offset']      = isset($params['offset']) ? $params['offset'] : '0,0';
 
 
 		$opt     = (object) array_filter((array) $opt);


### PR DESCRIPTION
[SOLVED] [#18724] - [4.0] Offsets separated by white space(s) are deprecated, use a comma (,) instead.

Pull Request for Issue #18724 .

### Summary of Changes

the hardcoded offsets were separated using a whitespace. replaced it with a comma

### Testing Instructions

mouse over a popover

### Expected result

no errors generated

### Actual result

no errors generated

### Documentation Changes Required

none