### PR TITLE
[4.0] Convert bootstrap.tab to uitab

### DIFF
--- a/administrator/components/com_admin/tmpl/profile/edit.php
+++ b/administrator/components/com_admin/tmpl/profile/edit.php
@@ -23,9 +23,9 @@ $fieldsets = $this->form->getFieldsets();
 ?>
 
 <form action="<?php echo Route::_('index.php?option=com_admin&view=profile&layout=edit&id=' . $this->item->id); ?>" method="post" name="adminForm" id="profile-form" enctype="multipart/form-data" class="form-validate">
-	<?php echo HTMLHelper::_('bootstrap.startTabSet', 'myTab', array('active' => 'account')); ?>
+	<?php echo HTMLHelper::_('uitab.startTabSet', 'myTab', array('active' => 'account')); ?>
 
-	<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'account', Text::_('COM_ADMIN_USER_ACCOUNT_DETAILS')); ?>
+	<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'account', Text::_('COM_ADMIN_USER_ACCOUNT_DETAILS')); ?>
 	<?php foreach ($this->form->getFieldset('user_details') as $field) : ?>
 		<div class="control-group">
 			<div class="control-label">
@@ -39,7 +39,7 @@ $fieldsets = $this->form->getFieldsets();
 			</div>
 		</div>
 	<?php endforeach; ?>
-	<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+	<?php echo HTMLHelper::_('uitab.endTab'); ?>
 
 	<?php foreach ($fieldsets as $fieldset) : ?>
 		<?php
@@ -48,7 +48,7 @@ $fieldsets = $this->form->getFieldsets();
 			continue;
 		}
 		?>
-		<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', $fieldset->name, Text::_($fieldset->label)); ?>
+		<?php echo HTMLHelper::_('uitab.addTab', 'myTab', $fieldset->name, Text::_($fieldset->label)); ?>
 		<?php foreach ($this->form->getFieldset($fieldset->name) as $field) : ?>
 			<?php if ($field->hidden) : ?>
 				<div class="control-group">
@@ -63,10 +63,10 @@ $fieldsets = $this->form->getFieldsets();
 				</div>
 			<?php endif; ?>
 		<?php endforeach; ?>
-		<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+		<?php echo HTMLHelper::_('uitab.endTab'); ?>
 	<?php endforeach; ?>
 
-	<?php echo HTMLHelper::_('bootstrap.endTabSet'); ?>
+	<?php echo HTMLHelper::_('uitab.endTabSet'); ?>
 	<input type="hidden" name="task" value="">
 	<?php echo HTMLHelper::_('form.token'); ?>
 </form>

--- a/administrator/components/com_admin/tmpl/sysinfo/default.php
+++ b/administrator/components/com_admin/tmpl/sysinfo/default.php
@@ -23,29 +23,29 @@ HTMLHelper::_('behavior.tabstate');
 	<div class="row">
 		<?php // Begin Content ?>
 		<div class="col-md-12">
-			<?php echo HTMLHelper::_('bootstrap.startTabSet', 'myTab', array('active' => 'site')); ?>
+			<?php echo HTMLHelper::_('uitab.startTabSet', 'myTab', array('active' => 'site')); ?>
 
-			<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'site', Text::_('COM_ADMIN_SYSTEM_INFORMATION')); ?>
+			<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'site', Text::_('COM_ADMIN_SYSTEM_INFORMATION')); ?>
 			<?php echo $this->loadTemplate('system'); ?>
-			<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+			<?php echo HTMLHelper::_('uitab.endTab'); ?>
 
-			<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'phpsettings', Text::_('COM_ADMIN_PHP_SETTINGS')); ?>
+			<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'phpsettings', Text::_('COM_ADMIN_PHP_SETTINGS')); ?>
 			<?php echo $this->loadTemplate('phpsettings'); ?>
-			<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+			<?php echo HTMLHelper::_('uitab.endTab'); ?>
 
-			<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'config', Text::_('COM_ADMIN_CONFIGURATION_FILE')); ?>
+			<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'config', Text::_('COM_ADMIN_CONFIGURATION_FILE')); ?>
 			<?php echo $this->loadTemplate('config'); ?>
-			<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+			<?php echo HTMLHelper::_('uitab.endTab'); ?>
 
-			<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'directory', Text::_('COM_ADMIN_DIRECTORY_PERMISSIONS')); ?>
+			<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'directory', Text::_('COM_ADMIN_DIRECTORY_PERMISSIONS')); ?>
 			<?php echo $this->loadTemplate('directory'); ?>
-			<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+			<?php echo HTMLHelper::_('uitab.endTab'); ?>
 
-			<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'phpinfo', Text::_('COM_ADMIN_PHP_INFORMATION')); ?>
+			<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'phpinfo', Text::_('COM_ADMIN_PHP_INFORMATION')); ?>
 			<?php echo $this->loadTemplate('phpinfo'); ?>
-			<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+			<?php echo HTMLHelper::_('uitab.endTab'); ?>
 
-			<?php echo HTMLHelper::_('bootstrap.endTabSet'); ?>
+			<?php echo HTMLHelper::_('uitab.endTabSet'); ?>
 		</div>
 		<input type="hidden" name="task" value="">
 		<?php echo HTMLHelper::_('form.token'); ?>

--- a/administrator/components/com_banners/tmpl/banner/edit.php
+++ b/administrator/components/com_banners/tmpl/banner/edit.php
@@ -28,9 +28,9 @@ HTMLHelper::_('script', 'com_banners/admin-banner-edit.min.js', array('version' 
 	<?php echo LayoutHelper::render('joomla.edit.title_alias', $this); ?>
 
 	<div>
-		<?php echo HTMLHelper::_('bootstrap.startTabSet', 'myTab', array('active' => 'details')); ?>
+		<?php echo HTMLHelper::_('uitab.startTabSet', 'myTab', array('active' => 'details')); ?>
 
-		<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'details', Text::_('COM_BANNERS_BANNER_DETAILS')); ?>
+		<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'details', Text::_('COM_BANNERS_BANNER_DETAILS')); ?>
 		<div class="row">
 			<div class="col-md-9">
 				<?php echo $this->form->renderField('type'); ?>
@@ -53,13 +53,13 @@ HTMLHelper::_('script', 'com_banners/admin-banner-edit.min.js', array('version' 
 				</div>
 			</div>
 		</div>
-		<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+		<?php echo HTMLHelper::_('uitab.endTab'); ?>
 
-		<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'otherparams', Text::_('COM_BANNERS_GROUP_LABEL_BANNER_DETAILS')); ?>
+		<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'otherparams', Text::_('COM_BANNERS_GROUP_LABEL_BANNER_DETAILS')); ?>
 		<?php echo $this->form->renderFieldset('otherparams'); ?>
-		<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+		<?php echo HTMLHelper::_('uitab.endTab'); ?>
 
-		<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'publishing', Text::_('JGLOBAL_FIELDSET_PUBLISHING')); ?>
+		<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'publishing', Text::_('JGLOBAL_FIELDSET_PUBLISHING')); ?>
 		<div class="row">
 			<div class="col-md-6">
 				<?php echo LayoutHelper::render('joomla.edit.publishingdata', $this); ?>
@@ -68,9 +68,9 @@ HTMLHelper::_('script', 'com_banners/admin-banner-edit.min.js', array('version' 
 				<?php echo $this->form->renderFieldset('metadata'); ?>
 			</div>
 		</div>
-		<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+		<?php echo HTMLHelper::_('uitab.endTab'); ?>
 
-		<?php echo HTMLHelper::_('bootstrap.endTabSet'); ?>
+		<?php echo HTMLHelper::_('uitab.endTabSet'); ?>
 	</div>
 
 	<input type="hidden" name="task" value="">

--- a/administrator/components/com_banners/tmpl/client/edit.php
+++ b/administrator/components/com_banners/tmpl/client/edit.php
@@ -23,9 +23,9 @@ HTMLHelper::_('behavior.formvalidator');
 	<?php echo LayoutHelper::render('joomla.edit.title_alias', $this); ?>
 
 	<div>
-		<?php echo HTMLHelper::_('bootstrap.startTabSet', 'myTab', array('active' => 'general')); ?>
+		<?php echo HTMLHelper::_('uitab.startTabSet', 'myTab', array('active' => 'general')); ?>
 
-		<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'general', empty($this->item->id) ? Text::_('COM_BANNERS_NEW_CLIENT') : Text::_('COM_BANNERS_EDIT_CLIENT')); ?>
+		<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'general', empty($this->item->id) ? Text::_('COM_BANNERS_NEW_CLIENT') : Text::_('COM_BANNERS_EDIT_CLIENT')); ?>
 		<div class="row">
 			<div class="col-md-9">
 				<?php
