### PR TITLE
Breadcrumbs for tags

### DIFF
--- a/components/com_tags/views/tag/view.html.php
+++ b/components/com_tags/views/tag/view.html.php
@@ -259,7 +259,7 @@ class TagsViewTag extends JViewLegacy
 		$app              = JFactory::getApplication();
 		$menu             = $app->getMenu()->getActive();
 		$this->tags_title = $this->getTagsTitle();
-		$pathway 		  = $app->getPathway();
+		$pathway	  = $app->getPathway();
 		$title            = '';
 
 		// Highest priority for "Browser Page Title".

--- a/components/com_tags/views/tag/view.html.php
+++ b/components/com_tags/views/tag/view.html.php
@@ -259,6 +259,7 @@ class TagsViewTag extends JViewLegacy
 		$app              = JFactory::getApplication();
 		$menu             = $app->getMenu()->getActive();
 		$this->tags_title = $this->getTagsTitle();
+		$pathway 		  = $app->getPathway();
 		$title            = '';
 
 		// Highest priority for "Browser Page Title".
@@ -297,6 +298,8 @@ class TagsViewTag extends JViewLegacy
 		}
 
 		$this->document->setTitle($title);
+		
+		$pathway->addItem($title);	
 
 		foreach ($this->item as $itemElement)
 		{


### PR DESCRIPTION
Breadcrumbs doesn't work correctly for com_tags

### To test
Create some tags and apply to articles
Create a menu item list all tags

### Expected behaviour
Clicking on a tag in an article will display a list of all articles that have that tag AND the breadcrumb module will indicate that you are looking at the tag
Clicking on the menu item for the tags shows you a list of all tags and the breadcrumb module indicates that. Clicking on a tag from the list the breacrumb doesnt change

### Actual behaviour
The tag is missing from the breadcrumbs

### Before
![tags-before](https://user-images.githubusercontent.com/1296369/51439893-61b01280-1cb8-11e9-87d5-516039e36fbb.gif)

### After
![tags-after](https://user-images.githubusercontent.com/1296369/51439896-67a5f380-1cb8-11e9-8fc5-fb66390c1b9c.gif)

