### PR TITLE
[4.0] HTML class naming standard [frontend][com-users]

### DIFF
--- a/components/com_users/tmpl/login/default_login.php
+++ b/components/com_users/tmpl/login/default_login.php
@@ -15,7 +15,7 @@ JHtml::_('behavior.formvalidator');
 $usersConfig = JComponentHelper::getParams('com_users');
 
 ?>
-<div class="login">
+<div class="com-users-login login">
 	<?php if ($this->params->get('show_page_heading')) : ?>
 	<div class="page-header">
 		<h1>
@@ -25,7 +25,7 @@ $usersConfig = JComponentHelper::getParams('com_users');
 	<?php endif; ?>
 
 	<?php if (($this->params->get('logindescription_show') == 1 && str_replace(' ', '', $this->params->get('login_description')) != '') || $this->params->get('login_image') != '') : ?>
-	<div class="login-description">
+	<div class="com-users-login__description login-description">
 	<?php endif; ?>
 
 		<?php if ($this->params->get('logindescription_show') == 1) : ?>
@@ -33,19 +33,19 @@ $usersConfig = JComponentHelper::getParams('com_users');
 		<?php endif; ?>
 
 		<?php if ($this->params->get('login_image') != '') : ?>
-			<img src="<?php echo $this->escape($this->params->get('login_image')); ?>" class="login-image" alt="<?php echo JText::_('COM_USERS_LOGIN_IMAGE_ALT'); ?>">
+			<img src="<?php echo $this->escape($this->params->get('login_image')); ?>" class="com-users-login__image login-image" alt="<?php echo JText::_('COM_USERS_LOGIN_IMAGE_ALT'); ?>">
 		<?php endif; ?>
 
 	<?php if (($this->params->get('logindescription_show') == 1 && str_replace(' ', '', $this->params->get('login_description')) != '') || $this->params->get('login_image') != '') : ?>
 	</div>
 	<?php endif; ?>
 
-	<form action="<?php echo JRoute::_('index.php?option=com_users&view=login'); ?>" method="post" class="form-validate form-horizontal well">
+	<form action="<?php echo JRoute::_('index.php?option=com_users&view=login'); ?>" method="post" class="com-users-login__form form-validate form-horizontal well">
 
 		<fieldset>
 			<?php foreach ($this->form->getFieldset('credentials') as $field) : ?>
 				<?php if (!$field->hidden) : ?>
-					<div class="control-group">
+					<div class="com-users-login__input control-group">
 						<div class="control-label">
 							<?php echo $field->label; ?>
 						</div>
@@ -57,7 +57,7 @@ $usersConfig = JComponentHelper::getParams('com_users');
 			<?php endforeach; ?>
 
 			<?php if ($this->tfa) : ?>
-				<div class="control-group">
+				<div class="com-users-login__secretkey control-group">
 					<div class="control-label">
 						<?php echo $this->form->getField('secretkey')->label; ?>
 					</div>
@@ -68,7 +68,7 @@ $usersConfig = JComponentHelper::getParams('com_users');
 			<?php endif; ?>
 
 			<?php if (JPluginHelper::isEnabled('system', 'remember')) : ?>
-				<div  class="control-group">
+				<div  class="com-users-login__remember control-group">
 					<div class="control-label">
 						<label for="remember">
 							<?php echo JText::_('COM_USERS_LOGIN_REMEMBER_ME'); ?>
@@ -80,7 +80,7 @@ $usersConfig = JComponentHelper::getParams('com_users');
 				</div>
 			<?php endif; ?>
 
-			<div class="control-group">
+			<div class="com-users-login__submit control-group">
 				<div class="controls">
 					<button type="submit" class="btn btn-primary">
 						<?php echo JText::_('JLOGIN'); ?>
@@ -96,15 +96,15 @@ $usersConfig = JComponentHelper::getParams('com_users');
 	</form>
 </div>
 <div>
