### PR TITLE
Add column alias

### DIFF
--- a/libraries/src/Table/Extension.php
+++ b/libraries/src/Table/Extension.php
@@ -30,6 +30,9 @@ class Extension extends Table
 	public function __construct($db)
 	{
 		parent::__construct('#__extensions', 'extension_id', $db);
+
+		// Set the alias since the column is called enabled
+		$this->setColumnAlias('published', 'enabled');
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue #22952.

The Table Joomla\CMS\Table\Extension has no column alias for the published column. 

Testing instructions:

Go to plugin manager and en/disable plugins