### PR TITLE
[4.0] Revert "Remove the deprecated code in the MenuItem class (#22362)"

### DIFF
--- a/libraries/src/Menu/MenuItem.php
+++ b/libraries/src/Menu/MenuItem.php
@@ -205,6 +205,69 @@ class MenuItem extends \stdClass
 	}
 
 	/**
+	 * Method to get certain otherwise inaccessible properties from the form field object.
+	 *
+	 * @param   string  $name  The property name for which to get the value.
+	 *
+	 * @return  mixed  The property value or null.
+	 *
+	 * @since   3.7.0
+	 * @deprecated  4.0  Access the item parameters through the `getParams()` method
+	 */
+	public function __get($name)
+	{
+		if ($name === 'params')
+		{
+			return $this->getParams();
+		}
+
+		return $this->get($name);
+	}
+
+	/**
+	 * Method to set certain otherwise inaccessible properties of the form field object.
+	 *
+	 * @param   string  $name   The property name for which to set the value.
+	 * @param   mixed   $value  The value of the property.
+	 *
+	 * @return  void
+	 *
+	 * @since   3.7.0
+	 * @deprecated  4.0  Set the item parameters through the `setParams()` method
+	 */
+	public function __set($name, $value)
+	{
+		if ($name === 'params')
+		{
+			$this->setParams($value);
+
+			return;
+		}
+
+		$this->set($name, $value);
+	}
+
+	/**
+	 * Method check if a certain otherwise inaccessible properties of the form field object is set.
+	 *
+	 * @param   string  $name  The property name to check.
+	 *
+	 * @return  boolean
+	 *
+	 * @since   3.7.1
+	 * @deprecated  4.0 Deprecated without replacement
+	 */
+	public function __isset($name)
+	{
+		if ($name === 'params')
+		{
+			return !($this->params instanceof Registry);
+		}
+
+		return $this->get($name) !== null;
+	}
+
+	/**
 	 * Returns the menu item parameters
 	 *
 	 * @return  Registry
@@ -245,5 +308,45 @@ class MenuItem extends \stdClass
 	public function setParams($params)
 	{
 		$this->params = $params;
+	}
+
+	/**
+	 * Returns a property of the object or the default value if the property is not set.
+	 *
+	 * @param   string  $property  The name of the property.
+	 * @param   mixed   $default   The default value.
+	 *
+	 * @return  mixed    The value of the property.
+	 *
+	 * @since   3.7.0
+	 * @deprecated  4.0
+	 */
+	public function get($property, $default = null)
+	{
+		if (isset($this->$property))
+		{
+			return $this->$property;
+		}
+
+		return $default;
+	}
+
+	/**
+	 * Modifies a property of the object, creating it if it does not already exist.
+	 *
+	 * @param   string  $property  The name of the property.
+	 * @param   mixed   $value     The value of the property to set.
+	 *
+	 * @return  mixed  Previous value of the property.
+	 *
+	 * @since   3.7.0
+	 * @deprecated  4.0
+	 */
+	public function set($property, $value = null)
+	{
+		$previous = $this->$property ?? null;
+		$this->$property = $value;
+
+		return $previous;
 	}
 }


### PR DESCRIPTION
The params property of the MenuItem class is used all over the core and also extensions. Currently the front end of J4 is broken.

Probably we should even think about removing the deprecated message as it is a hard BC break.