### PR TITLE
[4.0] Fix styling of cancel button in com_content batch. Fixes #22886

### DIFF
--- a/administrator/components/com_content/tmpl/articles/default_batch_footer.php
+++ b/administrator/components/com_content/tmpl/articles/default_batch_footer.php
@@ -13,9 +13,9 @@ use Joomla\CMS\Language\Text;
 
 HTMLHelper::_('script', 'com_content/admin-articles-default-batch-footer.js', ['version' => 'auto', 'relative' => true]);
 ?>
-<a class="btn btn-secondary" type="button" data-dismiss="modal">
+<button class="btn btn-secondary" type="button" data-dismiss="modal">
 	<?php echo Text::_('JCANCEL'); ?>
-</a>
+</button>
 <button id='batch-submit-button-id' class="btn btn-success" type="submit" data-submit-task='article.batch'>
 	<?php echo Text::_('JGLOBAL_BATCH_PROCESS'); ?>
 </button>


### PR DESCRIPTION
Updated PR of #22886 without the extra stuff added

Check the cancel button of the batch modal in com_content, before patch not styled, after patch styled