### PR TITLE
Fix subform.repeatable-table multi field styling

### DIFF
--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -10058,10 +10058,3 @@ a.grid_true {
 	border-right: 0;
 	border-left: 1px solid rgba(0,0,0,0.08);
 }
-.btn-group > .btn:first-child,
-.radio.btn-group > label:first-of-type {
-	margin-left: 0;
-	-webkit-border-radius: 0 4px 4px 0;
-	-moz-border-radius: 0 4px 4px 0;
-	border-radius: 0 4px 4px 0;
-}

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -10058,3 +10058,10 @@ a.grid_true {
 	border-right: 0;
 	border-left: 1px solid rgba(0,0,0,0.08);
 }
+.btn-group > .btn:first-child,
+.radio.btn-group > label:first-of-type {
+	margin-left: 0;
+	-webkit-border-radius: 0 4px 4px 0;
+	-moz-border-radius: 0 4px 4px 0;
+	border-radius: 0 4px 4px 0;
+}

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -7538,7 +7538,9 @@ textarea.noResize {
 		margin-bottom: 10px;
 	}
 }
-.subform-table-layout .control-group,
+.subform-table-layout .control-group {
+	margin-bottom: 10px;
+}
 .subform-table-layout .control-group:last-of-type {
 	margin-bottom: 0;
 }
@@ -9351,22 +9353,6 @@ body {
 }
 .pager .previous a {
 	float: right;
-}
-.btn-group > .btn:first-child,
-.radio.btn-group > label:first-of-type {
-	margin-left: 0;
-	-webkit-border-bottom-left-radius: 0px;
-	border-bottom-left-radius: 0px;
-	-webkit-border-top-left-radius: 0px;
-	border-top-left-radius: 0px;
-	-moz-border-radius-bottomleft: 0px;
-	-moz-border-radius-topleft: 0px;
-	-webkit-border-bottom-right-radius: 4px;
-	border-bottom-right-radius: 4px;
-	-webkit-border-top-right-radius: 4px;
-	border-top-right-radius: 4px;
-	-moz-border-radius-bottomright: 4px;
-	-moz-border-radius-topright: 4px;
 }
 .icon-arrow-right {
 	background-position: -241px -94px;

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -7538,7 +7538,9 @@ textarea.noResize {
 		margin-bottom: 10px;
 	}
 }
-.subform-table-layout .control-group,
+.subform-table-layout .control-group {
+	margin-bottom: 10px;
+}
 .subform-table-layout .control-group:last-of-type {
 	margin-bottom: 0;
 }

--- a/administrator/templates/isis/less/blocks/_forms.less
+++ b/administrator/templates/isis/less/blocks/_forms.less
@@ -253,8 +253,11 @@ textarea.noResize {
 }
 
 .subform-table-layout {
-	.control-group, .control-group:last-of-type {
-		margin-bottom: 0;
+	.control-group {
+		margin-bottom: 10px;
+		&:last-of-type {
+			margin-bottom: 0;
+		}
 	}
 	.controls {
 		padding-right: 20px;

--- a/administrator/templates/isis/less/template-rtl.less
+++ b/administrator/templates/isis/less/template-rtl.less
@@ -434,9 +434,3 @@ a.grid_true {
 		}
 	}
 }
-
-.btn-group > .btn:first-child,
-.radio.btn-group > label:first-of-type {
-	margin-left: 0;
-	.border-radius(0 4px 4px 0);
-}

--- a/administrator/templates/isis/less/template-rtl.less
+++ b/administrator/templates/isis/less/template-rtl.less
@@ -434,3 +434,9 @@ a.grid_true {
 		}
 	}
 }
+
+.btn-group > .btn:first-child,
+.radio.btn-group > label:first-of-type {
+	margin-left: 0;
+	.border-radius(0 4px 4px 0);
+}


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/17589#issuecomment-323596736 .

### Summary of Changes
Fixes subform.repeatable-table styling when multiple fields are placed in the same cell.

#### Before PR
![image](https://user-images.githubusercontent.com/2803503/39093400-3b3be2e6-4617-11e8-94ec-c5d5623c916a.png)

#### After PR
![image](https://user-images.githubusercontent.com/2803503/39093410-5f1a17b4-4617-11e8-8a0d-3c6fa7c05cb9.png)

### Testing Instructions
Add the following after https://github.com/joomla/joomla-cms/blob/staging/modules/mod_login/mod_login.xml#L26

```
<field name="sebform1" type="subform" label="subform"
	layout="joomla.form.field.subform.repeatable-table" multiple="true" groupByFieldset="true">
	<form>
		<fieldset name="group1" label="group 1">
			<field type="text" name="text" label="text 1"/>
			<field type="text" name="text2" label="text 2"/>
			<field type="text" name="text3" label="text 3"/>
		</fieldset>
		<fieldset name="group2" label="group 2">
			<field type="text" name="text4" label="text 4"/>
			<field type="textarea" name="textarea" label="textarea"/>
		</fieldset>
	</form>
</field>
```
Open login module settings. Check repeatable field styling.

