### PR TITLE
[3.9.0] Correcting link when switching to current language

### DIFF
--- a/modules/mod_languages/tmpl/default.php
+++ b/modules/mod_languages/tmpl/default.php
@@ -60,7 +60,7 @@ if ($params->get('dropdown', 0) && !$params->get('dropdownimage', 1))
 				<li class="lang-active">
 				<a href="<?php echo htmlspecialchars_decode(htmlspecialchars($base, ENT_QUOTES, 'UTF-8'), ENT_NOQUOTES); ?>">
 					<?php if ($language->image) : ?>
-						<?php echo JHtml::_('image', 'mod_languages/' . $language->image . '.gif',  '', null, true); ?>
+						<?php echo JHtml::_('image', 'mod_languages/' . $language->image . '.gif', '', null, true); ?>
 					<?php endif; ?>
 				<?php echo $language->title_native; ?>
 				</a>

--- a/modules/mod_languages/tmpl/default.php
+++ b/modules/mod_languages/tmpl/default.php
@@ -23,10 +23,10 @@ if ($params->get('dropdown', 0) && !$params->get('dropdownimage', 1))
 <?php endif; ?>
 
 <?php if ($params->get('dropdown', 0) && !$params->get('dropdownimage', 1)) : ?>
-	<form name="lang" method="post" action="<?php echo JFilterOutput::ampReplace(htmlspecialchars(JUri::current(), ENT_COMPAT, 'UTF-8')); ?>">
+	<form name="lang" method="post" action="<?php echo htmlspecialchars(JUri::current(), ENT_COMPAT, 'UTF-8'); ?>">
 	<select class="inputbox advancedSelect" onchange="document.location.replace(this.value);" >
 	<?php foreach ($list as $language) : ?>
-		<option dir=<?php echo $language->rtl ? '"rtl"' : '"ltr"'; ?> value="<?php echo JFilterOutput::ampReplace(htmlspecialchars($language->link, ENT_QUOTES, 'UTF-8')); ?>" <?php echo $language->active ? 'selected="selected"' : ''; ?>>
+		<option dir=<?php echo $language->rtl ? '"rtl"' : '"ltr"'; ?> value="<?php echo htmlspecialchars($language->link, ENT_QUOTES, 'UTF-8'); ?>" <?php echo $language->active ? 'selected="selected"' : ''; ?>>
 		<?php echo $language->title_native; ?></option>
 	<?php endforeach; ?>
 	</select>
@@ -48,7 +48,7 @@ if ($params->get('dropdown', 0) && !$params->get('dropdownimage', 1))
 		<?php foreach ($list as $language) : ?>
 			<?php if (!$language->active) : ?>
 				<li>
-				<a href="<?php echo JFilterOutput::ampReplace(htmlspecialchars($language->link, ENT_QUOTES, 'UTF-8')); ?>">
+				<a href="<?php echo htmlspecialchars($language->link, ENT_QUOTES, 'UTF-8'); ?>">
 					<?php if ($language->image) : ?>
 						<?php echo JHtml::_('image', 'mod_languages/' . $language->image . '.gif', '', null, true); ?>
 					<?php endif; ?>
@@ -58,7 +58,7 @@ if ($params->get('dropdown', 0) && !$params->get('dropdownimage', 1))
 			<?php elseif ($params->get('show_active', 1)) : ?>
 				<?php $base = JUri::getInstance(); ?>
 				<li class="lang-active">
-				<a href="<?php echo JFilterOutput::ampReplace(htmlspecialchars($base, ENT_QUOTES, 'UTF-8')); ?>">
+				<a href="<?php echo htmlspecialchars($base, ENT_QUOTES, 'UTF-8'); ?>">
 					<?php if ($language->image) : ?>
 						<?php echo JHtml::_('image', 'mod_languages/' . $language->image . '.gif',  '', null, true); ?>
 					<?php endif; ?>
@@ -74,7 +74,7 @@ if ($params->get('dropdown', 0) && !$params->get('dropdownimage', 1))
 	<?php foreach ($list as $language) : ?>
 		<?php if (!$language->active) : ?>
 			<li>
