### PR TITLE
Fix PHP 5.3 error in JHtmlContent

### DIFF
--- a/libraries/cms/html/content.php
+++ b/libraries/cms/html/content.php
@@ -71,7 +71,8 @@ abstract class JHtmlContent
 
 		foreach ($model->countItemsByMonth() as $item)
 		{
-			$items[] = JHtml::_('select.option', $item->d, (new JDate($item->d))->format('F Y') . ' [' . $item->c . ']');
+			$date    = new JDate($item->d);
+			$items[] = JHtml::_('select.option', $item->d, $date->format('F Y') . ' [' . $item->c . ']');
 		}
 
 		return $items;


### PR DESCRIPTION
Pull Request for Issue #22876.

### Summary of Changes

Fixes a syntax error on PHP 5.3.

### Testing Instructions

Test on PHP 5.3 setup.
Create `Category List` menu item.
Set `Filter Field` to `Month (published)`.
View menu item in frontend.

### Expected result

Select with months shown.

### Actual result

`Parse error: syntax error, unexpected T_OBJECT_OPERATOR in /libraries/cms/html/content.php on line 74`

### Documentation Changes Required
No.
