### PR TITLE
Privacy dashboard: direct access to the privacy consent plugin

### DIFF
--- a/administrator/components/com_privacy/helpers/privacy.php
+++ b/administrator/components/com_privacy/helpers/privacy.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Factory;
+
 /**
  * Privacy component helper.
  *
@@ -103,7 +105,7 @@ class PrivacyHelper extends JHelperContent
 	 */
 	public static function getPrivacyConsentPluginId()
 	{
-		$db    = JFactory::getDbo();
+		$db    = Factory::getDbo();
 		$query = $db->getQuery(true)
 			->select($db->quoteName('extension_id'))
 			->from($db->quoteName('#__extensions'))

--- a/administrator/components/com_privacy/helpers/privacy.php
+++ b/administrator/components/com_privacy/helpers/privacy.php
@@ -93,4 +93,34 @@ class PrivacyHelper extends JHelperContent
 
 		return $dom->saveXML();
 	}
+
+	/**
+	 * Gets the privacyconsent system plugin extension id.
+	 *
+	 * @return  integer  The privacyconsent system plugin extension id.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public static function getPrivacyConsentPluginId()
+	{
+		$db    = JFactory::getDbo();
+		$query = $db->getQuery(true)
+			->select($db->quoteName('extension_id'))
+			->from($db->quoteName('#__extensions'))
+			->where($db->quoteName('folder') . ' = ' . $db->quote('system'))
+			->where($db->quoteName('element') . ' = ' . $db->quote('privacyconsent'));
+
+		$db->setQuery($query);
+
+		try
+		{
+			$result = (int) $db->loadResult();
+		}
+		catch (RuntimeException $e)
+		{
+			JError::raiseWarning(500, $e->getMessage());
+		}
+
+		return $result;
+	}
 }

--- a/administrator/components/com_privacy/views/dashboard/tmpl/default.php
+++ b/administrator/components/com_privacy/views/dashboard/tmpl/default.php
@@ -99,6 +99,9 @@ $activeRequests = 0;
 							<div><?php echo JText::_('COM_PRIVACY_STATUS_CHECK_PRIVACY_POLICY_PUBLISHED'); ?></div>
 							<?php if ($this->privacyPolicyInfo['editLink'] !== '') : ?>
 								<small><a href="<?php echo $this->privacyPolicyInfo['editLink']; ?>"><?php echo JText::_('COM_PRIVACY_EDIT_PRIVACY_POLICY'); ?></a></small>
+							<?php else : ?>
+								<?php $link = JRoute::_('index.php?option=com_plugins&task=plugin.edit&extension_id=' . $this->privacyConsentPluginId); ?>
+								<small><a href="<?php echo $link; ?>"</a><?php echo JText::_('COM_PRIVACY_EDIT_PRIVACY_CONSENT_PLUGIN'); ?></small>
 							<?php endif; ?>
 						</div>
 					</div>

--- a/administrator/components/com_privacy/views/dashboard/tmpl/default.php
+++ b/administrator/components/com_privacy/views/dashboard/tmpl/default.php
@@ -101,7 +101,7 @@ $activeRequests = 0;
 								<small><a href="<?php echo $this->privacyPolicyInfo['editLink']; ?>"><?php echo JText::_('COM_PRIVACY_EDIT_PRIVACY_POLICY'); ?></a></small>
 							<?php else : ?>
 								<?php $link = JRoute::_('index.php?option=com_plugins&task=plugin.edit&extension_id=' . $this->privacyConsentPluginId); ?>
-								<small><a href="<?php echo $link; ?>"</a><?php echo JText::_('COM_PRIVACY_EDIT_PRIVACY_CONSENT_PLUGIN'); ?></small>
+								<small><a href="<?php echo $link; ?>"><?php echo JText::_('COM_PRIVACY_EDIT_PRIVACY_CONSENT_PLUGIN'); ?></a></small>
 							<?php endif; ?>
 						</div>
 					</div>

--- a/administrator/components/com_privacy/views/dashboard/tmpl/default.php
+++ b/administrator/components/com_privacy/views/dashboard/tmpl/default.php
@@ -9,6 +9,9 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Language\Text;
+use Joomla\CMS\Router\Route;
+
 /** @var PrivacyViewDashboard $this */
 
 // Include the component HTML helpers.
