### PR TITLE
[plg_system_privacyconsent] Don't redirect on menu logout

### DIFF
--- a/plugins/system/privacyconsent/privacyconsent.php
+++ b/plugins/system/privacyconsent/privacyconsent.php
@@ -318,7 +318,7 @@ class PlgSystemPrivacyconsent extends JPlugin
 			 * If user is already on edit profile screen or view privacy article
 			 * or press update/apply button, or logout, do nothing to avoid infinite redirect
 			 */
-			if ($option == 'com_users' && in_array($task, array('profile.save', 'profile.apply', 'user.logout'))
+			if ($option == 'com_users' && in_array($task, array('profile.save', 'profile.apply', 'user.logout', 'user.menulogout'))
 				|| ($option == 'com_content' && $view == 'article' && $id == $privacyArticleId)
 				|| ($option == 'com_users' && $view == 'profile' && $layout == 'edit'))
 			{


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Prevents plugin from running when logging out through a menu item.

### Testing Instructions

Create `Users » Logout` menu item.
Login to frontend with user that hasn't consented yet.
Attempt to logout through the menu item.

### Expected result

Can logout.

### Actual result

Can't logout, redirected to profile page.

### Documentation Changes Required
No.
