### PR TITLE
[4.0]Fixing double translation of Help toolbar button

### DIFF
--- a/libraries/src/Toolbar/Button/HelpButton.php
+++ b/libraries/src/Toolbar/Button/HelpButton.php
@@ -40,7 +40,7 @@ class HelpButton extends BasicButton
 	 */
 	protected function prepareOptions(array &$options)
 	{
-		$options['text'] = $options['text'] ?: Text::_('JTOOLBAR_HELP');
+		$options['text'] = $options['text'] ?: 'JTOOLBAR_HELP';
 		$options['icon'] = $options['icon'] ?? 'fa fa-question';
 		$options['button_class'] = $options['button_class'] ?? 'btn btn-info';
 		$options['onclick'] = $options['onclick'] ?? $this->_getCommand();


### PR DESCRIPTION
### Summary of Changes
Useless Text::_ for the Help Toolbar button = double translation


### Testing Instructions
Set Debug Language in Global Configuration.
Display a Categories Manager page.


### Before patch
<img width="603" alt="screen shot 2018-07-16 at 07 45 32" src="https://user-images.githubusercontent.com/869724/42744511-6565f770-88cd-11e8-9f7c-ffd98b85c6ef.png">




### After patch
<img width="347" alt="screen shot 2018-07-16 at 07 45 55" src="https://user-images.githubusercontent.com/869724/42744506-5c405d8e-88cd-11e8-83d4-c11d09ecc469.png">


Simple fix

### Documentation Changes Required

None