### PR TITLE
Media manager doesn't obey relative pathes for video files

### DIFF
--- a/administrator/components/com_media/views/medialist/tmpl/thumbs_videos.php
+++ b/administrator/components/com_media/views/medialist/tmpl/thumbs_videos.php
@@ -39,7 +39,7 @@ jQuery(document).ready(function($){
 
 		<div class="small">
 			<a class="video-preview" href="<?php echo COM_MEDIA_BASEURL, '/', rawurlencode($video->name); ?>" title="<?php echo $this->escape($video->name); ?>">
-				<?php echo JHtml::_('string.truncate', $this->escape($video->name), 10, false); ?>
+				<?php echo JHtml::_('string.truncate', $this->escape($video->path_relative), 10, false); ?>
 			</a>
 		</div>
 	</li>

--- a/administrator/components/com_media/views/medialist/tmpl/thumbs_videos.php
+++ b/administrator/components/com_media/views/medialist/tmpl/thumbs_videos.php
@@ -38,8 +38,8 @@ jQuery(document).ready(function($){
 		</div>
 
 		<div class="small">
-			<a class="video-preview" href="<?php echo COM_MEDIA_BASEURL, '/', rawurlencode($video->name); ?>" title="<?php echo $this->escape($video->name); ?>">
-				<?php echo JHtml::_('string.truncate', $this->escape($video->path_relative), 10, false); ?>
+			<a class="video-preview" href="<?php echo COM_MEDIA_BASEURL, '/', rawurlencode($video->path_relative); ?>" title="<?php echo $this->escape($video->name); ?>">
+				<?php echo JHtml::_('string.truncate', $this->escape($video->name), 10, false); ?>
 			</a>
 		</div>
 	</li>


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/21145 .

### Summary of Changes



### Testing Instructions

- Make sure video files can be uploaded (legal extensions, MIME times). Let's the media folder is www.mysite/mymedia
- Create any sub-folder in main Media folder (for example 'myvideos')
- Upload a video to this new folder, so the correct location is www.mysite/mymedia/myvideo/myvideo.mp4.
 - Hover the mouse, notice that the lacking sub-folder part (www.mysite/mymedia/myvideo.mp4)
- Try to click the preview link, get the error about file not existing or not supported format.
- Apply patch and repeat above steps
### Expected result
The link to the video file should be resolved to the correct location like for images ( www.mysite/ymedia/myvideo/myvideo.mp4 )
### Actual result
The link is broken (lacks the sub-folder part) ( www.mysite/mymedia/myvideo.mp4 )


### Documentation Changes Required
no

@tonypartridge @Codereamp please test.

