### PR TITLE
[Newsfeeds] Use item link instead of guid.

### DIFF
--- a/administrator/modules/mod_feed/tmpl/default.php
+++ b/administrator/modules/mod_feed/tmpl/default.php
@@ -85,18 +85,18 @@ else
 			endif;
 			$uri  = $feed[$i]->uri || !$feed[$i]->isPermaLink ? trim($feed[$i]->uri) : trim($feed[$i]->guid);
 			$uri  = !$uri || stripos($uri, 'http') !== 0 ? $params->get('rsslink') : $uri;
-			$text = !empty($feed[$i]->content) || !is_null($feed[$i]->content) ? $feed[$i]->content : $feed[$i]->description;
+			$text = $feed[$i]->content !== '' ? trim($feed[$i]->content) : '';
 			?>
 				<li>
 					<?php if (!empty($uri)) : ?>
 						<h5 class="feed-link">
 						<a href="<?php echo $uri; ?>" target="_blank">
-						<?php echo $feed[$i]->title; ?></a></h5>
+						<?php echo trim($feed[$i]->title); ?></a></h5>
 					<?php else : ?>
-						<h5 class="feed-link"><?php echo $feed[$i]->title; ?></h5>
+						<h5 class="feed-link"><?php echo trim($feed[$i]->title); ?></h5>
 					<?php endif; ?>
 
-					<?php if ($params->get('rssitemdesc') && !empty($text)) : ?>
+					<?php if ($params->get('rssitemdesc') && $text !== '') : ?>
 						<div class="feed-item-description">
 						<?php
 							// Strip the images.

--- a/administrator/modules/mod_feed/tmpl/default.php
+++ b/administrator/modules/mod_feed/tmpl/default.php
@@ -83,8 +83,8 @@ else
 			if (!$feed->offsetExists($i)) :
 				break;
 			endif;
-			$uri  = (!empty($feed[$i]->uri) || !is_null($feed[$i]->uri)) ? $feed[$i]->uri : $feed[$i]->guid;
-			$uri  = substr($uri, 0, 4) != 'http' ? $params->get('rsslink') : $uri;
+			$uri   = $feed[$i]->uri || !$feed[$i]->isPermaLink ? trim($feed[$i]->uri) : trim($feed[$i]->guid);
+			$uri  = !$uri ? $params->get('rsslink') : $uri;
 			$text = !empty($feed[$i]->content) ||  !is_null($feed[$i]->content) ? $feed[$i]->content : $feed[$i]->description;
 			?>
 				<li>

--- a/administrator/modules/mod_feed/tmpl/default.php
+++ b/administrator/modules/mod_feed/tmpl/default.php
@@ -84,17 +84,17 @@ else
 				break;
 			endif;
 			$uri   = $feed[$i]->uri || !$feed[$i]->isPermaLink ? trim($feed[$i]->uri) : trim($feed[$i]->guid);
-			$uri  = !$uri ? $params->get('rsslink') : $uri;
-			$text = !empty($feed[$i]->content) ||  !is_null($feed[$i]->content) ? $feed[$i]->content : $feed[$i]->description;
+			$uri  = !$uri || stripos($uri, 'http') !== 0 ? $params->get('rsslink') : $uri;
+			$text = !empty($feed[$i]->content) || !is_null($feed[$i]->content) ? $feed[$i]->content : $feed[$i]->description;
 			?>
 				<li>
 					<?php if (!empty($uri)) : ?>
 						<h5 class="feed-link">
 						<a href="<?php echo $uri; ?>" target="_blank">
-						<?php  echo $feed[$i]->title; ?></a></h5>
+						<?php echo $feed[$i]->title; ?></a></h5>
 					<?php else : ?>
-						<h5 class="feed-link"><?php  echo $feed[$i]->title; ?></h5>
-					<?php  endif; ?>
+						<h5 class="feed-link"><?php echo $feed[$i]->title; ?></h5>
+					<?php endif; ?>
 
 					<?php if ($params->get('rssitemdesc') && !empty($text)) : ?>
 						<div class="feed-item-description">

