### PR TITLE
Fix for: Can't choose module using editor plugin if you search first

### DIFF
--- a/administrator/components/com_modules/views/modules/tmpl/modal.php
+++ b/administrator/components/com_modules/views/modules/tmpl/modal.php
@@ -35,7 +35,7 @@ $link      = 'index.php?option=com_modules&view=modules&layout=modal&tmpl=compon
 
 if (!empty($editor))
 {
-	$link = 'index.php?option=com_modules&view=modules&layout=modal&tmpl=component&' . $editor . '&'  . JSession::getFormToken() . '=1';
+	$link = 'index.php?option=com_modules&view=modules&layout=modal&tmpl=component&' . $editor . '&' . JSession::getFormToken() . '=1';
 }
 ?>
 <div class="container-popup">

--- a/administrator/components/com_modules/views/modules/tmpl/modal.php
+++ b/administrator/components/com_modules/views/modules/tmpl/modal.php
@@ -31,10 +31,16 @@ JHtml::_('bootstrap.tooltip', '#filter_search', array('title' => JText::_($searc
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
 $editor    = JFactory::getApplication()->input->get('editor', '', 'cmd');
+$link      = 'index.php?option=com_modules&view=modules&layout=modal&tmpl=component&' . JSession::getFormToken() . '=1';
+
+if (!empty($editor))
+{
+	$link = 'index.php?option=com_modules&view=modules&layout=modal&tmpl=component&' . $editor . '&'  . JSession::getFormToken() . '=1';
+}
 ?>
 <div class="container-popup">
 
-	<form action="<?php echo JRoute::_('index.php?option=com_modules&view=modules&layout=modal&tmpl=component&' . JSession::getFormToken() . '=1'); ?>" method="post" name="adminForm" id="adminForm">
+	<form action="<?php echo JRoute::_($link); ?>" method="post" name="adminForm" id="adminForm">
 
 		<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
 		<?php if ($this->total > 0) : ?>
@@ -123,6 +129,7 @@ $editor    = JFactory::getApplication()->input->get('editor', '', 'cmd');
 
 		<input type="hidden" name="task" value="" />
 		<input type="hidden" name="boxchecked" value="0" />
+		<input type="hidden" name="editor" value="<?php echo $editor; ?>" />
 		<?php echo JHtml::_('form.token'); ?>
 
 	</form>

--- a/administrator/components/com_modules/views/modules/tmpl/modal.php
+++ b/administrator/components/com_modules/views/modules/tmpl/modal.php
@@ -35,7 +35,7 @@ $link      = 'index.php?option=com_modules&view=modules&layout=modal&tmpl=compon
 
 if (!empty($editor))
 {
-	$link = 'index.php?option=com_modules&view=modules&layout=modal&tmpl=component&' . $editor . '&' . JSession::getFormToken() . '=1';
+	$link = 'index.php?option=com_modules&view=modules&layout=modal&tmpl=component&editor=' . $editor . '&' . JSession::getFormToken() . '=1';
 }
 ?>
 <div class="container-popup">


### PR DESCRIPTION
Pull Request for Issue #19306 .

### Summary of Changes
Open an article.
Click on the module editor button to insert a module
Click on search tools
Select a module type
Click on the name of the module.


### Testing Instructions
Inserts module shortcode


### Expected result
Nothing happens. But if you close down the window and reopen it you will be able to choose the module and the search will still be in place.


### Actual result
Work flawlessly


### Documentation Changes Required
No, this is a bug. Probably this needs to be applied to the rest of the xtd-buttons modals

@brianteeman there you go

@uglyeoin can you please test this?