### PR TITLE
[4.0] Multilingual : Correcting info-block category and parent category urls

### DIFF
--- a/components/com_content/Model/ArticleModel.php
+++ b/components/com_content/Model/ArticleModel.php
@@ -115,7 +115,8 @@ class ArticleModel extends ItemModel
 					->where($db->quoteName('wa.stage_id') . ' = ' . $db->quoteName('ws.id'));
 
 				// Join on category table.
-				$query->select('c.title AS category_title, c.alias AS category_alias, c.access AS category_access')
+				$query->select('c.title AS category_title, c.alias AS category_alias, c.access AS category_access,' .
+						'c.language AS category_language')
 					->innerJoin('#__categories AS c on c.id = a.catid')
 					->where('c.published > 0');
 
@@ -130,7 +131,8 @@ class ArticleModel extends ItemModel
 				}
 
 				// Join over the categories to get parent category titles
-				$query->select('parent.title as parent_title, parent.id as parent_id, parent.path as parent_route, parent.alias as parent_alias')
+				$query->select('parent.title as parent_title, parent.id as parent_id, parent.path as parent_route,' .
+						'parent.alias as parent_alias, parent.language as parent_language')
 					->join('LEFT', '#__categories as parent ON parent.id = c.parent_id');
 
 				// Join on voting table

--- a/components/com_content/Model/ArticlesModel.php
+++ b/components/com_content/Model/ArticlesModel.php
@@ -251,7 +251,8 @@ class ArticlesModel extends ListModel
 			->join('LEFT', '#__workflow_stages AS ws ON ws.id = wa.stage_id');
 
 		// Join over the categories.
-		$query->select('c.title AS category_title, c.path AS category_route, c.access AS category_access, c.alias AS category_alias')
+		$query->select('c.title AS category_title, c.path AS category_route, c.access AS category_access, c.alias AS category_alias,' .
+				'c.language AS category_language')
 			->select('c.published, c.published AS parents_published, c.lft')
 			->join('LEFT', '#__categories AS c ON c.id = a.catid');
 
@@ -262,7 +263,8 @@ class ArticlesModel extends ListModel
 			->join('LEFT', '#__users AS uam ON uam.id = a.modified_by');
 
 		// Join over the categories to get parent category titles
-		$query->select('parent.title as parent_title, parent.id as parent_id, parent.path as parent_route, parent.alias as parent_alias')
+		$query->select('parent.title as parent_title, parent.id as parent_id, parent.path as parent_route, parent.alias as parent_alias,' .
+				'parent.language as parent_language')
 			->join('LEFT', '#__categories as parent ON parent.id = c.parent_id');
 
 		if (PluginHelper::isEnabled('content', 'vote'))

