### PR TITLE
Fix for Field Group being output when empty

### DIFF
--- a/components/com_fields/layouts/fields/render.php
+++ b/components/com_fields/layouts/fields/render.php
@@ -51,7 +51,8 @@ if (empty($fields))
 
 $output = [];
 
-foreach ($fields as $field) {
+foreach ($fields as $field)
+{
 	 // If the value is empty do nothing
 	if (!isset($field->value) || $field->value == '') {
 		 continue;

--- a/components/com_fields/layouts/fields/render.php
+++ b/components/com_fields/layouts/fields/render.php
@@ -53,7 +53,7 @@ $output = array();
 
 foreach ($fields as $field)
 {
-	 // If the value is empty do nothing
+	// If the value is empty do nothing
 	if (!isset($field->value) || $field->value == '')
 	{
 		continue;

--- a/components/com_fields/layouts/fields/render.php
+++ b/components/com_fields/layouts/fields/render.php
@@ -58,6 +58,7 @@ foreach ($fields as $field)
 	{
 		 continue;
 	}
+
 	$class = $field->params->get('render_class');
 	$layout = $field->params->get('layout', 'render');
 	$content = FieldsHelper::render($context, 'field.' . $layout, array('field' => $field));

--- a/components/com_fields/layouts/fields/render.php
+++ b/components/com_fields/layouts/fields/render.php
@@ -56,7 +56,7 @@ foreach ($fields as $field)
 	 // If the value is empty do nothing
 	if (!isset($field->value) || $field->value == '')
 	{
-		 continue;
+		continue;
 	}
 
 	$class = $field->params->get('render_class');

--- a/components/com_fields/layouts/fields/render.php
+++ b/components/com_fields/layouts/fields/render.php
@@ -49,7 +49,7 @@ if (empty($fields))
 	return;
 }
 
-$output = [];
+$output = array();
 
 foreach ($fields as $field)
 {

--- a/components/com_fields/layouts/fields/render.php
+++ b/components/com_fields/layouts/fields/render.php
@@ -44,22 +44,31 @@ else
 	$fields = $item->jcfields ?: FieldsHelper::getFields($context, $item, true);
 }
 
-if (!$fields)
+if (empty($fields))
+{
+	return;
+}
+
+$output = [];
+
+foreach ($fields as $field) {
+	 // If the value is empty do nothing
+	if (!isset($field->value) || $field->value == '') {
+		 continue;
+	}
+	$class = $field->params->get('render_class');
+	$layout = $field->params->get('layout', 'render');
+	$content = FieldsHelper::render($context, 'field.' . $layout, array('field' => $field));
+
+	$output[] = '<dd class="field-entry ' . $class . '">' . $content . '</dd>';
+}
+
+if (empty($output))
 {
 	return;
 }
 
 ?>
 <dl class="fields-container">
-	<?php foreach ($fields as $field) : ?>
-		<?php // If the value is empty do nothing ?>
-		<?php if (!isset($field->value) || $field->value == '') : ?>
-			<?php continue; ?>
-		<?php endif; ?>
-		<?php $class = $field->params->get('render_class'); ?>
-		<?php $layout = $field->params->get('layout', 'render'); ?>
-		<dd class="field-entry <?php echo $class; ?>">
-			<?php echo FieldsHelper::render($context, 'field.' . $layout, array('field' => $field)); ?>
-		</dd>
-	<?php endforeach; ?>
+	<?php echo implode("\n", $output); ?>
 </dl>

--- a/components/com_fields/layouts/fields/render.php
+++ b/components/com_fields/layouts/fields/render.php
@@ -54,7 +54,8 @@ $output = [];
 foreach ($fields as $field)
 {
 	 // If the value is empty do nothing
-	if (!isset($field->value) || $field->value == '') {
+	if (!isset($field->value) || $field->value == '')
+	{
 		 continue;
 	}
 	$class = $field->params->get('render_class');


### PR DESCRIPTION
### Summary of Changes

Currently in Joomla, if a Field Group is empty (there are no values attached to any of the fields included in the field group) the surrounding `<dl>` tag is still output. Causing unwanted empty spaces.

There already is a check for individual fields not containing values, but there is no check if ALL the fields don't contain values at all.

This fixes the issue.

### Testing Instructions

- Create a Field Group
- Assign a Field to this Field Group, and assign it to a Category
- Visit an article included in the assigned Category (without giving a value to the field)
- See that an empty `<dl class="fields-container"></dl>` is output.
- Apply Patch
- See that the empty  `<dl class="fields-container"></dl>` is not output anymore.

### Expected result

- There should be no ouput when the group is empty.

### Actual result

- Surrounding HTML is output even when there is nothing to display.

### Documentation Changes Required

None