### PR TITLE
[4.0] Fix wrong workflow after change of stage state

### DIFF
--- a/administrator/components/com_workflow/Controller/StagesController.php
+++ b/administrator/components/com_workflow/Controller/StagesController.php
@@ -165,4 +165,28 @@ class StagesController extends AdminController
 			)
 		);
 	}
+
+	/**
+	 * Method to publish a list of items
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function publish()
+	{
+		parent::publish();
+
+		$extension = $this->input->get('extension');
+		$extensionURL = $extension ? '&extension=' . $extension : '';
+
+		$workflow_id = $this->input->getInt('workflow_id');
+
+		$this->setRedirect(
+			Route::_(
+				'index.php?option=' . $this->option . '&view=' . $this->view_list
+				. $extensionURL . '&workflow_id=' . $workflow_id, false
+			)
+		);
+	}
 }

--- a/administrator/components/com_workflow/Controller/TransitionsController.php
+++ b/administrator/components/com_workflow/Controller/TransitionsController.php
@@ -54,4 +54,28 @@ class TransitionsController extends AdminController
 			)
 		);
 	}
+
+	/**
+	 * Method to publish a list of items
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function publish()
+	{
+		parent::publish();
+
+		$extension = $this->input->get('extension');
+		$extensionURL = $extension ? '&extension=' . $extension : '';
+
+		$workflow_id = $this->input->getInt('workflow_id');
+
+		$this->setRedirect(
+			Route::_(
+				'index.php?option=' . $this->option . '&view=' . $this->view_list
+				. $extensionURL . '&workflow_id=' . $workflow_id, false
+			)
+		);
+	}
 }


### PR DESCRIPTION
Pull Request for Issue #21689  .

### Summary of Changes
Fix the described bug


### Testing Instructions
1. create a custom Workflow
2. create a new Stage in this Workflow
3. trash this Stage
4. select in "Table Options" Status "Trashed"
5. select trashed Stage and click on "Publish Item"-Icon
6. select in "Table Options" Status "Select Status"

=> same for transitions

### Expected result
Stay on current workflow


### Actual result
Default workflow will be loaded