### PR TITLE
[4.0] [a11y] Set login page title

### DIFF
--- a/administrator/templates/atum/login.php
+++ b/administrator/templates/atum/login.php
@@ -51,7 +51,7 @@ $this->setMetaData('viewport', 'width=device-width, initial-scale=1');
 $this->setMetaData('theme-color', '#1c3d5c');
 
 // Set page title
-$this->setTitle(Text::_('JACTION_LOGIN_ADMIN') . ' - ' . $sitename);
+$this->setTitle($sitename . ' - ' . Text::_('JACTION_LOGIN_ADMIN'));
 
 ?>
 <!DOCTYPE html>

--- a/administrator/templates/atum/login.php
+++ b/administrator/templates/atum/login.php
@@ -51,7 +51,7 @@ $this->setMetaData('viewport', 'width=device-width, initial-scale=1');
 $this->setMetaData('theme-color', '#1c3d5c');
 
 // Set page title
-$this->setTitle('Administrator Login - ' . $sitename . Text::_('JACTION_LOGIN_ADMIN'));
+$this->setTitle(Text::_('JACTION_LOGIN_ADMIN') . ' - ' . $sitename);
 
 ?>
 <!DOCTYPE html>

--- a/administrator/templates/atum/login.php
+++ b/administrator/templates/atum/login.php
@@ -50,6 +50,9 @@ $this->setMetaData('viewport', 'width=device-width, initial-scale=1');
 // @TODO sync with _variables.scss
 $this->setMetaData('theme-color', '#1c3d5c');
 
+// Set page title
+$this->setTitle('Administrator Login - ' . $sitename . Text::_('JACTION_LOGIN_ADMIN'));
+
 ?>
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">


### PR DESCRIPTION
a11y rules says that every page should have a meaningfu title

This PR adds the title "Administrator Login - sitename" to the title on the login page