### PR TITLE
Add the return value to the Cancel option

### DIFF
--- a/libraries/src/MVC/Controller/FormController.php
+++ b/libraries/src/MVC/Controller/FormController.php
@@ -324,12 +324,21 @@ class FormController extends BaseController
 		$this->releaseEditId($context, $recordId);
 		\JFactory::getApplication()->setUserState($context . '.data', null);
 
-		$this->setRedirect(
-			\JRoute::_(
-				'index.php?option=' . $this->option . '&view=' . $this->view_list
-				. $this->getRedirectToListAppend(), false
-			)
+		$url = \JRoute::_(
+			'index.php?option=' . $this->option . '&view=' . $this->view_list
+			. $this->getRedirectToListAppend(), false
 		);
+
+		// Check if there is a return value
+		$return = $this->input->get('return', null, 'base64');
+
+		if (!is_null($return) && \JUri::isInternal(base64_decode($return)))
+		{
+			$url = base64_decode($return);
+		}
+
+		// Redirect to the list screen.
+		$this->setRedirect(\JRoute::_($url, false));
 
 		return true;
 	}
@@ -812,11 +821,20 @@ class FormController extends BaseController
 				$this->releaseEditId($context, $recordId);
 				$app->setUserState($context . '.data', null);
 
+				// Check if there is a return value
+				$return = $this->input->get('return', null, 'base64');
+				$url    = '';
+
+				if (!is_null($return) && \JUri::isInternal(base64_decode($return)))
+				{
+					$url = '&return=' . $return;
+				}
+
 				// Redirect back to the edit screen.
 				$this->setRedirect(
 					\JRoute::_(
 						'index.php?option=' . $this->option . '&view=' . $this->view_item
-						. $this->getRedirectToItemAppend(null, $urlVar), false
+						. $this->getRedirectToItemAppend(null, $urlVar) . $url, false
 					)
 				);
 				break;

--- a/libraries/src/MVC/Controller/FormController.php
+++ b/libraries/src/MVC/Controller/FormController.php
@@ -324,10 +324,8 @@ class FormController extends BaseController
 		$this->releaseEditId($context, $recordId);
 		\JFactory::getApplication()->setUserState($context . '.data', null);
 
-		$url = \JRoute::_(
-			'index.php?option=' . $this->option . '&view=' . $this->view_list
-			. $this->getRedirectToListAppend(), false
-		);
+		$url = 'index.php?option=' . $this->option . '&view=' . $this->view_list
+			. $this->getRedirectToListAppend();
 
 		// Check if there is a return value
 		$return = $this->input->get('return', null, 'base64');

--- a/libraries/src/MVC/Controller/FormController.php
+++ b/libraries/src/MVC/Controller/FormController.php
@@ -821,20 +821,11 @@ class FormController extends BaseController
 				$this->releaseEditId($context, $recordId);
 				$app->setUserState($context . '.data', null);
 
-				// Check if there is a return value
-				$return = $this->input->get('return', null, 'base64');
-				$url    = '';
-
-				if (!is_null($return) && \JUri::isInternal(base64_decode($return)))
-				{
-					$url = '&return=' . $return;
-				}
-
 				// Redirect back to the edit screen.
 				$this->setRedirect(
 					\JRoute::_(
 						'index.php?option=' . $this->option . '&view=' . $this->view_item
-						. $this->getRedirectToItemAppend(null, $urlVar) . $url, false
+						. $this->getRedirectToItemAppend(null, $urlVar), false
 					)
 				);
 				break;


### PR DESCRIPTION
### Summary of Changes
This change adds the behavior of being able to use a return URL on the **Cancel** button. This feature already exists on the Save & Close button and makes sense to me to add it to the other functions as well.

This is not something users will use manually but programmers can use it to make sure users go back to where they came from. It adds consistency to the workflow.

### Testing Instructions
We are going to assume you reached the article via Banners

1. Open an article in Content management
2. Add `&return=aW5kZXgucGhwP29wdGlvbj1jb21fYmFubmVycw==` behind the URL
3. Click Save & Close
4. You are now on the Banner listing because that is the return URL used

Repeat step 1 & 2
3. Click Cancel
4. You are now on the Article listing instead of the Banner listing despite providing a return URL

**Apply Patch**

1. Open an article in Content management
2. Add `&return=aW5kZXgucGhwP29wdGlvbj1jb21fYmFubmVycw==` behind the URL
3. Click Save & Close
4. You are now on the Banner listing because that is the return URL used

Repeat step 1 & 2
3. Click Cancel
4. You are now on the Banner listing as expected due to the provided return URL

### Expected result
After Cancel you end up where you started

### Actual result
You end up at the Article listing


### Documentation Changes Required
None
