### PR TITLE
[4.0] Size is not a valid attribute for number

### DIFF
--- a/administrator/components/com_config/forms/application.xml
+++ b/administrator/components/com_config/forms/application.xml
@@ -35,7 +35,7 @@
 			filter="integer"
 			validate="number"
 			showon="caching:1,2"
-			size="6" />
+		 />
 
 		<field
 			name="cache_path"
@@ -92,7 +92,6 @@
 			default="11211"
 			filter="integer"
 			validate="number"
-			size="5"
 		/>
 
 		<field
@@ -128,7 +127,6 @@
 			default="6379"
 			filter="integer"
 			validate="number"
-			size="5"
 		/>
 
 		<field
@@ -159,7 +157,6 @@
 			default="15"
 			filter="integer"
 			validate="number"
-			size="6"
 		/>
 
 		<field
@@ -300,7 +297,6 @@
 			hint="21"
 			validate="number"
 			filter="integer"
-			size="5"
 		/>
 
 		<field
@@ -369,7 +365,6 @@
 			hint="8080"
 			validate="number"
 			filter="integer"
-			size="5"
 		/>
 
 		<field
@@ -520,7 +515,6 @@
 			hint="25"
 			validate="number"
 			filter="integer"
-			size="5"
 		/>
 
 		<field
@@ -803,7 +797,6 @@
 			default="11211"
 			validate="number"
 			filter="integer"
-			size="5"
 		/>
 
 		<field
@@ -842,7 +835,6 @@
 			default="6379"
 			validate="number"
 			filter="integer"
-			size="5"
 		/>
 
 		<field
@@ -864,7 +856,6 @@
 			default="0"
 			filter="integer"
 			showon="session_handler:redis"
-			size="4"
 		/>
 		<field
 			name="lifetime"
@@ -875,7 +866,6 @@
 			default="15"
 			filter="integer"
 			validate="number"
-			size="6"
 		/>
 
 		<field

--- a/administrator/components/com_config/forms/application.xml
+++ b/administrator/components/com_config/forms/application.xml
@@ -146,7 +146,6 @@
 			default="0"
 			filter="integer"
 			showon="cache_handler:redis"
-			size="4"
 		/>
 
 		<field

--- a/administrator/components/com_finder/config.xml
+++ b/administrator/components/com_finder/config.xml
@@ -32,7 +32,6 @@
 			name="description_length"
 			type="number"
 			label="COM_FINDER_CONFIG_DESCRIPTION_LENGTH_LABEL"
-			size="5"
 			default="255"
 			filter="integer"
 			showon="show_description:1"
@@ -224,7 +223,6 @@
 			name="memory_table_limit"
 			type="number"
 			label="COM_FINDER_CONFIG_MEMORY_TABLE_LIMIT_LABEL"
-			size="10"
 			default="30000"
 			filter="integer"
 		/>
@@ -233,7 +231,6 @@
 			name="title_multiplier"
 			type="number"
 			label="COM_FINDER_CONFIG_TITLE_MULTIPLIER_LABEL"
-			size="5"
 			default="1.7"
 		/>
 
@@ -241,7 +238,6 @@
 			name="text_multiplier"
 			type="number"
 			label="COM_FINDER_CONFIG_TEXT_MULTIPLIER_LABEL"
-			size="5"
 			default="0.7"
 		/>
 
@@ -249,7 +245,6 @@
 			name="meta_multiplier"
 			type="number"
 			label="COM_FINDER_CONFIG_META_MULTIPLIER_LABEL"
-			size="5"
 			default="1.2"
 		/>
 
@@ -257,7 +252,6 @@
 			name="path_multiplier"
 			type="number"
 			label="COM_FINDER_CONFIG_PATH_MULTIPLIER_LABEL"
-			size="5"
 			default="2.0"
 		/>
 
@@ -265,7 +259,6 @@
 			name="misc_multiplier"
 			type="number"
 			label="COM_FINDER_CONFIG_MISC_MULTIPLIER_LABEL"
-			size="5"
 			default="0.3"
 		/>
 

--- a/administrator/components/com_media/config.xml
+++ b/administrator/components/com_media/config.xml
@@ -19,7 +19,6 @@
 			description="COM_MEDIA_FIELD_MAXIMUM_SIZE_DESC" 
 			validate="number"
 			min="0"
