### PR TITLE
[4.0] Remove the deprecated code in the JHtmlSearchtools class

### DIFF
--- a/libraries/cms/html/searchtools.php
+++ b/libraries/cms/html/searchtools.php
@@ -28,28 +28,6 @@ abstract class JHtmlSearchtools
 	protected static $loaded = array();
 
 	/**
-	 * Load the main Searchtools libraries
-	 *
-	 * @return  void
-	 *
-	 * @since   3.2
-	 *
-	 * @deprecated 4.0
-	 */
-	public static function main()
-	{
-		// Only load once
-		if (empty(static::$loaded[__METHOD__]))
-		{
-			// Load the script && css files
-			HTMLHelper::_('script', 'system/searchtools.min.js', array('version' => 'auto', 'relative' => true));
-			HTMLHelper::_('stylesheet', 'system/searchtools.css', array('version' => 'auto', 'relative' => true));
-
-			static::$loaded[__METHOD__] = true;
-		}
-	}
-
-	/**
 	 * Load searchtools for a specific form
 	 *
 	 * @param   mixed  $selector  Is debugging mode on? [optional]


### PR DESCRIPTION
Removes the deprecated code in the `JHtmlSearchtools` class.