-			<a href="<?php echo JFilterOutput::ampReplace(htmlspecialchars($language->link, ENT_QUOTES, 'UTF-8')); ?>">
+			<a href="<?php echo htmlspecialchars($language->link, ENT_QUOTES, 'UTF-8'); ?>">
 			<?php if ($params->get('image', 1)) : ?>
 				<?php if ($language->image) : ?>
 					<?php echo JHtml::_('image', 'mod_languages/' . $language->image . '.gif', $language->title_native, array('title' => $language->title_native), true); ?>
@@ -89,7 +89,7 @@ if ($params->get('dropdown', 0) && !$params->get('dropdownimage', 1))
 		<?php elseif ($params->get('show_active', 1)) : ?>
 			<?php $base = JUri::getInstance(); ?>
 			<li class="lang-active">
-			<a href="<?php echo JFilterOutput::ampReplace(htmlspecialchars($base, ENT_QUOTES, 'UTF-8')); ?>">
+			<a href="<?php echo htmlspecialchars($base, ENT_QUOTES, 'UTF-8'); ?>">
 			<?php if ($params->get('image', 1)) : ?>
 				<?php if ($language->image) : ?>
 					<?php echo JHtml::_('image', 'mod_languages/' . $language->image . '.gif', $language->title_native, array('title' => $language->title_native), true); ?>

--- a/modules/mod_languages/tmpl/default.php
+++ b/modules/mod_languages/tmpl/default.php
@@ -23,10 +23,10 @@ if ($params->get('dropdown', 0) && !$params->get('dropdownimage', 1))
 <?php endif; ?>
 
 <?php if ($params->get('dropdown', 0) && !$params->get('dropdownimage', 1)) : ?>
-	<form name="lang" method="post" action="<?php echo htmlspecialchars(JUri::current(), ENT_COMPAT, 'UTF-8'); ?>">
+	<form name="lang" method="post" action="<?php echo JFilterOutput::ampReplace(htmlspecialchars(JUri::current(), ENT_COMPAT, 'UTF-8')); ?>">
 	<select class="inputbox advancedSelect" onchange="document.location.replace(this.value);" >
 	<?php foreach ($list as $language) : ?>
-		<option dir=<?php echo $language->rtl ? '"rtl"' : '"ltr"'; ?> value="<?php echo htmlspecialchars($language->link, ENT_QUOTES, 'UTF-8'); ?>" <?php echo $language->active ? 'selected="selected"' : ''; ?>>
+		<option dir=<?php echo $language->rtl ? '"rtl"' : '"ltr"'; ?> value="<?php echo JFilterOutput::ampReplace(htmlspecialchars($language->link, ENT_QUOTES, 'UTF-8')); ?>" <?php echo $language->active ? 'selected="selected"' : ''; ?>>
 		<?php echo $language->title_native; ?></option>
 	<?php endforeach; ?>
 	</select>
@@ -48,17 +48,17 @@ if ($params->get('dropdown', 0) && !$params->get('dropdownimage', 1))
 		<?php foreach ($list as $language) : ?>
 			<?php if (!$language->active) : ?>
 				<li>
-				<a href="<?php echo htmlspecialchars($language->link, ENT_QUOTES, 'UTF-8'); ?>">
+				<a href="<?php echo JFilterOutput::ampReplace(htmlspecialchars($language->link, ENT_QUOTES, 'UTF-8')); ?>">
 					<?php if ($language->image) : ?>
 						<?php echo JHtml::_('image', 'mod_languages/' . $language->image . '.gif', '', null, true); ?>
 					<?php endif; ?>
 				<?php echo $language->title_native; ?>
 				</a>
 				</li>
-			<?php elseif ($language->active && $params->get('show_active', 1)) : ?>
+			<?php elseif ($params->get('show_active', 1)) : ?>
 				<?php $base = JUri::getInstance(); ?>
 				<li class="lang-active">
-				<a href="<?php echo htmlspecialchars($base, ENT_QUOTES, 'UTF-8'); ?>">
+				<a href="<?php echo JFilterOutput::ampReplace(htmlspecialchars($base, ENT_QUOTES, 'UTF-8')); ?>">
 					<?php if ($language->image) : ?>
 						<?php echo JHtml::_('image', 'mod_languages/' . $language->image . '.gif',  '', null, true); ?>
 					<?php endif; ?>
