### PR TITLE
[4.0] Detect debug etc

### DIFF
--- a/administrator/components/com_cache/tmpl/cache/default.php
+++ b/administrator/components/com_cache/tmpl/cache/default.php
@@ -16,7 +16,7 @@ use Joomla\CMS\HTML\HTMLHelper;
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
 
-HTMLHelper::_('script', 'com_cache/admin-cache-default.js', ['relative' => true, 'version' => 'auto']);
+HTMLHelper::_('script', 'com_cache/admin-cache-default.js', ['version' => 'auto', 'relative' => true]);
 ?>
 <form action="<?php echo Route::_('index.php?option=com_cache'); ?>" method="post" name="adminForm" id="adminForm">
 	<div class="row">

--- a/administrator/components/com_config/tmpl/component/default.php
+++ b/administrator/components/com_config/tmpl/component/default.php
@@ -30,7 +30,7 @@ HTMLHelper::_('behavior.tabstate');
 HTMLHelper::_('formbehavior.chosen', '.chzn-custom-value', null, array('disable_search_threshold' => 0));
 
 // @TODO delete this when custom elements modal is merged
-HTMLHelper::_('script', 'com_config/admin-application-default.min.js', ['relative' => true, 'version' => 'auto']);
+HTMLHelper::_('script', 'com_config/admin-application-default.min.js', ['version' => 'auto', 'relative' => true]);
 ?>
 
 <form action="<?php echo Route::_('index.php?option=com_config'); ?>" id="component-form" method="post" class="form-validate" name="adminForm" autocomplete="off" data-cancel-task="config.cancel.component">

--- a/administrator/components/com_content/tmpl/articles/default_batch_footer.php
+++ b/administrator/components/com_content/tmpl/articles/default_batch_footer.php
@@ -12,7 +12,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\HTML\HTMLHelper;
 
-HTMLHelper::_('script', 'com_content/admin-articles-default-batch-footer.js', ['relative' => true, 'version' => 'auto']);
+HTMLHelper::_('script', 'com_content/admin-articles-default-batch-footer.js', ['version' => 'auto', 'relative' => true]);
 ?>
 <a class="btn btn-secondary" type="button" data-dismiss="modal">
 	<?php echo Text::_('JCANCEL'); ?>

--- a/administrator/components/com_fields/tmpl/field/edit.php
+++ b/administrator/components/com_fields/tmpl/field/edit.php
@@ -27,7 +27,7 @@ $input = $app->input;
 
 $this->useCoreUI = true;
 
-HTMLHelper::_('script', 'com_fields/admin-field-edit.js', ['relative' => true, 'version' => 'auto']);
+HTMLHelper::_('script', 'com_fields/admin-field-edit.js', ['version' => 'auto', 'relative' => true]);
 ?>
 
 <form action="<?php echo Route::_('index.php?option=com_fields&context=' . $input->getCmd('context', 'com_content') . '&layout=edit&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="item-form" class="form-validate">

--- a/administrator/components/com_fields/tmpl/fields/default_batch_body.php
+++ b/administrator/components/com_fields/tmpl/fields/default_batch_body.php
@@ -14,7 +14,7 @@ use Joomla\CMS\Layout\LayoutHelper;
 
 HTMLHelper::_('formbehavior.chosen', '.advancedSelect');
 
-HTMLHelper::_('script', 'com_fields/admin-fields-default-batch.js', ['relative' => true, 'version' => 'auto']);
+HTMLHelper::_('script', 'com_fields/admin-fields-default-batch.js', ['version' => 'auto', 'relative' => true]);
 
 $context   = $this->escape($this->state->get('filter.context'));
 ?>

--- a/administrator/components/com_finder/tmpl/filters/default.php
+++ b/administrator/components/com_finder/tmpl/filters/default.php
@@ -17,7 +17,7 @@ $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
 
 JText::script('COM_FINDER_INDEX_CONFIRM_DELETE_PROMPT');
-HTMLHelper::_('script', 'com_finder/filters.js', ['relative' => true, 'version' => 'auto']);
+HTMLHelper::_('script', 'com_finder/filters.js', ['version' => 'auto', 'relative' => true]);
 ?>
 <form action="<?php echo JRoute::_('index.php?option=com_finder&view=filters'); ?>" method="post" name="adminForm" id="adminForm">
 	<div class="row">

--- a/administrator/components/com_finder/tmpl/index/default.php
+++ b/administrator/components/com_finder/tmpl/index/default.php
@@ -20,7 +20,7 @@ $lang      = JFactory::getLanguage();
 
 JText::script('COM_FINDER_INDEX_CONFIRM_PURGE_PROMPT');
 JText::script('COM_FINDER_INDEX_CONFIRM_DELETE_PROMPT');
