### PR TITLE
[4.0] Make categories use an interface

### DIFF
--- a/administrator/components/com_associations/Helper/AssociationsHelper.php
+++ b/administrator/components/com_associations/Helper/AssociationsHelper.php
@@ -10,6 +10,8 @@ namespace Joomla\Component\Associations\Administrator\Helper;
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Association\AssociationAwareInterface;
+use Joomla\CMS\Association\Exception\AssociationsNotImplementedException;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Helper\ContentHelper;
 use Joomla\CMS\Layout\LayoutHelper;
@@ -343,9 +345,18 @@ class AssociationsHelper extends ContentHelper
 		$result->def('helper', null);
 
 		// Get the associations class
-		$helper = Factory::getApplication()->bootComponent($extensionName)->getAssociationsExtension();
+		$componentInterface = Factory::getApplication()->bootComponent($extensionName);
 
-		if (!$helper)
+		if (!$componentInterface instanceof AssociationAwareInterface)
+		{
+			return $result;
+		}
+
+		try
+		{
+			$helper = $componentInterface->getAssociationsExtension();
+		}
+		catch (AssociationsNotImplementedException $e)
 		{
 			return $result;
 		}

--- a/administrator/components/com_content/services/provider.php
+++ b/administrator/components/com_content/services/provider.php
@@ -12,6 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Association\AssociationExtensionInterface;
 use Joomla\CMS\Application\SiteApplication;
 use Joomla\CMS\Categories\Categories;
+use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Dispatcher\DispatcherFactory;
 use Joomla\CMS\Dispatcher\DispatcherFactoryInterface;
 use Joomla\CMS\Extension\Service\Provider\Component;
@@ -32,6 +33,14 @@ use Joomla\DI\ServiceProviderInterface;
  */
 return new class implements ServiceProviderInterface
 {
+	/**
+	 * The extension name to use
+	 *
+	 * @type   string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $extension_name = 'com_content';
+
 	/**
 	 * Registers the service provider with a DI container.
 	 *
@@ -56,13 +65,16 @@ return new class implements ServiceProviderInterface
 		$container->set(Categories::class, ['' => new Category]);
 		$container->set(AssociationExtensionInterface::class, new AssociationsHelper);
 
-		$factory = new MVCFactoryFactory('\\Joomla\\Component\\Content');
+		$factory = new MVCFactoryFactory(ComponentHelper::getComponent($this->extension_name)->namespace);
 		$factory->setFormFactory($container->get(\Joomla\CMS\Form\FormFactoryInterface::class));
 		$container->set(MVCFactoryFactoryInterface::class, $factory);
 
 		$container->set(
 			DispatcherFactoryInterface::class,
-			new DispatcherFactory('\\Joomla\\Component\\Content', $container->get(MVCFactoryFactoryInterface::class))
+			new DispatcherFactory(
+				ComponentHelper::getComponent($this->extension_name)->namespace,
+				$container->get(MVCFactoryFactoryInterface::class)
+			)
 		);
 		$container->registerServiceProvider(new Component);
 	}

--- a/administrator/components/com_fields/Model/FieldModel.php
+++ b/administrator/components/com_fields/Model/FieldModel.php
@@ -10,6 +10,8 @@ namespace Joomla\Component\Fields\Administrator\Model;
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Categories\CategoryNotFoundExceptionInterface;
+use Joomla\CMS\Categories\CategoryAwareInterface;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\MVC\Model\AdminModel;
@@ -967,7 +969,20 @@ class FieldModel extends AdminModel
 		}
 
 		// Setting the context for the category field
-		$cat = $this->bootComponent($component)->getCategories();
+		$componentClass = $this->bootComponent($component);
+		$cat = null;
+
+		if ($componentClass instanceof CategoryAwareInterface)
+		{
+			try
+			{
+				$cat = $componentClass->getCategories();
+			}
+			catch (CategoryNotFoundExceptionInterface $e)
+			{
+				// Categories not supported
+			}
+		}
 
 		if ($cat && $cat->get('root')->hasChildren())
 		{

--- a/libraries/src/Association/AssociationAwareInterface.php
+++ b/libraries/src/Association/AssociationAwareInterface.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Association;
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * Access to component specific services.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+interface AssociationAwareInterface
+{
+	/**
+	 * Returns the associations helper.
+	 *
+	 * @return  AssociationExtensionInterface
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  Exception\AssociationsNotImplementedException
+	 */
+	public function getAssociationsExtension(): AssociationExtensionInterface;
+}

