### PR TITLE
[4.0] Update draggablelist.php to use array as parameters

### DIFF
--- a/libraries/cms/html/draggablelist.php
+++ b/libraries/cms/html/draggablelist.php
@@ -74,9 +74,9 @@ abstract class JHtmlDraggablelist
 		HTMLHelper::_('behavior.core');
 
 		// Attach draggable to document
-		HTMLHelper::_('script', 'vendor/dragula/dragula.min.js', array('framework'=>false, 'relative'=>true));
-		HTMLHelper::_('script', 'system/draggable.min.js', array('framework'=>false, 'relative'=>true));
-		HTMLHelper::_('stylesheet', 'vendor/dragula/dragula.min.css', array('framework'=>false, 'relative'=>true, 'pathOnly'=>false));
+		HTMLHelper::_('script', 'vendor/dragula/dragula.min.js', ['framework'=>false, 'relative'=>true]);
+		HTMLHelper::_('script', 'system/draggable.min.js', ['framework'=>false, 'relative'=>true]);
+		HTMLHelper::_('stylesheet', 'vendor/dragula/dragula.min.css', ['framework'=>false, 'relative'=>true, 'pathOnly'=>false]);
 
 		// Set static array
 		static::$loaded[__METHOD__] = true;

--- a/libraries/cms/html/draggablelist.php
+++ b/libraries/cms/html/draggablelist.php
@@ -74,9 +74,9 @@ abstract class JHtmlDraggablelist
 		HTMLHelper::_('behavior.core');
 
 		// Attach draggable to document
-		HTMLHelper::_('script', 'vendor/dragula/dragula.min.js', false, true);
-		HTMLHelper::_('script', 'system/draggable.min.js', false, true);
-		HTMLHelper::_('stylesheet', 'vendor/dragula/dragula.min.css', false, true, false);
+		HTMLHelper::_('script', 'vendor/dragula/dragula.min.js', array('framework'=>false, 'relative'=>true));
+		HTMLHelper::_('script', 'system/draggable.min.js', array('framework'=>false, 'relative'=>true));
+		HTMLHelper::_('stylesheet', 'vendor/dragula/dragula.min.css', array('framework'=>false, 'relative'=>true, 'pathOnly'=>false));
 
 		// Set static array
 		static::$loaded[__METHOD__] = true;


### PR DESCRIPTION
### Summary of Changes
The function 'draggable' has not been updated to use arrays for parameters, thus the css/js files are no more loaded in the Joomla backend.


### Testing Instructions
Test the draggable feature for articles in the backend


### Expected result
Draggable feature is working


### Actual result
Draggable feature is not working because files are not loaded


### Documentation Changes Required

