### PR TITLE
[4.0] [a11y] Hide empty nav

### DIFF
--- a/layouts/joomla/pagination/links.php
+++ b/layouts/joomla/pagination/links.php
@@ -50,38 +50,42 @@ if ($currentPage >= $step)
 	}
 }
 ?>
-<nav role="navigation" aria-label="<?php echo Text::_('JLIB_HTML_PAGINATION'); ?>">
-	<div class="pagination pagination-toolbar text-center">
 
-		<?php if ($showLimitBox) : ?>
-			<div class="limit float-right">
-				<?php echo Text::_('JGLOBAL_DISPLAY_NUM') . $list['limitfield']; ?>
-			</div>
-		<?php endif; ?>
 
-		<?php if ($showPagesLinks && (!empty($pages))) : ?>
-			<ul class="pagination ml-0 mb-4">
-				<?php echo LayoutHelper::render('joomla.pagination.link', $pages['start']); ?>
-				<?php echo LayoutHelper::render('joomla.pagination.link', $pages['previous']); ?>
-				<?php foreach ($pages['pages'] as $k => $page) : ?>
+<?php if (!empty($pages)) : ?>
+	<nav role="navigation" aria-label="<?php echo Text::_('JLIB_HTML_PAGINATION'); ?>">
+		<div class="pagination pagination-toolbar text-center">
 
-					<?php $output = LayoutHelper::render('joomla.pagination.link', $page); ?>
-					<?php if (in_array($k, range($range * $step - ($step + 1), $range * $step), true)) : ?>
-						<?php if (($k % $step === 0 || $k === $range * $step - ($step + 1)) && $k !== $currentPage && $k !== $range * $step - $step) : ?>
-							<?php $output = preg_replace('#(<a.*?>).*?(</a>)#', '$1...$2', $output); ?>
+			<?php if ($showLimitBox) : ?>
+				<div class="limit float-right">
+					<?php echo Text::_('JGLOBAL_DISPLAY_NUM') . $list['limitfield']; ?>
+				</div>
+			<?php endif; ?>
+
+			<?php if ($showPagesLinks) : ?>
+				<ul class="pagination ml-0 mb-4">
+					<?php echo LayoutHelper::render('joomla.pagination.link', $pages['start']); ?>
+					<?php echo LayoutHelper::render('joomla.pagination.link', $pages['previous']); ?>
+					<?php foreach ($pages['pages'] as $k => $page) : ?>
+
+						<?php $output = LayoutHelper::render('joomla.pagination.link', $page); ?>
+						<?php if (in_array($k, range($range * $step - ($step + 1), $range * $step), true)) : ?>
+							<?php if (($k % $step === 0 || $k === $range * $step - ($step + 1)) && $k !== $currentPage && $k !== $range * $step - $step) : ?>
+								<?php $output = preg_replace('#(<a.*?>).*?(</a>)#', '$1...$2', $output); ?>
+							<?php endif; ?>
 						<?php endif; ?>
-					<?php endif; ?>
 
-					<?php echo $output; ?>
-				<?php endforeach; ?>
-				<?php echo LayoutHelper::render('joomla.pagination.link', $pages['next']); ?>
-				<?php echo LayoutHelper::render('joomla.pagination.link', $pages['end']); ?>
-			</ul>
-		<?php endif; ?>
+						<?php echo $output; ?>
+					<?php endforeach; ?>
+					<?php echo LayoutHelper::render('joomla.pagination.link', $pages['next']); ?>
+					<?php echo LayoutHelper::render('joomla.pagination.link', $pages['end']); ?>
+				</ul>
+			<?php endif; ?>
 
-		<?php if ($showLimitStart) : ?>
-			<input type="hidden" name="<?php echo $list['prefix']; ?>limitstart" value="<?php echo $list['limitstart']; ?>">
-		<?php endif; ?>
+			<?php if ($showLimitStart) : ?>
+				<input type="hidden" name="<?php echo $list['prefix']; ?>limitstart" value="<?php echo $list['limitstart']; ?>">
+			<?php endif; ?>
 
-	</div>
-</nav>
+		</div>
+	</nav>
+<?php endif; ?>


### PR DESCRIPTION
This pr moves the if statement outside of the NAV container so that we dont end up with an empty nav when there is no pagination

To test go to any list view in the admin which does not have an enough entries for their to be any pagination. View source and you will find a `<nav>`container with no content. After the PR the container is not present.
