### PR TITLE
[4.0] Error in Joomla update. Invalid Ajax data. Fix #21160

### DIFF
--- a/administrator/components/com_joomlaupdate/restore_finalisation.php
+++ b/administrator/components/com_joomlaupdate/restore_finalisation.php
@@ -5,184 +5,194 @@
  *
  * @copyright   Copyright (C) 2005 - 2018 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ *
+ * Important Notes:
+ * - Unlike other files, this file requires multiple namespace declarations in order to overload core classes during the update process
+ * - Also unlike other files, the normal constant defined checks must be within the global namespace declaration and can't be outside of it
  */
 
-// Require the restoration environment or fail cold. Prevents direct web access.
-defined('_AKEEBA_RESTORATION') or die();
-
-// Fake a miniature Joomla environment
-if (!defined('_JEXEC'))
+namespace
 {
-	define('_JEXEC', 1);
-}
+	// Require the restoration environment or fail cold. Prevents direct web access.
+	defined('_AKEEBA_RESTORATION') or die();
 
-use Joomla\CMS\Language\Text;
-
-if (!function_exists('jimport'))
-{
-	/**
-	 * We don't use it but the post-update script is using it anyway, so LET'S FAKE IT!
-	 *
-	 * @param   string  $path  A dot syntax path.
-	 * @param   string  $base  Search this directory for the class.
-	 *
-	 * @return  boolean  True on success.
-	 *
-	 * @since   11.1
-	 */
-	function jimport($path, $base = null)
+	// Fake a miniature Joomla environment
+	if (!defined('_JEXEC'))
 	{
-		// Do nothing
+		define('_JEXEC', 1);
 	}
-}
 
-// Fake the JFile class, mapping it to Restore's post-processing class
-if (!class_exists('JFile'))
-{
-	/**
-	 * JFile mock class proxing behaviour in the post-upgrade script to that of either native PHP or restore.php
-	 *
-	 * @since  3.5.1
-	 */
-	abstract class JFile
+	if (!function_exists('jimport'))
 	{
 		/**
-		 * Proxies checking a folder exists to the native php version
+		 * We don't use it but the post-update script is using it anyway, so LET'S FAKE IT!
 		 *
-		 * @param   string  $fileName  The path to the file to be checked
+		 * @param   string  $path  A dot syntax path.
+		 * @param   string  $base  Search this directory for the class.
 		 *
-		 * @return  boolean
+		 * @return  boolean  True on success.
 		 *
-		 * @since   3.5.1
+		 * @since   11.1
 		 */
-		public static function exists($fileName)
+		function jimport($path, $base = null)
 		{
-			return @file_exists($fileName);
-		}
-
-		/**
-		 * Proxies deleting a file to the restore.php version
-		 *
-		 * @param   string  $fileName  The path to the file to be deleted
-		 *
-		 * @return  boolean
-		 *
-		 * @since   3.5.1
-		 */
-		public static function delete($fileName)
-		{
-			$postproc = AKFactory::getPostProc();
-			$postproc->unlink($fileName);
+			// Do nothing
 		}
 	}
-}
 
-// Fake the Folder class, mapping it to Restore's post-processing class
-if (!class_exists('Folder'))
-{
-	/**
-	 * Folder mock class proxing behaviour in the post-upgrade script to that of either native PHP or restore.php
-	 *
-	 * @since  3.5.1
-	 */
-	abstract class Folder
+	if (!function_exists('finalizeRestore'))
 	{
 		/**
-		 * Proxies checking a folder exists to the native php version
+		 * Run part of the Joomla! finalisation script, namely the part that cleans up unused files/folders
 		 *
-		 * @param   string  $folderName  The path to the folder to be checked
-		 *
-		 * @return  boolean
-		 *
-		 * @since   3.5.1
-		 */
-		public static function exists($folderName)
-		{
-			return @is_dir($folderName);
-		}
-
-		/**
-		 * Proxies deleting a folder to the restore.php version
-		 *
-		 * @param   string  $folderName  The path to the folder to be deleted
+		 * @param   string  $siteRoot     The root to the Joomla! site
+		 * @param   string  $restorePath  The base path to restore.php
 		 *
 		 * @return  void
 		 *
 		 * @since   3.5.1
 		 */
-		public static function delete($folderName)
+		function finalizeRestore($siteRoot, $restorePath)
 		{
-			recursive_remove_directory($folderName);
+			if (!defined('JPATH_ROOT'))
+			{
+				define('JPATH_ROOT', $siteRoot);
+			}
+
+			$filePath = JPATH_ROOT . '/administrator/components/com_admin/script.php';
+
+			if (file_exists($filePath))
+			{
+				require_once $filePath;
+			}
+
+			// Make sure Joomla!'s code can figure out which files exist and need be removed
+			clearstatcache();
+
+			// Remove obsolete files - prevents errors occuring in some system plugins
+			if (class_exists('JoomlaInstallerScript'))
+			{
+				(new JoomlaInstallerScript)->deleteUnexistingFiles();
+			}
+
+			// Clear OPcache
+			if (function_exists('opcache_reset'))
+			{
+				opcache_reset();
+			}
 		}
 	}
 }
 
