### PR TITLE
[com_fields] Language filter

### DIFF
--- a/administrator/components/com_fields/helpers/fields.php
+++ b/administrator/components/com_fields/helpers/fields.php
@@ -107,9 +107,16 @@ class FieldsHelper
 			$item = (object) $item;
 		}
 
-		if (JLanguageMultilang::isEnabled() && isset($item->language) && $item->language != '*')
+		if (JLanguageMultilang::isEnabled())
 		{
-			self::$fieldsCache->setState('filter.language', array('*', $item->language));
+			if (!isset($item->language))
+			{
+				self::$fieldsCache->setState('filter.language', array('*', JFactory::getLanguage()->getTag()));
+			}
+			elseif ($item->language !== '*')
+			{
+				self::$fieldsCache->setState('filter.language', array('*', $item->language));
+			}
 		}
 
 		self::$fieldsCache->setState('filter.context', $context);


### PR DESCRIPTION
Pull Request for Issue #20593.

### Summary of Changes

On multilingual sites custom fields are filtered by language only when current item has language property. Some items (e.g. user registration form) do not have language property. This PR enables filtering by current language on items which do not have language property.

### Testing Instructions

See #20593.

### Documentation Changes Required
No.