### PR TITLE
The fix for Joomla progressive cache causing multiple duplicate javas…

### DIFF
--- a/libraries/src/Document/HtmlDocument.php
+++ b/libraries/src/Document/HtmlDocument.php
@@ -309,7 +309,7 @@ class HtmlDocument extends Document
 		{
 			foreach ($data['style'] as $type => $stdata)
 			{
-				if (!isset($this->_style[strtolower($type)]) || !stristr($this->_style[strtolower($type)], $stdata))
+				if (!isset($this->_style[strtolower($type)]) || !stristr($stdata, $this->_style[strtolower($type)]))
 				{
 					$this->addStyleDeclaration($stdata, $type);
 				}
@@ -324,7 +324,7 @@ class HtmlDocument extends Document
 		{
 			foreach ($data['script'] as $type => $sdata)
 			{
-				if (!isset($this->_script[strtolower($type)]) || !stristr($this->_script[strtolower($type)], $sdata))
+				if (!isset($this->_script[strtolower($type)]) || !stristr($sdata, $this->_script[strtolower($type)]))
 				{
 					$this->addScriptDeclaration($sdata, $type);
 				}


### PR DESCRIPTION
…cript declarations

The issue has been described and discussed at 
https://github.com/joomla/joomla-cms/issues/5933
https://github.com/joomla/joomla-cms/pull/2558
https://github.com/joomla/joomla-platform/issues/673

In my case I had a problem with JCE mediabox plugin failing once a page has been cached, due to its init script getting duplicated up to 8 times. 

This PR fixes the bugs in two lines that were meant to prevent duplication but the stristr() checks string inclusion in the wrong way: $sdata/$stdata here is the cached script declarations string so it has to be a haystack and be the first argument.

Pull Request for Issue # .

### Summary of Changes



### Testing Instructions



### Expected result



### Actual result



### Documentation Changes Required

