### PR TITLE
[4.0]tinyMCE - unwanted CMS Content dropdown button

### DIFF
--- a/build/media_src/editors/tinymce/js/tinymce.es6.js
+++ b/build/media_src/editors/tinymce/js/tinymce.es6.js
@@ -82,14 +82,16 @@
         buttonValues.push(tmp);
       });
 
-      options.setup = (editor) => {
-        editor.addButton('jxtdbuttons', {
-          type: 'menubutton',
-          text: Joomla.JText._('PLG_TINY_CORE_BUTTONS'),
-          icon: 'none icon-joomla',
-          menu: buttonValues,
-        });
-      };
+      if (buttonValues.length) {
+        options.setup = (editor) => {
+          editor.addButton('jxtdbuttons', {
+            type: 'menubutton',
+            text: Joomla.JText._('PLG_TINY_CORE_BUTTONS'),
+            icon: 'none icon-joomla',
+            menu: buttonValues,
+          });
+        };
+      }
 
       // Create a new instance
       // eslint-disable-next-line no-undef


### PR DESCRIPTION
Pull Request for Issue #21711

### Summary of Changes
CMS Content button in TinyMCE editor is only displayed when needed. 
### Testing Instructions
If you have a form with a "custom" editor field you see it. Otherwise edit the article form in `administrator/components/com_content/forms/article.xml`
- Change buttons="true" to buttons="false" for field-name articletext
- Open New Article
- The CMS Content drop-down button is there with an empty drop-down list.
![44307173-06db5d80-a39e-11e8-84c8-dd56f3ab0f7a](https://user-images.githubusercontent.com/4176111/44310180-32783b00-a3d2-11e8-871c-cb8ff7777b6b.jpg)
Example:
```
<field
      name="descripton" 
      type="editor" 
      ==>    buttons="false" 
      filter="JComponentHelper::filterText"
      height="200" 
     label="COM_MYCOMP_FIELD_DESCRIPPTION_LABEL"/>
```
### Expected result
No button
### Actual result
Button is there
### Documentation Changes Required

N/A

cc @schnuti @dgrammatiko 

This PR requires npm for testing.