### PR TITLE
Remove title attribute / cs

### DIFF
--- a/administrator/modules/mod_stats_admin/tmpl/default.php
+++ b/administrator/modules/mod_stats_admin/tmpl/default.php
@@ -30,10 +30,10 @@ JFactory::getDocument()->addScriptDeclaration('
 	<?php foreach ($list as $item) : ?>
 		<div class="row-fluid">
 			<div class="span4">
-				<span class="icon-<?php echo $item->icon; ?>" title="<?php echo $item->title; ?>" aria-hidden="true"></span> <?php echo $item->title . ' '; ?>
+				<span class="icon-<?php echo $item->icon; ?>" aria-hidden="true"></span> <?php echo $item->title; ?>
 			</div>
 			<div class="span8">
-				<?php if(isset($item->link)) : ?>
+				<?php if (isset($item->link)) : ?>
 					<a class="btn btn-info btn-small js-revert" href="<?php echo $item->link; ?>"><?php echo $item->data; ?></a>
 				<?php else : ?>
 					<?php echo $item->data; ?>


### PR DESCRIPTION
### Summary of Changes
In Statistics box, the title attribute of the icon is the same as the text next to it which adds no additional information. This PR removes it.


### Testing Instructions
Log in to the backend.
In the Statistics box, move cursor over an icon.


### Expected result
No tooltip


### Actual result
Tooltip displays the same as the text.


### Documentation Changes Required
None
