### PR TITLE
[3.9.2][com_menus] template style select not shown

### DIFF
--- a/administrator/components/com_menus/models/forms/item.xml
+++ b/administrator/components/com_menus/models/forms/item.xml
@@ -146,7 +146,7 @@
 			description="COM_MENUS_ITEM_FIELD_TEMPLATE_DESC"
 			client="site"
 			filter="int"
-			showon="params.alias_redirect:0"
+			showon="type!:alias[OR]params.alias_redirect:0"
 			>
 			<option value="0">JOPTION_USE_DEFAULT</option>
 		</field>


### PR DESCRIPTION
Pull Request for Issue #23551

### Summary of Changes
fix for template style in menu manager


### Testing Instructions
1. Go to Menus -> New or existing menu item -> every menu type except menu item alias.
2. Observe there is no template style selectbox.
3. Apply patch
4. Go to Menus -> New or existing menu item -> every menu type except menu item alias.
5. Check whether template style is shown.
### Expected result
template style selectbox is displayed
### Actual result
template style selectbox is hidden
### Documentation Changes Required
no
