### PR TITLE
Escaping HTML special characters to prevent XSS

### DIFF
--- a/modules/mod_languages/tmpl/default.php
+++ b/modules/mod_languages/tmpl/default.php
@@ -25,8 +25,8 @@ if ($params->get('dropdown', 1) && !$params->get('dropdownimage', 0))
 	<form name="lang" method="post" action="<?php echo htmlspecialchars(JUri::current(), ENT_COMPAT, 'UTF-8'); ?>">
 	<select class="inputbox advancedSelect" onchange="document.location.replace(this.value);" >
 	<?php foreach ($list as $language) : ?>
-		<option dir=<?php echo $language->rtl ? '"rtl"' : '"ltr"'; ?> value="<?php echo $language->link; ?>" <?php echo $language->active ? 'selected="selected"' : ''; ?>>
-		<?php echo $language->title_native; ?></option>
+		<option dir=<?php echo $language->rtl ? '"rtl"' : '"ltr"'; ?> value="<?php echo htmlspecialchars($language->link); ?>" <?php echo $language->active ? 'selected="selected"' : ''; ?>>
+		<?php echo htmlspecialchars($language->title_native); ?></option>
 	<?php endforeach; ?>
 	</select>
 	</form>
@@ -39,7 +39,7 @@ if ($params->get('dropdown', 1) && !$params->get('dropdownimage', 0))
 					<?php if ($language->image) : ?>
 						&nbsp;<?php echo JHtml::_('image', 'mod_languages/' . $language->image . '.gif', '', null, true); ?>
 					<?php endif; ?>
-					<?php echo $language->title_native; ?>
+					<?php echo htmlspecialchars($language->title_native); ?>
 				</a>
 			<?php endif; ?>
 		<?php endforeach; ?>
@@ -47,11 +47,11 @@ if ($params->get('dropdown', 1) && !$params->get('dropdownimage', 0))
 		<?php foreach ($list as $language) : ?>
 			<?php if (!$language->active || $params->get('show_active', 0)) : ?>
 				<li<?php echo $language->active ? ' class="lang-active"' : ''; ?>>
-				<a href="<?php echo $language->link; ?>">
+				<a href="<?php echo htmlspecialchars($language->link); ?>">
 					<?php if ($language->image) : ?>
 						<?php echo JHtml::_('image', 'mod_languages/' . $language->image . '.gif', '', null, true); ?>
 					<?php endif; ?>
-					<?php echo $language->title_native; ?>
+					<?php echo htmlspecialchars($language->title_native); ?>
 				</a>
 				</li>
 			<?php endif; ?>
@@ -63,15 +63,15 @@ if ($params->get('dropdown', 1) && !$params->get('dropdownimage', 0))
 	<?php foreach ($list as $language) : ?>
 		<?php if (!$language->active || $params->get('show_active', 0)) : ?>
 			<li<?php echo $language->active ? ' class="lang-active"' : ''; ?> dir="<?php echo $language->rtl ? 'rtl' : 'ltr'; ?>">
-			<a href="<?php echo $language->link; ?>">
+			<a href="<?php echo htmlspecialchars($language->link); ?>">
 			<?php if ($params->get('image', 1)) : ?>
 				<?php if ($language->image) : ?>
 					<?php echo JHtml::_('image', 'mod_languages/' . $language->image . '.gif', $language->title_native, array('title' => $language->title_native), true); ?>
 				<?php else : ?>
-					<span class="label"><?php echo strtoupper($language->sef); ?></span>
+					<span class="label"><?php echo htmlspecialchars(strtoupper($language->sef)); ?></span>
 				<?php endif; ?>
 			<?php else : ?>
-				<?php echo $params->get('full_name', 1) ? $language->title_native : strtoupper($language->sef); ?>
+				<?php echo htmlspecialchars($params->get('full_name', 1) ? $language->title_native : strtoupper($language->sef)); ?>
 			<?php endif; ?>
 			</a>
 			</li>


### PR DESCRIPTION
There are some cases in which the link on the flag of the current language does not escape HTML special characters. This may lead to reflective XSS via injection of arbitrary parameters and/or values on the current page url.