### PR TITLE
[4.0] Atum template scss

### DIFF
--- a/administrator/templates/atum/scss/template.scss
+++ b/administrator/templates/atum/scss/template.scss
@@ -19,7 +19,6 @@
 @import "blocks/header";
 @import "blocks/icons";
 @import "blocks/iframe";
-@import "blocks/layout";
 @import "blocks/login";
 @import "blocks/modals";
 @import "blocks/quickicons";


### PR DESCRIPTION
The build script wasn't completing because it was complaining

> something exploded File to import not found or unreadable: blocks/layout

Checking the repo there is no _blocks.scss file so this pr removes the import statement and allows the uild script to complete
