### PR TITLE
[4.0] Missing files in template manifests

### DIFF
--- a/administrator/templates/atum/templateDetails.xml
+++ b/administrator/templates/atum/templateDetails.xml
@@ -15,6 +15,7 @@
 		<filename>error_login.php</filename>
 		<filename>favicon.ico</filename>
 		<filename>index.php</filename>
+		<filename>joomla.asset.json</filename>
 		<filename>login.php</filename>
 		<filename>templateDetails.xml</filename>
 		<filename>template_preview.png</filename>

--- a/templates/cassiopeia/templateDetails.xml
+++ b/templates/cassiopeia/templateDetails.xml
@@ -12,6 +12,8 @@
 		<filename>error.php</filename>
 		<filename>favicon.ico</filename>
 		<filename>index.php</filename>
+		<filename>joomla.asset.json</filename>
+		<filename>offline.php</filename>
 		<filename>templateDetails.xml</filename>
 		<filename>template_preview.png</filename>
 		<filename>template_thumbnail.png</filename>


### PR DESCRIPTION
Pull Request for Issue #23483.

### Summary of Changes

Adds some missing files to `templateDetails.xml`.

### Testing Instructions

Copy a template.

### Expected result

All template files are copied.

### Actual result

Copies are missing `joomla.asset.json` file. Cassiopeia copy is also missing `offline.php`. 

### Documentation Changes Required
No.
