### PR TITLE
[4.0] spinner as web component

### DIFF
--- a/administrator/components/com_associations/tmpl/association/edit.php
+++ b/administrator/components/com_associations/tmpl/association/edit.php
@@ -17,8 +17,9 @@ HTMLHelper::_('behavior.formvalidator');
 HTMLHelper::_('behavior.keepalive');
 HTMLHelper::_('jquery.framework');
 
-HTMLHelper::_('script', 'com_associations/sidebyside.js', false, true);
-HTMLHelper::_('stylesheet', 'com_associations/sidebyside.css', array(), true);
+HTMLHelper::_('webcomponent', 'system/webcomponents/joomla-core-loader.min.js', ['relative' => true, 'version' => 'auto']);
+HTMLHelper::_('script', 'com_associations/sidebyside.js', ['relative' => true, 'version' => 'auto']);
+HTMLHelper::_('stylesheet', 'com_associations/sidebyside.css', ['relative' => true, 'version' => 'auto']);
 
 $options = array(
 			'layout'   => $this->app->input->get('layout', '', 'string'),

--- a/administrator/components/com_fields/Helper/FieldsHelper.php
+++ b/administrator/components/com_fields/Helper/FieldsHelper.php
@@ -332,24 +332,11 @@ class FieldsHelper
 			/*
 			 * Setting the onchange event to reload the page when the category
 			 * has changed
-			*/
-			$form->setFieldAttribute('catid', 'onchange', 'categoryHasChanged(this);');
-
-			// Preload spindle-wheel when we need to submit form due to category selector changed
-			Factory::getDocument()->addScriptDeclaration("
-			function categoryHasChanged(element) {
-				var cat = jQuery(element);
-				if (cat.val() == '" . $assignedCatids . "')return;
-				Joomla.loadingLayer('show');
-				jQuery('input[name=task]').val('" . $section . ".reload');
-				element.form.submit();
-			}
-			jQuery( document ).ready(function() {
-				Joomla.loadingLayer('load');
-				var formControl = '#" . $form->getFormControl() . "_catid';
-				if (!jQuery(formControl).val() != '" . $assignedCatids . "'){jQuery(formControl).val('" . $assignedCatids . "');}
-			});"
-			);
+			 */
+			$form->setFieldAttribute('catid', 'custom-fields-enabled', 'true');
+			$form->setFieldAttribute('catid', 'custom-fields-cat-id', $assignedCatids);
+			$form->setFieldAttribute('catid', 'custom-fields-form-id', $form->getFormControl());
+			$form->setFieldAttribute('catid', 'custom-fields-section', $section);
 		}
 
 		// Getting the fields

