### PR TITLE
Remove logic in library extension updates that causes them to be uninstalled for some unknown reason that makes absolutely zero sense

### DIFF
--- a/libraries/src/Installer/Adapter/LibraryAdapter.php
+++ b/libraries/src/Installer/Adapter/LibraryAdapter.php
@@ -303,65 +303,6 @@ class LibraryAdapter extends InstallerAdapter
 	}
 
 	/**
-	 * Custom update method
-	 *
-	 * @return  boolean|integer  The extension ID on success, boolean false on failure
-	 *
-	 * @since   3.1
-	 */
-	public function update()
-	{
-		// Since this is just files, an update removes old files
-		// Get the extension manifest object
-		$this->setManifest($this->parent->getManifest());
-
-		// Set the overwrite setting
-		$this->parent->setOverwrite(true);
-		$this->parent->setUpgrade(true);
-
-		// And make sure the route is set correctly
-		$this->setRoute('update');
-
-		/*
-		 * ---------------------------------------------------------------------------------------------
-		 * Manifest Document Setup Section
-		 * ---------------------------------------------------------------------------------------------
-		 */
-
-		// Set the extensions name
-		$name = (string) $this->getManifest()->name;
-		$name = \JFilterInput::getInstance()->clean($name, 'string');
-		$element = str_replace('.xml', '', basename($this->parent->getPath('manifest')));
-		$this->set('name', $name);
-		$this->set('element', $element);
-
-		// We don't want to compromise this instance!
-		$installer = new Installer;
-		$db = $this->parent->getDbo();
-		$query = $db->getQuery(true)
-			->select($db->quoteName('extension_id'))
-			->from($db->quoteName('#__extensions'))
-			->where($db->quoteName('type') . ' = ' . $db->quote('library'))
-			->where($db->quoteName('element') . ' = ' . $db->quote($element));
-		$db->setQuery($query);
-		$result = $db->loadResult();
-
-		if ($result)
-		{
-			// Already installed, which would make sense
-			$installer->setPackageUninstall(true);
-			$installer->uninstall('library', $result);
-
-			// Clear the cached data
-			$this->currentExtensionId = null;
-			$this->extension = Table::getInstance('Extension', 'JTable', array('dbo' => $this->db));
-		}
-
-		// Now create the new files
-		return $this->install();
-	}
-
-	/**
 	 * Custom uninstall method
 	 *
 	 * @param   string  $id  The id of the library to uninstall.


### PR DESCRIPTION
Pull Request for https://twitter.com/akeebabackup/status/1075379522613190657

### Summary of Changes

Removes the uninstallation of library extensions when updating them.  Because this is just fatally flawed logic.

### Testing Instructions

Find a library extension.  Install an older version of it.  Update it to the latest version.  It should still work, now the library will have a consistent ID in the extensions table and using the install script features is actually a safe thing to do.

### Expected result

Libraries aren't fatally destroyed when updating them.

### Actual result

Libraries are fatally destroyed when updating them, and heaven forbid there's an error during the install/update process (like an install script aborting things...).

### Documentation Changes Required

If this fatally flawed behavior is documented somewhere, fix said documentation and offer condolences to those who have had to work around it for the last 9 years.