### PR TITLE
[4.0] Group toolbar buttons for workflows

### DIFF
--- a/administrator/components/com_workflow/View/Workflows/HtmlView.php
+++ b/administrator/components/com_workflow/View/Workflows/HtmlView.php
@@ -13,6 +13,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Helper\ContentHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
+use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 use Joomla\Component\Workflow\Administrator\Helper\WorkflowHelper;
 
@@ -123,40 +124,57 @@ class HtmlView extends BaseHtmlView
 	{
 		$canDo = ContentHelper::getActions($this->extension);
 
+		// Get the toolbar object instance
+		$toolbar = Toolbar::getInstance('toolbar');
+
 		ToolbarHelper::title(Text::_('COM_WORKFLOW_WORKFLOWS_LIST'), 'address contact');
 
 		if ($canDo->get('core.create'))
 		{
-			ToolbarHelper::addNew('workflow.add');
+			$toolbar->addNew('workflow.add');
 		}
 
-		if ($canDo->get('core.edit.state'))
-		{
-			ToolbarHelper::publishList('workflows.publish');
-			ToolbarHelper::unpublishList('workflows.unpublish');
-			ToolbarHelper::makeDefault('workflows.setDefault', 'COM_WORKFLOW_TOOLBAR_DEFAULT');
-		}
+		if ($canDo->get('core.edit.state') || $user->authorise('core.admin'))
+		{		
+			$dropdown = $toolbar->dropdownButton('status-group')
+				->text('JTOOLBAR_CHANGE_STATUS')
+				->toggleSplit(false)
+				->icon('fa fa-globe')
+				->buttonClass('btn btn-info')
+				->listCheck(true);
 
-		if ($canDo->get('core.admin'))
-		{
-			ToolbarHelper::checkin('workflows.checkin', 'JTOOLBAR_CHECKIN', true);
+			$childBar = $dropdown->getChildToolbar();
+
+			$childBar->publish('workflows.publish');
+			$childBar->unpublish('workflows.unpublish');
+			$childBar->makeDefault('workflows.setDefault', 'COM_WORKFLOW_TOOLBAR_DEFAULT');
+
+			if ($canDo->get('core.admin'))
+			{
+				// @Todo implement the checked_out/checkin feature
+				// $childBar->checkin('workflows.checkin');
+			}
+
+			if ($canDo->get('core.edit.state') && $this->state->get('filter.published') != -2)
+			{
+				$childBar->trash('workflows.trash');
+			}
 		}
 
 		if ($this->state->get('filter.published') === '-2' && $canDo->get('core.delete'))
 		{
-			ToolbarHelper::deleteList(Text::_('COM_WORKFLOW_ARE_YOU_SURE'), 'workflows.delete');
-		}
-		elseif ($canDo->get('core.edit.state'))
-		{
-			ToolbarHelper::trash('workflows.trash');
+			$toolbar->delete('workflows.delete')
+				->text('JTOOLBAR_EMPTY_TRASH')
+				->message('JGLOBAL_CONFIRM_DELETE')
+				->listCheck(true);
 		}
 
 		if ($canDo->get('core.admin') || $canDo->get('core.options'))
 		{
-			ToolbarHelper::preferences($this->extension);
+			$toolbar->preferences($this->extension);
 		}
 
-		ToolbarHelper::help('JHELP_WORKFLOWS_LIST');
+		$toolbar->help('JHELP_WORKFLOWS_LIST');
 	}
 
 	/**


### PR DESCRIPTION
### Summary of Changes

This PR continues the grouping of action buttons in the backend (see #22832, #22393, #23337 and #23336, #23374, #23368, #23380). This time the workflows.

### Testing Instructions

Go to the workflows in the backend and check the toolbar. There should be a "Change status" dropdown now which activates when you select one or more workflows. 

NOTE: A checkin button will be added as soon as the checked_out functionality is available

### Actual result



### Documentation Changes Required

