### PR TITLE
Import from database dump only imports first table

### DIFF
--- a/libraries/joomla/database/importer.php
+++ b/libraries/joomla/database/importer.php
@@ -187,7 +187,7 @@ abstract class JDatabaseImporter
 			if (in_array($tableName, $tables))
 			{
 				// The table already exists. Now check if there is any difference.
-				if ($queries = $this->getAlterTableSql($xml->database->table_structure))
+				if ($queries = $this->getAlterTableSql($table))
 				{
 					// Run the queries to upgrade the data structure.
 					foreach ($queries as $query)


### PR DESCRIPTION
Import from database dump only imports first table .

Pull Request for Issue #22620.

### Summary of Changes
    On expression inside foreach


### Testing Instructions
      1. Export structure dump for more then one table.
      2.  Merge from dump generated in step one .

### Expected result
      it shall merge all tables .


### Actual result
    it only merges first table


### Documentation Changes Required

