### PR TITLE
Add the possibility to load multiple default field values as JSON

### DIFF
--- a/libraries/src/Form/FormField.php
+++ b/libraries/src/Form/FormField.php
@@ -600,7 +600,14 @@ abstract class FormField
 		$this->default = isset($element['value']) ? (string) $element['value'] : $this->default;
 
 		// Set the field default value.
-		$this->value = $value;
+		if ($element['multiple'] && is_string($value) && is_array(json_decode($value, true)))
+		{
+			$this->value = (array) json_decode($value);
+		}
+		else 
+		{
+			$this->value = $value;
+		}
 
 		foreach ($attributes as $attributeName)
 		{


### PR DESCRIPTION
Joomla saves and loads multiple field values as JSON, but it doesn't load default field values as JSON.

### Summary of Changes
Add the possibility to load multiple default field values as JSON

### Testing Instructions
Adding the default attribute to the field access with the json value "[1,2]" to the file administrator/components/com_content/models/forms/filter_articles.xml
```
		<field
			name="access"
			type="accesslevel"
			multiple="true"
			class="multipleAccessLevels"
			onchange="this.form.submit();"
			default="[1,2]"
		/>
```

### Expected result
The filter is enabled and the access levels "Public" and "Registered" are selected.

### Actual result
The filter is disabled

### Documentation Changes Required
