### PR TITLE
Changed viewname filter in RouteHelper

### DIFF
--- a/libraries/src/Helper/RouteHelper.php
+++ b/libraries/src/Helper/RouteHelper.php
@@ -71,7 +71,7 @@ class RouteHelper
 		}
 		else
 		{
-			$this->view = \JFactory::getApplication()->input->getString('view');
+			$this->view = \JFactory::getApplication()->input->getCmd('view');
 			$this->extension = \JFactory::getApplication()->input->getCmd('option');
 		}
 


### PR DESCRIPTION
### Summary of Changes
The RouteHelper class uses the "String" filter to retrieve the current view name. As this name is then used in the returned link and *might* be outputted in plaintext i.e. in a 3rd party extension, changing that filter to cmd (which doesn't allow characters relevant for XSS) makes sense and hardens security.


### Testing Instructions
Apply patch, browse through frontend and make sure that stuff still works.


### Expected result
View name is filtered for dangerous characters


### Actual result
No filtering applied


### Documentation Changes Required
None
