### PR TITLE
[4.0] PR #21558 moved system-message outside if(empty) in layouts/joomla/system/message.php file

### DIFF
--- a/layouts/joomla/system/message.php
+++ b/layouts/joomla/system/message.php
@@ -31,8 +31,8 @@ $alert = [
 HTMLHelper::_('webcomponent', 'vendor/joomla-custom-elements/joomla-alert.min.js', ['version' => 'auto', 'relative' => true]);
 ?>
 <div id="system-message-container">
-	<div id="system-message">
-		<?php if (is_array($msgList) && !empty($msgList)) : ?>
+	<?php if (is_array($msgList) && !empty($msgList)) : ?>
+		<div id="system-message">
 			<?php foreach ($msgList as $type => $msgs) : ?>
 				<joomla-alert type="<?php echo $alert[$type] ?? $type; ?>" dismiss="true">
 					<?php if (!empty($msgs)) : ?>
@@ -45,6 +45,6 @@ HTMLHelper::_('webcomponent', 'vendor/joomla-custom-elements/joomla-alert.min.js
 					<?php endif; ?>
 				</joomla-alert>
 			<?php endforeach; ?>
-		<?php endif; ?>
-	</div>
+		</div>
+	<?php endif; ?>
 </div>


### PR DESCRIPTION
Pull Request for Issue #23420 .

### Summary of Changes

Moved `<div id="system-messsage">` back inside `<?php if....>`

### Testing Instructions
With your WebBrowser DevTools, check that `<div id="system-message"><div`> is not displayed if no system message is to be displayed

