### PR TITLE
[3.9.0] plg_content_contact. Respect default values

### DIFF
--- a/plugins/content/contact/contact.php
+++ b/plugins/content/contact/contact.php
@@ -52,7 +52,7 @@ class PlgContentContact extends JPlugin
 		}
 
 		// Return if an alias is used
-		if ($this->params->get('link_to_alias') == 0 & $row->created_by_alias != '')
+		if ((int) $this->params->get('link_to_alias', 0) === 0 && $row->created_by_alias != '')
 		{
 			return true;
 		}
@@ -63,21 +63,22 @@ class PlgContentContact extends JPlugin
 			return true;
 		}
 
-		$contact = $this->getContactData($row->created_by);
+		$contact        = $this->getContactData($row->created_by);
 		$row->contactid = $contact->contactid;
-		$row->webpage = $contact->webpage;
-		$row->email = $contact->email_to;
+		$row->webpage   = $contact->webpage;
+		$row->email     = $contact->email_to;
+		$url            = $this->params->get('url', 'url');
 
-		if ($row->contactid && $this->params->get('url') == 'url')
+		if ($row->contactid && $url === 'url')
 		{
 			JLoader::register('ContactHelperRoute', JPATH_SITE . '/components/com_contact/helpers/route.php');
 			$row->contact_link = JRoute::_(ContactHelperRoute::getContactRoute($contact->contactid . ':' . $contact->alias, $contact->catid));
 		}
-		elseif ($row->webpage && $this->params->get('url') == 'webpage')
+		elseif ($row->webpage && $url === 'webpage')
 		{
 			$row->contact_link = $row->webpage;
 		}
-		elseif ($row->email && $this->params->get('url') == 'email')
+		elseif ($row->email && $url === 'email')
 		{
 			$row->contact_link = 'mailto:' . $row->email;
 		}

--- a/plugins/content/contact/contact.xml
+++ b/plugins/content/contact/contact.xml
@@ -24,7 +24,7 @@
 					type="list"
 					label="PLG_CONTENT_CONTACT_PARAM_URL_LABEL"
 					description="PLG_CONTENT_CONTACT_PARAM_URL_DESCRIPTION"
-					default="0"
+					default="url"
 					>
 					<option value="url">PLG_CONTENT_CONTACT_PARAM_URL_URL</option>
 					<option value="webpage">PLG_CONTENT_CONTACT_PARAM_URL_WEBPAGE</option>
@@ -38,6 +38,7 @@
 					description="PLG_CONTENT_CONTACT_PARAM_ALIAS_DESCRIPTION"
 					default="0"
 					class="btn-group btn-group-yesno"
+					filter="integer"
 					>
 					<option value="0">JNO</option>
 					<option value="1">JYES</option>


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/22896

### Summary of Changes
- Correct default value of parameter `url` in xml
- Add filter `integer ` to 0/1 parameter `link_to_alias` in xml
- Respect/Force default values  in php if plugin settings are not newly saved by user
- Force integer for `link_to_alias` (B\C) in php
- type-safe comparisons

### Testing Instructions
- Install Joomla 3.9.0 or update from 3.8.x to 3.9.0
- **Don't save the plugin settings of plg_content_contact !**
- Create Contact and assign Linked User
- Create Article created by user linked to contact
- Set content component `Show Author` and `Link Author` to `Yes`, and set menu/article settings to use global

### Expected result
- Code falls back to default values if user doesn't save the plugin settings
- Article displays link to contact page of author.

### Actual result
- see https://github.com/joomla/joomla-cms/issues/22896
