### PR TITLE
[3.9][a11y] Improve accessiblity in mod_search

### DIFF
--- a/modules/mod_search/tmpl/default.php
+++ b/modules/mod_search/tmpl/default.php
@@ -26,7 +26,7 @@ else
 }
 ?>
 <div class="search<?php echo $moduleclass_sfx; ?>">
-	<form action="<?php echo JRoute::_('index.php'); ?>" method="post" class="form-inline">
+	<form action="<?php echo JRoute::_('index.php'); ?>" method="post" class="form-inline" role="search">
 		<?php
 			$output = '<label for="mod-search-searchword' . $module->id . '" class="element-invisible">' . $label . '</label> ';
 			$output .= '<input name="searchword" id="mod-search-searchword' . $module->id . '" maxlength="' . $maxlength . '"  class="inputbox search-query input-medium" type="search"' . $width;

--- a/tests/unit/suites/libraries/joomla/document/renderer/JDocumentRendererHtmlModulesTest.php
+++ b/tests/unit/suites/libraries/joomla/document/renderer/JDocumentRendererHtmlModulesTest.php
@@ -117,7 +117,7 @@ class JDocumentRendererHtmlModulesTest extends TestCaseDatabase
 		$htmlClean              = trim(preg_replace('~>\s+<~', '><', $output));
 		$this->assertTrue($this->callbackExecuted, 'onAfterRenderModules event is not executed');
 		$html = '<div class="moduletable"><h3>Search</h3><div class="search mod_search63">'
-			. '<form action="" method="post" class="form-inline">'
+			. '<form action="" method="post" class="form-inline" role="search">'
 			. '<label for="mod-search-searchword63" class="element-invisible">Search ...</label>'
 			. '<input name="searchword" id="mod-search-searchword63" maxlength="200"  '
 			. 'class="inputbox search-query input-medium" type="search" size="20" placeholder="Search ..." />'


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Added role="search" attribute to the form tag
### Testing Instructions
- code inspection
- use screen reader (e.g. NVDA) and see that the search form is accessible during navigation as a landmark 
### Expected result
Attribute role="search" defines one of the landmarks of the page. This allows the user of assistive technology to easily navigate to the search module.
### Actual result
Assistive technology does not recognize the form as a landmark.
### Documentation Changes Required
no