### PR TITLE
[a11y] post-installation message in control panel

### DIFF
--- a/administrator/components/com_cpanel/views/cpanel/tmpl/default.php
+++ b/administrator/components/com_cpanel/views/cpanel/tmpl/default.php
@@ -32,9 +32,9 @@ $user = JFactory::getUser();
 		<?php if ($user->authorise('core.manage', 'com_postinstall') && $this->postinstall_message_count) : ?>
 			<div class="row-fluid">
 				<div class="alert alert-info">
-					<h4>
+					<h3>
 						<?php echo JText::_('COM_CPANEL_MESSAGES_TITLE'); ?>
-					</h4>
+					</h3>
 					<p>
 						<?php echo JText::_('COM_CPANEL_MESSAGES_BODY_NOCLOSE'); ?>
 					</p>


### PR DESCRIPTION
> Headings communicate the organization of the content on the page. Web browsers, plug-ins, and assistive technologies can use them to provide in-page navigation.

> Skipping heading ranks can be confusing and should be avoided where possible: Make sure that a < h2> is not followed directly by an < h4>, for example.

Source (https://www.w3.org/WAI/tutorials/page-structure/headings/)

The heading was probably chosen for cosmetic reasons and not structural reasons which they should have been

This PR changes the heading for the post-installtion message i the control panel from h4 to h3

There is a very small visual change as a result but imho the benefits outweigh the small cost
