### PR TITLE
Escaping float value should be non-locale aware

### DIFF
--- a/libraries/joomla/database/driver/mysql.php
+++ b/libraries/joomla/database/driver/mysql.php
@@ -138,6 +138,17 @@ class JDatabaseDriverMysql extends JDatabaseDriverMysqli
 	 */
 	public function escape($text, $extra = false)
 	{
+		if (is_int($text))
+		{
+			return $text;
+		}
+
+		if (is_float($text))
+		{
+			// Force the dot as a decimal point.
+			return str_replace(',', '.', $text);
+		}
+
 		$this->connect();
 
 		$result = mysql_real_escape_string($text, $this->getConnection());

--- a/libraries/joomla/database/driver/mysqli.php
+++ b/libraries/joomla/database/driver/mysqli.php
@@ -231,6 +231,17 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 	 */
 	public function escape($text, $extra = false)
 	{
+		if (is_int($text))
+		{
+			return $text;
+		}
+
+		if (is_float($text))
+		{
+			// Force the dot as a decimal point.
+			return str_replace(',', '.', $text);
+		}
+
 		$this->connect();
 
 		$result = mysqli_real_escape_string($this->getConnection(), $text);

--- a/libraries/joomla/database/driver/pdo.php
+++ b/libraries/joomla/database/driver/pdo.php
@@ -341,9 +341,15 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 	 */
 	public function escape($text, $extra = false)
 	{
-		if (is_int($text) || is_float($text))
+		if (is_int($text))
 		{
 			return $text;
+		}
+
+		if (is_float($text))
+		{
+			// Force the dot as a decimal point.
+			return str_replace(',', '.', $text);
 		}
 
 		$text = str_replace("'", "''", $text);

--- a/libraries/joomla/database/driver/pdomysql.php
+++ b/libraries/joomla/database/driver/pdomysql.php
@@ -456,12 +456,18 @@ class JDatabaseDriverPdomysql extends JDatabaseDriverPdo
 	 */
 	public function escape($text, $extra = false)
 	{
-		$this->connect();
-
-		if (is_int($text) || is_float($text))
+		if (is_int($text))
 		{
 			return $text;
 		}
+
+		if (is_float($text))
+		{
+			// Force the dot as a decimal point.
+			return str_replace(',', '.', $text);
+		}
+
+		$this->connect();
 
 		$result = substr($this->connection->quote($text), 1, -1);
 

--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -167,6 +167,17 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 	 */
 	public function escape($text, $extra = false)
 	{
+		if (is_int($text))
+		{
+			return $text;
+		}
+
+		if (is_float($text))
+		{
+			// Force the dot as a decimal point.
+			return str_replace(',', '.', $text);
+		}
+
 		$this->connect();
 
 		$result = pg_escape_string($this->connection, $text);

--- a/libraries/joomla/database/driver/sqlite.php
+++ b/libraries/joomla/database/driver/sqlite.php
@@ -147,9 +147,15 @@ class JDatabaseDriverSqlite extends JDatabaseDriverPdo
 	 */
 	public function escape($text, $extra = false)
 	{
-		if (is_int($text) || is_float($text))
+		if (is_int($text))
 		{
 			return $text;
+		}
+
+		if (is_float($text))
+		{
+			// Force the dot as a decimal point.
+			return str_replace(',', '.', $text);
 		}
 
 		return SQLite3::escapeString($text);

--- a/libraries/joomla/database/driver/sqlsrv.php
+++ b/libraries/joomla/database/driver/sqlsrv.php
@@ -225,6 +225,17 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 	 */
 	public function escape($text, $extra = false)
 	{
+		if (is_int($text))
+		{
+			return $text;
+		}
+
+		if (is_float($text))
+		{
+			// Force the dot as a decimal point.
+			return str_replace(',', '.', $text);
+		}
+
 		$result = str_replace("'", "''", $text);
 
 		// SQL Server does not accept NULL byte in query string

--- a/libraries/joomla/database/query/sqlite.php
+++ b/libraries/joomla/database/query/sqlite.php
@@ -245,7 +245,9 @@ class JDatabaseQuerySqlite extends JDatabaseQueryPdo implements JDatabaseQueryPr
 		// SQLite does not support microseconds as a separate unit. Convert the interval to seconds
 		if (strcasecmp($datePart, 'microseconds') == 0)
 		{
-			$interval = .001 * $interval;
+			// Force the dot as a decimal point
+			$interval = str_replace(',', '.', .001 * $interval);
+
 			$datePart = 'seconds';
 		}
 

--- a/tests/unit/suites/database/driver/mysql/JDatabaseDriverMysqlTest.php
+++ b/tests/unit/suites/database/driver/mysql/JDatabaseDriverMysqlTest.php
@@ -27,7 +27,9 @@ class JDatabaseDriverMysqlTest extends TestCaseDatabaseMysql
 	{
 		return array(
 			array("'%_abc123", false, '\\\'%_abc123'),
-			array("'%_abc123", true, '\\\'\\%\_abc123')
+			array("'%_abc123", true, '\\\'\\%\_abc123'),
+			array(3, false, 3),
+			array(3.14, false, '3.14'),
 		);
 	}
 
@@ -140,6 +142,39 @@ class JDatabaseDriverMysqlTest extends TestCaseDatabaseMysql
 	public function testEscape($text, $extra, $expected)
 	{
 		$this->assertSame($expected, self::$driver->escape($text, $extra), 'The string was not escaped properly');
+	}
+
+	/**
+	 * Tests the escape method 2.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testEscapeNonLocaleAware()
+	{
+		$origin = setLocale(LC_NUMERIC, 0);
+
+		// Test with decimal_point equals to comma
+		setLocale(LC_NUMERIC, 'pl_PL');
+
+		$this->assertThat(
+			self::$driver->escape(3.14),
+			$this->equalTo('3.14'),
+			'The string was not escaped properly'
+		);
+
+		// Test with C locale
+		setLocale(LC_NUMERIC, 'C');
+
+		$this->assertThat(
+			self::$driver->escape(3.14),
+			$this->equalTo('3.14'),
+			'The string was not escaped properly'
+		);
+
+		// Revert to origin locale
+		setLocale(LC_NUMERIC, $origin);
 	}
 
 	/**

--- a/tests/unit/suites/database/driver/mysqli/JDatabaseDriverMysqliTest.php
+++ b/tests/unit/suites/database/driver/mysqli/JDatabaseDriverMysqliTest.php
@@ -27,7 +27,9 @@ class JDatabaseDriverMysqliTest extends TestCaseDatabaseMysqli
 	{
 		return array(
 			array("'%_abc123", false, '\\\'%_abc123'),
-			array("'%_abc123", true, '\\\'\\%\_abc123')
+			array("'%_abc123", true, '\\\'\\%\_abc123'),
+			array(3, false, 3),
+			array(3.14, false, '3.14'),
 		);
 	}
 
@@ -140,6 +142,39 @@ class JDatabaseDriverMysqliTest extends TestCaseDatabaseMysqli
 	public function testEscape($text, $extra, $expected)
 	{
 		$this->assertThat(self::$driver->escape($text, $extra), $this->equalTo($expected), 'The string was not escaped properly');
+	}
+
+	/**
+	 * Tests the escape method 2.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testEscapeNonLocaleAware()
+	{
+		$origin = setLocale(LC_NUMERIC, 0);
+
+		// Test with decimal_point equals to comma
+		setLocale(LC_NUMERIC, 'pl_PL');
+
+		$this->assertThat(
+			self::$driver->escape(3.14),
+			$this->equalTo('3.14'),
+			'The string was not escaped properly'
+		);
+
+		// Test with C locale
+		setLocale(LC_NUMERIC, 'C');
+
+		$this->assertThat(
+			self::$driver->escape(3.14),
+			$this->equalTo('3.14'),
+			'The string was not escaped properly'
+		);
+
+		// Revert to origin locale
+		setLocale(LC_NUMERIC, $origin);
 	}
 
 	/**

--- a/tests/unit/suites/database/driver/pdomysql/JDatabaseDriverPdomysqlTest.php
+++ b/tests/unit/suites/database/driver/pdomysql/JDatabaseDriverPdomysqlTest.php
@@ -27,7 +27,9 @@ class JDatabaseDriverPdomysqlTest extends TestCaseDatabasePdomysql
 	{
 		return array(
 			array("'%_abc123", false, '\\\'%_abc123'),
-			array("'%_abc123", true, '\\\'\\%\_abc123')
+			array("'%_abc123", true, '\\\'\\%\_abc123'),
+			array(3, false, 3),
+			array(3.14, false, '3.14'),
 		);
 	}
 
@@ -129,6 +131,39 @@ class JDatabaseDriverPdomysqlTest extends TestCaseDatabasePdomysql
 			$this->equalTo($expected),
 			'The string was not escaped properly'
 		);
+	}
+
+	/**
+	 * Tests the escape method 2.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testEscapeNonLocaleAware()
+	{
+		$origin = setLocale(LC_NUMERIC, 0);
+
+		// Test with decimal_point equals to comma
+		setLocale(LC_NUMERIC, 'pl_PL');
+
+		$this->assertThat(
+			self::$driver->escape(3.14),
+			$this->equalTo('3.14'),
+			'The string was not escaped properly'
+		);
+
+		// Test with C locale
+		setLocale(LC_NUMERIC, 'C');
+
+		$this->assertThat(
+			self::$driver->escape(3.14),
+			$this->equalTo('3.14'),
+			'The string was not escaped properly'
+		);
+
+		// Revert to origin locale
+		setLocale(LC_NUMERIC, $origin);
 	}
 
 	/**

--- a/tests/unit/suites/database/driver/postgresql/JDatabaseDriverPostgresqlTest.php
+++ b/tests/unit/suites/database/driver/postgresql/JDatabaseDriverPostgresqlTest.php
@@ -31,24 +31,10 @@ class JDatabaseDriverPostgresqlTest extends TestCaseDatabasePostgresql
 
 			// ' and \ will be escaped: the first become '', the latter \\
 			array("\'%_abc123", false, '\\\\\'\'%_abc123'),
-			array("\'%_abc123", true, '\\\\\'\'\%\_abc123'));
-	}
-
-	/**
-	 * Data for the testGetEscaped test, proxies of escape, so same data test.
-	 *
-	 * @return  array
-	 *
-	 * @since   11.3
-	 */
-	public function dataTestGetEscaped()
-	{
-		return array(
-			// ' will be escaped and become ''
-			array("'%_abc123", false), array("'%_abc123", true),
-
-			// ' and \ will be escaped: the first become '', the latter \\
-			array("\'%_abc123", false), array("\'%_abc123", true));
+			array("\'%_abc123", true, '\\\\\'\'\%\_abc123'),
+			array(3, false, 3),
+			array(3.14, false, '3.14'),
+		);
 	}
 
 	/**
@@ -241,6 +227,39 @@ class JDatabaseDriverPostgresqlTest extends TestCaseDatabasePostgresql
 	public function testEscape($text, $extra, $result)
 	{
 		$this->assertEquals($result, self::$driver->escape($text, $extra), 'The string was not escaped properly');
+	}
+
+	/**
+	 * Tests the escape method 2.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testEscapeNonLocaleAware()
+	{
+		$origin = setLocale(LC_NUMERIC, 0);
+
+		// Test with decimal_point equals to comma
+		setLocale(LC_NUMERIC, 'pl_PL');
+
+		$this->assertThat(
+			self::$driver->escape(3.14),
+			$this->equalTo('3.14'),
+			'The string was not escaped properly'
+		);
+
+		// Test with C locale
+		setLocale(LC_NUMERIC, 'C');
+
+		$this->assertThat(
+			self::$driver->escape(3.14),
+			$this->equalTo('3.14'),
+			'The string was not escaped properly'
+		);
+
+		// Revert to origin locale
+		setLocale(LC_NUMERIC, $origin);
 	}
 
 	/**

--- a/tests/unit/suites/database/driver/sqlsrv/JDatabaseDriverSqlsrvTest.php
+++ b/tests/unit/suites/database/driver/sqlsrv/JDatabaseDriverSqlsrvTest.php
@@ -28,6 +28,8 @@ class JDatabaseDriverSqlsrvTest extends TestCaseDatabaseSqlsrv
 			array("'%_abc123[]", false, "''%_abc123[]"),
 			array("'%_abc123[]", true, "''[%][_]abc123[[]]"),
 			array("binary\000data", false, "binary' + CHAR(0) + N'data"),
+			array(3, false, 3),
+			array(3.14, false, '3.14'),
 		);
 	}
 
@@ -82,6 +84,39 @@ class JDatabaseDriverSqlsrvTest extends TestCaseDatabaseSqlsrv
 			$this->equalTo($expected),
 			'The string was not escaped properly'
 		);
+	}
+
+	/**
+	 * Tests the escape method 2.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testEscapeNonLocaleAware()
+	{
+		$origin = setLocale(LC_NUMERIC, 0);
+
+		// Test with decimal_point equals to comma
+		setLocale(LC_NUMERIC, 'pl_PL');
+
+		$this->assertThat(
+			self::$driver->escape(3.14),
+			$this->equalTo('3.14'),
+			'The string was not escaped properly'
+		);
+
+		// Test with C locale
+		setLocale(LC_NUMERIC, 'C');
+
+		$this->assertThat(
+			self::$driver->escape(3.14),
+			$this->equalTo('3.14'),
+			'The string was not escaped properly'
+		);
+
+		// Revert to origin locale
+		setLocale(LC_NUMERIC, $origin);
 	}
 
 	/**

--- a/tests/unit/suites/libraries/joomla/database/JDatabaseDriverTest.php
+++ b/tests/unit/suites/libraries/joomla/database/JDatabaseDriverTest.php
@@ -445,9 +445,11 @@ class JDatabaseDriverTest extends TestCaseDatabase
 	 */
 	public function testQuoteFloat()
 	{
+		// This call `escape()` method from nosqldriver, which is locale aware
 		$this->assertThat(
+			// Below line may generate "'-3.14-'" or "'-3,14-'"
 			$this->db->quote(3.14),
-			$this->equalTo("'-3.14-'"),
+			$this->equalTo("'-" . 3.14 . "-'"),
 			'Tests handling of float with escaping (default).'
 		);
 	}


### PR DESCRIPTION
Pull Request for Issue #17114 and PR #17345

### Summary of Changes
Correctly escape the float value and always use the dot as a decimal point.
This is a copy of https://github.com/joomla-framework/database/pull/127


### Testing Instructions
Take a look at https://github.com/joomla/joomla-cms/issues/17114

Phpunit tested it successfully.
Merge by code review.