### PR TITLE
[4.0] Define a standard for marking DI services as deprecated

### DIFF
--- a/libraries/src/Service/Provider/Authentication.php
+++ b/libraries/src/Service/Provider/Authentication.php
@@ -92,6 +92,15 @@ class Authentication implements ServiceProviderInterface
 				MD5Handler::class,
 				function (Container $container)
 				{
+					@trigger_error(
+						sprintf(
+							'The "%1$s" class service is deprecated, use the "%2$s" service for the active password handler instead.',
+							MD5Handler::class,
+							'password.handler.default'
+						),
+						E_USER_DEPRECATED
+					);
+
 					return new MD5Handler;
 				},
 				true
@@ -102,6 +111,15 @@ class Authentication implements ServiceProviderInterface
 				PHPassHandler::class,
 				function (Container $container)
 				{
+					@trigger_error(
+						sprintf(
+							'The "%1$s" class service is deprecated, use the "%2$s" service for the active password handler instead.',
+							PHPassHandler::class,
+							'password.handler.default'
+						),
+						E_USER_DEPRECATED
+					);
+
 					return new PHPassHandler;
 				},
 				true
@@ -112,6 +130,15 @@ class Authentication implements ServiceProviderInterface
 				SHA256Handler::class,
 				function (Container $container)
 				{
+					@trigger_error(
+						sprintf(
+							'The "%1$s" class service is deprecated, use the "%2$s" service for the active password handler instead.',
+							SHA256Handler::class,
+							'password.handler.default'
+						),
+						E_USER_DEPRECATED
+					);
+
 					return new SHA256Handler;
 				},
 				true


### PR DESCRIPTION
### Summary of Changes

Our DI container doesn't have a notion of deprecated services, but, we already have a case where we have services in the container for deprecated classes so we should also have a standard for deprecating services as well.  Therefore, this PR introduces said standard.

### Testing Instructions

Calling `Joomla\CMS\Factory::getContainer()->get('password.handler.sha256');` should result in a deprecation message being logged, note the syntax used is basically the same as used in deprecated methods.