### PR TITLE
[FIX 3.9.1] Add column alias com_banners Clients (Published state broken)

### DIFF
--- a/administrator/components/com_banners/tables/client.php
+++ b/administrator/components/com_banners/tables/client.php
@@ -30,6 +30,8 @@ class BannersTableClient extends JTable
 		$this->checked_out_time = $db->getNullDate();
 		parent::__construct('#__banner_clients', 'id', $db);
 
+		$this->setColumnAlias('published', 'state');
+
 		JTableObserverContenthistory::createObserver($this, array('typeAlias' => 'com_banners.client'));
 	}
 


### PR DESCRIPTION
Pull Request for Issue with com_banners Clients published state broken in 3.9.1
Related to PR #22851

### Summary of Changes
- Add column alias


### Testing Instructions
- Test to change published state for one or multiple Clients with button and checkbox.
- Apply this PR and test again.


### Expected result
- Published state is changed
![capture d ecran 2018-11-28 a 17 16 29](https://user-images.githubusercontent.com/2385058/49165605-dce8ee00-f331-11e8-9849-5332d56d1c21.png)



### Actual result
- No effect
![capture d ecran 2018-11-28 a 17 16 59](https://user-images.githubusercontent.com/2385058/49165625-e83c1980-f331-11e8-846c-a57f57a0a593.png)



