### PR TITLE
Multilingual=> mod_language: taking off url lang code in source when set such in language filter plugin

### DIFF
--- a/modules/mod_languages/helper.php
+++ b/modules/mod_languages/helper.php
@@ -168,7 +168,7 @@ abstract class ModLanguagesHelper
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public static function setLanguageCookie($languageCode)
+	private static function setLanguageCookie($languageCode)
 	{
 		$app    = JFactory::getApplication();
 		$plugin = \JPluginHelper::getPlugin('system', 'languagefilter');

--- a/modules/mod_languages/helper.php
+++ b/modules/mod_languages/helper.php
@@ -150,8 +150,7 @@ abstract class ModLanguagesHelper
 			// Remove the sef from the default language if "Remove URL Language Code" is on
 			if ($remove_default_prefix && isset($languages[$default_lang]->link))
 			{
-				$languages[$default_lang]->link
-								= preg_replace('|/' . $languages[$default_lang]->sef . '/|', '/', $languages[$default_lang]->link, 1);
+				$languages[$default_lang]->link = preg_replace('|/' . $languages[$default_lang]->sef . '/|', '/', $languages[$default_lang]->link, 1);
 
 				self::setLanguageCookie($default_lang);
 			}

--- a/modules/mod_languages/helper.php
+++ b/modules/mod_languages/helper.php
@@ -151,7 +151,7 @@ abstract class ModLanguagesHelper
 			if ($remove_default_prefix && isset($languages[$default_lang]->link))
 			{
 				$languages[$default_lang]->link
-					= preg_replace('|/' . $languages[$default_lang]->sef . '/|', '/', $languages[$default_lang]->link, 1);
+								= preg_replace('|/' . $languages[$default_lang]->sef . '/|', '/', $languages[$default_lang]->link, 1);
 
 				self::setLanguageCookie($default_lang);
 			}


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/23144 (That issue has a wrong title)

### Summary of Changes
When "Remove URL Language Code" is set to ON in the language filter plugin, the url produced for the default site language does not include the url language code.

Example on a site with fr-FR, en-GB and it-IT.
en-GB is set as default site language

Resulting urls will contain

`mysite.com/` for en-GB 
`mysite.com/fr/` for fr-FR
`mysite.com/it/` for it-IT

Before this patch, the source of the page was still showing the `/en/` url language code for the part of the code concerning mod_languages flag/name link.
This has no effect on the final url but it may have some effects for crawlers as they look at all urls in a page source and therefore follow the redirect.

This patch modifies the code for the switcher in order to take off the url language code in source when necessary.


### Testing Instructions

Create a multilingual site with associations. 
Make sure you set "Remove URL Language Code" to ON in the Language Filter system plugin
Display frontend, hover the flag/name of the site default language in the language switcher module.
This on the home page as well as some associated pages.

### Before patch
for the home (but would be similar for other pages)
![switcher-before](https://user-images.githubusercontent.com/869724/49072869-7d0b1e00-f231-11e8-80eb-e5828976a30d.gif)


### After patch
![switcher](https://user-images.githubusercontent.com/869724/49072335-47b20080-f230-11e8-9040-9b713480d738.gif)

@Giuse69 




### Documentation Changes Required

