### PR TITLE
[FIX} Calendar wrong locale variable

### DIFF
--- a/media/system/js/fields/calendar-locales/af.js
+++ b/media/system/js/fields/calendar-locales/af.js
@@ -15,5 +15,5 @@ window.JoomlaCalLocale = {
 	minYear : 1900,
 	maxYear : 2100,
 	exit: "Sluit",
-	save: "Stoor"
+	clear: "Stoor"
 };

--- a/media/system/js/fields/calendar-locales/ar.js
+++ b/media/system/js/fields/calendar-locales/ar.js
@@ -15,5 +15,5 @@ window.JoomlaCalLocale = {
 	minYear : 1900,
 	maxYear : 2100,
 	exit: "إغلاق",
-	save: "الغاء"
+	clear: "الغاء"
 };

--- a/media/system/js/fields/calendar-locales/bg.js
+++ b/media/system/js/fields/calendar-locales/bg.js
@@ -15,5 +15,5 @@ window.JoomlaCalLocale = {
 	minYear : 1900,
 	maxYear : 2100,
 	exit: "Затвори",
-	save: "Изчисти"
+	clear: "Изчисти"
 };

--- a/media/system/js/fields/calendar-locales/bn.js
+++ b/media/system/js/fields/calendar-locales/bn.js
@@ -15,5 +15,5 @@ window.JoomlaCalLocale = {
 	minYear : 1900,
 	maxYear : 2100,
 	exit: "প্রস্থান",
-	save: "সংরক্ষণ"
+	clear: "সংরক্ষণ"
 };

--- a/media/system/js/fields/calendar-locales/bs.js
+++ b/media/system/js/fields/calendar-locales/bs.js
@@ -15,5 +15,5 @@ window.JoomlaCalLocale = {
 	minYear : 1900,
 	maxYear : 2100,
 	exit: "Zatvori",
-	save: "Snimi"
+	clear: "Snimi"
 };

--- a/media/system/js/fields/calendar-locales/ca.js
+++ b/media/system/js/fields/calendar-locales/ca.js
@@ -15,5 +15,5 @@ window.JoomlaCalLocale = {
 	minYear : 1900,
 	maxYear : 2100,
 	exit: "Tancar",
-	save: "Desar"
+	clear: "Desar"
 };

--- a/media/system/js/fields/calendar-locales/cs.js
+++ b/media/system/js/fields/calendar-locales/cs.js
@@ -15,5 +15,5 @@ window.JoomlaCalLocale = {
 	minYear : 1900,
 	maxYear : 2100,
 	exit: "zavřít",
-	save: "vymazat"
+	clear: "vymazat"
 };

--- a/media/system/js/fields/calendar-locales/cy.js
+++ b/media/system/js/fields/calendar-locales/cy.js
@@ -15,5 +15,5 @@ window.JoomlaCalLocale = {
 	minYear : 1900,
 	maxYear : 2100,
 	exit: "Cau",
-	save: "Clirio"
+	clear: "Clirio"
 };

--- a/media/system/js/fields/calendar-locales/da.js
+++ b/media/system/js/fields/calendar-locales/da.js
@@ -15,5 +15,5 @@ window.JoomlaCalLocale = {
 	minYear : 1900,
 	maxYear : 2100,
 	exit: "Luk",
-	save: "Nulstil"
+	clear: "Nulstil"
 };

--- a/media/system/js/fields/calendar-locales/de.js
+++ b/media/system/js/fields/calendar-locales/de.js
@@ -15,5 +15,5 @@ window.JoomlaCalLocale = {
 	minYear : 1900,
 	maxYear : 2100,
 	exit: "Schließen",
-	save: "Leeren"
+	clear: "Leeren"
 };

--- a/media/system/js/fields/calendar-locales/el.js
+++ b/media/system/js/fields/calendar-locales/el.js
@@ -15,5 +15,5 @@ window.JoomlaCalLocale = {
 	minYear : 1900,
 	maxYear : 2100,
 	exit: "Κλείσιμο",
-	save: "Καθαρισμός"
+	clear: "Καθαρισμός"
 };

