### PR TITLE
Fixing composr.lock file

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "deaacc2328e7698c3006c275a10799c9",
+    "content-hash": "19de3ee890b8cdee59719917e6e07c44",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -6693,7 +6693,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.0"
+        "php": ">=7.0",
+        "ext-json": "*"
     },
     "platform-dev": [],
     "platform-overrides": {


### PR DESCRIPTION
Pull Request for Issue #23257  .

### Summary of Changes
This PR is a result of `composer update --lock` command.
Error was most probably caused by manual edit of `composer.json` in https://github.com/joomla/joomla-cms/commit/cfb0fb91ee00c56a47fd89ba7785ef5e22032768


### Testing Instructions
code review or apply this PR and run `composer install` and observe there is not 

> Warning: The lock file is not up to date with the latest changes in composer.json. You may be getting outdated dependencies. Run update to update them.

on top of the output.
### Expected result
no warning
### Actual result
warning is generated
### Documentation Changes Required
no

cc @brianteeman 