### PR TITLE
Fix wrong action log link when add/edit article

### DIFF
--- a/plugins/actionlog/joomla/joomla.php
+++ b/plugins/actionlog/joomla/joomla.php
@@ -31,6 +31,13 @@ class PlgActionlogJoomla extends ActionLogPlugin
 	protected $loggableExtensions = array();
 
 	/**
+	 * Context aliases
+	 *
+	 * @var array
+	 */
+	protected $contextAliases = array('com_content.form' => 'com_content.article');
+
+	/**
 	 * Constructor.
 	 *
 	 * @param   object  &$subject  The object to observe.
@@ -62,6 +69,11 @@ class PlgActionlogJoomla extends ActionLogPlugin
 	 */
 	public function onContentAfterSave($context, $article, $isNew)
 	{
+		if (isset($this->contextAliases[$context]))
+		{
+			$context = $this->contextAliases[$context];
+		}
+
 		$option = $this->app->input->getCmd('option');
 
 		if (!$this->checkLoggable($option))

--- a/plugins/actionlog/joomla/joomla.php
+++ b/plugins/actionlog/joomla/joomla.php
@@ -34,6 +34,7 @@ class PlgActionlogJoomla extends ActionLogPlugin
 	 * Context aliases
 	 *
 	 * @var array
+	 * @since  3.9.0 
 	 */
 	protected $contextAliases = array('com_content.form' => 'com_content.article');
 

--- a/plugins/actionlog/joomla/joomla.php
+++ b/plugins/actionlog/joomla/joomla.php
@@ -33,7 +33,7 @@ class PlgActionlogJoomla extends ActionLogPlugin
 	/**
 	 * Context aliases
 	 *
-	 * @var array
+	 * @var    array
 	 * @since  3.9.0 
 	 */
 	protected $contextAliases = array('com_content.form' => 'com_content.article');


### PR DESCRIPTION
Pull Request for Issue #22551.

### Summary of Changes
This is an alternative and maybe better fix for issue #22551 compare to PR #22554. 


### Testing Instructions
1. See #22551 for issue description, confirm the issue
2. Apply patch, try to edit article from frontend again, check action log link, confirm it's fixed.