### PR TITLE
Load MenusHelper - fix fatal error preset import

### DIFF
--- a/administrator/components/com_menus/controllers/menu.php
+++ b/administrator/components/com_menus/controllers/menu.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+JLoader::register('MenusHelper', JPATH_ADMINISTRATOR . '/components/com_menus/helpers/menus.php');
+
 /**
  * The Menu Type Controller
  *


### PR DESCRIPTION
Attempt to install presets to (Admin) menu and get fatal error: "Class 'MenusHelper' not found" in /administrator/components/com_menus/controllers/menu.php at line 136:
```
MenusHelper::installPreset($preset, $data['menutype']);
```

### Summary of Changes

Add a line at the beginning of the php file to import the MenusHelper.

### Testing Instructions
Attempt to install presets without this fix, get fatal error, presets not installed.

Attempt to install presets with this fix, no fatal error, presets are installed.

### Documentation Changes Required
None.