### PR TITLE
J4: Fixing bugs in menu manager

### DIFF
--- a/administrator/components/com_menus/Model/ItemModel.php
+++ b/administrator/components/com_menus/Model/ItemModel.php
@@ -1440,7 +1440,7 @@ class ItemModel extends AdminModel
 		}
 
 		// Trigger the before save event.
-		$result = Factory::getApplication()->triggerEvent($this->event_before_save, array($context, &$table, $isNew));
+		$result = Factory::getApplication()->triggerEvent($this->event_before_save, array($context, &$table, $isNew, $data));
 
 		// Store the data.
 		if (in_array(false, $result, true)|| !$table->store())

--- a/administrator/components/com_menus/Model/ItemsModel.php
+++ b/administrator/components/com_menus/Model/ItemsModel.php
@@ -261,11 +261,6 @@ class ItemsModel extends ListModel
 						'a.id', 'a.menutype', 'a.title', 'a.alias', 'a.note', 'a.path', 'a.link', 'a.type', 'a.parent_id',
 						'a.level', 'a.published', 'a.component_id', 'a.checked_out', 'a.checked_out_time', 'a.browserNav',
 						'a.access', 'a.img', 'a.template_style_id', 'a.params', 'a.lft', 'a.rgt', 'a.home', 'a.language', 'a.client_id'
-					),
-					array(
-						null, null, null, null, null, null, null, null, null,
-						null, 'a.published', null, null, null, null,
-						null, null, null, null, null, null, null, null, null
 					)
 				)
 			)


### PR DESCRIPTION
Opening the menu manager right now in 4.0-dev throws a SQL query error. This PR fixes that. Saveing a menu item also results in a PHP error because the data array is missing in the onBeforeContentSave event. This also fixes that. With that, installing sample data is also again possible. So: Happy merging! :smile: 