### PR TITLE
Improve UX for loggable extensions checkboxes with a select all/none

### DIFF
--- a/administrator/components/com_actionlogs/config.xml
+++ b/administrator/components/com_actionlogs/config.xml
@@ -29,7 +29,6 @@
 			label="COM_ACTIONLOGS_LOG_EXTENSIONS_LABEL"
 			description="COM_ACTIONLOGS_LOG_EXTENSIONS_DESC"
 			multiple="true"
-			default="com_banners,com_cache,com_categories,com_config,com_contact,com_content,com_installer,com_media,com_menus,com_messages,com_modules,com_newsfeeds,com_plugins,com_redirect,com_tags,com_templates,com_users"
 		/>
 	</fieldset>
 </config>

--- a/administrator/components/com_actionlogs/models/fields/logtype.php
+++ b/administrator/components/com_actionlogs/models/fields/logtype.php
@@ -96,7 +96,6 @@ class JFormFieldLogType extends JFormFieldCheckboxes
 		}
 
 		$html .= '</fieldset>';
-
 		$html .= '</div>';
 
 		return $html;

--- a/administrator/components/com_actionlogs/models/fields/logtype.php
+++ b/administrator/components/com_actionlogs/models/fields/logtype.php
@@ -30,6 +30,82 @@ class JFormFieldLogType extends JFormFieldCheckboxes
 	protected $type = 'LogType';
 
 	/**
+	 * Method to get the field input markup for check boxes.
+	 *
+	 * @return  string  The field input markup.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getInput()
+	{
+		// Including fallback code for HTML5 non supported browsers.
+		JHtml::_('jquery.framework');
+		JHtml::_('script', 'system/html5fallback.js', false, true);
+
+		$script = "
+			// Checks/Uncheck all checkboxes
+			function eventsCheckAll(value)
+			{
+				events = document.querySelectorAll('.checkboxes input');
+
+				for (i = 0; i < events.length; i++) {
+					events[i].checked = value;
+				}
+			}
+		";
+
+		// Add the script to the document head
+		JFactory::getDocument()->addScriptDeclaration($script);
+
+		$html = '<div class="well well-small">';
+		$html .= '<div class="form-inline">';
+		$html .= '<span class="small">' . JText::_('JSELECT') . ': ';
+		$html .= '<a id="checkAll" href="javascript://" onclick="eventsCheckAll(true)">' . JText::_('JALL') . '</a>, ';
+		$html .= '<a id="uncheckAll" href="javascript://" onclick="eventsCheckAll(false)">' . JText::_('JNONE') . '</a>';
+		$html .= '</span>';
+		$html .= '</div>';
+
+		$html .= '<div class="clearfix"></div>';
+
+		$html .= '<hr class="hr-condensed" />';
+
+		/**
+		 * The format of the input tag to be filled in using sprintf.
+		 *     %1 - id
+		 *     %2 - name
+		 *     %3 - value
+		 *     %4 = any other attributes
+		 */
+		$format = '<input type="checkbox" id="%1$s" name="%2$s" value="%3$s" %4$s />';
+
+		// Initialize the field checked options.
+		$checkedOptions = is_array($this->value) ? $this->value : explode(',', (string) $this->value);
+
+		// Get the field options.
+		$options = $this->getOptions();
+
+		$html .= '<fieldset id="' . $this->id . '" class="' . trim($this->class . ' checkboxes') . '">';
+
+		foreach ($options as $i => $option)
+		{
+			// Initialize some option attributes.
+			$checked = in_array((string) $option->value, $checkedOptions, true) ? 'checked' : '';
+			$oid     = $this->id . $i;
+			$value   = htmlspecialchars($option->value, ENT_COMPAT, 'UTF-8');
+
+			$html .= '<label for="' . $oid . '" class="checkbox">';
+			$html .= sprintf($format, $oid, $this->name, $value, $checked);
+			$html .= $option->text . '</label>';
+		}
+
+		$html .= '</fieldset>';
+
+		$html .= '</div>';
+
+		return $html;
+	}
+
+	/**
 	 * Method to get the field options.
 	 *
 	 * @return  array  The field option objects.
@@ -46,13 +122,12 @@ class JFormFieldLogType extends JFormFieldCheckboxes
 		$extensions = $db->setQuery($query)->loadColumn();
 
 		$options = array();
-		$tmp     = array('checked' => true);
 
 		foreach ($extensions as $extension)
 		{
 			ActionlogsHelper::loadTranslationFiles($extension);
 			$option = JHtml::_('select.option', $extension, JText::_($extension));
-			$options[ApplicationHelper::stringURLSafe(JText::_($extension)) . '_' . $extension] = (object) array_merge($tmp, (array) $option);
+			$options[ApplicationHelper::stringURLSafe(JText::_($extension)) . '_' . $extension] = (object) $option;
 		}
 
 		ksort($options);

--- a/administrator/components/com_actionlogs/models/fields/logtype.php
+++ b/administrator/components/com_actionlogs/models/fields/logtype.php
@@ -64,9 +64,6 @@ class JFormFieldLogType extends JFormFieldCheckboxes
 		$html .= '<a id="uncheckAll" href="javascript://" onclick="eventsCheckAll(false)">' . JText::_('JNONE') . '</a>';
 		$html .= '</span>';
 		$html .= '</div>';
-
-		$html .= '<div class="clearfix"></div>';
-
 		$html .= '<hr class="hr-condensed" />';
 
 		/**

--- a/administrator/components/com_actionlogs/models/fields/logtype.php
+++ b/administrator/components/com_actionlogs/models/fields/logtype.php
@@ -46,7 +46,7 @@ class JFormFieldLogType extends JFormFieldCheckboxes
 			// Checks/Uncheck all checkboxes
 			function eventsCheckAll(value)
 			{
-				events = document.querySelectorAll('.checkboxes input');
+				events = document.querySelectorAll('#" . $this->id . ".checkboxes input');
 
 				for (i = 0; i < events.length; i++) {
 					events[i].checked = value;

--- a/plugins/system/actionlogs/actionlogs.php
+++ b/plugins/system/actionlogs/actionlogs.php
@@ -321,14 +321,14 @@ class PlgSystemActionLogs extends JPlugin
 		// If preferences don't exist, insert.
 		if (!$exists && $authorised && isset($user['actionlogs']))
 		{
-			$values  = array((int) $user['id'], (int) $user['actionlogs']['actionlogsNotify']);
-			$columns = array('user_id', 'notify');
-
-			if (isset($user['actionlogs']['actionlogsExtensions']))
-			{
-				$values[]  = $this->db->quote(json_encode($user['actionlogs']['actionlogsExtensions']));
-				$columns[] = 'extensions';
-			}
+			$values  = array(
+				(int) $user['id'],
+				(int) $user['actionlogs']['actionlogsNotify'],
+				$this->db->quote(
+					isset($user['actionlogs']['actionlogsExtensions']) ? json_encode($user['actionlogs']['actionlogsExtensions']) : '[]'
+				),
+			);
+			$columns = array('user_id', 'notify', 'extensions');
 
 			$query = $this->db->getQuery(true)
 				->insert($this->db->quoteName('#__action_logs_users'))
@@ -338,16 +338,12 @@ class PlgSystemActionLogs extends JPlugin
 		elseif ($exists && $authorised && isset($user['actionlogs']))
 		{
 			// Update preferences.
-			$values = array($this->db->quoteName('notify') . ' = ' . (int) $user['actionlogs']['actionlogsNotify']);
-
-			if (isset($user['actionlogs']['actionlogsExtensions']))
-			{
-				$values[] = $this->db->quoteName('extensions') . ' = ' . $this->db->quote(json_encode($user['actionlogs']['actionlogsExtensions']));
-			}
-			else
-			{
-				$values[] = $this->db->quoteName('extensions') . ' = ' . $this->db->quote(json_encode(array('')));
-			}
+			$values = array(
+				$this->db->quoteName('notify') . ' = ' . (int) $user['actionlogs']['actionlogsNotify'],
+				$this->db->quoteName('extensions') . ' = ' . $this->db->quote(
+					isset($user['actionlogs']['actionlogsExtensions']) ? json_encode($user['actionlogs']['actionlogsExtensions']) : '[]'
+				),
+			);
 
 			$query = $this->db->getQuery(true)
 				->update($this->db->quoteName('#__action_logs_users'))

--- a/plugins/system/actionlogs/actionlogs.php
+++ b/plugins/system/actionlogs/actionlogs.php
@@ -344,6 +344,10 @@ class PlgSystemActionLogs extends JPlugin
 			{
 				$values[] = $this->db->quoteName('extensions') . ' = ' . $this->db->quote(json_encode($user['actionlogs']['actionlogsExtensions']));
 			}
+			else
+			{
+				$values[] = $this->db->quoteName('extensions') . ' = ' . $this->db->quote(json_encode(array('')));
+			}
 
 			$query = $this->db->getQuery(true)
 				->update($this->db->quoteName('#__action_logs_users'))


### PR DESCRIPTION
Pull Request for Issue #22627.
REDO https://github.com/joomla/joomla-cms/pull/22674

### Summary of Changes
- Remove default attribute for `loggable_extensions` (Fix #22627 UX issue)
- Add a "Select All/None" for loggable extensions to help selecting all or clearing all on one click.
- Allow empty selection selection for actionlogs Notification Extensions

com_actionlogs global options
![capture d ecran 2018-10-16 a 21 20 40](https://user-images.githubusercontent.com/2385058/47041559-6c26b180-d189-11e8-85ee-a46179d9a71b.png)

Super user edit view
![capture d ecran 2018-10-18 a 16 32 48](https://user-images.githubusercontent.com/2385058/47162021-82e91780-d2f3-11e8-90fd-f1b2ba70bc19.png)


### Testing Instructions
- See issue #22627
- Install latest staging (needs merged PR #21983)
- Test actions logging options in global options of com_actionlogs and in super user edit view. All selected, some selected, none selected.
