### PR TITLE
[4.0] Remove jimport calls

### DIFF
--- a/administrator/components/com_admin/Model/HelpModel.php
+++ b/administrator/components/com_admin/Model/HelpModel.php
@@ -156,7 +156,6 @@ class HelpModel extends BaseDatabaseModel
 		}
 
 		// Get Help files
-		jimport('joomla.filesystem.folder');
 		$files = Folder::files(JPATH_BASE . '/help/' . $lang_tag, '\.xml$|\.html$');
 		$this->toc = array();
 

--- a/administrator/components/com_admin/postinstall/eaccelerator.php
+++ b/administrator/components/com_admin/postinstall/eaccelerator.php
@@ -53,9 +53,6 @@ function admin_postinstall_eaccelerator_action()
 
 	$config = new Registry($data);
 
-	jimport('joomla.filesystem.path');
-	jimport('joomla.filesystem.file');
-
 	// Set the configuration file path.
 	$file = JPATH_CONFIGURATION . '/configuration.php';
 

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -3947,8 +3947,6 @@ class JoomlaInstallerScript
 			'/media/jui/less',
 		);
 
-		jimport('joomla.filesystem.file');
-
 		foreach ($files as $file)
 		{
 			if (File::exists(JPATH_ROOT . $file) && !File::delete(JPATH_ROOT . $file))
@@ -3956,8 +3954,6 @@ class JoomlaInstallerScript
 				echo Text::sprintf('FILES_JOOMLA_ERROR_FILE_FOLDER', $file) . '<br>';
 			}
 		}
