### PR TITLE
[3.9] LayoutHelper::render(..., $displayData, ...) is mixed at best; searchtools expects array

### DIFF
--- a/libraries/src/Layout/LayoutHelper.php
+++ b/libraries/src/Layout/LayoutHelper.php
@@ -31,7 +31,7 @@ class LayoutHelper
 	 * Method to render a layout with debug info
 	 *
 	 * @param   string  $layoutFile   Dot separated path to the layout file, relative to base path
-	 * @param   object  $displayData  Object which properties are used inside the layout file to build displayed output
+	 * @param   mixed   $displayData  Object which properties are used inside the layout file to build displayed output
 	 * @param   string  $basePath     Base path to use when loading layout files
 	 * @param   mixed   $options      Optional custom options to load. Registry or array format
 	 *


### PR DESCRIPTION
This fixes issues with the static analysis tool Phan.

When using Search Tools layout it expects an array, however, the documentation for the `render` method states that the `$displayData` parameter is an object. This commit sets the type of the parameter to `mixed`.