### PR TITLE
Removing CODE_OF_CONDUCT form the packages

### DIFF
--- a/build/build.php
+++ b/build/build.php
@@ -171,6 +171,7 @@ $doNotPackage = array(
 	'jenkins-phpunit.xml',
 	'RoboFile.php',
 	'RoboFile.dist.ini',
+	'CODE_OF_CONDUCT.md',
 	// Remove the testing sample data from all packages
 	'installation/sql/mysql/sample_testing.sql',
 	'installation/sql/postgresql/sample_testing.sql',


### PR DESCRIPTION
### Summary of Changes
This will remove `CODE_OF_CONDUCT.md` from the built packages as pointed out in https://github.com/joomla/joomla-cms/pull/21383#issuecomment-410226632


### Expected result
`CODE_OF_CONDUCT.md` is not present in the packages.


### Actual result
`CODE_OF_CONDUCT.md` is present in the packages after #21383 .


### Documentation Changes Required
None
