### PR TITLE
[4.0] com_finder: "use Joomla\CMS\Factory;" one call too much

### DIFF
--- a/components/com_finder/View/Search/HtmlView.php
+++ b/components/com_finder/View/Search/HtmlView.php
@@ -17,7 +17,6 @@ use Joomla\CMS\Pagination\Pagination;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Profiler\Profiler;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/pull/20384#issuecomment-403274591
`[08-Jul-2018 11:02:36 Europe/Berlin] PHP Fatal error: Cannot use Joomla\CMS\Factory as Factory because the name is already in use in /Applications/MAMP/htdocs/installmulti/joomla40/components/com_finder/View/Search/HtmlView.php on line 20`

### Summary of Changes

Take off the supplementary call

Can be merged on review
@Webdongle @laoneo @mbabker 


