### PR TITLE
[plg_content_pagebreak] Remove exception of pr #11217. Fixes #17305

### DIFF
--- a/plugins/content/pagebreak/pagebreak.php
+++ b/plugins/content/pagebreak/pagebreak.php
@@ -51,6 +51,12 @@ class PlgContentPagebreak extends JPlugin
 			return;
 		}
 
+		// Simple performance check to determine whether bot should process further.
+		if (StringHelper::strpos($row->text, 'class="system-pagebreak') === false)
+		{
+			return true;
+		}
+
 		$style = $this->params->get('style', 'pages');
 
 		// Expression to search for.
@@ -69,17 +75,6 @@ class PlgContentPagebreak extends JPlugin
 		if ($print)
 		{
 			$row->text = preg_replace($regex, '<br />', $row->text);
-
-			return true;
-		}
-
-		// Simple performance check to determine whether bot should process further.
-		if (StringHelper::strpos($row->text, 'class="system-pagebreak') === false)
-		{
-			if ($page > 0)
-			{
-				throw new Exception(JText::_('JERROR_PAGE_NOT_FOUND'), 404);
-			}
 
 			return true;
 		}


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/17305

As info: I have written a plugin that adds JPagination navigation and an extended toc for specific articles in a similiar way like plg_content_pagebreak does but that listens to another tag/regex. Whenever there is no "system-pagebreak" marker inside an article plg_content_pagebreak throws a 404 then.

### Summary of Changes
- Remove exception that ignores that several use cases and extensions could use pagination or toc without "system-pagebreak" regexes. The exception was added with https://github.com/joomla/joomla-cms/pull/11217
- Set "Simple performance check" earlier.

### Testing Instructions
- See https://github.com/joomla/joomla-cms/issues/17305 for cases where the exception creates annoying conflicts.
- Apply patch and test again if any failures come up.

### Expected result
- Also other extensions can use JPagination and things similiar like TOC  (start=xyz) without failures.
- It should be possible to use these extensions without deactivating plg_content_pagebreak that could be used in other articles.
- Even if placed lately in code lines https://github.com/joomla/joomla-cms/blob/staging/plugins/content/pagebreak/pagebreak.php#L132-L135 should be sufficient as "page-exists?-test"

### Actual result
- One have to deactivate plg_content_pagebreak to get no 404 or have to kick custom extensions that use Joomla features and standards (e.g. $page that comes from core).
- <strike>The only way to get rid of this 404 is to add a senseless `class="system-pagebreak` to your custom extension tag or the article text before plg_content_pagebreak  works. Bad practice.</strike> [EDIT: That's a stupid idea because plg_content_pagebreak then throws another exception. I don't understand at all why this plugin has to throw 404 exceptions.]