### PR TITLE
[mod_login] - no need field cache

### DIFF
--- a/modules/mod_login/mod_login.xml
+++ b/modules/mod_login/mod_login.xml
@@ -152,17 +152,6 @@
 					description="COM_MODULES_FIELD_MODULECLASS_SFX_DESC"
 					rows="3"
 				/>
-
-				<field
-					name="cache"
-					type="list"
-					label="COM_MODULES_FIELD_CACHING_LABEL"
-					description="COM_MODULES_FIELD_CACHING_DESC"
-					default="0"
-					filter="integer"
-					>
-					<option value="0">COM_MODULES_FIELD_VALUE_NOCACHING</option>
-				</field>
 			</fieldset>
 		</fields>
 	</config>


### PR DESCRIPTION
Pull Request for Issue #23147 .

### Summary of Changes
removed field cache


### Testing Instructions
mod_login works as before
