### PR TITLE
[com_content] Correctly adding layout to links

### DIFF
--- a/administrator/components/com_categories/helpers/association.php
+++ b/administrator/components/com_categories/helpers/association.php
@@ -25,12 +25,13 @@ abstract class CategoryHelperAssociation
 	 *
 	 * @param   integer  $id         Id of the item
 	 * @param   string   $extension  Name of the component
+	 * @param   string   $layout     Category layout
 	 *
 	 * @return  array    Array of associations for the component categories
 	 *
 	 * @since  3.0
 	 */
-	public static function getCategoryAssociations($id = 0, $extension = 'com_content')
+	public static function getCategoryAssociations($id = 0, $extension = 'com_content', $layout = null)
 	{
 		$return = array();
 
@@ -46,11 +47,11 @@ abstract class CategoryHelperAssociation
 			{
 				if (class_exists($helperClassname) && is_callable(array($helperClassname, 'getCategoryRoute')))
 				{
-					$return[$tag] = $helperClassname::getCategoryRoute($item, $tag);
+					$return[$tag] = $helperClassname::getCategoryRoute($item, $tag, $layout);
 				}
 				else
 				{
-					$return[$tag] = 'index.php?option=' . $extension . '&view=category&id=' . $item;
+					$return[$tag] = 'index.php?option=' . $extension . '&view=category&id=' . $item . '&layout=' . $layout;
 				}
 			}
 		}

--- a/components/com_content/helpers/association.php
+++ b/components/com_content/helpers/association.php
@@ -35,7 +35,7 @@ abstract class ContentHelperAssociation extends CategoryHelperAssociation
 	{
 		$jinput = JFactory::getApplication()->input;
 		$view   = $view === null ? $jinput->get('view') : $view;
-		$layout = $layout === null ? $jinput->get('view', '', 'string') : $view;
+		$layout = $layout === null ? $jinput->get('layout', '', 'string') : $layout;
 		$id     = empty($id) ? $jinput->getInt('id') : $id;
 		$user   = JFactory::getUser();
 		$groups = implode(',', $user->getAuthorisedViewLevels());

--- a/components/com_content/helpers/association.php
+++ b/components/com_content/helpers/association.php
@@ -23,17 +23,19 @@ abstract class ContentHelperAssociation extends CategoryHelperAssociation
 	/**
 	 * Method to get the associations for a given item
 	 *
-	 * @param   integer  $id    Id of the item
-	 * @param   string   $view  Name of the view
+	 * @param   integer  $id      Id of the item
+	 * @param   string   $view    Name of the view
+	 * @param   string   $layout  View layout
 	 *
 	 * @return  array   Array of associations for the item
 	 *
 	 * @since  3.0
 	 */
-	public static function getAssociations($id = 0, $view = null)
+	public static function getAssociations($id = 0, $view = null, $layout = null)
 	{
 		$jinput = JFactory::getApplication()->input;
 		$view   = $view === null ? $jinput->get('view') : $view;
+		$layout = $layout === null ? $jinput->get('view', '', 'string') : $view;
 		$id     = empty($id) ? $jinput->getInt('id') : $id;
 		$user   = JFactory::getUser();
 		$groups = implode(',', $user->getAuthorisedViewLevels());
@@ -65,7 +67,7 @@ abstract class ContentHelperAssociation extends CategoryHelperAssociation
 
 						if ($result > 0)
 						{
-							$return[$tag] = ContentHelperRoute::getArticleRoute($item->id, (int) $item->catid, $item->language);
+							$return[$tag] = ContentHelperRoute::getArticleRoute($item->id, (int) $item->catid, $item->language, $layout);
 						}
 					}
 				}

--- a/components/com_content/helpers/association.php
+++ b/components/com_content/helpers/association.php
@@ -50,10 +50,7 @@ abstract class ContentHelperAssociation extends CategoryHelperAssociation
 				{
 					if ($item->language != JFactory::getLanguage()->getTag())
 					{
-						$arrId   = explode(':', $item->id);
-						$assocId = $arrId[0];
-
-						$return[$tag] = ContentHelperRoute::getArticleRoute($assocId, (int) $item->catid, $item->language, $layout);
+						$return[$tag] = ContentHelperRoute::getArticleRoute($item->id, (int) $item->catid, $item->language, $layout);
 					}
 				}
 

--- a/components/com_content/helpers/association.php
+++ b/components/com_content/helpers/association.php
@@ -78,7 +78,7 @@ abstract class ContentHelperAssociation extends CategoryHelperAssociation
 
 		if ($view === 'category' || $view === 'categories')
 		{
-			return self::getCategoryAssociations($id, 'com_content');
+			return self::getCategoryAssociations($id, 'com_content', $layout);
 		}
 
 		return array();

--- a/components/com_content/helpers/association.php
+++ b/components/com_content/helpers/association.php
@@ -37,8 +37,6 @@ abstract class ContentHelperAssociation extends CategoryHelperAssociation
 		$view   = $view === null ? $jinput->get('view') : $view;
 		$layout = $layout === null ? $jinput->get('layout', '', 'string') : $layout;
 		$id     = empty($id) ? $jinput->getInt('id') : $id;
