### PR TITLE
Add json to source_formats of template editor

### DIFF
--- a/administrator/components/com_templates/config.xml
+++ b/administrator/components/com_templates/config.xml
@@ -49,7 +49,7 @@
 			type="text"
 			label="COM_TEMPLATES_CONFIG_SOURCE_LABEL"
 			description="COM_TEMPLATES_CONFIG_SOURCE_DESC"
-			default="txt,less,ini,xml,js,php,css,sass,scss"
+			default="txt,less,ini,xml,js,php,css,sass,scss,json"
 			extension="com_templates"
 		/>
 


### PR DESCRIPTION
### Testing Instructions
- 4.0 nightly build.
- Go to `administrator/index.php?option=com_templates&view=templates`
- Click on "Cassiopeia Details and Files"
- See file list on the left:
File `joomla.asset.json` (an essential file for templates configuration in J4) is missing.
- Apply patch
- Test again