### PR TITLE
Fix Updater Stability Constant reference

### DIFF
--- a/libraries/src/Updater/Update.php
+++ b/libraries/src/Updater/Update.php
@@ -545,7 +545,7 @@ class Update extends \JObject
 	 */
 	protected function stabilityTagToInteger($tag)
 	{
-		$constant = '\\Joomla\\CMS\\Update\\Updater::STABILITY_' . strtoupper($tag);
+		$constant = '\\Joomla\\CMS\\Updater\\Updater::STABILITY_' . strtoupper($tag);
 
 		if (defined($constant))
 		{


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/23318

### Summary of Changes
Fixing a typo in the reference for the constant. Probably happend due to namespacing efforts.


### Testing Instructions
See testing instructions in referenced issue. Needs a test extension which has beta and stable releases in the manifest. Below is the one from the original issue poster - it should work to test as long as he doesn't change the manifest 😄 
[test.zip](https://github.com/joomla/joomla-cms/files/2705366/test.zip)

### Expected result
With the above plugin (v1.0.0) the updater should offer the version 1.0.1. After updating that version should be installed.


### Actual result
v1.0.1 is shown as update but v3.0.0.beta is installed


### Documentation Changes Required
None