### PR TITLE
[4.0] Modal dismiss button

### DIFF
--- a/layouts/joomla/modal/header.php
+++ b/layouts/joomla/modal/header.php
@@ -37,6 +37,8 @@ extract($displayData);
 		<h3 class="modal-title"><?php echo $params['title']; ?></h3>
 	<?php endif; ?>
 	<?php if (!isset($params['closeButton']) || $params['closeButton']) : ?>
-		<button type="button" class="close novalidate" data-dismiss="modal">&times;</button>
+		<button type="button" class="close novalidate" data-dismiss="modal" aria-label="<?php echo JText::_('JCANCEL'); ?>">
+			<span aria-hidden="true">&times;</span>
+		</button>
 	<?php endif; ?>
 </div>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
The dismiss button in the modal header is not read correctly by the screan reader. It reads  "multiplication operator" - depending on the language. In German "mal" (2 x 2 = 4).
The PR adds a aria label "closed" and hides the "X" which is read as "multiplication operator", so the screen reader reads "close".

### Testing Instructions
Open a modal, for example in articles overview, Batch-Button.
Hear what the screen reader says before and after the Patch.
Make sure that the dismiss-button is the same before and after the patch.

### Documentation Changes Required
no