--- a/libraries/src/Association/AssociationAwareTrait.php
+++ b/libraries/src/Association/AssociationAwareTrait.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\CMS\Association;
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * Trait for component Service Providers that support Associations built to implement AssociationAwareInterface
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+trait AssociationAwareTrait
+{
+	/**
+	 * The association extension.
+	 *
+	 * @var AssociationExtensionInterface
+	 *
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $associationExtension = null;
+
+	/**
+	 * Returns the associations helper.
+	 *
+	 * @return  AssociationExtensionInterface
+	 *
+	 * @since  __DEPLOY_VERSION__
+	 * @throws  Exception\AssociationsNotImplementedException
+	 */
+	public function getAssociationsExtension(): AssociationExtensionInterface
+	{
+		if ($this->associationExtension === null)
+		{
+			throw new Exception\AssociationsNotImplementedException;
+		}
+
+		return $this->associationExtension;
+	}
+
+	/**
+	 * The association extension.
+	 *
+	 * @param   AssociationExtensionInterface  $associationExtension  The extension
+	 *
+	 * @return void
+	 *
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public function setAssociationExtension(AssociationExtensionInterface $associationExtension)
+	{
+		$this->associationExtension = $associationExtension;
+	}
+
+}

--- a/libraries/src/Association/Exception/AssociationsNotImplementedException.php
+++ b/libraries/src/Association/Exception/AssociationsNotImplementedException.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Association\Exception;
+
+use Joomla\CMS\Categories\CategoryNotFoundExceptionInterface;
+
+/**
+ * The component does not support categories.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class AssociationsNotImplementedException extends \RuntimeException implements CategoryNotFoundExceptionInterface
+{
+}

--- a/libraries/src/Categories/Categories.php
+++ b/libraries/src/Categories/Categories.php
@@ -139,7 +139,22 @@ class Categories
 
 		$parts = explode('.', $extension, 2);
 
-		$categories = Factory::getApplication()->bootComponent($parts[0])->getCategories($options, count($parts) > 1 ? $parts[1] : '');
+		// Setting the context for the category field
+		$componentClass = Factory::getApplication()->bootComponent($parts[0]);
+
+		if (!$componentClass instanceof CategoryAwareInterface)
+		{
+			return false;
+		}
+
+		try
+		{
+			$categories = $componentClass->getCategories($options, count($parts) > 1 ? $parts[1] : '');
+		}
+		catch (CategoryNotFoundExceptionInterface $e)
+		{
+			return false;
+		}
 
 		self::$instances[$hash] = $categories;
 

--- a/libraries/src/Categories/CategoryAwareInterface.php
+++ b/libraries/src/Categories/CategoryAwareInterface.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Categories;
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * Access to component specific services.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+interface CategoryAwareInterface
+{
+	/**
+	 * Returns the category service
+	 *
+	 * @param   array   $options  The options
+	 * @param   string  $section  The section
+	 *
+	 * @return  Categories
+	 *
+	 * @see Categories::setOptions()
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  CategoryNotFoundExceptionInterface
+	 */
+	public function getCategories(array $options = [], $section = ''): Categories;
+}

