### PR TITLE
onContentAfterBatch, onContentBeforeBatch

### DIFF
--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -311,11 +311,6 @@ abstract class AdminModel extends FormModel
 		// Initialize re-usable member properties
 		$this->initBatch();
 
-		// Include the plugins for the batch events.
-		\JPluginHelper::importPlugin($this->events_map['batch']);
-
-		$dispatcher = \JEventDispatcher::getInstance();
-
 		if ($this->batch_copymove && !empty($commands[$this->batch_copymove]))
 		{
 			$cmd = ArrayHelper::getValue($commands, 'move_copy', 'c');
@@ -345,6 +340,11 @@ abstract class AdminModel extends FormModel
 
 			$done = true;
 		}
+
+		// Include the plugins for the batch events.
+		\JPluginHelper::importPlugin($this->events_map['batch']);
+
+		$dispatcher = \JEventDispatcher::getInstance();
 
 		foreach ($this->batch_commands as $identifier => $command)
 		{

--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -258,6 +258,7 @@ abstract class AdminModel extends FormModel
 
 		$this->events_map = array_merge(
 			array(
+				'batch'        => 'content',
 				'delete'       => 'content',
 				'save'         => 'content',
 				'change_state' => 'content',

--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -341,10 +341,9 @@ abstract class AdminModel extends FormModel
 			$done = true;
 		}
 
-		// Include the plugins for the batch events.
-		\JPluginHelper::importPlugin($this->events_map['batch']);
-
+		// Get the dispatcher and load the plugins for the batch events.
 		$dispatcher = \JEventDispatcher::getInstance();
+		\JPluginHelper::importPlugin($this->events_map['batch']);
 
 		foreach ($this->batch_commands as $identifier => $command)
 		{


### PR DESCRIPTION
### Summary of Changes
Added the events onContentAfterBatch and onContentBeforeBatch

### Testing Instructions

### Expected result

### Actual result

### Documentation Changes Required
```
	/**
	 * Method is called before the batch function is runned.
	 *
	 * @param   string $identifier  The identifier of the field to change.
	 * @param   string $value       The value to set.
	 * @param   array  $pks         An array of item ids.
	 * @param   array  $contexts    An array of item contexts.
	 *
	 * @return  boolean  Returns true on success, false on failure.
	 *
	 * @since   __DEPLOY_VERSION__
	 */
	public function onContentBeforeBatch($identifier, $value, &$pks, &$contexts) {}

	/**
	 * Method is called after the batch function is runned.
	 *
	 * @param   string $identifier  The identifier of the field to change.
	 * @param   string $value       The value to set.
	 * @param   array  $pks         An array of item ids.
	 * @param   array  $contexts    An array of item contexts.
	 *
	 * @return  void
	 *
	 * @since   __DEPLOY_VERSION__
	 */
	public function onContentAfterBatch($identifier, $value, $pks, $contexts) {}

```
