### PR TITLE
Fix dateadd function for MS SQL Server

### DIFF
--- a/libraries/joomla/database/query/sqlsrv.php
+++ b/libraries/joomla/database/query/sqlsrv.php
@@ -335,7 +335,7 @@ class JDatabaseQuerySqlsrv extends JDatabaseQuery implements JDatabaseQueryLimit
 	 */
 	public function dateAdd($date, $interval, $datePart)
 	{
-		return "DATEADD('" . $datePart . "', '" . $interval . "', '" . $date . "'" . ')';
+		return "DATEADD(" . $datePart . ", " . $interval . ", " . $date . ')';
 	}
 
 	/**

--- a/libraries/joomla/database/query/sqlsrv.php
+++ b/libraries/joomla/database/query/sqlsrv.php
@@ -335,7 +335,7 @@ class JDatabaseQuerySqlsrv extends JDatabaseQuery implements JDatabaseQueryLimit
 	 */
 	public function dateAdd($date, $interval, $datePart)
 	{
-		return "DATEADD(" . $datePart . ", " . $interval . ", " . $date . ')';
+		return 'DATEADD(' . $datePart . ', ' . $interval . ', ' . $date . ')';
 	}
 
 	/**

--- a/tests/unit/suites/database/driver/sqlsrv/JDatabaseQuerySqlsrvTest.php
+++ b/tests/unit/suites/database/driver/sqlsrv/JDatabaseQuerySqlsrvTest.php
@@ -74,9 +74,9 @@ class JDatabaseQuerySqlsrvTest extends TestCase
 	{
 		return array(
 			// Elements: date, interval, datepart, expected
-			'Add date'			=> array('2008-12-31', '1', 'day', "DATEADD('day', '1', '2008-12-31')"),
-			'Subtract date'		=> array('2008-12-31', '-1', 'day', "DATEADD('day', '-1', '2008-12-31')"),
-			'Add datetime'		=> array('2008-12-31 23:59:59', '1', 'day', "DATEADD('day', '1', '2008-12-31 23:59:59')"),
+			'Add date'			=> array("'2008-12-31'", '1', 'day', "DATEADD(day, 1, '2008-12-31')"),
+			'Subtract date'		=> array("'2008-12-31'", '-1', 'day', "DATEADD(day, -1, '2008-12-31')"),
+			'Add datetime'		=> array("'2008-12-31 23:59:59'", '1', 'day', "DATEADD(day, 1, '2008-12-31 23:59:59')"),
 		);
 	}
 

--- a/tests/unit/suites/database/driver/sqlsrv/JDatabaseQuerySqlsrvTest.php
+++ b/tests/unit/suites/database/driver/sqlsrv/JDatabaseQuerySqlsrvTest.php
@@ -74,7 +74,7 @@ class JDatabaseQuerySqlsrvTest extends TestCase
 	{
 		return array(
 			// Elements: date, interval, datepart, expected
-			'Add date'			=> array("'2008-12-31'", '1', 'day', "DATEADD(day, 1, '2008-12-31')"),
+			'Add date'		=> array("'2008-12-31'", '1', 'day', "DATEADD(day, 1, '2008-12-31')"),
 			'Subtract date'		=> array("'2008-12-31'", '-1', 'day', "DATEADD(day, -1, '2008-12-31')"),
 			'Add datetime'		=> array("'2008-12-31 23:59:59'", '1', 'day', "DATEADD(day, 1, '2008-12-31 23:59:59')"),
 		);


### PR DESCRIPTION
### Summary of Changes

Fix an error at `/administrator/index.php?option=com_privacy`

```
An error has occurred.

    102 [Microsoft][ODBC Driver 17 for SQL Server][SQL Server]Incorrect syntax near '2018'. 
```

See ~~http://dev.mysql.com/doc/refman/5.1/en/date-and-time-functions.html#function_date-add~~
http://msdn.microsoft.com/en-us/library/ms186819.aspx

The first argument can not be a string (I mean the quoted string), the second must be an integer, the third argument is manually quoted in:

https://github.com/joomla/joomla-cms/blob/fad16e6c7346803801575f234b1fc8a9a8854651/administrator/components/com_privacy/models/requests.php#L185

### Testing Instructions
Code review

### Expected result
Page `/administrator/index.php?option=com_privacy` will start working.

### Actual result
Error

### Documentation Changes Required
No
