### PR TITLE
Improve PLG_SYSTEM_ACTIONLOGS_XML_DESCRIPTION

### DIFF
--- a/administrator/language/en-GB/en-GB.plg_system_actionlogs.ini
+++ b/administrator/language/en-GB/en-GB.plg_system_actionlogs.ini
@@ -11,7 +11,7 @@ PLG_SYSTEM_ACTIONLOGS_LOG_DELETE_PERIOD_DESC="Enter how many days logs should be
 PLG_SYSTEM_ACTIONLOGS_NOTIFICATIONS="Send notifications for User Actions Log"
 PLG_SYSTEM_ACTIONLOGS_NOTIFICATIONS_DESC="Send a notifications of users' actions log to your email"
 PLG_SYSTEM_ACTIONLOGS_OPTIONS="User Actions Log Options"
-PLG_SYSTEM_ACTIONLOGS_XML_DESCRIPTION="Record the actions of users on the site so they can be reviewed if required."
+PLG_SYSTEM_ACTIONLOGS_XML_DESCRIPTION="Records the actions of users on the site so they can be reviewed if required."
 ; Common content type log messages
 PLG_SYSTEM_ACTIONLOGS_CONTENT_ADDED="User <a href=\"{accountlink}\">{username}</a> added new {type} <a href=\"{itemlink}\">{title}</a>"
 PLG_SYSTEM_ACTIONLOGS_CONTENT_ARCHIVED="User <a href=\"{accountlink}\">{username}</a> archived the {type} <a href=\"{itemlink}\">{title}</a>"

--- a/administrator/language/en-GB/en-GB.plg_system_actionlogs.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_system_actionlogs.sys.ini
@@ -4,4 +4,4 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_SYSTEM_ACTIONLOGS="System - User Actions Log"
-PLG_SYSTEM_ACTIONLOGS_XML_DESCRIPTION="To record actions of users within the CMS, to know who to blame when something wrong happens."
+PLG_SYSTEM_ACTIONLOGS_XML_DESCRIPTION="Records the actions of users on the site so they can be reviewed if required."


### PR DESCRIPTION
Change value of PLG_SYSTEM_ACTIONLOGS_XML_DESCRIPTION

The language string values for the same constant are not the same in the following files.

(a) File: plg_system_actionlogs.ini
PLG_SYSTEM_ACTIONLOGS_XML_DESCRIPTION="Record the actions of users on the site so they can be reviewed if required."

(b) File: plg_system_actionlogs.sys.ini
PLG_SYSTEM_ACTIONLOGS_XML_DESCRIPTION="To record actions of users within the CMS."
(this value is after the PR https://github.com/joomla/joomla-cms/pull/23059)
Before the PR 23059, the language string was:
PLG_SYSTEM_ACTIONLOGS_XML_DESCRIPTION="To record actions of users within the CMS, to know who to blame when something wrong happens."

My suggestion:
(i) Make the language string values for the language constant PLG_SYSTEM_ACTIONLOGS_XML_DESCRIPTION the same (ie. in both the files).

(ii) Probably the language string value could be changed as follows to reflect the action of the plugin.
PLG_SYSTEM_ACTIONLOGS_XML_DESCRIPTION="Records the actions of users on the site so they can be reviewed if required."

Pull Request for Issue # .

### Summary of Changes

Modified the language string values of the language constant PLG_SYSTEM_ACTIONLOGS_XML_DESCRIPTION in the files plg_system_actionlogs.ini and plg_system_actionlogs.sys.ini.


### Testing Instructions

These descriptions would appear in two places:
(i) In the screen "Extensions: Manage" - when the mouse hovers over the plugin name - source of this message is from the file plg_system_actionlogs.sys.ini

(ii) In the screen "Plugins: System - User Actions Log" when you open the plugin for Edit - source of this message is from the file plg_system_actionlogs.ini


### Expected result

Revised language string value.


### Actual result

Original language string value


### Documentation Changes Required

