### PR TITLE
[4.0] Fixing Suggestions in Finder/Smart Search

### DIFF
--- a/components/com_finder/Controller/SuggestionsController.php
+++ b/components/com_finder/Controller/SuggestionsController.php
@@ -57,7 +57,7 @@ class SuggestionsController extends BaseController
 		if ($params->get('show_autosuggest', 1))
 		{
 			// Get the suggestions.
-			$model = $this->getModel('Suggestions', 'FinderModel');
+			$model = $this->getModel('Suggestions');
 			$return = $model->getItems();
 		}
 


### PR DESCRIPTION
The suggestions in Smart Search currently throw an error, because the controller can't find the right model. This fixes that.

## Testing instructions
1. Build the index in the backend.
2. Go to the frontend to the Smart Search view and type in "joo". Notice nothing is happening.
3. Apply patch
4. Type in "joo" and see that you get lots of suggestions.