### PR TITLE
Don't show module chromes of disabled templates

### DIFF
--- a/libraries/src/Form/Field/ChromestyleField.php
+++ b/libraries/src/Form/Field/ChromestyleField.php
@@ -218,7 +218,6 @@ class ChromestyleField extends \JFormFieldGroupedList
 		$template = new \stdClass;
 		$template->element = 'system';
 		$template->name    = 'system';
-		$template->enabled = 1;
 
 		return $template;
 	}
@@ -238,10 +237,11 @@ class ChromestyleField extends \JFormFieldGroupedList
 		$query = $db->getQuery(true);
 
 		// Build the query.
-		$query->select('element, name, enabled')
+		$query->select('element, name')
 			->from('#__extensions')
 			->where('client_id = ' . $this->clientId)
-			->where('type = ' . $db->quote('template'));
+			->where('type = ' . $db->quote('template'))
+			->where('enabled = 1');
 
 		// Set the query and load the templates.
 		$db->setQuery($query);


### PR DESCRIPTION
Pull Request for Issue #21429.

### Summary of Changes

This filters out module chromes of disabled templates from chrome field.

### Testing Instructions

Disable a template. Edit a module. Check available chromes in `Module Style` field.

### Expected result

Modules chromes of disabled templates are not shown.

### Actual result

Modules chromes of disabled templates are shown.

### Documentation Changes Required

No.