### PR TITLE
[4.0] Fix CSP reporting

### DIFF
--- a/administrator/components/com_csp/Table/ReportTable.php
+++ b/administrator/components/com_csp/Table/ReportTable.php
@@ -12,6 +12,7 @@ namespace Joomla\Component\Csp\Administrator\Table;
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Table\Table;
+use Joomla\Database\DatabaseInterface;
 
 /**
  * Report table
@@ -23,11 +24,11 @@ class ReportTable extends Table
 	/**
 	 * Constructor
 	 *
-	 * @param   DatabaseDriver  $db  Database driver object.
+	 * @param   DatabaseInterface  $db  Database driver object.
 	 *
 	 * @since   4.0.0
 	 */
-	public function __construct(DatabaseDriver $db)
+	public function __construct(DatabaseInterface $db)
 	{
 		parent::__construct('#__csp', 'id', $db);
 	}

--- a/components/com_csp/Controller/ReportController.php
+++ b/components/com_csp/Controller/ReportController.php
@@ -94,7 +94,7 @@ class ReportController extends BaseController
 			$this->app->close();
 		}
 
-		$table = new ReportTable(Factory::getDbo());
+		$table = $this->app->bootComponent('com_csp')->getMVCFactory()->createTable('Report', 'Administrator');
 
 		$table->bind($report);
 		$table->store();

--- a/components/com_csp/Controller/ReportController.php
+++ b/components/com_csp/Controller/ReportController.php
@@ -14,7 +14,6 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\MVC\Controller\BaseController;
 use Joomla\CMS\Plugin\PluginHelper;
-use Joomla\Component\Csp\Administrator\Table\ReportTable;
 use Joomla\Registry\Registry;
 
 /**


### PR DESCRIPTION
### Summary of Changes
When he HTTP Headers is activated, no reports are created. An error is thrown that the class Joomla\Component\Csp\Administrator\Table\DatabaseDriver is not found. This is due a missing namespace import.

cc @zero-24

### Testing Instructions
- Enable the HTTP headers plugin
- In the CSP tab select "Detect" as mode
- Save the plugin
- Open the front page

### Expected result
In /administrator/index.php?option=com_csp are reports visible.

### Actual result
No reports are generated.