### PR TITLE
basic support for tags in com_banners

### DIFF
--- a/administrator/components/com_banners/models/banner.php
+++ b/administrator/components/com_banners/models/banner.php
@@ -265,6 +265,25 @@ class BannersModelBanner extends JModelAdmin
 	}
 
 	/**
+	 * Method to get a single record.
+	 *
+	 * @param   integer  $pk  The id of the primary key.
+	 *
+	 * @return  mixed  Object on success, false on failure.
+	 */
+	public function getItem($pk = null)
+	{
+		if ($item = parent::getItem($pk)) {
+			if (!empty($item->id)) {
+				$item->tags = new JHelperTags;
+				$item->tags->getTagIds($item->id, 'com_banners.banner');
+			}
+		}
+
+		return $item;
+	}
+
+	/**
 	 * Method to stick records.
 	 *
 	 * @param   array    $pks    The ids of the items to publish.

--- a/administrator/components/com_banners/models/forms/banner.xml
+++ b/administrator/components/com_banners/models/forms/banner.xml
@@ -43,6 +43,15 @@
 		/>
 
 		<field
+			name="tags"
+			type="tag"
+			label="JTAG"
+			description="JTAG_DESC"
+			class="span12"
+			multiple="true"
+		/>
+
+		<field
 			name="state"
 			type="list"
 			label="JSTATUS"

--- a/administrator/components/com_banners/tables/banner.php
+++ b/administrator/components/com_banners/tables/banner.php
@@ -30,6 +30,7 @@ class BannersTableBanner extends JTable
 	{
 		parent::__construct('#__banners', 'id', $db);
 
+		JTableObserverTags::createObserver($this, array('typeAlias' => 'com_banners.banner'));
 		JTableObserverContenthistory::createObserver($this, array('typeAlias' => 'com_banners.banner'));
 
 		$this->created = JFactory::getDate()->toSql();


### PR DESCRIPTION

### Summary of Changes

Adds basic support for tagging banners. The banner form will have a tags field which should work exactly like the tags field for other content-types.

It may be necessary to add a few more tag-related features to this (searching, etc.) before merging it but I'm putting in the PR now to hopefully get some feedback. I don't see any harm in adding tags to banners and there can surely be some benefits to it. However, since banners has been without tag support until now, I wonder if there could have been some reason other than simple oversight or disinterest. So I want to know, is this or is this not doable? Are there any potential problems to be aware of? 

If it looks like there's no issue, I'll go ahead and complete this PR. 

### Testing Instructions

Create or edit a banner. Add or remove tags. Save it.

### Expected result

Tags should be saved along with your banner.

### Actual result

Works for me.

### Documentation Changes Required

Maybe?