### PR TITLE
Remove not necessary line of code

### DIFF
--- a/administrator/components/com_fields/helpers/fields.php
+++ b/administrator/components/com_fields/helpers/fields.php
@@ -90,8 +90,7 @@ class FieldsHelper
 	{
 		if (self::$fieldsCache === null)
 		{
-			// Load the model
-			JLoader::import('joomla.application.component.model');
+			// Load the model			
 			JModelLegacy::addIncludePath(JPATH_ADMINISTRATOR . '/components/com_fields/models', 'FieldsModel');
 
 			self::$fieldsCache = JModelLegacy::getInstance('Fields', 'FieldsModel', array(

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -203,9 +203,8 @@ class PlgSystemFields extends JPlugin
 			return true;
 		}
 
-		$context = $parts[0] . '.' . $parts[1];
-
-		JLoader::import('joomla.application.component.model');
+		$context = $parts[0] . '.' . $parts[1];		
+		
 		JModelLegacy::addIncludePath(JPATH_ADMINISTRATOR . '/components/com_fields/models', 'FieldsModel');
 
 		$model = JModelLegacy::getInstance('Field', 'FieldsModel', array('ignore_request' => true));

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -203,8 +203,8 @@ class PlgSystemFields extends JPlugin
 			return true;
 		}
 
-		$context = $parts[0] . '.' . $parts[1];		
-		
+		$context = $parts[0] . '.' . $parts[1];
+
 		JModelLegacy::addIncludePath(JPATH_ADMINISTRATOR . '/components/com_fields/models', 'FieldsModel');
 
 		$model = JModelLegacy::getInstance('Field', 'FieldsModel', array('ignore_request' => true));

--- a/plugins/system/updatenotification/updatenotification.php
+++ b/plugins/system/updatenotification/updatenotification.php
@@ -43,7 +43,6 @@ class PlgSystemUpdatenotification extends JPlugin
 	public function onAfterRender()
 	{
 		// Get the timeout for Joomla! updates, as configured in com_installer's component parameters
-		JLoader::import('joomla.application.component.helper');
 		$component = JComponentHelper::getComponent('com_installer');
 
 		/** @var \Joomla\Registry\Registry $params */


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This line of code is used to register JModel class with Joomla loader. It is not valid anymore and should be removed

### Testing Instructions
Apply patch and test the following cases:

1. Access to a random page on frontend of your site, make sure it is still loading as expected (it is related to the command removed in update notification plugin)

2. For the changes related to custom fields (two files), please create custom field for article, then try to add/edit an article, check and make sure custom fields still being saved. Delete the article and confirm that it is being deleted, too (I am not sure if it covers all the cases) 
