### PR TITLE
[3.9][a11y] Improve accessiblity in mod_finder

### DIFF
--- a/modules/mod_finder/tmpl/default.php
+++ b/modules/mod_finder/tmpl/default.php
@@ -148,7 +148,7 @@ JFactory::getDocument()->addScriptDeclaration($script);
 ?>
 
 <div class="finder<?php echo $suffix; ?>">
-	<form id="mod-finder-searchform<?php echo $module->id; ?>" action="<?php echo JRoute::_($route); ?>" method="get" class="form-search">
+	<form id="mod-finder-searchform<?php echo $module->id; ?>" action="<?php echo JRoute::_($route); ?>" method="get" class="form-search" role="search">
 		<?php
 		// Show the form fields.
 		echo $output;


### PR DESCRIPTION
Pull Request for Issue # .
### Summary of Changes
Added role="search" attribute to the form tag
### Testing Instructions
- code inspection
- use screen reader (e.g. NVDA) and see that the search form is accessible during navigation as a landmark 
### Expected result
Attribute role="search" defines one of the landmarks of the page. This allows the user of assistive technology to easily navigate to the finder module.
### Actual result
Assistive technology does not recognize the form as a landmark.
### Documentation Changes Required
no