### PR TITLE
[4.0][a11y]Remove incorrect role attribute

### DIFF
--- a/layouts/joomla/quickicons/icon.php
+++ b/layouts/joomla/quickicons/icon.php
@@ -23,7 +23,7 @@ if ($id !== '')
 }
 
 ?>
-<a<?php echo $id . $class; ?> href="<?php echo $displayData['link']; ?>"<?php echo $target . $onclick . $title; ?> role="button">
+<a<?php echo $id . $class; ?> href="<?php echo $displayData['link']; ?>"<?php echo $target . $onclick . $title; ?>>
 	<div class="quickicon-icon d-flex align-items-end"><span class="<?php echo $displayData['image']; ?>" aria-hidden="true"></span></div>
 	<div class="quickicon-text d-flex align-items-center"><?php echo $text; ?></div>
 </a>


### PR DESCRIPTION
Pull Request for Issue #20992

### Summary of Changes
The links in the Quickicon module are assigned the role=button attribute. This is incorrect. These are not buttons. These are the links that open new pages


### Testing Instructions
code review 


### Expected result
The links in the Quickicon module are not assigned the role=button attribute.


### Actual result
The links in the Quickicon module are assigned the role=button attribute.


### Documentation Changes Required
N/A

cc @zwiastunsw @chmst please test