### PR TITLE
[4.0] Dropdown menu overflow

### DIFF
--- a/administrator/templates/atum/scss/template-rtl.scss
+++ b/administrator/templates/atum/scss/template-rtl.scss
@@ -38,9 +38,6 @@ body {
 }
 
 .dropdown-menu-right {
-  right: auto;
-  left: 0;
-
   &::after {
     right: auto;
     left: .9rem;

--- a/administrator/templates/atum/scss/vendor/bootstrap/_dropdown.scss
+++ b/administrator/templates/atum/scss/vendor/bootstrap/_dropdown.scss
@@ -1,7 +1,6 @@
 // Dropdown
 
 .btn-group .dropdown-menu {
-  width: auto;
   box-shadow: $atum-box-shadow;
 
   [class^='icon-'],

--- a/administrator/templates/atum/scss/vendor/bootstrap/_dropdown.scss
+++ b/administrator/templates/atum/scss/vendor/bootstrap/_dropdown.scss
@@ -1,7 +1,7 @@
 // Dropdown
 
 .btn-group .dropdown-menu {
-  width: 100%;
+  width: auto;
   box-shadow: $atum-box-shadow;
 
   [class^='icon-'],

--- a/layouts/joomla/toolbar/dropdown.php
+++ b/layouts/joomla/toolbar/dropdown.php
@@ -10,6 +10,10 @@
 defined('JPATH_BASE') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Factory;
+
+$direction = Factory::getLanguage()->isRtl() ? 'dropdown-menu-right' : '';
+
 
 /**
  * @var  string  $id
@@ -33,13 +37,13 @@ extract($displayData, EXTR_OVERWRITE);
 
 		<?php if ($toggleSplit ?? true): ?>
 			<button type="button" class="<?php echo $caretClass ?? ''; ?> dropdown-toggle dropdown-toggle-split"
-				data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+				data-toggle="dropdown" data-display="static" aria-haspopup="true" aria-expanded="false">
 				<span class="sr-only">Toggle Dropdown</span>
 			</button>
 		<?php endif; ?>
 
 		<?php if (trim($dropdownItems) !== ''): ?>
-			<div class="dropdown-menu dropdown-menu-right">
+			<div class="dropdown-menu <?php echo $direction; ?>">
 				<?php echo $dropdownItems; ?>
 			</div>
 		<?php endif; ?>


### PR DESCRIPTION
PR for #22012

As seen in the screenshot if the menu text is too long it breaks out of the dropdown. This PR fixes that. Note it doesn't fix the left alignment

@ciar4n nany suggestions

_testing_ requires` npm run build:css` and changing the language string to something long

### before
<img width="240" alt="chrome_2018-09-05_12-49-48" src="https://user-images.githubusercontent.com/1296369/45091421-52199e00-b10a-11e8-8c11-7fe42f248e9d.png">

### after
<img width="415" alt="chrome_2018-09-05_12-45-39" src="https://user-images.githubusercontent.com/1296369/45091420-52199e00-b10a-11e8-9b38-43101fff72af.png">
