### PR TITLE
Fix the autoloader for Windows platforms

### DIFF
--- a/libraries/loader.php
+++ b/libraries/loader.php
@@ -546,7 +546,7 @@ abstract class JLoader
 					$classFilePath = realpath($path . DIRECTORY_SEPARATOR . substr_replace($classPath, '', 0, strlen($nsPath) + 1));
 
 					// We do not allow files outside the namespace root to be loaded
-					if (strpos($classFilePath, $path) !== 0)
+					if (strpos($classFilePath, realpath($path)) !== 0)
 					{
 						continue;
 					}
@@ -614,7 +614,7 @@ abstract class JLoader
 					$classFilePath = realpath($path . DIRECTORY_SEPARATOR . $classPath);
 
 					// We do not allow files outside the namespace root to be loaded
-					if (strpos($classFilePath, $path) !== 0)
+					if (strpos($classFilePath, realpath($path)) !== 0)
 					{
 						continue;
 					}
@@ -733,7 +733,7 @@ abstract class JLoader
 			$path = realpath($base . '/' . implode('/', array_map('strtolower', $parts)) . '.php');
 
 			// Load the file if it exists and is in the lookup path.
-			if (strpos($path, $base) === 0 && file_exists($path))
+			if (strpos($path, realpath($base)) === 0 && file_exists($path))
 			{
 				$found = (bool) include_once $path;
 
@@ -754,7 +754,7 @@ abstract class JLoader
 				$path = realpath($base . '/' . implode('/', array_map('strtolower', array($parts[0], $parts[0]))) . '.php');
 
 				// Load the file if it exists and is in the lookup path.
-				if (strpos($path, $base) === 0 && file_exists($path))
+				if (strpos($path, realpath($base)) === 0 && file_exists($path))
 				{
 					$found = (bool) include_once $path;
 


### PR DESCRIPTION
Pull Request for Issue #20875

### Summary of Changes

As part of the security fixes in 3.8.9, the autoloader no longer allows inclusion of files outside of a namespace or prefix path.  This is in part enforced by a string comparison of the resolved file path and the base path, however as this is a string comparison it needs to take into consideration the operation system directory separator and that was not happening.  In effect, it was comparing `C:\xampp\htdocs\j389\libraries\cms\class\loader.php` against `C:\xampp\htdocs\j389/libraries/cms/class/loader.php`.

### Testing Instructions

Apply patch.  Autoload files.  Rejoice while I go through the pain of building a new release.