### PR TITLE
Add an event to trigger when you execute a workflow transition

### DIFF
--- a/libraries/src/Workflow/Workflow.php
+++ b/libraries/src/Workflow/Workflow.php
@@ -208,7 +208,15 @@ class Workflow
 			$component->updateContentState($pks, $transition->condition);
 		}
 
-		return $this->updateAssociations($pks, $transition->to_stage_id);
+		$success = $this->updateAssociations($pks, $transition->to_stage_id);
+
+		if ($success)
+		{
+			$app = Factory::getApplication();
+			$app->triggerEvent('onWorkflowAfterTransition', ['pks' => $pks, 'extension' => $this->extension, 'user' => $app->getIdentity(), 'transition' => $transition];
+		}
+
+		return $success;
 	}
 
 	/**

--- a/libraries/src/Workflow/Workflow.php
+++ b/libraries/src/Workflow/Workflow.php
@@ -213,7 +213,7 @@ class Workflow
 		if ($success)
 		{
 			$app = Factory::getApplication();
-			$app->triggerEvent('onWorkflowAfterTransition', ['pks' => $pks, 'extension' => $this->extension, 'user' => $app->getIdentity(), 'transition' => $transition];
+			$app->triggerEvent('onWorkflowAfterTransition', ['pks' => $pks, 'extension' => $this->extension, 'user' => $app->getIdentity(), 'transition' => $transition]);
 		}
 
 		return $success;


### PR DESCRIPTION
Add an event triggered when you execute a transition. Easier to listen for than onContentAfterSave and also contains the transition rather than the stage that you have to diff yourself

// cc @bembelimen 