### PR TITLE
[3.9] Allow to lock more tables in JDatabaseDriver::lockTable() method

### DIFF
--- a/libraries/joomla/database/driver.php
+++ b/libraries/joomla/database/driver.php
@@ -1823,16 +1823,16 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 	}
 
 	/**
-	 * Locks a table in the database.
+	 * Locks one or more tables in the database.
 	 *
-	 * @param   string  $tableName  The name of the table to unlock.
+	 * @param   array|string  $tableNames  The table name or names to lock.
 	 *
 	 * @return  JDatabaseDriver     Returns this object to support chaining.
 	 *
 	 * @since   11.4
 	 * @throws  RuntimeException
 	 */
-	abstract public function lockTable($tableName);
+	abstract public function lockTable($tableNames);
 
 	/**
 	 * Quotes and optionally escapes a string to database requirements for use in database queries.

--- a/libraries/joomla/database/driver/mysqli.php
+++ b/libraries/joomla/database/driver/mysqli.php
@@ -519,18 +519,19 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 	}
 
 	/**
-	 * Locks a table in the database.
+	 * Locks one or more tables in the database.
 	 *
-	 * @param   string  $table  The name of the table to unlock.
+	 * @param   array|string  $tableNames  The table name or names to lock.
 	 *
 	 * @return  JDatabaseDriverMysqli  Returns this object to support chaining.
 	 *
 	 * @since   12.2
 	 * @throws  RuntimeException
 	 */
-	public function lockTable($table)
+	public function lockTable($tableNames)
 	{
-		$this->setQuery('LOCK TABLES ' . $this->quoteName($table) . ' WRITE')->execute();
+		$sql = 'LOCK TABLES ' . implode(' WRITE, ', $this->quoteName((array) $tableNames)) . ' WRITE';
+		$this->setQuery($sql)->execute();
 
 		return $this;
 	}

--- a/libraries/joomla/database/driver/oracle.php
+++ b/libraries/joomla/database/driver/oracle.php
@@ -460,18 +460,20 @@ class JDatabaseDriverOracle extends JDatabaseDriverPdo
 	}
 
 	/**
-	 * Locks a table in the database.
+	 * Locks one or more tables in the database.
 	 *
-	 * @param   string  $table  The name of the table to unlock.
+	 * @param   array|string  $tableNames  The table name or names to lock.
 	 *
 	 * @return  JDatabaseDriverOracle  Returns this object to support chaining.
 	 *
 	 * @since   12.1
 	 * @throws  RuntimeException
 	 */
-	public function lockTable($table)
+	public function lockTable($tableNames)
 	{
-		$this->setQuery('LOCK TABLE ' . $this->quoteName($table) . ' IN EXCLUSIVE MODE')->execute();
+		$this->transactionStart();
+		$sql = 'LOCK TABLE ' . implode(', ', $this->quoteName((array) $tableNames)) . ' IN EXCLUSIVE MODE';
+		$this->setQuery($sql)->execute();
 
 		return $this;
 	}

--- a/libraries/joomla/database/driver/pdomysql.php
+++ b/libraries/joomla/database/driver/pdomysql.php
@@ -394,19 +394,21 @@ class JDatabaseDriverPdomysql extends JDatabaseDriverPdo
 		return $this->getOption(PDO::ATTR_SERVER_VERSION);
 	}
 
+
 	/**
-	 * Locks a table in the database.
+	 * Locks one or more tables in the database.
 	 *
-	 * @param   string  $table  The name of the table to unlock.
+	 * @param   array|string  $tableNames  The table name or names to lock.
 	 *
 	 * @return  JDatabaseDriverPdomysql  Returns this object to support chaining.
 	 *
 	 * @since   3.4
 	 * @throws  RuntimeException
 	 */
-	public function lockTable($table)
+	public function lockTable($tableNames)
 	{
-		$this->setQuery('LOCK TABLES ' . $this->quoteName($table) . ' WRITE')->execute();
+		$sql = 'LOCK TABLES ' . implode(' WRITE, ', $this->quoteName((array) $tableNames)) . ' WRITE';
+		$this->setQuery($sql)->execute();
 
 		return $this;
 	}

--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -629,19 +629,20 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 	}
 
 	/**
-	 * Locks a table in the database.
+	 * Locks one or more tables in the database.
 	 *
-	 * @param   string  $tableName  The name of the table to unlock.
+	 * @param   array|string  $tableNames  The table name or names to lock.
 	 *
 	 * @return  JDatabaseDriverPostgresql  Returns this object to support chaining.
 	 *
 	 * @since   12.1
 	 * @throws  RuntimeException
 	 */
-	public function lockTable($tableName)
+	public function lockTable($tableNames)
 	{
 		$this->transactionStart();
-		$this->setQuery('LOCK TABLE ' . $this->quoteName($tableName) . ' IN ACCESS EXCLUSIVE MODE')->execute();
+		$sql = 'LOCK TABLE ' . implode(', ', $this->quoteName((array) $tableNames)) . ' IN ACCESS EXCLUSIVE MODE';
+		$this->setQuery($sql)->execute();
 
 		return $this;
 	}

--- a/libraries/joomla/database/driver/sqlite.php
+++ b/libraries/joomla/database/driver/sqlite.php
@@ -379,16 +379,16 @@ class JDatabaseDriverSqlite extends JDatabaseDriverPdo
 	}
 
 	/**
-	 * Locks a table in the database.
+	 * Locks one or more tables in the database.
 	 *
-	 * @param   string  $table  The name of the table to unlock.
+	 * @param   array|string  $tableNames  The table name or names to lock.
 	 *
 	 * @return  JDatabaseDriverSqlite  Returns this object to support chaining.
 	 *
 	 * @since   12.1
 	 * @throws  RuntimeException
 	 */
-	public function lockTable($table)
+	public function lockTable($tableNames)
 	{
 		return $this;
 	}

--- a/libraries/joomla/database/driver/sqlsrv.php
+++ b/libraries/joomla/database/driver/sqlsrv.php
@@ -1021,16 +1021,16 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 	}
 
 	/**
-	 * Locks a table in the database.
+	 * Locks one or more tables in the database.
 	 *
-	 * @param   string  $tableName  The name of the table to lock.
+	 * @param   array|string  $tableNames  The table name or names to lock.
 	 *
 	 * @return  JDatabaseDriverSqlsrv  Returns this object to support chaining.
 	 *
 	 * @since   12.1
 	 * @throws  RuntimeException
 	 */
-	public function lockTable($tableName)
+	public function lockTable($tableNames)
 	{
 		return $this;
 	}


### PR DESCRIPTION
### Summary of Changes

Currently method `JDatabaseDriver::lockTable()` can not lock more than one table in one call.
To lock more tables we have to call the method more times but for mysql server there is an exception:

> LOCK TABLES implicitly releases any table locks held by the current session before acquiring new locks. 

https://dev.mysql.com/doc/refman/5.5/en/lock-tables.html

which means that for the mysql database we can not have 2 locked tables using this method.
This PR solves that.


### Testing Instructions
Code review.