### PR TITLE
[mod_articles_latest] Option for choose an specific author(s)

### DIFF
--- a/language/en-GB/en-GB.mod_articles_latest.ini
+++ b/language/en-GB/en-GB.mod_articles_latest.ini
@@ -5,7 +5,7 @@
 
 MOD_ARTICLES_LATEST="Articles - Latest"
 MOD_LATEST_NEWS_FIELD_AUTHOR_DESC="Select one or more authors from the list below."
-MOD_LATEST_NEWS_FIELD_AUTHOR_LABEL="Authors"
+MOD_LATEST_NEWS_FIELD_AUTHOR_LABEL="Created by author(s)"
 MOD_LATEST_NEWS_FIELD_CATEGORY_DESC="Selects Articles from one or more Categories. If no selection will show all categories as default."
 MOD_LATEST_NEWS_FIELD_COUNT_DESC="The number of Articles to display (the default is 5)."
 MOD_LATEST_NEWS_FIELD_COUNT_LABEL="Count"

--- a/language/en-GB/en-GB.mod_articles_latest.ini
+++ b/language/en-GB/en-GB.mod_articles_latest.ini
@@ -4,7 +4,7 @@
 ; Note : All ini files need to be saved as UTF-8
 
 MOD_ARTICLES_LATEST="Articles - Latest"
-MOD_LATEST_NEWS_FIELD_AUTHOR_DESC="Select one or more authors from the list below."
+MOD_LATEST_NEWS_FIELD_AUTHOR_DESC="Select one or more authors."
 MOD_LATEST_NEWS_FIELD_AUTHOR_LABEL="Created by author(s)"
 MOD_LATEST_NEWS_FIELD_CATEGORY_DESC="Selects Articles from one or more Categories. If no selection will show all categories as default."
 MOD_LATEST_NEWS_FIELD_COUNT_DESC="The number of Articles to display (the default is 5)."

--- a/language/en-GB/en-GB.mod_articles_latest.ini
+++ b/language/en-GB/en-GB.mod_articles_latest.ini
@@ -5,7 +5,7 @@
 
 MOD_ARTICLES_LATEST="Articles - Latest"
 MOD_LATEST_NEWS_FIELD_AUTHOR_DESC="Select one or more authors."
-MOD_LATEST_NEWS_FIELD_AUTHOR_LABEL="Created by author(s)"
+MOD_LATEST_NEWS_FIELD_AUTHOR_LABEL="Created by Author(s)"
 MOD_LATEST_NEWS_FIELD_CATEGORY_DESC="Selects Articles from one or more Categories. If no selection will show all categories as default."
 MOD_LATEST_NEWS_FIELD_COUNT_DESC="The number of Articles to display (the default is 5)."
 MOD_LATEST_NEWS_FIELD_COUNT_LABEL="Count"

--- a/language/en-GB/en-GB.mod_articles_latest.ini
+++ b/language/en-GB/en-GB.mod_articles_latest.ini
@@ -4,6 +4,8 @@
 ; Note : All ini files need to be saved as UTF-8
 
 MOD_ARTICLES_LATEST="Articles - Latest"
+MOD_LATEST_NEWS_FIELD_AUTHOR_DESC="Select one or more authors from the list below."
+MOD_LATEST_NEWS_FIELD_AUTHOR_LABEL="Authors"
 MOD_LATEST_NEWS_FIELD_CATEGORY_DESC="Selects Articles from one or more Categories. If no selection will show all categories as default."
 MOD_LATEST_NEWS_FIELD_COUNT_DESC="The number of Articles to display (the default is 5)."
 MOD_LATEST_NEWS_FIELD_COUNT_LABEL="Count"
@@ -15,6 +17,7 @@ MOD_LATEST_NEWS_FIELD_USER_DESC="Filter by author."
 MOD_LATEST_NEWS_FIELD_USER_LABEL="Authors"
 MOD_LATEST_NEWS_VALUE_ADDED_BY_ME="Added or modified by me"
 MOD_LATEST_NEWS_VALUE_ANYONE="Anyone"
