### PR TITLE
Marked as archived, archive articles

### DIFF
--- a/components/com_content/views/article/tmpl/default.php
+++ b/components/com_content/views/article/tmpl/default.php
@@ -54,6 +54,9 @@ JHtml::_('behavior.caption');
 				<?php echo $this->escape($this->item->title); ?>
 			</h2>
 		<?php endif; ?>
+		<?php if ($this->item->state == 2) : ?>
+			<span class="label label-warning"><?php echo JText::_('JARCHIVED'); ?></span>
+		<?php endif; ?>
 		<?php if ($this->item->state == 0) : ?>
 			<span class="label label-warning"><?php echo JText::_('JUNPUBLISHED'); ?></span>
 		<?php endif; ?>


### PR DESCRIPTION
Pull Request for Issue #19401 

### Summary of Changes
Add an indication, for when you enter to an archived article. 


### Testing Instructions
It suffices reviewing the code. But if you want a test, just change the state of an article to Archived, and go to the frontend and check if the article have the label "Archived".

### Expected result
The label "Archived" show up

### Actual result
There is no indication that a file is archived

### Documentation Changes Required
No
