### PR TITLE
[3.9] Make sure ArrayHelper is used correctly

### DIFF
--- a/administrator/components/com_newsfeeds/models/newsfeeds.php
+++ b/administrator/components/com_newsfeeds/models/newsfeeds.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Utilities\ArrayHelper;
+
 /**
  * Methods supporting a list of newsfeed records.
  *
@@ -262,8 +264,7 @@ class NewsfeedsModelNewsfeeds extends JModelList
 		}
 		elseif (is_array($tagId))
 		{
-			ArrayHelper::toInteger($tagId);
-			$tagId = implode(',', $tagId);
+			$tagId = implode(',', ArrayHelper::toInteger($tagId));
 
 			if (!empty($tagId))
 			{


### PR DESCRIPTION
### Summary of Changes

Make sure ArrayHelper is used correctly

### Testing Instructions

Changing the filter name from filter[tag] to filter[tag][] will make the else expression match and with the current code produce an error because the ArrayHelper is not loaded

### Expected result

No ArrayHelper error

### Actual result

ArrayHelper error

### Documentation Changes Required

none

### More information

This issue has been reported to the JSST but at it is not exploitable the JSST decided to patch it in this public tracker PR. Thanks to the reporter: @ggppdk 
cc @joomla/security 