### PR TITLE
[4.0] Reset workflow when changing the category

### DIFF
--- a/libraries/src/Workflow/Workflow.php
+++ b/libraries/src/Workflow/Workflow.php
@@ -228,6 +228,15 @@ class Workflow
 			$db    = Factory::getDbo();
 			$query = $db->getQuery(true);
 
+			// Avoid having more than one association
+			$query->delete($db->quoteName('#__workflow_associations'))
+					->where($db->quoteName('item_id') . ' = ' . (int) $pk)
+					->where($db->quoteName('extension') . ' = ' . $db->quote($this->extension));
+
+			$db->setQuery($query)->execute();
+
+			$query = $db->getQuery(true);
+
 			$query->insert($db->quoteName('#__workflow_associations'))
 				->columns($db->quoteName(array('item_id', 'stage_id', 'extension')))
 				->values((int) $pk . ', ' . (int) $state . ', ' . $db->quote($this->extension));


### PR DESCRIPTION
Pull Request for Issue #21973 .

### Summary of Changes
Resets the workflow, when the category is changed and a new workflow applied


### Testing Instructions
- Create 2 workflows and assign them to 2 different categories
- Create an article for category 1
- Execute transitions
- Change the category

- Do the same with the batch => move

### Expected result
if category is changed and they have different workflows the new workflow is assigned
