### PR TITLE
Indexer fix for large articles

### DIFF
--- a/administrator/components/com_finder/helpers/indexer/helper.php
+++ b/administrator/components/com_finder/helpers/indexer/helper.php
@@ -329,7 +329,7 @@ class FinderIndexerHelper
 		// If language requested is wildcard, use the default language.
 		if ($default === null && $lang === '*')
 		{
-			$default = substr(self::getDefaultLanguage(), 0, 2);
+			$default = strstr(self::getDefaultLanguage(), '-', true);
 			$langCode = $default;
 		}
 

--- a/administrator/components/com_finder/helpers/indexer/helper.php
+++ b/administrator/components/com_finder/helpers/indexer/helper.php
@@ -327,9 +327,9 @@ class FinderIndexerHelper
 		$langCode = $lang;
 
 		// If language requested is wildcard, use the default language.
-		if ($lang == '*')
+		if ($default === null && $lang === '*')
 		{
-			$default = $default === null ? substr(self::getDefaultLanguage(), 0, 2) : $default;
+			$default = substr(self::getDefaultLanguage(), 0, 2);
 			$langCode = $default;
 		}
 

--- a/administrator/components/com_finder/helpers/indexer/indexer.php
+++ b/administrator/components/com_finder/helpers/indexer/indexer.php
@@ -117,7 +117,10 @@ abstract class FinderIndexer
 
 		$db = $this->db;
 
-		// Set up query template for addTokensToDb
+		/**
+		 * Set up query template for addTokensToDb, we will be cloning this template when needed.
+		 * This is about twice as fast as calling the clear function or setting up a new object.
+		 */
 		$this->addTokensToDbQueryTemplate = $db->getQuery(true)->insert($db->quoteName('#__finder_tokens'))
 			->columns(
 				array(
@@ -510,30 +513,44 @@ abstract class FinderIndexer
 		// Get the database object.
 		$db = $this->db;
 
-		$query = clone $this->addTokensToDbQueryTemplate;
 
 		// Count the number of token values.
 		$values = 0;
 
-		// Iterate through the tokens to create SQL value sets.
-		if (!is_a($tokens, 'FinderIndexerToken'))
+		if (($tokens instanceof FinderIndexerToken) === false)
 		{
-			foreach ($tokens as $token)
+			// Break into chunks of no more than 1000 items
+			$chunks = count($tokens) > 1000
+				? array_chunk($tokens, 1000)
+				: array($tokens);
+
+			foreach ($chunks as $chunkTokens)
 			{
-				$query->values(
-					$db->quote($token->term) . ', '
-					. $db->quote($token->stem) . ', '
-					. (int) $token->common . ', '
-					. (int) $token->phrase . ', '
-					. $db->escape((float) $token->weight) . ', '
-					. (int) $context . ', '
-					. $db->quote($token->language)
-				);
-				++$values;
+				// Cloning a new query template is twice as fast as calling the clear function
+				$query = clone $this->addTokensToDbQueryTemplate;
+
+				// Iterate through the tokens to create SQL value sets.
+				foreach ($chunkTokens as $token)
+				{
+					$query->values(
+						$db->quote($token->term) . ', '
+						. $db->quote($token->stem) . ', '
+						. (int) $token->common . ', '
+						. (int) $token->phrase . ', '
+						. $db->escape((float) $token->weight) . ', '
+						. (int) $context . ', '
+						. $db->quote($token->language)
+					);
+					++$values;
+				}
+
+				$db->setQuery($query)->execute();
 			}
 		}
 		else
 		{
+			$query = clone $this->addTokensToDbQueryTemplate;
+
 			$query->values(
 				$db->quote($tokens->term) . ', '
 				. $db->quote($tokens->stem) . ', '
@@ -544,8 +561,9 @@ abstract class FinderIndexer
 				. $db->quote($tokens->language)
 			);
 			++$values;
+
+			$db->setQuery($query)->execute();
 		}
-		$db->setQuery($query)->execute();
 
 		return $values;
 	}

--- a/administrator/components/com_finder/helpers/indexer/indexer.php
+++ b/administrator/components/com_finder/helpers/indexer/indexer.php
@@ -513,7 +513,6 @@ abstract class FinderIndexer
 		// Get the database object.
 		$db = $this->db;
 
-
 		// Count the number of token values.
 		$values = 0;
 


### PR DESCRIPTION
Pull Request for Issue #22098 .

### Summary of Changes
This PR re-adds and optimizes chunking (for the VALUES clause) to the smart search indexer, allowing for larget articles to be saved correctly, and their terms to be correctly added to the index, again.
It also optimizes a condition check in the helper.

With a standard configuration of a PHP memoy limit at 128MB and the default Mysql HEAP limits for MEMORY tables these instructions should provide solid results.


### Testing Instructions

#### Introduction:

There are three scenarios. Each one involves saving a predefined article and getting an expected result.
The first scenario uses a text of ~32000 words. This one should be saved successfully. 
In the second scenario, we use a text of ~45000 words. This one will fail to save because of surpassing the finder_token table limits. 
Finally, in the third scenario we use a text of ~65000 words. This should cause a php fatal error, stating that the memory has been exhausted.


#### Preparation: 

- **Error reporting** should be set to **development mode**
- Enable the "Content - Smart Search" plugin (and the other Smart Search related) 
- Open a tab for a new article
- Open a tab for components/Smart Search

#### Scenarios:

1) Article with near maximum possible text
 a) On the "Smart Search" tab, click "Clear Index"
 b) Copy and paste the complete text (select all) from this [gist](https://gist.githubusercontent.com/frankmayer/f0864c40597a7f71d33da63ca18b7599/raw/35c992afa59fde43298c41e3a5889b4becab939a/lorem%2520x5) (213,4KiB unformatted text) into the article in the other tab
 c) Give it a title and "save" the article
 d) Expected result:  **Message** Article saved.
 e) On the "Smart Search" tab, click "Statistics" and check that it says "The indexed content on this site includes 11,995 terms across 1 links..." 