-HTMLHelper::_('script', 'com_finder/index.js', ['relative' => true, 'version' => 'auto']);
+HTMLHelper::_('script', 'com_finder/index.js', ['version' => 'auto', 'relative' => true]);
 ?>
 <form action="<?php echo JRoute::_('index.php?option=com_finder&view=index'); ?>" method="post" name="adminForm" id="adminForm">
 	<div class="row">

--- a/administrator/components/com_finder/tmpl/maps/default.php
+++ b/administrator/components/com_finder/tmpl/maps/default.php
@@ -17,7 +17,7 @@ $listDirn      = $this->escape($this->state->get('list.direction'));
 $lang          = JFactory::getLanguage();
 $branchFilter  = $this->escape($this->state->get('filter.branch'));
 JText::script('COM_FINDER_MAPS_CONFIRM_DELETE_PROMPT');
-HTMLHelper::_('script', 'com_finder/maps.js', ['relative' => true, 'version' => 'auto']);
+HTMLHelper::_('script', 'com_finder/maps.js', ['version' => 'auto', 'relative' => true]);
 ?>
 <form action="<?php echo JRoute::_('index.php?option=com_finder&view=maps'); ?>" method="post" name="adminForm" id="adminForm">
 	<div class="row">

--- a/administrator/components/com_joomlaupdate/tmpl/update/default.php
+++ b/administrator/components/com_joomlaupdate/tmpl/update/default.php
@@ -26,7 +26,7 @@ $filesize = Factory::getApplication()->getUserState('com_joomlaupdate.filesize',
 $ajaxUrl = Uri::base() . 'components/com_joomlaupdate/restore.php';
 $returnUrl = 'index.php?option=com_joomlaupdate&task=update.finalise&' . Factory::getSession()->getFormToken() . '=1';
 
-HTMLHelper::_('script', 'com_joomlaupdate/admin-update-default.js', ['relative' => true, 'version' => 'auto']);
+HTMLHelper::_('script', 'com_joomlaupdate/admin-update-default.js', ['version' => 'auto', 'relative' => true]);
 
 Factory::getDocument()->addScriptOptions(
 	'joomlaupdate',

--- a/administrator/components/com_languages/tmpl/language/edit.php
+++ b/administrator/components/com_languages/tmpl/language/edit.php
@@ -19,7 +19,7 @@ HTMLHelper::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 HTMLHelper::_('behavior.formvalidator');
 HTMLHelper::_('behavior.tabstate');
 
-HTMLHelper::_('script', 'com_languages/admin-language-edit-change-flag.js', ['relative' => true, 'version' => 'auto']);
+HTMLHelper::_('script', 'com_languages/admin-language-edit-change-flag.js', ['version' => 'auto', 'relative' => true]);
 ?>
 
 <form action="<?php echo Route::_('index.php?option=com_languages&view=language&layout=edit&lang_id=' . (int) $this->item->lang_id); ?>" method="post" name="adminForm" id="language-form" class="form-validate">

--- a/administrator/components/com_languages/tmpl/override/edit.php
+++ b/administrator/components/com_languages/tmpl/override/edit.php
@@ -26,7 +26,7 @@ HTMLHelper::_('stylesheet', 'com_languages/overrider.css', array('version' => 'a
 HTMLHelper::_('behavior.core');
 HTMLHelper::_('jquery.framework');
 HTMLHelper::_('script', 'com_languages/overrider.min.js', array('version' => 'auto', 'relative' => true));
-HTMLHelper::_('script', 'com_languages/admin-override-edit-refresh-searchstring.js', ['relative' => true, 'version' => 'auto']);
+HTMLHelper::_('script', 'com_languages/admin-override-edit-refresh-searchstring.js', ['version' => 'auto', 'relative' => true]);
 ?>
 
 <form action="<?php echo Route::_('index.php?option=com_languages&id=' . $this->item->key); ?>" method="post" name="adminForm" id="override-form" class="form-validate">

--- a/administrator/components/com_menus/tmpl/items/default_batch_body.php
+++ b/administrator/components/com_menus/tmpl/items/default_batch_body.php
@@ -20,7 +20,7 @@ $published = $this->state->get('filter.published');
 $clientId  = $this->state->get('filter.client_id');
 $menuType  = Factory::getApplication()->getUserState('com_menus.items.menutype');
 if ($clientId == 1) :
-	HTMLHelper::_('script', 'com_menus/default-batch-body.min.js', ['relative' => true, 'version' => 'auto']);
+	HTMLHelper::_('script', 'com_menus/default-batch-body.min.js', ['version' => 'auto', 'relative' => true]);
 endif;
 
 ?>

--- a/components/com_config/tmpl/config/default.php
+++ b/components/com_config/tmpl/config/default.php
@@ -15,7 +15,7 @@ use Joomla\CMS\Language\Text;
 
 // Load tooltips behavior
 HTMLHelper::_('behavior.formvalidator');
-HTMLHelper::_('script', 'com_config/config-default.js', ['relative' => true, 'version' => 'auto']);
+HTMLHelper::_('script', 'com_config/config-default.js', ['version' => 'auto', 'relative' => true]);
 ?>
 
 <form action="<?php echo Route::_('index.php?option=com_config'); ?>" id="application-form" method="post" name="adminForm" class="form-validate"  data-cancel-task="config.cancel.component">

--- a/components/com_config/tmpl/modules/default.php
+++ b/components/com_config/tmpl/modules/default.php
@@ -19,7 +19,7 @@ HTMLHelper::_('behavior.formvalidator');
 HTMLHelper::_('behavior.keepalive');
 HTMLHelper::_('behavior.combobox');
 
-HTMLHelper::_('script', 'com_config/modules-default.js', ['relative' => true, 'version' => 'auto']);
+HTMLHelper::_('script', 'com_config/modules-default.js', ['version' => 'auto', 'relative' => true]);
 
 $hasContent = empty($this->item['module']) || $this->item['module'] === 'custom' || $this->item['module'] === 'mod_custom';
 

--- a/components/com_config/tmpl/templates/default.php
+++ b/components/com_config/tmpl/templates/default.php
@@ -18,7 +18,7 @@ HTMLHelper::_('behavior.formvalidator');
 HTMLHelper::_('behavior.keepalive');
 $user = Factory::getUser();
 
-HTMLHelper::_('script', 'com_config/templates-default.js', ['relative' => true, 'version' => 'auto']);
+HTMLHelper::_('script', 'com_config/templates-default.js', ['version' => 'auto', 'relative' => true]);
 ?>
 
 <form action="<?php echo Route::_('index.php?option=com_config'); ?>" method="post" name="adminForm" id="templates-form" class="form-validate"  data-cancel-task="config.cancel.templates">

--- a/components/com_contact/tmpl/categories/default.php
+++ b/components/com_contact/tmpl/categories/default.php
@@ -20,7 +20,7 @@ HTMLHelper::_('behavior.core');
 Text::script('JGLOBAL_EXPAND_CATEGORIES');
 Text::script('JGLOBAL_COLLAPSE_CATEGORIES');
 
-HTMLHelper::_('script', 'com_contact/categories-default.js', ['relative' => true, 'version' => 'auto']);
+HTMLHelper::_('script', 'com_contact/categories-default.js', ['version' => 'auto', 'relative' => true]);
 
 ?>
 <div class="com-contact-categories categories-list">

--- a/components/com_content/tmpl/form/edit.php
+++ b/components/com_content/tmpl/form/edit.php
@@ -20,7 +20,7 @@ HTMLHelper::_('behavior.keepalive');
 HTMLHelper::_('behavior.formvalidator');
 HTMLHelper::_('formbehavior.chosen', '#jform_catid', null, array('disable_search_threshold' => 0));
 
-HTMLHelper::_('script', 'com_content/form-edit.js', ['relative' => true, 'version' => 'auto']);
+HTMLHelper::_('script', 'com_content/form-edit.js', ['version' => 'auto', 'relative' => true]);
 
 $this->tab_name = 'com-content-form';
 $this->ignore_fieldsets = array('image-intro', 'image-full', 'jmetadata', 'item_associations');

--- a/components/com_mailto/tmpl/mailto/default.php
+++ b/components/com_mailto/tmpl/mailto/default.php
@@ -18,7 +18,7 @@ HTMLHelper::_('behavior.keepalive');
 
 Text::script('COM_MAILTO_EMAIL_ERR_NOINFO', true);
 
-HTMLHelper::_('script', 'com_mailto/mailto-default.js', ['relative' => true, 'version' => 'auto']);
+HTMLHelper::_('script', 'com_mailto/mailto-default.js', ['version' => 'auto', 'relative' => true]);
 
 $data = $this->get('data');
 ?>

--- a/components/com_newsfeeds/tmpl/categories/default.php
+++ b/components/com_newsfeeds/tmpl/categories/default.php
@@ -20,7 +20,7 @@ HTMLHelper::_('behavior.core');
 Text::script('JGLOBAL_EXPAND_CATEGORIES');
 Text::script('JGLOBAL_COLLAPSE_CATEGORIES');
 
-HTMLHelper::_('script', 'com_newsfeeds/categories-default.js', ['relative' => true, 'version' => 'auto']);
+HTMLHelper::_('script', 'com_newsfeeds/categories-default.js', ['version' => 'auto', 'relative' => true]);
 
 ?>
 <div class="com-newsfeeds-categories categories-list">

--- a/components/com_tags/tmpl/tag/default_items.php
+++ b/components/com_tags/tmpl/tag/default_items.php
@@ -19,7 +19,7 @@ HTMLHelper::addIncludePath(JPATH_COMPONENT . '/helpers');
 
 HTMLHelper::_('behavior.core');
 
-HTMLHelper::_('script', 'com_tags/tag-default.js', ['relative' => true, 'version' => 'auto']);
+HTMLHelper::_('script', 'com_tags/tag-default.js', ['version' => 'auto', 'relative' => true]);
 
 // Get the user object.
 $user = Factory::getUser();

--- a/components/com_tags/tmpl/tag/list_items.php
+++ b/components/com_tags/tmpl/tag/list_items.php
@@ -16,7 +16,7 @@ use Joomla\CMS\Language\Text;
 
 HTMLHelper::_('behavior.core');
 
-HTMLHelper::_('script', 'com_tags/tag-list.js', ['relative' => true, 'version' => 'auto']);
+HTMLHelper::_('script', 'com_tags/tag-list.js', ['version' => 'auto', 'relative' => true]);
 
 $n         = count($this->items);
 $listOrder = $this->escape($this->state->get('list.ordering'));

--- a/components/com_tags/tmpl/tags/default_items.php
+++ b/components/com_tags/tmpl/tags/default_items.php
@@ -19,7 +19,7 @@ HTMLHelper::addIncludePath(JPATH_COMPONENT . '/helpers');
 
 HTMLHelper::_('behavior.core');
 
-HTMLHelper::_('script', 'com_tags/tags-default.js', ['relative' => true, 'version' => 'auto']);
+HTMLHelper::_('script', 'com_tags/tags-default.js', ['version' => 'auto', 'relative' => true]);
 
 // Get the user object.
 $user = Factory::getUser();

--- a/layouts/joomla/form/field/media.php
+++ b/layouts/joomla/form/field/media.php
@@ -135,7 +135,7 @@ $url    = ($readonly ? ''
 		)
 	);
 
-	HTMLHelper::_('webcomponent', 'system/webcomponents/joomla-field-media.min.js', ['relative' => true, 'version' => 'auto', 'detectBrowser' => false, 'detectDebug' => true]);
+	HTMLHelper::_('webcomponent', 'system/webcomponents/joomla-field-media.min.js', ['version' => 'auto', 'relative' => true]);
 	Text::script('JLIB_FORM_MEDIA_PREVIEW_EMPTY', true);
 	?>
 	<?php if ($showPreview) : ?>

--- a/layouts/joomla/form/field/radio/switcher.php
+++ b/layouts/joomla/form/field/radio/switcher.php
@@ -60,7 +60,7 @@ $alt        = preg_replace('/[^a-zA-Z0-9_\-]/', '_', $name);
 
 HTMLHelper::_('webcomponent',
 	'system/webcomponents/joomla-field-switcher.min.js',
-	['relative' => true, 'version' => 'auto']
+	['version' => 'auto', 'relative' => true]
 );
 
 // Set the type of switcher

--- a/layouts/joomla/form/field/rules.php
+++ b/layouts/joomla/form/field/rules.php
@@ -56,7 +56,7 @@ $document = Factory::getDocument();
 // Add Javascript for permission change
 HTMLHelper::_('form.csrf');
 HTMLHelper::_('webcomponent', 'system/webcomponents/joomla-field-permissions.min.js', ['version' => 'auto', 'relative' => true]);
-HTMLHelper::_('webcomponent', 'vendor/joomla-custom-elements/joomla-tab.min.js', ['relative' => true, 'version' => 'auto']);
+HTMLHelper::_('webcomponent', 'vendor/joomla-custom-elements/joomla-tab.min.js', ['version' => 'auto', 'relative' => true]);
 
 // Load JavaScript message titles
 Text::script('ERROR');

--- a/layouts/joomla/form/field/subform/repeatable-table.php
+++ b/layouts/joomla/form/field/subform/repeatable-table.php
@@ -34,7 +34,7 @@ extract($displayData);
 // Add script
 if ($multiple)
 {
-	HTMLHelper::_('webcomponent', 'system/webcomponents/joomla-field-subform.min.js', ['relative' => true, 'version' => 'auto', 'detectBrowser' => false, 'detectDebug' => true]);
+	HTMLHelper::_('webcomponent', 'system/webcomponents/joomla-field-subform.min.js', ['version' => 'auto', 'relative' => true]);
 }
 
 // Build heading

--- a/layouts/joomla/form/field/subform/repeatable.php
+++ b/layouts/joomla/form/field/subform/repeatable.php
@@ -33,7 +33,7 @@ extract($displayData);
 // Add script
 if ($multiple)
 {
-	HTMLHelper::_('webcomponent', 'system/webcomponents/joomla-field-subform.min.js', ['relative' => true, 'version' => 'auto', 'detectBrowser' => false, 'detectDebug' => true]);
+	HTMLHelper::_('webcomponent', 'system/webcomponents/joomla-field-subform.min.js', ['version' => 'auto', 'relative' => true]);
 }
 $sublayout = empty($groupByFieldset) ? 'section' : 'section-byfieldsets';
 ?>

--- a/layouts/joomla/system/message.php
+++ b/layouts/joomla/system/message.php
@@ -28,7 +28,7 @@ $alert = [
 ];
 
 // Alerts progressive enhancement
-HTMLHelper::_('webcomponent', 'vendor/joomla-custom-elements/joomla-alert.min.js', ['relative' => true, 'version' => 'auto', 'detectBrowser' => false, 'detectDebug' => false]);
+HTMLHelper::_('webcomponent', 'vendor/joomla-custom-elements/joomla-alert.min.js', ['version' => 'auto', 'relative' => true]);
 ?>
 <div id="system-message-container">
 	<div id="system-message">

--- a/layouts/joomla/toolbar/popup.php
+++ b/layouts/joomla/toolbar/popup.php
@@ -13,7 +13,7 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\Utilities\ArrayHelper;
 
 HTMLHelper::_('behavior.core');
-HTMLHelper::_('webcomponent', 'system/webcomponents/joomla-toolbar-button.min.js', ['relative' => true, 'version' => 'auto', 'detectDebug' => true]);
+HTMLHelper::_('webcomponent', 'system/webcomponents/joomla-toolbar-button.min.js', ['version' => 'auto', 'relative' => true]);
 
 /**
  * @var  int     $id

--- a/layouts/joomla/toolbar/standard.php
+++ b/layouts/joomla/toolbar/standard.php
@@ -12,7 +12,7 @@ defined('JPATH_BASE') or die;
 use Joomla\CMS\HTML\HTMLHelper;
 
 HTMLHelper::_('behavior.core');
-HTMLHelper::_('webcomponent', 'system/webcomponents/joomla-toolbar-button.min.js', ['relative' => true, 'version' => 'auto', 'detectDebug' => true]);
+HTMLHelper::_('webcomponent', 'system/webcomponents/joomla-toolbar-button.min.js', ['version' => 'auto', 'relative' => true]);
 
 /**
  * @var  string  $id

--- a/libraries/cms/html/uitab.php
+++ b/libraries/cms/html/uitab.php
@@ -39,7 +39,7 @@ abstract class JHtmlUiTab
 		if (!isset(static::$loaded[__METHOD__][$sig]))
 		{
 			// Include the custom element
-			JHtml::_('webcomponent', 'vendor/joomla-custom-elements/joomla-tab.min.js', ['relative' => true, 'version' => 'auto']);
+			JHtml::_('webcomponent', 'vendor/joomla-custom-elements/joomla-tab.min.js', ['version' => 'auto', 'relative' => true]);
 
 			// Setup options object
 			$opt['active'] = (isset($params['active']) && ($params['active'])) ? (string) $params['active'] : '';

--- a/plugins/system/stats/layouts/field/data.php
+++ b/plugins/system/stats/layouts/field/data.php
@@ -12,7 +12,7 @@ defined('JPATH_BASE') or die;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
-HTMLHelper::_('script', 'plg_system_stats/stats.js', ['relative' => true, 'version' => 'auto']);
+HTMLHelper::_('script', 'plg_system_stats/stats.js', ['version' => 'auto', 'relative' => true]);
 
 extract($displayData);
 


### PR DESCRIPTION
Pull Request for Issue #21612 

After #21617 we now have sensible defaults.

This pr - 
- [x] removes any setting that was the default as its no longer needed
- [x] standardises the ordering to `['version' => 'auto', 'relative' => true]` 
- [x] fixes the joomla-alert js that incorrectly was set to always load the minimised version and ignore the debug setting
