### PR TITLE
Test PHP 7.3 on Travis, remove allowed failure for 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,10 +31,11 @@ matrix:
       env: INSTALL_APCU="yes"
     - php: 7.2
       env: INSTALL_APCU="yes" INSTALL_MEMCACHE="no"
+    - php: 7.3
+      env: INSTALL_APCU="yes" INSTALL_MEMCACHE="no" INSTALL_MEMCACHED="no"
     - php: nightly
-      env: INSTALL_APCU="yes" INSTALL_MEMCACHE="no"
+      env: INSTALL_APCU="no" INSTALL_MEMCACHE="no" INSTALL_MEMCACHED="no"
   allow_failures:
-    - php: 7.2
     - php: nightly
 
 services:

--- a/build/travis/phpenv/apcu-7.3.ini
+++ b/build/travis/phpenv/apcu-7.3.ini
@@ -1,0 +1,2 @@
+apc.enabled=true
+apc.enable_cli=true


### PR DESCRIPTION
### Summary of Changes

Travis-CI finally added PHP 7.3 to the build matrix, add it to our configuration as well

- `ext/memcached` isn't resolving something installable at the moment, so disable it for the PHP 7.3 build until ready

We've kept PHP 7.2 on the allowed failure list for a long time, even though we've been supporting PHP 7.2 pretty much in full for a while now.  Remove the allowed failure.

The nightly PHP build (always the PHP master branch, currently PHP 7.4) generally has issues pulling PECL dependencies, turn off trying to install APCu and Memcached for this build. 

### Testing Instructions

Travis build passes, Automated Testing Team greenlights PR.

### Expected result

Joomla is tested on all supported PHP versions.

### Actual result

PHP 7.3 is not tested due to delays in CI platform support.

### Documentation Changes Required

N/A