### PR TITLE
Remove type Attribute from <script> tag

### DIFF
--- a/libraries/cms/html/email.php
+++ b/libraries/cms/html/email.php
@@ -99,7 +99,7 @@ abstract class JHtmlEmail
 		";
 
 		// TODO: Use inline script for now
-		$inlineScript = "<script type='text/javascript'>" . $script . "</script>";
+		$inlineScript = "<script>" . $script . "</script>";
 
 		return '<span id="cloak' . $rand . '">' . JText::_('JLIB_HTML_CLOAKING') . '</span>' . $inlineScript;
 	}


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Remove type Attribute vom Inline script

### Testing Instructions

enable emailcloack plugin
set document->isHTML5(true)
have an emial in Content
Check the gernerated page with https://validator.w3.org/nu/
