### PR TITLE
[4.0] Fixing merging error with double Factory

### DIFF
--- a/components/com_finder/View/Search/HtmlView.php
+++ b/components/com_finder/View/Search/HtmlView.php
@@ -17,7 +17,6 @@ use Joomla\CMS\Pagination\Pagination;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Profiler\Profiler;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;


### PR DESCRIPTION
Due to a merging error, the Factory class "use" statement was added twice. This fixes this. How to test? It throws a fatal error before applying and works after.