--- a/administrator/modules/mod_feed/tmpl/default.php
+++ b/administrator/modules/mod_feed/tmpl/default.php
@@ -83,7 +83,7 @@ else
 			if (!$feed->offsetExists($i)) :
 				break;
 			endif;
-			$uri   = $feed[$i]->uri || !$feed[$i]->isPermaLink ? trim($feed[$i]->uri) : trim($feed[$i]->guid);
+			$uri  = $feed[$i]->uri || !$feed[$i]->isPermaLink ? trim($feed[$i]->uri) : trim($feed[$i]->guid);
 			$uri  = !$uri || stripos($uri, 'http') !== 0 ? $params->get('rsslink') : $uri;
 			$text = !empty($feed[$i]->content) || !is_null($feed[$i]->content) ? $feed[$i]->content : $feed[$i]->description;
 			?>

--- a/components/com_newsfeeds/views/newsfeed/tmpl/default.php
+++ b/components/com_newsfeeds/views/newsfeed/tmpl/default.php
@@ -91,21 +91,20 @@ defined('_JEXEC') or die;
 					<?php if (empty($this->rssDoc[$i])) : ?>
 						<?php break; ?>
 					<?php endif; ?>
-					<?php $uri   = $this->rssDoc[$i]->uri || !$this->rssDoc[$i]->isPermaLink ? trim($this->rssDoc[$i]->uri) : trim($this->rssDoc[$i]->guid); ?>
-					<?php $uri   = !$uri || stripos($uri, 'http') !== 0 ? $this->item->link : $uri; ?>
-					<?php $text  = !empty($this->rssDoc[$i]->content) || $this->rssDoc[$i]->content !== null ? trim($this->rssDoc[$i]->content) : trim($this->rssDoc[$i]->description); ?>
-					<?php $title = trim($this->rssDoc[$i]->title); ?>
+					<?php $uri  = $this->rssDoc[$i]->uri || !$this->rssDoc[$i]->isPermaLink ? trim($this->rssDoc[$i]->uri) : trim($this->rssDoc[$i]->guid); ?>
+					<?php $uri  = !$uri || stripos($uri, 'http') !== 0 ? $this->item->link : $uri; ?>
+					<?php $text = $this->rssDoc[$i]->content !== '' ? trim($this->rssDoc[$i]->content) : ''; ?>
 					<li>
 						<?php if (!empty($uri)) : ?>
 							<h3 class="feed-link">
 								<a href="<?php echo htmlspecialchars($uri); ?>" target="_blank">
-									<?php echo $title; ?>
+									<?php echo trim($this->rssDoc[$i]->title); ?>
 								</a>
 							</h3>
 						<?php else : ?>
-							<h3 class="feed-link"><?php echo $title; ?></h3>
+							<h3 class="feed-link"><?php echo trim($this->rssDoc[$i]->title); ?></h3>
 						<?php endif; ?>
-						<?php if ($this->params->get('show_item_description') && !empty($text)) : ?>
+						<?php if ($this->params->get('show_item_description') && $text !== '') : ?>
 							<div class="feed-item-description">
 								<?php if ($this->params->get('show_feed_image', 0) == 0) : ?>
 									<?php $text = JFilterOutput::stripImages($text); ?>

--- a/components/com_newsfeeds/views/newsfeed/tmpl/default.php
+++ b/components/com_newsfeeds/views/newsfeed/tmpl/default.php
@@ -92,7 +92,7 @@ defined('_JEXEC') or die;
 						<?php break; ?>
 					<?php endif; ?>
 					<?php $uri   = $this->rssDoc[$i]->uri || !$this->rssDoc[$i]->isPermaLink ? trim($this->rssDoc[$i]->uri) : trim($this->rssDoc[$i]->guid); ?>
