### PR TITLE
[4.0] btn-secondary missing css

### DIFF
--- a/administrator/templates/atum/scss/vendor/bootstrap/_dropdown.scss
+++ b/administrator/templates/atum/scss/vendor/bootstrap/_dropdown.scss
@@ -15,6 +15,10 @@
     background-color: theme-color("primary");
   }
 
+  .btn-secondary + .dropdown-menu  & {
+    background-color: theme-color("secondary");
+  }
+
   .btn-success + .dropdown-menu  & {
     background-color: theme-color("success");
   }


### PR DESCRIPTION
The css for this btn-secondary class was missing. If you go to administrator/index.php?option=com_menus&view=menus and click on a module button then the text disappears when you hover on it as its white text on a transparent baackground. This fixes that

Cannot be tested just with patchtester

PR for #21464