### PR TITLE
[4.0]Checkbox label [a11y]

### DIFF
--- a/libraries/src/Form/Field/CheckboxField.php
+++ b/libraries/src/Form/Field/CheckboxField.php
@@ -146,11 +146,9 @@ class CheckboxField extends FormField
 		$onchange = !empty($this->onchange) ? ' onchange="' . $this->onchange . '"' : '';
 
 		$html = '<div class="form-check">';
-		$html .= '<label class="form-check-label">';
 		$html .= '<input type="checkbox" name="' . $this->name . '" id="' . $this->id . '" value="'
 				. htmlspecialchars($value, ENT_COMPAT, 'UTF-8') . '"' . $class . $checked . $disabled . $onclick . $onchange
 				. $required . $autofocus . '>';
-		$html .= '</label>';
 		$html .= '</div>';
 
 		return $html;


### PR DESCRIPTION
The library file libraries\src\Form\Field\CheckboxField.php generates invalid markup by adding a blank label for the checkbox (the code in the component already creates a valid label)

This blank label is a problem for a11y as it is a label for nothing and as it occurs multiple times on the page assistive technology thinks that there also multiple fields with the same label.

As far as I can see this is only used in mass mail users (/administrator/index.php?option=com_users&view=mail)  for the bcc fields etc

Testing is easiest by viewing the generated source of the page before and after the patch
