### PR TITLE
Allow to generate sef URL for menu item alias

### DIFF
--- a/libraries/src/Menu/SiteMenu.php
+++ b/libraries/src/Menu/SiteMenu.php
@@ -79,7 +79,7 @@ class SiteMenu extends AbstractMenu
 			$query = $db->getQuery(true)
 				->select('m.id, m.menutype, m.title, m.alias, m.note, m.path AS route, m.link, m.type, m.level, m.language')
 				->select($db->quoteName('m.browserNav') . ', m.access, m.params, m.home, m.img, m.template_style_id, m.component_id, m.parent_id')
-				->select('e.element as component')
+				->select('COALESCE(e.element, ' . $db->quote('') . ') AS component')
 				->from('#__menu AS m')
 				->join('LEFT', '#__extensions AS e ON m.component_id = e.extension_id')
 				->where('m.published = 1')

--- a/libraries/src/Router/SiteRouter.php
+++ b/libraries/src/Router/SiteRouter.php
@@ -522,12 +522,19 @@ class SiteRouter extends Router
 		}
 
 		// Build the component route
-		$component = preg_replace('/[^A-Z0-9_\.-]/i', '', $query['option']);
-		$itemID    = !empty($query['Itemid']) ? $query['Itemid'] : null;
-		$crouter   = $this->getComponentRouter($component);
-		$parts     = $crouter->build($query);
-		$result    = implode('/', $parts);
-		$tmp       = ($result !== '') ? $result : '';
+		$itemID = !empty($query['Itemid']) ? $query['Itemid'] : null;
+
+		if ($query['option'] !== '')
+		{
+			$component = preg_replace('/[^A-Z0-9_\.-]/i', '', $query['option']);
+			$crouter   = $this->getComponentRouter($component);
+			$parts     = $crouter->build($query);
+			$tmp       = implode('/', $parts);
+		}
+		else
+		{
+			$tmp = '';
+		}
 
 		// Build the application route
 		$built = false;


### PR DESCRIPTION
Related to #23278

### Summary of Changes
Joomla disallows us to create a SEF URL to menu item alias.
This PR changes that.

The main change is in
```diff
-				->select('e.element as component')
+				->select('COALESCE(e.element, ' . $db->quote('') . ') AS component')
```
which replace NULL with an empty string. That's all.
Other changes are made to optimize.

### Testing Instructions

1. Create a menu item alias on backend, ex: title= `Alias URL`, link `index.php?Itemid=105`
2. Add in your active template file (`index.php`) such php code:
```php
<?= \JRoute::('index.php?Itemid=105'); ?>
```
Note: to work correctly in a multilingual version, you must add the lang parameter.
```php
<?= \JRoute::('index.php?Itemid=105&lang=en-GB'); ?>
```

### Expected result
You will get a SEF URL `/alias-url`

### Actual result
You get `/?Itemid=105`

### Documentation Changes Required
No
