### PR TITLE
[com_actionlogs] Sort events in alpha order

### DIFF
--- a/administrator/components/com_actionlogs/models/fields/logtype.php
+++ b/administrator/components/com_actionlogs/models/fields/logtype.php
@@ -56,6 +56,6 @@ class JFormFieldLogType extends JFormFieldCheckboxes
 			$options[] = (object) array_merge($tmp, (array) $option);
 		}
 
-		return array_merge(parent::getOptions(), ArrayHelper::sortObjects($options, 'text', 1, true, Factory::getLanguage()->getLocale()));
+		return array_merge(parent::getOptions(), ArrayHelper::sortObjects($options, 'text', 1, false, Factory::getLanguage()->getLocale()));
 	}
 }

--- a/administrator/components/com_actionlogs/models/fields/logtype.php
+++ b/administrator/components/com_actionlogs/models/fields/logtype.php
@@ -9,6 +9,9 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Factory;
+use Joomla\Utilities\ArrayHelper;
+
 JFormHelper::loadFieldClass('checkboxes');
 JLoader::register('ActionlogsHelper', JPATH_ADMINISTRATOR . '/components/com_actionlogs/helpers/actionlogs.php');
 
@@ -38,29 +41,21 @@ class JFormFieldLogType extends JFormFieldCheckboxes
 	{
 		$db = JFactory::getDbo();
 		$query = $db->getQuery(true)
-			->select('a.extension')
-			->from($db->quoteName('#__action_logs_extensions', 'a'));
+			->select($db->quoteName('extension'))
+			->from($db->quoteName('#__action_logs_extensions'));
 
-		$db->setQuery($query);
+		$extensions = $db->setQuery($query)->loadColumn();
 
-		$extensions = $db->loadObjectList();
-
-		$options  = array();
-		$defaults = array();
+		$options = array();
+		$tmp     = array('checked' => true);
 
 		foreach ($extensions as $extension)
 		{
-			$tmp = array(
-				'checked' => true,
-			);
-
-			$defaults[] = $extension;
-
-			ActionlogsHelper::loadTranslationFiles($extension->extension);
-			$option = JHtml::_('select.option', $extension->extension, JText::_($extension->extension));
+			ActionlogsHelper::loadTranslationFiles($extension);
+			$option = JHtml::_('select.option', $extension, JText::_($extension));
 			$options[] = (object) array_merge($tmp, (array) $option);
 		}
 
-		return array_merge(parent::getOptions(), $options);
+		return array_merge(parent::getOptions(), ArrayHelper::sortObjects($options, 'text', 1, true, Factory::getLanguage()->getLocale()));
 	}
 }

--- a/administrator/components/com_actionlogs/models/fields/logtype.php
+++ b/administrator/components/com_actionlogs/models/fields/logtype.php
@@ -9,8 +9,7 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\Factory;
-use Joomla\Utilities\ArrayHelper;
+use Joomla\CMS\Application\ApplicationHelper;
 
 JFormHelper::loadFieldClass('checkboxes');
 JLoader::register('ActionlogsHelper', JPATH_ADMINISTRATOR . '/components/com_actionlogs/helpers/actionlogs.php');
@@ -53,9 +52,11 @@ class JFormFieldLogType extends JFormFieldCheckboxes
 		{
 			ActionlogsHelper::loadTranslationFiles($extension);
 			$option = JHtml::_('select.option', $extension, JText::_($extension));
-			$options[] = (object) array_merge($tmp, (array) $option);
+			$options[ApplicationHelper::stringURLSafe(JText::_($extension)) . '_' . $extension] = (object) array_merge($tmp, (array) $option);
 		}
 
-		return array_merge(parent::getOptions(), ArrayHelper::sortObjects($options, 'text', 1, false, Factory::getLanguage()->getLocale()));
+		ksort($options);
+
+		return array_merge(parent::getOptions(), array_values($options));
 	}
 }


### PR DESCRIPTION
Pull Request for Issue  #22533.

### Summary of Changes

This sorts loggable extensions alphabetically.

### Testing Instructions

Go to ```System > Global Configuration > User Actions Log```

### Expected result

Extensions sorted alphabetically.

### Actual result

```Articles``` and ```Check-in``` are not in alpha order.

### Documentation Changes Required
No.