### PR TITLE
[4.0] Fix transitions controller missing namespace

### DIFF
--- a/administrator/components/com_workflow/Controller/StagesController.php
+++ b/administrator/components/com_workflow/Controller/StagesController.php
@@ -26,7 +26,7 @@ use Joomla\Utilities\ArrayHelper;
 class StagesController extends AdminController
 {
 	/**
-	 * The workflow in where the stage belons to
+	 * The workflow in where the stage belongs to
 	 *
 	 * @var    integer
 	 * @since  __DEPLOY_VERSION__

--- a/administrator/components/com_workflow/Controller/TransitionsController.php
+++ b/administrator/components/com_workflow/Controller/TransitionsController.php
@@ -12,6 +12,7 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Controller\AdminController;
+use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
 use Joomla\CMS\Router\Route;
 
 /**


### PR DESCRIPTION
Followup pr to fix #21641 missing namespace in transitions controller class

### Testing Instructions
Trash/Publish a transition.

### Expected result
Should work.

### Actual result
Fails with a PHP telling you on variable is wrong.
```
Argument 2 passed to Joomla\Component\Workflow\Administrator\Controller\TransitionsController::__construct() must be an instance of Joomla\Component\Workflow\Administrator\Controller\MVCFactoryInterface or null, instance of Joomla\CMS\MVC\Factory\MVCFactory given, called in libraries/src/MVC/Factory/MVCFactory.php on line 86
```

