### PR TITLE
[4.0] [a11y] Pagination part 1

### DIFF
--- a/administrator/components/com_associations/tmpl/associations/default.php
+++ b/administrator/components/com_associations/tmpl/associations/default.php
@@ -77,13 +77,6 @@ HTMLHelper::_('script', 'com_associations/admin-associations-default.min.js', fa
 							</th>
 						</tr>
 					</thead>
-					<tfoot>
-						<tr>
-							<td colspan="<?php echo $colSpan; ?>">
-								<?php echo $this->pagination->getListFooter(); ?>
-							</td>
-						</tr>
-					</tfoot>
 					<tbody>
 					<?php foreach ($this->items as $i => $item) :
 						$canCheckin = true;

--- a/administrator/components/com_associations/tmpl/associations/default.php
+++ b/administrator/components/com_associations/tmpl/associations/default.php
@@ -141,6 +141,10 @@ HTMLHelper::_('script', 'com_associations/admin-associations-default.min.js', fa
 					<?php endforeach; ?>
 					</tbody>
 					</table>
+					
+					<?php // load the pagination. ?>
+					<?php echo $this->pagination->getListFooter(); ?>
+
 				<?php endif; ?>
 				<input type="hidden" name="task" value="">
 				<?php echo HTMLHelper::_('form.token'); ?>

--- a/administrator/components/com_associations/tmpl/associations/default.php
+++ b/administrator/components/com_associations/tmpl/associations/default.php
@@ -22,7 +22,6 @@ HTMLHelper::_('behavior.multiselect');
 $listOrder        = $this->escape($this->state->get('list.ordering'));
 $listDirn         = $this->escape($this->state->get('list.direction'));
 $canManageCheckin = Factory::getUser()->authorise('core.manage', 'com_checkin');
-$colSpan          = 5;
 
 $iconStates = array(
 	-2 => 'icon-trash',
@@ -47,7 +46,7 @@ HTMLHelper::_('script', 'com_associations/admin-associations-default.min.js', fa
 						<tr>
 							<?php if (!empty($this->typeSupports['state'])) : ?>
 								<th scope="col" style="width:1%" class="text-center nowrap">
-									<?php echo HTMLHelper::_('searchtools.sort', 'JSTATUS', 'state', $listDirn, $listOrder); $colSpan++; ?>
+									<?php echo HTMLHelper::_('searchtools.sort', 'JSTATUS', 'state', $listDirn, $listOrder); ?>
 								</th>
 							<?php endif; ?>
 							<th scope="col" class="nowrap">
@@ -64,12 +63,12 @@ HTMLHelper::_('script', 'com_associations/admin-associations-default.min.js', fa
 							</th>
 							<?php if (!empty($this->typeFields['menutype'])) : ?>
 								<th scope="col" style="width:10%" class="nowrap">
-									<?php echo HTMLHelper::_('searchtools.sort', 'COM_ASSOCIATIONS_HEADING_MENUTYPE', 'menutype_title', $listDirn, $listOrder); $colSpan++; ?>
+									<?php echo HTMLHelper::_('searchtools.sort', 'COM_ASSOCIATIONS_HEADING_MENUTYPE', 'menutype_title', $listDirn, $listOrder); ?>
 								</th>
 							<?php endif; ?>
 							<?php if (!empty($this->typeFields['access'])) : ?>
 								<th scope="col" style="width:5%" class="nowrap d-none d-md-table-cell">
-									<?php echo HTMLHelper::_('searchtools.sort', 'JGRID_HEADING_ACCESS', 'access_level', $listDirn, $listOrder); $colSpan++; ?>
+									<?php echo HTMLHelper::_('searchtools.sort', 'JGRID_HEADING_ACCESS', 'access_level', $listDirn, $listOrder); ?>
 								</th>
 							<?php endif; ?>
 							<th scope="col" style="width:1%" class="nowrap d-none d-md-table-cell text-center">

--- a/administrator/components/com_associations/tmpl/associations/modal.php
+++ b/administrator/components/com_associations/tmpl/associations/modal.php
@@ -89,13 +89,6 @@ HTMLHelper::_('script', 'com_associations/admin-associations-modal.min.js', fals
 					</th>
 				</tr>
 			</thead>
-			<tfoot>
-				<tr>
-					<td colspan="<?php echo $colSpan; ?>">
-						<?php echo $this->pagination->getListFooter(); ?>
-					</td>
-				</tr>
-			</tfoot>
 			<tbody>
 			<?php foreach ($this->items as $i => $item) :
 				$canEdit    = AssociationsHelper::allowEdit($this->extensionName, $this->typeName, $item->id);
@@ -159,6 +152,9 @@ HTMLHelper::_('script', 'com_associations/admin-associations-modal.min.js', fals
 				<?php endforeach; ?>
 			</tbody>
 		</table>
+
+		<?php // load the pagination. ?>
+		<?php echo $this->pagination->getListFooter(); ?>
 
 	<?php endif; ?>
 

--- a/administrator/components/com_banners/tmpl/banners/default.php
+++ b/administrator/components/com_banners/tmpl/banners/default.php
@@ -169,6 +169,10 @@ if ($saveOrder && !empty($this->items))
 							<?php endforeach; ?>
 						</tbody>
 					</table>
+					
+					<?php // load the pagination. ?>
+					<?php echo $this->pagination->getListFooter(); ?>
+
 					<?php // Load the batch processing form. ?>
 					<?php if ($user->authorise('core.create', 'com_banners')
 						&& $user->authorise('core.edit', 'com_banners')

--- a/administrator/components/com_banners/tmpl/banners/default.php
+++ b/administrator/components/com_banners/tmpl/banners/default.php
@@ -85,13 +85,6 @@ if ($saveOrder && !empty($this->items))
 								</th>
 							</tr>
 						</thead>
-						<tfoot>
-							<tr>
-								<td colspan="13">
-									<?php echo $this->pagination->getListFooter(); ?>
-								</td>
-							</tr>
-						</tfoot>
 						<tbody <?php if ($saveOrder) :?> class="js-draggable" data-url="<?php echo $saveOrderingUrl; ?>" data-direction="<?php echo strtolower($listDirn); ?>" data-nested="true"<?php endif; ?>>
 							<?php foreach ($this->items as $i => $item) :
 								$ordering  = ($listOrder == 'ordering');

--- a/administrator/components/com_banners/tmpl/clients/default.php
+++ b/administrator/components/com_banners/tmpl/clients/default.php
@@ -153,6 +153,10 @@ $params     = $this->state->params ?? new JObject;
 							<?php endforeach; ?>
 						</tbody>
 					</table>
+					
+					<?php // load the pagination. ?>
+					<?php echo $this->pagination->getListFooter(); ?>
+
 				<?php endif; ?>
 
 				<input type="hidden" name="task" value="">

--- a/administrator/components/com_banners/tmpl/clients/default.php
+++ b/administrator/components/com_banners/tmpl/clients/default.php
@@ -90,13 +90,6 @@ $params     = $this->state->params ?? new JObject;
 								</th>
 							</tr>
 						</thead>
-						<tfoot>
-							<tr>
-								<td colspan="11">
-									<?php echo $this->pagination->getListFooter(); ?>
-								</td>
-							</tr>
-						</tfoot>
 						<tbody>
 							<?php foreach ($this->items as $i => $item) :
 								$canCreate  = $user->authorise('core.create',     'com_banners');

--- a/administrator/components/com_banners/tmpl/tracks/default.php
+++ b/administrator/components/com_banners/tmpl/tracks/default.php
@@ -48,13 +48,6 @@ $listDirn   = $this->escape($this->state->get('list.direction'));
 								</th>
 							</tr>
 						</thead>
-						<tfoot>
-							<tr>
-								<td colspan="5">
-									<?php echo $this->pagination->getListFooter(); ?>
-								</td>
-							</tr>
-						</tfoot>
 						<tbody>
 							<?php foreach ($this->items as $i => $item) : ?>
 								<tr class="row<?php echo $i % 2; ?>">

--- a/administrator/components/com_banners/tmpl/tracks/default.php
+++ b/administrator/components/com_banners/tmpl/tracks/default.php
@@ -73,6 +73,10 @@ $listDirn   = $this->escape($this->state->get('list.direction'));
 							<?php endforeach; ?>
 						</tbody>
 					</table>
+					
+					<?php // load the pagination. ?>
+					<?php echo $this->pagination->getListFooter(); ?>
+
 				<?php endif; ?>
 				<?php // Load the export form ?>
 				<?php echo HTMLHelper::_(

--- a/administrator/components/com_cache/tmpl/cache/default.php
+++ b/administrator/components/com_cache/tmpl/cache/default.php
@@ -44,13 +44,6 @@ HTMLHelper::_('script', 'com_cache/admin-cache-default.js', ['relative' => true,
 							</th>
 						</tr>
 					</thead>
-					<tfoot>
-						<tr>
-							<td colspan="4">
-							<?php echo $this->pagination->getListFooter(); ?>
-							</td>
-						</tr>
-					</tfoot>
 					<tbody>
 						<?php $i = 0; ?>
 						<?php foreach ($this->data as $folder => $item) : ?>

--- a/administrator/components/com_cache/tmpl/cache/default.php
+++ b/administrator/components/com_cache/tmpl/cache/default.php
@@ -66,6 +66,10 @@ HTMLHelper::_('script', 'com_cache/admin-cache-default.js', ['relative' => true,
 						<?php $i++; endforeach; ?>
 					</tbody>
 				</table>
+					
+				<?php // load the pagination. ?>
+				<?php echo $this->pagination->getListFooter(); ?>
+
 				<?php endif; ?>
 				<input type="hidden" name="task" value="">
 				<input type="hidden" name="boxchecked" value="0">

--- a/administrator/components/com_categories/tmpl/categories/default.php
+++ b/administrator/components/com_categories/tmpl/categories/default.php
@@ -136,13 +136,6 @@ if ($saveOrder && !empty($this->items))
 								</th>
 							</tr>
 						</thead>
-						<tfoot>
-							<tr>
-								<td colspan="<?php echo $columns; ?>">
-									<?php echo $this->pagination->getListFooter(); ?>
-								</td>
-							</tr>
-						</tfoot>
 						<tbody <?php if ($saveOrder) :?> class="js-draggable" data-url="<?php echo $saveOrderingUrl; ?>" data-direction="<?php echo strtolower($listDirn); ?>" data-nested="false"<?php endif; ?>>
 							<?php foreach ($this->items as $i => $item) : ?>
 								<?php

--- a/administrator/components/com_categories/tmpl/categories/default.php
+++ b/administrator/components/com_categories/tmpl/categories/default.php
@@ -266,6 +266,10 @@ if ($saveOrder && !empty($this->items))
 							<?php endforeach; ?>
 						</tbody>
 					</table>
+					
+					<?php // load the pagination. ?>
+					<?php echo $this->pagination->getListFooter(); ?>
+
 					<?php // Load the batch processing form. ?>
 					<?php if ($user->authorise('core.create', $extension)
 						&& $user->authorise('core.edit', $extension)

--- a/administrator/components/com_categories/tmpl/categories/modal.php
+++ b/administrator/components/com_categories/tmpl/categories/modal.php
@@ -66,13 +66,6 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 						</th>
 					</tr>
 				</thead>
-				<tfoot>
-					<tr>
-						<td colspan="5">
-							<?php echo $this->pagination->getListFooter(); ?>
-						</td>
-					</tr>
-				</tfoot>
 				<tbody>
 					<?php
 					$iconStates = array(
@@ -127,6 +120,10 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 					<?php endforeach; ?>
 				</tbody>
 			</table>
+
+			<?php // load the pagination. ?>
+			<?php echo $this->pagination->getListFooter(); ?>
+
 		<?php endif; ?>
 
 		<input type="hidden" name="extension" value="<?php echo $extension; ?>">

--- a/administrator/components/com_checkin/tmpl/checkin/default.php
+++ b/administrator/components/com_checkin/tmpl/checkin/default.php
@@ -62,6 +62,10 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 							<?php endforeach; ?>
 						</tbody>
 					</table>
+					
+					<?php // load the pagination. ?>
+					<?php echo $this->pagination->getListFooter(); ?>
+
 				<?php endif; ?>
 				<input type="hidden" name="task" value="">
 				<input type="hidden" name="boxchecked" value="0">

--- a/administrator/components/com_checkin/tmpl/checkin/default.php
+++ b/administrator/components/com_checkin/tmpl/checkin/default.php
@@ -42,13 +42,6 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 								</th>
 							</tr>
 						</thead>
-						<tfoot>
-							<tr>
-								<td colspan="3">
-									<?php echo $this->pagination->getListFooter(); ?>
-								</td>
-							</tr>
-						</tfoot>
 						<tbody>
 							<?php $i = 0; ?>
 							<?php foreach ($this->items as $table => $count) : ?>

--- a/administrator/components/com_contact/tmpl/contacts/default.php
+++ b/administrator/components/com_contact/tmpl/contacts/default.php
@@ -83,13 +83,6 @@ if ($saveOrder && !empty($this->items))
 								</th>
 							</tr>
 						</thead>
-						<tfoot>
-							<tr>
-								<td colspan="10">
-									<?php echo $this->pagination->getListFooter(); ?>
-								</td>
-							</tr>
-						</tfoot>
 						<tbody <?php if ($saveOrder) :?> class="js-draggable" data-url="<?php echo $saveOrderingUrl; ?>" data-direction="<?php echo strtolower($listDirn); ?>" data-nested="true"<?php endif; ?>>
 						<?php
 						$n = count($this->items);

--- a/administrator/components/com_contact/tmpl/contacts/default.php
+++ b/administrator/components/com_contact/tmpl/contacts/default.php
@@ -173,6 +173,10 @@ if ($saveOrder && !empty($this->items))
 							<?php endforeach; ?>
 						</tbody>
 					</table>
+					
+					<?php // load the pagination. ?>
+					<?php echo $this->pagination->getListFooter(); ?>
+
 					<?php // Load the batch processing form. ?>
 					<?php if ($user->authorise('core.create', 'com_contact')
 						&& $user->authorise('core.edit', 'com_contact')

--- a/administrator/components/com_contact/tmpl/contacts/modal.php
+++ b/administrator/components/com_contact/tmpl/contacts/modal.php
@@ -77,13 +77,6 @@ if (!empty($editor))
 						</th>
 					</tr>
 				</thead>
-				<tfoot>
-					<tr>
-						<td colspan="6">
-							<?php echo $this->pagination->getListFooter(); ?>
-						</td>
-					</tr>
-				</tfoot>
 				<tbody>
 				<?php
 				$iconStates = array(
@@ -144,6 +137,10 @@ if (!empty($editor))
 				<?php endforeach; ?>
 				</tbody>
 			</table>
+
+			<?php // load the pagination. ?>
+			<?php echo $this->pagination->getListFooter(); ?>
+
 		<?php endif; ?>
 
 		<input type="hidden" name="task" value="">

--- a/administrator/components/com_content/tmpl/articles/default.php
+++ b/administrator/components/com_content/tmpl/articles/default.php
@@ -143,11 +143,6 @@ $featuredButton = (new ActionButton(['tip_title' => 'JGLOBAL_TOGGLE_FEATURED']))
 								</th>
 							</tr>
 						</thead>
-						<tfoot>
-							<tr>
-								<td colspan="<?php echo $columns; ?>"><?php echo $this->pagination->getListFooter(); ?></td>
-							</tr>
-						</tfoot>
 						<tbody <?php if ($saveOrder) :?> class="js-draggable" data-url="<?php echo $saveOrderingUrl; ?>" data-direction="<?php echo strtolower($listDirn); ?>" data-nested="true"<?php endif; ?>>
 						<?php foreach ($this->items as $i => $item) :
 							$item->max_ordering = 0;
@@ -271,6 +266,10 @@ $featuredButton = (new ActionButton(['tip_title' => 'JGLOBAL_TOGGLE_FEATURED']))
 							<?php endforeach; ?>
 						</tbody>
 					</table>
+					
+					<?php // load the paagination. ?>
+					<?php echo $this->pagination->getListFooter(); ?>
+
 					<?php // Load the batch processing form. ?>
 					<?php if ($user->authorise('core.create', 'com_content')
 						&& $user->authorise('core.edit', 'com_content')

--- a/administrator/components/com_content/tmpl/articles/default.php
+++ b/administrator/components/com_content/tmpl/articles/default.php
@@ -267,7 +267,7 @@ $featuredButton = (new ActionButton(['tip_title' => 'JGLOBAL_TOGGLE_FEATURED']))
 						</tbody>
 					</table>
 					
-					<?php // load the paagination. ?>
+					<?php // load the pagination. ?>
 					<?php echo $this->pagination->getListFooter(); ?>
 
 					<?php // Load the batch processing form. ?>

--- a/administrator/components/com_content/tmpl/articles/default.php
+++ b/administrator/components/com_content/tmpl/articles/default.php
@@ -32,7 +32,6 @@ $userId    = $user->get('id');
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
 $saveOrder = $listOrder == 'a.ordering';
-$columns   = 10;
 
 if (strpos($listOrder, 'publish_up') !== false)
 {
@@ -109,7 +108,6 @@ $featuredButton = (new ActionButton(['tip_title' => 'JGLOBAL_TOGGLE_FEATURED']))
 									<?php echo HTMLHelper::_('searchtools.sort',  'JGRID_HEADING_ACCESS', 'a.access', $listDirn, $listOrder); ?>
 								</th>
 								<?php if ($assoc) : ?>
-									<?php $columns++; ?>
 									<th scope="col" style="width:5%" class="nowrap d-none d-md-table-cell text-center">
 										<?php echo HTMLHelper::_('searchtools.sort', 'COM_CONTENT_HEADING_ASSOCIATION', 'association', $listDirn, $listOrder); ?>
 									</th>
@@ -129,11 +127,9 @@ $featuredButton = (new ActionButton(['tip_title' => 'JGLOBAL_TOGGLE_FEATURED']))
 									<?php echo HTMLHelper::_('searchtools.sort', 'JGLOBAL_HITS', 'a.hits', $listDirn, $listOrder); ?>
 								</th>
 								<?php if ($this->vote) : ?>
-									<?php $columns++; ?>
 									<th scope="col" style="width:3%" class="nowrap d-none d-md-table-cell text-center">
 										<?php echo HTMLHelper::_('searchtools.sort', 'JGLOBAL_VOTES', 'rating_count', $listDirn, $listOrder); ?>
 									</th>
-									<?php $columns++; ?>
 									<th scope="col" style="width:3%" class="nowrap d-none d-md-table-cell text-center">
 										<?php echo HTMLHelper::_('searchtools.sort', 'JGLOBAL_RATINGS', 'rating', $listDirn, $listOrder); ?>
 									</th>

--- a/administrator/components/com_content/tmpl/articles/modal.php
+++ b/administrator/components/com_content/tmpl/articles/modal.php
@@ -80,13 +80,6 @@ if (!empty($editor))
 						</th>
 					</tr>
 				</thead>
-				<tfoot>
-					<tr>
-						<td colspan="6">
-							<?php echo $this->pagination->getListFooter(); ?>
-						</td>
-					</tr>
-				</tfoot>
 				<tbody>
 				<?php
 				$iconStates = array(
@@ -152,6 +145,10 @@ if (!empty($editor))
 				<?php endforeach; ?>
 				</tbody>
 			</table>
+
+			<?php // load the pagination. ?>
+			<?php echo $this->pagination->getListFooter(); ?>
+
 		<?php endif; ?>
 
 		<input type="hidden" name="task" value="">

--- a/administrator/components/com_content/tmpl/featured/default.php
+++ b/administrator/components/com_content/tmpl/featured/default.php
@@ -112,13 +112,6 @@ if ($saveOrder)
 								</th>
 							</tr>
 						</thead>
-						<tfoot>
-							<tr>
-								<td colspan="<?php echo $columns; ?>">
-									<?php echo $this->pagination->getListFooter(); ?>
-								</td>
-							</tr>
-						</tfoot>
 						<tbody>
 						<?php $count = count($this->items); ?>
 						<?php foreach ($this->items as $i => $item) :

--- a/administrator/components/com_content/tmpl/featured/default.php
+++ b/administrator/components/com_content/tmpl/featured/default.php
@@ -230,6 +230,10 @@ if ($saveOrder)
 						<?php endforeach; ?>
 						</tbody>
 					</table>
+					
+					<?php // load the pagination. ?>
+					<?php echo $this->pagination->getListFooter(); ?>
+
 				<?php endif; ?>
 
 				<input type="hidden" name="task" value="">

--- a/administrator/components/com_content/tmpl/featured/default.php
+++ b/administrator/components/com_content/tmpl/featured/default.php
@@ -27,7 +27,6 @@ $userId    = $user->get('id');
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
 $saveOrder = $listOrder == 'fp.ordering';
-$columns   = 10;
 
 if (strpos($listOrder, 'publish_up') !== false)
 {
@@ -98,11 +97,9 @@ if ($saveOrder)
 									<?php echo HTMLHelper::_('searchtools.sort', 'JGLOBAL_HITS', 'a.hits', $listDirn, $listOrder); ?>
 								</th>
 								<?php if ($this->vote) : ?>
-									<?php $columns++; ?>
 									<th scope="col" style="width:3%" class="nowrap d-none d-md-table-cell text-center">
 										<?php echo HTMLHelper::_('searchtools.sort', 'JGLOBAL_VOTES', 'rating_count', $listDirn, $listOrder); ?>
 									</th>
-									<?php $columns++; ?>
 									<th scope="col" style="width:3%" class="nowrap d-none d-md-table-cell text-center">
 										<?php echo HTMLHelper::_('searchtools.sort', 'JGLOBAL_RATINGS', 'rating', $listDirn, $listOrder); ?>
 									</th>

--- a/administrator/components/com_contenthistory/tmpl/history/modal.php
+++ b/administrator/components/com_contenthistory/tmpl/history/modal.php
@@ -91,13 +91,6 @@ HTMLHelper::_('script', 'com_contenthistory/admin-history-modal.min.js', array('
 					</th>
 				</tr>
 			</thead>
-			<tfoot>
-				<tr>
-					<td colspan="15">
-						<?php echo $this->pagination->getListFooter(); ?>
-					</td>
-				</tr>
-			</tfoot>
 			<tbody>
 			<?php $i = 0; ?>
 			<?php foreach ($this->items as $item) : ?>
@@ -143,6 +136,9 @@ HTMLHelper::_('script', 'com_contenthistory/admin-history-modal.min.js', array('
 			<?php endforeach; ?>
 			</tbody>
 		</table>
+
+		<?php // load the pagination. ?>
+		<?php echo $this->pagination->getListFooter(); ?>
 
 		<input type="hidden" name="task" value="">
 		<input type="hidden" name="boxchecked" value="0">

--- a/administrator/components/com_csp/tmpl/reports/default.php
+++ b/administrator/components/com_csp/tmpl/reports/default.php
@@ -87,13 +87,6 @@ $saveOrder = $listOrder == 'a.id';
 								</th>
 							</tr>
 						</thead>
-						<tfoot>
-							<tr>
-								<td colspan="8">
-									<?php echo $this->pagination->getListFooter(); ?>
-								</td>
-							</tr>
-						</tfoot>
 						<tbody>
 							<?php foreach ($this->items as $i => $item) : ?>
 								<?php $canChange  = $user->authorise('core.edit.state', 'com_csp'); ?>

--- a/administrator/components/com_csp/tmpl/reports/default.php
+++ b/administrator/components/com_csp/tmpl/reports/default.php
@@ -121,6 +121,10 @@ $saveOrder = $listOrder == 'a.id';
 							<?php endforeach; ?>
 						</tbody>
 					</table>
+					
+					<?php // load the pagination. ?>
+					<?php echo $this->pagination->getListFooter(); ?>
+
 				<?php endif; ?>
 				<input type="hidden" name="task" value="">
 				<input type="hidden" name="boxchecked" value="0">

--- a/administrator/components/com_fields/tmpl/fields/default.php
+++ b/administrator/components/com_fields/tmpl/fields/default.php
@@ -171,6 +171,10 @@ if ($saveOrder && !empty($this->items))
 							<?php endforeach; ?>
 						</tbody>
 					</table>
+					
+					<?php // load the pagination. ?>
+					<?php echo $this->pagination->getListFooter(); ?>
+
 					<?php //Load the batch processing form. ?>
 					<?php if ($user->authorise('core.create', $component)
 						&& $user->authorise('core.edit', $component)

--- a/administrator/components/com_fields/tmpl/fields/default.php
+++ b/administrator/components/com_fields/tmpl/fields/default.php
@@ -88,13 +88,6 @@ if ($saveOrder && !empty($this->items))
 								</th>
 							</tr>
 						</thead>
-						<tfoot>
-							<tr>
-								<td colspan="9">
-									<?php echo $this->pagination->getListFooter(); ?>
-								</td>
-							</tr>
-						</tfoot>
 						<tbody <?php if ($saveOrder) : ?> class="js-draggable" data-url="<?php echo $saveOrderingUrl; ?>" data-direction="<?php echo strtolower($listDirn); ?>" data-nested="true"<?php endif; ?>>
 							<?php foreach ($this->items as $i => $item) : ?>
 								<?php $ordering   = ($listOrder == 'a.ordering'); ?>

--- a/administrator/components/com_fields/tmpl/fields/modal.php
+++ b/administrator/components/com_fields/tmpl/fields/modal.php
@@ -63,13 +63,6 @@ $editor    = Factory::getApplication()->input->get('editor', '', 'cmd');
 						</th>
 					</tr>
 				</thead>
-				<tfoot>
-					<tr>
-						<td colspan="8">
-							<?php echo $this->pagination->getListFooter(); ?>
-						</td>
-					</tr>
-				</tfoot>
 				<tbody>
 					<?php
 					$iconStates = array(
@@ -106,6 +99,10 @@ $editor    = Factory::getApplication()->input->get('editor', '', 'cmd');
 				<?php endforeach; ?>
 				</tbody>
 			</table>
+
+			<?php // load the pagination. ?>
+			<?php echo $this->pagination->getListFooter(); ?>
+
 		<?php endif; ?>
 
 		<input type="hidden" name="task" value="">

--- a/administrator/components/com_fields/tmpl/groups/default.php
+++ b/administrator/components/com_fields/tmpl/groups/default.php
@@ -86,13 +86,6 @@ if ($saveOrder && !empty($this->items))
 								</th>
 							</tr>
 						</thead>
-						<tfoot>
-							<tr>
-								<td colspan="9">
-									<?php echo $this->pagination->getListFooter(); ?>
-								</td>
-							</tr>
-						</tfoot>
 						<tbody <?php if ($saveOrder) : ?> class="js-draggable" data-url="<?php echo $saveOrderingUrl; ?>" data-direction="<?php echo strtolower($listDirn); ?>" data-nested="true"<?php endif; ?>>
 							<?php foreach ($this->items as $i => $item) : ?>
 								<?php $ordering   = ($listOrder == 'a.ordering'); ?>

--- a/administrator/components/com_fields/tmpl/groups/default.php
+++ b/administrator/components/com_fields/tmpl/groups/default.php
@@ -150,6 +150,10 @@ if ($saveOrder && !empty($this->items))
 							<?php endforeach; ?>
 						</tbody>
 					</table>
+					
+					<?php // load the pagination. ?>
+					<?php echo $this->pagination->getListFooter(); ?>
+
 					<?php //Load the batch processing form. ?>
 					<?php if ($user->authorise('core.create', $component)
 						&& $user->authorise('core.edit', $component)

--- a/administrator/components/com_finder/tmpl/filters/default.php
+++ b/administrator/components/com_finder/tmpl/filters/default.php
@@ -56,13 +56,6 @@ HTMLHelper::_('script', 'com_finder/filters.js', ['relative' => true, 'version' 
 							</th>
 						</tr>
 					</thead>
-					<tfoot>
-						<tr>
-							<td colspan="7">
-								<?php echo $this->pagination->getListFooter(); ?>
-							</td>
-						</tr>
-					</tfoot>
 					<tbody>
 						<?php
 						$canCreate                  = $user->authorise('core.create',     'com_finder');

--- a/administrator/components/com_finder/tmpl/filters/default.php
+++ b/administrator/components/com_finder/tmpl/filters/default.php
@@ -102,6 +102,10 @@ HTMLHelper::_('script', 'com_finder/filters.js', ['relative' => true, 'version' 
 						<?php endforeach; ?>
 					</tbody>
 				</table>
+					
+				<?php // load the pagination. ?>
+				<?php echo $this->pagination->getListFooter(); ?>
+
 				<?php endif; ?>
 				<input type="hidden" name="task" value="">
 				<input type="hidden" name="boxchecked" value="0">

--- a/administrator/components/com_finder/tmpl/index/default.php
+++ b/administrator/components/com_finder/tmpl/index/default.php
@@ -93,6 +93,10 @@ HTMLHelper::_('script', 'com_finder/index.js', ['relative' => true, 'version' =>
 						<?php endforeach; ?>
 					</tbody>
 				</table>
+					
+				<?php // load the pagination. ?>
+				<?php echo $this->pagination->getListFooter(); ?>
+
 				<input type="hidden" name="task" value="display">
 				<input type="hidden" name="boxchecked" value="0">
 				<?php echo JHtml::_('form.token'); ?>

--- a/administrator/components/com_finder/tmpl/index/default.php
+++ b/administrator/components/com_finder/tmpl/index/default.php
@@ -56,13 +56,6 @@ HTMLHelper::_('script', 'com_finder/index.js', ['relative' => true, 'version' =>
 							</th>
 						</tr>
 					</thead>
-					<tfoot>
-						<tr>
-							<td colspan="7">
-								<?php echo $this->pagination->getListFooter(); ?>
-							</td>
-						</tr>
-					</tfoot>
 					<tbody>
 						<?php $canChange = JFactory::getUser()->authorise('core.manage', 'com_finder'); ?>
 						<?php foreach ($this->items as $i => $item) : ?>

--- a/administrator/components/com_finder/tmpl/maps/default.php
+++ b/administrator/components/com_finder/tmpl/maps/default.php
@@ -16,7 +16,6 @@ $listOrder     = $this->escape($this->state->get('list.ordering'));
 $listDirn      = $this->escape($this->state->get('list.direction'));
 $lang          = JFactory::getLanguage();
 $branchFilter  = $this->escape($this->state->get('filter.branch'));
-$colSpan       = $branchFilter ? 5 : 6;
 JText::script('COM_FINDER_MAPS_CONFIRM_DELETE_PROMPT');
 HTMLHelper::_('script', 'com_finder/maps.js', ['relative' => true, 'version' => 'auto']);
 ?>

--- a/administrator/components/com_finder/tmpl/maps/default.php
+++ b/administrator/components/com_finder/tmpl/maps/default.php
@@ -58,13 +58,6 @@ HTMLHelper::_('script', 'com_finder/maps.js', ['relative' => true, 'version' => 
 							</th>
 						</tr>
 					</thead>
-					<tfoot>
-						<tr>
-							<td colspan="<?php echo $colSpan; ?>">
-								<?php echo $this->pagination->getListFooter(); ?>
-							</td>
-						</tr>
-					</tfoot>
 					<tbody>
 						<?php $canChange = JFactory::getUser()->authorise('core.manage', 'com_finder'); ?>
 						<?php foreach ($this->items as $i => $item) : ?>

--- a/administrator/components/com_finder/tmpl/maps/default.php
+++ b/administrator/components/com_finder/tmpl/maps/default.php
@@ -120,6 +120,10 @@ HTMLHelper::_('script', 'com_finder/maps.js', ['relative' => true, 'version' => 
 						<?php endforeach; ?>
 					</tbody>
 				</table>
+					
+				<?php // load the pagination. ?>
+				<?php echo $this->pagination->getListFooter(); ?>
+
 				<?php endif; ?>
 			</div>
 

--- a/administrator/components/com_finder/tmpl/searches/default.php
+++ b/administrator/components/com_finder/tmpl/searches/default.php
@@ -58,6 +58,10 @@ $listDirn = $this->escape($this->state->get('list.direction'));
 					<?php endforeach; ?>
 					</tbody>
 				</table>
+					
+				<?php // load the pagination. ?>
+				<?php echo $this->pagination->getListFooter(); ?>
+
 				<?php endif; ?>
 				<input type="hidden" name="task" value="">
 				<input type="hidden" name="boxchecked" value="0">

--- a/administrator/components/com_finder/tmpl/searches/default.php
+++ b/administrator/components/com_finder/tmpl/searches/default.php
@@ -42,13 +42,6 @@ $listDirn = $this->escape($this->state->get('list.direction'));
 							</th>
 						</tr>
 					</thead>
-					<tfoot>
-						<tr>
-							<td colspan="3">
-								<?php echo $this->pagination->getListFooter(); ?>
-							</td>
-						</tr>
-					</tfoot>
 					<tbody>
 					<?php foreach ($this->items as $i => $item) : ?>
 						<tr class="row<?php echo $i % 2; ?>">

--- a/administrator/components/com_installer/tmpl/database/default.php
+++ b/administrator/components/com_installer/tmpl/database/default.php
@@ -72,13 +72,6 @@ $listDirection = $this->escape($this->state->get('list.direction'));
 										</th>
 									</tr>
 								</thead>
-								<tfoot>
-									<tr>
-										<td colspan="9">
-											<?php echo $this->pagination->getListFooter(); ?>
-										</td>
-									</tr>
-								</tfoot>
 								<tbody>
 									<?php foreach ($this->changeSet as $i => $item) : ?>
 										<?php $extension = $item['extension']; ?>

--- a/administrator/components/com_installer/tmpl/database/default.php
+++ b/administrator/components/com_installer/tmpl/database/default.php
@@ -118,6 +118,10 @@ $listDirection = $this->escape($this->state->get('list.direction'));
 									<?php endforeach; ?>
 								</tbody>
 							</table>
+					
+							<?php // load the pagination. ?>
+							<?php echo $this->pagination->getListFooter(); ?>
+
 						<?php endif; ?>
 					</div>
 					<input type="hidden" name="task" value="">

--- a/administrator/components/com_installer/tmpl/discover/default.php
+++ b/administrator/components/com_installer/tmpl/discover/default.php
@@ -65,11 +65,6 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 								</th>
 							</tr>
 						</thead>
-						<tfoot>
-							<tr>
-								<td colspan="9"><?php echo $this->pagination->getListFooter(); ?></td>
-							</tr>
-						</tfoot>
 						<tbody>
 						<?php foreach ($this->items as $i => $item) : ?>
 							<tr class="row<?php echo $i % 2; ?>">

--- a/administrator/components/com_installer/tmpl/discover/default.php
+++ b/administrator/components/com_installer/tmpl/discover/default.php
@@ -103,6 +103,10 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 						<?php endforeach; ?>
 						</tbody>
 					</table>
+					
+					<?php // load the pagination. ?>
+					<?php echo $this->pagination->getListFooter(); ?>
+
 					<?php endif; ?>
 					<input type="hidden" name="task" value="">
 					<input type="hidden" name="boxchecked" value="0">

--- a/administrator/components/com_installer/tmpl/languages/default.php
+++ b/administrator/components/com_installer/tmpl/languages/default.php
@@ -44,13 +44,6 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 								</th>
 							</tr>
 						</thead>
-						<tfoot>
-							<tr>
-								<td colspan="6">
-									<?php echo $this->pagination->getListFooter(); ?>
-								</td>
-							</tr>
-						</tfoot>
 						<tbody>
 						<?php
 						$version = new JVersion;

--- a/administrator/components/com_installer/tmpl/languages/default.php
+++ b/administrator/components/com_installer/tmpl/languages/default.php
@@ -82,6 +82,10 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 						<?php endforeach; ?>
 						</tbody>
 					</table>
+					
+					<?php // load the pagination. ?>
+					<?php echo $this->pagination->getListFooter(); ?>
+
 					<?php endif; ?>
 					<input type="hidden" name="task" value="">
 					<input type="hidden" name="return" value="<?php echo base64_encode('index.php?option=com_installer&view=languages') ?>">

--- a/administrator/components/com_installer/tmpl/manage/default.php
+++ b/administrator/components/com_installer/tmpl/manage/default.php
@@ -70,13 +70,6 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 								</th>
 							</tr>
 						</thead>
-						<tfoot>
-							<tr>
-								<td colspan="11">
-									<?php echo $this->pagination->getListFooter(); ?>
-								</td>
-							</tr>
-						</tfoot>
 						<tbody>
 						<?php foreach ($this->items as $i => $item) : ?>
 							<tr class="row<?php echo $i % 2; if ($item->status == 2) echo ' protected'; ?>">

--- a/administrator/components/com_installer/tmpl/manage/default.php
+++ b/administrator/components/com_installer/tmpl/manage/default.php
@@ -120,6 +120,10 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 						<?php endforeach; ?>
 						</tbody>
 					</table>
+					
+					<?php // load the pagination. ?>
+					<?php echo $this->pagination->getListFooter(); ?>
+
 					<?php endif; ?>
 					<input type="hidden" name="task" value="">
 					<input type="hidden" name="boxchecked" value="0">

--- a/administrator/components/com_installer/tmpl/update/default.php
+++ b/administrator/components/com_installer/tmpl/update/default.php
@@ -65,13 +65,6 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 								</th>
 							</tr>
 							</thead>
-							<tfoot>
-							<tr>
-								<td colspan="9">
-									<?php echo $this->pagination->getListFooter(); ?>
-								</td>
-							</tr>
-							</tfoot>
 							<tbody>
 							<?php foreach ($this->items as $i => $item) : ?>
 								<?php

--- a/administrator/components/com_installer/tmpl/update/default.php
+++ b/administrator/components/com_installer/tmpl/update/default.php
@@ -114,6 +114,10 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 							<?php endforeach; ?>
 							</tbody>
 						</table>
+					
+						<?php // load the pagination. ?>
+						<?php echo $this->pagination->getListFooter(); ?>
+
 					<?php endif; ?>
 					<input type="hidden" name="task" value="">
 					<input type="hidden" name="boxchecked" value="0">

--- a/administrator/components/com_installer/tmpl/updatesites/default.php
+++ b/administrator/components/com_installer/tmpl/updatesites/default.php
@@ -98,6 +98,10 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 						<?php endforeach; ?>
 						</tbody>
 					</table>
+					
+					<?php // load the pagination. ?>
+					<?php echo $this->pagination->getListFooter(); ?>
+
 					<?php endif; ?>
 					<input type="hidden" name="task" value="">
 					<input type="hidden" name="boxchecked" value="0">

--- a/administrator/components/com_installer/tmpl/updatesites/default.php
+++ b/administrator/components/com_installer/tmpl/updatesites/default.php
@@ -55,13 +55,6 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 								</th>
 							</tr>
 						</thead>
-						<tfoot>
-							<tr>
-								<td colspan="8">
-									<?php echo $this->pagination->getListFooter(); ?>
-								</td>
-							</tr>
-						</tfoot>
 						<tbody>
 						<?php foreach ($this->items as $i => $item) : ?>
 							<tr class="row<?php echo $i % 2; if ($item->enabled == 2) echo ' protected'; ?>">

--- a/administrator/components/com_languages/tmpl/installed/default.php
+++ b/administrator/components/com_languages/tmpl/installed/default.php
@@ -62,13 +62,6 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 							</th>
 						</tr>
 					</thead>
-					<tfoot>
-						<tr>
-							<td colspan="10">
-								<?php echo $this->pagination->getListFooter(); ?>
-							</td>
-						</tr>
-					</tfoot>
 					<tbody>
 					<?php
 					$version = new JVersion;

--- a/administrator/components/com_languages/tmpl/installed/default.php
+++ b/administrator/components/com_languages/tmpl/installed/default.php
@@ -114,6 +114,10 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 					<?php endforeach; ?>
 					</tbody>
 				</table>
+					
+				<?php // load the pagination. ?>
+				<?php echo $this->pagination->getListFooter(); ?>
+
 				<?php endif; ?>
 				<input type="hidden" name="task" value="">
 				<input type="hidden" name="boxchecked" value="0">

--- a/administrator/components/com_languages/tmpl/languages/default.php
+++ b/administrator/components/com_languages/tmpl/languages/default.php
@@ -145,6 +145,10 @@ if ($saveOrder)
 							<?php endforeach; ?>
 						</tbody>
 					</table>
+					
+					<?php // load the pagination. ?>
+					<?php echo $this->pagination->getListFooter(); ?>
+
 				<?php endif; ?>
 				<input type="hidden" name="task" value="">
 				<input type="hidden" name="boxchecked" value="0">

--- a/administrator/components/com_languages/tmpl/languages/default.php
+++ b/administrator/components/com_languages/tmpl/languages/default.php
@@ -73,13 +73,6 @@ if ($saveOrder)
 								</th>
 							</tr>
 						</thead>
-						<tfoot>
-							<tr>
-								<td colspan="11">
-									<?php echo $this->pagination->getListFooter(); ?>
-								</td>
-							</tr>
-						</tfoot>
 						<tbody>
 						<?php
 						foreach ($this->items as $i => $item) :

--- a/administrator/components/com_languages/tmpl/overrides/default.php
+++ b/administrator/components/com_languages/tmpl/overrides/default.php
@@ -104,6 +104,10 @@ $opposite_strings  = LanguagesHelper::parseFile($opposite_filename);
 						<?php endforeach; ?>
 						</tbody>
 					</table>
+					
+					<?php // load the pagination. ?>
+					<?php echo $this->pagination->getListFooter(); ?>
+
 				<?php endif; ?>
 
 				<input type="hidden" name="task" value="">

--- a/administrator/components/com_languages/tmpl/overrides/default.php
+++ b/administrator/components/com_languages/tmpl/overrides/default.php
@@ -68,13 +68,6 @@ $opposite_strings  = LanguagesHelper::parseFile($opposite_filename);
 								</th>
 							</tr>
 						</thead>
-						<tfoot>
-							<tr>
-								<td colspan="5">
-									<?php echo $this->pagination->getListFooter(); ?>
-								</td>
-							</tr>
-						</tfoot>
 						<tbody>
 						<?php $canEdit = JFactory::getUser()->authorise('core.edit', 'com_languages'); ?>
 						<?php $i = 0; ?>

--- a/administrator/components/com_menus/tmpl/items/default.php
+++ b/administrator/components/com_menus/tmpl/items/default.php
@@ -39,12 +39,7 @@ if ($saveOrder && $menuType && !empty($this->items))
 }
 
 $assoc   = Associations::isEnabled() && $this->state->get('filter.client_id') == 0;
-$colSpan = $assoc ? 10 : 9;
 
-if ($menuType == '')
-{
-	$colSpan--;
-}
 ?>
 <?php // Set up the filter bar. ?>
 <form action="<?php echo Route::_('index.php?option=com_menus&view=items'); ?>" method="post" name="adminForm"

--- a/administrator/components/com_menus/tmpl/items/default.php
+++ b/administrator/components/com_menus/tmpl/items/default.php
@@ -104,14 +104,6 @@ if ($menuType == '')
 							</th>
 						</tr>
 						</thead>
-						<tfoot>
-						<tr>
-							<td colspan="<?php echo $colSpan; ?>">
-								<?php echo $this->pagination->getListFooter(); ?>
-							</td>
-						</tr>
-						</tfoot>
-
 						<tbody <?php if ($saveOrder && $menuType) :?> class="js-draggable" data-url="<?php echo $saveOrderingUrl; ?>" data-direction="<?php echo strtolower($listDirn); ?>" data-nested="false"<?php endif; ?>>
 						<?php
 						foreach ($this->items as $i => $item) :

--- a/administrator/components/com_menus/tmpl/items/default.php
+++ b/administrator/components/com_menus/tmpl/items/default.php
@@ -264,6 +264,10 @@ if ($menuType == '')
 						<?php endforeach; ?>
 						</tbody>
 					</table>
+					
+					<?php // load the pagination. ?>
+					<?php echo $this->pagination->getListFooter(); ?>
+
 					<?php // Load the batch processing form if user is allowed ?>
 					<?php if ($user->authorise('core.create', 'com_menus') || $user->authorise('core.edit', 'com_menus')) : ?>
 						<?php echo HTMLHelper::_(

--- a/administrator/components/com_menus/tmpl/items/modal.php
+++ b/administrator/components/com_menus/tmpl/items/modal.php
@@ -79,13 +79,6 @@ if (!empty($editor))
 						</th>
 					</tr>
 				</thead>
-				<tfoot>
-					<tr>
-						<td colspan="7">
-							<?php echo $this->pagination->getListFooter(); ?>
-						</td>
-					</tr>
-				</tfoot>
 				<tbody>
 				<?php foreach ($this->items as $i => $item) : ?>
 					<?php $uselessMenuItem = in_array($item->type, array('separator', 'heading', 'alias', 'url', 'container')); ?>
@@ -169,6 +162,10 @@ if (!empty($editor))
 				<?php endforeach; ?>
 				</tbody>
 			</table>
+
+			<?php // load the pagination. ?>
+			<?php echo $this->pagination->getListFooter(); ?>
+
 		<?php endif; ?>
 
 		<input type="hidden" name="task" value="">

--- a/administrator/components/com_menus/tmpl/menus/default.php
+++ b/administrator/components/com_menus/tmpl/menus/default.php
@@ -81,13 +81,6 @@ HTMLHelper::_('script', 'com_menus/admin-menus-default.min.js', array('version' 
 								</th>
 							</tr>
 						</thead>
-						<tfoot>
-							<tr>
-								<td colspan="15">
-									<?php echo $this->pagination->getListFooter(); ?>
-								</td>
-							</tr>
-						</tfoot>
 						<tbody>
 						<?php foreach ($this->items as $i => $item) :
 							$canEdit        = $user->authorise('core.edit',   'com_menus.menu.' . (int) $item->id);

--- a/administrator/components/com_menus/tmpl/menus/default.php
+++ b/administrator/components/com_menus/tmpl/menus/default.php
@@ -220,6 +220,10 @@ HTMLHelper::_('script', 'com_menus/admin-menus-default.min.js', array('version' 
 							<?php endforeach; ?>
 						</tbody>
 					</table>
+					
+					<?php // load the pagination. ?>
+					<?php echo $this->pagination->getListFooter(); ?>
+
 				<?php endif; ?>
 
 				<input type="hidden" name="task" value="">

--- a/administrator/components/com_messages/tmpl/messages/default.php
+++ b/administrator/components/com_messages/tmpl/messages/default.php
@@ -50,13 +50,6 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 						</th>
 					</tr>
 				</thead>
-				<tfoot>
-					<tr>
-						<td colspan="5">
-							<?php echo $this->pagination->getListFooter(); ?>
-						</td>
-					</tr>
-				</tfoot>
 				<tbody>
 				<?php foreach ($this->items as $i => $item) :
 					$canChange = $user->authorise('core.edit.state', 'com_messages');

--- a/administrator/components/com_messages/tmpl/messages/default.php
+++ b/administrator/components/com_messages/tmpl/messages/default.php
@@ -75,6 +75,10 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 					<?php endforeach; ?>
 				</tbody>
 			</table>
+					
+			<?php // load the pagination. ?>
+			<?php echo $this->pagination->getListFooter(); ?>
+
 		<?php endif; ?>
 		<div>
 			<input type="hidden" name="task" value="">

--- a/administrator/components/com_modules/tmpl/modules/default.php
+++ b/administrator/components/com_modules/tmpl/modules/default.php
@@ -31,7 +31,6 @@ if ($saveOrder && !empty($this->items))
 	$saveOrderingUrl = 'index.php?option=com_modules&task=modules.saveOrderAjax&tmpl=component' . Session::getFormToken() . '=1';
 	HTMLHelper::_('draggablelist.draggable');
 }
-$colSpan = $clientId === 1 ? 8 : 10;
 ?>
 <form action="<?php echo Route::_('index.php?option=com_modules'); ?>" method="post" name="adminForm" id="adminForm">
 	<div id="j-main-container" class="j-main-container">

--- a/administrator/components/com_modules/tmpl/modules/default.php
+++ b/administrator/components/com_modules/tmpl/modules/default.php
@@ -80,13 +80,6 @@ $colSpan = $clientId === 1 ? 8 : 10;
 						</th>
 					</tr>
 				</thead>
-				<tfoot>
-					<tr>
-						<td colspan="<?php echo $colSpan; ?>">
-							<?php echo $this->pagination->getListFooter(); ?>
-						</td>
-					</tr>
-				</tfoot>
 				<tbody <?php if ($saveOrder) :?> class="js-draggable" data-url="<?php echo $saveOrderingUrl; ?>" data-direction="<?php echo strtolower($listDirn); ?>" data-nested="false"<?php endif; ?>>
 				<?php foreach ($this->items as $i => $item) :
 					$ordering   = ($listOrder == 'a.ordering');

--- a/administrator/components/com_modules/tmpl/modules/default.php
+++ b/administrator/components/com_modules/tmpl/modules/default.php
@@ -190,6 +190,10 @@ $colSpan = $clientId === 1 ? 8 : 10;
 					<?php endforeach; ?>
 				</tbody>
 			</table>
+					
+			<?php // load the pagination. ?>
+			<?php echo $this->pagination->getListFooter(); ?>
+
 		<?php endif; ?>
 
 		<?php // Load the batch processing form. ?>

--- a/administrator/components/com_modules/tmpl/modules/modal.php
+++ b/administrator/components/com_modules/tmpl/modules/modal.php
@@ -68,13 +68,6 @@ $editor    = Factory::getApplication()->input->get('editor', '', 'cmd');
 					</th>
 				</tr>
 			</thead>
-			<tfoot>
-				<tr>
-					<td colspan="8">
-						<?php echo $this->pagination->getListFooter(); ?>
-					</td>
-				</tr>
-			</tfoot>
 			<tbody>
 				<?php
 				$iconStates = array(
@@ -120,6 +113,10 @@ $editor    = Factory::getApplication()->input->get('editor', '', 'cmd');
 			<?php endforeach; ?>
 			</tbody>
 		</table>
+
+		<?php // load the pagination. ?>
+		<?php echo $this->pagination->getListFooter(); ?>
+
 		<?php endif; ?>
 
 		<input type="hidden" name="task" value="">

--- a/administrator/components/com_newsfeeds/tmpl/newsfeeds/default.php
+++ b/administrator/components/com_newsfeeds/tmpl/newsfeeds/default.php
@@ -171,6 +171,10 @@ if ($saveOrder && !empty($this->items))
 							<?php endforeach; ?>
 						</tbody>
 					</table>
+					
+					<?php // load the pagination. ?>
+					<?php echo $this->pagination->getListFooter(); ?>
+
 					<?php // Load the batch processing form if user is allowed ?>
 					<?php if ($user->authorise('core.create', 'com_newsfeeds')
 						&& $user->authorise('core.edit', 'com_newsfeeds')

--- a/administrator/components/com_newsfeeds/tmpl/newsfeeds/default.php
+++ b/administrator/components/com_newsfeeds/tmpl/newsfeeds/default.php
@@ -86,13 +86,6 @@ if ($saveOrder && !empty($this->items))
 								</th>
 							</tr>
 						</thead>
-						<tfoot>
-							<tr>
-								<td colspan="11">
-									<?php echo $this->pagination->getListFooter(); ?>
-								</td>
-							</tr>
-						</tfoot>
 						<tbody <?php if ($saveOrder) :?> class="js-draggable" data-url="<?php echo $saveOrderingUrl; ?>" data-direction="<?php echo strtolower($listDirn); ?>" data-nested="true"<?php endif; ?>>
 						<?php foreach ($this->items as $i => $item) :
 							$ordering   = ($listOrder == 'a.ordering');

--- a/administrator/components/com_newsfeeds/tmpl/newsfeeds/modal.php
+++ b/administrator/components/com_newsfeeds/tmpl/newsfeeds/modal.php
@@ -58,13 +58,6 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 						</th>
 					</tr>
 				</thead>
-				<tfoot>
-					<tr>
-						<td colspan="5">
-							<?php echo $this->pagination->getListFooter(); ?>
-						</td>
-					</tr>
-				</tfoot>
 				<tbody>
 				<?php
 				$iconStates = array(
@@ -119,6 +112,10 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 				<?php endforeach; ?>
 				</tbody>
 			</table>
+
+			<?php // load the pagination. ?>
+			<?php echo $this->pagination->getListFooter(); ?>
+
 		<?php endif; ?>
 
 		<input type="hidden" name="task" value="">

--- a/administrator/components/com_plugins/tmpl/plugins/default.php
+++ b/administrator/components/com_plugins/tmpl/plugins/default.php
@@ -129,6 +129,10 @@ if ($saveOrder)
 				<?php endforeach; ?>
 				</tbody>
 			</table>
+					
+			<?php // load the pagination. ?>
+			<?php echo $this->pagination->getListFooter(); ?>
+
 		<?php endif; ?>
 
 		<input type="hidden" name="task" value="">

--- a/administrator/components/com_plugins/tmpl/plugins/default.php
+++ b/administrator/components/com_plugins/tmpl/plugins/default.php
@@ -68,13 +68,6 @@ if ($saveOrder)
 						</th>
 					</tr>
 				</thead>
-				<tfoot>
-					<tr>
-						<td colspan="8">
-							<?php echo $this->pagination->getListFooter(); ?>
-						</td>
-					</tr>
-				</tfoot>
                 <tbody <?php if ($saveOrder) :?> class="js-draggable" data-url="<?php echo $saveOrderingUrl; ?>" data-direction="<?php echo strtolower($listDirn); ?>" data-nested="true"<?php endif; ?>>
 				<?php foreach ($this->items as $i => $item) :
 					$ordering   = ($listOrder == 'ordering');

--- a/administrator/components/com_redirect/tmpl/links/default.php
+++ b/administrator/components/com_redirect/tmpl/links/default.php
@@ -89,13 +89,6 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 						</th>
 					</tr>
 				</thead>
-				<tfoot>
-					<tr>
-						<td colspan="9">
-							<?php echo $this->pagination->getListFooter(); ?>
-						</td>
-					</tr>
-				</tfoot>
 				<tbody>
 				<?php foreach ($this->items as $i => $item) :
 					$canEdit   = $user->authorise('core.edit',       'com_redirect');

--- a/administrator/components/com_redirect/tmpl/links/default.php
+++ b/administrator/components/com_redirect/tmpl/links/default.php
@@ -133,6 +133,10 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 					<?php endforeach; ?>
 				</tbody>
 			</table>
+					
+			<?php // load the pagination. ?>
+			<?php echo $this->pagination->getListFooter(); ?>
+
 		<?php endif; ?>
 
 		<?php if (!empty($this->items)) : ?>

--- a/administrator/components/com_search/tmpl/searches/default.php
+++ b/administrator/components/com_search/tmpl/searches/default.php
@@ -43,13 +43,6 @@ $listDirn = $this->escape($this->state->get('list.direction'));
 					</th>
 				</tr>
 			</thead>
-			<tfoot>
-				<tr>
-					<td colspan="3">
-						<?php echo $this->pagination->getListFooter(); ?>
-					</td>
-				</tr>
-			</tfoot>
 			<tbody>
 			<?php foreach ($this->items as $i => $item) : ?>
 				<tr class="row<?php echo $i % 2; ?>">

--- a/administrator/components/com_search/tmpl/searches/default.php
+++ b/administrator/components/com_search/tmpl/searches/default.php
@@ -66,6 +66,10 @@ $listDirn = $this->escape($this->state->get('list.direction'));
 			<?php endforeach; ?>
 			</tbody>
 		</table>
+					
+		<?php // load the pagination. ?>
+		<?php echo $this->pagination->getListFooter(); ?>
+
 		<?php endif; ?>
 		<input type="hidden" name="task" value="">
 		<input type="hidden" name="boxchecked" value="0">

--- a/administrator/components/com_tags/tmpl/tags/default.php
+++ b/administrator/components/com_tags/tmpl/tags/default.php
@@ -34,7 +34,6 @@ $parts     = explode('.', $extension);
 $component = $parts[0];
 $section   = null;
 $mode      = false;
-$columns   = 7;
 
 if (count($parts) > 1)
 {
@@ -89,25 +88,21 @@ if ($saveOrder && !empty($this->items))
 							<th scope="col" style="width:1%" class="nowrap text-center d-none d-md-table-cell">
 								<span class="icon-publish hasTooltip" aria-hidden="true" title="<?php echo Text::_('COM_TAGS_COUNT_PUBLISHED_ITEMS'); ?>"><span class="sr-only"><?php echo Text::_('COM_TAGS_COUNT_PUBLISHED_ITEMS'); ?></span></span>
 							</th>
-							<?php $columns++; ?>
 						<?php endif; ?>
 						<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_unpublished')) : ?>
 							<th scope="col" style="width:1%" class="nowrap text-center d-none d-md-table-cell">
 								<span class="icon-unpublish hasTooltip" aria-hidden="true" title="<?php echo Text::_('COM_TAGS_COUNT_UNPUBLISHED_ITEMS'); ?>"><span class="sr-only"><?php echo Text::_('COM_TAGS_COUNT_UNPUBLISHED_ITEMS'); ?></span></span>
 							</th>
-							<?php $columns++; ?>
 						<?php endif; ?>
 						<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_archived')) : ?>
 							<th scope="col" style="width:1%" class="nowrap text-center d-none d-md-table-cell">
 								<span class="icon-archive hasTooltip" aria-hidden="true" title="<?php echo Text::_('COM_TAGS_COUNT_ARCHIVED_ITEMS'); ?>"><span class="sr-only"><?php echo Text::_('COM_TAGS_COUNT_ARCHIVED_ITEMS'); ?></span></span>
 							</th>
-							<?php $columns++; ?>
 						<?php endif; ?>
 						<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_trashed')) : ?>
 							<th scope="col" style="width:1%" class="nowrap text-center d-none d-md-table-cell">
 								<span class="icon-trash hasTooltip" aria-hidden="true" title="<?php echo Text::_('COM_TAGS_COUNT_TRASHED_ITEMS'); ?>"><span class="sr-only"><?php echo Text::_('COM_TAGS_COUNT_TRASHED_ITEMS'); ?></span></span>
 							</th>
-							<?php $columns++; ?>
 						<?php endif; ?>
  
 						<th scope="col" style="width:10%" class="nowrap d-none d-md-table-cell text-center">

--- a/administrator/components/com_tags/tmpl/tags/default.php
+++ b/administrator/components/com_tags/tmpl/tags/default.php
@@ -123,13 +123,6 @@ if ($saveOrder && !empty($this->items))
 						</th>
 					</tr>
 				</thead>
-				<tfoot>
-					<tr>
-						<td colspan="<?php echo $columns; ?>">
-							<?php echo $this->pagination->getListFooter(); ?>
-						</td>
-					</tr>
-				</tfoot>
 				<tbody <?php if ($saveOrder) :?> class="js-draggable" data-url="<?php echo $saveOrderingUrl; ?>" data-direction="<?php echo strtolower($listDirn); ?>" data-nested="true"<?php endif; ?>>
 				<?php
 				foreach ($this->items as $i => $item) :

--- a/administrator/components/com_tags/tmpl/tags/default.php
+++ b/administrator/components/com_tags/tmpl/tags/default.php
@@ -247,6 +247,10 @@ if ($saveOrder && !empty($this->items))
 				<?php endforeach; ?>
 				</tbody>
 			</table>
+					
+			<?php // load the pagination. ?>
+			<?php echo $this->pagination->getListFooter(); ?>
+
 			<?php // Load the batch processing form if user is allowed ?>
 			<?php if ($user->authorise('core.create', 'com_tags')
 				&& $user->authorise('core.edit', 'com_tags')

--- a/administrator/components/com_templates/tmpl/styles/default.php
+++ b/administrator/components/com_templates/tmpl/styles/default.php
@@ -137,6 +137,10 @@ $colSpan = $clientId === 1 ? 5 : 6;
 							<?php endforeach; ?>
 						</tbody>
 					</table>
+					
+					<?php // load the pagination. ?>
+					<?php echo $this->pagination->getListFooter(); ?>
+
 				<?php endif; ?>
 
 				<input type="hidden" name="task" value="">

--- a/administrator/components/com_templates/tmpl/styles/default.php
+++ b/administrator/components/com_templates/tmpl/styles/default.php
@@ -62,13 +62,6 @@ $colSpan = $clientId === 1 ? 5 : 6;
 								</th>
 							</tr>
 						</thead>
-						<tfoot>
-							<tr>
-								<td colspan="<?php echo $colSpan; ?>">
-									<?php echo $this->pagination->getListFooter(); ?>
-								</td>
-							</tr>
-						</tfoot>
 						<tbody>
 							<?php foreach ($this->items as $i => $item) :
 								$canCreate = $user->authorise('core.create',     'com_templates');

--- a/administrator/components/com_templates/tmpl/styles/default.php
+++ b/administrator/components/com_templates/tmpl/styles/default.php
@@ -26,7 +26,6 @@ $user      = Factory::getUser();
 $clientId = (int) $this->state->get('client_id', 0);
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
-$colSpan = $clientId === 1 ? 5 : 6;
 ?>
 <form action="<?php echo Route::_('index.php?option=com_templates&view=styles'); ?>" method="post" name="adminForm" id="adminForm">
 	<div class="row">

--- a/administrator/components/com_templates/tmpl/templates/default.php
+++ b/administrator/components/com_templates/tmpl/templates/default.php
@@ -93,6 +93,10 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 							<?php endforeach; ?>
 						</tbody>
 					</table>
+					
+					<?php // load the pagination. ?>
+					<?php echo $this->pagination->getListFooter(); ?>
+
 				<?php endif; ?>
 
 				<input type="hidden" name="task" value="">

--- a/administrator/components/com_templates/tmpl/templates/default.php
+++ b/administrator/components/com_templates/tmpl/templates/default.php
@@ -48,13 +48,6 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 								</th>
 							</tr>
 						</thead>
-						<tfoot>
-							<tr>
-								<td colspan="5">
-									<?php echo $this->pagination->getListFooter(); ?>
-								</td>
-							</tr>
-						</tfoot>
 						<tbody>
 						<?php foreach ($this->items as $i => $item) : ?>
 							<tr class="row<?php echo $i % 2; ?>">

--- a/administrator/components/com_users/tmpl/debuggroup/default.php
+++ b/administrator/components/com_users/tmpl/debuggroup/default.php
@@ -19,7 +19,6 @@ HTMLHelper::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
-$colSpan   = 4 + count($this->actions);
 ?>
 <form action="<?php echo Route::_('index.php?option=com_users&view=debuggroup&group_id=' . (int) $this->state->get('group_id')); ?>" method="post" name="adminForm" id="adminForm">
 	<div id="j-main-container" class="j-main-container">
@@ -47,20 +46,6 @@ $colSpan   = 4 + count($this->actions);
 						</th>
 					</tr>
 				</thead>
-				<tfoot>
-					<tr>
-						<td colspan="<?php echo $colSpan; ?>">
-							<?php echo $this->pagination->getListFooter(); ?>
-							<div class="legend">
-								<?php echo Text::_('COM_USERS_DEBUG_LEGEND'); ?>
-								<span class="text-danger icon-ban-circle"></span><?php echo Text::_('COM_USERS_DEBUG_IMPLICIT_DENY'); ?>&nbsp;
-								<span class="text-success icon-ok"></span><?php echo Text::_('COM_USERS_DEBUG_EXPLICIT_ALLOW'); ?>&nbsp;
-								<span class="icon-remove"></span><?php echo Text::_('COM_USERS_DEBUG_EXPLICIT_DENY'); ?>
-								<br><br>
-							</div>
-						</td>
-					</tr>
-				</tfoot>
 				<tbody>
 					<?php foreach ($this->items as $i => $item) : ?>
 						<tr class="row0">
@@ -103,6 +88,16 @@ $colSpan   = 4 + count($this->actions);
 					<?php endforeach; ?>
 				</tbody>
 			</table>
+			<div class="legend">
+				<?php echo Text::_('COM_USERS_DEBUG_LEGEND'); ?>
+				<span class="text-danger icon-ban-circle"></span><?php echo Text::_('COM_USERS_DEBUG_IMPLICIT_DENY'); ?>&nbsp;
+				<span class="text-success icon-ok"></span><?php echo Text::_('COM_USERS_DEBUG_EXPLICIT_ALLOW'); ?>&nbsp;
+				<span class="icon-remove"></span><?php echo Text::_('COM_USERS_DEBUG_EXPLICIT_DENY'); ?>
+			</div>
+
+			<?php // load the pagination. ?>
+			<?php echo $this->pagination->getListFooter(); ?>
+
 		</div>
 		<input type="hidden" name="task" value="">
 		<input type="hidden" name="boxchecked" value="0">

--- a/administrator/components/com_users/tmpl/debuguser/default.php
+++ b/administrator/components/com_users/tmpl/debuguser/default.php
@@ -19,7 +19,6 @@ HTMLHelper::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
-$colSpan   = 4 + count($this->actions);
 ?>
 <form action="<?php echo Route::_('index.php?option=com_users&view=debuguser&user_id=' . (int) $this->state->get('user_id')); ?>" method="post" name="adminForm" id="adminForm">
 	<div id="j-main-container" class="j-main-container">
@@ -47,20 +46,6 @@ $colSpan   = 4 + count($this->actions);
 						</th>
 					</tr>
 				</thead>
-				<tfoot>
-					<tr>
-						<td colspan="<?php echo $colSpan; ?>">
-							<?php echo $this->pagination->getListFooter(); ?>
-							<div class="legend">
-								<?php echo Text::_('COM_USERS_DEBUG_LEGEND'); ?>
-								<span class="text-danger icon-ban-circle"></span><?php echo Text::_('COM_USERS_DEBUG_IMPLICIT_DENY'); ?>&nbsp;
-								<span class="icon-ok"></span><?php echo Text::_('COM_USERS_DEBUG_EXPLICIT_ALLOW'); ?>&nbsp;
-								<span class="icon-remove icon-remove"></span><?php echo Text::_('COM_USERS_DEBUG_EXPLICIT_DENY'); ?>
-								<br><br>
-							</div>
-						</td>
-					</tr>
-				</tfoot>
 				<tbody>
 					<?php foreach ($this->items as $i => $item) : ?>
 						<tr class="row0">
@@ -103,6 +88,16 @@ $colSpan   = 4 + count($this->actions);
 					<?php endforeach; ?>
 				</tbody>
 			</table>
+			<div class="legend">
+				<?php echo Text::_('COM_USERS_DEBUG_LEGEND'); ?>
+				<span class="text-danger icon-ban-circle"></span><?php echo Text::_('COM_USERS_DEBUG_IMPLICIT_DENY'); ?>&nbsp;
+				<span class="icon-ok"></span><?php echo Text::_('COM_USERS_DEBUG_EXPLICIT_ALLOW'); ?>&nbsp;
+				<span class="icon-remove icon-remove"></span><?php echo Text::_('COM_USERS_DEBUG_EXPLICIT_DENY'); ?>
+			</div>
+
+			<?php // load the pagination. ?>
+			<?php echo $this->pagination->getListFooter(); ?>
+
 		</div>
 		<input type="hidden" name="task" value="">
 		<input type="hidden" name="boxchecked" value="0">

--- a/administrator/components/com_users/tmpl/groups/default.php
+++ b/administrator/components/com_users/tmpl/groups/default.php
@@ -109,6 +109,10 @@ HTMLHelper::_('script', 'com_users/admin-users-groups.min.js', array('version' =
 							<?php endforeach; ?>
 						</tbody>
 					</table>
+					
+					<?php // load the pagination. ?>
+					<?php echo $this->pagination->getListFooter(); ?>
+
 				<?php endif; ?>
 
 				<input type="hidden" name="task" value="">

--- a/administrator/components/com_users/tmpl/groups/default.php
+++ b/administrator/components/com_users/tmpl/groups/default.php
@@ -63,13 +63,6 @@ HTMLHelper::_('script', 'com_users/admin-users-groups.min.js', array('version' =
 								</th>
 							</tr>
 						</thead>
-						<tfoot>
-							<tr>
-								<td colspan="5">
-									<?php echo $this->pagination->getListFooter(); ?>
-								</td>
-							</tr>
-						</tfoot>
 						<tbody>
 						<?php foreach ($this->items as $i => $item) :
 							$canCreate = $user->authorise('core.create', 'com_users');

--- a/administrator/components/com_users/tmpl/levels/default.php
+++ b/administrator/components/com_users/tmpl/levels/default.php
@@ -64,13 +64,6 @@ if ($saveOrder)
 								</th>
 							</tr>
 						</thead>
-						<tfoot>
-							<tr>
-								<td colspan="5">
-									<?php echo $this->pagination->getListFooter(); ?>
-								</td>
-							</tr>
-						</tfoot>
 						<tbody>
 						<?php $count = count($this->items); ?>
 						<?php foreach ($this->items as $i => $item) :

--- a/administrator/components/com_users/tmpl/levels/default.php
+++ b/administrator/components/com_users/tmpl/levels/default.php
@@ -113,6 +113,10 @@ if ($saveOrder)
 						<?php endforeach; ?>
 						</tbody>
 					</table>
+					
+					<?php // load the pagination. ?>
+					<?php echo $this->pagination->getListFooter(); ?>
+
 				<?php endif; ?>
 				<input type="hidden" name="task" value="">
 				<input type="hidden" name="boxchecked" value="0">

--- a/administrator/components/com_users/tmpl/notes/default.php
+++ b/administrator/components/com_users/tmpl/notes/default.php
@@ -106,6 +106,10 @@ $listDirn   = $this->escape($this->state->get('list.direction'));
 					<?php endforeach; ?>
 					</tbody>
 				</table>
+					
+				<?php // load the pagination. ?>
+				<?php echo $this->pagination->getListFooter(); ?>
+
 				<?php endif; ?>
 
 				<div>

--- a/administrator/components/com_users/tmpl/notes/default.php
+++ b/administrator/components/com_users/tmpl/notes/default.php
@@ -57,13 +57,6 @@ $listDirn   = $this->escape($this->state->get('list.direction'));
 							</th>
 						</tr>
 					</thead>
-					<tfoot>
-						<tr>
-							<td colspan="6">
-								<?php echo $this->pagination->getListFooter(); ?>
-							</td>
-						</tr>
-					</tfoot>
 					<tbody>
 					<?php foreach ($this->items as $i => $item) :
 						$canEdit    = $user->authorise('core.edit',       'com_users.category.' . $item->catid);

--- a/administrator/components/com_users/tmpl/users/default.php
+++ b/administrator/components/com_users/tmpl/users/default.php
@@ -168,6 +168,10 @@ $debugUsers = $this->state->get('params')->get('debugUsers', 1);
 							<?php endforeach; ?>
 						</tbody>
 					</table>
+					
+					<?php // load the pagination. ?>
+					<?php echo $this->pagination->getListFooter(); ?>
+
 					<?php // Load the batch processing form if user is allowed ?>
 					<?php if ($loggeduser->authorise('core.create', 'com_users')
 						&& $loggeduser->authorise('core.edit', 'com_users')

--- a/administrator/components/com_users/tmpl/users/default.php
+++ b/administrator/components/com_users/tmpl/users/default.php
@@ -74,13 +74,6 @@ $debugUsers = $this->state->get('params')->get('debugUsers', 1);
 								</th>
 							</tr>
 						</thead>
-						<tfoot>
-							<tr>
-								<td colspan="10">
-									<?php echo $this->pagination->getListFooter(); ?>
-								</td>
-							</tr>
-						</tfoot>
 						<tbody>
 						<?php foreach ($this->items as $i => $item) :
 							$canEdit   = $this->canDo->get('core.edit');

--- a/administrator/components/com_users/tmpl/users/modal.php
+++ b/administrator/components/com_users/tmpl/users/modal.php
@@ -65,13 +65,6 @@ $onClick         = "window.parent.jSelectUser(this);window.parent.Joomla.Modal.g
 					</th>
 				</tr>
 			</thead>
-			<tfoot>
-				<tr>
-					<td colspan="6">
-						<?php echo $this->pagination->getListFooter(); ?>
-					</td>
-				</tr>
-			</tfoot>
 			<tbody>
                 <?php $i = 0; ?>
                 <?php foreach ($this->items as $item) : ?>
@@ -101,6 +94,10 @@ $onClick         = "window.parent.jSelectUser(this);window.parent.Joomla.Modal.g
 				<?php endforeach; ?>
 			</tbody>
 		</table>
+
+		<?php // load the pagination. ?>
+		<?php echo $this->pagination->getListFooter(); ?>
+
 		<?php endif; ?>
 		<input type="hidden" name="task" value="">
 		<input type="hidden" name="field" value="<?php echo $this->escape($field); ?>">

--- a/libraries/src/Access/Access.php
+++ b/libraries/src/Access/Access.php
@@ -13,6 +13,7 @@ defined('JPATH_PLATFORM') or die;
 use Joomla\Utilities\ArrayHelper;
 use Joomla\CMS\Table\Asset;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Log\Log;
 
 /**
  * Class that handles all access authorisation routines.
@@ -559,14 +560,14 @@ class Access
 		{
 			if ($extensionName && $assetName !== $extensionName)
 			{
-				\JLog::add('No asset found for ' . $assetName . ', falling back to ' . $extensionName, \JLog::WARNING, 'assets');
+				Log::add('No asset found for ' . $assetName . ', falling back to ' . $extensionName, Log::WARNING, 'assets');
 
 				return self::getAssetRules($extensionName, $recursive, $recursiveParentAsset, $preload);
 			}
 
 			if (self::$rootAssetId !== null && $assetName !== self::$preloadedAssets[self::$rootAssetId])
 			{
-				\JLog::add('No asset found for ' . $assetName . ', falling back to ' . self::$preloadedAssets[self::$rootAssetId], \JLog::WARNING, 'assets');
+				Log::add('No asset found for ' . $assetName . ', falling back to ' . self::$preloadedAssets[self::$rootAssetId], Log::WARNING, 'assets');
 
 				return self::getAssetRules(self::$preloadedAssets[self::$rootAssetId], $recursive, $recursiveParentAsset, $preload);
 			}
@@ -643,7 +644,7 @@ class Access
 		}
 
 		// Non preloading code. Use old slower method, slower. Only used in rare cases (if any) or without preloading chosen.
-		\JLog::add('Asset ' . $assetKey . ' permissions fetch without preloading (slower method).', \JLog::INFO, 'assets');
+		Log::add('Asset ' . $assetKey . ' permissions fetch without preloading (slower method).', Log::INFO, 'assets');
 
 		!JDEBUG ?: \JProfiler::getInstance('Application')->mark('Before Access::getAssetRules (assetKey:' . $assetKey . ')');
 
@@ -1131,7 +1132,7 @@ class Access
 	 */
 	public static function getActions($component, $section = 'component')
 	{
-		\JLog::add(__METHOD__ . ' is deprecated. Use Access::getActionsFromFile or Access::getActionsFromData instead.', \JLog::WARNING, 'deprecated');
+		Log::add(__METHOD__ . ' is deprecated. Use Access::getActionsFromFile or Access::getActionsFromData instead.', Log::WARNING, 'deprecated');
 
 		$actions = self::getActionsFromFile(
 			JPATH_ADMINISTRATOR . '/components/' . $component . '/access.xml',

--- a/libraries/src/Access/Access.php
+++ b/libraries/src/Access/Access.php
@@ -14,6 +14,7 @@ use Joomla\Utilities\ArrayHelper;
 use Joomla\CMS\Table\Asset;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Log\Log;
+use Joomla\CMS\Component\ComponentHelper;
 
 /**
  * Class that handles all access authorisation routines.
@@ -410,7 +411,7 @@ class Access
 		$components = array('root.1');
 
 		// Add enabled components to asset names list.
-		foreach (\JComponentHelper::getComponents() as $component)
+		foreach (ComponentHelper::getComponents() as $component)
 		{
 			if ($component->enabled)
 			{
@@ -935,10 +936,10 @@ class Access
 
 		if (!isset(self::$groupsByUser[$storeId]))
 		{
-			// TODO: Uncouple this from \JComponentHelper and allow for a configuration setting or value injection.
-			if (class_exists('\JComponentHelper'))
+			// TODO: Uncouple this from ComponentHelper and allow for a configuration setting or value injection.
+			if (class_exists('ComponentHelper'))
 			{
-				$guestUsergroup = \JComponentHelper::getParams('com_users')->get('guest_usergroup', 1);
+				$guestUsergroup = ComponentHelper::getParams('com_users')->get('guest_usergroup', 1);
 			}
 			else
 			{

--- a/libraries/src/Access/Rules.php
+++ b/libraries/src/Access/Rules.php
@@ -10,6 +10,8 @@ namespace Joomla\CMS\Access;
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\CMS\Object\CMSObject;
+
 /**
  * Access rules class.
  *
@@ -177,14 +179,14 @@ class Rules
 	 *
 	 * @param   mixed  $identity  An integer representing the identity or an array of identities
 	 *
-	 * @return  \JObject  Allowed actions for the identity or identities
+	 * @return  CMSObject  Allowed actions for the identity or identities
 	 *
 	 * @since   11.1
 	 */
 	public function getAllowed($identity)
 	{
 		// Sweep for the allowed actions.
-		$allowed = new \JObject;
+		$allowed = new CMSObject;
 
 		foreach ($this->data as $name => &$action)
 		{

--- a/libraries/src/Application/AdministratorApplication.php
+++ b/libraries/src/Application/AdministratorApplication.php
@@ -20,6 +20,7 @@ use Joomla\Registry\Registry;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Filter\InputFilter;
+use Joomla\CMS\Session\Session;
 
 /**
  * Joomla! Administrator Application class
@@ -421,7 +422,7 @@ class AdministratorApplication extends CMSApplication
 				$this->enqueueMessage(
 					Text::sprintf(
 						'JWARNING_REMOVE_ROOT_USER',
-						'index.php?option=com_config&task=config.removeroot&' . \JSession::getFormToken() . '=1'
+						'index.php?option=com_config&task=config.removeroot&' . Session::getFormToken() . '=1'
 					),
 					'error'
 				);
@@ -433,7 +434,7 @@ class AdministratorApplication extends CMSApplication
 					Text::sprintf(
 						'JWARNING_REMOVE_ROOT_USER_ADMIN',
 						$rootUser,
-						'index.php?option=com_config&task=config.removeroot&' . \JSession::getFormToken() . '=1'
+						'index.php?option=com_config&task=config.removeroot&' . Session::getFormToken() . '=1'
 					),
 					'error'
 				);

--- a/libraries/src/Application/AdministratorApplication.php
+++ b/libraries/src/Application/AdministratorApplication.php
@@ -158,12 +158,12 @@ class AdministratorApplication extends CMSApplication
 	}
 
 	/**
-	 * Return a reference to the \JRouter object.
+	 * Return a reference to the Router object.
 	 *
 	 * @param   string  $name     The name of the application.
 	 * @param   array   $options  An optional associative array of configuration settings.
 	 *
-	 * @return  \JRouter
+	 * @return  Router
 	 *
 	 * @since	3.2
 	 */

--- a/libraries/src/Application/AdministratorApplication.php
+++ b/libraries/src/Application/AdministratorApplication.php
@@ -58,7 +58,7 @@ class AdministratorApplication extends CMSApplication
 		parent::__construct($input, $config, $client, $container);
 
 		// Set the root in the URI based on the application name
-		URI::root(null, rtrim(dirname(URI::base(true)), '/\\'));
+		Uri::root(null, rtrim(dirname(Uri::base(true)), '/\\'));
 	}
 
 	/**
@@ -317,7 +317,7 @@ class AdministratorApplication extends CMSApplication
 		// Set the application login entry point
 		if (!array_key_exists('entry_url', $options))
 		{
-			$options['entry_url'] = URI::base() . 'index.php?option=com_users&task=login';
+			$options['entry_url'] = Uri::base() . 'index.php?option=com_users&task=login';
 		}
 
 		// Set the access control action to check.
@@ -459,7 +459,7 @@ class AdministratorApplication extends CMSApplication
 	 */
 	protected function route()
 	{
-		$uri = URI::getInstance();
+		$uri = Uri::getInstance();
 
 		if ($this->get('force_ssl') >= 1 && strtolower($uri->getScheme()) !== 'https')
 		{

--- a/libraries/src/Application/AdministratorApplication.php
+++ b/libraries/src/Application/AdministratorApplication.php
@@ -21,6 +21,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\Session\Session;
+use Joomla\CMS\Uri\Uri;
 
 /**
  * Joomla! Administrator Application class
@@ -57,7 +58,7 @@ class AdministratorApplication extends CMSApplication
 		parent::__construct($input, $config, $client, $container);
 
 		// Set the root in the URI based on the application name
-		\JUri::root(null, rtrim(dirname(\JUri::base(true)), '/\\'));
+		URI::root(null, rtrim(dirname(URI::base(true)), '/\\'));
 	}
 
 	/**
@@ -316,7 +317,7 @@ class AdministratorApplication extends CMSApplication
 		// Set the application login entry point
 		if (!array_key_exists('entry_url', $options))
 		{
-			$options['entry_url'] = \JUri::base() . 'index.php?option=com_users&task=login';
+			$options['entry_url'] = URI::base() . 'index.php?option=com_users&task=login';
 		}
 
 		// Set the access control action to check.
@@ -458,7 +459,7 @@ class AdministratorApplication extends CMSApplication
 	 */
 	protected function route()
 	{
-		$uri = \JUri::getInstance();
+		$uri = URI::getInstance();
 
 		if ($this->get('force_ssl') >= 1 && strtolower($uri->getScheme()) !== 'https')
 		{

--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -34,6 +34,7 @@ use Joomla\Registry\Registry;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Uri\Uri;
 use Joomla\CMS\Router\Router;
+use Joomla\CMS\Router\Route;
 
 /**
  * Joomla! CMS Application class
@@ -348,7 +349,7 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
 			{
 				// Redirect to the profile edit page
 				$this->enqueueMessage(Text::_('JGLOBAL_PASSWORD_RESET_REQUIRED'), 'notice');
-				$this->redirect(\JRoute::_('index.php?option=' . $option . '&view=' . $view . '&layout=' . $layout, false));
+				$this->redirect(Route::_('index.php?option=' . $option . '&view=' . $view . '&layout=' . $layout, false));
 			}
 		}
 	}

--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -33,6 +33,7 @@ use Joomla\DI\ContainerAwareTrait;
 use Joomla\Registry\Registry;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Uri\Uri;
+use Joomla\CMS\Router\Router;
 
 /**
  * Joomla! CMS Application class
@@ -526,12 +527,12 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
 	}
 
 	/**
-	 * Returns the application \JRouter object.
+	 * Returns the application Router object.
 	 *
 	 * @param   string  $name     The name of the application.
 	 * @param   array   $options  An optional associative array of configuration settings.
 	 *
-	 * @return  \JRouter
+	 * @return  Router
 	 *
 	 * @since   3.2
 	 */
@@ -543,7 +544,7 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
 			$name = $app->getName();
 		}
 
-		return \JRouter::getInstance($name, $options);
+		return Router::getInstance($name, $options);
 	}
 
 	/**

--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -1021,7 +1021,7 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
 	protected function route()
 	{
 		// Get the full request URI.
-		$uri = clone URI::getInstance();
+		$uri = clone Uri::getInstance();
 
 		$router = static::getRouter();
 		$result = $router->parse($uri, true);

--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -32,6 +32,7 @@ use Joomla\DI\ContainerAwareInterface;
 use Joomla\DI\ContainerAwareTrait;
 use Joomla\Registry\Registry;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Uri\Uri;
 
 /**
  * Joomla! CMS Application class
@@ -1018,7 +1019,7 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
 	protected function route()
 	{
 		// Get the full request URI.
-		$uri = clone \JUri::getInstance();
+		$uri = clone URI::getInstance();
 
 		$router = static::getRouter();
 		$result = $router->parse($uri, true);

--- a/libraries/src/Application/DaemonApplication.php
+++ b/libraries/src/Application/DaemonApplication.php
@@ -15,6 +15,7 @@ jimport('joomla.filesystem.folder');
 use Joomla\CMS\Event\BeforeExecuteEvent;
 use Joomla\Event\DispatcherInterface;
 use Joomla\Registry\Registry;
+use Joomla\CMS\Filesystem\Folder;
 
 /**
  * Class to turn CliApplication applications into daemons.  It requires CLI and PCNTL support built into PHP.
@@ -802,7 +803,7 @@ abstract class DaemonApplication extends CliApplication
 		// Make sure that the folder where we are writing the process id file exists.
 		$folder = dirname($file);
 
-		if (!is_dir($folder) && !\JFolder::create($folder))
+		if (!is_dir($folder) && !Folder::create($folder))
 		{
 			\JLog::add('Unable to create directory: ' . $folder, \JLog::ERROR);
 

--- a/libraries/src/Application/DaemonApplication.php
+++ b/libraries/src/Application/DaemonApplication.php
@@ -16,6 +16,7 @@ use Joomla\CMS\Event\BeforeExecuteEvent;
 use Joomla\Event\DispatcherInterface;
 use Joomla\Registry\Registry;
 use Joomla\CMS\Filesystem\Folder;
+use Joomla\CMS\Log\Log;
 
 /**
  * Class to turn CliApplication applications into daemons.  It requires CLI and PCNTL support built into PHP.
@@ -116,14 +117,14 @@ abstract class DaemonApplication extends CliApplication
 		// Verify that the process control extension for PHP is available.
 		if (!defined('SIGHUP'))
 		{
-			\JLog::add('The PCNTL extension for PHP is not available.', \JLog::ERROR);
+			Log::add('The PCNTL extension for PHP is not available.', Log::ERROR);
 			throw new \RuntimeException('The PCNTL extension for PHP is not available.');
 		}
 
 		// Verify that POSIX support for PHP is available.
 		if (!function_exists('posix_getpid'))
 		{
-			\JLog::add('The POSIX extension for PHP is not available.', \JLog::ERROR);
+			Log::add('The POSIX extension for PHP is not available.', Log::ERROR);
 			throw new \RuntimeException('The POSIX extension for PHP is not available.');
 		}
 
@@ -156,12 +157,12 @@ abstract class DaemonApplication extends CliApplication
 	public static function signal($signal)
 	{
 		// Log all signals sent to the daemon.
-		\JLog::add('Received signal: ' . $signal, \JLog::DEBUG);
+		Log::add('Received signal: ' . $signal, Log::DEBUG);
 
 		// Let's make sure we have an application instance.
 		if (!is_subclass_of(static::$instance, CliApplication::class))
 		{
-			\JLog::add('Cannot find the application instance.', \JLog::EMERGENCY);
+			Log::add('Cannot find the application instance.', Log::EMERGENCY);
 			throw new \RuntimeException('Cannot find the application instance.');
 		}
 
@@ -247,7 +248,7 @@ abstract class DaemonApplication extends CliApplication
 		{
 			// No response so remove the process id file and log the situation.
 			@ unlink($pidFile);
-			\JLog::add('The process found based on PID file was unresponsive.', \JLog::WARNING);
+			Log::add('The process found based on PID file was unresponsive.', Log::WARNING);
 
 			return false;
 		}
@@ -373,7 +374,7 @@ abstract class DaemonApplication extends CliApplication
 		// Enable basic garbage collection.
 		gc_enable();
 
-		\JLog::add('Starting ' . $this->name, \JLog::INFO);
+		Log::add('Starting ' . $this->name, Log::INFO);
 
 		// Set off the process for becoming a daemon.
 		if ($this->daemonize())
@@ -398,7 +399,7 @@ abstract class DaemonApplication extends CliApplication
 		// We were not able to daemonize the application so log the failure and die gracefully.
 		else
 		{
-			\JLog::add('Starting ' . $this->name . ' failed', \JLog::INFO);
+			Log::add('Starting ' . $this->name . ' failed', Log::INFO);
 		}
 
 		// Trigger the onAfterExecute event.
@@ -414,7 +415,7 @@ abstract class DaemonApplication extends CliApplication
 	 */
 	public function restart()
 	{
-		\JLog::add('Stopping ' . $this->name, \JLog::INFO);
+		Log::add('Stopping ' . $this->name, Log::INFO);
 		$this->shutdown(true);
 	}
 
@@ -427,7 +428,7 @@ abstract class DaemonApplication extends CliApplication
 	 */
 	public function stop()
 	{
-		\JLog::add('Stopping ' . $this->name, \JLog::INFO);
+		Log::add('Stopping ' . $this->name, Log::INFO);
 		$this->shutdown();
 	}
 
@@ -451,7 +452,7 @@ abstract class DaemonApplication extends CliApplication
 		// Change the user id for the process id file if necessary.
 		if ($uid && (fileowner($file) != $uid) && (!@ chown($file, $uid)))
 		{
-			\JLog::add('Unable to change user ownership of the process id file.', \JLog::ERROR);
+			Log::add('Unable to change user ownership of the process id file.', Log::ERROR);
 
 			return false;
 		}
@@ -459,7 +460,7 @@ abstract class DaemonApplication extends CliApplication
 		// Change the group id for the process id file if necessary.
 		if ($gid && (filegroup($file) != $gid) && (!@ chgrp($file, $gid)))
 		{
-			\JLog::add('Unable to change group ownership of the process id file.', \JLog::ERROR);
+			Log::add('Unable to change group ownership of the process id file.', Log::ERROR);
 
 			return false;
 		}
@@ -473,7 +474,7 @@ abstract class DaemonApplication extends CliApplication
 		// Change the user id for the process necessary.
 		if ($uid && (posix_getuid($file) != $uid) && (!@ posix_setuid($uid)))
 		{
-			\JLog::add('Unable to change user ownership of the proccess.', \JLog::ERROR);
+			Log::add('Unable to change user ownership of the proccess.', Log::ERROR);
 
 			return false;
 		}
@@ -481,7 +482,7 @@ abstract class DaemonApplication extends CliApplication
 		// Change the group id for the process necessary.
 		if ($gid && (posix_getgid($file) != $gid) && (!@ posix_setgid($gid)))
 		{
-			\JLog::add('Unable to change group ownership of the proccess.', \JLog::ERROR);
+			Log::add('Unable to change group ownership of the proccess.', Log::ERROR);
 
 			return false;
 		}
@@ -490,7 +491,7 @@ abstract class DaemonApplication extends CliApplication
 		$user = posix_getpwuid($uid);
 		$group = posix_getgrgid($gid);
 
-		\JLog::add('Changed daemon identity to ' . $user['name'] . ':' . $group['name'], \JLog::INFO);
+		Log::add('Changed daemon identity to ' . $user['name'] . ':' . $group['name'], Log::INFO);
 
 		return true;
 	}
@@ -508,7 +509,7 @@ abstract class DaemonApplication extends CliApplication
 		// Is there already an active daemon running?
 		if ($this->isActive())
 		{
-			\JLog::add($this->name . ' daemon is still running. Exiting the application.', \JLog::EMERGENCY);
+			Log::add($this->name . ' daemon is still running. Exiting the application.', Log::EMERGENCY);
 
 			return false;
 		}
@@ -540,7 +541,7 @@ abstract class DaemonApplication extends CliApplication
 		}
 		catch (\RuntimeException $e)
 		{
-			\JLog::add('Unable to fork.', \JLog::EMERGENCY);
+			Log::add('Unable to fork.', Log::EMERGENCY);
 
 			return false;
 		}
@@ -548,7 +549,7 @@ abstract class DaemonApplication extends CliApplication
 		// Verify the process id is valid.
 		if ($this->processId < 1)
 		{
-			\JLog::add('The process id is invalid; the fork failed.', \JLog::EMERGENCY);
+			Log::add('The process id is invalid; the fork failed.', Log::EMERGENCY);
 
 			return false;
 		}
@@ -559,7 +560,7 @@ abstract class DaemonApplication extends CliApplication
 		// Write out the process id file for concurrency management.
 		if (!$this->writeProcessIdFile())
 		{
-			\JLog::add('Unable to write the pid file at: ' . $this->config->get('application_pid_file'), \JLog::EMERGENCY);
+			Log::add('Unable to write the pid file at: ' . $this->config->get('application_pid_file'), Log::EMERGENCY);
 
 			return false;
 		}
@@ -570,13 +571,13 @@ abstract class DaemonApplication extends CliApplication
 			// If the identity change was required then we need to return false.
 			if ($this->config->get('application_require_identity'))
 			{
-				\JLog::add('Unable to change process owner.', \JLog::CRITICAL);
+				Log::add('Unable to change process owner.', Log::CRITICAL);
 
 				return false;
 			}
 			else
 			{
-				\JLog::add('Unable to change process owner.', \JLog::WARNING);
+				Log::add('Unable to change process owner.', Log::WARNING);
 			}
 		}
 
@@ -603,7 +604,7 @@ abstract class DaemonApplication extends CliApplication
 	 */
 	protected function detach()
 	{
-		\JLog::add('Detaching the ' . $this->name . ' daemon.', \JLog::DEBUG);
+		Log::add('Detaching the ' . $this->name . ' daemon.', Log::DEBUG);
 
 		// Attempt to fork the process.
 		$pid = $this->fork();
@@ -612,7 +613,7 @@ abstract class DaemonApplication extends CliApplication
 		if ($pid)
 		{
 			// Add the log entry for debugging purposes and exit gracefully.
-			\JLog::add('Ending ' . $this->name . ' parent process', \JLog::DEBUG);
+			Log::add('Ending ' . $this->name . ' parent process', Log::DEBUG);
 			$this->close();
 		}
 		// We are in the forked child process.
@@ -654,7 +655,7 @@ abstract class DaemonApplication extends CliApplication
 		else
 		{
 			// Log the fork.
-			\JLog::add('Process forked ' . $pid, \JLog::DEBUG);
+			Log::add('Process forked ' . $pid, Log::DEBUG);
 		}
 
 		// Trigger the onFork event.
@@ -699,7 +700,7 @@ abstract class DaemonApplication extends CliApplication
 			if (!defined($signal) || !is_int(constant($signal)) || (constant($signal) === 0))
 			{
 				// Define the signal to avoid notices.
-				\JLog::add('Signal "' . $signal . '" not defined. Defining it as null.', \JLog::DEBUG);
+				Log::add('Signal "' . $signal . '" not defined. Defining it as null.', Log::DEBUG);
 				define($signal, null);
 
 				// Don't listen for signal.
@@ -709,7 +710,7 @@ abstract class DaemonApplication extends CliApplication
 			// Attach the signal handler for the signal.
 			if (!$this->pcntlSignal(constant($signal), array('DaemonApplication', 'signal')))
 			{
-				\JLog::add(sprintf('Unable to reroute signal handler: %s', $signal), \JLog::EMERGENCY);
+				Log::add(sprintf('Unable to reroute signal handler: %s', $signal), Log::EMERGENCY);
 
 				return false;
 			}
@@ -743,7 +744,7 @@ abstract class DaemonApplication extends CliApplication
 		// If we aren't already daemonized then just kill the application.
 		if (!$this->running && !$this->isActive())
 		{
-			\JLog::add('Process was not daemonized yet, just halting current process', \JLog::INFO);
+			Log::add('Process was not daemonized yet, just halting current process', Log::INFO);
 			$this->close();
 		}
 
@@ -785,7 +786,7 @@ abstract class DaemonApplication extends CliApplication
 		// Verify the process id is valid.
 		if ($this->processId < 1)
 		{
-			\JLog::add('The process id is invalid.', \JLog::EMERGENCY);
+			Log::add('The process id is invalid.', Log::EMERGENCY);
 
 			return false;
 		}
@@ -795,7 +796,7 @@ abstract class DaemonApplication extends CliApplication
 
 		if (empty($file))
 		{
-			\JLog::add('The process id file path is empty.', \JLog::ERROR);
+			Log::add('The process id file path is empty.', Log::ERROR);
 
 			return false;
 		}
@@ -805,7 +806,7 @@ abstract class DaemonApplication extends CliApplication
 
 		if (!is_dir($folder) && !Folder::create($folder))
 		{
-			\JLog::add('Unable to create directory: ' . $folder, \JLog::ERROR);
+			Log::add('Unable to create directory: ' . $folder, Log::ERROR);
 
 			return false;
 		}
@@ -813,7 +814,7 @@ abstract class DaemonApplication extends CliApplication
 		// Write the process id file out to disk.
 		if (!file_put_contents($file, $this->processId))
 		{
-			\JLog::add('Unable to write proccess id file: ' . $file, \JLog::ERROR);
+			Log::add('Unable to write proccess id file: ' . $file, Log::ERROR);
 
 			return false;
 		}
@@ -821,7 +822,7 @@ abstract class DaemonApplication extends CliApplication
 		// Make sure the permissions for the proccess id file are accurate.
 		if (!chmod($file, 0644))
 		{
-			\JLog::add('Unable to adjust permissions for the proccess id file: ' . $file, \JLog::ERROR);
+			Log::add('Unable to adjust permissions for the proccess id file: ' . $file, Log::ERROR);
 
 			return false;
 		}

--- a/libraries/src/Application/SiteApplication.php
+++ b/libraries/src/Application/SiteApplication.php
@@ -383,12 +383,12 @@ final class SiteApplication extends CMSApplication
 	}
 
 	/**
-	 * Return a reference to the \JRouter object.
+	 * Return a reference to the Router object.
 	 *
 	 * @param   string  $name     The name of the application.
 	 * @param   array   $options  An optional associative array of configuration settings.
 	 *
-	 * @return	\JRouter
+	 * @return	Router
 	 *
 	 * @since	3.2
 	 */

--- a/libraries/src/Application/SiteApplication.php
+++ b/libraries/src/Application/SiteApplication.php
@@ -97,7 +97,7 @@ final class SiteApplication extends CMSApplication
 			if ($user->get('id') == 0)
 			{
 				// Set the data
-				$this->setUserState('users.login.form.data', array('return' => URI::getInstance()->toString()));
+				$this->setUserState('users.login.form.data', array('return' => Uri::getInstance()->toString()));
 
 				$url = Route::_('index.php?option=com_users&view=login', false);
 
@@ -171,7 +171,7 @@ final class SiteApplication extends CMSApplication
 
 				if ($this->get('sef'))
 				{
-					$document->setBase(htmlspecialchars(URI::current()));
+					$document->setBase(htmlspecialchars(Uri::current()));
 				}
 
 				// Get the template
@@ -184,7 +184,7 @@ final class SiteApplication extends CMSApplication
 				break;
 
 			case 'feed':
-				$document->setBase(htmlspecialchars(URI::current()));
+				$document->setBase(htmlspecialchars(Uri::current()));
 				break;
 		}
 
@@ -699,7 +699,7 @@ final class SiteApplication extends CMSApplication
 		// Set the application login entry point
 		if (!array_key_exists('entry_url', $options))
 		{
-			$options['entry_url'] = URI::base() . 'index.php?option=com_users&task=user.login';
+			$options['entry_url'] = Uri::base() . 'index.php?option=com_users&task=user.login';
 		}
 
 		// Set the access control action to check.
@@ -737,7 +737,7 @@ final class SiteApplication extends CMSApplication
 
 				if ($this->get('offline') && !Factory::getUser()->authorise('core.login.offline'))
 				{
-					$this->setUserState('users.login.form.data', array('return' => URI::getInstance()->toString()));
+					$this->setUserState('users.login.form.data', array('return' => Uri::getInstance()->toString()));
 					$this->set('themeFile', 'offline.php');
 					$this->setHeader('Status', '503 Service Temporarily Unavailable', 'true');
 				}

--- a/libraries/src/Application/SiteApplication.php
+++ b/libraries/src/Application/SiteApplication.php
@@ -23,6 +23,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\Uri\Uri;
+use Joomla\CMS\Router\Route;
 
 /**
  * Joomla! Site Application class
@@ -98,7 +99,7 @@ final class SiteApplication extends CMSApplication
 				// Set the data
 				$this->setUserState('users.login.form.data', array('return' => URI::getInstance()->toString()));
 
-				$url = \JRoute::_('index.php?option=com_users&view=login', false);
+				$url = Route::_('index.php?option=com_users&view=login', false);
 
 				$this->enqueueMessage(Text::_('JGLOBAL_YOU_MUST_LOGIN_FIRST'));
 				$this->redirect($url);
@@ -116,7 +117,7 @@ final class SiteApplication extends CMSApplication
 
 				// Otherwise redirect to the homepage and show an error
 				$this->enqueueMessage(Text::_('JERROR_ALERTNOAUTHOR'), 'error');
-				$this->redirect(\JRoute::_('index.php?Itemid=' . $home_item->id, false));
+				$this->redirect(Route::_('index.php?Itemid=' . $home_item->id, false));
 			}
 		}
 	}

--- a/libraries/src/Application/SiteApplication.php
+++ b/libraries/src/Application/SiteApplication.php
@@ -22,6 +22,7 @@ use Joomla\Registry\Registry;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Filter\InputFilter;
+use Joomla\CMS\Uri\Uri;
 
 /**
  * Joomla! Site Application class
@@ -95,7 +96,7 @@ final class SiteApplication extends CMSApplication
 			if ($user->get('id') == 0)
 			{
 				// Set the data
-				$this->setUserState('users.login.form.data', array('return' => \JUri::getInstance()->toString()));
+				$this->setUserState('users.login.form.data', array('return' => URI::getInstance()->toString()));
 
 				$url = \JRoute::_('index.php?option=com_users&view=login', false);
 
@@ -169,7 +170,7 @@ final class SiteApplication extends CMSApplication
 
 				if ($this->get('sef'))
 				{
-					$document->setBase(htmlspecialchars(\JUri::current()));
+					$document->setBase(htmlspecialchars(URI::current()));
 				}
 
 				// Get the template
@@ -182,7 +183,7 @@ final class SiteApplication extends CMSApplication
 				break;
 
 			case 'feed':
-				$document->setBase(htmlspecialchars(\JUri::current()));
+				$document->setBase(htmlspecialchars(URI::current()));
 				break;
 		}
 
@@ -697,7 +698,7 @@ final class SiteApplication extends CMSApplication
 		// Set the application login entry point
 		if (!array_key_exists('entry_url', $options))
 		{
-			$options['entry_url'] = \JUri::base() . 'index.php?option=com_users&task=user.login';
+			$options['entry_url'] = URI::base() . 'index.php?option=com_users&task=user.login';
 		}
 
 		// Set the access control action to check.
@@ -735,7 +736,7 @@ final class SiteApplication extends CMSApplication
 
 				if ($this->get('offline') && !Factory::getUser()->authorise('core.login.offline'))
 				{
-					$this->setUserState('users.login.form.data', array('return' => \JUri::getInstance()->toString()));
+					$this->setUserState('users.login.form.data', array('return' => URI::getInstance()->toString()));
 					$this->set('themeFile', 'offline.php');
 					$this->setHeader('Status', '503 Service Temporarily Unavailable', 'true');
 				}

--- a/libraries/src/Application/WebApplication.php
+++ b/libraries/src/Application/WebApplication.php
@@ -361,14 +361,14 @@ abstract class WebApplication extends AbstractWebApplication implements Dispatch
 
 		if ($siteUri != '')
 		{
-			$uri = URI::getInstance($siteUri);
+			$uri = Uri::getInstance($siteUri);
 			$path = $uri->toString(array('path'));
 		}
 		// No explicit base URI was set so we need to detect it.
 		else
 		{
 			// Start with the requested URI.
-			$uri = URI::getInstance($this->get('uri.request'));
+			$uri = Uri::getInstance($this->get('uri.request'));
 
 			// If we are working from a CGI SAPI with the 'cgi.fix_pathinfo' directive disabled we use PHP_SELF.
 			if (strpos(php_sapi_name(), 'cgi') !== false && !ini_get('cgi.fix_pathinfo') && !empty($_SERVER['REQUEST_URI']))

--- a/libraries/src/Application/WebApplication.php
+++ b/libraries/src/Application/WebApplication.php
@@ -24,6 +24,7 @@ use Joomla\Registry\Registry;
 use Joomla\Session\SessionEvent;
 use Psr\Http\Message\ResponseInterface;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Session\Session;
 
 /**
  * Base class for a Joomla! Web application.
@@ -292,14 +293,14 @@ abstract class WebApplication extends AbstractWebApplication implements Dispatch
 	 * but for many applications it will make sense to override this method and create a session,
 	 * if required, based on more specific needs.
 	 *
-	 * @param   \JSession  $session  An optional session object. If omitted, the session is created.
+	 * @param   Session  $session  An optional session object. If omitted, the session is created.
 	 *
 	 * @return  WebApplication This method is chainable.
 	 *
 	 * @since   11.3
 	 * @deprecated  5.0  The session should be injected as a service.
 	 */
-	public function loadSession(\JSession $session = null)
+	public function loadSession(Session $session = null)
 	{
 		$this->getLogger()->warning(__METHOD__ . '() is deprecated.  Inject the session as a service instead.', array('category' => 'deprecated'));
 

--- a/libraries/src/Application/WebApplication.php
+++ b/libraries/src/Application/WebApplication.php
@@ -25,6 +25,7 @@ use Joomla\Session\SessionEvent;
 use Psr\Http\Message\ResponseInterface;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Session\Session;
+use Joomla\CMS\Uri\Uri;
 
 /**
  * Base class for a Joomla! Web application.
@@ -360,14 +361,14 @@ abstract class WebApplication extends AbstractWebApplication implements Dispatch
 
 		if ($siteUri != '')
 		{
-			$uri = \JUri::getInstance($siteUri);
+			$uri = URI::getInstance($siteUri);
 			$path = $uri->toString(array('path'));
 		}
 		// No explicit base URI was set so we need to detect it.
 		else
 		{
 			// Start with the requested URI.
-			$uri = \JUri::getInstance($this->get('uri.request'));
+			$uri = URI::getInstance($this->get('uri.request'));
 
 			// If we are working from a CGI SAPI with the 'cgi.fix_pathinfo' directive disabled we use PHP_SELF.
 			if (strpos(php_sapi_name(), 'cgi') !== false && !ini_get('cgi.fix_pathinfo') && !empty($_SERVER['REQUEST_URI']))

--- a/libraries/src/Authentication/Authentication.php
+++ b/libraries/src/Authentication/Authentication.php
@@ -16,6 +16,7 @@ use Joomla\Event\DispatcherInterface;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Object\CMSObject;
+use Joomla\CMS\Log\Log;
 
 /**
  * Authentication class, provides an interface for the Joomla authentication system
@@ -95,7 +96,7 @@ class Authentication extends CMSObject
 
 		if (!$isLoaded)
 		{
-			\JLog::add(Text::_('JLIB_USER_ERROR_AUTHENTICATION_LIBRARIES'), \JLog::WARNING, 'jerror');
+			Log::add(Text::_('JLIB_USER_ERROR_AUTHENTICATION_LIBRARIES'), Log::WARNING, 'jerror');
 		}
 	}
 
@@ -158,7 +159,7 @@ class Authentication extends CMSObject
 			else
 			{
 				// Bail here if the plugin can't be created
-				\JLog::add(Text::sprintf('JLIB_USER_ERROR_AUTHENTICATION_FAILED_LOAD_PLUGIN', $className), \JLog::WARNING, 'jerror');
+				Log::add(Text::sprintf('JLIB_USER_ERROR_AUTHENTICATION_FAILED_LOAD_PLUGIN', $className), Log::WARNING, 'jerror');
 				continue;
 			}
 

--- a/libraries/src/Authentication/Authentication.php
+++ b/libraries/src/Authentication/Authentication.php
@@ -15,13 +15,14 @@ use Joomla\Event\DispatcherAwareTrait;
 use Joomla\Event\DispatcherInterface;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Object\CMSObject;
 
 /**
  * Authentication class, provides an interface for the Joomla authentication system
  *
  * @since  11.1
  */
-class Authentication extends \JObject
+class Authentication extends CMSObject
 {
 	use DispatcherAwareTrait;
 

--- a/libraries/src/Cache/Cache.php
+++ b/libraries/src/Cache/Cache.php
@@ -14,6 +14,7 @@ use Joomla\Application\Web\WebClient;
 use Joomla\CMS\Cache\Exception\CacheExceptionInterface;
 use Joomla\String\StringHelper;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Session\Session;
 
 /**
  * Joomla! Cache base object
@@ -566,7 +567,7 @@ class Cache
 		// The following code searches for a token in the cached page and replaces it with the proper token.
 		if (isset($data['body']))
 		{
-			$token       = \JSession::getFormToken();
+			$token       = Session::getFormToken();
 			$search      = '#<input type="hidden" name="[0-9a-f]{32}" value="1">#';
 			$replacement = '<input type="hidden" name="' . $token . '" value="1">';
 

--- a/libraries/src/Cache/Cache.php
+++ b/libraries/src/Cache/Cache.php
@@ -15,6 +15,7 @@ use Joomla\CMS\Cache\Exception\CacheExceptionInterface;
 use Joomla\String\StringHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Session\Session;
+use Joomla\CMS\Filesystem\Path;
 
 /**
  * Joomla! Cache base object
@@ -836,8 +837,7 @@ class Cache
 
 		if (!empty($path) && !in_array($path, $paths))
 		{
-			\JLoader::import('joomla.filesystem.path');
-			array_unshift($paths, \JPath::clean($path));
+			array_unshift($paths, Path::clean($path));
 		}
 
 		return $paths;

--- a/libraries/src/Cache/CacheController.php
+++ b/libraries/src/Cache/CacheController.php
@@ -11,6 +11,7 @@ namespace Joomla\CMS\Cache;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Factory;
+use Joomla\CMS\Filesystem\Path;
 
 /**
  * Public cache handler
@@ -100,9 +101,7 @@ class CacheController
 		if (!class_exists($class))
 		{
 			// Search for the class file in the Cache include paths.
-			\JLoader::import('joomla.filesystem.path');
-
-			$path = \JPath::find(self::addIncludePath(), strtolower($type) . '.php');
+			$path = Path::find(self::addIncludePath(), strtolower($type) . '.php');
 
 			if ($path !== false)
 			{
@@ -145,8 +144,7 @@ class CacheController
 
 		if (!empty($path) && !in_array($path, $paths))
 		{
-			\JLoader::import('joomla.filesystem.path');
-			array_unshift($paths, \JPath::clean($path));
+			array_unshift($paths, Path::clean($path));
 		}
 
 		return $paths;

--- a/libraries/src/Cache/CacheStorage.php
+++ b/libraries/src/Cache/CacheStorage.php
@@ -13,6 +13,7 @@ defined('JPATH_PLATFORM') or die;
 use Joomla\CMS\Cache\Exception\UnsupportedCacheException;
 use Joomla\CMS\Log\Log;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Filesystem\Path;
 
 /**
  * Abstract cache storage handler
@@ -156,9 +157,7 @@ class CacheStorage
 		if (!class_exists($class))
 		{
 			// Search for the class file in the JCacheStorage include paths.
-			\JLoader::import('joomla.filesystem.path');
-
-			$path = \JPath::find(self::addIncludePath(), strtolower($handler) . '.php');
+			$path = Path::find(self::addIncludePath(), strtolower($handler) . '.php');
 
 			if ($path === false)
 			{
@@ -380,8 +379,7 @@ class CacheStorage
 
 		if (!empty($path) && !in_array($path, $paths))
 		{
-			\JLoader::import('joomla.filesystem.path');
-			array_unshift($paths, \JPath::clean($path));
+			array_unshift($paths, Path::clean($path));
 		}
 
 		return $paths;

--- a/libraries/src/Categories/CategoryNode.php
+++ b/libraries/src/Categories/CategoryNode.php
@@ -12,13 +12,14 @@ defined('JPATH_PLATFORM') or die;
 
 use Joomla\Registry\Registry;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Object\CMSObject;
 
 /**
  * Helper class to load Categorytree
  *
  * @since  1.6
  */
-class CategoryNode extends \JObject
+class CategoryNode extends CMSObject
 {
 	/**
 	 * Primary key

--- a/libraries/src/Component/ComponentHelper.php
+++ b/libraries/src/Component/ComponentHelper.php
@@ -427,7 +427,7 @@ class ComponentHelper
 				/*
 				 * Fatal error
 				 *
-				 * It is possible for this error to be reached before the global \JLanguage instance has been loaded so we check for its presence
+				 * It is possible for this error to be reached before the global Language instance has been loaded so we check for its presence
 				 * before logging the error to ensure a human friendly message is always given
 				 */
 

--- a/libraries/src/Component/ComponentHelper.php
+++ b/libraries/src/Component/ComponentHelper.php
@@ -17,6 +17,7 @@ use Joomla\CMS\Dispatcher\Dispatcher;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Filter\InputFilter;
+use Joomla\CMS\Log\Log;
 
 /**
  * Component helper class
@@ -406,13 +407,13 @@ class ComponentHelper
 			// Log deprecated warning and display missing component warning only if using deprecated format.
 			try
 			{
-				\JLog::add(
+				Log::add(
 					sprintf(
 						'Passing a parameter into %s() is deprecated and will be removed in 4.0. Read %s::$components directly after loading the data.',
 						__METHOD__,
 						__CLASS__
 					),
-					\JLog::WARNING,
+					Log::WARNING,
 					'deprecated'
 				);
 			}
@@ -439,7 +440,7 @@ class ComponentHelper
 					$msg = sprintf('Error loading component: %1$s, %2$s', $option, 'Component not found.');
 				}
 
-				\JLog::add($msg, \JLog::WARNING, 'jerror');
+				Log::add($msg, Log::WARNING, 'jerror');
 
 				return false;
 			}

--- a/libraries/src/Component/Router/Rules/MenuRules.php
+++ b/libraries/src/Component/Router/Rules/MenuRules.php
@@ -12,6 +12,7 @@ defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Component\Router\RouterView;
+use Joomla\CMS\Language\Multilanguage;
 
 /**
  * Rule to identify the right Itemid for a view in a component
@@ -162,7 +163,7 @@ class MenuRules implements RulesInterface
 
 		// Check if the active menuitem matches the requested language
 		if ($active && $active->component === 'com_' . $this->router->getName()
-			&& ($language === '*' || in_array($active->language, array('*', $language)) || !\JLanguageMultilang::isEnabled()))
+			&& ($language === '*' || in_array($active->language, array('*', $language)) || !\LanguageMultilang::isEnabled()))
 		{
 			$query['Itemid'] = $active->id;
 			return;

--- a/libraries/src/Document/Document.php
+++ b/libraries/src/Document/Document.php
@@ -14,6 +14,7 @@ use Joomla\Application\AbstractWebApplication;
 use Joomla\CMS\Date\Date;
 use Symfony\Component\WebLink\HttpHeaderSerializer;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Log\Log;
 
 /**
  * Document class, provides an easy interface to parse and display a document
@@ -502,7 +503,7 @@ class Document
 		// B/C before 3.7.0
 		if (!is_array($options) && (!is_array($attribs) || $attribs === array()))
 		{
-			\JLog::add('The addScript method signature used has changed, use (url, options, attributes) instead.', \JLog::WARNING, 'deprecated');
+			Log::add('The addScript method signature used has changed, use (url, options, attributes) instead.', Log::WARNING, 'deprecated');
 
 			$argList = func_get_args();
 			$options = array();
@@ -554,7 +555,7 @@ class Document
 	 */
 	public function addScriptVersion($url, $options = array(), $attribs = array())
 	{
-		\JLog::add('The method is deprecated, use addScript(url, attributes, options) instead.', \JLog::WARNING, 'deprecated');
+		Log::add('The method is deprecated, use addScript(url, attributes, options) instead.', Log::WARNING, 'deprecated');
 
 		// B/C before 3.7.0
 		if (!is_array($options) && (!is_array($attribs) || $attribs === array()))
@@ -685,7 +686,7 @@ class Document
 		// B/C before 3.7.0
 		if (is_string($options))
 		{
-			\JLog::add('The addStyleSheet method signature used has changed, use (url, options, attributes) instead.', \JLog::WARNING, 'deprecated');
+			Log::add('The addStyleSheet method signature used has changed, use (url, options, attributes) instead.', Log::WARNING, 'deprecated');
 
 			$argList = func_get_args();
 			$options = array();
@@ -745,7 +746,7 @@ class Document
 	 */
 	public function addStyleSheetVersion($url, $options = array(), $attribs = array())
 	{
-		\JLog::add('The method is deprecated, use addStyleSheet(url, attributes, options) instead.', \JLog::WARNING, 'deprecated');
+		Log::add('The method is deprecated, use addStyleSheet(url, attributes, options) instead.', Log::WARNING, 'deprecated');
 
 		// B/C before 3.7.0
 		if (!is_array($options) && (!is_array($attribs) || $attribs === array()))

--- a/libraries/src/Document/OpensearchDocument.php
+++ b/libraries/src/Document/OpensearchDocument.php
@@ -14,6 +14,7 @@ use Joomla\CMS\Document\Opensearch\OpensearchImage;
 use Joomla\CMS\Document\Opensearch\OpensearchUrl;
 use Joomla\CMS\Uri\Uri;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Router\Route;
 
 /**
  * Opensearch class, provides an easy interface to display an Opensearch document
@@ -72,7 +73,7 @@ class OpensearchDocument extends Document
 		$update = new OpensearchUrl;
 		$update->type = 'application/opensearchdescription+xml';
 		$update->rel = 'self';
-		$update->template = \JRoute::_(Uri::getInstance());
+		$update->template = Route::_(Uri::getInstance());
 		$this->addUrl($update);
 
 		// Add the favicon as the default image

--- a/libraries/src/Document/Renderer/Feed/AtomRenderer.php
+++ b/libraries/src/Document/Renderer/Feed/AtomRenderer.php
@@ -14,6 +14,7 @@ use Joomla\CMS\Document\DocumentRenderer;
 use Joomla\CMS\Uri\Uri;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Router\Route;
 
 /**
  * AtomRenderer is a feed that implements the atom specification
@@ -61,7 +62,7 @@ class AtomRenderer extends DocumentRenderer
 		$data = $this->_doc;
 
 		$url = Uri::getInstance()->toString(array('scheme', 'user', 'pass', 'host', 'port'));
-		$syndicationURL = \JRoute::_('&format=feed&type=atom');
+		$syndicationURL = Route::_('&format=feed&type=atom');
 
 		$title = $data->getTitle();
 

--- a/libraries/src/Document/Renderer/Feed/RssRenderer.php
+++ b/libraries/src/Document/Renderer/Feed/RssRenderer.php
@@ -14,6 +14,7 @@ use Joomla\CMS\Document\DocumentRenderer;
 use Joomla\CMS\Uri\Uri;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Router\Route;
 
 /**
  * RssRenderer is a feed that implements RSS 2.0 Specification
@@ -61,7 +62,7 @@ class RssRenderer extends DocumentRenderer
 		}
 
 		$url = URI::getInstance()->toString(array('scheme', 'user', 'pass', 'host', 'port'));
-		$syndicationURL = \JRoute::_('&format=feed&type=rss');
+		$syndicationURL = Route::_('&format=feed&type=rss');
 
 		$title = $data->getTitle();
 

--- a/libraries/src/Document/Renderer/Feed/RssRenderer.php
+++ b/libraries/src/Document/Renderer/Feed/RssRenderer.php
@@ -60,7 +60,7 @@ class RssRenderer extends DocumentRenderer
 			$data->lastBuildDate->setTimeZone(new \DateTimeZone($app->get('offset')));
 		}
 
-		$url = \JUri::getInstance()->toString(array('scheme', 'user', 'pass', 'host', 'port'));
+		$url = URI::getInstance()->toString(array('scheme', 'user', 'pass', 'host', 'port'));
 		$syndicationURL = \JRoute::_('&format=feed&type=rss');
 
 		$title = $data->getTitle();

--- a/libraries/src/Document/Renderer/Feed/RssRenderer.php
+++ b/libraries/src/Document/Renderer/Feed/RssRenderer.php
@@ -61,7 +61,7 @@ class RssRenderer extends DocumentRenderer
 			$data->lastBuildDate->setTimeZone(new \DateTimeZone($app->get('offset')));
 		}
 
-		$url = URI::getInstance()->toString(array('scheme', 'user', 'pass', 'host', 'port'));
+		$url = Uri::getInstance()->toString(array('scheme', 'user', 'pass', 'host', 'port'));
 		$syndicationURL = Route::_('&format=feed&type=rss');
 
 		$title = $data->getTitle();

--- a/libraries/src/Editor/Editor.php
+++ b/libraries/src/Editor/Editor.php
@@ -19,6 +19,7 @@ use Joomla\Registry\Registry;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Filter\InputFilter;
+use Joomla\CMS\Log\Log;
 
 /**
  * Editor class to handle WYSIWYG editors
@@ -304,7 +305,7 @@ class Editor implements DispatcherAwareInterface
 
 		if (!is_file($path))
 		{
-			\JLog::add(Text::_('JLIB_HTML_EDITOR_CANNOT_LOAD'), \JLog::WARNING, 'jerror');
+			Log::add(Text::_('JLIB_HTML_EDITOR_CANNOT_LOAD'), Log::WARNING, 'jerror');
 
 			return false;
 		}

--- a/libraries/src/Environment/Browser.php
+++ b/libraries/src/Environment/Browser.php
@@ -10,6 +10,8 @@ namespace Joomla\CMS\Environment;
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\CMS\Log\Log;
+
 /**
  * Browser class, provides capability information about the current web client.
  *
@@ -691,9 +693,9 @@ class Browser
 	 */
 	public function isSSLConnection()
 	{
-		\JLog::add(
+		Log::add(
 			'Browser::isSSLConnection() is deprecated. Use the isSSLConnection method on the application object instead.',
-			\JLog::WARNING,
+			Log::WARNING,
 			'deprecated'
 		);
 

--- a/libraries/src/Extension/LegacyComponent.php
+++ b/libraries/src/Extension/LegacyComponent.php
@@ -21,6 +21,7 @@ use Joomla\CMS\MVC\Factory\LegacyFactory;
 use Joomla\CMS\MVC\Factory\MVCFactory;
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
 use Joomla\CMS\MVC\Factory\MVCFactoryServiceInterface;
+use Joomla\CMS\Filesystem\Path;
 
 /**
  * Access to component specific services.
@@ -223,7 +224,7 @@ class LegacyComponent implements ComponentInterface, MVCFactoryServiceInterface,
 			return $className;
 		}
 
-		$file = \JPath::clean(JPATH_ADMINISTRATOR . '/components/com_' . $this->component . '/helpers/' . $this->component . '.php');
+		$file = Path::clean(JPATH_ADMINISTRATOR . '/components/com_' . $this->component . '/helpers/' . $this->component . '.php');
 
 		if (!file_exists($file))
 		{

--- a/libraries/src/Filesystem/Folder.php
+++ b/libraries/src/Filesystem/Folder.php
@@ -203,7 +203,7 @@ abstract class Folder
 			// Create the parent directory
 			if (self::create($parent, $mode) !== true)
 			{
-				// JFolder::create throws an error
+				// Folder::create throws an error
 				$nested--;
 
 				return false;
@@ -361,7 +361,7 @@ abstract class Folder
 			}
 			elseif (self::delete($folder) !== true)
 			{
-				// JFolder::delete throws an error
+				// Folder::delete throws an error
 				return false;
 			}
 		}

--- a/libraries/src/Form/Field/SubformField.php
+++ b/libraries/src/Form/Field/SubformField.php
@@ -280,7 +280,7 @@ class SubformField extends FormField
 		// Prepare renderer
 		$renderer = $this->getRenderer($this->layout);
 
-		// Allow to define some JLayout options as attribute of the element
+		// Allow to define some Layout options as attribute of the element
 		if ($this->element['component'])
 		{
 			$renderer->setComponent((string) $this->element['component']);

--- a/libraries/src/Help/Help.php
+++ b/libraries/src/Help/Help.php
@@ -13,6 +13,7 @@ defined('JPATH_PLATFORM') or die;
 use Joomla\CMS\Application\ApplicationHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Component\ComponentHelper;
 
 /**
  * Help system class
@@ -66,7 +67,7 @@ class Help
 			if ($useComponent)
 			{
 				// Look for help URL in component parameters.
-				$params = \JComponentHelper::getParams($component);
+				$params = ComponentHelper::getParams($component);
 				$url    = $params->get('helpURL');
 
 				if ($url == '')

--- a/libraries/src/Helper/ContentHelper.php
+++ b/libraries/src/Helper/ContentHelper.php
@@ -21,6 +21,7 @@ use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Table\Table;
 use Joomla\Registry\Registry;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Object\CMSObject;
 
 /**
  * Helper for standard content style extensions.
@@ -50,7 +51,7 @@ class ContentHelper
 	 * @param   string   $section    The access section name.
 	 * @param   integer  $id         The item ID.
 	 *
-	 * @return  \JObject
+	 * @return  CMSObject
 	 *
 	 * @since   3.2
 	 */
@@ -63,7 +64,7 @@ class ContentHelper
 			$assetName .= '.' . $section . '.' . (int) $id;
 		}
 
-		$result = new \JObject;
+		$result = new CMSObject;
 
 		$user = Factory::getUser();
 

--- a/libraries/src/Helper/LibraryHelper.php
+++ b/libraries/src/Helper/LibraryHelper.php
@@ -13,6 +13,7 @@ defined('JPATH_PLATFORM') or die;
 use Joomla\Registry\Registry;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Log\Log;
 
 /**
  * Library helper class
@@ -185,7 +186,7 @@ class LibraryHelper
 		{
 			// Fatal error.
 			$error = Text::_('JLIB_APPLICATION_ERROR_LIBRARY_NOT_FOUND');
-			\JLog::add(Text::sprintf('JLIB_APPLICATION_ERROR_LIBRARY_NOT_LOADING', $element, $error), \JLog::WARNING, 'jerror');
+			Log::add(Text::sprintf('JLIB_APPLICATION_ERROR_LIBRARY_NOT_LOADING', $element, $error), Log::WARNING, 'jerror');
 
 			return false;
 		}

--- a/libraries/src/Helper/ModuleHelper.php
+++ b/libraries/src/Helper/ModuleHelper.php
@@ -16,6 +16,7 @@ use Joomla\Registry\Registry;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Filter\InputFilter;
+use Joomla\CMS\Log\Log;
 
 /**
  * Module helper class
@@ -153,7 +154,7 @@ abstract class ModuleHelper
 		{
 			if (JDEBUG)
 			{
-				\JLog::addLogger(array('text_file' => 'jmodulehelper.log.php'), \JLog::ALL, array('modulehelper'));
+				Log::addLogger(array('text_file' => 'jmodulehelper.log.php'), Log::ALL, array('modulehelper'));
 				$app->getLogger()->debug(
 					__METHOD__ . '() - The $module parameter should be a module object.',
 					array('category' => 'modulehelper')

--- a/libraries/src/Image/Filter/Backgroundfill.php
+++ b/libraries/src/Image/Filter/Backgroundfill.php
@@ -12,8 +12,9 @@ namespace Joomla\CMS\Image\Filter;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Image\ImageFilter;
+use Joomla\CMS\Log\Log;
 
-\JLog::add('JImageFilterBackgroundfill is deprecated, use Joomla\Image\Filter\Backgroundfill instead.', \JLog::WARNING, 'deprecated');
+Log::add('JImageFilterBackgroundfill is deprecated, use Joomla\Image\Filter\Backgroundfill instead.', Log::WARNING, 'deprecated');
 
 /**
  * Image Filter class fill background with color;

--- a/libraries/src/Image/Filter/Brightness.php
+++ b/libraries/src/Image/Filter/Brightness.php
@@ -12,8 +12,9 @@ namespace Joomla\CMS\Image\Filter;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Image\ImageFilter;
+use Joomla\CMS\Log\Log;
 
-\JLog::add('JImageFilterBrightness is deprecated, use Joomla\Image\Filter\Brightness instead.', \JLog::WARNING, 'deprecated');
+Log::add('JImageFilterBrightness is deprecated, use Joomla\Image\Filter\Brightness instead.', Log::WARNING, 'deprecated');
 
 /**
  * Image Filter class adjust the brightness of an image.

--- a/libraries/src/Image/Filter/Contrast.php
+++ b/libraries/src/Image/Filter/Contrast.php
@@ -12,8 +12,9 @@ namespace Joomla\CMS\Image\Filter;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Image\ImageFilter;
+use Joomla\CMS\Log\Log;
 
-\JLog::add('JImageFilterContrast is deprecated, use Joomla\Image\Filter\Contrast instead.', \JLog::WARNING, 'deprecated');
+Log::add('JImageFilterContrast is deprecated, use Joomla\Image\Filter\Contrast instead.', Log::WARNING, 'deprecated');
 
 /**
  * Image Filter class adjust the contrast of an image.

--- a/libraries/src/Image/Filter/Edgedetect.php
+++ b/libraries/src/Image/Filter/Edgedetect.php
@@ -12,8 +12,9 @@ namespace Joomla\CMS\Image\Filter;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Image\ImageFilter;
+use Joomla\CMS\Log\Log;
 
-\JLog::add('JImageFilterEdgedetect is deprecated, use Joomla\Image\Filter\Edgedetect instead.', \JLog::WARNING, 'deprecated');
+Log::add('JImageFilterEdgedetect is deprecated, use Joomla\Image\Filter\Edgedetect instead.', Log::WARNING, 'deprecated');
 
 /**
  * Image Filter class to add an edge detect effect to an image.

--- a/libraries/src/Image/Filter/Emboss.php
+++ b/libraries/src/Image/Filter/Emboss.php
@@ -12,8 +12,9 @@ namespace Joomla\CMS\Image\Filter;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Image\ImageFilter;
+use Joomla\CMS\Log\Log;
 
-\JLog::add('JImageFilterEmboss is deprecated, use Joomla\Image\Filter\Emboss instead.', \JLog::WARNING, 'deprecated');
+Log::add('JImageFilterEmboss is deprecated, use Joomla\Image\Filter\Emboss instead.', Log::WARNING, 'deprecated');
 
 /**
  * Image Filter class to emboss an image.

--- a/libraries/src/Image/Filter/Grayscale.php
+++ b/libraries/src/Image/Filter/Grayscale.php
@@ -12,8 +12,9 @@ namespace Joomla\CMS\Image\Filter;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Image\ImageFilter;
+use Joomla\CMS\Log\Log;
 
-\JLog::add('JImageFilterGrayscale is deprecated, use Joomla\Image\Filter\Grayscale instead.', \JLog::WARNING, 'deprecated');
+Log::add('JImageFilterGrayscale is deprecated, use Joomla\Image\Filter\Grayscale instead.', Log::WARNING, 'deprecated');
 
 /**
  * Image Filter class to transform an image to grayscale.

--- a/libraries/src/Image/Filter/Negate.php
+++ b/libraries/src/Image/Filter/Negate.php
@@ -12,8 +12,9 @@ namespace Joomla\CMS\Image\Filter;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Image\ImageFilter;
+use Joomla\CMS\Log\Log;
 
-\JLog::add('JImageFilterNegate is deprecated, use Joomla\Image\Filter\Negate instead.', \JLog::WARNING, 'deprecated');
+Log::add('JImageFilterNegate is deprecated, use Joomla\Image\Filter\Negate instead.', Log::WARNING, 'deprecated');
 
 /**
  * Image Filter class to negate the colors of an image.

--- a/libraries/src/Image/Filter/Sketchy.php
+++ b/libraries/src/Image/Filter/Sketchy.php
@@ -12,8 +12,9 @@ namespace Joomla\CMS\Filter\Image;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Image\ImageFilter;
+use Joomla\CMS\Log\Log;
 
-\JLog::add('JImageFilterSketchy is deprecated, use Joomla\Image\Filter\Sketchy instead.', \JLog::WARNING, 'deprecated');
+Log::add('JImageFilterSketchy is deprecated, use Joomla\Image\Filter\Sketchy instead.', Log::WARNING, 'deprecated');
 
 /**
  * Image Filter class to make an image appear "sketchy".

--- a/libraries/src/Image/Filter/Smooth.php
+++ b/libraries/src/Image/Filter/Smooth.php
@@ -12,8 +12,9 @@ namespace Joomla\CMS\Image\Filter;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Image\ImageFilter;
+use Joomla\CMS\Log\Log;
 
-\JLog::add('JImageFilterSmooth is deprecated, use Joomla\Image\Filter\Smooth instead.', \JLog::WARNING, 'deprecated');
+Log::add('JImageFilterSmooth is deprecated, use Joomla\Image\Filter\Smooth instead.', Log::WARNING, 'deprecated');
 
 /**
  * Image Filter class adjust the smoothness of an image.

--- a/libraries/src/Image/Image.php
+++ b/libraries/src/Image/Image.php
@@ -12,6 +12,7 @@ namespace Joomla\CMS\Image;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\Image\Image as FrameworkImage;
+use Joomla\CMS\Log\Log;
 
 /**
  * Class to manipulate an image.
@@ -39,7 +40,7 @@ class Image extends FrameworkImage
 	public function __construct($source = null)
 	{
 		// Inject the PSR-3 compatible logger in for forward compatibility
-		$this->setLogger(\JLog::createDelegatedLogger());
+		$this->setLogger(Log::createDelegatedLogger());
 
 		parent::__construct($source);
 	}
@@ -287,7 +288,7 @@ class Image extends FrameworkImage
 
 			if (!class_exists($className))
 			{
-				\JLog::add('The ' . ucfirst($type) . ' image filter is not available.', \JLog::ERROR);
+				Log::add('The ' . ucfirst($type) . ' image filter is not available.', Log::ERROR);
 				throw new \RuntimeException('The ' . ucfirst($type) . ' image filter is not available.');
 			}
 		}
@@ -299,7 +300,7 @@ class Image extends FrameworkImage
 		if (!($instance instanceof ImageFilter))
 		{
 			// @codeCoverageIgnoreStart
-			\JLog::add('The ' . ucfirst($type) . ' image filter is not valid.', \JLog::ERROR);
+			Log::add('The ' . ucfirst($type) . ' image filter is not valid.', Log::ERROR);
 			throw new \RuntimeException('The ' . ucfirst($type) . ' image filter is not valid.');
 
 			// @codeCoverageIgnoreEnd

--- a/libraries/src/Installer/Adapter/ComponentAdapter.php
+++ b/libraries/src/Installer/Adapter/ComponentAdapter.php
@@ -21,6 +21,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Filesystem\Folder;
 use Joomla\CMS\Log\Log;
+use Joomla\CMS\Filesystem\Path;
 
 /**
  * Component installer
@@ -654,8 +655,8 @@ class ComponentAdapter extends InstallerAdapter
 	protected function setupInstallPaths()
 	{
 		// Set the installation target paths
-		$this->parent->setPath('extension_site', \JPath::clean(JPATH_SITE . '/components/' . $this->element));
-		$this->parent->setPath('extension_administrator', \JPath::clean(JPATH_ADMINISTRATOR . '/components/' . $this->element));
+		$this->parent->setPath('extension_site', Path::clean(JPATH_SITE . '/components/' . $this->element));
+		$this->parent->setPath('extension_administrator', Path::clean(JPATH_ADMINISTRATOR . '/components/' . $this->element));
 
 		// Copy the admin path as it's used as a common base
 		$this->parent->setPath('extension_root', $this->parent->getPath('extension_administrator'));
@@ -677,8 +678,8 @@ class ComponentAdapter extends InstallerAdapter
 	protected function setupUninstall()
 	{
 		// Get the admin and site paths for the component
-		$this->parent->setPath('extension_administrator', \JPath::clean(JPATH_ADMINISTRATOR . '/components/' . $this->extension->element));
-		$this->parent->setPath('extension_site', \JPath::clean(JPATH_SITE . '/components/' . $this->extension->element));
+		$this->parent->setPath('extension_administrator', Path::clean(JPATH_ADMINISTRATOR . '/components/' . $this->extension->element));
+		$this->parent->setPath('extension_site', Path::clean(JPATH_SITE . '/components/' . $this->extension->element));
 
 		// Copy the admin path as it's used as a common base
 		$this->parent->setPath('extension_root', $this->parent->getPath('extension_administrator'));

--- a/libraries/src/Installer/Adapter/ComponentAdapter.php
+++ b/libraries/src/Installer/Adapter/ComponentAdapter.php
@@ -19,8 +19,7 @@ use Joomla\CMS\Table\Table;
 use Joomla\CMS\Table\Update;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
-
-jimport('joomla.filesystem.folder');
+use Joomla\CMS\Filesystem\Folder;
 
 /**
  * Component installer
@@ -214,7 +213,7 @@ class ComponentAdapter extends InstallerAdapter
 
 		if (!file_exists($this->parent->getPath('extension_site')))
 		{
-			if (!$created = \JFolder::create($this->parent->getPath('extension_site')))
+			if (!$created = Folder::create($this->parent->getPath('extension_site')))
 			{
 				throw new \RuntimeException(
 					Text::sprintf(
@@ -245,7 +244,7 @@ class ComponentAdapter extends InstallerAdapter
 
 		if (!file_exists($this->parent->getPath('extension_administrator')))
 		{
-			if (!$created = \JFolder::create($this->parent->getPath('extension_administrator')))
+			if (!$created = Folder::create($this->parent->getPath('extension_administrator')))
 			{
 				throw new \RuntimeException(
 					Text::sprintf(
@@ -416,7 +415,7 @@ class ComponentAdapter extends InstallerAdapter
 			// Delete the component site directory
 			if (is_dir($this->parent->getPath('extension_site')))
 			{
-				if (!\JFolder::delete($this->parent->getPath('extension_site')))
+				if (!Folder::delete($this->parent->getPath('extension_site')))
 				{
 					\JLog::add(Text::_('JLIB_INSTALLER_ERROR_COMP_UNINSTALL_FAILED_REMOVE_DIRECTORY_SITE'), \JLog::WARNING, 'jerror');
 					$retval = false;
@@ -426,7 +425,7 @@ class ComponentAdapter extends InstallerAdapter
 			// Delete the component admin directory
 			if (is_dir($this->parent->getPath('extension_administrator')))
 			{
-				if (!\JFolder::delete($this->parent->getPath('extension_administrator')))
+				if (!Folder::delete($this->parent->getPath('extension_administrator')))
 				{
 					\JLog::add(Text::_('JLIB_INSTALLER_ERROR_COMP_UNINSTALL_FAILED_REMOVE_DIRECTORY_ADMIN'), \JLog::WARNING, 'jerror');
 					$retval = false;
@@ -694,8 +693,8 @@ class ComponentAdapter extends InstallerAdapter
 		if (!$this->getManifest())
 		{
 			// Make sure we delete the folders if no manifest exists
-			\JFolder::delete($this->parent->getPath('extension_administrator'));
-			\JFolder::delete($this->parent->getPath('extension_site'));
+			Folder::delete($this->parent->getPath('extension_administrator'));
+			Folder::delete($this->parent->getPath('extension_site'));
 
 			// Remove the menu
 			$this->_removeAdminMenus($this->extension->extension_id);
@@ -1182,8 +1181,8 @@ class ComponentAdapter extends InstallerAdapter
 	public function discover()
 	{
 		$results = array();
-		$site_components = \JFolder::folders(JPATH_SITE . '/components');
-		$admin_components = \JFolder::folders(JPATH_ADMINISTRATOR . '/components');
+		$site_components = Folder::folders(JPATH_SITE . '/components');
+		$admin_components = Folder::folders(JPATH_ADMINISTRATOR . '/components');
 
 		foreach ($site_components as $component)
 		{

--- a/libraries/src/Installer/Adapter/ComponentAdapter.php
+++ b/libraries/src/Installer/Adapter/ComponentAdapter.php
@@ -20,6 +20,7 @@ use Joomla\CMS\Table\Update;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Filesystem\Folder;
+use Joomla\CMS\Log\Log;
 
 /**
  * Component installer
@@ -316,14 +317,14 @@ class ComponentAdapter extends InstallerAdapter
 		// Time to build the admin menus
 		if (!$this->_buildAdminMenus($this->extension->extension_id))
 		{
-			\JLog::add(Text::_('JLIB_INSTALLER_ABORT_COMP_BUILDADMINMENUS_FAILED'), \JLog::WARNING, 'jerror');
+			Log::add(Text::_('JLIB_INSTALLER_ABORT_COMP_BUILDADMINMENUS_FAILED'), Log::WARNING, 'jerror');
 		}
 
 		// Make sure that menu items pointing to the component have correct component id assigned to them.
 		// Prevents message "Component 'com_extension' does not exist." after uninstalling / re-installing component.
 		if (!$this->_updateMenus($this->extension->extension_id))
 		{
-			\JLog::add(Text::_('JLIB_INSTALLER_ABORT_COMP_UPDATESITEMENUS_FAILED'), \JLog::WARNING, 'jerror');
+			Log::add(Text::_('JLIB_INSTALLER_ABORT_COMP_UPDATESITEMENUS_FAILED'), Log::WARNING, 'jerror');
 		}
 
 		/** @var Asset $asset */
@@ -417,7 +418,7 @@ class ComponentAdapter extends InstallerAdapter
 			{
 				if (!Folder::delete($this->parent->getPath('extension_site')))
 				{
-					\JLog::add(Text::_('JLIB_INSTALLER_ERROR_COMP_UNINSTALL_FAILED_REMOVE_DIRECTORY_SITE'), \JLog::WARNING, 'jerror');
+					Log::add(Text::_('JLIB_INSTALLER_ERROR_COMP_UNINSTALL_FAILED_REMOVE_DIRECTORY_SITE'), Log::WARNING, 'jerror');
 					$retval = false;
 				}
 			}
@@ -427,7 +428,7 @@ class ComponentAdapter extends InstallerAdapter
 			{
 				if (!Folder::delete($this->parent->getPath('extension_administrator')))
 				{
-					\JLog::add(Text::_('JLIB_INSTALLER_ERROR_COMP_UNINSTALL_FAILED_REMOVE_DIRECTORY_ADMIN'), \JLog::WARNING, 'jerror');
+					Log::add(Text::_('JLIB_INSTALLER_ERROR_COMP_UNINSTALL_FAILED_REMOVE_DIRECTORY_ADMIN'), Log::WARNING, 'jerror');
 					$retval = false;
 				}
 			}
@@ -439,7 +440,7 @@ class ComponentAdapter extends InstallerAdapter
 		}
 
 		// No component option defined... cannot delete what we don't know about
-		\JLog::add(Text::_('JLIB_INSTALLER_ERROR_COMP_UNINSTALL_NO_OPTION'), \JLog::WARNING, 'jerror');
+		Log::add(Text::_('JLIB_INSTALLER_ERROR_COMP_UNINSTALL_NO_OPTION'), Log::WARNING, 'jerror');
 
 		return false;
 	}
@@ -1257,7 +1258,7 @@ class ComponentAdapter extends InstallerAdapter
 		}
 		catch (\RuntimeException $e)
 		{
-			\JLog::add(Text::_('JLIB_INSTALLER_ERROR_COMP_REFRESH_MANIFEST_CACHE'), \JLog::WARNING, 'jerror');
+			Log::add(Text::_('JLIB_INSTALLER_ERROR_COMP_REFRESH_MANIFEST_CACHE'), Log::WARNING, 'jerror');
 
 			return false;
 		}
@@ -1284,7 +1285,7 @@ class ComponentAdapter extends InstallerAdapter
 		}
 		catch (\InvalidArgumentException $e)
 		{
-			\JLog::add($e->getMessage(), \JLog::WARNING, 'jerror');
+			Log::add($e->getMessage(), Log::WARNING, 'jerror');
 
 			return false;
 		}

--- a/libraries/src/Installer/Adapter/FileAdapter.php
+++ b/libraries/src/Installer/Adapter/FileAdapter.php
@@ -15,8 +15,7 @@ use Joomla\CMS\Installer\InstallerAdapter;
 use Joomla\CMS\Table\Table;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Filesystem\File;
-
-\JLoader::import('joomla.filesystem.folder');
+use Joomla\CMS\Filesystem\Folder;
 
 /**
  * File installer
@@ -59,9 +58,9 @@ class FileAdapter extends InstallerAdapter
 		// Now that we have folder list, lets start creating them
 		foreach ($this->folderList as $folder)
 		{
-			if (!\JFolder::exists($folder))
+			if (!Folder::exists($folder))
 			{
-				if (!$created = \JFolder::create($folder))
+				if (!$created = Folder::create($folder))
 				{
 					throw new \RuntimeException(
 						Text::sprintf('JLIB_INSTALLER_ABORT_FILE_INSTALL_FAIL_SOURCE_DIRECTORY', $folder)
@@ -123,7 +122,7 @@ class FileAdapter extends InstallerAdapter
 			// First, we have to create a folder for the script if one isn't present
 			if (!file_exists($this->parent->getPath('extension_root')))
 			{
-				\JFolder::create($this->parent->getPath('extension_root'));
+				Folder::create($this->parent->getPath('extension_root'));
 			}
 
 			$path['src'] = $this->parent->getPath('source') . '/' . $this->manifest_script;
@@ -282,11 +281,11 @@ class FileAdapter extends InstallerAdapter
 			// Delete any folders that don't have any content in them.
 			foreach ($folderList as $folder)
 			{
-				$files = \JFolder::files($folder);
+				$files = Folder::files($folder);
 
 				if (!count($files))
 				{
-					\JFolder::delete($folder);
+					Folder::delete($folder);
 				}
 			}
 		}
@@ -294,9 +293,9 @@ class FileAdapter extends InstallerAdapter
 		// Lastly, remove the extension_root
 		$folder = $this->parent->getPath('extension_root');
 
-		if (\JFolder::exists($folder))
+		if (Folder::exists($folder))
 		{
-			\JFolder::delete($folder);
+			Folder::delete($folder);
 		}
 
 		$this->parent->removeFiles($this->getManifest()->languages);
@@ -518,7 +517,7 @@ class FileAdapter extends InstallerAdapter
 				$folderName .= '/' . $dir;
 
 				// Check if folder exists, if not then add to the array for folder creation
-				if (!\JFolder::exists($folderName))
+				if (!Folder::exists($folderName))
 				{
 					$this->folderList[] = $folderName;
 				}
@@ -529,7 +528,7 @@ class FileAdapter extends InstallerAdapter
 			$targetFolder = empty($target) ? $jRootPath : $jRootPath . '/' . $target;
 
 			// Check if source folder exists
-			if (!\JFolder::exists($sourceFolder))
+			if (!Folder::exists($sourceFolder))
 			{
 				\JLog::add(Text::sprintf('JLIB_INSTALLER_ABORT_FILE_INSTALL_FAIL_SOURCE_DIRECTORY', $sourceFolder), \JLog::WARNING, 'jerror');
 
@@ -561,7 +560,7 @@ class FileAdapter extends InstallerAdapter
 			}
 			else
 			{
-				$files = \JFolder::files($sourceFolder);
+				$files = Folder::files($sourceFolder);
 
 				foreach ($files as $file)
 				{

--- a/libraries/src/Installer/Adapter/FileAdapter.php
+++ b/libraries/src/Installer/Adapter/FileAdapter.php
@@ -16,6 +16,7 @@ use Joomla\CMS\Table\Table;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Filesystem\File;
 use Joomla\CMS\Filesystem\Folder;
+use Joomla\CMS\Log\Log;
 
 /**
  * File installer
@@ -530,7 +531,7 @@ class FileAdapter extends InstallerAdapter
 			// Check if source folder exists
 			if (!Folder::exists($sourceFolder))
 			{
-				\JLog::add(Text::sprintf('JLIB_INSTALLER_ABORT_FILE_INSTALL_FAIL_SOURCE_DIRECTORY', $sourceFolder), \JLog::WARNING, 'jerror');
+				Log::add(Text::sprintf('JLIB_INSTALLER_ABORT_FILE_INSTALL_FAIL_SOURCE_DIRECTORY', $sourceFolder), Log::WARNING, 'jerror');
 
 				// If installation fails, rollback
 				$this->parent->abort();
@@ -597,7 +598,7 @@ class FileAdapter extends InstallerAdapter
 		}
 		catch (\RuntimeException $e)
 		{
-			\JLog::add(Text::_('JLIB_INSTALLER_ERROR_PACK_REFRESH_MANIFEST_CACHE'), \JLog::WARNING, 'jerror');
+			Log::add(Text::_('JLIB_INSTALLER_ERROR_PACK_REFRESH_MANIFEST_CACHE'), Log::WARNING, 'jerror');
 
 			return false;
 		}

--- a/libraries/src/Installer/Adapter/FileAdapter.php
+++ b/libraries/src/Installer/Adapter/FileAdapter.php
@@ -17,6 +17,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Filesystem\File;
 use Joomla\CMS\Filesystem\Folder;
 use Joomla\CMS\Log\Log;
+use Joomla\CMS\Filesystem\Path;
 
 /**
  * File installer
@@ -198,7 +199,7 @@ class FileAdapter extends InstallerAdapter
 	{
 		if (!$element)
 		{
-			$manifestPath = \JPath::clean($this->parent->getPath('manifest'));
+			$manifestPath = Path::clean($this->parent->getPath('manifest'));
 			$element = preg_replace('/\.xml/', '', basename($manifestPath));
 		}
 
@@ -494,7 +495,7 @@ class FileAdapter extends InstallerAdapter
 
 		// Set root folder names
 		$packagePath = $this->parent->getPath('source');
-		$jRootPath = \JPath::clean(JPATH_ROOT);
+		$jRootPath = Path::clean(JPATH_ROOT);
 
 		// Loop through all elements and get list of files and folders
 		foreach ($this->getManifest()->fileset->files as $eFiles)

--- a/libraries/src/Installer/Adapter/LanguageAdapter.php
+++ b/libraries/src/Installer/Adapter/LanguageAdapter.php
@@ -22,8 +22,7 @@ use Joomla\Registry\Registry;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Filter\InputFilter;
-
-jimport('joomla.filesystem.folder');
+use Joomla\CMS\Filesystem\Folder;
 
 /**
  * Language installer
@@ -185,7 +184,7 @@ class LanguageAdapter extends InstallerAdapter
 		// Construct the path from the client, the language and the extension element name
 		$path = ApplicationHelper::getClientInfo($this->extension->client_id)->path . '/language/' . $this->extension->element;
 
-		if (!\JFolder::delete($path))
+		if (!Folder::delete($path))
 		{
 			// If deleting failed we'll leave the extension entry in tact just in case
 			\JLog::add(Text::_('JLIB_INSTALLER_ERROR_LANG_UNINSTALL_DIRECTORY'), \JLog::WARNING, 'jerror');
@@ -239,7 +238,7 @@ class LanguageAdapter extends InstallerAdapter
 		$this->parent->setPath('source', $path);
 
 		// Check it exists
-		if (!\JFolder::exists($path))
+		if (!Folder::exists($path))
 		{
 			// If the folder doesn't exist lets just nuke the row as well and presume the user killed it for us
 			$this->extension->delete();
@@ -378,7 +377,7 @@ class LanguageAdapter extends InstallerAdapter
 
 		if (!file_exists($this->parent->getPath('extension_site')))
 		{
-			if (!$created = \JFolder::create($this->parent->getPath('extension_site')))
+			if (!$created = Folder::create($this->parent->getPath('extension_site')))
 			{
 				$this->parent
 					->abort(
@@ -787,8 +786,8 @@ class LanguageAdapter extends InstallerAdapter
 	public function discover()
 	{
 		$results = array();
-		$site_languages = \JFolder::folders(JPATH_SITE . '/language');
-		$admin_languages = \JFolder::folders(JPATH_ADMINISTRATOR . '/language');
+		$site_languages = Folder::folders(JPATH_SITE . '/language');
+		$admin_languages = Folder::folders(JPATH_ADMINISTRATOR . '/language');
 
 		foreach ($site_languages as $language)
 		{

--- a/libraries/src/Installer/Adapter/LanguageAdapter.php
+++ b/libraries/src/Installer/Adapter/LanguageAdapter.php
@@ -23,6 +23,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\Filesystem\Folder;
+use Joomla\CMS\Log\Log;
 
 /**
  * Language installer
@@ -160,7 +161,7 @@ class LanguageAdapter extends InstallerAdapter
 
 		if (!empty($count))
 		{
-			\JLog::add(Text::plural('JLIB_INSTALLER_NOTICE_LANG_RESET_USERS', $count), \JLog::NOTICE, 'jerror');
+			Log::add(Text::plural('JLIB_INSTALLER_NOTICE_LANG_RESET_USERS', $count), Log::NOTICE, 'jerror');
 		}
 
 		// Remove the extension table entry
@@ -187,7 +188,7 @@ class LanguageAdapter extends InstallerAdapter
 		if (!Folder::delete($path))
 		{
 			// If deleting failed we'll leave the extension entry in tact just in case
-			\JLog::add(Text::_('JLIB_INSTALLER_ERROR_LANG_UNINSTALL_DIRECTORY'), \JLog::WARNING, 'jerror');
+			Log::add(Text::_('JLIB_INSTALLER_ERROR_LANG_UNINSTALL_DIRECTORY'), Log::WARNING, 'jerror');
 
 			$this->ignoreUninstallQueries = true;
 		}
@@ -408,19 +409,19 @@ class LanguageAdapter extends InstallerAdapter
 				if (file_exists($this->parent->getPath('extension_site')))
 				{
 					// If the site exists say so.
-					\JLog::add(
+					Log::add(
 						Text::sprintf('JLIB_INSTALLER_ABORT', Text::sprintf('JLIB_INSTALLER_ERROR_FOLDER_IN_USE', $this->parent->getPath('extension_site'))),
-						\JLog::WARNING, 'jerror'
+						Log::WARNING, 'jerror'
 					);
 				}
 				else
 				{
 					// If the admin exists say so.
-					\JLog::add(
+					Log::add(
 						Text::sprintf('JLIB_INSTALLER_ABORT',
 							Text::sprintf('JLIB_INSTALLER_ERROR_FOLDER_IN_USE', $this->parent->getPath('extension_administrator'))
 						),
-						\JLog::WARNING, 'jerror'
+						Log::WARNING, 'jerror'
 					);
 				}
 
@@ -563,9 +564,9 @@ class LanguageAdapter extends InstallerAdapter
 
 			if (!$tableLanguage->bind($languageData) || !$tableLanguage->check() || !$tableLanguage->store() || !$tableLanguage->reorder())
 			{
-				\JLog::add(
+				Log::add(
 					Text::sprintf('JLIB_INSTALLER_WARNING_UNABLE_TO_INSTALL_CONTENT_LANGUAGE', $siteLanguageManifest['name'], $tableLanguage->getError()),
-					\JLog::NOTICE,
+					Log::NOTICE,
 					'jerror'
 				);
 			}
@@ -860,7 +861,7 @@ class LanguageAdapter extends InstallerAdapter
 		}
 		catch (\RuntimeException $e)
 		{
-			\JLog::add(Text::_('JLIB_INSTALLER_ERROR_LANG_DISCOVER_STORE_DETAILS'), \JLog::WARNING, 'jerror');
+			Log::add(Text::_('JLIB_INSTALLER_ERROR_LANG_DISCOVER_STORE_DETAILS'), Log::WARNING, 'jerror');
 
 			return false;
 		}
@@ -894,7 +895,7 @@ class LanguageAdapter extends InstallerAdapter
 		}
 		else
 		{
-			\JLog::add(Text::_('JLIB_INSTALLER_ERROR_MOD_REFRESH_MANIFEST_CACHE'), \JLog::WARNING, 'jerror');
+			Log::add(Text::_('JLIB_INSTALLER_ERROR_MOD_REFRESH_MANIFEST_CACHE'), Log::WARNING, 'jerror');
 
 			return false;
 		}

--- a/libraries/src/Installer/Adapter/LibraryAdapter.php
+++ b/libraries/src/Installer/Adapter/LibraryAdapter.php
@@ -18,8 +18,7 @@ use Joomla\CMS\Table\Update;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\Filesystem\File;
-
-\JLoader::import('joomla.filesystem.folder');
+use Joomla\CMS\Filesystem\Folder;
 
 /**
  * Library installer
@@ -266,15 +265,15 @@ class LibraryAdapter extends InstallerAdapter
 
 		// TODO: Change this so it walked up the path backwards so we clobber multiple empties
 		// If the folder is empty, let's delete it
-		if (\JFolder::exists($this->parent->getPath('extension_root')))
+		if (Folder::exists($this->parent->getPath('extension_root')))
 		{
 			if (is_dir($this->parent->getPath('extension_root')))
 			{
-				$files = \JFolder::files($this->parent->getPath('extension_root'));
+				$files = Folder::files($this->parent->getPath('extension_root'));
 
 				if (!count($files))
 				{
-					\JFolder::delete($this->parent->getPath('extension_root'));
+					Folder::delete($this->parent->getPath('extension_root'));
 				}
 			}
 		}
@@ -482,7 +481,7 @@ class LibraryAdapter extends InstallerAdapter
 	public function discover()
 	{
 		$results = array();
-		$file_list = \JFolder::files(JPATH_MANIFESTS . '/libraries', '\.xml$');
+		$file_list = Folder::files(JPATH_MANIFESTS . '/libraries', '\.xml$');
 
 		foreach ($file_list as $file)
 		{

--- a/libraries/src/Installer/Adapter/LibraryAdapter.php
+++ b/libraries/src/Installer/Adapter/LibraryAdapter.php
@@ -19,6 +19,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\Filesystem\File;
 use Joomla\CMS\Filesystem\Folder;
+use Joomla\CMS\Log\Log;
 
 /**
  * Library installer
@@ -526,7 +527,7 @@ class LibraryAdapter extends InstallerAdapter
 		}
 		catch (\RuntimeException $e)
 		{
-			\JLog::add(Text::_('JLIB_INSTALLER_ERROR_LIB_REFRESH_MANIFEST_CACHE'), \JLog::WARNING, 'jerror');
+			Log::add(Text::_('JLIB_INSTALLER_ERROR_LIB_REFRESH_MANIFEST_CACHE'), Log::WARNING, 'jerror');
 
 			return false;
 		}

--- a/libraries/src/Installer/Adapter/LibraryAdapter.php
+++ b/libraries/src/Installer/Adapter/LibraryAdapter.php
@@ -20,6 +20,7 @@ use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\Filesystem\File;
 use Joomla\CMS\Filesystem\Folder;
 use Joomla\CMS\Log\Log;
+use Joomla\CMS\Filesystem\Path;
 
 /**
  * Library installer
@@ -191,7 +192,7 @@ class LibraryAdapter extends InstallerAdapter
 	{
 		if (!$element)
 		{
-			$manifestPath = \JPath::clean($this->parent->getPath('manifest'));
+			$manifestPath = Path::clean($this->parent->getPath('manifest'));
 			$element = preg_replace('/\.xml/', '', basename($manifestPath));
 		}
 

--- a/libraries/src/Installer/Adapter/ModuleAdapter.php
+++ b/libraries/src/Installer/Adapter/ModuleAdapter.php
@@ -17,6 +17,7 @@ use Joomla\CMS\Table\Table;
 use Joomla\Utilities\ArrayHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Filesystem\Folder;
+use Joomla\CMS\Log\Log;
 
 /**
  * Module installer
@@ -257,7 +258,7 @@ class ModuleAdapter extends InstallerAdapter
 			}
 			catch (\RuntimeException $e)
 			{
-				\JLog::add(Text::sprintf('JLIB_INSTALLER_ERROR_MOD_UNINSTALL_EXCEPTION', $e->getMessage()), \JLog::WARNING, 'jerror');
+				Log::add(Text::sprintf('JLIB_INSTALLER_ERROR_MOD_UNINSTALL_EXCEPTION', $e->getMessage()), Log::WARNING, 'jerror');
 				$retval = false;
 			}
 
@@ -271,7 +272,7 @@ class ModuleAdapter extends InstallerAdapter
 
 				if (!$module->delete())
 				{
-					\JLog::add(Text::sprintf('JLIB_INSTALLER_ERROR_MOD_UNINSTALL_EXCEPTION', $module->getError()), \JLog::WARNING, 'jerror');
+					Log::add(Text::sprintf('JLIB_INSTALLER_ERROR_MOD_UNINSTALL_EXCEPTION', $module->getError()), Log::WARNING, 'jerror');
 					$retval = false;
 				}
 			}
@@ -430,7 +431,7 @@ class ModuleAdapter extends InstallerAdapter
 		}
 		else
 		{
-			\JLog::add(Text::_('JLIB_INSTALLER_ERROR_MOD_REFRESH_MANIFEST_CACHE'), \JLog::WARNING, 'jerror');
+			Log::add(Text::_('JLIB_INSTALLER_ERROR_MOD_REFRESH_MANIFEST_CACHE'), Log::WARNING, 'jerror');
 
 			return false;
 		}

--- a/libraries/src/Installer/Adapter/ModuleAdapter.php
+++ b/libraries/src/Installer/Adapter/ModuleAdapter.php
@@ -16,8 +16,7 @@ use Joomla\CMS\Installer\InstallerAdapter;
 use Joomla\CMS\Table\Table;
 use Joomla\Utilities\ArrayHelper;
 use Joomla\CMS\Language\Text;
-
-\JLoader::import('joomla.filesystem.folder');
+use Joomla\CMS\Filesystem\Folder;
 
 /**
  * Module installer
@@ -120,8 +119,8 @@ class ModuleAdapter extends InstallerAdapter
 	public function discover()
 	{
 		$results = array();
-		$site_list = \JFolder::folders(JPATH_SITE . '/modules');
-		$admin_list = \JFolder::folders(JPATH_ADMINISTRATOR . '/modules');
+		$site_list = Folder::folders(JPATH_SITE . '/modules');
+		$admin_list = Folder::folders(JPATH_ADMINISTRATOR . '/modules');
 		$site_info = ApplicationHelper::getClientInfo('site', true);
 		$admin_info = ApplicationHelper::getClientInfo('administrator', true);
 
@@ -297,9 +296,9 @@ class ModuleAdapter extends InstallerAdapter
 		}
 
 		// Remove the installation folder
-		if (!\JFolder::delete($this->parent->getPath('extension_root')))
+		if (!Folder::delete($this->parent->getPath('extension_root')))
 		{
-			// \JFolder should raise an error
+			// Folder should raise an error
 			$retval = false;
 		}
 

--- a/libraries/src/Installer/Adapter/PackageAdapter.php
+++ b/libraries/src/Installer/Adapter/PackageAdapter.php
@@ -23,6 +23,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\Filesystem\File;
 use Joomla\CMS\Filesystem\Folder;
+use Joomla\CMS\Log\Log;
 
 /**
  * Package installer
@@ -232,7 +233,7 @@ class PackageAdapter extends InstallerAdapter
 			}
 			catch (\JDatabaseExceptionExecuting $e)
 			{
-				\JLog::add(Text::_('JLIB_INSTALLER_ERROR_PACK_SETTING_PACKAGE_ID'), \JLog::WARNING, 'jerror');
+				Log::add(Text::_('JLIB_INSTALLER_ERROR_PACK_SETTING_PACKAGE_ID'), Log::WARNING, 'jerror');
 			}
 		}
 
@@ -435,12 +436,12 @@ class PackageAdapter extends InstallerAdapter
 				if (!$tmpInstaller->uninstall($extension->type, $id))
 				{
 					$error = true;
-					\JLog::add(Text::sprintf('JLIB_INSTALLER_ERROR_PACK_UNINSTALL_NOT_PROPER', basename($extension->filename)), \JLog::WARNING, 'jerror');
+					Log::add(Text::sprintf('JLIB_INSTALLER_ERROR_PACK_UNINSTALL_NOT_PROPER', basename($extension->filename)), Log::WARNING, 'jerror');
 				}
 			}
 			else
 			{
-				\JLog::add(Text::_('JLIB_INSTALLER_ERROR_PACK_UNINSTALL_UNKNOWN_EXTENSION'), \JLog::WARNING, 'jerror');
+				Log::add(Text::_('JLIB_INSTALLER_ERROR_PACK_UNINSTALL_UNKNOWN_EXTENSION'), Log::WARNING, 'jerror');
 			}
 		}
 
@@ -733,7 +734,7 @@ class PackageAdapter extends InstallerAdapter
 		}
 		catch (\RuntimeException $e)
 		{
-			\JLog::add(Text::_('JLIB_INSTALLER_ERROR_PACK_REFRESH_MANIFEST_CACHE'), \JLog::WARNING, 'jerror');
+			Log::add(Text::_('JLIB_INSTALLER_ERROR_PACK_REFRESH_MANIFEST_CACHE'), Log::WARNING, 'jerror');
 
 			return false;
 		}

--- a/libraries/src/Installer/Adapter/PackageAdapter.php
+++ b/libraries/src/Installer/Adapter/PackageAdapter.php
@@ -22,6 +22,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\Filesystem\File;
+use Joomla\CMS\Filesystem\Folder;
 
 /**
  * Package installer
@@ -257,7 +258,7 @@ class PackageAdapter extends InstallerAdapter
 			// First, we have to create a folder for the script if one isn't present
 			if (!file_exists($this->parent->getPath('extension_root')))
 			{
-				if (!\JFolder::create($this->parent->getPath('extension_root')))
+				if (!Folder::create($this->parent->getPath('extension_root')))
 				{
 					throw new \RuntimeException(
 						Text::sprintf(
@@ -333,9 +334,9 @@ class PackageAdapter extends InstallerAdapter
 
 		$folder = $this->parent->getPath('extension_root');
 
-		if (\JFolder::exists($folder))
+		if (Folder::exists($folder))
 		{
-			\JFolder::delete($folder);
+			Folder::delete($folder);
 		}
 
 		$this->extension->delete();

--- a/libraries/src/Installer/Adapter/PluginAdapter.php
+++ b/libraries/src/Installer/Adapter/PluginAdapter.php
@@ -17,8 +17,7 @@ use Joomla\CMS\Table\Table;
 use Joomla\CMS\Table\Update;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Filesystem\File;
-
-\JLoader::import('joomla.filesystem.folder');
+use Joomla\CMS\Filesystem\Folder;
 
 /**
  * Plugin installer
@@ -212,7 +211,7 @@ class PluginAdapter extends InstallerAdapter
 		$this->extension->delete($this->extension->extension_id);
 
 		// Remove the plugin's folder
-		\JFolder::delete($this->parent->getPath('extension_root'));
+		Folder::delete($this->parent->getPath('extension_root'));
 
 		return true;
 	}
@@ -526,11 +525,11 @@ class PluginAdapter extends InstallerAdapter
 	public function discover()
 	{
 		$results = array();
-		$folder_list = \JFolder::folders(JPATH_SITE . '/plugins');
+		$folder_list = Folder::folders(JPATH_SITE . '/plugins');
 
 		foreach ($folder_list as $folder)
 		{
-			$file_list = \JFolder::files(JPATH_SITE . '/plugins/' . $folder, '\.xml$');
+			$file_list = Folder::files(JPATH_SITE . '/plugins/' . $folder, '\.xml$');
 
 			foreach ($file_list as $file)
 			{
@@ -557,11 +556,11 @@ class PluginAdapter extends InstallerAdapter
 				$results[] = $extension;
 			}
 
-			$folder_list = \JFolder::folders(JPATH_SITE . '/plugins/' . $folder);
+			$folder_list = Folder::folders(JPATH_SITE . '/plugins/' . $folder);
 
 			foreach ($folder_list as $plugin_folder)
 			{
-				$file_list = \JFolder::files(JPATH_SITE . '/plugins/' . $folder . '/' . $plugin_folder, '\.xml$');
+				$file_list = Folder::files(JPATH_SITE . '/plugins/' . $folder . '/' . $plugin_folder, '\.xml$');
 
 				foreach ($file_list as $file)
 				{

--- a/libraries/src/Installer/Adapter/PluginAdapter.php
+++ b/libraries/src/Installer/Adapter/PluginAdapter.php
@@ -18,6 +18,7 @@ use Joomla\CMS\Table\Update;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Filesystem\File;
 use Joomla\CMS\Filesystem\Folder;
+use Joomla\CMS\Log\Log;
 
 /**
  * Plugin installer
@@ -624,7 +625,7 @@ class PluginAdapter extends InstallerAdapter
 		}
 		else
 		{
-			\JLog::add(Text::_('JLIB_INSTALLER_ERROR_PLG_REFRESH_MANIFEST_CACHE'), \JLog::WARNING, 'jerror');
+			Log::add(Text::_('JLIB_INSTALLER_ERROR_PLG_REFRESH_MANIFEST_CACHE'), Log::WARNING, 'jerror');
 
 			return false;
 		}

--- a/libraries/src/Installer/Adapter/TemplateAdapter.php
+++ b/libraries/src/Installer/Adapter/TemplateAdapter.php
@@ -18,6 +18,7 @@ use Joomla\CMS\Table\Update;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Filesystem\Folder;
+use Joomla\CMS\Log\Log;
 
 /**
  * Template installer
@@ -360,7 +361,7 @@ class TemplateAdapter extends InstallerAdapter
 		}
 		else
 		{
-			\JLog::add(Text::_('JLIB_INSTALLER_ERROR_TPL_UNINSTALL_TEMPLATE_DIRECTORY'), \JLog::WARNING, 'jerror');
+			Log::add(Text::_('JLIB_INSTALLER_ERROR_TPL_UNINSTALL_TEMPLATE_DIRECTORY'), Log::WARNING, 'jerror');
 		}
 	}
 
@@ -641,7 +642,7 @@ class TemplateAdapter extends InstallerAdapter
 		}
 		catch (\RuntimeException $e)
 		{
-			\JLog::add(Text::_('JLIB_INSTALLER_ERROR_TPL_REFRESH_MANIFEST_CACHE'), \JLog::WARNING, 'jerror');
+			Log::add(Text::_('JLIB_INSTALLER_ERROR_TPL_REFRESH_MANIFEST_CACHE'), Log::WARNING, 'jerror');
 
 			return false;
 		}

--- a/libraries/src/Installer/Adapter/TemplateAdapter.php
+++ b/libraries/src/Installer/Adapter/TemplateAdapter.php
@@ -17,8 +17,7 @@ use Joomla\CMS\Table\Table;
 use Joomla\CMS\Table\Update;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
-
-\JLoader::import('joomla.filesystem.folder');
+use Joomla\CMS\Filesystem\Folder;
 
 /**
  * Template installer
@@ -355,9 +354,9 @@ class TemplateAdapter extends InstallerAdapter
 		$this->parent->removeFiles($this->getManifest()->languages, $this->extension->client_id);
 
 		// Delete the template directory
-		if (\JFolder::exists($this->parent->getPath('extension_root')))
+		if (Folder::exists($this->parent->getPath('extension_root')))
 		{
-			\JFolder::delete($this->parent->getPath('extension_root'));
+			Folder::delete($this->parent->getPath('extension_root'));
 		}
 		else
 		{
@@ -467,7 +466,7 @@ class TemplateAdapter extends InstallerAdapter
 			$this->extension->delete($this->extension->extension_id);
 
 			// Make sure we delete the folders
-			\JFolder::delete($this->parent->getPath('extension_root'));
+			Folder::delete($this->parent->getPath('extension_root'));
 
 			throw new \RuntimeException(Text::_('JLIB_INSTALLER_ERROR_TPL_UNINSTALL_INVALID_NOTFOUND_MANIFEST'));
 		}
@@ -561,8 +560,8 @@ class TemplateAdapter extends InstallerAdapter
 	public function discover()
 	{
 		$results = array();
-		$site_list = \JFolder::folders(JPATH_SITE . '/templates');
-		$admin_list = \JFolder::folders(JPATH_ADMINISTRATOR . '/templates');
+		$site_list = Folder::folders(JPATH_SITE . '/templates');
+		$admin_list = Folder::folders(JPATH_ADMINISTRATOR . '/templates');
 		$site_info = ApplicationHelper::getClientInfo('site', true);
 		$admin_info = ApplicationHelper::getClientInfo('administrator', true);
 

--- a/libraries/src/Installer/Installer.php
+++ b/libraries/src/Installer/Installer.php
@@ -20,9 +20,8 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\Database\DatabaseDriver;
 use Joomla\CMS\Filesystem\File;
+use Joomla\CMS\Filesystem\Folder;
 
-\JLoader::import('joomla.filesystem.file');
-\JLoader::import('joomla.filesystem.folder');
 \JLoader::import('joomla.filesystem.path');
 \JLoader::import('joomla.base.adapter');
 
@@ -386,7 +385,7 @@ class Installer extends \JAdapter
 
 				case 'folder':
 					// Remove the folder
-					$stepval = \JFolder::delete($step['path']);
+					$stepval = Folder::delete($step['path']);
 					break;
 
 				case 'query':
@@ -466,7 +465,7 @@ class Installer extends \JAdapter
 	 */
 	public function install($path = null)
 	{
-		if ($path && \JFolder::exists($path))
+		if ($path && Folder::exists($path))
 		{
 			$this->setPath('source', $path);
 		}
@@ -675,7 +674,7 @@ class Installer extends \JAdapter
 	 */
 	public function update($path = null)
 	{
-		if ($path && \JFolder::exists($path))
+		if ($path && Folder::exists($path))
 		{
 			$this->setPath('source', $path);
 		}
@@ -1065,7 +1064,7 @@ class Installer extends \JAdapter
 
 				if ($schemapath !== '')
 				{
-					$files = str_replace('.sql', '', \JFolder::files($this->getPath('extension_root') . '/' . $schemapath, '\.sql$'));
+					$files = str_replace('.sql', '', Folder::files($this->getPath('extension_root') . '/' . $schemapath, '\.sql$'));
 					usort($files, 'version_compare');
 
 					// Update the database
@@ -1139,7 +1138,7 @@ class Installer extends \JAdapter
 
 				if ($schemapath !== '')
 				{
-					$files = str_replace('.sql', '', \JFolder::files($this->getPath('extension_root') . '/' . $schemapath, '\.sql$'));
+					$files = str_replace('.sql', '', Folder::files($this->getPath('extension_root') . '/' . $schemapath, '\.sql$'));
 					usort($files, 'version_compare');
 
 					if (!count($files))
@@ -1324,7 +1323,7 @@ class Installer extends \JAdapter
 
 				foreach ($deletions['folders'] as $deleted_folder)
 				{
-					\JFolder::delete($destination . '/' . $deleted_folder);
+					Folder::delete($destination . '/' . $deleted_folder);
 				}
 
 				foreach ($deletions['files'] as $deleted_file)
@@ -1364,7 +1363,7 @@ class Installer extends \JAdapter
 			{
 				$newdir = dirname($path['dest']);
 
-				if (!\JFolder::create($newdir))
+				if (!Folder::create($newdir))
 				{
 					\JLog::add(Text::sprintf('JLIB_INSTALLER_ERROR_CREATE_DIRECTORY', $newdir), \JLog::WARNING, 'jerror');
 
@@ -1459,7 +1458,7 @@ class Installer extends \JAdapter
 				}
 
 				// If the language folder is not present, then the core pack hasn't been installed... ignore
-				if (!\JFolder::exists(dirname($path['dest'])))
+				if (!Folder::exists(dirname($path['dest'])))
 				{
 					continue;
 				}
@@ -1480,7 +1479,7 @@ class Installer extends \JAdapter
 			{
 				$newdir = dirname($path['dest']);
 
-				if (!\JFolder::create($newdir))
+				if (!Folder::create($newdir))
 				{
 					\JLog::add(Text::sprintf('JLIB_INSTALLER_ERROR_CREATE_DIRECTORY', $newdir), \JLog::WARNING, 'jerror');
 
@@ -1561,7 +1560,7 @@ class Installer extends \JAdapter
 			{
 				$newdir = dirname($path['dest']);
 
-				if (!\JFolder::create($newdir))
+				if (!Folder::create($newdir))
 				{
 					\JLog::add(Text::sprintf('JLIB_INSTALLER_ERROR_CREATE_DIRECTORY', $newdir), \JLog::WARNING, 'jerror');
 
@@ -1697,7 +1696,7 @@ class Installer extends \JAdapter
 					// Copy the folder or file to the new location.
 					if ($filetype === 'folder')
 					{
-						if (!\JFolder::copy($filesource, $filedest, null, $overwrite))
+						if (!Folder::copy($filesource, $filedest, null, $overwrite))
 						{
 							\JLog::add(Text::sprintf('JLIB_INSTALLER_ERROR_FAIL_COPY_FOLDER', $filesource, $filedest), \JLog::WARNING, 'jerror');
 
@@ -1866,7 +1865,7 @@ class Installer extends \JAdapter
 				}
 
 				// If the language folder is not present, then the core pack hasn't been installed... ignore
-				if (!\JFolder::exists(dirname($path)))
+				if (!Folder::exists(dirname($path)))
 				{
 					continue;
 				}
@@ -1880,7 +1879,7 @@ class Installer extends \JAdapter
 
 			if (is_dir($path))
 			{
-				$val = \JFolder::delete($path);
+				$val = Folder::delete($path);
 			}
 			else
 			{
@@ -1896,7 +1895,7 @@ class Installer extends \JAdapter
 
 		if (!empty($folder))
 		{
-			\JFolder::delete($source);
+			Folder::delete($source);
 		}
 
 		return $retval;
@@ -1942,16 +1941,16 @@ class Installer extends \JAdapter
 	public function findManifest()
 	{
 		// Do nothing if folder does not exist for some reason
-		if (!\JFolder::exists($this->getPath('source')))
+		if (!Folder::exists($this->getPath('source')))
 		{
 			return false;
 		}
 
 		// Main folder manifests (higher priority)
-		$parentXmlfiles = \JFolder::files($this->getPath('source'), '.xml$', false, true);
+		$parentXmlfiles = Folder::files($this->getPath('source'), '.xml$', false, true);
 
 		// Search for children manifests (lower priority)
-		$allXmlFiles    = \JFolder::files($this->getPath('source'), '.xml$', 1, true);
+		$allXmlFiles    = Folder::files($this->getPath('source'), '.xml$', 1, true);
 
 		// Create an unique array of files ordered by priority
 		$xmlfiles = array_unique(array_merge($parentXmlfiles, $allXmlFiles));

--- a/libraries/src/Installer/Installer.php
+++ b/libraries/src/Installer/Installer.php
@@ -22,8 +22,8 @@ use Joomla\Database\DatabaseDriver;
 use Joomla\CMS\Filesystem\File;
 use Joomla\CMS\Filesystem\Folder;
 use Joomla\CMS\Log\Log;
+use Joomla\CMS\Filesystem\Path;
 
-\JLoader::import('joomla.filesystem.path');
 \JLoader::import('joomla.base.adapter');
 
 /**
@@ -1520,7 +1520,7 @@ class Installer extends \JAdapter
 		// Default 'media' Files are copied to the JPATH_BASE/media folder
 
 		$folder = ((string) $element->attributes()->destination) ? '/' . $element->attributes()->destination : null;
-		$destination = \JPath::clean(JPATH_ROOT . '/media' . $folder);
+		$destination = Path::clean(JPATH_ROOT . '/media' . $folder);
 
 		// Here we set the folder we are going to copy the files from.
 
@@ -1664,8 +1664,8 @@ class Installer extends \JAdapter
 			foreach ($files as $file)
 			{
 				// Get the source and destination paths
-				$filesource = \JPath::clean($file['src']);
-				$filedest = \JPath::clean($file['dest']);
+				$filesource = Path::clean($file['src']);
+				$filedest = Path::clean($file['dest']);
 				$filetype = array_key_exists('type', $file) ? $file['type'] : 'file';
 
 				if (!file_exists($filesource))

--- a/libraries/src/Installer/Installer.php
+++ b/libraries/src/Installer/Installer.php
@@ -21,6 +21,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\Database\DatabaseDriver;
 use Joomla\CMS\Filesystem\File;
 use Joomla\CMS\Filesystem\Folder;
+use Joomla\CMS\Log\Log;
 
 \JLoader::import('joomla.filesystem.path');
 \JLoader::import('joomla.base.adapter');
@@ -371,7 +372,7 @@ class Installer extends \JAdapter
 		// Raise abort warning
 		if ($msg)
 		{
-			\JLog::add($msg, \JLog::WARNING, 'jerror');
+			Log::add($msg, Log::WARNING, 'jerror');
 		}
 
 		while ($step != null)
@@ -412,7 +413,7 @@ class Installer extends \JAdapter
 					catch (\JDatabaseExceptionExecuting $e)
 					{
 						// The database API will have already logged the error it caught, we just need to alert the user to the issue
-						\JLog::add(Text::_('JLIB_INSTALLER_ABORT_ERROR_DELETING_EXTENSIONS_RECORD'), \JLog::WARNING, 'jerror');
+						Log::add(Text::_('JLIB_INSTALLER_ABORT_ERROR_DELETING_EXTENSIONS_RECORD'), Log::WARNING, 'jerror');
 
 						$stepval = false;
 					}
@@ -914,7 +915,7 @@ class Installer extends \JAdapter
 			}
 			catch (\JDatabaseExceptionExecuting $e)
 			{
-				\JLog::add(Text::sprintf('JLIB_INSTALLER_ERROR_SQL_ERROR', $e->getMessage()), \JLog::WARNING, 'jerror');
+				Log::add(Text::sprintf('JLIB_INSTALLER_ERROR_SQL_ERROR', $e->getMessage()), Log::WARNING, 'jerror');
 
 				return false;
 			}
@@ -970,7 +971,7 @@ class Installer extends \JAdapter
 				// Check that sql files exists before reading. Otherwise raise error for rollback
 				if (!file_exists($sqlfile))
 				{
-					\JLog::add(Text::sprintf('JLIB_INSTALLER_ERROR_SQL_FILENOTFOUND', $sqlfile), \JLog::WARNING, 'jerror');
+					Log::add(Text::sprintf('JLIB_INSTALLER_ERROR_SQL_FILENOTFOUND', $sqlfile), Log::WARNING, 'jerror');
 
 					return false;
 				}
@@ -980,7 +981,7 @@ class Installer extends \JAdapter
 				// Graceful exit and rollback if read not successful
 				if ($buffer === false)
 				{
-					\JLog::add(Text::_('JLIB_INSTALLER_ERROR_SQL_READBUFFER'), \JLog::WARNING, 'jerror');
+					Log::add(Text::_('JLIB_INSTALLER_ERROR_SQL_READBUFFER'), Log::WARNING, 'jerror');
 
 					return false;
 				}
@@ -1010,7 +1011,7 @@ class Installer extends \JAdapter
 					}
 					catch (\JDatabaseExceptionExecuting $e)
 					{
-						\JLog::add(Text::sprintf('JLIB_INSTALLER_ERROR_SQL_ERROR', $e->getMessage()), \JLog::WARNING, 'jerror');
+						Log::add(Text::sprintf('JLIB_INSTALLER_ERROR_SQL_ERROR', $e->getMessage()), Log::WARNING, 'jerror');
 
 						return false;
 					}
@@ -1176,7 +1177,7 @@ class Installer extends \JAdapter
 							// Graceful exit and rollback if read not successful
 							if ($buffer === false)
 							{
-								\JLog::add(Text::sprintf('JLIB_INSTALLER_ERROR_SQL_READBUFFER'), \JLog::WARNING, 'jerror');
+								Log::add(Text::sprintf('JLIB_INSTALLER_ERROR_SQL_READBUFFER'), Log::WARNING, 'jerror');
 
 								return false;
 							}
@@ -1206,14 +1207,14 @@ class Installer extends \JAdapter
 								}
 								catch (\JDatabaseExceptionExecuting $e)
 								{
-									\JLog::add(Text::sprintf('JLIB_INSTALLER_ERROR_SQL_ERROR', $e->getMessage()), \JLog::WARNING, 'jerror');
+									Log::add(Text::sprintf('JLIB_INSTALLER_ERROR_SQL_ERROR', $e->getMessage()), Log::WARNING, 'jerror');
 
 									return false;
 								}
 
 								$queryString = (string) $query;
 								$queryString = str_replace(array("\r", "\n"), array('', ' '), substr($queryString, 0, 80));
-								\JLog::add(Text::sprintf('JLIB_INSTALLER_UPDATE_LOG_QUERY', $file, $queryString), \JLog::INFO, 'Update');
+								Log::add(Text::sprintf('JLIB_INSTALLER_UPDATE_LOG_QUERY', $file, $queryString), Log::INFO, 'Update');
 
 								$update_count++;
 							}
@@ -1239,7 +1240,7 @@ class Installer extends \JAdapter
 					}
 					catch (ExecutionFailureException $e)
 					{
-						\JLog::add(Text::sprintf('JLIB_INSTALLER_ERROR_SQL_ERROR', $e->getMessage()), \JLog::WARNING, 'jerror');
+						Log::add(Text::sprintf('JLIB_INSTALLER_ERROR_SQL_ERROR', $e->getMessage()), Log::WARNING, 'jerror');
 
 						return false;
 					}
@@ -1365,7 +1366,7 @@ class Installer extends \JAdapter
 
 				if (!Folder::create($newdir))
 				{
-					\JLog::add(Text::sprintf('JLIB_INSTALLER_ERROR_CREATE_DIRECTORY', $newdir), \JLog::WARNING, 'jerror');
+					Log::add(Text::sprintf('JLIB_INSTALLER_ERROR_CREATE_DIRECTORY', $newdir), Log::WARNING, 'jerror');
 
 					return false;
 				}
@@ -1481,7 +1482,7 @@ class Installer extends \JAdapter
 
 				if (!Folder::create($newdir))
 				{
-					\JLog::add(Text::sprintf('JLIB_INSTALLER_ERROR_CREATE_DIRECTORY', $newdir), \JLog::WARNING, 'jerror');
+					Log::add(Text::sprintf('JLIB_INSTALLER_ERROR_CREATE_DIRECTORY', $newdir), Log::WARNING, 'jerror');
 
 					return false;
 				}
@@ -1562,7 +1563,7 @@ class Installer extends \JAdapter
 
 				if (!Folder::create($newdir))
 				{
-					\JLog::add(Text::sprintf('JLIB_INSTALLER_ERROR_CREATE_DIRECTORY', $newdir), \JLog::WARNING, 'jerror');
+					Log::add(Text::sprintf('JLIB_INSTALLER_ERROR_CREATE_DIRECTORY', $newdir), Log::WARNING, 'jerror');
 
 					return false;
 				}
@@ -1673,7 +1674,7 @@ class Installer extends \JAdapter
 					 * The source file does not exist.  Nothing to copy so set an error
 					 * and return false.
 					 */
-					\JLog::add(Text::sprintf('JLIB_INSTALLER_ERROR_NO_FILE', $filesource), \JLog::WARNING, 'jerror');
+					Log::add(Text::sprintf('JLIB_INSTALLER_ERROR_NO_FILE', $filesource), Log::WARNING, 'jerror');
 
 					return false;
 				}
@@ -1687,7 +1688,7 @@ class Installer extends \JAdapter
 
 					// The destination file already exists and the overwrite flag is false.
 					// Set an error and return false.
-					\JLog::add(Text::sprintf('JLIB_INSTALLER_ERROR_FILE_EXISTS', $filedest), \JLog::WARNING, 'jerror');
+					Log::add(Text::sprintf('JLIB_INSTALLER_ERROR_FILE_EXISTS', $filedest), Log::WARNING, 'jerror');
 
 					return false;
 				}
@@ -1698,7 +1699,7 @@ class Installer extends \JAdapter
 					{
 						if (!Folder::copy($filesource, $filedest, null, $overwrite))
 						{
-							\JLog::add(Text::sprintf('JLIB_INSTALLER_ERROR_FAIL_COPY_FOLDER', $filesource, $filedest), \JLog::WARNING, 'jerror');
+							Log::add(Text::sprintf('JLIB_INSTALLER_ERROR_FAIL_COPY_FOLDER', $filesource, $filedest), Log::WARNING, 'jerror');
 
 							return false;
 						}
@@ -1709,12 +1710,12 @@ class Installer extends \JAdapter
 					{
 						if (!File::copy($filesource, $filedest, null))
 						{
-							\JLog::add(Text::sprintf('JLIB_INSTALLER_ERROR_FAIL_COPY_FILE', $filesource, $filedest), \JLog::WARNING, 'jerror');
+							Log::add(Text::sprintf('JLIB_INSTALLER_ERROR_FAIL_COPY_FILE', $filesource, $filedest), Log::WARNING, 'jerror');
 
 							// In 3.2, TinyMCE language handling changed.  Display a special notice in case an older language pack is installed.
 							if (strpos($filedest, 'media/editors/tinymce/jscripts/tiny_mce/langs'))
 							{
-								\JLog::add(Text::_('JLIB_INSTALLER_NOT_ERROR'), \JLog::WARNING, 'jerror');
+								Log::add(Text::_('JLIB_INSTALLER_NOT_ERROR'), Log::WARNING, 'jerror');
 							}
 
 							return false;
@@ -1888,7 +1889,7 @@ class Installer extends \JAdapter
 
 			if ($val === false)
 			{
-				\JLog::add('Failed to delete ' . $path, \JLog::WARNING, 'jerror');
+				Log::add('Failed to delete ' . $path, Log::WARNING, 'jerror');
 				$retval = false;
 			}
 		}
@@ -1990,14 +1991,14 @@ class Installer extends \JAdapter
 			}
 
 			// None of the XML files found were valid install files
-			\JLog::add(Text::_('JLIB_INSTALLER_ERROR_NOTFINDJOOMLAXMLSETUPFILE'), \JLog::WARNING, 'jerror');
+			Log::add(Text::_('JLIB_INSTALLER_ERROR_NOTFINDJOOMLAXMLSETUPFILE'), Log::WARNING, 'jerror');
 
 			return false;
 		}
 		else
 		{
 			// No XML files were found in the install folder
-			\JLog::add(Text::_('JLIB_INSTALLER_ERROR_NOTFINDXMLSETUPFILE'), \JLog::WARNING, 'jerror');
+			Log::add(Text::_('JLIB_INSTALLER_ERROR_NOTFINDXMLSETUPFILE'), Log::WARNING, 'jerror');
 
 			return false;
 		}

--- a/libraries/src/Installer/InstallerAdapter.php
+++ b/libraries/src/Installer/InstallerAdapter.php
@@ -19,6 +19,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\Database\DatabaseDriver;
 use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\Filesystem\Folder;
+use Joomla\CMS\Log\Log;
 
 /**
  * Abstract adapter for the installer.
@@ -1139,7 +1140,7 @@ abstract class InstallerAdapter
 	{
 		if (!$this->extension->load((int) $id))
 		{
-			\JLog::add(Text::_('JLIB_INSTALLER_ERROR_UNKNOWN_EXTENSION'), \JLog::WARNING, 'jerror');
+			Log::add(Text::_('JLIB_INSTALLER_ERROR_UNKNOWN_EXTENSION'), Log::WARNING, 'jerror');
 
 			return false;
 		}
@@ -1147,7 +1148,7 @@ abstract class InstallerAdapter
 		// Protected extensions cannot be removed
 		if ($this->extension->protected)
 		{
-			\JLog::add(Text::_('JLIB_INSTALLER_ERROR_UNINSTALL_PROTECTED_EXTENSION'), \JLog::WARNING, 'jerror');
+			Log::add(Text::_('JLIB_INSTALLER_ERROR_UNINSTALL_PROTECTED_EXTENSION'), Log::WARNING, 'jerror');
 
 			return false;
 		}
@@ -1158,9 +1159,9 @@ abstract class InstallerAdapter
 		 */
 		if ($this->extension->package_id && !$this->parent->isPackageUninstall() && !$this->canUninstallPackageChild($this->extension->package_id))
 		{
-			\JLog::add(
+			Log::add(
 				Text::sprintf('JLIB_INSTALLER_ERROR_CANNOT_UNINSTALL_CHILD_OF_PACKAGE', $this->extension->name),
-				\JLog::WARNING,
+				Log::WARNING,
 				'jerror'
 			);
 
@@ -1174,7 +1175,7 @@ abstract class InstallerAdapter
 		}
 		catch (\RuntimeException $e)
 		{
-			\JLog::add($e->getMessage(), \JLog::WARNING, 'jerror');
+			Log::add($e->getMessage(), Log::WARNING, 'jerror');
 
 			return false;
 		}
@@ -1197,7 +1198,7 @@ abstract class InstallerAdapter
 		}
 		catch (\RuntimeException $e)
 		{
-			\JLog::add($e->getMessage(), \JLog::WARNING, 'jerror');
+			Log::add($e->getMessage(), Log::WARNING, 'jerror');
 
 			return false;
 		}
@@ -1226,7 +1227,7 @@ abstract class InstallerAdapter
 		}
 		catch (\RuntimeException $e)
 		{
-			\JLog::add($e->getMessage(), \JLog::WARNING, 'jerror');
+			Log::add($e->getMessage(), Log::WARNING, 'jerror');
 
 			$retval = false;
 		}
@@ -1243,7 +1244,7 @@ abstract class InstallerAdapter
 		}
 		catch (\RuntimeException $e)
 		{
-			\JLog::add($e->getMessage(), \JLog::WARNING, 'jerror');
+			Log::add($e->getMessage(), Log::WARNING, 'jerror');
 
 			$retval = false;
 		}
@@ -1260,7 +1261,7 @@ abstract class InstallerAdapter
 		}
 		catch (\RuntimeException $e)
 		{
-			\JLog::add($e->getMessage(), \JLog::WARNING, 'jerror');
+			Log::add($e->getMessage(), Log::WARNING, 'jerror');
 
 			$retval = false;
 		}
@@ -1272,7 +1273,7 @@ abstract class InstallerAdapter
 		}
 		catch (\RuntimeException $e)
 		{
-			\JLog::add($e->getMessage(), \JLog::WARNING, 'jerror');
+			Log::add($e->getMessage(), Log::WARNING, 'jerror');
 
 			$retval = false;
 		}

--- a/libraries/src/Installer/InstallerAdapter.php
+++ b/libraries/src/Installer/InstallerAdapter.php
@@ -18,6 +18,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\Database\DatabaseDriver;
 use Joomla\CMS\Filter\InputFilter;
+use Joomla\CMS\Filesystem\Folder;
 
 /**
  * Abstract adapter for the installer.
@@ -299,7 +300,7 @@ abstract class InstallerAdapter
 
 		if (!file_exists($this->parent->getPath('extension_root')))
 		{
-			if (!$created = \JFolder::create($this->parent->getPath('extension_root')))
+			if (!$created = Folder::create($this->parent->getPath('extension_root')))
 			{
 				throw new \RuntimeException(
 					Text::sprintf(

--- a/libraries/src/Installer/InstallerExtension.php
+++ b/libraries/src/Installer/InstallerExtension.php
@@ -13,6 +13,7 @@ defined('JPATH_PLATFORM') or die;
 use Joomla\CMS\Application\ApplicationHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Object\CMSObject;
+use Joomla\CMS\Log\Log;
 
 /**
  * Extension object
@@ -122,7 +123,7 @@ class InstallerExtension extends CMSObject
 
 					if ($tmp_client_id == null)
 					{
-						\JLog::add(Text::_('JLIB_INSTALLER_ERROR_EXTENSION_INVALID_CLIENT_IDENTIFIER'), \JLog::WARNING, 'jerror');
+						Log::add(Text::_('JLIB_INSTALLER_ERROR_EXTENSION_INVALID_CLIENT_IDENTIFIER'), Log::WARNING, 'jerror');
 					}
 					else
 					{

--- a/libraries/src/Installer/InstallerExtension.php
+++ b/libraries/src/Installer/InstallerExtension.php
@@ -12,13 +12,14 @@ defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Application\ApplicationHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Object\CMSObject;
 
 /**
  * Extension object
  *
  * @since  3.1
  */
-class InstallerExtension extends \JObject
+class InstallerExtension extends CMSObject
 {
 	/**
 	 * Filename of the extension

--- a/libraries/src/Installer/InstallerHelper.php
+++ b/libraries/src/Installer/InstallerHelper.php
@@ -18,8 +18,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Filesystem\File;
 use Joomla\CMS\Filesystem\Folder;
 use Joomla\CMS\Log\Log;
-
-\JLoader::import('joomla.filesystem.path');
+use Joomla\CMS\Filesystem\Path;
 
 /**
  * Installer helper class
@@ -128,8 +127,8 @@ abstract class InstallerHelper
 		$tmpdir = uniqid('install_');
 
 		// Clean the paths to use for archive extraction
-		$extractdir = \JPath::clean(dirname($p_filename) . '/' . $tmpdir);
-		$archivename = \JPath::clean($archivename);
+		$extractdir = Path::clean(dirname($p_filename) . '/' . $tmpdir);
+		$archivename = Path::clean($archivename);
 
 		// Do the unpacking of the archive
 		try
@@ -185,7 +184,7 @@ abstract class InstallerHelper
 		{
 			if (Folder::exists($extractdir . '/' . $dirList[0]))
 			{
-				$extractdir = \JPath::clean($extractdir . '/' . $dirList[0]);
+				$extractdir = Path::clean($extractdir . '/' . $dirList[0]);
 			}
 		}
 
@@ -309,10 +308,10 @@ abstract class InstallerHelper
 		{
 			File::delete($package);
 		}
-		elseif (is_file(\JPath::clean($config->get('tmp_path') . '/' . $package)))
+		elseif (is_file(Path::clean($config->get('tmp_path') . '/' . $package)))
 		{
 			// It might also be just a base filename
-			File::delete(\JPath::clean($config->get('tmp_path') . '/' . $package));
+			File::delete(Path::clean($config->get('tmp_path') . '/' . $package));
 		}
 	}
 }

--- a/libraries/src/Installer/InstallerHelper.php
+++ b/libraries/src/Installer/InstallerHelper.php
@@ -16,9 +16,8 @@ use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Version;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Filesystem\File;
+use Joomla\CMS\Filesystem\Folder;
 
-\JLoader::import('joomla.filesystem.file');
-\JLoader::import('joomla.filesystem.folder');
 \JLoader::import('joomla.filesystem.path');
 
 /**
@@ -179,11 +178,11 @@ abstract class InstallerHelper
 		 * List all the items in the installation directory.  If there is only one, and
 		 * it is a folder, then we will set that folder to be the installation folder.
 		 */
-		$dirList = array_merge((array) \JFolder::files($extractdir, ''), (array) \JFolder::folders($extractdir, ''));
+		$dirList = array_merge((array) Folder::files($extractdir, ''), (array) Folder::folders($extractdir, ''));
 
 		if (count($dirList) === 1)
 		{
-			if (\JFolder::exists($extractdir . '/' . $dirList[0]))
+			if (Folder::exists($extractdir . '/' . $dirList[0]))
 			{
 				$extractdir = \JPath::clean($extractdir . '/' . $dirList[0]);
 			}
@@ -223,7 +222,7 @@ abstract class InstallerHelper
 	public static function detectType($p_dir)
 	{
 		// Search the install dir for an XML file
-		$files = \JFolder::files($p_dir, '\.xml$', 1, true);
+		$files = Folder::files($p_dir, '\.xml$', 1, true);
 
 		if (!$files || !count($files))
 		{
@@ -301,7 +300,7 @@ abstract class InstallerHelper
 		// Does the unpacked extension directory exist?
 		if ($resultdir && is_dir($resultdir))
 		{
-			\JFolder::delete($resultdir);
+			Folder::delete($resultdir);
 		}
 
 		// Is the package file a valid file?

--- a/libraries/src/Installer/InstallerHelper.php
+++ b/libraries/src/Installer/InstallerHelper.php
@@ -17,6 +17,7 @@ use Joomla\CMS\Version;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Filesystem\File;
 use Joomla\CMS\Filesystem\Folder;
+use Joomla\CMS\Log\Log;
 
 \JLoader::import('joomla.filesystem.path');
 
@@ -58,7 +59,7 @@ abstract class InstallerHelper
 		}
 		catch (\RuntimeException $exception)
 		{
-			\JLog::add(Text::sprintf('JLIB_INSTALLER_ERROR_DOWNLOAD_SERVER_CONNECT', $exception->getMessage()), \JLog::WARNING, 'jerror');
+			Log::add(Text::sprintf('JLIB_INSTALLER_ERROR_DOWNLOAD_SERVER_CONNECT', $exception->getMessage()), Log::WARNING, 'jerror');
 
 			return false;
 		}
@@ -69,7 +70,7 @@ abstract class InstallerHelper
 		}
 		elseif (200 != $response->code)
 		{
-			\JLog::add(Text::sprintf('JLIB_INSTALLER_ERROR_DOWNLOAD_SERVER_CONNECT', $response->code), \JLog::WARNING, 'jerror');
+			Log::add(Text::sprintf('JLIB_INSTALLER_ERROR_DOWNLOAD_SERVER_CONNECT', $response->code), Log::WARNING, 'jerror');
 
 			return false;
 		}
@@ -226,7 +227,7 @@ abstract class InstallerHelper
 
 		if (!$files || !count($files))
 		{
-			\JLog::add(Text::_('JLIB_INSTALLER_ERROR_NOTFINDXMLSETUPFILE'), \JLog::WARNING, 'jerror');
+			Log::add(Text::_('JLIB_INSTALLER_ERROR_NOTFINDXMLSETUPFILE'), Log::WARNING, 'jerror');
 
 			return false;
 		}
@@ -254,7 +255,7 @@ abstract class InstallerHelper
 			return $type;
 		}
 
-		\JLog::add(Text::_('JLIB_INSTALLER_ERROR_NOTFINDJOOMLAXMLSETUPFILE'), \JLog::WARNING, 'jerror');
+		Log::add(Text::_('JLIB_INSTALLER_ERROR_NOTFINDJOOMLAXMLSETUPFILE'), Log::WARNING, 'jerror');
 
 		// Free up memory.
 		unset($xml);

--- a/libraries/src/Installer/InstallerScript.php
+++ b/libraries/src/Installer/InstallerScript.php
@@ -14,6 +14,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Filesystem\File;
 use Joomla\CMS\Filesystem\Folder;
+use Joomla\CMS\Log\Log;
 
 /**
  * Base install script for use by extensions providing helper methods for common behaviours.
@@ -111,7 +112,7 @@ class InstallerScript
 		// Check for the minimum PHP version before continuing
 		if (!empty($this->minimumPhp) && version_compare(PHP_VERSION, $this->minimumPhp, '<'))
 		{
-			\JLog::add(Text::sprintf('JLIB_INSTALLER_MINIMUM_PHP', $this->minimumPhp), \JLog::WARNING, 'jerror');
+			Log::add(Text::sprintf('JLIB_INSTALLER_MINIMUM_PHP', $this->minimumPhp), Log::WARNING, 'jerror');
 
 			return false;
 		}
@@ -119,7 +120,7 @@ class InstallerScript
 		// Check for the minimum Joomla version before continuing
 		if (!empty($this->minimumJoomla) && version_compare(JVERSION, $this->minimumJoomla, '<'))
 		{
-			\JLog::add(Text::sprintf('JLIB_INSTALLER_MINIMUM_JOOMLA', $this->minimumJoomla), \JLog::WARNING, 'jerror');
+			Log::add(Text::sprintf('JLIB_INSTALLER_MINIMUM_JOOMLA', $this->minimumJoomla), Log::WARNING, 'jerror');
 
 			return false;
 		}

--- a/libraries/src/Installer/InstallerScript.php
+++ b/libraries/src/Installer/InstallerScript.php
@@ -13,9 +13,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Filesystem\File;
-
-\JLoader::import('joomla.filesystem.file');
-\JLoader::import('joomla.filesystem.folder');
+use Joomla\CMS\Filesystem\Folder;
 
 /**
  * Base install script for use by extensions providing helper methods for common behaviours.
@@ -329,7 +327,7 @@ class InstallerScript
 		{
 			foreach ($this->deleteFolders as $folder)
 			{
-				if (\JFolder::exists(JPATH_ROOT . $folder) && !\JFolder::delete(JPATH_ROOT . $folder))
+				if (Folder::exists(JPATH_ROOT . $folder) && !Folder::delete(JPATH_ROOT . $folder))
 				{
 					echo Text::sprintf('JLIB_INSTALLER_ERROR_FILE_FOLDER', $folder) . '<br>';
 				}

--- a/libraries/src/Language/Language.php
+++ b/libraries/src/Language/Language.php
@@ -11,6 +11,7 @@ namespace Joomla\CMS\Language;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\String\StringHelper;
+use Joomla\CMS\Log\Log;
 
 /**
  * Allows for quoting in language .ini files.
@@ -690,7 +691,7 @@ class Language
 	 */
 	public static function exists($lang, $basePath = JPATH_BASE)
 	{
-		\JLog::add(__METHOD__ . '() is deprecated, use LanguageHelper::exists() instead.', \JLog::WARNING, 'deprecated');
+		Log::add(__METHOD__ . '() is deprecated, use LanguageHelper::exists() instead.', Log::WARNING, 'deprecated');
 
 		return LanguageHelper::exists($lang, $basePath);
 	}
@@ -1234,7 +1235,7 @@ class Language
 	 */
 	public static function getMetadata($lang)
 	{
-		\JLog::add(__METHOD__ . '() is deprecated, use LanguageHelper::getMetadata() instead.', \JLog::WARNING, 'deprecated');
+		Log::add(__METHOD__ . '() is deprecated, use LanguageHelper::getMetadata() instead.', Log::WARNING, 'deprecated');
 
 		return LanguageHelper::getMetadata($lang);
 	}
@@ -1251,7 +1252,7 @@ class Language
 	 */
 	public static function getKnownLanguages($basePath = JPATH_BASE)
 	{
-		\JLog::add(__METHOD__ . '() is deprecated, use LanguageHelper::getKnownLanguages() instead.', \JLog::WARNING, 'deprecated');
+		Log::add(__METHOD__ . '() is deprecated, use LanguageHelper::getKnownLanguages() instead.', Log::WARNING, 'deprecated');
 
 		return LanguageHelper::getKnownLanguages($basePath);
 	}
@@ -1269,7 +1270,7 @@ class Language
 	 */
 	public static function getLanguagePath($basePath = JPATH_BASE, $language = null)
 	{
-		\JLog::add(__METHOD__ . '() is deprecated, use LanguageHelper::getLanguagePath() instead.', \JLog::WARNING, 'deprecated');
+		Log::add(__METHOD__ . '() is deprecated, use LanguageHelper::getLanguagePath() instead.', Log::WARNING, 'deprecated');
 
 		return LanguageHelper::getLanguagePath($basePath, $language);
 	}
@@ -1288,7 +1289,7 @@ class Language
 	 */
 	public function setLanguage($lang)
 	{
-		\JLog::add(__METHOD__ . ' is deprecated. Instantiate a new Language object instead.', \JLog::WARNING, 'deprecated');
+		Log::add(__METHOD__ . ' is deprecated. Instantiate a new Language object instead.', Log::WARNING, 'deprecated');
 
 		$previous = $this->lang;
 		$this->lang = $lang;
@@ -1359,7 +1360,7 @@ class Language
 	 */
 	public static function parseLanguageFiles($dir = null)
 	{
-		\JLog::add(__METHOD__ . '() is deprecated, use LanguageHelper::parseLanguageFiles() instead.', \JLog::WARNING, 'deprecated');
+		Log::add(__METHOD__ . '() is deprecated, use LanguageHelper::parseLanguageFiles() instead.', Log::WARNING, 'deprecated');
 
 		return LanguageHelper::parseLanguageFiles($dir);
 	}
@@ -1377,7 +1378,7 @@ class Language
 	 */
 	public static function parseXMLLanguageFile($path)
 	{
-		\JLog::add(__METHOD__ . '() is deprecated, use LanguageHelper::parseXMLLanguageFile() instead.', \JLog::WARNING, 'deprecated');
+		Log::add(__METHOD__ . '() is deprecated, use LanguageHelper::parseXMLLanguageFile() instead.', Log::WARNING, 'deprecated');
 
 		return LanguageHelper::parseXMLLanguageFile($path);
 	}

--- a/libraries/src/Language/LanguageHelper.php
+++ b/libraries/src/Language/LanguageHelper.php
@@ -15,6 +15,7 @@ use Joomla\Utilities\ArrayHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Filesystem\File;
+use Joomla\CMS\Log\Log;
 
 /**
  * Language helper class
@@ -247,7 +248,7 @@ class LanguageHelper
 					// Not able to process xml language file. Fail silently.
 					catch (\Exception $e)
 					{
-						\JLog::add(Text::sprintf('JLIB_LANGUAGE_ERROR_CANNOT_LOAD_METAFILE', $language->element, $metafile), \JLog::WARNING, 'language');
+						Log::add(Text::sprintf('JLIB_LANGUAGE_ERROR_CANNOT_LOAD_METAFILE', $language->element, $metafile), Log::WARNING, 'language');
 
 						continue;
 					}
@@ -255,7 +256,7 @@ class LanguageHelper
 					// No metadata found, not a valid language. Fail silently.
 					if (!is_array($lang->metadata))
 					{
-						\JLog::add(Text::sprintf('JLIB_LANGUAGE_ERROR_CANNOT_LOAD_METADATA', $language->element, $metafile), \JLog::WARNING, 'language');
+						Log::add(Text::sprintf('JLIB_LANGUAGE_ERROR_CANNOT_LOAD_METADATA', $language->element, $metafile), Log::WARNING, 'language');
 
 						continue;
 					}
@@ -272,7 +273,7 @@ class LanguageHelper
 					// Not able to process xml language file. Fail silently.
 					catch (\Exception $e)
 					{
-						\JLog::add(Text::sprintf('JLIB_LANGUAGE_ERROR_CANNOT_LOAD_METAFILE', $language->element, $metafile), \JLog::WARNING, 'language');
+						Log::add(Text::sprintf('JLIB_LANGUAGE_ERROR_CANNOT_LOAD_METAFILE', $language->element, $metafile), Log::WARNING, 'language');
 
 						continue;
 					}
@@ -280,7 +281,7 @@ class LanguageHelper
 					// No metadata found, not a valid language. Fail silently.
 					if (!is_array($lang->manifest))
 					{
-						\JLog::add(Text::sprintf('JLIB_LANGUAGE_ERROR_CANNOT_LOAD_METADATA', $language->element, $metafile), \JLog::WARNING, 'language');
+						Log::add(Text::sprintf('JLIB_LANGUAGE_ERROR_CANNOT_LOAD_METADATA', $language->element, $metafile), Log::WARNING, 'language');
 
 						continue;
 					}

--- a/libraries/src/Language/Multilanguage.php
+++ b/libraries/src/Language/Multilanguage.php
@@ -11,6 +11,7 @@ namespace Joomla\CMS\Language;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Factory;
+use Joomla\CMS\Log\Log;
 
 /**
  * Utitlity class for multilang
@@ -87,7 +88,7 @@ class Multilanguage
 	 */
 	public static function getSiteLangs()
 	{
-		\JLog::add(__METHOD__ . ' is deprecated. Use \JLanguageHelper::getInstalledLanguages(0) instead.', \JLog::WARNING, 'deprecated');
+		Log::add(__METHOD__ . ' is deprecated. Use \JLanguageHelper::getInstalledLanguages(0) instead.', Log::WARNING, 'deprecated');
 
 		return \JLanguageHelper::getInstalledLanguages(0);
 	}

--- a/libraries/src/Language/Multilanguage.php
+++ b/libraries/src/Language/Multilanguage.php
@@ -12,6 +12,7 @@ defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Log\Log;
+use Joomla\CMS\Language\LanguageHelper;
 
 /**
  * Utitlity class for multilang
@@ -84,13 +85,13 @@ class Multilanguage
 	 * @return  array of language extension objects.
 	 *
 	 * @since   3.5
-	 * @deprecated   3.7.0  Use \JLanguageHelper::getInstalledLanguages(0) instead.
+	 * @deprecated   3.7.0  Use LanguageHelper::getInstalledLanguages(0) instead.
 	 */
 	public static function getSiteLangs()
 	{
-		Log::add(__METHOD__ . ' is deprecated. Use \JLanguageHelper::getInstalledLanguages(0) instead.', Log::WARNING, 'deprecated');
+		Log::add(__METHOD__ . ' is deprecated. Use LanguageHelper::getInstalledLanguages(0) instead.', Log::WARNING, 'deprecated');
 
-		return \JLanguageHelper::getInstalledLanguages(0);
+		return LanguageHelper::getInstalledLanguages(0);
 	}
 
 	/**

--- a/libraries/src/Layout/FileLayout.php
+++ b/libraries/src/Layout/FileLayout.php
@@ -13,6 +13,7 @@ defined('JPATH_PLATFORM') or die;
 use Joomla\CMS\Application\ApplicationHelper;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Filesystem\Path;
 
 /**
  * Base class for rendering a display layout
@@ -139,8 +140,6 @@ class FileLayout extends BaseLayout
 	 */
 	protected function getPath()
 	{
-		\JLoader::import('joomla.filesystem.path');
-
 		$layoutId     = $this->getLayoutId();
 		$includePaths = $this->getIncludePaths();
 		$suffixes     = $this->getSuffixes();
@@ -189,7 +188,7 @@ class FileLayout extends BaseLayout
 				$rawPath  = str_replace('.', '/', $this->layoutId) . '.' . $suffix . '.php';
 				$this->addDebugMessage('<strong>Searching layout for:</strong> ' . $rawPath);
 
-				if ($foundLayout = \JPath::find($this->includePaths, $rawPath))
+				if ($foundLayout = Path::find($this->includePaths, $rawPath))
 				{
 					$this->addDebugMessage('<strong>Found layout:</strong> ' . $this->fullPath);
 
@@ -204,7 +203,7 @@ class FileLayout extends BaseLayout
 		$rawPath  = str_replace('.', '/', $this->layoutId) . '.php';
 		$this->addDebugMessage('<strong>Searching layout for:</strong> ' . $rawPath);
 
-		$foundLayout = \JPath::find($this->includePaths, $rawPath);
+		$foundLayout = Path::find($this->includePaths, $rawPath);
 
 		if (!$foundLayout)
 		{

--- a/libraries/src/Log/Logger.php
+++ b/libraries/src/Log/Logger.php
@@ -21,7 +21,7 @@ defined('JPATH_PLATFORM') or die;
 abstract class Logger
 {
 	/**
-	 * Options array for the JLog instance.
+	 * Options array for the Log instance.
 	 *
 	 * @var    array
 	 * @since  12.2

--- a/libraries/src/Log/Logger/FormattedtextLogger.php
+++ b/libraries/src/Log/Logger/FormattedtextLogger.php
@@ -14,9 +14,7 @@ use Joomla\CMS\Log\LogEntry;
 use Joomla\CMS\Log\Logger;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Filesystem\File;
-
-\JLoader::import('joomla.filesystem.file');
-\JLoader::import('joomla.filesystem.folder');
+use Joomla\CMS\Filesystem\Folder;
 
 /**
  * Joomla! Formatted Text File Log class
@@ -213,7 +211,7 @@ class FormattedtextLogger extends Logger
 		}
 
 		// Make sure the folder exists in which to create the log file.
-		\JFolder::create(dirname($this->path));
+		Folder::create(dirname($this->path));
 
 		// Build the log file header.
 		$head = $this->generateFileHeader();

--- a/libraries/src/MVC/Controller/AdminController.php
+++ b/libraries/src/MVC/Controller/AdminController.php
@@ -14,6 +14,7 @@ use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
 use Joomla\Utilities\ArrayHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Session\Session;
 
 /**
  * Base class for a Joomla Administrator Controller
@@ -123,7 +124,7 @@ class AdminController extends BaseController
 	public function delete()
 	{
 		// Check for request forgeries
-		\JSession::checkToken() or die(Text::_('JINVALID_TOKEN'));
+		Session::checkToken() or die(Text::_('JINVALID_TOKEN'));
 
 		// Get items to remove from the request.
 		$cid = $this->input->get('cid', array(), 'array');
@@ -197,7 +198,7 @@ class AdminController extends BaseController
 	public function publish()
 	{
 		// Check for request forgeries
-		\JSession::checkToken() or die(Text::_('JINVALID_TOKEN'));
+		Session::checkToken() or die(Text::_('JINVALID_TOKEN'));
 
 		// Get items to publish from the request.
 		$cid   = $this->input->get('cid', array(), 'array');
@@ -274,7 +275,7 @@ class AdminController extends BaseController
 	public function reorder()
 	{
 		// Check for request forgeries.
-		\JSession::checkToken() or jexit(Text::_('JINVALID_TOKEN'));
+		Session::checkToken() or jexit(Text::_('JINVALID_TOKEN'));
 
 		$ids = $this->input->post->get('cid', array(), 'array');
 		$inc = $this->getTask() === 'orderup' ? -1 : 1;
@@ -310,7 +311,7 @@ class AdminController extends BaseController
 	public function saveorder()
 	{
 		// Check for request forgeries.
-		\JSession::checkToken() or jexit(Text::_('JINVALID_TOKEN'));
+		Session::checkToken() or jexit(Text::_('JINVALID_TOKEN'));
 
 		// Get the input
 		$pks = $this->input->post->get('cid', array(), 'array');
@@ -354,7 +355,7 @@ class AdminController extends BaseController
 	public function checkin()
 	{
 		// Check for request forgeries.
-		\JSession::checkToken() or jexit(Text::_('JINVALID_TOKEN'));
+		Session::checkToken() or jexit(Text::_('JINVALID_TOKEN'));
 
 		$ids = $this->input->post->get('cid', array(), 'array');
 

--- a/libraries/src/MVC/Controller/AdminController.php
+++ b/libraries/src/MVC/Controller/AdminController.php
@@ -15,6 +15,7 @@ use Joomla\Utilities\ArrayHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Session\Session;
+use Joomla\CMS\Router\Route;
 
 /**
  * Base class for a Joomla Administrator Controller
@@ -155,7 +156,7 @@ class AdminController extends BaseController
 			$this->postDeleteHook($model, $cid);
 		}
 
-		$this->setRedirect(\JRoute::_('index.php?option=' . $this->option . '&view=' . $this->view_list, false));
+		$this->setRedirect(Route::_('index.php?option=' . $this->option . '&view=' . $this->view_list, false));
 	}
 
 	/**
@@ -262,7 +263,7 @@ class AdminController extends BaseController
 
 		$extension = $this->input->get('extension');
 		$extensionURL = $extension ? '&extension=' . $extension : '';
-		$this->setRedirect(\JRoute::_('index.php?option=' . $this->option . '&view=' . $this->view_list . $extensionURL, false));
+		$this->setRedirect(Route::_('index.php?option=' . $this->option . '&view=' . $this->view_list . $extensionURL, false));
 	}
 
 	/**
@@ -287,7 +288,7 @@ class AdminController extends BaseController
 		{
 			// Reorder failed.
 			$message = Text::sprintf('JLIB_APPLICATION_ERROR_REORDER_FAILED', $model->getError());
-			$this->setRedirect(\JRoute::_('index.php?option=' . $this->option . '&view=' . $this->view_list, false), $message, 'error');
+			$this->setRedirect(Route::_('index.php?option=' . $this->option . '&view=' . $this->view_list, false), $message, 'error');
 
 			return false;
 		}
@@ -295,7 +296,7 @@ class AdminController extends BaseController
 		{
 			// Reorder succeeded.
 			$message = Text::_('JLIB_APPLICATION_SUCCESS_ITEM_REORDERED');
-			$this->setRedirect(\JRoute::_('index.php?option=' . $this->option . '&view=' . $this->view_list, false), $message);
+			$this->setRedirect(Route::_('index.php?option=' . $this->option . '&view=' . $this->view_list, false), $message);
 
 			return true;
 		}
@@ -331,7 +332,7 @@ class AdminController extends BaseController
 		{
 			// Reorder failed
 			$message = Text::sprintf('JLIB_APPLICATION_ERROR_REORDER_FAILED', $model->getError());
-			$this->setRedirect(\JRoute::_('index.php?option=' . $this->option . '&view=' . $this->view_list, false), $message, 'error');
+			$this->setRedirect(Route::_('index.php?option=' . $this->option . '&view=' . $this->view_list, false), $message, 'error');
 
 			return false;
 		}
@@ -339,7 +340,7 @@ class AdminController extends BaseController
 		{
 			// Reorder succeeded.
 			$this->setMessage(Text::_('JLIB_APPLICATION_SUCCESS_ORDERING_SAVED'));
-			$this->setRedirect(\JRoute::_('index.php?option=' . $this->option . '&view=' . $this->view_list, false));
+			$this->setRedirect(Route::_('index.php?option=' . $this->option . '&view=' . $this->view_list, false));
 
 			return true;
 		}
@@ -366,7 +367,7 @@ class AdminController extends BaseController
 		{
 			// Checkin failed.
 			$message = Text::sprintf('JLIB_APPLICATION_ERROR_CHECKIN_FAILED', $model->getError());
-			$this->setRedirect(\JRoute::_('index.php?option=' . $this->option . '&view=' . $this->view_list, false), $message, 'error');
+			$this->setRedirect(Route::_('index.php?option=' . $this->option . '&view=' . $this->view_list, false), $message, 'error');
 
 			return false;
 		}
@@ -374,7 +375,7 @@ class AdminController extends BaseController
 		{
 			// Checkin succeeded.
 			$message = Text::plural($this->text_prefix . '_N_ITEMS_CHECKED_IN', count($ids));
-			$this->setRedirect(\JRoute::_('index.php?option=' . $this->option . '&view=' . $this->view_list, false), $message);
+			$this->setRedirect(Route::_('index.php?option=' . $this->option . '&view=' . $this->view_list, false), $message);
 
 			return true;
 		}

--- a/libraries/src/MVC/Controller/AdminController.php
+++ b/libraries/src/MVC/Controller/AdminController.php
@@ -16,6 +16,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Session\Session;
 use Joomla\CMS\Router\Route;
+use Joomla\CMS\Component\ComponentHelper;
 
 /**
  * Base class for a Joomla Administrator Controller
@@ -86,7 +87,7 @@ class AdminController extends BaseController
 		// Guess the option as com_NameOfController.
 		if (empty($this->option))
 		{
-			$this->option = \JComponentHelper::getComponentName($this, $this->getName());
+			$this->option = ComponentHelper::getComponentName($this, $this->getName());
 		}
 
 		// Guess the \JText message prefix. Defaults to the option.

--- a/libraries/src/MVC/Controller/BaseController.php
+++ b/libraries/src/MVC/Controller/BaseController.php
@@ -20,6 +20,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\Session\Session;
 use Joomla\CMS\Uri\Uri;
+use Joomla\CMS\Log\Log;
 
 /**
  * Base class for a Joomla Controller
@@ -367,7 +368,7 @@ class BaseController implements ControllerInterface
 
 		if (defined('JDEBUG') && JDEBUG)
 		{
-			\JLog::addLogger(array('text_file' => 'jcontroller.log.php'), \JLog::ALL, array('controller'));
+			Log::addLogger(array('text_file' => 'jcontroller.log.php'), Log::ALL, array('controller'));
 		}
 
 		// Determine the methods to exclude from the base class.

--- a/libraries/src/MVC/Controller/BaseController.php
+++ b/libraries/src/MVC/Controller/BaseController.php
@@ -1063,7 +1063,7 @@ class BaseController implements ControllerInterface
 		{
 			$referrer = $this->input->server->getString('HTTP_REFERER');
 
-			if (!URI::isInternal($referrer))
+			if (!Uri::isInternal($referrer))
 			{
 				$referrer = 'index.php';
 			}

--- a/libraries/src/MVC/Controller/BaseController.php
+++ b/libraries/src/MVC/Controller/BaseController.php
@@ -19,6 +19,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\Session\Session;
+use Joomla\CMS\Uri\Uri;
 
 /**
  * Base class for a Joomla Controller
@@ -1060,7 +1061,7 @@ class BaseController implements ControllerInterface
 		{
 			$referrer = $this->input->server->getString('HTTP_REFERER');
 
-			if (!\JUri::isInternal($referrer))
+			if (!URI::isInternal($referrer))
 			{
 				$referrer = 'index.php';
 			}

--- a/libraries/src/MVC/Controller/BaseController.php
+++ b/libraries/src/MVC/Controller/BaseController.php
@@ -21,6 +21,7 @@ use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\Session\Session;
 use Joomla\CMS\Uri\Uri;
 use Joomla\CMS\Log\Log;
+use Joomla\CMS\Filesystem\Path;
 
 /**
  * Base class for a Joomla Controller
@@ -495,7 +496,7 @@ class BaseController implements ControllerInterface
 		foreach ((array) $path as $dir)
 		{
 			// No surrounding spaces allowed!
-			$dir = rtrim(\JPath::check($dir), '/') . '/';
+			$dir = rtrim(Path::check($dir), '/') . '/';
 
 			// Add to the top of the search dirs
 			array_unshift($this->paths[$type], $dir);

--- a/libraries/src/MVC/Controller/BaseController.php
+++ b/libraries/src/MVC/Controller/BaseController.php
@@ -18,6 +18,7 @@ use Joomla\CMS\MVC\View\AbstractView;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Filter\InputFilter;
+use Joomla\CMS\Session\Session;
 
 /**
  * Base class for a Joomla Controller
@@ -1041,7 +1042,7 @@ class BaseController implements ControllerInterface
 	/**
 	 * Checks for a form token in the request.
 	 *
-	 * Use in conjunction with HTMLHelper::_('form.token') or \JSession::getFormToken.
+	 * Use in conjunction with HTMLHelper::_('form.token') or Session::getFormToken.
 	 *
 	 * @param   string   $method    The request method in which to look for the token key.
 	 * @param   boolean  $redirect  Whether to implicitly redirect user to the referrer page on failure or simply return false.
@@ -1049,11 +1050,11 @@ class BaseController implements ControllerInterface
 	 * @return  boolean  True if found and valid, otherwise return false or redirect to referrer page.
 	 *
 	 * @since   3.7.0
-	 * @see     \JSession::checkToken()
+	 * @see     Session::checkToken()
 	 */
 	public function checkToken($method = 'post', $redirect = true)
 	{
-		$valid = \JSession::checkToken($method);
+		$valid = Session::checkToken($method);
 
 		if (!$valid && $redirect)
 		{

--- a/libraries/src/MVC/Controller/FormController.php
+++ b/libraries/src/MVC/Controller/FormController.php
@@ -19,6 +19,7 @@ use Joomla\CMS\Form\FormFactoryInterface;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Session\Session;
+use Joomla\CMS\Uri\Uri;
 
 /**
  * Controller tailored to suit most form-based admin operations.
@@ -821,7 +822,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
 				// Check if there is a return value
 				$return = $this->input->get('return', null, 'base64');
 
-				if (!is_null($return) && \JUri::isInternal(base64_decode($return)))
+				if (!is_null($return) && URI::isInternal(base64_decode($return)))
 				{
 					$url = base64_decode($return);
 				}

--- a/libraries/src/MVC/Controller/FormController.php
+++ b/libraries/src/MVC/Controller/FormController.php
@@ -21,6 +21,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Session\Session;
 use Joomla\CMS\Uri\Uri;
 use Joomla\CMS\Router\Route;
+use Joomla\CMS\Component\ComponentHelper;
 
 /**
  * Controller tailored to suit most form-based admin operations.
@@ -93,7 +94,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
 		// Guess the option as com_NameOfController
 		if (empty($this->option))
 		{
-			$this->option = \JComponentHelper::getComponentName($this, $this->getName());
+			$this->option = ComponentHelper::getComponentName($this, $this->getName());
 		}
 
 		// Guess the \JText message prefix. Defaults to the option.

--- a/libraries/src/MVC/Controller/FormController.php
+++ b/libraries/src/MVC/Controller/FormController.php
@@ -824,7 +824,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
 				// Check if there is a return value
 				$return = $this->input->get('return', null, 'base64');
 
-				if (!is_null($return) && URI::isInternal(base64_decode($return)))
+				if (!is_null($return) && Uri::isInternal(base64_decode($return)))
 				{
 					$url = base64_decode($return);
 				}

--- a/libraries/src/MVC/Controller/FormController.php
+++ b/libraries/src/MVC/Controller/FormController.php
@@ -20,6 +20,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Session\Session;
 use Joomla\CMS\Uri\Uri;
+use Joomla\CMS\Router\Route;
 
 /**
  * Controller tailored to suit most form-based admin operations.
@@ -161,7 +162,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
 			$this->setMessage(Text::_('JLIB_APPLICATION_ERROR_CREATE_RECORD_NOT_PERMITTED'), 'error');
 
 			$this->setRedirect(
-				\JRoute::_(
+				Route::_(
 					'index.php?option=' . $this->option . '&view=' . $this->view_list
 					. $this->getRedirectToListAppend(), false
 				)
@@ -175,7 +176,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
 
 		// Redirect to the edit screen.
 		$this->setRedirect(
-			\JRoute::_(
+			Route::_(
 				'index.php?option=' . $this->option . '&view=' . $this->view_item
 				. $this->getRedirectToItemAppend(), false
 			)
@@ -316,7 +317,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
 			$this->setMessage(Text::sprintf('JLIB_APPLICATION_ERROR_CHECKIN_FAILED', $model->getError()), 'error');
 
 			$this->setRedirect(
-				\JRoute::_(
+				Route::_(
 					'index.php?option=' . $this->option . '&view=' . $this->view_item
 					. $this->getRedirectToItemAppend($recordId, $key), false
 				)
@@ -330,7 +331,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
 		Factory::getApplication()->setUserState($context . '.data', null);
 
 		$this->setRedirect(
-			\JRoute::_(
+			Route::_(
 				'index.php?option=' . $this->option . '&view=' . $this->view_list
 				. $this->getRedirectToListAppend(), false
 			)
@@ -382,7 +383,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
 			$this->setMessage(Text::_('JLIB_APPLICATION_ERROR_EDIT_NOT_PERMITTED'), 'error');
 
 			$this->setRedirect(
-				\JRoute::_(
+				Route::_(
 					'index.php?option=' . $this->option . '&view=' . $this->view_list
 					. $this->getRedirectToListAppend(), false
 				)
@@ -398,7 +399,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
 			$this->setMessage(Text::sprintf('JLIB_APPLICATION_ERROR_CHECKOUT_FAILED', $model->getError()), 'error');
 
 			$this->setRedirect(
-				\JRoute::_(
+				Route::_(
 					'index.php?option=' . $this->option . '&view=' . $this->view_item
 					. $this->getRedirectToItemAppend($recordId, $urlVar), false
 				)
@@ -413,7 +414,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
 			Factory::getApplication()->setUserState($context . '.data', null);
 
 			$this->setRedirect(
-				\JRoute::_(
+				Route::_(
 					'index.php?option=' . $this->option . '&view=' . $this->view_item
 					. $this->getRedirectToItemAppend($recordId, $urlVar), false
 				)
@@ -547,7 +548,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
 			$this->setMessage($model->getError(), 'error');
 
 			$this->setRedirect(
-				\JRoute::_(
+				Route::_(
 					'index.php?option=' . $this->option . '&view=' . $this->view_list
 					. $this->getRedirectToListAppend(), false
 				)
@@ -573,7 +574,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
 			$this->setMessage(Text::_('JLIB_APPLICATION_ERROR_EDIT_NOT_PERMITTED'), 'error');
 
 			$this->setRedirect(
-				\JRoute::_(
+				Route::_(
 					'index.php?option=' . $this->option . '&view=' . $this->view_list
 					. $this->getRedirectToListAppend(), false
 				)
@@ -585,7 +586,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
 
 		$table->store();
 		$this->setRedirect(
-			\JRoute::_(
+			Route::_(
 				'index.php?option=' . $this->option . '&view=' . $this->view_item
 				. $this->getRedirectToItemAppend($recordId, $urlVar), false
 			)
@@ -653,7 +654,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
 				$this->setMessage(Text::sprintf('JLIB_APPLICATION_ERROR_CHECKIN_FAILED', $model->getError()), 'error');
 
 				$this->setRedirect(
-					\JRoute::_(
+					Route::_(
 						'index.php?option=' . $this->option . '&view=' . $this->view_item
 						. $this->getRedirectToItemAppend($recordId, $urlVar), false
 					)
@@ -674,7 +675,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
 			$this->setMessage(Text::_('JLIB_APPLICATION_ERROR_SAVE_NOT_PERMITTED'), 'error');
 
 			$this->setRedirect(
-				\JRoute::_(
+				Route::_(
 					'index.php?option=' . $this->option . '&view=' . $this->view_list
 					. $this->getRedirectToListAppend(), false
 				)
@@ -721,7 +722,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
 
 			// Redirect back to the edit screen.
 			$this->setRedirect(
-				\JRoute::_(
+				Route::_(
 					'index.php?option=' . $this->option . '&view=' . $this->view_item
 					. $this->getRedirectToItemAppend($recordId, $urlVar), false
 				)
@@ -745,7 +746,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
 			$this->setMessage(Text::sprintf('JLIB_APPLICATION_ERROR_SAVE_FAILED', $model->getError()), 'error');
 
 			$this->setRedirect(
-				\JRoute::_(
+				Route::_(
 					'index.php?option=' . $this->option . '&view=' . $this->view_item
 					. $this->getRedirectToItemAppend($recordId, $urlVar), false
 				)
@@ -764,7 +765,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
 			$this->setMessage(Text::sprintf('JLIB_APPLICATION_ERROR_CHECKIN_FAILED', $model->getError()), 'error');
 
 			$this->setRedirect(
-				\JRoute::_(
+				Route::_(
 					'index.php?option=' . $this->option . '&view=' . $this->view_item
 					. $this->getRedirectToItemAppend($recordId, $urlVar), false
 				)
@@ -790,7 +791,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
 
 				// Redirect back to the edit screen.
 				$this->setRedirect(
-					\JRoute::_(
+					Route::_(
 						'index.php?option=' . $this->option . '&view=' . $this->view_item
 						. $this->getRedirectToItemAppend($recordId, $urlVar), false
 					)
@@ -804,7 +805,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
 
 				// Redirect back to the edit screen.
 				$this->setRedirect(
-					\JRoute::_(
+					Route::_(
 						'index.php?option=' . $this->option . '&view=' . $this->view_item
 						. $this->getRedirectToItemAppend(null, $urlVar), false
 					)
@@ -828,7 +829,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
 				}
 
 				// Redirect to the list screen.
-				$this->setRedirect(\JRoute::_($url, false));
+				$this->setRedirect(Route::_($url, false));
 				break;
 		}
 
@@ -878,7 +879,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
 		if (($recordId && !$this->allowEdit($data, $key)) || (!$recordId && !$this->allowAdd($data)))
 		{
 			$this->setRedirect(
-				\JRoute::_(
+				Route::_(
 					'index.php?option=' . $this->option . '&view=' . $this->view_list
 					. $this->getRedirectToListAppend(), false
 				)
@@ -887,7 +888,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
 		}
 
 		// The redirect url
-		$redirectUrl = \JRoute::_(
+		$redirectUrl = Route::_(
 			'index.php?option=' . $this->option . '&view=' . $this->view_item .
 			$this->getRedirectToItemAppend($recordId, $urlVar),
 			false

--- a/libraries/src/MVC/Controller/FormController.php
+++ b/libraries/src/MVC/Controller/FormController.php
@@ -18,6 +18,7 @@ use Joomla\CMS\Form\FormFactoryAwareTrait;
 use Joomla\CMS\Form\FormFactoryInterface;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Session\Session;
 
 /**
  * Controller tailored to suit most form-based admin operations.
@@ -294,7 +295,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
 	 */
 	public function cancel($key = null)
 	{
-		\JSession::checkToken() or jexit(Text::_('JINVALID_TOKEN'));
+		Session::checkToken() or jexit(Text::_('JINVALID_TOKEN'));
 
 		$model = $this->getModel();
 		$table = $model->getTable();
@@ -614,7 +615,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
 	public function save($key = null, $urlVar = null)
 	{
 		// Check for request forgeries.
-		\JSession::checkToken() or jexit(Text::_('JINVALID_TOKEN'));
+		Session::checkToken() or jexit(Text::_('JINVALID_TOKEN'));
 
 		$app   = Factory::getApplication();
 		$model = $this->getModel();
@@ -849,7 +850,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
 	public function reload($key = null, $urlVar = null)
 	{
 		// Check for request forgeries.
-		\JSession::checkToken() or jexit(Text::_('JINVALID_TOKEN'));
+		Session::checkToken() or jexit(Text::_('JINVALID_TOKEN'));
 
 		$app     = Factory::getApplication();
 		$model   = $this->getModel();

--- a/libraries/src/MVC/Factory/LegacyFactory.php
+++ b/libraries/src/MVC/Factory/LegacyFactory.php
@@ -16,6 +16,7 @@ use Joomla\CMS\MVC\Model\BaseDatabaseModel;
 use Joomla\CMS\Table\Table;
 use Joomla\Input\Input;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Filesystem\Path;
 
 /**
  * Factory to create MVC objects in legacy mode.
@@ -92,7 +93,7 @@ class LegacyFactory implements MVCFactoryInterface
 		if (!class_exists($viewClass))
 		{
 			jimport('joomla.filesystem.path');
-			$path = \JPath::find($config['paths'], BaseController::createFileName('view', array('name' => $viewName, 'type' => $viewType)));
+			$path = Path::find($config['paths'], BaseController::createFileName('view', array('name' => $viewName, 'type' => $viewType)));
 
 			if (!$path)
 			{

--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -21,6 +21,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Log\Log;
 use Joomla\CMS\Language\Associations;
+use Joomla\CMS\Component\ComponentHelper;
 
 /**
  * Prototype admin model.
@@ -968,7 +969,7 @@ abstract class AdminModel extends FormModel
 		$this->setState($this->getName() . '.id', $pk);
 
 		// Load the parameters.
-		$value = \JComponentHelper::getParams($this->option);
+		$value = ComponentHelper::getParams($this->option);
 		$this->setState('params', $value);
 	}
 

--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -18,6 +18,7 @@ use Joomla\Utilities\ArrayHelper;
 use Joomla\CMS\Form\FormFactoryInterface;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Object\CMSObject;
 
 /**
  * Prototype admin model.
@@ -898,7 +899,7 @@ abstract class AdminModel extends FormModel
 	 *
 	 * @param   integer  $pk  The id of the primary key.
 	 *
-	 * @return  \JObject|boolean  Object on success, false on failure.
+	 * @return  CMSObject|boolean  Object on success, false on failure.
 	 *
 	 * @since   1.6
 	 */
@@ -921,9 +922,9 @@ abstract class AdminModel extends FormModel
 			}
 		}
 
-		// Convert to the \JObject before adding other data.
+		// Convert to the CMSObject before adding other data.
 		$properties = $table->getProperties(1);
-		$item = ArrayHelper::toObject($properties, '\JObject');
+		$item = ArrayHelper::toObject($properties, 'CMSObject');
 
 		if (property_exists($item, 'params'))
 		{

--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -19,6 +19,7 @@ use Joomla\CMS\Form\FormFactoryInterface;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Object\CMSObject;
+use Joomla\CMS\Log\Log;
 
 /**
  * Prototype admin model.
@@ -843,13 +844,13 @@ abstract class AdminModel extends FormModel
 
 					if ($error)
 					{
-						\JLog::add($error, \JLog::WARNING, 'jerror');
+						Log::add($error, Log::WARNING, 'jerror');
 
 						return false;
 					}
 					else
 					{
-						\JLog::add(Text::_('JLIB_APPLICATION_ERROR_DELETE_NOT_PERMITTED'), \JLog::WARNING, 'jerror');
+						Log::add(Text::_('JLIB_APPLICATION_ERROR_DELETE_NOT_PERMITTED'), Log::WARNING, 'jerror');
 
 						return false;
 					}
@@ -1015,7 +1016,7 @@ abstract class AdminModel extends FormModel
 					// Prune items that you can't change.
 					unset($pks[$i]);
 
-					\JLog::add(Text::_('JLIB_APPLICATION_ERROR_EDITSTATE_NOT_PERMITTED'), \JLog::WARNING, 'jerror');
+					Log::add(Text::_('JLIB_APPLICATION_ERROR_EDITSTATE_NOT_PERMITTED'), Log::WARNING, 'jerror');
 
 					return false;
 				}
@@ -1023,7 +1024,7 @@ abstract class AdminModel extends FormModel
 				// If the table is checked out by another user, drop it and report to the user trying to change its state.
 				if (property_exists($table, 'checked_out') && $table->checked_out && ($table->checked_out != $user->id))
 				{
-					\JLog::add(Text::_('JLIB_APPLICATION_ERROR_CHECKIN_USER_MISMATCH'), \JLog::WARNING, 'jerror');
+					Log::add(Text::_('JLIB_APPLICATION_ERROR_CHECKIN_USER_MISMATCH'), Log::WARNING, 'jerror');
 
 					// Prune items that you can't change.
 					unset($pks[$i]);
@@ -1092,7 +1093,7 @@ abstract class AdminModel extends FormModel
 					// Prune items that you can't change.
 					unset($pks[$i]);
 					$this->checkin($pk);
-					\JLog::add(Text::_('JLIB_APPLICATION_ERROR_EDITSTATE_NOT_PERMITTED'), \JLog::WARNING, 'jerror');
+					Log::add(Text::_('JLIB_APPLICATION_ERROR_EDITSTATE_NOT_PERMITTED'), Log::WARNING, 'jerror');
 					$allowed = false;
 					continue;
 				}
@@ -1338,7 +1339,7 @@ abstract class AdminModel extends FormModel
 			{
 				// Prune items that you can't change.
 				unset($pks[$i]);
-				\JLog::add(Text::_('JLIB_APPLICATION_ERROR_EDITSTATE_NOT_PERMITTED'), \JLog::WARNING, 'jerror');
+				Log::add(Text::_('JLIB_APPLICATION_ERROR_EDITSTATE_NOT_PERMITTED'), Log::WARNING, 'jerror');
 			}
 			elseif ($this->table->$orderingField != $order[$i])
 			{

--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -20,6 +20,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Log\Log;
+use Joomla\CMS\Language\Associations;
 
 /**
  * Prototype admin model.
@@ -795,7 +796,7 @@ abstract class AdminModel extends FormModel
 					}
 
 					// Multilanguage: if associated, delete the item in the _associations table
-					if ($this->associationsContext && \JLanguageAssociations::isEnabled())
+					if ($this->associationsContext && Associations::isEnabled())
 					{
 						$db = $this->getDbo();
 						$query = $db->getQuery(true)
@@ -1224,7 +1225,7 @@ abstract class AdminModel extends FormModel
 
 		$this->setState($this->getName() . '.new', $isNew);
 
-		if ($this->associationsContext && \JLanguageAssociations::isEnabled() && !empty($data['associations']))
+		if ($this->associationsContext && Associations::isEnabled() && !empty($data['associations']))
 		{
 			$associations = $data['associations'];
 

--- a/libraries/src/MVC/Model/BaseDatabaseModel.php
+++ b/libraries/src/MVC/Model/BaseDatabaseModel.php
@@ -22,6 +22,7 @@ use Joomla\Database\DatabaseDriver;
 use Joomla\Utilities\ArrayHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\Database\DatabaseQuery;
+use Joomla\CMS\Log\Log;
 
 /**
  * Base class for a database aware Joomla Model
@@ -212,7 +213,7 @@ abstract class BaseDatabaseModel extends CMSObject
 
 			if (!class_exists($modelClass))
 			{
-				\JLog::add(Text::sprintf('JLIB_APPLICATION_ERROR_MODELCLASS_NOT_FOUND', $modelClass), \JLog::WARNING, 'jerror');
+				Log::add(Text::sprintf('JLIB_APPLICATION_ERROR_MODELCLASS_NOT_FOUND', $modelClass), Log::WARNING, 'jerror');
 
 				return false;
 			}

--- a/libraries/src/MVC/Model/BaseDatabaseModel.php
+++ b/libraries/src/MVC/Model/BaseDatabaseModel.php
@@ -67,7 +67,7 @@ abstract class BaseDatabaseModel extends CMSObject
 	/**
 	 * A state object
 	 *
-	 * @var    \JObject
+	 * @var    CMSObject
 	 * @since  3.0
 	 */
 	protected $state;
@@ -271,7 +271,7 @@ abstract class BaseDatabaseModel extends CMSObject
 		}
 		else
 		{
-			$this->state = new \JObject;
+			$this->state = new CMSObject;
 		}
 
 		// Set the model dbo

--- a/libraries/src/MVC/Model/BaseDatabaseModel.php
+++ b/libraries/src/MVC/Model/BaseDatabaseModel.php
@@ -23,6 +23,7 @@ use Joomla\Utilities\ArrayHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\Database\DatabaseQuery;
 use Joomla\CMS\Log\Log;
+use Joomla\CMS\Filesystem\Path;
 
 /**
  * Base class for a database aware Joomla Model
@@ -127,12 +128,12 @@ abstract class BaseDatabaseModel extends CMSObject
 			{
 				if (!in_array($includePath, $paths[$prefix]))
 				{
-					array_unshift($paths[$prefix], \JPath::clean($includePath));
+					array_unshift($paths[$prefix], Path::clean($includePath));
 				}
 
 				if (!in_array($includePath, $paths['']))
 				{
-					array_unshift($paths[''], \JPath::clean($includePath));
+					array_unshift($paths[''], Path::clean($includePath));
 				}
 			}
 		}
@@ -197,11 +198,11 @@ abstract class BaseDatabaseModel extends CMSObject
 		if (!class_exists($modelClass))
 		{
 			jimport('joomla.filesystem.path');
-			$path = \JPath::find(self::addIncludePath(null, $prefix), self::_createFileName('model', array('name' => $type)));
+			$path = Path::find(self::addIncludePath(null, $prefix), self::_createFileName('model', array('name' => $type)));
 
 			if (!$path)
 			{
-				$path = \JPath::find(self::addIncludePath(null, ''), self::_createFileName('model', array('name' => $type)));
+				$path = Path::find(self::addIncludePath(null, ''), self::_createFileName('model', array('name' => $type)));
 			}
 
 			if (!$path)

--- a/libraries/src/MVC/View/AbstractView.php
+++ b/libraries/src/MVC/View/AbstractView.php
@@ -13,6 +13,7 @@ defined('JPATH_PLATFORM') or die;
 use Joomla\CMS\Document\Document;
 use Joomla\CMS\MVC\Model\BaseDatabaseModel;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Object\CMSObject;
 
 /**
  * Base class for a Joomla View
@@ -21,7 +22,7 @@ use Joomla\CMS\Language\Text;
  *
  * @since  2.5.5
  */
-abstract class AbstractView extends \JObject
+abstract class AbstractView extends CMSObject
 {
 	/**
 	 * The active document object
@@ -146,7 +147,7 @@ abstract class AbstractView extends \JObject
 			}
 		}
 
-		// Degrade to \JObject::get
+		// Degrade to CMSObject::get
 		return parent::get($property, $default);
 	}
 

--- a/libraries/src/MVC/View/CategoryFeedView.php
+++ b/libraries/src/MVC/View/CategoryFeedView.php
@@ -12,6 +12,7 @@ defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Router\Route;
 
 /**
  * Base feed View class for a category
@@ -54,7 +55,7 @@ class CategoryFeedView extends HtmlView
 			$titleField = $ucmMapCommon[0]->core_title;
 		}
 
-		$document->link = \JRoute::_(\JHelperRoute::getCategoryRoute($app->input->getInt('id'), $language = 0, $extension));
+		$document->link = Route::_(\JHelperRoute::getCategoryRoute($app->input->getInt('id'), $language = 0, $extension));
 
 		$app->input->set('limit', $app->get('feed_limit'));
 		$siteEmail        = $app->get('mailfrom');
@@ -94,7 +95,7 @@ class CategoryFeedView extends HtmlView
 
 			// URL link to article
 			$router = new \JHelperRoute;
-			$link   = \JRoute::_($router->getRoute($item->id, $contentType, null, null, $item->catid));
+			$link   = Route::_($router->getRoute($item->id, $contentType, null, null, $item->catid));
 
 			// Strip HTML from feed item description text.
 			$description = $item->description;

--- a/libraries/src/MVC/View/CategoryView.php
+++ b/libraries/src/MVC/View/CategoryView.php
@@ -12,6 +12,7 @@ defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Router\Route;
 
 /**
  * Base HTML View class for the a Category list
@@ -333,9 +334,9 @@ class CategoryView extends HtmlView
 		{
 			$link    = '&format=feed&limitstart=';
 			$attribs = array('type' => 'application/rss+xml', 'title' => 'RSS 2.0');
-			$this->document->addHeadLink(\JRoute::_($link . '&type=rss'), 'alternate', 'rel', $attribs);
+			$this->document->addHeadLink(Route::_($link . '&type=rss'), 'alternate', 'rel', $attribs);
 			$attribs = array('type' => 'application/atom+xml', 'title' => 'Atom 1.0');
-			$this->document->addHeadLink(\JRoute::_($link . '&type=atom'), 'alternate', 'rel', $attribs);
+			$this->document->addHeadLink(Route::_($link . '&type=atom'), 'alternate', 'rel', $attribs);
 		}
 	}
 }

--- a/libraries/src/MVC/View/FormView.php
+++ b/libraries/src/MVC/View/FormView.php
@@ -14,6 +14,7 @@ defined('JPATH_PLATFORM') or die;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Object\CMSObject;
 
 /**
  * Base class for a Joomla Form View
@@ -48,7 +49,7 @@ class FormView extends HtmlView
 	/**
 	 * The actions the user is authorised to perform
 	 *
-	 * @var  \JObject
+	 * @var  CMSObject
 	 */
 	protected $canDo;
 
@@ -104,7 +105,7 @@ class FormView extends HtmlView
 		}
 
 		// Set default value for $canDo to avoid fatal error if child class doesn't set value for this property
-		$this->canDo = new \JObject;
+		$this->canDo = new CMSObject;
 	}
 
 	/**

--- a/libraries/src/MVC/View/HtmlView.php
+++ b/libraries/src/MVC/View/HtmlView.php
@@ -13,6 +13,7 @@ defined('JPATH_PLATFORM') or die;
 use Joomla\CMS\Application\ApplicationHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Uri\Uri;
 
 /**
  * Base class for a Joomla Html View
@@ -170,7 +171,7 @@ class HtmlView extends AbstractView
 			$this->setLayout('default');
 		}
 
-		$this->baseurl = \JUri::base(true);
+		$this->baseurl = URI::base(true);
 	}
 
 	/**

--- a/libraries/src/MVC/View/HtmlView.php
+++ b/libraries/src/MVC/View/HtmlView.php
@@ -15,6 +15,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Uri\Uri;
 use Joomla\CMS\Log\Log;
+use Joomla\CMS\Filesystem\Path;
 
 /**
  * Base class for a Joomla Html View
@@ -357,13 +358,13 @@ class HtmlView extends AbstractView
 		// Load the template script
 		jimport('joomla.filesystem.path');
 		$filetofind = $this->_createFileName('template', array('name' => $file));
-		$this->_template = \JPath::find($this->_path['template'], $filetofind);
+		$this->_template = Path::find($this->_path['template'], $filetofind);
 
 		// If alternate layout can't be found, fall back to default layout
 		if ($this->_template == false)
 		{
 			$filetofind = $this->_createFileName('', array('name' => 'default' . (isset($tpl) ? '_' . $tpl : $tpl)));
-			$this->_template = \JPath::find($this->_path['template'], $filetofind);
+			$this->_template = Path::find($this->_path['template'], $filetofind);
 		}
 
 		if ($this->_template != false)
@@ -411,7 +412,7 @@ class HtmlView extends AbstractView
 
 		// Load the template script
 		jimport('joomla.filesystem.path');
-		$helper = \JPath::find($this->_path['helper'], $this->_createFileName('helper', array('name' => $file)));
+		$helper = Path::find($this->_path['helper'], $this->_createFileName('helper', array('name' => $file)));
 
 		if ($helper != false)
 		{
@@ -482,7 +483,7 @@ class HtmlView extends AbstractView
 		foreach ((array) $path as $dir)
 		{
 			// Clean up the path
-			$dir = \JPath::clean($dir);
+			$dir = Path::clean($dir);
 
 			// Add trailing separators as needed
 			if (substr($dir, -1) != DIRECTORY_SEPARATOR)

--- a/libraries/src/MVC/View/HtmlView.php
+++ b/libraries/src/MVC/View/HtmlView.php
@@ -173,7 +173,7 @@ class HtmlView extends AbstractView
 			$this->setLayout('default');
 		}
 
-		$this->baseurl = URI::base(true);
+		$this->baseurl = Uri::base(true);
 	}
 
 	/**

--- a/libraries/src/MVC/View/HtmlView.php
+++ b/libraries/src/MVC/View/HtmlView.php
@@ -14,6 +14,7 @@ use Joomla\CMS\Application\ApplicationHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Uri\Uri;
+use Joomla\CMS\Log\Log;
 
 /**
  * Base class for a Joomla Html View
@@ -109,7 +110,7 @@ class HtmlView extends AbstractView
 		// Set the charset (used by the variable escaping functions)
 		if (array_key_exists('charset', $config))
 		{
-			\JLog::add('Setting a custom charset for escaping is deprecated. Override \JViewLegacy::escape() instead.', \JLog::WARNING, 'deprecated');
+			Log::add('Setting a custom charset for escaping is deprecated. Override \JViewLegacy::escape() instead.', Log::WARNING, 'deprecated');
 			$this->_charset = $config['charset'];
 		}
 

--- a/libraries/src/MVC/View/ListView.php
+++ b/libraries/src/MVC/View/ListView.php
@@ -15,6 +15,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Object\CMSObject;
+use Joomla\CMS\Layout\FileLayout;
 
 /**
  * Base class for a Joomla List View
@@ -252,8 +253,8 @@ class ListView extends HtmlView
 		{
 			$title = Text::_('JTOOLBAR_BATCH');
 
-			// Instantiate a new \JLayoutFile instance and render the batch button
-			$layout = new \JLayoutFile('joomla.toolbar.batch');
+			// Instantiate a new LayoutFile instance and render the batch button
+			$layout = new FileLayout('joomla.toolbar.batch');
 
 			$dhtml = $layout->render(array('title' => $title));
 			$bar->appendButton('Custom', $dhtml, 'batch');

--- a/libraries/src/MVC/View/ListView.php
+++ b/libraries/src/MVC/View/ListView.php
@@ -14,6 +14,7 @@ defined('JPATH_PLATFORM') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Object\CMSObject;
 
 /**
  * Base class for a Joomla List View
@@ -41,14 +42,14 @@ class ListView extends HtmlView
 	/**
 	 * The model state
 	 *
-	 * @var  \JObject
+	 * @var  CMSObject
 	 */
 	protected $state;
 
 	/**
 	 * The actions the user is authorised to perform
 	 *
-	 * @var  \JObject
+	 * @var  CMSObject
 	 */
 	protected $canDo;
 
@@ -140,7 +141,7 @@ class ListView extends HtmlView
 		}
 
 		// Set default value for $canDo to avoid fatal error if child class doesn't set value for this property
-		$this->canDo = new \JObject;
+		$this->canDo = new CMSObject;
 	}
 
 	/**

--- a/libraries/src/Menu/MenuHelper.php
+++ b/libraries/src/Menu/MenuHelper.php
@@ -11,6 +11,7 @@ defined('JPATH_PLATFORM') or die;
 
 use Joomla\Registry\Registry;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Filesystem\Folder;
 
 /**
  * Menu Helper utility
@@ -99,7 +100,7 @@ class MenuHelper
 			{
 				jimport('joomla.filesystem.folder');
 
-				$files = \JFolder::files($tpl, '\.xml$');
+				$files = Folder::files($tpl, '\.xml$');
 
 				foreach ($files as $file)
 				{

--- a/libraries/src/Pagination/Pagination.php
+++ b/libraries/src/Pagination/Pagination.php
@@ -14,6 +14,7 @@ use Joomla\CMS\Application\CMSApplication;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Router\Route;
 
 /**
  * Pagination Class. Provides a common interface for content pagination for the Joomla! CMS.
@@ -778,7 +779,7 @@ class Pagination
 		if (!$this->viewall)
 		{
 			$data->all->base = '0';
-			$data->all->link = \JRoute::_($params . '&' . $this->prefix . 'limitstart=');
+			$data->all->link = Route::_($params . '&' . $this->prefix . 'limitstart=');
 		}
 
 		// Set the start and previous data objects.
@@ -793,9 +794,9 @@ class Pagination
 			// @todo remove code: $page = $page == 0 ? '' : $page;
 
 			$data->start->base    = '0';
-			$data->start->link    = \JRoute::_($params . '&' . $this->prefix . 'limitstart=0');
+			$data->start->link    = Route::_($params . '&' . $this->prefix . 'limitstart=0');
 			$data->previous->base = $page;
-			$data->previous->link = \JRoute::_($params . '&' . $this->prefix . 'limitstart=' . $page);
+			$data->previous->link = Route::_($params . '&' . $this->prefix . 'limitstart=' . $page);
 		}
 
 		// Set the next and end data objects.
@@ -808,9 +809,9 @@ class Pagination
 			$end  = ($this->pagesTotal - 1) * $this->limit;
 
 			$data->next->base = $next;
-			$data->next->link = \JRoute::_($params . '&' . $this->prefix . 'limitstart=' . $next);
+			$data->next->link = Route::_($params . '&' . $this->prefix . 'limitstart=' . $next);
 			$data->end->base  = $end;
-			$data->end->link  = \JRoute::_($params . '&' . $this->prefix . 'limitstart=' . $end);
+			$data->end->link  = Route::_($params . '&' . $this->prefix . 'limitstart=' . $end);
 		}
 
 		$data->pages = array();
@@ -825,7 +826,7 @@ class Pagination
 			if ($i != $this->pagesCurrent || $this->viewall)
 			{
 				$data->pages[$i]->base = $offset;
-				$data->pages[$i]->link = \JRoute::_($params . '&' . $this->prefix . 'limitstart=' . $offset);
+				$data->pages[$i]->link = Route::_($params . '&' . $this->prefix . 'limitstart=' . $offset);
 			}
 			else
 			{

--- a/libraries/src/Pagination/Pagination.php
+++ b/libraries/src/Pagination/Pagination.php
@@ -16,6 +16,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Log\Log;
+use Joomla\CMS\Layout\LayoutHelper;
 
 /**
  * Pagination Class. Provides a common interface for content pagination for the Joomla! CMS.
@@ -470,7 +471,7 @@ class Pagination
 			'pagesTotal'   => $this->pagesTotal,
 		);
 
-		return \JLayoutHelper::render($layoutId, array('list' => $list, 'options' => $options));
+		return LayoutHelper::render($layoutId, array('list' => $list, 'options' => $options));
 	}
 
 	/**
@@ -696,7 +697,7 @@ class Pagination
 	 */
 	protected function _list_render($list)
 	{
-		return \JLayoutHelper::render('joomla.pagination.list', array('list' => $list));
+		return LayoutHelper::render('joomla.pagination.list', array('list' => $list));
 	}
 
 	/**
@@ -707,7 +708,7 @@ class Pagination
 	 * @return  string  HTML link
 	 *
 	 * @since   1.5
-	 * @note    As of 4.0 this method will proxy to `\JLayoutHelper::render('joomla.pagination.link', ['data' => $item, 'active' => true])`
+	 * @note    As of 4.0 this method will proxy to `LayoutHelper::render('joomla.pagination.link', ['data' => $item, 'active' => true])`
 	 */
 	protected function _item_active(PaginationObject $item)
 	{
@@ -739,7 +740,7 @@ class Pagination
 	 * @return  string
 	 *
 	 * @since   1.5
-	 * @note    As of 4.0 this method will proxy to `\JLayoutHelper::render('joomla.pagination.link', ['data' => $item, 'active' => false])`
+	 * @note    As of 4.0 this method will proxy to `LayoutHelper::render('joomla.pagination.link', ['data' => $item, 'active' => false])`
 	 */
 	protected function _item_inactive(PaginationObject $item)
 	{

--- a/libraries/src/Pagination/Pagination.php
+++ b/libraries/src/Pagination/Pagination.php
@@ -15,6 +15,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Router\Route;
+use Joomla\CMS\Log\Log;
 
 /**
  * Pagination Class. Provides a common interface for content pagination for the Joomla! CMS.
@@ -340,9 +341,9 @@ class Pagination
 			 */
 			if (function_exists('pagination_item_active') && function_exists('pagination_item_inactive'))
 			{
-				\JLog::add(
+				Log::add(
 					'pagination_item_active and pagination_item_inactive are deprecated. Use the layout joomla.pagination.link instead.',
-					\JLog::WARNING,
+					Log::WARNING,
 					'deprecated'
 				);
 
@@ -355,7 +356,7 @@ class Pagination
 			 */
 			if (function_exists('pagination_list_render'))
 			{
-				\JLog::add('pagination_list_render is deprecated. Use the layout joomla.pagination.list instead.', \JLog::WARNING, 'deprecated');
+				Log::add('pagination_list_render is deprecated. Use the layout joomla.pagination.list instead.', Log::WARNING, 'deprecated');
 				$listOverride = true;
 			}
 		}
@@ -537,7 +538,7 @@ class Pagination
 
 			if (function_exists('pagination_list_footer'))
 			{
-				\JLog::add('pagination_list_footer is deprecated. Use the layout joomla.pagination.links instead.', \JLog::WARNING, 'deprecated');
+				Log::add('pagination_list_footer is deprecated. Use the layout joomla.pagination.links instead.', Log::WARNING, 'deprecated');
 
 				$list = array(
 					'prefix'       => $this->prefix,

--- a/libraries/src/Router/AdministratorRouter.php
+++ b/libraries/src/Router/AdministratorRouter.php
@@ -10,6 +10,8 @@ namespace Joomla\CMS\Router;
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\CMS\Uri\Uri;
+
 /**
  * Class to create and parse routes
  *
@@ -51,7 +53,7 @@ class AdministratorRouter extends Router
 		$route = $uri->getPath();
 
 		// Add basepath to the uri
-		$uri->setPath(URI::base(true) . '/' . $route);
+		$uri->setPath(Uri::base(true) . '/' . $route);
 
 		return $uri;
 	}

--- a/libraries/src/Router/AdministratorRouter.php
+++ b/libraries/src/Router/AdministratorRouter.php
@@ -20,9 +20,9 @@ class AdministratorRouter extends Router
 	/**
 	 * Function to convert a route to an internal URI.
 	 *
-	 * @param   Uri  &$uri     The uri.
-	 * @param   bool   $setVars  Set the parsed data in the internal
-	 *                           storage for current-request-URLs
+	 * @param   Uri   &$uri     The uri.
+	 * @param   bool  $setVars  Set the parsed data in the internal
+	 *                          storage for current-request-URLs
 	 *
 	 * @return  array
 	 *

--- a/libraries/src/Router/AdministratorRouter.php
+++ b/libraries/src/Router/AdministratorRouter.php
@@ -20,7 +20,7 @@ class AdministratorRouter extends Router
 	/**
 	 * Function to convert a route to an internal URI.
 	 *
-	 * @param   \JUri  &$uri     The uri.
+	 * @param   Uri  &$uri     The uri.
 	 * @param   bool   $setVars  Set the parsed data in the internal
 	 *                           storage for current-request-URLs
 	 *
@@ -51,7 +51,7 @@ class AdministratorRouter extends Router
 		$route = $uri->getPath();
 
 		// Add basepath to the uri
-		$uri->setPath(\JUri::base(true) . '/' . $route);
+		$uri->setPath(URI::base(true) . '/' . $route);
 
 		return $uri;
 	}

--- a/libraries/src/Router/Router.php
+++ b/libraries/src/Router/Router.php
@@ -14,7 +14,6 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Exception\RouteNotFoundException;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Uri\Uri;
-use Joomla\CMS\Router\Router;
 
 /**
  * Class to create and parse routes
@@ -103,7 +102,7 @@ class Router
 		if (empty(self::$instances[$client]))
 		{
 			// Create a Router object
-			$classname = 'Router::class' . ucfirst($client);
+			$classname = 'JRouter' . ucfirst($client);
 
 			if (!class_exists($classname))
 			{

--- a/libraries/src/Router/Router.php
+++ b/libraries/src/Router/Router.php
@@ -13,6 +13,7 @@ defined('JPATH_PLATFORM') or die;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Exception\RouteNotFoundException;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Uri\Uri;
 
 /**
  * Class to create and parse routes
@@ -125,9 +126,9 @@ class Router
 	/**
 	 * Function to convert a route to an internal URI
 	 *
-	 * @param   \JUri  &$uri     The uri.
-	 * @param   bool   $setVars  Set the parsed data in the internal
-	 *                           storage for current-request-URLs
+	 * @param   Uri   &$uri     The uri.
+	 * @param   bool  $setVars  Set the parsed data in the internal
+	 *                          storage for current-request-URLs
 	 *
 	 * @return  array
 	 *
@@ -167,7 +168,7 @@ class Router
 	 *
 	 * @param   string  $url  The internal URL or an associative array
 	 *
-	 * @return  \JUri  The absolute search engine friendly URL object
+	 * @return  Uri  The absolute search engine friendly URL object
 	 *
 	 * @since   1.5
 	 */
@@ -424,7 +425,7 @@ class Router
 	 *
 	 * @param   string  $url  The URI or an associative array
 	 *
-	 * @return  \JUri
+	 * @return  Uri
 	 *
 	 * @since   3.2
 	 */
@@ -432,10 +433,10 @@ class Router
 	{
 		if (!is_array($url) && substr($url, 0, 1) !== '&')
 		{
-			return new \JUri($url);
+			return new Uri($url);
 		}
 
-		$uri = new \JUri('index.php');
+		$uri = new Uri('index.php');
 
 		if (is_string($url))
 		{

--- a/libraries/src/Router/Router.php
+++ b/libraries/src/Router/Router.php
@@ -14,6 +14,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Exception\RouteNotFoundException;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Uri\Uri;
+use Joomla\CMS\Router\Router;
 
 /**
  * Class to create and parse routes
@@ -86,7 +87,7 @@ class Router
 	protected static $instances = array();
 
 	/**
-	 * Returns the global JRouter object, only creating it if it
+	 * Returns the global Router object, only creating it if it
 	 * doesn't already exist.
 	 *
 	 * @param   string  $client   The name of the client
@@ -102,7 +103,7 @@ class Router
 		if (empty(self::$instances[$client]))
 		{
 			// Create a Router object
-			$classname = 'JRouter' . ucfirst($client);
+			$classname = 'Router::class' . ucfirst($client);
 
 			if (!class_exists($classname))
 			{

--- a/libraries/src/Router/SiteRouter.php
+++ b/libraries/src/Router/SiteRouter.php
@@ -16,7 +16,7 @@ use Joomla\CMS\Component\Router\RouterInterface;
 use Joomla\CMS\Component\Router\RouterLegacy;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Menu\AbstractMenu;
-use Joomla\Cms\Uri\Uri as JUri;
+use Joomla\CMS\Uri\Uri;
 use Joomla\String\StringHelper;
 
 /**
@@ -100,7 +100,7 @@ class SiteRouter extends Router
 	 * Force to SSL
 	 *
 	 * @param   Router  &$router  Router object
-	 * @param   JUri    &$uri     URI object to process
+	 * @param   Uri     &$uri     URI object to process
 	 *
 	 * @return  void
 	 *
@@ -120,7 +120,7 @@ class SiteRouter extends Router
 	 * Do some initial cleanup before parsing the URL
 	 *
 	 * @param   SiteRouter  &$router  Router object
-	 * @param   JUri        &$uri     URI object to process
+	 * @param   Uri         &$uri     URI object to process
 	 *
 	 * @return  void
 	 *
@@ -139,7 +139,7 @@ class SiteRouter extends Router
 		 */
 		try
 		{
-			$baseUri = \JUri::base(true);
+			$baseUri = URI::base(true);
 		}
 		catch (\RuntimeException $e)
 		{
@@ -173,7 +173,7 @@ class SiteRouter extends Router
 	 * Parse the format of the request
 	 *
 	 * @param   SiteRouter  &$router  Router object
-	 * @param   JUri        &$uri     URI object to process
+	 * @param   Uri         &$uri     URI object to process
 	 *
 	 * @return  void
 	 *
@@ -196,7 +196,7 @@ class SiteRouter extends Router
 	 * Convert a sef route to an internal URI
 	 *
 	 * @param   SiteRouter  &$router  Router object
-	 * @param   JUri        &$uri     URI object to process
+	 * @param   Uri         &$uri     URI object to process
 	 *
 	 * @return  void
 	 *
@@ -331,7 +331,7 @@ class SiteRouter extends Router
 	 * Convert a raw route to an internal URI
 	 *
 	 * @param   SiteRouter  &$router  Router object
-	 * @param   JUri        &$uri     URI object to process
+	 * @param   Uri         &$uri     URI object to process
 	 *
 	 * @return  void
 	 *
@@ -373,7 +373,7 @@ class SiteRouter extends Router
 	 * Convert limits for pagination
 	 *
 	 * @param   SiteRouter  &$router  Router object
-	 * @param   JUri        &$uri     URI object to process
+	 * @param   Uri         &$uri     URI object to process
 	 *
 	 * @return  void
 	 *
@@ -393,7 +393,7 @@ class SiteRouter extends Router
 	 * Do some initial processing for building a URL
 	 *
 	 * @param   SiteRouter  &$router  Router object
-	 * @param   JUri        &$uri     URI object to process
+	 * @param   Uri         &$uri     URI object to process
 	 *
 	 * @return  void
 	 *
@@ -423,7 +423,7 @@ class SiteRouter extends Router
 	 * Run the component preprocess method
 	 *
 	 * @param   SiteRouter  &$router  Router object
-	 * @param   JUri        &$uri     URI object to process
+	 * @param   Uri         &$uri     URI object to process
 	 *
 	 * @return  void
 	 *
@@ -459,7 +459,7 @@ class SiteRouter extends Router
 	 * Build the SEF route
 	 *
 	 * @param   SiteRouter  &$router  Router object
-	 * @param   JUri        &$uri     URI object to process
+	 * @param   Uri         &$uri     URI object to process
 	 *
 	 * @return  void
 	 *
@@ -514,7 +514,7 @@ class SiteRouter extends Router
 	 * Convert limits for pagination
 	 *
 	 * @param   SiteRouter  &$router  Router object
-	 * @param   JUri        &$uri     URI object to process
+	 * @param   Uri         &$uri     URI object to process
 	 *
 	 * @return  void
 	 *
@@ -533,7 +533,7 @@ class SiteRouter extends Router
 	 * Build the format of the request
 	 *
 	 * @param   SiteRouter  &$router  Router object
-	 * @param   JUri        &$uri     URI object to process
+	 * @param   Uri         &$uri     URI object to process
 	 *
 	 * @return  void
 	 *
@@ -556,7 +556,7 @@ class SiteRouter extends Router
 	 * Create a uri based on a full or partial URL string
 	 *
 	 * @param   SiteRouter  &$router  Router object
-	 * @param   JUri        &$uri     URI object to process
+	 * @param   Uri         &$uri     URI object to process
 	 *
 	 * @return  void
 	 *
@@ -584,7 +584,7 @@ class SiteRouter extends Router
 	 * Add the basepath to the URI
 	 *
 	 * @param   SiteRouter  &$router  Router object
-	 * @param   JUri        &$uri     URI object to process
+	 * @param   Uri         &$uri     URI object to process
 	 *
 	 * @return  void
 	 *
@@ -593,7 +593,7 @@ class SiteRouter extends Router
 	public function buildBase(&$router, &$uri)
 	{
 		// Add basepath to the uri
-		$uri->setPath(JUri::base(true) . '/' . $uri->getPath());
+		$uri->setPath(URI::base(true) . '/' . $uri->getPath());
 	}
 
 	/**

--- a/libraries/src/Router/SiteRouter.php
+++ b/libraries/src/Router/SiteRouter.php
@@ -139,7 +139,7 @@ class SiteRouter extends Router
 		 */
 		try
 		{
-			$baseUri = URI::base(true);
+			$baseUri = Uri::base(true);
 		}
 		catch (\RuntimeException $e)
 		{
@@ -593,7 +593,7 @@ class SiteRouter extends Router
 	public function buildBase(&$router, &$uri)
 	{
 		// Add basepath to the uri
-		$uri->setPath(URI::base(true) . '/' . $uri->getPath());
+		$uri->setPath(Uri::base(true) . '/' . $uri->getPath());
 	}
 
 	/**

--- a/libraries/src/Schema/ChangeSet.php
+++ b/libraries/src/Schema/ChangeSet.php
@@ -13,8 +13,7 @@ defined('JPATH_PLATFORM') or die;
 use Joomla\Database\UTF8MB4SupportInterface;
 use Joomla\CMS\Factory;
 use Joomla\Database\DatabaseDriver;
-
-jimport('joomla.filesystem.folder');
+use Joomla\CMS\Filesystem\Folder;
 
 /**
  * Contains a set of JSchemaChange objects for a particular instance of Joomla.
@@ -273,7 +272,7 @@ class ChangeSet
 			$this->folder = JPATH_ADMINISTRATOR . '/components/com_admin/sql/updates/';
 		}
 
-		return \JFolder::files(
+		return Folder::files(
 			$this->folder . '/' . $sqlFolder, '\.sql$', 1, true, array('.svn', 'CVS', '.DS_Store', '__MACOSX'), array('^\..*', '.*~'), true
 		);
 	}

--- a/libraries/src/Session/Session.php
+++ b/libraries/src/Session/Session.php
@@ -15,6 +15,7 @@ use Joomla\Session\Session as BaseSession;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
+use Joomla\CMS\Log\Log;
 
 /**
  * Class for managing HTTP sessions
@@ -89,9 +90,9 @@ class Session extends BaseSession
 	 */
 	public static function getInstance()
 	{
-		\JLog::add(
+		Log::add(
 			__METHOD__ . '() is deprecated. Load the session from the dependency injection container or via Factory::getApplication()->getSession().',
-			\JLog::WARNING,
+			Log::WARNING,
 			'deprecated'
 		);
 
@@ -117,9 +118,9 @@ class Session extends BaseSession
 
 			if (!empty($args[2]))
 			{
-				\JLog::add(
+				Log::add(
 					'Passing a namespace as a parameter to ' . __METHOD__ . '() is deprecated. The namespace should be prepended to the name instead.',
-					\JLog::WARNING,
+					Log::WARNING,
 					'deprecated'
 				);
 
@@ -149,9 +150,9 @@ class Session extends BaseSession
 
 			if (!empty($args[2]))
 			{
-				\JLog::add(
+				Log::add(
 					'Passing a namespace as a parameter to ' . __METHOD__ . '() is deprecated. The namespace should be prepended to the name instead.',
-					\JLog::WARNING,
+					Log::WARNING,
 					'deprecated'
 				);
 
@@ -180,9 +181,9 @@ class Session extends BaseSession
 
 			if (!empty($args[1]))
 			{
-				\JLog::add(
+				Log::add(
 					'Passing a namespace as a parameter to ' . __METHOD__ . '() is deprecated. The namespace should be prepended to the name instead.',
-					\JLog::WARNING,
+					Log::WARNING,
 					'deprecated'
 				);
 
@@ -209,9 +210,9 @@ class Session extends BaseSession
 
 			if (!empty($args[0]))
 			{
-				\JLog::add(
+				Log::add(
 					'Using ' . __METHOD__ . '() to remove a single element from the session is deprecated.  Use ' . __CLASS__ . '::remove() instead.',
-					\JLog::WARNING,
+					Log::WARNING,
 					'deprecated'
 				);
 
@@ -220,9 +221,9 @@ class Session extends BaseSession
 				// Also check for a namespace
 				if (func_num_args() > 1 && !empty($args[1]))
 				{
-					\JLog::add(
+					Log::add(
 						'Passing a namespace as a parameter to ' . __METHOD__ . '() is deprecated. The namespace should be prepended to the name instead.',
-						\JLog::WARNING,
+						Log::WARNING,
 						'deprecated'
 					);
 

--- a/libraries/src/Session/Session.php
+++ b/libraries/src/Session/Session.php
@@ -14,6 +14,7 @@ use Joomla\CMS\Application\ApplicationHelper;
 use Joomla\Session\Session as BaseSession;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Router\Route;
 
 /**
  * Class for managing HTTP sessions
@@ -51,7 +52,7 @@ class Session extends BaseSession
 			{
 				// Redirect to login screen.
 				$app->enqueueMessage(Text::_('JLIB_ENVIRONMENT_SESSION_EXPIRED'), 'warning');
-				$app->redirect(\JRoute::_('index.php'));
+				$app->redirect(Route::_('index.php'));
 
 				return true;
 			}

--- a/libraries/src/Table/Menu.php
+++ b/libraries/src/Table/Menu.php
@@ -16,6 +16,7 @@ use Joomla\Registry\Registry;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\Database\DatabaseDriver;
+use Joomla\CMS\Filesystem\Folder;
 
 /**
  * Menu table
@@ -180,7 +181,7 @@ class Menu extends Nested
 			// Verify that a first level menu item alias is not the name of a folder.
 			jimport('joomla.filesystem.folder');
 
-			if (in_array($this->alias, \JFolder::folders(JPATH_ROOT)))
+			if (in_array($this->alias, Folder::folders(JPATH_ROOT)))
 			{
 				$this->setError(Text::sprintf('JLIB_DATABASE_ERROR_MENU_ROOT_ALIAS_FOLDER', $this->alias, $this->alias));
 

--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -10,8 +10,6 @@ namespace Joomla\CMS\Table;
 
 defined('JPATH_PLATFORM') or die;
 
-\JLoader::import('joomla.filesystem.path');
-
 use Joomla\CMS\Event\AbstractEvent;
 use Joomla\Database\DatabaseDriver;
 use Joomla\Database\DatabaseQuery;
@@ -22,6 +20,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Access\Rules;
 use Joomla\CMS\Object\CMSObject;
+use Joomla\CMS\Filesystem\Path;
 
 /**
  * Abstract Table class
@@ -283,7 +282,7 @@ abstract class Table extends CMSObject implements \JTableInterface, DispatcherAw
 
 			while (!class_exists($tableClass) && $pathIndex < count($paths))
 			{
-				if ($tryThis = \JPath::find($paths[$pathIndex++], strtolower($type) . '.php'))
+				if ($tryThis = Path::find($paths[$pathIndex++], strtolower($type) . '.php'))
 				{
 					// Import the class file.
 					include_once $tryThis;

--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -21,6 +21,7 @@ use Joomla\Event\DispatcherInterface;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Access\Rules;
+use Joomla\CMS\Object\CMSObject;
 
 /**
  * Abstract Table class
@@ -30,7 +31,7 @@ use Joomla\CMS\Access\Rules;
  * @since  11.1
  * @tutorial  Joomla.Platform/jtable.cls
  */
-abstract class Table extends \JObject implements \JTableInterface, DispatcherAwareInterface
+abstract class Table extends CMSObject implements \JTableInterface, DispatcherAwareInterface
 {
 	use DispatcherAwareTrait;
 

--- a/libraries/src/Toolbar/Button/SliderButton.php
+++ b/libraries/src/Toolbar/Button/SliderButton.php
@@ -14,6 +14,7 @@ use Joomla\CMS\Layout\FileLayout;
 use Joomla\CMS\Toolbar\ToolbarButton;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Uri\Uri;
 
 /**
  * Renders a button to render an HTML element in a slider container
@@ -103,7 +104,7 @@ class SliderButton extends ToolbarButton
 	{
 		if (strpos($url, 'http') !== 0)
 		{
-			$url = \JUri::base() . $url;
+			$url = URI::base() . $url;
 		}
 
 		return $url;

--- a/libraries/src/Toolbar/Button/SliderButton.php
+++ b/libraries/src/Toolbar/Button/SliderButton.php
@@ -49,7 +49,7 @@ class SliderButton extends ToolbarButton
 	{
 		HTMLHelper::_('script', 'system/cms.min.js', array('version' => 'auto', 'relative' => true));
 
-		// Store all data to the options array for use with JLayout
+		// Store all data to the options array for use with Layout
 		$options = array();
 		$options['text']    = Text::_($text);
 		$options['name']    = $name;
@@ -70,7 +70,7 @@ class SliderButton extends ToolbarButton
 			$options['onClose'] = ' rel="{onClose: function() {' . $onClose . '}}"';
 		}
 
-		// Instantiate a new JLayoutFile instance and render the layout
+		// Instantiate a new LayoutFile instance and render the layout
 		$layout = new FileLayout('joomla.toolbar.slider');
 
 		return $layout->render($options);

--- a/libraries/src/Toolbar/Button/SliderButton.php
+++ b/libraries/src/Toolbar/Button/SliderButton.php
@@ -104,7 +104,7 @@ class SliderButton extends ToolbarButton
 	{
 		if (strpos($url, 'http') !== 0)
 		{
-			$url = URI::base() . $url;
+			$url = Uri::base() . $url;
 		}
 
 		return $url;

--- a/libraries/src/Toolbar/ContainerAwareToolbarFactory.php
+++ b/libraries/src/Toolbar/ContainerAwareToolbarFactory.php
@@ -14,6 +14,7 @@ use Joomla\DI\ContainerAwareInterface;
 use Joomla\DI\ContainerAwareTrait;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Filter\InputFilter;
+use Joomla\CMS\Log\Log;
 
 /**
  * Default factory for creating toolbar objects
@@ -54,7 +55,7 @@ class ContainerAwareToolbarFactory implements ToolbarFactoryInterface, Container
 			}
 			else
 			{
-				\JLog::add(Text::sprintf('JLIB_HTML_BUTTON_NO_LOAD', $buttonClass, $buttonFile), \JLog::WARNING, 'jerror');
+				Log::add(Text::sprintf('JLIB_HTML_BUTTON_NO_LOAD', $buttonClass, $buttonFile), Log::WARNING, 'jerror');
 
 				throw new \InvalidArgumentException(Text::sprintf('JLIB_HTML_BUTTON_NO_LOAD', $buttonClass, $buttonFile));
 			}

--- a/libraries/src/Toolbar/ContainerAwareToolbarFactory.php
+++ b/libraries/src/Toolbar/ContainerAwareToolbarFactory.php
@@ -15,6 +15,7 @@ use Joomla\DI\ContainerAwareTrait;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\Log\Log;
+use Joomla\CMS\Filesystem\Path;
 
 /**
  * Default factory for creating toolbar objects
@@ -49,7 +50,7 @@ class ContainerAwareToolbarFactory implements ToolbarFactoryInterface, Container
 
 			jimport('joomla.filesystem.path');
 
-			if ($buttonFile = \JPath::find($dirs, $file))
+			if ($buttonFile = Path::find($dirs, $file))
 			{
 				include_once $buttonFile;
 			}

--- a/libraries/src/Toolbar/CoreButtonsTrait.php
+++ b/libraries/src/Toolbar/CoreButtonsTrait.php
@@ -488,7 +488,7 @@ trait CoreButtonsTrait
 		$contentTypeTable = Table::getInstance('Contenttype');
 		$typeId           = $contentTypeTable->getTypeId($typeAlias);
 
-		// Options array for JLayout
+		// Options array for Layout
 		$options              = array();
 		$options['title']     = Text::_($text);
 		$options['height']    = $height;

--- a/libraries/src/Toolbar/ToolbarButton.php
+++ b/libraries/src/Toolbar/ToolbarButton.php
@@ -186,7 +186,7 @@ abstract class ToolbarButton
 		$options['htmlAttributes'] = ArrayHelper::toString($options['attributes']);
 		$options['btnClass'] = 'button-' . $this->getName() . ' ' . ($options['btnClass'] ?? '');
 
-		// Instantiate a new JLayoutFile instance and render the layout
+		// Instantiate a new LayoutFile instance and render the layout
 		$layout = new FileLayout($this->layout);
 
 		return $layout->render($options);

--- a/libraries/src/Toolbar/ToolbarHelper.php
+++ b/libraries/src/Toolbar/ToolbarHelper.php
@@ -598,7 +598,7 @@ abstract class ToolbarHelper
 		$path = urlencode($path);
 		$bar = Toolbar::getInstance('toolbar');
 
-		$uri = (string) URI::getInstance();
+		$uri = (string) Uri::getInstance();
 		$return = urlencode(base64_encode($uri));
 
 		// Add a button linking to config for component.

--- a/libraries/src/Toolbar/ToolbarHelper.php
+++ b/libraries/src/Toolbar/ToolbarHelper.php
@@ -632,7 +632,7 @@ abstract class ToolbarHelper
 		$contentTypeTable = Table::getInstance('Contenttype');
 		$typeId           = $contentTypeTable->getTypeId($typeAlias);
 
-		// Options array for JLayout
+		// Options array for Layout
 		$options              = array();
 		$options['title']     = Text::_($alt);
 		$options['height']    = $height;

--- a/libraries/src/Toolbar/ToolbarHelper.php
+++ b/libraries/src/Toolbar/ToolbarHelper.php
@@ -11,9 +11,10 @@ namespace Joomla\CMS\Toolbar;
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Layout\FileLayout;
-use Joomla\Cms\Table\Table;
+use Joomla\CMS\Table\Table;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Uri\Uri;
 
 /**
  * Utility class for the button bar.
@@ -597,7 +598,7 @@ abstract class ToolbarHelper
 		$path = urlencode($path);
 		$bar = Toolbar::getInstance('toolbar');
 
-		$uri = (string) \JUri::getInstance();
+		$uri = (string) URI::getInstance();
 		$return = urlencode(base64_encode($uri));
 
 		// Add a button linking to config for component.

--- a/libraries/src/Updater/Update.php
+++ b/libraries/src/Updater/Update.php
@@ -17,6 +17,7 @@ use Joomla\CMS\Log\Log;
 use Joomla\CMS\Version;
 use Joomla\Registry\Registry;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Object\CMSObject;
 
 /**
  * Update class. It is used by Updater::update() to install an update. Use Updater::findUpdates() to find updates for
@@ -24,7 +25,7 @@ use Joomla\CMS\Language\Text;
  *
  * @since  11.1
  */
-class Update extends \JObject
+class Update extends CMSObject
 {
 	/**
 	 * Update manifest `<name>` element

--- a/libraries/src/Updater/Updater.php
+++ b/libraries/src/Updater/Updater.php
@@ -15,7 +15,6 @@ use Joomla\CMS\Table\Table;
 
 \JLoader::import('joomla.filesystem.file');
 \JLoader::import('joomla.filesystem.folder');
-\JLoader::import('joomla.filesystem.path');
 \JLoader::import('joomla.base.adapter');
 
 /**

--- a/libraries/src/Uri/Uri.php
+++ b/libraries/src/Uri/Uri.php
@@ -13,7 +13,7 @@ defined('JPATH_PLATFORM') or die;
 use Joomla\CMS\Factory;
 
 /**
- * JUri Class
+ * Uri Class
  *
  * This class serves two purposes. First it parses a URI and provides a common interface
  * for the Joomla Platform to access and manipulate a URI.  Second it obtains the URI of
@@ -24,7 +24,7 @@ use Joomla\CMS\Factory;
 class Uri extends \Joomla\Uri\Uri
 {
 	/**
-	 * @var    Uri[]  An array of JUri instances.
+	 * @var    Uri[]  An array of Uri instances.
 	 * @since  11.1
 	 */
 	protected static $instances = array();
@@ -48,7 +48,7 @@ class Uri extends \Joomla\Uri\Uri
 	protected static $current;
 
 	/**
-	 * Returns the global JUri object, only creating it if it doesn't already exist.
+	 * Returns the global Uri object, only creating it if it doesn't already exist.
 	 *
 	 * @param   string  $uri  The URI to parse.  [optional: if null uses script URI]
 	 *
@@ -262,7 +262,7 @@ class Uri extends \Joomla\Uri\Uri
 		$base = $uri->toString(array('scheme', 'host', 'port', 'path'));
 		$host = $uri->toString(array('scheme', 'host', 'port'));
 
-		// @see JUriTest
+		// @see UriTest
 		if (empty($host) && strpos($uri->path, 'index.php') === 0
 			|| !empty($host) && preg_match('#' . preg_quote(static::base(), '#') . '#', $base)
 			|| !empty($host) && $host === static::getInstance(static::base())->host && strpos($uri->path, 'index.php') !== false

--- a/libraries/src/User/User.php
+++ b/libraries/src/User/User.php
@@ -17,13 +17,14 @@ use Joomla\Registry\Registry;
 use Joomla\Utilities\ArrayHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Object\CMSObject;
 
 /**
  * User class.  Handles all application interaction with a user
  *
  * @since  11.1
  */
-class User extends \JObject
+class User extends CMSObject
 {
 	/**
 	 * A cached switch for if this user has root access rights.

--- a/libraries/src/User/User.php
+++ b/libraries/src/User/User.php
@@ -18,6 +18,7 @@ use Joomla\Utilities\ArrayHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Object\CMSObject;
+use Joomla\CMS\Log\Log;
 
 /**
  * User class.  Handles all application interaction with a user
@@ -866,7 +867,7 @@ class User extends CMSObject
 			// Reset to guest user
 			$this->guest = 1;
 
-			\JLog::add(Text::sprintf('JLIB_USER_ERROR_UNABLE_TO_LOAD_USER', $id), \JLog::WARNING, 'jerror');
+			Log::add(Text::sprintf('JLIB_USER_ERROR_UNABLE_TO_LOAD_USER', $id), Log::WARNING, 'jerror');
 
 			return false;
 		}

--- a/libraries/src/User/UserHelper.php
+++ b/libraries/src/User/UserHelper.php
@@ -23,6 +23,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\Utilities\ArrayHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Uri\Uri;
 
 /**
  * Authorisation helper class, provides static methods to perform various tasks relevant
@@ -530,7 +531,7 @@ abstract class UserHelper
 		$browserVersion = $ua->browserVersion;
 		$uaShort = str_replace($browserVersion, 'abcd', $uaString);
 
-		return md5(\JUri::base() . $uaShort);
+		return md5(URI::base() . $uaShort);
 	}
 
 	/**

--- a/libraries/src/User/UserHelper.php
+++ b/libraries/src/User/UserHelper.php
@@ -25,6 +25,7 @@ use Joomla\Utilities\ArrayHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Uri\Uri;
 use Joomla\CMS\Object\CMSObject;
+use Joomla\CMS\Log\Log;
 
 /**
  * Authorisation helper class, provides static methods to perform various tasks relevant
@@ -329,14 +330,14 @@ abstract class UserHelper
 			// Time to take care of business.... store the user.
 			if (!$user->save())
 			{
-				\JLog::add($user->getError(), \JLog::WARNING, 'jerror');
+				Log::add($user->getError(), Log::WARNING, 'jerror');
 
 				return false;
 			}
 		}
 		else
 		{
-			\JLog::add(Text::_('JLIB_USER_ERROR_UNABLE_TO_FIND_USER'), \JLog::WARNING, 'jerror');
+			Log::add(Text::_('JLIB_USER_ERROR_UNABLE_TO_FIND_USER'), Log::WARNING, 'jerror');
 
 			return false;
 		}

--- a/libraries/src/User/UserHelper.php
+++ b/libraries/src/User/UserHelper.php
@@ -24,6 +24,7 @@ use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\Utilities\ArrayHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Uri\Uri;
+use Joomla\CMS\Object\CMSObject;
 
 /**
  * Authorisation helper class, provides static methods to perform various tasks relevant
@@ -285,7 +286,7 @@ abstract class UserHelper
 		// Get the dispatcher and load the user's plugins.
 		PluginHelper::importPlugin('user');
 
-		$data = new \JObject;
+		$data = new CMSObject;
 		$data->id = $userId;
 
 		// Trigger the data preparation event.

--- a/libraries/src/User/UserHelper.php
+++ b/libraries/src/User/UserHelper.php
@@ -533,7 +533,7 @@ abstract class UserHelper
 		$browserVersion = $ua->browserVersion;
 		$uaShort = str_replace($browserVersion, 'abcd', $uaString);
 
-		return md5(URI::base() . $uaShort);
+		return md5(Uri::base() . $uaShort);
 	}
 
 	/**


### PR DESCRIPTION
All current views with pagination in the administration have mistakenly had the pagination placed in the table footer. This is not correct as the table footer is only for use with summarising the data in the table.

This pr moves the pagination to immediately after the rendering of the table.

As a result we can also remove the column counts as we dont have a need for them (and they weren't used consistently anyway)

Confirmed by the a11y team https://github.com/joomla/accessibility/issues/46

A future pr will look at restoring the a11y of the pagination itself which has been lost in the movee from j3