### PR TITLE
Fixing com_fields integration in com_contact

### DIFF
--- a/components/com_contact/models/contact.php
+++ b/components/com_contact/models/contact.php
@@ -139,6 +139,11 @@ class ContactModelContact extends JModelForm
 		{
 			$data['language'] = JFactory::getLanguage()->getTag();
 		}
+		
+		// Add contact id to contact form data, so fields plugin can work propertly
+		if(empty($data['catid'])) {
+			$data['catid'] = $this->getItem()->catid;
+		}
 
 		$this->preprocessData('com_contact.contact', $data);
 

--- a/components/com_contact/models/contact.php
+++ b/components/com_contact/models/contact.php
@@ -141,7 +141,8 @@ class ContactModelContact extends JModelForm
 		}
 		
 		// Add contact id to contact form data, so fields plugin can work propertly
-		if(empty($data['catid'])) {
+		if (empty($data['catid']))
+		{
 			$data['catid'] = $this->getItem()->catid;
 		}
 

--- a/components/com_contact/models/contact.php
+++ b/components/com_contact/models/contact.php
@@ -139,8 +139,8 @@ class ContactModelContact extends JModelForm
 		{
 			$data['language'] = JFactory::getLanguage()->getTag();
 		}
-		
-		// Add contact id to contact form data, so fields plugin can work propertly
+
+		// Add contact id to contact form data, so fields plugin can work properly
 		if (empty($data['catid']))
 		{
 			$data['catid'] = $this->getItem()->catid;


### PR DESCRIPTION
Custom fields in com_contact currently doesn't work propertly. Choosing a category on which they should appear doesn't work cause fields plugin has no information about contact catid as not data is passed to form when contact form is displayed. Below is a test for the bug it fixes.

### Summary of Changes
Adding `catid` to contact form data.


### Testing Instructions
- Create 2 contacts categories
- Create 2 contacts, select them different categories and link them in menu (with enabled contact form)
- Create 2 checkbox type fields (in `Mail` group so they will be displayed in contact form), One should have a selected category, the other should have `All` in category select
- Go to front and look at both contact forms

### Expected result
- One contact should have 2 checkbox fields added
- The other should have only one checkbox field added

### Actual result
- Both checkboxes display in both contacts


### Documentation Changes Required
None
