### PR TITLE
Single Contact format Tabs

### DIFF
--- a/components/com_contact/views/contact/tmpl/default_user_custom_fields.php
+++ b/components/com_contact/views/contact/tmpl/default_user_custom_fields.php
@@ -35,7 +35,7 @@ $userFieldGroups    = array();
 	<?php if ($presentation_style == 'sliders') : ?>
 		<?php echo JHtml::_('bootstrap.addSlide', 'slide-contact', $groupTitle ?: JText::_('COM_CONTACT_USER_FIELDS'), 'display-' . $id); ?>
 	<?php elseif ($presentation_style == 'tabs') : ?>
-		<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'display-profile', $groupTitle ?: JText::_('COM_CONTACT_USER_FIELDS')); ?>
+		<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'display-' . $id, $groupTitle ?: JText::_('COM_CONTACT_USER_FIELDS')); ?>
 	<?php elseif ($presentation_style == 'plain') : ?>
 		<?php echo '<h3>' . ($groupTitle ?: JText::_('COM_CONTACT_USER_FIELDS')) . '</h3>'; ?>
 	<?php endif; ?>


### PR DESCRIPTION
### Summary of Changes
Fixed User Custom Field Tab in Single Contact view with Tab format 

### Testing Instructions
From the backend
Open the menu item About Joomla > Using Joomla! > Using Extensions > Components > Contact Component > Single Contact
Set the option "Display format" to "Tabs"
Set the option "Show User Custom Fields" to "All"

Link the contact "Contact Name Here" to the user "Super User"
Set the option "User Profile" to "Show" in the Contact options

Enable the plugin User - profile

Create a custom Field for Users

Compile the custom field of the user "Super User"
Compile a field in the profile of the user "Super User"

From the frontend
Click on the menu item About Joomla > Using Joomla! > Using Extensions > Components > Contact Component > Single Contact

### Expected result
If you click on the Profile tab you show the user profile fields
If you click on the Fields tab you show the user custom fields

### Actual result
Both Profile and Fields tabs show you the user profile fields

### System information (as much as possible)
Joomla! 3.8.6
Learn Joomla English (GB) Sample Data