### PR TITLE
[4.0] Remove deprecated profiler global

### DIFF
--- a/administrator/includes/framework.php
+++ b/administrator/includes/framework.php
@@ -79,10 +79,3 @@ switch ($config->error_reporting)
 define('JDEBUG', $config->debug);
 
 unset($config);
-
-// System profiler
-if (JDEBUG)
-{
-	// @deprecated 4.0 - The $_PROFILER global will be removed
-	$_PROFILER = JProfiler::getInstance('Application');
-}

--- a/includes/framework.php
+++ b/includes/framework.php
@@ -79,10 +79,3 @@ switch ($config->error_reporting)
 define('JDEBUG', $config->debug);
 
 unset($config);
-
-// System profiler
-if (JDEBUG)
-{
-	// @deprecated 4.0 - The $_PROFILER global will be removed
-	$_PROFILER = JProfiler::getInstance('Application');
-}


### PR DESCRIPTION
In #10845 the `$_PROFILER` variable got deprecated. This pr removes it.