### PR TITLE
[4.0] Only add debug information during installation on HTML documents

### DIFF
--- a/installation/src/Application/InstallationApplication.php
+++ b/installation/src/Application/InstallationApplication.php
@@ -102,6 +102,11 @@ final class InstallationApplication extends CMSApplication
 	 */
 	public function debugLanguage()
 	{
+		if ($this->getDocument()->getType() != 'html')
+		{
+			return '';
+		}
+
 		$lang   = Factory::getLanguage();
 		$output = '<h4>' . \JText::_('JDEBUG_LANGUAGE_FILES_IN_ERROR') . '</h4>';
 


### PR DESCRIPTION
Pull Request for Issue #20524.

### Summary of Changes
Adds debug information only for HTML documents.

### Testing Instructions
Install a clean joomla 4.0-dev after setting the `installation/localise.xml` file to debug
```
<?xml version="1.0" encoding="utf-8"?>
<localise version="3.6" client="installation">
	<forceLang></forceLang>
	<helpurl></helpurl>
	<debug>1</debug>
	<sampledata></sampledata>
	<params/>
</localise>
```

### Expected result
Installer runs through.

### Actual result
Installer does not flip to the last page.