### PR TITLE
[4.0] Remove not needed JLoader imports

### DIFF
--- a/administrator/components/com_joomlaupdate/Controller/UpdateController.php
+++ b/administrator/components/com_joomlaupdate/Controller/UpdateController.php
@@ -295,8 +295,6 @@ class UpdateController extends BaseController
 		// Do I really have an update package?
 		$tempFile = Factory::getApplication()->getUserState('com_joomlaupdate.temp_file', null);
 
-		\JLoader::import('joomla.filesystem.file');
-
 		if (empty($tempFile) || !File::exists($tempFile))
 		{
 			throw new \RuntimeException(Text::_('JLIB_APPLICATION_ERROR_ACCESS_FORBIDDEN'), 403);

--- a/administrator/components/com_joomlaupdate/Model/UpdateModel.php
+++ b/administrator/components/com_joomlaupdate/Model/UpdateModel.php
@@ -359,8 +359,6 @@ class UpdateModel extends BaseDatabaseModel
 	 */
 	protected function downloadPackage($url, $target)
 	{
-		\JLoader::import('helpers.download', JPATH_COMPONENT_ADMINISTRATOR);
-
 		try
 		{
 			Log::add(Text::sprintf('COM_JOOMLAUPDATE_UPDATE_LOG_URL', $url), Log::INFO, 'Update');
@@ -1007,8 +1005,6 @@ ENDDATA;
 	{
 		$file = Factory::getApplication()->getUserState('com_joomlaupdate.temp_file', null);
 
-		\JLoader::import('joomla.filesystem.file');
-
 		if (empty($file) || !File::exists($file))
 		{
 			return false;
@@ -1030,8 +1026,6 @@ ENDDATA;
 			Factory::getApplication()->getUserState('com_joomlaupdate.temp_file', null),
 			Factory::getApplication()->getUserState('com_joomlaupdate.file', null),
 		);
-
-		\JLoader::import('joomla.filesystem.file');
 
 		foreach ($files as $file)
 		{

--- a/installation/src/Model/LanguagesModel.php
+++ b/installation/src/Model/LanguagesModel.php
@@ -24,8 +24,6 @@ use Joomla\CMS\Updater\Update;
 use Joomla\CMS\Updater\Updater;
 use Joomla\CMS\Language\Text;
 
-\JLoader::import('joomla.updater.update');
-
 /**
  * Language Installer model for the Joomla Core Installer.
  *

--- a/libraries/src/Console/RemoveOldFilesCommand.php
+++ b/libraries/src/Console/RemoveOldFilesCommand.php
@@ -33,10 +33,6 @@ class RemoveOldFilesCommand extends AbstractCommand
 
 		$symfonyStyle->title('Removing Old Files');
 
-		// Import the dependencies
-		\JLoader::import('joomla.filesystem.file');
-		\JLoader::import('joomla.filesystem.folder');
-
 		// We need the update script
 		\JLoader::register('JoomlaInstallerScript', JPATH_ADMINISTRATOR . '/components/com_admin/script.php');
 

--- a/libraries/src/Factory.php
+++ b/libraries/src/Factory.php
@@ -15,6 +15,7 @@ use Joomla\CMS\Cache\Cache;
 use Joomla\CMS\Date\Date;
 use Joomla\CMS\Document\Document;
 use Joomla\CMS\Document\FactoryInterface;
+use Joomla\CMS\Filesystem\Stream;
 use Joomla\CMS\Input\Input;
 use Joomla\CMS\Language\Language;
 use Joomla\CMS\Log\Log;
@@ -734,8 +735,6 @@ abstract class Factory
 	 */
 	public static function getStream($use_prefix = true, $use_network = true, $ua = 'Joomla', $uamask = false)
 	{
-		\JLoader::import('joomla.filesystem.stream');
-
 		// Setup the context; Joomla! UA and overwrite
 		$context = array();
 		$version = new Version;
@@ -766,11 +765,11 @@ abstract class Factory
 				$prefix = JPATH_ROOT . '/';
 			}
 
-			$retval = new \JStream($prefix, JPATH_ROOT, $context);
+			$retval = new Stream($prefix, JPATH_ROOT, $context);
 		}
 		else
 		{
-			$retval = new \JStream('', '', $context);
+			$retval = new Stream('', '', $context);
 		}
 
 		return $retval;

--- a/libraries/src/Form/Field/ModulelayoutField.php
+++ b/libraries/src/Form/Field/ModulelayoutField.php
@@ -19,8 +19,6 @@ use Joomla\CMS\Form\FormField;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
-\JLoader::import('joomla.filesystem.folder');
-
 /**
  * Form Field to display a list of the layouts for module display from the module or template overrides.
  *

--- a/libraries/src/Installer/Manifest.php
+++ b/libraries/src/Installer/Manifest.php
@@ -12,8 +12,6 @@ defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Language\Text;
 
-\JLoader::import('joomla.filesystem.file');
-
 /**
  * Joomla! Package Manifest File
  *

--- a/libraries/src/Updater/Updater.php
+++ b/libraries/src/Updater/Updater.php
@@ -13,8 +13,6 @@ defined('JPATH_PLATFORM') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Table\Table;
 
-\JLoader::import('joomla.filesystem.file');
-\JLoader::import('joomla.filesystem.folder');
 \JLoader::import('joomla.base.adapter');
 
 /**

--- a/plugins/system/updatenotification/updatenotification.php
+++ b/plugins/system/updatenotification/updatenotification.php
@@ -56,7 +56,6 @@ class PlgSystemUpdatenotification extends CMSPlugin
 	public function onAfterRender()
 	{
 		// Get the timeout for Joomla! updates, as configured in com_installer's component parameters
-		JLoader::import('joomla.application.component.helper');
 		$component = ComponentHelper::getComponent('com_installer');
 
 		/** @var \Joomla\Registry\Registry $params */


### PR DESCRIPTION
As the namespaced classes are automatically loaded, there is no need anymore to import them through JLoader.

See #21781 for more information why they are not needed anymore.