### PR TITLE
[4.0] Fix missed subform field

### DIFF
--- a/build/build-modules-js/settings.json
+++ b/build/build-modules-js/settings.json
@@ -13,6 +13,7 @@
       "field-permissions",
       "field-simple-color",
       "field-send-test-mail",
+      "field-subform",
       "editor-codemirror",
       "hidden-mail",
       "editor-none",
@@ -48,6 +49,10 @@
         "js": "media/system/webcomponents/js"
       },
       "field-hidden-mail": {
+        "css": "media/system/webcomponents/css",
+        "js": "media/system/webcomponents/js"
+      },
+      "field-subform": {
         "css": "media/system/webcomponents/css",
         "js": "media/system/webcomponents/js"
       }


### PR DESCRIPTION
Pull Request for Issue #22183

### Summary of Changes
I guess at some merge conflict the subform CE was acidently removed from `settings.json`
The patch fix it.


### Testing Instructions
Apply patch, run `npm install`

Add subform field somwhere, example to Custom Module
`/modules/mod_custom/mod_custom.xml`

```xml
<field type="subform" name="subform" label="Subform1" multiple="true">
  <form>
    <field type="text" name="text1" label="Text1"/>
      <field type="subform" name="subform_nested" label="Subform Nested" multiple="true"
			   default='[{"text_nested":"ueue"}]'>
        <form>
            <field type="text" name="text_nested" label="Text nested"/>
        </form>
    </field>
  </form>
</field>
```

Go to any Custom Module and try edit this field.



### Expected result
Field working


### Actual result
Field not working


### Documentation Changes Required
nope
