### PR TITLE
[4.0] Merge article title, alias, category to one column

### DIFF
--- a/administrator/components/com_content/tmpl/articles/default.php
+++ b/administrator/components/com_content/tmpl/articles/default.php
@@ -112,12 +112,6 @@ $featuredButton = (new ActionButton(['tip_title' => 'JGLOBAL_TOGGLE_FEATURED']))
 								<th scope="col" style="min-width:100px" class="nowrap">
 									<?php echo HTMLHelper::_('searchtools.sort', 'JGLOBAL_TITLE', 'a.title', $listDirn, $listOrder); ?>
 								</th>
-								<th style="width:1%" class="nowrap text-center">
-									<?php echo JText::_("COM_CONTENT_STATE") ?>
-								</th>
-								<th scope="col" style="width:10%" class="nowrap d-none d-md-table-cell text-center">
-									<?php echo JHtml::_('searchtools.sort', 'JCATEGORY', 'a.title', $listDirn, $listOrder); ?>
-								</th>
 								<th scope="col" style="width:10%" class="nowrap d-none d-md-table-cell text-center">
 									<?php echo HTMLHelper::_('searchtools.sort',  'JGRID_HEADING_ACCESS', 'a.access', $listDirn, $listOrder); ?>
 								</th>
@@ -254,14 +248,14 @@ $featuredButton = (new ActionButton(['tip_title' => 'JGLOBAL_TOGGLE_FEATURED']))
 										<?php else : ?>
 											<span title="<?php echo Text::sprintf('JFIELD_ALIAS_LABEL', $this->escape($item->alias)); ?>"><?php echo $this->escape($item->title); ?></span>
 										<?php endif; ?>
+											<span class="small break-word">
+												<?php echo Text::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->alias)); ?>
+											</span>
+											<div class="small">
+												<?php echo Text::_('JCATEGORY') . ': ' . $this->escape($item->category_title); ?>
+											</div>
 									</div>
 								</th>
-								<td class="text-secondary d-none d-md-table-cell">
-									<?php echo $this->escape($item->alias); ?>
-								</td>
-								<td class="text-secondary d-none d-md-table-cell text-center">
-									<?php echo $this->escape($item->category_title); ?>
-								</td>
 								<td class="small d-none d-md-table-cell text-center">
 									<?php echo $this->escape($item->access_level); ?>
 								</td>


### PR DESCRIPTION
Pull Request for Issue #21498

### Summary of Changes
Unify the article title/alias/category display in the list again

### Expected result
Title, Alias, Category are in one column again


### Actual result
Alias, Category has their own column