### PR TITLE
Deprecates the filesystem wrapper classes

### DIFF
--- a/libraries/src/Filesystem/Wrapper/FileWrapper.php
+++ b/libraries/src/Filesystem/Wrapper/FileWrapper.php
@@ -18,6 +18,7 @@ defined('JPATH_PLATFORM') or die;
  * @package     Joomla.Platform
  * @subpackage  Filesystem
  * @since       3.4
+ * @deprecated  4.0 Will be removed without replacement
  */
 class FileWrapper
 {
@@ -28,8 +29,9 @@ class FileWrapper
 	 *
 	 * @return  string  The file extension.
 	 *
-	 * @see     File::getExt()
-	 * @since   3.4
+	 * @see         File::getExt()
+	 * @since       3.4
+	 * @deprecated  4.0 Will be removed without replacement
 	 */
 	public function getExt($file)
 	{
@@ -43,8 +45,9 @@ class FileWrapper
 	 *
 	 * @return  string  The file name without the extension.
 	 *
-	 * @see     File::stripExt()
-	 * @since   3.4
+	 * @see         File::stripExt()
+	 * @since       3.4
+	 * @deprecated  4.0 Will be removed without replacement
 	 */
 	public function stripExt($file)
 	{
@@ -58,8 +61,9 @@ class FileWrapper
 	 *
 	 * @return  string  The sanitised string.
 	 *
-	 * @see     File::makeSafe()
-	 * @since   3.4
+	 * @see         File::makeSafe()
+	 * @since       3.4
+	 * @deprecated  4.0 Will be removed without replacement
 	 */
 	public function makeSafe($file)
 	{
@@ -76,8 +80,9 @@ class FileWrapper
 	 *
 	 * @return  boolean  True on success.
 	 *
-	 * @see     File::copy()
-	 * @since   3.4
+	 * @see         File::copy()
+	 * @since       3.4
+	 * @deprecated  4.0 Will be removed without replacement
 	 */
 	public function copy($src, $dest, $path = null, $use_streams = false)
 	{
@@ -91,8 +96,9 @@ class FileWrapper
 	 *
 	 * @return  boolean  True on success.
 	 *
-	 * @see     File::delete()
-	 * @since   3.4
+	 * @see         File::delete()
+	 * @since       3.4
+	 * @deprecated  4.0 Will be removed without replacement
 	 */
 	public function delete($file)
 	{
@@ -109,8 +115,9 @@ class FileWrapper
 	 *
 	 * @return  boolean  True on success.
 	 *
-	 * @see     File::move()
-	 * @since   3.4
+	 * @see         File::move()
+	 * @since       3.4
+	 * @deprecated  4.0 Will be removed without replacement
 	 */
 	public function move($src, $dest, $path = '', $use_streams = false)
 	{
@@ -128,8 +135,9 @@ class FileWrapper
 	 *
 	 * @return mixed  Returns file contents or boolean False if failed.
 	 *
-	 * @see     File::read()
-	 * @since   3.4
+	 * @see         File::read()
+	 * @since       3.4
+	 * @deprecated  4.0 Will be removed without replacement
 	 */
 	public function read($filename, $incpath = false, $amount = 0, $chunksize = 8192, $offset = 0)
 	{
@@ -145,8 +153,9 @@ class FileWrapper
 	 *
 	 * @return boolean  True on success.
 	 *
-	 * @see     File::write()
-	 * @since   3.4
+	 * @see         File::write()
+	 * @since       3.4
+	 * @deprecated  4.0 Will be removed without replacement
 	 */
 	public function write($file, &$buffer, $use_streams = false)
 	{
@@ -162,8 +171,9 @@ class FileWrapper
 	 *
 	 * @return boolean  True on success.
 	 *
-	 * @see     File::upload()
-	 * @since   3.4
+	 * @see         File::upload()
+	 * @since       3.4
+	 * @deprecated  4.0 Will be removed without replacement
 	 */
 	public function upload($src, $dest, $use_streams = false)
 	{
@@ -177,8 +187,9 @@ class FileWrapper
 	 *
 	 * @return boolean  True if path is a file.
 	 *
-	 * @see     File::exists()
-	 * @since   3.4
+	 * @see         File::exists()
+	 * @since       3.4
+	 * @deprecated  4.0 Will be removed without replacement
 	 */
 	public function exists($file)
 	{
@@ -192,8 +203,9 @@ class FileWrapper
 	 *
 	 * @return string  filename.
 	 *
-	 * @see     File::getName()
-	 * @since   3.4
+	 * @see         File::getName()
+	 * @since       3.4
+	 * @deprecated  4.0 Will be removed without replacement
 	 */
 	public function getName($file)
 	{

--- a/libraries/src/Filesystem/Wrapper/FileWrapper.php
+++ b/libraries/src/Filesystem/Wrapper/FileWrapper.php
@@ -18,7 +18,7 @@ defined('JPATH_PLATFORM') or die;
  * @package     Joomla.Platform
  * @subpackage  Filesystem
  * @since       3.4
- * @deprecated  4.0 Will be removed without replacement
+ * @deprecated  4.0 Use \Joomla\CMS\Filesystem\File instead
  */
 class FileWrapper
 {
@@ -31,7 +31,7 @@ class FileWrapper
 	 *
 	 * @see         File::getExt()
 	 * @since       3.4
-	 * @deprecated  4.0 Will be removed without replacement
+	 * @deprecated  4.0 Use \Joomla\CMS\Filesystem\File instead
 	 */
 	public function getExt($file)
 	{
@@ -47,7 +47,7 @@ class FileWrapper
 	 *
 	 * @see         File::stripExt()
 	 * @since       3.4
-	 * @deprecated  4.0 Will be removed without replacement
+	 * @deprecated  4.0 Use \Joomla\CMS\Filesystem\File instead
 	 */
 	public function stripExt($file)
 	{
@@ -63,7 +63,7 @@ class FileWrapper
 	 *
 	 * @see         File::makeSafe()
 	 * @since       3.4
-	 * @deprecated  4.0 Will be removed without replacement
+	 * @deprecated  4.0 Use \Joomla\CMS\Filesystem\File instead
 	 */
 	public function makeSafe($file)
 	{
@@ -82,7 +82,7 @@ class FileWrapper
 	 *
 	 * @see         File::copy()
 	 * @since       3.4
-	 * @deprecated  4.0 Will be removed without replacement
+	 * @deprecated  4.0 Use \Joomla\CMS\Filesystem\File instead
 	 */
 	public function copy($src, $dest, $path = null, $use_streams = false)
 	{
@@ -98,7 +98,7 @@ class FileWrapper
 	 *
 	 * @see         File::delete()
 	 * @since       3.4
-	 * @deprecated  4.0 Will be removed without replacement
+	 * @deprecated  4.0 Use \Joomla\CMS\Filesystem\File instead
 	 */
 	public function delete($file)
 	{
@@ -117,7 +117,7 @@ class FileWrapper
 	 *
 	 * @see         File::move()
 	 * @since       3.4
-	 * @deprecated  4.0 Will be removed without replacement
+	 * @deprecated  4.0 Use \Joomla\CMS\Filesystem\File instead
 	 */
 	public function move($src, $dest, $path = '', $use_streams = false)
 	{
@@ -137,7 +137,7 @@ class FileWrapper
 	 *
 	 * @see         File::read()
 	 * @since       3.4
-	 * @deprecated  4.0 Will be removed without replacement
+	 * @deprecated  4.0 Use \Joomla\CMS\Filesystem\File instead
 	 */
 	public function read($filename, $incpath = false, $amount = 0, $chunksize = 8192, $offset = 0)
 	{
@@ -155,7 +155,7 @@ class FileWrapper
 	 *
 	 * @see         File::write()
 	 * @since       3.4
-	 * @deprecated  4.0 Will be removed without replacement
+	 * @deprecated  4.0 Use \Joomla\CMS\Filesystem\File instead
 	 */
 	public function write($file, &$buffer, $use_streams = false)
 	{
@@ -173,7 +173,7 @@ class FileWrapper
 	 *
 	 * @see         File::upload()
 	 * @since       3.4
-	 * @deprecated  4.0 Will be removed without replacement
+	 * @deprecated  4.0 Use \Joomla\CMS\Filesystem\File instead
 	 */
 	public function upload($src, $dest, $use_streams = false)
 	{
@@ -189,7 +189,7 @@ class FileWrapper
 	 *
 	 * @see         File::exists()
 	 * @since       3.4
-	 * @deprecated  4.0 Will be removed without replacement
+	 * @deprecated  4.0 Use \Joomla\CMS\Filesystem\File instead
 	 */
 	public function exists($file)
 	{
@@ -205,7 +205,7 @@ class FileWrapper
 	 *
 	 * @see         File::getName()
 	 * @since       3.4
-	 * @deprecated  4.0 Will be removed without replacement
+	 * @deprecated  4.0 Use \Joomla\CMS\Filesystem\File instead
 	 */
 	public function getName($file)
 	{

--- a/libraries/src/Filesystem/Wrapper/FolderWrapper.php
+++ b/libraries/src/Filesystem/Wrapper/FolderWrapper.php
@@ -18,6 +18,7 @@ defined('JPATH_PLATFORM') or die;
  * @package     Joomla.Platform
  * @subpackage  Filesystem
  * @since       3.4
+ * @deprecated  4.0 Will be removed without replacement
  */
 class FolderWrapper
 {
@@ -32,9 +33,10 @@ class FolderWrapper
 	 *
 	 * @return  boolean  True on success.
 	 *
-	 * @see     Folder::copy()
-	 * @since   3.4
-	 * @throws  RuntimeException
+	 * @see         Folder::copy()
+	 * @since       3.4
+	 * @throws      RuntimeException
+	 * @deprecated  4.0 Will be removed without replacement
 	 */
 	public function copy($src, $dest, $path = '', $force = false, $use_streams = false)
 	{
@@ -49,8 +51,9 @@ class FolderWrapper
 	 *
 	 * @return  boolean  True if successful.
 	 *
-	 * @see     Folder::create()
-	 * @since   3.4
+	 * @see         Folder::create()
+	 * @since       3.4
+	 * @deprecated  4.0 Will be removed without replacement
 	 */
 	public function create($path = '', $mode = 493)
 	{
@@ -64,9 +67,10 @@ class FolderWrapper
 	 *
 	 * @return  boolean  True on success.
 	 *
-	 * @see     Folder::delete()
-	 * @since   3.4
-	 * @throws  UnexpectedValueException
+	 * @see         Folder::delete()
+	 * @since       3.4
+	 * @throws      UnexpectedValueException
+	 * @deprecated  4.0 Will be removed without replacement
 	 */
 	public function delete($path)
 	{
@@ -83,8 +87,9 @@ class FolderWrapper
 	 *
 	 * @return  mixed  Error message on false or boolean true on success.
 	 *
-	 * @see     Folder::move()
-	 * @since   3.4
+	 * @see         Folder::move()
+	 * @since       3.4
+	 * @deprecated  4.0 Will be removed without replacement
 	 */
 	public function move($src, $dest, $path = '', $use_streams = false)
 	{
@@ -98,8 +103,9 @@ class FolderWrapper
 	 *
 	 * @return  boolean  True if path is a folder.
 	 *
-	 * @see     Folder::exists()
-	 * @since   3.4
+	 * @see         Folder::exists()
+	 * @since       3.4
+	 * @deprecated  4.0 Will be removed without replacement
 	 */
 	public function exists($path)
 	{
@@ -119,8 +125,9 @@ class FolderWrapper
 	 *
 	 * @return  array  Files in the given folder.
 	 *
-	 * @see     Folder::files()
-	 * @since   3.4
+	 * @see         Folder::files()
+	 * @since       3.4
+	 * @deprecated  4.0 Will be removed without replacement
 	 */
 	public function files($path, $filter = '.', $recurse = false, $full = false, $exclude = array('.svn', 'CVS', '.DS_Store', '__MACOSX'),
 		$excludefilter = array('^\..*', '.*~'), $naturalSort = false)
@@ -140,8 +147,9 @@ class FolderWrapper
 	 *
 	 * @return  array  Folders in the given folder.
 	 *
-	 * @see     Folder::folders()
-	 * @since   3.4
+	 * @see         Folder::folders()
+	 * @since       3.4
+	 * @deprecated  4.0 Will be removed without replacement
 	 */
 	public function folders($path, $filter = '.', $recurse = false, $full = false, $exclude = array('.svn', 'CVS', '.DS_Store', '__MACOSX'),
 		$excludefilter = array('^\..*'))
@@ -160,8 +168,9 @@ class FolderWrapper
 	 *
 	 * @return  array  Folders in the given folder.
 	 *
-	 * @see     Folder::listFolderTree()
-	 * @since   3.4
+	 * @see         Folder::listFolderTree()
+	 * @since       3.4
+	 * @deprecated  4.0 Will be removed without replacement
 	 */
 	public function listFolderTree($path, $filter, $maxLevel = 3, $level = 0, $parent = 0)
 	{
@@ -175,8 +184,9 @@ class FolderWrapper
 	 *
 	 * @return  string  The sanitised string
 	 *
-	 * @see     Folder::makeSafe()
-	 * @since   3.4
+	 * @see         Folder::makeSafe()
+	 * @since       3.4
+	 * @deprecated  4.0 Will be removed without replacement
 	 */
 	public function makeSafe($path)
 	{

--- a/libraries/src/Filesystem/Wrapper/FolderWrapper.php
+++ b/libraries/src/Filesystem/Wrapper/FolderWrapper.php
@@ -18,7 +18,7 @@ defined('JPATH_PLATFORM') or die;
  * @package     Joomla.Platform
  * @subpackage  Filesystem
  * @since       3.4
- * @deprecated  4.0 Will be removed without replacement
+ * @deprecated  4.0 Use \Joomla\CMS\Filesystem\Folder instead
  */
 class FolderWrapper
 {
@@ -36,7 +36,7 @@ class FolderWrapper
 	 * @see         Folder::copy()
 	 * @since       3.4
 	 * @throws      RuntimeException
-	 * @deprecated  4.0 Will be removed without replacement
+	 * @deprecated  4.0 Use \Joomla\CMS\Filesystem\Folder instead
 	 */
 	public function copy($src, $dest, $path = '', $force = false, $use_streams = false)
 	{
@@ -53,7 +53,7 @@ class FolderWrapper
 	 *
 	 * @see         Folder::create()
 	 * @since       3.4
-	 * @deprecated  4.0 Will be removed without replacement
+	 * @deprecated  4.0 Use \Joomla\CMS\Filesystem\Folder instead
 	 */
 	public function create($path = '', $mode = 493)
 	{
@@ -70,7 +70,7 @@ class FolderWrapper
 	 * @see         Folder::delete()
 	 * @since       3.4
 	 * @throws      UnexpectedValueException
-	 * @deprecated  4.0 Will be removed without replacement
+	 * @deprecated  4.0 Use \Joomla\CMS\Filesystem\Folder instead
 	 */
 	public function delete($path)
 	{
@@ -89,7 +89,7 @@ class FolderWrapper
 	 *
 	 * @see         Folder::move()
 	 * @since       3.4
-	 * @deprecated  4.0 Will be removed without replacement
+	 * @deprecated  4.0 Use \Joomla\CMS\Filesystem\Folder instead
 	 */
 	public function move($src, $dest, $path = '', $use_streams = false)
 	{
@@ -105,7 +105,7 @@ class FolderWrapper
 	 *
 	 * @see         Folder::exists()
 	 * @since       3.4
-	 * @deprecated  4.0 Will be removed without replacement
+	 * @deprecated  4.0 Use \Joomla\CMS\Filesystem\Folder instead
 	 */
 	public function exists($path)
 	{
@@ -127,7 +127,7 @@ class FolderWrapper
 	 *
 	 * @see         Folder::files()
 	 * @since       3.4
-	 * @deprecated  4.0 Will be removed without replacement
+	 * @deprecated  4.0 Use \Joomla\CMS\Filesystem\Folder instead
 	 */
 	public function files($path, $filter = '.', $recurse = false, $full = false, $exclude = array('.svn', 'CVS', '.DS_Store', '__MACOSX'),
 		$excludefilter = array('^\..*', '.*~'), $naturalSort = false)
@@ -149,7 +149,7 @@ class FolderWrapper
 	 *
 	 * @see         Folder::folders()
 	 * @since       3.4
-	 * @deprecated  4.0 Will be removed without replacement
+	 * @deprecated  4.0 Use \Joomla\CMS\Filesystem\Folder instead
 	 */
 	public function folders($path, $filter = '.', $recurse = false, $full = false, $exclude = array('.svn', 'CVS', '.DS_Store', '__MACOSX'),
 		$excludefilter = array('^\..*'))
@@ -170,7 +170,7 @@ class FolderWrapper
 	 *
 	 * @see         Folder::listFolderTree()
 	 * @since       3.4
-	 * @deprecated  4.0 Will be removed without replacement
+	 * @deprecated  4.0 Use \Joomla\CMS\Filesystem\Folder instead
 	 */
 	public function listFolderTree($path, $filter, $maxLevel = 3, $level = 0, $parent = 0)
 	{
@@ -186,7 +186,7 @@ class FolderWrapper
 	 *
 	 * @see         Folder::makeSafe()
 	 * @since       3.4
-	 * @deprecated  4.0 Will be removed without replacement
+	 * @deprecated  4.0 Use \Joomla\CMS\Filesystem\Folder instead
 	 */
 	public function makeSafe($path)
 	{

--- a/libraries/src/Filesystem/Wrapper/PathWrapper.php
+++ b/libraries/src/Filesystem/Wrapper/PathWrapper.php
@@ -18,6 +18,7 @@ defined('JPATH_PLATFORM') or die;
  * @package     Joomla.Platform
  * @subpackage  Filesystem
  * @since       3.4
+ * @deprecated  4.0 Will be removed without replacement
  */
 class PathWrapper
 {
@@ -28,8 +29,9 @@ class PathWrapper
 	 *
 	 * @return  boolean  True if path can have mode changed.
 	 *
-	 * @see     Path::canChmod()
-	 * @since   3.4
+	 * @see         Path::canChmod()
+	 * @since       3.4
+	 * @deprecated  4.0 Will be removed without replacement
 	 */
 	public function canChmod($path)
 	{
@@ -45,8 +47,9 @@ class PathWrapper
 	 *
 	 * @return  boolean  True if successful [one fail means the whole operation failed].
 	 *
-	 * @see     Path::setPermissions()
-	 * @since   3.4
+	 * @see         Path::setPermissions()
+	 * @since       3.4
+	 * @deprecated  4.0 Will be removed without replacement
 	 */
 	public function setPermissions($path, $filemode = '0644', $foldermode = '0755')
 	{
@@ -60,8 +63,9 @@ class PathWrapper
 	 *
 	 * @return  string  Filesystem permissions.
 	 *
-	 * @see     Path::getPermissions()
-	 * @since   3.4
+	 * @see         Path::getPermissions()
+	 * @since       3.4
+	 * @deprecated  4.0 Will be removed without replacement
 	 */
 	public function getPermissions($path)
 	{
@@ -75,9 +79,10 @@ class PathWrapper
 	 *
 	 * @return  string  A cleaned version of the path or exit on error.
 	 *
-	 * @see     Path::check()
-	 * @since   3.4
-	 * @throws  Exception
+	 * @see         Path::check()
+	 * @since       3.4
+	 * @throws      Exception
+	 * @deprecated  4.0 Will be removed without replacement
 	 */
 	public function check($path)
 	{
@@ -92,9 +97,10 @@ class PathWrapper
 	 *
 	 * @return  string  The cleaned path.
 	 *
-	 * @see     Path::clean()
-	 * @since   3.4
-	 * @throws  UnexpectedValueException
+	 * @see         Path::clean()
+	 * @since       3.4
+	 * @throws      UnexpectedValueException
+	 * @deprecated  4.0 Will be removed without replacement
 	 */
 	public function clean($path, $ds = DIRECTORY_SEPARATOR)
 	{
@@ -108,8 +114,9 @@ class PathWrapper
 	 *
 	 * @return  boolean  True if the php script owns the path passed.
 	 *
-	 * @see     Path::isOwner()
-	 * @since   3.4
+	 * @see         Path::isOwner()
+	 * @since       3.4
+	 * @deprecated  4.0 Will be removed without replacement
 	 */
 	public function isOwner($path)
 	{
@@ -124,8 +131,9 @@ class PathWrapper
 	 *
 	 * @return mixed   The full path and file name for the target file, or boolean false if the file is not found in any of the paths.
 	 *
-	 * @see     Path::find()
-	 * @since   3.4
+	 * @see         Path::find()
+	 * @since       3.4
+	 * @deprecated  4.0 Will be removed without replacement
 	 */
 	public function find($paths, $file)
 	{

--- a/libraries/src/Filesystem/Wrapper/PathWrapper.php
+++ b/libraries/src/Filesystem/Wrapper/PathWrapper.php
@@ -18,7 +18,7 @@ defined('JPATH_PLATFORM') or die;
  * @package     Joomla.Platform
  * @subpackage  Filesystem
  * @since       3.4
- * @deprecated  4.0 Will be removed without replacement
+ * @deprecated  4.0 Use \Joomla\CMS\Filesystem\Path instead
  */
 class PathWrapper
 {
@@ -31,7 +31,7 @@ class PathWrapper
 	 *
 	 * @see         Path::canChmod()
 	 * @since       3.4
-	 * @deprecated  4.0 Will be removed without replacement
+	 * @deprecated  4.0 Use \Joomla\CMS\Filesystem\Path instead
 	 */
 	public function canChmod($path)
 	{
@@ -49,7 +49,7 @@ class PathWrapper
 	 *
 	 * @see         Path::setPermissions()
 	 * @since       3.4
-	 * @deprecated  4.0 Will be removed without replacement
+	 * @deprecated  4.0 Use \Joomla\CMS\Filesystem\Path instead
 	 */
 	public function setPermissions($path, $filemode = '0644', $foldermode = '0755')
 	{
@@ -65,7 +65,7 @@ class PathWrapper
 	 *
 	 * @see         Path::getPermissions()
 	 * @since       3.4
-	 * @deprecated  4.0 Will be removed without replacement
+	 * @deprecated  4.0 Use \Joomla\CMS\Filesystem\Path instead
 	 */
 	public function getPermissions($path)
 	{
@@ -82,7 +82,7 @@ class PathWrapper
 	 * @see         Path::check()
 	 * @since       3.4
 	 * @throws      Exception
-	 * @deprecated  4.0 Will be removed without replacement
+	 * @deprecated  4.0 Use \Joomla\CMS\Filesystem\Path instead
 	 */
 	public function check($path)
 	{
@@ -100,7 +100,7 @@ class PathWrapper
 	 * @see         Path::clean()
 	 * @since       3.4
 	 * @throws      UnexpectedValueException
-	 * @deprecated  4.0 Will be removed without replacement
+	 * @deprecated  4.0 Use \Joomla\CMS\Filesystem\Path instead
 	 */
 	public function clean($path, $ds = DIRECTORY_SEPARATOR)
 	{
@@ -116,7 +116,7 @@ class PathWrapper
 	 *
 	 * @see         Path::isOwner()
 	 * @since       3.4
-	 * @deprecated  4.0 Will be removed without replacement
+	 * @deprecated  4.0 Use \Joomla\CMS\Filesystem\Path instead
 	 */
 	public function isOwner($path)
 	{
@@ -133,7 +133,7 @@ class PathWrapper
 	 *
 	 * @see         Path::find()
 	 * @since       3.4
-	 * @deprecated  4.0 Will be removed without replacement
+	 * @deprecated  4.0 Use \Joomla\CMS\Filesystem\Path instead
 	 */
 	public function find($paths, $file)
 	{


### PR DESCRIPTION
The wrapper classes got deprecated for Joomla 4. This pr deprecates the wrappers for the filesystem library.