### PR TITLE
[4.0][SQL] custom_data, system_data has been removed

### DIFF
--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2017-04-25.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2017-04-25.sql
@@ -1,5 +1,5 @@
-INSERT INTO "#__extensions" ("extension_id", "name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "manifest_cache", "params", "custom_data", "system_data", "checked_out", "checked_out_time", "ordering", "state") VALUES
-(481, 'plg_filesystem_local', 'plugin', 'local', 'filesystem', 0, 1, 1, 0, '', '{}', '', '', 0, '1970-01-01 00:00:00', 0, 0),
-(482, 'plg_media-action_crop', 'plugin', 'crop', 'media-action', 0, 1, 1, 0, '', '{}', '', '', 0, '1970-01-01 00:00:00', 0, 0),
-(483, 'plg_media-action_resize', 'plugin', 'resize', 'media-action', 0, 1, 1, 0, '', '{}', '', '', 0, '1970-01-01 00:00:00', 0, 0),
-(484, 'plg_media-action_rotate', 'plugin', 'rotate', 'media-action', 0, 1, 1, 0, '', '{}', '', '', 0, '1970-01-01 00:00:00', 0, 0),;
+INSERT INTO "#__extensions" ("extension_id", "name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "manifest_cache", "params", "checked_out", "checked_out_time", "ordering", "state") VALUES
+(481, 'plg_filesystem_local', 'plugin', 'local', 'filesystem', 0, 1, 1, 0, '', '{}', 0, '1970-01-01 00:00:00', 0, 0),
+(482, 'plg_media-action_crop', 'plugin', 'crop', 'media-action', 0, 1, 1, 0, '', '{}', 0, '1970-01-01 00:00:00', 0, 0),
+(483, 'plg_media-action_resize', 'plugin', 'resize', 'media-action', 0, 1, 1, 0, '', '{}', 0, '1970-01-01 00:00:00', 0, 0),
+(484, 'plg_media-action_rotate', 'plugin', 'rotate', 'media-action', 0, 1, 1, 0, '', '{}', 0, '1970-01-01 00:00:00', 0, 0),;

--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2017-10-10.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2017-10-10.sql
@@ -1,5 +1,5 @@
-INSERT INTO "#__extensions" ("extension_id", "name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "manifest_cache", "params", "custom_data", "system_data", "checked_out", "checked_out_time", "ordering", "state") VALUES
-(487, 'plg_system_httpheaders', 'plugin', 'httpheaders', 'system', 0, 0, 1, 0, '', '{}', '', '', 0, '1970-01-01 00:00:00', 0, 0);
+INSERT INTO "#__extensions" ("extension_id", "name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "manifest_cache", "params", "checked_out", "checked_out_time", "ordering", "state") VALUES
+(487, 'plg_system_httpheaders', 'plugin', 'httpheaders', 'system', 0, 0, 1, 0, '', '{}', 0, '1970-01-01 00:00:00', 0, 0);
 
 INSERT INTO "#__postinstall_messages" ("extension_id", "title_key", "description_key", "action_key", "language_extension", "language_client_id", "type", "action_file", "action", "condition_file", "condition_method", "version_introduced", "enabled")
 VALUES

--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2018-06-11.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2018-06-11.sql
@@ -1,4 +1,4 @@
 INSERT INTO "#__extensions"
-("extension_id", "package_id", "name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "manifest_cache", "params", "custom_data", "system_data", "checked_out", "checked_out_time", "ordering", "state")
+("extension_id", "package_id", "name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "manifest_cache", "params", "checked_out", "checked_out_time", "ordering", "state")
 VALUES
-  (488, 0, 'plg_sampledata_blog', 'plugin', 'multilang', 'sampledata', 0, 0, 1, 0, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0);
+  (488, 0, 'plg_sampledata_blog', 'plugin', 'multilang', 'sampledata', 0, 0, 1, 0, '', '', 0, '1970-01-01 00:00:00', 0, 0);


### PR DESCRIPTION
Pull Request for Issue 
wrong update sql for postgresql

### Summary of Changes
these fields` custom_data`, `system_data` from  `#__extensions` table has been removed since 4.0.0-2017-03-18.sql
