### PR TITLE
Remove trailing whitespaces from com_tags xml files

### DIFF
--- a/administrator/components/com_tags/config.xml
+++ b/administrator/components/com_tags/config.xml
@@ -37,8 +37,8 @@
 			showon="save_history:1"
 		/>
 
-		<field 
-			name="show_tag_title" 
+		<field
+			name="show_tag_title"
 			type="radio"
 			label="COM_TAGS_SHOW_TAG_TITLE_LABEL"
 			description="COM_TAGS_SHOW_TAG_TITLE_DESC"
@@ -49,8 +49,8 @@
 			<option value="0">JHIDE</option>
 		</field>
 
-		<field 
-			name="tag_list_show_tag_image" 
+		<field
+			name="tag_list_show_tag_image"
 			type="radio"
 			label="COM_TAGS_SHOW_TAG_IMAGE_LABEL"
 			description="COM_TAGS_SHOW_TAG_IMAGE_DESC"
@@ -61,9 +61,9 @@
 			<option value="0">JHIDE</option>
 		</field>
 
-		<field 
-			name="tag_list_show_tag_description" 
-			type="radio" 
+		<field
+			name="tag_list_show_tag_description"
+			type="radio"
 			label="COM_TAGS_SHOW_TAG_DESCRIPTION_LABEL"
 			description="COM_TAGS_SHOW_TAG_DESCRIPTION_DESC"
 			class="btn-group btn-group-yesno"
@@ -73,14 +73,14 @@
 			<option value="0">JHIDE</option>
 		</field>
 
-		<field 
-			name="tag_list_image" 
+		<field
+			name="tag_list_image"
 			type="media"
 			label="COM_TAGS_TAG_LIST_MEDIA_LABEL"
 			description="COM_TAGS_TAG_LIST_MEDIA_DESC"
 		/>
-	
-		<field 
+
+		<field
 			name="tag_list_orderby"
 			type="list"
 			label="JGLOBAL_FIELD_FIELD_ORDERING_LABEL"
@@ -94,9 +94,9 @@
 			<option value="c.core_publish_up">JGLOBAL_PUBLISHED_DATE</option>
 		</field>
 
-		<field 
-			name="tag_list_orderby_direction" 
-			type="radio" 
+		<field
+			name="tag_list_orderby_direction"
+			type="radio"
 			label="JGLOBAL_ORDER_DIRECTION_LABEL"
 			description="JGLOBAL_ORDER_DIRECTION_DESC"
 			class="btn-group btn-group-yesno"
@@ -106,19 +106,19 @@
 			<option value="DESC">JGLOBAL_ORDER_DESCENDING</option>
 		</field>
 
-		<field 
-			name="show_headings" 
+		<field
+			name="show_headings"
 			type="radio"
 			label="COM_TAGS_TAG_LIST_SHOW_HEADINGS_LABEL"
 			description="COM_TAGS_TAG_LIST_SHOW_HEADINGS_DESC"
 			class="btn-group btn-group-yesno"
-			default="1"			
+			default="1"
 			>
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
 		</field>
 
-		<field 
+		<field
 			name="tag_list_show_date"
 			type="list"
 			label="COM_TAGS_TAG_LIST_SHOW_DATE_DESC"
@@ -131,9 +131,9 @@
 			<option value="published">JPUBLISHED</option>
 		</field>
 
-		<field 
-			name="tag_list_show_item_image" 
-			type="radio" 
+		<field
+			name="tag_list_show_item_image"
+			type="radio"
 			label="COM_TAGS_SHOW_ITEM_IMAGE_LABEL"
 			description="COM_TAGS_SHOW_ITEM_IMAGE_DESC"
 			class="btn-group btn-group-yesno"
@@ -142,9 +142,9 @@
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
 		</field>
-		
-		<field 
-			name="tag_list_show_item_description" 
+
+		<field
+			name="tag_list_show_item_description"
 			type="radio"
 			label="COM_TAGS_TAG_LIST_SHOW_ITEM_DESCRIPTION_LABEL"
 			description="COM_TAGS_TAG_LIST_SHOW_ITEM_DESCRIPTION_DESC"
