### PR TITLE
(UX) Add link to edit categories and show parent category

### DIFF
--- a/administrator/components/com_content/models/articles.php
+++ b/administrator/components/com_content/models/articles.php
@@ -206,7 +206,7 @@ class ContentModelArticles extends JModelList
 			->join('LEFT', '#__viewlevels AS ag ON ag.id = a.access');
 
 		// Join over the categories.
-		$query->select('c.title AS category_title, c.created_user_id as category_uid')
+		$query->select('c.title AS category_title, c.created_user_id as category_uid, c.level as category_level')
 			->join('LEFT', '#__categories AS c ON c.id = a.catid');
 
 		// Join over the parent categories.

--- a/administrator/components/com_content/models/articles.php
+++ b/administrator/components/com_content/models/articles.php
@@ -188,7 +188,7 @@ class ContentModelArticles extends JModelList
 				'list.select',
 				'DISTINCT a.id, a.title, a.alias, a.checked_out, a.checked_out_time, a.catid' .
 				', a.state, a.access, a.created, a.created_by, a.created_by_alias, a.modified, a.ordering, a.featured, a.language, a.hits' .
-				', a.publish_up, a.publish_down, c.parent_id, c.title, p.title'
+				', a.publish_up, a.publish_down'
 			)
 		);
 		$query->from('#__content AS a');
@@ -219,7 +219,7 @@ class ContentModelArticles extends JModelList
 
 		// Join over category creator
 		$query->select('cuid.created_user_id AS category_uid')
-			->join('LEFT', '#__categories AS cuid ON cuid.id = a.catid'); 
+			->join('LEFT', '#__categories AS cuid ON cuid.id = a.catid');
 
 		// Join over the users for the author.
 		$query->select('ua.name AS author_name')

--- a/administrator/components/com_content/models/articles.php
+++ b/administrator/components/com_content/models/articles.php
@@ -188,7 +188,7 @@ class ContentModelArticles extends JModelList
 				'list.select',
 				'DISTINCT a.id, a.title, a.alias, a.checked_out, a.checked_out_time, a.catid' .
 				', a.state, a.access, a.created, a.created_by, a.created_by_alias, a.modified, a.ordering, a.featured, a.language, a.hits' .
-				', a.publish_up, a.publish_down'
+				', a.publish_up, a.publish_down, c.parent_id, p.title'
 			)
 		);
 		$query->from('#__content AS a');
@@ -205,9 +205,13 @@ class ContentModelArticles extends JModelList
 		$query->select('ag.title AS access_level')
 			->join('LEFT', '#__viewlevels AS ag ON ag.id = a.access');
 
-		// Join over the categories.
-		$query->select('c.title AS category_title')
+		// Join over the categories and parent categories.
+		$query->select('c.title AS category_title, c.parent_id AS parent_category_id')
 			->join('LEFT', '#__categories AS c ON c.id = a.catid');
+
+		// Join over parent category title
+		$query->select('p.title AS parent_category_title')
+			->join('LEFT', '#__categories AS p ON p.id = c.parent_id');
 
 		// Join over the users for the author.
 		$query->select('ua.name AS author_name')

--- a/administrator/components/com_content/models/articles.php
+++ b/administrator/components/com_content/models/articles.php
@@ -206,11 +206,11 @@ class ContentModelArticles extends JModelList
 			->join('LEFT', '#__viewlevels AS ag ON ag.id = a.access');
 
 		// Join over the categories.
-		$query->select('c.title AS category_title, c.created_user_id as category_uid, c.level as category_level')
+		$query->select('c.title AS category_title, c.created_user_id AS category_uid, c.level AS category_level')
 			->join('LEFT', '#__categories AS c ON c.id = a.catid');
 
 		// Join over the parent categories.
-		$query->select('parent.title AS parent_category_title, parent.id AS parent_category_id, parent.created_user_id AS parent_category_uid')
+		$query->select('parent.title AS parent_category_title, parent.id AS parent_category_id, parent.created_user_id AS parent_category_uid, parent.level AS parent_category_level')
 			->join('LEFT', '#__categories AS parent ON parent.id = c.parent_id');
 
 		// Join over the users for the author.

--- a/administrator/components/com_content/models/articles.php
+++ b/administrator/components/com_content/models/articles.php
@@ -210,7 +210,8 @@ class ContentModelArticles extends JModelList
 			->join('LEFT', '#__categories AS c ON c.id = a.catid');
 
 		// Join over the parent categories.
-		$query->select('parent.title AS parent_category_title, parent.id AS parent_category_id, parent.created_user_id AS parent_category_uid, parent.level AS parent_category_level')
+		$query->select('parent.title AS parent_category_title, parent.id AS parent_category_id, 
+								parent.created_user_id AS parent_category_uid, parent.level AS parent_category_level')
 			->join('LEFT', '#__categories AS parent ON parent.id = c.parent_id');
 
 		// Join over the users for the author.

--- a/administrator/components/com_content/models/articles.php
+++ b/administrator/components/com_content/models/articles.php
@@ -205,21 +205,13 @@ class ContentModelArticles extends JModelList
 		$query->select('ag.title AS access_level')
 			->join('LEFT', '#__viewlevels AS ag ON ag.id = a.access');
 
-		// Join over the categories and parent categories.
-		$query->select('c.title AS category_title, c.parent_id AS parent_category_id')
+		// Join over the categories.
+		$query->select('c.title AS category_title, c.created_user_id as category_uid')
 			->join('LEFT', '#__categories AS c ON c.id = a.catid');
 
-		// Join over parent category title
-		$query->select('p.title AS parent_category_title, p.parent_id AS parent_parent_category_id')
-			->join('LEFT', '#__categories AS p ON p.id = c.parent_id');
-
-		// Join over parent category creator
-		$query->select('puid.created_user_id AS parent_category_uid')
-			->join('LEFT', '#__categories AS puid ON puid.id = c.parent_id');
-
-		// Join over category creator
-		$query->select('cuid.created_user_id AS category_uid')
-			->join('LEFT', '#__categories AS cuid ON cuid.id = a.catid');
+		// Join over the parent categories.
+		$query->select('parent.title AS parent_category_title, parent.id AS parent_category_id, parent.created_user_id AS parent_category_uid')
+			->join('LEFT', '#__categories AS parent ON parent.id = c.parent_id');
 
 		// Join over the users for the author.
 		$query->select('ua.name AS author_name')

--- a/administrator/components/com_content/models/articles.php
+++ b/administrator/components/com_content/models/articles.php
@@ -210,7 +210,7 @@ class ContentModelArticles extends JModelList
 			->join('LEFT', '#__categories AS c ON c.id = a.catid');
 
 		// Join over parent category title
-		$query->select('p.title AS parent_category_title')
+		$query->select('p.title AS parent_category_title, p.parent_id AS parent_parent_category_id')
 			->join('LEFT', '#__categories AS p ON p.id = c.parent_id');
 
 		// Join over the users for the author.

--- a/administrator/components/com_content/models/articles.php
+++ b/administrator/components/com_content/models/articles.php
@@ -188,7 +188,7 @@ class ContentModelArticles extends JModelList
 				'list.select',
 				'DISTINCT a.id, a.title, a.alias, a.checked_out, a.checked_out_time, a.catid' .
 				', a.state, a.access, a.created, a.created_by, a.created_by_alias, a.modified, a.ordering, a.featured, a.language, a.hits' .
-				', a.publish_up, a.publish_down, c.parent_id, p.title'
+				', a.publish_up, a.publish_down, c.parent_id, c.title, p.title'
 			)
 		);
 		$query->from('#__content AS a');
