### PR TITLE
Correct markup in inline editing

### DIFF
--- a/layouts/joomla/edit/frontediting_modules.php
+++ b/layouts/joomla/edit/frontediting_modules.php
@@ -50,7 +50,7 @@ $moduleHtml = preg_replace(
 	. '"'
 	// And if menu editing is enabled and allowed and it's a menu module, add data attributes for menu editing:
 	.	($menusEditing && $mod->module === 'mod_menu' ?
-			'" data-jmenuedittip="' . JHtml::_('tooltipText', 'JLIB_HTML_EDIT_MENU_ITEM', 'JLIB_HTML_EDIT_MENU_ITEM_ID') . '"'
+			' data-jmenuedittip="' . JHtml::_('tooltipText', 'JLIB_HTML_EDIT_MENU_ITEM', 'JLIB_HTML_EDIT_MENU_ITEM_ID') . '"'
 			:
 			''
 		),


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Removes extra `"`.

### Testing Instructions

Set `Inline Editing` to `Modules & Menus`.
Publish a menu module.
Login with super user.
Inspect menu module markup.

### Expected result

Valid HTML.

### Actual result

Invalid HTML.

### Documentation Changes Required

No.