### PR TITLE
[4.0] Extensions Update Message: correcting broken link from #23362

### DIFF
--- a/build/media_src/plg_quickicon_extensionupdate/js/extensionupdatecheck.es6.js
+++ b/build/media_src/plg_quickicon_extensionupdate/js/extensionupdatecheck.es6.js
@@ -43,7 +43,7 @@
                 warning: [
                   `<div class="message-alert">
   ${Joomla.Text._('PLG_QUICKICON_EXTENSIONUPDATE_UPDATEFOUND_MESSAGE').replace('%s', `<span class="badge badge-pill badge-danger">${updateInfoList.length}</span>`)}
-  <button type="button" class="btn btn-sm btn-primary" onclick="document.location=${options.url}">
+  <button type="button" class="btn btn-sm btn-primary" onclick="document.location='${options.url}'">
     ${Joomla.Text._('PLG_QUICKICON_EXTENSIONUPDATE_UPDATEFOUND_BUTTON')}
   </button>
 </div>`,


### PR DESCRIPTION
### Summary of Changes
#23362 Missing single quotes in the js for the extension Update URL in the message displayed in CPanel
Therefore link is broken when clicking on the View Updates button

### Testing Instructions
Install any extension for which there is an update.
For example, install 
[fr-FR_joomla_lang_full_3.9.0v3.zip](https://github.com/joomla/joomla-cms/files/2723544/fr-FR_joomla_lang_full_3.9.0v3.zip)

Load CPanel
A 3.9.1.0 version is available and the message displays
<img width="447" alt="screen shot 2019-01-03 at 12 42 18" src="https://user-images.githubusercontent.com/869724/50636129-2e9a1f00-0f55-11e9-8b23-5170a35d73c8.png">

### After patch
Clicking on the button now works fine.

@dgrammatiko 
@wilsonge 