### PR TITLE
[4.0] No jQuery in the xml files...

### DIFF
--- a/administrator/components/com_associations/forms/filter_associations.xml
+++ b/administrator/components/com_associations/forms/filter_associations.xml
@@ -4,7 +4,7 @@
 		name="itemtype"
 		type="itemtype"
 		filtermode="selector"
-		onchange="jQuery('select[id^=\'filter_\']').val('');jQuery('select[id^=\'list_\']').val('');this.form.submit();"
+		onchange="Joomla.resetFilters('select[id^=\'filter_\'],select[id^=\'list_\']', this.form)"
 		>
 		<option value="">COM_ASSOCIATIONS_FILTER_SELECT_ITEM_TYPE</option>
 	</field>

--- a/administrator/components/com_associations/forms/filter_associations.xml
+++ b/administrator/components/com_associations/forms/filter_associations.xml
@@ -4,7 +4,7 @@
 		name="itemtype"
 		type="itemtype"
 		filtermode="selector"
-		onchange="Joomla.resetFilters('select[id^=\'filter_\'],select[id^=\'list_\']', this.form)"
+		onchange="Joomla.resetFilters(this)"
 		>
 		<option value="">COM_ASSOCIATIONS_FILTER_SELECT_ITEM_TYPE</option>
 	</field>

--- a/administrator/components/com_languages/forms/filter_installed.xml
+++ b/administrator/components/com_languages/forms/filter_installed.xml
@@ -3,7 +3,7 @@
 	<field
 		name="client_id"
 		type="list"
-		onchange="Joomla.resetFilters('#filter_search,select[id^=filter_],#list_fullordering', this.form)"
+		onchange="Joomla.resetFilters(this)"
 		filtermode="selector"
 		>
 		<option value="0">JSITE</option>

--- a/administrator/components/com_languages/forms/filter_installed.xml
+++ b/administrator/components/com_languages/forms/filter_installed.xml
@@ -3,7 +3,7 @@
 	<field
 		name="client_id"
 		type="list"
-		onchange="jQuery('#filter_search, select[id^=filter_], #list_fullordering').val('');this.form.submit();"
+		onchange="Joomla.resetFilters('#filter_search,select[id^=filter_],#list_fullordering', this.form)"
 		filtermode="selector"
 		>
 		<option value="0">JSITE</option>

--- a/administrator/components/com_modules/forms/filter_modulesadmin.xml
+++ b/administrator/components/com_modules/forms/filter_modulesadmin.xml
@@ -8,7 +8,7 @@
 		label=""
 		filtermode="selector"
 		layout="default"
-		onchange="Joomla.resetFilters('#filter_position,#filter_module,#filter_language', this.form)"
+		onchange="Joomla.resetFilters(this)"
 		>
 		<option value="0">JSITE</option>
 		<option value="1">JADMINISTRATOR</option>

--- a/administrator/components/com_modules/forms/filter_modulesadmin.xml
+++ b/administrator/components/com_modules/forms/filter_modulesadmin.xml
@@ -8,7 +8,7 @@
 		label=""
 		filtermode="selector"
 		layout="default"
-		onchange="jQuery('#filter_position, #filter_module, #filter_language').val('');this.form.submit();"
+		onchange="Joomla.resetFilters('#filter_position,#filter_module,#filter_language', this.form)"
 		>
 		<option value="0">JSITE</option>
 		<option value="1">JADMINISTRATOR</option>

--- a/administrator/components/com_templates/forms/filter_styles.xml
+++ b/administrator/components/com_templates/forms/filter_styles.xml
@@ -4,7 +4,7 @@
 		name="client_id"
 		type="list"
 		filtermode="selector"
-		onchange="Joomla.resetFilters('#filter_search,select[id^=filter_],#list_fullordering', this.form)"
+		onchange="Joomla.resetFilters(this)"
 		>
 		<option value="0">JSITE</option>
 		<option value="1">JADMINISTRATOR</option>

--- a/administrator/components/com_templates/forms/filter_styles.xml
+++ b/administrator/components/com_templates/forms/filter_styles.xml
@@ -4,7 +4,7 @@
 		name="client_id"
 		type="list"
 		filtermode="selector"
