### PR TITLE
Remove html <base> tag

### DIFF
--- a/libraries/src/Application/SiteApplication.php
+++ b/libraries/src/Application/SiteApplication.php
@@ -159,11 +159,6 @@ final class SiteApplication extends CMSApplication
 
 				$document->setMetaData('rights', $this->get('MetaRights'));
 
-				if ($router->getMode() == JROUTER_MODE_SEF)
-				{
-					$document->setBase(htmlspecialchars(\JUri::current()));
-				}
-
 				// Get the template
 				$template = $this->getTemplate(true);
 


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/9010

### Summary of Changes
Remove <base> tag from html document.
Check the conversation on #22565


### Testing Instructions
Check html code on front-end. After patch the `<base>` tag is missing.


### Expected result
There is no `<base>` tag. Anchor links works if you are on page with a query like `...?start=2`.


### Actual result
The `<base>` tag exists, but if you are on page with a query like `...?start=2` then anchor does not work correctly and reload the page.


### Documentation Changes Required
The `<base>` tag has been removed from HTML version of the document.