### PR TITLE
[3.9] Remove factually incorrect sentence

### DIFF
--- a/administrator/language/en-GB/en-GB.plg_privacy_actionlogs.ini
+++ b/administrator/language/en-GB/en-GB.plg_privacy_actionlogs.ini
@@ -4,4 +4,4 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_PRIVACY_ACTIONLOGS="Privacy - Action Logs"
-PLG_PRIVACY_ACTIONLOGS_XML_DESCRIPTION="Responsible for exporting the action log data for a user's privacy request. Since the action logs are an audit log, these can not be deleted from the system."
+PLG_PRIVACY_ACTIONLOGS_XML_DESCRIPTION="Responsible for exporting the action log data for a user's privacy request."

--- a/administrator/language/en-GB/en-GB.plg_privacy_actionlogs.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_privacy_actionlogs.sys.ini
@@ -4,4 +4,4 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_PRIVACY_ACTIONLOGS="Privacy - Action Logs"
-PLG_PRIVACY_ACTIONLOGS_XML_DESCRIPTION="Responsible for exporting the action log data for a user's privacy request. Since the action logs are an audit log, these can not be deleted from the system."
+PLG_PRIVACY_ACTIONLOGS_XML_DESCRIPTION="Responsible for exporting the action log data for a user's privacy request."


### PR DESCRIPTION
### Summary of Changes

Remove factually incorrect sentence - Closes #22873


### Testing Instructions

install Joomla 4 and edit the `Privacy - Action Logs` plugin

http://example.com/administrator/index.php?option=com_plugins&view=plugin&layout=edit&extension_id=493


### Expected result

Factually correct information - the action logs CAN be deleted (purged in total, or row by row)
![screenshot 2018-11-12 at 01 03 58](https://user-images.githubusercontent.com/400092/48320977-e0346800-e616-11e8-878c-024c082e6965.png)



### Actual result

> "Since the action logs are an audit log, these can not be deleted from the system"

![screenshot 2018-11-12 at 01 04 08](https://user-images.githubusercontent.com/400092/48320979-e4608580-e616-11e8-97fb-7ccb5463f4df.png)
### Documentation Changes Required

Probably... 
