### PR TITLE
[4.0] HTML class naming standard [frontend][com-mailto]

### DIFF
--- a/components/com_mailto/tmpl/mailto/default.php
+++ b/components/com_mailto/tmpl/mailto/default.php
@@ -74,11 +74,11 @@ $data = $this->get('data');
 				<input type="text" id="subject_field" name="subject" class="form-control" value="<?php echo $this->escape($data->subject); ?>">
 			</div>
 		</div>
-		<div class="com-mailto__buttons control-group">
+		<div class="com-mailto__submit control-group">
 			<button type="button" class="com-mailto__cancel btn btn-danger close-mailto">
 				<?php echo JText::_('COM_MAILTO_CANCEL'); ?>
 			</button>
-			<button type="submit" class="com-mailto__submit com-mailto__send btn btn-success">
+			<button type="submit" class="com-mailto__send btn btn-success">
 				<?php echo JText::_('COM_MAILTO_SEND'); ?>
 			</button>
 		</div>

--- a/components/com_mailto/tmpl/mailto/default.php
+++ b/components/com_mailto/tmpl/mailto/default.php
@@ -22,19 +22,19 @@ HTMLHelper::_('script', 'com_mailto/mailto-default.js', ['relative' => true, 've
 $data = $this->get('data');
 ?>
 
-<div id="mailto-window" class="p-2">
+<div id="mailto-window" class="com-mailto p-2">
 	<h2>
 		<?php echo JText::_('COM_MAILTO_EMAIL_TO_A_FRIEND'); ?>
 	</h2>
-	<div class="mailto-close">
+	<div class="com-mailto__close mailto-close">
 		<a title="<?php echo JText::_('COM_MAILTO_CLOSE_WINDOW'); ?>" href="#" class="close-mailto">
 		 <span>
              <?php echo JText::_('COM_MAILTO_CLOSE_WINDOW'); ?>
          </span></a>
 	</div>
 
-	<form action="<?php echo JUri::base() ?>index.php" id="mailtoForm" method="post">
-		<div class="control-group">
+	<form action="<?php echo JUri::base() ?>index.php" id="mailtoForm" method="post" class="com-mailto__form">
+		<div class="com-mailto__emailto control-group">
 			<div class="control-label">
 				<label for="mailto_field">
                     <?php echo JText::_('COM_MAILTO_EMAIL_TO'); ?>
@@ -44,7 +44,7 @@ $data = $this->get('data');
 				<input type="text" id="mailto_field" name="mailto" class="form-control" value="<?php echo $this->escape($data->mailto); ?>">
 			</div>
 		</div>
-		<div class="control-group">
+		<div class="com-mailto__sender control-group">
 			<div class="control-label">
 				<label for="sender_field">
                     <?php echo JText::_('COM_MAILTO_SENDER'); ?>
@@ -54,7 +54,7 @@ $data = $this->get('data');
 				<input type="text" id="sender_field" name="sender" class="form-control" value="<?php echo $this->escape($data->sender); ?>">
 			</div>
 		</div>
-		<div class="control-group">
+		<div class="com-mailto__your-email control-group">
 			<div class="control-label">
 				<label for="from_field">
                     <?php echo JText::_('COM_MAILTO_YOUR_EMAIL'); ?>
@@ -64,7 +64,7 @@ $data = $this->get('data');
 				<input type="text" id="from_field" name="from" class="form-control" value="<?php echo $this->escape($data->from); ?>">
 			</div>
 		</div>
-		<div class="control-group">
+		<div class="com-mailto__subject control-group">
 				<div class="control-label">
 			<label for="subject_field">
                 <?php echo JText::_('COM_MAILTO_SUBJECT'); ?>
@@ -74,11 +74,11 @@ $data = $this->get('data');
 				<input type="text" id="subject_field" name="subject" class="form-control" value="<?php echo $this->escape($data->subject); ?>">
 			</div>
 		</div>
-		<div class="control-group">
-			<button type="button" class="btn btn-danger close-mailto">
+		<div class="com-mailto__buttons control-group">
+			<button type="button" class="com-mailto__cancel btn btn-danger close-mailto">
 				<?php echo JText::_('COM_MAILTO_CANCEL'); ?>
 			</button>
-			<button type="submit" class="btn btn-success">
+			<button type="submit" class="com-mailto__send btn btn-success">
 				<?php echo JText::_('COM_MAILTO_SEND'); ?>
 			</button>
 		</div>

--- a/components/com_mailto/tmpl/mailto/default.php
+++ b/components/com_mailto/tmpl/mailto/default.php
@@ -78,7 +78,7 @@ $data = $this->get('data');
 			<button type="button" class="com-mailto__cancel btn btn-danger close-mailto">
 				<?php echo JText::_('COM_MAILTO_CANCEL'); ?>
 			</button>
-			<button type="submit" class="com-mailto__send btn btn-success">
+			<button type="submit" class="com-mailto__submit com-mailto__send btn btn-success">
 				<?php echo JText::_('COM_MAILTO_SEND'); ?>
 			</button>
 		</div>

--- a/components/com_mailto/tmpl/sent/default.php
+++ b/components/com_mailto/tmpl/sent/default.php
@@ -10,13 +10,13 @@
 defined('_JEXEC') or die;
 
 ?>
-<div class="p-2">
-	<div class="text-right">
+<div class="com-mailto-send p-2">
+	<div class="com-mailto-send__close text-right">
 		<a href="javascript: void window.close()">
 			<?php echo JText::_('COM_MAILTO_CLOSE_WINDOW'); ?> <?php echo JHtml::_('image', 'mailto/close-x.png', null, null, true); ?>
 		</a>
 	</div>
-	<h2>
+	<h2 class="com-mailto-send__message">
 		<?php echo JText::_('COM_MAILTO_EMAIL_SENT'); ?>
 	</h2>
 </div>


### PR DESCRIPTION
Pull Request for Issue #15279 .

### Summary of Changes
Adds HTML classes using the following standard to com-mailto frontend views.

`ExtensionType-Extension(-SubExtension)(-View)` (Eg. `com-mailto-sent`).

Note: If the default view then `-View` is omitted. If only one SubExtension exists or if the SubExtension matches the Extension then `-SubExtension ` is omitted.

#### Child views and child elements within the views

BEM class naming is adopted.. 

- **Block** (https://en.bem.info/methodology/quick-start/#block): `ExtensionType-Extension(-View)`
- **Element** (https://en.bem.info/methodology/quick-start/#element): Child view/element

`ExtensionType-Extension__Element`.

For B/C, old classes remain. 

### Testing Instructions
Code review.

### Expected result
All works fine

### Actual result
All works fine

### Documentation Changes Required
Yes
