### PR TITLE
A better way to check MIME type of the uploaded file

### DIFF
--- a/libraries/src/Helper/MediaHelper.php
+++ b/libraries/src/Helper/MediaHelper.php
@@ -79,7 +79,7 @@ class MediaHelper
 				// Check if fileinfo database was found
 				if ($finfo)
 				{
-					$mime  = finfo_file($finfo, $file);
+					$mime = finfo_file($finfo, $file);
 					finfo_close($finfo);
 				}
 			}


### PR DESCRIPTION
Pull Request for Issue #16086

### Summary of Changes
A better way to check the MIME file type if the operating system is incorrectly configured.

If you still have a problem and your server is not running on Windows, test the following patch:
```diff
diff --git a/libraries/src/Helper/MediaHelper.php b/libraries/src/Helper/MediaHelper.php
index 60f7fab83d..99cb1d80e1 100644
--- a/libraries/src/Helper/MediaHelper.php
+++ b/libraries/src/Helper/MediaHelper.php
@@ -102,6 +102,12 @@ class MediaHelper
                                        $mime      = isset($imagesize['mime']) ? $imagesize['mime'] : false;
                                }
                        }
+
+                       // Last chance to get to know the type of mime
+                       if (!$mime && IS_UNIX && function_exists('exec') && function_exists('escapeshellarg'))
+                       {
+                               $mime = strtok(exec('file -bi ' . escapeshellarg($file)), ';');
+                       }
                }
                catch (\Exception $e)
                {
```

### Testing Instructions
Try to upload pdf or image file.
Take a look at #16086

Please test if you still interested @goforitweb, @uglyeoin, @edthenet, @OrignlCin


### Expected result
PDF file is recognized.


### Actual result
#16086


### Documentation Changes Required
No
