### PR TITLE
[4.0] Fix: Saving menu item fails. Call to a member function validate() on bool. Field "show_associations"

### DIFF
--- a/administrator/components/com_menus/Model/ItemModel.php
+++ b/administrator/components/com_menus/Model/ItemModel.php
@@ -591,6 +591,12 @@ class ItemModel extends AdminModel
 		$form->setFieldAttribute('menutype', 'accesstype', $action);
 		$form->setFieldAttribute('type', 'clientid', $clientId);
 
+		// Remove show_associations field if associations is not enabled
+		if (!Associations::isEnabled())
+		{
+			$form->removeField('show_associations', 'params');
+		}
+
 		return $form;
 	}
 


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/23696

Related and already merged fix: https://github.com/joomla/joomla-cms/pull/23501

### Testing Instructions
- Install a J4 nightly build of today (Monday, 28 January 2019) or update an older J4 with that package
- Go to menu items manager in back-end.
- Open `Home` menu item (type "Articles > Featured Articles")
- Save it.
- Error like described in https://github.com/joomla/joomla-cms/issues/23696#issue-403588121

- Apply patch
- Try again to save the menu item. 
- Should be successful.