### PR TITLE
Remove "use_article" for show_noauth

### DIFF
--- a/components/com_content/views/featured/tmpl/default.xml
+++ b/components/com_content/views/featured/tmpl/default.xml
@@ -480,7 +480,6 @@
 				useglobal="true"
 				class="chzn-color"
 				>
-				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
 				<option value="0">JNO</option>
 				<option value="1">JYES</option>
 			</field>


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/21407

A pr for menu item type "category blog" will follow if this pr is accepted.

### Summary of Changes
- Menu item type "Featured Articles".
- Remove option "Use article settings" from parameter "Show Unauthorised Links" in tabulator "Options". - It has an unsolvable(?) bug.

### Testing Instructions
- Please see issue and please **read also discussion** there: https://github.com/joomla/joomla-cms/issues/21407

#### Before patch
![07-08-_2018_17-26-16](https://user-images.githubusercontent.com/20780646/43785739-44394ed4-9a67-11e8-9223-1069b41f21c0.jpg)

#### After patch
![07-08-_2018_17-25-41](https://user-images.githubusercontent.com/20780646/43785760-4b482236-9a67-11e8-93bc-aa9beafdac83.jpg)

### Documentation Changes Required
- Maybe a "Post-installation Message for Joomla CMS" would be helpful. 