### PR TITLE
[4.0] Enable detect debug by default

### DIFF
--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -842,7 +842,7 @@ abstract class HTMLHelper
 			$file,
 			$options['relative'] ?? true,
 			$options['detectBrowser'] ?? false,
-			$options['detectDebug'] ?? false
+			$options['detectDebug'] ?? true
 		);
 
 		if (count($includes) === 0)


### PR DESCRIPTION
### Summary of Changes
As discussed in https://github.com/joomla/joomla-cms/issues/21612 this changes the default behavior of the new method `\Joomla\CMS\HTML\HTMLHelper::webcomponent` so `detectDebug` is enabled.



### Testing Instructions
If you enabled debug, it should load load not-minified versions of webcomponents where it's not alreadyd explicitely specified in the call. Should be for example `system/webcomponents/joomla-field-permissions.min.js`
Maybe @brianteeman can say which view it would affect as he found the issue while testing.

### Expected result
Non-minified files are loaded


### Actual result
Minified files are loaded



### Documentation Changes Required
None