### PR TITLE
Remove duplicate observers ~ 20 queries less while saving the article

### DIFF
--- a/libraries/joomla/observer/updater.php
+++ b/libraries/joomla/observer/updater.php
@@ -66,26 +66,18 @@ class JObserverUpdater implements JObserverUpdaterInterface
 	{
 		$class = get_class($observer);
 
-		// Also register the alias
+		// Also register the alias if exists
 		foreach (JLoader::getDeprecatedAliases() as $alias)
 		{
 			$realClass  = trim($alias['new'], '\\');
-			$aliasClass = trim($alias['old'], '\\');
 
 			// Check if we have an alias for the observer class
 			if ($realClass === $class)
 			{
-				// Add an alias to known aliases
-				$this->aliases[$aliasClass] = $class;
-			}
-			// Check if the observer class is an alias
-			elseif ($aliasClass === $class)
-			{
-				// Add an alias to known aliases
-				$this->aliases[$aliasClass] = $class;
+				$aliasClass = trim($alias['old'], '\\');
 
-				// Set the real class
-				$class = $realClass;
+				// Add an alias to known aliases
+				$this->aliases[$aliasClass] = $class;
 			}
 		}
 


### PR DESCRIPTION
### Summary of Changes

Every observer that have an alias is attached and triggered twice. It started from #17739.
Ping @laoneo 

Example: tags, content history.

I did test on saving existed article. 
After patch there is ~20 queries less.

Tags and ucm_content are updated twice.

To test you can use below dirty patch to display queries from the POST request
```diff
diff --git a/libraries/joomla/database/driver.php b/libraries/joomla/database/driver.php
index f771013380..af6cb8bc74 100644
--- a/libraries/joomla/database/driver.php
+++ b/libraries/joomla/database/driver.php
@@ -78,19 +78,19 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 	 * @var    array  The log of executed SQL statements by the database driver.
 	 * @since  11.1
 	 */
-	protected $log = array();
+	public $log = array();
 
 	/**
 	 * @var    array  The log of executed SQL statements timings (start and stop microtimes) by the database driver.
 	 * @since  CMS 3.1.2
 	 */
-	protected $timings = array();
+	public $timings = array();
 
 	/**
 	 * @var    array  The log of executed SQL statements timings (start and stop microtimes) by the database driver.
 	 * @since  CMS 3.1.2
 	 */
-	protected $callStacks = array();
+	public $callStacks = array();
 
 	/**
 	 * @var    string  The character(s) used to quote SQL statement names such as table names or field names,
diff --git a/libraries/src/Application/WebApplication.php b/libraries/src/Application/WebApplication.php
index afac65dac0..4226c4f627 100644
--- a/libraries/src/Application/WebApplication.php
+++ b/libraries/src/Application/WebApplication.php
@@ -621,9 +621,15 @@ class WebApplication extends BaseApplication
 			}
 		}
 
+		// Trigger the onBeforeRespond event.
+		$this->triggerEvent('onBeforeRespond');
+
 		// Set appropriate headers
 		$this->respond();
 
+		// Trigger the onAfterRespond event.
+		$this->triggerEvent('onAfterRespond');
+
 		//  Close the application after the redirect.
 		$this->close();
 	}
diff --git a/plugins/system/debug/debug.php b/plugins/system/debug/debug.php
index e1989e945a..24b1c420fc 100644
--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -177,6 +177,27 @@ class PlgSystemDebug extends JPlugin
 
 		// Prepare disconnect handler for SQL profiling.
 		$db = $this->db;
+
+		$session = JFactory::getSession();
+
+		if ($session->get('dbLogs'))
+		{
+			$db->log = array_merge($session->get('dbLogs'), $db->log);
+			$session->set('dbLogs', null);
+		}
+
+		if ($session->get('dbTimings'))
+		{
+			$db->timings = array_merge($session->get('dbTimings'), $db->timings);
+			$session->set('dbTimings', null);
+		}
+
+		if ($session->get('dbCallStacks'))
+		{
+			$db->callStacks = array_merge($session->get('dbCallStacks'), $db->callStacks);
+			$session->set('dbCallStacks', null);
+		}
+
 		$db->addDisconnectHandler(array($this, 'mysqlDisconnectHandler'));
 
 		// Log deprecated class aliases
@@ -195,6 +216,14 @@ class PlgSystemDebug extends JPlugin
 		}
 	}
 
+	public function onBeforeRespond() {
+		$session = JFactory::getSession();
+
+		$session->set('dbLogs', $this->db->log);
+		$session->set('dbTimings', $this->db->timings);
+		$session->set('dbCallStacks', $this->db->callStacks);
+	}
+
 	/**
 	 * Add the CSS for debug.
 	 * We can't do this in the constructor because stuff breaks.
@@ -1214,7 +1243,7 @@ class PlgSystemDebug extends JPlugin
 
 		if ($this->totalQueries === 0)
 		{
-			$this->totalQueries = $db->getCount();
+			$this->totalQueries = count($db->getLog());
 		}
 
 		$html = array();
@@ -1485,7 +1514,7 @@ class PlgSystemDebug extends JPlugin
 	{
 		$db->setDebug(false);
 
-		$this->totalQueries = $db->getCount();
+		$this->totalQueries = count($db->getLog());
 
 		$dbVersion5037 = $db->getServerType() === 'mysql' && version_compare($db->getVersion(), '5.0.37', '>=');
 
```