### PR TITLE
Correctly escape the random image module output

### DIFF
--- a/modules/mod_random_image/tmpl/default.php
+++ b/modules/mod_random_image/tmpl/default.php
@@ -13,7 +13,7 @@ defined('_JEXEC') or die;
 <?php if ($link) : ?>
 <a href="<?php echo $link; ?>">
 <?php endif; ?>
-	<?php echo JHtml::_('image', $image->folder . '/' . $this->escape($image->name), $this->escape($image->name), array('width' => $image->width, 'height' => $image->height)); ?>
+	<?php echo JHtml::_('image', $image->folder . '/' . htmlspecialchars($image->name, ENT_COMPAT, 'UTF-8'), htmlspecialchars($image->name, ENT_COMPAT, 'UTF-8'), array('width' => $image->width, 'height' => $image->height)); ?>
 <?php if ($link) : ?>
 </a>
 <?php endif; ?>


### PR DESCRIPTION
Pull Request for Issue #20531

### Summary of Changes

Modules don't have `$this` context, so can't call `$this->escape()`.  Escape output using `htmlspecialchars()` instead.

### Testing Instructions

Apply patch, make sure module works again.

### Expected result

Module shows an image.

### Actual result

Module causes a fatal error.

### Documentation Changes Required

Somewhere in the security team's testing and review workflow there probably does need to be a change...