### PR TITLE
Fix stale session data wrongly overriding configuration file when editing global configuration

### DIFF
--- a/administrator/components/com_config/controller/application/save.php
+++ b/administrator/components/com_config/controller/application/save.php
@@ -107,7 +107,7 @@ class ConfigControllerApplicationSave extends JControllerBase
 		$this->app->enqueueMessage(JText::_('COM_CONFIG_SAVE_SUCCESS'), 'message');
 
 		// Clear the data from the session.
-		$app->setUserState('com_config.config.global.data', null);
+		$this->app->setUserState('com_config.config.global.data', null);
 
 		// Set the redirect based on the task.
 		switch ($this->options[3])

--- a/administrator/components/com_config/controller/application/save.php
+++ b/administrator/components/com_config/controller/application/save.php
@@ -71,15 +71,15 @@ class ConfigControllerApplicationSave extends JControllerBase
 		// Validate the posted data.
 		$return = $model->validate($form, $data);
 
-		// Save the posted data in the session.
-		$this->app->setUserState('com_config.config.global.data', $data);
-
 		// Check for validation errors.
 		if ($return === false)
 		{
 			/*
 			 * The validate method enqueued all messages for us, so we just need to redirect back.
 			 */
+
+			// Save the posted data in the session.
+			$this->app->setUserState('com_config.config.global.data', $data);
 
 			// Redirect back to the edit screen.
 			$this->app->redirect(JRoute::_('index.php?option=com_config&controller=config.display.application', false));
@@ -89,9 +89,6 @@ class ConfigControllerApplicationSave extends JControllerBase
 		$data   = $return;
 		$return = $model->save($data);
 
-		// Save the validated data in the session.
-		$this->app->setUserState('com_config.config.global.data', $data);
-
 		// Check the return value.
 		if ($return === false)
 		{
@@ -99,12 +96,18 @@ class ConfigControllerApplicationSave extends JControllerBase
 			 * The save method enqueued all messages for us, so we just need to redirect back.
 			 */
 
+			// Save the validated data in the session.
+			$this->app->setUserState('com_config.config.global.data', $data);
+
 			// Save failed, go back to the screen and display a notice.
 			$this->app->redirect(JRoute::_('index.php?option=com_config&controller=config.display.application', false));
 		}
 
 		// Set the success message.
 		$this->app->enqueueMessage(JText::_('COM_CONFIG_SAVE_SUCCESS'), 'message');
+
+		// Clear the data from the session.
+		$app->setUserState('com_config.config.global.data', null);
 
 		// Set the redirect based on the task.
 		switch ($this->options[3])


### PR DESCRIPTION
Pull Request for Issue #20588 

Stale session data should not override configuration file when editing global configuration

Make it consistent with all other controllers

### Summary of Changes

1. Only save data (of global configuration) into session when an error occurs
- validation error
- saving error

2. Clear session data on successful execution of the task


### Testing Instructions
1. Load global config and set debug to ON and save and close
2. Manually edit $debug = '0'; in /configuration.php, thus setting debug to OFF
3. Click to re-edit global config

### Expected result
The DEBUG setting is shown as OFF


### Actual result
The DEBUG setting is shown as ON



### Documentation Changes Required
None
