### PR TITLE
Allow form submission if Google Captcha v1 is enabled

### DIFF
--- a/plugins/captcha/recaptcha/recaptcha.php
+++ b/plugins/captcha/recaptcha/recaptcha.php
@@ -47,14 +47,8 @@ class PlgCaptchaRecaptcha extends JPlugin
 
 		if ($this->params->get('version', '1.0') === '1.0')
 		{
-			JHtml::_('jquery.framework');
-
-			$theme	= $this->params->get('theme', 'clean');
-			$file	= 'https://www.google.com/recaptcha/api/js/recaptcha_ajax.js';
-
-			JHtml::_('script', $file);
-			JFactory::getDocument()->addScriptDeclaration('jQuery( document ).ready(function()
-				{Recaptcha.create("' . $pubkey . '", "' . $id . '", {theme: "' . $theme . '",' . $this->_getLanguage() . 'tabindex: 0});});');
+            // Deprecated - @see https://developers.google.com/recaptcha/docs/faq#what-happens-to-recaptcha-v1
+			return true;
 		}
 		else
 		{
@@ -84,7 +78,8 @@ class PlgCaptchaRecaptcha extends JPlugin
 	{
 		if ($this->params->get('version', '1.0') === '1.0')
 		{
-			return '<div id="' . $id . '" ' . $class . '></div>';
+            // Deprecated - @see https://developers.google.com/recaptcha/docs/faq#what-happens-to-recaptcha-v1
+			return '';
 		}
 		else
 		{
@@ -115,9 +110,8 @@ class PlgCaptchaRecaptcha extends JPlugin
 		switch ($version)
 		{
 			case '1.0':
-				$challenge = $input->get('recaptcha_challenge_field', '', 'string');
-				$response  = $input->get('recaptcha_response_field', '', 'string');
-				$spam      = ($challenge === '' || $response === '');
+                // Deprecated - @see https://developers.google.com/recaptcha/docs/faq#what-happens-to-recaptcha-v1
+				return true;
 				break;
 			case '2.0':
 				// Challenge Not needed in 2.0 but needed for getResponse call
@@ -172,26 +166,9 @@ class PlgCaptchaRecaptcha extends JPlugin
 
 		switch ($version)
 		{
-			case '1.0':
-				$response = $this->_recaptcha_http_post(
-					'www.google.com', '/recaptcha/api/verify',
-					array(
-						'privatekey' => $privatekey,
-						'remoteip'   => $remoteip,
-						'challenge'  => $challenge,
-						'response'   => $response
-					)
-				);
-
-				$answers = explode("\n", $response[1]);
-
-				if (trim($answers[0]) !== 'true')
-				{
-					// @todo use exceptions here
-					$this->_subject->setError(JText::_('PLG_RECAPTCHA_ERROR_' . strtoupper(str_replace('-', '_', $answers[1]))));
-
-					return false;
-				}
+            case '1.0':
+			    // Deprecated - @see https://developers.google.com/recaptcha/docs/faq#what-happens-to-recaptcha-v1
+				return true;
 				break;
 			case '2.0':
 				require_once 'recaptchalib.php';

--- a/plugins/captcha/recaptcha/recaptcha.php
+++ b/plugins/captcha/recaptcha/recaptcha.php
@@ -47,7 +47,7 @@ class PlgCaptchaRecaptcha extends JPlugin
 
 		if ($this->params->get('version', '1.0') === '1.0')
 		{
-            // Deprecated - @see https://developers.google.com/recaptcha/docs/faq#what-happens-to-recaptcha-v1
+			// Deprecated - @see https://developers.google.com/recaptcha/docs/faq#what-happens-to-recaptcha-v1
 			return true;
 		}
 		else
@@ -78,7 +78,7 @@ class PlgCaptchaRecaptcha extends JPlugin
 	{
 		if ($this->params->get('version', '1.0') === '1.0')
 		{
-            // Deprecated - @see https://developers.google.com/recaptcha/docs/faq#what-happens-to-recaptcha-v1
+			// Deprecated - @see https://developers.google.com/recaptcha/docs/faq#what-happens-to-recaptcha-v1
 			return '';
 		}
 		else
@@ -110,7 +110,7 @@ class PlgCaptchaRecaptcha extends JPlugin
 		switch ($version)
 		{
 			case '1.0':
-                // Deprecated - @see https://developers.google.com/recaptcha/docs/faq#what-happens-to-recaptcha-v1
+				// Deprecated - @see https://developers.google.com/recaptcha/docs/faq#what-happens-to-recaptcha-v1
 				return true;
 				break;
 			case '2.0':
@@ -166,8 +166,8 @@ class PlgCaptchaRecaptcha extends JPlugin
 
 		switch ($version)
 		{
-            case '1.0':
-			    // Deprecated - @see https://developers.google.com/recaptcha/docs/faq#what-happens-to-recaptcha-v1
+			case '1.0':
+				// Deprecated - @see https://developers.google.com/recaptcha/docs/faq#what-happens-to-recaptcha-v1
 				return true;
 				break;
 			case '2.0':


### PR DESCRIPTION
Pull Request for Issue #20960 .

### Summary of Changes

allow form submission if Google Recaptcha v1 enabled 

**Will allow spamming of forms configured with v1 captcha where those forms are relying on the (broken/discontinued) API,** but will now also provide backward compatibility allowing of real users to submit the form.

Will remove the JS warnings in Console.

### Testing Instructions

Configure Google recaptcha v1 with a fake key

### Expected result

You can still submit forms - proving b/c works and the absence of a working google api is not blocking form submissions
