### PR TITLE
[4.0] Using namespaced classes inside html classes

### DIFF
--- a/libraries/cms/html/date.php
+++ b/libraries/cms/html/date.php
@@ -7,6 +7,9 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
+use Joomla\CMS\Date\Date;
+use Joomla\CMS\Language\Text;
+
 defined('JPATH_PLATFORM') or die;
 
 /**
@@ -34,7 +37,7 @@ abstract class JHtmlDate
 		if ($time === null)
 		{
 			// Get now
-			$time = new JDate('now');
+			$time = new Date('now');
 		}
 
 		// Get the difference in seconds between now and the time
@@ -43,7 +46,7 @@ abstract class JHtmlDate
 		// Less than a minute
 		if ($diff < 60)
 		{
-			return JText::_('JLIB_HTML_DATE_RELATIVE_LESSTHANAMINUTE');
+			return Text::_('JLIB_HTML_DATE_RELATIVE_LESSTHANAMINUTE');
 		}
 
 		// Round to minutes
@@ -52,7 +55,7 @@ abstract class JHtmlDate
 		// 1 to 59 minutes
 		if ($diff < 60 || $unit === 'minute')
 		{
-			return JText::plural('JLIB_HTML_DATE_RELATIVE_MINUTES', $diff);
+			return Text::plural('JLIB_HTML_DATE_RELATIVE_MINUTES', $diff);
 		}
 
 		// Round to hours
@@ -61,7 +64,7 @@ abstract class JHtmlDate
 		// 1 to 23 hours
 		if ($diff < 24 || $unit === 'hour')
 		{
-			return JText::plural('JLIB_HTML_DATE_RELATIVE_HOURS', $diff);
+			return Text::plural('JLIB_HTML_DATE_RELATIVE_HOURS', $diff);
 		}
 
 		// Round to days
@@ -70,7 +73,7 @@ abstract class JHtmlDate
 		// 1 to 6 days
 		if ($diff < 7 || $unit === 'day')
 		{
-			return JText::plural('JLIB_HTML_DATE_RELATIVE_DAYS', $diff);
+			return Text::plural('JLIB_HTML_DATE_RELATIVE_DAYS', $diff);
 		}
 
 		// Round to weeks
@@ -79,7 +82,7 @@ abstract class JHtmlDate
 		// 1 to 4 weeks
 		if ($diff <= 4 || $unit === 'week')
 		{
-			return JText::plural('JLIB_HTML_DATE_RELATIVE_WEEKS', $diff);
+			return Text::plural('JLIB_HTML_DATE_RELATIVE_WEEKS', $diff);
 		}
 
 		// Over a month, return the absolute time

--- a/libraries/cms/html/email.php
+++ b/libraries/cms/html/email.php
@@ -7,6 +7,9 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
+use Joomla\CMS\Language\Text;
+use Joomla\CMS\String\PunycodeHelper;
+
 defined('JPATH_PLATFORM') or die;
 
 /**
@@ -36,12 +39,12 @@ abstract class JHtmlEmail
 		if ($mailto && (empty($text) || $email))
 		{
 			// Use dedicated $text whereas $mail is used as href and must be punycoded.
-			$text = JStringPunycode::emailToUTF8($text ?: $mail);
+			$text = PunycodeHelper::emailToUTF8($text ?: $mail);
 		}
 		elseif (!$mailto)
 		{
 			// In that case we don't use link - so convert $mail back to utf-8.
-			$mail = JStringPunycode::emailToUTF8($mail);
+			$mail = PunycodeHelper::emailToUTF8($mail);
 		}
 
 		// Convert mail
@@ -101,7 +104,7 @@ abstract class JHtmlEmail
 		// TODO: Use inline script for now
 		$inlineScript = "<script type='text/javascript'>" . $script . "</script>";
 
-		return '<span id="cloak' . $rand . '">' . JText::_('JLIB_HTML_CLOAKING') . '</span>' . $inlineScript;
+		return '<span id="cloak' . $rand . '">' . Text::_('JLIB_HTML_CLOAKING') . '</span>' . $inlineScript;
 	}
 
 	/**

--- a/libraries/cms/html/number.php
+++ b/libraries/cms/html/number.php
@@ -7,6 +7,8 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
+use Joomla\CMS\Language\Text;
+
 defined('JPATH_PLATFORM') or die;
 
 /**
@@ -106,7 +108,7 @@ abstract class JHtmlNumber
 		}
 
 		return number_format(
-			round($oBytes / pow($base, $i), (int) $precision), (int) $precision, JText::_('DECIMALS_SEPARATOR'), JText::_('THOUSANDS_SEPARATOR')
+			round($oBytes / pow($base, $i), (int) $precision), (int) $precision, Text::_('DECIMALS_SEPARATOR'), Text::_('THOUSANDS_SEPARATOR')
 		) . ' ' . $suffix;
 	}
 }


### PR DESCRIPTION
### Summary of Changes
Using the namespaced version of classes inside the cms/html classes

This is done because within our unit testing I will not load the class mapper because then I have to load JLoader.

### Testing Instructions
Review


### Expected result
Nothing should change

