### PR TITLE
[4.0][a11y] Sysinfo table caption

### DIFF
--- a/administrator/components/com_admin/tmpl/sysinfo/default_config.php
+++ b/administrator/components/com_admin/tmpl/sysinfo/default_config.php
@@ -14,6 +14,9 @@ use Joomla\CMS\Language\Text;
 ?>
 <div class="sysinfo">
 	<table class="table">
+		<caption id="captionTable" class="sr-only">
+			<?php echo Text::_('COM_ADMIN_CONFIGURATION_FILE'); ?>
+		</caption>
 		<thead>
 			<tr>
 				<th scope="col" style="width:300px">

--- a/administrator/components/com_admin/tmpl/sysinfo/default_config.php
+++ b/administrator/components/com_admin/tmpl/sysinfo/default_config.php
@@ -14,7 +14,7 @@ use Joomla\CMS\Language\Text;
 ?>
 <div class="sysinfo">
 	<table class="table">
-		<caption id="captionTable" class="sr-only">
+		<caption class="sr-only">
 			<?php echo Text::_('COM_ADMIN_CONFIGURATION_FILE'); ?>
 		</caption>
 		<thead>

--- a/administrator/components/com_admin/tmpl/sysinfo/default_directory.php
+++ b/administrator/components/com_admin/tmpl/sysinfo/default_directory.php
@@ -16,7 +16,7 @@ use Joomla\CMS\Language\Text;
 <div class="sysinfo">
 	<table class="table">
 		<caption class="sr-only">
-			<?php echo Text::_('COM_ADMIN_SYSTEM_INFORMATION'); ?>
+			<?php echo Text::_('COM_ADMIN_DIRECTORY_PERMISSIONS'); ?>
 		</caption>
 		<thead>
 			<tr>

--- a/administrator/components/com_admin/tmpl/sysinfo/default_directory.php
+++ b/administrator/components/com_admin/tmpl/sysinfo/default_directory.php
@@ -15,7 +15,7 @@ use Joomla\CMS\Language\Text;
 ?>
 <div class="sysinfo">
 	<table class="table">
-		<caption id="captionTable" class="sr-only">
+		<caption class="sr-only">
 			<?php echo Text::_('COM_ADMIN_SYSTEM_INFORMATION'); ?>
 		</caption>
 		<thead>

--- a/administrator/components/com_admin/tmpl/sysinfo/default_directory.php
+++ b/administrator/components/com_admin/tmpl/sysinfo/default_directory.php
@@ -15,6 +15,9 @@ use Joomla\CMS\Language\Text;
 ?>
 <div class="sysinfo">
 	<table class="table">
+		<caption id="captionTable" class="sr-only">
+			<?php echo Text::_('COM_ADMIN_SYSTEM_INFORMATION'); ?>
+		</caption>
 		<thead>
 			<tr>
 				<th scope="col" style="width:850px">

--- a/administrator/components/com_admin/tmpl/sysinfo/default_phpsettings.php
+++ b/administrator/components/com_admin/tmpl/sysinfo/default_phpsettings.php
@@ -15,7 +15,7 @@ use Joomla\CMS\Language\Text;
 ?>
 <div class="sysinfo">
 	<table class="table">
-		<caption id="captionTable" class="sr-only">
+		<caption class="sr-only">
 			<?php echo Text::_('COM_ADMIN_PHP_SETTINGS'); ?>
 		</caption>
 		<thead>

--- a/administrator/components/com_admin/tmpl/sysinfo/default_phpsettings.php
+++ b/administrator/components/com_admin/tmpl/sysinfo/default_phpsettings.php
@@ -15,6 +15,9 @@ use Joomla\CMS\Language\Text;
 ?>
 <div class="sysinfo">
 	<table class="table">
+		<caption id="captionTable" class="sr-only">
+			<?php echo Text::_('COM_ADMIN_PHP_SETTINGS'); ?>
+		</caption>
 		<thead>
 			<tr>
 				<th scope="col" style="width:250px">

--- a/administrator/components/com_admin/tmpl/sysinfo/default_system.php
+++ b/administrator/components/com_admin/tmpl/sysinfo/default_system.php
@@ -15,7 +15,7 @@ use Joomla\CMS\Language\Text;
 ?>
 <div class="sysinfo">
 	<table class="table">
-		<caption id="captionTable" class="sr-only">
+		<caption class="sr-only">
 			<?php echo Text::_('COM_ADMIN_SYSTEM_INFORMATION'); ?>
 		</caption>
 		<thead>

--- a/administrator/components/com_admin/tmpl/sysinfo/default_system.php
+++ b/administrator/components/com_admin/tmpl/sysinfo/default_system.php
@@ -15,6 +15,9 @@ use Joomla\CMS\Language\Text;
 ?>
 <div class="sysinfo">
 	<table class="table">
+		<caption id="captionTable" class="sr-only">
+			<?php echo Text::_('COM_ADMIN_SYSTEM_INFORMATION'); ?>
+		</caption>
 		<thead>
 			<tr>
 				<th scope="col" style="width:25%">


### PR DESCRIPTION
As required in https://github.com/joomla/joomla-cms/pull/21724#event-2034082335 .

### Summary of Changes
Tables are providede with a caption.
NOTE: This PR does not deal with issue https://issues.joomla.org/tracker/joomla-cms/23154, (phpinfo).

### Testing Instructions
Inspect code, test with screenreader.

### Expected result
No visible changes in Views. Blind users get information via the table caption

### Actual result
Captions are missing 

### Documentation Changes Required
no 
