### PR TITLE
Update readme to link to Launch instead of Demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Is Joomla! for you?
 ---------------------
 * Joomla! is [the right solution for most content web projects](https://docs.joomla.org/Special:MyLanguage/Portal:Learn_More).
 * View Joomla's [core features here](https://www.joomla.org/core-features.html).
-* Try it out for yourself in our [online demo](https://launch.joomla.org).
+* Try it out for yourself on our [free hosting service](https://launch.joomla.org).
 
 How to find a Joomla! translation?
 ---------------------

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Is Joomla! for you?
 ---------------------
 * Joomla! is [the right solution for most content web projects](https://docs.joomla.org/Special:MyLanguage/Portal:Learn_More).
 * View Joomla's [core features here](https://www.joomla.org/core-features.html).
-* Try it out for yourself in our [online demo](https://demo.joomla.org).
+* Try it out for yourself in our [online demo](https://launch.joomla.org).
 
 How to find a Joomla! translation?
 ---------------------

--- a/README.txt
+++ b/README.txt
@@ -13,7 +13,7 @@
 3- Is Joomla! for you?
 	* Joomla! is the right solution for most content web projects: https://docs.joomla.org/Special:MyLanguage/Portal:Learn_More
 	* See Joomla's core features - https://www.joomla.org/core-features.html
-	* Try out our online demo: https://launch.joomla.org
+	* Try out our free hosting service: https://launch.joomla.org
 
 4- How to find a Joomla! translation?
 	* Repository of accredited language packs: https://community.joomla.org/translations.html

--- a/README.txt
+++ b/README.txt
@@ -13,7 +13,7 @@
 3- Is Joomla! for you?
 	* Joomla! is the right solution for most content web projects: https://docs.joomla.org/Special:MyLanguage/Portal:Learn_More
 	* See Joomla's core features - https://www.joomla.org/core-features.html
-	* Try out our online demo: https://demo.joomla.org
+	* Try out our online demo: https://launch.joomla.org
 
 4- How to find a Joomla! translation?
 	* Repository of accredited language packs: https://community.joomla.org/translations.html


### PR DESCRIPTION
### Summary of Changes
Link in the Readme to demo.joomla.org has been updated to launch.joomla.org


### Testing Instructions
None


### Documentation Changes Required
None
