### PR TITLE
[4.0] Fatal error in FormModel

### DIFF
--- a/libraries/src/MVC/Model/FormModel.php
+++ b/libraries/src/MVC/Model/FormModel.php
@@ -104,7 +104,7 @@ abstract class FormModel extends BaseDatabaseModel implements FormFactoryAwareIn
 				return true;
 			}
 
-			$checkedOutField = $this->getColumnAlias('checked_out');
+			$checkedOutField = $table->getColumnAlias('checked_out');
 
 			// Check if this is the user having previously checked out the row.
 			if ($table->$checkedOutField > 0 && $table->$checkedOutField != $user->get('id') && !$user->authorise('core.admin', 'com_checkin'))


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Fixes an error caused by typo in #23139 (oops).

### Testing Instructions

Try to save a plugin.

### Expected result

Saved.

### Actual result
```
Call to undefined method Joomla\Component\Plugins\Administrator\Model\PluginModel::getColumnAlias() 
```

### Documentation Changes Required

No.