### PR TITLE
Check for the presence of the optional input param before checking data

### DIFF
--- a/libraries/src/Form/Form.php
+++ b/libraries/src/Form/Form.php
@@ -2066,14 +2066,18 @@ class Form
 
 		// Check if the field is required.
 		$required = ((string) $element['required'] == 'true' || (string) $element['required'] == 'required');
-		$disabled = ((string) $element['disabled'] == 'true' || (string) $element['disabled'] == 'disabled');
 
-		$fieldExistsInRequestData = $input->exists((string) $element['name']) || $input->exists($group . '.' . (string) $element['name']);
-
-		// If the field is disabled but it is passed in the request this is invalid as disabled fields are not added to the request
-		if ($disabled && $fieldExistsInRequestData)
+		if ($input)
 		{
-			return new \RuntimeException(\JText::sprintf('JLIB_FORM_VALIDATE_FIELD_INVALID', $element['name']));
+			$disabled = ((string) $element['disabled'] == 'true' || (string) $element['disabled'] == 'disabled');
+
+			$fieldExistsInRequestData = $input->exists((string) $element['name']) || $input->exists($group . '.' . (string) $element['name']);
+
+			// If the field is disabled but it is passed in the request this is invalid as disabled fields are not added to the request
+			if ($disabled && $fieldExistsInRequestData)
+			{
+				return new \RuntimeException(\JText::sprintf('JLIB_FORM_VALIDATE_FIELD_INVALID', $element['name']));
+			}
 		}
 
 		if ($required)


### PR DESCRIPTION
### Summary of Changes

One of the security patches for 3.8.12 adds an extra check in `Joomla\CMS\Form\Form::validateField()` and makes use of an optional method parameter to do this.  For the single legitimate call to this method in the production code, this assumption is OK to make, but it has broken our unit tests and potentially causes issues if someone has subclassed this class and calls the method omitting the optional `$input` argument.  Therefore, we must check the argument is provided before using it.

### Testing Instructions

I think you're going to have to rely on the tests and code review for this one.  There is not a use in this repo that can create this issue outside the unit test suite, and I'm not about to build an extension package to try and recreate this bug so it can be "easily" validated.