### PR TITLE
[4.0] Finder: Replacing iconv() with mb_convert_encoding()

### DIFF
--- a/administrator/components/com_finder/helpers/indexer/parser/html.php
+++ b/administrator/components/com_finder/helpers/indexer/parser/html.php
@@ -33,7 +33,10 @@ class FinderIndexerParserHtml extends FinderIndexerParser
 	public function parse($input)
 	{
 		// Strip invalid UTF-8 characters.
-		$input = iconv('utf-8', 'utf-8//IGNORE', $input);
+		$oldSetting = ini_get('mbstring.substitute_character');
+		ini_set('mbstring.substitute_character', 'none');
+		$input = mb_convert_encoding($input, 'UTF-8', 'UTF-8'); 
+		ini_set('mbstring.substitute_character', $oldSetting);
 
 		// Remove anything between <head> and </head> tags.  Do this first
 		// because there might be <script> or <style> tags nested inside.


### PR DESCRIPTION
The original issue is this here: https://forum.joomla.org/viewtopic.php?t=860554#p3503601
Looking through the documentation, iconv() indeed has issues: https://secure.php.net/manual/en/function.iconv.php

The more reliable solution as it seems is this code.

### Testing Instructions
Apply this patch and run the indexer of Smart Search in the backend. See that it still works.