### PR TITLE
Optimization and fix of multilingual associations and add layouts to com_content links

### DIFF
--- a/administrator/components/com_categories/helpers/association.php
+++ b/administrator/components/com_categories/helpers/association.php
@@ -51,7 +51,7 @@ abstract class CategoryHelperAssociation
 				}
 				else
 				{
-					$viewLayout = ($layout) ? '&layout=' . $layout : '';
+					$viewLayout = $layout ? '&layout=' . $layout : '';
 
 					$return[$tag] = 'index.php?option=' . $extension . '&view=category&id=' . $item . $viewLayout;
 				}

--- a/administrator/components/com_categories/helpers/association.php
+++ b/administrator/components/com_categories/helpers/association.php
@@ -25,12 +25,13 @@ abstract class CategoryHelperAssociation
 	 *
 	 * @param   integer  $id         Id of the item
 	 * @param   string   $extension  Name of the component
+	 * @param   string   $layout     Category layout
 	 *
 	 * @return  array    Array of associations for the component categories
 	 *
 	 * @since  3.0
 	 */
-	public static function getCategoryAssociations($id = 0, $extension = 'com_content')
+	public static function getCategoryAssociations($id = 0, $extension = 'com_content', $layout = null)
 	{
 		$return = array();
 
@@ -46,11 +47,13 @@ abstract class CategoryHelperAssociation
 			{
 				if (class_exists($helperClassname) && is_callable(array($helperClassname, 'getCategoryRoute')))
 				{
-					$return[$tag] = $helperClassname::getCategoryRoute($item, $tag);
+					$return[$tag] = $helperClassname::getCategoryRoute($item, $tag, $layout);
 				}
 				else
 				{
-					$return[$tag] = 'index.php?option=' . $extension . '&view=category&id=' . $item;
+					$viewLayout = ($layout) ? '&layout=' . $layout : '';
+
+					$return[$tag] = 'index.php?option=' . $extension . '&view=category&id=' . $item . $viewLayout;
 				}
 			}
 		}

--- a/components/com_content/helpers/association.php
+++ b/components/com_content/helpers/association.php
@@ -56,7 +56,7 @@ abstract class ContentHelperAssociation extends CategoryHelperAssociation
 				$advClause[] = 'c2.access IN (' . $groups . ')';
 
 				// Filter by current language
