### PR TITLE
[4.0] Namespacemap Updater plugin

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/4.0.0-2018-07-02.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.0.0-2018-07-02.sql
@@ -1,0 +1,1 @@
+UPDATE `#__extensions` SET `protected` = 1 WHERE `name` = 'plg_extension_namespacemap';

--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2018-07-02.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2018-07-02.sql
@@ -1,0 +1,1 @@
+UPDATE "#__extensions" SET "protected" = 1 WHERE "name" = 'plg_extension_namespacemap';

--- a/administrator/language/en-GB/en-GB.plg_extension_namespacemap.ini
+++ b/administrator/language/en-GB/en-GB.plg_extension_namespacemap.ini
@@ -1,0 +1,7 @@
+; Joomla! Project
+; Copyright (C) 2005 - 2018 Open Source Matters. All rights reserved.
+; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
+; Note : All ini files need to be saved as UTF-8
+
+PLG_EXTENSION_NAMESPACEMAP="Extension - Namespace Updater"
+PLG_EXTENSION_NAMESPACEMAP_XML_DESCRIPTION="Automatically builds and updates the <strong>libraries\autoload_psr4.php</strong> file that is used to autoload extensions.<br><strong>Warning! This plugin must be enabled</strong> it runs on extension install, update and deletion."

--- a/administrator/language/en-GB/en-GB.plg_extension_namespacemap.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_extension_namespacemap.sys.ini
@@ -1,0 +1,7 @@
+; Joomla! Project
+; Copyright (C) 2005 - 2018 Open Source Matters. All rights reserved.
+; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
+; Note : All ini files need to be saved as UTF-8
+
+PLG_EXTENSION_NAMESPACEMAP="Extension - Namespace Updater"
+PLG_EXTENSION_NAMESPACEMAP_XML_DESCRIPTION="Automatically builds and updates the <strong>libraries\autoload_psr4.php</strong> file that is used to autoload extensions.<br><strong>Warning! This plugin must be enabled</strong> it runs on extension install, update and deletion."

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -661,7 +661,7 @@ INSERT INTO `#__extensions` (`extension_id`, `package_id`, `name`, `type`, `elem
 (486, 0, 'plg_installer_webinstaller', 'plugin', 'webinstaller', 'installer', 0, 1, 1, 0, '', '{"tab_position":"1"}', 0, '0000-00-00 00:00:00', 0, 0, ''),
 (487, 0, 'plg_system_httpheaders', 'plugin', 'httpheaders', 'system', 0, 1, 1, 0, '', '{}', 0, '0000-00-00 00:00:00', 0, 0, ''),
 (488, 0, 'plg_sampledata_multilang', 'plugin', 'multilang', 'sampledata', 0, 1, 1, 0, '', '', 0, '0000-00-00 00:00:00', 0, 0, ''),
-(489, 0, 'plg_extension_namespacemap', 'plugin', 'namespacemap', 'extension', 0, 1, 1, 0, '', '{}', 0, '0000-00-00 00:00:00', 0, 0, ''),
+(489, 0, 'plg_extension_namespacemap', 'plugin', 'namespacemap', 'extension', 0, 1, 1, 1, '', '{}', 0, '0000-00-00 00:00:00', 0, 0, ''),
 (509, 0, 'atum', 'template', 'atum', '', 1, 1, 1, 0, '', '', 0, '0000-00-00 00:00:00', 0, 0, ''),
 (510, 0, 'cassiopeia', 'template', 'cassiopeia', '', 0, 1, 1, 0, '', '{"logoFile":"","fluidContainer":"0","sidebarLeftWidth":"3","sidebarRightWidth":"3"}', 0, '0000-00-00 00:00:00', 0, 0, ''),
 (600, 802, 'English (en-GB)', 'language', 'en-GB', '', 0, 1, 1, 1, '', '', 0, '0000-00-00 00:00:00', 0, 0, ''),

--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -674,7 +674,7 @@ INSERT INTO "#__extensions" ("extension_id", "package_id", "name", "type", "elem
 (486, 0, 'plg_installer_webinstaller', 'plugin', 'webinstaller', 'installer', 0, 1, 1, 0, '', '{"tab_position":"1"}', 0, '1970-01-01 00:00:00', 0, 0, ''),
 (487, 0, 'plg_system_httpheaders', 'plugin', 'httpheaders', 'system', 0, 1, 1, 0, '', '{}', 0, '1970-01-01 00:00:00', 0, 0, ''),
 (488, 0, 'plg_sampledata_multilang', 'plugin', 'multilang', 'sampledata', 0, 1, 1, 0, '', '', 0, '0000-00-00 00:00:00', 0, 0, ''),
-(489, 0, 'plg_extension_namespacemap', 'plugin', 'namespacemap', 'extension', 0, 1, 1, 0, '', '{}', 0, '1970-01-01 00:00:00', 0, 0, ''),
+(489, 0, 'plg_extension_namespacemap', 'plugin', 'namespacemap', 'extension', 0, 1, 1, 1, '', '{}', 0, '1970-01-01 00:00:00', 0, 0, ''),
 (600, 802, 'English (en-GB)', 'language', 'en-GB', '', 0, 1, 1, 1, '', '', 0, '1970-01-01 00:00:00', 0, 0, ''),
 (601, 802, 'English (en-GB)', 'language', 'en-GB', '', 1, 1, 1, 1, '', '', 0, '1970-01-01 00:00:00', 0, 0, ''),
 (700, 0, 'files_joomla', 'file', 'joomla', '', 0, 1, 1, 1, '', '', 0, '1970-01-01 00:00:00', 0, 0, ''),

--- a/plugins/extension/namespacemap/namespacemap.php
+++ b/plugins/extension/namespacemap/namespacemap.php
@@ -14,7 +14,7 @@ use Joomla\Event\DispatcherInterface;
 use Joomla\CMS\Installer\Installer as JInstaller;
 
 /**
- * Joomla! namespace map updater.
+ * Joomla! namespace map creator / updater.
  *
  * @since  4.0.0
  */
@@ -33,9 +33,9 @@ class PlgExtensionNamespacemap extends CMSPlugin
 	 * @param   DispatcherInterface  &$subject  The object to observe
 	 * @param   array                $config    An optional associative array of configuration settings.
 	 *                                          Recognized key values include 'name', 'group', 'params', 'language'
-	 *                                         (this list is not meant to be comprehensive).
+	 *                                          (this list is not meant to be comprehensive).
 	 *
-	 * @since   1.5
+	 * @since   4.0
 	 */
 	public function __construct(&$subject, $config = array())
 	{
@@ -45,10 +45,10 @@ class PlgExtensionNamespacemap extends CMSPlugin
 	}
 
 	/**
-	 * Handle post extension install update sites
+	 * Update / Create map on extension install
 	 *
-	 * @param   JInstaller  $installer  Installer object
-	 * @param   integer     $eid        Extension Identifier
+	 * @param   JInstaller  $installer  Installer instance
+	 * @param   integer     $eid        Extension id
 	 *
 	 * @return  void
 	 *
@@ -56,15 +56,16 @@ class PlgExtensionNamespacemap extends CMSPlugin
 	 */
 	public function onExtensionAfterInstall($installer, $eid)
 	{
-		// Update / Create new map
+		// Check that we have a valid extension
 		if ($eid)
 		{
+			// Update / Create new map
 			$this->fileCreator->create();
 		}
 	}
 
 	/**
-	 * Handle extension uninstall
+	 * Update / Create map on extension uninstall
 	 *
 	 * @param   JInstaller  $installer  Installer instance
 	 * @param   integer     $eid        Extension id
@@ -76,8 +77,7 @@ class PlgExtensionNamespacemap extends CMSPlugin
 	 */
 	public function onExtensionAfterUninstall($installer, $eid, $removed)
 	{
-		// If we have a valid extension ID and the extension was successfully uninstalled wipe out any
-		// update sites for it
+		// Check that we have a valid extension and that it has been removed
 		if ($eid && $removed)
 		{
 			// Update / Create new map
@@ -86,10 +86,10 @@ class PlgExtensionNamespacemap extends CMSPlugin
 	}
 
 	/**
-	 * After update of an extension
+	 * Update map on extension update
 	 *
-	 * @param   JInstaller  $installer  Installer object
-	 * @param   integer     $eid        Extension identifier
+	 * @param   JInstaller  $installer  Installer instance
+	 * @param   integer     $eid        Extension id
 	 *
 	 * @return  void
 	 *
@@ -97,25 +97,7 @@ class PlgExtensionNamespacemap extends CMSPlugin
 	 */
 	public function onExtensionAfterUpdate($installer, $eid)
 	{
-		if ($eid)
-		{
-			// Update / Create new map
-			$this->fileCreator->create();
-		}
-	}
-
-	/**
-	 * After update of an extension
-	 *
-	 * @param   JInstaller  $installer  Installer object
-	 * @param   integer     $eid        Extension identifier
-	 *
-	 * @return  void
-	 *
-	 * @since   4.0.0
-	 */
-	public function onExtensionAfterSave($installer, $eid)
-	{
+		// Check that we have a valid extension
 		if ($eid)
 		{
 			// Update / Create new map


### PR DESCRIPTION
### Changes
- Added language file
- Changed to a protected extension
- Updated code comments
- Removed onExtensionAfterSave (I dont think that ever happens?)

### Possible improvements and Issues to solve
- add a button to manually regenerate the file

- we are writing to a folder /libaries that we haven't written to in the past and so might not be writable. To test I made the libraries folder readonly and I didnt get any error message about not being able to build the map when i installed or deleted an extension

@wilsonge here you are
