### PR TITLE
[4.0] Fix SQL for creating table "#__csp" in installation and schema update for PostgreSQL

### DIFF
--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2018-06-03.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2018-06-03.sql
@@ -3,7 +3,7 @@
 --
 
 CREATE TABLE IF NOT EXISTS "#__csp" (
-  "id" int(11) NOT NULL AUTO_INCREMENT,
+  "id" serial NOT NULL,
   "document_uri" varchar(500) NOT NULL DEFAULT '',
   "blocked_uri" varchar(500) NOT NULL DEFAULT '',
   "directive" varchar(500) NOT NULL DEFAULT '',

--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -479,7 +479,7 @@ CREATE TABLE IF NOT EXISTS "#__core_log_searches" (
 --
 
 CREATE TABLE IF NOT EXISTS "#__csp" (
-  "id" int(11) NOT NULL AUTO_INCREMENT,
+  "id" serial NOT NULL,
   "document_uri" varchar(500) NOT NULL DEFAULT '',
   "blocked_uri" varchar(500) NOT NULL DEFAULT '',
   "directive" varchar(500) NOT NULL DEFAULT '',


### PR DESCRIPTION
Remove copy and paste artifacts with MySQL syntax in create table statement for table "#__csp" from PostgreSQL installation and schema update script.

Can be merged on review.

@alikon please review.