@@ -74,7 +74,7 @@ if ($params->get('dropdown', 0) && !$params->get('dropdownimage', 1))
 	<?php foreach ($list as $language) : ?>
 		<?php if (!$language->active) : ?>
 			<li>
-			<a href="<?php echo htmlspecialchars($language->link, ENT_QUOTES, 'UTF-8'); ?>">
+			<a href="<?php echo JFilterOutput::ampReplace(htmlspecialchars($language->link, ENT_QUOTES, 'UTF-8')); ?>">
 			<?php if ($params->get('image', 1)) : ?>
 				<?php if ($language->image) : ?>
 					<?php echo JHtml::_('image', 'mod_languages/' . $language->image . '.gif', $language->title_native, array('title' => $language->title_native), true); ?>
@@ -86,10 +86,10 @@ if ($params->get('dropdown', 0) && !$params->get('dropdownimage', 1))
 			<?php endif; ?>
 			</a>
 			</li>
-		<?php elseif ($language->active && $params->get('show_active', 1)) : ?>
+		<?php elseif ($params->get('show_active', 1)) : ?>
 			<?php $base = JUri::getInstance(); ?>
 			<li class="lang-active">
-			<a href="<?php echo htmlspecialchars($base, ENT_QUOTES, 'UTF-8'); ?>">
+			<a href="<?php echo JFilterOutput::ampReplace(htmlspecialchars($base, ENT_QUOTES, 'UTF-8')); ?>">
 			<?php if ($params->get('image', 1)) : ?>
 				<?php if ($language->image) : ?>
 					<?php echo JHtml::_('image', 'mod_languages/' . $language->image . '.gif', $language->title_native, array('title' => $language->title_native), true); ?>

--- a/modules/mod_languages/tmpl/default.php
+++ b/modules/mod_languages/tmpl/default.php
@@ -23,10 +23,10 @@ if ($params->get('dropdown', 0) && !$params->get('dropdownimage', 1))
 <?php endif; ?>
 
 <?php if ($params->get('dropdown', 0) && !$params->get('dropdownimage', 1)) : ?>
-	<form name="lang" method="post" action="<?php echo htmlspecialchars(JUri::current(), ENT_COMPAT, 'UTF-8'); ?>">
+	<form name="lang" method="post" action="<?php echo htmlspecialchars_decode(htmlspecialchars(JUri::current(), ENT_COMPAT, 'UTF-8'), ENT_NOQUOTES); ?>">
 	<select class="inputbox advancedSelect" onchange="document.location.replace(this.value);" >
 	<?php foreach ($list as $language) : ?>
-		<option dir=<?php echo $language->rtl ? '"rtl"' : '"ltr"'; ?> value="<?php echo htmlspecialchars($language->link, ENT_QUOTES, 'UTF-8'); ?>" <?php echo $language->active ? 'selected="selected"' : ''; ?>>
+		<option dir=<?php echo $language->rtl ? '"rtl"' : '"ltr"'; ?> value="<?php echo htmlspecialchars_decode(htmlspecialchars($language->link, ENT_QUOTES, 'UTF-8'), ENT_NOQUOTES); ?>" <?php echo $language->active ? 'selected="selected"' : ''; ?>>
 		<?php echo $language->title_native; ?></option>
 	<?php endforeach; ?>
 	</select>
@@ -48,7 +48,7 @@ if ($params->get('dropdown', 0) && !$params->get('dropdownimage', 1))
 		<?php foreach ($list as $language) : ?>
 			<?php if (!$language->active) : ?>
 				<li>
-				<a href="<?php echo htmlspecialchars($language->link, ENT_QUOTES, 'UTF-8'); ?>">
+				<a href="<?php echo htmlspecialchars_decode(htmlspecialchars($language->link, ENT_QUOTES, 'UTF-8'), ENT_NOQUOTES); ?>">
 					<?php if ($language->image) : ?>
 						<?php echo JHtml::_('image', 'mod_languages/' . $language->image . '.gif', '', null, true); ?>
 					<?php endif; ?>
@@ -58,7 +58,7 @@ if ($params->get('dropdown', 0) && !$params->get('dropdownimage', 1))
 			<?php elseif ($params->get('show_active', 1)) : ?>
 				<?php $base = JUri::getInstance(); ?>
 				<li class="lang-active">
