### PR TITLE
Fix for 403 error on session timeout Updated #15839

### DIFF
--- a/libraries/cms/html/menu.php
+++ b/libraries/cms/html/menu.php
@@ -235,8 +235,6 @@ abstract class JHtmlMenu
 		return $ordering;
 	}
 
-	/**
-	 * Build the multiple select list for Menu Links/Pages
 	 /**
 	 * Set the user property
 	 *
@@ -244,13 +242,17 @@ abstract class JHtmlMenu
 	 *
 	 * @return  JMenu  The menu object if the user property has been set or null
 	 *
-	 * @since   3.7.1
+	 * @since   __DEPLOY_VERSION__
 	 */
 	public function setUser(JUser $user)
 	{
 		$this->user = $user;
+
 		return $this;
 	}
+
+	/**
+	 * Build the multiple select list for Menu Links/Pages
 	 * @param   boolean  $all         True if all can be selected
 	 * @param   boolean  $unassigned  True if unassigned can be selected
 	 * @param   int      $clientId    The client id

--- a/libraries/cms/html/menu.php
+++ b/libraries/cms/html/menu.php
@@ -237,7 +237,20 @@ abstract class JHtmlMenu
 
 	/**
 	 * Build the multiple select list for Menu Links/Pages
+	 /**
+	 * Set the user property
 	 *
+	 * @param   JUser  $user  The user object
+	 *
+	 * @return  JMenu  The menu object if the user property has been set or null
+	 *
+	 * @since   3.7.1
+	 */
+	public function setUser(JUser $user)
+	{
+		$this->user = $user;
+		return $this;
+	}
 	 * @param   boolean  $all         True if all can be selected
 	 * @param   boolean  $unassigned  True if unassigned can be selected
 	 * @param   int      $clientId    The client id

--- a/libraries/cms/html/menu.php
+++ b/libraries/cms/html/menu.php
@@ -235,7 +235,7 @@ abstract class JHtmlMenu
 		return $ordering;
 	}
 
-	 /**
+	/**
 	 * Set the user property
 	 *
 	 * @param   JUser  $user  The user object
@@ -253,6 +253,7 @@ abstract class JHtmlMenu
 
 	/**
 	 * Build the multiple select list for Menu Links/Pages
+	 *
 	 * @param   boolean  $all         True if all can be selected
 	 * @param   boolean  $unassigned  True if unassigned can be selected
 	 * @param   int      $clientId    The client id

--- a/libraries/cms/html/menu.php
+++ b/libraries/cms/html/menu.php
@@ -236,22 +236,6 @@ abstract class JHtmlMenu
 	}
 
 	/**
-	 * Set the user property
-	 *
-	 * @param   JUser  $user  The user object
-	 *
-	 * @return  JMenu  The menu object if the user property has been set or null
-	 *
-	 * @since   __DEPLOY_VERSION__
-	 */
-	public function setUser(JUser $user)
-	{
-		$this->user = $user;
-
-		return $this;
-	}
-
-	/**
 	 * Build the multiple select list for Menu Links/Pages
 	 *
 	 * @param   boolean  $all         True if all can be selected

--- a/libraries/src/Menu/AbstractMenu.php
+++ b/libraries/src/Menu/AbstractMenu.php
@@ -10,6 +10,7 @@ namespace Joomla\CMS\Menu;
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\CMS\User\User;
 use Joomla\Registry\Registry;
 
 /**
@@ -237,6 +238,22 @@ class AbstractMenu
 		}
 
 		return;
+	}
+
+	/**
+	 * Set the user property
+	 *
+	 * @param   User  $user  The user object
+	 *
+	 * @return  AbstractMenu  The menu object if the user property has been set or null
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function setUser(User $user)
+	{
+		$this->user = $user;
+
+		return $this;
 	}
 
 	/**

--- a/plugins/system/remember/remember.php
+++ b/plugins/system/remember/remember.php
@@ -63,6 +63,7 @@ class PlgSystemRemember extends JPlugin
 			if ($this->app->input->cookie->get($cookieName))
 			{
 				$this->app->login(array('username' => ''), array('silent' => true));
+				$this->app->getMenu()->setUser(JFactory::getUser())->load();
 			}
 		}
 	}


### PR DESCRIPTION
Pull Request for Issue #15839

Steps to reproduce the issue
1. Create a menu link to a single article with Access set to Registered (e.g. /test)
2. Enable System - Language Filter plugin
3. Go to System -> Global configuration -> System
4. Set the Session Lifetime to 1 minute
<img width="432" alt="image" src="https://user-images.githubusercontent.com/359377/43255017-fa45836c-90c8-11e8-8f3f-52ccd1b3b025.png">

5. Save the change
6. Login on frontend with "Remember me" checkbox ticked
7. Wait 1 minutes for session to expire ;)
8. Visit the protected page (e.g. /en/test)
9. You get a message saying you are not authorized to view the page
10. Apply the patch
11. Login on frontend with "Remember me" checkbox ticked
12. Wait 1 minutes for session to expire ;)
13. Visit the protected page (e.g. /en/test)

#Expected result
You should be automatically logged in and land on open protected page.

Actual result
You are redirected to frontpage with message:
Error: You are not authorised to view this resource.
If your homepage requires access then you end up on 403 page.

System information (as much as possible)
What happens is that the language filter plugin builds the menu with access levels before the remember plugin had a chance to login the user. The menu is built with access levels of the guest user and updates only on refresh. So, on first visit, after the session expires, the menu thinks it's a guest and denies the access.

The quick fix is to re-build the menu after the remember plugin has logged in the user.
Here is the Gist, line 66: https://gist.github.com/sakicnet/f2b8e2486011093d08e544423d8e5124