### PR TITLE
Rewrite of caption.js as a jQuery plugin (stand-alone function still works)

### DIFF
--- a/media/system/js/caption-uncompressed.js
+++ b/media/system/js/caption-uncompressed.js
@@ -8,42 +8,38 @@
  *
  * Used for displaying image captions
  *
- * @package     Joomla
- * @since       1.5
- * @version  1.0
+ * @package  Joomla
+ * @since    1.5
+ * @version  1.1
  */
-var JCaption = function(_selector) {
-    var $, selector,
-    
-    initialize = function(_selector) {
-        $ = jQuery.noConflict();
-        selector = _selector;
-        $(selector).each(function(index, el) {
-            createCaption(el);
-        })
-    },
-    
-    createCaption = function(element) {
-        var $el = $(element), 
-        caption = $el.attr('title'),
-        width = $el.attr("width") || element.width,
-        align = $el.attr("align") || $el.css("float") || element.style.styleFloat || "none",
-        $p = $('<p/>', {
-            "text" : caption,
-            "class" : selector.replace('.', '_')
-        }),
-        $container = $('<div/>', {
-            "class" : selector.replace('.', '_') + " " + align,
-            "css" : {
-                "float" : align,
-                "width" : width
+
+jQuery.fn.JCaption = function () {
+	'use strict';
+
+	var $ = jQuery;
+	var selector = this.selector.replace('.', '_');
+
+    return this.each(function () {
+        var $el = $(this);
+        var caption = $el.prop('title');
+        var width = $el.prop('width') || this.width;
+        var align = $el.prop('align') || $el.css('float') || this.style.float || 'none';
+
+        var $container = $('<div/>', {
+            'class' : selector + ' ' + align,
+            'css' : {
+                'float' : align,
+                'width' : width
             }
-        });
-        $el.before($container);
-        $container.append($el);
-        if (caption !== "") {
-            $container.append($p);
+        }).insertBefore($el).append($el);
+
+        if (caption !== '') {
+            $('<p/>', {
+                'text' : caption,
+                'class' : selector
+            }).appendTo($container);
         }
-    }
-    initialize(_selector);
-}
+    });
+};
+
+function JCaption (selector) { jQuery(selector).JCaption(); }

--- a/media/system/js/caption.js
+++ b/media/system/js/caption.js
@@ -1,4 +1,4 @@
 /*
         GNU General Public License version 2 or later; see LICENSE.txt
 */
-var JCaption=function(c){var e,b,a=function(f){e=jQuery.noConflict();b=f;e(b).each(function(g,h){d(h)})},d=function(i){var h=e(i),f=h.attr("title"),j=h.attr("width")||i.width,l=h.attr("align")||h.css("float")||i.style.styleFloat||"none",g=e("<p/>",{text:f,"class":b.replace(".","_")}),k=e("<div/>",{"class":b.replace(".","_")+" "+l,css:{"float":l,width:j}});h.before(k);k.append(h);if(f!==""){k.append(g)}};a(c)};
+function JCaption(t){jQuery(t).JCaption()}jQuery.fn.JCaption=function(){"use strict";var t=jQuery,e=this.selector.replace(".","_");return this.each((function(){var i=t(this),s=i.prop("title"),n=i.prop("width")||this.width,o=i.prop("align")||i.css("float")||this.style.float||"none",a=t("<div/>",{class:e+" "+o,css:{float:o,width:n}}).insertBefore(i).append(i);""!==s&&t("<p/>",{text:s,class:e}).appendTo(a)}))};


### PR DESCRIPTION
### Summary of Changes

The JCaption js function is rewritten as a jQuery extension. Compared with the original function, it is simpler and more straight-forward although its actual behavior is exactly the same. 

The function has `'use strict';` to help avoid some common problems.

Redundant code was removed: `selector.replace('.', '_')` was used twice.

`jQuery.noConflict();` was called for no good reason.

`element.style.styleFloat` was used. Surely it was meant to be `element.style.float` because what is 'styleFloat'?

A global JCaption function is still provided for backward compatibility. 

### Testing Instructions

View any page that uses `JHtml::_('behavior.caption');` and which has images with the `caption` class.
For example, create a regular article page and put one or more images on it. Images should have class 'caption' and a title attribute (which will be used as a caption). 

### Expected result

Caption should be created (same before and after applying the patch).

### Actual result

Same

### Documentation Changes Required

No