-			size="50"
 			default="10"
 		/>
 

--- a/administrator/components/com_messages/forms/config.xml
+++ b/administrator/components/com_messages/forms/config.xml
@@ -27,7 +27,6 @@
 			name="auto_purge"
 			type="number"
 			label="COM_MESSAGES_FIELD_AUTO_PURGE_LABEL"
-			size="6"
 			default="7"
 		/>
 	</fieldset>

--- a/administrator/components/com_newsfeeds/config.xml
+++ b/administrator/components/com_newsfeeds/config.xml
@@ -79,7 +79,6 @@
 			description="COM_NEWSFEEDS_FIELD_CHARACTER_COUNT_DESC"
 			id="feed_character_count"
 			default="0"
-			size="6"
 		/>
 
 		<field 

--- a/administrator/components/com_newsfeeds/forms/newsfeed.xml
+++ b/administrator/components/com_newsfeeds/forms/newsfeed.xml
@@ -100,7 +100,6 @@
 			type="number"
 			label="COM_NEWSFEEDS_FIELD_NUM_ARTICLES_LABEL"
 			default="5"
-			size="2"
 		/>
 
 		<field
@@ -108,7 +107,6 @@
 			type="number"
 			label="COM_NEWSFEEDS_FIELD_CACHETIME_LABEL"
 			default="3600"
-			size="4"
 		/>
 
 		<field
@@ -322,7 +320,6 @@
 			type="number"
 			label="COM_NEWSFEEDS_FIELD_NUM_ARTICLES_LABEL"
 			default="5"
-			size="2"
 		/>
 
 		<field
@@ -330,7 +327,6 @@
 			type="number"
 			label="COM_NEWSFEEDS_FIELD_CACHETIME_LABEL"
 			default="3600"
-			size="4"
 		/>
 
 		<field
@@ -381,7 +377,6 @@
 				type="number"
 				label="COM_NEWSFEEDS_FIELD_CHARACTERS_COUNT_LABEL"
 				description="COM_NEWSFEEDS_FIELD_CHARACTERS_COUNT_DESC"
-				size="6"
 				useglobal="true"
 			/>
 
@@ -436,7 +431,6 @@
 				type="number"
 				label="JGLOBAL_HITS"
 				class="readonly"
-				size="6"
 				readonly="true"
 				filter="unset"
 			/>

--- a/administrator/components/com_redirect/forms/link.xml
+++ b/administrator/components/com_redirect/forms/link.xml
@@ -87,7 +87,6 @@
 			label="JGLOBAL_HITS"
 			id="hits"
 			class="readonly"
-			size="20"
 			readonly="true"
 			filter="unset" 
 		/>

--- a/administrator/components/com_users/forms/user.xml
+++ b/administrator/components/com_users/forms/user.xml
@@ -134,7 +134,7 @@
 			name="id"
 			type="number"
 			label="JGLOBAL_FIELD_ID_LABEL"
-				class="readonly"
+			class="readonly"
 			default="0"
 			readonly="true"
 		/>

--- a/administrator/modules/mod_quickicon/mod_quickicon.xml
+++ b/administrator/modules/mod_quickicon/mod_quickicon.xml
@@ -59,7 +59,6 @@
 					name="cache_time"
 					type="number"
 					label="COM_MODULES_FIELD_CACHE_TIME_LABEL"
-
 					default="900"
 				/>
 			</fieldset>

--- a/components/com_content/tmpl/categories/default.xml
+++ b/components/com_content/tmpl/categories/default.xml
@@ -207,7 +207,6 @@
 				name="num_leading_articles" 
 				type="number"
 				label="JGLOBAL_NUM_LEADING_ARTICLES_LABEL"
-				size="3"
 				useglobal="true"
 			/>
 
@@ -215,7 +214,6 @@
 				name="num_intro_articles" 
 				type="number"
 				label="JGLOBAL_NUM_INTRO_ARTICLES_LABEL"
-				size="3"
 				useglobal="true"
 			/>
 
@@ -223,7 +221,6 @@
 				name="num_columns" 
 				type="number"
 				label="JGLOBAL_NUM_COLUMNS_LABEL"
