### PR TITLE
Login to view the article redirect fix

### DIFF
--- a/components/com_content/views/article/view.html.php
+++ b/components/com_content/views/article/view.html.php
@@ -150,7 +150,7 @@ class ContentViewArticle extends JViewLegacy
 			if ($this->user->get('guest'))
 			{
 				$return = base64_encode(JUri::getInstance());
-				$login_url_with_return = JRoute::_('index.php?option=com_users&return=' . $return);
+				$login_url_with_return = JRoute::_('index.php?option=com_users&view=login&return=' . $return);
 				$app->enqueueMessage(JText::_('JERROR_ALERTNOAUTHOR'), 'notice');
 				$app->redirect($login_url_with_return, 403);
 			}


### PR DESCRIPTION
## About the fix

Without the view=login parameter JRoute can not resolve the Itemid. 
So the menu item assigned to 'login' view is not active.

## Step to reproduce the issue

1) Create a menu item for the login page (option=com_users&view=login).

2) Create an article with :
Article -> Access level : Registered
Article -> Properties: "Link not authorized" = "Yes".

3) Create a menu item for this article :
Article -> Properties: "Link not authorized" = "Yes". (to be sure)

4) Click on the menu item (you must not be logged in frontend)

## Actual result

You are redirected to the login page but the right menu item is not active.

## Expected result

You are redirected to the login page and the right menu item is active.

## Additional comments

**Seems there is a related hack here**:
/com_content/views/article/tmpl/default.php ~line 143

This can also cause problems with third party extensions like sh404sef.
