### PR TITLE
[4.0] Correcting Quickicons Update Message

### DIFF
--- a/build/media_src/plg_quickicon_extensionupdate/js/extensionupdatecheck.es6.js
+++ b/build/media_src/plg_quickicon_extensionupdate/js/extensionupdatecheck.es6.js
@@ -30,10 +30,9 @@
               }
             } else {
               const messages = {
-                message: [
+                [Joomla.JText._('MESSAGE')]: [
                   `${Joomla.JText._('PLG_QUICKICON_EXTENSIONUPDATE_UPDATEFOUND_MESSAGE').replace('%s', `<span class="badge badge-pill badge-danger">${updateInfoList.length}</span>`)}<button class="btn btn-primary" onclick="document.location='${options.url}'">${Joomla.JText._('PLG_QUICKICON_EXTENSIONUPDATE_UPDATEFOUND_BUTTON')}</button>`,
-                ],
-                error: ['info'],
+                ]
               };
 
               // Render the message

--- a/build/media_src/plg_quickicon_extensionupdate/js/extensionupdatecheck.es6.js
+++ b/build/media_src/plg_quickicon_extensionupdate/js/extensionupdatecheck.es6.js
@@ -32,7 +32,7 @@
               const messages = {
                 [Joomla.JText._('MESSAGE')]: [
                   `${Joomla.JText._('PLG_QUICKICON_EXTENSIONUPDATE_UPDATEFOUND_MESSAGE').replace('%s', `<span class="badge badge-pill badge-danger">${updateInfoList.length}</span>`)}<button class="btn btn-primary" onclick="document.location='${options.url}'">${Joomla.JText._('PLG_QUICKICON_EXTENSIONUPDATE_UPDATEFOUND_BUTTON')}</button>`,
-                ]
+                ],
               };
 
               // Render the message

--- a/build/media_src/plg_quickicon_joomlaupdate/js/jupdatecheck.es6.js
+++ b/build/media_src/plg_quickicon_joomlaupdate/js/jupdatecheck.es6.js
@@ -37,7 +37,7 @@
                   `${Joomla.JText._('PLG_QUICKICON_JOOMLAUPDATE_UPDATEFOUND_MESSAGE').replace('%s', `<span class="badge badge-danger">${updateInfoList.length}</span>`)}`
                   + `<button class="btn btn-primary" onclick="document.location='${options.url}'">`
                   + `${Joomla.JText._('PLG_QUICKICON_JOOMLAUPDATE_UPDATEFOUND_BUTTON')}</button>`,
-                ]
+                ],
               };
 
               // Render the message

--- a/build/media_src/plg_quickicon_joomlaupdate/js/jupdatecheck.es6.js
+++ b/build/media_src/plg_quickicon_joomlaupdate/js/jupdatecheck.es6.js
@@ -33,12 +33,11 @@
 
             if (updateInfo.version !== options.version) {
               const messages = {
-                message: [
+                [Joomla.JText._('MESSAGE')]: [
                   `${Joomla.JText._('PLG_QUICKICON_JOOMLAUPDATE_UPDATEFOUND_MESSAGE').replace('%s', `<span class="badge badge-danger">${updateInfoList.length}</span>`)}`
                   + `<button class="btn btn-primary" onclick="document.location='${options.url}'">`
                   + `${Joomla.JText._('PLG_QUICKICON_JOOMLAUPDATE_UPDATEFOUND_BUTTON')}</button>`,
-                ],
-                error: ['info'],
+                ]
               };
 
               // Render the message

--- a/plugins/quickicon/extensionupdate/extensionupdate.php
+++ b/plugins/quickicon/extensionupdate/extensionupdate.php
@@ -70,6 +70,7 @@ class PlgQuickiconExtensionupdate extends CMSPlugin
 		Text::script('PLG_QUICKICON_EXTENSIONUPDATE_UPDATEFOUND_MESSAGE', true);
 		Text::script('PLG_QUICKICON_EXTENSIONUPDATE_UPDATEFOUND_BUTTON', true);
 		Text::script('PLG_QUICKICON_EXTENSIONUPDATE_ERROR', true);
+		Text::script('MESSAGE', true);
 
 		HTMLHelper::_('behavior.core');
 		HTMLHelper::_('script', 'plg_quickicon_extensionupdate/extensionupdatecheck.min.js', array('version' => 'auto', 'relative' => true));

--- a/plugins/quickicon/joomlaupdate/joomlaupdate.php
+++ b/plugins/quickicon/joomlaupdate/joomlaupdate.php
@@ -80,6 +80,7 @@ class PlgQuickiconJoomlaupdate extends CMSPlugin implements SubscriberInterface
 		Text::script('PLG_QUICKICON_JOOMLAUPDATE_UPDATEFOUND_MESSAGE', true);
 		Text::script('PLG_QUICKICON_JOOMLAUPDATE_UPDATEFOUND', true);
 		Text::script('PLG_QUICKICON_JOOMLAUPDATE_UPTODATE', true);
+		Text::script('MESSAGE', true);
 
 		$this->app->getDocument()->addScriptOptions(
 			'js-joomla-update',


### PR DESCRIPTION
### Testing instructions
Install an older language pack, for example:
[fr-FR_joomla_lang_full_3.9.0v2.zip](https://github.com/joomla/joomla-cms/files/2561099/fr-FR_joomla_lang_full_3.9.0v2.zip)

Display Control Panel
An extension update is proposed.

Note: process would be similar for Joomla Update

### Before patch

`message` is not translated.
A supplementary useless `error info` message is displayed.

<img width="478" alt="screen shot 2018-11-08 at 09 51 52" src="https://user-images.githubusercontent.com/869724/48189436-8004a400-e340-11e8-9181-2ce42f7e538d.png">


### After patch
<img width="528" alt="screen shot 2018-11-08 at 10 06 45" src="https://user-images.githubusercontent.com/869724/48189536-b80be700-e340-11e8-9664-49b1239d9f75.png">


### Note
Needs running npm ci
