### PR TITLE
Add trigger events onBeforeRespond and onAfterRespond during redirection

### DIFF
--- a/libraries/src/Application/WebApplication.php
+++ b/libraries/src/Application/WebApplication.php
@@ -621,8 +621,14 @@ class WebApplication extends BaseApplication
 			}
 		}
 
+		// Trigger the onBeforeRespond event.
+		$this->triggerEvent('onBeforeRespond');
+
 		// Set appropriate headers
 		$this->respond();
+
+		// Trigger the onAfterRespond event.
+		$this->triggerEvent('onAfterRespond');
 
 		//  Close the application after the redirect.
 		$this->close();


### PR DESCRIPTION
### Summary of Changes

Add missing triggers before and after send redirection headers.


### Testing Instructions
Code review.


### Expected result
The `onBeforeRespond` and` onAfterRespond` events should be triggered during redirection in the same way that they are triggered when delivering the page.


### Actual result
The `onBeforeRespond` and` onAfterRespond` events are not triggered during redirection.
