### PR TITLE
Don't delete the template index.php file

### DIFF
--- a/administrator/components/com_templates/controllers/template.php
+++ b/administrator/components/com_templates/controllers/template.php
@@ -380,7 +380,7 @@ class TemplatesControllerTemplate extends JControllerLegacy
 		$id    = $app->input->get('id');
 		$file  = $app->input->get('file');
 
-		if (base64_decode(urldecode($file)) == 'index.php')
+		if (base64_decode(urldecode($file)) == '/index.php')
 		{
 			$app->enqueueMessage(JText::_('COM_TEMPLATES_ERROR_INDEX_DELETE'), 'warning');
 			$url = 'index.php?option=com_templates&view=template&id=' . $id . '&file=' . $file;

--- a/administrator/components/com_templates/controllers/template.php
+++ b/administrator/components/com_templates/controllers/template.php
@@ -584,7 +584,7 @@ class TemplatesControllerTemplate extends JControllerLegacy
 		$file    = $app->input->get('file');
 		$newName = $app->input->get('new_name');
 
-		if (base64_decode(urldecode($file)) == 'index.php')
+		if (base64_decode(urldecode($file)) == '/index.php')
 		{
 			$app->enqueueMessage(JText::_('COM_TEMPLATES_ERROR_RENAME_INDEX'), 'warning');
 			$url = 'index.php?option=com_templates&view=template&id=' . $id . '&file=' . $file;


### PR DESCRIPTION
### Summary of Changes
Adjusting the check for the index.php file the template controller to match what is actually passed in the request.


### Testing Instructions
In the template file manager, try to delete and rename the index.php file of a template


### Expected result
A warning message and the file isn't deleted/renamed


### Actual result
File is deleted/renamed without any warning.


### Documentation Changes Required
None
