### PR TITLE
[4.0] Fixing contacts routing in multilingual sites

### DIFF
--- a/components/com_contact/View/Category/HtmlView.php
+++ b/components/com_contact/View/Category/HtmlView.php
@@ -106,7 +106,7 @@ class HtmlView extends CategoryView
 
 			while (($menu->query['option'] !== 'com_contact' || $menu->query['view'] === 'contact' || $id != $category->id) && $category->id > 1)
 			{
-				$path[] = array('title' => $category->title, 'link' => ContactHelperRoute::getCategoryRoute($category->id));
+				$path[] = array('title' => $category->title, 'link' => ContactHelperRoute::getCategoryRoute($category->id, $category->language));
 				$category = $category->getParent();
 			}
 

--- a/components/com_contact/View/Contact/HtmlView.php
+++ b/components/com_contact/View/Contact/HtmlView.php
@@ -335,10 +335,10 @@ class HtmlView extends BaseHtmlView
 		{
 			foreach ($contacts as &$contact)
 			{
-				$contact->link = Route::_(ContactHelperRoute::getContactRoute($contact->slug, $contact->catid));
+				$contact->link = Route::_(ContactHelperRoute::getContactRoute($contact->slug, $contact->catid, $contact->language));
 			}
 
-			$item->link = Route::_(ContactHelperRoute::getContactRoute($item->slug, $item->catid), false);
+			$item->link = Route::_(ContactHelperRoute::getContactRoute($item->slug, $item->catid, $item->language), false);
 		}
 
 		// Process the content plugins.

--- a/components/com_contact/tmpl/category/default_children.php
+++ b/components/com_contact/tmpl/category/default_children.php
@@ -21,7 +21,7 @@ if ($this->maxLevel != 0 && count($this->children[$this->category->id]) > 0) :
 	<?php if ($this->params->get('show_empty_categories') || $child->numitems || count($child->getChildren())) : ?>
 	<li>
 		<h4 class="item-title">
-			<a href="<?php echo Route::_(ContactHelperRoute::getCategoryRoute($child->id)); ?>">
+			<a href="<?php echo Route::_(ContactHelperRoute::getCategoryRoute($child->id, $child->language)); ?>">
 			<?php echo $this->escape($child->title); ?>
 			</a>
 

--- a/components/com_contact/tmpl/category/default_items.php
+++ b/components/com_contact/tmpl/category/default_items.php
@@ -59,7 +59,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 							<?php $contact_width = 7; ?>
 							<div class="col-md-2">
 								<?php if ($this->items[$i]->image) : ?>
-									<a href="<?php echo Route::_(ContactHelperRoute::getContactRoute($item->slug, $item->catid)); ?>">
+									<a href="<?php echo Route::_(ContactHelperRoute::getContactRoute($item->slug, $item->catid, $item->language)); ?>">
 										<?php echo HTMLHelper::_('image', $this->items[$i]->image, JText::_('COM_CONTACT_IMAGE_DETAILS'), array('class' => 'contact-thumbnail img-thumbnail')); ?></a>
 								<?php endif; ?>
 							</div>
@@ -68,7 +68,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 						<?php endif; ?>
 
 						<div class="list-title col-md-<?php echo $contact_width; ?>">
-							<a href="<?php echo Route::_(ContactHelperRoute::getContactRoute($item->slug, $item->catid)); ?>">
+							<a href="<?php echo Route::_(ContactHelperRoute::getContactRoute($item->slug, $item->catid, $item->language)); ?>">
 								<?php echo $item->name; ?></a>
 							<?php if ($this->items[$i]->published == 0) : ?>
 								<span class="badge badge-warning"><?php echo JText::_('JUNPUBLISHED'); ?></span>

--- a/components/com_contact/tmpl/contact/default.php
+++ b/components/com_contact/tmpl/contact/default.php
@@ -45,7 +45,7 @@ $tparams = $this->item->params;
 			<span class="contact-category"><?php echo $this->contact->category_title; ?></span>
 		</h3>
 	<?php elseif ($show_contact_category === 'show_with_link') : ?>
-		<?php $contactLink = ContactHelperRoute::getCategoryRoute($this->contact->catid); ?>
+		<?php $contactLink = ContactHelperRoute::getCategoryRoute($this->contact->catid, $this->contact->language); ?>
 		<h3>
 			<span class="contact-category"><a href="<?php echo $contactLink; ?>">
 				<?php echo $this->escape($this->contact->category_title); ?></a>

--- a/components/com_contact/tmpl/featured/default_items.php
+++ b/components/com_contact/tmpl/featured/default_items.php
@@ -116,7 +116,7 @@ $params = &$this->item->params;
 							<?php if ($this->items[$i]->published == 0) : ?>
 								<span class="badge badge-warning"><?php echo Text::_('JUNPUBLISHED'); ?></span>
 							<?php endif; ?>
-							<a href="<?php echo Route::_(ContactHelperRoute::getContactRoute($item->slug, $item->catid)); ?>" itemprop="url">
+							<a href="<?php echo Route::_(ContactHelperRoute::getContactRoute($item->slug, $item->catid, $item->language)); ?>" itemprop="url">
 								<span itemprop="name"><?php echo $item->name; ?></span>
 							</a>
 						</td>


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/21200

### Summary of Changes
`getCategoryRoute` as well as `getContactRoute` do need the $language parameter added.


### Testing Instructions
Use latest 4.0-dev
Tested on a multilingual site.
Create a contact category tagged to each language.
Create a contact in each of these categories, tagged to the same language.

I have as menu item type "List Contacts in a category" 
`/index.php/en/contact-category-en-gb`

The link on that page displaying the contact is
`/index.php/en/contact-category-en-gb/mycontact` // see below direct menu item. this url is a double with the one below (it should be `/index.php/en/my-contact`). Alias of that single contact is `mycontact`

// I do also have a direct menu item to that contact (alias of the menu item is `my_contact`)
When I use this last one (`/index.php/en/my-contact`), the category link above the contact gives
`/index.php/en/my-contact?view=category&id=14` instead of the existing `/index.php/en/contact-category-en-gb`




### After patch
All is solved to use the correct urls and no double.

Note: 
Contacts is not the only place where the $language parameter is missing for that kind of method.
Future PRs should take care of this.

@wilsonge @Hackwar @franz-wohlkoenig