### PR TITLE
[3.9] Use the new link helper to generate links for specific app

### DIFF
--- a/administrator/components/com_messages/models/message.php
+++ b/administrator/components/com_messages/models/message.php
@@ -358,9 +358,11 @@ class MessagesModelMessage extends JModelAdmin
 			$lang->load('com_messages', JPATH_ADMINISTRATOR);
 
 			// Build the email subject and message
-			$sitename = JFactory::getApplication()->get('sitename');
+			$app      = JFactory::getApplication();
+			$linkMode = $app->get('force_ssl', 0) >= 1 ? 1 : -1;
+			$sitename = $app->get('sitename');
 			$fromName = $fromUser->get('name');
-			$siteURL  = JUri::root() . 'administrator/index.php?option=com_messages&view=message&message_id=' . $table->message_id;
+			$siteURL  = JRoute::link('administrator', 'index.php?option=com_messages&view=message&message_id=' . $table->message_id, true, $linkMode);
 			$subject  = html_entity_decode($table->subject, ENT_COMPAT, 'UTF-8');
 			$message  = strip_tags(html_entity_decode($table->message, ENT_COMPAT, 'UTF-8'));
 

--- a/components/com_users/models/registration.php
+++ b/components/com_users/models/registration.php
@@ -94,22 +94,14 @@ class UsersModelRegistration extends JModelForm
 		// Admin activation is on and user is verifying their email
 		if (($userParams->get('useractivation') == 2) && !$user->getParam('activate', 0))
 		{
-			$uri = JUri::getInstance();
+			$linkMode = $config->get('force_ssl', 0) == 2 ? 1 : -1;
 
 			// Compile the admin notification mail values.
 			$data = $user->getProperties();
 			$data['activation'] = JApplicationHelper::getHash(JUserHelper::genRandomPassword());
 			$user->set('activation', $data['activation']);
 			$data['siteurl'] = JUri::base();
-			$base = $uri->toString(array('scheme', 'user', 'pass', 'host', 'port'));
-			$data['activate'] = $base . JRoute::_('index.php?option=com_users&task=registration.activate&token=' . $data['activation'], false);
-
-			// Remove administrator/ from activate URL in case this method is called from admin
-			if (JFactory::getApplication()->isClient('administrator'))
-			{
-				$adminPos         = strrpos($data['activate'], 'administrator/');
-				$data['activate'] = substr_replace($data['activate'], '', $adminPos, 14);
-			}
+			$data['activate'] = JRoute::link('site', 'index.php?option=com_users&task=registration.activate&token=' . $data['activation'], false, $linkMode);
 
 			$data['fromname'] = $config->get('fromname');
 			$data['mailfrom'] = $config->get('mailfrom');
@@ -464,16 +456,9 @@ class UsersModelRegistration extends JModelForm
 		if ($useractivation == 2)
 		{
 			// Set the link to confirm the user email.
-			$uri = JUri::getInstance();
-			$base = $uri->toString(array('scheme', 'user', 'pass', 'host', 'port'));
-			$data['activate'] = $base . JRoute::_('index.php?option=com_users&task=registration.activate&token=' . $data['activation'], false);
+			$linkMode = $config->get('force_ssl', 0) == 2 ? 1 : -1;
 
-			// Remove administrator/ from activate URL in case this method is called from admin
-			if (JFactory::getApplication()->isClient('administrator'))
-			{
-				$adminPos         = strrpos($data['activate'], 'administrator/');
-				$data['activate'] = substr_replace($data['activate'], '', $adminPos, 14);
-			}
+			$data['activate'] = JRoute::link('site', 'index.php?option=com_users&task=registration.activate&token=' . $data['activation'], false, $linkMode);
 
 			$emailSubject = JText::sprintf(
 				'COM_USERS_EMAIL_ACCOUNT_DETAILS',
@@ -508,16 +493,9 @@ class UsersModelRegistration extends JModelForm
 		elseif ($useractivation == 1)
 		{
 			// Set the link to activate the user account.
-			$uri = JUri::getInstance();
-			$base = $uri->toString(array('scheme', 'user', 'pass', 'host', 'port'));
-			$data['activate'] = $base . JRoute::_('index.php?option=com_users&task=registration.activate&token=' . $data['activation'], false);
+			$linkMode = $config->get('force_ssl', 0) == 2 ? 1 : -1;
 
-			// Remove administrator/ from activate URL in case this method is called from admin
-			if (JFactory::getApplication()->isClient('administrator'))
-			{
-				$adminPos         = strrpos($data['activate'], 'administrator/');
-				$data['activate'] = substr_replace($data['activate'], '', $adminPos, 14);
-			}
+			$data['activate'] = JRoute::link('site', 'index.php?option=com_users&task=registration.activate&token=' . $data['activation'], false, $linkMode);
 
 			$emailSubject = JText::sprintf(
 				'COM_USERS_EMAIL_ACCOUNT_DETAILS',


### PR DESCRIPTION
### Summary of Changes

With `Joomla\CMS\Router\Route::link()` introduced in 3.9, we should use it to generate links for a specific application as requested instead of doing other random craziness to build links.  And that's what this PR does.

### Testing Instructions

- Go through user registration with the need to activate accounts, the links in the emails sent after activation should be generated correctly
- Do something that saves a message to `com_messages`, the link for the email should be generated correctly