### PR TITLE
[4.0] Correct obvious typo in libraries/cms/html/adminlanguage.php coming from PR #21240

### DIFF
--- a/libraries/cms/html/adminlanguage.php
+++ b/libraries/cms/html/adminlanguage.php
@@ -11,7 +11,7 @@ defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Language\LanguageHelper;
-use \oomla\CMS\Object\CMSObject;
+use Joomla\CMS\Object\CMSObject;
 
 /**
  * Utility class working with administrator language select lists


### PR DESCRIPTION
Pull Request for new issue.

### Summary of Changes

Correct obvious typo "/oomla" instead of "Joomla" in libraries/cms/html/adminlanguage.php coming from PR #21240

### Testing Instructions

Code review.

### Expected result

Code correct.

### Actual result

Code incorrect.

### Documentation Changes Required

None.