### PR TITLE
[4.0] Use navbar-nav class for menus, remove flex-column

### DIFF
--- a/modules/mod_menu/tmpl/default.php
+++ b/modules/mod_menu/tmpl/default.php
@@ -18,9 +18,9 @@ if ($tagId = $params->get('tag_id', ''))
 	$id = ' id="' . $tagId . '"';
 }
 
-// The menu class is deprecated. Use nav instead
+// The menu class is deprecated. Use navbar-nav instead
 ?>
-<ul<?php echo $id; ?> class="nav flex-column <?php echo $class_sfx; ?>">
+<ul<?php echo $id; ?> class="navbar-nav <?php echo $class_sfx; ?>">
 <?php foreach ($list as $i => &$item)
 {
 	$class = 'nav-item';


### PR DESCRIPTION
Use navbar-nav class for menus and don't use flex-column for Bootstrap 4 menus.

Pull Request for Issue # ?.

### Summary of Changes

This Pull Request (PR) changes the default template of `mod_menu` so the `ul` item's class is `navbar-nav` instead of `nav`, and the `flex-column` class is removed from that item.

The `flex-column` class made it impossible to get horizontal menus, see picture in section "Actual result" below.

After removing the flex-column` class, the menu still does not look like on the template's preview picture when using the default Cassiopeia template, see following picture:
![intermediate](https://user-images.githubusercontent.com/7413183/40909823-db92b0e0-67ea-11e8-9362-338191cbe56b.png)

After changing class `nav` to `navbar-nav`, the menu looks like on the template's preview, see picture in section "Expected result" below.

The changes of this PR make the navbar's html fit to the description on 
[https://www.w3schools.com/bootstrap4/bootstrap_navbar.asp](https://www.w3schools.com/bootstrap4/bootstrap_navbar.asp "Bootstrap 4 navbar doc at w3schools").

### Testing Instructions

Use current 4.0-dev branch with the default Cassiopeia frontent template and have a menu in module position `menu` which should be shown in horizontal direction, and some other menus in some side position shown in vertical direction.

I used blog testing data and moved the "Main Menu Blog" module to the `menu` position. In the module's advanced setting there is no class suffix defined for the module or the menu.

Check that the menu at the `menu` position (left beside the search box) is shown as expected with this PR applied.

Check that the look of all other things on the page has not changed after applying this PR.

Check with your browser's developer tools that the navbar's html fits to what is described on 
[https://www.w3schools.com/bootstrap4/bootstrap_navbar.asp](https://www.w3schools.com/bootstrap4/bootstrap_navbar.asp "Bootstrap 4 navbar doc at w3schools").


### Expected result

See following picture with the menu marked with a red ellipse:
![after](https://user-images.githubusercontent.com/7413183/40909066-f127951c-67e8-11e8-91e5-9d2377683874.png)


### Actual result

See following picture with the menu marked with a red ellipse:
![before](https://user-images.githubusercontent.com/7413183/40909073-f670d024-67e8-11e8-83f0-6f342e12b1db.png)


### Documentation Changes Required

None.