### PR TITLE
Remove rtrim() since it allows invalid emails

### DIFF
--- a/libraries/src/Mail/MailHelper.php
+++ b/libraries/src/Mail/MailHelper.php
@@ -153,7 +153,7 @@ abstract class MailHelper
 		}
 
 		// Check the domain
-		$domain_array = explode('.', rtrim($domain, '.'));
+		$domain_array = explode('.', $domain);
 		$regex = '/^[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/';
 
 		foreach ($domain_array as $domain)


### PR DESCRIPTION
Pull Request for Issue #20075 .

### Summary of Changes
JMailHelper was right-trimming all dots in the domain part of an email address, so invalid emails such as `test@joomla.org.` were passing validation.


### Testing Instructions
Testing instructions in #20075 


### Expected result



### Actual result



### Documentation Changes Required

