### PR TITLE
[4.0] Fix stats alert information

### DIFF
--- a/build/media_src/plg_system_stats/js/stats-message.es6.js
+++ b/build/media_src/plg_system_stats/js/stats-message.es6.js
@@ -12,7 +12,7 @@ Joomla = window.Joomla || {};
   const initStatsEvents = (callback) => {
     const messageContainer = document.getElementById('system-message-container');
     const joomlaAlert = messageContainer.querySelector('.js-pstats-alert');
-    const detailsContainer = messageContainer.querySelector('.js-pstats-data-details');
+    const detailsContainer = messageContainer.querySelector('#js-pstats-data-details');
 
     // Show details about the information being sent
     document.addEventListener('click', (event) => {


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Fix the JS error when clicking **Select here to see the information that will be sent** in the stats alert in a fresh installation.

### Testing Instructions

1. Fresh installation of Joomla (or reset the stats plugin)
2. Visit any page in the Joomla backend
3. Click **Select here to see the information that will be sent**

### Expected result

A table is displayed within the alert showing you which information will be collected

### Actual result

No table and a JS error