@@ -153,7 +153,7 @@
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
 		</field>
-		
+
 		<field
 			name="tag_list_item_maximum_characters"
 			type="number"
@@ -164,7 +164,7 @@
 		/>
 
 	</fieldset>
-	
+
 	<fieldset
 		name="tagselection"
 		label="COM_TAGS_CONFIG_SELECTION_SETTINGS_LABEL"
@@ -181,9 +181,9 @@
 			default="3"
 		/>
 
-		<field 
-			name="return_any_or_all" 
-			type="radio" 
+		<field
+			name="return_any_or_all"
+			type="radio"
 			label="COM_TAGS_SEARCH_TYPE_LABEL"
 			description="COM_TAGS_SEARCH_TYPE_DESC"
 			class="btn-group btn-group-yesno"
@@ -192,10 +192,10 @@
 			<option value="1">COM_TAGS_ANY</option>
 			<option value="0">COM_TAGS_ALL</option>
 		</field>
-		
-		<field 
-			name="include_children" 
-			type="radio" 
+
+		<field
+			name="include_children"
+			type="radio"
 			label="COM_TAGS_INCLUDE_CHILDREN_LABEL"
 			description="COM_TAGS_INCLUDE_CHILDREN_DESC"
 			class="btn-group btn-group-yesno"
@@ -204,7 +204,7 @@
 			<option value="1">COM_TAGS_INCLUDE</option>
 			<option value="0">COM_TAGS_EXCLUDE</option>
 		</field>
-		
+
 		<field
 			name="maximum"
 			type="number"
@@ -213,8 +213,8 @@
 			default="200"
 			filter="integer"
 		/>
-		
-		<field 
+
+		<field
 			name="tag_list_language_filter"
 			type="contentlanguage"
 			label="COM_TAGS_FIELD_LANGUAGE_FILTER_LABEL"
@@ -224,8 +224,8 @@
 			<option value="all">JALL</option>
 			<option value="current_language">JCURRENT</option>
 		</field>
-		
-	</fieldset>	
+
+	</fieldset>
 
 	<fieldset
 		name="alltags"
@@ -233,7 +233,7 @@
 		description="COM_TAGS_CONFIG_ALL_TAGS_SETTINGS_DESC">
 
 		<field
-			name="tags_layout" 
+			name="tags_layout"
 			type="componentlayout"
 			label="COM_TAGS_CONFIG_ALL_TAGS_FIELD_LAYOUT_LABEL"
 			description="COM_TAGS_CONFIG_ALL_TAGS_FIELD_LAYOUT_DESC"
@@ -242,7 +242,7 @@
 			view="tags"
 		/>
 
-		<field 
+		<field
 			name="all_tags_orderby"
 			type="list"
 			label="JGLOBAL_FIELD_FIELD_ORDERING_LABEL"
@@ -256,8 +256,8 @@
 			<option value="publish_up">JGLOBAL_PUBLISHED_DATE</option>
 		</field>
 
-		<field 
-			name="all_tags_orderby_direction" 
+		<field
+			name="all_tags_orderby_direction"
 			type="radio"
 			label="JGLOBAL_ORDER_DIRECTION_LABEL"
 			description="JGLOBAL_ORDER_DIRECTION_DESC"
@@ -268,9 +268,9 @@
 			<option value="DESC">JGLOBAL_ORDER_DESCENDING</option>
 		</field>
 
-		<field 
-			name="all_tags_show_tag_image" 
-			type="radio" 
+		<field
+			name="all_tags_show_tag_image"
+			type="radio"
 			label="COM_TAGS_SHOW_ITEM_IMAGE_LABEL"
 			description="COM_TAGS_SHOW_ITEM_IMAGE_DESC"
 			class="btn-group btn-group-yesno"
@@ -280,9 +280,9 @@
 			<option value="0">JHIDE</option>
 		</field>
 