@@ -212,6 +212,14 @@ class ContentModelArticles extends JModelList
 		// Join over parent category title
 		$query->select('p.title AS parent_category_title, p.parent_id AS parent_parent_category_id')
 			->join('LEFT', '#__categories AS p ON p.id = c.parent_id');
+
+		// Join over parent category creator
+		$query->select('puid.created_user_id AS parent_category_uid')
+			->join('LEFT', '#__categories AS puid ON puid.id = c.parent_id');
+
+		// Join over category creator
+		$query->select('cuid.created_user_id AS category_uid')
+			->join('LEFT', '#__categories AS cuid ON cuid.id = a.catid'); 
 
 		// Join over the users for the author.
 		$query->select('ua.name AS author_name')

--- a/administrator/components/com_content/models/featured.php
+++ b/administrator/components/com_content/models/featured.php
@@ -108,7 +108,8 @@ class ContentModelFeatured extends ContentModelArticles
 			->join('LEFT', '#__categories AS c ON c.id = a.catid');
 
 		// Join over the parent categories.
-		$query->select('parent.title AS parent_category_title, parent.id AS parent_category_id, parent.created_user_id AS parent_category_uid, parent.level AS parent_category_level')
+		$query->select('parent.title AS parent_category_title, parent.id AS parent_category_id, 
+								parent.created_user_id AS parent_category_uid, parent.level AS parent_category_level')
 			->join('LEFT', '#__categories AS parent ON parent.id = c.parent_id');
 
 		// Join over the users for the author.

--- a/administrator/components/com_content/models/featured.php
+++ b/administrator/components/com_content/models/featured.php
@@ -104,8 +104,12 @@ class ContentModelFeatured extends ContentModelArticles
 			->join('LEFT', '#__viewlevels AS ag ON ag.id = a.access');
 
 		// Join over the categories.
-		$query->select('c.title AS category_title')
+		$query->select('c.title AS category_title, c.created_user_id AS category_uid, c.level AS category_level')
 			->join('LEFT', '#__categories AS c ON c.id = a.catid');
+
+		// Join over the parent categories.
+		$query->select('parent.title AS parent_category_title, parent.id AS parent_category_id, parent.created_user_id AS parent_category_uid, parent.level AS parent_category_level')
+			->join('LEFT', '#__categories AS parent ON parent.id = c.parent_id');
 
 		// Join over the users for the author.
 		$query->select('ua.name AS author_name')

--- a/administrator/components/com_content/views/articles/tmpl/default.php
+++ b/administrator/components/com_content/views/articles/tmpl/default.php
@@ -215,7 +215,7 @@ $assoc = JLanguageAssociations::isEnabled();
 										{
 											if ($item->category_level != '1') :
 												if ($canEditParCat || $canEditOwnParCat) :
-													echo '<a class="hasTooltip" href=' . $ParentCatUrl . '" title="' . $EditCatTxt . '">';
+													echo '<a class="hasTooltip" href="' . $ParentCatUrl . '" title="' . $EditCatTxt . '">';
 												endif;
 												echo $this->escape($item->parent_category_title);
 												if ($canEditParCat || $canEditOwnParCat) :
@@ -224,7 +224,7 @@ $assoc = JLanguageAssociations::isEnabled();
 												echo ' &#187; ';
 											endif;
 											if ($canEditCat || $canEditOwnCat) :
-												echo '<a class="hasTooltip" href=' . $CurrentCatUrl . '" title="' . $EditCatTxt . '">';
+												echo '<a class="hasTooltip" href="' . $CurrentCatUrl . '" title="' . $EditCatTxt . '">';
 											endif;
 											echo $this->escape($item->category_title);
 											if ($canEditCat || $canEditOwnCat) :
@@ -232,10 +232,9 @@ $assoc = JLanguageAssociations::isEnabled();
 											endif;
 										}
 										else
-											{
-
+										{
 											if ($canEditCat || $canEditOwnCat) :
-												echo '<a class="hasTooltip" href=' . $CurrentCatUrl . '" title="' . $EditCatTxt . '">';
+												echo '<a class="hasTooltip" href="' . $CurrentCatUrl . '" title="' . $EditCatTxt . '">';
 											endif;
 											echo $this->escape($item->category_title);
 											if ($canEditCat || $canEditOwnCat) :
@@ -245,7 +244,7 @@ $assoc = JLanguageAssociations::isEnabled();
 											if ($item->category_level != '1') :
 												echo ' &#171; ';
 												if ($canEditParCat || $canEditOwnParCat) :
-													echo '<a class="hasTooltip" href=' . $ParentCatUrl . '" title="' . $EditCatTxt . '">';
+													echo '<a class="hasTooltip" href="' . $ParentCatUrl . '" title="' . $EditCatTxt . '">';
 												endif;
 												echo $this->escape($item->parent_category_title);
 												if ($canEditParCat || $canEditOwnParCat) :

--- a/administrator/components/com_content/views/articles/tmpl/default.php
+++ b/administrator/components/com_content/views/articles/tmpl/default.php
@@ -137,13 +137,10 @@ $assoc = JLanguageAssociations::isEnabled();
 					$canCheckin = $user->authorise('core.manage',     'com_checkin') || $item->checked_out == $userId || $item->checked_out == 0;
 					$canEditOwn = $user->authorise('core.edit.own',   'com_content.article.' . $item->id) && $item->created_by == $userId;
 					$canChange  = $user->authorise('core.edit.state', 'com_content.article.' . $item->id) && $canCheckin;
-
 					$canEditCat    = $user->authorise('core.edit',       'com_content.category.' . $item->catid);
 					$canEditOwnCat = $user->authorise('core.edit.own',   'com_content.category.' . $item->catid) && $item->category_uid == $userId;
-
 					$canEditParCat    = $user->authorise('core.edit',       'com_content.category.' . $item->parent_category_id);
 					$canEditOwnParCat = $user->authorise('core.edit.own',   'com_content.category.' . $item->parent_category_id) && $item->parent_category_uid == $userId;
-
 					?>
 					<tr class="row<?php echo $i % 2; ?>" sortable-group-id="<?php echo $item->catid; ?>">
 						<td class="order nowrap center hidden-phone">
@@ -197,7 +194,6 @@ $assoc = JLanguageAssociations::isEnabled();
 									<?php echo JText::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->alias)); ?>
 								</span>
 								<div class="small">
-
 									<?php
 									$ParentCatUrl = JRoute::_('index.php?option=com_categories&task=category.edit&id=' . $item->parent_category_id . '&extension=com_content');
 									$CurrentCatUrl = JRoute::_('index.php?option=com_categories&task=category.edit&id=' . $item->catid . '&extension=com_content');

--- a/administrator/components/com_content/views/articles/tmpl/default.php
+++ b/administrator/components/com_content/views/articles/tmpl/default.php
@@ -198,7 +198,7 @@ $assoc = JLanguageAssociations::isEnabled();
 								</span>
 								<div class="small">
 									<?php echo JText::_('JCATEGORY') . ':' ?>
-										<?php if ($item->parent_category_id != '1') : ?>
+										<?php if ($item->parent_category_title != 'ROOT') : ?>
 											<?php echo ' » '; ?>
 											<?php if ($canEditParCat || $canEditOwnParCat) : ?>
 												<a 	class="hasTooltip"

--- a/administrator/components/com_content/views/articles/tmpl/default.php
+++ b/administrator/components/com_content/views/articles/tmpl/default.php
@@ -138,6 +138,12 @@ $assoc = JLanguageAssociations::isEnabled();
 					$canEditOwn = $user->authorise('core.edit.own',   'com_content.article.' . $item->id) && $item->created_by == $userId;
 					$canChange  = $user->authorise('core.edit.state', 'com_content.article.' . $item->id) && $canCheckin;
 
+					$canEditCat    = $user->authorise('core.edit',       'com_content.category.' . $item->catid);
+					$canEditOwnCat = $user->authorise('core.edit.own',   'com_content.category.' . $item->catid) && $item->category_uid == $userId;
+
+					$canEditParCat    = $user->authorise('core.edit',       'com_content.category.' . $item->parent_category_id);
+					$canEditOwnParCat = $user->authorise('core.edit.own',   'com_content.category.' . $item->parent_category_id) && $item->parent_category_uid == $userId;
+
 					?>
 					<tr class="row<?php echo $i % 2; ?>" sortable-group-id="<?php echo $item->catid; ?>">
 						<td class="order nowrap center hidden-phone">
@@ -192,12 +198,12 @@ $assoc = JLanguageAssociations::isEnabled();
 								</span>
 								<div class="small">
 									<?php echo JText::_('JCATEGORY') . ':' ?>
-									
+
 										<?php if ($item->parent_parent_category_id != '0')  : ?>
 
 											<?php echo ' » '; ?>
 
-											<?php if ($canEdit || $canEditOwn) : ?>
+											<?php if ($canEditParCat || $canEditOwnParCat) : ?>
 
 												<a  class="hasTooltip"
 									                href="<?php echo JRoute::_('index.php?option=com_categories&task=category.edit&id=' . $item->parent_category_id . '&extension=com_content'); ?>"
@@ -207,7 +213,7 @@ $assoc = JLanguageAssociations::isEnabled();
 
 											<?php echo '' . $item->parent_category_title . ''; ?>
 
-											<?php if ($canEdit || $canEditOwn) : ?>
+											<?php if ($canEditParCat || $canEditOwnParCat) : ?>
 
 												</a>
 
@@ -217,7 +223,7 @@ $assoc = JLanguageAssociations::isEnabled();
 
 										<?php endif; ?>
 
-										<?php if ($canEdit || $canEditOwn) : ?>
+										<?php if ($canEditCat || $canEditOwnCat) : ?>
 
 											<a  class="hasTooltip"
 									            href="<?php echo JRoute::_('index.php?option=com_categories&task=category.edit&id=' . $item->catid . '&extension=com_content'); ?>"
@@ -227,7 +233,7 @@ $assoc = JLanguageAssociations::isEnabled();
 
 											<?php echo $this->escape($item->category_title); ?>
 
-										<?php if ($canEdit || $canEditOwn) : ?>
+										<?php if ($canEditCat || $canEditOwnCat) : ?>
 
 											</a>
 

--- a/administrator/components/com_content/views/articles/tmpl/default.php
+++ b/administrator/components/com_content/views/articles/tmpl/default.php
@@ -207,7 +207,7 @@ $assoc = JLanguageAssociations::isEnabled();
 
 										if ($item->category_level != '1') :
 											if ($item->parent_category_level != '1') :
-												echo ' » ';
+												echo ' &#187; ';
 											endif;
 										endif;
 
@@ -221,7 +221,7 @@ $assoc = JLanguageAssociations::isEnabled();
 												if ($canEditParCat || $canEditOwnParCat) :
 													echo '</a>';
 												endif;
-												echo ' » ';
+												echo ' &#187; ';
 											endif;
 											if ($canEditCat || $canEditOwnCat) :
 												echo '<a class="hasTooltip" href=' . $CurrentCatUrl . '" title="' . $EditCatTxt . '">';
@@ -233,7 +233,7 @@ $assoc = JLanguageAssociations::isEnabled();
 										}
 										else
 											{
-												
+
 											if ($canEditCat || $canEditOwnCat) :
 												echo '<a class="hasTooltip" href=' . $CurrentCatUrl . '" title="' . $EditCatTxt . '">';
 											endif;
@@ -243,7 +243,7 @@ $assoc = JLanguageAssociations::isEnabled();
 											endif;
 
 											if ($item->category_level != '1') :
-												echo ' « ';
+												echo ' &#171; ';
 												if ($canEditParCat || $canEditOwnParCat) :
 													echo '<a class="hasTooltip" href=' . $ParentCatUrl . '" title="' . $EditCatTxt . '">';
 												endif;

--- a/administrator/components/com_content/views/articles/tmpl/default.php
+++ b/administrator/components/com_content/views/articles/tmpl/default.php
@@ -192,8 +192,10 @@ $assoc = JLanguageAssociations::isEnabled();
 								</span>
 								<div class="small">
 									<?php echo JText::_('JCATEGORY') . ':' ?>
+									
+										<?php if ($item->parent_parent_category_id != '0')  : ?>
 
-										<?php if ($item->parent_category_title != 'ROOT')  : ?>
+											<?php echo ' » '; ?>
 
 											<?php if ($canEdit || $canEditOwn) : ?>
 
@@ -230,7 +232,7 @@ $assoc = JLanguageAssociations::isEnabled();
 											</a>
 
 										<?php endif; ?>
-									
+
 								</div>
 							</div>
 						</td>

--- a/administrator/components/com_content/views/articles/tmpl/default.php
+++ b/administrator/components/com_content/views/articles/tmpl/default.php
@@ -197,31 +197,58 @@ $assoc = JLanguageAssociations::isEnabled();
 									<?php echo JText::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->alias)); ?>
 								</span>
 								<div class="small">
