### PR TITLE
[4.0] Make Notification Dropdown viewable.

### DIFF
--- a/administrator/templates/atum/scss/blocks/_header.scss
+++ b/administrator/templates/atum/scss/blocks/_header.scss
@@ -57,6 +57,7 @@
     min-width: 280px;
     padding: 0;
     border: 0;
+    z-index: 1041;
 
     h2 {
       font-size: $h5-font-size;


### PR DESCRIPTION
Pull Request for Issue #22118  .

### Summary of Changes
Will cause notifications to be above the headers.


### Testing Instructions
go to extension manager click on notification bell in top right.
drop down will be obscured by header.
install patch
now drop down will be above the header


### Expected result

![after](https://user-images.githubusercontent.com/1850089/45565274-bfb77f80-b818-11e8-8d03-9ff0f392a53e.png)


### Actual result
![before](https://user-images.githubusercontent.com/1850089/45565279-c2b27000-b818-11e8-8e12-2a0b6f01eee8.png)



### Documentation Changes Required
none
