### PR TITLE
[4.0] Installation unused strings

### DIFF
--- a/installation/language/en-GB/en-GB.ini
+++ b/installation/language/en-GB/en-GB.ini
@@ -20,9 +20,6 @@ INSTL_SETUP_LOGIN_DATA="Setup Login Data"
 
 ;Preinstall view
 INSTL_PRECHECK_TITLE="Pre-Installation Check"
-INSTL_PRECHECK_DESC="If any of these items are not supported then please take actions to correct them.<br>You can't install Joomla until your setup meets these requirements."
-INSTL_PRECHECK_RECOMMENDED_SETTINGS_TITLE="Recommended settings:"
-INSTL_PRECHECK_RECOMMENDED_SETTINGS_DESC="These settings are recommended for PHP in order to ensure full compatibility with Joomla."
 INSTL_PRECHECK_DIRECTIVE="Directive"
 INSTL_PRECHECK_RECOMMENDED="Recommended"
 INSTL_PRECHECK_ACTUAL="Actual"
@@ -62,10 +59,6 @@ INSTL_SITE_INSTALL_SAMPLE_LABEL="Do you want to install Sample Data?"
 INSTL_SITE_INSTALL_SAMPLE_NONE="None (<strong>Required for basic native multilingual site creation</strong>)"
 INSTL_SITE_INSTALL_SAMPLE_NONE_DESC="Install Joomla with one menu and a login form, without any content."
 INSTL_SAMPLE_DATA_NOT_FOUND="Sample data file was not found."
-INSTL_SAMPLE_BLOG_SET_DESC="Install Joomla with a few articles and blog related modules like Older Posts, Blog Roll, Most Read Posts."
-INSTL_SAMPLE_BROCHURE_SET_DESC="Install Joomla with a few pages (a menu with pages Home, About Us, News, Contact Us) and modules like Search, Custom, Login Form."
-INSTL_SAMPLE_DATA_SET_DESC="Install Joomla with one page (a menu with one link) and modules like Latest Article, Login Form."
-INSTL_SAMPLE_LEARN_SET_DESC="Install Joomla with example articles that describe how Joomla works."
 INSTL_SAMPLE_TESTING_SET_DESC="Install Joomla with all possible menu items to help with testing Joomla."
 
 ;Complete view
@@ -87,7 +80,6 @@ INSTL_COMPLETE_REMOVE_INSTALLATION="PLEASE REMEMBER TO COMPLETELY REMOVE THE INS
 INSTL_COMPLETE_CONGRAT="Congratulations!"
 INSTL_COMPLETE_TITLE="Congratulations! Your Joomla site is ready."
 INSTL_COMPLETE_DESC="<p>You now have the option to customise your installation by adding another language or installing the sample data.</p>"
-INSTL_COMPLETE_ADD_FEATURES="Add Features"
 INSTL_COMPLETE_FINISH="Finish Installation Process"
 INSTL_COMPLETE_INSTALL_LANGUAGES="Extra steps: Install languages"
 INSTL_COMPLETE_SITE_BTN="Complete & Open Site"

--- a/installation/language/en-GB/en-GB.ini
+++ b/installation/language/en-GB/en-GB.ini
@@ -22,6 +22,7 @@ INSTL_SETUP_LOGIN_DATA="Setup Login Data"
 INSTL_PRECHECK_TITLE="Pre-Installation Check"
 INSTL_PRECHECK_DIRECTIVE="Directive"
 INSTL_PRECHECK_RECOMMENDED="Recommended"
+INSTL_PRECHECK_RECOMMENDED_SETTINGS_DESC="These settings are recommended for PHP in order to ensure full compatibility with Joomla."
 INSTL_PRECHECK_ACTUAL="Actual"
 
 ; Database view

--- a/installation/language/en-US/en-US.ini
+++ b/installation/language/en-US/en-US.ini
@@ -22,6 +22,7 @@ INSTL_SETUP_LOGIN_DATA="Setup Login Data"
 INSTL_PRECHECK_TITLE="Pre-Installation Check"
 INSTL_PRECHECK_DIRECTIVE="Directive"
 INSTL_PRECHECK_RECOMMENDED="Recommended"
+INSTL_PRECHECK_RECOMMENDED_SETTINGS_DESC="These settings are recommended for PHP in order to ensure full compatibility with Joomla."
 INSTL_PRECHECK_ACTUAL="Actual"
 
 ; Database view

--- a/installation/language/en-US/en-US.ini
+++ b/installation/language/en-US/en-US.ini
@@ -20,9 +20,6 @@ INSTL_SETUP_LOGIN_DATA="Setup Login Data"
 
 ;Preinstall view
 INSTL_PRECHECK_TITLE="Pre-Installation Check"
-INSTL_PRECHECK_DESC="If any of these items are not supported then please take actions to correct them.<br>You can't install Joomla until your setup meets these requirements."
-INSTL_PRECHECK_RECOMMENDED_SETTINGS_TITLE="Recommended settings:"
-INSTL_PRECHECK_RECOMMENDED_SETTINGS_DESC="These settings are recommended for PHP in order to ensure full compatibility with Joomla."
 INSTL_PRECHECK_DIRECTIVE="Directive"
 INSTL_PRECHECK_RECOMMENDED="Recommended"
 INSTL_PRECHECK_ACTUAL="Actual"
@@ -62,10 +59,6 @@ INSTL_SITE_INSTALL_SAMPLE_LABEL="Do you want to install Sample Data?"
 INSTL_SITE_INSTALL_SAMPLE_NONE="None (<strong>Required for basic native multilingual site creation</strong>)"
 INSTL_SITE_INSTALL_SAMPLE_NONE_DESC="Install Joomla with one menu and a login form, without any content."
 INSTL_SAMPLE_DATA_NOT_FOUND="Sample data file was not found."
-INSTL_SAMPLE_BLOG_SET_DESC="Install Joomla with a few articles and blog related modules like Older Posts, Blog Roll, Most Read Posts."
-INSTL_SAMPLE_BROCHURE_SET_DESC="Install Joomla with a few pages (a menu with pages Home, About Us, News, Contact Us) and modules like Search, Custom, Login Form."
-INSTL_SAMPLE_DATA_SET_DESC="Install Joomla with one page (a menu with one link) and modules like Latest Article, Login Form."
-INSTL_SAMPLE_LEARN_SET_DESC="Install Joomla with example articles that describe how Joomla works."
 INSTL_SAMPLE_TESTING_SET_DESC="Install Joomla with all possible menu items to help with testing Joomla."
 
 ;Complete view
@@ -87,7 +80,6 @@ INSTL_COMPLETE_REMOVE_INSTALLATION="PLEASE REMEMBER TO COMPLETELY REMOVE THE INS
 INSTL_COMPLETE_CONGRAT="Congratulations!"
 INSTL_COMPLETE_TITLE="Congratulations! Your Joomla site is ready."
 INSTL_COMPLETE_DESC="<p>You now have the option to customize your installation by adding another language or installing the sample data.</p>"
-INSTL_COMPLETE_ADD_FEATURES="Add Features"
 INSTL_COMPLETE_FINISH="Finish Installation Process"
 INSTL_COMPLETE_INSTALL_LANGUAGES="Extra steps: Install languages"
 INSTL_COMPLETE_SITE_BTN="Complete & Open Site"


### PR DESCRIPTION
These strings are not used in the j4 installer

If the functionality is added later then they can be added back
