### PR TITLE
[plg_content_pagebreak] Let users template override Previous/Next navigation

### DIFF
--- a/plugins/content/pagebreak/pagebreak.php
+++ b/plugins/content/pagebreak/pagebreak.php
@@ -342,44 +342,31 @@ class PlgContentPagebreak extends JPlugin
 	 */
 	protected function _createNavigation(&$row, $page, $n)
 	{
-		$pnSpace = '';
-
-		if (JText::_('JGLOBAL_LT') || JText::_('JGLOBAL_LT'))
-		{
-			$pnSpace = ' ';
-		}
+		$links = array(
+			'next' => '',
+			'previous' => ''
+		);
 
 		if ($page < $n - 1)
 		{
-			$page_next = $page + 1;
-
-			$link_next = JRoute::_(ContentHelperRoute::getArticleRoute($row->slug, $row->catid, $row->language) . '&limitstart=' . $page_next);
-
-			// Next >>
-			$next = '<a href="' . $link_next . '">' . JText::_('JNEXT') . $pnSpace . JText::_('JGLOBAL_GT') . JText::_('JGLOBAL_GT') . '</a>';
-		}
-		else
-		{
-			$next = JText::_('JNEXT');
+			$links['next'] = JRoute::_(ContentHelperRoute::getArticleRoute($row->slug, $row->catid, $row->language) . '&limitstart=' . ($page + 1));
 		}
 
 		if ($page > 0)
 		{
-			$link_prev = ContentHelperRoute::getArticleRoute($row->slug, $row->catid, $row->language);
+			$links['previous'] = ContentHelperRoute::getArticleRoute($row->slug, $row->catid, $row->language);
 
 			if ($page > 1)
 			{
-				$link_prev .= '&limitstart=' . ($page - 1);
+				$links['previous'] .= '&limitstart=' . ($page - 1);
 			}
 
-			// << Prev
-			$prev = '<a href="' . JRoute::_($link_prev) . '">' . JText::_('JGLOBAL_LT') . JText::_('JGLOBAL_LT') . $pnSpace . JText::_('JPREV') . '</a>';
-		}
-		else
-		{
-			$prev = JText::_('JPREV');
+			$links['previous'] = JRoute::_($links['previous']);
 		}
 
-		$row->text .= '<ul><li>' . $prev . ' </li><li>' . $next . '</li></ul>';
+		$path = JPluginHelper::getLayoutPath('content', 'pagebreak', 'navigation');
+		ob_start();
+		include $path;
+		$row->text .= ob_get_clean();
 	}
 }

--- a/plugins/content/pagebreak/tmpl/navigation.php
+++ b/plugins/content/pagebreak/tmpl/navigation.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * @package     Joomla.Plugin
+ * @subpackage  Content.pagebreak
+ *
+ * @copyright   Copyright (C) 2005 - 2018 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+?>
+<ul>
+	<li>
+		<?php if ($links['previous']) : ?>
+		<a href="<?php echo $links['previous']; ?>">
+			<?php echo trim(str_repeat(JText::_('JGLOBAL_LT'), 2) . ' ' . JText::_('JPREV')); ?>
+		</a>
+		<?php else: ?>
+		<?php echo JText::_('JPREV'); ?>
+		<?php endif; ?>
+	</li>
+	<li>
+		<?php if ($links['next']) : ?>
+		<a href="<?php echo $links['next']; ?>">
+			<?php echo trim(JText::_('JNEXT') . ' ' . str_repeat(JText::_('JGLOBAL_GT'), 2)); ?>
+		</a>
+		<?php else: ?>
+		<?php echo JText::_('JNEXT'); ?>
+		<?php endif; ?>
+	</li>
+</ul>


### PR DESCRIPTION
Continuation of https://github.com/joomla/joomla-cms/pull/20202
Joomla 3

### Summary of Changes
- Add possibility to use a template override for Previous/Next pagination.
- Don't break B\C.
- Replace "`$pnSpace bug`" by `trim()`s

### Testing Instructions
- Plugin "Content - Page Break". Make settings:
![19-04-_2018_19-35-49](https://user-images.githubusercontent.com/20780646/39008439-f5028d6c-4408-11e8-9bda-eb3771ac4598.jpg)

- Add some pagebreak markers to an article and open article in frontend.
- See Previous/Next navigation below article.
![03-11-_2018_20-50-23](https://user-images.githubusercontent.com/20780646/47956771-3451a380-dfaa-11e8-9b27-2b156895cb00.jpg)

- Apply patch

### Expected result
- Nothing has changed.

- Create a template override for new file tmpl/navigation.php.
Example with template Protostar:

![03-11-_2018_20-58-58](https://user-images.githubusercontent.com/20780646/47956832-66afd080-dfab-11e8-9aa9-9f04996ef875.jpg)

- Check that the override works.
