### PR TITLE
[4.0] Add New sidebar menu

### DIFF
--- a/administrator/components/com_menus/presets/joomla.xml
+++ b/administrator/components/com_menus/presets/joomla.xml
@@ -124,13 +124,6 @@
 					link="index.php?option=com_menus&amp;view=items&amp;menutype={sql:menutype}"
 					icon="{sql:icon}"
 					class="class:menu">
-				<menuitem
-						title="MOD_MENU_MENU_MANAGER_NEW_MENU_ITEM"
-						type="component"
-						element="com_menus"
-						link="index.php?option=com_menus&amp;view=item&amp;layout=edit&amp;menutype={sql:menutype}"
-						scope="edit"
-				/>
 			</menuitem>
 		</menuitem>
 		<menuitem


### PR DESCRIPTION
In the recent pr for the new sidebar menu we deleted the "add new" from the menu>manage
This PR does the sane for the "add new menu item"

**_Without this PR it is not possible to select a menu_**

This is a temporary measure so that the menu link is usable and while we investigate the best way to support "add new" links for this menu design

@wilsonge if you still plan to push another alpha then this really should be merged asap