### PR TITLE
Common class for list type modules

### DIFF
--- a/modules/mod_articles_archive/tmpl/default.php
+++ b/modules/mod_articles_archive/tmpl/default.php
@@ -10,7 +10,7 @@
 defined('_JEXEC') or die;
 ?>
 <?php if (!empty($list)) : ?>
-	<ul class="archive-module<?php echo $moduleclass_sfx; ?>">
+	<ul class="archive-module<?php echo $moduleclass_sfx; ?> mod-list">
 	<?php foreach ($list as $item) : ?>
 	<li>
 		<a href="<?php echo $item->link; ?>">

--- a/modules/mod_articles_categories/tmpl/default.php
+++ b/modules/mod_articles_categories/tmpl/default.php
@@ -9,6 +9,6 @@
 
 defined('_JEXEC') or die;
 ?>
-<ul class="categories-module<?php echo $moduleclass_sfx; ?>">
+<ul class="categories-module<?php echo $moduleclass_sfx; ?> mod-list">
 <?php require JModuleHelper::getLayoutPath('mod_articles_categories', $params->get('layout', 'default') . '_items'); ?>
 </ul>

--- a/modules/mod_articles_category/tmpl/default.php
+++ b/modules/mod_articles_category/tmpl/default.php
@@ -10,7 +10,7 @@
 defined('_JEXEC') or die;
 
 ?>
-<ul class="category-module<?php echo $moduleclass_sfx; ?>">
+<ul class="category-module<?php echo $moduleclass_sfx; ?> mod-list">
 	<?php if ($grouped) : ?>
 		<?php foreach ($list as $group_name => $group) : ?>
 		<li>

--- a/modules/mod_articles_latest/tmpl/default.php
+++ b/modules/mod_articles_latest/tmpl/default.php
@@ -9,7 +9,7 @@
 
 defined('_JEXEC') or die;
 ?>
-<ul class="latestnews<?php echo $moduleclass_sfx; ?>">
+<ul class="latestnews<?php echo $moduleclass_sfx; ?> mod-list">
 <?php foreach ($list as $item) : ?>
 	<li itemscope itemtype="https://schema.org/Article">
 		<a href="<?php echo $item->link; ?>" itemprop="url">

--- a/modules/mod_articles_news/tmpl/horizontal.php
+++ b/modules/mod_articles_news/tmpl/horizontal.php
@@ -9,7 +9,7 @@
 
 defined('_JEXEC') or die;
 ?>
-<ul class="newsflash-horiz<?php echo $params->get('moduleclass_sfx'); ?>">
+<ul class="newsflash-horiz<?php echo $params->get('moduleclass_sfx'); ?> mod-list">
 	<?php for ($i = 0, $n = count($list); $i < $n; $i ++) : ?>
 		<?php $item = $list[$i]; ?>
 		<li>

--- a/modules/mod_articles_news/tmpl/vertical.php
+++ b/modules/mod_articles_news/tmpl/vertical.php
@@ -9,7 +9,7 @@
 
 defined('_JEXEC') or die;
 ?>
-<ul class="newsflash-vert<?php echo $params->get('moduleclass_sfx'); ?>">
+<ul class="newsflash-vert<?php echo $params->get('moduleclass_sfx'); ?> mod-list">
 	<?php for ($i = 0, $n = count($list); $i < $n; $i ++) : ?>
 		<?php $item = $list[$i]; ?>
 		<li class="newsflash-item">

--- a/modules/mod_articles_popular/tmpl/default.php
+++ b/modules/mod_articles_popular/tmpl/default.php
@@ -9,7 +9,7 @@
 
 defined('_JEXEC') or die;
 ?>
-<ul class="mostread<?php echo $moduleclass_sfx; ?>">
+<ul class="mostread<?php echo $moduleclass_sfx; ?> mod-list">
 <?php foreach ($list as $item) : ?>
 	<li itemscope itemtype="https://schema.org/Article">
 		<a href="<?php echo $item->link; ?>" itemprop="url">

--- a/modules/mod_menu/tmpl/default.php
+++ b/modules/mod_menu/tmpl/default.php
@@ -18,7 +18,7 @@ if ($tagId = $params->get('tag_id', ''))
 
 // The menu class is deprecated. Use nav instead
 ?>
-<ul class="nav menu<?php echo $class_sfx; ?>"<?php echo $id; ?>>
+<ul class="nav menu<?php echo $class_sfx; ?> mod-list"<?php echo $id; ?>>
 <?php foreach ($list as $i => &$item)
 {
 	$class = 'item-' . $item->id;

--- a/modules/mod_related_items/tmpl/default.php
+++ b/modules/mod_related_items/tmpl/default.php
@@ -9,7 +9,7 @@
 
 defined('_JEXEC') or die;
 ?>
-<ul class="relateditems<?php echo $moduleclass_sfx; ?>">
+<ul class="relateditems<?php echo $moduleclass_sfx; ?> mod-list">
 <?php foreach ($list as $item) : ?>
 <li>
 	<a href="<?php echo $item->route; ?>">

--- a/modules/mod_users_latest/tmpl/default.php
+++ b/modules/mod_users_latest/tmpl/default.php
@@ -10,7 +10,7 @@
 defined('_JEXEC') or die;
 ?>
 <?php if (!empty($names)) : ?>
-	<ul class="latestusers<?php echo $moduleclass_sfx; ?>" >
+	<ul class="latestusers<?php echo $moduleclass_sfx; ?> mod-list" >
 	<?php foreach ($names as $name) : ?>
 		<li>
 			<?php echo $name->username; ?>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
The following list modules often get the same CSS applied to them however there is no common HTML class to target them. This PR adds a common class to each (`mod-list`).

mod_articles_archive
mod_articles_categories
mod_articles_category
mod_articles_latest
mod_articles_news
mod_articles_popular
mod_menu
mod_related_items
mod_users_latest


### Testing Instructions
Code review
