### PR TITLE
Replace 2 queries by one in UCMType

### DIFF
--- a/libraries/src/UCM/UCMType.php
+++ b/libraries/src/UCM/UCMType.php
@@ -93,7 +93,7 @@ class UCMType implements UCM
 
 		// Make the best guess we can in the absence of information.
 		$this->alias = $alias ?: $app->input->get('option') . '.' . $app->input->get('view');
-		$this->type  = $this->getType();
+		$this->type  = $this->getTypeByAlias($this->alias);
 	}
 
 	/**
@@ -109,7 +109,7 @@ class UCMType implements UCM
 	{
 		if (!$pk)
 		{
-			$pk = $this->getTypeId();
+			return $this->getTypeByAlias($this->alias);
 		}
 
 		$query = $this->db->getQuery(true);


### PR DESCRIPTION
### Summary of Changes

It loads the entire row by the alias directly, instead of loading the id by the alias, and then the entire row.

### Testing Instructions
Unit tests passes.
Code review.