### PR TITLE
[#18721] - [4.0] Editing module on frontend causes 500 on ordering ajax

### DIFF
--- a/components/com_modules/dispatcher.php
+++ b/components/com_modules/dispatcher.php
@@ -76,9 +76,10 @@ class ModulesDispatcher extends Dispatcher
 	 */
 	public function getController(string $name, string $client = '', array $config = array()): BaseController
 	{
-		if ($this->input->get('task') === 'module.orderPosition')
+		if ($this->input->get('task') === 'orderPosition')
 		{
 			$config['base_path'] = JPATH_COMPONENT_ADMINISTRATOR;
+			$client = 'Administrator';
 		}
 
 		return parent::getController($name, $client, $config);


### PR DESCRIPTION
Modified the code related to module ordering, in the module dispatcher

Pull Request for Issue #18721  .

### Summary of Changes

The value of task was wrongly identified. Also, the client was changed from site to administrator, to invoke the controller present on the administrator's side

### Testing Instructions

Edit a module on the frontend

### Expected result

No errors with a select field in front of 'ordering' option

### Actual result

Same as expected

### Documentation Changes Required

None