### PR TITLE
If user data has already been loaded, then do not reload record from DB when unserializing a JUser object

### DIFF
--- a/libraries/src/User/User.php
+++ b/libraries/src/User/User.php
@@ -942,15 +942,33 @@ class User extends \JObject
 		$this->userHelper = new UserWrapper;
 		$this->_params    = new Registry;
 
-		// Load the user if it exists
-		if (!empty($this->id) && $this->load($this->id))
+		// Check if user instance exists, and do not reload user record from DB
+		if (isset(self::$instances[$this->id]))
+		{
+			// Duplicate user instance
+			foreach(self::$instances[$this->id] as $k => $v)
+			{
+				if (is_object($v))
+				{
+					$this->$k = clone($v);
+				}
+				else
+				{
+					$this->$k = $v;
+				}
+			}
+		}
+
+		// User instance does not exist, continue to load the user if it exists
+		elseif (!empty($this->id) && $this->load($this->id))
 		{
 			// Push user into cached instances.
 			self::$instances[$this->id] = $this;
 		}
+
+		// Empty user ID or loading of user failed, initialise a guest user object
 		else
 		{
-			// Initialise
 			$this->id = 0;
 			$this->sendEmail = 0;
 			$this->aid = 0;

--- a/libraries/src/User/User.php
+++ b/libraries/src/User/User.php
@@ -946,11 +946,11 @@ class User extends \JObject
 		if (isset(self::$instances[$this->id]))
 		{
 			// Duplicate user instance
-			foreach(self::$instances[$this->id] as $k => $v)
+			foreach (self::$instances[$this->id] as $k => $v)
 			{
 				if (is_object($v))
 				{
-					$this->$k = clone($v);
+					$this->$k = clone $v;
 				}
 				else
 				{


### PR DESCRIPTION
Pull Request for Issue #20698
Better alternative to the closed PR #20697, @mbabker , i hope it is ok to ping you to review this 

### Summary of Changes
Modified method __wakeup()   (class Joomla\CMS\User\User)
-- which is called when unserialize() is called on the JUser object
so that it does not reload user record from DB 


### Testing Instructions
1. Enable DEBUG in global configuration
2. Visit Control Panel screen


### Expected result
Show only 2 duplicates queries 
- without any duplicate queries to DB Tables: __users , __usergroups 


### Actual result
6 duplicates queries are reported
- 2 of them to  __users DB Table
- 2 of them to  __usergroups DB Table

### Documentation Changes Required
None

