### PR TITLE
[4.0] Clean up and alpha-order imports

### DIFF
--- a/libraries/cms/html/access.php
+++ b/libraries/cms/html/access.php
@@ -9,11 +9,11 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\CMS\Access\Access;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Helper\UserGroupsHelper;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
-use Joomla\CMS\Access\Access;
-use Joomla\CMS\Helper\UserGroupsHelper;
 use Joomla\CMS\Layout\LayoutHelper;
 
 /**

--- a/libraries/cms/html/adminlanguage.php
+++ b/libraries/cms/html/adminlanguage.php
@@ -9,8 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\CMS\Language\Text;
 use Joomla\CMS\Language\LanguageHelper;
+use Joomla\CMS\Language\Text;
 use Joomla\CMS\Object\CMSObject;
 
 /**

--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -10,12 +10,12 @@
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Factory;
+use Joomla\CMS\Filter\OutputFilter;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
-use Joomla\CMS\Filter\OutputFilter;
+use Joomla\CMS\Log\Log;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
-use Joomla\CMS\Log\Log;
 
 /**
  * Utility class for JavaScript behaviors

--- a/libraries/cms/html/bootstrap.php
+++ b/libraries/cms/html/bootstrap.php
@@ -11,8 +11,8 @@ defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
-use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Layout\FileLayout;
+use Joomla\CMS\Layout\LayoutHelper;
 
 /**
  * Utility class for Bootstrap elements.

--- a/libraries/cms/html/category.php
+++ b/libraries/cms/html/category.php
@@ -9,10 +9,10 @@
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\Utilities\ArrayHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\Utilities\ArrayHelper;
 
 /**
  * Utility class for categories

--- a/libraries/cms/html/date.php
+++ b/libraries/cms/html/date.php
@@ -9,9 +9,9 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\CMS\Date\Date;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
-use Joomla\CMS\Date\Date;
 
 /**
  * Extended Utility class for handling date display.

--- a/libraries/cms/html/email.php
+++ b/libraries/cms/html/email.php
@@ -7,10 +7,9 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-use Joomla\CMS\Factory;
+use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\String\PunycodeHelper;
-use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Uri\Uri;
 
 defined('JPATH_PLATFORM') or die;

--- a/libraries/cms/html/form.php
+++ b/libraries/cms/html/form.php
@@ -10,9 +10,9 @@
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Document\HtmlDocument;
-use Joomla\Utilities\ArrayHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Session\Session;
+use Joomla\Utilities\ArrayHelper;
 
 /**
  * Utility class for form elements

--- a/libraries/cms/html/formbehavior.php
+++ b/libraries/cms/html/formbehavior.php
@@ -9,10 +9,10 @@
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\Registry\Registry;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\Registry\Registry;
 
 /**
  * Utility class for form related behaviors

--- a/libraries/cms/html/jgrid.php
+++ b/libraries/cms/html/jgrid.php
@@ -9,11 +9,10 @@
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\CMS\Button\PublishedButton;
 use Joomla\CMS\Factory;
-use Joomla\Utilities\ArrayHelper;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\Utilities\ArrayHelper;
 
 /**
  * Utility class for creating HTML Grids

--- a/libraries/cms/html/list.php
+++ b/libraries/cms/html/list.php
@@ -9,10 +9,10 @@
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\String\StringHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\String\StringHelper;
 
 /**
  * Utility class for creating different select lists

--- a/libraries/cms/html/searchtools.php
+++ b/libraries/cms/html/searchtools.php
@@ -9,10 +9,10 @@
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\Registry\Registry;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Layout\LayoutHelper;
+use Joomla\Registry\Registry;
 
 /**
  * Searchtools elements.

--- a/libraries/cms/html/select.php
+++ b/libraries/cms/html/select.php
@@ -9,9 +9,9 @@
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\Utilities\ArrayHelper;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\Utilities\ArrayHelper;
 
 /**
  * Utility class for creating HTML select lists

--- a/libraries/cms/html/string.php
+++ b/libraries/cms/html/string.php
@@ -9,8 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\String\StringHelper;
 use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\String\StringHelper;
 
 /**
  * HTML helper class for rendering manipulated strings.

--- a/libraries/cms/html/tag.php
+++ b/libraries/cms/html/tag.php
@@ -9,12 +9,12 @@
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\Utilities\ArrayHelper;
+use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
-use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Uri\Uri;
+use Joomla\Utilities\ArrayHelper;
 
 /**
  * Utility class for tags

--- a/libraries/cms/html/uitab.php
+++ b/libraries/cms/html/uitab.php
@@ -9,8 +9,6 @@
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\CMS\HTML\HTMLHelper;
-
 /**
  * Utility class for the Joomla core UI Tab element.
  *

--- a/libraries/cms/html/user.php
+++ b/libraries/cms/html/user.php
@@ -9,9 +9,9 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\CMS\Access\Access;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
-use Joomla\CMS\Access\Access;
 
 /**
  * Utility class working with users

--- a/libraries/src/Access/Access.php
+++ b/libraries/src/Access/Access.php
@@ -10,11 +10,11 @@ namespace Joomla\CMS\Access;
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\Utilities\ArrayHelper;
-use Joomla\CMS\Table\Asset;
+use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Log\Log;
-use Joomla\CMS\Component\ComponentHelper;
+use Joomla\CMS\Table\Asset;
+use Joomla\Utilities\ArrayHelper;
 
 /**
  * Class that handles all access authorisation routines.

--- a/libraries/src/Application/AdministratorApplication.php
+++ b/libraries/src/Application/AdministratorApplication.php
@@ -12,16 +12,16 @@ defined('JPATH_PLATFORM') or die;
 
 use Joomla\Application\Web\WebClient;
 use Joomla\CMS\Component\ComponentHelper;
+use Joomla\CMS\Factory;
+use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\Input\Input;
 use Joomla\CMS\Language\LanguageHelper;
-use Joomla\CMS\Plugin\PluginHelper;
-use Joomla\DI\Container;
-use Joomla\Registry\Registry;
-use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
-use Joomla\CMS\Filter\InputFilter;
+use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Session\Session;
 use Joomla\CMS\Uri\Uri;
+use Joomla\DI\Container;
+use Joomla\Registry\Registry;
 
 /**
  * Joomla! Administrator Application class

--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -17,24 +17,23 @@ use Joomla\CMS\Event\BeforeExecuteEvent;
 use Joomla\CMS\Event\ErrorEvent;
 use Joomla\CMS\Exception\ExceptionHandler;
 use Joomla\CMS\Extension\ExtensionManagerTrait;
+use Joomla\CMS\Factory;
 use Joomla\CMS\Input\Input;
-use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\Language\Language;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Menu\AbstractMenu;
 use Joomla\CMS\Pathway\Pathway;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Profiler\Profiler;
+use Joomla\CMS\Router\Route;
+use Joomla\CMS\Router\Router;
 use Joomla\CMS\Session\MetadataManager;
 use Joomla\CMS\Session\Session;
+use Joomla\CMS\Uri\Uri;
 use Joomla\DI\Container;
 use Joomla\DI\ContainerAwareInterface;
 use Joomla\DI\ContainerAwareTrait;
 use Joomla\Registry\Registry;
-use Joomla\CMS\Factory;
-use Joomla\CMS\Uri\Uri;
-use Joomla\CMS\Router\Router;
-use Joomla\CMS\Router\Route;
 
 /**
  * Joomla! CMS Application class

--- a/libraries/src/Application/CliApplication.php
+++ b/libraries/src/Application/CliApplication.php
@@ -16,16 +16,16 @@ use Joomla\CMS\Application\CLI\CliOutput;
 use Joomla\CMS\Application\CLI\Output\Stdout;
 use Joomla\CMS\Event\BeforeExecuteEvent;
 use Joomla\CMS\Extension\ExtensionManagerTrait;
-use Joomla\Input\Cli;
-use Joomla\Input\Input;
+use Joomla\CMS\Factory;
 use Joomla\DI\Container;
 use Joomla\DI\ContainerAwareTrait;
 use Joomla\Event\DispatcherAwareInterface;
 use Joomla\Event\DispatcherAwareTrait;
 use Joomla\Event\DispatcherInterface;
+use Joomla\Input\Cli;
+use Joomla\Input\Input;
 use Joomla\Registry\Registry;
 use Joomla\Session\SessionInterface;
-use Joomla\CMS\Factory;
 
 /**
  * Base class for a Joomla! command line application.

--- a/libraries/src/Application/ConsoleApplication.php
+++ b/libraries/src/Application/ConsoleApplication.php
@@ -12,7 +12,7 @@ defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Console;
 use Joomla\CMS\Extension\ExtensionManagerTrait;
-use Joomla\Input\Cli;
+use Joomla\CMS\Factory;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\Console\Application;
 use Joomla\DI\Container;
@@ -20,10 +20,10 @@ use Joomla\DI\ContainerAwareTrait;
 use Joomla\Event\DispatcherAwareInterface;
 use Joomla\Event\DispatcherAwareTrait;
 use Joomla\Event\DispatcherInterface;
+use Joomla\Input\Cli;
 use Joomla\Registry\Registry;
 use Joomla\Session\SessionInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use Joomla\CMS\Factory;
 
 /**
  * The Joomla! CMS Console Application

--- a/libraries/src/Application/DaemonApplication.php
+++ b/libraries/src/Application/DaemonApplication.php
@@ -13,10 +13,10 @@ defined('JPATH_PLATFORM') or die;
 jimport('joomla.filesystem.folder');
 
 use Joomla\CMS\Event\BeforeExecuteEvent;
-use Joomla\Event\DispatcherInterface;
-use Joomla\Registry\Registry;
 use Joomla\CMS\Filesystem\Folder;
 use Joomla\CMS\Log\Log;
+use Joomla\Event\DispatcherInterface;
+use Joomla\Registry\Registry;
 
 /**
  * Class to turn CliApplication applications into daemons.  It requires CLI and PCNTL support built into PHP.

--- a/libraries/src/Application/SiteApplication.php
+++ b/libraries/src/Application/SiteApplication.php
@@ -12,18 +12,18 @@ defined('JPATH_PLATFORM') or die;
 
 use Joomla\Application\Web\WebClient;
 use Joomla\CMS\Component\ComponentHelper;
+use Joomla\CMS\Factory;
+use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\Input\Input;
 use Joomla\CMS\Language\LanguageHelper;
+use Joomla\CMS\Language\Text;
 use Joomla\CMS\Menu\AbstractMenu;
 use Joomla\CMS\Pathway\Pathway;
 use Joomla\CMS\Plugin\PluginHelper;
+use Joomla\CMS\Router\Route;
+use Joomla\CMS\Uri\Uri;
 use Joomla\DI\Container;
 use Joomla\Registry\Registry;
-use Joomla\CMS\Factory;
-use Joomla\CMS\Language\Text;
-use Joomla\CMS\Filter\InputFilter;
-use Joomla\CMS\Uri\Uri;
-use Joomla\CMS\Router\Route;
 
 /**
  * Joomla! Site Application class

--- a/libraries/src/Application/WebApplication.php
+++ b/libraries/src/Application/WebApplication.php
@@ -14,8 +14,11 @@ use Joomla\Application\AbstractWebApplication;
 use Joomla\Application\Web\WebClient;
 use Joomla\CMS\Document\Document;
 use Joomla\CMS\Event\BeforeExecuteEvent;
+use Joomla\CMS\Factory;
 use Joomla\CMS\Input\Input;
 use Joomla\CMS\Language\Language;
+use Joomla\CMS\Session\Session;
+use Joomla\CMS\Uri\Uri;
 use Joomla\CMS\User\User;
 use Joomla\CMS\Version;
 use Joomla\Event\DispatcherAwareInterface;
@@ -23,9 +26,6 @@ use Joomla\Event\DispatcherAwareTrait;
 use Joomla\Registry\Registry;
 use Joomla\Session\SessionEvent;
 use Psr\Http\Message\ResponseInterface;
-use Joomla\CMS\Factory;
-use Joomla\CMS\Session\Session;
-use Joomla\CMS\Uri\Uri;
 
 /**
  * Base class for a Joomla! Web application.

--- a/libraries/src/Authentication/Authentication.php
+++ b/libraries/src/Authentication/Authentication.php
@@ -10,13 +10,13 @@ namespace Joomla\CMS\Authentication;
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\CMS\Factory;
+use Joomla\CMS\Language\Text;
+use Joomla\CMS\Log\Log;
+use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\Event\DispatcherAwareTrait;
 use Joomla\Event\DispatcherInterface;
-use Joomla\CMS\Factory;
-use Joomla\CMS\Language\Text;
-use Joomla\CMS\Object\CMSObject;
-use Joomla\CMS\Log\Log;
 
 /**
  * Authentication class, provides an interface for the Joomla authentication system

--- a/libraries/src/Authentication/Password/CheckIfRehashNeededHandlerInterface.php
+++ b/libraries/src/Authentication/Password/CheckIfRehashNeededHandlerInterface.php
@@ -10,10 +10,6 @@ namespace Joomla\CMS\Authentication\Password;
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\Authentication\Password\HandlerInterface;
-use Joomla\CMS\Crypt\Crypt;
-use Joomla\CMS\User\UserHelper;
-
 /**
  * Interface for a password handler which supports checking if the password requires rehashing
  *

--- a/libraries/src/Cache/Cache.php
+++ b/libraries/src/Cache/Cache.php
@@ -12,10 +12,10 @@ defined('JPATH_PLATFORM') or die;
 
 use Joomla\Application\Web\WebClient;
 use Joomla\CMS\Cache\Exception\CacheExceptionInterface;
-use Joomla\String\StringHelper;
 use Joomla\CMS\Factory;
-use Joomla\CMS\Session\Session;
 use Joomla\CMS\Filesystem\Path;
+use Joomla\CMS\Session\Session;
+use Joomla\String\StringHelper;
 
 /**
  * Joomla! Cache base object

--- a/libraries/src/Cache/CacheStorage.php
+++ b/libraries/src/Cache/CacheStorage.php
@@ -11,7 +11,6 @@ namespace Joomla\CMS\Cache;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Cache\Exception\UnsupportedCacheException;
-use Joomla\CMS\Log\Log;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Filesystem\Path;
 

--- a/libraries/src/Cache/Controller/OutputController.php
+++ b/libraries/src/Cache/Controller/OutputController.php
@@ -11,7 +11,6 @@ namespace Joomla\CMS\Cache\Controller;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Cache\CacheController;
-use Joomla\CMS\Log\Log;
 
 /**
  * Joomla Cache output type object

--- a/libraries/src/Cache/Storage/FileStorage.php
+++ b/libraries/src/Cache/Storage/FileStorage.php
@@ -11,9 +11,9 @@ namespace Joomla\CMS\Cache\Storage;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Cache\CacheStorage;
-use Joomla\CMS\Log\Log;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Log\Log;
 
 /**
  * File cache storage handler

--- a/libraries/src/Cache/Storage/RedisStorage.php
+++ b/libraries/src/Cache/Storage/RedisStorage.php
@@ -11,8 +11,8 @@ namespace Joomla\CMS\Cache\Storage;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Cache\CacheStorage;
-use Joomla\CMS\Log\Log;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Log\Log;
 
 /**
  * Redis cache storage handler for PECL

--- a/libraries/src/Captcha/Captcha.php
+++ b/libraries/src/Captcha/Captcha.php
@@ -10,15 +10,15 @@ namespace Joomla\CMS\Captcha;
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\CMS\Factory;
+use Joomla\CMS\Filter\InputFilter;
+use Joomla\CMS\Language\Text;
+use Joomla\CMS\Plugin\CMSPlugin;
+use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\Event\DispatcherAwareInterface;
 use Joomla\Event\DispatcherAwareTrait;
 use Joomla\Event\Event;
-use Joomla\CMS\Plugin\CMSPlugin;
-use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\Registry\Registry;
-use Joomla\CMS\Factory;
-use Joomla\CMS\Language\Text;
-use Joomla\CMS\Filter\InputFilter;
 
 /**
  * Joomla! Captcha base object

--- a/libraries/src/Categories/CategoriesServiceTrait.php
+++ b/libraries/src/Categories/CategoriesServiceTrait.php
@@ -10,8 +10,8 @@ namespace Joomla\CMS\Categories;
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\CMS\Form\Form;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Form\Form;
 
 /**
  * Trait for component categories service.

--- a/libraries/src/Categories/CategoryNode.php
+++ b/libraries/src/Categories/CategoryNode.php
@@ -10,9 +10,9 @@ namespace Joomla\CMS\Categories;
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\Registry\Registry;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Object\CMSObject;
+use Joomla\Registry\Registry;
 
 /**
  * Helper class to load Categorytree

--- a/libraries/src/Client/FtpClient.php
+++ b/libraries/src/Client/FtpClient.php
@@ -10,9 +10,9 @@ namespace Joomla\CMS\Client;
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
 use Joomla\CMS\Utility\BufferStreamHandler;
-use Joomla\CMS\Language\Text;
 
 /** Error Codes:
  * - 30 : Unable to connect to host

--- a/libraries/src/Component/ComponentHelper.php
+++ b/libraries/src/Component/ComponentHelper.php
@@ -12,12 +12,12 @@ defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Access\Access;
 use Joomla\CMS\Component\Exception\MissingComponentException;
-use Joomla\Registry\Registry;
 use Joomla\CMS\Dispatcher\Dispatcher;
 use Joomla\CMS\Factory;
-use Joomla\CMS\Language\Text;
 use Joomla\CMS\Filter\InputFilter;
+use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
+use Joomla\Registry\Registry;
 
 /**
  * Component helper class

--- a/libraries/src/Dispatcher/Dispatcher.php
+++ b/libraries/src/Dispatcher/Dispatcher.php
@@ -13,10 +13,10 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Access\Exception\NotAllowed;
 use Joomla\CMS\Application\CMSApplication;
 use Joomla\CMS\Component\ComponentHelper;
+use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Controller\BaseController;
 use Joomla\CMS\MVC\Factory\MVCFactoryFactoryInterface;
 use Joomla\Input\Input;
-use Joomla\CMS\Language\Text;
 
 /**
  * Base class for a Joomla Dispatcher

--- a/libraries/src/Dispatcher/DispatcherFactory.php
+++ b/libraries/src/Dispatcher/DispatcherFactory.php
@@ -11,8 +11,8 @@ namespace Joomla\CMS\Dispatcher;
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Application\CMSApplicationInterface;
-use Joomla\Input\Input;
 use Joomla\CMS\MVC\Factory\MVCFactoryFactoryInterface;
+use Joomla\Input\Input;
 
 /**
  * Namesapce based implementation of the DispatcherFactoryInterface

--- a/libraries/src/Dispatcher/LegacyDispatcher.php
+++ b/libraries/src/Dispatcher/LegacyDispatcher.php
@@ -11,8 +11,8 @@ namespace Joomla\CMS\Dispatcher;
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Application\CMSApplication;
-use Joomla\CMS\MVC\Factory\MVCFactoryFactory;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\MVC\Factory\MVCFactoryFactory;
 
 /**
  * Base class for a legacy Joomla Dispatcher

--- a/libraries/src/Document/Document.php
+++ b/libraries/src/Document/Document.php
@@ -12,9 +12,9 @@ defined('JPATH_PLATFORM') or die;
 
 use Joomla\Application\AbstractWebApplication;
 use Joomla\CMS\Date\Date;
-use Symfony\Component\WebLink\HttpHeaderSerializer;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Log\Log;
+use Symfony\Component\WebLink\HttpHeaderSerializer;
 
 /**
  * Document class, provides an easy interface to parse and display a document

--- a/libraries/src/Document/ErrorDocument.php
+++ b/libraries/src/Document/ErrorDocument.php
@@ -10,8 +10,8 @@ namespace Joomla\CMS\Document;
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Layout\LayoutHelper;
 
 /**
  * ErrorDocument class, provides an easy interface to parse and display an HTML based error page

--- a/libraries/src/Document/HtmlDocument.php
+++ b/libraries/src/Document/HtmlDocument.php
@@ -11,13 +11,13 @@ namespace Joomla\CMS\Document;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Cache\Cache;
+use Joomla\CMS\Factory;
+use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\Helper\ModuleHelper;
+use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
 use Joomla\CMS\Uri\Uri;
 use Joomla\Registry\Registry;
-use Joomla\CMS\Factory;
-use Joomla\CMS\Language\Text;
-use Joomla\CMS\Filter\InputFilter;
 
 jimport('joomla.utilities.utility');
 

--- a/libraries/src/Document/OpensearchDocument.php
+++ b/libraries/src/Document/OpensearchDocument.php
@@ -12,9 +12,9 @@ defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Document\Opensearch\OpensearchImage;
 use Joomla\CMS\Document\Opensearch\OpensearchUrl;
-use Joomla\CMS\Uri\Uri;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Router\Route;
+use Joomla\CMS\Uri\Uri;
 
 /**
  * Opensearch class, provides an easy interface to display an Opensearch document

--- a/libraries/src/Document/Renderer/Feed/AtomRenderer.php
+++ b/libraries/src/Document/Renderer/Feed/AtomRenderer.php
@@ -11,10 +11,10 @@ namespace Joomla\CMS\Document\Renderer\Feed;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Document\DocumentRenderer;
-use Joomla\CMS\Uri\Uri;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
+use Joomla\CMS\Uri\Uri;
 
 /**
  * AtomRenderer is a feed that implements the atom specification

--- a/libraries/src/Document/Renderer/Feed/RssRenderer.php
+++ b/libraries/src/Document/Renderer/Feed/RssRenderer.php
@@ -11,10 +11,10 @@ namespace Joomla\CMS\Document\Renderer\Feed;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Document\DocumentRenderer;
-use Joomla\CMS\Uri\Uri;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
+use Joomla\CMS\Uri\Uri;
 
 /**
  * RssRenderer is a feed that implements RSS 2.0 Specification

--- a/libraries/src/Document/Renderer/Html/HeadRenderer.php
+++ b/libraries/src/Document/Renderer/Html/HeadRenderer.php
@@ -11,9 +11,6 @@ namespace Joomla\CMS\Document\Renderer\Html;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Document\DocumentRenderer;
-use Joomla\CMS\Helper\TagsHelper;
-use Joomla\CMS\Uri\Uri;
-use Joomla\Utilities\ArrayHelper;
 
 /**
  * HTML document renderer for the document `<head>` element

--- a/libraries/src/Document/Renderer/Html/MessageRenderer.php
+++ b/libraries/src/Document/Renderer/Html/MessageRenderer.php
@@ -11,9 +11,9 @@ namespace Joomla\CMS\Document\Renderer\Html;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Document\DocumentRenderer;
-use Joomla\CMS\Log\Log;
-use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Layout\LayoutHelper;
+use Joomla\CMS\Log\Log;
 
 /**
  * HTML document renderer for the system message queue

--- a/libraries/src/Document/Renderer/Html/MetasRenderer.php
+++ b/libraries/src/Document/Renderer/Html/MetasRenderer.php
@@ -12,10 +12,10 @@ namespace Joomla\CMS\Document\Renderer\Html;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Document\DocumentRenderer;
-use Joomla\CMS\Helper\TagsHelper;
 use Joomla\CMS\Factory;
-use Joomla\Utilities\ArrayHelper;
+use Joomla\CMS\Helper\TagsHelper;
 use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\Utilities\ArrayHelper;
 
 /**
  * JDocument metas renderer

--- a/libraries/src/Document/Renderer/Html/ModuleRenderer.php
+++ b/libraries/src/Document/Renderer/Html/ModuleRenderer.php
@@ -11,11 +11,9 @@ namespace Joomla\CMS\Document\Renderer\Html;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Document\DocumentRenderer;
-use Joomla\CMS\Helper\ModuleHelper;
-use Joomla\CMS\Log\Log;
-use Joomla\CMS\Layout\LayoutHelper;
-use Joomla\Registry\Registry;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Helper\ModuleHelper;
+use Joomla\Registry\Registry;
 
 /**
  * HTML document renderer for a single module

--- a/libraries/src/Document/Renderer/Html/ModulesRenderer.php
+++ b/libraries/src/Document/Renderer/Html/ModulesRenderer.php
@@ -11,9 +11,9 @@ namespace Joomla\CMS\Document\Renderer\Html;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Document\DocumentRenderer;
+use Joomla\CMS\Factory;
 use Joomla\CMS\Helper\ModuleHelper;
 use Joomla\CMS\Layout\LayoutHelper;
-use Joomla\CMS\Factory;
 
 /**
  * HTML document renderer for a module position

--- a/libraries/src/Editor/Editor.php
+++ b/libraries/src/Editor/Editor.php
@@ -10,16 +10,16 @@ namespace Joomla\CMS\Editor;
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\CMS\Factory;
+use Joomla\CMS\Filter\InputFilter;
+use Joomla\CMS\Language\Text;
+use Joomla\CMS\Log\Log;
+use Joomla\Event\AbstractEvent;
 use Joomla\Event\DispatcherAwareInterface;
 use Joomla\Event\DispatcherAwareTrait;
 use Joomla\Event\DispatcherInterface;
 use Joomla\Event\Event;
-use Joomla\Event\AbstractEvent;
 use Joomla\Registry\Registry;
-use Joomla\CMS\Factory;
-use Joomla\CMS\Language\Text;
-use Joomla\CMS\Filter\InputFilter;
-use Joomla\CMS\Log\Log;
 
 /**
  * Editor class to handle WYSIWYG editors

--- a/libraries/src/Event/AbstractEvent.php
+++ b/libraries/src/Event/AbstractEvent.php
@@ -10,9 +10,9 @@ namespace Joomla\CMS\Event;
 
 defined('JPATH_PLATFORM') or die;
 
+use BadMethodCallException;
 use Joomla\Event\Event as BaseEvent;
 use Joomla\String\Normalise;
-use BadMethodCallException;
 
 /**
  * This class implements the base Event object used system-wide to offer orthogonality. Core objects such as Models,

--- a/libraries/src/Event/AfterExtensionBootEvent.php
+++ b/libraries/src/Event/AfterExtensionBootEvent.php
@@ -8,8 +8,6 @@
 
 namespace Joomla\CMS\Event;
 
-use Joomla\CMS\Application\CMSApplication;
-use Joomla\CMS\Extension\ComponentInterface;
 use Joomla\DI\Container;
 
 defined('JPATH_PLATFORM') or die;

--- a/libraries/src/Event/BeforeExtensionBootEvent.php
+++ b/libraries/src/Event/BeforeExtensionBootEvent.php
@@ -8,7 +8,6 @@
 
 namespace Joomla\CMS\Event;
 
-use Joomla\CMS\Application\CMSApplication;
 use Joomla\DI\Container;
 
 defined('JPATH_PLATFORM') or die;

--- a/libraries/src/Event/Table/AfterReorderEvent.php
+++ b/libraries/src/Event/Table/AfterReorderEvent.php
@@ -11,7 +11,6 @@ namespace Joomla\CMS\Event\Table;
 defined('JPATH_PLATFORM') or die;
 
 use BadMethodCallException;
-use stdClass;
 
 /**
  * Event class for JTable's onAfterReorder event

--- a/libraries/src/Extension/LegacyComponent.php
+++ b/libraries/src/Extension/LegacyComponent.php
@@ -18,11 +18,11 @@ use Joomla\CMS\Categories\SectionNotFoundException;
 use Joomla\CMS\Dispatcher\DispatcherInterface;
 use Joomla\CMS\Dispatcher\LegacyDispatcher;
 use Joomla\CMS\Fields\FieldsServiceInterface;
+use Joomla\CMS\Filesystem\Path;
 use Joomla\CMS\MVC\Factory\LegacyFactory;
 use Joomla\CMS\MVC\Factory\MVCFactory;
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
 use Joomla\CMS\MVC\Factory\MVCFactoryServiceInterface;
-use Joomla\CMS\Filesystem\Path;
 
 /**
  * Access to component specific services.

--- a/libraries/src/Factory.php
+++ b/libraries/src/Factory.php
@@ -21,13 +21,12 @@ use Joomla\CMS\Log\Log;
 use Joomla\CMS\Mail\Mail;
 use Joomla\CMS\Mail\MailHelper;
 use Joomla\CMS\Session\Session;
+use Joomla\CMS\User\User;
 use Joomla\Database\DatabaseDriver;
 use Joomla\Database\DatabaseInterface;
 use Joomla\DI\Container;
-use Joomla\CMS\User\User;
 use Joomla\Registry\Registry;
 use PHPMailer\PHPMailer\Exception as phpmailerException;
-use Psr\Log\LoggerInterface;
 
 /**
  * Joomla Platform Factory class.

--- a/libraries/src/Filesystem/Folder.php
+++ b/libraries/src/Filesystem/Folder.php
@@ -10,13 +10,13 @@ namespace Joomla\CMS\Filesystem;
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\CMS\Factory;
-use Joomla\CMS\Log\Log;
-use Joomla\CMS\Filesystem\Wrapper\PathWrapper;
-use Joomla\CMS\Filesystem\Wrapper\FileWrapper;
 use Joomla\CMS\Client\ClientHelper;
 use Joomla\CMS\Client\FtpClient;
+use Joomla\CMS\Factory;
+use Joomla\CMS\Filesystem\Wrapper\FileWrapper;
+use Joomla\CMS\Filesystem\Wrapper\PathWrapper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Log\Log;
 
 /**
  * A Folder handling class

--- a/libraries/src/Filesystem/Patcher.php
+++ b/libraries/src/Filesystem/Patcher.php
@@ -10,7 +10,6 @@ namespace Joomla\CMS\Filesystem;
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\CMS\Log\Log;
 use Joomla\CMS\Language\Text;
 
 /**

--- a/libraries/src/Filesystem/Path.php
+++ b/libraries/src/Filesystem/Path.php
@@ -10,9 +10,9 @@ namespace Joomla\CMS\Filesystem;
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\CMS\Filesystem\Wrapper\PathWrapper;
-use Joomla\CMS\Filesystem\Wrapper\FileWrapper;
 use Joomla\CMS\Crypt\Crypt;
+use Joomla\CMS\Filesystem\Wrapper\FileWrapper;
+use Joomla\CMS\Filesystem\Wrapper\PathWrapper;
 
 if (!defined('JPATH_ROOT'))
 {

--- a/libraries/src/Filesystem/Stream.php
+++ b/libraries/src/Filesystem/Stream.php
@@ -10,9 +10,8 @@ namespace Joomla\CMS\Filesystem;
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\CMS\Object\CMSObject;
-use Joomla\CMS\Filesystem\FilesystemHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Object\CMSObject;
 
 /**
  * Joomla! Stream Interface

--- a/libraries/src/Filter/InputFilter.php
+++ b/libraries/src/Filter/InputFilter.php
@@ -10,9 +10,9 @@ namespace Joomla\CMS\Filter;
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\CMS\Factory;
 use Joomla\Database\UTF8MB4SupportInterface;
 use Joomla\Filter\InputFilter as BaseInputFilter;
-use Joomla\CMS\Factory;
 
 /**
  * InputFilter is a class for filtering input from any data source

--- a/libraries/src/Filter/OutputFilter.php
+++ b/libraries/src/Filter/OutputFilter.php
@@ -10,10 +10,10 @@ namespace Joomla\CMS\Filter;
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\CMS\Factory;
+use Joomla\CMS\Language\Language;
 use Joomla\Filter\OutputFilter as BaseOutputFilter;
 use Joomla\String\StringHelper;
-use Joomla\CMS\Language\Language;
-use Joomla\CMS\Factory;
 
 /**
  * OutputFilter

--- a/libraries/src/Form/Field/AliastagField.php
+++ b/libraries/src/Form/Field/AliastagField.php
@@ -11,8 +11,8 @@ namespace Joomla\CMS\Form\Field;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Factory;
-use Joomla\CMS\Form\FormHelper;
 use Joomla\CMS\Filesystem\Path;
+use Joomla\CMS\Form\FormHelper;
 use Joomla\CMS\Language\Text;
 
 FormHelper::loadFieldClass('list');

--- a/libraries/src/Form/Field/CategoryField.php
+++ b/libraries/src/Form/Field/CategoryField.php
@@ -12,9 +12,9 @@ defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\FormHelper;
-use Joomla\CMS\Log\Log;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Log\Log;
 
 FormHelper::loadFieldClass('list');
 

--- a/libraries/src/Form/Field/CheckboxField.php
+++ b/libraries/src/Form/Field/CheckboxField.php
@@ -10,7 +10,6 @@ namespace Joomla\CMS\Form\Field;
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\CMS\Factory;
 use Joomla\CMS\Form\FormField;
 
 /**

--- a/libraries/src/Form/Field/ChromestyleField.php
+++ b/libraries/src/Form/Field/ChromestyleField.php
@@ -10,10 +10,10 @@ namespace Joomla\CMS\Form\Field;
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\CMS\Factory;
-use Joomla\CMS\Form\FormHelper;
 use Joomla\CMS\Application\ApplicationHelper;
+use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;
+use Joomla\CMS\Form\FormHelper;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 

--- a/libraries/src/Form/Field/ComponentlayoutField.php
+++ b/libraries/src/Form/Field/ComponentlayoutField.php
@@ -12,10 +12,10 @@ defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Application\ApplicationHelper;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Filesystem\Folder;
+use Joomla\CMS\Filesystem\Path;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Form\FormField;
-use Joomla\CMS\Filesystem\Path;
-use Joomla\CMS\Filesystem\Folder;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 

--- a/libraries/src/Form/Field/ComponentsField.php
+++ b/libraries/src/Form/Field/ComponentsField.php
@@ -10,10 +10,10 @@ namespace Joomla\CMS\Form\Field;
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\Utilities\ArrayHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\FormHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\Utilities\ArrayHelper;
 
 FormHelper::loadFieldClass('list');
 

--- a/libraries/src/Form/Field/ContenthistoryField.php
+++ b/libraries/src/Form/Field/ContenthistoryField.php
@@ -11,9 +11,9 @@ namespace Joomla\CMS\Form\Field;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Form\FormField;
+use Joomla\CMS\Language\Text;
 use Joomla\CMS\Session\Session;
 use Joomla\CMS\Table\Table;
-use Joomla\CMS\Language\Text;
 
 /**
  * Field to select Content History from a modal list.

--- a/libraries/src/Form/Field/DatabaseconnectionField.php
+++ b/libraries/src/Form/Field/DatabaseconnectionField.php
@@ -10,9 +10,9 @@ namespace Joomla\CMS\Form\Field;
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\CMS\Form\FormHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\Database\DatabaseDriver;
-use Joomla\CMS\Form\FormHelper;
 
 FormHelper::loadFieldClass('list');
 

--- a/libraries/src/Form/Field/FilelistField.php
+++ b/libraries/src/Form/Field/FilelistField.php
@@ -13,8 +13,8 @@ defined('JPATH_PLATFORM') or die;
 use Joomla\CMS\Form\FormHelper;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
-use Joomla\Filesystem\Folder;
 use Joomla\Filesystem\File;
+use Joomla\Filesystem\Folder;
 use Joomla\Filesystem\Path;
 
 FormHelper::loadFieldClass('list');

--- a/libraries/src/Form/Field/HiddenField.php
+++ b/libraries/src/Form/Field/HiddenField.php
@@ -10,7 +10,6 @@ namespace Joomla\CMS\Form\Field;
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\CMS\Factory;
 use Joomla\CMS\Form\FormField;
 
 /**

--- a/libraries/src/Form/Field/LanguageField.php
+++ b/libraries/src/Form/Field/LanguageField.php
@@ -10,9 +10,9 @@ namespace Joomla\CMS\Form\Field;
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\FormHelper;
-use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Language\LanguageHelper;
 
 FormHelper::loadFieldClass('list');

--- a/libraries/src/Form/Field/ListField.php
+++ b/libraries/src/Form/Field/ListField.php
@@ -18,8 +18,8 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Associations;
 use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\Language\Text;
-use Joomla\CMS\Uri\Uri;
 use Joomla\CMS\Plugin\PluginHelper;
+use Joomla\CMS\Uri\Uri;
 
 /**
  * Form Field class for the Joomla Platform.

--- a/libraries/src/Form/Field/ModulelayoutField.php
+++ b/libraries/src/Form/Field/ModulelayoutField.php
@@ -12,12 +12,12 @@ defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Application\ApplicationHelper;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Filesystem\Folder;
+use Joomla\CMS\Filesystem\Path;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Form\FormField;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
-use Joomla\CMS\Filesystem\Folder;
-use Joomla\CMS\Filesystem\Path;
 
 \JLoader::import('joomla.filesystem.folder');
 

--- a/libraries/src/Form/Field/PredefinedlistField.php
+++ b/libraries/src/Form/Field/PredefinedlistField.php
@@ -10,7 +10,6 @@ namespace Joomla\CMS\Form\Field;
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\CMS\Form\FormHelper;
 use Joomla\CMS\Language\Text;
 
 /**

--- a/libraries/src/Form/Field/RulesField.php
+++ b/libraries/src/Form/Field/RulesField.php
@@ -14,7 +14,6 @@ use Joomla\CMS\Access\Access;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\FormField;
 use Joomla\CMS\Helper\UserGroupsHelper;
-use Joomla\CMS\Layout\LayoutHelper;
 
 /**
  * Form Field class for the Joomla Platform.

--- a/libraries/src/Form/Field/SpacerField.php
+++ b/libraries/src/Form/Field/SpacerField.php
@@ -10,7 +10,6 @@ namespace Joomla\CMS\Form\Field;
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\CMS\Factory;
 use Joomla\CMS\Form\FormField;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;

--- a/libraries/src/Form/Field/SubformField.php
+++ b/libraries/src/Form/Field/SubformField.php
@@ -10,9 +10,9 @@ namespace Joomla\CMS\Form\Field;
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\CMS\Filesystem\Path;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Form\FormField;
-use Joomla\CMS\Filesystem\Path;
 
 /**
  * The Field to load the form inside current form

--- a/libraries/src/Form/Field/TimezoneField.php
+++ b/libraries/src/Form/Field/TimezoneField.php
@@ -10,7 +10,6 @@ namespace Joomla\CMS\Form\Field;
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\CMS\Factory;
 use Joomla\CMS\Form\FormHelper;
 use Joomla\CMS\HTML\HTMLHelper;
 

--- a/libraries/src/Form/Field/TransitionField.php
+++ b/libraries/src/Form/Field/TransitionField.php
@@ -12,9 +12,8 @@ defined('JPATH_BASE') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\FormHelper;
-use Joomla\Utilities\ArrayHelper;
 use Joomla\CMS\Workflow\Workflow;
-use Joomla\CMS\Form\Field\ListField;
+use Joomla\Utilities\ArrayHelper;
 
 FormHelper::loadFieldClass('list');
 

--- a/libraries/src/Form/Field/UrlField.php
+++ b/libraries/src/Form/Field/UrlField.php
@@ -10,7 +10,6 @@ namespace Joomla\CMS\Form\Field;
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\CMS\Factory;
 use Joomla\CMS\Form\FormHelper;
 
 FormHelper::loadFieldClass('text');

--- a/libraries/src/Form/Field/UsergroupField.php
+++ b/libraries/src/Form/Field/UsergroupField.php
@@ -10,7 +10,6 @@ namespace Joomla\CMS\Form\Field;
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\CMS\Factory;
 use Joomla\CMS\Form\FormField;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Log\Log;

--- a/libraries/src/Form/Field/WorkflowStateField.php
+++ b/libraries/src/Form/Field/WorkflowStateField.php
@@ -12,7 +12,6 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
-use Joomla\CMS\Form\Field\GroupedlistField;
 
 /**
  * Workflow States field.

--- a/libraries/src/Form/Form.php
+++ b/libraries/src/Form/Form.php
@@ -10,16 +10,16 @@ namespace Joomla\CMS\Form;
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\CMS\Factory;
+use Joomla\CMS\Filesystem\Path;
+use Joomla\CMS\Filter\InputFilter;
+use Joomla\CMS\Language\Text;
+use Joomla\CMS\Log\Log;
+use Joomla\CMS\Object\CMSObject;
+use Joomla\CMS\String\PunycodeHelper;
 use Joomla\CMS\Uri\Uri;
 use Joomla\Registry\Registry;
 use Joomla\Utilities\ArrayHelper;
-use Joomla\CMS\Language\Text;
-use Joomla\CMS\Factory;
-use Joomla\CMS\Object\CMSObject;
-use Joomla\CMS\Log\Log;
-use Joomla\CMS\Filesystem\Path;
-use Joomla\CMS\Filter\InputFilter;
-use Joomla\CMS\String\PunycodeHelper;
 
 /**
  * Form Class for the Joomla Platform.

--- a/libraries/src/Form/FormField.php
+++ b/libraries/src/Form/FormField.php
@@ -10,11 +10,11 @@ namespace Joomla\CMS\Form;
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\FileLayout;
+use Joomla\CMS\Log\Log;
 use Joomla\String\Normalise;
 use Joomla\String\StringHelper;
-use Joomla\CMS\Language\Text;
-use Joomla\CMS\Log\Log;
 
 /**
  * Abstract Form Field class for the Joomla Platform.

--- a/libraries/src/Form/Rule/CalendarRule.php
+++ b/libraries/src/Form/Rule/CalendarRule.php
@@ -11,10 +11,10 @@ namespace Joomla\CMS\Form\Rule;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Date\Date;
+use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Form\FormRule;
 use Joomla\Registry\Registry;
-use Joomla\CMS\Factory;
 
 /**
  * Form Rule class for the Joomla Platform

--- a/libraries/src/Form/Rule/CaptchaRule.php
+++ b/libraries/src/Form/Rule/CaptchaRule.php
@@ -11,10 +11,10 @@ namespace Joomla\CMS\Form\Rule;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Captcha\Captcha;
+use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Form\FormRule;
 use Joomla\Registry\Registry;
-use Joomla\CMS\Factory;
 
 /**
  * Form Rule class for the Joomla Framework.

--- a/libraries/src/Form/Rule/EmailRule.php
+++ b/libraries/src/Form/Rule/EmailRule.php
@@ -10,11 +10,11 @@ namespace Joomla\CMS\Form\Rule;
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Form\FormRule;
-use Joomla\Registry\Registry;
-use Joomla\CMS\Factory;
 use Joomla\CMS\String\PunycodeHelper;
+use Joomla\Registry\Registry;
 
 /**
  * Form Rule class for the Joomla Platform.

--- a/libraries/src/Form/Rule/PasswordRule.php
+++ b/libraries/src/Form/Rule/PasswordRule.php
@@ -11,11 +11,11 @@ namespace Joomla\CMS\Form\Rule;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Component\ComponentHelper;
+use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Form\FormRule;
-use Joomla\Registry\Registry;
 use Joomla\CMS\Language\Text;
-use Joomla\CMS\Factory;
+use Joomla\Registry\Registry;
 
 /**
  * Form Rule class for the Joomla Platform.

--- a/libraries/src/Form/Rule/UrlRule.php
+++ b/libraries/src/Form/Rule/UrlRule.php
@@ -12,10 +12,10 @@ defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Form\FormRule;
+use Joomla\CMS\Language\Text;
 use Joomla\Registry\Registry;
 use Joomla\String\StringHelper;
 use Joomla\Uri\UriHelper;
-use Joomla\CMS\Language\Text;
 
 /**
  * Form Rule class for the Joomla Platform.

--- a/libraries/src/Form/Rule/UsernameRule.php
+++ b/libraries/src/Form/Rule/UsernameRule.php
@@ -10,10 +10,10 @@ namespace Joomla\CMS\Form\Rule;
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Form\FormRule;
 use Joomla\Registry\Registry;
-use Joomla\CMS\Factory;
 
 /**
  * Form Rule class for the Joomla Platform.

--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -10,15 +10,15 @@ namespace Joomla\CMS\HTML;
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\Utilities\ArrayHelper;
 use Joomla\CMS\Environment\Browser;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Filesystem\File;
-use Joomla\CMS\Layout\LayoutHelper;
-use Joomla\CMS\Log\Log;
 use Joomla\CMS\Filesystem\Path;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
+use Joomla\CMS\Log\Log;
 use Joomla\CMS\Uri\Uri;
+use Joomla\Utilities\ArrayHelper;
 
 /**
  * Utility class for all HTML drawing classes

--- a/libraries/src/Help/Help.php
+++ b/libraries/src/Help/Help.php
@@ -11,9 +11,9 @@ namespace Joomla\CMS\Help;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Application\ApplicationHelper;
+use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
-use Joomla\CMS\Component\ComponentHelper;
 
 /**
  * Help system class

--- a/libraries/src/Helper/AuthenticationHelper.php
+++ b/libraries/src/Helper/AuthenticationHelper.php
@@ -11,8 +11,8 @@ namespace Joomla\CMS\Helper;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Factory;
-use Joomla\CMS\Language\Text;
 use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Language\Text;
 
 /**
  * Authentication helper class

--- a/libraries/src/Helper/ContentHelper.php
+++ b/libraries/src/Helper/ContentHelper.php
@@ -16,12 +16,12 @@ use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\LanguageHelper;
 use Joomla\CMS\Language\Multilanguage;
+use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
+use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Table\Table;
 use Joomla\Registry\Registry;
-use Joomla\CMS\Language\Text;
-use Joomla\CMS\Object\CMSObject;
 
 /**
  * Helper for standard content style extensions.

--- a/libraries/src/Helper/ContentHistoryHelper.php
+++ b/libraries/src/Helper/ContentHistoryHelper.php
@@ -11,9 +11,9 @@ namespace Joomla\CMS\Helper;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Component\ComponentHelper;
-use Joomla\CMS\Table\Table;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Filter\InputFilter;
+use Joomla\CMS\Table\Table;
 
 /**
  * Versions helper class, provides methods to perform various tasks relevant

--- a/libraries/src/Helper/LibraryHelper.php
+++ b/libraries/src/Helper/LibraryHelper.php
@@ -10,10 +10,10 @@ namespace Joomla\CMS\Helper;
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\Registry\Registry;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
+use Joomla\Registry\Registry;
 
 /**
  * Library helper class

--- a/libraries/src/Helper/ModuleHelper.php
+++ b/libraries/src/Helper/ModuleHelper.php
@@ -11,12 +11,12 @@ namespace Joomla\CMS\Helper;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Component\ComponentHelper;
-use Joomla\CMS\Language\LanguageHelper;
-use Joomla\Registry\Registry;
 use Joomla\CMS\Factory;
-use Joomla\CMS\Language\Text;
 use Joomla\CMS\Filter\InputFilter;
+use Joomla\CMS\Language\LanguageHelper;
+use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
+use Joomla\Registry\Registry;
 
 /**
  * Module helper class

--- a/libraries/src/Helper/RouteHelper.php
+++ b/libraries/src/Helper/RouteHelper.php
@@ -11,8 +11,8 @@ namespace Joomla\CMS\Helper;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Component\ComponentHelper;
-use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Language\Multilanguage;
 
 /**
  * Route Helper

--- a/libraries/src/Helper/TagsHelper.php
+++ b/libraries/src/Helper/TagsHelper.php
@@ -11,11 +11,11 @@ namespace Joomla\CMS\Helper;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Component\ComponentHelper;
+use Joomla\CMS\Factory;
 use Joomla\CMS\Table\CoreContent;
 use Joomla\CMS\Table\Table;
 use Joomla\CMS\Table\TableInterface;
 use Joomla\Utilities\ArrayHelper;
-use Joomla\CMS\Factory;
 
 /**
  * Tags helper class, provides methods to perform various tasks relevant

--- a/libraries/src/Http/Transport/CurlTransport.php
+++ b/libraries/src/Http/Transport/CurlTransport.php
@@ -10,6 +10,7 @@ namespace Joomla\CMS\Http\Transport;
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\CMS\Factory;
 use Joomla\CMS\Http\Response;
 use Joomla\CMS\Http\TransportInterface;
 use Joomla\CMS\Uri\Uri;
@@ -17,7 +18,6 @@ use Joomla\Http\AbstractTransport;
 use Joomla\Http\Exception\InvalidResponseCodeException;
 use Joomla\Uri\UriInterface;
 use Zend\Diactoros\Stream as StreamResponse;
-use Joomla\CMS\Factory;
 
 /**
  * HTTP transport class for using cURL.

--- a/libraries/src/Http/Transport/SocketTransport.php
+++ b/libraries/src/Http/Transport/SocketTransport.php
@@ -10,6 +10,7 @@ namespace Joomla\CMS\Http\Transport;
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\CMS\Factory;
 use Joomla\CMS\Http\Response;
 use Joomla\CMS\Http\TransportInterface;
 use Joomla\CMS\Uri\Uri;
@@ -17,7 +18,6 @@ use Joomla\Http\AbstractTransport;
 use Joomla\Http\Exception\InvalidResponseCodeException;
 use Joomla\Uri\UriInterface;
 use Zend\Diactoros\Stream as StreamResponse;
-use Joomla\CMS\Factory;
 
 /**
  * HTTP transport class for using sockets directly.

--- a/libraries/src/Http/Transport/StreamTransport.php
+++ b/libraries/src/Http/Transport/StreamTransport.php
@@ -10,14 +10,14 @@ namespace Joomla\CMS\Http\Transport;
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\Http\AbstractTransport;
-use Joomla\Http\Exception\InvalidResponseCodeException;
+use Joomla\CMS\Factory;
 use Joomla\CMS\Http\Response;
 use Joomla\CMS\Http\TransportInterface;
+use Joomla\Http\AbstractTransport;
+use Joomla\Http\Exception\InvalidResponseCodeException;
 use Joomla\Uri\Uri;
 use Joomla\Uri\UriInterface;
 use Zend\Diactoros\Stream as StreamResponse;
-use Joomla\CMS\Factory;
 
 /**
  * HTTP transport class for using PHP streams.

--- a/libraries/src/Image/Image.php
+++ b/libraries/src/Image/Image.php
@@ -11,8 +11,8 @@ namespace Joomla\CMS\Image;
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\Image\Image as FrameworkImage;
 use Joomla\CMS\Log\Log;
+use Joomla\Image\Image as FrameworkImage;
 
 /**
  * Class to manipulate an image.

--- a/libraries/src/Installer/Adapter/ComponentAdapter.php
+++ b/libraries/src/Installer/Adapter/ComponentAdapter.php
@@ -11,17 +11,17 @@ namespace Joomla\CMS\Installer\Adapter;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Application\ApplicationHelper;
+use Joomla\CMS\Factory;
+use Joomla\CMS\Filesystem\Folder;
+use Joomla\CMS\Filesystem\Path;
 use Joomla\CMS\Installer\Installer;
 use Joomla\CMS\Installer\InstallerAdapter;
+use Joomla\CMS\Language\Text;
+use Joomla\CMS\Log\Log;
 use Joomla\CMS\Table\Asset;
 use Joomla\CMS\Table\Extension;
 use Joomla\CMS\Table\Table;
 use Joomla\CMS\Table\Update;
-use Joomla\CMS\Factory;
-use Joomla\CMS\Language\Text;
-use Joomla\CMS\Filesystem\Folder;
-use Joomla\CMS\Log\Log;
-use Joomla\CMS\Filesystem\Path;
 use Joomla\Database\ParameterType;
 
 /**

--- a/libraries/src/Installer/Adapter/FileAdapter.php
+++ b/libraries/src/Installer/Adapter/FileAdapter.php
@@ -10,14 +10,14 @@ namespace Joomla\CMS\Installer\Adapter;
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\CMS\Installer\Installer;
-use Joomla\CMS\Installer\InstallerAdapter;
-use Joomla\CMS\Table\Table;
-use Joomla\CMS\Language\Text;
 use Joomla\CMS\Filesystem\File;
 use Joomla\CMS\Filesystem\Folder;
-use Joomla\CMS\Log\Log;
 use Joomla\CMS\Filesystem\Path;
+use Joomla\CMS\Installer\Installer;
+use Joomla\CMS\Installer\InstallerAdapter;
+use Joomla\CMS\Language\Text;
+use Joomla\CMS\Log\Log;
+use Joomla\CMS\Table\Table;
 use Joomla\Database\ParameterType;
 
 /**

--- a/libraries/src/Installer/Adapter/LanguageAdapter.php
+++ b/libraries/src/Installer/Adapter/LanguageAdapter.php
@@ -12,19 +12,19 @@ defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Application\ApplicationHelper;
 use Joomla\CMS\Component\ComponentHelper;
+use Joomla\CMS\Factory;
+use Joomla\CMS\Filesystem\Folder;
+use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\Installer\Installer;
 use Joomla\CMS\Installer\InstallerAdapter;
 use Joomla\CMS\Language\Language;
 use Joomla\CMS\Language\LanguageHelper;
+use Joomla\CMS\Language\Text;
+use Joomla\CMS\Log\Log;
 use Joomla\CMS\Table\Table;
 use Joomla\CMS\Table\Update;
 use Joomla\Database\ParameterType;
 use Joomla\Registry\Registry;
-use Joomla\CMS\Factory;
-use Joomla\CMS\Language\Text;
-use Joomla\CMS\Filter\InputFilter;
-use Joomla\CMS\Filesystem\Folder;
-use Joomla\CMS\Log\Log;
 
 /**
  * Language installer

--- a/libraries/src/Installer/Adapter/LibraryAdapter.php
+++ b/libraries/src/Installer/Adapter/LibraryAdapter.php
@@ -10,17 +10,17 @@ namespace Joomla\CMS\Installer\Adapter;
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\CMS\Filesystem\File;
+use Joomla\CMS\Filesystem\Folder;
+use Joomla\CMS\Filesystem\Path;
+use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\Installer\Installer;
 use Joomla\CMS\Installer\InstallerAdapter;
 use Joomla\CMS\Installer\Manifest\LibraryManifest;
+use Joomla\CMS\Language\Text;
+use Joomla\CMS\Log\Log;
 use Joomla\CMS\Table\Table;
 use Joomla\CMS\Table\Update;
-use Joomla\CMS\Language\Text;
-use Joomla\CMS\Filter\InputFilter;
-use Joomla\CMS\Filesystem\File;
-use Joomla\CMS\Filesystem\Folder;
-use Joomla\CMS\Log\Log;
-use Joomla\CMS\Filesystem\Path;
 use Joomla\Database\ParameterType;
 
 /**

--- a/libraries/src/Installer/Adapter/ModuleAdapter.php
+++ b/libraries/src/Installer/Adapter/ModuleAdapter.php
@@ -11,14 +11,14 @@ namespace Joomla\CMS\Installer\Adapter;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Application\ApplicationHelper;
+use Joomla\CMS\Filesystem\Folder;
 use Joomla\CMS\Installer\Installer;
 use Joomla\CMS\Installer\InstallerAdapter;
+use Joomla\CMS\Language\Text;
+use Joomla\CMS\Log\Log;
 use Joomla\CMS\Table\Table;
 use Joomla\Database\ParameterType;
 use Joomla\Utilities\ArrayHelper;
-use Joomla\CMS\Language\Text;
-use Joomla\CMS\Filesystem\Folder;
-use Joomla\CMS\Log\Log;
 
 /**
  * Module installer

--- a/libraries/src/Installer/Adapter/PackageAdapter.php
+++ b/libraries/src/Installer/Adapter/PackageAdapter.php
@@ -11,20 +11,20 @@ namespace Joomla\CMS\Installer\Adapter;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Application\ApplicationHelper;
+use Joomla\CMS\Factory;
+use Joomla\CMS\Filesystem\File;
+use Joomla\CMS\Filesystem\Folder;
+use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\Installer\Installer;
 use Joomla\CMS\Installer\InstallerAdapter;
 use Joomla\CMS\Installer\InstallerHelper;
 use Joomla\CMS\Installer\Manifest\PackageManifest;
+use Joomla\CMS\Language\Text;
+use Joomla\CMS\Log\Log;
 use Joomla\CMS\Table\Table;
 use Joomla\CMS\Table\Update;
 use Joomla\Database\ParameterType;
 use Joomla\Event\Event;
-use Joomla\CMS\Factory;
-use Joomla\CMS\Language\Text;
-use Joomla\CMS\Filter\InputFilter;
-use Joomla\CMS\Filesystem\File;
-use Joomla\CMS\Filesystem\Folder;
-use Joomla\CMS\Log\Log;
 
 /**
  * Package installer

--- a/libraries/src/Installer/Adapter/PluginAdapter.php
+++ b/libraries/src/Installer/Adapter/PluginAdapter.php
@@ -11,14 +11,14 @@ namespace Joomla\CMS\Installer\Adapter;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Application\ApplicationHelper;
-use Joomla\CMS\Installer\Installer;
-use Joomla\CMS\Installer\InstallerAdapter;
-use Joomla\CMS\Table\Table;
-use Joomla\CMS\Table\Update;
-use Joomla\CMS\Language\Text;
 use Joomla\CMS\Filesystem\File;
 use Joomla\CMS\Filesystem\Folder;
+use Joomla\CMS\Installer\Installer;
+use Joomla\CMS\Installer\InstallerAdapter;
+use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
+use Joomla\CMS\Table\Table;
+use Joomla\CMS\Table\Update;
 
 /**
  * Plugin installer

--- a/libraries/src/Installer/Adapter/TemplateAdapter.php
+++ b/libraries/src/Installer/Adapter/TemplateAdapter.php
@@ -11,14 +11,14 @@ namespace Joomla\CMS\Installer\Adapter;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Application\ApplicationHelper;
+use Joomla\CMS\Factory;
+use Joomla\CMS\Filesystem\Folder;
 use Joomla\CMS\Installer\Installer;
 use Joomla\CMS\Installer\InstallerAdapter;
+use Joomla\CMS\Language\Text;
+use Joomla\CMS\Log\Log;
 use Joomla\CMS\Table\Table;
 use Joomla\CMS\Table\Update;
-use Joomla\CMS\Factory;
-use Joomla\CMS\Language\Text;
-use Joomla\CMS\Filesystem\Folder;
-use Joomla\CMS\Log\Log;
 use Joomla\Database\ParameterType;
 
 /**

--- a/libraries/src/Installer/Installer.php
+++ b/libraries/src/Installer/Installer.php
@@ -11,19 +11,19 @@ namespace Joomla\CMS\Installer;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Application\ApplicationHelper;
+use Joomla\CMS\Factory;
+use Joomla\CMS\Filesystem\File;
+use Joomla\CMS\Filesystem\Folder;
+use Joomla\CMS\Filesystem\Path;
+use Joomla\CMS\Language\Text;
+use Joomla\CMS\Log\Log;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Table\Extension;
 use Joomla\CMS\Table\Table;
+use Joomla\Database\DatabaseDriver;
 use Joomla\Database\Exception\ExecutionFailureException;
 use Joomla\Database\ParameterType;
 use Joomla\Database\UTF8MB4SupportInterface;
-use Joomla\CMS\Factory;
-use Joomla\CMS\Language\Text;
-use Joomla\Database\DatabaseDriver;
-use Joomla\CMS\Filesystem\File;
-use Joomla\CMS\Filesystem\Folder;
-use Joomla\CMS\Log\Log;
-use Joomla\CMS\Filesystem\Path;
 
 \JLoader::import('joomla.base.adapter');
 

--- a/libraries/src/Installer/InstallerAdapter.php
+++ b/libraries/src/Installer/InstallerAdapter.php
@@ -10,16 +10,16 @@ namespace Joomla\CMS\Installer;
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\CMS\Factory;
+use Joomla\CMS\Filesystem\Folder;
+use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\Installer\Manifest\PackageManifest;
+use Joomla\CMS\Language\Text;
+use Joomla\CMS\Log\Log;
 use Joomla\CMS\Table\Extension;
 use Joomla\CMS\Table\Table;
 use Joomla\CMS\Table\TableInterface;
-use Joomla\CMS\Factory;
-use Joomla\CMS\Language\Text;
 use Joomla\Database\DatabaseDriver;
-use Joomla\CMS\Filter\InputFilter;
-use Joomla\CMS\Filesystem\Folder;
-use Joomla\CMS\Log\Log;
 
 /**
  * Abstract adapter for the installer.

--- a/libraries/src/Installer/InstallerExtension.php
+++ b/libraries/src/Installer/InstallerExtension.php
@@ -12,8 +12,8 @@ defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Application\ApplicationHelper;
 use Joomla\CMS\Language\Text;
-use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Log\Log;
+use Joomla\CMS\Object\CMSObject;
 
 /**
  * Extension object

--- a/libraries/src/Installer/InstallerHelper.php
+++ b/libraries/src/Installer/InstallerHelper.php
@@ -10,15 +10,15 @@ namespace Joomla\CMS\Installer;
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\CMS\Factory;
 use Joomla\Archive\Archive;
-use Joomla\CMS\Plugin\PluginHelper;
-use Joomla\CMS\Version;
-use Joomla\CMS\Language\Text;
+use Joomla\CMS\Factory;
 use Joomla\CMS\Filesystem\File;
 use Joomla\CMS\Filesystem\Folder;
-use Joomla\CMS\Log\Log;
 use Joomla\CMS\Filesystem\Path;
+use Joomla\CMS\Language\Text;
+use Joomla\CMS\Log\Log;
+use Joomla\CMS\Plugin\PluginHelper;
+use Joomla\CMS\Version;
 
 /**
  * Installer helper class

--- a/libraries/src/Installer/InstallerScript.php
+++ b/libraries/src/Installer/InstallerScript.php
@@ -11,9 +11,9 @@ namespace Joomla\CMS\Installer;
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
-use Joomla\CMS\Language\Text;
 use Joomla\CMS\Filesystem\File;
 use Joomla\CMS\Filesystem\Folder;
+use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
 use Joomla\Database\ParameterType;
 

--- a/libraries/src/Language/Associations.php
+++ b/libraries/src/Language/Associations.php
@@ -10,8 +10,8 @@ namespace Joomla\CMS\Language;
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\Registry\Registry;
 use Joomla\CMS\Factory;
+use Joomla\Registry\Registry;
 
 /**
  * Utitlity class for associations in multilang

--- a/libraries/src/Language/Language.php
+++ b/libraries/src/Language/Language.php
@@ -10,8 +10,8 @@ namespace Joomla\CMS\Language;
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\String\StringHelper;
 use Joomla\CMS\Log\Log;
+use Joomla\String\StringHelper;
 
 /**
  * Allows for quoting in language .ini files.

--- a/libraries/src/Language/LanguageHelper.php
+++ b/libraries/src/Language/LanguageHelper.php
@@ -10,12 +10,11 @@ namespace Joomla\CMS\Language;
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\Registry\Registry;
-use Joomla\Utilities\ArrayHelper;
 use Joomla\CMS\Factory;
-use Joomla\CMS\Language\Text;
 use Joomla\CMS\Filesystem\File;
 use Joomla\CMS\Log\Log;
+use Joomla\Registry\Registry;
+use Joomla\Utilities\ArrayHelper;
 
 /**
  * Language helper class

--- a/libraries/src/Language/LanguageStemmer.php
+++ b/libraries/src/Language/LanguageStemmer.php
@@ -10,8 +10,6 @@ namespace Joomla\CMS\Language;
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\CMS\Language\Text;
-
 /**
  * Stemmer base class.
  *

--- a/libraries/src/Language/Multilanguage.php
+++ b/libraries/src/Language/Multilanguage.php
@@ -12,7 +12,6 @@ defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Log\Log;
-use Joomla\CMS\Language\LanguageHelper;
 
 /**
  * Utitlity class for multilang

--- a/libraries/src/Log/Logger/DatabaseLogger.php
+++ b/libraries/src/Log/Logger/DatabaseLogger.php
@@ -10,9 +10,9 @@ namespace Joomla\CMS\Log\Logger;
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\CMS\Factory;
 use Joomla\CMS\Log\LogEntry;
 use Joomla\CMS\Log\Logger;
-use Joomla\CMS\Factory;
 use Joomla\Database\DatabaseDriver;
 
 /**

--- a/libraries/src/Log/Logger/FormattedtextLogger.php
+++ b/libraries/src/Log/Logger/FormattedtextLogger.php
@@ -10,11 +10,11 @@ namespace Joomla\CMS\Log\Logger;
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\CMS\Log\LogEntry;
-use Joomla\CMS\Log\Logger;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Filesystem\File;
 use Joomla\CMS\Filesystem\Folder;
+use Joomla\CMS\Log\LogEntry;
+use Joomla\CMS\Log\Logger;
 
 /**
  * Joomla! Formatted Text File Log class

--- a/libraries/src/Log/Logger/MessagequeueLogger.php
+++ b/libraries/src/Log/Logger/MessagequeueLogger.php
@@ -10,10 +10,10 @@ namespace Joomla\CMS\Log\Logger;
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\CMS\Factory;
 use Joomla\CMS\Log\Log;
 use Joomla\CMS\Log\LogEntry;
 use Joomla\CMS\Log\Logger;
-use Joomla\CMS\Factory;
 
 /**
  * Joomla MessageQueue logger class.

--- a/libraries/src/MVC/Controller/AdminController.php
+++ b/libraries/src/MVC/Controller/AdminController.php
@@ -10,14 +10,14 @@ namespace Joomla\CMS\MVC\Controller;
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
-use Joomla\CMS\MVC\Model\BaseDatabaseModel;
-use Joomla\Utilities\ArrayHelper;
+use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
-use Joomla\CMS\Session\Session;
+use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
+use Joomla\CMS\MVC\Model\BaseDatabaseModel;
 use Joomla\CMS\Router\Route;
-use Joomla\CMS\Component\ComponentHelper;
+use Joomla\CMS\Session\Session;
+use Joomla\Utilities\ArrayHelper;
 
 /**
  * Base class for a Joomla Administrator Controller

--- a/libraries/src/MVC/Controller/BaseController.php
+++ b/libraries/src/MVC/Controller/BaseController.php
@@ -11,17 +11,17 @@ namespace Joomla\CMS\MVC\Controller;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Application\CMSApplication;
-use Joomla\CMS\MVC\Model\BaseDatabaseModel;
+use Joomla\CMS\Factory;
+use Joomla\CMS\Filesystem\Path;
+use Joomla\CMS\Filter\InputFilter;
+use Joomla\CMS\Language\Text;
+use Joomla\CMS\Log\Log;
 use Joomla\CMS\MVC\Factory\LegacyFactory;
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
+use Joomla\CMS\MVC\Model\BaseDatabaseModel;
 use Joomla\CMS\MVC\View\AbstractView;
-use Joomla\CMS\Factory;
-use Joomla\CMS\Language\Text;
-use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\Session\Session;
 use Joomla\CMS\Uri\Uri;
-use Joomla\CMS\Log\Log;
-use Joomla\CMS\Filesystem\Path;
 
 /**
  * Base class for a Joomla Controller

--- a/libraries/src/MVC/Controller/FormController.php
+++ b/libraries/src/MVC/Controller/FormController.php
@@ -11,17 +11,17 @@ namespace Joomla\CMS\MVC\Controller;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Application\CMSApplication;
-use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
-use Joomla\CMS\MVC\Model\BaseDatabaseModel;
+use Joomla\CMS\Component\ComponentHelper;
+use Joomla\CMS\Factory;
 use Joomla\CMS\Form\FormFactoryAwareInterface;
 use Joomla\CMS\Form\FormFactoryAwareTrait;
 use Joomla\CMS\Form\FormFactoryInterface;
-use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
+use Joomla\CMS\MVC\Model\BaseDatabaseModel;
+use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
 use Joomla\CMS\Uri\Uri;
-use Joomla\CMS\Router\Route;
-use Joomla\CMS\Component\ComponentHelper;
 
 /**
  * Controller tailored to suit most form-based admin operations.

--- a/libraries/src/MVC/Factory/LegacyFactory.php
+++ b/libraries/src/MVC/Factory/LegacyFactory.php
@@ -11,12 +11,12 @@ namespace Joomla\CMS\MVC\Factory;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Application\CMSApplicationInterface;
+use Joomla\CMS\Filesystem\Path;
+use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Controller\BaseController;
 use Joomla\CMS\MVC\Model\BaseDatabaseModel;
 use Joomla\CMS\Table\Table;
 use Joomla\Input\Input;
-use Joomla\CMS\Language\Text;
-use Joomla\CMS\Filesystem\Path;
 
 /**
  * Factory to create MVC objects in legacy mode.

--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -10,18 +10,18 @@ namespace Joomla\CMS\MVC\Model;
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\CMS\Component\ComponentHelper;
+use Joomla\CMS\Factory;
+use Joomla\CMS\Form\FormFactoryInterface;
+use Joomla\CMS\Language\Associations;
+use Joomla\CMS\Language\Text;
+use Joomla\CMS\Log\Log;
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
+use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Table\Table;
 use Joomla\Registry\Registry;
 use Joomla\String\StringHelper;
 use Joomla\Utilities\ArrayHelper;
-use Joomla\CMS\Form\FormFactoryInterface;
-use Joomla\CMS\Factory;
-use Joomla\CMS\Language\Text;
-use Joomla\CMS\Object\CMSObject;
-use Joomla\CMS\Log\Log;
-use Joomla\CMS\Language\Associations;
-use Joomla\CMS\Component\ComponentHelper;
 
 /**
  * Prototype admin model.

--- a/libraries/src/MVC/Model/BaseDatabaseModel.php
+++ b/libraries/src/MVC/Model/BaseDatabaseModel.php
@@ -10,20 +10,20 @@ namespace Joomla\CMS\MVC\Model;
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\CMS\Extension\ComponentInterface;
 use Joomla\CMS\Component\ComponentHelper;
+use Joomla\CMS\Extension\ComponentInterface;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Filesystem\Path;
+use Joomla\CMS\Language\Text;
+use Joomla\CMS\Log\Log;
 use Joomla\CMS\MVC\Factory\LegacyFactory;
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
 use Joomla\CMS\MVC\Factory\MVCFactoryServiceInterface;
 use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Table\Table;
 use Joomla\Database\DatabaseDriver;
-use Joomla\Utilities\ArrayHelper;
-use Joomla\CMS\Language\Text;
 use Joomla\Database\DatabaseQuery;
-use Joomla\CMS\Log\Log;
-use Joomla\CMS\Filesystem\Path;
+use Joomla\Utilities\ArrayHelper;
 
 /**
  * Base class for a database aware Joomla Model

--- a/libraries/src/MVC/Model/FormModel.php
+++ b/libraries/src/MVC/Model/FormModel.php
@@ -10,13 +10,13 @@ namespace Joomla\CMS\MVC\Model;
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\FormFactoryAwareInterface;
 use Joomla\CMS\Form\FormFactoryAwareTrait;
 use Joomla\CMS\Form\FormFactoryInterface;
-use Joomla\Utilities\ArrayHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
+use Joomla\Utilities\ArrayHelper;
 
 /**
  * Prototype form model.

--- a/libraries/src/MVC/Model/ListModel.php
+++ b/libraries/src/MVC/Model/ListModel.php
@@ -10,10 +10,10 @@ namespace Joomla\CMS\MVC\Model;
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
-use Joomla\Utilities\ArrayHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Filter\InputFilter;
+use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
+use Joomla\Utilities\ArrayHelper;
 
 /**
  * Model class for handling lists of items.

--- a/libraries/src/MVC/View/AbstractView.php
+++ b/libraries/src/MVC/View/AbstractView.php
@@ -11,8 +11,8 @@ namespace Joomla\CMS\MVC\View;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Document\Document;
-use Joomla\CMS\MVC\Model\BaseDatabaseModel;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\MVC\Model\BaseDatabaseModel;
 use Joomla\CMS\Object\CMSObject;
 
 /**

--- a/libraries/src/MVC/View/HtmlView.php
+++ b/libraries/src/MVC/View/HtmlView.php
@@ -12,10 +12,10 @@ defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Application\ApplicationHelper;
 use Joomla\CMS\Factory;
-use Joomla\CMS\Language\Text;
-use Joomla\CMS\Uri\Uri;
-use Joomla\CMS\Log\Log;
 use Joomla\CMS\Filesystem\Path;
+use Joomla\CMS\Language\Text;
+use Joomla\CMS\Log\Log;
+use Joomla\CMS\Uri\Uri;
 
 /**
  * Base class for a Joomla Html View

--- a/libraries/src/MVC/View/ListView.php
+++ b/libraries/src/MVC/View/ListView.php
@@ -12,10 +12,10 @@ namespace Joomla\CMS\MVC\View;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Factory;
-use Joomla\CMS\Language\Text;
 use Joomla\CMS\HTML\HTMLHelper;
-use Joomla\CMS\Object\CMSObject;
+use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\FileLayout;
+use Joomla\CMS\Object\CMSObject;
 
 /**
  * Base class for a Joomla List View

--- a/libraries/src/Mail/Mail.php
+++ b/libraries/src/Mail/Mail.php
@@ -11,8 +11,8 @@ namespace Joomla\CMS\Mail;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Factory;
-use Joomla\CMS\Log\Log;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Log\Log;
 use PHPMailer\PHPMailer\Exception as phpmailerException;
 use PHPMailer\PHPMailer\PHPMailer;
 

--- a/libraries/src/Menu/AbstractMenu.php
+++ b/libraries/src/Menu/AbstractMenu.php
@@ -10,9 +10,9 @@ namespace Joomla\CMS\Menu;
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\Registry\Registry;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
+use Joomla\Registry\Registry;
 
 /**
  * Menu class

--- a/libraries/src/Menu/MenuHelper.php
+++ b/libraries/src/Menu/MenuHelper.php
@@ -9,9 +9,9 @@ namespace Joomla\CMS\Menu;
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\Registry\Registry;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Filesystem\Folder;
+use Joomla\Registry\Registry;
 
 /**
  * Menu Helper utility

--- a/libraries/src/Menu/Node/Component.php
+++ b/libraries/src/Menu/Node/Component.php
@@ -9,8 +9,8 @@ namespace Joomla\CMS\Menu\Node;
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\CMS\Menu\Node;
 use Joomla\CMS\Filter\OutputFilter;
+use Joomla\CMS\Menu\Node;
 
 /**
  * A Component type of node for MenuTree

--- a/libraries/src/Menu/Node/Url.php
+++ b/libraries/src/Menu/Node/Url.php
@@ -9,8 +9,8 @@ namespace Joomla\CMS\Menu\Node;
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\CMS\Menu\Node;
 use Joomla\CMS\Filter\OutputFilter;
+use Joomla\CMS\Menu\Node;
 
 /**
  * An external Url type of node for MenuTree

--- a/libraries/src/Menu/SiteMenu.php
+++ b/libraries/src/Menu/SiteMenu.php
@@ -11,9 +11,9 @@ namespace Joomla\CMS\Menu;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Application\CMSApplication;
+use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Language;
 use Joomla\CMS\Language\Multilanguage;
-use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\Database\DatabaseDriver;
 

--- a/libraries/src/Pagination/Pagination.php
+++ b/libraries/src/Pagination/Pagination.php
@@ -12,11 +12,11 @@ defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Application\CMSApplication;
 use Joomla\CMS\Factory;
-use Joomla\CMS\Language\Text;
 use Joomla\CMS\HTML\HTMLHelper;
-use Joomla\CMS\Router\Route;
-use Joomla\CMS\Log\Log;
+use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
+use Joomla\CMS\Log\Log;
+use Joomla\CMS\Router\Route;
 
 /**
  * Pagination Class. Provides a common interface for content pagination for the Joomla! CMS.

--- a/libraries/src/Plugin/CMSPlugin.php
+++ b/libraries/src/Plugin/CMSPlugin.php
@@ -12,9 +12,9 @@ defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\Event\AbstractEvent;
-use Joomla\Event\DispatcherInterface;
 use Joomla\Event\DispatcherAwareInterface;
 use Joomla\Event\DispatcherAwareTrait;
+use Joomla\Event\DispatcherInterface;
 use Joomla\Event\SubscriberInterface;
 use Joomla\Registry\Registry;
 

--- a/libraries/src/Plugin/PluginHelper.php
+++ b/libraries/src/Plugin/PluginHelper.php
@@ -10,8 +10,8 @@ namespace Joomla\CMS\Plugin;
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\Event\DispatcherInterface;
 use Joomla\CMS\Factory;
+use Joomla\Event\DispatcherInterface;
 
 /**
  * Plugin helper class

--- a/libraries/src/Router/Router.php
+++ b/libraries/src/Router/Router.php
@@ -10,9 +10,9 @@ namespace Joomla\CMS\Router;
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Exception\RouteNotFoundException;
-use Joomla\CMS\Factory;
 use Joomla\CMS\Uri\Uri;
 
 /**

--- a/libraries/src/Schema/ChangeItem.php
+++ b/libraries/src/Schema/ChangeItem.php
@@ -10,10 +10,9 @@ namespace Joomla\CMS\Schema;
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\CMS\Factory;
 use Joomla\Database\Exception\ExecutionFailureException;
 use Joomla\Database\UTF8MB4SupportInterface;
-use Joomla\CMS\Factory;
-use Joomla\CMS\Language\Text;
 
 /**
  * Each object represents one query, which is one line from a DDL SQL query.

--- a/libraries/src/Schema/ChangeSet.php
+++ b/libraries/src/Schema/ChangeSet.php
@@ -10,10 +10,10 @@ namespace Joomla\CMS\Schema;
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\Database\UTF8MB4SupportInterface;
 use Joomla\CMS\Factory;
-use Joomla\Database\DatabaseDriver;
 use Joomla\CMS\Filesystem\Folder;
+use Joomla\Database\DatabaseDriver;
+use Joomla\Database\UTF8MB4SupportInterface;
 
 /**
  * Contains a set of JSchemaChange objects for a particular instance of Joomla.

--- a/libraries/src/Service/Provider/Application.php
+++ b/libraries/src/Service/Provider/Application.php
@@ -11,14 +11,14 @@ namespace Joomla\CMS\Service\Provider;
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\CMS\Console\SessionGcCommand;
-use Joomla\CMS\Console\SessionMetadataGcCommand;
-use Joomla\Console\Application as BaseConsoleApplication;
 use Joomla\CMS\Application\AdministratorApplication;
 use Joomla\CMS\Application\ConsoleApplication;
 use Joomla\CMS\Application\SiteApplication;
+use Joomla\CMS\Console\SessionGcCommand;
+use Joomla\CMS\Console\SessionMetadataGcCommand;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Session\Session;
+use Joomla\Console\Application as BaseConsoleApplication;
 use Joomla\Console\Loader\ContainerLoader;
 use Joomla\Console\Loader\LoaderInterface;
 use Joomla\DI\Container;

--- a/libraries/src/Service/Provider/Authentication.php
+++ b/libraries/src/Service/Provider/Authentication.php
@@ -10,11 +10,11 @@ namespace Joomla\CMS\Service\Provider;
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\Authentication\Password\Argon2iHandler as BaseArgon2iHandler;
 use Joomla\Authentication\Password\Argon2idHandler as BaseArgon2idHandler;
+use Joomla\Authentication\Password\Argon2iHandler as BaseArgon2iHandler;
 use Joomla\Authentication\Password\BCryptHandler as BaseBCryptHandler;
-use Joomla\CMS\Authentication\Password\Argon2iHandler;
 use Joomla\CMS\Authentication\Password\Argon2idHandler;
+use Joomla\CMS\Authentication\Password\Argon2iHandler;
 use Joomla\CMS\Authentication\Password\BCryptHandler;
 use Joomla\CMS\Authentication\Password\ChainedHandler;
 use Joomla\CMS\Authentication\Password\MD5Handler;

--- a/libraries/src/Session/Session.php
+++ b/libraries/src/Session/Session.php
@@ -11,11 +11,11 @@ namespace Joomla\CMS\Session;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Application\ApplicationHelper;
-use Joomla\Session\Session as BaseSession;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
-use Joomla\CMS\Router\Route;
 use Joomla\CMS\Log\Log;
+use Joomla\CMS\Router\Route;
+use Joomla\Session\Session as BaseSession;
 
 /**
  * Class for managing HTTP sessions

--- a/libraries/src/Session/Storage/JoomlaStorage.php
+++ b/libraries/src/Session/Storage/JoomlaStorage.php
@@ -10,10 +10,10 @@ namespace Joomla\CMS\Session\Storage;
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\CMS\Factory;
 use Joomla\Input\Input;
 use Joomla\Registry\Registry;
 use Joomla\Session\Storage\NativeStorage;
-use Joomla\CMS\Factory;
 
 /**
  * Service provider for the application's session dependency

--- a/libraries/src/Table/Category.php
+++ b/libraries/src/Table/Category.php
@@ -12,12 +12,12 @@ defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Access\Rules;
 use Joomla\CMS\Application\ApplicationHelper;
-use Joomla\CMS\Table\Observer\ContentHistory;
-use Joomla\CMS\Table\Observer\Tags;
-use Joomla\Registry\Registry;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Table\Observer\ContentHistory;
+use Joomla\CMS\Table\Observer\Tags;
 use Joomla\Database\DatabaseDriver;
+use Joomla\Registry\Registry;
 
 /**
  * Category table

--- a/libraries/src/Table/Content.php
+++ b/libraries/src/Table/Content.php
@@ -13,11 +13,11 @@ defined('JPATH_PLATFORM') or die;
 use Joomla\CMS\Access\Access;
 use Joomla\CMS\Access\Rules;
 use Joomla\CMS\Application\ApplicationHelper;
-use Joomla\Registry\Registry;
-use Joomla\String\StringHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\Database\DatabaseDriver;
+use Joomla\Registry\Registry;
+use Joomla\String\StringHelper;
 
 /**
  * Content table

--- a/libraries/src/Table/CoreContent.php
+++ b/libraries/src/Table/CoreContent.php
@@ -11,12 +11,12 @@ namespace Joomla\CMS\Table;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Application\ApplicationHelper;
-use Joomla\Registry\Registry;
-use Joomla\String\StringHelper;
-use Joomla\Utilities\ArrayHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\Database\DatabaseDriver;
+use Joomla\Registry\Registry;
+use Joomla\String\StringHelper;
+use Joomla\Utilities\ArrayHelper;
 
 /**
  * Core content table

--- a/libraries/src/Table/Extension.php
+++ b/libraries/src/Table/Extension.php
@@ -10,10 +10,10 @@ namespace Joomla\CMS\Table;
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\Registry\Registry;
-use Joomla\Utilities\ArrayHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\Database\DatabaseDriver;
+use Joomla\Registry\Registry;
+use Joomla\Utilities\ArrayHelper;
 
 /**
  * Extension table

--- a/libraries/src/Table/Menu.php
+++ b/libraries/src/Table/Menu.php
@@ -11,12 +11,12 @@ namespace Joomla\CMS\Table;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Application\ApplicationHelper;
-use Joomla\CMS\Language\Multilanguage;
-use Joomla\Registry\Registry;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Filesystem\Folder;
+use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\Language\Text;
 use Joomla\Database\DatabaseDriver;
-use Joomla\CMS\Filesystem\Folder;
+use Joomla\Registry\Registry;
 
 /**
  * Menu table

--- a/libraries/src/Table/Module.php
+++ b/libraries/src/Table/Module.php
@@ -11,10 +11,10 @@ namespace Joomla\CMS\Table;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Access\Rules;
-use Joomla\Registry\Registry;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\Database\DatabaseDriver;
+use Joomla\Registry\Registry;
 
 /**
  * Module table

--- a/libraries/src/Table/Nested.php
+++ b/libraries/src/Table/Nested.php
@@ -10,9 +10,9 @@ namespace Joomla\CMS\Table;
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\CMS\Event\AbstractEvent;
 use Joomla\Event\Dispatcher;
 use Joomla\Event\Event;
-use Joomla\CMS\Event\AbstractEvent;
 use Joomla\Utilities\ArrayHelper;
 
 /**

--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -10,17 +10,17 @@ namespace Joomla\CMS\Table;
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\CMS\Access\Rules;
 use Joomla\CMS\Event\AbstractEvent;
+use Joomla\CMS\Factory;
+use Joomla\CMS\Filesystem\Path;
+use Joomla\CMS\Language\Text;
+use Joomla\CMS\Object\CMSObject;
 use Joomla\Database\DatabaseDriver;
 use Joomla\Database\DatabaseQuery;
 use Joomla\Event\DispatcherAwareInterface;
 use Joomla\Event\DispatcherAwareTrait;
 use Joomla\Event\DispatcherInterface;
-use Joomla\CMS\Factory;
-use Joomla\CMS\Language\Text;
-use Joomla\CMS\Access\Rules;
-use Joomla\CMS\Object\CMSObject;
-use Joomla\CMS\Filesystem\Path;
 
 /**
  * Abstract Table class

--- a/libraries/src/Table/Update.php
+++ b/libraries/src/Table/Update.php
@@ -10,9 +10,9 @@ namespace Joomla\CMS\Table;
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\Registry\Registry;
 use Joomla\CMS\Language\Text;
 use Joomla\Database\DatabaseDriver;
+use Joomla\Registry\Registry;
 
 /**
  * Update table

--- a/libraries/src/Table/User.php
+++ b/libraries/src/Table/User.php
@@ -10,12 +10,12 @@ namespace Joomla\CMS\Table;
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\Registry\Registry;
-use Joomla\Utilities\ArrayHelper;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\Language\Text;
 use Joomla\Database\DatabaseDriver;
-use Joomla\CMS\Filter\InputFilter;
+use Joomla\Registry\Registry;
+use Joomla\Utilities\ArrayHelper;
 
 /**
  * Users table

--- a/libraries/src/Toolbar/Button/SliderButton.php
+++ b/libraries/src/Toolbar/Button/SliderButton.php
@@ -10,10 +10,10 @@ namespace Joomla\CMS\Toolbar\Button;
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\FileLayout;
 use Joomla\CMS\Toolbar\ToolbarButton;
-use Joomla\CMS\Language\Text;
-use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Uri\Uri;
 
 /**

--- a/libraries/src/Toolbar/ContainerAwareToolbarFactory.php
+++ b/libraries/src/Toolbar/ContainerAwareToolbarFactory.php
@@ -10,12 +10,12 @@ namespace Joomla\CMS\Toolbar;
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Filesystem\Path;
+use Joomla\CMS\Filter\InputFilter;
+use Joomla\CMS\Language\Text;
+use Joomla\CMS\Log\Log;
 use Joomla\DI\ContainerAwareInterface;
 use Joomla\DI\ContainerAwareTrait;
-use Joomla\CMS\Language\Text;
-use Joomla\CMS\Filter\InputFilter;
-use Joomla\CMS\Log\Log;
-use Joomla\CMS\Filesystem\Path;
 
 /**
  * Default factory for creating toolbar objects

--- a/libraries/src/Toolbar/CoreButtonsTrait.php
+++ b/libraries/src/Toolbar/CoreButtonsTrait.php
@@ -9,6 +9,7 @@
 namespace Joomla\CMS\Toolbar;
 
 use Joomla\CMS\Factory;
+use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\FileLayout;
 use Joomla\CMS\Table\Table;
 use Joomla\CMS\Toolbar\Button\ConfirmButton;
@@ -19,7 +20,6 @@ use Joomla\CMS\Toolbar\Button\PopupButton;
 use Joomla\CMS\Toolbar\Button\SeparatorButton;
 use Joomla\CMS\Toolbar\Button\StandardButton;
 use Joomla\CMS\Uri\Uri;
-use Joomla\CMS\Language\Text;
 
 /**
  * Enhance Toolbar class to add more pre-defined methods.

--- a/libraries/src/Toolbar/ToolbarHelper.php
+++ b/libraries/src/Toolbar/ToolbarHelper.php
@@ -10,10 +10,10 @@ namespace Joomla\CMS\Toolbar;
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\Layout\FileLayout;
-use Joomla\CMS\Table\Table;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\FileLayout;
+use Joomla\CMS\Table\Table;
 use Joomla\CMS\Uri\Uri;
 
 /**

--- a/libraries/src/UCM/UCMBase.php
+++ b/libraries/src/UCM/UCMBase.php
@@ -10,10 +10,10 @@ namespace Joomla\CMS\UCM;
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\CMS\Factory;
 use Joomla\CMS\Helper\ContentHelper;
 use Joomla\CMS\Table\Table;
 use Joomla\CMS\Table\TableInterface;
-use Joomla\CMS\Factory;
 
 /**
  * Base class for implementing UCM

--- a/libraries/src/UCM/UCMContent.php
+++ b/libraries/src/UCM/UCMContent.php
@@ -10,10 +10,10 @@ namespace Joomla\CMS\UCM;
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\CMS\Factory;
 use Joomla\CMS\Helper\ContentHelper;
 use Joomla\CMS\Table\Table;
 use Joomla\CMS\Table\TableInterface;
-use Joomla\CMS\Factory;
 
 /**
  * Base class for implementing UCM

--- a/libraries/src/Updater/Adapter/CollectionAdapter.php
+++ b/libraries/src/Updater/Adapter/CollectionAdapter.php
@@ -13,10 +13,10 @@ defined('JPATH_PLATFORM') or die;
 use Joomla\CMS\Application\ApplicationHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Filter\InputFilter;
+use Joomla\CMS\Language\Text;
 use Joomla\CMS\Table\Table;
 use Joomla\CMS\Updater\UpdateAdapter;
 use Joomla\CMS\Version;
-use Joomla\CMS\Language\Text;
 
 /**
  * Collection Update Adapter Class

--- a/libraries/src/Updater/Adapter/ExtensionAdapter.php
+++ b/libraries/src/Updater/Adapter/ExtensionAdapter.php
@@ -13,12 +13,12 @@ defined('JPATH_PLATFORM') or die;
 use Joomla\CMS\Application\ApplicationHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Filter\InputFilter;
+use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
 use Joomla\CMS\Table\Table;
 use Joomla\CMS\Updater\UpdateAdapter;
 use Joomla\CMS\Updater\Updater;
 use Joomla\CMS\Version;
-use Joomla\CMS\Language\Text;
 
 /**
  * Extension class for updater

--- a/libraries/src/Updater/Update.php
+++ b/libraries/src/Updater/Update.php
@@ -13,11 +13,11 @@ defined('JPATH_PLATFORM') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\Http\HttpFactory;
+use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
+use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Version;
 use Joomla\Registry\Registry;
-use Joomla\CMS\Language\Text;
-use Joomla\CMS\Object\CMSObject;
 
 /**
  * Update class. It is used by Updater::update() to install an update. Use Updater::findUpdates() to find updates for

--- a/libraries/src/Updater/UpdateAdapter.php
+++ b/libraries/src/Updater/UpdateAdapter.php
@@ -12,10 +12,10 @@ defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Http\HttpFactory;
+use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
 use Joomla\CMS\Version;
 use Joomla\Registry\Registry;
-use Joomla\CMS\Language\Text;
 
 \JLoader::import('joomla.base.adapterinstance');
 

--- a/libraries/src/User/User.php
+++ b/libraries/src/User/User.php
@@ -11,14 +11,14 @@ namespace Joomla\CMS\User;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Access\Access;
+use Joomla\CMS\Factory;
+use Joomla\CMS\Language\Text;
+use Joomla\CMS\Log\Log;
+use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Table\Table;
 use Joomla\Registry\Registry;
 use Joomla\Utilities\ArrayHelper;
-use Joomla\CMS\Factory;
-use Joomla\CMS\Language\Text;
-use Joomla\CMS\Object\CMSObject;
-use Joomla\CMS\Log\Log;
 
 /**
  * User class.  Handles all application interaction with a user

--- a/libraries/src/User/UserHelper.php
+++ b/libraries/src/User/UserHelper.php
@@ -10,8 +10,8 @@ namespace Joomla\CMS\User;
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\Authentication\Password\Argon2iHandler;
 use Joomla\Authentication\Password\Argon2idHandler;
+use Joomla\Authentication\Password\Argon2iHandler;
 use Joomla\Authentication\Password\BCryptHandler;
 use Joomla\CMS\Access\Access;
 use Joomla\CMS\Authentication\Password\ChainedHandler;
@@ -20,12 +20,12 @@ use Joomla\CMS\Authentication\Password\MD5Handler;
 use Joomla\CMS\Authentication\Password\PHPassHandler;
 use Joomla\CMS\Authentication\Password\SHA256Handler;
 use Joomla\CMS\Factory;
-use Joomla\CMS\Plugin\PluginHelper;
-use Joomla\Utilities\ArrayHelper;
 use Joomla\CMS\Language\Text;
-use Joomla\CMS\Uri\Uri;
-use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Log\Log;
+use Joomla\CMS\Object\CMSObject;
+use Joomla\CMS\Plugin\PluginHelper;
+use Joomla\CMS\Uri\Uri;
+use Joomla\Utilities\ArrayHelper;
 
 /**
  * Authorisation helper class, provides static methods to perform various tasks relevant

--- a/libraries/src/Version.php
+++ b/libraries/src/Version.php
@@ -11,7 +11,6 @@ namespace Joomla\CMS;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Helper\LibraryHelper;
-use Joomla\CMS\Factory;
 
 /**
  * Version information class for the Joomla CMS.

--- a/libraries/src/Workflow/Workflow.php
+++ b/libraries/src/Workflow/Workflow.php
@@ -12,8 +12,6 @@ defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\Utilities\ArrayHelper;
-use Joomla\CMS\HTML\HTMLHelper;
-use Joomla\CMS\Language\Text;
 
 /**
  * Workflow Class.


### PR DESCRIPTION
### Summary of Changes
This PR only cleans up the imports by alpha-ordering them. After this we should enforce alpha-ordering the imports so we don't get fatal errors anymore because people add multiple includes.

For those on PhpStorm, you can enable the `Optimize Imports` in your commit window
![image](https://user-images.githubusercontent.com/359377/44006219-d2c11926-9e80-11e8-8152-f0767416e11d.png)



### Testing Instructions
There are no functional changes, everything should work as before.
