### PR TITLE
List of all tags

### DIFF
--- a/components/com_tags/views/tags/tmpl/default_items.php
+++ b/components/com_tags/views/tags/tmpl/default_items.php
@@ -112,7 +112,7 @@ JFactory::getDocument()->addScriptDeclaration("
 			<?php endif; ?>
 			<?php if ($this->params->get('all_tags_show_tag_description', 1) or $this->params->get('all_tags_show_tag_hits')) : ?>
 				<div class="caption">
-					<?php if (!empty($item->description)) : ?>
+					<?php if ($this->params->get('all_tags_show_tag_description', 1) && !empty($item->description)) : ?>
 						<span class="tag-body">
 							<?php echo JHtml::_('string.truncate', $item->description, $this->params->get('all_tags_tag_maximum_characters')); ?>
 						</span>

--- a/components/com_tags/views/tags/tmpl/default_items.php
+++ b/components/com_tags/views/tags/tmpl/default_items.php
@@ -110,7 +110,7 @@ JFactory::getDocument()->addScriptDeclaration("
 					<?php endif; ?>
 				</span>
 			<?php endif; ?>
-			<?php if ($this->params->get('all_tags_show_tag_description', 1) or $this->params->get('all_tags_show_tag_hits')) : ?>
+			<?php if (($this->params->get('all_tags_show_tag_description', 1) && !empty($item->description)) || $this->params->get('all_tags_show_tag_hits')) : ?>
 				<div class="caption">
 					<?php if ($this->params->get('all_tags_show_tag_description', 1) && !empty($item->description)) : ?>
 						<span class="tag-body">

--- a/components/com_tags/views/tags/tmpl/default_items.php
+++ b/components/com_tags/views/tags/tmpl/default_items.php
@@ -110,18 +110,20 @@ JFactory::getDocument()->addScriptDeclaration("
 					<?php endif; ?>
 				</span>
 			<?php endif; ?>
-			<div class="caption">
-				<?php if ($this->params->get('all_tags_show_tag_description', 1)) : ?>
-					<span class="tag-body">
-						<?php echo JHtml::_('string.truncate', $item->description, $this->params->get('all_tags_tag_maximum_characters')); ?>
-					</span>
-				<?php endif; ?>
-				<?php if ($this->params->get('all_tags_show_tag_hits')) : ?>
-					<span class="list-hits badge badge-info">
-						<?php echo JText::sprintf('JGLOBAL_HITS_COUNT', $item->hits); ?>
-					</span>
-				<?php endif; ?>
-			</div>
+			<?php if ($this->params->get('all_tags_show_tag_description', 1) or $this->params->get('all_tags_show_tag_hits')) : ?>
+				<div class="caption">
+					<?php if (!empty($item->description)) : ?>
+						<span class="tag-body">
+							<?php echo JHtml::_('string.truncate', $item->description, $this->params->get('all_tags_tag_maximum_characters')); ?>
+						</span>
+					<?php endif; ?>
+					<?php if ($this->params->get('all_tags_show_tag_hits')) : ?>
+						<span class="list-hits badge badge-info">
+							<?php echo JText::sprintf('JGLOBAL_HITS_COUNT', $item->hits); ?>
+						</span>
+					<?php endif; ?>
+				</div>
+			<?php endif; ?>
 			</li>
 			<?php if (($i === 0 && $n === 1) || $i === $n - 1 || $bscolumns === 1 || (($i + 1) % $bscolumns === 0)) : ?>
 				</ul>


### PR DESCRIPTION
The check to see if an item description or hits should be displayed is inside `div class=caption` which can result in empty divs being output

This simple pr fixes that bug so that so we never get empty div or span
