### PR TITLE
Deprecating loadFieldType & loadRuleType

### DIFF
--- a/libraries/src/Form/Form.php
+++ b/libraries/src/Form/Form.php
@@ -1941,6 +1941,7 @@ class Form
 	 * @return  FormField|boolean  FormField object on success, false otherwise.
 	 *
 	 * @since   1.7.0
+	 * @deprecated  4.0  Use FormHelper::loadFieldType() directly
 	 */
 	protected function loadFieldType($type, $new = true)
 	{
@@ -1957,6 +1958,7 @@ class Form
 	 *
 	 * @see     FormHelper::loadRuleType()
 	 * @since   1.7.0
+	 * @deprecated  4.0  Use FormHelper::loadRuleType() directly
 	 */
 	protected function loadRuleType($type, $new = true)
 	{


### PR DESCRIPTION
This is the PR to deprecate these 2 methods for #12414 