### PR TITLE
[4.0] Add hasField method to the JTable interface

### DIFF
--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -1978,6 +1978,7 @@ abstract class Table extends \JObject implements \JTableInterface, DispatcherAwa
 	 * @param   string  $key  key to be checked
 	 *
 	 * @return  boolean
+	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
 	public function hasField($key)

--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -1971,4 +1971,19 @@ abstract class Table extends \JObject implements \JTableInterface, DispatcherAwa
 
 		return true;
 	}
+
+	/**
+	 * Check if the record has a property (applying a column alias if it exists)
+	 *
+	 * @param   string  $key  key to be checked
+	 *
+	 * @return  boolean
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function hasField($key)
+	{
+		$key = $this->getColumnAlias($key);
+
+		return property_exists($this, $key);
+	}
 }

--- a/libraries/src/Table/TableInterface.php
+++ b/libraries/src/Table/TableInterface.php
@@ -122,4 +122,15 @@ interface TableInterface
 	 * @since  4.0
 	 */
 	public function getId();
+
+	/**
+	 * Check if the record has a property (applying a column alias if it exists)
+	 *
+	 * @param   string  $key  key to be checked
+	 *
+	 * @return  boolean
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function hasField($key);
 }


### PR DESCRIPTION
Adds a hasField method to the JTable interface so we can phase out the use of `property_exists` in the system. This is in anticipation of the introduction of Joomla's entity system being introduced

This will require documentation on the b/c break to the interface (requiring a new method)

// cc @nikosdion as fof uses this interface (you already implement this method with the same signature - so no changes will be required) but as an FYI)

This work comes from the GSOC 2018 project by @isacandrei for webservices