2) Article which exceeds the maximum entries for the `finder_token` table
 a) On the Smart Search tab, click "Clear Index"
 b) Copy and paste the complete text (select all) from this [gist](https://gist.githubusercontent.com/frankmayer/f0864c40597a7f71d33da63ca18b7599/raw/35c992afa59fde43298c41e3a5889b4becab939a/lorem%2520x7) (298,8KiB unformatted text) into the article in the other tab
 c) Save the article
 d) Expected result:  **Error** Save failed with the following error: The table '#__finder_tokens' is full
 e) On the "Smart Search" tab, click "Statistics" and check that it says "The indexed content on this site includes 0 terms across 1 links..."
**Remarks** 
If you get a message that the acrticle was saved, instead of the error, you probably have higher heap settings for the MEMORY tables in mysql. Still this result would count as expected.
If you get a php error showing that the memory is exhausted, you are probably running php with a limit of less than 128MB. If that happens, please copy/paste the error message into a comment of this issue.

3) Article which results in a fatal php error due to memory exhaustion
 a) On the Smart Search tab, click "Clear Index"
 b) Copy and paste the complete text (select all) from this [gist](https://gist.githubusercontent.com/frankmayer/f0864c40597a7f71d33da63ca18b7599/raw/35c992afa59fde43298c41e3a5889b4becab939a/lorem%2520x10) into the article in the other tab
 c) Save the article
 d) Expected result: a php error showing that the memory is exhausted
 e) On the "Smart Search" tab, click "Statistics" and check that it says "The indexed content on this site includes 0 terms across 1 links..."
**Remarks** 
If you get a message that the acrticle was saved, instead of the error, you probably have higher heap settings for the MEMORY tables in mysql. Still this result would count as expected.
If you get the error: The table '#__finder_tokens' is full, you might have a higher memory limit than 128MB on PHP.


### Documentation Changes Required
none
