### PR TITLE
[com_fields] List field to always return array.

### DIFF
--- a/administrator/components/com_fields/helpers/fields.php
+++ b/administrator/components/com_fields/helpers/fields.php
@@ -187,11 +187,6 @@ class FieldsHelper
 
 				$field->rawvalue = $field->value;
 
-				// List fields need to always be an array.
-				if ($field->type === 'list' && !is_array($field->value)) {
-					$field->rawvalue = (array) $field->value;
-				}
-
 				if ($prepareValue)
 				{
 					JPluginHelper::importPlugin('fields');

--- a/administrator/components/com_fields/helpers/fields.php
+++ b/administrator/components/com_fields/helpers/fields.php
@@ -187,6 +187,11 @@ class FieldsHelper
 
 				$field->rawvalue = $field->value;
 
+				// List fields need to always be an array.
+				if ($field->type === 'list' && !is_array($field->value)) {
+					$field->rawvalue = (array) $field->value;
+				}
+
 				if ($prepareValue)
 				{
 					JPluginHelper::importPlugin('fields');

--- a/administrator/components/com_fields/helpers/fields.php
+++ b/administrator/components/com_fields/helpers/fields.php
@@ -193,7 +193,7 @@ class FieldsHelper
 
 					$dispatcher = JEventDispatcher::getInstance();
 
-					// Event allow plugins to modfify the output of the field before it is prepared
+					// Event allow plugins to modify the output of the field before it is prepared
 					$dispatcher->trigger('onCustomFieldsBeforePrepareField', array($context, $item, &$field));
 
 					// Gathering the value for the field
@@ -204,7 +204,7 @@ class FieldsHelper
 						$value = implode(' ', $value);
 					}
 
-					// Event allow plugins to modfify the output of the prepared field
+					// Event allow plugins to modify the output of the prepared field
 					$dispatcher->trigger('onCustomFieldsAfterPrepareField', array($context, $item, $field, &$value));
 
 					// Assign the value

--- a/plugins/fields/list/list.php
+++ b/plugins/fields/list/list.php
@@ -19,13 +19,13 @@ JLoader::import('components.com_fields.libraries.fieldslistplugin', JPATH_ADMINI
 class PlgFieldsList extends FieldsListPlugin
 {
 	/**
-	 * Prepares the field value.
+	 * Prepares the field
 	 *
 	 * @param   string    $context  The context.
 	 * @param   stdclass  $item     The item.
 	 * @param   stdclass  $field    The field.
 	 *
-	 * @return  array
+	 * @return  object
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */

--- a/plugins/fields/list/list.php
+++ b/plugins/fields/list/list.php
@@ -18,4 +18,26 @@ JLoader::import('components.com_fields.libraries.fieldslistplugin', JPATH_ADMINI
  */
 class PlgFieldsList extends FieldsListPlugin
 {
+	/**
+	 * Prepares the field value.
+	 *
+	 * @param   string    $context  The context.
+	 * @param   stdclass  $item     The item.
+	 * @param   stdclass  $field    The field.
+	 *
+	 * @return  string
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function onCustomFieldsPrepareField($context, $item, $field)
+	{
+
+		// rawvalue should be an array
+		if(!is_array($field->rawvalue))
+		{
+			$field->rawvalue = (array) $field->rawvalue;
+		}
+
+		return parent::onCustomFieldsPrepareField($context, $item, $field);
+	}
 }

--- a/plugins/fields/list/list.php
+++ b/plugins/fields/list/list.php
@@ -31,6 +31,12 @@ class PlgFieldsList extends FieldsListPlugin
 	 */
 	public function onCustomFieldsPrepareField($context, $item, $field)
 	{
+		// Check if the field should be processed
+		if (!$this->isTypeSupported($field->type))
+		{
+			return;
+		}
+		
 		// The field's rawvalue should be an array
 		if (!is_array($field->rawvalue))
 		{

--- a/plugins/fields/list/list.php
+++ b/plugins/fields/list/list.php
@@ -36,7 +36,7 @@ class PlgFieldsList extends FieldsListPlugin
 		{
 			return;
 		}
-		
+	
 		// The field's rawvalue should be an array
 		if (!is_array($field->rawvalue))
 		{

--- a/plugins/fields/list/list.php
+++ b/plugins/fields/list/list.php
@@ -25,7 +25,7 @@ class PlgFieldsList extends FieldsListPlugin
 	 * @param   stdclass  $item     The item.
 	 * @param   stdclass  $field    The field.
 	 *
-	 * @return  string
+	 * @return  array
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */

--- a/plugins/fields/list/list.php
+++ b/plugins/fields/list/list.php
@@ -32,7 +32,7 @@ class PlgFieldsList extends FieldsListPlugin
 	public function onCustomFieldsPrepareField($context, $item, $field)
 	{
 
-		// rawvalue should be an array
+		// The fields rawvalue should be an array
 		if(!is_array($field->rawvalue))
 		{
 			$field->rawvalue = (array) $field->rawvalue;

--- a/plugins/fields/list/list.php
+++ b/plugins/fields/list/list.php
@@ -31,9 +31,8 @@ class PlgFieldsList extends FieldsListPlugin
 	 */
 	public function onCustomFieldsPrepareField($context, $item, $field)
 	{
-
-		// The fields rawvalue should be an array
-		if(!is_array($field->rawvalue))
+		// The field's rawvalue should be an array
+		if (!is_array($field->rawvalue))
 		{
 			$field->rawvalue = (array) $field->rawvalue;
 		}

--- a/plugins/fields/list/list.php
+++ b/plugins/fields/list/list.php
@@ -37,6 +37,7 @@ class PlgFieldsList extends FieldsListPlugin
 			return;
 		}
 		// The field's rawvalue should be an array
+
 		if (!is_array($field->rawvalue))
 		{
 			$field->rawvalue = (array) $field->rawvalue;

--- a/plugins/fields/list/list.php
+++ b/plugins/fields/list/list.php
@@ -36,8 +36,8 @@ class PlgFieldsList extends FieldsListPlugin
 		{
 			return;
 		}
-		// The field's rawvalue should be an array
 
+		// The field's rawvalue should be an array
 		if (!is_array($field->rawvalue))
 		{
 			$field->rawvalue = (array) $field->rawvalue;

--- a/plugins/fields/list/list.php
+++ b/plugins/fields/list/list.php
@@ -36,7 +36,6 @@ class PlgFieldsList extends FieldsListPlugin
 		{
 			return;
 		}
-	
 		// The field's rawvalue should be an array
 		if (!is_array($field->rawvalue))
 		{


### PR DESCRIPTION
Pull Request for Issue #16177.

List custom field rawvalue should always return an array.

### Summary of Changes
Added a check and convert string to array  if needed.

### Testing Instructions
RawValue should always return as an array for list, so var_dump() on jcfields ie with:

```
echo '<pre>';
var_dump($this->item->jcfields);
die;
```

the list type should always be an array with 1 value or two.

### Expected result
RawValue should always return as an array for list

### Actual result
RawValue is a string if only 1 value is selected.