### PR TITLE
[com_actionlogs]  - fix non object notice

### DIFF
--- a/administrator/components/com_actionlogs/libraries/actionlogplugin.php
+++ b/administrator/components/com_actionlogs/libraries/actionlogplugin.php
@@ -57,7 +57,7 @@ abstract class ActionLogPlugin extends JPlugin
 	 */
 	protected function addLog($messages, $messageLanguageKey, $context, $userId = null)
 	{
-		$user = $this->app->getIdentity();
+		$user = JFactory::getUser();
 
 		foreach ($messages as $index => $message)
 		{


### PR DESCRIPTION
Pull Request for Issue #22525


### Testing Instructions
see #22525


### Expected result
no notice


### Actual result
PHP error log
`PHP Notice:  Trying to get property 'id' of non-object `

