### PR TITLE
The JPATH_ constants are not magic strings

### DIFF
--- a/administrator/components/com_contact/models/contact.php
+++ b/administrator/components/com_contact/models/contact.php
@@ -267,7 +267,7 @@ class ContactModelContact extends JModelAdmin
 	 */
 	public function getForm($data = array(), $loadData = true)
 	{
-		JForm::addFieldPath('JPATH_ADMINISTRATOR/components/com_users/models/fields');
+		JForm::addFieldPath(JPATH_ADMINISTRATOR . '/components/com_users/models/fields');
 
 		// Get the form.
 		$form = $this->loadForm('com_contact.contact', 'contact', array('control' => 'jform', 'load_data' => $loadData));


### PR DESCRIPTION
### Summary of Changes

Apparently it was intended for the admin com_contact contact view to import fields from the admin com_users component.  This has never worked because the `JPATH_ADMINISTRATOR` constant has been referenced as a string instead of a constant.  I honestly have no idea if the call is even needed, but the code is so obviously broken.

### Testing Instructions

Review the code.  If you're brave, wire up a debugger to check the contents of `Joomla\CMS\Form\FormHelper::$paths` before and after the patch on the contact edit page.