### PR TITLE
[3.9] Deprecate JAdapter classes

### DIFF
--- a/libraries/joomla/base/adapter.php
+++ b/libraries/joomla/base/adapter.php
@@ -14,7 +14,8 @@ defined('JPATH_PLATFORM') or die;
  * Retains common adapter pattern functions
  * Class harvested from joomla.installer.installer
  *
- * @since  11.1
+ * @since       11.1
+ * @deprecated  5.0 Will be removed without replacement
  */
 class JAdapter extends JObject
 {

--- a/libraries/joomla/base/adapterinstance.php
+++ b/libraries/joomla/base/adapterinstance.php
@@ -12,7 +12,8 @@ defined('JPATH_PLATFORM') or die;
 /**
  * Adapter Instance Class
  *
- * @since  11.1
+ * @since       11.1
+ * @deprecated  5.0 Will be removed without replacement
  */
 class JAdapterInstance extends JObject
 {


### PR DESCRIPTION
`JAdapter` does have it's own class loading and file path lookup logic. With the introduction of a DI container which can manage objects this becomes obsolete.

This pr deprecates the classes.