### PR TITLE
[4.0] Fix npm script on windows

### DIFF
--- a/build/build-modules-js/compile-es6.js
+++ b/build/build-modules-js/compile-es6.js
@@ -39,7 +39,7 @@ const compileFile = (filePath) => {
     );
     // Also write the minified
     fs.writeFile(
-      `${fileName.replace('/build/media_src/', '/media/').replace('\\build\\media_src\\', '\\media\\')}.js`,
+      `${fileName.replace('/build/media_src/', '/media/').replace('\\build\\media_src\\', '\\media\\')}.min.js`,
       UglifyJS.minify(result.code).code + os.EOL,
       (fsError) => {
         if (fsError) {

--- a/build/build-modules-js/compile-es6.js
+++ b/build/build-modules-js/compile-es6.js
@@ -27,7 +27,7 @@ const compileFile = (filePath) => {
     const fileName = filePath.slice(0, -7);
     console.log(`Compiling: ${fileName.replace('/build/media_src/', '/media/')}.js`);
     fs.writeFile(
-      `${fileName.replace('/build/media_src/', '/media/')}.js`,
+      `${fileName.replace('/build/media_src/', '/media/').replace('\\build\\media_src\\', '\\media\\')}.js`,
       result.code + os.EOL,
       (fsError) => {
         if (fsError) {
@@ -39,7 +39,7 @@ const compileFile = (filePath) => {
     );
     // Also write the minified
     fs.writeFile(
-      `${fileName.replace('/build/media_src/', '/media/')}.min.js`,
+      `${fileName.replace('/build/media_src/', '/media/').replace('\\build\\media_src\\', '\\media\\')}.js`,
       UglifyJS.minify(result.code).code + os.EOL,
       (fsError) => {
         if (fsError) {


### PR DESCRIPTION
Currently, if you run `npm install` on a Windows machine, the compiled JS files aren't moved to the correct folder. Git will show a bunch of untracked files in /build/media_src

### Summary of Changes
This adjusts the script for Windows folders. Code comes from @dgrammatiko (Thanks!).


### Testing Instructions
Run `npm install`

Please test both on Linux and Windows.


### Expected result
Works


### Actual result
Doesn't work on Windows


### Documentation Changes Required
None
