### PR TITLE
Set option by mime type, not by mode name

### DIFF
--- a/plugins/editors/codemirror/layouts/editors/codemirror/init.php
+++ b/plugins/editors/codemirror/layouts/editors/codemirror/init.php
@@ -51,9 +51,9 @@ JFactory::getDocument()->addScriptDeclaration(
 
 				cm.autoLoadMode(editor, mode ? mode.mode : editor.options.mode);
 
-				if (mode)
+				if (mode && mode.mime)
 				{
-					editor.setOption('mode', mode.mode);
+					editor.setOption('mode', mode.mime);
 				}
 
 				// Handle gutter clicks (place or remove a marker).


### PR DESCRIPTION
Pull Request for Issue #21451 .

### Summary of Changes

We shall set the mode option by mime rather than by mode name. Because some modes such as 'less' are considered 'css' by Codemirror but are differentiated by mime type. 

### Testing Instructions

Open a less file with Codemirror. Before the patch it should be highlighted like css, after it will use less syntax highlighting. Auto formatting (select a block of code and hit shift-tab) should also be affected. 

Probably also test some html, css, and js code to make sure it's still working as expected.

### Expected result

Syntax highlighting and auto-formatting will work according to whatever language is being displayed.

### Actual result

Well, it wasn't for 'less' and possibly some others. 

### Documentation Changes Required

Nope.