### PR TITLE
Batch article copy/move Fix json encoded values

### DIFF
--- a/plugins/fields/repeatable/repeatable.php
+++ b/plugins/fields/repeatable/repeatable.php
@@ -134,6 +134,12 @@ class PlgFieldsRepeatable extends FieldsPlugin
 			// Determine the value if it is available from the data
 			$value = key_exists($field->name, $fieldsData) ? $fieldsData[$field->name] : null;
 
+			// Handle json encoded values
+			if(!is_array($value))
+			{
+				$value = json_decode($value, true);
+			}
+
 			// Setting the value for the field and the item
 			$model->setFieldValue($field->id, $item->get('id'), json_encode($value));
 		}

--- a/plugins/fields/repeatable/repeatable.php
+++ b/plugins/fields/repeatable/repeatable.php
@@ -135,7 +135,7 @@ class PlgFieldsRepeatable extends FieldsPlugin
 			$value = key_exists($field->name, $fieldsData) ? $fieldsData[$field->name] : null;
 
 			// Handle json encoded values
-			if(!is_array($value))
+			if (!is_array($value))
 			{
 				$value = json_decode($value, true);
 			}


### PR DESCRIPTION
Batch article copy/move Fix json encoded values  when batch copying/moving, model expects multi-dimensional arrays.

Pull Request for Issue #23307 .

### Summary of Changes
Check if rawvalue is array if not json_descode into an array


### Testing Instructions
Batch copy / move an article with a repeatable field 


### Expected result
Custom values are copied across


### Actual result
custom values from repeatable fields are lost.


### Documentation Changes Required

