### PR TITLE
Fix display of Associations toolbar when editing a custom  admin menu item

### DIFF
--- a/administrator/components/com_menus/views/item/view.html.php
+++ b/administrator/components/com_menus/views/item/view.html.php
@@ -140,7 +140,7 @@ class MenusViewItem extends JViewLegacy
 			JToolbarHelper::save2copy('item.save2copy');
 		}
 
-		if (!$isNew && JLanguageAssociations::isEnabled() && JComponentHelper::isEnabled('com_associations'))
+		if (!$isNew && JLanguageAssociations::isEnabled() && JComponentHelper::isEnabled('com_associations') && $clientId != 1)
 		{
 			JToolbarHelper::custom('item.editAssociations', 'contract', 'contract', 'JTOOLBAR_ASSOCIATIONS', false, false);
 		}

--- a/administrator/components/com_menus/views/item/view.html.php
+++ b/administrator/components/com_menus/views/item/view.html.php
@@ -107,6 +107,7 @@ class MenusViewItem extends JViewLegacy
 		$isNew      = ($this->item->id == 0);
 		$checkedOut = !($this->item->checked_out == 0 || $this->item->checked_out == $user->get('id'));
 		$canDo      = $this->canDo;
+		$clientId   = $this->state->get('item.client_id', 0);
 
 		JToolbarHelper::title(JText::_($isNew ? 'COM_MENUS_VIEW_NEW_ITEM_TITLE' : 'COM_MENUS_VIEW_EDIT_ITEM_TITLE'), 'list menu-add');
 


### PR DESCRIPTION
Redo of https://github.com/joomla/joomla-cms/pull/22175 as there was a mix in branches.

### Summary of Changes
Display the Associations toolbar only for site menu items


### Testing Instructions
Create a custom admin menu
Create an admin menu item in this menu.
The toolbar "Associations" displays.
It should not.
This was forgotten in my PR https://github.com/joomla/joomla-cms/pull/21022


### Before patch
<img width="1127" alt="screen shot 2018-09-13 at 17 45 00" src="https://user-images.githubusercontent.com/869724/45499476-cdb7c280-b77c-11e8-96e4-53025b6df5f1.png">

### After patch
<img width="1132" alt="screen shot 2018-09-13 at 17 44 11" src="https://user-images.githubusercontent.com/869724/45499501-d7412a80-b77c-11e8-957d-4cc7a735a30f.png">

can be merged on review as it is quite obvious.

