### PR TITLE
jdatabase importer exporter

### DIFF
--- a/cli/exporter.php
+++ b/cli/exporter.php
@@ -2,7 +2,7 @@
 /**
  * @package    Joomla.Cli
  *
- * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2019 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/cli/exporter.php
+++ b/cli/exporter.php
@@ -122,7 +122,7 @@ class DbExporterCli extends JApplicationCli
 
 				JFile::write($filename, $data);
 
-				if (($imode) && ($imode === 'zip'))
+				if ($imode && $imode === 'zip')
 				{
 					$zipFilesArray[] = array('name' => $table . '.xml', 'data' => $data);
 					$zip->create($zipfile, $zipFilesArray);
@@ -133,7 +133,7 @@ class DbExporterCli extends JApplicationCli
 			}
 		}
 
-		$this->out('Total time:' . round(microtime(true) - $total_time, 3));
+		$this->out('Total time: ' . round(microtime(true) - $total_time, 3));
 	}
 }
 

--- a/cli/exporter.php
+++ b/cli/exporter.php
@@ -75,7 +75,7 @@ class DbExporterCli extends JApplicationCli
 
 		if (!(($itable)||($iall)||($ihelp)))
 		{
-			if (!($ihelp))
+			if (!$ihelp)
 			{
 				$this->out('[WARNING] Missing or wrong parameters');
 				$this->out();

--- a/cli/exporter.php
+++ b/cli/exporter.php
@@ -73,7 +73,7 @@ class DbExporterCli extends JApplicationCli
 		$ipath   = $this->input->get('folder', null, 'folder');
 		$zipfile = $ipath . 'jdata_exported_' . JFactory::getDate()->format('Y-m-d') . '.zip';
 
-		if (!(($itable)||($iall)||($ihelp)))
+		if (!($itable || $iall || $ihelp))
 		{
 			if (!$ihelp)
 			{

--- a/cli/exporter.php
+++ b/cli/exporter.php
@@ -110,7 +110,7 @@ class DbExporterCli extends JApplicationCli
 			if (strpos(substr($table, 0, strlen($prefix)), $prefix) !== false)
 			{
 				$task_i_time = microtime(true);
-				$filename    = $ipath . $table . '.xml';
+				$filename    = $ipath . '/' . $table . '.xml';
 				$this->out();
 				$this->out('Exporting ' . $table . '....');
 				$data = (string) $exp->from($table)->withData(true);

--- a/cli/exporter.php
+++ b/cli/exporter.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * @package    Joomla.Cli
+ *
+ * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+// We are a valid entry point.
+const _JEXEC = 1;
+
+// Load system defines
+if (file_exists(dirname(__DIR__) . '/defines.php'))
+{
+	require_once dirname(__DIR__) . '/defines.php';
+}
+
+if (!defined('_JDEFINES'))
+{
+	define('JPATH_BASE', dirname(__DIR__));
+	require_once JPATH_BASE . '/includes/defines.php';
+}
+
+// Get the framework.
+require_once JPATH_LIBRARIES . '/import.legacy.php';
+
+// Bootstrap the CMS libraries.
+require_once JPATH_LIBRARIES . '/cms.php';
+
+// Configure error reporting to maximum for CLI output.
+error_reporting(E_ALL);
+ini_set('display_errors', 1);
+
+// Load Library language
+$lang = JFactory::getLanguage();
+
+// Try the files_joomla file in the current language (without allowing the loading of the file in the default language)
+$lang->load('files_joomla.sys', JPATH_SITE, null, false, false)
+// Fallback to the files_joomla file in the default language
+|| $lang->load('files_joomla.sys', JPATH_SITE, null, true);
+
+/**
+ * A command line cron job to export tables and data.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class DbExporterCli extends JApplicationCli
+{
+	/**
+	 * Entry point for CLI script
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function doExecute()
+	{
+		$this->out(JText::_('DbExporterCli'));
+		$this->out('============================');
+		$total_time = microtime(true);
+
+		// Import the dependencies
+		jimport('joomla.filesystem.file');
+
+		$tables   = JFactory::getDbo()->getTableList();
+		$prefix   = JFactory::getDbo()->getPrefix();
+		$exp      = JFactory::getDbo()->getExporter()->withStructure();
+
+		$iall    = $this->input->getString('all', null);
+		$ihelp   = $this->input->getString('help', null);
+		$itable  = $this->input->getString('table', null);
+		$imode   = $this->input->getString('mode', null);
+		$ipath   = $this->input->get('folder', null, 'folder');
+		$zipfile = $ipath . 'jdata_exported_' . JFactory::getDate()->format('Y-m-d') . '.zip';
+
+		if (!(($itable)||($iall)||($ihelp)))
+		{
+			if (!($ihelp))
+			{
+				$this->out('[WARNING] Missing or wrong parameters');
+				$this->out();
+			}
+
+			$this->out('Usage: php exporter.php <options>');
+			$this->out('php exporter.php --all                  dump all tables');
+			$this->out('php exporter.php --mode zip             dump in zip format');
+			$this->out('php exporter.php --table <table_name>   dump <table_name>');
+			$this->out('php exporter.php --folder <folder_path> dump in <folder_path>');
+
+			return;
+		}
+
+		if (($itable))
+		{
+			if (!in_array($itable, $tables))
+			{
+				$this->out('Not Found ' . $itable . '....');
+				$this->out();
+
+				return;
+			}
+
+			$tables = array($itable);
+		}
+
+		$zip = JArchive::getAdapter('zip');
+
+		foreach ($tables as $table)
+		{
+			if (strpos(substr($table, 0, strlen($prefix)), $prefix) !== false)
+			{
+				$task_i_time = microtime(true);
+				$filename    = $ipath . $table . '.xml';
+				$this->out();
+				$this->out('Exporting ' . $table . '....');
+				$data = (string) $exp->from($table)->withData(true);
+
+				if (JFile::exists($filename))
+				{
+					JFile::delete($filename);
+				}
+
+				JFile::write($filename, $data);
+
+				if (($imode) && ($imode === 'zip'))
+				{
+					$zipFilesArray[] = array('name' => $table . '.xml', 'data' => $data);
+					$zip->create($zipfile, $zipFilesArray);
+					JFile::delete($filename);
+				}
+
+				$this->out('Exported in ' . round(microtime(true) - $task_i_time, 3));
+			}
+		}
+
+		$this->out('Total time:' . round(microtime(true) - $total_time, 3));
+	}
+}
+
+// Instantiate the application object, passing the class name to JCli::getInstance
+// and use chaining to execute the application.
+JApplicationCli::getInstance('DbExporterCli')->execute();

--- a/cli/exporter.php
+++ b/cli/exporter.php
@@ -90,7 +90,7 @@ class DbExporterCli extends JApplicationCli
 			return;
 		}
 
-		if (($itable))
+		if ($itable)
 		{
 			if (!in_array($itable, $tables))
 			{

--- a/cli/importer.php
+++ b/cli/importer.php
@@ -96,7 +96,7 @@ class DbImporterCli extends JApplicationCli
 		foreach ($tables as $table)
 		{
 			$task_i_time = microtime(true);
-			$percorso    = $ipath . $table;
+			$percorso    = $ipath . '/' . $table;
 
 			// Check file
 			if (!JFile::exists($percorso))

--- a/cli/importer.php
+++ b/cli/importer.php
@@ -69,9 +69,9 @@ class DbImporterCli extends JApplicationCli
 		$itable = $this->input->getString('table', null);
 		$tables = JFolder::files($ipath, '\.xml$');
 
-		if (!(($itable)||($iall)||($ihelp)))
+		if (!($itable || $iall || $ihelp))
 		{
-			if (!($ihelp))
+			if (!$ihelp)
 			{
 				$this->out('[WARNING] Missing or wrong parameters');
 				$this->out();
@@ -161,7 +161,7 @@ class DbImporterCli extends JApplicationCli
 			$this->out();
 		}
 
-		$this->out('Total time:' . round(microtime(true) - $total_time, 3));
+		$this->out('Total time: ' . round(microtime(true) - $total_time, 3));
 	}
 }
 

--- a/cli/importer.php
+++ b/cli/importer.php
@@ -1,0 +1,170 @@
+<?php
+/**
+ * @package    Joomla.Cli
+ *
+ * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+// We are a valid entry point.
+const _JEXEC = 1;
+
+// Load system defines
+if (file_exists(dirname(__DIR__) . '/defines.php'))
+{
+	require_once dirname(__DIR__) . '/defines.php';
+}
+
+if (!defined('_JDEFINES'))
+{
+	define('JPATH_BASE', dirname(__DIR__));
+	require_once JPATH_BASE . '/includes/defines.php';
+}
+
+// Get the framework.
+require_once JPATH_LIBRARIES . '/import.legacy.php';
+
+// Bootstrap the CMS libraries.
+require_once JPATH_LIBRARIES . '/cms.php';
+
+// Configure error reporting to maximum for CLI output.
+error_reporting(E_ALL);
+ini_set('display_errors', 1);
+
+// Load Library language
+$lang = JFactory::getLanguage();
+
+// Try the files_joomla file in the current language (without allowing the loading of the file in the default language)
+$lang->load('files_joomla.sys', JPATH_SITE, null, false, false)
+// Fallback to the files_joomla file in the default language
+|| $lang->load('files_joomla.sys', JPATH_SITE, null, true);
+
+/**
+ * A command line cron job to import tables and data.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class DbImporterCli extends JApplicationCli
+{
+	/**
+	 * Entry point for CLI script
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function doExecute()
+	{
+		$this->out(JText::_('DbImporterCli'));
+		$this->out('============================');
+		$total_time = microtime(true);
+
+		// Import the dependencies
+		jimport('joomla.filesystem.file');
+		jimport('joomla.filesystem.folder');
+
+		$ipath  = $this->input->get('folder', null, 'folder');
+		$iall   = $this->input->getString('all', null);
+		$ihelp  = $this->input->getString('help', null);
+		$itable = $this->input->getString('table', null);
+		$tables = JFolder::files($ipath, '\.xml$');
+
+		if (!(($itable)||($iall)||($ihelp)))
+		{
+			if (!($ihelp))
+			{
+				$this->out('[WARNING] Missing or wrong parameters');
+				$this->out();
+			}
+
+			$this->out('Usage: php importer.php <options>');
+			$this->out('php importer.php --all                  import all files');
+			$this->out('php importer.php --table <table_name>   import <table_name>');
+			$this->out('php importer.php --folder <folder_path> import from <folder_path>');
+
+			return;
+		}
+
+		if ($this->input->getString('table', false))
+		{
+			$tables = array($itable . '.xml');
+		}
+
+		$db       = JFactory::getDbo();
+		$prefix   = $db->getPrefix();
+
+		foreach ($tables as $table)
+		{
+			$task_i_time = microtime(true);
+			$percorso    = $ipath . $table;
+
+			// Check file
+			if (!JFile::exists($percorso))
+			{
+				$this->out('Not Found ' . $table);
+
+				return false;
+			}
+
+			$table_name = str_replace('.xml', '', $table);
+			$this->out('Importing ' . $table_name . ' from ' . $table);
+
+			try
+			{
+				$imp = JFactory::getDbo()->getImporter()->from(JFile::read($percorso))->withStructure()->asXml();
+			}
+			catch (JDatabaseExceptionExecuting $e)
+			{
+				$this->out('Error on getImporter' . $table . ' ' . $e);
+
+				return false;
+			}
+
+			$this->out('Reading data from ' . $table);
+
+			try
+			{
+				$this->out('Drop ' . $table_name);
+				$db->dropTable($table_name, true);
+			}
+			catch (JDatabaseExceptionExecuting $e)
+			{
+				$this->out(' Error in DROP TABLE ' . $table_name . ' ' . $e);
+
+				return false;
+			}
+
+			try
+			{
+				$imp->mergeStructure();
+			}
+			catch (JDatabaseExceptionExecuting $e)
+			{
+				$this->out('Error on mergeStructure' . $table . ' ' . $e);
+
+				return false;
+			}
+
+			$this->out('Checked structure ' . $table);
+
+			try
+			{
+				$imp->importData();
+			}
+			catch (JDatabaseExceptionExecuting $e)
+			{
+				$this->out('Error on importData' . $table . ' ' . $e);
+
+				return false;
+			}
+			$this->out('Data loaded ' . $table . ' in ' . round(microtime(true) - $task_i_time, 3));
+			$this->out();
+		}
+
+		$this->out('Total time:' . round(microtime(true) - $total_time, 3));
+	}
+}
+
+// Instantiate the application object, passing the class name to JCli::getInstance
+// and use chaining to execute the application.
+JApplicationCli::getInstance('DbImporterCli')->execute();

--- a/libraries/joomla/database/driver/pgsql.php
+++ b/libraries/joomla/database/driver/pgsql.php
@@ -407,6 +407,7 @@ class JDatabaseDriverPgsql extends JDatabaseDriverPdo
 		$retVal = false;
 
 		$this->setQuery("SELECT setval('" . $sequence . "', " . (string) $last_value . ", " . (string) $is_called . ")");
+
 		if ($this->execute())
 		{
 			$retVal = true;

--- a/libraries/joomla/database/driver/pgsql.php
+++ b/libraries/joomla/database/driver/pgsql.php
@@ -578,6 +578,10 @@ class JDatabaseDriverPgsql extends JDatabaseDriverPdo
 				$val = $field_value === '' ? 'NULL' : $field_value;
 				break;
 
+			case 'bytea':
+				$val = $this->quote(base64_decode($field_value));
+				break;
+
 			case 'date':
 			case 'timestamp without time zone':
 				if (empty($field_value))

--- a/libraries/joomla/database/driver/pgsql.php
+++ b/libraries/joomla/database/driver/pgsql.php
@@ -297,8 +297,8 @@ class JDatabaseDriverPgsql extends JDatabaseDriverPdo
 		/**
 		 * Get the list of column names this index indexes.
 		 *
-		 * @param   string  $table  The name of the table.
-		 * @param   string  $indKey The list of column numbers for the table
+		 * @param   string  $table   The name of the table.
+		 * @param   string  $indKey  The list of column numbers for the table
 		 *
 		 * @return  string  A list of the column names for the table.
 		 *
@@ -312,7 +312,7 @@ class JDatabaseDriverPgsql extends JDatabaseDriverPdo
 			$tabInd = explode(' ', $indKey);
 			$colNames = array();
 
-			foreach($tabInd as $numCol)
+			foreach ($tabInd as $numCol)
 			{
 				$query = $this->getQuery(true)
 					->select('attname')

--- a/libraries/joomla/database/driver/pgsql.php
+++ b/libraries/joomla/database/driver/pgsql.php
@@ -578,10 +578,6 @@ class JDatabaseDriverPgsql extends JDatabaseDriverPdo
 				$val = $field_value === '' ? 'NULL' : $field_value;
 				break;
 
-			case 'bytea':
-				$val = $this->quote(base64_decode($field_value));
-				break;
-
 			case 'date':
 			case 'timestamp without time zone':
 				if (empty($field_value))

--- a/libraries/joomla/database/driver/pgsql.php
+++ b/libraries/joomla/database/driver/pgsql.php
@@ -271,8 +271,9 @@ class JDatabaseDriverPgsql extends JDatabaseDriverPdo
 
 		// To check if table exists and prevent SQL injection
 		$tableList = $this->getTableList();
+		$tableSub = $this->replacePrefix($table);
 
-		if (in_array($table, $tableList, true))
+		if (in_array($tableSub, $tableList, true))
 		{
 			// Get the details columns information.
 			$this->setQuery('
@@ -285,7 +286,7 @@ class JDatabaseDriverPgsql extends JDatabaseDriverPdo
 				FROM pg_indexes
 				LEFT JOIN pg_class AS pgClassFirst ON indexname=pgClassFirst.relname
 				LEFT JOIN pg_index AS pgIndex ON pgClassFirst.oid=pgIndex.indexrelid
-				WHERE tablename=' . $this->quote($table) . ' ORDER BY indkey'
+				WHERE tablename=' . $this->quote($tableSub) . ' ORDER BY indkey'
 			);
 
 			return $this->loadObjectList();
@@ -309,6 +310,8 @@ class JDatabaseDriverPgsql extends JDatabaseDriverPdo
 		{
 			$this->connect();
 
+			$tableSub = $this->replacePrefix($table);
+
 			$tabInd = explode(' ', $indKey);
 			$colNames = array();
 
@@ -317,7 +320,7 @@ class JDatabaseDriverPgsql extends JDatabaseDriverPdo
 				$query = $this->getQuery(true)
 					->select('attname')
 					->from('pg_attribute')
-					->join('LEFT', 'pg_class ON pg_class.relname=' . $this->quote($table))
+					->join('LEFT', 'pg_class ON pg_class.relname=' . $this->quote($tableSub))
 					->where('attnum=' . $numCol . ' AND attrelid=pg_class.oid');
 				$this->setQuery($query);
 				$colNames[] = $this->loadResult();
@@ -362,8 +365,9 @@ class JDatabaseDriverPgsql extends JDatabaseDriverPdo
 	{
 		// To check if table exists and prevent SQL injection
 		$tableList = $this->getTableList();
+		$tableSub = $this->replacePrefix($table);
 
-		if (in_array($table, $tableList, true))
+		if (in_array($tableSub, $tableList, true))
 		{
 			$name = array(
 				's.relname', 'n.nspname', 't.relname', 'a.attname', 'info.data_type',
@@ -387,7 +391,7 @@ class JDatabaseDriverPgsql extends JDatabaseDriverPdo
 				->leftJoin('pg_namespace n ON n.oid = t.relnamespace')
 				->leftJoin('pg_attribute a ON a.attrelid = t.oid AND a.attnum = d.refobjsubid')
 				->leftJoin('information_schema.sequences AS info ON info.sequence_name = s.relname')
-				->where('s.relkind = ' . $this->quote('S') . ' AND d.deptype = ' . $this->quote('a') . ' AND t.relname = ' . $this->quote($table));
+				->where('s.relkind = ' . $this->quote('S') . ' AND d.deptype = ' . $this->quote('a') . ' AND t.relname = ' . $this->quote($tableSub));
 			$this->setQuery($query);
 
 			return $this->loadObjectList();

--- a/libraries/joomla/database/driver/pgsql.php
+++ b/libraries/joomla/database/driver/pgsql.php
@@ -317,7 +317,7 @@ class JDatabaseDriverPgsql extends JDatabaseDriverPdo
 				$query = $this->getQuery(true)
 					->select('attname')
 					->from('pg_attribute')
-					->join('LEFT', 'pg_class ON pg_class.relname=' . $this->q($table))
+					->join('LEFT', 'pg_class ON pg_class.relname=' . $this->quote($table))
 					->where('attnum=' . $numCol . ' AND attrelid=pg_class.oid');
 				$this->setQuery($query);
 				$colNames[] = $this->loadResult();

--- a/libraries/joomla/database/driver/pgsql.php
+++ b/libraries/joomla/database/driver/pgsql.php
@@ -226,16 +226,6 @@ class JDatabaseDriverPgsql extends JDatabaseDriverPdo
 		{
 			foreach ($fields as $field)
 			{
-				if (stristr(strtolower($field->type), 'character varying'))
-				{
-					$field->Default = '';
-				}
-
-				if (stristr(strtolower($field->type), 'text'))
-				{
-					$field->Default = '';
-				}
-
 				// Do some dirty translation to MySQL output.
 				// @todo: Come up with and implement a standard across databases.
 				$result[$field->column_name] = (object) array(
@@ -372,6 +362,57 @@ class JDatabaseDriverPgsql extends JDatabaseDriverPdo
 		}
 
 		return false;
+	}
+
+	/**
+	 * Method to get the last value of a sequence in the database.
+	 *
+	 * @param   string  $sequence  The name of the sequence.
+	 *
+	 * @return  integer  The last value of the sequence.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  RuntimeException
+	 */
+	public function getSequenceLastValue($sequence)
+	{
+		$this->connect();
+
+		$query = $this->getQuery(true)
+			->select('last_value')
+			->from($sequence);
+
+		$this->setQuery($query);
+		$lastId = $this->loadResult();
+
+		return $lastId;
+	}
+
+	/**
+	 * Method to set the last value of a sequence in the database.
+	 *
+	 * @param   string   $sequence    The name of the sequence.
+	 * @param   integer  $last_value  The last value of the sequence.
+	 * @param   boolean  $is_called   Flag to advance the sequence before returning a value
+	 *
+	 * @return	boolean	True on success.
+	 *
+	 * @since	__DEPLOY_VERSION__
+	 * @throws	RuntimeException
+	 */
+	public function setSequenceLastValue($sequence, $last_value, $is_called = true)
+	{
+		$this->connect();
+
+		$retVal = false;
+
+		$this->setQuery("SELECT setval('" . $sequence . "', " . (string) $last_value . ", " . (string) $is_called . ")");
+		if ($this->execute())
+		{
+			$retVal = true;
+		}
+
+		return $retVal;
 	}
 
 	/**

--- a/libraries/joomla/database/driver/pgsql.php
+++ b/libraries/joomla/database/driver/pgsql.php
@@ -276,7 +276,7 @@ class JDatabaseDriverPgsql extends JDatabaseDriverPdo
 		{
 			// Get the details columns information.
 			$this->setQuery('
-				SELECT indexname AS "idxName", indisprimary AS "isPrimary", indisunique  AS "isUnique",
+				SELECT indexname AS "idxName", indisprimary AS "isPrimary", indisunique  AS "isUnique", indkey AS "indKey",
 					CASE WHEN indisprimary = true THEN
 						( SELECT \'ALTER TABLE \' || tablename || \' ADD \' || pg_catalog.pg_get_constraintdef(const.oid, true)
 							FROM pg_constraint AS const WHERE const.conname= pgClassFirst.relname )
@@ -293,6 +293,38 @@ class JDatabaseDriverPgsql extends JDatabaseDriverPdo
 
 		return false;
 	}
+
+		/**
+		 * Get the list of column names this index indexes.
+		 *
+		 * @param   string  $table  The name of the table.
+		 * @param   string  $indKey The list of column numbers for the table
+		 *
+		 * @return  string  A list of the column names for the table.
+		 *
+		 * @since   __DEPLOY_VERSION__
+		 * @throws  RuntimeException
+		 */
+		public function getNamesKey($table, $indKey)
+		{
+			$this->connect();
+
+			$tabInd = explode(' ', $indKey);
+			$colNames = array();
+
+			foreach($tabInd as $numCol)
+			{
+				$query = $this->getQuery(true)
+					->select('attname')
+					->from('pg_attribute')
+					->join('LEFT', 'pg_class ON pg_class.relname=' . $this->q($table))
+					->where('attnum=' . $numCol . ' AND attrelid=pg_class.oid');
+				$this->setQuery($query);
+				$colNames[] = $this->loadResult();
+			}
+
+			return implode(', ', $colNames);
+		}
 
 	/**
 	 * Method to get an array of all tables in the database.

--- a/libraries/joomla/database/driver/pgsql.php
+++ b/libraries/joomla/database/driver/pgsql.php
@@ -415,6 +415,7 @@ class JDatabaseDriverPgsql extends JDatabaseDriverPdo
 			->from($sequence);
 
 		$this->setQuery($query);
+
 		return $this->loadResult();
 	}
 
@@ -437,6 +438,7 @@ class JDatabaseDriverPgsql extends JDatabaseDriverPdo
 			->from($sequence);
 
 		$this->setQuery($query);
+
 		return $this->loadResult();
 	}
 

--- a/libraries/joomla/database/driver/pgsql.php
+++ b/libraries/joomla/database/driver/pgsql.php
@@ -379,41 +379,33 @@ class JDatabaseDriverPgsql extends JDatabaseDriverPdo
 		$this->connect();
 
 		$query = $this->getQuery(true)
-			->select('last_value')
+			->select($this->quoteName('last_value'))
 			->from($sequence);
 
 		$this->setQuery($query);
-		$lastId = $this->loadResult();
-
-		return $lastId;
+		return $this->loadResult();
 	}
 
 	/**
-	 * Method to set the last value of a sequence in the database.
+	 * Method to get the is_called attribute of a sequence.
 	 *
-	 * @param   string   $sequence    The name of the sequence.
-	 * @param   integer  $last_value  The last value of the sequence.
-	 * @param   boolean  $is_called   Flag to advance the sequence before returning a value
+	 * @param   string  $sequence  The name of the sequence.
 	 *
-	 * @return	boolean	True on success.
+	 * @return  boolean  The is_called attribute of the sequence.
 	 *
-	 * @since	__DEPLOY_VERSION__
-	 * @throws	RuntimeException
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  RuntimeException
 	 */
