### PR TITLE
[4.0] Deprecate functions in the CMS Factory where we have a service for

### DIFF
--- a/libraries/src/Factory.php
+++ b/libraries/src/Factory.php
@@ -246,7 +246,7 @@ abstract class Factory
 	{
 		@trigger_error(
 			sprintf(
-				'%1$s() is deprecated. Load the language from the dependency injection container or via %2$s::getApplication()->getSession().',
+				'%1$s() is deprecated. Load the language from the dependency injection container or via %2$s::getApplication()->getLanguage().',
 				__METHOD__,
 				__CLASS__
 			),

--- a/libraries/src/Factory.php
+++ b/libraries/src/Factory.php
@@ -57,9 +57,9 @@ abstract class Factory
 	/**
 	 * Global configuration object
 	 *
-	 * @var    \JConfig
-	 * @since  1.7.0
-	 * @deprecated  5.0  Use the configuration object within the application.
+	 * @var         \JConfig
+	 * @since       1.7.0
+	 * @deprecated  5.0  Use the configuration object within the application
 	 */
 	public static $config = null;
 
@@ -82,32 +82,35 @@ abstract class Factory
 	/**
 	 * Global session object
 	 *
-	 * @var    Session
-	 * @since  1.7.0
+	 * @var         Session
+	 * @since       1.7.0
+	 * @deprecated  5.0  Use the session service in the DI container
 	 */
 	public static $session = null;
 
 	/**
 	 * Global language object
 	 *
-	 * @var   Language
-	 * @since  1.7.0
+	 * @var         Language
+	 * @since       1.7.0
+	 * @deprecated  5.0  Use the language service in the DI container
 	 */
 	public static $language = null;
 
 	/**
 	 * Global document object
 	 *
-	 * @var    Document
-	 * @since  1.7.0
+	 * @var         Document
+	 * @since       1.7.0
+	 * @deprecated  5.0  Use the document service in the DI container
 	 */
 	public static $document = null;
 
 	/**
 	 * Global database object
 	 *
-	 * @var    DatabaseDriver
-	 * @since  1.7.0
+	 * @var         DatabaseDriver
+	 * @since       1.7.0
 	 * @deprecated  5.0  Use the database service in the DI container
 	 */
 	public static $database = null;
@@ -149,8 +152,8 @@ abstract class Factory
 	 *
 	 * @return  Registry
 	 *
-	 * @see     Registry
-	 * @since   1.7.0
+	 * @see         Registry
+	 * @since       1.7.0
 	 * @deprecated  5.0  Use the configuration object within the application.
 	 */
 	public static function getConfig($file = null, $type = 'PHP', $namespace = '')
@@ -210,8 +213,8 @@ abstract class Factory
 	 *
 	 * @return  Session object
 	 *
-	 * @see     Session
-	 * @since   1.7.0
+	 * @see         Session
+	 * @since       1.7.0
 	 * @deprecated  5.0  Load the session service from the dependency injection container or via $app->getSession()
 	 */
 	public static function getSession(array $options = array())
@@ -235,11 +238,21 @@ abstract class Factory
 	 *
 	 * @return  Language object
 	 *
-	 * @see     Language
-	 * @since   1.7.0
+	 * @see         Language
+	 * @since       1.7.0
+	 * @deprecated  5.0  Load the language service from the dependency injection container or via $app->getSession()
 	 */
 	public static function getLanguage()
 	{
+		@trigger_error(
+			sprintf(
+				'%1$s() is deprecated. Load the language from the dependency injection container or via %2$s::getApplication()->getSession().',
+				__METHOD__,
+				__CLASS__
+			),
+			E_USER_DEPRECATED
+		);
+
 		if (!self::$language)
 		{
 			self::$language = self::createLanguage();
@@ -255,11 +268,21 @@ abstract class Factory
 	 *
 	 * @return  Document object
 	 *
-	 * @see     Document
-	 * @since   1.7.0
+	 * @see         Document
+	 * @since       1.7.0
+	 * @deprecated  5.0  Load the document service from the dependency injection container or via $app->getDocument()
 	 */
 	public static function getDocument()
 	{
+		@trigger_error(
+			sprintf(
+				'%1$s() is deprecated. Load the document from the dependency injection container or via %2$s::getApplication()->getDocument().',
+				__METHOD__,
+				__CLASS__
+			),
+			E_USER_DEPRECATED
+		);
+
 		if (!self::$document)
 		{
 			self::$document = self::createDocument();
@@ -355,11 +378,21 @@ abstract class Factory
 	 *
 	 * @return  DatabaseDriver
 	 *
-	 * @see     DatabaseDriver
-	 * @since   1.7.0
+	 * @see         DatabaseDriver
+	 * @since       1.7.0
+	 * @deprecated  5.0  Load the database service from the dependency injection container
 	 */
 	public static function getDbo()
 	{
+		@trigger_error(
+			sprintf(
+				'%1$s() is deprecated. Load the database from the dependency injection container.',
+				__METHOD__,
+				__CLASS__
+			),
+			E_USER_DEPRECATED
+		);
+
 		if (!self::$database)
 		{
 			if (self::getContainer()->exists('DatabaseDriver'))
@@ -459,8 +492,8 @@ abstract class Factory
 	 *
 	 * @return  Registry
 	 *
-	 * @see     Registry
-	 * @since   1.7.0
+	 * @see         Registry
+	 * @since       1.7.0
 	 * @deprecated  5.0  Use the configuration object within the application.
 	 */
 	protected static function createConfig($file, $type = 'PHP', $namespace = '')
@@ -538,7 +571,7 @@ abstract class Factory
 	 *
 	 * @return  Session object
 	 *
-	 * @since   1.7.0
+	 * @since       1.7.0
 	 * @deprecated  5.0  Load the session service from the dependency injection container or via $app->getSession()
 	 */
 	protected static function createSession(array $options = array())
@@ -579,8 +612,8 @@ abstract class Factory
 	 *
 	 * @return  DatabaseDriver
 	 *
-	 * @see     DatabaseDriver
-	 * @since   1.7.0
+	 * @see         DatabaseDriver
+	 * @since       1.7.0
 	 * @deprecated  5.0  Use the database service in the DI container
 	 */
 	protected static function createDbo()
@@ -692,11 +725,21 @@ abstract class Factory
 	 *
 	 * @return  Language object
 	 *
-	 * @see     Language
-	 * @since   1.7.0
+	 * @see         Language
+	 * @since       1.7.0
+	 * @deprecated  5.0  Load the language service from the dependency injection container or via $app->getSession()
 	 */
 	protected static function createLanguage()
 	{
+		@trigger_error(
+			sprintf(
+				'%1$s() is deprecated. Load the language from the dependency injection container or via %2$s::getApplication()->getSession().',
+				__METHOD__,
+				__CLASS__
+			),
+			E_USER_DEPRECATED
+		);
+
 		$conf = self::getConfig();
 		$locale = $conf->get('language');
 		$debug = $conf->get('debug_lang');
@@ -710,11 +753,21 @@ abstract class Factory
 	 *
 	 * @return  Document object
 	 *
-	 * @see     Document
-	 * @since   1.7.0
+	 * @see         Document
+	 * @since       1.7.0
+	 * @deprecated  5.0  Load the document service from the dependency injection container or via $app->getDocument()
 	 */
 	protected static function createDocument()
 	{
+		@trigger_error(
+			sprintf(
+				'%1$s() is deprecated. Load the document from the dependency injection container or via %2$s::getApplication()->getDocument().',
+				__METHOD__,
+				__CLASS__
+			),
+			E_USER_DEPRECATED
+		);
+
 		$lang = self::getLanguage();
 
 		$input = self::getApplication()->input;

--- a/libraries/src/Factory.php
+++ b/libraries/src/Factory.php
@@ -240,7 +240,7 @@ abstract class Factory
 	 *
 	 * @see         Language
 	 * @since       1.7.0
-	 * @deprecated  5.0  Load the language service from the dependency injection container or via $app->getSession()
+	 * @deprecated  5.0  Load the language service from the dependency injection container or via $app->getLanguage()
 	 */
 	public static function getLanguage()
 	{

--- a/libraries/src/Factory.php
+++ b/libraries/src/Factory.php
@@ -733,7 +733,7 @@ abstract class Factory
 	{
 		@trigger_error(
 			sprintf(
-				'%1$s() is deprecated. Load the language from the dependency injection container or via %2$s::getApplication()->getSession().',
+				'%1$s() is deprecated. Load the language from the dependency injection container or via %2$s::getApplication()->getLanguage().',
 				__METHOD__,
 				__CLASS__
 			),

--- a/libraries/src/Factory.php
+++ b/libraries/src/Factory.php
@@ -727,7 +727,7 @@ abstract class Factory
 	 *
 	 * @see         Language
 	 * @since       1.7.0
-	 * @deprecated  5.0  Load the language service from the dependency injection container or via $app->getSession()
+	 * @deprecated  5.0  Load the language service from the dependency injection container or via $app->getLanguage()
 	 */
 	protected static function createLanguage()
 	{


### PR DESCRIPTION
Adds proper deprecate messages to the `Joomla\CMS\Factory` class where we have a service provider for. Additionally it cleans up some code styles in the deprecated doc blocks and does proper intending of the doc tags.