### PR TITLE
[4.0] Fix broken multilingual handling

### DIFF
--- a/administrator/components/com_content/Model/ArticlesModel.php
+++ b/administrator/components/com_content/Model/ArticlesModel.php
@@ -272,6 +272,10 @@ class ArticlesModel extends ListModel
 			'ag.title',
 			'c.title',
 			'ua.name',
+			'ws.title',
+			'ws.workflow_id',
+			'ws.condition',
+			'wa.state_id'
 		);
 
 		if (PluginHelper::isEnabled('content', 'vote'))


### PR DESCRIPTION
Pull Request for Issue #21475 .

### Summary of Changes
Added new workflow fields to the grouping parameter


### Testing Instructions
#21475


### Expected result
No error


### Actual result
```'wa.state_id' isn't in GROUP BY```

