### PR TITLE
Fix the construction of category routes to include the correct layout

### DIFF
--- a/components/com_content/helpers/route.php
+++ b/components/com_content/helpers/route.php
@@ -80,7 +80,7 @@ abstract class ContentHelperRoute
 			}
 
 			$jinput = JFactory::getApplication()->input;
-			$layout = $jinput->get('layout');
+			$layout = $jinput->getString('layout');
 
 			if ($layout !== '')
 			{


### PR DESCRIPTION
This commit fixes a bug where special characters like a semicolon get incorrectly removed from the layout parameter, leading to the url using an invalid layout.

### Summary of Changes
Using the `ContentHelperRoute` class to construct a category route can sometimes result in generating an invalid url. The `layout` parameter has been obtained by `JInput::get` which by default will use the `cmd` filter, which removes certain special characters from the string.

We should use the `string` filter instead here, which allows more characters than `cmd`. Note: This does not introduce any security issues as far as I'd assess, because XSS-suspicious strings still get removed by the `string` filter, and other stuff should be catched by url-encoding methods such as `JRoute::_`. I might have overseen something though, so if somebody could confirm this I'd be very happy.

### Testing Instructions
Create a layout with some special characters in it, e.g. a semicolon. This is e.g. being used YOOthemes Warp Framework to split the used layout and the used style from each other.
Then call this method from somewhere and notice that your semicolon has been removed, leading to an incorrect link.

### Expected result
The link should contain the correct layout paramater.

### Actual result
The link contains a layout parameter with certain special characters removed, leading to an incorrect link as the layout will not be found and the default layout used instead.
