### PR TITLE
[4.0] No need to double implement MVCFactoryServiceInterface

### DIFF
--- a/administrator/components/com_content/Extension/ContentComponent.php
+++ b/administrator/components/com_content/Extension/ContentComponent.php
@@ -37,8 +37,7 @@ use Joomla\CMS\Factory;
  * @since  __DEPLOY_VERSION__
  */
 class ContentComponent extends MVCComponent implements
-	BootableExtensionInterface, MVCFactoryServiceInterface, CategoryServiceInterface, FieldsServiceInterface,
-	AssociationServiceInterface, WorkflowServiceInterface
+	BootableExtensionInterface, CategoryServiceInterface, FieldsServiceInterface, AssociationServiceInterface, WorkflowServiceInterface
 {
 	use CategoryServiceTrait;
 	use AssociationServiceTrait;


### PR DESCRIPTION
The `MVCComponent` is already implementing the `MVCFactoryServiceInterface`, so there is no need to use the import statement in the `ContentComponent` class again.