### PR TITLE
[4.0] Possible PR for #22091 view=menus change behaver list switch to edit

### DIFF
--- a/administrator/components/com_menus/tmpl/menus/default.php
+++ b/administrator/components/com_menus/tmpl/menus/default.php
@@ -91,20 +91,15 @@ HTMLHelper::_('script', 'com_menus/admin-menus-default.min.js', array('version' 
 									<?php echo HTMLHelper::_('grid.id', $i, $item->id); ?>
 								</td>
 								<th scope="row">
-									<?php if ($canManageItems) : ?>
-										<a href="<?php echo Route::_('index.php?option=com_menus&view=items&menutype=' . $item->menutype); ?>" title="<?php echo Text::_('JACTION_EDIT'); ?> <?php echo $this->escape(addslashes($item->title)); ?>">
-											<span class="fa fa-pencil-square mr-2" aria-hidden="true"></span><?php echo $this->escape($item->title); ?></a>
-									<?php else : ?>
+									<?php if ($canEdit): ?>
+                                       						<a href="<?php echo Route::_('index.php?option=com_menus&task=menu.edit&id=' . $item->id); ?>" title="<?php echo Text::_('JACTION_EDIT'); ?> <?php echo $this->escape(addslashes($item->title)); ?>">
+                                            					<span class="fa fa-pencil-square mr-2" aria-hidden="true"></span><?php echo $this->escape($item->title); ?></a>
+                                  					 <?php else: ?>
 										<?php echo $this->escape($item->title); ?>
 									<?php endif; ?>
 									<div class="small">
 										<?php echo Text::_('COM_MENUS_MENU_MENUTYPE_LABEL'); ?>:
-										<?php if ($canEdit) : ?>
-											<a href="<?php echo Route::_('index.php?option=com_menus&task=menu.edit&id=' . $item->id); ?>" title="<?php echo $this->escape($item->description); ?>">
-											<?php echo $this->escape($item->menutype); ?></a>
-										<?php else : ?>
-											<?php echo $this->escape($item->menutype); ?>
-										<?php endif; ?>
+										<?php echo $this->escape($item->menutype); ?>
 									</div>
 								</th>
 								<td class="text-center btns">


### PR DESCRIPTION
Pull Request for Issue #22091 

### Summary of Changes
Change event to edit insted of list view change as described and suggested in #22091 
$canManageItems ist also not more needed, simply simplified and the known way.

### Actual result
of com_menus&view=menus

![editmenu](https://user-images.githubusercontent.com/12803406/45255527-f9573900-b387-11e8-82b3-b219b8a7a05e.jpg)

### Expected result
of com_menus&view=menus

![editmenu](https://user-images.githubusercontent.com/12803406/45255859-e9daee80-b38d-11e8-8671-ac6373c1b2b0.jpg)

### Testing Instructions
The Screenshots should be selfexplained, just test if it does the new expectation

### Additional comments
In J3 we had a edit button. Clicking on a menu item was also in J3 for me a bit confused, why i will jump to items. And now, in J4 the edit button was moved, but now we have a pencil and it did not edit, it did even jump to items view :/ ? This is really confused and i know no component in joomla where we have such a behaver. If I'm on a list view, i expect to go to edit view after onclick to any item and no to switch the list view ;) Fot this I did done that change.

