### PR TITLE
[3.9] missing string in en-GB.plg_system_actionlogs.ini

### DIFF
--- a/administrator/language/en-GB/en-GB.plg_system_actionlogs.ini
+++ b/administrator/language/en-GB/en-GB.plg_system_actionlogs.ini
@@ -14,6 +14,7 @@ PLG_SYSTEM_ACTIONLOGS_OPTIONS="User Actions Log Options"
 PLG_SYSTEM_ACTIONLOGS_XML_DESCRIPTION="Record the actions of users on the site so they can be reviewed if required."
 ; Common content type log messages
 PLG_SYSTEM_ACTIONLOGS_CONTENT_ADDED="User <a href=\"{accountlink}\">{username}</a> added new {type} <a href=\"{itemlink}\">{title}</a>"
+PLG_SYSTEM_ACTIONLOGS_CONTENT_ARCHIVED="User <a href=\"{accountlink}\">{username}</a> archived the {type} <a href=\"{itemlink}\">{title}</a>"
 PLG_SYSTEM_ACTIONLOGS_CONTENT_UPDATED="User <a href=\"{accountlink}\">{username}</a> updated the {type} <a href=\"{itemlink}\">{title}</a>"
 PLG_SYSTEM_ACTIONLOGS_CONTENT_PUBLISHED="User <a href=\"{accountlink}\">{username}</a> published the {type} <a href=\"{itemlink}\">{title}</a>"
 PLG_SYSTEM_ACTIONLOGS_CONTENT_UNPUBLISHED="User <a href=\"{accountlink}\">{username}</a> unpublished the {type} <a href=\"{itemlink}\">{title}</a>"


### PR DESCRIPTION
### Summary of Changes

add missing string

### Testing Instructions

Go to any core extension an archive something.
Then switch to User -> User Actions Log.

### Expected result

User <username> archived the <type> <link>

### Actual result

Only string output
PLG_SYSTEM_ACTIONLOGS_CONTENT_ARCHIVED

![screenshot 2018-09-03 21 37 15](https://user-images.githubusercontent.com/1752513/44999987-90f00c80-afc1-11e8-9752-142474acc182.png)