--- a/administrator/components/com_fields/Helper/FieldsHelper.php
+++ b/administrator/components/com_fields/Helper/FieldsHelper.php
@@ -330,8 +330,7 @@ class FieldsHelper
 		if ($form->getField('catid') && $parts[0] != 'com_fields')
 		{
 			/*
-			 * Setting the onchange event to reload the page when the category
-			 * has changed
+			 * Setting some parameters for the category field
 			 */
 			$form->setFieldAttribute('catid', 'custom-fields-enabled', 'true');
 			$form->setFieldAttribute('catid', 'custom-fields-cat-id', $assignedCatids);

--- a/administrator/modules/mod_sampledata/tmpl/default.php
+++ b/administrator/modules/mod_sampledata/tmpl/default.php
@@ -15,7 +15,6 @@ use Joomla\CMS\Uri\Uri;
 use Joomla\CMS\HTML\HTMLHelper;
 
 HTMLHelper::_('script', 'mod_sampledata/sampledata-process.js', ['version' => 'auto', 'relative' => true]);
-HTMLHelper::_('webcomponent', 'system/webcomponents/joomla-core-loader.min.js', ['relative' => true, 'version' => 'auto']);
 
 Text::script('MOD_SAMPLEDATA_CONFIRM_START');
 Text::script('MOD_SAMPLEDATA_ITEM_ALREADY_PROCESSED');

--- a/administrator/modules/mod_sampledata/tmpl/default.php
+++ b/administrator/modules/mod_sampledata/tmpl/default.php
@@ -15,6 +15,7 @@ use Joomla\CMS\Uri\Uri;
 use Joomla\CMS\HTML\HTMLHelper;
 
 HTMLHelper::_('script', 'mod_sampledata/sampledata-process.js', ['version' => 'auto', 'relative' => true]);
+HTMLHelper::_('webcomponent', 'system/webcomponents/joomla-core-loader.min.js', ['relative' => true, 'version' => 'auto']);
 
 Text::script('MOD_SAMPLEDATA_CONFIRM_START');
 Text::script('MOD_SAMPLEDATA_ITEM_ALREADY_PROCESSED');

--- a/build/build-modules-js/compilecejs.js
+++ b/build/build-modules-js/compilecejs.js
@@ -10,19 +10,19 @@ const UglyCss = require('uglifycss');
 const UglifyJS = require('uglify-es');
 const rootPath = require('./rootpath.js')._();
 
-const createJsFiles = (element, es6File) => {
+const createJsFiles = (element, es6File, options) => {
   const b = browserify();
   const c = browserify();
 
-  fs.writeFileSync(`${rootPath}/media/system/webcomponents/js/joomla-${element}.js`, es6File, { encoding: 'utf8' });
+  fs.writeFileSync(`${rootPath}/media/${options.settings.webcomponents[element]['js']}/joomla-${element}.js`, es6File, { encoding: 'utf8' });
 
   // And the minified version
-  fs.writeFileSync(`${rootPath}/media/system/webcomponents/js/joomla-${element}.min.js`, UglifyJS.minify(es6File).code, { encoding: 'utf8' });
+  fs.writeFileSync(`${rootPath}/media/${options.settings.webcomponents[element]['js']}/joomla-${element}.min.js`, UglifyJS.minify(es6File).code, { encoding: 'utf8' });
 
   // Transpile a copy for ES5
-  fs.writeFileSync(`${rootPath}/media/system/webcomponents/js/joomla-${element}-es5.js`, '');
-  const bundleFs = fs.createWriteStream(`${rootPath}/media/system/webcomponents/js/joomla-${element}-es5.js`);
-  const bundleFsMin = fs.createWriteStream(`${rootPath}/media/system/webcomponents/js/joomla-${element}-es5.min.js`);
+  fs.writeFileSync(`${rootPath}/media/${options.settings.webcomponents[element]['js']}/joomla-${element}-es5.js`, '');
+  const bundleFs = fs.createWriteStream(`${rootPath}/media/${options.settings.webcomponents[element]['js']}/joomla-${element}-es5.js`);
+  const bundleFsMin = fs.createWriteStream(`${rootPath}/media/${options.settings.webcomponents[element]['js']}/joomla-${element}-es5.min.js`);
 
   b.add(`${rootPath}/build/media/webcomponents/js/${element}/${element}.js`);
   c.add(`${rootPath}/build/media/webcomponents/js/${element}/${element}.js`);
@@ -31,19 +31,31 @@ const createJsFiles = (element, es6File) => {
 };
 
 const compile = (options) => {
-  // Make sure that the dist paths exist
-  if (!fs.existsSync(`${rootPath}/media/system/webcomponents`)) {
-    fsExtra.mkdirSync(`${rootPath}/media/system/webcomponents`);
-  }
-  if (!fs.existsSync(`${rootPath}/media/system/webcomponents/js`)) {
-    fsExtra.mkdirSync(`${rootPath}/media/system/webcomponents/js`);
-  }
+    // Make sure that the dist paths exist
+    if (!fs.existsSync(`${rootPath}/media/system/webcomponents`)) {
+        fsExtra.mkdirSync(`${rootPath}/media/system/webcomponents`);
+    }
+    if (!fs.existsSync(`${rootPath}/media/system/webcomponents/js`)) {
+        fsExtra.mkdirSync(`${rootPath}/media/system/webcomponents/js`);
+    }
 
-  if (!fs.existsSync(`${rootPath}/media/system/webcomponents/css`)) {
-    fs.mkdirSync(`${rootPath}/media/system/webcomponents/css`);
-  }
+    if (!fs.existsSync(`${rootPath}/media/system/webcomponents/css`)) {
+        fs.mkdirSync(`${rootPath}/media/system/webcomponents/css`);
+    }
 
   options.settings.elements.forEach((element) => {
+    console.log(element)
+    console.log(options.settings.webcomponents[element]['css']);
+    console.log(options.settings.webcomponents[element]['js']);
+    // Make sure that the dist paths exist
+    if (!fs.existsSync(`${rootPath}/media/${options.settings.webcomponents[element]['js']}`)) {
+        fsExtra.mkdirSync(`${rootPath}/media/${options.settings.webcomponents[element]['js']}`);
+    }
+
+    if (!fs.existsSync(`${rootPath}/media/${options.settings.webcomponents[element]['css']}`)) {
+        fs.mkdirSync(`${rootPath}/media/${options.settings.webcomponents[element]['css']}`);
+    }
+
     // Copy the ES6 file
     let es6File = fs.readFileSync(`${rootPath}/build/media/webcomponents/js/${element}/${element}.js`, 'utf8');
     // Check if there is a css file
@@ -86,23 +98,23 @@ const compile = (options) => {
                   if (typeof res === 'object' && res.css) {
                     es6File = es6File.replace('{{CSS_CONTENTS_PLACEHOLDER}}', UglyCss.processString(res.css.toString()));
 
-                    createJsFiles(element, es6File);
+                    createJsFiles(element, es6File, options);
                   }
                 } else {
                   if (typeof res === 'object' && res.css) {
                     fs.writeFileSync(
-                      `${rootPath}/media/system/webcomponents/css/joomla-${element}.css`,
+                      `${rootPath}/media/${options.settings.webcomponents[element]['css']}/joomla-${element}.css`,
                       res.css.toString(),
                       { encoding: 'UTF-8' },
                     );
                     fs.writeFileSync(
-                      `${rootPath}/media/system/webcomponents/css/joomla-${element}.min.css`,
+                      `${rootPath}/media/${options.settings.webcomponents[element]['css']}/joomla-${element}.min.css`,
                       UglyCss.processString(res.css.toString(), { expandVars: false }),
                       { encoding: 'UTF-8' },
                     );
                   }
 
-                  createJsFiles(element, es6File);
+                  createJsFiles(element, es6File, options);
                 }
               })
 
@@ -120,7 +132,7 @@ const compile = (options) => {
         }
       });
     } else {
-      createJsFiles(element, es6File);
+      createJsFiles(element, es6File, options);
     }
   });
 };

--- a/build/build-modules-js/settings.json
+++ b/build/build-modules-js/settings.json
@@ -17,44 +17,65 @@
       "editor-codemirror",
       "hidden-mail",
       "editor-none",
