### PR TITLE
[4.0][SQL] - fix #__finder_logging indexes

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/4.0.0-2018-06-06.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.0.0-2018-06-06.sql
@@ -4,6 +4,6 @@ CREATE TABLE IF NOT EXISTS `#__finder_logging` (
   `query` BLOB NOT NULL,
   `hits` INT(11) NOT NULL DEFAULT '1',
   `results` INT(11) NOT NULL DEFAULT '0',
-  UNIQUE INDEX `md5sum` (`md5sum`),
-  INDEX `searchterm` (`searchterm`)
+  PRIMARY KEY `md5sum` (`md5sum`),
+  `searchterm` (`searchterm`(191))
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_general_ci;

--- a/administrator/components/com_admin/sql/updates/mysql/4.0.0-2018-06-06.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.0.0-2018-06-06.sql
@@ -5,5 +5,5 @@ CREATE TABLE IF NOT EXISTS `#__finder_logging` (
   `hits` INT(11) NOT NULL DEFAULT '1',
   `results` INT(11) NOT NULL DEFAULT '0',
   PRIMARY KEY `md5sum` (`md5sum`),
-  `searchterm` (`searchterm`(191))
+  INDEX `searchterm` (`searchterm`(191))
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_general_ci;

--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2018-06-06.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2018-06-06.sql
@@ -4,7 +4,7 @@ CREATE TABLE IF NOT EXISTS "#__finder_logging" (
   "query" bytes NOT NULL,
   "hits" integer NOT NULL DEFAULT 1,
   "results" integer NOT NULL DEFAULT 0,
-  CONSTRAINT "#__finder_logging_idx_md5sum" UNIQUE ("md5sum")
+  PRIMARY KEY ("md5sum")
 );
 CREATE INDEX "#__finder_logging_idx_md5sum" on "#__finder_logging" ("md5sum");
 CREATE INDEX "#__finder_logging_idx_searchterm" on "#__finder_logging" ("searchterm");

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -857,8 +857,8 @@ CREATE TABLE IF NOT EXISTS `#__finder_logging` (
   `query` BLOB NOT NULL,
   `hits` INT(11) NOT NULL DEFAULT '1',
   `results` INT(11) NOT NULL DEFAULT '0',
-  UNIQUE INDEX `md5sum` (`md5sum`),
-  INDEX `searchterm` (`searchterm`)
+  PRIMARY KEY `md5sum` (`md5sum`),
+  INDEX `searchterm` (`searchterm`(191))
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_general_ci;
 
 -- --------------------------------------------------------

--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -858,7 +858,7 @@ CREATE TABLE IF NOT EXISTS "#__finder_logging" (
   "query" bytes NOT NULL,
   "hits" integer NOT NULL DEFAULT 1,
   "results" integer NOT NULL DEFAULT 0,
-  CONSTRAINT "#__finder_logging_idx_md5sum" UNIQUE ("md5sum")
+  PRIMARY KEY ("md5sum")
 );
 CREATE INDEX "#__finder_logging_idx_md5sum" on "#__finder_logging" ("md5sum");
 CREATE INDEX "#__finder_logging_idx_searchterm" on "#__finder_logging" ("searchterm");


### PR DESCRIPTION
Pull Request for Issue #21235 .

### Summary of Changes
fixed indexes for  #__finder_logging table (mysql cannot index > 191 chars)
added a primary key

### Testing Instructions
com_finder work like before


