### PR TITLE
[fix] Error decoding JSON data: Syntax error

### DIFF
--- a/libraries/src/User/User.php
+++ b/libraries/src/User/User.php
@@ -896,7 +896,10 @@ class User extends \JObject
 		 * user parameters, but for right now we'll leave it how it is.
 		 */
 
-		$this->_params->loadString($table->params);
+		if ($table->params)
+		{
+			$this->_params->loadString($table->params);
+		}
 
 		// Assuming all is well at this point let's bind the data
 		$this->setProperties($table->getProperties());

--- a/tests/unit/stubs/database/jos_users.csv
+++ b/tests/unit/stubs/database/jos_users.csv
@@ -4,3 +4,4 @@
 '44','Manager','manager','manager@example.com','b69eafa62e549e5fa875e127fadc3c83:VapLaQZx00iYDRwgMjgsfyIHgoe01DK8','0','1','2010-02-13 00:34:42','2010-02-13 00:34:42','0','{}','0000-00-00 00:00:00','0'
 '99','Test','test','test@example.com','b69eafa62e549e5fa875e127fadc3c83:VapLaQZx00iYDRwgMjgsfyIHgoe01DK8','0','1','2010-02-13 00:34:42','2010-02-13 00:34:42','0','{}','0000-00-00 00:00:00','0'
 '100','Activate','activate','activate@example.com','b69eafa62e549e5fa875e127fadc3c83:VapLaQZx00iYDRwgMjgsfyIHgoe01DK8','1','1','2010-02-13 00:34:42','0000-00-00 00:00:00','30cc6de70fb18231196a28dd83363d57','{}','0000-00-00 00:00:00','0'
+'101','Empty params','empty-params','empty-params@example.com','b69eafa62e549e5fa875e127fadc3c83:VapLaQZx00iYDRwgMjgsfyIHgoe01DK8','1','1','2010-02-13 00:34:42','0000-00-00 00:00:00','30cc6de70fb18231196a28dd83363d57','','0000-00-00 00:00:00','0'

--- a/tests/unit/suites/libraries/joomla/user/JUserTest.php
+++ b/tests/unit/suites/libraries/joomla/user/JUserTest.php
@@ -397,6 +397,11 @@ class JUserTest extends TestCaseDatabase
 				true,
 				false
 			),
+			'empty-params' => array(
+				101,
+				true,
+				false
+			),
 			'existing-but-guest' => array(
 				0,
 				false,


### PR DESCRIPTION
### Summary of Changes

Using latest staging after installation you cannot login into backend because an error message appears:

`Error decoding JSON data: Syntax error`

This is caused because db `params` column is empty which fails when trying to load as json. 

This seems to be already fixed in v4 branch. I just backported it.

### Testing Instructions

Install latest staging version and try to login into backend.

### Expected result

User gets logged in.

### Actual result

An error message appears:

`Error decoding JSON data: Syntax error`

### Documentation Changes Required

Nein