### PR TITLE
Clean up code in JTable::store()

### DIFF
--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -803,9 +803,6 @@ abstract class Table extends \JObject implements \JObservableInterface, \JTableI
 		// If the table is not set to track assets return true.
 		if ($this->_trackAssets)
 		{
-			/** @var  \JTableAsset  $asset */
-			$asset = self::getInstance('Asset', 'JTable', array('dbo' => $this->_db));
-
 			if ($this->_locked)
 			{
 				$this->_unlock();
@@ -818,6 +815,8 @@ abstract class Table extends \JObject implements \JObservableInterface, \JTableI
 			$name     = $this->_getAssetName();
 			$title    = $this->_getAssetTitle();
 
+			/** @var  \JTableAsset  $asset */
+			$asset = self::getInstance('Asset', 'JTable', array('dbo' => $this->_db));
 			$asset->loadByName($name);
 
 			// Specify how a new or moved node asset is inserted into the tree.


### PR DESCRIPTION
### Summary of Changes

Improve code style.

1. Replace:
```php
if (...)
{ 
    return false;
}
else 
{
    // ...
}
```

by 
```php
if (...) 
{
    return false;
}

// ...
```

2. Remove lines below `$asset->loadByName($name);` because it does not set error if asset does not exist.
3. A few simple changes to improve the legibility of the code.

### Testing Instructions
Php units passes.
Code review. 

I suggest you do a review by ignoring the white spaces https://github.com/joomla/joomla-cms/pull/20673/files?w=1

### Expected result
Works as before.