### PR TITLE
Adjusting folder location to cope with changes in Crowdin.

### DIFF
--- a/administrator/manifests/packages/pkg_en-GB.xml
+++ b/administrator/manifests/packages/pkg_en-GB.xml
@@ -15,8 +15,8 @@
 	<description><![CDATA[en-GB language pack]]></description>
 	<blockChildUninstall>true</blockChildUninstall>
 	<files>
-		<folder type="language" client="site" id="en-GB">site_en-GB</folder>
-		<folder type="language" client="administrator" id="en-GB">admin_en-GB</folder>
+		<folder type="language" client="site" id="en-GB">language/en-GB</folder>
+		<folder type="language" client="administrator" id="en-GB">administrator/language/en-GB</folder>
 	</files>
 	<updateservers>
 		<server type="collection" priority="1" name="Accredited Joomla! Translations">


### PR DESCRIPTION
### Summary of Changes
Adjusting the folders in the language package manifest to cope with the changed folder structur in Crowdin.


### Testing Instructions
Could only be tested by downloading a pack from Crowdin (https://crowdin.com/project/joomla-cms) and then adjust the package manifest there and rezip and install.
However some review should do as well. This file isn't used by the CMS anyway.


### Expected result
The manifest exported by Crowdin can be used to create a working package.


### Actual result
Folders are wrong (pointing to old structure)


### Documentation Changes Required
None