### PR TITLE
[4.0] [a11y] Required field

### DIFF
--- a/layouts/joomla/form/renderlabel.php
+++ b/layouts/joomla/form/renderlabel.php
@@ -58,5 +58,5 @@ if ($required)
 
 ?>
 <label id="<?php echo $id; ?>" for="<?php echo $for; ?>"<?php if (!empty($classes)) echo ' class="' . implode(' ', $classes) . '"'; ?><?php echo $title; ?><?php echo $position; ?>>
-	<?php echo $text; ?><?php if ($required) : ?><span class="star">&#160;*</span><?php endif; ?>
+	<?php echo $text; ?><?php if ($required) : ?><span class="star" aria-hidden="true">&#160;*</span><?php endif; ?>
 </label>


### PR DESCRIPTION
When a field is required we add a star to field label as a visual indicator
There is no need for an extra indicator for screenreaders as that relies on the required attribute on the field

Currently when a screenreader gets to a required field it announces the field as "Name star"
Obviously the star is not part of the field name so this super simple pr hides the star from screenreaders.

There are many techniques that could be used to do this but with our current codebase this is the absolute simplest method to adopt
