### PR TITLE
Inject the active user into JAdminCssMenu

### DIFF
--- a/administrator/modules/mod_menu/menu.php
+++ b/administrator/modules/mod_menu/menu.php
@@ -9,9 +9,12 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Factory;
+use Joomla\CMS\Log\Log;
 use Joomla\CMS\Menu\Node;
 use Joomla\CMS\Menu\Tree;
 use Joomla\CMS\Menu\MenuHelper;
+use Joomla\CMS\User\User;
 use Joomla\Registry\Registry;
 use Joomla\Utilities\ArrayHelper;
 
@@ -26,7 +29,6 @@ class JAdminCssMenu
 	 * The Menu tree object
 	 *
 	 * @var    Tree
-	 *
 	 * @since  3.8.0
 	 */
 	protected $tree;
@@ -35,7 +37,6 @@ class JAdminCssMenu
 	 * The module options
 	 *
 	 * @var    Registry
-	 *
 	 * @since  3.8.0
 	 */
 	protected $params;
@@ -44,10 +45,44 @@ class JAdminCssMenu
 	 * The menu bar state
 	 *
 	 * @var    bool
-	 *
 	 * @since  3.8.0
 	 */
 	protected $enabled;
+
+	/**
+	 * The current user
+	 *
+	 * @var    User
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $user;
+
+	/**
+	 * JAdminCssMenu constructor.
+	 *
+	 * @param   User|null  $user  The current user
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function __construct(User $user = null)
+	{
+		if ($user === null)
+		{
+			Log::add(
+				sprintf(
+					'Not passing a %s instance into the %s constructor is deprecated. As of 4.0, it will be required.',
+					'Joomla\CMS\User\User',
+					__CLASS__
+				),
+				Log::WARNING,
+				'deprecated'
+			);
+
+			$user = Factory::getUser();
+		}
+
+		$this->user = $user;
+	}
 
 	/**
 	 * Get the current menu tree
@@ -163,9 +198,8 @@ class JAdminCssMenu
 	 */
 	protected function check($items, Registry $params)
 	{
-		$me          = JFactory::getUser();
-		$authMenus   = $me->authorise('core.manage', 'com_menus');
-		$authModules = $me->authorise('core.manage', 'com_modules');
+		$authMenus   = $this->user->authorise('core.manage', 'com_menus');
+		$authModules = $this->user->authorise('core.manage', 'com_modules');
 
 		if (!$authMenus && !$authModules)
 		{
@@ -233,9 +267,8 @@ class JAdminCssMenu
 	 */
 	protected function preprocess($items)
 	{
-		$result     = array();
-		$user       = JFactory::getUser();
-		$language   = JFactory::getLanguage();
+		$result   = array();
+		$language = JFactory::getLanguage();
 
 		$noSeparator = true;
 
@@ -315,11 +348,11 @@ class JAdminCssMenu
 				list($assetName) = isset($query['context']) ? explode('.', $query['context'], 2) : array('com_fields');
 			}
 			// Special case for components which only allow super user access
-			elseif (in_array($item->element, array('com_config', 'com_privacy', 'com_actionlogs'), true) && !$user->authorise('core.admin'))
+			elseif (in_array($item->element, array('com_config', 'com_privacy', 'com_actionlogs'), true) && !$this->user->authorise('core.admin'))
 			{
 				continue;
 			}
-			elseif ($item->element === 'com_joomlaupdate' && !$user->authorise('core.admin'))
+			elseif ($item->element === 'com_joomlaupdate' && !$this->user->authorise('core.admin'))
 			{
 				continue;
 			}
@@ -327,13 +360,13 @@ class JAdminCssMenu
 			{
 				parse_str($item->link, $query);
 
-				if (isset($query['view']) && $query['view'] === 'sysinfo' && !$user->authorise('core.admin'))
+				if (isset($query['view']) && $query['view'] === 'sysinfo' && !$this->user->authorise('core.admin'))
 				{
 					continue;
 				}
 			}
 
-			if ($assetName && !$user->authorise(($item->scope === 'edit') ? 'core.create' : 'core.manage', $assetName))
+			if ($assetName && !$this->user->authorise(($item->scope === 'edit') ? 'core.create' : 'core.manage', $assetName))
 			{
 				continue;
 			}

--- a/administrator/modules/mod_menu/mod_menu.php
+++ b/administrator/modules/mod_menu/mod_menu.php
@@ -22,7 +22,7 @@ $user    = JFactory::getUser();
 $input   = JFactory::getApplication()->input;
 $enabled = !$input->getBool('hidemainmenu');
 
-$menu = new JAdminCssMenu;
+$menu = new JAdminCssMenu($user);
 $menu->load($params, $enabled);
 
 // Render the module layout


### PR DESCRIPTION
### Summary of Changes

Calls to `Joomla\CMS\Factory::getUser()` without specifying the user ID (i.e. to get the currently logged in user) are expensive because this always ends up calling `Joomla\CMS\Session\Session::get()`.  In the admin `mod_menu`, we repetitively call this method to do ACL checks on menu items in the `JAdminCssMenu` class.  We can make a micro-optimization of the module's performance by injecting the user we're getting in the module's main file when instantiating this class.

Therefore, this PR changes the module to inject that user instance, and for B/C this constructor argument is optional until 4.0.

You can review the call graph comparison at https://blackfire.io/profiles/compare/e6c27a22-f126-4539-9406-032cc260658e/graph to see how many fewer calls there are as a result, which also creates a small performance enhancement.

### Testing Instructions

With the patch applied, navigate the backend.  The admin menu is correctly assembled.