### PR TITLE
[4.0] Fixing Edit Contact: Associations tab form and normalise catid field

### DIFF
--- a/administrator/components/com_contact/forms/contact.xml
+++ b/administrator/components/com_contact/forms/contact.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <form>
 
-	<fieldset addfieldprefix="Joomla\Component\Categories\Administrator\Field">
+	<fieldset addfieldprefix="Joomla\Component\Contact\Administrator\Field">
 
 		<field
 			name="id"
@@ -63,9 +63,9 @@
 		<field
 			name="catid"
 			type="categoryedit"
-			class="advancedSelect"
 			label="JCATEGORY"
 			extension="com_contact"
+			addfieldprefix="Joomla\Component\Categories\Administrator\Field"
 			required="true"
 			default=""
 		/>

--- a/administrator/components/com_contact/tmpl/contact/edit.php
+++ b/administrator/components/com_contact/tmpl/contact/edit.php
@@ -21,7 +21,7 @@ HTMLHelper::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
 HTMLHelper::_('behavior.formvalidator');
 HTMLHelper::_('behavior.keepalive');
-HTMLHelper::_('formbehavior.chosen', '.advancedSelect', null, array('disable_search_threshold' => 0 ));
+HTMLHelper::_('formbehavior.chosen', '#jform_catid', null, array('disable_search_threshold' => 0 ));
 
 $app = Factory::getApplication();
 $input = $app->input;


### PR DESCRIPTION
### Steps to reproduce the issue
Create a multilingual site. Make sure Associations are set (use multilingual sample data)
Create a contact (assign a language, save, NOT save and close)
Click on the Associations tab.

### Summary of Changes
The contact.xml was not loading the modal_contact field
The catid field was different than the equivalent Newsfeed one 


### Expected result
Similar to Newsfeed, i.e.
<img width="795" alt="screen shot 2018-07-17 at 15 44 17" src="https://user-images.githubusercontent.com/869724/42821207-53530d5a-89d8-11e8-8364-c5e545313a45.png">



### Actual result
<img width="639" alt="screen shot 2018-07-17 at 15 38 33" src="https://user-images.githubusercontent.com/869724/42821145-2d74814a-89d8-11e8-81b7-8ad746f0e50a.png">



### After patch
<img width="732" alt="screen shot 2018-07-17 at 16 32 02" src="https://user-images.githubusercontent.com/869724/42823889-fdc2c946-89de-11e8-9cc6-2f5701b683e4.png">

### Documentation Changes Required
None.
