### PR TITLE
Correct css classes of header menu in Cassiopeia template

### DIFF
--- a/modules/mod_menu/tmpl/default.php
+++ b/modules/mod_menu/tmpl/default.php
@@ -20,7 +20,7 @@ if ($tagId = $params->get('tag_id', ''))
 
 // The menu class is deprecated. Use nav instead
 ?>
-<ul<?php echo $id; ?> class="nav flex-column <?php echo $class_sfx; ?>">
+<ul<?php echo $id; ?> class="nav <?php echo $class_sfx; ?>">
 <?php foreach ($list as $i => &$item)
 {
 	$class = 'nav-item';

--- a/templates/cassiopeia/scss/blocks/_header.scss
+++ b/templates/cassiopeia/scss/blocks/_header.scss
@@ -53,7 +53,7 @@
     }
   }
 
-  .navbar-nav.flex-column {
+  .nav.flex-column {
     flex-direction: row !important;
 
     @include media-breakpoint-down(md) {
@@ -67,7 +67,7 @@
     flex-grow: 0;
   }
 
-  .navbar-nav li {
+  .nav li {
     position: relative;
     display: inline-block;
     margin-right: 20px;


### PR DESCRIPTION
Pull Request for Issue # ?.

### Summary of Changes

This pull request (PR) removes the bootstrap class `flex-column` from the menu module's `ul` element and changes class `navbar-nav` to `nav` in the Cassiopeia template's (s)css so it fits to the html.

The `flex-column` class makes it impossible to get horizontal menus in the header area of Casiopeia, see picture in section "Actual result" below, and so the apperance is not as shown on the template's preview picture.

After removing the flex-column` class, the menu still does not look like it should, see following picture:
![intermediate](https://user-images.githubusercontent.com/7413183/41189584-854bba1c-6bd0-11e8-9b40-9f547af5cf83.png)

The reason is that in (s)css for the header area the `navbar-nav` class is used instead of `nav`.

After changing that, the menu looks like on the template's preview, see picture in section "Expected result" below.

### Testing Instructions

**_Please don't test yet, I have to check how to provide compiled and minified template.css._**

Use current 4.0-dev branch with the default Cassiopeia frontent template and have a menu in module position `menu` which should be shown in horizontal direction, and some other menus in some side position shown in vertical direction.

I used blog testing data and moved the "Main Menu Blog" module to the `menu` position. In the module's advanced setting there is no class suffix defined for the module or the menu.

Check that the menu at the `menu` position (left beside the search box) is shown as expected with this PR applied.

Check that the look of all other things on the page has not changed after applying this PR.

### Expected result

See following picture with the menu marked with a red ellipse:
![after](https://user-images.githubusercontent.com/7413183/41189615-e70b47a4-6bd0-11e8-9548-8f4d5c1111d3.png)


### Actual result

See following picture with the menu marked with a red ellipse:
![before](https://user-images.githubusercontent.com/7413183/41189616-eb664560-6bd0-11e8-8a9e-072cabb0ae0f.png)


### Documentation Changes Required

None.