### PR TITLE
[4.0] Fix switcher colors

### DIFF
--- a/build/media/webcomponents/scss/field-switcher/field-switcher.scss
+++ b/build/media/webcomponents/scss/field-switcher/field-switcher.scss
@@ -1,5 +1,36 @@
 // Switcher
 
+//
+// Functions
+//
+
+// Retrieve color Sass maps
+@function color($key: "blue") {
+  @return map-get($colors, $key);
+}
+
+@function theme-color($key: "primary") {
+  @return map-get($theme-colors, $key);
+}
+
+@function gray($key: "100") {
+  @return map-get($grays, $key);
+}
+
+// Request a theme color level
+@function theme-color-level($color-name: "primary", $level: 0) {
+  $color: theme-color($color-name);
+  $color-base: if($level > 0, $black, $white);
+  $level: abs($level);
+
+  @return mix($color-base, $color, $level * $theme-color-interval);
+}
+
+
+//
+// Variables
+//
+
 $switcher-width:  62px;
 $switcher-height: 28px;
 $border-width:    1px;
@@ -22,6 +53,12 @@ $theme-colors: map-merge((
         danger: $red
 ), $theme-colors);
 
+$theme-color-interval:        8%;
+
+
+//
+// Base styles
+//
 
 joomla-field-switcher {
   box-sizing: border-box;


### PR DESCRIPTION
Pull Request for Issue  #21639 .

### Summary of Changes
#21615 removed some required functions and variables which killed the color variations in the switcher. This PR fixes that.

### Testing Instructions
Apply PR and run `node build.js --compile-ce`

Check switcher colors (article edit)

### Before
See #21639


### After
![image](https://user-images.githubusercontent.com/2803503/44255035-a103a000-a1fc-11e8-9e15-049333b94c4e.png)



### Documentation Changes Required

