### PR TITLE
[3.9-alpha] [mod_articles_category] Make sure the tag does not conflict with the title of the article

### DIFF
--- a/modules/mod_articles_category/helper.php
+++ b/modules/mod_articles_category/helper.php
@@ -516,7 +516,7 @@ abstract class ModArticlesCategoryHelper
 	public static function groupByTags($list, $direction = 'ksort')
 	{
 		$grouped  = array();
-		$untagged = 'MOD_ARTICLES_CATEGORY_UNTAGGED';
+		$untagged = array();
 
 		if (!$list)
 		{
@@ -534,11 +534,16 @@ abstract class ModArticlesCategoryHelper
 			}
 			else
 			{
-				$grouped[$untagged][] = $item;
+				$untagged[] = $item;
 			}
 		}
 
 		$direction($grouped);
+
+		if ($untagged)
+		{
+			$grouped['MOD_ARTICLES_CATEGORY_UNTAGGED'] = $untagged;
+		}
 
 		return $grouped;
 	}

--- a/modules/mod_articles_category/helper.php
+++ b/modules/mod_articles_category/helper.php
@@ -516,7 +516,7 @@ abstract class ModArticlesCategoryHelper
 	public static function groupByTags($list, $direction = 'ksort')
 	{
 		$grouped  = array();
-		$untagged = JText::_('MOD_ARTICLES_CATEGORY_UNTAGGED');
+		$untagged = 'MOD_ARTICLES_CATEGORY_UNTAGGED';
 
 		if (!$list)
 		{

--- a/modules/mod_articles_category/tmpl/default.php
+++ b/modules/mod_articles_category/tmpl/default.php
@@ -14,7 +14,7 @@ defined('_JEXEC') or die;
 	<?php if ($grouped) : ?>
 		<?php foreach ($list as $group_name => $group) : ?>
 		<li>
-			<div class="mod-articles-category-group"><?php echo $group_name; ?></div>
+			<div class="mod-articles-category-group"><?php echo JText::_($group_name); ?></div>
 			<ul>
 				<?php foreach ($group as $item) : ?>
 					<li>


### PR DESCRIPTION
Pull Request for Issue #21083

### Summary of Changes

I have moved the translation part to the view so the code does not work different on different languages. As currently the array key is the translated word already and in that case have different results depending on the used language this patch makes sure the result is always the same on all languages by translating the key later.

### Testing Instructions

- install 3.9-alpha (with sample testing data)
- create and mod_articles_category with the new option (Group by tags) added here #21083
- Check that is displays good in the frontend
- Create an article with the Tag "Untagged"
- Notice that the article is listed in the Untagged list in the frontend.
- apply this patch
- Joomla differentiate now between actually tagged and not tagged articles.

### Expected result

Joomla differentiate now between actually tagged and not tagged articles.

### Actual result

Joomla does not differentiate between actually tagged and not tagged articles.

### Documentation Changes Required

None.

cc @SharkyKZ as original author of the PR #21083