### PR TITLE
Use better text from other file, which has now been corrected

### DIFF
--- a/administrator/components/com_actionlogs/models/fields/logcreator.php
+++ b/administrator/components/com_actionlogs/models/fields/logcreator.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 JFormHelper::loadFieldClass('list');
 
 /**
- * Form Field to load a list of content authors
+ * Field to load a list of all users that have logged actions
  *
  * @since  3.9.0
  */


### PR DESCRIPTION
s/Form Field to load a list of content authors/Field to load a list of all users that have logged actions/

Use "Field to load a list of all users that have logged actions" which was the text in the form field for the extension dropdown as that makes more sense here, I have [already corrected](https://github.com/joomla/joomla-cms/pull/22654) the extensions dropdown text too

