### PR TITLE
Two new fonts for CodeMirror: IBM Plex Mono, Nanum Gothic Coding

### DIFF
--- a/plugins/editors/codemirror/fonts.json
+++ b/plugins/editors/codemirror/fonts.json
@@ -24,6 +24,11 @@
 		"url": "https://fonts.googleapis.com/css?family=Fira+Mono",
 		"css": "'Fira Mono', monospace"
 	},
+	"ibm_plex_mono": {
+		"name": "IBM Plex Mono",
+		"url": "https://fonts.googleapis.com/css?family=IBM+Plex+Mono",
+		"css": "'IBM Plex Mono', monospace;"
+	},
 	"inconsolata": {
 		"name": "Inconsolata",
 		"url": "https://fonts.googleapis.com/css?family=Inconsolata",
@@ -33,6 +38,11 @@
 		"name": "Lekton",
 		"url": "https://fonts.googleapis.com/css?family=Lekton",
 		"css": "Lekton, monospace"
+	},
+	"nanum_gothic_coding": {
+		"name": "Nanum Gothic Coding",
+		"url": "https://fonts.googleapis.com/css?family=Nanum+Gothic+Coding",
+		"css": "'Nanum Gothic Coding', monospace"
 	},
 	"nova_mono": {
 		"name": "Nova Mono",


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Added a two new coding font options to CodeMirror. 


### Testing Instructions
Select one of these fonts in the CodeMirror plugin options. Use CodeMirror.


### Expected result
Your selected font should be used.


### Actual result
Fonts are loaded from fonts.google.com so, as long as nothing is block you from accessing that, the correct font should be used. If it can't be loaded, your default monospace font will be used instead.


### Documentation Changes Required
No