@@ -45,13 +45,13 @@ HTMLHelper::_('behavior.formvalidator');
 				</div>
 			</div>
 		</div>
-		<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+		<?php echo HTMLHelper::_('uitab.endTab'); ?>
 
-		<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'metadata', Text::_('JGLOBAL_FIELDSET_METADATA_OPTIONS')); ?>
+		<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'metadata', Text::_('JGLOBAL_FIELDSET_METADATA_OPTIONS')); ?>
 		<?php echo $this->form->renderFieldset('metadata'); ?>
-		<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+		<?php echo HTMLHelper::_('uitab.endTab'); ?>
 
-		<?php echo HTMLHelper::_('bootstrap.endTabSet'); ?>
+		<?php echo HTMLHelper::_('uitab.endTabSet'); ?>
 	</div>
 
 	<input type="hidden" name="task" value="">

--- a/administrator/components/com_contact/tmpl/contact/edit.php
+++ b/administrator/components/com_contact/tmpl/contact/edit.php
@@ -30,6 +30,7 @@ $assoc = Associations::isEnabled();
 
 // Fieldsets to not automatically render by /layouts/joomla/edit/params.php
 $this->ignore_fieldsets = array('details', 'item_associations', 'jmetadata');
+$this->useCoreUI = true;
 
 // In case of modal
 $isModal = $input->get('layout') == 'modal' ? true : false;
@@ -42,9 +43,9 @@ $tmpl    = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=c
 	<?php echo LayoutHelper::render('joomla.edit.title_alias', $this); ?>
 
 	<div>
-		<?php echo HTMLHelper::_('bootstrap.startTabSet', 'myTab', array('active' => 'details')); ?>
+		<?php echo HTMLHelper::_('uitab.startTabSet', 'myTab', array('active' => 'details')); ?>
 
-		<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'details', empty($this->item->id) ? Text::_('COM_CONTACT_NEW_CONTACT') : Text::_('COM_CONTACT_EDIT_CONTACT')); ?>
+		<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'details', empty($this->item->id) ? Text::_('COM_CONTACT_NEW_CONTACT') : Text::_('COM_CONTACT_EDIT_CONTACT')); ?>
 		<div class="row">
 			<div class="col-md-9">
 				<div class="row">
@@ -78,19 +79,19 @@ $tmpl    = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=c
 				</div>
 			</div>
 		</div>
-		<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+		<?php echo HTMLHelper::_('uitab.endTab'); ?>
 
-		<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'misc', Text::_('JGLOBAL_FIELDSET_MISCELLANEOUS')); ?>
+		<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'misc', Text::_('JGLOBAL_FIELDSET_MISCELLANEOUS')); ?>
 		<div class="row">
 			<div class="col-md-12">
 				<?php echo $this->form->renderField('misc'); ?>
 			</div>
 		</div>
-		<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+		<?php echo HTMLHelper::_('uitab.endTab'); ?>
 
 		<?php echo LayoutHelper::render('joomla.edit.params', $this); ?>
 
-		<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'publishing', Text::_('JGLOBAL_FIELDSET_PUBLISHING')); ?>
+		<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'publishing', Text::_('JGLOBAL_FIELDSET_PUBLISHING')); ?>
 		<div class="row">
 			<div class="col-md-6">
 				<?php echo LayoutHelper::render('joomla.edit.publishingdata', $this); ?>
@@ -99,17 +100,17 @@ $tmpl    = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=c
 				<?php echo LayoutHelper::render('joomla.edit.metadata', $this); ?>
 			</div>
 		</div>
-		<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+		<?php echo HTMLHelper::_('uitab.endTab'); ?>
 
 		<?php if ( ! $isModal && $assoc) : ?>
-			<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'associations', Text::_('JGLOBAL_FIELDSET_ASSOCIATIONS')); ?>
+			<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'associations', Text::_('JGLOBAL_FIELDSET_ASSOCIATIONS')); ?>
 			<?php echo $this->loadTemplate('associations'); ?>
-			<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+			<?php echo HTMLHelper::_('uitab.endTab'); ?>
 		<?php elseif ($isModal && $assoc) : ?>
 			<div class="hidden"><?php echo $this->loadTemplate('associations'); ?></div>
 		<?php endif; ?>
 
-		<?php echo HTMLHelper::_('bootstrap.endTabSet'); ?>
+		<?php echo HTMLHelper::_('uitab.endTabSet'); ?>
 	</div>
 	<input type="hidden" name="task" value="">
 	<input type="hidden" name="forcedLanguage" value="<?php echo $input->get('forcedLanguage', '', 'cmd'); ?>">

--- a/administrator/components/com_contact/tmpl/contact/edit.php
+++ b/administrator/components/com_contact/tmpl/contact/edit.php
@@ -30,7 +30,6 @@ $assoc = Associations::isEnabled();
 
 // Fieldsets to not automatically render by /layouts/joomla/edit/params.php
 $this->ignore_fieldsets = array('details', 'item_associations', 'jmetadata');
-$this->useCoreUI = true;
 
 // In case of modal
 $isModal = $input->get('layout') == 'modal' ? true : false;
@@ -43,9 +42,9 @@ $tmpl    = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=c
 	<?php echo LayoutHelper::render('joomla.edit.title_alias', $this); ?>
 
 	<div>
-		<?php echo HTMLHelper::_('uitab.startTabSet', 'myTab', array('active' => 'details')); ?>
+		<?php echo HTMLHelper::_('bootstrap.startTabSet', 'myTab', array('active' => 'details')); ?>
 
-		<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'details', empty($this->item->id) ? Text::_('COM_CONTACT_NEW_CONTACT') : Text::_('COM_CONTACT_EDIT_CONTACT')); ?>
+		<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'details', empty($this->item->id) ? Text::_('COM_CONTACT_NEW_CONTACT') : Text::_('COM_CONTACT_EDIT_CONTACT')); ?>
 		<div class="row">
 			<div class="col-md-9">
 				<div class="row">
@@ -79,19 +78,19 @@ $tmpl    = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=c
 				</div>
 			</div>
 		</div>
-		<?php echo HTMLHelper::_('uitab.endTab'); ?>
+		<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
 
-		<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'misc', Text::_('JGLOBAL_FIELDSET_MISCELLANEOUS')); ?>
+		<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'misc', Text::_('JGLOBAL_FIELDSET_MISCELLANEOUS')); ?>
 		<div class="row">
 			<div class="col-md-12">
 				<?php echo $this->form->renderField('misc'); ?>
 			</div>
 		</div>
-		<?php echo HTMLHelper::_('uitab.endTab'); ?>
+		<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
 
 		<?php echo LayoutHelper::render('joomla.edit.params', $this); ?>
 
-		<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'publishing', Text::_('JGLOBAL_FIELDSET_PUBLISHING')); ?>
+		<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'publishing', Text::_('JGLOBAL_FIELDSET_PUBLISHING')); ?>
 		<div class="row">
 			<div class="col-md-6">
 				<?php echo LayoutHelper::render('joomla.edit.publishingdata', $this); ?>
@@ -100,17 +99,17 @@ $tmpl    = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=c
 				<?php echo LayoutHelper::render('joomla.edit.metadata', $this); ?>
 			</div>
 		</div>
-		<?php echo HTMLHelper::_('uitab.endTab'); ?>
+		<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
 
 		<?php if ( ! $isModal && $assoc) : ?>
-			<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'associations', Text::_('JGLOBAL_FIELDSET_ASSOCIATIONS')); ?>
+			<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'associations', Text::_('JGLOBAL_FIELDSET_ASSOCIATIONS')); ?>
 			<?php echo $this->loadTemplate('associations'); ?>
-			<?php echo HTMLHelper::_('uitab.endTab'); ?>
+			<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
 		<?php elseif ($isModal && $assoc) : ?>
 			<div class="hidden"><?php echo $this->loadTemplate('associations'); ?></div>
 		<?php endif; ?>
 
-		<?php echo HTMLHelper::_('uitab.endTabSet'); ?>
+		<?php echo HTMLHelper::_('bootstrap.endTabSet'); ?>
 	</div>
 	<input type="hidden" name="task" value="">
 	<input type="hidden" name="forcedLanguage" value="<?php echo $input->get('forcedLanguage', '', 'cmd'); ?>">

