### PR TITLE
[4.0] Turn the ComponentInterface into a generic service locator

### DIFF
--- a/administrator/components/com_associations/Helper/AssociationsHelper.php
+++ b/administrator/components/com_associations/Helper/AssociationsHelper.php
@@ -10,6 +10,7 @@ namespace Joomla\Component\Associations\Administrator\Helper;
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Association\AssociationExtensionInterface;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Helper\ContentHelper;
 use Joomla\CMS\Layout\LayoutHelper;
@@ -343,7 +344,7 @@ class AssociationsHelper extends ContentHelper
 		$result->def('helper', null);
 
 		// Get the associations class
-		$helper = Factory::getApplication()->bootComponent($extensionName)->getAssociationsExtension();
+		$helper = Factory::getApplication()->bootComponent($extensionName)->getService(AssociationExtensionInterface::class);
 
 		if (!$helper)
 		{

--- a/libraries/src/Extension/Component.php
+++ b/libraries/src/Extension/Component.php
@@ -17,6 +17,7 @@ use Joomla\CMS\Dispatcher\DispatcherFactoryInterface;
 use Joomla\CMS\Dispatcher\DispatcherInterface;
 use Joomla\CMS\MVC\Factory\MVCFactoryFactoryInterface;
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
+use Psr\Container\ContainerInterface;
 
 /**
  * Access to component specific services.
@@ -51,13 +52,25 @@ class Component implements ComponentInterface
 	private $dispatcherFactory;
 
 	/**
-	 * The association extension.
+	 * The container for the additional services.
 	 *
-	 * @var AssociationExtensionInterface
+	 * @var ContainerInterface
 	 *
 	 * @since  __DEPLOY_VERSION__
 	 */
-	private $associationExtension;
+	private $container;
+
+	/**
+	 * Component constructor.
+	 *
+	 * @param   ContainerInterface  $container  The container
+	 *
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public function __construct(ContainerInterface $container)
+	{
+		$this->container = $container;
+	}
 
 	/**
 	 * Returns the dispatcher for the given application.
@@ -168,28 +181,21 @@ class Component implements ComponentInterface
 	}
 
 	/**
-	 * Returns the associations helper.
+	 * Returns a service for the given key.
 	 *
-	 * @return  AssociationExtensionInterface|null
+	 * @param   string  $key  The key
+	 *
+	 * @return  mixed
 	 *
 	 * @since  __DEPLOY_VERSION__
 	 */
-	public function getAssociationsExtension()
+	public function getService(string $key)
 	{
-		return $this->associationExtension;
-	}
+		if (!$this->container->has($key))
+		{
+			return null;
+		}
 
-	/**
-	 * The association extension.
-	 *
-	 * @param   AssociationExtensionInterface  $associationExtension  The extension
-	 *
-	 * @return void
-	 *
-	 * @since  __DEPLOY_VERSION__
-	 */
-	public function setAssociationExtension(AssociationExtensionInterface $associationExtension)
-	{
-		$this->associationExtension = $associationExtension;
+		return $this->container->get($key);
 	}
 }

--- a/libraries/src/Extension/ComponentInterface.php
+++ b/libraries/src/Extension/ComponentInterface.php
@@ -11,7 +11,6 @@ namespace Joomla\CMS\Extension;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Application\CMSApplicationInterface;
-use Joomla\CMS\Association\AssociationExtensionInterface;
 use Joomla\CMS\Categories\Categories;
 use Joomla\CMS\Dispatcher\DispatcherInterface;
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
@@ -46,6 +45,17 @@ interface ComponentInterface
 	public function createMVCFactory(CMSApplicationInterface $application): MVCFactoryInterface;
 
 	/**
+	 * Returns a service for the given key.
+	 *
+	 * @param   string  $key  The key
+	 *
+	 * @return  mixed
+	 *
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public function getService(string $key);
+
+	/**
 	 * Returns the category service. If the service is not available
 	 * null is returned.
 	 *
@@ -59,13 +69,4 @@ interface ComponentInterface
 	 * @since  __DEPLOY_VERSION__
 	 */
 	public function getCategories(array $options = [], $section = '');
-
-	/**
-	 * Returns the associations extension helper class.
-	 *
-	 * @return  AssociationExtensionInterface|null
-	 *
-	 * @since  __DEPLOY_VERSION__
-	 */
-	public function getAssociationsExtension();
 }

--- a/libraries/src/Extension/LegacyComponent.php
+++ b/libraries/src/Extension/LegacyComponent.php
@@ -117,13 +117,32 @@ class LegacyComponent implements ComponentInterface
 	}
 
 	/**
+	 * Returns a service for the given key.
+	 *
+	 * @param   string  $key  The key
+	 *
+	 * @return  mixed
+	 *
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public function getService(string $key)
+	{
+		if ($key == AssociationExtensionInterface::class)
+		{
+			return $this->getAssociationsExtension();
+		}
+
+		return null;
+	}
+
+	/**
 	 * Returns the associations helper.
 	 *
 	 * @return  AssociationExtensionInterface|null
 	 *
 	 * @since  __DEPLOY_VERSION__
 	 */
-	public function getAssociationsExtension()
+	private function getAssociationsExtension()
 	{
 		$className = ucfirst($this->component) . 'AssociationsHelper';
 

--- a/libraries/src/Extension/Service/Provider/Component.php
+++ b/libraries/src/Extension/Service/Provider/Component.php
@@ -40,7 +40,7 @@ class Component implements ServiceProviderInterface
 			ComponentInterface::class,
 			function (Container $container)
 			{
-				$component = new \Joomla\CMS\Extension\Component;
+				$component = new \Joomla\CMS\Extension\Component($container);
 
 				if ($container->has(Categories::class))
 				{
@@ -55,11 +55,6 @@ class Component implements ServiceProviderInterface
 				if ($container->has(MVCFactoryFactoryInterface::class))
 				{
 					$component->setMvcFactory($container->get(MVCFactoryFactoryInterface::class));
-				}
-
-				if ($container->has(AssociationExtensionInterface::class))
-				{
-					$component->setAssociationExtension($container->get(AssociationExtensionInterface::class));
 				}
 
 				return $component;


### PR DESCRIPTION
While redoing the pr #19843 to showcase how we will add new services to the `ComponentInterface`, the outcome is not really satisfying. @wilsonge brought up the idea turning the `ComponentInterface` into a service locator. I was playing with this and added a generic `getService` function to the interface and removed the `getAssociationsExtension` function. The `AssociationExtensionInterface` is now loaded the new way.

Ping @mbabker and @wilsonge. 