### PR TITLE
[4.0] Add space before the ellipsis

### DIFF
--- a/administrator/language/en-GB/en-GB.plg_quickicon_extensionupdate.ini
+++ b/administrator/language/en-GB/en-GB.plg_quickicon_extensionupdate.ini
@@ -4,8 +4,8 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_QUICKICON_EXTENSIONUPDATE="Quick Icon - Joomla! Extensions Updates Notification"
-PLG_QUICKICON_EXTENSIONUPDATE_CHECKING="Checking extensions..."
-PLG_QUICKICON_EXTENSIONUPDATE_ERROR="Unknown extensions..."
+PLG_QUICKICON_EXTENSIONUPDATE_CHECKING="Checking extensions ..."
+PLG_QUICKICON_EXTENSIONUPDATE_ERROR="Unknown extensions ..."
 PLG_QUICKICON_EXTENSIONUPDATE_GROUP_DESC="The group of this plugin (this value is compared with the group value used in <strong>Quick Icons</strong> modules to inject icons)."
 PLG_QUICKICON_EXTENSIONUPDATE_GROUP_LABEL="Group"
 PLG_QUICKICON_EXTENSIONUPDATE_UPDATEFOUND="Updates are available! %s"

--- a/administrator/language/en-GB/en-GB.plg_quickicon_extensionupdate.ini
+++ b/administrator/language/en-GB/en-GB.plg_quickicon_extensionupdate.ini
@@ -4,8 +4,8 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_QUICKICON_EXTENSIONUPDATE="Quick Icon - Joomla! Extensions Updates Notification"
-PLG_QUICKICON_EXTENSIONUPDATE_CHECKING="Checking extensions ..."
-PLG_QUICKICON_EXTENSIONUPDATE_ERROR="Unknown extensions ..."
+PLG_QUICKICON_EXTENSIONUPDATE_CHECKING="Checking extensions..."
+PLG_QUICKICON_EXTENSIONUPDATE_ERROR="Unknown extensions..."
 PLG_QUICKICON_EXTENSIONUPDATE_GROUP_DESC="The group of this plugin (this value is compared with the group value used in <strong>Quick Icons</strong> modules to inject icons)."
 PLG_QUICKICON_EXTENSIONUPDATE_GROUP_LABEL="Group"
 PLG_QUICKICON_EXTENSIONUPDATE_UPDATEFOUND="Updates are available! %s"

--- a/administrator/language/en-GB/en-GB.plg_quickicon_joomlaupdate.ini
+++ b/administrator/language/en-GB/en-GB.plg_quickicon_joomlaupdate.ini
@@ -4,8 +4,8 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_QUICKICON_JOOMLAUPDATE="Quick Icon - Joomla Update Notification"
-PLG_QUICKICON_JOOMLAUPDATE_CHECKING="Checking Joomla..."
-PLG_QUICKICON_JOOMLAUPDATE_ERROR="Unknown Joomla..."
+PLG_QUICKICON_JOOMLAUPDATE_CHECKING="Checking Joomla ..."
+PLG_QUICKICON_JOOMLAUPDATE_ERROR="Unknown Joomla ..."
 PLG_QUICKICON_JOOMLAUPDATE_GROUP_DESC="The group of this plugin (this value is compared with the group value used in <strong>Quick Icons</strong> modules to inject icons)."
 PLG_QUICKICON_JOOMLAUPDATE_GROUP_LABEL="Group"
 PLG_QUICKICON_JOOMLAUPDATE_UPDATEFOUND="Joomla %s, Update now!"


### PR DESCRIPTION
### Summary of Changes
To be consistent with the following language strings, add the space before the ellipsis.
```
PLG_QUICKICON_EXTENSIONUPDATE_CHECKING="Checking extensions ..."
PLG_QUICKICON_EXTENSIONUPDATE_ERROR="Unknown extensions ..."
```
```
PLG_QUICKICON_JOOMLAUPDATE_CHECKING="Checking Joomla..."
PLG_QUICKICON_JOOMLAUPDATE_ERROR="Unknown Joomla..."
```

### Testing Instructions
Code review