### PR TITLE
[4.0] Rename the registry for HTML services to HTMLRegistry

### DIFF
--- a/administrator/components/com_admin/Extension/AdminComponent.php
+++ b/administrator/components/com_admin/Extension/AdminComponent.php
@@ -46,8 +46,8 @@ class AdminComponent extends Component implements BootableExtensionInterface, MV
 	 */
 	public function boot(ContainerInterface $container)
 	{
-		$this->getRegistry()->register('system', new System);
-		$this->getRegistry()->register('phpsetting', new PhpSetting);
-		$this->getRegistry()->register('directory', new Directory);
+		$this->getHTMLRegistry()->register('system', new System);
+		$this->getHTMLRegistry()->register('phpsetting', new PhpSetting);
+		$this->getHTMLRegistry()->register('directory', new Directory);
 	}
 }

--- a/administrator/components/com_admin/services/provider.php
+++ b/administrator/components/com_admin/services/provider.php
@@ -13,7 +13,7 @@ use Joomla\CMS\Dispatcher\DispatcherFactoryInterface;
 use Joomla\CMS\Extension\ComponentInterface;
 use Joomla\CMS\Extension\Service\Provider\DispatcherFactory;
 use Joomla\CMS\Extension\Service\Provider\MVCFactoryFactory;
-use Joomla\CMS\HTML\Registry;
+use Joomla\CMS\HTML\HTMLRegistry;
 use Joomla\CMS\MVC\Factory\MVCFactoryFactoryInterface;
 use Joomla\Component\Admin\Administrator\Extension\AdminComponent;
 use Joomla\DI\Container;
@@ -47,7 +47,7 @@ return new class implements ServiceProviderInterface
 				$component = new AdminComponent($container->get(DispatcherFactoryInterface::class));
 
 				$component->setMvcFactoryFactory($container->get(MVCFactoryFactoryInterface::class));
-				$component->setRegistry($container->get(Registry::class));
+				$component->setHTMLRegistry($container->get(HTMLRegistry::class));
 
 				return $component;
 			}

--- a/administrator/components/com_content/Extension/ContentComponent.php
+++ b/administrator/components/com_content/Extension/ContentComponent.php
@@ -54,11 +54,11 @@ class ContentComponent extends Component implements
 	 */
 	public function boot(ContainerInterface $container)
 	{
-		$this->getRegistry()->register('contentadministrator', new AdministratorService);
-		$this->getRegistry()->register('contenticon', new Icon($container->get(SiteApplication::class)));
+		$this->getHTMLRegistry()->register('contentadministrator', new AdministratorService);
+		$this->getHTMLRegistry()->register('contenticon', new Icon($container->get(SiteApplication::class)));
 
 		// The layout joomla.content.icons does need a general icon service
-		$this->getRegistry()->register('icon', $this->getRegistry()->getService('contenticon'));
+		$this->getHTMLRegistry()->register('icon', $this->getHTMLRegistry()->getService('contenticon'));
 	}
 
 	/**

--- a/administrator/components/com_content/services/provider.php
+++ b/administrator/components/com_content/services/provider.php
@@ -15,7 +15,7 @@ use Joomla\CMS\Dispatcher\DispatcherFactoryInterface;
 use Joomla\CMS\Extension\ComponentInterface;
 use Joomla\CMS\Extension\Service\Provider\DispatcherFactory;
 use Joomla\CMS\Extension\Service\Provider\MVCFactoryFactory;
-use Joomla\CMS\HTML\Registry;
+use Joomla\CMS\HTML\HTMLRegistry;
 use Joomla\CMS\MVC\Factory\MVCFactoryFactoryInterface;
 use Joomla\Component\Content\Administrator\Extension\ContentComponent;
 use Joomla\Component\Content\Administrator\Helper\AssociationsHelper;
@@ -53,7 +53,7 @@ return new class implements ServiceProviderInterface
 			{
 				$component = new ContentComponent($container->get(DispatcherFactoryInterface::class));
 
-				$component->setRegistry($container->get(Registry::class));
+				$component->setHTMLRegistry($container->get(HTMLRegistry::class));
 				$component->setMvcFactoryFactory($container->get(MVCFactoryFactoryInterface::class));
 				$component->setCategories($container->get(Categories::class));
 				$component->setAssociationExtension($container->get(AssociationExtensionInterface::class));

--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -61,7 +61,7 @@ abstract class HTMLHelper
 	/**
 	 * The service registry for custom and overridden JHtml helpers
 	 *
-	 * @var    Registry
+	 * @var    HTMLRegistry
 	 * @since  4.0.0
 	 */
 	protected static $serviceRegistry;
