### PR TITLE
[4.0]Fix loading language files from module extension folder

### DIFF
--- a/libraries/src/Dispatcher/AbstractModuleDispatcher.php
+++ b/libraries/src/Dispatcher/AbstractModuleDispatcher.php
@@ -108,7 +108,7 @@ abstract class AbstractModuleDispatcher extends Dispatcher
 		$language = $this->app->getLanguage();
 
 		$coreLanguageDirectory      = JPATH_BASE;
-		$extensionLanguageDirectory = dirname(JPATH_BASE . '/modules/' . $this->module->module);
+		$extensionLanguageDirectory = dirname(JPATH_BASE . '/modules/' . $this->module->module . '/' .  $this->module->module . '.php');
 
 		$langPaths = $language->getPaths();
 

--- a/libraries/src/Dispatcher/AbstractModuleDispatcher.php
+++ b/libraries/src/Dispatcher/AbstractModuleDispatcher.php
@@ -108,7 +108,7 @@ abstract class AbstractModuleDispatcher extends Dispatcher
 		$language = $this->app->getLanguage();
 
 		$coreLanguageDirectory      = JPATH_BASE;
-		$extensionLanguageDirectory = dirname(JPATH_BASE . '/modules/' . $this->module->module . '/' .  $this->module->module . '.php');
+		$extensionLanguageDirectory = JPATH_BASE . '/modules/' . $this->module->module;
 
 		$langPaths = $language->getPaths();
 


### PR DESCRIPTION
Pull Request for Issue #22768 .

### Summary of Changes
dirname(..) is not referring to the correct file/path anymore, that is causing the loading of modules language files failing.


