### PR TITLE
Manual selection of tags in module Tags Popular

### DIFF
--- a/modules/mod_tags_popular/mod_tags_popular.xml
+++ b/modules/mod_tags_popular/mod_tags_popular.xml
@@ -67,6 +67,7 @@
 					>
 					<option value="title">MOD_TAGS_POPULAR_FIELD_ORDER_VALUE_TITLE</option>
 					<option value="count">MOD_TAGS_POPULAR_FIELD_ORDER_VALUE_COUNT</option>
+					<option value="lft">JGLOBAL_FIELD_FIELD_ORDERING_LABEL</option>
 					<option value="rand()">MOD_TAGS_POPULAR_FIELD_ORDER_VALUE_RANDOM</option>
 				</field>
 


### PR DESCRIPTION
In mod_tags_popular.xml I added an extra option to the parameter field order_value. If this option is selected, the module shows the tags in the order as set manually in the Tags component. This can be combined with setting the maximum number of tags in order to create your custom selection (up to the overall maximum of 20). The idea for this functionality comes from a request from a site owner (one of my customers).

Please note that in this case the module does not take into account the "popularity" of the tag. This is exactly as I intended but it may conflict with the idea of the module: showing popular tags. However, the Random option of the module doesn't take that into account either (as a matter of fact, when selecting my cusom option the execution of the module script follows the same 'logical path' through the code as when selecting the Random option).

It might be a good idea to add some instruction about this. Apart from that, I think this offers some nice extra fuctionality and I was surprised at how easy it was to add this.

Please note this is the first pull request I made. If I did something wrong, please tell me.

Pull Request for Issue # .

### Summary of Changes
New feature: added an extra option to the Order parameter of the Tags - popular module: manual ordering


### Testing Instructions
- create a module of the type Tags - popular and make sure that is is displayed in the front end.
- the drop-down select box for the parameter Order should now have one extra option: Ordering. 
- set the Order parameter to Ordering and the Maximum number of Tags to  20.
- in Components > Tags, create more than one tag, then check in which order they are displayed by the module in the front end.
- in Components > Tags, manually change the  order of the tags (click the icon on top of the left hand column Ordering, then drag the tags up or down the list) and in the front end, check how the new order of the tags is reflected in the module.

### Expected result
In the module you should see the tags in the order as manually set. The display is still limited to the number as set in the Maximum tags parameter, so you will be able to manually select the tags to be displayed up to 20 tags and these tags should be in the first 20 positions of the tags list.

### Actual result
This is a new feat so there is no actual result.


### Documentation Changes Required
This does not take into account the "popularity" of the tag. That is exactly as I intended but it may conflict with the idea of the module: showing popular tags, so it may confuse the users. 

However, the Random option of the module doesn't take that into account either (as a matter of fact, when selecting my cusom option the execution of the module script follows the same 'logical path' through the code as when selecting the Random option).

Maybe it would be a good idea to add a comment about this to the parameter description?