### PR TITLE
[4.0] [a11y] SkipTo Links for Atum

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/4.0.0-2018-09-13.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.0.0-2018-09-13.sql
@@ -1,0 +1,2 @@
+INSERT INTO `#__extensions` (`extension_id`, `package_id`, `name`, `type`, `element`, `folder`, `client_id`, `enabled`, `access`, `protected`, `manifest_cache`, `params`, `checked_out`, `checked_out_time`, `ordering`, `state`, `namespace`) VALUES
+(493, 0, 'plg_system_skipto', 'plugin', 'skipto', 'system', 0, 1, 1, 1, '', '', 0, '0000-00-00 00:00:00', 0, 0, '');

--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2018-09-13.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2018-09-13.sql
@@ -1,0 +1,2 @@
+INSERT INTO `#__extensions` (`extension_id`, `package_id`, `name`, `type`, `element`, `folder`, `client_id`, `enabled`, `access`, `protected`, `manifest_cache`, `params`, `checked_out`, `checked_out_time`, `ordering`, `state`, `namespace`) VALUES
+(493, 0, 'plg_system_skipto', 'plugin', 'skipto', 'system', 0, 1, 1, 1, '', '', 0, '1970-01-01 00:00:00', 0, 0, '');

--- a/administrator/language/en-GB/en-GB.plg_system_skipto.ini
+++ b/administrator/language/en-GB/en-GB.plg_system_skipto.ini
@@ -4,9 +4,9 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_SYSTEM_SKIPTO_SKIP_TO="Skip To"
-PLG_SYSTEM_SKIPTO_SKIP_TO_KEYBOARD=""
-PLG_SYSTEM_SKIPTO_SKIP_TO_AND_PAGE_OUTLINE="Page Outline"
-PLG_SYSTEM_SKIPTO_PAGE_OUTLINE=""
+PLG_SYSTEM_SKIPTO_SKIP_TO_KEYBOARD="Skip To Keyboard Navigation"
+PLG_SYSTEM_SKIPTO_SKIP_TO_AND_PAGE_OUTLINE="Skip To and Page Outline"
+PLG_SYSTEM_SKIPTO_PAGE_OUTLINE="Page Outline"
 PLG_SYSTEM_SKIPTO_CONTENT=" Content"
 PLG_SYSTEM_SKIPTO="System - Skip-To Navigation"
 PLG_SYSTEM_SKIPTO_XML_DESCRIPTION="The plugin creates a drop-down menu consisting of the links to the important places on a given web page. This makes it easier for keyboard and screen reader users to quickly jump to the desired location by simply choosing it from the list of options."

--- a/administrator/language/en-GB/en-GB.plg_system_skipto.ini
+++ b/administrator/language/en-GB/en-GB.plg_system_skipto.ini
@@ -1,0 +1,12 @@
+; Joomla! Project
+; Copyright (C) 2005 - 2018 Open Source Matters. All rights reserved.
+; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
+; Note : All ini files need to be saved as UTF-8
+
+PLG_SYSTEM_SKIPTO_SKIP_TO="Skip To"
+PLG_SYSTEM_SKIPTO_SKIP_TO_KEYBOARD=""
+PLG_SYSTEM_SKIPTO_SKIP_TO_AND_PAGE_OUTLINE="Page Outline"
+PLG_SYSTEM_SKIPTO_PAGE_OUTLINE=""
+PLG_SYSTEM_SKIPTO_CONTENT=" Content"
+PLG_SYSTEM_SKIPTO="System - Skip-To Navigation"
+PLG_SYSTEM_SKIPTO_XML_DESCRIPTION="The plugin creates a drop-down menu consisting of the links to the important places on a given web page. This makes it easier for keyboard and screen reader users to quickly jump to the desired location by simply choosing it from the list of options."

--- a/administrator/language/en-GB/en-GB.plg_system_skipto.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_system_skipto.sys.ini
@@ -1,0 +1,7 @@
+; Joomla! Project
+; Copyright (C) 2005 - 2018 Open Source Matters. All rights reserved.
+; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
+; Note : All ini files need to be saved as UTF-8
+
+PLG_SYSTEM_SKIPTO="System - Skip-To Navigation"
+PLG_SYSTEM_SKIPTO_XML_DESCRIPTION="The plugin creates a drop-down menu consisting of the links to the important places on a given web page. This makes it easier for keyboard and screen reader users to quickly jump to the desired location by simply choosing it from the list of options."

