### PR TITLE
Change value column of #__fields_values from text to longtext

### DIFF
--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -746,7 +746,7 @@ CREATE TABLE IF NOT EXISTS `#__fields_groups` (
 CREATE TABLE IF NOT EXISTS `#__fields_values` (
   `field_id` int(10) unsigned NOT NULL,
   `item_id` varchar(255) NOT NULL COMMENT 'Allow references to items which have strings as ids, eg. none db systems.',
-  `value` text NOT NULL DEFAULT '',
+  `value` longtext NOT NULL DEFAULT '',
   KEY `idx_field_id` (`field_id`),
   KEY `idx_item_id` (`item_id`(191))
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;


### PR DESCRIPTION
[com_fields| Joomla custom field data length

Pull Request for Issue # 9618.

Summary of Changes

Change value column of #__fields_values from text to longtext
Testing Instructions

Create a content field, create an article using that field, insert more than 65535 bytes of data into that field (e.g. a PDF document).
Expected result

The document is stored correctly and can be retreived.
Actual result

As expected.
Documentation Changes Required

None known.
Advice for anyone wanting to store very large quantities of data (e.g. 1G / videos)?
