### PR TITLE
[4.0] Missing quote in HTML metatag

### DIFF
--- a/templates/system/build_incomplete.html
+++ b/templates/system/build_incomplete.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-  <meta charset=utf-8">
+  <meta charset="utf-8">
   <meta http-equiv="Content-Language" content="en-GB">
   <meta name="robots" content="noindex, nofollow">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/templates/system/incompatible.html
+++ b/templates/system/incompatible.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-  <meta charset=utf-8">
+  <meta charset="utf-8">
   <meta http-equiv="Content-Language" content="en-GB">
   <meta name="robots" content="noindex, nofollow">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
### Summary of Changes
Added missing quote to the HTML metatag in system template html files.


### Testing Instructions
Code review


### Expected result
HTML renders properly on failed build or unsupported PHP version (PHP < 7)


### Documentation Changes Required
Nope
