### PR TITLE
[4.0] Removing obsolete azure update file

### DIFF
--- a/administrator/components/com_admin/sql/updates/sqlazure/3.8.4-2018-01-16.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.8.4-2018-01-16.sql
@@ -1,2 +1,0 @@
-ALTER TABLE [#__user_keys] DROP CONSTRAINT [#__user_keys$series_2];
-ALTER TABLE [#__user_keys] DROP CONSTRAINT [#__user_keys$series_3];


### PR DESCRIPTION
We don't support azure anymore. Looks like a merge gone wrong here.