### PR TITLE
Make sure manifest object returned before logging actions

### DIFF
--- a/plugins/actionlog/joomla/joomla.php
+++ b/plugins/actionlog/joomla/joomla.php
@@ -366,6 +366,12 @@ class PlgActionlogJoomla extends JPlugin
 		$language      = JFactory::getLanguage();
 		$user          = JFactory::getUser();
 		$manifest      = $installer->get('manifest');
+
+		if ($manifest === null)
+		{
+			return;
+		}
+
 		$extensionType = $manifest->attributes()->type;
 
 		// If the extension type has it own language key, use it, otherwise, use default language key
@@ -423,6 +429,12 @@ class PlgActionlogJoomla extends JPlugin
 		$language      = JFactory::getLanguage();
 		$user          = JFactory::getUser();
 		$manifest      = $installer->get('manifest');
+
+		if ($manifest === null)
+		{
+			return;
+		}
+
 		$extensionType = $manifest->attributes()->type;
 
 		// If the extension type has it own language key, use it, otherwise, use default language key
@@ -473,6 +485,12 @@ class PlgActionlogJoomla extends JPlugin
 		$language      = JFactory::getLanguage();
 		$user          = JFactory::getUser();
 		$manifest      = $installer->get('manifest');
+
+		if ($manifest === null)
+		{
+			return;
+		}
+
 		$extensionType = $manifest->attributes()->type;
 
 		// If the extension type has it own language key, use it, otherwise, use default language key


### PR DESCRIPTION
Pull Request for Issue #22221.

### Summary of Changes
This PR added some check to make sure $installer return a manifest object before logging install/uninstall/update action. Although it doesn't fix the root of the error, it is added to make sure install/uninstall/update process still working well as expected when action logs is enabled.


### Testing Instructions
1. Install latest staging (or 3.9 beta)
2. Follow the instructions at https://github.com/joomla/joomla-cms/issues/22221 , install/uninstall test library to confirm the issue
3. Apply patch, confirm the fatal error does not happen again

### Documentation Changes Required
None