### PR TITLE
[4.0] Save tab state when editing a plugin

### DIFF
--- a/administrator/components/com_plugins/tmpl/plugin/edit.php
+++ b/administrator/components/com_plugins/tmpl/plugin/edit.php
@@ -13,6 +13,7 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
 JHtml::_('behavior.formvalidator');
 JHtml::_('behavior.keepalive');
+JHtml::_('behavior.tabstate');
 
 $this->fieldsets = $this->form->getFieldsets('params');
 


### PR DESCRIPTION
### Summary of Changes
When editing a plugin and switching to a tab, after save the same tab should be opened as it is the case in J3.

### Testing Instructions
- Change the line 23 in the file /plugins/fields/checkboxes/checkboxes.xml to `<fieldset name="basic1" label="Test">`
- Open the fields check boxes plugin in the back end
- Switch to tab "Test"
- Save the plugin settings

### Expected result
Page opens with the tab "Test" active.

### Actual result
Page opens with the first tab.