### PR TITLE
[4.0] Menu Type select button [a11y]

### DIFF
--- a/administrator/components/com_menus/Field/MenutypeField.php
+++ b/administrator/components/com_menus/Field/MenutypeField.php
@@ -90,9 +90,9 @@ class MenutypeField extends ListField
 		$link = Route::_('index.php?option=com_menus&view=menutypes&tmpl=component&client_id=' . $clientId . '&recordId=' . $recordId);
 		$html[] = '<span class="input-group"><input type="text" ' . $required . ' readonly="readonly" id="' . $this->id
 			. '" value="' . $value . '"' . $size . $class . '>';
-		$html[] = '<span class="input-group-append"><a href="#menuTypeModal" role="button" class="btn btn-primary" data-toggle="modal" title="'
+		$html[] = '<span class="input-group-append"><button href="#menuTypeModal" class="btn btn-primary" data-toggle="modal" title="'
 			. Text::_('JSELECT') . '">' . '<span class="icon-list icon-white" aria-hidden="true"></span> '
-			. Text::_('JSELECT') . '</a></span></span>';
+			. Text::_('JSELECT') . '</button></span></span>';
 		$html[] = HTMLHelper::_(
 			'bootstrap.renderModal',
 			'menuTypeModal',

--- a/administrator/components/com_menus/Field/MenutypeField.php
+++ b/administrator/components/com_menus/Field/MenutypeField.php
@@ -90,7 +90,7 @@ class MenutypeField extends ListField
 		$link = Route::_('index.php?option=com_menus&view=menutypes&tmpl=component&client_id=' . $clientId . '&recordId=' . $recordId);
 		$html[] = '<span class="input-group"><input type="text" ' . $required . ' readonly="readonly" id="' . $this->id
 			. '" value="' . $value . '"' . $size . $class . '>';
-		$html[] = '<span class="input-group-append"><button href="#menuTypeModal" class="btn btn-primary" data-toggle="modal" title="'
+		$html[] = '<span class="input-group-append"><button type="button" href="#menuTypeModal" class="btn btn-primary" data-toggle="modal" title="'
 			. Text::_('JSELECT') . '">' . '<span class="icon-list icon-white" aria-hidden="true"></span> '
 			. Text::_('JSELECT') . '</button></span></span>';
 		$html[] = HTMLHelper::_(


### PR DESCRIPTION
this Pr is for the menu type select button

![image](https://user-images.githubusercontent.com/1296369/46352101-e1a26600-c650-11e8-94e8-2cde35f51f23.png)

Before this pr it was `<a href= .... role=button`

This is fine but it is a  button, it is visually styled as a button and it is identified as a button to assistive technology.

However the default behaviour for a button is for it to be selected by either space or enter whereas the default behaviour for a link is for it only to be selected by the enter key.

This could be fixed by jvascript but far better to use the correct html and make the button really a button

There is no visual change - however if you use the tab key to navigate to the button you will be able to test that you can select the button and a modal opens by pressing the space bar as well as the enter key.


Please dont tell me about other areas of core that are also wrong - there are a lot - and I will submit discrete pr for them - as it will be easier to test