### PR TITLE
[FIX 3.9.1] Add column alias com_users Notes (Published state broken)

### DIFF
--- a/administrator/components/com_users/tables/note.php
+++ b/administrator/components/com_users/tables/note.php
@@ -29,6 +29,8 @@ class UsersTableNote extends JTable
 	{
 		parent::__construct('#__user_notes', 'id', $db);
 
+		$this->setColumnAlias('published', 'state');
+
 		JTableObserverContenthistory::createObserver($this, array('typeAlias' => 'com_users.note'));
 	}
 


### PR DESCRIPTION
Pull Request for Issue with User Note published state broken in 3.9.1
Related to PR #22851

### Summary of Changes
- Add column alias


### Testing Instructions
- Test to change published state for one or multiple User Notes with button and checkbox.
- Apply this PR and test again.


### Expected result
- Published state is changed
![capture d ecran 2018-11-28 a 17 06 42](https://user-images.githubusercontent.com/2385058/49164760-09036f80-f330-11e8-96a9-db0230719136.png)


### Actual result
- No effect
![capture d ecran 2018-11-28 a 17 06 12](https://user-images.githubusercontent.com/2385058/49164766-0f91e700-f330-11e8-9497-2402294eb165.png)


