### PR TITLE
[4.0]Update SiteRouter.php 

### DIFF
--- a/libraries/src/Router/SiteRouter.php
+++ b/libraries/src/Router/SiteRouter.php
@@ -616,6 +616,35 @@ class SiteRouter extends Router
 			{
 				$this->componentRouters[$component] = $componentInstance->createRouter($this->app, $this->menu);
 			}
+			
+			// Keep support for components implementing the new format but don't implement the RouterServiceInterface
+			if (!isset($this->componentRouters[$component]))
+			{
+				$compname = ucfirst(substr($component, 4));
+				$class = $compname . 'Router';
+				
+				if (!class_exists($class))
+				{
+					// Use the component routing handler if it exists
+					$path = JPATH_SITE . '/components/' . $component . '/router.php';
+				
+					// Use the custom routing handler if it exists
+					if (file_exists($path))
+					{
+						require_once $path;
+					}
+				}
+				
+				if (class_exists($class))
+				{
+					$reflection = new \ReflectionClass($class);
+				
+					if (in_array('Joomla\\CMS\\Component\\Router\\RouterInterface', $reflection->getInterfaceNames()))
+					{
+						$this->componentRouters[$component] = new $class($this->app, $this->menu);
+					}
+				}
+			}
 
 			if (!isset($this->componentRouters[$component]))
 			{

--- a/libraries/src/Router/SiteRouter.php
+++ b/libraries/src/Router/SiteRouter.php
@@ -616,29 +616,29 @@ class SiteRouter extends Router
 			{
 				$this->componentRouters[$component] = $componentInstance->createRouter($this->app, $this->menu);
 			}
-			
+
 			// Keep support for components implementing the new format but don't implement the RouterServiceInterface
 			if (!isset($this->componentRouters[$component]))
 			{
 				$compname = ucfirst(substr($component, 4));
 				$class = $compname . 'Router';
-				
+
 				if (!class_exists($class))
 				{
 					// Use the component routing handler if it exists
 					$path = JPATH_SITE . '/components/' . $component . '/router.php';
-				
+
 					// Use the custom routing handler if it exists
 					if (file_exists($path))
 					{
 						require_once $path;
 					}
 				}
-				
+
 				if (class_exists($class))
 				{
 					$reflection = new \ReflectionClass($class);
-				
+
 					if (in_array('Joomla\\CMS\\Component\\Router\\RouterInterface', $reflection->getInterfaceNames()))
 					{
 						$this->componentRouters[$component] = new $class($this->app, $this->menu);


### PR DESCRIPTION
Pull Request for Issue #20339 .

### Summary of Changes
Keep support for components that implement the new J4 format but don't implement the RouterServiceInterface

As of now the classic router.php is no more working and executed. Having a component in the new J4 format that doesn't implement the RouterServiceInterface is fully broken and executed without any component router inclusion. It simply creates a RouterLegacy dummy class.
