### PR TITLE
[#18618] - [4.0] WYSIWYG Editor "Page Break" Button leads to 404

### DIFF
--- a/components/com_content/View/Article/HtmlView.php
+++ b/components/com_content/View/Article/HtmlView.php
@@ -75,6 +75,11 @@ class HtmlView extends BaseHtmlView
 	 */
 	public function display($tpl = null)
 	{
+		if ($this->getLayout() == 'pagebreak')
+		{
+			return parent::display($tpl);
+		}
+
 		$app        = \JFactory::getApplication();
 		$user       = \JFactory::getUser();
 


### PR DESCRIPTION
With the solution, the page breaking functionality does start working, though the display of the form looks a little messed up.

Pull Request for Issue #18618  .

### Summary of Changes

Added code to Article view, to return page break template, before any other operation

### Testing Instructions

Try to add a page break to article, from the front end

### Expected result

pop up comes up and page break is inserted

### Actual result

same as expected, though the form looks a little buggy

### Documentation Changes Required

none