### PR TITLE
[4.0] Improve workflow association DB keys

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/4.0.0-2018-05-15.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.0.0-2018-05-15.sql
@@ -41,7 +41,8 @@ CREATE TABLE IF NOT EXISTS `#__workflow_associations` (
   `item_id` int(10) NOT NULL DEFAULT 0 COMMENT 'Extension table id value',
   `stage_id` int(10) NOT NULL COMMENT 'Foreign Key to #__workflow_stages.id',
   `extension` varchar(50) NOT NULL,
-  PRIMARY KEY (`item_id`, `stage_id`, `extension`),
+  PRIMARY KEY (`item_id`, `extension`),
+  KEY `idx_item_stage_extension` (`item_id`, `stage_id`, `extension`)
   KEY `idx_item_id` (`item_id`),
   KEY `idx_stage_id` (`stage_id`),
   KEY `idx_extension` (`extension`)

--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2018-05-15.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2018-05-15.sql
@@ -38,8 +38,9 @@ CREATE TABLE IF NOT EXISTS "#__workflow_associations" (
   "item_id" bigint DEFAULT 0 NOT NULL,
   "stage_id" bigint DEFAULT 0 NOT NULL,
   "extension" varchar(50) NOT NULL,
-  PRIMARY KEY ("item_id", "stage_id", "extension")
+  PRIMARY KEY ("item_id", "extension")
 );
+CREATE INDEX "#__workflow_associations_idx_item_stage_extension" ON "#__workflow_associations" ("item_id", "stage_id", "extension");
 CREATE INDEX "#__workflow_associations_idx_item_id" ON "#__workflow_associations" ("item_id");
 CREATE INDEX "#__workflow_associations_idx_stage_id" ON "#__workflow_associations" ("stage_id");
 CREATE INDEX "#__workflow_associations_idx_extension" ON "#__workflow_associations" ("extension");

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -1997,7 +1997,8 @@ CREATE TABLE IF NOT EXISTS `#__workflow_associations` (
   `item_id` int(10) NOT NULL DEFAULT 0 COMMENT 'Extension table id value',
   `stage_id` int(10) NOT NULL COMMENT 'Foreign Key to #__workflow_stages.id',
   `extension` varchar(50) NOT NULL,
-  PRIMARY KEY (`item_id`, `stage_id`, `extension`),
+  PRIMARY KEY (`item_id`, `extension`),
+  KEY `idx_item_stage_extension` (`item_id`, `stage_id`, `extension`),
   KEY `idx_item_id` (`item_id`),
   KEY `idx_stage_id` (`stage_id`),
   KEY `idx_extension` (`extension`)

--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -1994,8 +1994,9 @@ CREATE TABLE IF NOT EXISTS "#__workflow_associations" (
   "item_id" bigint DEFAULT 0 NOT NULL,
   "stage_id" bigint DEFAULT 0 NOT NULL,
   "extension" varchar(50) NOT NULL,
-  PRIMARY KEY ("item_id", "stage_id", "extension")
+  PRIMARY KEY ("item_id", "extension")
 );
+CREATE INDEX "#__workflow_associations_idx_item_stage_extension" ON "#__workflow_associations" ("item_id", "stage_id", "extension");
 CREATE INDEX "#__workflow_associations_idx_item_id" ON "#__workflow_associations" ("item_id");
 CREATE INDEX "#__workflow_associations_idx_stage_id" ON "#__workflow_associations" ("stage_id");
 CREATE INDEX "#__workflow_associations_idx_extension" ON "#__workflow_associations" ("extension");


### PR DESCRIPTION
### Summary of Changes
This PR just correct the primary (unique) key for the workflow association tables. The stage ID should not be part of the key, because otherwise you could add something like: (1, 1, 'com_content'), (1, 2, 'com_content'), which is not correct.


### Testing Instructions
Install Joomla!, should behave as before.

