### PR TITLE
[4.0] Layout systeminfo - improve accessibility

### DIFF
--- a/administrator/components/com_admin/tmpl/sysinfo/default.php
+++ b/administrator/components/com_admin/tmpl/sysinfo/default.php
@@ -19,36 +19,33 @@ HTMLHelper::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 HTMLHelper::_('behavior.tabstate');
 ?>
 
-<form action="<?php echo Route::_('index.php?option=com_admin&view=sysinfo'); ?>" method="post" name="adminForm" id="adminForm">
-	<div class="row">
-		<?php // Begin Content ?>
-		<div class="col-md-12">
-			<?php echo HTMLHelper::_('bootstrap.startTabSet', 'myTab', array('active' => 'site')); ?>
+<div class="row">
+	<?php // Begin Content ?>
+	<div class="col-md-12">
+		<?php echo HTMLHelper::_('bootstrap.startTabSet', 'myTab', array('active' => 'site')); ?>
 
-			<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'site', Text::_('COM_ADMIN_SYSTEM_INFORMATION')); ?>
-			<?php echo $this->loadTemplate('system'); ?>
-			<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+		<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'site', Text::_('COM_ADMIN_SYSTEM_INFORMATION')); ?>
+		<?php echo $this->loadTemplate('system'); ?>
+		<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
 
-			<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'phpsettings', Text::_('COM_ADMIN_PHP_SETTINGS')); ?>
-			<?php echo $this->loadTemplate('phpsettings'); ?>
-			<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+		<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'phpsettings', Text::_('COM_ADMIN_PHP_SETTINGS')); ?>
+		<?php echo $this->loadTemplate('phpsettings'); ?>
+		<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
 
-			<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'config', Text::_('COM_ADMIN_CONFIGURATION_FILE')); ?>
-			<?php echo $this->loadTemplate('config'); ?>
-			<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+		<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'config', Text::_('COM_ADMIN_CONFIGURATION_FILE')); ?>
+		<?php echo $this->loadTemplate('config'); ?>
+		<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
 
-			<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'directory', Text::_('COM_ADMIN_DIRECTORY_PERMISSIONS')); ?>
-			<?php echo $this->loadTemplate('directory'); ?>
-			<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+		<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'directory', Text::_('COM_ADMIN_DIRECTORY_PERMISSIONS')); ?>
+		<?php echo $this->loadTemplate('directory'); ?>
+		<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
 
-			<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'phpinfo', Text::_('COM_ADMIN_PHP_INFORMATION')); ?>
-			<?php echo $this->loadTemplate('phpinfo'); ?>
-			<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+		<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'phpinfo', Text::_('COM_ADMIN_PHP_INFORMATION')); ?>
+		<?php echo $this->loadTemplate('phpinfo'); ?>
+		<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
 
-			<?php echo HTMLHelper::_('bootstrap.endTabSet'); ?>
-		</div>
-		<input type="hidden" name="task" value="">
-		<?php echo HTMLHelper::_('form.token'); ?>
-		<?php // End Content ?>
+		<?php echo HTMLHelper::_('bootstrap.endTabSet'); ?>
 	</div>
-</form>
+	<?php // End Content ?>
+</div>
+

--- a/administrator/components/com_admin/tmpl/sysinfo/default_config.php
+++ b/administrator/components/com_admin/tmpl/sysinfo/default_config.php
@@ -14,7 +14,6 @@ use Joomla\CMS\Language\Text;
 ?>
 <div class="adminform">
 	<table class="table">
-		<caption><?php echo Text::_('COM_ADMIN_CONFIGURATION_FILE'); ?></caption>
 		<thead>
 			<tr>
 				<th scope="col" style="width:300px">

--- a/administrator/components/com_admin/tmpl/sysinfo/default_config.php
+++ b/administrator/components/com_admin/tmpl/sysinfo/default_config.php
@@ -12,9 +12,9 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Language\Text;
 
 ?>