-				<a href="<?php echo htmlspecialchars($base, ENT_QUOTES, 'UTF-8'); ?>">
+				<a href="<?php echo htmlspecialchars_decode(htmlspecialchars($base, ENT_QUOTES, 'UTF-8'), ENT_NOQUOTES); ?>">
 					<?php if ($language->image) : ?>
 						<?php echo JHtml::_('image', 'mod_languages/' . $language->image . '.gif',  '', null, true); ?>
 					<?php endif; ?>
@@ -74,7 +74,7 @@ if ($params->get('dropdown', 0) && !$params->get('dropdownimage', 1))
 	<?php foreach ($list as $language) : ?>
 		<?php if (!$language->active) : ?>
 			<li>
-			<a href="<?php echo htmlspecialchars($language->link, ENT_QUOTES, 'UTF-8'); ?>">
+			<a href="<?php echo htmlspecialchars_decode(htmlspecialchars($language->link, ENT_QUOTES, 'UTF-8'), ENT_NOQUOTES); ?>">
 			<?php if ($params->get('image', 1)) : ?>
 				<?php if ($language->image) : ?>
 					<?php echo JHtml::_('image', 'mod_languages/' . $language->image . '.gif', $language->title_native, array('title' => $language->title_native), true); ?>
@@ -89,7 +89,7 @@ if ($params->get('dropdown', 0) && !$params->get('dropdownimage', 1))
 		<?php elseif ($params->get('show_active', 1)) : ?>
 			<?php $base = JUri::getInstance(); ?>
 			<li class="lang-active">
-			<a href="<?php echo htmlspecialchars($base, ENT_QUOTES, 'UTF-8'); ?>">
+			<a href="<?php echo htmlspecialchars_decode(htmlspecialchars($base, ENT_QUOTES, 'UTF-8'), ENT_NOQUOTES); ?>">
 			<?php if ($params->get('image', 1)) : ?>
 				<?php if ($language->image) : ?>
 					<?php echo JHtml::_('image', 'mod_languages/' . $language->image . '.gif', $language->title_native, array('title' => $language->title_native), true); ?>

--- a/modules/mod_languages/tmpl/default.php
+++ b/modules/mod_languages/tmpl/default.php
@@ -57,7 +57,7 @@ if ($params->get('dropdown', 0) && !$params->get('dropdownimage', 1))
 				</li>
 			<?php elseif ($language->active && $params->get('show_active', 1)) : ?>
 				<?php $base = JUri::getInstance(); ?>
-				<li <?php echo $language->active ? ' class="lang-active"' : ''; ?>>
+				<li<?php echo $language->active ? ' class="lang-active"' : ''; ?>>
 				<a href="<?php echo htmlspecialchars($base, ENT_QUOTES, 'UTF-8'); ?>">
 					<?php if ($language->image) : ?>
 						<?php echo JHtml::_('image', 'mod_languages/' . $language->image . '.gif',  '', null, true); ?>

--- a/modules/mod_languages/tmpl/default.php
+++ b/modules/mod_languages/tmpl/default.php
@@ -55,8 +55,6 @@ if ($params->get('dropdown', 0) && !$params->get('dropdownimage', 1))
 				<?php echo $language->title_native; ?>
 				</a>
 				</li>
-			<?php elseif ($language->active && !$params->get('show_active', 1)) : ?>
-				<li></li>
 			<?php elseif ($language->active && $params->get('show_active', 1)) : ?>
 				<?php $base = JUri::getInstance(); ?>
 				<li <?php echo $language->active ? ' class="lang-active"' : ''; ?>>
@@ -88,8 +86,6 @@ if ($params->get('dropdown', 0) && !$params->get('dropdownimage', 1))
 			<?php endif; ?>
 			</a>
 			</li>
-		<?php elseif ($language->active && !$params->get('show_active', 1)) : ?>
-			<li></li>
 		<?php elseif ($language->active && $params->get('show_active', 1)) : ?>
 			<?php $base = JUri::getInstance(); ?>
 			<li<?php echo $language->active ? ' class="lang-active"' : ''; ?> dir="<?php echo $language->rtl ? 'rtl' : 'ltr'; ?>">

