### PR TITLE
Hide batch action button in toolbar for menu items when we cannot process them

### DIFF
--- a/administrator/components/com_menus/views/items/tmpl/default_batch_footer.php
+++ b/administrator/components/com_menus/views/items/tmpl/default_batch_footer.php
@@ -7,10 +7,14 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 defined('_JEXEC') or die;
+$published = $this->state->get('filter.published');
+$menuType  = JFactory::getApplication()->getUserState('com_menus.items.menutype');
 ?>
 <a class="btn" type="button" onclick="document.getElementById('batch-menu-id').value='';document.getElementById('batch-access').value='';document.getElementById('batch-language-id').value=''" data-dismiss="modal">
 	<?php echo JText::_('JCANCEL'); ?>
 </a>
-<button class="btn btn-success" type="submit" onclick="Joomla.submitbutton('item.batch');">
-	<?php echo JText::_('JGLOBAL_BATCH_PROCESS'); ?>
-</button>
+<?php if (strlen($menuType) && $menuType != '*' && $published != 2): ?>
+	<button class="btn btn-success" type="submit" onclick="Joomla.submitbutton('item.batch');">
+		<?php echo JText::_('JGLOBAL_BATCH_PROCESS'); ?>
+	</button>
+<?php endif; ?>

--- a/administrator/components/com_menus/views/items/tmpl/default_batch_footer.php
+++ b/administrator/components/com_menus/views/items/tmpl/default_batch_footer.php
@@ -7,15 +7,10 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 defined('_JEXEC') or die;
-$published = $this->state->get('filter.published');
-$clientId  = $this->state->get('filter.client_id');
-$menuType = JFactory::getApplication()->getUserState('com_menus.items.menutype');
 ?>
 <a class="btn" type="button" onclick="document.getElementById('batch-menu-id').value='';document.getElementById('batch-access').value='';document.getElementById('batch-language-id').value=''" data-dismiss="modal">
 	<?php echo JText::_('JCANCEL'); ?>
 </a>
-<?php if ((strlen($menuType) && $menuType != '*' && $clientId == 0) || ($published > 0 && $clientId == 1)): ?>
-	<button class="btn btn-success" type="submit" onclick="Joomla.submitbutton('item.batch');">
-		<?php echo JText::_('JGLOBAL_BATCH_PROCESS'); ?>
-	</button>
-<?php endif; ?>
+<button class="btn btn-success" type="submit" onclick="Joomla.submitbutton('item.batch');">
+	<?php echo JText::_('JGLOBAL_BATCH_PROCESS'); ?>
+</button>