-									<?php echo JText::_('JCATEGORY') . ':' ?>
-										<?php if ($item->category_level != '1') : ?>
-											<?php if ($item->parent_category_level != '1') : ?>
-												<?php echo ' » '; ?>
-											<?php endif; ?>
-											<?php if ($canEditParCat || $canEditOwnParCat) : ?>
-												<a 	class="hasTooltip"
-													href="<?php echo JRoute::_('index.php?option=com_categories&task=category.edit&id=' . $item->parent_category_id . '&extension=com_content'); ?>"
-													title="<?php echo JText::_('JACTION_EDIT') . ' ' . JText::_('JCATEGORY'); ?>">
-											<?php endif; ?>
-											<?php echo $item->parent_category_title ; ?>
-											<?php if ($canEditParCat || $canEditOwnParCat) : ?>
-												</a>
-											<?php endif; ?>
-											<?php echo ' » '; ?>
-										<?php endif; ?>
-										<?php if ($canEditCat || $canEditOwnCat) : ?>
-											<a	class="hasTooltip"
-												href="<?php echo JRoute::_('index.php?option=com_categories&task=category.edit&id=' . $item->catid . '&extension=com_content'); ?>"
-												title="<?php echo JText::_('JACTION_EDIT') . ' ' . JText::_('JCATEGORY'); ?>">
-										<?php endif; ?>
-											<?php echo $this->escape($item->category_title); ?>
-										<?php if ($canEditCat || $canEditOwnCat) : ?>
-											</a>
-										<?php endif; ?>
+
+									<?php
+									$ParentCatUrl = JRoute::_('index.php?option=com_categories&task=category.edit&id=' . $item->parent_category_id . '&extension=com_content');
+									$CurrentCatUrl = JRoute::_('index.php?option=com_categories&task=category.edit&id=' . $item->catid . '&extension=com_content');
+									$EditCatTxt = JText::_('JACTION_EDIT') . ' ' . JText::_('JCATEGORY');
+
+										echo JText::_('JCATEGORY') . ': ';
+										if ($item->category_level != '1') :
+											if ($item->parent_category_level != '1') :
+												echo ' » ';
+											endif;
+										endif;
+
+										if ($this->document->direction == "ltr") {
+											if ($item->category_level != '1') :
+												if ($canEditParCat || $canEditOwnParCat) :
+													echo '<a class="hasTooltip" href=' . $ParentCatUrl . '" title="' . $EditCatTxt . '">';
+												endif;
+												echo $this->escape($item->parent_category_title);
+												if ($canEditParCat || $canEditOwnParCat) :
+													echo '</a>';
+												endif;
+												echo ' » ';
+											endif;
+											if ($canEditCat || $canEditOwnCat) :
+												echo '<a class="hasTooltip" href=' . $CurrentCatUrl . '" title="' . $EditCatTxt . '">';
+											endif;
+											echo $this->escape($item->category_title);
+											if ($canEditCat || $canEditOwnCat) :
+												echo '</a>';
+											endif;
+										} else {
+											if ($canEditCat || $canEditOwnCat) :
+												echo '<a class="hasTooltip" href=' . $CurrentCatUrl . '" title="' . $EditCatTxt . '">';
+											endif;
+											echo $this->escape($item->category_title);
+											if ($canEditCat || $canEditOwnCat) :
+												echo '</a>';
+											endif;
+
+											if ($item->category_level != '1') :
+												echo ' « ';
+												if ($canEditParCat || $canEditOwnParCat) :
+													echo '<a class="hasTooltip" href=' . $ParentCatUrl . '" title="' . $EditCatTxt . '">';
+												endif;
+												echo $this->escape($item->parent_category_title);
+												if ($canEditParCat || $canEditOwnParCat) :
+													echo '</a>';
+												endif;
+											endif;
+										}
+									?>
 								</div>
 							</div>
 						</td>

