### PR TITLE
[module] [articles category] filter by multiple tags

### DIFF
--- a/modules/mod_articles_category/helper.php
+++ b/modules/mod_articles_category/helper.php
@@ -189,7 +189,7 @@ abstract class ModArticlesCategoryHelper
 				break;
 		}
 
-		// Filter by multple tags
+		// Filter by multiple tags
 		$articles->setState('filter.tag', $params->get('filter_tag', array()));
 
 		$articles->setState('filter.featured', $params->get('show_front', 'show'));

--- a/modules/mod_articles_category/helper.php
+++ b/modules/mod_articles_category/helper.php
@@ -189,11 +189,8 @@ abstract class ModArticlesCategoryHelper
 				break;
 		}
 
-		// New Parameters
-		if ($params->get('filter_tag', ''))
-		{
-			$articles->setState('filter.tag', $params->get('filter_tag', ''));
-		}
+		// Filter by multple tags
+		$articles->setState('filter.tag', $params->get('filter_tag', array()));
 
 		$articles->setState('filter.featured', $params->get('show_front', 'show'));
 		$articles->setState('filter.author_id', $params->get('created_by', ''));

--- a/modules/mod_articles_category/mod_articles_category.xml
+++ b/modules/mod_articles_category/mod_articles_category.xml
@@ -137,10 +137,11 @@
 					name="filter_tag"
 					type="tag"
 					label="JTAG"
-				       	description="JTAG_FIELD_SELECT_DESC"
-					>
-					<option value="">JNONE</option>
-				</field>
+					description="JTAG_FIELD_SELECT_DESC"
+					mode="nested"
+					multiple="true"
+					class="multipleTags"
+				/>
 
 				<field
 					name="filteringspacer2"


### PR DESCRIPTION
Pull Request for Issue #19885 .

### Summary of Changes
added multiple tags selection filter


### Testing Instructions
go to Extensions->Modules
select Articles - Category module
go to Filtering options tab
select multiple tags
![screenshot from 2018-03-25 09-45-49](https://user-images.githubusercontent.com/181681/37872911-5a8bbc0a-3011-11e8-9a07-6dfa98029815.png)
verify on frontend that the module shows items accordingly





### Expected result
you can select multiple tags


### Actual result
you can select one tag only