### PR TITLE
Optimize plural suffix logic for en-GB

### DIFF
--- a/administrator/language/en-GB/en-GB.localise.php
+++ b/administrator/language/en-GB/en-GB.localise.php
@@ -26,18 +26,17 @@ abstract class En_GBLocalise
 	 */
 	public static function getPluralSuffixes($count)
 	{
-		if ($count == 0)
-		{
-			return array('0');
-		}
-		elseif ($count == 1)
-		{
-			return array('1');
-		}
-		else
+		/*
+		 * The language handler will attempt to suffix a language string with the item count before
+		 * applying suffixes given by this handler, therefore we only need to return extra suffixes
+		 * to be attempted if a string for the item count does not exist.
+		 */
+		if ($count == 0 || $count >= 2)
 		{
 			return array('MORE');
 		}
+
+		return array();
 	}
 
 	/**

--- a/language/en-GB/en-GB.localise.php
+++ b/language/en-GB/en-GB.localise.php
@@ -26,18 +26,17 @@ abstract class En_GBLocalise
 	 */
 	public static function getPluralSuffixes($count)
 	{
-		if ($count == 0)
-		{
-			return array('0');
-		}
-		elseif ($count == 1)
-		{
-			return array('1');
-		}
-		else
+		/*
+		 * The language handler will attempt to suffix a language string with the item count before
+		 * applying suffixes given by this handler, therefore we only need to return extra suffixes
+		 * to be attempted if a string for the item count does not exist.
+		 */
+		if ($count == 0 || $count >= 2)
 		{
 			return array('MORE');
 		}
+
+		return array();
 	}
 
 	/**

--- a/tests/unit/suites/libraries/joomla/language/JLanguageTest.php
+++ b/tests/unit/suites/libraries/joomla/language/JLanguageTest.php
@@ -275,13 +275,13 @@ class JLanguageTest extends \PHPUnit\Framework\TestCase
 	public function testGetPluralSuffixes()
 	{
 		$this->assertEquals(
-			array('0'),
+			array('MORE'),
 			$this->object->getPluralSuffixes(0),
 			'Line: ' . __LINE__
 		);
 
 		$this->assertEquals(
-			array('1'),
+			array(),
 			$this->object->getPluralSuffixes(1),
 			'Line: ' . __LINE__
 		);

--- a/tests/unit/suites/libraries/joomla/language/data/language/en-GB/en-GB.localise.php
+++ b/tests/unit/suites/libraries/joomla/language/data/language/en-GB/en-GB.localise.php
@@ -24,19 +24,17 @@ abstract class En_GBLocalise
 	 */
 	public static function getPluralSuffixes($count)
 	{
-		if ($count == 0)
+		/*
+		 * The language handler will attempt to suffix a language string with the item count before
+		 * applying suffixes given by this handler, therefore we only need to return extra suffixes
+		 * to be attempted if a string for the item count does not exist.
+		 */
+		if ($count == 0 || $count >= 2)
 		{
-			$return = array('0');
+			return array('MORE');
 		}
-		elseif ($count == 1)
-		{
-			$return = array('1');
-		}
-		else
-		{
-			$return = array('MORE');
-		}
-		return $return;
+
+		return array();
 	}
 
 	/**


### PR DESCRIPTION
### Summary of Changes

1) In the English language, often times when using a text string for 0 items, the text string will read the same as if you have 2 or more items.  Therefore, our plural suffixes should allow a 0 count to use the `_MORE` suffixed key; in the case of our en-GB strings this can potentially eliminate redundant plural strings where the `_0` and `_MORE` suffixed strings are the same.
2) `JText::plural()` automatically prepends the item count to the suffix array when trying to look for language keys, therefore there is no need for the callback method in the localise class to include an extra definition for that suffix (with the current code when the count is 1 basically the suffix lookup array is `array('1', '1')`, for 2 or more in en-GB it's `array($count, 'MORE')`.  So, we can simplify the logic here and basically only return our `MORE` suffix when the count is anything but one.
3) Added an inline comment to the method to explain the rationale here, and to make sure it's you only need to define extra suffixes for whatever rules you need to follow since Joomla will automatically try to find a matching string for the specific item count before processing the extra suffixes.

### Testing Instructions

Pluralized strings should still correctly be processed for en-GB.  With this change, some of the `_0` suffixed strings for `mod_status` could be removed (i.e. `MOD_STATUS_TOTAL_USERS_0`) since the corresponding `_MORE` suffixed string is the same text and there is no need in this case for a contextually different string for a 0 count versus 2+.