### PR TITLE
[plg_content_vote] Put back rating display where it was

### DIFF
--- a/plugins/content/vote/tmpl/rating.php
+++ b/plugins/content/vote/tmpl/rating.php
@@ -33,6 +33,7 @@ $starImageOn  = JHtml::_('image', 'system/rating_star.png', JText::_('PLG_VOTE_S
 $starImageOff = JHtml::_('image', 'system/rating_star_blank.png', JText::_('PLG_VOTE_STAR_INACTIVE'), null, true);
 
 $img = '';
+
 for ($i = 0; $i < $rating; $i++)
 {
 	$img .= $starImageOn;
@@ -44,13 +45,13 @@ for ($i = $rating; $i < 5; $i++)
 }
 
 ?>
-<?php if ($rcount) : ?>
-<div class="content_rating" itemprop="aggregateRating" itemscope itemtype="https://schema.org/AggregateRating">
-	<p class="unseen element-invisible">
-		<?php echo JText::sprintf('PLG_VOTE_USER_RATING', '<span itemprop="ratingValue">' . $rating . '</span>', '<span itemprop="bestRating">5</span>'); ?>
-		<meta itemprop="ratingCount" content="<?php echo $rcount; ?>" />
-		<meta itemprop="worstRating" content="1" />
-	</p>
+<div class="content_rating">
+	<?php if ($rcount) : ?>
+		<p class="unseen element-invisible" itemprop="aggregateRating" itemscope itemtype="https://schema.org/AggregateRating">
+			<?php echo JText::sprintf('PLG_VOTE_USER_RATING', '<span itemprop="ratingValue">' . $rating . '</span>', '<span itemprop="bestRating">5</span>'); ?>
+			<meta itemprop="ratingCount" content="<?php echo $rcount; ?>" />
+			<meta itemprop="worstRating" content="1" />
+		</p>
+	<?php endif; ?>
+	<?php echo $img; ?>
 </div>
-<?php endif; ?>
-<?php echo $img; ?>


### PR DESCRIPTION
Issue reported on forum https://forum.joomla.org/viewtopic.php?f=706&t=966845.

### Summary of Changes

In #18166 rating display was moved outside of `div` with `.content_rating` class. That made custom styling impossible without template overrides because there's no selector that can be used. This puts rating display back inside `.content_rating` while still hiding the microdata when no ratings are available.

### Testing Instructions

Code review or inspect the generated markup.

### Expected result

Star images are inside `.content_rating`.

### Actual result

Star images are outside of `.content_rating`.

### Documentation Changes Required
No.
