### PR TITLE
[4.0] Correcting success colour after installing sample data

### DIFF
--- a/build/media_src/mod_sampledata/js/sampledata-process.es6.js
+++ b/build/media_src/mod_sampledata/js/sampledata-process.es6.js
@@ -63,7 +63,7 @@
 
             // Display success alert
             if (success) {
-              Joomla.renderMessages({ success: [value.message] }, `.sampledata-steps-${type}-${step}`);
+              Joomla.renderMessages({ message: [value.message] }, `.sampledata-steps-${type}-${step}`);
             } else {
               Joomla.renderMessages({ error: [value.message] }, `.sampledata-steps-${type}-${step}`);
             }


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/23632

### Summary of Changes
When using Joomla.renderMessages, the correct class for a success and getting a greenish colour is `message` and not `success`.
This is defined in `core.es6.js` by the code
```
if (['notice', 'message', 'error', 'warning'].indexOf(type) > -1) {
          alertClass = (type === 'notice') ? 'info' : type;
          alertClass = (type === 'message') ? 'success' : alertClass;
          alertClass = (type === 'error') ? 'danger' : alertClass;
          alertClass = (type === 'warning') ? 'warning' : alertClass;
        } else {
          alertClass = 'info';
        }
```


### Testing Instructions
Patch.
Run npm ci
Install some sample data 


### After patch
<img width="714" alt="screen shot 2019-01-31 at 11 20 06" src="https://user-images.githubusercontent.com/869724/52048441-aefb7200-254b-11e9-84d7-077bf70f2f21.png">
