### PR TITLE
[3.x] Trim extra spaces from download URL in com_installer and com_joomlaupdate

### DIFF
--- a/administrator/components/com_installer/models/update.php
+++ b/administrator/components/com_installer/models/update.php
@@ -406,7 +406,7 @@ class InstallerModelUpdate extends JModelList
 			return false;
 		}
 
-		$url     = $update->downloadurl->_data;
+		$url     = trim($update->downloadurl->_data);
 		$sources = $update->get('downloadSources', array());
 
 		if ($extra_query = $update->get('extra_query'))
@@ -420,7 +420,7 @@ class InstallerModelUpdate extends JModelList
 		while (!($p_file = InstallerHelper::downloadPackage($url)) && isset($sources[$mirror]))
 		{
 			$name = $sources[$mirror];
-			$url  = $name->url;
+			$url  = trim($name->url);
 
 			if ($extra_query)
 			{

--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -250,7 +250,7 @@ class JoomlaupdateModelDefault extends JModelLegacy
 	public function download()
 	{
 		$updateInfo = $this->getUpdateInformation();
-		$packageURL = $updateInfo['object']->downloadurl->_data;
+		$packageURL = trim($updateInfo['object']->downloadurl->_data);
 		$sources    = $updateInfo['object']->get('downloadSources', array());
 		$headers    = get_headers($packageURL, 1);
 
@@ -286,7 +286,7 @@ class JoomlaupdateModelDefault extends JModelLegacy
 			while (!($download = $this->downloadPackage($packageURL, $target)) && isset($sources[$mirror]))
 			{
 				$name       = $sources[$mirror];
-				$packageURL = $name->url;
+				$packageURL = trim($name->url);
 				$mirror++;
 			}
 
@@ -304,7 +304,7 @@ class JoomlaupdateModelDefault extends JModelLegacy
 				while (!($download = $this->downloadPackage($packageURL, $target)) && isset($sources[$mirror]))
 				{
 					$name       = $sources[$mirror];
-					$packageURL = $name->url;
+					$packageURL = trim($name->url);
 					$mirror++;
 				}
 


### PR DESCRIPTION
### Summary of Changes

Trim extra spaces from download URL as we do in other places in the installer already as it should be consisted. I have extended this PR to the new downloadsource tag too.

cc @astridx 

### Testing Instructions

Install this component: https://github.com/astridx/mod_agiframewrapper/releases/tag/v0.0.2
See it finds the update to 0.0.3
Notice that when you try to install it it gets an error (can't download the package)
apply the patch
try to apply the update again

### Expected result

Update works

### Actual result

Update errors with "Can't download package"

### Documentation Changes Required

None.

### More Information

The reason for that extra spaces is that here: https://github.com/astridx/mod_agiframewrapper/blob/v0.0.3/agiframewrapper-update.xml#L57-L63 there is a return an this gets into the variable.