### PR TITLE
Widen table field of #__content_types (#21395)

### DIFF
--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -393,7 +393,7 @@ CREATE TABLE IF NOT EXISTS `#__content_types` (
   `type_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `type_title` varchar(255) NOT NULL DEFAULT '',
   `type_alias` varchar(400) NOT NULL DEFAULT '',
-  `table` varchar(255) NOT NULL DEFAULT '',
+  `table` varchar(2048) NOT NULL DEFAULT '',
   `rules` text NOT NULL,
   `field_mappings` text NOT NULL,
   `router` varchar(255) NOT NULL DEFAULT '',

--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -399,7 +399,7 @@ CREATE TABLE "#__content_types" (
   "type_id" serial NOT NULL,
   "type_title" varchar(255) NOT NULL DEFAULT '',
   "type_alias" varchar(255) NOT NULL DEFAULT '',
-  "table" varchar(255) NOT NULL DEFAULT '',
+  "table" varchar(2048) NOT NULL DEFAULT '',
   "rules" text NOT NULL,
   "field_mappings" text NOT NULL,
   "router" varchar(255) NOT NULL DEFAULT '',

--- a/installation/sql/sqlazure/joomla.sql
+++ b/installation/sql/sqlazure/joomla.sql
@@ -581,7 +581,7 @@ CREATE TABLE "#__content_types" (
   "type_id" bigint IDENTITY(10000,1) NOT NULL,
   "type_title" nvarchar(255) NOT NULL DEFAULT '',
   "type_alias" nvarchar(255) NOT NULL DEFAULT '',
-  "table" nvarchar(255) NOT NULL DEFAULT '',
+  "table" nvarchar(2048) NOT NULL DEFAULT '',
   "rules" nvarchar(max) NOT NULL,
   "field_mappings" nvarchar(max) NOT NULL,
   "router" nvarchar(255) NOT NULL DEFAULT '',


### PR DESCRIPTION
Widen default "table" field of  "#__content_types" table in install scripts

Pull Request for Issue #21395 .

### Summary of Changes
Changed width of "table" field in "#__content_types" table from `VARCHAR(255)` to `VARCHAR(2048)` for MySQL, PostgreSQL, and Azure install scripts. Provides room for parameters and longer values.

### Testing Instructions
1. Follow instructions in Joomla! documentation to [enable content history](https://docs.joomla.org/Using_Content_History_in_your_Component) for a third-party component. For the "table" JSON key, use a wide vendor-prefixed value for the "dbtable" key of configuration for "special", e.g.:

    "dbtable":"#__mylongvendorprefixname_mylongcustomcomponentname",

2. Apply this PR.
3. Install third-party component.

### Expected result
No database errors

### Actual result
No database errors

### Documentation Changes Required
None.
