### PR TITLE
Change 404 message from URL Invalid to Not Found

### DIFF
--- a/libraries/src/Router/Router.php
+++ b/libraries/src/Router/Router.php
@@ -10,6 +10,7 @@ namespace Joomla\CMS\Router;
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Exception\RouteNotFoundException;
 
 /**
@@ -147,7 +148,7 @@ class Router
 		// Otherwise we have an invalid URL
 		if (strlen($uri->getPath()) > 0)
 		{
-			throw new RouteNotFoundException('URL invalid');
+			throw new RouteNotFoundException(Text::_('JERROR_PAGE_NOT_FOUND'));
 		}
 
 		if ($setVars)


### PR DESCRIPTION
### Steps to reproduce the issue
Closes #20358 

Go to any fake url to generate a 404

Although the Status text can be any human readable string, it is most common to stick to the accepted text of "Not Found"

### Expected result

"404 Not Found"
or 
"404 Page Not Found"


### Actual result

404 URL Invalid

**The URL is a VALID Url,** just in the context of the routing in Joomla doesnt lead to a "page".... so "URL Invalid is syntactically wrong. 


### System information (as much as possible)

Joomla! 4.0.0-alpha3 Alpha [ Amani ] 12-May-2018 15:23 GMT

### Additional comments
