### PR TITLE
[4.0] Correct "#__workflow_id_seq" in installation joomla.sql for PostgreSQL

### DIFF
--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -1971,7 +1971,7 @@ CREATE INDEX "#__workflows_idx_modified_by" ON "#__workflows" ("modified_by");
 INSERT INTO "#__workflows" ("id", "asset_id", "published", "title", "description", "extension", "default", "ordering", "created", "created_by", "modified", "modified_by") VALUES
 (1, 56, 1, 'Joomla! Default', '', 'com_content', 1, 1, '1970-01-01 00:00:00', 0, '1970-01-01 00:00:00', 0);
 
-SELECT setval('#__workflow_id_seq', 2, false);
+SELECT setval('#__workflows_id_seq', 2, false);
 
 --
 -- Table structure for table "#__workflow_associations"


### PR DESCRIPTION
Correct sequence name "#__workflow_id_seq" to "#__workflows_id_seq" in joomla.sql.

In schema updates, this error does not exist.

Can be tested and merged by review.

@alikon Please review.

By the way: When my other PR #21884 has been merged, this one here fixes the last error which makes Joomla 4.0 installation not work with PostgreSQL.
