### PR TITLE
[4.0] Checkall style

### DIFF
--- a/administrator/components/com_installer/tmpl/manage/default.php
+++ b/administrator/components/com_installer/tmpl/manage/default.php
@@ -40,7 +40,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 					<table class="table" id="manageList">
 						<thead>
 							<tr>
-								<td style="width:1%" class="nowrap">
+								<td style="width:1%" class="nowrap text-center">
 									<?php echo HTMLHelper::_('grid.checkall'); ?>
 								</td>
 								<th scope="col" style="width:1%" class="nowrap text-center">

--- a/administrator/components/com_installer/tmpl/update/default.php
+++ b/administrator/components/com_installer/tmpl/update/default.php
@@ -41,7 +41,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 						<table class="table">
 							<thead>
 							<tr>
-								<td style="width:1%" class="nowrap">
+								<td style="width:1%" class="nowrap text-center">
 									<?php echo HTMLHelper::_('grid.checkall'); ?>
 								</td>
 								<th scope="col" class="nowrap">

--- a/administrator/components/com_users/tmpl/groups/default.php
+++ b/administrator/components/com_users/tmpl/groups/default.php
@@ -44,7 +44,7 @@ HTMLHelper::_('script', 'com_users/admin-users-groups.min.js', array('version' =
 					<table class="table" id="groupList">
 						<thead>
 							<tr>
-								<td style="width:1%" class="nowrap">
+								<td style="width:1%" class="nowrap text-center">
 									<?php echo HTMLHelper::_('grid.checkall'); ?>
 								</td>
 								<th scope="col" class="nowrap">


### PR DESCRIPTION
Small adjustment to
- com_installer view update
- com_installer view manage
- com_users view groups

Before this PR the checkall box in the table header is misaligned

### Before

<img width="417" alt="chrome_2018-08-16_18-15-42" src="https://user-images.githubusercontent.com/1296369/44224076-542eb380-a181-11e8-9fe3-0be2f289e8d3.png">


### After

<img width="389" alt="chrome_2018-08-16_18-15-30" src="https://user-images.githubusercontent.com/1296369/44224075-542eb380-a181-11e8-8faa-ffa932065ef9.png">
