### PR TITLE
[4.0] Workflows and stages: Remove checkin buttons

### DIFF
--- a/administrator/components/com_workflow/Controller/StagesController.php
+++ b/administrator/components/com_workflow/Controller/StagesController.php
@@ -165,28 +165,6 @@ class StagesController extends AdminController
 	}
 
 	/**
-	 * Check in of one or more records.
-	 *
-	 * @return  boolean  True on success
-	 *
-	 * @since   __DEPLOY_VERSION__
-	 */
-	public function checkin()
-	{
-		$result = parent::checkin();
-
-		$this->setRedirect(
-			Route::_(
-				'index.php?option=' . $this->option . '&view=' . $this->view_list
-				. '&extension=' . $this->extension
-				. '&workflow_id=' . $this->workflowId, false
-			)
-		);
-
-		return $result;
-	}
-
-	/**
 	 * Deletes and returns correctly.
 	 *
 	 * @return  void

--- a/administrator/components/com_workflow/View/Stages/HtmlView.php
+++ b/administrator/components/com_workflow/View/Stages/HtmlView.php
@@ -162,11 +162,6 @@ class HtmlView extends BaseHtmlView
 			ToolbarHelper::makeDefault('stages.setDefault', 'COM_WORKFLOW_TOOLBAR_DEFAULT');
 		}
 
-		if ($canDo->get('core.admin'))
-		{
-			ToolbarHelper::checkin('stages.checkin', 'JTOOLBAR_CHECKIN', true);
-		}
-
 		if ($this->state->get('filter.published') === '-2' && $canDo->get('core.delete'))
 		{
 			ToolbarHelper::deleteList(Text::_('COM_WORKFLOW_ARE_YOU_SURE'), 'stages.delete');

--- a/administrator/components/com_workflow/View/Workflows/HtmlView.php
+++ b/administrator/components/com_workflow/View/Workflows/HtmlView.php
@@ -136,12 +136,7 @@ class HtmlView extends BaseHtmlView
 			ToolbarHelper::unpublishList('workflows.unpublish');
 			ToolbarHelper::makeDefault('workflows.setDefault', 'COM_WORKFLOW_TOOLBAR_DEFAULT');
 		}
-
-		if ($canDo->get('core.admin'))
-		{
-			ToolbarHelper::checkin('workflows.checkin', 'JTOOLBAR_CHECKIN', true);
-		}
-
+		
 		if ($this->state->get('filter.published') === '-2' && $canDo->get('core.delete'))
 		{
 			ToolbarHelper::deleteList(Text::_('COM_WORKFLOW_ARE_YOU_SURE'), 'workflows.delete');


### PR DESCRIPTION
### Summary of Changes
Workflows and stages do not have checkout fields, therefore the checkin buttons are superfluous.


### Testing Instructions
See workflows and stages view before and after patch, 
![checkout](https://user-images.githubusercontent.com/1035262/46903069-15db1980-ced0-11e8-8af0-5daeb7cbbc95.PNG)

### Documentation Changes Required
yes
