### PR TITLE
Remove debug from calendar field as it breaks saving to the DB

### DIFF
--- a/libraries/joomla/form/fields/calendar.php
+++ b/libraries/joomla/form/fields/calendar.php
@@ -200,6 +200,9 @@ class JFormFieldCalendar extends JFormField
 		{
 			$showTime = (string) $this->element['showtime'];
 
+			$lang  = \JFactory::getLanguage();
+			$debug = $lang->setDebug(false);
+
 			if ($showTime && $showTime != 'false')
 			{
 				$this->format = JText::_('DATE_FORMAT_CALENDAR_DATETIME');
@@ -208,6 +211,8 @@ class JFormFieldCalendar extends JFormField
 			{
 				$this->format = JText::_('DATE_FORMAT_CALENDAR_DATE');
 			}
+
+			$lang->setDebug($debug);
 		}
 
 		// If a known filter is given use it.


### PR DESCRIPTION
Fixes #19607 

When you have language debug enabled the calendar dates will not save to the db as they are in the incorrect format. We can't show these in debug mode. This is similar to the fix for e.g in the template adapter.

Note in 4.x this gives an error correctly but in 3.x will silently insert an empty string to the db