### PR TITLE
Exceptions in Joomla\CMS\Table\Usergroup refer to categories

### DIFF
--- a/libraries/src/Table/Usergroup.php
+++ b/libraries/src/Table/Usergroup.php
@@ -160,7 +160,7 @@ class Usergroup extends Table
 
 		if ($this->id == 0)
 		{
-			throw new \UnexpectedValueException('Global usergroup not found');
+			throw new \UnexpectedValueException('Usergroup not found');
 		}
 
 		if ($this->parent_id == 0)

--- a/libraries/src/Table/Usergroup.php
+++ b/libraries/src/Table/Usergroup.php
@@ -160,12 +160,12 @@ class Usergroup extends Table
 
 		if ($this->id == 0)
 		{
-			throw new \UnexpectedValueException('Global Category not found');
+			throw new \UnexpectedValueException('Global usergroup not found');
 		}
 
 		if ($this->parent_id == 0)
 		{
-			throw new \UnexpectedValueException('Root categories cannot be deleted.');
+			throw new \UnexpectedValueException('Root usergroup cannot be deleted.');
 		}
 
 		if ($this->lft == 0 || $this->rgt == 0)
@@ -188,9 +188,6 @@ class Usergroup extends Table
 		{
 			throw new \UnexpectedValueException('Left-Right data inconsistency. Cannot delete usergroup.');
 		}
-
-		// Delete the category dependencies
-		// @todo Remove all related threads, posts and subscriptions
 
 		// Delete the usergroup and its children
 		$query->clear()


### PR DESCRIPTION
Pull Request for Issue #21092 .

### Summary of Changes
remove todo that is clearly a copy paste error from somewhere else
change exception message to usergroups from catergory

NOTE the first exception` if ($this->id == 0)`
I am not sure if that should even be present - doesn't look like it to me - please advise
