### PR TITLE
[action logs] Add action log plugin library class

### DIFF
--- a/administrator/components/com_actionlogs/libraries/actionlogplugin.php
+++ b/administrator/components/com_actionlogs/libraries/actionlogplugin.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_actionlogs
+ *
+ * @copyright   Copyright (C) 2005 - 2018 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+defined('_JEXEC') or die;
+
+JModelLegacy::addIncludePath(JPATH_ADMINISTRATOR . '/components/com_actionlogs/models', 'ActionlogsModel');
+
+/**
+ * Abstract Action Log Plugin
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+abstract class ActionLogPlugin extends JPlugin
+{
+	/**
+	 * Application object.
+	 *
+	 * @var    JApplicationCms
+	 * @since  3.9.0
+	 */
+	protected $app;
+
+	/**
+	 * Database object.
+	 *
+	 * @var    JDatabaseDriver
+	 * @since  3.9.0
+	 */
+	protected $db;
+
+	/**
+	 * Load plugin language file automatically so that it can be used inside component
+	 *
+	 * @var    boolean
+	 * @since  3.9.0
+	 */
+	protected $autoloadLanguage = true;
+
+	/**
+	 * Proxy for ActionlogsModelUserlog addLog method
+	 *
+	 * This method adds a record to #__action_logs contains (message_language_key, message, date, context, user)
+	 *
+	 * @param   array   $messages            The contents of the messages to be logged
+	 * @param   string  $messageLanguageKey  The language key of the message
+	 * @param   string  $context             The context of the content passed to the plugin
+	 * @param   int     $userId              ID of user perform the action, usually ID of current logged in user
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function addLog($messages, $messageLanguageKey, $context, $userId = null)
+	{
+		$user = $this->app->getIdentity();
+
+		foreach ($messages as $index => $message)
+		{
+			if (!array_key_exists('userid', $message))
+			{
+				$message['userid'] = $user->id;
+			}
+
+			if (!array_key_exists('username', $message))
+			{
+				$message['username'] = $user->username;
+			}
+
+			if (!array_key_exists('accountlink', $message))
+			{
+				$message['accountlink'] = 'index.php?option=com_users&task=user.edit&id=' . $user->id;
+			}
+
+			if (array_key_exists('type', $message))
+			{
+				$message['type'] = strtoupper($message['type']);
+			}
+
+			if (array_key_exists('app', $message))
+			{
+				$message['app'] = strtoupper($message['app']);
+			}
+
+			$messages[$index] = $message;
+		}
+
+		/* @var ActionlogsModelActionlog $model */
+		$model = JModelLegacy::getInstance('Actionlog', 'ActionlogsModel');
+		$model->addLog($messages, strtoupper($messageLanguageKey), $context, $userId);
+	}
+}

--- a/administrator/components/com_actionlogs/libraries/actionlogplugin.php
+++ b/administrator/components/com_actionlogs/libraries/actionlogplugin.php
@@ -89,7 +89,7 @@ abstract class ActionLogPlugin extends JPlugin
 			$messages[$index] = $message;
 		}
 
-		/* @var ActionlogsModelActionlog $model */
+		/** @var ActionlogsModelActionlog $model **/
 		$model = JModelLegacy::getInstance('Actionlog', 'ActionlogsModel');
 		$model->addLog($messages, strtoupper($messageLanguageKey), $context, $userId);
 	}

--- a/plugins/actionlog/joomla/joomla.php
+++ b/plugins/actionlog/joomla/joomla.php
@@ -12,6 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\Utilities\ArrayHelper;
 
+JLoader::import('com_actionlogs.libraries.actionlogplugin', JPATH_ADMINISTRATOR . '/components');
 JLoader::register('ActionlogsHelper', JPATH_ADMINISTRATOR . '/components/com_actionlogs/helpers/actionlogs.php');
 
 /**
@@ -19,7 +20,7 @@ JLoader::register('ActionlogsHelper', JPATH_ADMINISTRATOR . '/components/com_act
  *
  * @since  3.9.0
  */
