### PR TITLE
[4.0][fix] Correcting wrong multilang urls

### DIFF
--- a/modules/mod_languages/Helper/LanguagesHelper.php
+++ b/modules/mod_languages/Helper/LanguagesHelper.php
@@ -130,7 +130,7 @@ abstract class LanguagesHelper
 				{
 					if (isset($cassociations[$language->lang_code]))
 					{
-						$language->link = Route::_($cassociations[$language->lang_code] . '&lang=' . $language->sef);
+						$language->link = Route::_($cassociations[$language->lang_code]);
 					}
 					elseif (isset($associations[$language->lang_code]) && $menu->getItem($associations[$language->lang_code]))
 					{


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/21132

### Summary of Changes
Route is much stricter in 4.0. Getting twice lang in the url, i.e.`$lang=xx-XX&lang=xx` breaks routing.

### Testing Instructions

Create a multilingual site with the multilingual sample data.
Make sure sef is on. Tested here with url rewriting.
Homes are category menu items per default.
Load frontend home and switch language via the language switcher.

### Before patch
We should get urls of type
`whatever/fr`
`whatever/en`

### Actual result
We get
`/en?view=category&id=8`
and
`/fr?view=category&id=9`

Also, If some article are associated and we have 2 **not associated** single menu items 
The switcher flag for the language in use gives correctly 
`/en/modules-en-gb`
but when switching to the other language, we get
`/fr?view=article&id=13&catid=12`

### After patch
Urls are correctly displaying.

Note: we can't test now for Contacts as we have multiple errors, but **it can be tested for single associated newsfeeds** (their menu items NOT associated) AFTER merging https://github.com/joomla/joomla-cms/pull/21140 OR using last instance of 4-0-dev (not nightly build).

For Newsfeeds categories as well as for Contacts categories, we have a fatal error (Cannot redeclare class) and therefore can't test.

@laoneo @franz-wohlkoenig