### PR TITLE
[3.9] Workaround for consentbox for com_mailto

### DIFF
--- a/components/com_mailto/controller.php
+++ b/components/com_mailto/controller.php
@@ -92,7 +92,7 @@ class MailtoController extends JControllerLegacy
 		{
 			foreach ($headers as $header)
 			{
-				if (strpos($value, $header) !== false)
+				if (is_string($value) && strpos($value, $header) !== false)
 				{
 					JError::raiseError(403, '');
 				}

--- a/components/com_mailto/models/mailto.php
+++ b/components/com_mailto/models/mailto.php
@@ -94,10 +94,11 @@ class MailtoModelMailto extends JModelForm
 	{
 		$input = JFactory::getApplication()->input;
 
-		$data['emailto']   = $input->get('emailto', '', 'string');
-		$data['sender']    = $input->get('sender', '', 'string');
-		$data['emailfrom'] = $input->get('emailfrom', '', 'string');
-		$data['subject']   = $input->get('subject', '', 'string');
+		$data['emailto']    = $input->get('emailto', '', 'string');
+		$data['sender']     = $input->get('sender', '', 'string');
+		$data['emailfrom']  = $input->get('emailfrom', '', 'string');
+		$data['subject']    = $input->get('subject', '', 'string');
+		$data['consentbox'] = $input->get('consentbox', '', 'string');
 
 		return $data;
 	}


### PR DESCRIPTION
Pull Request for Issue #22066

### Summary of Changes

Implement a workaround for the consentbox with com_mailto. Lets softcode the consentbox than :(

### Testing Instructions

- Install 3.9.0beta4
- enable mailto
- enable recaptcha (or invisible captcha) [(keys for localhost can be found here)](https://developers.google.com/recaptcha/docs/faq)
- go to the mailto page
![image](https://user-images.githubusercontent.com/2596554/46417347-b93a6a80-c729-11e8-8651-663d18432ba5.png)
- make sure the form can't be submitted when the privacy checkbox is not ticked.
- make sure the form can be submitted when everything is correct.

### Expected result

Form now works in combination with recatcha too.

### Actual result

Email is not sent. An error message is displayed at the top with the legend: ‘Field Required: Privacy Note’.

### Documentation Changes Required

None