### PR TITLE
[CS] fix some doc comment types

### DIFF
--- a/administrator/components/com_banners/helpers/banners.php
+++ b/administrator/components/com_banners/helpers/banners.php
@@ -188,7 +188,7 @@ class BannersHelper extends JHelperContent
 	/**
 	 * Adds Count Items for Category Manager.
 	 *
-	 * @param   stdClass[]  &$items  The banner category objects
+	 * @param   stdClass[]  $items  The banner category objects
 	 *
 	 * @return  stdClass[]
 	 *
@@ -242,7 +242,7 @@ class BannersHelper extends JHelperContent
 	/**
 	 * Adds Count Items for Tag Manager.
 	 *
-	 * @param   stdClass[]  &$items     The banner tag objects
+	 * @param   stdClass[]  $items      The banner tag objects
 	 * @param   string      $extension  The name of the active view.
 	 *
 	 * @return  stdClass[]

--- a/administrator/components/com_banners/models/banner.php
+++ b/administrator/components/com_banners/models/banner.php
@@ -373,7 +373,7 @@ class BannersModelBanner extends JModelAdmin
 	/**
 	 * Method to stick records.
 	 *
-	 * @param   array    &$pks   The ids of the items to publish.
+	 * @param   array    $pks    The ids of the items to publish.
 	 * @param   integer  $value  The value of the published state
 	 *
 	 * @return  boolean  True on success.

--- a/administrator/components/com_banners/tables/banner.php
+++ b/administrator/components/com_banners/tables/banner.php
@@ -22,7 +22,7 @@ class BannersTableBanner extends JTable
 	/**
 	 * Constructor
 	 *
-	 * @param   JDatabaseDriver  &$db  Database connector object
+	 * @param   JDatabaseDriver  $db  Database connector object
 	 *
 	 * @since   1.5
 	 */

--- a/administrator/components/com_banners/tables/client.php
+++ b/administrator/components/com_banners/tables/client.php
@@ -21,7 +21,7 @@ class BannersTableClient extends JTable
 	/**
 	 * Constructor
 	 *
-	 * @param   JDatabaseDriver  &$db  Database connector object
+	 * @param   JDatabaseDriver  $db  Database connector object
 	 *
 	 * @since   1.5
 	 */

--- a/administrator/components/com_categories/controllers/categories.php
+++ b/administrator/components/com_categories/controllers/categories.php
@@ -68,7 +68,7 @@ class CategoriesControllerCategories extends JControllerAdmin
 	/**
 	 * Save the manual order inputs from the categories list page.
 	 *
-	 * @return      void
+	 * @return      boolean  True on success
 	 *
 	 * @since       1.6
 	 * @see         JControllerAdmin::saveorder()

--- a/administrator/components/com_categories/models/categories.php
+++ b/administrator/components/com_categories/models/categories.php
@@ -366,7 +366,7 @@ class CategoriesModelCategories extends JModelList
 	/**
 	 * Method to load the countItems method from the extensions
 	 *
-	 * @param   stdClass[]  &$items     The category items
+	 * @param   stdClass[]  $items      The category items
 	 * @param   string      $extension  The category extension
 	 *
 	 * @return  void

--- a/administrator/components/com_categories/models/category.php
+++ b/administrator/components/com_categories/models/category.php
@@ -359,7 +359,7 @@ class CategoriesModelCategory extends JModelAdmin
 	 * @param   mixed   $data   The data expected for the form.
 	 * @param   string  $group  The name of the plugin group to import.
 	 *
-	 * @return  void
+	 * @return  mixed
 	 *
 	 * @see     JFormField
 	 * @since   1.6
@@ -695,7 +695,7 @@ class CategoriesModelCategory extends JModelAdmin
 	/**
 	 * Method to change the published state of one or more records.
 	 *
-	 * @param   array    &$pks   A list of the primary keys to change.
+	 * @param   array    $pks    A list of the primary keys to change.
 	 * @param   integer  $value  The value of the published state.
 	 *
 	 * @return  boolean  True on success.

--- a/administrator/components/com_contact/helpers/contact.php
+++ b/administrator/components/com_contact/helpers/contact.php
@@ -57,7 +57,7 @@ class ContactHelper extends JHelperContent
 	/**
 	 * Adds Count Items for Category Manager.
 	 *
-	 * @param   stdClass[]  &$items  The contact category objects
+	 * @param   stdClass[]  $items  The contact category objects
 	 *
 	 * @return  stdClass[]
 	 *
@@ -111,7 +111,7 @@ class ContactHelper extends JHelperContent
 	/**
 	 * Adds Count Items for Tag Manager.
 	 *
-	 * @param   stdClass[]  &$items     The banner tag objects
+	 * @param   stdClass[]  $items      The banner tag objects
 	 * @param   string      $extension  The name of the active view.
 	 *
 	 * @return  stdClass[]

--- a/administrator/components/com_contact/tables/contact.php
+++ b/administrator/components/com_contact/tables/contact.php
@@ -30,7 +30,7 @@ class ContactTableContact extends JTable
 	/**
 	 * Constructor
 	 *
-	 * @param   JDatabaseDriver  &$db  Database connector object
+	 * @param   JDatabaseDriver  $db  Database connector object
 	 *
 	 * @since   1.0
 	 */

