### PR TITLE
[com_privacy][3.9] Make urgent less meh, give more room for date

### DIFF
--- a/administrator/components/com_privacy/views/requests/tmpl/default.php
+++ b/administrator/components/com_privacy/views/requests/tmpl/default.php
@@ -96,9 +96,9 @@ $urgentRequestDate->sub(new DateInterval('P' . $this->urgentRequestAge . 'D'));
 								<?php echo JHtml::_('PrivacyHtml.helper.statusLabel', $item->status); ?>
 							</td>
 							<td>
-                                <?php if ($item->status == 1 && $urgentRequestDate >= $itemRequestedAt) : ?>
-                                    <span class="pull-right label label-important"><?php echo JText::_('COM_PRIVACY_BADGE_URGENT_REQUEST'); ?></span>
-                                <?php endif; ?>
+								<?php if ($item->status == 1 && $urgentRequestDate >= $itemRequestedAt) : ?>
+									<span class="pull-right label label-important"><?php echo JText::_('COM_PRIVACY_BADGE_URGENT_REQUEST'); ?></span>
+								<?php endif; ?>
 								<a class="hasTooltip" href="<?php echo JRoute::_('index.php?option=com_privacy&view=request&id=' . (int) $item->id); ?>" title="<?php echo JText::_('COM_PRIVACY_ACTION_VIEW'); ?>">
 									<?php echo JStringPunycode::emailToUTF8($this->escape($item->email)); ?>
 								</a>

--- a/administrator/components/com_privacy/views/requests/tmpl/default.php
+++ b/administrator/components/com_privacy/views/requests/tmpl/default.php
@@ -58,7 +58,7 @@ $urgentRequestDate->sub(new DateInterval('P' . $this->urgentRequestAge . 'D'));
 						<th width="10%" class="nowrap">
 							<?php echo JHtml::_('searchtools.sort', 'COM_PRIVACY_HEADING_REQUEST_TYPE', 'a.request_type', $listDirn, $listOrder); ?>
 						</th>
-						<th width="15%" class="nowrap">
+						<th width="20%" class="nowrap">
 							<?php echo JHtml::_('searchtools.sort', 'COM_PRIVACY_HEADING_REQUESTED_AT', 'a.requested_at', $listDirn, $listOrder); ?>
 						</th>
 						<th width="1%" class="nowrap hidden-phone">
@@ -96,12 +96,12 @@ $urgentRequestDate->sub(new DateInterval('P' . $this->urgentRequestAge . 'D'));
 								<?php echo JHtml::_('PrivacyHtml.helper.statusLabel', $item->status); ?>
 							</td>
 							<td>
+                                <?php if ($item->status == 1 && $urgentRequestDate >= $itemRequestedAt) : ?>
+                                    <span class="pull-right label label-important"><?php echo JText::_('COM_PRIVACY_BADGE_URGENT_REQUEST'); ?></span>
+                                <?php endif; ?>
 								<a class="hasTooltip" href="<?php echo JRoute::_('index.php?option=com_privacy&view=request&id=' . (int) $item->id); ?>" title="<?php echo JText::_('COM_PRIVACY_ACTION_VIEW'); ?>">
 									<?php echo JStringPunycode::emailToUTF8($this->escape($item->email)); ?>
 								</a>
-								<?php if ($item->status == 1 && $urgentRequestDate >= $itemRequestedAt) : ?>
-									<span class="label"><?php echo JText::_('COM_PRIVACY_BADGE_URGENT_REQUEST'); ?></span>
-								<?php endif; ?>
 							</td>
 							<td class="break-word">
 								<?php echo JText::_('COM_PRIVACY_HEADING_REQUEST_TYPE_TYPE_' . $item->request_type); ?>


### PR DESCRIPTION


Pull Request for Issue #22704 .

### Summary of Changes

Have an overdue request in com_privacy
Urgent label now red - and better positioned to the right 
Date to have enough room to breath on wider range of monitor resolutions, was wrapping rendered date even on half a 27" iMac on 2560x1440!


### Expected result

[Urgent] label to instill a sense of urgency and be very evident and in your face
![screenshot 2018-10-20 at 14 36 42](https://user-images.githubusercontent.com/400092/47256301-97551d80-d475-11e8-8fe4-1658fb5f7a96.png)

### previous look

Grey washed out label

![screenshot 2018-10-18 at 16 28 34](https://user-images.githubusercontent.com/400092/47165936-fe969480-d2f2-11e8-8fc6-c39c06c7b98c.png)

