### PR TITLE
Fix subform.repeatable-table small screen padding

### DIFF
--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -7553,7 +7553,7 @@ textarea.noResize {
 .subform-table-layout table .btn-group {
 	margin: 0 7px;
 }
-@media (max-width: 1024px) {
+@media (max-width: 1199px) {
 	.subform-table-layout .subform-repeatable {
 		padding-right: 0;
 	}
@@ -7592,7 +7592,7 @@ textarea.noResize {
 	.subform-table-layout td {
 		border: none;
 		position: relative;
-		padding-left: 50%;
+		padding-left: 15px;
 	}
 	.subform-table-layout tbody td:first-of-type {
 		padding-top: 15px;

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -7553,7 +7553,7 @@ textarea.noResize {
 .subform-table-layout table .btn-group {
 	margin: 0 7px;
 }
-@media (max-width: 1024px) {
+@media (max-width: 1199px) {
 	.subform-table-layout .subform-repeatable {
 		padding-right: 0;
 	}
@@ -7592,7 +7592,7 @@ textarea.noResize {
 	.subform-table-layout td {
 		border: none;
 		position: relative;
-		padding-left: 50%;
+		padding-left: 15px;
 	}
 	.subform-table-layout tbody td:first-of-type {
 		padding-top: 15px;

--- a/administrator/templates/isis/less/blocks/_forms.less
+++ b/administrator/templates/isis/less/blocks/_forms.less
@@ -273,7 +273,7 @@ textarea.noResize {
 		margin: 0 7px;
 	}
 }
-@media (max-width: 1024px) {
+@media (max-width: @xl-max) {
 	.subform-table-layout {
 		.subform-repeatable {
 			padding-right: 0;
@@ -311,7 +311,7 @@ textarea.noResize {
 		td {
 			border: none;
 			position: relative;
-			padding-left: 50%;
+			padding-left: 15px;
 		}
 		tbody {
 			td:first-of-type {


### PR DESCRIPTION
Pull Request for Issue #20210 .

### Summary of Changes
Fix subform.repeatable-table small screen padding


### Testing Instructions
Add the following after https://github.com/joomla/joomla-cms/blob/staging/modules/mod_login/mod_login.xml#L26

Open login module settings. Check repeatable field styling on reduced browser width.

```
<field name="sebform1" type="subform" label="subform"
	layout="joomla.form.field.subform.repeatable-table" multiple="true" groupByFieldset="true">
	<form>
		<fieldset name="group1" label="group 1">
			<field type="text" name="text" label="text 1"/>
			<field type="text" name="text2" label="text 2"/>
			<field type="text" name="text3" label="text 3"/>
		</fieldset>
		<fieldset name="group2" label="group 2">
			<field type="text" name="text4" label="text 4"/>
			<field type="textarea" name="textarea" label="textarea"/>
		</fieldset>
	</form>
</field>
```


### Before
![image](https://user-images.githubusercontent.com/2803503/45926482-54596600-bf1a-11e8-9c5d-8e2b627135ef.png)



### After
![image](https://user-images.githubusercontent.com/2803503/45926488-63401880-bf1a-11e8-9547-b4b591886d3b.png)



### Documentation Changes Required