-		onchange="jQuery('#filter_search, select[id^=filter_], #list_fullordering').val('');this.form.submit();"
+		onchange="Joomla.resetFilters('#filter_search,select[id^=filter_],#list_fullordering', this.form)"
 		>
 		<option value="0">JSITE</option>
 		<option value="1">JADMINISTRATOR</option>

--- a/administrator/components/com_templates/forms/filter_templates.xml
+++ b/administrator/components/com_templates/forms/filter_templates.xml
@@ -4,7 +4,7 @@
 		name="client_id"
 		type="list"
 		filtermode="selector"
-		onchange="jQuery('#filter_search, select[id^=filter_], #list_fullordering').val('');this.form.submit();"
+		onchange="Joomla.resetFilters('#filter_search,select[id^=filter_],#list_fullordering', this.form)"
 		>
 		<option value="0">JSITE</option>
 		<option value="1">JADMINISTRATOR</option>

--- a/administrator/components/com_templates/forms/filter_templates.xml
+++ b/administrator/components/com_templates/forms/filter_templates.xml
@@ -4,7 +4,7 @@
 		name="client_id"
 		type="list"
 		filtermode="selector"
-		onchange="Joomla.resetFilters('#filter_search,select[id^=filter_],#list_fullordering', this.form)"
+		onchange="Joomla.resetFilters('#filter_search,#list_limit,#list_fullordering', this.form)"
 		>
 		<option value="0">JSITE</option>
 		<option value="1">JADMINISTRATOR</option>

--- a/administrator/components/com_templates/forms/filter_templates.xml
+++ b/administrator/components/com_templates/forms/filter_templates.xml
@@ -4,7 +4,7 @@
 		name="client_id"
 		type="list"
 		filtermode="selector"
-		onchange="Joomla.resetFilters('#filter_search,#list_limit,#list_fullordering', this.form)"
+		onchange="Joomla.resetFilters(this)"
 		>
 		<option value="0">JSITE</option>
 		<option value="1">JADMINISTRATOR</option>

--- a/build/media_src/system/js/core.es6.js
+++ b/build/media_src/system/js/core.es6.js
@@ -1146,15 +1146,20 @@ window.Joomla.Modal = window.Joomla.Modal || {
    * @param {HTMLFormElement} form      The form that will be finally submitted
    */
   Joomla.resetFilters = (selectors, form) => {
+    debugger;
+    const elementsArray = [];
     const cssSelectors = selectors.split(',');
     cssSelectors.forEach((selector) => {
-      const element = document.querySelector(selector);
+      const elements = [].slice.call(document.querySelectorAll(selector));
 
-      if (element) {
-        element.value = '';
+      if (elements.length) {
+        elementsArray.concat(elements);
       }
     });
 
+    elementsArray.forEach((element) => {
+      element.value = '';
+    });
     form.submit();
   };
 })(Joomla, document);

--- a/build/media_src/system/js/core.es6.js
+++ b/build/media_src/system/js/core.es6.js
@@ -1142,25 +1142,39 @@ window.Joomla.Modal = window.Joomla.Modal || {
 
   /**
    * Method that resets given inputs and submits the given form
-   * @param {string}          selectors Comma separated css selectors of the inputs
-   * @param {HTMLFormElement} form      The form that will be finally submitted
+   * @param {HTMLElement}  The element that initiates the call
    */
-  Joomla.resetFilters = (selectors, form) => {
-    debugger;
-    const elementsArray = [];
-    const cssSelectors = selectors.split(',');
-    cssSelectors.forEach((selector) => {
-      const elements = [].slice.call(document.querySelectorAll(selector));
+  Joomla.resetFilters = (element) => {
+    const form = element.form;
+    if (!form) {
+      throw new Error('Element must be inside a form!')
+    }
 
-      if (elements.length) {
-        elementsArray.concat(elements);
-      }
-    });
+    const elementsArray = [].slice.call(form.elements);
 
-    elementsArray.forEach((element) => {
-      element.value = '';
-    });
-    form.submit();
+    if (elementsArray.length) {
+      const newElementsArray = [];
+      elementsArray.forEach((element) => {
+        // Skip these
+        if (element.getAttribute('name') === 'task' || element.getAttribute('name') === 'boxchecked') {
+          return;
+        }
+        // Skip the token
+        // !/^[0-9A-F]{32}$/i.test(newToken)
+        if (element.value === '1' && /^[0-9A-F]{32}$/i.test(element.name)) {
+          return;
+        }
+
+        newElementsArray.push(element)
+      });
+
+      // Reset all filters
+      newElementsArray.forEach((element) => {
+        element.value = '';
+      });
+
+      form.submit();
+    }
   };
 })(Joomla, document);
 

