### PR TITLE
Use search tools in the overrides view

### DIFF
--- a/administrator/components/com_languages/models/fields/languageclient.php
+++ b/administrator/components/com_languages/models/fields/languageclient.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_newsfeeds
+ *
+ * @copyright   Copyright (C) 2005 - 2018 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('JPATH_BASE') or die;
+
+JFormHelper::loadFieldClass('list');
+
+/**
+ * Client Language List field.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class JFormFieldLanguageclient extends JFormFieldList
+{
+	/**
+	 * The form field type.
+	 *
+	 * @var		string
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected $type = 'Languageclient';
+
+	/**
+	 * Cached form field options.
+	 *
+	 * @var		array
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected $cache = array();
+
+	/**
+	 * Method to get the field options.
+	 *
+	 * @return  array  The field option objects.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function getOptions()
+	{
+		// Try to load the data from our mini-cache.
+		if (!empty($this->cache))
+		{
+			return $this->cache;
+		}
+
+		// Get all languages of frontend and backend.
+		$languages       = array();
+		$site_languages  = JLanguageHelper::getKnownLanguages(JPATH_SITE);
+		$admin_languages = JLanguageHelper::getKnownLanguages(JPATH_ADMINISTRATOR);
+
+		// Create a single array of them.
+		foreach ($site_languages as $tag => $language)
+		{
+			$languages[$tag . '0'] = JText::sprintf('COM_LANGUAGES_VIEW_OVERRIDES_LANGUAGES_BOX_ITEM', $language['name'], JText::_('JSITE'));
+		}
+
+		foreach ($admin_languages as $tag => $language)
+		{
+			$languages[$tag . '1'] = JText::sprintf('COM_LANGUAGES_VIEW_OVERRIDES_LANGUAGES_BOX_ITEM', $language['name'], JText::_('JADMINISTRATOR'));
+		}
+
+		// Sort it by language tag and by client after that.
+		ksort($languages);
+
+		// Add the languages to the internal cache.
+		$this->cache = $languages;
+
+		return $this->cache;
+	}
+}

--- a/administrator/components/com_languages/models/forms/filter_overrides.xml
+++ b/administrator/components/com_languages/models/forms/filter_overrides.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<form>
+	<fields name="filter">
+		<field
+			name="search"
+			type="text"
+			label="JSEARCH_FILTER"
+			description="COM_LANGUAGES_SEARCH_IN_TITLE"
+			hint="JSEARCH_FILTER"
+		/>
+		<field
+			name="language_client"
+			type="languageclient"
+			onchange="this.form.submit();"
+			>
+		</field>
+	</fields>
+	<fields name="list">
+		<field
+			name="limit"
+			type="limitbox"
+			label="JGLOBAL_LIMIT"
+			description="JGLOBAL_LIMIT"
+			class="input-mini"
+			default="25"
+			onchange="this.form.submit();"
+		/>
+	</fields>
+</form>

--- a/administrator/components/com_languages/models/overrides.php
+++ b/administrator/components/com_languages/models/overrides.php
@@ -183,49 +183,6 @@ class LanguagesModelOverrides extends JModelList
 	}
 
 	/**
-	 * Method to get all found languages of frontend and backend.
-	 *
-	 * The resulting array has entries of the following style:
-	 * <Language Tag>0|1 => <Language Name> - <Client Name>
-	 *
-	 * @return  array  Sorted associative array of languages.
-	 *
-	 * @since   2.5
-	 */
-	public function getLanguages()
-	{
-		// Try to load the data from internal storage.
-		if (!empty($this->cache['languages']))
-		{
-			return $this->cache['languages'];
-		}
-
-		// Get all languages of frontend and backend.
-		$languages       = array();
-		$site_languages  = JLanguageHelper::getKnownLanguages(JPATH_SITE);
-		$admin_languages = JLanguageHelper::getKnownLanguages(JPATH_ADMINISTRATOR);
-
-		// Create a single array of them.
-		foreach ($site_languages as $tag => $language)
-		{
-			$languages[$tag . '0'] = JText::sprintf('COM_LANGUAGES_VIEW_OVERRIDES_LANGUAGES_BOX_ITEM', $language['name'], JText::_('JSITE'));
-		}
-
-		foreach ($admin_languages as $tag => $language)
-		{
-			$languages[$tag . '1'] = JText::sprintf('COM_LANGUAGES_VIEW_OVERRIDES_LANGUAGES_BOX_ITEM', $language['name'], JText::_('JADMINISTRATOR'));
-		}
-
-		// Sort it by language tag and by client after that.
-		ksort($languages);
-
-		// Add the languages to the internal cache.
-		$this->cache['languages'] = $languages;
-
-		return $this->cache['languages'];
-	}
-
-	/**
 	 * Method to delete one or more overrides.
 	 *
 	 * @param   array  $cids  Array of keys to delete.

--- a/administrator/components/com_languages/views/overrides/tmpl/default.php
+++ b/administrator/components/com_languages/views/overrides/tmpl/default.php
@@ -13,13 +13,13 @@ JHtml::_('formbehavior.chosen', 'select');
 JHtml::_('bootstrap.tooltip');
 
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
-$client    = $this->state->get('filter.client') == '0' ? JText::_('JSITE') : JText::_('JADMINISTRATOR');
+$client    = $this->state->get('filter.client') == 'site' ? JText::_('JSITE') : JText::_('JADMINISTRATOR');
 $language  = $this->state->get('filter.language');
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
 
-$opposite_client   = $this->state->get('filter.client') == '1' ? JText::_('JSITE') : JText::_('JADMINISTRATOR');
-$opposite_filename = constant('JPATH_' . strtoupper(1 - $this->state->get('filter.client')? 'administrator' : 'site'))
+$opposite_client   = $this->state->get('filter.client') == 'administrator' ? JText::_('JSITE') : JText::_('JADMINISTRATOR');
+$opposite_filename = constant('JPATH_' . strtoupper($this->state->get('filter.client') === 'site' ? 'administrator' : 'site'))
 	. '/language/overrides/' . $this->state->get('filter.language', 'en-GB') . '.override.ini';
 $opposite_strings  = LanguagesHelper::parseFile($opposite_filename);
 ?>
@@ -33,19 +33,8 @@ $opposite_strings  = LanguagesHelper::parseFile($opposite_filename);
 <?php else : ?>
 	<div id="j-main-container">
 <?php endif; ?>
-		<div id="filter-bar" class="btn-toolbar clearfix">
-			<div class="filter-search btn-group pull-left">
-				<input type="text" name="filter_search" id="filter_search" placeholder="<?php echo JText::_('JSEARCH_FILTER'); ?>" value="<?php echo $this->escape($this->state->get('filter.search')); ?>" class="hasTooltip" title="<?php echo JHtml::_('tooltipText', 'COM_LANGUAGES_VIEW_OVERRIDES_FILTER_SEARCH_DESC'); ?>" />
-			</div>
-			<div class="btn-group pull-left">
-				<button type="submit" class="btn hasTooltip" title="<?php echo JHtml::_('tooltipText', 'JSEARCH_FILTER_SUBMIT'); ?>"><span class="icon-search" aria-hidden="true"></span></button>
-				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::_('tooltipText', 'JSEARCH_FILTER_CLEAR'); ?>" onclick="document.getElementById('filter_search').value='';this.form.submit();"><span class="icon-remove" aria-hidden="true"></span></button>
-			</div>
-			<div class="btn-group pull-right hidden-phone">
-				<label for="limit" class="element-invisible"><?php echo JText::_('JFIELD_PLG_SEARCH_SEARCHLIMIT_DESC'); ?></label>
-				<?php echo $this->pagination->getLimitBox(); ?>
-			</div>
-		</div>
+		<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
+        <div class="clearfix"></div>
 		<?php if (empty($this->items)) : ?>
 			<div class="alert alert-no-items">
 				<?php echo JText::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>

--- a/administrator/components/com_languages/views/overrides/tmpl/default.php
+++ b/administrator/components/com_languages/views/overrides/tmpl/default.php
@@ -47,10 +47,10 @@ $opposite_strings  = LanguagesHelper::parseFile($opposite_filename);
 							<?php echo JHtml::_('grid.checkall'); ?>
 						</th>
 						<th width="30%" class="left">
-							<?php echo JHtml::_('grid.sort', 'COM_LANGUAGES_VIEW_OVERRIDES_KEY', 'key', $listDirn, $listOrder); ?>
+							<?php echo JHtml::_('searchtools.sort', 'COM_LANGUAGES_VIEW_OVERRIDES_KEY', 'key', $listDirn, $listOrder); ?>
 						</th>
 						<th class="left hidden-phone">
-							<?php echo JHtml::_('grid.sort', 'COM_LANGUAGES_VIEW_OVERRIDES_TEXT', 'text', $listDirn, $listOrder); ?>
+							<?php echo JHtml::_('searchtools.sort', 'COM_LANGUAGES_VIEW_OVERRIDES_TEXT', 'text', $listDirn, $listOrder); ?>
 						</th>
 						<th class="nowrap hidden-phone">
 							<?php echo JText::_('COM_LANGUAGES_FIELD_LANG_TAG_LABEL'); ?>
@@ -105,8 +105,6 @@ $opposite_strings  = LanguagesHelper::parseFile($opposite_filename);
 
 		<input type="hidden" name="task" value="" />
 		<input type="hidden" name="boxchecked" value="0" />
-		<input type="hidden" name="filter_order" value="<?php echo $listOrder; ?>" />
-		<input type="hidden" name="filter_order_Dir" value="<?php echo $listDirn; ?>" />
 		<?php echo JHtml::_('form.token'); ?>
 	</div>
 </form>

--- a/administrator/components/com_languages/views/overrides/view.html.php
+++ b/administrator/components/com_languages/views/overrides/view.html.php
@@ -55,6 +55,8 @@ class LanguagesViewOverrides extends JViewLegacy
 		$this->items      = $this->get('Overrides');
 		$this->languages  = $this->get('Languages');
 		$this->pagination = $this->get('Pagination');
+		$this->filterForm    = $this->get('FilterForm');
+		$this->activeFilters = $this->get('ActiveFilters');
 
 		LanguagesHelper::addSubmenu('overrides');
 
@@ -111,13 +113,6 @@ class LanguagesViewOverrides extends JViewLegacy
 		JToolbarHelper::help('JHELP_EXTENSIONS_LANGUAGE_MANAGER_OVERRIDES');
 
 		JHtmlSidebar::setAction('index.php?option=com_languages&view=overrides');
-
-		JHtmlSidebar::addFilter(
-			'',
-			'filter_language_client',
-			JHtml::_('select.options', $this->languages, null, 'text', $this->state->get('filter.language_client')),
-			true
-		);
 
 		$this->sidebar = JHtmlSidebar::render();
 	}


### PR DESCRIPTION
Pull Request for Issue #11976 .

### Summary of Changes
Moves the overrides view to use search tools

#### Known Bug that needs solving before this is merged
I can't seem to get the session to persist the client across into the edit view - so it always uses the default (administrator) - filter by english admin then create a new overrides and the client is site not admin. @mbabker would appreciate some help cause I'm sure i'm doing something crazy dumb in the session

### Testing Instructions
After patch we have search tools instead of the filtering in the sidebar

### Documentation Changes Required
help screens

//cc @infograf768 