-	public function setSequenceLastValue($sequence, $last_value, $is_called = true)
+	public function getSequenceIsCalled($sequence)
 	{
 		$this->connect();
 
-		$retVal = false;
+		$query = $this->getQuery(true)
+			->select($this->quoteName('is_called'))
+			->from($sequence);
 
-		$this->setQuery("SELECT setval('" . $sequence . "', " . (string) $last_value . ", " . (string) $is_called . ")");
-
-		if ($this->execute())
-		{
-			$retVal = true;
-		}
-
-		return $retVal;
+		$this->setQuery($query);
+		return $this->loadResult();
 	}
 
 	/**

--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -562,7 +562,7 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 		{
 			$name = array(
 				's.relname', 'n.nspname', 't.relname', 'a.attname', 'info.data_type', 'info.minimum_value', 'info.maximum_value',
-				'info.increment', 'info.cycle_option',
+				'info.increment', 'info.cycle_option'
 			);
 			$as = array('sequence', 'schema', 'table', 'column', 'data_type', 'minimum_value', 'maximum_value', 'increment', 'cycle_option');
 
@@ -592,6 +592,28 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 	}
 
 	/**
+	 * Method to get the is_called attribute of a sequence.
+	 *
+	 * @param   string  $sequence  The name of the sequence.
+	 *
+	 * @return  boolean  The is_called attribute of the sequence.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  RuntimeException
+	 */
+	public function getSequenceIsCalled($sequence)
+	{
+		$this->connect();
+
+		$query = $this->getQuery(true)
+			->select($this->quoteName('is_called'))
+			->from($sequence);
+
+		$this->setQuery($query);
+		return $this->loadResult();
+	}
+
+	/**
 	 * Method to get the last value of a sequence in the database.
 	 *
 	 * @param   string  $sequence  The name of the sequence.
@@ -606,41 +628,11 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 		$this->connect();
 
 		$query = $this->getQuery(true)
-			->select('last_value')
+			->select($this->quoteName('last_value'))
 			->from($sequence);
 
 		$this->setQuery($query);
-		$lastId = $this->loadResult();
-
-		return $lastId;
-	}
-
-	/**
-	 * Method to set the last value of a sequence in the database.
-	 *
-	 * @param   string   $sequence    The name of the sequence.
-	 * @param   integer  $last_value  The last value of the sequence.
-	 * @param   boolean  $is_called   Flag to advance the sequence before returning a value
-	 *
-	 * @return	boolean	True on success.
-	 *
-	 * @since	__DEPLOY_VERSION__
-	 * @throws	RuntimeException
-	 */
-	public function setSequenceLastValue($sequence, $last_value, $is_called = true)
-	{
-		$this->connect();
-
-		$retVal = false;
-
-		$this->setQuery("SELECT setval('" . $sequence . "', " . (string) $last_value . ", " . (string) $is_called . ")");
-
-		if ($this->execute())
-		{
-			$retVal = true;
-		}
-
-		return $retVal;
+		return $this->loadResult();
 	}
 
 	/**

--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -538,7 +538,7 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 			$query = $this->getQuery(true)
 				->select('attname')
 				->from('pg_attribute')
-				->join('LEFT', 'pg_class ON pg_class.relname=' . $this->q($table))
+				->join('LEFT', 'pg_class ON pg_class.relname=' . $this->quote($table))
 				->where('attnum=' . $numCol . ' AND attrelid=pg_class.oid');
 			$this->setQuery($query);
 			$colNames[] = $this->loadResult();
@@ -593,7 +593,7 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 		{
 			$name = array(
 				's.relname', 'n.nspname', 't.relname', 'a.attname', 'info.data_type', 'info.minimum_value', 'info.maximum_value',
-				'info.increment', 'info.cycle_option'
+				'info.increment', 'info.cycle_option',
 			);
 			$as = array('sequence', 'schema', 'table', 'column', 'data_type', 'minimum_value', 'maximum_value', 'increment', 'cycle_option');
 

--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -592,6 +592,28 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 	}
 
 	/**
+	 * Method to get the last value of a sequence in the database.
+	 *
+	 * @param   string  $sequence  The name of the sequence.
+	 *
+	 * @return  integer  The last value of the sequence.
+	 *
+	 * @since   3.0.0
+	 * @throws  RuntimeException
+	 */
+	public function getSequenceLastValue($sequence)
+	{
+		$query = $this->getQuery(true)
+			->select('last_value')
+			->from($sequence);
+
+		$this->setQuery($query);
+		$lastId = $this->loadResult();
+
+		return $lastId;
+	}
+
+	/**
 	 * Get the version of the database connector.
 	 *
 	 * @return  string  The database connector version.

--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -518,8 +518,8 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 	/**
 	 * Get the list of column names this index indexes.
 	 *
-	 * @param   string  $table  The name of the table.
-	 * @param   string  $indKey The list of column numbers for the table
+	 * @param   string  $table   The name of the table.
+	 * @param   string  $indKey  The list of column numbers for the table
 	 *
 	 * @return  string  A list of the column names for the table.
 	 *
@@ -533,7 +533,7 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 		$tabInd = explode(' ', $indKey);
 		$colNames = array();
 
-		foreach($tabInd as $numCol)
+		foreach ($tabInd as $numCol)
 		{
 			$query = $this->getQuery(true)
 				->select('attname')

--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -446,15 +446,6 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 		{
 			foreach ($fields as $field)
 			{
-				if (stristr(strtolower($field->type), 'character varying'))
-				{
-					$field->Default = '';
-				}
-
-				if (stristr(strtolower($field->type), 'text'))
-				{
-					$field->Default = '';
-				}
 				// Do some dirty translation to MySQL output.
 				// TODO: Come up with and implement a standard across databases.
 				$result[$field->column_name] = (object) array(

--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -634,6 +634,7 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 		$retVal = false;
 
 		$this->setQuery("SELECT setval('" . $sequence . "', " . (string) $last_value . ", " . (string) $is_called . ")");
+
 		if ($this->execute())
 		{
 			$retVal = true;

--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -491,8 +491,9 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 
 		// To check if table exists and prevent SQL injection
 		$tableList = $this->getTableList();
+		$tableSub = $this->replacePrefix($table);
 
-		if (in_array($table, $tableList))
+		if (in_array($tableSub, $tableList))
 		{
 			// Get the details columns information.
 			$this->setQuery('
@@ -505,7 +506,7 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 				FROM pg_indexes
 				LEFT JOIN pg_class AS pgClassFirst ON indexname=pgClassFirst.relname
 				LEFT JOIN pg_index AS pgIndex ON pgClassFirst.oid=pgIndex.indexrelid
-				WHERE tablename=' . $this->quote($table) . ' ORDER BY indkey'
+				WHERE tablename=' . $this->quote($tableSub) . ' ORDER BY indkey'
 			);
 
 			$keys = $this->loadObjectList();
@@ -530,6 +531,8 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 	{
 		$this->connect();
 
+		$tableSub = $this->replacePrefix($table);
+
 		$tabInd = explode(' ', $indKey);
 		$colNames = array();
 
@@ -538,7 +541,7 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 			$query = $this->getQuery(true)
 				->select('attname')
 				->from('pg_attribute')
-				->join('LEFT', 'pg_class ON pg_class.relname=' . $this->quote($table))
+				->join('LEFT', 'pg_class ON pg_class.relname=' . $this->quote($tableSub))
 				->where('attnum=' . $numCol . ' AND attrelid=pg_class.oid');
 			$this->setQuery($query);
 			$colNames[] = $this->loadResult();
@@ -588,8 +591,9 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 
 		// To check if table exists and prevent SQL injection
 		$tableList = $this->getTableList();
+		$tableSub = $this->replacePrefix($table);
 
-		if (in_array($table, $tableList))
+		if (in_array($tableSub, $tableList))
 		{
 			$name = array(
 				's.relname', 'n.nspname', 't.relname', 'a.attname', 'info.data_type', 'info.minimum_value', 'info.maximum_value',
@@ -612,7 +616,7 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 				->join('LEFT', 'pg_namespace n ON n.oid=t.relnamespace')
 				->join('LEFT', 'pg_attribute a ON a.attrelid=t.oid AND a.attnum=d.refobjsubid')
 				->join('LEFT', 'information_schema.sequences AS info ON info.sequence_name=s.relname')
-				->where("s.relkind='S' AND d.deptype='a' AND t.relname=" . $this->quote($table));
+				->where("s.relkind='S' AND d.deptype='a' AND t.relname=" . $this->quote($tableSub));
 			$this->setQuery($query);
 			$seq = $this->loadObjectList();
 

--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -641,6 +641,7 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 			->from($sequence);
 
 		$this->setQuery($query);
+
 		return $this->loadResult();
 	}
 
@@ -663,6 +664,7 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 			->from($sequence);
 
 		$this->setQuery($query);
+
 		return $this->loadResult();
 	}
 

--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -598,11 +598,13 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 	 *
 	 * @return  integer  The last value of the sequence.
 	 *
-	 * @since   3.0.0
+	 * @since   __DEPLOY_VERSION__
 	 * @throws  RuntimeException
 	 */
 	public function getSequenceLastValue($sequence)
 	{
+		$this->connect();
+
 		$query = $this->getQuery(true)
 			->select('last_value')
 			->from($sequence);
@@ -611,6 +613,33 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 		$lastId = $this->loadResult();
 
 		return $lastId;
+	}
+
+	/**
+	 * Method to set the last value of a sequence in the database.
+	 *
+	 * @param	string  $sequence	The name of the sequence.
+	 * @param	integer $last_value	The last value of the sequence.
+	 * @param	boolean	$is_called	Flag to advance the sequence before returning a value
+	 *
+	 * @return	boolean	True on success.
+	 *
+	 * @since	__DEPLOY_VERSION__
+	 * @throws	RuntimeException
+	 */
+	public function setSequenceLastValue($sequence, $last_value, $is_called = true)
+	{
+		$this->connect();
+
+		$retVal = false;
+
+		$this->setQuery("SELECT setval('" . $sequence . "', " . (string) $last_value . ", " . (string) $is_called . ")");
+		if ($this->execute())
+		{
+			$retVal = true;
+		}
+
+		return $retVal;
 	}
 
 	/**

--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -1030,10 +1030,6 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 				$val = strlen($field_value) == 0 ? 'NULL' : $field_value;
 				break;
 
-			case 'bytea':
-				$val = $this->quote(base64_decode($field_value));
-				break;
-
 			case 'date':
 			case 'timestamp without time zone':
 				if (empty($field_value))

--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -618,9 +618,9 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 	/**
 	 * Method to set the last value of a sequence in the database.
 	 *
-	 * @param	string  $sequence	The name of the sequence.
-	 * @param	integer $last_value	The last value of the sequence.
-	 * @param	boolean	$is_called	Flag to advance the sequence before returning a value
+	 * @param   string   $sequence    The name of the sequence.
+	 * @param   integer  $last_value  The last value of the sequence.
+	 * @param   boolean  $is_called   Flag to advance the sequence before returning a value
 	 *
 	 * @return	boolean	True on success.
 	 *

--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -1030,6 +1030,10 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 				$val = strlen($field_value) == 0 ? 'NULL' : $field_value;
 				break;
 
+			case 'bytea':
+				$val = $this->quote(base64_decode($field_value));
+				break;
+
 			case 'date':
 			case 'timestamp without time zone':
 				if (empty($field_value))

--- a/libraries/joomla/database/exporter.php
+++ b/libraries/joomla/database/exporter.php
@@ -276,8 +276,8 @@ abstract class JDatabaseExporter
 			}
 
 			$query = $this->db->getQuery(true);
-			$query->select($query->qn(array_keys($fields)))
-				->from($query->qn($table));
+			$query->select($query->quoteName(array_keys($fields)))
+				->from($query->quoteName($table));
 			$this->db->setQuery($query);
 
 			$rows = $this->db->loadObjectList();

--- a/libraries/joomla/database/exporter.php
+++ b/libraries/joomla/database/exporter.php
@@ -71,8 +71,9 @@ abstract class JDatabaseExporter
 
 		// Set up the class defaults:
 
-		// Export with only structure
+		// Export not only structure
 		$this->withStructure();
+		$this->withData();
 
 		// Export as xml.
 		$this->asXml();
@@ -226,5 +227,90 @@ abstract class JDatabaseExporter
 		$this->options->withStructure = (boolean) $setting;
 
 		return $this;
+	}
+
+	/**
+	 * Sets an internal option to export the data of the input table(s).
+	 *
+	 * @param   boolean  $setting  True to export the data, false to not.
+	 *
+	 * @return  JDatabaseExporter  Method supports chaining.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function withData($setting = false)
+	{
+		$this->options->withData = (boolean) $setting;
+
+		return $this;
+	}
+
+	/**
+	 * Builds the XML data to export.
+	 *
+	 * @return  array  An array of XML lines (strings).
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  Exception if an error occurs.
+	 */
+	protected function buildXmlData()
+	{
+		$buffer = array();
+
+		foreach ($this->from as $table)
+		{
+			// Replace the magic prefix if found.
+			$table = $this->getGenericTableName($table);
+
+			// Get the details columns information.
+			$fields  = $this->db->getTableColumns($table, false);
+			$colblob = array();
+
+			foreach ($fields as $field)
+			{
+				// Cacth blob for conversion xml
+				if ($field->Type == 'mediumblob')
+				{
+					$colblob[] = $field->Field;
+				}
+			}
+
+			$query = $this->db->getQuery(true);
+			$query->select($query->qn(array_keys($fields)))
+				->from($query->qn($table));
+			$this->db->setQuery($query);
+
+			$rows = $this->db->loadObjectList();
+
+			if (!count($rows))
+			{
+				continue;
+			}
+
+			$buffer[] = '  <table_data name="' . $table . '">';
+
+			foreach ($rows as $row)
+			{
+				$buffer[] = '   <row>';
+
+				foreach ($row as $key => $value)
+				{
+					if (!in_array($key, $colblob))
+					{
+						$buffer[] = '    <field name="' . $key . '">' . htmlspecialchars($value, ENT_COMPAT, 'UTF-8') . '</field>';
+					}
+					else
+					{
+						$buffer[] = '    <field name="' . $key . '">' . base64_encode($value) . '</field>';
+					}
+				}
+
+				$buffer[] = '   </row>';
+			}
+
+			$buffer[] = '  </table_data>';
+		}
+
+		return $buffer;
 	}
 }

