### PR TITLE
[com_tags] Images in Tagged Items view

### DIFF
--- a/components/com_tags/views/tag/view.html.php
+++ b/components/com_tags/views/tag/view.html.php
@@ -154,16 +154,13 @@ class TagsViewTag extends JViewLegacy
 				{
 					$itemElement->core_body = $itemElement->text;
 				}
-			}
-		}
 
-		// Categories store the images differently so lets re-map it so the display is correct
-		if ($items && $items[0]->type_alias === 'com_content.category')
-		{
-			foreach ($items as $row)
-			{
-				$core_params = json_decode($row->core_params);
-				$row->core_images = json_encode(array('image_intro' => $core_params->image, 'image_intro_alt' => $core_params->image_alt));
+				// Categories store the images differently so lets re-map it so the display is correct
+				if ($itemElement->type_alias === 'com_content.category')
+				{
+					$coreParams = json_decode($itemElement->core_params);
+					$itemElement->core_images = json_encode(array('image_intro' => $coreParams->image, 'image_intro_alt' => $coreParams->image_alt));
+				}
 			}
 		}
 


### PR DESCRIPTION
Pull Request for Issue #20600.

### Summary of Changes

This corrects image display in Tagged Items view when multiple item types are displayed and one of the types is Category.

### Testing Instructions

Apply a tag to some articles and categories.
Add images to articles and categories.
Create Tagged Items menu item.
Enable 'Item Image' under 'Item Options' in menu item.

### Expected result

Images of all tagged items displayed correctly.

### Actual result

Two possible results depending on the type of the first item in the list. If the first item is an article, category images are not shown. If the first item is a category, article images are not shown and notice appears:
>Notice: Undefined property: stdClass::$image in /public_html/components/com_tags/views/tag/view.html.php on line 166

### Documentation Changes Required
No.