--- a/modules/mod_languages/tmpl/default.php
+++ b/modules/mod_languages/tmpl/default.php
@@ -50,7 +50,7 @@ if ($params->get('dropdown', 0) && !$params->get('dropdownimage', 1))
 				<li>
 				<a href="<?php echo htmlspecialchars($language->link, ENT_QUOTES, 'UTF-8'); ?>">
 					<?php if ($language->image) : ?>
-						<?php echo JHtml::_('image', 'mod_languages/' . $language->image . '.gif',  '', null, true); ?>
+						<?php echo JHtml::_('image', 'mod_languages/' . $language->image . '.gif', '', null, true); ?>
 					<?php endif; ?>
 				<?php echo $language->title_native; ?>
 				</a>

--- a/modules/mod_languages/tmpl/default.php
+++ b/modules/mod_languages/tmpl/default.php
@@ -57,7 +57,7 @@ if ($params->get('dropdown', 0) && !$params->get('dropdownimage', 1))
 				</li>
 			<?php elseif ($language->active && $params->get('show_active', 1)) : ?>
 				<?php $base = JUri::getInstance(); ?>
-				<li<?php echo $language->active ? ' class="lang-active"' : ''; ?>>
+				<li class="lang-active">
 				<a href="<?php echo htmlspecialchars($base, ENT_QUOTES, 'UTF-8'); ?>">
 					<?php if ($language->image) : ?>
 						<?php echo JHtml::_('image', 'mod_languages/' . $language->image . '.gif',  '', null, true); ?>
@@ -70,10 +70,10 @@ if ($params->get('dropdown', 0) && !$params->get('dropdownimage', 1))
 		</ul>
 	</div>
 <?php else : ?>
-	<ul class="<?php echo $params->get('inline', 1) ? 'lang-inline' : 'lang-block'; ?>">
+	<ul class="<?php echo $params->get('inline', 1) ? 'lang-inline' : 'lang-block'; ?>" dir="<?php echo JFactory::getLanguage()->isRtl() ? 'rtl' : 'ltr'; ?>">
 	<?php foreach ($list as $language) : ?>
 		<?php if (!$language->active) : ?>
-			<li<?php echo $language->active ? ' class="lang-active"' : ''; ?> dir="<?php echo $language->rtl ? 'rtl' : 'ltr'; ?>">
+			<li>
 			<a href="<?php echo htmlspecialchars($language->link, ENT_QUOTES, 'UTF-8'); ?>">
 			<?php if ($params->get('image', 1)) : ?>
 				<?php if ($language->image) : ?>
@@ -88,7 +88,7 @@ if ($params->get('dropdown', 0) && !$params->get('dropdownimage', 1))
 			</li>
 		<?php elseif ($language->active && $params->get('show_active', 1)) : ?>
 			<?php $base = JUri::getInstance(); ?>
-			<li<?php echo $language->active ? ' class="lang-active"' : ''; ?> dir="<?php echo $language->rtl ? 'rtl' : 'ltr'; ?>">
+			<li class="lang-active">
 			<a href="<?php echo htmlspecialchars($base, ENT_QUOTES, 'UTF-8'); ?>">
 			<?php if ($params->get('image', 1)) : ?>
 				<?php if ($language->image) : ?>

--- a/modules/mod_languages/tmpl/default.php
+++ b/modules/mod_languages/tmpl/default.php
@@ -47,19 +47,27 @@ if ($params->get('dropdown', 0) && !$params->get('dropdownimage', 1))
 		<ul class="<?php echo $params->get('lineheight', 0) ? 'lang-block' : 'lang-inline'; ?> dropdown-menu" dir="<?php echo JFactory::getLanguage()->isRtl() ? 'rtl' : 'ltr'; ?>">
 		<?php foreach ($list as $language) : ?>
 			<?php if (!$language->active) : ?>
-				<li<?php echo $language->active ? ' class="lang-active"' : ''; ?>>
+				<li>
 				<a href="<?php echo htmlspecialchars($language->link, ENT_QUOTES, 'UTF-8'); ?>">
