### PR TITLE
[4.0] Error in System Information

### DIFF
--- a/administrator/components/com_admin/tmpl/sysinfo/default_phpsettings.php
+++ b/administrator/components/com_admin/tmpl/sysinfo/default_phpsettings.php
@@ -86,7 +86,7 @@ use Joomla\CMS\HTML\HTMLHelper;
 					<?php echo Text::_('COM_ADMIN_SESSION_AUTO_START'); ?>
 				</th>
 				<td>
-					<?php echo HTMLHelper::_('phpsetting.integer', $this->php_settings['session.auto_start']); ?>
+					<?php echo $this->php_settings['session.auto_start']; ?>
 				</td>
 			</tr>
 			<tr>
@@ -142,7 +142,7 @@ use Joomla\CMS\HTML\HTMLHelper;
 					<?php echo Text::_('COM_ADMIN_MAX_INPUT_VARS'); ?>
 				</th>
 				<td>
-					<?php echo HTMLHelper::_('phpsetting.integer', $this->php_settings['max_input_vars']); ?>
+					<?php echo $this->php_settings['max_input_vars']; ?>
 				</td>
 			</tr>
 		</tbody>

--- a/administrator/components/com_admin/tmpl/sysinfo/default_phpsettings.php
+++ b/administrator/components/com_admin/tmpl/sysinfo/default_phpsettings.php
@@ -86,7 +86,7 @@ use Joomla\CMS\HTML\HTMLHelper;
 					<?php echo Text::_('COM_ADMIN_SESSION_AUTO_START'); ?>
 				</th>
 				<td>
-					<?php echo $this->php_settings['session.auto_start']; ?>
+					<?php echo (int) $this->php_settings['session.auto_start']; ?>
 				</td>
 			</tr>
 			<tr>
@@ -142,7 +142,7 @@ use Joomla\CMS\HTML\HTMLHelper;
 					<?php echo Text::_('COM_ADMIN_MAX_INPUT_VARS'); ?>
 				</th>
 				<td>
-					<?php echo $this->php_settings['max_input_vars']; ?>
+					<?php echo (int) $this->php_settings['max_input_vars']; ?>
 				</td>
 			</tr>
 		</tbody>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Removes calls to code that was removed in #22297.

### Testing Instructions

Go to System -> Information -> System Information (`/administrator/index.php?option=com_admin&view=sysinfo`).

### Expected result

No error. `Session Auto Start` and `Maximum Input Variables` values shown.

### Actual result
```
Recoverable fatal error: Object of class Joomla\Component\Admin\Administrator\Service\HTML\PhpSetting could not be converted to string in /public_html/400/libraries/src/HTML/HTMLHelper.php on line 149
```

### Documentation Changes Required
No.
