### PR TITLE
Document _getListCount() assumption of unique set by getListQuery()

### DIFF
--- a/libraries/src/MVC/Model/BaseDatabaseModel.php
+++ b/libraries/src/MVC/Model/BaseDatabaseModel.php
@@ -314,7 +314,7 @@ abstract class BaseDatabaseModel extends \JObject
 	 * Note: Current implementation of this method assumes that getListQuery() returns a set of unique rows,
 	 * thus it uses SELECT COUNT(*) to count the rows. In cases that getListQuery() uses DISTINCT
 	 * then either this method must be overriden by a custom implementation at the derived Model Class
-	 * or a GROUP BY clause should be used to make the set unique
+	 * or a GROUP BY clause should be used to make the set unique.
 	 *
 	 * @param   \JDatabaseQuery|string  $query  The query.
 	 *

--- a/libraries/src/MVC/Model/BaseDatabaseModel.php
+++ b/libraries/src/MVC/Model/BaseDatabaseModel.php
@@ -311,6 +311,11 @@ abstract class BaseDatabaseModel extends \JObject
 	/**
 	 * Returns a record count for the query.
 	 *
+	 * Note: Current implementation of this method assumes that getListQuery() returns a set of unique rows,
+	 * thus it uses SELECT COUNT(*) to count the rows. In cases that getListQuery() uses DISTINCT
+	 * then either this method must be overriden by a custom implementation at the derived Model Class
+	 * or a GROUP BY clause should be used to make the set unique
+	 *
 	 * @param   \JDatabaseQuery|string  $query  The query.
 	 *
 	 * @return  integer  Number of rows for query.


### PR DESCRIPTION
Pull Request for Issue #22891

### Summary of Changes
_getListCount() assumes that getListQuery() returns a unique set of rows
This PR documents this assumption

### Testing Instructions
Please review the added comments and suggest corrections / better text

### Expected result
Above behavior is documented


### Actual result
Behavior is not documented



### Documentation Changes Required
Maybe ?
