### PR TITLE
[FIX] Forcing Menu to have a unique title

### DIFF
--- a/administrator/language/en-GB/en-GB.lib_joomla.ini
+++ b/administrator/language/en-GB/en-GB.lib_joomla.ini
@@ -182,6 +182,7 @@ JLIB_DATABASE_ERROR_LANGUAGE_UNIQUE_IMAGE="A content language already exists wit
 JLIB_DATABASE_ERROR_LANGUAGE_UNIQUE_LANG_CODE="A content language already exists with this Language Tag."
 JLIB_DATABASE_ERROR_LANGUAGE_UNIQUE_SEF="A content language already exists with this URL Language Code."
 JLIB_DATABASE_ERROR_LOAD_DATABASE_DRIVER="Unable to load Database Driver: %s"
+JLIB_DATABASE_ERROR_MENUTITLE_EXISTS="Menu title exists: %s"
 JLIB_DATABASE_ERROR_MENUTYPE="Some menu items or some menu modules related to this menutype are checked out by another user or the default menu item is in this menu."
 JLIB_DATABASE_ERROR_MENUTYPE_CHECKOUT="The user checking out does not match the user who checked out this menu and/or its linked menu module."
 JLIB_DATABASE_ERROR_MENUTYPE_EMPTY="Menu type empty."

--- a/language/en-GB/en-GB.lib_joomla.ini
+++ b/language/en-GB/en-GB.lib_joomla.ini
@@ -182,6 +182,7 @@ JLIB_DATABASE_ERROR_LANGUAGE_UNIQUE_IMAGE="A content language already exists wit
 JLIB_DATABASE_ERROR_LANGUAGE_UNIQUE_LANG_CODE="A content language already exists with this Language Tag."
 JLIB_DATABASE_ERROR_LANGUAGE_UNIQUE_SEF="A content language already exists with this URL Language Code."
 JLIB_DATABASE_ERROR_LOAD_DATABASE_DRIVER="Unable to load Database Driver: %s"
+JLIB_DATABASE_ERROR_MENUTITLE_EXISTS="Menu title exists: %s"
 JLIB_DATABASE_ERROR_MENUTYPE="Some menu items or some menu modules related to this menutype are checked out by another user or the default menu item is in this menu."
 JLIB_DATABASE_ERROR_MENUTYPE_CHECKOUT="The user checking out does not match the user who checked out this menu and/or its linked menu module."
 JLIB_DATABASE_ERROR_MENUTYPE_EMPTY="Menu type empty."

--- a/libraries/src/Table/MenuType.php
+++ b/libraries/src/Table/MenuType.php
@@ -71,6 +71,21 @@ class MenuType extends Table
 			return false;
 		}
 
+		// Check for unique menu title.
+		$query = $this->_db->getQuery(true)
+			->select('COUNT(id)')
+			->from($this->_db->quoteName('#__menu_types'))
+			->where($this->_db->quoteName('title') . ' = ' . $this->_db->quote($this->title))
+			->where($this->_db->quoteName('id') . ' <> ' . (int) $this->id);
+		$this->_db->setQuery($query);
+
+		if ($this->_db->loadResult())
+		{
+			$this->setError(\JText::sprintf('JLIB_DATABASE_ERROR_MENUTITLE_EXISTS', $this->title));
+
+			return false;
+		}
+
 		return true;
 	}
 


### PR DESCRIPTION
### Summary of Changes
Preventing saving the same title for a Menu


### Testing Instructions
Create a new Menu `administrator/index.php?option=com_menus&view=menu&layout=edit`
Use the same title as an existing Menu, for example `Main Menu`

### Before patch
The Menu is saved OK.
<img width="526" alt="screen shot 2018-07-12 at 12 52 39" src="https://user-images.githubusercontent.com/869724/42629200-e5f1f16c-85d2-11e8-91ab-64bb75bcfd1c.png">


Its title displays in all Select Menu fields
<img width="384" alt="screen shot 2018-07-12 at 12 53 02" src="https://user-images.githubusercontent.com/869724/42629226-f867c092-85d2-11e8-9e7e-b6ca99a4bb06.png">

==> Great confusion as we have 2 Menu with the same title

### After patch
It now does the same as for the Menu Type, i.e. it prevents saving.
<img width="549" alt="screen shot 2018-07-12 at 12 51 39" src="https://user-images.githubusercontent.com/869724/42629359-559fbfda-85d3-11e8-97a3-fe7c6178dd37.png">

### Documentation Changes Required
Don't know if we have a doc for the Menu Type. If yes, may need changes to add this aspect.
