### PR TITLE
Change spacer's tooltip from tooltip to popover

### DIFF
--- a/libraries/joomla/form/fields/spacer.php
+++ b/libraries/joomla/form/fields/spacer.php
@@ -68,7 +68,7 @@ class JFormFieldSpacer extends JFormField
 			$text = $this->translateLabel ? JText::_($text) : $text;
 
 			// Build the class for the label.
-			$class = !empty($this->description) ? 'hasTooltip' : '';
+			$class = !empty($this->description) ? 'hasPopover' : '';
 			$class = $this->required == true ? $class . ' required' : $class;
 
 			// Add the opening label tag and main attributes attributes.
@@ -77,8 +77,18 @@ class JFormFieldSpacer extends JFormField
 			// If a description is specified, use it to build a tooltip.
 			if (!empty($this->description))
 			{
-				JHtml::_('bootstrap.tooltip');
-				$label .= ' title="' . JHtml::_('tooltipText', trim($text, ':'), JText::_($this->description), 0) . '"';
+				JHtml::_('bootstrap.popover');
+				$label .= ' title="' . htmlspecialchars(trim($text, ':'), ENT_COMPAT, 'UTF-8') . '"';
+				$label .= ' data-content="' . htmlspecialchars(
+					$this->translateDescription ? JText::_($this->description) : $this->description,
+					ENT_COMPAT,
+					'UTF-8'
+				) . '"';
+
+				if (JFactory::getLanguage()->isRtl())
+				{
+					$label .= ' data-placement="left"';
+				}
 			}
 
 			// Add the label text and closing tag.

--- a/tests/unit/suites/libraries/joomla/form/fields/JFormFieldSpacerTest.php
+++ b/tests/unit/suites/libraries/joomla/form/fields/JFormFieldSpacerTest.php
@@ -119,7 +119,7 @@ class JFormFieldSpacerTest extends TestCase
 		);
 
 		$equals = '<span class="spacer"><span class="before"></span><span>' .
-			'<label id="spacer-lbl" class="hasPopover" title="&lt;strong&gt;spacer&lt;/strong&gt;">spacer</label></span>' .
+			'<label id="spacer-lbl" class="hasPopover" title="spacer" data-content="spacer">spacer</label></span>' .
 			'<span class="after"></span></span>';
 
 		$this->assertEquals(

--- a/tests/unit/suites/libraries/joomla/form/fields/JFormFieldSpacerTest.php
+++ b/tests/unit/suites/libraries/joomla/form/fields/JFormFieldSpacerTest.php
@@ -119,7 +119,7 @@ class JFormFieldSpacerTest extends TestCase
 		);
 
 		$equals = '<span class="spacer"><span class="before"></span><span>' .
-			'<label id="spacer-lbl" class="hasTooltip" title="&lt;strong&gt;spacer&lt;/strong&gt;">spacer</label></span>' .
+			'<label id="spacer-lbl" class="hasPopover" title="&lt;strong&gt;spacer&lt;/strong&gt;">spacer</label></span>' .
 			'<span class="after"></span></span>';
 
 		$this->assertEquals(


### PR DESCRIPTION
Pull Request for Issue #19604 .

### Summary of Changes
Change spacer's tooltip from tooltip to popover to match the other form fields.


### Testing Instructions
Edit file `\administrator\components\com_content\models\forms\article.xml`
Change line 847 from:
```
		<field
			name="spacer1"
			type="spacer"
			hr="true"
		/>
```
to:
```
		<field
			name="spacer1"
			type="spacer"
			label="Label"
			description="This is a description"
		/>
```
Log in the backend
Edit an article
Under `Images and Links`, hover over `Label`

### Expected result
Tooltip as popover


### Actual result
Tooltip as tooltip


### Documentation Changes Required
none
