### PR TITLE
Typo and copy paste error

### DIFF
--- a/administrator/components/com_cache/models/cache.php
+++ b/administrator/components/com_cache/models/cache.php
@@ -54,7 +54,7 @@ class CacheModelCache extends JModelList
 				'group',
 				'count',
 				'size',
-				'cliend_id',
+				'client_id',
 			);
 		}
 

--- a/administrator/components/com_languages/models/installed.php
+++ b/administrator/components/com_languages/models/installed.php
@@ -83,7 +83,7 @@ class LanguagesModelInstalled extends JModelList
 				'author',
 				'authorEmail',
 				'extension_id',
-				'cliend_id',
+				'client_id',
 			);
 		}
 


### PR DESCRIPTION
Someone couldn't spell and then someone else must have copy pasted the error

No idea how to test but this has been wrong since 3.5
