### PR TITLE
[Performance] Category manager / Tag Manager, get all counters via single query, reduce 20, 50, 100 queries (page limit) to 1

### DIFF
--- a/administrator/components/com_banners/helpers/banners.php
+++ b/administrator/components/com_banners/helpers/banners.php
@@ -188,54 +188,22 @@ class BannersHelper extends JHelperContent
 	/**
 	 * Adds Count Items for Category Manager.
 	 *
-	 * @param   stdClass[]  $items  The banner category objects
+	 * @param   stdClass[]  &$items     The category objects
+	 * @param   stdClass    $config     Configuration object allowing to use a custom relations table
 	 *
 	 * @return  stdClass[]
 	 *
 	 * @since   3.5
 	 */
-	public static function countItems(&$items)
+	public static function countItems(&$items, $config = null)
 	{
-		$db = JFactory::getDbo();
+		$config = $config ?: (object) array(
+			'related_tbl'   => 'banners',
+			'state_col'     => 'state',
+			'group_col'     => 'catid',
+			'relation_type' => 'category_or_group',
+		);
 
-		foreach ($items as $item)
-		{
-			$item->count_trashed = 0;
-			$item->count_archived = 0;
-			$item->count_unpublished = 0;
-			$item->count_published = 0;
-			$query = $db->getQuery(true);
-			$query->select('state, count(*) AS count')
-				->from($db->qn('#__banners'))
-				->where('catid = ' . (int) $item->id)
-				->group('state');
-			$db->setQuery($query);
-			$banners = $db->loadObjectList();
-
-			foreach ($banners as $banner)
-			{
-				if ($banner->state == 1)
-				{
-					$item->count_published = $banner->count;
-				}
-
-				if ($banner->state == 0)
-				{
-					$item->count_unpublished = $banner->count;
-				}
-
-				if ($banner->state == 2)
-				{
-					$item->count_archived = $banner->count;
-				}
-
-				if ($banner->state == -2)
-				{
-					$item->count_trashed = $banner->count;
-				}
-			}
-		}
-
-		return $items;
+		return parent::countRelations($items, $config);
 	}
 }

--- a/administrator/components/com_banners/helpers/banners.php
+++ b/administrator/components/com_banners/helpers/banners.php
@@ -188,8 +188,8 @@ class BannersHelper extends JHelperContent
 	/**
 	 * Adds Count Items for Category Manager.
 	 *
-	 * @param   stdClass[]  &$items     The category objects
-	 * @param   stdClass    $config     Configuration object allowing to use a custom relations table
+	 * @param   stdClass[]  &$items  The category objects
+	 * @param   stdClass    $config  Configuration object allowing to use a custom relations table
 	 *
 	 * @return  stdClass[]
 	 *

--- a/administrator/components/com_banners/helpers/banners.php
+++ b/administrator/components/com_banners/helpers/banners.php
@@ -189,15 +189,14 @@ class BannersHelper extends JHelperContent
 	 * Adds Count Items for Category Manager.
 	 *
 	 * @param   stdClass[]  &$items  The category objects
-	 * @param   stdClass    $config  Configuration object allowing to use a custom relations table
 	 *
 	 * @return  stdClass[]
 	 *
 	 * @since   3.5
 	 */
