### PR TITLE
[4.0] RTL: Correcting broken installation

### DIFF
--- a/installation/template/scss/template-rtl.scss
+++ b/installation/template/scss/template-rtl.scss
@@ -89,3 +89,12 @@ textarea.noResize {
 .j-install-last-step .fa {
   display: inline;
 }
+
+.j-install-step-header span {
+  margin-left: 5px;
+  margin-right: auto; }
+
+#jform_db_prefix {
+  direction: ltr;
+  text-align: right;
+}


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/23164

### Summary of Changes
The db_prefix input has to be proposed as ltr and text align to the right to be able to install Joomla when choosing an RTL language.
Otherwise we get an error

Plus a small correction of margins for the headers

### Testing Instructions
See https://github.com/joomla/joomla-cms/issues/23164 to use Persian
OR just modify installation/language/en-GB.xml to rtl 1

### Before patch
Using en-GB.xml set as rtl

<img width="683" alt="screen shot 2018-11-30 at 10 53 17" src="https://user-images.githubusercontent.com/869724/49282035-67466480-f48e-11e8-908d-6e4f2e680d83.png">

### After patch
Joomla installs normally

@wilsonge 