### PR TITLE
[4.0] Duplicate custom-select class

### DIFF
--- a/libraries/cms/html/select.php
+++ b/libraries/cms/html/select.php
@@ -219,7 +219,7 @@ abstract class JHtmlSelect
 
 		$baseIndent = str_repeat($options['format.indent'], $options['format.depth']++);
 		$html = $baseIndent . '<select' . ($id !== '' ? ' id="' . $id . '"' : '')
-				. ' name="' . $name . '"' . $attribs . ' class="custom-select">' . $options['format.eol'];
+				. ' name="' . $name . '"' . $attribs . '>' . $options['format.eol'];
 		$groupIndent = str_repeat($options['format.indent'], $options['format.depth']++);
 
 		foreach ($data as $dataKey => $group)


### PR DESCRIPTION
Any field that extends the groupedlist field ends up with two class=custom-select

This can be seen on the
1. timezone field in global configuration
2. menu field in mod_menu
3. templatestyle field in com_menu

and various other places

note: you need to view source - not inspect source to see this

When testing please check all select based fields - it should be easy as without any class=custom-select it will visually look wrong