### PR TITLE
[4.0] Follow-up adding category language to getCategoryRoute()

### DIFF
--- a/components/com_contact/View/Contact/HtmlView.php
+++ b/components/com_contact/View/Contact/HtmlView.php
@@ -477,7 +477,7 @@ class HtmlView extends BaseHtmlView
 
 			while ($category && ($menu->query['option'] !== 'com_contact' || $menu->query['view'] === 'contact' || $id != $category->id) && $category->id > 1)
 			{
-				$path[] = array('title' => $category->title, 'link' => ContactHelperRoute::getCategoryRoute($this->contact->catid));
+				$path[] = array('title' => $category->title, 'link' => ContactHelperRoute::getCategoryRoute($category->id, $category->language));
 				$category = $category->getParent();
 			}
 

--- a/components/com_newsfeeds/View/Category/HtmlView.php
+++ b/components/com_newsfeeds/View/Category/HtmlView.php
@@ -82,7 +82,7 @@ class HtmlView extends CategoryView
 
 			while (($menu->query['option'] !== 'com_newsfeeds' || $menu->query['view'] === 'newsfeed' || $id != $category->id) && $category->id > 1)
 			{
-				$path[] = array('title' => $category->title, 'link' => NewsfeedsHelperRoute::getCategoryRoute($category->id));
+				$path[] = array('title' => $category->title, 'link' => NewsfeedsHelperRoute::getCategoryRoute($category->id, $category->language));
 				$category = $category->getParent();
 			}
 

--- a/components/com_newsfeeds/tmpl/category/default_children.php
+++ b/components/com_newsfeeds/tmpl/category/default_children.php
@@ -21,7 +21,7 @@ use Joomla\CMS\Language\Text;
 			<?php if ($this->params->get('show_empty_categories') || $child->numitems || count($child->getChildren())) : ?>
 				<li>
 					<span class="item-title">
-						<a href="<?php echo Route::_(NewsfeedsHelperRoute::getCategoryRoute($child->id)); ?>">
+						<a href="<?php echo Route::_(NewsfeedsHelperRoute::getCategoryRoute($child->id, $child->language)); ?>">
 							<?php echo $this->escape($child->title); ?>
 						</a>
 					</span>

--- a/modules/mod_articles_categories/tmpl/default_items.php
+++ b/modules/mod_articles_categories/tmpl/default_items.php
@@ -22,7 +22,7 @@ $id     = $input->getInt('id');
 foreach ($list as $item) : ?>
 	<li<?php if ($id == $item->id && $view == 'category' && $option == 'com_content') echo ' class="active"'; ?>> <?php $levelup = $item->level - $startLevel - 1; ?>
 		<h<?php echo $params->get('item_heading') + $levelup; ?>>
-		<a href="<?php echo Route::_(ContentHelperRoute::getCategoryRoute($item->id)); ?>">
+		<a href="<?php echo Route::_(ContentHelperRoute::getCategoryRoute($item->id, $item->language)); ?>">
 		<?php echo $item->title; ?>
 			<?php if ($params->get('numitems')) : ?>
 				(<?php echo $item->numitems; ?>)

--- a/modules/mod_articles_category/Helper/ArticlesCategoryHelper.php
+++ b/modules/mod_articles_category/Helper/ArticlesCategoryHelper.php
@@ -299,7 +299,7 @@ abstract class ArticlesCategoryHelper
 
 			if ($item->catid)
 			{
-				$item->displayCategoryLink  = Route::_(\ContentHelperRoute::getCategoryRoute($item->catid));
+				$item->displayCategoryLink  = Route::_(\ContentHelperRoute::getCategoryRoute($item->catid, $item->category_language));
 				$item->displayCategoryTitle = $show_category ? '<a href="' . $item->displayCategoryLink . '">' . $item->category_title . '</a>' : '';
 			}
 			else

--- a/plugins/search/categories/categories.php
+++ b/plugins/search/categories/categories.php
@@ -154,14 +154,14 @@ class PlgSearchCategories extends CMSPlugin
 
 		$query->select('a.title, a.description AS text, a.created_time AS created')
 			->select($db->quote('2') . ' AS browsernav')
-			->select('a.id AS catid')
+			->select('a.id AS catid, a.language AS category_language')
 			->select($case_when)
 			->from($db->quoteName('#__categories', 'a'))
 			->where(
 				'(a.title LIKE ' . $text . ' OR a.description LIKE ' . $text . ') AND a.published IN (' . implode(',', $state) . ') AND a.extension = '
 				. $db->quote('com_content') . 'AND a.access IN (' . $groups . ')'
 			)
-			->group('a.id, a.title, a.description, a.alias, a.created_time')
+			->group('a.id, a.title, a.description, a.alias, a.created_time, a.language')
 			->order($order);
 
 		if ($app->isClient('site') && Multilanguage::isEnabled())
@@ -189,7 +189,7 @@ class PlgSearchCategories extends CMSPlugin
 			{
 				if (searchHelper::checkNoHtml($row, $searchText, array('name', 'title', 'text')))
 				{
-					$row->href = ContentHelperRoute::getCategoryRoute($row->slug);
+					$row->href = ContentHelperRoute::getCategoryRoute($row->slug, $row->category_language);
 					$row->section = Text::_('JCATEGORY');
 
 					$return[] = $row;


### PR DESCRIPTION
Pull Request to follow-up https://github.com/joomla/joomla-cms/pull/21916 which has now been merged.

### Summary of Changes
Adding the $language variable where missing when using getCategoryRoute()
Newsfeeds, Contact, mod_articles_categories, mod_articles_category, categories search plugin

### Testing Instructions
Monolanguage: all should work as before.
Multilingual: info-block is not concerned as in #21916, but now all non menu links should work correctly for these components, modules, com_search for category name.

IMPORTANT:
One has to create a `List All Categories` menu item for articles as well as a `List All Contact Categories` and a `List All News Feed Categories` to cope with categories which do not have any specific menu item. This in order to get nice urls. 

As the modifications are quite obvious, it can be merged on review.

@Hackwar @csthomas 
