### PR TITLE
Display 404 page when tracking clicks of a non-existing banner

### DIFF
--- a/components/com_banners/models/banner.php
+++ b/components/com_banners/models/banner.php
@@ -35,6 +35,13 @@ class BannersModelBanner extends JModelLegacy
 	 */
 	public function click()
 	{
+		$item = $this->getItem();
+
+		if (empty($item))
+		{
+			throw new Exception(JText::_('JERROR_PAGE_NOT_FOUND'), 404);
+		}
+
 		$id = $this->getState('banner.id');
 
 		// Update click count
@@ -54,8 +61,6 @@ class BannersModelBanner extends JModelLegacy
 		{
 			JError::raiseError(500, $e->getMessage());
 		}
-
-		$item = $this->getItem();
 
 		// Track clicks
 		$trackClicks = $item->track_clicks;


### PR DESCRIPTION
Pull Request for Issue #20325.

### Summary of Changes
When tracking clicks of a deleted/non existent banner ID, the redirect URL is `http://` which causes browser error. This PR checks that the banner ID is valid and if not, display a 404 page.


### Testing Instructions
On the front end, enter the following URL `index.php/component/banners/click/123`


### Expected result
Display a 404 page


### Actual result
Error message generated by the browser regarding broken contents. The return HTTP status is 303 with header Location: http://

In PHP error log:
> PHP Notice:  Trying to get property 'track_clicks' of non-object in \components\com_banners\models\banner.php on line 61
> PHP Notice:  Trying to get property 'clickurl' of non-object in \components\com_banners\models\banner.php on line 197


### Documentation Changes Required
none
