### PR TITLE
Fix OpenSearch implementation

### DIFF
--- a/libraries/src/Document/OpensearchDocument.php
+++ b/libraries/src/Document/OpensearchDocument.php
@@ -135,7 +135,7 @@ class OpensearchDocument extends Document
 		$osns = 'http://a9.com/-/spec/opensearch/1.1/';
 
 		// Create the root element
-		$elOs = $xml->createElementNs($osns, 'OpensearchDescription');
+		$elOs = $xml->createElementNs($osns, 'OpenSearchDescription');
 
 		$elShortName = $xml->createElementNs($osns, 'ShortName');
 		$elShortName->appendChild($xml->createTextNode(htmlspecialchars($this->_shortName)));


### PR DESCRIPTION
OpenSearch allows you to (for example) add your site search to the search engines of your browser. Right now, this does not work and has been broken for about a year (See https://github.com/joomla/joomla-cms/commit/00d8bacf260741cef8ea8bf052f2e6347da04a90)

This PR fixes the OpenSearchDescription.

### How to test
* Open your site in Firefox and go to a page with mod_search displayed.
* In the address bar, there is a menu (the three horizontal dots). In that menu, you have an entry "Add searchengine" (The last menuitem) Click that and see that it throws an error message shortly after that it couldn't install the search engine.
* Apply patch and click the link again and see, that it works now.

I discovered this issue while working on com_finder for 4.0 and I also fixed the issue there, too. So while you are at it, it would be really nice if you could test #20936 also. :smile: 