### PR TITLE
Class JFormFieldSkins extends JFormFieldFolderList (TinyMCE skin)

### DIFF
--- a/plugins/editors/tinymce/field/skins.php
+++ b/plugins/editors/tinymce/field/skins.php
@@ -11,7 +11,7 @@ defined('_JEXEC') or die;
 
 jimport('joomla.form.helper');
 
-JFormHelper::loadFieldClass('list');
+JFormHelper::loadFieldClass('folderlist');
 
 /**
  * Generates the list of options for available skins.
@@ -20,32 +20,35 @@ JFormHelper::loadFieldClass('list');
  * @subpackage  Editors.tinymce
  * @since       3.4
  */
-class JFormFieldSkins extends JFormFieldList
+class JFormFieldSkins extends JFormFieldFolderList
 {
 	protected $type = 'skins';
 
 	/**
-	 * Method to get the skins options.
+	 * Method to attach a JForm object to the field.
 	 *
-	 * @return  array  The skins option objects.
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
+	 * @param   mixed             $value    The form field value to validate.
+	 * @param   string            $group    The field name group control value. This acts as an array container for the field.
+	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the
+	 *                                      full field name would end up being "bar[foo]".
 	 *
-	 * @since   3.4
+	 * @return  boolean  True on success.
+	 *
+	 * @see     JFormField::setup()
+	 * @since   3.7.0
 	 */
-	public function getOptions()
+	public function setup(SimpleXMLElement $element, $value, $group = null)
 	{
-		$options = array();
+		$return = parent::setup($element, $value, $group);
 
-		$directories = glob(JPATH_ROOT . '/media/editors/tinymce/skins' . '/*', GLOB_ONLYDIR);
+		// Get the path in which to search for skin options.
+		$this->directory   = JPATH_ROOT . '/media/editors/tinymce/skins';
+		$this->recursive   = false;
+		$this->hideNone = true;
+		$this->hideDefault = true;
 
-		for ($i = 0, $iMax = count($directories); $i < $iMax; ++$i)
-		{
-			$dir = basename($directories[$i]);
-			$options[] = JHtml::_('select.option', $i, $dir);
-		}
-
-		$options = array_merge(parent::getOptions(), $options);
-
-		return $options;
+		return $return;
 	}
 
 	/**

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -261,19 +261,12 @@ class PlgEditorTinymce extends JPlugin
 		$levelParams->loadObject($toolbarParams);
 		$levelParams->loadObject($extraOptions);
 
+		// List the skins
+		$skindirs = glob(JPATH_ROOT . '/media/editors/tinymce/skins' . '/*', GLOB_ONLYDIR);
+
 		// Set the selected skin
 		$skin = 'lightgray';
 		$side = $app->isClient('administrator') ? 'skin_admin' : 'skin';
-
-		// List the skins
-		if ($side == 'skin_admin')
-		{
-			$skindirs = glob(JPATH_ROOT . '../media/editors/tinymce/skins' . '/*', GLOB_ONLYDIR);
-		}
-		else
-		{
-			$skindirs = glob(JPATH_ROOT . '/media/editors/tinymce/skins' . '/*', GLOB_ONLYDIR);
-		}
 
 		if ((int) $levelParams->get($side, 0) < count($skindirs))
 		{
@@ -1313,19 +1306,13 @@ class PlgEditorTinymce extends JPlugin
 		$mode     = (int) $this->params->get('mode', 1);
 		$theme    = 'modern';
 
+		// List the skins
+		$skindirs = glob(JPATH_ROOT . '/media/editors/tinymce/skins' . '/*', GLOB_ONLYDIR);
+
+
 		// Set the selected skin
 		$skin = 'lightgray';
 		$side = $app->isClient('administrator') ? 'skin_admin' : 'skin';
-
-		// List the skins
-		if ($side == 'skin_admin')
-		{
-			$skindirs = glob(JPATH_ROOT . '../media/editors/tinymce/skins' . '/*', GLOB_ONLYDIR);
-		}
-		else
-		{
-			$skindirs = glob(JPATH_ROOT . '/media/editors/tinymce/skins' . '/*', GLOB_ONLYDIR);
-		}
 
 		if ((int) $this->params->get($side, 0) < count($skindirs))
 		{

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -1313,13 +1313,19 @@ class PlgEditorTinymce extends JPlugin
 		$mode     = (int) $this->params->get('mode', 1);
 		$theme    = 'modern';
 
-		// List the skins
-		$skindirs = glob(JPATH_ROOT . '/media/editors/tinymce/skins' . '/*', GLOB_ONLYDIR);
-
-
 		// Set the selected skin
 		$skin = 'lightgray';
 		$side = $app->isClient('administrator') ? 'skin_admin' : 'skin';
+
+		// List the skins
+		if ($side == 'skin_admin')
+		{
+			$skindirs = glob(JPATH_ROOT . '../media/editors/tinymce/skins' . '/*', GLOB_ONLYDIR);
+		}
+		else
+		{
+			$skindirs = glob(JPATH_ROOT . '/media/editors/tinymce/skins' . '/*', GLOB_ONLYDIR);
+		}
 
 		if ((int) $this->params->get($side, 0) < count($skindirs))
 		{

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -266,7 +266,7 @@ class PlgEditorTinymce extends JPlugin
 		$side = $app->isClient('administrator') ? 'skin_admin' : 'skin';
 
 		// List the skins
-		if($side == 'skin_admin')
+		if ($side == 'skin_admin')
 		{
 			$skindirs = glob(JPATH_ROOT . '../media/editors/tinymce/skins' . '/*', GLOB_ONLYDIR);
 		}

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -261,17 +261,9 @@ class PlgEditorTinymce extends JPlugin
 		$levelParams->loadObject($toolbarParams);
 		$levelParams->loadObject($extraOptions);
 
-		// List the skins
-		$skindirs = glob(JPATH_ROOT . '/media/editors/tinymce/skins' . '/*', GLOB_ONLYDIR);
-
-		// Set the selected skin
-		$skin = 'lightgray';
+		// Get the selected skin
 		$side = $app->isClient('administrator') ? 'skin_admin' : 'skin';
-
-		if ((int) $levelParams->get($side, 0) < count($skindirs))
-		{
-			$skin = basename($skindirs[(int) $levelParams->get($side, 0)]);
-		}
+		$skin = $levelParams->get($side, '');
 
 		$langMode   = $levelParams->get('lang_mode', 1);
 		$langPrefix = $levelParams->get('lang_code', 'en');
@@ -1306,18 +1298,9 @@ class PlgEditorTinymce extends JPlugin
 		$mode     = (int) $this->params->get('mode', 1);
 		$theme    = 'modern';
 
-		// List the skins
-		$skindirs = glob(JPATH_ROOT . '/media/editors/tinymce/skins' . '/*', GLOB_ONLYDIR);
-
-
-		// Set the selected skin
-		$skin = 'lightgray';
+		// Get the selected skin
 		$side = $app->isClient('administrator') ? 'skin_admin' : 'skin';
-
-		if ((int) $this->params->get($side, 0) < count($skindirs))
-		{
-			$skin = basename($skindirs[(int) $this->params->get($side, 0)]);
-		}
+		$skin = $this->params->get($side, '');
 
 		$langMode        = $this->params->get('lang_mode', 0);
 		$langPrefix      = $this->params->get('lang_code', 'en');

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -261,12 +261,19 @@ class PlgEditorTinymce extends JPlugin
 		$levelParams->loadObject($toolbarParams);
 		$levelParams->loadObject($extraOptions);
 
-		// List the skins
-		$skindirs = glob(JPATH_ROOT . '/media/editors/tinymce/skins' . '/*', GLOB_ONLYDIR);
-
 		// Set the selected skin
 		$skin = 'lightgray';
 		$side = $app->isClient('administrator') ? 'skin_admin' : 'skin';
+
+		// List the skins
+		if($side == 'skin_admin')
+		{
+			$skindirs = glob(JPATH_ROOT . '../media/editors/tinymce/skins' . '/*', GLOB_ONLYDIR);
+		}
+		else
+		{
+			$skindirs = glob(JPATH_ROOT . '/media/editors/tinymce/skins' . '/*', GLOB_ONLYDIR);
+		}
 
 		if ((int) $levelParams->get($side, 0) < count($skindirs))
 		{


### PR DESCRIPTION
### Summary of Changes
class JFormFieldSkins extends JFormFieldFolderList


### Testing Instructions
1. Go to http://skin.tinymce.com and select the preset charcoal or tundra and download it. (lightgray is the one that ships with Joomla!)
2. Extract the skin in /media/editors/tinymce/skins
3. Go to plugins->tinyMCE
4. Select a set with administrator (admin) or guest (site) assigned
5. Select the skin you just copied.
6. Edit an article with your new skin (admin or site side).

