### PR TITLE
[4.0] Remove registering form paths for paths that no longer exist

### DIFF
--- a/libraries/bootstrap.php
+++ b/libraries/bootstrap.php
@@ -82,9 +82,3 @@ JLoader::register('PasswordHash', JPATH_PLATFORM . '/phpass/PasswordHash.php');
 // @deprecated  4.0
 JLoader::registerAlias('JAdministrator', 'JApplicationAdministrator');
 JLoader::registerAlias('JSite', 'JApplicationSite');
-
-// Can be removed when the move of all core fields to namespace is finished
-\Joomla\CMS\Form\FormHelper::addFieldPath(JPATH_LIBRARIES . '/joomla/form/fields');
-\Joomla\CMS\Form\FormHelper::addRulePath(JPATH_LIBRARIES . '/joomla/form/rule');
-\Joomla\CMS\Form\FormHelper::addFieldPath(JPATH_LIBRARIES . '/cms/form/field');
-\Joomla\CMS\Form\FormHelper::addRulePath(JPATH_LIBRARIES . '/cms/form/rule');

--- a/libraries/cms.php
+++ b/libraries/cms.php
@@ -80,11 +80,3 @@ JLoader::register('JInstallerTemplate',  JPATH_PLATFORM . '/cms/installer/adapte
 JLoader::register('JExtension',  JPATH_PLATFORM . '/cms/installer/extension.php');
 JLoader::registerAlias('JAdministrator',  'JApplicationAdministrator');
 JLoader::registerAlias('JSite',  'JApplicationSite');
-
-// Can be removed when the move of all core fields to namespace is finished
-\Joomla\CMS\Form\FormHelper::addFieldPath(JPATH_LIBRARIES . '/joomla/form/fields');
-\Joomla\CMS\Form\FormHelper::addRulePath(JPATH_LIBRARIES . '/joomla/form/rule');
-\Joomla\CMS\Form\FormHelper::addRulePath(JPATH_LIBRARIES . '/joomla/form/rules');
-\Joomla\CMS\Form\FormHelper::addFormPath(JPATH_LIBRARIES . '/joomla/form/forms');
-\Joomla\CMS\Form\FormHelper::addFieldPath(JPATH_LIBRARIES . '/cms/form/field');
-\Joomla\CMS\Form\FormHelper::addRulePath(JPATH_LIBRARIES . '/cms/form/rule');

--- a/libraries/src/Form/FormHelper.php
+++ b/libraries/src/Form/FormHelper.php
@@ -11,8 +11,6 @@ namespace Joomla\CMS\Form;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Filesystem\Path;
-use Joomla\CMS\Log\Log;
-use Joomla\String\Inflector;
 use Joomla\String\Normalise;
 use Joomla\String\StringHelper;
 
@@ -316,36 +314,13 @@ class FormHelper
 	 */
 	protected static function addPath($entity, $new = null)
 	{
+		if (!isset(self::$paths[$entity]))
+		{
+			self::$paths[$entity] = [];
+		}
+
 		// Reference to an array with paths for current entity
 		$paths = &self::$paths[$entity];
-
-		// Add the default entity's search path if not set.
-		if (empty($paths))
-		{
-			// While we support limited number of entities (form, field and rule) we can do simple pluralisation
-			$entityPlural = $entity . 's';
-
-			// Relying on "simple" plurals is deprecated, use the properly inflected plural form
-			$paths[] = __DIR__ . '/' . $entityPlural;
-
-			$inflectedPlural = Inflector::getInstance()->toPlural($entity);
-
-			if ($entityPlural !== $inflectedPlural)
-			{
-				Log::add(
-					sprintf(
-						'File paths for form entity type validations should be properly inflected as of 5.0.'
-							. ' The folder for entity type "%1$s" should be renamed from "%2$s" to "%3$s".',
-						$entity,
-						$entityPlural,
-						$inflectedPlural
-					),
-					Log::WARNING,
-					'deprecated'
-				);
-				$paths[] = __DIR__ . '/' . $inflectedPlural;
-			}
-		}
 
 		// Force the new path(s) to an array.
 		settype($new, 'array');


### PR DESCRIPTION
### Summary of Changes

The platform bootstrap was registering the old form entity paths but that is no longer necessary because the paths no longer exist.

Additionally, the form helper was default registering path lookups based on the original coding without namespace or autoload support.  This behavior is actually now entirely unnecessary as all core form entities are autoloaded, so this path registration is dropped.

### Testing Instructions

CMS, especially views with forms, still functions.