### PR TITLE
Smart Search (finder) module

### DIFF
--- a/modules/mod_finder/tmpl/default.php
+++ b/modules/mod_finder/tmpl/default.php
@@ -147,8 +147,8 @@ $script .= '});';
 JFactory::getDocument()->addScriptDeclaration($script);
 ?>
 
-<form id="mod-finder-searchform<?php echo $module->id; ?>" action="<?php echo JRoute::_($route); ?>" method="get" class="form-search">
-	<div class="finder<?php echo $suffix; ?>">
+<div class="finder<?php echo $suffix; ?>">
+	<form id="mod-finder-searchform<?php echo $module->id; ?>" action="<?php echo JRoute::_($route); ?>" method="get" class="form-search">
 		<?php
 		// Show the form fields.
 		echo $output;
@@ -164,5 +164,5 @@ JFactory::getDocument()->addScriptDeclaration($script);
 			</div>
 		<?php endif; ?>
 		<?php echo modFinderHelper::getGetFields($route, (int) $params->get('set_itemid', 0)); ?>
-	</div>
-</form>
+	</form>
+</div>


### PR DESCRIPTION
### Expected
The module  form should be wrapped in a div that a class suffix can be applied to

### Actual
The module div is wrapped in the form tag

### Changes
This simple PR switches the form and the div - making it the same structure as other modules - see mod_search - makes it easier (aka consistent) for styling and easier/cleaner when reading the outputted source code
