### PR TITLE
Pass the default value of layout while getting it from input

### DIFF
--- a/components/com_content/helpers/route.php
+++ b/components/com_content/helpers/route.php
@@ -80,7 +80,7 @@ abstract class ContentHelperRoute
 			}
 
 			$jinput = JFactory::getApplication()->input;
-			$layout = $jinput->get('layout');
+			$layout = $jinput->get('layout', '');
 
 			if ($layout !== '')
 			{


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Either we should pass the default value '' (blank) or we should check `if (!empty($layout)) {`. As in case `layout` is not set in input, it's value will be `null` and it will pass the if condition and ultimately it will add `layout=` in the url.

### Testing Instructions
I was using CanonicalLinks plugin, with param to be set yes to redirect canonicals. So due to this Joomla was adding `layout=` in home page url and it is being redirected to `www.sitename.com/?layout=` instead of `www.sitename.com`


### Expected result
Url should not have have `layout=`


### Actual result
It is adding `layout=` in the url.


### Documentation Changes Required
No
