### PR TITLE
[4.0] Atum table head border bottom

### DIFF
--- a/administrator/templates/atum/scss/vendor/bootstrap/_table.scss
+++ b/administrator/templates/atum/scss/vendor/bootstrap/_table.scss
@@ -3,10 +3,12 @@
 .table {
 
   thead {
-    th {
+    th,
+    td {
       white-space: nowrap;
       font-weight: normal;
       color: $gray-800;
+      border-bottom: 2px solid $gray-300;
     }
     td {
       padding: 0;


### PR DESCRIPTION
The border bottom was only set on `thead th` This pr correctly sets it on `thead td` as well

_(cannot be tested with patchtester alone)_

### Before
<img width="387" alt="chrome_2018-09-04_08-50-45" src="https://user-images.githubusercontent.com/1296369/45019482-59ff1280-b024-11e8-8c31-d3b4fd4a03b2.png">



### After
<img width="451" alt="chrome_2018-09-04_09-20-28" src="https://user-images.githubusercontent.com/1296369/45019483-59ff1280-b024-11e8-9d6f-10faaa592005.png">