-					<?php $uri   = !$uri ? $this->item->link : $uri; ?>
+					<?php $uri   = !$uri || stripos($uri, 'http') !== 0 ? $this->item->link : $uri; ?>
 					<?php $text  = !empty($this->rssDoc[$i]->content) || $this->rssDoc[$i]->content !== null ? trim($this->rssDoc[$i]->content) : trim($this->rssDoc[$i]->description); ?>
 					<?php $title = trim($this->rssDoc[$i]->title); ?>
 					<li>

--- a/components/com_newsfeeds/views/newsfeed/tmpl/default.php
+++ b/components/com_newsfeeds/views/newsfeed/tmpl/default.php
@@ -91,8 +91,8 @@ defined('_JEXEC') or die;
 					<?php if (empty($this->rssDoc[$i])) : ?>
 						<?php break; ?>
 					<?php endif; ?>
-					<?php $uri   = !empty($this->rssDoc[$i]->guid) || $this->rssDoc[$i]->guid !== null ? trim($this->rssDoc[$i]->guid) : trim($this->rssDoc[$i]->uri); ?>
-					<?php $uri   = strpos($uri, 'http') !== 0 ? $this->item->link : $uri; ?>
+					<?php $uri   = $this->rssDoc[$i]->uri || !$this->rssDoc[$i]->isPermaLink ? trim($this->rssDoc[$i]->uri) : trim($this->rssDoc[$i]->guid); ?>
+					<?php $uri   = !$uri ? $this->item->link : $uri; ?>
 					<?php $text  = !empty($this->rssDoc[$i]->content) || $this->rssDoc[$i]->content !== null ? trim($this->rssDoc[$i]->content) : trim($this->rssDoc[$i]->description); ?>
 					<?php $title = trim($this->rssDoc[$i]->title); ?>
 					<li>

--- a/libraries/src/Feed/Parser/RssParser.php
+++ b/libraries/src/Feed/Parser/RssParser.php
@@ -372,6 +372,7 @@ class RssParser extends FeedParser
 		$entry->updatedDate   = (string) $el->pubDate;
 		$entry->content       = (string) $el->description;
 		$entry->guid          = (string) $el->guid;
+		$entry->isPermaLink   = $entry->guid === '' || (string) $el->guid['isPermaLink'] === 'false' ? false : true;
 		$entry->comments      = (string) $el->comments;
 
 		// Add the feed entry author if available.

