### PR TITLE
[4.0] Fix jgrid.php to match correct parameters count

### DIFF
--- a/libraries/cms/html/jgrid.php
+++ b/libraries/cms/html/jgrid.php
@@ -390,7 +390,7 @@ abstract class JHtmlJGrid
 			$prefix = array_key_exists('prefix', $options) ? $options['prefix'] : '';
 		}
 
-		return static::action($i, $task, $prefix, $text, $text, $text, false, 'uparrow', 'uparrow_disabled', $enabled, true, $checkbox, $formId);
+		return static::action($i, $task, $prefix, $text, $text, false, 'uparrow', 'uparrow_disabled', $enabled, true, $checkbox, $formId);
 	}
 
 	/**
@@ -420,6 +420,6 @@ abstract class JHtmlJGrid
 			$prefix = array_key_exists('prefix', $options) ? $options['prefix'] : '';
 		}
 
-		return static::action($i, $task, $prefix, $text, $text, $text, false, 'downarrow', 'downarrow_disabled', $enabled, true, $checkbox, $formId);
+		return static::action($i, $task, $prefix, $text, $text, false, 'downarrow', 'downarrow_disabled', $enabled, true, $checkbox, $formId);
 	}
 }


### PR DESCRIPTION
### Summary of Changes
The $text parameter of the 'action' function in the class JHtmlGrid has been removed:
$text An optional text to display [unused - @deprecated 4.0]

however the functions orderUp and orderDown are still calling the 'action' function with the wrong parameter count.


### Expected result
All works as before when using orderUp and orderDown


### Actual result
The icons are not rendered because the parameters are mismatching


