### PR TITLE
Fire onContentBeforeSave and onContentAfterSave when change the access level of the content via the batch button

### DIFF
--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -383,7 +383,7 @@ abstract class AdminModel extends FormModel
 				}
 
 				// Trigger the after save event.
-				\JFactory::getApplication()->triggerEvent($this->event_after_save, array($context, &$this->table, false));
+				\JFactory::getApplication()->triggerEvent($this->event_after_save, array($context, &$this->table, false, array('access' => (int) $value)));
 			}
 			else
 			{

--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -371,7 +371,7 @@ abstract class AdminModel extends FormModel
 				if (in_array(false, $result, true))
 				{
 					$this->setError($table->getError());
-					
+
 					return false;
 				}
 

--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -349,6 +349,9 @@ abstract class AdminModel extends FormModel
 		// Initialize re-usable member properties, and re-usable local variables
 		$this->initBatch();
 
+		// Include the plugins for the save events.
+		\JPluginHelper::importPlugin($this->events_map['save']);
+
 		foreach ($pks as $pk)
 		{
 			if ($this->user->authorise('core.edit', $contexts[$pk]))
@@ -362,12 +365,18 @@ abstract class AdminModel extends FormModel
 					$this->createTagsHelper($this->tagsObserver, $this->type, $pk, $this->typeAlias, $this->table);
 				}
 
+				// Trigger the before save event.
+				\JFactory::getApplication()->triggerEvent($this->event_before_save, array($context, &$this->table, false));
+
 				if (!$this->table->store())
 				{
 					$this->setError($this->table->getError());
 
 					return false;
 				}
+
+				// Trigger the after save event.
+				\JFactory::getApplication()->triggerEvent($this->event_after_save, array($context, &$this->table, false));
 			}
 			else
 			{

--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -352,6 +352,10 @@ abstract class AdminModel extends FormModel
 		// Include the plugins for the save events.
 		\JPluginHelper::importPlugin($this->events_map['save']);
 
+		$dispatcher = \JEventDispatcher::getInstance();
+
+		$context = $this->option . '.' . $this->name;
+
 		foreach ($pks as $pk)
 		{
 			if ($this->user->authorise('core.edit', $contexts[$pk]))
@@ -366,7 +370,7 @@ abstract class AdminModel extends FormModel
 				}
 
 				// Trigger the before save event.
-				$result = \JFactory::getApplication()->triggerEvent($this->event_before_save, array($context, &$this->table, false, array('access' => (int) $value)));
+				$result = $dispatcher->triggerEvent($this->event_before_save, array($context, &$this->table, false, array('access' => (int) $value)));
 
 				if (in_array(false, $result, true))
 				{
@@ -383,7 +387,7 @@ abstract class AdminModel extends FormModel
 				}
 
 				// Trigger the after save event.
-				\JFactory::getApplication()->triggerEvent($this->event_after_save, array($context, &$this->table, false, array('access' => (int) $value)));
+				$dispatcher->triggerEvent($this->event_after_save, array($context, &$this->table, false, array('access' => (int) $value)));
 			}
 			else
 			{

--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -366,7 +366,14 @@ abstract class AdminModel extends FormModel
 				}
 
 				// Trigger the before save event.
-				\JFactory::getApplication()->triggerEvent($this->event_before_save, array($context, &$this->table, false));
+				$result = \JFactory::getApplication()->triggerEvent($this->event_before_save, array($context, &$this->table, false, array('access' => (int) $value)));
+
+				if (in_array(false, $result, true))
+				{
+					$this->setError($table->getError());
+					
+					return false;
+				}
 
 				if (!$this->table->store())
 				{


### PR DESCRIPTION
There's no way of knowing if a user has changed the access level of an article if he uses the batch command

### Summary of Changes
Added the events event_before_save and event_after_save to the function batchAccess in AdminModel class

### Testing Instructions

### Expected result

### Actual result

### Documentation Changes Required
