### PR TITLE
[4.0] Fix hard coded class attribute in select.groupedlist, also causing invalid HTML markup

### DIFF
--- a/libraries/cms/html/select.php
+++ b/libraries/cms/html/select.php
@@ -219,7 +219,7 @@ abstract class JHtmlSelect
 
 		$baseIndent = str_repeat($options['format.indent'], $options['format.depth']++);
 		$html = $baseIndent . '<select' . ($id !== '' ? ' id="' . $id . '"' : '')
-				. ' name="' . $name . '"' . $attribs . ' class="custom-select">' . $options['format.eol'];
+				. ' name="' . $name . '"' . $attribs . '>' . $options['format.eol'];
 		$groupIndent = str_repeat($options['format.indent'], $options['format.depth']++);
 
 		foreach ($data as $dataKey => $group)


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Remove hard coded class attribute from `JHtml('select.groupedlist', ...`


### Testing Instructions
Code review


### Expected result
Hard coded class attribute for select.groupedlist does not exist


### Actual result
Hard coded class attribute for select.groupedlist exists

Why remove it ?

- it is hard coded
- it causes invalid HTML when given custom class attribute
- it does not exist in J3
- it does not exist for select.list , not even in J4

If anyone suggests to add it as a default value , yes it is easy, but i will not do it, because it is rather wrong

no reason to introduce a hard code styling in the library that is 
- neither really needed, 
- nor is J4 yet released to call it a B/C break or similar


### Documentation Changes Required

None

