### PR TITLE
Fixing notices in debug plugin

### DIFF
--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -665,7 +665,7 @@ class PlgSystemDebug extends JPlugin
 		}
 
 		$avgTime = $totalTime / max(count($marks), 1);
-		$avgMem  = $totalMem / max(array(count($marks), 1));
+		$avgMem  = $totalMem / max(count($marks), 1);
 
 		foreach ($marks as $mark)
 		{

--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -637,6 +637,8 @@ class PlgSystemDebug extends JPlugin
 		$totalTime = 0;
 		$totalMem  = 0;
 		$marks     = array();
+		$bars      = array();
+		$barsMem   = array();
 
 		foreach (JProfiler::getInstance('Application')->getMarks() as $mark)
 		{
@@ -662,8 +664,8 @@ class PlgSystemDebug extends JPlugin
 			);
 		}
 
-		$avgTime = $totalTime / count($marks);
-		$avgMem  = $totalMem / count($marks);
+		$avgTime = $totalTime / max(array(count($marks), 1));
+		$avgMem  = $totalMem / max(array(count($marks), 1));
 
 		foreach ($marks as $mark)
 		{

--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -664,7 +664,7 @@ class PlgSystemDebug extends JPlugin
 			);
 		}
 
-		$avgTime = $totalTime / max(array(count($marks), 1));
+		$avgTime = $totalTime / max(count($marks), 1);
 		$avgMem  = $totalMem / max(array(count($marks), 1));
 
 		foreach ($marks as $mark)


### PR DESCRIPTION
I've messed around a bit and ran into a bunch of issues in the debug plugin. Simply said, I didn't create any $marks in my script and thus got 2 notices about division by zero. And the $bars/$barsMem vars are not initialised. Not much more that I can say...