### PR TITLE
[4.0] use font variables in atum

### DIFF
--- a/administrator/templates/atum/scss/_variables.scss
+++ b/administrator/templates/atum/scss/_variables.scss
@@ -89,6 +89,17 @@ $font-size-sm:                     .8rem;
 $fa-css-prefix:                    fa;
 $fa-font-path:                     "../../../../media/vendor/font-awesome/fonts";
 
+// Font weights
+$thin-weight:                      100;
+$extralight-weight:                200;
+$light-weight:                     300;
+$normal-weight:                    400;
+$medium-weight:                    500;
+$semibold-weight:                  600;
+$bold-weight:                      700;
+$extrabold-weight:                 800;
+$black-weight:                     900;
+
 // Text
 $body-color:                       var(--dark);
 

--- a/administrator/templates/atum/scss/blocks/_global.scss
+++ b/administrator/templates/atum/scss/blocks/_global.scss
@@ -17,11 +17,11 @@ h3,
 h4,
 h5,
 h6 {
-  font-weight: bold;
+  font-weight: $bold-weight;
 }
 
 h1 {
-  font-weight: normal;
+  font-weight: $normal-weight;
 }
 
 small,
@@ -31,7 +31,8 @@ small,
 
 legend {
   font-size: 1.2rem;
-  font-weight: 700;
+  font-weight: $black-weight;
+  ;
 }
 
 // focus-visible polyfil rule

--- a/administrator/templates/atum/scss/blocks/_modals.scss
+++ b/administrator/templates/atum/scss/blocks/_modals.scss
@@ -37,7 +37,7 @@
 }
 
 .modal-title {
-  font-weight: normal;
+  font-weight: $normal-weight;
   line-height: $modal-header-height;
 }
 

--- a/administrator/templates/atum/scss/blocks/_sidebar-nav.scss
+++ b/administrator/templates/atum/scss/blocks/_sidebar-nav.scss
@@ -9,7 +9,7 @@
   li {
     padding-bottom: 3px;
     font-size: .9rem;
-    font-weight: bold;
+    font-weight: $bold-weight;
 
     &.nav-header {
       padding: .5rem 0 .2rem;

--- a/administrator/templates/atum/scss/blocks/_treeselect.scss
+++ b/administrator/templates/atum/scss/blocks/_treeselect.scss
@@ -4,7 +4,7 @@
   list-style: none;
 
   .nav-header {
-    font-weight: $font-weight-bold;
+    font-weight: $bold-weight;
     color: $gray-900;
   }
 

--- a/administrator/templates/atum/scss/vendor/bootstrap/_collapse.scss
+++ b/administrator/templates/atum/scss/vendor/bootstrap/_collapse.scss
@@ -5,7 +5,7 @@
   .card-header {
     display: block;
     font-size: $h5-font-size;
-    font-weight: bold;
+    font-weight: $bold-weight;
     line-height: $headings-line-height;
   }
 

--- a/administrator/templates/atum/scss/vendor/bootstrap/_table.scss
+++ b/administrator/templates/atum/scss/vendor/bootstrap/_table.scss
@@ -5,7 +5,7 @@
   thead {
     th,
     td {
-      font-weight: normal;
+      font-weight: $normal-weight;
       color: $gray-800;
       white-space: nowrap;
     }
@@ -13,7 +13,7 @@
       padding: 0;
     }
     a {
-      font-weight: normal;
+      font-weight: $normal-weight;
       color: $gray-800;
     }
   }


### PR DESCRIPTION
Pull Request for Issue #21727

### Summary of Changes
As per https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight defining an array of font weight values in an array in variables.scss 

to test you will need to 
`npm run build:css`