### PR TITLE
[4.0] Fix npm cli for the wi(n)dows

### DIFF
--- a/build/build-modules-js/compile-es6.js
+++ b/build/build-modules-js/compile-es6.js
@@ -1,16 +1,7 @@
-const glob = require('glob');
 const fs = require('fs');
 const babel = require('babel-core');
 const UglifyJS = require('uglify-es');
 const os = require('os');
-
-const pattern = './**/*.es6.js';
-const options = {
-  ignore: [
-    './node_modules/**',
-    './build/media/webcomponents/**/js/**',
-  ],
-};
 
 const headerText = `PLEASE DO NOT MODIFY THIS FILE. WORK ON THE ES6 VERSION.
 OTHERWISE YOUR CHANGES WILL BE REPLACED ON THE NEXT BUILD.`;

--- a/build/build-modules-js/compilejs.js
+++ b/build/build-modules-js/compilejs.js
@@ -38,7 +38,7 @@ const uglifyJs = (options, path) => {
       (files) => {
         files.forEach(
             (file) => {
-            if (file.match(/.es6.js/)) {
+            if (file.match(/\.es6\.js/)) {
               // Transpile the file
               transpileEs5.compileFile(file);
             }
@@ -65,12 +65,12 @@ const watchFiles = (options, folders, compileFirst = false) => {
         (files) => {
           files.forEach(
             (file) => {
-              if (file.match(/.js/)) {
+              if (file.match(/\.js/)) {
                 fs.watchFile(file, () => {
                   // eslint-disable-next-line no-console
                   console.warn(`File: ${file} changed.`);
                   debounce(() => {
-                    if (file.match(/.es6.js/)) {
+                    if (file.match(/\.es6\.js/)) {
                       // Transpile the file
                       transpileEs5.compileFile(file);
                       fs.writeFileSync(file.replace('.es6.js', '.min.js'), UglifyJS.minify(fs.readFileSync(file, 'utf8')).code, { encoding: 'utf8' });

--- a/build/build-modules-js/update.js
+++ b/build/build-modules-js/update.js
@@ -280,7 +280,7 @@ const uglifyLegacyFiles = () => {
 					// Create the minified file
 					fs.writeFileSync(file.replace('.js', '.min.js'), UglifyJS.minify(fs.readFileSync(file, 'utf8')).code, {encoding: 'utf8'});
 				}
-				if (file.match(/.css/) && !file.match(/.min.css/) && !file.match(/.css.map/) && !file.toLowerCase().match(/license/)) {
+				if (file.match(/\.css/) && !file.match(/\.min\.css/) && !file.match(/\.css\.map/) && !file.toLowerCase().match(/license/)) {
 					console.log(`Processing: ${file}`);
 					// Create the minified file
 					fs.writeFileSync(


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
There is a bug in some regexes, `.` needs to be escaped


### Testing Instructions
run npm i
run `npm run build:css`. This should work now


### Expected result



### Actual result



### Documentation Changes Required

