### PR TITLE
Fix the default value for the ordering field in Articles - Latest module

### DIFF
--- a/modules/mod_articles_latest/mod_articles_latest.xml
+++ b/modules/mod_articles_latest/mod_articles_latest.xml
@@ -59,7 +59,7 @@
 					type="list"
 					label="MOD_LATEST_NEWS_FIELD_ORDERING_LABEL"
 					description="MOD_LATEST_NEWS_FIELD_ORDERING_DESC"
-					default="published"
+					default="p_dsc"
 					>
 					<option value="c_dsc">MOD_LATEST_NEWS_VALUE_RECENT_ADDED</option>
 					<option value="m_dsc">MOD_LATEST_NEWS_VALUE_RECENT_MODIFIED</option>


### PR DESCRIPTION
### Summary of Changes
Correct the default value for the `ordering` field in Articles - Latest module.


### Testing Instructions
Simple code review.