### PR TITLE
[4.0] Fix: List Contacts in a Category menu item - Fields groups missing addfieldprefix

### DIFF
--- a/components/com_contact/tmpl/category/default.xml
+++ b/components/com_contact/tmpl/category/default.xml
@@ -591,6 +591,7 @@
 				label="COM_CONTACT_FIELD_USER_CUSTOM_FIELDS_SHOW_LABEL"
 				multiple="true"
 				context="com_users.user"
+				addfieldprefix="Joomla\Component\Fields\Administrator\Field"
 				>
 				<option value="-1">JALL</option>
 			</field>

--- a/components/com_contact/tmpl/category/default.xml
+++ b/components/com_contact/tmpl/category/default.xml
@@ -303,7 +303,7 @@
 		</fieldset>
 
 		<fieldset name="contact" label="COM_CONTACT_BASIC_OPTIONS_FIELDSET_LABEL"
-			addfieldpath="/administrator/components/com_fields/models/fields">
+			addfieldprefix="Joomla\Component\Fields\Administrator\Field">
 			<field 
 				name="presentation_style"
 				type="list"
@@ -591,7 +591,6 @@
 				label="COM_CONTACT_FIELD_USER_CUSTOM_FIELDS_SHOW_LABEL"
 				multiple="true"
 				context="com_users.user"
-				addfieldprefix="Joomla\Component\Fields\Administrator\Field"
 				>
 				<option value="-1">JALL</option>
 			</field>


### PR DESCRIPTION
As title says.

### Summary of Changes
Added `addfieldprefix="Joomla\Component\Fields\Administrator\Field"` for the com_contact/category/default.xml

### Testing Instructions
Create a `List Contacts in a Category` menu item
Look at `User Custom Fields` in the `Contact Display Options` tab
It is empty instead of defaulting to `All`

Save the menu item.
PHP log error:
`[26-Jul-2018 11:29:33 Europe/Berlin] PHP Warning:  htmlspecialchars() expects parameter 1 to be string, array given in .../layouts/joomla/form/field/text.php on line 96`
Look at the field: it contains the html of the error.

### After patch
Click on `All'
<img width="501" alt="screen shot 2018-07-26 at 12 02 04" src="https://user-images.githubusercontent.com/869724/43256032-c2db8f04-90cb-11e8-87c7-b1aa4e6c3e7b.png">

Save. No more error.

Simple change. Can be merged on review.