### PR TITLE
Smart Search: Highlighting terms also in fulltext when using readmore

### DIFF
--- a/components/com_finder/views/search/tmpl/default_result.php
+++ b/components/com_finder/views/search/tmpl/default_result.php
@@ -26,7 +26,7 @@ if ($show_description)
 	// Make sure we highlight term both in introtext and fulltext
 	if (!empty($this->result->summary) && !empty($this->result->body))
 	{
-		$full_description = $this->result->summary . $this->result->body;
+		$full_description = FinderIndexerHelper::parse($this->result->summary . $this->result->body);
 	}
 	else
 	{

--- a/components/com_finder/views/search/tmpl/default_result.php
+++ b/components/com_finder/views/search/tmpl/default_result.php
@@ -23,17 +23,27 @@ if ($show_description)
 	$desc_length = $this->params->get('description_length', 255);
 	$pad_length  = $term_length < $desc_length ? (int) floor(($desc_length - $term_length) / 2) : 0;
 
+	// Make sure we highlight term both in introtext and fulltext
+	if (!empty($this->result->summary) && !empty($this->result->body))
+	{
+		$full_description = $this->result->summary . $this->result->body;
+	}
+	else
+	{
+		$full_description = $this->result->description;
+	}
+
 	// Find the position of the search term
-	$pos = $term_length ? StringHelper::strpos(StringHelper::strtolower($this->result->description), StringHelper::strtolower($this->query->input)) : false;
+	$pos = $term_length ? StringHelper::strpos(StringHelper::strtolower($full_description), StringHelper::strtolower($this->query->input)) : false;
 
 	// Find a potential start point
 	$start = ($pos && $pos > $pad_length) ? $pos - $pad_length : 0;
 
 	// Find a space between $start and $pos, start right after it.
-	$space = StringHelper::strpos($this->result->description, ' ', $start > 0 ? $start - 1 : 0);
+	$space = StringHelper::strpos($full_description, ' ', $start > 0 ? $start - 1 : 0);
 	$start = ($space && $space < $pos) ? $space + 1 : $start;
 
-	$description = JHtml::_('string.truncate', StringHelper::substr($this->result->description, $start), $desc_length, true);
+	$description = JHtml::_('string.truncate', StringHelper::substr($full_description, $start), $desc_length, true);
 }
 
 $route = $this->result->route;


### PR DESCRIPTION
Pull Request for Issue #19518

### Summary of Changes
Adding fulltext to the introtext to highlight the found term
### Testing Instructions
Create an article with a readmore.
Add some text after the readmore: I used here `elegant`
Use smartsearch in frontend and search for `elegant`
### Expected result
Term highlighted.
### Actual result
Term not highlighted.

### After patch
<img width="745" alt="screen shot 2018-03-29 at 14 06 49" src="https://user-images.githubusercontent.com/869724/38088110-fc1bb3a8-335a-11e8-90be-0718bf0761d7.png">


### Documentation Changes Required
None
