### PR TITLE
[#19461] [4.0] Image manipulation broken when inserting image in article

### DIFF
--- a/administrator/components/com_media/tmpl/media/default.php
+++ b/administrator/components/com_media/tmpl/media/default.php
@@ -39,7 +39,7 @@ $config = array(
 	'filePath'                => $params->get('file_path', 'images'),
 	'fileBaseUrl'             => JUri::root() . $params->get('file_path', 'images'),
 	'fileBaseRelativeUrl'     => $params->get('file_path', 'images'),
-	'editViewUrl'             => JUri::root() . 'administrator/index.php?option=com_media&view=file' . $tmpl,
+	'editViewUrl'             => JUri::root() . 'administrator/index.php?option=com_media&view=file&tmpl=' . $tmpl,
 	'allowedUploadExtensions' => $params->get('upload_extensions', ''),
 	'maxUploadSizeMb'         => $params->get('upload_maxsize', 10),
 	'providers'               => (array) $this->providers,


### PR DESCRIPTION
Image manipulation broken when inserting image in article

Pull Request for Issue #19461  .

### Summary of Changes

modified the value of the URL for the edit button

### Testing Instructions

try inserting an image in an article after clicking the edit button

### Expected result

the image should get edited and inserted

### Actual result

the image doesn't get inserted but the editing options do work

### Documentation Changes Required

none