### PR TITLE
Option to display only user created/owned content

### DIFF
--- a/modules/mod_articles_category/mod_articles_category.xml
+++ b/modules/mod_articles_category/mod_articles_category.xml
@@ -161,6 +161,7 @@
 					>
 					<option value="1">MOD_ARTICLES_CATEGORY_OPTION_INCLUSIVE_VALUE</option>
 					<option value="0">MOD_ARTICLES_CATEGORY_OPTION_EXCLUSIVE_VALUE</option>
+					<option value="2">User created/owned content</option>
 				</field>
 
 				<field


### PR DESCRIPTION
Besides Including or Excluding content by created_by ID it can be useful to display just content that is created/owned by current user.

Pull Request for Issue # .

### Summary of Changes



### Testing Instructions



### Expected result



### Actual result



### Documentation Changes Required

