### PR TITLE
[4.0] Load the cache controller through the factory in the component helper

### DIFF
--- a/libraries/src/Component/ComponentHelper.php
+++ b/libraries/src/Component/ComponentHelper.php
@@ -11,6 +11,8 @@ namespace Joomla\CMS\Component;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Access\Access;
+use Joomla\CMS\Cache\CacheControllerFactoryInterface;
+use Joomla\CMS\Cache\Controller\CallbackController;
 use Joomla\CMS\Component\Exception\MissingComponentException;
 use Joomla\CMS\Dispatcher\ComponentDispatcher;
 use Joomla\CMS\Factory;
@@ -413,8 +415,8 @@ class ComponentHelper
 			return $db->loadObjectList('option', '\JComponentRecord');
 		};
 
-		/** @var \JCacheControllerCallback $cache */
-		$cache = Factory::getCache('_system', 'callback');
+		/** @var CallbackController $cache */
+		$cache = Factory::getContainer()->get(CacheControllerFactoryInterface::class)->createCacheController('callback', ['defaultgroup' => '_system']);
 
 		try
 		{


### PR DESCRIPTION
Load the cache controller through the factory in the component helper. See #22687 for more details.