--- a/administrator/components/com_content/views/articles/tmpl/default.php
+++ b/administrator/components/com_content/views/articles/tmpl/default.php
@@ -198,47 +198,28 @@ $assoc = JLanguageAssociations::isEnabled();
 								</span>
 								<div class="small">
 									<?php echo JText::_('JCATEGORY') . ':' ?>
-
-										<?php if ($item->parent_category_id != '1')  : ?>
-										
+										<?php if ($item->parent_category_id != '1') : ?>
 											<?php echo ' » '; ?>
-
 											<?php if ($canEditParCat || $canEditOwnParCat) : ?>
-
-												<a  class="hasTooltip"
-									                href="<?php echo JRoute::_('index.php?option=com_categories&task=category.edit&id=' . $item->parent_category_id . '&extension=com_content'); ?>"
-									                title="<?php echo JText::_('JACTION_EDIT') . ' ' . JText::_('JCATEGORY'); ?>">
-
-											<?php endif ?>
-
-											<?php echo '' . $item->parent_category_title . ''; ?>
-
-											<?php if ($canEditParCat || $canEditOwnParCat) : ?>
-
-												</a>
-
+												<a 	class="hasTooltip"
+													href="<?php echo JRoute::_('index.php?option=com_categories&task=category.edit&id=' . $item->parent_category_id . '&extension=com_content'); ?>"
+													title="<?php echo JText::_('JACTION_EDIT') . ' ' . JText::_('JCATEGORY'); ?>">
 											<?php endif; ?>
