### PR TITLE
[3.9][postgresql] - wrong field name subjext

### DIFF
--- a/administrator/components/com_admin/sql/updates/postgresql/3.9.0-2018-05-24.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.9.0-2018-05-24.sql
@@ -9,7 +9,7 @@ CREATE TABLE "#__privacy_consents" (
   "id" serial NOT NULL,
   "user_id" bigint DEFAULT 0 NOT NULL,
   "created" timestamp without time zone DEFAULT '1970-01-01 00:00:00' NOT NULL,
-  "subjext" varchar(255) DEFAULT '' NOT NULL,
+  "subject" varchar(255) DEFAULT '' NOT NULL,
   "body" text NOT NULL,
   "remind" smallint DEFAULT 0 NOT NULL,
   "token" varchar(100) DEFAULT '' NOT NULL,

--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -1685,7 +1685,7 @@ CREATE TABLE "#__privacy_consents" (
   "user_id" bigint DEFAULT 0 NOT NULL,
   "state" smallint DEFAULT 1 NOT NULL,
   "created" timestamp without time zone DEFAULT '1970-01-01 00:00:00' NOT NULL,
-  "subjext" varchar(255) DEFAULT '' NOT NULL,
+  "subject" varchar(255) DEFAULT '' NOT NULL,
   "body" text NOT NULL,
   "remind" smallint DEFAULT 0 NOT NULL,
   "token" varchar(100) DEFAULT '' NOT NULL,


### PR DESCRIPTION

### Summary of Changes
fix the typo on `#__privacy_consents` table from field `subjext` to `subject`

can be merged on review