### PR TITLE
[com_modules] Client filter not respected in fields after editing module

### DIFF
--- a/administrator/components/com_modules/models/fields/modulesmodule.php
+++ b/administrator/components/com_modules/models/fields/modulesmodule.php
@@ -37,8 +37,7 @@ class JFormFieldModulesModule extends JFormFieldList
 	 */
 	public function getOptions()
 	{
-		$clientId = JFactory::getApplication()->input->get('client_id', 0, 'int');
-		$options  = ModulesHelper::getModules($clientId);
+		$options  = ModulesHelper::getModules(JFactory::getApplication()->getUserState('com_modules.modules.client_id', 0, 'int'));
 
 		return array_merge(parent::getOptions(), $options);
 	}

--- a/administrator/components/com_modules/models/fields/modulesposition.php
+++ b/administrator/components/com_modules/models/fields/modulesposition.php
@@ -37,8 +37,7 @@ class JFormFieldModulesPosition extends JFormFieldList
 	 */
 	public function getOptions()
 	{
-		$clientId = JFactory::getApplication()->input->get('client_id', 0, 'int');
-		$options  = ModulesHelper::getPositions($clientId);
+		$options  = ModulesHelper::getPositions(JFactory::getApplication()->getUserState('com_modules.modules.client_id', 0, 'int'));
 
 		return array_merge(parent::getOptions(), $options);
 	}


### PR DESCRIPTION
Pull Request for Issue #22037.

### Summary of Changes

This fixes the issue of module positions and types not being filtered correctly in filter form fields.

### Testing Instructions
Go to `com_modules`.
In filter form select `Administrator` client.
Check that administrator positions and types are shown in `- Select Position -` and `- Select Type -` fields.
Mark any module and click Publish or Unpublish.
Check position and type fields again.

### Expected result
Administrator positions and types shown.

### Actual result
Site positions and types shown.

### Documentation Changes Required
No.
