### PR TITLE
Add forgotten css class to com_fields display front-end

### DIFF
--- a/components/com_fields/layouts/field/render.php
+++ b/components/com_fields/layouts/field/render.php
@@ -18,6 +18,7 @@ $label = JText::_($field->label);
 $value = $field->value;
 $showLabel = $field->params->get('showlabel');
 $labelClass = $field->params->get('label_render_class');
+$fieldvalueClass = $field->params->get('render_class');
 
 if ($value == '')
 {
@@ -28,4 +29,4 @@ if ($value == '')
 <?php if ($showLabel == 1) : ?>
 	<span class="field-label <?php echo $labelClass; ?>"><?php echo htmlentities($label, ENT_QUOTES | ENT_IGNORE, 'UTF-8'); ?>: </span>
 <?php endif; ?>
-<span class="field-value"><?php echo $value; ?></span>
+<span class="field-value <?php echo $fieldvalueClass; ?>"><?php echo $value ?></span>

--- a/components/com_fields/layouts/field/render.php
+++ b/components/com_fields/layouts/field/render.php
@@ -29,4 +29,4 @@ if ($value == '')
 <?php if ($showLabel == 1) : ?>
 	<span class="field-label <?php echo $labelClass; ?>"><?php echo htmlentities($label, ENT_QUOTES | ENT_IGNORE, 'UTF-8'); ?>: </span>
 <?php endif; ?>
-<span class="field-value <?php echo $fieldvalueClass; ?>"><?php echo $value ?></span>
+<span class="field-value <?php echo $fieldvalueClass; ?>"><?php echo $value; ?></span>


### PR DESCRIPTION
When exploring settings of a field, we should be able to add a css class to Render Class in Render Options, tab Options.

Actual result:

```
<span class="field-label labelcssadded">Title of the field</span>
<span class="field-value">
```

Expected result:

```
<span class="field-label labelcssadded">Title of the field</span>
<span class="field-value valuecssadded">
```


