### PR TITLE
Allow groups to render custom form elements

### DIFF
--- a/administrator/components/com_users/models/forms/group.xml
+++ b/administrator/components/com_users/models/forms/group.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <form>
-	<fieldset>
+	<fieldset name="group_details">
 		<field 
 			name="id" 
 			type="hidden"

--- a/administrator/components/com_users/views/group/tmpl/edit.php
+++ b/administrator/components/com_users/views/group/tmpl/edit.php
@@ -28,27 +28,16 @@ JFactory::getDocument()->addScriptDeclaration("
 
 <form action="<?php echo JRoute::_('index.php?option=com_users&layout=edit&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="group-form" class="form-validate form-horizontal">
 	<fieldset>
-		<legend><?php echo JText::_('COM_USERS_USERGROUP_DETAILS'); ?></legend>
-		<div class="control-group">
-			<div class="control-label">
-				<?php echo $this->form->getLabel('title'); ?>
-			</div>
-			<div class="controls">
-				<?php echo $this->form->getInput('title'); ?>
-			</div>
-		</div>
-		<div class="control-group">
-			<?php $parent_id = $this->form->getField('parent_id'); ?>
-			<?php if (!$parent_id->hidden) : ?>
-				<div class="control-label">
-					<?php echo $parent_id->label; ?>
-				</div>
-			<?php endif; ?>
-			<div class="controls">
-				<?php echo $parent_id->input; ?>
-			</div>
-		</div>
+		<?php echo JHtml::_('bootstrap.startTabSet', 'myTab', array('active' => 'details')); ?>
+		<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'details', JText::_('COM_USERS_USERGROUP_DETAILS')); ?>
+			<?php echo $this->form->renderField('title'); ?>
+			<?php echo $this->form->renderField('parent_id'); ?>
+		<?php echo JHtml::_('bootstrap.endTab'); ?>
+		<?php $this->ignore_fieldsets = array('group_details'); ?>
+		<?php echo JLayoutHelper::render('joomla.edit.params', $this); ?>
+		<?php echo JHtml::_('bootstrap.endTabSet'); ?>
 	</fieldset>
+
 	<input type="hidden" name="task" value="" />
 	<?php echo JHtml::_('form.token'); ?>
 </form>


### PR DESCRIPTION
Pull Request for Issue #16026 .

### Summary of Changes
Allows the com_users groups view to render custom fields


### Testing Instructions
Create a plugin using the sample code in the original issue (I added it to the existing joomla user plugin). It adds a field to the groups view

### Documentation Changes Required
n/a
