### PR TITLE
[3.9][a11y] Add landmark to breadcrumbs

### DIFF
--- a/modules/mod_breadcrumbs/tmpl/default.php
+++ b/modules/mod_breadcrumbs/tmpl/default.php
@@ -9,7 +9,7 @@
 
 defined('_JEXEC') or die;
 ?>
-<nav aria-label="<?php echo $module->name; ?>" role="navigation">
+<div aria-label="<?php echo $module->name; ?>" role="navigation">
 	<ul itemscope itemtype="https://schema.org/BreadcrumbList" class="breadcrumb<?php echo $moduleclass_sfx; ?>">
 		<?php if ($params->get('showHere', 1)) : ?>
 			<li>

--- a/modules/mod_breadcrumbs/tmpl/default.php
+++ b/modules/mod_breadcrumbs/tmpl/default.php
@@ -9,7 +9,7 @@
 
 defined('_JEXEC') or die;
 ?>
-<nav aria-label="<?php echo $module->name; ?>">
+<nav aria-label="<?php echo $module->name; ?>" role="navigation">
 	<ul itemscope itemtype="https://schema.org/BreadcrumbList" class="breadcrumb<?php echo $moduleclass_sfx; ?>">
 		<?php if ($params->get('showHere', 1)) : ?>
 			<li>

--- a/modules/mod_breadcrumbs/tmpl/default.php
+++ b/modules/mod_breadcrumbs/tmpl/default.php
@@ -71,4 +71,4 @@ defined('_JEXEC') or die;
 			<?php endif;
 		endforeach; ?>
 	</ul>
-</nav>
+</div>

--- a/modules/mod_breadcrumbs/tmpl/default.php
+++ b/modules/mod_breadcrumbs/tmpl/default.php
@@ -9,65 +9,66 @@
 
 defined('_JEXEC') or die;
 ?>
+<nav aria-label="<?php echo $module->name; ?>">
+	<ul itemscope itemtype="https://schema.org/BreadcrumbList" class="breadcrumb<?php echo $moduleclass_sfx; ?>">
+		<?php if ($params->get('showHere', 1)) : ?>
+			<li>
+				<?php echo JText::_('MOD_BREADCRUMBS_HERE'); ?>&#160;
+			</li>
+		<?php else : ?>
+			<li class="active">
+				<span class="divider icon-location"></span>
+			</li>
+		<?php endif; ?>
 
-<ul itemscope itemtype="https://schema.org/BreadcrumbList" class="breadcrumb<?php echo $moduleclass_sfx; ?>">
-	<?php if ($params->get('showHere', 1)) : ?>
-		<li>
-			<?php echo JText::_('MOD_BREADCRUMBS_HERE'); ?>&#160;
-		</li>
-	<?php else : ?>
-		<li class="active">
-			<span class="divider icon-location"></span>
-		</li>
-	<?php endif; ?>
-
-	<?php
-	// Get rid of duplicated entries on trail including home page when using multilanguage
-	for ($i = 0; $i < $count; $i++)
-	{
-		if ($i === 1 && !empty($list[$i]->link) && !empty($list[$i - 1]->link) && $list[$i]->link === $list[$i - 1]->link)
+		<?php
+		// Get rid of duplicated entries on trail including home page when using multilanguage
+		for ($i = 0; $i < $count; $i++)
 		{
-			unset($list[$i]);
+			if ($i === 1 && !empty($list[$i]->link) && !empty($list[$i - 1]->link) && $list[$i]->link === $list[$i - 1]->link)
+			{
+				unset($list[$i]);
+			}
 		}
-	}
 
-	// Find last and penultimate items in breadcrumbs list
-	end($list);
-	$last_item_key   = key($list);
-	prev($list);
-	$penult_item_key = key($list);
+		// Find last and penultimate items in breadcrumbs list
+		end($list);
+		$last_item_key   = key($list);
+		prev($list);
+		$penult_item_key = key($list);
 
-	// Make a link if not the last item in the breadcrumbs
-	$show_last = $params->get('showLast', 1);
+		// Make a link if not the last item in the breadcrumbs
+		$show_last = $params->get('showLast', 1);
 
-	// Generate the trail
-	foreach ($list as $key => $item) :
-		if ($key !== $last_item_key) :
-			// Render all but last item - along with separator ?>
-			<li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
-				<?php if (!empty($item->link)) : ?>
-					<a itemprop="item" href="<?php echo $item->link; ?>" class="pathway"><span itemprop="name"><?php echo $item->name; ?></span></a>
-				<?php else : ?>
+		// Generate the trail
+		foreach ($list as $key => $item) :
+			if ($key !== $last_item_key) :
+				// Render all but last item - along with separator ?>
+				<li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+					<?php if (!empty($item->link)) : ?>
+						<a itemprop="item" href="<?php echo $item->link; ?>" class="pathway"><span itemprop="name"><?php echo $item->name; ?></span></a>
+					<?php else : ?>
+						<span itemprop="name">
+							<?php echo $item->name; ?>
+						</span>
+					<?php endif; ?>
+
+					<?php if (($key !== $penult_item_key) || $show_last) : ?>
+						<span class="divider">
+							<?php echo $separator; ?>
+						</span>
+					<?php endif; ?>
+					<meta itemprop="position" content="<?php echo $key + 1; ?>">
+				</li>
+			<?php elseif ($show_last) :
+				// Render last item if reqd. ?>
+				<li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem" class="active">
 					<span itemprop="name">
 						<?php echo $item->name; ?>
 					</span>
-				<?php endif; ?>
-
-				<?php if (($key !== $penult_item_key) || $show_last) : ?>
-					<span class="divider">
-						<?php echo $separator; ?>
-					</span>
-				<?php endif; ?>
-				<meta itemprop="position" content="<?php echo $key + 1; ?>">
-			</li>
-		<?php elseif ($show_last) :
-			// Render last item if reqd. ?>
-			<li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem" class="active">
-				<span itemprop="name">
-					<?php echo $item->name; ?>
-				</span>
-				<meta itemprop="position" content="<?php echo $key + 1; ?>">
-			</li>
-		<?php endif;
-	endforeach; ?>
-</ul>
+					<meta itemprop="position" content="<?php echo $key + 1; ?>">
+				</li>
+			<?php endif;
+		endforeach; ?>
+	</ul>
+</nav>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
- added nav tag
- added attribute aria-label and role="navigation" to nav tag
### Testing Instructions
- code inspection
- use screen reader (e.g. NVDA) and see that the breadcrumbs is accessible during navigation as a landmark 

Similar to  PR https://github.com/joomla/joomla-cms/pull/23685 for Joomla 4.
### Expected result
The 'nav' tag defines one of the main landmarks of the page, and the aria-label attribute makes it possible to distinguish this landmark from other navigation points, e.g. general menu.  
Landmarks are supported by assistive technologies. Users of screen readers use them as one of the navigation systems on the page. 
### Actual result
Assistive technology does not recognize the breadcrumb as a landmark.
### Documentation Changes Required
In the Help screens
Include information that the title of the module is used as a label for assistive technologies, so it should be translated (since the title of this module is not displayed, administrators often leave it in English).
