### PR TITLE
Add missing language string COM_USERS_LOGIN_DEFAULT_LABEL

### DIFF
--- a/language/en-GB/en-GB.com_users.ini
+++ b/language/en-GB/en-GB.com_users.ini
@@ -41,6 +41,7 @@ COM_USERS_FIELD_RESET_PASSWORD1_MESSAGE="The passwords you entered do not match.
 COM_USERS_FIELD_RESET_PASSWORD2_DESC="Confirm your new password."
 COM_USERS_FIELD_RESET_PASSWORD2_LABEL="Confirm Password"
 COM_USERS_INVALID_EMAIL="Invalid email address"
+COM_USERS_LOGIN_DEFAULT_LABEL="User Login"
 COM_USERS_LOGIN_IMAGE_ALT="Login image"
 COM_USERS_LOGIN_REGISTER="Don't have an account?"
 COM_USERS_LOGIN_REMEMBER_ME="Remember me"


### PR DESCRIPTION
Pull Request for Issue #21917  .

### Summary of Changes

Add missing language string COM_USERS_LOGIN_DEFAULT_LABEL to language/en-GB/en-GB.com_users.ini.

@brianteeman Please review.

### Testing Instructions

Code review:

1. Check that this language string is already used in file components\com_users\models\forms\login.xml:
`<fieldset name="credentials" label="COM_USERS_LOGIN_DEFAULT_LABEL">`
2. Check that this language string is defined nowhere (with `grep` on Linux or `findstr` on Windows CMD).

### Expected result

Language string "COM_USERS_LOGIN_DEFAULT_LABEL" defined.

### Actual result

Language string "COM_USERS_LOGIN_DEFAULT_LABEL" not defined.

### Documentation Changes Required

None.