### PR TITLE
[com_actionlogs][3.9]Apply timezone to datetime in com_actionlogs emails

### DIFF
--- a/administrator/components/com_actionlogs/layouts/logstable.php
+++ b/administrator/components/com_actionlogs/layouts/logstable.php
@@ -34,7 +34,7 @@ $showIpColumn = $displayData['showIpColumn'];
 		<?php foreach ($messages as $message) : ?>
 			<tr>
 				<td><?php echo $message->message; ?></td>
-				<td><?php echo JHtml::_('date', $message->log_date, JText::_('DATE_FORMAT_LC6')); ?></td>
+				<td><?php echo JHtml::_('date', $message->log_date, 'Y-m-d H:i:s T', 'UTC'); ?></td>
 				<td><?php echo $message->extension; ?></td>
 				<td><?php echo $displayData['username']; ?></td>
 				<?php if ($showIpColumn) : ?>

--- a/administrator/components/com_actionlogs/layouts/logstable.php
+++ b/administrator/components/com_actionlogs/layouts/logstable.php
@@ -34,7 +34,7 @@ $showIpColumn = $displayData['showIpColumn'];
 		<?php foreach ($messages as $message) : ?>
 			<tr>
 				<td><?php echo $message->message; ?></td>
-				<td><?php echo $message->log_date; ?></td>
+				<td><?php echo JHtml::_('date', $message->log_date, JText::_('DATE_FORMAT_LC6')); ?></td>
 				<td><?php echo $message->extension; ?></td>
 				<td><?php echo $displayData['username']; ?></td>
 				<?php if ($showIpColumn) : ?>


### PR DESCRIPTION
### Steps to reproduce the issue

Closes #22711 

Enable the sending of Action Log entries to a Super Admin by Mail in Joomla 3.9
Set your Joomla Global Timezone to be something the other side of the world
Generate a load of emails

### Expected result

Any reference to the date/time an event occured should be translated to the Joomla Global Configuration Timezone/offset 


### Actual result

The date/time right now is UTC/GMT, but a Joomla Super Admin the other side of the world (with a server another third of the way around the world) is confused and assumes its local time, **so would be best when giving the date/time to tell the recipient WHAT timezone that timestamp relates to.** 

![screenshot 2018-10-19 at 00 54 31](https://user-images.githubusercontent.com/400092/47190627-63291200-d33a-11e8-97ca-7a0cc599aade.png)

