### PR TITLE
Improves the getFilenameFromUrl method

### DIFF
--- a/libraries/src/Installer/InstallerHelper.php
+++ b/libraries/src/Installer/InstallerHelper.php
@@ -309,6 +309,7 @@ abstract class InstallerHelper
 
 		// Replace special characters with underscores.
 		$filename = preg_replace('/[^a-z0-9\_\-\.]/i', '_', $filename);
+
 		// Replace multiple underscores with just one.
 		$filename = preg_replace('/__+/i', '_', trim($filename, '_'));
 

--- a/libraries/src/Installer/InstallerHelper.php
+++ b/libraries/src/Installer/InstallerHelper.php
@@ -30,7 +30,7 @@ abstract class InstallerHelper
 	 *
 	 * @var    integer
 	 * @since  3.9.0
-	 */
+	 */	
 	const HASH_NOT_VALIDATED = 0;
 
 	/**
@@ -309,9 +309,8 @@ abstract class InstallerHelper
 
 		// Replace special characters with underscores.
 		$filename = preg_replace('/[^a-z0-9\_\-\.]/i', '_', $filename);
-
 		// Replace multiple underscores with just one.
-		$filename = preg_replace('/__+/', '_', trim($filename, '_'));
+		$filename = preg_replace('/__+/i', '_', trim($filename, '_'));
 
 		// Return the cleaned filename or, if it is empty, a unique id.
 		return $filename ?: $default;

--- a/libraries/src/Installer/InstallerHelper.php
+++ b/libraries/src/Installer/InstallerHelper.php
@@ -30,7 +30,7 @@ abstract class InstallerHelper
 	 *
 	 * @var    integer
 	 * @since  3.9.0
-	 */	
+	 */
 	const HASH_NOT_VALIDATED = 0;
 
 	/**
@@ -311,7 +311,7 @@ abstract class InstallerHelper
 		$filename = preg_replace('/[^a-z0-9\_\-\.]/i', '_', $filename);
 
 		// Replace multiple underscores with just one.
-		$filename = preg_replace('/__+/i', '_', trim($filename, '_'));
+		$filename = preg_replace('/__+/', '_', trim($filename, '_'));
 
 		// Return the cleaned filename or, if it is empty, a unique id.
 		return $filename ?: $default;

--- a/libraries/src/Installer/InstallerHelper.php
+++ b/libraries/src/Installer/InstallerHelper.php
@@ -290,20 +290,30 @@ abstract class InstallerHelper
 	 *
 	 * @param   string  $url  URL to get name from
 	 *
-	 * @return  mixed   String filename or boolean false if failed
+	 * @return  string  Clean version of the filename or a unique id
 	 *
 	 * @since   3.1
 	 */
 	public static function getFilenameFromUrl($url)
 	{
-		if (is_string($url))
-		{
-			$parts = explode('/', $url);
+		$default = uniqid();
 
-			return $parts[count($parts) - 1];
+		if (!is_string($url) || strpos($url, '/') === false)
+		{
+			return $default;
 		}
 
-		return false;
+		// Get last part of the url (after the last slash).
+		$parts    = explode('/', $url);
+		$filename = array_pop($parts);
+
+		// Replace special characters with underscores.
+		$filename = preg_replace('/[^a-z0-9\_\-\.]/i', '_', $filename);
+		// Replace multiple underscores with just one.
+		$filename = preg_replace('/__+/i', '_', trim($filename, '_'));
+
+		// Return the cleaned filename or, if it is empty, a unique id.
+		return $filename ?: $default;
 	}
 
 	/**


### PR DESCRIPTION
When using the 'Install from URL' (or any extension using that functionality), downloads the package file, it will try to find a suitable file name to use to store in the tmp folder.
In most cases the filename is taken from the header information from the file.

However, if that information is not available, it will try to create a filename based on the url.
It does this using the `getFilenameFromUrl()` method.

So if the file is:
```
https://www.some-domain.com/downloads/foobar.zip
```
Then the filename will be `foobar.zip`.

That's all great.
However, what if the url is:
```
https://www.some-domain.com/downloads/file.php?file=foobar
```
Then the filename will be `file.php?file=foobar`.
Or even worse:
```
https://www.some-domain.com/downloads/?file=foobar
```
Will result in the filename `?file=foobar`.

If this happens, then the next step in the process, the unpacking of the package, will fail miserably. As the special characters in the filename will cause kittens to die.

But there is another issue with the `getFilenameFromUrl()` method.
It is only used by the parent `InstallerHelper` class  code (even though it is a public method). 
And this is the code where it is used:
```php
$target = $tmpPath . '/' . self::getFilenameFromUrl($url);
```
But the `getFilenameFromUrl()` method will return a false if it can't find a filename for whatever reason.
So that would result in the filename 'false'... Not good.

### Summary of Changes
So the PR makes the whole `getFilenameFromUrl()` method smarter.

1. It will trim and replace any special characters with underscores.
So `https://www.some-domain.com/downloads/?file=foobar` will result in `file_foobar`.
2. It will fall back to and return a unique id (like ``) if there is no file name found for whatever reason.


### Testing Instructions
This is hard to test in real life, as this code only gets triggered when stuff is not as it should be (no correct header information and such).
So probably best to test this through test suits passing dummy (fake) data to it.
If you can do that, I don't have to explain :)


### Documentation Changes Required
https://api.joomla.org/cms-3/classes/Joomla.CMS.Installer.InstallerHelper.html
The return value of the `getFilenameFromUrl() ` mothod has changed, as it now will always return a string. No more false value.
So:
```
getFilenameFromUrl(string $url) : mixed
```
Becomes:
```
getFilenameFromUrl(string $url) : string
```
And:
```
Response
mixed String filename or boolean false if failed
```
Becomes:
```
Response
string Clean version of the filename or a unique id
```