### PR TITLE
Invalid field settings

### DIFF
--- a/administrator/components/com_templates/config.xml
+++ b/administrator/components/com_templates/config.xml
@@ -31,8 +31,6 @@
 			type="note"
 			label="COM_TEMPLATES_CONFIG_SUPPORTED_LABEL"
 			description="COM_TEMPLATES_CONFIG_SUPPORTED_DESC"
-			default="zip"
-			extension="com_templates"
 		/>
 
 		<field


### PR DESCRIPTION
The note field does not have an extension or default params. They have been put here in error
