### PR TITLE
Make privacy consent required

### DIFF
--- a/plugins/system/privacyconsent/privacyconsent/privacyconsent.xml
+++ b/plugins/system/privacyconsent/privacyconsent/privacyconsent.xml
@@ -12,6 +12,7 @@
 				description="PLG_SYSTEM_PRIVACYCONSENT_FIELD_DESC"
 				default="0"
 				filter="integer"
+				required="true"
 				>
 				<option value="1">PLG_SYSTEM_PRIVACYCONSENT_OPTION_AGREE</option>
 				<option value="0">JNO</option>


### PR DESCRIPTION
Pull Request for Issue #22082 

### Summary of Changes
This makes sure the consent field is set to required.


### Testing Instructions
1. Make sure user registration is enabled
2. Go to plugins
3. Filter on `privacy`
4. Enable the `System - Privacy Consent` plugin
5. Go to the front-end and click on `Create an account`
6. Scroll to the bottom of the page and see the Privacy Policy has `Optional` behind it.
<img width="354" alt="image" src="https://user-images.githubusercontent.com/359377/45255683-7a173480-b38a-11e8-9790-d8b5bd41bd36.png">
7. Apply patch
8. Refresh page
9. Notice the `Optional` is gone
<img width="311" alt="image" src="https://user-images.githubusercontent.com/359377/45255685-90bd8b80-b38a-11e8-96a8-eb44081b4928.png">

When you enable the Privacy Consent plugin the field must be required, otherwise it is useless.

### Expected result
Field not to have the text optional.


### Actual result
Field has text it is optional.

### Documentation Changes Required
None
