### PR TITLE
[4.0] [WIP] Add AccessControl replacement class for Access

### DIFF
--- a/administrator/components/com_categories/Field/CategoryeditField.php
+++ b/administrator/components/com_categories/Field/CategoryeditField.php
@@ -156,7 +156,7 @@ class CategoryeditField extends \JFormFieldList
 		$user = Factory::getUser();
 
 		$query = $db->getQuery(true)
-			->select('a.id AS value, a.title AS text, a.level, a.published, a.lft, a.language')
+			->select('a.id AS value, a.title AS text, a.asset_id, a.level, a.published, a.lft, a.language')
 			->from('#__categories AS a');
 
 		// Filter by the extension type
@@ -232,9 +232,14 @@ class CategoryeditField extends \JFormFieldList
 			Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');
 		}
 
+		/** @var AccessControl */
+		$acl = Factory::getContainer()->get('acl');
+
 		// Pad the option text with spaces using depth level as a multiplier.
 		for ($i = 0, $n = count($options); $i < $n; $i++)
 		{
+			$acl->addAssetIdToPreload($options[$i]->asset_id);
+
 			// Translate ROOT
 			if ($this->element['parent'] == true || $jinput->get('option') == 'com_categories')
 			{

--- a/administrator/components/com_content/Model/ArticlesModel.php
+++ b/administrator/components/com_content/Model/ArticlesModel.php
@@ -197,7 +197,7 @@ class ArticlesModel extends ListModel
 		$query->select(
 			$this->getState(
 				'list.select',
-				'DISTINCT a.id, a.title, a.alias, a.checked_out, a.checked_out_time, a.catid' .
+				'DISTINCT a.id, a.asset_id, a.title, a.alias, a.checked_out, a.checked_out_time, a.catid' .
 				', a.state, a.access, a.created, a.created_by, a.created_by_alias, a.modified, a.ordering, a.featured, a.language, a.hits' .
 				', a.publish_up, a.publish_down'
 			)
@@ -218,6 +218,7 @@ class ArticlesModel extends ListModel
 
 		// Join over the categories.
 		$query->select('c.title AS category_title')
+			->select('c.asset_id AS category_asset_id')
 			->join('LEFT', '#__categories AS c ON c.id = a.catid');
 
 		// Join over the users for the author.

--- a/administrator/components/com_modules/Model/ModulesModel.php
+++ b/administrator/components/com_modules/Model/ModulesModel.php
@@ -217,6 +217,15 @@ class ModulesModel extends ListModel
 		// Process pagination.
 		$result = parent::_getList($query, $limitstart, $limit);
 
+		/** @var AccessControl */
+		$acl = Factory::getContainer()->get('acl');
+
+		foreach ($result as $item)
+		{
+			// Preload assets.
+			$acl->addAssetNameToPreload('com_modules.module.' . $item->id, 0);
+		}
+
 		// Translate the results.
 		$this->translate($result);
 

--- a/administrator/modules/mod_latest/Helper/ModLatestHelper.php
+++ b/administrator/modules/mod_latest/Helper/ModLatestHelper.php
@@ -38,8 +38,11 @@ abstract class ModLatestHelper
 		$user = Factory::getUser();
 
 		// Set List SELECT
-		$model->setState('list.select', 'a.id, a.title, a.checked_out, a.checked_out_time, ' .
-			' a.access, a.created, a.created_by, a.created_by_alias, a.featured, a.state, a.publish_up, a.publish_down');
+		$model->setState('list.select',
+			'a.id, a.asset_id, a.title, a.checked_out, a.checked_out_time,'
+				. ' a.access, a.created, a.created_by, a.created_by_alias,'
+				. ' a.featured, a.state, a.publish_up, a.publish_down'
+		);
 
 		// Set Ordering filter
 		switch ($params->get('ordering'))
@@ -92,8 +95,16 @@ abstract class ModLatestHelper
 			return false;
 		}
 
+		/** @var AccessControl */
+		$acl = Factory::getContainer()->get('acl');
+
+		foreach ($items as $item)
+		{
+			$acl->addAssetIdToPreload($item->asset_id ?: $item->category_asset_id);
+		}
+
 		// Set the links
-		foreach ($items as &$item)
+		foreach ($items as $item)
 		{
 			$item->link = '';
 

--- a/administrator/modules/mod_popular/Helper/PopularHelper.php
+++ b/administrator/modules/mod_popular/Helper/PopularHelper.php
@@ -38,7 +38,7 @@ abstract class PopularHelper
 		$user = Factory::getUser();
 
 		// Set List SELECT
-		$model->setState('list.select', 'a.id, a.title, a.checked_out, a.checked_out_time, ' .
+		$model->setState('list.select', 'a.id, a.asset_id, a.title, a.checked_out, a.checked_out_time, ' .
 				' a.publish_up, a.hits');
 
 		// Set Ordering filter
@@ -79,6 +79,13 @@ abstract class PopularHelper
 			throw new \Exception($error, 500);
 
 			return false;
+		}
+
+		$acl = Factory::getContainer()->get('acl');
+
+		foreach ($items as $item)
+		{
+			$acl->addAssetIdToPreload($item->asset_id ?: $item->category_asset_id);
 		}
 
 		// Set the links

--- a/components/com_content/Model/ArticleModel.php
+++ b/components/com_content/Model/ArticleModel.php
@@ -117,6 +117,7 @@ class ArticleModel extends ItemModel
 				// Join on category table.
 				$query->select('c.title AS category_title, c.alias AS category_alias, c.access AS category_access,' .
 						'c.language AS category_language')
+					->select('c.asset_id AS category_asset_id')
 					->innerJoin('#__categories AS c on c.id = a.catid')
 					->where('c.published > 0');
 
@@ -187,16 +188,16 @@ class ArticleModel extends ItemModel
 				if (!$user->get('guest'))
 				{
 					$userId = $user->get('id');
-					$asset = 'com_content.article.' . $data->id;
+					$assetId = $data->asset_id ?: $data->category_asset_id;
 
 					// Check general edit permission first.
-					if ($user->authorise('core.edit', $asset))
+					if ($user->isAuthorised('core.edit', $assetId, 'com_content'))
 					{
 						$data->params->set('access-edit', true);
 					}
 
 					// Now check if edit.own is available.
-					elseif (!empty($userId) && $user->authorise('core.edit.own', $asset))
+					elseif (!empty($userId) && $user->isAuthorised('core.edit.own', $assetId, 'com_content'))
 					{
 						// Check for a valid user and that they are the owner.
 						if ($userId == $data->created_by)

--- a/components/com_content/Model/FormModel.php
+++ b/components/com_content/Model/FormModel.php
@@ -97,16 +97,18 @@ class FormModel extends \Joomla\Component\Content\Administrator\Model\ArticleMod
 		// Compute selected asset permissions.
 		$user   = Factory::getUser();
 		$userId = $user->get('id');
-		$asset  = 'com_content.article.' . $value->id;
+
+		// If article asset id does not exists then fallback to category asset id
+		$assetId  = $value->asset_id ?: $value->category_asset_id;
 
 		// Check general edit permission first.
-		if ($user->authorise('core.edit', $asset))
+		if ($user->isAuthorised('core.edit', $assetId, 'com_content'))
 		{
 			$value->params->set('access-edit', true);
 		}
 
 		// Now check if edit.own is available.
-		elseif (!empty($userId) && $user->authorise('core.edit.own', $asset))
+		elseif (!empty($userId) && $user->isAuthorised('core.edit.own', $assetId, 'com_content'))
 		{
 			// Check for a valid user and that they are the owner.
 			if ($userId == $value->created_by)
@@ -119,7 +121,7 @@ class FormModel extends \Joomla\Component\Content\Administrator\Model\ArticleMod
 		if ($itemId)
 		{
 			// Existing item
-			$value->params->set('access-change', $user->authorise('core.edit.state', $asset));
+			$value->params->set('access-change', $user->isAuthorised('core.edit.state', $assetId, 'com_content'));
 		}
 		else
 		{

--- a/libraries/src/Access/AccessControl.php
+++ b/libraries/src/Access/AccessControl.php
@@ -1,0 +1,957 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  Copyright (C) 2005 - 2018 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Access;
+
+defined('JPATH_PLATFORM') or die;
+
+use Joomla\CMS\Factory;
+use Joomla\CMS\Log\Log;
+use Joomla\CMS\Component\ComponentHelper;
+
+/**
+ * Class that handles all access authorisation routines.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class AccessControl
+{
+	/**
+	 * Array of the assets by id
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $assets = [];
+
+	/**
+	 * Array of asset ids by name
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $assetIdsByName = [];
+
+	/**
+	 * Array of rules for the asset by id
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $assetRules = [];
+
+	/**
+	 * Array of identities for asset rules by hash
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $assetRulesIdentities = [];
+
+	/**
+	 * Array of assets to preload, key is an asset id or name
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $assetsToPreload = [];
+
+	/**
+	 * Array of loaded user identities
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $identities = [];
+
+	/**
+	 * Array of cached groups by user.
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $groupsByUser = [];
+
+	/**
+	 * Array of view levels
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $viewLevels = [];
+
+	/**
+	 * Array of the groups by id
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $groups = [];
+
+	/**
+	 *  Default value for number of table joins for assets
+	 *
+	 * @var    integer
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $defaultNestedForAssets = 5;
+
+	/**
+	 * Method to preload the Rules objects for all components.
+	 *
+	 * Note: This will only get the base permissions for the component.
+	 * e.g. it will get 'com_content', but not 'com_content.article.1' or
+	 * any more specific asset type rules.
+	 *
+	 * @return  boolean  True if assets were preloaded.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function preloadComponents()
+	{
+		if ($this->assets)
+		{
+			return false;
+		}
+
+		!JDEBUG ?: \JProfiler::getInstance('Application')->mark('Before AccessControl::preloadComponents');
+
+		$components = ['root.1'];
+
+		foreach (ComponentHelper::getComponents() as $component)
+		{
+			if ($component->enabled)
+			{
+				$components[] = $component->option;
+			}
+		}
+
+		$db = Factory::getDbo();
+
+		$query = $db->getQuery(true)
+			->select('id, name, rules, parent_id')
+			->from($db->quoteName('#__assets'))
+			->where('name IN (' . implode(',', $db->quote($components)) . ')');
+
+		$it = $db->setQuery($query)->getIterator();
+
+		foreach ($it as $row)
+		{
+			// Cast to integer at the beginning to save memory
+			$row->id = (int) $row->id;
+			$row->parent_id = (int) $row->parent_id;
+
+			$this->assets[$row->id] = $row;
+			$this->assetIdsByName[$row->name] = $row->id;
+		}
+
+		!JDEBUG ?: \JProfiler::getInstance('Application')->mark('After AccessControl::preloadComponents');
+
+		return true;
+	}
+
+	/**
+	 * Method to check if a user is authorised to perform an action, optionally on an asset.
+	 * If an asset key is not found then extension asset will be used.
+	 *
+	 * @param   integer          $userId     Id of the user for which to check authorisation.
+	 * @param   string           $action     The name of the action to authorise.
+	 * @param   integer|string   $assetKey   The asset id or name or null to fallback to extension asset.
+	 * @param   string           $extension  The name of the extension, ex 'com_content'.
+	 * @param   boolean|integer  $nested     Indicates the level of optimalization. If True then default.
+	 *
+	 * @return  boolean|null  True if allowed, false for an explicit deny, null for an implicit deny.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function check($userId, $action, $assetKey = null, $extension = null, $nested = true)
+	{
+		// Sanitise input
+		$userId = (int) $userId;
+
+		if (!isset($this->identities[$userId]))
+		{
+			// Get all groups against which the user is mapped
+			$this->identities[$userId] = $this->getGroupsByUser($userId);
+			$this->identities[$userId][-$userId] = -$userId;
+		}
+
+		return $this->getAssetRules($assetKey, $extension, true, $nested)->allow($action, $this->identities[$userId]);
+	}
+
+	/**
+	 * Method to recursively retrieve the list of parent Asset IDs
+	 * for a particular Asset.
+	 *
+	 * @param   integer  $assetId  The numeric asset id.
+	 *
+	 * @return  array  List of ancestor ids (includes original $assetId).
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function getAssetAncestors($assetId)
+	{
+		// Holds the list of ancestors for the Asset Id
+		$ancestors = [];
+
+		while (isset($this->assets[$assetId]))
+		{
+			$ancestors[] = $assetId;
+
+			$assetId = $this->assets[$assetId]->parent_id;
+		}
+
+		return $ancestors;
+	}
+
+	/**
+	 * Method to return the Rules object for an asset. The returned object can optionally hold
+	 * only the rules explicitly set for the asset or the summation of all inherited rules from
+	 * parent assets and explicit rules.
+	 * If assetKey does not exists then rules from supplied extension will be used.
+	 *
+	 * @param   integer|string   $assetKey   The asset id, name or null to fallback to extension asset.
+	 * @param   string           $extension  The name of the extension, ex 'com_content'.
+	 * @param   boolean          $recursive  True to return the rules object with inherited rules.
+	 * @param   boolean|integer  $nested     Indicates the level of optimalization. If True then default.
+	 *
+	 * @return  Rules  Rules object for the asset.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getAssetRules($assetKey, $extension = null, $recursive = false, $nested = true)
+	{
+		// Sanitise input
+		$assetKey = $assetKey ?: null;
+
+		$this->preloadComponents();
+
+		if (is_numeric($assetKey))
+		{
+			$assetKey  = (int) $assetKey;
+			$assetId   = $assetKey;
+		}
+		else
+		{
+			$assetId = null;
+
+			if ($extension === null && $assetKey)
+			{
+				// Get fallabck extension name, e.g. 'com_content' from asset name 'com_content.article.1'
+				list($extension) = explode('.', $assetKey, 2);
+			}
+		}
+
+		if ($assetKey !== null)
+		{
+			// When $assetKey type is an integer, treat it as the asset id, otherwise as the asset name
+			if (is_int($assetKey))
+			{
+				$this->addAssetIdToPreload($assetKey, $nested);
+			}
+			else
+			{
+				$this->addAssetNameToPreload($assetKey, $nested);
+			}
+		}
+
+		$this->preloadAssets();
+
+		// Get asset id after preloading assets
+		if ($assetId === null && isset($this->assetIdsByName[$assetKey]))
+		{
+			$assetId = (int) $this->assetIdsByName[$assetKey];
+		}
+
+		if ($recursive)
+		{
+			// If asset id does not exist fallback to extension asset, then root asset
+			if ($assetId === null || !isset($this->assets[$assetId]))
+			{
+				if (isset($this->assetIdsByName[$extension]))
+				{
+					$assetId = (int) $this->assetIdsByName[$extension];
+
+					Log::add("No asset found for '$assetKey', falling back to '$extension'", Log::WARNING, 'assets');
+				}
+				else
+				{
+					// The root asset id
+					$assetId = 1;
+
+					Log::add("No asset found for '$assetKey', falling back to 'root.1'", Log::WARNING, 'assets');
+				}
+			}
+
+			// If asset rules already cached em memory return it (only in full recursive mode).
+			if (isset($this->assetRules[$assetId]))
+			{
+				return $this->assetRules[$assetId];
+			}
+		}
+
+		// Collects permissions for each asset
+		$collected = [];
+
+		// If not in any recursive mode. We only want the asset rules.
+		if (!$recursive)
+		{
+			$collected = [isset($this->assets[$assetId]) ? $this->assets[$assetId]->rules : '{}'];
+		}
+		// If there is any type of recursive mode.
+		else
+		{
+			$ancestors = array_reverse($this->getAssetAncestors($assetId));
+
+			foreach ($ancestors as $id)
+			{
+				// If empty asset to not add to rules.
+				if ($this->assets[$id]->rules === '{}')
+				{
+					continue;
+				}
+
+				$collected[] = $this->assets[$id]->rules;
+			}
+		}
+
+		/**
+		* Hashing the collected rules allows us to store
+		* only one instance of the Rules object for
+		* Assets that have the same exact permissions...
+		* it's a great way to save some memory.
+		*/
+		$hash = md5(implode(',', $collected));
+
+		if (!isset($this->assetRulesIdentities[$hash]))
+		{
+			$rules = new Rules;
+			$rules->mergeCollection($collected);
+
+			$this->assetRulesIdentities[$hash] = $rules;
+		}
+
+		// Save asset rules to memory cache(only in full recursive mode).
+		if ($recursive)
+		{
+			$this->assetRules[$assetId] = $this->assetRulesIdentities[$hash];
+		}
+
+		if (JDEBUG)
+		{
+			\JProfiler::getInstance('Application')->mark(
+				'After AccessControl::getAssetRules (id:' . $assetId . ' name:' . $this->assets[$assetId]->name . ')'
+			);
+		}
+
+		return $this->assetRulesIdentities[$hash];
+	}
+
+	/**
+	 * Method to add asset id to preload list.
+	 *
+	 * @param   integer          $assetId  The numeric asset id.
+	 * @param   boolean|integer  $nested   Indicates the level of optimalization. If True then default.
+	 *
+	 * @return  boolean  True if assets were preloaded.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function addAssetIdToPreload($assetId, $nested = true)
+	{
+		// Sanitise assetId
+		$assetId = (int) $assetId;
+
+		if ($assetId && !isset($this->assets[$assetId]))
+		{
+			// Sanitise the nested value, default 5, minimum 0
+			$nested = $nested === true ? $this->defaultNestedForAssets : max(0, (int) $nested);
+
+			$this->assetsToPreload['id'][$nested][$assetId] = $assetId;
+		}
+	}
+
+	/**
+	 * Method to add asset name to preload list.
+	 *
+	 * @param   string           $assetName  The asset name.
+	 * @param   boolean|integer  $nested     Indicates the level of optimalization. If True then default.
+	 *
+	 * @return  boolean  True if assets were preloaded.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function addAssetNameToPreload($assetName, $nested = true)
+	{
+		if ($assetName && !isset($this->assetIdsByName[$assetName]))
+		{
+			// Sanitise the nested value, default 5, minimum 0
+			$nested = $nested === true ? $this->defaultNestedForAssets : max(0, (int) $nested);
+
+			$this->assetsToPreload['name'][$nested][$assetName] = $assetName;
+		}
+	}
+
+	/**
+	 * Method to preload the Rules objects for marked assets (include ancestors).
+	 *
+	 * @return  boolean  True if assets were preloaded.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function preloadAssets()
+	{
+		$total = 0;
+
+		foreach ($this->assetsToPreload as $key => $assetsToPreloadByNested)
+		{
+			foreach ($assetsToPreloadByNested as $nested => $assetKeys)
+			{
+				$total += count($assetKeys);
+			}
+		}
+
+		if ($total === 0)
+		{
+			return false;
+		}
+
+		$db = Factory::getDbo();
+
+		$unionQuery = null;
+
+		foreach ($this->assetsToPreload as $key => $assetsToPreloadByNested)
+		{
+			foreach ($assetsToPreloadByNested as $nested => $assetKeys)
+			{
+				if ($nested === 0)
+				{
+					$tbl = 'a0';
+
+					$subquery = $db->getQuery(true)
+						->from($db->quoteName('#__assets', $tbl));
+
+					if ($key === 'id')
+					{
+						$subquery->where('a0.id IN (' . implode(', ', $assetKeys) . ')');
+					}
+					else
+					{
+						$subquery->where('a0.name IN (' . implode(', ', $db->quote($assetKeys)) . ')');
+					}
+
+					if ($total === count($assetKeys))
+					{
+						// No UNION
+						$subquery->select("$tbl.id, $tbl.name, $tbl.rules, $tbl.parent_id, $tbl.level");
+
+						// There is no more assets, set as 1 to skip LEFT JOIN
+						$total = 1;
+					}
+					else
+					{
+						// All column will be joined later to speed up UNION DISTINCT
+						$subquery->select("$tbl.id");
+					}
+
+					$unionQuery = $unionQuery === null ? $subquery : $unionQuery->union($subquery);
+				}
+				else
+				{
+					foreach ($assetKeys as $assetKey)
+					{
+						$tbl = 'a0';
+
+						$subquery = $db->getQuery(true)
+							->from($db->quoteName('#__assets', $tbl));
+
+						$j = 0;
+
+						// All ids from rows
+						$aids = '';
+
+						for ($i = 0; $i < $nested; $i++)
+						{
+							$j = $i + 1;
+							$tbl = 'a' . $j;
+							$aids .= 'a' . $i . '.id, ';
+
+							if ($j === $nested)
+							{
+								$aids .= 'a' . $i . '.parent_id';
+
+								$subquery->leftJoin(
+									$db->quoteName('#__assets', $tbl)
+									. " ON $tbl.id IN ($aids)"
+								);
+							}
+							else
+							{
+								// Do not include the root asset
+								$subquery->leftJoin(
+									$db->quoteName('#__assets', $tbl)
+									. " ON $tbl.id = a$i.parent_id AND $tbl.id != 1"
+								);
+							}
+						}
+
+						if ($total === 1)
+						{
+							// No UNION
+							$subquery->select("$tbl.id, $tbl.name, $tbl.rules, $tbl.parent_id, $tbl.level");
+						}
+						else
+						{
+							// All column will be joined later to speed up UNION DISTINCT
+							$subquery->select("$tbl.id");
+						}
+
+						if ($key === 'id')
+						{
+							$subquery->where("a0.id = " . $assetKey);
+						}
+						else
+						{
+							$subquery->where("a0.name = " . $db->quote($assetKey));
+						}
+
+						$unionQuery = $unionQuery === null ? $subquery : $unionQuery->union($subquery);
+					}
+				}
+			}
+		}
+
+		if ($total === 1)
+		{
+			$query = $unionQuery->order("$tbl.lft");
+		}
+		else
+		{
+			// Add missing columns after UNION result
+			$query = $db->getQuery(true)
+				->from('(' . (string) $unionQuery . ') AS pks')
+				->leftJoin($db->quoteName('#__assets', 'b') . ' ON b.id = pks.id')
+				->select('b.id, b.name, b.rules, b.parent_id, b.level')
+				->order('b.lft');
+		}
+
+		$it = $db->setQuery($query)->getIterator();
+
+		// Reset lists
+		$this->assetsToPreload = [];
+
+		foreach ($it as $row)
+		{
+			$row->id        = (int) $row->id;
+			$row->parent_id = (int) $row->parent_id;
+
+			if (!isset($this->assets[$row->parent_id]))
+			{
+				// Set a nested variable based on the level value
+				$this->assetsToPreload['id'][(int) $row->level - 3][] = $row->parent_id;
+			}
+
+			unset($row->level);
+
+			if (!isset($this->assets[$row->id]))
+			{
+				$this->assets[$row->id]           = $row;
+				$this->assetIdsByName[$row->name] = $row->id;
+			}
+		}
+
+		if ($this->assetsToPreload)
+		{
+			return $this->preloadAssets();
+		}
+
+		return true;
+	}
+
+	/**
+	 * Method to check if a group is authorised to perform an action, optionally on an asset.
+	 *
+	 * @param   integer         $groupId    The path to the group for which to check authorisation.
+	 * @param   string          $action     The name of the action to authorise.
+	 * @param   integer|string  $assetKey   The asset key (asset id or asset name). null fallback to root asset.
+	 * @param   string          $extension  The name of the extension, ex 'com_content'.
+	 * @param   boolean         $nested     Indicates whether preloading should be used.
+	 *
+	 * @return  boolean  True if authorised.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function checkGroup($groupId, $action, $assetKey = null, $extension = null, $nested = true)
+	{
+		return $this->getAssetRules($assetKey, $extension, true, $nested)
+			->allow($action, $this->getGroupAncestors($groupId));
+	}
+
+	/**
+	 * Method to recursively retrieve the list of parent Group IDs
+	 * for a particular Group Id.
+	 *
+	 * @param   integer  $groupId  The group id.
+	 *
+	 * @return  array  List of ancestor ids (includes original $groupId).
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getGroupAncestors($groupId)
+	{
+		// Sanitise groupId
+		$groupId = (int) $groupId;
+
+		$this->loadAllGroups();
+
+		// Holds the list of ancestors for the Asset Id
+		$ancestors = [];
+
+		while (isset($this->groups[$groupId]))
+		{
+			$ancestors[$groupId] = $groupId;
+
+			$groupId = $this->groups[$groupId]->parent_id;
+		}
+
+		return $ancestors;
+	}
+
+	/**
+	 * Get the list of existing user groups.
+	 *
+	 * @param   boolean  $populate  True to add a level property to all groups.
+	 *
+	 * @return  array  List of group objects.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getAllGroups($populate = false)
+	{
+		$this->loadAllGroups();
+
+		if ($populate && !isset(current($this->groups)->level))
+		{
+			foreach ($this->groups as $group)
+			{
+				$group->level = $group->parent_id ? $this->groups[$group->parent_id]->level + 1 : 0;
+			}
+		}
+
+		return $this->groups;
+	}
+
+	/**
+	 * Load all user groups from the database.
+	 *
+	 * @return  boolean  True if groups were loaded.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function loadAllGroups()
+	{
+		if ($this->groups)
+		{
+			return false;
+		}
+
+		$db = Factory::getDbo();
+
+		$query = $db->getQuery(true)
+			->select('id, parent_id, lft, rgt, title')
+			->from($db->quoteName('#__usergroups'))
+			->order('lft');
+
+		$it = $db->setQuery($query)->getIterator();
+
+		foreach ($it as $row)
+		{
+			$row->id        = (int) $row->id;
+			$row->parent_id = (int) $row->parent_id;
+
+			$this->groups[$row->id] = $row;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Method to return a list of user groups mapped to a user. The returned list can optionally hold
+	 * only the groups explicitly mapped to the user or all groups both explicitly mapped and inherited
+	 * by the user.
+	 *
+	 * @param   integer  $userId     Id of the user for which to get the list of groups.
+	 * @param   boolean  $recursive  True to include inherited user groups.
+	 *
+	 * @return  array    List of user group ids to which the user is mapped.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getGroupsByUser($userId, $recursive = true)
+	{
+		// Creates a simple unique string for each parameter combination:
+		$storeId = $userId . ':' . (int) $recursive;
+
+		if (isset($this->groupsByUser[$storeId]))
+		{
+			return $this->groupsByUser[$storeId];
+		}
+
+		// TODO: Uncouple this from ComponentHelper and allow for a configuration setting or value injection.
+		$guestUsergroup = ComponentHelper::getParams('com_users')->get('guest_usergroup', 1);
+
+		if (!$userId)
+		{
+			if ($recursive)
+			{
+				$this->groupsByUser[$storeId] = $this->getGroupAncestors($guestUsergroup);
+			}
+			else
+			{
+				// Guest user (if only the actually assigned group is requested)
+				$this->groupsByUser[$storeId] = [$guestUsergroup => $guestUsergroup];
+			}
+
+			return $this->groupsByUser[$storeId];
+		}
+
+		$db = Factory::getDbo();
+
+		$query = $db->getQuery(true)
+			->select('group_id')
+			->from($db->quoteName('#__user_usergroup_map'))
+			->where('user_id = ' . (int) $userId);
+
+		$groupIds = $db->setQuery($query)->loadColumn();
+
+		// Array of unique group ids
+		$result = [];
+
+		// Registered user and guest if all groups are requested
+		if ($recursive)
+		{
+			foreach ($groupIds as $groupId)
+			{
+				foreach ($this->getGroupAncestors($groupId) as $gid)
+				{
+					// Group id as a key and value to eliminate duplicates
+					$result[$gid] = $gid;
+				}
+			}
+		}
+		else
+		{
+			$this->loadAllGroups();
+
+			foreach ($groupIds as $groupId)
+			{
+				$gid = (int) $groupId;
+
+				// To be sure that this group exists
+				if (isset($this->groups[$gid]))
+				{
+					$result[$gid] = $gid;
+				}
+			}
+		}
+
+		if (!$result)
+		{
+			// Fallback to guest user group
+			$result = [$guestUsergroup => $guestUsergroup];
+		}
+
+		$this->groupsByUser[$storeId] = $result;
+
+		return $result;
+	}
+
+	/**
+	 * Method to return a list of view levels for which the user is authorised.
+	 *
+	 * @param   integer  $userId  Id of the user for which to get the list of authorised view levels.
+	 *
+	 * @return  array    List of view levels for which the user is authorised.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getAuthorisedViewLevels($userId)
+	{
+		// Only load the view levels once
+		if (!$this->viewLevels)
+		{
+			// Get a database object
+			$db = Factory::getDbo();
+
+			// Build the base query.
+			$query = $db->getQuery(true)
+				->select('id, rules')
+				->from($db->quoteName('#__viewlevels'));
+
+			// Set the query for execution
+			$db->setQuery($query);
+
+			// Build the view levels array
+			foreach ($db->loadRowList() as $row)
+			{
+				$this->viewLevels[(int) $row[0]] = (array) json_decode($row[1]);
+			}
+		}
+
+		// Public access
+		$access = (int) Factory::getConfig()->get('access', 1);
+
+		// Initialise the authorised array
+		$authorised = [$access => $access];
+
+		// Check for the recovery mode setting and return early
+		$root_user = Factory::getConfig()->get('root_user');
+
+		if ($root_user)
+		{
+			$user = \Joomla\CMS\User\User::getInstance($userId);
+
+			if (($user->username && $user->username == $root_user)
+				|| (is_numeric($root_user) && $user->id > 0 && $user->id == $root_user))
+			{
+				// Find the super user levels
+				foreach ($this->viewLevels as $level => $rules)
+				{
+					foreach ($rules as $id)
+					{
+						if ($id > 0 && $this->checkGroup($id, 'core.admin'))
+						{
+							$authorised[$level] = $level;
+							break;
+						}
+					}
+				}
+
+				return $authorised;
+			}
+		}
+
+		// Get all groups that the user is mapped to recursively
+		$userGroups = $this->getGroupsByUser($userId);
+
+		// Find the authorised levels
+		foreach ($this->viewLevels as $level => $rules)
+		{
+			foreach ($rules as $id)
+			{
+				// Check to see if the group is mapped to the level
+				if ($id > 0)
+				{
+					if (isset($userGroups[$id]))
+					{
+						$authorised[$level] = $level;
+						break;
+					}
+				}
+				elseif ($id < 0 && -$id == $userId)
+				{
+					$authorised[$level] = $level;
+					break;
+				}
+			}
+		}
+
+		return $authorised;
+	}
+
+	/**
+	 * Method to return a list of actions from a file for which permissions can be set.
+	 *
+	 * @param   string  $file   The path to the XML file.
+	 * @param   string  $xpath  An optional xpath to search for the fields.
+	 *
+	 * @return  boolean|array   False if case of error or the list of actions available.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public static function getActionsFromFile($file, $xpath = "/access/section[@name='component']/")
+	{
+		if (!is_file($file) || !is_readable($file))
+		{
+			// If unable to find the file return false.
+			return false;
+		}
+
+		// Return the actions from the xml.
+		$xml = simplexml_load_file($file);
+
+		return self::getActionsFromData($xml, $xpath);
+	}
+
+	/**
+	 * Method to return a list of actions from a string or from an xml for which permissions can be set.
+	 *
+	 * @param   string|\SimpleXMLElement  $data   The XML string or an XML element.
+	 * @param   string                    $xpath  An optional xpath to search for the fields.
+	 *
+	 * @return  boolean|array   False if case of error or the list of actions available.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public static function getActionsFromData($data, $xpath = "/access/section[@name='component']/")
+	{
+		// If the data to load isn't already an XML element or string return false.
+		if ((!($data instanceof \SimpleXMLElement)) && (!is_string($data)))
+		{
+			return false;
+		}
+
+		// Attempt to load the XML if a string.
+		if (is_string($data))
+		{
+			try
+			{
+				$data = new \SimpleXMLElement($data);
+			}
+			catch (\Exception $e)
+			{
+				return false;
+			}
+
+			// Make sure the XML loaded correctly.
+			if (!$data)
+			{
+				return false;
+			}
+		}
+
+		// Initialise the actions array
+		$actions = [];
+
+		// Get the elements from the xpath
+		$elements = $data->xpath($xpath . 'action[@name][@title]');
+
+		// If there some elements, analyse them
+		if (!empty($elements))
+		{
+			foreach ($elements as $element)
+			{
+				// Add the action to the actions array
+				$action = array(
+					'name' => (string) $element['name'],
+					'title' => (string) $element['title'],
+				);
+
+				if (isset($element['description']))
+				{
+					$action['description'] = (string) $element['description'];
+				}
+
+				$actions[] = (object) $action;
+			}
+		}
+
+		// Finally return the actions array
+		return $actions;
+	}
+}

--- a/libraries/src/Document/Renderer/Html/ModulesRenderer.php
+++ b/libraries/src/Document/Renderer/Html/ModulesRenderer.php
@@ -41,13 +41,13 @@ class ModulesRenderer extends DocumentRenderer
 		$app          = Factory::getApplication();
 		$user         = Factory::getUser();
 		$frontediting = ($app->isClient('site') && $app->get('frontediting', 1) && !$user->guest);
-		$menusEditing = ($app->get('frontediting', 1) == 2) && $user->authorise('core.edit', 'com_menus');
+		$menusEditing = ($app->get('frontediting', 1) == 2) && $user->isAuthorised('core.edit', 'com_menus');
 
 		foreach (ModuleHelper::getModules($position) as $mod)
 		{
 			$moduleHtml = $renderer->render($mod, $params, $content);
 
-			if ($frontediting && trim($moduleHtml) != '' && $user->authorise('module.edit.frontend', 'com_modules.module.' . $mod->id))
+			if ($frontediting && trim($moduleHtml) != '' && $user->isAuthorised('module.edit.frontend', $mod->asset_id, 'com_modules', false))
 			{
 				$displayData = array('moduleHtml' => &$moduleHtml, 'module' => $mod, 'position' => $position, 'menusediting' => $menusEditing);
 				LayoutHelper::render('joomla.edit.frontediting_modules', $displayData);

--- a/libraries/src/Factory.php
+++ b/libraries/src/Factory.php
@@ -500,6 +500,7 @@ abstract class Factory
 	protected static function createContainer(): Container
 	{
 		$container = (new Container)
+			->registerServiceProvider(new \Joomla\CMS\Service\Provider\Acl)
 			->registerServiceProvider(new \Joomla\CMS\Service\Provider\Application)
 			->registerServiceProvider(new \Joomla\CMS\Service\Provider\Authentication)
 			->registerServiceProvider(new \Joomla\CMS\Service\Provider\Config)

--- a/libraries/src/Helper/ContentHelper.php
+++ b/libraries/src/Helper/ContentHelper.php
@@ -10,7 +10,7 @@ namespace Joomla\CMS\Helper;
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\CMS\Access\Access;
+use Joomla\CMS\Access\AccessControl;
 use Joomla\CMS\Application\ApplicationHelper;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
@@ -68,7 +68,7 @@ class ContentHelper
 
 		$user = Factory::getUser();
 
-		$actions = Access::getActionsFromFile(
+		$actions = AccessControl::getActionsFromFile(
 			JPATH_ADMINISTRATOR . '/components/' . $component . '/access.xml', '/access/section[@name="component"]/'
 		);
 

--- a/libraries/src/Helper/ModuleHelper.php
+++ b/libraries/src/Helper/ModuleHelper.php
@@ -10,6 +10,7 @@ namespace Joomla\CMS\Helper;
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\CMS\Access\AccessControl;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Filter\InputFilter;
@@ -385,7 +386,7 @@ abstract class ModuleHelper
 		$db = Factory::getDbo();
 
 		$query = $db->getQuery(true)
-			->select('m.id, m.title, m.module, m.position, m.content, m.showtitle, m.params, mm.menuid')
+			->select('m.id, m.asset_id, m.title, m.module, m.position, m.content, m.showtitle, m.params, mm.menuid')
 			->from('#__modules AS m')
 			->join('LEFT', '#__modules_menu AS mm ON mm.moduleid = m.id')
 			->where('m.published = 1')
@@ -434,6 +435,14 @@ abstract class ModuleHelper
 			);
 
 			return array();
+		}
+
+		/** @var AccessControl */
+		$acl = Factory::getContainer()->get('acl');
+
+		foreach ($modules as $m)
+		{
+			$acl->addAssetIdToPreload($m->asset_id, false);
 		}
 
 		return $modules;

--- a/libraries/src/Service/Provider/Acl.php
+++ b/libraries/src/Service/Provider/Acl.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  Copyright (C) 2005 - 2018 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Service\Provider;
+
+defined('JPATH_PLATFORM') or die;
+
+use Joomla\CMS\Access\AccessControl;
+
+// TODO: use Joomla\CMS\Access\AccessControlInterface;
+use Joomla\DI\Container;
+use Joomla\DI\ServiceProviderInterface;
+
+/**
+ * Service provider for the form dependency
+ *
+ * @since  4.0
+ */
+class Acl implements ServiceProviderInterface
+{
+	/**
+	 * Registers the service provider with a DI container.
+	 *
+	 * @param   Container  $container  The DI container.
+	 *
+	 * @return  void
+	 *
+	 * @since   4.0
+	 */
+	public function register(Container $container)
+	{
+		$container->alias('acl', AccessControl::class)
+			->share(
+				AccessControl::class,
+				function (Container $container)
+				{
+					return new AccessControl;
+				},
+				true
+			);
+	}
+}

--- a/plugins/content/pagenavigation/pagenavigation.php
+++ b/plugins/content/pagenavigation/pagenavigation.php
@@ -57,8 +57,8 @@ class PlgContentPagenavigation extends CMSPlugin
 			$now  = $date->toSql();
 
 			$uid        = $row->id;
-			$option     = 'com_content';
-			$canPublish = $user->authorise('core.edit.state', $option . '.article.' . $row->id);
+			$assetId    = $row->asset_id ?: $row->category_asset_id;
+			$canPublish = $user->isAuthorised('core.edit.state', $assetId, 'com_content');
 
 			/**
 			 * The following is needed as different menu items types utilise a different param to control ordering.


### PR DESCRIPTION
### Summary of Changes

1. Stop preloading the entire component's assets.
2. **There is no database changes.**
3. If you do not use subclass of `Joomla\CMS\Access\Access` then this PR should be B/C.
4. Adds a new class `Joomla\CMS\Access\AccessControl` as a replacement for `Joomla\CMS\Access\Access`.


I would like to do it in similar way as modern router, but
only developers of 3rd party extension will decide which way want to go.
In this part I have not decided yet, I do not know if I'm doing it right.



You can still use `Access` class as before, but protected methods/variables may be missing.
Most 3rd party extensions, which does not use advanced access managements shouldn't see any difference.

This `Access` methods are proxy to the new methods in `AccessControl`, there are slight differences:
* `getGroupsByUser()` - the new method returns items in reverse order
* `getAuthorisedViewLevels()` - the new method returns `array_combine($oldResult, $oldResult)`, it means that you get levels in the keys and values of the array.
* `getActionsFromFile()` - only a proxy to the same code
* `getActionsFromData()` - only a proxy to the same code
* `preloadComponents()` - acts as a proxy but fills in its own protected variables, will use more memory
* `checkGroup()` - acts as a proxy, cleans input data, `AccessControl::checkGroup` does not.

The next methods are totally rewritten in the new `AccessControl` class, has different parameters, use a new structure of data, get less memory:
* `check()`
* `getAssetRules()`

To not duplicate memory consumption I suggest to use only new methods in all extensions.

There is a new method in `Joomla\CMS\User`:
```
public function isAuthorised($action, $assetKey = null, $extension = null, $nested = true)
```

and the old method looks like:
```php
public function authorise($action, $assetname = null)
{
        return $this->isAuthorised($action, $assetname);
}
```

The new method has a few more arguments to be more flexible.
The `$extension` argument (ex. com_content) is used as a fallback if $assetKey (`asset_id`) does not exist.
The `$nested` is used to optimization, for example modules always has level 1. Then we can always set `$nested = false` to generate simpler sql query.

Instead of load from database single row or all rows that match `name LIKE 'com_content.%'`
this PR use `UNION` and `LEFT JOIN` statement to emulate `WITH RECURSIVE` , example:

```sql
SELECT a5.id, a5.name, a5.rules, a5.parent_id, a5.level
FROM `j40_assets` AS `a0`
LEFT JOIN `j40_assets` AS `a1` ON a1.id = a0.parent_id AND a1.id != 1
LEFT JOIN `j40_assets` AS `a2` ON a2.id = a1.parent_id AND a2.id != 1
LEFT JOIN `j40_assets` AS `a3` ON a3.id = a2.parent_id AND a3.id != 1
LEFT JOIN `j40_assets` AS `a4` ON a4.id = a3.parent_id AND a4.id != 1
LEFT JOIN `j40_assets` AS `a5` ON a5.id IN (a0.id, a1.id, a2.id, a3.id, a4.id, a4.parent_id)
WHERE a0.id = 78
ORDER BY a5.lft
```

Result:

```csv
id	name	rules	parent_id	level
8	com_content	{"core.admin":{"7":1},"core.manage":{"6":1},"core.create":{"3":1},"core.edit":{"4":1},"core.edit.state":{"5":1},"core.execute.transition":{"6":1,"5":1}}	1	1
74	com_content.category.8	{}	8	2
78	com_content.article.3	{}	74	3
```

For this example the nested variable can be set even to 2 (article->category), but by default is 5.
If assets are more nested then joomla will check whether `parent_id` has been loaded and if not then generates the next query
based on level depth to load the rest of missing parents.

For category view to load all article assets joomla will use:
```sql
SELECT b.id, b.name, b.rules, b.parent_id, b.level
FROM (
SELECT a5.id
FROM `j40_assets` AS `a0`
LEFT JOIN `j40_assets` AS `a1` ON a1.id = a0.parent_id AND a1.id != 1
LEFT JOIN `j40_assets` AS `a2` ON a2.id = a1.parent_id AND a2.id != 1
LEFT JOIN `j40_assets` AS `a3` ON a3.id = a2.parent_id AND a3.id != 1
LEFT JOIN `j40_assets` AS `a4` ON a4.id = a3.parent_id AND a4.id != 1
LEFT JOIN `j40_assets` AS `a5` ON a5.id IN (a0.id, a1.id, a2.id, a3.id, a4.id, a4.parent_id)
WHERE a0.id = 78
UNION (
SELECT a5.id
FROM `j40_assets` AS `a0`
LEFT JOIN `j40_assets` AS `a1` ON a1.id = a0.parent_id AND a1.id != 1
LEFT JOIN `j40_assets` AS `a2` ON a2.id = a1.parent_id AND a2.id != 1
LEFT JOIN `j40_assets` AS `a3` ON a3.id = a2.parent_id AND a3.id != 1
LEFT JOIN `j40_assets` AS `a4` ON a4.id = a3.parent_id AND a4.id != 1
LEFT JOIN `j40_assets` AS `a5` ON a5.id IN (a0.id, a1.id, a2.id, a3.id, a4.id, a4.parent_id)
WHERE a0.id = 79)
UNION (
SELECT a5.id
FROM `j40_assets` AS `a0`
LEFT JOIN `j40_assets` AS `a1` ON a1.id = a0.parent_id AND a1.id != 1
LEFT JOIN `j40_assets` AS `a2` ON a2.id = a1.parent_id AND a2.id != 1
LEFT JOIN `j40_assets` AS `a3` ON a3.id = a2.parent_id AND a3.id != 1
LEFT JOIN `j40_assets` AS `a4` ON a4.id = a3.parent_id AND a4.id != 1
LEFT JOIN `j40_assets` AS `a5` ON a5.id IN (a0.id, a1.id, a2.id, a3.id, a4.id, a4.parent_id)
WHERE a0.id = 80)
UNION (
SELECT a5.id
FROM `j40_assets` AS `a0`
LEFT JOIN `j40_assets` AS `a1` ON a1.id = a0.parent_id AND a1.id != 1
LEFT JOIN `j40_assets` AS `a2` ON a2.id = a1.parent_id AND a2.id != 1
LEFT JOIN `j40_assets` AS `a3` ON a3.id = a2.parent_id AND a3.id != 1
LEFT JOIN `j40_assets` AS `a4` ON a4.id = a3.parent_id AND a4.id != 1
LEFT JOIN `j40_assets` AS `a5` ON a5.id IN (a0.id, a1.id, a2.id, a3.id, a4.id, a4.parent_id)
WHERE a0.id = 81)) AS pks
LEFT JOIN `j40_assets` AS `b` ON b.id = pks.id
ORDER BY b.lft
```

The query will only load assets that are required for articles.

The result:

```csv
id 	name 	rules 	parent_id 	level
8	com_content	{"core.admin":{"7":1},"core.manage":{"6":1},"core.create":{"3":1},"core.edit":{"4":1},"core.edit.sta...	1	1
74	com_content.category.8	{}	8	2
78	com_content.article.3	{}	74	3
79	com_content.article.4	{}	74	3
80	com_content.article.5	{}	74	3
81	com_content.article.6	{}	74	3
```

### Comparission

Below table describes situation when you are logged (as not Super User).

| Available Action | Supported by `Access` | Supported by `AccessControl`  |
| ------------- | ------------- | ------------- |
| Preload components | Yes | Yes |
| Preload all assets per component | Yes | No |
| Preload only specified asset rules, ex. for 'com_content.article.1' | No. Always preload all assets per component, ex: `... WHERE `name` LIKE 'com_content.%'`. It takes a lots of memory. | Only load asset of article and parent assets (in one query) |
| Preload only assets for modules on visited page | No. Load all asset rows. May take a lot of memory if you have a lot of modules in database | Only preload selected assets (in one query) |
| Preload only assets for articles in category view| No. Only preload all assets per component. | Preload only assets for selected articles and its parents. *Can preload it in one query using UNION sql statement.* |
|Number of sql queries | Low (`Components` + `com_content.%` + `com_modules.%` = 3 queries) | In the worse case one per asset but we can use preload to load a few assets in one sql query. (`Components` + `only required component items assets` + `only active modules` = 3 queries |
| Total loaded `#__assets` rows| Very high| Low (preload components + only required rows) |
| Memory usage | Very High | Low |
|Speed of queries| Slow because of load a big amount of rows| Quite fast |
| Allows for custom preload | No | Yes - you can put a list of asset name or asset id to preload. E. g. `foreach ($assets as $id) $acl->addAssetIdToPreload($id)` |
| Article asset fallback| Only directly to `com_content` component asset | First fallback to category, if not exists then fallback to `com_content` component asset |


### Testing Instructions
Check ACL Permission (categories, articles, general) before and after patch.
Joomla should work as before.


### To Do

- [x] Sort of deprecations
- [ ] Better support for services
- [ ] Check B/C for `Access` class
- [ ] More tests
