### PR TITLE
[4.0] Adds deprecated messages to the getInstance functions for the model and controller

### DIFF
--- a/libraries/src/MVC/Controller/BaseController.php
+++ b/libraries/src/MVC/Controller/BaseController.php
@@ -245,10 +245,9 @@ class BaseController implements ControllerInterface
 	 *
 	 * @return  static
 	 *
-	 * @since   3.0
-	 *
-	 * @deprecated 4.0
-	 * @throws  \Exception if the controller cannot be loaded.
+	 * @since       3.0
+	 * @deprecated  5.0 Get the controller through the MVCFactory instead
+	 * @throws      \Exception if the controller cannot be loaded.
 	 */
 	public static function getInstance($prefix, $config = array())
 	{

--- a/libraries/src/MVC/Controller/BaseController.php
+++ b/libraries/src/MVC/Controller/BaseController.php
@@ -256,6 +256,14 @@ class BaseController implements ControllerInterface
 			return self::$instance;
 		}
 
+		@trigger_error(
+			sprintf(
+				'%1$s::getInstance() is deprecated. Load it through the MVC factory.',
+				self::class
+			),
+			E_USER_DEPRECATED
+		);
+
 		$app   = Factory::getApplication();
 		$input = $app->input;
 

--- a/libraries/src/MVC/Model/BaseDatabaseModel.php
+++ b/libraries/src/MVC/Model/BaseDatabaseModel.php
@@ -186,7 +186,8 @@ abstract class BaseDatabaseModel extends CMSObject
 	 *
 	 * @return  self|boolean   A \JModelLegacy instance or false on failure
 	 *
-	 * @since   3.0
+	 * @since       3.0
+	 * @deprecated  5.0 Get the model through the MVCFactory instead
 	 */
 	public static function getInstance($type, $prefix = '', $config = array())
 	{

--- a/libraries/src/MVC/Model/BaseDatabaseModel.php
+++ b/libraries/src/MVC/Model/BaseDatabaseModel.php
@@ -191,6 +191,14 @@ abstract class BaseDatabaseModel extends CMSObject
 	 */
 	public static function getInstance($type, $prefix = '', $config = array())
 	{
+		@trigger_error(
+			sprintf(
+				'%1$s::getInstance() is deprecated. Load it through the MVC factory.',
+				self::class
+			),
+			E_USER_DEPRECATED
+		);
+
 		$type = preg_replace('/[^A-Z0-9_\.-]/i', '', $type);
 		$modelClass = $prefix . ucfirst($type);
 


### PR DESCRIPTION
- Adds a deprecated message to the BaseController::getInstance function and deprecates it for 5.
- Adds a deprecated message to the BaseDatabaseModel::getInstance function and deprecates it for 5.