### PR TITLE
[4.0] Cancel/Close button

### DIFF
--- a/administrator/components/com_config/View/Application/HtmlView.php
+++ b/administrator/components/com_config/View/Application/HtmlView.php
@@ -109,7 +109,7 @@ class HtmlView extends BaseHtmlView
 			'btn-success'
 		);
 		ToolbarHelper::divider();
-		ToolbarHelper::cancel('application.cancel');
+		ToolbarHelper::cancel('application.cancel', 'JTOOLBAR_CLOSE');
 		ToolbarHelper::divider();
 		ToolbarHelper::help('JHELP_SITE_GLOBAL_CONFIGURATION');
 	}

--- a/administrator/components/com_config/View/Component/HtmlView.php
+++ b/administrator/components/com_config/View/Component/HtmlView.php
@@ -111,7 +111,7 @@ class HtmlView extends BaseHtmlView
 			'btn-success'
 		);
 		ToolbarHelper::divider();
-		ToolbarHelper::cancel('component.cancel');
+		ToolbarHelper::cancel('component.cancel', 'JTOOLBAR_CLOSE');
 		ToolbarHelper::divider();
 		ToolbarHelper::help('JHELP_COMPONENTS_' . $this->currentComponent . '_OPTIONS');
 	}

--- a/administrator/components/com_messages/View/Message/HtmlView.php
+++ b/administrator/components/com_messages/View/Message/HtmlView.php
@@ -84,7 +84,7 @@ class HtmlView extends BaseHtmlView
 			Factory::getApplication()->input->set('hidemainmenu', true);
 			ToolbarHelper::title(Text::_('COM_MESSAGES_WRITE_PRIVATE_MESSAGE'), 'envelope-opened new-privatemessage');
 			ToolbarHelper::save('message.save', 'COM_MESSAGES_TOOLBAR_SEND');
-			ToolbarHelper::cancel('message.cancel');
+			ToolbarHelper::cancel('message.cancel', 'JTOOLBAR_CLOSE');
 			ToolbarHelper::help('JHELP_COMPONENTS_MESSAGING_WRITE');
 		}
 		else


### PR DESCRIPTION
Throughout the cms we have a Cancel button on a new item and a Close button on an existing item.

![image](https://user-images.githubusercontent.com/1296369/46424746-dc691800-c731-11e8-9db2-56fb0ea26949.png)
![image](https://user-images.githubusercontent.com/1296369/46424769-ed198e00-c731-11e8-8ff8-40571b6e30c9.png)

This PR ensures that com_messages follows that same pattern

As global config and component options always exist then they should also have a Close button not a Cancel button if they are to follow the same UI pattern