-				size="3"
 				useglobal="true"
 			/>
 
@@ -231,7 +228,6 @@
 				name="num_links" 
 				type="number"
 				label="JGLOBAL_NUM_LINKS_LABEL"
-				size="3"
 				useglobal="true"
 			/>
 

--- a/components/com_content/tmpl/featured/default.xml
+++ b/components/com_content/tmpl/featured/default.xml
@@ -58,7 +58,6 @@
 				type="number"
 				label="JGLOBAL_NUM_LEADING_ARTICLES_LABEL"
 				useglobal="true"
-				size="3"
 			/>
 
 			<field 
@@ -66,7 +65,6 @@
 				type="number"
 				label="JGLOBAL_NUM_INTRO_ARTICLES_LABEL"
 				useglobal="true"
-				size="3"
 			/>
 
 			<field 
@@ -74,7 +72,6 @@
 				type="number"
 				label="JGLOBAL_NUM_COLUMNS_LABEL"
 				useglobal="true"
-				size="3"
 			/>
 
 			<field 
@@ -82,7 +79,6 @@
 				type="number"
 				label="JGLOBAL_NUM_LINKS_LABEL"
 				useglobal="true"
-				size="3"
 			/>
 
 			<field

--- a/components/com_newsfeeds/tmpl/categories/default.xml
+++ b/components/com_newsfeeds/tmpl/categories/default.xml
@@ -317,7 +317,6 @@
 				type="number"
 				label="COM_NEWSFEEDS_FIELD_CHARACTER_COUNT_LABEL"
 				description="COM_NEWSFEEDS_FIELD_CHARACTER_COUNT_DESC"
-				size="6"
 				useglobal="true"
 			/>
 		</fieldset>

--- a/components/com_newsfeeds/tmpl/category/default.xml
+++ b/components/com_newsfeeds/tmpl/category/default.xml
@@ -253,7 +253,6 @@
 				type="number"
 				description="COM_NEWSFEEDS_FIELD_CHARACTER_COUNT_DESC"
 				label="COM_NEWSFEEDS_FIELD_CHARACTER_COUNT_LABEL"
-				size="6"
 				useglobal="true"
 			/>
 			

--- a/components/com_newsfeeds/tmpl/newsfeed/default.xml
+++ b/components/com_newsfeeds/tmpl/newsfeed/default.xml
@@ -82,7 +82,6 @@
 				type="number"
 				label="COM_NEWSFEEDS_FIELD_CHARACTER_COUNT_LABEL"
 				description="COM_NEWSFEEDS_FIELD_CHARACTER_COUNT_DESC"
-				size="6"
 				useglobal="true"
 			/>
 

--- a/components/com_wrapper/tmpl/wrapper/default.xml
+++ b/components/com_wrapper/tmpl/wrapper/default.xml
@@ -51,7 +51,6 @@
 				type="number"
 				label="COM_WRAPPER_FIELD_HEIGHT_LABEL"
 				default="500"
-				size="5"
 			/>
 
 		</fieldset>

--- a/layouts/joomla/form/field/number.php
+++ b/layouts/joomla/form/field/number.php
@@ -33,7 +33,6 @@ extract($displayData);
  * @var   boolean  $readonly        Is this field read only?
  * @var   boolean  $repeat          Allows extensions to duplicate elements.
  * @var   boolean  $required        Is this field required?
- * @var   integer  $size            Size attribute of the input.
  * @var   boolean  $spellcheck      Spellcheck state for the form field.
  * @var   string   $validate        Validation rules to apply.
  * @var   string   $value           Value attribute of the field.
