### PR TITLE
[4.0] Register the correct templates component class in the container

### DIFF
--- a/administrator/components/com_modules/Service/HTML/Modules.php
+++ b/administrator/components/com_modules/Service/HTML/Modules.php
@@ -144,8 +144,6 @@ class Modules
 	 */
 	public function positions($clientId, $state = 1, $selectedPosition = '')
 	{
-		\JLoader::register('TemplatesHelper', JPATH_ADMINISTRATOR . '/components/com_templates/helpers/templates.php');
-
 		$templates      = array_keys(ModulesHelper::getTemplates($clientId, $state));
 		$templateGroups = array();
 

--- a/administrator/components/com_modules/tmpl/module/edit_positions.php
+++ b/administrator/components/com_modules/tmpl/module/edit_positions.php
@@ -9,13 +9,10 @@
 
 defined('_JEXEC') or die;
 
-JLoader::register('TemplatesHelper', JPATH_ADMINISTRATOR . '/components/com_templates/helpers/templates.php');
-
-JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
-$clientId       = $this->item->client_id;
-$state          = 1;
+$clientId         = $this->item->client_id;
+$state            = 1;
 $selectedPosition = $this->item->position;
-$positions = JHtml::_('modules.positions', $clientId, $state, $selectedPosition);
+$positions        = JHtml::_('modules.positions', $clientId, $state, $selectedPosition);
 
 // Add custom position to options
 $customGroupText = JText::_('COM_MODULES_CUSTOM_POSITION');

--- a/administrator/components/com_templates/helpers/template.php
+++ b/administrator/components/com_templates/helpers/template.php
@@ -18,5 +18,4 @@ defined('_JEXEC') or die;
  */
 abstract class TemplateHelper extends \Joomla\Component\Templates\Administrator\Helper\TemplateHelper
 {
-
 }

--- a/administrator/components/com_templates/helpers/templates.php
+++ b/administrator/components/com_templates/helpers/templates.php
@@ -18,5 +18,4 @@ defined('_JEXEC') or die;
  */
 class TemplatesHelper extends \Joomla\Component\Templates\Administrator\Helper\TemplatesHelper
 {
-
 }

--- a/administrator/components/com_templates/services/provider.php
+++ b/administrator/components/com_templates/services/provider.php
@@ -11,10 +11,11 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Dispatcher\DispatcherFactoryInterface;
 use Joomla\CMS\Extension\ComponentInterface;
-use Joomla\CMS\Extension\MVCComponent;
 use Joomla\CMS\Extension\Service\Provider\DispatcherFactory;
 use Joomla\CMS\Extension\Service\Provider\MVCFactoryFactory;
+use Joomla\CMS\HTML\Registry;
 use Joomla\CMS\MVC\Factory\MVCFactoryFactoryInterface;
+use Joomla\Component\Templates\Administrator\Extension\TemplatesComponent;
 use Joomla\DI\Container;
 use Joomla\DI\ServiceProviderInterface;
 
@@ -43,9 +44,10 @@ return new class implements ServiceProviderInterface
 			ComponentInterface::class,
 			function (Container $container)
 			{
-				$component = new MVCComponent($container->get(DispatcherFactoryInterface::class));
+				$component = new TemplatesComponent($container->get(DispatcherFactoryInterface::class));
 
 				$component->setMvcFactoryFactory($container->get(MVCFactoryFactoryInterface::class));
+				$component->setRegistry($container->get(Registry::class));
 
 				return $component;
 			}

--- a/administrator/components/com_templates/tmpl/template/default_description.php
+++ b/administrator/components/com_templates/tmpl/template/default_description.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Application\ApplicationHelper;
+use \Joomla\Component\Templates\Administrator\Helper\TemplatesHelper;
 ?>
 
 <div class="clearfix">


### PR DESCRIPTION
Pull Request for Issue #20645.

### Summary of Changes
Registers the correct component class in the templates DI container.

### Testing Instructions
Open Extensions -> Templates -> Templates.

### Expected result
List of templates is shown.

### Actual result
Error: _JHtml templates not found._