### PR TITLE
[4.0] Replace JFactory to Factory

### DIFF
--- a/administrator/components/com_content/Service/HTML/Icon.php
+++ b/administrator/components/com_content/Service/HTML/Icon.php
@@ -158,7 +158,7 @@ class Icon
 			&& $article->checked_out > 0
 			&& $article->checked_out != $user->get('id'))
 		{
-			$checkoutUser = JFactory::getUser($article->checked_out);
+			$checkoutUser = Factory::getUser($article->checked_out);
 			$date         = HTMLHelper::_('date', $article->checked_out_time);
 			$tooltip      = Text::_('JLIB_HTML_CHECKED_OUT') . ' :: ' . Text::sprintf('COM_CONTENT_CHECKED_OUT_BY', $checkoutUser->name)
 				. ' <br> ' . $date;


### PR DESCRIPTION
### Summary of Changes
One change from `JFactory` to` Factory`.

Fix error on frontage for logged registered user.

### Testing Instructions
Code review should be enough.

### Expected result
No error.

### Actual result
On front page, for logged user:

`Class 'Joomla\Component\Content\Administrator\Service\HTML\JFactory' not found `

### Documentation Changes Required
No
