### PR TITLE
[4.0] Use the external-link icon in the backend login page

### DIFF
--- a/administrator/templates/atum/login.php
+++ b/administrator/templates/atum/login.php
@@ -85,7 +85,7 @@ $this->setMetaData('theme-color', '#1c3d5c');
 				<?php // End Content ?>
 			</div>
 			<div class="mt-4 d-none d-md-flex justify-content-between">
-				<a href="<?php echo Uri::root(); ?>" target="_blank" class="text-white"><span class="fa fa-eye mr-1" aria-hidden="true"></span><?php echo Text::_('TPL_ATUM_VIEW_SITE'); ?></a>
+				<a href="<?php echo Uri::root(); ?>" target="_blank" class="text-white"><span class="fa fa-external-link mr-1" aria-hidden="true"></span><?php echo Text::_('TPL_ATUM_VIEW_SITE'); ?></a>
 				<span class="text-white">&nbsp;&copy; <?php echo date('Y'); ?> <?php echo $sitename; ?></span>
 			</div>
 		</div>


### PR DESCRIPTION
The backend login page shows an eye icon together with a link to the home page. 

![login-with-eye-icon](https://user-images.githubusercontent.com/1035262/43045717-23bf9024-8dbe-11e8-8c49-01b6034684a0.PNG)

This PR replaces the eye icon by the external-link icon, which is also used in the top right corner of every backend view. 

![login-with-link-icon](https://user-images.githubusercontent.com/1035262/43045718-29e61c0c-8dbe-11e8-9fc1-92389d796db1.PNG):

### Documentation Changes Required
Yes, screen is changed
