### PR TITLE
[4.0] Correcting icons display in debug bar

### DIFF
--- a/build/media/plg_system_debug/widgets/languageStrings/widget.css
+++ b/build/media/plg_system_debug/widgets/languageStrings/widget.css
@@ -44,7 +44,7 @@ table.phpdebugbar-widgets-languageStrings span.phpdebugbar-widgets-eye-dash {
 
 table.phpdebugbar-widgets-languageStrings span.phpdebugbar-widgets-eye:before,
 table.phpdebugbar-widgets-languageStrings span.phpdebugbar-widgets-eye-dash:before {
-    font-family: PhpDebugbarFontAwesome;
+    font-family: FontAwesome;
     margin-right: 4px;
     /*font-size: 12px;*/
 }

--- a/build/media/plg_system_debug/widgets/sqlqueries/widget.css
+++ b/build/media/plg_system_debug/widgets/sqlqueries/widget.css
@@ -49,7 +49,7 @@ div.phpdebugbar-widgets-sqlqueries span.phpdebugbar-widgets-eye:before,
 div.phpdebugbar-widgets-sqlqueries span.phpdebugbar-widgets-eye-dash:before,
 div.phpdebugbar-widgets-sqlqueries span.phpdebugbar-widgets-stmt-id:before,
 div.phpdebugbar-widgets-sqlqueries a.phpdebugbar-widgets-editor-link:before {
-    font-family: PhpDebugbarFontAwesome;
+    font-family: FontAwesome;
     margin-right: 4px;
     font-size: 12px;
 }


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/23644

Explanations: https://github.com/joomla/joomla-cms/issues/23644#issuecomment-459625847

### Summary of Changes
Changing font from PhpDebugbarFontAwesome to FontAwesome in 2 widget.css files.


### Testing Instructions
Run patch.
Use npm ci
Enable debug system and debug language.


### After patch
<img width="1092" alt="screen shot 2019-02-01 at 08 07 35" src="https://user-images.githubusercontent.com/869724/52107915-8aa99f00-25f8-11e9-828d-b11c31ef68e1.png">

<img width="737" alt="screen shot 2019-02-01 at 08 07 50" src="https://user-images.githubusercontent.com/869724/52107920-9301da00-25f8-11e9-8c03-b53fe86ce9eb.png">

@hardik-codes @roland-d @Fedik 
