### PR TITLE
Better mode autoloading.

### DIFF
--- a/plugins/editors/codemirror/layouts/editors/codemirror/init.php
+++ b/plugins/editors/codemirror/layouts/editors/codemirror/init.php
@@ -45,16 +45,15 @@ JFactory::getDocument()->addScriptDeclaration(
 			cm.defineInitHook(function (editor)
 			{
 				// Try to set up the mode
-				var mode = cm.findModeByName(editor.options.mode || '');
+				var mode = cm.findModeByMIME(editor.options.mode || '') ||
+							cm.findModeByName(editor.options.mode || '') ||
+							cm.findModeByExtension(editor.options.mode || '');
+
+				cm.autoLoadMode(editor, mode ? mode.mode : editor.options.mode);
 
 				if (mode)
 				{
-					cm.autoLoadMode(editor, mode.mode);
-					editor.setOption('mode', mode.mime);
-				}
-				else
-				{
-					cm.autoLoadMode(editor, editor.options.mode);
+					editor.setOption('mode', mode.mode);
 				}
 
 				// Handle gutter clicks (place or remove a marker).


### PR DESCRIPTION
### Summary of Changes

Improvement to editor mode autoselection.
Should now find the correct mode whether the option is set to a mode's name, mime-type, or extension.
Setting the mode is also improved, especially for php mode. 

### Testing Instructions

Use codemirror. Open as many document types as possible.
Especially try testing PHP documents before and after applying the patch.

### Expected result

Mode should be selected correctly so that syntax highlighting and other mode-specific features should work normally.

### Actual result

Before this change there is a problem with PHP documents. If they contain HTML sections, it will not be highlighted properly and features such as tag autoclosing will not work.

After this change, all is well.

### Documentation Changes Required

Nope.