### PR TITLE
[4.0] Fixing bugs in menu manager (Redo of half of #23293)

### DIFF
--- a/administrator/components/com_menus/Model/ItemModel.php
+++ b/administrator/components/com_menus/Model/ItemModel.php
@@ -1440,7 +1440,7 @@ class ItemModel extends AdminModel
 		}
 
 		// Trigger the before save event.
-		$result = Factory::getApplication()->triggerEvent($this->event_before_save, array($context, &$table, $isNew));
+		$result = Factory::getApplication()->triggerEvent($this->event_before_save, array($context, &$table, $isNew, $data));
 
 		// Store the data.
 		if (in_array(false, $result, true)|| !$table->store())


### PR DESCRIPTION
Saving a menu item also results in a PHP error because the data array is missing in the onBeforeContentSave event. This fixes that, allowing sample data creation to work again (yay). Work done by @Hackwar and already tested in #23293 