### PR TITLE
[4.0] fetch the head of custom-elements

### DIFF
--- a/build/build-modules-js/settings.json
+++ b/build/build-modules-js/settings.json
@@ -185,22 +185,7 @@
       },
       "joomla-ui-custom-elements": {
         "name": "joomla-custom-elements",
-        "js": {
-          "dist/js/joomla-alert.js": "js/joomla-alert.js",
-          "dist/js/joomla-alert.min.js": "js/joomla-alert.min.js",
-          "dist/js/joomla-alert-es5.js": "js/joomla-alert-es5.js",
-          "dist/js/joomla-alert-es5.min.js": "js/joomla-alert-es5.min.js",
-          "dist/js/joomla-tab.js": "js/joomla-tab.js",
-          "dist/js/joomla-tab.min.js": "js/joomla-tab.js",
-          "dist/js/joomla-tab-es5.js": "js/joomla-tab-es5.js",
-          "dist/js/joomla-tab-es5.min.js": "js/joomla-tab-es5.min.js"
-        },
-        "css": {
-          "dist/css/joomla-alert.css": "css/joomla-alert.css",
-          "dist/css/joomla-alert.min.css": "css/joomla-alert.min.css",
-          "dist/css/joomla-tab.css": "css/joomla-tab.css",
-          "dist/css/joomla-tab.min.css": "css/joomla-tab.min.css"
-        },
+        "dist": "dist",
         "dependencies": [],
         "licenseFilename": "LICENSE"
       },

--- a/build/build-modules-js/update.js
+++ b/build/build-modules-js/update.js
@@ -9,7 +9,9 @@ const rootPath = require('./rootpath.js')._();
 
 const xmlVersionStr = /(<version>)(\d+.\d+.\d+)(<\/version>)/;
 
-// rm -rf media/vendor
+/**
+ * rm -rf media/vendor
+ */
 const cleanVendors = () => {
   // Remove the vendor folder
   fsExtra.removeSync(Path.join(rootPath, 'media/vendor'));
@@ -23,11 +25,19 @@ const cleanVendors = () => {
   fsExtra.copySync(Path.join(rootPath, 'build/media/vendor/jquery-ui'), Path.join(rootPath, 'media/vendor/jquery-ui'));
 };
 
-// Copies all the files from a directory
-const copyAll = (dirName, name, type) => {
-  const folderName = dirName === '/' ? '/' : `/${dirName}`;
-  fsExtra.copySync(Path.join(rootPath, `node_modules/${name}/${folderName}`),
-    Path.join(rootPath, `media/vendor/${name.replace(/.+\//, '')}/${type}`));
+/**
+ * Copies all the files from a directory
+ *
+ * @param sourceSubDir string The source folder name (eg: dist)
+ * @param sourceDir    string The source parent folder name (eg: package name)
+ * @param destDir      string The destination folder name
+ * @param destFolder   string The destination parent folder name
+ */
+const copyAll = (sourceSubDir, sourceDir, destDir, destFolder) => {
+  let folder = !destFolder ? sourceDir : destFolder;
+  const folderName = sourceSubDir === '/' ? '/' : `/${sourceSubDir}`;
+  fsExtra.copySync(Path.join(rootPath, `node_modules/${sourceDir}/${folderName}`),
+    Path.join(rootPath, `media/vendor/${folder.replace(/.+\//, '')}/${destDir}`));
 };
 
 // Copies an array of files from a directory
@@ -77,6 +87,11 @@ const concatFiles = (files, output) => {
   fs.writeFileSync(`${rootPath}/${output}`, tempMem);
 };
 
+/**
+ * Populates the media/vendor folder
+ *
+ * @param options object  the application options
+ */
 const copyFiles = (options) => {
   const mediaVendorPath = Path.join(rootPath, 'media/vendor');
   const registry = {
@@ -188,6 +203,9 @@ const copyFiles = (options) => {
       let tinyWrongMap = fs.readFileSync(`${rootPath}/media/vendor/tinymce/skins/lightgray/skin.min.css`, { encoding: 'UTF-8' });
       tinyWrongMap = tinyWrongMap.replace('/*# sourceMappingURL=skin.min.css.map */', '');
       fs.writeFileSync(`${rootPath}/media/vendor/tinymce/skins/lightgray/skin.min.css`, tinyWrongMap, { encoding: 'UTF-8' });
+    } else if (packageName === 'joomla-ui-custom-elements') {
+      copyAll('dist/js', 'joomla-ui-custom-elements', 'js', 'joomla-custom-elements');
+      copyAll('dist/css', 'joomla-ui-custom-elements', 'css', 'joomla-custom-elements');
     } else {
       ['js', 'css', 'filesExtra'].forEach((type) => {
         if (!vendor[type]) return;

--- a/package-lock.json
+++ b/package-lock.json
@@ -4634,27 +4634,6 @@
           "requires": {
             "amdefine": ">=0.0.4"
           }
-        },
-        "uglify-js": {
-          "version": "2.8.29",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "source-map": "~0.5.1",
-            "uglify-to-browserify": "~1.0.0",
-            "yargs": "~3.10.0"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.5.7",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-              "dev": true,
-              "optional": true
-            }
-          }
         }
       }
     },
@@ -5661,9 +5640,8 @@
       }
     },
     "joomla-ui-custom-elements": {
-      "version": "0.0.25",
-      "resolved": "https://registry.npmjs.org/joomla-ui-custom-elements/-/joomla-ui-custom-elements-0.0.25.tgz",
-      "integrity": "sha512-Hwzwgak0mTr6Gfx5q4hSsznf89l4CTcZaD7bnobTZcz8EhZM+woayx8pQkYMhPMXg1hbxyNpMdzesabxl0JePw==",
+      "version": "github:joomla-projects/custom-elements#2d5f984a2cc8aa40a6978dced6e7742eee517ff0",
+      "from": "github:joomla-projects/custom-elements",
       "requires": {
         "babel-core": "^6.26.3",
         "bootstrap": "^4.0.0"
@@ -9980,6 +9958,18 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         }
+      }
+    },
+    "uglify-js": {
+      "version": "2.8.29",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "source-map": "~0.5.1",
+        "uglify-to-browserify": "~1.0.0",
+        "yargs": "~3.10.0"
       }
     },
     "uglify-to-browserify": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "dragula": "3.7.2",
     "focus-visible": "^4.1.4",
     "font-awesome": "4.7.0",
-    "joomla-ui-custom-elements": "0.0.25",
+    "joomla-ui-custom-elements": "joomla-projects/custom-elements",
     "jquery": "3.3.1",
     "jquery-migrate": "1.4.1",
     "mediaelement": "4.2.8",

--- a/plugins/editors/tinymce/tinymce.xml
+++ b/plugins/editors/tinymce/tinymce.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension version="3.2" type="plugin" group="editors" method="upgrade">
 	<name>plg_editors_tinymce</name>
-	<version>4.7.7</version>
+	<version>4.8.2</version>
 	<creationDate>2005-2017</creationDate>
 	<author>Ephox Corporation</author>
 	<authorEmail>N/A</authorEmail>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Instead of fetching a particular release we're gonna fetch the latest code from that repo


### Testing Instructions
npm i on a clean slate will create correctly the media/vedor/joomla-custom-elements with the js and css.
Tabs and alerts work correctly in the article edit form (backend)


### Expected result



### Actual result



### Documentation Changes Required
No, just skipping the npm publish to save us some time