--- a/libraries/joomla/database/exporter/mysqli.php
+++ b/libraries/joomla/database/exporter/mysqli.php
@@ -32,7 +32,15 @@ class JDatabaseExporterMysqli extends JDatabaseExporter
 		$buffer[] = '<mysqldump xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">';
 		$buffer[] = ' <database name="">';
 
-		$buffer = array_merge($buffer, $this->buildXmlStructure());
+		if ($this->options->withStructure)
+		{
+			$buffer = array_merge($buffer, $this->buildXmlStructure());
+		}
+
+		if ($this->options->withData)
+		{
+			$buffer = array_merge($buffer, $this->buildXmlData());
+		}
 
 		$buffer[] = ' </database>';
 		$buffer[] = '</mysqldump>';
@@ -75,6 +83,7 @@ class JDatabaseExporterMysqli extends JDatabaseExporter
 				$buffer[] = '   <key Table="' . $table . '"' . ' Non_unique="' . $key->Non_unique . '"' . ' Key_name="' . $key->Key_name . '"' .
 					' Seq_in_index="' . $key->Seq_in_index . '"' . ' Column_name="' . $key->Column_name . '"' . ' Collation="' . $key->Collation . '"' .
 					' Null="' . $key->Null . '"' . ' Index_type="' . $key->Index_type . '"' .
+					' Sub_part="' . $key->Sub_part . '"' .
 					' Comment="' . htmlspecialchars($key->Comment, ENT_COMPAT, 'UTF-8') . '"' . ' />';
 			}
 

--- a/libraries/joomla/database/exporter/pgsql.php
+++ b/libraries/joomla/database/exporter/pgsql.php
@@ -102,7 +102,7 @@ class JDatabaseExporterPgsql extends JDatabaseExporterPostgresql
 					{
 						$buffer[] = '    <field name="' . $key . '">' . htmlspecialchars($value, ENT_COMPAT, 'UTF-8') . '</field>';
 					}
-					else if (in_array($key, $collob))
+					elseif (in_array($key, $collob))
 					{
 						$buffer[] = '    <field name="' . $key . '">' . htmlspecialchars(stream_get_contents($value), ENT_COMPAT, 'UTF-8') . '</field>';
 					}

--- a/libraries/joomla/database/exporter/pgsql.php
+++ b/libraries/joomla/database/exporter/pgsql.php
@@ -73,8 +73,8 @@ class JDatabaseExporterPgsql extends JDatabaseExporterPostgresql
 			}
 
 			$query = $this->db->getQuery(true);
-			$query->select($query->qn(array_keys($fields)))
-				->from($query->qn($table));
+			$query->select($query->quoteName(array_keys($fields)))
+				->from($query->quoteName($table));
 			$this->db->setQuery($query);
 
 			$rows = $this->db->loadObjectList();

--- a/libraries/joomla/database/exporter/pgsql.php
+++ b/libraries/joomla/database/exporter/pgsql.php
@@ -98,7 +98,7 @@ class JDatabaseExporterPgsql extends JDatabaseExporterPostgresql
 					}
 					else
 					{
-						$buffer[] = '    <field name="' . $key . '">' . base64_encode(stream_get_contents($value)) . '</field>';
+						$buffer[] = '    <field name="' . $key . '">' . stream_get_contents($value) . '</field>';
 					}
 				}
 

--- a/libraries/joomla/database/exporter/pgsql.php
+++ b/libraries/joomla/database/exporter/pgsql.php
@@ -61,20 +61,14 @@ class JDatabaseExporterPgsql extends JDatabaseExporterPostgresql
 			// Get the details columns information.
 			$fields  = $this->db->getTableColumns($table, false);
 			$colblob = array();
-			$collob = array();
 
 			foreach ($fields as $field)
 			{
-				// Cacth blob for conversion xml
-				if ($field->Type == 'mediumblob')
-				{
-					$colblob[] = $field->Field;
-				}
-
-				// Catch lob PDO stream for conversion xml
+				// Cacth blob for xml conversion
+				// PostgreSQL binary large object type
 				if ($field->Type == 'bytea')
 				{
-					$collob[] = $field->Field;
+					$colblob[] = $field->Field;
 				}
 			}
 
@@ -98,17 +92,13 @@ class JDatabaseExporterPgsql extends JDatabaseExporterPostgresql
 
 				foreach ($row as $key => $value)
 				{
-					if (!in_array($key, $colblob) && !in_array($key, $collob))
+					if (!in_array($key, $colblob))
 					{
 						$buffer[] = '    <field name="' . $key . '">' . htmlspecialchars($value, ENT_COMPAT, 'UTF-8') . '</field>';
 					}
-					elseif (in_array($key, $collob))
-					{
-						$buffer[] = '    <field name="' . $key . '">' . htmlspecialchars(stream_get_contents($value), ENT_COMPAT, 'UTF-8') . '</field>';
-					}
 					else
 					{
-						$buffer[] = '    <field name="' . $key . '">' . base64_encode($value) . '</field>';
+						$buffer[] = '    <field name="' . $key . '">' . base64_encode(stream_get_contents($value)) . '</field>';
 					}
 				}
 

--- a/libraries/joomla/database/exporter/pgsql.php
+++ b/libraries/joomla/database/exporter/pgsql.php
@@ -64,7 +64,7 @@ class JDatabaseExporterPgsql extends JDatabaseExporterPostgresql
 
 			foreach ($fields as $field)
 			{
-				// Cacth blob for xml conversion
+				// Catch blob for xml conversion
 				// PostgreSQL binary large object type
 				if ($field->Type == 'bytea')
 				{

--- a/libraries/joomla/database/exporter/postgresql.php
+++ b/libraries/joomla/database/exporter/postgresql.php
@@ -108,7 +108,7 @@ class JDatabaseExporterPostgresql extends JDatabaseExporter
 				foreach ($keys as $key)
 				{
 					$buffer[] = '   <key Index="' . $key->idxName . '"' . ' is_primary="' . $key->isPrimary . '"' . ' is_unique="' . $key->isUnique . '"' .
-						' Query=\'' . $key->Query . '\' />';
+						' Key_name="' . $this->db->getNamesKey($table_name, $key->indKey) . '"' . ' Query=\'' . $key->Query . '\' />';
 				}
 			}
 

--- a/libraries/joomla/database/exporter/postgresql.php
+++ b/libraries/joomla/database/exporter/postgresql.php
@@ -66,6 +66,7 @@ class JDatabaseExporterPostgresql extends JDatabaseExporter
 		foreach ($this->from as $table)
 		{
 			$table = $this->getGenericTableName($table);
+
 			// Get the details columns information.
 			$fields = $this->db->getTableColumns($table, false);
 			$keys = $this->db->getTableKeys($table);
@@ -129,6 +130,7 @@ class JDatabaseExporterPostgresql extends JDatabaseExporter
 		foreach ($this->from as $table)
 		{
 			$table = $this->getGenericTableName($table);
+
 			// Get the details columns information.
 			$fields  = $this->db->getTableColumns($table, false);
 			$colblob = array();

--- a/libraries/joomla/database/exporter/postgresql.php
+++ b/libraries/joomla/database/exporter/postgresql.php
@@ -104,8 +104,9 @@ class JDatabaseExporterPostgresql extends JDatabaseExporter
 			{
 				foreach ($keys as $key)
 				{
-					$buffer[] = '   <key Index="' . $this->getGenericTableName($key->idxName) . '"' . ' is_primary="' . $key->isPrimary . '"' . ' is_unique="' . $key->isUnique . '"' .
-						' Key_name="' . $this->db->getNamesKey($table, $key->indKey) . '"' . ' Query=\'' . $key->Query . '\' />';
+					$buffer[] = '   <key Index="' . $this->getGenericTableName($key->idxName) . '"' . ' is_primary="' . $key->isPrimary . '"' .
+						' is_unique="' . $key->isUnique . '"' . ' Key_name="' . $this->db->getNamesKey($table, $key->indKey) . '"' .
+						' Query=\'' . $key->Query . '\' />';
 				}
 			}
 

--- a/libraries/joomla/database/exporter/postgresql.php
+++ b/libraries/joomla/database/exporter/postgresql.php
@@ -65,15 +65,10 @@ class JDatabaseExporterPostgresql extends JDatabaseExporter
 
 		foreach ($this->from as $table)
 		{
-			// Replace the magic prefix if found.
-			$table = $this->getGenericTableName($table);
-
 			// Get the details columns information.
 			$fields = $this->db->getTableColumns($table, false);
-			$prefix = $this->db->getPrefix();
-			$table_name = str_replace('#__', $prefix, $table);
-			$keys = $this->db->getTableKeys($table_name);
-			$sequences = $this->db->getTableSequences($table_name);
+			$keys = $this->db->getTableKeys($table);
+			$sequences = $this->db->getTableSequences($table);
 
 			$buffer[] = '  <table_structure name="' . $table . '">';
 
@@ -108,7 +103,7 @@ class JDatabaseExporterPostgresql extends JDatabaseExporter
 				foreach ($keys as $key)
 				{
 					$buffer[] = '   <key Index="' . $key->idxName . '"' . ' is_primary="' . $key->isPrimary . '"' . ' is_unique="' . $key->isUnique . '"' .
-						' Key_name="' . $this->db->getNamesKey($table_name, $key->indKey) . '"' . ' Query=\'' . $key->Query . '\' />';
+						' Key_name="' . $this->db->getNamesKey($table, $key->indKey) . '"' . ' Query=\'' . $key->Query . '\' />';
 				}
 			}
 
@@ -132,9 +127,6 @@ class JDatabaseExporterPostgresql extends JDatabaseExporter
 
 		foreach ($this->from as $table)
 		{
-			// Replace the magic prefix if found.
-			$table = $this->getGenericTableName($table);
-
 			// Get the details columns information.
 			$fields  = $this->db->getTableColumns($table, false);
 			$colblob = array();

--- a/libraries/joomla/database/exporter/postgresql.php
+++ b/libraries/joomla/database/exporter/postgresql.php
@@ -78,14 +78,14 @@ class JDatabaseExporterPostgresql extends JDatabaseExporter
 					' Table="' . $sequence->table . '"' . ' Column="' . $sequence->column . '"' . ' Type="' . $sequence->data_type . '"' .
 					' Start_Value="' . $sequence->start_value . '"' . ' Min_Value="' . $sequence->minimum_value . '"' .
 					' Max_Value="' . $sequence->maximum_value . '"' . ' Increment="' . $sequence->increment . '"' .
-					' Cycle_option="' . $sequence->cycle_option . '"' .
+					' Cycle_option="' . $sequence->cycle_option . '"' . ' Is_called="YES"' .
 					' />';
 			}
 
 			foreach ($fields as $field)
 			{
 				$buffer[] = '   <field Field="' . $field->column_name . '"' . ' Type="' . $field->type . '"' . ' Null="' . $field->null . '"' .
-							(isset($field->default) ? ' Default="' . $field->default . '"' : '') . ' Comments="' . $field->comments . '"' .
+							' Default="' . $field->Default . '"' . ' Comments="' . $field->comments . '"' .
 					' />';
 			}
 

--- a/libraries/joomla/database/exporter/postgresql.php
+++ b/libraries/joomla/database/exporter/postgresql.php
@@ -90,7 +90,8 @@ class JDatabaseExporterPostgresql extends JDatabaseExporter
 						' Table="' . $sequence->table . '"' . ' Column="' . $sequence->column . '"' . ' Type="' . $sequence->data_type . '"' .
 						' Start_Value="' . $sequence->start_value . '"' . ' Min_Value="' . $sequence->minimum_value . '"' .
 						' Max_Value="' . $sequence->maximum_value . '"' . ' Last_Value="' . $this->db->getSequenceLastValue($sequence->sequence) . '"' .
-						' Increment="' . $sequence->increment . '"' . ' Cycle_option="' . $sequence->cycle_option . '"' . ' Is_called="YES"' .
+						' Increment="' . $sequence->increment . '"' . ' Cycle_option="' . $sequence->cycle_option . '"' .
+						' Is_called="' . $this->db->getSequenceIsCalled($sequence->sequence) . '"' .
 						' />';
 				}
 			}

--- a/libraries/joomla/database/exporter/postgresql.php
+++ b/libraries/joomla/database/exporter/postgresql.php
@@ -175,7 +175,7 @@ class JDatabaseExporterPostgresql extends JDatabaseExporter
 					}
 					else
 					{
-						$buffer[] = '    <field name="' . $key . '">' . base64_encode(pg_unescape_bytea($value)) . '</field>';
+						$buffer[] = '    <field name="' . $key . '">' . pg_unescape_bytea($value) . '</field>';
 					}
 				}
 

--- a/libraries/joomla/database/exporter/postgresql.php
+++ b/libraries/joomla/database/exporter/postgresql.php
@@ -83,8 +83,8 @@ class JDatabaseExporterPostgresql extends JDatabaseExporter
 						$sequence->start_value = null;
 					}
 