-// Fake the Text class - we aren't going to show errors to people anyhow
-if (!class_exists('Text'))
+namespace Joomla\CMS\Filesystem
 {
-	/**
-	 * Text mock class proxing behaviour in the post-upgrade script to that of either native PHP or restore.php
-	 *
-	 * @since  3.5.1
-	 */
-	abstract class Text
+	// Fake the JFile class, mapping it to Restore's post-processing class
+	if (!class_exists('File'))
 	{
 		/**
-		 * No need for translations in a non-interactive script, so always return an empty string here
+		 * JFile mock class proxing behaviour in the post-upgrade script to that of either native PHP or restore.php
 		 *
-		 * @param   string  $text  A language constant
-		 *
-		 * @return  string
-		 *
-		 * @since   3.5.1
+		 * @since  3.5.1
 		 */
-		public static function sprintf($text)
+		abstract class File
 		{
-			return '';
+			/**
+			 * Proxies checking a folder exists to the native php version
+			 *
+			 * @param   string  $fileName  The path to the file to be checked
+			 *
+			 * @return  boolean
+			 *
+			 * @since   3.5.1
+			 */
+			public static function exists($fileName)
+			{
+				return @file_exists($fileName);
+			}
+
+			/**
+			 * Proxies deleting a file to the restore.php version
+			 *
+			 * @param   string  $fileName  The path to the file to be deleted
+			 *
+			 * @return  boolean
+			 *
+			 * @since   3.5.1
+			 */
+			public static function delete($fileName)
+			{
+				$postproc = AKFactory::getPostProc();
+				$postproc->unlink($fileName);
+			}
+		}
+	}
+
+	// Fake the Folder class, mapping it to Restore's post-processing class
+	if (!class_exists('Folder'))
+	{
+		/**
+		 * Folder mock class proxing behaviour in the post-upgrade script to that of either native PHP or restore.php
+		 *
+		 * @since  3.5.1
+		 */
+		abstract class Folder
+		{
+			/**
+			 * Proxies checking a folder exists to the native php version
+			 *
+			 * @param   string  $folderName  The path to the folder to be checked
+			 *
+			 * @return  boolean
+			 *
+			 * @since   3.5.1
+			 */
+			public static function exists($folderName)
+			{
+				return @is_dir($folderName);
+			}
+
+			/**
+			 * Proxies deleting a folder to the restore.php version
+			 *
+			 * @param   string  $folderName  The path to the folder to be deleted
+			 *
+			 * @return  void
+			 *
+			 * @since   3.5.1
+			 */
+			public static function delete($folderName)
+			{
+				recursive_remove_directory($folderName);
+			}
 		}
 	}
 }
 
-if (!function_exists('finalizeRestore'))
+namespace Joomla\CMS\Language
 {
-	/**
-	 * Run part of the Joomla! finalisation script, namely the part that cleans up unused files/folders
-	 *
-	 * @param   string  $siteRoot     The root to the Joomla! site
-	 * @param   string  $restorePath  The base path to restore.php
-	 *
-	 * @return  void
-	 *
-	 * @since   3.5.1
-	 */
-	function finalizeRestore($siteRoot, $restorePath)
+	// Fake the Text class - we aren't going to show errors to people anyhow
+	if (!class_exists('Text'))
 	{
-		if (!defined('JPATH_ROOT'))
+		/**
+		 * Text mock class proxing behaviour in the post-upgrade script to that of either native PHP or restore.php
+		 *
+		 * @since  3.5.1
+		 */
+		abstract class Text
 		{
-			define('JPATH_ROOT', $siteRoot);
-		}
-
-		$filePath = JPATH_ROOT . '/administrator/components/com_admin/script.php';
-
-		if (file_exists($filePath))
-		{
-			require_once $filePath;
-		}
-
-		// Make sure Joomla!'s code can figure out which files exist and need be removed
-		clearstatcache();
-
-		// Remove obsolete files - prevents errors occuring in some system plugins
-		if (class_exists('JoomlaInstallerScript'))
-		{
-			$script = new JoomlaInstallerScript;
-			$script->deleteUnexistingFiles();
-		}
-
-		// Clear OPcache
-		if (function_exists('opcache_reset'))
-		{
-			opcache_reset();
+			/**
+			 * No need for translations in a non-interactive script, so always return an empty string here
+			 *
+			 * @param   string  $text  A language constant
+			 *
+			 * @return  string
+			 *
+			 * @since   3.5.1
+			 */
+			public static function sprintf($text)
+			{
+				return '';
+			}
 		}
 	}
 }


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/21160

This file was provided by @mbabker (https://gist.github.com/mbabker/5e171b1df99f71a30290125e0292b1d9).

I only created this pr.

### Summary of Changes
mbabker:

> We're going to have to get tricky with this file. The intent is to overload the core classes, so as they're now namespaced, the overloading has to use the correct namespacing as well. I think this is right (there are no IDE reported errors and no reported syntax errors linting the file), but I never write files using multiple namespaces, so I have no idea if this is going to do what we want it to. 

### Testing Instructions
I've tested it like this. The dilettantish way:

- See https://github.com/joomla/joomla-cms/issues/21211 and https://github.com/joomla/joomla-cms/issues/21160
- Install a [nightly build](https://developer.joomla.org/nightly-builds.html) 4.0 or [alpha](https://github.com/joomla/joomla-cms/releases/tag/4.0.0-alpha4).
- Download the nightly full package and also the update package 4.0.
- Go to Joomla Update > Tabulator Upload&Update.
- Try to update with one of the downloaded packages.
You'll get an AJAX Error.

- Extract the downloaded packages and exchange `administrator/components/com_joomlaupdate/restore_finalisation.php` [with the file of this pr](https://github.com/ReLater/joomla-cms/blob/2054bf3c3c1835ec8dde48c90fb2bcc2ca9a0676/administrator/components/com_joomlaupdate/restore_finalisation.php).
- Zip the packages.
- Repeat the steps above.
- No AJAX error. Update successful.