### PR TITLE
Com_finder meta data

### DIFF
--- a/components/com_finder/views/search/view.html.php
+++ b/components/com_finder/views/search/view.html.php
@@ -271,18 +271,31 @@ class FinderViewSearch extends JViewLegacy
 			$explained = $this->escape(html_entity_decode(strip_tags($this->explained), ENT_QUOTES, 'UTF-8'));
 			$this->document->setDescription($explained);
 		}
+		elseif ($this->params->get('menu-meta_description'))
+		{
+			$this->document->setDescription($this->params->get('menu-meta_description'));
+		}
 
 		// Configure the document meta-keywords.
 		if (!empty($query->highlight))
 		{
 			$this->document->setMetaData('keywords', implode(', ', $query->highlight));
 		}
+		elseif ($this->params->get('menu-meta_keywords'))
+		{
+			$this->document->setMetadata('keywords', $this->params->get('menu-meta_keywords'));
+		}
 
 		if ($this->params->get('robots'))
 		{
-			$this->document->setMetaData('robots', $this->params->get('robots'));
+			$this->document->setMetadata('robots', $this->params->get('robots'));
 		}
 
+		if ($app->get('MetaAuthor') == '1')
+		{
+			$author = $this->item->created_by_alias ?: $this->item->author;
+			$this->document->setMetaData('author', $author);
+		}
 		// Add feed link to the document head.
 		if ($this->params->get('show_feed_link', 1) == 1)
 		{

--- a/components/com_finder/views/search/view.html.php
+++ b/components/com_finder/views/search/view.html.php
@@ -291,11 +291,6 @@ class FinderViewSearch extends JViewLegacy
 			$this->document->setMetadata('robots', $this->params->get('robots'));
 		}
 
-		if ($app->get('MetaAuthor') == '1')
-		{
-			$author = $this->item->created_by_alias ?: $this->item->author;
-			$this->document->setMetaData('author', $author);
-		}
 		// Add feed link to the document head.
 		if ($this->params->get('show_feed_link', 1) == 1)
 		{


### PR DESCRIPTION
com_finder aka smart search was not following any meta data set in the menu item

#### to test

 - setup and configure smart search
 - create a menu item for smart search and set the meta description and meta keywords
 - open the menu item on the front end - check source and the meta data set in the menu is not present
 - do a search
 - check source and the meta data has been generated from the search

Apply this PR
 - open the menu item on the front end - check source and the meta data set in the menu is present
 - do a search
 - check source and the meta data has been generated from the search

Pull Request for Issue #20737 