### PR TITLE
[4.0] Fix retrieval of guest user group

### DIFF
--- a/libraries/src/Access/Access.php
+++ b/libraries/src/Access/Access.php
@@ -862,14 +862,7 @@ class Access
 		if (!isset(self::$groupsByUser[$storeId]))
 		{
 			// TODO: Uncouple this from ComponentHelper and allow for a configuration setting or value injection.
-			if (class_exists(ComponentHelper::class))
-			{
-				$guestUsergroup = ComponentHelper::getParams('com_users')->get('guest_usergroup', 1);
-			}
-			else
-			{
-				$guestUsergroup = 1;
-			}
+			$guestUsergroup = ComponentHelper::getParams('com_users')->get('guest_usergroup', 1);
 
 			// Guest user (if only the actually assigned group is requested)
 			if (empty($userId) && !$recursive)

--- a/libraries/src/Access/Access.php
+++ b/libraries/src/Access/Access.php
@@ -862,7 +862,7 @@ class Access
 		if (!isset(self::$groupsByUser[$storeId]))
 		{
 			// TODO: Uncouple this from ComponentHelper and allow for a configuration setting or value injection.
-			if (class_exists('ComponentHelper'))
+			if (class_exists(ComponentHelper::class))
 			{
 				$guestUsergroup = ComponentHelper::getParams('com_users')->get('guest_usergroup', 1);
 			}


### PR DESCRIPTION
Pull Request for Issue #23083.

### Summary of Changes

This fixes `class_exists()` check so guest user group can be retrieved from component configuration.

### Testing Instructions

a) See the output of `var_dump(JFactory::getUser()->getAuthorisedViewLevels());` when not logged in.
b) Create a menu item. Set its access level to `Guest`. Open site and look at menu module when not logged in.

### Expected result
a) Guest user group included:  `array(3) { [0]=> int(1) [1]=> int(1) [2]=> int(5) }`
b) Menu item shown.

### Actual result
a) Guest user group not included: `array(2) { [0]=> int(1) [1]=> int(1) }`
b) Menu item not shown.

### Documentation Changes Required
No.
