### PR TITLE
[4.0] The dispatcher factory is a required dependency

### DIFF
--- a/administrator/components/com_admin/services/provider.php
+++ b/administrator/components/com_admin/services/provider.php
@@ -44,9 +44,8 @@ return new class implements ServiceProviderInterface
 			ComponentInterface::class,
 			function (Container $container)
 			{
-				$component = new AdminComponent;
+				$component = new AdminComponent($container->get(DispatcherFactoryInterface::class));
 
-				$component->setDispatcherFactory($container->get(DispatcherFactoryInterface::class));
 				$component->setMvcFactoryFactory($container->get(MVCFactoryFactoryInterface::class));
 				$component->setRegistry($container->get(Registry::class));
 

--- a/administrator/components/com_content/services/provider.php
+++ b/administrator/components/com_content/services/provider.php
@@ -51,9 +51,8 @@ return new class implements ServiceProviderInterface
 			ComponentInterface::class,
 			function (Container $container)
 			{
-				$component = new ContentComponent;
+				$component = new ContentComponent($container->get(DispatcherFactoryInterface::class));
 
-				$component->setDispatcherFactory($container->get(DispatcherFactoryInterface::class));
 				$component->setRegistry($container->get(Registry::class));
 				$component->setMvcFactoryFactory($container->get(MVCFactoryFactoryInterface::class));
 				$component->setCategories($container->get(Categories::class));

--- a/administrator/components/com_modules/services/provider.php
+++ b/administrator/components/com_modules/services/provider.php
@@ -43,9 +43,8 @@ return new class implements ServiceProviderInterface
 			ComponentInterface::class,
 			function (Container $container)
 			{
-				$component = new ModulesComponent;
+				$component = new ModulesComponent($container->get(DispatcherFactoryInterface::class));
 
-				$component->setDispatcherFactory($container->get(DispatcherFactoryInterface::class));
 				$component->setMvcFactoryFactory($container->get(MVCFactoryFactoryInterface::class));
 
 				return $component;

--- a/libraries/src/Extension/Component.php
+++ b/libraries/src/Extension/Component.php
@@ -31,6 +31,18 @@ class Component implements ComponentInterface
 	private $dispatcherFactory;
 
 	/**
+	 * Component constructor.
+	 *
+	 * @param   DispatcherFactoryInterface  $dispatcherFactory  The dispatcher factory
+	 *
+	 * @since   4.0.0
+	 */
+	public function __construct(DispatcherFactoryInterface $dispatcherFactory)
+	{
+		$this->dispatcherFactory = $dispatcherFactory;
+	}
+
+	/**
 	 * Returns the dispatcher for the given application.
 	 *
 	 * @param   CMSApplicationInterface  $application  The application
@@ -41,25 +53,6 @@ class Component implements ComponentInterface
 	 */
 	public function getDispatcher(CMSApplicationInterface $application): DispatcherInterface
 	{
-		if ($this->dispatcherFactory === null)
-		{
-			return null;
-		}
-
 		return $this->dispatcherFactory->createDispatcher($application);
-	}
-
-	/**
-	 * Sets the dispatcher factory.
-	 *
-	 * @param   DispatcherFactoryInterface  $dispatcherFactory  The dispatcher factory
-	 *
-	 * @return  void
-	 *
-	 * @since   4.0.0
-	 */
-	public function setDispatcherFactory(DispatcherFactoryInterface $dispatcherFactory)
-	{
-		$this->dispatcherFactory = $dispatcherFactory;
 	}
 }


### PR DESCRIPTION
The dispatcher factory is a required dependency which should be injected in the constructor. It can't return null.