-					$buffer[] = '   <sequence Name="' . $sequence->sequence . '"' . ' Schema="' . $sequence->schema . '"' .
-						' Table="' . $sequence->table . '"' . ' Column="' . $sequence->column . '"' . ' Type="' . $sequence->data_type . '"' .
+					$buffer[] = '   <sequence Name="' . $this->getGenericTableName($sequence->sequence) . '"' . ' Schema="' . $sequence->schema . '"' .
+						' Table="' . $table . '"' . ' Column="' . $sequence->column . '"' . ' Type="' . $sequence->data_type . '"' .
 						' Start_Value="' . $sequence->start_value . '"' . ' Min_Value="' . $sequence->minimum_value . '"' .
 						' Max_Value="' . $sequence->maximum_value . '"' . ' Last_Value="' . $this->db->getSequenceLastValue($sequence->sequence) . '"' .
 						' Increment="' . $sequence->increment . '"' . ' Cycle_option="' . $sequence->cycle_option . '"' .
@@ -104,7 +104,7 @@ class JDatabaseExporterPostgresql extends JDatabaseExporter
 			{
 				foreach ($keys as $key)
 				{
-					$buffer[] = '   <key Index="' . $key->idxName . '"' . ' is_primary="' . $key->isPrimary . '"' . ' is_unique="' . $key->isUnique . '"' .
+					$buffer[] = '   <key Index="' . $this->getGenericTableName($key->idxName) . '"' . ' is_primary="' . $key->isPrimary . '"' . ' is_unique="' . $key->isUnique . '"' .
 						' Key_name="' . $this->db->getNamesKey($table, $key->indKey) . '"' . ' Query=\'' . $key->Query . '\' />';
 				}
 			}

--- a/libraries/joomla/database/exporter/postgresql.php
+++ b/libraries/joomla/database/exporter/postgresql.php
@@ -65,6 +65,7 @@ class JDatabaseExporterPostgresql extends JDatabaseExporter
 
 		foreach ($this->from as $table)
 		{
+			$table = $this->getGenericTableName($table);
 			// Get the details columns information.
 			$fields = $this->db->getTableColumns($table, false);
 			$keys = $this->db->getTableKeys($table);
@@ -127,6 +128,7 @@ class JDatabaseExporterPostgresql extends JDatabaseExporter
 
 		foreach ($this->from as $table)
 		{
+			$table = $this->getGenericTableName($table);
 			// Get the details columns information.
 			$fields  = $this->db->getTableColumns($table, false);
 			$colblob = array();

--- a/libraries/joomla/database/exporter/postgresql.php
+++ b/libraries/joomla/database/exporter/postgresql.php
@@ -107,7 +107,7 @@ class JDatabaseExporterPostgresql extends JDatabaseExporter
 				foreach ($keys as $key)
 				{
 					$buffer[] = '   <key Index="' . $key->idxName . '"' . ' is_primary="' . $key->isPrimary . '"' . ' is_unique="' . $key->isUnique . '"' .
-						' Query="' . $key->Query . '" />';
+						' Query=\'' . $key->Query . '\' />';
 				}
 			}
 

--- a/libraries/joomla/database/exporter/postgresql.php
+++ b/libraries/joomla/database/exporter/postgresql.php
@@ -77,8 +77,8 @@ class JDatabaseExporterPostgresql extends JDatabaseExporter
 				$buffer[] = '   <sequence Name="' . $sequence->sequence . '"' . ' Schema="' . $sequence->schema . '"' .
 					' Table="' . $sequence->table . '"' . ' Column="' . $sequence->column . '"' . ' Type="' . $sequence->data_type . '"' .
 					' Start_Value="' . $sequence->start_value . '"' . ' Min_Value="' . $sequence->minimum_value . '"' .
-					' Max_Value="' . $sequence->maximum_value . '"' . ' Increment="' . $sequence->increment . '"' .
-					' Cycle_option="' . $sequence->cycle_option . '"' . ' Is_called="YES"' .
+					' Max_Value="' . $sequence->maximum_value . '"' . ' Last_Value="' . $this->db->getSequenceLastValue($sequence->sequence) . '"' .
+					' Increment="' . $sequence->increment . '"' . ' Cycle_option="' . $sequence->cycle_option . '"' . ' Is_called="YES"' .
 					' />';
 			}
 

--- a/libraries/joomla/database/exporter/postgresql.php
+++ b/libraries/joomla/database/exporter/postgresql.php
@@ -119,6 +119,76 @@ class JDatabaseExporterPostgresql extends JDatabaseExporter
 	}
 
 	/**
+	 * Builds the XML data to export.
+	 *
+	 * @return  array  An array of XML lines (strings).
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  Exception if an error occurs.
+	 */
+	protected function buildXmlData()
+	{
+		$buffer = array();
+
+		foreach ($this->from as $table)
+		{
+			// Replace the magic prefix if found.
+			$table = $this->getGenericTableName($table);
+
+			// Get the details columns information.
+			$fields  = $this->db->getTableColumns($table, false);
+			$colblob = array();
+
+			foreach ($fields as $field)
+			{
+				// Cacth blob for xml conversion
+				// PostgreSQL binary large object type
+				if ($field->Type == 'bytea')
+				{
+					$colblob[] = $field->Field;
+				}
+			}
+
+			$query = $this->db->getQuery(true);
+			$query->select($query->qn(array_keys($fields)))
+				->from($query->qn($table));
+			$this->db->setQuery($query);
+
+			$rows = $this->db->loadObjectList();
+
+			if (!count($rows))
+			{
+				continue;
+			}
+
+			$buffer[] = '  <table_data name="' . $table . '">';
+
+			foreach ($rows as $row)
+			{
+				$buffer[] = '   <row>';
+
+				foreach ($row as $key => $value)
+				{
+					if (!in_array($key, $colblob))
+					{
+						$buffer[] = '    <field name="' . $key . '">' . htmlspecialchars($value, ENT_COMPAT, 'UTF-8') . '</field>';
+					}
+					else
+					{
+						$buffer[] = '    <field name="' . $key . '">' . base64_encode(pg_unescape_bytea($value)) . '</field>';
+					}
+				}
+
+				$buffer[] = '   </row>';
+			}
+
+			$buffer[] = '  </table_data>';
+		}
+
+		return $buffer;
+	}
+
+	/**
 	 * Checks if all data and options are in order prior to exporting.
 	 *
 	 * @return  JDatabaseExporterPostgresql  Method supports chaining.

--- a/libraries/joomla/database/exporter/postgresql.php
+++ b/libraries/joomla/database/exporter/postgresql.php
@@ -150,8 +150,8 @@ class JDatabaseExporterPostgresql extends JDatabaseExporter
 			}
 
 			$query = $this->db->getQuery(true);
-			$query->select($query->qn(array_keys($fields)))
-				->from($query->qn($table));
+			$query->select($query->quoteName(array_keys($fields)))
+				->from($query->quoteName($table));
 			$this->db->setQuery($query);
 
 			$rows = $this->db->loadObjectList();

--- a/libraries/joomla/database/exporter/postgresql.php
+++ b/libraries/joomla/database/exporter/postgresql.php
@@ -70,7 +70,7 @@ class JDatabaseExporterPostgresql extends JDatabaseExporter
 
 			// Get the details columns information.
 			$fields = $this->db->getTableColumns($table, false);
-			$prefix   = $this->db->getPrefix();
+			$prefix = $this->db->getPrefix();
 			$table_name = str_replace('#__', $prefix, $table);
 			$keys = $this->db->getTableKeys($table_name);
 			$sequences = $this->db->getTableSequences($table_name);

--- a/libraries/joomla/database/exporter/sqlsrv.php
+++ b/libraries/joomla/database/exporter/sqlsrv.php
@@ -3,35 +3,33 @@
  * @package     Joomla.Platform
  * @subpackage  Database
  *
- * @copyright   Copyright (C) 2005 - 2018 Open Source Matters, Inc. All rights reserved.
+ * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE
  */
 
 defined('JPATH_PLATFORM') or die;
 
 /**
- * MySQL export driver for the PDO based MySQL database driver.
+ * Sqlsrv export driver.
  *
- * @package     Joomla.Platform
- * @subpackage  Database
- * @since       3.4
+ * @since  __DEPLOY_VERSION__
  */
-class JDatabaseExporterPdomysql extends JDatabaseExporter
+class JDatabaseExporterSqlsrv extends JDatabaseExporter
 {
 	/**
 	 * Builds the XML data for the tables to export.
 	 *
 	 * @return  string  An XML string
 	 *
-	 * @since   3.4
+	 * @since   __DEPLOY_VERSION__
 	 * @throws  Exception if an error occurs.
 	 */
 	protected function buildXml()
 	{
-		$buffer   = array();
+		$buffer = array();
 
 		$buffer[] = '<?xml version="1.0"?>';
-		$buffer[] = '<mysqldump xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">';
+		$buffer[] = '<sqlsrvdump xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">';
 		$buffer[] = ' <database name="">';
 
 		if ($this->options->withStructure)
@@ -45,7 +43,7 @@ class JDatabaseExporterPdomysql extends JDatabaseExporter
 		}
 
 		$buffer[] = ' </database>';
-		$buffer[] = '</mysqldump>';
+		$buffer[] = '</sqlsrvdump>';
 
 		return implode("\n", $buffer);
 	}
@@ -55,7 +53,7 @@ class JDatabaseExporterPdomysql extends JDatabaseExporter
 	 *
 	 * @return  array  An array of XML lines (strings).
 	 *
-	 * @since   3.4
+	 * @since   __DEPLOY_VERSION__
 	 * @throws  Exception if an error occurs.
 	 */
 	protected function buildXmlStructure()
@@ -69,14 +67,15 @@ class JDatabaseExporterPdomysql extends JDatabaseExporter
 
 			// Get the details columns information.
 			$fields = $this->db->getTableColumns($table, false);
-			$keys   = $this->db->getTableKeys($table);
+			$keys = $this->db->getTableKeys($table);
 
 			$buffer[] = '  <table_structure name="' . $table . '">';
 
 			foreach ($fields as $field)
 			{
-				$buffer[] = '   <field Field="' . $field->Field . '"' . ' Type="' . $field->Type . '"' . ' Null="' . $field->Null . '"' . ' Key="' .
-					$field->Key . '"' . (isset($field->Default) ? ' Default="' . $field->Default . '"' : '') . ' Extra="' . $field->Extra . '"' .
+				$buffer[] = '   <field Field="' . $field->Field . '"' . ' Type="' . $field->Type . '"' . ' Null="' . $field->Null . '"' .
+					(isset($field->Key) ? ' Key="' . $field->Key . '"' : '') .
+					(isset($field->Default) ? ' Default="' . $field->Default . '"' : '') .
 					' />';
 			}
 
@@ -85,7 +84,7 @@ class JDatabaseExporterPdomysql extends JDatabaseExporter
 				$buffer[] = '   <key Table="' . $table . '"' . ' Non_unique="' . $key->Non_unique . '"' . ' Key_name="' . $key->Key_name . '"' .
 					' Seq_in_index="' . $key->Seq_in_index . '"' . ' Column_name="' . $key->Column_name . '"' . ' Collation="' . $key->Collation . '"' .
 					' Null="' . $key->Null . '"' . ' Index_type="' . $key->Index_type . '"' .
-					' Sub_part="' . $key->Sub_part . '"' .
+					' Sub_part ="' . $key->Sub_part . '"' .
 					' Comment="' . htmlspecialchars($key->Comment, ENT_COMPAT, 'UTF-8') . '"' . ' />';
 			}
 
@@ -98,15 +97,15 @@ class JDatabaseExporterPdomysql extends JDatabaseExporter
 	/**
 	 * Checks if all data and options are in order prior to exporting.
 	 *
-	 * @return  JDatabaseExporterPdomysql  Method supports chaining.
+	 * @return  JDatabaseExporterSqlsrv  Method supports chaining.
 	 *
-	 * @since   3.4
+	 * @since   __DEPLOY_VERSION__
 	 * @throws  Exception if an error is encountered.
 	 */
 	public function check()
 	{
 		// Check if the db connector has been set.
-		if (!($this->db instanceof JDatabaseDriverPdomysql))
+		if (!($this->db instanceof JDatabaseDriverSqlsrv))
 		{
 			throw new Exception('JPLATFORM_ERROR_DATABASE_CONNECTOR_WRONG_TYPE');
 		}

--- a/libraries/joomla/database/importer.php
+++ b/libraries/joomla/database/importer.php
@@ -246,9 +246,15 @@ abstract class JDatabaseImporter
 			{
 				// This is a new table.
 				$sql = $this->xmlToCreate($table);
-
-				$this->db->setQuery((string) $sql);
-				$this->db->execute();
+				$queries = explode(';', (string) $sql);
+				foreach ($queries as $query)
+        {
+					if(!empty($query))
+          {
+            $this->db->setQuery($query);
+            $this->db->execute();
+          }
+				}
 			}
 		}
 	}

--- a/libraries/joomla/database/importer.php
+++ b/libraries/joomla/database/importer.php
@@ -250,10 +250,10 @@ abstract class JDatabaseImporter
 				foreach ($queries as $query)
 				{
 					if(!empty($query))
-          				{
-            					$this->db->setQuery($query);
-            					$this->db->execute();
-          				}
+					{
+						$this->db->setQuery($query);
+						$this->db->execute();
+					}
 				}
 			}
 		}

