### PR TITLE
[4.0] Template name missing string

### DIFF
--- a/language/en-GB/en-GB.tpl_cassiopeia.sys.ini
+++ b/language/en-GB/en-GB.tpl_cassiopeia.sys.ini
@@ -3,6 +3,7 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 
+CASSIOPEIA="Cassiopeia Site template"
 TPL_CASSIOPEIA_POSITION_MENU="Menu"
 TPL_CASSIOPEIA_POSITION_SEARCH="Search"
 TPL_CASSIOPEIA_POSITION_BANNER="Banner"

--- a/templates/cassiopeia/language/en-GB/en-GB.tpl_cassiopeia.sys.ini
+++ b/templates/cassiopeia/language/en-GB/en-GB.tpl_cassiopeia.sys.ini
@@ -3,6 +3,7 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 
+CASSIOPEIA="Cassiopeia Site template"
 TPL_CASSIOPEIA_POSITION_MENU="Menu"
 TPL_CASSIOPEIA_POSITION_SEARCH="Search"
 TPL_CASSIOPEIA_POSITION_BANNER="Banner"


### PR DESCRIPTION
If you go to extensions->manage and filter on templates you will see the unformatted string for the Cassiopeia template - especially compared to the atum template

This was because there as no language string

### Before

![image](https://user-images.githubusercontent.com/1296369/44959884-07bbd580-aeee-11e8-8fcb-c9ad948dad5e.png)


### After
![image](https://user-images.githubusercontent.com/1296369/44959881-f70b5f80-aeed-11e8-840a-8088d1c5a516.png)

