### PR TITLE
Change to allow str_pos to match when the exclude term is at the root…

### DIFF
--- a/plugins/system/redirect/redirect.php
+++ b/plugins/system/redirect/redirect.php
@@ -169,7 +169,7 @@ class PlgSystemRedirect extends JPlugin
 			}
 			else
 			{
-				if (StringHelper::strpos(' ' . $orgurlRel, $exclude->term))
+				if (StringHelper::strpos($orgurlRel, $exclude->term) !== false)
 				{
 					$skipUrl = true;
 					break;

--- a/plugins/system/redirect/redirect.php
+++ b/plugins/system/redirect/redirect.php
@@ -169,7 +169,7 @@ class PlgSystemRedirect extends JPlugin
 			}
 			else
 			{
-				if (StringHelper::strpos($orgurlRel, $exclude->term))
+				if (StringHelper::strpos(' ' . $orgurlRel, $exclude->term))
 				{
 					$skipUrl = true;
 					break;


### PR DESCRIPTION
… of the path

Pull Request for Issue #19973 .

### Summary of Changes
add a space beginning of the heystack,
str_pos seems to fail when begining with a / in the heystack so begin with a space followed by a /

### Testing Instructions
Add:

/bogus/

to a url in your site, it should 404.

Now delete the 404, add /bogus/ to the exclusion list 

Access the /bogus/ url again.

### Expected result
404 and not add to the com_redirects

### Actual result
404 and adds to the com_redirects. 