-	<div class="list-group">
-		<a class="list-group-item" href="<?php echo JRoute::_('index.php?option=com_users&view=reset'); ?>">
+	<div class="com-users-login__options list-group">
+		<a class="com-users-login__reset list-group-item" href="<?php echo JRoute::_('index.php?option=com_users&view=reset'); ?>">
 			<?php echo JText::_('COM_USERS_LOGIN_RESET'); ?>
 		</a>
-		<a class="list-group-item" href="<?php echo JRoute::_('index.php?option=com_users&view=remind'); ?>">
+		<a class="com-users-login__remind list-group-item" href="<?php echo JRoute::_('index.php?option=com_users&view=remind'); ?>">
 			<?php echo JText::_('COM_USERS_LOGIN_REMIND'); ?>
 		</a>
 		<?php if ($usersConfig->get('allowUserRegistration')) : ?>
-			<a class="list-group-item" href="<?php echo JRoute::_('index.php?option=com_users&view=registration'); ?>">
+			<a class="com-users-login__register list-group-item" href="<?php echo JRoute::_('index.php?option=com_users&view=registration'); ?>">
 				<?php echo JText::_('COM_USERS_LOGIN_REGISTER'); ?>
 			</a>
 		<?php endif; ?>

--- a/components/com_users/tmpl/login/default_logout.php
+++ b/components/com_users/tmpl/login/default_logout.php
@@ -10,7 +10,7 @@
 defined('_JEXEC') or die;
 
 ?>
-<div class="logout">
+<div class="com-users-logout logout">
 	<?php if ($this->params->get('show_page_heading')) : ?>
 	<div class="page-header">
 		<h1>
@@ -20,7 +20,7 @@ defined('_JEXEC') or die;
 	<?php endif; ?>
 
 	<?php if (($this->params->get('logoutdescription_show') == 1 && str_replace(' ', '', $this->params->get('logout_description')) != '')|| $this->params->get('logout_image') != '') : ?>
-	    <div class="logout-description">
+	    <div class="com-users-logout__description logout-description">
 	<?php endif; ?>
 
     <?php if ($this->params->get('logoutdescription_show') == 1) : ?>
@@ -28,15 +28,15 @@ defined('_JEXEC') or die;
     <?php endif; ?>
 
     <?php if ($this->params->get('logout_image') != '') : ?>
-        <img src="<?php echo $this->escape($this->params->get('logout_image')); ?>" class="thumbnail float-right logout-image" alt="<?php echo JText::_('COM_USER_LOGOUT_IMAGE_ALT'); ?>">
+        <img src="<?php echo $this->escape($this->params->get('logout_image')); ?>" class="com-users-logout__image thumbnail float-right logout-image" alt="<?php echo JText::_('COM_USER_LOGOUT_IMAGE_ALT'); ?>">
     <?php endif; ?>
 
 	<?php if (($this->params->get('logoutdescription_show') == 1 && str_replace(' ', '', $this->params->get('logout_description')) != '')|| $this->params->get('logout_image') != '') : ?>
 	    </div>
 	<?php endif; ?>
 
-	<form action="<?php echo JRoute::_('index.php?option=com_users&task=user.logout'); ?>" method="post" class="form-horizontal well">
-		<div class="control-group">
+	<form action="<?php echo JRoute::_('index.php?option=com_users&task=user.logout'); ?>" method="post" class="com-users-logout__form form-horizontal well">
+		<div class="com-users-logout__submit control-group">
 			<div class="controls">
 				<button type="submit" class="btn btn-primary">
                     <span class="icon-arrow-left icon-white"></span>

--- a/components/com_users/tmpl/profile/default.php
+++ b/components/com_users/tmpl/profile/default.php
@@ -9,7 +9,7 @@
 
 defined('_JEXEC') or die;
 ?>
-<div class="profile">
+<div class="com-users-profile profile">
     <?php if ($this->params->get('show_page_heading')) : ?>
         <div class="page-header">
             <h1>
