### PR TITLE
The DisplayController of com_config is needed on J3

### DIFF
--- a/administrator/components/com_config/controller.php
+++ b/administrator/components/com_config/controller.php
@@ -13,14 +13,12 @@ defined('_JEXEC') or die;
  * Config Component Controller
  *
  * @since       1.5
- * @deprecated  4.0
  */
 class ConfigController extends JControllerLegacy
 {
 	/**
 	 * @var    string  The default view.
 	 * @since  1.6
-	 * @deprecated  4.0
 	 */
 	protected $default_view = 'application';
 
@@ -33,7 +31,6 @@ class ConfigController extends JControllerLegacy
 	 * @return  ConfigController  This object to support chaining.
 	 *
 	 * @since   1.5
-	 * @deprecated  4.0
 	 */
 	public function display($cachable = false, $urlparams = array())
 	{


### PR DESCRIPTION
The DisplayController class of com_config is needed in J4, so the deprecate message should be removed.

See #22298 for more details.