### PR TITLE
[3.8] Fix mod_menu params to add class

### DIFF
--- a/modules/mod_menu/mod_menu.php
+++ b/modules/mod_menu/mod_menu.php
@@ -20,7 +20,7 @@ $active_id  = $active->id;
 $default_id = $default->id;
 $path       = $base->tree;
 $showAll    = $params->get('showAllChildren', 1);
-$class_sfx  = htmlspecialchars($params->get('class_sfx'), ENT_COMPAT, 'UTF-8');
+$class_sfx  = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
 
 if (count($list))
 {


### PR DESCRIPTION
### Summary of Changes
Fixed the params string 'class_sfx' to 'moduleclass_sfx' to be able to add class to menu


### Testing Instructions
(Using joomla 3.8.x and protostar template)
1. Create or edit a module menu
2. Go to "advanced" panel, add in "Module Class Suffix" : " nav-pills" (add a space if you have already strings)
3. Go to frontend, nothing change

Apply fix
Go to frontend, you can see change
