### PR TITLE
Escape full query in NestedTable debug mode

### DIFF
--- a/libraries/src/Table/Nested.php
+++ b/libraries/src/Table/Nested.php
@@ -1733,7 +1733,7 @@ class Nested extends Table
 
 		if ($showQuery)
 		{
-			$buffer .= "\n" . $this->_db->getQuery() . $sep;
+			$buffer .= "\n" . htmlspecialchars($this->_db->getQuery(), ENT_QUOTES, 'UTF-8') . $sep;
 		}
 
 		if ($showData)


### PR DESCRIPTION
### Summary of Changes
The nested table class has a debug mode which can be enabled by developers to get additional output of the inner workings of that class. Without this PR, a full DB query (that i.e. might include HTML markup) would be outputted without any escaping, breaking the debug output with the then parsed HTML.


### Testing Instructions
1. Login to the administrator area, navigate to the screen where you can create a new com_content category and fill that form - do not submit it yet!

Open administrator/components/com_categories/tables/category.php, enable debugging by adding the following property:

`protected $_debug = 1;`

Open libraries/src/Application/WebApplication and empty the redirect() method to suppress the redirect after save.

Hit save, see a debug output comparable to this screenshot.
![voila_capture 2018-03-30_11-40-36_am](https://user-images.githubusercontent.com/498096/38133371-2ebb31bc-340f-11e8-932d-2bab826658b9.png)


Apply patch, restore redirect method, navigate to form again, empty the redirect method and save again. Check that the debug output still works.

### Expected result
Debug output is escaped


### Actual result
Debug output is unescaped


### Documentation Changes Required
None
