### PR TITLE
[4.0] Correct obvious syntax error in installation and schema update for PostgreSQL

### DIFF
--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2018-05-15.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2018-05-15.sql
@@ -6,7 +6,7 @@ CREATE TABLE IF NOT EXISTS "#__workflows" (
   "id" serial NOT NULL,
   "asset_id" bigint DEFAULT 0 NOT NULL,
   "published" smallint DEFAULT 0 NOT NULL,
-  "title" varchar(255) DEFAULT '' NOT NULL,,
+  "title" varchar(255) DEFAULT '' NOT NULL,
   "description" text NOT NULL,
   "extension" varchar(50) NOT NULL,
   "default" smallint NOT NULL  DEFAULT 0,

--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -1947,7 +1947,7 @@ CREATE TABLE IF NOT EXISTS "#__workflows" (
   "id" serial NOT NULL,
   "asset_id" bigint DEFAULT 0 NOT NULL,
   "published" smallint DEFAULT 0 NOT NULL,
-  "title" varchar(255) DEFAULT '' NOT NULL,,
+  "title" varchar(255) DEFAULT '' NOT NULL,
   "description" text NOT NULL,
   "extension" varchar(50) NOT NULL,
   "default" smallint NOT NULL  DEFAULT 0,


### PR DESCRIPTION
Correct obvious syntax error in create table statement for the workflows table in installation and schema update for PostgreSQL.

Can be tested and merged by review.

@alikon please review.