### PR TITLE
Fix a few sql errors in Article List on SQL Server

### DIFF
--- a/administrator/components/com_content/models/articles.php
+++ b/administrator/components/com_content/models/articles.php
@@ -210,7 +210,7 @@ class ContentModelArticles extends JModelList
 			->join('LEFT', '#__categories AS c ON c.id = a.catid');
 
 		// Join over the parent categories.
-		$query->select('parent.title AS parent_category_title, parent.id AS parent_category_id, 
+		$query->select('parent.title AS parent_category_title, parent.id AS parent_category_id,
 								parent.created_user_id AS parent_category_uid, parent.level AS parent_category_level')
 			->join('LEFT', '#__categories AS parent ON parent.id = c.parent_id');
 
@@ -224,7 +224,7 @@ class ContentModelArticles extends JModelList
 		if (JPluginHelper::isEnabled('content', 'vote'))
 		{
 			$assogroup .= ', v.rating_sum, v.rating_count';
-			$query->select('COALESCE(NULLIF(ROUND(v.rating_sum  / v.rating_count, 0), 0), 0) AS rating, 
+			$query->select('COALESCE(NULLIF(ROUND(v.rating_sum  / v.rating_count, 0), 0), 0) AS rating,
 					COALESCE(NULLIF(v.rating_count, 0), 0) as rating_count')
 				->join('LEFT', '#__content_rating AS v ON a.id = v.content_id');
 		}
@@ -232,9 +232,9 @@ class ContentModelArticles extends JModelList
 		// Join over the associations.
 		if (JLanguageAssociations::isEnabled())
 		{
-			$query->select('COUNT(asso2.id)>1 as association')
+			$query->select('CASE WHEN COUNT(asso2.id)>1 THEN 1 ELSE 0 END as association')
 				->join('LEFT', '#__associations AS asso ON asso.id = a.id AND asso.context=' . $db->quote('com_content.item'))
-				->join('LEFT', '#__associations AS asso2 ON asso2.key = asso.key')
+				->join('LEFT', '#__associations AS asso2 ON ' . $db->quoteName('asso2.key') . ' = ' . $db->quoteName('asso.key'))
 				->group($assogroup);
 		}
 

--- a/installation/sql/sqlazure/joomla.sql
+++ b/installation/sql/sqlazure/joomla.sql
@@ -98,7 +98,7 @@ INSERT INTO "#__assets" ("id", "parent_id", "lft", "rgt", "level", "name", "titl
 (55, 18, 72, 73, 2, 'com_modules.module.87', 'Sample Data', '{}'),
 (56, 1, 109, 110, 1, 'com_privacy', 'com_privacy', '{}'),
 (57, 1, 111, 112, 1, 'com_actionlogs', 'com_actionlogs', '{}'),
-(58, 18, 74, 75, 2, 'com_modules.module.88', 'Latest Actions', '{}');
+(58, 18, 74, 75, 2, 'com_modules.module.88', 'Latest Actions', '{}'),
 (59, 18, 76, 77, 2, 'com_modules.module.89', 'Privacy Dashboard', '{}');
 
 SET IDENTITY_INSERT "#__assets" OFF;

--- a/libraries/joomla/database/query/sqlsrv.php
+++ b/libraries/joomla/database/query/sqlsrv.php
@@ -685,7 +685,7 @@ class JDatabaseQuerySqlsrv extends JDatabaseQuery implements JDatabaseQueryLimit
 			if ($i == 0 && stripos(' DISTINCT ALL ', " $column[0] ") !== false)
 			{
 				// This words are reserved, they are not column names
-				array_shift($columns[$i]);
+				array_shift($column);
 				$size--;
 			}
 
@@ -810,6 +810,14 @@ class JDatabaseQuerySqlsrv extends JDatabaseQuery implements JDatabaseQueryLimit
 			if ($size === 0)
 			{
 				continue;
+			}
+
+			if ($i == 0 && stripos(' DISTINCT ALL ', " $column[0] ") !== false)
+			{
+				// This words are reserved, they are not column names
+				array_shift($selectColumns[0]);
+				array_shift($column);
+				$size--;
 			}
 
 			if ($size > 2 && $column[$size - 2] === 'AS')

--- a/libraries/joomla/database/query/sqlsrv.php
+++ b/libraries/joomla/database/query/sqlsrv.php
@@ -233,7 +233,7 @@ class JDatabaseQuerySqlsrv extends JDatabaseQuery implements JDatabaseQueryLimit
 	 *
 	 * Ensure that the value is properly quoted before passing to the method.
 	 *
-	 * @param   string  $value  The value to cast as a char.	 
+	 * @param   string  $value  The value to cast as a char.
 	 *
 	 * @param   string  $len    The lenght of the char.
 	 *
@@ -244,7 +244,7 @@ class JDatabaseQuerySqlsrv extends JDatabaseQuery implements JDatabaseQueryLimit
 	public function castAsChar($value, $len = null)
 	{
 		if (!$len)
-		{			
+		{
 			return 'CAST(' . $value . ' as NVARCHAR(30))';
 		}
 		else
@@ -685,7 +685,7 @@ class JDatabaseQuerySqlsrv extends JDatabaseQuery implements JDatabaseQueryLimit
 			if ($i == 0 && stripos(' DISTINCT ALL ', " $column[0] ") !== false)
 			{
 				// This words are reserved, they are not column names
-				array_shift($column);
+				array_shift($columns[$i]);
 				$size--;
 			}
 

--- a/libraries/joomla/database/query/sqlsrv.php
+++ b/libraries/joomla/database/query/sqlsrv.php
@@ -814,7 +814,7 @@ class JDatabaseQuerySqlsrv extends JDatabaseQuery implements JDatabaseQueryLimit
 
 			if ($i == 0 && stripos(' DISTINCT ALL ', " $column[0] ") !== false)
 			{
-				// This words are reserved, they are not column names
+				// These words are reserved, they are not column names
 				array_shift($selectColumns[0]);
 				array_shift($column);
 				$size--;

--- a/libraries/src/Language/Associations.php
+++ b/libraries/src/Language/Associations.php
@@ -56,7 +56,7 @@ class Associations
 				->select($db->quoteName('c2.language'))
 				->from($db->quoteName($tablename, 'c'))
 				->join('INNER', $db->quoteName('#__associations', 'a') . ' ON a.id = c.' . $db->quoteName($pk) . ' AND a.context=' . $db->quote($context))
-				->join('INNER', $db->quoteName('#__associations', 'a2') . ' ON a.key = a2.key')
+				->join('INNER', $db->quoteName('#__associations', 'a2') . ' ON ' . $db->quoteName('a.key') . ' = ' . $db->quoteName('a2.key'))
 				->join('INNER', $db->quoteName($tablename, 'c2') . ' ON a2.id = c2.' . $db->quoteName($pk) . $categoriesExtraSql);
 
 			// Use alias field ?


### PR DESCRIPTION
### Summary of Changes

There is a few errors in sql query for Sql Server:
- the keyword `KEY` is reserved and has to be quoted: https://docs.microsoft.com/en-us/sql/t-sql/language-elements/reserved-keywords-transact-sql?view=sql-server-2017
- `COUNT(asso2.id)>1 as association` is incorrect. The Sql server does not accept such syntax. I changed it to `CASE WHEN COUNT(asso2.id)>1 THEN 1 ELSE 0 END as association` 
- replace the semicolon with a comma in installation file for SQL Server
- fix `JDatabaseQuerySqlsrv` method to correctly remove the `DISTINCT` keyword from column names in `GROUP BY` statement.

### Testing Instructions
Test the list of articles on MySql on a multilingual website.

Sql Server may still be broken due to an additional error in SQL queries to the the session table.
```
[Microsoft][ODBC Driver 17 for SQL Server][SQL Server]Implicit conversion from data type nvarchar to varbinary is not allowed. Use the CONVERT function to run this query
```

### Expected result
Article List still works on mysql.


### Actual result
Article List on frontend / backend  does not work on SQL Server. (multilingual)


### Documentation Changes Required
No
