### PR TITLE
[a11y] Hide Enabled/Disabled users column headers

### DIFF
--- a/administrator/components/com_users/views/groups/tmpl/default.php
+++ b/administrator/components/com_users/views/groups/tmpl/default.php
@@ -68,12 +68,14 @@ JFactory::getDocument()->addScriptDeclaration('
 							<?php echo JHtml::_('searchtools.sort', 'COM_USERS_HEADING_GROUP_TITLE', 'a.title', $listDirn, $listOrder); ?>
 						</th>
 						<th width="1%" class="nowrap center">
-							<span class="icon-publish hasTooltip" aria-hidden="true" title="<?php echo JText::_('COM_USERS_COUNT_ENABLED_USERS'); ?>"></span>
-							<span class="hidden-phone"><?php echo JText::_('COM_USERS_COUNT_ENABLED_USERS'); ?></span>
+							<span class="icon-publish hasTooltip" aria-hidden="true" title="<?php echo JText::_('COM_USERS_COUNT_ENABLED_USERS'); ?>">
+								<span class="element-invisible"><?php echo JText::_('COM_USERS_COUNT_ENABLED_USERS'); ?></span>
+							</span>
 						</th>
 						<th width="1%" class="nowrap center">
-							<span class="icon-unpublish hasTooltip" aria-hidden="true" title="<?php echo JText::_('COM_USERS_COUNT_DISABLED_USERS'); ?>"></span>
-							<span class="hidden-phone"><?php echo JText::_('COM_USERS_COUNT_DISABLED_USERS'); ?></span>
+							<span class="icon-unpublish hasTooltip" aria-hidden="true" title="<?php echo JText::_('COM_USERS_COUNT_DISABLED_USERS'); ?>">
+								<span class="element-invisible"><?php echo JText::_('COM_USERS_COUNT_DISABLED_USERS'); ?></span>
+							</span>
 						</th>
 						<th width="1%" class="nowrap hidden-phone">
 							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>


### PR DESCRIPTION
Redo Issue #17924.

### Summary of Changes
`Enabled users` and `Disabled users` column headers are hidden on phone devices. This PR hides them on all devices but make them a11y compliant.


### Testing Instructions
Go to Users > User Groups
View the 2 columns next to the last column on the right side.

View page source or web inspector to see the following:
`<span class="element-invisible">Enabled Users</span>`
`<span class="element-invisible">Disabled Users</span>`



### Expected result
Column headers hidden.

![12086-after](https://user-images.githubusercontent.com/368084/39504001-be7eca52-4d7d-11e8-81f2-3a6b7bc80900.png)



### Actual result
Column headers visible.

![12086-before](https://user-images.githubusercontent.com/368084/39504003-c4538332-4d7d-11e8-8a62-97f62433dd73.png)


### Documentation Changes Required
none
