### PR TITLE
Fix links to restricted pages

### DIFF
--- a/libraries/src/Component/Router/Rules/MenuRules.php
+++ b/libraries/src/Component/Router/Rules/MenuRules.php
@@ -202,6 +202,9 @@ class MenuRules implements RulesInterface
 			$attributes[] = 'language';
 			$values[]     = array($language, '*');
 
+			$attributes[] = 'access';
+			$values[]     = null;
+
 			$items = $this->router->menu->getItems($attributes, $values);
 
 			foreach ($items as $item)


### PR DESCRIPTION
### Summary of Changes

Generate a correct link to the restricted page, even you have no access yet.
This PR prevents duplicate links when you are logged in or not.

### Testing Instructions
1. Create  a two menu items. One for `Login Form` and the other for `User Profile`.
![screenshot_20181001_225658](https://user-images.githubusercontent.com/9054379/46315281-4ddb8600-c5cd-11e8-880a-9993067fb59e.png)

2. Enable Modern Routing for `com_users`
3. Go to login form `/login` and log in.
4. After logged in you should be redirected to `/profile`
5. Change access level from Public to Registered for User Profile menu item (`/profile`)

**Note**: to clear old return URL (if you tested patched version first, after logged in, you should go to the other page (ex. home page) and logout. Next, back to the login page again). If this does not help then clear cookies.

### Actual result
After logout and log in again you are redirected to `/login?view=profile`. If not then see at the note above.

### Expected result
After logout and log in again you should be redirected to `/profile`.

### Documentation Changes Required
No
