### PR TITLE
[4.0] JFactory class not found

### DIFF
--- a/administrator/components/com_menus/Model/ItemsModel.php
+++ b/administrator/components/com_menus/Model/ItemsModel.php
@@ -122,7 +122,7 @@ class ItemsModel extends ListModel
 		// Load mod_menu.ini file when client is administrator
 		if ($clientId == 1)
 		{
-			JFactory::getLanguage()->load('mod_menu', JPATH_ADMINISTRATOR, null, false, true);
+			Factory::getLanguage()->load('mod_menu', JPATH_ADMINISTRATOR, null, false, true);
 		}
 
 		$currentMenuType = $app->getUserState($this->context . '.menutype', '');


### PR DESCRIPTION
### Summary of Changes
change JFactory to Factory

This happens when displaying the Menu items manager
Can be merged on review
@wilsonge @laoneo 