### PR TITLE
[4.0] Remove jQuery from modal fields JS file

### DIFF
--- a/administrator/components/com_categories/Field/Modal/CategoryField.php
+++ b/administrator/components/com_categories/Field/Modal/CategoryField.php
@@ -65,7 +65,6 @@ class CategoryField extends FormField
 		$modalId = 'Category_' . $this->id;
 
 		// Add the modal field script to the document head.
-		HTMLHelper::_('jquery.framework');
 		HTMLHelper::_('script', 'system/fields/modal-fields.min.js', array('version' => 'auto', 'relative' => true));
 
 		// Script to proxy the select modal function to the modal-fields.js file.

--- a/administrator/components/com_contact/Field/Modal/ContactField.php
+++ b/administrator/components/com_contact/Field/Modal/ContactField.php
@@ -56,7 +56,6 @@ class ContactField extends FormField
 		$modalId = 'Contact_' . $this->id;
 
 		// Add the modal field script to the document head.
-		HTMLHelper::_('jquery.framework');
 		HTMLHelper::_('script', 'system/fields/modal-fields.min.js', array('version' => 'auto', 'relative' => true));
 
 		// Script to proxy the select modal function to the modal-fields.js file.

--- a/administrator/components/com_content/Field/Modal/ArticleField.php
+++ b/administrator/components/com_content/Field/Modal/ArticleField.php
@@ -56,7 +56,6 @@ class ArticleField extends FormField
 		$modalId = 'Article_' . $this->id;
 
 		// Add the modal field script to the document head.
-		HTMLHelper::_('jquery.framework');
 		HTMLHelper::_('script', 'system/fields/modal-fields.min.js', array('version' => 'auto', 'relative' => true));
 
 		// Script to proxy the select modal function to the modal-fields.js file.

--- a/administrator/components/com_content/View/Article/HtmlView.php
+++ b/administrator/components/com_content/View/Article/HtmlView.php
@@ -212,7 +212,6 @@ class HtmlView extends BaseHtmlView
 				ToolbarHelper::modal('ModalNewItem_' . $modalId, 'icon-new', 'COM_CONTENT_ADD_NEW_MENU_ITEM');
 
 				// Add the modal field script to the document head.
-				HTMLHelper::_('jquery.framework');
 				HTMLHelper::_('script', 'system/fields/modal-fields.min.js', array('version' => 'auto', 'relative' => true));
 
 				// Load the language files

--- a/administrator/components/com_menus/Field/Modal/MenuField.php
+++ b/administrator/components/com_menus/Field/Modal/MenuField.php
@@ -164,7 +164,6 @@ class MenuField extends FormField
 		$modalId = 'Item_' . $this->id;
 
 		// Add the modal field script to the document head.
-		HTMLHelper::_('jquery.framework');
 		HTMLHelper::_('script', 'system/fields/modal-fields.min.js', array('version' => 'auto', 'relative' => true));
 
 		// Script to proxy the select modal function to the modal-fields.js file.

--- a/administrator/components/com_newsfeeds/Field/Modal/NewsfeedField.php
+++ b/administrator/components/com_newsfeeds/Field/Modal/NewsfeedField.php
@@ -56,7 +56,6 @@ class NewsfeedField extends FormField
 		$modalId = 'Newsfeed_' . $this->id;
 
 		// Add the modal field script to the document head.
-		HTMLHelper::_('jquery.framework');
 		HTMLHelper::_('script', 'system/fields/modal-fields.min.js', array('version' => 'auto', 'relative' => true));
 
 		// Script to proxy the select modal function to the modal-fields.js file.

--- a/build/media/system/js/fields/modal-fields.js
+++ b/build/media/system/js/fields/modal-fields.js
@@ -110,17 +110,18 @@
 		titleFieldId = titleFieldId || 'jform_title';
 
 		var modalId = element.parentNode.parentNode.parentNode.parentNode.id, submittedTask = task;
+		var iframe  = document.getElementById(modalId + ' iframe');
 
 		// Set frame id.
-		jQuery('#' + modalId + ' iframe').get(0).id = 'Frame_' + modalId;
+		iframe.id = 'Frame_' + modalId;
 
-		var iframeDocument = jQuery('#Frame_' + modalId).contents().get(0);
+		var iframeDocument = iframe.firstChild;
 
 		// If Close (cancel task), close the modal.
 		if (task === 'cancel')
 		{
 			// Submit button on child iframe so we can check out.
-			document.getElementById('Frame_' + modalId).contentWindow.Joomla.submitbutton(itemType.toLowerCase() + '.' + task);
+			iframe.contentWindow.Joomla.submitbutton(itemType.toLowerCase() + '.' + task);
 
 			Joomla.Modal.getCurrent().close();
 		}
@@ -128,10 +129,10 @@
 		else
 		{
 			// Attach onload event to the iframe.
-			jQuery('#Frame_' + modalId).on('load', function()
+			iframe.addEventListener('load', function()
 			{
 				// Reload iframe document var value.
-				iframeDocument = jQuery(this).contents().get(0);
+				iframeDocument = this.firstChild;
 
 				// Validate the child form and update parent form.
 				if (iframeDocument.getElementById(idFieldId) && iframeDocument.getElementById(idFieldId).value != '0')
@@ -146,7 +147,7 @@
 				}
 
 				// Show the iframe again for future modals or in case of error.
-				jQuery('#' + modalId + ' iframe').removeClass('sr-only');
+				iframe.classList.remove('sr-only');
 			});
 
 			// Submit button on child iframe.
@@ -156,10 +157,10 @@
 				if (task === 'save')
 				{
 					submittedTask = 'apply';
-					jQuery('#' + modalId + ' iframe').addClass('sr-only');
+					iframe.classList.add('sr-only');
 				}
 
-				document.getElementById('Frame_' + modalId).contentWindow.Joomla.submitbutton(itemType.toLowerCase() + '.' + submittedTask);
+				iframe.contentWindow.Joomla.submitbutton(itemType.toLowerCase() + '.' + submittedTask);
 			}
 		}
 


### PR DESCRIPTION
### Summary of Changes
Removes jQuery dependency from the modal field JS file.

### Testing Instructions
- Log in on the back end
- Create an article
- Create a new Single article menu item
- Click on "Select" to select an article

### Expected result
The modal window opens with a list of articles.

### Actual result
The modal window opens with a list of articles.