### PR TITLE
Also set Cache-Control private (proxies should not cache this) and max-age=0 (modern way) when browser caching is OFF

### DIFF
--- a/libraries/src/Application/WebApplication.php
+++ b/libraries/src/Application/WebApplication.php
@@ -505,7 +505,7 @@ class WebApplication extends BaseApplication
 
 			// Always modified.
 			$this->setHeader('Last-Modified', gmdate('D, d M Y H:i:s') . ' GMT', true);
-			$this->setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, post-check=0, pre-check=0', false);
+			$this->setHeader('Cache-Control', 'private, max-age=0, no-store, no-cache, must-revalidate, post-check=0, pre-check=0', false);
 
 			// HTTP 1.0
 			$this->setHeader('Pragma', 'no-cache');


### PR DESCRIPTION
Pull Request for Issue #20008 

### Summary of Changes

Normally when max-age=NNN is missing from the HTTP header:
`Cache-Control`

then browser and proxies should respect the "Expires" header, but issue #20008 says otherwise

There is no harm to also set `Cache-Control: max-age=0' , in `Cache-Control` header when browser caching is OFF, because it instructs to do what we already request with the rest of the headers

Also added `Cache-Control: private` so that proxies should not cache the response, despite not being 
the above should not be needed because the response is supposed to not be cached anyway , but i see that is not uncommon to be added it when max-age=0 **and we do not know if the current page is  only meant for a single user**

### Testing Instructions
Install PR in an installation that does not enable browser caching (e.g. default installation) and examine 

### Expected result
The `Cache-Control` header of the response, includes
private
max-age=0

### Actual result
It does not


### Documentation Changes Required
Maybe