### PR TITLE
Fix the base meta-tag to point to the real path

### DIFF
--- a/libraries/src/Application/SiteApplication.php
+++ b/libraries/src/Application/SiteApplication.php
@@ -161,7 +161,7 @@ final class SiteApplication extends CMSApplication
 
 				if ($router->getMode() == JROUTER_MODE_SEF)
 				{
-					$document->setBase(htmlspecialchars(\JUri::current()));
+					$document->setBase(htmlspecialchars(\JUri::base()));
 				}
 
 				// Get the template


### PR DESCRIPTION
Pull Request for Issue #22527

### Summary of Changes
Set the correct URL address of the base of website. 
This will be the equivalent of `JUri::base()`.

The `<base>` tag should point to the real path, not to the SEF virtual path.
The `<base>` tag can be useful for creating shortened relative links to images, css or scripts.
 

### Testing Instructions
See at #22527