-      "toolbar-button"
+      "toolbar-button",
+      "core-loader"
     ],
     "webcomponents": {
+      "core-loader": {
+        "css": "system/webcomponents/css",
+        "js": "system/webcomponents/js"
+      },
+      "field-user": {
+        "css": "system/webcomponents/css",
+        "js": "system/webcomponents/js"
+      },
       "field-media": {
-        "css": "media/system/webcomponents/css",
-        "js": "media/system/webcomponents/js"
+        "css": "system/webcomponents/css",
+        "js": "system/webcomponents/js"
+      },
+      "field-permissions": {
+        "css": "system/webcomponents/css",
+        "js": "system/webcomponents/js"
+      },
+      "hidden-mail": {
+        "css": "system/webcomponents/css",
+        "js": "system/webcomponents/js"
+      },
+      "toolbar-button": {
+        "css": "system/webcomponents/css",
+        "js": "system/webcomponents/js"
       },
       "field-switcher": {
-        "css": "media/system/webcomponents/css",
-        "js": "media/system/webcomponents/js"
+        "css": "system/webcomponents/css",
+        "js": "system/webcomponents/js"
       },
       "field-simple-color": {
-        "css": "media/system/webcomponents/css",
-        "js": "media/system/webcomponents/js"
+        "css": "system/webcomponents/css",
+        "js": "system/webcomponents/js"
       },
       "field-send-test-mail": {
-        "css": "media/system/webcomponents/css",
-        "js": "media/system/webcomponents/js"
+        "css": "system/webcomponents/css",
+        "js": "system/webcomponents/js"
       },
       "editor-codemirror": {
-        "css": "media/system/webcomponents/css",
-        "js": "media/system/webcomponents/js"
+        "css": "system/webcomponents/css",
+        "js": "system/webcomponents/js"
       },
       "editor-none": {
-        "css": "media/system/webcomponents/css",
-        "js": "media/system/webcomponents/js"
+        "css": "system/webcomponents/css",
+        "js": "system/webcomponents/js"
       },
       "field-module-order": {
-        "css": "media/system/webcomponents/css",
-        "js": "media/system/webcomponents/js"
+        "css": "system/webcomponents/css",
+        "js": "system/webcomponents/js"
       },
       "field-hidden-mail": {
-        "css": "media/system/webcomponents/css",
-        "js": "media/system/webcomponents/js"
+        "css": "system/webcomponents/css",
+        "js": "system/webcomponents/js"
       },
       "field-subform": {
-        "css": "media/system/webcomponents/css",
-        "js": "media/system/webcomponents/js"
+        "css": "system/webcomponents/css",
+        "js": "system/webcomponents/js"
       }
     },
     "vendors": {

--- a/build/media/com_associations/js/sidebyside.js
+++ b/build/media/com_associations/js/sidebyside.js
@@ -13,7 +13,7 @@ jQuery(document).ready(function($) {
 		if (task === 'association.cancel') {
 			Joomla.submitform(task);
 		} else if(task === 'copy') {
-			Joomla.loadingLayer('show');
+            document.body.appendChild(document.createElement('joomla-core-loader'));
 
 			var targetLang = document.getElementById('target-association').getAttribute('data-language'),
 			    referlangInput = window.frames['reference-association'].document.getElementById('jform_language');
@@ -83,9 +83,6 @@ jQuery(document).ready(function($) {
 		return false;
 	};
 
-	// Preload Joomla loading layer.
-	Joomla.loadingLayer('load');
-
 	// Attach behaviour to toggle button.
 	$(document).on('click', '#toogle-left-panel', function() {
 		var referenceHide = this.getAttribute('data-hide-reference');
@@ -113,7 +110,7 @@ jQuery(document).ready(function($) {
 			target.setAttribute('data-language', selected.split(':')[0]);
 
 			// Iframe load start, show Joomla loading layer.
-			Joomla.loadingLayer('show');
+            document.body.appendChild(document.createElement('joomla-core-loader'));
 
 			// Load the target frame.
 			target.src = target.getAttribute('data-editurl') + '&task=' + target.getAttribute('data-item') + '.' + target.getAttribute('data-action') + '&id=' + target.getAttribute('data-id');
@@ -168,7 +165,8 @@ jQuery(document).ready(function($) {
 		});
 
 		// Iframe load finished, hide Joomla loading layer.
-		Joomla.loadingLayer('hide');
+        var spinner = document.querySelector('joomla-core-loader');
+        spinner.parentNode.removeChild(spinner)
 	});
 
 	// Attach behaviour to target frame load event.
@@ -274,8 +272,9 @@ jQuery(document).ready(function($) {
 				}
 			});
 
-			// Iframe load finished, hide Joomla loading layer.
-			Joomla.loadingLayer('hide');
+            // Iframe load finished, hide Joomla loading layer.
+            var spinner = document.querySelector('joomla-core-loader');
+            spinner.parentNode.removeChild(spinner)
 		}
 	});
 });

--- a/build/media/webcomponents/js/core-loader/core-loader.js
+++ b/build/media/webcomponents/js/core-loader/core-loader.js
@@ -1,0 +1,56 @@
+((customElements) => {
+    'strict';
+
+    /**
+     * Creates a custom element with the default spinner of the Joomla logo
+     */
+    class JoomlaCoreLoader extends HTMLElement {
+        constructor() {
+            super();
+
+            const template = document.createElement('template');
+            template.innerHTML = `<style>{{CSS_CONTENTS_PLACEHOLDER}}</style>
+<div><span class="yellow"></span><span class="red"></span><span class="blue"></span><span class="green"></span><p>&reg;</p></div>`;
+
+            // Patch the shadow DOM
+            if (window.ShadyCSS) {
+                ShadyCSS.prepareTemplate(template, 'joomla-core-loader');
+            }
+
+            this.attachShadow({mode: 'open'});
+            this.shadowRoot.appendChild(template.content.cloneNode(true));
+
+            // Patch the shadow DOM
+            if (window.ShadyCSS) {
+                ShadyCSS.styleElement(this)
+            }
+        }
+
+        connectedCallback() {
+            this.style.backgroundColor = this.color;
+            this.style.opacity = 0.8;
+            this.shadowRoot.querySelector('div').classList.add('box');
+        }
+
+        static get observedAttributes() {
+            return ['color'];
+        }
+
+        get color() { return this.getAttribute('color') || '#fff'; }
+        set color(value) { this.setAttribute('color', value); }
+
+        attributeChangedCallback(attr, oldValue, newValue) {
+            switch (attr) {
+                case 'color':
+                    if (newValue && newValue !== oldValue) {
+                        this.style.backgroundColor = this.color;
+                    }
+                    break;
+                default:
+                // Do nothing
+            }
+        }
+    }
+
+    customElements.define('joomla-core-loader', JoomlaCoreLoader);
+})(customElements);

--- a/build/media/webcomponents/scss/core-loader/core-loader.scss
+++ b/build/media/webcomponents/scss/core-loader/core-loader.scss
@@ -1,0 +1,125 @@
+$theme-colours: ();
+$theme-colours: map-merge((
+        "yellow" : #f9a541,
+        "red"    : #f44321,
+        "blue"   : #5091cd,
+        "green"  : #7ac143,
+), $theme-colours);
+
+:host {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 10000;
+  display: block;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  opacity: .8;
+}
+
+.box {
+  width: 300px;
+  height: 300px;
+  margin: 0 auto;
+  transform: rotate(45deg);
+
+  p {
+    float: left;
+    margin: -20px 0 0 252px;
+    font: normal 1.25em/1em sans-serif;
+    color: #999;
+    transform: rotate(-45deg);
+  }
+
+  > span {
+    animation: jspinner 2s infinite ease-in-out;
+  }
+
+  .red {
+    animation-delay: -1.5s;
+  }
+  .blue {
+    animation-delay: -1s;
+  }
+  .green {
+    animation-delay: -.5s;
+  }
+}
+
+@each $colour in $theme-colours {
+  $key: nth($colour, 1);
+  $value: nth($colour, 2);
+
+  .#{$key} {
+    position: absolute;
+    width: 90px;
+    height: 90px;
+    content: "";
+    background: $value;
+    border-radius: 90px;
+
+    &::before,
+    &::after {
+      box-sizing: content-box;
+      border: 50px solid $value;
+    }
+
+    &::before {
+      position: absolute;
+      width: 50px;
+      height: 35px;
+      margin: 60px 0 0 -30px;
+      content: "";
+      background: transparent;
+      border-width: 50px 50px 0;
+      border-radius: 75px 75px 0 0;
+    }
+
+    &::after {
+      position: absolute;
+      width: 50px;
+      height: 101px;
+      margin: 145px 0 0 -30px;
+      content: "";
+      background: transparent;
+      border-width: 0 0 0 50px;
+    }
+  }
+}
+
+.yellow {
+  margin: 0 0 0 182px;
+  transform: rotate(0deg);
+}
+
+.red {
+  margin: 182px 0 0 364px;
+  transform: rotate(90deg);
+}
+
+.blue {
+  margin: 364px 0 0 182px;
+  transform: rotate(180deg);
+}
+
+.green {
+  margin: 182px 0 0;
+  transform: rotate(270deg);
+}
+
+@keyframes jspinner {
+  0%, 40%, 100% {
+    opacity: .3;
+  }
+  20% {
+    opacity: 1;
+  }
+}
+
+
+@media (prefers-reduced-motion: reduce) {
+  .box > span {
+    animation: none;
+  }
+}

