### PR TITLE
[3.x] Correct the use of the use command and move it below the defined command

### DIFF
--- a/libraries/joomla/controller/controller.php
+++ b/libraries/joomla/controller/controller.php
@@ -7,9 +7,9 @@
  * @license     GNU General Public License version 2 or later; see LICENSE
  */
 
-use Joomla\Application\AbstractApplication;
-
 defined('JPATH_PLATFORM') or die;
+
+use Joomla\Application\AbstractApplication;
 
 /**
  * Joomla Platform Controller Interface

--- a/libraries/src/Authentication/Authentication.php
+++ b/libraries/src/Authentication/Authentication.php
@@ -8,9 +8,9 @@
 
 namespace Joomla\CMS\Authentication;
 
-use Joomla\CMS\Plugin\PluginHelper;
-
 defined('JPATH_PLATFORM') or die;
+
+use Joomla\CMS\Plugin\PluginHelper;
 
 /**
  * Authentication class, provides an interface for the Joomla authentication system

--- a/libraries/src/Cache/CacheStorage.php
+++ b/libraries/src/Cache/CacheStorage.php
@@ -8,10 +8,10 @@
 
 namespace Joomla\CMS\Cache;
 
+defined('JPATH_PLATFORM') or die;
+
 use Joomla\CMS\Cache\Exception\UnsupportedCacheException;
 use Joomla\CMS\Log\Log;
-
-defined('JPATH_PLATFORM') or die;
 
 /**
  * Abstract cache storage handler

--- a/libraries/src/Component/Exception/MissingComponentException.php
+++ b/libraries/src/Component/Exception/MissingComponentException.php
@@ -8,9 +8,9 @@
 
 namespace Joomla\CMS\Component\Exception;
 
-use Joomla\CMS\Router\Exception\RouteNotFoundException;
-
 defined('JPATH_PLATFORM') or die;
+
+use Joomla\CMS\Router\Exception\RouteNotFoundException;
 
 /**
  * Exception class defining an error for a missing component

--- a/libraries/src/Crypt/Crypt.php
+++ b/libraries/src/Crypt/Crypt.php
@@ -8,10 +8,10 @@
 
 namespace Joomla\CMS\Crypt;
 
+defined('JPATH_PLATFORM') or die;
+
 use Joomla\CMS\Crypt\Cipher\SimpleCipher;
 use Joomla\CMS\Log\Log;
-
-defined('JPATH_PLATFORM') or die;
 
 /**
  * Crypt is a Joomla Platform class for handling basic encryption/decryption of data.

--- a/libraries/src/Feed/Feed.php
+++ b/libraries/src/Feed/Feed.php
@@ -8,9 +8,9 @@
 
 namespace Joomla\CMS\Feed;
 
-use Joomla\CMS\Date\Date;
-
 defined('JPATH_PLATFORM') or die();
+
+use Joomla\CMS\Date\Date;
 
 /**
  * Class to encapsulate a feed for the Joomla Platform.

--- a/libraries/src/Feed/FeedEntry.php
+++ b/libraries/src/Feed/FeedEntry.php
@@ -8,9 +8,9 @@
 
 namespace Joomla\CMS\Feed;
 
-use Joomla\CMS\Date\Date;
-
 defined('JPATH_PLATFORM') or die;
+
+use Joomla\CMS\Date\Date;
 
 /**
  * Class to encapsulate a feed entry for the Joomla Platform.

--- a/libraries/src/Feed/FeedParser.php
+++ b/libraries/src/Feed/FeedParser.php
@@ -8,9 +8,9 @@
 
 namespace Joomla\CMS\Feed;
 
-use Joomla\CMS\Feed\Parser\NamespaceParserInterface;
-
 defined('JPATH_PLATFORM') or die;
+
+use Joomla\CMS\Feed\Parser\NamespaceParserInterface;
 
 /**
  * Feed Parser class.

--- a/libraries/src/Helper/ContentHistoryHelper.php
+++ b/libraries/src/Helper/ContentHistoryHelper.php
@@ -8,10 +8,10 @@
 
 namespace Joomla\CMS\Helper;
 
+defined('JPATH_PLATFORM') or die;
+
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Table\Table;
-
-defined('JPATH_PLATFORM') or die;
 
 /**
  * Versions helper class, provides methods to perform various tasks relevant

--- a/libraries/src/Input/Json.php
+++ b/libraries/src/Input/Json.php
@@ -8,9 +8,9 @@
 
 namespace Joomla\CMS\Input;
 
-use Joomla\CMS\Filter\InputFilter;
-
 defined('JPATH_PLATFORM') or die;
+
+use Joomla\CMS\Filter\InputFilter;
 
 /**
  * Joomla! Input JSON Class

--- a/libraries/src/Installer/Installer.php
+++ b/libraries/src/Installer/Installer.php
@@ -8,12 +8,12 @@
 
 namespace Joomla\CMS\Installer;
 
+defined('JPATH_PLATFORM') or die;
+
 use Joomla\CMS\Application\ApplicationHelper;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Table\Extension;
 use Joomla\CMS\Table\Table;
-
-defined('JPATH_PLATFORM') or die;
 
 \JLoader::import('joomla.filesystem.file');
 \JLoader::import('joomla.filesystem.folder');

--- a/libraries/src/Installer/InstallerAdapter.php
+++ b/libraries/src/Installer/InstallerAdapter.php
@@ -8,12 +8,12 @@
 
 namespace Joomla\CMS\Installer;
 
+defined('JPATH_PLATFORM') or die;
+
 use Joomla\CMS\Installer\Manifest\PackageManifest;
 use Joomla\CMS\Table\Extension;
 use Joomla\CMS\Table\Table;
 use Joomla\CMS\Table\TableInterface;
-
-defined('JPATH_PLATFORM') or die;
 
 \JLoader::import('joomla.base.adapterinstance');
 

--- a/libraries/src/Language/Text.php
+++ b/libraries/src/Language/Text.php
@@ -8,11 +8,11 @@
 
 namespace Joomla\CMS\Language;
 
+defined('JPATH_PLATFORM') or die;
+
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Log\Log;
-
-defined('JPATH_PLATFORM') or die;
 
 /**
  * Text handling class.

--- a/libraries/src/Layout/FileLayout.php
+++ b/libraries/src/Layout/FileLayout.php
@@ -8,10 +8,10 @@
 
 namespace Joomla\CMS\Layout;
 
+defined('JPATH_PLATFORM') or die;
+
 use Joomla\CMS\Application\ApplicationHelper;
 use Joomla\CMS\Component\ComponentHelper;
-
-defined('JPATH_PLATFORM') or die;
 
 /**
  * Base class for rendering a display layout

--- a/libraries/src/Mail/Mail.php
+++ b/libraries/src/Mail/Mail.php
@@ -8,10 +8,10 @@
 
 namespace Joomla\CMS\Mail;
 
+defined('JPATH_PLATFORM') or die;
+
 use Joomla\CMS\Factory;
 use Joomla\CMS\Log\Log;
-
-defined('JPATH_PLATFORM') or die;
 
 /**
  * Email Class.  Provides a common interface to send email from the Joomla! Platform

--- a/libraries/src/Table/Observer/AbstractObserver.php
+++ b/libraries/src/Table/Observer/AbstractObserver.php
@@ -8,10 +8,10 @@
 
 namespace Joomla\CMS\Table\Observer;
 
+defined('JPATH_PLATFORM') or die;
+
 use Joomla\CMS\Table\TableInterface;
 use Joomla\CMS\Table\Table;
-
-defined('JPATH_PLATFORM') or die;
 
 /**
  * Table class supporting modified pre-order tree traversal behavior.

--- a/libraries/src/Toolbar/Toolbar.php
+++ b/libraries/src/Toolbar/Toolbar.php
@@ -8,9 +8,9 @@
 
 namespace Joomla\CMS\Toolbar;
 
-use Joomla\CMS\Layout\FileLayout;
-
 defined('JPATH_PLATFORM') or die;
+
+use Joomla\CMS\Layout\FileLayout;
 
 /**
  * ToolBar handler

--- a/libraries/src/Toolbar/ToolbarButton.php
+++ b/libraries/src/Toolbar/ToolbarButton.php
@@ -8,9 +8,9 @@
 
 namespace Joomla\CMS\Toolbar;
 
-use Joomla\CMS\Layout\FileLayout;
-
 defined('JPATH_PLATFORM') or die;
+
+use Joomla\CMS\Layout\FileLayout;
 
 /**
  * Button base class


### PR DESCRIPTION
### Summary of Changes

Correct the use of the use command and move it below the defined command.
This is a report that we got at security@joomla.org and we decided that this is not a security issue for this files. cc @joomla/security 

### Testing Instructions

Review. Navigate the backend and make sure nothing breaks ;)

### Expected result

use command is below the `defined('JPATH_PLATFORM') or die;` line.

### Actual result

In some cases `defined('JPATH_PLATFORM') or die;` is below the use command.

### Documentation Changes Required

none.