@@ -19,7 +19,7 @@ defined('_JEXEC') or die;
     <?php endif; ?>
 
     <?php if (JFactory::getUser()->id == $this->data->id) : ?>
-        <ul class="btn-toolbar float-right">
+        <ul class="com-users-profile__edit btn-toolbar float-right">
             <li class="btn-group">
                 <a class="btn" href="<?php echo JRoute::_('index.php?option=com_users&task=profile.edit&user_id=' . (int) $this->data->id); ?>">
                     <span class="icon-user"></span> <?php echo JText::_('COM_USERS_EDIT_PROFILE'); ?>

--- a/components/com_users/tmpl/profile/default_core.php
+++ b/components/com_users/tmpl/profile/default_core.php
@@ -10,7 +10,7 @@
 defined('_JEXEC') or die;
 
 ?>
-<fieldset id="users-profile-core">
+<fieldset id="com-users-profile__core users-profile-core">
 	<legend>
 		<?php echo JText::_('COM_USERS_PROFILE_CORE_LEGEND'); ?>
 	</legend>

--- a/components/com_users/tmpl/profile/default_custom.php
+++ b/components/com_users/tmpl/profile/default_custom.php
@@ -36,7 +36,7 @@ foreach ($tmp as $customField)
 <?php foreach ($fieldsets as $group => $fieldset) : ?>
 	<?php $fields = $this->form->getFieldset($group); ?>
 	<?php if (count($fields)) : ?>
-		<fieldset id="users-profile-custom-<?php echo $group; ?>" class="users-profile-custom-<?php echo $group; ?>">
+		<fieldset id="users-profile-custom-<?php echo $group; ?>" class="com-users-profile__custom users-profile-custom-<?php echo $group; ?>">
 			<?php if (isset($fieldset->label) && ($legend = trim(JText::_($fieldset->label))) !== '') : ?>
 				<legend><?php echo $legend; ?></legend>
 			<?php endif; ?>

--- a/components/com_users/tmpl/profile/default_params.php
+++ b/components/com_users/tmpl/profile/default_params.php
@@ -14,7 +14,7 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 ?>
 <?php $fields = $this->form->getFieldset('params'); ?>
 <?php if (count($fields)) : ?>
-	<fieldset id="users-profile-custom">
+	<fieldset id="users-profile-custom" class="com-users-profile__params">
 		<legend><?php echo JText::_('COM_USERS_SETTINGS_FIELDSET_LABEL'); ?></legend>
 		<dl class="dl-horizontal">
 			<?php foreach ($fields as $field) : ?>

--- a/components/com_users/tmpl/profile/edit.php
+++ b/components/com_users/tmpl/profile/edit.php
@@ -18,7 +18,7 @@ $lang = JFactory::getLanguage();
 $lang->load('plg_user_profile', JPATH_ADMINISTRATOR);
 
 ?>
-<div class="profile-edit">
+<div class="com-users-profile__edit profile-edit">
 	<?php if ($this->params->get('show_page_heading')) : ?>
 		<div class="page-header">
 			<h1>
@@ -46,7 +46,7 @@ $lang->load('plg_user_profile', JPATH_ADMINISTRATOR);
 		}
 	</script>
 
-	<form id="member-profile" action="<?php echo JRoute::_('index.php?option=com_users&task=profile.save'); ?>" method="post" class="form-validate form-horizontal well" enctype="multipart/form-data">
+	<form id="member-profile" action="<?php echo JRoute::_('index.php?option=com_users&task=profile.save'); ?>" method="post" class="com-users-profile__edit-form form-validate form-horizontal well" enctype="multipart/form-data">
 		<?php // Iterate through the form fieldsets and display each one. ?>
 		<?php foreach ($this->form->getFieldsets() as $group => $fieldset) : ?>
 			<?php $fields = $this->form->getFieldset($group); ?>
@@ -89,10 +89,10 @@ $lang->load('plg_user_profile', JPATH_ADMINISTRATOR);
 		<?php endforeach; ?>
 
 		<?php if (count($this->twofactormethods) > 1) : ?>
