### PR TITLE
com_media: normalizing uploaded file names

### DIFF
--- a/administrator/components/com_media/controllers/file.json.php
+++ b/administrator/components/com_media/controllers/file.json.php
@@ -82,7 +82,7 @@ class MediaControllerFile extends JControllerLegacy
 
 			// Transform filename to punycode
 			$fileparts['filename'] = JStringPunycode::toPunycode($fileparts['filename']);
-			$tempExt = (!empty($fileparts['extension'])) ? strtolower($fileparts['extension']) : '';
+			$tempExt = !empty($fileparts['extension']) ? strtolower($fileparts['extension']) : '';
 
 			// Transform filename to punycode, then neglect otherthan non-alphanumeric characters & underscores. Also transform extension to lowercase
 			$safeFileName = preg_replace(array("/[\\s]/", '/[^a-zA-Z0-9_\-]/'), array('_', ''), $fileparts['filename']) . '.' . $tempExt;

--- a/administrator/components/com_media/controllers/file.json.php
+++ b/administrator/components/com_media/controllers/file.json.php
@@ -85,7 +85,7 @@ class MediaControllerFile extends JControllerLegacy
 			$tempExt = (!empty($fileparts['extension'])) ? strtolower($fileparts['extension']) : '';
 
 			// Transform filename to punycode, then neglect otherthan non-alphanumeric characters & underscores. Also transform extension to lowercase
-			$safeFileName = preg_replace(array("/[\\s]/", '/[^a-zA-Z0-9_]/'), array('_', ''), $fileparts['filename']) . '.' . $tempExt;
+			$safeFileName = preg_replace(array("/[\\s]/", '/[^a-zA-Z0-9_\-]/'), array('_', ''), $fileparts['filename']) . '.' . $tempExt;
 
 			// Create filepath with safe-filename
 			$files['final'] = $fileparts['dirname'] . DIRECTORY_SEPARATOR . $safeFileName;

--- a/administrator/components/com_media/controllers/file.php
+++ b/administrator/components/com_media/controllers/file.php
@@ -116,7 +116,7 @@ class MediaControllerFile extends JControllerLegacy
 
 			// Transform filename to punycode, check extension and transform it to lowercase
 			$fileparts['filename'] = JStringPunycode::toPunycode($fileparts['filename']);
-			$tempExt = (!empty($fileparts['extension'])) ? strtolower($fileparts['extension']) : '';
+			$tempExt = !empty($fileparts['extension']) ? strtolower($fileparts['extension']) : '';
 
 			// Neglect other than non-alphanumeric characters, hyphens & underscores.
 			$safeFileName = preg_replace(array("/[\\s]/", '/[^a-zA-Z0-9_\-]/'), array('_', ''), $fileparts['filename']) . '.' . $tempExt;

--- a/administrator/components/com_media/controllers/file.php
+++ b/administrator/components/com_media/controllers/file.php
@@ -108,8 +108,21 @@ class MediaControllerFile extends JControllerLegacy
 		// Perform basic checks on file info before attempting anything
 		foreach ($files as &$file)
 		{
-			$file['name']     = JFile::makeSafe($file['name']);
-			$file['name']     = str_replace(' ', '-', $file['name']);
+			// Make the filename safe
+			$file['name'] = JFile::makeSafe($file['name']);
+
+			// We need a url safe name
+			$fileparts = pathinfo(COM_MEDIA_BASE . '/' . $this->folder . '/' . $file['name']);
+
+			// Transform filename to punycode, check extension and transform it to lowercase
+			$fileparts['filename'] = JStringPunycode::toPunycode($fileparts['filename']);
+			$tempExt = (!empty($fileparts['extension'])) ? strtolower($fileparts['extension']) : '';
+
+			// Neglect other than non-alphanumeric characters, hyphens & underscores.
+			$safeFileName = preg_replace(array("/[\\s]/", '/[^a-zA-Z0-9_\-]/'), array('_', ''), $fileparts['filename']) . '.' . $tempExt;
+
+			$file['name'] = $safeFileName;
+
 			$file['filepath'] = JPath::clean(implode(DIRECTORY_SEPARATOR, array(COM_MEDIA_BASE, $this->folder, $file['name'])));
 
 			if (($file['error'] == 1)


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/23249

### Summary of Changes
Adding hyphens to allowed characters in file names uploaded by drag and drop in TinyMCE.

Normalizing file names in direct com_media upload files to fit with the drag and drop format:

1. the name of a file should not contain any period `.` before the extension.
(real original name of these files are of the type: `Screen Shot 2018-12-09 at 07.43.58.png` on my Mac)
This is nicely taken care of when drag and drop as periods are replaced by nothing (after adding the hyphen in the code above).
`Screen_Shot_2018-12-09_at_075108.png`
BUT not in normal upload where I get:
`Screen-Shot-2018-12-10-at-09.29.49.png`

2. Also, spaces are replaced by hyphens in one case and by underscores in the other.

### Testing Instructions
Upload a file (usually an image) containing spaces and periods in other place than before the extension, both using com_media and drag and drop.


### After patch
An image which name on the desktop is
`Screen Shot 2018-12-09 at 07.43.58.png`

will be uploaded to Joomla as
`Screen_Shot_2018-12-09_at_074358.png`

