### PR TITLE
Fix missing line numbers in language file errors when xdebug.file_link_format is not set

### DIFF
--- a/build/media/plg_system_debug/widgets/languageErrors/widget.js
+++ b/build/media/plg_system_debug/widgets/languageErrors/widget.js
@@ -25,7 +25,7 @@
                             )
                         li.append(link)
                     } else {
-                        li.text(relPath)
+                        li.text(relPath + ':' + file[1])
                     }
                     this.$el.append(li)
                 }


### PR DESCRIPTION
Pull Request for Issue #23305

### Testing Instructions

* Have some error in a (loaded) language file. (e.g. remove a quote)
* Turn on language debug
* Check that the error is shown in debug console including the line number
* Try with and without `xdebug.file_link_format`

### Expected result

Line numbers are shown both in links and plain text

### Actual result

Line numbers are shown only in links. (When `xdebug.file_link_format` is set)

### Documentation Changes Required
nah...

Fix #23305