### PR TITLE
Fix for JUserHelper::addUserToGroup() when user group title is a number.

### DIFF
--- a/libraries/src/User/UserHelper.php
+++ b/libraries/src/User/UserHelper.php
@@ -50,16 +50,15 @@ abstract class UserHelper
 				->from($db->quoteName('#__usergroups'))
 				->where($db->quoteName('id') . ' = ' . (int) $groupId);
 			$db->setQuery($query);
-			$title = $db->loadResult();
 
 			// If the group does not exist, return an exception.
-			if (!$title)
+			if ($db->loadResult() === null)
 			{
 				throw new \RuntimeException('Access Usergroup Invalid');
 			}
 
 			// Add the group data to the user object.
-			$user->groups[$title] = $groupId;
+			$user->groups[$groupId] = $groupId;
 
 			// Store the user object.
 			$user->save();

--- a/libraries/src/User/UserHelper.php
+++ b/libraries/src/User/UserHelper.php
@@ -43,10 +43,10 @@ abstract class UserHelper
 		// Add the user to the group if necessary.
 		if (!in_array($groupId, $user->groups))
 		{
-			// Get the title of the group.
+			// Check whether the group exists.
 			$db = \JFactory::getDbo();
 			$query = $db->getQuery(true)
-				->select($db->quoteName('title'))
+				->select($db->quoteName('id'))
 				->from($db->quoteName('#__usergroups'))
 				->where($db->quoteName('id') . ' = ' . (int) $groupId);
 			$db->setQuery($query);


### PR DESCRIPTION
Issue reported by user on forum https://forum.joomla.org/viewtopic.php?f=708&t=960491.

### Summary of Changes
This fixes an issue with ` JUserHelper::addUserToGroup()` when user group title is a number.

### Testing Instructions
Create an user assigned to group with ID 2 (that would be "Registered"  group on fresh installation).
Create user groups titled "2" and "0".
Use `JUserHelper::addUserToGroup($userId, $groupId);` to add user to newly created groups:
a) group "2";
b) group "0".

### Expected result
a) User is added to user group titled "2".
b) User is added to user group titled "0".

### Actual result
a) User is added to user group titled "2" but also removed from user group with ID 2 ("Registered").
b) "Access Usergroup Invalid" error.

### Documentation Changes Required
No.