### PR TITLE
Featured articles page subheading

### DIFF
--- a/components/com_content/views/featured/tmpl/default.php
+++ b/components/com_content/views/featured/tmpl/default.php
@@ -24,7 +24,11 @@ JHtml::_('behavior.caption');
 	</h1>
 </div>
 <?php endif; ?>
-
+<?php if ($this->params->get('page_subheading')) : ?>
+	<h2> 
+		<?php echo $this->escape($this->params->get('page_subheading')); ?>
+	</h2>
+<?php endif; ?>
 <?php $leadingcount = 0; ?>
 <?php if (!empty($this->lead_items)) : ?>
 <div class="items-leading clearfix">

--- a/components/com_content/views/featured/tmpl/default.xml
+++ b/components/com_content/views/featured/tmpl/default.xml
@@ -159,6 +159,15 @@
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
+
+			<field
+				name="page_subheading"
+				type="text"
+				label="JGLOBAL_SUBHEADING_LABEL"
+				description="JGLOBAL_SUBHEADING_DESC"
+				size="20"
+			/>
+
 	</fieldset>
 
 	<fieldset name="article" label="COM_CONTENT_ATTRIBS_FIELDSET_LABEL">


### PR DESCRIPTION
The featured articles view is intended to be identical to the blog view. The only differences are because it is not purely based on category selection but also on the featured attribute of an article.

The blog view has a page_subheading option but this is missing from the featured view. This PR adds the page_subheading to that view so that the two views are as consistent as possible.

### Testing
Create a blog and a featured view
Add a page subheading - you will find the option in the menu. For featured it is at the bottom of the Layout tab. For blog it is at the bottom o the category tab (I think thats wrong but is beyond the scope of this PR)
You will now see the subheading in an h2 tag at the top of the page (below the page title if set)

I see this as a bug not a new feature as stated above

