### PR TITLE
[4.0] Migration JFilterInput to InputFilter for File

### DIFF
--- a/libraries/src/Filesystem/File.php
+++ b/libraries/src/Filesystem/File.php
@@ -13,6 +13,7 @@ defined('JPATH_PLATFORM') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Log\Log;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\Filesystem\Path;
 use Joomla\CMS\Filesystem\Wrapper\PathWrapper;
 use Joomla\CMS\Filesystem\Wrapper\FolderWrapper;
@@ -522,7 +523,7 @@ class File
 	 * @param   string   $dest             The path (including filename) to move the uploaded file to
 	 * @param   boolean  $use_streams      True to use streams
 	 * @param   boolean  $allow_unsafe     Allow the upload of unsafe files
-	 * @param   boolean  $safeFileOptions  Options to JFilterInput::isSafeFile
+	 * @param   boolean  $safeFileOptions  Options to InputFilter::isSafeFile
 	 *
 	 * @return  boolean  True on success
 	 *
@@ -540,7 +541,7 @@ class File
 				'size'     => '',
 			);
 
-			$isSafe = JFilterInput::isSafeFile($descriptor, $safeFileOptions);
+			$isSafe = InputFilter::isSafeFile($descriptor, $safeFileOptions);
 
 			if (!$isSafe)
 			{


### PR DESCRIPTION
Pull Request for Issue (not reported yet) .

### Summary of Changes

The class JFilterInput is no more, the call to isSafeFile needs to be updated to Joomla\CMS\Filter\InputFilter;

### Testing Instructions

Call the File::upload function with parameter $allow_unsafe "false" (which is the default value).

### Expected result

The function isSafeFile will be called.

### Actual result

A fatal error will raise due to the missing JInputFilter class.

### Documentation Changes Required

None