--- a/components/com_content/View/Archive/HtmlView.php
+++ b/components/com_content/View/Archive/HtmlView.php
@@ -115,13 +115,16 @@ class HtmlView extends BaseHtmlView
 
 		foreach ($items as $item)
 		{
-			$item->catslug     = $item->category_alias ? ($item->catid . ':' . $item->category_alias) : $item->catid;
-			$item->parent_slug = $item->parent_alias ? ($item->parent_id . ':' . $item->parent_alias) : $item->parent_id;
+			$item->slug           = $item->alias ? ($item->id . ':' . $item->alias) : $item->id;
+			$item->catslug        = $item->category_alias ? ($item->catid . ':' . $item->category_alias) : $item->catid;
+			$item->parent_slug    = $item->parent_alias ? ($item->parent_id . ':' . $item->parent_alias) : $item->parent_id;
+			$item->catlanguage    = $item->category_language;
+			$item->parentlanguage = $item->parent_language;
 
 			// No link for ROOT category
 			if ($item->parent_alias === 'root')
 			{
-				$item->parent_slug = null;
+				$item->parent_slug    = null;
 			}
 
 			$item->event = new \stdClass;

--- a/components/com_content/View/Archive/HtmlView.php
+++ b/components/com_content/View/Archive/HtmlView.php
@@ -115,16 +115,12 @@ class HtmlView extends BaseHtmlView
 
 		foreach ($items as $item)
 		{
-			$item->slug           = $item->alias ? ($item->id . ':' . $item->alias) : $item->id;
-			$item->catslug        = $item->category_alias ? ($item->catid . ':' . $item->category_alias) : $item->catid;
-			$item->parent_slug    = $item->parent_alias ? ($item->parent_id . ':' . $item->parent_alias) : $item->parent_id;
-			$item->catlanguage    = $item->category_language;
-			$item->parentlanguage = $item->parent_language;
+			$item->slug = $item->alias ? ($item->id . ':' . $item->alias) : $item->id;
 
 			// No link for ROOT category
 			if ($item->parent_alias === 'root')
 			{
-				$item->parent_slug    = null;
+				$item->parent_id = null;
 			}
 
 			$item->event = new \stdClass;

--- a/components/com_content/View/Article/HtmlView.php
+++ b/components/com_content/View/Article/HtmlView.php
@@ -107,16 +107,12 @@ class HtmlView extends BaseHtmlView
 		$item->tagLayout = new FileLayout('joomla.content.tags');
 
 		// Add router helpers.
-		$item->slug           = $item->alias ? ($item->id . ':' . $item->alias) : $item->id;
-		$item->catslug        = $item->category_alias ? ($item->catid . ':' . $item->category_alias) : $item->catid;
-		$item->catlanguage    = $item->category_language;
-		$item->parent_slug    = $item->parent_alias ? ($item->parent_id . ':' . $item->parent_alias) : $item->parent_id;
-		$item->parentlanguage = $item->parent_language;
+		$item->slug = $item->alias ? ($item->id . ':' . $item->alias) : $item->id;
 
 		// No link for ROOT category
 		if ($item->parent_alias === 'root')
 		{
-			$item->parent_slug = null;
+			$item->parent_id = null;
 		}
 
 		// TODO: Change based on shownoauth

--- a/components/com_content/View/Article/HtmlView.php
+++ b/components/com_content/View/Article/HtmlView.php
@@ -107,9 +107,11 @@ class HtmlView extends BaseHtmlView
 		$item->tagLayout = new FileLayout('joomla.content.tags');
 
 		// Add router helpers.
-		$item->slug        = $item->alias ? ($item->id . ':' . $item->alias) : $item->id;
-		$item->catslug     = $item->category_alias ? ($item->catid . ':' . $item->category_alias) : $item->catid;
-		$item->parent_slug = $item->parent_alias ? ($item->parent_id . ':' . $item->parent_alias) : $item->parent_id;
+		$item->slug           = $item->alias ? ($item->id . ':' . $item->alias) : $item->id;
+		$item->catslug        = $item->category_alias ? ($item->catid . ':' . $item->category_alias) : $item->catid;
+		$item->catlanguage    = $item->category_language;
+		$item->parent_slug    = $item->parent_alias ? ($item->parent_id . ':' . $item->parent_alias) : $item->parent_id;
+		$item->parentlanguage = $item->parent_language;
 
 		// No link for ROOT category
 		if ($item->parent_alias === 'root')
@@ -302,7 +304,7 @@ class HtmlView extends BaseHtmlView
 
 			while ($category && ($menu->query['option'] !== 'com_content' || $menu->query['view'] === 'article' || $id != $category->id) && $category->id > 1)
 			{
-				$path[]   = array('title' => $category->title, 'link' => \ContentHelperRoute::getCategoryRoute($category->id));
+				$path[]   = array('title' => $category->title, 'link' => \ContentHelperRoute::getCategoryRoute($category->id, $category->language));
 				$category = $category->getParent();
 			}
 

--- a/components/com_content/View/Category/HtmlView.php
+++ b/components/com_content/View/Category/HtmlView.php
@@ -93,16 +93,12 @@ class HtmlView extends CategoryView
 		// Compute the article slugs and prepare introtext (runs content plugins).
 		foreach ($this->items as $item)
 		{
-			$item->slug           = $item->alias ? ($item->id . ':' . $item->alias) : $item->id;
-			$item->catslug        = $item->category_alias ? ($item->catid . ':' . $item->category_alias) : $item->catid;
-			$item->catlanguage    = $item->category_language;
-			$item->parent_slug    = $item->parent_alias ? ($item->parent_id . ':' . $item->parent_alias) : $item->parent_id;
-			$item->parentlanguage = $item->parent_language;
+			$item->slug = $item->alias ? ($item->id . ':' . $item->alias) : $item->id;
 
 			// No link for ROOT category
 			if ($item->parent_alias === 'root')
 			{
-				$item->parent_slug = null;
+				$item->parent_id = null;
 			}
 
 			$item->event   = new \stdClass;

--- a/components/com_content/View/Category/HtmlView.php
+++ b/components/com_content/View/Category/HtmlView.php
@@ -93,9 +93,11 @@ class HtmlView extends CategoryView
 		// Compute the article slugs and prepare introtext (runs content plugins).
 		foreach ($this->items as $item)
 		{
-			$item->slug = $item->alias ? ($item->id . ':' . $item->alias) : $item->id;
-
-			$item->parent_slug = $item->parent_alias ? ($item->parent_id . ':' . $item->parent_alias) : $item->parent_id;
+			$item->slug           = $item->alias ? ($item->id . ':' . $item->alias) : $item->id;
+			$item->catslug        = $item->category_alias ? ($item->catid . ':' . $item->category_alias) : $item->catid;
+			$item->catlanguage    = $item->category_language;
+			$item->parent_slug    = $item->parent_alias ? ($item->parent_id . ':' . $item->parent_alias) : $item->parent_id;
+			$item->parentlanguage = $item->parent_language;
 
 			// No link for ROOT category
 			if ($item->parent_alias === 'root')
@@ -103,7 +105,6 @@ class HtmlView extends CategoryView
 				$item->parent_slug = null;
 			}
 
-			$item->catslug = $item->category_alias ? ($item->catid . ':' . $item->category_alias) : $item->catid;
 			$item->event   = new \stdClass;
 
 			// Old plugins: Ensure that text property is available

--- a/components/com_content/View/Category/HtmlView.php
+++ b/components/com_content/View/Category/HtmlView.php
@@ -287,7 +287,7 @@ class HtmlView extends CategoryView
 
 			while (($menu->query['option'] !== 'com_content' || $menu->query['view'] === 'article' || $id != $category->id) && $category->id > 1)
 			{
-				$path[] = array('title' => $category->title, 'link' => \ContentHelperRoute::getCategoryRoute($category->id));
+				$path[] = array('title' => $category->title, 'link' => \ContentHelperRoute::getCategoryRoute($category->id, $category->language));
 				$category = $category->getParent();
 			}
 

--- a/components/com_content/View/Featured/HtmlView.php
+++ b/components/com_content/View/Featured/HtmlView.php
@@ -140,16 +140,12 @@ class HtmlView extends BaseHtmlView
 		// Compute the article slugs and prepare introtext (runs content plugins).
 		foreach ($items as &$item)
 		{
-			$item->slug           = $item->alias ? ($item->id . ':' . $item->alias) : $item->id;
-			$item->catslug        = $item->category_alias ? ($item->catid . ':' . $item->category_alias) : $item->catid;
-			$item->parent_slug    = $item->parent_alias ? ($item->parent_id . ':' . $item->parent_alias) : $item->parent_id;
-			$item->catlanguage    = $item->category_language;
-			$item->parentlanguage = $item->parent_language;
+			$item->slug = $item->alias ? ($item->id . ':' . $item->alias) : $item->id;
 
 			// No link for ROOT category
 			if ($item->parent_alias === 'root')
 			{
-				$item->parent_slug = null;
+				$item->parent_id = null;
 			}
 
 			$item->event = new \stdClass;

--- a/components/com_content/View/Featured/HtmlView.php
+++ b/components/com_content/View/Featured/HtmlView.php
@@ -140,9 +140,11 @@ class HtmlView extends BaseHtmlView
 		// Compute the article slugs and prepare introtext (runs content plugins).
 		foreach ($items as &$item)
 		{
-			$item->slug        = $item->alias ? ($item->id . ':' . $item->alias) : $item->id;
-			$item->catslug     = $item->category_alias ? ($item->catid . ':' . $item->category_alias) : $item->catid;
-			$item->parent_slug = $item->parent_alias ? ($item->parent_id . ':' . $item->parent_alias) : $item->parent_id;
+			$item->slug           = $item->alias ? ($item->id . ':' . $item->alias) : $item->id;
+			$item->catslug        = $item->category_alias ? ($item->catid . ':' . $item->category_alias) : $item->catid;
+			$item->parent_slug    = $item->parent_alias ? ($item->parent_id . ':' . $item->parent_alias) : $item->parent_id;
+			$item->catlanguage    = $item->category_language;
+			$item->parentlanguage = $item->parent_language;
 
 			// No link for ROOT category
 			if ($item->parent_alias === 'root')

--- a/components/com_content/helpers/route.php
+++ b/components/com_content/helpers/route.php
@@ -84,11 +84,6 @@ abstract class ContentHelperRoute
 				{
 					$link .= '&lang=' . $language;
 				}
-				else
-				{
-					$lang  = Factory::getLanguage()->getTag();
-					$link .= '&lang=' . $lang;
-				}
 			}
 		}
 

--- a/components/com_content/helpers/route.php
+++ b/components/com_content/helpers/route.php
@@ -10,7 +10,6 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Categories\CategoryNode;
-use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Multilanguage;
 
 /**

--- a/components/com_content/helpers/route.php
+++ b/components/com_content/helpers/route.php
@@ -78,12 +78,9 @@ abstract class ContentHelperRoute
 		{
 			$link = 'index.php?option=com_content&view=category&id=' . $id;
 
-			if ($language && Multilanguage::isEnabled())
+			if ($language && $language !== '*' && Multilanguage::isEnabled())
 			{
-				if ($language !== '*')
-				{
-					$link .= '&lang=' . $language;
-				}
+				$link .= '&lang=' . $language;
 			}
 		}
 

--- a/components/com_content/helpers/route.php
+++ b/components/com_content/helpers/route.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Categories\CategoryNode;
+use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Multilanguage;
 
 /**
@@ -77,17 +78,17 @@ abstract class ContentHelperRoute
 		{
 			$link = 'index.php?option=com_content&view=category&id=' . $id;
 
-			if ($language && $language !== '*' && Multilanguage::isEnabled())
+			if ($language && Multilanguage::isEnabled())
 			{
-				$link .= '&lang=' . $language;
-			}
-
-			$jinput = JFactory::getApplication()->input;
-			$layout = $jinput->get('layout');
-
-			if ($layout !== '')
-			{
-				$link .= '&layout=' . $layout;
+				if ($language !== '*')
+				{
+					$link .= '&lang=' . $language;
+				}
+				else
+				{
+					$lang  = Factory::getLanguage()->getTag();
+					$link .= '&lang=' . $lang;
+				}
 			}
 		}
 

--- a/components/com_content/tmpl/archive/default_items.php
+++ b/components/com_content/tmpl/archive/default_items.php
@@ -60,7 +60,8 @@ $params = $this->params;
 						<div class="parent-category-name">
 							<?php $title = $this->escape($item->parent_title); ?>
 							<?php if ($params->get('link_parent_category') && !empty($item->parent_slug)) : ?>
-								<?php $url = '<a href="' . Route::_(ContentHelperRoute::getCategoryRoute($item->parent_slug)) . '" itemprop="genre">' . $title . '</a>'; ?>
+								<?php $url = '<a href="' . Route::_(ContentHelperRoute::getCategoryRoute($item->parent_slug),
+										$item->parentlanguage ) . '" itemprop="genre">' . $title . '</a>'; ?>
 								<?php echo JText::sprintf('COM_CONTENT_PARENT', $url); ?>
 							<?php else : ?>
 								<?php echo JText::sprintf('COM_CONTENT_PARENT', '<span itemprop="genre">' . $title . '</span>'); ?>
@@ -73,7 +74,8 @@ $params = $this->params;
 						<div class="category-name">
 							<?php $title = $this->escape($item->category_title); ?>
 							<?php if ($params->get('link_category') && $item->catslug) : ?>
-								<?php $url = '<a href="' . Route::_(ContentHelperRoute::getCategoryRoute($item->catslug)) . '" itemprop="genre">' . $title . '</a>'; ?>
+								<?php $url = '<a href="' . Route::_(ContentHelperRoute::getCategoryRoute($item->catslug,
+										$item->catlanguage)) . '" itemprop="genre">' . $title . '</a>'; ?>
 								<?php echo JText::sprintf('COM_CONTENT_CATEGORY', $url); ?>
 							<?php else : ?>
 								<?php echo JText::sprintf('COM_CONTENT_CATEGORY', '<span itemprop="genre">' . $title . '</span>'); ?>
@@ -146,7 +148,8 @@ $params = $this->params;
 							<div class="parent-category-name">
 								<?php $title = $this->escape($item->parent_title); ?>
 								<?php if ($params->get('link_parent_category') && $item->parent_slug) : ?>
-									<?php $url = '<a href="' . Route::_(ContentHelperRoute::getCategoryRoute($item->parent_slug)) . '" itemprop="genre">' . $title . '</a>'; ?>
+									<?php $url = '<a href="' . Route::_(ContentHelperRoute::getCategoryRoute($item->parent_slug,
+											$item->parentlanguage)) . '" itemprop="genre">' . $title . '</a>'; ?>
 									<?php echo JText::sprintf('COM_CONTENT_PARENT', $url); ?>
 								<?php else : ?>
 									<?php echo JText::sprintf('COM_CONTENT_PARENT', '<span itemprop="genre">' . $title . '</span>'); ?>
@@ -159,7 +162,7 @@ $params = $this->params;
 							<div class="category-name">
 								<?php $title = $this->escape($item->category_title); ?>
 								<?php if ($params->get('link_category') && $item->catslug) : ?>
-									<?php $url = '<a href="' . Route::_(ContentHelperRoute::getCategoryRoute($item->catslug)) . '" itemprop="genre">' . $title . '</a>'; ?>
+									<?php $url = '<a href="' . Route::_(ContentHelperRoute::getCategoryRoute($item->catslug, $item->catlanguage)) . '" itemprop="genre">' . $title . '</a>'; ?>
 									<?php echo JText::sprintf('COM_CONTENT_CATEGORY', $url); ?>
 								<?php else : ?>
 									<?php echo JText::sprintf('COM_CONTENT_CATEGORY', '<span itemprop="genre">' . $title . '</span>'); ?>
@@ -223,6 +226,6 @@ $params = $this->params;
 		</p>
 	<?php endif; ?>
 	<div class="com-content-archive__pagination">
-		<?php echo $this->pagination->getPagesLinks(); ?>		
+		<?php echo $this->pagination->getPagesLinks(); ?>
 	</div>
 </div>

--- a/components/com_content/tmpl/archive/default_items.php
+++ b/components/com_content/tmpl/archive/default_items.php
@@ -55,13 +55,15 @@ $params = $this->params;
 					<?php echo JText::_('COM_CONTENT_ARTICLE_INFO'); ?>
 				</dt>
 
-				<?php if ($params->get('show_parent_category') && !empty($item->parent_slug)) : ?>
+				<?php if ($params->get('show_parent_category') && !empty($item->parent_id)) : ?>
 					<dd>
 						<div class="parent-category-name">
 							<?php $title = $this->escape($item->parent_title); ?>
-							<?php if ($params->get('link_parent_category') && !empty($item->parent_slug)) : ?>
-								<?php $url = '<a href="' . Route::_(ContentHelperRoute::getCategoryRoute($item->parent_slug),
-										$item->parentlanguage ) . '" itemprop="genre">' . $title . '</a>'; ?>
+							<?php if ($params->get('link_parent_category') && !empty($item->parent_id)) : ?>
+								<?php $url = '<a href="' . Route::_(
+									ContentHelperRoute::getCategoryRoute($item->parent_id), $item->parent_language
+									)
+									. '" itemprop="genre">' . $title . '</a>'; ?>
 								<?php echo JText::sprintf('COM_CONTENT_PARENT', $url); ?>
 							<?php else : ?>
 								<?php echo JText::sprintf('COM_CONTENT_PARENT', '<span itemprop="genre">' . $title . '</span>'); ?>
@@ -73,9 +75,11 @@ $params = $this->params;
 					<dd>
 						<div class="category-name">
 							<?php $title = $this->escape($item->category_title); ?>
-							<?php if ($params->get('link_category') && $item->catslug) : ?>
-								<?php $url = '<a href="' . Route::_(ContentHelperRoute::getCategoryRoute($item->catslug,
-										$item->catlanguage)) . '" itemprop="genre">' . $title . '</a>'; ?>
+							<?php if ($params->get('link_category') && $item->catid) : ?>
+								<?php $url = '<a href="' . Route::_(
+									ContentHelperRoute::getCategoryRoute($item->catid, $item->category_language)
+									)
+									. '" itemprop="genre">' . $title . '</a>'; ?>
 								<?php echo JText::sprintf('COM_CONTENT_CATEGORY', $url); ?>
 							<?php else : ?>
 								<?php echo JText::sprintf('COM_CONTENT_CATEGORY', '<span itemprop="genre">' . $title . '</span>'); ?>
@@ -143,13 +147,15 @@ $params = $this->params;
 				<dt class="article-info-term"><?php echo JText::_('COM_CONTENT_ARTICLE_INFO'); ?></dt>
 
 				<?php if ($info == 1) : ?>
-					<?php if ($params->get('show_parent_category') && !empty($item->parent_slug)) : ?>
+					<?php if ($params->get('show_parent_category') && !empty($item->parent_id)) : ?>
 						<dd>
 							<div class="parent-category-name">
 								<?php $title = $this->escape($item->parent_title); ?>
-								<?php if ($params->get('link_parent_category') && $item->parent_slug) : ?>
-									<?php $url = '<a href="' . Route::_(ContentHelperRoute::getCategoryRoute($item->parent_slug,
-											$item->parentlanguage)) . '" itemprop="genre">' . $title . '</a>'; ?>
+								<?php if ($params->get('link_parent_category') && $item->parent_id) : ?>
+									<?php $url = '<a href="' . Route::_(
+										ContentHelperRoute::getCategoryRoute($item->parent_id, $item->parent_language)
+										)
+										. '" itemprop="genre">' . $title . '</a>'; ?>
 									<?php echo JText::sprintf('COM_CONTENT_PARENT', $url); ?>
 								<?php else : ?>
 									<?php echo JText::sprintf('COM_CONTENT_PARENT', '<span itemprop="genre">' . $title . '</span>'); ?>
@@ -161,8 +167,11 @@ $params = $this->params;
 						<dd>
 							<div class="category-name">
 								<?php $title = $this->escape($item->category_title); ?>
-								<?php if ($params->get('link_category') && $item->catslug) : ?>
-									<?php $url = '<a href="' . Route::_(ContentHelperRoute::getCategoryRoute($item->catslug, $item->catlanguage)) . '" itemprop="genre">' . $title . '</a>'; ?>
+								<?php if ($params->get('link_category') && $item->catid) : ?>
+									<?php $url = '<a href="' . Route::_(
+										ContentHelperRoute::getCategoryRoute($item->catslug, $item->category_language)
+										)
+										. '" itemprop="genre">' . $title . '</a>'; ?>
 									<?php echo JText::sprintf('COM_CONTENT_CATEGORY', $url); ?>
 								<?php else : ?>
 									<?php echo JText::sprintf('COM_CONTENT_CATEGORY', '<span itemprop="genre">' . $title . '</span>'); ?>

--- a/components/com_content/tmpl/archive/default_items.php
+++ b/components/com_content/tmpl/archive/default_items.php
@@ -61,7 +61,7 @@ $params = $this->params;
 							<?php $title = $this->escape($item->parent_title); ?>
 							<?php if ($params->get('link_parent_category') && !empty($item->parent_id)) : ?>
 								<?php $url = '<a href="' . Route::_(
-									ContentHelperRoute::getCategoryRoute($item->parent_id), $item->parent_language
+									ContentHelperRoute::getCategoryRoute($item->parent_id, $item->parent_language)
 									)
 									. '" itemprop="genre">' . $title . '</a>'; ?>
 								<?php echo JText::sprintf('COM_CONTENT_PARENT', $url); ?>
@@ -169,7 +169,7 @@ $params = $this->params;
 								<?php $title = $this->escape($item->category_title); ?>
 								<?php if ($params->get('link_category') && $item->catid) : ?>
 									<?php $url = '<a href="' . Route::_(
-										ContentHelperRoute::getCategoryRoute($item->catslug, $item->category_language)
+										ContentHelperRoute::getCategoryRoute($item->catid, $item->category_language)
 										)
 										. '" itemprop="genre">' . $title . '</a>'; ?>
 									<?php echo JText::sprintf('COM_CONTENT_CATEGORY', $url); ?>

--- a/components/com_content/tmpl/category/blog_children.php
+++ b/components/com_content/tmpl/category/blog_children.php
@@ -32,7 +32,7 @@ if ($this->maxLevel != 0 && count($this->children[$this->category->id]) > 0) : ?
 							<?php echo $child->getNumItems(true); ?>
 						</span>
 					<?php endif; ?>
-					<a href="<?php echo Route::_(ContentHelperRoute::getCategoryRoute($child->id)); ?>">
+					<a href="<?php echo Route::_(ContentHelperRoute::getCategoryRoute($child->id, $child->language)); ?>">
 					<?php echo $this->escape($child->title); ?></a>
 
 					<?php if ($this->maxLevel > 1 && count($child->getChildren()) > 0) : ?>
@@ -40,7 +40,7 @@ if ($this->maxLevel != 0 && count($this->children[$this->category->id]) > 0) : ?
 					<?php endif; ?>
 				</h3>
 				<?php else : ?>
-				<h3 class="page-header item-title"><a href="<?php echo Route::_(ContentHelperRoute::getCategoryRoute($child->id)); ?>">
+				<h3 class="page-header item-title"><a href="<?php echo Route::_(ContentHelperRoute::getCategoryRoute($child->id, $child->language)); ?>">
 					<?php echo $this->escape($child->title); ?></a>
 					<?php if ( $this->params->get('show_cat_num_articles', 1)) : ?>
 						<span class="badge badge-info tip hasTooltip" title="<?php echo HTMLHelper::_('tooltipText', 'COM_CONTENT_NUM_ITEMS_TIP'); ?>">

--- a/components/com_content/tmpl/category/default_children.php
+++ b/components/com_content/tmpl/category/default_children.php
@@ -32,7 +32,7 @@ $groups = $user->getAuthorisedViewLevels();
 							<?php echo $child->getNumItems(true); ?>
 						</span>
 					<?php endif; ?>
-					<a href="<?php echo Route::_(ContentHelperRoute::getCategoryRoute($child->id)); ?>">
+					<a href="<?php echo Route::_(ContentHelperRoute::getCategoryRoute($child->id, $child->language)); ?>">
 					<?php echo $this->escape($child->title); ?></a>
 
 					<?php if (count($child->getChildren()) > 0 && $this->maxLevel > 1) : ?>
@@ -40,7 +40,7 @@ $groups = $user->getAuthorisedViewLevels();
 					<?php endif; ?>
 				</h3>
 				<?php else : ?>
-				<h3 class="page-header item-title"><a href="<?php echo Route::_(ContentHelperRoute::getCategoryRoute($child->id)); ?>">
+				<h3 class="page-header item-title"><a href="<?php echo Route::_(ContentHelperRoute::getCategoryRoute($child->id, $child->language)); ?>">
 					<?php echo $this->escape($child->title); ?></a>
 					<?php if ( $this->params->get('show_cat_num_articles', 1)) : ?>
 						<span class="badge badge-info tip hasTooltip" title="<?php echo HTMLHelper::_('tooltipText', 'COM_CONTENT_NUM_ITEMS_TIP'); ?>">

--- a/layouts/joomla/content/info_block.php
+++ b/layouts/joomla/content/info_block.php
@@ -30,7 +30,7 @@ $blockPosition = $displayData['params']->get('info_block_position', 0);
 			<?php echo $this->sublayout('author', $displayData); ?>
 		<?php endif; ?>
 
-		<?php if ($displayData['params']->get('show_parent_category') && !empty($displayData['item']->parent_slug)) : ?>
+		<?php if ($displayData['params']->get('show_parent_category') && !empty($displayData['item']->parent_id)) : ?>
 			<?php echo $this->sublayout('parent_category', $displayData); ?>
 		<?php endif; ?>
 

--- a/layouts/joomla/content/info_block/category.php
+++ b/layouts/joomla/content/info_block/category.php
@@ -15,9 +15,11 @@ use Joomla\CMS\Router\Route;
 ?>
 <dd class="category-name">
 	<?php $title = $this->escape($displayData['item']->category_title); ?>
-	<?php if ($displayData['params']->get('link_category') && !empty($displayData['item']->catslug)) : ?>
-		<?php $url = '<a href="' . Route::_(ContentHelperRoute::getCategoryRoute($displayData['item']->catslug,
-				$displayData['item']->catlanguage)) . '" itemprop="genre">' . $title . '</a>'; ?>
+	<?php if ($displayData['params']->get('link_category') && !empty($displayData['item']->catid)) : ?>
+		<?php $url = '<a href="' . Route::_(
+			ContentHelperRoute::getCategoryRoute($displayData['item']->catid, $displayData['item']->category_language)
+			)
+			. '" itemprop="genre">' . $title . '</a>'; ?>
 		<?php echo Text::sprintf('COM_CONTENT_CATEGORY', $url); ?>
 	<?php else : ?>
 		<?php echo Text::sprintf('COM_CONTENT_CATEGORY', '<span itemprop="genre">' . $title . '</span>'); ?>

--- a/layouts/joomla/content/info_block/category.php
+++ b/layouts/joomla/content/info_block/category.php
@@ -15,8 +15,9 @@ use Joomla\CMS\Router\Route;
 ?>
 <dd class="category-name">
 	<?php $title = $this->escape($displayData['item']->category_title); ?>
-	<?php if ($displayData['params']->get('link_category') && $displayData['item']->catslug) : ?>
-		<?php $url = '<a href="' . Route::_(ContentHelperRoute::getCategoryRoute($displayData['item']->catslug)) . '" itemprop="genre">' . $title . '</a>'; ?>
+	<?php if ($displayData['params']->get('link_category') && !empty($displayData['item']->catslug)) : ?>
+		<?php $url = '<a href="' . Route::_(ContentHelperRoute::getCategoryRoute($displayData['item']->catslug,
+				$displayData['item']->catlanguage)) . '" itemprop="genre">' . $title . '</a>'; ?>
 		<?php echo Text::sprintf('COM_CONTENT_CATEGORY', $url); ?>
 	<?php else : ?>
 		<?php echo Text::sprintf('COM_CONTENT_CATEGORY', '<span itemprop="genre">' . $title . '</span>'); ?>

--- a/layouts/joomla/content/info_block/parent_category.php
+++ b/layouts/joomla/content/info_block/parent_category.php
@@ -9,16 +9,17 @@
 
 defined('JPATH_BASE') or die;
 
-use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 
 ?>
 <dd class="parent-category-name">
 	<?php $title = $this->escape($displayData['item']->parent_title); ?>
-	<?php if ($displayData['params']->get('link_parent_category') && !empty($displayData['item']->parent_slug)) : ?>
-		<?php $url = '<a href="' . Route::_(ContentHelperRoute::getCategoryRoute($displayData['item']->parent_slug,
-				$displayData['item']->parent_language)) . '" itemprop="genre">' . $title . '</a>'; ?>
+	<?php if ($displayData['params']->get('link_parent_category') && !empty($displayData['item']->parent_id)) : ?>
+		<?php $url = '<a href="' . Route::_(
+			ContentHelperRoute::getCategoryRoute($displayData['item']->parent_id, $displayData['item']->parent_language)
+			)
+			. '" itemprop="genre">' . $title . '</a>'; ?>
 		<?php echo Text::sprintf('COM_CONTENT_PARENT', $url); ?>
 	<?php else : ?>
 		<?php echo Text::sprintf('COM_CONTENT_PARENT', '<span itemprop="genre">' . $title . '</span>'); ?>

--- a/layouts/joomla/content/info_block/parent_category.php
+++ b/layouts/joomla/content/info_block/parent_category.php
@@ -17,7 +17,8 @@ use Joomla\CMS\Router\Route;
 <dd class="parent-category-name">
 	<?php $title = $this->escape($displayData['item']->parent_title); ?>
 	<?php if ($displayData['params']->get('link_parent_category') && !empty($displayData['item']->parent_slug)) : ?>
-		<?php $url = '<a href="' . Route::_(ContentHelperRoute::getCategoryRoute($displayData['item']->parent_slug)) . '" itemprop="genre">' . $title . '</a>'; ?>
+		<?php $url = '<a href="' . Route::_(ContentHelperRoute::getCategoryRoute($displayData['item']->parent_slug,
+				$displayData['item']->parent_language)) . '" itemprop="genre">' . $title . '</a>'; ?>
 		<?php echo Text::sprintf('COM_CONTENT_PARENT', $url); ?>
 	<?php else : ?>
 		<?php echo Text::sprintf('COM_CONTENT_PARENT', '<span itemprop="genre">' . $title . '</span>'); ?>

--- a/libraries/src/Component/Router/Rules/MenuRules.php
+++ b/libraries/src/Component/Router/Rules/MenuRules.php
@@ -12,6 +12,7 @@ defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Component\Router\RouterView;
+use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Multilanguage;
 
 /**
@@ -76,10 +77,10 @@ class MenuRules implements RulesInterface
 		// Get query language
 		$language = isset($query['lang']) ? $query['lang'] : '*';
 
-		// Set the language to the active one when multilang is enabled and item is tagged to ALL
-		if ($active !== null && Multilanguage::isEnabled() && $language === '*')
+		// Set the language to the current one when multilang is enabled and item is tagged to ALL
+		if (Multilanguage::isEnabled() && $language === '*')
 		{
-			$language = $active->language;
+			$language = Factory::getLanguage()->getTag();
 		}
 
 		if (!isset($this->lookup[$language]))

--- a/libraries/src/Component/Router/Rules/MenuRules.php
+++ b/libraries/src/Component/Router/Rules/MenuRules.php
@@ -12,7 +12,6 @@ defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Component\Router\RouterView;
-use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Multilanguage;
 
 /**
@@ -80,7 +79,7 @@ class MenuRules implements RulesInterface
 		// Set the language to the current one when multilang is enabled and item is tagged to ALL
 		if (Multilanguage::isEnabled() && $language === '*')
 		{
-			$language = Factory::getLanguage()->getTag();
+			$language = $this->router->app->get('language');
 		}
 
 		if (!isset($this->lookup[$language]))

--- a/libraries/src/Component/Router/Rules/MenuRules.php
+++ b/libraries/src/Component/Router/Rules/MenuRules.php
@@ -76,6 +76,12 @@ class MenuRules implements RulesInterface
 		// Get query language
 		$language = isset($query['lang']) ? $query['lang'] : '*';
 
+		// Set the language to the active one when multilang is enabled and item is tagged to ALL
+		if ($active !== null && Multilanguage::isEnabled() && $language === '*')
+		{
+			$language = $active->language;
+		}
+
 		if (!isset($this->lookup[$language]))
 		{
 			$this->buildLookup($language);


### PR DESCRIPTION
Problem: on a multilingual site, when displaying the info-block for articles in frontend , the urls of the category and parent category are real bad.

### Summary of Changes
1. `ContentHelperRoute::getCategoryRoute()` should ALWAYS contain the `$language` variable.
This PR adds it wherever necessary, including in `layouts/joomla/content/info-block/ `corresponding files. Queries are modified to also select the category language. The language is also added in data.

2. `com_content/helpers/route.php` should cope with categories set to ALL languages
The code is modified to take this into account as, in this case, the language to use in the url should be the language of the UI content language.

3. `com_content/helpers/route.php` should not add for example `&layout=cassiopeamyblog` to the end of the sef url when such a specific `html/com_content/category/myblog.etc` menu item type is present in the template.
To solve this, I had to revert https://github.com/joomla/joomla-cms/pull/19681

### Testing Instructions
Install a multilingual site with 2 content languages.
Tests can be done on a single language. Choose en-GB for example as it is easier.

Create some categories and articles in these categories both tagged to the same language [CATen-GB, CATfr-FR].
Create a home blog menu item for each content language to display one CATen-GB and one CATfr-FR
Make sure you create a (hidden or not) `List All Categories` menu item tagged to en-GB in mainmenu en-GB.
=> This is important as any category which has no specific menu item will still get a nice sef url.

Create also a Category set to ALL language and a child category of that category (tagged to ALL or to en-GB). Add to the child category an article tagged to en-GB ("Articletest").
Create a single menu item in mainmenu en-GB to display the "articletest" article.

Now, the second part of the test concerns the revert of the layout code in route.php.
To test this, it is necessary to add a new menu item type.
Find here a .zip of the files to add in `/templates/cassiopeia/html/com_content/category/`
[myblog.zip](https://github.com/joomla/joomla-cms/files/2335647/myblog.zip)

Create a menu item using this type in mainmenu en-GB to display any category not yet displayed by the former menu items.

In Articles Options, make sure show category and link as well as show Parent category and link are set to yes.
Make sure all your menu items use these global settings

### Expected result
When clicking on the Category or Parent category links you should get nice urls 
not containing some stuff like 
`?view=category&id=18`
or
`&layout=cassiopeamyblog` when using the custom menu item type

Instead one may get for example when no menu item for the category 
`/en/allcategories-en-gb/category-all` (here set to ALL)
or
`/en/allcategories-en-gb/category-all/othercaten-gb` (category set to en-GB)

and same for the custom menu item type (myblog menu item type)
![screen shot 2018-08-30 at 12 20 50](https://user-images.githubusercontent.com/869724/44845952-3bc59b00-ac4f-11e8-9266-ca22b1116708.png)


### Note A
Reverting https://github.com/joomla/joomla-cms/pull/19681 is necessary.
We should look for another way to implement this feature.

### Note B
The modifications concerning getCategoryRoute() and route.php should also be done for other components using this method.

@alikon @Hackwar @csthomas