### PR TITLE
[4.0] Make sure the SECURITY.md is not included in the final packages

### DIFF
--- a/build/build.php
+++ b/build/build.php
@@ -68,6 +68,7 @@ function clean_checkout(string $dir)
 	system('find . -name phpunit.*.xml | xargs rm -rf -');
 	system('find . -name phpunit.xml.dist | xargs rm -rf -');
 	system('find . -name README.md | xargs rm -rf -');
+	system('find . -name SECURITY.md | xargs rm -rf -');
 
 	echo "Cleaning vendors.\n";
 


### PR DESCRIPTION
### Summary of Changes

Make sure the SECURITY.md is not included in the final packages

### Testing Instructions

Build an release with the shipped build tools. => no SECURITY.md file in the release package anymore
code review

### Expected result

no SECURITY.md file in the release package anymore

### Actual result

the SECURITY.md file is in the release packages

### Documentation Changes Required

I'm not sure how the latest version runs but this need to be adopted to the build tools for the nightly builds too.