### PR TITLE
[4.0] [RFC] JavaScript: use ES6 code by default, and fallback to ES5

### DIFF
--- a/build/build-modules-js/compile-es6.js
+++ b/build/build-modules-js/compile-es6.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const path = require('path');
 const babel = require('babel-core');
 const UglifyJS = require('uglify-es');
 const os = require('os');
@@ -17,35 +18,45 @@ const babelOptions = {
  * @param filePath
  */
 const compileFile = (filePath) => {
+  console.log(`Compiling ES5 version for: ${path.relative(process.cwd(), filePath)}`);
+
+  // Make sure the file has .es6.js extension
+  if (filePath.indexOf('.es6.js') === -1) {
+    throw new Error('File that contain ES6 code must have .es6.js extension');
+  }
+
   babel.transformFile(filePath, babelOptions, (error, result) => {
     if (error) {
-      // eslint-disable-next-line no-console
-      console.error(`${error}`);
-      process.exit(1);
+      throw error;
     }
 
-    const fileName = filePath.slice(0, -7);
-    console.log(`Compiling: ${fileName.replace('/build/media_src/', '/media/')}.js`);
+    const dirName = path.dirname(filePath),
+      fileName    = path.basename(filePath, '.es6.js'),
+      destDirName = dirName.replace('/build/media_src/', '/media/'),
+      destFile    = `${destDirName}/${fileName}.es5.js`,
+      destFileMin = `${destDirName}/${fileName}.es5.min.js`;
+
+    // Make sure a destination folder exists
+    fs.mkdirSync(destDirName, {recursive: true});
+
+    // Write the result
     fs.writeFile(
-      `${fileName.replace('/build/media_src/', '/media/').replace('\\build\\media_src\\', '\\media\\')}.js`,
+      destFile,
       result.code + os.EOL,
       (fsError) => {
         if (fsError) {
-          // eslint-disable-next-line no-console
-          console.error(`${fsError}`);
-          process.exit(1);
+          throw fsError;
         }
       }
     );
-    // Also write the minified
+
+    // Also write the minified version
     fs.writeFile(
-      `${fileName.replace('/build/media_src/', '/media/').replace('\\build\\media_src\\', '\\media\\')}.min.js`,
+      destFileMin,
       UglifyJS.minify(result.code).code + os.EOL,
       (fsError) => {
         if (fsError) {
-          // eslint-disable-next-line no-console
-          console.error(`${fsError}`);
-          process.exit(1);
+          throw fsError;
         }
       }
     );

--- a/build/build-modules-js/compile-es6.js
+++ b/build/build-modules-js/compile-es6.js
@@ -37,7 +37,7 @@ const compileFile = (filePath) => {
       destFileMin = `${destDirName}/${fileName}.es5.min.js`;
 
     // Make sure a destination folder exists
-    fs.mkdirSync(destDirName, {recursive: true});
+    //fs.mkdirSync(destDirName, {recursive: true});
 
     // Write the result
     fs.writeFile(

--- a/build/build-modules-js/compilejs.js
+++ b/build/build-modules-js/compilejs.js
@@ -44,8 +44,9 @@ const uglifyJs = (options, path) => {
             }
           },
           (error) => {
-            // eslint-disable-next-line no-console
-            console.error(`something exploded ${error}`);
+            if (error) {
+              throw error;
+            }
           },
         );
       });

--- a/build/build-modules-js/update.js
+++ b/build/build-modules-js/update.js
@@ -275,30 +275,37 @@ const copyFiles = (options) => {
 };
 
 const recreateMediaFolder = () => {
-	// eslint-disable-next-line no-console
-	console.log(`Recreating the media folder...`);
+  // eslint-disable-next-line no-console
+  console.log(`Recreating the media folder...`);
 
-    copydir.sync(Path.join(rootPath, 'build/media'), Path.join(rootPath, 'media'), function(stat, filepath, filename){
-        if (stat === 'directory' && (filename === 'webcomponents' || filename === 'scss')) {
-            return false;
-        }
-        return true;
-    }, function(err){
-        if (!err) {
-            console.log('Legacy media files restored');
-        }
-    });
+  const destDirName = Path.join(rootPath, 'media');
 
-    copydir.sync(Path.join(rootPath, 'build/media_src'), Path.join(rootPath, 'media'), function(stat, filepath, filename){
-        if (stat === 'directory' && filename === 'scss') {
-            return false;
-        }
-        return true;
-    }, function(err){
-        if (!err) {
-            console.log('Media folder structure was created');
-        }
+  copydir.sync(Path.join(rootPath, 'build/media'), destDirName, function(stat, filepath, filename){
+    if (stat === 'directory' && (filename === 'webcomponents' || filename === 'scss')) {
+      return false;
+    }
+    return true;
+  });
+
+  console.log('Folder build/media was copied');
+
+  copydir.sync(Path.join(rootPath, 'build/media_src'), destDirName, function(stat, filepath, filename){
+    if (stat === 'directory' && filename === 'scss') {
+      return false;
+    }
+    return true;
+  });
+
+  console.log('Folder build/media_src was copied');
+
+  // Rename *.es6.js => *.js
+  walkSync(destDirName).forEach((file) => {
+    if (!file.match(/\.es6\.js$/)) return;
+
+    fs.rename(file, file.replace(/\.es6\.js$/, '.js'), (error) => {
+      if (error) throw error;
     });
+  });
 };
 
 // List all files in a directory recursively in a synchronous fashion

--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -742,7 +742,8 @@ abstract class HTMLHelper
 				$es5Ext   = $isMin ? '.es5.min.js' : '.es5.js';
 				$es5File  = $pathInfo['dirname'] . '/' . $fileName . $es5Ext;
 
-				if (is_file(JPATH_ROOT . '/' . $es5File))
+				// Check if there ES5 counterpart
+				if (is_file(JPATH_ROOT . substr($es5File, strlen(Uri::root(true)))))
 				{
 					$includes[$i] = $es5File;
 				}

--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -724,7 +724,7 @@ abstract class HTMLHelper
 			];
 			$navigator    = Browser::getInstance();
 			$es6Supported = empty($es6BlackList[$navigator->getBrowser()])
-				&& empty($es6BlackList[$navigator->getBrowser().$navigator->getMajor()]);
+				&& empty($es6BlackList[$navigator->getBrowser() . $navigator->getMajor()]);
 		}
 
 		if (!$es6Supported)


### PR DESCRIPTION
### Summary of Changes

The patch enable use of es6 code by default, and fallback to es5 when it possible.
It use "Optimistic assumption" that most of user has a browser with es6 support, 
and for rest of users it has a "black list", so they will get es5 counterpart (if it available).

This need to be done sooner or later.

_Note: The patch allow to serve an existing code (non es6) as usual, without renaming to es5.js, untill it get converted to es6._


### Testing Instructions

Apply patch, run `npm install`.
Look example in to `/media/system/js`, you should notice .es5.js files (eg core.es5.js).

then

Open the site in a browser, click around, all should work as before.
Open the site in IE11, and check the source code, you should see js files with .es5.js extension  (eg core.es5.js).

### Documentation Changes Required

yeap, in 2 words: Joomla! allow to use es6 code aside with non es6 code. 
But each es6 file should have es5 counterpart with extension `.es5.js` (in the same folder), to use it in older browsers.

ping @wilsonge @dgrammatiko @C-Lodder 
