### PR TITLE
[4.0] Load the document properly in the exception handler

### DIFF
--- a/libraries/src/Exception/ExceptionHandler.php
+++ b/libraries/src/Exception/ExceptionHandler.php
@@ -129,6 +129,7 @@ class ExceptionHandler
 
 			// Reset the document object in the factory, this gives us a clean slate and lets everything render properly
 			Factory::$document = $renderer->getDocument();
+			Factory::getApplication()->loadDocument(Factory::$document);
 
 			$data = $renderer->render($error);
 

--- a/templates/cassiopeia/error.php
+++ b/templates/cassiopeia/error.php
@@ -27,7 +27,7 @@ $task     = $app->input->getCmd('task', '');
 $itemid   = $app->input->getCmd('Itemid', '');
 $sitename = $app->get('sitename');
 $menu     = $app->getMenu()->getActive();
-$pageclass = $menu ? $menu->params->get('pageclass_sfx') : '';
+$pageclass = $menu !== null ? $menu->params->get('pageclass_sfx', '') : '';
 
 // Add JavaScript Frameworks
 HTMLHelper::_('bootstrap.framework');

--- a/templates/cassiopeia/error.php
+++ b/templates/cassiopeia/error.php
@@ -27,7 +27,7 @@ $task     = $app->input->getCmd('task', '');
 $itemid   = $app->input->getCmd('Itemid', '');
 $sitename = $app->get('sitename');
 $menu     = $app->getMenu()->getActive();
-$pageclass = $menu->params->get('pageclass_sfx');
+$pageclass = $menu ? $menu->params->get('pageclass_sfx') : '';
 
 // Add JavaScript Frameworks
 HTMLHelper::_('bootstrap.framework');


### PR DESCRIPTION
### Summary of Changes
The error page is currently broken. The error document is not set in the application and the active menu is accessed, even when it can't exist.

### Testing Instructions
Open a none existing url, which should produce a 404.

### Expected result
The error page is displayed.

### Actual result
An error is thrown.