### PR TITLE
[4.0] Fix reorder not working in backend managers

### DIFF
--- a/libraries/src/Event/Table/AfterReorderEvent.php
+++ b/libraries/src/Event/Table/AfterReorderEvent.php
@@ -45,7 +45,7 @@ class AfterReorderEvent extends AbstractEvent
 	/**
 	 * Setter for the where argument
 	 *
-	 * @param   string|null  $value  The value to set
+	 * @param   array|string|null  $value  A string or array of where conditions.
 	 *
 	 * @return  mixed
 	 *
@@ -53,9 +53,9 @@ class AfterReorderEvent extends AbstractEvent
 	 */
 	protected function setWhere($value)
 	{
-		if (!empty($value) && !is_string($value))
+		if (!empty($value) && !is_string($value) && !is_array($value))
 		{
-			throw new BadMethodCallException("Argument 'where' of event {$this->name} must be empty or string");
+			throw new BadMethodCallException("Argument 'where' of event {$this->name} must be empty or string or array of strings");
 		}
 
 		return $value;

--- a/libraries/src/Event/Table/BeforeReorderEvent.php
+++ b/libraries/src/Event/Table/BeforeReorderEvent.php
@@ -70,7 +70,7 @@ class BeforeReorderEvent extends AbstractEvent
 	/**
 	 * Setter for the where argument
 	 *
-	 * @param   string|null  $value  The value to set
+	 * @param   array|string|null  $value  A string or array of where conditions.
 	 *
 	 * @return  mixed
 	 *
@@ -78,9 +78,9 @@ class BeforeReorderEvent extends AbstractEvent
 	 */
 	protected function setWhere($value)
 	{
-		if (!empty($value) && !is_string($value))
+		if (!empty($value) && !is_string($value) && !is_array($value))
 		{
-			throw new BadMethodCallException("Argument 'where' of event {$this->name} must be empty or string");
+			throw new BadMethodCallException("Argument 'where' of event {$this->name} must be empty or string or array of strings");
 		}
 
 		return $value;

--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -1348,11 +1348,6 @@ abstract class AdminModel extends FormModel
 			{
 				$this->table->$orderingField = $order[$i];
 
-				if ($this->type)
-				{
-					$this->createTagsHelper($this->tagsObserver, $this->type, $pk, $this->typeAlias, $this->table);
-				}
-
 				if (!$this->table->store())
 				{
 					$this->setError($this->table->getError());


### PR DESCRIPTION
Pull Request for Issue #20136
and maybe some other open issue ?

### Summary of Changes
Remove call to non-existing method `createTagsHelper()` , as its work is now handled by events
@laoneo  please confirm this

Fix `setWhere()` method of classes
`BeforeReorderEvent, AfterReorderEvent`
to also accept where conditions as an array too


### Testing Instructions
Try to re-order in article manager

### Expected result
Re-ordering works


### Actual result
(browser console, network response TAB) You get error page with createTagsHelper  helper undefined


### Documentation Changes Required

