### PR TITLE
[3.10] Drop the unused use command from com_joomlaupdate

### DIFF
--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -1366,7 +1366,7 @@ ENDDATA;
 	 */
 	private static function isNonCoreExtension($extension)
 	{
-		$coreExtensions = JExtensionHelper::getCoreExtensions();
+		$coreExtensions = ExtensionHelper::getCoreExtensions();
 
 		foreach ($coreExtensions as $coreExtension)
 		{

--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -9,8 +9,6 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\Extension\ExtensionHelper;
-
 jimport('joomla.filesystem.folder');
 jimport('joomla.filesystem.file');
 
@@ -1366,7 +1364,7 @@ ENDDATA;
 	 */
 	private static function isNonCoreExtension($extension)
 	{
-		$coreExtensions = ExtensionHelper::getCoreExtensions();
+		$coreExtensions = JExtensionHelper::getCoreExtensions();
 
 		foreach ($coreExtensions as $coreExtension)
 		{


### PR DESCRIPTION
### Summary of Changes

Drop the unused use command from com_joomlaupdate

### Testing Instructions

Review. In the code we use JExtensionHelper for now: https://github.com/joomla/joomla-cms/blob/3.9-dev/administrator/components/com_joomlaupdate/models/default.php#L1369
