### PR TITLE
Standardize CSV export timezone on UTC, don't use translated timestamp format, include timezone in printed text

### DIFF
--- a/administrator/components/com_actionlogs/controllers/actionlogs.php
+++ b/administrator/components/com_actionlogs/controllers/actionlogs.php
@@ -79,8 +79,9 @@ class ActionlogsControllerActionlogs extends JControllerAdmin
 
 		if (count($data))
 		{
-			$rows = ActionlogsHelper::getCsvData($data);
-			$filename     = 'logs_' . JFactory::getDate()->format('Y-m-d_His_T');
+			$date         = new JDate('now', new DateTimeZone('UTC'));
+			$rows         = ActionlogsHelper::getCsvData($data);
+			$filename     = 'logs_' . $date->format('Y-m-d_His_T');
 			$csvDelimiter = ComponentHelper::getComponent('com_actionlogs')->getParams()->get('csv_delimiter', ',');
 
 			$app = JFactory::getApplication();

--- a/administrator/components/com_actionlogs/helpers/actionlogs.php
+++ b/administrator/components/com_actionlogs/helpers/actionlogs.php
@@ -42,7 +42,7 @@ class ActionlogsHelper
 			$row               = array();
 			$row['id']         = $log->id;
 			$row['message']    = strip_tags(static::getHumanReadableLogMessage($log));
-			$row['date']       = JHtml::_('date', $log->log_date, JText::_('DATE_FORMAT_LC6'));
+			$row['date']       = JHtml::_('date', $log->log_date, 'Y-m-d H:i:s T', 'UTC');
 			$row['extension']  = JText::_($extension);
 			$row['name']       = $log->name;
 			$row['ip_address'] = JText::_($log->ip_address);


### PR DESCRIPTION
Pull Request for Issue #22629

### Summary of Changes

- Standardizes the timezone used for timestamps in the actionlog export to UTC
- Standardizes the timestamp to always use the `Y-m-d H:i:s T` format versus one that is translated so the format does not change based on who exports the data
- As hinted at above, the timezone is printed in the timestamp now

### Testing Instructions

- Apply patch
- Export action logs
- Check the date column

### Expected result

Timestamp is clear as it relates to timezones and consistently formatted

### Actual result

Timestamp is ambiguous and can be formatted differently based on the admin who exports the logs