--- a/administrator/components/com_contact/tmpl/contact/edit_params.php
+++ b/administrator/components/com_contact/tmpl/contact/edit_params.php
@@ -15,7 +15,7 @@ use Joomla\CMS\HTML\HTMLHelper;
 $fieldSets = $this->form->getFieldsets('params');
 foreach ($fieldSets as $name => $fieldSet) :
 	$paramstabs = 'params-' . $name;
-	echo HTMLHelper::_('bootstrap.addTab', 'myTab', $paramstabs, Text::_($fieldSet->label));
+	echo HTMLHelper::_('z', 'myTab', $paramstabs, Text::_($fieldSet->label));
 
 	if (isset($fieldSet->description) && trim($fieldSet->description)) :
 		echo '<joomla-alert type="info">' . $this->escape(Text::_($fieldSet->description)) . '</joomla-alert>';

--- a/administrator/components/com_contact/tmpl/contact/edit_params.php
+++ b/administrator/components/com_contact/tmpl/contact/edit_params.php
@@ -15,7 +15,7 @@ use Joomla\CMS\HTML\HTMLHelper;
 $fieldSets = $this->form->getFieldsets('params');
 foreach ($fieldSets as $name => $fieldSet) :
 	$paramstabs = 'params-' . $name;
-	echo HTMLHelper::_('z', 'myTab', $paramstabs, Text::_($fieldSet->label));
+	echo HTMLHelper::_('bootstrap.addTab', 'myTab', $paramstabs, Text::_($fieldSet->label));
 
 	if (isset($fieldSet->description) && trim($fieldSet->description)) :
 		echo '<joomla-alert type="info">' . $this->escape(Text::_($fieldSet->description)) . '</joomla-alert>';

--- a/administrator/components/com_fields/tmpl/field/edit.php
+++ b/administrator/components/com_fields/tmpl/field/edit.php
@@ -25,6 +25,8 @@ HTMLHelper::_('formbehavior.chosen', '#jform_catid', null, array('disable_search
 $app = Factory::getApplication();
 $input = $app->input;
 
+$this->useCoreUI = true;
+
 HTMLHelper::_('script', 'com_fields/admin-field-edit.js', ['relative' => true, 'version' => 'auto']);
 ?>
 
@@ -32,8 +34,8 @@ HTMLHelper::_('script', 'com_fields/admin-field-edit.js', ['relative' => true, '
 
 	<?php echo LayoutHelper::render('joomla.edit.title_alias', $this); ?>
 
-	<?php echo HTMLHelper::_('bootstrap.startTabSet', 'myTab', array('active' => 'general')); ?>
-	<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'general', Text::_('COM_FIELDS_VIEW_FIELD_FIELDSET_GENERAL', true)); ?>
+	<?php echo HTMLHelper::_('uitab.startTabSet', 'myTab', array('active' => 'general')); ?>
+	<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'general', Text::_('COM_FIELDS_VIEW_FIELD_FIELDSET_GENERAL', true)); ?>
 	<div class="row">
 		<div class="col-md-9">
 			<?php echo $this->form->renderField('type'); ?>
@@ -73,10 +75,10 @@ HTMLHelper::_('script', 'com_fields/admin-field-edit.js', ['relative' => true, '
 			</div>
 		</div>
 	</div>
-	<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+	<?php echo HTMLHelper::_('uitab.endTab'); ?>
 	<?php $this->set('ignore_fieldsets', array('fieldparams')); ?>
 	<?php echo LayoutHelper::render('joomla.edit.params', $this); ?>
-	<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'publishing', Text::_('JGLOBAL_FIELDSET_PUBLISHING', true)); ?>
+	<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'publishing', Text::_('JGLOBAL_FIELDSET_PUBLISHING', true)); ?>
 	<div class="row">
 		<div class="col-md-6">
 			<?php echo LayoutHelper::render('joomla.edit.publishingdata', $this); ?>
@@ -84,13 +86,13 @@ HTMLHelper::_('script', 'com_fields/admin-field-edit.js', ['relative' => true, '
 		<div class="col-md-6">
 		</div>
 	</div>
-	<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+	<?php echo HTMLHelper::_('uitab.endTab'); ?>
 	<?php if ($this->canDo->get('core.admin')) : ?>
-		<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'rules', Text::_('JGLOBAL_ACTION_PERMISSIONS_LABEL', true)); ?>
+		<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'rules', Text::_('JGLOBAL_ACTION_PERMISSIONS_LABEL', true)); ?>
 		<?php echo $this->form->getInput('rules'); ?>
-		<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+		<?php echo HTMLHelper::_('uitab.endTab'); ?>
 	<?php endif; ?>
-	<?php echo HTMLHelper::_('bootstrap.endTabSet'); ?>
+	<?php echo HTMLHelper::_('uitab.endTabSet'); ?>
 	<?php echo $this->form->getInput('context'); ?>
 	<input type="hidden" name="task" value="">
 	<?php echo HTMLHelper::_('form.token'); ?>

--- a/administrator/components/com_fields/tmpl/field/modal.php
+++ b/administrator/components/com_fields/tmpl/field/modal.php
@@ -24,6 +24,8 @@ HTMLHelper::_('formbehavior.chosen', '.advancedSelect');
 $app = Factory::getApplication();
 $input = $app->input;
 
+$this->useCoreUI = true;
+
 Factory::getDocument()->addScriptDeclaration("
 	Joomla.submitbutton = function(task)
 	{
@@ -54,9 +56,9 @@ Factory::getDocument()->addScriptDeclaration("
 		<?php echo LayoutHelper::render('joomla.edit.title_alias', $this); ?>
 
 		<div>
-			<?php echo HTMLHelper::_('bootstrap.startTabSet', 'myTab', array('active' => 'general')); ?>
+			<?php echo HTMLHelper::_('uitab.startTabSet', 'myTab', array('active' => 'general')); ?>
 
-			<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'general', Text::_('COM_FIELDS', true)); ?>
+			<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'general', Text::_('COM_FIELDS', true)); ?>
 			<div class="row">
 				<div class="col-md-9">
 					<?php echo $this->form->getLabel('description'); ?>
@@ -66,9 +68,9 @@ Factory::getDocument()->addScriptDeclaration("
 					<?php echo LayoutHelper::render('joomla.edit.global', $this); ?>
 				</div>
 			</div>
-			<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+			<?php echo HTMLHelper::_('uitab.endTab'); ?>
 
-			<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'publishing', Text::_('COM_FIELDS_FIELDSET_PUBLISHING', true)); ?>
+			<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'publishing', Text::_('COM_FIELDS_FIELDSET_PUBLISHING', true)); ?>
 			<div class="row">
 				<div class="col-md-6">
 					<?php echo LayoutHelper::render('joomla.edit.publishingdata', $this); ?>
@@ -76,17 +78,17 @@ Factory::getDocument()->addScriptDeclaration("
 				<div class="col-md-6">
 				</div>
 			</div>
-			<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+			<?php echo HTMLHelper::_('uitab.endTab'); ?>
 
 			<?php if ($this->canDo->get('core.admin')) : ?>
-				<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'rules', Text::_('COM_FIELDS_FIELDSET_RULES', true)); ?>
+				<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'rules', Text::_('COM_FIELDS_FIELDSET_RULES', true)); ?>
 				<?php echo $this->form->getInput('rules'); ?>
-				<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+				<?php echo HTMLHelper::_('uitab.endTab'); ?>
 			<?php endif; ?>
 
 			<?php echo LayoutHelper::render('joomla.edit.params', $this); ?>
 
-			<?php echo HTMLHelper::_('bootstrap.endTabSet'); ?>
+			<?php echo HTMLHelper::_('uitab.endTabSet'); ?>
 
 			<?php echo $this->form->getInput('context'); ?>
 			<input type="hidden" name="task" value="">

--- a/administrator/components/com_fields/tmpl/group/edit.php
+++ b/administrator/components/com_fields/tmpl/group/edit.php
@@ -29,8 +29,8 @@ $input = $app->input;
 <form action="<?php echo Route::_('index.php?option=com_fields&layout=edit&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="item-form" class="form-validate">
 	<?php echo LayoutHelper::render('joomla.edit.title_alias', $this); ?>
 	<div class="form-horizontal">
-		<?php echo HTMLHelper::_('bootstrap.startTabSet', 'myTab', array('active' => 'general')); ?>
-		<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'general', Text::_('COM_FIELDS_VIEW_FIELD_FIELDSET_GENERAL', true)); ?>
+		<?php echo HTMLHelper::_('uitab.startTabSet', 'myTab', array('active' => 'general')); ?>
+		<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'general', Text::_('COM_FIELDS_VIEW_FIELD_FIELDSET_GENERAL', true)); ?>
 		<div class="row">
 			<div class="col-md-9">
 				<?php echo $this->form->renderField('label'); ?>
