### PR TITLE
[4.0] [com_menus] Fix "Too few arguments to function PlgContentJoomla::onContentBeforeSave"

### DIFF
--- a/administrator/components/com_menus/Model/MenuModel.php
+++ b/administrator/components/com_menus/Model/MenuModel.php
@@ -246,7 +246,7 @@ class MenuModel extends FormModel
 		}
 
 		// Trigger the before event.
-		$result = Factory::getApplication()->triggerEvent('onContentBeforeSave', array($this->_context, &$table, $isNew));
+		$result = Factory::getApplication()->triggerEvent('onContentBeforeSave', array($this->_context, &$table, $isNew, $data));
 
 		// Store the data.
 		if (in_array(false, $result, true) || !$table->store())


### PR DESCRIPTION
Similar PR as https://github.com/joomla/joomla-cms/pull/23531 but for com_menus

### Summary of Changes
Adding $data

### Testing Instructions
Create or edit and save a Menu
`Too few arguments to function PlgContentJoomla::onContentBeforeSave(), 3 passed in /Applications/MAMP/htdocs/installmulti/joomla40/libraries/src/Plugin/CMSPlugin.php on line 287 and exactly 4 expected `


### After patch
Issue solved