-		<field 
-			name="all_tags_show_tag_descripion" 
-			type="radio" 
+		<field
+			name="all_tags_show_tag_descripion"
+			type="radio"
 			label="COM_TAGS_SHOW_ITEM_DESCRIPTION_LABEL"
 			description="COM_TAGS_SHOW_ITEM_DESCRIPTION_DESC"
 			class="btn-group btn-group-yesno"
@@ -291,7 +291,7 @@
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
 		</field>
-		
+
 		<field
 			name="all_tags_tag_maximum_characters"
 			type="number"
@@ -300,10 +300,10 @@
 			filter="integer"
 			showon="all_tags_show_tag_descripion:1"
 		/>
-		
-		<field 
-			name="all_tags_show_tag_hits" 
-			type="radio" 
+
+		<field
+			name="all_tags_show_tag_hits"
+			type="radio"
 			label="JGLOBAL_HITS"
 			description="COM_TAGS_FIELD_CONFIG_HITS_DESC"
 			class="btn-group btn-group-yesno"
@@ -319,7 +319,7 @@
 		name="shared"
 		label="COM_TAGS_CONFIG_SHARED_SETTINGS_LABEL"
 		description="COM_TAGS_CONFIG_SHARED_SETTINGS_DESC">
-		
+
 		<field
 			name="filter_field"
 			type="radio"
@@ -332,8 +332,8 @@
 			<option value="0">JHIDE</option>
 		</field>
 
-		<field 
-			name="show_pagination_limit" 
+		<field
+			name="show_pagination_limit"
 			type="radio"
 			label="JGLOBAL_DISPLAY_SELECT_LABEL"
 			description="JGLOBAL_DISPLAY_SELECT_DESC"
@@ -343,9 +343,9 @@
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
 		</field>
-		
-		<field 
-			name="show_pagination" 
+
+		<field
+			name="show_pagination"
 			type="list"
 			label="JGLOBAL_PAGINATION_LABEL"
 			description="JGLOBAL_PAGINATION_DESC"
@@ -368,17 +368,17 @@
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
 		</field>
-		
+
 	</fieldset>
-	
+
 	<fieldset
 		name="data_entry"
 		label="COM_TAGS_CONFIG_DATA_ENTRY_SETTINGS_LABEL"
 		description="COM_TAGS_CONFIG_DATA_ENTRY_SETTINGS_DESC">
-		
-		<field 
-			name="tag_field_ajax_mode" 
-			type="radio" 
+
+		<field
+			name="tag_field_ajax_mode"
+			type="radio"
 			label="COM_TAGS_TAG_FIELD_MODE_LABEL"
 			description="COM_TAGS_TAG_FIELD_MODE_DESC"
 			class="btn-group btn-group-yesno"
@@ -389,8 +389,8 @@
 		</field>
 
 	</fieldset>
-	
-	<fieldset 
+
+	<fieldset
 		name="integration"
 		label="JGLOBAL_INTEGRATION_LABEL"
 		description="COM_TAGS_CONFIG_INTEGRATION_SETTINGS_DESC"

--- a/administrator/components/com_tags/models/forms/tag.xml
+++ b/administrator/components/com_tags/models/forms/tag.xml
@@ -210,7 +210,7 @@
 		<option value="*">JALL</option>
 	</field>
 
-	<field 
+	<field
 		name="version_note"
 		type="text"
 		label="JGLOBAL_FIELD_VERSION_NOTE_LABEL"

--- a/components/com_tags/views/tag/tmpl/default.xml
+++ b/components/com_tags/views/tag/tmpl/default.xml
@@ -13,8 +13,8 @@
 	<fields name="request">
 		<fieldset name="request">
 
-			<field 
-				name="id" 
+			<field
+				name="id"
 				type="tag"
 				label="COM_TAGS_FIELD_TAG_LABEL"
 				description="COM_TAGS_FIELD_SELECT_TAG_DESC"
@@ -23,15 +23,15 @@
 				multiple="true"
 			/>
 