-
-		jimport('joomla.filesystem.folder');
 
 		foreach ($folders as $folder)
 		{

--- a/administrator/components/com_banners/Model/TracksModel.php
+++ b/administrator/components/com_banners/Model/TracksModel.php
@@ -500,8 +500,6 @@ class TracksModel extends ListModel
 				$ziproot = $app->get('tmp_path') . '/' . uniqid('banners_tracks_') . '.zip';
 
 				// Run the packager
-				jimport('joomla.filesystem.folder');
-				jimport('joomla.filesystem.file');
 				$delete = Folder::files($app->get('tmp_path') . '/', uniqid('banners_tracks_'), false, true);
 
 				if (!empty($delete))

--- a/administrator/components/com_categories/Model/CategoryModel.php
+++ b/administrator/components/com_categories/Model/CategoryModel.php
@@ -387,8 +387,6 @@ class CategoryModel extends AdminModel
 	 */
 	protected function preprocessForm(\JForm $form, $data, $group = 'content')
 	{
-		jimport('joomla.filesystem.path');
-
 		$lang = Factory::getLanguage();
 		$component = $this->getState('category.component');
 		$section = $this->getState('category.section');

--- a/administrator/components/com_config/Model/ApplicationModel.php
+++ b/administrator/components/com_config/Model/ApplicationModel.php
@@ -553,9 +553,6 @@ class ApplicationModel extends FormModel
 	 */
 	private function writeConfigFile(Registry $config)
 	{
-		jimport('joomla.filesystem.path');
-		jimport('joomla.filesystem.file');
-
 		// Set the configuration file path.
 		$file = JPATH_CONFIGURATION . '/configuration.php';
 

--- a/administrator/components/com_contenthistory/Helper/ContenthistoryHelper.php
+++ b/administrator/components/com_contenthistory/Helper/ContenthistoryHelper.php
@@ -169,8 +169,6 @@ class ContenthistoryHelper
 	public static function getFormFile(ContentType $typesTable)
 	{
 		$result = false;
-		jimport('joomla.filesystem.file');
-		jimport('joomla.filesystem.folder');
 
 		// First, see if we have a file name in the $typesTable
 		$options = json_decode($typesTable->content_history_options);

--- a/administrator/components/com_finder/helpers/indexer/driver/mysql.php
+++ b/administrator/components/com_finder/helpers/indexer/driver/mysql.php
@@ -9,8 +9,6 @@
 
 defined('_JEXEC') or die;
 
-jimport('joomla.filesystem.file');
-
 /**
  * Indexer class supporting MySQL(i) for the Finder indexer package.
  *

--- a/administrator/components/com_finder/helpers/indexer/driver/postgresql.php
+++ b/administrator/components/com_finder/helpers/indexer/driver/postgresql.php
@@ -9,8 +9,6 @@
 
 defined('_JEXEC') or die;
 
-jimport('joomla.filesystem.file');
-
 /**
  * Indexer class supporting PostgreSQL for the Finder indexer package.
  *

--- a/administrator/components/com_finder/helpers/indexer/indexer.php
+++ b/administrator/components/com_finder/helpers/indexer/indexer.php
@@ -17,8 +17,6 @@ JLoader::register('FinderIndexerParser', __DIR__ . '/parser.php');
 JLoader::register('FinderIndexerTaxonomy', __DIR__ . '/taxonomy.php');
 JLoader::register('FinderIndexerToken', __DIR__ . '/token.php');
 
-jimport('joomla.filesystem.file');
-
 /**
  * Main indexer class for the Finder indexer package.
  *

--- a/administrator/components/com_installer/Model/InstallModel.php
+++ b/administrator/components/com_installer/Model/InstallModel.php
@@ -318,7 +318,6 @@ class InstallModel extends BaseDatabaseModel
 		$tmp_src  = $userfile['tmp_name'];
 
 		// Move uploaded file.
-		jimport('joomla.filesystem.file');
 		File::upload($tmp_src, $tmp_dest, false, true);
 
 		// Unpack the downloaded package file.
@@ -392,7 +391,6 @@ class InstallModel extends BaseDatabaseModel
 		// Handle updater XML file case:
 		if (preg_match('/\.xml\s*$/', $url))
 		{
-			jimport('joomla.updater.update');
 			$update = new Update;
 			$update->loadFromXml($url);
 			$package_url = trim($update->get('downloadurl', false)->_data);

--- a/administrator/components/com_installer/Model/LanguagesModel.php
+++ b/administrator/components/com_installer/Model/LanguagesModel.php
@@ -10,8 +10,6 @@ namespace Joomla\Component\Installer\Administrator\Model;
 
 defined('_JEXEC') or die;
 
-jimport('joomla.updater.update');
-
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
 use Joomla\CMS\MVC\Model\ListModel;
 use Joomla\String\StringHelper;

--- a/administrator/components/com_installer/Model/UpdateModel.php
+++ b/administrator/components/com_installer/Model/UpdateModel.php
@@ -11,8 +11,6 @@ namespace Joomla\Component\Installer\Administrator\Model;
 
 defined('_JEXEC') or die;
 
-jimport('joomla.updater.update');
-
 use Joomla\CMS\MVC\Model\ListModel;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\Utilities\ArrayHelper;
@@ -559,8 +557,6 @@ class UpdateModel extends ListModel
 	 */
 	protected function preparePreUpdate($update, $table)
 	{
-		jimport('joomla.filesystem.file');
-
 		switch ($table->type)
 		{
 			// Components could have a helper which adds additional data

--- a/administrator/components/com_joomlaupdate/Model/UpdateModel.php
+++ b/administrator/components/com_joomlaupdate/Model/UpdateModel.php
@@ -28,9 +28,6 @@ use Joomla\CMS\Log\Log;
 use Joomla\CMS\Http\HttpFactory;
 use Joomla\CMS\Installer\Installer;
 
-jimport('joomla.filesystem.folder');
-jimport('joomla.filesystem.file');
-
 /**
  * Joomla! update overview Model
  *
@@ -205,7 +202,6 @@ class UpdateModel extends BaseDatabaseModel
 		$this->updateInformation['hasUpdate'] = $updateObject->version != \JVERSION;
 
 		// Fetch the full update details from the update details URL.
-		jimport('joomla.updater.update');
 		$update = new Update;
 		$update->loadFromXML($updateObject->detailsurl);
 
@@ -369,8 +365,6 @@ class UpdateModel extends BaseDatabaseModel
 		{
 			// Informational log only
 		}
-
-		jimport('joomla.filesystem.file');
 
 		// Make sure the target does not exist.
 		File::delete($target);
@@ -938,8 +932,6 @@ ENDDATA;
 		$tmp_src  = $userfile['tmp_name'];
 
 		// Move uploaded file.
-		jimport('joomla.filesystem.file');
-
 		if (version_compare(\JVERSION, '3.4.0', 'ge'))
 		{
 			$result = File::upload($tmp_src, $tmp_dest, false, true);

--- a/administrator/components/com_languages/Model/InstalledModel.php
+++ b/administrator/components/com_languages/Model/InstalledModel.php
@@ -426,7 +426,6 @@ class InstalledModel extends ListModel
 		if (is_null($this->folders))
 		{
 			$path = $this->getPath();
-			jimport('joomla.filesystem.folder');
 			$this->folders = Folder::folders($path, '.', false, false, array('.svn', 'CVS', '.DS_Store', '__MACOSX', 'pdf_fonts', 'overrides'));
 		}
 

--- a/administrator/components/com_languages/Model/OverrideModel.php
+++ b/administrator/components/com_languages/Model/OverrideModel.php
@@ -133,8 +133,6 @@ class OverrideModel extends AdminModel
 	 */
 	public function save($data, $opposite_client = false)
 	{
-		jimport('joomla.filesystem.file');
-
 		$app = Factory::getApplication();
 
 		$client   = $app->getUserState('com_languages.overrides.filter.client', 0);

--- a/administrator/components/com_languages/Model/OverridesModel.php
+++ b/administrator/components/com_languages/Model/OverridesModel.php
@@ -54,8 +54,6 @@ class OverridesModel extends ListModel
 	 */
 	public function getOverrides($all = false)
 	{
-		jimport('joomla.filesystem.file');
-
 		// Get a storage key.
 		$store = $this->getStoreId();
 
@@ -258,8 +256,6 @@ class OverridesModel extends ListModel
 
 			return false;
 		}
-
-		jimport('joomla.filesystem.file');
 
 		$filterclient = Factory::getApplication()->getUserState('com_languages.overrides.filter.client');
 		$client = $filterclient == 0 ? 'SITE' : 'ADMINISTRATOR';

--- a/administrator/components/com_languages/Model/StringsModel.php
+++ b/administrator/components/com_languages/Model/StringsModel.php
@@ -64,8 +64,6 @@ class StringsModel extends BaseDatabaseModel
 		$files = array();
 
 		// Parse common language directory.
-		jimport('joomla.filesystem.folder');
-
 		if (is_dir($path))
 		{
 			$files = Folder::files($path, $language . '.*ini$', false, true);

--- a/administrator/components/com_menus/Model/ItemModel.php
+++ b/administrator/components/com_menus/Model/ItemModel.php
@@ -26,8 +26,6 @@ use Joomla\CMS\Uri\Uri;
 use Joomla\CMS\Filesystem\Path;
 use Joomla\CMS\Factory;
 
-jimport('joomla.filesystem.path');
-
 /**
  * Menu Item Model for Menus.
  *

--- a/administrator/components/com_menus/Model/MenutypesModel.php
+++ b/administrator/components/com_menus/Model/MenutypesModel.php
@@ -17,8 +17,6 @@ use Joomla\Component\Menus\Administrator\Helper\MenusHelper;
 use Joomla\CMS\Filesystem\Folder;
 use Joomla\CMS\Factory;
 
-jimport('joomla.filesystem.folder');
-jimport('joomla.filesystem.path');
 /**
  * Menu Item Types Model for Menus.
  *
@@ -80,8 +78,6 @@ class MenutypesModel extends BaseDatabaseModel
 	 */
 	public function getTypeOptions()
 	{
-		jimport('joomla.filesystem.file');
-
 		$lang = Factory::getLanguage();
 		$list = array();
 

--- a/administrator/components/com_modules/Model/ModuleModel.php
+++ b/administrator/components/com_modules/Model/ModuleModel.php
@@ -837,8 +837,6 @@ class ModuleModel extends AdminModel
 	 */
 	protected function preprocessForm(\JForm $form, $data, $group = 'content')
 	{
-		jimport('joomla.filesystem.path');
-
 		$lang     = Factory::getLanguage();
 		$clientId = $this->getState('item.client_id');
 		$module   = $this->getState('item.module');

--- a/administrator/components/com_plugins/Model/PluginModel.php
+++ b/administrator/components/com_plugins/Model/PluginModel.php
@@ -248,8 +248,6 @@ class PluginModel extends AdminModel
 	 */
 	protected function preprocessForm(\JForm $form, $data, $group = 'content')
 	{
-		jimport('joomla.filesystem.path');
-
 		$folder  = $this->getState('item.folder');
 		$element = $this->getState('item.element');
 		$lang    = Factory::getLanguage();

--- a/administrator/components/com_postinstall/Controller/MessageController.php
+++ b/administrator/components/com_postinstall/Controller/MessageController.php
@@ -98,8 +98,6 @@ class MessageController extends BaseController
 				break;
 
 			case 'action':
-				jimport('joomla.filesystem.file');
-
 				$helper = new PostinstallHelper;
 				$file = $helper->parsePath($item->action_file);
 

--- a/administrator/components/com_postinstall/Model/MessagesModel.php
+++ b/administrator/components/com_postinstall/Model/MessagesModel.php
@@ -228,8 +228,6 @@ class MessagesModel extends BaseDatabaseModel
 			// Filter out messages based on dynamically loaded programmatic conditions.
 			if (!empty($item->condition_file) && !empty($item->condition_method))
 			{
-				jimport('joomla.filesystem.file');
-
 				$helper = new PostinstallHelper;
 				$file = $helper->parsePath($item->condition_file);
 

--- a/administrator/components/com_templates/Helper/TemplateHelper.php
+++ b/administrator/components/com_templates/Helper/TemplateHelper.php
@@ -83,8 +83,6 @@ abstract class TemplateHelper
 			}
 		}
 
-		jimport('joomla.filesystem.file');
-
 		if ($file['name'] !== File::makeSafe($file['name']) || preg_match('/\s/', File::makeSafe($file['name'])))
 		{
 			$app = Factory::getApplication();

--- a/administrator/components/com_templates/Model/StyleModel.php
+++ b/administrator/components/com_templates/Model/StyleModel.php
@@ -412,8 +412,6 @@ class StyleModel extends AdminModel
 			throw new \Exception(Text::_('JERROR_LOADFILE_FAILED'));
 		}
 
-		jimport('joomla.filesystem.path');
-
 		$formFile = Path::clean($client->path . '/templates/' . $template . '/templateDetails.xml');
 
 		// Load the core and/or local language file(s).

--- a/administrator/components/com_templates/Model/TemplateModel.php
+++ b/administrator/components/com_templates/Model/TemplateModel.php
@@ -82,7 +82,6 @@ class TemplateModel extends FormModel
 
 		if ($template = $this->getTemplate())
 		{
-			jimport('joomla.filesystem.folder');
 			$app    = Factory::getApplication();
 			$client = ApplicationHelper::getClientInfo($template->client_id);
 			$path   = Path::clean($client->path . '/templates/' . $template->element . '/');
@@ -166,7 +165,6 @@ class TemplateModel extends FormModel
 	 */
 	protected function populateState()
 	{
-		jimport('joomla.filesystem.file');
 		$app = Factory::getApplication();
 
 		// Load the User state.
@@ -271,7 +269,6 @@ class TemplateModel extends FormModel
 
 		if ($template = $this->getTemplate())
 		{
-			jimport('joomla.filesystem.folder');
 			$client = ApplicationHelper::getClientInfo($template->client_id);
 			$fromPath = Path::clean($client->path . '/templates/' . $template->element . '/');
 
@@ -339,8 +336,6 @@ class TemplateModel extends FormModel
 		$template = $this->getTemplate();
 		$oldName  = $template->element;
 		$manifest = json_decode($template->manifest_cache);
-
-		jimport('joomla.filesystem.file');
 
 		foreach ($files as $file)
 		{
@@ -485,8 +480,6 @@ class TemplateModel extends FormModel
 	 */
 	public function save($data)
 	{
-		jimport('joomla.filesystem.file');
-
 		// Get the template.
 		$template = $this->getTemplate();
 
@@ -676,8 +669,6 @@ class TemplateModel extends FormModel
 	 */
 	public function createOverride($override)
 	{
-		jimport('joomla.filesystem.folder');
-
 		if ($template = $this->getTemplate())
 		{
 			$app          = Factory::getApplication();
@@ -905,8 +896,6 @@ class TemplateModel extends FormModel
 	 */
 	public function uploadFile($file, $location)
 	{
-		jimport('joomla.filesystem.folder');
-
 		if ($template = $this->getTemplate())
 		{
 			$app      = Factory::getApplication();
@@ -954,8 +943,6 @@ class TemplateModel extends FormModel
 	 */
 	public function createFolder($name, $location)
 	{
-		jimport('joomla.filesystem.folder');
-
 		if ($template = $this->getTemplate())
 		{
 			$app    = Factory::getApplication();
@@ -991,8 +978,6 @@ class TemplateModel extends FormModel
 	 */
 	public function deleteFolder($location)
 	{
-		jimport('joomla.filesystem.folder');
-
 		if ($template = $this->getTemplate())
 		{
 			$app    = Factory::getApplication();

--- a/administrator/components/com_users/Controller/ProfileController.php
+++ b/administrator/components/com_users/Controller/ProfileController.php
@@ -36,8 +36,6 @@ class ProfileController extends BaseController
 	 */
 	public function gethelpsites()
 	{
-		jimport('joomla.filesystem.file');
-
 		// Set FTP credentials, if given
 		ClientHelper::setCredentialsFromRequest('ftp');
 

--- a/administrator/components/com_users/helpers/html/users.php
+++ b/administrator/components/com_users/helpers/html/users.php
@@ -37,7 +37,6 @@ class JHtmlUsers
 		$src = preg_replace('#[^A-Z0-9\-_\./]#i', '', $src);
 		$file = JPATH_SITE . '/' . $src;
 
-		jimport('joomla.filesystem.path');
 		Path::check($file);
 
 		if (!file_exists($file))

--- a/components/com_config/Model/ModulesModel.php
+++ b/components/com_config/Model/ModulesModel.php
@@ -83,8 +83,6 @@ class ModulesModel extends FormModel
 	 */
 	protected function preprocessForm(Form $form, $data, $group = 'content')
 	{
-		jimport('joomla.filesystem.path');
-
 		$lang     = Factory::getLanguage();
 		$module   = $this->getState()->get('module.name');
 		$basePath = JPATH_BASE;

--- a/components/com_config/Model/TemplatesModel.php
+++ b/components/com_config/Model/TemplatesModel.php
@@ -97,8 +97,6 @@ class TemplatesModel extends FormModel
 
 		$template = Factory::getApplication()->getTemplate();
 
-		jimport('joomla.filesystem.path');
-
 		// Load the core and/or local language file(s).
 		$lang->load('tpl_' . $template, JPATH_BASE, null, false, true)
 		|| $lang->load('tpl_' . $template, JPATH_BASE . '/templates/' . $template, null, false, true);

--- a/components/com_users/Controller/ProfileController.php
+++ b/components/com_users/Controller/ProfileController.php
@@ -275,8 +275,6 @@ class ProfileController extends BaseController
 	 */
 	public function gethelpsites()
 	{
-		jimport('joomla.filesystem.file');
-
 		// Set FTP credentials, if given
 		ClientHelper::setCredentialsFromRequest('ftp');
 

--- a/installation/includes/framework.php
+++ b/installation/includes/framework.php
@@ -33,8 +33,3 @@ if (file_exists(JPATH_CONFIGURATION . '/configuration.php')
 
 // Import the Joomla Platform.
 require_once JPATH_LIBRARIES . '/bootstrap.php';
-
-// Import filesystem and utilities classes since they aren't autoloaded
-jimport('joomla.filesystem.file');
-jimport('joomla.filesystem.folder');
-jimport('joomla.filesystem.path');

--- a/libraries/joomla/view/html.php
+++ b/libraries/joomla/view/html.php
@@ -9,8 +9,6 @@
 
 defined('JPATH_PLATFORM') or die;
 
-jimport('joomla.filesystem.path');
-
 /**
  * Joomla Platform HTML View Class
  *

--- a/libraries/src/Application/DaemonApplication.php
+++ b/libraries/src/Application/DaemonApplication.php
@@ -10,8 +10,6 @@ namespace Joomla\CMS\Application;
 
 defined('JPATH_PLATFORM') or die;
 
-jimport('joomla.filesystem.folder');
-
 use Joomla\CMS\Event\BeforeExecuteEvent;
 use Joomla\CMS\Filesystem\Folder;
 use Joomla\CMS\Log\Log;

--- a/libraries/src/Document/HtmlDocument.php
+++ b/libraries/src/Document/HtmlDocument.php
@@ -19,8 +19,6 @@ use Joomla\CMS\Log\Log;
 use Joomla\CMS\Uri\Uri;
 use Joomla\Registry\Registry;
 
-jimport('joomla.utilities.utility');
-
 /**
  * HtmlDocument class, provides an easy interface to parse and display a HTML document
  *

--- a/libraries/src/MVC/Factory/LegacyFactory.php
+++ b/libraries/src/MVC/Factory/LegacyFactory.php
@@ -92,7 +92,6 @@ class LegacyFactory implements MVCFactoryInterface
 
 		if (!class_exists($viewClass))
 		{
-			jimport('joomla.filesystem.path');
 			$path = Path::find($config['paths'], BaseController::createFileName('view', array('name' => $viewName, 'type' => $viewType)));
 
 			if (!$path)

--- a/libraries/src/MVC/Model/BaseDatabaseModel.php
+++ b/libraries/src/MVC/Model/BaseDatabaseModel.php
@@ -122,8 +122,6 @@ abstract class BaseDatabaseModel extends CMSObject
 
 		if (!empty($path))
 		{
-			jimport('joomla.filesystem.path');
-
 			foreach ((array) $path as $includePath)
 			{
 				if (!in_array($includePath, $paths[$prefix]))
@@ -197,7 +195,6 @@ abstract class BaseDatabaseModel extends CMSObject
 
 		if (!class_exists($modelClass))
 		{
-			jimport('joomla.filesystem.path');
 			$path = Path::find(self::addIncludePath(null, $prefix), self::_createFileName('model', array('name' => $type)));
 
 			if (!$path)

--- a/libraries/src/MVC/View/HtmlView.php
+++ b/libraries/src/MVC/View/HtmlView.php
@@ -356,7 +356,6 @@ class HtmlView extends AbstractView
 		}
 
 		// Load the template script
-		jimport('joomla.filesystem.path');
 		$filetofind = $this->_createFileName('template', array('name' => $file));
 		$this->_template = Path::find($this->_path['template'], $filetofind);
 
@@ -411,7 +410,6 @@ class HtmlView extends AbstractView
 		$file = preg_replace('/[^A-Z0-9_\.-]/i', '', $hlp);
 
 		// Load the template script
-		jimport('joomla.filesystem.path');
 		$helper = Path::find($this->_path['helper'], $this->_createFileName('helper', array('name' => $file)));
 
 		if ($helper != false)
@@ -477,8 +475,6 @@ class HtmlView extends AbstractView
 	 */
 	protected function _addPath($type, $path)
 	{
-		jimport('joomla.filesystem.path');
-
 		// Loop through the path directories
 		foreach ((array) $path as $dir)
 		{

--- a/libraries/src/Menu/MenuHelper.php
+++ b/libraries/src/Menu/MenuHelper.php
@@ -98,8 +98,6 @@ class MenuHelper
 
 			if (is_dir($tpl))
 			{
-				jimport('joomla.filesystem.folder');
-
 				$files = Folder::files($tpl, '\.xml$');
 
 				foreach ($files as $file)

--- a/libraries/src/Table/Menu.php
+++ b/libraries/src/Table/Menu.php
@@ -179,8 +179,6 @@ class Menu extends Nested
 			}
 
 			// Verify that a first level menu item alias is not the name of a folder.
-			jimport('joomla.filesystem.folder');
-
 			if (in_array($this->alias, Folder::folders(JPATH_ROOT)))
 			{
 				$this->setError(Text::sprintf('JLIB_DATABASE_ERROR_MENU_ROOT_ALIAS_FOLDER', $this->alias, $this->alias));

--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -275,8 +275,6 @@ abstract class Table extends CMSObject implements \JTableInterface, DispatcherAw
 		if (!class_exists($tableClass))
 		{
 			// Search for the class file in the JTable include paths.
-			jimport('joomla.filesystem.path');
-
 			$paths = self::addIncludePath();
 			$pathIndex = 0;
 

--- a/libraries/src/Toolbar/ContainerAwareToolbarFactory.php
+++ b/libraries/src/Toolbar/ContainerAwareToolbarFactory.php
@@ -48,8 +48,6 @@ class ContainerAwareToolbarFactory implements ToolbarFactoryInterface, Container
 
 			$file = InputFilter::getInstance()->clean(str_replace('_', DIRECTORY_SEPARATOR, strtolower($type)) . '.php', 'path');
 
-			jimport('joomla.filesystem.path');
-
 			if ($buttonFile = Path::find($dirs, $file))
 			{
 				include_once $buttonFile;

--- a/plugins/content/pagebreak/pagebreak.php
+++ b/plugins/content/pagebreak/pagebreak.php
@@ -18,8 +18,6 @@ use Joomla\String\StringHelper;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\CMS\Pagination\Pagination;
 
-jimport('joomla.utilities.utility');
-
 /**
  * Page break plugin
  *

--- a/plugins/editors/tinymce/field/skins.php
+++ b/plugins/editors/tinymce/field/skins.php
@@ -12,9 +12,6 @@ defined('_JEXEC') or die;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Form\Field\ListField;
 
-jimport('joomla.form.helper');
-
-
 /**
  * Generates the list of options for available skins.
  *

--- a/plugins/editors/tinymce/field/uploaddirs.php
+++ b/plugins/editors/tinymce/field/uploaddirs.php
@@ -13,9 +13,6 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Form\Field\FolderlistField;
 
-jimport('joomla.form.helper');
-
-
 /**
  * Generates the list of directories  available for drag and drop upload.
  *

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -644,8 +644,6 @@ class PlgSystemLanguageFilter extends CMSPlugin
 					$lang_code = $this->default_lang;
 				}
 
-				jimport('joomla.filesystem.folder');
-
 				// The language has been deleted/disabled or the related content language does not exist/has been unpublished
 				// or the related home page does not exist/has been unpublished
 				if (!array_key_exists($lang_code, $this->lang_codes)


### PR DESCRIPTION
As the namespaced classes are automatically loaded, there is no need anymore to import them through jimport.

See #21781 for more information why they are not needed anymore.