### PR TITLE
[staging] Debug language correction

### DIFF
--- a/libraries/src/Language/Language.php
+++ b/libraries/src/Language/Language.php
@@ -865,6 +865,10 @@ class Language
 
 			// Remove the "_QQ_" from the equation
 			$line = str_replace('"_QQ_"', '', $line);
+
+			// Remove any escaped double quotes \" from the equation
+			$line = str_replace('\"', '', $line);
+
 			$realNumber = $lineNumber + 1;
 
 			// Check for any incorrect uses of _QQ_.


### PR DESCRIPTION
Pull Request for Issue https://forum.joomla.org/viewtopic.php?f=711&t=969007

### Summary of Changes
In some cases, the language string may contain an odd number of double quotes.
If this is due to an escaped double quote, it should not show as an error.

### Testing Instructions
Enable debug language
Load admin.

Modify the string en-GB.lib_joomla.ini in the en-GB administrator language
from
`JLIB_DATABASE_ERROR_VALID_AZ09="Please enter a valid username. No space at beginning or end, at least %d characters and must <strong>not</strong> have the following characters: < > \ &quot; ' &#37; ; ( ) &."
`
to
`JLIB_DATABASE_ERROR_VALID_AZ09="Please enter a valid username. No space at beginning or end, at least %d characters and must <strong>not</strong> have the following characters: < > \ \" ' &#37; ; ( ) &."
`

i.e. replacing `&quot;` by `\"`


### Before patch

Debug lang is showing Error for the line 226

### After patch
No more error.