--- a/administrator/modules/mod_menu/tmpl/default.php
+++ b/administrator/modules/mod_menu/tmpl/default.php
@@ -25,7 +25,7 @@ $root     = $menuTree->reset();
 
 if ($root->hasChildren())
 {
-	echo '<div class="main-nav-container" role="navigation" aria-label="Main menu">';
+	echo '<div class="main-nav-container" role="navigation" aria-label="Main Menu">';
 	echo '<ul id="menu" class="' . $class . '" role="menu">' . "\n";
 	echo '<li role="menuitem">';
 	echo '<a id="menu-collapse" href="#">';

--- a/build/media/plg_system_skipto/css/skipto.css
+++ b/build/media/plg_system_skipto/css/skipto.css
@@ -1,0 +1,249 @@
+.skipTo {
+  padding: .5em;
+  position: absolute;
+  background: transparent;
+  color: #000000;
+  -webkit-transition: top .5s ease-out, background .5s linear;
+  -moz-transition: top .5s ease-out, background .5s linear;
+  -o-transition: top .5s ease-out, background .5s linear;
+  transition: top .5s ease-out, background .5s linear;
+}
+.skipTo:focus {
+  position: absolute;
+  top: 0;
+  left: 0;
+  background: #cccccc;
+  z-index: 2000;
+  text-decoration: underline;
+  -webkit-transition: top .1s ease-in, background .3s linear;
+  -moz-transition: top .1s ease-in, background .3s linear;
+  -o-transition: top .1s ease-in, background .3s linear;
+  transition: top .1s ease-in, background .3s linear;
+}
+.onFocus {
+  top: -5em;
+  left: 0;
+}
+.onLoad {
+  top: 0 ;
+  left: 0;
+  background: #cccccc;
+}
+.dropup,
+.dropMenu {
+  position: relative;
+}
+.dropMenu-toggle {
+  *margin-bottom: -3px;
+}
+.dropMenu-toggle:active,
+.open .dropMenu-toggle {
+  outline: 0;
+}
+#skipToMenu .caret {
+  display: inline-block;
+  width: 0;
+  height: 0;
+  vertical-align: top;
+  border-top: 4px solid #000000;
+  border-right: 4px solid transparent;
+  border-left: 4px solid transparent;
+  content: '';
+  pointer-events: none;
+}
+#skipToMenu .dropMenu .caret {
+  margin-top: 8px;
+  margin-left: 2px;
+}
+.dropMenu-menu {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  z-index: 2000;
+  display: none;
+  float: left;
+  min-width: 160px;
+  padding: 5px 0;
+  margin: 2px 0 0;
+  list-style: none;
+  background-color: #ffffff;
+  border: 1px solid #ccc;
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  *border-right-width: 2px;
+  *border-bottom-width: 2px;
+  -webkit-border-radius: 6px;
+  -moz-border-radius: 6px;
+  border-radius: 6px;
+  -webkit-box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
+  -moz-box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
+  -webkit-background-clip: padding-box;
+  -moz-background-clip: padding;
+  background-clip: padding-box;
+}
+.dropMenu-menu.pull-right {
+  right: 0;
+  left: auto;
+}
+.dropMenu-menu .divider {
+  *width: 100%;
+  height: 1px;
+  margin: 9px 1px;
+  *margin: -5px 0 5px;
+  overflow: hidden;
+  background-color: #e5e5e5;
+  border-bottom: 1px solid #ffffff;
+}
+.dropMenu-menu > li > a {
+  display: block;
+  padding: 3px 20px;
+  clear: both;
+  font-weight: normal;
+  line-height: 20px;
+  color: #333333;
+  white-space: nowrap;
+  text-decoration: none;
+}
+.dropMenu-menu > li > a.po-h1 {
+  font-size: 110%;
+}
+.dropMenu-menu > li > a.po-h2 {
+  padding-left: 28px;
+}
+.dropMenu-menu > li > a.po-h3 {
+  padding-left: 36px;
+}
+.dropMenu-menu > li > a.po-h4 {
+  padding-left: 44px;
+}
+.dropMenu-menu > li > a.po-h5 {
+  padding-left: 52px;
+}
+.dropMenu-menu > li > a.po-6 {
+  padding-left: 60px;
+}
+.dropMenu-menu > li[role=separator] {
+  padding-left: 20px;
+  margin-top: 9px;
+  font-weight: bold;
+  border-bottom: thin solid black;
+}
+.dropMenu-menu > li > a:hover,
+.dropMenu-menu > li > a:focus,
+.dropMenu-submenu:hover > a,
+.dropMenu-submenu:focus > a {
+  text-decoration: none;
+  color: #ffffff;
+  background-color: #0081c2;
+  background-image: -moz-linear-gradient(top, #0088cc, #0077b3);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#0088cc), to(#0077b3));
+  background-image: -webkit-linear-gradient(top, #0088cc, #0077b3);
+  background-image: -o-linear-gradient(top, #0088cc, #0077b3);
+  background-image: linear-gradient(to bottom, #0088cc, #0077b3);
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff0088cc', endColorstr='#ff0077b3', GradientType=0);
+}
+.dropMenu-menu > .active > a,
+.dropMenu-menu > .active > a:hover,
+.dropMenu-menu > .active > a:focus {
+  color: #ffffff;
+  text-decoration: none;
+  outline: 0;
+  background-color: #0081c2;
+  background-image: -moz-linear-gradient(top, #0088cc, #0077b3);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#0088cc), to(#0077b3));
+  background-image: -webkit-linear-gradient(top, #0088cc, #0077b3);
+  background-image: -o-linear-gradient(top, #0088cc, #0077b3);
+  background-image: linear-gradient(to bottom, #0088cc, #0077b3);
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff0088cc', endColorstr='#ff0077b3', GradientType=0);
+}
+.dropMenu-menu > .disabled > a,
+.dropMenu-menu > .disabled > a:hover,
+.dropMenu-menu > .disabled > a:focus {
+  color: #999999;
+}
+.dropMenu-menu > .disabled > a:hover,
+.dropMenu-menu > .disabled > a:focus {
+  text-decoration: none;
+  background-color: transparent;
+  background-image: none;
+  filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
+  cursor: default;
+}
+.open {
+  *z-index: 2000;
+}
+.open > .dropMenu-menu {
+  display: block;
+}
+.pull-right > .dropMenu-menu {
+  right: 0;
+  left: auto;
+}
+#skipToMenu .dropup .caret,
+#skipToMenu .navbar-fixed-bottom .dropMenu .caret {
+  border-top: 0;
+  border-bottom: 4px solid #000000;
+  content: '';
+}
+#skipToMenu .dropup .dropMenu-menu,
+#skipToMenu .navbar-fixed-bottom .dropMenu .dropMenu-menu {
+  top: auto;
+  bottom: 100%;
+  margin-bottom: 1px;
+}
+.dropMenu-submenu {
+  position: relative;
+}
+.dropMenu-submenu > .dropMenu-menu {
+  top: 0;
+  left: 100%;
+  margin-top: -6px;
+  margin-left: -1px;
+  -webkit-border-radius: 0 6px 6px 6px;
+  -moz-border-radius: 0 6px 6px 6px;
+  border-radius: 0 6px 6px 6px;
+}
+.dropMenu-submenu:hover > .dropMenu-menu {
+  display: block;
+}
+.dropup .dropMenu-submenu > .dropMenu-menu {
+  top: auto;
+  bottom: 0;
+  margin-top: 0;
+  margin-bottom: -2px;
+  -webkit-border-radius: 5px 5px 5px 0;
+  -moz-border-radius: 5px 5px 5px 0;
+  border-radius: 5px 5px 5px 0;
+}
+.dropMenu-submenu > a:after {
+  display: block;
+  content: ' ';
+  float: right;
+  width: 0;
+  height: 0;
+  border-color: transparent;
+  border-style: solid;
+  border-width: 5px 0 5px 5px;
+  border-left-color: #cccccc;
+  margin-top: 5px;
+  margin-right: -10px;
+}
+.dropMenu-submenu:hover > a:after {
+  border-left-color: #ffffff;
+}
+.dropMenu-submenu.pull-left {
+  float: none;
+}
+.dropMenu-submenu.pull-left > .dropMenu-menu {
+  left: -100%;
+  margin-left: 10px;
+  -webkit-border-radius: 6px 0 6px 6px;
+  -moz-border-radius: 6px 0 6px 6px;
+  border-radius: 6px 0 6px 6px;
+}
+.dropMenu .dropMenu-menu .nav-header {
+  padding-left: 20px;
+  padding-right: 20px;
+}

--- a/build/media/plg_system_skipto/js/skipto.js
+++ b/build/media/plg_system_skipto/js/skipto.js
@@ -1,0 +1,604 @@
+/*! skipto - v2.0.0 - 2018-09-12
+* https://github.com/paypal/skipto
+* Copyright (c) 2018 PayPal Accessibility Team and University of Illinois; Licensed BSD */
+ /*@cc_on @*/
+/*@if (@_jscript_version >= 5.8) @*/
+/* ========================================================================
+* Copyright (c) <2013> PayPal
+
+* All rights reserved.
+
+* Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+* Neither the name of PayPal or any of its subsidiaries or affiliates nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+* ======================================================================== */
+
+(function () {
+	"use strict";
+
+	var Dropdown = {};
+
+	Dropdown.prototype = {
+		btn: null,
+		prt: null,
+		menu: null,
+		wrap: "false",
+
+		clearMenus: function () {
+			var self = this;
+			setTimeout(function () {
+				var isActive = self.prt.classList.contains('open');
+				if ((!isActive) || (self.prt.contains(document.activeElement))) {
+					return;
+				}
+				self.prt.classList.remove('open');
+				self.btn.setAttribute('aria-expanded', 'false');
+			}, 150);
+		},
+
+		toggleOptList: function (e) {
+			this.btn = e.target;
+			this.prt = this.btn.parentNode;
+			this.menu = document.getElementById(this.btn.getAttribute('data-target'));
+
+			if(typeof this.btn.getAttribute('data-wrap') !== 'undefined') {
+				this.wrap = this.btn.getAttribute('data-wrap');
+			}
+			this.prt.classList.toggle('open');
+			//Set Aria-expanded to true only if the class open exists in dropMenu div
+			if (this.prt.classList.contains('open')) {
+				this.btn.setAttribute('aria-expanded', 'true');
+			} else {
+				this.btn.setAttribute('aria-expanded', 'false');
+			}
+			try {
+				this.menu.getElementsByTagName('a')[0].focus();
+			}
+			catch(err){
+			}
+		},
+
+		navigateMenus: function (e) {
+			var keyCode = e.keyCode || e.which,
+				arrow = {
+					spacebar: 32,
+					up: 38,
+					esc: 27,
+					down: 40
+				},
+				isActive = this.prt.classList.contains('open'),
+				items = this.menu.getElementsByTagName("a"),
+				index = Array.prototype.indexOf.call(items, e.target);
+	
+
+			if (!/(32|38|40|27)/.test(keyCode)) {
+				return;
+			}
+			e.preventDefault();
+
+			switch (keyCode) {
+			case arrow.down:
+				index = index + 1;
+				break;
+			case arrow.up:
+				index = index - 1;
+				break;
+			case arrow.esc:
+				if (isActive) {
+					this.btn.click();
+					this.btn.focus();
+					return;
+				}
+				break;
+			}
+			if (index < 0) {
+				if(this.wrap === 'true'){
+					index = items.length - 1;
+				}else{
+					index=0;
+				}
+			}
+			if (index === items.length) {
+				if(this.wrap === 'true'){
+					index = 0;
+				}else{
+					index = items.length -1;
+				}
+			}
+
+			items.item(index).focus();
+		},
+
+		init: function () {
+			var toggle = document.getElementsByClassName('dropMenu-toggle'),
+				toggleBtn,
+				k,
+				l,
+				menu,
+				items,
+				i,
+				j,
+				self=this,
+				item;
+				
+			for (k = 0, l = toggle.length; k < l; k = k + 1) {
+				toggleBtn = toggle[k];
+				menu = document.getElementById(toggleBtn.getAttribute('data-target'));
+				items = menu.getElementsByTagName("a");
+
+				toggleBtn.addEventListener('click', function(e) {
+					self.toggleOptList(e);
+				});
+				toggleBtn.addEventListener('keydown', function(e){
+					var keyCode = e.keyCode || e.which;
+					if(keyCode === 32){						//SpaceBar should open the menu
+						this.click(e);
+						e.preventDefault();
+					}
+				});
+
+				for (i = 0, j = items.length; i < j; i = i + 1) {
+					item = items[i];
+					item.addEventListener('keydown', function(e) {
+						self.navigateMenus(e);
+					});
+
+					item.addEventListener('blur', function(e) {
+						self.clearMenus(e);
+					});
+				}
+			}
+		} //end init
+
+	}; //End Dropdown class
+
+	Dropdown.prototype.init();
+	window.skipToDropDownInit=function(){
+		Dropdown.prototype.init();
+	};
+
+}());;/* ========================================================================
+* Copyright (c) <2013> PayPal
+
+* All rights reserved.
+
+* Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+* Neither the name of PayPal or any of its subsidiaries or affiliates nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+* ======================================================================== */
+
+
+(function (appConfig) {
+	"use strict";
+	var SkipTo = {};
+
+	SkipTo.prototype = {
+		headingElementsArr:  [],
+		landmarkElementsArr:  [],
+		idElementsArr:  [],
+		dropdownHTML: null,
+		config: {
+			buttonLabel:    Joomla.JText._('PLG_SYSTEM_SKIPTO_SKIP_TO'),
+			buttonDivTitle: Joomla.JText._('PLG_SYSTEM_SKIPTO_SKIP_TO_KEYBOARD'),
+			buttonDivRole: 'complementary',
+			buttonDivLabel: '',
+			menuLabel:      Joomla.JText._('PLG_SYSTEM_SKIPTO_SKIP_TO_AND_PAGE_OUTLINE'),
+			landmarksLabel: Joomla.JText._('PLG_SYSTEM_SKIPTO_SKIP_TO'),
+			headingsLabel:  Joomla.JText._('PLG_SYSTEM_SKIPTO_PAGE_OUTLINE'),
+			main:      'main, [role="main"]',
+			landmarks: '[role="navigation"], [role="search"]',
+			sections:  'nav',
+			headings:  'h1, h2, h3',
+			ids:       '#SkipToA1, #SkipToA2',
+			accessKey: '0',
+			wrap: "false",
+			visibility: "onFocus",
+			customClass: "",
+			attachElement: document.body
+		},
+
+		setUpConfig: function (appConfig) {
+			var localConfig = this.config,
+				name,
+
+				appConfigSettings = typeof appConfig.settings !== 'undefined' ? appConfig.settings.skipTo : {};
+				
+			for (name in appConfigSettings) {
+				//overwrite values of our local config, based on the external config
+				if (localConfig.hasOwnProperty(name)) {
+					localConfig[name] = appConfigSettings[name];
+				}
+			}
+		},
+
+		init: function (appConfig) {
+
+			this.setUpConfig(appConfig);
+
+
+			// if the menu exists, recreate it
+			if(document.getElementById('skipToMenu')!==null){
+				var existingMenu=document.getElementById('skipToMenu');
+				existingMenu.parentNode.removeChild(existingMenu);
+			}
+
+			var div = document.createElement('div'),
+			attachElement = (!this.config.attachElement.nodeType) ? document.querySelector(this.config.attachElement) : this.config.attachElement,
+			htmlStr = '';
+
+			div.setAttribute('id', 'skipToMenu');
+			if(this.config.buttonDivRole!==''){div.setAttribute('role', this.config.buttonDivRole);}
+			if(this.config.buttonDivTitle!==''){div.setAttribute('title', this.config.buttonDivTitle);}
+			if(this.config.buttonDivLabel!==''){div.setAttribute('aria-label', this.config.buttonDivLabel);}
+
+			this.dropdownHTML = '<a accesskey="'+ this.config.accessKey +'" tabindex="0" data-wrap="'+ this.config.wrap +'"class="dropMenu-toggle skipTo '+ this.config.visibility + ' '+ this.config.customClass +'" id="drop4" role="button" aria-haspopup="true" ';
+			this.dropdownHTML += 'aria-expanded="false" data-toggle="dropMenu" href="#" data-target="menu1">' + this.config.buttonLabel + '<span class="caret"></span></a>';
+			this.dropdownHTML += '<ul id="menu1" class="dropMenu-menu" role="menu" aria-label="' + this.config.menuLabel + '" style="top:3%; text-align:left">';
+
+			this.getLandMarks(this.config.main);
+			this.getLandMarks(this.config.landmarks);
+			this.getSections(this.config.sections);
+
+			this.getIdElements();
+
+			this.getHeadings();
+
+			htmlStr = this.getdropdownHTML();
+			this.dropdownHTML += htmlStr + '</ul>';
+
+			if ( htmlStr.length >0 ) {
+				div.className = "dropMenu";
+				attachElement.insertBefore(div, attachElement.firstChild);
+				div.innerHTML = this.dropdownHTML;
+				this.addListeners();
+			}
+			window.skipToDropDownInit();
+		},
+
+		normalizeName: function (name) {
+			if (typeof name === 'string') return name.replace(/\w\S*/g, function(txt){return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();});
+			return "";
+		},
+
+		getTextContent: function (elem) {
+			
+			function getText(e, strings) {
+				// If text node get the text and return
+				if( e.nodeType === 3 ) { /*IE8 - Node.TEXT_NODE*/
+					strings.push(e.data);
+				} else {
+					// if an element for through all the children elements looking for text
+					if( e.nodeType === 1 ) { /*IE8 - Node.ELEMENT_NODE*/
+					// check to see if IMG or AREA element and to use ALT content if defined
+						var tagName = e.tagName.toLowerCase();
+						if((tagName === 'img') || (tagName === 'area')) {
+							if (e.alt) {
+								strings.push(e.alt);
+							}
+						} else {
+							var c = e.firstChild;
+							while (c) {
+								getText(c, strings);
+								c = c.nextSibling;
+							} // end loop
+						}
+					}
+				}
+			} // end function getStrings
+
+			// Create return object
+			var str = "Test",
+			strings = [];
+			getText(elem, strings);
+			if (strings.length) str = strings.join(" ");
+			if (str.length > 30) str = str.substring(0,27) + "...";
+			return str;
+		},
+
+		getAccessibleName: function (elem) {
+			var labelledbyIds = elem.getAttribute('aria-labelledby'),
+			label = elem.getAttribute('aria-label'),
+			title = elem.getAttribute('title'),
+			name = "";
+			
+			if (labelledbyIds && labelledbyIds.length) {
+				var str,
+				strings = [],
+				ids = labelledbyIds.split(' ');
+				if (!ids.length) ids = [labelledbyIds];
+				for (var i = 0, l = ids.length; i < l; i += 1) {
+					var e = document.getElementById(ids[i]);
+					if (e) str = this.getTextContent(e);
+					if (str.length) strings.push(str);
+				}
+				name = strings.join(" ");
+			}
+			else {
+				if (label && label.length) {
+					name = label;
+				}
+				else {
+					if (title && title.length) {
+						name = title;
+					}
+				}
+			}
+			return name;
+		},
+
+		getHeadings: function () {
+			var targets = this.config.headings;
+			if (typeof targets !== 'string' || targets.length === 0) return;
+			var headings = document.querySelectorAll(targets),
+				i,
+				j,
+				heading,
+				role,
+				id;
+			for (i = 0, j = headings.length; i < j; i = i + 1) {
+				heading = headings[i];
+				role = heading.getAttribute('role');
+				if ((typeof role === 'string') && (role === 'presentation')) continue;
+				if (this.isVisible(heading)) {
+					id = heading.getAttribute('id') || heading.innerHTML.replace(/\s+/g, '_').toLowerCase().replace(/[&\/\\#,+()$~%.'"!:*?<>{}¹]/g, '') + '_' + i;
+
+					heading.tabIndex = "-1";
+					heading.setAttribute('id', id);
+					
+					//this.headingElementsArr[id] = heading.tagName.toLowerCase() + ": " + this.getTextContent(heading);
+					//IE8 fix: Use JSON object to supply names to array values. This allows enumerating over the array without picking up prototype properties.
+					this.headingElementsArr[id] = {id: id, name: heading.tagName.toLowerCase() + ": " + this.getTextContent(heading)};
+				}
+			}
+		},
+		
+		isVisible: function(element) {
+		
+			function isVisibleRec (el) {
+				if (el.nodeType === 9) return true; /*IE8 does not support Node.DOCUMENT_NODE*/
+
+				//For IE8: Use standard means if available, otherwise use the IE methods
+				var display = document.defaultView?document.defaultView.getComputedStyle(el,null).getPropertyValue('display'):el.currentStyle.display;
+				var visibility = document.defaultView?document.defaultView.getComputedStyle(el,null).getPropertyValue('visibility'):el.currentStyle.visibility;
+				//var computedStyle = window.getComputedStyle(el, null);
+				//var display = computedStyle.getPropertyValue('display');
+				//var visibility = computedStyle.getPropertyValue('visibility');
+				var hidden = el.getAttribute('hidden');
+				var ariaHidden = el.getAttribute('aria-hidden');
+				var clientRect = el.getBoundingClientRect();
+
+				if ((display === 'none') ||
+						(visibility === 'hidden') ||
+						(hidden !== null) ||
+						(ariaHidden === 'true') ||
+						(clientRect.height < 4) ||
+						(clientRect.width < 4)) {
+					return false;
+				}
+				
+				return isVisibleRec(el.parentNode);
+			}
+			
+			return isVisibleRec(element);
+		},
+
+		getSections: function (targets) {
+			if (typeof targets !== 'string' || targets.length === 0) return;
+			var sections = document.querySelectorAll(targets),
+				k,
+				l,
+				section,
+				id1,
+				role,
+				val,
+				name;
+
+			for (k = 0, l = sections.length; k < l; k = k + 1) {
+				section = sections[k];
+				role = section.getAttribute(role);
+				if ((typeof role === 'string') && (role === 'presentation')) continue;
+				if (this.isVisible(section)) {
+					id1 = section.getAttribute('id') || 'ui-skip-' + Math.floor((Math.random() * 100) + 1);
+					section.tabIndex = "-1";
+					section.setAttribute('id', id1);
+					role = section.tagName.toLowerCase();
+					val = this.normalizeName(role);
+
+					name = this.getAccessibleName(section);
+
+					if (name && name.length) {
+						val += ": " + name;
+					}
+					else {
+						if (role === 'main') {
+							val += Joomla.JText._('A11Y_CONTENT');
+						}
+					}
+					this.landmarkElementsArr[id1] = val;
+				}
+			}
+		},
+
+
+		getLandMarks: function (targets) {
+			if (typeof targets !== 'string' || targets.length === 0) return;
+			var landmarks = document.querySelectorAll(targets),
+				k,
+				l,
+				landmark,
+				id1,
+				role,
+				name,
+				val;
+
+			for (k = 0, l = landmarks.length; k < l; k = k + 1) {
+				landmark = landmarks[k];
+				role = landmark.getAttribute('role');
+				if ((typeof role === 'string') && (role === 'presentation')) continue;
+				if (this.isVisible(landmark)) {
+					id1 = landmark.getAttribute('id') || 'ui-skip-' + Math.floor((Math.random() * 100) + 1);
+					landmark.tabIndex = "-1";
+					landmark.setAttribute('id', id1);
+					if (!role) role = landmark.tagName.toLowerCase();
+					name = this.getAccessibleName(landmark);
+
+					if (role === 'banner') {
+						role = 'header';
+					} // banner landmark is the same as header element in HTML5
+
+					if (role === 'contentinfo') {
+						role = 'footer';
+					} //contentinfo landmark is the same as footer element in HTML5
+
+					if (role === 'navigation') {
+						role = 'nav';
+					} // navigation landmark is the same as nav element in HTML5
+
+					val = this.normalizeName(role);
+
+					if (name && name.length) {
+						val += ": " + name;
+					}
+					else {
+						if (role === 'main') {
+							val += Joomla.JText._('A11Y_CONTENT');
+						}
+					}
+					this.landmarkElementsArr[id1] = val;
+				}
+			}
+		},
+
+		getIdElements: function () {
+			var els = document.querySelectorAll(this.config.ids),
+				i,
+				j,
+				el,
+				id,
+				val;
+
+			for (i = 0, j = els.length; i < j; i = i + 1) {
+				el = els[i];
+				id = el.getAttribute('id');
+				/*val = el.innerHTML.replace(/<\/?[^>]+>/gi, '').replace(/\s+/g, ' ').trim();*/
+				val = el.innerHTML.replace(/<\/?[^>]+>/gi, '').replace(/\s+/g, ' ').replace(/^\s+|\s+$/g, "");/*for IE8*/
+
+				if (val.length > 30)	val = val.replace(val, val.substr(0, 30)	+	'...');
+				this.idElementsArr[id] = "id: " + val;
+			}
+		},
+
+		getdropdownHTML: function(){
+			var key,
+				val,
+				htmlStr = '',
+				landmarkSep = true,
+				headingSep = true,
+				headingClass = '';
+
+			// window.console.log(this.elementsArr);
+			
+			//IE8 fix: for...in loop enumerates over all properties in an object including its prototype. This was returning some undesirable items such as indexof
+			//Make sure that the key is not from the prototype.
+			for (key in this.landmarkElementsArr) {
+				if (this.landmarkElementsArr.hasOwnProperty(key)){
+					if (landmarkSep) {
+						htmlStr += '<li role="separator" style="list-style:none outside none">' + this.config.landmarksLabel + '</li>';
+						landmarkSep = false;
+					}
+					val = this.landmarkElementsArr[key];
+					htmlStr += '<li role="presentation" style="list-style:none outside none"><a tabindex="-1" role="menuitem" href="#';
+					htmlStr += key + '">' + val;
+					htmlStr += '</a></li>';
+				}
+			}
+
+			//IE8 fix: for...in loop enumerates over all properties in an object including its prototype. This was returning some undesirable items such as indexof
+			//Make sure that the key is not from the prototype.
+			for (key in this.idElementsArr) {
+				if (this.idElementsArr.hasOwnProperty(key)){
+					if (landmarkSep) {
+						htmlStr += '<li role="separator" style="list-style:none outside none">' + this.config.landmarksLabel + '</li>';
+						landmarkSep = false;
+					}
+					val = this.idElementsArr[key];
+					htmlStr += '<li role="presentation" style="list-style:none outside none"><a tabindex="-1" role="menuitem" href="#';
+					htmlStr += key + '">' + val;
+					htmlStr += '</a></li>';
+				}
+			}
+			//for...in loop enumerates over all properties in an object including its prototype. This was returning some undesirable items such as indexof
+			//James' workaround to get for JSON name/value pair appears to address the issue.
+			for (key in this.headingElementsArr) {
+				if (this.headingElementsArr[key].name){
+					if (headingSep) {
+						htmlStr += '<li role="separator" style="list-style:none outside none">' + this.config.headingsLabel + '</li>';
+						headingSep = false;
+					}
+					val = this.headingElementsArr[key].name;
+				
+					headingClass = val.substring(0,2);
+				
+					htmlStr += '<li role="presentation" style="list-style:none outside none"><a class="po-' + headingClass + '" tabindex="-1" role="menuitem" href="#';
+					htmlStr += key + '">' + val;
+					htmlStr += '</a></li>';
+				}
+			}
+
+			return htmlStr;
+		},
+
+		addStyles: function (cssString) {
+			var ss1 = document.createElement('style'),
+				hh1 = document.getElementsByTagName('head')[0],
+				tt1;
+
+			ss1.setAttribute("type", "text/css");
+			hh1.appendChild(ss1);
+
+			if (ss1.styleSheet) {
+				// IE
+				ss1.styleSheet.cssText = cssString;
+			} else {
+				tt1 = document.createTextNode(cssString);
+				ss1.appendChild(tt1);
+			}
+		},
+
+		addListeners: function () {
+			window.addEventListener("hashchange", function () {
+				var element = document.getElementById(location.hash.substring(1));
+				if (element) {
+					if (!/^(?:a|select|input|button|textarea)$/i.test(element.tagName)) {
+						element.tabIndex = -1;
+					}
+					element.focus();
+					element.scrollIntoView(true); //IE8 - Make sure to scroll to top
+				}
+			}, false);
+		}
+	};
+
+	SkipTo.prototype.init(appConfig);
+
+	// Make this public so it can be called again in the future;
+	window.skipToMenuInit=function(){
+		SkipTo.prototype.init(window.SkipToConfig || {});
+	};
+
+
+
+}(window.SkipToConfig || {}));
+/*@end @*/

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -676,6 +676,7 @@ INSERT INTO `#__extensions` (`extension_id`, `package_id`, `name`, `type`, `elem
 (490, 0, 'plg_extension_namespacemap', 'plugin', 'namespacemap', 'extension', 0, 1, 1, 1, '', '{}', 0, '0000-00-00 00:00:00', 0, 0, ''),
 (491, 0, 'plg_installer_override', 'plugin', 'override', 'installer', 0, 1, 1, 1, '', '', 0, '0000-00-00 00:00:00', 4, 0, ''),
 (492, 0, 'plg_quickicon_overridecheck', 'plugin', 'overridecheck', 'quickicon', 0, 1, 1, 1, '', '', 0, '0000-00-00 00:00:00', 0, 0, ''),
+(493, 0, 'plg_system_skipto', 'plugin', 'skipto', 'system', 0, 1, 1, 1, '', '', 0, '0000-00-00 00:00:00', 0, 0, ''),
 (509, 0, 'atum', 'template', 'atum', '', 1, 1, 1, 0, '', '', 0, '0000-00-00 00:00:00', 0, 0, ''),
 (510, 0, 'cassiopeia', 'template', 'cassiopeia', '', 0, 1, 1, 0, '', '{"logoFile":"","fluidContainer":"0","sidebarLeftWidth":"3","sidebarRightWidth":"3"}', 0, '0000-00-00 00:00:00', 0, 0, ''),
 (600, 802, 'English (en-GB)', 'language', 'en-GB', '', 0, 1, 1, 1, '', '', 0, '0000-00-00 00:00:00', 0, 0, ''),

--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -685,6 +685,7 @@ INSERT INTO "#__extensions" ("extension_id", "package_id", "name", "type", "elem
 (490, 0, 'plg_extension_namespacemap', 'plugin', 'namespacemap', 'extension', 0, 1, 1, 1, '', '{}', 0, '1970-01-01 00:00:00', 0, 0, ''),
 (491, 0, 'plg_installer_override', 'plugin', 'override', 'installer', 0, 1, 1, 1, '', '', 0, '1970-01-01 00:00:00', 4, 0, ''),
 (492, 0, 'plg_quickicon_overridecheck', 'plugin', 'overridecheck', 'quickicon', 0, 1, 1, 1, '', '', 0, '1970-01-01 00:00:00', 0, 0, ''),
+(493, 0, 'plg_system_skipto', 'plugin', 'skipto', 'system', 0, 1, 1, 1, '', '', 0, '1970-01-01 00:00:00', 0, 0, ''),
 (600, 802, 'English (en-GB)', 'language', 'en-GB', '', 0, 1, 1, 1, '', '', 0, '1970-01-01 00:00:00', 0, 0, ''),
 (601, 802, 'English (en-GB)', 'language', 'en-GB', '', 1, 1, 1, 1, '', '', 0, '1970-01-01 00:00:00', 0, 0, ''),
 (700, 0, 'files_joomla', 'file', 'joomla', '', 0, 1, 1, 1, '', '', 0, '1970-01-01 00:00:00', 0, 0, ''),

--- a/libraries/src/Extension/ExtensionHelper.php
+++ b/libraries/src/Extension/ExtensionHelper.php
@@ -237,6 +237,7 @@ class ExtensionHelper
 		array('plugin', 'redirect', 'system', 0),
 		array('plugin', 'remember', 'system', 0),
 		array('plugin', 'sef', 'system', 0),
+		array('plugin', 'skipto', 'system', 0),
 		array('plugin', 'stats', 'system', 0),
 		array('plugin', 'sessiongc', 'system', 0),
 		array('plugin', 'updatenotification', 'system', 0),

--- a/plugins/system/skipto/skipto.php
+++ b/plugins/system/skipto/skipto.php
@@ -44,7 +44,7 @@ class PlgSystemSkipto extends CMSPlugin
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function onAfterInitialise()
+	public function onBeforeCompileHead()
 	{
 		// Get the document object.
 		$document = Factory::getDocument();

--- a/plugins/system/skipto/skipto.php
+++ b/plugins/system/skipto/skipto.php
@@ -60,6 +60,6 @@ class PlgSystemSkipto extends CMSPlugin
 
 			HTMLHelper::_('script', 'plg_system_skipto/skipto.js', ['version' => 'auto', 'relative' => true], ['defer' => true]);
 			HTMLHelper::_('stylesheet', 'plg_system_skipto/skipto.css', array('version' => 'auto', 'relative' => true));
- 		}
+		}
 	}
 }

--- a/plugins/system/skipto/skipto.php
+++ b/plugins/system/skipto/skipto.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * @package     Joomla.Plugin
+ * @subpackage  System.skipto
+ *
+ * @copyright   Copyright (C) 2005 - 2018 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+use Joomla\CMS\Factory;
+use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Language\Text;
+use Joomla\CMS\Plugin\CMSPlugin;
+
+/**
+ * Skipto plugin to add accessible keyboard navigation to the administrator template .
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class PlgSystemSkipto extends CMSPlugin
+{
+	/**
+	 * If true, language files will be loaded automatically.
+	 *
+	 * @var    boolean
+	 * @since  4.0.0
+	 */
+	protected $autoloadLanguage = true;
+
+	/**
+	 * Application object.
+	 *
+	 * @var    JApplicationCms
+	 * @since  4.0.0
+	 */
+	protected $app;
+
+	/**
+	 * Add the css and javascript for the skipto navigation menu
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function onAfterInitialise()
+	{
+		// Get the document object.
+		$document = Factory::getDocument();
+
+		if ($this->app->isClient('administrator'))
+		{
+			// Add strings for translations in Javascript.
+			Text::script('PLG_SYSTEM_SKIPTO_CONTENT');
+			Text::script('PLG_SYSTEM_SKIPTO_PAGE_OUTLINE');
+			Text::script('PLG_SYSTEM_SKIPTO_SKIP_TO');
+			Text::script('PLG_SYSTEM_SKIPTO_SKIP_TO_KEYBOARD');
+			Text::script('PLG_SYSTEM_SKIPTO_SKIP_TO_AND_PAGE_OUTLINE');
+
+			HTMLHelper::_('script', 'plg_system_skipto/skipto.js', ['version' => 'auto', 'relative' => true], ['defer' => true]);
+			HTMLHelper::_('stylesheet', 'plg_system_skipto/skipto.css', array('version' => 'auto', 'relative' => true));
+ 		}
+	}
+}

--- a/plugins/system/skipto/skipto.php
+++ b/plugins/system/skipto/skipto.php
@@ -15,7 +15,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Plugin\CMSPlugin;
 
 /**
- * Skipto plugin to add accessible keyboard navigation to the administrator template .
+ * Skipto plugin to add accessible keyboard navigation to the administrator template.
  *
  * @since  __DEPLOY_VERSION__
  */

--- a/plugins/system/skipto/skipto.xml
+++ b/plugins/system/skipto/skipto.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<extension version="4.0" type="plugin" group="system" method="upgrade">
+	<name>plg_system_skipto</name>
+	<author>Joomla! Project</author>
+	<creationDate>2018-9-12</creationDate>
+	<copyright>(C) 2005 - 2018 Open Source Matters. All rights reserved.</copyright>
+	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
+	<authorEmail>admin@joomla.org</authorEmail>
+	<authorUrl>www.joomla.org</authorUrl>
+	<version>4.0.0</version>
+	<description>PLG_SYSTEM_SKIPTO_XML_DESCRIPTION</description>
+	<files>
+		<filename plugin="system">skipto.php</filename>
+	</files>
+	<languages>
+		<language tag="en-GB">language/en-GB/en-GB.plg_system_skipto.ini</language>
+		<language tag="en-GB">language/en-GB/en-GB.plg_system_skipto.sys.ini</language>
+	</languages>
+</extension>


### PR DESCRIPTION
Based on https://github.com/paypal/skipto

SkipTo is a replacement for your old classic "Skipnav" link. The script dynamically determines the most important places on the page and presents them to the user in a drop-down menu. 

The menu makes it easier for keyboard and screen reader users to quickly jump to the desired location by simply choosing it from the list of options.

It is activated on the first press of the tab key (or by pressing the accesskey ctrl-0, cmd=0)

**IMPORTANT NOTE** we have not finished ensuring that all the parts of the page are in the correct landmark yet - that's beyond the scope of this

**BUG - Help Required** Since recording the examples below I moved the strings to the correct file but for some reason I can't see they are not loading

I have only enabled this for the admin but we could add a param to enable it in the frontend as well

**Static image**
![image](https://user-images.githubusercontent.com/1296369/45444680-0b0a4a80-b6c0-11e8-9e28-98f8bbca1bb9.png)

**Animation showing that after selecting an item the keyboard has focus on that item**
![cpanel](https://user-images.githubusercontent.com/1296369/45444729-2d9c6380-b6c0-11e8-9f4f-16319e7dbdfc.gif)
