### PR TITLE
[4.0] Simplifying lang load for Article New Menu Item

### DIFF
--- a/administrator/components/com_content/View/Article/HtmlView.php
+++ b/administrator/components/com_content/View/Article/HtmlView.php
@@ -217,9 +217,7 @@ class HtmlView extends BaseHtmlView
 
 				// Load the language files
 				$language = Factory::getLanguage();
-				$language->load('com_menus', JPATH_ADMINISTRATOR, 'en-GB');
-				$language->load('com_menus', JPATH_ADMINISTRATOR, $language->getDefault());
-				$language->load('com_menus', JPATH_ADMINISTRATOR);
+				$language->load('com_menus', JPATH_ADMINISTRATOR, null, false, true);
 
 				// Add the modal html to the document
 				echo HTMLHelper::_(


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/pull/21391#issuecomment-410293319

### Summary of Changes
Simple change to use our API


### Testing Instructions
When using the the new "New Menu Item" button when editing a saved article, check that com_menus language file is still loaded.
Test easy when using another language than en-GB in back-end

Can be merged on review.
@laoneo @wilsonge 