### PR TITLE
Only get config and user from factory when needed in `JHtml::date()`

### DIFF
--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -781,10 +781,6 @@ abstract class HTMLHelper
 	 */
 	public static function date($input = 'now', $format = null, $tz = true, $gregorian = false)
 	{
-		// Get some system objects.
-		$config = Factory::getConfig();
-		$user   = Factory::getUser();
-
 		// UTC date converted to user time zone.
 		if ($tz === true)
 		{
@@ -792,7 +788,7 @@ abstract class HTMLHelper
 			$date = Factory::getDate($input, 'UTC');
 
 			// Set the correct time zone based on the user configuration.
-			$date->setTimezone($user->getTimezone());
+			$date->setTimezone(Factory::getUser()->getTimezone());
 		}
 		// UTC date converted to server time zone.
 		elseif ($tz === false)
@@ -801,7 +797,7 @@ abstract class HTMLHelper
 			$date = Factory::getDate($input, 'UTC');
 
 			// Set the correct time zone based on the server configuration.
-			$date->setTimezone(new \DateTimeZone($config->get('offset')));
+			$date->setTimezone(new \DateTimeZone(Factory::getConfig()->get('offset')));
 		}
 		// No date conversion.
 		elseif ($tz === null)


### PR DESCRIPTION
Partial Pull Request for Issue #22779

### Summary of Changes

Calls to `Joomla\CMS\Factory::getUser()` with no arguments end up in a call to `Joomla\CMS\Session\Session::get()` so this isn't a highly performant method call and should only happen when needed.  In `Joomla\CMS\HTML\HTMLHelper::date()`, it is only needed in one of the four conditions, so there is no need to always call this method.  Likewise, `Joomla\CMS\Factory::getConfig()` only needs to be called in one of the four conditions.  So, stop arbitrarily calling these two methods on every call to `Joomla\CMS\HTML\HTMLHelper::date()` and only call them when actually needed.

### Testing Instructions

With the patch applied, date/time strings are still correctly localized.