@@ -31,19 +34,19 @@ $activeRequests = 0;
 	<div class="row-fluid">
 		<div class="span6">
 			<div class="well well-small">
-				<h3 class="module-title nav-header"><?php echo JText::_('COM_PRIVACY_DASHBOARD_HEADING_TOTAL_REQUEST_COUNT'); ?></h3>
+				<h3 class="module-title nav-header"><?php echo Text::_('COM_PRIVACY_DASHBOARD_HEADING_TOTAL_REQUEST_COUNT'); ?></h3>
 				<div class="row-striped">
 					<?php if (count($this->requestCounts)) : ?>
 						<div class="row-fluid">
-							<div class="span5"><strong><?php echo JText::_('COM_PRIVACY_DASHBOARD_HEADING_REQUEST_TYPE'); ?></strong></div>
-							<div class="span5"><strong><?php echo JText::_('COM_PRIVACY_DASHBOARD_HEADING_REQUEST_STATUS'); ?></strong></div>
-							<div class="span2"><strong><?php echo JText::_('COM_PRIVACY_DASHBOARD_HEADING_REQUEST_COUNT'); ?></strong></div>
+							<div class="span5"><strong><?php echo Text::_('COM_PRIVACY_DASHBOARD_HEADING_REQUEST_TYPE'); ?></strong></div>
+							<div class="span5"><strong><?php echo Text::_('COM_PRIVACY_DASHBOARD_HEADING_REQUEST_STATUS'); ?></strong></div>
+							<div class="span2"><strong><?php echo Text::_('COM_PRIVACY_DASHBOARD_HEADING_REQUEST_COUNT'); ?></strong></div>
 						</div>
 						<?php foreach ($this->requestCounts as $row) : ?>
 							<div class="row-fluid">
 								<div class="span5">
 									<a class="hasTooltip" href="<?php echo JRoute::_('index.php?option=com_privacy&view=requests&filter[request_type]=' . $row->request_type . '&filter[status]=' . $row->status); ?>" data-original-title="<?php echo JText::_('COM_PRIVACY_DASHBOARD_VIEW_REQUESTS'); ?>">
-										<strong><?php echo JText::_('COM_PRIVACY_HEADING_REQUEST_TYPE_TYPE_' . $row->request_type); ?></strong>
+										<strong><?php echo Text::_('COM_PRIVACY_HEADING_REQUEST_TYPE_TYPE_' . $row->request_type); ?></strong>
 									</a>
 								</div>
 								<div class="span5"><?php echo JHtml::_('PrivacyHtml.helper.statusLabel', $row->status); ?></div>
@@ -55,13 +58,13 @@ $activeRequests = 0;
 							<?php $totalRequests += $row->count; ?>
 						<?php endforeach; ?>
 						<div class="row-fluid">
-							<div class="span5"><?php echo JText::plural('COM_PRIVACY_DASHBOARD_BADGE_TOTAL_REQUESTS', $totalRequests); ?></div>
-							<div class="span7"><?php echo JText::plural('COM_PRIVACY_DASHBOARD_BADGE_ACTIVE_REQUESTS', $activeRequests); ?></div>
+							<div class="span5"><?php echo Text::plural('COM_PRIVACY_DASHBOARD_BADGE_TOTAL_REQUESTS', $totalRequests); ?></div>
+							<div class="span7"><?php echo Text::plural('COM_PRIVACY_DASHBOARD_BADGE_ACTIVE_REQUESTS', $activeRequests); ?></div>
 						</div>
 					<?php else : ?>
 						<div class="row-fluid">
 							<div class="span12">
-								<div class="alert"><?php echo JText::_('COM_PRIVACY_DASHBOARD_NO_REQUESTS'); ?></div>
+								<div class="alert"><?php echo Text::_('COM_PRIVACY_DASHBOARD_NO_REQUESTS'); ?></div>
 							</div>
 						</div>
 					<?php endif; ?>
