### PR TITLE
[4.0] Remove unnecessary DB field alias

### DIFF
--- a/administrator/components/com_menus/Model/ItemsModel.php
+++ b/administrator/components/com_menus/Model/ItemsModel.php
@@ -261,11 +261,6 @@ class ItemsModel extends ListModel
 						'a.id', 'a.menutype', 'a.title', 'a.alias', 'a.note', 'a.path', 'a.link', 'a.type', 'a.parent_id',
 						'a.level', 'a.published', 'a.component_id', 'a.checked_out', 'a.checked_out_time', 'a.browserNav',
 						'a.access', 'a.img', 'a.template_style_id', 'a.params', 'a.lft', 'a.rgt', 'a.home', 'a.language', 'a.client_id'
-					),
-					array(
-						null, null, null, null, null, null, null, null, null,
-						null, 'a.published', null, null, null, null,
-						null, null, null, null, null, null, null, null, null
 					)
 				)
 			)


### PR DESCRIPTION
### Summary of Changes
This PR removes some unnecessary DB field aliases which break com_menu


### Testing Instructions
- Reinstall Joomla! 4
- Apply sample data
- Go to a menu


### Expected result
Everything works


### Actual result
Error: ```You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '.`published`,`a`.`component_id`,`a`.`checked_out`,`a`.`checked_out_time`,`a`.`br' at line 1```

