### PR TITLE
[4.0] Fix system test setup: create mysql testing db

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -66,6 +66,7 @@ services:
       MYSQL_USER: joomla_ut
       MYSQL_PASSWORD: joomla_ut
       MYSQL_ROOT_PASSWORD: joomla_ut
+      MYSQL_DATABASE: test_joomla
 
   memcached:
     image: memcached:alpine


### PR DESCRIPTION
This PR fixes the current system tests error `Db: SQLSTATE[HY000] [1049] Unknown database'test_joomla' while creating PDO connection`

@rdeutz 