--- a/build/media_src/system/js/core.es6.js
+++ b/build/media_src/system/js/core.es6.js
@@ -705,69 +705,6 @@ Joomla.Modal = {
   };
 
   /**
-   * Add Joomla! loading image layer.
-   *
-   * Used in: /administrator/components/com_installer/views/languages/tmpl/default.php
-   *          /installation/template/js/installation.js
-   *
-   * @param   {String}       task           The task to do [load, show, hide] (defaults to show).
-   * @param   {HTMLElement}  parentElement  The HTML element where we are appending the layer
-   *          (defaults to body).
-   *
-   * @return  {HTMLElement}  The HTML loading layer element.
-   *
-   * @since  3.6.0
-   */
-  Joomla.loadingLayer = (task, parentElement) => {
-    // Set default values.
-    const newTask = task || 'show';
-    const newParentElement = parentElement || document.body;
-
-    // Create the loading layer (hidden by default).
-    if (newTask === 'load') {
-      // Gets the site base path
-      const systemPaths = Joomla.getOptions('system.paths') || {};
-      const basePath = systemPaths.root || '';
-
-      const loadingDiv = document.createElement('div');
-
-      loadingDiv.id = 'loading-logo';
-
-      // The loading layer CSS styles are JS hardcoded so they can be used without adding CSS.
-
-      // Loading layer style and positioning.
-      loadingDiv.style.position = 'fixed';
-      loadingDiv.style.top = '0';
-      loadingDiv.style.left = '0';
-      loadingDiv.style.width = '100%';
-      loadingDiv.style.height = '100%';
-      loadingDiv.style.opacity = '0.8';
-      loadingDiv.style.filter = 'alpha(opacity=80)';
-      loadingDiv.style.overflow = 'hidden';
-      loadingDiv.style['z-index'] = '10000';
-      loadingDiv.style.display = 'none';
-      loadingDiv.style['background-color'] = '#fff';
-
-      // Loading logo positioning.
-      loadingDiv.style['background-image'] = `url("${basePath}/media/system/images/ajax-loader.gif")`;
-      loadingDiv.style['background-position'] = 'center';
-      loadingDiv.style['background-repeat'] = 'no-repeat';
-      loadingDiv.style['background-attachment'] = 'fixed';
-
-      newParentElement.appendChild(loadingDiv);
-    } else {
-      // Show or hide the layer.
-      if (!document.getElementById('loading-logo')) {
-        Joomla.loadingLayer('load', newParentElement);
-      }
-
-      document.getElementById('loading-logo').style.display = (newTask === 'show') ? 'block' : 'none';
-    }
-
-    return document.getElementById('loading-logo');
-  };
-
-  /**
    * Method to Extend Objects
    *
    * @param  {Object}  destination

--- a/installation/template/index.php
+++ b/installation/template/index.php
@@ -24,6 +24,7 @@ HTMLHelper::_('behavior.keepalive');
 HTMLHelper::_('behavior.formvalidator');
 HTMLHelper::_('script', 'installation/template/js/template.js', ['version' => 'auto']);
 HTMLHelper::_('webcomponent', 'vendor/joomla-custom-elements/joomla-alert.min.js', ['version' => 'auto', 'relative' => true]);
+HTMLHelper::_('webcomponent', 'system/webcomponents/joomla-core-loader.min.js', ['version' => 'auto', 'relative' => true]);
 
 // Add script options
 $this->addScriptOptions('system.installation', ['url' => JRoute::_('index.php')]);

--- a/installation/template/js/setup.js
+++ b/installation/template/js/setup.js
@@ -12,7 +12,7 @@
 Joomla.setlanguage = function(form) {
 	var data = Joomla.serialiseForm(form);
 
-	Joomla.loadingLayer("show");
+    document.body.appendChild(document.createElement('joomla-core-loader'));
 	Joomla.removeMessages();
 
 	Joomla.request({
@@ -30,14 +30,17 @@ Joomla.setlanguage = function(form) {
 
 			if (response.error) {
 				Joomla.renderMessages({'error': [response.message]});
-				Joomla.loadingLayer("hide");
+				var el = document.querySelector('joomla-core-loader')
+				el.parentNode.removeChild(el);
 			} else {
-				Joomla.loadingLayer("hide");
+                var el = document.querySelector('joomla-core-loader')
+                el.parentNode.removeChild(el);
 				Joomla.goToPage(response.data.view, true);
 			}
 		},
 		onError:   function(xhr){
-			Joomla.loadingLayer("hide");
+            var el = document.querySelector('joomla-core-loader')
+            el.parentNode.removeChild(el);
 			try {
 				var r = JSON.parse(xhr.responseText);
 				Joomla.replaceTokens(r.token);
@@ -71,7 +74,7 @@ Joomla.checkInputs = function() {
 
 
 Joomla.checkDbCredentials = function() {
-	Joomla.loadingLayer("show");
+    document.body.appendChild(document.createElement('joomla-core-loader'));
 
 	var form = document.getElementById('adminForm'),
 		data = Joomla.serialiseForm(form);
@@ -89,7 +92,8 @@ Joomla.checkDbCredentials = function() {
 			}
 
 			Joomla.replaceTokens(response.token);
-			Joomla.loadingLayer("hide");
+            var el = document.querySelector('joomla-core-loader')
+            el.parentNode.removeChild(el);
 
 			if (response.error) {
 				Joomla.renderMessages({'error': [response.message]});
@@ -102,7 +106,8 @@ Joomla.checkDbCredentials = function() {
 		onError:   function(xhr){
 			Joomla.renderMessages([['', Joomla.JText._('JLIB_DATABASE_ERROR_DATABASE_CONNECT', 'A Database error occurred.')]]);
 			//Install.goToPage('summary');
-			Joomla.loadingLayer('hide');
+            var el = document.querySelector('joomla-core-loader')
+            el.parentNode.removeChild(el);
 			try {
 				var r = JSON.parse(xhr.responseText);
 				Joomla.replaceTokens(r.token);

--- a/installation/template/js/setup.js
+++ b/installation/template/js/setup.js
@@ -12,7 +12,7 @@
 Joomla.setlanguage = function(form) {
 	var data = Joomla.serialiseForm(form);
 
-    document.body.appendChild(document.createElement('joomla-core-loader'));
+	document.body.appendChild(document.createElement('joomla-core-loader'));
 	Joomla.removeMessages();
 
 	Joomla.request({
@@ -34,12 +34,12 @@ Joomla.setlanguage = function(form) {
 				el.parentNode.removeChild(el);
 			} else {
                 var el = document.querySelector('joomla-core-loader')
-                el.parentNode.removeChild(el);
+				el.parentNode.removeChild(el);
 				Joomla.goToPage(response.data.view, true);
 			}
 		},
 		onError:   function(xhr){
-            var el = document.querySelector('joomla-core-loader')
+			var el = document.querySelector('joomla-core-loader')
             el.parentNode.removeChild(el);
 			try {
 				var r = JSON.parse(xhr.responseText);
@@ -74,7 +74,7 @@ Joomla.checkInputs = function() {
 
 
 Joomla.checkDbCredentials = function() {
-    document.body.appendChild(document.createElement('joomla-core-loader'));
+	document.body.appendChild(document.createElement('joomla-core-loader'));
 
 	var form = document.getElementById('adminForm'),
 		data = Joomla.serialiseForm(form);
@@ -92,8 +92,8 @@ Joomla.checkDbCredentials = function() {
 			}
 
 			Joomla.replaceTokens(response.token);
-            var el = document.querySelector('joomla-core-loader')
-            el.parentNode.removeChild(el);
+			var el = document.querySelector('joomla-core-loader')
+			el.parentNode.removeChild(el);
 
 			if (response.error) {
 				Joomla.renderMessages({'error': [response.message]});
@@ -106,8 +106,8 @@ Joomla.checkDbCredentials = function() {
 		onError:   function(xhr){
 			Joomla.renderMessages([['', Joomla.JText._('JLIB_DATABASE_ERROR_DATABASE_CONNECT', 'A Database error occurred.')]]);
 			//Install.goToPage('summary');
-            var el = document.querySelector('joomla-core-loader')
-            el.parentNode.removeChild(el);
+			var el = document.querySelector('joomla-core-loader')
+			el.parentNode.removeChild(el);
 			try {
 				var r = JSON.parse(xhr.responseText);
 				Joomla.replaceTokens(r.token);

--- a/installation/template/js/template.js
+++ b/installation/template/js/template.js
@@ -34,7 +34,7 @@
 	Joomla.goToPage = function(page, fromSubmit) {
 		if (!fromSubmit) {
 			Joomla.removeMessages();
-            document.body.appendChild(document.createElement('joomla-core-loader'));
+			document.body.appendChild(document.createElement('joomla-core-loader'));
 		}
 
 		if (page) {
@@ -52,7 +52,7 @@
 	Joomla.submitform = function(form) {
 		var data = Joomla.serialiseForm(form);
 
-        document.body.appendChild(document.createElement('joomla-core-loader'));
+		document.body.appendChild(document.createElement('joomla-core-loader'));
 		Joomla.removeMessages();
 
 		Joomla.request({
@@ -69,19 +69,19 @@
 
 				if (response.error) {
 					Joomla.renderMessages({'error': [response.message]});
-                    var el = document.querySelector('joomla-core-loader')
-                    el.parentNode.removeChild(el);
+					var el = document.querySelector('joomla-core-loader')
+					el.parentNode.removeChild(el);
 				} else {
-                    var el = document.querySelector('joomla-core-loader')
-                    el.parentNode.removeChild(el);
+					var el = document.querySelector('joomla-core-loader')
+					el.parentNode.removeChild(el);
 					if (response.data && response.data.view) {
 						Install.goToPage(response.data.view, true);
 					}
 				}
 			},
 			onError  : function (xhr) {
-                var el = document.querySelector('joomla-core-loader')
-                el.parentNode.removeChild(el);
+				var el = document.querySelector('joomla-core-loader')
+				el.parentNode.removeChild(el);
 				busy = false;
 				try {
 					var r = JSON.parse(xhr.responseText);
@@ -193,8 +193,8 @@
 					Joomla.renderMessages(response.messages);
 					Joomla.goToPage(response.data.view, true);
 				} else {
-                    var el = document.querySelector('joomla-core-loader')
-                    el.parentNode.removeChild(el);
+					var el = document.querySelector('joomla-core-loader')
+					el.parentNode.removeChild(el);
 					Joomla.install(tasks, form);
 				}
 			},

--- a/installation/template/js/template.js
+++ b/installation/template/js/template.js
@@ -34,7 +34,7 @@
 	Joomla.goToPage = function(page, fromSubmit) {
 		if (!fromSubmit) {
 			Joomla.removeMessages();
-			Joomla.loadingLayer("show");
+            document.body.appendChild(document.createElement('joomla-core-loader'));
 		}
 
 		if (page) {
@@ -52,7 +52,7 @@
 	Joomla.submitform = function(form) {
 		var data = Joomla.serialiseForm(form);
 
-		Joomla.loadingLayer("show");
+        document.body.appendChild(document.createElement('joomla-core-loader'));
 		Joomla.removeMessages();
 
 		Joomla.request({
@@ -69,16 +69,19 @@
 
 				if (response.error) {
 					Joomla.renderMessages({'error': [response.message]});
-					Joomla.loadingLayer("hide");
+                    var el = document.querySelector('joomla-core-loader')
+                    el.parentNode.removeChild(el);
 				} else {
-					Joomla.loadingLayer("hide");
+                    var el = document.querySelector('joomla-core-loader')
+                    el.parentNode.removeChild(el);
 					if (response.data && response.data.view) {
 						Install.goToPage(response.data.view, true);
 					}
 				}
 			},
 			onError  : function (xhr) {
-				Joomla.loadingLayer("hide");
+                var el = document.querySelector('joomla-core-loader')
+                el.parentNode.removeChild(el);
 				busy = false;
 				try {
 					var r = JSON.parse(xhr.responseText);
@@ -140,9 +143,6 @@
 			document.formvalidator.attachToForm(form);
 		});
 
-		// Create and append the loading layer.
-		Joomla.loadingLayer("load");
-
 		// Check for FTP credentials
 		Joomla.installation = Joomla.installation || {};
 
@@ -178,7 +178,7 @@
 
 		var task = tasks.shift();
 		var data = Joomla.serialiseForm(form);
-		Joomla.loadingLayer("show");
+        document.body.appendChild(document.createElement('joomla-core-loader'));
 
 		Joomla.request({
 			method: "POST",
@@ -193,7 +193,8 @@
 					Joomla.renderMessages(response.messages);
 					Joomla.goToPage(response.data.view, true);
 				} else {
-					Joomla.loadingLayer('hide');
+                    var el = document.querySelector('joomla-core-loader')
+                    el.parentNode.removeChild(el);
 					Joomla.install(tasks, form);
 				}
 			},

--- a/layouts/joomla/form/field/category.php
+++ b/layouts/joomla/form/field/category.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   Copyright (C) 2005 - 2018 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('JPATH_BASE') or die;
+
+use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Language\Text;
+
+extract($displayData, null);
+
+/**
+ * Layout variables
+ * -----------------
+ * @var   string   $autocomplete    Autocomplete attribute for the field.
+ * @var   boolean  $autofocus       Is autofocus enabled?
+ * @var   string   $class           Classes for the input.
+ * @var   string   $description     Description of the field.
+ * @var   boolean  $disabled        Is this field disabled?
+ * @var   string   $group           Group the field belongs to. <fields> section in form XML.
+ * @var   boolean  $hidden          Is this field hidden in the form?
+ * @var   string   $hint            Placeholder for the field.
+ * @var   string   $id              DOM id of the field.
+ * @var   string   $label           Label of the field.
+ * @var   string   $labelclass      Classes to apply to the label.
+ * @var   boolean  $multiple        Does this field support multiple values?
+ * @var   string   $name            Name of the input field.
+ * @var   string   $onchange        Onchange attribute for the field.
+ * @var   string   $onclick         Onclick attribute for the field.
+ * @var   string   $pattern         Pattern (Reg Ex) of value of the form field.
+ * @var   boolean  $readonly        Is this field read only?
+ * @var   boolean  $repeat          Allows extensions to duplicate elements.
+ * @var   boolean  $required        Is this field required?
+ * @var   integer  $size            Size attribute of the input.
+ * @var   boolean  $spellchec       Spellcheck state for the form field.
+ * @var   string   $validate        Validation rules to apply.
+ * @var   string   $value           Value attribute of the field.
+ * @var   array    $checkedOptions  Options that will be set as checked.
+ * @var   boolean  $hasValue        Has this field a value assigned?
+ * @var   array    $options         Options available for this field.
+ */
+$class    = ' class="custom-select ' . trim($class) . '"';
+$disabled = $disabled ? ' disabled' : '';
+$readonly = $readonly ? ' readonly' : '';
+
+$html  = [];
+$class = [];
+$attr  = '';
+
+// Initialize some field attributes.
+$class[] = !empty($class) ? $class : '';
+
+if ($allowAdd)
+{
+	$class[] = 'chosen-custom-value';
+	$attr .= ' data-custom_group_text="' . Text::_('JGLOBAL_CUSTOM_CATEGORY') . '" '
+		. 'data-no_results_text="' . Text::_('JGLOBAL_ADD_CUSTOM_CATEGORY') . '" '
+		. 'data-placeholder="' . Text::_('JGLOBAL_TYPE_OR_SELECT_CATEGORY') . '" ';
+}
+
+if ($class)
+{
+	$attr .= 'class="' . implode(' ', $class) . '"';
+}
+
+$attr .= !empty($size) ? ' size="' . $size . '"' : '';
+$attr .= $multiple ? ' multiple' : '';
+$attr .= $required ? ' required' : '';
+$attr .= $autofocus ? ' autofocus' : '';
+
+// To avoid user's confusion, readonly="true" should imply disabled="true".
+if ((string) $readonly == '1'
+	|| (string) $readonly == 'true'
+	|| (string) $disabled == '1'
+	|| (string) $disabled == 'true')
+{
+	$attr .= ' disabled';
+}
+
+if ($enabledCF === true)
+{
+	$attr .= ' data-cat-id="' . $catId . '" data-form-id="' . $formId . '" data-section="' . $section . '"';
+	$attr .= ' onchange="Joomla.categoryHasChanged(this)"';
+}
+else
+{
+	$attr .= $onchange ? ' onchange="' . $onchange . '"' : '';
+}
+
+// Create a read-only list (no name) with hidden input(s) to store the value(s).
+if ((string) $readonly == '1' || (string) $readonly == 'true')
+{
+	$html[] = HTMLHelper::_('select.genericlist', $options, '', trim($attr), 'value', 'text', $value, $id);
+
+	// E.g. form field type tag sends $this->value as array
+	if ($multiple && is_array($value))
+	{
+		if (!count($value))
+		{
+			$value[] = '';
+		}
+
+		foreach ($value as $val)
+		{
+			$html[] = '<input type="hidden" name="' . $name . '" value="' . htmlspecialchars($val, ENT_COMPAT, 'UTF-8') . '">';
+		}
+	}
+	else
+	{
+		$html[] = '<input type="hidden" name="' . $name . '" value="' . htmlspecialchars($value, ENT_COMPAT, 'UTF-8') . '">';
+	}
+}
+else
+{
+	// Create a regular list.
+	if (count($options) === 0)
+	{
+		// All Categories have been deleted, so we need a new category (This will create on save if selected).
+		$options[0] = new \stdClass;
+		$options[0]->value     = 'Uncategorised';
+		$options[0]->text      = 'Uncategorised';
+		$options[0]->level     = '1';
+		$options[0]->published = '1';
+		$options[0]->lft       = '1';
+	}
+
+	HTMLHelper::_('webcomponent', 'system/webcomponents/joomla-core-loader.min.js', ['relative' => true, 'version' => 'auto']);
+
+	$html[] = HTMLHelper::_('select.genericlist', $options, $name, trim($attr), 'value', 'text', $value, $id);
+}
+
+echo implode($html);
+
+// Preload spindle-wheel when we need to submit form due to category selector changed
+\Joomla\CMS\Factory::getDocument()->addScriptDeclaration(
+<<<JS
+document.addEventListener('DOMContentLoaded', function() {
+	var element = document.querySelector('#$id');
+	if (!element.value != element.getAttribute('data-cat-id')) {
+		element.value = element.getAttribute('data-cat-id');
+	}
+
+	Joomla.categoryHasChanged = function (el) {
+		if (el.value == el.getAttribute('data-cat-id')) {
+			return;
+		}
+
+		document.body.appendChild(document.createElement('joomla-core-loader'));
+		document.querySelector('input[name=task]').value = el.getAttribute('data-section') + '.reload';
+		element.form.submit();
+	};
+});
+JS
+);

