### PR TITLE
Force file type in Crowdin for new files.

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -2,6 +2,7 @@ export_languages: ["en-GB"]
 files:
   - source: /administrator/language/en-GB/*.ini
     translation: /administrator/language/%locale%/%locale%.%original_file_name%
+    type: ini
     translation_replace:
       en-GB.:
     update_option: update_as_unapproved
@@ -20,6 +21,7 @@ files:
     content_segmentation: 0
   - source: /language/en-GB/*.ini
     translation: /language/%locale%/%locale%.%original_file_name%
+    type: ini
     translation_replace:
       en-GB.:
     update_option: update_as_unapproved


### PR DESCRIPTION
### Summary of Changes
This changes the Crowdin configuration file so Crowdin will threat newly added language files as "Generic INI" file instead of the "Joomla INI" format.
The difference between those formats is that the Joomla format escapes double quotes (`"`) as `_QQ_` while in the "Generic INI" format it is escaped as `\"`.
Since we're phasing out the use of `_QQ_` within Joomla, it makes sense imho to change the file format in Crowdin.

Small remark: We can't change the format of existing files. So those will stay untouched.
For 4.0, we will have to redo the integration so the files are detected fresh. But since there may be other changes to the files as well, I want to wait with that to reduce the impact on TTs.

### Testing Instructions
Nothing really testable. Just review and decide.


### Expected result
Newly added language files are added as generic INI files


### Actual result
Newly added language files are detected as Joomla INI files (due to either "Joomla" header or use of _QQ_)


### Documentation Changes Required
None