--- a/libraries/joomla/database/importer.php
+++ b/libraries/joomla/database/importer.php
@@ -153,6 +153,51 @@ abstract class JDatabaseImporter
 	}
 
 	/**
+	 * Import the data from the source into the existing tables.
+	 *
+	 * @return  void
+	 *
+	 * @note    Currently only supports XML format.
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  RuntimeException on error.
+	 */
+	public function importData()
+	{
+		if ($this->from instanceof SimpleXMLElement)
+		{
+			$xml = $this->from;
+		}
+		else
+		{
+			$xml = new SimpleXMLElement($this->from);
+		}
+
+		// Get all the table definitions.
+		$xmlTables = $xml->xpath('database/table_data');
+
+		foreach ($xmlTables as $table)
+		{
+			$tableName = (string) $table['name'];
+			$rows = $table->children();
+
+			foreach ($rows as $row)
+			{
+				if ($row->getName() == 'row')
+				{
+					$entry = new stdClass;
+
+					foreach ($row->children() as $data)
+					{
+						$entry->{(string) $data['name']} = (string) $data;
+					}
+
+					$this->db->insertObject($tableName, $entry);
+				}
+			}
+		}
+	}
+
+	/**
 	 * Merges the incoming structure definition with the existing structure.
 	 *
 	 * @return  void

--- a/libraries/joomla/database/importer.php
+++ b/libraries/joomla/database/importer.php
@@ -247,6 +247,7 @@ abstract class JDatabaseImporter
 				// This is a new table.
 				$sql = $this->xmlToCreate($table);
 				$queries = explode(';', (string) $sql);
+
 				foreach ($queries as $query)
 				{
 					if (!empty($query))

--- a/libraries/joomla/database/importer.php
+++ b/libraries/joomla/database/importer.php
@@ -248,12 +248,12 @@ abstract class JDatabaseImporter
 				$sql = $this->xmlToCreate($table);
 				$queries = explode(';', (string) $sql);
 				foreach ($queries as $query)
-        {
+				{
 					if(!empty($query))
-          {
-            $this->db->setQuery($query);
-            $this->db->execute();
-          }
+          				{
+            					$this->db->setQuery($query);
+            					$this->db->execute();
+          				}
 				}
 			}
 		}

--- a/libraries/joomla/database/importer.php
+++ b/libraries/joomla/database/importer.php
@@ -249,7 +249,7 @@ abstract class JDatabaseImporter
 				$queries = explode(';', (string) $sql);
 				foreach ($queries as $query)
 				{
-					if(!empty($query))
+					if (!empty($query))
 					{
 						$this->db->setQuery($query);
 						$this->db->execute();

--- a/libraries/joomla/database/importer/pdomysql.php
+++ b/libraries/joomla/database/importer/pdomysql.php
@@ -30,9 +30,7 @@ class JDatabaseImporterPdomysql extends JDatabaseImporter
 	 */
 	protected function getAddColumnSql($table, SimpleXMLElement $field)
 	{
-		$sql = 'ALTER TABLE ' . $this->db->quoteName($table) . ' ADD COLUMN ' . $this->getColumnSql($field);
-
-		return $sql;
+		return 'ALTER TABLE ' . $this->db->quoteName($table) . ' ADD COLUMN ' . $this->getColumnSql($field);
 	}
 
 	/**
@@ -47,9 +45,7 @@ class JDatabaseImporterPdomysql extends JDatabaseImporter
 	 */
 	protected function getAddKeySql($table, $keys)
 	{
-		$sql = 'ALTER TABLE ' . $this->db->quoteName($table) . ' ADD ' . $this->getKeySql($keys);
-
-		return $sql;
+		return 'ALTER TABLE ' . $this->db->quoteName($table) . ' ADD ' . $this->getKeySql($keys);
 	}
 
 	/**
@@ -133,6 +129,7 @@ class JDatabaseImporterPdomysql extends JDatabaseImporter
 							&& ((string) $newLookup[$name][$i]['Column_name'] == $oldLookup[$name][$i]->Column_name)
 							&& ((string) $newLookup[$name][$i]['Seq_in_index'] == $oldLookup[$name][$i]->Seq_in_index)
 							&& ((string) $newLookup[$name][$i]['Collation'] == $oldLookup[$name][$i]->Collation)
+							&& ((string) $newLookup[$name][$i]['Sub_part'] == $oldLookup[$name][$i]->Sub_part)
 							&& ((string) $newLookup[$name][$i]['Index_type'] == $oldLookup[$name][$i]->Index_type));
 
 						/*
@@ -214,10 +211,8 @@ class JDatabaseImporterPdomysql extends JDatabaseImporter
 	 */
 	protected function getChangeColumnSql($table, SimpleXMLElement $field)
 	{
-		$sql = 'ALTER TABLE ' . $this->db->quoteName($table) . ' CHANGE COLUMN ' . $this->db->quoteName((string) $field['Field']) . ' '
+		return 'ALTER TABLE ' . $this->db->quoteName($table) . ' CHANGE COLUMN ' . $this->db->quoteName((string) $field['Field']) . ' '
 			. $this->getColumnSql($field);
-
-		return $sql;
 	}
 
 	/**
@@ -241,39 +236,46 @@ class JDatabaseImporterPdomysql extends JDatabaseImporter
 		$fDefault = isset($field['Default']) ? (string) $field['Default'] : null;
 		$fExtra   = (string) $field['Extra'];
 
-		$sql = $this->db->quoteName($fName) . ' ' . $fType;
+		$query = $this->db->quoteName($fName) . ' ' . $fType;
 
 		if ($fNull == 'NO')
 		{
 			if (in_array($fType, $blobs) || $fDefault === null)
 			{
-				$sql .= ' NOT NULL';
+				$query .= ' NOT NULL';
 			}
 			else
 			{
 				// TODO Don't quote numeric values.
-				$sql .= ' NOT NULL DEFAULT ' . $this->db->quote($fDefault);
+				if (strpos($fDefault, 'CURRENT') !== false)
+				{
+					$query .= ' NOT NULL DEFAULT CURRENT_TIMESTAMP()';
+				}
+				else
+				{
+					$query .= ' NOT NULL DEFAULT ' . $this->db->quote($fDefault);
+				}
 			}
 		}
 		else
 		{
 			if ($fDefault === null)
 			{
-				$sql .= ' DEFAULT NULL';
+				$query .= ' DEFAULT NULL';
 			}
 			else
 			{
 				// TODO Don't quote numeric values.
-				$sql .= ' DEFAULT ' . $this->db->quote($fDefault);
+				$query .= ' DEFAULT ' . $this->db->quote($fDefault);
 			}
 		}
 
 		if ($fExtra)
 		{
-			$sql .= ' ' . strtoupper($fExtra);
+			$query .= ' ' . strtoupper($fExtra);
 		}
 
-		return $sql;
+		return $query;
 	}
 
 	/**
@@ -288,9 +290,7 @@ class JDatabaseImporterPdomysql extends JDatabaseImporter
 	 */
 	protected function getDropColumnSql($table, $name)
 	{
-		$sql = 'ALTER TABLE ' . $this->db->quoteName($table) . ' DROP COLUMN ' . $this->db->quoteName($name);
-
-		return $sql;
+		return 'ALTER TABLE ' . $this->db->quoteName($table) . ' DROP COLUMN ' . $this->db->quoteName($name);
 	}
 
 	/**
@@ -305,9 +305,7 @@ class JDatabaseImporterPdomysql extends JDatabaseImporter
 	 */
 	protected function getDropKeySql($table, $name)
 	{
-		$sql = 'ALTER TABLE ' . $this->db->quoteName($table) . ' DROP KEY ' . $this->db->quoteName($name);
-
-		return $sql;
+		return 'ALTER TABLE ' . $this->db->quoteName($table) . ' DROP KEY ' . $this->db->quoteName($name);
 	}
 
 	/**
@@ -321,9 +319,7 @@ class JDatabaseImporterPdomysql extends JDatabaseImporter
 	 */
 	protected function getDropPrimaryKeySql($table)
 	{
-		$sql = 'ALTER TABLE ' . $this->db->quoteName($table) . ' DROP PRIMARY KEY';
-
-		return $sql;
+		return 'ALTER TABLE ' . $this->db->quoteName($table) . ' DROP PRIMARY KEY';
 	}
 
 	/**
@@ -374,11 +370,8 @@ class JDatabaseImporterPdomysql extends JDatabaseImporter
 	 */
 	protected function getKeySql($columns)
 	{
-		// TODO Error checking on array and element types.
-
 		$kNonUnique = (string) $columns[0]['Non_unique'];
 		$kName      = (string) $columns[0]['Key_name'];
-		$kColumn    = (string) $columns[0]['Column_name'];
 		$prefix     = '';
 
 		if ($kName == 'PRIMARY')
@@ -390,24 +383,21 @@ class JDatabaseImporterPdomysql extends JDatabaseImporter
 			$prefix = 'UNIQUE ';
 		}
 
-		$nColumns = count($columns);
 		$kColumns = array();
 
-		if ($nColumns == 1)
+		foreach ($columns as $column)
 		{
-			$kColumns[] = $this->db->quoteName($kColumn);
-		}
-		else
-		{
-			foreach ($columns as $column)
+			$kLength = '';
+
+			if (!empty($column['Sub_part']))
 			{
-				$kColumns[] = (string) $column['Column_name'];
+				$kLength = '(' . $column['Sub_part'] . ')';
 			}
+
+			$kColumns[] = $this->db->quoteName((string) $column['Column_name']) . $kLength;
 		}
 
-		$sql = $prefix . 'KEY ' . ($kName != 'PRIMARY' ? $this->db->quoteName($kName) : '') . ' (' . implode(',', $kColumns) . ')';
-
-		return $sql;
+		return $prefix . 'KEY ' . ($kName != 'PRIMARY' ? $this->db->quoteName($kName) : '') . ' (' . implode(',', $kColumns) . ')';
 	}
 
 	/**
@@ -433,5 +423,48 @@ class JDatabaseImporterPdomysql extends JDatabaseImporter
 		}
 
 		return $this;
+	}
+
+	/**
+	 * Get the SQL syntax to add a table.
+	 *
+	 * @param   SimpleXMLElement  $table  The table information.
+	 *
+	 * @return  string
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  RuntimeException
+	 */
+	protected function xmlToCreate(SimpleXMLElement $table)
+	{
+		$existingTables = $this->db->getTableList();
+		$tableName = (string) $table['name'];
+
+		if (in_array($tableName, $existingTables))
+		{
+			throw new RuntimeException('The table you are trying to create already exists');
+		}
+
+		$createTableStatement = 'CREATE TABLE ' . $this->db->quoteName($tableName) . ' (';
+
+		foreach ($table->xpath('field') as $field)
+		{
+			$createTableStatement .= $this->getColumnSQL($field) . ', ';
+		}
+
+		$newLookup = $this->getKeyLookup($table->xpath('key'));
+
+		// Loop through each key in the new structure.
+		foreach ($newLookup as $key)
+		{
+			$createTableStatement .= $this->getKeySQL($key) . ', ';
+		}
+
+		// Remove the comma after the last key
+		$createTableStatement = rtrim($createTableStatement, ', ');
+
+		$createTableStatement .= ')';
+
+		return $createTableStatement;
 	}
 }

--- a/libraries/joomla/database/importer/postgresql.php
+++ b/libraries/joomla/database/importer/postgresql.php
@@ -411,7 +411,7 @@ class JDatabaseImporterPostgresql extends JDatabaseImporter
 	 */
 	protected function getSetvalSequenceSql($field)
 	{
-		$is_called = $field['Is_called'] == 't' ? 'TRUE' : 'FALSE';
+		$is_called = $field['Is_called'] == 't' || $field['Is_called'] == '1' ? 'TRUE' : 'FALSE';
 
 		return 'SELECT setval(\'' . (string) $field['Name'] . '\', ' . (string) $field['Last_Value'] . ', ' . $is_called . ')';
 	}

--- a/libraries/joomla/database/importer/postgresql.php
+++ b/libraries/joomla/database/importer/postgresql.php
@@ -622,7 +622,7 @@ class JDatabaseImporterPostgresql extends JDatabaseImporter
 	 * Get the SQL syntax to add a unique constraint for a table key.
 	 *
 	 * @param   string  $table  The table name.
-	 * @param   array   $key   The key.
+	 * @param   array   $key    The key.
 	 *
 	 * @return  string
 	 *
