### PR TITLE
PHP 7.3 warning in debug plugin

### DIFF
--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -587,7 +587,7 @@ class PlgSystemDebug extends CMSPlugin
 				case 'deprecated':
 					if (!$logDeprecated && !$logDeprecatedCore)
 					{
-						continue;
+						break;
 					}
 					$file = $entry->callStack[2]['file'] ?? '';
 					$line = $entry->callStack[2]['line'] ?? '';
@@ -608,13 +608,13 @@ class PlgSystemDebug extends CMSPlugin
 					{
 						if (!$logDeprecatedCore)
 						{
-							continue;
+							break;
 						}
 						$category .= '-core';
 					}
 					elseif (!$logDeprecated)
 					{
-						continue;
+						break;
 					}
 
 					$message = [


### PR DESCRIPTION
PHP 7.3 warns using continue instead of break in switch statement.

### Summary of Changes

Change ```continue``` to ```break```


### Testing Instructions

Use the debug plugin with different options in different PHP versions

### Expected result

No warning

### Actual result
```"continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"```


### Documentation Changes Required

no

