### PR TITLE
[3.9] action logs notifications. showon attribute for field logs_notification_extensions

### DIFF
--- a/plugins/system/actionlogs/forms/actionlogs.xml
+++ b/plugins/system/actionlogs/forms/actionlogs.xml
@@ -21,6 +21,7 @@
 				label="PLG_SYSTEM_ACTIONLOGS_EXTENSIONS_NOTIFICATIONS"
 				description="PLG_SYSTEM_ACTIONLOGS_EXTENSIONS_NOTIFICATIONS_DESC"
 				multiple="true"
+			       ahowon="logs_notification_option:1"
 			/>
 		</fieldset>
 	</fields>

--- a/plugins/system/actionlogs/forms/actionlogs.xml
+++ b/plugins/system/actionlogs/forms/actionlogs.xml
@@ -21,7 +21,7 @@
 				label="PLG_SYSTEM_ACTIONLOGS_EXTENSIONS_NOTIFICATIONS"
 				description="PLG_SYSTEM_ACTIONLOGS_EXTENSIONS_NOTIFICATIONS_DESC"
 				multiple="true"
-			       ahowon="logs_notification_option:1"
+				showon="logs_notification_option:1"
 			/>
 		</fieldset>
 	</fields>


### PR DESCRIPTION
Pull Request for comment https://github.com/joomla/joomla-cms/issues/22247#issuecomment-422747585

@SharkyKZ 
<strike>**Conflict with pr https://github.com/joomla/joomla-cms/pull/21983 because fields have been renamed there!**</strike> Solved

### Summary of Changes
- Show select list only if `Send notifications for User Actions Log : Yes`

### Testing Instructions
- Apply patch.
- Go to user profile of a "Super User"
- Check that select list is not shown if `Send notifications for User Actions Log : No`

#### Before

![19-09-_2018_14-36-52](https://user-images.githubusercontent.com/20780646/45753650-c9c2ef00-bc19-11e8-96c3-92adaf80a41a.jpg)

#### After

![19-09-_2018_14-37-48](https://user-images.githubusercontent.com/20780646/45753664-d8110b00-bc19-11e8-967e-94463b7a52a0.jpg)