### PR TITLE
[4.0] Sample Data button [a11y]

### DIFF
--- a/administrator/modules/mod_sampledata/tmpl/default.php
+++ b/administrator/modules/mod_sampledata/tmpl/default.php
@@ -37,7 +37,9 @@ Factory::getDocument()->addScriptOptions(
 						<?php echo htmlspecialchars($item->title, ENT_QUOTES, 'UTF-8'); ?>
 					</div>
 					<button type="button" class="btn btn-primary btn-sm apply-sample-data" data-type="<?php echo $item->name; ?>" data-steps="<?php echo $item->steps; ?>">
-					<?php echo Text::_('JLIB_INSTALLER_INSTALL'); ?></button>
+						<?php echo Text::_('JLIB_INSTALLER_INSTALL'); ?>
+						<span class="sr-only"><?php echo $item->title; ?></span>
+					</button>
 				</div>
 				<p class="small mt-1"><?php echo $item->description; ?></p>
 			</li>


### PR DESCRIPTION
Button text should be unique within a page, should be meaningful when read out of context, and should help users to know something about the purpose of the button

Before this both sample data just had `<button>Install</button>` so both buttons would appear to be the same if a user was looking at a list of buttons for example.

This PR add the plugin title to the button behind a sr-only tag