### PR TITLE
[4.0] Run a pre-check in app bootup to make sure dependencies are installed

### DIFF
--- a/administrator/includes/app.php
+++ b/administrator/includes/app.php
@@ -23,6 +23,14 @@ if (!defined('_JDEFINES'))
 	require_once JPATH_BASE . '/includes/defines.php';
 }
 
+// Check for presence of vendor dependencies not included in the git repository
+if (!file_exists(JPATH_LIBRARIES . '/vendor/autoload.php') || !is_dir(JPATH_ROOT . '/media/vendor'))
+{
+	echo file_get_contents(JPATH_ROOT . '/templates/system/build_incomplete.html');
+
+	exit;
+}
+
 require_once JPATH_BASE . '/includes/framework.php';
 
 // Set profiler start time and memory usage and mark afterLoad in the profiler.

--- a/build.js
+++ b/build.js
@@ -6,6 +6,7 @@
  * npm install
  *
  * For dedicated tasks, please run:
+ * node build.js --buildcheck     === will create the error page (for incomplete repo build)
  * node build.js --installer       === will create the error page (for unsupported PHP version)
  * node build.js --copy-assets     === will clean the media/vendor folder and then will populate the folder from node_modules
  * node build.js --compile-js      === will transpile ES6 files and also uglify the ES6,ES5 files
@@ -19,6 +20,7 @@ const Program = require('commander');
 // eslint-disable-next-line import/no-extraneous-dependencies
 
 // Joomla Build modules
+const buildCheck = require('./build/build-modules-js/build-check.js');
 const installer = require('./build/build-modules-js/installation.js');
 const update = require('./build/build-modules-js/update.js');
 const css = require('./build/build-modules-js/compilescss.js');
@@ -43,6 +45,7 @@ Program
   .option('--compile-ce, --compile-ce path', 'Compiles/traspiles all the custom elements files')
   .option('--watch, --watch path', 'Watch file changes and re-compile (Only work for compile-css and compile-js now).')
   .option('--installer', 'Creates the language file for installer error page')
