### PR TITLE
[4.0] Add required use statements for UsersHelper access

### DIFF
--- a/administrator/components/com_users/View/Debuggroup/HtmlView.php
+++ b/administrator/components/com_users/View/Debuggroup/HtmlView.php
@@ -94,8 +94,6 @@ class HtmlView extends BaseHtmlView
 			throw new Notallowed(Text::_('JERROR_ALERTNOAUTHOR'), 403);
 		}
 
-		\JLoader::register('UsersHelperDebug', JPATH_ADMINISTRATOR . '/components/com_users/helpers/debug.php');
-
 		$this->actions       = $this->get('DebugActions');
 		$this->items         = $this->get('Items');
 		$this->pagination    = $this->get('Pagination');

--- a/administrator/components/com_users/View/Debuguser/HtmlView.php
+++ b/administrator/components/com_users/View/Debuguser/HtmlView.php
@@ -94,8 +94,6 @@ class HtmlView extends BaseHtmlView
 			throw new Notallowed(Text::_('JERROR_ALERTNOAUTHOR'), 403);
 		}
 
-		\JLoader::register('UsersHelperDebug', JPATH_ADMINISTRATOR . '/components/com_users/helpers/debug.php');
-
 		$this->actions       = $this->get('DebugActions');
 		$this->items         = $this->get('Items');
 		$this->pagination    = $this->get('Pagination');

--- a/administrator/components/com_users/tmpl/levels/default.php
+++ b/administrator/components/com_users/tmpl/levels/default.php
@@ -14,6 +14,7 @@ use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Factory;
+use Joomla\Component\Users\Administrator\Helper\UsersHelper;
 
 // Include the component HTML helpers.
 HTMLHelper::addIncludePath(JPATH_COMPONENT . '/helpers/html');

--- a/administrator/components/com_users/tmpl/user/edit.php
+++ b/administrator/components/com_users/tmpl/user/edit.php
@@ -13,6 +13,7 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
+use Joomla\Component\Users\Administrator\Helper\UsersHelper;
 
 // Include the component HTML helpers.
 HTMLHelper::addIncludePath(JPATH_COMPONENT . '/helpers/html');

--- a/plugins/fields/usergrouplist/tmpl/usergrouplist.php
+++ b/plugins/fields/usergrouplist/tmpl/usergrouplist.php
@@ -8,14 +8,14 @@
  */
 defined('_JEXEC') or die;
 
+use Joomla\Component\Users\Administrator\Helper\UsersHelper;
+
 $value = $field->value;
 
 if ($value == '')
 {
 	return;
 }
-
-JLoader::register('UsersHelper', JPATH_ADMINISTRATOR . '/components/com_users/helpers/users.php');
 
 $value  = (array) $value;
 $texts  = array();


### PR DESCRIPTION
Pull Request for Issue #21771.

### Summary of Changes
Instead of reverting, it fixes the `UsersHelper` imports.

### Testing Instructions
Go to Users -> Access Levels.

### Expected result
The list of access levels is shown.

### Actual result
An error is displayed.