@@ -53,8 +53,8 @@ $input = $app->input;
 				<?php $this->set('fields', null); ?>
 			</div>
 		</div>
-		<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
-		<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'publishing', Text::_('JGLOBAL_FIELDSET_PUBLISHING', true)); ?>
+		<?php echo HTMLHelper::_('uitab.endTab'); ?>
+		<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'publishing', Text::_('JGLOBAL_FIELDSET_PUBLISHING', true)); ?>
 		<div class="row form-horizontal-desktop">
 			<div class="col-md-6">
 				<?php echo LayoutHelper::render('joomla.edit.publishingdata', $this); ?>
@@ -62,15 +62,15 @@ $input = $app->input;
 			<div class="col-md-6">
 			</div>
 		</div>
-		<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+		<?php echo HTMLHelper::_('uitab.endTab'); ?>
 		<?php $this->set('ignore_fieldsets', array('fieldparams')); ?>
 		<?php echo LayoutHelper::render('joomla.edit.params', $this); ?>
 		<?php if ($this->canDo->get('core.admin')) : ?>
-			<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'rules', Text::_('JGLOBAL_ACTION_PERMISSIONS_LABEL', true)); ?>
+			<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'rules', Text::_('JGLOBAL_ACTION_PERMISSIONS_LABEL', true)); ?>
 			<?php echo $this->form->getInput('rules'); ?>
-			<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+			<?php echo HTMLHelper::_('uitab.endTab'); ?>
 		<?php endif; ?>
-		<?php echo HTMLHelper::_('bootstrap.endTabSet'); ?>
+		<?php echo HTMLHelper::_('uitab.endTabSet'); ?>
 		<?php echo $this->form->getInput('context'); ?>
 		<input type="hidden" name="task" value="">
 		<?php echo HTMLHelper::_('form.token'); ?>

--- a/administrator/components/com_finder/tmpl/filter/edit.php
+++ b/administrator/components/com_finder/tmpl/filter/edit.php
@@ -17,6 +17,8 @@ JHtml::_('behavior.tabstate');
 JText::script('COM_FINDER_FILTER_SHOW_ALL', true);
 JText::script('COM_FINDER_FILTER_HIDE_ALL', true);
 
+$this->useCoreUI = true;
+
 JHtml::_('script', 'com_finder/finder-edit.min.js', array('version' => 'auto', 'relative' => true));
 ?>
 
@@ -24,9 +26,9 @@ JHtml::_('script', 'com_finder/finder-edit.min.js', array('version' => 'auto', '
 
 	<?php echo JLayoutHelper::render('joomla.edit.title_alias', $this); ?>
 
-	<?php echo JHtml::_('bootstrap.startTabSet', 'myTab', array('active' => 'details')); ?>
+	<?php echo JHtml::_('uitab.startTabSet', 'myTab', array('active' => 'details')); ?>
 
-	<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'details', JText::_('COM_FINDER_EDIT_FILTER')); ?>
+	<?php echo JHtml::_('uitab.addTab', 'myTab', 'details', JText::_('COM_FINDER_EDIT_FILTER')); ?>
 	<div class="row">
 		<div class="col-md-9">
 			<?php if ($this->total > 0) : ?>
@@ -50,15 +52,15 @@ JHtml::_('script', 'com_finder/finder-edit.min.js', array('version' => 'auto', '
 			</div>
 		</div>
 	</div>
-	<?php echo JHtml::_('bootstrap.endTab'); ?>
+	<?php echo JHtml::_('uitab.endTab'); ?>
 
-	<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'publishing', JText::_('JGLOBAL_FIELDSET_PUBLISHING')); ?>
+	<?php echo JHtml::_('uitab.addTab', 'myTab', 'publishing', JText::_('JGLOBAL_FIELDSET_PUBLISHING')); ?>
 	<?php echo JLayoutHelper::render('joomla.edit.publishingdata', $this); ?>
-	<?php echo JHtml::_('bootstrap.endTab'); ?>
+	<?php echo JHtml::_('uitab.endTab'); ?>
 
 	<?php echo JLayoutHelper::render('joomla.edit.params', $this); ?>
 
-	<?php echo JHtml::_('bootstrap.endTabSet'); ?>
+	<?php echo JHtml::_('uitab.endTabSet'); ?>
 
 	<input type="hidden" name="task" value="">
 	<input type="hidden" name="return" value="<?php echo JFactory::getApplication()->input->get('return', '', 'cmd'); ?>">

--- a/administrator/components/com_installer/tmpl/install/default.php
+++ b/administrator/components/com_installer/tmpl/install/default.php
@@ -43,14 +43,14 @@ $app = Factory::getApplication();
 					<?php // Show installation tabs at the start ?>
 					<?php $firstTab = $app->triggerEvent('onInstallerViewBeforeFirstTab', array()); ?>
 					<?php $tabs = $app->triggerEvent('onInstallerAddInstallationTab', array()); ?>
-					<?php echo HTMLHelper::_('bootstrap.startTabSet', 'myTab', array('active' => $tabs[0]['name'])); ?>
+					<?php echo HTMLHelper::_('uitab.startTabSet', 'myTab', array('active' => $tabs[0]['name'])); ?>
 					<?php // Show installation tabs ?>
 					<?php foreach ($tabs as $tab) : ?>
-						<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', $tab['name'], $tab['label']); ?>
+						<?php echo HTMLHelper::_('uitab.addTab', 'myTab', $tab['name'], $tab['label']); ?>
 						<fieldset class="uploadform">
 							<?php echo $tab['content']; ?>
 						</fieldset>
-						<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+						<?php echo HTMLHelper::_('uitab.endTab'); ?>
 					<?php endforeach; ?>
 					<?php // Show installation tabs at the end ?>
 					<?php $lastTab = $app->triggerEvent('onInstallerViewAfterLastTab', array()); ?>
@@ -60,16 +60,16 @@ $app = Factory::getApplication();
 					<?php endif; ?>
 
 					<?php if ($this->ftp) : ?>
-						<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'ftp', Text::_('COM_INSTALLER_MSG_DESCFTPTITLE')); ?>
+						<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'ftp', Text::_('COM_INSTALLER_MSG_DESCFTPTITLE')); ?>
 						<?php echo $this->loadTemplate('ftp'); ?>
-						<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+						<?php echo HTMLHelper::_('uitab.endTab'); ?>
 					<?php endif; ?>
 
 					<input type="hidden" name="installtype" value="">
 					<input type="hidden" name="task" value="install.install">
 					<?php echo HTMLHelper::_('form.token'); ?>
 
-					<?php echo HTMLHelper::_('bootstrap.endTabSet'); ?>
+					<?php echo HTMLHelper::_('uitab.endTabSet'); ?>
 				</div>
 			</div>
 		</div>

--- a/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default.php
+++ b/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default.php
@@ -29,13 +29,13 @@ $latestJoomlaVersion = $this->updateInfo['latest'];
 
 <div id="joomlaupdate-wrapper" data-joomla-target-version="<?php echo $latestJoomlaVersion; ?>">
 	<?php if ($this->showUploadAndUpdate) : ?>
-		<?php echo HTMLHelper::_('bootstrap.startTabSet', 'joomlaupdate-tabs', array('active' => $this->shouldDisplayPreUpdateCheck() ? 'pre-update-check' : 'online-update')); ?>
+		<?php echo HTMLHelper::_('uitab.startTabSet', 'joomlaupdate-tabs', array('active' => $this->shouldDisplayPreUpdateCheck() ? 'pre-update-check' : 'online-update')); ?>
 		<?php if ($this->shouldDisplayPreUpdateCheck()) : ?>
