### PR TITLE
[4.0] Notices when uninstalling a language pack

### DIFF
--- a/libraries/src/Installer/Adapter/LanguageAdapter.php
+++ b/libraries/src/Installer/Adapter/LanguageAdapter.php
@@ -119,7 +119,7 @@ class LanguageAdapter extends InstallerAdapter
 		{
 			$registry = new Registry($user->params);
 
-			if ($registry->get($param_name) === $element)
+			if ($registry->get($param_name) === $this->extension->element)
 			{
 				$registry->set($param_name, '');
 				$query->clear()

--- a/libraries/src/Installer/Adapter/PackageAdapter.php
+++ b/libraries/src/Installer/Adapter/PackageAdapter.php
@@ -416,6 +416,7 @@ class PackageAdapter extends InstallerAdapter
 	protected function removeExtensionFiles()
 	{
 		$manifest = new PackageManifest(JPATH_MANIFESTS . '/packages/' . $this->extension->element . '.xml');
+		$error = false;
 
 		foreach ($manifest->filelist as $extension)
 		{


### PR DESCRIPTION
Pull Request for Issue #21153 .

### Summary of Changes
Fix some undefined variables in the installer

### Testing Instructions
Install a language pack (German, French or Persian are available through Install Languages)
Then go to Extensions : Manage and uninstall the pack

### Expected result
Pack is correctly uninstalled.
Notices in php logs

### Actual result
[17-Jul-2018 07:27:54 Europe/Berlin] PHP Notice:  Undefined variable: element in /Applications/MAMP/htdocs/installmulti/joomla40/libraries/src/Installer/Adapter/LanguageAdapter.php on line 122
[17-Jul-2018 07:27:54 Europe/Berlin] PHP Notice:  Undefined variable: element in /Applications/MAMP/htdocs/installmulti/joomla40/libraries/src/Installer/Adapter/LanguageAdapter.php on line 122
[17-Jul-2018 07:27:54 Europe/Berlin] PHP Notice:  Undefined variable: error in /Applications/MAMP/htdocs/installmulti/joomla40/libraries/src/Installer/Adapter/PackageAdapter.php on line 445

Note these variables won't show on screen because of the redirect - you'll need to either add breakpoints or check your php error log