### PR TITLE
onChangeState for Extension Manager

### DIFF
--- a/administrator/components/com_installer/models/manage.php
+++ b/administrator/components/com_installer/models/manage.php
@@ -138,6 +138,10 @@ class InstallerModelManage extends InstallerModel
 			{
 				$table->enabled = $value;
 			}
+		
+			$context = $this->option . '.' . $this->name;
+			JPluginHelper::importPlugin('extension');
+			JEventDispatcher::getInstance()->trigger('onExtensionChangeState', array($context, $eid, $value));
 
 			if (!$table->store())
 			{


### PR DESCRIPTION
PR for #13278

Adds a trigger event so that you can capture when an extensin is disabled etc

To test
Apply this PR

and then in `plugins\extension\joomla\joomla.php`
add this code for testing

```
	public function onExtensionChangeState($context, $eid, $value)
	{
		die ('caught you');
	}

```
Now try to disable an extension in the manage screen and you should catch the event and the message is displayed
