### PR TITLE
[4.0] Fix multiple Editor instances

### DIFF
--- a/libraries/src/Editor/Editor.php
+++ b/libraries/src/Editor/Editor.php
@@ -18,7 +18,6 @@ use Joomla\Event\AbstractEvent;
 use Joomla\Event\DispatcherAwareInterface;
 use Joomla\Event\DispatcherAwareTrait;
 use Joomla\Event\DispatcherInterface;
-use Joomla\Event\Event;
 use Joomla\Registry\Registry;
 
 /**
@@ -141,9 +140,10 @@ class Editor implements DispatcherAwareInterface
 			return;
 		}
 
-		$event = new Event('onInit');
-
-		$this->getDispatcher()->dispatch('onInit', $event);
+		if (method_exists($this->_editor, 'onInit'))
+		{
+			call_user_func(array($this->_editor, 'onInit'));
+		}
 	}
 
 	/**
@@ -198,17 +198,7 @@ class Editor implements DispatcherAwareInterface
 		$args['author'] = $author;
 		$args['params'] = $params;
 
-		$event = new Event('onDisplay', $args);
-
-		$results = $this->getDispatcher()->dispatch('onDisplay', $event);
-
-		foreach ($results['result'] as $result)
-		{
-			if (trim($result))
-			{
-				$return .= $result;
-			}
-		}
+		$return = call_user_func_array(array($this->_editor, 'onDisplay'), $args);
 
 		return $return;
 	}

--- a/libraries/src/Editor/Editor.php
+++ b/libraries/src/Editor/Editor.php
@@ -198,9 +198,7 @@ class Editor implements DispatcherAwareInterface
 		$args['author'] = $author;
 		$args['params'] = $params;
 
-		$return = call_user_func_array(array($this->_editor, 'onDisplay'), $args);
-
-		return $return;
+		return call_user_func_array(array($this->_editor, 'onDisplay'), $args);
 	}
 
 	/**


### PR DESCRIPTION
### Summary of Changes

Since an editors is a special plugins rendering through `$this->getDispatcher()->dispatch('onDisplay', $event);` leads to rendering of ALL loaded editors, instead of ONE.

I guess `onDisplay` should be called directly, per specific editor.


### Testing Instructions
in mod_custom XML, in params fieldset add fields with 2 different type of editor, eg:

```xml
<field name="editor1" type="editor" label="None" editor="none" />
<field name="editor2" type="editor" label="Default"/>
```


### Expected result
Should be rendered 2 editor:
Editor type None
TinyMCE editor 


### Actual result
Rendered 4 editors.
For a first field:
 - editor none with name `name="editor1"`
 - editor TinyMce with name `name="editor1"`

For a second field:
 - editor none with name `name="editor2"`
 - editor TinyMce with name `name="editor2"`


