### PR TITLE
[4.0] module modal select

### DIFF
--- a/administrator/components/com_modules/tmpl/modules/modal.php
+++ b/administrator/components/com_modules/tmpl/modules/modal.php
@@ -91,7 +91,7 @@ $editor    = Factory::getApplication()->input->get('editor', '', 'cmd');
 						<?php if ($item->position) : ?>
 						<a class="js-position-insert btn btn-sm btn-block btn-warning" href="#" data-position="<?php echo $this->escape($item->position); ?>" data-editor="<?php echo $this->escape($editor); ?>"><?php echo $this->escape($item->position); ?></a>
 						<?php else : ?>
-						<span class="badge badge-secondary"><?php echo Text::_('JNONE'); ?></span>
+						<span class="btn btn-sm btn-block btn-secondary"><?php echo Text::_('JNONE'); ?></span>
 						<?php endif; ?>
 					</td>
 					<td class="small d-none d-md-table-cell">


### PR DESCRIPTION
The xtd-editor plugin for modules opens a modal
If the module position is "none" then it is currently a badge which looks wrong - see screenshots


### Before
<img width="562" alt="chrome_2018-08-22_12-10-54" src="https://user-images.githubusercontent.com/1296369/44460350-9f731700-a604-11e8-9074-ebd66d311663.png">



### After
<img width="548" alt="chrome_2018-08-22_12-10-06" src="https://user-images.githubusercontent.com/1296369/44460361-aa2dac00-a604-11e8-8743-2cff28873dae.png">
