### PR TITLE
[4.0] Adding links to Modules in the System Panel

### DIFF
--- a/administrator/components/com_cpanel/View/System/HtmlView.php
+++ b/administrator/components/com_cpanel/View/System/HtmlView.php
@@ -352,6 +352,35 @@ class HtmlView extends BaseHtmlView
 			static::$notEmpty = true;
 		}
 
+		if ($user->authorise('core.manage', 'com_modules'))
+		{
+			$new = [
+				'com_modules' => static::arrayBuilder(
+					'MOD_MENU_EXTENSIONS_MODULE_MANAGER_SITE',
+					'index.php?option=com_modules&view=modules&client_id=0',
+					'cog'
+				),
+				'com_modules_edit' => static::arrayBuilder(
+					'MOD_MENU_EXTENSIONS_MODULE_MANAGER_ADMINISTRATOR',
+					'index.php?option=com_modules&view=modules&client_id=1',
+					'cog'
+				),
+			];
+
+			if (!empty($links['MOD_MENU_MANAGE']))
+			{
+				$links['MOD_MENU_MANAGE'] = array_merge($links['MOD_MENU_MANAGE'], $new);
+			}
+			else
+			{
+				$links['MOD_MENU_MANAGE'] = $new;
+
+				$headerIcons['MOD_MENU_MANAGE'] = 'refresh';
+			}
+
+			static::$notEmpty = true;
+		}
+
 		// Update
 		if ($user->authorise('core.manage', 'com_joomlaupdate'))
 		{


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/22950

### Summary of Changes
As title says. 
Links to site modules and admin modules are added in the Manage group


### After patch

<img width="377" alt="screen shot 2018-11-07 at 11 17 03" src="https://user-images.githubusercontent.com/869724/48125318-b11ca000-e27e-11e8-87da-fc0d0e8ae065.png">

Note: the order of the new links in that group may be modified if desired.
Imho, the 3 languages links could be separated in a new group by itself as we do for templates.