### PR TITLE
[4.0] Fix batch modals display for Menu items and Newsfeeds

### DIFF
--- a/administrator/components/com_menus/tmpl/items/default_batch_body.php
+++ b/administrator/components/com_menus/tmpl/items/default_batch_body.php
@@ -27,8 +27,8 @@ endif;
 <div class="container">
 	<?php if (strlen($menuType) && $menuType != '*') : ?>
 	<?php if ($clientId != 1) : ?>
-    <div class="row">
-        <div class="form-group col-md-6">
+	<div class="row">
+		<div class="form-group col-md-6">
 			<div class="controls">
 				<?php echo HTMLHelper::_('batch.language'); ?>
 			</div>
@@ -40,13 +40,13 @@ endif;
 		</div>
 	</div>
 	<?php endif; ?>
-    <div class="row">
+	<div class="row">
 		<?php if ($published >= 0) : ?>
-			<div id="batch-choose-action" class="combo control-group">
-				<label id="batch-choose-action-lbl" class="control-label" for="batch-menu-id">
-					<?php echo Text::_('COM_MENUS_BATCH_MENU_LABEL'); ?>
-				</label>
+			<div class="form-group col-md-6">
 				<div class="controls">
+					<label id="batch-choose-action-lbl" for="batch-menu-id">
+						<?php echo Text::_('COM_MENUS_BATCH_MENU_LABEL'); ?>
+					</label>
 					<select class="custom-select" name="batch[menu_id]" id="batch-menu-id">
 						<option value=""><?php echo Text::_('JLIB_HTML_BATCH_NO_CATEGORY'); ?></option>
 						<?php
@@ -59,10 +59,11 @@ endif;
 						?>
 					</select>
 				</div>
-			</div>
-			<div id="batch-copy-move" class="control-group radio">
-				<?php echo Text::_('JLIB_HTML_BATCH_MOVE_QUESTION'); ?>
-				<?php echo HTMLHelper::_('select.radiolist', $options, 'batch[move_copy]', '', 'value', 'text', 'm'); ?>
+
+				<div id="batch-copy-move" class="control-group radio">
+					<?php echo Text::_('JLIB_HTML_BATCH_MOVE_QUESTION'); ?>
+					<?php echo HTMLHelper::_('select.radiolist', $options, 'batch[move_copy]', '', 'value', 'text', 'm'); ?>
+				</div>
 			</div>
 		<?php endif; ?>
 

--- a/administrator/components/com_newsfeeds/tmpl/newsfeeds/default_batch_body.php
+++ b/administrator/components/com_newsfeeds/tmpl/newsfeeds/default_batch_body.php
@@ -30,10 +30,14 @@ $published = $this->state->get('filter.published');
 		<?php if ($published >= 0) : ?>
 			<div class="form-group col-md-6">
 				<div class="controls">
-					<?php echo HTMLHelper::_('batch.tag'); ?>
+					<?php echo HTMLHelper::_('batch.item', 'com_newsfeeds'); ?>
 				</div>
 			</div>
-		</div>
 		<?php endif; ?>
+		<div class="form-group col-md-6">
+			<div class="controls">
+				<?php echo HTMLHelper::_('batch.tag'); ?>
+			</div>
+		</div>
 	</div>
 </div>


### PR DESCRIPTION
### Summary of Changes
As title says. Normalise both batch modals display.
Plus: added Move or Copy for Newsfeeds


### Testing Instructions
Can be tested by PatchTester users.

Display Menu items Manager. Select an item and click on the Batch button.

Make sure you have at least 2 Newsfeeds categories. 
Display Newsfeeds Manager. Select an item and click on the Batch button.

### Before patch

For Menu items
<img width="851" alt="screen shot 2018-08-19 at 19 22 07" src="https://user-images.githubusercontent.com/869724/44311381-a58bac80-a3e6-11e8-877b-7b78664b7af4.png">

For Newsfeeds

<img width="853" alt="screen shot 2018-08-19 at 19 19 35" src="https://user-images.githubusercontent.com/869724/44311385-bdfbc700-a3e6-11e8-8086-c0260b50d9fc.png">


### After patch
For Menu items
<img width="850" alt="screen shot 2018-08-19 at 19 23 55" src="https://user-images.githubusercontent.com/869724/44311389-d0760080-a3e6-11e8-8e92-817e3553ba00.png">

For Newsfeeds
<img width="846" alt="screen shot 2018-08-19 at 19 18 37" src="https://user-images.githubusercontent.com/869724/44311405-0d41f780-a3e7-11e8-8d99-d0c0aaa3dced.png">





### Documentation Changes Required

