### PR TITLE
[Policy] Introduce CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,60 @@
+# Custom Fields
+administrator/components/com_fields/*  @laoneo
+components/com_fields/*  @laoneo
+plugins/content/fields/*  @laoneo
+plugins/editors-xtd/fields/*  @laoneo
+plugins/fields/*  @laoneo
+plugins/systems/fields/*  @laoneo
+
+# Smart Search
+administrator/components/com_finder/*  @mbabker
+components/com_finder/*  @mbabker
+modules/mod_finder/*  @mbabker
+plugins/content/finder/*  @mbabker
+plugins/finder/*  @mbabker
+
+# Language strings
+administrator/language/en-GB/*  @brianteeman
+installation/language/en-GB/*  @brianteeman
+language/en-GB/*  @brianteeman
+README.md  @brianteeman
+README.txt  @brianteeman
+
+# CodeMirror
+media/editors/codemirror/*  @okonomiyaki3000
+plugins/editors/codemirror/*  @okonomiyaki3000
+
+# Statistics Server
+plugins/system/stats/*  @mbabker @wilsonge
+
+# Release Tools
+build.xml  @mbabker
+build/build.php  @mbabker @rdeutz @wilsonge
+build/bump.php  @mbabker @rdeutz @wilsonge
+build/deleted_file_check.php  @mbabker @rdeutz @wilsonge
+
+# Core/Extension Install/Update Tools
+administrator/components/com_joomlaupdate/*  @mbabker @rdeutz @wilsonge @zero-24
+libraries/src/Installer/*  @mbabker @rdeutz @wilsonge @zero-24
+libraries/src/Updater/*  @mbabker @rdeutz @wilsonge @zero-24
+
+# Automated Testing
+build/jenkins/*  @mbabker @rdeutz
+build/travis/*  @mbabker @rdeutz
+tests/codeception/*  @rdeutz
+tests/javascript/*  @dgt41 @rdeutz
+tests/unit/*  @mbabker @rdeutz
+.appveyor.yml  @mbabker @rdeutz
+.drone.yml  @rdeutz
+.hound.yml  @mbabker
+.travis.yml  @mbabker @rdeutz
+appveyor-phpunit.xml  @mbabker @rdeutz
+codeception.yml  @rdeutz
+karma.conf.js  @dgt41 @rdeutz
+phpunit.xml.dist  @mbabker @rdeutz
+RoboFile.dist.ini  @rdeutz
+RoboFile.php  @rdeutz
+travis-phpunit.xml  @mbabker @rdeutz
+
+# Core JS
+media/*/js/*  @dgt41


### PR DESCRIPTION
This proposal is a result of discussions between myself and @brianteeman during our time at DrupalCon Nashville while evaluating the current state of the project and ways in which workflows and processes could improve as a whole.  As a proof of concept, the names in this list should NOT be considered a finalized product but it is based heavily on current contributor or team status and the individuals who are presently involved with or engaged in activity commonly affecting various code elements.

## Introducing Code Owners

Currently every pull request must pass automated tests and two human tests. This is great but we can do even better. We don’t have a system to request reviews from specific people, teams or subject experts. With this GitHub feature, reviews from the “code owners” will be automatically requested when any pull request changes any of their owned files.

### Why

We can’t all check every new PR to see if it affects the code that we own, maintain, or are generally “experts“ in. Some pull requests might be really obvious from the title but more often than not it really isn’t, especially as we often rely on someone being tagged about the issue for various reasons. This is not efficient or productive and we often find ourselves having to create further pull requests to address issues that we could and should have caught before.

### How does this work?

If a review has been requested by a “code owner” then the “code owner” will be notified and they should review the Pull Request as many contributors already do. Just like with the automated tests the pull request will not be mergeable unless it has been reviewed by the “code owner”.

The “code owner” does not have to review and approve every aspect of the PR - only the parts that they are involved in. For example if a PR touches a library file that has an “owner” they should review their piece. Of course it would be great if they could test the entire PR but it isn’t a requirement and their “Review” is only required for the code they own (as an example, for https://github.com/joomla/joomla-cms/pull/19990 the pull request would require a review from the “owner” of the en-GB language strings, session API, and automated testing suites).

In this initial proposal, not all elements of Joomla are assigned an owner.  I have created a list of owners for a small subsection of the repo as a demonstration of how the feature works and inevitably the coordination that would be required for PRs affecting different parts of the system (i.e. a new feature for custom fields which includes language strings as it adds something to the UI would require an approval from whomever is the “owner” of the en-GB language strings and the “owner” of the PHP code in the custom fields extensions, but these would be separate approvals for their sections only and not the overall pull request).  Generally this should be a list of GitHub teams, however we do not have a full list of teams at this time therefore the use of individual usernames should suffice for demonstrating the intent.

If approved in theory, as a testing phase this PR could be merged to the 4.0 branch to evaluate the workflow changes it introduces prior to merging to staging and in effect changing the workflow for all PRs.