### PR TITLE
[mysql] Correct position of column "state" in table "#__privacy_consents" in file "3.9.0-2018-08-12.sql"

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/3.9.0-2018-08-12.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.9.0-2018-08-12.sql
@@ -1,1 +1,1 @@
-ALTER TABLE `#__privacy_consents` ADD COLUMN `state` INT(10) NOT NULL DEFAULT '1';
+ALTER TABLE `#__privacy_consents` ADD COLUMN `state` INT(10) NOT NULL DEFAULT '1' AFTER `user_id`;


### PR DESCRIPTION
Pull Request for new issue.

### Summary of Changes

Add new column `state` to table `#__privacy_consents` at the same place as with a new installation in schema update **for mysql**.

### Testing Instructions

Code review: Check the position of column `state` in the `CREATE TABLE` statement for table `#__privacy_consents` in the installation sql **for mysql**. Check that the changes of this PR correct the schema update so it adds the column at the same place.

See here:

[https://github.com/joomla/joomla-cms/blob/staging/installation/sql/mysql/joomla.sql#L1702](https://github.com/joomla/joomla-cms/blob/staging/installation/sql/mysql/joomla.sql#L1702).

Verify also that there are already schema updates **for mysql** which use the "AFTER" clause when adding new columns, e.g. 2.5.0-2011-12-06.sql, 2.5.0-2012-01-10.sql, ..., 3.8.0-2017-07-28.sql, so you can see this PR adds nothing new regarding that.

Or real life test: **Using MySQL database**, install a new 3.9-beta2-dev (nightly build from today) on one site, install a 3.8.12 on another site and then update that site to nightly build from today. Then export both databases in sql and compare the sql files regarding table structures.

### Expected result

Code review: Column `state` of table `#__privacy_consents` will be added at the right place by the schema update with this PR.

Real life test: Column `state` of table `#__privacy_consents` is at the same place on both sites.

### Actual result

On a new installation, the column `state` of table `#__privacy_consents` comes after column `user_id`, while on an updated 3.8.12 it comes at the end of the table.

### Documentation Changes Required

None.