### PR TITLE
[4.0] Session metadata manager updates

### DIFF
--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -171,8 +171,7 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
 	 */
 	public function checkSession()
 	{
-		$metadataManager = new MetadataManager($this, Factory::getDbo());
-		$metadataManager->createRecordIfNonExisting(Factory::getSession(), Factory::getUser());
+		$this->getContainer()->get(MetadataManager::class)->createRecordIfNonExisting($this->getSession(), $this->getIdentity());
 	}
 
 	/**

--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -171,7 +171,7 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
 	 */
 	public function checkSession()
 	{
-		$this->getContainer()->get(MetadataManager::class)->createRecordIfNonExisting($this->getSession(), $this->getIdentity());
+		$this->getContainer()->get(MetadataManager::class)->createOrUpdateRecord($this->getSession(), $this->getIdentity());
 	}
 
 	/**

--- a/libraries/src/Console/SessionMetadataGcCommand.php
+++ b/libraries/src/Console/SessionMetadataGcCommand.php
@@ -10,9 +10,9 @@ namespace Joomla\CMS\Console;
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\CMS\Factory;
 use Joomla\CMS\Session\MetadataManager;
 use Joomla\Console\AbstractCommand;
-use Joomla\Database\DatabaseInterface;
 use Joomla\Session\SessionInterface;
 
 /**
@@ -23,12 +23,12 @@ use Joomla\Session\SessionInterface;
 class SessionMetadataGcCommand extends AbstractCommand
 {
 	/**
-	 * The database object.
+	 * The session metadata manager.
 	 *
-	 * @var    DatabaseInterface
+	 * @var    MetadataManager
 	 * @since  4.0.0
 	 */
-	private $db;
+	private $metadataManager;
 
 	/**
 	 * The session object.
@@ -41,15 +41,15 @@ class SessionMetadataGcCommand extends AbstractCommand
 	/**
 	 * Instantiate the command.
 	 *
-	 * @param   SessionInterface   $session  The session object.
-	 * @param   DatabaseInterface  $db       The database object.
+	 * @param   SessionInterface  $session          The session object.
+	 * @param   MetadataManager   $metadataManager  The session metadata manager.
 	 *
 	 * @since   4.0.0
 	 */
-	public function __construct(SessionInterface $session, DatabaseInterface $db)
+	public function __construct(SessionInterface $session, MetadataManager $metadataManager)
 	{
-		$this->session = $session;
-		$this->db      = $db;
+		$this->session         = $session;
+		$this->metadataManager = $metadataManager;
 
 		parent::__construct();
 	}
@@ -69,7 +69,7 @@ class SessionMetadataGcCommand extends AbstractCommand
 
 		$sessionExpire = $this->session->getExpire();
 
-		(new MetadataManager($this->getApplication(), $this->db))->deletePriorTo(time() - $sessionExpire);
+		$this->metadataManager->deletePriorTo(time() - $sessionExpire);
 
 		$symfonyStyle->success('Metadata garbage collection completed.');
 

--- a/libraries/src/Service/Provider/Console.php
+++ b/libraries/src/Service/Provider/Console.php
@@ -13,6 +13,7 @@ defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Console\SessionGcCommand;
 use Joomla\CMS\Console\SessionMetadataGcCommand;
+use Joomla\CMS\Session\MetadataManager;
 use Joomla\DI\Container;
 use Joomla\DI\ServiceProviderInterface;
 
@@ -54,7 +55,7 @@ class Console implements ServiceProviderInterface
 			SessionMetadataGcCommand::class,
 			function (Container $container)
 			{
-				return new SessionMetadataGcCommand($container->get('session'), $container->get('db'));
+				return new SessionMetadataGcCommand($container->get('session'), $container->get(MetadataManager::class));
 			},
 			true
 		);

--- a/libraries/src/Service/Provider/Dispatcher.php
+++ b/libraries/src/Service/Provider/Dispatcher.php
@@ -14,9 +14,10 @@ defined('JPATH_PLATFORM') or die;
 use Joomla\DI\Container;
 use Joomla\DI\ServiceProviderInterface;
 use Joomla\Event\Dispatcher as EventDispatcher;
