### PR TITLE
[4.0] Fix "Too few arguments to function onContentBeforeSave"

### DIFF
--- a/plugins/content/joomla/joomla.php
+++ b/plugins/content/joomla/joomla.php
@@ -52,7 +52,7 @@ class PlgContentJoomla extends CMSPlugin
 	 *
 	 * @since   4.0.0
 	 */
-	public function onContentBeforeSave($context, $table, $isNew, $data)
+	public function onContentBeforeSave($context, $table, $isNew, $data = array())
 	{
 		// Check we are handling the frontend edit form.
 		if (!in_array($context, ['com_workflow.stage', 'com_workflow.workflow']) || $isNew)


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/23276 , https://github.com/joomla/joomla-cms/issues/23401

### Testing Instructions
- Create a new administrator menu:
`Too few arguments to function PlgContentJoomla::onContentBeforeSave(), 3 passed in D:\www\joomla4\libraries\src\Plugin\CMSPlugin.php on line 287 and exactly 4 expected`
- Apply patch.
- Create a new administrator menu without error.
