### PR TITLE
[4.0] Context for workflow and not category

### DIFF
--- a/administrator/components/com_workflow/Controller/DisplayController.php
+++ b/administrator/components/com_workflow/Controller/DisplayController.php
@@ -31,7 +31,7 @@ class DisplayController extends BaseController
 	protected $default_view = 'workflows';
 
 	/**
-	 * The extension for which the categories apply.
+	 * The extension for which the workflow apply.
 	 *
 	 * @var    string
 	 * @since  __DEPLOY_VERSION__


### PR DESCRIPTION
Is the extension attribute in the workflow `DisplayController` for categories or workflows?