### PR TITLE
[4.0][com_menus] Saving new menu type fails

### DIFF
--- a/administrator/components/com_menus/Model/MenuModel.php
+++ b/administrator/components/com_menus/Model/MenuModel.php
@@ -106,7 +106,7 @@ class MenuModel extends FormModel
 		$this->setState('params', $params);
 
 		// Load the clientId.
-		$clientId = $app->getUserState('com_menus.menus.client_id', 'client_id');
+		$clientId = $app->getUserStateFromRequest('com_menus.menus.client_id', 'client_id', 0, 'int');
 		$this->setState('client_id', $clientId);
 	}
 
@@ -161,6 +161,11 @@ class MenuModel extends FormModel
 		if (empty($form))
 		{
 			return false;
+		}
+
+		if (!$this->getState('client_id', 0))
+		{
+			$form->removeField('preset');
 		}
 
 		return $form;

--- a/administrator/components/com_menus/tmpl/menu/edit.php
+++ b/administrator/components/com_menus/tmpl/menu/edit.php
@@ -36,9 +36,7 @@ Text::script('ERROR');
 
 			echo $this->form->renderField('client_id');
 
-			if ($this->state->get('client_id') == '1') :
-				echo $this->form->renderField('preset');
-			endif;
+			echo $this->form->renderField('preset');
 			?>
 
 			<?php echo HTMLHelper::_('uitab.endTab'); ?>


### PR DESCRIPTION
Pull Request for Issue #22928 .

### Summary of Changes

Fixes saving of new menu.

### Testing Instructions

Attempt to save a new menu.

### Expected result

Menu saved successfully.

### Actual result

> Error
> Save failed with the following error: Incorrect integer value: 'client_id' for column 'client_id' at row 1


### Documentation Changes Required

No.