### PR TITLE
class Archive: Folder::create $extractdir instead of $path

### DIFF
--- a/libraries/vendor/joomla/archive/src/Archive.php
+++ b/libraries/vendor/joomla/archive/src/Archive.php
@@ -107,7 +107,7 @@ class Archive
 				}
 				else
 				{
-					Folder::create($path);
+					Folder::create($extractdir);
 					$result = File::copy($tmpfname, $extractdir . '/' . $filename, null, 0);
 				}
 


### PR DESCRIPTION
Issue and solution reported by user jooomlaa at
https://forum.joomla.de/thread/6201-vermutl-fehler-in-libraries-vendor-joomla-archive-src-archive-php-beim-entpacken/ 

### Summary of Changes
- Correct target path of extracted `gzip` or `gz` archives.

### Testing Instructions
- Joomla staging with template protostar.
- Configuration: error_reporting => Maximum
- Configuration: debug => Yes
- Crréate a folder /tmp/source/
- Put a gzip file in it that shall be extracted.
e.g. https://forum.joomla.de/core/attachment/2757-namen-fr-fenja-txt-gzip/

- Enter following code in protostar index.php after line `defined('_JEXEC') or die;`

```
use Joomla\Archive\Archive;

$fileName = 'Namen_fr-Fenja.txt.gzip';

$archive = new Archive(array('tmp_path' => JFactory::getConfig()->get('tmp_path')));

$archiveName = JPATH_SITE . '/tmp/source/' . $fileName;
$extractDir = JPATH_SITE . '/tmp/target';
$archive->extract($archiveName, $extractDir);
exit;
```

- Pay attention that folder /tmp/target doesn't exist before test.

- Open protostar page in frontend that runs the code. 

### Expected result
- A new folder `/tmp/target/` with extracted file `Namen_fr-Fenja` in it

### Actual result
- A temporary file like `gzip5b83db746bab9` in `/tmp/`
- error page
```
Joomla\Filesystem\File::copy: Copy failed.
.../libraries/vendor/joomla/filesystem/src/File.php:94

Call stack
--
# | Function | Location
1 | () | JROOT/libraries/vendor/joomla/filesystem/src/File.php:94
2 | Joomla\Filesystem\File::copy() | JROOT/libraries/vendor/joomla/archive/src/Archive.php:115
```

### Apply patch
- Try again.
- Beware that protostar page is just empty because of `exit;` in code above (= OK).
- A new folder `/tmp/target/` with extracted file `Namen_fr-Fenja` in it
- The temporary file like `gzip5b83db746bab9` is not present in folder `/tmp/`