### PR TITLE
[4.0] Correct missing constant JPATH_COMPONENT_SITE in mod_languages LanguagesHelper.php

### DIFF
--- a/modules/mod_languages/Helper/LanguagesHelper.php
+++ b/modules/mod_languages/Helper/LanguagesHelper.php
@@ -78,7 +78,7 @@ abstract class LanguagesHelper
 			{
 				// Load component associations
 				$class = str_replace('com_', '', $app->input->get('option')) . 'HelperAssociation';
-				\JLoader::register($class, JPATH_COMPONENT_SITE . '/helpers/association.php');
+				\JLoader::register($class, JPATH_SITE . '/components/' . $component->option . '/helpers/association.php');
 
 				if (class_exists($class) && is_callable(array($class, 'getAssociations')))
 				{


### PR DESCRIPTION
Pull Request for Issue # ?.

### Summary of Changes

This PR replaces the missing `JPATH_COMPONENT_SITE` constant in mod_languages's LanguagesHelper.php by `JPATH_SITE . '/components/' . $component->option`.

The ComponentRecord object is fetched a few lines above with `$component = $app->bootComponent($app->input->get('option'));`

### Testing Instructions

Have a multilingual site with item associations enabled and PHP error reporting set to developer.

Edit an article which is tagged to a particular language.

Check for PHP notices/warnings/errors.

### Expected result

No PHP notice about missing constants in LanguagesHelper.php.

### Actual result

PHP Notice:  Use of undefined constant JPATH_COMPONENT_SITE - assumed 'JPATH_COMPONENT_SITE' in /joomla4home/modules/mod_languages/Helper/LanguagesHelper.php on line 81

### Documentation Changes Required

No.