### PR TITLE
[com_menus] Menu item type ordering

### DIFF
--- a/administrator/components/com_menus/views/menutypes/view.html.php
+++ b/administrator/components/com_menus/views/menutypes/view.html.php
@@ -50,11 +50,11 @@ class MenusViewMenutypes extends JViewLegacy
 				$tmp[JText::_($item->title)] = $item;
 			}
 
-			ksort($tmp);
+			uksort($tmp, 'strcasecmp');
 			$sortedTypes[JText::_($name)] = $tmp;
 		}
 
-		ksort($sortedTypes);
+		uksort($sortedTypes, 'strcasecmp');
 
 		$this->types = $sortedTypes;
 


### PR DESCRIPTION
Pull Request for Issue #22182 .

### Summary of Changes

This fixes menu item type ordering for items starting with lowercase.

### Testing Instructions

Create administrator language override for component name. Change it to start with lowercase, e.g. `COM_CONTACTS`="contact".
Create a menu item and choose a menu item type. See ordering of menu item types.

### Expected result

Items sorted alphabetically.

### Actual result

`contact` sorted at the bottom.

### Documentation Changes Required

No.