### PR TITLE
Fix sampledata menu creation

### DIFF
--- a/plugins/sampledata/blog/blog.php
+++ b/plugins/sampledata/blog/blog.php
@@ -342,6 +342,7 @@ class PlgSampledataBlog extends JPlugin
 
 			$menuTable->load();
 			$menuTable->bind($menu);
+			$menuTable->check();
 
 			try
 			{

--- a/plugins/sampledata/blog/blog.php
+++ b/plugins/sampledata/blog/blog.php
@@ -340,12 +340,16 @@ class PlgSampledataBlog extends JPlugin
 
 			$menu['menutype'] = $i . $type;
 
-			$menuTable->load();
-			$menuTable->bind($menu);
-			$menuTable->check();
-
 			try
 			{
+				$menuTable->load();
+				$menuTable->bind($menu);
+
+				if (!$menuTable->check())
+				{
+					throw new Exception($menuTable->getError());
+				}
+
 				$menuTable->store();
 			}
 			catch (Exception $e)


### PR DESCRIPTION
Pull Request for Issue #21073 .

### Summary of Changes
Adds a table check prior to storing.


### Testing Instructions
Create the blog sampledata and check the menutype of the created menus. 


### Expected result
They should contain no spaces and be lowercased.


### Actual result
Contain spaces and uppercase characters


### Documentation Changes Required
None
