### PR TITLE
[fix] publish does not work with tables using null as default checked_out value

### DIFF
--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -1582,7 +1582,13 @@ abstract class Table extends \JObject implements \JObservableInterface, \JTableI
 			// Determine if there is checkin support for the table.
 			if (property_exists($this, 'checked_out') || property_exists($this, 'checked_out_time'))
 			{
-				$query->where('(' . $this->_db->quoteName($checkedOutField) . ' = 0 OR ' . $this->_db->quoteName($checkedOutField) . ' = ' . (int) $userId . ')');
+				$query->where(
+					'('
+						. $this->_db->quoteName($checkedOutField) . ' = 0'
+						. ' OR ' . $this->_db->quoteName($checkedOutField) . ' = ' . (int) $userId
+						. ' OR ' . $this->_db->quoteName($checkedOutField) . ' IS NULL'
+					. ')'
+				);
 				$checkin = true;
 			}
 			else


### PR DESCRIPTION
### Summary of Changes

Technically what joomla does to set an item as checked out is to set the `checked_out` column to `0`. If you have a proper DB schema you probably have a foreign key that connects your `checkout_out` column to `#__users` table. But joomla does not allow to do this because `0` cannot be assigned because there is no user with id `0`. 

So:
* the correct checked_out column values should be `NULL` or values > 0.
* values checked by joomla are `0` or values > 0

For backward compatibility we cannot change current allowed values. This pull request changes publish checked out check to accept:

* `NULL`
* `0`
* values > 0

Which should be ok to keep current behaviour but not punishing those that want to use correct foreign keys. Keep compatibility allowing correct DB schemas to be used.

### Testing Instructions

After applying this patch go to articles and publish/unpublish items. Do the same for any other management you want like banners, etc. Ensure that things work as expected.

### Documentation Changes Required

No changes required.