-			<fieldset>
+			<fieldset class="com-users-profile__twofactor">
 				<legend><?php echo JText::_('COM_USERS_PROFILE_TWO_FACTOR_AUTH'); ?></legend>
 
-				<div class="control-group">
+				<div class="com-users-profile__twofactor-method control-group">
 					<div class="control-label">
 						<label id="jform_twofactor_method-lbl" for="jform_twofactor_method" class="hasTooltip"
 							   title="<?php echo '<strong>' . JText::_('COM_USERS_PROFILE_TWOFACTOR_LABEL') . '</strong><br>' . JText::_('COM_USERS_PROFILE_TWOFACTOR_DESC'); ?>">
@@ -103,7 +103,7 @@ $lang->load('plg_user_profile', JPATH_ADMINISTRATOR);
 						<?php echo JHtml::_('select.genericlist', $this->twofactormethods, 'jform[twofactor][method]', array('onchange' => 'Joomla.twoFactorMethodChange()'), 'value', 'text', $this->otpConfig->method, 'jform_twofactor_method', false); ?>
 					</div>
 				</div>
-				<div id="com_users_twofactor_forms_container">
+				<div id="com_users_twofactor_forms_container" class="com-users-profile__twofactor-form">
 					<?php foreach ($this->twofactorform as $form) : ?>
 						<?php $style = $form['method'] == $this->otpConfig->method ? 'display: block' : 'display: none'; ?>
 						<div id="com_users_twofactor_<?php echo $form['method']; ?>" style="<?php echo $style; ?>">
@@ -113,7 +113,7 @@ $lang->load('plg_user_profile', JPATH_ADMINISTRATOR);
 				</div>
 			</fieldset>
 
-			<fieldset>
+			<fieldset class="com-users-profile__oteps">
 				<legend>
 					<?php echo JText::_('COM_USERS_PROFILE_OTEPS'); ?>
 				</legend>
@@ -131,7 +131,7 @@ $lang->load('plg_user_profile', JPATH_ADMINISTRATOR);
 			</fieldset>
 		<?php endif; ?>
 
-		<div class="control-group">
+		<div class="com-users-profile__edit-submit control-group">
 			<div class="controls">
 				<button type="submit" class="btn btn-primary validate">
 					<span>

--- a/components/com_users/tmpl/registration/complete.php
+++ b/components/com_users/tmpl/registration/complete.php
@@ -10,7 +10,7 @@
 defined('_JEXEC') or die;
 
 ?>
-<div class="registration-complete">
+<div class="com-users-registration-complete registration-complete">
 	<?php if ($this->params->get('show_page_heading')) : ?>
 		<h1>
 			<?php echo $this->escape($this->params->get('page_heading')); ?>

--- a/components/com_users/tmpl/registration/default.php
+++ b/components/com_users/tmpl/registration/default.php
@@ -13,14 +13,14 @@ JHtml::_('behavior.keepalive');
 JHtml::_('behavior.formvalidator');
 
 ?>
-<div class="registration">
+<div class="com-users-registration registration">
 	<?php if ($this->params->get('show_page_heading')) : ?>
 		<div class="page-header">
 			<h1><?php echo $this->escape($this->params->get('page_heading')); ?></h1>
 		</div>
 	<?php endif; ?>
 
-	<form id="member-registration" action="<?php echo JRoute::_('index.php?option=com_users&task=registration.register'); ?>" method="post" class="form-validate" enctype="multipart/form-data">
+	<form id="member-registration" action="<?php echo JRoute::_('index.php?option=com_users&task=registration.register'); ?>" method="post" class="com-users-registration__form form-validate" enctype="multipart/form-data">
 		<?php // Iterate through the form fieldsets and display each one. ?>
 		<?php foreach ($this->form->getFieldsets() as $fieldset) : ?>
 			<?php $fields = $this->form->getFieldset($fieldset->name); ?>
