### PR TITLE
[4.0] The DisplayController of com_config is needed

### DIFF
--- a/administrator/components/com_config/Controller/DisplayController.php
+++ b/administrator/components/com_config/Controller/DisplayController.php
@@ -17,7 +17,6 @@ use Joomla\CMS\MVC\Controller\BaseController as BaseController;
  * Controller for global configuration
  *
  * @since       1.5
- * @deprecated  4.0
  */
 class DisplayController extends BaseController
 {


### PR DESCRIPTION
The `DisplayController` class of com_config is needed, so the deprecate message should be removed.