### PR TITLE
[4.0] Add missing eye icons to installer css

### DIFF
--- a/installation/template/scss/template.scss
+++ b/installation/template/scss/template.scss
@@ -281,3 +281,11 @@ caption {
 .badge-warning {
   color: #292b2c;
 }
+
+.fa-eye:before, .icon-eye-open:before, .icon-eye:before {
+  font-family: FontAwesome;
+  content: "\f06e"; }
+
+.fa-eye-slash:before, .icon-eye-close:before, .icon-eye-blocked:before, .icon-eye-2:before {
+  font-family: FontAwesome;
+  content: "\f070"; }

--- a/installation/template/scss/template.scss
+++ b/installation/template/scss/template.scss
@@ -284,8 +284,10 @@ caption {
 
 .fa-eye:before, .icon-eye-open:before, .icon-eye:before {
   font-family: FontAwesome;
+  cursor: pointer;
   content: "\f06e"; }
 
 .fa-eye-slash:before, .icon-eye-close:before, .icon-eye-blocked:before, .icon-eye-2:before {
   font-family: FontAwesome;
+  cursor: pointer;
   content: "\f070"; }

--- a/installation/template/scss/template.scss
+++ b/installation/template/scss/template.scss
@@ -285,9 +285,11 @@ caption {
 .fa-eye:before, .icon-eye-open:before, .icon-eye:before {
   font-family: FontAwesome;
   cursor: pointer;
-  content: "\f06e"; }
+  content: "\f06e";
+}
 
 .fa-eye-slash:before, .icon-eye-close:before, .icon-eye-blocked:before, .icon-eye-2:before {
   font-family: FontAwesome;
   cursor: pointer;
-  content: "\f070"; }
+  content: "\f070";
+}


### PR DESCRIPTION
Closes #22963

### Summary of Changes

Added missing CSS for the eye and eye close icons (hide/show password icon) and set correct cursor

### Testing Instructions

checkout 4.0-dev
apply pr
npm ci
npm run build:css  (just in case) 
clear browser cache
load installation page, enter site name, click Setup Login data
On this next page note the new eye icon - click it

### Expected result

<img width="694" alt="screenshot 2018-11-16 at 12 07 29" src="https://user-images.githubusercontent.com/400092/48620570-8a561c00-e998-11e8-8f3d-f6d3a2fa41cf.png">


### Actual result

<img width="694" alt="screenshot 2018-11-16 at 12 07 29" src="https://user-images.githubusercontent.com/400092/48179390-d9f07400-e316-11e8-9bfb-737e578ee1d9.png">

### Documentation Changes Required

None