### PR TITLE
Tooltips not loading com_users

### DIFF
--- a/components/com_users/views/profile/tmpl/edit.php
+++ b/components/com_users/views/profile/tmpl/edit.php
@@ -12,6 +12,8 @@ defined('_JEXEC') or die;
 JHtml::_('behavior.keepalive');
 JHtml::_('behavior.formvalidator');
 JHtml::_('formbehavior.chosen', 'select');
+JHtml::_('bootstrap.tooltip');
+
 
 // Load user_profile plugin language
 $lang = JFactory::getLanguage();


### PR DESCRIPTION
The edit profile form is not loading the bootstrap tooltip code. So any tooltip (not popovers) are displayed as html, for example when TFA is enabled.

This was spotted by @o2tsen and @sandewt while testing #20051 but as it is a bug effecting more than that PR I have created a new PR. (a pr should only fix one problem)

