### PR TITLE
Enable Profiling tab for mysql (PDO) queries and disable cache in debug mode

### DIFF
--- a/libraries/joomla/database/driver/mysql.php
+++ b/libraries/joomla/database/driver/mysql.php
@@ -96,10 +96,15 @@ class JDatabaseDriverMysql extends JDatabaseDriverMysqli
 		// Set the character set (needed for MySQL 4.1.2+).
 		$this->utf = $this->setUtf();
 
-		// Turn MySQL profiling ON in debug mode:
-		if ($this->debug && $this->hasProfiling())
+		// Disable query cache and turn profiling ON in debug mode.
+		if ($this->debug)
 		{
-			mysql_query('SET profiling = 1;', $this->connection);
+			mysql_query('SET query_cache_type = 0;', $this->connection);
+
+			if ($this->hasProfiling())
+			{
+				mysql_query('SET profiling_history_size = 100, profiling = 1;', $this->connection);
+			}
 		}
 	}
 

--- a/libraries/joomla/database/driver/mysqli.php
+++ b/libraries/joomla/database/driver/mysqli.php
@@ -188,11 +188,15 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 		// Set the character set (needed for MySQL 4.1.2+).
 		$this->utf = $this->setUtf();
 
-		// Turn MySQL profiling ON in debug mode:
-		if ($this->debug && $this->hasProfiling())
+		// Disable query cache and turn profiling ON in debug mode.
+		if ($this->debug)
 		{
-			mysqli_query($this->connection, 'SET profiling_history_size = 100;');
-			mysqli_query($this->connection, 'SET profiling = 1;');
+			mysqli_query($this->connection, 'SET query_cache_type = 0;');
+
+			if ($this->hasProfiling())
+			{
+				mysqli_query($this->connection, 'SET profiling_history_size = 100, profiling = 1;');
+			}
 		}
 	}
 

--- a/libraries/joomla/database/driver/pdomysql.php
+++ b/libraries/joomla/database/driver/pdomysql.php
@@ -153,6 +153,17 @@ class JDatabaseDriverPdomysql extends JDatabaseDriverPdo
 
 		// Set sql_mode to non_strict mode
 		$this->connection->query("SET @@SESSION.sql_mode = '';");
+
+		// Disable query cache and turn profiling ON in debug mode.
+		if ($this->debug)
+		{
+			$this->connection->query('SET query_cache_type = 0;');
+
+			if ($this->hasProfiling())
+			{
+				$this->connection->query('SET profiling_history_size = 100, profiling = 1;');
+			}
+		}
 	}
 
 	/**
@@ -570,5 +581,19 @@ class JDatabaseDriverPdomysql extends JDatabaseDriverPdo
 				$this->transactionDepth++;
 			}
 		}
+	}
+
+	/**
+	 * Internal function to check if profiling is available.
+	 *
+	 * @return  boolean
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	private function hasProfiling()
+	{
+		$result = $this->setQuery("SHOW VARIABLES LIKE 'have_profiling'")->loadAssoc();
+
+		return isset($result);
 	}
 }


### PR DESCRIPTION
Pull Request for Issue #13265.

### Summary of Changes

1. This PR makes the query cache disabled when db driver runs in debug mode.
2. Enable Profile for Mysql PDO.

Not direct forked but based on #13268. 

### Testing Instructions
Details at  #13268

1. Enable debug mode in global config and system debug plugin
2. Test at least one of driver: Mysql, MySqli or PDO Mysql. 
3. Check debug console "Database Queries" and "Profile" tab. Each query should run without using database cache. 


### Expected result
No cached query.
On PDOMYSQL driver profile tab is enabled.

### Actual result

On debug mode queries use database cache.
On PDOMYSQL driver profile tab is disabled.

### Documentation Changes Required
No