+					<?php if ($language->image) : ?>
+						<?php echo JHtml::_('image', 'mod_languages/' . $language->image . '.gif',  '', null, true); ?>
+					<?php endif; ?>
+				<?php echo $language->title_native; ?>
+				</a>
+				</li>
+			<?php elseif ($language->active && !$params->get('show_active', 1)) : ?>
+				<a><li>
 			<?php elseif ($language->active && $params->get('show_active', 1)) : ?>
-					<?php $base = JUri::getInstance(); ?>
-					<li<?php echo $language->active ? ' class="lang-active"' : ''; ?> dir="<?php echo $language->rtl ? 'rtl' : 'ltr'; ?>">
-					<a href="<?php echo htmlspecialchars($base, ENT_QUOTES, 'UTF-8'); ?>">
+				<?php $base = JUri::getInstance(); ?>
+				<li <?php echo $language->active ? ' class="lang-active"' : ''; ?>>
+				<a href="<?php echo htmlspecialchars($base, ENT_QUOTES, 'UTF-8'); ?>">
+					<?php if ($language->image) : ?>
+						<?php echo JHtml::_('image', 'mod_languages/' . $language->image . '.gif',  '', null, true); ?>
+					<?php endif; ?>
+				<?php echo $language->title_native; ?>
+				</a>
+				</li>
 			<?php endif; ?>
-			<?php if ($language->image) : ?>
-				<?php echo JHtml::_('image', 'mod_languages/' . $language->image . '.gif', '', null, true); ?>
-			<?php endif; ?>
-			<?php echo $language->title_native; ?>
-			</a>
-			</li>
 		<?php endforeach; ?>
 		</ul>
 	</div>
@@ -69,22 +77,35 @@ if ($params->get('dropdown', 0) && !$params->get('dropdownimage', 1))
 		<?php if (!$language->active) : ?>
 			<li<?php echo $language->active ? ' class="lang-active"' : ''; ?> dir="<?php echo $language->rtl ? 'rtl' : 'ltr'; ?>">
 			<a href="<?php echo htmlspecialchars($language->link, ENT_QUOTES, 'UTF-8'); ?>">
+			<?php if ($params->get('image', 1)) : ?>
+				<?php if ($language->image) : ?>
+					<?php echo JHtml::_('image', 'mod_languages/' . $language->image . '.gif', $language->title_native, array('title' => $language->title_native), true); ?>
+				<?php else : ?>
+					<span class="label"><?php echo strtoupper($language->sef); ?></span>
+				<?php endif; ?>
+			<?php else : ?>
+				<?php echo $params->get('full_name', 1) ? $language->title_native : strtoupper($language->sef); ?>
+			<?php endif; ?>
+			</a>
+			</li>
+		<?php elseif ($language->active && !$params->get('show_active', 1)) : ?>
+			<a><li>
 		<?php elseif ($language->active && $params->get('show_active', 1)) : ?>
 			<?php $base = JUri::getInstance(); ?>
 			<li<?php echo $language->active ? ' class="lang-active"' : ''; ?> dir="<?php echo $language->rtl ? 'rtl' : 'ltr'; ?>">
 			<a href="<?php echo htmlspecialchars($base, ENT_QUOTES, 'UTF-8'); ?>">
-		<?php endif; ?>
-		<?php if ($params->get('image', 1)) : ?>
-			<?php if ($language->image) : ?>
-				<?php echo JHtml::_('image', 'mod_languages/' . $language->image . '.gif', $language->title_native, array('title' => $language->title_native), true); ?>
+			<?php if ($params->get('image', 1)) : ?>
+				<?php if ($language->image) : ?>
+					<?php echo JHtml::_('image', 'mod_languages/' . $language->image . '.gif', $language->title_native, array('title' => $language->title_native), true); ?>
+				<?php else : ?>
+					<span class="label"><?php echo strtoupper($language->sef); ?></span>
+				<?php endif; ?>
 			<?php else : ?>
-				<span class="label"><?php echo strtoupper($language->sef); ?></span>
+				<?php echo $params->get('full_name', 1) ? $language->title_native : strtoupper($language->sef); ?>
 			<?php endif; ?>
-		<?php else : ?>
-			<?php echo $params->get('full_name', 1) ? $language->title_native : strtoupper($language->sef); ?>
+			</a>
+			</li>
 		<?php endif; ?>
-		</a>
-		</li>
 	<?php endforeach; ?>
 	</ul>
 <?php endif; ?>

