### PR TITLE
[4.0][Workflow] POC fixing multilingual sample data

### DIFF
--- a/plugins/sampledata/multilang/multilang.php
+++ b/plugins/sampledata/multilang/multilang.php
@@ -1120,15 +1120,15 @@ class PlgSampledataMultilang extends CMSPlugin
 		$db->setQuery($query);
 
 		try
-			{
-				$db->execute();
-			}
-			catch (JDatabaseExceptionExecuting $e)
-			{
-				$this->setError($e->getMessage());
+		{
+			$db->execute();
+		}
+		catch (JDatabaseExceptionExecuting $e)
+		{
+			$this->setError($e->getMessage());
 
-				return false;
-			}
+			return false;
+		}
 
 		$query->clear()
 			->insert($db->qn('#__workflow_associations'))
@@ -1142,6 +1142,8 @@ class PlgSampledataMultilang extends CMSPlugin
 		}
 		catch (JDatabaseExceptionExecuting $e)
 		{
+			$this->setError($e->getMessage());
+
 			return false;
 		}
 


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/21548

### Summary of Changes
Adapting multilingual sample data to workflow


### Testing Instructions
Patch tester should be OK.
Just do as usual, i.e. install some languages (French, German, Persian) and click install in CPanel

### Why is it a POC?

For the simple reason that the default workflow may have been changed or the "Joomla! Default" one in core  modified (WHICH BTW should have as title a translatable language constant), thus state 2 could be anything instead of "Published".

@bembelimen 
@franz-wohlkoenig