### PR TITLE
fix es6 compilation

### DIFF
--- a/build/build-modules-js/compile-es6.js
+++ b/build/build-modules-js/compile-es6.js
@@ -61,4 +61,15 @@ const compileFile = (filePath) => {
   });
 };
 
+// Compile all files of the given pattern
+glob(pattern, options, (error, files) => {
+  if (error) {
+    // eslint-disable-next-line no-console
+    console.error(`${error}`);
+    process.exit(1);
+  }
+
+  files.forEach(compileFile);
+});
+
 module.exports.compileFile = compileFile;


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This PR reverts  build/build-modules-js/compile-es6.js to https://raw.githubusercontent.com/joomla/joomla-cms/0d996e30749bbeee4681b02a5e1be0dd91addb2e/build/build-modules-js/compile-es6.js removing testing changes made in PR https://github.com/joomla/joomla-cms/pull/21350

Problem is reproducible at least on Windows.

### Testing Instructions

code review
or  install 4.0-dev on [this commit](https://github.com/joomla/joomla-cms/commit/c669dac01ef191611f6a12925909bfebd5535c25) from github - [see docs](https://docs.joomla.org/J4.x:Setting_Up_Your_Local_Environment#Steps_to_setup_the_local_environment)

after applying this  you must run `npm run build:js`


### Expected result
![no_admin_erroradministration](https://user-images.githubusercontent.com/4176111/43612485-ca139dfc-96ac-11e8-8e58-a066f5eda2ea.png)
### Actual result
![admin_error](https://user-images.githubusercontent.com/4176111/43612536-eb741fb2-96ac-11e8-9a16-1a0d2273f4ad.jpg)


### Documentation Changes Required
no

cc @wilsonge @dgrammatiko 