### PR TITLE
Tags view - remove "PHP Warning: Creating default object from empty value"

### DIFF
--- a/components/com_tags/views/tags/view.html.php
+++ b/components/com_tags/views/tags/view.html.php
@@ -45,7 +45,7 @@ class TagsViewTags extends JViewLegacy
 		$this->user   = JFactory::getUser();
 
 		// Flag indicates to not add limitstart=0 to URL
-		$pagination->hideEmptyLimitstart = true;
+		$this->pagination->hideEmptyLimitstart = true;
 
 		/*
 		 * // Change to catch


### PR DESCRIPTION
### Summary of Changes

Remove `PHP Warning:  Creating default object from empty value in ../components/com_tags/views/tags/view.html.php on line 48`

### Testing Instructions
Code review.