--- a/administrator/components/com_content/helpers/content.php
+++ b/administrator/components/com_content/helpers/content.php
@@ -91,7 +91,7 @@ class ContentHelper extends JHelperContent
 	/**
 	 * Adds Count Items for Category Manager.
 	 *
-	 * @param   stdClass[]  &$items  The banner category objects
+	 * @param   stdClass[]  $items  The banner category objects
 	 *
 	 * @return  stdClass[]
 	 *
@@ -145,7 +145,7 @@ class ContentHelper extends JHelperContent
 	/**
 	 * Adds Count Items for Tag Manager.
 	 *
-	 * @param   stdClass[]  &$items     The content objects
+	 * @param   stdClass[]  $items      The content objects
 	 * @param   string      $extension  The name of the active view.
 	 *
 	 * @return  stdClass[]

--- a/administrator/components/com_content/models/article.php
+++ b/administrator/components/com_content/models/article.php
@@ -970,7 +970,7 @@ class ContentModelArticle extends JModelAdmin
 	/**
 	 * Delete #__content_frontpage items if the deleted articles was featured
 	 *
-	 * @param   object  &$pks  The primary key related to the contents that was deleted.
+	 * @param   object  $pks  The primary key related to the contents that was deleted.
 	 *
 	 * @return  boolean
 	 *

--- a/administrator/components/com_content/tables/featured.php
+++ b/administrator/components/com_content/tables/featured.php
@@ -19,7 +19,7 @@ class ContentTableFeatured extends JTable
 	/**
 	 * Constructor
 	 *
-	 * @param   JDatabaseDriver  &$db  Database connector object
+	 * @param   JDatabaseDriver  $db  Database connector object
 	 *
 	 * @since   1.6
 	 */

--- a/administrator/components/com_contenthistory/models/history.php
+++ b/administrator/components/com_contenthistory/models/history.php
@@ -104,7 +104,7 @@ class ContenthistoryModelHistory extends JModelList
 	/**
 	 * Method to delete one or more records from content history table.
 	 *
-	 * @param   array  &$pks  An array of record primary keys.
+	 * @param   array  $pks  An array of record primary keys.
 	 *
 	 * @return  boolean  True if successful, false if an error occurs.
 	 *
@@ -243,7 +243,7 @@ class ContenthistoryModelHistory extends JModelList
 	/**
 	 * Method to toggle on and off the keep forever value for one or more records from content history table.
 	 *
-	 * @param   array  &$pks  An array of record primary keys.
+	 * @param   array  $pks  An array of record primary keys.
 	 *
 	 * @return  boolean  True if successful, false if an error occurs.
 	 *

--- a/administrator/components/com_fields/helpers/fields.php
+++ b/administrator/components/com_fields/helpers/fields.php
@@ -591,7 +591,7 @@ class FieldsHelper
 	/**
 	 * Adds Count Items for Category Manager.
 	 *
-	 * @param   stdClass[]  &$items  The field category objects
+	 * @param   stdClass[]  $items  The field category objects
 	 *
 	 * @return  stdClass[]
 	 *

--- a/administrator/components/com_fields/models/field.php
+++ b/administrator/components/com_fields/models/field.php
@@ -433,7 +433,7 @@ class FieldsModelField extends JModelAdmin
 	/**
 	 * Method to delete one or more records.
 	 *
-	 * @param   array  &$pks  An array of record primary keys.
+	 * @param   array  $pks  An array of record primary keys.
 	 *
 	 * @return  boolean  True if successful, false if an error occurs.
 	 *

--- a/build/phpcs/Joomla/ruleset.xml
+++ b/build/phpcs/Joomla/ruleset.xml
@@ -157,6 +157,7 @@
 		<exclude-pattern type="relative">templates/*</exclude-pattern>
 		<exclude-pattern type="relative">layouts/*</exclude-pattern>
 		<exclude-pattern type="relative">tests/*</exclude-pattern>
+		<exclude-pattern type="relative">administrator/components/*</exclude-pattern>
 	</rule>
 
 	<rule ref="Joomla.Commenting.SingleComment">


### PR DESCRIPTION
Pull Request for Issue code style corrections for doc comment types.

### Summary of Changes
PHPCS2 manual fixes
- Variables passed by reference should not have the `&` prefixed in the doc comment
  - Joomla.Commenting.FunctionComment.MissingParamTag
  - Joomla.Commenting.FunctionComment.ParamNameNoMatch
- Correct return statement

[Found using the Joomla code standards 2.0.0 PHPCS2-RC](https://github.com/joomla/coding-standards/releases/tag/2.0.0-rc)

### Testing Instructions
Merge by code review

### Expected result
code style has been applied as listed above, old code style testing on drone does not error.

### Actual result
code style had not been applied. [Found using the Joomla code standards 2.0.0 PHPCS2-RC](https://github.com/joomla/coding-standards/releases/tag/2.0.0-rc)


### Documentation Changes Required
none