### PR TITLE
#19932 CategoryEdit field published filter

### DIFF
--- a/administrator/components/com_categories/models/fields/categoryedit.php
+++ b/administrator/components/com_categories/models/fields/categoryedit.php
@@ -119,7 +119,7 @@ class JFormFieldCategoryEdit extends JFormFieldList
 	protected function getOptions()
 	{
 		$options = array();
-		$published = $this->element['published'] ?: array(0, 1);
+		$published = $this->element['published'] ? explode(',', (string) $this->element['published']) : array(0, 1);
 		$name = (string) $this->element['name'];
 
 		// Let's get the id for the current item, either category or content item.
@@ -179,14 +179,7 @@ class JFormFieldCategoryEdit extends JFormFieldList
 		}
 
 		// Filter on the published state
-		if (is_numeric($published))
-		{
-			$query->where('a.published = ' . (int) $published);
-		}
-		elseif (is_array($published))
-		{
-			$query->where('a.published IN (' . implode(',', ArrayHelper::toInteger($published)) . ')');
-		}
+		$query->where('a.published IN (' . implode(',', ArrayHelper::toInteger($published)) . ')');
 
 		// Filter categories on User Access Level
 		// Filter by access level on categories.


### PR DESCRIPTION
Pull Request for Issue #19932  .

### Summary of Changes

Currently, is_numeric and is_array checks are performed but value returned from XML form is always a string. This removes the checks to allow proper filtering.

### Testing Instructions

Add published attribute to categoryedit field in a form. For example, add `published="0,-2"` to `catid` field in `/administrator/components/com_content/models/forms/article.xml`. Start creating an article.
### Expected result

Categories in form are filtered by state.

### Actual result

Categories in form are not filtered by state.

### Documentation Changes Required

None.