-<fieldset class="adminform">
-	<legend><?php echo Text::_('COM_ADMIN_CONFIGURATION_FILE'); ?></legend>
+<div class="adminform">
 	<table class="table">
+		<caption><?php echo Text::_('COM_ADMIN_CONFIGURATION_FILE'); ?></caption>
 		<thead>
 			<tr>
 				<th scope="col" style="width:300px">
@@ -25,11 +25,6 @@ use Joomla\CMS\Language\Text;
 				</th>
 			</tr>
 		</thead>
-		<tfoot>
-			<tr>
-				<td colspan="2">&#160;</td>
-			</tr>
-		</tfoot>
 		<tbody>
 			<?php foreach ($this->config as $key => $value) : ?>
 				<tr>
@@ -43,4 +38,4 @@ use Joomla\CMS\Language\Text;
 			<?php endforeach; ?>
 		</tbody>
 	</table>
-</fieldset>
+</div>

--- a/administrator/components/com_admin/tmpl/sysinfo/default_directory.php
+++ b/administrator/components/com_admin/tmpl/sysinfo/default_directory.php
@@ -15,7 +15,6 @@ use Joomla\CMS\HTML\HTMLHelper;
 ?>
 <div class="adminform">
 	<table class="table">
-		<caption><?php echo Text::_('COM_ADMIN_DIRECTORY_PERMISSIONS'); ?></caption>
 		<thead>
 			<tr>
 				<th scope="col" style="width:650px">

--- a/administrator/components/com_admin/tmpl/sysinfo/default_directory.php
+++ b/administrator/components/com_admin/tmpl/sysinfo/default_directory.php
@@ -13,9 +13,9 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\HTML\HTMLHelper;
 
 ?>
-<fieldset class="adminform">
-	<legend><?php echo Text::_('COM_ADMIN_DIRECTORY_PERMISSIONS'); ?></legend>
+<div class="adminform">
 	<table class="table">
+		<caption><?php echo Text::_('COM_ADMIN_DIRECTORY_PERMISSIONS'); ?></caption>
 		<thead>
 			<tr>
 				<th scope="col" style="width:650px">
@@ -26,11 +26,6 @@ use Joomla\CMS\HTML\HTMLHelper;
 				</th>
 			</tr>
 		</thead>
-		<tfoot>
-			<tr>
-				<td colspan="2">&#160;</td>
-			</tr>
-		</tfoot>
 		<tbody>
 			<?php foreach ($this->directory as $dir => $info) : ?>
 				<tr>
@@ -44,4 +39,4 @@ use Joomla\CMS\HTML\HTMLHelper;
 			<?php endforeach; ?>
 		</tbody>
 	</table>
-</fieldset>
+</div>

--- a/administrator/components/com_admin/tmpl/sysinfo/default_phpinfo.php
+++ b/administrator/components/com_admin/tmpl/sysinfo/default_phpinfo.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Language\Text;
 
 ?>
-<fieldset class="adminform">
+<div class="adminform">
 	<legend><?php echo Text::_('COM_ADMIN_PHP_INFORMATION'); ?></legend>
 	<?php echo $this->php_info; ?>
-</fieldset>
+</div>

--- a/administrator/components/com_admin/tmpl/sysinfo/default_phpinfo.php
+++ b/administrator/components/com_admin/tmpl/sysinfo/default_phpinfo.php
@@ -13,6 +13,5 @@ use Joomla\CMS\Language\Text;
 
 ?>
 <div class="adminform">
-	<legend><?php echo Text::_('COM_ADMIN_PHP_INFORMATION'); ?></legend>
 	<?php echo $this->php_info; ?>
 </div>

--- a/administrator/components/com_admin/tmpl/sysinfo/default_phpsettings.php
+++ b/administrator/components/com_admin/tmpl/sysinfo/default_phpsettings.php
@@ -13,9 +13,9 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\HTML\HTMLHelper;
 
 ?>
-<fieldset class="adminform">
-	<legend><?php echo Text::_('COM_ADMIN_RELEVANT_PHP_SETTINGS'); ?></legend>
+<div class="adminform">
 	<table class="table">
