### PR TITLE
Enable mod_sampledata extension

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/3.8.9-2018-06-19.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.8.9-2018-06-19.sql
@@ -1,0 +1,2 @@
+-- Enable Sample Data Module.
+UPDATE `#__extensions` SET `enabled` = '1' WHERE `name` = 'mod_sampledata';

--- a/administrator/components/com_admin/sql/updates/postgresql/3.8.9-2018-06-19.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.8.9-2018-06-19.sql
@@ -1,0 +1,2 @@
+-- Enable Sample Data Module.
+UPDATE "#__extensions" SET "enabled" = '1' WHERE "name" = 'mod_sampledata';

--- a/administrator/components/com_admin/sql/updates/sqlazure/3.8.9-2018-06-19.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.8.9-2018-06-19.sql
@@ -1,0 +1,3 @@
+-- Enable Sample Data Module.
+UPDATE [#__extensions] SET [enabled] = '1' WHERE [name] = 'mod_sampledata';
+


### PR DESCRIPTION
Today I wanted to test something with the Sample Data Module and found that when I wrote the update SQL for its installation, I made it as a disabled extension.
This was fine and correct for the plugin, but doesn't make sense for the module.

### Summary of Changes
This PR just changes the extension state of the administrator module mod_sampledata so it is enabled.
Please note that this doesn't mean it shows up magically in the Control Panel like in new installations. It still would have to be created like any regular module. But now it will show up in the list of possible modules.


### Testing Instructions
* Apply SQL statement and check extension state in the extension manager.
* Check that the module appears in the list when you try to create an admin module


### Expected result
Module can be created
![image](https://user-images.githubusercontent.com/1018684/41600505-64b0a62e-73d6-11e8-8307-9dce55b1dd78.png)


### Actual result
Module doesn't show up as its extension is disabled.
![image](https://user-images.githubusercontent.com/1018684/41600454-44e7ac3e-73d6-11e8-92eb-f5ebb47de99b.png)


### Documentation Changes Required
None