-			<?php echo HTMLHelper::_('bootstrap.addTab', 'joomlaupdate-tabs', 'pre-update-check', Text::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_TAB_PRE_UPDATE_CHECK')); ?>
+			<?php echo HTMLHelper::_('uitab.addTab', 'joomlaupdate-tabs', 'pre-update-check', Text::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_TAB_PRE_UPDATE_CHECK')); ?>
 			<?php echo $this->loadTemplate('preupdatecheck'); ?>
-			<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+			<?php echo HTMLHelper::_('uitab.endTab'); ?>
 		<?php endif; ?>
-		<?php echo HTMLHelper::_('bootstrap.addTab', 'joomlaupdate-tabs', 'online-update', Text::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_TAB_ONLINE')); ?>
+		<?php echo HTMLHelper::_('uitab.addTab', 'joomlaupdate-tabs', 'online-update', Text::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_TAB_ONLINE')); ?>
 	<?php endif; ?>
 
 	<form enctype="multipart/form-data" action="index.php" method="post" id="adminForm">
@@ -68,11 +68,11 @@ $latestJoomlaVersion = $this->updateInfo['latest'];
 
 	<?php // Only Super Users have access to the Update & Install for obvious security reasons ?>
 	<?php if ($this->showUploadAndUpdate) : ?>
-		<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
-		<?php echo HTMLHelper::_('bootstrap.addTab', 'joomlaupdate-tabs', 'upload-update', Text::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_TAB_UPLOAD')); ?>
+		<?php echo HTMLHelper::_('uitab.endTab'); ?>
+		<?php echo HTMLHelper::_('uitab.addTab', 'joomlaupdate-tabs', 'upload-update', Text::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_TAB_UPLOAD')); ?>
 		<?php echo $this->loadTemplate('upload'); ?>
-		<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
-		<?php echo HTMLHelper::_('bootstrap.endTabSet'); ?>
+		<?php echo HTMLHelper::_('uitab.endTab'); ?>
+		<?php echo HTMLHelper::_('uitab.endTabSet'); ?>
 	<?php endif; ?>
 
 	<div id="download-message" style="display:none">

--- a/administrator/components/com_languages/tmpl/language/edit.php
+++ b/administrator/components/com_languages/tmpl/language/edit.php
@@ -27,9 +27,9 @@ HTMLHelper::_('script', 'com_languages/admin-language-edit-change-flag.js', ['re
 	<?php echo LayoutHelper::render('joomla.edit.item_title', $this); ?>
 
 	<fieldset>
-	<?php echo HTMLHelper::_('bootstrap.startTabSet', 'myTab', array('active' => 'details')); ?>
+	<?php echo HTMLHelper::_('uitab.startTabSet', 'myTab', array('active' => 'details')); ?>
 
-		<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'details', Text::_('JDETAILS')); ?>
+		<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'details', Text::_('JDETAILS')); ?>
 			<?php echo $this->form->renderField('title'); ?>
 			<?php echo $this->form->renderField('title_native'); ?>
 			<?php echo $this->form->renderField('lang_code'); ?>
@@ -52,17 +52,17 @@ HTMLHelper::_('script', 'com_languages/admin-language-edit-change-flag.js', ['re
 			<?php echo $this->form->renderField('access'); ?>
 			<?php echo $this->form->renderField('description'); ?>
 			<?php echo $this->form->renderField('lang_id'); ?>
-		<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+		<?php echo HTMLHelper::_('uitab.endTab'); ?>
 
-		<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'metadata', Text::_('JGLOBAL_FIELDSET_METADATA_OPTIONS')); ?>
+		<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'metadata', Text::_('JGLOBAL_FIELDSET_METADATA_OPTIONS')); ?>
 		<?php echo $this->form->renderFieldset('metadata'); ?>
-		<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+		<?php echo HTMLHelper::_('uitab.endTab'); ?>
 
-		<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'site_name', Text::_('COM_LANGUAGES_FIELDSET_SITE_NAME_LABEL')); ?>
+		<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'site_name', Text::_('COM_LANGUAGES_FIELDSET_SITE_NAME_LABEL')); ?>
 		<?php echo $this->form->renderFieldset('site_name'); ?>
-		<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+		<?php echo HTMLHelper::_('uitab.endTab'); ?>
 
-	<?php echo HTMLHelper::_('bootstrap.endTabSet'); ?>
+	<?php echo HTMLHelper::_('uitab.endTabSet'); ?>
 	</fieldset>
 	<input type="hidden" name="task" value="">
 	<?php echo HTMLHelper::_('form.token'); ?>

--- a/administrator/components/com_menus/tmpl/item/edit.php
+++ b/administrator/components/com_menus/tmpl/item/edit.php
@@ -24,6 +24,8 @@ HTMLHelper::_('behavior.tabstate');
 HTMLHelper::_('behavior.formvalidator');
 HTMLHelper::_('behavior.keepalive');
 
+$this->useCoreUI = true;
+
 Text::script('ERROR');
 Text::script('JGLOBAL_VALIDATION_FORM_FAILED');
 
@@ -72,9 +74,9 @@ $clientId = $this->state->get('item.client_id', 0);
 
 	<div>
 
-		<?php echo HTMLHelper::_('bootstrap.startTabSet', 'myTab', array('active' => 'details')); ?>
+		<?php echo HTMLHelper::_('uitab.startTabSet', 'myTab', array('active' => 'details')); ?>
 
-		<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'details', Text::_('COM_MENUS_ITEM_DETAILS')); ?>
+		<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'details', Text::_('COM_MENUS_ITEM_DETAILS')); ?>
 		<div class="row">
 			<div class="col-md-9">
 				<?php
@@ -136,7 +138,7 @@ $clientId = $this->state->get('item.client_id', 0);
 				</div>
 			</div>
 		</div>
-		<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+		<?php echo HTMLHelper::_('uitab.endTab'); ?>
 
 		<?php
 		$this->fieldsets = array();
@@ -147,21 +149,21 @@ $clientId = $this->state->get('item.client_id', 0);
 		<?php if (!$isModal && $assoc && $this->state->get('item.client_id') != 1) : ?>
 			<?php if ($this->item->type !== 'alias' && $this->item->type !== 'url'
 				&& $this->item->type !== 'separator' && $this->item->type !== 'heading') : ?>
-				<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'associations', Text::_('JGLOBAL_FIELDSET_ASSOCIATIONS')); ?>
+				<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'associations', Text::_('JGLOBAL_FIELDSET_ASSOCIATIONS')); ?>
 				<?php echo $this->loadTemplate('associations'); ?>
-				<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+				<?php echo HTMLHelper::_('uitab.endTab'); ?>
 			<?php endif; ?>
 		<?php elseif ($isModal && $assoc && $this->state->get('item.client_id') != 1) : ?>
 			<div class="hidden"><?php echo $this->loadTemplate('associations'); ?></div>
 		<?php endif; ?>
 
 		<?php if (!empty($this->modules)) : ?>
-			<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'modules', Text::_('COM_MENUS_ITEM_MODULE_ASSIGNMENT')); ?>
+			<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'modules', Text::_('COM_MENUS_ITEM_MODULE_ASSIGNMENT')); ?>
 			<?php echo $this->loadTemplate('modules'); ?>
-			<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+			<?php echo HTMLHelper::_('uitab.endTab'); ?>
 		<?php endif; ?>
 
-		<?php echo HTMLHelper::_('bootstrap.endTabSet'); ?>
+		<?php echo HTMLHelper::_('uitab.endTabSet'); ?>
 	</div>
 
 	<input type="hidden" name="task" value="">

--- a/administrator/components/com_menus/tmpl/menu/edit.php
+++ b/administrator/components/com_menus/tmpl/menu/edit.php
@@ -28,9 +28,9 @@ Text::script('ERROR');
 	<?php echo LayoutHelper::render('joomla.edit.title_alias', $this); ?>
 
 	<div>
-		<?php echo HTMLHelper::_('bootstrap.startTabSet', 'myTab', array('active' => 'details')); ?>
+		<?php echo HTMLHelper::_('uitab.startTabSet', 'myTab', array('active' => 'details')); ?>
 
-			<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'details', Text::_('COM_MENUS_MENU_DETAILS')); ?>
+			<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'details', Text::_('COM_MENUS_MENU_DETAILS')); ?>
 
 			<?php
 			echo $this->form->renderField('menutype');
@@ -42,15 +42,15 @@ Text::script('ERROR');
 			echo $this->form->renderField('preset');
 			?>
 
-			<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+			<?php echo HTMLHelper::_('uitab.endTab'); ?>
 
 			<?php if ($this->canDo->get('core.admin')) : ?>
