### PR TITLE
[com_mailto] Fix undefined index

### DIFF
--- a/components/com_mailto/controller.php
+++ b/components/com_mailto/controller.php
@@ -92,11 +92,14 @@ class MailtoController extends JControllerLegacy
 		 */
 		foreach ($fields as $field)
 		{
-			foreach ($headers as $header)
+			if (!empty($_POST[$field]))
 			{
-				if (strpos($_POST[$field], $header) !== false)
+				foreach ($headers as $header)
 				{
-					JError::raiseError(403, '');
+					if (strpos($_POST[$field], $header) !== false)
+					{
+						JError::raiseError(403, '');
+					}
 				}
 			}
 		}


### PR DESCRIPTION
### Summary of Changes
The fields in `Email this link to a friend` form can be renamed resulting in undefined index notices upon submission. This PR checks that these fields exist before performing operations to them.


### Testing Instructions
* Log in on the frontend
* Go to an article
* Select `Email` in the dropdown
* Using the Web Developer Inspector, rename the following fields: `sender` and `subject` to `sender2` and `subject2`
* Fill out form
* Submit form

### Expected result
no notices


### Actual result
In PHP error log:
```
PHP Notice:  Undefined index: sender in \components\com_mailto\controller.php on line 97

PHP Notice:  Undefined index: subject in \components\com_mailto\controller.php on line 97
```


### Documentation Changes Required
no
