### PR TITLE
[4.0] Preventing weight in Finder from locale formating

### DIFF
--- a/administrator/components/com_finder/helpers/indexer/indexer.php
+++ b/administrator/components/com_finder/helpers/indexer/indexer.php
@@ -526,7 +526,7 @@ abstract class FinderIndexer
 					. $db->quote($token->stem) . ', '
 					. (int) $token->common . ', '
 					. (int) $token->phrase . ', '
-					. (float) $token->weight . ', '
+					. $db->quote($token->weight) . ', '
 					. (int) $context . ', '
 					. $db->quote($token->language)
 				);


### PR DESCRIPTION
Alternative PR for issue #17114. (Original PR: #17345)

When casting the weight as float, it seems PHP is using a locale aware method, which results in the number sometimes having the wrong decimal-separator and then the query fails. The weight already is formatted as a float with a dot as a decimal-separator, so it should be enough to simply quote this, as @csthomas wrote in the original PR.