### PR TITLE
[4.0] Fixed the drag and drop installation failing due to missing data

### DIFF
--- a/build/media_src/com_installer/js/installer.es6.js
+++ b/build/media_src/com_installer/js/installer.es6.js
@@ -185,6 +185,7 @@ document.addEventListener('DOMContentLoaded', () => {
       url: uploadUrl,
       method: 'POST',
       perform: true,
+      data: data,
       headers: { 'Content-Type': 'false' },
       onSuccess: (response) => {
         const res = JSON.parse(response);

--- a/libraries/src/Installer/InstallerScript.php
+++ b/libraries/src/Installer/InstallerScript.php
@@ -127,8 +127,9 @@ class InstallerScript
 		}
 
 		// Extension manifest file version
-		$this->release = $parent->getManifest()->version;
-		$extensionType = substr($this->extension, 0, 3);
+		$this->extension = $parent->getName();
+		$this->release   = $parent->getManifest()->version;
+		$extensionType   = substr($this->extension, 0, 3);
 
 		// Modules parameters are located in the module table - else in the extension table
 		if ($extensionType === 'mod')


### PR DESCRIPTION
Pull Request for Issue #22043 

### Summary of Changes
Added the data to be posted on installation

### Testing Instructions
1. Go to System -> Install -> Extension
2. Click on the Upload Package File tab
3. Drag and drop a package
4. Notice the installation fails
5. Apply patch
6. Run `npm install`
7. Go to System -> Install -> Extension
8. Click on the Upload Package File tab
9. Drag and drop a package
10. Notice the installation succeeds


### Expected result
Installation succeeds


### Actual result
Installation fails


### Documentation Changes Required
None
