### PR TITLE
[com_privacy] Redirect to request form after login

### DIFF
--- a/components/com_privacy/controller.php
+++ b/components/com_privacy/controller.php
@@ -33,7 +33,9 @@ class PrivacyController extends JControllerLegacy
 		// Submitting information requests through the frontend is restricted to authenticated users at this time
 		if ($view === 'request' && JFactory::getUser()->guest)
 		{
-			$this->setRedirect(JRoute::_('index.php?option=com_users&view=login', false));
+			$this->setRedirect(
+				JRoute::_('index.php?option=com_users&view=login&return=' . base64_encode('index.php?option=com_privacy&view=request'), false)
+			);
 
 			return $this;
 		}


### PR DESCRIPTION
Issue reported by user on forum https://forum.joomla.org/viewtopic.php?f=706&t=966856

### Summary of Changes

This redirects users back to Privacy Request form when they login after trying to access the form.

### Testing Instructions

While logged out, access `Privacy » Create Request` page (either directly (`index.php?option=com_privacy&view=request`) or through a menu item.
Login.

### Expected result

Redirected to privacy request form.

### Actual result

Redirected to user profile.

### Documentation Changes Required
No.
