### PR TITLE
Fix user session on mssql server and a new $db->quoteBinary() method

### DIFF
--- a/libraries/joomla/database/driver.php
+++ b/libraries/joomla/database/driver.php
@@ -1867,6 +1867,21 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 	}
 
 	/**
+	 * Quotes a binary string to database requirements for use in database queries.
+	 *
+	 * @param   mixed  $data  A binary string to quote.
+	 *
+	 * @return  string  The binary quoted input string.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function quoteBinary($data)
+	{
+		// SQL standard syntax for hexadecimal literals
+		return "X'" . bin2hex($data) . "'";
+	}
+
+	/**
 	 * Wrap an SQL statement identifier name such as column, table or database names in quotes to prevent injection
 	 * risks and reserved word conflicts.
 	 *

--- a/libraries/joomla/database/driver/pgsql.php
+++ b/libraries/joomla/database/driver/pgsql.php
@@ -987,4 +987,18 @@ class JDatabaseDriverPgsql extends JDatabaseDriverPdo
 
 		return $this->execute();
 	}
+
+	/**
+	 * Quotes a binary string to database requirements for use in database queries.
+	 *
+	 * @param   mixed  $data  A binary string to quote.
+	 *
+	 * @return  string  The binary quoted input string.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function quoteBinary($data)
+	{
+		return "decode('" . bin2hex($data) . "', 'hex')";
+	}
 }

--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -1600,4 +1600,18 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 	{
 		return 'CREATE DATABASE ' . $this->quoteName($options->db_name);
 	}
+
+	/**
+	 * Quotes a binary string to database requirements for use in database queries.
+	 *
+	 * @param   mixed  $data  A binary string to quote.
+	 *
+	 * @return  string  The binary quoted input string.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function quoteBinary($data)
+	{
+		return "decode('" . bin2hex($data) . "', 'hex')";
+	}
 }

--- a/libraries/joomla/database/driver/sqlsrv.php
+++ b/libraries/joomla/database/driver/sqlsrv.php
@@ -284,6 +284,21 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 	}
 
 	/**
+	 * Quotes a binary string to database requirements for use in database queries.
+	 *
+	 * @param   mixed  $data  A binary string to quote.
+	 *
+	 * @return  string  The binary quoted input string.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function quoteBinary($data)
+	{
+		// ODBC syntax for hexadecimal literals
+		return '0x' . bin2hex($data);
+	}
+
+	/**
 	 * Determines if the connection to the server is active.
 	 *
 	 * @return  boolean  True if connected to the database engine.

--- a/libraries/joomla/session/storage/database.php
+++ b/libraries/joomla/session/storage/database.php
@@ -38,7 +38,7 @@ class JSessionStorageDatabase extends JSessionStorage
 			$query = $db->getQuery(true)
 				->select($db->quoteName('data'))
 			->from($db->quoteName('#__session'))
-			->where($db->quoteName('session_id') . ' = ' . $db->quote($id));
+			->where($db->quoteName('session_id') . ' = ' . $db->quoteBinary($id));
 
 			$db->setQuery($query);
 
@@ -77,7 +77,7 @@ class JSessionStorageDatabase extends JSessionStorage
 				->update($db->quoteName('#__session'))
 				->set($db->quoteName('data') . ' = ' . $db->quote($data))
 				->set($db->quoteName('time') . ' = ' . time())
-				->where($db->quoteName('session_id') . ' = ' . $db->quote($id));
+				->where($db->quoteName('session_id') . ' = ' . $db->quoteBinary($id));
 
 			// Try to update the session data in the database table.
 			$db->setQuery($query);
@@ -114,7 +114,7 @@ class JSessionStorageDatabase extends JSessionStorage
 		{
 			$query = $db->getQuery(true)
 				->delete($db->quoteName('#__session'))
-				->where($db->quoteName('session_id') . ' = ' . $db->quote($id));
+				->where($db->quoteName('session_id') . ' = ' . $db->quoteBinary($id));
 
 			// Remove a session from the database.
 			$db->setQuery($query);

--- a/libraries/legacy/application/application.php
+++ b/libraries/legacy/application/application.php
@@ -1041,7 +1041,7 @@ class JApplication extends BaseApplication
 		$query = $db->getQuery(true)
 			->select($db->quoteName('session_id'))
 			->from($db->quoteName('#__session'))
-			->where($db->quoteName('session_id') . ' = ' . $db->quote($session->getId()));
+			->where($db->quoteName('session_id') . ' = ' . $db->quoteBinary($session->getId()));
 
 		$db->setQuery($query, 0, 1);
 		$exists = $db->loadResult();

--- a/libraries/src/Session/MetadataManager.php
+++ b/libraries/src/Session/MetadataManager.php
@@ -68,7 +68,7 @@ final class MetadataManager
 		$query = $this->db->getQuery(true)
 			->select($this->db->quoteName('session_id'))
 			->from($this->db->quoteName('#__session'))
-			->where($this->db->quoteName('session_id') . ' = ' . $this->db->quote($session->getId()));
+			->where($this->db->quoteName('session_id') . ' = ' . $this->db->quoteBinary($session->getId()));
 
 		$this->db->setQuery($query, 0, 1);
 		$exists = $this->db->loadResult();
@@ -92,7 +92,7 @@ final class MetadataManager
 		);
 
 		$values = array(
-			$this->db->quote($session->getId()),
+			$this->db->quoteBinary($session->getId()),
 			(int) $user->guest,
 			(int) $time,
 			(int) $user->id,

--- a/plugins/privacy/user/user.php
+++ b/plugins/privacy/user/user.php
@@ -141,7 +141,7 @@ class PlgPrivacyUser extends PrivacyPlugin
 		foreach ($sessionIds as $sessionId)
 		{
 			$store->destroy($sessionId);
-			$quotedIds[] = $this->db->quote($sessionId);
+			$quotedIds[] = $this->db->quoteBinary($sessionId);
 		}
 
 		$this->db->setQuery(

--- a/plugins/user/joomla/joomla.php
+++ b/plugins/user/joomla/joomla.php
@@ -239,7 +239,7 @@ class PlgUserJoomla extends JPlugin
 		// Purge the old session
 		$query = $this->db->getQuery(true)
 			->delete('#__session')
-			->where($this->db->quoteName('session_id') . ' = ' . $this->db->quote($oldSessionId));
+			->where($this->db->quoteName('session_id') . ' = ' . $this->db->quoteBinary($oldSessionId));
 
 		try
 		{


### PR DESCRIPTION
### Summary of Changes

From J3.9 the type of `session_id` column is `varbinary(192)` and it works OK for mysql and PostgreSQL database.

In the case of mssql, this column requires explicitly cast to binary value to work properly.

See https://docs.microsoft.com/en-us/sql/t-sql/data-types/data-type-conversion-database-engine?view=sql-server-2017

### Testing Instructions
Test user session, login. logout, action logs, etc.

Probably no one will test it on mssql server, please test it at least on mysql. 

### Expected result
Joomla works (after installing or updating) on the mssql server.


### Actual result
Joomla does not work (after installing or updating) on the mssql server.


### Documentation Changes Required
Yes. 
A new method `$db->quoteBinary($data)`.