### PR TITLE
Callback plural suffixes have not a priority in extra cases

### DIFF
--- a/libraries/src/Language/Text.php
+++ b/libraries/src/Language/Text.php
@@ -217,7 +217,7 @@ class Text
 		// Try the key from the language plural potential suffixes
 		$found = false;
 		$suffixes = $lang->getPluralSuffixes((int) $n);
-		array_unshift($suffixes, (int) $n);
+		array_push($suffixes, (int) $n);
 
 		foreach ($suffixes as $suffix)
 		{


### PR DESCRIPTION
Pull Request for Issue #20002 .

### Summary of Changes

Change in priority for the language plural potential suffixes

### Testing Instructions

See Steps to reproduce the issue on https://github.com/joomla/joomla-cms/issues/20002.
Each language package should work with plurals as well or better than before.

### Expected result
See Expected result on https://github.com/joomla/joomla-cms/issues/20002
Each language package should work with plurals as well or better than before.


### Actual result

See Actual result on https://github.com/joomla/joomla-cms/issues/20002

### Documentation Changes Required

