### PR TITLE
[4.0] Lookup layout path first in tmpl

### DIFF
--- a/libraries/src/MVC/View/HtmlView.php
+++ b/libraries/src/MVC/View/HtmlView.php
@@ -126,6 +126,10 @@ class HtmlView extends AbstractView
 			// User-defined dirs
 			$this->_setPath('template', $config['template_path']);
 		}
+		elseif (is_dir($this->_basePath . '/tmpl/' . $this->getName()))
+		{
+			$this->_setPath('template', $this->_basePath . '/tmpl/' . $this->getName());
+		}
 		elseif (is_dir($this->_basePath . '/View/' . $this->getName() . '/tmpl'))
 		{
 			$this->_setPath('template', $this->_basePath . '/View/' . $this->getName() . '/tmpl');
@@ -133,10 +137,6 @@ class HtmlView extends AbstractView
 		elseif (is_dir($this->_basePath . '/view/' . $this->getName() . '/tmpl'))
 		{
 			$this->_setPath('template', $this->_basePath . '/view/' . $this->getName() . '/tmpl');
-		}
-		elseif (is_dir($this->_basePath . '/tmpl/' . $this->getName()))
-		{
-			$this->_setPath('template', $this->_basePath . '/tmpl/' . $this->getName());
 		}
 		elseif (is_dir($this->_basePath . '/views/' . $this->getName() . '/tmpl'))
 		{


### PR DESCRIPTION
Pull Request based on comment https://github.com/joomla/joomla-cms/pull/20088#issuecomment-379719609.

### Summary of Changes
When upgrading a "New MVC" extension to the namespaced one where the layout files are in the top level /tmpl folder of the extension (eg. /components/com_foo/tmpl), then we have a path lookup issue. The folder /components/com_foo/view/myview/tmpl does then still exists with the old files as they will not get erased on upgrade.

This pr moves the top level folder as first choice in the path lookup, so it has the same logic as with the "Legacy MVC" views set up.

### Testing Instructions
- Create the folder /components/com_config/view/modules/tmpl
- Edit a module

### Expected result
Module can be edited.

### Actual result
Error: _500 Layout default not found._


### Documentation Changes Required

