### PR TITLE
Adds missing language files to the namespace mapper plugin

### DIFF
--- a/administrator/language/en-GB/en-GB.plg_extension_namespacemap.ini
+++ b/administrator/language/en-GB/en-GB.plg_extension_namespacemap.ini
@@ -1,0 +1,7 @@
+; Joomla! Project
+; Copyright (C) 2005 - 2018 Open Source Matters. All rights reserved.
+; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
+; Note : All ini files need to be saved as UTF-8
+
+PLG_EXTENSION_NAMESPACEMAP="Extension - Namespace Updater"
+PLG_EXTENSION_NAMESPACEMAP_XML_DESCRIPTION="Namespace updater regenerates the file that autoloads extensions when they are installed, updated or deleted."

--- a/administrator/language/en-GB/en-GB.plg_extension_namespacemap.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_extension_namespacemap.sys.ini
@@ -1,0 +1,7 @@
+; Joomla! Project
+; Copyright (C) 2005 - 2018 Open Source Matters. All rights reserved.
+; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
+; Note : All ini files need to be saved as UTF-8
+
+PLG_EXTENSION_NAMESPACEMAP="Extension - Namespace Updater"
+PLG_EXTENSION_NAMESPACEMAP_XML_DESCRIPTION="Namespace updater regenerates the file that autoloads extensions when they are installed, updated or deleted."


### PR DESCRIPTION
I managed to miss out the language files to the namespace map plugin. Brian I'm sure this is almost impossible to explain to a regular user. But I tried. Any ideas welcome