### PR TITLE
[4.0] Fix broken stage filter

### DIFF
--- a/administrator/components/com_content/forms/filter_articles.xml
+++ b/administrator/components/com_content/forms/filter_articles.xml
@@ -14,6 +14,7 @@
 			type="workflowstage"
 			onchange="this.form.submit();"
 			activeonly="true"
+			extension="com_content"
 			>
 			<option value="">JOPTION_SELECT_STAGE</option>
 		</field>

--- a/administrator/components/com_content/forms/filter_featured.xml
+++ b/administrator/components/com_content/forms/filter_featured.xml
@@ -14,6 +14,7 @@
 			type="workflowstage"
 			onchange="this.form.submit();"
 			activeonly="true"
+			extension="com_content"
 			>
 			<option value="">JOPTION_SELECT_STAGE</option>
 		</field>


### PR DESCRIPTION
### Summary of Changes
With https://github.com/joomla/joomla-cms/commit/df09dc0d1f6a4546eb09c381841979926d1cdbca#diff-04f34fdd1d4475406e217b9de50c2eb3R39 com_content as fallbck was removed, so it has to be set manually in the XML.


### Testing Instructions
1. Open articles view in the backend
2. Open the Stages filter options


### Expected result
Active stages are listed


### Actual result
Dropdown is empty
