### PR TITLE
[4.0] Fix notice in mod_syndicate.xml

### DIFF
--- a/modules/mod_syndicate/mod_syndicate.xml
+++ b/modules/mod_syndicate/mod_syndicate.xml
@@ -31,7 +31,6 @@
 					description="MOD_SYNDICATE_FIELD_DISPLAYTEXT_DESC"
 					default="1"
 					filter="integer"
-					class="btn-group btn-group-yesno"
 					>
 					<option value="0">JNO</option>
 					<option value="1">JYES</option>


### PR DESCRIPTION
### Summary of Changes
Fix a notice in backend, Sypstem Panel (settings).  Warning: simplexml_load_file(): .../modules/mod_syndicate/mod_syndicate.xml:35: parser error 