-			<field 
-				name="types" 
+			<field
+				name="types"
 				type="contenttype"
 				label="COM_TAGS_FIELD_TYPE_LABEL"
 				description="COM_TAGS_FIELD_TYPE_DESC"
 				multiple="true"
 			/>
 
-			<field 
+			<field
 				name="tag_list_language_filter"
 				type="contentlanguage"
 				label="COM_TAGS_FIELD_LANGUAGE_FILTER_LABEL"
@@ -50,8 +50,8 @@
 <fields name="params">
 	<fieldset name="basic" label="COM_TAGS_OPTIONS">
 
-			<field 
-				name="show_tag_title" 
+			<field
+				name="show_tag_title"
 				type="list"
 				label="COM_TAGS_SHOW_TAG_TITLE_LABEL"
 				description="COM_TAGS_SHOW_TAG_TITLE_DESC"
@@ -62,8 +62,8 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field 
-				name="tag_list_show_tag_image" 
+			<field
+				name="tag_list_show_tag_image"
 				type="list"
 				label="COM_TAGS_SHOW_TAG_IMAGE_LABEL"
 				description="COM_TAGS_SHOW_TAG_IMAGE_DESC"
@@ -74,8 +74,8 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field 
-				name="tag_list_show_tag_description" 
+			<field
+				name="tag_list_show_tag_description"
 				type="list"
 				label="COM_TAGS_SHOW_TAG_DESCRIPTION_LABEL"
 				description="COM_TAGS_SHOW_TAG_DESCRIPTION_DESC"
@@ -86,25 +86,25 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field 
-				name="tag_list_image" 
+			<field
+				name="tag_list_image"
 				type="media"
 				label="COM_TAGS_TAG_LIST_MEDIA_LABEL"
 				description="COM_TAGS_TAG_LIST_MEDIA_DESC"
 			/>
 
-			<field 
-				name="tag_list_description" 
+			<field
+				name="tag_list_description"
 				type="textarea"
 				class="inputbox"
 				label="COM_TAGS_SHOW_TAG_LIST_DESCRIPTION_LABEL"
 				description="COM_TAGS_TAG_LIST_DESCRIPTION_DESC"
-				rows="3" 
-				cols="30" 
+				rows="3"
+				cols="30"
 				filter="safehtml"
 			/>
 
-			<field 
+			<field
 				name="tag_list_orderby"
 				type="list"
 				label="JGLOBAL_FIELD_FIELD_ORDERING_LABEL"
@@ -119,8 +119,8 @@
 				<option value="c.core_publish_up">JGLOBAL_PUBLISHED_DATE</option>
 			</field>
 
-			<field 
-				name="tag_list_orderby_direction" 
+			<field
+				name="tag_list_orderby_direction"
 				type="list"
 				label="JGLOBAL_ORDER_DIRECTION_LABEL"
 				description="JGLOBAL_ORDER_DIRECTION_DESC"
@@ -134,15 +134,15 @@
 
 		<fieldset name="advanced" label="COM_TAGS_ITEM_OPTIONS">
 
-			<field 
-				name="spacer2" 
-				type="spacer" 
+			<field
+				name="spacer2"
+				type="spacer"
 				label="COM_TAGS_SUBSLIDER_DRILL_TAG_LIST_LABEL"
 				class="text"
 			/>
 
-			<field 
-				name="tag_list_show_item_image" 
+			<field
+				name="tag_list_show_item_image"
 				type="list"
 				label="COM_TAGS_TAG_LIST_SHOW_ITEM_IMAGE_LABEL"
 				description="COM_TAGS_TAG_LIST_SHOW_ITEM_IMAGE_DESC"
@@ -153,8 +153,8 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field 
-				name="tag_list_show_item_description" 
+			<field
+				name="tag_list_show_item_description"
 				type="list"
 				label="COM_TAGS_TAG_LIST_SHOW_ITEM_DESCRIPTION_LABEL"
 				description="COM_TAGS_TAG_LIST_SHOW_ITEM_DESCRIPTION_DESC"
