### PR TITLE
[4.0] Correct hits count icon in article info

### DIFF
--- a/layouts/joomla/content/info_block/hits.php
+++ b/layouts/joomla/content/info_block/hits.php
@@ -13,7 +13,7 @@ use Joomla\CMS\Language\Text;
 
 ?>
 <dd class="hits">
-	<span class="fa fa-eye-o" aria-hidden="true"></span>
+	<span class="fa fa-eye" aria-hidden="true"></span>
 	<meta itemprop="interactionCount" content="UserPageVisits:<?php echo $displayData['item']->hits; ?>">
 	<?php echo Text::sprintf('COM_CONTENT_ARTICLE_HITS', $displayData['item']->hits); ?>
 </dd>


### PR DESCRIPTION
Pull Request for new issue.

### Summary of Changes
In article info no eye icon is shown left beside the hits counter. See screenshot in section "Actual result" below.

The reason is that in file `layouts/joomla/content/info_block/hits.php` the wrong class `fa-eye-o` is used. 
Correct would be `fa-eye`, see screenshot in section "Expected result" below.

The following screenshot of `findstr` commands issued in a Windows command shell shows following:
- The only PHP file in current 4.0-dev using `fa-eye-o` is `layouts/joomla/content/info_block/hits.php`, see 1st findstr command.
- In general in all other files `fa-eye` is used without anything appended to the end, see 2nd command.
- Details in PHP files see 3rd command.

![finstr-fa-eye](https://user-images.githubusercontent.com/7413183/42419225-8c4c45ce-82b0-11e8-8914-6667ceb62443.png)

### Testing Instructions

Reviev by a maintainer should be enough, but if not:

Use current 4.0-dev with Casiopeia template and no overrides for com_content or layouts/joomla/content.

Show article info including the hits counter in some article.

Check icon beside hits counter and inspect html.

### Expected result

![hits-icon-present](https://user-images.githubusercontent.com/7413183/42419243-0618b6b2-82b1-11e8-95b4-03dc7624af8d.png)

### Actual result

![hits-icon-missing](https://user-images.githubusercontent.com/7413183/42419246-0ba42404-82b1-11e8-9389-5136a77b10fb.png)

### Documentation Changes Required

No.