### PR TITLE
[4.0] HTML class naming standard [frontend][com-tags]

### DIFF
--- a/components/com_tags/tmpl/tag/default.php
+++ b/components/com_tags/tmpl/tag/default.php
@@ -15,7 +15,7 @@ $isSingleTag = count($this->item) === 1;
 
 ?>
 
-<div class="tag-category">
+<div class="com-tags-tag tag-category">
 
 	<?php if ($this->params->get('show_page_heading')) : ?>
 		<h1>
@@ -31,7 +31,7 @@ $isSingleTag = count($this->item) === 1;
 
 	<?php // We only show a tag description if there is a single tag. ?>
 	<?php if (count($this->item) === 1 && ($this->params->get('tag_list_show_tag_image', 1) || $this->params->get('tag_list_show_tag_description', 1))) : ?>
-		<div class="category-desc">
+		<div class="com-tags-tag__description category-desc">
 			<?php $images = json_decode($this->item[0]->images); ?>
 			<?php if ($this->params->get('tag_list_show_tag_image', 1) == 1 && !empty($images->image_fulltext)) : ?>
 				<img src="<?php echo htmlspecialchars($images->image_fulltext, ENT_COMPAT, 'UTF-8'); ?>"
@@ -55,7 +55,7 @@ $isSingleTag = count($this->item) === 1;
 	<?php echo $this->loadTemplate('items'); ?>
 
 	<?php if (($this->params->def('show_pagination', 1) == 1 || ($this->params->get('show_pagination') == 2)) && ($this->pagination->pagesTotal > 1)) : ?>
-		<div class="w-100">
+		<div class="com-tags-tag__pagination w-100">
 			<?php if ($this->params->def('show_pagination_results', 1)) : ?>
 				<p class="counter float-right pt-3 pr-2">
 					<?php echo $this->pagination->getPagesCounter(); ?>

--- a/components/com_tags/tmpl/tag/default_items.php
+++ b/components/com_tags/tmpl/tag/default_items.php
@@ -28,9 +28,9 @@ $canEditState = $user->authorise('core.edit.state', 'com_tags');
 $items        = $this->items;
 $n            = count($this->items);
 ?>
-<form action="<?php echo htmlspecialchars(JUri::getInstance()->toString()); ?>" method="post" name="adminForm" id="adminForm">
+<form action="<?php echo htmlspecialchars(JUri::getInstance()->toString()); ?>" method="post" name="adminForm" id="adminForm" class="com-tags-tag__items">
 	<?php if ($this->params->get('show_headings') || $this->params->get('filter_field') || $this->params->get('show_pagination_limit')) : ?>
-		<fieldset class="filters d-flex justify-content-between mb-3">
+		<fieldset class="com-tags-tag__filters filters d-flex justify-content-between mb-3">
 			<?php if ($this->params->get('filter_field')) : ?>
 				<div class="input-group">
 					<label class="filter-search-lbl sr-only" for="filter-search">
@@ -66,7 +66,7 @@ $n            = count($this->items);
 	<?php if ($this->items === false || $n === 0) : ?>
 		<p><?php echo JText::_('COM_TAGS_NO_ITEMS'); ?></p>
 	<?php else : ?>
-		<ul class="category list-group">
+		<ul class="com-tags-tag__category category list-group">
 			<?php foreach ($items as $i => $item) : ?>
 				<?php if ($item->core_state == 0) : ?>
 					<li class="list-group-item-danger">

--- a/components/com_tags/tmpl/tag/list.php
+++ b/components/com_tags/tmpl/tag/list.php
@@ -16,7 +16,7 @@ $n = count($this->items);
 
 ?>
 
-<div class="tag-category">
+<div class="com-tags-tag-list tag-category">
 
 	<?php if ($this->params->get('show_page_heading')) : ?>
 		<h1>
@@ -32,7 +32,7 @@ $n = count($this->items);
 
 	<?php // We only show a tag description if there is a single tag. ?>
 	<?php if (count($this->item) === 1 && ($this->params->get('tag_list_show_tag_image', 1) || $this->params->get('tag_list_show_tag_description', 1))) : ?>
