### PR TITLE
Fix tags RSS Feed

### DIFF
--- a/components/com_tags/views/tag/view.feed.php
+++ b/components/com_tags/views/tag/view.feed.php
@@ -27,7 +27,26 @@ class TagsViewTag extends JViewLegacy
 	{
 		$app            = JFactory::getApplication();
 		$document       = JFactory::getDocument();
-		$document->link = JRoute::_(TagsHelperRoute::getTagRoute($app->input->getInt('id')));
+
+		$ids = $app->input->get('id');
+
+		$i = 0;
+		$tagIds = '';
+		$filter = new JFilterInput;
+
+		foreach ($ids as $id)
+		{
+			if ($i !== 0)
+			{
+				$tagIds .= '&';
+			}
+
+			$tagIds .= 'id[' . $i . ']=' . $filter->clean($id, 'INT');
+
+			$i++;
+		}
+
+		$document->link = JRoute::_('index.php?option=com_tags&view=tag&' . $tagIds);
 
 		$app->input->set('limit', $app->get('feed_limit'));
 		$siteEmail        = $app->get('mailfrom');

--- a/components/com_tags/views/tag/view.feed.php
+++ b/components/com_tags/views/tag/view.feed.php
@@ -25,14 +25,12 @@ class TagsViewTag extends JViewLegacy
 	 */
 	public function display($tpl = null)
 	{
-		$app            = JFactory::getApplication();
-		$document       = JFactory::getDocument();
-
-		$ids = $app->input->get('id');
-
-		$i = 0;
-		$tagIds = '';
-		$filter = new JFilterInput;
+		$app       = JFactory::getApplication();
+		$document  = JFactory::getDocument();
+		$ids       = $app->input->get('id');
+		$i         = 0;
+		$tagIds    = '';
+		$filter    = new JFilterInput;
 
 		foreach ($ids as $id)
 		{


### PR DESCRIPTION
Pull Request for Issue #18249 .

### Summary of Changes
Fixes the channel link for the tags RSS Feed. There is an array of integers for this view - not a single one which broke things

### Testing Instructions
Install Joomla with sample testing data and go to `ROOT/index.php/tagged-items?format=feed&type=rss`

Before Patch the channel link is: `ROOT/index.php/all-tags/Array`

After Patch it is: `ROOT/index.php/tagged-items`
