### PR TITLE
Use an editor for custom banner code

### DIFF
--- a/administrator/components/com_banners/models/forms/banner.xml
+++ b/administrator/components/com_banners/models/forms/banner.xml
@@ -108,7 +108,8 @@
 
 		<field
 			name="custombannercode"
-			type="textarea"
+			type="editor"
+			editor="codemirror|none"
 			label="COM_BANNERS_FIELD_CUSTOMCODE_LABEL"
 			description="COM_BANNERS_FIELD_CUSTOMCODE_DESC"
 			rows="3"


### PR DESCRIPTION
Custom banner code should be html. It's inhumane to ask people to write it into a `textarea`. Use Codemirror.

Pull Request for Issue # .

### Summary of Changes

Changed field type from `textarea` to `editor`, specifically Codemirror.

### Testing Instructions

Edit/Create code-type banners. 

### Expected result

Editing the code should be a lot more comfortable than before. Other than that, no change. 

### Actual result

As expected

### Documentation Changes Required

Nope