### PR TITLE
[com_privacy] Delete request if we cant send email

### DIFF
--- a/components/com_privacy/controllers/request.php
+++ b/components/com_privacy/controllers/request.php
@@ -108,8 +108,14 @@ class PrivacyControllerRequest extends JControllerLegacy
 		}
 		elseif ($return === false)
 		{
-			// Confirm failed.
-			// Go back to the confirm form.
+			/**
+			 * If we were able to createRequest before that method returned false, then clean up
+			 * This can happen if we save the request and then there was a problem sending the email.
+			 */
+			/** @var PrivacyTableRequest $table */
+			$model->removeRequest();
+
+			// Confirm failed and go back to the confirm form.
 			$message = JText::sprintf('COM_PRIVACY_ERROR_CREATING_REQUEST_FAILED', $model->getError());
 			$this->setRedirect(JRoute::_('index.php?option=com_privacy&view=request', false), $message, 'notice');
 

--- a/components/com_privacy/models/request.php
+++ b/components/com_privacy/models/request.php
@@ -235,7 +235,8 @@ class PrivacyModelRequest extends JModelAdmin
 		}
 
 		// This can happen if a duplicate request was attempted, so the new request was not created, and so doesnt need to be deleted
-		if (!$id){
+		if (!$id)
+		{
 			return false;
 		}
 

--- a/components/com_privacy/models/request.php
+++ b/components/com_privacy/models/request.php
@@ -234,6 +234,11 @@ class PrivacyModelRequest extends JModelAdmin
 			$id = $this->getState($this->getName() . '.id');
 		}
 
+		// This can happen if a duplicate request was attempted, so the new request was not created, and so doesnt need to be deleted
+		if (!$id){
+			return false;
+		}
+
 		/** @var PrivacyTableRequest $table */
 		$table = $this->getTable();
 

--- a/components/com_privacy/models/request.php
+++ b/components/com_privacy/models/request.php
@@ -218,6 +218,34 @@ class PrivacyModelRequest extends JModelAdmin
 	}
 
 	/**
+	 * Deletes an information request.
+	 *
+	 * @param   integer $id The primary id of the request
+	 *
+	 * @return  boolean
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  Exception
+	 */
+	public function removeRequest($id = null)
+	{
+		if (null === $id)
+		{
+			$id = $this->getState($this->getName() . '.id');
+		}
+
+		/** @var PrivacyTableRequest $table */
+		$table = $this->getTable();
+
+		if ($table->load($id))
+		{
+			return $table->delete($id);
+		}
+
+		return false;
+	}
+
+	/**
 	 * Method for getting the form from the model.
 	 *
 	 * @param   array    $data      Data for the form.


### PR DESCRIPTION
Closes #23074

### Summary of Changes

If mail is enabled in Joomla config, but we were unable to send the email, the request is created, but the error message states that the request was not created.

There is no point in creating a request if we cannot send the email - this is why mailing has to be enabled. If your mail settings are wrong, the mail cannot be sent, and therefore we should remove the request and inform the user correctly.

### Testing Instructions

Default 3.9.0 installation with this PR.
Create a "Create Request" Menu item using Privacy -> Create Request menu type
in Joomla Global Config set:
 - Send Mail = Yes
 - Mailer = SMTP
 - SMTP HOST = NO_SUCH_SERVER
Login to frontend of the site
Click Create Request
Enter email address
Click submit

### Expected result

<img width="727" alt="screenshot 2018-11-16 at 11 37 54" src="https://user-images.githubusercontent.com/400092/48619341-19146a00-e994-11e8-83b8-1fb0033651b4.png">

**and NO ROW left in #__privacy_requests**

### Actual result

(note this error was NOT generated with the above testing instructions, for this one you need to disable mail in php which is harder than the above testing instructions.)

<img width="767" alt="48470377-2ccf9d00-e7e9-11e8-8c94-0837f45200cd" src="https://user-images.githubusercontent.com/400092/48619418-55e06100-e994-11e8-8acf-142128f3b39c.png">

and ROW left in #__privacy_requests even though the error says no request was made.

### Documentation Changes Required

None