### PR TITLE
[4.0] [Workflow] Restore publish, unpublish, archive, trash tasks to AdminController for extensions using workflow (and readd them to backend articles manager)

### DIFF
--- a/administrator/components/com_content/View/Articles/HtmlView.php
+++ b/administrator/components/com_content/View/Articles/HtmlView.php
@@ -173,6 +173,10 @@ class HtmlView extends BaseHtmlView
 
 		if ($canDo->get('core.edit.state'))
 		{
+			$toolbar->publish('articles.publish')->listCheck(true);
+
+			$toolbar->unpublish('articles.unpublish')->listCheck(true);
+
 			$toolbar->standardButton('featured')
 				->text('JFEATURE')
 				->task('articles.featured')
@@ -182,6 +186,8 @@ class HtmlView extends BaseHtmlView
 				->text('JUNFEATURE')
 				->task('articles.unfeatured')
 				->listCheck(true);
+
+			$toolbar->archive('articles.archive')->listCheck(true);
 
 			$toolbar->checkin('articles.checkin')->listCheck(true);
 		}

--- a/libraries/src/MVC/Controller/AdminController.php
+++ b/libraries/src/MVC/Controller/AdminController.php
@@ -262,7 +262,6 @@ class AdminController extends BaseController
 					foreach($cid as $pk)
 					{
 						$model->runTransition($pk, $transitionId);
-						print_r($model->getErrors());
 
 						foreach ($model->getErrors() as $err)
 						{
@@ -277,7 +276,6 @@ class AdminController extends BaseController
 					$model->publish($cid, $value);
 					$errors = $model->getErrors();
 				}
-				exit;
 
 				/**
 				 * Add task result messages


### PR DESCRIPTION
[Workflow] Restore tasks:
- publish, unpublish, archive, trash 
to AdminController for extensions using workflow

and re-add them to backend articles manager) 

Pull Request for Issue #21527

### Summary of Changes

All tasks are mapped to 'publish' of AdminController,
make AdminController aware of workflow transitions
by checking if a model extension implements 'runTransition()' Method
and the run the correspoding "from-any-stage" transitions

### Testing Instructions
Go to article manager select some articles and use Toolbar buttons

publish, unpublish, archive, trash 

After / if this tested / merged
https://github.com/joomla/joomla-cms/pull/21585

Then we may also improve transition selection in the controller

### Expected result
Buttons are in the toolbar and they work


### Actual result
Buttons were removed from the toolbar


### Documentation Changes Required

