### PR TITLE
[4.0] Remove hard coded string in language errors display

### DIFF
--- a/libraries/src/Language/Language.php
+++ b/libraries/src/Language/Language.php
@@ -953,7 +953,7 @@ class Language
 		// Check if we encountered any errors.
 		if (count($errors))
 		{
-			$this->errorfiles[$filename] = $filename . ' : error(s) in line(s) ' . implode(', ', $errors);
+			$this->errorfiles[$filename] = $errors;
 		}
 		elseif ($php_errormsg)
 		{

--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -1508,9 +1508,12 @@ class PlgSystemDebug extends CMSPlugin
 
 		$html[] = '<ul>';
 
-		foreach ($errorfiles as $file => $error)
+		foreach ($errorfiles as $file => $errors)
 		{
-			$html[] = '<li>' . $this->formatLink($file) . str_replace($file, '', $error) . '</li>';
+			foreach ($errors as $error)
+			{
+				$html[] = '<li>' . $this->formatLink($file, $error) . '</li>';
+			}
 		}
 
 		$html[] = '</ul>';


### PR DESCRIPTION
### Summary of Changes
I was thinking on how to "sell" this to the "gate keepers" so I guess that I should start with

* Remove hard coded string in language errors display
    The string `error(s) in line(s)` is hard coded and untranslatable.

On the other hand I believe that it should be the responsibility of the "caller" to format this message.

It will also be useful while refactoring the debug plugin in #20380

As a bonus the file links are now pointing to the error line if you have xdebug links set up.

### Testing Instructions

Switch on language debug and produce some errors in language files

### Expected result

![bildschirmfoto_2018-08-24_17-06-34](https://user-images.githubusercontent.com/33978/44610402-98453800-a7c1-11e8-8be3-6a89ec62b927.png)

### Actual result

![bildschirmfoto_2018-08-24_15-44-57](https://user-images.githubusercontent.com/33978/44610401-97aca180-a7c1-11e8-89c0-c612734b1306.png)


### Documentation Changes Required

I believe that this is somewhat B/C breaking since the return values have changed - you might get an "array to string conversion" warning.