### PR TITLE
Ordering field in module's settings

### DIFF
--- a/layouts/joomla/form/field/moduleorder.php
+++ b/layouts/joomla/form/field/moduleorder.php
@@ -58,6 +58,7 @@ $attr .= !empty($onchange) ? ' onchange="' . $onchange . '"' : '';
 // Including fallback code for HTML5 non supported browsers.
 JHtml::_('behavior.core');
 JHtml::_('jquery.framework');
+JHtml::_('formbehavior.chosen', 'select', null, array('disable_search_threshold' => 0));
 JHtml::_('script', 'system/moduleorder.js', array('version' => 'auto', 'relative' => true));
 ?>
 <div id="parent_<?php echo $id; ?>" <?php echo $attr; ?> data-url="<?php echo 'index.php?option=com_modules&task=module.orderPosition&'

--- a/media/system/js/moduleorder.js
+++ b/media/system/js/moduleorder.js
@@ -7,7 +7,7 @@
 			$linkedField = $field.data('linked-field') ? $field.data('linked-field') : 'jform_position',
 			$linkedFieldEl = $('#' + $linkedField),
 			$originalOrder = $field.data('ordering'),
-			$originalPos = $linkedFieldEl.val(),
+			$originalPos = $linkedFieldEl.chosen().val(),
 			$name = $field.data('name'),
 			$attr = $field.data('client-attr') ? $field.data('client-attr') : '',
 			$id = $field.attr('id') + '_1',
@@ -41,7 +41,7 @@
 
 								// Add chosen to the element
 								var $el = $("#" + $id);
-								if ($el.length && $el.data('chosen') && $.fn.chosen) {
+								if ($el) {
 									$el.chosen('destroy');
 									$el.chosen();
 								}
@@ -61,8 +61,8 @@
 		getNewOrder();
 
 		// Event listener for the linked field
-		$linkedFieldEl.change( function() {
-			$originalPos = $('#' + $linkedField).val();
+		$linkedFieldEl.chosen().change( function() {
+			$originalPos = $('#' + $linkedField).chosen().val();
 			getNewOrder();
 		});
 	});


### PR DESCRIPTION
PR for #13904

### Steps to reproduce the issue
Extensions > Modules > Go to any module's settings
Module ordering field looks different.

### Expected result
All select fields must looks the same.

### Actual result
![module-settings-ordering](https://cloud.githubusercontent.com/assets/1245155/22618818/9c8a2dd6-eaf7-11e6-8cc8-06a9ae610849.png)

### After pr
all select fields look the same
