### PR TITLE
[com_privacy][3.9] Clear confirm_token when no longer needed

### DIFF
--- a/components/com_privacy/models/confirm.php
+++ b/components/com_privacy/models/confirm.php
@@ -88,6 +88,7 @@ class PrivacyModelConfirm extends JModelAdmin
 		{
 			// Invalidate the request
 			$table->status = -1;
+			$table->confirm_token = '';
 
 			try
 			{
@@ -116,6 +117,7 @@ class PrivacyModelConfirm extends JModelAdmin
 			array(
 				'id'     => $table->id,
 				'status' => 1,
+				'confirm_token' => '',
 			)
 		);
 


### PR DESCRIPTION
Pull Request for Issue #22721 .

### Summary of Changes

Joomla 3.9 
Request an export of your data
Confirm that request 


### Expected result

The confirm_token is removed from the database once used to confirm your request. 
The confirm_token is removed from the database if you try to use it after 24 hours have elapsed
It is no longer needed, just taking up space, and as it was used as a token, should be removed. 

### Actual result

The token remains in the db

E.g
`$2y$10$H8JDZa3vV6k0DV/g0Gr6ZeHptmW1MJ9Lfn/f1YHmP3YFqcvQP.C1y`

### Testing Instructions

Create an export request
Click on link in email to confirm, enter email address, check db for token having now been deleted