--- a/media/system/js/fields/calendar-locales/en.js
+++ b/media/system/js/fields/calendar-locales/en.js
@@ -15,5 +15,5 @@ window.JoomlaCalLocale = {
 	minYear : 1900,
 	maxYear : 2100,
 	exit: "Close",
-	save: "Clear"
+	clear: "Clear"
 };

--- a/media/system/js/fields/calendar-locales/es.js
+++ b/media/system/js/fields/calendar-locales/es.js
@@ -15,5 +15,5 @@ window.JoomlaCalLocale = {
 	minYear : 1900,
 	maxYear : 2100,
 	exit: "Cerrar",
-	save: "Limpiar"
+	clear: "Limpiar"
 };

--- a/media/system/js/fields/calendar-locales/eu.js
+++ b/media/system/js/fields/calendar-locales/eu.js
@@ -15,5 +15,5 @@ window.JoomlaCalLocale = {
 	minYear : 1900,
 	maxYear : 2100,
 	exit: "Itxi",
-	save: "Garbitu"
+	clear: "Garbitu"
 };

--- a/media/system/js/fields/calendar-locales/fa-ir.js
+++ b/media/system/js/fields/calendar-locales/fa-ir.js
@@ -15,6 +15,6 @@ window.JoomlaCalLocale = {
 	minYear : 1268,
 	maxYear : 1458,
 	exit: "بستن",
-	save: "پاک",
+	clear: "پاک",
 	localLangNumbers: ["۰","۱","۲","۳","۴","۵","۶","۷","۸","۹"]
 };

--- a/media/system/js/fields/calendar-locales/fi.js
+++ b/media/system/js/fields/calendar-locales/fi.js
@@ -15,5 +15,5 @@ window.JoomlaCalLocale = {
 	minYear : 1900,
 	maxYear : 2100,
 	exit: "Sulje",
-	save: "Tyhjennä"
+	clear: "Tyhjennä"
 };

--- a/media/system/js/fields/calendar-locales/fr.js
+++ b/media/system/js/fields/calendar-locales/fr.js
@@ -15,5 +15,5 @@ window.JoomlaCalLocale = {
 	minYear : 1900,
 	maxYear : 2100,
 	exit: "Fermer",
-	save: "Effacer"
+	clear: "Effacer"
 };

--- a/media/system/js/fields/calendar-locales/ga.js
+++ b/media/system/js/fields/calendar-locales/ga.js
@@ -15,5 +15,5 @@ window.JoomlaCalLocale = {
 	minYear : 1900,
 	maxYear : 2100,
 	exit: "Dún",
-	save: "Glan"
+	clear: "Glan"
 };

--- a/media/system/js/fields/calendar-locales/hr.js
+++ b/media/system/js/fields/calendar-locales/hr.js
@@ -15,5 +15,5 @@ window.JoomlaCalLocale = {
 	minYear : 1900,
 	maxYear : 2100,
 	exit: "Zatvori",
-	save: "Otkaži"
+	clear: "Otkaži"
 };

--- a/media/system/js/fields/calendar-locales/hu.js
+++ b/media/system/js/fields/calendar-locales/hu.js
@@ -15,5 +15,5 @@ window.JoomlaCalLocale = {
 	minYear : 1900,
 	maxYear : 2100,
 	exit: "Bezárás",
-	save: "Törlés"
+	clear: "Törlés"
 };

--- a/media/system/js/fields/calendar-locales/it.js
+++ b/media/system/js/fields/calendar-locales/it.js
@@ -15,5 +15,5 @@ window.JoomlaCalLocale = {
 	minYear : 1900,
 	maxYear : 2100,
 	exit: "Chiudi",
-	save: "Annulla"
+	clear: "Annulla"
 };

--- a/media/system/js/fields/calendar-locales/ja.js
+++ b/media/system/js/fields/calendar-locales/ja.js
@@ -15,5 +15,5 @@ window.JoomlaCalLocale = {
 	minYear : 1900,
 	maxYear : 2100,
 	exit: "閉じる",
-	save: "クリア"
+	clear: "クリア"
 };

--- a/media/system/js/fields/calendar-locales/ka.js
+++ b/media/system/js/fields/calendar-locales/ka.js
@@ -15,5 +15,5 @@ window.JoomlaCalLocale = {
 	minYear : 1900,
 	maxYear : 2100,
 	exit: "დახურვა",
-	save: "გასუფთავება"
+	clear: "გასუფთავება"
 };

