### PR TITLE
[4.0] [a11y] Incorrect aria role

### DIFF
--- a/layouts/joomla/searchtools/default/bar.php
+++ b/layouts/joomla/searchtools/default/bar.php
@@ -39,7 +39,7 @@ $filters = $data['view']->filterForm->getGroup('filter');
 				<?php echo Text::_('JSEARCH_FILTER'); ?>
 			<?php endif; ?>
 		</label>
-		<div class="btn-toolbar" role="toolbar">
+		<div class="btn-toolbar">
 			<div class="btn-group mr-2">
 				<div class="input-group">
 					<?php echo $filters['filter_search']->input; ?>


### PR DESCRIPTION
Remove incorrect aria landmark of toolbar on the search item in the searchtools layout


### Testing Instructions
apply this pr and then test by either viewing source or use the tota11y chrome browser extension


