### PR TITLE
Script second argument should not be the value

### DIFF
--- a/libraries/src/Document/HtmlDocument.php
+++ b/libraries/src/Document/HtmlDocument.php
@@ -254,7 +254,7 @@ class HtmlDocument extends Document
 		{
 			foreach ($data['scriptText'] as $key => $string)
 			{
-				\JText::script($key, $string);
+				\JText::script($key);
 			}
 		}
 


### PR DESCRIPTION
### Summary of Changes
As I was testing 3.8.9 RC I found this issue popping up when clicking to install the sample data:

![image](https://user-images.githubusercontent.com/359377/41806435-37d871dc-76be-11e8-800d-86b71c6fda26.png)

Notice the `\'` in the text. I tracked this down and it happened because in the process of rendering the page we call the function `onBeforeCompileHead()`. I have a plugin installed that listens to this and in the plugin at some point the `setHeadData()` of `HtmlDocument` class is called. This method calls the `JText::script()` again. It calls it with the language key and language value but the second argument is not the value but if the text should be considered JavaScript safe. Supplying a text string as second argument tells the method that it should always treat the string as JavaScript safe. Since the language strings was originally already set to be JavaScript safe it now gets 2 backslashes. If I were to have 3 more plugins calling `setHeadData()` I would end up with 4 backslashes.

I tracked the implementation of this code back to this commit https://github.com/joomla/joomla-cms/commit/9f692f7b8271f6a006af929bc0a14ec33aaa1194 which shows the code has never changed since it's original implementation in May 2013. Interesting enough either this never showed up or nobody noticed :)

### Testing Instructions
1. Open the file `plugins/system/updatenotification/updatenotification.php` (assuming you have the update notification plugin enabled)
2. After line 419 add this code and save
```
public function onBeforeCompileHead(){
		$doc = JFactory::getDocument();
		$head = $doc->getHeadData();
		$doc->setHeadData($head);
	}
```
3. Create a sample data module in the backend
4. Enable the Sample Data Blog plugin
5. Click on the Blog Sample Data link
![image](https://user-images.githubusercontent.com/359377/41806532-13816954-76c0-11e8-8a99-6ddb80a1a8a6.png)
6. Notice the text with the `\'` in it.
7. Apply the patch
8. Refresh the page
9. Click on the Blog Sample Data link again
10. Notice the word is now `can't` as expected.

### Expected result
The word `can't`


### Actual result
The word `can\'t`


### Documentation Changes Required
None
