### PR TITLE
Reset hits on save as copy

### DIFF
--- a/administrator/components/com_content/models/article.php
+++ b/administrator/components/com_content/models/article.php
@@ -629,7 +629,11 @@ class ContentModelArticle extends JModelAdmin
 				}
 			}
 
+			// Unpublish
 			$data['state'] = 0;
+
+			// Reset hits
+			$data['hits'] = 0;
 		}
 
 		// Automatic handling of alias for empty fields


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
When you edit an article and press _save as copy_ the hits counter is not reset. This PR adds a line of code to reset the hits of an article when you click _save as copy_

### Testing Instructions
- Open an article to edit
- Click the button _save as copy_
- See the copied article

### Expected result
Hits are reset to zero after duplication.

### Actual result
Hits are currently the same as the item copied from

### Result after applying PR
Hits are set to zero

### Documentation Changes Required

