### PR TITLE
[3.9.0] com_actionlogs: Translating extension_name not working in some situations

### DIFF
--- a/administrator/components/com_actionlogs/helpers/actionlogs.php
+++ b/administrator/components/com_actionlogs/helpers/actionlogs.php
@@ -11,7 +11,6 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Filesystem\Path;
 use Joomla\String\StringHelper;
-use Joomla\Utilities\ArrayHelper;
 
 /**
  * Actionlogs component helper.
@@ -66,6 +65,7 @@ class ActionlogsHelper
 	public static function loadTranslationFiles($extension)
 	{
 		static $cache = array();
+		$extension = strtolower($extension);
 
 		if (isset($cache[$extension]))
 		{
@@ -100,8 +100,14 @@ class ActionlogsHelper
 
 		}
 
-		$lang->load(strtolower($extension), JPATH_ADMINISTRATOR, null, false, true)
-			|| $lang->load(strtolower($extension), $source, null, false, true);
+		$lang->load($extension, JPATH_ADMINISTRATOR, null, false, true)
+			|| $lang->load($extension, $source, null, false, true);
+
+		if (!$lang->hasKey(strtoupper($extension)))
+		{
+			$lang->load($extension . '.sys', JPATH_ADMINISTRATOR, null, false, true)
+				|| $lang->load($extension . '.sys', $source, null, false, true);
+		}
 
 		$cache[$extension] = true;
 	}


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/pull/22621

### Summary of Changes
If an extension name has been saved as uppercase
or
if the extension name language string is not present in its .ini file but only in its .sys.ini file
The name of the extension is not translated in the log manager.

This patch makes sure the lang file concerned is loaded.

### Test
Test update and install such extensions. (Uninstalling would anyway delete the lang files and force the display to use the `<name>` , for exemple `com_something`)

@SharkyKZ 