### PR TITLE
[com_tags] Image caption in Tags view

### DIFF
--- a/components/com_tags/views/tags/tmpl/default_items.php
+++ b/components/com_tags/views/tags/tmpl/default_items.php
@@ -11,6 +11,7 @@ defined('_JEXEC') or die;
 
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers');
 
+JHtml::_('behavior.caption');
 JHtml::_('behavior.core');
 JHtml::_('formbehavior.chosen', 'select');
 


### PR DESCRIPTION
Pull Request for Issue #14636.

### Summary of Changes

This loads caption.js in Tags view so teaser image caption displays properly.

### Testing Instructions

Create a tag, add teaser image and caption.
Create `List of all tags` menu item, set `Item Images` to `Show`.
Open the menu item in frontend.

### Expected result

Caption appears under image.

### Actual result

Caption does not appear.

### Documentation Changes Required
No.