### PR TITLE
[4.0] Access the arguments directly from the array to prevent an infinite loop

### DIFF
--- a/libraries/src/Event/AfterExtensionBootEvent.php
+++ b/libraries/src/Event/AfterExtensionBootEvent.php
@@ -41,7 +41,7 @@ class AfterExtensionBootEvent extends AbstractImmutableEvent
 	 */
 	public function getExtensionName(): string
 	{
-		return $this->getArgument('extensionName');
+		return $this->arguments['extensionName'];
 	}
 
 	/**
@@ -53,6 +53,6 @@ class AfterExtensionBootEvent extends AbstractImmutableEvent
 	 */
 	public function getContainer(): Container
 	{
-		return $this->getArgument('container');
+		return $this->arguments['container'];
 	}
 }

--- a/libraries/src/Event/BeforeExecuteEvent.php
+++ b/libraries/src/Event/BeforeExecuteEvent.php
@@ -41,6 +41,6 @@ class BeforeExecuteEvent extends AbstractImmutableEvent
 	 */
 	public function getContainer(): Container
 	{
-		return $this->getArgument('container');
+		return $this->arguments['container'];
 	}
 }

--- a/libraries/src/Event/BeforeExtensionBootEvent.php
+++ b/libraries/src/Event/BeforeExtensionBootEvent.php
@@ -41,7 +41,7 @@ class BeforeExtensionBootEvent extends AbstractImmutableEvent
 	 */
 	public function getExtensionName(): string
 	{
-		return $this->getArgument('extensionName');
+		return $this->arguments['extensionName'];
 	}
 
 	/**
@@ -53,6 +53,6 @@ class BeforeExtensionBootEvent extends AbstractImmutableEvent
 	 */
 	public function getContainer(): Container
 	{
-		return $this->getArgument('container');
+		return $this->arguments['container'];
 	}
 }

--- a/libraries/src/Event/ErrorEvent.php
+++ b/libraries/src/Event/ErrorEvent.php
@@ -28,7 +28,7 @@ class ErrorEvent extends AbstractEvent
 	 */
 	public function getApplication(): AbstractApplication
 	{
-		return $this->getArgument('application');
+		return $this->arguments['application'];
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for pr comment #https://github.com/joomla/joomla-cms/pull/22913#issuecomment-435346420.

### Summary of Changes
In the abstract event when the argument has the same name as the getter/setter function, then an infinite loop happens. This is a workaround to directly fetch the Arguments in the getter, instead of calling the helper function of the abstract base class.

The problem is this line https://github.com/joomla/joomla-cms/blob/4.0-dev/libraries/src/Event/AbstractEvent.php#L138, which produces an infinite loop. Honestly I would remove the getArgument/setArgument overriden functions completely. @mbabker thoughts?

### Testing Instructions
- Apply patch #22913
- Activate the redirect plugin
- On the front open a none existent url

### Expected result
Error page with 404 is shown.

### Actual result
Site crashes with an infinite loop.