--- a/modules/mod_languages/tmpl/default.php
+++ b/modules/mod_languages/tmpl/default.php
@@ -56,7 +56,7 @@ if ($params->get('dropdown', 0) && !$params->get('dropdownimage', 1))
 				</a>
 				</li>
 			<?php elseif ($language->active && !$params->get('show_active', 1)) : ?>
-				<a><li>
+				<li></li>
 			<?php elseif ($language->active && $params->get('show_active', 1)) : ?>
 				<?php $base = JUri::getInstance(); ?>
 				<li <?php echo $language->active ? ' class="lang-active"' : ''; ?>>
@@ -89,7 +89,7 @@ if ($params->get('dropdown', 0) && !$params->get('dropdownimage', 1))
 			</a>
 			</li>
 		<?php elseif ($language->active && !$params->get('show_active', 1)) : ?>
-			<a><li>
+			<li></li>
 		<?php elseif ($language->active && $params->get('show_active', 1)) : ?>
 			<?php $base = JUri::getInstance(); ?>
 			<li<?php echo $language->active ? ' class="lang-active"' : ''; ?> dir="<?php echo $language->rtl ? 'rtl' : 'ltr'; ?>">

--- a/modules/mod_languages/tmpl/default.php
+++ b/modules/mod_languages/tmpl/default.php
@@ -50,7 +50,7 @@ if ($params->get('dropdown', 0) && !$params->get('dropdownimage', 1))
 				<li<?php echo $language->active ? ' class="lang-active"' : ''; ?>>
 				<a href="<?php echo htmlspecialchars($language->link, ENT_QUOTES, 'UTF-8'); ?>">
 			<?php elseif ($language->active && $params->get('show_active', 1)) : ?>
-					<?php $base = JFactory::getDocument()->getBase(); ?>
+					<?php $base = JUri::getInstance(); ?>
 					<li<?php echo $language->active ? ' class="lang-active"' : ''; ?> dir="<?php echo $language->rtl ? 'rtl' : 'ltr'; ?>">
 					<a href="<?php echo htmlspecialchars($base, ENT_QUOTES, 'UTF-8'); ?>">
 			<?php endif; ?>
@@ -70,7 +70,7 @@ if ($params->get('dropdown', 0) && !$params->get('dropdownimage', 1))
 			<li<?php echo $language->active ? ' class="lang-active"' : ''; ?> dir="<?php echo $language->rtl ? 'rtl' : 'ltr'; ?>">
 			<a href="<?php echo htmlspecialchars($language->link, ENT_QUOTES, 'UTF-8'); ?>">
 		<?php elseif ($language->active && $params->get('show_active', 1)) : ?>
-			<?php $base = JFactory::getDocument()->getBase(); ?>
+			<?php $base = JUri::getInstance(); ?>
 			<li<?php echo $language->active ? ' class="lang-active"' : ''; ?> dir="<?php echo $language->rtl ? 'rtl' : 'ltr'; ?>">
 			<a href="<?php echo htmlspecialchars($base, ENT_QUOTES, 'UTF-8'); ?>">
 		<?php endif; ?>

--- a/modules/mod_languages/tmpl/default.php
+++ b/modules/mod_languages/tmpl/default.php
@@ -15,6 +15,7 @@ if ($params->get('dropdown', 0) && !$params->get('dropdownimage', 1))
 {
 	JHtml::_('formbehavior.chosen');
 }
+
 ?>
 <div class="mod-languages<?php echo $moduleclass_sfx; ?>">
 <?php if ($headerText) : ?>
@@ -45,37 +46,45 @@ if ($params->get('dropdown', 0) && !$params->get('dropdownimage', 1))
 		<?php endforeach; ?>
 		<ul class="<?php echo $params->get('lineheight', 0) ? 'lang-block' : 'lang-inline'; ?> dropdown-menu" dir="<?php echo JFactory::getLanguage()->isRtl() ? 'rtl' : 'ltr'; ?>">
 		<?php foreach ($list as $language) : ?>
-			<?php if (!$language->active || $params->get('show_active', 1)) : ?>
+			<?php if (!$language->active) : ?>
 				<li<?php echo $language->active ? ' class="lang-active"' : ''; ?>>
 				<a href="<?php echo htmlspecialchars($language->link, ENT_QUOTES, 'UTF-8'); ?>">
