### PR TITLE
Re-add generic CSS classes in subforms.

### DIFF
--- a/layouts/joomla/form/field/subform/repeatable-table.php
+++ b/layouts/joomla/form/field/subform/repeatable-table.php
@@ -87,7 +87,7 @@ else
 								<?php if (!empty($buttons['add'])) : ?>
 									<div class="btn-group">
 										<a
-											class="btn btn-mini button btn-success group-add-<?php echo $unique_subform_id; ?>"
+											class="btn btn-mini button btn-success group-add group-add-<?php echo $unique_subform_id; ?>"
 											aria-label="<?php echo JText::_('JGLOBAL_FIELD_ADD'); ?>"
 										>
 											<span class="icon-plus" aria-hidden="true"></span>

--- a/layouts/joomla/form/field/subform/repeatable-table/section-byfieldsets.php
+++ b/layouts/joomla/form/field/subform/repeatable-table/section-byfieldsets.php
@@ -36,17 +36,17 @@ extract($displayData);
 	<td>
 		<div class="btn-group">
 			<?php if (!empty($buttons['add'])) : ?>
-				<a class="btn btn-mini button btn-success group-add-<?php echo $unique_subform_id; ?>" aria-label="<?php echo JText::_('JGLOBAL_FIELD_ADD'); ?>">
+				<a class="btn btn-mini button btn-success group-add group-add-<?php echo $unique_subform_id; ?>" aria-label="<?php echo JText::_('JGLOBAL_FIELD_ADD'); ?>">
 					<span class="icon-plus" aria-hidden="true"></span>
 				</a>
 			<?php endif; ?>
 			<?php if (!empty($buttons['remove'])) : ?>
-				<a class="btn btn-mini button btn-danger group-remove-<?php echo $unique_subform_id; ?>" aria-label="<?php echo JText::_('JGLOBAL_FIELD_REMOVE'); ?>">
+				<a class="btn btn-mini button btn-danger group-remove group-remove-<?php echo $unique_subform_id; ?>" aria-label="<?php echo JText::_('JGLOBAL_FIELD_REMOVE'); ?>">
 					<span class="icon-minus" aria-hidden="true"></span>
 				</a>
 			<?php endif; ?>
 			<?php if (!empty($buttons['move'])) : ?>
-				<a class="btn btn-mini button btn-primary group-move-<?php echo $unique_subform_id; ?>" aria-label="<?php echo JText::_('JGLOBAL_FIELD_MOVE'); ?>">
+				<a class="btn btn-mini button btn-primary group-move group-move-<?php echo $unique_subform_id; ?>" aria-label="<?php echo JText::_('JGLOBAL_FIELD_MOVE'); ?>">
 					<span class="icon-move" aria-hidden="true"></span>
 				</a>
 			<?php endif; ?>

--- a/layouts/joomla/form/field/subform/repeatable-table/section.php
+++ b/layouts/joomla/form/field/subform/repeatable-table/section.php
@@ -35,17 +35,17 @@ extract($displayData);
 	<td>
 		<div class="btn-group">
 			<?php if (!empty($buttons['add'])) : ?>
-				<a class="btn btn-mini button btn-success group-add-<?php echo $unique_subform_id; ?>" aria-label="<?php echo JText::_('JGLOBAL_FIELD_ADD'); ?>">
+				<a class="btn btn-mini button btn-success group-add group-add-<?php echo $unique_subform_id; ?>" aria-label="<?php echo JText::_('JGLOBAL_FIELD_ADD'); ?>">
 					<span class="icon-plus" aria-hidden="true"></span>
 				</a>
 			<?php endif; ?>
 			<?php if (!empty($buttons['remove'])) : ?>
-				<a class="btn btn-mini button btn-danger group-remove-<?php echo $unique_subform_id; ?>" aria-label="<?php echo JText::_('JGLOBAL_FIELD_REMOVE'); ?>">
+				<a class="btn btn-mini button btn-danger group-remove group-remove-<?php echo $unique_subform_id; ?>" aria-label="<?php echo JText::_('JGLOBAL_FIELD_REMOVE'); ?>">
 					<span class="icon-minus" aria-hidden="true"></span>
 				</a>
 			<?php endif; ?>
 			<?php if (!empty($buttons['move'])) : ?>
-				<a class="btn btn-mini button btn-primary group-move-<?php echo $unique_subform_id; ?>" aria-label="<?php echo JText::_('JGLOBAL_FIELD_MOVE'); ?>">
+				<a class="btn btn-mini button btn-primary group-move group-move-<?php echo $unique_subform_id; ?>" aria-label="<?php echo JText::_('JGLOBAL_FIELD_MOVE'); ?>">
 					<span class="icon-move" aria-hidden="true"></span>
 				</a>
 			<?php endif; ?>

--- a/layouts/joomla/form/field/subform/repeatable.php
+++ b/layouts/joomla/form/field/subform/repeatable.php
@@ -49,7 +49,7 @@ $sublayout = empty($groupByFieldset) ? 'section' : 'section-byfieldsets';
 			<?php if (!empty($buttons['add'])) : ?>
 			<div class="btn-toolbar">
 				<div class="btn-group">
