### PR TITLE
Don't generate links for action logs CSV export

### DIFF
--- a/administrator/components/com_actionlogs/helpers/actionlogs.php
+++ b/administrator/components/com_actionlogs/helpers/actionlogs.php
@@ -64,7 +64,7 @@ class ActionlogsHelper
 
 			$rows[] = array(
 				'id'         => $log->id,
-				'message'    => strip_tags(static::getHumanReadableLogMessage($log)),
+				'message'    => strip_tags(static::getHumanReadableLogMessage($log, false)),
 				'date'       => $date->format('Y-m-d H:i:s T'),
 				'extension'  => JText::_($extension),
 				'name'       => $log->name,
@@ -159,13 +159,14 @@ class ActionlogsHelper
 	/**
 	 * Get human readable log message for a User Action Log
 	 *
-	 * @param   stdClass  $log  A User Action log message record
+	 * @param   stdClass  $log            A User Action log message record
+	 * @param   boolean   $generateLinks  Flag to disable link generation when creating a message
 	 *
 	 * @return  string
 	 *
 	 * @since   3.9.0
 	 */
-	public static function getHumanReadableLogMessage($log)
+	public static function getHumanReadableLogMessage($log, $generateLinks = true)
 	{
 		static $links = array();
 
@@ -184,7 +185,7 @@ class ActionlogsHelper
 		foreach ($messageData as $key => $value)
 		{
 			// Convert relative url to absolute url so that it is clickable in action logs notification email
-			if (StringHelper::strpos($value, 'index.php?') === 0)
+			if ($generateLinks && StringHelper::strpos($value, 'index.php?') === 0)
 			{
 				if (!isset($links[$value]))
 				{

--- a/administrator/components/com_actionlogs/helpers/actionlogsphp55.php
+++ b/administrator/components/com_actionlogs/helpers/actionlogsphp55.php
@@ -54,7 +54,7 @@ class ActionlogsHelperPhp55
 
 			yield array(
 				'id'         => $log->id,
-				'message'    => strip_tags(ActionlogsHelper::getHumanReadableLogMessage($log)),
+				'message'    => strip_tags(ActionlogsHelper::getHumanReadableLogMessage($log, false)),
 				'date'       => (new JDate($log->log_date, new DateTimeZone('UTC')))->format('Y-m-d H:i:s T'),
 				'extension'  => JText::_($extension),
 				'name'       => $log->name,


### PR DESCRIPTION
### Summary of Changes

As suggested in #22700 this skips generating links for the action log messages since they aren't going to be used in most export formats anyway (and in fact the CSV export helper has a `strip_tags()` call).  This offers a memory boost by not having to go through the router after the memory issues identified in #22807.

A Blackfire graph can be reviewed at https://blackfire.io/profiles/compare/4f46ce4e-d86a-4496-b857-146bb34f7956/graph - note that the increased number of `Joomla\CMS\Language\Text::_()` and `ActionlogsHelper::getHumanReadableLogMessage()` calls is actually because more log messages are being included in my exports; the first request in the comparison is actually reaching my 90 second timeout (after 58,700 rows while with this patch I'm now over 102,000 rows before the timeout is reached)

### Testing Instructions

With the patch applied, the action logs CSV file should still be exported.  If you're profiling the request, you should note a decrease in memory use, and depending on how large of an export you're working with probably an increase in row count.