### PR TITLE
Changed bootstrap  grid from 4+ 4+ 4 to 2 + 8 +2

### DIFF
--- a/templates/cassiopeia/index.php
+++ b/templates/cassiopeia/index.php
@@ -132,12 +132,12 @@ $this->setMetaData('viewport', 'width=device-width, initial-scale=1');
 	<div class="grid-child container-main">
 
 		<?php if ($this->countModules('sidebar-left')) : ?>
-		<div class="container-sidebar-left">
+		<div class="container-sidebar-left col-2">
 			<jdoc:include type="modules" name="sidebar-left" style="default" />
 		</div>
 		<?php endif; ?>
 
-		<div class="container-component">
+		<div class="container-component col-8">
 			<jdoc:include type="modules" name="main-top" style="cardGrey" />
 			<jdoc:include type="message" />
 			<jdoc:include type="component" />
@@ -146,7 +146,7 @@ $this->setMetaData('viewport', 'width=device-width, initial-scale=1');
 		</div>
 
 		<?php if ($this->countModules('sidebar-right')) : ?>
-		<div class="container-sidebar-right">
+		<div class="container-sidebar-right col-2">
 			<jdoc:include type="modules" name="sidebar-right" style="default" />
 		</div>
 		<?php endif; ?>

--- a/templates/cassiopeia/index.php
+++ b/templates/cassiopeia/index.php
@@ -129,15 +129,15 @@ $this->setMetaData('viewport', 'width=device-width, initial-scale=1');
 	</div>
 	<?php endif; ?>
 
-	<div class="grid-child container-main">
+	<div class="grid-child container-main row">
 
 		<?php if ($this->countModules('sidebar-left')) : ?>
-		<div class="container-sidebar-left col-2">
+		<div class="container-sidebar-left col-12 col-sm-12 col-md-3 col-lg-2">
 			<jdoc:include type="modules" name="sidebar-left" style="default" />
 		</div>
 		<?php endif; ?>
 
-		<div class="container-component col-8">
+		<div class="container-component col-12 col-sm-12 col-md-6 col-lg-8">
 			<jdoc:include type="modules" name="main-top" style="cardGrey" />
 			<jdoc:include type="message" />
 			<jdoc:include type="component" />
@@ -146,7 +146,7 @@ $this->setMetaData('viewport', 'width=device-width, initial-scale=1');
 		</div>
 
 		<?php if ($this->countModules('sidebar-right')) : ?>
-		<div class="container-sidebar-right col-2">
+		<div class="container-sidebar-right col-12 col-sm-12 col-md-3 col-lg-2">
 			<jdoc:include type="modules" name="sidebar-right" style="default" />
 		</div>
 		<?php endif; ?>


### PR DESCRIPTION
Default bootstrap grid is 4+ 4+ 4. It creates small middle section. To increase it the column parameters are specified.

Pull Request for Issue # .

### Summary of Changes



### Testing Instructions



### Expected result



### Actual result



### Documentation Changes Required