+		<caption><?php echo Text::_('COM_ADMIN_RELEVANT_PHP_SETTINGS'); ?></caption>
 		<thead>
 			<tr>
 				<th scope="col" style="width:250px">
@@ -26,12 +26,6 @@ use Joomla\CMS\HTML\HTMLHelper;
 				</th>
 			</tr>
 		</thead>
-		<tfoot>
-			<tr>
-				<td colspan="2">&#160;
-				</td>
-			</tr>
-		</tfoot>
 		<tbody>
 			<tr>
 				<th scope="row">
@@ -147,4 +141,4 @@ use Joomla\CMS\HTML\HTMLHelper;
 			</tr>
 		</tbody>
 	</table>
-</fieldset>
+</div>

--- a/administrator/components/com_admin/tmpl/sysinfo/default_phpsettings.php
+++ b/administrator/components/com_admin/tmpl/sysinfo/default_phpsettings.php
@@ -15,7 +15,6 @@ use Joomla\CMS\HTML\HTMLHelper;
 ?>
 <div class="adminform">
 	<table class="table">
-		<caption><?php echo Text::_('COM_ADMIN_RELEVANT_PHP_SETTINGS'); ?></caption>
 		<thead>
 			<tr>
 				<th scope="col" style="width:250px">

--- a/administrator/components/com_admin/tmpl/sysinfo/default_system.php
+++ b/administrator/components/com_admin/tmpl/sysinfo/default_system.php
@@ -15,7 +15,6 @@ use Joomla\CMS\HTML\HTMLHelper;
 ?>
 <div class="adminform">
 	<table class="table">
-		<caption><?php echo Text::_('COM_ADMIN_SYSTEM_INFORMATION'); ?></caption>
 		<thead>
 			<tr>
 				<th scope="col" style="width:25%">

--- a/administrator/components/com_admin/tmpl/sysinfo/default_system.php
+++ b/administrator/components/com_admin/tmpl/sysinfo/default_system.php
@@ -13,9 +13,9 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\HTML\HTMLHelper;
 
 ?>
-<fieldset class="adminform">
-	<legend><?php echo Text::_('COM_ADMIN_SYSTEM_INFORMATION'); ?></legend>
+<div class="adminform">
 	<table class="table">
+		<caption><?php echo Text::_('COM_ADMIN_SYSTEM_INFORMATION'); ?></caption>
 		<thead>
 			<tr>
 				<th scope="col" style="width:25%">
@@ -26,11 +26,6 @@ use Joomla\CMS\HTML\HTMLHelper;
 				</th>
 			</tr>
 		</thead>
-		<tfoot>
-			<tr>
-				<td colspan="2">&#160;</td>
-			</tr>
-		</tfoot>
 		<tbody>
 			<tr>
 				<th scope="row">
@@ -114,4 +109,4 @@ use Joomla\CMS\HTML\HTMLHelper;
 			</tr>
 		</tbody>
 	</table>
-</fieldset>
+</div>

--- a/administrator/templates/atum/scss/vendor/bootstrap/_table.scss
+++ b/administrator/templates/atum/scss/vendor/bootstrap/_table.scss
@@ -39,5 +39,8 @@
   td {
     padding: 18px 12px;
   }
-
+  
+  caption {
+    caption-side: top;
+  }
 }

--- a/administrator/templates/atum/scss/vendor/bootstrap/_table.scss
+++ b/administrator/templates/atum/scss/vendor/bootstrap/_table.scss
@@ -39,7 +39,7 @@
   td {
     padding: 18px 12px;
   }
-  
+
   caption {
     caption-side: top;
   }


### PR DESCRIPTION
JAT has found several a11y issues in the SystemInformation View:

### Summary of Changes
Remove the < form > tag, as this is not a form.
Remove empty Table Footers
Replace the < fieldset > Tag by < div >
Replace the < legend > by Table < caption >


### Testing Instructions
There should be no visible difference in the View System Information before and after patch.

Test of accessibility with screenreader is required. 



