### PR TITLE
[4.0] Inconsistent module header text

### DIFF
--- a/administrator/language/en-GB/en-GB.mod_logged.ini
+++ b/administrator/language/en-GB/en-GB.mod_logged.ini
@@ -6,7 +6,6 @@
 
 MOD_LOGGED="Logged-in Users"
 MOD_LOGGED_FIELD_COUNT_LABEL="Users to Display"
-MOD_LOGGED_LAST_ACTIVITY="Date"
 MOD_LOGGED_LOGOUT="Logout"
 MOD_LOGGED_NAME="Name"
 MOD_LOGGED_NO_SESSION_METADATA="Session metadata is disabled, cannot display the list of logged-in users."

--- a/administrator/language/en-GB/en-GB.mod_logged.ini
+++ b/administrator/language/en-GB/en-GB.mod_logged.ini
@@ -6,7 +6,7 @@
 
 MOD_LOGGED="Logged-in Users"
 MOD_LOGGED_FIELD_COUNT_LABEL="Users to Display"
-MOD_LOGGED_LAST_ACTIVITY="Last Activity"
+MOD_LOGGED_LAST_ACTIVITY="Date"
 MOD_LOGGED_LOGOUT="Logout"
 MOD_LOGGED_NAME="Name"
 MOD_LOGGED_NO_SESSION_METADATA="Session metadata is disabled, cannot display the list of logged-in users."

--- a/administrator/modules/mod_logged/tmpl/default.php
+++ b/administrator/modules/mod_logged/tmpl/default.php
@@ -25,7 +25,7 @@ use Joomla\CMS\Language\Text;
 				<?php endif; ?>
 			</th>
 			<th scope="col" style="width:30%"><?php echo Text::_('JCLIENT'); ?></th>
-			<th scope="col" style="width:20%"><?php echo Text::_('MOD_LOGGED_LAST_ACTIVITY'); ?></th>
+			<th scope="col" style="width:20%"><?php echo Text::_('JDATE'); ?></th>
 		</tr>
 	</thead>
 	<tbody>


### PR DESCRIPTION
All the other modules in the admin control panel use Date. The Loggedin module was using Last activity.

This simple PR changes the text to make it consistent

### Before
![image](https://user-images.githubusercontent.com/1296369/51786335-a0334a80-215a-11e9-9119-404f24512a9d.png)

### After
![image](https://user-images.githubusercontent.com/1296369/51786327-8560d600-215a-11e9-8773-f22d468ece73.png)
