### PR TITLE
Name attribute is deprecated, in the future fetch the pathway through the respective application

### DIFF
--- a/libraries/src/Application/SiteApplication.php
+++ b/libraries/src/Application/SiteApplication.php
@@ -383,7 +383,7 @@ final class SiteApplication extends CMSApplication
 	 *
 	 * @since   3.2
 	 */
-	public function getPathway($name = 'site', $options = array())
+	public function getPathway($name = null, $options = array())
 	{
 		return parent::getPathway($name, $options);
 	}


### PR DESCRIPTION
Pull Request for Issue #20203 .

### Summary of Changes
Because $name attribute in \Joomla\CMS\Application\CMSApplication::getPathway is deprecated, \Joomla\CMS\Application\SiteApplication::getPathway should also not provide a hardcoded name.

### Testing Instructions

1. Use following code

```php
$app = JFactory::getApplication();
$pathway = $app->getPathway();

//debug
echo '<pre>';
var_dump($pathway);
echo '</pre>';
```
2. Open page where you use it.
3. Open /logs/deprecated.php check if there is message 'Name attribute is deprecated, in the future fetch the pathway...'.
4. Delete log file and apply patch
5. Reload page where you use the code
6. Check log again. No deprecated message should be there anymore.
7. Compare output of var_dump before/after.

### Expected result
Behavior like before, but no deprecated message in log file.

### Actual result
Deprecated message 'Name attribute is deprecated, in the future fetch the pathway through the respective application' in log, when `Factory::getApplication()->getPathway();` is used without attributes.

### Documentation Changes Required
I don't think so.
