### PR TITLE
Fixed page with multiple codemirror editors fields with different syntax highlighting

### DIFF
--- a/plugins/editors/codemirror/codemirror.php
+++ b/plugins/editors/codemirror/codemirror.php
@@ -234,7 +234,9 @@ class PlgEditorCodemirror extends JPlugin
 		}
 
 		// Load the syntax mode.
-		$syntax = $this->params->get('syntax', 'html');
+		$syntax = !empty($params['syntax'])
+			? $params['syntax']
+			: $this->params->get('syntax', 'html');
 		$options->mode = isset($this->modeAlias[$syntax]) ? $this->modeAlias[$syntax] : $syntax;
 
 		// Load the theme if specified.


### PR DESCRIPTION
Pull Request for Issue #20062 

### Summary of Changes
getInput() method of file
libraries/src/Form/Field/EditorField.php
(form field element type="editor" in the our XML files)

https://github.com/joomla/joomla-cms/blob/staging/libraries/src/Form/Field/EditorField.php#L245
is passing "syntax" (syntax highlighting) in $params array
https://github.com/joomla/joomla-cms/blob/staging/libraries/src/Form/Field/EditorField.php#L254

but the `display()` method in codemirror.php file is not using `$params['syntax']`
instead it uses:  `$this->params->get('syntax' ...`
- which contains the $params data from the 1st call that loaded the editor instance
(which is a bug for which i will make 2nd PR, but this 2nd PR might have side-effects as it is a more general fix that this PR)

This PR patches `display()` method in codemirror.php file to use `$params['syntax']`, similar like  `$params['readonly']` is used

### Testing Instructions
XML for testing

```xml
<form>
	<field name="html" type="editor" filter="raw" editor="codemirror|none" syntax="html"/>
	<field name="css" type="editor" filter="raw" editor="codemirror|none" syntax="css"/>
	<field name="js" type="editor" filter="raw" editor="codemirror|none" syntax="js"/>
</form>
```

### Expected result
The 1st editor will have HTML syntax highlighting
The 2nd editor will have CSS syntax highlighting
The 3nd editor will have JS syntax highlighting


### Actual result
All codemirror editors have HTML syntax highlighting


### Documentation Changes Required
None