-		<div class="category-desc">
+		<div class="com-tags-tag-list__description category-desc">
 			<?php $images = json_decode($this->item[0]->images); ?>
 			<?php if ($this->params->get('tag_list_show_tag_image', 1) == 1 && !empty($images->image_fulltext)) : ?>
 				<img src="<?php echo htmlspecialchars($images->image_fulltext, ENT_COMPAT, 'UTF-8'); ?>">

--- a/components/com_tags/tmpl/tag/list_items.php
+++ b/components/com_tags/tmpl/tag/list_items.php
@@ -19,9 +19,9 @@ $n         = count($this->items);
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
 ?>
-<form action="<?php echo htmlspecialchars(JUri::getInstance()->toString()); ?>" method="post" name="adminForm" id="adminForm">
+<form action="<?php echo htmlspecialchars(JUri::getInstance()->toString()); ?>" method="post" name="adminForm" id="adminForm" class="com-tags-tag-list__items">
 	<?php if ($this->params->get('filter_field') || $this->params->get('show_pagination_limit')) : ?>
-		<fieldset class="filters d-flex justify-content-between mb-3">
+		<fieldset class="com-tags-tag-list__filters filters d-flex justify-content-between mb-3">
 			<?php if ($this->params->get('filter_field')) : ?>
 				<div class="input-group">
 					<label class="filter-search-lbl sr-only" for="filter-search">
@@ -57,7 +57,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 	<?php if ($this->items === false || $n === 0) : ?>
 		<p><?php echo JText::_('COM_TAGS_NO_ITEMS'); ?></p>
 	<?php else : ?>
-		<table class="category table table-striped table-bordered table-hover">
+		<table class="com-tags-tag-list__category category table table-striped table-bordered table-hover">
 			<?php if ($this->params->get('show_headings')) : ?>
 				<thead>
 					<tr>
@@ -115,7 +115,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 	<?php // Add pagination links ?>
 	<?php if (!empty($this->items)) : ?>
 		<?php if (($this->params->def('show_pagination', 2) == 1 || ($this->params->get('show_pagination') == 2)) && ($this->pagination->pagesTotal > 1)) : ?>
-			<div class="w-100">
+			<div class="com-tags-tag-list__pagination w-100">
 				<?php if ($this->params->def('show_pagination_results', 1)) : ?>
 					<p class="counter float-right pt-3 pr-2">
 						<?php echo $this->pagination->getPagesCounter(); ?>

--- a/components/com_tags/tmpl/tags/default.php
+++ b/components/com_tags/tmpl/tags/default.php
@@ -16,19 +16,19 @@ $description      = $this->params->get('all_tags_description');
 $descriptionImage = $this->params->get('all_tags_description_image');
 
 ?>
-<div class="tag-category">
+<div class="com-tags tag-category">
 	<?php if ($this->params->get('show_page_heading')) : ?>
 		<h1>
 			<?php echo $this->escape($this->params->get('page_heading')); ?>
 		</h1>
 	<?php endif; ?>
 	<?php if ($this->params->get('all_tags_show_description_image') && !empty($descriptionImage)) : ?>
-		<div>
+		<div class="com-tags__image">
 			<img src="<?php echo $descriptionImage; ?>" />
 		</div>
 	<?php endif; ?>
 	<?php if (!empty($description)) : ?>
-		<div>
+		<div class="com-tags__description">
 			<?php echo $description; ?>
 		</div>
 	<?php endif; ?>

--- a/components/com_tags/tmpl/tags/default_items.php
+++ b/components/com_tags/tmpl/tags/default_items.php
@@ -47,7 +47,7 @@ $n         = count($this->items);
 
 <div class="com-tags__items">
 	<?php if ($this->params->get('filter_field') || $this->params->get('show_pagination_limit')) : ?>
-		<form action="<?php echo htmlspecialchars(JUri::getInstance()->toString()); ?>" method="post" name="adminForm" id="adminForm" class="com-tags__items">
+		<form action="<?php echo htmlspecialchars(JUri::getInstance()->toString()); ?>" method="post" name="adminForm" id="adminForm">
 			<fieldset class="com-tags__filters filters d-flex justify-content-between mb-3">
 				<?php if ($this->params->get('filter_field')) : ?>
 					<div class="input-group">

