### PR TITLE
[4.0][com_menus] Use correct language constant

### DIFF
--- a/administrator/components/com_menus/tmpl/items/default.php
+++ b/administrator/components/com_menus/tmpl/items/default.php
@@ -48,7 +48,7 @@ if ($menuType == '')
 			<div id="j-main-container" class="j-main-container">
 				<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this, 'options' => array('selectorFieldName' => 'menutype'))); ?>
 				<?php if (empty($this->items)) : ?>
-					<joomla-alert type="warning"><?php echo JText::_('COM_LANGUAGES_MULTILANGSTATUS_NONE'); ?></joomla-alert>
+					<joomla-alert type="warning"><?php echo JText::_('JGLOBAL_NO_MATCHING_RESULTS'); ?></joomla-alert>
 				<?php else : ?>
 					<table class="table table-striped" id="itemList">
 						<thead>

--- a/administrator/components/com_menus/tmpl/items/modal.php
+++ b/administrator/components/com_menus/tmpl/items/modal.php
@@ -42,7 +42,7 @@ if (!empty($editor))
 		<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
 
 		<?php if (empty($this->items)) : ?>
-			<joomla-alert type="warning"><?php echo JText::_('COM_LANGUAGES_MULTILANGSTATUS_NONE'); ?></joomla-alert>
+			<joomla-alert type="warning"><?php echo JText::_('JGLOBAL_NO_MATCHING_RESULTS'); ?></joomla-alert>
 		<?php else : ?>
 			<table class="table table-striped table-sm">
 				<thead>


### PR DESCRIPTION
### Summary of Changes
Use the right language constant. 
Change `COM_LANGUAGES_MULTILANGSTATUS_NONE` to `JGLOBAL_NO_MATCHING_RESULTS`


### Testing Instructions
Create a new menu
Go to the new menu
See listings

Create a new menu item
Select `System Links > Menu Item Alias`
Switch to the new menu
Select `Menu Item > Select`
See listings

### Expected result
`No Matching Results`


### Actual result
`COM_LANGUAGES_MULTILANGSTATUS_NONE`