### PR TITLE
[4.0] [a11y] control panel table modules

### DIFF
--- a/administrator/modules/mod_latest/tmpl/default.php
+++ b/administrator/modules/mod_latest/tmpl/default.php
@@ -14,9 +14,7 @@ use Joomla\CMS\HTML\HTMLHelper;
 
 ?>
 <table class="table table-striped" id="<?php echo str_replace(' ', '', $module->title) . $module->id; ?>">
-	<?php if (!$module->showtitle) : ?>
-		<caption class="sr-only"><?php echo $module->title; ?></caption>
-	<?php endif; ?>
+	<caption class="sr-only"><?php echo $module->title; ?></caption>
 	<thead>
 		<tr>
 			<th scope="col" style="width:60%"><?php echo Text::_('JGLOBAL_TITLE'); ?></th>

--- a/administrator/modules/mod_logged/tmpl/default.php
+++ b/administrator/modules/mod_logged/tmpl/default.php
@@ -14,9 +14,7 @@ use Joomla\CMS\HTML\HTMLHelper;
 
 ?>
 <table class="table table-striped" id="<?php echo str_replace(' ', '', $module->title) . $module->id; ?>">
-	<?php if (!$module->showtitle) : ?>
-		<caption class="sr-only"><?php echo $module->title; ?></caption>
-	<?php endif; ?>
+	<caption class="sr-only"><?php echo $module->title; ?></caption>
 	<thead>
 		<tr>
 			<th scope="col" style="width:50%">

--- a/administrator/modules/mod_popular/tmpl/default.php
+++ b/administrator/modules/mod_popular/tmpl/default.php
@@ -14,9 +14,7 @@ use Joomla\CMS\Language\Text;
 
 ?>
 <table class="table table-striped" id="<?php echo str_replace(' ', '', $module->title) . $module->id; ?>">
-	<?php if (!$module->showtitle) : ?>
-		<caption class="sr-only"><?php echo $module->title; ?></caption>
-	<?php endif; ?>
+	<caption class="sr-only"><?php echo $module->title; ?></caption>
 	<thead>
 		<tr>
 			<th scope="col" style="width:2%"><?php echo Text::_('JGLOBAL_HITS'); ?></th>


### PR DESCRIPTION
In #20962 I changed the latest, logged, and popular modules from lists to tables to improve a11y

I did add a caption for the table but only for when the module heading was not displayed - this was wrong

When using a screen reader such as nvda you can navigate between tables by pressing the T key. When you do this the heading is not announced as it is before the table - so the user does not know what the purpose of the table is.

This PR makes the table caption always available so that when navigating with the T key the user will know the purpose of the table.