@@ -280,15 +280,15 @@ abstract class HTMLHelper
 	/**
 	 * Retrieves the service registry.
 	 *
-	 * @return  Registry
+	 * @return  HTMLRegistry
 	 *
 	 * @since   4.0.0
 	 */
-	public static function getServiceRegistry(): Registry
+	public static function getServiceRegistry(): HTMLRegistry
 	{
 		if (!static::$serviceRegistry)
 		{
-			static::$serviceRegistry = Factory::getContainer()->get(Registry::class);
+			static::$serviceRegistry = Factory::getContainer()->get(HTMLRegistry::class);
 		}
 
 		return static::$serviceRegistry;

--- a/libraries/src/HTML/HTMLRegistry.php
+++ b/libraries/src/HTML/HTMLRegistry.php
@@ -15,7 +15,7 @@ defined('JPATH_PLATFORM') or die;
  *
  * @since  4.0.0
  */
-final class Registry
+final class HTMLRegistry
 {
 	/**
 	 * Mapping array of the core CMS JHtml helpers

--- a/libraries/src/HTML/HTMLRegistryAwareTrait.php
+++ b/libraries/src/HTML/HTMLRegistryAwareTrait.php
@@ -20,24 +20,24 @@ trait HTMLRegistryAwareTrait
 	/**
 	 * The registry
 	 *
-	 * @var    Registry
+	 * @var    HTMLRegistry
 	 * @since  4.0.0
 	 */
-	private $registry;
+	private $htmlRegistry;
 
 	/**
 	 * Get the registry.
 	 *
-	 * @return  Registry
+	 * @return  HTMLRegistry
 	 *
 	 * @since   4.0.0
 	 * @throws  \UnexpectedValueException May be thrown if the registry has not been set.
 	 */
-	public function getRegistry()
+	public function getHTMLRegistry()
 	{
-		if ($this->registry)
+		if ($this->htmlRegistry)
 		{
-			return $this->registry;
+			return $this->htmlRegistry;
 		}
 
 		throw new \UnexpectedValueException('HTML registry not set in ' . __CLASS__);
@@ -46,14 +46,14 @@ trait HTMLRegistryAwareTrait
 	/**
 	 * Set the registry to use.
 	 *
-	 * @param   Registry  $registry  The registry
+	 * @param   HTMLRegistry  $htmlRegistry  The registry
 	 *
 	 * @return  void
 	 *
 	 * @since   4.0.0
 	 */
-	public function setRegistry(Registry $registry = null)
+	public function setHTMLRegistry(HTMLRegistry $htmlRegistry = null)
 	{
-		$this->registry = $registry;
+		$this->htmlRegistry = $htmlRegistry;
 	}
 }

--- a/libraries/src/Service/Provider/HTMLRegistry.php
+++ b/libraries/src/Service/Provider/HTMLRegistry.php
@@ -10,7 +10,6 @@ namespace Joomla\CMS\Service\Provider;
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\CMS\HTML\Registry;
 use Joomla\DI\Container;
 use Joomla\DI\ServiceProviderInterface;
 
@@ -33,10 +32,10 @@ class HTMLRegistry implements ServiceProviderInterface
 	public function register(Container $container)
 	{
 		$container->share(
-				Registry::class,
+				\Joomla\CMS\HTML\HTMLRegistry::class,
 				function (Container $container)
 				{
-					return new Registry;
+					return new \Joomla\CMS\HTML\HTMLRegistry;
 				},
 				true
 			);


### PR DESCRIPTION
Renames the `\Joomla\CMS\HTML\Registry` to `\Joomla\CMS\HTML\HTMLRegistry`.

Merge on review @wilsonge.