### PR TITLE
Fix typos

### DIFF
--- a/libraries/src/Log/Logger/FormattedtextLogger.php
+++ b/libraries/src/Log/Logger/FormattedtextLogger.php
@@ -139,7 +139,7 @@ class FormattedtextLogger extends Logger
 
 		if (!\JFile::append($this->path, implode("\n", $lines) . "\n"))
 		{
-			throw new RuntimeException('Cannot write to log file.');
+			throw new \RuntimeException('Cannot write to log file.');
 		}
 	}
 
@@ -172,7 +172,7 @@ class FormattedtextLogger extends Logger
 
 			if (!\JFile::append($this->path, $line))
 			{
-				throw new RuntimeException('Cannot write to log file.');
+				throw new \RuntimeException('Cannot write to log file.');
 			}
 		}
 	}


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This PR just fixes some small typos in FormattedtextLogger class. We need to use \RuntimeException instead of RuntimeException since the class is namespaced. I found this error because we use Kunena forum on our website and sometime, we see this error 
**0 - Class 'Joomla\CMS\Log\Logger\RuntimeException' not found**


### Testing Instructions
Code review.
