### PR TITLE
[4.0] Fix preinstall view in installer

### DIFF
--- a/installation/src/Model/ChecksModel.php
+++ b/installation/src/Model/ChecksModel.php
@@ -251,7 +251,7 @@ class ChecksModel extends BaseInstallationModel
 		}
 
 		// Get the form.
-		Form::addFormPath(JPATH_COMPONENT . '/model/forms');
+		Form::addFormPath(JPATH_COMPONENT . '/forms');
 
 		try
 		{

--- a/installation/src/Model/LanguagesModel.php
+++ b/installation/src/Model/LanguagesModel.php
@@ -520,7 +520,7 @@ class LanguagesModel extends BaseInstallationModel
 		}
 
 		// Get the form.
-		Form::addFormPath(JPATH_COMPONENT . '/model/forms');
+		Form::addFormPath(JPATH_COMPONENT . '/forms');
 		Form::addFieldPath(JPATH_COMPONENT . '/model/fields');
 		Form::addRulePath(JPATH_COMPONENT . '/model/rules');
 

--- a/installation/src/View/Preinstall/HtmlView.php
+++ b/installation/src/View/Preinstall/HtmlView.php
@@ -29,6 +29,14 @@ class HtmlView extends DefaultView
 	protected $options;
 
 	/**
+	 * The default model
+	 *
+	 * @var	   string
+	 * @since  3.0
+	 */
+	protected $_defaultModel = 'checks';
+
+	/**
 	 * Execute and display a template script.
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
@@ -39,7 +47,7 @@ class HtmlView extends DefaultView
 	 */
 	public function display($tpl = null)
 	{
-		$this->options  = $this->get('PhpOptions', 'Checks');
+		$this->options = $this->get('PhpOptions');
 
 		return parent::display($tpl);
 	}


### PR DESCRIPTION
Installer is unable to display the preinstall view. There are 2 reasons for this.

First the DefaultView can't load the correct Model because it is not defined.
Second the search path for the form preinstall.xml is wrong.

### Summary of Changes

Set default model to 'checks' in Preinstall/HtmlView.php
Change AddFormPath to JPATH_COMPONENT.'/forms' (removed the subfolder 'model') in ChecksModel
This is also done for LanguagesModel


### Testing Instructions
Try to install J4 without fulfill all dependencies, for example non writeable configuration.php 


### Expected result
Get the preinstall view that informs you whats wrong.


### Actual result
Something like
```
An error has occurred while processing your request.
0 Call to a member function getLabel() on boolean
```


### Documentation Changes Required
No