@@ -631,15 +631,15 @@ class JDatabaseImporterPostgresql extends JDatabaseImporter
 	protected function getAddUniqueSql($table, $key)
 	{
 		if ($key instanceof SimpleXMLElement)
-                {
-                        $kName = (string) $key['Key_name'];
-                        $kIndex = (string) $key['Index'];
-                }
-                else
-                {
-                        $kName = $key->Key_name;
-                        $kIndex = $key->Index;
-                }
+		{
+			$kName = (string) $key['Key_name'];
+			$kIndex = (string) $key['Index'];
+		}
+		else
+		{
+			$kName = $key->Key_name;
+			$kIndex = $key->Index;
+		}
 
 		$unique = $kIndex . ' UNIQUE (' . $kName . ')';
 

--- a/libraries/joomla/database/importer/postgresql.php
+++ b/libraries/joomla/database/importer/postgresql.php
@@ -411,7 +411,9 @@ class JDatabaseImporterPostgresql extends JDatabaseImporter
 	 */
 	protected function getSetvalSequenceSql($field)
 	{
-		return 'SELECT setval(\'' . (string) $field['Name'] . '\', ' . (string) $field['Last_Value'] . ', true)';
+		$is_called = $field['Is_called'] == 't' ? 'TRUE' : 'FALSE';
+
+		return 'SELECT setval(\'' . (string) $field['Name'] . '\', ' . (string) $field['Last_Value'] . ', ' . $is_called . ')';
 	}
 
 	/**

--- a/libraries/joomla/database/importer/postgresql.php
+++ b/libraries/joomla/database/importer/postgresql.php
@@ -283,7 +283,7 @@ class JDatabaseImporterPostgresql extends JDatabaseImporter
 			$field['Start_Value'] = '1';
 		}
 
-		return 'CREATE SEQUENCE ' . (string) $field['Name'] .
+		return 'CREATE SEQUENCE IF NOT EXISTS ' . (string) $field['Name'] .
 			' INCREMENT BY ' . (string) $field['Increment'] . ' MINVALUE ' . $field['Min_Value'] .
 			' MAXVALUE ' . (string) $field['Max_Value'] . ' START ' . (string) $field['Start_Value'] .
 			(((string) $field['Cycle_option'] == 'NO') ? ' NO' : '') . ' CYCLE' .
@@ -405,9 +405,17 @@ class JDatabaseImporterPostgresql extends JDatabaseImporter
 		$fName = (string) $field['Field'];
 		$fType = (string) $field['Type'];
 		$fNull = (string) $field['Null'];
-		$fDefault = (isset($field['Default']) && $field['Default'] != 'NULL') ?
-						preg_match('/^[0-9]$/', $field['Default']) ? $field['Default'] : $this->db->quote((string) $field['Default'])
-					: null;
+
+		if (strpos($field['Default'], "::") != false)
+		{
+			$fDefault = strstr($field['Default'], '::', true);
+		}
+		else
+		{
+			$fDefault = (isset($field['Default']) && (strlen($field['Default']) != 0)) ?
+							preg_match('/^[0-9]$/', $field['Default']) ? $field['Default'] : $this->db->quote((string) $field['Default'])
+							: null;
+		}
 
 		/* nextval() as default value means that type field is serial */
 		if (strpos($fDefault, 'nextval') !== false)

--- a/libraries/joomla/database/importer/postgresql.php
+++ b/libraries/joomla/database/importer/postgresql.php
@@ -496,9 +496,6 @@ class JDatabaseImporterPostgresql extends JDatabaseImporter
 	 */
 	protected function getColumnSql(SimpleXMLElement $field)
 	{
-		// TODO Incorporate into parent class and use $this.
-		$blobs = array('text', 'smalltext', 'mediumtext', 'largetext');
-
 		$fName = (string) $field['Field'];
 		$fType = (string) $field['Type'];
 		$fNull = (string) $field['Null'];
@@ -525,7 +522,7 @@ class JDatabaseImporterPostgresql extends JDatabaseImporter
 
 			if ($fNull == 'NO')
 			{
-				if (in_array($fType, $blobs) || $fDefault === null)
+				if ($fDefault === null)
 				{
 					$query .= ' NOT NULL';
 				}

--- a/libraries/joomla/database/importer/postgresql.php
+++ b/libraries/joomla/database/importer/postgresql.php
@@ -287,7 +287,8 @@ class JDatabaseImporterPostgresql extends JDatabaseImporter
 			' INCREMENT BY ' . (string) $field['Increment'] . ' MINVALUE ' . $field['Min_Value'] .
 			' MAXVALUE ' . (string) $field['Max_Value'] . ' START ' . (string) $field['Start_Value'] .
 			(((string) $field['Cycle_option'] == 'NO') ? ' NO' : '') . ' CYCLE' .
-			' OWNED BY ' . $this->db->quoteName((string) $field['Schema'] . '.' . (string) $field['Table'] . '.' . (string) $field['Column']);
+			' OWNED BY ' . $this->db->quoteName((string) $field['Schema'] . '.' . (string) $field['Table'] . '.' . (string) $field['Column']) . '; ' .
+			"SELECT setval('" . (string) $field['Name'] . "', " . (string) $field['Last_Value'] . ", true)";
 	}
 
 	/**

--- a/libraries/joomla/database/importer/postgresql.php
+++ b/libraries/joomla/database/importer/postgresql.php
@@ -74,13 +74,13 @@ class JDatabaseImporterPostgresql extends JDatabaseImporter
 
 		foreach ($table->xpath('sequence') as $seq)
 		{
-			$createTableStatement .= $this->getAddSequenceSql($seq) . '; ';
-			$createTableStatement .= $this->getSetvalSequenceSql($seq) . '; ';
+			$createTableStatement .= $this->getAddSequenceSql($seq) . ';';
+			$createTableStatement .= $this->getSetvalSequenceSql($seq) . ';';
 		}
 
 		foreach ($table->xpath('key') as $key)
 		{
-			$createTableStatement .= $this->getAddIndexSql($key) . '; ';
+			$createTableStatement .= $this->getAddIndexSql($key) . ';';
 		}
 
 		return $createTableStatement;

--- a/libraries/joomla/database/importer/postgresql.php
+++ b/libraries/joomla/database/importer/postgresql.php
@@ -43,6 +43,87 @@ class JDatabaseImporterPostgresql extends JDatabaseImporter
 	}
 
 	/**
+	 * Get the SQL syntax to add a table.
+	 *
+	 * @param   SimpleXMLElement  $table  The table information.
+	 *
+	 * @return  string
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  RuntimeException
+	 */
+	protected function xmlToCreate(SimpleXMLElement $table)
+	{
+		$existingTables = $this->db->getTableList();
+		$tableName = (string) $table['name'];
+
+		if (in_array($tableName, $existingTables))
+		{
+			throw new RuntimeException('The table you are trying to create already exists');
+		}
+
+		$createTableStatement = 'CREATE TABLE ' . $this->db->quoteName($tableName) . ' (';
+
+		foreach ($table->xpath('field') as $field)
+		{
+			$createTableStatement .= $this->getColumnSQL($field) . ', ';
+		}
+
+		$createTableStatement = rtrim($createTableStatement, ', ');
+		$createTableStatement .= ');';
+
+		foreach ($table->xpath('sequence') as $seq)
+		{
+			$createTableStatement .= $this->getAddSequenceSql($seq) . '; ';
+			$createTableStatement .= $this->getSetvalSequenceSql($seq) . '; ';
+		}
+
+		foreach ($table->xpath('key') as $key)
+		{
+			$createTableStatement .= $this->getAddIndexSql($key) . '; ';
+		}
+
+		return $createTableStatement;
+	}
+
+	/**
+	 * Get the details list of keys for a table.
+	 *
+	 * @param   array  $keys  An array of objects that comprise the keys for the table.
+	 *
+	 * @return  array  The lookup array. array({key name} => array(object, ...))
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  Exception
+	 */
+	protected function getKeyLookup($keys)
+	{
+		// First pass, create a lookup of the keys.
+		$lookup = array();
+
+		foreach ($keys as $key)
+		{
+			if ($key instanceof SimpleXMLElement)
+			{
+				$kName = (string) $key['Key_name'];
+			}
+			else
+			{
+				$kName = $key->Key_name;
+			}
+
+			if (empty($lookup[$kName]))
+			{
+				$lookup[$kName] = array();
+			}
+
+			$lookup[$kName][] = $key;
+		}
+
+		return $lookup;
+	}
+
+	/**
 	 * Get the SQL syntax to add a column.
 	 *
 	 * @param   string            $table  The table name.

--- a/libraries/joomla/database/importer/sqlsrv.php
+++ b/libraries/joomla/database/importer/sqlsrv.php
@@ -3,31 +3,31 @@
  * @package     Joomla.Platform
  * @subpackage  Database
  *
- * @copyright   Copyright (C) 2005 - 2018 Open Source Matters, Inc. All rights reserved.
+ * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE
  */
 
 defined('JPATH_PLATFORM') or die;
 
 /**
- * MySQLi import driver.
+ * Sqlsrv import driver.
  *
- * @since  1.7.0
+ * @since  __DEPLOY_VERSION__
  */
-class JDatabaseImporterMysqli extends JDatabaseImporter
+class JDatabaseImporterSqlsrv extends JDatabaseImporter
 {
 	/**
 	 * Checks if all data and options are in order prior to exporting.
 	 *
-	 * @return  JDatabaseImporterMysqli  Method supports chaining.
+	 * @return  JDatabaseImporterSqlsrv  Method supports chaining.
 	 *
-	 * @since   1.7.0
+	 * @since   __DEPLOY_VERSION__
 	 * @throws  Exception if an error is encountered.
 	 */
 	public function check()
 	{
 		// Check if the db connector has been set.
-		if (!($this->db instanceof JDatabaseDriverMysqli))
+		if (!($this->db instanceof JDatabaseDriverSqlsrv))
 		{
 			throw new Exception('JPLATFORM_ERROR_DATABASE_CONNECTOR_WRONG_TYPE');
 		}
@@ -48,7 +48,7 @@ class JDatabaseImporterMysqli extends JDatabaseImporter
 	 *
 	 * @return  string
 	 *
-	 * @since   1.7.0
+	 * @since   __DEPLOY_VERSION__
 	 * @throws  RuntimeException
 	 */
 	protected function xmlToCreate(SimpleXMLElement $table)
@@ -68,14 +68,6 @@ class JDatabaseImporterMysqli extends JDatabaseImporter
 			$createTableStatement .= $this->getColumnSQL($field) . ', ';
 		}
 
-		$newLookup = $this->getKeyLookup($table->xpath('key'));
-
-		// Loop through each key in the new structure.
-		foreach ($newLookup as $key)
-		{
-			$createTableStatement .= $this->getKeySQL($key) . ', ';
-		}
-
 		// Remove the comma after the last key
 		$createTableStatement = rtrim($createTableStatement, ', ');
 
@@ -92,7 +84,7 @@ class JDatabaseImporterMysqli extends JDatabaseImporter
 	 *
 	 * @return  string
 	 *
-	 * @since   1.7.0
+	 * @since   __DEPLOY_VERSION__
 	 */
 	protected function getAddColumnSql($table, SimpleXMLElement $field)
 	{
@@ -107,7 +99,7 @@ class JDatabaseImporterMysqli extends JDatabaseImporter
 	 *
 	 * @return  string
 	 *
-	 * @since   1.7.0
+	 * @since   __DEPLOY_VERSION__
 	 */
 	protected function getAddKeySql($table, $keys)
 	{
@@ -117,16 +109,16 @@ class JDatabaseImporterMysqli extends JDatabaseImporter
 	/**
 	 * Get alters for table if there is a difference.
 	 *
-	 * @param   SimpleXMLElement  $structure  The XML structure of the table.
+	 * @param   SimpleXMLElement  $structure  The XML structure pf the table.
 	 *
 	 * @return  array
 	 *
-	 * @since   1.7.0
+	 * @since   __DEPLOY_VERSION__
 	 */
 	protected function getAlterTableSql(SimpleXMLElement $structure)
 	{
 		$table = $this->getRealTableName($structure['name']);
-		$oldFields = $this->db->getTableColumns($table, false);
+		$oldFields = $this->db->getTableColumns($table);
 		$oldKeys = $this->db->getTableKeys($table);
 		$alters = array();
 
@@ -194,30 +186,7 @@ class JDatabaseImporterMysqli extends JDatabaseImporter
 							&& ((string) $newLookup[$name][$i]['Column_name'] == $oldLookup[$name][$i]->Column_name)
 							&& ((string) $newLookup[$name][$i]['Seq_in_index'] == $oldLookup[$name][$i]->Seq_in_index)
 							&& ((string) $newLookup[$name][$i]['Collation'] == $oldLookup[$name][$i]->Collation)
-							&& ((string) $newLookup[$name][$i]['Sub_part'] == $oldLookup[$name][$i]->Sub_part)
 							&& ((string) $newLookup[$name][$i]['Index_type'] == $oldLookup[$name][$i]->Index_type));
-
-						/*
-						Debug.
-						echo '<pre>';
-						echo '<br />Non_unique:   '.
-							((string) $newLookup[$name][$i]['Non_unique'] == $oldLookup[$name][$i]->Non_unique ? 'Pass' : 'Fail').' '.
-							(string) $newLookup[$name][$i]['Non_unique'].' vs '.$oldLookup[$name][$i]->Non_unique;
-						echo '<br />Column_name:  '.
-							((string) $newLookup[$name][$i]['Column_name'] == $oldLookup[$name][$i]->Column_name ? 'Pass' : 'Fail').' '.
-							(string) $newLookup[$name][$i]['Column_name'].' vs '.$oldLookup[$name][$i]->Column_name;
-						echo '<br />Seq_in_index: '.
-							((string) $newLookup[$name][$i]['Seq_in_index'] == $oldLookup[$name][$i]->Seq_in_index ? 'Pass' : 'Fail').' '.
-							(string) $newLookup[$name][$i]['Seq_in_index'].' vs '.$oldLookup[$name][$i]->Seq_in_index;
-						echo '<br />Collation:    '.
-							((string) $newLookup[$name][$i]['Collation'] == $oldLookup[$name][$i]->Collation ? 'Pass' : 'Fail').' '.
-							(string) $newLookup[$name][$i]['Collation'].' vs '.$oldLookup[$name][$i]->Collation;
-						echo '<br />Index_type:   '.
-							((string) $newLookup[$name][$i]['Index_type'] == $oldLookup[$name][$i]->Index_type ? 'Pass' : 'Fail').' '.
-							(string) $newLookup[$name][$i]['Index_type'].' vs '.$oldLookup[$name][$i]->Index_type;
-						echo '<br />Same = '.($same ? 'true' : 'false');
-						echo '</pre>';
-						 */
 
 						if (!$same)
 						{
@@ -272,7 +241,7 @@ class JDatabaseImporterMysqli extends JDatabaseImporter
 	 *
 	 * @return  string
 	 *
-	 * @since   1.7.0
+	 * @since   __DEPLOY_VERSION__
 	 */
 	protected function getChangeColumnSql($table, SimpleXMLElement $field)
 	{
@@ -287,7 +256,7 @@ class JDatabaseImporterMysqli extends JDatabaseImporter
 	 *
 	 * @return  string
 	 *
-	 * @since   1.7.0
+	 * @since   __DEPLOY_VERSION__
 	 */
 	protected function getColumnSql(SimpleXMLElement $field)
 	{
@@ -311,14 +280,7 @@ class JDatabaseImporterMysqli extends JDatabaseImporter
 			else
 			{
 				// TODO Don't quote numeric values.
-				if (strpos($fDefault, 'CURRENT') !== false)
-				{
-					$query .= ' NOT NULL DEFAULT CURRENT_TIMESTAMP()';
-				}
-				else
-				{
-					$query .= ' NOT NULL DEFAULT ' . $this->db->quote($fDefault);
-				}
+				$query .= ' NOT NULL DEFAULT ' . $this->db->quote($fDefault);
 			}
 		}
 		else
@@ -350,7 +312,7 @@ class JDatabaseImporterMysqli extends JDatabaseImporter
 	 *
 	 * @return  string
 	 *
-	 * @since   1.7.0
+	 * @since   __DEPLOY_VERSION__
 	 */
 	protected function getDropKeySql($table, $name)
 	{
@@ -364,7 +326,7 @@ class JDatabaseImporterMysqli extends JDatabaseImporter
 	 *
 	 * @return  string
 	 *
-	 * @since   1.7.0
+	 * @since   __DEPLOY_VERSION__
 	 */
 	protected function getDropPrimaryKeySql($table)
 	{
@@ -378,7 +340,7 @@ class JDatabaseImporterMysqli extends JDatabaseImporter
 	 *
 	 * @return  array  The lookup array. array({key name} => array(object, ...))
 	 *
-	 * @since   1.7.0
+	 * @since   __DEPLOY_VERSION__
 	 * @throws  Exception
 	 */
 	protected function getKeyLookup($keys)
@@ -415,7 +377,7 @@ class JDatabaseImporterMysqli extends JDatabaseImporter
 	 *
 	 * @return  string
 	 *
-	 * @since   1.7.0
+	 * @since   __DEPLOY_VERSION__
 	 */
 	protected function getKeySql($columns)
 	{

--- a/tests/unit/suites/database/driver/mysql/JDatabaseExporterMysqlTest.php
+++ b/tests/unit/suites/database/driver/mysql/JDatabaseExporterMysqlTest.php
@@ -21,7 +21,7 @@ class JDatabaseExporterMysqlTest extends TestCase
   <table_structure name="#__test">
    <field Field="id" Type="int(11) unsigned" Null="NO" Key="PRI" Default="" Extra="auto_increment" />
    <field Field="title" Type="varchar(255)" Null="NO" Key="" Default="" Extra="" />
-   <key Table="#__test" Non_unique="0" Key_name="PRIMARY" Seq_in_index="1" Column_name="id" Collation="A" Null="" Index_type="BTREE" Comment="" />
+   <key Table="#__test" Non_unique="0" Key_name="PRIMARY" Seq_in_index="1" Column_name="id" Collation="A" Null="" Index_type="BTREE" Sub_part="" Comment="" />
   </table_structure>
  </database>
 </mysqldump>';
@@ -223,7 +223,7 @@ class JDatabaseExporterMysqlTest extends TestCase
 				'   <field Field="id" Type="int(11) unsigned" Null="NO" Key="PRI" Default="" Extra="auto_increment" />',
 				'   <field Field="title" Type="varchar(255)" Null="NO" Key="" Default="" Extra="" />',
 				'   <key Table="#__test" Non_unique="0" Key_name="PRIMARY" Seq_in_index="1" Column_name="id" Collation="A" ' .
-				'Null="" Index_type="BTREE" Comment="" />',
+				'Null="" Index_type="BTREE" Sub_part="" Comment="" />',
 				'  </table_structure>'
 			),
 			TestReflection::invoke($instance, 'buildXmlStructure')

--- a/tests/unit/suites/database/driver/mysqli/JDatabaseExporterMysqliTest.php
+++ b/tests/unit/suites/database/driver/mysqli/JDatabaseExporterMysqliTest.php
@@ -129,7 +129,7 @@ class JDatabaseExporterMysqliTest extends TestCase
   <table_structure name="#__test">
    <field Field="id" Type="int(11) unsigned" Null="NO" Key="PRI" Default="" Extra="auto_increment" />
    <field Field="title" Type="varchar(255)" Null="NO" Key="" Default="" Extra="" />
-   <key Table="#__test" Non_unique="0" Key_name="PRIMARY" Seq_in_index="1" Column_name="id" Collation="A" Null="" Index_type="BTREE" Comment="" />
+   <key Table="#__test" Non_unique="0" Key_name="PRIMARY" Seq_in_index="1" Column_name="id" Collation="A" Null="" Index_type="BTREE" Sub_part="" Comment="" />
   </table_structure>
  </database>
 </mysqldump>';
@@ -180,7 +180,7 @@ class JDatabaseExporterMysqliTest extends TestCase
   <table_structure name="#__test">
    <field Field="id" Type="int(11) unsigned" Null="NO" Key="PRI" Default="" Extra="auto_increment" />
    <field Field="title" Type="varchar(255)" Null="NO" Key="" Default="" Extra="" />
-   <key Table="#__test" Non_unique="0" Key_name="PRIMARY" Seq_in_index="1" Column_name="id" Collation="A" Null="" Index_type="BTREE" Comment="" />
+   <key Table="#__test" Non_unique="0" Key_name="PRIMARY" Seq_in_index="1" Column_name="id" Collation="A" Null="" Index_type="BTREE" Sub_part="" Comment="" />
   </table_structure>
  </database>
 </mysqldump>';
@@ -210,7 +210,7 @@ class JDatabaseExporterMysqliTest extends TestCase
 				'   <field Field="id" Type="int(11) unsigned" Null="NO" Key="PRI" Default="" Extra="auto_increment" />',
 				'   <field Field="title" Type="varchar(255)" Null="NO" Key="" Default="" Extra="" />',
 				'   <key Table="#__test" Non_unique="0" Key_name="PRIMARY" Seq_in_index="1" Column_name="id" Collation="A" ' .
-				'Null="" Index_type="BTREE" Comment="" />',
+				'Null="" Index_type="BTREE" Sub_part="" Comment="" />',
 				'  </table_structure>'
 			),
 			TestReflection::invoke($instance, 'buildXmlStructure')

--- a/tests/unit/suites/database/driver/pdomysql/JDatabaseExporterPdomysqlTest.php
+++ b/tests/unit/suites/database/driver/pdomysql/JDatabaseExporterPdomysqlTest.php
@@ -112,6 +112,7 @@ class JDatabaseExporterPdomysqlTest extends \PHPUnit\Framework\TestCase
 						'Packed' => '',
 						'Null' => '',
 						'Index_type' => 'BTREE',
+						'Sub_part' => '',
 						'Comment' => '',
 					)
 					)
@@ -227,7 +228,7 @@ class JDatabaseExporterPdomysqlTest extends \PHPUnit\Framework\TestCase
   <table_structure name="#__test">
    <field Field="id" Type="int(11) unsigned" Null="NO" Key="PRI" Default="" Extra="auto_increment" />
    <field Field="title" Type="varchar(255)" Null="NO" Key="" Default="" Extra="" />
-   <key Table="#__test" Non_unique="0" Key_name="PRIMARY" Seq_in_index="1" Column_name="id" Collation="A" Null="" Index_type="BTREE" Comment="" />
+   <key Table="#__test" Non_unique="0" Key_name="PRIMARY" Seq_in_index="1" Column_name="id" Collation="A" Null="" Index_type="BTREE" Sub_part="" Comment="" />
   </table_structure>
  </database>
 </mysqldump>';
@@ -290,7 +291,7 @@ class JDatabaseExporterPdomysqlTest extends \PHPUnit\Framework\TestCase
   <table_structure name="#__test">
    <field Field="id" Type="int(11) unsigned" Null="NO" Key="PRI" Default="" Extra="auto_increment" />
    <field Field="title" Type="varchar(255)" Null="NO" Key="" Default="" Extra="" />
-   <key Table="#__test" Non_unique="0" Key_name="PRIMARY" Seq_in_index="1" Column_name="id" Collation="A" Null="" Index_type="BTREE" Comment="" />
+   <key Table="#__test" Non_unique="0" Key_name="PRIMARY" Seq_in_index="1" Column_name="id" Collation="A" Null="" Index_type="BTREE" Sub_part="" Comment="" />
   </table_structure>
  </database>
 </mysqldump>';
@@ -330,7 +331,7 @@ class JDatabaseExporterPdomysqlTest extends \PHPUnit\Framework\TestCase
 					'   <field Field="id" Type="int(11) unsigned" Null="NO" Key="PRI" Default="" Extra="auto_increment" />',
 					'   <field Field="title" Type="varchar(255)" Null="NO" Key="" Default="" Extra="" />',
 					'   <key Table="#__test" Non_unique="0" Key_name="PRIMARY" Seq_in_index="1" Column_name="id" Collation="A" ' .
-					'Null="" Index_type="BTREE" Comment="" />',
+					'Null="" Index_type="BTREE" Sub_part="" Comment="" />',
 					'  </table_structure>'
 				)
 			),

--- a/tests/unit/suites/database/driver/postgresql/JDatabaseDriverPostgresqlTest.php
+++ b/tests/unit/suites/database/driver/postgresql/JDatabaseDriverPostgresqlTest.php
@@ -395,24 +395,28 @@ class JDatabaseDriverPostgresqlTest extends TestCaseDatabasePostgresql
 		$pkey->idxName = 'jos_assets_pkey';
 		$pkey->isPrimary = 't';
 		$pkey->isUnique = 't';
+		$pkey->indKey = '1';
 		$pkey->Query = 'ALTER TABLE jos_assets ADD PRIMARY KEY (id)';
 
 		$asset = new stdClass;
 		$asset->idxName = 'idx_asset_name';
 		$asset->isPrimary = 'f';
 		$asset->isUnique = 't';
+		$asset->indKey = '6';
 		$asset->Query = 'CREATE UNIQUE INDEX idx_asset_name ON jos_assets USING btree (name)';
 
 		$lftrgt = new stdClass;
 		$lftrgt->idxName = 'jos_assets_idx_lft_rgt';
 		$lftrgt->isPrimary = 'f';
 		$lftrgt->isUnique = 'f';
+		$lftrgt->indKey = '3 4';
 		$lftrgt->Query = 'CREATE INDEX jos_assets_idx_lft_rgt ON jos_assets USING btree (lft, rgt)';
 
 		$id = new stdClass;
 		$id->idxName = 'jos_assets_idx_parent_id';
 		$id->isPrimary = 'f';
 		$id->isUnique = 'f';
+		$id->indKey = '2';
 		$id->Query = 'CREATE INDEX jos_assets_idx_parent_id ON jos_assets USING btree (parent_id)';
 
 		$this->assertEquals(array($pkey, $id, $lftrgt, $asset), self::$driver->getTableKeys('jos_assets'));

--- a/tests/unit/suites/database/driver/postgresql/JDatabaseExporterPostgresqlTest.php
+++ b/tests/unit/suites/database/driver/postgresql/JDatabaseExporterPostgresqlTest.php
@@ -220,7 +220,7 @@ class JDatabaseExporterPostgresqlTest extends TestCase
 		$expecting = '<?xml version="1.0"?>
 <postgresqldump xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <database name="">
-  <table_structure name="jos_dbtest">
+  <table_structure name="#__dbtest">
    <sequence Name="jos_dbtest_id_seq" Schema="public" Table="jos_dbtest" Column="id" Type="bigint" Start_Value="' .
 			$start_val . '" Min_Value="1" Max_Value="9223372036854775807" Last_Value="1" Increment="1" Cycle_option="NO" Is_called="f" />
    <field Field="id" Type="integer" Null="NO" Default="nextval(\'jos_dbtest_id_seq\'::regclass)" Comments="" />
@@ -286,7 +286,7 @@ class JDatabaseExporterPostgresqlTest extends TestCase
 		$expecting = '<?xml version="1.0"?>
 <postgresqldump xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <database name="">
-  <table_structure name="jos_dbtest">
+  <table_structure name="#__dbtest">
    <sequence Name="jos_dbtest_id_seq" Schema="public" Table="jos_dbtest" Column="id" Type="bigint" Start_Value="' .
 			$start_val . '" Min_Value="1" Max_Value="9223372036854775807" Last_Value="1" Increment="1" Cycle_option="NO" Is_called="f" />
    <field Field="id" Type="integer" Null="NO" Default="nextval(\'jos_dbtest_id_seq\'::regclass)" Comments="" />
@@ -329,7 +329,7 @@ class JDatabaseExporterPostgresqlTest extends TestCase
 
 		$this->assertEquals(
 			array(
-				'  <table_structure name="jos_dbtest">',
+				'  <table_structure name="#__dbtest">',
 				'   <sequence Name="jos_dbtest_id_seq" Schema="public" Table="jos_dbtest" Column="id" Type="bigint" Start_Value="' .
 				$start_val . '" Min_Value="1" Max_Value="9223372036854775807" Last_Value="1" Increment="1" Cycle_option="NO" Is_called="f" />',
 				'   <field Field="id" Type="integer" Null="NO" Default="nextval(\'jos_dbtest_id_seq\'::regclass)" Comments="" />',

--- a/tests/unit/suites/database/driver/postgresql/JDatabaseExporterPostgresqlTest.php
+++ b/tests/unit/suites/database/driver/postgresql/JDatabaseExporterPostgresqlTest.php
@@ -214,7 +214,7 @@ class JDatabaseExporterPostgresqlTest extends TestCase
    <field Field="title" Type="character varying(50)" Null="NO" Default="NULL" Comments="" />
    <field Field="start_date" Type="timestamp without time zone" Null="NO" Default="NULL" Comments="" />
    <field Field="description" Type="text" Null="NO" Default="NULL" Comments="" />
-   <key Index="jos_dbtest_pkey" is_primary="TRUE" is_unique="TRUE" Query="ALTER TABLE "jos_dbtest" ADD PRIMARY KEY (id)" />
+   <key Index="jos_dbtest_pkey" is_primary="TRUE" is_unique="TRUE" Query="ALTER TABLE jos_dbtest ADD PRIMARY KEY (id)" />
   </table_structure>
  </database>
 </postgresqldump>';
@@ -280,7 +280,7 @@ class JDatabaseExporterPostgresqlTest extends TestCase
    <field Field="title" Type="character varying(50)" Null="NO" Default="NULL" Comments="" />
    <field Field="start_date" Type="timestamp without time zone" Null="NO" Default="NULL" Comments="" />
    <field Field="description" Type="text" Null="NO" Default="NULL" Comments="" />
-   <key Index="jos_dbtest_pkey" is_primary="TRUE" is_unique="TRUE" Query="ALTER TABLE "jos_dbtest" ADD PRIMARY KEY (id)" />
+   <key Index="jos_dbtest_pkey" is_primary="TRUE" is_unique="TRUE" Query="ALTER TABLE jos_dbtest ADD PRIMARY KEY (id)" />
   </table_structure>
  </database>
 </postgresqldump>';
@@ -323,7 +323,7 @@ class JDatabaseExporterPostgresqlTest extends TestCase
 				'   <field Field="title" Type="character varying(50)" Null="NO" Default="NULL" Comments="" />',
 				'   <field Field="start_date" Type="timestamp without time zone" Null="NO" Default="NULL" Comments="" />',
 				'   <field Field="description" Type="text" Null="NO" Default="NULL" Comments="" />',
-				'   <key Index="jos_dbtest_pkey" is_primary="TRUE" is_unique="TRUE" Query="ALTER TABLE "jos_dbtest" ADD PRIMARY KEY (id)" />',
+				'   <key Index="jos_dbtest_pkey" is_primary="TRUE" is_unique="TRUE" Query="ALTER TABLE jos_dbtest ADD PRIMARY KEY (id)" />',
 				'  </table_structure>'
 			),
 			TestReflection::invoke($instance, 'buildXmlStructure')

--- a/tests/unit/suites/database/driver/postgresql/JDatabaseExporterPostgresqlTest.php
+++ b/tests/unit/suites/database/driver/postgresql/JDatabaseExporterPostgresqlTest.php
@@ -52,28 +52,28 @@ class JDatabaseExporterPostgresqlTest extends TestCase
 						'column_name' => 'id',
 						'type' => 'integer',
 						'null' => 'NO',
-						'default' => 'nextval(\'jos_dbtest_id_seq\'::regclass)',
+						'Default' => 'nextval(\'jos_dbtest_id_seq\'::regclass)',
 						'comments' => '',
 					),
 					(object) array(
 						'column_name' => 'title',
 						'type' => 'character varying(50)',
 						'null' => 'NO',
-						'default' => 'NULL',
+						'Default' => 'NULL',
 						'comments' => '',
 					),
 					(object) array(
 						'column_name' => 'start_date',
 						'type' => 'timestamp without time zone',
 						'null' => 'NO',
-						'default' => 'NULL',
+						'Default' => 'NULL',
 						'comments' => '',
 					),
 					(object) array(
 						'column_name' => 'description',
 						'type' => 'text',
 						'null' => 'NO',
-						'default' => 'NULL',
+						'Default' => 'NULL',
 						'comments' => '',
 					)
 				)

--- a/tests/unit/suites/database/driver/postgresql/JDatabaseExporterPostgresqlTest.php
+++ b/tests/unit/suites/database/driver/postgresql/JDatabaseExporterPostgresqlTest.php
@@ -221,13 +221,13 @@ class JDatabaseExporterPostgresqlTest extends TestCase
 <postgresqldump xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <database name="">
   <table_structure name="#__dbtest">
-   <sequence Name="jos_dbtest_id_seq" Schema="public" Table="jos_dbtest" Column="id" Type="bigint" Start_Value="' .
+   <sequence Name="#__dbtest_id_seq" Schema="public" Table="#__dbtest" Column="id" Type="bigint" Start_Value="' .
 			$start_val . '" Min_Value="1" Max_Value="9223372036854775807" Last_Value="1" Increment="1" Cycle_option="NO" Is_called="f" />
    <field Field="id" Type="integer" Null="NO" Default="nextval(\'jos_dbtest_id_seq\'::regclass)" Comments="" />
    <field Field="title" Type="character varying(50)" Null="NO" Default="NULL" Comments="" />
    <field Field="start_date" Type="timestamp without time zone" Null="NO" Default="NULL" Comments="" />
    <field Field="description" Type="text" Null="NO" Default="NULL" Comments="" />
-   <key Index="jos_dbtest_pkey" is_primary="TRUE" is_unique="TRUE" Key_name="id" Query=\'ALTER TABLE "jos_dbtest" ADD PRIMARY KEY (id)\' />
+   <key Index="#__dbtest_pkey" is_primary="TRUE" is_unique="TRUE" Key_name="id" Query=\'ALTER TABLE "jos_dbtest" ADD PRIMARY KEY (id)\' />
   </table_structure>
  </database>
 </postgresqldump>';
@@ -287,13 +287,13 @@ class JDatabaseExporterPostgresqlTest extends TestCase
 <postgresqldump xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <database name="">
   <table_structure name="#__dbtest">
-   <sequence Name="jos_dbtest_id_seq" Schema="public" Table="jos_dbtest" Column="id" Type="bigint" Start_Value="' .
+   <sequence Name="#__dbtest_id_seq" Schema="public" Table="#__dbtest" Column="id" Type="bigint" Start_Value="' .
 			$start_val . '" Min_Value="1" Max_Value="9223372036854775807" Last_Value="1" Increment="1" Cycle_option="NO" Is_called="f" />
    <field Field="id" Type="integer" Null="NO" Default="nextval(\'jos_dbtest_id_seq\'::regclass)" Comments="" />
    <field Field="title" Type="character varying(50)" Null="NO" Default="NULL" Comments="" />
    <field Field="start_date" Type="timestamp without time zone" Null="NO" Default="NULL" Comments="" />
    <field Field="description" Type="text" Null="NO" Default="NULL" Comments="" />
-   <key Index="jos_dbtest_pkey" is_primary="TRUE" is_unique="TRUE" Key_name="id" Query=\'ALTER TABLE "jos_dbtest" ADD PRIMARY KEY (id)\' />
+   <key Index="#__dbtest_pkey" is_primary="TRUE" is_unique="TRUE" Key_name="id" Query=\'ALTER TABLE "jos_dbtest" ADD PRIMARY KEY (id)\' />
   </table_structure>
  </database>
 </postgresqldump>';
@@ -330,13 +330,13 @@ class JDatabaseExporterPostgresqlTest extends TestCase
 		$this->assertEquals(
 			array(
 				'  <table_structure name="#__dbtest">',
-				'   <sequence Name="jos_dbtest_id_seq" Schema="public" Table="jos_dbtest" Column="id" Type="bigint" Start_Value="' .
+				'   <sequence Name="#__dbtest_id_seq" Schema="public" Table="#__dbtest" Column="id" Type="bigint" Start_Value="' .
 				$start_val . '" Min_Value="1" Max_Value="9223372036854775807" Last_Value="1" Increment="1" Cycle_option="NO" Is_called="f" />',
 				'   <field Field="id" Type="integer" Null="NO" Default="nextval(\'jos_dbtest_id_seq\'::regclass)" Comments="" />',
 				'   <field Field="title" Type="character varying(50)" Null="NO" Default="NULL" Comments="" />',
 				'   <field Field="start_date" Type="timestamp without time zone" Null="NO" Default="NULL" Comments="" />',
 				'   <field Field="description" Type="text" Null="NO" Default="NULL" Comments="" />',
-				'   <key Index="jos_dbtest_pkey" is_primary="TRUE" is_unique="TRUE" Key_name="id" Query=\'ALTER TABLE "jos_dbtest" ADD PRIMARY KEY (id)\' />',
+				'   <key Index="#__dbtest_pkey" is_primary="TRUE" is_unique="TRUE" Key_name="id" Query=\'ALTER TABLE "jos_dbtest" ADD PRIMARY KEY (id)\' />',
 				'  </table_structure>'
 			),
 			TestReflection::invoke($instance, 'buildXmlStructure')

--- a/tests/unit/suites/database/driver/postgresql/JDatabaseExporterPostgresqlTest.php
+++ b/tests/unit/suites/database/driver/postgresql/JDatabaseExporterPostgresqlTest.php
@@ -220,7 +220,7 @@ class JDatabaseExporterPostgresqlTest extends TestCase
 		$expecting = '<?xml version="1.0"?>
 <postgresqldump xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <database name="">
-  <table_structure name="#__dbtest">
+  <table_structure name="jos_dbtest">
    <sequence Name="jos_dbtest_id_seq" Schema="public" Table="jos_dbtest" Column="id" Type="bigint" Start_Value="' .
 			$start_val . '" Min_Value="1" Max_Value="9223372036854775807" Last_Value="1" Increment="1" Cycle_option="NO" Is_called="f" />
    <field Field="id" Type="integer" Null="NO" Default="nextval(\'jos_dbtest_id_seq\'::regclass)" Comments="" />
@@ -286,7 +286,7 @@ class JDatabaseExporterPostgresqlTest extends TestCase
 		$expecting = '<?xml version="1.0"?>
 <postgresqldump xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <database name="">
-  <table_structure name="#__dbtest">
+  <table_structure name="jos_dbtest">
    <sequence Name="jos_dbtest_id_seq" Schema="public" Table="jos_dbtest" Column="id" Type="bigint" Start_Value="' .
 			$start_val . '" Min_Value="1" Max_Value="9223372036854775807" Last_Value="1" Increment="1" Cycle_option="NO" Is_called="f" />
    <field Field="id" Type="integer" Null="NO" Default="nextval(\'jos_dbtest_id_seq\'::regclass)" Comments="" />
@@ -329,7 +329,7 @@ class JDatabaseExporterPostgresqlTest extends TestCase
 
 		$this->assertEquals(
 			array(
-				'  <table_structure name="#__dbtest">',
+				'  <table_structure name="jos_dbtest">',
 				'   <sequence Name="jos_dbtest_id_seq" Schema="public" Table="jos_dbtest" Column="id" Type="bigint" Start_Value="' .
 				$start_val . '" Min_Value="1" Max_Value="9223372036854775807" Last_Value="1" Increment="1" Cycle_option="NO" Is_called="f" />',
 				'   <field Field="id" Type="integer" Null="NO" Default="nextval(\'jos_dbtest_id_seq\'::regclass)" Comments="" />',

--- a/tests/unit/suites/database/driver/postgresql/JDatabaseExporterPostgresqlTest.php
+++ b/tests/unit/suites/database/driver/postgresql/JDatabaseExporterPostgresqlTest.php
@@ -122,10 +122,8 @@ class JDatabaseExporterPostgresqlTest extends TestCase
 						'start_value' => $start_val,
 						'minimum_value' => '1',
 						'maximum_value' => '9223372036854775807',
-						'last_value' => '1',
 						'increment' => '1',
 						'cycle_option' => 'NO',
-						'is_called' => 'f',
 					)
 				)
 			);
@@ -133,6 +131,14 @@ class JDatabaseExporterPostgresqlTest extends TestCase
 		$this->dbo->expects($this->any())
 			->method('loadObjectList')
 			->willReturn(array());
+
+		$this->dbo->expects($this->any())
+			->method('getSequenceLastValue')
+			->willReturn('1');
+
+		$this->dbo->expects($this->any())
+			->method('getSequenceIsCalled')
+			->willReturn('f');
 
 		$this->dbo->expects($this->any())
 			->method('getTableList')

--- a/tests/unit/suites/database/driver/postgresql/JDatabaseExporterPostgresqlTest.php
+++ b/tests/unit/suites/database/driver/postgresql/JDatabaseExporterPostgresqlTest.php
@@ -122,8 +122,10 @@ class JDatabaseExporterPostgresqlTest extends TestCase
 						'start_value' => $start_val,
 						'minimum_value' => '1',
 						'maximum_value' => '9223372036854775807',
+						'last_value' => '1',
 						'increment' => '1',
 						'cycle_option' => 'NO',
+						'is_called' => 'f',
 					)
 				)
 			);
