### PR TITLE
Remove if/else in user debug models that can never hit else conditions

### DIFF
--- a/administrator/components/com_users/models/debuggroup.php
+++ b/administrator/components/com_users/models/debuggroup.php
@@ -78,19 +78,8 @@ class UsersModelDebuggroup extends JModelList
 				foreach ($actions as $action)
 				{
 					$name = $action[0];
-					$level = $action[1];
 
-					// Check that we check this action for the level of the asset.
-					if ($level === null || $level >= $asset->level)
-					{
-						// We need to test this action.
-						$asset->checks[$name] = JAccess::checkGroup($groupId, $name, $asset->name);
-					}
-					else
-					{
-						// We ignore this action.
-						$asset->checks[$name] = 'skip';
-					}
+					$asset->checks[$name] = JAccess::checkGroup($groupId, $name, $asset->name);
 				}
 			}
 		}

--- a/administrator/components/com_users/models/debuguser.php
+++ b/administrator/components/com_users/models/debuguser.php
@@ -79,19 +79,8 @@ class UsersModelDebugUser extends JModelList
 				foreach ($actions as $action)
 				{
 					$name = $action[0];
-					$level = $action[1];
 
-					// Check that we check this action for the level of the asset.
-					if ($level === null || $level >= $asset->level)
-					{
-						// We need to test this action.
-						$asset->checks[$name] = $user->authorise($name, $asset->name);
-					}
-					else
-					{
-						// We ignore this action.
-						$asset->checks[$name] = 'skip';
-					}
+					$asset->checks[$name] = $user->authorise($name, $asset->name);
 				}
 			}
 		}


### PR DESCRIPTION
### Summary of Changes

Once upon a time, the debug user and debug group views were short circuited to be able to skip access checks for certain levels of the ACL tree.  However, since [the commit](https://github.com/joomla/joomla-cms/commit/5d4746a41dc7f0ebaff77d9a0221106f51d9349d) for [JoomlaCode item 22868](https://developer.joomla.org/joomlacode-archive/issue-22868.html) this short circuiting was broken because the arrays that are being processed went from an array of action name and level to action name and description.

So, when you actually get to the part of the models that is changed here, essentially you're doing an if check on "is the ACL tree level greater than or equal to zero" (code example: https://3v4l.org/7Pprh).  Unless your `#__assets` table is a level beyond FUBAR than anything I've ever seen, this condition is always going to be true.  Therefore, we can remove the dead code.

### Testing Instructions

The debug user and debug group reports still generate correct reports.

// @wilsonge 