### PR TITLE
Deprecate ContactModelContact::getContactQuery()

### DIFF
--- a/components/com_contact/models/contact.php
+++ b/components/com_contact/models/contact.php
@@ -420,6 +420,7 @@ class ContactModelContact extends JModelForm
 	 * @return  mixed    The contact object on success, false on failure
 	 *
 	 * @throws  Exception  On database failure
+	 * @deprecated  4.0    Use ContactModelContact::getItem() instead
 	 */
 	protected function getContactQuery($pk = null)
 	{


### PR DESCRIPTION
Redo Issue #16460.

### Summary of Changes
Deprecate ContactModelContact::getContactQuery() instead of removing.

> This removes the method ContactModelContact::getContactQuery(). I was unable to find any place in our codebase where we use it and to be honest, it looks as if this was added 8 years ago rather by mistake. All changes since then seem to have been mass-refactorings. While the method does return more or less correct data, it does not return all data that you get with ContactModelContact::getItem(). Since the method is protected and in a component, there should be no issue with backwards compatibility.

Thanks @Hackwar 

### Testing Instructions
Code review
