### PR TITLE
[3.9] Change link generation on feed links

### DIFF
--- a/components/com_content/views/category/view.feed.php
+++ b/components/com_content/views/category/view.feed.php
@@ -56,7 +56,7 @@ class ContentViewCategory extends JViewCategoryfeed
 			$item->slug = $item->alias ? ($item->id . ':' . $item->alias) : $item->id;
 
 			// URL link to article
-			$link = JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catid, $item->language));
+			$link = JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catid, $item->language), true, 1 );
 
 			$item->description .= '<p class="feed-readmore"><a target="_blank" href ="' . $link . '">' . JText::_('COM_CONTENT_FEED_READMORE') . '</a></p>';
 		}


### PR DESCRIPTION
Pull Request for Issue #23064.

Hard to replicate the issue in #23064, if I fake the params to get the layout, -  this does indeed fix it

```html
<p class="feed-readmore"><a target="_blank" href ="/index.php">Read More ...</a></p>]]></description>
```

becomes 

```html
<p class="feed-readmore"><a target="_blank" href ="https://0.0.0.0/index.php">Read More ...</a></p>]]></description>
```

see: #23064