### PR TITLE
[4.0] Fix SQL for creating table "#__finder_logging" in installation and schema update for PostgreSQL

### DIFF
--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2018-06-06.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2018-06-06.sql
@@ -1,7 +1,7 @@
 CREATE TABLE IF NOT EXISTS "#__finder_logging" (
   "searchterm" character varying(255) NOT NULL DEFAULT '',
   "md5sum" character varying(32) NOT NULL DEFAULT '',
-  "query" bytes NOT NULL,
+  "query" bytea NOT NULL,
   "hits" integer NOT NULL DEFAULT 1,
   "results" integer NOT NULL DEFAULT 0,
   PRIMARY KEY ("md5sum")

--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -865,7 +865,7 @@ CREATE INDEX "#__finder_links_terms_idx_link_term_weight" on "#__finder_links_te
 CREATE TABLE IF NOT EXISTS "#__finder_logging" (
   "searchterm" character varying(255) NOT NULL DEFAULT '',
   "md5sum" character varying(32) NOT NULL DEFAULT '',
-  "query" bytes NOT NULL,
+  "query" bytea NOT NULL,
   "hits" integer NOT NULL DEFAULT 1,
   "results" integer NOT NULL DEFAULT 0,
   PRIMARY KEY ("md5sum")


### PR DESCRIPTION
The data type for binary strings in PostgreSQL is `bytea`, not `bytes`. There is no data type `bytes` in postgreSQL.

`bytea` is correct for that column because in MySQL it is a `BLOB`, see the joomla.sql for MySQL.

Can be tested and merged by review.

@alikon please review.