### PR TITLE
Front-end: Display fieldset descriptions on user registration

### DIFF
--- a/components/com_users/views/registration/tmpl/default.php
+++ b/components/com_users/views/registration/tmpl/default.php
@@ -29,6 +29,12 @@ JHtml::_('behavior.formvalidator');
 					<?php if (isset($fieldset->label)) : ?>
 						<legend><?php echo JText::_($fieldset->label); ?></legend>
 					<?php endif; ?>
+					<?php // If the fieldset has a description set, display it under the legend. ?>
+					<?php if (isset($fieldset->description) && trim($fieldset->description)) : ?>
+						<p>
+							<?php echo $this->escape(JText::_($fieldset->description)); ?>
+						</p>
+					<?php endif; ?>
 					<?php echo $this->form->renderFieldset($fieldset->name); ?>
 				</fieldset>
 			<?php endif; ?>


### PR DESCRIPTION
### Summary of Changes
On the user registration view, fieldset descriptions were not shown, while on the profile view they are. This includes the description of the field groups. This commit adds the display of those descriptions on registration.


### Testing Instructions
Under the user manager in the administrator backend, go to field groups and create a new group or edit an existing one. Set the description of the field group and save it. Afterward on the frontend go to the user registration view at index.php?option=com_users&view=registration.


### Expected result
The descriptions for the field groups are shown under their names on the registration view.


### Documentation Changes Required
Unknown. I was unable to find any documentation for fields on the users component specifically.
