### PR TITLE
[4.0] stats plugin buttons [a11y]

### DIFF
--- a/plugins/system/stats/layouts/message.php
+++ b/plugins/system/stats/layouts/message.php
@@ -33,8 +33,8 @@ extract($displayData);
 	?>
 	<p><?php echo Text::_('PLG_SYSTEM_STATS_MSG_ALLOW_SENDING_DATA'); ?></p>
 	<p class="actions">
-		<a href="#" class="btn btn-primary js-pstats-btn-allow-always"><?php echo Text::_('PLG_SYSTEM_STATS_BTN_SEND_ALWAYS'); ?></a>
-		<a href="#" class="btn btn-primary js-pstats-btn-allow-once"><?php echo Text::_('PLG_SYSTEM_STATS_BTN_SEND_NOW'); ?></a>
-		<a href="#" class="btn btn-primary js-pstats-btn-allow-never"><?php echo Text::_('PLG_SYSTEM_STATS_BTN_NEVER_SEND'); ?></a>
+		<button type="button" class="btn btn-primary js-pstats-btn-allow-always"><?php echo Text::_('PLG_SYSTEM_STATS_BTN_SEND_ALWAYS'); ?></button>
+		<button type="button" class="btn btn-primary js-pstats-btn-allow-once"><?php echo Text::_('PLG_SYSTEM_STATS_BTN_SEND_NOW'); ?></button>
+		<button type="button" class="btn btn-primary js-pstats-btn-allow-never"><?php echo Text::_('PLG_SYSTEM_STATS_BTN_NEVER_SEND'); ?></button>
 	</p>
 </joomla-alert>


### PR DESCRIPTION
this Pr is for the the buttons on the joomla stats popup buttons 

![image](https://user-images.githubusercontent.com/1296369/46530422-94f99d80-c891-11e8-9d75-8e35bcc9d0c2.png)


Before this pr they were `<a href=` with a class to make them look like buttons but without a role=nutton

They are visually styled as buttons and they work like buttons so they should behave as buttons and be identified as buttons

The default behaviour for a button is for it to be selected by either space or enter whereas the default behaviour for a link is for it only to be selected by the enter key.


There is no visual change - however if you use the tab key to navigate to the buttons you will be able to test that you can select the button and a modal opens by pressing the space bar as well as the enter key.


Please dont tell me about other areas of core that are also wrong - there are a lot - and I will submit discrete pr for them - as it will be easier to test