### PR TITLE
Improve performance of #__session with a large session count - New Index

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/3.9.0-2018-10-16.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.9.0-2018-10-16.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `#__session` ADD INDEX `client_guest` (`client_id`, `guest`);

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -1760,7 +1760,7 @@ CREATE TABLE IF NOT EXISTS `#__session` (
   PRIMARY KEY (`session_id`),
   KEY `userid` (`userid`),
   KEY `time` (`time`),
-  KEY `client_guest` (`client_id`, `guest`);
+  KEY `client_guest` (`client_id`, `guest`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
 
 -- --------------------------------------------------------

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -1759,7 +1759,8 @@ CREATE TABLE IF NOT EXISTS `#__session` (
   `username` varchar(150) DEFAULT '',
   PRIMARY KEY (`session_id`),
   KEY `userid` (`userid`),
-  KEY `time` (`time`)
+  KEY `time` (`time`),
+  KEY `client_guest` (`client_id`, `guest`);
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
 
 -- --------------------------------------------------------


### PR DESCRIPTION
Pull Request for Issue #22632 .

### Summary of Changes
Adds a new index 'client_guest' against client and guest columns

### Testing Instructions
Have a large sessions table i.e. 14,000 rows. You can use a script I created to add these;
https://gist.github.com/tonypartridge/43c3d6f2f47d566fa8f7a28c9c4089a8

### Expected result
as it is now but faster

### Actual result
as it is now


### Documentation Changes Required

The index will improve session query performance on MySQL databases. Omn average I am seeing a 30ms session query brought down to around 8ms saving 22ms. 

Note, testing should be done on non-cached queries. 