### PR TITLE
[4.0] Editor buttons [a11y]

### DIFF
--- a/layouts/joomla/editors/buttons/button.php
+++ b/layouts/joomla/editors/buttons/button.php
@@ -22,8 +22,8 @@ if ($button->get('name')) :
 	$onclick = ($button->get('onclick')) ? ' onclick="' . $button->get('onclick') . '"' : '';
 	$title   = ($button->get('title')) ? $button->get('title') : $button->get('text');
 ?>
-<a href="<?php echo $href; ?>" role="button" class="xtd-button btn btn-secondary <?php echo $class; ?>" <?php echo $button->get('modal') ? 'data-toggle="modal"' : '' ?> title="<?php echo $title; ?>" <?php echo $onclick; ?>>
+<button href="<?php echo $href; ?>" role="button" class="xtd-button btn btn-secondary <?php echo $class; ?>" <?php echo $button->get('modal') ? 'data-toggle="modal"' : '' ?> title="<?php echo $title; ?>" <?php echo $onclick; ?>>
 	<span class="icon-<?php echo $button->get('name'); ?>" aria-hidden="true"></span>
 	<?php echo $button->get('text'); ?>
-</a>
+</button>
 <?php endif; ?>

--- a/layouts/joomla/editors/buttons/button.php
+++ b/layouts/joomla/editors/buttons/button.php
@@ -22,7 +22,7 @@ if ($button->get('name')) :
 	$onclick = ($button->get('onclick')) ? ' onclick="' . $button->get('onclick') . '"' : '';
 	$title   = ($button->get('title')) ? $button->get('title') : $button->get('text');
 ?>
-<button href="<?php echo $href; ?>" role="button" class="xtd-button btn btn-secondary <?php echo $class; ?>" <?php echo $button->get('modal') ? 'data-toggle="modal"' : '' ?> title="<?php echo $title; ?>" <?php echo $onclick; ?>>
+<button type="button" href="<?php echo $href; ?>" class="xtd-button btn btn-secondary <?php echo $class; ?>" <?php echo $button->get('modal') ? 'data-toggle="modal"' : '' ?> title="<?php echo $title; ?>" <?php echo $onclick; ?>>
 	<span class="icon-<?php echo $button->get('name'); ?>" aria-hidden="true"></span>
 	<?php echo $button->get('text'); ?>
 </button>


### PR DESCRIPTION
this Pr is for the joomla xtd-editor buttons that appear BELOW the editor when not using tinymce

Before this pr they were `<a href= .... role=button`

This is fine but they are buttons, they are visually styled as buttons and they are identified as buttons to assistive technology.

However the default behaviour for a button is for it to be selected by either space or enter whereas the default behaviour for a link is for it only to be selected by the enter key.

This could be fixed by javascript but far better to use the correct html and make the button really a button

There is no visual change - however if you use the tab key to navigate to the buttons you will be able to test that you can select the button and a modal opens by pressing the space bar as well as the enter key.


Please dont tell me about other areas of core that are also wrong - there are a lot - and I will submit discrete pr for them - as it will be easier to test