### PR TITLE
[4.0] Link joomla logo in left menu footer to official site

### DIFF
--- a/administrator/templates/atum/error_full.php
+++ b/administrator/templates/atum/error_full.php
@@ -96,9 +96,9 @@ $this->addScriptDeclaration('cssVars();')
 		<div id="sidebar-wrapper" class="sidebar-wrapper" <?php echo $hidden ? 'data-hidden="' . $hidden . '"' : ''; ?>>
 			<jdoc:include type="modules" name="menu" style="none" />
 			<div id="main-brand" class="main-brand d-flex align-items-center justify-content-center">
-                <a href="https://www.joomla.org" rel="noreferrer noopener" target="_blank">
-                    <img src="<?php echo $logo; ?>" alt="">
-                </a>
+				<a href="https://www.joomla.org" rel="noreferrer noopener" target="_blank">
+					<img src="<?php echo $logo; ?>" alt="">
+				</a>
 			</div>
 		</div>
 		<?php endif; ?>

--- a/administrator/templates/atum/error_full.php
+++ b/administrator/templates/atum/error_full.php
@@ -96,7 +96,9 @@ $this->addScriptDeclaration('cssVars();')
 		<div id="sidebar-wrapper" class="sidebar-wrapper" <?php echo $hidden ? 'data-hidden="' . $hidden . '"' : ''; ?>>
 			<jdoc:include type="modules" name="menu" style="none" />
 			<div id="main-brand" class="main-brand d-flex align-items-center justify-content-center">
-				<img src="<?php echo $logo; ?>" alt="">
+                <a href="https://www.joomla.org" rel="noreferrer noopener" target="_blank">
+                    <img src="<?php echo $logo; ?>" alt="">
+                </a>
 			</div>
 		</div>
 		<?php endif; ?>

--- a/administrator/templates/atum/index.php
+++ b/administrator/templates/atum/index.php
@@ -87,7 +87,9 @@ $this->addScriptDeclaration('cssVars();');
 		<div id="sidebar-wrapper" class="sidebar-wrapper" <?php echo $hidden ? 'data-hidden="' . $hidden . '"' : ''; ?>>
 			<jdoc:include type="modules" name="menu" style="none" />
 			<div id="main-brand" class="main-brand d-flex align-items-center justify-content-center">
-				<img src="<?php echo $logo; ?>" alt="">
+                <a href="https://www.joomla.org" rel="noreferrer noopener" target="_blank">
+				    <img src="<?php echo $logo; ?>" alt="">
+                </a>
 			</div>
 		</div>
 		<?php endif; ?>

--- a/administrator/templates/atum/index.php
+++ b/administrator/templates/atum/index.php
@@ -87,9 +87,9 @@ $this->addScriptDeclaration('cssVars();');
 		<div id="sidebar-wrapper" class="sidebar-wrapper" <?php echo $hidden ? 'data-hidden="' . $hidden . '"' : ''; ?>>
 			<jdoc:include type="modules" name="menu" style="none" />
 			<div id="main-brand" class="main-brand d-flex align-items-center justify-content-center">
-                <a href="https://www.joomla.org" rel="noreferrer noopener" target="_blank">
-				    <img src="<?php echo $logo; ?>" alt="">
-                </a>
+				<a href="https://www.joomla.org" rel="noreferrer noopener" target="_blank">
+					<img src="<?php echo $logo; ?>" alt="">
+				</a>
 			</div>
 		</div>
 		<?php endif; ?>


### PR DESCRIPTION
Link the Joomla logo in the left menu footer of Joomla 4.0 admin console to joomla.org with rel and blank