### PR TITLE
Fix errors exposed by strict and also improve js

### DIFF
--- a/administrator/templates/isis/js/template.js
+++ b/administrator/templates/isis/js/template.js
@@ -12,111 +12,80 @@ jQuery(function($)
 
 	var $w = $(window);
 
-	$('*[rel=tooltip]').tooltip();
+	$(document.body)
+		.on('click', '.btn-group label:not(.active)', function() {
+			var $label = $(this);
+			var $input = $('#' + $label.attr('for'));
 
-	// Turn radios into btn-group
-	$('.radio.btn-group label').addClass('btn');
+			if ($input.prop('checked'))
+			{
+				return;
+			}
 
-	$('fieldset.btn-group').each(function() {
+			$label.closest('.btn-group').find('label').removeClass('active btn-success btn-danger btn-primary');
+
+			var btnClass = 'primary';
+
+			if ($input.val() != '')
+			{
+				var reversed = $label.closest('.btn-group').hasClass('btn-group-reversed');
+				btnClass = ($input.val() == 0 ? !reversed : reversed) ? 'danger' : 'success';
+			}
+
+			$label.addClass('active btn-' + btnClass);
+			$input.prop('checked', true).trigger('change');
+		})
+		.on('subform-row-add', initButtonGroup)
+		.on('subform-row-add', initTooltip);
+
+	initButtonGroup();
+	initTooltip();
+
+	// Called once on domready, again when a subform row is added
+	function initTooltip(event, container)
+	{
+		$(container || document).find('*[rel=tooltip]').tooltip();
+	}
+
+	// Called once on domready, again when a subform row is added
+	function initButtonGroup(event, container)
+	{
+		var $container = $(container || document);
+
+		// Turn radios into btn-group
+		$container.find('.radio.btn-group label').addClass('btn');
+
 		// Handle disabled, prevent clicks on the container, and add disabled style to each button
-		if ($(this).prop('disabled')) {
-			$(this).css('pointer-events', 'none').off('click');
-			$(this).find('.btn').addClass('disabled');
-		}
-	});
+		$container.find('fieldset.btn-group:disabled').each(function() {
+			$(this).css('pointer-events', 'none').off('click').find('.btn').addClass('disabled');
+		});
 
-	$('.btn-group label:not(.active)').click(function()
-	{
-		var label = $(this);
-		var input = $('#' + label.attr('for'));
+		// Setup coloring for buttons
+		$container.find('.btn-group input:checked').each(function() {
+			var $input  = $(this);
+			var $label = $('label[for=' + $input.attr('id') + ']');
+			var btnClass = 'primary';
 
-		if (!input.prop('checked'))
-		{
-			label.closest('.btn-group').find('label').removeClass('active btn-success btn-danger btn-primary');
+			if ($input.val() != '')
+			{
+				var reversed = $input.parent().hasClass('btn-group-reversed');
+				btnClass = ($input.val() == 0 ? !reversed : reversed) ? 'danger' : 'success';
+			}
 
-			if (label.closest('.btn-group').hasClass('btn-group-reversed'))
-			{
-				if (input.val() == '')
-				{
-					label.addClass('active btn-primary');
-				}
-				else if (input.val() == 0)
-				{
-					label.addClass('active btn-success');
-				}
-				else
-				{
-					label.addClass('active btn-danger');
-				}
-			}
-			else
-			{
-				if (input.val() == '')
-				{
-					label.addClass('active btn-primary');
-				}
-				else if (input.val() == 0)
-				{
-					label.addClass('active btn-danger');
-				}
-				else
-				{
-					label.addClass('active btn-success');
-				}
-
-			}
-			input.prop('checked', true);
-			input.trigger('change');
-		}
-	});
-	$('.btn-group input[checked=checked]').each(function()
-	{
-		var $self  = $(this);
-		var attrId = $self.attr('id');
-
-		if ($self.parent().hasClass('btn-group-reversed'))
-		{
-			if ($self.val() == '')
-			{
-				$('label[for=' + attrId + ']').addClass('active btn-primary');
-			}
-			else if ($self.val() == 0)
-			{
-				$('label[for=' + attrId + ']').addClass('active btn-success');
-			}
-			else
-			{
-				$('label[for=' + attrId + ']').addClass('active btn-danger');
-			}
-		}
-		else
-		{
-			if ($self.val() == '')
-			{
-				$('label[for=' + attrId + ']').addClass('active btn-primary');
-			}
-			else if ($self.val() == 0)
-			{
-				$('label[for=' + attrId + ']').addClass('active btn-danger');
-			}
-			else
-			{
-				$('label[for=' + attrId + ']').addClass('active btn-success');
-			}
-		}
-	});
+			$label.addClass('active btn-' + btnClass);
+		});
+	}
 
 	// add color classes to chosen field based on value
 	$('select[class^="chzn-color"], select[class*=" chzn-color"]').on('liszt:ready', function(){
-		var select = $(this);
+		var $select = $(this);
 		var cls = this.className.replace(/^.(chzn-color[a-z0-9-_]*)$.*/, '$1');
-		var container = select.next('.chzn-container').find('.chzn-single');
-		container.addClass(cls).attr('rel', 'value_' + select.val());
-		select.on('change click', function()
-		{
-			container.attr('rel', 'value_' + select.val());
-		});
+		var $container = $select.next('.chzn-container').find('.chzn-single');
 
+		$container.addClass(cls).attr('rel', 'value_' + $select.val());
+		$select.on('change click', function() {
+			$container.attr('rel', 'value_' + $select.val());
+		});
 	});
 
 	/**

--- a/administrator/templates/isis/js/template.js
+++ b/administrator/templates/isis/js/template.js
@@ -13,6 +13,18 @@ jQuery(function($)
 	var $w = $(window);
 
 	$(document.body)
+		// add color classes to chosen field based on value
+		.on('liszt:ready', 'select[class^="chzn-color"], select[class*=" chzn-color"]', function() {
+			var $select = $(this);
+			var cls = this.className.replace(/^.(chzn-color[a-z0-9-_]*)$.*/, '$1');
+			var $container = $select.next('.chzn-container').find('.chzn-single');
+
+			$container.addClass(cls).attr('rel', 'value_' + $select.val());
+			$select.on('change click', function() {
+				$container.attr('rel', 'value_' + $select.val());
+			});
+		})
+		// Handle clicks to button groups
 		.on('click', '.btn-group label:not(.active)', function() {
 			var $label = $(this);
 			var $input = $('#' + $label.attr('for'));
@@ -76,17 +88,6 @@ jQuery(function($)
 		});
 	}
 
