### PR TITLE
[4.0] Extension Update count

### DIFF
--- a/build/media_src/plg_quickicon_extensionupdate/js/extensionupdatecheck.es6.js
+++ b/build/media_src/plg_quickicon_extensionupdate/js/extensionupdatecheck.es6.js
@@ -31,7 +31,7 @@
             } else {
               const messages = {
                 message: [
-                  `${Joomla.JText._('PLG_QUICKICON_EXTENSIONUPDATE_UPDATEFOUND_MESSAGE').replace('%s', `<span class="badge badge-light">${updateInfoList.length}</span>`)}<button class="btn btn-primary" onclick="document.location='${options.url}'">${Joomla.JText._('PLG_QUICKICON_EXTENSIONUPDATE_UPDATEFOUND_BUTTON')}</button>`,
+                  `${Joomla.JText._('PLG_QUICKICON_EXTENSIONUPDATE_UPDATEFOUND_MESSAGE').replace('%s', `<span class="badge badge-pill badge-danger">${updateInfoList.length}</span>`)}<button class="btn btn-primary" onclick="document.location='${options.url}'">${Joomla.JText._('PLG_QUICKICON_EXTENSIONUPDATE_UPDATEFOUND_BUTTON')}</button>`,
                 ],
                 error: ['info'],
               };


### PR DESCRIPTION
As shown in the screenshots if an extension is available the count is on a grey background tht is hrd to see and I would have expected to see it inn red similar to the count of postinstallation messages.

To test you will need to npm i and to trick joomla to find an update which I did by changing the version number of the french language file

### Before
<img width="640" alt="chrome_2018-08-29_12-53-26" src="https://user-images.githubusercontent.com/1296369/44786168-2dae4680-ab8b-11e8-956f-539cdff6f54c.png">


### After
<img width="600" alt="chrome_2018-08-29_12-53-49" src="https://user-images.githubusercontent.com/1296369/44786175-356deb00-ab8b-11e8-80d4-0e7d66e2e742.png">