-				<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'permissions', Text::_('COM_MENUS_FIELDSET_RULES')); ?>
+				<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'permissions', Text::_('COM_MENUS_FIELDSET_RULES')); ?>
 					<?php echo $this->form->getInput('rules'); ?>
-				<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+				<?php echo HTMLHelper::_('uitab.endTab'); ?>
 			<?php endif; ?>
 
-		<?php echo HTMLHelper::_('bootstrap.endTabSet'); ?>
+		<?php echo HTMLHelper::_('uitab.endTabSet'); ?>
 		<input type="hidden" name="task" value="">
 		<?php echo HTMLHelper::_('form.token'); ?>
 	</div>

--- a/administrator/components/com_modules/tmpl/module/edit.php
+++ b/administrator/components/com_modules/tmpl/module/edit.php
@@ -35,6 +35,7 @@ if ($hasContent)
 
 // Get Params Fieldsets
 $this->fieldsets = $this->form->getFieldsets('params');
+$this->useCoreUI = true;
 
 Text::script('JYES');
 Text::script('JNO');
@@ -57,9 +58,9 @@ $tmpl    = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=c
 	<?php echo LayoutHelper::render('joomla.edit.title_alias', $this); ?>
 
 	<div>
-		<?php echo HTMLHelper::_('bootstrap.startTabSet', 'myTab', array('active' => 'general')); ?>
+		<?php echo HTMLHelper::_('uitab.startTabSet', 'myTab', array('active' => 'general')); ?>
 
-		<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'general', Text::_('COM_MODULES_MODULE')); ?>
+		<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'general', Text::_('COM_MODULES_MODULE')); ?>
 
 		<div class="row">
 			<div class="col-md-9">
@@ -164,18 +165,18 @@ $tmpl    = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=c
 				</div>
 			</div>
 		</div>
-		<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+		<?php echo HTMLHelper::_('uitab.endTab'); ?>
 
 		<?php if (isset($long_description) && $long_description != '') : ?>
-			<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'description', Text::_('JGLOBAL_FIELDSET_DESCRIPTION')); ?>
+			<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'description', Text::_('JGLOBAL_FIELDSET_DESCRIPTION')); ?>
 			<?php echo $long_description; ?>
-			<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+			<?php echo HTMLHelper::_('uitab.endTab'); ?>
 		<?php endif; ?>
 
 		<?php if ($this->item->client_id == 0) : ?>
-			<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'assignment', Text::_('COM_MODULES_MENU_ASSIGNMENT')); ?>
+			<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'assignment', Text::_('COM_MODULES_MENU_ASSIGNMENT')); ?>
 			<?php echo $this->loadTemplate('assignment'); ?>
-			<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+			<?php echo HTMLHelper::_('uitab.endTab'); ?>
 		<?php endif; ?>
 
 		<?php
@@ -185,12 +186,12 @@ $tmpl    = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=c
 		?>
 
 		<?php if ($this->canDo->get('core.admin')) : ?>
-			<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'permissions', Text::_('COM_MODULES_FIELDSET_RULES')); ?>
+			<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'permissions', Text::_('COM_MODULES_FIELDSET_RULES')); ?>
 			<?php echo $this->form->getInput('rules'); ?>
-			<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+			<?php echo HTMLHelper::_('uitab.endTab'); ?>
 		<?php endif; ?>
 
-		<?php echo HTMLHelper::_('bootstrap.endTabSet'); ?>
+		<?php echo HTMLHelper::_('uitab.endTabSet'); ?>
 
 		<input type="hidden" name="task" value="">
 		<?php echo HTMLHelper::_('form.token'); ?>

--- a/administrator/components/com_newsfeeds/tmpl/newsfeed/edit.php
+++ b/administrator/components/com_newsfeeds/tmpl/newsfeed/edit.php
@@ -30,6 +30,7 @@ $assoc = Associations::isEnabled();
 
 // Fieldsets to not automatically render by /layouts/joomla/edit/params.php
 $this->ignore_fieldsets = array('images', 'jbasic', 'jmetadata', 'item_associations');
+$this->useCoreUI = true;
 
 // In case of modal
 $isModal = $input->get('layout') == 'modal' ? true : false;

--- a/administrator/components/com_newsfeeds/tmpl/newsfeed/edit.php
+++ b/administrator/components/com_newsfeeds/tmpl/newsfeed/edit.php
@@ -42,9 +42,9 @@ $tmpl    = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=c
 	<?php echo LayoutHelper::render('joomla.edit.title_alias', $this); ?>
 
 	<div>
-		<?php echo HTMLHelper::_('bootstrap.startTabSet', 'myTab', array('active' => 'details')); ?>
+		<?php echo HTMLHelper::_('uitab.startTabSet', 'myTab', array('active' => 'details')); ?>
 
-		<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'details', empty($this->item->id) ? Text::_('COM_NEWSFEEDS_NEW_NEWSFEED') : Text::_('COM_NEWSFEEDS_EDIT_NEWSFEED')); ?>
+		<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'details', empty($this->item->id) ? Text::_('COM_NEWSFEEDS_NEW_NEWSFEED') : Text::_('COM_NEWSFEEDS_EDIT_NEWSFEED')); ?>
 		<div class="row">
 			<div class="col-md-9">
 				<div class="form-vertical">
@@ -60,9 +60,9 @@ $tmpl    = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=c
 				</div>
 			</div>
 		</div>
-		<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+		<?php echo HTMLHelper::_('uitab.endTab'); ?>
 
-		<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'images', Text::_('JGLOBAL_FIELDSET_IMAGE_OPTIONS')); ?>
+		<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'images', Text::_('JGLOBAL_FIELDSET_IMAGE_OPTIONS')); ?>
 		<div class="row">
 			<div class="col-md-6">
 					<?php echo $this->form->renderField('images'); ?>
@@ -71,15 +71,15 @@ $tmpl    = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=c
 					<?php endforeach; ?>
 				</div>
 			</div>
-		<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+		<?php echo HTMLHelper::_('uitab.endTab'); ?>
 
-		<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'attrib-jbasic', Text::_('JGLOBAL_FIELDSET_DISPLAY_OPTIONS')); ?>
+		<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'attrib-jbasic', Text::_('JGLOBAL_FIELDSET_DISPLAY_OPTIONS')); ?>
 		<?php echo $this->loadTemplate('display'); ?>
-		<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+		<?php echo HTMLHelper::_('uitab.endTab'); ?>
 
 		<?php echo LayoutHelper::render('joomla.edit.params', $this); ?>
 
-		<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'publishing', Text::_('JGLOBAL_FIELDSET_PUBLISHING')); ?>
+		<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'publishing', Text::_('JGLOBAL_FIELDSET_PUBLISHING')); ?>
 		<div class="row">
 			<div class="col-md-6">
 				<?php echo LayoutHelper::render('joomla.edit.publishingdata', $this); ?>
@@ -88,17 +88,17 @@ $tmpl    = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=c
 				<?php echo LayoutHelper::render('joomla.edit.metadata', $this); ?>
 			</div>
 		</div>
-		<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+		<?php echo HTMLHelper::_('uitab.endTab'); ?>
 
 		<?php if ( ! $isModal && $assoc) : ?>
-			<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'associations', Text::_('JGLOBAL_FIELDSET_ASSOCIATIONS')); ?>
+			<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'associations', Text::_('JGLOBAL_FIELDSET_ASSOCIATIONS')); ?>
 			<?php echo $this->loadTemplate('associations'); ?>
-			<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+			<?php echo HTMLHelper::_('uitab.endTab'); ?>
 		<?php elseif ($isModal && $assoc) : ?>
 			<div class="hidden"><?php echo $this->loadTemplate('associations'); ?></div>
 		<?php endif; ?>
 
-		<?php echo HTMLHelper::_('bootstrap.endTabSet'); ?>
+		<?php echo HTMLHelper::_('uitab.endTabSet'); ?>
 	</div>
 	<input type="hidden" name="task" value="">
 	<input type="hidden" name="forcedLanguage" value="<?php echo $input->get('forcedLanguage', '', 'cmd'); ?>">

--- a/administrator/components/com_plugins/tmpl/plugin/edit.php
+++ b/administrator/components/com_plugins/tmpl/plugin/edit.php
@@ -22,6 +22,7 @@ HTMLHelper::_('behavior.keepalive');
 HTMLHelper::_('behavior.tabstate');
 
 $this->fieldsets = $this->form->getFieldsets('params');
+$this->useCoreUI = true;
 
 $input = Factory::getApplication()->input;
 
