### PR TITLE
[4.0] [Cassiopeia] Remove global display declaration on img tags

### DIFF
--- a/templates/cassiopeia/css/template.css
+++ b/templates/cassiopeia/css/template.css
@@ -8525,7 +8525,6 @@ body {
   background: #fff; }
 
 img {
-  display: block;
   max-width: 100%; }
 
 h1, h2, h3, h4, h5, h6 {
@@ -9181,7 +9180,7 @@ joomla-alert {
   /* autoprefixer: off */
   .site-grid {
     display: grid;
-    grid-template-areas: ". head head head head ." ". banner banner banner banner ." ". top-a top-a top-a top-a ." ". top-b top-b top-b top-b ." ". main main main main ." ". bot-a bot-a bot-a bot-a ." ". bot-b bot-b bot-b bot-b ." ". footer footer footer footer ." ". debug debug debug debug .";
+    grid-template-areas: ". head head head head ." ". banner banner banner banner ." ". top-a top-a top-a top-a ." ". top-b top-b top-b top-b ." ". main main main main ." ". bot-a bot-a bot-a bot-a ." ". bot-b bot-b bot-b bot-b ." ". footer footer footer footer ." ". debug debug debug debug .";
     grid-template-columns: [full-start] minmax(0, 1fr) [main-start] repeat(4, minmax(0, 270px)) [main-end] minmax(0, 1fr) [full-end];
     grid-gap: 0 15px; }
     .site-grid > [class^='container-'],
@@ -9205,7 +9204,7 @@ joomla-alert {
       grid-column: full-start / full-end; }
     @media (max-width: 575.98px) {
       .site-grid {
-        grid-template-areas: ". head head head head ." ". banner banner banner banner ." ". main main main main ." ". top-a top-a top-a top-a ." ". top-b top-b top-b top-b ." ". bot-a bot-a bot-a bot-a ." ". bot-b bot-b bot-b bot-b ." ". footer footer footer footer ." ". debug debug debug debug ."; } }
+        grid-template-areas: ". head head head head ." ". banner banner banner banner ." ". main main main main ." ". top-a top-a top-a top-a ." ". top-b top-b top-b top-b ." ". bot-a bot-a bot-a bot-a ." ". bot-b bot-b bot-b bot-b ." ". footer footer footer footer ." ". debug debug debug debug ."; } }
     .site-grid .container-header {
       margin-top: 0;
       margin-bottom: 20px; }

--- a/templates/cassiopeia/scss/blocks/_global.scss
+++ b/templates/cassiopeia/scss/blocks/_global.scss
@@ -13,7 +13,6 @@ body {
 }
 
 img {
-  display: block;
   max-width: 100%;
 }
 


### PR DESCRIPTION
Pull Request for Issue #20143 .

### Summary of Changes
Best avoid such global declarations from default. img tags are inline-block elements. 

### Testing Instructions
Code review
