### PR TITLE
[4.0] Fix permissions report. Handle missing descriptions in asset files.

### DIFF
--- a/administrator/components/com_users/Helper/UsersHelperDebug.php
+++ b/administrator/components/com_users/Helper/UsersHelperDebug.php
@@ -121,8 +121,7 @@ class UsersHelperDebug
 							{
 								foreach ($field->children() as $action)
 								{
-									// Actions can have a description. If not, use
-									if (isset($action['description']) && !empty($action['description']) )
+									if (isset($action['description']) && !empty($action['description']))
 									{
 										$descr = (string) $action['description'];
 									}

--- a/administrator/components/com_users/Helper/UsersHelperDebug.php
+++ b/administrator/components/com_users/Helper/UsersHelperDebug.php
@@ -88,15 +88,13 @@ class UsersHelperDebug
 			{
 				foreach ($component_actions as &$action)
 				{
+					$descr = (string) $action['title'];
+					
 					if (isset($action['description']) && !empty($action['description']))
 					{
 						$descr = (string) $action['description'];
 					}
-					else 
-					{
-						$descr = (string) $action['title'];
-					}
-					
+
 					$actions[$action->title] = array($action->name, $descr);
 				}
 			}
@@ -121,15 +119,13 @@ class UsersHelperDebug
 							{
 								foreach ($field->children() as $action)
 								{
+									$descr = (string) $action['title'];
+									
 									if (isset($action['description']) && !empty($action['description']))
 									{
 										$descr = (string) $action['description'];
 									}
-									else 
-									{
-										$descr = (string) $action['title'];
-									}
-						
+
 									$actions[(string) $action['title']] = array(
 										(string) $action['name'],
 										$descr

--- a/administrator/components/com_users/Helper/UsersHelperDebug.php
+++ b/administrator/components/com_users/Helper/UsersHelperDebug.php
@@ -89,7 +89,7 @@ class UsersHelperDebug
 				foreach ($component_actions as &$action)
 				{
 					$descr = (string) $action['title'];
-					
+
 					if (isset($action['description']) && !empty($action['description']))
 					{
 						$descr = (string) $action['description'];
@@ -120,7 +120,7 @@ class UsersHelperDebug
 								foreach ($field->children() as $action)
 								{
 									$descr = (string) $action['title'];
-									
+
 									if (isset($action['description']) && !empty($action['description']))
 									{
 										$descr = (string) $action['description'];

--- a/administrator/components/com_users/Helper/UsersHelperDebug.php
+++ b/administrator/components/com_users/Helper/UsersHelperDebug.php
@@ -88,7 +88,16 @@ class UsersHelperDebug
 			{
 				foreach ($component_actions as &$action)
 				{
-					$actions[$action->title] = array($action->name, $action->description);
+					if (isset($action['description']) && !empty($action['description']))
+					{
+						$descr = (string) $action['description'];
+					}
+					else 
+					{
+						$descr = (string) $action['title'];
+					}
+					
+					$actions[$action->title] = array($action->name, $descr);
 				}
 			}
 		}
@@ -112,9 +121,19 @@ class UsersHelperDebug
 							{
 								foreach ($field->children() as $action)
 								{
+									// Actions can have a description. If not, use
+									if (isset($action['description']) && !empty($action['description']) )
+									{
+										$descr = (string) $action['description'];
+									}
+									else 
+									{
+										$descr = (string) $action['title'];
+									}
+						
 									$actions[(string) $action['title']] = array(
 										(string) $action['name'],
-										(string) $action['description']
+										$descr
 									);
 								}
 

--- a/administrator/components/com_users/Model/DebuggroupModel.php
+++ b/administrator/components/com_users/Model/DebuggroupModel.php
@@ -88,7 +88,7 @@ class DebuggroupModel extends ListModel
 				foreach ($actions as $action)
 				{
 					$name = $action[0];
-					$level = $action[1];
+					$level = $asset->level;
 
 					// Check that we check this action for the level of the asset.
 					if ($level === null || $level >= $asset->level)

--- a/administrator/components/com_users/Model/DebuguserModel.php
+++ b/administrator/components/com_users/Model/DebuguserModel.php
@@ -88,7 +88,7 @@ class DebuguserModel extends ListModel
 				foreach ($actions as $action)
 				{
 					$name = $action[0];
-					$level = $action[1];
+					$level = $asset->level;
 
 					// Check that we check this action for the level of the asset.
 					if ($level === null || $level >= $asset->level)


### PR DESCRIPTION
Pull Request for Issue #22761 .

### Summary of Changes
In many xml files, the description has been removed. If there is no description, use the title of the action.
Fixed wrong access level.

### Testing Instructions
Ad different users with different permissions.
Check the permission report for users and usergroups if everything is as expected. 


### Expected result
All permissions are displayed 

![permission-report](https://user-images.githubusercontent.com/1035262/47603527-41402700-d9ed-11e8-947c-aeef18a04d9f.PNG)


### Actual result
https://issues.joomla.org/tracker/joomla-cms/22761


### Documentation Changes Required
no
