### PR TITLE
[4.0] Empty Trash

### DIFF
--- a/libraries/src/Toolbar/Button/StandardButton.php
+++ b/libraries/src/Toolbar/Button/StandardButton.php
@@ -118,6 +118,7 @@ class StandardButton extends BasicButton
 				return ' btn btn-sm btn-danger';
 
 			case 'trash':
+			case 'delete':
 				return ' btn btn-sm btn-danger';
 
 			default:


### PR DESCRIPTION
Makes the empty-trash button red just as the delete button is

### before
<img width="538" alt="chrome_2018-08-13_23-15-50" src="https://user-images.githubusercontent.com/1296369/44061167-23a07e8a-9f4f-11e8-85c9-5e11c79f4e91.png">


### after
<img width="542" alt="chrome_2018-08-13_23-15-56" src="https://user-images.githubusercontent.com/1296369/44061170-2a66f92e-9f4f-11e8-9981-8e497c986f7c.png">
