### PR TITLE
[3.x] New sessiongc plugin is not declared as core plugin for manifest cache refresh

### DIFF
--- a/libraries/src/Extension/ExtensionHelper.php
+++ b/libraries/src/Extension/ExtensionHelper.php
@@ -223,9 +223,9 @@ class ExtensionHelper
 		array('plugin', 'redirect', 'system', 0),
 		array('plugin', 'remember', 'system', 0),
 		array('plugin', 'sef', 'system', 0),
+		array('plugin', 'sessiongc', 'system', 0),
 		array('plugin', 'stats', 'system', 0),
 		array('plugin', 'updatenotification', 'system', 0),
-		array('plugin', 'sessiongc', 'system', 0),
 
 		// Core plugin extensions - two factor authentication
 		array('plugin', 'totp', 'twofactorauth', 0),

--- a/libraries/src/Extension/ExtensionHelper.php
+++ b/libraries/src/Extension/ExtensionHelper.php
@@ -225,6 +225,7 @@ class ExtensionHelper
 		array('plugin', 'sef', 'system', 0),
 		array('plugin', 'stats', 'system', 0),
 		array('plugin', 'updatenotification', 'system', 0),
+		array('plugin', 'sessiongc', 'system', 0),
 
 		// Core plugin extensions - two factor authentication
 		array('plugin', 'totp', 'twofactorauth', 0),


### PR DESCRIPTION
Pull Request for Issue #20013

### Summary of Changes

Add sessiongc plugin to the list of core plugins

### Testing Instructions

- Add this line to the upgrade package
- Apply the upgrade package

### Expected result

Manifest cache is updated

### Actual result

Manifest cache is not updated

### Documentation Changes Required

none.