### PR TITLE
[4.0] HTML class naming standard [frontend][com-wrapper]

### DIFF
--- a/components/com_wrapper/tmpl/wrapper/default.php
+++ b/components/com_wrapper/tmpl/wrapper/default.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 JHtml::_('script', 'com_wrapper/iframe-height.min.js', array('version' => 'auto', 'relative' => true));
 
 ?>
-<div class="contentpane">
+<div class="com-wrapper contentpane">
 	<?php if ($this->params->get('show_page_heading')) : ?>
 		<div class="page-header">
 			<h1>
@@ -37,7 +37,7 @@ JHtml::_('script', 'com_wrapper/iframe-height.min.js', array('version' => 'auto'
 		<?php else : ?>
 			title="<?php echo $this->escape($this->params->get('page_title')); ?>"
 		<?php endif; ?>
-		class="wrapper <?php echo $this->pageclass_sfx; ?>">
+		class="com-wrapper__iframe wrapper <?php echo $this->pageclass_sfx; ?>">
 		<?php echo JText::_('COM_WRAPPER_NO_IFRAMES'); ?>
 	</iframe>
 </div>


### PR DESCRIPTION
Pull Request for Issue #15279 .

### Summary of Changes
Adds HTML classes using the following standard to com-wrapper frontend views.

`ExtensionType-Extension(-View)` (Eg. `mod-wrapper`).

Note: If the default view then `-View` is omitted. If only one SubExtension exists or if the SubExtension matches the Extension then `-SubExtension ` is omitted.

#### Child views and child elements within the views

BEM class naming is adopted.. 

- **Block** (https://en.bem.info/methodology/quick-start/#block): `ExtensionType-Extension(-View)`
- **Element** (https://en.bem.info/methodology/quick-start/#element): Child view/element

`ExtensionType-Extension__Element`.

For B/C, old classes remain. 


### Testing Instructions
Code review.


### Expected result
All works fine


### Actual result
All works fine


### Documentation Changes Required
Yes