@@ -209,12 +211,12 @@ class JDatabaseExporterPostgresqlTest extends TestCase
  <database name="">
   <table_structure name="#__test">
    <sequence Name="jos_dbtest_id_seq" Schema="public" Table="jos_dbtest" Column="id" Type="bigint" Start_Value="' .
-			$start_val . '" Min_Value="1" Max_Value="9223372036854775807" Increment="1" Cycle_option="NO" />
+			$start_val . '" Min_Value="1" Max_Value="9223372036854775807" Last_Value="1" Increment="1" Cycle_option="NO" Is_called="f" />
    <field Field="id" Type="integer" Null="NO" Default="nextval(\'jos_dbtest_id_seq\'::regclass)" Comments="" />
    <field Field="title" Type="character varying(50)" Null="NO" Default="NULL" Comments="" />
    <field Field="start_date" Type="timestamp without time zone" Null="NO" Default="NULL" Comments="" />
    <field Field="description" Type="text" Null="NO" Default="NULL" Comments="" />
-   <key Index="jos_dbtest_pkey" is_primary="TRUE" is_unique="TRUE" Query="ALTER TABLE jos_dbtest ADD PRIMARY KEY (id)" />
+   <key Index="jos_dbtest_pkey" is_primary="TRUE" is_unique="TRUE" Query=\'ALTER TABLE "jos_dbtest" ADD PRIMARY KEY (id)\' />
   </table_structure>
  </database>
 </postgresqldump>';
@@ -275,12 +277,12 @@ class JDatabaseExporterPostgresqlTest extends TestCase
  <database name="">
   <table_structure name="#__test">
    <sequence Name="jos_dbtest_id_seq" Schema="public" Table="jos_dbtest" Column="id" Type="bigint" Start_Value="' .
