### PR TITLE
Remove unused postSaveHook methods

### DIFF
--- a/administrator/components/com_newsfeeds/Controller/NewsfeedController.php
+++ b/administrator/components/com_newsfeeds/Controller/NewsfeedController.php
@@ -115,19 +115,4 @@ class NewsfeedController extends FormController
 
 		return parent::batch($model);
 	}
-
-	/**
-	 * Function that allows child controller access to model data after the data has been saved.
-	 *
-	 * @param   Model  $model      The data model object.
-	 * @param   array  $validData  The validated data.
-	 *
-	 * @return  void
-	 *
-	 * @since   3.1
-	 */
-	protected function postSaveHook(BaseDatabaseModel $model, $validData = array())
-	{
-
-	}
 }

--- a/administrator/components/com_newsfeeds/Controller/NewsfeedsController.php
+++ b/administrator/components/com_newsfeeds/Controller/NewsfeedsController.php
@@ -35,19 +35,4 @@ class NewsfeedsController extends AdminController
 	{
 		return parent::getModel($name, $prefix, $config);
 	}
-
-	/**
-	 * Function that allows child controller access to model data
-	 * after the item has been deleted.
-	 *
-	 * @param   Model    $model  The data model object.
-	 * @param   integer  $ids    The validated data.
-	 *
-	 * @return  void
-	 *
-	 * @since   3.1
-	 */
-	protected function postDeleteHook(Model $model, $ids = null)
-	{
-	}
 }


### PR DESCRIPTION
Pull Request for Issue #23403

### Summary of Changes
Remove unused postSaveHook methods (fallback to the default) and fix the error in the mentioned issue


### Testing Instructions
Delete newsfeed items


### Expected result
No errors, items deleted


### Actual result
Error message