-					<a class="btn btn-mini button btn-success group-add-<?php echo $unique_subform_id; ?>" aria-label="<?php echo JText::_('JGLOBAL_FIELD_ADD'); ?>">
+					<a class="btn btn-mini button btn-success group-add group-add-<?php echo $unique_subform_id; ?>" aria-label="<?php echo JText::_('JGLOBAL_FIELD_ADD'); ?>">
 						<span class="icon-plus" aria-hidden="true"></span>
 					</a>
 				</div>

--- a/layouts/joomla/form/field/subform/repeatable/section-byfieldsets.php
+++ b/layouts/joomla/form/field/subform/repeatable/section-byfieldsets.php
@@ -29,17 +29,17 @@ extract($displayData);
 	<div class="btn-toolbar text-right">
 		<div class="btn-group">
 			<?php if (!empty($buttons['add'])) : ?>
-				<a class="btn btn-mini button btn-success group-add-<?php echo $unique_subform_id; ?>" aria-label="<?php echo JText::_('JGLOBAL_FIELD_ADD'); ?>">
+				<a class="btn btn-mini button btn-success group-add group-add-<?php echo $unique_subform_id; ?>" aria-label="<?php echo JText::_('JGLOBAL_FIELD_ADD'); ?>">
 					<span class="icon-plus" aria-hidden="true"></span>
 				</a>
 			<?php endif; ?>
 			<?php if (!empty($buttons['remove'])) : ?>
-				<a class="btn btn-mini button btn-danger group-remove-<?php echo $unique_subform_id; ?>" aria-label="<?php echo JText::_('JGLOBAL_FIELD_REMOVE'); ?>">
+				<a class="btn btn-mini button btn-danger group-remove group-remove-<?php echo $unique_subform_id; ?>" aria-label="<?php echo JText::_('JGLOBAL_FIELD_REMOVE'); ?>">
 					<span class="icon-minus" aria-hidden="true"></span>
 				</a>
 			<?php endif; ?>
 			<?php if (!empty($buttons['move'])) : ?>
-				<a class="btn btn-mini button btn-primary group-move-<?php echo $unique_subform_id; ?>" aria-label="<?php echo JText::_('JGLOBAL_FIELD_MOVE'); ?>">
+				<a class="btn btn-mini button btn-primary group-move group-move-<?php echo $unique_subform_id; ?>" aria-label="<?php echo JText::_('JGLOBAL_FIELD_MOVE'); ?>">
 					<span class="icon-move" aria-hidden="true"></span>
 				</a>
 			<?php endif; ?>

--- a/layouts/joomla/form/field/subform/repeatable/section.php
+++ b/layouts/joomla/form/field/subform/repeatable/section.php
@@ -30,17 +30,17 @@ extract($displayData);
 	<div class="btn-toolbar text-right">
 		<div class="btn-group">
 			<?php if (!empty($buttons['add'])) : ?>
-				<a class="btn btn-mini button btn-success group-add-<?php echo $unique_subform_id; ?>" aria-label="<?php echo JText::_('JGLOBAL_FIELD_ADD'); ?>">
+				<a class="btn btn-mini button btn-success group-add group-add-<?php echo $unique_subform_id; ?>" aria-label="<?php echo JText::_('JGLOBAL_FIELD_ADD'); ?>">
 					<span class="icon-plus" aria-hidden="true"></span>
 				</a>
 			<?php endif; ?>
 			<?php if (!empty($buttons['remove'])) : ?>
-				<a class="btn btn-mini button btn-danger group-remove-<?php echo $unique_subform_id; ?>" aria-label="<?php echo JText::_('JGLOBAL_FIELD_REMOVE'); ?>">
+				<a class="btn btn-mini button btn-danger group-remove group-remove-<?php echo $unique_subform_id; ?>" aria-label="<?php echo JText::_('JGLOBAL_FIELD_REMOVE'); ?>">
 					<span class="icon-minus" aria-hidden="true"></span>
 				</a>
 			<?php endif; ?>
 			<?php if (!empty($buttons['move'])) : ?>
-				<a class="btn btn-mini button btn-primary group-move-<?php echo $unique_subform_id; ?>" aria-label="<?php echo JText::_('JGLOBAL_FIELD_MOVE'); ?>">
+				<a class="btn btn-mini button btn-primary group-move group-move-<?php echo $unique_subform_id; ?>" aria-label="<?php echo JText::_('JGLOBAL_FIELD_MOVE'); ?>">
 					<span class="icon-move" aria-hidden="true"></span>
 				</a>
 			<?php endif; ?>


### PR DESCRIPTION
### Summary of Changes
When support for nested subforms was added in https://github.com/joomla/joomla-cms/pull/17552  (Joomla 3.9.0) the generic CSS classes group-add, group-remove and group-move were replaced by subform-specific classes which include the subform id.  Unfortunately, the absence of the generic classes makes it harder to style these elements, so this PR adds the generic classes back in.

### Testing Instructions
Set up a subform so you check the markup.  A good example can be found in https://github.com/joomla/joomla-cms/pull/17552

In your browser, view source or use dev tools to check that the generic group-add, group-remove and group-move classes are now included as well as the group-add-xx, group-remove-xx and group-move-xx classes (where xx is a subform id).

### Expected result
Generic and subform-specific classes should both be available.

### Actual result
Only subform-specific classes are available.

### Documentation Changes Required
None.
