### PR TITLE
[4.0] Deprecate to load a JS script file in none defer mode

### DIFF
--- a/libraries/src/Document/Document.php
+++ b/libraries/src/Document/Document.php
@@ -516,6 +516,14 @@ class Document
 	 */
 	public function addScript($url, $options = array(), $attribs = array())
 	{
+		if (!isset($attribs['defer']) || $attribs['defer'] == false)
+		{
+			@trigger_error(
+				'Loading a script in none defer mode is deprecated and will not being supported in 5.0 anymore.',
+				E_USER_DEPRECATED
+			);
+		}
+
 		// Default value for type.
 		if (!isset($attribs['type']) && !isset($attribs['mime']))
 		{


### PR DESCRIPTION
Pull Request for pr #22460.

### Summary of Changes
Deprecates when Javascript files are loaded in none defer mode. This is a less disruptive way to migrate the eco system to load JS files in a none blocking way.

### Testing Instructions
Open the back end.

### Expected result
All is working as expected.

### Actual result
All is working as expected.

### Documentation Changes Required
Loading JS files in defer mode must be documented.