### PR TITLE
[4.0] Remove placeholder tag

### DIFF
--- a/administrator/components/com_content/forms/filter_featured.xml
+++ b/administrator/components/com_content/forms/filter_featured.xml
@@ -60,9 +60,7 @@
 			class="multipleTags"
 			mode="nested"
 			onchange="this.form.submit();"
-			>
-			<option value="">JOPTION_SELECT_TAG</option>
-		</field>
+		/>
 
 		<field
 			name="level"


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This removes placeholder tag from tag filter field in Featured Articles view. It was removed with #17668 but stayed in 4.0 by mistake. Merge on review.