### PR TITLE
[styles] Fix checkboxes/buttons not clickable under Menu Assignment in Chrome

### DIFF
--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -9088,8 +9088,6 @@ input:focus,
 	margin-bottom: 15px;
 	width: 100%;
 	list-style: none;
-	-webkit-column-break-inside: avoid;
-	-webkit-backface-visibility: hidden;
 }
 #menu-assignment .menu-links-block {
 	background-color: #fafafa;

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -9088,8 +9088,6 @@ input:focus,
 	margin-bottom: 15px;
 	width: 100%;
 	list-style: none;
-	-webkit-column-break-inside: avoid;
-	-webkit-backface-visibility: hidden;
 }
 #menu-assignment .menu-links-block {
 	background-color: #fafafa;

--- a/administrator/templates/isis/less/pages/_com_templates.less
+++ b/administrator/templates/isis/less/pages/_com_templates.less
@@ -16,9 +16,7 @@
 			vertical-align: top;
 			margin-bottom: 15px;
 			width: 100%;
-			list-style: none;
-			-webkit-column-break-inside: avoid;
-			-webkit-backface-visibility: hidden;	
+			list-style: none;	
 		}
 	}
 	.menu-links-block {

--- a/administrator/templates/isis/less/pages/_com_templates.less
+++ b/administrator/templates/isis/less/pages/_com_templates.less
@@ -16,7 +16,7 @@
 			vertical-align: top;
 			margin-bottom: 15px;
 			width: 100%;
-			list-style: none;	
+			list-style: none;
 		}
 	}
 	.menu-links-block {


### PR DESCRIPTION
Pull Request for Issue #20446.

### Summary of Changes
Remove css causing checkboxes/toggle selection buttons under Menu Assignment to be non clickable in Google Chrome.

@dgrammatiko  @ciar4n Please confirm that it is safe to remove these offending css.

### Testing Instructions
Use Google Chrome
Go to Extensions > Templates > Styles
Click `protostar - Default`
Click `Menu Assignment`
Click checkboxes/toggle selection buttons in the 2nd and 3rd columns

Apply PR and repeat above steps


### Expected result
Checkboxes/Toggle Selection buttons clickable


### Actual result
Checkboxes/Toggle Selection buttons not clickable


### Documentation Changes Required
none
