### PR TITLE
Allow filtering by archived in Redirect Manager

### DIFF
--- a/libraries/src/Form/Field/RedirectStatusField.php
+++ b/libraries/src/Form/Field/RedirectStatusField.php
@@ -39,6 +39,7 @@ class RedirectStatusField extends \JFormFieldPredefinedList
 		'-2' => 'JTRASHED',
 		'0'  => 'JDISABLED',
 		'1'  => 'JENABLED',
+        '2'  => 'JARCHIVED',
 		'*'  => 'JALL',
 	);
 }

--- a/libraries/src/Form/Field/RedirectStatusField.php
+++ b/libraries/src/Form/Field/RedirectStatusField.php
@@ -39,7 +39,7 @@ class RedirectStatusField extends \JFormFieldPredefinedList
 		'-2' => 'JTRASHED',
 		'0'  => 'JDISABLED',
 		'1'  => 'JENABLED',
-        '2'  => 'JARCHIVED',
+		'2'  => 'JARCHIVED',
 		'*'  => 'JALL',
 	);
 }


### PR DESCRIPTION
### Summary of Changes
Allows filtering by the archived state in the redirect component.

### Testing Instructions
In search tools of the redirect component there is now an archived option in the dropdown which allows filtering by archived options

### Documentation Changes Required
n/a