-					<?php if ($language->image) : ?>
-						<?php echo JHtml::_('image', 'mod_languages/' . $language->image . '.gif', '', null, true); ?>
-					<?php endif; ?>
-					<?php echo $language->title_native; ?>
-				</a>
-				</li>
+			<?php elseif ($language->active && $params->get('show_active', 1)) : ?>
+					<?php $base = JFactory::getDocument()->getBase(); ?>
+					<li<?php echo $language->active ? ' class="lang-active"' : ''; ?> dir="<?php echo $language->rtl ? 'rtl' : 'ltr'; ?>">
+					<a href="<?php echo htmlspecialchars($base, ENT_QUOTES, 'UTF-8'); ?>">
 			<?php endif; ?>
+			<?php if ($language->image) : ?>
+				<?php echo JHtml::_('image', 'mod_languages/' . $language->image . '.gif', '', null, true); ?>
+			<?php endif; ?>
+			<?php echo $language->title_native; ?>
+			</a>
+			</li>
 		<?php endforeach; ?>
 		</ul>
 	</div>
 <?php else : ?>
 	<ul class="<?php echo $params->get('inline', 1) ? 'lang-inline' : 'lang-block'; ?>">
 	<?php foreach ($list as $language) : ?>
-		<?php if (!$language->active || $params->get('show_active', 1)) : ?>
+		<?php if (!$language->active) : ?>
 			<li<?php echo $language->active ? ' class="lang-active"' : ''; ?> dir="<?php echo $language->rtl ? 'rtl' : 'ltr'; ?>">
 			<a href="<?php echo htmlspecialchars($language->link, ENT_QUOTES, 'UTF-8'); ?>">
-			<?php if ($params->get('image', 1)) : ?>
-				<?php if ($language->image) : ?>
-					<?php echo JHtml::_('image', 'mod_languages/' . $language->image . '.gif', $language->title_native, array('title' => $language->title_native), true); ?>
-				<?php else : ?>
-					<span class="label"><?php echo strtoupper($language->sef); ?></span>
-				<?php endif; ?>
-			<?php else : ?>
-				<?php echo $params->get('full_name', 1) ? $language->title_native : strtoupper($language->sef); ?>
-			<?php endif; ?>
-			</a>
-			</li>
+		<?php elseif ($language->active && $params->get('show_active', 1)) : ?>
+			<?php $base = JFactory::getDocument()->getBase(); ?>
+			<li<?php echo $language->active ? ' class="lang-active"' : ''; ?> dir="<?php echo $language->rtl ? 'rtl' : 'ltr'; ?>">
+			<a href="<?php echo htmlspecialchars($base, ENT_QUOTES, 'UTF-8'); ?>">
 		<?php endif; ?>
+		<?php if ($params->get('image', 1)) : ?>
+			<?php if ($language->image) : ?>
+				<?php echo JHtml::_('image', 'mod_languages/' . $language->image . '.gif', $language->title_native, array('title' => $language->title_native), true); ?>
+			<?php else : ?>
+				<span class="label"><?php echo strtoupper($language->sef); ?></span>
+			<?php endif; ?>
+		<?php else : ?>
+			<?php echo $params->get('full_name', 1) ? $language->title_native : strtoupper($language->sef); ?>
+		<?php endif; ?>
+		</a>
+		</li>
 	<?php endforeach; ?>
 	</ul>
 <?php endif; ?>


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/22555

### Summary of Changes
Using current url when Active Languages is set to display in the language switcher module and there is no specific menu item for the page.

### Testing Instructions
See https://github.com/joomla/joomla-cms/issues/22555

Create a multilingual site. Associate articles or not.
Make sure you set Active Language to Yes in the language switcher module.
Create a blog menu item (or list) for articles, but do NOT create any single article menu item.
Click on the title of one of these articles to display it by itself.
In the language switcher module, **click on the language or flag for the current language.**

### Before patch
The link obtained may load the original menu item (in that case the blog or list enu item).

### After patch
The link is the current link. It will reload the current page.

### Note
We could very easily not add any link in that case, but it would look weird to get a flag or a language name among the others with no action when clicking on it.