### PR TITLE
When preparing module content, pass the params

### DIFF
--- a/administrator/modules/mod_custom/mod_custom.php
+++ b/administrator/modules/mod_custom/mod_custom.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 if ($params->def('prepare_content', 1))
 {
 	JPluginHelper::importPlugin('content');
-	$module->content = JHtml::_('content.prepare', $module->content, '', 'mod_custom.content');
+	$module->content = JHtml::_('content.prepare', $module->content, $params, 'mod_custom.content');
 }
 
 // Replace 'images/' to '../images/' when using an image from /images in backend.

--- a/libraries/cms/html/content.php
+++ b/libraries/cms/html/content.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Utility class to fire onContentPrepare for non-article based content.
  *
@@ -20,7 +22,7 @@ abstract class JHtmlContent
 	 * Fire onContentPrepare for content that isn't part of an article.
 	 *
 	 * @param   string  $text     The content to be transformed.
-	 * @param   array   $params   The content params.
+	 * @param   mixed   $params   The content params.
 	 * @param   string  $context  The context of the content to be transformed.
 	 *
 	 * @return  string   The content after transformation.
@@ -29,9 +31,9 @@ abstract class JHtmlContent
 	 */
 	public static function prepare($text, $params = null, $context = 'text')
 	{
-		if ($params === null)
+		if (!is_a($params, 'Registry'))
 		{
-			$params = new JObject;
+			$params = new Registry($params);
 		}
 
 		$article = new stdClass;
@@ -56,7 +58,7 @@ abstract class JHtmlContent
 	{
 		$model = JModelLegacy::getInstance('Articles', 'ContentModel', array('ignore_request' => true));
 
-		foreach ($state as $key => $value) 
+		foreach ($state as $key => $value)
 		{
 			$model->setState($key, $value);
 		}

--- a/modules/mod_custom/mod_custom.php
+++ b/modules/mod_custom/mod_custom.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 if ($params->def('prepare_content', 1))
 {
 	JPluginHelper::importPlugin('content');
-	$module->content = JHtml::_('content.prepare', $module->content, '', 'mod_custom.content');
+	$module->content = JHtml::_('content.prepare', $module->content, $params, 'mod_custom.content');
 }
 
 $moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

When using the 'Prepare Content' option in mod_custom, the module params will be passed to the event handler. The 'onContentPrepare' event accepts a params (Registry) object but, for most types of content, none is sent. Why? We actually need this. 

Unless there is some good reason why params are not being passed here and in a lot of other cases where they could be, I will expand on this to have them passed in all suitable cases. Also, `JHtmlContent::prepare` does something weird as well. When `$params` is not passed (or passed as null), it creates $params as a `JObject` and passes it to the plugins. Which is weird because you'd really want a `Registry` there. But worst of all is that most callers of that function do not pass `null` but rather `''` so then it's not even set as a `JObject`, it's just an empty string. So plugins don't know what to expect. It's a mess. I recommend that, when `$params` is not a `Registry`, we do `$params = new Registry($params);` so that we can always pass a registry to the plugins. 

### Testing Instructions

OK... so to test this I guess you're going to want to create a content plugin that implements `onContentPrepare` and then set one or more modules to prepare content. 

### Expected result

I expect a module which prepares content (or any item which prepares content and has params) to pass its params to the content plugins. 

### Actual result

As it is, modules which prepare content are not passing their params.


### Documentation Changes Required

Maybe