### PR TITLE
[4.0] Fix the imports in the archive model

### DIFF
--- a/components/com_content/Model/ArchiveModel.php
+++ b/components/com_content/Model/ArchiveModel.php
@@ -13,9 +13,6 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\Component\Content\Site\Helper\QueryHelper;
-use Joomla\Component\Content\Site\Model\ArticlesModel;
-use Joomla\Utilities\ArrayHelper;
-use Joomla\CMS\Factory;
 
 /**
  * Content Component Archive Model


### PR DESCRIPTION
The Factory import in the ArchiveModel is doubled which will throw an error. The other two's are not used so removed too.