### PR TITLE
Update default.php

### DIFF
--- a/administrator/components/com_privacy/views/dashboard/tmpl/default.php
+++ b/administrator/components/com_privacy/views/dashboard/tmpl/default.php
@@ -124,7 +124,7 @@ $activeRequests = 0;
 						<div class="span9">
 							<div><?php echo JText::_('COM_PRIVACY_STATUS_CHECK_REQUEST_FORM_MENU_ITEM_PUBLISHED'); ?></div>
 							<?php if ($this->requestFormPublished['link'] !== '') : ?>
-								<small><a href="<?php echo $this->requestFormPublished['link']; ?>"><?php echo $this->requestFormPublished['link']; ?></a></small>
+								<small><a href="<?php echo $this->requestFormPublished['link']; ?>" target="_blank"><?php echo $this->requestFormPublished['link']; ?></a></small>
 							<?php endif; ?>
 						</div>
 					</div>


### PR DESCRIPTION
### Summary of Changes
Added target="_blank" to the COM_PRIVACY_STATUS_CHECK_REQUEST_FORM_MENU_ITEM_PUBLISHED link.
The link is a frontend address and should open a new window instead of browsing away from the backend.

### Testing Instructions
Click the link.

### Expected result
Link opens new window


### Actual result
Before change the link just opens the frontend with loosing the backend.
<img width="371" alt="image" src="https://user-images.githubusercontent.com/11913918/47256242-d044c080-d47c-11e8-9e9f-e21a59144970.png">
