### PR TITLE
[4.0] Fix markup

### DIFF
--- a/layouts/joomla/searchtools/grid/sort.php
+++ b/layouts/joomla/searchtools/grid/sort.php
@@ -33,8 +33,8 @@ endif;
 	data-direction="<?php echo strtoupper($data->direction); ?>"
 	data-caption="<?php echo $caption; ?>"
 	<?php if (!empty($sort)) : ?>
-		data-sort="<?php echo $sort; ?>
-	<?php endif; ?>">
+		data-sort="<?php echo $sort; ?>"
+	<?php endif; ?>>
 	<?php if (!empty($data->title)) : ?>
 		<span>
 			<?php echo Text::_($data->title); ?>


### PR DESCRIPTION
### Summary of Changes
There is an extra double quote before `>` in the markup.


### Testing Instructions
Go to `Content > Articles`.
View page source.


### Actual result
```
<a href="" onclick="return false;" class="js-stools-column-order js-stools-button-sort"
		data-order="a.ordering"
	data-direction="ASC"
	data-caption=""
	">
```