@@ -191,7 +191,7 @@
 		<fieldset name="pagination" label="COM_TAGS_PAGINATION_OPTIONS">
 
 			<field
-				name="show_pagination_limit" 
+				name="show_pagination_limit"
 				type="list"
 				label="JGLOBAL_DISPLAY_SELECT_LABEL"
 				description="JGLOBAL_DISPLAY_SELECT_DESC"
@@ -202,8 +202,8 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field 
-				name="show_pagination" 
+			<field
+				name="show_pagination"
 				type="list"
 				label="JGLOBAL_PAGINATION_LABEL"
 				description="JGLOBAL_PAGINATION_DESC"
@@ -215,8 +215,8 @@
 				<option value="2">JGLOBAL_AUTO</option>
 			</field>
 
-			<field 
-				name="show_pagination_results" 
+			<field
+				name="show_pagination_results"
 				type="list"
 				label="JGLOBAL_PAGINATION_RESULTS_LABEL"
 				description="JGLOBAL_PAGINATION_RESULTS_DESC"
@@ -232,7 +232,7 @@
 		<fieldset name="selection" label="COM_TAGS_LIST_SELECTION_OPTIONS">
 
 			<field
-				name="return_any_or_all" 
+				name="return_any_or_all"
 				type="list"
 				label="COM_TAGS_SEARCH_TYPE_LABEL"
 				description="COM_TAGS_SEARCH_TYPE_DESC"
@@ -242,8 +242,8 @@
 				<option value="1">COM_TAGS_ANY</option>
 			</field>
 
-			<field 
-				name="include_children" 
+			<field
+				name="include_children"
 				type="list"
 				label="COM_TAGS_INCLUDE_CHILDREN_LABEL"
 				description="COM_TAGS_INCLUDE_CHILDREN_DESC"
@@ -259,7 +259,7 @@
 		<fieldset name="integration">
 
 			<field
-				name="show_feed_link" 
+				name="show_feed_link"
 				type="list"
 				label="JGLOBAL_SHOW_FEED_LINK_LABEL"
 				description="JGLOBAL_SHOW_FEED_LINK_DESC"

--- a/components/com_tags/views/tag/tmpl/list.xml
+++ b/components/com_tags/views/tag/tmpl/list.xml
@@ -13,9 +13,9 @@
 	<fields name="request">
 		<fieldset name="request">
 
-			<field 
-				name="id" 
-				type="tag" 
+			<field
+				name="id"
+				type="tag"
 				label="COM_TAGS_FIELD_TAG_LABEL"
 				description="COM_TAGS_FIELD_SELECT_TAG_DESC"
 				custom="deny"
@@ -23,15 +23,15 @@
 				multiple="true"
 			/>
 
-			<field 
-				name="types" 
+			<field
+				name="types"
 				type="contenttype"
 				label="COM_TAGS_FIELD_TYPE_LABEL"
 				description="COM_TAGS_FIELD_TYPE_DESC"
 				multiple="true"
 			/>
 
-			<field 
+			<field
 				name="tag_list_language_filter"
 				type="contentlanguage"
 				label="COM_TAGS_FIELD_LANGUAGE_FILTER_LABEL"
@@ -49,8 +49,8 @@
 	<fields name="params">
 		<fieldset name="basic" label="COM_TAGS_OPTIONS">
 
-			<field 
-				name="show_tag_title" 
+			<field
+				name="show_tag_title"
 				type="list"
 				label="COM_TAGS_SHOW_TAG_TITLE_LABEL"
 				description="COM_TAGS_SHOW_TAG_TITLE_DESC"
@@ -61,8 +61,8 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field 
-				name="tag_list_show_tag_image" 
+			<field
+				name="tag_list_show_tag_image"
 				type="list"
 				label="COM_TAGS_SHOW_TAG_IMAGE_LABEL"
 				description="COM_TAGS_SHOW_TAG_IMAGE_DESC"
