### PR TITLE
[4.0] Fix text colour on toolbar dropdown item hover

### DIFF
--- a/administrator/templates/atum/scss/blocks/_toolbar.scss
+++ b/administrator/templates/atum/scss/blocks/_toolbar.scss
@@ -56,11 +56,8 @@
     }
   }
 
-  .dropdown-item {
-
-    &:hover {
-      color: #212529;
-    }
+  .dropdown-item:hover {
+    color: var(--white);
   }
 
   .dropdown-toggle {


### PR DESCRIPTION
### Before and after:

![screeny](https://user-images.githubusercontent.com/2019801/51538362-fcd7f200-1e48-11e9-8797-dc6a019ee69e.png)

Assume this fixes the colour contrast for a11y too
