### PR TITLE
[4.0] Add a migration layer for PostgreSQL configured sites to the database service provider

### DIFF
--- a/libraries/src/Service/Provider/Database.php
+++ b/libraries/src/Service/Provider/Database.php
@@ -71,6 +71,16 @@ class Database implements ServiceProviderInterface
 					}
 				}
 
+				/*
+				 * Joomla! 4.0 removes support for the `ext/pgsql` PHP extension.  To help with the migration, we will migrate the configuration
+				 * to the PDO PostgreSQL driver regardless of if the environment supports it.  Instead of getting a "driver not found" type of
+				 * error, this will instead force the API to report that the driver is not supported.
+				 */
+				if (strtolower($dbtype) === 'postgresql')
+				{
+					$dbtype = 'pgsql';
+				}
+
 				$options = [
 					'driver'   => $dbtype,
 					'host'     => $conf->get('host'),


### PR DESCRIPTION
### Summary of Changes

Framework 2.0 has removed the `ext/pgsql` database driver.  This adds a migration layer to the database service provider to migrate the `postgresql` database config to `pgsql` to force use of PDO PostgreSQL if someone doesn't update their configuration.  Basically instead of giving a "driver not found" error if config isn't updated, you get a "driver unsupported" error if the server stack isn't ready or things will just transparently continue working if the server stack is good to go.