### PR TITLE
[4.0] [WIP] Fix debug

### DIFF
--- a/administrator/templates/atum/index.php
+++ b/administrator/templates/atum/index.php
@@ -144,10 +144,8 @@ $this->setMetaData('theme-color', '#1c3d5c');
 			</div>
 
 		</div>
-
+		<joomla-debug><jdoc:include type="modules" name="debug" style="none" /></joomla-debug>
 	</div>
-
-	<jdoc:include type="modules" name="debug" style="none" />
 
 </body>
 </html>

--- a/administrator/templates/atum/index.php
+++ b/administrator/templates/atum/index.php
@@ -144,7 +144,7 @@ $this->setMetaData('theme-color', '#1c3d5c');
 			</div>
 
 		</div>
-		<joomla-debug><jdoc:include type="modules" name="debug" style="none" /></joomla-debug>
+		<joomla-debug></joomla-debug><jdoc:include type="modules" name="debug" style="none" />
 	</div>
 
 </body>

--- a/administrator/templates/atum/login.php
+++ b/administrator/templates/atum/login.php
@@ -101,7 +101,7 @@ $this->setMetaData('theme-color', '#1c3d5c');
 		</div>
 	</div>
 
-	<jdoc:include type="modules" name="debug" style="none" />
+	<joomla-debug></joomla-debug><jdoc:include type="modules" name="debug" style="none" />
 
 	<jdoc:include type="scripts" />
 </body>

--- a/media/plg_system_debug/js/debug.js
+++ b/media/plg_system_debug/js/debug.js
@@ -4,7 +4,7 @@
  */
 
 Joomla = window.Joomla || {};
- 
+
 (function( Joomla, document ) {
 	"use strict";
 
@@ -14,12 +14,6 @@ Joomla = window.Joomla || {};
 			var e = document.getElementById(name);
 			e.style.display = (e.style.display == 'none') ? 'block' : 'none';
 		};
-
-		var sidebarWrapper = document.getElementById('sidebar-wrapper'),
-		    debugWrapper   = document.getElementById('system-debug');
-		if (sidebarWrapper && debugWrapper) {
-			debugWrapper.style.marginLeft = '60px';
-		}
 	});
 
 }( Joomla, document ));

--- a/media/plg_system_debug/js/debug.min.js
+++ b/media/plg_system_debug/js/debug.min.js
@@ -1,1 +1,1 @@
-Joomla=window.Joomla||{},function(e,t){"use strict";t.addEventListener("DOMContentLoaded",function(){e.toggleContainer=function(e){var n=t.getElementById(e);n.style.display="none"==n.style.display?"block":"none"};var n=t.getElementById("sidebar-wrapper"),o=t.getElementById("system-debug");n&&o&&(o.style.marginLeft="60px")})}(Joomla,document);
+Joomla=window.Joomla||{},function(n,o){"use strict";o.addEventListener("DOMContentLoaded",function(){n.toggleContainer=function(n){var e=o.getElementById(n);e.style.display="none"==e.style.display?"block":"none"}})}(Joomla,document);

--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -352,7 +352,7 @@ class PlgSystemDebug extends CMSPlugin
 
 		$html[] = '</div>';
 
-		echo str_replace('<joomla-debug></joomla-debug>', '<joomla-debug>' . implode('', $html) . '</joomla-debug>', $contents);
+		echo str_replace('<joomla-debug></joomla-debug>', implode('', $html), $contents);
 	}
 
 	/**

--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -352,7 +352,7 @@ class PlgSystemDebug extends CMSPlugin
 
 		$html[] = '</div>';
 
-		echo str_replace('</body>', implode('', $html) . '</body>', $contents);
+		echo str_replace('<joomla-debug></joomla-debug>', '<joomla-debug>' . implode('', $html) . '</joomla-debug>', $contents);
 	}
 
 	/**

--- a/templates/cassiopeia/error.php
+++ b/templates/cassiopeia/error.php
@@ -172,9 +172,8 @@ $scriptOptions = [
 			</a>
 		</p>
 		<?php echo $this->getBuffer('modules', 'footer', ['style' => 'none']); ?>
+		<joomla-debug></joomla-debug><?php echo $this->getBuffer('modules', 'debug', ['style' => 'none']); ?>
 	</footer>
-
-	<?php echo $this->getBuffer('modules', 'debug', ['style' => 'none']); ?>
 
 </body>
 </html>

--- a/templates/cassiopeia/index.php
+++ b/templates/cassiopeia/index.php
@@ -182,20 +182,22 @@ $this->setMetaData('viewport', 'width=device-width, initial-scale=1');
 	</div>
 	<?php endif; ?>
 
-	<?php if ($this->countModules('footer')) : ?>
+
 	<footer class="grid-child container-footer footer">
 		<hr>
-		<p class="float-right">
-			<a href="#top" id="back-top" class="back-top">
-				<span class="icon-arrow-up-4" aria-hidden="true"></span>
-				<span class="sr-only"><?php echo Text::_('TPL_CASSIOPEIA_BACKTOTOP'); ?></span>
-			</a>
-		</p>
-		<jdoc:include type="modules" name="footer" style="none" />
-	</footer>
-	<?php endif; ?>
+		<?php if ($this->countModules('footer')) : ?>
+			<p class="float-right">
+				<a href="#top" id="back-top" class="back-top">
+					<span class="icon-arrow-up-4" aria-hidden="true"></span>
+					<span class="sr-only"><?php echo Text::_('TPL_CASSIOPEIA_BACKTOTOP'); ?></span>
+				</a>
+			</p>
+			<jdoc:include type="modules" name="footer" style="none" />
 
-	<jdoc:include type="modules" name="debug" style="none" />
+		<?php endif; ?>
+		<joomla-debug><jdoc:include type="modules" name="debug" style="none" /></joomla-debug>
+	</footer>
+
 
 </body>
 </html>

--- a/templates/cassiopeia/index.php
+++ b/templates/cassiopeia/index.php
@@ -195,7 +195,7 @@ $this->setMetaData('viewport', 'width=device-width, initial-scale=1');
 			<jdoc:include type="modules" name="footer" style="none" />
 
 		<?php endif; ?>
-		<joomla-debug><jdoc:include type="modules" name="debug" style="none" /></joomla-debug>
+		<joomla-debug></joomla-debug><jdoc:include type="modules" name="debug" style="none" />
 	</footer>
 
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Fixes the debug display backend/frontend


### Testing Instructions
Apply PR and check the bedug output


### Expected result
![screen shot 2018-04-09 at 16 13 04](https://user-images.githubusercontent.com/3889375/38502905-f95833e4-3c10-11e8-86eb-0ea84566fef3.png)
![screen shot 2018-04-09 at 16 13 22](https://user-images.githubusercontent.com/3889375/38502907-f973b812-3c10-11e8-9cc3-c367b3545f7d.png)



### Actual result
broken


### Documentation Changes Required
There is a mild B/C break here: the old code in the debug plugin is based on the `</body>` tag but the new expects `<joomla-debug></joomla-debug>`. If we go ahead with @mbabker 's proposal to drop the debug from the plugin then I would suggest to also have a `<jdoc:include type="debug"/>` with the appropriate renderer as that will render the extra custom tag useless...