@@ -73,8 +73,8 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field 
-				name="tag_list_show_tag_description" 
+			<field
+				name="tag_list_show_tag_description"
 				type="list"
 				label="COM_TAGS_SHOW_TAG_DESCRIPTION_LABEL"
 				description="COM_TAGS_SHOW_TAG_DESCRIPTION_DESC"
@@ -85,25 +85,25 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field 
-				name="tag_list_image" 
+			<field
+				name="tag_list_image"
 				type="media"
 				label="COM_TAGS_TAG_LIST_MEDIA_LABEL"
 				description="COM_TAGS_TAG_LIST_MEDIA_DESC"
 			/>
 
-			<field 
-				name="tag_list_description" 
+			<field
+				name="tag_list_description"
 				type="textarea"
 				label="COM_TAGS_SHOW_TAG_LIST_DESCRIPTION_LABEL"
 				description="COM_TAGS_TAG_LIST_DESCRIPTION_DESC"
 				class="inputbox"
-				rows="3" 
-				cols="30" 
+				rows="3"
+				cols="30"
 				filter="safehtml"
 			/>
 
-			<field 
+			<field
 				name="tag_list_orderby"
 				type="list"
 				label="JGLOBAL_FIELD_FIELD_ORDERING_LABEL"
@@ -118,8 +118,8 @@
 				<option value="c.core_publish_up">JGLOBAL_PUBLISHED_DATE</option>
 			</field>
 
-			<field 
-				name="tag_list_orderby_direction" 
+			<field
+				name="tag_list_orderby_direction"
 				type="list"
 				label="JGLOBAL_ORDER_DIRECTION_LABEL"
 				description="JGLOBAL_ORDER_DIRECTION_DESC"
@@ -133,15 +133,15 @@
 
 		<fieldset name="advanced" label="JGLOBAL_LIST_LAYOUT_OPTIONS">
 
-			<field 
-				name="spacer2" 
-				type="spacer" 
+			<field
+				name="spacer2"
+				type="spacer"
 				label="COM_TAGS_SUBSLIDER_DRILL_TAG_LIST_LABEL"
 				class="text"
 			/>
 
-			<field 
-				name="tag_list_show_item_image" 
+			<field
+				name="tag_list_show_item_image"
 				type="list"
 				label="COM_TAGS_TAG_LIST_SHOW_ITEM_IMAGE_LABEL"
 				description="COM_TAGS_TAG_LIST_SHOW_ITEM_IMAGE_DESC"
@@ -152,8 +152,8 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field 
-				name="tag_list_show_item_description" 
+			<field
+				name="tag_list_show_item_description"
 				type="list"
 				label="COM_TAGS_TAG_LIST_SHOW_ITEM_DESCRIPTION_LABEL"
 				description="COM_TAGS_TAG_LIST_SHOW_ITEM_DESCRIPTION_DESC"
@@ -186,8 +186,8 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field	
-				name="show_pagination_limit" 
+			<field
+				name="show_pagination_limit"
 				type="list"
 				label="JGLOBAL_DISPLAY_SELECT_LABEL"
 				description="JGLOBAL_DISPLAY_SELECT_DESC"
@@ -198,8 +198,8 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field 
-				name="display_num" 
+			<field
+				name="display_num"
 				type="list"
 				label="COM_TAGS_FIELD_NUMBER_ITEMS_LIST_LABEL"
 				description="COM_TAGS_FIELD_NUMBER_ITEMS_LIST_DESC"
@@ -217,8 +217,8 @@
 				<option value="0">JALL</option>
 			</field>
 
-			<field 
-				name="show_pagination" 
+			<field
+				name="show_pagination"
 				type="list"
 				label="JGLOBAL_PAGINATION_LABEL"
 				description="JGLOBAL_PAGINATION_DESC"
@@ -230,8 +230,8 @@
 				<option value="2">JGLOBAL_AUTO</option>
 			</field>
 
-			<field 
-				name="show_pagination_results" 
+			<field
+				name="show_pagination_results"
 				type="list"
 				label="JGLOBAL_PAGINATION_RESULTS_LABEL"
 				description="JGLOBAL_PAGINATION_RESULTS_DESC"
