### PR TITLE
[4.0] Remove obsolete template color handling from Cassiopeia offline.php - 1st try

### DIFF
--- a/templates/cassiopeia/offline.php
+++ b/templates/cassiopeia/offline.php
@@ -31,29 +31,6 @@ HTMLHelper::_('behavior.core');
 HTMLHelper::_('stylesheet', 'template' . ($this->direction === 'rtl' ? '-rtl' : '') . '.css', ['version' => 'auto', 'relative' => true]);
 HTMLHelper::_('stylesheet', 'offline.css', ['version' => 'auto', 'relative' => true]);
 
-// Template color
-if ($this->params->get('templateColor'))
-{
-	$this->addStyleDeclaration('
-	body.site {
-		border-top: 3px solid ' . $this->params->get('templateColor') . ';
-		background-color: ' . $this->params->get('templateBackgroundColor') . ';
-	}
-	a {
-		color: ' . $this->params->get('templateColor') . ';
-	}
-	.nav-list > .active > a,
-	.nav-list > .active > a:hover,
-	.dropdown-menu li > a:hover,
-	.dropdown-menu .active > a,
-	.dropdown-menu .active > a:hover,
-	.nav-pills > .active > a,
-	.nav-pills > .active > a:hover,
-	.btn-primary {
-		background: ' . $this->params->get('templateColor') . ';
-	}');
-}
-
 // Check for a custom CSS file
 HTMLHelper::_('stylesheet', 'user.css', ['version' => 'auto', 'relative' => true]);
 


### PR DESCRIPTION
Pull Request for Issue # N.A.

### Summary of Changes

Remove handling of not existing parameter "templateColor" from offline page of Cassiopeia template.

It seems to be a remainder from copying the offline.php from Joomla 3 (staging).

### Testing Instructions

1. Code review: Check that in no other file of the Cassiopeia template than the offline.php is any use of parameter "templateColor", and check that this PR removes this.
2. In addition to test 1, check that in the Cassiopeia template style settings there is nowhere any option related to template color.

### Expected result

No use of not existing parameter "templateColor" in any file of the Casssiopeia template.

### Actual result

Not existing parameter "templateColor" is used in file "offline.php" of the Casssiopeia template.

### Documentation Changes Required

None.