### PR TITLE
[4.0] Event - onUserBeforeDataValidation

### DIFF
--- a/administrator/modules/mod_logged/Helper/LoggedHelper.php
+++ b/administrator/modules/mod_logged/Helper/LoggedHelper.php
@@ -35,7 +35,7 @@ abstract class LoggedHelper
 		$query = $db->getQuery(true)
 			->select('s.time, s.client_id, u.id, u.name, u.username')
 			->from('#__session AS s')
-			->join('LEFT', '#__users AS u ON s.userid = u.id')
+			->join('INNER', '#__users AS u ON s.userid = u.id')
 			->where('s.guest = 0')
 			->where('s.userid > 0')
 			->order('s.time DESC');

--- a/administrator/modules/mod_logged/Helper/LoggedHelper.php
+++ b/administrator/modules/mod_logged/Helper/LoggedHelper.php
@@ -36,7 +36,9 @@ abstract class LoggedHelper
 			->select('s.time, s.client_id, u.id, u.name, u.username')
 			->from('#__session AS s')
 			->join('LEFT', '#__users AS u ON s.userid = u.id')
-			->where('s.guest = 0');
+			->where('s.guest = 0')
+			->where('s.userid > 0')
+			->order('s.time DESC');
 		$db->setQuery($query, 0, $params->get('count', 5));
 
 		try

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -739,7 +739,7 @@ CREATE TABLE IF NOT EXISTS `#__fields_groups` (
 CREATE TABLE IF NOT EXISTS `#__fields_values` (
   `field_id` int(10) unsigned NOT NULL,
   `item_id` varchar(255) NOT NULL COMMENT 'Allow references to items which have strings as ids, eg. none db systems.',
-  `value` longtext NOT NULL DEFAULT '',
+  `value` text NOT NULL DEFAULT '',
   KEY `idx_field_id` (`field_id`),
   KEY `idx_item_id` (`item_id`(191))
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -1685,7 +1685,8 @@ CREATE TABLE IF NOT EXISTS `#__session` (
   `username` varchar(150) DEFAULT '',
   PRIMARY KEY (`session_id`),
   KEY `userid` (`userid`),
-  KEY `time` (`time`)
+  KEY `time` (`time`),
+  KEY `guest` (`guest`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
 
 -- --------------------------------------------------------

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -739,7 +739,7 @@ CREATE TABLE IF NOT EXISTS `#__fields_groups` (
 CREATE TABLE IF NOT EXISTS `#__fields_values` (
   `field_id` int(10) unsigned NOT NULL,
   `item_id` varchar(255) NOT NULL COMMENT 'Allow references to items which have strings as ids, eg. none db systems.',
-  `value` text NOT NULL DEFAULT '',
+  `value` longtext NOT NULL DEFAULT '',
   KEY `idx_field_id` (`field_id`),
   KEY `idx_item_id` (`item_id`(191))
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;

--- a/libraries/src/CMS/Form/Form.php
+++ b/libraries/src/CMS/Form/Form.php
@@ -856,6 +856,11 @@ class Form
 		// Attempt to load the XML file.
 		$xml = simplexml_load_file($file);
 
+		if ($xml === false)
+		{
+			throw new \RuntimeException(sprintf('%s() could not load file', __METHOD__));
+		}
+
 		return $this->load($xml, $reset, $xpath);
 	}
 

--- a/libraries/src/CMS/Model/Form.php
+++ b/libraries/src/CMS/Model/Form.php
@@ -332,7 +332,14 @@ abstract class Form extends Model
 		// Include the plugins for the delete events.
 		\JPluginHelper::importPlugin($this->events_map['validate']);
 
-		\JFactory::getApplication()->triggerEvent('onUserBeforeDataValidation', array($form, &$data));
+		$calledClass = get_called_class();
+		if (strpos($calledClass, 'User') === 0) {
+			// onUserBeforeDataValidation retained for backward compatibility
+			// See Joomla Issue #19584
+			\JFactory::getApplication()->triggerEvent('onUserBeforeDataValidation', array($form, &$data));
+		}
+		// Trigger event name compatible with others in this class
+		\JFactory::getApplication()->triggerEvent('onContentValidateData', array($form, &$data));
 
 		// Filter and validate the form data.
 		$data = $form->filter($data);

--- a/libraries/src/CMS/Model/Form.php
+++ b/libraries/src/CMS/Model/Form.php
@@ -332,14 +332,13 @@ abstract class Form extends Model
 		// Include the plugins for the delete events.
 		\JPluginHelper::importPlugin($this->events_map['validate']);
 
-		$calledClass = get_called_class();
-		if (strpos($calledClass, 'User') === 0)
-		{
-			// onUserBeforeDataValidation retained for backward compatibility
-			// See Joomla Issue #19584
+		$dispatcher = \JFactory::getContainer()->get('dispatcher');
+
+		if (!empty($dispatcher->getListeners('onUserBeforeDataValidation'))) {
+			@trigger_error('The `onUserBeforeDataValidation` event is deprecated and will be removed in 5.0, use the `onContentValidateData` event instead.', E_USER_DEPRECATED);
 			\JFactory::getApplication()->triggerEvent('onUserBeforeDataValidation', array($form, &$data));
 		}
-		// Trigger event name compatible with others in this class
+
 		\JFactory::getApplication()->triggerEvent('onContentValidateData', array($form, &$data));
 
 		// Filter and validate the form data.

--- a/libraries/src/CMS/Model/Form.php
+++ b/libraries/src/CMS/Model/Form.php
@@ -333,7 +333,8 @@ abstract class Form extends Model
 		\JPluginHelper::importPlugin($this->events_map['validate']);
 
 		$calledClass = get_called_class();
-		if (strpos($calledClass, 'User') === 0) {
+		if (strpos($calledClass, 'User') === 0)
+		{
 			// onUserBeforeDataValidation retained for backward compatibility
 			// See Joomla Issue #19584
 			\JFactory::getApplication()->triggerEvent('onUserBeforeDataValidation', array($form, &$data));

--- a/libraries/src/CMS/Model/Form.php
+++ b/libraries/src/CMS/Model/Form.php
@@ -334,8 +334,10 @@ abstract class Form extends Model
 
 		$dispatcher = \JFactory::getContainer()->get('dispatcher');
 
-		if (!empty($dispatcher->getListeners('onUserBeforeDataValidation'))) {
-			@trigger_error('The `onUserBeforeDataValidation` event is deprecated and will be removed in 5.0, use the `onContentValidateData` event instead.', E_USER_DEPRECATED);
+		if (!empty($dispatcher->getListeners('onUserBeforeDataValidation')))
+		{
+			@trigger_error('The `onUserBeforeDataValidation` event is deprecated and will be removed in 5.0, ' .
+				       'use the `onContentValidateData` event instead.', E_USER_DEPRECATED);
 			\JFactory::getApplication()->triggerEvent('onUserBeforeDataValidation', array($form, &$data));
 		}
 

--- a/libraries/src/CMS/Model/Form.php
+++ b/libraries/src/CMS/Model/Form.php
@@ -337,8 +337,8 @@ abstract class Form extends Model
 		if (!empty($dispatcher->getListeners('onUserBeforeDataValidation')))
 		{
 			@trigger_error('The `onUserBeforeDataValidation` event is deprecated and will be removed in 5.0, ' .
-				       'use the `onContentValidateData` event instead.', E_USER_DEPRECATED
-				      );
+				'use the `onContentValidateData` event instead.', E_USER_DEPRECATED
+			);
 			\JFactory::getApplication()->triggerEvent('onUserBeforeDataValidation', array($form, &$data));
 		}
 

--- a/libraries/src/CMS/Model/Form.php
+++ b/libraries/src/CMS/Model/Form.php
@@ -337,7 +337,8 @@ abstract class Form extends Model
 		if (!empty($dispatcher->getListeners('onUserBeforeDataValidation')))
 		{
 			@trigger_error('The `onUserBeforeDataValidation` event is deprecated and will be removed in 5.0, ' .
-				       'use the `onContentValidateData` event instead.', E_USER_DEPRECATED);
+				       'use the `onContentValidateData` event instead.', E_USER_DEPRECATED
+				      );
 			\JFactory::getApplication()->triggerEvent('onUserBeforeDataValidation', array($form, &$data));
 		}
 


### PR DESCRIPTION
Pull Request for Issue #19584 .

### Summary of Changes

Added event onContentValidateData

### Testing Instructions

Create a field plugin which implements onContentValidateData function like this...
  public function onContentValidateData($form, &$data) {
    // Change the data in some way
  }

### Expected result

The data get's changed.

### Actual result

The data get's changed.

### Documentation Changes Required

Add documentation for onContentValidateData event.
Add documentation for the existing, but undocumented and now deprecated, onUserBeforeDataValidation event.
This event will only get triggered when validate() overridden by a user component model.