### PR TITLE
[4.0] Adding Joomla Version in Quickicon

### DIFF
--- a/build/media_src/plg_quickicon_joomlaupdate/js/jupdatecheck.es6.js
+++ b/build/media_src/plg_quickicon_joomlaupdate/js/jupdatecheck.es6.js
@@ -34,8 +34,8 @@
             if (updateInfo.version !== options.version) {
               const messages = {
                 warning: [
-                  `${Joomla.JText._('PLG_QUICKICON_JOOMLAUPDATE_UPDATEFOUND_MESSAGE').replace('%s', `<span class="badge badge-danger">${updateInfoList.length}</span>`)}`
-                  + `<button class="btn btn-primary" onclick="document.location='${options.url}'">`
+                  `${Joomla.JText._('PLG_QUICKICON_JOOMLAUPDATE_UPDATEFOUND_MESSAGE').replace('%s', `<span class="badge badge-danger">${updateInfo.version}</span>`)}`
+                  + `<button class="btn btn-sm btn-primary" onclick="document.location='${options.url}'">`
                   + `${Joomla.JText._('PLG_QUICKICON_JOOMLAUPDATE_UPDATEFOUND_BUTTON')}</button>`,
                 ],
               };
@@ -48,7 +48,7 @@
 
               link.classList.add('danger');
               linkSpans.forEach((span) => {
-                span.innerHTML = Joomla.JText._('PLG_QUICKICON_JOOMLAUPDATE_UPDATEFOUND').replace('%s', `<span class="badge badge-light">${updateInfoList.length}</span>`);
+                span.innerHTML = Joomla.JText._('PLG_QUICKICON_JOOMLAUPDATE_UPDATEFOUND').replace('%s', `<span class="badge badge-light">${updateInfo.version}</span>`);
               });
             } else {
               linkSpans.forEach((span) => {


### PR DESCRIPTION
Pull Request for NOTE in Issue https://github.com/joomla/joomla-cms/pull/23047#issuecomment-437835801

### Summary of Changes
Display the JVersion instead of 0 when an Update is available, both in the Message and the icon itself.
Make the `Update Now` button the same size as for Extensions Update message by using `btn-sm`

### Testing Instructions
**To test on 4.0-dev branch**
Modify version.php line 63 to `const EXTRA_VERSION = 'alpha4-dev';`
Go to database and Fix database.
Then in JoomlaUpdate Options choose Custom URL and add this link (Thanks Tobias) :
https://update.joomla.org/core/nightlies/next_major_list.xml
Save Options.
Display Control Panel.

**Run npm ci**
### After patch
<img width="487" alt="screen shot 2018-11-13 at 11 27 09" src="https://user-images.githubusercontent.com/869724/48407440-1963f980-e737-11e8-8005-ebea1e244bb8.png">

@laoneo @PhilETaylor