### PR TITLE
[4.0] Remove not needed jQuery imports as the JS files are vanilla JS

### DIFF
--- a/administrator/components/com_associations/tmpl/associations/default.php
+++ b/administrator/components/com_associations/tmpl/associations/default.php
@@ -16,7 +16,6 @@ use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 
-HTMLHelper::_('jquery.framework');
 HTMLHelper::_('behavior.multiselect');
 
 $listOrder        = $this->escape($this->state->get('list.ordering'));

--- a/administrator/components/com_banners/tmpl/banner/edit.php
+++ b/administrator/components/com_banners/tmpl/banner/edit.php
@@ -16,7 +16,6 @@ use Joomla\CMS\HTML\HTMLHelper;
 
 HTMLHelper::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
-HTMLHelper::_('jquery.framework');
 HTMLHelper::_('behavior.formvalidator');
 HTMLHelper::_('formbehavior.chosen', '#jform_catid', null, array('disable_search_threshold' => 0 ));
 

--- a/administrator/components/com_contenthistory/tmpl/history/modal.php
+++ b/administrator/components/com_contenthistory/tmpl/history/modal.php
@@ -18,7 +18,6 @@ use Joomla\CMS\HTML\HTMLHelper;
 Session::checkToken('get') or die(Text::_('JINVALID_TOKEN'));
 
 HTMLHelper::_('behavior.multiselect');
-HTMLHelper::_('jquery.framework');
 
 $input          = Factory::getApplication()->input;
 $field          = $input->getCmd('field');

--- a/administrator/components/com_finder/tmpl/indexer/default.php
+++ b/administrator/components/com_finder/tmpl/indexer/default.php
@@ -11,7 +11,6 @@ defined('_JEXEC') or die;
 
 JHtml::_('behavior.keepalive');
 JHtml::_('behavior.core');
-JHtml::_('jquery.framework');
 JHtml::_('script', 'com_finder/indexer.min.js', array('version' => 'auto', 'relative' => true));
 JFactory::getDocument()->addScriptDeclaration('var msg = "' . JText::_('COM_FINDER_INDEXER_MESSAGE_COMPLETE') . '";');
 ?>

--- a/administrator/components/com_languages/tmpl/override/edit.php
+++ b/administrator/components/com_languages/tmpl/override/edit.php
@@ -24,7 +24,6 @@ $expired = ($this->state->get('cache_expired') == 1 ) ? '1' : '';
 HTMLHelper::_('stylesheet', 'com_languages/overrider.css', array('version' => 'auto', 'relative' => true));
 
 HTMLHelper::_('behavior.core');
-HTMLHelper::_('jquery.framework');
 HTMLHelper::_('script', 'com_languages/overrider.min.js', array('version' => 'auto', 'relative' => true));
 HTMLHelper::_('script', 'com_languages/admin-override-edit-refresh-searchstring.js', ['version' => 'auto', 'relative' => true]);
 ?>

--- a/administrator/components/com_menus/tmpl/item/edit_modules.php
+++ b/administrator/components/com_menus/tmpl/item/edit_modules.php
@@ -23,9 +23,6 @@ foreach ($this->levels as $key => $value)
 
 Factory::getDocument()->addScriptOptions('menus-edit-modules', ['viewLevels' => $allLevels, 'itemId' => $this->item->id]);
 HTMLHelper::_('stylesheet', 'com_menus/admin-item-edit_modules.css', array('version' => 'auto', 'relative' => true));
-
-// TODO: Re-remove the jQuery dependency in the admin-item-edit_modules.js file:
-HTMLHelper::_('jquery.framework');
 HTMLHelper::_('script', 'com_menus/admin-item-edit_modules.min.js', array('version' => 'auto', 'relative' => true));
 
 // Set up the bootstrap modal that will be used for all module editors

--- a/components/com_contact/layouts/joomla/form/renderfield.php
+++ b/components/com_contact/layouts/joomla/form/renderfield.php
@@ -23,7 +23,6 @@ extract($displayData);
 
 if (!empty($options['showonEnabled']))
 {
-	HTMLHelper::_('jquery.framework');
 	HTMLHelper::_('script', 'system/showon.min.js', array('version' => 'auto', 'relative' => true));
 }
 

--- a/layouts/joomla/edit/associations.php
+++ b/layouts/joomla/edit/associations.php
@@ -20,7 +20,6 @@ $options  = array(
 );
 
 HTMLHelper::_('behavior.core');
-HTMLHelper::_('jquery.framework');
 Text::script('JGLOBAL_ASSOC_NOT_POSSIBLE');
 Text::script('JGLOBAL_ASSOCIATIONS_RESET_WARNING');
 Factory::getDocument()->addScriptOptions('system.associations.edit', $options);

--- a/layouts/joomla/form/field/user.php
+++ b/layouts/joomla/form/field/user.php
@@ -50,9 +50,6 @@ extract($displayData);
 
 if (!$readonly)
 {
-	// @TODO remove jQuery dependency once modal moves to webcomponents
-	HTMLHelper::_('jquery.framework');
-
 	HTMLHelper::_('webcomponent', 'system/webcomponents/joomla-field-user.min.js', ['version' => 'auto', 'relative' => true]);
 }
 

--- a/layouts/joomla/form/field/user.php
+++ b/layouts/joomla/form/field/user.php
@@ -53,7 +53,8 @@ if (!$readonly)
 	// @TODO remove jQuery dependency once modal moves to webcomponents
 	HTMLHelper::_('jquery.framework');
 
-	HTMLHelper::_('webcomponent', 'system/webcomponents/joomla-field-user.min.js', ['version' => 'auto', 'relative' => true]);}
+	HTMLHelper::_('webcomponent', 'system/webcomponents/joomla-field-user.min.js', ['version' => 'auto', 'relative' => true]);
+}
 
 $uri = new Uri('index.php?option=com_users&view=users&layout=modal&tmpl=component&required=0');
 


### PR DESCRIPTION
jQuery got removed in most JS files. The import declaration is still there. The pr removes them, where no JS file is loaded with jQuery code.
