### PR TITLE
[4.0] com_associations: sidebyside js and css not loaded

### DIFF
--- a/administrator/components/com_associations/tmpl/association/edit.php
+++ b/administrator/components/com_associations/tmpl/association/edit.php
@@ -17,8 +17,8 @@ HTMLHelper::_('behavior.formvalidator');
 HTMLHelper::_('behavior.keepalive');
 HTMLHelper::_('jquery.framework');
 
-HTMLHelper::_('script', 'com_associations/sidebyside.js', false, true);
-HTMLHelper::_('stylesheet', 'com_associations/sidebyside.css', array(), true);
+HTMLHelper::_('script', 'com_associations/sidebyside.js', ['version' => 'auto', 'relative' => true]);
+HTMLHelper::_('stylesheet', 'com_associations/sidebyside.css', ['version' => 'auto', 'relative' => true]);
 
 $options = array(
 			'layout'   => $this->app->input->get('layout', '', 'string'),


### PR DESCRIPTION
### Summary of Changes
Loading the js and css files

### Testing Instructions
Although we still need to modify some stuff in com_associations ( see https://github.com/joomla/joomla-cms/pull/22166 ), the js and css were no more loaded.

### After patch
Both panels are now displayed side by side and not one upon the other, etc.

Can be merged on review.

@laoneo @wilsonge  