### PR TITLE
[a11y] Headings consecutive order Debug Console

### DIFF
--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -283,7 +283,7 @@ class PlgSystemDebug extends JPlugin
 
 		$html[] = '<div id="system-debug" class="profiler">';
 
-		$html[] = '<h1>' . JText::_('PLG_DEBUG_TITLE') . '</h1>';
+		$html[] = '<h2>' . JText::_('PLG_DEBUG_TITLE') . '</h2>';
 
 		if (JDEBUG)
 		{


### PR DESCRIPTION
> Headings communicate the organization of the content on the page. Web browsers, plug-ins, and assistive technologies can use them to provide in-page navigation.

> Skipping heading ranks can be confusing and should be avoided where possible: Make sure that a < h2> is not followed directly by an < h4>, for example.

Source (https://www.w3.org/WAI/tutorials/page-structure/headings/)

This PR changes the heading in the debug console from h1 to h2

The headings were probably chosen for cosmetic reasons and not structural reasons which they should have been


There is a very small visual change as a result but imho the benefits outweigh the small cost