--- a/components/com_tags/tmpl/tags/default_items.php
+++ b/components/com_tags/tmpl/tags/default_items.php
@@ -45,110 +45,112 @@ $n         = count($this->items);
 
 ?>
 
-<?php if ($this->params->get('filter_field') || $this->params->get('show_pagination_limit')) : ?>
-	<form action="<?php echo htmlspecialchars(JUri::getInstance()->toString()); ?>" method="post" name="adminForm" id="adminForm">
-		<fieldset class="filters d-flex justify-content-between mb-3">
-			<?php if ($this->params->get('filter_field')) : ?>
-				<div class="input-group">
-					<label class="filter-search-lbl sr-only" for="filter-search">
-						<?php echo JText::_('COM_TAGS_TITLE_FILTER_LABEL') . '&#160;'; ?>
-					</label>
-					<input type="text" name="filter-search" id="filter-search" value="<?php echo $this->escape($this->state->get('list.filter')); ?>" class="form-control" title="<?php echo JText::_('COM_TAGS_FILTER_SEARCH_DESC'); ?>" placeholder="<?php echo JText::_('COM_TAGS_TITLE_FILTER_LABEL'); ?>">
-					<span class="input-group-append">
-						<button type="submit" name="filter-search-button" title="<?php echo JText::_('JSEARCH_FILTER_SUBMIT'); ?>" class="btn btn-secondary">
-							<span class="fa fa-search" aria-hidden="true"></span>
-						</button>
-						<button type="reset" name="filter-clear-button" title="<?php echo JText::_('JSEARCH_FILTER_CLEAR'); ?>" class="btn btn-secondary">
-							<span class="fa fa-times" aria-hidden="true"></span>
-						</button>
-					</span>
-				</div>
-			<?php endif; ?>
-			<?php if ($this->params->get('show_pagination_limit')) : ?>
-				<div class="btn-group float-right">
-					<label for="limit" class="sr-only">
-						<?php echo JText::_('JGLOBAL_DISPLAY_NUM'); ?>
-					</label>
-					<?php echo $this->pagination->getLimitBox(); ?>
-				</div>
-			<?php endif; ?>
-
-			<input type="hidden" name="filter_order" value="">
-			<input type="hidden" name="filter_order_Dir" value="">
-			<input type="hidden" name="limitstart" value="">
-			<input type="hidden" name="task" value="">
-		</fieldset>
-	</form>
-<?php endif; ?>
-
-<?php if ($this->items == false || $n === 0) : ?>
-	<p><?php echo JText::_('COM_TAGS_NO_TAGS'); ?></p>
-<?php else : ?>
-	<?php foreach ($this->items as $i => $item) : ?>
-
-		<?php if ($n === 1 || $i === 0 || $bscolumns === 1 || $i % $bscolumns === 0) : ?>
-			<ul class="category list-group">
-		<?php endif; ?>
-
-		<li class="list-group-item list-group-item-action">
-			<?php if ((!empty($item->access)) && in_array($item->access, $this->user->getAuthorisedViewLevels())) : ?>
-				<h3 class="mb-0">
-					<a href="<?php echo JRoute::_(TagsHelperRoute::getTagRoute($item->id . ':' . $item->alias)); ?>">
-						<?php echo $this->escape($item->title); ?>
-					</a>
-				</h3>
-			<?php endif; ?>
-
-			<?php if ($this->params->get('all_tags_show_tag_image') && !empty($item->images)) : ?>
-				<?php $images = json_decode($item->images); ?>
-				<span class="tag-body">
-					<?php if (!empty($images->image_intro)) : ?>
-						<?php $imgfloat = empty($images->float_intro) ? $this->params->get('float_intro') : $images->float_intro; ?>
-						<div class="float-<?php echo htmlspecialchars($imgfloat); ?> item-image">
-							<img
-								<?php if ($images->image_intro_caption) : ?>
-									<?php echo 'class="caption"' . ' title="' . htmlspecialchars($images->image_intro_caption) . '"'; ?>
-								<?php endif; ?>
-								src="<?php echo $images->image_intro; ?>"
-								alt="<?php echo htmlspecialchars($images->image_intro_alt); ?>">
-						</div>
-					<?php endif; ?>
-				</span>
-			<?php endif; ?>
-
-			<?php if ($this->params->get('all_tags_show_tag_description') || $this->params->get('all_tags_show_tag_hits')) : ?>
-				<div class="caption">
-					<?php if ($this->params->get('all_tags_show_tag_description')) : ?>
-						<span class="tag-body">
-							<?php echo JHtml::_('string.truncate', $item->description, $this->params->get('all_tags_tag_maximum_characters')); ?>
+<div class="com-tags__items">
+	<?php if ($this->params->get('filter_field') || $this->params->get('show_pagination_limit')) : ?>
+		<form action="<?php echo htmlspecialchars(JUri::getInstance()->toString()); ?>" method="post" name="adminForm" id="adminForm" class="com-tags__items">
+			<fieldset class="com-tags__filters filters d-flex justify-content-between mb-3">
+				<?php if ($this->params->get('filter_field')) : ?>
+					<div class="input-group">
+						<label class="filter-search-lbl sr-only" for="filter-search">
+							<?php echo JText::_('COM_TAGS_TITLE_FILTER_LABEL') . '&#160;'; ?>
+						</label>
+						<input type="text" name="filter-search" id="filter-search" value="<?php echo $this->escape($this->state->get('list.filter')); ?>" class="form-control" title="<?php echo JText::_('COM_TAGS_FILTER_SEARCH_DESC'); ?>" placeholder="<?php echo JText::_('COM_TAGS_TITLE_FILTER_LABEL'); ?>">
+						<span class="input-group-append">
+							<button type="submit" name="filter-search-button" title="<?php echo JText::_('JSEARCH_FILTER_SUBMIT'); ?>" class="btn btn-secondary">
+								<span class="fa fa-search" aria-hidden="true"></span>
+							</button>
+							<button type="reset" name="filter-clear-button" title="<?php echo JText::_('JSEARCH_FILTER_CLEAR'); ?>" class="btn btn-secondary">
+								<span class="fa fa-times" aria-hidden="true"></span>
+							</button>
 						</span>
