### PR TITLE
Deprecating JFormFieldDirectories

### DIFF
--- a/administrator/components/com_finder/models/fields/directories.php
+++ b/administrator/components/com_finder/models/fields/directories.php
@@ -18,6 +18,7 @@ JFormHelper::loadFieldClass('list');
  * Renders a list of directories.
  *
  * @since  2.5
+ * @deprecated  4.0  Use JFormFieldFolderlist
  */
 class JFormFieldDirectories extends JFormFieldList
 {

--- a/administrator/components/com_finder/models/fields/directories.php
+++ b/administrator/components/com_finder/models/fields/directories.php
@@ -17,7 +17,7 @@ JFormHelper::loadFieldClass('list');
 /**
  * Renders a list of directories.
  *
- * @since  2.5
+ * @since       2.5
  * @deprecated  4.0  Use JFormFieldFolderlist
  */
 class JFormFieldDirectories extends JFormFieldList


### PR DESCRIPTION
This class has been removed in 4.0. This would deprecate it in 3.9.