-
+											<?php echo $item->parent_category_title ; ?>
+											<?php if ($canEditParCat || $canEditOwnParCat) : ?>
+												</a>
+											<?php endif; ?>
 											<?php echo ' » '; ?>
-
 										<?php endif; ?>
-
 										<?php if ($canEditCat || $canEditOwnCat) : ?>
-
-											<a  class="hasTooltip"
-									            href="<?php echo JRoute::_('index.php?option=com_categories&task=category.edit&id=' . $item->catid . '&extension=com_content'); ?>"
-									            title="<?php echo JText::_('JACTION_EDIT') . ' ' . JText::_('JCATEGORY'); ?>">
-
+											<a	class="hasTooltip"
+												href="<?php echo JRoute::_('index.php?option=com_categories&task=category.edit&id=' . $item->catid . '&extension=com_content'); ?>"
+												title="<?php echo JText::_('JACTION_EDIT') . ' ' . JText::_('JCATEGORY'); ?>">
 										<?php endif; ?>
-
 											<?php echo $this->escape($item->category_title); ?>
-
 										<?php if ($canEditCat || $canEditOwnCat) : ?>
-
 											</a>
-
 										<?php endif; ?>
-
 								</div>
 							</div>
 						</td>

--- a/administrator/components/com_content/views/articles/tmpl/default.php
+++ b/administrator/components/com_content/views/articles/tmpl/default.php
@@ -199,7 +199,9 @@ $assoc = JLanguageAssociations::isEnabled();
 								<div class="small">
 									<?php echo JText::_('JCATEGORY') . ':' ?>
 										<?php if ($item->category_level != '1') : ?>
+											<?php if ($item->parent_category_level != '1') : ?>
 												<?php echo ' » '; ?>
+											<?php endif; ?>
 											<?php if ($canEditParCat || $canEditOwnParCat) : ?>
 												<a 	class="hasTooltip"
 													href="<?php echo JRoute::_('index.php?option=com_categories&task=category.edit&id=' . $item->parent_category_id . '&extension=com_content'); ?>"

--- a/administrator/components/com_content/views/articles/tmpl/default.php
+++ b/administrator/components/com_content/views/articles/tmpl/default.php
@@ -199,8 +199,8 @@ $assoc = JLanguageAssociations::isEnabled();
 								<div class="small">
 									<?php echo JText::_('JCATEGORY') . ':' ?>
 
-										<?php if ($item->parent_parent_category_id != '0')  : ?>
-
+										<?php if ($item->parent_category_id != '1')  : ?>
+										
 											<?php echo ' » '; ?>
 
 											<?php if ($canEditParCat || $canEditOwnParCat) : ?>

--- a/administrator/components/com_content/views/articles/tmpl/default.php
+++ b/administrator/components/com_content/views/articles/tmpl/default.php
@@ -198,8 +198,8 @@ $assoc = JLanguageAssociations::isEnabled();
 								</span>
 								<div class="small">
 									<?php echo JText::_('JCATEGORY') . ':' ?>
-										<?php if ($item->parent_category_title != 'ROOT') : ?>
-											<?php echo ' » '; ?>
+										<?php if ($item->category_level != '1') : ?>
+												<?php echo ' » '; ?>
 											<?php if ($canEditParCat || $canEditOwnParCat) : ?>
 												<a 	class="hasTooltip"
 													href="<?php echo JRoute::_('index.php?option=com_categories&task=category.edit&id=' . $item->parent_category_id . '&extension=com_content'); ?>"

--- a/administrator/components/com_content/views/articles/tmpl/default.php
+++ b/administrator/components/com_content/views/articles/tmpl/default.php
@@ -200,6 +200,7 @@ $assoc = JLanguageAssociations::isEnabled();
 								<div class="small">
 									<?php echo JText::_('JCATEGORY') . ':' ?>
 
+									<?php if ($parent_cattitle != 'ROOT') : ?>
 									<?php if ($canEdit || $canEditOwn) : ?>
 
 									<a class="hasTooltip"
@@ -207,16 +208,16 @@ $assoc = JLanguageAssociations::isEnabled();
 									   title="<?php echo JText::_('JACTION_EDIT') . ' ' . JText::_('JCATEGORY'); ?>">
 										<?php endif ?>
 
-										<?php if ($parent_cattitle != 'ROOT') :
-											echo '' . $parent_cattitle . '';
-										endif; ?>
+										<?php echo ' ' . $parent_cattitle; ?>
+
 
 										<?php if ($canEdit || $canEditOwn) : ?>
 									</a>
 
-								<?php echo ' » '; ?>
+									<?php echo ' » '; ?>
 
-								<?php endif ?>
+									<?php endif ?>
+									<?php endif ?>
 
 									<?php if ($canEdit || $canEditOwn) : ?>
 									<a class="hasTooltip"

--- a/administrator/components/com_content/views/articles/tmpl/default.php
+++ b/administrator/components/com_content/views/articles/tmpl/default.php
@@ -204,13 +204,15 @@ $assoc = JLanguageAssociations::isEnabled();
 									$EditCatTxt = JText::_('JACTION_EDIT') . ' ' . JText::_('JCATEGORY');
 
 										echo JText::_('JCATEGORY') . ': ';
+
 										if ($item->category_level != '1') :
 											if ($item->parent_category_level != '1') :
 												echo ' » ';
 											endif;
 										endif;
 
