### PR TITLE
[4.0] minified file overwritten

### DIFF
--- a/build/build-modules-js/settings.json
+++ b/build/build-modules-js/settings.json
@@ -196,7 +196,7 @@
           "dist/js/joomla-alert-es5.js": "js/joomla-alert-es5.js",
           "dist/js/joomla-alert-es5.min.js": "js/joomla-alert-es5.min.js",
           "dist/js/joomla-tab.js": "js/joomla-tab.js",
-          "dist/js/joomla-tab.min.js": "js/joomla-tab.js",
+          "dist/js/joomla-tab.min.js": "js/joomla-tab.min.js",
           "dist/js/joomla-tab-es5.js": "js/joomla-tab-es5.js",
           "dist/js/joomla-tab-es5.min.js": "js/joomla-tab-es5.min.js"
         },


### PR DESCRIPTION
Code review - the file `joomla-tab.min.js` is being saved as `joomla-tab.js` so that there is no un-minified file available to the cms
