### PR TITLE
[ModuleHelper] Accept integer as owncache value

### DIFF
--- a/libraries/src/Helper/ModuleHelper.php
+++ b/libraries/src/Helper/ModuleHelper.php
@@ -535,7 +535,7 @@ abstract class ModuleHelper
 		$cache = \JFactory::getCache($cacheparams->cachegroup, 'callback');
 
 		// Turn cache off for internal callers if parameters are set to off and for all logged in users
-		if ($moduleparams->get('owncache', null) === '0' || $conf->get('caching') == 0 || $user->get('id'))
+		if ($moduleparams->get('owncache') === 0 || $moduleparams->get('owncache') === '0' || $conf->get('caching') == 0 || $user->get('id'))
 		{
 			$cache->setCaching(false);
 		}


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This sets up ModuleHelper to allow integer `owncache` value. This is needed in case integer filter is applied to the field in module manifest file.

### Testing Instructions

Code review.

### Documentation Changes Required
No.
