### PR TITLE
[4.0] Onclick and Onchange in joomla-field-switcher

### DIFF
--- a/build/webcomponents/js/field-switcher/field-switcher.js
+++ b/build/webcomponents/js/field-switcher/field-switcher.js
@@ -97,14 +97,6 @@
 				// Remove the tab focus from the inputs
 				input.setAttribute('tabindex', '-1');
 
-				if (this.hasAttribute('onclick')) {
-					input.setAttribute('onclick', this.getAttribute('onclick'));
-				}
-
-				if (this.hasAttribute('onchange')) {
-					input.setAttribute('onchange', this.getAttribute('onchange'));
-				}
-
 				if (input.checked) {
 					spanFirst.setAttribute('aria-checked', true);
 				}

--- a/build/webcomponents/js/field-switcher/field-switcher.js
+++ b/build/webcomponents/js/field-switcher/field-switcher.js
@@ -97,6 +97,14 @@
 				// Remove the tab focus from the inputs
 				input.setAttribute('tabindex', '-1');
 
+				if (this.hasAttribute('onclick')) {
+					input.setAttribute('onclick', this.getAttribute('onclick'));
+				}
+
+				if (this.hasAttribute('onchange')) {
+					input.setAttribute('onchange', this.getAttribute('onchange'));
+				}
+
 				if (input.checked) {
 					spanFirst.setAttribute('aria-checked', true);
 				}

--- a/layouts/joomla/form/field/radio/switcher.php
+++ b/layouts/joomla/form/field/radio/switcher.php
@@ -84,6 +84,16 @@ if (!empty($disabled))
 	$attribs[] = 'disabled';
 }
 
+if (!empty($onclick))
+{
+	$attribs[] = 'onclick="' . $onclick . '()"';
+}
+
+if (!empty($onchange))
+{
+	$attribs[] = 'onchange="' . $onchange . '()"';
+}
+
 ?>
 <joomla-field-switcher <?php echo implode(' ', $attribs); ?>>
 	<?php foreach ($options as $i => $option) : ?>
@@ -93,11 +103,9 @@ if (!empty($disabled))
 		$active  = ((string) $option->value == $value) ? 'class="active"' : '';
 
 		// Initialize some JavaScript option attributes.
-		$onclick    = !empty($option->onclick) ? 'onclick="' . $option->onclick . '"' : '';
-		$onchange   = !empty($option->onchange) ? 'onchange="' . $option->onchange . '"' : '';
 		$oid        = $id . $i;
 		$ovalue     = htmlspecialchars($option->value, ENT_COMPAT, 'UTF-8');
-		$attributes = array_filter(array($checked, $active, null, $onchange, $onclick));
+		$attributes = array_filter(array($checked, $active, null));
 		?>
 		<?php echo sprintf($format, $oid, $name, $ovalue, implode(' ', $attributes)); ?>
 	<?php endforeach; ?>


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/20853 .

### Summary of Changes
Make it possible to use `onclick` and `onchange` event in `joomla-field-switcher`


### Testing Instructions

Open global configuration and see outer html of the field "Search Engine Friendly URLs"
```

<joomla-field-switcher id="jform_sef" off-text="No" on-text="Yes" type="success">
<span class="switcher active has-success" tabindex="0" aria-checked="true" role="switch" aria-label="Yes"><input id="jform_sef0" name="jform[sef]" value="0" tabindex="-1" class="valid form-control-success" aria-invalid="false" type="radio"><input id="jform_sef1" name="jform[sef]" value="1" class="valid active form-control-success" tabindex="-1" checked="" aria-invalid="false" type="radio"><span class="switch"></span></span><span class="switcher-labels"><span class="switcher-label-0">No</span><span class="switcher-label-1 active">Yes</span></span></joomla-field-switcher>
```

Open `/administrator/components/com_config/forms/application.xml`

and change the field (insert onclick and onchange`)

```
		<field
			name="sef"
			type="radio"
			label="COM_CONFIG_FIELD_SEF_URL_LABEL"
			class="switcher"
			default="1"
			filter="boolean"
			>
			<option value="0">JNO</option>
			<option value="1">JYES</option>
		</field>

```
to 

```
		<field
			name="sef"
			type="radio"
			label="COM_CONFIG_FIELD_SEF_URL_LABEL"
			class="switcher"
			default="1"
			filter="boolean"
			onclick="MyOnclickEvent"
			onchange="MyOnchangeEvent"
			>
			<option value="0">JNO</option>
			<option value="1">JYES</option>
		</field>
```

Add the function for triggering the events. For example: Open the file /administrator/templates/atum/index.php and change the text

```
<head>
	<jdoc:include type="metas" />
	<jdoc:include type="styles" />
	<jdoc:include type="scripts" />
</head>
```

to 
```

<head>
	<jdoc:include type="metas" />
	<jdoc:include type="styles" />
	<jdoc:include type="scripts" />
	<script>
		function MyOnclickEvent(){
			alert('click');
		};
		function MyOnchangeEvent(){
			alert('change');
		};
	</script>
</head>
```



Open again global configuration and see outer html of the field "Search Engine Friendly URLs". No the attributes are added. If you click on the field "Search Engine Friendly URLs" the events  `onclick` and `onchange` are triggert. You see the alerts.



### Expected result
Onclick event and Onchange event are added to the field "Search Engine Friendly URLs". The Event you inserted in autom template is triggert.


### Actual result
Nothing changed. No attribut is added to the joomla-field-switcher. No event is triggert. You see the alert.





### Documentation Changes Required

