### PR TITLE
[4.0][a11y]Redundant tabindex - login page

### DIFF
--- a/administrator/modules/mod_login/Helper/LoginHelper.php
+++ b/administrator/modules/mod_login/Helper/LoginHelper.php
@@ -58,7 +58,7 @@ abstract class LoginHelper
 
 		array_unshift($languages, HTMLHelper::_('select.option', '', Text::_('JDEFAULTLANGUAGE')));
 
-		return HTMLHelper::_('select.genericlist', $languages, 'lang', 'class="custom-select" tabindex="4"', 'value', 'text', null);
+		return HTMLHelper::_('select.genericlist', $languages, 'lang', 'class="custom-select"', 'value', 'text', null);
 	}
 
 	/**

--- a/administrator/modules/mod_login/tmpl/default.php
+++ b/administrator/modules/mod_login/tmpl/default.php
@@ -44,7 +44,6 @@ Text::script('JHIDE');
 					class="form-control input-full"
 					required="required"
 					autofocus
-					tabindex="1"
 				>
 			</div>
 		</div>
@@ -65,7 +64,6 @@ Text::script('JHIDE');
 					type="password"
 					class="form-control input-full"
 					required="required"
-					tabindex="2"
 				>
 			</div>
 		</div>
@@ -85,7 +83,6 @@ Text::script('JHIDE');
 						id="mod-login-secretkey"
 						type="text"
 						class="form-control input-full"
-						tabindex="3"
 					>
 				</div>
 			</div>
@@ -99,7 +96,7 @@ Text::script('JHIDE');
 			</div>
 		<?php endif; ?>
 		<div class="form-group">
-			<button tabindex="5" class="btn btn-primary btn-block btn-lg mt-4" id="btn-login-submit"><?php echo Text::_('JLOGIN'); ?></button>
+			<button class="btn btn-primary btn-block btn-lg mt-4" id="btn-login-submit"><?php echo Text::_('JLOGIN'); ?></button>
 		</div>
 		<div class="text-center">
 			<div>


### PR DESCRIPTION
A positive `tabindex` value is present in two input field and in button element. Tabindex values of 1 or greater specify an explicit tab/navigation order for page elements. Because it modifies the default tab order, cause confusion, and result in decreased keyboard accessibility, it should be avoided.
**How to fix it**
If the natural tab order is already logical, remove the `tabindex`. Otherwise, consider restructuring the page so that `tabindex` is not needed. If `tabindex` is maintained, ensure that the resulting navigation is logical and complete.
See: 
* [2.4.3 Focus Order - Level A](https://www.w3.org/WAI/WCAG21/quickref/?showtechniques=243#focus-order)