### PR TITLE
[4.0] Use basename instead of removed getName from the File class

### DIFF
--- a/libraries/src/Installer/Installer.php
+++ b/libraries/src/Installer/Installer.php
@@ -2290,7 +2290,7 @@ class Installer extends \JAdapter
 
 		if ($xml->files && count($xml->files->children()))
 		{
-			$filename = File::getName($path);
+			$filename = basename($path);
 			$data['filename'] = File::stripExt($filename);
 
 			foreach ($xml->files->children() as $oneFile)


### PR DESCRIPTION
Pull Request for Issue #22438.

### Summary of Changes
Due the removal of the getName function in #22383 the installer was still using it. This pr changes the code to the recommended basename function.

### Testing Instructions
- Install Joomla
- Try to log in

### Expected result
Login works and user is created in the database.

### Actual result
Login doesn't work.