### PR TITLE
[4.0] Various adjustments in database driver checks

### DIFF
--- a/installation/forms/setup.xml
+++ b/installation/forms/setup.xml
@@ -78,7 +78,7 @@
 				label="INSTL_DATABASE_TYPE_DESC"
 				supported="mysql,mysqli,pgsql,postgresql"
 				required="true"
-				default="mysql"
+				default="mysqli"
 				filter="string"
 		/>
 		<field

--- a/installation/src/Form/Field/Installation/SampleField.php
+++ b/installation/src/Form/Field/Installation/SampleField.php
@@ -41,9 +41,13 @@ class SampleField extends RadioField
 		$type    = $this->form->getValue('db_type');
 
 		// Some database drivers share DDLs; point these drivers to the correct parent
-		if ($type === 'mysqli' || $type === 'pdomysql')
+		if ($type === 'mysqli')
 		{
 			$type = 'mysql';
+		}
+		elseif ($type === 'pgsql')
+		{
+			$type = 'postgresql';
 		}
 
 		// Get a list of files in the search path with the given filter.

--- a/installation/src/Model/DatabaseModel.php
+++ b/installation/src/Model/DatabaseModel.php
@@ -15,9 +15,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Installation\Helper\DatabaseHelper;
 use Joomla\CMS\Installer\Installer;
 use Joomla\CMS\Language\LanguageHelper;
-use Joomla\Database\DatabaseDriver;
 use Joomla\Database\DatabaseInterface;
-use Joomla\Database\Exception\ExecutionFailureException;
 use Joomla\Database\UTF8MB4SupportInterface;
 use Joomla\Utilities\ArrayHelper;
 
@@ -175,8 +173,8 @@ class DatabaseModel extends BaseInstallationModel
 			return false;
 		}
 
