### PR TITLE
[4.0] Combine class attributes in pagination

### DIFF
--- a/administrator/templates/atum/html/pagination.php
+++ b/administrator/templates/atum/html/pagination.php
@@ -188,13 +188,16 @@ function pagination_item_active(&$item)
 		$limit = 'limitstart.value=0';
 	}
 
-	$title = '';
+	$title      = '';
+	$titleClass = '';
+
 	if (!is_numeric($item->text))
 	{
-		$title = ' class="hasTooltip" title="' . $item->text . '"';
+		$title      = ' title="' . $item->text . '"';
+		$titleClass = ' hasTooltip';
 	}
 
-	return '<li' . $class . '><a class="page-link"' . $title . ' href="#" onclick="document.adminForm.' . $item->prefix . $limit . '; Joomla.submitform();return false;">' . $display . '</a></li>';
+	return '<li' . $class . '><a class="page-link' . $titleClass . '"' . $title . ' href="#" onclick="document.adminForm.' . $item->prefix . $limit . '; Joomla.submitform();return false;">' . $display . '</a></li>';
 }
 
 /**


### PR DESCRIPTION
Pull Request for Issue #20971.

### Summary of Changes
This PR combines class attributes into one in pagination.


### Testing Instructions
Go to Content > Articles
Make sure there is pagination at the bottom of the page.
View page source.


### Expected result
1 class attribute
![class2](https://user-images.githubusercontent.com/368084/42288920-b1b4a99c-7f71-11e8-8c20-5757c4b446a5.jpg)



### Actual result
2 class attributes
![class](https://user-images.githubusercontent.com/368084/42288926-b448e97a-7f71-11e8-8645-b284e90c443f.jpg)



### Documentation Changes Required
none
