### PR TITLE
[3.9] Fix filesystem helper class not found

### DIFF
--- a/libraries/src/Filesystem/Stream.php
+++ b/libraries/src/Filesystem/Stream.php
@@ -11,7 +11,7 @@ namespace Joomla\CMS\Filesystem;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Object\CMSObject;
-use Joomla\Filesystem\FilesystemHelper;
+use Joomla\CMS\Filesystem\FilesystemHelper;
 use Joomla\Language\Text;
 
 /**


### PR DESCRIPTION
### Issue 
>0 Class 'Joomla\Filesystem\FilesystemHelper' not found

### Summary of Changes
Fix filesystem helper class not found
Changes in <code>libraries/src/Filesystem/Stream.php</code>
Use correct namespace class
<code>Joomla\Filesystem\FilesystemHelper; </code> --> <code>Joomla\CMS\Filesystem\FilesystemHelper; </code>

### Testing Instructions
Try to create override in template manager.

### Expected result
Override file easily created.  


### Actual result
Error 
>0 Class 'Joomla\Filesystem\FilesystemHelper' not found


### Documentation Changes Required

