### PR TITLE
Improved extension update error message.

### DIFF
--- a/administrator/components/com_installer/models/update.php
+++ b/administrator/components/com_installer/models/update.php
@@ -444,6 +444,12 @@ class InstallerModelUpdate extends JModelList
 
 		// Unpack the downloaded package file
 		$package = InstallerHelper::unpack($tmp_dest . '/' . $p_file);
+		if (!isset($package['type']))
+		{
+			$app->enqueueMessage(JText::sprintf('COM_INSTALLER_MSG_UPDATE_INVALID_PKG', $url));
+
+			return false;
+		}
 
 		// Get an installer instance
 		$installer = JInstaller::getInstance();

--- a/administrator/components/com_installer/models/update.php
+++ b/administrator/components/com_installer/models/update.php
@@ -444,7 +444,8 @@ class InstallerModelUpdate extends JModelList
 
 		// Unpack the downloaded package file
 		$package = InstallerHelper::unpack($tmp_dest . '/' . $p_file);
-		if (!isset($package['type']))
+
+		if ($package === false || !isset($package['type']) || $package['type'] === false)
 		{
 			$app->enqueueMessage(JText::sprintf('COM_INSTALLER_MSG_UPDATE_INVALID_PKG', $url));
 

--- a/administrator/language/en-GB/en-GB.com_installer.ini
+++ b/administrator/language/en-GB/en-GB.com_installer.ini
@@ -139,6 +139,7 @@ COM_INSTALLER_MSG_MANAGE_NOUPDATESITE="There are no update sites matching your q
 COM_INSTALLER_MSG_N_DATABASE_ERROR_PANEL="%d Database Problems Found."
 COM_INSTALLER_MSG_N_DATABASE_ERROR_PANEL_1="1 Database Problem Found."
 COM_INSTALLER_MSG_UPDATE_ERROR="Error updating %s."
+COM_INSTALLER_MSG_UPDATE_INVALID_PKG="Invalid package : '%s'"
 COM_INSTALLER_MSG_UPDATE_NODESC="No description available for this item."
 COM_INSTALLER_MSG_UPDATE_NOUPDATES="There are no updates available at the moment. Please check again later."
 COM_INSTALLER_MSG_UPDATE_SITES_COUNT_CHECK="Some update sites are disabled. You may want to check the <a href="_QQ_"%s"_QQ_">Update Sites Manager</a>."

--- a/administrator/language/en-GB/en-GB.com_installer.ini
+++ b/administrator/language/en-GB/en-GB.com_installer.ini
@@ -139,7 +139,7 @@ COM_INSTALLER_MSG_MANAGE_NOUPDATESITE="There are no update sites matching your q
 COM_INSTALLER_MSG_N_DATABASE_ERROR_PANEL="%d Database Problems Found."
 COM_INSTALLER_MSG_N_DATABASE_ERROR_PANEL_1="1 Database Problem Found."
 COM_INSTALLER_MSG_UPDATE_ERROR="Error updating %s."
-COM_INSTALLER_MSG_UPDATE_INVALID_PKG="Invalid package: '%s'"
+COM_INSTALLER_MSG_UPDATE_INVALID_PKG="Invalid package: %s"
 COM_INSTALLER_MSG_UPDATE_NODESC="No description available for this item."
 COM_INSTALLER_MSG_UPDATE_NOUPDATES="There are no updates available at the moment. Please check again later."
 COM_INSTALLER_MSG_UPDATE_SITES_COUNT_CHECK="Some update sites are disabled. You may want to check the <a href="_QQ_"%s"_QQ_">Update Sites Manager</a>."

--- a/administrator/language/en-GB/en-GB.com_installer.ini
+++ b/administrator/language/en-GB/en-GB.com_installer.ini
@@ -139,7 +139,7 @@ COM_INSTALLER_MSG_MANAGE_NOUPDATESITE="There are no update sites matching your q
 COM_INSTALLER_MSG_N_DATABASE_ERROR_PANEL="%d Database Problems Found."
 COM_INSTALLER_MSG_N_DATABASE_ERROR_PANEL_1="1 Database Problem Found."
 COM_INSTALLER_MSG_UPDATE_ERROR="Error updating %s."
-COM_INSTALLER_MSG_UPDATE_INVALID_PKG="Invalid package : '%s'"
+COM_INSTALLER_MSG_UPDATE_INVALID_PKG="Invalid package: '%s'"
 COM_INSTALLER_MSG_UPDATE_NODESC="No description available for this item."
 COM_INSTALLER_MSG_UPDATE_NOUPDATES="There are no updates available at the moment. Please check again later."
 COM_INSTALLER_MSG_UPDATE_SITES_COUNT_CHECK="Some update sites are disabled. You may want to check the <a href="_QQ_"%s"_QQ_">Update Sites Manager</a>."


### PR DESCRIPTION
Pull Request for Issue ##22762.

### Summary of Changes

Improved error messages when the manifest retrieves and invalid manifest file.

### Testing Instructions

Get update site to include an invalid download URL - or get a valid one to fail.
For example.
<downloadurl type="full" format="">http://thisisinvalid/donotuse.zip</downloadurl>

### Expected result

Get sensible message pointing to problem.

### Actual result

Currently get message
Error updating COM_INSTALLER_TYPE_TYPE_.

### Documentation Changes Required

None