### PR TITLE
Fix count() in PHP 7.2

### DIFF
--- a/libraries/src/Installer/Adapter/FileAdapter.php
+++ b/libraries/src/Installer/Adapter/FileAdapter.php
@@ -448,7 +448,7 @@ class FileAdapter extends InstallerAdapter
 				{
 					$files = \JFolder::files($folder);
 
-					if (!count($files))
+					if ($files !== false && !count($files))
 					{
 						\JFolder::delete($folder);
 					}


### PR DESCRIPTION
Pull Request for Issue #19852.

### Summary of Changes
Fix Warning: count(): Parameter must be an array or an object that implements Countable in \libraries\src\Installer\Adapter\FileAdapter.php on line 451


### Testing Instructions

* Install PHP 7.2
* Install Akeeba Backup
* Admin -> Extensions -> Manage -> search for akeeba
* Select all
* Click uninstall


### Documentation Changes Required
no
