### PR TITLE
[4.0] Installer library query fixes

### DIFF
--- a/libraries/src/Installer/Adapter/ComponentAdapter.php
+++ b/libraries/src/Installer/Adapter/ComponentAdapter.php
@@ -393,9 +393,9 @@ class ComponentAdapter extends InstallerAdapter
 		$query->clear()
 			->delete('#__categories')
 			->where('extension = :extension')
-			->where('extension LIKE :extension_wildcard')
+			->where('extension LIKE :wildcard')
 			->bind(':extension', $extensionName)
-			->bind(':extension_wildcard', $extensionNameWithWildcard);
+			->bind(':wildcard', $extensionNameWithWildcard);
 		$db->setQuery($query);
 		$db->execute();
 

--- a/libraries/src/Installer/Adapter/PluginAdapter.php
+++ b/libraries/src/Installer/Adapter/PluginAdapter.php
@@ -19,6 +19,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
 use Joomla\CMS\Table\Table;
 use Joomla\CMS\Table\Update;
+use Joomla\Database\ParameterType;
 
 /**
  * Plugin installer


### PR DESCRIPTION
Pull Request for Issues #21958 & #22531

### Summary of Changes

As it seems nobody else will fix database query related issues, here's the pull request fixing two reported issues with queries in the extension installer library:

- Renames a query parameter since parameter substitution is incorrectly replacing the second parameter
- Adds a missing use statement for a PHP class

### Testing Instructions

- Code review
- Attempt to uninstall a component or plugin

### Expected result

Operations complete successfully

### Actual result

Operations do not complete

### Additional Comments

Any other style related fixes or errors are out of scope of this pull request and will not be addressed by me.  Far too often unrelated fixes are being requested in pull requests making it easier for pull requests to introduce more changes and newer bugs, changes should be isolated and tested/reviewed separately.