### PR TITLE
Fix validation messages in reverse order on installation

### DIFF
--- a/installation/model/setup.php
+++ b/installation/model/setup.php
@@ -444,8 +444,10 @@ class InstallationModelSetup extends JModelBase
 		// Check the validation results.
 		if ($return === false)
 		{
+			$messages = array_reverse($form->getErrors());
+
 			// Get the validation messages from the form.
-			foreach ($form->getErrors() as $message)
+			foreach ($messages as $message)
 			{
 				if ($message instanceof Exception)
 				{

--- a/installation/model/setup.php
+++ b/installation/model/setup.php
@@ -444,9 +444,9 @@ class InstallationModelSetup extends JModelBase
 		// Check the validation results.
 		if ($return === false)
 		{
+			// Get the validation messages from the form.
 			$messages = array_reverse($form->getErrors());
 
-			// Get the validation messages from the form.
 			foreach ($messages as $message)
 			{
 				if ($message instanceof Exception)


### PR DESCRIPTION
Pull Request for Issue #15622.

### Summary of Changes
Fix validation error messages to display in order, from top to bottom of the page,


### Testing Instructions
Install this branch https://github.com/Quy/joomla-cms/archive/patch-1.zip
On the first page, leave all fields blank
Click Next button

### Expected result
```
Warning
Field required: Site Name
Field required: Email
Field required: Username
Field required: Password
Field required: Confirm Administrator Password
```

### Actual result
```
Warning
Field required: Confirm Administrator Password
Field required: Password
Field required: Username
Field required: Email
Field required: Site Name
```


### Documentation Changes Required
no