-		$user   = JFactory::getUser();
-		$groups = implode(',', $user->getAuthorisedViewLevels());
 
 		if ($view === 'article')
 		{
@@ -55,20 +53,7 @@ abstract class ContentHelperAssociation extends CategoryHelperAssociation
 						$arrId   = explode(':', $item->id);
 						$assocId = $arrId[0];
 
-						$db    = JFactory::getDbo();
-						$query = $db->getQuery(true)
-							->select($db->qn('state'))
-							->from($db->qn('#__content'))
-							->where($db->qn('id') . ' = ' . (int) ($assocId))
-							->where('access IN (' . $groups . ')');
-						$db->setQuery($query);
-
-						$result = (int) $db->loadResult();
-
-						if ($result > 0)
-						{
-							$return[$tag] = ContentHelperRoute::getArticleRoute($item->id, (int) $item->catid, $item->language, $layout);
-						}
+						$return[$tag] = ContentHelperRoute::getArticleRoute($assocId, (int) $item->catid, $item->language, $layout);
 					}
 				}
 

--- a/components/com_content/helpers/route.php
+++ b/components/com_content/helpers/route.php
@@ -19,15 +19,16 @@ abstract class ContentHelperRoute
 	/**
 	 * Get the article route.
 	 *
-	 * @param   integer  $id        The route of the content item.
-	 * @param   integer  $catid     The category ID.
-	 * @param   integer  $language  The language code.
+	 * @param   integer $id       The route of the content item.
+	 * @param   integer $catid    The category ID.
+	 * @param   integer $language The language code.
+	 * @param   string  $layout   The Article layout
 	 *
 	 * @return  string  The article route.
 	 *
 	 * @since   1.5
 	 */
-	public static function getArticleRoute($id, $catid = 0, $language = 0)
+	public static function getArticleRoute($id, $catid = 0, $language = 0, $layout = null)
 	{
 		// Create the link
 		$link = 'index.php?option=com_content&view=article&id=' . $id;
@@ -42,20 +43,26 @@ abstract class ContentHelperRoute
 			$link .= '&lang=' . $language;
 		}
 
+		if ($layout)
+		{
+			$link .= '&layout=' . $layout;
+		}
+
 		return $link;
 	}
 
 	/**
 	 * Get the category route.
 	 *
-	 * @param   integer  $catid     The category ID.
-	 * @param   integer  $language  The language code.
+	 * @param   integer $catid    The category ID.
+	 * @param   integer $language The language code.
+	 * @param   string  $layout   The category layout
 	 *
 	 * @return  string  The article route.
 	 *
 	 * @since   1.5
 	 */
-	public static function getCategoryRoute($catid, $language = 0)
+	public static function getCategoryRoute($catid, $language = 0, $layout = null)
 	{
 		if ($catid instanceof JCategoryNode)
 		{
@@ -77,6 +84,11 @@ abstract class ContentHelperRoute
 			if ($language && $language !== '*' && JLanguageMultilang::isEnabled())
 			{
 				$link .= '&lang=' . $language;
+			}
+
+			if ($layout)
+			{
+				$link .= '&layout=' . $layout;
 			}
 		}
 

--- a/components/com_content/helpers/route.php
+++ b/components/com_content/helpers/route.php
@@ -19,10 +19,10 @@ abstract class ContentHelperRoute
 	/**
 	 * Get the article route.
 	 *
-	 * @param   integer $id       The route of the content item.
-	 * @param   integer $catid    The category ID.
-	 * @param   integer $language The language code.
-	 * @param   string  $layout   The Article layout
+	 * @param   integer  $id        The route of the content item.
+	 * @param   integer  $catid     The category ID.
+	 * @param   integer  $language  The language code.
+	 * @param   string   $layout    The Article layout
 	 *
 	 * @return  string  The article route.
 	 *
@@ -54,9 +54,9 @@ abstract class ContentHelperRoute
 	/**
 	 * Get the category route.
 	 *
-	 * @param   integer $catid    The category ID.
-	 * @param   integer $language The language code.
-	 * @param   string  $layout   The category layout
+	 * @param   integer  $catid     The category ID.
+	 * @param   integer  $language  The language code.
+	 * @param   string   $layout    The category layout
 	 *
 	 * @return  string  The article route.
 	 *

--- a/components/com_content/helpers/route.php
+++ b/components/com_content/helpers/route.php
@@ -78,14 +78,6 @@ abstract class ContentHelperRoute
 			{
 				$link .= '&lang=' . $language;
 			}
-
-			$jinput = JFactory::getApplication()->input;
-			$layout = $jinput->get('layout');
-
-			if ($layout !== '')
-			{
-				$link .= '&layout=' . $layout;
-			}
 		}
 
 		return $link;


### PR DESCRIPTION
Pull Request for Issue #20199.

### Summary of Changes
Fix incorrect layout in category link after  #19681 PR

### Reasons
1.  Bag with `layout=` or `layout=templatelayout`  in com_content category link  
*This bug is fraught with the fact that search results could get duplicate pages. And some No Dubles \ Canonical Links Plugins began to cause endless redirects*

### How reproduce bug by @Quy
* Install the last demo.
* Under System > Global Configuration > Articles > Integration > URL Routing, select Modern
* Search Park Blog
* Hover Park Blog link to see URL:  
`http://localhost/joomla387/index.php/using-joomla/extensions/components/content-component/article-category-blog?layout=`

### Testing Instructions
If you have this bug, apply the patch

### Expected result
Link was `/category`

### Actual result
Now link `/category?layout`= or `/category?layout=templatelayout` if override com_content category view