### PR TITLE
[4.0] Admin page header in Edge/IE11

### DIFF
--- a/administrator/modules/mod_title/tmpl/default.php
+++ b/administrator/modules/mod_title/tmpl/default.php
@@ -10,7 +10,7 @@
 defined('_JEXEC') or die;
 ?>
 <?php if (!empty($title)) : ?>
-<div class="d-flex col">
+<div class="d-flex px-2">
 	<div class="container-title">
 		<?php echo $title; ?>
 	</div>


### PR DESCRIPTION
Pull Request for Issue #21040.

### Summary of Changes

This fixes administrator page header display on Edge/IE11.

### Testing Instructions

Check that page header displays correctly with Edge/IE11, i.e. not like pictured in #21040.


### Documentation Changes Required

No.