-										if ($this->document->direction == "ltr") {
+										if ($this->document->direction == "ltr")
+										{
 											if ($item->category_level != '1') :
 												if ($canEditParCat || $canEditOwnParCat) :
 													echo '<a class="hasTooltip" href=' . $ParentCatUrl . '" title="' . $EditCatTxt . '">';
@@ -228,7 +230,10 @@ $assoc = JLanguageAssociations::isEnabled();
 											if ($canEditCat || $canEditOwnCat) :
 												echo '</a>';
 											endif;
-										} else {
+										}
+										else
+											{
+												
 											if ($canEditCat || $canEditOwnCat) :
 												echo '<a class="hasTooltip" href=' . $CurrentCatUrl . '" title="' . $EditCatTxt . '">';
 											endif;

--- a/administrator/components/com_content/views/articles/tmpl/default.php
+++ b/administrator/components/com_content/views/articles/tmpl/default.php
@@ -138,13 +138,6 @@ $assoc = JLanguageAssociations::isEnabled();
 					$canEditOwn = $user->authorise('core.edit.own',   'com_content.article.' . $item->id) && $item->created_by == $userId;
 					$canChange  = $user->authorise('core.edit.state', 'com_content.article.' . $item->id) && $canCheckin;
 
-					$db = JFactory::getDbo();
-					$catid = $item->catid;
-					$db->setQuery("SELECT cat.parent_id FROM #__categories cat WHERE cat.id='$catid'");
-					$parent_catid = $db->loadResult();
-					$db->setQuery("SELECT cat.title FROM #__categories cat WHERE cat.id='$parent_catid'");
-					$parent_cattitle = $db->loadResult();
-
 					?>
 					<tr class="row<?php echo $i % 2; ?>" sortable-group-id="<?php echo $item->catid; ?>">
 						<td class="order nowrap center hidden-phone">
@@ -200,34 +193,44 @@ $assoc = JLanguageAssociations::isEnabled();
 								<div class="small">
 									<?php echo JText::_('JCATEGORY') . ':' ?>
 
-									<?php if ($parent_cattitle != 'ROOT') : ?>
-									<?php if ($canEdit || $canEditOwn) : ?>
+										<?php if ($item->parent_category_title != 'ROOT')  : ?>
 
-									<a class="hasTooltip"
-									   href="<?php echo JRoute::_('index.php?option=com_categories&task=category.edit&id=' . $parent_catid . '&extension=com_content'); ?>"
-									   title="<?php echo JText::_('JACTION_EDIT') . ' ' . JText::_('JCATEGORY'); ?>">
-										<?php endif ?>
+											<?php if ($canEdit || $canEditOwn) : ?>
 
-										<?php echo '' . $parent_cattitle . ''; ?>
+												<a  class="hasTooltip"
+									                href="<?php echo JRoute::_('index.php?option=com_categories&task=category.edit&id=' . $item->parent_category_id . '&extension=com_content'); ?>"
+									                title="<?php echo JText::_('JACTION_EDIT') . ' ' . JText::_('JCATEGORY'); ?>">
+
+											<?php endif ?>
+
+											<?php echo '' . $item->parent_category_title . ''; ?>
+
+											<?php if ($canEdit || $canEditOwn) : ?>
+
+												</a>
+
+											<?php endif; ?>
+
+											<?php echo ' » '; ?>
+
+										<?php endif; ?>
 
 										<?php if ($canEdit || $canEditOwn) : ?>
-									</a>
 
-								<?php echo ' » '; ?>
+											<a  class="hasTooltip"
+									            href="<?php echo JRoute::_('index.php?option=com_categories&task=category.edit&id=' . $item->catid . '&extension=com_content'); ?>"
+									            title="<?php echo JText::_('JACTION_EDIT') . ' ' . JText::_('JCATEGORY'); ?>">
 
-								<?php endif; ?>
-								<?php endif; ?>
+										<?php endif; ?>
 
-									<?php if ($canEdit || $canEditOwn) : ?>
-									<a class="hasTooltip"
-									   href="<?php echo JRoute::_('index.php?option=com_categories&task=category.edit&id=' . $item->catid . '&extension=com_content'); ?>"
-									   title="<?php echo JText::_('JACTION_EDIT') . ' ' . JText::_('JCATEGORY'); ?>">
-									<?php endif; ?>
+											<?php echo $this->escape($item->category_title); ?>
 
-										<?php echo $this->escape($item->category_title); ?>
-									<?php if ($canEdit || $canEditOwn) : ?>
-									</a>
-									<?php endif; ?>
+										<?php if ($canEdit || $canEditOwn) : ?>
+
+											</a>
+
+										<?php endif; ?>
+									
 								</div>
 							</div>
 						</td>

--- a/administrator/components/com_content/views/articles/tmpl/default.php
+++ b/administrator/components/com_content/views/articles/tmpl/default.php
@@ -142,7 +142,7 @@ $assoc = JLanguageAssociations::isEnabled();
 					$catid = $item->catid;
 					$db->setQuery("SELECT cat.parent_id FROM #__categories cat WHERE cat.id='$catid'");
 					$parent_catid = $db->loadResult();
-					$db->setQuery("SELECT cat.title FROM #__categories cat WHERE cat.id='$parent_category_id'");
+					$db->setQuery("SELECT cat.title FROM #__categories cat WHERE cat.id='$parent_catid'");
 					$parent_cattitle = $db->loadResult();
 
 					?>
@@ -208,27 +208,26 @@ $assoc = JLanguageAssociations::isEnabled();
 									   title="<?php echo JText::_('JACTION_EDIT') . ' ' . JText::_('JCATEGORY'); ?>">
 										<?php endif ?>
 
-										<?php echo ' ' . $parent_cattitle; ?>
-
+										<?php echo '' . $parent_cattitle . ''; ?>
 
 										<?php if ($canEdit || $canEditOwn) : ?>
 									</a>
 
-									<?php echo ' » '; ?>
+								<?php echo ' » '; ?>
 
-									<?php endif ?>
-									<?php endif ?>
+								<?php endif; ?>
+								<?php endif; ?>
 
 									<?php if ($canEdit || $canEditOwn) : ?>
 									<a class="hasTooltip"
 									   href="<?php echo JRoute::_('index.php?option=com_categories&task=category.edit&id=' . $item->catid . '&extension=com_content'); ?>"
 									   title="<?php echo JText::_('JACTION_EDIT') . ' ' . JText::_('JCATEGORY'); ?>">
-									<?php endif ?>
+									<?php endif; ?>
 
 										<?php echo $this->escape($item->category_title); ?>
 									<?php if ($canEdit || $canEditOwn) : ?>
 									</a>
-									<?php endif ?>
+									<?php endif; ?>
 								</div>
 							</div>
 						</td>

--- a/administrator/components/com_content/views/articles/tmpl/default.php
+++ b/administrator/components/com_content/views/articles/tmpl/default.php
@@ -137,6 +137,14 @@ $assoc = JLanguageAssociations::isEnabled();
 					$canCheckin = $user->authorise('core.manage',     'com_checkin') || $item->checked_out == $userId || $item->checked_out == 0;
 					$canEditOwn = $user->authorise('core.edit.own',   'com_content.article.' . $item->id) && $item->created_by == $userId;
 					$canChange  = $user->authorise('core.edit.state', 'com_content.article.' . $item->id) && $canCheckin;
+
+					$db = JFactory::getDbo();
+					$catid = $item->catid;
+					$db->setQuery("SELECT cat.parent_id FROM #__categories cat WHERE cat.id='$catid'");
+					$parent_catid = $db->loadResult();
+					$db->setQuery("SELECT cat.title FROM #__categories cat WHERE cat.id='$parent_category_id'");
+					$parent_cattitle = $db->loadResult();
+
 					?>
 					<tr class="row<?php echo $i % 2; ?>" sortable-group-id="<?php echo $item->catid; ?>">
 						<td class="order nowrap center hidden-phone">
@@ -190,7 +198,36 @@ $assoc = JLanguageAssociations::isEnabled();
 									<?php echo JText::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->alias)); ?>
 								</span>
 								<div class="small">
