### PR TITLE
Fix redirection from a restricted page to the page with associated language after log in

### DIFF
--- a/libraries/src/Application/SiteApplication.php
+++ b/libraries/src/Application/SiteApplication.php
@@ -86,8 +86,11 @@ final class SiteApplication extends CMSApplication
 		{
 			if ($user->get('id') == 0)
 			{
+				$uri = new \JUri('index.php');
+				$uri->setQuery($this->getRouter()->getVars());
+
 				// Set the data
-				$this->setUserState('users.login.form.data', array('return' => \JUri::getInstance()->toString()));
+				$this->setUserState('users.login.form.data', array('return' => $uri->toString()));
 
 				$url = \JRoute::_('index.php?option=com_users&view=login', false);
 

--- a/libraries/src/Router/SiteRouter.php
+++ b/libraries/src/Router/SiteRouter.php
@@ -602,7 +602,7 @@ class SiteRouter extends Router
 				if ($start !== null)
 				{
 					$uri->delVar('start');
-					$vars['limitstart'] = $start;
+					$uri->setVar('limitstart', $start);
 				}
 			}
 		}

--- a/tests/unit/suites/libraries/cms/router/JRouterSiteTest.php
+++ b/tests/unit/suites/libraries/cms/router/JRouterSiteTest.php
@@ -1130,7 +1130,7 @@ class JRouterSiteTest extends TestCaseDatabase
 	 */
 	public function testProcessParseRules()
 	{
-		$uri = new JUri('index.php?start=42');
+		$uri = new JUri('index.php?limit=30&start=42');
 
 		$object = new JRouterSite(
 			array(),
@@ -1144,8 +1144,8 @@ class JRouterSiteTest extends TestCaseDatabase
 
 		$vars = $processParseRulesMethod->invokeArgs($object, array(&$uri));
 
-		$this->assertEquals('index.php', $uri->toString());
-		$this->assertEquals(array('limitstart' => '42'), $vars);
+		$this->assertEquals('index.php?limit=30&limitstart=42', $uri->toString());
+		$this->assertEquals(array(), $vars);
 	}
 
 	/**


### PR DESCRIPTION
### Summary of Changes

This patch fix a redirection issue on a multilingual website with association enabled.


### Testing Instructions
On multilingual website create two associated articles (in English and in other one, e.g. Polish), then create separated menu item for them:

`/en/blog/simple-article`
`/pl/blog/prosty-artykul`

and associate them (menu items for articles) with each other.

Create a user with frontend Polish language. Go to `/en/blog/simple-article`. After log in you will go to `/pl/blog/prosty-artykul`. It works before and after patch.

Now go to backend and set Access Level to Registered for both **menu items**.
Log out and go to `/en/blog/simple-article`, it should redirect you to login page.


### Expected result
After log in you are redirected to `/pl/blog/prosty-artykul` - association works correctly

### Actual result
After log in you are redirected to `/en/blog/simple-article` - association does not work


### Note
There is a change in `libraries/src/Router/SiteRouter.php`, which does not set `$vars['limitstart']` in `processParseRules()` but it is set later in (parseRawRoute, parseSefRoute)

https://github.com/joomla/joomla-cms/blob/921ed7b82e8859868a9c5c97f113f15ea0fa667e/libraries/src/Router/SiteRouter.php#L286

and 

https://github.com/joomla/joomla-cms/blob/921ed7b82e8859868a9c5c97f113f15ea0fa667e/libraries/src/Router/SiteRouter.php#L229

I changed it in order to include `limitstart` URL query parameter in `$this->getVars()` result.

### Documentation Changes Required
No