### PR TITLE
URL Menu Item Type link should be required.

### DIFF
--- a/administrator/components/com_menus/views/item/tmpl/edit.php
+++ b/administrator/components/com_menus/views/item/tmpl/edit.php
@@ -164,6 +164,7 @@ if ($clientId === 1)
 				if ($this->item->type == 'url')
 				{
 					$this->form->setFieldAttribute('link', 'readonly', 'false');
+					$this->form->setFieldAttribute('link', 'required', 'true');
 				}
 
 				echo $this->form->renderField('link');


### PR DESCRIPTION
### Summary of Changes
Make the `link` field required when the menu item type is URL


### Testing Instructions
Before patch, one can save a menu item of type URL without any link...

After patch, it will be impossible.