### PR TITLE
Allow to generate non SEF link when SEF is ON

### DIFF
--- a/libraries/src/Router/SiteRouter.php
+++ b/libraries/src/Router/SiteRouter.php
@@ -658,7 +658,7 @@ class SiteRouter extends Router
 
 		if ($stage === self::PROCESS_BEFORE)
 		{
-			$this->buildComponentPreprocess($router, $uri);
+			$this->buildComponentPreprocess($this, $uri);
 		}
 
 		if ($stage === self::PROCESS_DURING)

--- a/libraries/src/Router/SiteRouter.php
+++ b/libraries/src/Router/SiteRouter.php
@@ -658,19 +658,7 @@ class SiteRouter extends Router
 
 		if ($stage === self::PROCESS_BEFORE)
 		{
-			// Get the query data
-			$query = $uri->getQuery(true);
-
-			if (!isset($query['option']))
-			{
-				return;
-			}
-
-			// Build the component route
-			$component = preg_replace('/[^A-Z0-9_\.-]/i', '', $query['option']);
-			$router   = $this->getComponentRouter($component);
-			$query     = $router->preprocess($query);
-			$uri->setQuery($query);
+			$this->buildComponentPreprocess($router, $uri);
 		}
 
 		if ($stage === self::PROCESS_DURING)
@@ -746,6 +734,33 @@ class SiteRouter extends Router
 		}
 
 		return $uri;
+	}
+
+	/**
+	 * Run the component preprocess method
+	 *
+	 * @param   SiteRouter  &$router  Router object
+	 * @param   Uri         &$uri     URI object to process
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function buildComponentPreprocess(&$router, &$uri)
+	{
+		// Get the query data
+		$query = $uri->getQuery(true);
+
+		if (!isset($query['option']))
+		{
+			return;
+		}
+
+		$component = preg_replace('/[^A-Z0-9_\.-]/i', '', $query['option']);
+		$crouter   = $this->getComponentRouter($component);
+		$query     = $crouter->preprocess($query);
+
+		$uri->setQuery($query);
 	}
 
 	/**


### PR DESCRIPTION
### Summary of Changes
Sometimes, on the login form we need to create a non SEF url for the `return` parameter.

Thanks to the fact that the URL is not SEF, we can retrieve `Itemid` directly from the link without parsing SEF URL.

This PR extracts part of the code and places it in a separate public method. 
It could be treated as a backport of `SiteRouter::buildComponentPreprocess()` from J4.

### Testing Instructions
Code review.


### Expected result
Woks as before. No changes.

Example of usage:
```php
// SEF link for login page
$link = new Uri(Route::_('index.php?option=com_users&view=login', false));
// Non SEF link without Itemid			
$uri = new Uri(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid, $this->item->language));

$router = Factory::getApplication()->getRouter();
// This method adds Itemid=xxx to the link
$router->buildComponentPreprocess($router, $uri);
// Add return parameter to the login URL
$link->setVar('return', base64_encode($uri->toString()));
```

### Documentation Changes Required
New public method ``SiteRouter::buildComponentPreprocess()`` available.
