### PR TITLE
com_users login view, add string and change xml

### DIFF
--- a/administrator/language/en-GB/en-GB.com_users.ini
+++ b/administrator/language/en-GB/en-GB.com_users.ini
@@ -106,6 +106,7 @@ COM_USERS_FIELD_LOGIN_REDIRECT_ERROR="Only one of the login redirect fields shou
 COM_USERS_FIELD_LOGIN_REDIRECTMENU_DESC="Select or create the page the user will be redirected to after a successful login. The default is to stay on the same page."
 COM_USERS_FIELD_LOGIN_REDIRECTMENU_LABEL="Menu Item Login Redirect"
 COM_USERS_FIELD_LOGIN_URL="Internal URL"
+COM_USERS_FIELD_LOGOUT_REDIRECT_CHOICE_DESC="'Internal URL' lets you manually enter any internal URL in the Redirect field. 'Menu Item' lets you directly select an existing menu item.<br />For a multilingual site, it is recommended to use 'Menu Item'."
 COM_USERS_FIELD_LOGOUT_REDIRECT_CHOICE_LABEL="Choose Logout Redirect Type"
 COM_USERS_FIELD_LOGOUT_REDIRECT_ERROR="Only one of the logout redirect fields should have a value."
 COM_USERS_FIELD_LOGOUT_REDIRECTMENU_DESC="Select or create the page the user will be redirected to after ending their current session by logging out. The default is to stay on the same page."

--- a/components/com_users/views/login/tmpl/default.xml
+++ b/components/com_users/views/login/tmpl/default.xml
@@ -95,7 +95,7 @@
 			name="logoutredirectchoice"
 			type="radio"
 			label="COM_USERS_FIELD_LOGOUT_REDIRECT_CHOICE_LABEL"
-			description="COM_USERS_FIELD_LOGIN_REDIRECT_CHOICE_DESC"
+			description="COM_USERS_FIELD_LOGOUT_REDIRECT_CHOICE_DESC"
 			class="btn-group btn-group-yesno"
 			default="1"
 			>


### PR DESCRIPTION
### Summary of Changes

During translation, it has been noticed that the same string is used for two credentials in Loginredirect and Logoutredirect.

### Testing Instructions

.

### Expected result

One string for loginredirect message and one for logoutredirect message.
In other languages, such as German, it is more understandable if the reference can be made.

### Actual result

One string for two messages

### Documentation Changes Required

.