### PR TITLE
Remove overly negative statement

### DIFF
--- a/administrator/language/en-GB/en-GB.plg_system_actionlogs.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_system_actionlogs.sys.ini
@@ -4,4 +4,4 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_SYSTEM_ACTIONLOGS="System - User Actions Log"
-PLG_SYSTEM_ACTIONLOGS_XML_DESCRIPTION="To record actions of users within the CMS, to know who to blame when something wrong happens."
+PLG_SYSTEM_ACTIONLOGS_XML_DESCRIPTION="To record actions of users within the CMS."

--- a/administrator/language/en-GB/en-GB.plg_system_actionlogs.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_system_actionlogs.sys.ini
@@ -4,4 +4,4 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_SYSTEM_ACTIONLOGS="System - User Actions Log"
-PLG_SYSTEM_ACTIONLOGS_XML_DESCRIPTION="To record actions of users within the CMS."
+PLG_SYSTEM_ACTIONLOGS_XML_DESCRIPTION="Records the actions of users within the CMS."


### PR DESCRIPTION
Change from 
> To record actions of users within the CMS, to know who to blame when something wrong happens.

to 

> To record actions of users within the CMS.


The user action log is not about blame. Its about logging. There is no need to be overly negative.