### PR TITLE
[mod_languages] - no need of cache fields

### DIFF
--- a/modules/mod_languages/mod_languages.xml
+++ b/modules/mod_languages/mod_languages.xml
@@ -172,35 +172,6 @@
 					description="COM_MODULES_FIELD_MODULECLASS_SFX_DESC"
 					rows="3"
 				/>
-
-				<field
-					name="cache"
-					type="list"
-					label="COM_MODULES_FIELD_CACHING_LABEL"
-					description="MOD_LANGUAGES_FIELD_CACHING_DESC"
-					default="0"
-					filter="integer"
-					>
-					<option value="1">JGLOBAL_USE_GLOBAL</option>
-					<option value="0">COM_MODULES_FIELD_VALUE_NOCACHING</option>
-				</field>
-
-				<field
-					name="cache_time"
-					type="number"
-					label="COM_MODULES_FIELD_CACHE_TIME_LABEL"
-					description="COM_MODULES_FIELD_CACHE_TIME_DESC"
-					default="900"
-					filter="integer"
-				/>
-
-				<field
-					name="cachemode"
-					type="hidden"
-					default="itemid"
-					>
-					<option	value="itemid"></option>
-				</field>
 			</fieldset>
 		</fields>
 	</config>


### PR DESCRIPTION
 Pull Request for Issue https://github.com/joomla/joomla-cms/pull/23166#issuecomment-441553945

### Summary of Changes
removed the unsed cache fields


### Testing Instructions
the module works as before

p.s 
cc : @infograf768 