### PR TITLE
Fix reCaptcha onDisplay

### DIFF
--- a/plugins/captcha/recaptcha/recaptcha.php
+++ b/plugins/captcha/recaptcha/recaptcha.php
@@ -121,7 +121,7 @@ class PlgCaptchaRecaptcha extends JPlugin
 		}
 
 		$dom->appendChild($ele);
-		return $dom->saveXML($ele);
+		return $dom->saveHTML($ele);
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue #22041 .

### Summary of Changes
PlgCaptchaRecaptcha->onDisplay event returns HTML node instead of XML node.


### Testing Instructions
I did my tests with recaptcha JComments (https://github.com/twister65/com_jcomments).
You can test it with any extension using reCaptcha plugin.


### Expected result
recaptcha box should display.


### Actual result
It appears.


### Documentation Changes Required
Documentation was correct : 
@return  string  The HTML to be embedded in the form.
