### PR TITLE
[4.0] Installation strings

### DIFF
--- a/installation/language/en-GB/en-GB.ini
+++ b/installation/language/en-GB/en-GB.ini
@@ -41,7 +41,7 @@ INSTL_DATABASE_PASSWORD_DESC="Either a password you created or a password provid
 INSTL_DATABASE_PREFIX_DESC="Enter a table prefix or use the randomly generated one."
 INSTL_DATABASE_TYPE_DESC="Select the database type."
 INSTL_DATABASE_USER_DESC="Either a username you created or a username provided by your host."
-INSTL_DATABASE_VALIDATION_ERROR="Check your DB credentials, db type, db name or hostname"
+INSTL_DATABASE_VALIDATION_ERROR="Check your database credentials, database type, database name or hostname"
 INSTL_INSTALL_JOOMLA="Install Joomla"
 INSTL_CONNECT_DB="Setup database connection"
 

--- a/installation/language/en-US/en-US.ini
+++ b/installation/language/en-US/en-US.ini
@@ -162,7 +162,7 @@ INSTL_DATABASE_INVALID_NAME="MySQL versions previous to 5.1.6 may not contain pe
 INSTL_DATABASE_NAME_INVALID_SPACES="MySQL database names and table names may not begin or end with spaces."
 INSTL_DATABASE_NAME_INVALID_CHAR="No MySQL identifier can contain a NULL ASCII(0x00)."
 INSTL_DATABASE_FILE_DOES_NOT_EXIST="File %s does not exist"
-INSTL_DATABASE_VALIDATION_ERROR="Check your DB credentials, db type, db name or hostname"
+INSTL_DATABASE_VALIDATION_ERROR="Check your database credentials, database type, database name or hostname"
 
 ;controllers
 INSTL_COOKIES_NOT_ENABLED="Cookies do not appear to be enabled on your browser client. You will not be able to install the application with this feature disabled. Alternatively, there could also be a problem with the server's <strong>session.save_path</strong>. If this is the case, please consult your hosting provider if you don't know how to check or fix this yourself."


### PR DESCRIPTION
lets try not to use acronyms or abbreviations in the installation. This is one area where the error messages should be really clear.

PS can we add the codeowners file to the 4.0 branch please. A lot of time and effort went into getting the strings in a decent state and it would be a shame for them to get in a mess again
