### PR TITLE
[4.0] RTL: Correcting Joomla Update version display in System CPanel badge and Joomla Update component

### DIFF
--- a/administrator/components/com_cpanel/tmpl/system/default.php
+++ b/administrator/components/com_cpanel/tmpl/system/default.php
@@ -28,7 +28,7 @@ use Joomla\CMS\Language\Text;
 					<a href="<?php echo $link['link']; ?>"><?php echo Text::_($link['title']); ?>
 					<?php if ($link['badge']) : ?>
 						<span class="pull-right badge badge-pill badge-warning">
-							<?php echo Text::_($link['badge']); ?>
+							<?php echo '&#x200E;' . Text::_($link['badge']); ?>
 						</span>
 					<?php endif; ?>
 					</a>

--- a/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_preupdatecheck.php
+++ b/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_preupdatecheck.php
@@ -15,7 +15,7 @@ use Joomla\CMS\Language\Text;
 ?>
 
 <h2>
-	<?php echo Text::sprintf('COM_JOOMLAUPDATE_VIEW_DEFAULT_COMPATIBILITY_CHECK', $this->updateInfo['latest']); ?>
+	<?php echo Text::sprintf('COM_JOOMLAUPDATE_VIEW_DEFAULT_COMPATIBILITY_CHECK', '&#x200E;' . $this->updateInfo['latest']); ?>
 </h2>
 
 <div class="row-fluid">
@@ -115,11 +115,11 @@ use Joomla\CMS\Language\Text;
 					</td>
 					<td class="extension-check"
 					    data-extension-id="<?php echo $extension->extension_id; ?>"
-					    data-extension-current-version="<?php echo $extension->version; ?>">
+					    data-extension-current-version="<?php echo $extension->version; ?>" dir="ltr">
 						<img src="../media/system/images/mootree_loader.gif" />
 					</td>
 					<td>
-						<?php echo $extension->version; ?>
+						<?php echo '&#x200E;' . $extension->version; ?>
 					</td>
 				</tr>
 			<?php endforeach; ?>

--- a/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_reinstall.php
+++ b/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_reinstall.php
@@ -18,7 +18,7 @@ use Joomla\CMS\Updater\Update;
 	<legend><?php echo Text::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_NOUPDATES'); ?></legend>
 	<p><?php echo Text::sprintf($this->langKey, $this->updateSourceKey); ?></p>
 	<div class="alert alert-success">
-		<?php echo Text::sprintf('COM_JOOMLAUPDATE_VIEW_DEFAULT_NOUPDATESNOTICE', JVERSION); ?>
+		<?php echo Text::sprintf('COM_JOOMLAUPDATE_VIEW_DEFAULT_NOUPDATESNOTICE', '&#x200E;' . JVERSION); ?>
 	</div>
 	<?php if (is_object($this->updateInfo['object']) && ($this->updateInfo['object'] instanceof Update)) : ?>
 		<table class="table">

--- a/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_update.php
+++ b/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_update.php
@@ -29,7 +29,7 @@ use Joomla\CMS\Language\Text;
 					<?php echo Text::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_INSTALLED'); ?>
 				</td>
 				<td>
-					<?php echo $this->updateInfo['installed']; ?>
+					<?php echo '&#x200E;' . $this->updateInfo['installed']; ?>
 				</td>
 			</tr>
 			<tr>
@@ -37,7 +37,7 @@ use Joomla\CMS\Language\Text;
 					<?php echo Text::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_LATEST'); ?>
 				</td>
 				<td>
-					<?php echo $this->updateInfo['latest']; ?>
+					<?php echo  '&#x200E;' . $this->updateInfo['latest']; ?>
 				</td>
 			</tr>
 			<tr>

--- a/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_update.php
+++ b/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_update.php
@@ -37,7 +37,7 @@ use Joomla\CMS\Language\Text;
 					<?php echo Text::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_LATEST'); ?>
 				</td>
 				<td>
-					<?php echo  '&#x200E;' . $this->updateInfo['latest']; ?>
+					<?php echo '&#x200E;' . $this->updateInfo['latest']; ?>
 				</td>
 			</tr>
 			<tr>

--- a/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_upload.php
+++ b/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_upload.php
@@ -58,7 +58,7 @@ Text::script('COM_INSTALLER_MSG_INSTALL_PLEASE_SELECT_A_PACKAGE', true);
 				<td>
 					<input class="form-control-file" id="install_package" name="install_package" type="file" size="57">
 					<?php $maxSize = HTMLHelper::_('number.bytes', Utility::getMaxUploadSize()); ?>
-					<small class="form-text text-muted"><?php echo Text::sprintf('JGLOBAL_MAXIMUM_UPLOAD_SIZE_LIMIT', $maxSize); ?></small>
+					<small class="form-text text-muted"><?php echo Text::sprintf('JGLOBAL_MAXIMUM_UPLOAD_SIZE_LIMIT', '&#x200E;' . $maxSize); ?></small>
 				</td>
 			</tr>
 			<tr>

