### PR TITLE
Build a not on windows group for test

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -130,4 +130,4 @@ before_test:
 
 test_script:
   - cd C:\projects\joomla-cms
-  - libraries/vendor/bin/phpunit -c appveyor-phpunit.xml
+  - ps: If ($env:php_ver_target -eq "5.6") {libraries/vendor/bin/phpunit -c appveyor-phpunit.xml --exclude-group not-on-windows } Else {libraries/vendor/bin/phpunit -c appveyor-phpunit.xml}

--- a/tests/unit/suites/libraries/joomla/crypt/cipher/JCryptCipherSodiumTest.php
+++ b/tests/unit/suites/libraries/joomla/crypt/cipher/JCryptCipherSodiumTest.php
@@ -40,6 +40,8 @@ class JCryptCipherSodiumTest extends TestCase
 	 *
 	 * @param   string  $data  The decrypted data to validate
 	 *
+	 * @group   not-on-windows
+	 *
 	 * @covers        Joomla\CMS\Crypt\Cipher\SodiumCipher::decrypt
 	 * @covers        Joomla\CMS\Crypt\Cipher\SodiumCipher::encrypt
 	 * @dataProvider  dataStrings
@@ -64,6 +66,8 @@ class JCryptCipherSodiumTest extends TestCase
 
 	/**
 	 * @testdox  Validates keys are correctly generated
+	 *
+	 * @group   not-on-windows
 	 *
 	 * @covers   Joomla\CMS\Crypt\Cipher\SodiumCipher::generateKey
 	 */


### PR DESCRIPTION
Pull Request for Issue #21388

### Summary of Changes
I have build a not-on-windows group and excluded the group from testing on php5.6.

The test I have excluded is still executed in our travis testing environment so not testing it on windows doesn't seems so bad. 


### Testing Instructions
Just look if the appveyor build run to the end


### Expected result
appveyor build run thru


### Actual result
appveyor build run in a timeout