### PR TITLE
Make the fieldname required as the field otherwise doesn't work

### DIFF
--- a/plugins/fields/repeatable/params/repeatable.xml
+++ b/plugins/fields/repeatable/params/repeatable.xml
@@ -16,6 +16,7 @@
 								type="text"
 								label="PLG_FIELDS_REPEATABLE_PARAMS_FIELDNAME_NAME_LABEL"
 								description="PLG_FIELDS_REPEATABLE_PARAMS_FIELDNAME_NAME_DESC"
+								required="true"
 							/>
 							<field
 								name="fieldtype"


### PR DESCRIPTION
### Summary of Changes
When creating a new custom field of the type *repeatable* and the fieldname is left empty, the values are not stored. This changed makes the fieldname required thus making sure the values can be stored.

### Testing Instructions
1. Setup a Joomla 3.9 installation
2. Go to Content Fields
3. Create a new field by clicking New
4. Enter the Title *Repeatable*
5. Select the type *repeatable*
6. Add a new Form Field by clicking on the  green +
7. Leave the Name empty
8. Set the Type to *Text*
9. The form now looks like this:
![image](https://user-images.githubusercontent.com/359377/41192987-e9d1f3f8-6c06-11e8-847f-7783bc005e1d.png)
10. Save & Close the field
11. Click on Articles
12. Click on New
13. Enter the article title
14. Click on the Fields tab
15. There is the repeatable field we just created
16. Click on the green + to add a value
17. Enter a value
18. Click on the green + again
18. Enter a second value
19. Save the article
20. Notice the two rows are there but there are no values
21. Apply the patch
22. Go to Content -> Fields
23. Edit the Repeatable field we created in step 10
24. Notice that the Name field is now required
25. Enter a name
26. Save & Close the field
27. Repeat step 11 until 19
28. Notice the two rows are there with values this time.


### Expected result
Values are stored and shown


### Actual result
Values are not stored and not shown


### Documentation Changes Required
None
