### PR TITLE
[4.0] Load the cache controller through the factory in the base model

### DIFF
--- a/libraries/src/MVC/Model/BaseDatabaseModel.php
+++ b/libraries/src/MVC/Model/BaseDatabaseModel.php
@@ -10,6 +10,8 @@ namespace Joomla\CMS\MVC\Model;
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\CMS\Cache\CacheControllerFactoryInterface;
+use Joomla\CMS\Cache\Controller\CallbackController;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Extension\ComponentInterface;
 use Joomla\CMS\Factory;
@@ -660,8 +662,8 @@ abstract class BaseDatabaseModel extends CMSObject
 
 		try
 		{
-			/** @var \JCacheControllerCallback $cache */
-			$cache = \JCache::getInstance('callback', $options);
+			/** @var CallbackController $cache */
+			$cache = Factory::getContainer()->get(CacheControllerFactoryInterface::class)->createCacheController('callback', $options);
 			$cache->clean();
 		}
 		catch (\JCacheException $exception)


### PR DESCRIPTION
Load the cache controller through the factory in the base model. See #22687 for more details.