--- a/modules/mod_feed/tmpl/default.php
+++ b/modules/mod_feed/tmpl/default.php
@@ -90,26 +90,24 @@ else
 		<ul class="newsfeed<?php echo $params->get('moduleclass_sfx'); ?>">
 		<?php for ($i = 0, $max = min(count($feed), $params->get('rssitems', 5)); $i < $max; $i++) { ?>
 			<?php
-				$uri   = $feed[$i]->uri || !$feed[$i]->isPermaLink ? trim($feed[$i]->uri) : trim($feed[$i]->guid);
-				$uri   = !$uri || stripos($uri, 'http') !== 0 ? $params->get('rsslink') : $uri;
-				$text  = !empty($feed[$i]->content) || $feed[$i]->content !== null ? trim($feed[$i]->content) : trim($feed[$i]->description);
-				$title = trim($feed[$i]->title);
+				$uri  = $feed[$i]->uri || !$feed[$i]->isPermaLink ? trim($feed[$i]->uri) : trim($feed[$i]->guid);
+				$uri  = !$uri || stripos($uri, 'http') !== 0 ? $params->get('rsslink') : $uri;
+				$text = $feed[$i]->content !== '' ? trim($feed[$i]->content) : '';
 			?>
 				<li>
 					<?php if (!empty($uri)) : ?>
 						<span class="feed-link">
 						<a href="<?php echo htmlspecialchars($uri, ENT_COMPAT, 'UTF-8'); ?>" target="_blank">
-						<?php echo $feed[$i]->title; ?></a></span>
+						<?php echo trim($feed[$i]->title); ?></a></span>
 					<?php else : ?>
-						<span class="feed-link"><?php echo $title; ?></span>
+						<span class="feed-link"><?php echo trim($feed[$i]->title); ?></span>
 					<?php endif; ?>
 
-					<?php if (!empty($text) && $params->get('rssitemdesc')) : ?>
+					<?php if ($params->get('rssitemdesc') && $text !== '') : ?>
 						<div class="feed-item-description">
 						<?php
 							// Strip the images.
 							$text = JFilterOutput::stripImages($text);
-
 							$text = JHtml::_('string.truncate', $text, $params->get('word_count'));
 							echo str_replace('&apos;', "'", $text);
 						?>

--- a/modules/mod_feed/tmpl/default.php
+++ b/modules/mod_feed/tmpl/default.php
@@ -90,8 +90,8 @@ else
 		<ul class="newsfeed<?php echo $params->get('moduleclass_sfx'); ?>">
 		<?php for ($i = 0, $max = min(count($feed), $params->get('rssitems', 5)); $i < $max; $i++) { ?>
 			<?php
-				$uri   = (!empty($feed[$i]->uri) || $feed[$i]->uri !== null) ? trim($feed[$i]->uri) : trim($feed[$i]->guid);
-				$uri   = strpos($uri, 'http') !== 0 ? $params->get('rsslink') : $uri;
+				$uri   = $feed[$i]->uri || !$feed[$i]->isPermaLink ? trim($feed[$i]->uri) : trim($feed[$i]->guid);
+				$uri   = !$uri ? $params->get('rsslink') : $uri;
 				$text  = !empty($feed[$i]->content) || $feed[$i]->content !== null ? trim($feed[$i]->content) : trim($feed[$i]->description);
 				$title = trim($feed[$i]->title);
 			?>

--- a/modules/mod_feed/tmpl/default.php
+++ b/modules/mod_feed/tmpl/default.php
@@ -58,7 +58,7 @@ else
 		$iUrl   = isset($feed->image) ? $feed->image : null;
 		$iTitle = isset($feed->imagetitle) ? $feed->imagetitle : null;
 		?>
-		<div style="direction: <?php echo $rssrtl ? 'rtl' :'ltr'; ?>; text-align: <?php echo $rssrtl ? 'right' :'left'; ?> !important"  class="feed<?php echo $moduleclass_sfx; ?>">
+		<div style="direction: <?php echo $rssrtl ? 'rtl' :'ltr'; ?>; text-align: <?php echo $rssrtl ? 'right' :'left'; ?> !important" class="feed<?php echo $moduleclass_sfx; ?>">
 		<?php
 		// Feed description
 		if ($feed->title !== null && $params->get('rsstitle', 1))
@@ -91,7 +91,7 @@ else
 		<?php for ($i = 0, $max = min(count($feed), $params->get('rssitems', 5)); $i < $max; $i++) { ?>
 			<?php
 				$uri   = $feed[$i]->uri || !$feed[$i]->isPermaLink ? trim($feed[$i]->uri) : trim($feed[$i]->guid);
-				$uri   = !$uri ? $params->get('rsslink') : $uri;
+				$uri   = !$uri || stripos($uri, 'http') !== 0 ? $params->get('rsslink') : $uri;
 				$text  = !empty($feed[$i]->content) || $feed[$i]->content !== null ? trim($feed[$i]->content) : trim($feed[$i]->description);
 				$title = trim($feed[$i]->title);
 			?>


### PR DESCRIPTION
Pull Request for Issue #19919.

### Summary of Changes
This changes newsfeed links in com_newsfeeds to use URL from item's `<link>` element as opposed to `<guid>` element. This is already done in mod_feed. Additionally, this adds a check for GUID's `isPermaLink` property so `<guid>` can only be used when `<link>` is missing and `isPermaLink` is not set to `false`.

### Testing Instructions
Install Joomla with sample data. Check newsfeed links in com_newsfeeds.

### Expected result
Links like this: `http://feeds.joomla.org/~r/JoomlaAnnouncements/~3/w60t6iTw8NI/5730-joomla-3-8-8-release.html`

### Actual result
Links like this: `https://www.joomla.org/announcements/release-news/5730-joomla-3-8-8-release.html`

### Documentation Changes Required
No.