### PR TITLE
Fixed users router

### DIFF
--- a/components/com_users/helpers/legacyrouter.php
+++ b/components/com_users/helpers/legacyrouter.php
@@ -62,7 +62,6 @@ class UsersRouterRulesLegacy implements JComponentRouterRulesInterface
 		static $default;
 		static $registration;
 		static $profile;
-		static $profileEdit;
 		static $login;
 		static $remind;
 		static $resend;
@@ -216,14 +215,9 @@ class UsersRouterRulesLegacy implements JComponentRouterRulesInterface
 
 				default:
 				case 'profile':
-//					if (!empty($query['view']))                 //this only adds "/profile" to the url
-//					{
-//						$segments[] = $query['view'];
-//					}
 					unset($query['view']);
 
 					$query['Itemid'] = $profile ? $profile : $default;
-
 
 					if ($query['Itemid'] = $profileEdit)
 					{
@@ -233,7 +227,6 @@ class UsersRouterRulesLegacy implements JComponentRouterRulesInterface
 					{
 						$query['Itemid'] = $default;
 					}
-
 
 					// Only append the user id if not "me".
 					$user = JFactory::getUser();

--- a/components/com_users/helpers/legacyrouter.php
+++ b/components/com_users/helpers/legacyrouter.php
@@ -62,6 +62,7 @@ class UsersRouterRulesLegacy implements JComponentRouterRulesInterface
 		static $default;
 		static $registration;
 		static $profile;
+		static $profileEdit;
 		static $login;
 		static $remind;
 		static $resend;
@@ -122,9 +123,16 @@ class UsersRouterRulesLegacy implements JComponentRouterRulesInterface
 				}
 
 				// Check to see if we have found the profile menu item.
-				if (empty($profile) && $item->query['view'] === 'profile')
+				if ($item->query['view'] === 'profile')
 				{
-					$profile = $item->id;
+					if (empty($profile) && $item->query['layout'] == null)
+					{
+						$profile = $item->id;
+					}
+					elseif (empty($profileEdit) && $item->query['layout'] == 'edit')
+					{
+						$profileEdit = $item->id;
+					}
 				}
 			}
 
@@ -132,6 +140,10 @@ class UsersRouterRulesLegacy implements JComponentRouterRulesInterface
 			if ($profile)
 			{
 				$default = $profile;
+			}
+			elseif ($profileEdit)
+			{
+				$default = $profileEdit;
 			}
 			elseif ($registration)
 			{
@@ -204,21 +216,24 @@ class UsersRouterRulesLegacy implements JComponentRouterRulesInterface
 
 				default:
 				case 'profile':
-					if (!empty($query['view']))
-					{
-						$segments[] = $query['view'];
-					}
-
+//					if (!empty($query['view']))                 //this only adds "/profile" to the url
+//					{
+//						$segments[] = $query['view'];
+//					}
 					unset($query['view']);
 
-					if ($query['Itemid'] = $profile)
+					$query['Itemid'] = $profile ? $profile : $default;
+
+
+					if ($query['Itemid'] = $profileEdit)
 					{
-						unset($query['view']);
+						unset($query['layout']);
 					}
 					else
 					{
 						$query['Itemid'] = $default;
 					}
+
 
 					// Only append the user id if not "me".
 					$user = JFactory::getUser();


### PR DESCRIPTION
### Summary of Changes
Added checks for the layout in the com_users router because at the moment the router returns the first menu item that has the view that we are searching for, not taking into consideration the layout.

### Testing Instructions

1. Create a menu item for "User profile", another one for "Edit user profile"
2. From "User profile" click "Edit Profile" button, which is redirecting to the edit profile view, having the correct url. (The url was `/alias-of-menu-item/profile?layout=edit`, now it is only `/alias-of-menu-item`)
3. From "edit user profile" click cancel button. Before these changes it redirected to the same page, now it goes to the "user profile" page.
