### PR TITLE
Joomla\CMS\Categories\Categories fix

### DIFF
--- a/libraries/src/Categories/Categories.php
+++ b/libraries/src/Categories/Categories.php
@@ -113,8 +113,6 @@ class Categories
 		$options['currentlang'] = Multilanguage::isEnabled() ? Factory::getLanguage()->getTag() : 0;
 
 		$this->_options = $options;
-
-		return true;
 	}
 
 	/**


### PR DESCRIPTION
A constructor can't return a value.

Pull Request for Issue # .

### Summary of Changes



### Testing Instructions



### Expected result



### Actual result



### Documentation Changes Required

