### PR TITLE
[3.9.0] Action Logs: Translating extensions names

### DIFF
--- a/plugins/actionlog/joomla/joomla.php
+++ b/plugins/actionlog/joomla/joomla.php
@@ -34,7 +34,7 @@ class PlgActionlogJoomla extends ActionLogPlugin
 	 * Context aliases
 	 *
 	 * @var    array
-	 * @since  3.9.0 
+	 * @since  3.9.0
 	 */
 	protected $contextAliases = array('com_content.form' => 'com_content.article');
 
@@ -350,8 +350,8 @@ class PlgActionlogJoomla extends ActionLogPlugin
 			'action'         => 'install',
 			'type'           => 'PLG_ACTIONLOG_JOOMLA_TYPE_' . $extensionType,
 			'id'             => $eid,
-			'name'           => (string) $manifest->name,
-			'extension_name' => (string) $manifest->name
+			'name'           => JText::_((string) $manifest->name),
+			'extension_name' => JText::_((string) $manifest->name)
 		);
 
 		$this->addLog(array($message), $messageLanguageKey, $context);
@@ -408,8 +408,8 @@ class PlgActionlogJoomla extends ActionLogPlugin
 			'action'         => 'install',
 			'type'           => 'PLG_ACTIONLOG_JOOMLA_TYPE_' . $extensionType,
 			'id'             => $eid,
-			'name'           => (string) $manifest->name,
-			'extension_name' => (string) $manifest->name
+			'name'           => JText::_((string) $manifest->name),
+			'extension_name' => JText::_((string) $manifest->name)
 		);
 
 		$this->addLog(array($message), $messageLanguageKey, $context);
@@ -459,8 +459,8 @@ class PlgActionlogJoomla extends ActionLogPlugin
 			'action'         => 'update',
 			'type'           => 'PLG_ACTIONLOG_JOOMLA_TYPE_' . $extensionType,
 			'id'             => $eid,
-			'name'           => (string) $manifest->name,
-			'extension_name' => (string) $manifest->name
+			'name'           => JText::_((string) $manifest->name),
+			'extension_name' => JText::_((string) $manifest->name)
 		);
 
 		$this->addLog(array($message), $messageLanguageKey, $context);


### PR DESCRIPTION
### Summary of Changes
As title says.
### Testing Instructions
Enable action logs.
Update, install, uninstall extension.
Display the action logs
/administrator/index.php?option=com_actionlogs
### Before patch
The extensions name will have the form `com_something`, `mod_something`, etc.

<img width="560" alt="screen shot 2018-10-15 at 09 26 12" src="https://user-images.githubusercontent.com/869724/46935929-fde4d080-d05c-11e8-811d-2bd5b63e8f7a.png">


### After patch
The extension names will be translated
<img width="548" alt="screen shot 2018-10-15 at 09 29 08" src="https://user-images.githubusercontent.com/869724/46935940-050bde80-d05d-11e8-96b6-8dba6799a79c.png">

