### PR TITLE
[4.0] Installation error message

### DIFF
--- a/installation/template/css/template.css
+++ b/installation/template/css/template.css
@@ -8681,7 +8681,8 @@ legend {
   background: none; }
 
 .form-control-feedback {
-  display: block; }
+  display: block;
+  color: #c52827; }
 
 caption {
   caption-side: top; }

--- a/installation/template/scss/template.scss
+++ b/installation/template/scss/template.scss
@@ -271,6 +271,7 @@ legend {
 // Block display for the validation message
 .form-control-feedback {
   display: block;
+  color: $red;
 }
 
 // Language Table


### PR DESCRIPTION
Make the error messages on field validation red

### Before
<img width="510" alt="chrome_2018-08-12_19-32-49" src="https://user-images.githubusercontent.com/1296369/44005153-8882bff0-9e66-11e8-8242-59e17a54671e.png">

### After
<img width="485" alt="chrome_2018-08-12_19-29-35" src="https://user-images.githubusercontent.com/1296369/44005155-8ea5a104-9e66-11e8-8c1d-f51f6e39d2db.png">
