### PR TITLE
[com_finder] Fix toggle selection (Regression #19969)

### DIFF
--- a/components/com_finder/helpers/html/filter.php
+++ b/components/com_finder/helpers/html/filter.php
@@ -187,10 +187,9 @@ abstract class JHtmlFilter
 				// Build a node.
 				$html .= '<div class="control-group">';
 				$html .= '<div class="controls">';
-				$html .= '<label class="checkbox" for="tax-'
-					. $nk . '">';
+				$html .= '<label class="checkbox">';
 				$html .= '<input type="checkbox" class="selector filter-node' . $classSuffix . '" value="' . $nk . '" name="t[]" id="tax-'
-					. $nk . '"' . $checked . ' />';
+					. $bk . '"' . $checked . ' />';
 				$html .= $nv->title;
 				$html .= '</label>';
 				$html .= '</div>';


### PR DESCRIPTION
Fix regression for Issue #19969.

### Summary of Changes
PR #19969 attempts to fix #19930, however, broke the `Toggle Selection` functionality. This PR removes the `for` attribute which is not required since the checkbox is wrapped in the `label` tag and use the `id` for the `Toggle Selection` button.


### Testing Instructions
Go to Components > Smart Search
Click `Index` button
Click `Search Filters`
Click `New` button
Go to a section and click the `Toggle Selection` button


### Expected result
`Toggle Selection` button toggles the checkboxes.


### Actual result
`Toggle Selection` button does not toggle the checkboxes.


### Documentation Changes Required
none
