### PR TITLE
[com_media] Add showon attribute

### DIFF
--- a/administrator/components/com_media/config.xml
+++ b/administrator/components/com_media/config.xml
@@ -67,6 +67,7 @@
 			description="COM_MEDIA_FIELD_CHECK_MIME_DESC"
 			class="btn-group btn-group-yesno"
 			default="1"
+			showon="restrict_uploads:1"
 			>
 			<option value="1">JYES</option>
 			<option value="0">JNO</option>
@@ -79,6 +80,7 @@
 			description="COM_MEDIA_FIELD_LEGAL_IMAGE_EXTENSIONS_DESC"
 			size="50"
 			default="bmp,gif,jpg,png"
+			showon="restrict_uploads:1"
 		/>
 
 		<field
@@ -96,6 +98,7 @@
 			description="COM_MEDIA_FIELD_LEGAL_MIME_TYPES_DESC"
 			size="50"
 			default="image/jpeg,image/gif,image/png,image/bmp,application/msword,application/excel,application/pdf,application/powerpoint,text/plain,application/x-zip"
+			showon="restrict_uploads:1"
 		/>
 
 		<field
@@ -105,7 +108,8 @@
 			description="COM_MEDIA_FIELD_ILLEGAL_MIME_TYPES_DESC"
 			size="50"
 			default="text/html"
-		 />
+			showon="restrict_uploads:1"
+		/>
 	</fieldset>
 
 	<fieldset


### PR DESCRIPTION
### Summary of Changes
Some settings under Media configuration depend on `Restrict Uploads` setting. This PR hides these settings when `Restrict Uploads` is No.


### Testing Instructions
Under Global Configuration > Media, toggle `Restrict Uploads` to No.


### Expected result
Applicable settings hidden.


### Actual result
Applicable settings are always visible.


### Documentation Changes Required
none

Ping @zero-24 
