### PR TITLE
[com_modules] Wrong module selected after Save & New

### DIFF
--- a/administrator/components/com_modules/models/module.php
+++ b/administrator/components/com_modules/models/module.php
@@ -1059,7 +1059,8 @@ class ModulesModelModule extends JModelAdmin
 			->select('extension_id')
 			->from('#__extensions AS e')
 			->join('LEFT', '#__modules AS m ON e.element = m.module')
-			->where('m.id = ' . (int) $table->id);
+			->where('m.id = ' . (int) $table->id)
+			->where('e.client_id = ' . (int) $table->client_id);
 		$db->setQuery($query);
 
 		try

--- a/administrator/components/com_modules/models/module.php
+++ b/administrator/components/com_modules/models/module.php
@@ -1056,10 +1056,14 @@ class ModulesModelModule extends JModelAdmin
 
 		// Compute the extension id of this module in case the controller wants it.
 		$query->clear()
-			->select('extension_id')
-			->from('#__extensions AS e')
-			->join('LEFT', '#__modules AS m ON e.client_id = ' . (int) $table->client_id . ' AND e.element = m.module')
-			->where('m.id = ' . (int) $table->id);
+			->select($db->quoteName('extension_id'))
+			->from($db->quoteName('#__extensions', 'e'))
+			->join(
+				'LEFT',
+				$db->quoteName('#__modules', 'm') . ' ON ' . $db->quoteName('e.client_id') . ' = ' . (int) $table->client_id .
+				' AND ' . $db->quoteName('e.element') . ' = ' . $db->quoteName('m.module')
+			)
+			->where($db->quoteName('m.id') . ' = ' . (int) $table->id);
 		$db->setQuery($query);
 
 		try

--- a/administrator/components/com_modules/models/module.php
+++ b/administrator/components/com_modules/models/module.php
@@ -1058,9 +1058,8 @@ class ModulesModelModule extends JModelAdmin
 		$query->clear()
 			->select('extension_id')
 			->from('#__extensions AS e')
-			->join('LEFT', '#__modules AS m ON e.element = m.module')
-			->where('m.id = ' . (int) $table->id)
-			->where('e.client_id = ' . (int) $table->client_id);
+			->join('LEFT', '#__modules AS m ON e.client_id = ' . (int) $table->client_id . ' AND e.element = m.module')
+			->where('m.id = ' . (int) $table->id);
 		$db->setQuery($query);
 
 		try


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This fixes the issue of site version of a module being created when using `Save & New` in administrator module form.

### Testing Instructions

Go to module list.
Filter by `Administrator` client.
Create and save `mod_login`, `mod_custom` or `mod_feed` module for administrator.
Click `Save & New`

### Expected result

New form opens with the same type of administrator module selected.

### Actual result

New form opens with site version of the module selected.

### Documentation Changes Required
No.