-					<?php endif; ?>
-					<?php if ($this->params->get('all_tags_show_tag_hits')) : ?>
-						<span class="list-hits badge badge-info">
-							<?php echo JText::sprintf('JGLOBAL_HITS_COUNT', $item->hits); ?>
-						</span>
-					<?php endif; ?>
-				</div>
-			<?php endif; ?>
-		</li>
+					</div>
+				<?php endif; ?>
+				<?php if ($this->params->get('show_pagination_limit')) : ?>
+					<div class="btn-group float-right">
+						<label for="limit" class="sr-only">
+							<?php echo JText::_('JGLOBAL_DISPLAY_NUM'); ?>
+						</label>
+						<?php echo $this->pagination->getLimitBox(); ?>
+					</div>
+				<?php endif; ?>
 
-		<?php if (($i === 0 && $n === 1) || $i === $n - 1 || $bscolumns === 1 || (($i + 1) % $bscolumns === 0)) : ?>
-			</ul>
-		<?php endif; ?>
-
-	<?php endforeach; ?>
-<?php endif; ?>
-
-<?php // Add pagination links ?>
-<?php if (!empty($this->items)) : ?>
-	<?php if (($this->params->def('show_pagination', 2) == 1 || ($this->params->get('show_pagination') == 2)) && ($this->pagination->pagesTotal > 1)) : ?>
-		<div class="w-100">
-			<?php if ($this->params->def('show_pagination_results', 1)) : ?>
-				<p class="counter float-right pt-3 pr-2">
-					<?php echo $this->pagination->getPagesCounter(); ?>
-				</p>
-			<?php endif; ?>
-			<?php echo $this->pagination->getPagesLinks(); ?>
-		</div>
+				<input type="hidden" name="filter_order" value="">
+				<input type="hidden" name="filter_order_Dir" value="">
+				<input type="hidden" name="limitstart" value="">
+				<input type="hidden" name="task" value="">
+			</fieldset>
+		</form>
 	<?php endif; ?>