+use Joomla\Event\DispatcherInterface as EventDispatcherInterface;
 
 /**
- * Service provider for the application's dispatcher dependency
+ * Service provider for the application's event dispatcher dependency
  *
  * @since  4.0
  */
@@ -33,10 +34,10 @@ class Dispatcher implements ServiceProviderInterface
 	 */
 	public function register(Container $container)
 	{
-		$container->alias('dispatcher', 'Joomla\Event\DispatcherInterface')
-			->alias('Joomla\Event\Dispatcher', 'Joomla\Event\DispatcherInterface')
+		$container->alias('dispatcher', EventDispatcherInterface::class)
+			->alias(EventDispatcher::class, EventDispatcherInterface::class)
 			->share(
-				'Joomla\Event\DispatcherInterface',
+				EventDispatcherInterface::class,
 				function (Container $container)
 				{
 					return new EventDispatcher;

--- a/libraries/src/Session/MetadataManager.php
+++ b/libraries/src/Session/MetadataManager.php
@@ -94,7 +94,7 @@ final class MetadataManager
 			return;
 		}
 
-		$query->clear();
+		$query = $this->db->getQuery(true);
 
 		$time = $session->isNew() ? time() : $session->get('session.timer.start');
 
@@ -118,7 +118,7 @@ final class MetadataManager
 		// Bind query values
 		$userIsGuest = $user->guest;
 		$userId      = $user->id;
-		$username    = $user->username;
+		$username    = $user->username === null ? '' : $user->username;
 
 		$query->bind(':session_id', $sessionId)
 			->bind(':guest', $userIsGuest, ParameterType::BOOLEAN)

--- a/libraries/src/Session/MetadataManager.php
+++ b/libraries/src/Session/MetadataManager.php
@@ -16,6 +16,7 @@ use Joomla\CMS\User\User;
 use Joomla\Database\DatabaseInterface;
 use Joomla\Database\Exception\ExecutionFailureException;
 use Joomla\Database\ParameterType;
+use Joomla\Session\SessionInterface;
 
 /**
  * Manager for optional session metadata.
@@ -25,6 +26,33 @@ use Joomla\Database\ParameterType;
  */
 final class MetadataManager
 {
+	/**
+	 * Internal variable indicating a session record exists.
+	 *
+	 * @var    integer
+	 * @since  __DEPLOY_VERSION__
+	 * @note   Once PHP 7.1 is the minimum supported version this should become a private constant
+	 */
+	private static $sessionRecordExists = 1;
+
+	/**
+	 * Internal variable indicating a session record does not exist.
+	 *
+	 * @var    integer
+	 * @since  __DEPLOY_VERSION__
+	 * @note   Once PHP 7.1 is the minimum supported version this should become a private constant
+	 */
+	private static $sessionRecordDoesNotExist = 0;
+
+	/**
+	 * Internal variable indicating an unknown session record statue.
+	 *
+	 * @var    integer
+	 * @since  __DEPLOY_VERSION__
+	 * @note   Once PHP 7.1 is the minimum supported version this should become a private constant
+	 */
+	private static $sessionRecordUnknown = -1;
+
 	/**
 	 * Application object.
 	 *
@@ -58,18 +86,97 @@ final class MetadataManager
 	/**
 	 * Create the metadata record if it does not exist.
 	 *
-	 * @param   Session  $session  The session to create the metadata record for.
-	 * @param   User     $user     The user to associate with the record.
+	 * @param   SessionInterface  $session  The session to create the metadata record for.
+	 * @param   User              $user     The user to associate with the record.
 	 *
 	 * @return  void
 	 *
 	 * @since   3.8.6
 	 * @throws  \RuntimeException
 	 */
-	public function createRecordIfNonExisting(Session $session, User $user)
+	public function createRecordIfNonExisting(SessionInterface $session, User $user)
 	{
-		$sessionId = $session->getId();
+		$exists = $this->checkSessionRecordExists($session->getId());
 
+		// Only touch the database if the record does not already exist
+		if ($exists !== self::$sessionRecordExists)
+		{
+			return;
+		}
+
+		$this->createSessionRecord($session, $user);
+	}
+
+	/**
+	 * Create the metadata record if it does not exist.
+	 *
+	 * @param   SessionInterface  $session  The session to create or update the metadata record for.
+	 * @param   User              $user     The user to associate with the record.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  \RuntimeException
+	 */
+	public function createOrUpdateRecord(SessionInterface $session, User $user)
+	{
+		$exists = $this->checkSessionRecordExists($session->getId());
+
+		// Do not try to touch the database if we can't determine the record state
+		if ($exists === self::$sessionRecordDoesNotExist)
+		{
+			return;
+		}
+
+		if ($exists === self::$sessionRecordDoesNotExist)
+		{
+			$this->createSessionRecord($session, $user);
+
+			return;
+		}
+
+		$this->updateSessionRecord($session, $user);
+	}
+
+	/**
+	 * Delete records with a timestamp prior to the given time.
+	 *
+	 * @param   integer  $time  The time records should be deleted if expired before.
+	 *
+	 * @return  void
+	 *
+	 * @since   3.8.6
+	 */
+	public function deletePriorTo($time)
+	{
+		$query = $this->db->getQuery(true)
+			->delete($this->db->quoteName('#__session'))
+			->where($this->db->quoteName('time') . ' < :time')
+			->bind(':time', $time, ParameterType::INTEGER);
+
+		$this->db->setQuery($query);
+
+		try
+		{
+			$this->db->execute();
+		}
+		catch (ExecutionFailureException $exception)
+		{
+			// Since garbage collection does not result in a fatal error when run in the session API, we don't allow it here either.
+		}
+	}
+
+	/**
+	 * Check if the session record exists
+	 *
+	 * @param   string  $sessionId  The session ID to check
+	 *
+	 * @return  integer  Status value for record presence
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	private function checkSessionRecordExists(string $sessionId): int
+	{
 		$query = $this->db->getQuery(true)
 			->select($this->db->quoteName('session_id'))
 			->from($this->db->quoteName('#__session'))
@@ -85,15 +192,29 @@ final class MetadataManager
 		}
 		catch (ExecutionFailureException $e)
 		{
-			return;
+			return self::$sessionRecordUnknown;
 		}
 
-		// If the session record doesn't exist initialise it.
 		if ($exists)
 		{
-			return;
+			return self::$sessionRecordExists;
 		}
 
+		return self::$sessionRecordDoesNotExist;
+	}
+
+	/**
+	 * Create the session record
+	 *
+	 * @param   SessionInterface  $session  The session to create the metadata record for.
+	 * @param   User              $user     The user to associate with the record.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	private function createSessionRecord(SessionInterface $session, User $user)
+	{
 		$query = $this->db->getQuery(true);
 
 		$time = $session->isNew() ? time() : $session->get('session.timer.start');
@@ -116,6 +237,7 @@ final class MetadataManager
 		];
 
 		// Bind query values
+		$sessionId   = $session->getId();
 		$userIsGuest = $user->guest;
 		$userId      = $user->id;
 		$username    = $user->username === null ? '' : $user->username;
@@ -153,20 +275,52 @@ final class MetadataManager
 	}
 
 	/**
-	 * Delete records with a timestamp prior to the given time.
+	 * Update the session record
 	 *
-	 * @param   integer  $time  The time records should be deleted if expired before.
+	 * @param   SessionInterface  $session  The session to update the metadata record for.
+	 * @param   User              $user     The user to associate with the record.
 	 *
 	 * @return  void
 	 *
-	 * @since   3.8.6
+	 * @since   __DEPLOY_VERSION__
 	 */
-	public function deletePriorTo($time)
+	private function updateSessionRecord(SessionInterface $session, User $user)
 	{
-		$query = $this->db->getQuery(true)
-			->delete($this->db->quoteName('#__session'))
-			->where($this->db->quoteName('time') . ' < :time')
-			->bind(':time', $time, ParameterType::INTEGER);
+		$query = $this->db->getQuery(true);
+
+		$time = $session->isNew() ? time() : $session->get('session.timer.start');
+
+		$setValues = [
+			$this->db->quoteName('guest') . ' = :guest',
+			$this->db->quoteName('time') . ' = :time',
+			$this->db->quoteName('userid') . ' = :user_id',
+			$this->db->quoteName('username') . ' = :username',
+		];
+
+		// Bind query values
+		$sessionId   = $session->getId();
+		$userIsGuest = $user->guest;
+		$userId      = $user->id;
+		$username    = $user->username === null ? '' : $user->username;
+
+		$query->bind(':session_id', $sessionId)
+			->bind(':guest', $userIsGuest, ParameterType::BOOLEAN)
+			->bind(':time', $time)
+			->bind(':user_id', $userId, ParameterType::INTEGER)
+			->bind(':username', $username);
+
+		if ($this->app instanceof CMSApplication && !$this->app->get('shared_session', false))
+		{
+			$clientId = $this->app->getClientId();
+
+			$setValues[] = $this->db->quoteName('client_id') . ' = :client_id';
+
+			$query->bind(':client_id', $clientId, ParameterType::INTEGER);
+		}
+
+		$query->update($this->db->quoteName('#__session'))
+			->set($setValues)
+			->where($this->db->quoteName('session_id') . ' = :session_id');
 
 		$this->db->setQuery($query);
 
@@ -174,9 +328,9 @@ final class MetadataManager
 		{
 			$this->db->execute();
 		}
-		catch (ExecutionFailureException $exception)
+		catch (ExecutionFailureException $e)
 		{
-			// Since garbage collection does not result in a fatal error when run in the session API, we don't allow it here either.
+			// This failure isn't critical, we can go on without the metadata
 		}
 	}
 }

--- a/plugins/system/sessiongc/sessiongc.php
+++ b/plugins/system/sessiongc/sessiongc.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Application\CMSApplication;
+use Joomla\CMS\Factory;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\CMS\Session\MetadataManager;
 
@@ -67,7 +68,8 @@ class PlgSystemSessionGc extends CMSPlugin
 
 			if ($probability > 0 && $random < $probability)
 			{
-				$metadataManager = new MetadataManager($this->app, $this->db);
+				/** @var MetadataManager $metadataManager */
+				$metadataManager = Factory::getContainer()->get(MetadataManager::class);
 				$metadataManager->deletePriorTo(time() - $this->app->getSession()->getExpire());
 			}
 		}


### PR DESCRIPTION
Partial Pull Request for https://github.com/joomla/joomla-cms/issues/17405#issuecomment-410900039

### Summary of Changes

- Works around a design flaw in the database API's handling of parameterized query values that disallows null values (probably because so much of the CMS application uses some form of `NOT NULL (DEFAULT ...)` statement on most of the schema) preventing metadata from being inserted for guest users
- Adds a `createOrUpdateRecord` method to the MetadataManager and uses it over the `createRecordIfNonExisting` method (as the session API correctly inserts records to the database in 4.0 and this insert generally occurs before the session's start event is fired, more often than not the update path here is going to be used when the database handler is in use and the create path only executed when the session is initially created for other handlers; note this should now also mean the timestamp is more accurate when not using the database handler)
- Adjusts the priority of the application's `afterSessionStart` listener for the `SessionEvents::START` event so it always runs before the metadata manager
- Registers a listener for `SessionEvents::START` to ensure the metadata manager is fired
    - This bit is hacky as all hell because doing it right gets into dependency hell (a proper event listener has a dependency to the `MetadataManager`, the `MetadataManager` has a dependency to the database, the database has a dependency to the event dispatcher, and when building the dispatcher service generally you'd have something like `foreach ($container->getTagged('event.subscriber') as $subscriber) { $dispatcher->addSubscriber($subscriber); }` in that service's callback, and that's the bit that would trigger a circular dependency problem and either the Container catches that and throws an error or PHP errors out with a maximum nesting related message)

### Testing Instructions

- Apply patch to a 4.0 install
- Ensure session metadata is correctly written at the start of each request when metadata is enabled
- Ensure no metadata writes are made when the option is disabled (global config)