### PR TITLE
[4.0] Improve DebugBar: view history, allow debug POST and non HTML requests, replace json storage to own

### DIFF
--- a/plugins/system/debug/Storage/FileStorage.php
+++ b/plugins/system/debug/Storage/FileStorage.php
@@ -68,10 +68,10 @@ class FileStorage extends \DebugBar\Storage\FileStorage
 	 *
 	 * @since __DEPLOY_VERSION__
 	 */
-	public function find(array $filters = array(), $max = 20, $offset = 0)
+	public function find(array $filters = [], $max = 20, $offset = 0)
 	{
 		// Loop through all .php files and remember the modified time and id.
-		$files = array();
+		$files = [];
 		foreach (new \DirectoryIterator($this->dirname) as $file)
 		{
 			if ($file->getExtension() == 'php')
@@ -92,7 +92,7 @@ class FileStorage extends \DebugBar\Storage\FileStorage
 		);
 
 		// Load the metadata and filter the results.
-		$results = array();
+		$results = [];
 		$i = 0;
 		foreach ($files as $file)
 		{

--- a/plugins/system/debug/Storage/FileStorage.php
+++ b/plugins/system/debug/Storage/FileStorage.php
@@ -21,8 +21,8 @@ class FileStorage extends \DebugBar\Storage\FileStorage
 	/**
 	 * Saves collected data
 	 *
-	 * @param   string  $id
-	 * @param   string  $data
+	 * @param   string  $id    The log id
+	 * @param   string  $data  The log data
 	 *
 	 * @return  void
 	 *
@@ -43,7 +43,7 @@ class FileStorage extends \DebugBar\Storage\FileStorage
 	/**
 	 * Returns collected data with the specified id
 	 *
-	 * @param   string   $id
+	 * @param   string   $id  The log id
 	 *
 	 * @return  array
 	 *
@@ -60,9 +60,9 @@ class FileStorage extends \DebugBar\Storage\FileStorage
 	/**
 	 * Returns a metadata about collected data
 	 *
-	 * @param   array    $filters
-	 * @param   integer  $max
-	 * @param   integer  $offset
+	 * @param   array    $filters  Filtering options
+	 * @param   integer  $max      The limit, items per page
+	 * @param   integer  $offset   The offset
 	 *
 	 * @return  array
 	 *
@@ -84,9 +84,12 @@ class FileStorage extends \DebugBar\Storage\FileStorage
 		}
 
 		// Sort the files, newest first
-		usort($files, function ($a, $b) {
-			return $a['time'] < $b['time'];
-		});
+		usort(
+			$files,
+			function ($a, $b) {
+				return $a['time'] < $b['time'];
+			}
+		);
 
 		// Load the metadata and filter the results.
 		$results = array();
@@ -118,9 +121,10 @@ class FileStorage extends \DebugBar\Storage\FileStorage
 		return array_slice($results, $offset, $max);
 	}
 
-
 	/**
-	 * @param  string $id
+	 * Get a full path to the file
+	 *
+	 * @param   string $id  The log id
 	 *
 	 * @return string
 	 *
@@ -128,6 +132,6 @@ class FileStorage extends \DebugBar\Storage\FileStorage
 	 */
 	public function makeFilename($id)
 	{
-		return $this->dirname . basename($id). '.php';
+		return $this->dirname . basename($id) . '.php';
 	}
 }

--- a/plugins/system/debug/Storage/FileStorage.php
+++ b/plugins/system/debug/Storage/FileStorage.php
@@ -43,7 +43,7 @@ class FileStorage extends \DebugBar\Storage\FileStorage
 	/**
 	 * Returns collected data with the specified id
 	 *
-	 * @param   string   $id  The log id
+	 * @param   string  $id  The log id
 	 *
 	 * @return  array
 	 *
@@ -124,7 +124,7 @@ class FileStorage extends \DebugBar\Storage\FileStorage
 	/**
 	 * Get a full path to the file
 	 *
-	 * @param   string $id  The log id
+	 * @param   string  $id  The log id
 	 *
 	 * @return string
 	 *

--- a/plugins/system/debug/Storage/FileStorage.php
+++ b/plugins/system/debug/Storage/FileStorage.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * @package     Joomla.Plugin
+ * @subpackage  System.Debug
+ *
+ * @copyright   Copyright (C) 2017 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\Plugin\System\Debug\Storage;
+
+/**
+ * Stores collected data into files
+ *
+ * @since __DEPLOY_VERSION__
+ */
+class FileStorage extends \DebugBar\Storage\FileStorage
+{
+	/**
+	 * {@inheritdoc}
+	 *
+	 * @since __DEPLOY_VERSION__
+	 */
+	public function save($id, $data)
+	{
+		if (!file_exists($this->dirname)) {
+			mkdir($this->dirname, 0777, true);
+		}
+
+		$dataStr = '<?php die(); ?>#x#' . json_encode($data);
+
+		file_put_contents($this->makeFilename($id), $dataStr);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 *
+	 * @since __DEPLOY_VERSION__
+	 */
+	public function get($id)
+	{
+		$dataStr = file_get_contents($this->makeFilename($id));
+		$dataStr = str_replace('<?php die("Access Denied"); ?>#x#', '', $dataStr);
+
+		return json_decode($dataStr, true);
+	}
+
+
+	/**
+	 * @param  string $id
+	 *
+	 * @return string
+	 *
+	 * @since __DEPLOY_VERSION__
+	 */
+	public function makeFilename($id)
+	{
+		return $this->dirname . basename($id). '.php';
+	}
+}

--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -287,14 +287,6 @@ class PlgSystemDebug extends CMSPlugin
 			return;
 		}
 
-		if ('com_content' === $this->app->input->get('option') && 'debug' === $this->app->input->get('view'))
-		{
-			$this->debugBar->stackData();
-
-			// Com_content debug view - @since 4.0
-			return;
-		}
-
 		// Capture output.
 		$contents = ob_get_contents();
 

--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -13,7 +13,6 @@ use DebugBar\DataCollector\MemoryCollector;
 use DebugBar\DataCollector\MessagesCollector;
 use DebugBar\DataCollector\RequestDataCollector;
 use DebugBar\DebugBar;
-use DebugBar\Storage\FileStorage;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Log\Log;
 use Joomla\CMS\Log\LogEntry;
@@ -30,6 +29,7 @@ use Joomla\Plugin\System\Debug\DataCollector\SessionCollector;
 use Joomla\Plugin\System\Debug\DebugMonitor;
 use Joomla\Database\DatabaseDriver;
 use Joomla\Database\Event\ConnectionEvent;
+use Joomla\Plugin\System\Debug\Storage\FileStorage;
 
 /**
  * Joomla! Debug plugin.
@@ -160,8 +160,10 @@ class PlgSystemDebug extends CMSPlugin
 
 		$this->db->setMonitor($this->queryMonitor);
 
+		$storagePath = JPATH_CACHE . '/plg_system_debug_' . $this->app->getClientId();
+
 		$this->debugBar = new DebugBar;
-		$this->debugBar->setStorage(new FileStorage($this->app->get('tmp_path')));
+		$this->debugBar->setStorage(new FileStorage($storagePath));
 
 		$this->setupLogging();
 	}

--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -19,6 +19,7 @@ use Joomla\CMS\Log\Log;
 use Joomla\CMS\Log\LogEntry;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Plugin\CMSPlugin;
+use Joomla\CMS\Session\Session;
 use Joomla\Event\DispatcherInterface;
 use Joomla\Plugin\System\Debug\DataCollector\InfoCollector;
 use Joomla\Plugin\System\Debug\DataCollector\LanguageErrorsCollector;
@@ -274,6 +275,8 @@ class PlgSystemDebug extends CMSPlugin
 
 		$debugBarRenderer = $this->debugBar->getJavascriptRenderer();
 		$openHandlerUrl   = JUri::base(true) . '/index.php?option=com_ajax&plugin=debug&group=system&format=raw&action=openhandler';
+		$openHandlerUrl  .= '&' . Session::getFormToken() . '=1';
+
 		$debugBarRenderer->setOpenHandlerUrl($openHandlerUrl);
 		$debugBarRenderer->setBaseUrl(JUri::root(true) . '/media/vendor/debugbar/');
 
@@ -332,7 +335,7 @@ class PlgSystemDebug extends CMSPlugin
 		}
 
 		// User has to be authorised to see the debug information.
-		if (!$this->isAuthorisedDisplayDebug())
+		if (!$this->isAuthorisedDisplayDebug() || !Session::checkToken('request'))
 		{
 			return '';
 		}


### PR DESCRIPTION
### Summary of Changes

The patch add possibility to view a Debug log, by use of DebugBar\OpenHandler.
It allows to debug POST (when #20677 will be merged to 4.0-dev) and non HTML request., and view of debug history.

Also I have changed default '.json' storage to '.php', wich is more secure.

### Testing Instructions
Apply path, enable debug. Visit a couple pages on a site.
Open debug bar, you should be able to see a little folder icon.

![screen 2018-09-22 21 27 13 450x94](https://user-images.githubusercontent.com/1568198/45920552-5be32580-beae-11e8-9018-e588b480c4ba.png)

Click on that folder and you will see Debug history per page.
![screen 2018-09-22 21 28 46 691x275](https://user-images.githubusercontent.com/1568198/45920564-9482ff00-beae-11e8-8411-bc5009d058d2.png)

Ping @elkuku 
Reference to DebugBar pr #20380


