### PR TITLE
[com_privacy] Use configured TimeZone

### DIFF
--- a/administrator/components/com_privacy/views/request/tmpl/default.php
+++ b/administrator/components/com_privacy/views/request/tmpl/default.php
@@ -72,7 +72,7 @@ JFactory::getDocument()->addScriptDeclaration($js);
 									<?php echo ActionlogsHelper::getHumanReadableLogMessage($item); ?>
 								</td>
 								<td>
-									<?php echo $this->escape($item->log_date); ?>
+									<?php echo JHtml::_('date', $item->log_date, JText::_('DATE_FORMAT_LC6')); ?>
 								</td>
 								<td>
 									<?php echo $item->name; ?>


### PR DESCRIPTION
Pull Request for Issue #22639 .

### Summary of Changes

Apply Joomla Global Config Timezone offset to logged dates

### Testing Instructions

Create action logs by requesting a request
note that the date on the left is different to the date on right if Joomla global Config has a different timezone

### Expected result

Both dates the same

### Actual result

date on the right before this PR was not offset 

### Documentation Changes Required

None

<img width="1012" alt="46947137-c896ad80-d071-11e8-9b34-74d7c129f228" src="https://user-images.githubusercontent.com/400092/47044787-06d2c080-d189-11e8-90a0-f527244661c3.png">