@@ -70,38 +73,38 @@ $activeRequests = 0;
 		</div>
 		<div class="span6">
 			<div class="well well-small">
-				<h3 class="module-title nav-header"><?php echo JText::_('COM_PRIVACY_DASHBOARD_HEADING_STATUS_CHECK'); ?></h3>
+				<h3 class="module-title nav-header"><?php echo Text::_('COM_PRIVACY_DASHBOARD_HEADING_STATUS_CHECK'); ?></h3>
 				<div class="row-striped">
 					<div class="row-fluid">
-						<div class="span3"><strong><?php echo JText::_('COM_PRIVACY_DASHBOARD_HEADING_STATUS'); ?></strong></div>
-						<div class="span9"><strong><?php echo JText::_('COM_PRIVACY_DASHBOARD_HEADING_CHECK'); ?></strong></div>
+						<div class="span3"><strong><?php echo Text::_('COM_PRIVACY_DASHBOARD_HEADING_STATUS'); ?></strong></div>
+						<div class="span9"><strong><?php echo Text::_('COM_PRIVACY_DASHBOARD_HEADING_CHECK'); ?></strong></div>
 					</div>
 					<div class="row-fluid">
 						<div class="span3">
 							<?php if ($this->privacyPolicyInfo['published'] && $this->privacyPolicyInfo['articlePublished']) : ?>
 								<span class="label label-success">
 									<span class="icon-checkbox" aria-hidden="true"></span>
-									<?php echo JText::_('JPUBLISHED'); ?>
+									<?php echo Text::_('JPUBLISHED'); ?>
 								</span>
 							<?php elseif ($this->privacyPolicyInfo['published'] && !$this->privacyPolicyInfo['articlePublished']) : ?>
 								<span class="label label-warning">
 									<span class="icon-warning" aria-hidden="true"></span>
-									<?php echo JText::_('JUNPUBLISHED'); ?>
+									<?php echo Text::_('JUNPUBLISHED'); ?>
 								</span>
 							<?php else : ?>
 								<span class="label label-warning">
 									<span class="icon-warning" aria-hidden="true"></span>
-									<?php echo JText::_('COM_PRIVACY_STATUS_CHECK_NOT_AVAILABLE'); ?>
+									<?php echo Text::_('COM_PRIVACY_STATUS_CHECK_NOT_AVAILABLE'); ?>
 								</span>
 							<?php endif; ?>
 						</div>
 						<div class="span9">
-							<div><?php echo JText::_('COM_PRIVACY_STATUS_CHECK_PRIVACY_POLICY_PUBLISHED'); ?></div>
+							<div><?php echo Text::_('COM_PRIVACY_STATUS_CHECK_PRIVACY_POLICY_PUBLISHED'); ?></div>
 							<?php if ($this->privacyPolicyInfo['editLink'] !== '') : ?>
-								<small><a href="<?php echo $this->privacyPolicyInfo['editLink']; ?>"><?php echo JText::_('COM_PRIVACY_EDIT_PRIVACY_POLICY'); ?></a></small>
+								<small><a href="<?php echo $this->privacyPolicyInfo['editLink']; ?>"><?php echo Text::_('COM_PRIVACY_EDIT_PRIVACY_POLICY'); ?></a></small>
 							<?php else : ?>
-								<?php $link = JRoute::_('index.php?option=com_plugins&task=plugin.edit&extension_id=' . $this->privacyConsentPluginId); ?>
-								<small><a href="<?php echo $link; ?>"><?php echo JText::_('COM_PRIVACY_EDIT_PRIVACY_CONSENT_PLUGIN'); ?></a></small>
+								<?php $link = Route::_('index.php?option=com_plugins&task=plugin.edit&extension_id=' . $this->privacyConsentPluginId); ?>
+								<small><a href="<?php echo $link; ?>"><?php echo Text::_('COM_PRIVACY_EDIT_PRIVACY_CONSENT_PLUGIN'); ?></a></small>
 							<?php endif; ?>
 						</div>
 					</div>
