### PR TITLE
Language switcher module: load helpers without component constant

### DIFF
--- a/modules/mod_languages/helper.php
+++ b/modules/mod_languages/helper.php
@@ -59,8 +59,9 @@ abstract class ModLanguagesHelper
 			}
 
 			// Load component associations
-			$class = str_replace('com_', '', $app->input->get('option')) . 'HelperAssociation';
-			JLoader::register($class, JPATH_COMPONENT_SITE . '/helpers/association.php');
+			$option = $app->input->get('option');
+			$class = ucfirst(str_replace('com_', '', $option)) . 'HelperAssociation';
+			\JLoader::register($class, JPATH_SITE . '/components/' . $option . '/helpers/association.php');
 
 			if (class_exists($class) && is_callable(array($class, 'getAssociations')))
 			{


### PR DESCRIPTION
### Summary of Changes

As title says. 
As this create a Notice in 4.0 when we get a 404 because of the modern Router (absence of a specific all categories menu item, for example for contacts), better do it now for 3.9.0

### Testing Instructions
Switching languages on a multilingual site should work as before.

can be merged on review as it is a cosmetic change.