### PR TITLE
[4.0] Use the correct params object in the redirect plugin

### DIFF
--- a/plugins/system/redirect/redirect.php
+++ b/plugins/system/redirect/redirect.php
@@ -251,7 +251,7 @@ class PlgSystemRedirect extends CMSPlugin implements SubscriberInterface
 		{
 			if ((bool) $this->params->get('collect_urls', true))
 			{
-				if (!$params->get('includeUrl', 1))
+				if (!$this->params->get('includeUrl', 1))
 				{
 					$url = $urlRel;
 				}


### PR DESCRIPTION
 Use the correct params object in the redirect plugin.