@@ -242,8 +242,8 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field 
-				name="tag_list_show_date" 
+			<field
+				name="tag_list_show_date"
 				type="list"
 				label="JGLOBAL_SHOW_DATE_LABEL"
 				description="JGLOBAL_SHOW_DATE_DESC"
@@ -256,8 +256,8 @@
 				<option value="published">JPUBLISHED</option>
 			</field>
 
-			<field 
-				name="date_format" 
+			<field
+				name="date_format"
 				type="text"
 				label="JGLOBAL_DATE_FORMAT_LABEL"
 				description="JGLOBAL_DATE_FORMAT_DESC"
@@ -268,8 +268,8 @@
 
 		<fieldset name="selection" label="COM_TAGS_LIST_SELECTION_OPTIONS">
 
-			<field 
-				name="return_any_or_all" 
+			<field
+				name="return_any_or_all"
 				type="list"
 				label="COM_TAGS_SEARCH_TYPE_LABEL"
 				description="COM_TAGS_SEARCH_TYPE_DESC"
@@ -279,8 +279,8 @@
 				<option value="1">COM_TAGS_ANY</option>
 			</field>
 
-			<field 
-				name="include_children" 
+			<field
+				name="include_children"
 				type="list"
 				label="COM_TAGS_INCLUDE_CHILDREN_LABEL"
 				description="COM_TAGS_INCLUDE_CHILDREN_DESC"
@@ -295,8 +295,8 @@
 
 		<fieldset name="integration">
 
-			<field 
-				name="show_feed_link" 
+			<field
+				name="show_feed_link"
 				type="list"
 				label="JGLOBAL_SHOW_FEED_LINK_LABEL"
 				description="JGLOBAL_SHOW_FEED_LINK_DESC"

--- a/components/com_tags/views/tags/tmpl/default.xml
+++ b/components/com_tags/views/tags/tmpl/default.xml
@@ -11,10 +11,10 @@
 	<!-- Add fields to the request variables for the layout. -->
 	<fields name="request">
 		<fieldset name="request">
-		
-			<field 
-				name="parent_id" 
-				type="tag" 
+
+			<field
+				name="parent_id"
+				type="tag"
 				label="COM_TAGS_FIELD_PARENT_TAG_LABEL"
 				description="COM_TAGS_FIELD_PARENT_TAG_DESC"
 				mode="nested"
@@ -22,8 +22,8 @@
 				<option value="">JNONE</option>
 				<option value="1">JGLOBAL_ROOT</option>
 			</field>
-			
-			<field 
+
+			<field
 				name="tag_list_language_filter"
 				type="contentlanguage"
 				label="COM_TAGS_FIELD_LANGUAGE_FILTER_LABEL"
@@ -34,13 +34,13 @@
 				<option value="all">JALL</option>
 				<option value="current_language">JCURRENT</option>
 			</field>
-			
+
 		</fieldset>
 	</fields>
 	<!-- Add fields to the parameters object for the layout. -->
 	<fields name="params">
 		<fieldset name="basic">
-			
+
 			<field
 				name="tag_columns"
 				type="number"
@@ -50,19 +50,19 @@
 				filter="integer"
 			/>
 
-			<field 
-				name="all_tags_description" 
+			<field
+				name="all_tags_description"
 				type="textarea"
 				label="COM_TAGS_SHOW_ALL_TAGS_DESCRIPTION_LABEL"
 				description="COM_TAGS_ALL_TAGS_DESCRIPTION_DESC"
 				class="inputbox"
-				rows="3" 
-				cols="30" 
+				rows="3"
+				cols="30"
 				filter="safehtml"
 			/>
 
-			<field 
-				name="all_tags_show_description_image" 
+			<field
+				name="all_tags_show_description_image"
 				type="list"
 				label="COM_TAGS_SHOW_ALL_TAGS_IMAGE_LABEL"
 				description="COM_TAGS_SHOW_ALL_TAGS_IMAGE_DESC"
