### PR TITLE
[4.0] Small change in batch-language.js file to cope with eventual absence of CopyMove method

### DIFF
--- a/build/media_src/layouts/js/joomla/html/batch/batch-language.es6.js
+++ b/build/media_src/layouts/js/joomla/html/batch/batch-language.es6.js
@@ -32,7 +32,9 @@
       batchSelector = batchPosition;
     }
 
-    batchCopyMove.style.display = 'none';
+    if (batchCopyMove) {
+      batchCopyMove.style.display = 'none';
+    }
 
     if (batchCopyMove) {
       batchSelector.addEventListener('change', onChange);


### PR DESCRIPTION
### Summary of Changes
Added a conditional to avoid some errors

### Testing Instructions
NOT for patch tester users.
Load Modules manager

### Before patch
When loading Modules Manager, we get a js error:
`TypeError: batchCopyMove is null`
This happens because the batch functionnality is broken atm for modules and the method batchCopyMove is not instantiated.

### After patch
No more errors

Code approved by @dgrammatiko 

Can be merged on review @wilsonge @laoneo 

