### PR TITLE
[4.0] FIX batch categories modal layout as well as batch-language js files

### DIFF
--- a/administrator/components/com_categories/tmpl/categories/default_batch_body.php
+++ b/administrator/components/com_categories/tmpl/categories/default_batch_body.php
@@ -11,14 +11,9 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\HTML\HTMLHelper;
 
-$options = array(
-	HTMLHelper::_('select.option', 'c', Text::_('JLIB_HTML_BATCH_COPY')),
-	HTMLHelper::_('select.option', 'm', Text::_('JLIB_HTML_BATCH_MOVE'))
-);
 $published = $this->state->get('filter.published');
 $extension = $this->escape($this->state->get('filter.extension'));
 
-HTMLHelper::_('formbehavior.chosen', '.chzn-custom-value');
 ?>
 
 <div class="container-fluid">
@@ -36,28 +31,20 @@ HTMLHelper::_('formbehavior.chosen', '.chzn-custom-value');
 	</div>
 	<div class="row">
 		<?php if ($published >= 0) : ?>
-			<div class="col-md-6">
-				<div class="control-group">
-					<label id="batch-choose-action-lbl" for="batch-category-id" class="control-label">
-						<?php echo Text::_('JLIB_HTML_BATCH_MENU_LABEL'); ?>
-					</label>
-					<div id="batch-choose-action" class="combo controls">
-						<select class="chzn-custom-value" name="batch[category_id]" id="batch-category-id">
-							<option value=""><?php echo Text::_('JLIB_HTML_BATCH_NO_CATEGORY'); ?></option>
-							<?php echo HTMLHelper::_('select.options', HTMLHelper::_('category.categories', $extension, array('filter.published' => $published))); ?>
-						</select>
-					</div>
-				</div>
-			<?php endif; ?>
-			<div class="control-group col-md-6">
+			<div class="form-group col-md-6">
 				<div class="controls">
-					<?php echo HTMLHelper::_('batch.tag'); ?>
+					<?php echo JLayoutHelper::render('joomla.html.batch.item', array('extension' => $extension)); ?>
 				</div>
+			</div>
+		<?php endif; ?>
+		<div class="form-group col-md-6">
+			<div class="controls">
+				<?php echo HTMLHelper::_('batch.tag'); ?>
 			</div>
 		</div>
 	</div>
 	<div class="row-fluid">
-		<div class="span6">
+		<div class="form-group col-md-6">
 			<div class="control-group">
 				<label id="flip-ordering-id-lbl" for="flip-ordering-id" class="control-label">
 					<?php echo Text::_('JLIB_HTML_BATCH_FLIPORDERING_LABEL'); ?>

--- a/administrator/components/com_categories/tmpl/categories/default_batch_body.php
+++ b/administrator/components/com_categories/tmpl/categories/default_batch_body.php
@@ -10,6 +10,7 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Layout\LayoutHelper;
 
 $published = $this->state->get('filter.published');
 $extension = $this->escape($this->state->get('filter.extension'));
@@ -33,7 +34,7 @@ $extension = $this->escape($this->state->get('filter.extension'));
 		<?php if ($published >= 0) : ?>
 			<div class="form-group col-md-6">
 				<div class="controls">
-					<?php echo JLayoutHelper::render('joomla.html.batch.item', array('extension' => $extension)); ?>
+					<?php echo LayoutHelper::render('joomla.html.batch.item', array('extension' => $extension)); ?>
 				</div>
 			</div>
 		<?php endif; ?>

--- a/build/media_src/layouts/js/joomla/html/batch/batch-language.es6.js
+++ b/build/media_src/layouts/js/joomla/html/batch/batch-language.es6.js
@@ -12,7 +12,8 @@
     let batchSelector;
 
     const onChange = () => {
-      if (!batchSelector.value || (batchSelector.value && parseInt(batchSelector.value, 10) === 0)) {
+      if (!batchSelector.value ||
+          (batchSelector.value && parseInt(batchSelector.value, 10) === 0)) {
         batchCopyMove.style.display = 'none';
       } else {
         batchCopyMove.style.display = 'block';

--- a/build/media_src/layouts/js/joomla/html/batch/batch-language.es6.js
+++ b/build/media_src/layouts/js/joomla/html/batch/batch-language.es6.js
@@ -11,6 +11,14 @@
     const batchCopyMove = document.getElementById('batch-copy-move');
     let batchSelector;
 
+    const onChange = () => {
+      if (!batchSelector.value || (batchSelector.value && parseInt(batchSelector.value, 10) === 0)) {
+        batchCopyMove.style.display = 'none';
+      } else {
+        batchCopyMove.style.display = 'block';
+      }
+    };
+
     if (batchCategory) {
       batchSelector = batchCategory;
     }
@@ -26,13 +34,7 @@
     batchCopyMove.style.display = 'none';
 
     if (batchCopyMove) {
-      batchSelector.addEventListener('change', () => {
-        if (batchSelector.value !== 0 || batchSelector.value !== '') {
-          batchCopyMove.style.display = 'block';
-        } else {
-          batchCopyMove.style.display = 'none';
-        }
-      });
+      batchSelector.addEventListener('change', onChange);
     }
 
     // Cleanup

--- a/layouts/joomla/html/batch/item.php
+++ b/layouts/joomla/html/batch/item.php
@@ -26,6 +26,7 @@ $options = array(
 	HTMLHelper::_('select.option', 'c', Text::_('JLIB_HTML_BATCH_COPY')),
 	HTMLHelper::_('select.option', 'm', Text::_('JLIB_HTML_BATCH_MOVE'))
 );
+HTMLHelper::_('script', 'layouts/joomla/html/batch/batch-language.min.js', ['version' => 'auto', 'relative' => true]);
 ?>
 <label id="batch-choose-action-lbl" for="batch-choose-action"><?php echo Text::_('JLIB_HTML_BATCH_MENU_LABEL'); ?></label>
 <div id="batch-choose-action" class="control-group">


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/21473
Also corrects js https://github.com/joomla/joomla-cms/pull/21685 (Thanks @dgrammatiko)

### Summary of Changes
Corrected and moved the batch-language js files to the right folder to be able to load them
Corrected display of default-batch-body. php for categories.
Added loading the js in the batch item layout file.

### Testing Instructions
Select a category. Click on Batch.


### Before batch
The layout is badly wrong. 

![image](https://user-images.githubusercontent.com/3968575/43869539-140e07ba-9b41-11e8-9d52-8bb1d52ab9b6.png)
Choosing or not a category to move or copy does not show/hide the Move/Copy buttons

### After patch
Layout may still need some work but now it is usable.
THAT aspect CAN be tested by patchtester users.

Move Copy category now displays the show Move buttons fine.
NOT for patchtester users!

![copy-move](https://user-images.githubusercontent.com/869724/44301705-dd79ed80-a31b-11e8-98e5-cb4d39d2e521.gif)

### Note
We need to correct other default-batch-body.php
Will do after this is merged.
