### PR TITLE
[3.9] Unification plugin name plg_system_actionlogs

### DIFF
--- a/administrator/language/en-GB/en-GB.plg_system_actionlogs.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_system_actionlogs.sys.ini
@@ -3,5 +3,5 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 
-PLG_SYSTEM_ACTIONLOGS="System - Actions Log"
+PLG_SYSTEM_ACTIONLOGS="System - User Actions Log"
 PLG_SYSTEM_ACTIONLOGS_XML_DESCRIPTION="To record actions of users within the CMS, to know who to blame when something wrong happens."


### PR DESCRIPTION
### Summary of Changes

change string to "System - User Actions Log"

### Testing Instructions

Extensions -> Plugins -> search for "Actions Log"

### Expected result

System - User Actions Log

### Actual result

System - Actions Log

### Documentation Changes Required

Appearance of the plugin name. My suggestion would be "System - User Actions Log" in both files, because these are User Actions.

See translation in en-GB.plg_system_actionlogs.ini https://github.com/joomla/joomla-cms/blob/a0c6aa6c58d92bb7725b7fdb6ea95061ea5e598a/administrator/language/en-GB/en-GB.plg_system_actionlogs.ini#L6