-	// add color classes to chosen field based on value
-	$('select[class^="chzn-color"], select[class*=" chzn-color"]').on('liszt:ready', function(){
-		var $select = $(this);
-		var cls = this.className.replace(/^.(chzn-color[a-z0-9-_]*)$.*/, '$1');
-		var $container = $select.next('.chzn-container').find('.chzn-single');
-
-		$container.addClass(cls).attr('rel', 'value_' + $select.val());
-		$select.on('change click', function() {
-			$container.attr('rel', 'value_' + $select.val());
-		});
-	});
 
 	/**
 	 * Append submenu items to empty UL on hover allowing a scrollable dropdown

--- a/administrator/templates/isis/js/template.js
+++ b/administrator/templates/isis/js/template.js
@@ -47,22 +47,17 @@ jQuery(function($)
 			$label.addClass('active btn-' + btnClass);
 			$input.prop('checked', true).trigger('change');
 		})
-		.on('subform-row-add', initButtonGroup)
-		.on('subform-row-add', initTooltip);
+		.on('subform-row-add', initTemplate);
 
-	initButtonGroup();
-	initTooltip();
+	initTemplate();
 
 	// Called once on domready, again when a subform row is added
-	function initTooltip(event, container)
-	{
-		$(container || document).find('*[rel=tooltip]').tooltip();
-	}
-
-	// Called once on domready, again when a subform row is added
-	function initButtonGroup(event, container)
+	function initTemplate(event, container)
 	{
 		var $container = $(container || document);
+
+		// Create tooltips
+		$container.find('*[rel=tooltip]').tooltip();
 
 		// Turn radios into btn-group
 		$container.find('.radio.btn-group label').addClass('btn');

--- a/administrator/templates/isis/js/template.js
+++ b/administrator/templates/isis/js/template.js
@@ -249,13 +249,11 @@ jQuery(function($)
 
 	}
 
-
 	/**
 	 * USED IN: All views with toolbar and sticky bar enabled
 	 */
 	var navTop;
 	var isFixed = false;
-
 
 	if (document.getElementById('isisJsData') && document.getElementById('isisJsData').getAttribute('data-tmpl-sticky') == "true") {
 		processScrollInit();


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This is just #12544 plus some additional improvements.
While that older PR was aimed only at fixing the "strict" errors, this one fixes other problems.
In particular, button groups (radio buttons) will now work properly when used inside of subforms. 
Same for Chosen selectors that use coloring based on state. 
Also, delegation is used to handle various events. This has several benefits. 

This is only a rewrite of the first part of this file. There is likely much more that can be improved. 

### Testing Instructions

This file only affects the administrator when using the Isis template so use that. 
First of all, nothing should be broken. This mainly affects Chosen, radio button groups, and tooltips. So check any pages that have those things.

The main improvements apply to subforms. Subforms with radio buttons set up as `btn-group` should be tested. There are probably none of these in Joomla because they didn't really work before this patch. So make one and test it. Same goes for Chosens used in subforms with the `chzn-color-state` class. 

### Expected result

When you dynamically add a subform row that contains radio buttons, Chosen, or tooltips, these things should be initialized properly in the new row. Before this patch they were not. 

### Actual result

Oh, it works.

### Documentation Changes Required

Probably not. Unless there were previously some documented warnings about using radio buttons or Chosens in subforms. If so, those warnings may be deleted as they will no longer apply. 