--- a/layouts/joomla/form/field/category.php
+++ b/layouts/joomla/form/field/category.php
@@ -84,8 +84,33 @@ if ((string) $readonly == '1'
 
 if ($enabledCF === true)
 {
+	HTMLHelper::_('webcomponent', 'system/webcomponents/joomla-core-loader.min.js', ['relative' => true, 'version' => 'auto']);
+
+
 	$attr .= ' data-cat-id="' . $catId . '" data-form-id="' . $formId . '" data-section="' . $section . '"';
 	$attr .= ' onchange="Joomla.categoryHasChanged(this)"';
+
+	// Preload spindle-wheel when we need to submit form due to category selector changed
+	\Joomla\CMS\Factory::getDocument()->addScriptDeclaration(
+<<<JS
+document.addEventListener('DOMContentLoaded', function() {
+	var element = document.querySelector('#$id');
+	if (!element.value != element.getAttribute('data-cat-id')) {
+		element.value = element.getAttribute('data-cat-id');
+	}
+
+	Joomla.categoryHasChanged = function (el) {
+		if (el.value == el.getAttribute('data-cat-id')) {
+			return;
+		}
+
+		document.body.appendChild(document.createElement('joomla-core-loader'));
+		document.querySelector('input[name=task]').value = el.getAttribute('data-section') + '.reload';
+		element.form.submit();
+	};
+});
+JS
+	);
 }
 else
 {
@@ -129,31 +154,7 @@ else
 		$options[0]->lft       = '1';
 	}
 
-	HTMLHelper::_('webcomponent', 'system/webcomponents/joomla-core-loader.min.js', ['relative' => true, 'version' => 'auto']);
-
 	$html[] = HTMLHelper::_('select.genericlist', $options, $name, trim($attr), 'value', 'text', $value, $id);
 }
 
 echo implode($html);
