### PR TITLE
[4.0] Forward port the hsts max-age fix from the original plugin

### DIFF
--- a/plugins/system/httpheaders/httpheaders.php
+++ b/plugins/system/httpheaders/httpheaders.php
@@ -301,7 +301,7 @@ class PlgSystemHttpHeaders extends CMSPlugin implements SubscriberInterface
 	{
 		$maxAge        = (int) $this->params->get('hsts_maxage', 31536000);
 		$hstsOptions   = array();
-		$hstsOptions[] = $maxAge < 300 ? 'max-age: 300' : 'max-age: ' . $maxAge;
+		$hstsOptions[] = $maxAge < 300 ? 'max-age=300' : 'max-age=' . $maxAge;
 
 		if ($this->params->get('hsts_subdomains', 0))
 		{


### PR DESCRIPTION
### Summary of Changes

the hsts max-age attribute is written with `=` and not with `:` this patch corrects that. The for the report by @SniperSister the 3.x plugin is also patched here https://github.com/zero-24/plg_system_httpheader/commit/b5e1ad5ca33f21eb8e2164e6d61f8309baa615d4 and a bug fixed version is released too: https://github.com/zero-24/plg_system_httpheader/releases/tag/1.0.3

### Testing Instructions

Apply this patch make sure the hsts header is generated as `strict-transport-security: max-age=31536000` vs `strict-transport-security: max-age: 31536000`

### Expected result

`strict-transport-security: max-age=31536000`

### Actual result

`strict-transport-security: max-age: 31536000`

### Documentation Changes Required

None