### PR TITLE
[4.0] Remove duplicate class="custom-select"

### DIFF
--- a/libraries/cms/html/select.php
+++ b/libraries/cms/html/select.php
@@ -219,7 +219,7 @@ abstract class JHtmlSelect
 
 		$baseIndent = str_repeat($options['format.indent'], $options['format.depth']++);
 		$html = $baseIndent . '<select' . ($id !== '' ? ' id="' . $id . '"' : '')
-				. ' name="' . $name . '"' . $attribs . ' class="custom-select">' . $options['format.eol'];
+				. ' name="' . $name . '"' . $attribs . '>' . $options['format.eol'];
 		$groupIndent = str_repeat($options['format.indent'], $options['format.depth']++);
 
 		foreach ($data as $dataKey => $group)


### PR DESCRIPTION
### Summary of Changes
Remove duplicate `class="custom-select"`.


### Testing Instructions
Go to Menus > Main Menu
View page source
Search for `<select id="menutype"`
`class="custom-select"` listed twice.


### Expected result
`<select id="menutype" name="menutype"  class="custom-select" onchange="this.form.submit();">`


### Actual result
`<select id="menutype" name="menutype"  class="custom-select" onchange="this.form.submit();" class="custom-select">`

