### PR TITLE
[com_contenthistory] - fix for not delete keep forever items

### DIFF
--- a/administrator/components/com_contenthistory/models/history.php
+++ b/administrator/components/com_contenthistory/models/history.php
@@ -118,9 +118,16 @@ class ContenthistoryModelHistory extends JModelList
 		// Iterate the items to delete each one.
 		foreach ($pks as $i => $pk)
 		{
+			
 			if ($table->load($pk))
 			{
-				if ($this->canEdit($table) && $table->keep_forever !== "1")
+				if ($table->keep_forever === "1")
+				{
+					unset($pks[$i]);
+					continue;	
+				}
+
+				if ($this->canEdit($table))
 				{
 					if (!$table->delete($pk))
 					{

--- a/administrator/components/com_contenthistory/models/history.php
+++ b/administrator/components/com_contenthistory/models/history.php
@@ -118,7 +118,6 @@ class ContenthistoryModelHistory extends JModelList
 		// Iterate the items to delete each one.
 		foreach ($pks as $i => $pk)
 		{
-			
 			if ($table->load($pk))
 			{
 				if ($table->keep_forever === "1")

--- a/administrator/components/com_contenthistory/models/history.php
+++ b/administrator/components/com_contenthistory/models/history.php
@@ -120,7 +120,7 @@ class ContenthistoryModelHistory extends JModelList
 		{
 			if ($table->load($pk))
 			{
-				if ($this->canEdit($table))
+				if ($this->canEdit($table) && $table->keep_forever !== "1")
 				{
 					if (!$table->delete($pk))
 					{

--- a/administrator/components/com_contenthistory/models/history.php
+++ b/administrator/components/com_contenthistory/models/history.php
@@ -123,7 +123,7 @@ class ContenthistoryModelHistory extends JModelList
 				if ($table->keep_forever === "1")
 				{
 					unset($pks[$i]);
-					continue;	
+					continue;
 				}
 
 				if ($this->canEdit($table))


### PR DESCRIPTION
Pull Request for Issue #20365 .

### Summary of Changes
added the missed check


### Testing Instructions
see #20365


### Expected result
not able to delete a keep forever marked content history item


### Actual result
able



