### PR TITLE
[4.0] Eliminate jQuery from Modal footer

### DIFF
--- a/administrator/components/com_banners/tmpl/tracks/default.php
+++ b/administrator/components/com_banners/tmpl/tracks/default.php
@@ -96,10 +96,10 @@ $listDirn   = $this->escape($this->state->get('list.direction'));
 						'width'       => '300px',
 						'modalWidth'  => '40',
 						'footer'      => '<a class="btn" data-dismiss="modal" type="button"'
-								. ' onclick="jQuery(\'#downloadModal iframe\').contents().find(\'#closeBtn\').click();">'
+								. ' onclick="Joomla.iframeButtonClick({iframeSelector: \'#downloadModal\', buttonSelector: \'#closeBtn\'})">'
 								. Text::_('COM_BANNERS_CANCEL') . '</a>'
 								. '<button class="btn btn-success" type="button"'
-								. ' onclick="jQuery(\'#downloadModal iframe\').contents().find(\'#exportBtn\').click();">'
+								. ' onclick="Joomla.iframeButtonClick({iframeSelector: \'#downloadModal\', buttonSelector: \'#exportBtn\'})">'
 								. Text::_('COM_BANNERS_TRACKS_EXPORT') . '</button>',
 					)
 				); ?>

--- a/administrator/components/com_csp/tmpl/reports/default.php
+++ b/administrator/components/com_csp/tmpl/reports/default.php
@@ -46,11 +46,11 @@ $saveOrder = $listOrder == 'a.id';
 							'backdrop'    => 'static',
 							'keyboard'    => false,
 							'footer'      => '<button type="button" class="btn" data-dismiss="modal"'
-								. ' onclick="jQuery(\'#plugin' . $this->httpHeadersId . 'Modal iframe\').contents().find(\'#closeBtn\').click();">'
+								. ' onclick="Joomla.iframeButtonClick({iframeSelector: \'#plugin' . $this->httpHeadersId . 'Modal\', buttonSelector: \'#closeBtn\'})">'
 								. Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>'
-								. '<button type="button" class="btn btn-primary" data-dismiss="modal" onclick="jQuery(\'#plugin' . $this->httpHeadersId . 'Modal iframe\').contents().find(\'#saveBtn\').click();">'
+								. '<button type="button" class="btn btn-primary" data-dismiss="modal" onclick="Joomla.iframeButtonClick({iframeSelector: \'#plugin' . $this->httpHeadersId . 'Modal\', buttonSelector: \'#saveBtn\'})">'
 								. Text::_("JSAVE") . '</button>'
-								. '<button type="button" class="btn btn-success" onclick="jQuery(\'#plugin' . $this->httpHeadersId . 'Modal iframe\').contents().find(\'#applyBtn\').click(); return false;">'
+								. '<button type="button" class="btn btn-success" onclick="Joomla.iframeButtonClick({iframeSelector: \'#plugin' . $this->httpHeadersId . 'Modal\', buttonSelector: \'#applyBtn\'})">'
 								. Text::_("JAPPLY") . '</button>'
 						)
 					); ?>

--- a/administrator/components/com_menus/tmpl/menus/default.php
+++ b/administrator/components/com_menus/tmpl/menus/default.php
@@ -182,13 +182,13 @@ HTMLHelper::_('script', 'com_menus/admin-menus-default.min.js', array('version' 
 															'bodyHeight'  => 70,
 															'modalWidth'  => 80,
 															'footer'      => '<a type="button" class="btn btn-secondary" data-dismiss="modal" aria-hidden="true"'
-																	. ' onclick="jQuery(\'#moduleEdit' . $module->id . 'Modal iframe\').contents().find(\'#closeBtn\').click();">'
+																	. ' onclick="Joomla.iframeButtonClick({iframeSelector: \'#moduleEdit' . $module->id . 'Modal\', buttonSelector: \'#closeBtn\'})">'
 																	. Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</a>'
 																	. '<button type="button" class="btn btn-primary" aria-hidden="true"'
-																	. ' onclick="jQuery(\'#moduleEdit' . $module->id . 'Modal iframe\').contents().find(\'#saveBtn\').click();">'
+																	. ' onclick="Joomla.iframeButtonClick({iframeSelector: \'#moduleEdit' . $module->id . 'Modal\', buttonSelector: \'#saveBtn\'})">'
 																	. Text::_('JSAVE') . '</button>'
 																	. '<button type="button" class="btn btn-success" aria-hidden="true"'
-																	. ' onclick="jQuery(\'#moduleEdit' . $module->id . 'Modal iframe\').contents().find(\'#applyBtn\').click();">'
+																	. ' onclick="Joomla.iframeButtonClick({iframeSelector: \'#moduleEdit' . $module->id . 'Modal\', buttonSelector: \'#applyBtn\'})">'
 																	. Text::_('JAPPLY') . '</button>',
 														)
 													); ?>
