### PR TITLE
Set the full classname to use

### DIFF
--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -927,7 +927,7 @@ abstract class AdminModel extends FormModel
 
 		// Convert to the CMSObject before adding other data.
 		$properties = $table->getProperties(1);
-		$item = ArrayHelper::toObject($properties, 'CMSObject');
+		$item = ArrayHelper::toObject($properties, 'Joomla\CMS\Object\CMSObject');
 
 		if (property_exists($item, 'params'))
 		{


### PR DESCRIPTION
Pull Request for Issue #21299 .

### Summary of Changes
This change sets the object to the full classname


### Testing Instructions
1. Go to Articles
2. Click on New
3. The error `Class 'CMSObject' not found`
4. Apply the patch
5. Reload the page or Click on New again
6. The article loads now.


### Expected result
The article loads


### Actual result
The error Class 'CMSObject' not found shows up


### Documentation Changes Required
None
