### PR TITLE
[isis] Template menu assign - 4 columns on lg screen

### DIFF
--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -9109,25 +9109,32 @@ input:focus,
 #menu-assignment .menu-links {
 	margin-top: 15px;
 	margin-left: 0;
-	-webkit-column-count: 3;
-	-moz-column-count: 3;
-	column-count: 3;
+	-webkit-column-count: 4;
+	-moz-column-count: 4;
+	column-count: 4;
 	-moz-column-gap: 15px;
 	-webkit-column-gap: 15px;
 	column-gap: 15px;
 }
 #menu-assignment .menu-links > li {
-	display: inline-block;
 	vertical-align: top;
 	margin-bottom: 15px;
 	width: 100%;
 	list-style: none;
+	page-break-inside: avoid;
 }
 #menu-assignment .menu-links-block {
 	background-color: #fafafa;
 	border: 1px solid #ddd;
 	border-radius: 3px;
 	padding: 15px;
+}
+@media (max-width: 1199px) {
+	#menu-assignment .menu-links {
+		-webkit-column-count: 3;
+		-moz-column-count: 3;
+		column-count: 3;
+	}
 }
 @media (max-width: 767px) {
 	#menu-assignment .menu-links {

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -9109,25 +9109,32 @@ input:focus,
 #menu-assignment .menu-links {
 	margin-top: 15px;
 	margin-left: 0;
-	-webkit-column-count: 3;
-	-moz-column-count: 3;
-	column-count: 3;
+	-webkit-column-count: 4;
+	-moz-column-count: 4;
+	column-count: 4;
 	-moz-column-gap: 15px;
 	-webkit-column-gap: 15px;
 	column-gap: 15px;
 }
 #menu-assignment .menu-links > li {
-	display: inline-block;
 	vertical-align: top;
 	margin-bottom: 15px;
 	width: 100%;
 	list-style: none;
+	page-break-inside: avoid;
 }
 #menu-assignment .menu-links-block {
 	background-color: #fafafa;
 	border: 1px solid #ddd;
 	border-radius: 3px;
 	padding: 15px;
+}
+@media (max-width: 1199px) {
+	#menu-assignment .menu-links {
+		-webkit-column-count: 3;
+		-moz-column-count: 3;
+		column-count: 3;
+	}
 }
 @media (max-width: 767px) {
 	#menu-assignment .menu-links {

--- a/administrator/templates/isis/less/pages/_com_templates.less
+++ b/administrator/templates/isis/less/pages/_com_templates.less
@@ -5,18 +5,18 @@
 	.menu-links {
 		margin-top: 15px;
 		margin-left: 0;
-		-webkit-column-count: 3;
-		-moz-column-count: 3;
-		column-count: 3;
+		-webkit-column-count: 4;
+		-moz-column-count: 4;
+		column-count: 4;
 		-moz-column-gap: 15px;
 		-webkit-column-gap: 15px;
 		column-gap: 15px;
 		> li {
-			display: inline-block;
 			vertical-align: top;
 			margin-bottom: 15px;
 			width: 100%;
 			list-style: none;
+			page-break-inside: avoid;
 		}
 	}
 	.menu-links-block {
@@ -24,6 +24,13 @@
 	    border: 1px solid #ddd;
 	    border-radius: 3px;
 	    padding: 15px;
+	}
+}
+@media (max-width: @xl-max) {
+	#menu-assignment .menu-links {
+		-webkit-column-count: 3;
+		-moz-column-count: 3;
+		column-count: 3;
 	}
 }
 @media (max-width: @md-max) {


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Changes template menu assignment to 4 columns (originally 3) on larger screens

### Testing Instructions
Apply PR. Navigate to Extensions -> Templates -> Protostar -> Menu Assignment

![image](https://user-images.githubusercontent.com/2803503/46069003-69c8cd00-c172-11e8-9147-74b5587705c0.png)
