### PR TITLE
add a HTML width element to the image in the RSS feed

### DIFF
--- a/components/com_content/views/category/view.feed.php
+++ b/components/com_content/views/category/view.feed.php
@@ -44,7 +44,7 @@ class ContentViewCategory extends JViewCategoryfeed
 		if (isset($introImage) && ($introImage != ''))
 		{
 			$image = preg_match('/http/', $introImage) ? $introImage : JURI::root() . $introImage;
-			$item->description = '<p><img src="' . $image . '" /></p>';
+			$item->description = '<p><img src="' . $image . '" width="640" /></p>';
 		}
 
 		$item->description .= ($params->get('feed_summary', 0) ? $item->introtext . $item->fulltext : $item->introtext);


### PR DESCRIPTION
As RSS is commonly used in Email clients we can limit the width of the image.  This will mean the images do not blow the width of emails in Outlook with the original image width - which potentially could be 1200 (or more if retina images are used).  Emails are generally no more than 640 pixels wide.  

Pull Request for Issue # .

### Summary of Changes

Max image width will be 640px

### Testing Instructions
Check RSS feed and see if image width is set.  You probably need to view source in your browser.


### Expected result
Image has a width of 640 added as a HTML element


### Actual result
No width is forced making people scroll left/right in their browsers


### Documentation Changes Required
n/a
