### PR TITLE
[com_content] Fix layout in category link

### DIFF
--- a/components/com_content/helpers/route.php
+++ b/components/com_content/helpers/route.php
@@ -79,10 +79,8 @@ abstract class ContentHelperRoute
 				$link .= '&lang=' . $language;
 			}
 
-			$jinput = JFactory::getApplication()->input;
-			$layout = $jinput->get('layout');
-
-			if ($layout !== '')
+			$layout = JFactory::getApplication()->input->get('layout', '', 'string');
+			if (!empty($layout))
 			{
 				$link .= '&layout=' . $layout;
 			}

--- a/components/com_content/helpers/route.php
+++ b/components/com_content/helpers/route.php
@@ -79,9 +79,11 @@ abstract class ContentHelperRoute
 				$link .= '&lang=' . $language;
 			}
 
-			$layout = JFactory::getApplication()->input->get('layout', '', 'string');
+			$component = JFactory::getApplication()->input->get('option', '', 'CMD');
+			$view      = JFactory::getApplication()->input->get('view', '', 'CMD');
+			$layout    = JFactory::getApplication()->input->get('layout', '', 'string');
 
-			if ($layout)
+			if ($component === 'com_content' && $view === 'category' && $layout)
 			{
 				$link .= '&layout=' . $layout;
 			}

--- a/components/com_content/helpers/route.php
+++ b/components/com_content/helpers/route.php
@@ -81,7 +81,7 @@ abstract class ContentHelperRoute
 
 			$layout = JFactory::getApplication()->input->get('layout', '', 'string');
 
-			if (!empty($layout))
+			if ($layout)
 			{
 				$link .= '&layout=' . $layout;
 			}

--- a/components/com_content/helpers/route.php
+++ b/components/com_content/helpers/route.php
@@ -80,6 +80,7 @@ abstract class ContentHelperRoute
 			}
 
 			$layout = JFactory::getApplication()->input->get('layout', '', 'string');
+
 			if (!empty($layout))
 			{
 				$link .= '&layout=' . $layout;

--- a/components/com_content/helpers/route.php
+++ b/components/com_content/helpers/route.php
@@ -79,9 +79,10 @@ abstract class ContentHelperRoute
 				$link .= '&lang=' . $language;
 			}
 
-			$component = JFactory::getApplication()->input->get('option', '', 'CMD');
-			$view      = JFactory::getApplication()->input->get('view', '', 'CMD');
-			$layout    = JFactory::getApplication()->input->get('layout', '', 'string');
+			$app       = JFactory::getApplication();
+			$component = $app->input->get('option', '', 'CMD');
+			$view      = $app->input->get('view', '', 'CMD');
+			$layout    = $app->input->get('layout', '', 'string');
 
 			if ($component === 'com_content' && $view === 'category' && $layout)
 			{


### PR DESCRIPTION
Pull Request for Issue #20199.

### Summary of Changes
Fix bag with `?layout=` in com_content category link after  #19681

### Testing Instructions
If you have this bug, apply the patch

### How reproduce bug by @Quy 
* Install the last demo.
* Under System > Global Configuration > Articles > Integration > URL Routing, select `Modern`
* Search `Park Blog`
* Hover Park Blog link to see URL:  
`http://localhost/joomla387/index.php/using-joomla/extensions/components/content-component/article-category-blog?layout=`


### Expected result
Link was `/category`


### Actual result
Now link `/category?layout=` or `/category?layout=templatelayout` if override com_content category view

