### PR TITLE
Speed up regex in emailcloak plugin

### DIFF
--- a/plugins/content/emailcloak/emailcloak.php
+++ b/plugins/content/emailcloak/emailcloak.php
@@ -486,7 +486,7 @@ class PlgContentEmailcloak extends JPlugin
 		 * <img src="..." title="email@example.org"> or <input type="text" placeholder="email@example.org">
 		 * The negative lookahead '(?![^<]*>)' is used to exclude this kind of occurrences
 		 */
-		$pattern = '~(?![^<>]*>)' . $searchEmail . '~i';
+		$pattern = '~<[^<]*>(*SKIP)(*F)|' . $searchEmail . '~i';
 
 		while (preg_match($pattern, $text, $regs, PREG_OFFSET_CAPTURE))
 		{

--- a/plugins/content/emailcloak/emailcloak.php
+++ b/plugins/content/emailcloak/emailcloak.php
@@ -484,7 +484,7 @@ class PlgContentEmailcloak extends JPlugin
 		/*
 		 * Search for plain text email addresses, such as email@example.org but not within HTML tags:
 		 * <img src="..." title="email@example.org"> or <input type="text" placeholder="email@example.org">
-		 * The negative lookahead '(?![^<]*>)' is used to exclude this kind of occurrences
+		 * The '<[^<]*>(*SKIP)(*F)|' trick is used to exclude this kind of occurrences
 		 */
 		$pattern = '~<[^<]*>(*SKIP)(*F)|' . $searchEmail . '~i';
 


### PR DESCRIPTION
### Summary of Changes
Better/faster regular expression for plugin "Content - Email Cloaking". No other changes.

Take a look at https://github.com/joomla/joomla-cms/pull/11353 for more information.

### Testing Instructions
Check if the email address between the tags is properly masked/cloaked.

E.g. `<span title="xxx@example.com"><strong>xxx@example.com</strong></span>`

Only email between tags should be masked as before PR.

### Test time improvement

Execute a few php commands:
```php
$a = array('<p><img src="data:image/png;base64,', '" alt="image" /></p>');
$b = implode(bin2hex(openssl_random_pseudo_bytes(50000)), $a);
$searchEmail = '([\w\.\'\-\+]+\@(?:[a-z0-9\.\-]+\.)+(?:[a-zA-Z0-9\-]{2,10}))';

$pattern_old = '~(?![^<>]*>)' . $searchEmail . '~i';
$pattern_new = '~<[^<]*>(*SKIP)(*F)|' . $searchEmail . '~i';

$t=microtime(1);preg_match($pattern_old, $b, $regs, PREG_OFFSET_CAPTURE);printf("%.5F", microtime(1)-$t);

$t=microtime(1);preg_match($pattern_new, $b, $regs, PREG_OFFSET_CAPTURE);printf("%.5F", microtime(1)-$t);
```

### Expected result
No changes, only time improvement.


### Actual result
`preg_match` on line 491 runs slowly.
https://github.com/joomla/joomla-cms/blob/899e7c93ba4c56558ab0a58a69281260b8b4af06/plugins/content/emailcloak/emailcloak.php#L484-L491


### Documentation Changes Required
No
