### PR TITLE
[Batch] Change State: pass only affected items to table and event

### DIFF
--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -1072,7 +1072,7 @@ abstract class AdminModel extends FormModel
 			}
 		}
 
-		// Check if there are items to publish
+		// Check if there are items to change
 		if(!count($pks))
 		{
 			return true;

--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -1073,7 +1073,7 @@ abstract class AdminModel extends FormModel
 		}
 
 		// Check if there are items to change
-		if(!count($pks))
+		if (!count($pks))
 		{
 			return true;
 		}

--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -1061,7 +1061,21 @@ abstract class AdminModel extends FormModel
 
 					return false;
 				}
+
+				// Prune items that are already at the given state
+				if ($table->get($table->getColumnAlias('published'), $value) == $value)
+				{
+					unset($pks[$i]);
+
+					continue;
+				}
 			}
+		}
+
+		// Check if there are items to publish
+		if(!count($pks))
+		{
+			return true;
 		}
 
 		// Attempt to change the state of the records.


### PR DESCRIPTION
### Summary of Changes

When you currently change the state of items (published, unpublished, trashed...)in the list via inline or toolbar button, joomla does not care about the current state of the item. 

This affects the notification (x items published...) and more importantly it also affects the primary keys that are passed to the onContentChangeState event (it passes all primary keys of all selected items including the ones where the state did not change). A plugin that listens to this event has no possibility to check if i.e. an article was unpublished before, because the value in db already changed. 

After these changes we pass only the pks that really should be/changed to the table and plugin event. If there are no items to change, we respond with a success message "0 items published". 

Because we already load the item, no additional query is needed. 

### Testing Instructions

Go to article Manager, set one article as unpublished. 
Checkall articles and publish them. 

![bildschirmfoto 2018-10-29 um 14 12 54](https://user-images.githubusercontent.com/1134007/47651942-e0e3ed80-db84-11e8-8dcc-711c150afbc1.png)

As the change was made in ArticleModel this will affect all Models in the backend, that are extending it. So it would be good to test other entities as well.  

#### Before Changes: 

![bildschirmfoto 2018-10-29 um 14 13 13](https://user-images.githubusercontent.com/1134007/47651940-e0e3ed80-db84-11e8-8fe2-1f296c4e2deb.png)

#### After Changes: 

![bildschirmfoto 2018-10-29 um 14 13 35](https://user-images.githubusercontent.com/1134007/47651941-e0e3ed80-db84-11e8-83ed-947482df2a31.png)

When no items were published:  

![bildschirmfoto 2018-10-29 um 14 14 47](https://user-images.githubusercontent.com/1134007/47651991-04a73380-db85-11e8-9b7b-374899ff5793.png)