### PR TITLE
Fix for creating links to categories

### DIFF
--- a/components/com_content/helpers/route.php
+++ b/components/com_content/helpers/route.php
@@ -82,7 +82,7 @@ abstract class ContentHelperRoute
 			$jinput = JFactory::getApplication()->input;
 			$layout = $jinput->get('layout');
 
-			if ($layout !== '')
+			if (isset($layout) && $layout !== '')
 			{
 				$link .= '&layout=' . $layout;
 			}


### PR DESCRIPTION
Before applying the option, check its existence to inadvertently nothing promolast