### PR TITLE
[4.0] Check if rules are available in rules field rule

### DIFF
--- a/libraries/src/Form/Rule/RulesRule.php
+++ b/libraries/src/Form/Rule/RulesRule.php
@@ -103,7 +103,8 @@ class RulesRule extends FormRule
 		if ($elActions)
 		{
 			// Iterate over the asset actions and add to the actions.
-			foreach ($elActions as $item) {
+			foreach ($elActions as $item)
+			{
 				$actions[] = $item->name;
 			}
 		}

--- a/libraries/src/Form/Rule/RulesRule.php
+++ b/libraries/src/Form/Rule/RulesRule.php
@@ -100,10 +100,12 @@ class RulesRule extends FormRule
 			"/access/section[@name='" . $section . "']/"
 		);
 
-		// Iterate over the asset actions and add to the actions.
-		foreach ($elActions as $item)
+		if ($elActions)
 		{
-			$actions[] = $item->name;
+			// Iterate over the asset actions and add to the actions.
+			foreach ($elActions as $item) {
+				$actions[] = $item->name;
+			}
 		}
 
 		// Iterate over the children and add to the actions.


### PR DESCRIPTION
Pull Request for Issue #23115.

### Summary of Changes
Check if the rules from the access.xml are available.

### Testing Instructions
- Go to Global Configuration
- Click Save button
- View PHP error log file

### Expected result
All is working as expected.

### Actual result
The following error is written to the server log:
_Invalid argument supplied for foreach()_