### PR TITLE
Correct length of column "subject" of table "#__privacy_consents" in mysql/3.9.0-2018-05-24.sql

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/3.9.0-2018-05-24.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.9.0-2018-05-24.sql
@@ -5,7 +5,7 @@ CREATE TABLE IF NOT EXISTS `#__privacy_consents` (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `user_id` int(10) unsigned NOT NULL DEFAULT '0',
   `created` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
-  `subject` varchar(25) NOT NULL DEFAULT '',
+  `subject` varchar(255) NOT NULL DEFAULT '',
   `body` text NOT NULL,
   `remind` tinyint(4) NOT NULL DEFAULT '0',
   `token` varchar(100) NOT NULL DEFAULT '',


### PR DESCRIPTION
Pull Request for new issue.

### Summary of Changes

Correct length of column "subject" of table "#__privacy_consents" in schema update for mysql

### Testing Instructions

Code review: Check length of column "subject" of table "#__privacy_consents" in files "installation/joomla.sql" and in schema updates "3.9.0-2018-05-24.sql", all for all database types. Check there is no other schema update later beside "3.9.0-2018-05-24.sql" which handles that database column.

Or real life test: Using MySQL database, install a new 3.9-beta2-dev (nightly build from today) on one site, install a 3.8.12 on another site and then update that site to nightly build from today. Then export both databases in sql and compare the sql files regarding table structures.

### Expected result

Code review: Column "subject" of table "#__privacy_consents" has the same length in all sql files.

Real life test: Column "subject" of table "#__privacy_consents" has the same length on both sites.

### Actual result

Code review: Column "subject" of table "#__privacy_consents" has in all sql files a lenght of 255 except in schema update "mysql/3.9.0-2018-05-24.sql", where it has a lenght of 25.

See here:
[https://github.com/joomla/joomla-cms/blob/staging/installation/sql/mysql/joomla.sql#L1704](https://github.com/joomla/joomla-cms/blob/staging/installation/sql/mysql/joomla.sql#L1704 "https://github.com/joomla/joomla-cms/blob/staging/installation/sql/mysql/joomla.sql#L1704")

[https://github.com/joomla/joomla-cms/blob/staging/installation/sql/postgresql/joomla.sql#L1688](https://github.com/joomla/joomla-cms/blob/staging/installation/sql/postgresql/joomla.sql#L1688 "https://github.com/joomla/joomla-cms/blob/staging/installation/sql/postgresql/joomla.sql#L1688")

[https://github.com/joomla/joomla-cms/blob/staging/installation/sql/sqlazure/joomla.sql#L2408](https://github.com/joomla/joomla-cms/blob/staging/installation/sql/sqlazure/joomla.sql#L2408 "https://github.com/joomla/joomla-cms/blob/staging/installation/sql/sqlazure/joomla.sql#L2408")

[https://github.com/joomla/joomla-cms/blob/staging/administrator/components/com_admin/sql/updates/mysql/3.9.0-2018-05-24.sql#L8](https://github.com/joomla/joomla-cms/blob/staging/administrator/components/com_admin/sql/updates/mysql/3.9.0-2018-05-24.sql#L8 "https://github.com/joomla/joomla-cms/blob/staging/administrator/components/com_admin/sql/updates/mysql/3.9.0-2018-05-24.sql#L8")

[https://github.com/joomla/joomla-cms/blob/staging/administrator/components/com_admin/sql/updates/postgresql/3.9.0-2018-05-24.sql#L12](https://github.com/joomla/joomla-cms/blob/staging/administrator/components/com_admin/sql/updates/postgresql/3.9.0-2018-05-24.sql#L12 "https://github.com/joomla/joomla-cms/blob/staging/administrator/components/com_admin/sql/updates/postgresql/3.9.0-2018-05-24.sql#L12")

[https://github.com/joomla/joomla-cms/blob/staging/administrator/components/com_admin/sql/updates/sqlazure/3.9.0-2018-05-24.sql#L16](https://github.com/joomla/joomla-cms/blob/staging/administrator/components/com_admin/sql/updates/sqlazure/3.9.0-2018-05-24.sql#L16 "https://github.com/joomla/joomla-cms/blob/staging/administrator/components/com_admin/sql/updates/sqlazure/3.9.0-2018-05-24.sql#L16")

Real life test: On the new installation, column "subject" of table "#__privacy_consents" has a length of 255, on the updated site it has a length of 25.

### Documentation Changes Required

None.