### PR TITLE
[3.9] JFilterInput' not found when uploading an image through Media manager

### DIFF
--- a/libraries/src/Filesystem/File.php
+++ b/libraries/src/Filesystem/File.php
@@ -522,7 +522,7 @@ class File
 	 * @param   string   $dest             The path (including filename) to move the uploaded file to
 	 * @param   boolean  $use_streams      True to use streams
 	 * @param   boolean  $allow_unsafe     Allow the upload of unsafe files
-	 * @param   boolean  $safeFileOptions  Options to JFilterInput::isSafeFile
+	 * @param   boolean  $safeFileOptions  Options to \JFilterInput::isSafeFile
 	 *
 	 * @return  boolean  True on success
 	 *
@@ -540,7 +540,7 @@ class File
 				'size'     => '',
 			);
 
-			$isSafe = JFilterInput::isSafeFile($descriptor, $safeFileOptions);
+			$isSafe = \JFilterInput::isSafeFile($descriptor, $safeFileOptions);
 
 			if (!$isSafe)
 			{


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/21288
### Summary of Changes
adding basic namespacing

### Testing Instructions

- Going to Content > Media.
- Uploading new image, opens new area to browse for new image.
- Find your file on computer and click on upload.

### Expected result
The image uploads and is added to the library.
### Actual result
Error shows up after steps above saying "Class 'Joomla\CMS\Filesystem\JFilterInput' not found"
### Documentation Changes Required
no


