### PR TITLE
[com_content] Redundant access check

### DIFF
--- a/administrator/components/com_content/models/articles.php
+++ b/administrator/components/com_content/models/articles.php
@@ -412,7 +412,6 @@ class ContentModelArticles extends JModelList
 
 	/**
 	 * Method to get a list of articles.
-	 * Overridden to add a check for access levels.
 	 *
 	 * @return  mixed  An array of data items on success, false on failure.
 	 *
@@ -421,20 +420,6 @@ class ContentModelArticles extends JModelList
 	public function getItems()
 	{
 		$items = parent::getItems();
-
-		if (JFactory::getApplication()->isClient('site'))
-		{
-			$groups = JFactory::getUser()->getAuthorisedViewLevels();
-
-			foreach (array_keys($items) as $x)
-			{
-				// Check the access level. Remove articles the user shouldn't see
-				if (!in_array($items[$x]->access, $groups))
-				{
-					unset($items[$x]);
-				}
-			}
-		}
 
 		return $items;
 	}

--- a/administrator/components/com_content/models/articles.php
+++ b/administrator/components/com_content/models/articles.php
@@ -419,8 +419,6 @@ class ContentModelArticles extends JModelList
 	 */
 	public function getItems()
 	{
-		$items = parent::getItems();
-
-		return $items;
+		return parent::getItems();
 	}
 }

--- a/administrator/components/com_content/models/articles.php
+++ b/administrator/components/com_content/models/articles.php
@@ -409,16 +409,4 @@ class ContentModelArticles extends JModelList
 		// Return the result
 		return $db->loadObjectList();
 	}
-
-	/**
-	 * Method to get a list of articles.
-	 *
-	 * @return  mixed  An array of data items on success, false on failure.
-	 *
-	 * @since   1.6.1
-	 */
-	public function getItems()
-	{
-		return parent::getItems();
-	}
 }


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This removes redundant access check from admin Articles model.

### Testing Instructions
Code review. See that we already filter by access in the query:

https://github.com/joomla/joomla-cms/blob/88bcd98c74063253b3427bc34f06fedabb48aed2/administrator/components/com_content/models/articles.php#L250-L256

Alternatively, you can check that this snippet (placed somehwere in frontend/site, e.g. in Protostar index file) doesn't return unauthorized articles. Where `$accessLevel` is some access level ID:
```
JModelLegacy::addIncludePath(JPATH_ADMINISTRATOR . '/components/com_content/models', 'ContentModel');
$model = JModelLegacy::getInstance('Articles', 'ContentModel', array('ignore_request' => true));
$model->setState('params',  JFactory::getApplication()->getParams());
$model->setState('filter.access', $accessLevel);
$articles = $model->getItems();
var_dump($articles);
```
### Documentation Changes Required
No.