@@ -52,12 +52,12 @@ JHtml::_('behavior.formvalidator');
 				</fieldset>
 			<?php endif; ?>
 		<?php endforeach; ?>
-		<div class="control-group">
+		<div class="com-users-registration__submit control-group">
 			<div class="controls">
-				<button type="submit" class="btn btn-primary validate">
+				<button type="submit" class="com-users-registration__register btn btn-primary validate">
                     <?php echo JText::_('JREGISTER'); ?>
                 </button>
-				<a class="btn btn-danger" href="<?php echo JRoute::_(''); ?>" title="<?php echo JText::_('JCANCEL'); ?>">
+				<a class="com-users-registration__cancel btn btn-danger" href="<?php echo JRoute::_(''); ?>" title="<?php echo JText::_('JCANCEL'); ?>">
                     <?php echo JText::_('JCANCEL'); ?>
                 </a>
 				<input type="hidden" name="option" value="com_users">

--- a/components/com_users/tmpl/remind/default.php
+++ b/components/com_users/tmpl/remind/default.php
@@ -13,7 +13,7 @@ JHtml::_('behavior.keepalive');
 JHtml::_('behavior.formvalidator');
 
 ?>
-<div class="remind">
+<div class="com-users-remind remind">
 	<?php if ($this->params->get('show_page_heading')) : ?>
 		<div class="page-header">
 			<h1>
@@ -21,7 +21,7 @@ JHtml::_('behavior.formvalidator');
 			</h1>
 		</div>
 	<?php endif; ?>
-	<form id="user-registration" action="<?php echo JRoute::_('index.php?option=com_users&task=remind.remind'); ?>" method="post" class="form-validate form-horizontal well">
+	<form id="user-registration" action="<?php echo JRoute::_('index.php?option=com_users&task=remind.remind'); ?>" method="post" class="com-users-remind__form form-validate form-horizontal well">
 		<?php foreach ($this->form->getFieldsets() as $fieldset) : ?>
 			<fieldset>
 				<p><?php echo JText::_($fieldset->label); ?></p>
@@ -39,7 +39,7 @@ JHtml::_('behavior.formvalidator');
 				<?php endforeach; ?>
 			</fieldset>
 		<?php endforeach; ?>
-		<div class="control-group">
+		<div class="com-users-remind__submit control-group">
 			<div class="controls">
 				<button type="submit" class="btn btn-primary validate">
 					<?php echo JText::_('JSUBMIT'); ?>

--- a/components/com_users/tmpl/reset/complete.php
+++ b/components/com_users/tmpl/reset/complete.php
@@ -13,7 +13,7 @@ JHtml::_('behavior.keepalive');
 JHtml::_('behavior.formvalidator');
 
 ?>
-<div class="reset-complete">
+<div class="com-users-reset-complete reset-complete">
 	<?php if ($this->params->get('show_page_heading')) : ?>
 		<div class="page-header">
 			<h1>
@@ -21,7 +21,7 @@ JHtml::_('behavior.formvalidator');
 			</h1>
 		</div>
 	<?php endif; ?>
-	<form action="<?php echo JRoute::_('index.php?option=com_users&task=reset.complete'); ?>" method="post" class="form-validate form-horizontal well">
+	<form action="<?php echo JRoute::_('index.php?option=com_users&task=reset.complete'); ?>" method="post" class="com-users-reset-complete__form form-validate form-horizontal well">
 		<?php foreach ($this->form->getFieldsets() as $fieldset) : ?>
 			<fieldset>
 				<p><?php echo JText::_($fieldset->label); ?></p>
@@ -37,7 +37,7 @@ JHtml::_('behavior.formvalidator');
 				<?php endforeach; ?>
 			</fieldset>
 		<?php endforeach; ?>
-		<div class="control-group">
+		<div class="com-users-reset-complete__submit control-group">
 			<div class="controls">
 				<button type="submit" class="btn btn-primary validate">
 					<?php echo JText::_('JSUBMIT'); ?>

