### PR TITLE
[4.0] Fix markup

### DIFF
--- a/administrator/modules/mod_menu/tmpl/default_submenu.php
+++ b/administrator/modules/mod_menu/tmpl/default_submenu.php
@@ -82,7 +82,7 @@ $link      = $current->get('link');
 
 // Get the menu icon
 $icon      = $this->tree->getIconClass();
-$iconClass = ($icon != '' && $current->getLevel() == 1) ? '<span class="' . $icon . ' aria-hidden="true"></span>' : '';
+$iconClass = ($icon != '' && $current->getLevel() == 1) ? '<span class="' . $icon . '" aria-hidden="true"></span>' : '';
 
 if ($link !== null && $current->get('target') !== null && $current->get('target') !== '')
 {


### PR DESCRIPTION
### Summary of Changes
Add closing `"`.


### Testing Instructions
Code review.
or
Log in the backend and view page source.


### Expected result
`<span class="fa-fw fa fa-home" aria-hidden="true">`


### Actual result
See missing `"` after `fa-home`.

`<span class="fa-fw fa fa-home aria-hidden="true">`