### PR TITLE
[4.0] JText not found in JROOT\libraries\src\Form\Field\PluginsField.php:173

### DIFF
--- a/libraries/src/Form/Field/PluginsField.php
+++ b/libraries/src/Form/Field/PluginsField.php
@@ -170,7 +170,7 @@ class PluginsField extends ListField
 	 */
 	protected function getInput()
 	{
-		if (count($this->options) === 1 && $this->options[0]->text === JText::_('JOPTION_DO_NOT_USE'))
+		if (count($this->options) === 1 && $this->options[0]->text === Text::_('JOPTION_DO_NOT_USE'))
 		{
 			$this->readonly = true;
 		}


### PR DESCRIPTION
### Testing Instructions
- Code review because it's obvious
OR:
- Install Nightly 4 of today Sunday, 07 October 2018 02:00:37 UTC
- Apply patch 22512 first!
(- Activate debug via configuration.php (I think not needed).)
- Go into Global configuration 
`Class 'Joomla\CMS\Form\Field\JText' not found in JROOT\libraries\src\Form\Field\PluginsField.php:173`

- Apply patch and try again.
