### PR TITLE
[4.0] Pagination [a11y] admin

### DIFF
--- a/administrator/components/com_associations/tmpl/associations/default.php
+++ b/administrator/components/com_associations/tmpl/associations/default.php
@@ -140,7 +140,7 @@ HTMLHelper::_('script', 'com_associations/admin-associations-default.min.js', fa
 					<?php endforeach; ?>
 					</tbody>
 					</table>
-					
+
 					<?php // load the pagination. ?>
 					<?php echo $this->pagination->getListFooter(); ?>
 

--- a/administrator/components/com_associations/tmpl/associations/default.php
+++ b/administrator/components/com_associations/tmpl/associations/default.php
@@ -22,7 +22,6 @@ HTMLHelper::_('behavior.multiselect');
 $listOrder        = $this->escape($this->state->get('list.ordering'));
 $listDirn         = $this->escape($this->state->get('list.direction'));
 $canManageCheckin = Factory::getUser()->authorise('core.manage', 'com_checkin');
-$colSpan          = 5;
 
 $iconStates = array(
 	-2 => 'icon-trash',
@@ -47,7 +46,7 @@ HTMLHelper::_('script', 'com_associations/admin-associations-default.min.js', fa
 						<tr>
 							<?php if (!empty($this->typeSupports['state'])) : ?>
 								<th scope="col" style="width:1%" class="text-center nowrap">
-									<?php echo HTMLHelper::_('searchtools.sort', 'JSTATUS', 'state', $listDirn, $listOrder); $colSpan++; ?>
+									<?php echo HTMLHelper::_('searchtools.sort', 'JSTATUS', 'state', $listDirn, $listOrder); ?>
 								</th>
 							<?php endif; ?>
 							<th scope="col" class="nowrap">
@@ -64,12 +63,12 @@ HTMLHelper::_('script', 'com_associations/admin-associations-default.min.js', fa
 							</th>
 							<?php if (!empty($this->typeFields['menutype'])) : ?>
 								<th scope="col" style="width:10%" class="nowrap">
-									<?php echo HTMLHelper::_('searchtools.sort', 'COM_ASSOCIATIONS_HEADING_MENUTYPE', 'menutype_title', $listDirn, $listOrder); $colSpan++; ?>
+									<?php echo HTMLHelper::_('searchtools.sort', 'COM_ASSOCIATIONS_HEADING_MENUTYPE', 'menutype_title', $listDirn, $listOrder); ?>
 								</th>
 							<?php endif; ?>
 							<?php if (!empty($this->typeFields['access'])) : ?>
 								<th scope="col" style="width:5%" class="nowrap d-none d-md-table-cell">
-									<?php echo HTMLHelper::_('searchtools.sort', 'JGRID_HEADING_ACCESS', 'access_level', $listDirn, $listOrder); $colSpan++; ?>
+									<?php echo HTMLHelper::_('searchtools.sort', 'JGRID_HEADING_ACCESS', 'access_level', $listDirn, $listOrder); ?>
 								</th>
 							<?php endif; ?>
 							<th scope="col" style="width:1%" class="nowrap d-none d-md-table-cell text-center">
@@ -77,13 +76,6 @@ HTMLHelper::_('script', 'com_associations/admin-associations-default.min.js', fa
 							</th>
 						</tr>
 					</thead>
-					<tfoot>
-						<tr>
-							<td colspan="<?php echo $colSpan; ?>">
-								<?php echo $this->pagination->getListFooter(); ?>
-							</td>
-						</tr>
-					</tfoot>
 					<tbody>
 					<?php foreach ($this->items as $i => $item) :
 						$canCheckin = true;
@@ -148,6 +140,10 @@ HTMLHelper::_('script', 'com_associations/admin-associations-default.min.js', fa
 					<?php endforeach; ?>
 					</tbody>
 					</table>
+					
+					<?php // load the pagination. ?>
+					<?php echo $this->pagination->getListFooter(); ?>
+
 				<?php endif; ?>
 				<input type="hidden" name="task" value="">
 				<?php echo HTMLHelper::_('form.token'); ?>

--- a/administrator/components/com_associations/tmpl/associations/modal.php
+++ b/administrator/components/com_associations/tmpl/associations/modal.php
@@ -61,7 +61,7 @@ HTMLHelper::_('script', 'com_associations/admin-associations-modal.min.js', fals
 				<tr>
 					<?php if (!empty($this->typeSupports['state'])) : ?>
 						<th scope="col" style="width:1%" class="center nowrap">
-							<?php echo HTMLHelper::_('searchtools.sort', 'JSTATUS', 'state', $listDirn, $listOrder); $colSpan++; ?>
+							<?php echo HTMLHelper::_('searchtools.sort', 'JSTATUS', 'state', $listDirn, $listOrder); ?>
 						</th>
 					<?php endif; ?>
 					<th scope="col" class="nowrap">
@@ -75,12 +75,12 @@ HTMLHelper::_('script', 'com_associations/admin-associations-modal.min.js', fals
 					</th>
 					<?php if (!empty($this->typeFields['menutype'])) : ?>
 						<th scope="col" style="width:10%" class="nowrap">
-							<?php echo HTMLHelper::_('searchtools.sort', 'COM_ASSOCIATIONS_HEADING_MENUTYPE', 'menutype_title', $listDirn, $listOrder); $colSpan++; ?>
+							<?php echo HTMLHelper::_('searchtools.sort', 'COM_ASSOCIATIONS_HEADING_MENUTYPE', 'menutype_title', $listDirn, $listOrder); ?>
 						</th>
 					<?php endif; ?>
 					<?php if (!empty($this->typeSupports['acl'])) : ?>
 						<th scope="col" style="width:5%" class="nowrap d-none d-sm-table-cell">
-							<?php echo HTMLHelper::_('searchtools.sort', 'JGRID_HEADING_ACCESS', 'access_level', $listDirn, $listOrder); $colSpan++; ?>
+							<?php echo HTMLHelper::_('searchtools.sort', 'JGRID_HEADING_ACCESS', 'access_level', $listDirn, $listOrder); ?>
 						</th>
 					<?php endif; ?>
 					<th scope="col" style="width:1%" class="nowrap d-none d-sm-table-cell">

--- a/administrator/components/com_associations/tmpl/associations/modal.php
+++ b/administrator/components/com_associations/tmpl/associations/modal.php
@@ -30,7 +30,6 @@ $function         = $app->input->getCmd('function', 'jSelectAssociation');
 $listOrder        = $this->escape($this->state->get('list.ordering'));
 $listDirn         = $this->escape($this->state->get('list.direction'));
 $canManageCheckin = Factory::getUser()->authorise('core.manage', 'com_checkin');
-$colSpan          = 4;
 
 $iconStates = array(
 	-2 => 'icon-trash',

--- a/administrator/components/com_associations/tmpl/associations/modal.php
+++ b/administrator/components/com_associations/tmpl/associations/modal.php
@@ -89,13 +89,6 @@ HTMLHelper::_('script', 'com_associations/admin-associations-modal.min.js', fals
 					</th>
 				</tr>
 			</thead>
-			<tfoot>
-				<tr>
-					<td colspan="<?php echo $colSpan; ?>">
-						<?php echo $this->pagination->getListFooter(); ?>
-					</td>
-				</tr>
-			</tfoot>
 			<tbody>
 			<?php foreach ($this->items as $i => $item) :
 				$canEdit    = AssociationsHelper::allowEdit($this->extensionName, $this->typeName, $item->id);
@@ -159,6 +152,9 @@ HTMLHelper::_('script', 'com_associations/admin-associations-modal.min.js', fals
 				<?php endforeach; ?>
 			</tbody>
 		</table>
+
+		<?php // load the pagination. ?>
+		<?php echo $this->pagination->getListFooter(); ?>
 
 	<?php endif; ?>
 

--- a/administrator/components/com_banners/tmpl/banners/default.php
+++ b/administrator/components/com_banners/tmpl/banners/default.php
@@ -85,13 +85,6 @@ if ($saveOrder && !empty($this->items))
 								</th>
 							</tr>
 						</thead>
-						<tfoot>
-							<tr>
-								<td colspan="13">
-									<?php echo $this->pagination->getListFooter(); ?>
-								</td>
-							</tr>
-						</tfoot>
 						<tbody <?php if ($saveOrder) :?> class="js-draggable" data-url="<?php echo $saveOrderingUrl; ?>" data-direction="<?php echo strtolower($listDirn); ?>" data-nested="true"<?php endif; ?>>
 							<?php foreach ($this->items as $i => $item) :
 								$ordering  = ($listOrder == 'ordering');
@@ -176,6 +169,10 @@ if ($saveOrder && !empty($this->items))
 							<?php endforeach; ?>
 						</tbody>
 					</table>
+					
+					<?php // load the pagination. ?>
+					<?php echo $this->pagination->getListFooter(); ?>
+
 					<?php // Load the batch processing form. ?>
 					<?php if ($user->authorise('core.create', 'com_banners')
 						&& $user->authorise('core.edit', 'com_banners')

--- a/administrator/components/com_banners/tmpl/banners/default.php
+++ b/administrator/components/com_banners/tmpl/banners/default.php
@@ -169,7 +169,7 @@ if ($saveOrder && !empty($this->items))
 							<?php endforeach; ?>
 						</tbody>
 					</table>
-					
+
 					<?php // load the pagination. ?>
 					<?php echo $this->pagination->getListFooter(); ?>
 

--- a/administrator/components/com_banners/tmpl/clients/default.php
+++ b/administrator/components/com_banners/tmpl/clients/default.php
@@ -153,7 +153,7 @@ $params     = $this->state->params ?? new JObject;
 							<?php endforeach; ?>
 						</tbody>
 					</table>
-					
+
 					<?php // load the pagination. ?>
 					<?php echo $this->pagination->getListFooter(); ?>
 

--- a/administrator/components/com_banners/tmpl/clients/default.php
+++ b/administrator/components/com_banners/tmpl/clients/default.php
@@ -90,13 +90,6 @@ $params     = $this->state->params ?? new JObject;
 								</th>
 							</tr>
 						</thead>
-						<tfoot>
-							<tr>
-								<td colspan="11">
-									<?php echo $this->pagination->getListFooter(); ?>
-								</td>
-							</tr>
-						</tfoot>
 						<tbody>
 							<?php foreach ($this->items as $i => $item) :
 								$canCreate  = $user->authorise('core.create',     'com_banners');
@@ -160,6 +153,10 @@ $params     = $this->state->params ?? new JObject;
 							<?php endforeach; ?>
 						</tbody>
 					</table>
+					
+					<?php // load the pagination. ?>
+					<?php echo $this->pagination->getListFooter(); ?>
+
 				<?php endif; ?>
 
 				<input type="hidden" name="task" value="">

--- a/administrator/components/com_banners/tmpl/tracks/default.php
+++ b/administrator/components/com_banners/tmpl/tracks/default.php
@@ -73,7 +73,7 @@ $listDirn   = $this->escape($this->state->get('list.direction'));
 							<?php endforeach; ?>
 						</tbody>
 					</table>
-					
+
 					<?php // load the pagination. ?>
 					<?php echo $this->pagination->getListFooter(); ?>
 

--- a/administrator/components/com_banners/tmpl/tracks/default.php
+++ b/administrator/components/com_banners/tmpl/tracks/default.php
@@ -48,13 +48,6 @@ $listDirn   = $this->escape($this->state->get('list.direction'));
 								</th>
 							</tr>
 						</thead>
-						<tfoot>
-							<tr>
-								<td colspan="5">
-									<?php echo $this->pagination->getListFooter(); ?>
-								</td>
-							</tr>
-						</tfoot>
 						<tbody>
 							<?php foreach ($this->items as $i => $item) : ?>
 								<tr class="row<?php echo $i % 2; ?>">
@@ -80,6 +73,10 @@ $listDirn   = $this->escape($this->state->get('list.direction'));
 							<?php endforeach; ?>
 						</tbody>
 					</table>
+					
+					<?php // load the pagination. ?>
+					<?php echo $this->pagination->getListFooter(); ?>
+
 				<?php endif; ?>
 				<?php // Load the export form ?>
 				<?php echo HTMLHelper::_(

--- a/administrator/components/com_cache/tmpl/cache/default.php
+++ b/administrator/components/com_cache/tmpl/cache/default.php
@@ -44,13 +44,6 @@ HTMLHelper::_('script', 'com_cache/admin-cache-default.js', ['relative' => true,
 							</th>
 						</tr>
 					</thead>
-					<tfoot>
-						<tr>
-							<td colspan="4">
-							<?php echo $this->pagination->getListFooter(); ?>
-							</td>
-						</tr>
-					</tfoot>
 					<tbody>
 						<?php $i = 0; ?>
 						<?php foreach ($this->data as $folder => $item) : ?>
@@ -73,6 +66,10 @@ HTMLHelper::_('script', 'com_cache/admin-cache-default.js', ['relative' => true,
 						<?php $i++; endforeach; ?>
 					</tbody>
 				</table>
+					
+				<?php // load the pagination. ?>
+				<?php echo $this->pagination->getListFooter(); ?>
+
 				<?php endif; ?>
 				<input type="hidden" name="task" value="">
 				<input type="hidden" name="boxchecked" value="0">

--- a/administrator/components/com_cache/tmpl/cache/default.php
+++ b/administrator/components/com_cache/tmpl/cache/default.php
@@ -66,7 +66,7 @@ HTMLHelper::_('script', 'com_cache/admin-cache-default.js', ['relative' => true,
 						<?php $i++; endforeach; ?>
 					</tbody>
 				</table>
-					
+
 				<?php // load the pagination. ?>
 				<?php echo $this->pagination->getListFooter(); ?>
 

--- a/administrator/components/com_categories/tmpl/categories/default.php
+++ b/administrator/components/com_categories/tmpl/categories/default.php
@@ -260,7 +260,7 @@ if ($saveOrder && !empty($this->items))
 							<?php endforeach; ?>
 						</tbody>
 					</table>
-					
+
 					<?php // load the pagination. ?>
 					<?php echo $this->pagination->getListFooter(); ?>
 

--- a/administrator/components/com_categories/tmpl/categories/default.php
+++ b/administrator/components/com_categories/tmpl/categories/default.php
@@ -136,13 +136,6 @@ if ($saveOrder && !empty($this->items))
 								</th>
 							</tr>
 						</thead>
-						<tfoot>
-							<tr>
-								<td colspan="<?php echo $columns; ?>">
-									<?php echo $this->pagination->getListFooter(); ?>
-								</td>
-							</tr>
-						</tfoot>
 						<tbody <?php if ($saveOrder) :?> class="js-draggable" data-url="<?php echo $saveOrderingUrl; ?>" data-direction="<?php echo strtolower($listDirn); ?>" data-nested="false"<?php endif; ?>>
 							<?php foreach ($this->items as $i => $item) : ?>
 								<?php
@@ -273,6 +266,10 @@ if ($saveOrder && !empty($this->items))
 							<?php endforeach; ?>
 						</tbody>
 					</table>
+					
+					<?php // load the pagination. ?>
+					<?php echo $this->pagination->getListFooter(); ?>
+
 					<?php // Load the batch processing form. ?>
 					<?php if ($user->authorise('core.create', $extension)
 						&& $user->authorise('core.edit', $extension)

--- a/administrator/components/com_categories/tmpl/categories/default.php
+++ b/administrator/components/com_categories/tmpl/categories/default.php
@@ -34,7 +34,6 @@ $saveOrder = ($listOrder == 'a.lft' && strtolower($listDirn) == 'asc');
 $parts     = explode('.', $extension, 2);
 $component = $parts[0];
 $section   = null;
-$columns   = 7;
 
 if (count($parts) > 1)
 {
@@ -85,32 +84,28 @@ if ($saveOrder && !empty($this->items))
 								<th scope="col" class="nowrap">
 									<?php echo HTMLHelper::_('searchtools.sort', 'JGLOBAL_TITLE', 'a.title', $listDirn, $listOrder); ?>
 								</th>
-								<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_published')) :
-									$columns++; ?>
+								<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_published')) : ?>
 									<th scope="col" style="width:3%" class="nowrap text-center d-none d-md-table-cell">
 										<span class="icon-publish hasTooltip" aria-hidden="true" title="<?php echo Text::_('COM_CATEGORY_COUNT_PUBLISHED_ITEMS'); ?>">
 											<span class="sr-only"><?php echo Text::_('COM_CATEGORY_COUNT_PUBLISHED_ITEMS'); ?></span>
 										</span>
 									</th>
 								<?php endif; ?>
-								<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_unpublished')) :
-									$columns++; ?>
+								<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_unpublished')) : ?>
 									<th scope="col" style="width:3%" class="nowrap text-center d-none d-md-table-cell">
 										<span class="icon-unpublish hasTooltip" aria-hidden="true" title="<?php echo Text::_('COM_CATEGORY_COUNT_UNPUBLISHED_ITEMS'); ?>">
 											<span class="sr-only"><?php echo Text::_('COM_CATEGORY_COUNT_UNPUBLISHED_ITEMS'); ?></span>
 										</span>
 									</th>
 								<?php endif; ?>
-								<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_archived')) :
-									$columns++; ?>
+								<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_archived')) : ?>
 									<th scope="col" style="width:3%" class="nowrap text-center d-none d-md-table-cell">
 										<span class="icon-archive hasTooltip" aria-hidden="true" title="<?php echo Text::_('COM_CATEGORY_COUNT_ARCHIVED_ITEMS'); ?>">
 											<span class="sr-only"><?php echo Text::_('COM_CATEGORY_COUNT_ARCHIVED_ITEMS'); ?></span>
 										</span>
 									</th>
 								<?php endif; ?>
-								<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_trashed')) :
-									$columns++; ?>
+								<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_trashed')) : ?>
 									<th scope="col" style="width:3%" class="nowrap text-center d-none d-md-table-cell">
 										<span class="icon-trash hasTooltip" aria-hidden="true" title="<?php echo Text::_('COM_CATEGORY_COUNT_TRASHED_ITEMS'); ?>">
 											<span class="sr-only"><?php echo Text::_('COM_CATEGORY_COUNT_TRASHED_ITEMS'); ?></span>
@@ -120,8 +115,7 @@ if ($saveOrder && !empty($this->items))
 								<th scope="col" style="width:10%" class="nowrap d-none d-md-table-cell text-center">
 									<?php echo HTMLHelper::_('searchtools.sort', 'JGRID_HEADING_ACCESS', 'access_level', $listDirn, $listOrder); ?>
 								</th>
-								<?php if ($this->assoc) :
-									$columns++; ?>
+								<?php if ($this->assoc) : ?>
 									<th scope="col" style="width:10%" class="nowrap d-none d-md-table-cell text-center">
 										<?php echo HTMLHelper::_('searchtools.sort', 'COM_CATEGORY_HEADING_ASSOCIATION', 'association', $listDirn, $listOrder); ?>
 									</th>

--- a/administrator/components/com_categories/tmpl/categories/modal.php
+++ b/administrator/components/com_categories/tmpl/categories/modal.php
@@ -66,13 +66,6 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 						</th>
 					</tr>
 				</thead>
-				<tfoot>
-					<tr>
-						<td colspan="5">
-							<?php echo $this->pagination->getListFooter(); ?>
-						</td>
-					</tr>
-				</tfoot>
 				<tbody>
 					<?php
 					$iconStates = array(
@@ -127,6 +120,10 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 					<?php endforeach; ?>
 				</tbody>
 			</table>
+
+			<?php // load the pagination. ?>
+			<?php echo $this->pagination->getListFooter(); ?>
+
 		<?php endif; ?>
 
 		<input type="hidden" name="extension" value="<?php echo $extension; ?>">

--- a/administrator/components/com_checkin/tmpl/checkin/default.php
+++ b/administrator/components/com_checkin/tmpl/checkin/default.php
@@ -62,7 +62,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 							<?php endforeach; ?>
 						</tbody>
 					</table>
-					
+
 					<?php // load the pagination. ?>
 					<?php echo $this->pagination->getListFooter(); ?>
 

--- a/administrator/components/com_checkin/tmpl/checkin/default.php
+++ b/administrator/components/com_checkin/tmpl/checkin/default.php
@@ -42,13 +42,6 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 								</th>
 							</tr>
 						</thead>
-						<tfoot>
-							<tr>
-								<td colspan="3">
-									<?php echo $this->pagination->getListFooter(); ?>
-								</td>
-							</tr>
-						</tfoot>
 						<tbody>
 							<?php $i = 0; ?>
 							<?php foreach ($this->items as $table => $count) : ?>
@@ -69,6 +62,10 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 							<?php endforeach; ?>
 						</tbody>
 					</table>
+					
+					<?php // load the pagination. ?>
+					<?php echo $this->pagination->getListFooter(); ?>
+
 				<?php endif; ?>
 				<input type="hidden" name="task" value="">
 				<input type="hidden" name="boxchecked" value="0">

--- a/administrator/components/com_contact/tmpl/contacts/default.php
+++ b/administrator/components/com_contact/tmpl/contacts/default.php
@@ -173,7 +173,7 @@ if ($saveOrder && !empty($this->items))
 							<?php endforeach; ?>
 						</tbody>
 					</table>
-					
+
 					<?php // load the pagination. ?>
 					<?php echo $this->pagination->getListFooter(); ?>
 

--- a/administrator/components/com_contact/tmpl/contacts/default.php
+++ b/administrator/components/com_contact/tmpl/contacts/default.php
@@ -83,13 +83,6 @@ if ($saveOrder && !empty($this->items))
 								</th>
 							</tr>
 						</thead>
-						<tfoot>
-							<tr>
-								<td colspan="10">
-									<?php echo $this->pagination->getListFooter(); ?>
-								</td>
-							</tr>
-						</tfoot>
 						<tbody <?php if ($saveOrder) :?> class="js-draggable" data-url="<?php echo $saveOrderingUrl; ?>" data-direction="<?php echo strtolower($listDirn); ?>" data-nested="true"<?php endif; ?>>
 						<?php
 						$n = count($this->items);
@@ -180,6 +173,10 @@ if ($saveOrder && !empty($this->items))
 							<?php endforeach; ?>
 						</tbody>
 					</table>
+					
+					<?php // load the pagination. ?>
+					<?php echo $this->pagination->getListFooter(); ?>
+
 					<?php // Load the batch processing form. ?>
 					<?php if ($user->authorise('core.create', 'com_contact')
 						&& $user->authorise('core.edit', 'com_contact')

--- a/administrator/components/com_contact/tmpl/contacts/modal.php
+++ b/administrator/components/com_contact/tmpl/contacts/modal.php
@@ -77,13 +77,6 @@ if (!empty($editor))
 						</th>
 					</tr>
 				</thead>
-				<tfoot>
-					<tr>
-						<td colspan="6">
-							<?php echo $this->pagination->getListFooter(); ?>
-						</td>
-					</tr>
-				</tfoot>
 				<tbody>
 				<?php
 				$iconStates = array(
@@ -144,6 +137,10 @@ if (!empty($editor))
 				<?php endforeach; ?>
 				</tbody>
 			</table>
+
+			<?php // load the pagination. ?>
+			<?php echo $this->pagination->getListFooter(); ?>
+
 		<?php endif; ?>
 
 		<input type="hidden" name="task" value="">

--- a/administrator/components/com_content/tmpl/articles/default.php
+++ b/administrator/components/com_content/tmpl/articles/default.php
@@ -262,7 +262,7 @@ $featuredButton = (new ActionButton(['tip_title' => 'JGLOBAL_TOGGLE_FEATURED']))
 							<?php endforeach; ?>
 						</tbody>
 					</table>
-					
+
 					<?php // load the pagination. ?>
 					<?php echo $this->pagination->getListFooter(); ?>
 

--- a/administrator/components/com_content/tmpl/articles/default.php
+++ b/administrator/components/com_content/tmpl/articles/default.php
@@ -32,7 +32,6 @@ $userId    = $user->get('id');
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
 $saveOrder = $listOrder == 'a.ordering';
-$columns   = 10;
 
 if (strpos($listOrder, 'publish_up') !== false)
 {
@@ -109,7 +108,6 @@ $featuredButton = (new ActionButton(['tip_title' => 'JGLOBAL_TOGGLE_FEATURED']))
 									<?php echo HTMLHelper::_('searchtools.sort',  'JGRID_HEADING_ACCESS', 'a.access', $listDirn, $listOrder); ?>
 								</th>
 								<?php if ($assoc) : ?>
-									<?php $columns++; ?>
 									<th scope="col" style="width:5%" class="nowrap d-none d-md-table-cell text-center">
 										<?php echo HTMLHelper::_('searchtools.sort', 'COM_CONTENT_HEADING_ASSOCIATION', 'association', $listDirn, $listOrder); ?>
 									</th>
@@ -129,11 +127,9 @@ $featuredButton = (new ActionButton(['tip_title' => 'JGLOBAL_TOGGLE_FEATURED']))
 									<?php echo HTMLHelper::_('searchtools.sort', 'JGLOBAL_HITS', 'a.hits', $listDirn, $listOrder); ?>
 								</th>
 								<?php if ($this->vote) : ?>
-									<?php $columns++; ?>
 									<th scope="col" style="width:3%" class="nowrap d-none d-md-table-cell text-center">
 										<?php echo HTMLHelper::_('searchtools.sort', 'JGLOBAL_VOTES', 'rating_count', $listDirn, $listOrder); ?>
 									</th>
-									<?php $columns++; ?>
 									<th scope="col" style="width:3%" class="nowrap d-none d-md-table-cell text-center">
 										<?php echo HTMLHelper::_('searchtools.sort', 'JGLOBAL_RATINGS', 'rating', $listDirn, $listOrder); ?>
 									</th>
@@ -143,11 +139,6 @@ $featuredButton = (new ActionButton(['tip_title' => 'JGLOBAL_TOGGLE_FEATURED']))
 								</th>
 							</tr>
 						</thead>
-						<tfoot>
-							<tr>
-								<td colspan="<?php echo $columns; ?>"><?php echo $this->pagination->getListFooter(); ?></td>
-							</tr>
-						</tfoot>
 						<tbody <?php if ($saveOrder) :?> class="js-draggable" data-url="<?php echo $saveOrderingUrl; ?>" data-direction="<?php echo strtolower($listDirn); ?>" data-nested="true"<?php endif; ?>>
 						<?php foreach ($this->items as $i => $item) :
 							$item->max_ordering = 0;
@@ -271,6 +262,10 @@ $featuredButton = (new ActionButton(['tip_title' => 'JGLOBAL_TOGGLE_FEATURED']))
 							<?php endforeach; ?>
 						</tbody>
 					</table>
+					
+					<?php // load the pagination. ?>
+					<?php echo $this->pagination->getListFooter(); ?>
+
 					<?php // Load the batch processing form. ?>
 					<?php if ($user->authorise('core.create', 'com_content')
 						&& $user->authorise('core.edit', 'com_content')

--- a/administrator/components/com_content/tmpl/articles/modal.php
+++ b/administrator/components/com_content/tmpl/articles/modal.php
@@ -80,13 +80,6 @@ if (!empty($editor))
 						</th>
 					</tr>
 				</thead>
-				<tfoot>
-					<tr>
-						<td colspan="6">
-							<?php echo $this->pagination->getListFooter(); ?>
-						</td>
-					</tr>
-				</tfoot>
 				<tbody>
 				<?php
 				$iconStates = array(
@@ -152,6 +145,10 @@ if (!empty($editor))
 				<?php endforeach; ?>
 				</tbody>
 			</table>
+
+			<?php // load the pagination. ?>
+			<?php echo $this->pagination->getListFooter(); ?>
+
 		<?php endif; ?>
 
 		<input type="hidden" name="task" value="">

--- a/administrator/components/com_content/tmpl/featured/default.php
+++ b/administrator/components/com_content/tmpl/featured/default.php
@@ -27,7 +27,6 @@ $userId    = $user->get('id');
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
 $saveOrder = $listOrder == 'fp.ordering';
-$columns   = 10;
 
 if (strpos($listOrder, 'publish_up') !== false)
 {
@@ -98,11 +97,9 @@ if ($saveOrder)
 									<?php echo HTMLHelper::_('searchtools.sort', 'JGLOBAL_HITS', 'a.hits', $listDirn, $listOrder); ?>
 								</th>
 								<?php if ($this->vote) : ?>
-									<?php $columns++; ?>
 									<th scope="col" style="width:3%" class="nowrap d-none d-md-table-cell text-center">
 										<?php echo HTMLHelper::_('searchtools.sort', 'JGLOBAL_VOTES', 'rating_count', $listDirn, $listOrder); ?>
 									</th>
-									<?php $columns++; ?>
 									<th scope="col" style="width:3%" class="nowrap d-none d-md-table-cell text-center">
 										<?php echo HTMLHelper::_('searchtools.sort', 'JGLOBAL_RATINGS', 'rating', $listDirn, $listOrder); ?>
 									</th>
@@ -112,13 +109,6 @@ if ($saveOrder)
 								</th>
 							</tr>
 						</thead>
-						<tfoot>
-							<tr>
-								<td colspan="<?php echo $columns; ?>">
-									<?php echo $this->pagination->getListFooter(); ?>
-								</td>
-							</tr>
-						</tfoot>
 						<tbody>
 						<?php $count = count($this->items); ?>
 						<?php foreach ($this->items as $i => $item) :
@@ -237,6 +227,10 @@ if ($saveOrder)
 						<?php endforeach; ?>
 						</tbody>
 					</table>
+					
+					<?php // load the pagination. ?>
+					<?php echo $this->pagination->getListFooter(); ?>
+
 				<?php endif; ?>
 
 				<input type="hidden" name="task" value="">

--- a/administrator/components/com_content/tmpl/featured/default.php
+++ b/administrator/components/com_content/tmpl/featured/default.php
@@ -227,7 +227,7 @@ if ($saveOrder)
 						<?php endforeach; ?>
 						</tbody>
 					</table>
-					
+
 					<?php // load the pagination. ?>
 					<?php echo $this->pagination->getListFooter(); ?>
 

--- a/administrator/components/com_contenthistory/tmpl/history/modal.php
+++ b/administrator/components/com_contenthistory/tmpl/history/modal.php
@@ -91,13 +91,6 @@ HTMLHelper::_('script', 'com_contenthistory/admin-history-modal.min.js', array('
 					</th>
 				</tr>
 			</thead>
-			<tfoot>
-				<tr>
-					<td colspan="15">
-						<?php echo $this->pagination->getListFooter(); ?>
-					</td>
-				</tr>
-			</tfoot>
 			<tbody>
 			<?php $i = 0; ?>
 			<?php foreach ($this->items as $item) : ?>
@@ -143,6 +136,9 @@ HTMLHelper::_('script', 'com_contenthistory/admin-history-modal.min.js', array('
 			<?php endforeach; ?>
 			</tbody>
 		</table>
+
+		<?php // load the pagination. ?>
+		<?php echo $this->pagination->getListFooter(); ?>
 
 		<input type="hidden" name="task" value="">
 		<input type="hidden" name="boxchecked" value="0">

--- a/administrator/components/com_csp/tmpl/reports/default.php
+++ b/administrator/components/com_csp/tmpl/reports/default.php
@@ -121,7 +121,7 @@ $saveOrder = $listOrder == 'a.id';
 							<?php endforeach; ?>
 						</tbody>
 					</table>
-					
+
 					<?php // load the pagination. ?>
 					<?php echo $this->pagination->getListFooter(); ?>
 

--- a/administrator/components/com_csp/tmpl/reports/default.php
+++ b/administrator/components/com_csp/tmpl/reports/default.php
@@ -87,13 +87,6 @@ $saveOrder = $listOrder == 'a.id';
 								</th>
 							</tr>
 						</thead>
-						<tfoot>
-							<tr>
-								<td colspan="8">
-									<?php echo $this->pagination->getListFooter(); ?>
-								</td>
-							</tr>
-						</tfoot>
 						<tbody>
 							<?php foreach ($this->items as $i => $item) : ?>
 								<?php $canChange  = $user->authorise('core.edit.state', 'com_csp'); ?>
@@ -128,6 +121,10 @@ $saveOrder = $listOrder == 'a.id';
 							<?php endforeach; ?>
 						</tbody>
 					</table>
+					
+					<?php // load the pagination. ?>
+					<?php echo $this->pagination->getListFooter(); ?>
+
 				<?php endif; ?>
 				<input type="hidden" name="task" value="">
 				<input type="hidden" name="boxchecked" value="0">

--- a/administrator/components/com_fields/tmpl/fields/default.php
+++ b/administrator/components/com_fields/tmpl/fields/default.php
@@ -88,13 +88,6 @@ if ($saveOrder && !empty($this->items))
 								</th>
 							</tr>
 						</thead>
-						<tfoot>
-							<tr>
-								<td colspan="9">
-									<?php echo $this->pagination->getListFooter(); ?>
-								</td>
-							</tr>
-						</tfoot>
 						<tbody <?php if ($saveOrder) : ?> class="js-draggable" data-url="<?php echo $saveOrderingUrl; ?>" data-direction="<?php echo strtolower($listDirn); ?>" data-nested="true"<?php endif; ?>>
 							<?php foreach ($this->items as $i => $item) : ?>
 								<?php $ordering   = ($listOrder == 'a.ordering'); ?>
@@ -178,6 +171,10 @@ if ($saveOrder && !empty($this->items))
 							<?php endforeach; ?>
 						</tbody>
 					</table>
+					
+					<?php // load the pagination. ?>
+					<?php echo $this->pagination->getListFooter(); ?>
+
 					<?php //Load the batch processing form. ?>
 					<?php if ($user->authorise('core.create', $component)
 						&& $user->authorise('core.edit', $component)

--- a/administrator/components/com_fields/tmpl/fields/default.php
+++ b/administrator/components/com_fields/tmpl/fields/default.php
@@ -171,7 +171,7 @@ if ($saveOrder && !empty($this->items))
 							<?php endforeach; ?>
 						</tbody>
 					</table>
-					
+
 					<?php // load the pagination. ?>
 					<?php echo $this->pagination->getListFooter(); ?>
 

--- a/administrator/components/com_fields/tmpl/fields/modal.php
+++ b/administrator/components/com_fields/tmpl/fields/modal.php
@@ -63,13 +63,6 @@ $editor    = Factory::getApplication()->input->get('editor', '', 'cmd');
 						</th>
 					</tr>
 				</thead>
-				<tfoot>
-					<tr>
-						<td colspan="8">
-							<?php echo $this->pagination->getListFooter(); ?>
-						</td>
-					</tr>
-				</tfoot>
 				<tbody>
 					<?php
 					$iconStates = array(
@@ -106,6 +99,10 @@ $editor    = Factory::getApplication()->input->get('editor', '', 'cmd');
 				<?php endforeach; ?>
 				</tbody>
 			</table>
+
+			<?php // load the pagination. ?>
+			<?php echo $this->pagination->getListFooter(); ?>
+
 		<?php endif; ?>
 
 		<input type="hidden" name="task" value="">

--- a/administrator/components/com_fields/tmpl/groups/default.php
+++ b/administrator/components/com_fields/tmpl/groups/default.php
@@ -86,13 +86,6 @@ if ($saveOrder && !empty($this->items))
 								</th>
 							</tr>
 						</thead>
-						<tfoot>
-							<tr>
-								<td colspan="9">
-									<?php echo $this->pagination->getListFooter(); ?>
-								</td>
-							</tr>
-						</tfoot>
 						<tbody <?php if ($saveOrder) : ?> class="js-draggable" data-url="<?php echo $saveOrderingUrl; ?>" data-direction="<?php echo strtolower($listDirn); ?>" data-nested="true"<?php endif; ?>>
 							<?php foreach ($this->items as $i => $item) : ?>
 								<?php $ordering   = ($listOrder == 'a.ordering'); ?>
@@ -157,6 +150,10 @@ if ($saveOrder && !empty($this->items))
 							<?php endforeach; ?>
 						</tbody>
 					</table>
+					
+					<?php // load the pagination. ?>
+					<?php echo $this->pagination->getListFooter(); ?>
+
 					<?php //Load the batch processing form. ?>
 					<?php if ($user->authorise('core.create', $component)
 						&& $user->authorise('core.edit', $component)

--- a/administrator/components/com_fields/tmpl/groups/default.php
+++ b/administrator/components/com_fields/tmpl/groups/default.php
@@ -150,7 +150,7 @@ if ($saveOrder && !empty($this->items))
 							<?php endforeach; ?>
 						</tbody>
 					</table>
-					
+
 					<?php // load the pagination. ?>
 					<?php echo $this->pagination->getListFooter(); ?>
 

--- a/administrator/components/com_finder/tmpl/filters/default.php
+++ b/administrator/components/com_finder/tmpl/filters/default.php
@@ -102,7 +102,7 @@ HTMLHelper::_('script', 'com_finder/filters.js', ['relative' => true, 'version' 
 						<?php endforeach; ?>
 					</tbody>
 				</table>
-					
+
 				<?php // load the pagination. ?>
 				<?php echo $this->pagination->getListFooter(); ?>
 

--- a/administrator/components/com_finder/tmpl/filters/default.php
+++ b/administrator/components/com_finder/tmpl/filters/default.php
@@ -56,13 +56,6 @@ HTMLHelper::_('script', 'com_finder/filters.js', ['relative' => true, 'version' 
 							</th>
 						</tr>
 					</thead>
-					<tfoot>
-						<tr>
-							<td colspan="7">
-								<?php echo $this->pagination->getListFooter(); ?>
-							</td>
-						</tr>
-					</tfoot>
 					<tbody>
 						<?php
 						$canCreate                  = $user->authorise('core.create',     'com_finder');
@@ -109,6 +102,10 @@ HTMLHelper::_('script', 'com_finder/filters.js', ['relative' => true, 'version' 
 						<?php endforeach; ?>
 					</tbody>
 				</table>
+					
+				<?php // load the pagination. ?>
+				<?php echo $this->pagination->getListFooter(); ?>
+
 				<?php endif; ?>
 				<input type="hidden" name="task" value="">
 				<input type="hidden" name="boxchecked" value="0">

--- a/administrator/components/com_finder/tmpl/index/default.php
+++ b/administrator/components/com_finder/tmpl/index/default.php
@@ -93,7 +93,7 @@ HTMLHelper::_('script', 'com_finder/index.js', ['relative' => true, 'version' =>
 						<?php endforeach; ?>
 					</tbody>
 				</table>
-					
+
 				<?php // load the pagination. ?>
 				<?php echo $this->pagination->getListFooter(); ?>
 

--- a/administrator/components/com_finder/tmpl/index/default.php
+++ b/administrator/components/com_finder/tmpl/index/default.php
@@ -56,13 +56,6 @@ HTMLHelper::_('script', 'com_finder/index.js', ['relative' => true, 'version' =>
 							</th>
 						</tr>
 					</thead>
-					<tfoot>
-						<tr>
-							<td colspan="7">
-								<?php echo $this->pagination->getListFooter(); ?>
-							</td>
-						</tr>
-					</tfoot>
 					<tbody>
 						<?php $canChange = JFactory::getUser()->authorise('core.manage', 'com_finder'); ?>
 						<?php foreach ($this->items as $i => $item) : ?>
@@ -100,6 +93,10 @@ HTMLHelper::_('script', 'com_finder/index.js', ['relative' => true, 'version' =>
 						<?php endforeach; ?>
 					</tbody>
 				</table>
+					
+				<?php // load the pagination. ?>
+				<?php echo $this->pagination->getListFooter(); ?>
+
 				<input type="hidden" name="task" value="display">
 				<input type="hidden" name="boxchecked" value="0">
 				<?php echo JHtml::_('form.token'); ?>

--- a/administrator/components/com_finder/tmpl/maps/default.php
+++ b/administrator/components/com_finder/tmpl/maps/default.php
@@ -119,7 +119,7 @@ HTMLHelper::_('script', 'com_finder/maps.js', ['relative' => true, 'version' => 
 						<?php endforeach; ?>
 					</tbody>
 				</table>
-					
+
 				<?php // load the pagination. ?>
 				<?php echo $this->pagination->getListFooter(); ?>
 

--- a/administrator/components/com_finder/tmpl/maps/default.php
+++ b/administrator/components/com_finder/tmpl/maps/default.php
@@ -16,7 +16,6 @@ $listOrder     = $this->escape($this->state->get('list.ordering'));
 $listDirn      = $this->escape($this->state->get('list.direction'));
 $lang          = JFactory::getLanguage();
 $branchFilter  = $this->escape($this->state->get('filter.branch'));
-$colSpan       = $branchFilter ? 5 : 6;
 JText::script('COM_FINDER_MAPS_CONFIRM_DELETE_PROMPT');
 HTMLHelper::_('script', 'com_finder/maps.js', ['relative' => true, 'version' => 'auto']);
 ?>
@@ -58,13 +57,6 @@ HTMLHelper::_('script', 'com_finder/maps.js', ['relative' => true, 'version' => 
 							</th>
 						</tr>
 					</thead>
-					<tfoot>
-						<tr>
-							<td colspan="<?php echo $colSpan; ?>">
-								<?php echo $this->pagination->getListFooter(); ?>
-							</td>
-						</tr>
-					</tfoot>
 					<tbody>
 						<?php $canChange = JFactory::getUser()->authorise('core.manage', 'com_finder'); ?>
 						<?php foreach ($this->items as $i => $item) : ?>
@@ -127,6 +119,10 @@ HTMLHelper::_('script', 'com_finder/maps.js', ['relative' => true, 'version' => 
 						<?php endforeach; ?>
 					</tbody>
 				</table>
+					
+				<?php // load the pagination. ?>
+				<?php echo $this->pagination->getListFooter(); ?>
+
 				<?php endif; ?>
 			</div>
 

--- a/administrator/components/com_finder/tmpl/searches/default.php
+++ b/administrator/components/com_finder/tmpl/searches/default.php
@@ -58,7 +58,7 @@ $listDirn = $this->escape($this->state->get('list.direction'));
 					<?php endforeach; ?>
 					</tbody>
 				</table>
-					
+
 				<?php // load the pagination. ?>
 				<?php echo $this->pagination->getListFooter(); ?>
 

--- a/administrator/components/com_finder/tmpl/searches/default.php
+++ b/administrator/components/com_finder/tmpl/searches/default.php
@@ -42,13 +42,6 @@ $listDirn = $this->escape($this->state->get('list.direction'));
 							</th>
 						</tr>
 					</thead>
-					<tfoot>
-						<tr>
-							<td colspan="3">
-								<?php echo $this->pagination->getListFooter(); ?>
-							</td>
-						</tr>
-					</tfoot>
 					<tbody>
 					<?php foreach ($this->items as $i => $item) : ?>
 						<tr class="row<?php echo $i % 2; ?>">
@@ -65,6 +58,10 @@ $listDirn = $this->escape($this->state->get('list.direction'));
 					<?php endforeach; ?>
 					</tbody>
 				</table>
+					
+				<?php // load the pagination. ?>
+				<?php echo $this->pagination->getListFooter(); ?>
+
 				<?php endif; ?>
 				<input type="hidden" name="task" value="">
 				<input type="hidden" name="boxchecked" value="0">

--- a/administrator/components/com_installer/tmpl/database/default.php
+++ b/administrator/components/com_installer/tmpl/database/default.php
@@ -118,7 +118,7 @@ $listDirection = $this->escape($this->state->get('list.direction'));
 									<?php endforeach; ?>
 								</tbody>
 							</table>
-					
+
 							<?php // load the pagination. ?>
 							<?php echo $this->pagination->getListFooter(); ?>
 

--- a/administrator/components/com_installer/tmpl/database/default.php
+++ b/administrator/components/com_installer/tmpl/database/default.php
@@ -72,13 +72,6 @@ $listDirection = $this->escape($this->state->get('list.direction'));
 										</th>
 									</tr>
 								</thead>
-								<tfoot>
-									<tr>
-										<td colspan="9">
-											<?php echo $this->pagination->getListFooter(); ?>
-										</td>
-									</tr>
-								</tfoot>
 								<tbody>
 									<?php foreach ($this->changeSet as $i => $item) : ?>
 										<?php $extension = $item['extension']; ?>
@@ -125,6 +118,10 @@ $listDirection = $this->escape($this->state->get('list.direction'));
 									<?php endforeach; ?>
 								</tbody>
 							</table>
+					
+							<?php // load the pagination. ?>
+							<?php echo $this->pagination->getListFooter(); ?>
+
 						<?php endif; ?>
 					</div>
 					<input type="hidden" name="task" value="">

--- a/administrator/components/com_installer/tmpl/discover/default.php
+++ b/administrator/components/com_installer/tmpl/discover/default.php
@@ -65,11 +65,6 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 								</th>
 							</tr>
 						</thead>
-						<tfoot>
-							<tr>
-								<td colspan="9"><?php echo $this->pagination->getListFooter(); ?></td>
-							</tr>
-						</tfoot>
 						<tbody>
 						<?php foreach ($this->items as $i => $item) : ?>
 							<tr class="row<?php echo $i % 2; ?>">
@@ -108,6 +103,10 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 						<?php endforeach; ?>
 						</tbody>
 					</table>
+					
+					<?php // load the pagination. ?>
+					<?php echo $this->pagination->getListFooter(); ?>
+
 					<?php endif; ?>
 					<input type="hidden" name="task" value="">
 					<input type="hidden" name="boxchecked" value="0">

--- a/administrator/components/com_installer/tmpl/discover/default.php
+++ b/administrator/components/com_installer/tmpl/discover/default.php
@@ -103,7 +103,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 						<?php endforeach; ?>
 						</tbody>
 					</table>
-					
+
 					<?php // load the pagination. ?>
 					<?php echo $this->pagination->getListFooter(); ?>
 

--- a/administrator/components/com_installer/tmpl/languages/default.php
+++ b/administrator/components/com_installer/tmpl/languages/default.php
@@ -82,7 +82,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 						<?php endforeach; ?>
 						</tbody>
 					</table>
-					
+
 					<?php // load the pagination. ?>
 					<?php echo $this->pagination->getListFooter(); ?>
 

--- a/administrator/components/com_installer/tmpl/languages/default.php
+++ b/administrator/components/com_installer/tmpl/languages/default.php
@@ -44,13 +44,6 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 								</th>
 							</tr>
 						</thead>
-						<tfoot>
-							<tr>
-								<td colspan="6">
-									<?php echo $this->pagination->getListFooter(); ?>
-								</td>
-							</tr>
-						</tfoot>
 						<tbody>
 						<?php
 						$version = new JVersion;
@@ -89,6 +82,10 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 						<?php endforeach; ?>
 						</tbody>
 					</table>
+					
+					<?php // load the pagination. ?>
+					<?php echo $this->pagination->getListFooter(); ?>
+
 					<?php endif; ?>
 					<input type="hidden" name="task" value="">
 					<input type="hidden" name="return" value="<?php echo base64_encode('index.php?option=com_installer&view=languages') ?>">

--- a/administrator/components/com_installer/tmpl/manage/default.php
+++ b/administrator/components/com_installer/tmpl/manage/default.php
@@ -120,7 +120,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 						<?php endforeach; ?>
 						</tbody>
 					</table>
-					
+
 					<?php // load the pagination. ?>
 					<?php echo $this->pagination->getListFooter(); ?>
 

--- a/administrator/components/com_installer/tmpl/manage/default.php
+++ b/administrator/components/com_installer/tmpl/manage/default.php
@@ -70,13 +70,6 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 								</th>
 							</tr>
 						</thead>
-						<tfoot>
-							<tr>
-								<td colspan="11">
-									<?php echo $this->pagination->getListFooter(); ?>
-								</td>
-							</tr>
-						</tfoot>
 						<tbody>
 						<?php foreach ($this->items as $i => $item) : ?>
 							<tr class="row<?php echo $i % 2; if ($item->status == 2) echo ' protected'; ?>">
@@ -127,6 +120,10 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 						<?php endforeach; ?>
 						</tbody>
 					</table>
+					
+					<?php // load the pagination. ?>
+					<?php echo $this->pagination->getListFooter(); ?>
+
 					<?php endif; ?>
 					<input type="hidden" name="task" value="">
 					<input type="hidden" name="boxchecked" value="0">

--- a/administrator/components/com_installer/tmpl/update/default.php
+++ b/administrator/components/com_installer/tmpl/update/default.php
@@ -114,7 +114,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 							<?php endforeach; ?>
 							</tbody>
 						</table>
-					
+
 						<?php // load the pagination. ?>
 						<?php echo $this->pagination->getListFooter(); ?>
 

--- a/administrator/components/com_installer/tmpl/update/default.php
+++ b/administrator/components/com_installer/tmpl/update/default.php
@@ -65,13 +65,6 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 								</th>
 							</tr>
 							</thead>
-							<tfoot>
-							<tr>
-								<td colspan="9">
-									<?php echo $this->pagination->getListFooter(); ?>
-								</td>
-							</tr>
-							</tfoot>
 							<tbody>
 							<?php foreach ($this->items as $i => $item) : ?>
 								<?php
@@ -121,6 +114,10 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 							<?php endforeach; ?>
 							</tbody>
 						</table>
+					
+						<?php // load the pagination. ?>
+						<?php echo $this->pagination->getListFooter(); ?>
+
 					<?php endif; ?>
 					<input type="hidden" name="task" value="">
 					<input type="hidden" name="boxchecked" value="0">

--- a/administrator/components/com_installer/tmpl/updatesites/default.php
+++ b/administrator/components/com_installer/tmpl/updatesites/default.php
@@ -55,13 +55,6 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 								</th>
 							</tr>
 						</thead>
-						<tfoot>
-							<tr>
-								<td colspan="8">
-									<?php echo $this->pagination->getListFooter(); ?>
-								</td>
-							</tr>
-						</tfoot>
 						<tbody>
 						<?php foreach ($this->items as $i => $item) : ?>
 							<tr class="row<?php echo $i % 2; if ($item->enabled == 2) echo ' protected'; ?>">
@@ -105,6 +98,10 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 						<?php endforeach; ?>
 						</tbody>
 					</table>
+					
+					<?php // load the pagination. ?>
+					<?php echo $this->pagination->getListFooter(); ?>
+
 					<?php endif; ?>
 					<input type="hidden" name="task" value="">
 					<input type="hidden" name="boxchecked" value="0">

--- a/administrator/components/com_installer/tmpl/updatesites/default.php
+++ b/administrator/components/com_installer/tmpl/updatesites/default.php
@@ -98,7 +98,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 						<?php endforeach; ?>
 						</tbody>
 					</table>
-					
+
 					<?php // load the pagination. ?>
 					<?php echo $this->pagination->getListFooter(); ?>
 

--- a/administrator/components/com_languages/tmpl/installed/default.php
+++ b/administrator/components/com_languages/tmpl/installed/default.php
@@ -114,7 +114,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 					<?php endforeach; ?>
 					</tbody>
 				</table>
-					
+
 				<?php // load the pagination. ?>
 				<?php echo $this->pagination->getListFooter(); ?>
 

--- a/administrator/components/com_languages/tmpl/installed/default.php
+++ b/administrator/components/com_languages/tmpl/installed/default.php
@@ -62,13 +62,6 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 							</th>
 						</tr>
 					</thead>
-					<tfoot>
-						<tr>
-							<td colspan="10">
-								<?php echo $this->pagination->getListFooter(); ?>
-							</td>
-						</tr>
-					</tfoot>
 					<tbody>
 					<?php
 					$version = new JVersion;
@@ -121,6 +114,10 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 					<?php endforeach; ?>
 					</tbody>
 				</table>
+					
+				<?php // load the pagination. ?>
+				<?php echo $this->pagination->getListFooter(); ?>
+
 				<?php endif; ?>
 				<input type="hidden" name="task" value="">
 				<input type="hidden" name="boxchecked" value="0">

--- a/administrator/components/com_languages/tmpl/languages/default.php
+++ b/administrator/components/com_languages/tmpl/languages/default.php
@@ -145,7 +145,7 @@ if ($saveOrder)
 							<?php endforeach; ?>
 						</tbody>
 					</table>
-					
+
 					<?php // load the pagination. ?>
 					<?php echo $this->pagination->getListFooter(); ?>
 

--- a/administrator/components/com_languages/tmpl/languages/default.php
+++ b/administrator/components/com_languages/tmpl/languages/default.php
@@ -73,13 +73,6 @@ if ($saveOrder)
 								</th>
 							</tr>
 						</thead>
-						<tfoot>
-							<tr>
-								<td colspan="11">
-									<?php echo $this->pagination->getListFooter(); ?>
-								</td>
-							</tr>
-						</tfoot>
 						<tbody>
 						<?php
 						foreach ($this->items as $i => $item) :
@@ -152,6 +145,10 @@ if ($saveOrder)
 							<?php endforeach; ?>
 						</tbody>
 					</table>
+					
+					<?php // load the pagination. ?>
+					<?php echo $this->pagination->getListFooter(); ?>
+
 				<?php endif; ?>
 				<input type="hidden" name="task" value="">
 				<input type="hidden" name="boxchecked" value="0">

--- a/administrator/components/com_languages/tmpl/overrides/default.php
+++ b/administrator/components/com_languages/tmpl/overrides/default.php
@@ -68,13 +68,6 @@ $opposite_strings  = LanguagesHelper::parseFile($opposite_filename);
 								</th>
 							</tr>
 						</thead>
-						<tfoot>
-							<tr>
-								<td colspan="5">
-									<?php echo $this->pagination->getListFooter(); ?>
-								</td>
-							</tr>
-						</tfoot>
 						<tbody>
 						<?php $canEdit = JFactory::getUser()->authorise('core.edit', 'com_languages'); ?>
 						<?php $i = 0; ?>
@@ -111,6 +104,10 @@ $opposite_strings  = LanguagesHelper::parseFile($opposite_filename);
 						<?php endforeach; ?>
 						</tbody>
 					</table>
+					
+					<?php // load the pagination. ?>
+					<?php echo $this->pagination->getListFooter(); ?>
+
 				<?php endif; ?>
 
 				<input type="hidden" name="task" value="">

--- a/administrator/components/com_languages/tmpl/overrides/default.php
+++ b/administrator/components/com_languages/tmpl/overrides/default.php
@@ -104,7 +104,7 @@ $opposite_strings  = LanguagesHelper::parseFile($opposite_filename);
 						<?php endforeach; ?>
 						</tbody>
 					</table>
-					
+
 					<?php // load the pagination. ?>
 					<?php echo $this->pagination->getListFooter(); ?>
 

--- a/administrator/components/com_menus/tmpl/items/default.php
+++ b/administrator/components/com_menus/tmpl/items/default.php
@@ -259,7 +259,7 @@ $assoc   = Associations::isEnabled() && $this->state->get('filter.client_id') ==
 						<?php endforeach; ?>
 						</tbody>
 					</table>
-					
+
 					<?php // load the pagination. ?>
 					<?php echo $this->pagination->getListFooter(); ?>
 

--- a/administrator/components/com_menus/tmpl/items/default.php
+++ b/administrator/components/com_menus/tmpl/items/default.php
@@ -39,12 +39,7 @@ if ($saveOrder && $menuType && !empty($this->items))
 }
 
 $assoc   = Associations::isEnabled() && $this->state->get('filter.client_id') == 0;
-$colSpan = $assoc ? 10 : 9;
 
-if ($menuType == '')
-{
-	$colSpan--;
-}
 ?>
 <?php // Set up the filter bar. ?>
 <form action="<?php echo Route::_('index.php?option=com_menus&view=items'); ?>" method="post" name="adminForm"
@@ -104,14 +99,6 @@ if ($menuType == '')
 							</th>
 						</tr>
 						</thead>
-						<tfoot>
-						<tr>
-							<td colspan="<?php echo $colSpan; ?>">
-								<?php echo $this->pagination->getListFooter(); ?>
-							</td>
-						</tr>
-						</tfoot>
-
 						<tbody <?php if ($saveOrder && $menuType) :?> class="js-draggable" data-url="<?php echo $saveOrderingUrl; ?>" data-direction="<?php echo strtolower($listDirn); ?>" data-nested="false"<?php endif; ?>>
 						<?php
 						foreach ($this->items as $i => $item) :
@@ -272,6 +259,10 @@ if ($menuType == '')
 						<?php endforeach; ?>
 						</tbody>
 					</table>
+					
+					<?php // load the pagination. ?>
+					<?php echo $this->pagination->getListFooter(); ?>
+
 					<?php // Load the batch processing form if user is allowed ?>
 					<?php if ($user->authorise('core.create', 'com_menus') || $user->authorise('core.edit', 'com_menus')) : ?>
 						<?php echo HTMLHelper::_(

--- a/administrator/components/com_menus/tmpl/items/modal.php
+++ b/administrator/components/com_menus/tmpl/items/modal.php
@@ -79,13 +79,6 @@ if (!empty($editor))
 						</th>
 					</tr>
 				</thead>
-				<tfoot>
-					<tr>
-						<td colspan="7">
-							<?php echo $this->pagination->getListFooter(); ?>
-						</td>
-					</tr>
-				</tfoot>
 				<tbody>
 				<?php foreach ($this->items as $i => $item) : ?>
 					<?php $uselessMenuItem = in_array($item->type, array('separator', 'heading', 'alias', 'url', 'container')); ?>
@@ -169,6 +162,10 @@ if (!empty($editor))
 				<?php endforeach; ?>
 				</tbody>
 			</table>
+
+			<?php // load the pagination. ?>
+			<?php echo $this->pagination->getListFooter(); ?>
+
 		<?php endif; ?>
 
 		<input type="hidden" name="task" value="">

--- a/administrator/components/com_menus/tmpl/menus/default.php
+++ b/administrator/components/com_menus/tmpl/menus/default.php
@@ -220,7 +220,7 @@ HTMLHelper::_('script', 'com_menus/admin-menus-default.min.js', array('version' 
 							<?php endforeach; ?>
 						</tbody>
 					</table>
-					
+
 					<?php // load the pagination. ?>
 					<?php echo $this->pagination->getListFooter(); ?>
 

--- a/administrator/components/com_menus/tmpl/menus/default.php
+++ b/administrator/components/com_menus/tmpl/menus/default.php
@@ -81,13 +81,6 @@ HTMLHelper::_('script', 'com_menus/admin-menus-default.min.js', array('version' 
 								</th>
 							</tr>
 						</thead>
-						<tfoot>
-							<tr>
-								<td colspan="15">
-									<?php echo $this->pagination->getListFooter(); ?>
-								</td>
-							</tr>
-						</tfoot>
 						<tbody>
 						<?php foreach ($this->items as $i => $item) :
 							$canEdit        = $user->authorise('core.edit',   'com_menus.menu.' . (int) $item->id);
@@ -227,6 +220,10 @@ HTMLHelper::_('script', 'com_menus/admin-menus-default.min.js', array('version' 
 							<?php endforeach; ?>
 						</tbody>
 					</table>
+					
+					<?php // load the pagination. ?>
+					<?php echo $this->pagination->getListFooter(); ?>
+
 				<?php endif; ?>
 
 				<input type="hidden" name="task" value="">

--- a/administrator/components/com_messages/tmpl/messages/default.php
+++ b/administrator/components/com_messages/tmpl/messages/default.php
@@ -50,13 +50,6 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 						</th>
 					</tr>
 				</thead>
-				<tfoot>
-					<tr>
-						<td colspan="5">
-							<?php echo $this->pagination->getListFooter(); ?>
-						</td>
-					</tr>
-				</tfoot>
 				<tbody>
 				<?php foreach ($this->items as $i => $item) :
 					$canChange = $user->authorise('core.edit.state', 'com_messages');
@@ -82,6 +75,10 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 					<?php endforeach; ?>
 				</tbody>
 			</table>
+					
+			<?php // load the pagination. ?>
+			<?php echo $this->pagination->getListFooter(); ?>
+
 		<?php endif; ?>
 		<div>
 			<input type="hidden" name="task" value="">

--- a/administrator/components/com_messages/tmpl/messages/default.php
+++ b/administrator/components/com_messages/tmpl/messages/default.php
@@ -75,7 +75,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 					<?php endforeach; ?>
 				</tbody>
 			</table>
-					
+
 			<?php // load the pagination. ?>
 			<?php echo $this->pagination->getListFooter(); ?>
 

--- a/administrator/components/com_modules/tmpl/modules/default.php
+++ b/administrator/components/com_modules/tmpl/modules/default.php
@@ -189,7 +189,7 @@ if ($saveOrder && !empty($this->items))
 					<?php endforeach; ?>
 				</tbody>
 			</table>
-					
+
 			<?php // load the pagination. ?>
 			<?php echo $this->pagination->getListFooter(); ?>
 

--- a/administrator/components/com_modules/tmpl/modules/default.php
+++ b/administrator/components/com_modules/tmpl/modules/default.php
@@ -31,7 +31,6 @@ if ($saveOrder && !empty($this->items))
 	$saveOrderingUrl = 'index.php?option=com_modules&task=modules.saveOrderAjax&tmpl=component' . Session::getFormToken() . '=1';
 	HTMLHelper::_('draggablelist.draggable');
 }
-$colSpan = $clientId === 1 ? 8 : 10;
 ?>
 <form action="<?php echo Route::_('index.php?option=com_modules'); ?>" method="post" name="adminForm" id="adminForm">
 	<div id="j-main-container" class="j-main-container">
@@ -80,13 +79,6 @@ $colSpan = $clientId === 1 ? 8 : 10;
 						</th>
 					</tr>
 				</thead>
-				<tfoot>
-					<tr>
-						<td colspan="<?php echo $colSpan; ?>">
-							<?php echo $this->pagination->getListFooter(); ?>
-						</td>
-					</tr>
-				</tfoot>
 				<tbody <?php if ($saveOrder) :?> class="js-draggable" data-url="<?php echo $saveOrderingUrl; ?>" data-direction="<?php echo strtolower($listDirn); ?>" data-nested="false"<?php endif; ?>>
 				<?php foreach ($this->items as $i => $item) :
 					$ordering   = ($listOrder == 'a.ordering');
@@ -197,6 +189,10 @@ $colSpan = $clientId === 1 ? 8 : 10;
 					<?php endforeach; ?>
 				</tbody>
 			</table>
+					
+			<?php // load the pagination. ?>
+			<?php echo $this->pagination->getListFooter(); ?>
+
 		<?php endif; ?>
 
 		<?php // Load the batch processing form. ?>

--- a/administrator/components/com_modules/tmpl/modules/modal.php
+++ b/administrator/components/com_modules/tmpl/modules/modal.php
@@ -68,13 +68,6 @@ $editor    = Factory::getApplication()->input->get('editor', '', 'cmd');
 					</th>
 				</tr>
 			</thead>
-			<tfoot>
-				<tr>
-					<td colspan="8">
-						<?php echo $this->pagination->getListFooter(); ?>
-					</td>
-				</tr>
-			</tfoot>
 			<tbody>
 				<?php
 				$iconStates = array(
@@ -120,6 +113,10 @@ $editor    = Factory::getApplication()->input->get('editor', '', 'cmd');
 			<?php endforeach; ?>
 			</tbody>
 		</table>
+
+		<?php // load the pagination. ?>
+		<?php echo $this->pagination->getListFooter(); ?>
+
 		<?php endif; ?>
 
 		<input type="hidden" name="task" value="">

--- a/administrator/components/com_newsfeeds/tmpl/newsfeeds/default.php
+++ b/administrator/components/com_newsfeeds/tmpl/newsfeeds/default.php
@@ -171,7 +171,7 @@ if ($saveOrder && !empty($this->items))
 							<?php endforeach; ?>
 						</tbody>
 					</table>
-					
+
 					<?php // load the pagination. ?>
 					<?php echo $this->pagination->getListFooter(); ?>
 

--- a/administrator/components/com_newsfeeds/tmpl/newsfeeds/default.php
+++ b/administrator/components/com_newsfeeds/tmpl/newsfeeds/default.php
@@ -86,13 +86,6 @@ if ($saveOrder && !empty($this->items))
 								</th>
 							</tr>
 						</thead>
-						<tfoot>
-							<tr>
-								<td colspan="11">
-									<?php echo $this->pagination->getListFooter(); ?>
-								</td>
-							</tr>
-						</tfoot>
 						<tbody <?php if ($saveOrder) :?> class="js-draggable" data-url="<?php echo $saveOrderingUrl; ?>" data-direction="<?php echo strtolower($listDirn); ?>" data-nested="true"<?php endif; ?>>
 						<?php foreach ($this->items as $i => $item) :
 							$ordering   = ($listOrder == 'a.ordering');
@@ -178,6 +171,10 @@ if ($saveOrder && !empty($this->items))
 							<?php endforeach; ?>
 						</tbody>
 					</table>
+					
+					<?php // load the pagination. ?>
+					<?php echo $this->pagination->getListFooter(); ?>
+
 					<?php // Load the batch processing form if user is allowed ?>
 					<?php if ($user->authorise('core.create', 'com_newsfeeds')
 						&& $user->authorise('core.edit', 'com_newsfeeds')

--- a/administrator/components/com_newsfeeds/tmpl/newsfeeds/modal.php
+++ b/administrator/components/com_newsfeeds/tmpl/newsfeeds/modal.php
@@ -58,13 +58,6 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 						</th>
 					</tr>
 				</thead>
-				<tfoot>
-					<tr>
-						<td colspan="5">
-							<?php echo $this->pagination->getListFooter(); ?>
-						</td>
-					</tr>
-				</tfoot>
 				<tbody>
 				<?php
 				$iconStates = array(
@@ -119,6 +112,10 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 				<?php endforeach; ?>
 				</tbody>
 			</table>
+
+			<?php // load the pagination. ?>
+			<?php echo $this->pagination->getListFooter(); ?>
+
 		<?php endif; ?>
 
 		<input type="hidden" name="task" value="">

--- a/administrator/components/com_plugins/tmpl/plugins/default.php
+++ b/administrator/components/com_plugins/tmpl/plugins/default.php
@@ -129,7 +129,7 @@ if ($saveOrder)
 				<?php endforeach; ?>
 				</tbody>
 			</table>
-					
+
 			<?php // load the pagination. ?>
 			<?php echo $this->pagination->getListFooter(); ?>
 

--- a/administrator/components/com_plugins/tmpl/plugins/default.php
+++ b/administrator/components/com_plugins/tmpl/plugins/default.php
@@ -68,13 +68,6 @@ if ($saveOrder)
 						</th>
 					</tr>
 				</thead>
-				<tfoot>
-					<tr>
-						<td colspan="8">
-							<?php echo $this->pagination->getListFooter(); ?>
-						</td>
-					</tr>
-				</tfoot>
                 <tbody <?php if ($saveOrder) :?> class="js-draggable" data-url="<?php echo $saveOrderingUrl; ?>" data-direction="<?php echo strtolower($listDirn); ?>" data-nested="true"<?php endif; ?>>
 				<?php foreach ($this->items as $i => $item) :
 					$ordering   = ($listOrder == 'ordering');
@@ -136,6 +129,10 @@ if ($saveOrder)
 				<?php endforeach; ?>
 				</tbody>
 			</table>
+					
+			<?php // load the pagination. ?>
+			<?php echo $this->pagination->getListFooter(); ?>
+
 		<?php endif; ?>
 
 		<input type="hidden" name="task" value="">

--- a/administrator/components/com_redirect/tmpl/links/default.php
+++ b/administrator/components/com_redirect/tmpl/links/default.php
@@ -133,7 +133,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 					<?php endforeach; ?>
 				</tbody>
 			</table>
-					
+
 			<?php // load the pagination. ?>
 			<?php echo $this->pagination->getListFooter(); ?>
 

--- a/administrator/components/com_redirect/tmpl/links/default.php
+++ b/administrator/components/com_redirect/tmpl/links/default.php
@@ -89,13 +89,6 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 						</th>
 					</tr>
 				</thead>
-				<tfoot>
-					<tr>
-						<td colspan="9">
-							<?php echo $this->pagination->getListFooter(); ?>
-						</td>
-					</tr>
-				</tfoot>
 				<tbody>
 				<?php foreach ($this->items as $i => $item) :
 					$canEdit   = $user->authorise('core.edit',       'com_redirect');
@@ -140,6 +133,10 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 					<?php endforeach; ?>
 				</tbody>
 			</table>
+					
+			<?php // load the pagination. ?>
+			<?php echo $this->pagination->getListFooter(); ?>
+
 		<?php endif; ?>
 
 		<?php if (!empty($this->items)) : ?>

--- a/administrator/components/com_search/tmpl/searches/default.php
+++ b/administrator/components/com_search/tmpl/searches/default.php
@@ -66,7 +66,7 @@ $listDirn = $this->escape($this->state->get('list.direction'));
 			<?php endforeach; ?>
 			</tbody>
 		</table>
-					
+
 		<?php // load the pagination. ?>
 		<?php echo $this->pagination->getListFooter(); ?>
 

--- a/administrator/components/com_search/tmpl/searches/default.php
+++ b/administrator/components/com_search/tmpl/searches/default.php
@@ -43,13 +43,6 @@ $listDirn = $this->escape($this->state->get('list.direction'));
 					</th>
 				</tr>
 			</thead>
-			<tfoot>
-				<tr>
-					<td colspan="3">
-						<?php echo $this->pagination->getListFooter(); ?>
-					</td>
-				</tr>
-			</tfoot>
 			<tbody>
 			<?php foreach ($this->items as $i => $item) : ?>
 				<tr class="row<?php echo $i % 2; ?>">
@@ -73,6 +66,10 @@ $listDirn = $this->escape($this->state->get('list.direction'));
 			<?php endforeach; ?>
 			</tbody>
 		</table>
+					
+		<?php // load the pagination. ?>
+		<?php echo $this->pagination->getListFooter(); ?>
+
 		<?php endif; ?>
 		<input type="hidden" name="task" value="">
 		<input type="hidden" name="boxchecked" value="0">

--- a/administrator/components/com_tags/tmpl/tags/default.php
+++ b/administrator/components/com_tags/tmpl/tags/default.php
@@ -34,7 +34,6 @@ $parts     = explode('.', $extension);
 $component = $parts[0];
 $section   = null;
 $mode      = false;
-$columns   = 7;
 
 if (count($parts) > 1)
 {
@@ -89,25 +88,21 @@ if ($saveOrder && !empty($this->items))
 							<th scope="col" style="width:1%" class="nowrap text-center d-none d-md-table-cell">
 								<span class="icon-publish hasTooltip" aria-hidden="true" title="<?php echo Text::_('COM_TAGS_COUNT_PUBLISHED_ITEMS'); ?>"><span class="sr-only"><?php echo Text::_('COM_TAGS_COUNT_PUBLISHED_ITEMS'); ?></span></span>
 							</th>
-							<?php $columns++; ?>
 						<?php endif; ?>
 						<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_unpublished')) : ?>
 							<th scope="col" style="width:1%" class="nowrap text-center d-none d-md-table-cell">
 								<span class="icon-unpublish hasTooltip" aria-hidden="true" title="<?php echo Text::_('COM_TAGS_COUNT_UNPUBLISHED_ITEMS'); ?>"><span class="sr-only"><?php echo Text::_('COM_TAGS_COUNT_UNPUBLISHED_ITEMS'); ?></span></span>
 							</th>
-							<?php $columns++; ?>
 						<?php endif; ?>
 						<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_archived')) : ?>
 							<th scope="col" style="width:1%" class="nowrap text-center d-none d-md-table-cell">
 								<span class="icon-archive hasTooltip" aria-hidden="true" title="<?php echo Text::_('COM_TAGS_COUNT_ARCHIVED_ITEMS'); ?>"><span class="sr-only"><?php echo Text::_('COM_TAGS_COUNT_ARCHIVED_ITEMS'); ?></span></span>
 							</th>
-							<?php $columns++; ?>
 						<?php endif; ?>
 						<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_trashed')) : ?>
 							<th scope="col" style="width:1%" class="nowrap text-center d-none d-md-table-cell">
 								<span class="icon-trash hasTooltip" aria-hidden="true" title="<?php echo Text::_('COM_TAGS_COUNT_TRASHED_ITEMS'); ?>"><span class="sr-only"><?php echo Text::_('COM_TAGS_COUNT_TRASHED_ITEMS'); ?></span></span>
 							</th>
-							<?php $columns++; ?>
 						<?php endif; ?>
  
 						<th scope="col" style="width:10%" class="nowrap d-none d-md-table-cell text-center">
@@ -123,13 +118,6 @@ if ($saveOrder && !empty($this->items))
 						</th>
 					</tr>
 				</thead>
-				<tfoot>
-					<tr>
-						<td colspan="<?php echo $columns; ?>">
-							<?php echo $this->pagination->getListFooter(); ?>
-						</td>
-					</tr>
-				</tfoot>
 				<tbody <?php if ($saveOrder) :?> class="js-draggable" data-url="<?php echo $saveOrderingUrl; ?>" data-direction="<?php echo strtolower($listDirn); ?>" data-nested="true"<?php endif; ?>>
 				<?php
 				foreach ($this->items as $i => $item) :
@@ -254,6 +242,10 @@ if ($saveOrder && !empty($this->items))
 				<?php endforeach; ?>
 				</tbody>
 			</table>
+					
+			<?php // load the pagination. ?>
+			<?php echo $this->pagination->getListFooter(); ?>
+
 			<?php // Load the batch processing form if user is allowed ?>
 			<?php if ($user->authorise('core.create', 'com_tags')
 				&& $user->authorise('core.edit', 'com_tags')

--- a/administrator/components/com_tags/tmpl/tags/default.php
+++ b/administrator/components/com_tags/tmpl/tags/default.php
@@ -242,7 +242,7 @@ if ($saveOrder && !empty($this->items))
 				<?php endforeach; ?>
 				</tbody>
 			</table>
-					
+
 			<?php // load the pagination. ?>
 			<?php echo $this->pagination->getListFooter(); ?>
 

--- a/administrator/components/com_templates/tmpl/styles/default.php
+++ b/administrator/components/com_templates/tmpl/styles/default.php
@@ -136,7 +136,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 							<?php endforeach; ?>
 						</tbody>
 					</table>
-					
+
 					<?php // load the pagination. ?>
 					<?php echo $this->pagination->getListFooter(); ?>
 

--- a/administrator/components/com_templates/tmpl/styles/default.php
+++ b/administrator/components/com_templates/tmpl/styles/default.php
@@ -26,7 +26,6 @@ $user      = Factory::getUser();
 $clientId = (int) $this->state->get('client_id', 0);
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
-$colSpan = $clientId === 1 ? 5 : 6;
 ?>
 <form action="<?php echo Route::_('index.php?option=com_templates&view=styles'); ?>" method="post" name="adminForm" id="adminForm">
 	<div class="row">
@@ -62,13 +61,6 @@ $colSpan = $clientId === 1 ? 5 : 6;
 								</th>
 							</tr>
 						</thead>
-						<tfoot>
-							<tr>
-								<td colspan="<?php echo $colSpan; ?>">
-									<?php echo $this->pagination->getListFooter(); ?>
-								</td>
-							</tr>
-						</tfoot>
 						<tbody>
 							<?php foreach ($this->items as $i => $item) :
 								$canCreate = $user->authorise('core.create',     'com_templates');
@@ -144,6 +136,10 @@ $colSpan = $clientId === 1 ? 5 : 6;
 							<?php endforeach; ?>
 						</tbody>
 					</table>
+					
+					<?php // load the pagination. ?>
+					<?php echo $this->pagination->getListFooter(); ?>
+
 				<?php endif; ?>
 
 				<input type="hidden" name="task" value="">

--- a/administrator/components/com_templates/tmpl/templates/default.php
+++ b/administrator/components/com_templates/tmpl/templates/default.php
@@ -93,7 +93,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 							<?php endforeach; ?>
 						</tbody>
 					</table>
-					
+
 					<?php // load the pagination. ?>
 					<?php echo $this->pagination->getListFooter(); ?>
 

--- a/administrator/components/com_templates/tmpl/templates/default.php
+++ b/administrator/components/com_templates/tmpl/templates/default.php
@@ -48,13 +48,6 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 								</th>
 							</tr>
 						</thead>
-						<tfoot>
-							<tr>
-								<td colspan="5">
-									<?php echo $this->pagination->getListFooter(); ?>
-								</td>
-							</tr>
-						</tfoot>
 						<tbody>
 						<?php foreach ($this->items as $i => $item) : ?>
 							<tr class="row<?php echo $i % 2; ?>">
@@ -100,6 +93,10 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 							<?php endforeach; ?>
 						</tbody>
 					</table>
+					
+					<?php // load the pagination. ?>
+					<?php echo $this->pagination->getListFooter(); ?>
+
 				<?php endif; ?>
 
 				<input type="hidden" name="task" value="">

--- a/administrator/components/com_users/tmpl/debuggroup/default.php
+++ b/administrator/components/com_users/tmpl/debuggroup/default.php
@@ -19,7 +19,6 @@ HTMLHelper::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
-$colSpan   = 4 + count($this->actions);
 ?>
 <form action="<?php echo Route::_('index.php?option=com_users&view=debuggroup&group_id=' . (int) $this->state->get('group_id')); ?>" method="post" name="adminForm" id="adminForm">
 	<div id="j-main-container" class="j-main-container">
@@ -47,20 +46,6 @@ $colSpan   = 4 + count($this->actions);
 						</th>
 					</tr>
 				</thead>
-				<tfoot>
-					<tr>
-						<td colspan="<?php echo $colSpan; ?>">
-							<?php echo $this->pagination->getListFooter(); ?>
-							<div class="legend">
-								<?php echo Text::_('COM_USERS_DEBUG_LEGEND'); ?>
-								<span class="text-danger icon-ban-circle"></span><?php echo Text::_('COM_USERS_DEBUG_IMPLICIT_DENY'); ?>&nbsp;
-								<span class="text-success icon-ok"></span><?php echo Text::_('COM_USERS_DEBUG_EXPLICIT_ALLOW'); ?>&nbsp;
-								<span class="icon-remove"></span><?php echo Text::_('COM_USERS_DEBUG_EXPLICIT_DENY'); ?>
-								<br><br>
-							</div>
-						</td>
-					</tr>
-				</tfoot>
 				<tbody>
 					<?php foreach ($this->items as $i => $item) : ?>
 						<tr class="row0">
@@ -103,6 +88,16 @@ $colSpan   = 4 + count($this->actions);
 					<?php endforeach; ?>
 				</tbody>
 			</table>
+			<div class="legend">
+				<?php echo Text::_('COM_USERS_DEBUG_LEGEND'); ?>
+				<span class="text-danger icon-ban-circle"></span><?php echo Text::_('COM_USERS_DEBUG_IMPLICIT_DENY'); ?>&nbsp;
+				<span class="text-success icon-ok"></span><?php echo Text::_('COM_USERS_DEBUG_EXPLICIT_ALLOW'); ?>&nbsp;
+				<span class="icon-remove"></span><?php echo Text::_('COM_USERS_DEBUG_EXPLICIT_DENY'); ?>
+			</div>
+
+			<?php // load the pagination. ?>
+			<?php echo $this->pagination->getListFooter(); ?>
+
 		</div>
 		<input type="hidden" name="task" value="">
 		<input type="hidden" name="boxchecked" value="0">

--- a/administrator/components/com_users/tmpl/debuguser/default.php
+++ b/administrator/components/com_users/tmpl/debuguser/default.php
@@ -19,7 +19,6 @@ HTMLHelper::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
-$colSpan   = 4 + count($this->actions);
 ?>
 <form action="<?php echo Route::_('index.php?option=com_users&view=debuguser&user_id=' . (int) $this->state->get('user_id')); ?>" method="post" name="adminForm" id="adminForm">
 	<div id="j-main-container" class="j-main-container">
@@ -47,20 +46,6 @@ $colSpan   = 4 + count($this->actions);
 						</th>
 					</tr>
 				</thead>
-				<tfoot>
-					<tr>
-						<td colspan="<?php echo $colSpan; ?>">
-							<?php echo $this->pagination->getListFooter(); ?>
-							<div class="legend">
-								<?php echo Text::_('COM_USERS_DEBUG_LEGEND'); ?>
-								<span class="text-danger icon-ban-circle"></span><?php echo Text::_('COM_USERS_DEBUG_IMPLICIT_DENY'); ?>&nbsp;
-								<span class="icon-ok"></span><?php echo Text::_('COM_USERS_DEBUG_EXPLICIT_ALLOW'); ?>&nbsp;
-								<span class="icon-remove icon-remove"></span><?php echo Text::_('COM_USERS_DEBUG_EXPLICIT_DENY'); ?>
-								<br><br>
-							</div>
-						</td>
-					</tr>
-				</tfoot>
 				<tbody>
 					<?php foreach ($this->items as $i => $item) : ?>
 						<tr class="row0">
@@ -103,6 +88,16 @@ $colSpan   = 4 + count($this->actions);
 					<?php endforeach; ?>
 				</tbody>
 			</table>
+			<div class="legend">
+				<?php echo Text::_('COM_USERS_DEBUG_LEGEND'); ?>
+				<span class="text-danger icon-ban-circle"></span><?php echo Text::_('COM_USERS_DEBUG_IMPLICIT_DENY'); ?>&nbsp;
+				<span class="icon-ok"></span><?php echo Text::_('COM_USERS_DEBUG_EXPLICIT_ALLOW'); ?>&nbsp;
+				<span class="icon-remove icon-remove"></span><?php echo Text::_('COM_USERS_DEBUG_EXPLICIT_DENY'); ?>
+			</div>
+
+			<?php // load the pagination. ?>
+			<?php echo $this->pagination->getListFooter(); ?>
+
 		</div>
 		<input type="hidden" name="task" value="">
 		<input type="hidden" name="boxchecked" value="0">

--- a/administrator/components/com_users/tmpl/groups/default.php
+++ b/administrator/components/com_users/tmpl/groups/default.php
@@ -63,13 +63,6 @@ HTMLHelper::_('script', 'com_users/admin-users-groups.min.js', array('version' =
 								</th>
 							</tr>
 						</thead>
-						<tfoot>
-							<tr>
-								<td colspan="5">
-									<?php echo $this->pagination->getListFooter(); ?>
-								</td>
-							</tr>
-						</tfoot>
 						<tbody>
 						<?php foreach ($this->items as $i => $item) :
 							$canCreate = $user->authorise('core.create', 'com_users');
@@ -116,6 +109,10 @@ HTMLHelper::_('script', 'com_users/admin-users-groups.min.js', array('version' =
 							<?php endforeach; ?>
 						</tbody>
 					</table>
+					
+					<?php // load the pagination. ?>
+					<?php echo $this->pagination->getListFooter(); ?>
+
 				<?php endif; ?>
 
 				<input type="hidden" name="task" value="">

--- a/administrator/components/com_users/tmpl/groups/default.php
+++ b/administrator/components/com_users/tmpl/groups/default.php
@@ -109,7 +109,7 @@ HTMLHelper::_('script', 'com_users/admin-users-groups.min.js', array('version' =
 							<?php endforeach; ?>
 						</tbody>
 					</table>
-					
+
 					<?php // load the pagination. ?>
 					<?php echo $this->pagination->getListFooter(); ?>
 

--- a/administrator/components/com_users/tmpl/levels/default.php
+++ b/administrator/components/com_users/tmpl/levels/default.php
@@ -64,13 +64,6 @@ if ($saveOrder)
 								</th>
 							</tr>
 						</thead>
-						<tfoot>
-							<tr>
-								<td colspan="5">
-									<?php echo $this->pagination->getListFooter(); ?>
-								</td>
-							</tr>
-						</tfoot>
 						<tbody>
 						<?php $count = count($this->items); ?>
 						<?php foreach ($this->items as $i => $item) :
@@ -120,6 +113,10 @@ if ($saveOrder)
 						<?php endforeach; ?>
 						</tbody>
 					</table>
+					
+					<?php // load the pagination. ?>
+					<?php echo $this->pagination->getListFooter(); ?>
+
 				<?php endif; ?>
 				<input type="hidden" name="task" value="">
 				<input type="hidden" name="boxchecked" value="0">

--- a/administrator/components/com_users/tmpl/levels/default.php
+++ b/administrator/components/com_users/tmpl/levels/default.php
@@ -113,7 +113,7 @@ if ($saveOrder)
 						<?php endforeach; ?>
 						</tbody>
 					</table>
-					
+
 					<?php // load the pagination. ?>
 					<?php echo $this->pagination->getListFooter(); ?>
 

--- a/administrator/components/com_users/tmpl/notes/default.php
+++ b/administrator/components/com_users/tmpl/notes/default.php
@@ -57,13 +57,6 @@ $listDirn   = $this->escape($this->state->get('list.direction'));
 							</th>
 						</tr>
 					</thead>
-					<tfoot>
-						<tr>
-							<td colspan="6">
-								<?php echo $this->pagination->getListFooter(); ?>
-							</td>
-						</tr>
-					</tfoot>
 					<tbody>
 					<?php foreach ($this->items as $i => $item) :
 						$canEdit    = $user->authorise('core.edit',       'com_users.category.' . $item->catid);
@@ -113,6 +106,10 @@ $listDirn   = $this->escape($this->state->get('list.direction'));
 					<?php endforeach; ?>
 					</tbody>
 				</table>
+					
+				<?php // load the pagination. ?>
+				<?php echo $this->pagination->getListFooter(); ?>
+
 				<?php endif; ?>
 
 				<div>

--- a/administrator/components/com_users/tmpl/notes/default.php
+++ b/administrator/components/com_users/tmpl/notes/default.php
@@ -106,7 +106,7 @@ $listDirn   = $this->escape($this->state->get('list.direction'));
 					<?php endforeach; ?>
 					</tbody>
 				</table>
-					
+
 				<?php // load the pagination. ?>
 				<?php echo $this->pagination->getListFooter(); ?>
 

--- a/administrator/components/com_users/tmpl/users/default.php
+++ b/administrator/components/com_users/tmpl/users/default.php
@@ -74,13 +74,6 @@ $debugUsers = $this->state->get('params')->get('debugUsers', 1);
 								</th>
 							</tr>
 						</thead>
-						<tfoot>
-							<tr>
-								<td colspan="10">
-									<?php echo $this->pagination->getListFooter(); ?>
-								</td>
-							</tr>
-						</tfoot>
 						<tbody>
 						<?php foreach ($this->items as $i => $item) :
 							$canEdit   = $this->canDo->get('core.edit');
@@ -175,6 +168,10 @@ $debugUsers = $this->state->get('params')->get('debugUsers', 1);
 							<?php endforeach; ?>
 						</tbody>
 					</table>
+					
+					<?php // load the pagination. ?>
+					<?php echo $this->pagination->getListFooter(); ?>
+
 					<?php // Load the batch processing form if user is allowed ?>
 					<?php if ($loggeduser->authorise('core.create', 'com_users')
 						&& $loggeduser->authorise('core.edit', 'com_users')

--- a/administrator/components/com_users/tmpl/users/default.php
+++ b/administrator/components/com_users/tmpl/users/default.php
@@ -168,7 +168,7 @@ $debugUsers = $this->state->get('params')->get('debugUsers', 1);
 							<?php endforeach; ?>
 						</tbody>
 					</table>
-					
+
 					<?php // load the pagination. ?>
 					<?php echo $this->pagination->getListFooter(); ?>
 

--- a/administrator/components/com_users/tmpl/users/modal.php
+++ b/administrator/components/com_users/tmpl/users/modal.php
@@ -65,13 +65,6 @@ $onClick         = "window.parent.jSelectUser(this);window.parent.Joomla.Modal.g
 					</th>
 				</tr>
 			</thead>
-			<tfoot>
-				<tr>
-					<td colspan="6">
-						<?php echo $this->pagination->getListFooter(); ?>
-					</td>
-				</tr>
-			</tfoot>
 			<tbody>
                 <?php $i = 0; ?>
                 <?php foreach ($this->items as $item) : ?>
@@ -101,6 +94,10 @@ $onClick         = "window.parent.jSelectUser(this);window.parent.Joomla.Modal.g
 				<?php endforeach; ?>
 			</tbody>
 		</table>
+
+		<?php // load the pagination. ?>
+		<?php echo $this->pagination->getListFooter(); ?>
+
 		<?php endif; ?>
 		<input type="hidden" name="task" value="">
 		<input type="hidden" name="field" value="<?php echo $this->escape($field); ?>">


### PR DESCRIPTION
All current views with pagination in the administration have mistakenly had the pagination placed in the table footer. This is not correct as the table footer is only for use with summarising the data in the table.

This pr moves the pagination to immediately after the rendering of the table.

As a result we can also remove the column counts as we dont have a need for them (and they weren't used consistently anyway)

Confirmed by the a11y team @chmst @zwiastunsw 

A future pr will look at restoring the a11y of the pagination itself which has been lost in the movee from j3

### Testing
make sure pagination works as before