### PR TITLE
[4.0][a11y] Content Navigation plugin

### DIFF
--- a/plugins/content/pagenavigation/tmpl/default.php
+++ b/plugins/content/pagenavigation/tmpl/default.php
@@ -14,21 +14,29 @@ use Joomla\CMS\Language\Text;
 
 $lang = Factory::getLanguage(); ?>
 
-<ul class="pagination ml-0">
-<?php if ($row->prev) :
-	$direction = $lang->isRtl() ? 'right' : 'left'; ?>
-	<li class="previous page-item">
-		<a class="hasTooltip page-link" title="<?php echo htmlspecialchars($rows[$location-1]->title); ?>" aria-label="<?php echo Text::sprintf('JPREVIOUS_TITLE', htmlspecialchars($rows[$location-1]->title)); ?>" href="<?php echo $row->prev; ?>" rel="prev">
+<nav class="pagenavigation" role="navigation">
+	<ul class="pagination ml-0">
+	<?php if ($row->prev) :
+		$direction = $lang->isRtl() ? 'right' : 'left'; ?>
+		<li class="previous page-item">
+			<a class="page-link" href="<?php echo $row->prev; ?>" rel="prev">
+			<span class="sr-only">
+				<?php echo Text::sprintf('JPREVIOUS_TITLE', htmlspecialchars($rows[$location-1]->title)); ?>
+			</span>
 			<?php echo '<span class="icon-chevron-' . $direction . '" aria-hidden="true"></span> <span aria-hidden="true">' . $row->prev_label . '</span>'; ?>
-		</a>
-	</li>
-<?php endif; ?>
-<?php if ($row->next) :
-	$direction = $lang->isRtl() ? 'left' : 'right'; ?>
-	<li class="next page-item">
-		<a class="hasTooltip page-link" title="<?php echo htmlspecialchars($rows[$location+1]->title); ?>" aria-label="<?php echo Text::sprintf('JNEXT_TITLE', htmlspecialchars($rows[$location+1]->title)); ?>" href="<?php echo $row->next; ?>" rel="next">
+			</a>
+		</li>
+	<?php endif; ?>
+	<?php if ($row->next) :
+		$direction = $lang->isRtl() ? 'left' : 'right'; ?>
+		<li class="next page-item">
+			<a class="page-link" href="<?php echo $row->next; ?>" rel="next">
+			<span class="sr-only">
+				<?php echo Text::sprintf('JNEXT_TITLE', htmlspecialchars($rows[$location+1]->title)); ?>
+			</span>
 			<?php echo '<span aria-hidden="true">' . $row->next_label . '</span> <span class="icon-chevron-' . $direction . '" aria-hidden="true"></span>'; ?>
-		</a>
-	</li>
-<?php endif; ?>
-</ul>
+			</a>
+		</li>
+	<?php endif; ?>
+	</ul>
+<nav>

--- a/plugins/content/pagenavigation/tmpl/default.php
+++ b/plugins/content/pagenavigation/tmpl/default.php
@@ -14,7 +14,7 @@ use Joomla\CMS\Language\Text;
 
 $lang = Factory::getLanguage(); ?>
 
-<nav class="pagenavigation" role="navigation">
+<nav class="pagenavigation">
 	<ul class="pagination ml-0">
 	<?php if ($row->prev) :
 		$direction = $lang->isRtl() ? 'right' : 'left'; ?>


### PR DESCRIPTION
This pr adds the role navigation to the next and previous buttons to the single article view when the content navigation plugin is enabled. It also ensures that the article title is announced to the screenreader. I added a class to the nav to assist with future styling although its not got any right now.