### PR TITLE
[com_content] Deprecate getAuthors()

### DIFF
--- a/administrator/components/com_content/models/articles.php
+++ b/administrator/components/com_content/models/articles.php
@@ -399,6 +399,8 @@ class ContentModelArticles extends JModelList
 	 * @return  stdClass
 	 *
 	 * @since   1.6
+	 *
+	 * @deprecated  4.0  To be removed with Hathor
 	 */
 	public function getAuthors()
 	{

--- a/administrator/components/com_content/views/articles/view.html.php
+++ b/administrator/components/com_content/views/articles/view.html.php
@@ -20,6 +20,8 @@ class ContentViewArticles extends JViewLegacy
 	 * The item authors
 	 *
 	 * @var  stdClass
+	 *
+	 * @deprecated  4.0  To be removed with Hathor
 	 */
 	protected $authors;
 

--- a/administrator/components/com_content/views/featured/view.html.php
+++ b/administrator/components/com_content/views/featured/view.html.php
@@ -20,6 +20,8 @@ class ContentViewFeatured extends JViewLegacy
 	 * The item authors
 	 *
 	 * @var  stdClass
+	 *
+	 * @deprecated  4.0  To be removed with Hathor
 	 */
 	protected $authors;
 


### PR DESCRIPTION
### Summary of Changes
Deprecates `getAuthors()` method which is only used in Hathor.

### Testing Instructions
Code review.