### PR TITLE
Fix state not possible to be changed to unpublish, when Model's (J)Table does not set correct alias for 'published' column

### DIFF
--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -1062,8 +1062,13 @@ abstract class AdminModel extends FormModel
 					return false;
 				}
 
-				// Prune items that are already at the given state
-				if ($table->get($table->getColumnAlias('published'), $value) == $value)
+				/**
+				 * Prune items that are already at the given state.  Note: Only models whose table correctly
+				 * sets 'published' column alias (if different than published) will benefit from this
+				 */
+				$published_col = $table->getColumnAlias('published');
+
+				if (property_exists($table, $published_col) && $table->get($published_col, $value) == $value)
 				{
 					unset($pks[$i]);
 

--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -1068,7 +1068,7 @@ abstract class AdminModel extends FormModel
 				 */
 				$publishedColumnName = $table->getColumnAlias('published');
 
-				if (property_exists($table, $published_col) && $table->get($published_col, $value) == $value)
+				if (property_exists($table, $publishedColumnName) && $table->get($publishedColumnName, $value) == $value)
 				{
 					unset($pks[$i]);
 

--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -1066,7 +1066,7 @@ abstract class AdminModel extends FormModel
 				 * Prune items that are already at the given state.  Note: Only models whose table correctly
 				 * sets 'published' column alias (if different than published) will benefit from this
 				 */
-				$published_col = $table->getColumnAlias('published');
+				$publishedColumnName = $table->getColumnAlias('published');
 
 				if (property_exists($table, $published_col) && $table->get($published_col, $value) == $value)
 				{


### PR DESCRIPTION
Pull Request for #23194, #23193, #23192, #23191, #23197 and quoting description from PR #23197

> from probably dozens of support requests on 3rd party extensions where unpublish doesn't work anymore in the back end.

### Summary of Changes
Only If model's Table correct sets the column alias of 'published' column
only then exclude the records having already the new state from the array of records to be changed


### Testing Instructions
Try to unpublish records of type
com_users Notes 
com_messages 
com_banners

and any other that has a state column with name different than 'published' but Model's Table does not set the 'published' column alias correctly

### Expected result
records are unpublished

### Actual result
records can not be unpublished


### Documentation Changes Required
Developer should always set 'published' column alias at Model's Table  as a good practice, if different than default
