### PR TITLE
correct sentence so that spelling is correct

### DIFF
--- a/components/com_privacy/controller.php
+++ b/components/com_privacy/controller.php
@@ -38,7 +38,7 @@ class PrivacyController extends JControllerLegacy
 			return $this;
 		}
 
-		// Make sure we don't send a referer
+		// Make sure we don't send a HTTP referer header
 		if (in_array($view, array('confirm', 'remind')))
 		{
 			JFactory::getApplication()->setHeader('Referrer-Policy', 'no-referrer', true);


### PR DESCRIPTION
using the mis-spelt word `referer` is only correct if referring to a the originally misspelt http header

using the mis-spelt word `referer` in a sentence without that context blatantly clear to the reader, it should be spelt correctly

Debatable. Merge or close. 

> The misspelling of referrer originated in the original proposal by computer scientist Phillip Hallam-Baker to incorporate the field into the HTTP specification.[4] The misspelling was set in stone by the time of its incorporation into the Request for Comments standards document RFC 1945; document co-author Roy Fielding has remarked that neither "referrer" nor the misspelling "referer" were recognized by the standard Unix spell checker of the period.[5] "Referer" has since become a widely used spelling in the industry when discussing HTTP referrers; usage of the misspelling is not universal, though, as the correct spelling "referrer" is used in some web specifications such as the Document Object Model.
