### PR TITLE
[4.0] Remove not used imports in fields helper class

### DIFF
--- a/administrator/components/com_fields/helpers/fields.php
+++ b/administrator/components/com_fields/helpers/fields.php
@@ -14,9 +14,6 @@ use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Filesystem\Path;
-use Joomla\CMS\Filesystem\Folder;
-
-JLoader::register('Folder', JPATH_LIBRARIES . '/joomla/filesystem/folder.php');
 
 /**
  * FieldsHelper


### PR DESCRIPTION
The folder class is not used in the fields helper, so the imports can be removed.