### PR TITLE
[4.0] Progressive Disclosure for the multilingual sampledata

### DIFF
--- a/administrator/modules/mod_sampledata/Helper/SampledataHelper.php
+++ b/administrator/modules/mod_sampledata/Helper/SampledataHelper.php
@@ -32,6 +32,6 @@ abstract class SampledataHelper
 	{
 		PluginHelper::importPlugin('sampledata');
 
-		return Factory::getApplication()->triggerEvent('onSampledataGetOverview', array('test', 'foo'));
+		return array_filter(Factory::getApplication()->triggerEvent('onSampledataGetOverview'));
 	}
 }

--- a/plugins/sampledata/multilang/multilang.php
+++ b/plugins/sampledata/multilang/multilang.php
@@ -87,6 +87,13 @@ class PlgSampledataMultilang extends CMSPlugin
 	 */
 	public function onSampledataGetOverview()
 	{
+		$languages = LanguageHelper::getContentLanguages(array(0, 1));
+
+		if (count($languages) < 2)
+		{
+			return;
+		}
+
 		$data              = new stdClass;
 		$data->name        = $this->_name;
 		$data->title       = Text::_('PLG_SAMPLEDATA_MULTILANG_OVERVIEW_TITLE');


### PR DESCRIPTION
As promised in https://github.com/joomla/joomla-cms/pull/20711#issuecomment-397023701

As I wrote in the referenced PR, I'm not convinced this is actually needed, but I wrote it as promised :smile: 
#### Pros:
* Sampledata installation is only proposed if it actually works.
* We save a bit of space.
* PROGRESSIVE DISCLOSURE (buzzword are always good)
#### Cons:
* Unlike other places (eg "showon" feature or toolbar buttons), the progressive disclosure doesn't work as nicely here since the user doesn't see the immediate change to his action (installing a language is a complete other view).
* The sampledata currently only features one sampledata, it would be nice to have a second one so people actually see it is supposed to be a list :smile: Also the space used by that second option isn't really an issue here.
* The user is aware that this feature exists to help set up a multilingual site. I can see the arguments for both ways.

I don't have any hard feelings either way. So you guys test and decide if it's merged or not. And please only comment after having at least tried to understand the other side (should be natural)

### Summary of Changes
Only shows the multilingual sample data option on sites that have more than one language installed.


### Testing Instructions
* Make sure the multilingual sampledata plugin is installed (discover it otherwise first) and enabled
* Check with one language installed -> Multilingual Sampledata doesn't appear in the cPanel Sample Data module
* Check with more than one language installed -> Multilingual Sampledata option appears in the module.


### Expected result
Option only shows when more than one language is installed


### Actual result
Option is always there as long as plugin is enabled.


### Documentation Changes Required
None
