### PR TITLE
[plg_editors_codemirror] Manifest cleanup

### DIFF
--- a/plugins/editors/codemirror/codemirror.php
+++ b/plugins/editors/codemirror/codemirror.php
@@ -207,8 +207,7 @@ class PlgEditorCodemirror extends JPlugin
 			$autofocused = $options->autofocus;
 		}
 
-		// Until there's a fix for the overflow problem, always wrap lines.
-		$options->lineWrapping = true;
+		$options->lineWrapping = (boolean) $this->params->get('lineWrapping', 1);
 
 		// Add styling to the active line.
 		$options->styleActiveLine = (boolean) $this->params->get('activeLine', 1);

--- a/plugins/editors/codemirror/codemirror.php
+++ b/plugins/editors/codemirror/codemirror.php
@@ -212,7 +212,7 @@ class PlgEditorCodemirror extends JPlugin
 		// Add styling to the active line.
 		$options->styleActiveLine = (boolean) $this->params->get('activeLine', 1);
 
-		// Add styling to the active line.
+		// Do we highlight selection matches?
 		if ($this->params->get('selectionMatches', 0))
 		{
 			$options->highlightSelectionMatches = array(

--- a/plugins/editors/codemirror/codemirror.php
+++ b/plugins/editors/codemirror/codemirror.php
@@ -66,7 +66,7 @@ class PlgEditorCodemirror extends JPlugin
 		JLayoutHelper::render('editors.codemirror.init', $displayData, __DIR__ . '/layouts');
 		ob_end_clean();
 
-		$font = $this->params->get('fontFamily', 0);
+		$font = $this->params->get('fontFamily', '0');
 		$fontInfo = $this->getFontInfo($font);
 
 		if (isset($fontInfo))
@@ -214,7 +214,7 @@ class PlgEditorCodemirror extends JPlugin
 		$options->styleActiveLine = (boolean) $this->params->get('activeLine', true);
 
 		// Add styling to the active line.
-		if ($this->params->get('selectionMatches', false))
+		if ($this->params->get('selectionMatches', 0))
 		{
 			$options->highlightSelectionMatches = array(
 					'showToken' => true,
@@ -257,20 +257,20 @@ class PlgEditorCodemirror extends JPlugin
 		if (in_array($options->mode, array('xml', 'html', 'php')))
 		{
 			// Autogenerate closing tags (html/xml only).
-			$options->autoCloseTags = (boolean) $this->params->get('autoCloseTags', true);
+			$options->autoCloseTags = (boolean) $this->params->get('autoCloseTags', 1);
 
 			// Highlight the matching tag when the cursor is in a tag (html/xml only).
-			$options->matchTags = (boolean) $this->params->get('matchTags', true);
+			$options->matchTags = (boolean) $this->params->get('matchTags', 1);
 		}
 
 		// Special options for non-tagged modes.
 		if (!in_array($options->mode, array('xml', 'html')))
 		{
 			// Autogenerate closing brackets.
-			$options->autoCloseBrackets = (boolean) $this->params->get('autoCloseBrackets', true);
+			$options->autoCloseBrackets = (boolean) $this->params->get('autoCloseBrackets', 1);
 
 			// Highlight the matching bracket.
-			$options->matchBrackets = (boolean) $this->params->get('matchBrackets', true);
+			$options->matchBrackets = (boolean) $this->params->get('matchBrackets', 1);
 		}
 
 		$options->scrollbarStyle = $this->params->get('scrollbarStyle', 'native');

--- a/plugins/editors/codemirror/codemirror.php
+++ b/plugins/editors/codemirror/codemirror.php
@@ -211,7 +211,7 @@ class PlgEditorCodemirror extends JPlugin
 		$options->lineWrapping = true;
 
 		// Add styling to the active line.
-		$options->styleActiveLine = (boolean) $this->params->get('activeLine', true);
+		$options->styleActiveLine = (boolean) $this->params->get('activeLine', 1);
 
 		// Add styling to the active line.
 		if ($this->params->get('selectionMatches', 0))

--- a/plugins/editors/codemirror/codemirror.php
+++ b/plugins/editors/codemirror/codemirror.php
@@ -213,7 +213,7 @@ class PlgEditorCodemirror extends JPlugin
 		$options->styleActiveLine = (boolean) $this->params->get('activeLine', 1);
 
 		// Do we highlight selection matches?
-		if ($this->params->get('selectionMatches', 0))
+		if ($this->params->get('selectionMatches', 1))
 		{
 			$options->highlightSelectionMatches = array(
 					'showToken' => true,
@@ -222,7 +222,7 @@ class PlgEditorCodemirror extends JPlugin
 		}
 
 		// Do we use line numbering?
-		if ($options->lineNumbers = (boolean) $this->params->get('lineNumbers', 0))
+		if ($options->lineNumbers = (boolean) $this->params->get('lineNumbers', 1))
 		{
 			$options->gutters[] = 'CodeMirror-linenumbers';
 		}
@@ -234,7 +234,7 @@ class PlgEditorCodemirror extends JPlugin
 		}
 
 		// Do we use a marker gutter?
-		if ($options->markerGutter = (boolean) $this->params->get('markerGutter', $this->params->get('marker-gutter', 0)))
+		if ($options->markerGutter = (boolean) $this->params->get('markerGutter', $this->params->get('marker-gutter', 1)))
 		{
 			$options->gutters[] = 'CodeMirror-markergutter';
 		}

--- a/plugins/editors/codemirror/codemirror.xml
+++ b/plugins/editors/codemirror/codemirror.xml
@@ -66,7 +66,7 @@
 
 				<field
 					name="lineWrapping"
-					type="hidden"
+					type="radio"
 					label="PLG_CODEMIRROR_FIELD_LINEWRAPPING_LABEL"
 					description="PLG_CODEMIRROR_FIELD_LINEWRAPPING_DESC"
 					class="btn-group btn-group-yesno"

--- a/plugins/editors/codemirror/codemirror.xml
+++ b/plugins/editors/codemirror/codemirror.xml
@@ -32,7 +32,7 @@
 					description="PLG_CODEMIRROR_FIELD_LINENUMBERS_DESC"
 					class="btn-group btn-group-yesno"
 					default="0"
-					filter="options"
+					filter="integer"
 					>
 					<option value="1">JON</option>
 					<option value="0">JOFF</option>
@@ -45,7 +45,7 @@
 					description="PLG_CODEMIRROR_FIELD_CODEFOLDING_DESC"
 					class="btn-group btn-group-yesno"
 					default="1"
-					filter="options"
+					filter="integer"
 					>
 					<option value="1">JON</option>
 					<option value="0">JOFF</option>
@@ -58,7 +58,7 @@
 					description="PLG_CODEMIRROR_FIELD_MARKERGUTTER_DESC"
 					class="btn-group btn-group-yesno"
 					default="0"
-					filter="options"
+					filter="integer"
 					>
 					<option value="1">JON</option>
 					<option value="0">JOFF</option>
@@ -71,7 +71,7 @@
 					description="PLG_CODEMIRROR_FIELD_LINEWRAPPING_DESC"
 					class="btn-group btn-group-yesno"
 					default="0"
-					filter="options"
+					filter="integer"
 					>
 					<option value="1">JON</option>
 					<option value="0">JOFF</option>
@@ -84,7 +84,7 @@
 					description="PLG_CODEMIRROR_FIELD_ACTIVELINE_DESC"
 					class="btn-group btn-group-yesno"
 					default="1"
-					filter="options"
+					filter="integer"
 					>
 					<option value="1">JON</option>
 					<option value="0">JOFF</option>
@@ -97,7 +97,7 @@
 					description="PLG_CODEMIRROR_FIELD_SELECTIONMATCHES_DESC"
 					class="btn-group btn-group-yesno"
 					default="0"
-					filter="options"
+					filter="integer"
 					>
 					<option value="1">JON</option>
 					<option value="0">JOFF</option>
@@ -110,7 +110,7 @@
 					description="PLG_CODEMIRROR_FIELD_MATCHTAGS_DESC"
 					class="btn-group btn-group-yesno"
 					default="1"
-					filter="options"
+					filter="integer"
 					>
 					<option value="1">JON</option>
 					<option value="0">JOFF</option>
@@ -123,7 +123,7 @@
 					description="PLG_CODEMIRROR_FIELD_MATCHBRACKETS_DESC"
 					class="btn-group btn-group-yesno"
 					default="1"
-					filter="options"
+					filter="integer"
 					>
 					<option value="1">JON</option>
 					<option value="0">JOFF</option>
@@ -136,7 +136,7 @@
 					description="PLG_CODEMIRROR_FIELD_AUTOCLOSETAGS_DESC"
 					class="btn-group btn-group-yesno"
 					default="1"
-					filter="options"
+					filter="integer"
 					>
 					<option value="1">JON</option>
 					<option value="0">JOFF</option>
@@ -149,7 +149,7 @@
 					description="PLG_CODEMIRROR_FIELD_AUTOCLOSEBRACKET_DESC"
 					class="btn-group btn-group-yesno"
 					default="1"
-					filter="options"
+					filter="integer"
 					>
 					<option value="1">JON</option>
 					<option value="0">JOFF</option>
@@ -161,7 +161,6 @@
 					label="PLG_CODEMIRROR_FIELD_KEYMAP_LABEL"
 					description="PLG_CODEMIRROR_FIELD_KEYMAP_DESC"
 					default=""
-					filter="options"
 					>
 					<option value="">JDEFAULT</option>
 					<option value="emacs">PLG_CODEMIRROR_FIELD_KEYMAP_EMACS</option>
@@ -175,7 +174,6 @@
 					label="PLG_CODEMIRROR_FIELD_FULLSCREEN_LABEL"
 					description="PLG_CODEMIRROR_FIELD_FULLSCREEN_DESC"
 					default="F10"
-					filter="options"
 					>
 					<option value="F1">F1</option>
 					<option value="F2">F2</option>
@@ -196,7 +194,6 @@
 					type="checkboxes"
 					label="PLG_CODEMIRROR_FIELD_FULLSCREEN_MOD_LABEL"
 					description="PLG_CODEMIRROR_FIELD_FULLSCREEN_MOD_DESC"
-					filter="options"
 					>
 					<option value="Shift">PLG_CODEMIRROR_FIELD_VALUE_FULLSCREEN_MOD_SHIFT</option>
 					<option value="Cmd">PLG_CODEMIRROR_FIELD_VALUE_FULLSCREEN_MOD_CMD</option>
@@ -229,9 +226,7 @@
 					hide_none="true"
 					hide_default="false"
 					directory="media/editors/codemirror/theme"
-					>
-					<option value="">JDEFAULT</option>
-				</field>
+				/>
 
 				<field
 					name="activeLineColor"
@@ -257,7 +252,6 @@
 					label="PLG_CODEMIRROR_FIELD_FONT_FAMILY_LABEL"
 					description="PLG_CODEMIRROR_FIELD_FONT_FAMILY_DESC"
 					default="0"
-					filter="options"
 					>
 					<option value="0">PLG_CODEMIRROR_FIELD_VALUE_FONT_FAMILY_DEFAULT</option>
 				</field>
@@ -271,7 +265,7 @@
 					last="16"
 					step="1"
 					default="13"
-					filter="intval"
+					filter="integer"
 				/>
 
 				<field
@@ -280,7 +274,7 @@
 					label="PLG_CODEMIRROR_FIELD_LINE_HEIGHT_LABEL"
 					description="PLG_CODEMIRROR_FIELD_LINE_HEIGHT_DESC"
 					default="1.2"
-					filter="options"
+					filter="float"
 					>
 					<option value="1.0">1.0</option>
 					<option value="1.1">1.1</option>
@@ -302,7 +296,6 @@
 					description="PLG_CODEMIRROR_FIELD_VALUE_SCROLLBARSTYLE_DESC"
 					class="btn-group btn-group-yesno"
 					default="native"
-					filter="options"
 					>
 					<option value="native">PLG_CODEMIRROR_FIELD_VALUE_SCROLLBARSTYLE_DEFAULT</option>
 					<option value="simple">PLG_CODEMIRROR_FIELD_VALUE_SCROLLBARSTYLE_SIMPLE</option>

--- a/plugins/editors/codemirror/codemirror.xml
+++ b/plugins/editors/codemirror/codemirror.xml
@@ -310,7 +310,7 @@
 					editor="codemirror"
 					filter="unset"
 					buttons="false"
-				>
+					>
 					<default>
 <![CDATA[
 <script type="text/javascript">

--- a/plugins/editors/codemirror/codemirror.xml
+++ b/plugins/editors/codemirror/codemirror.xml
@@ -31,7 +31,7 @@
 					label="PLG_CODEMIRROR_FIELD_LINENUMBERS_LABEL"
 					description="PLG_CODEMIRROR_FIELD_LINENUMBERS_DESC"
 					class="btn-group btn-group-yesno"
-					default="0"
+					default="1"
 					filter="integer"
 					>
 					<option value="1">JON</option>
@@ -57,7 +57,7 @@
 					label="PLG_CODEMIRROR_FIELD_MARKERGUTTER_LABEL"
 					description="PLG_CODEMIRROR_FIELD_MARKERGUTTER_DESC"
 					class="btn-group btn-group-yesno"
-					default="0"
+					default="1"
 					filter="integer"
 					>
 					<option value="1">JON</option>
@@ -70,7 +70,7 @@
 					label="PLG_CODEMIRROR_FIELD_LINEWRAPPING_LABEL"
 					description="PLG_CODEMIRROR_FIELD_LINEWRAPPING_DESC"
 					class="btn-group btn-group-yesno"
-					default="0"
+					default="1"
 					filter="integer"
 					>
 					<option value="1">JON</option>
@@ -96,7 +96,7 @@
 					label="PLG_CODEMIRROR_FIELD_SELECTIONMATCHES_LABEL"
 					description="PLG_CODEMIRROR_FIELD_SELECTIONMATCHES_DESC"
 					class="btn-group btn-group-yesno"
-					default="0"
+					default="1"
 					filter="integer"
 					>
 					<option value="1">JON</option>

--- a/plugins/editors/codemirror/layouts/editors/codemirror/element.php
+++ b/plugins/editors/codemirror/layouts/editors/codemirror/element.php
@@ -10,15 +10,15 @@
 // No direct access
 defined('_JEXEC') or die;
 
-$options = $displayData->options;
-$params  = $displayData->params;
-$name    = $displayData->name;
-$id      = $displayData->id;
-$cols    = $displayData->cols;
-$rows    = $displayData->rows;
-$content = $displayData->content;
-$buttons = $displayData->buttons;
-$modifier = $params->get('fullScreenMod', '') !== '' ? implode($params->get('fullScreenMod', ''), ' + ') . ' + ' : '';
+$options  = $displayData->options;
+$params   = $displayData->params;
+$name     = $displayData->name;
+$id       = $displayData->id;
+$cols     = $displayData->cols;
+$rows     = $displayData->rows;
+$content  = $displayData->content;
+$buttons  = $displayData->buttons;
+$modifier = $params->get('fullScreenMod', array()) ? implode(' + ', $params->get('fullScreenMod', array())) . ' + ' : '';
 
 ?>
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Added/replaced filters (`options` is not a valid filter, assume it was mistaken for validation rule).
Synced fallback values.
Removed doubled empty value option from  `appearance` field.

### Testing Instructions
1) Code review.
2) Check that editor options toggle on and off correctly.

### Documentation Changes Required
No.