### PR TITLE
Remove duplicate / redundant queries when creating multiple JUser instances for same user

### DIFF
--- a/libraries/src/User/User.php
+++ b/libraries/src/User/User.php
@@ -223,6 +223,12 @@ class User extends \JObject
 	protected static $instances = array();
 
 	/**
+	 * @var    array  JTable user records
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected static $records = array();
+
+	/**
 	 * Constructor activating the default information of the language
 	 *
 	 * @param   integer      $identifier  The primary key of the user to load (optional).
@@ -879,8 +885,22 @@ class User extends \JObject
 		// Create the user table object
 		$table = $this->getTable();
 
-		// Load the UserModel object based on the user id or throw a warning.
-		if (!$table->load($id))
+		// Check for already loaded JTable record for given record id
+		if (!empty(self::$records[$this->id]))
+		{
+			$table = self::$records[$this->id];
+			$loaded = true;
+		}
+
+		// Load JTable record for given record id
+		else
+		{
+			$loaded = $table->load($id);
+			self::$records[$this->id] = $table;
+		}
+
+		// Throw a warning on loading error
+		if (!$loaded)
 		{
 			// Reset to guest user
 			$this->guest = 1;


### PR DESCRIPTION
Pull Request for Issue #20698

### Summary of Changes
Cache JTable records loaded by JUser class (Joomla\CMS\User\User)


### Testing Instructions
1. Enable DEBUG in global configuration
2. Visit Control Panel screen


### Expected result
Show only 2 duplicates queries 
- without any duplicate queries to DB Tables: __users , __usergroups 


### Actual result
6 duplicates queries are reported
- 2 of them to  __users DB Table
- 2 of them to  __usergroups DB Table

### Documentation Changes Required
None

