### PR TITLE
[router] Do not strict ids to integer type for ItemId lookup

### DIFF
--- a/libraries/src/Component/Router/Rules/MenuRules.php
+++ b/libraries/src/Component/Router/Rules/MenuRules.php
@@ -129,9 +129,9 @@ class MenuRules implements RulesInterface
 
 					foreach ($ids as $id => $segment)
 					{
-						if (isset($this->lookup[$language][$viewLayout][(int) $id]))
+						if (isset($this->lookup[$language][$viewLayout][$id]))
 						{
-							$query['Itemid'] = $this->lookup[$language][$viewLayout][(int) $id];
+							$query['Itemid'] = $this->lookup[$language][$viewLayout][$id];
 
 							return;
 						}
@@ -149,9 +149,9 @@ class MenuRules implements RulesInterface
 
 					foreach ($ids as $id => $segment)
 					{
-						if (isset($this->lookup[$language][$view][(int) $id]))
+						if (isset($this->lookup[$language][$view][$id]))
 						{
-							$query['Itemid'] = $this->lookup[$language][$view][(int) $id];
+							$query['Itemid'] = $this->lookup[$language][$view][$id];
 
 							return;
 						}


### PR DESCRIPTION
### Summary of Changes
While working on a new component which integrates external systems, where category ids are strings and not integers. I ran into an issue that the lookup in the router failed because category ids and item ids are assumed to be integers. This pr removes that restriction.

Ping @Hackwar for review and feedback.

### Testing Instructions
Just browse around the articles in the front end with modern routing and id removed.

### Expected result
All should work as before.

### Actual result
All ok.