-									<?php echo JText::_('JCATEGORY') . ': ' . $this->escape($item->category_title); ?>
+									<?php echo JText::_('JCATEGORY') . ':' ?>
+
+									<?php if ($canEdit || $canEditOwn) : ?>
+
+									<a class="hasTooltip"
+									   href="<?php echo JRoute::_('index.php?option=com_categories&task=category.edit&id=' . $parent_catid . '&extension=com_content'); ?>"
+									   title="<?php echo JText::_('JACTION_EDIT') . ' ' . JText::_('JCATEGORY'); ?>">
+										<?php endif ?>
+
+										<?php if ($parent_cattitle != 'ROOT') :
+											echo '' . $parent_cattitle . '';
+										endif; ?>
+
+										<?php if ($canEdit || $canEditOwn) : ?>
+									</a>
+
+								<?php echo ' » '; ?>
+
+								<?php endif ?>
+
+									<?php if ($canEdit || $canEditOwn) : ?>
+									<a class="hasTooltip"
+									   href="<?php echo JRoute::_('index.php?option=com_categories&task=category.edit&id=' . $item->catid . '&extension=com_content'); ?>"
+									   title="<?php echo JText::_('JACTION_EDIT') . ' ' . JText::_('JCATEGORY'); ?>">
+									<?php endif ?>
+
+										<?php echo $this->escape($item->category_title); ?>
+									<?php if ($canEdit || $canEditOwn) : ?>
+									</a>
+									<?php endif ?>
 								</div>
 							</div>
 						</td>

--- a/administrator/components/com_content/views/articles/tmpl/default.php
+++ b/administrator/components/com_content/views/articles/tmpl/default.php
@@ -207,27 +207,7 @@ $assoc = JLanguageAssociations::isEnabled();
 											endif;
 										endif;
 
-										if ($this->document->direction == "ltr")
-										{
-											if ($item->category_level != '1') :
-												if ($canEditParCat || $canEditOwnParCat) :
-													echo '<a class="hasTooltip" href="' . $ParentCatUrl . '" title="' . $EditCatTxt . '">';
-												endif;
-												echo $this->escape($item->parent_category_title);
-												if ($canEditParCat || $canEditOwnParCat) :
-													echo '</a>';
-												endif;
-												echo ' &#187; ';
-											endif;
-											if ($canEditCat || $canEditOwnCat) :
-												echo '<a class="hasTooltip" href="' . $CurrentCatUrl . '" title="' . $EditCatTxt . '">';
-											endif;
-											echo $this->escape($item->category_title);
-											if ($canEditCat || $canEditOwnCat) :
-												echo '</a>';
-											endif;
-										}
-										else
+										if (JFactory::getLanguage()->isRtl())
 										{
 											if ($canEditCat || $canEditOwnCat) :
 												echo '<a class="hasTooltip" href="' . $CurrentCatUrl . '" title="' . $EditCatTxt . '">';
@@ -246,6 +226,26 @@ $assoc = JLanguageAssociations::isEnabled();
 												if ($canEditParCat || $canEditOwnParCat) :
 													echo '</a>';
 												endif;
+											endif;
+										}
+										else
+										{
+											if ($item->category_level != '1') :
+												if ($canEditParCat || $canEditOwnParCat) :
+													echo '<a class="hasTooltip" href="' . $ParentCatUrl . '" title="' . $EditCatTxt . '">';
+												endif;
+												echo $this->escape($item->parent_category_title);
+												if ($canEditParCat || $canEditOwnParCat) :
+													echo '</a>';
+												endif;
+												echo ' &#187; ';
+											endif;
+											if ($canEditCat || $canEditOwnCat) :
+												echo '<a class="hasTooltip" href="' . $CurrentCatUrl . '" title="' . $EditCatTxt . '">';
+											endif;
+											echo $this->escape($item->category_title);
+											if ($canEditCat || $canEditOwnCat) :
+												echo '</a>';
 											endif;
 										}
 									?>

--- a/administrator/components/com_content/views/featured/tmpl/default.php
+++ b/administrator/components/com_content/views/featured/tmpl/default.php
@@ -120,12 +120,16 @@ if ($saveOrder)
 					<?php $count = count($this->items); ?>
 					<?php foreach ($this->items as $i => $item) :
 						$item->max_ordering = 0;