--- a/media/system/js/fields/calendar-locales/ko.js
+++ b/media/system/js/fields/calendar-locales/ko.js
@@ -15,5 +15,5 @@ window.JoomlaCalLocale = {
 	minYear : 1900,
 	maxYear : 2100,
 	exit: "닫기",
-	save: "Clear"
+	clear: "Clear"
 };

--- a/media/system/js/fields/calendar-locales/lt.js
+++ b/media/system/js/fields/calendar-locales/lt.js
@@ -15,5 +15,5 @@ window.JoomlaCalLocale = {
 	minYear : 1900,
 	maxYear : 2100,
 	exit: "Uždaryti",
-	save: "Išvalyti"
+	clear: "Išvalyti"
 };

--- a/media/system/js/fields/calendar-locales/mk.js
+++ b/media/system/js/fields/calendar-locales/mk.js
@@ -15,5 +15,5 @@ window.JoomlaCalLocale = {
 	minYear : 1900,
 	maxYear : 2100,
 	exit: "Затвори",
-	save: "Зачувај"
+	clear: "Зачувај"
 };

--- a/media/system/js/fields/calendar-locales/nb.js
+++ b/media/system/js/fields/calendar-locales/nb.js
@@ -15,5 +15,5 @@ window.JoomlaCalLocale = {
 	minYear : 1900,
 	maxYear : 2100,
 	exit: "Lukk",
-	save: "Tøm"
+	clear: "Tøm"
 };

--- a/media/system/js/fields/calendar-locales/nl.js
+++ b/media/system/js/fields/calendar-locales/nl.js
@@ -15,5 +15,5 @@ window.JoomlaCalLocale = {
 	minYear : 1900,
 	maxYear : 2100,
 	exit: "Sluiten",
-	save: "Legen"
+	clear: "Legen"
 };

--- a/media/system/js/fields/calendar-locales/pl.js
+++ b/media/system/js/fields/calendar-locales/pl.js
@@ -15,5 +15,5 @@ window.JoomlaCalLocale = {
 	minYear : 1900,
 	maxYear : 2100,
 	exit: "Zamknij",
-	save: "Wyczyść"
+	clear: "Wyczyść"
 };

--- a/media/system/js/fields/calendar-locales/prs-af.js
+++ b/media/system/js/fields/calendar-locales/prs-af.js
@@ -15,6 +15,6 @@ window.JoomlaCalLocale = {
 	minYear : 1268,
 	maxYear : 1458,
 	exit: "بستن",
-	save: "پاک",
+	clear: "پاک",
 	localLangNumbers: ["۰","۱","۲","۳","۴","۵","۶","۷","۸","۹"]
 };

--- a/media/system/js/fields/calendar-locales/pt.js
+++ b/media/system/js/fields/calendar-locales/pt.js
@@ -15,5 +15,5 @@ window.JoomlaCalLocale = {
 	minYear : 1900,
 	maxYear : 2100,
 	exit: "Fechar",
-	save: "Limpar"
+	clear: "Limpar"
 };

--- a/media/system/js/fields/calendar-locales/ru.js
+++ b/media/system/js/fields/calendar-locales/ru.js
@@ -15,5 +15,5 @@ window.JoomlaCalLocale = {
 	minYear : 1900,
 	maxYear : 2100,
 	exit: "Закрыть",
-	save: "Очистить"
+	clear: "Очистить"
 };

--- a/media/system/js/fields/calendar-locales/sk.js
+++ b/media/system/js/fields/calendar-locales/sk.js
@@ -15,5 +15,5 @@ window.JoomlaCalLocale = {
 	minYear : 1900,
 	maxYear : 2100,
 	exit: "Zavrieť",
-	save: "Vymazať"
+	clear: "Vymazať"
 };

--- a/media/system/js/fields/calendar-locales/sl.js
+++ b/media/system/js/fields/calendar-locales/sl.js
@@ -15,5 +15,5 @@ window.JoomlaCalLocale = {
 	minYear : 1900,
 	maxYear : 2100,
 	exit: "Zapri",
-	save: "Počisti"
+	clear: "Počisti"
 };

