### PR TITLE
Show the full sub-tree of menu-items when filtering by a parent menu item, while respecting the max levels filter

### DIFF
--- a/administrator/components/com_menus/models/items.php
+++ b/administrator/components/com_menus/models/items.php
@@ -368,7 +368,7 @@ class MenusModelItems extends JModelList
 
 			if ($level)
 			{
-				$subQuery->where('sub.level <= this.level + ' . $level);
+				$subQuery->where('sub.level <= this.level + ' . (int) ($level - 1));
 			}
 
 			// Add the subquery to the main query

--- a/administrator/components/com_menus/models/items.php
+++ b/administrator/components/com_menus/models/items.php
@@ -357,7 +357,28 @@ class MenusModelItems extends JModelList
 
 		if (!empty($parentId))
 		{
-			$query->where('a.parent_id = ' . (int) $parentId);
+			$level = $this->getState('filter.level');
+
+			// Create a subquery for the sub-items list
+			$subQuery = $db->getQuery(true)
+				->select('sub.id')
+				->from('#__menu as sub')
+				->join('INNER', '#__menu as this ON sub.lft > this.lft AND sub.rgt < this.rgt')
+				->where('this.id = ' . (int) $parentId);
+
+			if ($level)
+			{
+				$subQuery->where('sub.level <= this.level + ' . $level);
+			}
+
+			// Add the subquery to the main query
+			$query->where('(a.parent_id = ' . (int) $parentId . ' OR a.parent_id IN (' . (string) $subQuery . '))');
+		}
+
+		// Filter on the level.
+		elseif ($level = $this->getState('filter.level'))
+		{
+			$query->where('a.level <= ' . (int) $level);
 		}
 
 		// Filter the items over the menu id if set.
@@ -419,12 +440,6 @@ class MenusModelItems extends JModelList
 			{
 				$query->where('a.access IN (' . implode(',', $groups) . ')');
 			}
-		}
-
-		// Filter on the level.
-		if ($level = $this->getState('filter.level'))
-		{
-			$query->where('a.level <= ' . (int) $level);
 		}
 
 		// Filter on the language.


### PR DESCRIPTION
Pull Request for Issue #22271

### Summary of Changes
This PR allows to see the full sub-tree of menu items when you filter by a specific parent menu item

Also the max levels filter is respected
e.g. to view only the direct children of the parent menu item, user can select a (max) level of "1"

### Testing Instructions
1. Go to menu items manager
2. Filter by a specific menu item (please choose a menu item that has a subtree with 2 or more levels)


### Expected result
You see the full sub-tree of menu items


### Actual result
You see only the direct children (1st level descedants)


### Documentation Changes Required
None
