### PR TITLE
[4.0] Remove the 1.5 "oldstatic" Cachemethod

### DIFF
--- a/libraries/src/Document/Renderer/Html/ModuleRenderer.php
+++ b/libraries/src/Document/Renderer/Html/ModuleRenderer.php
@@ -79,8 +79,8 @@ class ModuleRenderer extends DocumentRenderer
 			$module->params = (string) $params;
 		}
 
-		// Default for compatibility purposes. Set cachemode parameter or use JModuleHelper::moduleCache from within the module instead
-		$cachemode = $params->get('cachemode', 'oldstatic');
+		// Set cachemode parameter or use JModuleHelper::moduleCache from within the module instead
+		$cachemode = $params->get('cachemode', 'static');
 
 		if ($params->get('cache', 0) == 1 && Factory::getApplication()->get('caching') >= 1 && $cachemode != 'id' && $cachemode != 'safeuri')
 		{

--- a/libraries/src/Helper/ModuleHelper.php
+++ b/libraries/src/Helper/ModuleHelper.php
@@ -485,8 +485,6 @@ abstract class ModuleHelper
 	 * Caching modes:
 	 * To be set in XML:
 	 * 'static'      One cache file for all pages with the same module parameters
-	 * 'oldstatic'   1.5 definition of module caching, one cache file for all pages
-	 *               with the same module id and user aid,
 	 * 'itemid'      Changes on itemid change, to be called from inside the module:
 	 * 'safeuri'     Id created from $cacheparams->modeparams array,
 	 * 'id'          Module sets own cache id's
@@ -580,17 +578,6 @@ abstract class ModuleHelper
 					array($cacheparams->class, $cacheparams->method),
 					$cacheparams->methodparams,
 					$module->module . md5(serialize($cacheparams->methodparams)),
-					$wrkarounds,
-					$wrkaroundoptions
-				);
-				break;
-
-			// Provided for backward compatibility, not really useful.
-			case 'oldstatic':
-				$ret = $cache->get(
-					array($cacheparams->class, $cacheparams->method),
-					$cacheparams->methodparams,
-					$module->id . $view_levels,
 					$wrkarounds,
 					$wrkaroundoptions
 				);


### PR DESCRIPTION
### Summary of Changes
Removes the `oldstatic` cachemethod. According to the comment this was the Joomla 1.5 cache style which was only kept for B/C reasons.
I've changed the default cachemethod to `static`

### Testing Instructions
I don't think this can actually be tested since no core module is using that method. I don't even know if that method actually works.

It's more code review and the decision if we want to keep that legacy cache behavior.

### Documentation Changes Required
Don't know.