--- a/media/system/js/fields/calendar-locales/sr-rs.js
+++ b/media/system/js/fields/calendar-locales/sr-rs.js
@@ -15,5 +15,5 @@ window.JoomlaCalLocale = {
 	minYear : 1900,
 	maxYear : 2100,
 	exit: "Затвори",
-	save: "Зачувај"
+	clear: "Зачувај"
 };

--- a/media/system/js/fields/calendar-locales/sr-yu.js
+++ b/media/system/js/fields/calendar-locales/sr-yu.js
@@ -15,5 +15,5 @@ window.JoomlaCalLocale = {
 	minYear : 1900,
 	maxYear : 2100,
 	exit: "Zatvori",
-	save: "Sačuvaj"
+	clear: "Sačuvaj"
 };

--- a/media/system/js/fields/calendar-locales/sv.js
+++ b/media/system/js/fields/calendar-locales/sv.js
@@ -15,5 +15,5 @@ window.JoomlaCalLocale = {
 	minYear : 1900,
 	maxYear : 2100,
 	exit: "Stäng",
-	save: "Rensa"
+	clear: "Rensa"
 };

--- a/media/system/js/fields/calendar-locales/sw.js
+++ b/media/system/js/fields/calendar-locales/sw.js
@@ -15,5 +15,5 @@
 	minYear : 1900,
 	maxYear : 2100,
 	exit: "Funga",
-	save: "Safisha"
+	clear: "Safisha"
 };

--- a/media/system/js/fields/calendar-locales/ta.js
+++ b/media/system/js/fields/calendar-locales/ta.js
@@ -15,5 +15,5 @@ window.JoomlaCalLocale = {
 	minYear : 1900,
 	maxYear : 2100,
 	exit: "மூடுக",
-	save: "துடைக்க"
+	clear: "துடைக்க"
 };

--- a/media/system/js/fields/calendar-locales/th.js
+++ b/media/system/js/fields/calendar-locales/th.js
@@ -15,5 +15,5 @@ window.JoomlaCalLocale = {
 	minYear : 1900,
 	maxYear : 2100,
 	exit: "ปิด",
-	save: "ล้าง"
+	clear: "ล้าง"
 };

--- a/media/system/js/fields/calendar-locales/uk.js
+++ b/media/system/js/fields/calendar-locales/uk.js
@@ -15,5 +15,5 @@ window.JoomlaCalLocale = {
 	minYear : 1900,
 	maxYear : 2100,
 	exit: "Закрити",
-	save: "Очистити"
+	clear: "Очистити"
 };

--- a/media/system/js/fields/calendar-locales/zh-CN.js
+++ b/media/system/js/fields/calendar-locales/zh-CN.js
@@ -15,5 +15,5 @@ window.JoomlaCalLocale = {
 	minYear : 1900,
 	maxYear : 2100,
 	exit: "关闭",
-	save: "清除"
+	clear: "清除"
 };

--- a/media/system/js/fields/calendar-locales/zh-TW.js
+++ b/media/system/js/fields/calendar-locales/zh-TW.js
@@ -15,5 +15,5 @@ window.JoomlaCalLocale = {
 	minYear : 1900,
 	maxYear : 2100,
 	exit: "關閉",
-	save: "清除"
+	clear: "清除"
 };


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/22025

### Summary of Changes
The calendar js is using the `clear` variable and not the `save` variable to clear the field.
Therefore the button `Clear` is NOT translated when using another language.

The js code is clear ( 😄 )
`this._nav_clear = hh(JoomlaCalLocale.clear, '', 100, 'button', '', 'js-btn btn btn-clear', {"type": "button", "data-action": "clear"});`

and not `save`...


### Testing Instructions
Click on a calendar icon in backend publishing article tab and look at the buttons at the bottom when using another language than English (therefore not en-GB, en-US, en-Ca, etc if any)

Test in French

### Before patch
<img width="485" alt="screen shot 2018-09-06 at 18 05 29" src="https://user-images.githubusercontent.com/869724/45170149-7a36f900-b1ff-11e8-97b2-fc7ba382154e.png">



### After patch

<img width="537" alt="screen shot 2018-09-06 at 18 03 19" src="https://user-images.githubusercontent.com/869724/45170062-4c51b480-b1ff-11e8-9b82-ab300c69a471.png">


@boomsya 