-		// Workaround for UPPERCASE table prefix for postgresql
-		if ($options->db_type == 'postgresql')
+		// Workaround for UPPERCASE table prefix for PostgreSQL
+		if (in_array($options->db_type, ['pgsql', 'postgresql']))
 		{
 			if (isset($options->db_prefix) && strtolower($options->db_prefix) !== $options->db_prefix)
 			{
@@ -340,7 +338,7 @@ class DatabaseModel extends BaseInstallationModel
 			 * PDO MySQL: [1049] Unknown database 'database_name'
 			 * PostgreSQL: Error connecting to PGSQL database
 			 */
-			if ($type === 'pdomysql' && strpos($e->getMessage(), '[1049] Unknown database') === 42)
+			if ($type === 'mysql' && strpos($e->getMessage(), '[1049] Unknown database') === 42)
 			{
 				/*
 				 * Now we're really getting insane here; we're going to try building a new JDatabaseDriver instance without the database name
@@ -395,15 +393,6 @@ class DatabaseModel extends BaseInstallationModel
 			throw new \RuntimeException(\JText::sprintf('INSTL_DATABASE_INVALID_' . strtoupper($type) . '_VERSION', $db_version));
 		}
 
-		if ($db->getServerType() === 'mysql')
-		{
-			// @internal MySQL versions pre 5.1.6 forbid . / or \ or NULL.
-			if (preg_match('#[\\\/\.\0]#', $options->db_name) && (!version_compare($db_version, '5.1.6', '>=')))
-			{
-				throw new \RuntimeException(\JText::sprintf('INSTL_DATABASE_INVALID_NAME', $db_version));
-			}
-		}
-
 		// @internal Check for spaces in beginning or end of name.
 		if (strlen(trim($options->db_name)) <> strlen($options->db_name))
 		{
@@ -414,37 +403,6 @@ class DatabaseModel extends BaseInstallationModel
 		if (strpos($options->db_name, chr(00)) !== false)
 		{
 			throw new \RuntimeException(\JText::_('INSTL_DATABASE_NAME_INVALID_CHAR'));
-		}
-
-		// PostgreSQL database older than version 9.0.0 needs to run 'CREATE LANGUAGE' to create function.
-		if ($db->getServerType() === 'postgresql' && !version_compare($db_version, '9.0.0', '>='))
-		{
-			$db->setQuery("select lanpltrusted from pg_language where lanname='plpgsql'");
-
-			try
-			{
-				$db->execute();
-			}
-			catch (\RuntimeException $e)
-			{
-				throw new \RuntimeException(\JText::_('INSTL_DATABASE_ERROR_POSTGRESQL_QUERY'), 500, $e);
-			}
-
-			$column = $db->loadResult();
-
-			if ($column != 't')
-			{
-				$db->setQuery('CREATE LANGUAGE plpgsql');
-
-				try
-				{
-					$db->execute();
-				}
-				catch (\RuntimeException $e)
-				{
-					throw new \RuntimeException(\JText::_('INSTL_DATABASE_ERROR_POSTGRESQL_QUERY'), 500, $e);
-				}
-			}
 		}
 
 		// Get database's UTF support.
@@ -576,15 +534,10 @@ class DatabaseModel extends BaseInstallationModel
 			// Continue Anyhow
 		}
 
+		$serverType = $db->getServerType();
+
 		// Set the appropriate schema script based on UTF-8 support.
-		if ($db->getServerType() === 'mysql')
-		{
-			$schema = 'sql/mysql/joomla.sql';
-		}
-		else
-		{
-			$schema = 'sql/' . $type . '/joomla.sql';
-		}
+		$schema = 'sql/' . $serverType . '/joomla.sql';
 
 		// Check if the schema is a valid file
 		if (!is_file($schema))
@@ -604,8 +557,6 @@ class DatabaseModel extends BaseInstallationModel
 		$query = $db->getQuery(true);
 
 		// MySQL only: Attempt to update the table #__utf8_conversion.
-		$serverType = $db->getServerType();
-
 		if ($serverType === 'mysql')
 		{
 			$query->clear()
@@ -626,16 +577,7 @@ class DatabaseModel extends BaseInstallationModel
 		}
 
 		// Attempt to update the table #__schema.
-		$pathPart = JPATH_ADMINISTRATOR . '/components/com_admin/sql/updates/';
-
-		if ($serverType === 'mysql')
-		{
-			$pathPart .= 'mysql/';
-		}
-		else
-		{
-			$pathPart .= $type . '/';
-		}
+		$pathPart = JPATH_ADMINISTRATOR . '/components/com_admin/sql/updates/' . $serverType . '/';
 
 		$files = \JFolder::files($pathPart, '\.sql$');
 
@@ -710,14 +652,7 @@ class DatabaseModel extends BaseInstallationModel
 		}
 
 		// Load the localise.sql for translating the data in joomla.sql.
-		if ($serverType === 'mysql')
-		{
-			$dblocalise = 'sql/mysql/localise.sql';
-		}
-		else
-		{
-			$dblocalise = 'sql/' . $type . '/localise.sql';
-		}
+		$dblocalise = 'sql/' . $serverType . '/localise.sql';
 
 		if (is_file($dblocalise))
 		{
@@ -806,12 +741,7 @@ class DatabaseModel extends BaseInstallationModel
 		}
 
 		// Build the path to the sample data file.
-		$type = $options->db_type;
-
-		if ($db->getServerType() === 'mysql')
-		{
-			$type = 'mysql';
-		}
+		$type = $db->getServerType();
 
 		if (Factory::getApplication()->input->get('sample_file', ''))
 		{
@@ -1187,15 +1117,18 @@ class DatabaseModel extends BaseInstallationModel
 				 * Note: the JDatabaseDriver::convertUtf8mb4QueryToUtf8 performs the conversion ONLY when
 				 * necessary, so there's no need to check the conditions in JInstaller.
 				 */
-				$query = $db->convertUtf8mb4QueryToUtf8($query);
-
-				/**
-				 * This is a query which was supposed to convert tables to utf8mb4 charset but the server doesn't
-				 * support utf8mb4. Therefore we don't have to run it, it has no effect and it's a mere waste of time.
-				 */
-				if (!$db->hasUTF8mb4Support() && stristr($query, 'CONVERT TO CHARACTER SET utf8 '))
+				if ($db instanceof UTF8MB4SupportInterface)
 				{
-					continue;
+					$query = $db->convertUtf8mb4QueryToUtf8($query);
+
+					/**
+					 * This is a query which was supposed to convert tables to utf8mb4 charset but the server doesn't
+					 * support utf8mb4. Therefore we don't have to run it, it has no effect and it's a mere waste of time.
+					 */
+					if (!$db->hasUTF8mb4Support() && stristr($query, 'CONVERT TO CHARACTER SET utf8 '))
+					{
+						continue;
+					}
 				}
 
 				// Execute the query.

--- a/installation/src/Model/SetupModel.php
+++ b/installation/src/Model/SetupModel.php
@@ -17,6 +17,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Installation\Helper\DatabaseHelper;
 use Joomla\CMS\Language\LanguageHelper;
+use Joomla\Database\UTF8MB4SupportInterface;
 use Joomla\Utilities\ArrayHelper;
 
 /**
@@ -377,7 +378,7 @@ class SetupModel extends BaseInstallationModel
 		}
 
 		// Workaround for UPPERCASE table prefix for postgresql
-		if ($options->db_type == 'postgresql')
+		if (in_array($options->db_type, ['pgsql', 'postgresql']))
 		{
 			if (strtolower($options->db_prefix) != $options->db_prefix)
 			{
@@ -461,7 +462,7 @@ class SetupModel extends BaseInstallationModel
 			 * PDO MySQL: [1049] Unknown database 'database_name'
 			 * PostgreSQL: Error connecting to PGSQL database
 			 */
-			if ($type == 'pdomysql' && strpos($e->getMessage(), '[1049] Unknown database') === 42)
+			if ($type == 'mysql' && strpos($e->getMessage(), '[1049] Unknown database') === 42)
 			{
 				/*
 				 * Now we're really getting insane here; we're going to try building a new JDatabaseDriver instance without the database name
@@ -516,15 +517,6 @@ class SetupModel extends BaseInstallationModel
 			throw new \RuntimeException(\JText::sprintf('INSTL_DATABASE_INVALID_' . strtoupper($type) . '_VERSION', $db_version));
 		}
 
-		if ($db->getServerType() === 'mysql')
-		{
-			// @internal MySQL versions pre 5.1.6 forbid . / or \ or NULL.
-			if (preg_match('#[\\\/\.\0]#', $options->db_name) && (!version_compare($db_version, '5.1.6', '>=')))
-			{
-				throw new \RuntimeException(\JText::sprintf('INSTL_DATABASE_INVALID_NAME', $db_version));
-			}
-		}
-
 		// @internal Check for spaces in beginning or end of name.
 		if (strlen(trim($options->db_name)) <> strlen($options->db_name))
 		{
@@ -535,37 +527,6 @@ class SetupModel extends BaseInstallationModel
 		if (strpos($options->db_name, chr(00)) !== false)
 		{
 			throw new \RuntimeException(\JText::_('INSTL_DATABASE_NAME_INVALID_CHAR'));
-		}
-
-		// PostgreSQL database older than version 9.0.0 needs to run 'CREATE LANGUAGE' to create function.
-		if ($db->getServerType() === 'postgresql' && !version_compare($db_version, '9.0.0', '>='))
-		{
-			$db->setQuery("select lanpltrusted from pg_language where lanname='plpgsql'");
-
-			try
-			{
-				$db->execute();
-			}
-			catch (\RuntimeException $e)
-			{
-				throw new \RuntimeException(\JText::_('INSTL_DATABASE_ERROR_POSTGRESQL_QUERY'), 500, $e);
-			}
-
-			$column = $db->loadResult();
-
-			if ($column != 't')
-			{
-				$db->setQuery('CREATE LANGUAGE plpgsql');
-
-				try
-				{
-					$db->execute();
-				}
-				catch (\RuntimeException $e)
-				{
-					throw new \RuntimeException(\JText::_('INSTL_DATABASE_ERROR_POSTGRESQL_QUERY'), 500, $e);
-				}
-			}
 		}
 
 		// Get database's UTF support.
@@ -703,15 +664,10 @@ class SetupModel extends BaseInstallationModel
 			// Continue Anyhow
 		}
 
+		$serverType = $db->getServerType();
+
 		// Set the appropriate schema script based on UTF-8 support.
-		if ($db->getServerType() === 'mysql')
-		{
-			$schema = 'sql/mysql/joomla.sql';
-		}
-		else
-		{
-			$schema = 'sql/' . $type . '/joomla.sql';
-		}
+		$schema = 'sql/' . $serverType . '/joomla.sql';
 
 		// Check if the schema is a valid file
 		if (!is_file($schema))
@@ -731,8 +687,6 @@ class SetupModel extends BaseInstallationModel
 		$query = $db->getQuery(true);
 
 		// MySQL only: Attempt to update the table #__utf8_conversion.
-		$serverType = $db->getServerType();
-
 		if ($serverType === 'mysql')
 		{
 			$query->clear()
@@ -753,16 +707,7 @@ class SetupModel extends BaseInstallationModel
 		}
 
 		// Attempt to update the table #__schema.
-		$pathPart = JPATH_ADMINISTRATOR . '/components/com_admin/sql/updates/';
-
-		if ($serverType === 'mysql')
-		{
-			$pathPart .= 'mysql/';
-		}
-		else
-		{
-			$pathPart .= $type . '/';
-		}
+		$pathPart = JPATH_ADMINISTRATOR . '/components/com_admin/sql/updates/' . $serverType . '/';
 
 		$files = \JFolder::files($pathPart, '\.sql$');
 
@@ -837,14 +782,7 @@ class SetupModel extends BaseInstallationModel
 		}
 
 		// Load the localise.sql for translating the data in joomla.sql.
-		if ($serverType === 'mysql')
-		{
-			$dblocalise = 'sql/mysql/localise.sql';
-		}
-		else
-		{
-			$dblocalise = 'sql/' . $type . '/localise.sql';
-		}
+		$dblocalise = 'sql/' . $serverType . '/localise.sql';
 
 		if (is_file($dblocalise))
 		{
@@ -925,12 +863,7 @@ class SetupModel extends BaseInstallationModel
 		$options = ArrayHelper::toObject($options);
 
 		// Build the path to the sample data file.
-		$type = $options->db_type;
-
-		if ($db->getServerType() === 'mysql')
-		{
-			$type = 'mysql';
-		}
+		$type = $db->getServerType();
 
 		$data = JPATH_INSTALLATION . '/sql/' . $type . '/' . $options->sample_file;
 
@@ -1301,15 +1234,18 @@ class SetupModel extends BaseInstallationModel
 				 * Note: the JDatabaseDriver::convertUtf8mb4QueryToUtf8 performs the conversion ONLY when
 				 * necessary, so there's no need to check the conditions in JInstaller.
 				 */
-				$query = $db->convertUtf8mb4QueryToUtf8($query);
-
-				/**
-				 * This is a query which was supposed to convert tables to utf8mb4 charset but the server doesn't
-				 * support utf8mb4. Therefore we don't have to run it, it has no effect and it's a mere waste of time.
-				 */
-				if (!$db->hasUTF8mb4Support() && stristr($query, 'CONVERT TO CHARACTER SET utf8 '))
+				if ($db instanceof UTF8MB4SupportInterface)
 				{
-					continue;
+					$query = $db->convertUtf8mb4QueryToUtf8($query);
+
+					/**
+					 * This is a query which was supposed to convert tables to utf8mb4 charset but the server doesn't
+					 * support utf8mb4. Therefore we don't have to run it, it has no effect and it's a mere waste of time.
+					 */
+					if (!$db->hasUTF8mb4Support() && stristr($query, 'CONVERT TO CHARACTER SET utf8 '))
+					{
+						continue;
+					}
 				}
 
 				// Execute the query.

--- a/libraries/src/Installer/Installer.php
+++ b/libraries/src/Installer/Installer.php
@@ -955,6 +955,10 @@ class Installer extends \JAdapter
 			{
 				$fDriver = 'mysql';
 			}
+			elseif ($fDriver === 'pgsql')
+			{
+				$fDriver = 'postgresql';
+			}
 
 			if ($fCharset === 'utf8' && $fDriver == $dbDriver)
 			{
@@ -1040,12 +1044,7 @@ class Installer extends \JAdapter
 
 			if (count($schemapaths))
 			{
-				$dbDriver = strtolower($db->name);
-
-				if ($db->getServerType() === 'mysql')
-				{
-					$dbDriver = 'mysql';
-				}
+				$dbDriver = $db->getServerType();
 
 				$schemapath = '';
 
@@ -1121,6 +1120,10 @@ class Installer extends \JAdapter
 					if ($uDriver === 'mysqli' || $uDriver === 'pdomysql')
 					{
 						$uDriver = 'mysql';
+					}
+					elseif ($uDriver === 'pgsql')
+					{
+						$uDriver = 'postgresql';
 					}
 
 					if ($uDriver == $dbDriver)


### PR DESCRIPTION
### Summary of Changes

- Removes code from install app for non-supported database platform versions
- Changes checks for `pdomysql` database type to `mysql`
- Adds checks for `pgsql` database type (the PDO PostgreSQL driver) to ensure things map correctly to established `postgresql` structures (i.e. SQL schema paths)

### Testing Instructions

Mostly code review, if someone's running an environment supporting PDO PostgreSQL I think the CMS would actually be installable now (if I'm following the code right it wanted SQL files at `installation/sql/pgsql` and that's not the case), same if you've got extension code floating around that might support PostgreSQL (patch tester would fall under this).