### PR TITLE
FIX: Install Languages Manager language badges wrongly set to not match since upgrade to 3.8.10

### DIFF
--- a/administrator/components/com_installer/views/languages/tmpl/default.php
+++ b/administrator/components/com_installer/views/languages/tmpl/default.php
@@ -82,7 +82,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 						<td class="center">
 								<?php $minorVersion = $version::MAJOR_VERSION . '.' . $version::MINOR_VERSION; ?>
 								<?php // Display a Note if language pack version is not equal to Joomla version ?>
-								<?php if (substr($language->version, 0, 3) != $minorVersion || substr($language->version, 0, 5) != $currentShortVersion) : ?>
+								<?php if (strpos($language->version, $minorVersion) !== 0 || strpos($language->version, $currentShortVersion) !== 0) : ?>
 									<span class="label label-warning hasTooltip" title="<?php echo JText::_('JGLOBAL_LANGUAGE_VERSION_NOT_PLATFORM'); ?>"><?php echo $language->version; ?></span>
 								<?php else : ?>
 									<span class="label label-success"><?php echo $language->version; ?></span>

--- a/administrator/components/com_languages/views/installed/tmpl/default.php
+++ b/administrator/components/com_languages/views/installed/tmpl/default.php
@@ -102,7 +102,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 					<td class="center small">
 					<?php $minorVersion = $version::MAJOR_VERSION . '.' . $version::MINOR_VERSION; ?>
 					<?php // Display a Note if language pack version is not equal to Joomla version ?>
-					<?php if (substr($row->version, 0, 3) != $minorVersion || substr($row->version, 0, 5) != $currentShortVersion) : ?>
+					<?php if (strpos($row->version, $minorVersion) !== 0 || strpos($row->version, $currentShortVersion) !== 0) : ?>
 						<span class="label label-warning hasTooltip" title="<?php echo JText::_('JGLOBAL_LANGUAGE_VERSION_NOT_PLATFORM'); ?>"><?php echo $row->version; ?></span>
 					<?php else : ?>
 						<span class="label label-success"><?php echo $row->version; ?></span>


### PR DESCRIPTION
As title says.

### Summary of Changes
the code in the Install Languages template was counting substrings. Switching to a count of 6 created the bug.
Replacing the entire line by the same code we use when installing languages at Joomla install time solves the issue.


### Testing Instructions
Load `administrator/index.php?option=com_installer&view=languages`


### Before patch

<img width="1266" alt="screen shot 2018-06-28 at 09 37 31" src="https://user-images.githubusercontent.com/869724/42020177-63354dd0-7ab7-11e8-912c-0532334fa9b3.png">

### After patch

<img width="1346" alt="screen shot 2018-06-28 at 09 36 56" src="https://user-images.githubusercontent.com/869724/42020182-68e77dfc-7ab7-11e8-86e0-9d3bbb31346d.png">


### Documentation Changes Required

None