### PR TITLE
[4.0] Use the injected application in the quickicon plugins

### DIFF
--- a/plugins/quickicon/extensionupdate/extensionupdate.php
+++ b/plugins/quickicon/extensionupdate/extensionupdate.php
@@ -32,6 +32,14 @@ class PlgQuickiconExtensionupdate extends CMSPlugin
 	protected $autoloadLanguage = true;
 
 	/**
+	 * Application object.
+	 *
+	 * @var    \Joomla\CMS\Application\CMSApplication
+	 * @since  3.7.0
+	 */
+	protected $app;
+
+	/**
 	 * Returns an icon definition for an icon which looks for extensions updates
 	 * via AJAX and displays a notification when such updates are found.
 	 *
@@ -44,7 +52,7 @@ class PlgQuickiconExtensionupdate extends CMSPlugin
 	 */
 	public function onGetIcons($context)
 	{
-		if ($context !== $this->params->get('context', 'mod_quickicon') || !Factory::getUser()->authorise('core.manage', 'com_installer'))
+		if ($context !== $this->params->get('context', 'mod_quickicon') || !$this->app->getIdentity()->authorise('core.manage', 'com_installer'))
 		{
 			return array();
 		}
@@ -55,7 +63,7 @@ class PlgQuickiconExtensionupdate extends CMSPlugin
 			'ajaxUrl' => Uri::base() . 'index.php?option=com_installer&view=update&task=update.ajax&' . $token,
 		);
 
-		Factory::getDocument()->addScriptOptions('js-extensions-update', $options);
+		$this->app->getDocument()->addScriptOptions('js-extensions-update', $options);
 
 		Text::script('PLG_QUICKICON_EXTENSIONUPDATE_UPTODATE', true);
 		Text::script('PLG_QUICKICON_EXTENSIONUPDATE_UPDATEFOUND', true);

--- a/plugins/quickicon/joomlaupdate/joomlaupdate.php
+++ b/plugins/quickicon/joomlaupdate/joomlaupdate.php
@@ -34,6 +34,14 @@ class PlgQuickiconJoomlaupdate extends CMSPlugin implements SubscriberInterface
 	protected $autoloadLanguage = true;
 
 	/**
+	 * Application object.
+	 *
+	 * @var    \Joomla\CMS\Application\CMSApplication
+	 * @since  3.7.0
+	 */
+	protected $app;
+
+	/**
 	 * Returns an array of events this subscriber will listen to.
 	 *
 	 * @return  array
@@ -62,7 +70,7 @@ class PlgQuickiconJoomlaupdate extends CMSPlugin implements SubscriberInterface
 	{
 		$context = $event->getContext();
 
-		if ($context !== $this->params->get('context', 'mod_quickicon') || !Factory::getUser()->authorise('core.manage', 'com_installer'))
+		if ($context !== $this->params->get('context', 'mod_quickicon') || !$this->app->getIdentity()->authorise('core.manage', 'com_installer'))
 		{
 			return;
 		}
@@ -73,7 +81,7 @@ class PlgQuickiconJoomlaupdate extends CMSPlugin implements SubscriberInterface
 		Text::script('PLG_QUICKICON_JOOMLAUPDATE_UPDATEFOUND', true);
 		Text::script('PLG_QUICKICON_JOOMLAUPDATE_UPTODATE', true);
 
-		Factory::getDocument()->addScriptOptions(
+		$this->app->getDocument()->addScriptOptions(
 			'js-joomla-update',
 			[
 				'url'     => Uri::base() . 'index.php?option=com_joomlaupdate',

--- a/plugins/quickicon/overridecheck/overridecheck.php
+++ b/plugins/quickicon/overridecheck/overridecheck.php
@@ -33,6 +33,23 @@ class PlgQuickiconOverrideCheck extends CMSPlugin
 	protected $autoloadLanguage = true;
 
 	/**
+	 * Application object.
+	 *
+	 * @var    \Joomla\CMS\Application\CMSApplication
+	 * @since  3.7.0
+	 */
+	protected $app;
+
+	/**
+	 * Database object
+	 *
+	 * @var    \Joomla\Database\DatabaseInterface
+	 *
+	 * @since  3.8.0
+	 */
+	protected $db;
+
+	/**
 	 * Returns an icon definition for an icon which looks for overrides update
 	 * via AJAX and displays a notification when such overrides are updated.
 	 *
@@ -45,7 +62,7 @@ class PlgQuickiconOverrideCheck extends CMSPlugin
 	 */
 	public function onGetIcons($context)
 	{
-		if ($context !== $this->params->get('context', 'mod_quickicon') || !Factory::getUser()->authorise('core.manage', 'com_installer'))
+		if ($context !== $this->params->get('context', 'mod_quickicon') || !$this->app->getIdentity()->authorise('core.manage', 'com_installer'))
 		{
 			return array();
 		}
@@ -57,7 +74,7 @@ class PlgQuickiconOverrideCheck extends CMSPlugin
 			'pluginId' => $this->getOverridePluginId()
 		);
 
-		Factory::getDocument()->addScriptOptions('js-override-check', $options);
+		$this->app->getDocument()->addScriptOptions('js-override-check', $options);
 
 		Text::script('PLG_QUICKICON_OVERRIDECHECK_ERROR', true);
 		Text::script('PLG_QUICKICON_OVERRIDECHECK_ERROR_ENABLE', true);
@@ -86,23 +103,22 @@ class PlgQuickiconOverrideCheck extends CMSPlugin
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public static function getOverridePluginId()
+	private function getOverridePluginId()
 	{
-		$db    = \JFactory::getDbo();
-		$query = $db->getQuery(true)
-			->select($db->quoteName('extension_id'))
-			->from($db->quoteName('#__extensions'))
-			->where($db->quoteName('folder') . ' = ' . $db->quote('installer'))
-			->where($db->quoteName('element') . ' = ' . $db->quote('override'));
-		$db->setQuery($query);
+		$query = $this->db->getQuery(true)
+			->select($this->db->quoteName('extension_id'))
+			->from($this->db->quoteName('#__extensions'))
+			->where($this->db->quoteName('folder') . ' = ' . $this->db->quote('installer'))
+			->where($this->db->quoteName('element') . ' = ' . $this->db->quote('override'));
+		$this->db->setQuery($query);
 
 		try
 		{
-			$result = (int) $db->loadResult();
+			$result = (int) $this->db->loadResult();
 		}
 		catch (\RuntimeException $e)
 		{
-			\JFactory::getApplication()->enqueueMessage($e->getMessage(), 'error');
+			$this->app->enqueueMessage($e->getMessage(), 'error');
 		}
 
 		return $result;

--- a/plugins/quickicon/phpversioncheck/phpversioncheck.php
+++ b/plugins/quickicon/phpversioncheck/phpversioncheck.php
@@ -48,7 +48,7 @@ class PlgQuickiconPhpVersionCheck extends CMSPlugin
 	/**
 	 * Application object.
 	 *
-	 * @var    JApplicationCms
+	 * @var    \Joomla\CMS\Application\CMSApplication
 	 * @since  3.7.0
 	 */
 	protected $app;
@@ -202,7 +202,7 @@ class PlgQuickiconPhpVersionCheck extends CMSPlugin
 		}
 
 		// Only if authenticated
-		if (Factory::getUser()->guest)
+		if ($this->app->getIdentity()->guest)
 		{
 			return false;
 		}


### PR DESCRIPTION
### Summary of Changes
Use the injected application in the quickicon plugins.

### Testing Instructions
Open the cpanel in the back end.

### Expected result
The update check icons are working.

### Actual result
The update check icons are working.