### PR TITLE
Fix extension installation in PostgreSQL

### DIFF
--- a/libraries/src/Installer/InstallerAdapter.php
+++ b/libraries/src/Installer/InstallerAdapter.php
@@ -136,8 +136,11 @@ abstract class InstallerAdapter extends \JAdapterInstance
 		{
 			// This assumes the adapter short class name in its namespace is `<foo>Adapter`, replace this logic in subclasses if needed
 			$reflection = new \ReflectionClass(get_called_class());
-			$this->type = strtolower(str_replace('Adapter', '', $reflection->getShortName()));
+			$this->type = str_replace('Adapter', '', $reflection->getShortName());
 		}
+
+		// Extension type is stored as lowercase in the database
+		$this->type = strtolower($this->type);
 	}
 
 	/**
@@ -185,9 +188,6 @@ abstract class InstallerAdapter extends \JAdapterInstance
 	 */
 	protected function checkExistingExtension()
 	{
-		// Extension type is stored as lowercase on the #__extensions table field type
-		$this->type = strtolower($this->type);
-
 		try
 		{
 			$this->currentExtensionId = $this->extension->find(


### PR DESCRIPTION
Pull Request for Issue #22949.

### Summary of Changes

This ensures that extension type is always lowercase.

### Testing Instructions

Before applying patch:
On PostgreSQL setup install any extension.
Install it again or update it. Repeat a few times.
Go to `Extensions -> Manage -> Manage`.
Search for installed extension.

Expected Result: single entry of the extension appears.
Actual Result: duplicated entries of the same extension appear.

Uninstall the extension.
Apply patch.
Install the extension.
Install it again or update it.
Go to `Extensions -> Manage -> Manage`.
Search for installed extension.

Expected Result: single entry of the extension appears.

Also test that extension installation continues to work normally on other database types.

### Documentation Changes Required
No.