### PR TITLE
[Fix] Batch menu items: Translate the menu item title when client is administrator

### DIFF
--- a/libraries/cms/html/menu.php
+++ b/libraries/cms/html/menu.php
@@ -126,6 +126,12 @@ abstract class JHtmlMenu
 
 				$lookup[$item->menutype][] = &$item;
 
+				// Translate the menu item title when client is administrator
+				if ($clientId === 1)
+				{
+					$item->text = JText::_($item->text);
+				}
+
 				$item->text = str_repeat('- ', $item->level) . $item->text;
 			}
 


### PR DESCRIPTION
### Summary of Changes
As title says


### Testing Instructions
Staging or last 3.8.x version.
Create a custom admin menu using preset.
Display the menu items for this menu in the menu items Manager.
Select an item and click on batch.
The modal displays.


### Before patch
The items are not translated.

<img width="500" alt="screen shot 2018-08-20 at 07 21 34" src="https://user-images.githubusercontent.com/869724/44322421-6a709400-a44d-11e8-8cb2-fc23d535ce30.png">

### After patch
<img width="532" alt="screen shot 2018-08-20 at 06 45 35" src="https://user-images.githubusercontent.com/869724/44322435-7f4d2780-a44d-11e8-976a-7e3ab7c3f0e1.png">


### Documentation Changes Required
None
