### PR TITLE
[4.0] Legend font weight

### DIFF
--- a/administrator/templates/atum/scss/blocks/_global.scss
+++ b/administrator/templates/atum/scss/blocks/_global.scss
@@ -31,7 +31,7 @@ small,
 
 legend {
   font-size: 1.2rem;
-  font-weight: $black-weight;
+  font-weight: $bold-weight;
   ;
 }
 


### PR DESCRIPTION
a font-weight of 900 for the legend is too much - this pr sets it to a more sensible 700

### before
![image](https://user-images.githubusercontent.com/1296369/46523870-fa905e80-c87e-11e8-8a81-abc2b8195f74.png)

### after
![image](https://user-images.githubusercontent.com/1296369/46523888-0714b700-c87f-11e8-8788-785a0729ef32.png)
