### PR TITLE
[staging] Bug: Correcting mod_custom-like module edit in frontend

### DIFF
--- a/components/com_config/view/modules/tmpl/default.php
+++ b/components/com_config/view/modules/tmpl/default.php
@@ -15,7 +15,22 @@ JHtml::_('behavior.keepalive');
 JHtml::_('behavior.combobox');
 JHtml::_('formbehavior.chosen', 'select');
 
-$hasContent = empty($this->item['module']) || $this->item['module'] === 'custom' || $this->item['module'] === 'mod_custom';
+jimport('joomla.filesystem.file');
+
+$editorText  = false;
+$moduleXml   = JPATH_SITE . '/modules/' . $this->item['module'] . '/' . $this->item['module'] . '.xml';
+
+if (JFile::exists($moduleXml))
+{
+	$xml = simplexml_load_file($moduleXml);
+
+	if (isset($xml->customContent))
+	{
+		$editorText = true;
+	}
+}
+
+$hasContent = empty($this->item['module']) || $this->item['module'] === 'custom' || $this->item['module'] === 'mod_custom' || $editorText = true;
 
 // If multi-language site, make language read-only
 if (JLanguageMultilang::isEnabled())

--- a/components/com_config/view/modules/tmpl/default.php
+++ b/components/com_config/view/modules/tmpl/default.php
@@ -30,7 +30,7 @@ if (JFile::exists($moduleXml))
 	}
 }
 
-$hasContent = empty($this->item['module']) || $this->item['module'] === 'custom' || $this->item['module'] === 'mod_custom' || $editorText = true;
+$hasContent = empty($this->item['module']) || $this->item['module'] === 'custom' || $this->item['module'] === 'mod_custom' || $editorText === true;
 
 // If multi-language site, make language read-only
 if (JLanguageMultilang::isEnabled())


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/23584

### Summary of Changes
The variable `$hasContent` lets display an editor text when editing a module of the type mod_custom or similar

Although the variable works in back-end for all modules where the manifest contains `<customContent />`, it does not work in frontend when editing a module which contains the same element in its manifest.

The code that makes it works in back-end is in the 
`/administrator/components/com_modules/views/module/tmpl/edit.php` line 24
`$hasContent = empty($this->item->module) ||  isset($this->item->xml->customContent);`

In frontend in the file
`/components/com_config/view/modules/tmpl/default.php`
we have 
`$hasContent = empty($this->item['module']) || $this->item['module'] === 'custom' || $this->item['module'] === 'mod_custom';`
Which means that not all modules which contains `<customContent />` in their manifest will display the text editor when edited in frontend.

To solve this issue we have to fetch the manifest of the edited module and check if the element exists in the manifest, same behavior as in back-end.

**Therefore this is a BUG and this PR is not a new Feature.**

### Testing Instructions
Install the following module, enter some text in the editor field in backend and display it in frontend.
[mod_customadv.zip](https://github.com/joomla/joomla-cms/files/2776896/mod_customadv.zip)

Set Global Config to let edit Modules in frontend. Login and edit the module.

### Before patch
The editor will not display. It should be below the Options and Advanced parameters.


### After patch
Issue solved. Editor displays.
<img width="865" alt="screen shot 2019-01-20 at 18 48 57" src="https://user-images.githubusercontent.com/869724/51443067-1c093f00-1ce4-11e9-9c59-c536ecd44b20.png">

@mino182 