### PR TITLE
[postgresql] - wrong GROUP BY in multilanguage site

### DIFF
--- a/administrator/components/com_content/models/articles.php
+++ b/administrator/components/com_content/models/articles.php
@@ -214,7 +214,7 @@ class ContentModelArticles extends JModelList
 			->join('LEFT', '#__users AS ua ON ua.id = a.created_by');
 
 		// Join on voting table
-		$assogroup = 'a.id, l.title, l.image, uc.name, ag.title, c.title, ua.name';
+		$assogroup = 'a.id, l.title, l.image, uc.name, ag.title, c.title, ua.name, c.created_user_id, c.level, parent.title, parent.created_user_id, parent.id';
 
 		if (JPluginHelper::isEnabled('content', 'vote'))
 		{


### PR DESCRIPTION
yet another one  wrong GROUP BY
### Summary of Changes
fixed wrong GROUP BY


### Testing Instructions
install a multilanguage site with postgresql 
simply open Control Panel or Articles

### Expected result
works as it should


### Actual result
![screenshot from 2018-08-03 10-38-25](https://user-images.githubusercontent.com/181681/43633406-6e7b99e2-9709-11e8-8195-f1ca693f2676.png)




