### PR TITLE
[mod_related_items] Fix when id is an array

### DIFF
--- a/modules/mod_related_items/helper.php
+++ b/modules/mod_related_items/helper.php
@@ -52,6 +52,11 @@ abstract class ModRelatedItemsHelper
 		$option = $app->input->get('option');
 		$view   = $app->input->get('view');
 
+		if (!($option === 'com_content' && $view === 'article'))
+		{
+			return array();
+		}
+
 		$temp = $app->input->getString('id');
 		$temp = explode(':', $temp);
 		$id   = $temp[0];
@@ -61,7 +66,7 @@ abstract class ModRelatedItemsHelper
 		$related  = array();
 		$query    = $db->getQuery(true);
 
-		if ($option === 'com_content' && $view === 'article' && $id)
+		if ($id)
 		{
 			// Select the meta keywords from the item
 			$query->select('metakey')


### PR DESCRIPTION
### Summary of Changes
When it is a Tags page, the id is an array. The Related Items module should not use this id, but it does the warning.

> index.php?option=com_tags&view=tag&id[0]=2&Itemid=475

### Testing Instructions
Install demo.
Under Extensions > Modules, assign `Articles Related Items` to `Right [position-7]` on all pages.
On the front end, click `Tagged items`.


### Actual result
> Warning: explode() expects parameter 2 to be string, array given in \modules\mod_related_items\helper.php on line 56


### Documentation Changes Required
No
