### PR TITLE
[4.0] Remove the deprecated icon arguments

### DIFF
--- a/administrator/components/com_content/Service/HTML/Icon.php
+++ b/administrator/components/com_content/Service/HTML/Icon.php
@@ -231,16 +231,14 @@ class Icon
 	/**
 	 * Method to generate a link to print an article
 	 *
-	 * @param   object    $article  Not used, @deprecated for 4.0
 	 * @param   Registry  $params   The item parameters
-	 * @param   array     $attribs  Not used, @deprecated for 4.0
 	 * @param   boolean   $legacy   True to use legacy images, false to use icomoon based graphic
 	 *
 	 * @return  string  The HTML markup for the popup link
 	 *
 	 * @since  4.0.0
 	 */
-	public function print_screen($article, $params, $attribs = array(), $legacy = false)
+	public function print_screen($params, $legacy = false)
 	{
 		$text = LayoutHelper::render('joomla.content.icons.print_screen', array('params' => $params, 'legacy' => $legacy));
 

--- a/components/com_content/helpers/icon.php
+++ b/components/com_content/helpers/icon.php
@@ -14,7 +14,8 @@ use Joomla\Registry\Registry;
 /**
  * Content Component HTML Helper
  *
- * @since  1.5
+ * @since      1.5
+ * @deprecated 5.0 Use the class \Joomla\Component\Content\Site\Service\HTML\Icon instead
  */
 abstract class JHtmlIcon
 {
@@ -105,7 +106,7 @@ abstract class JHtmlIcon
 	 */
 	public static function print_screen($article, $params, $attribs = array(), $legacy = false)
 	{
-		return self::getIcon()->print_screen($article, $params, $attribs, $legacy);
+		return self::getIcon()->print_screen($params, $legacy);
 	}
 
 	/**

--- a/components/com_content/tmpl/article/default.php
+++ b/components/com_content/tmpl/article/default.php
@@ -49,7 +49,7 @@ $assocParam = (Associations::isEnabled() && $params->get('show_associations'));
 
 	<?php if (!$useDefList && $this->print) : ?>
 		<div id="pop-print" class="btn hidden-print">
-			<?php echo HTMLHelper::_('contenticon.print_screen', $this->item, $params); ?>
+			<?php echo HTMLHelper::_('contenticon.print_screen', $params); ?>
 		</div>
 		<div class="clearfix"> </div>
 	<?php endif; ?>
@@ -78,7 +78,7 @@ $assocParam = (Associations::isEnabled() && $params->get('show_associations'));
 	<?php else : ?>
 		<?php if ($useDefList) : ?>
 			<div id="pop-print" class="btn hidden-print">
-				<?php echo HTMLHelper::_('contenticon.print_screen', $this->item, $params); ?>
+				<?php echo HTMLHelper::_('contenticon.print_screen', $params); ?>
 			</div>
 		<?php endif; ?>
 	<?php endif; ?>


### PR DESCRIPTION
Remove the deprecated icon arguments in the content icon class. For BC the old icon class is left as it is.