### PR TITLE
Fix overwrite by .table-striped

### DIFF
--- a/media/system/css/fields/calendar.css
+++ b/media/system/css/fields/calendar.css
@@ -83,7 +83,7 @@ div.calendar-container table td.title { /* This holds the current "month, year" 
 	background-color: #f4f4f4;
 }
 
-.calendar-container table tbody td.selected { /* Cell showing today date */
+.calendar-container table tbody td.day.selected { /* Cell showing today date */
 	background: #3071a9;
 	color: #fff;
 	border: 0;


### PR DESCRIPTION
Fix overwrite by administrator/templates/isis/css/template.css line 1787

table.table-striped tbody > tr:nth-child(odd) > td,
table.table-striped tbody > tr:nth-child(odd) > th {
	background-color: #f9f9f9;
}

Pull Request for Issue # .

### Summary of Changes



### Testing Instructions



### Expected result



### Actual result



### Documentation Changes Required

