### PR TITLE
Add 'btn-small' to mod-stats-admin buttons

### DIFF
--- a/administrator/modules/mod_stats_admin/tmpl/default.php
+++ b/administrator/modules/mod_stats_admin/tmpl/default.php
@@ -34,7 +34,7 @@ JFactory::getDocument()->addScriptDeclaration('
 			</div>
 			<div class="span8">
 				<?php if(isset($item->link)) : ?>
-					<a class="btn btn-info btn-small js-revert" href ="<?php echo $item->link; ?>"><?php echo $item->data; ?></a>
+					<a class="btn btn-info btn-small js-revert" href="<?php echo $item->link; ?>"><?php echo $item->data; ?></a>
 				<?php else : ?>
 					<?php echo $item->data; ?>
 				<?php endif; ?>

--- a/administrator/modules/mod_stats_admin/tmpl/default.php
+++ b/administrator/modules/mod_stats_admin/tmpl/default.php
@@ -34,7 +34,7 @@ JFactory::getDocument()->addScriptDeclaration('
 			</div>
 			<div class="span8">
 				<?php if(isset($item->link)) : ?>
-					<a class="btn btn-info js-revert" href ="<?php echo $item->link; ?>"><?php echo $item->data; ?></a>
+					<a class="btn btn-info btn-small js-revert" href ="<?php echo $item->link; ?>"><?php echo $item->data; ?></a>
 				<?php else : ?>
 					<?php echo $item->data; ?>
 				<?php endif; ?>


### PR DESCRIPTION
Pull Request for Issue #22269 (kinda) .

### Summary of Changes
A minor tweak. Adds a `btn-small` class to the mod-stats-admin module buttons

### Testing Instructions
Check stats module in cpanel

### Before
![image](https://user-images.githubusercontent.com/2803503/45819341-f9d2c680-bcdb-11e8-8e7a-76f577f4baef.png)

### After
![image](https://user-images.githubusercontent.com/2803503/45819258-d7d94400-bcdb-11e8-90ae-3abfad30530a.png)

### Documentation Changes Required
