### PR TITLE
[com_modules] Remove unused function argument

### DIFF
--- a/administrator/components/com_modules/models/fields/modulesmodule.php
+++ b/administrator/components/com_modules/models/fields/modulesmodule.php
@@ -37,7 +37,7 @@ class JFormFieldModulesModule extends JFormFieldList
 	 */
 	public function getOptions()
 	{
-		$options  = ModulesHelper::getModules(JFactory::getApplication()->getUserState('com_modules.modules.client_id', 0));
+		$options = ModulesHelper::getModules(JFactory::getApplication()->getUserState('com_modules.modules.client_id', 0));
 
 		return array_merge(parent::getOptions(), $options);
 	}

--- a/administrator/components/com_modules/models/fields/modulesmodule.php
+++ b/administrator/components/com_modules/models/fields/modulesmodule.php
@@ -37,7 +37,7 @@ class JFormFieldModulesModule extends JFormFieldList
 	 */
 	public function getOptions()
 	{
-		$options  = ModulesHelper::getModules(JFactory::getApplication()->getUserState('com_modules.modules.client_id', 0, 'int'));
+		$options  = ModulesHelper::getModules(JFactory::getApplication()->getUserState('com_modules.modules.client_id', 0));
 
 		return array_merge(parent::getOptions(), $options);
 	}

--- a/administrator/components/com_modules/models/fields/modulesposition.php
+++ b/administrator/components/com_modules/models/fields/modulesposition.php
@@ -37,7 +37,7 @@ class JFormFieldModulesPosition extends JFormFieldList
 	 */
 	public function getOptions()
 	{
-		$options  = ModulesHelper::getPositions(JFactory::getApplication()->getUserState('com_modules.modules.client_id', 0, 'int'));
+		$options  = ModulesHelper::getPositions(JFactory::getApplication()->getUserState('com_modules.modules.client_id', 0));
 
 		return array_merge(parent::getOptions(), $options);
 	}

--- a/administrator/components/com_modules/models/fields/modulesposition.php
+++ b/administrator/components/com_modules/models/fields/modulesposition.php
@@ -37,7 +37,7 @@ class JFormFieldModulesPosition extends JFormFieldList
 	 */
 	public function getOptions()
 	{
-		$options  = ModulesHelper::getPositions(JFactory::getApplication()->getUserState('com_modules.modules.client_id', 0));
+		$options = ModulesHelper::getPositions(JFactory::getApplication()->getUserState('com_modules.modules.client_id', 0));
 
 		return array_merge(parent::getOptions(), $options);
 	}


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Removes unused function argument.

### Testing Instructions

Code review. See that `Joomla\CMS\Application\CMSApplication::getUserState()` has only two arguments https://github.com/joomla/joomla-cms/blob/staging/libraries/src/Application/CMSApplication.php#L535

### Documentation Changes Required
No.
