### PR TITLE
[ContenttypeField] Fix notice when using custom options

### DIFF
--- a/libraries/src/Form/Field/ContenttypeField.php
+++ b/libraries/src/Form/Field/ContenttypeField.php
@@ -84,9 +84,6 @@ class ContenttypeField extends \JFormFieldList
 			return array();
 		}
 
-		// Merge any additional options in the XML definition.
-		$options = array_merge(parent::getOptions(), $options);
-
 		foreach ($options as $option)
 		{
 			// Make up the string from the component sys.ini file
@@ -105,6 +102,9 @@ class ContenttypeField extends \JFormFieldList
 				$option->text = \JText::_($option->string);
 			}
 		}
+
+		// Merge any additional options in the XML definition.
+		$options = array_merge(parent::getOptions(), $options);
 
 		return $options;
 	}


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Fixes a notice when adding custom options in XML form.

### Testing Instructions

Add `contenttype` field with custom option to a form, e.g.:

```
<field
	name="type"
	type="contenttype"
	label="Content Type"
	>
	<option value="0">JNONE</option>
</field>
```

### Expected result

No notice.

### Actual result


```
Notice: Undefined property: stdClass::$alias in /home/libraries/src/Form/Field/ContenttypeField.php on line 93
```

### Documentation Changes Required
No.
