### PR TITLE
[4.0] [a11y] Toggle Editor button

### DIFF
--- a/layouts/joomla/tinymce/togglebutton.php
+++ b/layouts/joomla/tinymce/togglebutton.php
@@ -16,12 +16,12 @@ $name = $displayData;
 ?>
 <div class="toggle-editor btn-toolbar float-right clearfix mt-3">
 	<div class="btn-group">
-		<a class="btn btn-secondary" href="#"
+		<button type="button" class="btn btn-secondary" href="#"
 			onclick="tinyMCE.execCommand('mceToggleEditor', false, '<?php echo $name; ?>');return false;"
 			title="<?php echo Text::_('PLG_TINY_BUTTON_TOGGLE_EDITOR'); ?>"
 		>
 			<span class="icon-eye" aria-hidden="true"></span>
 			<?php echo Text::_('PLG_TINY_BUTTON_TOGGLE_EDITOR'); ?>
-		</a>
+		</button>
 	</div>
 </div>


### PR DESCRIPTION
This is a clear example of something that should be a button and not an "a" styled as a button.

In some cases it is ok to add a role=button to an "a" but there is one issue with that technique - an "a" only responds to an enter key. a button responds to an enter and a space. So if you use an "a" you have to add something to monitor the space. (http://www.last-child.com/keyboard-accessibility-with-the-space-bar/)

In this specific case it is super easy to change from an "a" to a "button"

To test make sure the toggle editor button still works. You can also test if it can be activated by tabbing to it and then selecting with either the space or the enter keys.