-	public static function countItems(&$items, $config = null)
+	public static function countItems(&$items)
 	{
-		$config = $config ?: (object) array(
+		$config = (object) array(
 			'related_tbl'   => 'banners',
 			'state_col'     => 'state',
 			'group_col'     => 'catid',

--- a/administrator/components/com_contact/helpers/contact.php
+++ b/administrator/components/com_contact/helpers/contact.php
@@ -57,8 +57,8 @@ class ContactHelper extends JHelperContent
 	/**
 	 * Adds Count Items for Category Manager.
 	 *
-	 * @param   stdClass[]  &$items     The category objects
-	 * @param   stdClass    $config     Configuration object allowing to use a custom relations table
+	 * @param   stdClass[]  &$items  The category objects
+	 * @param   stdClass    $config  Configuration object allowing to use a custom relations table
 	 *
 	 * @return  stdClass[]
 	 *

--- a/administrator/components/com_contact/helpers/contact.php
+++ b/administrator/components/com_contact/helpers/contact.php
@@ -57,127 +57,50 @@ class ContactHelper extends JHelperContent
 	/**
 	 * Adds Count Items for Category Manager.
 	 *
-	 * @param   stdClass[]  $items  The contact category objects
+	 * @param   stdClass[]  &$items     The category objects
+	 * @param   stdClass    $config     Configuration object allowing to use a custom relations table
 	 *
 	 * @return  stdClass[]
 	 *
 	 * @since   3.5
 	 */
-	public static function countItems(&$items)
+	public static function countItems(&$items, $config = null)
 	{
-		$db = JFactory::getDbo();
+		$config = $config ?: (object) array(
+			'related_tbl'   => 'contact_details',
+			'state_col'     => 'published',
+			'group_col'     => 'catid',
+			'relation_type' => 'category_or_group',
+		);
 
-		foreach ($items as $item)
-		{
-			$item->count_trashed = 0;
-			$item->count_archived = 0;
-			$item->count_unpublished = 0;
-			$item->count_published = 0;
-			$query = $db->getQuery(true);
-			$query->select('published AS state, count(*) AS count')
-				->from($db->qn('#__contact_details'))
-				->where('catid = ' . (int) $item->id)
-				->group('published');
-			$db->setQuery($query);
-			$contacts = $db->loadObjectList();
-
-			foreach ($contacts as $contact)
-			{
-				if ($contact->state == 1)
-				{
-					$item->count_published = $contact->count;
-				}
-
-				if ($contact->state == 0)
-				{
-					$item->count_unpublished = $contact->count;
-				}
-
-				if ($contact->state == 2)
-				{
-					$item->count_archived = $contact->count;
-				}
-
-				if ($contact->state == -2)
-				{
-					$item->count_trashed = $contact->count;
-				}
-			}
-		}
-
-		return $items;
+		return parent::countRelations($items, $config);
 	}
 
 	/**
 	 * Adds Count Items for Tag Manager.
 	 *
-	 * @param   stdClass[]  $items      The banner tag objects
+	 * @param   stdClass[]  &$items     The tag objects
 	 * @param   string      $extension  The name of the active view.
+	 * @param   stdClass    $config     Configuration object allowing to use a custom relations table
 	 *
 	 * @return  stdClass[]
 	 *
 	 * @since   3.6
 	 */
-	public static function countTagItems(&$items, $extension)
+	public static function countTagItems(&$items, $extension, $config = null)
 	{
-		$db = JFactory::getDbo();
-		$parts     = explode('.', $extension);
-		$section   = null;
+		$parts   = explode('.', $extension);
+		$section = count($parts) > 1 ? $parts[1] : null;
 
-		if (count($parts) > 1)
-		{
-			$section = $parts[1];
-		}
+		$config = $config ?: (object) array(
+			'related_tbl'   => ($section === 'category' ? 'categories' : 'contact_details'),
+			'state_col'     => 'published',
+			'group_col'     => 'tag_id',
+			'extension'     => $extension,
+			'relation_type' => 'tag_assigments',
+		);
 
-		$join = $db->qn('#__contact_details') . ' AS c ON ct.content_item_id=c.id';
-
-		if ($section === 'category')
-		{
-			$join = $db->qn('#__categories') . ' AS c ON ct.content_item_id=c.id';
-		}
-
-		foreach ($items as $item)
-		{
-			$item->count_trashed = 0;
-			$item->count_archived = 0;
-			$item->count_unpublished = 0;
-			$item->count_published = 0;
-			$query = $db->getQuery(true);
-			$query->select('published as state, count(*) AS count')
-				->from($db->qn('#__contentitem_tag_map') . 'AS ct ')
-				->where('ct.tag_id = ' . (int) $item->id)
-				->where('ct.type_alias =' . $db->q($extension))
-				->join('LEFT', $join)
-				->group('published');
-
-			$db->setQuery($query);
-			$contacts = $db->loadObjectList();
-
-			foreach ($contacts as $contact)
-			{
-				if ($contact->state == 1)
-				{
-					$item->count_published = $contact->count;
-				}
-
-				if ($contact->state == 0)
-				{
-					$item->count_unpublished = $contact->count;
-				}
-
-				if ($contact->state == 2)
-				{
-					$item->count_archived = $contact->count;
-				}
-
-				if ($contact->state == -2)
-				{
-					$item->count_trashed = $contact->count;
-				}
-			}
-		}
-
-		return $items;
+		return parent::countRelations($items, $config);
 	}
 
 	/**

--- a/administrator/components/com_contact/helpers/contact.php
+++ b/administrator/components/com_contact/helpers/contact.php
@@ -58,15 +58,14 @@ class ContactHelper extends JHelperContent
 	 * Adds Count Items for Category Manager.
 	 *
 	 * @param   stdClass[]  &$items  The category objects
-	 * @param   stdClass    $config  Configuration object allowing to use a custom relations table
 	 *
 	 * @return  stdClass[]
 	 *
 	 * @since   3.5
 	 */
-	public static function countItems(&$items, $config = null)
+	public static function countItems(&$items)
 	{
-		$config = $config ?: (object) array(
+		$config = (object) array(
 			'related_tbl'   => 'contact_details',
 			'state_col'     => 'published',
 			'group_col'     => 'catid',
@@ -81,18 +80,17 @@ class ContactHelper extends JHelperContent
 	 *
 	 * @param   stdClass[]  &$items     The tag objects
 	 * @param   string      $extension  The name of the active view.
-	 * @param   stdClass    $config     Configuration object allowing to use a custom relations table
 	 *
 	 * @return  stdClass[]
 	 *
 	 * @since   3.6
 	 */
-	public static function countTagItems(&$items, $extension, $config = null)
+	public static function countTagItems(&$items, $extension)
 	{
 		$parts   = explode('.', $extension);
 		$section = count($parts) > 1 ? $parts[1] : null;
 
-		$config = $config ?: (object) array(
+		$config = (object) array(
 			'related_tbl'   => ($section === 'category' ? 'categories' : 'contact_details'),
 			'state_col'     => 'published',
 			'group_col'     => 'tag_id',

--- a/administrator/components/com_content/helpers/content.php
+++ b/administrator/components/com_content/helpers/content.php
@@ -91,8 +91,8 @@ class ContentHelper extends JHelperContent
 	/**
 	 * Adds Count Items for Category Manager.
 	 *
-	 * @param   stdClass[]  &$items     The category objects
-	 * @param   stdClass    $config     Configuration object allowing to use a custom relations table
+	 * @param   stdClass[]  &$items  The category objects
+	 * @param   stdClass    $config  Configuration object allowing to use a custom relations table
 	 *
 	 * @return  stdClass[]
 	 *

--- a/administrator/components/com_content/helpers/content.php
+++ b/administrator/components/com_content/helpers/content.php
@@ -92,15 +92,14 @@ class ContentHelper extends JHelperContent
 	 * Adds Count Items for Category Manager.
 	 *
 	 * @param   stdClass[]  &$items  The category objects
-	 * @param   stdClass    $config  Configuration object allowing to use a custom relations table
 	 *
 	 * @return  stdClass[]
 	 *
 	 * @since   3.5
 	 */
-	public static function countItems(&$items, $config = null)
+	public static function countItems(&$items)
 	{
-		$config = $config ?: (object) array(
+		$config = (object) array(
 			'related_tbl'   => 'content',
 			'state_col'     => 'state',
 			'group_col'     => 'catid',
@@ -115,18 +114,17 @@ class ContentHelper extends JHelperContent
 	 *
 	 * @param   stdClass[]  &$items     The tag objects
 	 * @param   string      $extension  The name of the active view.
-	 * @param   stdClass    $config     Configuration object allowing to use a custom relations table
 	 *
 	 * @return  stdClass[]
 	 *
 	 * @since   3.6
 	 */
-	public static function countTagItems(&$items, $extension, $config = null)
+	public static function countTagItems(&$items, $extension)
 	{
 		$parts   = explode('.', $extension);
 		$section = count($parts) > 1 ? $parts[1] : null;
 
-		$config = $config ?: (object) array(
+		$config = (object) array(
 			'related_tbl'   => ($section === 'category' ? 'categories' : 'content'),
 			'state_col'     => ($section === 'category' ? 'published' : 'state'),
 			'group_col'     => 'tag_id',

--- a/administrator/components/com_fields/helpers/fields.php
+++ b/administrator/components/com_fields/helpers/fields.php
@@ -590,8 +590,8 @@ class FieldsHelper
 	/**
 	 * Adds Count Items for Category Manager.
 	 *
-	 * @param   stdClass[]  &$items     The fieldgroup objects
-	 * @param   stdClass    $config     Configuration object allowing to use a custom relations table
+	 * @param   stdClass[]  &$items  The fieldgroup objects
+	 * @param   stdClass    $config  Configuration object allowing to use a custom relations table
 	 *
 	 * @return  stdClass[]
 	 *

--- a/administrator/components/com_fields/helpers/fields.php
+++ b/administrator/components/com_fields/helpers/fields.php
@@ -590,47 +590,23 @@ class FieldsHelper
 	/**
 	 * Adds Count Items for Category Manager.
 	 *
-	 * @param   stdClass[]  $items  The field category objects
+	 * @param   stdClass[]  &$items     The fieldgroup objects
+	 * @param   stdClass    $config     Configuration object allowing to use a custom relations table
 	 *
 	 * @return  stdClass[]
 	 *
 	 * @since   3.7.0
 	 */
-	public static function countItems(&$items)
+	public static function countItems(&$items, $config = null)
 	{
-		$db = JFactory::getDbo();
+		$config = $config ?: (object) array(
+			'related_tbl'   => 'fields',
+			'state_col'     => 'state',
+			'group_col'     => 'group_id',
+			'relation_type' => 'category_or_group',
+		);
 
-		foreach ($items as $item)
-		{
-			$item->count_trashed     = 0;
-			$item->count_archived    = 0;
-			$item->count_unpublished = 0;
-			$item->count_published   = 0;
-
-			$query = $db->getQuery(true);
-			$query->select('state, count(1) AS count')
-				->from($db->quoteName('#__fields'))
-				->where('group_id = ' . (int) $item->id)
-				->group('state');
-			$db->setQuery($query);
-
-			$fields = $db->loadObjectList();
-
-			$states = array(
-				'-2' => 'count_trashed',
-				'0'  => 'count_unpublished',
-				'1'  => 'count_published',
-				'2'  => 'count_archived',
-			);
-
-			foreach ($fields as $field)
-			{
-				$property = $states[$field->state];
-				$item->$property = $field->count;
-			}
-		}
-
-		return $items;
+		return parent::countRelations($items, $config);
 	}
 
 	/**

--- a/administrator/components/com_fields/helpers/fields.php
+++ b/administrator/components/com_fields/helpers/fields.php
@@ -591,15 +591,14 @@ class FieldsHelper
 	 * Adds Count Items for Category Manager.
 	 *
 	 * @param   stdClass[]  &$items  The fieldgroup objects
-	 * @param   stdClass    $config  Configuration object allowing to use a custom relations table
 	 *
 	 * @return  stdClass[]
 	 *
 	 * @since   3.7.0
 	 */
-	public static function countItems(&$items, $config = null)
+	public static function countItems(&$items)
 	{
-		$config = $config ?: (object) array(
+		$config = (object) array(
 			'related_tbl'   => 'fields',
 			'state_col'     => 'state',
 			'group_col'     => 'group_id',

--- a/administrator/components/com_newsfeeds/helpers/newsfeeds.php
+++ b/administrator/components/com_newsfeeds/helpers/newsfeeds.php
@@ -43,8 +43,8 @@ class NewsfeedsHelper extends JHelperContent
 	/**
 	 * Adds Count Items for Category Manager.
 	 *
-	 * @param   stdClass[]  &$items     The category objects
-	 * @param   stdClass    $config     Configuration object allowing to use a custom relations table
+	 * @param   stdClass[]  &$items  The category objects
+	 * @param   stdClass    $config  Configuration object allowing to use a custom relations table
 	 *
 	 * @return  stdClass[]
 	 *

--- a/administrator/components/com_newsfeeds/helpers/newsfeeds.php
+++ b/administrator/components/com_newsfeeds/helpers/newsfeeds.php
@@ -43,126 +43,49 @@ class NewsfeedsHelper extends JHelperContent
 	/**
 	 * Adds Count Items for Category Manager.
 	 *
-	 * @param   stdClass[]  &$items  The banner category objects
+	 * @param   stdClass[]  &$items     The category objects
+	 * @param   stdClass    $config     Configuration object allowing to use a custom relations table
 	 *
 	 * @return  stdClass[]
 	 *
 	 * @since   3.5
 	 */
-	public static function countItems(&$items)
+	public static function countItems(&$items, $config = null)
 	{
-		$db = JFactory::getDbo();
+		$config = $config ?: (object) array(
+			'related_tbl'   => 'newsfeeds',
+			'state_col'     => 'published',
+			'group_col'     => 'catid',
+			'relation_type' => 'category_or_group',
+		);
 
-		foreach ($items as $item)
-		{
-			$item->count_trashed = 0;
-			$item->count_archived = 0;
-			$item->count_unpublished = 0;
-			$item->count_published = 0;
-			$query = $db->getQuery(true);
-			$query->select('published AS state, count(*) AS count')
-				->from($db->qn('#__newsfeeds'))
-				->where('catid = ' . (int) $item->id)
-				->group('state');
-			$db->setQuery($query);
-			$newfeeds = $db->loadObjectList();
-
-			foreach ($newfeeds as $newsfeed)
-			{
-				if ($newsfeed->state == 1)
-				{
-					$item->count_published = $newsfeed->count;
-				}
-
-				if ($newsfeed->state == 0)
-				{
-					$item->count_unpublished = $newsfeed->count;
-				}
-
-				if ($newsfeed->state == 2)
-				{
-					$item->count_archived = $newsfeed->count;
-				}
-
-				if ($newsfeed->state == -2)
-				{
-					$item->count_trashed = $newsfeed->count;
-				}
-			}
-		}
-
-		return $items;
+		return parent::countRelations($items, $config);
 	}
 
 	/**
 	 * Adds Count Items for Tag Manager.
 	 *
-	 * @param   stdClass[]  &$items     The newsfeed tag objects
+	 * @param   stdClass[]  &$items     The tag objects
 	 * @param   string      $extension  The name of the active view.
+	 * @param   stdClass    $config     Configuration object allowing to use a custom relations table
 	 *
 	 * @return  stdClass[]
 	 *
 	 * @since   3.6
 	 */
-	public static function countTagItems(&$items, $extension)
+	public static function countTagItems(&$items, $extension, $config = null)
 	{
-		$db = JFactory::getDbo();
-		$parts     = explode('.', $extension);
-		$section   = null;
+		$parts   = explode('.', $extension);
+		$section = count($parts) > 1 ? $parts[1] : null;
 
-		if (count($parts) > 1)
-		{
-			$section = $parts[1];
-		}
+		$config = $config ?: (object) array(
+			'related_tbl'   => ($section === 'category' ? 'categories' : 'newsfeeds'),
+			'state_col'     => 'published',
+			'group_col'     => 'tag_id',
+			'extension'     => $extension,
+			'relation_type' => 'tag_assigments',
+		);
 
-		$join = $db->qn('#__newsfeeds') . ' AS c ON ct.content_item_id=c.id';
-
-		if ($section === 'category')
-		{
-			$join = $db->qn('#__categories') . ' AS c ON ct.content_item_id=c.id';
-		}
-
-		foreach ($items as $item)
-		{
-			$item->count_trashed = 0;
-			$item->count_archived = 0;
-			$item->count_unpublished = 0;
-			$item->count_published = 0;
-			$query = $db->getQuery(true);
-			$query->select('published AS state, count(*) AS count')
-				->from($db->qn('#__contentitem_tag_map') . 'AS ct ')
-				->where('ct.tag_id = ' . (int) $item->id)
-				->where('ct.type_alias =' . $db->q($extension))
-				->join('LEFT', $join)
-				->group('state');
-
-			$db->setQuery($query);
-			$newsfeeds = $db->loadObjectList();
-
-			foreach ($newsfeeds as $newsfeed)
-			{
-				if ($newsfeed->state == 1)
-				{
-					$item->count_published = $newsfeed->count;
-				}
-
-				if ($newsfeed->state == 0)
-				{
-					$item->count_unpublished = $newsfeed->count;
-				}
-
-				if ($newsfeed->state == 2)
-				{
-					$item->count_archived = $newsfeed->count;
-				}
-
-				if ($newsfeed->state == -2)
-				{
-					$item->count_trashed = $newsfeed->count;
-				}
-			}
-		}
-
-		return $items;
+		return parent::countRelations($items, $config);
 	}
 }

--- a/administrator/components/com_newsfeeds/helpers/newsfeeds.php
+++ b/administrator/components/com_newsfeeds/helpers/newsfeeds.php
@@ -44,15 +44,14 @@ class NewsfeedsHelper extends JHelperContent
 	 * Adds Count Items for Category Manager.
 	 *
 	 * @param   stdClass[]  &$items  The category objects
-	 * @param   stdClass    $config  Configuration object allowing to use a custom relations table
 	 *
 	 * @return  stdClass[]
 	 *
 	 * @since   3.5
 	 */
-	public static function countItems(&$items, $config = null)
+	public static function countItems(&$items)
 	{
-		$config = $config ?: (object) array(
+		$config = (object) array(
 			'related_tbl'   => 'newsfeeds',
 			'state_col'     => 'published',
 			'group_col'     => 'catid',
@@ -67,18 +66,17 @@ class NewsfeedsHelper extends JHelperContent
 	 *
 	 * @param   stdClass[]  &$items     The tag objects
 	 * @param   string      $extension  The name of the active view.
-	 * @param   stdClass    $config     Configuration object allowing to use a custom relations table
 	 *
 	 * @return  stdClass[]
 	 *
 	 * @since   3.6
 	 */
-	public static function countTagItems(&$items, $extension, $config = null)
+	public static function countTagItems(&$items, $extension)
 	{
 		$parts   = explode('.', $extension);
 		$section = count($parts) > 1 ? $parts[1] : null;
 
-		$config = $config ?: (object) array(
+		$config = (object) array(
 			'related_tbl'   => ($section === 'category' ? 'categories' : 'newsfeeds'),
 			'state_col'     => 'published',
 			'group_col'     => 'tag_id',

--- a/libraries/src/Helper/ContentHelper.php
+++ b/libraries/src/Helper/ContentHelper.php
@@ -43,6 +43,99 @@ class ContentHelper
 	}
 
 	/**
+	 * Adds Count relations for Category and Tag Managers
+	 *
+	 * @param   stdClass[]  $items      The category or tag objects
+	 * @param   stdClass    $config     Configuration object allowing to use a custom relations table
+	 *
+	 * @return  stdClass[]
+	 *
+	 * @since   3.6
+	 */
+	public static function countRelations(&$items, $config)
+	{
+		$db = Factory::getDbo();
+
+		// Allow custom state / condition values and custom column names to support custom components
+		$counter_names = isset($config->counter_names) ? $config->counter_names : array(
+			'-2' => 'count_trashed',
+			'2'  => 'count_archived',
+			'0'  => 'count_unpublished',
+			'1'  => 'count_published',
+		);
+
+		// Index category objects by their ID
+		$records = array();
+
+		foreach ($items as $item)
+		{
+			$records[(int) $item->id] = $item;
+		}
+
+		// The relation query does not return a value for cases without relations of a particular state / condition, set zero as default
+		foreach ($items as $item)
+		{
+			foreach($counter_names as $n)
+			{
+				$item->{$n} = 0;
+			}
+		}
+
+		// Table alias for related data table below will be 'c', and state / condition column is inside related data table
+		$related_tbl = $db->quoteName('#__' . $config->related_tbl);
+		$state_col   = 'c.' . $db->quoteName($config->state_col);
+
+		// Supported cases
+		switch ($config->relation_type)
+		{
+			case 'tag_assigments':
+				$recid_col = 'ct.' . $db->quoteName($config->group_col);
+
+				$query = $db->getQuery(true)
+					->from($db->quoteName('#__contentitem_tag_map') . 'AS ct ')
+					->join('INNER',  $related_tbl . ' AS c ON ct.content_item_id = c.id AND ct.type_alias = ' . $db->quote($config->extension));
+				break;
+
+			case 'category_or_group':
+				$recid_col = 'c.' . $db->quoteName($config->group_col);
+
+				$query = $db->getQuery(true)
+					->from($related_tbl . ' AS c ');
+				break;
+
+			default:
+				return $items;
+		}
+
+		/**
+		 * Get relation counts for all category objects with single query
+		 * NOTE: 'state IN', allows counting specific states / conditions only, also prevents warnings with custom states / conditions, do not remove
+		 */
+		$query
+			->select($recid_col . ' AS catid, ' . $state_col . ' AS state, COUNT(*) AS count')
+			->where($recid_col . ' IN (' . implode(',', array_keys($records)) . ')')
+			->where('state IN (' . implode(',', array_keys($counter_names)) . ')')
+			->group($recid_col . ', ' . $state_col);
+
+		$relationsAll = $db->setQuery($query)->loadObjectList();
+
+		// Loop through the DB data overwritting the above zeros with the found count
+		foreach ($relationsAll as $relation)
+		{
+			// Sanity check in case someone removes the state IN above ... and some views may start throwing warnings
+			if (isset($counter_names[$relation->state]))
+			{
+				$id = (int) $relation->catid;
+				$cn = $counter_names[$relation->state];
+
+				$records[$id]->{$cn} = $relation->count;
+			}
+		}
+
+		return $items;
+	}
+
+	/**
 	 * Gets a list of the actions that can be performed.
 	 *
 	 * @param   integer  $categoryId  The category ID.

--- a/libraries/src/Helper/ContentHelper.php
+++ b/libraries/src/Helper/ContentHelper.php
@@ -45,8 +45,8 @@ class ContentHelper
 	/**
 	 * Adds Count relations for Category and Tag Managers
 	 *
-	 * @param   stdClass[]  $items      The category or tag objects
-	 * @param   stdClass    $config     Configuration object allowing to use a custom relations table
+	 * @param   stdClass[]  &$items  The category or tag objects
+	 * @param   stdClass    $config  Configuration object allowing to use a custom relations table
 	 *
 	 * @return  stdClass[]
 	 *
@@ -75,7 +75,7 @@ class ContentHelper
 		// The relation query does not return a value for cases without relations of a particular state / condition, set zero as default
 		foreach ($items as $item)
 		{
-			foreach($counter_names as $n)
+			foreach ($counter_names as $n)
 			{
 				$item->{$n} = 0;
 			}

--- a/libraries/src/Helper/ContentHelper.php
+++ b/libraries/src/Helper/ContentHelper.php
@@ -82,25 +82,26 @@ class ContentHelper
 		}
 
 		// Table alias for related data table below will be 'c', and state / condition column is inside related data table
-		$related_tbl = $db->quoteName('#__' . $config->related_tbl);
-		$state_col   = 'c.' . $db->quoteName($config->state_col);
+		$related_tbl = $db->quoteName('#__' . $config->related_tbl, 'c');
+		$state_col   = $db->quoteName('c.' . $config->state_col);
 
 		// Supported cases
 		switch ($config->relation_type)
 		{
 			case 'tag_assigments':
-				$recid_col = 'ct.' . $db->quoteName($config->group_col);
+				$recid_col = $db->quoteName('ct.' . $config->group_col);
 
 				$query = $db->getQuery(true)
-					->from($db->quoteName('#__contentitem_tag_map') . 'AS ct ')
-					->join('INNER',  $related_tbl . ' AS c ON ct.content_item_id = c.id AND ct.type_alias = ' . $db->quote($config->extension));
+					->from($db->quoteName('#__contentitem_tag_map', 'ct'))
+					->join('INNER', $related_tbl . ' ON ' . $db->quoteName('ct.content_item_id') . ' = ' . $db->quoteName('c.id') . ' AND ' .
+						$db->quoteName('ct.type_alias') . ' = ' . $db->quote($config->extension));
 				break;
 
 			case 'category_or_group':
-				$recid_col = 'c.' . $db->quoteName($config->group_col);
+				$recid_col = $db->quoteName('c.' . $config->group_col);
 
 				$query = $db->getQuery(true)
-					->from($related_tbl . ' AS c ');
+					->from($related_tbl);
 				break;
 
 			default:
@@ -114,7 +115,7 @@ class ContentHelper
 		$query
 			->select($recid_col . ' AS catid, ' . $state_col . ' AS state, COUNT(*) AS count')
 			->where($recid_col . ' IN (' . implode(',', array_keys($records)) . ')')
-			->where('state IN (' . implode(',', array_keys($counter_names)) . ')')
+			->where($state_col . ' IN (' . implode(',', array_keys($counter_names)) . ')')
 			->group($recid_col . ', ' . $state_col);
 
 		$relationsAll = $db->setQuery($query)->loadObjectList();

--- a/libraries/src/Helper/ContentHelper.php
+++ b/libraries/src/Helper/ContentHelper.php
@@ -59,9 +59,9 @@ class ContentHelper
 		// Allow custom state / condition values and custom column names to support custom components
 		$counter_names = isset($config->counter_names) ? $config->counter_names : array(
 			'-2' => 'count_trashed',
-			'2'  => 'count_archived',
 			'0'  => 'count_unpublished',
 			'1'  => 'count_published',
+			'2'  => 'count_archived',
 		);
 
 		// Index category objects by their ID

--- a/libraries/src/Helper/ContentHelper.php
+++ b/libraries/src/Helper/ContentHelper.php
@@ -50,7 +50,7 @@ class ContentHelper
 	 *
 	 * @return  stdClass[]
 	 *
-	 * @since   3.6
+	 * @since   __DEPLOY_VERSION__
 	 */
 	public static function countRelations(&$items, $config)
 	{

--- a/libraries/src/Helper/ContentHelper.php
+++ b/libraries/src/Helper/ContentHelper.php
@@ -94,7 +94,8 @@ class ContentHelper
 				$query = $db->getQuery(true)
 					->from($db->quoteName('#__contentitem_tag_map', 'ct'))
 					->join('INNER', $related_tbl . ' ON ' . $db->quoteName('ct.content_item_id') . ' = ' . $db->quoteName('c.id') . ' AND ' .
-						$db->quoteName('ct.type_alias') . ' = ' . $db->quote($config->extension));
+						$db->quoteName('ct.type_alias') . ' = ' . $db->quote($config->extension)
+					);
 				break;
 
 			case 'category_or_group':


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Category manager creates 1 query per category to get the assigned item counts by state
These are used to displays the columns
total published, total unpublished, total archived, total trashed


### Testing Instructions
1. Open 2 Tabs of **Category manager** and 2 Tabs of **Tag manager**
2. Filter the 2 Tabs of **Tag manager** by "**Tag Type**" article (click search tools button)
2. Apply patch
3. Refresh 2nd TAB of **Category manager** and 2nd Tab of **Tag manager**

Both 1st and 2nd tabs should show the same counted items per state

---- 

Category managers to test
- articles, banners, contact, newsfeeds, and for fieldgroups management

---- 
Tags manager:
- repeat test for every listed Tag Type, in the Tag Type Filter (click search tools)


### Expected result
1 query to get the total assigned items for the categories shown by current page


### Actual result
20, 50, 100 queries to get the assigned items for the categories


### Documentation Changes Required
None
