### PR TITLE
Respect access of editor plugin inside profile form

### DIFF
--- a/administrator/components/com_admin/models/forms/profile.xml
+++ b/administrator/components/com_admin/models/forms/profile.xml
@@ -137,6 +137,7 @@
 				label="COM_ADMIN_USER_FIELD_EDITOR_LABEL"
 				description="COM_ADMIN_USER_FIELD_EDITOR_DESC"
 				folder="editors"
+				useaccess="1"
 				>
 				<option value="">JOPTION_USE_DEFAULT</option>
 			</field>

--- a/administrator/components/com_admin/models/forms/profile.xml
+++ b/administrator/components/com_admin/models/forms/profile.xml
@@ -137,7 +137,7 @@
 				label="COM_ADMIN_USER_FIELD_EDITOR_LABEL"
 				description="COM_ADMIN_USER_FIELD_EDITOR_DESC"
 				folder="editors"
-				useaccess="1"
+				useaccess="true"
 				>
 				<option value="">JOPTION_USE_DEFAULT</option>
 			</field>

--- a/components/com_users/models/forms/frontend.xml
+++ b/components/com_users/models/forms/frontend.xml
@@ -9,7 +9,7 @@
 				label="COM_USERS_USER_FIELD_EDITOR_LABEL"
 				description="COM_USERS_USER_FIELD_EDITOR_DESC"
 				folder="editors"
-				useaccess="1"
+				useaccess="true"
 				>
 				<option value="">JOPTION_USE_DEFAULT</option>
 			</field>

--- a/components/com_users/models/forms/frontend.xml
+++ b/components/com_users/models/forms/frontend.xml
@@ -9,6 +9,7 @@
 				label="COM_USERS_USER_FIELD_EDITOR_LABEL"
 				description="COM_USERS_USER_FIELD_EDITOR_DESC"
 				folder="editors"
+				useaccess="1"
 				>
 				<option value="">JOPTION_USE_DEFAULT</option>
 			</field>

--- a/libraries/joomla/form/fields/plugins.php
+++ b/libraries/joomla/form/fields/plugins.php
@@ -117,6 +117,8 @@ class JFormFieldPlugins extends JFormFieldList
 
 		if (!empty($folder))
 		{
+			$useAccess = (int) $this->element['useaccess'];
+
 			// Get list of plugins
 			$db    = JFactory::getDbo();
 			$query = $db->getQuery(true)
@@ -125,6 +127,12 @@ class JFormFieldPlugins extends JFormFieldList
 				->where('folder = ' . $db->quote($folder))
 				->where('enabled = 1')
 				->order('ordering, name');
+
+			if ($useAccess)
+			{
+				$groups = implode(',', JFactory::getUser()->getAuthorisedViewLevels());
+				$query->where('access IN (' . $groups . ')');
+			}
 
 			$options   = $db->setQuery($query)->loadObjectList();
 			$lang      = JFactory::getLanguage();

--- a/libraries/joomla/form/fields/plugins.php
+++ b/libraries/joomla/form/fields/plugins.php
@@ -117,8 +117,6 @@ class JFormFieldPlugins extends JFormFieldList
 
 		if (!empty($folder))
 		{
-			$useAccess = (int) $this->element['useaccess'];
-
 			// Get list of plugins
 			$db    = JFactory::getDbo();
 			$query = $db->getQuery(true)
@@ -128,10 +126,10 @@ class JFormFieldPlugins extends JFormFieldList
 				->where('enabled = 1')
 				->order('ordering, name');
 
-			if ($useAccess)
+			if ((string) $this->element['useaccess'] === 'true')
 			{
 				$groups = implode(',', JFactory::getUser()->getAuthorisedViewLevels());
-				$query->where('access IN (' . $groups . ')');
+				$query->where($db->quoteName('access') . ' IN (' . $groups . ')');
 			}
 
 			$options   = $db->setQuery($query)->loadObjectList();


### PR DESCRIPTION
Pull Request for Issue #20605

### Summary of Changes
1. Add support for option `useaccess="1" ' to form field element 'plugins' (class JFormFieldPlugins)
\libraries\joomla\form\fields\plugins

2. Use the above option in the form XML for profile edit screens
(**frontend**: /components/com_users/models/forms/frontend.xml)
(**backend**: /administrator/components/com_users/models/forms/profile.xml)


### Testing Instructions
After installing patch

1. Set codemirror to access 'Customer Access Level (Example)'
3. Login backend and frontend as super admin (or with some other account that does not have the access level 'Customer ....'
3. Click to "edit account" in backend or "Your profile" menu link in frontend 
4. Go to Basic Settings (Fieldset or Tab) and try to select editor. Verify that codemirror is no longer shown



### Expected result
A user editing its own profile,
should not be able to select an editor that has an non-granted access level 

thus in the above case the codemirror should not be shown


### Actual result
Codemirror option is shown inside the select editor drop-down and it is selectabe


### Documentation Changes Required
Yes
document new optio here (and elsewhere):
https://docs.joomla.org/Plugins_form_field_type
**useaccess** set to 1 to only list plugins with an allowed access level for current usertext for the form field.
