### PR TITLE
[4.0] Remove table-striped class from com-workflow

### DIFF
--- a/administrator/components/com_workflow/tmpl/stages/default.php
+++ b/administrator/components/com_workflow/tmpl/stages/default.php
@@ -51,7 +51,7 @@ if ($saveOrder)
 						<?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
 					</div>
 				<?php else: ?>
-					<table class="table table-striped">
+					<table class="table">
 						<thead>
 							<tr>
 								<th scope="col" style="width:1%" class="nowrap text-center hidden-sm-down">

--- a/administrator/components/com_workflow/tmpl/transitions/default.php
+++ b/administrator/components/com_workflow/tmpl/transitions/default.php
@@ -50,7 +50,7 @@ if ($saveOrder)
 						<?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
 					</div>
 				<?php else: ?>
-					<table class="table table-striped">
+					<table class="table">
 						<thead>
 							<tr>
 								<th scope="col" style="width:1%" class="nowrap text-center hidden-sm-down">

--- a/administrator/components/com_workflow/tmpl/workflows/default.php
+++ b/administrator/components/com_workflow/tmpl/workflows/default.php
@@ -59,7 +59,7 @@ $userId = $user->id;
 						<?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
 					</div>
 				<?php else: ?>
-					<table class="table table-striped">
+					<table class="table">
 						<thead>
 							<tr>
 								<th scope="col" style="width:1%" class="nowrap text-center d-none d-md-table-cell">


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
To keep the workflow component inline with other components, the PR remove the `table-striped` class from tables


### Testing Instructions
Apply PR. Navigate to workflows.


### Brefore
![image](https://user-images.githubusercontent.com/2803503/44257530-2d659100-a204-11e8-9349-919aad4db039.png)



### After
![image](https://user-images.githubusercontent.com/2803503/44257506-1d4db180-a204-11e8-8d9d-5beeceac57c0.png)



### Documentation Changes Required

