### PR TITLE
Add support for heading nodes to access.xml files

### DIFF
--- a/libraries/joomla/form/fields/rules.php
+++ b/libraries/joomla/form/fields/rules.php
@@ -163,7 +163,10 @@ class JFormFieldRules extends JFormField
 		$isGlobalConfig = $component === 'root.1';
 
 		// Get the actions for the asset.
-		$actions = JAccess::getActions($component, $section);
+		$actions = JAccess::getNodesFromFile(
+			JPATH_ADMINISTRATOR . '/components/' . $component . '/access.xml',
+			"/access/section[@name='" . $section . "']/"
+		);
 
 		// Iterate over the children and add to the actions.
 		foreach ($this->element->children() as $el)
@@ -293,6 +296,24 @@ class JFormFieldRules extends JFormField
 
 			foreach ($actions as $action)
 			{
+				if (!empty($action->_node_name_) && $action->_node_name_ !== 'action')
+				{
+					if ($action->_node_name_ === 'heading')
+					{
+						$heading = & $action;
+						$heading_class = 'jrule-h' . (isset($heading->level) ? (int) $heading->level : 0) . ($heading->class ? ' ' . $heading->class : '');
+						$html[] = '
+						<tr>
+							<td colspan="2">
+								<span class="' . $heading_class . ' hasTooltip" title="' . JHtml::_('tooltipText', $heading->title, $heading->description) . '">
+									' . JText::_($heading->title) .'
+								</span>
+							</td>
+						</tr>';
+					}
+					continue;
+				}
+
 				$html[] = '<tr>';
 				$html[] = '<td headers="actions-th' . $group->value . '">';
 				$html[] = '<label for="' . $this->id . '_' . $action->name . '_' . $group->value . '" class="hasTooltip" title="'


### PR DESCRIPTION
Pull Request for Issue #20007 

Having many ACL rules is a big headache (a real one) to edit
It is a long list of non-distiguishable things

Grouping  using headings (with levels, similar to html's H1, H2, H3) is big UX improvement

### Summary of Changes
1. Add 2 methods to JAccess to support reading non-action nodes from access.xml files
2. Then change the rules layout to check node type and if it is of **heading** then output a heading

### Testing Instructions
Edit any XML file and add heading like this
```xml
<heading name="basic"
 title="Basic rules" description="Rules for basic management"
 class="alert alert-info" level="1" />
```

### Expected result
You can display headings

### Actual result
You can not display headings


### Documentation Changes Required
YES, headings can be added to 
**access.xml** files
like this:

```xml
<heading
 name="basic"
 title="Basic rules"
 description="Rules for basic management"
 class="alert alert-info"
 level="1"
/>
```

**name**: name of the heading (currently unused)
**class**: CSS class of the container of the heading
**title**: Text of the heading
**description**: Tooltip text of the heading
**level**: Integer used to add CSS class `jrule_h*` to the container of the heading



