### PR TITLE
[4.0] Define required engine versions for Node/NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
     "type": "git",
     "url": "https://github.com/joomla/joomla-cms.git"
   },
+  "engines": {
+    "node": ">=8.9.4",
+    "npm": ">=5.6.0"
+  },
   "scripts": {
     "build:js": "node build.js --compilejs",
     "build:css": "node build.js --compilecss",


### PR DESCRIPTION
### Summary of Changes

Defines required versions of Node and NPM for the repo.  Note this is purposefully very conservative so as to not force onto bleeding edge (remember some of us actually use Node and NPM outside of Joomla 😉) but relatively new enough to ensure key features are consistently available (such as the lock file).

### Testing Instructions

Review