--- a/build/media_src/system/js/core.es6.js
+++ b/build/media_src/system/js/core.es6.js
@@ -1142,7 +1142,10 @@ window.Joomla.Modal = window.Joomla.Modal || {
 
   /**
    * Method that resets given inputs and submits the given form
+   *
    * @param {HTMLElement}  The element that initiates the call
+   * @returns {void}
+   * @since   4.0
    */
   Joomla.resetFilters = (element) => {
     const { form } = element;

--- a/build/media_src/system/js/core.es6.js
+++ b/build/media_src/system/js/core.es6.js
@@ -1145,32 +1145,31 @@ window.Joomla.Modal = window.Joomla.Modal || {
    * @param {HTMLElement}  The element that initiates the call
    */
   Joomla.resetFilters = (element) => {
-    const form = element.form;
+    const { form } = element;
+
     if (!form) {
-      throw new Error('Element must be inside a form!')
+      throw new Error('Element must be inside a form!');
     }
 
     const elementsArray = [].slice.call(form.elements);
 
     if (elementsArray.length) {
       const newElementsArray = [];
-      elementsArray.forEach((element) => {
-        // Skip these
-        if (element.getAttribute('name') === 'task' || element.getAttribute('name') === 'boxchecked') {
-          return;
-        }
-        // Skip the token
-        // !/^[0-9A-F]{32}$/i.test(newToken)
-        if (element.value === '1' && /^[0-9A-F]{32}$/i.test(element.name)) {
+      elementsArray.forEach((elem) => {
+        // Skip the token, the task, the boxchecked and the calling element
+        if (elem.getAttribute('name') === 'task'
+          || elem.getAttribute('name') === 'boxchecked'
+          || (elem.value === '1' && /^[0-9A-F]{32}$/i.test(elem.name))
+          || elem === element) {
           return;
         }
 
-        newElementsArray.push(element)
+        newElementsArray.push(elem);
       });
 
       // Reset all filters
-      newElementsArray.forEach((element) => {
-        element.value = '';
+      newElementsArray.forEach((elem) => {
+        elem.value = '';
       });
 
       form.submit();

--- a/build/media_src/system/js/core.es6.js
+++ b/build/media_src/system/js/core.es6.js
@@ -1139,6 +1139,24 @@ window.Joomla.Modal = window.Joomla.Modal || {
       }
     }
   };
+
+  /**
+   * Method that resets given inputs and submits the given form
+   * @param {string}          selectors Comma separated css selectors of the inputs
+   * @param {HTMLFormElement} form      The form that will be finally submitted
+   */
+  Joomla.resetFilters = (selectors, form) => {
+    const cssSelectors = selectors.split(',');
+    cssSelectors.forEach((selector) => {
+      const element = document.querySelector(selector);
+
+      if (element) {
+        element.value = '';
+      }
+    });
+
+    form.submit();
+  };
 })(Joomla, document);
 
 /**


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
- Added a new method in core.js
```js
  /**
   * Method that resets given inputs and submits the given form
   * @param {HTMLElement}  The element that initiates the call
   */
  Joomla.resetFilters = (element) => { }
```
- Changed all the xml filters to use this method
- The method will reset all the fields **of the filters form only** except:
-- the task
-- the token
-- the boxcheked

### Testing Instructions
Go to Admin templates, check if the site/admin dropdown resets the table options
<img width="1466" alt="screenshot 2018-12-31 at 21 53 28" src="https://user-images.githubusercontent.com/3889375/50567584-f45b3280-0d46-11e9-876e-1166e4f1e326.png">


### Expected result



### Actual result



### Documentation Changes Required
Yes.
Basically to implement the filter reset one just needs to add in the XML:
```xml
		onchange="Joomla.resetFilters(this)"
```
That simple 