### PR TITLE
[3.9] Add php extension & Forbidden head to sql log files

### DIFF
--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -2060,7 +2060,7 @@ class PlgSystemDebug extends JPlugin
 			JFile::delete($file);
 		}
 
-		$head[] = '#';
+		$head   = ['#'];
 		$head[] = '#<?php die(\'Forbidden.\'); ?>';
 		$head[] = '#Date: ' . gmdate('Y-m-d H:i:s') . ' UTC';
 		$head[] = '#Software: ' . \JPlatform::getLongVersion();

--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -2037,7 +2037,7 @@ class PlgSystemDebug extends JPlugin
 		$app    = JFactory::getApplication();
 		$domain = $app->isClient('site') ? 'site' : 'admin';
 		$input  = $app->input;
-		$file   = $app->get('log_path') . '/' . $domain . '_' . $input->get('option') . $input->get('view') . $input->get('layout') . '.sql';
+		$file   = $app->get('log_path') . '/' . $domain . '_' . $input->get('option') . $input->get('view') . $input->get('layout') . '.sql.php';
 
 		// Get the queries from log.
 		$current = '';
@@ -2059,6 +2059,12 @@ class PlgSystemDebug extends JPlugin
 		{
 			JFile::delete($file);
 		}
+
+		$head[] = '#';
+		$head[] = '#<?php die(\'Forbidden.\'); ?>';
+		$head[] = '#Date: ' . gmdate('Y-m-d H:i:s') . ' UTC';
+		$head[] = '#Software: ' . \JPlatform::getLongVersion();
+		$head[] = "\n";
 
 		// Write new file.
 		JFile::write($file, $current);

--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -2067,6 +2067,6 @@ class PlgSystemDebug extends JPlugin
 		$head[] = "\n";
 
 		// Write new file.
-		JFile::write($file, $current);
+		JFile::write($file, implode("\n", $head) . $current);
 	}
 }

--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -2060,7 +2060,7 @@ class PlgSystemDebug extends JPlugin
 			JFile::delete($file);
 		}
 
-		$head   = ['#'];
+		$head   = array('#');
 		$head[] = '#<?php die(\'Forbidden.\'); ?>';
 		$head[] = '#Date: ' . gmdate('Y-m-d H:i:s') . ' UTC';
 		$head[] = '#Software: ' . \JPlatform::getLongVersion();


### PR DESCRIPTION
Related Issue/Discussion https://github.com/joomla/joomla-cms/issues/22137

### Summary of Changes
Harden sql log files in Joomla 3 like other log files.
Let plugin "System - Log Rotation" delete and versioning sql log files, too

Add php filename extension to sql log files (before: `*.sql`; after: `*.sql.php`)
Add `<?php die('Forbidden.'); ?>` to these files, too, to protect them.

### Testing Instructions
- Install current staging. (= Joomla 3.9)
- Have always a look on your logs directory to see what happens. And delete everything in it before you start.
- To have an eye on the file timestamps during testing could also help a bit.

- Activate plugin "System - Debug" with ALL options. Especially `Log Executed Queries` : `YES`.
- Activate `Debug (System)` in Global Configuration.
- Reload some pages.
- In your logs directory you'll find some files with filename extension `sql`
- Check that you can display them in your browser by just calling them via address bar.

- Then activate plugin "System - Log Rotation". And set option `Maximum Logs : 2`.
And `Log Rotation (in days) : 0`

- Reload some pages and every page 3 times or more often.
- In your logs directory you'll find files with a leading version number in filenames and one per group without. E.g. group
`1.deprecated.php`
`2.deprecated.php` 
`deprecated.php` (newest version)

**BUT only `php `files NOT `sql `files.** Because Log Rotator ignores them.

- Apply patch
- Clear your logs directory
- Test again.

### Expected but not actual result
- New plugin "System - Log Rotation" deletes sql log files, too.
- New plugin "System - Log Rotation" is versioning sql log files, too.
- No chance to simply display log files in browser.