@@ -110,22 +113,22 @@ $activeRequests = 0;
 							<?php if ($this->requestFormPublished['published'] && $this->requestFormPublished['exists']) : ?>
 								<span class="label label-success">
 									<span class="icon-checkbox" aria-hidden="true"></span>
-									<?php echo JText::_('JPUBLISHED'); ?>
+									<?php echo Text::_('JPUBLISHED'); ?>
 								</span>
 							<?php elseif (!$this->requestFormPublished['published'] && $this->requestFormPublished['exists']) : ?>
 								<span class="label label-warning">
 									<span class="icon-warning" aria-hidden="true"></span>
-									<?php echo JText::_('JUNPUBLISHED'); ?>
+									<?php echo Text::_('JUNPUBLISHED'); ?>
 								</span>
 							<?php else : ?>
 								<span class="label label-warning">
 									<span class="icon-warning" aria-hidden="true"></span>
-									<?php echo JText::_('COM_PRIVACY_STATUS_CHECK_NOT_AVAILABLE'); ?>
+									<?php echo Text::_('COM_PRIVACY_STATUS_CHECK_NOT_AVAILABLE'); ?>
 								</span>
 							<?php endif; ?>
 						</div>
 						<div class="span9">
-							<div><?php echo JText::_('COM_PRIVACY_STATUS_CHECK_REQUEST_FORM_MENU_ITEM_PUBLISHED'); ?></div>
+							<div><?php echo Text::_('COM_PRIVACY_STATUS_CHECK_REQUEST_FORM_MENU_ITEM_PUBLISHED'); ?></div>
 							<?php if ($this->requestFormPublished['link'] !== '') : ?>
 								<small><a href="<?php echo $this->requestFormPublished['link']; ?>"><?php echo $this->requestFormPublished['link']; ?></a></small>
 							<?php endif; ?>
@@ -136,20 +139,20 @@ $activeRequests = 0;
 							<?php if ($this->numberOfUrgentRequests === 0) : ?>
 								<span class="label label-success">
 									<span class="icon-checkbox" aria-hidden="true"></span>
-									<?php echo JText::_('JNONE'); ?>
+									<?php echo Text::_('JNONE'); ?>
 								</span>
 							<?php else : ?>
 								<span class="label label-important">
 									<span class="icon-warning" aria-hidden="true"></span>
-									<?php echo JText::_('WARNING'); ?>
+									<?php echo Text::_('WARNING'); ?>
 								</span>
 							<?php endif; ?>
 						</div>
 						<div class="span9">
-							<div><?php echo JText::_('COM_PRIVACY_STATUS_CHECK_OUTSTANDING_URGENT_REQUESTS'); ?></div>
-							<small><?php echo JText::plural('COM_PRIVACY_STATUS_CHECK_OUTSTANDING_URGENT_REQUESTS_DESCRIPTION', $this->urgentRequestDays); ?></small>
+							<div><?php echo Text::_('COM_PRIVACY_STATUS_CHECK_OUTSTANDING_URGENT_REQUESTS'); ?></div>
+							<small><?php echo Text::plural('COM_PRIVACY_STATUS_CHECK_OUTSTANDING_URGENT_REQUESTS_DESCRIPTION', $this->urgentRequestDays); ?></small>
 							<?php if ($this->numberOfUrgentRequests > 0) : ?>
-								<small><a href="<?php echo JRoute::_('index.php?option=com_privacy&view=requests&filter[status]=1&list[fullordering]=a.requested_at ASC'); ?>"><?php echo JText::_('COM_PRIVACY_SHOW_URGENT_REQUESTS'); ?></a></small>
+								<small><a href="<?php echo Route::_('index.php?option=com_privacy&view=requests&filter[status]=1&list[fullordering]=a.requested_at ASC'); ?>"><?php echo JText::_('COM_PRIVACY_SHOW_URGENT_REQUESTS'); ?></a></small>
 							<?php endif; ?>
 						</div>
 					</div>