+MOD_LATEST_NEWS_VALUE_CREATED_BY="Created by"
 MOD_LATEST_NEWS_VALUE_NOTADDED_BY_ME="Not added or modified by me"
 MOD_LATEST_NEWS_VALUE_ONLY_SHOW_FEATURED="Only show Featured Articles"
 MOD_LATEST_NEWS_VALUE_RECENT_ADDED="Recently Added First"

--- a/modules/mod_articles_latest/helper.php
+++ b/modules/mod_articles_latest/helper.php
@@ -74,7 +74,7 @@ abstract class ModArticlesLatestHelper
 				break;
 
 			case 'created_by' :
-				$model->setState('filter.author_id', $params->get('author'));
+				$model->setState('filter.author_id', $params->get('author', array()));
 				break;
 
 			case '0' :

--- a/modules/mod_articles_latest/helper.php
+++ b/modules/mod_articles_latest/helper.php
@@ -73,6 +73,10 @@ abstract class ModArticlesLatestHelper
 				$model->setState('filter.author_id.include', false);
 				break;
 
+			case 'created_by' :
+				$model->setState('filter.author_id', $params->get('author'));
+				break;
+
 			case '0' :
 				break;
 

--- a/modules/mod_articles_latest/mod_articles_latest.xml
+++ b/modules/mod_articles_latest/mod_articles_latest.xml
@@ -94,7 +94,7 @@
 					value_field="name"
 					showon="user_id:created_by"
 					>
-					<option value="0">JOPTION_SELECT_AUTHORS</option>
+					<option value="0">JNONE</option>
 				</field>
 			</fieldset>
 

--- a/modules/mod_articles_latest/mod_articles_latest.xml
+++ b/modules/mod_articles_latest/mod_articles_latest.xml
@@ -79,6 +79,22 @@
 					<option value="0">MOD_LATEST_NEWS_VALUE_ANYONE</option>
 					<option value="by_me">MOD_LATEST_NEWS_VALUE_ADDED_BY_ME</option>
 					<option value="not_me">MOD_LATEST_NEWS_VALUE_NOTADDED_BY_ME</option>
+					<option value="created_by">MOD_LATEST_NEWS_VALUE_CREATED_BY</option>
+				</field>
+
+				<field
+					name="author"
+					type="sql"
+					label="MOD_LATEST_NEWS_FIELD_AUTHOR_LABEL"
+					description="MOD_LATEST_NEWS_FIELD_AUTHOR_DESC"
+					multiple="true"
+					size="5"
+					query="select id, name, username from #__users where id IN (select distinct(created_by) from #__content) order by name ASC"
+					key_field="id"
+					value_field="name"
+					showon="user_id:created_by"
+					>
+					<option value="0">JOPTION_SELECT_AUTHORS</option>
 				</field>
 			</fieldset>
 

--- a/modules/mod_articles_latest/mod_articles_latest.xml
+++ b/modules/mod_articles_latest/mod_articles_latest.xml
@@ -84,18 +84,12 @@
 
 				<field
 					name="author"
-					type="sql"
+					type="author"
 					label="MOD_LATEST_NEWS_FIELD_AUTHOR_LABEL"
 					description="MOD_LATEST_NEWS_FIELD_AUTHOR_DESC"
 					multiple="true"
-					size="5"
-					query="select id, name, username from #__users where id IN (select distinct(created_by) from #__content) order by name ASC"
-					key_field="id"
-					value_field="name"
 					showon="user_id:created_by"
-					>
-					<option value="0">JNONE</option>
-				</field>
+				/>
 			</fieldset>
 
 			<fieldset name="advanced">


### PR DESCRIPTION
Pull Request for Issue #20685 

### Summary of Changes
New option for filter articles by a specific authors


### Testing Instructions

-  Enter to the mod_articles_latest and choose the value `Created by` in the option `Authors`. Select an author(s) and save.
- Go to the front end, and check the list of articles is only from the author(s) you selected 


### Expected result
Only articles from selected users are displayed


### Actual result
The module no have the option to choose specific author(s)


### Documentation Changes Required
Yes, need document the new option

### Additional comments
You can use the module `Articles - Category` for have this, but as `Articles - Latest` have an option for filter by authors, is incomplete if you cant choose a specific author(s).
