### PR TITLE
[4.0] getReorderConditions() cleanup

### DIFF
--- a/administrator/components/com_banners/Model/BannerModel.php
+++ b/administrator/components/com_banners/Model/BannerModel.php
@@ -408,16 +408,16 @@ class BannerModel extends AdminModel
 	 *
 	 * @param   Table  $table  A record object.
 	 *
-	 * @return  array  An array of conditions to add to add to ordering queries.
+	 * @return  array  An array of conditions to add to ordering queries.
 	 *
 	 * @since   1.6
 	 */
 	protected function getReorderConditions($table)
-	{
-		return array(
-			'catid = ' . (int) $table->catid,
-			'state >= 0'
-		);
+	{	
+		return [
+			$this->_db->quoteName('catid') . ' = ' . (int) $table->catid,
+			$this->_db->quoteName('state') . ' >= 0',
+		];
 	}
 
 	/**

--- a/administrator/components/com_banners/Model/BannerModel.php
+++ b/administrator/components/com_banners/Model/BannerModel.php
@@ -413,7 +413,7 @@ class BannerModel extends AdminModel
 	 * @since   1.6
 	 */
 	protected function getReorderConditions($table)
-	{	
+	{
 		return [
 			$this->_db->quoteName('catid') . ' = ' . (int) $table->catid,
 			$this->_db->quoteName('state') . ' >= 0',

--- a/administrator/components/com_categories/Model/CategoryModel.php
+++ b/administrator/components/com_categories/Model/CategoryModel.php
@@ -319,13 +319,15 @@ class CategoryModel extends AdminModel
 	 *
 	 * @param   \JTableCategory  $table  Current table instance
 	 *
-	 * @return  array           An array of conditions to add to add to ordering queries.
+	 * @return  array           An array of conditions to add to ordering queries.
 	 *
 	 * @since   1.6
 	 */
 	protected function getReorderConditions($table)
 	{
-		return 'extension = ' . $this->_db->quote($table->extension);
+		return [
+			$this->_db->quoteName('extension') . ' = ' . $this->_db->quote($table->extension),
+		];
 	}
 
 	/**

--- a/administrator/components/com_categories/Model/CategoryModel.php
+++ b/administrator/components/com_categories/Model/CategoryModel.php
@@ -319,7 +319,7 @@ class CategoryModel extends AdminModel
 	 *
 	 * @param   \JTableCategory  $table  Current table instance
 	 *
-	 * @return  array           An array of conditions to add to ordering queries.
+	 * @return  array  An array of conditions to add to ordering queries.
 	 *
 	 * @since   1.6
 	 */

--- a/administrator/components/com_contact/Model/ContactModel.php
+++ b/administrator/components/com_contact/Model/ContactModel.php
@@ -482,13 +482,15 @@ class ContactModel extends AdminModel
 	 *
 	 * @param   \Joomla\CMS\Table\Table  $table  A record object.
 	 *
-	 * @return  array  An array of conditions to add to add to ordering queries.
+	 * @return  array  An array of conditions to add to ordering queries.
 	 *
 	 * @since   1.6
 	 */
 	protected function getReorderConditions($table)
 	{
-		return array('catid = ' . (int) $table->catid);
+		return [
+			$this->_db->quoteName('catid') . ' = ' . (int) $table->catid,
+		];
 	}
 
 	/**

--- a/administrator/components/com_content/Model/ArticleModel.php
+++ b/administrator/components/com_content/Model/ArticleModel.php
@@ -1043,7 +1043,7 @@ class ArticleModel extends AdminModel
 	protected function getReorderConditions($table)
 	{
 		return [
-			$this->_db->quoteName('catid') .' = ' . (int) $table->catid,
+			$this->_db->quoteName('catid') . ' = ' . (int) $table->catid,
 		];
 	}
 

--- a/administrator/components/com_content/Model/ArticleModel.php
+++ b/administrator/components/com_content/Model/ArticleModel.php
@@ -1036,13 +1036,15 @@ class ArticleModel extends AdminModel
 	 *
 	 * @param   object  $table  A record object.
 	 *
-	 * @return  array  An array of conditions to add to add to ordering queries.
+	 * @return  array  An array of conditions to add to ordering queries.
 	 *
 	 * @since   1.6
 	 */
 	protected function getReorderConditions($table)
 	{
-		return array('catid = ' . (int) $table->catid);
+		return [
+			$this->_db->quoteName('catid') .' = ' . (int) $table->catid,
+		];
 	}
 
 	/**

--- a/administrator/components/com_content/Model/FeatureModel.php
+++ b/administrator/components/com_content/Model/FeatureModel.php
@@ -39,12 +39,12 @@ class FeatureModel extends ArticleModel
 	 *
 	 * @param   object  $table  A record object.
 	 *
-	 * @return  array  An array of conditions to add to add to ordering queries.
+	 * @return  array  An array of conditions to add to ordering queries.
 	 *
 	 * @since   1.6
 	 */
 	protected function getReorderConditions($table)
 	{
-		return array();
+		return [];
 	}
 }

--- a/administrator/components/com_fields/Model/FieldModel.php
+++ b/administrator/components/com_fields/Model/FieldModel.php
@@ -867,7 +867,9 @@ class FieldModel extends AdminModel
 	 */
 	protected function getReorderConditions($table)
 	{
-		return 'context = ' . $this->_db->quote($table->context);
+		return [
+			$this->_db->quoteName('context') . ' = ' . $this->_db->quote($table->context),
+		];
 	}
 
 	/**

--- a/administrator/components/com_fields/Model/GroupModel.php
+++ b/administrator/components/com_fields/Model/GroupModel.php
@@ -218,7 +218,9 @@ class GroupModel extends AdminModel
 	 */
 	protected function getReorderConditions($table)
 	{
-		return 'context = ' . $this->_db->quote($table->context);
+		return [
+			$this->_db->quoteName('context') . ' = ' . $this->_db->quote($table->context),
+		];
 	}
 
 	/**

--- a/administrator/components/com_menus/Model/ItemModel.php
+++ b/administrator/components/com_menus/Model/ItemModel.php
@@ -932,7 +932,9 @@ class ItemModel extends AdminModel
 	 */
 	protected function getReorderConditions($table)
 	{
-		return array('menutype = ' . $this->_db->quote($table->get('menutype')));
+		return [
+			$this->_db->quoteName('menutype') . ' = ' . $this->_db->quote($table->menutype),
+		];
 	}
 
 	/**

--- a/administrator/components/com_modules/Model/ModuleModel.php
+++ b/administrator/components/com_modules/Model/ModuleModel.php
@@ -1101,17 +1101,16 @@ class ModuleModel extends AdminModel
 	 *
 	 * @param   object  $table  A record object.
 	 *
-	 * @return  array  An array of conditions to add to add to ordering queries.
+	 * @return  array  An array of conditions to add to ordering queries.
 	 *
 	 * @since   1.6
 	 */
 	protected function getReorderConditions($table)
 	{
-		$condition = array();
-		$condition[] = 'client_id = ' . (int) $table->client_id;
-		$condition[] = 'position = ' . $this->_db->quote($table->position);
-
-		return $condition;
+		return [
+			$this->_db->quoteName('client_id') . ' = ' . (int) $table->client_id,
+			$this->_db->quoteName('position') . ' = ' . $this->_db->quote($table->position),
+		];
 	}
 
 	/**

--- a/administrator/components/com_newsfeeds/Model/NewsfeedModel.php
+++ b/administrator/components/com_newsfeeds/Model/NewsfeedModel.php
@@ -466,16 +466,15 @@ class NewsfeedModel extends AdminModel
 	 *
 	 * @param   object  $table  A record object.
 	 *
-	 * @return  array  An array of conditions to add to add to ordering queries.
+	 * @return  array  An array of conditions to add to ordering queries.
 	 *
 	 * @since   1.6
 	 */
 	protected function getReorderConditions($table)
 	{
-		$condition = array();
-		$condition[] = 'catid = ' . (int) $table->catid;
-
-		return $condition;
+		return [
+			$this->_db->quoteName('catid') . ' = ' . (int) $table->catid,
+		];
 	}
 
 	/**

--- a/administrator/components/com_plugins/Model/PluginModel.php
+++ b/administrator/components/com_plugins/Model/PluginModel.php
@@ -321,17 +321,16 @@ class PluginModel extends AdminModel
 	 *
 	 * @param   object  $table  A record object.
 	 *
-	 * @return  array  An array of conditions to add to add to ordering queries.
+	 * @return  array  An array of conditions to add to ordering queries.
 	 *
 	 * @since   1.6
 	 */
 	protected function getReorderConditions($table)
 	{
-		$condition = array();
-		$condition[] = 'type = ' . $this->_db->quote($table->type);
-		$condition[] = 'folder = ' . $this->_db->quote($table->folder);
-
-		return $condition;
+		return [
+			$this->_db->quoteName('type') . ' = ' . $this->_db->quote($table->type),
+			$this->_db->quoteName('folder') . ' = ' . $this->_db->quote($table->folder),
+		];
 	}
 
 	/**

--- a/administrator/components/com_workflow/Model/StagesModel.php
+++ b/administrator/components/com_workflow/Model/StagesModel.php
@@ -89,14 +89,14 @@ class StagesModel extends ListModel
 	 *
 	 * @param   object  $table  A record object.
 	 *
-	 * @return  array  An array of conditions to add to add to ordering queries.
+	 * @return  array  An array of conditions to add to ordering queries.
 	 *
 	 * @since   4.0.0
 	 */
 	protected function getReorderConditions($table)
 	{
 		return [
-			'workflow_id = ' . (int) $table->workflow_id
+			$this->_db->quoteName('workflow_id') . ' = ' . (int) $table->workflow_id,
 		];
 	}
 

--- a/administrator/components/com_workflow/Model/TransitionsModel.php
+++ b/administrator/components/com_workflow/Model/TransitionsModel.php
@@ -107,13 +107,15 @@ class TransitionsModel extends ListModel
 	 *
 	 * @param   object  $table  A record object.
 	 *
-	 * @return  array  An array of conditions to add to add to ordering queries.
+	 * @return  array  An array of conditions to add to ordering queries.
 	 *
 	 * @since   4.0.0
 	 */
 	protected function getReorderConditions($table)
 	{
-		return 'workflow_id = ' . $this->getDbo()->quote((int) $table->workflow_id);
+		return [
+			$this->_db->quoteName('workflow_id') . ' = ' . (int) $table->workflow_id,
+		];
 	}
 
 	/**

--- a/administrator/components/com_workflow/Model/WorkflowModel.php
+++ b/administrator/components/com_workflow/Model/WorkflowModel.php
@@ -275,13 +275,15 @@ class WorkflowModel extends AdminModel
 	 *
 	 * @param   object  $table  A record object.
 	 *
-	 * @return  array  An array of conditions to add to add to ordering queries.
+	 * @return  array  An array of conditions to add to ordering queries.
 	 *
 	 * @since   4.0.0
 	 */
 	protected function getReorderConditions($table)
 	{
-		return 'extension = ' . $this->getDbo()->quote($table->extension);
+		return [
+			$this->_db->quoteName('extension') . ' = ' . $this->_db->quote($table->extension),
+		];
 	}
 
 	/**

--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -950,7 +950,7 @@ abstract class AdminModel extends FormModel
 	 */
 	protected function getReorderConditions($table)
 	{
-		return array();
+		return [];
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue #23021.

### Summary of Changes
Always return an array.
Switch to short array syntax.
Escape column names.
Don't escape integers.
Fix typo in comment.

### Testing Instructions
Code review.

### Documentation Changes Required
No.
