### PR TITLE
Only show ip address sort options in actions log if IP logging is enabled

### DIFF
--- a/administrator/components/com_actionlogs/models/actionlogs.php
+++ b/administrator/components/com_actionlogs/models/actionlogs.php
@@ -9,8 +9,8 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\Utilities\ArrayHelper;
 use Joomla\CMS\Component\ComponentHelper;
+use Joomla\Utilities\ArrayHelper;
 
 /**
  * Methods supporting a list of article records.
@@ -329,7 +329,7 @@ class ActionlogsModelActionlogs extends JModelList
 	 *
 	 * @return  \JForm|boolean  The \JForm object or false on error
 	 *
-	 * @since   3.2
+	 * @since  3.9.0
 	 */
 	public function getFilterForm($data = array(), $loadData = true)
 	{

--- a/administrator/components/com_actionlogs/models/actionlogs.php
+++ b/administrator/components/com_actionlogs/models/actionlogs.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 use Joomla\Utilities\ArrayHelper;
+use Joomla\CMS\Component\ComponentHelper;
 
 /**
  * Methods supporting a list of article records.
@@ -318,5 +319,33 @@ class ActionlogsModelActionlogs extends JModelList
 		{
 			return false;
 		}
+	}
+
+	/**
+	 * Get the filter form
+	 *
+	 * @param   array    $data      data
+	 * @param   boolean  $loadData  load current data
+	 *
+	 * @return  \JForm|boolean  The \JForm object or false on error
+	 *
+	 * @since   3.2
+	 */
+	public function getFilterForm($data = array(), $loadData = true)
+	{
+		$form      = parent::getFilterForm($data, $loadData);
+		$params    = ComponentHelper::getParams('com_actionlogs');
+		$ipLogging = (bool) $params->get('ip_logging', 0);
+
+		// Add ip sort options to sort dropdown
+		if ($form && $ipLogging)
+		{
+			/* @var JFormFieldList $field */
+			$field = $form->getField('fullordering', 'list');
+			$field->addOption(JText::_('COM_ACTIONLOGS_IP_ADDRESS_ASC', array('value' => 'a.ip_address ASC')));
+			$field->addOption(JText::_('COM_ACTIONLOGS_IP_ADDRESS_DESC', array('value' => 'a.ip_address DESC')));
+		}
+
+		return $form;
 	}
 }

--- a/administrator/components/com_actionlogs/models/actionlogs.php
+++ b/administrator/components/com_actionlogs/models/actionlogs.php
@@ -342,8 +342,8 @@ class ActionlogsModelActionlogs extends JModelList
 		{
 			/* @var JFormFieldList $field */
 			$field = $form->getField('fullordering', 'list');
-			$field->addOption(JText::_('COM_ACTIONLOGS_IP_ADDRESS_ASC', array('value' => 'a.ip_address ASC')));
-			$field->addOption(JText::_('COM_ACTIONLOGS_IP_ADDRESS_DESC', array('value' => 'a.ip_address DESC')));
+			$field->addOption(JText::_('COM_ACTIONLOGS_IP_ADDRESS_ASC'), array('value' => 'a.ip_address ASC'));
+			$field->addOption(JText::_('COM_ACTIONLOGS_IP_ADDRESS_DESC'), array('value' => 'a.ip_address DESC'));
 		}
 
 		return $form;

--- a/administrator/components/com_actionlogs/models/forms/filter_actionlogs.xml
+++ b/administrator/components/com_actionlogs/models/forms/filter_actionlogs.xml
@@ -50,9 +50,7 @@
 			<option value="a.log_date ASC">JDATE_ASC</option>
 			<option value="a.log_date DESC">JDATE_DESC</option>
 			<option value="a.user_id ASC">COM_ACTIONLOGS_NAME_ASC</option>
-			<option value="a.user_id DESC">COM_ACTIONLOGS_NAME_DESC</option>
-			<option value="a.ip_address ASC">COM_ACTIONLOGS_IP_ADDRESS_ASC</option>
-			<option value="a.ip_address DESC">COM_ACTIONLOGS_IP_ADDRESS_DESC</option>
+			<option value="a.user_id DESC">COM_ACTIONLOGS_NAME_DESC</option>			
 			<option value="a.id ASC">JGRID_HEADING_ID_ASC</option>
 			<option value="a.id DESC">JGRID_HEADING_ID_DESC</option>
 		</field>

--- a/administrator/components/com_actionlogs/models/forms/filter_actionlogs.xml
+++ b/administrator/components/com_actionlogs/models/forms/filter_actionlogs.xml
@@ -50,7 +50,7 @@
 			<option value="a.log_date ASC">JDATE_ASC</option>
 			<option value="a.log_date DESC">JDATE_DESC</option>
 			<option value="a.user_id ASC">COM_ACTIONLOGS_NAME_ASC</option>
-			<option value="a.user_id DESC">COM_ACTIONLOGS_NAME_DESC</option>			
+			<option value="a.user_id DESC">COM_ACTIONLOGS_NAME_DESC</option>
 			<option value="a.id ASC">JGRID_HEADING_ID_ASC</option>
 			<option value="a.id DESC">JGRID_HEADING_ID_DESC</option>
 		</field>


### PR DESCRIPTION
Pull Request for Issue #22211.

### Summary of Changes
This PR fixes issue described at https://github.com/joomla/joomla-cms/issues/22211. Instead of always showing IP address sort options, it will now only be shown if IP logging is enabled.

### Testing Instructions
1. Install Joomla 3.9 beta (or latest staging)
2. Go to Users -> User Actions Log, click on Options button in the toolbar, set IP logging to No
3. Before patch: Access to Users -> User Actions Log, you still see IP address sort options in sort dropdown.
4. After patch: The IP address sort options will only be show if you enable IP Logging. If you disable IP Logging, the IP address sort options will be removed

### Documentation Changes Required
None