### PR TITLE
[4.0][com_categories] Duplicate use statement

### DIFF
--- a/administrator/components/com_categories/Model/CategoryModel.php
+++ b/administrator/components/com_categories/Model/CategoryModel.php
@@ -29,7 +29,6 @@ use Joomla\CMS\Access\Rules;
 use Joomla\CMS\Date\Date;
 use Joomla\CMS\UCM\UCMType;
 use Joomla\CMS\Filesystem\Path;
-use Joomla\CMS\Factory;
 
 /**
  * Categories Component Category Model


### PR DESCRIPTION
Pull Request for Issue #21111 .

### Summary of Changes

`Joomla\CMS\Factory` is called twice, causing a fatal error:
`Fatal error: Cannot use Joomla\CMS\Factory as Factory because the name is already in use in /administrator/components/com_categories/Model/CategoryModel.php on line 32`

### Testing Instructions

Code review or try to create a new category for any component.

### Expected result

Category form opens without errors.

### Actual result

Fatal error.

### Documentation Changes Required
No.