--- a/administrator/templates/atum/scss/font-awesome.scss
+++ b/administrator/templates/atum/scss/font-awesome.scss
@@ -6,3 +6,8 @@
 
 // B/C for Icomoon
 @import "../../../../build/media/system/scss/icomoon";
+
+// RTL override
+html[dir=rtl] .pull-right {
+    float: left;
+}

--- a/build/media/com_joomlaupdate/js/default.js
+++ b/build/media/com_joomlaupdate/js/default.js
@@ -146,6 +146,7 @@ Joomla = window.Joomla || {};
      */
     PreUpdateChecker.setResultView = function (extensionData) {
         var html = '';
+        var direction = (document.dir !== undefined) ? document.dir : document.getElementsByTagName("html")[0].getAttribute("dir");
 
         // Switch the compatibility state
         switch (extensionData.state) {
@@ -155,8 +156,13 @@ Joomla = window.Joomla || {};
                     html = '<span class="badge badge-success">' + Joomla.JText._('JYES') + '</span>';
                 } else {
                     // The compatible version does not match the current version => display warning label.
-                    html = '<span class="badge badge-warning">' + Joomla.JText._('JYES')
-                        + ' (' + extensionData.compatibleVersion + ')</span>';
+                    if (direction === 'rtl') {
+                        html = '<span class="badge badge-warning">' + '(' + extensionData.compatibleVersion + ') '
+                           + Joomla.JText._('JYES') + '</span>';
+                    } else {
+                        html = '<span class="badge badge-warning">' + Joomla.JText._('JYES')
+                            + ' (' + extensionData.compatibleVersion + ')</span>';
+                    }
                 }
                 break;
             case PreUpdateChecker.STATE.INCOMPATIBLE:


### PR DESCRIPTION
Completing https://github.com/joomla/joomla-cms/pull/23047 ++

### Summary of Changes
Correcting RTL display of Joomla Update version in CPanel System as well as in the Joomla update component.
Correcting Extension version in Joomla Update component. That one required also to modify joomlaupdate default js file to change the order of version and 'Yes' when present

Basically we want to get for example:
`4.0.0-alpha6-dev` instead of `alpha-dev-4.0.0` and align correctly the `<span>` concerned.

### Testing Instructions
On last 4.0.0-dev branch
Modify libraries/src/Version.php
to `const EXTRA_VERSION = 'alpha4-dev';`
in order to get a database fix issue
Fix database.
Then in JoomlaUpdate Options choose Custom URL and add this link:
https://update.joomla.org/core/nightlies/next_major_list.xml

Install Persian language and set admin language to Persian.

Requires using `npm ci` to test.
### Before patch

![screen shot 2018-11-22 at 10 19 14](https://user-images.githubusercontent.com/869724/48893227-258b3d80-ee40-11e8-9e37-31d299701b8b.png)

![4 0jupdate_before_1](https://user-images.githubusercontent.com/869724/48892581-afd2a200-ee3e-11e8-8513-e41f121f80f6.png)

![40jupdate_before_3](https://user-images.githubusercontent.com/869724/48892579-af3a0b80-ee3e-11e8-8799-cbe96c1090e9.png)

![4 0jupdate_before_2](https://user-images.githubusercontent.com/869724/48892580-afd2a200-ee3e-11e8-8ab3-05e5ec749702.png)

![screen shot 2018-11-22 at 10 20 58](https://user-images.githubusercontent.com/869724/48893361-76029b00-ee40-11e8-9b11-91b8180de845.png)


### After patch
![screen shot 2018-11-22 at 07 30 05](https://user-images.githubusercontent.com/869724/48892705-f45e3d80-ee3e-11e8-88f2-5e5e635a7b2c.png)
![after-1](https://user-images.githubusercontent.com/869724/48892728-0049ff80-ee3f-11e8-9bb4-4ae363fb1621.png)
![after-3](https://user-images.githubusercontent.com/869724/48892779-18ba1a00-ee3f-11e8-90dd-9b82a9e2f2a7.png)
![after2-a](https://user-images.githubusercontent.com/869724/48892792-22dc1880-ee3f-11e8-8196-671af4bcacfd.png)

If no update available 

![after2-b](https://user-images.githubusercontent.com/869724/48892796-266f9f80-ee3f-11e8-9d79-c25139ddf438.png)

![screen shot 2018-11-22 at 09 18 12](https://user-images.githubusercontent.com/869724/48892809-2b345380-ee3f-11e8-90e6-f560fe8bff5d.png)


### Documentation Changes Required

None

@Quy @richard67 @C-Lodder @wilsonge 