### PR TITLE
Add tag description extract to administrator tags view

### DIFF
--- a/administrator/components/com_tags/models/tags.php
+++ b/administrator/components/com_tags/models/tags.php
@@ -141,7 +141,7 @@ class TagsModelTags extends JModelList
 		$query->select(
 			$this->getState(
 				'list.select',
-				'a.id, a.title, a.alias, a.note, a.published, a.access' .
+				'a.id, a.title, a.alias, a.note, a.published, a.access, a.description' .
 					', a.checked_out, a.checked_out_time, a.created_user_id' .
 					', a.path, a.parent_id, a.level, a.lft, a.rgt' .
 					', a.language'


### PR DESCRIPTION
Pull Request for Issue #23056 .

### Summary of Changes

Get tags description from the db for later output by 3rd party template overides.

### Testing Instructions

**Note: Coded in Github UI, not tested in php, please ensure you test correctly**

see #23056

### Expected result

see #23056

### Actual result

see #23056

### Documentation Changes Required

None