### PR TITLE
[4.0] administrator login style change

### DIFF
--- a/administrator/modules/mod_login/tmpl/default.php
+++ b/administrator/modules/mod_login/tmpl/default.php
@@ -53,8 +53,8 @@ Text::script('JHIDE');
 			<div class="input-group">
 				<span class="input-group-prepend">
 					<span class="sr-only"><?php echo Text::_('JSHOW'); ?></span>
-					<span class="input-group-text" aria-hidden="true">
-						<span class="fa fa-fw fa-lock"></span>
+					<span class="input-group-text">
+						<span class="fa fa-fw fa-lock" aria-hidden="true"></span>
 					</span>
 				</span>
 				<input

--- a/administrator/modules/mod_login/tmpl/default.php
+++ b/administrator/modules/mod_login/tmpl/default.php
@@ -72,7 +72,9 @@ Text::script('JHIDE');
 				</label>
 				<div class="input-group">
 					<span class="input-group-prepend">
-						<span class="input-group-text"><span class="fa fa-shield" aria-hidden="true"></span></span>
+						<span class="input-group-text">
+							<span class="fa fa-shield" aria-hidden="true"></span>
+						</span>
 					</span>
 					<input
 						name="secretkey"

--- a/administrator/modules/mod_login/tmpl/default.php
+++ b/administrator/modules/mod_login/tmpl/default.php
@@ -33,7 +33,7 @@ Text::script('JHIDE');
 			<div class="input-group">
 				<span class="input-group-prepend">
 					<span class="input-group-text">
-						<span class="fa fa-user" aria-hidden="true"></span>
+						<span class="fa fa-fw fa-user" aria-hidden="true"></span>
 					</span>
 				</span>
 				<input
@@ -53,7 +53,9 @@ Text::script('JHIDE');
 			<div class="input-group">
 				<span class="input-group-prepend">
 					<span class="sr-only"><?php echo Text::_('JSHOW'); ?></span>
-					<span class="input-group-text icon-eye" aria-hidden="true"></span>
+					<span class="input-group-text" aria-hidden="true">
+						<span class="fa fa-fw fa-lock"></span>
+					</span>
 				</span>
 				<input
 					name="passwd"
@@ -72,9 +74,7 @@ Text::script('JHIDE');
 				</label>
 				<div class="input-group">
 					<span class="input-group-prepend">
-						<span class="input-group-text">
-							<span class="fa fa-shield" aria-hidden="true"></span>
-						</span>
+						<span class="input-group-text"><span class="fa fa-shield" aria-hidden="true"></span></span>
 					</span>
 					<input
 						name="secretkey"


### PR DESCRIPTION
### Summary of Changes
Small style adjustment to login module for administrator. Swapped the password label to use a Font Awesome icon and forced them to the same width. This makes the fields line up.


### Testing Instructions
Check that the labels and inputs line up across all viewports.


### Expected result
The labels and input fields line up appropriately.


### Documentation Changes Required
No documentation changes I can think of.

