### PR TITLE
[4.0] Make the new stage from a new workflow translateable

### DIFF
--- a/administrator/components/com_workflow/Model/WorkflowModel.php
+++ b/administrator/components/com_workflow/Model/WorkflowModel.php
@@ -112,7 +112,7 @@ class WorkflowModel extends AdminModel
 			$newstage = new \stdClass;
 
 			$newstage->workflow_id = (int) $this->getState($this->getName() . '.id');
-			$newstage->title = Text::_('COM_WORKFLOW_PUBLISHED');
+			$newstage->title = 'COM_WORKFLOW_PUBLISHED';
 			$newstage->description = '';
 			$newstage->published = 1;
 			$newstage->condition = 1;


### PR DESCRIPTION
### Summary of Changes
When creating a new workflow, one default stage will also be created.
This default stage was translated on the creation process, with #21506 it can be translated on the fly, so there should only be the constant from now on.

### Testing Instructions
Create a new workflow.


### Expected result
The new stage has the title "COM_WORKFLOW_PUBLISHED" and is translated everywhere


### Actual result
The new stage is not translated in the system.
