### PR TITLE
[4.0] Double label in filter_modulesadmin.xml breaks admin modules manager

### DIFF
--- a/administrator/components/com_modules/forms/filter_modulesadmin.xml
+++ b/administrator/components/com_modules/forms/filter_modulesadmin.xml
@@ -26,7 +26,6 @@
 			name="state"
 			type="status"
 			label="JOPTION_SELECT_PUBLISHED"
-			label="JSTATUS"
 			filter="*,-2,0,1"
 			onchange="this.form.submit();"
 			>


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/22769#issuecomment-432115801

### Summary of Changes
Deleting double label


### Testing Instructions
Patch and display admin modules manager

@laoneo 
I guess this can be merged on review.