-<?php endif; ?>
+
+	<?php if ($this->items == false || $n === 0) : ?>
+		<p class="com-tags__no-tags"><?php echo JText::_('COM_TAGS_NO_TAGS'); ?></p>
+	<?php else : ?>
+		<?php foreach ($this->items as $i => $item) : ?>
+
+			<?php if ($n === 1 || $i === 0 || $bscolumns === 1 || $i % $bscolumns === 0) : ?>
+				<ul class="com-tags__category category list-group">
+			<?php endif; ?>
+
+			<li class="list-group-item list-group-item-action">
+				<?php if ((!empty($item->access)) && in_array($item->access, $this->user->getAuthorisedViewLevels())) : ?>
+					<h3 class="mb-0">
+						<a href="<?php echo JRoute::_(TagsHelperRoute::getTagRoute($item->id . ':' . $item->alias)); ?>">
+							<?php echo $this->escape($item->title); ?>
+						</a>
+					</h3>
+				<?php endif; ?>
+
+				<?php if ($this->params->get('all_tags_show_tag_image') && !empty($item->images)) : ?>
+					<?php $images = json_decode($item->images); ?>
+					<span class="tag-body">
+						<?php if (!empty($images->image_intro)) : ?>
+							<?php $imgfloat = empty($images->float_intro) ? $this->params->get('float_intro') : $images->float_intro; ?>
+							<div class="float-<?php echo htmlspecialchars($imgfloat); ?> item-image">
+								<img
+									<?php if ($images->image_intro_caption) : ?>
+										<?php echo 'class="caption"' . ' title="' . htmlspecialchars($images->image_intro_caption) . '"'; ?>
+									<?php endif; ?>
+									src="<?php echo $images->image_intro; ?>"
+									alt="<?php echo htmlspecialchars($images->image_intro_alt); ?>">
+							</div>
+						<?php endif; ?>
+					</span>
+				<?php endif; ?>
+
+				<?php if ($this->params->get('all_tags_show_tag_description') || $this->params->get('all_tags_show_tag_hits')) : ?>
+					<div class="caption">
+						<?php if ($this->params->get('all_tags_show_tag_description')) : ?>
+							<span class="tag-body">
+								<?php echo JHtml::_('string.truncate', $item->description, $this->params->get('all_tags_tag_maximum_characters')); ?>
+							</span>
+						<?php endif; ?>
+						<?php if ($this->params->get('all_tags_show_tag_hits')) : ?>
+							<span class="list-hits badge badge-info">
+								<?php echo JText::sprintf('JGLOBAL_HITS_COUNT', $item->hits); ?>
+							</span>
+						<?php endif; ?>
+					</div>
+				<?php endif; ?>
+			</li>
+
+			<?php if (($i === 0 && $n === 1) || $i === $n - 1 || $bscolumns === 1 || (($i + 1) % $bscolumns === 0)) : ?>
+				</ul>
+			<?php endif; ?>
+
+		<?php endforeach; ?>
+	<?php endif; ?>
+
+	<?php // Add pagination links ?>
+	<?php if (!empty($this->items)) : ?>
+		<?php if (($this->params->def('show_pagination', 2) == 1 || ($this->params->get('show_pagination') == 2)) && ($this->pagination->pagesTotal > 1)) : ?>
+			<div class="com-tags__pagination w-100">
+				<?php if ($this->params->def('show_pagination_results', 1)) : ?>
+					<p class="counter float-right pt-3 pr-2">
+						<?php echo $this->pagination->getPagesCounter(); ?>
+					</p>
+				<?php endif; ?>
+				<?php echo $this->pagination->getPagesLinks(); ?>
+			</div>
+		<?php endif; ?>
+	<?php endif; ?>
+</div>


### PR DESCRIPTION
Pull Request for Issue #15279 .

### Summary of Changes
Adds HTML classes using the following standard to com-tags frontend views.

`ExtensionType-Extension(-SubExtension)(-View)` (Eg. `mod-tags-tag-list`).

Note: If the default view then `-View` is omitted. If only one SubExtension exists or if the SubExtension matches the Extension then `-SubExtension ` is omitted.

#### Child views and child elements within the views

BEM class naming is adopted.. 

- **Block** (https://en.bem.info/methodology/quick-start/#block): `ExtensionType-Extension(-View)`
- **Element** (https://en.bem.info/methodology/quick-start/#element): Child view/element

`ExtensionType-Extension__Element`.

For B/C, old classes remain. 

### Testing Instructions
Code review.

### Expected result
All works fine

### Actual result
All works fine

### Documentation Changes Required
Yes
