### PR TITLE
[4.0][a11y]Convert link to a button in sample data admin module

### DIFF
--- a/administrator/modules/mod_sampledata/tmpl/default.php
+++ b/administrator/modules/mod_sampledata/tmpl/default.php
@@ -36,7 +36,7 @@ Factory::getDocument()->addScriptOptions(
 						<span class="fa fa-<?php echo $item->icon; ?>" aria-hidden="true"></span>
 						<?php echo htmlspecialchars($item->title, ENT_QUOTES, 'UTF-8'); ?>
 					</div>
-					<button class="btn btn-primary btn-sm apply-sample-data" data-type="<?php echo $item->name; ?>" data-steps="<?php echo $item->steps; ?>">
+					<button type="button" class="btn btn-primary btn-sm apply-sample-data" data-type="<?php echo $item->name; ?>" data-steps="<?php echo $item->steps; ?>">
 					<?php echo Text::_('JLIB_INSTALLER_INSTALL'); ?></button>
 				</div>
 				<p class="small mt-1"><?php echo $item->description; ?></p>

--- a/administrator/modules/mod_sampledata/tmpl/default.php
+++ b/administrator/modules/mod_sampledata/tmpl/default.php
@@ -36,8 +36,8 @@ Factory::getDocument()->addScriptOptions(
 						<span class="fa fa-<?php echo $item->icon; ?>" aria-hidden="true"></span>
 						<?php echo htmlspecialchars($item->title, ENT_QUOTES, 'UTF-8'); ?>
 					</div>
-					<a href="#" class="btn btn-primary btn-sm apply-sample-data" data-type="<?php echo $item->name; ?>" data-steps="<?php echo $item->steps; ?>">
-					<?php echo Text::_('JLIB_INSTALLER_INSTALL'); ?></a>
+					<button class="btn btn-primary btn-sm apply-sample-data" data-type="<?php echo $item->name; ?>" data-steps="<?php echo $item->steps; ?>">
+					<?php echo Text::_('JLIB_INSTALLER_INSTALL'); ?></button>
 				</div>
 				<p class="small mt-1"><?php echo $item->description; ?></p>
 			</li>


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/20997

### Summary of Changes
The Install button in Sample data module is incorrectly marked as a link.
See:
- [1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG21/quickref/?versions=2.0&showtechniques=111%2C412#info-and-relationships) (Level A)
- [G115:](https://www.w3.org/TR/WCAG20-TECHS/G115.html) Using semantic elements to mark up structure
- [Links vs. Buttons in Modern Web Applications](https://marcysutton.com/links-vs-buttons-in-modern-web-applications/)
### Testing Instructions
code review and check if install buttons in sape data module are working.
### Expected result
Install button in sample data module is a button.
### Actual result
Install button in sample data module is a link.
### Documentation Changes Required
N/A

cc @zwiastunsw @chmst please test