### PR TITLE
[Re] [#18724] [4.0] Offsets separated by white space(s) are deprecated, use a comma (,) instead

### DIFF
--- a/libraries/cms/html/bootstrap.php
+++ b/libraries/cms/html/bootstrap.php
@@ -256,7 +256,7 @@ abstract class JHtmlBootstrap
 		$opt['title']       = isset($params['title']) ? $params['title'] : null;
 		$opt['trigger']     = isset($params['trigger']) ? $params['trigger'] : 'hover focus';
 		$opt['constraints'] = isset($params['constraints']) ? $params['constraints'] : ['to' => 'scrollParent', 'attachment' => 'together', 'pin' => true];
-		$opt['offset']      = isset($params['offset']) ? $params['offset'] : '0 0';
+		$opt['offset']      = isset($params['offset']) ? $params['offset'] : '0,0';
 
 
 		$opt     = (object) array_filter((array) $opt);
@@ -311,7 +311,7 @@ abstract class JHtmlBootstrap
 	 *                                html         boolean          Insert HTML into the popover. If false, jQuery's text method will be used to insert
 	 *                                                              content into the dom.
 	 *                                placement    string|function  how to position the popover - top | bottom | left | right
-	 *                                selector     string           If a selector is provided, popover objects will be 
+	 *                                selector     string           If a selector is provided, popover objects will be
 	 *                                                              delegated to the specified targets.
 	 *                                template     string           Base HTML to use when creating the popover.
 	 *                                title        string|function  default title value if `title` tag isn't present


### PR DESCRIPTION
Pull Request for Issue #18724 .
(The branch for #19975 was mistakenly deleted)

### Summary of Changes

the hardcoded offsets were separated using a whitespace. replaced it with a comma

### Testing Instructions

mouse over a popover

### Expected result

no errors generated in the console

### Actual result

same as expected

### Documentation Changes Required

none