### PR TITLE
[actionlogs] Remove limitations on the logDeletePeriod

### DIFF
--- a/plugins/system/actionlogs/actionlogs.xml
+++ b/plugins/system/actionlogs/actionlogs.xml
@@ -23,8 +23,6 @@
 					description="PLG_SYSTEM_ACTIONLOGS_LOG_DELETE_PERIOD_DESC"
 					default="0"
 					min="0"
-					max="30"
-					step="5"
 					filter="int"
 					validate="number"
 				/>


### PR DESCRIPTION
This removes the arbitrary limit of 30 days, and the step of 5 day implements for the logDeletePeriod in plg_actionlogs

The reason behind this, is that its impossible to select a period like 1 year (365 days) or quarterly or anything greater than 30 days... 

We should leave it up to the Joomla Admin to choose his period. (Although I dread to think how much will be collected in 365 days, but as the default is NEVER to delete (0) the logs, then this obviously is not Joomla's issue) 

Quickly PR'ed in GitHub, Not tested. 

Before PR: 
<img width="633" alt="screenshot 2018-11-15 at 07 34 39" src="https://user-images.githubusercontent.com/400092/48537254-ee99b280-e8a8-11e8-93cf-fdb437d2dabc.png">


After PR you should be able to select any number of days. 