--- a/libraries/src/Categories/CategoryAwareTrait.php
+++ b/libraries/src/Categories/CategoryAwareTrait.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\CMS\Categories;
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * Trait for component Service Providers that support Categories built to implement CategoryAwareInterface
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+trait CategoryAwareTrait
+{
+	/**
+	 * An array of categories.
+	 *
+	 * @var  Categories[]
+	 *
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $categories;
+
+	/**
+	 * Returns the category service
+	 *
+	 * @param   array   $options  The options
+	 * @param   string  $section  The section
+	 *
+	 * @return  Categories
+	 *
+	 * @see Categories::setOptions()
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  CategoryNotFoundExceptionInterface
+	 */
+	public function getCategories(array $options = [], $section = ''): Categories
+	{
+		if (!array_key_exists($section, $this->categories))
+		{
+			throw new Exception\SectionNotFoundException;
+		}
+
+		$categories = clone $this->categories[$section];
+		$categories->setOptions($options);
+
+		return $categories;
+	}
+
+	/**
+	 * An array of categories where the key is the name of the section.
+	 * If the component has no sections then the array must have at least
+	 * an empty key.
+	 *
+	 * @param   array  $categories  The categories
+	 *
+	 * @return  void
+	 *
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public function setCategories(array $categories)
+	{
+		$this->categories = $categories;
+	}
+}

--- a/libraries/src/Categories/CategoryNotFoundExceptionInterface.php
+++ b/libraries/src/Categories/CategoryNotFoundExceptionInterface.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Categories;
+
+/**
+ * Base interface representing when a category cannot be found.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+interface CategoryNotFoundExceptionInterface
+{
+}

--- a/libraries/src/Categories/Exception/CategoriesNotImplementedException.php
+++ b/libraries/src/Categories/Exception/CategoriesNotImplementedException.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Categories\Exception;
+
+use Joomla\CMS\Categories\CategoryNotFoundExceptionInterface;
+
+/**
+ * The component does not support categories.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class CategoriesNotImplementedException extends \RuntimeException implements CategoryNotFoundExceptionInterface
+{
+}

--- a/libraries/src/Categories/Exception/SectionNotFoundException.php
+++ b/libraries/src/Categories/Exception/SectionNotFoundException.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Categories\Exception;
+
+use Joomla\CMS\Categories\CategoryNotFoundExceptionInterface;
+
+/**
+ * The section has not been implemented by the component service provider.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class SectionNotFoundException extends \RuntimeException implements CategoryNotFoundExceptionInterface
+{
+}

--- a/libraries/src/Extension/Component.php
+++ b/libraries/src/Extension/Component.php
@@ -13,6 +13,9 @@ defined('JPATH_PLATFORM') or die;
 use Joomla\CMS\Application\CMSApplicationInterface;
 use Joomla\CMS\Association\AssociationExtensionInterface;
 use Joomla\CMS\Categories\Categories;
+use Joomla\CMS\Categories\CategoryAwareInterface;
+use Joomla\CMS\Categories\CategoryNotFoundExceptionInterface;
+use Joomla\CMS\Categories\Exception\SectionNotFoundException;
 use Joomla\CMS\Dispatcher\DispatcherFactoryInterface;
 use Joomla\CMS\Dispatcher\DispatcherInterface;
 use Joomla\CMS\MVC\Factory\MVCFactoryFactoryInterface;
@@ -23,12 +26,14 @@ use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
  *
  * @since  __DEPLOY_VERSION__
  */
-class Component implements ComponentInterface
+class Component implements ComponentInterface, CategoryAwareInterface
 {
 	/**
 	 * The MVC Factory.
 	 *
 	 * @var MVCFactoryFactoryInterface
+	 *
+	 * @since  __DEPLOY_VERSION__
 	 */
 	private $mvcFactoryFactory;
 
@@ -126,23 +131,23 @@ class Component implements ComponentInterface
 	}
 
 	/**
-	 * Returns the category service. If the service is not available
-	 * null is returned.
+	 * Returns the category service
 	 *
 	 * @param   array   $options  The options
 	 * @param   string  $section  The section
 	 *
-	 * @return  Categories|null
+	 * @return  Categories
 	 *
 	 * @see Categories::setOptions()
 	 *
-	 * @since  __DEPLOY_VERSION__
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  CategoryNotFoundExceptionInterface
 	 */
-	public function getCategories(array $options = [], $section = '')
+	public function getCategories(array $options = [], $section = ''): Categories
 	{
 		if (!array_key_exists($section, $this->categories))
 		{
-			return null;
+			throw new SectionNotFoundException;
 		}
 
 		$categories = clone $this->categories[$section];

--- a/libraries/src/Extension/Component.php
+++ b/libraries/src/Extension/Component.php
@@ -12,10 +12,8 @@ defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Application\CMSApplicationInterface;
 use Joomla\CMS\Association\AssociationExtensionInterface;
-use Joomla\CMS\Categories\Categories;
 use Joomla\CMS\Categories\CategoryAwareInterface;
-use Joomla\CMS\Categories\CategoryNotFoundExceptionInterface;
-use Joomla\CMS\Categories\Exception\SectionNotFoundException;
+use Joomla\CMS\Categories\CategoryAwareTrait;
 use Joomla\CMS\Dispatcher\DispatcherFactoryInterface;
 use Joomla\CMS\Dispatcher\DispatcherInterface;
 use Joomla\CMS\MVC\Factory\MVCFactoryFactoryInterface;
@@ -28,6 +26,8 @@ use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
  */
 class Component implements ComponentInterface, CategoryAwareInterface
 {
+	use CategoryAwareTrait;
+
 	/**
 	 * The MVC Factory.
 	 *
@@ -36,15 +36,6 @@ class Component implements ComponentInterface, CategoryAwareInterface
 	 * @since  __DEPLOY_VERSION__
 	 */
 	private $mvcFactoryFactory;
-
-	/**
-	 * An array of categories.
-	 *
-	 * @var array
-	 *
-	 * @since  __DEPLOY_VERSION__
-	 */
-	private $categories;
 
 	/**
 	 * The dispatcher factory.
@@ -128,48 +119,6 @@ class Component implements ComponentInterface, CategoryAwareInterface
 	public function setMvcFactory(MVCFactoryFactoryInterface $mvcFactoryFactory)
 	{
 		$this->mvcFactoryFactory = $mvcFactoryFactory;
-	}
-
-	/**
-	 * Returns the category service
-	 *
-	 * @param   array   $options  The options
-	 * @param   string  $section  The section
-	 *
-	 * @return  Categories
-	 *
-	 * @see Categories::setOptions()
-	 *
-	 * @since   __DEPLOY_VERSION__
-	 * @throws  CategoryNotFoundExceptionInterface
-	 */
-	public function getCategories(array $options = [], $section = ''): Categories
-	{
-		if (!array_key_exists($section, $this->categories))
-		{
-			throw new SectionNotFoundException;
-		}
-
-		$categories = clone $this->categories[$section];
-		$categories->setOptions($options);
-
-		return $categories;
-	}
-
-	/**
-	 * An array of categories where the key is the name of the section.
-	 * If the component has no sections then the array must have at least
-	 * an empty key.
-	 *
-	 * @param   array  $categories  The categories
-	 *
-	 * @return  void
-	 *
-	 * @since  __DEPLOY_VERSION__
-	 */
-	public function setCategories(array $categories)
-	{
-		$this->categories = $categories;
 	}
 
 	/**

--- a/libraries/src/Extension/Component.php
+++ b/libraries/src/Extension/Component.php
@@ -11,7 +11,8 @@ namespace Joomla\CMS\Extension;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Application\CMSApplicationInterface;
-use Joomla\CMS\Association\AssociationExtensionInterface;
+use Joomla\CMS\Association\AssociationAwareInterface;
+use Joomla\CMS\Association\AssociationAwareTrait;
 use Joomla\CMS\Categories\CategoryAwareInterface;
 use Joomla\CMS\Categories\CategoryAwareTrait;
 use Joomla\CMS\Dispatcher\DispatcherFactoryInterface;
@@ -24,9 +25,9 @@ use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
  *
  * @since  __DEPLOY_VERSION__
  */
-class Component implements ComponentInterface, CategoryAwareInterface
+class Component implements ComponentInterface, CategoryAwareInterface, AssociationAwareInterface
 {
-	use CategoryAwareTrait;
+	use CategoryAwareTrait, AssociationAwareTrait;
 
 	/**
 	 * The MVC Factory.
@@ -45,15 +46,6 @@ class Component implements ComponentInterface, CategoryAwareInterface
 	 * @since  __DEPLOY_VERSION__
 	 */
 	private $dispatcherFactory;
-
-	/**
-	 * The association extension.
-	 *
-	 * @var AssociationExtensionInterface
-	 *
-	 * @since  __DEPLOY_VERSION__
-	 */
-	private $associationExtension;
 
 	/**
 	 * Returns the dispatcher for the given application.
@@ -119,31 +111,5 @@ class Component implements ComponentInterface, CategoryAwareInterface
 	public function setMvcFactory(MVCFactoryFactoryInterface $mvcFactoryFactory)
 	{
 		$this->mvcFactoryFactory = $mvcFactoryFactory;
-	}
-
-	/**
-	 * Returns the associations helper.
-	 *
-	 * @return  AssociationExtensionInterface|null
-	 *
-	 * @since  __DEPLOY_VERSION__
-	 */
-	public function getAssociationsExtension()
-	{
-		return $this->associationExtension;
-	}
-
-	/**
-	 * The association extension.
-	 *
-	 * @param   AssociationExtensionInterface  $associationExtension  The extension
-	 *
-	 * @return void
-	 *
-	 * @since  __DEPLOY_VERSION__
-	 */
-	public function setAssociationExtension(AssociationExtensionInterface $associationExtension)
-	{
-		$this->associationExtension = $associationExtension;
 	}
 }

--- a/libraries/src/Extension/ComponentInterface.php
+++ b/libraries/src/Extension/ComponentInterface.php
@@ -11,7 +11,6 @@ namespace Joomla\CMS\Extension;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Application\CMSApplicationInterface;
-use Joomla\CMS\Association\AssociationExtensionInterface;
 use Joomla\CMS\Dispatcher\DispatcherInterface;
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
 
@@ -43,13 +42,4 @@ interface ComponentInterface
 	 * @since  __DEPLOY_VERSION__
 	 */
 	public function createMVCFactory(CMSApplicationInterface $application): MVCFactoryInterface;
-
-	/**
-	 * Returns the associations extension helper class.
-	 *
-	 * @return  AssociationExtensionInterface|null
-	 *
-	 * @since  __DEPLOY_VERSION__
-	 */
-	public function getAssociationsExtension();
 }

--- a/libraries/src/Extension/ComponentInterface.php
+++ b/libraries/src/Extension/ComponentInterface.php
@@ -12,7 +12,6 @@ defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Application\CMSApplicationInterface;
 use Joomla\CMS\Association\AssociationExtensionInterface;
-use Joomla\CMS\Categories\Categories;
 use Joomla\CMS\Dispatcher\DispatcherInterface;
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
 
@@ -44,21 +43,6 @@ interface ComponentInterface
 	 * @since  __DEPLOY_VERSION__
 	 */
 	public function createMVCFactory(CMSApplicationInterface $application): MVCFactoryInterface;
-
-	/**
-	 * Returns the category service. If the service is not available
-	 * null is returned.
-	 *
-	 * @param   array   $options  The options
-	 * @param   string  $section  The section
-	 *
-	 * @return  Categories|null
-	 *
-	 * @see Categories::setOptions()
-	 *
-	 * @since  __DEPLOY_VERSION__
-	 */
-	public function getCategories(array $options = [], $section = '');
 
 	/**
 	 * Returns the associations extension helper class.

--- a/libraries/src/Extension/LegacyComponent.php
+++ b/libraries/src/Extension/LegacyComponent.php
@@ -13,6 +13,9 @@ defined('JPATH_PLATFORM') or die;
 use Joomla\CMS\Application\CMSApplicationInterface;
 use Joomla\CMS\Association\AssociationExtensionInterface;
 use Joomla\CMS\Categories\Categories;
+use Joomla\CMS\Categories\CategoryAwareInterface;
+use Joomla\CMS\Categories\CategoryNotFoundExceptionInterface;
+use Joomla\CMS\Categories\Exception\CategoriesNotImplementedException;
 use Joomla\CMS\Dispatcher\DispatcherInterface;
 use Joomla\CMS\Dispatcher\LegacyDispatcher;
 use Joomla\CMS\MVC\Factory\LegacyFactory;
@@ -24,7 +27,7 @@ use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
  *
  * @since  __DEPLOY_VERSION__
  */
-class LegacyComponent implements ComponentInterface
+class LegacyComponent implements ComponentInterface, CategoryAwareInterface
 {
 	/**
 	 * @var string
@@ -91,8 +94,9 @@ class LegacyComponent implements ComponentInterface
 	 * @see Categories::setOptions()
 	 *
 	 * @since  __DEPLOY_VERSION__
+	 * @throws CategoryNotFoundExceptionInterface
 	 */
-	public function getCategories(array $options = [], $section = '')
+	public function getCategories(array $options = [], $section = ''): Categories
 	{
 		$classname = ucfirst($this->component) . ucfirst($section) . 'Categories';
 
@@ -102,7 +106,7 @@ class LegacyComponent implements ComponentInterface
 
 			if (!is_file($path))
 			{
-				return null;
+				throw new CategoriesNotImplementedException;
 			}
 
 			include_once $path;
@@ -110,7 +114,7 @@ class LegacyComponent implements ComponentInterface
 
 		if (!class_exists($classname))
 		{
-			return null;
+			throw new CategoriesNotImplementedException;
 		}
 
 		return new $classname($options);

--- a/libraries/src/Extension/LegacyComponent.php
+++ b/libraries/src/Extension/LegacyComponent.php
@@ -11,7 +11,9 @@ namespace Joomla\CMS\Extension;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Application\CMSApplicationInterface;
+use Joomla\CMS\Association\AssociationAwareInterface;
 use Joomla\CMS\Association\AssociationExtensionInterface;
+use Joomla\CMS\Association\Exception\AssociationsNotImplementedException;
 use Joomla\CMS\Categories\Categories;
 use Joomla\CMS\Categories\CategoryAwareInterface;
 use Joomla\CMS\Categories\CategoryNotFoundExceptionInterface;
@@ -27,7 +29,7 @@ use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
  *
  * @since  __DEPLOY_VERSION__
  */
-class LegacyComponent implements ComponentInterface, CategoryAwareInterface
+class LegacyComponent implements ComponentInterface, CategoryAwareInterface, AssociationAwareInterface
 {
 	/**
 	 * @var string
@@ -123,11 +125,12 @@ class LegacyComponent implements ComponentInterface, CategoryAwareInterface
 	/**
 	 * Returns the associations helper.
 	 *
-	 * @return  AssociationExtensionInterface|null
+	 * @return  AssociationExtensionInterface
 	 *
-	 * @since  __DEPLOY_VERSION__
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  AssociationsNotImplementedException
 	 */
-	public function getAssociationsExtension()
+	public function getAssociationsExtension(): AssociationExtensionInterface
 	{
 		$className = ucfirst($this->component) . 'AssociationsHelper';
 
@@ -139,7 +142,7 @@ class LegacyComponent implements ComponentInterface, CategoryAwareInterface
 		// Check if associations helper exists
 		if (!file_exists(JPATH_ADMINISTRATOR . '/components/com_' . $this->component . '/helpers/associations.php'))
 		{
-			return null;
+			throw new AssociationsNotImplementedException;
 		}
 
 		require_once JPATH_ADMINISTRATOR . '/components/com_' . $this->component . '/helpers/associations.php';

--- a/libraries/src/MVC/Factory/MVCFactoryFactory.php
+++ b/libraries/src/MVC/Factory/MVCFactoryFactory.php
@@ -51,7 +51,6 @@ class MVCFactoryFactory implements MVCFactoryFactoryInterface, FormFactoryAwareI
 	 * @return  \Joomla\CMS\MVC\Factory\MVCFactoryInterface
 	 *
 	 * @since   __DEPLOY_VERSION__
-	 * @throws  \Exception
 	 */
 	public function createFactory(CMSApplicationInterface $application): MVCFactoryInterface
 	{

--- a/libraries/src/MVC/Factory/MVCFactoryFactoryInterface.php
+++ b/libraries/src/MVC/Factory/MVCFactoryFactoryInterface.php
@@ -27,7 +27,6 @@ interface MVCFactoryFactoryInterface
 	 * @return  \Joomla\CMS\MVC\Factory\MVCFactoryInterface
 	 *
 	 * @since   __DEPLOY_VERSION__
-	 * @throws  \Exception
 	 */
 	public function createFactory(CMSApplicationInterface $application): MVCFactoryInterface;
 }


### PR DESCRIPTION
- No hardcoding namespaces in the provider - grab them from the db so there's a single point of truth
- Use a feature interface for categories with an exception interface