### PR TITLE
[4.0][com_templates] Copying Atum administrator template fails.

### DIFF
--- a/administrator/templates/atum/templateDetails.xml
+++ b/administrator/templates/atum/templateDetails.xml
@@ -23,7 +23,6 @@
 		<folder>css</folder>
 		<folder>html</folder>
 		<folder>images</folder>
-		<folder>img</folder>
 		<folder>js</folder>
 		<folder>language</folder>
 		<folder>scss</folder>


### PR DESCRIPTION
### Summary of Changes
Removed `<folder>img</folder>` 'cause directory doesn't exist.

### Testing Instructions
- Current nightly.
- Try to copy the Atum template via templates manager.
- You'll get an error:
```
Warning
JInstaller: :Install: File does not exist /tmp/template_copy_xyz/img
Template Install: Could not copy files from the files source.
Error
Error installing template
Unable to install new template from temporary folder.
```
- Apply patch.
- Try again.