--- a/administrator/components/com_menus/views/items/view.html.php
+++ b/administrator/components/com_menus/views/items/view.html.php
@@ -261,14 +261,13 @@ class MenusViewItems extends JViewLegacy
 	 */
 	protected function addToolbar()
 	{
-		$menuType      = $this->state->get('filter.menutype');
-		$menutypeId    = (int) $this->state->get('menutypeid');
-		$menuTypeTitle = $this->get('State')->get('menutypetitle');
-		$published     = $this->state->get('filter.published');
-		$protected     = $menuType == 'main';
+		$menutypeId = (int) $this->state->get('menutypeid');
 
 		$canDo = JHelperContent::getActions('com_menus', 'menu', (int) $menutypeId);
 		$user  = JFactory::getUser();
+
+		// Get the menu title
+		$menuTypeTitle = $this->get('State')->get('menutypetitle');
 
 		// Get the toolbar object instance
 		$bar = JToolbar::getInstance('toolbar');
@@ -286,6 +285,8 @@ class MenusViewItems extends JViewLegacy
 		{
 			JToolbarHelper::addNew('item.add');
 		}
+
+		$protected = $this->state->get('filter.menutype') == 'main';
 
 		if ($canDo->get('core.edit') && !$protected)
 		{
@@ -314,8 +315,7 @@ class MenusViewItems extends JViewLegacy
 		}
 
 		// Add a batch button
-		if ((!$protected && strlen($menuType) && $menuType != '*' && $published != - 2)
-			&& $user->authorise('core.create', 'com_menus')
+		if (!$protected && $user->authorise('core.create', 'com_menus')
 			&& $user->authorise('core.edit', 'com_menus')
 			&& $user->authorise('core.edit.state', 'com_menus'))
 		{
@@ -323,12 +323,12 @@ class MenusViewItems extends JViewLegacy
 
 			// Instantiate a new JLayoutFile instance and render the batch button
 			$layout = new JLayoutFile('joomla.toolbar.batch');
-			$dhtml  = $layout->render(array('title' => $title));
 
+			$dhtml = $layout->render(array('title' => $title));
 			$bar->appendButton('Custom', $dhtml, 'batch');
 		}
 
-		if (!$protected && $published == -2 && $canDo->get('core.delete'))
+		if (!$protected && $this->state->get('filter.published') == -2 && $canDo->get('core.delete'))
 		{
 			JToolbarHelper::deleteList('JGLOBAL_CONFIRM_DELETE', 'items.delete', 'JTOOLBAR_EMPTY_TRASH');
 		}

--- a/administrator/components/com_menus/views/items/view.html.php
+++ b/administrator/components/com_menus/views/items/view.html.php
@@ -261,13 +261,14 @@ class MenusViewItems extends JViewLegacy
 	 */
 	protected function addToolbar()
 	{
-		$menutypeId = (int) $this->state->get('menutypeid');
+		$menuType      = $this->state->get('filter.menutype');
+		$menutypeId    = (int) $this->state->get('menutypeid');
+		$menuTypeTitle = $this->get('State')->get('menutypetitle');
+		$published     = $this->state->get('filter.published');
+		$protected     = $menuType == 'main';
 
 		$canDo = JHelperContent::getActions('com_menus', 'menu', (int) $menutypeId);
 		$user  = JFactory::getUser();
-
-		// Get the menu title
-		$menuTypeTitle = $this->get('State')->get('menutypetitle');
 
 		// Get the toolbar object instance
 		$bar = JToolbar::getInstance('toolbar');
@@ -285,8 +286,6 @@ class MenusViewItems extends JViewLegacy
 		{
 			JToolbarHelper::addNew('item.add');
 		}
-
-		$protected = $this->state->get('filter.menutype') == 'main';
 
 		if ($canDo->get('core.edit') && !$protected)
 		{
@@ -315,20 +314,21 @@ class MenusViewItems extends JViewLegacy
 		}
 
 		// Add a batch button
-		if (!$protected && $user->authorise('core.create', 'com_menus')
-			&& $user->authorise('core.edit', 'com_menus')
-			&& $user->authorise('core.edit.state', 'com_menus'))
+		if ((!$protected && strlen($menuType) && $menuType != '*' && $published != - 2)
+		    && $user->authorise('core.create', 'com_menus')
+		    && $user->authorise('core.edit', 'com_menus')
+		    && $user->authorise('core.edit.state', 'com_menus'))
 		{
 			$title = JText::_('JTOOLBAR_BATCH');
 
 			// Instantiate a new JLayoutFile instance and render the batch button
 			$layout = new JLayoutFile('joomla.toolbar.batch');
+			$dhtml  = $layout->render(array('title' => $title));
 
-			$dhtml = $layout->render(array('title' => $title));
 			$bar->appendButton('Custom', $dhtml, 'batch');
 		}
 
-		if (!$protected && $this->state->get('filter.published') == -2 && $canDo->get('core.delete'))
+		if (!$protected && $published == -2 && $canDo->get('core.delete'))
 		{
 			JToolbarHelper::deleteList('JGLOBAL_CONFIRM_DELETE', 'items.delete', 'JTOOLBAR_EMPTY_TRASH');
 		}

--- a/administrator/components/com_menus/views/items/view.html.php
+++ b/administrator/components/com_menus/views/items/view.html.php
@@ -315,9 +315,9 @@ class MenusViewItems extends JViewLegacy
 
 		// Add a batch button
 		if ((!$protected && strlen($menuType) && $menuType != '*' && $published != - 2)
-		    && $user->authorise('core.create', 'com_menus')
-		    && $user->authorise('core.edit', 'com_menus')
-		    && $user->authorise('core.edit.state', 'com_menus'))
+			&& $user->authorise('core.create', 'com_menus')
+			&& $user->authorise('core.edit', 'com_menus')
+			&& $user->authorise('core.edit.state', 'com_menus'))
 		{
 			$title = JText::_('JTOOLBAR_BATCH');
 


### PR DESCRIPTION
Pull Request for Issue #22154, #19827

### Summary of Changes
Do not show Batch action in the toolbar if batch action is not possible.

### Testing Instructions
* Create an admin menu
* Create some menu items in this admin menu
* Trash some of these menu items
* Filter by menu type or published state or both

**Earlier** - Batch button is displayed in the toolbar but "Process" button is hidden when filtered by trash or menu type is not selected.

**After this patch** - The Batch button is only displayed when some menu type is selected and filtered by states other than trashed.


### Documentation Changes Required
NA
