### PR TITLE
[4.0] Use the correct function signature in the slider button fetchId function

### DIFF
--- a/libraries/src/Toolbar/Button/SliderButton.php
+++ b/libraries/src/Toolbar/Button/SliderButton.php
@@ -80,16 +80,13 @@ class SliderButton extends ToolbarButton
 	/**
 	 * Get the button id
 	 *
-	 * @param   string  $type  Button type
-	 * @param   string  $name  Button name
-	 *
 	 * @return  string	Button CSS Id
 	 *
 	 * @since   3.0
 	 */
-	public function fetchId($type, $name)
+	public function fetchId()
 	{
-		return $this->parent->getName() . '-slider-' . $name;
+		return $this->parent->getName() . '-slider-' . $this->getName();
 	}
 
 	/**


### PR DESCRIPTION
The stub generator on J4 is broken. Because the slider button's fetchId has a wrong function signature.