### PR TITLE
Add UTF-8 encoding to phpcs in .drone.yml

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -7,7 +7,7 @@ pipeline:
     image: joomlaprojects/docker-phpcs
     commands:
       - echo $(date)
-      - /root/.composer/vendor/bin/phpcs --report=full --extensions=php -p --standard=build/phpcs/Joomla .
+      - /root/.composer/vendor/bin/phpcs --report=full --encoding=utf-8 --extensions=php -p --standard=build/phpcs/Joomla .
       - echo $(date)
 
   javascript:


### PR DESCRIPTION
Pull Request for Issue PHPCS 1.5.x will report the wrong values for some things if it's not forced UTF-8.

### Summary of Changes
Add UTF-8 encoding to phpcs in .drone.yml


### Testing Instructions
code review


### Expected result
drone does not error


### Actual result
drone does not error


### Documentation Changes Required
none