+  .option('--buildcheck', 'Creates the language file for build check error page')
   .on('--help', () => {
     // eslint-disable-next-line no-console
     console.log(`Version: ${options.version}`);
@@ -76,6 +79,11 @@ if (Program.copyAssets) {
 // Create the languages file for the error page on the installer
 if (Program.installer) {
   installer.installation();
+}
+
+// Create the languages file for the error page on incomplete repo build
+if (Program.buildcheck) {
+    buildCheck.buildCheck();
 }
 
 // Convert scss to css

--- a/build/build-modules-js/build-check.js
+++ b/build/build-modules-js/build-check.js
@@ -1,0 +1,69 @@
+const fs = require('fs');
+const ini = require('ini');
+const Recurs = require('recursive-readdir');
+const uglifyCss = require('uglifycss');
+const uglifyJs = require('uglify-es');
+const rootPath = require('./rootpath.js')._();
+
+const dir = `${rootPath}/installation/language`;
+const installationFile = `${rootPath}/templates/system/build_incomplete.html`;
+const srcPath = `${rootPath}/build/repo_build_incomplete`;
+
+// Set the initial template
+let template = 'window.errorLocale = {';
+
+const buildCheck = () => {
+  let checkContent = fs.readFileSync(`${srcPath}/incomplete.html`, 'utf-8');
+  let cssContent = fs.readFileSync(`${srcPath}/incomplete.css`, 'utf-8');
+  let jsContent = fs.readFileSync(`${srcPath}/incomplete.js`, 'utf-8');
+
+  cssContent = uglifyCss.processString(cssContent, { expandVars: false });
+  jsContent = uglifyJs.minify(jsContent);
+
+  Recurs(dir).then(
+    (files) => {
+      files.forEach((file) => {
+        const languageStrings = ini.parse(fs.readFileSync(file, 'UTF-8'));
+        if (languageStrings.BUILD_INCOMPLETE_LANGUAGE) {
+          const name = file.replace('.ini', '').replace(/.+\//, '');
+          template += `
+"${name}":{"language":"${languageStrings.BUILD_INCOMPLETE_LANGUAGE}","header":"${languageStrings.BUILD_INCOMPLETE_HEADER}","text1":"${languageStrings.BUILD_INCOMPLETE_TEXT}","help-url-text":"${languageStrings.BUILD_INCOMPLETE_URL_TEXT}"},`;
+        }
+      });
+
+      template = `${template}
+}`;
+
+      checkContent = checkContent.replace('{{jsonContents}}', template);
+
+      if (cssContent) {
+        checkContent = checkContent.replace('{{cssContents}}', cssContent);
+      }
+
+      if (jsContent) {
+        checkContent = checkContent.replace('{{jsContents}}', jsContent.code);
+      }
+
+      fs.writeFile(
+        installationFile,
+        checkContent,
+        (err) => {
+          if (err) {
+            // eslint-disable-next-line no-console
+            console.log(err);
+            return;
+          }
+
+          // eslint-disable-next-line no-console
+          console.log('The build check error page was saved!');
+        },
+      );
+    },
+    (error) => {
+      // eslint-disable-next-line no-console
+      console.error('something exploded', error);
+    },
+  );
+};
+
+module.exports.buildCheck = buildCheck;

--- a/build/repo_build_incomplete/incomplete.css
+++ b/build/repo_build_incomplete/incomplete.css
@@ -1,0 +1,162 @@
+body {
+  margin: 0;
+  padding: 0;
+  font: 14px / 18px sans-serif;
+  color: #555;
+  background-color: transparent
+}
+
+html {
+  background: rgb(241,241,241);
+  background: -moz-radial-gradient(center, ellipse cover, rgba(241,241,241,1) 0%, rgba(58,146,200,1) 100%);
+  background: -webkit-radial-gradient(center, ellipse cover, rgba(241,241,241,1) 0%,rgba(58,146,200,1) 100%);
+  background: radial-gradient(ellipse at center, rgba(241,241,241,1) 0%,rgba(58,146,200,1) 100%);
+  background-repeat: no-repeat;
+  background-attachment: fixed;
+}
+
+ol, ul {
+  padding: 0;
+  margin: 0;
+  list-style: none
+}
+
+a {
+  color: #0084b4;
+  text-decoration: none;
+  outline: 0
+}
+
+a:hover, a:focus {
+  text-decoration: underline
+}
+
+p a {
+  line-height: inherit
+}
+
+.container {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+  margin: 0 auto;
+  width: 100%;
+  height: 100vh;
+  overflow: hidden;
+}
+
+.alert-main {
+  display: block;
+  position: relative;
+  background: #fff;
+  border: 1px solid rgba(0,0,0,0.1);
+  border-radius: 5px;
+  padding: 20px 60px;
+  margin: 0 20px;
+  box-shadow: 0 0 10px rgba(0,0,0,0.05);
+}
+
+svg {
+  position: absolute;
+  bottom: -120px;
+  right: -70px;
+  width: 400px;
+  transform: rotate(10deg);
+  z-index: -1;
+}
+
+h1, p {
+  position: relative;
+  z-index: 10;
+  text-align: center;
+  text-rendering: optimizeLegibility
+}
+
+h1 {
+  margin: 18px 0 0;
+  font-size: 40px;
+  font-weight: 200;
+  line-height: 1;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, .2)
+}
+
+p, label {
+  margin: 10px 0 20px;
+  font-size: 18px;
+  font-weight: 300;
+  line-height: 25px;
+  color: #777
+}
+
+p a {
+  font-weight: bold;
+  color: #1C3D5C
+}
+
+.link-help {
+  padding: .4rem .85rem;
+  font-size: 1rem;
+  font-weight: normal;
+  border-radius: .25rem;
+  text-decoration: none;
+  background-color: #f5f5f5;
+  border: 1px solid rgba(0,0,0,0.1);
+}
+.link-help:hover {
+  background-color: #eee;
+  text-decoration: none;
+}
+
+.footer {
+  margin: 8px 20px;
+  text-align: left;
+  font-size: 11px
+}
+
+.footer ul {
+  margin-bottom: 5px;
+}
+
+.footer li {
+  display: inline;
+  margin: 0 5px;
+  line-height: 20px
+}
+
+.footer li, .footer a {
+  color: #1C3D5C
+}
+
+.footer a:hover {
+  color: #59B0FF
+}
+
+.links {
+  display: block;
+  text-align: center;
+  margin-top: 4rem;
+  margin-left: auto;
+  margin-right: auto;
+  font-size: 1rem
+}
+.links li {
+  display: inline-block;
+  margin-top: 20px;
+}
+
+@media screen and (max-width:480px) {
+  .container {
+    height: auto;
+    padding-top: 20px;
+    padding-bottom: 20px;
+  }
+  h1 {
+    font-size: 30px
+  }
+
+  .link-help {
+    white-space: nowrap;
+  }
+}

--- a/build/repo_build_incomplete/incomplete.html
+++ b/build/repo_build_incomplete/incomplete.html
@@ -1,0 +1,41 @@
+<html>
+<head>
+  <meta charset=utf-8">
+  <meta http-equiv="Content-Language" content="en-GB">
+  <meta name="robots" content="noindex, nofollow">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Joomla: Environment Setup Incomplete</title>
+  <!-- Set the page styling, IMPORTANT DO NOT REMOVE -->
+  <style>{{cssContents}}</style>
+  <!-- Set the content of the translated text, IMPORTANT DO NOT REMOVE -->
+  <script>{{jsonContents}}</script>
+</head>
+<!-- Set the minimum PHP version, IMPORTANT DO NOT REMOVE -->
+<body>
+<div class="container">
+  <div class="container-main">
+    <div class="alert-main">
+      <h1 id="headerText">Environment Setup Incomplete</h1>
+      <p><span id="descText1">It looks like you are trying to run Joomla! from our git repository. To do so requires you complete a couple of extra steps first.</span></p>
+      <p><a id="linkHelp" class="link-help" href="https://docs.joomla.org/Special:MyLanguage/J4.x:Setting_Up_Your_Local_Environment">More Details</a></p>
+      <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 74.8 74.8" enable-background="new 0 0 74.8 74.8" xml:space="preserve">
+        <g id="brandmark">
+          <path id="j-green" fill="#fff" d="M13.5,37.7L12,36.3c-4.5-4.5-5.8-10.8-4.2-16.5c-4.5-1-7.8-5-7.8-9.8c0-5.5,4.5-10,10-10 c5,0,9.1,3.6,9.9,8.4c5.4-1.3,11.3,0.2,15.5,4.4l0.6,0.6l-7.4,7.4l-0.6-0.6c-2.4-2.4-6.3-2.4-8.7,0c-2.4,2.4-2.4,6.3,0,8.7l1.4,1.4 l7.4,7.4l7.8,7.8l-7.4,7.4l-7.8-7.8L13.5,37.7L13.5,37.7z"/>
+          <path id="j-orange" fill="#fff" d="M21.8,29.5l7.8-7.8l7.4-7.4l1.4-1.4C42.9,8.4,49.2,7,54.8,8.6C55.5,3.8,59.7,0,64.8,0 c5.5,0,10,4.5,10,10c0,5.1-3.8,9.3-8.7,9.9c1.6,5.6,0.2,11.9-4.2,16.3l-0.6,0.6l-7.4-7.4l0.6-0.6c2.4-2.4,2.4-6.3,0-8.7 c-2.4-2.4-6.3-2.4-8.7,0l-1.4,1.4L37,29l-7.8,7.8L21.8,29.5L21.8,29.5z"/>
+          <path id="j-red" fill="#fff" d="M55,66.8c-5.7,1.7-12.1,0.4-16.6-4.1l-0.6-0.6l7.4-7.4l0.6,0.6c2.4,2.4,6.3,2.4,8.7,0 c2.4-2.4,2.4-6.3,0-8.7L53,45.1l-7.4-7.4l-7.8-7.8l7.4-7.4l7.8,7.8l7.4,7.4l1.5,1.5c4.2,4.2,5.7,10.2,4.4,15.7 c4.9,0.7,8.6,4.9,8.6,9.9c0,5.5-4.5,10-10,10C60,74.8,56,71.3,55,66.8L55,66.8z"/>
+          <path id="j-blue" fill="#fff" d="M52.2,46l-7.8,7.8L37,61.2l-1.4,1.4c-4.3,4.3-10.3,5.7-15.7,4.4c-1,4.5-5,7.8-9.8,7.8 c-5.5,0-10-4.5-10-10C0,60,3.3,56.1,7.7,55C6.3,49.5,7.8,43.5,12,39.2l0.6-0.6L20,46l-0.6,0.6c-2.4,2.4-2.4,6.3,0,8.7 c2.4,2.4,6.3,2.4,8.7,0l1.4-1.4l7.4-7.4l7.8-7.8L52.2,46L52.2,46z"/>
+        </g>
+      </svg>
+    </div>
+    <div class="footer">
+      <select id="translatedLanguagesSelect"></select>
+      <ul class="links">
+        <li><a href="https://www.joomla.org/">Joomla</a></li> -
+        <li><a href="https://docs.joomla.org/">Help</a></li>
+      </ul>
+    </div>
+  </div>
+</div>
+<script>{{jsContents}}</script>
+</body>
+</html>

--- a/build/repo_build_incomplete/incomplete.js
+++ b/build/repo_build_incomplete/incomplete.js
@@ -1,0 +1,62 @@
+var errorLocale = window.errorLocale || null;
+
+(function(document, errorLocale) {
+  'use strict';
+
+  if (errorLocale) {
+    var header = document.getElementById('headerText');
+
+    // Create links for all the languages
+    Object.keys(errorLocale).forEach(function(key) {
+      var sel = document.getElementById('translatedLanguagesSelect');
+      var opt = document.createElement('option');
+      opt.text = errorLocale[key].language;
+      opt.value = key;
+
+      if (key === 'en-GB') {
+        opt.setAttribute('selected', 'selected');
+      }
+
+      document.getElementById('translatedLanguagesSelect').addEventListener('change', function(e) {
+        var ref = e.target.value;
+        if (ref) {
+          header.innerHTML = errorLocale[ref].header;
+        }
+
+        var helpLink = document.getElementById('linkHelp');
+        if (helpLink) {
+          helpLink.innerText = errorLocale[ref]['help-url-text'];
+        }
+
+        var meta = document.querySelector('[http-equiv="Content-Language"]');
+        if (meta) {
+          meta.setAttribute('content', ref);
+        }
+      });
+
+      sel.appendChild(opt)
+    });
+
+    // Select language based on Browser's language
+    Object.keys(errorLocale).forEach(function(key) {
+      if (navigator.language === key) {
+        // Remove the selected property
+        document.querySelector('#translatedLanguagesSelect option[value="en-GB"]').removeAttribute('selected');
+        document.querySelector('#translatedLanguagesSelect option[value="' + key + '"]').setAttribute('selected', 'selected');
+
+        // Append the translated strings
+        header.innerHTML = errorLocale[key].header;
+
+        var helpLink = document.getElementById('linkHelp');
+        if (helpLink) {
+          helpLink.innerText = errorLocale[key]['help-url-text'];
+        }
+
+        var meta = document.querySelector('[http-equiv="Content-Language"]');
+        if (meta) {
+          meta.setAttribute('content', key);
+        }
+      }
+    });
+  }
+})(document, errorLocale);

--- a/cli/joomla.php
+++ b/cli/joomla.php
@@ -21,6 +21,16 @@ if (!defined('_JDEFINES'))
 	require_once JPATH_BASE . '/includes/defines.php';
 }
 
+// Check for presence of vendor dependencies not included in the git repository
+if (!file_exists(JPATH_LIBRARIES . '/vendor/autoload.php') || !is_dir(JPATH_ROOT . '/media/vendor'))
+{
+	echo 'It looks like you are trying to run Joomla! from our git repository.' . PHP_EOL;
+	echo 'To do so requires you complete a couple of extra steps first.' . PHP_EOL;
+	echo 'Please see https://docs.joomla.org/Special:MyLanguage/J4.x:Setting_Up_Your_Local_Environment for further details.' . PHP_EOL;
+
+	exit;
+}
+
 // Get the framework.
 require_once JPATH_BASE . '/includes/framework.php';
 

--- a/includes/app.php
+++ b/includes/app.php
@@ -23,6 +23,14 @@ if (!defined('_JDEFINES'))
 	require_once JPATH_BASE . '/includes/defines.php';
 }
 
+// Check for presence of vendor dependencies not included in the git repository
+if (!file_exists(JPATH_LIBRARIES . '/vendor/autoload.php') || !is_dir(JPATH_ROOT . '/media/vendor'))
+{
+	echo file_get_contents(JPATH_ROOT . '/templates/system/build_incomplete.html');
+
+	exit;
+}
+
 require_once JPATH_BASE . '/includes/framework.php';
 
 // Set profiler start time and memory usage and mark afterLoad in the profiler.

--- a/installation/includes/app.php
+++ b/installation/includes/app.php
@@ -14,6 +14,14 @@ define('JPATH_BASE', dirname(__DIR__));
 
 require_once __DIR__ . '/defines.php';
 
+// Check for presence of vendor dependencies not included in the git repository
+if (!file_exists(JPATH_LIBRARIES . '/vendor/autoload.php') || !is_dir(JPATH_ROOT . '/media/vendor'))
+{
+	echo file_get_contents(JPATH_ROOT . '/templates/system/build_incomplete.html');
+
+	exit;
+}
+
 // Launch the application
 require_once __DIR__ . '/framework.php';
 

--- a/installation/language/en-GB/en-GB.ini
+++ b/installation/language/en-GB/en-GB.ini
@@ -3,8 +3,16 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt
 ; Note : All ini files need to be saved as UTF-8
 
+;Build incomplete error page
+;These will be processed by the JavaScript Build
+BUILD_INCOMPLETE_LANGUAGE="English GB"
+BUILD_INCOMPLETE_HEADER="Environment Setup Incomplete"
+BUILD_INCOMPLETE_TEXT="It looks like you are trying to run Joomla! from our git repository. To do so requires you complete a couple of extra steps first."
+BUILD_INCOMPLETE_URL_TEXT="More Details"
+;End of build incomplete error page
+
 ;Minimum PHP error page
-;These will be processed by Grunt
+;These will be processed by the JavaScript Build
 MIN_PHP_ERROR_LANGUAGE="English GB"
 MIN_PHP_ERROR_HEADER="Sorry, your PHP version is not supported"
 MIN_PHP_ERROR_TEXT="Your host needs to use PHP version {{phpversion}} or newer to run this version of Joomla"

--- a/installation/language/en-US/en-US.ini
+++ b/installation/language/en-US/en-US.ini
@@ -3,8 +3,16 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt
 ; Note : All ini files need to be saved as UTF-8
 
+;Build incomplete error page
+;These will be processed by the JavaScript Build
+BUILD_INCOMPLETE_LANGUAGE="English US"
+BUILD_INCOMPLETE_HEADER="Environment Setup Incomplete"
+BUILD_INCOMPLETE_TEXT="It looks like you are trying to run Joomla! from our git repository. To do so requires you complete a couple of extra steps first."
+BUILD_INCOMPLETE_URL_TEXT="More Details"
+;End of build incomplete error page
+
 ;Minimum PHP error page
-;These will be processed by Grunt
+;These will be processed by the JavaScript Build
 MIN_PHP_ERROR_LANGUAGE="English US"
 MIN_PHP_ERROR_HEADER="Sorry, your PHP version is not supported"
 MIN_PHP_ERROR_TEXT="Your host needs to use PHP version {{phpversion}} or newer to run this version of Joomla"

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
     "watch:css": "node build.js --compilecss --watch",
     "lint:js": "node ./node_modules/eslint/bin/eslint.js . || exit 0",
     "test": "node node_modules/karma/bin/karma start karma.conf.js --single-run",
-    "install": "node build.js --copy-assets && node build.js --installer",
+    "install": "node build.js --copy-assets && node build.js --installer && node build.js --buildcheck",
     "postinstall": "node build.js --compile-js && node build.js --compile-css && node build.js --compile-ce",
-    "update": "node build.js --copy-assets && node build.js --installer && node build.js --compile-js && node build.js --compile-ce && node build.js --compile-css"
+    "update": "node build.js --copy-assets && node build.js --installer && node build.js --buildcheck && node build.js --compile-js && node build.js --compile-ce && node build.js --compile-css"
   },
   "dependencies": {
     "@claviska/jquery-minicolors": "2.2.6",

--- a/templates/system/build_incomplete.html
+++ b/templates/system/build_incomplete.html
@@ -1,0 +1,44 @@
+<html>
+<head>
+  <meta charset=utf-8">
+  <meta http-equiv="Content-Language" content="en-GB">
+  <meta name="robots" content="noindex, nofollow">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Joomla: Environment Setup Incomplete</title>
+  <!-- Set the page styling, IMPORTANT DO NOT REMOVE -->
+  <style>body{margin:0;padding:0;font:14px / 18px sans-serif;color:#555;background-color:transparent}html{background:#f1f1f1;background:-moz-radial-gradient(center,ellipse cover,rgba(241,241,241,1) 0,rgba(58,146,200,1) 100%);background:-webkit-radial-gradient(center,ellipse cover,rgba(241,241,241,1) 0,rgba(58,146,200,1) 100%);background:radial-gradient(ellipse at center,rgba(241,241,241,1) 0,rgba(58,146,200,1) 100%);background-repeat:no-repeat;background-attachment:fixed}ol,ul{padding:0;margin:0;list-style:none}a{color:#0084b4;text-decoration:none;outline:0}a:hover,a:focus{text-decoration:underline}p a{line-height:inherit}.container{display:flex;flex-direction:column;justify-content:center;align-items:center;position:relative;margin:0 auto;width:100%;height:100vh;overflow:hidden}.alert-main{display:block;position:relative;background:#fff;border:1px solid rgba(0,0,0,0.1);border-radius:5px;padding:20px 60px;margin:0 20px;box-shadow:0 0 10px rgba(0,0,0,0.05)}svg{position:absolute;bottom:-120px;right:-70px;width:400px;transform:rotate(10deg);z-index:-1}h1,p{position:relative;z-index:10;text-align:center;text-rendering:optimizeLegibility}h1{margin:18px 0 0;font-size:40px;font-weight:200;line-height:1;text-shadow:0 1px 2px rgba(0,0,0,.2)}p,label{margin:10px 0 20px;font-size:18px;font-weight:300;line-height:25px;color:#777}p a{font-weight:bold;color:#1c3d5c}.link-help{padding:.4rem .85rem;font-size:1rem;font-weight:normal;border-radius:.25rem;text-decoration:none;background-color:#f5f5f5;border:1px solid rgba(0,0,0,0.1)}.link-help:hover{background-color:#eee;text-decoration:none}.footer{margin:8px 20px;text-align:left;font-size:11px}.footer ul{margin-bottom:5px}.footer li{display:inline;margin:0 5px;line-height:20px}.footer li,.footer a{color:#1c3d5c}.footer a:hover{color:#59b0ff}.links{display:block;text-align:center;margin-top:4rem;margin-left:auto;margin-right:auto;font-size:1rem}.links li{display:inline-block;margin-top:20px}@media screen and (max-width:480px){.container{height:auto;padding-top:20px;padding-bottom:20px}h1{font-size:30px}.link-help{white-space:nowrap}}</style>
+  <!-- Set the content of the translated text, IMPORTANT DO NOT REMOVE -->
+  <script>window.errorLocale = {
+"en-US":{"language":"English US","header":"Environment Setup Incomplete","text1":"It looks like you are trying to run Joomla! from our git repository. To do so requires you complete a couple of extra steps first.","help-url-text":"More Details"},
+"en-GB":{"language":"English GB","header":"Environment Setup Incomplete","text1":"It looks like you are trying to run Joomla! from our git repository. To do so requires you complete a couple of extra steps first.","help-url-text":"More Details"},
+}</script>
+</head>
+<!-- Set the minimum PHP version, IMPORTANT DO NOT REMOVE -->
+<body>
+<div class="container">
+  <div class="container-main">
+    <div class="alert-main">
+      <h1 id="headerText">Environment Setup Incomplete</h1>
+      <p><span id="descText1">It looks like you are trying to run Joomla! from our git repository. To do so requires you complete a couple of extra steps first.</span></p>
+      <p><a id="linkHelp" class="link-help" href="https://docs.joomla.org/Special:MyLanguage/J4.x:Setting_Up_Your_Local_Environment">More Details</a></p>
+      <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 74.8 74.8" enable-background="new 0 0 74.8 74.8" xml:space="preserve">
+        <g id="brandmark">
+          <path id="j-green" fill="#fff" d="M13.5,37.7L12,36.3c-4.5-4.5-5.8-10.8-4.2-16.5c-4.5-1-7.8-5-7.8-9.8c0-5.5,4.5-10,10-10 c5,0,9.1,3.6,9.9,8.4c5.4-1.3,11.3,0.2,15.5,4.4l0.6,0.6l-7.4,7.4l-0.6-0.6c-2.4-2.4-6.3-2.4-8.7,0c-2.4,2.4-2.4,6.3,0,8.7l1.4,1.4 l7.4,7.4l7.8,7.8l-7.4,7.4l-7.8-7.8L13.5,37.7L13.5,37.7z"/>
+          <path id="j-orange" fill="#fff" d="M21.8,29.5l7.8-7.8l7.4-7.4l1.4-1.4C42.9,8.4,49.2,7,54.8,8.6C55.5,3.8,59.7,0,64.8,0 c5.5,0,10,4.5,10,10c0,5.1-3.8,9.3-8.7,9.9c1.6,5.6,0.2,11.9-4.2,16.3l-0.6,0.6l-7.4-7.4l0.6-0.6c2.4-2.4,2.4-6.3,0-8.7 c-2.4-2.4-6.3-2.4-8.7,0l-1.4,1.4L37,29l-7.8,7.8L21.8,29.5L21.8,29.5z"/>
+          <path id="j-red" fill="#fff" d="M55,66.8c-5.7,1.7-12.1,0.4-16.6-4.1l-0.6-0.6l7.4-7.4l0.6,0.6c2.4,2.4,6.3,2.4,8.7,0 c2.4-2.4,2.4-6.3,0-8.7L53,45.1l-7.4-7.4l-7.8-7.8l7.4-7.4l7.8,7.8l7.4,7.4l1.5,1.5c4.2,4.2,5.7,10.2,4.4,15.7 c4.9,0.7,8.6,4.9,8.6,9.9c0,5.5-4.5,10-10,10C60,74.8,56,71.3,55,66.8L55,66.8z"/>
+          <path id="j-blue" fill="#fff" d="M52.2,46l-7.8,7.8L37,61.2l-1.4,1.4c-4.3,4.3-10.3,5.7-15.7,4.4c-1,4.5-5,7.8-9.8,7.8 c-5.5,0-10-4.5-10-10C0,60,3.3,56.1,7.7,55C6.3,49.5,7.8,43.5,12,39.2l0.6-0.6L20,46l-0.6,0.6c-2.4,2.4-2.4,6.3,0,8.7 c2.4,2.4,6.3,2.4,8.7,0l1.4-1.4l7.4-7.4l7.8-7.8L52.2,46L52.2,46z"/>
+        </g>
+      </svg>
+    </div>
+    <div class="footer">
+      <select id="translatedLanguagesSelect"></select>
+      <ul class="links">
+        <li><a href="https://www.joomla.org/">Joomla</a></li> -
+        <li><a href="https://docs.joomla.org/">Help</a></li>
+      </ul>
+    </div>
+  </div>
+</div>
+<script>var errorLocale=window.errorLocale||null;!function(e,t){"use strict";if(t){var n=e.getElementById("headerText");Object.keys(t).forEach(function(a){var r=e.getElementById("translatedLanguagesSelect"),l=e.createElement("option");l.text=t[a].language,l.value=a,"en-GB"===a&&l.setAttribute("selected","selected"),e.getElementById("translatedLanguagesSelect").addEventListener("change",function(a){var r=a.target.value;r&&(n.innerHTML=t[r].header);var l=e.getElementById("linkHelp");l&&(l.innerText=t[r]["help-url-text"]);var u=e.querySelector('[http-equiv="Content-Language"]');u&&u.setAttribute("content",r)}),r.appendChild(l)}),Object.keys(t).forEach(function(a){if(navigator.language===a){e.querySelector('#translatedLanguagesSelect option[value="en-GB"]').removeAttribute("selected"),e.querySelector('#translatedLanguagesSelect option[value="'+a+'"]').setAttribute("selected","selected"),n.innerHTML=t[a].header;var r=e.getElementById("linkHelp");r&&(r.innerText=t[a]["help-url-text"]);var l=e.querySelector('[http-equiv="Content-Language"]');l&&l.setAttribute("content",a)}})}}(document,errorLocale);</script>
+</body>
+</html>


### PR DESCRIPTION
Pull Request for Issue #21278

### Summary of Changes

Run a check during the application bootup to make sure that `composer install` and `npm install` are run (well, relatively sane checks at least).

This uses the same approach as the incompatible PHP version page as it relates to language strings, page design, etc.  If you're reviewing and don't like the JavaScript, you don't like your own script because it's a copy of the PHP page logic 😉

### Testing Instructions

Try to run Joomla without the Composer autoloader (file `libraries/vendor/autoload.php` generated by `composer install`) or the `media/vendor` directory (created by `npm install`).  You'll get a friendly error page pointing out you have some extra work to do and a link to the docs page for the extra info.

### TODO

- Try to DRY up the code for these error pages

### Screenshot

<img width="1440" alt="screen shot 2018-07-28 at 3 41 25 pm" src="https://user-images.githubusercontent.com/368545/43360577-54106a64-927d-11e8-8942-10d5d4a82924.png">