### PR TITLE
[3.9] Adjustments for upcoming Install from Web plugin update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ phpdoc-*
 /media/com_patchtester
 
 # Install from Web plugin #
+/media/plg_installer_webinstaller
 /plugins/installer/webinstaller
 
 # Languages #

--- a/administrator/language/en-GB/en-GB.plg_installer_webinstaller.ini
+++ b/administrator/language/en-GB/en-GB.plg_installer_webinstaller.ini
@@ -4,9 +4,18 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_INSTALLER_WEBINSTALLER="Installer - Install from Web"
+PLG_INSTALLER_WEBINSTALLER_CANNOT_INSTALL_EXTENSION_IN_PLUGIN="This extension cannot be installed using the install from web system. Please visit the developer's website to purchase/download."
+PLG_INSTALLER_WEBINSTALLER_ERROR_PLUGIN_INCLUDED_IN_CORE="Plugin installation has been aborted. The Install from Web plugin is included in core as of Joomla! 4.0."
+; This string is not used.
 PLG_INSTALLER_WEBINSTALLER_LOAD_APPS="Display the extensions"
+; The [SITEURL] placeholder should not be translated as it is used in the JavaScript API to insert the correct URL
+PLG_INSTALLER_WEBINSTALLER_REDIRECT_TO_EXTERNAL_SITE_TO_INSTALL="You will be redirected to the following link to complete the registration/purchase: [SITEURL]"
+; This string is deprecated and not used in version 2.0 of the plugin but is required for compatibility with 1.x releases due to the language files being bundled in the CMS package.
 PLG_INSTALLER_WEBINSTALLER_TAB_POSITION_DESC="Place the Install from Web tab first or last."
+; This string is deprecated and not used in version 2.0 of the plugin but is required for compatibility with 1.x releases due to the language files being bundled in the CMS package.
 PLG_INSTALLER_WEBINSTALLER_TAB_POSITION_LABEL="Tab Position"
+; This string is deprecated and not used in version 2.0 of the plugin but is required for compatibility with 1.x releases due to the language files being bundled in the CMS package.
 PLG_INSTALLER_WEBINSTALLER_TAB_POSITION_FIRST="First"
+; This string is deprecated and not used in version 2.0 of the plugin but is required for compatibility with 1.x releases due to the language files being bundled in the CMS package.
 PLG_INSTALLER_WEBINSTALLER_TAB_POSITION_LAST="Last"
 PLG_INSTALLER_WEBINSTALLER_XML_DESCRIPTION="This plugin offers functionality for the 'Install from Web' tab."


### PR DESCRIPTION
### Summary of Changes

In preparation for the [upcoming Install from Web update](https://github.com/joomla-extensions/install-from-web-client/releases/tag/2.0.0-alpha) there are language string changes needed, and since the language file is in this repo and not distributed as part of the plugin, the updates must be made here.

In short, this:

- Marks strings being removed deprecated, they have to stay here since the language file will be used for any IFW plugin release
- Adds new strings replacing hardcoded English, similar to the changes in 4.0
- Adds the media path to `.gitignore`

### Testing Instructions

Install IFW plugin update, apply this patch.  Without it you're going to have untranslated strings in a couple JavaScript actions.
