### PR TITLE
Add the default.xml file to useractions default view

### DIFF
--- a/administrator/components/com_actionlogs/views/actionlogs/tmpl/default.xml
+++ b/administrator/components/com_actionlogs/views/actionlogs/tmpl/default.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<metadata>
+	<layout title="COM_ACTIONLOGS_VIEW_DEFAULT_TITLE">
+		<message>
+			<![CDATA[COM_ACTIONLOGS_VIEW_DEFAULT_DESC]]>
+		</message>
+	</layout>
+</metadata>
+

--- a/administrator/language/en-GB/en-GB.com_actionlogs.sys.ini
+++ b/administrator/language/en-GB/en-GB.com_actionlogs.sys.ini
@@ -5,5 +5,5 @@
 
 COM_ACTIONLOGS="User Actions Log"
 COM_ACTIONLOGS_VIEW_DEFAULT_DESC="Shows a list of user actions."
-COM_ACTIONLOGS_VIEW_DEFAULT_TITLE="Privacy: User Action Log"
+COM_ACTIONLOGS_VIEW_DEFAULT_TITLE="User Action Log"
 COM_ACTIONLOGS_XML_DESCRIPTION="Displays a log of actions performed by users on your website."

--- a/administrator/language/en-GB/en-GB.com_actionlogs.sys.ini
+++ b/administrator/language/en-GB/en-GB.com_actionlogs.sys.ini
@@ -4,7 +4,6 @@
 ; Note : All ini files need to be saved as UTF-8
 
 COM_ACTIONLOGS="User Actions Log"
-COM_ACTIONLOGS_VIEW_DEFAULT_TITLE="Privacy: User Action Logs"
 COM_ACTIONLOGS_VIEW_DEFAULT_DESC="Shows a list of user actions."
+COM_ACTIONLOGS_VIEW_DEFAULT_TITLE="Privacy: User Action Log"
 COM_ACTIONLOGS_XML_DESCRIPTION="Displays a log of actions performed by users on your website."
-

--- a/administrator/language/en-GB/en-GB.com_actionlogs.sys.ini
+++ b/administrator/language/en-GB/en-GB.com_actionlogs.sys.ini
@@ -4,4 +4,7 @@
 ; Note : All ini files need to be saved as UTF-8
 
 COM_ACTIONLOGS="User Actions Log"
+COM_ACTIONLOGS_VIEW_DEFAULT_TITLE="Privacy: User Action Logs"
+COM_ACTIONLOGS_VIEW_DEFAULT_DESC="Shows a list of user actions."
 COM_ACTIONLOGS_XML_DESCRIPTION="Displays a log of actions performed by users on your website."
+


### PR DESCRIPTION
### Summary of Changes
Add a default.xml to the user actionlogs.


### Testing Instructions
Got to Backend Menus, switch to "administrator".
Add a new menu.
Try to add a new Menuitem to this menu. 
Click on select menu type - a modal opens.

### Expected result
You can select a menutype "actionlog"

![actionlog-after](https://user-images.githubusercontent.com/1035262/47012429-868a6c00-d144-11e8-8191-c788477e72bf.PNG)


### Actual result
This menutype is missing


### Documentation Changes Required

