### PR TITLE
[4.0] [UX] Sample Data success message

### DIFF
--- a/administrator/language/en-GB/en-GB.plg_sampledata_blog.ini
+++ b/administrator/language/en-GB/en-GB.plg_sampledata_blog.ini
@@ -61,4 +61,5 @@ PLG_SAMPLEDATA_BLOG_STEP_SKIPPED="Step %1$u Skipped: '%2$s' is either not instal
 PLG_SAMPLEDATA_BLOG_STEP1_SUCCESS="Step 1: Articles done!"
 PLG_SAMPLEDATA_BLOG_STEP2_SUCCESS="Step 2: Menus done!"
 PLG_SAMPLEDATA_BLOG_STEP3_SUCCESS="Step 3: Modules done!"
+PLG_SAMPLEDATA_BLOG_STEP4_SUCCESS="Blog Sample Data has been successfully installed!"
 PLG_SAMPLEDATA_BLOG_XML_DESCRIPTION="Provides the blog sample data. Can be installed using the sample data module."

--- a/administrator/language/en-GB/en-GB.plg_sampledata_blog.ini
+++ b/administrator/language/en-GB/en-GB.plg_sampledata_blog.ini
@@ -61,5 +61,5 @@ PLG_SAMPLEDATA_BLOG_STEP_SKIPPED="Step %1$u Skipped: '%2$s' is either not instal
 PLG_SAMPLEDATA_BLOG_STEP1_SUCCESS="Step 1: Articles done!"
 PLG_SAMPLEDATA_BLOG_STEP2_SUCCESS="Step 2: Menus done!"
 PLG_SAMPLEDATA_BLOG_STEP3_SUCCESS="Step 3: Modules done!"
-PLG_SAMPLEDATA_BLOG_STEP4_SUCCESS="Blog Sample Data has been successfully installed!"
+PLG_SAMPLEDATA_BLOG_STEP4_SUCCESS="Blog Sample Data has been installed!"
 PLG_SAMPLEDATA_BLOG_XML_DESCRIPTION="Provides the blog sample data. Can be installed using the sample data module."

--- a/plugins/sampledata/blog/blog.php
+++ b/plugins/sampledata/blog/blog.php
@@ -953,11 +953,11 @@ class PlgSampledataBlog extends CMSPlugin
 	}
 
 	/**
-	 * Final step to show completion of  sampledata.
+	 * Final step to show completion of sampledata.
 	 *
 	 * @return  array or void  Will be converted into the JSON response to the module.
 	 *
-	 * @since __DEPLOY_VERSION__
+	 * @since  __DEPLOY_VERSION__
 	 */
 
 	public function onAjaxSampledataApplyStep4()

--- a/plugins/sampledata/blog/blog.php
+++ b/plugins/sampledata/blog/blog.php
@@ -74,7 +74,7 @@ class PlgSampledataBlog extends CMSPlugin
 		$data->title       = Text::_('PLG_SAMPLEDATA_BLOG_OVERVIEW_TITLE');
 		$data->description = Text::_('PLG_SAMPLEDATA_BLOG_OVERVIEW_DESC');
 		$data->icon        = 'broadcast';
-		$data->steps       = 3;
+		$data->steps       = 4;
 
 		return $data;
 	}
@@ -948,6 +948,22 @@ class PlgSampledataBlog extends CMSPlugin
 		$response            = array();
 		$response['success'] = true;
 		$response['message'] = Text::_('PLG_SAMPLEDATA_BLOG_STEP3_SUCCESS');
+
+		return $response;
+	}
+
+	/**
+	 * Final step to show completion of  sampledata.
+	 *
+	 * @return  array or void  Will be converted into the JSON response to the module.
+	 *
+	 * @since __DEPLOY_VERSION__
+	 */
+
+	public function onAjaxSampledataApplyStep4()
+	{
+		$response['success'] = true;
+		$response['message'] = Text::_('PLG_SAMPLEDATA_BLOG_STEP4_SUCCESS');
 
 		return $response;
 	}

--- a/plugins/sampledata/blog/blog.php
+++ b/plugins/sampledata/blog/blog.php
@@ -959,7 +959,6 @@ class PlgSampledataBlog extends CMSPlugin
 	 *
 	 * @since  __DEPLOY_VERSION__
 	 */
-
 	public function onAjaxSampledataApplyStep4()
 	{
 		$response['success'] = true;


### PR DESCRIPTION
Add an extra stage to the sampledata plugin just so that we display a message so the user knows the install of the sample data has finished

### Test instructions
Before this PR you get 3 success messages, 

After this PR you get a final success message as below

<img width="580" alt="chrome_2018-06-27_18-51-58" src="https://user-images.githubusercontent.com/1296369/41991717-62080318-7a3e-11e8-9332-a8d7be2280c4.png">