@@ -211,13 +211,13 @@ HTMLHelper::_('script', 'com_menus/admin-menus-default.min.js', array('version' 
 													'bodyHeight'  => 70,
 													'modalWidth'  => 80,
 													'footer'      => '<a type="button" class="btn btn-secondary" data-dismiss="modal" aria-hidden="true"'
-															. ' onclick="jQuery(\'#moduleAddModal iframe\').contents().find(\'#closeBtn\').click();">'
+															. ' onclick="Joomla.iframeButtonClick({iframeSelector: \'#moduleAddModal\', buttonSelector: \'#closeBtn\'})">'
 															. Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</a>'
 															. '<button type="button" class="btn btn-primary" aria-hidden="true"'
-															. ' onclick="jQuery(\'#moduleAddModal iframe\').contents().find(\'#saveBtn\').click();">'
+															. ' onclick="Joomla.iframeButtonClick({iframeSelector: \'#moduleAddModal\', buttonSelector: \'#saveBtn\'})">'
 															. Text::_('JSAVE') . '</button>'
 															. '<button type="button" class="btn btn-success" aria-hidden="true"'
-															. ' onclick="jQuery(\'#moduleAddModal iframe\').contents().find(\'#applyBtn\').click();">'
+															. ' onclick="Joomla.iframeButtonClick({iframeSelector: \'#moduleAddModal\', buttonSelector: \'#applyBtn\'})">'
 															. Text::_('JAPPLY') . '</button>',
 												)
 											); ?>

--- a/administrator/components/com_messages/View/Messages/HtmlView.php
+++ b/administrator/components/com_messages/View/Messages/HtmlView.php
@@ -131,7 +131,7 @@ class HtmlView extends BaseHtmlView
 			. Text::_('JCANCEL')
 			. '</button>'
 			. '<button class="btn btn-success" type="button" data-dismiss="modal" aria-hidden="true"'
-			. ' onclick="jQuery(\'#modal-cog iframe\').contents().find(\'#saveBtn\').click();">'
+			. ' onclick="Joomla.iframeButtonClick({iframeSelector: \'#modal-cog\', buttonSelector: \'#saveBtn\'})">'
 			. Text::_('JSAVE')
 			. '</button>'
 		);

--- a/administrator/components/com_redirect/tmpl/links/default.php
+++ b/administrator/components/com_redirect/tmpl/links/default.php
@@ -41,11 +41,11 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 					'backdrop'    => 'static',
 					'keyboard'    => false,
 					'footer'      => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true"'
-						. ' onclick="jQuery(\'#plugin' . $this->redirectPluginId . 'Modal iframe\').contents().find(\'#closeBtn\').click();">'
+						. ' onclick="Joomla.iframeButtonClick({iframeSelector: \'#plugin' . $this->redirectPluginId . 'Modal\', buttonSelector: \'#closeBtn\'})">'
 						. Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>'
-						. '<button type="button" class="btn btn-primary" data-dismiss="modal" aria-hidden="true" onclick="jQuery(\'#plugin' . $this->redirectPluginId . 'Modal iframe\').contents().find(\'#saveBtn\').click();">'
+						. '<button type="button" class="btn btn-primary" data-dismiss="modal" aria-hidden="true" onclick="Joomla.iframeButtonClick({iframeSelector: \'#plugin' . $this->redirectPluginId . 'Modal\', buttonSelector: \'#saveBtn\'})">'
 						. Text::_("JSAVE") . '</button>'
