### PR TITLE
[4.0] Fix for #22053 COM_USERS enabling and adding YubiKey runs into Fatal error Joomla\CMS\Encrypt\Randvalinterface not found

### DIFF
--- a/libraries/src/Encrypt/Randval.php
+++ b/libraries/src/Encrypt/Randval.php
@@ -10,8 +10,6 @@ namespace Joomla\CMS\Encrypt;
 
 defined('JPATH_PLATFORM') or die;
 
-use \Joomla\CMS\Encrypt\RandValInterface;
-
 /**
  * Generates cryptographically-secure random values.
  */

--- a/libraries/src/Encrypt/Randval.php
+++ b/libraries/src/Encrypt/Randval.php
@@ -10,10 +10,12 @@ namespace Joomla\CMS\Encrypt;
 
 defined('JPATH_PLATFORM') or die;
 
+use \Joomla\CMS\Encrypt\RandValInterface;
+
 /**
  * Generates cryptographically-secure random values.
  */
-class Randval implements Randvalinterface
+class Randval implements RandValInterface
 {
 	/**
 	 *


### PR DESCRIPTION
Pull Request for Issue #22053.

### Summary of Changes
uses and implements the missing namespace

### Testing Instructions
Enable Two Factor Authentication - YubiKey Plugin
Edit a user and set Authentication Method to YubiKey
Add a YubiKey and trigger save

### Expected result
Save event should run without errors and YubiKey should be added

### Actual result
Save event did run into fatal error: Interface 'Joomla\CMS\Encrypt\Randvalinterface' not found in /html/joomladev_nightly-build2/libraries/src/Encrypt/Randval.php on line 16

### Documentation Changes Required
No
