### PR TITLE
Fix export action logs error

### DIFF
--- a/administrator/components/com_actionlogs/controllers/actionlogs.php
+++ b/administrator/components/com_actionlogs/controllers/actionlogs.php
@@ -68,8 +68,7 @@ class ActionlogsControllerActionlogs extends JControllerAdmin
 
 		if ($task == 'exportSelectedLogs')
 		{
-			// Get selected logs
-			$cids = $this->input->post->getString('cids');
+			// Get selected logs			
 			$pks = ArrayHelper::toInteger(explode(',', $this->input->post->getString('cids')));
 		}
 		else

--- a/administrator/components/com_actionlogs/controllers/actionlogs.php
+++ b/administrator/components/com_actionlogs/controllers/actionlogs.php
@@ -65,7 +65,7 @@ class ActionlogsControllerActionlogs extends JControllerAdmin
 		JSession::checkToken() or die(JText::_('JINVALID_TOKEN'));
 
 		// Get selected logs
-		$pks = ArrayHelper::toInteger($this->input->post->get('cid', array(), 'array'));
+		$pks = ArrayHelper::toInteger(explode(',', $this->input->post->getString('cids')));
 
 		// Get the logs data
 		$data = $this->getModel()->getLogsData($pks);

--- a/administrator/components/com_actionlogs/controllers/actionlogs.php
+++ b/administrator/components/com_actionlogs/controllers/actionlogs.php
@@ -66,16 +66,14 @@ class ActionlogsControllerActionlogs extends JControllerAdmin
 
 		$task = $this->getTask();
 
+		$pks = array();
+
 		if ($task == 'exportSelectedLogs')
 		{
 			// Get selected logs			
 			$pks = ArrayHelper::toInteger(explode(',', $this->input->post->getString('cids')));
 		}
-		else
-		{
-			$pks = array();
-		}
-		
+
 		// Get the logs data
 		$data = $this->getModel()->getLogsData($pks);
 

--- a/administrator/components/com_actionlogs/controllers/actionlogs.php
+++ b/administrator/components/com_actionlogs/controllers/actionlogs.php
@@ -64,9 +64,19 @@ class ActionlogsControllerActionlogs extends JControllerAdmin
 		// Check for request forgeries.
 		JSession::checkToken() or die(JText::_('JINVALID_TOKEN'));
 
-		// Get selected logs
-		$pks = ArrayHelper::toInteger(explode(',', $this->input->post->getString('cids')));
+		$task = $this->getTask();
 
+		if ($task == 'exportSelectedLogs')
+		{
+			// Get selected logs
+			$cids = $this->input->post->getString('cids');
+			$pks = ArrayHelper::toInteger(explode(',', $this->input->post->getString('cids')));
+		}
+		else
+		{
+			$pks = array();
+		}
+		
 		// Get the logs data
 		$data = $this->getModel()->getLogsData($pks);
 

--- a/administrator/components/com_actionlogs/views/actionlogs/tmpl/default.php
+++ b/administrator/components/com_actionlogs/views/actionlogs/tmpl/default.php
@@ -26,9 +26,7 @@ JFactory::getDocument()->addScriptDeclaration('
 		if (task == "actionlogs.exportLogs")
 		{
 			Joomla.submitform(task, document.getElementById("exportForm"));
-
-			document.exportForm.cids.value = "";
-
+			
 			return;
 		}
 

--- a/administrator/components/com_actionlogs/views/actionlogs/tmpl/default.php
+++ b/administrator/components/com_actionlogs/views/actionlogs/tmpl/default.php
@@ -19,6 +19,37 @@ JHtml::_('formbehavior.chosen', 'select');
 
 $listOrder  = $this->escape($this->state->get('list.ordering'));
 $listDirn   = $this->escape($this->state->get('list.direction'));
+
+JFactory::getDocument()->addScriptDeclaration('
+	Joomla.submitbutton = function(task)
+	{
+		if (task == "actionlogs.exportLogs")
+		{
+			Joomla.submitform(task, document.getElementById("exportForm"));
+			
+			document.exportForm.cids.value = "";
+			
+			return;
+		}
+		
+		if (task == "actionlogs.exportSelectedLogs")
+		{
+			// Get id of selected action logs item and pass it to export form hidden input
+			var cids = [];
+			
+			jQuery("input[name=\'cid[]\']:checked").each(function() {
+					cids.push(jQuery(this).val());
+			});
+			
+			document.exportForm.cids.value = cids.join(",");
+			Joomla.submitform(task, document.getElementById("exportForm"));
+			
+			return;
+		}
+		
+		Joomla.submitform(task);
+	};
+');
 ?>
 <form action="<?php echo JRoute::_('index.php?option=com_actionlogs&view=actionlogs'); ?>" method="post" name="adminForm" id="adminForm">
 	<div id="j-main-container">
@@ -100,4 +131,9 @@ $listDirn   = $this->escape($this->state->get('list.direction'));
 		<input type="hidden" name="boxchecked" value="0" />
 		<?php echo JHtml::_('form.token'); ?>
 	</div>
+</form>
+<form action="<?php echo JRoute::_('index.php?option=com_actionlogs&view=actionlogs'); ?>" method="post" name="exportForm" id="exportForm">
+    <input type="hidden" name="task" value="" />
+    <input type="hidden" name="cids" value="" />
+	<?php echo JHtml::_('form.token'); ?>
 </form>

--- a/administrator/components/com_actionlogs/views/actionlogs/tmpl/default.php
+++ b/administrator/components/com_actionlogs/views/actionlogs/tmpl/default.php
@@ -26,27 +26,27 @@ JFactory::getDocument()->addScriptDeclaration('
 		if (task == "actionlogs.exportLogs")
 		{
 			Joomla.submitform(task, document.getElementById("exportForm"));
-			
+
 			document.exportForm.cids.value = "";
-			
+
 			return;
 		}
-		
+
 		if (task == "actionlogs.exportSelectedLogs")
 		{
 			// Get id of selected action logs item and pass it to export form hidden input
 			var cids = [];
-			
+
 			jQuery("input[name=\'cid[]\']:checked").each(function() {
 					cids.push(jQuery(this).val());
 			});
-			
+
 			document.exportForm.cids.value = cids.join(",");
 			Joomla.submitform(task, document.getElementById("exportForm"));
-			
+
 			return;
 		}
-		
+
 		Joomla.submitform(task);
 	};
 ');
@@ -133,7 +133,7 @@ JFactory::getDocument()->addScriptDeclaration('
 	</div>
 </form>
 <form action="<?php echo JRoute::_('index.php?option=com_actionlogs&view=actionlogs'); ?>" method="post" name="exportForm" id="exportForm">
-    <input type="hidden" name="task" value="" />
-    <input type="hidden" name="cids" value="" />
+	<input type="hidden" name="task" value="" />
+	<input type="hidden" name="cids" value="" />
 	<?php echo JHtml::_('form.token'); ?>
 </form>


### PR DESCRIPTION
Pull Request for Issue #22095 .

### Summary of Changes
This PR fixes issue Export of User Actions Log keeps popping up after export error as described in https://github.com/joomla/joomla-cms/issues/22095 .

### Testing Instructions
1. Log in to administrator area of your site
2. Access to Users -> User Actions Log
3. Press one of the two export buttons to export actions log
4. Before patch: If you try to press Search or Clear button , the system keep exporting user actions log.
5. After path: It won't export actions log anymore (Perform correct action search or clear as expected)

### Documentation Changes Required
None