### PR TITLE
[4.0] Fix footer button markup in modal

### DIFF
--- a/layouts/joomla/form/field/user.php
+++ b/layouts/joomla/form/field/user.php
@@ -125,7 +125,7 @@ if (!$readonly)
 						'width'       => '100%',
 						'modalWidth'  => 80,
 						'bodyHeight'  => 60,
-						'footer'      => '<a type="button" class="btn btn-secondary" data-dismiss="modal">' . Text::_('JCANCEL') . '</a>'
+						'footer'      => '<a role="button" class="btn btn-secondary" data-dismiss="modal" aria-hidden="true">' . Text::_('JCANCEL') . '</a>'
 					)
 				); ?>
 				</span>


### PR DESCRIPTION
Pull Request for Issue #20499 .

### Summary of Changes
Fix footer button markup in modal to be consistent with other modals.


### Testing Instructions
Go to Users > User Notes
Create a new note
Click on the User icon (See Cancel button)
Click on the Select button (See Close button)

or 

Code review via page source

Before:
`<a type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</a>`

After:
`<a role="button" class="btn btn-secondary" data-dismiss="modal" aria-hidden="true">Close</a>`


### Expected result
Buttons markup to be the same.


### Actual result
Buttons markup are different.


### Documentation Changes Required
none
