### PR TITLE
[4.0] Fixing wrong newsfeeds call to Feedfactory

### DIFF
--- a/components/com_newsfeeds/View/Newsfeed/HtmlView.php
+++ b/components/com_newsfeeds/View/Newsfeed/HtmlView.php
@@ -15,7 +15,7 @@ use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\Component\Newsfeeds\Site\Helper\Route as NewsfeedsHelperRoute;
 use Joomla\Component\Newsfeeds\Site\Model\CategoryModel;
 use Joomla\CMS\Categories\Categories;
-use Joomla\CMS\Document\Feed\FeedFactory;
+use Joomla\CMS\Feed\FeedFactory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Factory;
 


### PR DESCRIPTION
### Summary of Changes
Corrected
`use Joomla\CMS\Document/Feed\FeedFactory;`
to
`use Joomla\CMS\Feed\FeedFactory;`


### Testing Instructions
Create a newfeed.
Create a single newfeed menu item.
Launch that menu item in frontend.


### Expected result
Newsfeed displays


### Actual result
Error as class is not loaded

### After patch
Newsfeed is correctly loaded.


Simple fix.

