### PR TITLE
[4.0][fix] getting back edit category tabs + using Text

### DIFF
--- a/administrator/components/com_categories/tmpl/category/edit.php
+++ b/administrator/components/com_categories/tmpl/category/edit.php
@@ -46,7 +46,7 @@ $tmpl    = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=c
 
 	<div>
 		<?php echo HTMLHelper::_('uitab.startTabSet', 'myTab', array('active' => 'general')); ?>
-		<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'general', JText::_('JCATEGORY')); ?>
+		<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'general', Text::_('JCATEGORY')); ?>
 		<div class="row">
 			<div class="col-md-9">
 				<?php echo $this->form->getLabel('description'); ?>
@@ -60,12 +60,12 @@ $tmpl    = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=c
 				</div>
 			</div>
 		</div>
-		<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+
 		<?php echo HTMLHelper::_('uitab.endTab'); ?>
 
 		<?php echo LayoutHelper::render('joomla.edit.params', $this); ?>
 
-		<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'publishing', JText::_('COM_CATEGORIES_FIELDSET_PUBLISHING')); ?>
+		<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'publishing', Text::_('COM_CATEGORIES_FIELDSET_PUBLISHING')); ?>
 		<div class="row">
 			<div class="col-md-6">
 				<?php echo LayoutHelper::render('joomla.edit.publishingdata', $this); ?>
@@ -78,7 +78,7 @@ $tmpl    = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=c
 		<?php echo HTMLHelper::_('uitab.endTab'); ?>
 
 		<?php if ( ! $isModal && $assoc && $extensionassoc) : ?>
-			<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'associations', JText::_('JGLOBAL_FIELDSET_ASSOCIATIONS')); ?>
+			<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'associations', Text::_('JGLOBAL_FIELDSET_ASSOCIATIONS')); ?>
 			<?php echo $this->loadTemplate('associations'); ?>
 			<?php echo HTMLHelper::_('uitab.endTab'); ?>
 		<?php elseif ($isModal && $assoc && $extensionassoc) : ?>
@@ -87,7 +87,7 @@ $tmpl    = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=c
 
 		<?php if ($this->canDo->get('core.admin')) : ?>
 
-			<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'rules', JText::_('COM_CATEGORIES_FIELDSET_RULES')); ?>
+			<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'rules', Text::_('COM_CATEGORIES_FIELDSET_RULES')); ?>
 			<?php echo $this->form->getInput('rules'); ?>
 			<?php echo HTMLHelper::_('uitab.endTab'); ?>
 		<?php endif; ?>


### PR DESCRIPTION
Only the "Category" tab displays when editing a category.
Also, although we already have `use Joomla\CMS\Language\Text;` strings are loaded with `JText`
### Summary of Changes
Taking off an extraneous bootstrap tab code.
Changed JText to Text


### Testing Instructions
Edit a category.

### Before patch
<img width="487" alt="screen shot 2018-07-15 at 18 21 27" src="https://user-images.githubusercontent.com/869724/42735854-f9bb926c-885b-11e8-91b5-711b0137d7e3.png">


### After patch
<img width="642" alt="screen shot 2018-07-15 at 18 10 41" src="https://user-images.githubusercontent.com/869724/42735832-740a746c-885b-11e8-8a84-6bc9c4b5ceb8.png">

simple fix.