### PR TITLE
[4.0] Add workflow to the installation sample data

### DIFF
--- a/installation/sql/mysql/sample_testing.sql
+++ b/installation/sql/mysql/sample_testing.sql
@@ -410,6 +410,12 @@ INSERT INTO `#__contentitem_tag_map` (`type_alias`, `core_content_id`, `content_
 ('com_content.article', 2, 71, 4, '2013-10-15 14:58:28', 1);
 
 --
+-- Creating Associations for existing content
+--
+INSERT INTO `#__workflow_associations` (`item_id`, `stage_id`, `extension`)
+SELECT `id`, CASE WHEN `state` = -2 THEN 3 WHEN `state` = 0 THEN 1 WHEN `state` = 2 THEN 4 ELSE 2 END, 'com_content' FROM `#__content`;
+
+--
 -- Dumping data for table `#__menu`
 --
 

--- a/installation/sql/postgresql/sample_testing.sql
+++ b/installation/sql/postgresql/sample_testing.sql
@@ -416,6 +416,13 @@ INSERT INTO "#__contentitem_tag_map" ("type_alias", "core_content_id", "content_
 ('com_content.article', 2, 71, 3, '2013-10-15 14:58:28', 1),
 ('com_content.article', 2, 71, 4, '2013-10-15 14:58:28', 1);
 
+
+--
+-- Creating Associations for existing content
+--
+INSERT INTO "#__workflow_associations" ("item_id", "stage_id", "extension")
+SELECT "id", CASE WHEN "state" = -2 THEN 3 WHEN "state" = 0 THEN 1 WHEN "state" = 2 THEN 4 ELSE 2 END, 'com_content' FROM "#__content";
+
 --
 -- Dumping data for table `#__menu`
 --


### PR DESCRIPTION
### Summary of Changes
This PR fixes the installation sample data. Now they are assigned to the specific stages.


### Testing Instructions
- Reinstall Joomla! 4
- At the last step, skip the language and install sample datas
- After the installation check the articles


### Expected result
- All articles should work with the default workflow (Change stage)


### Actual result
- Articles are broken