### PR TITLE
Trigger "change" event after updating user field input value

### DIFF
--- a/media/system/webcomponents/js/joomla-field-user.js
+++ b/media/system/webcomponents/js/joomla-field-user.js
@@ -98,6 +98,8 @@
     setValue(value, name) {
       this.input.setAttribute('value', value);
       this.inputName.setAttribute('value', name || value);
+      
+      this.input.dispatchEvent(new Event('change'));
     }
   }
 


### PR DESCRIPTION
### Summary of Changes

The onchange event is not triggered on a form element when the element's value is updated programmatically, only on user input, therefore a "change" event must be dispatched when the user id field value is set.

Without dispatching a change event, the change event listener created for the data-onchange attribute is not triggered, and the associated function is not called. 

### Testing Instructions

Edit administrator/components/com_content/forms/article.xml and set an onchange attribute for the create_by field, eg:

```xml
<field 
    name="created_by" 
    type="user"
    label="COM_CONTENT_FIELD_CREATED_BY_LABEL"
    onchange="(function(){console.log('change')})()" 
/>
```

Create or edit an article, and in the Options tab, select a new user for the Created By field.

### Expected result

In the browser console, "change" should be displayed when the new user is selected.

### Actual result

Nothing is displayed in the console as a change event is not triggered.

### Documentation Changes Required

None.
