### PR TITLE
[staging fix] Class 'ContentHelperAssociation' not found when editing a module in frontend

### DIFF
--- a/components/com_content/models/articles.php
+++ b/components/com_content/models/articles.php
@@ -13,6 +13,8 @@ use Joomla\Registry\Registry;
 use Joomla\String\StringHelper;
 use Joomla\Utilities\ArrayHelper;
 
+JLoader::register('ContentHelperAssociation', JPATH_SITE . '/components/com_content/helpers/association.php');
+
 /**
  * This models supports retrieving lists of articles.
  *
@@ -246,13 +248,13 @@ class ContentModelArticles extends JModelList
 		if (JPluginHelper::isEnabled('content', 'vote'))
 		{
 			// Join on voting table
-			$query->select('COALESCE(NULLIF(ROUND(v.rating_sum  / v.rating_count, 0), 0), 0) AS rating, 
+			$query->select('COALESCE(NULLIF(ROUND(v.rating_sum  / v.rating_count, 0), 0), 0) AS rating,
 							COALESCE(NULLIF(v.rating_count, 0), 0) as rating_count')
 				->join('LEFT', '#__content_rating AS v ON a.id = v.content_id');
 		}
 
 		// Filter by access level.
-		if ($this->getState('filter.access', true))	
+		if ($this->getState('filter.access', true))
 		{
 			$groups = implode(',', $user->getAuthorisedViewLevels());
 			$query->where('a.access IN (' . $groups . ')')


### PR DESCRIPTION
### Summary of Changes
Loading the class in SITE/components/com_content/models/articles.php

### Testing Instructions
Set a multilingual site.
In Global Configuration allow Inline Editing for `Modules & Menus`
<img width="691" alt="screen shot 2018-10-06 at 12 23 48" src="https://user-images.githubusercontent.com/869724/46570329-cb531d80-c962-11e8-9852-8c5637131e83.png">

Edit Global Options for Articles and set `Show associations` to Show
<img width="694" alt="screen shot 2018-10-06 at 12 23 05" src="https://user-images.githubusercontent.com/869724/46570338-eb82dc80-c962-11e8-9253-5a85dc02637a.png">

Make sure you have some articles associated.

**EDIT: Display on the page a `mod_latest_news` module.**

Login frontend as super user and edit a module by clicking on the icon

<img width="419" alt="screen shot 2018-10-06 at 12 27 43" src="https://user-images.githubusercontent.com/869724/46570366-41578480-c963-11e8-8158-28d70feb6d5e.png">



### Before patch
Protostar in error and `Class 'ContentHelperAssociation' not found` (this will show if debug is on)

### After patch
All OK.


_Note: The class is loaded in 4.0_