-				$advClause[] = 'c2.language != '.$db->quote(JFactory::getLanguage()->getTag());
+				$advClause[] = 'c2.language != ' . $db->quote(JFactory::getLanguage()->getTag());
 
 				if ((!$user->authorise('core.edit.state', 'com_content')) && (!$user->authorise('core.edit', 'com_content')))
 				{
@@ -97,7 +97,7 @@ abstract class ContentHelperAssociation extends CategoryHelperAssociation
 	/**
 	 * Method to display in frontend the associations for a given article
 	 *
-	 * @param   integer $id Id of the article
+	 * @param   integer  $id Id of the article
 	 *
 	 * @return  array  An array containing the association URL and the related language object
 	 *

--- a/components/com_content/helpers/association.php
+++ b/components/com_content/helpers/association.php
@@ -62,7 +62,7 @@ abstract class ContentHelperAssociation extends CategoryHelperAssociation
 
 		if ($view === 'category' || $view === 'categories')
 		{
-			return self::getCategoryAssociations($id, 'com_content');
+			return self::getCategoryAssociations($id, 'com_content', $layout);
 		}
 
 		return array();

--- a/components/com_content/helpers/association.php
+++ b/components/com_content/helpers/association.php
@@ -97,7 +97,7 @@ abstract class ContentHelperAssociation extends CategoryHelperAssociation
 	/**
 	 * Method to display in frontend the associations for a given article
 	 *
-	 * @param   integer  $id Id of the article
+	 * @param   integer  $id  Id of the article
 	 *
 	 * @return  array  An array containing the association URL and the related language object
 	 *

--- a/components/com_content/helpers/association.php
+++ b/components/com_content/helpers/association.php
@@ -23,8 +23,8 @@ abstract class ContentHelperAssociation extends CategoryHelperAssociation
 	/**
 	 * Method to get the associations for a given item
 	 *
-	 * @param   integer  $id    Id of the item
-	 * @param   string   $view  Name of the view
+	 * @param   integer $id   Id of the item
+	 * @param   string  $view Name of the view
 	 *
 	 * @return  array   Array of associations for the item
 	 *
@@ -35,8 +35,6 @@ abstract class ContentHelperAssociation extends CategoryHelperAssociation
 		$jinput = JFactory::getApplication()->input;
 		$view   = $view === null ? $jinput->get('view') : $view;
 		$id     = empty($id) ? $jinput->getInt('id') : $id;
-		$user   = JFactory::getUser();
-		$groups = implode(',', $user->getAuthorisedViewLevels());
 
 		if ($view === 'article')
 		{
@@ -48,26 +46,7 @@ abstract class ContentHelperAssociation extends CategoryHelperAssociation
 
 				foreach ($associations as $tag => $item)
 				{
-					if ($item->language != JFactory::getLanguage()->getTag())
-					{
-						$arrId   = explode(':', $item->id);
-						$assocId = $arrId[0];
-
-						$db    = JFactory::getDbo();
-						$query = $db->getQuery(true)
-							->select($db->qn('state'))
-							->from($db->qn('#__content'))
-							->where($db->qn('id') . ' = ' . (int) ($assocId))
-							->where('access IN (' . $groups . ')');
-						$db->setQuery($query);
-
-						$result = (int) $db->loadResult();
-
-						if ($result > 0)
-						{
-							$return[$tag] = ContentHelperRoute::getArticleRoute($item->id, (int) $item->catid, $item->language);
-						}
-					}
+					$return[$tag] = ContentHelperRoute::getArticleRoute($item->id, (int) $item->catid, $item->language);
 				}
 
 				return $return;
@@ -85,7 +64,7 @@ abstract class ContentHelperAssociation extends CategoryHelperAssociation
 	/**
 	 * Method to display in frontend the associations for a given article
 	 *
-	 * @param   integer  $id  Id of the article
+	 * @param   integer $id Id of the article
 	 *
 	 * @return  array   An array containing the association URL and the related language object
 	 *

--- a/components/com_content/helpers/association.php
+++ b/components/com_content/helpers/association.php
@@ -21,14 +21,6 @@ JLoader::register('CategoryHelperAssociation', JPATH_ADMINISTRATOR . '/component
 abstract class ContentHelperAssociation extends CategoryHelperAssociation
 {
 	/**
-	 * Cached array of the content item id.
-	 *
-	 * @var    array
-	 * @since  __DEPLOY_VERSION__
-	 */
-	protected static $filters = array();
-
-	/**
 	 * Method to get the associations for a given item
 	 *
 	 * @param   integer  $id    Id of the item
@@ -50,45 +42,35 @@ abstract class ContentHelperAssociation extends CategoryHelperAssociation
 		{
 			if ($id)
 			{
-				if (!isset(static::$filters[$id])) 
+				$associations = JLanguageAssociations::getAssociations('com_content', '#__content', 'com_content.item', $id);
+
+				$return = array();
+
+				foreach ($associations as $tag => $item)
 				{
-					$associations = JLanguageAssociations::getAssociations('com_content', '#__content', 'com_content.item', $id);
-
-					$return = array();
-
-					foreach ($associations as $tag => $item)
+					if ($item->language != JFactory::getLanguage()->getTag())
 					{
-						if ($item->language != JFactory::getLanguage()->getTag())
+						$arrId   = explode(':', $item->id);
+						$assocId = $arrId[0];
+
+						$db    = JFactory::getDbo();
+						$query = $db->getQuery(true)
+							->select($db->qn('state'))
+							->from($db->qn('#__content'))
+							->where($db->qn('id') . ' = ' . (int) ($assocId))
+							->where('access IN (' . $groups . ')');
+						$db->setQuery($query);
+
+						$result = (int) $db->loadResult();
+
+						if ($result > 0)
 						{
-							$arrId   = explode(':', $item->id);
-							$assocId = $arrId[0];
-
-							$db    = JFactory::getDbo();
-							$query = $db->getQuery(true)
-								->select($db->qn('state'))
-								->from($db->qn('#__content'))
-								->where($db->qn('id') . ' = ' . (int) $assocId)
-								->where($db->qn('access') . ' IN (' . $groups . ')');
-							$db->setQuery($query);
-
-							$result = (int) $db->loadResult();
-
-							if ($result > 0)
-							{
-								$return[$tag] = ContentHelperRoute::getArticleRoute($item->id, (int) $item->catid, $item->language);
-							}
+							$return[$tag] = ContentHelperRoute::getArticleRoute($item->id, (int) $item->catid, $item->language);
 						}
-
-						static::$filters[$id] = $return;
-					}
-
-					if (count($associations) === 0)
-					{
-						static::$filters[$id] = array();
 					}
 				}
 
-				return static::$filters[$id];
+				return $return;
 			}
 		}
 

--- a/components/com_content/helpers/association.php
+++ b/components/com_content/helpers/association.php
@@ -58,7 +58,7 @@ abstract class ContentHelperAssociation extends CategoryHelperAssociation
 				// Filter by current language
 				$advClause[] = 'c2.language != ' . $db->quote(JFactory::getLanguage()->getTag());
 
-				if ((!$user->authorise('core.edit.state', 'com_content')) && (!$user->authorise('core.edit', 'com_content')))
+				if (!$user->authorise('core.edit.state', 'com_content') && !$user->authorise('core.edit', 'com_content'))
 				{
 					// Filter by start and end dates.
 					$nullDate = $db->quote($db->getNullDate());

--- a/components/com_content/helpers/association.php
+++ b/components/com_content/helpers/association.php
@@ -58,7 +58,6 @@ abstract class ContentHelperAssociation extends CategoryHelperAssociation
 				// Filter by current language
 				$advClause[] = 'c2.language != '.$db->quote(JFactory::getLanguage()->getTag());
 
-
 				if ((!$user->authorise('core.edit.state', 'com_content')) && (!$user->authorise('core.edit', 'com_content')))
 				{
 					// Filter by start and end dates.
@@ -74,9 +73,7 @@ abstract class ContentHelperAssociation extends CategoryHelperAssociation
 					$advClause[] = 'c2.state = 1';
 				}
 
-
-				$associations = JLanguageAssociations::getAssociations('com_content', '#__content',
-					'com_content.item', $id, 'id', 'alias', 'catid', $advClause);
+				$associations = JLanguageAssociations::getAssociations('com_content', '#__content', 'com_content.item', $id, 'id', 'alias', 'catid', $advClause);
 
 				$return = array();
 
@@ -102,7 +99,7 @@ abstract class ContentHelperAssociation extends CategoryHelperAssociation
 	 *
 	 * @param   integer $id Id of the article
 	 *
-	 * @return  array   An array containing the association URL and the related language object
+	 * @return  array  An array containing the association URL and the related language object
 	 *
 	 * @since  3.7.0
 	 */

--- a/components/com_content/helpers/association.php
+++ b/components/com_content/helpers/association.php
@@ -23,18 +23,25 @@ abstract class ContentHelperAssociation extends CategoryHelperAssociation
 	/**
 	 * Method to get the associations for a given item
 	 *
-	 * @param   integer $id   Id of the item
-	 * @param   string  $view Name of the view
+	 * @param   integer  $id      Id of the item
+	 * @param   string   $view    Name of the view
+	 * @param   string   $layout  View layout
 	 *
 	 * @return  array   Array of associations for the item
 	 *
 	 * @since  3.0
 	 */
-	public static function getAssociations($id = 0, $view = null)
+	public static function getAssociations($id = 0, $view = null, $layout = null)
 	{
-		$jinput = JFactory::getApplication()->input;
-		$view   = $view === null ? $jinput->get('view') : $view;
-		$id     = empty($id) ? $jinput->getInt('id') : $id;
+		$jinput    = JFactory::getApplication()->input;
+		$view      = $view === null ? $jinput->get('view') : $view;
+		$component = $jinput->getCmd('option');
+		$id        = empty($id) ? $jinput->getInt('id') : $id;
+
+		if ($layout === null && $jinput->get('view') == $view && $component == 'com_content')
+		{
+			$layout = $jinput->get('layout', '', 'string');
+		}
 
 		if ($view === 'article')
 		{
@@ -46,7 +53,7 @@ abstract class ContentHelperAssociation extends CategoryHelperAssociation
 
 				foreach ($associations as $tag => $item)
 				{
-					$return[$tag] = ContentHelperRoute::getArticleRoute($item->id, (int) $item->catid, $item->language);
+					$return[$tag] = ContentHelperRoute::getArticleRoute($item->id, (int) $item->catid, $item->language, $layout);
 				}
 
 				return $return;

--- a/components/com_content/helpers/route.php
+++ b/components/com_content/helpers/route.php
@@ -22,12 +22,13 @@ abstract class ContentHelperRoute
 	 * @param   integer  $id        The route of the content item.
 	 * @param   integer  $catid     The category ID.
 	 * @param   integer  $language  The language code.
+	 * @param   string   $layout    The layout value.
 	 *
 	 * @return  string  The article route.
 	 *
 	 * @since   1.5
 	 */
-	public static function getArticleRoute($id, $catid = 0, $language = 0)
+	public static function getArticleRoute($id, $catid = 0, $language = 0, $layout = null)
 	{
 		// Create the link
 		$link = 'index.php?option=com_content&view=article&id=' . $id;
@@ -42,6 +43,11 @@ abstract class ContentHelperRoute
 			$link .= '&lang=' . $language;
 		}
 
+		if ($layout)
+		{
+			$link .= '&layout=' . $layout;
+		}
+
 		return $link;
 	}
 
@@ -50,12 +56,13 @@ abstract class ContentHelperRoute
 	 *
 	 * @param   integer  $catid     The category ID.
 	 * @param   integer  $language  The language code.
+	 * @param   string   $layout    TThe layout value.
 	 *
 	 * @return  string  The article route.
 	 *
 	 * @since   1.5
 	 */
-	public static function getCategoryRoute($catid, $language = 0)
+	public static function getCategoryRoute($catid, $language = 0, $layout = null)
 	{
 		if ($catid instanceof JCategoryNode)
 		{
@@ -68,16 +75,19 @@ abstract class ContentHelperRoute
 
 		if ($id < 1)
 		{
-			$link = '';
+			return '';
 		}
-		else
-		{
-			$link = 'index.php?option=com_content&view=category&id=' . $id;
 
-			if ($language && $language !== '*' && JLanguageMultilang::isEnabled())
-			{
-				$link .= '&lang=' . $language;
-			}
+		$link = 'index.php?option=com_content&view=category&id=' . $id;
+
+		if ($language && $language !== '*' && JLanguageMultilang::isEnabled())
+		{
+			$link .= '&lang=' . $language;
+		}
+
+		if ($layout)
+		{
+			$link .= '&layout=' . $layout;
 		}
 
 		return $link;

--- a/components/com_content/helpers/route.php
+++ b/components/com_content/helpers/route.php
@@ -78,14 +78,6 @@ abstract class ContentHelperRoute
 			{
 				$link .= '&lang=' . $language;
 			}
-
-			$jinput = JFactory::getApplication()->input;
-			$layout = $jinput->get('layout');
-
-			if ($layout !== '')
-			{
-				$link .= '&layout=' . $layout;
-			}
 		}
 
 		return $link;

--- a/components/com_content/helpers/route.php
+++ b/components/com_content/helpers/route.php
@@ -56,7 +56,7 @@ abstract class ContentHelperRoute
 	 *
 	 * @param   integer  $catid     The category ID.
 	 * @param   integer  $language  The language code.
-	 * @param   string   $layout    TThe layout value.
+	 * @param   string   $layout    The layout value.
 	 *
 	 * @return  string  The article route.
 	 *

--- a/libraries/src/Language/Associations.php
+++ b/libraries/src/Language/Associations.php
@@ -29,9 +29,9 @@ class Associations
 	 * @param   string   $pk          The name of the primary key in the given $table.
 	 * @param   string   $aliasField  If the table has an alias field set it here. Null to not use it
 	 * @param   string   $catField    If the table has a catid field set it here. Null to not use it
-	 * @param   array    $advClause   Array with advanced where clause use c as parent column key, c2 as associations column key
+	 * @param   array    $advClause   Additional advanced 'where' clause; use c as parent column key, c2 as associations column key
 	 *
-	 * @return  array                The associated items
+	 * @return  array  The associated items
 	 *
 	 * @since   3.1
 	 *

--- a/libraries/src/Language/Associations.php
+++ b/libraries/src/Language/Associations.php
@@ -44,7 +44,7 @@ class Associations
 		static $multilanguageAssociations = array();
 
 		// Multilanguage association array key. If the key is already in the array we don't need to run the query again, just return it.
-		$queryKey = implode('|', array($extension, $tablename, $context, $id));
+		$queryKey = md5(serialize(array_merge(array($extension, $tablename, $context, $id), $advClause)));
 
 		if (!isset($multilanguageAssociations[$queryKey]))
 		{

--- a/libraries/src/Language/Associations.php
+++ b/libraries/src/Language/Associations.php
@@ -37,7 +37,8 @@ class Associations
 	 *
 	 * @throws  \Exception
 	 */
-	public static function getAssociations($extension, $tablename, $context, $id, $pk = 'id', $aliasField = 'alias', $catField = 'catid', $advClause = array())
+	public static function getAssociations($extension, $tablename, $context, $id, $pk = 'id', $aliasField = 'alias', $catField = 'catid',
+	                                       $advClause = array())
 	{
 		// To avoid doing duplicate database queries.
 		static $multilanguageAssociations = array();

--- a/libraries/src/Language/Associations.php
+++ b/libraries/src/Language/Associations.php
@@ -29,6 +29,7 @@ class Associations
 	 * @param   string   $pk          The name of the primary key in the given $table.
 	 * @param   string   $aliasField  If the table has an alias field set it here. Null to not use it
 	 * @param   string   $catField    If the table has a catid field set it here. Null to not use it
+	 * @param   array    $advClause   Array with advanced where clause use c as parent column key, c2 as associations column key
 	 *
 	 * @return  array                The associated items
 	 *
@@ -36,13 +37,13 @@ class Associations
 	 *
 	 * @throws  \Exception
 	 */
-	public static function getAssociations($extension, $tablename, $context, $id, $pk = 'id', $aliasField = 'alias', $catField = 'catid')
+	public static function getAssociations($extension, $tablename, $context, $id, $pk = 'id', $aliasField = 'alias', $catField = 'catid', $advClause = array())
 	{
 		// To avoid doing duplicate database queries.
 		static $multilanguageAssociations = array();
 
 		// Multilanguage association array key. If the key is already in the array we don't need to run the query again, just return it.
-		$queryKey = implode('|', func_get_args());
+		$queryKey = implode('|', array($extension, $tablename, $context, $id));
 
 		if (!isset($multilanguageAssociations[$queryKey]))
 		{
@@ -95,6 +96,15 @@ class Associations
 			if ($tablename === '#__categories')
 			{
 				$query->where('c.extension = ' . $db->quote($extension));
+			}
+
+			// Advanced where clause
+			if (!empty($advClause))
+			{
+				foreach ($advClause as $clause)
+				{
+					$query->where($clause);
+				}
 			}
 
 			$db->setQuery($query);

--- a/libraries/src/Language/Associations.php
+++ b/libraries/src/Language/Associations.php
@@ -38,7 +38,7 @@ class Associations
 	 * @throws  \Exception
 	 */
 	public static function getAssociations($extension, $tablename, $context, $id, $pk = 'id', $aliasField = 'alias', $catField = 'catid',
-	                                       $advClause = array())
+		$advClause = array())
 	{
 		// To avoid doing duplicate database queries.
 		static $multilanguageAssociations = array();


### PR DESCRIPTION
### Summary of Changes
This PR contains many fixes based on the following PR's
#19681 #19683 #19314 #20211

### Differences from previous PR
* #19681 - Completely cleaned, now the layout is passed to the helper, and not taken from the parameters. That the bug with `?layout=` is corrected, as well as allowing developers to output a specific layout as needed
* #20211 - Add an additional check on option and view to exclude misunderstandings when an incorrect layout could be passed to the link
* #19314 - Removed an extra query, additionally added checks for publish_up and publish_down, except the conditions themselves now depend on the rights of the user. I was based on the arcitle model
* #19683 - This PR is no longer needed


### Testing Instructions
In advance I apologize for the laziness. But I'll just list pr in which you can see `Testing Instructions`
*In the courtyard night. And if all the tests listed in this description it turns out to be too huge*

* #20211 - `?layout=` bug
* #19683 - Remove duplicated queries
* #19681 - Fix link when layout and association (I still think that this is not correct, but I must agree that such a version of associations is the most common)
* #19314 Correcting display of associated articles. Additionally, need to check publish_up/publish_down and also, at the same time check the display of people with editing rights, for example, super user

### Explanations about `add advanced where clause param`  (d99dca5)

I thought for a long time how best to do it. It was necessary to take into account an infinite number of options. The highest priority was to ensure that developers do not have to make unnecessary queries to the database.

With this, completely delete what did @infograf768 in #19314 because if the visitor can not go to the article page, then neither the flag nor the link should be displayed.

The obvious option was to have all the necessary conditions passed to `libraries/src/Language/Associations.php` However, the conditions for a correct selection can be countless.

* Someone uses `state` in their components
* someone uses `published` \ `trashed`
* someone who uses `access` does not have someone
* someone will use `publish_up` `publish_down`
* someone in general needs absolutely different conditions

How many components are there and so many options.

Based on this, I decided to add `$advClause` param

This is an array through which any developer can add to the requests those where he needs.

Truth had to change the value of `$queryKey` but according to my understanding `$extension, $tablename, $context, $id` would be enough to identify the query

P.S I have rather bad English and I often resort to the help of an interpreter, so if something is not clear, or do not properly ask at once, or point out mistakes

@Quy  If there are fixes for docblock I will be very grateful if you immediately attach the code