### PR TITLE
[3.9.0] No need to escape PLG_QUICKICON_PRIVACYCHECK language strings values

### DIFF
--- a/plugins/quickicon/privacycheck/privacycheck.php
+++ b/plugins/quickicon/privacycheck/privacycheck.php
@@ -54,11 +54,11 @@ class PlgQuickiconPrivacyCheck extends JPlugin
 			'plg_quickicon_privacycheck_url'      => Uri::base() . $privacy . '&view=requests&filter[status]=1&list[fullordering]=a.requested_at ASC',
 			'plg_quickicon_privacycheck_ajax_url' => Uri::base() . $privacy . '&task=getNumberUrgentRequests&' . $token,
 			'plg_quickicon_privacycheck_text'     => array(
-				"NOREQUEST"            => Text::_('PLG_QUICKICON_PRIVACYCHECK_NOREQUEST', true),
-				"REQUESTFOUND"         => Text::_('PLG_QUICKICON_PRIVACYCHECK_REQUESTFOUND', true),
-				"REQUESTFOUND_MESSAGE" => Text::_('PLG_QUICKICON_PRIVACYCHECK_REQUESTFOUND_MESSAGE', true),
-				"REQUESTFOUND_BUTTON"  => Text::_('PLG_QUICKICON_PRIVACYCHECK_REQUESTFOUND_BUTTON', true),
-				"ERROR"                => Text::_('PLG_QUICKICON_PRIVACYCHECK_ERROR', true),
+				"NOREQUEST"            => Text::_('PLG_QUICKICON_PRIVACYCHECK_NOREQUEST'),
+				"REQUESTFOUND"         => Text::_('PLG_QUICKICON_PRIVACYCHECK_REQUESTFOUND'),
+				"REQUESTFOUND_MESSAGE" => Text::_('PLG_QUICKICON_PRIVACYCHECK_REQUESTFOUND_MESSAGE'),
+				"REQUESTFOUND_BUTTON"  => Text::_('PLG_QUICKICON_PRIVACYCHECK_REQUESTFOUND_BUTTON'),
+				"ERROR"                => Text::_('PLG_QUICKICON_PRIVACYCHECK_ERROR'),
 			)
 		);
 


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/22549

### Summary of Changes
As title says

### Testing Instructions
Add some single quotes in the `administrator/language/en-GB/en-GB.plg_quickicon_privacycheck.ini`
Create a privacy request. Load cpanel

### Before patch
<img width="633" alt="screen shot 2018-10-08 at 12 10 20" src="https://user-images.githubusercontent.com/869724/46603553-a6da7b00-caf3-11e8-810d-db657d9ae2ab.png">

<img width="336" alt="screen shot 2018-10-08 at 12 10 26" src="https://user-images.githubusercontent.com/869724/46603555-a9d56b80-caf3-11e8-9348-b2da48315cdf.png">



### After patch

<img width="690" alt="screen shot 2018-10-09 at 09 30 53" src="https://user-images.githubusercontent.com/869724/46653797-40af3000-cba7-11e8-884c-65d36cc43ce6.png">

<img width="352" alt="screen shot 2018-10-09 at 09 31 00" src="https://user-images.githubusercontent.com/869724/46653811-473da780-cba7-11e8-8b83-0e1c630132ba.png">

