### PR TITLE
[router] Create routes without a menu item with the id and not alias

### DIFF
--- a/libraries/src/Component/Router/Rules/NomenuRules.php
+++ b/libraries/src/Component/Router/Rules/NomenuRules.php
@@ -121,7 +121,12 @@ class NomenuRules implements RulesInterface
 					if (is_callable(array($this->router, 'get' . ucfirst($view->name) . 'Segment')))
 					{
 						$result = call_user_func_array(array($this->router, 'get' . ucfirst($view->name) . 'Segment'), array($query[$view->key], $query));
-						$segments[] = str_replace(':', '-', array_shift($result));
+
+						// Make sure the internal pointer is on the first element
+						reset($result);
+
+						// Get the id from the first segment, the key is always the id
+						$segments[] = str_replace(':', '-', key($result));
 					}
 					else
 					{

--- a/tests/unit/suites/libraries/cms/component/router/rules/JComponentRouterRulesNomenuTest.php
+++ b/tests/unit/suites/libraries/cms/component/router/rules/JComponentRouterRulesNomenuTest.php
@@ -158,6 +158,6 @@ class JComponentRouterRulesNomenuTest extends TestCase
 		$segments = array();
 		$this->object->build($query, $segments);
 		$this->assertEquals(array('option' => 'com_content'), $query);
-		$this->assertEquals(array('article', '42-the-answer'), $segments);
+		$this->assertEquals(array('article', '42'), $segments);
 	}
 }


### PR DESCRIPTION
Alternative for pull request #19280.

### Summary of Changes
When there is no menu item for category/categories/article view in com_content and the option _Remove IDs_ is enabled then a link like the following is created:
/index.php/en/component/content/article/article-en-gb?catid=8

This returns an error 404. This pr changes the url to contain the id instead of the alias like:
/index.php/en/component/content/article/1?catid=8

It is a break as it is ignoring the setting _Remove IDs_.

### Testing Instructions
- Create an article
- Create a latest articles module
- Create a wrapper menu item
- Set it as default menu item
- Unpublish the Home menu item
- Open the front end
- Click on the article link in the module

### Expected result
The article is opened.

### Actual result
A 404 is thrown.