### PR TITLE
[4.0] Add icons to conditions in workflow-stages

### DIFF
--- a/administrator/components/com_workflow/tmpl/stages/default.php
+++ b/administrator/components/com_workflow/tmpl/stages/default.php
@@ -129,11 +129,23 @@ if ($saveOrder)
 											<div class="small"><?php echo $this->escape(Text::_($item->description)); ?></div>
 										<?php endif; ?>
 									</th>
-									<td class="text-center">
+									<td class="nowrap">
+										<?php 
+											if ($item->condition == 'JARCHIVED'):
+												$icon = 'icon-archive';
+											elseif ($item->condition == 'JTRASHED'):
+												$icon = 'icon-trash';
+											elseif ($item->condition == 'JPUBLISHED'):
+												$icon = 'icon-publish';
+											elseif ($item->condition == 'JUNPUBLISHED'):
+												$icon = 'icon-unpublish';
+											endif; 
+										?>
+										<span class="<?php echo $icon; ?>" aria-hidden="true"></span>
 										<?php echo Text::_($item->condition); ?>
 									</td>
-									<td class="text-right">
-										<?php echo $item->id; ?>
+									<td class="d-none d-md-table-cell">
+										<?php echo (int) $item->id; ?>
 									</td>
 								</tr>
 							<?php endforeach ?>

--- a/administrator/components/com_workflow/tmpl/stages/default.php
+++ b/administrator/components/com_workflow/tmpl/stages/default.php
@@ -70,10 +70,10 @@ if ($saveOrder)
 								<th scope="col" style="width:10%" class="hidden-sm-down">
 									<?php echo HTMLHelper::_('searchtools.sort', 'COM_WORKFLOW_NAME', 's.title', $listDirn, $listOrder); ?>
 								</th>
-								<th scope="col" style="width:10%" class="text-center hidden-sm-down">
+								<th scope="col" style="width:10%" class="hidden-sm-down">
 									<?php echo HTMLHelper::_('searchtools.sort', 'COM_WORKFLOW_CONDITION', 's.condition', $listDirn, $listOrder); ?>
 								</th>
-								<th scope="col" style="width:10%" class="text-right hidden-sm-down">
+								<th scope="col" style="width:1%" class="hidden-sm-down">
 									<?php echo HTMLHelper::_('searchtools.sort', 'COM_WORKFLOW_ID', 's.id', $listDirn, $listOrder); ?>
 								</th>
 							</tr>
@@ -114,7 +114,7 @@ if ($saveOrder)
 											<?php echo HTMLHelper::_('jgrid.published', $item->published, $i, 'stages.', $canChange); ?>
 										</div>
 									</td>
-									<td class="text-center hidden-sm-down">
+									<td class="text-center">
 										<?php echo HTMLHelper::_('jgrid.isdefault', $item->default, $i, 'stages.', $canChange); ?>
 									</td>
 									<th scope="row">


### PR DESCRIPTION
### Summary of Changes
Add icons to conditions - similiar to https://github.com/joomla/joomla-cms/pull/22315

![stages-after](https://user-images.githubusercontent.com/1035262/45917863-33433780-be7e-11e8-93e4-3872d20b9713.PNG)


Note: This is pure decoration, therefore the icons are hidden for screenreaders (aria-hidden="true") and do not need information sr-only.

### Testing Instructions
Compare an overview of workflow stages before and after patch

### Expected result
Every condition has it's respective icon.

### Actual result
Conditions are only text.

### Documentation Changes Required
lyout has changed
