### PR TITLE
[4.0] update tinyMCE to version 4.8.2

### DIFF
--- a/build/media_src/editors/tinymce/js/tinymce.es6.js
+++ b/build/media_src/editors/tinymce/js/tinymce.es6.js
@@ -91,15 +91,6 @@
         });
       };
 
-      // @todo remove next 2 lines once the issue
-      // https://github.com/tinymce/tinymce/issues/4502
-      // is fixed
-
-      if (typeof window.InstallTrigger !== 'undefined') {
-        delete options.external_plugins;
-        delete options.plugins;
-      }
-
       // Create a new instance
       // eslint-disable-next-line no-undef
       const ed = new tinyMCE.Editor(element.id, options, tinymce.EditorManager);

--- a/package-lock.json
+++ b/package-lock.json
@@ -5573,7 +5573,7 @@
       "dev": true
     },
     "joomla-javascript-tests": {
-      "version": "github:joomla/test-javascript#27179e49acc52dc915cf32c724c1152faeee845d",
+      "version": "github:joomla/test-javascript#8c931eab39b33050eaa1d8b69ac8f481041d3faf",
       "from": "github:joomla/test-javascript#4.0-dev",
       "dev": true,
       "requires": {
@@ -9787,9 +9787,9 @@
       "optional": true
     },
     "tinymce": {
-      "version": "4.7.7",
-      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-4.7.7.tgz",
-      "integrity": "sha512-p+HLvdK1ttZeoaIwojZtE9dYZjOBtUH01EyCXJO8+GpglcWgKipGZ0IgPpCvCV0xkgD1snvfYj1rXiGPmRL3/Q=="
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-4.8.2.tgz",
+      "integrity": "sha512-ssq/cGcK8ELG+a96H2mqH6QvsmTSlQk9wj+OYxLIOxsDnWfu90T1TGIachwcQnXsD5FeNFz5X7K860CP9JQCtQ=="
     },
     "tmp": {
       "version": "0.0.33",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "mediaelement": "4.2.8",
     "popper.js": "^1.14.3",
     "punycode": "1.4.1",
-    "tinymce": "4.7.7"
+    "tinymce": "4.8.2"
   },
   "devDependencies": {
     "autoprefixer": "^8.0.0",


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
- Update to latest version
- remove the temporary patch for Firefox
- ref: https://github.com/tinymce/tinymce/issues/4502#issuecomment-412481458

### Testing Instructions
TinyMCE works correctly in Firefox

### Expected result



### Actual result



### Documentation Changes Required
No

@infograf768 can you also verify that there is no issue with FF anymore?