### PR TITLE
Fix image's microdata in single articles

### DIFF
--- a/layouts/joomla/content/full_image.php
+++ b/layouts/joomla/content/full_image.php
@@ -17,5 +17,5 @@ $params = $displayData->params;
 		<?php if ($images->image_fulltext_caption) :
 			echo 'class="caption"' . ' title="' . htmlspecialchars($images->image_fulltext_caption) . '"';
 		endif; ?>
-		src="<?php echo htmlspecialchars($images->image_fulltext); ?>" alt="<?php echo htmlspecialchars($images->image_fulltext_alt); ?>" itemprop="url"/> </div>
+		src="<?php echo htmlspecialchars($images->image_fulltext); ?>" alt="<?php echo htmlspecialchars($images->image_fulltext_alt); ?>" itemprop="url" content="<?php echo JURI::base() . htmlspecialchars($images->image_fulltext); ?>"/> </div>
 	<?php endif; ?>

--- a/layouts/joomla/content/full_image.php
+++ b/layouts/joomla/content/full_image.php
@@ -13,9 +13,9 @@ $params = $displayData->params;
 <?php $images = json_decode($displayData->images); ?>
 	<?php if (isset($images->image_fulltext) && !empty($images->image_fulltext)) : ?>
 		<?php $imgfloat = empty($images->float_fulltext) ? $params->get('float_fulltext') : $images->float_fulltext; ?>
-		<div class="pull-<?php echo htmlspecialchars($imgfloat); ?> item-image"> <img
+		<div class="pull-<?php echo htmlspecialchars($imgfloat); ?> item-image" itemprop="image" itemscope itemtype="http://schema.org/ImageObject"> <img
 		<?php if ($images->image_fulltext_caption) :
 			echo 'class="caption"' . ' title="' . htmlspecialchars($images->image_fulltext_caption) . '"';
 		endif; ?>
-		src="<?php echo htmlspecialchars($images->image_fulltext); ?>" alt="<?php echo htmlspecialchars($images->image_fulltext_alt); ?>" itemprop="image"/> </div>
+		src="<?php echo htmlspecialchars($images->image_fulltext); ?>" alt="<?php echo htmlspecialchars($images->image_fulltext_alt); ?>" itemprop="url"/> </div>
 	<?php endif; ?>


### PR DESCRIPTION
Pull Request for Issue # N/A .

### Summary of Changes
Include the image's URL to complement "image" property in single articles

### Testing Instructions
- In a Joomla website in frontend, copy the source code of a single article (HTML from the browser)
- Paste the code into the [Google Structured Data Testing Tool](https://search.google.com/structured-data/testing-tool/u/0/?hl=en)  

### Expected result
The "image" property should be ok
<img width="567" alt="screen shot 2018-10-31 at 2 38 48 pm" src="https://user-images.githubusercontent.com/4999794/47817201-b461da00-dd1a-11e8-87f1-882e170f4ac0.png">


### Actual result
The "image" property generates an error:
<img width="572" alt="screen shot 2018-10-31 at 2 36 36 pm" src="https://user-images.githubusercontent.com/4999794/47817089-63ea7c80-dd1a-11e8-9578-7fef9a05deb0.png">



### Documentation Changes Required

**Please note: testing this fix in localhost may generate an error since Google Structured Data Testing Tool is looking for an actual domain (e.g. http://something .com), not http://localhost/something**