### PR TITLE
Mod_Language css (small) annoying issue on Protostar

### DIFF
--- a/media/mod_languages/css/template.css
+++ b/media/mod_languages/css/template.css
@@ -1,8 +1,3 @@
-div.mod-languages ul {
-	margin: 0;
-	padding: 0;
-	list-style:none;
-}
 div.mod-languages li {
 	margin-left: 5px;
 	margin-right: 5px;


### PR DESCRIPTION
As reported #13678

On a default multilingual install with the language switcher and search module published in the default protostar positions the styling is not great. This simple pr resolves that by removing the extra styling. Out of the box the joomla template and styling should look good

### before
<img width="197" alt="chrome_2018-05-29_09-52-08" src="https://user-images.githubusercontent.com/1296369/40648290-f9627278-6325-11e8-8af6-ab4188dec951.png">


### after
<img width="259" alt="chrome_2018-05-29_09-44-38" src="https://user-images.githubusercontent.com/1296369/40648224-cb1a5e58-6325-11e8-94cc-9941bfb43479.png">
