### PR TITLE
[com_joomlaupdate] restore vs php 7.3

### DIFF
--- a/administrator/components/com_joomlaupdate/restore.php
+++ b/administrator/components/com_joomlaupdate/restore.php
@@ -1222,7 +1222,7 @@ abstract class AKAbstractUnarchiver extends AKAbstractPart
 						$this->notify($message);
 					}
 					$this->runState = AK_STATE_NOFILE;
-					continue;
+					break;
 			}
 		}
 


### PR DESCRIPTION
Pull Request for Issue #23266

### Summary of Changes
break vs continue for php 7.3.


### Testing Instructions
on php 7.3 no more that warning 

