### PR TITLE
[4.0] Finish moving error templates to proper HtmlDocument structure

### DIFF
--- a/administrator/templates/system/error.php
+++ b/administrator/templates/system/error.php
@@ -9,15 +9,22 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\HTML\HTMLHelper;
+
 /** @var JDocumentError $this */
 
+// Load template CSS file
+HTMLHelper::_('stylesheet', 'error.css', ['version' => 'auto', 'relative' => true]);
+
+// Set page title
+$this->setTitle($this->error->getCode() . ' - ' . htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'));
 ?>
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
-	<meta charset="utf-8">
-	<title><?php echo $this->error->getCode(); ?> - <?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></title>
-	<link href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/error.css" rel="stylesheet">
+	<jdoc:include type="metas" />
+	<jdoc:include type="styles" />
+	<jdoc:include type="scripts" />
 </head>
 <body>
 	<table class="outline" style="margin: 0 auto; width: 550px;">
@@ -61,5 +68,7 @@ defined('_JEXEC') or die;
 			</td>
 		</tr>
 	</table>
+
+	<jdoc:include type="modules" name="debug" style="none" />
 </body>
 </html>

--- a/installation/template/error.php
+++ b/installation/template/error.php
@@ -9,17 +9,30 @@
 defined('_JEXEC') or die;
 
 /** @var JDocumentError $this */
+
+// Add Stylesheets
+JHtml::_('stylesheet', 'installation/template/css/template.css', ['version' => 'auto']);
+JHtml::_('stylesheet', 'media/vendor/font-awesome/css/font-awesome.min.css', ['version' => 'auto']);
+JHtml::_('stylesheet', 'installation/template/css/joomla-alert.min.css', ['version' => 'auto']);
+
+// Add scripts
+JHtml::_('script', 'installation/template/js/template.js', ['version' => 'auto']);
+JHtml::_('webcomponent', 'vendor/joomla-custom-elements/joomla-alert.min.js', ['version' => 'auto', 'relative' => true]);
+
+// Add script options
+$this->addScriptOptions('system.installation', ['url' => JRoute::_('index.php')]);
+
+// Set page title
+$this->setTitle($this->error->getCode() . ' - ' . htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'));
+
+$this->setMetaData('viewport', 'width=device-width, initial-scale=1');
+
 ?>
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 	<head>
-		<title><?php echo $this->title; ?> <?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></title>
-		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<!--		<link href="--><?php //echo JUri::root(true); ?><!--/media/jui/css/bootstrap.min.css" rel="stylesheet">-->
-		<?php if ($this->direction == 'rtl') : ?>
-<!--			<link href="--><?php //echo JUri::root(true); ?><!--/media/jui/css/bootstrap-rtl.css" rel="stylesheet">-->
-		<?php endif; ?>
-		<link href="<?php echo $this->baseurl; ?>/template/css/template.css" rel="stylesheet">
+		<jdoc:include type="metas" />
+		<jdoc:include type="styles" />
 	</head>
 	<body>
 		<div class="j-install">
@@ -85,6 +98,7 @@ defined('_JEXEC') or die;
 					</div>
 				</div>
 			</section>
+			<jdoc:include type="scripts" />
 			<footer class="j-footer">
 				<a href="https://www.joomla.org" target="_blank">Joomla!</a>
 				is free software released under the

--- a/templates/system/error.php
+++ b/templates/system/error.php
@@ -9,28 +9,34 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\HTML\HTMLHelper;
+
 /** @var JDocumentError $this */
 
 if (!isset($this->error))
 {
-	$this->error = JFactory::getApplication()->enqueueMessage(JText::_('JERROR_ALERTNOAUTHOR'), 'error');
+	$this->error = new Exception(JText::_('JERROR_ALERTNOAUTHOR'));
 	$this->debug = false;
 }
 
-$app = JFactory::getApplication();
+// Load template CSS file
+HTMLHelper::_('stylesheet', 'error.css', ['version' => 'auto', 'relative' => true]);
+
+if ($this->direction === 'rtl')
+{
+	HTMLHelper::_('stylesheet', 'error_rtl.css', ['version' => 'auto', 'relative' => true]);
+}
+
+// Set page title
+$this->setTitle($this->error->getCode() . ' - ' . htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'));
+
 ?>
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
-	<meta charset="utf-8">
-	<title><?php echo $this->error->getCode(); ?> - <?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></title>
-	<link href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/error.css" rel="stylesheet">
-	<?php if ($this->direction === 'rtl') : ?>
-		<link href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/error_rtl.css" rel="stylesheet">
-	<?php endif; ?>
-	<?php if ($app->get('debug_lang', '0') == '1' || $app->get('debug', '0') == '1') : ?>
-		<link href="<?php echo JUri::root(true); ?>/media/system/css/debug.css" rel="stylesheet">
-	<?php endif; ?>
+	<jdoc:include type="metas" />
+	<jdoc:include type="styles" />
+	<jdoc:include type="scripts" />
 </head>
 <body>
 	<div class="error">
@@ -87,5 +93,7 @@ $app = JFactory::getApplication();
 		</div>
 		</div>
 	</div>
+
+	<jdoc:include type="modules" name="debug" style="none" />
 </body>
 </html>


### PR DESCRIPTION
### Summary of Changes

Finishing #20734 the system and installation app error templates are updated to reflect the error document now being an extension of the HTML document.

### Testing Instructions

- Temporarily rename `error.php` in the themed templates to anything else temporarily so the system template's `error.php` layout is rendered
- Trigger error page
- See error page
- Rename the `error.php` file(s) you previously renamed back to `error.php`
- Mark successful test