### PR TITLE
[4.0] Fixing multilang alternate urls

### DIFF
--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -822,7 +822,7 @@ class PlgSystemLanguageFilter extends CMSPlugin
 
 					// Component association
 					case (isset($cassociations[$i])):
-						$language->link = Route::_($cassociations[$i] . '&lang=' . $language->sef);
+						$language->link = Route::_($cassociations[$i]);
 						break;
 
 					// Menu items association


### PR DESCRIPTION
Patch similar to https://github.com/joomla/joomla-cms/pull/21141

### Summary of Changes
Correcting alternate urls.
Route is much stricter in 4.0. Getting twice lang in the url, i.e.$lang=xx-XX&lang=xx breaks routing.

### Testing Instructions
Create a multilingual site with the multilingual sample data.
Make sure sef is on.
Homes are category menu items per default.
Create 1 article in each language and associate them.
Create single article menu items for these 2 articles and DO NOT associate them.
In front end load one of the articles menu items.
Look at source.


### Before patch
my single article menu items aliases are 
`modules-fr-fr` and `modules-en-gb`
```
<link href="http://localhost:8888/installmulti/joomla40/index.php/fr?view=article&amp;id=13&amp;catid=12" rel="alternate" hreflang="fr-FR">
<link href="http://localhost:8888/installmulti/joomla40/index.php/en/modules-en-gb" rel="alternate" hreflang="en-GB">
```

### After patch
```
<link href="http://localhost:8888/installmulti/joomla40/index.php/fr/modules-fr-fr" rel="alternate" hreflang="fr-FR">
<link href="http://localhost:8888/installmulti/joomla40/index.php/en/modules-en-gb" rel="alternate" hreflang="en-GB">
```

@franz-wohlkoenig @wilsonge @laoneo 
### Documentation Changes Required
None.
