### PR TITLE
[3.9] Making the alias menu item multilingual aware (for core menu module only)

### DIFF
--- a/modules/mod_menu/helper.php
+++ b/modules/mod_menu/helper.php
@@ -115,6 +115,19 @@ class ModMenuHelper
 
 						case 'alias':
 							$item->flink = 'index.php?Itemid=' . $item->params->get('aliasoptions');
+
+							// Get the language of the target menu item when site is multilingual
+							if (JLanguageMultilang::isEnabled())
+							{
+								$newItem = JFactory::getApplication()->getMenu()->getItem((int) $item->params->get('aliasoptions'));
+								$language = $newItem->language;
+
+								// Use language code if not set to ALL
+								if ($language && $language !== '*')
+								{
+									$item->flink = $item->flink . '&lang=' . $language;
+								}
+							}
 							break;
 
 						default:

--- a/modules/mod_menu/helper.php
+++ b/modules/mod_menu/helper.php
@@ -124,7 +124,7 @@ class ModMenuHelper
 								// Use language code if not set to ALL
 								if ($newItem != null && $newItem->language && $newItem->language !== '*')
 								{
-									$item->flink .= '&lang=' . $language;
+									$item->flink .= '&lang=' . $newItem->language;
 								}
 							}
 							break;

--- a/modules/mod_menu/helper.php
+++ b/modules/mod_menu/helper.php
@@ -125,7 +125,7 @@ class ModMenuHelper
 								// Use language code if not set to ALL
 								if ($language && $language !== '*')
 								{
-									$item->flink = $item->flink . '&lang=' . $language;
+									$item->flink .= '&lang=' . $language;
 								}
 							}
 							break;

--- a/modules/mod_menu/helper.php
+++ b/modules/mod_menu/helper.php
@@ -120,10 +120,9 @@ class ModMenuHelper
 							if (JLanguageMultilang::isEnabled())
 							{
 								$newItem = JFactory::getApplication()->getMenu()->getItem((int) $item->params->get('aliasoptions'));
-								$language = $newItem->language;
 
 								// Use language code if not set to ALL
-								if ($language && $language !== '*')
+								if ($newItem != null && $newItem->language && $newItem->language !== '*')
 								{
 									$item->flink .= '&lang=' . $language;
 								}


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/22515
Thanks @csthomas for the code to not use the db query
### Summary of Changes
Adding `$lang` parameter to the target menu item when site is multilingual

### Testing Instructions
Create a multilingual site. 2 languages are enough.
Use multiple menu items in both languages
Among them create an Alias menu item to a menu item tagged to the other language.
Click on the Alias menu item in frontend.

### Before patch
The menu item may display but with the wrong language interface
### After patch
Issue solved. One is redirected to the menu item in the other language.

### Warning
This will NOT work when not using the core menu module.
It does not break 3rd party menu solutions but they will lack this improvement.

@B3nito
@HLeithner 
@csthomas 