### PR TITLE
Make com_actionlogs accessible for super admins only

### DIFF
--- a/administrator/components/com_actionlogs/actionlogs.php
+++ b/administrator/components/com_actionlogs/actionlogs.php
@@ -9,7 +9,7 @@
 
 defined('_JEXEC') or die;
 
-if (!JFactory::getUser()->authorise('core.manage', 'com_actionlogs'))
+if (!JFactory::getUser()->authorise('core.admin'))
 {
 	throw new JAccessExceptionNotallowed(JText::_('JERROR_ALERTNOAUTHOR'), 403);
 }


### PR DESCRIPTION
Pull Request for Issue #22153.

### Summary of Changes
This simple PR makes com_actionlogs accessible to super admin only.

### Testing Instructions
1. Login to administrator area of the site using an administrator account
2. Before patch, you can access to administrator/index.php?option=com_actionlogs by entering the URL on browser
3. After patch, you will receive 403 error
4. Login using super admin account and make sure you can access to User Actions Log (Users -> User Actions Log)
