### PR TITLE
[4.0] [a11y] Text filter settings

### DIFF
--- a/administrator/components/com_config/Field/FiltersField.php
+++ b/administrator/components/com_config/Field/FiltersField.php
@@ -86,6 +86,7 @@ class FiltersField extends FormField
 			$html[] = '			' . \JLayoutHelper::render('joomla.html.treeprefix', array('level' => $group->level + 1)) . $group->text;
 			$html[] = '		</td>';
 			$html[] = '		<td>';
+			$html[] = '			<label for="' . $this->id . $group->value . '_filter_type" class="sr-only">' . \JText::_('JGLOBAL_FILTER_TYPE_LABEL') . '</label>';
 			$html[] = '				<select'
 				. ' name="' . $this->name . '[' . $group->value . '][filter_type]"'
 				. ' id="' . $this->id . $group->value . '_filter_type"'
@@ -104,6 +105,7 @@ class FiltersField extends FormField
 			$html[] = '				</select>';
 			$html[] = '		</td>';
 			$html[] = '		<td>';
+			$html[] = '			<label for="' . $this->id . $group->value . '_filter_tags" class="sr-only">' . \JText::_('JGLOBAL_FILTER_TAGS_LABEL') . '</label>';
 			$html[] = '				<input'
 				. ' name="' . $this->name . '[' . $group->value . '][filter_tags]"'
 				. ' type="text"'
@@ -112,6 +114,7 @@ class FiltersField extends FormField
 				. '>';
 			$html[] = '		</td>';
 			$html[] = '		<td>';
+			$html[] = '			<label for="' . $this->id . $group->value . '_filter_attributes" class="sr-only">' . \JText::_('JGLOBAL_FILTER_ATTRIBUTES_LABEL') . '</label>';
 			$html[] = '				<input'
 				. ' name="' . $this->name . '[' . $group->value . '][filter_attributes]"'
 				. ' type="text"'

--- a/administrator/components/com_config/Field/FiltersField.php
+++ b/administrator/components/com_config/Field/FiltersField.php
@@ -114,7 +114,8 @@ class FiltersField extends FormField
 				. '>';
 			$html[] = '		</td>';
 			$html[] = '		<td>';
-			$html[] = '			<label for="' . $this->id . $group->value . '_filter_attributes" class="sr-only">' . \JText::_('JGLOBAL_FILTER_ATTRIBUTES_LABEL') . '</label>';
+			$html[] = '			<label for="' . $this->id . $group->value . '_filter_attributes"'
+				. ' class="sr-only">' . \JText::_('JGLOBAL_FILTER_ATTRIBUTES_LABEL') . '</label>';
 			$html[] = '				<input'
 				. ' name="' . $this->name . '[' . $group->value . '][filter_attributes]"'
 				. ' type="text"'


### PR DESCRIPTION
Every field must have a label. None of the fields in the text-settings tab of global configuration had a label. This PR adds a label with a class of sr-only so it is only "visible" to assistive technology
