### PR TITLE
[4.0] Batch Workflows

### DIFF
--- a/libraries/cms/html/workflowstage.php
+++ b/libraries/cms/html/workflowstage.php
@@ -54,6 +54,7 @@ abstract class JHtmlWorkflowstage
 				)
 			->from($db->quoteName('#__workflow_stages', 'ws'))
 			->leftJoin($db->quoteName('#__workflows', 'w') . ' ON w.id = ws.workflow_id')
+			->where('w.published = 1')
 			->order('ws.ordering');
 
 		// Set the query and load the options.


### PR DESCRIPTION
When displaying the list of stages in the batch modal for articles it was not checking to see if the workflow was published

To test create more than one workflow and make one of them unpublished

Try to batch change an article and you should only see the stages from the published workflows in the list
