### PR TITLE
Fix language strings in recaptcha plugin

### DIFF
--- a/administrator/language/en-GB/en-GB.plg_captcha_recaptcha.ini
+++ b/administrator/language/en-GB/en-GB.plg_captcha_recaptcha.ini
@@ -39,10 +39,10 @@ PLG_RECAPTCHA_TABINDEX_LABEL="Tabindex"
 PLG_RECAPTCHA_TABINDEX_DESC="The tabindex of the reCAPTCHA widget"
 PLG_RECAPTCHA_CALLBACK_LABEL="Callback"
 PLG_RECAPTCHA_CALLBACK_DESC="(Optional) JavaScript callback, executed after successful reCAPTCHA response"
-PLG_RECAPTCHA_EXPIRED_CALLBACK_LABEL="Expired callback"
-PLG_RECAPTCHA_EXPIRED_CALLBACK_DESC="(Optional) JavaScript callback, executed when the reCAPTCHA expired"
 PLG_RECAPTCHA_ERROR_CALLBACK_LABEL="Error callback"
 PLG_RECAPTCHA_ERROR_CALLBACK_DESC="(Optional) JavaScript callback, executed when the reCAPTCHA encounters an error"
+PLG_RECAPTCHA_EXPIRED_CALLBACK_LABEL="Expired callback"
+PLG_RECAPTCHA_EXPIRED_CALLBACK_DESC="(Optional) JavaScript callback, executed when the reCAPTCHA expired"
 
 ; Error messages
 PLG_RECAPTCHA_ERROR_NO_PRIVATE_KEY="reCAPTCHA plugin needs a secret key to be set in its parameters. Please contact a site administrator."

--- a/administrator/language/en-GB/en-GB.plg_captcha_recaptcha.ini
+++ b/administrator/language/en-GB/en-GB.plg_captcha_recaptcha.ini
@@ -41,8 +41,8 @@ PLG_RECAPTCHA_CALLBACK_LABEL="Callback"
 PLG_RECAPTCHA_CALLBACK_DESC="(Optional) JavaScript callback, executed after successful reCAPTCHA response"
 PLG_RECAPTCHA_EXPIRED_CALLBACK_LABEL="Expired callback"
 PLG_RECAPTCHA_EXPIRED_CALLBACK_DESC="(Optional) JavaScript callback, executed when the reCAPTCHA expired"
-PLG_RECAPTCHA_EXPIRED_CALLBACK_LABEL="Error callback"
-PLG_RECAPTCHA_EXPIRED_CALLBACK_DESC="(Optional) JavaScript callback, executed when the reCAPTCHA encounters an error"
+PLG_RECAPTCHA_ERROR_CALLBACK_LABEL="Error callback"
+PLG_RECAPTCHA_ERROR_CALLBACK_DESC="(Optional) JavaScript callback, executed when the reCAPTCHA encounters an error"
 
 ; Error messages
 PLG_RECAPTCHA_ERROR_NO_PRIVATE_KEY="reCAPTCHA plugin needs a secret key to be set in its parameters. Please contact a site administrator."


### PR DESCRIPTION
Pull Request for Issue #18146 .

### Summary of Changes

There were two double strings.

### Testing Instructions

Please go to the plugin recaptcha in the backend and check the label and description.

### Expected result

PLG_RECAPTCHA_CALLBACK_DESC="(Optional) JavaScript callback, executed after successful reCAPTCHA response"
PLG_RECAPTCHA_EXPIRED_CALLBACK_LABEL="Expired callback"
PLG_RECAPTCHA_ERROR_CALLBACK_DESC="(Optional) JavaScript callback, executed when the reCAPTCHA expired"
PLG_RECAPTCHA_ERROR_CALLBACK_LABEL="Error callback"

### Actual result

PLG_RECAPTCHA_CALLBACK_DESC="(Optional) JavaScript callback, executed after successful reCAPTCHA response"
PLG_RECAPTCHA_EXPIRED_CALLBACK_LABEL="Expired callback"
PLG_RECAPTCHA_EXPIRED_CALLBACK_DESC="(Optional) JavaScript callback, executed when the reCAPTCHA expired"
PLG_RECAPTCHA_EXPIRED_CALLBACK_LABEL="Error callback"

### Documentation Changes Required

rename two strings