### PR TITLE
[4.0] configuration options

### DIFF
--- a/administrator/components/com_config/tmpl/component/default.php
+++ b/administrator/components/com_config/tmpl/component/default.php
@@ -72,24 +72,7 @@ HTMLHelper::_('script', 'com_config/admin-application-default.min.js', ['version
 								$dataShowOn = '';
 								$groupClass = $field->type === 'Spacer' ? ' field-spacer' : '';
 							?>
-							<?php if ($field->showon) : ?>
-								<?php HTMLHelper::_('script', 'system/showon.min.js', array('version' => 'auto', 'relative' => true)); ?>
-								<?php $dataShowOn = ' data-showon=\'' . json_encode(FormHelper::parseShowOnConditions($field->showon, $field->formControl, $field->group)) . '\''; ?>
-							<?php endif; ?>
-							<?php if ($field->hidden) : ?>
-								<?php echo $field->input; ?>
-							<?php else : ?>
-								<div class="control-group<?php echo $groupClass; ?>"<?php echo $dataShowOn; ?>>
-									<?php if ($name != 'permissions') : ?>
-										<div class="control-label">
-											<?php echo $field->label; ?>
-										</div>
-									<?php endif; ?>
-									<div class="<?php if ($name != 'permissions') : ?>controls<?php endif; ?>">
-										<?php echo $field->input; ?>
-									</div>
-								</div>
-							<?php endif; ?>
+							<?php echo $field->renderField(); ?>
 						<?php endforeach; ?>
 					</div>
 				<?php endforeach; ?>

--- a/layouts/joomla/content/options_default.php
+++ b/layouts/joomla/content/options_default.php
@@ -24,16 +24,7 @@ use Joomla\CMS\Form\FormHelper;
     	<?php foreach ($displayData->form->getFieldset($fieldname) as $field) : ?>
         	<?php $datashowon = ''; ?>
         	<?php $groupClass = $field->type === 'Spacer' ? ' field-spacer' : ''; ?>
-            <?php if ($field->showon) : ?>
-                <?php HTMLHelper::_('script', 'system/showon.min.js', array('version' => 'auto', 'relative' => true)); ?>
-                <?php $datashowon = ' data-showon=\'' . json_encode(FormHelper::parseShowOnConditions($field->showon, $field->formControl, $field->group)) . '\''; ?>
-            <?php endif; ?>
-            <div class="control-group<?php echo $groupClass; ?>"<?php echo $datashowon; ?>>
-				<?php if (!isset($displayData->showlabel) || $displayData->showlabel) : ?>
-					<div class="control-label"><?php echo $field->label; ?></div>
-				<?php endif; ?>
-				<div class="controls"><?php echo $field->input; ?></div>
-			</div>
+			<?php echo $field->renderField(); ?>
 		<?php endforeach; ?>
 	<?php endforeach; ?>
 </fieldset>

--- a/layouts/joomla/content/options_default.php
+++ b/layouts/joomla/content/options_default.php
@@ -21,9 +21,9 @@ use Joomla\CMS\Form\FormHelper;
 	<?php endif; ?>
 	<?php $fieldsnames = explode(',', $displayData->fieldsname); ?>
 	<?php foreach ($fieldsnames as $fieldname) : ?>
-    	<?php foreach ($displayData->form->getFieldset($fieldname) as $field) : ?>
-        	<?php $datashowon = ''; ?>
-        	<?php $groupClass = $field->type === 'Spacer' ? ' field-spacer' : ''; ?>
+		<?php foreach ($displayData->form->getFieldset($fieldname) as $field) : ?>
+			<?php $datashowon = ''; ?>
+			<?php $groupClass = $field->type === 'Spacer' ? ' field-spacer' : ''; ?>
 			<?php echo $field->renderField(); ?>
 		<?php endforeach; ?>
 	<?php endforeach; ?>


### PR DESCRIPTION
If you go to the options of an article then the fields are rendered by `$field->renderfield`
BUt if you go to the options of the component then each field is rendered by `$field->label` and `$field->input`

This pr changes that so the component options are also using `$field->renderfield` which they should be.

### testing
Check that showon etc still works
There should be no visual changes

### notes
This pr will expose some descriptions previously only available in a tooltip. The tooltip is removed by #22165 and a future pr will look at potentially removing some of those descriptions if they are no longer needed
