### PR TITLE
Create and apply 'dropdown-reverse' css class

### DIFF
--- a/administrator/components/com_menus/views/menus/tmpl/default.php
+++ b/administrator/components/com_menus/views/menus/tmpl/default.php
@@ -167,7 +167,7 @@ JFactory::getDocument()->addScriptDeclaration(implode("\n", $script));
 										<?php echo JText::_('COM_MENUS_MODULES'); ?>
 										<span class="caret"></span>
 									</a>
-									<ul class="dropdown-menu dropdown-left">
+									<ul class="dropdown-menu dropdown-reverse">
 										<?php foreach ($this->modules[$item->menutype] as &$module) : ?>
 											<li>
 												<?php if ($user->authorise('core.edit', 'com_modules.module.' . (int) $module->id)) : ?>

--- a/administrator/components/com_menus/views/menus/tmpl/default.php
+++ b/administrator/components/com_menus/views/menus/tmpl/default.php
@@ -167,7 +167,7 @@ JFactory::getDocument()->addScriptDeclaration(implode("\n", $script));
 										<?php echo JText::_('COM_MENUS_MODULES'); ?>
 										<span class="caret"></span>
 									</a>
-									<ul class="dropdown-menu">
+									<ul class="dropdown-menu dropdown-left">
 										<?php foreach ($this->modules[$item->menutype] as &$module) : ?>
 											<li>
 												<?php if ($user->authorise('core.edit', 'com_modules.module.' . (int) $module->id)) : ?>

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -8810,13 +8810,10 @@ ul.treeselect ul.dropdown-menu li {
 .pagination-toolbar a {
 	line-height: 26px;
 }
-.pull-right > .dropdown-menu {
-	left: auto;
-	right: 0;
-}
+.pull-right > .dropdown-menu,
 .dropdown-left {
-	right: 0;
 	left: auto;
+	right: 0;
 }
 .nav-filters hr {
 	margin: 5px 0;

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -8811,7 +8811,7 @@ ul.treeselect ul.dropdown-menu li {
 	line-height: 26px;
 }
 .pull-right > .dropdown-menu,
-.dropdown-left {
+.dropdown-reverse {
 	left: auto;
 	right: 0;
 }
@@ -10088,4 +10088,8 @@ a.grid_true {
 	box-shadow: 3px 0 0 #3071a9;
 	border-right: 0;
 	border-left: 1px solid rgba(0,0,0,0.08);
+}
+.dropdown-reverse {
+	left: 0;
+	right: auto;
 }

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -8814,6 +8814,10 @@ ul.treeselect ul.dropdown-menu li {
 	left: auto;
 	right: 0;
 }
+.dropdown-left {
+	right: 0;
+	left: auto;
+}
 .nav-filters hr {
 	margin: 5px 0;
 }

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -8811,7 +8811,7 @@ ul.treeselect ul.dropdown-menu li {
 	line-height: 26px;
 }
 .pull-right > .dropdown-menu,
-.dropdown-left {
+.dropdown-reverse {
 	left: auto;
 	right: 0;
 }

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -8810,13 +8810,10 @@ ul.treeselect ul.dropdown-menu li {
 .pagination-toolbar a {
 	line-height: 26px;
 }
-.pull-right > .dropdown-menu {
-	left: auto;
-	right: 0;
-}
+.pull-right > .dropdown-menu,
 .dropdown-left {
-	right: 0;
 	left: auto;
+	right: 0;
 }
 .nav-filters hr {
 	margin: 5px 0;

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -8814,6 +8814,10 @@ ul.treeselect ul.dropdown-menu li {
 	left: auto;
 	right: 0;
 }
+.dropdown-left {
+	right: 0;
+	left: auto;
+}
 .nav-filters hr {
 	margin: 5px 0;
 }

--- a/administrator/templates/isis/less/blocks/_custom.less
+++ b/administrator/templates/isis/less/blocks/_custom.less
@@ -21,15 +21,12 @@
 .pagination-toolbar a {
 	line-height: 26px;
 }
+
 /* Toolbar dropdown */
-.pull-right > .dropdown-menu {
+.pull-right > .dropdown-menu,
+.dropdown-left {
 	left: auto;
 	right: 0;
-}
-
-.dropdown-left {
-    right: 0;
-    left: auto;
 }
 
 /* Nav list filters */

--- a/administrator/templates/isis/less/blocks/_custom.less
+++ b/administrator/templates/isis/less/blocks/_custom.less
@@ -22,9 +22,9 @@
 	line-height: 26px;
 }
 
-/* Toolbar dropdown */
+/* Dropdown */
 .pull-right > .dropdown-menu,
-.dropdown-left {
+.dropdown-reverse {
 	left: auto;
 	right: 0;
 }

--- a/administrator/templates/isis/less/blocks/_custom.less
+++ b/administrator/templates/isis/less/blocks/_custom.less
@@ -27,6 +27,11 @@
 	right: 0;
 }
 
+.dropdown-left {
+    right: 0;
+    left: auto;
+}
+
 /* Nav list filters */
 .nav-filters hr {
 	margin: 5px 0;

--- a/administrator/templates/isis/less/template-rtl.less
+++ b/administrator/templates/isis/less/template-rtl.less
@@ -434,3 +434,9 @@ a.grid_true {
 		}
 	}
 }
+
+/* Dropdown */
+.dropdown-reverse {
+	left: 0;
+	right: auto;
+}


### PR DESCRIPTION
Pull Request for Issue #  .

### Summary of Changes
Creates a `dropdown-reverse` class to align dropdowns left instead of right. Applies this class to com-menus -> menus.

Simple class which will only work for one level of child items.

### Testing Instructions
Apply and navigate to Menu Manager


### Before
![image](https://user-images.githubusercontent.com/2803503/45941309-7bc13900-bfd5-11e8-80f8-eeeb882fbd2e.png)



### After
![image](https://user-images.githubusercontent.com/2803503/45941312-7e239300-bfd5-11e8-98f9-db863c5e6652.png)



### Documentation Changes Required

