### PR TITLE
[4.0] WebAsset allow to set a custom weight when it possible, and speed up checking for new files

### DIFF
--- a/administrator/templates/atum/joomla.asset.json
+++ b/administrator/templates/atum/joomla.asset.json
@@ -15,7 +15,7 @@
         "css-vars-ponyfill"
       ],
       "js": [],
-      "weight": 1000
+      "weight": 100000
     },
     "template.atum.ltr": {
       "name": "template.atum.ltr",

--- a/administrator/templates/atum/joomla.asset.json
+++ b/administrator/templates/atum/joomla.asset.json
@@ -14,7 +14,8 @@
         "bootstrap.js.bundle",
         "css-vars-ponyfill"
       ],
-      "js": []
+      "js": [],
+      "weight": 1000
     },
     "template.atum.ltr": {
       "name": "template.atum.ltr",

--- a/administrator/templates/atum/joomla.asset.json
+++ b/administrator/templates/atum/joomla.asset.json
@@ -15,7 +15,7 @@
         "css-vars-ponyfill"
       ],
       "js": [],
-      "weight": 100000
+      "weight": 10000
     },
     "template.atum.ltr": {
       "name": "template.atum.ltr",

--- a/build/media/legacy/joomla.asset.json
+++ b/build/media/legacy/joomla.asset.json
@@ -11,7 +11,8 @@
       ],
       "js": [
         "media/legacy/js/jquery-noconflict.min.js"
-      ]
+      ],
+      "weight": 1
     },
     "jquery.ui.core": {
       "name": "jquery.ui.core",

--- a/build/media/legacy/joomla.asset.json
+++ b/build/media/legacy/joomla.asset.json
@@ -11,8 +11,7 @@
       ],
       "js": [
         "media/legacy/js/jquery-noconflict.min.js"
-      ],
-      "weight": 1
+      ]
     },
     "jquery.ui.core": {
       "name": "jquery.ui.core",

--- a/build/media_src/system/joomla.asset.json
+++ b/build/media_src/system/joomla.asset.json
@@ -8,7 +8,8 @@
       "name": "core",
       "js": [
         "media/system/js/core.min.js"
-      ]
+      ],
+      "weight": -1
     },
     "keepalive": {
       "name": "keepalive",

--- a/build/media_src/system/joomla.asset.json
+++ b/build/media_src/system/joomla.asset.json
@@ -9,7 +9,7 @@
       "js": [
         "media/system/js/core.min.js"
       ],
-      "weight": -1
+      "weight": 70
     },
     "keepalive": {
       "name": "keepalive",

--- a/libraries/src/WebAsset/WebAssetItem.php
+++ b/libraries/src/WebAsset/WebAssetItem.php
@@ -160,6 +160,11 @@ class WebAssetItem
 		{
 			$this->dependencies = (array) $data['dependencies'];
 		}
+
+		if (!empty($data['weight']))
+		{
+			$this->weight = (float) $data['weight'];
+		}
 	}
 
 	/**

--- a/libraries/src/WebAsset/WebAssetRegistry.php
+++ b/libraries/src/WebAsset/WebAssetRegistry.php
@@ -484,7 +484,7 @@ class WebAssetRegistry implements DispatcherAwareInterface
 				$requestedWeights[$name] = $activeAssets[$name]->getWeight();
 			}
 
-			$activeAssets[$name]->setWeight($index * 10);
+			$activeAssets[$name]->setWeight($index * 10 + 100);
 		}
 
 		// Try to set a requested weight, or make it close as possible to requested, but keep the Graph order

--- a/templates/cassiopeia/joomla.asset.json
+++ b/templates/cassiopeia/joomla.asset.json
@@ -16,7 +16,7 @@
         "template.js",
         "user.js"
       ],
-      "weight": 100000
+      "weight": 10000
     },
     "template.cassiopeia.ltr": {
       "name": "template.cassiopeia.ltr",

--- a/templates/cassiopeia/joomla.asset.json
+++ b/templates/cassiopeia/joomla.asset.json
@@ -15,7 +15,8 @@
       "js": [
         "template.js",
         "user.js"
-      ]
+      ],
+      "weight": 100000
     },
     "template.cassiopeia.ltr": {
       "name": "template.cassiopeia.ltr",


### PR DESCRIPTION
### Summary of Changes

The Topological sorting for WebAsset works good, but can have a bit random order between **non dependent** items.
With a weight we can control that.

@infograf768 already found related issue, when template.css not always at "bottom"
See his comment https://github.com/joomla/joomla-cms/pull/22263#issuecomment-448137042

I have set default weight for a template assets to 100000 so it should be always at bottom, unless someone want it more down.

### Testing Instructions

Apply the patch and make sure all still working as before.

Additionally inspect the source of `/administrator/index.php?option=com_content` page,
make sure that template.css at bottom (not before choices.css).

@infograf768 please test :wink: 
ping @wilsonge 

_Note: The patch does not always set the weight "exact to requested" but tries to do it as close as possible, to keep the dependency sorting._

For reference #22435
