### PR TITLE
[com_contact] Don't hide contact filter form

### DIFF
--- a/components/com_contact/views/category/tmpl/default_items.php
+++ b/components/com_contact/views/category/tmpl/default_items.php
@@ -11,66 +11,81 @@ defined('_JEXEC') or die;
 
 JHtml::_('behavior.core');
 
-$listOrder = $this->escape($this->state->get('list.ordering'));
-$listDirn  = $this->escape($this->state->get('list.direction'));
 ?>
-<?php if (empty($this->items)) : ?>
-	<p> <?php echo JText::_('COM_CONTACT_NO_CONTACTS'); ?>	 </p>
-<?php else : ?>
-
-	<form action="<?php echo htmlspecialchars(JUri::getInstance()->toString()); ?>" method="post" name="adminForm" id="adminForm">
+<form action="<?php echo htmlspecialchars(JUri::getInstance()->toString()); ?>" method="post" name="adminForm" id="adminForm">
 	<?php if ($this->params->get('filter_field') || $this->params->get('show_pagination_limit')) : ?>
-	<fieldset class="filters btn-toolbar">
-		<?php if ($this->params->get('filter_field')) : ?>
-			<div class="btn-group">
-				<label class="filter-search-lbl element-invisible" for="filter-search"><span class="label label-warning"><?php echo JText::_('JUNPUBLISHED'); ?></span><?php echo JText::_('COM_CONTACT_FILTER_LABEL') . '&#160;'; ?></label>
-				<input type="text" name="filter-search" id="filter-search" value="<?php echo $this->escape($this->state->get('list.filter')); ?>" class="inputbox" onchange="document.adminForm.submit();" title="<?php echo JText::_('COM_CONTACT_FILTER_SEARCH_DESC'); ?>" placeholder="<?php echo JText::_('COM_CONTACT_FILTER_SEARCH_DESC'); ?>" />
-			</div>
-		<?php endif; ?>
-
-		<?php if ($this->params->get('show_pagination_limit')) : ?>
-			<div class="btn-group pull-right">
-				<label for="limit" class="element-invisible">
-					<?php echo JText::_('JGLOBAL_DISPLAY_NUM'); ?>
-				</label>
-				<?php echo $this->pagination->getLimitBox(); ?>
-			</div>
-		<?php endif; ?>
-	</fieldset>
+		<fieldset class="filters btn-toolbar">
+			<?php if ($this->params->get('filter_field')) : ?>
+				<div class="btn-group">
+					<label class="filter-search-lbl element-invisible" for="filter-search">
+						<span class="label label-warning">
+							<?php echo JText::_('JUNPUBLISHED'); ?>
+						</span>
+							<?php echo JText::_('COM_CONTACT_FILTER_LABEL') . '&#160;'; ?>
+					</label>
+					<input
+						type="text"
+						name="filter-search"
+						id="filter-search"
+						value="<?php echo $this->escape($this->state->get('list.filter')); ?>"
+						class="inputbox"
+						onchange="document.adminForm.submit();"
+						title="<?php echo JText::_('COM_CONTACT_FILTER_SEARCH_DESC'); ?>"
+						placeholder="<?php echo JText::_('COM_CONTACT_FILTER_SEARCH_DESC'); ?>"
+					/>
+				</div>
+			<?php endif; ?>
+			<?php if ($this->params->get('show_pagination_limit')) : ?>
+				<div class="btn-group pull-right">
+					<label for="limit" class="element-invisible">
+						<?php echo JText::_('JGLOBAL_DISPLAY_NUM'); ?>
+					</label>
+					<?php echo $this->pagination->getLimitBox(); ?>
+				</div>
+			<?php endif; ?>
+		</fieldset>
 	<?php endif; ?>
-
+	<?php if (empty($this->items)) : ?>
+		<p>
+			<?php echo JText::_('COM_CONTACT_NO_CONTACTS'); ?>
+		</p>
+	<?php else : ?>
 		<ul class="category row-striped">
 			<?php foreach ($this->items as $i => $item) : ?>
-
 				<?php if (in_array($item->access, $this->user->getAuthorisedViewLevels())) : ?>
 					<?php if ($this->items[$i]->published == 0) : ?>
 						<li class="row-fluid system-unpublished cat-list-row<?php echo $i % 2; ?>">
 					<?php else : ?>
 						<li class="row-fluid cat-list-row<?php echo $i % 2; ?>" >
 					<?php endif; ?>
-
 					<?php if ($this->params->get('show_image_heading')) : ?>
