### PR TITLE
[4.0] Fix default value for hits in articles

### DIFF
--- a/libraries/src/Table/Content.php
+++ b/libraries/src/Table/Content.php
@@ -359,6 +359,8 @@ class Content extends Table
 			{
 				$this->created_by = $user->get('id');
 			}
+
+			$this->hits = 0;
 		}
 
 		// Verify that the alias is unique


### PR DESCRIPTION
### Summary of Changes
Set hits to 0 for new articles. 
Same as https://issues.joomla.org/tracker/joomla-cms/23688

### Testing Instructions
Ty to save a new article.


### Expected result
Article ist saved.


### Actual result
Save failed with the following error: Incorrect integer value: '' for column 'hits' at row 1


### Documentation Changes Required

