### PR TITLE
Fix issues with language SEF

### DIFF
--- a/libraries/src/Router/SiteRouter.php
+++ b/libraries/src/Router/SiteRouter.php
@@ -161,7 +161,11 @@ class SiteRouter extends Router
 		{
 			if ($this->app->get('sef_suffix') && !(substr($route, -9) === 'index.php' || substr($route, -1) === '/'))
 			{
-				if (($format = $uri->getVar('format', 'html')) && empty($uri->skipFormat))
+				if ($uri->getVar('nolangformat'))
+				{
+					$uri->delVar('nolangformat');
+				}
+				elseif (($format = $uri->getVar('format', 'html')))
 				{
 					$route .= '.' . $format;
 					$uri->delVar('format');

--- a/libraries/src/Router/SiteRouter.php
+++ b/libraries/src/Router/SiteRouter.php
@@ -156,19 +156,12 @@ class SiteRouter extends Router
 		// Get the path data
 		$route = $uri->getPath();
 
-		$nolangformat = $uri->getVar('nolangformat');
-
-		if ($nolangformat !== null)
-		{
-			$uri->delVar('nolangformat');
-		}
-
 		// Add the suffix to the uri
 		if ($this->_mode == JROUTER_MODE_SEF && $route)
 		{
 			if ($this->app->get('sef_suffix') && !(substr($route, -9) === 'index.php' || substr($route, -1) === '/'))
 			{
-				if ($nolangformat === null && ($format = $uri->getVar('format', 'html')))
+				if ($format = $uri->getVar('format', 'html'))
 				{
 					$route .= '.' . $format;
 					$uri->delVar('format');

--- a/libraries/src/Router/SiteRouter.php
+++ b/libraries/src/Router/SiteRouter.php
@@ -161,7 +161,7 @@ class SiteRouter extends Router
 		{
 			if ($this->app->get('sef_suffix') && !(substr($route, -9) === 'index.php' || substr($route, -1) === '/'))
 			{
-				if ($format = $uri->getVar('format', 'html'))
+				if (($format = $uri->getVar('format', 'html')) && empty($uri->skipFormat))
 				{
 					$route .= '.' . $format;
 					$uri->delVar('format');

--- a/libraries/src/Router/SiteRouter.php
+++ b/libraries/src/Router/SiteRouter.php
@@ -156,16 +156,19 @@ class SiteRouter extends Router
 		// Get the path data
 		$route = $uri->getPath();
 
+		$nolangformat = $uri->getVar('nolangformat');
+
+		if ($nolangformat !== null)
+		{
+			$uri->delVar('nolangformat');
+		}
+
 		// Add the suffix to the uri
 		if ($this->_mode == JROUTER_MODE_SEF && $route)
 		{
 			if ($this->app->get('sef_suffix') && !(substr($route, -9) === 'index.php' || substr($route, -1) === '/'))
 			{
-				if ($uri->getVar('nolangformat'))
-				{
-					$uri->delVar('nolangformat');
-				}
-				elseif (($format = $uri->getVar('format', 'html')))
+				if ($nolangformat === null && ($format = $uri->getVar('format', 'html')))
 				{
 					$route .= '.' . $format;
 					$uri->delVar('format');

--- a/modules/mod_languages/helper.php
+++ b/modules/mod_languages/helper.php
@@ -114,7 +114,7 @@ abstract class ModLanguagesHelper
 					{
 						$language->link = JRoute::_($cassociations[$language->lang_code] . '&lang=' . $language->sef);
 					}
-					elseif (isset($associations[$language->lang_code]) && $menu->getItem($associations[$language->lang_code]))
+					elseif (!$language->active && isset($associations[$language->lang_code]) && $menu->getItem($associations[$language->lang_code]))
 					{
 						$itemid = $associations[$language->lang_code];
 						$language->link = JRoute::_('index.php?lang=' . $language->sef . '&Itemid=' . $itemid);
@@ -127,7 +127,8 @@ abstract class ModLanguagesHelper
 					{
 						if ($language->active)
 						{
-							$language->link = JUri::getInstance()->toString(array('path', 'query'));
+							// Correct the active link if needed
+							$language->link = JRoute::_('&');
 						}
 						else
 						{

--- a/modules/mod_languages/helper.php
+++ b/modules/mod_languages/helper.php
@@ -127,8 +127,10 @@ abstract class ModLanguagesHelper
 					{
 						if ($language->active)
 						{
-							// Correct the active link if needed
-							$language->link = JRoute::_('&');
+							$limitstart = $app->input->get('limitstart');
+
+							// Correct the current URL, if it is damaged, add an additional fix for the limitstart parameter
+							$language->link = JRoute::_('&' . ($limitstart !== null ? 'limitstart=' . $limitstart : ''));
 						}
 						else
 						{

--- a/modules/mod_languages/tmpl/default.php
+++ b/modules/mod_languages/tmpl/default.php
@@ -56,9 +56,8 @@ if ($params->get('dropdown', 0) && !$params->get('dropdownimage', 1))
 				</a>
 				</li>
 			<?php elseif ($params->get('show_active', 1)) : ?>
-				<?php $base = JUri::getInstance(); ?>
 				<li class="lang-active">
-				<a href="<?php echo htmlspecialchars_decode(htmlspecialchars($base, ENT_QUOTES, 'UTF-8'), ENT_NOQUOTES); ?>">
+				<a href="<?php echo htmlspecialchars_decode(htmlspecialchars($language->link, ENT_QUOTES, 'UTF-8'), ENT_NOQUOTES); ?>">
 					<?php if ($language->image) : ?>
 						<?php echo JHtml::_('image', 'mod_languages/' . $language->image . '.gif', '', null, true); ?>
 					<?php endif; ?>
@@ -87,9 +86,8 @@ if ($params->get('dropdown', 0) && !$params->get('dropdownimage', 1))
 			</a>
 			</li>
 		<?php elseif ($params->get('show_active', 1)) : ?>
-			<?php $base = JUri::getInstance(); ?>
 			<li class="lang-active">
-			<a href="<?php echo htmlspecialchars_decode(htmlspecialchars($base, ENT_QUOTES, 'UTF-8'), ENT_NOQUOTES); ?>">
+			<a href="<?php echo htmlspecialchars_decode(htmlspecialchars($language->link, ENT_QUOTES, 'UTF-8'), ENT_NOQUOTES); ?>">
 			<?php if ($params->get('image', 1)) : ?>
 				<?php if ($language->image) : ?>
 					<?php echo JHtml::_('image', 'mod_languages/' . $language->image . '.gif', $language->title_native, array('title' => $language->title_native), true); ?>

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -227,7 +227,7 @@ class PlgSystemLanguageFilter extends JPlugin
 			|| $lang !== $this->default_lang
 			|| $lang !== $this->current_lang))
 		{
-			$uri->setPath($uri->getPath() . '/' . $sef . '/');
+			$uri->setPath($uri->getPath() . '/' . $sef);
 		}
 	}
 
@@ -286,6 +286,18 @@ class PlgSystemLanguageFilter extends JPlugin
 		{
 			$path = $uri->getPath();
 			$parts = explode('/', $path);
+
+			if (count($parts) === 1)
+			{
+				// Remove the suffix
+				if ($this->app->get('sef_suffix'))
+				{
+					if ($suffix = pathinfo($parts[0], PATHINFO_EXTENSION))
+					{
+						$parts[0] = str_replace('.' . $suffix, '', $parts[0]);
+					}
+				}
+			}
 
 			$sef = $parts[0];
 
@@ -440,14 +452,30 @@ class PlgSystemLanguageFilter extends JPlugin
 				if ($lang_code !== $this->default_lang
 					|| !$this->params->get('remove_default_prefix', 0))
 				{
-					$path = $this->lang_codes[$lang_code]->sef . '/' . $path;
+					if ($path !== '')
+					{
+						$path = $this->lang_codes[$lang_code]->sef . '/' . $path;
+					}
+					else
+					{
+						$path = $this->lang_codes[$lang_code]->sef;
+
+						// Add the suffix
+						if ($this->app->get('sef_suffix'))
+						{
+							$format = $uri->getVar('format', 'html');
+							$uri->delVar('format');
+
+							$path .= ".$format";
+						}
+					}
 				}
 
 				$uri->setPath($path);
 
 				if (!$this->app->get('sef_rewrite'))
 				{
-					$uri->setPath('index.php/' . $uri->getPath());
+					$uri->setPath('index.php' . ($uri->getPath() !== '' ? '/' . $uri->getPath() : ''));
 				}
 
 				$redirectUri = $uri->base() . $uri->toString(array('path', 'query', 'fragment'));

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -260,7 +260,7 @@ class PlgSystemLanguageFilter extends JPlugin
 			$uri->setPath("index.php/$sef");
 
 			// To prevent creating /en.html instead of /en
-			$uri->skipFormat = true;
+			$uri->setVar('nolangformat', '1');
 		}
 
 		$uri->delVar('lang');

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -222,7 +222,10 @@ class PlgSystemLanguageFilter extends JPlugin
 			$sef = $this->lang_codes[$this->current_lang]->sef;
 		}
 
-		if ($this->mode_sef)
+		if ($this->mode_sef
+			&& (!$this->params->get('remove_default_prefix', 0)
+			|| $lang !== $this->default_lang
+			|| $lang !== $this->current_lang))
 		{
 			$uri->setPath($uri->getPath() . '/' . $sef . '/');
 		}
@@ -251,19 +254,12 @@ class PlgSystemLanguageFilter extends JPlugin
 			$sef = $this->lang_codes[$this->current_lang]->sef;
 		}
 
-		$path = $uri->getPath();
-
-		if ($this->params->get('remove_default_prefix', 0)
-			&& $lang === $this->default_lang
-			&& $lang === $this->current_lang)
-		{
-			// Remove /sef/ from index.php/sef/
-			$uri->setPath(substr_replace($path, '', 9, strlen($sef) + 1));
-		}
-		elseif ($path === "index.php/$sef/")
+		if ($uri->getPath() === "index.php/$sef/")
 		{
 			// Remove the trailing slash
 			$uri->setPath("index.php/$sef");
+
+			// To prevent creating /en.html instead of /en
 			$uri->skipFormat = true;
 		}
 
@@ -856,7 +852,7 @@ class PlgSystemLanguageFilter extends JPlugin
 				{
 					$sef = $languages[$this->default_lang]->sef;
 
-					$languages[$this->default_lang]->link = preg_replace("~/$sef/?\b~", '/', $languages[$this->default_lang]->link, 1);
+					$languages[$this->default_lang]->link = preg_replace("~/$sef(?:/|(?=[?#]|$))~", '/', $languages[$this->default_lang]->link, 1);
 				}
 
 				foreach ($languages as $i => &$language)

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -243,26 +243,6 @@ class PlgSystemLanguageFilter extends JPlugin
 	 */
 	public function postprocessSEFBuildRule(&$router, &$uri)
 	{
-		$lang = $uri->getVar('lang');
-
-		if (isset($this->lang_codes[$lang]))
-		{
-			$sef = $this->lang_codes[$lang]->sef;
-		}
-		else
-		{
-			$sef = $this->lang_codes[$this->current_lang]->sef;
-		}
-
-		if ($uri->getPath() === "index.php/$sef/")
-		{
-			// Remove the trailing slash
-			$uri->setPath("index.php/$sef");
-
-			// To prevent creating /en.html instead of /en
-			$uri->setVar('nolangformat', '1');
-		}
-
 		$uri->delVar('lang');
 	}
 
@@ -460,15 +440,14 @@ class PlgSystemLanguageFilter extends JPlugin
 				if ($lang_code !== $this->default_lang
 					|| !$this->params->get('remove_default_prefix', 0))
 				{
-					$path = $this->lang_codes[$lang_code]->sef . ($path !== '' ? '/' . $path : '');
+					$path = $this->lang_codes[$lang_code]->sef . '/' . $path;
 				}
 
 				$uri->setPath($path);
 
 				if (!$this->app->get('sef_rewrite'))
 				{
-					$path = $uri->getPath();
-					$uri->setPath('index.php' . ($path !== '' ? '/' . $path : ''));
+					$uri->setPath('index.php/' . $uri->getPath());
 				}
 
 				$redirectUri = $uri->base() . $uri->toString(array('path', 'query', 'fragment'));
@@ -852,7 +831,7 @@ class PlgSystemLanguageFilter extends JPlugin
 				{
 					$sef = $languages[$this->default_lang]->sef;
 
-					$languages[$this->default_lang]->link = preg_replace("~/$sef(?:/|(?=[?#]|$))~", '/', $languages[$this->default_lang]->link, 1);
+					$languages[$this->default_lang]->link = preg_replace("~/$sef/~", '/', $languages[$this->default_lang]->link, 1);
 				}
 
 				foreach ($languages as $i => &$language)


### PR DESCRIPTION
Pull Request for Issue #23209 and #23144

### Summary of Changes
1. Remove default `sef` from URL when "Remove URL Language Code" is set to ON in the language filter plugin.
2. Remove trailing slash after `sef`.
3. Replace `/en/` to `/en`~~.html when "Add Suffix to URL" is ON, I'm not sure about B/C for that.~~
4. Correct the active language link (mod_languages) when you are on `/en/`:
    - when "Add Suffix to URL" is ON then link is corrected to `/en`~~.html~~
    - when "Add Suffix to URL" is OFF then link is corrected to `/en` (remove trailing slash)

### Testing Instructions
Multilingual webisite with associations.


### Expected result
Issues fixed.


### Actual result


### Documentation Changes Required
??
