### PR TITLE
[FIX 3.9.1] Add column alias com_finder Search Filter (Published state broken)

### DIFF
--- a/administrator/components/com_finder/tables/filter.php
+++ b/administrator/components/com_finder/tables/filter.php
@@ -29,6 +29,8 @@ class FinderTableFilter extends JTable
 	public function __construct(&$db)
 	{
 		parent::__construct('#__finder_filters', 'filter_id', $db);
+
+		$this->setColumnAlias('published', 'state');
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue with com_finder Smart Search Filters published state broken in 3.9.1
Related to PR #22851

### Summary of Changes
- Add column alias


### Testing Instructions
- Add Search filters and test to change published state for one or multiple Filters with button and checkbox.
- Apply this PR and test again.


### Expected result
- Published state is changed
![capture d ecran 2018-11-28 a 17 32 17](https://user-images.githubusercontent.com/2385058/49166621-0a369b80-f334-11e8-9309-5283b37c1f32.png)




### Actual result
- No effect
![capture d ecran 2018-11-28 a 17 32 38](https://user-images.githubusercontent.com/2385058/49166636-13276d00-f334-11e8-9a4d-e4cda252e6cf.png)


