### PR TITLE
Remove check for a valid form from two places in plugins

### DIFF
--- a/plugins/system/languagecode/languagecode.php
+++ b/plugins/system/languagecode/languagecode.php
@@ -113,7 +113,7 @@ class PlgSystemLanguagecode extends JPlugin
 	 *
 	 * @since	2.5
 	 */
-	public function onContentPrepareForm($form, $data)
+	public function onContentPrepareForm(JForm $form, $data)
 	{
 		// Check we are manipulating the languagecode plugin.
 		if ($form->getName() !== 'com_plugins.plugin' || !$form->getField('languagecodeplugin', 'params'))

--- a/plugins/system/languagecode/languagecode.php
+++ b/plugins/system/languagecode/languagecode.php
@@ -115,14 +115,6 @@ class PlgSystemLanguagecode extends JPlugin
 	 */
 	public function onContentPrepareForm($form, $data)
 	{
-		// Check we have a form.
-		if (!($form instanceof JForm))
-		{
-			$this->_subject->setError('JERROR_NOT_A_FORM');
-
-			return false;
-		}
-
 		// Check we are manipulating the languagecode plugin.
 		if ($form->getName() !== 'com_plugins.plugin' || !$form->getField('languagecodeplugin', 'params'))
 		{

--- a/plugins/user/profile/profile.php
+++ b/plugins/user/profile/profile.php
@@ -226,13 +226,6 @@ class PlgUserProfile extends JPlugin
 	 */
 	public function onContentPrepareForm($form, $data)
 	{
-		if (!($form instanceof JForm))
-		{
-			$this->_subject->setError('JERROR_NOT_A_FORM');
-
-			return false;
-		}
-
 		// Check we are manipulating a valid form.
 		$name = $form->getName();
 

--- a/plugins/user/profile/profile.php
+++ b/plugins/user/profile/profile.php
@@ -224,7 +224,7 @@ class PlgUserProfile extends JPlugin
 	 *
 	 * @since   1.6
 	 */
-	public function onContentPrepareForm($form, $data)
+	public function onContentPrepareForm(JForm $form, $data)
 	{
 		// Check we are manipulating a valid form.
 		$name = $form->getName();


### PR DESCRIPTION
### Summary of Changes

If the passed parameter is not a valid form our system is broken at all.

### Testing Instructions

- Enable the profile plugin
- confirm that the profile fields are added to the frontend band backend views.
- enable the language code plugin
- confirm that the language code field is placed in the language code plugin

### Expected result

Still works as expected

### Actual result

There is a check if there is a valid form. But if at that place is somehow not a valid form the site is broken anyway.

### Documentation Changes Required

none.