### PR TITLE
Exceptions in Joomla\CMS\Table\Usergroup refer to categories

### DIFF
--- a/libraries/src/Table/Usergroup.php
+++ b/libraries/src/Table/Usergroup.php
@@ -171,12 +171,12 @@ class Usergroup extends Table
 
 		if ($this->id == 0)
 		{
-			throw new \UnexpectedValueException('Global Category not found');
+			throw new \UnexpectedValueException('Global Usergroup not found');
 		}
 
 		if ($this->parent_id == 0)
 		{
-			throw new \UnexpectedValueException('Root categories cannot be deleted.');
+			throw new \UnexpectedValueException('Root Usergroups cannot be deleted.');
 		}
 
 		if ($this->lft == 0 || $this->rgt == 0)
@@ -199,9 +199,6 @@ class Usergroup extends Table
 		{
 			throw new \UnexpectedValueException('Left-Right data inconsistency. Cannot delete usergroup.');
 		}
-
-		// Delete the category dependencies
-		// @todo Remove all related threads, posts and subscriptions
 
 		// Delete the usergroup and its children
 		$query->clear()


### PR DESCRIPTION
Pull Request for Issue #21092 .

### Summary of Changes
remove todo that is clearly a copy paste error from somewhere else
change exception message to usergroups from catergory

NOTE the first exception` if ($this->id == 0)`
I am not sure if that should even be present - doesnt look like it to me