### PR TITLE
Keep the J4 branch working for now

### DIFF
--- a/libraries/namespacemap.php
+++ b/libraries/namespacemap.php
@@ -81,12 +81,23 @@ class JNamespacePsr4Map
 
 				if (file_exists(JPATH_ADMINISTRATOR . '/components/' . $element))
 				{
+					// If a component has a src/ directory use it. Else just use the main component directory
 					$elements[$baseNamespace . '\\\\Administrator\\\\'] = array('/administrator/components/' . $element);
+
+					if (file_exists(JPATH_ADMINISTRATOR . '/components/' . $element . '/src/'))
+					{
+						$elements[$baseNamespace . '\\\\Administrator\\\\'] = array('/administrator/components/' . $element . '/src/');
+					}
 				}
 
 				if (file_exists(JPATH_ROOT . '/components/' . $element))
 				{
 					$elements[$baseNamespace . '\\\\Site\\\\'] = array('/components/' . $element);
+
+					if (file_exists(JPATH_ROOT . '/components/' . $element . '/src/'))
+					{
+						$elements[$baseNamespace . '\\\\Site\\\\'] = array('/components/' . $element . '/src/');
+					}
 				}
 			}
 			elseif ($extension->type === 'module')

--- a/plugins/filesystem/local/local.php
+++ b/plugins/filesystem/local/local.php
@@ -88,6 +88,9 @@ class PlgFileSystemLocal extends CMSPlugin implements ProviderInterface
 			list($directories) = $directories;
 		}
 
+		// TODO: This should be removed once there is proper support for namespaced plugins
+		JLoader::registerNamespace('\\Joomla\\Plugin\\Filesystem\\Local\\Adapter', __DIR__ . '/Adapter', false, true, 'psr4');
+
 		foreach ($directories as $directoryEntity)
 		{
 			if ($directoryEntity->directory)


### PR DESCRIPTION
A slightly dodgy change for https://github.com/joomla/joomla-cms/issues/20823 to short term make things work in media manager and get tests passing again

Medium term I agree with the change proposed by @dneukirchen for the namespace definition