### PR TITLE
[4.0] Typo in update sql

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/4.0.0-2018-07-19.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.0.0-2018-07-19.sql
@@ -15,4 +15,4 @@ CREATE TABLE IF NOT EXISTS `#__template_overrides` (
 
 INSERT INTO `#__extensions` (`extension_id`, `package_id`, `name`, `type`, `element`, `folder`, `client_id`, `enabled`, `access`, `protected`, `manifest_cache`, `params`, `checked_out`, `checked_out_time`, `ordering`, `state`, `namespace`) VALUES
 (491, 0, 'plg_installer_override', 'plugin', 'override', 'installer', 0, 1, 1, 1, '', '', 0, '0000-00-00 00:00:00', 4, 0, ''),
-(492, 0, 'plg_quickicon_overridecheck', 'plugin', 'overridecheck', 'quickicon', 0, 1, 1, 1, '', '', 0, '0000-00-00 00:00:00', 0, 0, ''),
+(492, 0, 'plg_quickicon_overridecheck', 'plugin', 'overridecheck', 'quickicon', 0, 1, 1, 1, '', '', 0, '0000-00-00 00:00:00', 0, 0, '');


### PR DESCRIPTION
Typo in https://github.com/joomla/joomla-cms/pull/21851 merge

### Summary of Changes
`,` changed to `;`


Can be merged on review