### PR TITLE
Fixed the double import of InputFilter

### DIFF
--- a/libraries/src/Filesystem/File.php
+++ b/libraries/src/Filesystem/File.php
@@ -10,16 +10,14 @@ namespace Joomla\CMS\Filesystem;
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\CMS\Factory;
-use Joomla\CMS\Log\Log;
-use Joomla\CMS\Language\Text;
-use Joomla\CMS\Filter\InputFilter;
-use Joomla\CMS\Filesystem\Path;
-use Joomla\CMS\Filesystem\Wrapper\PathWrapper;
-use Joomla\CMS\Filesystem\Wrapper\FolderWrapper;
 use Joomla\CMS\Client\ClientHelper;
 use Joomla\CMS\Client\FtpClient;
+use Joomla\CMS\Factory;
+use Joomla\CMS\Filesystem\Wrapper\FolderWrapper;
+use Joomla\CMS\Filesystem\Wrapper\PathWrapper;
 use Joomla\CMS\Filter\InputFilter;
+use Joomla\CMS\Language\Text;
+use Joomla\CMS\Log\Log;
 
 /**
  * A File handling class


### PR DESCRIPTION
Pull Request for Issue #21174

### Summary of Changes
This removes the double import statement of `use Joomla\CMS\Filter\InputFilter;` causing a fatal error.

In addition, the import statements are now alphabetically ordered, should help prevent these kind of issues :)

### Testing Instructions
1. Try to login to Joomla in backend, you get a fatal error
2. Apply patch
3. You get login screen


### Expected result
Login screen in backend


### Actual result
Fatal error: Cannot use Joomla\CMS\Filter\InputFilter as InputFilter because the name is already in use in /usr/local/var/www/joomlacms/libraries/src/Filesystem/File.php on line 22


### Documentation Changes Required
None

@laoneo You merged #21174 so calling you here.
