### PR TITLE
Removed the return if no items found

### DIFF
--- a/modules/mod_tags_similar/mod_tags_similar.php
+++ b/modules/mod_tags_similar/mod_tags_similar.php
@@ -21,11 +21,6 @@ $cacheparams->modeparams = array('id' => 'array', 'Itemid' => 'int');
 
 $list = JModuleHelper::moduleCache($module, $params, $cacheparams);
 
-if (!count($list))
-{
-	return;
-}
-
 $moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
 
 require JModuleHelper::getLayoutPath('mod_tags_similar', $params->get('layout', 'default'));


### PR DESCRIPTION
Pull Request for Issue #20810 .

### Summary of Changes
Removed the return if no items found.


### Testing Instructions
Create and publish an instance of mod_tags_similar.


### Expected result
If the current item has items with related tags then these are shown, if not then an error message is shown "No matching tags."


### Actual result



### Documentation Changes Required