-
-// Preload spindle-wheel when we need to submit form due to category selector changed
-\Joomla\CMS\Factory::getDocument()->addScriptDeclaration(
-<<<JS
-document.addEventListener('DOMContentLoaded', function() {
-	var element = document.querySelector('#$id');
-	if (!element.value != element.getAttribute('data-cat-id')) {
-		element.value = element.getAttribute('data-cat-id');
-	}
-
-	Joomla.categoryHasChanged = function (el) {
-		if (el.value == el.getAttribute('data-cat-id')) {
-			return;
-		}
-
-		document.body.appendChild(document.createElement('joomla-core-loader'));
-		document.querySelector('input[name=task]').value = el.getAttribute('data-section') + '.reload';
-		element.form.submit();
-	};
-});
-JS
-);


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
- Drops the code from the core.js for the spinner (already deprecated in j3) and introduces a web component
- Some minor changes in the build module for the web components. The settings.json will now allow custom paths in the media folder. So someone could do some PRs to move the fields custom elements to their appropriate place (/media/system/js/fields/)
- Seperated the logic from the mark up for the category field (someone really needs to do this for all the mark up that is hidden in fields or some helpers!!!)
- Reworked the custom fields part that injected some inline jQuery script. So now the script is part of the category field (that is the right place for the js to live) and the helper just passes some data to the field. The js is still inline so someone should just move it to a file...
- Patched the custom fields to work with the new element
- Patched the installation to work with the new element
- Patched the com_associations to work with the new element

