### PR TITLE
[4.0] Sidebar Menu [a11y]

### DIFF
--- a/administrator/modules/mod_menu/tmpl/default.php
+++ b/administrator/modules/mod_menu/tmpl/default.php
@@ -26,7 +26,7 @@ $root     = $menuTree->reset();
 
 if ($root->hasChildren())
 {
-	echo '<div class="main-nav-container" role="navigation" aria-label="' . Text::_('MOD_MENU_ARIA_MAIN_MENU') . '">';
+	echo '<nav class="main-nav-container" aria-label="' . Text::_('MOD_MENU_ARIA_MAIN_MENU') . '">';
 	echo '<ul id="menu" class="' . $class . '" role="menu">' . "\n";
 	echo '<li role="menuitem">';
 	echo '<a id="menu-collapse" href="#">';
@@ -38,7 +38,7 @@ if ($root->hasChildren())
 	// WARNING: Do not use direct 'include' or 'require' as it is important to isolate the scope for each call
 	$menu->renderSubmenu(ModuleHelper::getLayoutPath('mod_menu', 'default_submenu'));
 
-	echo "</ul></div>\n";
+	echo "</ul></nav>\n";
 
 	if ($css = $menuTree->getCss())
 	{

--- a/administrator/modules/mod_menu/tmpl/default_submenu.php
+++ b/administrator/modules/mod_menu/tmpl/default_submenu.php
@@ -45,7 +45,7 @@ elseif ($current->hasChildren())
 	}
 }
 
-// Set the correct aria rolw and print the item
+// Set the correct aria role and print the item
 if ($current instanceOf Separator)
 {
 	echo '<li' . $class . ' role="presentation">';

--- a/administrator/modules/mod_menu/tmpl/default_submenu.php
+++ b/administrator/modules/mod_menu/tmpl/default_submenu.php
@@ -45,8 +45,15 @@ elseif ($current->hasChildren())
 	}
 }
 
-// Print the item
-echo '<li' . $class . ' role="menuitem">';
+// Set the correct aria rolw and print the item
+if ($current instanceOf Separator)
+{
+	echo '<li' . $class . ' role="presentation">';
+}
+else
+{
+	echo '<li' . $class . ' role="menuitem">';
+}
 
 // Print a link if it exists
 $linkClass  = [];
@@ -75,12 +82,7 @@ $link      = $current->get('link');
 
 // Get the menu icon
 $icon      = $this->tree->getIconClass();
-$iconClass = ($icon != '' && $current->getLevel() == 1) ? '<span class="' . $icon . '"></span>' : '';
-
-if ($current->get('link') === '#')
-{
-	$link = '#collapse' . $this->tree->getCounter();
-}
+$iconClass = ($icon != '' && $current->getLevel() == 1) ? '<span class="' . $icon . ' aria-hidden="true"></span>' : '';
 
 if ($link !== null && $current->get('target') !== null && $current->get('target') !== '')
 {
@@ -92,13 +94,13 @@ elseif ($link !== null)
 {
 	echo "<a" . $linkClass . $dataToggle . " href=\"" . $link . "\">"
 		. $iconClass
-		. '<span class="sidebar-item-title" >' . Text::_($current->get('title')) . "</span></a>";
+		. '<span class="sidebar-item-title">' . Text::_($current->get('title')) . "</span></a>";
 }
 elseif ($current->get('title') !== null && $current->get('class') !== 'separator')
 {
 	echo "<a" . $linkClass . $dataToggle . ">"
 		. $iconClass
-		. '<span class="sidebar-item-title" >' . Text::_($current->get('title')) . "</span></a>";
+		. '<span class="sidebar-item-title">' . Text::_($current->get('title')) . "</span></a>";
 }
 else
 {
@@ -116,7 +118,7 @@ if ($this->enabled && $current->hasChildren())
 	}
 	else
 	{
-		echo '<ul id="collapse' . $this->tree->getCounter() . '" class="collapse-level-1 collapse" role="menu" aria-hidden="true">' . "\n";
+		echo '<ul id="collapse' . $this->tree->getCounter() . '" class="collapse-level-1 collapse" role="menu" aria-haspopup="true">' . "\n";
 	}
 
 	// WARNING: Do not use direct 'include' or 'require' as it is important to isolate the scope for each call

--- a/administrator/templates/atum/scss/blocks/_sidebar.scss
+++ b/administrator/templates/atum/scss/blocks/_sidebar.scss
@@ -40,6 +40,7 @@
   // All list items
   li {
     color: $sidebar-text-color;
+    list-style-type: none;
   }
 
   // All links


### PR DESCRIPTION
### Changes etc

- **Info and Relationships**
	Local link destination does not exist
	A local link (anchor link) occurs but the destination does not exist.
	When using local links they must refer to an existing element on the page.
	So changed the #collapse1 etc to simply #

- **role=Presentation**
	when a menu item is just a separator then the role is not menuitem
	https://www.w3.org/TR/wai-aria/#presentation
	
- **collapsible menus**
	Should not have aria-hidden

- **Expandable menu**
	Should have aria-haspopup=true

- **Icons** 
	icons on menu items should have aria-hidden="true"

- **Nav**
	The entire menu should be wrapped in a nav (not a div) and therefore we dont need role=navigation as it is implicit
	
- **Link Purpose (In Context)**
	The same link text is used for links going to different destinations eg "categories". Users might not know the difference if they are not somehow explained.
	This should not be a problem as only unique links are exposed to the accessibility tree at any time
	Accessibility testing tools may still report this as an issue
	
- **_Extra markup??_**
data-toggle="dropdown"
	I don't believe this is required any more but I have left it in for now and this can be addressed ion another PR
	
- **List-style-none**
	This needs to be explicitly set to none or the screenreader will announce "white bullet"
_This is the only part of this pr that requires `npm run build:css` everything else can be tested just with patchtester_
