### PR TITLE
[4.0] Count on non-Countable object

### DIFF
--- a/libraries/src/Schema/ChangeItem.php
+++ b/libraries/src/Schema/ChangeItem.php
@@ -199,7 +199,7 @@ abstract class ChangeItem
 
 			try
 			{
-				$rows = $this->db->loadObject();
+				$rows = $this->db->loadRowList();
 			}
 			catch (\RuntimeException $e)
 			{


### PR DESCRIPTION
Using php 7.2 and above
Go to extensions->manage->database

`Warning: count(): Parameter must be an array or an object that implements Countable in C:\htdocs\cms4\libraries\src\Schema\ChangeItem.php on line 214`

Apply patch

no more warning
