### PR TITLE
Tiny JLanguage::loadLanguage() code improvement

### DIFF
--- a/libraries/src/Language/Language.php
+++ b/libraries/src/Language/Language.php
@@ -791,13 +791,10 @@ class Language
 			$strings = $this->parse($filename);
 		}
 
-		if ($strings)
+		if (is_array($strings) && count($strings))
 		{
-			if (is_array($strings) && count($strings))
-			{
-				$this->strings = array_replace($this->strings, $strings, $this->override);
-				$result = true;
-			}
+			$this->strings = array_replace($this->strings, $strings, $this->override);
+			$result = true;
 		}
 
 		// Record the result of loading the extension's file.


### PR DESCRIPTION
Rebase PR #14653

### Summary of Changes
From original PR: 
> This simplifies the code slightly. The additional if() is unnecessary. The $strings variable is always defined and the if() does contain nothing else than yet another if(). This change is not really testable and requires a code review.

Credit goes to @Hackwar

### Testing Instructions
Code review.


### Expected result
Works as expected on frontend and backend.


### Documentation Changes Required
none
