### PR TITLE
[com_users] Change the display of toolbar buttons in the Administrator user view

### DIFF
--- a/administrator/components/com_users/views/users/view.html.php
+++ b/administrator/components/com_users/views/users/view.html.php
@@ -133,16 +133,34 @@ class UsersViewUsers extends JViewLegacy
 			JToolbarHelper::editList('user.edit');
 		}
 
+		// Get states
+		$state = $this->state->get('filter.state');
+		$active = $this->state->get('filter.active');
+
 		if ($canDo->get('core.edit.state'))
 		{
 			JToolbarHelper::divider();
-			JToolbarHelper::publish('users.activate', 'COM_USERS_TOOLBAR_ACTIVATE', true);
-			JToolbarHelper::unpublish('users.block', 'COM_USERS_TOOLBAR_BLOCK', true);
-			JToolbarHelper::custom('users.unblock', 'unblock.png', 'unblock_f2.png', 'COM_USERS_TOOLBAR_UNBLOCK', true);
+
+			if ($active !== '0')
+			{
+				JToolbarHelper::publish('users.activate', 'COM_USERS_TOOLBAR_ACTIVATE', true);
+			}
+
+			if ($state !== '1')
+			{
+				JToolbarHelper::unpublish('users.block', 'COM_USERS_TOOLBAR_BLOCK', true);
+			}
+
+			if ($state !== '0')
+			{
+				JToolbarHelper::custom('users.unblock', 'unblock.png', 'unblock_f2.png', 'COM_USERS_TOOLBAR_UNBLOCK', true);
+
+			}
+
 			JToolbarHelper::divider();
 		}
 
-		if ($canDo->get('core.delete'))
+		if ($canDo->get('core.delete') && $state)
 		{
 			JToolbarHelper::deleteList('JGLOBAL_CONFIRM_DELETE', 'users.delete', 'JTOOLBAR_DELETE');
 			JToolbarHelper::divider();

--- a/administrator/components/com_users/views/users/view.html.php
+++ b/administrator/components/com_users/views/users/view.html.php
@@ -134,7 +134,7 @@ class UsersViewUsers extends JViewLegacy
 		}
 
 		// Get states
-		$state = $this->state->get('filter.state');
+		$state  = $this->state->get('filter.state');
 		$active = $this->state->get('filter.active');
 
 		if ($canDo->get('core.edit.state'))

--- a/administrator/components/com_users/views/users/view.html.php
+++ b/administrator/components/com_users/views/users/view.html.php
@@ -154,7 +154,6 @@ class UsersViewUsers extends JViewLegacy
 			if ($state !== '0')
 			{
 				JToolbarHelper::custom('users.unblock', 'unblock.png', 'unblock_f2.png', 'COM_USERS_TOOLBAR_UNBLOCK', true);
-
 			}
 
 			JToolbarHelper::divider();


### PR DESCRIPTION
Pull Request for Issue #20049 .

### Summary of Changes
Change users toolbar buttons visibility


### Testing Instructions
* Install Joomla 3.8.7
* Apply this path
* Go to admin users view `/administrator/index.php?option=com_users&view=users`
* Change the filter values and watch what buttons are reflected
	* If the filter is empty show all buttons except `Delete`
	* If set `- Select State -` to `Enabled`:  
	Show `Block`;  
	Hide `Unblock`
	* If set `- Select State -` to `Disabled`:  
	Show `Unblock` `Delete`;  
	Hide `Block`
	* If set `- Select Active State -` to `Activated`:
	Hide : `Activate`

### Expected result
The buttons will be displayed depending on the filter



### Actual result
All buttons are always displayed