### PR TITLE
[4.0] Load language strings for message titles used by core.js

### DIFF
--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -59,6 +59,13 @@ abstract class JHtmlBehavior
 			return;
 		}
 
+		// Add core.js language strings
+		JText::script('ERROR');
+		JText::script('INFO');
+		JText::script('NOTICE');
+		JText::script('MESSAGE');
+		JText::script('WARNING');
+
 		JHtml::_('form.csrf');
 		JHtml::_('script', 'system/core.min.js', array('version' => 'auto', 'relative' => true));
 

--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -60,11 +60,11 @@ abstract class JHtmlBehavior
 		}
 
 		// Add core.js language strings
-		JText::script('ERROR', false, true, false);
-		JText::script('INFO', false, true, false);
-		JText::script('NOTICE', false, true, false);
-		JText::script('MESSAGE', false, true, false);
-		JText::script('WARNING', false, true, false);
+		JText::script('ERROR');
+		JText::script('INFO');
+		JText::script('NOTICE');
+		JText::script('MESSAGE');
+		JText::script('WARNING');
 
 		JHtml::_('form.csrf');
 		JHtml::_('script', 'system/core.min.js', array('version' => 'auto', 'relative' => true));

--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -60,11 +60,11 @@ abstract class JHtmlBehavior
 		}
 
 		// Add core.js language strings
-		JText::script('ERROR');
-		JText::script('INFO');
-		JText::script('NOTICE');
-		JText::script('MESSAGE');
-		JText::script('WARNING');
+		JText::script('ERROR', false, true, false);
+		JText::script('INFO', false, true, false);
+		JText::script('NOTICE', false, true, false);
+		JText::script('MESSAGE', false, true, false);
+		JText::script('WARNING', false, true, false);
 
 		JHtml::_('form.csrf');
 		JHtml::_('script', 'system/core.min.js', array('version' => 'auto', 'relative' => true));

--- a/libraries/src/Language/Text.php
+++ b/libraries/src/Language/Text.php
@@ -358,12 +358,13 @@ class Text
 	 * @param   string   $string                The Text key.
 	 * @param   boolean  $jsSafe                Ensure the output is JavaScript safe.
 	 * @param   boolean  $interpretBackSlashes  Interpret \t and \n.
+	 * @param   boolean  $loadDependentJsLibs   Load dependent JS libraries
 	 *
 	 * @return  string
 	 *
 	 * @since   11.1
 	 */
-	public static function script($string = null, $jsSafe = false, $interpretBackSlashes = true)
+	public static function script($string = null, $jsSafe = false, $interpretBackSlashes = true, $loadDependentJsLibs = true)
 	{
 		if ($string === null)
 		{
@@ -403,7 +404,10 @@ class Text
 			static::$strings[strtoupper($string)] = Factory::getLanguage()->_($string, $jsSafe, $interpretBackSlashes);
 
 			// Load core.js dependency
-			HTMLHelper::_('behavior.core');
+			if ($loadDependentJsLibs)
+			{
+				HTMLHelper::_('behavior.core');
+			}
 
 			// Update Joomla.JText script options
 			Factory::getDocument()->addScriptOptions('joomla.jtext', static::$strings, false);

--- a/libraries/src/Language/Text.php
+++ b/libraries/src/Language/Text.php
@@ -403,9 +403,9 @@ class Text
 			static::$strings[strtoupper($string)] = Factory::getLanguage()->_($string, $jsSafe, $interpretBackSlashes);
 
 			// Load needed JS libs
-			static $dependentJsLoaded = null;
+			static $dependentJsLoaded = false;
 
-			if ($dependentJsLoaded === null)
+			if ($dependentJsLoaded === false)
 			{
 				// Important !! Set static variable before making any calls to HTMLHelper methods
 				$dependentJsLoaded = true;

--- a/libraries/src/Language/Text.php
+++ b/libraries/src/Language/Text.php
@@ -358,13 +358,12 @@ class Text
 	 * @param   string   $string                The Text key.
 	 * @param   boolean  $jsSafe                Ensure the output is JavaScript safe.
 	 * @param   boolean  $interpretBackSlashes  Interpret \t and \n.
-	 * @param   boolean  $loadDependentJsLibs   Load dependent JS libraries
 	 *
 	 * @return  string
 	 *
 	 * @since   11.1
 	 */
-	public static function script($string = null, $jsSafe = false, $interpretBackSlashes = true, $loadDependentJsLibs = true)
+	public static function script($string = null, $jsSafe = false, $interpretBackSlashes = true)
 	{
 		if ($string === null)
 		{
@@ -403,9 +402,13 @@ class Text
 			// Normalize the key and translate the string.
 			static::$strings[strtoupper($string)] = Factory::getLanguage()->_($string, $jsSafe, $interpretBackSlashes);
 
-			// Load core.js dependency
-			if ($loadDependentJsLibs)
+			// Load needed JS libs
+			static $dependentJsLoaded = null;
+
+			if ($dependentJsLoaded === null)
 			{
+				// Important !! Set static variable before making any calls to HTMLHelper methods
+				$dependentJsLoaded = true;
 				HTMLHelper::_('behavior.core');
 			}
 


### PR DESCRIPTION
Pull Request for Issue #20719 

### Summary of Changes
Make `JHtml::_('behavior.core');` also load language strings used by core.js
```php
		JText::script('ERROR');
		JText::script('INFO');
		JText::script('NOTICE');
		JText::script('MESSAGE');
		JText::script('WARNING');
```

### Testing Instructions
A backend message should show as title
Success instead of success
Warning instead of warning

notice the capital letter to know that translation is working


### Expected result



### Actual result



### Documentation Changes Required

