### PR TITLE
[4.0] System menu incorrect link

### DIFF
--- a/administrator/components/com_cpanel/View/System/HtmlView.php
+++ b/administrator/components/com_cpanel/View/System/HtmlView.php
@@ -103,7 +103,7 @@ class HtmlView extends BaseHtmlView
 			$links['MOD_MENU_TEMPLATES'] = [
 				'com_templates' => static::arrayBuilder(
 					'MOD_MENU_TEMPLATE_SITE_TEMPLATES',
-					'index.php?option=com_templates&client_id=0',
+					'index.php?option=com_templates&view=templates&client_id=0',
 					'edit'
 				),
 				'com_templates_site_styles' => static::arrayBuilder(


### PR DESCRIPTION
The link to the Site templates in the new system menu was incorrect