### PR TITLE
[modules] - only for superadmin eyes

### DIFF
--- a/administrator/modules/mod_latestactions/mod_latestactions.php
+++ b/administrator/modules/mod_latestactions/mod_latestactions.php
@@ -9,6 +9,12 @@
 
 defined('_JEXEC') or die;
 
+// Only super user can view this data
+if (!JFactory::getUser()->authorise('core.admin'))
+{
+	return;
+}
+
 // Include dependencies.
 JLoader::register('ModLatestActionsHelper', __DIR__ . '/helper.php');
 

--- a/administrator/modules/mod_privacy_dashboard/mod_privacy_dashboard.php
+++ b/administrator/modules/mod_privacy_dashboard/mod_privacy_dashboard.php
@@ -9,7 +9,7 @@
 
 defined('_JEXEC') or die;
 
-// Only super user can access here
+// Only super user can view this data
 if (!JFactory::getUser()->authorise('core.admin'))
 {
 	return;

--- a/administrator/modules/mod_privacy_dashboard/mod_privacy_dashboard.php
+++ b/administrator/modules/mod_privacy_dashboard/mod_privacy_dashboard.php
@@ -9,6 +9,12 @@
 
 defined('_JEXEC') or die;
 
+// Only super user can access here
+if (!JFactory::getUser()->authorise('core.admin'))
+{
+	return;
+}
+
 // Load the privacy component language file.
 $lang = JFactory::getLanguage();
 $lang->load('com_privacy', JPATH_ADMINISTRATOR, null, false, true)

--- a/plugins/quickicon/privacycheck/privacycheck.php
+++ b/plugins/quickicon/privacycheck/privacycheck.php
@@ -40,7 +40,7 @@ class PlgQuickiconPrivacyCheck extends JPlugin
 	 */
 	public function onGetIcons($context)
 	{
-		if ($context !== $this->params->get('context', 'mod_quickicon') || !Factory::getUser()->authorise('core.admin', 'com_privacy'))
+		if ($context !== $this->params->get('context', 'mod_quickicon') || !Factory::getUser()->authorise('core.admin'))
 		{
 			return;
 		}


### PR DESCRIPTION
Pull Request for Issue #22236.

### Summary of Changes

- module mod_latestactions 
- module mod_privacy_dashboard

are for superadmin eyes only


### Testing Instructions
see #22236


### Expected result
only superadmin can see data


### Actual result

administrators can see these 2 privacy tools modules data
