### PR TITLE
Allow for more fluid .modal-body class

### DIFF
--- a/administrator/templates/hathor/css/template.css
+++ b/administrator/templates/hathor/css/template.css
@@ -118,7 +118,6 @@ div.modal.fade.in {
 }
 .modal-body {
 	overflow-y: auto;
-	max-height: 400px;
 	padding: 15px;
 }
 .modal-form {

--- a/administrator/templates/hathor/less/modals.less
+++ b/administrator/templates/hathor/less/modals.less
@@ -62,7 +62,6 @@ div.modal {
 // Body (where all modal content resides)
 .modal-body {
   overflow-y: auto;
-  max-height: 400px;
   padding: 15px;
 }
 // Remove bottom margin if need be

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -3775,7 +3775,6 @@ input[type="submit"].btn.btn-mini {
 .modal-body {
 	width: 98%;
 	position: relative;
-	max-height: 400px;
 	padding: 1%;
 }
 .modal-body iframe {

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -3775,7 +3775,6 @@ input[type="submit"].btn.btn-mini {
 .modal-body {
 	width: 98%;
 	position: relative;
-	max-height: 400px;
 	padding: 1%;
 }
 .modal-body iframe {

--- a/media/jui/css/bootstrap.css
+++ b/media/jui/css/bootstrap.css
@@ -5206,7 +5206,6 @@ input[type="submit"].btn.btn-mini {
 
 .modal-body {
   position: relative;
-  max-height: 400px;
   padding: 15px;
   overflow-y: auto;
 }

--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -3965,7 +3965,6 @@ input[type="submit"].btn.btn-mini {
 .modal-body {
 	width: 98%;
 	position: relative;
-	max-height: 400px;
 	padding: 1%;
 }
 .modal-body iframe {


### PR DESCRIPTION
Pull Request for Issue #22332 

### Summary of Changes
removed max-height limits for .modal-body content.

### Testing Instructions
go to template manager and click on beez 3 template preview image.
Using the element inspector change height of the image to 500px;
Contents will overflow...
![image](https://user-images.githubusercontent.com/1850089/46043132-c8436c00-c0dc-11e8-991b-6724f8471419.png)

### Expected result
now modal resizes to keep contents visible.
![image](https://user-images.githubusercontent.com/1850089/46043144-d2656a80-c0dc-11e8-80e9-b81cf8b456a1.png)

### Actual result
![image](https://user-images.githubusercontent.com/1850089/46043151-dbeed280-c0dc-11e8-994e-eea8e3ff35be.png)


### Documentation Changes Required
ios js fix for max-height may need to be adjusted as well.