-						<?php $contact_width = 7; ?>
+						<?php $contactWidth = 7; ?>
 						<div class="span2 col-md-2">
 							<?php if ($this->items[$i]->image) : ?>
 								<a href="<?php echo JRoute::_(ContactHelperRoute::getContactRoute($item->slug, $item->catid)); ?>">
-									<?php echo JHtml::_('image', $this->items[$i]->image, JText::_('COM_CONTACT_IMAGE_DETAILS'), array('class' => 'contact-thumbnail img-thumbnail')); ?></a>
+									<?php echo JHtml::_(
+										'image',
+										$this->items[$i]->image,
+										JText::_('COM_CONTACT_IMAGE_DETAILS'),
+										array('class' => 'contact-thumbnail img-thumbnail')
+									); ?>
+								</a>
 							<?php endif; ?>
 						</div>
 					<?php else : ?>
-						<?php $contact_width = 9; ?>
+						<?php $contactWidth = 9; ?>
 					<?php endif; ?>
-
-					<div class="list-title span<?php echo $contact_width; ?> col-md-<?php echo $contact_width; ?>">
+					<div class="list-title span<?php echo $contactWidth; ?> col-md-<?php echo $contactWidth; ?>">
 						<a href="<?php echo JRoute::_(ContactHelperRoute::getContactRoute($item->slug, $item->catid)); ?>">
-							<?php echo $item->name; ?></a>
+							<?php echo $item->name; ?>
+						</a>
 						<?php if ($this->items[$i]->published == 0) : ?>
-							<span class="label label-warning"><?php echo JText::_('JUNPUBLISHED'); ?></span>
+							<span class="label label-warning">
+								<?php echo JText::_('JUNPUBLISHED'); ?>
+							</span>
 						<?php endif; ?>
 						<?php echo $item->event->afterDisplayTitle; ?>
-
 						<?php echo $item->event->beforeDisplayContent; ?>
-
 						<?php if ($this->params->get('show_position_headings')) : ?>
 								<?php echo $item->con_position; ?><br />
 						<?php endif; ?>
@@ -89,40 +104,35 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 						<?php endif; ?>
 						<?php echo implode($location, ', '); ?>
 					</div>
-
 					<div class="span3 col-md-3">
 						<?php if ($this->params->get('show_telephone_headings') && !empty($item->telephone)) : ?>
 							<?php echo JText::sprintf('COM_CONTACT_TELEPHONE_NUMBER', $item->telephone); ?><br />
 						<?php endif; ?>
-
 						<?php if ($this->params->get('show_mobile_headings') && !empty ($item->mobile)) : ?>
 								<?php echo JText::sprintf('COM_CONTACT_MOBILE_NUMBER', $item->mobile); ?><br />
 						<?php endif; ?>
-
-						<?php if ($this->params->get('show_fax_headings') && !empty($item->fax) ) : ?>
+						<?php if ($this->params->get('show_fax_headings') && !empty($item->fax)) : ?>
 							<?php echo JText::sprintf('COM_CONTACT_FAX_NUMBER', $item->fax); ?><br />
 						<?php endif; ?>
 					</div>
-
 					<?php echo $item->event->afterDisplayContent; ?>
 				</li>
 				<?php endif; ?>
 			<?php endforeach; ?>
 		</ul>
-
-		<?php if ($this->params->get('show_pagination', 2)) : ?>
-		<div class="pagination">
-			<?php if ($this->params->def('show_pagination_results', 1)) : ?>
-			<p class="counter">
-				<?php echo $this->pagination->getPagesCounter(); ?>
-			</p>
-			<?php endif; ?>
-			<?php echo $this->pagination->getPagesLinks(); ?>
-		</div>
 		<?php endif; ?>
-		<div>
-			<input type="hidden" name="filter_order" value="<?php echo $listOrder; ?>" />
-			<input type="hidden" name="filter_order_Dir" value="<?php echo $listDirn; ?>" />
-		</div>
+		<?php if ($this->params->get('show_pagination', 2)) : ?>
+			<div class="pagination">
+				<?php if ($this->params->def('show_pagination_results', 1)) : ?>
+					<p class="counter">
+						<?php echo $this->pagination->getPagesCounter(); ?>
+					</p>
+				<?php endif; ?>
+			<?php echo $this->pagination->getPagesLinks(); ?>
+			</div>
+		<?php endif; ?>
+	<div>
+		<input type="hidden" name="filter_order" value="<?php echo $this->escape($this->state->get('list.ordering')); ?>" />
+		<input type="hidden" name="filter_order_Dir" value="<?php echo $this->escape($this->state->get('list.direction')); ?>" />
+	</div>
 </form>
