### PR TITLE
[RFC] Fix editor instance always using the configuration of its 1st call

### DIFF
--- a/libraries/src/Editor/Editor.php
+++ b/libraries/src/Editor/Editor.php
@@ -520,6 +520,8 @@ class Editor extends \JObject
 		// Check whether editor is already loaded
 		if ($this->_editor !== null)
 		{
+			// Editor already loaded, but we have a new configuration array, set it into editor parameters
+			$this->_editor->params->loadArray($config);
 			return;
 		}
 


### PR DESCRIPTION
Pull Request for issues similar to #20062

### Summary of Changes
The editor instance created by method
`JEditor::_loadEditor($config);`

will always ignore `$config` 2nd, 3rd, etc call

Are there any side-effects to this PR
Is there code depending on current bogus behaviour ?

Also this fix is propably incomplete,
because the new `$config` array will be set but any values existing in the old `$config` continue to be in use

### Testing Instructions



### Expected result



### Actual result



### Documentation Changes Required

