### PR TITLE
[com_content] Filter by no author

### DIFF
--- a/components/com_content/models/articles.php
+++ b/components/com_content/models/articles.php
@@ -377,11 +377,11 @@ class ContentModelArticles extends JModelList
 		}
 		elseif (is_array($authorId))
 		{
-			$authorId = ArrayHelper::toInteger($authorId);
-			$authorId = implode(',', $authorId);
+			$authorId = array_filter($authorId, 'is_numeric');
 
 			if ($authorId)
 			{
+				$authorId    = implode(',', $authorId);
 				$type        = $this->getState('filter.author_id.include', true) ? 'IN' : 'NOT IN';
 				$authorWhere = 'a.created_by ' . $type . ' (' . $authorId . ')';
 			}


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This sets up site Articles model to allow filtering articles by no author, like in administrator.
### Testing Instructions
Create an article without author.
Modify 'Articles - Category' module form (/modules/mod_articles_category/mod_articles_category.xml) by adding option with value 0 to created_by field. So the field looks like this:
```
<field
	name="created_by"
	type="sql"
	label="MOD_ARTICLES_CATEGORY_FIELD_AUTHOR_LABEL"
	description="MOD_ARTICLES_CATEGORY_FIELD_AUTHOR_DESC"
	multiple="true"
	size="5"
	query="select id, name, username from #__users where id IN (select distinct(created_by) from #__content) order by name ASC"
	key_field="id"
	value_field="name"
	>
	<option value="">JOPTION_SELECT_AUTHORS</option>
	<option value="0">JNONE</option>
</field>
```
Publish the module. In author field try these combinations:
a) No option
b) Option with empty value
c) Option with 0 value
d) Option with empty value and option with 0 value
e) Option with empty value and option with >= 1 value (e.g. author with ID 50)
f) Option with 0 value and option with >= 1 value (e.g. author with ID 50)
### Expected result
a) All articles are shown
b) All articles are shown
c) Only articles without author are shown
d) Only articles without author are shown
e) Only articles from selected author (e.g. author with ID 50) are shown
f) Articles from selected author (e.g. author with ID 50) and without author are shown

### Actual result
a) All articles are shown (correct)
b) All articles are shown (correct)
c) All articles are shown (incorrect)
d) Only articles without author are shown (correct)
e) Articles from selected author (e.g. author with ID 50) and without author are shown (incorrect)
f) Articles from selected author (e.g. author with ID 50) and without author are shown (correct)

### Documentation Changes Required
No.