### PR TITLE
[FIX 3.9.1] Add column alias com_messages (Read state broken)

### DIFF
--- a/administrator/components/com_messages/tables/message.php
+++ b/administrator/components/com_messages/tables/message.php
@@ -28,6 +28,8 @@ class MessagesTableMessage extends JTable
 	public function __construct(&$db)
 	{
 		parent::__construct('#__messages', 'message_id', $db);
+
+		$this->setColumnAlias('published', 'state');
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue with Messages Read state broken in 3.9.1
Related to PR #22851

### Summary of Changes
- Add column alias


### Testing Instructions
- Test to change Read state for one or multiple messages with button and checkbox.
- Apply this PR and test again.


### Expected result
- Read state is changed
![capture d ecran 2018-11-28 a 17 10 08](https://user-images.githubusercontent.com/2385058/49165310-2a189000-f331-11e8-8ae6-b52b968d3b67.png)


### Actual result
- No effect
![capture d ecran 2018-11-28 a 17 10 57](https://user-images.githubusercontent.com/2385058/49165330-343a8e80-f331-11e8-95b0-22fb85960c50.png)



