### PR TITLE
remove console.log debug call from javascript

### DIFF
--- a/media/com_joomlaupdate/js/update.js
+++ b/media/com_joomlaupdate/js/update.js
@@ -192,7 +192,6 @@ pingExtract = function()
 
 startExtract = function()
 {
-	console.log("started");
 	// Reset variables
 	this.stat_files = 0;
 	this.stat_inbytes = 0;


### PR DESCRIPTION
remove console.log debug call from javascript when extracting a Joomla update