### PR TITLE
Enable to change FormData in com_menu

### DIFF
--- a/administrator/components/com_banners/models/download.php
+++ b/administrator/components/com_banners/models/download.php
@@ -72,7 +72,7 @@ class BannersModelDownload extends JModelForm
 	 */
 	protected function loadFormData()
 	{
-		$data = array(
+		$data = (object) array(
 			'basename'   => $this->getState('basename'),
 			'compressed' => $this->getState('compressed'),
 		);

--- a/administrator/components/com_menus/models/item.php
+++ b/administrator/components/com_menus/models/item.php
@@ -627,7 +627,7 @@ class MenusModelItem extends JModelAdmin
 			$this->setState('item.menutypeid', $menuTypeId);
 		}
 
-		$data = ArrayHelper::toObject($data, 'JObject');
+		$data = (object) $data;
 
 		$this->preprocessData('com_menus.item', $data);
 

--- a/administrator/components/com_menus/models/item.php
+++ b/administrator/components/com_menus/models/item.php
@@ -627,6 +627,8 @@ class MenusModelItem extends JModelAdmin
 			$this->setState('item.menutypeid', $menuTypeId);
 		}
 
+		$data = ArrayHelper::toObject($data, 'JObject');
+
 		$this->preprocessData('com_menus.item', $data);
 
 		return $data;


### PR DESCRIPTION
### Summary of Changes
Changed the `loadFormData` to cast `$data` to an object (in com_menus/item and com_banners/download). All other components/models use an object when calling `$this->preprocessData`, com_menu and com_banner (and these specific models) seem to be the only exceptions. These changes should have no negative effect on existing code. This change is required to be able to alter the data of the JForm because the original array will not be modified (an object will however).

### Testing Instructions
1. Open the file plugins/system/stats/stats.php
2. Add these lines after line 22
```
 public function onContentPrepareData($context, $data)
    {
        $data['title'] = "foo";
    }
```
3. Go in the backend to a menu-item (here I open a menu item called Login)
4. Notice how the title remains unchanged
<img width="304" alt="image" src="https://user-images.githubusercontent.com/359377/40567941-fdb266cc-6077-11e8-8e77-e0b51e369747.png">
On all other views this will throw an exception/error (this is the inconsistency)

5. Apply the patch
6. Change the code in stats.php to look like the following
```
 public function onContentPrepareData($context, $data)
    {
        $data->title = "foo";
    }
```
7. Now reload the menu item page and see the title is changed
<img width="247" alt="image" src="https://user-images.githubusercontent.com/359377/40567998-47fcf328-6078-11e8-89a2-f9747d8d3c21.png">

To test this with the banners fix, do the following:
1. Open the file plugins/system/stats/stats.php
2. Add these lines after line 22
```
 public function onContentPrepareData($context, $data)
    {
        $data['basename'] = "foo";
    }
```
3. Go in the backend to Banners -> Tracks
4. Click on Export
5. The modal shows the File Name as __SITE__ instead of foo
<img width="314" alt="image" src="https://user-images.githubusercontent.com/359377/40568106-dd09cb58-6078-11e8-9b01-7309a3217a3c.png">

6. Close the modal
7. Change the code in stats.php to look like the following
```
 public function onContentPrepareData($context, $data)
    {
        $data->basename = "foo";
    }
```
8. Now click on the Export button again and notice the File Name is changed to foo
<img width="304" alt="image" src="https://user-images.githubusercontent.com/359377/40568124-04e8964a-6079-11e8-9aef-a1e4284d52d4.png">

Now both have been successfully tested

### Expected result
Title of menu-item is changed to "foo"

### Actual result
Title remains unchanged

### Documentation Changes Required
None