### PR TITLE
Fix Configuration change has no effect #21943

### DIFF
--- a/administrator/components/com_config/model/application.php
+++ b/administrator/components/com_config/model/application.php
@@ -458,6 +458,12 @@ class ConfigModelApplication extends ConfigModelForm
 		{
 			throw new RuntimeException(JText::_('COM_CONFIG_ERROR_WRITE_FAILED'));
 		}
+		
+		// Invalidates the cached configuration file
+		if (function_exists('opcache_invalidate'))
+		{
+			opcache_invalidate($file);
+		}
 
 		// Attempt to make the file unwriteable if using FTP.
 		if (!$ftp['enabled'] && JPath::isOwner($file) && !JPath::setPermissions($file, '0444'))

--- a/administrator/components/com_config/model/application.php
+++ b/administrator/components/com_config/model/application.php
@@ -458,7 +458,7 @@ class ConfigModelApplication extends ConfigModelForm
 		{
 			throw new RuntimeException(JText::_('COM_CONFIG_ERROR_WRITE_FAILED'));
 		}
-		
+
 		// Invalidates the cached configuration file
 		if (function_exists('opcache_invalidate'))
 		{

--- a/libraries/src/Factory.php
+++ b/libraries/src/Factory.php
@@ -569,7 +569,6 @@ abstract class Factory
 	{
 		if (is_file($file))
 		{
-			// opcode cache busting before including the filename
 			if (function_exists('opcache_invalidate'))
 			{
 				opcache_invalidate($file);

--- a/libraries/src/Factory.php
+++ b/libraries/src/Factory.php
@@ -569,11 +569,6 @@ abstract class Factory
 	{
 		if (is_file($file))
 		{
-			if (function_exists('opcache_invalidate'))
-			{
-				opcache_invalidate($file);
-			}
-
 			include_once $file;
 		}
 

--- a/libraries/src/Factory.php
+++ b/libraries/src/Factory.php
@@ -573,18 +573,7 @@ abstract class Factory
 			{
 				opcache_invalidate($file);
 			}
-			if (function_exists('apc_compile_file'))
-			{
-				apc_compile_file($file);
-			}
-			if (function_exists('wincache_refresh_if_changed'))
-			{
-				wincache_refresh_if_changed(array($file));
-			}
-			if (function_exists('xcache_asm'))
-			{
-				xcache_asm($file);
-			}
+
 			include_once $file;
 		}
 

--- a/libraries/src/Factory.php
+++ b/libraries/src/Factory.php
@@ -569,6 +569,23 @@ abstract class Factory
 	{
 		if (is_file($file))
 		{
+			// opcode cache busting before including the filename
+			if (function_exists('opcache_invalidate'))
+			{
+				opcache_invalidate($file);
+			}
+			if (function_exists('apc_compile_file'))
+			{
+				apc_compile_file($file);
+			}
+			if (function_exists('wincache_refresh_if_changed'))
+			{
+				wincache_refresh_if_changed(array($file));
+			}
+			if (function_exists('xcache_asm'))
+			{
+				xcache_asm($file);
+			}
 			include_once $file;
 		}
 


### PR DESCRIPTION
Pull Request for Issue #21943   .

### Summary of Changes
Adds the opcache_invalidate function before loading the configuration file.
**opcache_invalidate** : invalidates the cached file if the modification time of the file is newer than the cached opcodes.

### Testing Instructions

1. Create a site with https://launch.joomla.org/ and change Global configuration (admin).

OR

2. Create a site on your localhost with these server settings.
Edit the php.ini file and set the opcache.revalidate_freq value to 60 in the opcache section : 

    [opcache]
    zend_extension=php_opcache.dll
    opcache.enable=1
    opcache.enable_cli=0
    opcache.memory_consumption=128
    opcache.interned_strings_buffer=8
    opcache.max_accelerated_files=10000
    **opcache.revalidate_freq=60**
    opcache.fast_shutdown=1

This is my default configuration (bitnami wappstack server).

Restart Apache service.

1. Log in as administrator
2. System -> Global configuration
3. Change any settings
4. Save


### Expected result
The settings in Global configuration are saved and taken into account.


### Actual result
The new global configuration is not taken into account each time I save it (if patch is not applied).


