### PR TITLE
[4.0] Get the config in the uri class from the container

### DIFF
--- a/libraries/src/Uri/Uri.php
+++ b/libraries/src/Uri/Uri.php
@@ -138,7 +138,7 @@ class Uri extends \Joomla\Uri\Uri
 		// Get the base request path.
 		if (empty(static::$base))
 		{
-			$config = Factory::getConfig();
+			$config = Factory::getContainer()->get('config');
 			$uri = static::getInstance();
 			$live_site = ($uri->isSsl()) ? str_replace('http://', 'https://', $config->get('live_site')) : $config->get('live_site');
 


### PR DESCRIPTION
The Uri class should fetch the configuration from the container instead of from the deprecated `Factory::getConfig()`. Thîs service is available since #19658.