### PR TITLE
[4.0] Installer cleanup

### DIFF
--- a/installation/forms/setup.xml
+++ b/installation/forms/setup.xml
@@ -49,28 +49,6 @@
 		/>
 
 		<field
-				name="site_metadesc"
-				type="textarea"
-				id="site_metadesc"
-				class="form-control text_area noResize"
-				label="INSTL_SITE_METADESC_DESC"
-				rows="3"
-		/>
-
-		<field
-				name="site_offline"
-				type="radio"
-				id="site_offline"
-				class="btn-group"
-				default="0"
-				label="INSTL_SITE_OFFLINE_DESC"
-				filter="integer"
-		>
-			<option value="1">JYES</option>
-			<option value="0">JNO</option>
-		</field>
-
-		<field
 				name="db_type"
 				type="databaseconnection"
 				id="db_type"


### PR DESCRIPTION
the ability to set the site_metadesc and the site_offline are not present in this installer

The language files hd also been removed but they were still referenced in the setup.xml

@dgrammatiko @wilsonge 
Don't forget that ftp is still marked todo
and
I wanted to try and check the pre-install screen strings but i couldnt trigger it for testing - any tips