--- a/components/com_users/tmpl/reset/confirm.php
+++ b/components/com_users/tmpl/reset/confirm.php
@@ -13,7 +13,7 @@ JHtml::_('behavior.keepalive');
 JHtml::_('behavior.formvalidator');
 
 ?>
-<div class="reset-confirm">
+<div class="com-users-reset-confirm reset-confirm">
 	<?php if ($this->params->get('show_page_heading')) : ?>
 		<div class="page-header">
 			<h1>
@@ -21,7 +21,7 @@ JHtml::_('behavior.formvalidator');
 			</h1>
 		</div>
 	<?php endif; ?>
-	<form action="<?php echo JRoute::_('index.php?option=com_users&task=reset.confirm'); ?>" method="post" class="form-validate form-horizontal well">
+	<form action="<?php echo JRoute::_('index.php?option=com_users&task=reset.confirm'); ?>" method="post" class="com-users-reset-confirm__form form-validate form-horizontal well">
 		<?php foreach ($this->form->getFieldsets() as $fieldset) : ?>
 			<fieldset>
 				<p><?php echo JText::_($fieldset->label); ?></p>
@@ -37,7 +37,7 @@ JHtml::_('behavior.formvalidator');
 				<?php endforeach; ?>
 			</fieldset>
 		<?php endforeach; ?>
-		<div class="control-group">
+		<div class="com-users-reset-confirm__submit control-group">
 			<div class="controls">
 				<button type="submit" class="btn btn-primary validate">
 					<?php echo JText::_('JSUBMIT'); ?>

--- a/components/com_users/tmpl/reset/default.php
+++ b/components/com_users/tmpl/reset/default.php
@@ -13,7 +13,7 @@ JHtml::_('behavior.keepalive');
 JHtml::_('behavior.formvalidator');
 
 ?>
-<div class="reset">
+<div class="com-users-reset reset">
 	<?php if ($this->params->get('show_page_heading')) : ?>
 		<div class="page-header">
 			<h1>
@@ -21,7 +21,7 @@ JHtml::_('behavior.formvalidator');
 			</h1>
 		</div>
 	<?php endif; ?>
-	<form id="user-registration" action="<?php echo JRoute::_('index.php?option=com_users&task=reset.request'); ?>" method="post" class="form-validate form-horizontal well">
+	<form id="user-registration" action="<?php echo JRoute::_('index.php?option=com_users&task=reset.request'); ?>" method="post" class="com-users-reset__form form-validate form-horizontal well">
 		<?php foreach ($this->form->getFieldsets() as $fieldset) : ?>
 			<fieldset>
 				<p><?php echo JText::_($fieldset->label); ?></p>
@@ -39,7 +39,7 @@ JHtml::_('behavior.formvalidator');
 				<?php endforeach; ?>
 			</fieldset>
 		<?php endforeach; ?>
-		<div class="control-group">
+		<div class="com-users-reset__submit control-group">
 			<div class="controls">
 				<button type="submit" class="btn btn-primary validate">
 					<?php echo JText::_('JSUBMIT'); ?>


### PR DESCRIPTION
Pull Request for Issue #15279 .

### Summary of Changes
Adds HTML classes using the following standard to com-users frontend views.

`ExtensionType-Extension(-SubExtension)(-View)` (Eg. `mod-users-registration-complete`).

Note: If the default view then `-View` is omitted. If only one SubExtension exists or if the SubExtension matches the Extension then `-SubExtension ` is omitted.

#### Child views and child elements within the views

BEM class naming is adopted.. 

- **Block** (https://en.bem.info/methodology/quick-start/#block): `ExtensionType-Extension(-View)`
- **Element** (https://en.bem.info/methodology/quick-start/#element): Child view/element

`ExtensionType-Extension__Element`.

For B/C, old classes remain. 

### Testing Instructions
Code review.


### Expected result
All works fine


### Actual result
All works fine


### Documentation Changes Required
Yes