@@ -73,14 +73,14 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field 
-				name="all_tags_description_image" 
+			<field
+				name="all_tags_description_image"
 				type="media"
 				label="COM_TAGS_ALL_TAGS_MEDIA_LABEL"
 				description="COM_TAGS_ALL_TAGS_MEDIA_DESC"
 			/>
 
-			<field 
+			<field
 				name="all_tags_orderby"
 				type="list"
 				label="JGLOBAL_FIELD_FIELD_ORDERING_LABEL"
@@ -94,8 +94,8 @@
 				<option value="publish_up">JGLOBAL_PUBLISHED_DATE</option>
 			</field>
 
-			<field 
-				name="all_tags_orderby_direction" 
+			<field
+				name="all_tags_orderby_direction"
 				type="list"
 				label="JGLOBAL_ORDER_DIRECTION_LABEL"
 				description="JGLOBAL_ORDER_DIRECTION_DESC"
@@ -105,8 +105,8 @@
 				<option value="DESC">JGLOBAL_ORDER_DESCENDING</option>
 			</field>
 
-			<field 
-				name="all_tags_show_tag_image" 
+			<field
+				name="all_tags_show_tag_image"
 				type="list"
 				label="COM_TAGS_SHOW_ITEM_IMAGE_LABEL"
 				description="COM_TAGS_SHOW_ITEM_IMAGE_DESC"
@@ -117,8 +117,8 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field 
-				name="all_tags_show_tag_description" 
+			<field
+				name="all_tags_show_tag_description"
 				type="list"
 				label="COM_TAGS_SHOW_ITEM_DESCRIPTION_LABEL"
 				description="COM_TAGS_SHOW_ITEM_DESCRIPTION_DESC"
@@ -137,8 +137,8 @@
 				filter="integer"
 			/>
 
-			<field 
-				name="all_tags_show_tag_hits" 
+			<field
+				name="all_tags_show_tag_hits"
 				type="list"
 				label="JGLOBAL_HITS"
 				description="COM_TAGS_FIELD_CONFIG_HITS_DESC"
@@ -148,12 +148,12 @@
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-			
+
 		</fieldset>
-		<fieldset 
-			name="selection" 
-			label="COM_TAGS_LIST_ALL_SELECTION_OPTIONS"> 
-			
+		<fieldset
+			name="selection"
+			label="COM_TAGS_LIST_ALL_SELECTION_OPTIONS">
+
 			<field
 				name="maximum"
 				type="number"
@@ -175,9 +175,9 @@
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-		
-			<field	
-				name="show_pagination_limit" 
+
+			<field
+				name="show_pagination_limit"
 				type="list"
 				label="JGLOBAL_DISPLAY_SELECT_LABEL"
 				description="JGLOBAL_DISPLAY_SELECT_DESC"
@@ -187,9 +187,9 @@
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-			
-			<field 
-				name="show_pagination" 
+
+			<field
+				name="show_pagination"
 				type="list"
 				label="JGLOBAL_PAGINATION_LABEL"
 				description="JGLOBAL_PAGINATION_DESC"
@@ -201,8 +201,8 @@
 				<option value="2">JGLOBAL_AUTO</option>
 			</field>
 
-			<field 
-				name="show_pagination_results" 
+			<field
+				name="show_pagination_results"
 				type="list"
 				label="JGLOBAL_PAGINATION_RESULTS_LABEL"
 				description="JGLOBAL_PAGINATION_RESULTS_DESC"
@@ -212,11 +212,11 @@
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-			
+
 		</fieldset>
 		<fieldset name="integration">
 			<field
-				name="show_feed_link" 
+				name="show_feed_link"
 				type="list"
 				label="JGLOBAL_SHOW_FEED_LINK_LABEL"
 				description="JGLOBAL_SHOW_FEED_LINK_DESC"


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Only remove trailing whitespaces in xml files.
In one file a new line was added at end of file.


### Testing Instructions
Merge by code review.
