### PR TITLE
Revert "[Batch] Change State: pass only affected items to table

### DIFF
--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -1061,21 +1061,7 @@ abstract class AdminModel extends FormModel
 
 					return false;
 				}
-
-				// Prune items that are already at the given state
-				if ($table->get($table->getColumnAlias('published'), $value) == $value)
-				{
-					unset($pks[$i]);
-
-					continue;
-				}
 			}
-		}
-
-		// Check if there are items to change
-		if (!count($pks))
-		{
-			return true;
 		}
 
 		// Attempt to change the state of the records.


### PR DESCRIPTION
Pull Request for #23194, #23193, #23192, #23191 and probably dozens of support requests on 3rd party extensions where unpublish doesn't work anymore in the back end.

### Summary of Changes
#22851 fixed bulk state changes but in a none BC way. After talking with @dneukirchen it is better to revert this change and apply it on joomla 4 as it is clearly a BC break.

### Testing Instructions
- Open banners in the back end
- Create a new client and click save and close
- On the client list, click on the publish button beside the new client

### Expected result
Client is unpublished.

### Actual result
Client is still published.