### PR TITLE
[Isis] Use native display sticky on toolbar

### DIFF
--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -8601,7 +8601,7 @@ td.nowrap.has-context {
 	}
 }
 @media (min-width: 768px) {
-	.subhead-collapse {
+	.subhead-collapse.sticky {
 		position: static;
 		position: sticky;
 		top: 30px;

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -8602,6 +8602,7 @@ td.nowrap.has-context {
 }
 @media (min-width: 768px) {
 	.subhead-collapse {
+		position: static;
 		position: sticky;
 		top: 30px;
 	}

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -8561,15 +8561,20 @@ td.nowrap.has-context {
 	width: 45%;
 }
 .subhead {
-	position: sticky;
-	top: 30px;
 	background: #F0F0F0;
 	border-bottom: 1px solid #dedede;
 	color: #0C192E;
 	text-shadow: 0 1px 0 #FFF;
-	margin-bottom: 19px;
+	margin-bottom: 10px;
 	min-height: 51px;
+}
+.subhead-collapse {
+	margin-bottom: 18px;
 	z-index: 100;
+}
+.subhead-collapse.collapse {
+	height: auto;
+	overflow: visible;
 }
 .btn-toolbar {
 	margin-bottom: 5px;
@@ -8593,6 +8598,12 @@ td.nowrap.has-context {
 		margin-right: -20px;
 		padding-left: 10px;
 		padding-right: 10px;
+	}
+}
+@media (min-width: 768px) {
+	.subhead-collapse {
+		position: sticky;
+		top: 30px;
 	}
 }
 .subhead h1 {

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -6995,7 +6995,6 @@ html {
 	height: 100%;
 }
 body {
-	height: 100%;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
 	box-sizing: border-box;

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -8561,19 +8561,15 @@ td.nowrap.has-context {
 	width: 45%;
 }
 .subhead {
+	position: sticky;
+	top: 30px;
 	background: #F0F0F0;
 	border-bottom: 1px solid #dedede;
 	color: #0C192E;
 	text-shadow: 0 1px 0 #FFF;
-	margin-bottom: 10px;
-	min-height: 51px;
-}
-.subhead-collapse {
 	margin-bottom: 19px;
-}
-.subhead-collapse.collapse {
-	height: auto;
-	overflow: visible;
+	min-height: 51px;
+	z-index: 100;
 }
 .btn-toolbar {
 	margin-bottom: 5px;

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -8601,7 +8601,7 @@ td.nowrap.has-context {
 	}
 }
 @media (min-width: 768px) {
-	.subhead-collapse {
+	.subhead-collapse.sticky {
 		position: static;
 		position: sticky;
 		top: 30px;

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -8602,6 +8602,7 @@ td.nowrap.has-context {
 }
 @media (min-width: 768px) {
 	.subhead-collapse {
+		position: static;
 		position: sticky;
 		top: 30px;
 	}

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -8561,15 +8561,20 @@ td.nowrap.has-context {
 	width: 45%;
 }
 .subhead {
-	position: sticky;
-	top: 30px;
 	background: #F0F0F0;
 	border-bottom: 1px solid #dedede;
 	color: #0C192E;
 	text-shadow: 0 1px 0 #FFF;
-	margin-bottom: 19px;
+	margin-bottom: 10px;
 	min-height: 51px;
+}
+.subhead-collapse {
+	margin-bottom: 18px;
 	z-index: 100;
+}
+.subhead-collapse.collapse {
+	height: auto;
+	overflow: visible;
 }
 .btn-toolbar {
 	margin-bottom: 5px;
@@ -8593,6 +8598,12 @@ td.nowrap.has-context {
 		margin-right: -20px;
 		padding-left: 10px;
 		padding-right: 10px;
+	}
+}
+@media (min-width: 768px) {
+	.subhead-collapse {
+		position: sticky;
+		top: 30px;
 	}
 }
 .subhead h1 {

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -6995,7 +6995,6 @@ html {
 	height: 100%;
 }
 body {
-	height: 100%;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
 	box-sizing: border-box;

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -8561,19 +8561,15 @@ td.nowrap.has-context {
 	width: 45%;
 }
 .subhead {
+	position: sticky;
+	top: 30px;
 	background: #F0F0F0;
 	border-bottom: 1px solid #dedede;
 	color: #0C192E;
 	text-shadow: 0 1px 0 #FFF;
-	margin-bottom: 10px;
-	min-height: 51px;
-}
-.subhead-collapse {
 	margin-bottom: 19px;
-}
-.subhead-collapse.collapse {
-	height: auto;
-	overflow: visible;
+	min-height: 51px;
+	z-index: 100;
 }
 .btn-toolbar {
 	margin-bottom: 5px;

--- a/administrator/templates/isis/index.php
+++ b/administrator/templates/isis/index.php
@@ -265,14 +265,16 @@ if ($this->params->get('linkColor'))
 	<!-- Subheader -->
 	<a class="btn btn-subhead" data-toggle="collapse" data-target=".subhead-collapse"><?php echo JText::_('TPL_ISIS_TOOLBAR'); ?>
 		<span class="icon-wrench"></span></a>
-	<div class="subhead">
-		<div class="container-fluid">
-			<div id="container-collapse" class="container-collapse"></div>
-			<div class="row-fluid">
-				<div class="span12">
-					<!-- target for skip to content link -->
-					<a id="skiptarget" class="element-invisible"><?php echo JText::_('TPL_ISIS_SKIP_TO_MAIN_CONTENT_HERE'); ?></a>
-					<jdoc:include type="modules" name="toolbar" style="no" />
+	<div class="subhead-collapse collapse">
+		<div class="subhead">
+			<div class="container-fluid">
+				<div id="container-collapse" class="container-collapse"></div>
+				<div class="row-fluid">
+					<div class="span12">
+						<!-- target for skip to content link -->
+						<a id="skiptarget" class="element-invisible"><?php echo JText::_('TPL_ISIS_SKIP_TO_MAIN_CONTENT_HERE'); ?></a>
+						<jdoc:include type="modules" name="toolbar" style="no" />
+					</div>
 				</div>
 			</div>
 		</div>

--- a/administrator/templates/isis/index.php
+++ b/administrator/templates/isis/index.php
@@ -265,16 +265,14 @@ if ($this->params->get('linkColor'))
 	<!-- Subheader -->
 	<a class="btn btn-subhead" data-toggle="collapse" data-target=".subhead-collapse"><?php echo JText::_('TPL_ISIS_TOOLBAR'); ?>
 		<span class="icon-wrench"></span></a>
-	<div class="subhead-collapse collapse" id="isisJsData" data-tmpl-sticky="<?php echo $stickyBar; ?>" data-tmpl-offset="<?php echo $offset; ?>">
-		<div class="subhead">
-			<div class="container-fluid">
-				<div id="container-collapse" class="container-collapse"></div>
-				<div class="row-fluid">
-					<div class="span12">
-						<!-- target for skip to content link -->
-						<a id="skiptarget" class="element-invisible"><?php echo JText::_('TPL_ISIS_SKIP_TO_MAIN_CONTENT_HERE'); ?></a>
-						<jdoc:include type="modules" name="toolbar" style="no" />
-					</div>
+	<div class="subhead">
+		<div class="container-fluid">
+			<div id="container-collapse" class="container-collapse"></div>
+			<div class="row-fluid">
+				<div class="span12">
+					<!-- target for skip to content link -->
+					<a id="skiptarget" class="element-invisible"><?php echo JText::_('TPL_ISIS_SKIP_TO_MAIN_CONTENT_HERE'); ?></a>
+					<jdoc:include type="modules" name="toolbar" style="no" />
 				</div>
 			</div>
 		</div>

--- a/administrator/templates/isis/index.php
+++ b/administrator/templates/isis/index.php
@@ -116,11 +116,11 @@ if ($displayHeader || !$statusFixed)
 	$offset = 30;
 }
 
-$stickyBar = 0;
+$stickyBar = '';
 
 if ($stickyToolbar)
 {
-	$stickyBar = 'true';
+	$stickyBar = ' sticky';
 }
 
 // Template color
@@ -265,7 +265,7 @@ if ($this->params->get('linkColor'))
 	<!-- Subheader -->
 	<a class="btn btn-subhead" data-toggle="collapse" data-target=".subhead-collapse"><?php echo JText::_('TPL_ISIS_TOOLBAR'); ?>
 		<span class="icon-wrench"></span></a>
-	<div class="subhead-collapse collapse">
+	<div class="subhead-collapse collapse<?php echo $stickyBar; ?>">
 		<div class="subhead">
 			<div class="container-fluid">
 				<div id="container-collapse" class="container-collapse"></div>

--- a/administrator/templates/isis/index.php
+++ b/administrator/templates/isis/index.php
@@ -108,14 +108,7 @@ function colorIsLight($color)
 	return $yiq >= 200;
 }
 
-// Pass some values to javascript
-$offset = 20;
-
-if ($displayHeader || !$statusFixed)
-{
-	$offset = 30;
-}
-
+// Sticky toolbar
 $stickyBar = '';
 
 if ($stickyToolbar)

--- a/administrator/templates/isis/index.php
+++ b/administrator/templates/isis/index.php
@@ -109,12 +109,7 @@ function colorIsLight($color)
 }
 
 // Sticky toolbar
-$stickyBar = '';
-
-if ($stickyToolbar)
-{
-	$stickyBar = ' sticky';
-}
+$stickyBar = $stickyToolbar ? ' sticky' : '';
 
 // Template color
 if ($navbar_color)

--- a/administrator/templates/isis/js/template.js
+++ b/administrator/templates/isis/js/template.js
@@ -215,51 +215,6 @@ jQuery(function($)
 	}
 
 	/**
-	 * USED IN: All views with toolbar and sticky bar enabled
-	 */
-	var navTop;
-	var isFixed = false;
-
-	if (document.getElementById('isisJsData') && document.getElementById('isisJsData').getAttribute('data-tmpl-sticky') == "true") {
-		processScrollInit();
-		processScroll();
-
-		$(window).on('resize', processScrollInit);
-		$(window).on('scroll', processScroll);
-	}
-
-	function processScrollInit() {
-		if ($('.subhead').length) {
-			navTop = $('.subhead').length && $('.subhead').offset().top - parseInt(document.getElementById('isisJsData').getAttribute('data-tmpl-offset'));
-
-			// Fix the container top
-			$(".container-main").css("top", $('.subhead').height() + $('nav.navbar').height());
-
-			// Only apply the scrollspy when the toolbar is not collapsed
-			if (document.body.clientWidth > 480) {
-				$('.subhead-collapse').height($('.subhead').height());
-				$('.subhead').scrollspy({offset: {top: $('.subhead').offset().top - $('nav.navbar').height()}});
-			}
-		}
-	}
-
-	function processScroll() {
-		if ($('.subhead').length) {
-			var scrollTop = $(window).scrollTop();
-			if (scrollTop >= navTop && !isFixed) {
-				isFixed = true;
-				$('.subhead').addClass('subhead-fixed');
-
-				// Fix the container top
-				$(".container-main").css("top", $('.subhead').height() + $('nav.navbar').height());
-			} else if (scrollTop <= navTop && isFixed) {
-				isFixed = false;
-				$('.subhead').removeClass('subhead-fixed');
-			}
-		}
-	}
-
-	/**
 	 * USED IN: All list views to hide/show the sidebar
 	 */
 	window.toggleSidebar = function(force)

--- a/administrator/templates/isis/less/blocks/_global.less
+++ b/administrator/templates/isis/less/blocks/_global.less
@@ -6,7 +6,6 @@ html {
 }
 
 body {
-	height: 100%;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
 	box-sizing: border-box;

--- a/administrator/templates/isis/less/blocks/_toolbar.less
+++ b/administrator/templates/isis/less/blocks/_toolbar.less
@@ -47,7 +47,7 @@
 	}
 }
 @media (min-width: @md) { 
-	.subhead-collapse {
+	.subhead-collapse.sticky {
 		position: static;
 		position: sticky;
 		top: 30px;

--- a/administrator/templates/isis/less/blocks/_toolbar.less
+++ b/administrator/templates/isis/less/blocks/_toolbar.less
@@ -48,6 +48,7 @@
 }
 @media (min-width: @md) { 
 	.subhead-collapse {
+		position: static;
 		position: sticky;
 		top: 30px;
 	}

--- a/administrator/templates/isis/less/blocks/_toolbar.less
+++ b/administrator/templates/isis/less/blocks/_toolbar.less
@@ -2,21 +2,15 @@
 
 /* Subhead */
 .subhead {
+	position: sticky;
+	top: 30px;
 	background: @wellBackground;
 	border-bottom: 1px solid darken(@wellBackground, 7%);
 	color: #0C192E;
 	text-shadow: 0 1px 0 #FFF;
-	margin-bottom: 10px;
-	min-height: 51px;
-}
-
-.subhead-collapse {
 	margin-bottom: 19px;
-}
-
-.subhead-collapse.collapse {
-	height: auto;
-	overflow: visible;
+	min-height: 51px;
+	z-index: 100;
 }
 
 .btn-toolbar {

--- a/administrator/templates/isis/less/blocks/_toolbar.less
+++ b/administrator/templates/isis/less/blocks/_toolbar.less
@@ -2,15 +2,22 @@
 
 /* Subhead */
 .subhead {
-	position: sticky;
-	top: 30px;
 	background: @wellBackground;
 	border-bottom: 1px solid darken(@wellBackground, 7%);
 	color: #0C192E;
 	text-shadow: 0 1px 0 #FFF;
-	margin-bottom: 19px;
+	margin-bottom: 10px;
 	min-height: 51px;
+}
+
+.subhead-collapse {
+	margin-bottom: 18px;
 	z-index: 100;
+}
+
+.subhead-collapse.collapse {
+	height: auto;
+	overflow: visible;
 }
 
 .btn-toolbar {
@@ -37,6 +44,12 @@
 		margin-right: -20px;
 		padding-left: 10px;
 		padding-right: 10px;
+	}
+}
+@media (min-width: @md) { 
+	.subhead-collapse {
+		position: sticky;
+		top: 30px;
 	}
 }
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Removes the sticky JS for the toolbar. Use native display sticky instead. The advantage is less/simpler code. The downside is the toolbar no longer sticks on browsers that dont support it (IE11).
 
### Testing Instructions
Apply PR and check toolbar displays and sticks correctly.


