### PR TITLE
[4.0] Class 'ModulesHelper' not found

### DIFF
--- a/administrator/components/com_modules/tmpl/modules/default_batch_body.php
+++ b/administrator/components/com_modules/tmpl/modules/default_batch_body.php
@@ -9,10 +9,11 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\Language\Text;
-use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Helper\ModuleHelper;
 use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
+use Joomla\Component\Modules\Administrator\Helper\ModulesHelper;
 
 $clientId  = $this->state->get('client_id');
 


### PR DESCRIPTION
### Summary of Changes
Missing use class when loading the Modules Manager


### Note

batch is nevetheless broken in modules manager