### PR TITLE
[4.0] Finally use the inflector in the FormHelper

### DIFF
--- a/libraries/src/Form/FormHelper.php
+++ b/libraries/src/Form/FormHelper.php
@@ -10,9 +10,11 @@ namespace Joomla\CMS\Form;
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\CMS\Filesystem\Path;
+use Joomla\CMS\Log\Log;
+use Joomla\String\Inflector;
 use Joomla\String\Normalise;
 use Joomla\String\StringHelper;
-use Joomla\CMS\Filesystem\Path;
 
 /**
  * Form's helper class.
@@ -320,16 +322,29 @@ class FormHelper
 		// Add the default entity's search path if not set.
 		if (empty($paths))
 		{
-			// While we support limited number of entities (form, field and rule)
-			// we can do this simple pluralisation:
-			$entity_plural = $entity . 's';
+			// While we support limited number of entities (form, field and rule) we can do simple pluralisation
+			$entityPlural = $entity . 's';
 
-			/*
-			 * But when someday we would want to support more entities, then we should consider adding
-			 * an inflector class to "libraries/joomla/utilities" and use it here (or somebody can use a real inflector in his subclass).
-			 * See also: pluralization snippet by Paul Osman in JControllerForm's constructor.
-			 */
-			$paths[] = __DIR__ . '/' . $entity_plural;
+			// Relying on "simple" plurals is deprecated, use the properly inflected plural form
+			$paths[] = __DIR__ . '/' . $entityPlural;
+
+			$inflectedPlural = Inflector::getInstance()->toPlural($entity);
+
+			if ($entityPlural !== $inflectedPlural)
+			{
+				Log::add(
+					sprintf(
+						'File paths for form entity type validations should be properly inflected as of 5.0.'
+							. ' The folder for entity type "%1$s" should be renamed from "%2$s" to "%3$s".',
+						$entity,
+						$entityPlural,
+						$inflectedPlural
+					),
+					Log::WARNING,
+					'deprecated'
+				);
+				$paths[] = __DIR__ . '/' . $inflectedPlural;
+			}
 		}
 
 		// Force the new path(s) to an array.


### PR DESCRIPTION
### Summary of Changes

Since introduced in 2010, the FormHelper class has always had a note about how the pluralization logic for form entity types should use a proper inflector, but it never being a big deal because our core API "only" supports entity types that are pluralized by tacking the letter S onto a word (field and rule).  We have had an inflector in our API since 2011.  It's 2018, I think we can use the inflector now.

### Testing Instructions

There should be no practical change here really.  Form fields and rules registered through path lookups should keep working.  If you actually have a custom Form API entity type, and its pluralization doesn't follow the simple "add S to word" (lets just say entity for the sake of discussion since right now the code would make that "entitys" for the path name when it should be "entities" following correct language rules), the incorrect spelling is deprecated and should raise a log notice (though to be honest the odds of this code path ever being triggered are going to be slim to none).