### PR TITLE
Deprecate JHtmlBehavior::caption

### DIFF
--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -104,9 +104,13 @@ abstract class JHtmlBehavior
 	 * @return  void
 	 *
 	 * @since   1.5
+	 *
+	 * @Deprecated 4.0 Use native HTML figure tags.
 	 */
 	public static function caption($selector = 'img.caption')
 	{
+		JLog::add('JHtmlBehavior::caption is deprecated. Use native HTML figure tags.', JLog::WARNING, 'deprecated');
+
 		// Only load once
 		if (isset(static::$loaded[__METHOD__][$selector]))
 		{


### PR DESCRIPTION
Since #20153 is merged into 4.0, we need a deprecation message in 3.x.

### Summary of Changes
Adds deprecation tag to the doc block and adds a deprecation log message.


### Testing Instructions
Check that a deprecation log is generated when visiting any site that loads caption.js (eg most com_content views)
