### PR TITLE
[plg_quickicon_phpversioncheck] Correct displayed PHP support date

### DIFF
--- a/plugins/quickicon/phpversioncheck/phpversioncheck.php
+++ b/plugins/quickicon/phpversioncheck/phpversioncheck.php
@@ -180,10 +180,10 @@ class PlgQuickiconPhpVersionCheck extends JPlugin
 			}
 
 			// If the version is still supported, check if it has reached eol minus 3 month
-			$interval = new DateInterval('P3M');
-			$phpEndOfSupport->sub($interval);
+			$securityWarningDate = clone $phpEndOfSupport;
+			$securityWarningDate->sub(new DateInterval('P3M'));
 
-			if (!$phpNotSupported && $today > $phpEndOfSupport)
+			if (!$phpNotSupported && $today > $securityWarningDate)
 			{
 				$supportStatus['status']  = self::PHP_SECURITY_ONLY;
 				$supportStatus['message'] = JText::sprintf(


### PR DESCRIPTION
Issue reported by user on forum https://forum.joomla.org/viewtopic.php?f=714&t=965158.

### Summary of Changes

This corrects the displayed security support date in PHP version warning.

### Testing Instructions

This can be normally tested only on PHP 7.0 setup. Open administrator panel. See date in PHP version warning.

### Expected result

Your PHP version, 7.0.31, is only receiving security fixes at this time from the PHP project. This means your PHP version will soon no longer be supported. We recommend planning to upgrade to a newer PHP version before it reaches end of support on **2018-12-03**. Joomla will be faster and more secure if you upgrade to a newer PHP version (PHP 7.x is recommended). Please contact your host for upgrade instructions.

### Actual result

Your PHP version, 7.0.31, is only receiving security fixes at this time from the PHP project. This means your PHP version will soon no longer be supported. We recommend planning to upgrade to a newer PHP version before it reaches end of support on **2018-09-03**. Joomla will be faster and more secure if you upgrade to a newer PHP version (PHP 7.x is recommended). Please contact your host for upgrade instructions.

### Documentation Changes Required
No.
