### PR TITLE
[4.0] [a11y] cyan

### DIFF
--- a/administrator/templates/atum/scss/_variables.scss
+++ b/administrator/templates/atum/scss/_variables.scss
@@ -21,7 +21,7 @@ $red:                              #c52827;
 $yellow:                           #b35900;
 $green:                            #2f7d32;
 $teal:                             #20c997;
-$cyan:                             #17a2b8;
+$cyan:                             #108193;
 
 $theme-colors: ();
 $theme-colors: map-merge((

--- a/templates/cassiopeia/scss/_variables.scss
+++ b/templates/cassiopeia/scss/_variables.scss
@@ -44,7 +44,7 @@ $orange:                             #fd7e14;
 $yellow:                             #f0ad4e;
 $green:                              #438243;
 $teal:                               #5bc0de;
-$cyan:                               #17a2b8;
+$cyan:                               #108193;
 
 $colors: (
   blue: $blue,


### PR DESCRIPTION
the cyan color used for example on the help buttons on the toolbar fails the a11y color contrast checks

this small adjustment fixes that

Note that there are a lot of other small colour changes here that have been done automatically as a result of calculations based on the $cyan variable

### before
<img width="560" alt="chrome_2018-08-14_10-49-09" src="https://user-images.githubusercontent.com/1296369/44086015-26481350-9fb3-11e8-84c9-62769cb32ebb.png">


### after
<img width="541" alt="chrome_2018-08-14_10-48-55" src="https://user-images.githubusercontent.com/1296369/44086024-2f013d32-9fb3-11e8-9033-69856db8769a.png">

~(can be tested with patchtester)~