### PR TITLE
Call the popover init function when creating new subform rows.

### DIFF
--- a/libraries/cms/html/bootstrap.php
+++ b/libraries/cms/html/bootstrap.php
@@ -364,9 +364,13 @@ abstract class JHtmlBootstrap
 
 		$options = JHtml::getJSObject($opt);
 
+		$initFunction = 'function initPopovers (event, container) { ' .
+				'$(container || document).find(' . json_encode($selector) . ').popover(' . $options . ');' .
+			'}';
+
 		// Attach the popover to the document
 		JFactory::getDocument()->addScriptDeclaration(
-			'jQuery(function($){ $(' . json_encode($selector) . ').popover(' . $options . '); });'
+			'jQuery(function($){ initPopovers(); $("body").on("subform-row-add", initPopovers); ' . $initFunction . ' });'
 		);
 
 		static::$loaded[__METHOD__][$selector] = true;

--- a/tests/unit/suites/libraries/cms/html/JHtmlBootstrapTest.php
+++ b/tests/unit/suites/libraries/cms/html/JHtmlBootstrapTest.php
@@ -328,7 +328,7 @@ class JHtmlBootstrapTest extends TestCase
 
 		$this->assertEquals(
 			$document->_script['text/javascript'],
-			'jQuery(function($){ $(".hasPopover").popover({"html": true,"trigger": "hover focus","container": "body"}); });',
+			'jQuery(function($){ initPopovers(); $("body").on("subform-row-add", initPopovers); function initPopovers (event, container) { $(container || document).find(".hasPopover").popover({"html": true,"trigger": "hover focus","container": "body"});} });',
 			'Verify that the popover script is initialised'
 		);
 	}


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Like #12996 but for popovers.

### Testing Instructions

Add new rows in a repeatable subform that has popovers in the rows. Previously, popovers would not be initialized for newly added rows. 

### Expected result

Popovers should work even in the new rows.

### Actual result

Yes, it works.

### Documentation Changes Required

No.