-<?php endif; ?>

--- a/components/com_contact/views/category/tmpl/default_items.php
+++ b/components/com_contact/views/category/tmpl/default_items.php
@@ -102,7 +102,7 @@ JHtml::_('behavior.core');
 						<?php if ($this->params->get('show_country_headings') && !empty($item->country)) : ?>
 							<?php $location[] = $item->country; ?>
 						<?php endif; ?>
-						<?php echo implode($location, ', '); ?>
+						<?php echo implode(', ', $location); ?>
 					</div>
 					<div class="span3 col-md-3">
 						<?php if ($this->params->get('show_telephone_headings') && !empty($item->telephone)) : ?>

--- a/components/com_contact/views/category/tmpl/default_items.php
+++ b/components/com_contact/views/category/tmpl/default_items.php
@@ -87,10 +87,10 @@ JHtml::_('behavior.core');
 						<?php echo $item->event->afterDisplayTitle; ?>
 						<?php echo $item->event->beforeDisplayContent; ?>
 						<?php if ($this->params->get('show_position_headings')) : ?>
-								<?php echo $item->con_position; ?><br />
+							<?php echo $item->con_position; ?><br />
 						<?php endif; ?>
 						<?php if ($this->params->get('show_email_headings')) : ?>
-								<?php echo $item->email_to; ?><br />
+							<?php echo $item->email_to; ?><br />
 						<?php endif; ?>
 						<?php $location = array(); ?>
 						<?php if ($this->params->get('show_suburb_headings') && !empty($item->suburb)) : ?>
@@ -109,7 +109,7 @@ JHtml::_('behavior.core');
 							<?php echo JText::sprintf('COM_CONTACT_TELEPHONE_NUMBER', $item->telephone); ?><br />
 						<?php endif; ?>
 						<?php if ($this->params->get('show_mobile_headings') && !empty ($item->mobile)) : ?>
-								<?php echo JText::sprintf('COM_CONTACT_MOBILE_NUMBER', $item->mobile); ?><br />
+							<?php echo JText::sprintf('COM_CONTACT_MOBILE_NUMBER', $item->mobile); ?><br />
 						<?php endif; ?>
 						<?php if ($this->params->get('show_fax_headings') && !empty($item->fax)) : ?>
 							<?php echo JText::sprintf('COM_CONTACT_FAX_NUMBER', $item->fax); ?><br />

--- a/components/com_contact/views/category/tmpl/default_items.php
+++ b/components/com_contact/views/category/tmpl/default_items.php
@@ -120,17 +120,17 @@ JHtml::_('behavior.core');
 				<?php endif; ?>
 			<?php endforeach; ?>
 		</ul>
-		<?php endif; ?>
-		<?php if ($this->params->get('show_pagination', 2)) : ?>
-			<div class="pagination">
-				<?php if ($this->params->def('show_pagination_results', 1)) : ?>
-					<p class="counter">
-						<?php echo $this->pagination->getPagesCounter(); ?>
-					</p>
-				<?php endif; ?>
+	<?php endif; ?>
+	<?php if ($this->params->get('show_pagination', 2)) : ?>
+		<div class="pagination">
+			<?php if ($this->params->def('show_pagination_results', 1)) : ?>
+				<p class="counter">
+					<?php echo $this->pagination->getPagesCounter(); ?>
+				</p>
+			<?php endif; ?>
 			<?php echo $this->pagination->getPagesLinks(); ?>
-			</div>
-		<?php endif; ?>
+		</div>
+	<?php endif; ?>
 	<div>
 		<input type="hidden" name="filter_order" value="<?php echo $this->escape($this->state->get('list.ordering')); ?>" />
 		<input type="hidden" name="filter_order_Dir" value="<?php echo $this->escape($this->state->get('list.direction')); ?>" />


### PR DESCRIPTION
Pull Request for Issue #19773.

### Summary of Changes
Currently, when a user searches for contacts and no contacts are found, the search form becomes hidden, making it impossible to return to previous state.

### Testing Instructions
Create some contacts.
Set 'Filter Field' to 'Show' in Contact configuration.
Enter contact category view and use the filter form, make sure no results are returned.

### Expected result
Filter form is shown.

### Actual result
Filter form is not shown, making it impossible to search for contacts again or to clear the search form.

### Documentation Changes Required
No.

### Additional Notes
Codestyle review required.