### PR TITLE
[4.0][a11y] Content Navigation plugin fix

### DIFF
--- a/plugins/content/pagenavigation/tmpl/default.php
+++ b/plugins/content/pagenavigation/tmpl/default.php
@@ -39,4 +39,4 @@ $lang = Factory::getLanguage(); ?>
 		</li>
 	<?php endif; ?>
 	</ul>
-<nav>
+</nav>


### PR DESCRIPTION
In #21144 I made a mistake and instead of putting a closing nav tag I put another open tag

Oops
