### PR TITLE
[3.9] Fix navigating to the first page in pagination when SEF is off

### DIFF
--- a/libraries/src/Pagination/Pagination.php
+++ b/libraries/src/Pagination/Pagination.php
@@ -784,15 +784,7 @@ class Pagination
 		if (!$this->viewall)
 		{
 			$data->all->base = '0';
-
-			if ($this->hideEmptyLimitstart)
-			{
-				$data->all->link = \JRoute::_($params ?: '&');
-			}
-			else
-			{
-				$data->all->link = \JRoute::_($params . '&' . $this->prefix . 'limitstart=');
-			}
+			$data->all->link = \JRoute::_($params . '&' . $this->prefix . 'limitstart=');
 		}
 
 		// Set the start and previous data objects.
@@ -805,7 +797,7 @@ class Pagination
 
 			if ($this->hideEmptyLimitstart)
 			{
-				$data->start->link = \JRoute::_($params ?: '&');
+				$data->start->link = \JRoute::_($params . '&' . $this->prefix . 'limitstart=');
 			}
 			else
 			{

--- a/tests/unit/suites/libraries/cms/pagination/JPaginationTest.php
+++ b/tests/unit/suites/libraries/cms/pagination/JPaginationTest.php
@@ -94,6 +94,17 @@ class JPaginationTest extends TestCase
 	{
 		if (substr($url, 0, 1) === '&')
 		{
+			parse_str($url, $vars);
+
+			foreach ($vars as $key => $var)
+			{
+				if ($var == '')
+				{
+					// Remove empty parameters
+					$url = str_replace("&$key=", '', $url) ?: '&';
+				}
+			}
+
 			$url = 'index.php?' . substr($url, 1);
 		}
 
@@ -311,7 +322,7 @@ class JPaginationTest extends TestCase
 					array(
 						'text' => 'JLIB_HTML_VIEW_ALL',
 						'base' => '0',
-						'link' => 'index.php?limitstart=',
+						'link' => 'index.php',
 						'prefix' => '',
 						'active' => false,
 					),


### PR DESCRIPTION
Pull Request for Issue #22983

### Summary of Changes
Reverted a few lines added in the previous PR  #19467 
Changed the unit test method `JPaginationTest::buildLink($url)` to better emulate `Router::build($url)`, where empty parameters such as `&limitstart=` are always removed from the URL.

### Testing Instructions
Test #22983 when SEF is ON and OFF.

### Expected result
You can back to the first page in pagination when SEF is OFF.

### Actual result
When SEF is OFF the `limitstart` parameter remains in the link to the first page and you can not back to the first page.

### Documentation Changes Required
No