@@ -158,21 +161,21 @@ $activeRequests = 0;
 							<?php if ($this->sendMailEnabled) : ?>
 								<span class="label label-success">
 									<span class="icon-checkbox" aria-hidden="true"></span>
-									<?php echo JText::_('JENABLED'); ?>
+									<?php echo Text::_('JENABLED'); ?>
 								</span>
 							<?php else : ?>
 								<span class="label label-important">
 									<span class="icon-warning" aria-hidden="true"></span>
-									<?php echo JText::_('JDISABLED'); ?>
+									<?php echo Text::_('JDISABLED'); ?>
 								</span>
 							<?php endif; ?>
 						</div>
 						<div class="span9">
 							<?php if (!$this->sendMailEnabled) : ?>
-								<div><?php echo JText::_('COM_PRIVACY_STATUS_CHECK_SENDMAIL_DISABLED'); ?></div>
-								<small><?php echo JText::_('COM_PRIVACY_STATUS_CHECK_SENDMAIL_DISABLED_DESCRIPTION'); ?></small>
+								<div><?php echo Text::_('COM_PRIVACY_STATUS_CHECK_SENDMAIL_DISABLED'); ?></div>
+								<small><?php echo Text::_('COM_PRIVACY_STATUS_CHECK_SENDMAIL_DISABLED_DESCRIPTION'); ?></small>
 							<?php else : ?>
-								<div><?php echo JText::_('COM_PRIVACY_STATUS_CHECK_SENDMAIL_ENABLED'); ?></div>
+								<div><?php echo Text::_('COM_PRIVACY_STATUS_CHECK_SENDMAIL_ENABLED'); ?></div>
 							<?php endif; ?>
 						</div>
 					</div>

--- a/administrator/components/com_privacy/views/dashboard/view.html.php
+++ b/administrator/components/com_privacy/views/dashboard/view.html.php
@@ -65,6 +65,14 @@ class PrivacyViewDashboard extends JViewLegacy
 	protected $sidebar;
 
 	/**
+	 * Id of the system privacy consent plugin
+	 *
+	 * @var    integer
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $privacyConsentPluginId;
+
+	/**
 	 * Execute and display a template script.
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
@@ -78,10 +86,11 @@ class PrivacyViewDashboard extends JViewLegacy
 	public function display($tpl = null)
 	{
 		// Initialise variables
-		$this->privacyPolicyInfo    = $this->get('PrivacyPolicyInfo');
-		$this->requestCounts        = $this->get('RequestCounts');
-		$this->requestFormPublished = $this->get('RequestFormPublished');
-		$this->sendMailEnabled      = (bool) JFactory::getConfig()->get('mailonline', 1);
+		$this->privacyConsentPluginId = PrivacyHelper::getPrivacyConsentPluginId();
+		$this->privacyPolicyInfo      = $this->get('PrivacyPolicyInfo');
+		$this->requestCounts          = $this->get('RequestCounts');
+		$this->requestFormPublished   = $this->get('RequestFormPublished');
+		$this->sendMailEnabled        = (bool) JFactory::getConfig()->get('mailonline', 1);
 
 		/** @var PrivacyModelRequests $requestsModel */
 		$requestsModel = $this->getModel('requests');

--- a/administrator/components/com_privacy/views/dashboard/view.html.php
+++ b/administrator/components/com_privacy/views/dashboard/view.html.php
@@ -9,6 +9,10 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Component\ComponentHelper;
+use Joomla\CMS\Factory;
+use Joomla\CMS\Language\Text;
+
 /**
  * Dashboard view class
  *
@@ -90,7 +94,7 @@ class PrivacyViewDashboard extends JViewLegacy
 		$this->privacyPolicyInfo      = $this->get('PrivacyPolicyInfo');
 		$this->requestCounts          = $this->get('RequestCounts');
 		$this->requestFormPublished   = $this->get('RequestFormPublished');
-		$this->sendMailEnabled        = (bool) JFactory::getConfig()->get('mailonline', 1);
+		$this->sendMailEnabled        = (bool) Factory::getConfig()->get('mailonline', 1);
 
 		/** @var PrivacyModelRequests $requestsModel */
 		$requestsModel = $this->getModel('requests');
