### PR TITLE
s/Referer/Referrer-Policy/

### DIFF
--- a/components/com_privacy/controller.php
+++ b/components/com_privacy/controller.php
@@ -38,7 +38,7 @@ class PrivacyController extends JControllerLegacy
 			return $this;
 		}
 
-		// Make sure we don't send a Referrer-Policy header
+		// Set a Referrer-Policy header for views which require it
 		if (in_array($view, array('confirm', 'remind')))
 		{
 			JFactory::getApplication()->setHeader('Referrer-Policy', 'no-referrer', true);

--- a/components/com_privacy/controller.php
+++ b/components/com_privacy/controller.php
@@ -38,7 +38,7 @@ class PrivacyController extends JControllerLegacy
 			return $this;
 		}
 
-		// Make sure we don't send a referer
+		// Make sure we don't send a Referrer-Policy header
 		if (in_array($view, array('confirm', 'remind')))
 		{
 			JFactory::getApplication()->setHeader('Referrer-Policy', 'no-referrer', true);


### PR DESCRIPTION
> Note that Referer is actually a misspelling of the word "referrer". The Referrer-Policy header does not share this misspelling. (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy)

Here we are referring to Referrer-Policy and not the `referrer` header