### PR TITLE
[4.0] Check session token in header

### DIFF
--- a/libraries/src/Session/Session.php
+++ b/libraries/src/Session/Session.php
@@ -36,6 +36,13 @@ class Session extends BaseSession
 		$app   = \JFactory::getApplication();
 		$token = static::getFormToken();
 
+		// Check from header first
+		if ($token === $app->input->server->get('HTTP_X_CSRF_TOKEN', '', 'alnum'))
+		{
+			return true;
+		}
+
+		// Then fallback to HTTP query
 		if (!$app->input->$method->get($token, '', 'alnum'))
 		{
 			if ($app->getSession()->isNew())


### PR DESCRIPTION
No idea what this is or how to check it

It was reported as missing by @schnuti in #20642

@mbabker said it was
> Probably lost in a merge conflict, not intentionally removed.

So this PR puts it back and someone clever than me can work out if it should be there or not