-			$start_val . '" Min_Value="1" Max_Value="9223372036854775807" Increment="1" Cycle_option="NO" />
+			$start_val . '" Min_Value="1" Max_Value="9223372036854775807" Last_Value="1" Increment="1" Cycle_option="NO" Is_called="f" />
    <field Field="id" Type="integer" Null="NO" Default="nextval(\'jos_dbtest_id_seq\'::regclass)" Comments="" />
    <field Field="title" Type="character varying(50)" Null="NO" Default="NULL" Comments="" />
    <field Field="start_date" Type="timestamp without time zone" Null="NO" Default="NULL" Comments="" />
    <field Field="description" Type="text" Null="NO" Default="NULL" Comments="" />
-   <key Index="jos_dbtest_pkey" is_primary="TRUE" is_unique="TRUE" Query="ALTER TABLE jos_dbtest ADD PRIMARY KEY (id)" />
+   <key Index="jos_dbtest_pkey" is_primary="TRUE" is_unique="TRUE" Query=\'ALTER TABLE "jos_dbtest" ADD PRIMARY KEY (id)\' />
   </table_structure>
  </database>
 </postgresqldump>';
@@ -318,12 +320,12 @@ class JDatabaseExporterPostgresqlTest extends TestCase
 			array(
 				'  <table_structure name="#__test">',
 				'   <sequence Name="jos_dbtest_id_seq" Schema="public" Table="jos_dbtest" Column="id" Type="bigint" Start_Value="' .
-				$start_val . '" Min_Value="1" Max_Value="9223372036854775807" Increment="1" Cycle_option="NO" />',
+				$start_val . '" Min_Value="1" Max_Value="9223372036854775807" Last_Value="1" Increment="1" Cycle_option="NO" Is_called="f" />',
 				'   <field Field="id" Type="integer" Null="NO" Default="nextval(\'jos_dbtest_id_seq\'::regclass)" Comments="" />',
 				'   <field Field="title" Type="character varying(50)" Null="NO" Default="NULL" Comments="" />',
 				'   <field Field="start_date" Type="timestamp without time zone" Null="NO" Default="NULL" Comments="" />',
 				'   <field Field="description" Type="text" Null="NO" Default="NULL" Comments="" />',
-				'   <key Index="jos_dbtest_pkey" is_primary="TRUE" is_unique="TRUE" Query="ALTER TABLE jos_dbtest ADD PRIMARY KEY (id)" />',
+				'   <key Index="jos_dbtest_pkey" is_primary="TRUE" is_unique="TRUE" Query=\'ALTER TABLE "jos_dbtest" ADD PRIMARY KEY (id)\' />',
 				'  </table_structure>'
 			),
 			TestReflection::invoke($instance, 'buildXmlStructure')

--- a/tests/unit/suites/database/driver/postgresql/JDatabaseExporterPostgresqlTest.php
+++ b/tests/unit/suites/database/driver/postgresql/JDatabaseExporterPostgresqlTest.php
@@ -38,7 +38,7 @@ class JDatabaseExporterPostgresqlTest extends TestCase
 	protected function setup()
 	{
 		// Set up the database object mock.
-		$this->dbo = $this->getMockDatabase('Postgresql', array('getTableSequences'), '1970-01-01 00:00:00', 'Y-m-d H:i:s');
+		$this->dbo = $this->getMockDatabase('Postgresql', array('getTableSequences','getSequenceLastValue','getSequenceIsCalled'), '1970-01-01 00:00:00', 'Y-m-d H:i:s');
 
 		$this->dbo->expects($this->any())
 			->method('getPrefix')
@@ -200,7 +200,7 @@ class JDatabaseExporterPostgresqlTest extends TestCase
 		// Set up the export settings.
 		$instance
 			->setDbo($this->dbo)
-			->from('jos_test')
+			->from('jos_dbtest')
 			->withStructure(true);
 
 		// Depending on which version is running, 9.1.0 or older
@@ -215,7 +215,7 @@ class JDatabaseExporterPostgresqlTest extends TestCase
 		$expecting = '<?xml version="1.0"?>
 <postgresqldump xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <database name="">
-  <table_structure name="#__test">
+  <table_structure name="#__dbtest">
    <sequence Name="jos_dbtest_id_seq" Schema="public" Table="jos_dbtest" Column="id" Type="bigint" Start_Value="' .
 			$start_val . '" Min_Value="1" Max_Value="9223372036854775807" Last_Value="1" Increment="1" Cycle_option="NO" Is_called="f" />
    <field Field="id" Type="integer" Null="NO" Default="nextval(\'jos_dbtest_id_seq\'::regclass)" Comments="" />
@@ -266,7 +266,7 @@ class JDatabaseExporterPostgresqlTest extends TestCase
 		// Set up the export settings.
 		$instance
 			->setDbo($this->dbo)
-			->from('jos_test')
+			->from('jos_dbtest')
 			->withStructure(true);
 
 		// Depending on which version is running, 9.1.0 or older
@@ -281,7 +281,7 @@ class JDatabaseExporterPostgresqlTest extends TestCase
 		$expecting = '<?xml version="1.0"?>
 <postgresqldump xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <database name="">
-  <table_structure name="#__test">
+  <table_structure name="#__dbtest">
    <sequence Name="jos_dbtest_id_seq" Schema="public" Table="jos_dbtest" Column="id" Type="bigint" Start_Value="' .
 			$start_val . '" Min_Value="1" Max_Value="9223372036854775807" Last_Value="1" Increment="1" Cycle_option="NO" Is_called="f" />
    <field Field="id" Type="integer" Null="NO" Default="nextval(\'jos_dbtest_id_seq\'::regclass)" Comments="" />
@@ -310,7 +310,7 @@ class JDatabaseExporterPostgresqlTest extends TestCase
 		// Set up the export settings.
 		$instance
 			->setDbo($this->dbo)
-			->from('jos_test')
+			->from('jos_dbtest')
 			->withStructure(true);
 
 		// Depending on which version is running, 9.1.0 or older
@@ -324,7 +324,7 @@ class JDatabaseExporterPostgresqlTest extends TestCase
 
 		$this->assertEquals(
 			array(
-				'  <table_structure name="#__test">',
+				'  <table_structure name="#__dbtest">',
 				'   <sequence Name="jos_dbtest_id_seq" Schema="public" Table="jos_dbtest" Column="id" Type="bigint" Start_Value="' .
 				$start_val . '" Min_Value="1" Max_Value="9223372036854775807" Last_Value="1" Increment="1" Cycle_option="NO" Is_called="f" />',
 				'   <field Field="id" Type="integer" Null="NO" Default="nextval(\'jos_dbtest_id_seq\'::regclass)" Comments="" />',
@@ -424,8 +424,8 @@ class JDatabaseExporterPostgresqlTest extends TestCase
 		$instance->setDbo($this->dbo);
 
 		$this->assertSame(
-			'#__test',
-			TestReflection::invoke($instance, 'getGenericTableName', 'jos_test'),
+			'#__dbtest',
+			TestReflection::invoke($instance, 'getGenericTableName', 'jos_dbtest'),
 			'The testGetGenericTableName should replace the database prefix with #__.'
 		);
 	}

--- a/tests/unit/suites/database/driver/postgresql/JDatabaseExporterPostgresqlTest.php
+++ b/tests/unit/suites/database/driver/postgresql/JDatabaseExporterPostgresqlTest.php
@@ -38,7 +38,7 @@ class JDatabaseExporterPostgresqlTest extends TestCase
 	protected function setup()
 	{
 		// Set up the database object mock.
-		$this->dbo = $this->getMockDatabase('Postgresql', array('getTableSequences','getSequenceLastValue','getSequenceIsCalled'), '1970-01-01 00:00:00', 'Y-m-d H:i:s');
+		$this->dbo = $this->getMockDatabase('Postgresql', array('getTableSequences', 'getSequenceLastValue', 'getSequenceIsCalled', 'getNamesKey'), '1970-01-01 00:00:00', 'Y-m-d H:i:s');
 
 		$this->dbo->expects($this->any())
 			->method('getPrefix')
@@ -86,10 +86,15 @@ class JDatabaseExporterPostgresqlTest extends TestCase
 					'idxName' => 'jos_dbtest_pkey',
 					'isPrimary' => 'TRUE',
 					'isUnique' => 'TRUE',
+					'indKey' => '1',
 					'Query' => 'ALTER TABLE "jos_dbtest" ADD PRIMARY KEY (id)',
 				)
 				)
 			);
+
+		$this->dbo->expects($this->any())
+			->method('getNamesKey')
+			->willReturn('id');
 
 		// Check if database is at least 9.1.0
 		$this->dbo->expects($this->any())
@@ -288,7 +293,7 @@ class JDatabaseExporterPostgresqlTest extends TestCase
    <field Field="title" Type="character varying(50)" Null="NO" Default="NULL" Comments="" />
    <field Field="start_date" Type="timestamp without time zone" Null="NO" Default="NULL" Comments="" />
    <field Field="description" Type="text" Null="NO" Default="NULL" Comments="" />
-   <key Index="jos_dbtest_pkey" is_primary="TRUE" is_unique="TRUE" Query=\'ALTER TABLE "jos_dbtest" ADD PRIMARY KEY (id)\' />
+   <key Index="jos_dbtest_pkey" is_primary="TRUE" is_unique="TRUE" Key_name="id" Query=\'ALTER TABLE "jos_dbtest" ADD PRIMARY KEY (id)\' />
   </table_structure>
  </database>
 </postgresqldump>';
@@ -331,7 +336,7 @@ class JDatabaseExporterPostgresqlTest extends TestCase
 				'   <field Field="title" Type="character varying(50)" Null="NO" Default="NULL" Comments="" />',
 				'   <field Field="start_date" Type="timestamp without time zone" Null="NO" Default="NULL" Comments="" />',
 				'   <field Field="description" Type="text" Null="NO" Default="NULL" Comments="" />',
-				'   <key Index="jos_dbtest_pkey" is_primary="TRUE" is_unique="TRUE" Query=\'ALTER TABLE "jos_dbtest" ADD PRIMARY KEY (id)\' />',
+				'   <key Index="jos_dbtest_pkey" is_primary="TRUE" is_unique="TRUE" Key_name="id" Query=\'ALTER TABLE "jos_dbtest" ADD PRIMARY KEY (id)\' />',
 				'  </table_structure>'
 			),
 			TestReflection::invoke($instance, 'buildXmlStructure')

--- a/tests/unit/suites/database/driver/postgresql/JDatabaseExporterPostgresqlTest.php
+++ b/tests/unit/suites/database/driver/postgresql/JDatabaseExporterPostgresqlTest.php
@@ -227,7 +227,7 @@ class JDatabaseExporterPostgresqlTest extends TestCase
    <field Field="title" Type="character varying(50)" Null="NO" Default="NULL" Comments="" />
    <field Field="start_date" Type="timestamp without time zone" Null="NO" Default="NULL" Comments="" />
    <field Field="description" Type="text" Null="NO" Default="NULL" Comments="" />
-   <key Index="jos_dbtest_pkey" is_primary="TRUE" is_unique="TRUE" Query=\'ALTER TABLE "jos_dbtest" ADD PRIMARY KEY (id)\' />
+   <key Index="jos_dbtest_pkey" is_primary="TRUE" is_unique="TRUE" Key_name="id" Query=\'ALTER TABLE "jos_dbtest" ADD PRIMARY KEY (id)\' />
   </table_structure>
  </database>
 </postgresqldump>';

--- a/tests/unit/suites/database/driver/postgresql/JDatabaseImporterPostgresqlTest.php
+++ b/tests/unit/suites/database/driver/postgresql/JDatabaseImporterPostgresqlTest.php
@@ -101,12 +101,14 @@ class JDatabaseImporterPostgresqlTest extends \PHPUnit\Framework\TestCase
 						'Index' => 'jos_dbtest_pkey',
 						'is_primary' => 'TRUE',
 						'is_unique' => 'TRUE',
+						'Key_name' => 'id',
 						'Query' => 'ALTER TABLE jos_dbtest ADD PRIMARY KEY (id)',
 					),
 					(object) array(
 						'Index' => 'jos_dbtest_idx_name',
 						'is_primary' => 'FALSE',
 						'is_unique' => 'FALSE',
+						'Key_name' => 'name',
 						'Query' => 'CREATE INDEX jos_dbtest_idx_name ON jos_dbtest USING btree (name)',
 					)
 					)
@@ -270,14 +272,14 @@ class JDatabaseImporterPostgresqlTest extends \PHPUnit\Framework\TestCase
 		$f3 = '<field Field="alias" Type="character varying(255)" Null="NO" Default="test" Comments="" />';
 		$f2_def = '<field Field="title" Type="character varying(50)" Null="NO" Default="add default" Comments="" />';
 
-		$k1 = '<key Index="jos_dbtest_pkey" is_primary="TRUE" is_unique="TRUE" Query="ALTER TABLE jos_dbtest ADD PRIMARY KEY (id)" />';
-		$k2 = '<key Index="jos_dbtest_idx_name" is_primary="FALSE" is_unique="FALSE" Query="CREATE INDEX jos_dbtest_idx_name ON' .
+		$k1 = '<key Index="jos_dbtest_pkey" is_primary="TRUE" is_unique="TRUE" Key_name="id" Query="ALTER TABLE jos_dbtest ADD PRIMARY KEY (id)" />';
+		$k2 = '<key Index="jos_dbtest_idx_name" is_primary="FALSE" is_unique="FALSE" Key_name="name" Query="CREATE INDEX jos_dbtest_idx_name ON' .
 			' jos_dbtest USING btree (name)" />';
-		$k3 = '<key Index="jos_dbtest_idx_title" is_primary="FALSE" is_unique="FALSE" Query="CREATE INDEX ' .
+		$k3 = '<key Index="jos_dbtest_idx_title" is_primary="FALSE" is_unique="FALSE" Key_name="title" Query="CREATE INDEX ' .
 			'jos_dbtest_idx_title ON jos_dbtest USING btree (title)" />';
-		$k4 = '<key Index="jos_dbtest_uidx_name" is_primary="FALSE" is_unique="TRUE" Query="CREATE UNIQUE INDEX ' .
+		$k4 = '<key Index="jos_dbtest_uidx_name" is_primary="FALSE" is_unique="TRUE" Key_name="name" Query="CREATE UNIQUE INDEX ' .
 			'jos_dbtest_uidx_name ON jos_dbtest USING btree (name)" />';
-		$pk = '<key Index="jos_dbtest_title_pkey" is_primary="TRUE" is_unique="TRUE" ' .
+		$pk = '<key Index="jos_dbtest_title_pkey" is_primary="TRUE" is_unique="TRUE" Key_name="title" ' .
 			'Query="ALTER TABLE jos_dbtest ADD PRIMARY KEY (title)" />';
 
 		$s1 = '<sequence Name="jos_dbtest_id_seq" Schema="public" Table="jos_dbtest" Column="id" Type="bigint" Start_Value="1" ' .
@@ -604,9 +606,9 @@ class JDatabaseImporterPostgresqlTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function testGetAddIndexSql()
 	{
-		$xmlIndex = '<key Index="jos_dbtest_idx_name" is_primary="FALSE" is_unique="FALSE" ' .
+		$xmlIndex = '<key Index="jos_dbtest_idx_name" is_primary="FALSE" is_unique="FALSE" Key_name="name" ' .
 			'Query="CREATE INDEX jos_dbtest_idx_name ON jos_dbtest USING btree (name)" />';
-		$xmlPrimaryKey = '<key Index="jos_dbtest_pkey" is_primary="TRUE" is_unique="TRUE" ' .
+		$xmlPrimaryKey = '<key Index="jos_dbtest_pkey" is_primary="TRUE" is_unique="TRUE" Key_name="id" ' .
 			'Query="ALTER TABLE jos_dbtest ADD PRIMARY KEY (id)" />';
 
 		$instance = new JDatabaseImporterPostgresql;


### PR DESCRIPTION
Retrieving PR #14272 (and #10991) to fix the PostgreSQL exporter and importer bugs.
This PR can be tested with any database driver supported by Joomla.
This is about exporting and importing any database with a command-line interface (it can be placed in cronjob to schedule the database backup).


### Summary of Changes

- Fix folder path.
- Fix postgresql issues :
     - Fix the default value of the table.
     - Gets, sets the `last_value` and `is_called` sequence attributes.
     - Fix key query.
     - Fix text default value.
     - Apply changes to unit tests.
     - Fix the execution of queries (xmlToCreate) with the pgsql (PDO) driver.
     - Add unique constraints.
     - Convert PostgreSQL BLOB data (bytea).


### Testing Instructions

- Select a database driver and save it in System -> Global Configuration -> Server ->Database Type
- Go to the cli folder of your website.
- Export all tables and data to the folder : 
`php exporter.php --all --folder <folder_path> `
- Delete and create an empty database with the same name.
- Overwriting the database can also be done. Verify that changes are applied.
- Import all from folder:
`php importer.php --all --folder <folder_path>`

You can also : 
- Export all tables and data in zip file : 
`php exporter.php --all --mode zip`
- Export a table : 
`php exporter.php --table <table_name>`
- Export a table as a .zip file : 
`php exporter.php --table <table_name> --mode zip`
- Import a table : 
`php importer.php --table <table_name>`


### Expected result

Export/import tables with structure (keys, constraints, sequences) and data.


### Actual result

Does not export/import views, stored procedures and triggers (optional for the Joomla database).
