### PR TITLE
[3.9.0] Enable privacy modules in sql updates

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/3.9.0-2018-05-20.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.9.0-2018-05-20.sql
@@ -1,2 +1,2 @@
 INSERT INTO `#__extensions` (`extension_id`, `package_id`, `name`, `type`, `element`, `folder`, `client_id`, `enabled`, `access`, `protected`, `manifest_cache`, `params`, `custom_data`, `system_data`, `checked_out`, `checked_out_time`, `ordering`, `state`) VALUES
-(319, 0, 'mod_latestactions', 'module', 'mod_latestactions', '', 1, 0, 1, 0, '', '{}', '', '', 0, '1970-01-01 00:00:00', 0, 0);
+(319, 0, 'mod_latestactions', 'module', 'mod_latestactions', '', 1, 1, 1, 0, '', '{}', '', '', 0, '1970-01-01 00:00:00', 0, 0);

--- a/administrator/components/com_admin/sql/updates/mysql/3.9.0-2018-06-12.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.9.0-2018-06-12.sql
@@ -1,2 +1,2 @@
 INSERT INTO `#__extensions` (`extension_id`, `package_id`, `name`, `type`, `element`, `folder`, `client_id`, `enabled`, `access`, `protected`, `manifest_cache`, `params`, `custom_data`, `system_data`, `checked_out`, `checked_out_time`, `ordering`, `state`) VALUES
-(320, 0, 'mod_privacy_dashboard', 'module', 'mod_privacy_dashboard', '', 1, 0, 1, 0, '', '{}', '', '', 0, '1970-01-01 00:00:00', 0, 0);
+(320, 0, 'mod_privacy_dashboard', 'module', 'mod_privacy_dashboard', '', 1, 1, 1, 0, '', '{}', '', '', 0, '1970-01-01 00:00:00', 0, 0);

--- a/administrator/components/com_admin/sql/updates/postgresql/3.9.0-2018-05-20.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.9.0-2018-05-20.sql
@@ -1,2 +1,2 @@
 INSERT INTO "#__extensions" ("extension_id", "package_id", "name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "manifest_cache", "params", "custom_data", "system_data", "checked_out", "checked_out_time", "ordering", "state") VALUES
-(319, 0, 'mod_latestactions', 'module', 'mod_latestactions', '', 1, 0, 1, 0, '', '{}', '', '', 0, '1970-01-01 00:00:00', 0, 0);
+(319, 0, 'mod_latestactions', 'module', 'mod_latestactions', '', 1, 1, 1, 0, '', '{}', '', '', 0, '1970-01-01 00:00:00', 0, 0);

--- a/administrator/components/com_admin/sql/updates/postgresql/3.9.0-2018-06-12.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.9.0-2018-06-12.sql
@@ -1,2 +1,2 @@
 INSERT INTO "#__extensions" ("extension_id", "package_id", "name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "manifest_cache", "params", "custom_data", "system_data", "checked_out", "checked_out_time", "ordering", "state") VALUES
-(320, 0, 'mod_privacy_dashboard', 'module', 'mod_privacy_dashboard', '', 1, 0, 1, 0, '', '{}', '', '', 0, '1970-01-01 00:00:00', 0, 0);
+(320, 0, 'mod_privacy_dashboard', 'module', 'mod_privacy_dashboard', '', 1, 1, 1, 0, '', '{}', '', '', 0, '1970-01-01 00:00:00', 0, 0);

--- a/administrator/components/com_admin/sql/updates/sqlazure/3.9.0-2018-05-20.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.9.0-2018-05-20.sql
@@ -1,6 +1,6 @@
 SET IDENTITY_INSERT #__extensions  ON;
 
 INSERT INTO "#__extensions" ("extension_id", "package_id", "name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "manifest_cache", "params", "custom_data", "system_data", "checked_out", "checked_out_time", "ordering", "state") VALUES
-(319, 0, 'mod_latestactions', 'module', 'mod_latestactions', '', 1, 0, 1, 0, '', '{}', '', '', 0, '1900-01-01 00:00:00', 0, 0);
+(319, 0, 'mod_latestactions', 'module', 'mod_latestactions', '', 1, 1, 1, 0, '', '{}', '', '', 0, '1900-01-01 00:00:00', 0, 0);
 
 SET IDENTITY_INSERT #__extensions  OFF;

--- a/administrator/components/com_admin/sql/updates/sqlazure/3.9.0-2018-06-12.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.9.0-2018-06-12.sql
@@ -1,6 +1,6 @@
 SET IDENTITY_INSERT #__extensions  ON;
 
 INSERT INTO "#__extensions" ("extension_id", "package_id", "name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "manifest_cache", "params", "custom_data", "system_data", "checked_out", "checked_out_time", "ordering", "state") VALUES
-(320, 0, 'mod_privacy_dashboard', 'module', 'mod_privacy_dashboard', '', 1, 0, 1, 0, '', '{}', '', '', 0, '1900-01-01 00:00:00', 0, 0);
+(320, 0, 'mod_privacy_dashboard', 'module', 'mod_privacy_dashboard', '', 1, 1, 1, 0, '', '{}', '', '', 0, '1900-01-01 00:00:00', 0, 0);
 
 SET IDENTITY_INSERT #__extensions  OFF;


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/22689

### Summary of Changes
SQL updates, contrary to joomla.sql, do not enable both modules which is confusing users.
mod_latestactions
mod_privacy_dashboard

### After patch
No need anymore after an update from 3.8.13 to go to Manage=>Manage and enable these modules to be able to add them in the modules Manager.

@mbabker 