### PR TITLE
[4.0] Deprecate JLoader helper classes for none namespaced imports

### DIFF
--- a/libraries/loader.php
+++ b/libraries/loader.php
@@ -90,7 +90,8 @@ abstract class JLoader
 	 *
 	 * @return  void
 	 *
-	 * @since   11.1
+	 * @since       11.1
+	 * @deprecated  5.0 Move to namespaces
 	 */
 	public static function discover($classPrefix, $parentPath, $force = true, $recurse = false)
 	{
@@ -184,7 +185,8 @@ abstract class JLoader
 	 *
 	 * @return  boolean  True on success.
 	 *
-	 * @since   11.1
+	 * @since       11.1
+	 * @deprecated  5.0 Move to namespaces
 	 */
 	public static function import($key, $base = null)
 	{
@@ -300,7 +302,8 @@ abstract class JLoader
 	 *
 	 * @return  void
 	 *
-	 * @since   11.1
+	 * @since       11.1
+	 * @deprecated  5.0 Move to namespaces
 	 */
 	public static function register($class, $path, $force = true)
 	{

--- a/libraries/loader.php
+++ b/libraries/loader.php
@@ -91,7 +91,7 @@ abstract class JLoader
 	 * @return  void
 	 *
 	 * @since       11.1
-	 * @deprecated  5.0 Move to namespaces
+	 * @deprecated  5.0 Classes should be autoloaded. Use JLoader::registerPrefix() or JLoader::registerNamespace() to register an autoloader for your files.
 	 */
 	public static function discover($classPrefix, $parentPath, $force = true, $recurse = false)
 	{
@@ -186,7 +186,7 @@ abstract class JLoader
 	 * @return  boolean  True on success.
 	 *
 	 * @since       11.1
-	 * @deprecated  5.0 Move to namespaces
+	 * @deprecated  5.0 Classes should be autoloaded. Use JLoader::registerPrefix() or JLoader::registerNamespace() to register an autoloader for your files.
 	 */
 	public static function import($key, $base = null)
 	{
@@ -303,7 +303,7 @@ abstract class JLoader
 	 * @return  void
 	 *
 	 * @since       11.1
-	 * @deprecated  5.0 Move to namespaces
+	 * @deprecated  5.0 Classes should be autoloaded. Use JLoader::registerPrefix() or JLoader::registerNamespace() to register an autoloader for your files.
 	 */
 	public static function register($class, $path, $force = true)
 	{
@@ -838,7 +838,7 @@ if (!function_exists('jexit'))
  * @return  boolean  True on success.
  *
  * @since       11.1
- * @deprecated  5.0 Move to namespaces
+ * @deprecated  5.0 Classes should be autoloaded. Use JLoader::registerPrefix() or JLoader::registerNamespace() to register an autoloader for your files.
  */
 function jimport($path, $base = null)
 {

--- a/libraries/loader.php
+++ b/libraries/loader.php
@@ -837,7 +837,8 @@ if (!function_exists('jexit'))
  *
  * @return  boolean  True on success.
  *
- * @since   11.1
+ * @since       11.1
+ * @deprecated  5.0 Move to namespaces
  */
 function jimport($path, $base = null)
 {


### PR DESCRIPTION
As the whole core is now namespaced, it is time to deprecate the JLoader helper functions for none namespaced classes. The following function are deprecated:

- **discover**  
This happens automatically when a namespace is registered.
- **import**  
Import is not needed as the classes are loaded automatically.
- **register**
Classes are lazy loaded anyway.
- **jimport**  
Wrapper for JLoader::import,