-						$ordering   = ($listOrder == 'fp.ordering');
-						$assetId    = 'com_content.article.' . $item->id;
-						$canCreate  = $user->authorise('core.create', 'com_content.category.' . $item->catid);
-						$canEdit    = $user->authorise('core.edit', 'com_content.article.' . $item->id);
-						$canCheckin = $user->authorise('core.manage', 'com_checkin') || $item->checked_out == $userId || $item->checked_out == 0;
-						$canChange  = $user->authorise('core.edit.state', 'com_content.article.' . $item->id) && $canCheckin;
+						$ordering         = ($listOrder == 'fp.ordering');
+						$assetId          = 'com_content.article.' . $item->id;
+						$canCreate        = $user->authorise('core.create', 'com_content.category.' . $item->catid);
+						$canEdit          = $user->authorise('core.edit', 'com_content.article.' . $item->id);
+						$canCheckin       = $user->authorise('core.manage', 'com_checkin') || $item->checked_out == $userId || $item->checked_out == 0;
+						$canChange        = $user->authorise('core.edit.state', 'com_content.article.' . $item->id) && $canCheckin;
+						$canEditCat       = $user->authorise('core.edit',       'com_content.category.' . $item->catid);
+						$canEditOwnCat    = $user->authorise('core.edit.own',   'com_content.category.' . $item->catid) && $item->category_uid == $userId;
+						$canEditParCat    = $user->authorise('core.edit',       'com_content.category.' . $item->parent_category_id);
+						$canEditOwnParCat = $user->authorise('core.edit.own',   'com_content.category.' . $item->parent_category_id) && $item->parent_category_uid == $userId;
 						?>
 						<tr class="row<?php echo $i % 2; ?>">
 							<td class="order nowrap center hidden-phone">
@@ -180,7 +184,61 @@ if ($saveOrder)
 									<?php echo JText::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->alias)); ?>
 								</span>
 									<div class="small">
-										<?php echo JText::_('JCATEGORY') . ': ' . $this->escape($item->category_title); ?>
+										<?php
+										$ParentCatUrl = JRoute::_('index.php?option=com_categories&task=category.edit&id=' . $item->parent_category_id . '&extension=com_content');
+										$CurrentCatUrl = JRoute::_('index.php?option=com_categories&task=category.edit&id=' . $item->catid . '&extension=com_content');
+										$EditCatTxt = JText::_('JACTION_EDIT') . ' ' . JText::_('JCATEGORY');
+
+										echo JText::_('JCATEGORY') . ': ';
+
+										if ($item->category_level != '1') :
+											if ($item->parent_category_level != '1') :
+												echo ' &#187; ';
+											endif;
+										endif;
+
+										if ($this->document->direction == "ltr")
+										{
+											if ($item->category_level != '1') :
+												if ($canEditParCat || $canEditOwnParCat) :
+													echo '<a class="hasTooltip" href="' . $ParentCatUrl . '" title="' . $EditCatTxt . '">';
+												endif;
+												echo $this->escape($item->parent_category_title);
+												if ($canEditParCat || $canEditOwnParCat) :
+													echo '</a>';
+												endif;
+												echo ' &#187; ';
+											endif;
+											if ($canEditCat || $canEditOwnCat) :
+												echo '<a class="hasTooltip" href="' . $CurrentCatUrl . '" title="' . $EditCatTxt . '">';
+											endif;
+											echo $this->escape($item->category_title);
+											if ($canEditCat || $canEditOwnCat) :
+												echo '</a>';
+											endif;
+										}
+										else
+										{
+											if ($canEditCat || $canEditOwnCat) :
+												echo '<a class="hasTooltip" href="' . $CurrentCatUrl . '" title="' . $EditCatTxt . '">';
+											endif;
+											echo $this->escape($item->category_title);
+											if ($canEditCat || $canEditOwnCat) :
+												echo '</a>';
+											endif;
+
+											if ($item->category_level != '1') :
+												echo ' &#171; ';
+												if ($canEditParCat || $canEditOwnParCat) :
+													echo '<a class="hasTooltip" href="' . $ParentCatUrl . '" title="' . $EditCatTxt . '">';
+												endif;
+												echo $this->escape($item->parent_category_title);
+												if ($canEditParCat || $canEditOwnParCat) :
+													echo '</a>';
+												endif;
+											endif;
+										}
+										?>
 									</div>
 								</div>
 							</td>

--- a/administrator/components/com_content/views/featured/tmpl/default.php
+++ b/administrator/components/com_content/views/featured/tmpl/default.php
@@ -197,27 +197,7 @@ if ($saveOrder)
 											endif;
 										endif;
 
-										if ($this->document->direction == "ltr")
-										{
-											if ($item->category_level != '1') :
-												if ($canEditParCat || $canEditOwnParCat) :
-													echo '<a class="hasTooltip" href="' . $ParentCatUrl . '" title="' . $EditCatTxt . '">';
-												endif;
-												echo $this->escape($item->parent_category_title);
-												if ($canEditParCat || $canEditOwnParCat) :
-													echo '</a>';
-												endif;
-												echo ' &#187; ';
-											endif;
-											if ($canEditCat || $canEditOwnCat) :
-												echo '<a class="hasTooltip" href="' . $CurrentCatUrl . '" title="' . $EditCatTxt . '">';
-											endif;
-											echo $this->escape($item->category_title);
-											if ($canEditCat || $canEditOwnCat) :
-												echo '</a>';
-											endif;
-										}
-										else
+										if (JFactory::getLanguage()->isRtl())
 										{
 											if ($canEditCat || $canEditOwnCat) :
 												echo '<a class="hasTooltip" href="' . $CurrentCatUrl . '" title="' . $EditCatTxt . '">';
@@ -236,6 +216,26 @@ if ($saveOrder)
 												if ($canEditParCat || $canEditOwnParCat) :
 													echo '</a>';
 												endif;
+											endif;
+										}
+										else
+										{
+											if ($item->category_level != '1') :
+												if ($canEditParCat || $canEditOwnParCat) :
+													echo '<a class="hasTooltip" href="' . $ParentCatUrl . '" title="' . $EditCatTxt . '">';
+												endif;
+												echo $this->escape($item->parent_category_title);
+												if ($canEditParCat || $canEditOwnParCat) :
+													echo '</a>';
+												endif;
+												echo ' &#187; ';
+											endif;
+											if ($canEditCat || $canEditOwnCat) :
+												echo '<a class="hasTooltip" href="' . $CurrentCatUrl . '" title="' . $EditCatTxt . '">';
+											endif;
+											echo $this->escape($item->category_title);
+											if ($canEditCat || $canEditOwnCat) :
+												echo '</a>';
 											endif;
 										}
 										?>


### PR DESCRIPTION
### Summary of Changes
This PR adds the Information to the parent category of the article before the category and offers a direct link to edit it.

### Testing Instructions
Small change, big UX improvement 
-> access the categories easier and faster 
-> Some pages have similar named subcategories so its better to know the parent too

Please test coding style and everything, I did it how I thought it might work... thanks a lot!

<img width="387" alt="grafik" src="https://user-images.githubusercontent.com/828371/41368440-3d58a4e8-6f42-11e8-98a9-1accb72f3b7b.png">

