### PR TITLE
Fixes issue with install via url failing when header keys are lowercase

### DIFF
--- a/libraries/src/Installer/InstallerHelper.php
+++ b/libraries/src/Installer/InstallerHelper.php
@@ -86,9 +86,12 @@ abstract class InstallerHelper
 			return false;
 		}
 
-		if (302 == $response->code && isset($response->headers['Location']))
+		// Convert keys of headers to lowercase, to accomodate for case variations
+		$headers = array_change_key_case($response->headers);
+
+		if (302 == $response->code && !empty($headers['location']))
 		{
-			return self::downloadPackage($response->headers['Location']);
+			return self::downloadPackage($headers['location']);
 		}
 		elseif (200 != $response->code)
 		{
@@ -98,8 +101,8 @@ abstract class InstallerHelper
 		}
 
 		// Parse the Content-Disposition header to get the file name
-		if (isset($response->headers['Content-Disposition'])
-			&& preg_match("/\s*filename\s?=\s?(.*)/", $response->headers['Content-Disposition'], $parts))
+		if (!empty($headers['content-disposition'])
+			&& preg_match("/\s*filename\s?=\s?(.*)/", $headers['content-disposition'], $parts))
 		{
 			$flds = explode(';', $parts[1]);
 			$target = trim($flds[0], '"');


### PR DESCRIPTION
On some servers headers of downloaded files have lowercase keys because some weird server settings.
So you get headers like:
```
[content-disposition] => attachment; filename="foobar-v1.2.3.zip"
```
instead of:
```
[Content-Disposition] => attachment; filename="foobar-v1.2.3.zip"
```
Because of the case difference, the Installer cannot find the correct filename in the 'Content-Disposition', as key matching is case sensitive.

### Summary of Changes
This PR will convert all keys to lowercase and base the 2 code parts trying to do stuff with the header info ('Location' and 'Content-Disposition') on the lowercase keys.

### Testing Instructions
This is hard to test, as the casing of the keys in the headers is server dependant.
I have no idea what server setting causes it yet.
So only way to test this would be to override the headers manually or something.

Or just read the code and see that it doesn't do anything crazy and doesn't break anything.