@@ -34,9 +35,9 @@ $tmpl     = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=
 <form action="<?php echo Route::_('index.php?option=com_plugins&view=plugin&layout=' . $layout . $tmpl . '&extension_id=' . (int) $this->item->extension_id); ?>" method="post" name="adminForm" id="style-form" class="form-validate">
 	<div>
 
-		<?php echo HTMLHelper::_('bootstrap.startTabSet', 'myTab', array('active' => 'general')); ?>
+		<?php echo HTMLHelper::_('uitab.startTabSet', 'myTab', array('active' => 'general')); ?>
 
-		<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'general', Text::_('COM_PLUGINS_PLUGIN')); ?>
+		<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'general', Text::_('COM_PLUGINS_PLUGIN')); ?>
 
 		<div class="row">
 			<div class="col-md-9">
@@ -139,12 +140,12 @@ $tmpl     = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=
 				</div>
 			</div>
 		</div>
-		<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+		<?php echo HTMLHelper::_('uitab.endTab'); ?>
 
 		<?php if (isset($long_description) && $long_description != '') : ?>
-			<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'description', Text::_('JGLOBAL_FIELDSET_DESCRIPTION')); ?>
+			<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'description', Text::_('JGLOBAL_FIELDSET_DESCRIPTION')); ?>
 			<?php echo $long_description; ?>
-			<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+			<?php echo HTMLHelper::_('uitab.endTab'); ?>
 		<?php endif; ?>
 
 		<?php
@@ -153,7 +154,7 @@ $tmpl     = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=
 		echo LayoutHelper::render('joomla.edit.params', $this);
 		?>
 
-		<?php echo HTMLHelper::_('bootstrap.endTabSet'); ?>
+		<?php echo HTMLHelper::_('uitab.endTabSet'); ?>
 	</div>
 
 	<input type="hidden" name="task" value="">

--- a/administrator/components/com_plugins/tmpl/plugin/edit_options.php
+++ b/administrator/components/com_plugins/tmpl/plugin/edit_options.php
@@ -18,7 +18,7 @@ foreach ($this->fieldsets as $name => $fieldset)
 	{
 		$label = !empty($fieldset->label) ? Text::_($fieldset->label) : Text::_('COM_PLUGINS_' . $fieldset->name . '_FIELDSET_LABEL', true);
 		$optionsname = 'options-' . $fieldset->name;
-		echo HTMLHelper::_('bootstrap.addTab', 'myTab', $optionsname,  $label);
+		echo HTMLHelper::_('uitab.addTab', 'myTab', $optionsname,  $label);
 
 		if (isset($fieldset->description) && trim($fieldset->description))
 		{
@@ -49,6 +49,6 @@ foreach ($this->fieldsets as $name => $fieldset)
 		}
 		echo $hidden_fields;
 
-		echo HTMLHelper::_('bootstrap.endTab');
+		echo HTMLHelper::_('uitab.endTab');
 	}
 }

--- a/administrator/components/com_redirect/tmpl/link/edit.php
+++ b/administrator/components/com_redirect/tmpl/link/edit.php
@@ -23,9 +23,9 @@ HTMLHelper::_('behavior.keepalive');
 
 <form action="<?php echo Route::_('index.php?option=com_redirect&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="link-form" class="form-validate">
 	<fieldset>
-		<?php echo HTMLHelper::_('bootstrap.startTabSet', 'myTab', array('active' => 'basic')); ?>
+		<?php echo HTMLHelper::_('uitab.startTabSet', 'myTab', array('active' => 'basic')); ?>
 
-			<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'basic', empty($this->item->id) ? Text::_('COM_REDIRECT_NEW_LINK') : Text::sprintf('COM_REDIRECT_EDIT_LINK', $this->item->id)); ?>
+			<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'basic', empty($this->item->id) ? Text::_('COM_REDIRECT_NEW_LINK') : Text::sprintf('COM_REDIRECT_EDIT_LINK', $this->item->id)); ?>
 				<?php echo $this->form->renderField('old_url'); ?>
 				<?php echo $this->form->renderField('new_url'); ?>
 				<?php echo $this->form->renderField('published'); ?>
@@ -36,8 +36,8 @@ HTMLHelper::_('behavior.keepalive');
 				<?php if (ComponentHelper::getParams('com_redirect')->get('mode')) : ?>
 					<?php echo $this->form->renderFieldset('advanced'); ?>
 				<?php endif; ?>
-			<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
-		<?php echo HTMLHelper::_('bootstrap.endTabSet'); ?>
+			<?php echo HTMLHelper::_('uitab.endTab'); ?>
+		<?php echo HTMLHelper::_('uitab.endTabSet'); ?>
 
 		<input type="hidden" name="task" value="">
 		<?php echo HTMLHelper::_('form.token'); ?>

--- a/administrator/components/com_tags/tmpl/tag/edit.php
+++ b/administrator/components/com_tags/tmpl/tag/edit.php
@@ -20,6 +20,8 @@ HTMLHelper::_('behavior.tabstate');
 
 // Fieldsets to not automatically render by /layouts/joomla/edit/params.php
 $this->ignore_fieldsets = array('jmetadata');
+$this->useCoreUI = true;
+
 ?>
 
 <form action="<?php echo Route::_('index.php?option=com_tags&layout=edit&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="item-form" class="form-validate">
@@ -27,9 +29,9 @@ $this->ignore_fieldsets = array('jmetadata');
 	<?php echo LayoutHelper::render('joomla.edit.title_alias', $this); ?>
 
 	<div>
-		<?php echo HTMLHelper::_('bootstrap.startTabSet', 'myTab', array('active' => 'details')); ?>
+		<?php echo HTMLHelper::_('uitab.startTabSet', 'myTab', array('active' => 'details')); ?>
 
-		<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'details', Text::_('COM_TAGS_FIELDSET_DETAILS')); ?>
+		<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'details', Text::_('COM_TAGS_FIELDSET_DETAILS')); ?>
 		<div class="row">
 			<div class="col-md-9">
 				<div class="form-vertical">
@@ -44,11 +46,11 @@ $this->ignore_fieldsets = array('jmetadata');
 				</div>
 			</div>
 		</div>
-		<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+		<?php echo HTMLHelper::_('uitab.endTab'); ?>
 
 		<?php echo LayoutHelper::render('joomla.edit.params', $this); ?>
 
-		<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'publishing', Text::_('JGLOBAL_FIELDSET_PUBLISHING')); ?>
+		<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'publishing', Text::_('JGLOBAL_FIELDSET_PUBLISHING')); ?>
 		<div class="row">
 			<div class="col-md-6">
 				<?php echo LayoutHelper::render('joomla.edit.publishingdata', $this); ?>
@@ -57,9 +59,9 @@ $this->ignore_fieldsets = array('jmetadata');
 				<?php echo LayoutHelper::render('joomla.edit.metadata', $this); ?>
 			</div>
 		</div>
-		<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+		<?php echo HTMLHelper::_('uitab.endTab'); ?>
 
-		<?php echo HTMLHelper::_('bootstrap.endTabSet'); ?>
+		<?php echo HTMLHelper::_('uitab.endTabSet'); ?>
 	</div>
 	<input type="hidden" name="task" value="">
 	<?php echo HTMLHelper::_('form.token'); ?>

--- a/administrator/components/com_templates/tmpl/style/edit.php
+++ b/administrator/components/com_templates/tmpl/style/edit.php
@@ -21,6 +21,8 @@ HTMLHelper::_('behavior.formvalidator');
 HTMLHelper::_('behavior.keepalive');
 HTMLHelper::_('behavior.tabstate');
 
+$this->useCoreUI = true;
+
 $user = Factory::getUser();
 ?>
 
@@ -29,9 +31,9 @@ $user = Factory::getUser();
 	<?php echo LayoutHelper::render('joomla.edit.title_alias', $this); ?>
 
 	<div>
-		<?php echo HTMLHelper::_('bootstrap.startTabSet', 'myTab', array('active' => 'details')); ?>
+		<?php echo HTMLHelper::_('uitab.startTabSet', 'myTab', array('active' => 'details')); ?>
 
-		<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'details', Text::_('JDETAILS')); ?>
+		<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'details', Text::_('JDETAILS')); ?>
 
 		<div class="row">
 			<div class="col-md-9">
@@ -79,12 +81,12 @@ $user = Factory::getUser();
 				</div>
 			</div>
 		</div>