### Testing Instructions
Install Joomla, spinner is ok
Make sure that you have custom fields assigned to one category. Edit an article and change its cat to the one that custom fields are attached. spinner is ok
Try a multilingual and check if the spinner works ok

### Expected result



### Actual result



### Documentation Changes Required

In 4.0 in each page that a spinner is needed the following steps will need to be done:

- Include the web component
```php
HTMLHelper::_('webcomponent', 'system/webcomponents/joomla-core-loader.min.js', ['relative' => true, 'version' => 'auto']);
```

- To show the spinner all we need to do is create an element:
```js
spinner = document.createElement('joomla-core-loader');

// Assuming that the spinner is full screen
document.body.appendChild(spinner);

/*
if we need to append the spinner to some other container
all we have to do is replace document.body with the element 
that we want the spinner to appear
*/
```

- To remove the spinner all we need to do is destroy the element:
```js
spinner = document.querySelector('joomla-core-loader');

spinner.parentNode.removeChild(spinner);
```

 if you want to use the same codebase for different versions (j3 and j4) here is a quick code:

```js
if (Joomla.loadingLayer && typeof Joomla.loadingLayer === 'function') {
 // We are in J3 so use the old method
 Joomla.loadingLayer('show');
} else {
 // We are in the future
spinner = document.createElement('joomla-core-loader');
document.body.appendChild(spinner);
}
```
