### PR TITLE
[4.0] com_finder: Properly truncate the taxonomy table

### DIFF
--- a/administrator/components/com_finder/Model/IndexModel.php
+++ b/administrator/components/com_finder/Model/IndexModel.php
@@ -350,12 +350,10 @@ class IndexModel extends ListModel
 		// Truncate the taxonomy map table.
 		$db->truncateTable('#__finder_taxonomy_map');
 
-		// Delete all the taxonomy nodes except the root.
-		$query = $db->getQuery(true)
-			->delete($db->quoteName('#__finder_taxonomy'))
-			->where($db->quoteName('id') . ' > 1');
-		$db->setQuery($query);
-		$db->execute();
+		// Truncate the taxonomy table and insert the root node.
+		$db->truncateTable('#__finder_taxonomy');
+		$root = (object) array('id' => 1, 'parent_id' => 0, 'title' => 'ROOT', 'state' => 0, 'access' => 0, 'ordering' => 0);
+		$db->insertObject('#__finder_taxonomy', $root);
 
 		// Truncate the tokens tables.
 		$db->truncateTable('#__finder_tokens');


### PR DESCRIPTION
All tables of com_finder are properly truncated when purging the index, except for the taxonomy table. In that table everything is deleted, except for the root node. That means that deleting this data takes basically the longest, but most importantly the autoincrement value is not reset. There isn't really a reason for this, so I'm changing this to actually truncate the table and re-insert the root node each time instead. 

There isn't really a way to test this, other than to see that the purge feature still works the way it did before. It rather requires a codereview.