### PR TITLE
Add "Reviewed by Hound" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Joomla! CMS™ [![Analytics](https://ga-beacon.appspot.com/UA-544070-3/joomla-cms/readme)](https://github.com/igrigorik/ga-beacon)
+Joomla! CMS™ [![Analytics](https://ga-beacon.appspot.com/UA-544070-3/joomla-cms/readme)](https://github.com/igrigorik/ga-beacon) [![Reviewed by Hound](https://img.shields.io/badge/Reviewed_by-Hound-8E64B0.svg)](https://houndci.com)
 ====================
 
 Build Status


### PR DESCRIPTION
The badge didn't seem to fit in with build statuses. Let me know if there's a better spot for the badge.

<img width="590" alt="screenshot 2018-07-26 10 15 31" src="https://user-images.githubusercontent.com/154463/43277510-1e7c6acc-90bd-11e8-9a3a-8db30ca02d48.png">