-						. '<button type="button" class="btn btn-success" aria-hidden="true" onclick="jQuery(\'#plugin' . $this->redirectPluginId . 'Modal iframe\').contents().find(\'#applyBtn\').click(); return false;">'
+						. '<button type="button" class="btn btn-success" aria-hidden="true" onclick="Joomla.iframeButtonClick({iframeSelector: \'#plugin' . $this->redirectPluginId . 'Modal\', buttonSelector: \'#applyBtn\'}); return false;">'
 						. Text::_("JAPPLY") . '</button>'
 				)
 			); ?>

--- a/build/media_src/system/js/core.es6.js
+++ b/build/media_src/system/js/core.es6.js
@@ -1139,6 +1139,30 @@ window.Joomla.Modal = window.Joomla.Modal || {
       }
     }
   };
+
+  /**
+   * Method to invoke a click on button inside an iframe
+   *
+   * @param   {object} options Object with the css selector for the parent element of an iframe
+   *                          and the selector of the button in the iframe that will be clicked
+   * @returns {boolean}
+   * @since   4.0
+   */
+  Joomla.iframeButtonClick = (options = {iframeSelector: '', buttonSelector: ''}) => {
+    if (!options.iframeSelector || !options.buttonSelector) {
+      throw new Error('Selector is missing')
+    }
+
+    const iframe = document.querySelector(`${options.iframeSelector} > iframe`);
+    if (iframe) {
+      const button = iframe.contentWindow.document.querySelector(options.buttonSelector);
+      if (button) {
+        button.click();
+      }
+    }
+
+    return false;
+  }
 })(Joomla, document);
 
 /**

--- a/build/media_src/system/js/core.es6.js
+++ b/build/media_src/system/js/core.es6.js
@@ -1148,9 +1148,9 @@ window.Joomla.Modal = window.Joomla.Modal || {
    * @returns {boolean}
    * @since   4.0
    */
-  Joomla.iframeButtonClick = (options = {iframeSelector: '', buttonSelector: ''}) => {
+  Joomla.iframeButtonClick = (options = { iframeSelector: '', buttonSelector: '' }) => {
     if (!options.iframeSelector || !options.buttonSelector) {
-      throw new Error('Selector is missing')
+      throw new Error('Selector is missing');
     }
 
     const iframe = document.querySelector(`${options.iframeSelector} > iframe`);
@@ -1162,7 +1162,7 @@ window.Joomla.Modal = window.Joomla.Modal || {
     }
 
     return false;
-  }
+  };
 })(Joomla, document);
 
 /**

--- a/layouts/joomla/toolbar/modal.php
+++ b/layouts/joomla/toolbar/modal.php
@@ -43,7 +43,7 @@ echo HTMLHelper::_('bootstrap.renderModal',
 						. ' onclick="window.parent.Joomla.Modal.getCurrent().close();">'
 						. Text::_('COM_BANNERS_CANCEL') . '</a>'
 						. '<button class="btn btn-success" type="button"'
-						. ' onclick="jQuery(\'#modal_downloadModal iframe\').contents().find(\'#exportBtn\').click();">'
+						. ' onclick="Joomla.iframeButtonClick({iframeSelector: \'#modal_downloadModal\', buttonSelector: \'#exportBtn\'})">'
 						. Text::_('COM_BANNERS_TRACKS_EXPORT') . '</button>',
 	]
 );


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
- Adds one more helper function in core.js: `Joomla.iframeButtonClick()`
- Function accepts object:
```js
{
iframeSelector: 'Some_css_selectror_or_id_of_the_iframe_parent',
buttonSelector: 'Some_css_selectror_or_id_of_the_button_in_the_iframe'
}
```
- Why object? It's easier to do changes without breaking B/C!!!

### Testing Instructions
Go to the admin area, system ->plugins and disable the redirects plugin
Go to components->redirects
There will be an alert with a link, click on the link
Click the buttons close, save, save and close and observe that everything works fine.

Code review the rest

### Expected result



### Actual result



### Documentation Changes Required
Yes, for the devs not for the users