### PR TITLE
[4.0] [Validation] Fix backend menu items with role="menuitem" not placed inside element with role="menu"

### DIFF
--- a/administrator/modules/mod_menu/tmpl/default.php
+++ b/administrator/modules/mod_menu/tmpl/default.php
@@ -26,7 +26,7 @@ $root     = $menuTree->reset();
 if ($root->hasChildren())
 {
 	echo '<div class="main-nav-container" role="navigation" aria-label="Main menu">';
-	echo '<ul id="menu" class="' . $class . '" role="menubar">' . "\n";
+	echo '<ul id="menu" class="' . $class . '" role="menu">' . "\n";
 	echo '<li role="menuitem">';
 	echo '<a id="menu-collapse" href="#">';
 	echo '<span id="menu-collapse-icon" class="fa-fw fa fa-toggle-off" aria-hidden="true"></span>';

--- a/administrator/modules/mod_menu/tmpl/default.php
+++ b/administrator/modules/mod_menu/tmpl/default.php
@@ -26,7 +26,7 @@ $root     = $menuTree->reset();
 if ($root->hasChildren())
 {
 	echo '<div class="main-nav-container" role="navigation" aria-label="Main menu">';
-	echo '<ul id="menu" class="' . $class . '">' . "\n";
+	echo '<ul id="menu" class="' . $class . '" role="menubar">' . "\n";
 	echo '<li role="menuitem">';
 	echo '<a id="menu-collapse" href="#">';
 	echo '<span id="menu-collapse-icon" class="fa-fw fa fa-toggle-off" aria-hidden="true"></span>';


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Backend menu items with role="menuitem" should be placed inside element with role="menubar" or role="menu"


### Testing Instructions
1. Code review
2. Validate backend, no more errors like:

> An element with “role=menuitem” must be contained in, or owned by, an element with “role=menubar” or “role=menu”


### Expected result
No error about “role=menubar” or “role=menu” missing


### Actual result
The above error


### Documentation Changes Required
None


