### PR TITLE
Default installation value in configuration.php-dist

### DIFF
--- a/installation/configuration.php-dist
+++ b/installation/configuration.php-dist
@@ -61,7 +61,6 @@ class JConfig
 	public $live_site = '';                   // Optional, full URL to Joomla install.
 	public $force_ssl = 0;                    // Force areas of the site to be SSL ONLY.  0 = None, 1 = Administrator, 2 = Both Site and Administrator
 
-	public $log_path = 'C:\\htdocs\\cms4\\administrator/logs';
 	/* Locale Settings */
 	public $offset = 'UTC';
 

--- a/installation/configuration.php-dist
+++ b/installation/configuration.php-dist
@@ -56,11 +56,12 @@ class JConfig
 	public $ftp_pass = '';
 	public $ftp_root = '';
 	public $ftp_enable = '0';
-	public $tmp_path = '/tmp';                // Please check with your host that this is the correct path to the temp directory. This path needs to be writable by Joomla!
-	public $log_path = '/var/logs';           // Please check with your host that this is the correct path to the logs directory. This path needs to be writable by Joomla!
+	public $tmp_path = '/tmp';                // This path needs to be writable by Joomla!
+	public $log_path = '/administrator/logs'; // This path needs to be writable by Joomla!
 	public $live_site = '';                   // Optional, full URL to Joomla install.
 	public $force_ssl = 0;                    // Force areas of the site to be SSL ONLY.  0 = None, 1 = Administrator, 2 = Both Site and Administrator
 
+	public $log_path = 'C:\\htdocs\\cms4\\administrator/logs';
 	/* Locale Settings */
 	public $offset = 'UTC';
 


### PR DESCRIPTION
The config file to use in manual installs has incorrect advice and paths for tmp and logs as they are referring to server paths and not paths within a joomla installation