### PR TITLE
[4.0] Content category state to stage

### DIFF
--- a/components/com_content/tmpl/category/blog_item.php
+++ b/components/com_content/tmpl/category/blog_item.php
@@ -85,7 +85,7 @@ $assocParam = (Associations::isEnabled() && $params->get('show_associations'));
 
 	<?php endif; ?>
 
-	<?php if ($this->item->state_condition == ContentComponent::CONDITION_UNPUBLISHED || strtotime($this->item->publish_up) > strtotime(Factory::getDate())
+	<?php if ($this->item->stage_condition == ContentComponent::CONDITION_UNPUBLISHED || strtotime($this->item->publish_up) > strtotime(Factory::getDate())
 		|| ((strtotime($this->item->publish_down) < strtotime(Factory::getDate())) && $this->item->publish_down != Factory::getDbo()->getNullDate())) : ?>
 	</div>
 	<?php endif; ?>

--- a/components/com_content/tmpl/category/default_articles.php
+++ b/components/com_content/tmpl/category/default_articles.php
@@ -198,7 +198,7 @@ if (!empty($this->items))
 						<?php endforeach; ?>
 					<?php endif; ?>
 				<?php endif; ?>
-				<?php if ($article->state_condition == ContentComponent::CONDITION_UNPUBLISHED) : ?>
+				<?php if ($article->stage_condition == ContentComponent::CONDITION_UNPUBLISHED) : ?>
 					<span class="list-published label label-warning">
 						<?php echo JText::_('JUNPUBLISHED'); ?>
 					</span>


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/21776
`Undefined property: stdClass::$state_condition`
Issue also present for category list

### Summary of Changes
correcting state_condition to stage_condition

### Testing Instructions
Create a content category menu item and also a category list menu item.
Open this views in frontend


### After patch
No more errors.
