### PR TITLE
[4.0] Fix missing use statement

### DIFF
--- a/administrator/components/com_workflow/View/Transitions/HtmlView.php
+++ b/administrator/components/com_workflow/View/Transitions/HtmlView.php
@@ -10,6 +10,7 @@ namespace Joomla\Component\Workflow\Administrator\View\Transitions;
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Factory;
 use Joomla\CMS\Helper\ContentHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;


### PR DESCRIPTION
### Summary of Changes
[This commit](https://github.com/joomla/joomla-cms/pull/23460/commits/f6538e2dc5d35780491e07b4dd3dc421fc2b9e48) forgot the ```use Factory``` statement in the file.
This PR fixes it.

Thanks for @fancyFranci for the find.

### Testing Instructions
Go to the transitions.


### Expected result
No error.


### Actual result
Error, because of the missing statement

@wilsonge 
