### PR TITLE
[4.0] Fatal error in PreviewHelper

### DIFF
--- a/administrator/components/com_content/Helper/PreviewHelper.php
+++ b/administrator/components/com_content/Helper/PreviewHelper.php
@@ -9,10 +9,6 @@
 
 namespace Joomla\Component\Content\Administrator\Helper;
 
-use Joomla\CMS\Factory;
-use Joomla\CMS\Language\Multilanguage;
-use Joomla\CMS\Uri\Uri;
-
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Multilanguage;


### PR DESCRIPTION
Correcting fatal error caused by https://github.com/joomla/joomla-cms/pull/19866

### Summary of Changes
using twice use...


### To reproduce, 
try to edit an article (my test is on a multilang site)

can be merged on review

@laoneo @wilsonge 