@@ -50,7 +49,6 @@ $autocomplete = $autocomplete === ' autocomplete="on"' ? '' : $autocomplete;
 
 $attributes = array(
 	!empty($class) ? 'class="form-control ' . $class . '"' : 'class="form-control"',
-	!empty($size) ? 'size="' . $size . '"' : '',
 	$disabled ? 'disabled' : '',
 	$readonly ? 'readonly' : '',
 	strlen($hint) ? 'placeholder="' . htmlspecialchars($hint, ENT_COMPAT, 'UTF-8') . '"' : '',

--- a/plugins/fields/integer/integer.xml
+++ b/plugins/fields/integer/integer.xml
@@ -37,7 +37,6 @@
 					type="number"
 					label="PLG_FIELDS_INTEGER_PARAMS_FIRST_LABEL"
 					default="1"
-					size="5"
 				/>
 	
 				<field
@@ -45,7 +44,6 @@
 					type="number"
 					label="PLG_FIELDS_INTEGER_PARAMS_LAST_LABEL"
 					default="100"
-					size="5"
 				/>
 	
 				<field
@@ -53,7 +51,6 @@
 					type="number"
 					label="PLG_FIELDS_INTEGER_PARAMS_STEP_LABEL"
 					default="1"
-					size="5"
 				/>
 			</fieldset>
 		</fields>

--- a/plugins/fields/integer/params/integer.xml
+++ b/plugins/fields/integer/params/integer.xml
@@ -16,21 +16,18 @@
 				name="first"
 				type="number"
 				label="PLG_FIELDS_INTEGER_PARAMS_FIRST_LABEL"
-				size="5"
 			/>
 
 			<field
 				name="last"
 				type="number"
 				label="PLG_FIELDS_INTEGER_PARAMS_LAST_LABEL"
-				size="5"
 			/>
 
 			<field
 				name="step"
 				type="number"
 				label="PLG_FIELDS_INTEGER_PARAMS_STEP_LABEL"
-				size="5"
 			/>
 		</fieldset>
 	</fields>

--- a/plugins/fields/textarea/params/textarea.xml
+++ b/plugins/fields/textarea/params/textarea.xml
@@ -6,14 +6,12 @@
 				name="rows"
 				type="number"
 				label="PLG_FIELDS_TEXTAREA_PARAMS_ROWS_LABEL"
-				size="5"
 			/>
 
 			<field
 				name="cols"
 				type="number"
 				label="PLG_FIELDS_TEXTAREA_PARAMS_COLS_LABEL"
-				size="5"
 			/>
 
 			<field

--- a/plugins/fields/textarea/textarea.xml
+++ b/plugins/fields/textarea/textarea.xml
@@ -26,7 +26,6 @@
 					type="number"
 					label="PLG_FIELDS_TEXTAREA_PARAMS_ROWS_LABEL"
 					default="10"
-					size="5"
 				/>
 
 				<field
@@ -34,7 +33,6 @@
 					type="number"
 					label="PLG_FIELDS_TEXTAREA_PARAMS_COLS_LABEL"
 					default="10"
-					size="5"
 				/>
 
 				<field

--- a/plugins/search/categories/categories.xml
+++ b/plugins/search/categories/categories.xml
@@ -25,7 +25,6 @@
 					type="number"
 					label="JFIELD_PLG_SEARCH_SEARCHLIMIT_LABEL"
 					default="50"
-					size="5"
 				/>
 
 				<field

--- a/plugins/search/contacts/contacts.xml
+++ b/plugins/search/contacts/contacts.xml
@@ -24,7 +24,6 @@
 					type="number"
 					label="JFIELD_PLG_SEARCH_SEARCHLIMIT_LABEL"
 					default="50"
-					size="5"
 				/>
 
 				<field

--- a/plugins/search/content/content.xml
+++ b/plugins/search/content/content.xml
@@ -24,7 +24,6 @@
 					type="number"
 					label="PLG_SEARCH_CONTENT_FIELD_SEARCHLIMIT_LABEL"
 					default="50"
-					size="5"
 				/>
 
 				<field

--- a/plugins/search/newsfeeds/newsfeeds.xml
+++ b/plugins/search/newsfeeds/newsfeeds.xml
@@ -24,7 +24,6 @@
 					type="number"
 					label="JFIELD_PLG_SEARCH_SEARCHLIMIT_LABEL"
 					default="50"
-					size="5"
 				/>
 
 				<field

--- a/plugins/search/tags/tags.xml
+++ b/plugins/search/tags/tags.xml
@@ -24,7 +24,6 @@
 					type="number"
 					label="JFIELD_PLG_SEARCH_SEARCHLIMIT_LABEL"
 					default="50"
-					size="5"
 				/>
 
 				<field


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/number

Attribute 'size' is only allowed when the input type is 'text', 'search', 'url', 'tel', 'email' or 'password'.

<input> elements of type "number" don't support form sizing attributes such as size.