### PR TITLE
[com_field] Don't output empty description/markup

### DIFF
--- a/layouts/joomla/form/field/subform/repeatable-table.php
+++ b/layouts/joomla/form/field/subform/repeatable-table.php
@@ -55,7 +55,12 @@ else
 {
 	foreach ($tmpl->getGroup('') as $field) {
 		$table_head .= '<th>' . strip_tags($field->label);
-		$table_head .= '<br /><small style="font-weight:normal">' . JText::_($field->description) . '</small>';
+
+		if (!empty(JText::_($field->description)))
+		{
+			$table_head .= '<br /><small style="font-weight:normal">' . JText::_($field->description) . '</small>';
+		}
+
 		$table_head .= '</th>';
 	}
 


### PR DESCRIPTION
### Summary of Changes
Don't output markup when there is no description.

### Testing Instructions
Create/edit a custom field of `List`.
View page source.
Search `<br /><small style="font-weight:normal"></small>`.
Apply PR.
`<br /><small style="font-weight:normal"></small>` is no longer outputted.