### PR TITLE
Extend language switcher for any-language-article view (fix for #22656)

### DIFF
--- a/modules/mod_languages/helper.php
+++ b/modules/mod_languages/helper.php
@@ -150,7 +150,8 @@ abstract class ModLanguagesHelper
 								// replace also menu item and language, then complete art_id with art slug
 								$newUrl = preg_replace("/Itemid=(\d*)/", "Itemid=" . $itemid, $newUrl);
 								$newUrl = preg_replace("/lang=((?>\w|-)*)/", "lang=" . $language->lang_code, $newUrl);
-								$newUrl = preg_replace("/&id=(\d*)/", "&id=" . $art_id . ":" . $art_alias, $newUrl);
+								if(strpos($newUrl, ":" . $art_alias) == false)
+									$newUrl = preg_replace("/&id=(\d*)/", "&id=" . $art_id . ":" . $art_alias, $newUrl);
 								
 								$simulatedAssoc = true;
 								$language->link = JRoute::_("index.php?" . $newUrl);

--- a/modules/mod_languages/helper.php
+++ b/modules/mod_languages/helper.php
@@ -137,7 +137,7 @@ abstract class ModLanguagesHelper
 							{
 								if(!isset($menuUrl))
 								{
-									// store current menu component into $menuComp[1] (can be different than current URL component)
+									// Store current menu component into $menuComp[1] (can be different than current URL component)
 									$menuUrl = $menu->getItem($input->get('Itemid'))->link;
 									preg_match("/option=com_(\w*)/", $menuUrl, $menuComp);
 									// retrieves current query in raw URL for replacement of its vars
@@ -145,9 +145,9 @@ abstract class ModLanguagesHelper
 									$query = JSite::getRouter()->parse($uriInst);
 									$rawQuery = $uriInst->buildQuery($query);
 								}
-								// replace current URL component with active menu's one for compatibility with overriding component
+								// Replace current URL component with active menu's one for compatibility with overriding component
 								$newUrl = preg_replace("/option=com_(\w*)/", "option=com_" . $menuComp[1], $rawQuery);
-								// replace also menu item and language, then complete art_id with art slug
+								// Replace also menu item and language, then complete art_id with art slug
 								$newUrl = preg_replace("/Itemid=(\d*)/", "Itemid=" . $itemid, $newUrl);
 								$newUrl = preg_replace("/lang=((?>\w|-)*)/", "lang=" . $language->lang_code, $newUrl);
 								if(strpos($newUrl, ":" . $art_alias) == false)

--- a/modules/mod_languages/helper.php
+++ b/modules/mod_languages/helper.php
@@ -118,12 +118,14 @@ abstract class ModLanguagesHelper
 					elseif (isset($associations[$language->lang_code]) && $menu->getItem($associations[$language->lang_code]))
 					{
 						$itemid = $associations[$language->lang_code];
+						// now dealing with an article view where article lang is * and menu item has associations
+						//  => with a "simulated" association: article view in other languages actually does exist
 						$simulatedAssoc = false;
 						if ($input->get('option') == "com_content" && $input->get('view') == "article")
 						{
 							if(!isset($art_lang))
 							{
-								// and current article's id/alias/lang
+								// retrieve current article's id/alias/lang
 								$ids = explode(':',$input->getString('id'));
 								$art_id = $ids[0];
 								$article = JTable::getInstance("content");
@@ -135,17 +137,17 @@ abstract class ModLanguagesHelper
 							{
 								if(!isset($menuUrl))
 								{
-									// we retrieve current menu component into $menuComp[1]
+									// store current menu component into $menuComp[1] (can be different than current URL component)
 									$menuUrl = $menu->getItem($input->get('Itemid'))->link;
 									preg_match("/option=com_(\w*)/", $menuUrl, $menuComp);
-									// and current query in raw URL for replacement of its vars
+									// retrieves current query in raw URL for replacement of its vars
 									$uriInst = clone JUri::getInstance();
 									$query = JSite::getRouter()->parse($uriInst);
 									$rawQuery = $uriInst->buildQuery($query);
 								}
 								// replace current URL component with active menu's one for compatibility with overriding component
 								$newUrl = preg_replace("/option=com_(\w*)/", "option=com_" . $menuComp[1], $rawQuery);
-								// replace also: menu item and language. Complete art_id with art slug
+								// replace also menu item and language, then complete art_id with art slug
 								$newUrl = preg_replace("/Itemid=(\d*)/", "Itemid=" . $itemid, $newUrl);
 								$newUrl = preg_replace("/lang=((?>\w|-)*)/", "lang=" . $language->lang_code, $newUrl);
 								$newUrl = preg_replace("/&id=(\d*)/", "&id=" . $art_id . ":" . $art_alias, $newUrl);

--- a/modules/mod_languages/helper.php
+++ b/modules/mod_languages/helper.php
@@ -122,7 +122,7 @@ abstract class ModLanguagesHelper
 						// Now dealing with an article view where article lang is * and menu item has associations
 						//  => with a "simulated" association: article view in other languages actually does exist
 						$simulatedAssoc = false;
-						if ($input->get('option') == "com_content" && $input->get('view') == "article")
+						if ($input->get('view') == "article")
 						{
 							if (!isset($art_lang))
 							{

--- a/modules/mod_languages/helper.php
+++ b/modules/mod_languages/helper.php
@@ -118,6 +118,7 @@ abstract class ModLanguagesHelper
 					elseif (isset($associations[$language->lang_code]) && $menu->getItem($associations[$language->lang_code]))
 					{
 						$itemid = $associations[$language->lang_code];
+
 						// Now dealing with an article view where article lang is * and menu item has associations
 						//  => with a "simulated" association: article view in other languages actually does exist
 						$simulatedAssoc = false;
@@ -140,6 +141,7 @@ abstract class ModLanguagesHelper
 									// Store current menu component into $menuComp[1] (can be different than current URL component)
 									$menuUrl = $menu->getItem($input->get('Itemid'))->link;
 									preg_match("/option=com_(\w*)/", $menuUrl, $menuComp);
+
 									// Retrieves current query in raw URL for replacement of its vars
 									$uriInst = clone JUri::getInstance();
 									$query = JSite::getRouter()->parse($uriInst);

--- a/modules/mod_languages/helper.php
+++ b/modules/mod_languages/helper.php
@@ -118,46 +118,47 @@ abstract class ModLanguagesHelper
 					elseif (isset($associations[$language->lang_code]) && $menu->getItem($associations[$language->lang_code]))
 					{
 						$itemid = $associations[$language->lang_code];
-						// now dealing with an article view where article lang is * and menu item has associations
+						// Now dealing with an article view where article lang is * and menu item has associations
 						//  => with a "simulated" association: article view in other languages actually does exist
 						$simulatedAssoc = false;
 						if ($input->get('option') == "com_content" && $input->get('view') == "article")
 						{
-							if(!isset($art_lang))
+							if (!isset($art_lang))
 							{
-								// retrieve current article's id/alias/lang
-								$ids = explode(':',$input->getString('id'));
+								// Retrieve current article's id/alias/lang
+								$ids = explode(':', $input->getString('id'));
 								$art_id = $ids[0];
 								$article = JTable::getInstance("content");
 								$article->load($art_id);
 								$art_alias = $article->get("alias");
 								$art_lang = $article->get("language");
 							}
-							if($art_lang == '*')
+							if ($art_lang == '*')
 							{
-								if(!isset($menuUrl))
+								if (!isset($menuUrl))
 								{
 									// Store current menu component into $menuComp[1] (can be different than current URL component)
 									$menuUrl = $menu->getItem($input->get('Itemid'))->link;
 									preg_match("/option=com_(\w*)/", $menuUrl, $menuComp);
-									// retrieves current query in raw URL for replacement of its vars
+									// Retrieves current query in raw URL for replacement of its vars
 									$uriInst = clone JUri::getInstance();
 									$query = JSite::getRouter()->parse($uriInst);
 									$rawQuery = $uriInst->buildQuery($query);
 								}
 								// Replace current URL component with active menu's one for compatibility with overriding component
 								$newUrl = preg_replace("/option=com_(\w*)/", "option=com_" . $menuComp[1], $rawQuery);
+								
 								// Replace also menu item and language, then complete art_id with art slug
 								$newUrl = preg_replace("/Itemid=(\d*)/", "Itemid=" . $itemid, $newUrl);
 								$newUrl = preg_replace("/lang=((?>\w|-)*)/", "lang=" . $language->lang_code, $newUrl);
-								if(strpos($newUrl, ":" . $art_alias) == false)
+								if (strpos($newUrl, ":" . $art_alias) == false)
 									$newUrl = preg_replace("/&id=(\d*)/", "&id=" . $art_id . ":" . $art_alias, $newUrl);
 								
 								$simulatedAssoc = true;
 								$language->link = JRoute::_("index.php?" . $newUrl);
 							}
 						}
-						if($simulatedAssoc == false)
+						if ($simulatedAssoc == false)
 							$language->link = JRoute::_('index.php?lang=' . $language->sef . '&Itemid=' . $itemid);
 					}
 					elseif ($active && $active->language == '*')

--- a/modules/mod_languages/helper.php
+++ b/modules/mod_languages/helper.php
@@ -153,14 +153,14 @@ abstract class ModLanguagesHelper
 								// Replace also menu item and language, then complete art_id with art slug
 								$newUrl = preg_replace("/Itemid=(\d*)/", "Itemid=" . $itemid, $newUrl);
 								$newUrl = preg_replace("/lang=((?>\w|-)*)/", "lang=" . $language->lang_code, $newUrl);
-								if (strpos($newUrl, ":" . $art_alias) == false)
+								if (strpos($newUrl, ":" . $art_alias) === false)
 									$newUrl = preg_replace("/&id=(\d*)/", "&id=" . $art_id . ":" . $art_alias, $newUrl);
 								
 								$simulatedAssoc = true;
 								$language->link = JRoute::_("index.php?" . $newUrl);
 							}
 						}
-						if ($simulatedAssoc == false)
+						if (!$simulatedAssoc)
 							$language->link = JRoute::_('index.php?lang=' . $language->sef . '&Itemid=' . $itemid);
 					}
 					elseif ($active && $active->language == '*')

--- a/modules/mod_languages/helper.php
+++ b/modules/mod_languages/helper.php
@@ -154,14 +154,18 @@ abstract class ModLanguagesHelper
 								$newUrl = preg_replace("/Itemid=(\d*)/", "Itemid=" . $itemid, $newUrl);
 								$newUrl = preg_replace("/lang=((?>\w|-)*)/", "lang=" . $language->lang_code, $newUrl);
 								if (strpos($newUrl, ":" . $art_alias) === false)
+								{
 									$newUrl = preg_replace("/&id=(\d*)/", "&id=" . $art_id . ":" . $art_alias, $newUrl);
+								}
 								
 								$simulatedAssoc = true;
 								$language->link = JRoute::_("index.php?" . $newUrl);
 							}
 						}
 						if (!$simulatedAssoc)
+						{
 							$language->link = JRoute::_('index.php?lang=' . $language->sef . '&Itemid=' . $itemid);
+						}
 					}
 					elseif ($active && $active->language == '*')
 					{


### PR DESCRIPTION
Pull Request for Issue #22656 .

### Summary of Changes
This PR extends mod_language to publish correct language flag links when an article that has language set to all (*) is being viewed (view=article) and current menu item has associations for other languages.
Currently since an any-language article cannot have associations but it is actually valid for being viewed in all installed languages, language switcher currently presents flag links pointing only to associated menu items but not to current article under associated menus in other languages.
The proposed solution is compatible with 3rd party components that override com_content so for building the routes with JRoute, the component of active menu is used and not the component of current URL, since with 3rd party components they can be different: the active menu component is of the 3rd party component while current URI component is always com_content.
Feel free to suggest improvements to code but keeping this compatibility with third party components.

### Testing Instructions
Backend Setup Scenario:
- a multilingual site with at least 2 installed content languages LANGA and LANGB
- a category CAT with language = All.
- an article ART with language = All, id = ARTID, alias = ARTALIAS
- a menu item for language LANGA of type "list article of category CAT", alias = MENUA
- a menu item for language LANGB of type "list article of category CAT", alias = MENUB
- language switcher module published
- SEF enabled (similar test for SEF disabled).

FrontEnd:
- while browsing in language LANGA, go to article view of ART: current URL will be .../MENUA/ARTID-ARTALIAS.
Now look at flag link for LANGB in the language switcher.

### Expected result
- link for LINGB should be .../MENUB/ARTID-ALIAS

### Actual result
- link for LINGB is .../MENUB

### Documentation Changes Required
For Developers, as said in the exec summary, this change works also with third party components overriding com_content: you have a menu link URL like "option=com_XXX&task=search..." that presents a list of articles, then clicking on an article you are directed to a view=article page with URL like "option=com_content&view=article..." - here this PR will deal with building correct language associations for any-language articles using com_XXX and not com_content.
This PR can be extended to language filter plugin to set metadata hreflang in <head> for any-language article.