### PR TITLE
Allow a database other than default to be specified

### DIFF
--- a/libraries/src/Helper/TagsHelper.php
+++ b/libraries/src/Helper/TagsHelper.php
@@ -10,8 +10,8 @@ namespace Joomla\CMS\Helper;
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\CMS\Factory;
 use Joomla\CMS\Component\ComponentHelper;
+use Joomla\CMS\Factory;
 use Joomla\CMS\Table\Table;
 use Joomla\CMS\Table\TableInterface;
 use Joomla\Utilities\ArrayHelper;
@@ -57,7 +57,8 @@ class TagsHelper extends CMSHelper
 	protected $db = null;
 
 	/**
-	 * Undocumented function
+	 * Constructor
+	 * Instance can be created using a specific database driver object.
 	 *
 	 * @param   \JDatabaseDriver  $db  Database driver to use with this instance.
 	 *
@@ -65,7 +66,7 @@ class TagsHelper extends CMSHelper
 	 */
 	public function __construct(\JDatabaseDriver $db = null)
 	{
-		$this->db = $db ? $db : Factory::getDBO();
+		$this->db = $db ?: Factory::getDBO();
 	}
 
 	/**

--- a/libraries/src/Helper/TagsHelper.php
+++ b/libraries/src/Helper/TagsHelper.php
@@ -772,11 +772,11 @@ class TagsHelper extends CMSHelper
 	/**
 	 * Method to get a list of types with associated data.
 	 *
-	 * @param   string   $arrayType    Optionally specify that the returned list consist of objects, associative arrays, or arrays.
-	 *                                 Options are: rowList, assocList, and objectList
-	 * @param   array    $selectTypes  Optional array of type ids to limit the results to. Often from a request.
-	 * @param   boolean  $useAlias     If true, the alias is used to match, if false the type_id is used.
-	 * @param   \JDatabaseDriver  $db    Optional database driver to use instead of default.
+	 * @param   string            $arrayType    Optionally specify that the returned list consist of objects, associative arrays, or arrays.
+	 *                                          Options are: rowList, assocList, and objectList
+	 * @param   array             $selectTypes  Optional array of type ids to limit the results to. Often from a request.
+	 * @param   boolean           $useAlias     If true, the alias is used to match, if false the type_id is used.
+	 * @param   \JDatabaseDriver  $db           Optional database driver to use instead of default.
 	 *
 	 * @return  array   Array of of types
 	 *
@@ -931,8 +931,8 @@ class TagsHelper extends CMSHelper
 	/**
 	 * Function to search tags
 	 *
-	 * @param   array  $filters  Filter to apply to the search
-	 * @param   \JDatabaseDriver  $db    Optional database driver to use instead of default.
+	 * @param   array             $filters  Filter to apply to the search
+	 * @param   \JDatabaseDriver  $db       Optional database driver to use instead of default.
 	 *
 	 * @return  array
 	 *


### PR DESCRIPTION
### Summary of Changes

Constructor takes an optional database object that will be used in all instance methods
Static functions can take an optional database object to use instead of default dbo
Also cleaned up some code in minor ways - much more can be done

Alternative database objects can now be used but default behavior will not have changed.

### Testing Instructions

Since this class is used for working with tags, you should do some things that involve tags. Especially, add or remove tags from content items such as articles. 

### Expected result

There should be no change from the current behavior. That is, it should continue to work as usual.

### Actual result

Yes.

### Documentation Changes Required

No.