### PR TITLE
[4.0] Fix sorting transitions list

### DIFF
--- a/administrator/components/com_workflow/tmpl/transitions/default.php
+++ b/administrator/components/com_workflow/tmpl/transitions/default.php
@@ -67,10 +67,10 @@ if ($saveOrder)
 									<?php echo HTMLHelper::_('searchtools.sort', 'COM_WORKFLOW_NAME', 't.title', $listDirn, $listOrder); ?>
 								</th>
 								<th scope="col" style="width:10%" class="text-center hidden-sm-down">
-									<?php echo HTMLHelper::_('searchtools.sort', 'COM_WORKFLOW_FROM_STAGE', 't.from_stage', $listDirn, $listOrder); ?>
+									<?php echo HTMLHelper::_('searchtools.sort', 'COM_WORKFLOW_FROM_STAGE', 'from_stage', $listDirn, $listOrder); ?>
 								</th>
 								<th scope="col" style="width:10%" class="text-center hidden-sm-down">
-									<?php echo HTMLHelper::_('searchtools.sort', 'COM_WORKFLOW_TO_STAGE', 't.to_stage', $listDirn, $listOrder); ?>
+									<?php echo HTMLHelper::_('searchtools.sort', 'COM_WORKFLOW_TO_STAGE', 'to_stage', $listDirn, $listOrder); ?>
 								</th>
 								<th scope="col" style="width:10%" class="text-right hidden-sm-down">
 									<?php echo HTMLHelper::_('searchtools.sort', 'COM_WORKFLOW_ID', 't.id', $listDirn, $listOrder); ?>


### PR DESCRIPTION
### Summary of Changes
Fix broken sorting the transitions by clicking the column in the table header.

### Testing Instructions
Sort the table of transitions by table header "current state" or "target state"

### Expected result
Transitions are orderend new

### Actual result
Nothing happens

### Documentation Changes Required
no
