### PR TITLE
[4.0] Fix xpath for the section in the rules field

### DIFF
--- a/libraries/src/Form/Field/RulesField.php
+++ b/libraries/src/Form/Field/RulesField.php
@@ -159,7 +159,10 @@ class RulesField extends FormField
 		$this->isGlobalConfig = $component === 'root.1';
 
 		// Get the actions for the asset.
-		$this->actions = Access::getActionsFromFile(JPATH_ADMINISTRATOR . '/components/' . $component . '/access.xml', $section);
+		$this->actions = Access::getActionsFromFile(
+			JPATH_ADMINISTRATOR . '/components/' . $component . '/access.xml',
+			"/access/section[@name='" . $section . "']/"
+		);
 
 		// Iterate over the children and add to the actions.
 		foreach ($this->element->children() as $el)

--- a/libraries/src/Form/Rule/RulesRule.php
+++ b/libraries/src/Form/Rule/RulesRule.php
@@ -95,7 +95,10 @@ class RulesRule extends FormRule
 		$component = $element['component'] ? (string) $element['component'] : '';
 
 		// Get the asset actions for the element.
-		$elActions = Access::getActionsFromFile(JPATH_ADMINISTRATOR . '/components/' . $component . '/access.xml', $section);
+		$elActions = Access::getActionsFromFile(
+			JPATH_ADMINISTRATOR . '/components/' . $component . '/access.xml',
+			"/access/section[@name='" . $section . "']/"
+		);
 
 		// Iterate over the asset actions and add to the actions.
 		foreach ($elActions as $item)


### PR DESCRIPTION
Pull Request for pr comment https://github.com/joomla/joomla-cms/pull/22378#issuecomment-427556012.

### Summary of Changes
Fixes the xpath in the rules field and rule.

### Testing Instructions
Open the permissions of the articles manager.

### Expected result
The permissions are displayed properly for the user groups.

### Actual result
No permissions are displayed.