### PR TITLE
[fix] openbase_dir correct processing, #13214

### DIFF
--- a/libraries/joomla/filesystem/folder.php
+++ b/libraries/joomla/filesystem/folder.php
@@ -247,7 +247,7 @@ abstract class JFolder
 				{
 					$test = $pathObject->clean($test);
 
-					if (strpos($path, $test) === 0)
+					if (strpos($path, $test) === 0 || strpos($path, realpath($test)) === 0)
 					{
 						$inBaseDir = true;
 						break;


### PR DESCRIPTION
Improved fix for pull request #17349 .

### Summary of Changes
If the open_basedir ini directive contains a path that links to a
symlink, PHP will resolve these paths and then perform the acutal
access check.

Joomla, however, only performed a plain string comparison. As a
result leading to false positives.

### Testing Instructions

- Create directory: ~/a/public_html
- Create symlink: ~/b/ pointing to ~/a/
- Configure PHP's openbasedir to contain ~/b/public_html
- Have Joomla create a folder inside ~/a/public_html

### Expected result

This should just work with no erorrs whatsoever.

### Actual result

An error is presented that the path is not within open_basedir..

### Documentation Changes Required

No