### PR TITLE
[4.0] Fix markup in installation error page

### DIFF
--- a/installation/template/error.php
+++ b/installation/template/error.php
@@ -58,7 +58,7 @@ defined('_JEXEC') or die;
 								</div>
 								<div class="alert-text">
 									<h2><?php echo JText::_('JERROR_LAYOUT_ERROR_HAS_OCCURRED_WHILE_PROCESSING_YOUR_REQUEST'); ?></h2>
-									<p class="form-text text-muted small"><?php echo $this->error->getCode(); ?></span> <?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></p>
+									<p class="form-text text-muted small"><span class="badge badge-default"><?php echo $this->error->getCode(); ?></span> <?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></p>
 								</div>
 							</div>
 							<?php if ($this->debug) : ?>


### PR DESCRIPTION
### Summary of Changes
Add missing markup.


### Testing Instructions
Go to this page `http://localhost/joomla-cms-4.0-dev/installation/index.php?view=warnings`
View page source

or

Code review

### Expected result
![error-after](https://user-images.githubusercontent.com/368084/42329580-d8febeb6-8025-11e8-81d2-95e7012dfce7.jpg)


### Actual result
![error-before](https://user-images.githubusercontent.com/368084/42329591-ddf6594c-8025-11e8-98a0-8df06c162e40.jpg)