-class PlgActionlogJoomla extends JPlugin
+class PlgActionlogJoomla extends ActionLogPlugin
 {
 	/**
 	 * Array of loggable extensions.
@@ -28,30 +29,6 @@ class PlgActionlogJoomla extends JPlugin
 	 * @since  3.9.0
 	 */
 	protected $loggableExtensions = array();
-
-	/**
-	 * Application object.
-	 *
-	 * @var    JApplicationCms
-	 * @since  3.9.0
-	 */
-	protected $app;
-
-	/**
-	 * Database object.
-	 *
-	 * @var    JDatabaseDriver
-	 * @since  3.9.0
-	 */
-	protected $db;
-
-	/**
-	 * Load plugin language file automatically so that it can be used inside component
-	 *
-	 * @var    boolean
-	 * @since  3.9.0
-	 */
-	protected $autoloadLanguage = true;
 
 	/**
 	 * Constructor.
@@ -100,27 +77,21 @@ class PlgActionlogJoomla extends JPlugin
 			return;
 		}
 
-		$user             = JFactory::getUser();
-		$contentTypeTitle = strtoupper($params->type_title);
 		list(, $contentType) = explode('.', $params->type_alias);
 
 		if ($isNew)
 		{
-			$messageLanguageKey = strtoupper($params->text_prefix . '_' . $contentTypeTitle . '_ADDED');
-			$defaultLanguageKey = strtoupper('PLG_SYSTEM_ACTIONLOGS_CONTENT_ADDED');
-
-			$action = 'add';
+			$messageLanguageKey = $params->text_prefix . '_' . $params->type_title . '_ADDED';
+			$defaultLanguageKey = 'PLG_SYSTEM_ACTIONLOGS_CONTENT_ADDED';
 		}
 		else
 		{
-			$messageLanguageKey = strtoupper($params->text_prefix . '_' . $contentTypeTitle . '_UPDATED');
-			$defaultLanguageKey = strtoupper('PLG_SYSTEM_ACTIONLOGS_CONTENT_UPDATED');
-
-			$action = 'update';
+			$messageLanguageKey = $params->text_prefix . '_' . $params->type_title . '_UPDATED';
+			$defaultLanguageKey = 'PLG_SYSTEM_ACTIONLOGS_CONTENT_UPDATED';
 		}
 
 		// If the content type doesn't has it own language key, use default language key
-		if (!JFactory::getLanguage()->hasKey($messageLanguageKey))
+		if (!$this->app->getLanguage()->hasKey($messageLanguageKey))
 		{
 			$messageLanguageKey = $defaultLanguageKey;
 		}
@@ -128,14 +99,11 @@ class PlgActionlogJoomla extends JPlugin
 		$id = empty($params->id_holder) ? 0 : $article->get($params->id_holder);
 
 		$message = array(
-			'action'      => $action,
-			'type'        => strtoupper($params->text_prefix . '_TYPE_' . $contentTypeTitle),
-			'id'          => $id,
-			'title'       => $article->get($params->title_holder),
-			'itemlink'    => ActionlogsHelper::getContentTypeLink($option, $contentType, $id),
-			'userid'      => $user->id,
-			'username'    => $user->username,
-			'accountlink' => 'index.php?option=com_users&task=user.edit&id=' . $user->id,
+			'action'   => $isNew ? 'add' : 'update',
+			'type'     => $params->text_prefix . '_TYPE_' . $params->type_title,
+			'id'       => $id,
+			'title'    => $article->get($params->title_holder),
+			'itemlink' => ActionlogsHelper::getContentTypeLink($option, $contentType, $id)
 		);
 
 		$this->addLog(array($message), $messageLanguageKey, $context);
@@ -170,30 +138,23 @@ class PlgActionlogJoomla extends JPlugin
 			return;
 		}
 
-		$language         = JFactory::getLanguage();
-		$user             = JFactory::getUser();
-		$contentTypeTitle = strtoupper($params->type_title);
-
 		// If the content type has it own language key, use it, otherwise, use default language key
-		if ($language->hasKey(strtoupper($params->text_prefix . '_' . $contentTypeTitle . '_DELETED')))
+		if ($this->app->getLanguage()->hasKey(strtoupper($params->text_prefix . '_' . $params->type_title . '_DELETED')))
 		{
-			$messageLanguageKey = strtoupper($params->text_prefix . '_' . $contentTypeTitle . '_DELETED');
+			$messageLanguageKey = $params->text_prefix . '_' . $params->type_title . '_DELETED';
 		}
 		else
 		{
-			$messageLanguageKey = strtoupper('PLG_SYSTEM_ACTIONLOGS_CONTENT_DELETED');
+			$messageLanguageKey = 'PLG_SYSTEM_ACTIONLOGS_CONTENT_DELETED';
 		}
 
 		$id = empty($params->id_holder) ? 0 : $article->get($params->id_holder);
 
 		$message = array(
-			'action'      => 'delete',
-			'type'        => strtoupper($params->text_prefix . '_TYPE_' . $contentTypeTitle),
-			'id'          => $id,
-			'title'       => $article->get($params->title_holder),
-			'userid'      => $user->id,
-			'username'    => $user->username,
-			'accountlink' => 'index.php?option=com_users&task=user.edit&id=' . $user->id,
+			'action' => 'delete',
+			'type'   => $params->text_prefix . '_TYPE_' . $params->type_title,
+			'id'     => $id,
+			'title'  => $article->get($params->title_holder)
 		);
 
 		$this->addLog(array($message), $messageLanguageKey, $context);
@@ -229,29 +190,27 @@ class PlgActionlogJoomla extends JPlugin
 			return;
 		}
 
-		$user             = JFactory::getUser();
-		$contentTypeTitle = strtoupper($params->type_title);
 		list(, $contentType) = explode('.', $params->type_alias);
 
 		switch ($value)
 		{
 			case 0:
-				$messageLanguageKey = strtoupper($params->text_prefix . '_' . $contentTypeTitle . '_UNPUBLISHED');
+				$messageLanguageKey = $params->text_prefix . '_' . $params->type_title . '_UNPUBLISHED';
 				$defaultLanguageKey = 'PLG_SYSTEM_ACTIONLOGS_CONTENT_UNPUBLISHED';
 				$action             = 'unpublish';
 				break;
 			case 1:
-				$messageLanguageKey = strtoupper($params->text_prefix . '_' . $contentTypeTitle . '_PUBLISHED');
+				$messageLanguageKey = $params->text_prefix . '_' . $params->type_title . '_PUBLISHED';
 				$defaultLanguageKey = 'PLG_SYSTEM_ACTIONLOGS_CONTENT_PUBLISHED';
 				$action             = 'publish';
 				break;
 			case 2:
-				$messageLanguageKey = strtoupper($params->text_prefix . '_' . $contentTypeTitle . '_ARCHIVED');
+				$messageLanguageKey = $params->text_prefix . '_' . $params->type_title . '_ARCHIVED';
 				$defaultLanguageKey = 'PLG_SYSTEM_ACTIONLOGS_CONTENT_ARCHIVED';
 				$action             = 'archive';
 				break;
 			case -2:
-				$messageLanguageKey = strtoupper($params->text_prefix . '_' . $contentTypeTitle . '_TRASHED');
+				$messageLanguageKey = $params->text_prefix . '_' . $params->type_title . '_TRASHED';
 				$defaultLanguageKey = 'PLG_SYSTEM_ACTIONLOGS_CONTENT_TRASHED';
 				$action             = 'trash';
 				break;
@@ -263,12 +222,12 @@ class PlgActionlogJoomla extends JPlugin
 		}
 
 		// If the content type doesn't has it own language key, use default language key
-		if (!JFactory::getLanguage()->hasKey($messageLanguageKey))
+		if (!$this->app->getLanguage()->hasKey($messageLanguageKey))
 		{
 			$messageLanguageKey = $defaultLanguageKey;
 		}
 
-		$db    = JFactory::getDbo();
+		$db    = $this->db;
 		$query = $db->getQuery(true)
 			->select($db->quoteName(array($params->title_holder, $params->id_holder)))
 			->from($db->quoteName($params->table_name))
@@ -290,13 +249,10 @@ class PlgActionlogJoomla extends JPlugin
 		{
 			$message = array(
 				'action'      => $action,
-				'type'        => strtoupper($params->text_prefix . '_TYPE_' . $params->type_title),
+				'type'        => $params->text_prefix . '_TYPE_' . $params->type_title,
 				'id'          => $pk,
 				'title'       => $items[$pk]->{$params->title_holder},
-				'itemlink'    => ActionlogsHelper::getContentTypeLink($option, $contentType, $pk),
-				'userid'      => $user->id,
-				'username'    => $user->username,
-				'accountlink' => 'index.php?option=com_users&task=user.edit&id=' . $user->id,
+				'itemlink'    => ActionlogsHelper::getContentTypeLink($option, $contentType, $pk)
 			);
 
 			$messages[] = $message;
@@ -324,19 +280,14 @@ class PlgActionlogJoomla extends JPlugin
 			return;
 		}
 
-		$messageLanguageKey = strtoupper('PLG_ACTIONLOG_JOOMLA_APPLICATION_CONFIG_UPDATED');
+		$messageLanguageKey = 'PLG_ACTIONLOG_JOOMLA_APPLICATION_CONFIG_UPDATED';
 		$action             = 'update';
-
-		$user = JFactory::getUser();
 
 		$message = array(
 			'action'         => $action,
-			'type'           => strtoupper('PLG_ACTIONLOG_JOOMLA_TYPE_APPLICATION_CONFIG'),
+			'type'           => 'PLG_ACTIONLOG_JOOMLA_TYPE_APPLICATION_CONFIG',
 			'extension_name' => 'com_config.application',
-			'itemlink'       => 'index.php?option=com_config',
-			'userid'         => $user->id,
-			'username'       => $user->username,
-			'accountlink'    => 'index.php?option=com_users&task=user.edit&id=' . $user->id,
+			'itemlink'       => 'index.php?option=com_config'
 		);
 
 		$this->addLog(array($message), $messageLanguageKey, 'com_config.application');
@@ -363,15 +314,13 @@ class PlgActionlogJoomla extends JPlugin
 			return;
 		}
 
-		$language      = JFactory::getLanguage();
-		$user          = JFactory::getUser();
 		$manifest      = $installer->get('manifest');
 		$extensionType = $manifest->attributes()->type;
 
 		// If the extension type has it own language key, use it, otherwise, use default language key
-		if ($language->hasKey(strtoupper('PLG_ACTIONLOG_JOOMLA_' . $extensionType . '_INSTALLED')))
+		if ($this->app->getLanguage()->hasKey(strtoupper('PLG_ACTIONLOG_JOOMLA_' . $extensionType . '_INSTALLED')))
 		{
-			$messageLanguageKey = strtoupper('PLG_ACTIONLOG_JOOMLA_' . $extensionType . '_INSTALLED');
+			$messageLanguageKey = 'PLG_ACTIONLOG_JOOMLA_' . $extensionType . '_INSTALLED';
 		}
 		else
 		{
@@ -380,13 +329,10 @@ class PlgActionlogJoomla extends JPlugin
 
 		$message = array(
 			'action'         => 'install',
-			'type'           => strtoupper('PLG_ACTIONLOG_JOOMLA_TYPE_' . $extensionType),
+			'type'           => 'PLG_ACTIONLOG_JOOMLA_TYPE_' . $extensionType,
 			'id'             => $eid,
 			'name'           => (string) $manifest->name,
-			'extension_name' => (string) $manifest->name,
-			'userid'         => $user->id,
-			'username'       => $user->username,
-			'accountlink'    => 'index.php?option=com_users&task=user.edit&id=' . $user->id,
+			'extension_name' => (string) $manifest->name
 		);
 
 		$this->addLog(array($message), $messageLanguageKey, $context);
@@ -420,15 +366,13 @@ class PlgActionlogJoomla extends JPlugin
 			return;
 		}
 
-		$language      = JFactory::getLanguage();
-		$user          = JFactory::getUser();
 		$manifest      = $installer->get('manifest');
 		$extensionType = $manifest->attributes()->type;
 
 		// If the extension type has it own language key, use it, otherwise, use default language key
-		if ($language->hasKey(strtoupper('PLG_ACTIONLOG_JOOMLA_' . $extensionType . '_UNINSTALLED')))
+		if ($this->app->getLanguage()->hasKey(strtoupper('PLG_ACTIONLOG_JOOMLA_' . $extensionType . '_UNINSTALLED')))
 		{
-			$messageLanguageKey = strtoupper('PLG_ACTIONLOG_JOOMLA_' . $extensionType . '_UNINSTALLED');
+			$messageLanguageKey = 'PLG_ACTIONLOG_JOOMLA_' . $extensionType . '_UNINSTALLED';
 		}
 		else
 		{
@@ -437,13 +381,10 @@ class PlgActionlogJoomla extends JPlugin
 
 		$message = array(
 			'action'         => 'install',
-			'type'           => strtoupper('PLG_ACTIONLOG_JOOMLA_TYPE_' . $extensionType),
+			'type'           => 'PLG_ACTIONLOG_JOOMLA_TYPE_' . $extensionType,
 			'id'             => $eid,
 			'name'           => (string) $manifest->name,
-			'extension_name' => (string) $manifest->name,
-			'userid'         => $user->id,
-			'username'       => $user->username,
-			'accountlink'    => 'index.php?option=com_users&task=user.edit&id=' . $user->id,
+			'extension_name' => (string) $manifest->name
 		);
 
 		$this->addLog(array($message), $messageLanguageKey, $context);
@@ -470,15 +411,13 @@ class PlgActionlogJoomla extends JPlugin
 			return;
 		}
 
-		$language      = JFactory::getLanguage();
-		$user          = JFactory::getUser();
 		$manifest      = $installer->get('manifest');
 		$extensionType = $manifest->attributes()->type;
 
 		// If the extension type has it own language key, use it, otherwise, use default language key
-		if ($language->hasKey(strtoupper('PLG_ACTIONLOG_JOOMLA_' . $extensionType . '_UPDATED')))
+		if ($this->app->getLanguage()->hasKey('PLG_ACTIONLOG_JOOMLA_' . $extensionType . '_UPDATED'))
 		{
-			$messageLanguageKey = strtoupper('PLG_ACTIONLOG_JOOMLA_' . $extensionType . '_UPDATED');
+			$messageLanguageKey = 'PLG_ACTIONLOG_JOOMLA_' . $extensionType . '_UPDATED';
 		}
 		else
 		{
@@ -487,13 +426,10 @@ class PlgActionlogJoomla extends JPlugin
 
 		$message = array(
 			'action'         => 'update',
-			'type'           => strtoupper('PLG_ACTIONLOG_JOOMLA_TYPE_' . $extensionType),
+			'type'           => 'PLG_ACTIONLOG_JOOMLA_TYPE_' . $extensionType,
 			'id'             => $eid,
 			'name'           => (string) $manifest->name,
-			'extension_name' => (string) $manifest->name,
-			'userid'         => $user->id,
-			'username'       => $user->username,
-			'accountlink'    => 'index.php?option=com_users&task=user.edit&id=' . $user->id,
+			'extension_name' => (string) $manifest->name
 		);
 
 		$this->addLog(array($message), $messageLanguageKey, $context);
@@ -528,40 +464,32 @@ class PlgActionlogJoomla extends JPlugin
 			return;
 		}
 
-		$extensionType = $params->type_title;
 		list(, $contentType) = explode('.', $params->type_alias);
 
 		if ($isNew)
 		{
-			$messageLanguageKey = strtoupper('PLG_ACTIONLOG_JOOMLA_' . $extensionType . '_ADDED');
-			$defaultLanguageKey = strtoupper('PLG_SYSTEM_ACTIONLOGS_CONTENT_ADDED');
-			$action             = 'add';
+			$messageLanguageKey = $params->text_prefix . '_' . $params->type_title . '_ADDED';
+			$defaultLanguageKey = 'PLG_SYSTEM_ACTIONLOGS_CONTENT_ADDED';
 		}
 		else
 		{
-			$messageLanguageKey = strtoupper('PLG_ACTIONLOG_JOOMLA_' . $extensionType . '_UPDATED');
+			$messageLanguageKey = $params->text_prefix . '_' . $params->type_title . '_UPDATED';
 			$defaultLanguageKey = 'PLG_SYSTEM_ACTIONLOGS_CONTENT_UPDATED';
-			$action             = 'update';
 		}
 
 		// If the extension type doesn't have it own language key, use default language key
-		if (!JFactory::getLanguage()->hasKey($messageLanguageKey))
+		if (!$this->app->getLanguage()->hasKey($messageLanguageKey))
 		{
 			$messageLanguageKey = $defaultLanguageKey;
 		}
 
-		$user = JFactory::getUser();
-
 		$message = array(
-			'action'         => $action,
-			'type'           => strtoupper('PLG_ACTIONLOG_JOOMLA_TYPE_' . $extensionType),
+			'action'         => $isNew ? 'add' : 'update',
+			'type'           => 'PLG_ACTIONLOG_JOOMLA_TYPE_' . $params->type_title,
 			'id'             => $table->get($params->id_holder),
 			'title'          => $table->get($params->title_holder),
 			'extension_name' => $table->get($params->title_holder),
-			'itemlink'       => ActionlogsHelper::getContentTypeLink($option, $contentType, $table->get($params->id_holder), $params->id_holder),
-			'userid'         => $user->id,
-			'username'       => $user->username,
-			'accountlink'    => 'index.php?option=com_users&task=user.edit&id=' . $user->id,
+			'itemlink'       => ActionlogsHelper::getContentTypeLink($option, $contentType, $table->get($params->id_holder), $params->id_holder)
 		);
 
 		$this->addLog(array($message), $messageLanguageKey, $context);
@@ -593,16 +521,12 @@ class PlgActionlogJoomla extends JPlugin
 			return;
 		}
 
-		$messageLanguageKey = strtoupper('PLG_SYSTEM_ACTIONLOGS_CONTENT_DELETED');
-		$user               = JFactory::getUser();
+		$messageLanguageKey = 'PLG_SYSTEM_ACTIONLOGS_CONTENT_DELETED';
 
 		$message = array(
-			'action'      => 'delete',
-			'type'        => strtoupper('PLG_ACTIONLOG_JOOMLA_TYPE_' . $params->type_title),
-			'title'       => $table->get($params->title_holder),
-			'userid'      => $user->id,
-			'username'    => $user->username,
-			'accountlink' => 'index.php?option=com_users&task=user.edit&id=' . $user->id,
+			'action' => 'delete',
+			'type'   => 'PLG_ACTIONLOG_JOOMLA_TYPE_' . $params->type_title,
+			'title'  => $table->get($params->title_holder)
 		);
 
 		$this->addLog(array($message), $messageLanguageKey, $context);
@@ -665,7 +589,7 @@ class PlgActionlogJoomla extends JPlugin
 			$action             = 'update';
 		}
 
-		$userId = $jUser->id ?: $user['id'];
+		$userId   = $jUser->id ?: $user['id'];
 		$username = $jUser->username ?: $user['username'];
 
 		$message = array(
@@ -705,16 +629,12 @@ class PlgActionlogJoomla extends JPlugin
 		}
 
 		$messageLanguageKey = 'PLG_SYSTEM_ACTIONLOGS_CONTENT_DELETED';
-		$jUser              = JFactory::getUser();
 
 		$message = array(
 			'action'      => 'delete',
 			'type'        => 'PLG_ACTIONLOG_JOOMLA_TYPE_USER',
 			'id'          => $user['id'],
-			'title'       => $user['name'],
-			'userid'      => $jUser->id,
-			'username'    => $jUser->username,
-			'accountlink' => 'index.php?option=com_users&task=user.edit&id=' . $jUser->id,
+			'title'       => $user['name']
 		);
 
 		$this->addLog(array($message), $messageLanguageKey, $context);
@@ -753,17 +673,12 @@ class PlgActionlogJoomla extends JPlugin
 			$action             = 'update';
 		}
 
-		$user = JFactory::getUser();
-
 		$message = array(
 			'action'      => $action,
 			'type'        => 'PLG_ACTIONLOG_JOOMLA_TYPE_USER_GROUP',
 			'id'          => $table->id,
 			'title'       => $table->title,
-			'itemlink'    => 'index.php?option=com_users&task=group.edit&id=' . $table->id,
-			'userid'      => $user->id,
-			'username'    => $user->username,
-			'accountlink' => 'index.php?option=com_users&task=user.edit&id=' . $user->id,
+			'itemlink'    => 'index.php?option=com_users&task=group.edit&id=' . $table->id
 		);
 
 		$this->addLog(array($message), $messageLanguageKey, $context);
@@ -791,18 +706,13 @@ class PlgActionlogJoomla extends JPlugin
 			return;
 		}
 
-		$user = JFactory::getUser();
-
 		$messageLanguageKey = 'PLG_SYSTEM_ACTIONLOGS_CONTENT_DELETED';
 
 		$message = array(
 			'action'      => 'delete',
 			'type'        => 'PLG_ACTIONLOG_JOOMLA_TYPE_USER_GROUP',
 			'id'          => $group['id'],
-			'title'       => $group['title'],
-			'userid'      => $user->id,
-			'username'    => $user->username,
-			'accountlink' => 'index.php?option=com_users&task=user.edit&id=' . $user->id,
+			'title'       => $group['title']
 		);
 
 		$this->addLog(array($message), $messageLanguageKey, $context);
@@ -831,9 +741,10 @@ class PlgActionlogJoomla extends JPlugin
 
 		$message = array(
 			'action'      => 'login',
+			'userid'      => $loggedInUser->id,
 			'username'    => $loggedInUser->username,
 			'accountlink' => 'index.php?option=com_users&task=user.edit&id=' . $loggedInUser->id,
-			'app'         => strtoupper('PLG_ACTIONLOG_JOOMLA_APPLICATION_' . $this->app->getName()),
+			'app'         => 'PLG_ACTIONLOG_JOOMLA_APPLICATION_' . $this->app->getName(),
 		);
 
 		$this->addLog(array($message), $messageLanguageKey, $context, $loggedInUser->id);
@@ -857,7 +768,7 @@ class PlgActionlogJoomla extends JPlugin
 			return;
 		}
 
-		$loggedInUser       = JUser::getInstance($response['username']);
+		$loggedInUser = JUser::getInstance($response['username']);
 
 		// Not a valid user, return
 		if (!$loggedInUser->id)
@@ -870,9 +781,10 @@ class PlgActionlogJoomla extends JPlugin
 		$message = array(
 			'action'      => 'login',
 			'id'          => $loggedInUser->id,
+			'userid'      => $loggedInUser->id,
 			'username'    => $loggedInUser->username,
 			'accountlink' => 'index.php?option=com_users&task=user.edit&id=' . $loggedInUser->id,
-			'app'         => strtoupper('PLG_ACTIONLOG_JOOMLA_APPLICATION_' . $this->app->getName()),
+			'app'         => 'PLG_ACTIONLOG_JOOMLA_APPLICATION_' . $this->app->getName(),
 		);
 
 		$this->addLog(array($message), $messageLanguageKey, $context, $loggedInUser->id);
@@ -903,35 +815,13 @@ class PlgActionlogJoomla extends JPlugin
 		$message = array(
 			'action'      => 'logout',
 			'id'          => $loggedOutUser->id,
+			'userid'      => $loggedOutUser->id,
 			'username'    => $loggedOutUser->username,
 			'accountlink' => 'index.php?option=com_users&task=user.edit&id=' . $loggedOutUser->id,
-			'app'         => strtoupper('PLG_ACTIONLOG_JOOMLA_APPLICATION_' . $this->app->getName()),
+			'app'         => 'PLG_ACTIONLOG_JOOMLA_APPLICATION_' . $this->app->getName(),
 		);
 
 		$this->addLog(array($message), $messageLanguageKey, $context);
-	}
-
-	/**
-	 * Proxy for ActionlogsModelUserlog addLog method
-	 *
-	 * This method adds a record to #__action_logs contains (message_language_key, message, date, context, user)
-	 *
-	 * @param   array   $messages            The contents of the messages to be logged
-	 * @param   string  $messageLanguageKey  The language key of the message
-	 * @param   string  $context             The context of the content passed to the plugin
-	 * @param   int     $userId              ID of user perform the action, usually ID of current logged in user
-	 *
-	 * @return  void
-	 *
-	 * @since   3.9.0
-	 */
-	protected function addLog($messages, $messageLanguageKey, $context, $userId = null)
-	{
-		JLoader::register('ActionlogsModelActionlog', JPATH_ADMINISTRATOR . '/components/com_actionlogs/models/actionlog.php');
-
-		/* @var ActionlogsModelActionlog $model */
-		$model = JModelLegacy::getInstance('Actionlog', 'ActionlogsModel');
-		$model->addLog($messages, $messageLanguageKey, $context, $userId);
 	}
 
 	/**

--- a/plugins/actionlog/joomla/joomla.php
+++ b/plugins/actionlog/joomla/joomla.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\Utilities\ArrayHelper;
 
-JLoader::import('com_actionlogs.libraries.actionlogplugin', JPATH_ADMINISTRATOR . '/components');
+JLoader::register('ActionLogPlugin', JPATH_ADMINISTRATOR . '/components/com_actionlogs/libraries/actionlogplugin.php');
 JLoader::register('ActionlogsHelper', JPATH_ADMINISTRATOR . '/components/com_actionlogs/helpers/actionlogs.php');
 
 /**


### PR DESCRIPTION
### Summary of Changes
As extension dev, I like to do as less repetitive work as possible. This pr adds a base class extension devs can use to log actions more convenient. For example a plugin can then look like:

```
JLoader::import('com_actionlogs.libraries.actionlogplugin', JPATH_ADMINISTRATOR . '/components');

class PlgActionlogFoo extends ActionLogPlugin
{
	public function onContentAfterSave($context, $item, $isNew)
	{
		if ($context != 'com_foo.bar')
		{
			return;
		}

		$message = array(
			'action'   => $isNew ? 'add' : 'update',
			'type'     => 'PLG_ACTIONLOG_FOO_TYPE_BAR',
			'id'       => $item->id,
			'title'    => $item->title,
			'itemlink' => 'index.php?option=com_foo&task=edit&id=' . $item->id
		);

		$this->addLog(array($message), 'PLG_ACTIONLOG_FOO_' . $message['action'], $context);
	}
}
```

Additionally it simplifies the default Joomla log plugin. 

### Testing Instructions
Save an article.

### Expected result
An action log is created.

### Actual result
An action log is created.

### Documentation Changes Required
Document that a base class exists.