### PR TITLE
Add missing return true; command to recaptcha invisible plugin

### DIFF
--- a/plugins/captcha/recaptcha_invisible/recaptcha_invisible.php
+++ b/plugins/captcha/recaptcha_invisible/recaptcha_invisible.php
@@ -197,5 +197,7 @@ class PlgCaptchaRecaptcha_Invisible extends \JPlugin
 
 			return false;
 		}
+
+		return true;
 	}
 }


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Method getResponse in PlgCaptchaRecaptcha_Invisible plugin https://github.com/joomla/joomla-cms/blob/staging/plugins/captcha/recaptcha_invisible/recaptcha_invisible.php#L186 should return true on success validation (instead of null at the moment).

### Testing Instructions
Code review

### Expected result
Method return true on success captcha validation

### Actual result
Method return null

### Documentation Changes Required
None