### PR TITLE
[CS] fix some doc comment types (round 2)

### DIFF
--- a/administrator/components/com_finder/helpers/indexer/adapter.php
+++ b/administrator/components/com_finder/helpers/indexer/adapter.php
@@ -125,8 +125,8 @@ abstract class FinderIndexerAdapter extends JPlugin
 	/**
 	 * Method to instantiate the indexer adapter.
 	 *
-	 * @param   object  $subject   The object to observe.
-	 * @param   array   $config    An array that holds the plugin configuration.
+	 * @param   object  $subject  The object to observe.
+	 * @param   array   $config   An array that holds the plugin configuration.
 	 *
 	 * @since   2.5
 	 */

--- a/administrator/components/com_finder/helpers/indexer/adapter.php
+++ b/administrator/components/com_finder/helpers/indexer/adapter.php
@@ -125,7 +125,7 @@ abstract class FinderIndexerAdapter extends JPlugin
 	/**
 	 * Method to instantiate the indexer adapter.
 	 *
-	 * @param   object  &$subject  The object to observe.
+	 * @param   object  $subject   The object to observe.
 	 * @param   array   $config    An array that holds the plugin configuration.
 	 *
 	 * @since   2.5

--- a/administrator/components/com_finder/helpers/indexer/helper.php
+++ b/administrator/components/com_finder/helpers/indexer/helper.php
@@ -443,7 +443,7 @@ class FinderIndexerHelper
 	 * Method to get extra data for a content before being indexed. This is how
 	 * we add Comments, Tags, Labels, etc. that should be available to Finder.
 	 *
-	 * @param   FinderIndexerResult  &$item  The item to index as a FinderIndexerResult object.
+	 * @param   FinderIndexerResult  $item  The item to index as a FinderIndexerResult object.
 	 *
 	 * @return  boolean  True on success, false on failure.
 	 *

--- a/administrator/components/com_finder/helpers/indexer/query.php
+++ b/administrator/components/com_finder/helpers/indexer/query.php
@@ -244,9 +244,8 @@ class FinderIndexerQuery
 		// Remove the temporary date storage.
 		unset($this->dates);
 
-		/*
-		 * Lastly, determine whether this query can return a result set.
-		 */
+		// Lastly, determine whether this query can return a result set.
+
 		// Check if we have a query string.
 		if (!empty($this->input))
 		{

--- a/administrator/components/com_finder/helpers/indexer/stemmer/porter_en.php
+++ b/administrator/components/com_finder/helpers/indexer/stemmer/porter_en.php
@@ -350,7 +350,7 @@ class FinderIndexerStemmerPorter_En extends FinderIndexerStemmer
 	 * Replaces the first string with the second, at the end of the string. If third
 	 * arg is given, then the preceding string must match that m count at least.
 	 *
-	 * @param   string   &$str   String to check
+	 * @param   string   $str    String to check
 	 * @param   string   $check  Ending to check for
 	 * @param   string   $repl   Replacement string
 	 * @param   integer  $m      Optional minimum number of m() to meet

--- a/administrator/components/com_finder/models/index.php
+++ b/administrator/components/com_finder/models/index.php
@@ -89,7 +89,7 @@ class FinderModelIndex extends JModelList
 	/**
 	 * Method to delete one or more records.
 	 *
-	 * @param   array  &$pks  An array of record primary keys.
+	 * @param   array  $pks  An array of record primary keys.
 	 *
 	 * @return  boolean  True if successful, false if an error occurs.
 	 *
@@ -395,7 +395,7 @@ class FinderModelIndex extends JModelList
 	/**
 	 * Method to change the published state of one or more records.
 	 *
-	 * @param   array    &$pks   A list of the primary keys to change.
+	 * @param   array    $pks    A list of the primary keys to change.
 	 * @param   integer  $value  The value of the published state. [optional]
 	 *
 	 * @return  boolean  True on success.

--- a/administrator/components/com_finder/models/maps.php
+++ b/administrator/components/com_finder/models/maps.php
@@ -71,7 +71,7 @@ class FinderModelMaps extends JModelList
 	/**
 	 * Method to delete one or more records.
 	 *
-	 * @param   array  &$pks  An array of record primary keys.
+	 * @param   array  $pks  An array of record primary keys.
 	 *
 	 * @return  boolean  True if successful, false if an error occurs.
 	 *
@@ -323,7 +323,7 @@ class FinderModelMaps extends JModelList
 	/**
 	 * Method to change the published state of one or more records.
 	 *
-	 * @param   array    &$pks   A list of the primary keys to change.
+	 * @param   array    $pks    A list of the primary keys to change.
 	 * @param   integer  $value  The value of the published state. [optional]
 	 *
 	 * @return  boolean  True on success.

--- a/administrator/components/com_finder/tables/filter.php
+++ b/administrator/components/com_finder/tables/filter.php
@@ -22,7 +22,7 @@ class FinderTableFilter extends JTable
 	/**
 	 * Constructor
 	 *
-	 * @param   JDatabaseDriver  &$db  JDatabaseDriver connector object.
+	 * @param   JDatabaseDriver  $db  JDatabaseDriver connector object.
 	 *
 	 * @since   2.5
 	 */

--- a/administrator/components/com_finder/tables/link.php
+++ b/administrator/components/com_finder/tables/link.php
@@ -19,7 +19,7 @@ class FinderTableLink extends JTable
 	/**
 	 * Constructor
 	 *
-	 * @param   JDatabaseDriver  &$db  JDatabaseDriver connector object.
+	 * @param   JDatabaseDriver  $db  JDatabaseDriver connector object.
 	 *
 	 * @since   2.5
 	 */

--- a/administrator/components/com_finder/tables/map.php
+++ b/administrator/components/com_finder/tables/map.php
@@ -21,7 +21,7 @@ class FinderTableMap extends JTable
 	/**
 	 * Constructor
 	 *
-	 * @param   JDatabaseDriver  &$db  JDatabaseDriver connector object.
+	 * @param   JDatabaseDriver  $db  JDatabaseDriver connector object.
 	 *
 	 * @since   2.5
 	 */

--- a/administrator/components/com_installer/models/extension.php
+++ b/administrator/components/com_installer/models/extension.php
@@ -137,7 +137,7 @@ class InstallerModel extends JModelList
 	/**
 	 * Translate a list of objects
 	 *
-	 * @param   array  &$items  The array of objects
+	 * @param   array  $items  The array of objects
 	 *
 	 * @return  array The array of translated objects
 	 */

--- a/administrator/components/com_installer/models/manage.php
+++ b/administrator/components/com_installer/models/manage.php
@@ -79,7 +79,7 @@ class InstallerModelManage extends InstallerModel
 	/**
 	 * Enable/Disable an extension.
 	 *
-	 * @param   array  &$eid   Extension ids to un/publish
+	 * @param   array  $eid    Extension ids to un/publish
 	 * @param   int    $value  Publish value
 	 *
 	 * @return  boolean  True on success

--- a/administrator/components/com_installer/models/update.php
+++ b/administrator/components/com_installer/models/update.php
@@ -154,7 +154,7 @@ class InstallerModelUpdate extends JModelList
 	/**
 	 * Translate a list of objects
 	 *
-	 * @param   array  &$items  The array of objects
+	 * @param   array  $items  The array of objects
 	 *
 	 * @return  array The array of translated objects
 	 *

--- a/administrator/components/com_installer/models/updatesites.php
+++ b/administrator/components/com_installer/models/updatesites.php
@@ -73,7 +73,7 @@ class InstallerModelUpdatesites extends InstallerModel
 	/**
 	 * Enable/Disable an extension.
 	 *
-	 * @param   array  &$eid   Extension ids to un/publish
+	 * @param   array  $eid    Extension ids to un/publish
 	 * @param   int    $value  Publish value
 	 *
 	 * @return  boolean  True on success

--- a/administrator/components/com_menus/helpers/menus.php
+++ b/administrator/components/com_menus/helpers/menus.php
@@ -430,7 +430,7 @@ class MenusHelper
 	/**
 	 * Method to install a preset menu item into database and link it to the given menutype
 	 *
-	 * @param   stdClass[]  &$items    The single menuitem instance with a list of its descendants
+	 * @param   stdClass[]  $items     The single menuitem instance with a list of its descendants
 	 * @param   string      $menutype  The target menutype
 	 * @param   int         $parent    The parent id or object
 	 *

--- a/administrator/components/com_menus/models/item.php
+++ b/administrator/components/com_menus/models/item.php
@@ -1596,7 +1596,7 @@ class MenusModelItem extends JModelAdmin
 	/**
 	 * Method to change the home state of one or more items.
 	 *
-	 * @param   array    &$pks   A list of the primary keys to change.
+	 * @param   array    $pks    A list of the primary keys to change.
 	 * @param   integer  $value  The value of the home state.
 	 *
 	 * @return  boolean  True on success.
@@ -1683,7 +1683,7 @@ class MenusModelItem extends JModelAdmin
 	/**
 	 * Method to change the published state of one or more records.
 	 *
-	 * @param   array    &$pks   A list of the primary keys to change.
+	 * @param   array    $pks    A list of the primary keys to change.
 	 * @param   integer  $value  The value of the published state.
 	 *
 	 * @return  boolean  True on success.

--- a/administrator/components/com_menus/views/menutypes/view.html.php
+++ b/administrator/components/com_menus/views/menutypes/view.html.php
@@ -89,7 +89,7 @@ class MenusViewMenutypes extends JViewLegacy
 	/**
 	 * Method to add system link types to the link types array
 	 *
-	 * @param   array  &$types  The list of link types
+	 * @param   array  $types  The list of link types
 	 *
 	 * @return  void
 	 *

--- a/build/phpcs/Joomla/ruleset.xml
+++ b/build/phpcs/Joomla/ruleset.xml
@@ -157,6 +157,13 @@
 		<exclude-pattern type="relative">templates/*</exclude-pattern>
 		<exclude-pattern type="relative">layouts/*</exclude-pattern>
 		<exclude-pattern type="relative">tests/*</exclude-pattern>
+	</rule>
+
+	<rule ref="Joomla.Commenting.FunctionComment.MissingParamTag">
+		<exclude-pattern type="relative">administrator/components/*</exclude-pattern>
+	</rule>
+
+	<rule ref="Joomla.Commenting.FunctionComment.ParamNameNoMatch">
 		<exclude-pattern type="relative">administrator/components/*</exclude-pattern>
 	</rule>
 


### PR DESCRIPTION
Pull Request for Issue code style corrections for doc comment types. continues work from #20522

### Summary of Changes
PHPCS2 manual fixes
- Variables passed by reference should not have the `&` prefixed in the doc comment
  - Joomla.Commenting.FunctionComment.MissingParamTag
  - Joomla.Commenting.FunctionComment.ParamNameNoMatch
  - Doc comment for a parameter does not match the actual variable name
- Comment closer must be on a new line
  - just convert to single line comment
- be more specific with the PHPCS rules we want to exclude

[Found using the Joomla code standards 2.0.0 PHPCS2-RC](https://github.com/joomla/coding-standards/releases/tag/2.0.0-rc)

### Testing Instructions
Merge by code review

### Expected result
code style has been applied as listed above, old code style testing on drone does not error.

### Actual result
code style had not been applied. [Found using the Joomla code standards 2.0.0 PHPCS2-RC](https://github.com/joomla/coding-standards/releases/tag/2.0.0-rc)


### Documentation Changes Required
none