### PR TITLE
[4.0] Ensure the default value is retrieved

### DIFF
--- a/administrator/components/com_workflow/Table/WorkflowTable.php
+++ b/administrator/components/com_workflow/Table/WorkflowTable.php
@@ -60,7 +60,7 @@ class WorkflowTable extends Table
 
 		// Gets the workflow information that is going to be deleted.
 		$query = $db->getQuery(true)
-			->select($db->quoteName(array('id', 'title')))
+			->select($db->quoteName(array('id', 'title', 'default')))
 			->from($db->quoteName('#__workflows'))
 			->where($db->quoteName('id') . ' = ' . (int) $pk);
 		$db->setQuery($query);


### PR DESCRIPTION
Straight after this we do a check we aren't deleting the default workflow, but we fail to retrieve the default property from the db.

I guess right now you can delete the default workflow. Where as you shouldn't be able to (currently I'm not on a machine with a working install so this needs testing)