### PR TITLE
[4.0] HTML class naming standard [frontend][com-finder]

### DIFF
--- a/components/com_finder/tmpl/search/default.php
+++ b/components/com_finder/tmpl/search/default.php
@@ -20,7 +20,7 @@ JText::script('MOD_FINDER_SEARCH_VALUE', true);
 JHtml::_('script', 'com_finder/finder.js', array('version' => 'auto', 'relative' => true));
 
 ?>
-<div class="finder">
+<div class="com-finder finder">
 	<?php if ($this->params->get('show_page_heading')) : ?>
 		<h1>
 			<?php if ($this->escape($this->params->get('page_heading'))) : ?>
@@ -31,13 +31,13 @@ JHtml::_('script', 'com_finder/finder.js', array('version' => 'auto', 'relative'
 		</h1>
 	<?php endif; ?>
 	<?php if ($this->params->get('show_search_form', 1)) : ?>
-		<div id="search-form">
+		<div id="search-form" class="com-finder__form">
 			<?php echo $this->loadTemplate('form'); ?>
 		</div>
 	<?php endif; ?>
 	<?php // Load the search results layout if we are performing a search. ?>
 	<?php if ($this->query->search === true) : ?>
-		<div id="search-results">
+		<div id="search-results" class="com-finder__results">
 			<?php echo $this->loadTemplate('results'); ?>
 		</div>
 	<?php endif; ?>

--- a/components/com_finder/tmpl/search/default_form.php
+++ b/components/com_finder/tmpl/search/default_form.php
@@ -27,7 +27,7 @@ if ($this->params->get('show_autosuggest', 1))
 	<?php if (false && $this->state->get('list.ordering') !== 'relevance_dsc') : ?>
 		<input type="hidden" name="o" value="<?php echo $this->escape($this->state->get('list.ordering')); ?>">
 	<?php endif; ?>
-	<fieldset class="word mb-3">
+	<fieldset class="com-finder__search word mb-3">
 		<div class="form-inline">
 			<label for="q" class="mr-2">
 				<?php echo JText::_('COM_FINDER_SEARCH_TERMS'); ?>
@@ -57,15 +57,15 @@ if ($this->params->get('show_autosuggest', 1))
 	</fieldset>
 
 	<?php if ($this->params->get('show_advanced', 1)) : ?>
-		<div id="advancedSearch" class="js-finder-advanced collapse<?php if ($this->params->get('expand_advanced', 0)) echo ' show'; ?>">
+		<div id="advancedSearch" class="com-finder__advanced js-finder-advanced collapse<?php if ($this->params->get('expand_advanced', 0)) echo ' show'; ?>">
 			<?php if ($this->params->get('show_advanced_tips', 1)) : ?>
-				<div class="card card-outline-secondary mb-3">
+				<div class="com-finder__tips card card-outline-secondary mb-3">
 					<div class="card-body">
 						<?php echo JText::_('COM_FINDER_ADVANCED_TIPS'); ?>
 					</div>
 				</div>
 			<?php endif; ?>
-			<div id="finder-filter-window">
+			<div id="finder-filter-window" class="com-finder__filter">
 				<?php echo JHtml::_('filter.select', $this->query, $this->params); ?>
 			</div>
 		</div>

--- a/components/com_finder/tmpl/search/default_result.php
+++ b/components/com_finder/tmpl/search/default_result.php
@@ -48,7 +48,7 @@ if (!empty($this->query->highlight)
 }
 
 ?>
-<li>
+<li class="com-finder__result">
 	<h4 class="result-title <?php echo $mime; ?>">
 		<a href="<?php echo JRoute::_($route); ?>">
 			<?php echo $this->result->title; ?>

--- a/components/com_finder/tmpl/search/default_results.php
+++ b/components/com_finder/tmpl/search/default_results.php
@@ -30,7 +30,7 @@ defined('_JEXEC') or die;
 <?php endif; ?>
 <?php // Display the 'no results' message and exit the template. ?>
 <?php if (($this->total === 0) || ($this->total === null)) : ?>
-	<div id="com-finder__empty search-result-empty">
+	<div id="search-result-empty" class="com-finder__empty">
 		<h2><?php echo JText::_('COM_FINDER_SEARCH_NO_RESULTS_HEADING'); ?></h2>
 		<?php $multilang = JFactory::getApplication()->getLanguageFilter() ? '_MULTILANG' : ''; ?>
 		<p><?php echo JText::sprintf('COM_FINDER_SEARCH_NO_RESULTS_BODY' . $multilang, $this->escape($this->query->input)); ?></p>

--- a/components/com_finder/tmpl/search/default_results.php
+++ b/components/com_finder/tmpl/search/default_results.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 ?>
 <?php // Display the suggested search if it is different from the current search. ?>
 <?php if (($this->suggested && $this->params->get('show_suggested_query', 1)) || ($this->explained && $this->params->get('show_explained_query', 1))) : ?>
-	<div id="search-query-explained">
+	<div id="search-query-explained" class="com-finder__explained">
 		<?php // Display the suggested search query. ?>
 		<?php if ($this->suggested && $this->params->get('show_suggested_query', 1)) : ?>
 			<?php // Replace the base query string with the suggested query string. ?>
@@ -30,7 +30,7 @@ defined('_JEXEC') or die;
 <?php endif; ?>
 <?php // Display the 'no results' message and exit the template. ?>
 <?php if (($this->total === 0) || ($this->total === null)) : ?>
-	<div id="search-result-empty">
+	<div id="com-finder__empty search-result-empty">
 		<h2><?php echo JText::_('COM_FINDER_SEARCH_NO_RESULTS_HEADING'); ?></h2>
 		<?php $multilang = JFactory::getApplication()->getLanguageFilter() ? '_MULTILANG' : ''; ?>
 		<p><?php echo JText::sprintf('COM_FINDER_SEARCH_NO_RESULTS_BODY' . $multilang, $this->escape($this->query->input)); ?></p>
@@ -44,7 +44,7 @@ defined('_JEXEC') or die;
 <?php endif; ?>
 <?php // Display a list of results ?>
 <br id="highlighter-start" />
-<ul class="search-results list-striped">
+<ul class="com-finder__results-list search-results list-striped">
 	<?php $this->baseUrl = JUri::getInstance()->toString(array('scheme', 'host', 'port')); ?>
 	<?php foreach ($this->results as $result) : ?>
 		<?php $this->result = &$result; ?>
@@ -54,11 +54,11 @@ defined('_JEXEC') or die;
 </ul>
 <br id="highlighter-end" />
 <?php // Display the pagination ?>
-<div class="search-pagination">
-	<div class="w-100">
+<div class="com-finder__navigation search-pagination">
+	<div class="com-finder__pagination w-100">
 		<?php echo $this->pagination->getPagesLinks(); ?>
 	</div>
-	<div class="search-pages-counter">
+	<div class="com-finder__counter search-pages-counter">
 		<?php // Prepare the pagination string.  Results X - Y of Z ?>
 		<?php $start = (int) $this->pagination->limitstart + 1; ?>
 		<?php $total = (int) $this->pagination->total; ?>


### PR DESCRIPTION
Pull Request for Issue #15279 .

### Summary of Changes
Adds HTML classes using the following standard to com-finder frontend views.

`ExtensionType-Extension(-SubExtension)(-View)` (Eg. 'com-finder`).

Note: If the default view then `-View` is omitted. If only one SubExtension exists or if the SubExtension matches the Extension then `-SubExtension ` is omitted.

#### Child views and child elements within the views

BEM class naming is adopted.. 

- **Block** (https://en.bem.info/methodology/quick-start/#block): `ExtensionType-Extension(-View)`
- **Element** (https://en.bem.info/methodology/quick-start/#element): Child view/element

`ExtensionType-Extension__Element`.

For B/C, old classes remain. 

### Testing Instructions
Code review.

### Expected result
All works fine

### Actual result
All works fine

### Documentation Changes Required
Yes
