### PR TITLE
com_content Ensure introtext and fulltext are valid html

### DIFF
--- a/libraries/src/Table/Content.php
+++ b/libraries/src/Table/Content.php
@@ -17,6 +17,7 @@ use Joomla\CMS\Table\Observer\Tags;
 use Joomla\CMS\Table\Observer\ContentHistory as ContentHistoryObserver;
 use Joomla\Registry\Registry;
 use Joomla\String\StringHelper;
+use Joomla\Utilities\DomHelper;
 
 /**
  * Content table
@@ -147,7 +148,11 @@ class Content extends Table
 			}
 			else
 			{
-				list ($this->introtext, $this->fulltext) = preg_split($pattern, $array['articletext'], 2);
+				list ($this->introtext, $this->fulltext) = array_map(function ($value)
+				{
+					return DomHelper::fixHtml($value);
+				}
+				, preg_split($pattern, $array['articletext'], 2));
 			}
 		}
 

--- a/libraries/vendor/joomla/utilities/src/DomHelper.php
+++ b/libraries/vendor/joomla/utilities/src/DomHelper.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Part of the Joomla Framework Utilities Package
+ *
+ * @copyright  Copyright (C) 2005 - 2018 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Utilities;
+
+/**
+ * Dom Helper.
+ *
+ * @since  3.8
+ */
+class DomHelper
+{
+	public static $dom = null;
+
+	private static function getDomInstance()
+	{
+		return self::$dom ? self::$dom : self::$dom = new DOMDocument();
+	}
+
+	/**
+	 * Function to fix Html errors like missing end tags.
+	 *
+	 * @param string $html
+	 *
+	 * @return string
+	 */
+	public static function fixHtml($html)
+	{
+		$dom = self::getDomInstance();
+		@$dom->loadHTML('<?xml encoding="utf-8" ?>' . $html, LIBXML_HTML_NODEFDTD);
+		// Fix the html errors
+		$value = $dom->saveHtml($dom->getElementsByTagName('body')->item(0));
+
+		// Remove body tag
+		return mb_strimwidth($value, 6, mb_strwidth($value, 'UTF-8') - 13, '', 'UTF-8');
+	}
+}


### PR DESCRIPTION
We had issues with the readmore tag causing the webpage layout to collaps due to unclosed `<div>`

### Summary of Changes
The content for `introtext ` and `fulltext ` are parsed by `DOMDocument`.
So no longer invalid html gets saved to database.

### Testing Instructions
Try to save following article with a `Readmore` tag.

```html
<div>This is a Simple Text</div>
<div><hr id="system-readmore" /></div>
<div>The Fulltext</div>
```

### Expected result
The Intro should be:

```html
<div>This is a Simple Text</div>
```
Or
```html
<div>This is a Simple Text</div>
<div></div>
```


### Actual result
```html
<div>This is a Simple Text</div>
<div>
```

This breaks the article listing.

### Documentation Changes Required
None.
