### PR TITLE
HTMLHelper stylesheet method

### DIFF
--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -607,7 +607,7 @@ abstract class HTMLHelper
 	public static function stylesheet($file, $options = array(), $attribs = array())
 	{
 		// B/C before 3.7.0
-		if (!is_array($attribs))
+		if (!is_array($attribs) || !is_array($options))
 		{
 			Log::add('The stylesheet method signature used has changed, use (file, options, attributes) instead.', Log::WARNING, 'deprecated');
 


### PR DESCRIPTION
Pull Request for Issue #21216  .

### Summary of Changes
In ./libraries/src/HTML/HTMLHelper.php at line 610 it writes:
`if (!is_array($attribs))`
but should better be
`if (!is_array($attribs) || !is_array($options))`


### Reason
An old extension adding stylesheets the (very) old way like
`JHTML::stylesheet('filename','path-to-file');`
will obviously not add the stylesheet but still create several "illegal string offset" notices instead of better eventually add a deprecated message to flog


(this is a recreation of a pr from @Foto50 which went wrong