### PR TITLE
Stick permissions tab on scroll

### DIFF
--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -9029,6 +9029,12 @@ input:focus,
 .hero-unit .lead {
 	font-weight: 400;
 }
+@media (min-width: 1200px) {
+	#permissions .tab-content {
+		position: sticky;
+		top: 90px;
+	}
+}
 .com_cpanel .well {
 	padding: 8px 14px;
 	border: 1px solid rgba(0,0,0,0.05);

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -9029,6 +9029,12 @@ input:focus,
 .hero-unit .lead {
 	font-weight: 400;
 }
+@media (min-width: 1200px) {
+	#permissions .tab-content {
+		position: sticky;
+		top: 90px;
+	}
+}
 .com_cpanel .well {
 	padding: 8px 14px;
 	border: 1px solid rgba(0,0,0,0.05);

--- a/administrator/templates/isis/less/blocks/_custom.less
+++ b/administrator/templates/isis/less/blocks/_custom.less
@@ -292,3 +292,13 @@ textarea:focus, input:focus, .uneditable-input:focus {
 .lead, .navbar .brand, .hero-unit, .hero-unit .lead {
 	font-weight: 400;
 }
+
+/* Stick permissions tab */
+@media (min-width: @xl) {
+	#permissions {
+		.tab-content {
+			position: sticky;
+			top: 90px;
+		}
+	}
+}


### PR DESCRIPTION
Pull Request for Issue #21630 .

### Summary of Changes
This PR sticks the permissions tab on scroll, ensuring options are always visible if a large number of groups exists.


### Testing Instructions
See original issue (#21630). Create a large number of groups. Navigate to the permissions tab of any item and scroll. Right panel should stick to header.

* Not compatible with IE11 or less
* Applies only to 1200px+ screen size

Edit: No change in IE11 and before

### Expected result
![permissions](https://user-images.githubusercontent.com/2803503/44199244-74d41a80-a13b-11e8-844d-c0f49d0acb80.gif)


