### PR TITLE
[4.0] Fix for parent constructor call mismatch #23038

### DIFF
--- a/libraries/src/Application/ConsoleApplication.php
+++ b/libraries/src/Application/ConsoleApplication.php
@@ -69,7 +69,7 @@ class ConsoleApplication extends Application implements DispatcherAwareInterface
 	 */
 	public function __construct(Cli $input = null, Registry $config = null, DispatcherInterface $dispatcher = null, Container $container = null)
 	{
-		parent::__construct($input, $config);
+		parent::__construct($config);
 
 		$this->setName('Joomla!');
 		$this->setVersion(JVERSION);


### PR DESCRIPTION
Pull Request for Issue #23038.

### Summary of Changes

The issue is caused by a mismatch between the Joomla\CMS\Application\ConsoleApplication call to the parent constructor, and the Joomla\Console\Application.

This fix simply removes the extra parameter of the parent constructor call, to match the parent constructor definition.

### Testing Instructions

1. Create a CLI script. For instance, you can use this script as a sample script [Joomla Console](https://github.com/joomla/joomla-cms/blob/4.0-dev/cli/joomla.php).
1. Read a variable from the general configuration. e.g. offline_message

### Expected result

The current value.

### Actual result

null

