### PR TITLE
Fix GMail plugin so it doesn't crash and burn on 4.0 upgrades

### DIFF
--- a/plugins/authentication/gmail/gmail.php
+++ b/plugins/authentication/gmail/gmail.php
@@ -9,6 +9,7 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Authentication\AuthenticationResponse;
 use Joomla\Registry\Registry;
 
 /**
@@ -21,11 +22,11 @@ class PlgAuthenticationGMail extends JPlugin
 	/**
 	 * This method should handle any authentication and report back to the subject
 	 *
-	 * @param   array   $credentials  Array holding the user credentials
-	 * @param   array   $options      Array of extra options
-	 * @param   object  &$response    Authentication response object
+	 * @param   array                   $credentials  Array holding the user credentials
+	 * @param   array                   $options      Array of extra options
+	 * @param   AuthenticationResponse  &$response    Authentication response object
 	 *
-	 * @return  boolean
+	 * @return  void
 	 *
 	 * @since   1.5
 	 */
@@ -121,9 +122,11 @@ class PlgAuthenticationGMail extends JPlugin
 		}
 		catch (Exception $e)
 		{
-			// If there was an error in the request then create a 'false' dummy response.
-			$result = new JHttpResponse;
-			$result->code = false;
+			$response->status        = JAuthentication::STATUS_FAILURE;
+			$response->type          = 'GMail';
+			$response->error_message = JText::sprintf('JGLOBAL_AUTH_FAILED', JText::_('JGLOBAL_AUTH_UNKNOWN_ACCESS_DENIED'));
+
+			return;
 		}
 
 		$code = $result->code;


### PR DESCRIPTION
### Summary of Changes

Since it was elected to remove this plugin from the 4.0 distro, the 3.x version of the plugin needs to be maintained well enough so that when sites upgrade to 4.0 they don't fatally error out because the plugin is enabled.  This PR fixes the one issue point.

When the HTTP layer throws an Exception, the plugin is currently creating a stubbed Response object which gets processed in the code immediately following the request.  In 4.0, the Response object won't be writable through the old class member variables so this mocking won't work correctly anymore.  Instead, as is done in other try/catch blocks, the authentication response should just be set as a failure and returned.

### Testing Instructions

Code review

### Expected result

GMail plugin can be migrated to 4.0 and continue functioning

### Actual result

Error handling in the plugin will not work in 4.0