### PR TITLE
[privacy] Create custom fields domain with section

### DIFF
--- a/administrator/components/com_privacy/helpers/plugin.php
+++ b/administrator/components/com_privacy/helpers/plugin.php
@@ -140,7 +140,7 @@ abstract class PrivacyPlugin extends JPlugin
 
 		$type = str_replace('com_', '', $parts[0]);
 
-		$domain = $this->createDomain($type . '_custom_fields', 'joomla_' . $type . '_custom_fields_data');
+		$domain = $this->createDomain($type . '_' . $parts[1] . '_custom_fields', 'joomla_' . $type . '_' . $parts[1] . '_custom_fields_data');
 
 		foreach ($items as $item)
 		{


### PR DESCRIPTION
### Summary of Changes
When you have an extension with multiple contexts for custom fields, then all of these are created under the same domain name for the privacy information request. This pr includes also the section. So 

`<domain name="users_custom_fields" description="joomla_users_custom_fields_data"/>`

renders then

`<domain name="users_user_custom_fields" description="joomla_users_user_custom_fields_data"/>`

### Testing Instructions
Export privacy data from a request.

### Expected result
The user tag contains the section of the custom fields like:
`<domain name="users_user_custom_fields" description="joomla_users_user_custom_fields_data"/>`

### Actual result
The user tag contains no section of the custom fields like:
`<domain name="users_custom_fields" description="joomla_users_custom_fields_data"/>`