### PR TITLE
[4.0] Pagebreak plugin tabs

### DIFF
--- a/plugins/content/pagebreak/pagebreak.php
+++ b/plugins/content/pagebreak/pagebreak.php
@@ -209,7 +209,7 @@ class PlgContentPagebreak extends CMSPlugin
 
 				if ($style === 'tabs')
 				{
-					$t[] = (string) HTMLHelper::_('bootstrap.startTabSet', 'myTab', array('active' => 'article' . $row->id . '-' . $style . '0'));
+					$t[] = (string) HTMLHelper::_('uitab.startTabSet', 'myTab', array('active' => 'article' . $row->id . '-' . $style . '0'));
 				}
 				else
 				{
@@ -241,7 +241,7 @@ class PlgContentPagebreak extends CMSPlugin
 
 					if ($style === 'tabs')
 					{
-						$t[] = (string) HTMLHelper::_('bootstrap.addTab', 'myTab', $index, $title);
+						$t[] = (string) HTMLHelper::_('uitab.addTab', 'myTab', $index, $title);
 					}
 					else
 					{
@@ -252,7 +252,7 @@ class PlgContentPagebreak extends CMSPlugin
 
 					if ($style === 'tabs')
 					{
-						$t[] = (string) HTMLHelper::_('bootstrap.endTab');
+						$t[] = (string) HTMLHelper::_('uitab.endTab');
 					}
 					else
 					{
@@ -262,7 +262,7 @@ class PlgContentPagebreak extends CMSPlugin
 
 				if ($style === 'tabs')
 				{
-					$t[] = (string) HTMLHelper::_('bootstrap.endTabSet');
+					$t[] = (string) HTMLHelper::_('uitab.endTabSet');
 				}
 				else
 				{


### PR DESCRIPTION
The pagebreak plugin has options for tabs, pagers and sliders
This pr updates the code to use the uitab instead of bootstrap for the tabs option
There are no cosmetic changes
