### PR TITLE
[4.0] Build script console log

### DIFF
--- a/build/build-modules-js/compilecejs.js
+++ b/build/build-modules-js/compilecejs.js
@@ -65,7 +65,7 @@ const compile = (options) => {
         } else {
           // Auto prefixing
           // eslint-disable-next-line no-console
-          console.log(`'Prefixing for: ${options.settings.browsers}`);
+          console.log(`Prefixing for: ${options.settings.browsers}`);
 
           const cleaner = postcss(
             [


### PR DESCRIPTION
Remove an extra apostrophe from the build script console logs

this is a non-functional cosmetic change