### PR TITLE
[a11y] Headings consecutive order

### DIFF
--- a/administrator/components/com_modules/views/module/tmpl/edit.php
+++ b/administrator/components/com_modules/views/module/tmpl/edit.php
@@ -174,7 +174,7 @@ $tmpl    = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=c
 			<div class="span9">
 				<?php if ($this->item->xml) : ?>
 					<?php if ($this->item->xml->description) : ?>
-						<h3>
+						<h2>
 							<?php
 							if ($this->item->xml)
 							{
@@ -185,7 +185,7 @@ $tmpl    = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=c
 								echo JText::_('COM_MODULES_ERR_XML');
 							}
 							?>
-						</h3>
+						</h2>
 						<div class="info-labels">
 							<span class="label hasTooltip" title="<?php echo JHtml::_('tooltipText', 'COM_MODULES_FIELD_CLIENT_ID_LABEL'); ?>">
 								<?php echo $this->item->client_id == 0 ? JText::_('JSITE') : JText::_('JADMINISTRATOR'); ?>

--- a/administrator/components/com_plugins/views/plugin/tmpl/edit.php
+++ b/administrator/components/com_plugins/views/plugin/tmpl/edit.php
@@ -51,7 +51,7 @@ JFactory::getDocument()->addScriptDeclaration("
 			<div class="span9">
 				<?php if ($this->item->xml) : ?>
 					<?php if ($this->item->xml->description) : ?>
-						<h3>
+						<h2>
 							<?php
 							if ($this->item->xml)
 							{
@@ -62,7 +62,7 @@ JFactory::getDocument()->addScriptDeclaration("
 								echo JText::_('COM_PLUGINS_XML_ERR');
 							}
 							?>
-						</h3>
+						</h2>
 						<div class="info-labels">
 							<span class="label hasTooltip" title="<?php echo JHtml::_('tooltipText', 'COM_PLUGINS_FIELD_FOLDER_LABEL', 'COM_PLUGINS_FIELD_FOLDER_DESC'); ?>">
 								<?php echo $this->form->getValue('folder'); ?>

--- a/administrator/components/com_templates/views/style/tmpl/edit.php
+++ b/administrator/components/com_templates/views/style/tmpl/edit.php
@@ -37,9 +37,9 @@ JFactory::getDocument()->addScriptDeclaration("
 
 		<div class="row-fluid">
 			<div class="span9">
-				<h3>
+				<h2>
 					<?php echo JText::_($this->item->template); ?>
-				</h3>
+				</h2>
 				<div class="info-labels">
 					<span class="label hasTooltip" title="<?php echo JHtml::_('tooltipText', 'COM_TEMPLATES_FIELD_CLIENT_LABEL'); ?>">
 						<?php echo $this->item->client_id == 0 ? JText::_('JSITE') : JText::_('JADMINISTRATOR'); ?>

--- a/layouts/joomla/edit/item_title.php
+++ b/layouts/joomla/edit/item_title.php
@@ -16,9 +16,9 @@ $name = $displayData->getForm()->getValue('name');
 ?>
 
 <?php if ($title) : ?>
-	<h4><?php echo $title; ?></h4>
+	<h2><?php echo $title; ?></h2>
 <?php endif; ?>
 
 <?php if ($name) : ?>
-	<h4><?php echo $name; ?></h4>
+	<h2><?php echo $name; ?></h2>
 <?php endif;


### PR DESCRIPTION
> Headings communicate the organization of the content on the page. Web browsers, plug-ins, and assistive technologies can use them to provide in-page navigation.

> Skipping heading ranks can be confusing and should be avoided where possible: Make sure that a < h2> is not followed directly by an < h4>, for example.

Source (https://www.w3.org/WAI/tutorials/page-structure/headings/)

The headings were probably chosen for cosmetic reasons and not structural reasons which they should have been

This PR changes the heading in the plugin and modules from h3 to h2 and in the template styles to h4 and the layout which is used in users and templates where it goes from h4 to h2

There is a very small visual change as a result but imho the benefits outweigh the small cost
