### PR TITLE
Fix for: FileLayout::refreshIncludePaths is deprecated, use FileLayout::clearIncludePaths() instead.

### DIFF
--- a/libraries/src/Layout/FileLayout.php
+++ b/libraries/src/Layout/FileLayout.php
@@ -469,8 +469,8 @@ class FileLayout extends BaseLayout
 
 		$this->options->set('component', $component);
 
-		// Refresh include paths
-		$this->refreshIncludePaths();
+		// Clear include paths
+		$this->clearIncludePaths();
 	}
 
 	/**
@@ -504,8 +504,8 @@ class FileLayout extends BaseLayout
 
 		$this->options->set('client', $client);
 
-		// Refresh include paths
-		$this->refreshIncludePaths();
+		// Clear include paths
+		$this->clearIncludePaths();
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue #20207.

### Summary of Changes
setComponent() and setClient() in `\Joomla\CMS\Layout\FileLayout` now using `clearIncludePaths()` instead of `$this->refreshIncludePaths()`


### Testing Instructions

1. Use LayoutHelper::render() to render a layout.
2. Check your deprecated log before and after the patch is applied.
3. Functionality should stay the same, but now without deprecated message in log.

### Expected result
No more message 'FileLayout::refreshIncludePaths is deprecated, use FileLayout::clearIncludePaths() instead.' in /logs/deprecated.php

### Actual result
Message 'FileLayout::refreshIncludePaths is deprecated, use FileLayout::clearIncludePaths() instead.' in /logs/deprecated.php


### Documentation Changes Required
No.

