### PR TITLE
Deprecate FinderIndexerHelper::getContentPath()

### DIFF
--- a/administrator/components/com_finder/helpers/indexer/helper.php
+++ b/administrator/components/com_finder/helpers/indexer/helper.php
@@ -416,7 +416,8 @@ class FinderIndexerHelper
 	 *
 	 * @return  string  The path for the content item.
 	 *
-	 * @since   2.5
+	 * @since       2.5
+	 * @deprecated  4.0
 	 */
 	public static function getContentPath($url)
 	{


### PR DESCRIPTION
This is a PR to enable #20571.

FinderIndexerHelper::getContentPath() is supposed to create the SEFed URL of the content item while indexing the content item. However, that doesn't really work for several reasons. First of all, there are component routers out there, that fail in the wrong circumstances, like being run in the backend. Then there are the issues of permissions. The user running the indexer (either by batch indexing in the backend or by saving a content item) in general has other permissions than a guest user and thus might see menu items that the guest user does not see. Last but not least, Smart Search does not really know anything about the routing system and thus also does not know when to update that data, thus we already have the wrong data in the DB when a user creates an article and then links it via a menu item.

Long story short: We have to create the right route on runtime and thus can't pre-compute this. That is why we haven't used the data from that in com_finder ever. Which is why this method is being deprecated here.