### PR TITLE
[3.9.0] correcting action log link when module is saved in frontend

### DIFF
--- a/plugins/actionlog/joomla/joomla.php
+++ b/plugins/actionlog/joomla/joomla.php
@@ -469,6 +469,11 @@ class PlgActionlogJoomla extends ActionLogPlugin
 	{
 		$option = $this->app->input->getCmd('option');
 
+		if ($table->get('module') != null)
+		{
+			$option = 'com_modules';
+		}
+
 		if (!$this->checkLoggable($option))
 		{
 			return;


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/22532

### Summary of Changes
When saving a module in frontend, the link created wrongly uses `com_config` in the url.
This PR checks the $table to get `com_modules` which is the right `$option` in this case. 
### Testing Instructions
See https://github.com/joomla/joomla-cms/issues/22532

@alikon 