### PR TITLE
[staging] Contact Banned parameters work only from component Options

### DIFF
--- a/components/com_contact/models/rules/contactemail.php
+++ b/components/com_contact/models/rules/contactemail.php
@@ -41,8 +41,32 @@ class JFormRuleContactEmail extends JFormRuleEmail
 			return false;
 		}
 
-		$params = JComponentHelper::getParams('com_contact');
-		$banned = $params->get('banned_email');
+		$app       = JFactory::getApplication();
+		$model     = JModelLegacy::getInstance('Contact', 'ContactModel');
+		$stub      = $app->input->getString('id');
+		$contactId = (int) $stub;
+
+		$contact = $model->getItem($contactId);
+
+		// Get item params, take menu parameters into account if necessary
+		$active      = $app->getMenu()->getActive();
+		$stateParams = clone $model->getState()->get('params');
+
+		// If the current view is the active item and a contact view for this contact, then the menu item params take priority
+		if ($active && strpos($active->link, 'view=contact') && strpos($active->link, '&id=' . (int) $contact->id))
+		{
+			// $item->params are the contact params, $active->params are the menu item params
+			// Merge so that the menu item params take priority
+			$contact->params->merge($active->params);
+		}
+		else
+		{
+			// Current view is not a single contact displayed by a specific menu item, so the contact params take priority here
+			$stateParams->merge($contact->params);
+			$contact->params = $stateParams;
+		}
+
+		$banned = $contact->params->get('banned_email');
 
 		if ($banned)
 		{

--- a/components/com_contact/models/rules/contactemailsubject.php
+++ b/components/com_contact/models/rules/contactemailsubject.php
@@ -34,8 +34,32 @@ class JFormRuleContactEmailSubject extends JFormRule
 	 */
 	public function test(SimpleXMLElement $element, $value, $group = null, Registry $input = null, JForm $form = null)
 	{
-		$params = JComponentHelper::getParams('com_contact');
-		$banned = $params->get('banned_subject');
+		$app       = JFactory::getApplication();
+		$model     = JModelLegacy::getInstance('Contact', 'ContactModel');
+		$stub      = $app->input->getString('id');
+		$contactId = (int) $stub;
+
+		$contact = $model->getItem($contactId);
+
+		// Get item params, take menu parameters into account if necessary
+		$active      = $app->getMenu()->getActive();
+		$stateParams = clone $model->getState()->get('params');
+
+		// If the current view is the active item and a contact view for this contact, then the menu item params take priority
+		if ($active && strpos($active->link, 'view=contact') && strpos($active->link, '&id=' . (int) $contact->id))
+		{
+			// $item->params are the contact params, $active->params are the menu item params
+			// Merge so that the menu item params take priority
+			$contact->params->merge($active->params);
+		}
+		else
+		{
+			// Current view is not a single contact displayed by a specific menu item, so the contact params take priority here
+			$stateParams->merge($contact->params);
+			$contact->params = $stateParams;
+		}
+
+		$banned = $contact->params->get('banned_subject');
 
 		if ($banned)
 		{


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/23546

### Summary of Changes
Concerns Banned Email, Banned Subject, Banned Text parameter fields.

The validation of these, before this patch, is only done depending on the parameters defined in the component Options Form tab.
Whatever has been entered in the Contact menu item or in the Contact itself are ignored.

### Testing Instructions
Tests have to be done when one sends mail to a contact in frontend.

The priorities for these parameters depend if the contact is displayed from a single contact menu item or not.

Set the parameters in the various places below and test priorities. Creating the params and taking them off between each test.

**Case1: From a single contact menu item**

Priority1: menu item parameters
Priority2: Contact parameters
Priority3: Component parameters

**Case2: No single contact menu item**
For example for another type of contacts menu item or from no menu item at all when clicking on the author link in an article.

Priority1: Contact parameters
Priority2: Component parameters

Test is successful when one gets a message of the type depending on the field where the banned item is used.
Error:
Invalid field:  Email 
Invalid field:  Subject 
Invalid field:  Message

### Before patch
Only the Component parameters are used.

### After patch
Parameters used depend on the priorities.

