### PR TITLE
[4.0] Modulle cog permissions

### DIFF
--- a/administrator/templates/atum/html/modules.php
+++ b/administrator/templates/atum/html/modules.php
@@ -53,7 +53,7 @@ function modChrome_well($module, &$params, &$attribs)
 	{
 		// Permission checks
 		$user           = Factory::getUser();
-		$canEdit	    = $user->authorise('core.edit', 'com_modules.module.' . $module->id);
+		$canEdit	    = $user->authorise('core.edit', 'com_modules.module.' . $module->id) && $user->authorise('core.manage', 'com_modules');
 
 		$moduleTag      = $params->get('module_tag', 'div');
 		$bootstrapSize  = (int) $params->get('bootstrap_size', 6);


### PR DESCRIPTION
All the modules in the admin control panel have a cog icon which lets you edit the module. Howeveer the permission check is not correct as you need to have access to the module component AND to edit the module.

### To test
Create a user with default manager permissions
Create a user with default administrator permissions
Change the permissions on one module so that only Super Users can edit the module

Login as manager - the cog is displayed on all the modules but you get a 403
Login as administrator - the cog is displayed and works on all the modules except the one you dont have permission to edit where you get a 403
Login as super user - the cog is displayed and works on all the modules

#### Apply the pr
Login as manager - the cog is not displayed at all
Login as administrator - the cog is displayed and works on all the modules except the one you dont have permission to edit where the cog is not displayed at all
Login as super user - the cog is displayed and works on all the modules


_this is a redo of #20967 where I couldnt resolve the conflicts due to the composer changes etc_