-		<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+		<?php echo HTMLHelper::_('uitab.endTab'); ?>
 
 		<?php if ($description) : ?>
-			<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'description', Text::_('JGLOBAL_FIELDSET_DESCRIPTION')); ?>
+			<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'description', Text::_('JGLOBAL_FIELDSET_DESCRIPTION')); ?>
 			<?php echo $description; ?>
-			<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+			<?php echo HTMLHelper::_('uitab.endTab'); ?>
 		<?php endif; ?>
 
 		<?php
@@ -94,12 +96,12 @@ $user = Factory::getUser();
 		?>
 
 		<?php if ($user->authorise('core.edit', 'com_menus') && $this->item->client_id == 0 && $this->canDo->get('core.edit.state')) : ?>
-			<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'assignment', Text::_('COM_TEMPLATES_MENUS_ASSIGNMENT')); ?>
+			<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'assignment', Text::_('COM_TEMPLATES_MENUS_ASSIGNMENT')); ?>
 			<?php echo $this->loadTemplate('assignment'); ?>
-			<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+			<?php echo HTMLHelper::_('uitab.endTab'); ?>
 		<?php endif; ?>
 
-		<?php echo HTMLHelper::_('bootstrap.endTabSet'); ?>
+		<?php echo HTMLHelper::_('uitab.endTabSet'); ?>
 
 		<input type="hidden" name="task" value="">
 		<?php echo HTMLHelper::_('form.token'); ?>

--- a/administrator/components/com_templates/tmpl/template/default.php
+++ b/administrator/components/com_templates/tmpl/template/default.php
@@ -53,8 +53,8 @@ if ($this->type == 'font')
 	");
 }
 ?>
-<?php echo HTMLHelper::_('bootstrap.startTabSet', 'myTab', array('active' => 'editor')); ?>
-<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'editor', Text::_('COM_TEMPLATES_TAB_EDITOR')); ?>
+<?php echo HTMLHelper::_('uitab.startTabSet', 'myTab', array('active' => 'editor')); ?>
+<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'editor', Text::_('COM_TEMPLATES_TAB_EDITOR')); ?>
 <div class="row">
 	<div class="col-md-12">
 		<?php if($this->type == 'file') : ?>
@@ -190,9 +190,9 @@ if ($this->type == 'font')
 		<?php endif; ?>
 	</div>
 </div>
-<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+<?php echo HTMLHelper::_('uitab.endTab'); ?>
 
-<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'overrides', Text::_('COM_TEMPLATES_TAB_OVERRIDES')); ?>
+<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'overrides', Text::_('COM_TEMPLATES_TAB_OVERRIDES')); ?>
 <div class="row">
 	<div class="col-md-4">
 		<legend><?php echo Text::_('COM_TEMPLATES_OVERRIDES_MODULES'); ?></legend>
@@ -264,12 +264,12 @@ if ($this->type == 'font')
 		</ul>
 	</div>
 </div>
-<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+<?php echo HTMLHelper::_('uitab.endTab'); ?>
 
-<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'description', Text::_('COM_TEMPLATES_TAB_DESCRIPTION')); ?>
+<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'description', Text::_('COM_TEMPLATES_TAB_DESCRIPTION')); ?>
 <?php echo $this->loadTemplate('description'); ?>
-<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
-<?php echo HTMLHelper::_('bootstrap.endTabSet'); ?>
+<?php echo HTMLHelper::_('uitab.endTab'); ?>
+<?php echo HTMLHelper::_('uitab.endTabSet'); ?>
 
 <?php // Collapse Modal
 $copyModalData = array(

--- a/administrator/components/com_templates/tmpl/template/readonly.php
+++ b/administrator/components/com_templates/tmpl/template/readonly.php
@@ -20,11 +20,11 @@ HTMLHelper::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 $input = Factory::getApplication()->input;
 ?>
 <form action="<?php echo Route::_('index.php?option=com_templates&view=template&id=' . $input->getInt('id') . '&file=' . $this->file); ?>" method="post" name="adminForm" id="adminForm">
-	<?php echo HTMLHelper::_('bootstrap.startTabSet', 'myTab', array('active' => 'description')); ?>
-		<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'description', Text::_('COM_TEMPLATES_TAB_DESCRIPTION')); ?>
+	<?php echo HTMLHelper::_('uitab.startTabSet', 'myTab', array('active' => 'description')); ?>
+		<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'description', Text::_('COM_TEMPLATES_TAB_DESCRIPTION')); ?>
 			<?php echo $this->loadTemplate('description'); ?>
-		<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
-	<?php echo HTMLHelper::_('bootstrap.endTabSet'); ?>
+		<?php echo HTMLHelper::_('uitab.endTab'); ?>
+	<?php echo HTMLHelper::_('uitab.endTabSet'); ?>
 	<input type="hidden" name="task" value="">
 	<?php echo HTMLHelper::_('form.token'); ?>
 </form>

--- a/administrator/components/com_users/tmpl/user/edit.php
+++ b/administrator/components/com_users/tmpl/user/edit.php
@@ -24,6 +24,9 @@ HTMLHelper::_('script', 'com_users/admin-users-user.min.js', array('version' => 
 // Get the form fieldsets.
 $fieldsets = $this->form->getFieldsets();
 $settings  = array();
+
+$this->useCoreUI = true;
+
 ?>
 
 <form action="<?php echo Route::_('index.php?option=com_users&layout=edit&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="user-form" enctype="multipart/form-data" class="form-validate">
@@ -31,9 +34,9 @@ $settings  = array();
 	<?php echo LayoutHelper::render('joomla.edit.item_title', $this); ?>
 
 	<fieldset>
-		<?php echo HTMLHelper::_('bootstrap.startTabSet', 'myTab', array('active' => 'details')); ?>
+		<?php echo HTMLHelper::_('uitab.startTabSet', 'myTab', array('active' => 'details')); ?>
 
-			<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'details', Text::_('COM_USERS_USER_ACCOUNT_DETAILS')); ?>
+			<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'details', Text::_('COM_USERS_USER_ACCOUNT_DETAILS')); ?>
 				<?php foreach ($this->form->getFieldset('user_details') as $field) : ?>
 					<div class="control-group">
 						<div class="control-label">
@@ -44,12 +47,12 @@ $settings  = array();
 						</div>
 					</div>
 				<?php endforeach; ?>
-			<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+			<?php echo HTMLHelper::_('uitab.endTab'); ?>
 
 			<?php if ($this->grouplist) : ?>
-				<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'groups', Text::_('COM_USERS_ASSIGNED_GROUPS')); ?>
+				<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'groups', Text::_('COM_USERS_ASSIGNED_GROUPS')); ?>
 					<?php echo $this->loadTemplate('groups'); ?>
-				<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+				<?php echo HTMLHelper::_('uitab.endTab'); ?>
 			<?php endif; ?>
 
 			<?php
@@ -58,7 +61,7 @@ $settings  = array();
 			?>
 
 		<?php if (!empty($this->tfaform) && $this->item->id) : ?>
-		<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'twofactorauth', Text::_('COM_USERS_USER_TWO_FACTOR_AUTH')); ?>
+		<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'twofactorauth', Text::_('COM_USERS_USER_TWO_FACTOR_AUTH')); ?>
 		<div class="control-group">
 			<div class="control-label">
 				<label id="jform_twofactor_method-lbl" for="jform_twofactor_method" class="hasTooltip"
@@ -95,10 +98,10 @@ $settings  = array();
 			<?php endif; ?>
 		</fieldset>
 
-		<?php echo HTMLHelper::_('bootstrap.endTab'); ?>
+		<?php echo HTMLHelper::_('uitab.endTab'); ?>
 		<?php endif; ?>
 
-		<?php echo HTMLHelper::_('bootstrap.endTabSet'); ?>
+		<?php echo HTMLHelper::_('uitab.endTabSet'); ?>
 	</fieldset>
 
 	<input type="hidden" name="task" value="">


### PR DESCRIPTION
This converts the majority of the instances in the administrator of the boostrap tabset to the ui tabset. It doesnt touch the frontend and it doesnt touch com-contact which I couldnt get to work after the conversions

### Before (example)
![image](https://user-images.githubusercontent.com/1296369/44456526-b0b62680-a5f8-11e8-8b6b-6024a328b041.png)

### After (example)
![image](https://user-images.githubusercontent.com/1296369/44456590-d4796c80-a5f8-11e8-85b1-ae60a16dd8c1.png)
