### PR TITLE
[com_contact] Display 0 value with custom field

### DIFF
--- a/components/com_contact/layouts/field/render.php
+++ b/components/com_contact/layouts/field/render.php
@@ -28,7 +28,7 @@ if ($field->context == 'com_contact.mail')
 	return;
 }
 
-if (!$value)
+if (!strlen($value))
 {
 	return;
 }

--- a/components/com_contact/layouts/fields/render.php
+++ b/components/com_contact/layouts/fields/render.php
@@ -62,7 +62,7 @@ if (!$isMail)
 foreach ($fields as $field)
 {
 	// If the value is empty do nothing
-	if (empty($field->value) && !$isMail)
+	if (!strlen($field->value) && !$isMail)
 	{
 		continue;
 	}


### PR DESCRIPTION
### Summary of Changes
Fix output of custom field of value 0 to display.


### Testing Instructions
Create a custom text field under Components > Contacts.
Edit a contact and enter a value of 0 for the custom field.
On the frontend, view the contact.


### Expected result
Custom field is displayed.


### Actual result
Custom field is not displayed.


### Documentation Changes Required
none
