### PR TITLE
[com_privacy] xml header encoding utf-8

### DIFF
--- a/administrator/components/com_privacy/helpers/privacy.php
+++ b/administrator/components/com_privacy/helpers/privacy.php
@@ -63,7 +63,7 @@ class PrivacyHelper extends JHelperContent
 	 */
 	public static function renderDataAsXml(array $exportData)
 	{
-		$export = new SimpleXMLElement("<data-export />");
+		$export = new SimpleXMLElement('<?xml version="1.0" encoding="utf-8"?><data-export />');
 
 		foreach ($exportData as $domain)
 		{


### PR DESCRIPTION
Pull Request for Issue .
https://github.com/joomla/joomla-cms/pull/22240#issuecomment-422863694

### Summary of Changes
added utf-8 encoding to the xml header


### Testing Instructions
submit a export data privacy request
confirm the request
Privacy: Information Requests
export the confirmed export data request
![screenshot from 2018-09-20 20-16-30](https://user-images.githubusercontent.com/181681/45838498-20abef80-bd12-11e8-8fd6-4bfef5df0822.png)
open the xml


### Expected result
```xml
<?xml version="1.0" encoding="utf-8"?>
<data-export>
  <domain name="users" description="Joomla! users table data">
    <item id="385">
....

```
### Actual result

```xml
<?xml version="1.0" ?>
```

### Documentation Changes Required

