### PR TITLE
[4.0] Joomla update: correcting missing code from #23095

### DIFF
--- a/administrator/components/com_cpanel/View/System/HtmlView.php
+++ b/administrator/components/com_cpanel/View/System/HtmlView.php
@@ -429,6 +429,7 @@ class HtmlView extends BaseHtmlView
 		if ($user->authorise('core.manage', 'com_joomlaupdate'))
 		{
 			$joomlaUpdateModel = $app->bootComponent('com_joomlaupdate')->getMVCFactory()->createModel('Update', 'Administrator', ['ignore_request' => true]);
+			$joomlaUpdateModel->refreshUpdates(true);
 			$joomlaUpdate      = $joomlaUpdateModel->getUpdateInformation();
 			$hasUpdate         = $joomlaUpdate['hasUpdate'] ? $joomlaUpdate['latest'] : '';
 

--- a/build/media_src/plg_quickicon_joomlaupdate/js/jupdatecheck.es6.js
+++ b/build/media_src/plg_quickicon_joomlaupdate/js/jupdatecheck.es6.js
@@ -22,15 +22,14 @@
         const updateInfoList = JSON.parse(response);
 
         if (updateInfoList instanceof Array) {
-          const updateInfo = updateInfoList.shift();
-
-          if (updateInfo.version === options.version) {
+          if (updateInfoList.length === 0) {
             // No updates
             link.classList.add('success');
             linkSpans.forEach((span) => {
               span.innerHTML = Joomla.JText._('PLG_QUICKICON_JOOMLAUPDATE_UPTODATE');
             });
           } else {
+            const updateInfo = updateInfoList.shift();
 
             if (updateInfo.version !== options.version) {
               const messages = {
@@ -52,6 +51,7 @@
                 span.innerHTML = Joomla.JText._('PLG_QUICKICON_JOOMLAUPDATE_UPDATEFOUND').replace('%s', `<span class="badge badge-light"> \u200E ${updateInfo.version}</span>`);
               });
             } else {
+              link.classList.add('success');
               linkSpans.forEach((span) => {
                 span.innerHTML = Joomla.JText._('PLG_QUICKICON_JOOMLAUPDATE_UPTODATE');
               });


### PR DESCRIPTION
### Summary of Changes
My fault.
When taking off rtl alert css from template in https://github.com/joomla/joomla-cms/pull/23095, I  also deleted @richard67 https://github.com/infograf768/joomla-cms/pull/50

This pr also adds to Cpanel System some code to refresh finding J Updates when modifying the Update channel.
### Testing Instructions
See https://github.com/joomla/joomla-cms/pull/23095

### Before patch
We are getting an error `updateInfo is undefined`

### after patch
all is fine

@wilsonge
Can be merged on review and sorry again.