### PR TITLE
[4.0] XAMPP on Windows. Template Manager. Saving of files fails

### DIFF
--- a/administrator/components/com_templates/Controller/TemplateController.php
+++ b/administrator/components/com_templates/Controller/TemplateController.php
@@ -13,6 +13,7 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Client\ClientHelper;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Filesystem\Path;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Controller\BaseController;
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
@@ -312,7 +313,7 @@ class TemplateController extends BaseController
 
 			return false;
 		}
-		elseif ($data['filename'] != end($explodeArray))
+		elseif (Path::clean($data['filename'], '/') != end($explodeArray))
 		{
 			$this->setMessage(Text::_('COM_TEMPLATES_ERROR_SOURCE_ID_FILENAME_MISMATCH'), 'error');
 


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/22535

### Summary of Changes
- Force slash in file paths for WINDOWS paths

### Testing Instructions
- Use **XAMPP on WINDOWS** with installation of nightly build Joomla 4. I've tested with  XAMPP 7.2.x
- Go to template manager:
`administrator/index.php?option=com_templates&view=templates&client_id=0`
- Open Casseiopaia template and edit a css file.
- After Save or Save&Close:
- - Empty grey component area.
- - Changed file not saved.

- Apply patch.
- Test again.

### Expected result
- Changed file saved.
- Correct template manager view.