### PR TITLE
[plg_user_terms] - Terms & Conditions consent field is set to required

### DIFF
--- a/plugins/user/terms/terms/terms.xml
+++ b/plugins/user/terms/terms/terms.xml
@@ -12,6 +12,7 @@
 				description="PLG_USER_TERMS_FIELD_DESC"
 				default="0"
 				filter="integer"
+				required="true"
 				>
 				<option value="1">PLG_USER_TERMS_OPTION_AGREE</option>
 				<option value="0">JNO</option>


### PR DESCRIPTION
### Summary of Changes
Make sure the Terms & Conditions consent field is set to required (if required cannot be optional)


### Testing Instructions


- Make sure user registration is enabled
- Go to plugins
- Filter on terms
- Enable the plugin - User - Terms and Conditions
- Go to the front-end and click on Create an account
- Scroll down and see the Terms & Conditions  has (optional) 


### Expected result

![screenshot from 2018-09-15 12-01-26](https://user-images.githubusercontent.com/181681/45585102-1be4d700-b8df-11e8-9002-7b54c3edb8a3.png)


### Actual result

![screenshot from 2018-09-15 12-00-44](https://user-images.githubusercontent.com/181681/45585095-053e8000-b8df-11e8-8285-15c7db57487e.png)


### Documentation Changes Required

