### PR TITLE
[imp] reset checked_out to DEFAULT instead of 0 in global checkin

### DIFF
--- a/administrator/components/com_checkin/models/checkin.php
+++ b/administrator/components/com_checkin/models/checkin.php
@@ -111,7 +111,7 @@ class CheckinModelCheckin extends JModelList
 
 			$query = $db->getQuery(true)
 				->update($db->quoteName($tn))
-				->set('checked_out = 0')
+				->set('checked_out = DEFAULT')
 				->set('checked_out_time = ' . $db->quote($nullDate))
 				->where('checked_out > 0');
 


### PR DESCRIPTION
Pull Request for Issue #23121 .

### Summary of Changes
reset check_out value to DEFAULT instead of 0 in global checkin


### Testing Instructions
use global checkin


### Expected result
should work


### Actual result
doesn't work if the checked_out olumn has a fk constraint on #_users table


### Documentation Changes Required