@@ -103,7 +107,7 @@ class PrivacyViewDashboard extends JViewLegacy
 			throw new Exception(implode("\n", $errors), 500);
 		}
 
-		$this->urgentRequestDays = (int) JComponentHelper::getParams('com_privacy')->get('notify', 14);
+		$this->urgentRequestDays = (int) ComponentHelper::getParams('com_privacy')->get('notify', 14);
 
 		$this->addToolbar();
 
@@ -121,7 +125,7 @@ class PrivacyViewDashboard extends JViewLegacy
 	 */
 	protected function addToolbar()
 	{
-		JToolbarHelper::title(JText::_('COM_PRIVACY_VIEW_DASHBOARD'), 'lock');
+		JToolbarHelper::title(Text::_('COM_PRIVACY_VIEW_DASHBOARD'), 'lock');
 
 		JToolbarHelper::preferences('com_privacy');
 

--- a/administrator/language/en-GB/en-GB.com_privacy.ini
+++ b/administrator/language/en-GB/en-GB.com_privacy.ini
@@ -50,6 +50,7 @@ COM_PRIVACY_DASHBOARD_HEADING_TOTAL_REQUEST_COUNT="Total Request Count"
 COM_PRIVACY_DASHBOARD_NO_REQUESTS="There are no requests."
 COM_PRIVACY_DASHBOARD_VIEW_REQUESTS="View Requests"
 COM_PRIVACY_DATA_REMOVED="Data removed"
+COM_PRIVACY_EDIT_PRIVACY_CONSENT_PLUGIN="Edit Privacy Consent Plugin"
 COM_PRIVACY_EDIT_PRIVACY_POLICY="Edit Privacy Policy"
 COM_PRIVACY_EXTENSION_CAPABILITY_PERSONAL_INFO="In order to process information requests, information about the user must be collected and logged for the purposes of retaining an audit log. The request system is based on an individual's email address which will be used to link the request to an existing site user if able."
 ; You can use the following merge codes for all COM_PRIVACY_EMAIL strings:

--- a/administrator/language/en-GB/en-GB.com_privacy.ini
+++ b/administrator/language/en-GB/en-GB.com_privacy.ini
@@ -50,7 +50,7 @@ COM_PRIVACY_DASHBOARD_HEADING_TOTAL_REQUEST_COUNT="Total Request Count"
 COM_PRIVACY_DASHBOARD_NO_REQUESTS="There are no requests."
 COM_PRIVACY_DASHBOARD_VIEW_REQUESTS="View Requests"
 COM_PRIVACY_DATA_REMOVED="Data removed"
-COM_PRIVACY_EDIT_PRIVACY_CONSENT_PLUGIN="Edit Privacy Consent Plugin"
+COM_PRIVACY_EDIT_PRIVACY_CONSENT_PLUGIN="Edit Privacy Consents Plugin"
 COM_PRIVACY_EDIT_PRIVACY_POLICY="Edit Privacy Policy"
 COM_PRIVACY_EXTENSION_CAPABILITY_PERSONAL_INFO="In order to process information requests, information about the user must be collected and logged for the purposes of retaining an audit log. The request system is based on an individual's email address which will be used to link the request to an existing site user if able."
 ; You can use the following merge codes for all COM_PRIVACY_EMAIL strings:


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/22869

### Summary of Changes
Adds direct link to the privacy consent plugin when there is no Privacy policy article defined.


### Testing Instructions
make sure no article is defined in the Privacy Consent System plugin parameters


### Before patch
No link to the plugin (and no idea what to do when getting The "Not available" button...)


### After patch
<img width="418" alt="screen shot 2018-10-31 at 12 13 02" src="https://user-images.githubusercontent.com/869724/47784612-66db7200-dd06-11e8-8e4c-757c49643d89.png">

The only other hyperlink for a chack check that "could" be also added is one to the Global Configuration for `mailonline`, but this is rather obvious.
For menus, it is also quite obvious.
Can be added though if judged necessary in another PR.