### PR TITLE
[Smart Search] Taxonomy node values should not be added as search terms in the index

### DIFF
--- a/administrator/components/com_finder/helpers/indexer/driver/mysql.php
+++ b/administrator/components/com_finder/helpers/indexer/driver/mysql.php
@@ -269,9 +269,6 @@ class FinderIndexerDriverMysql extends FinderIndexer
 
 				// Add the link => node map.
 				FinderIndexerTaxonomy::addMap($linkId, $nodeId);
-
-				// Tokenize the node title and add them to the database.
-				$count += $this->tokenizeToDb($node->title, static::META_CONTEXT, $item->language, $format);
 			}
 		}
 

--- a/administrator/components/com_finder/helpers/indexer/driver/postgresql.php
+++ b/administrator/components/com_finder/helpers/indexer/driver/postgresql.php
@@ -261,9 +261,6 @@ class FinderIndexerDriverPostgresql extends FinderIndexer
 
 				// Add the link => node map.
 				FinderIndexerTaxonomy::addMap($linkId, $nodeId);
-
-				// Tokenize the node title and add them to the database.
-				$count += $this->tokenizeToDb($node->title, static::META_CONTEXT, $item->language, $format);
 			}
 		}
 

--- a/administrator/components/com_finder/helpers/indexer/driver/sqlsrv.php
+++ b/administrator/components/com_finder/helpers/indexer/driver/sqlsrv.php
@@ -269,9 +269,6 @@ class FinderIndexerDriverSqlsrv extends FinderIndexer
 
 				// Add the link => node map.
 				FinderIndexerTaxonomy::addMap($linkId, $nodeId);
-
-				// Tokenize the node title and add them to the database.
-				$count += $this->tokenizeToDb($node->title, static::META_CONTEXT, $item->language, $format);
 			}
 		}
 


### PR DESCRIPTION
It isn't necessary to add the values of all taxonomy (content map) node values as search terms in the index.

For example, all Joomla websites with regular content items will have the word "article" in the index and will bring back *all* articles if the word "article" is used as a search term, including any that don't actually contain the word "article".  Similarly for "category".  You'll even find all the author names have been indexed, including "super user"!

This is unnecessary for two reasons; firstly because any search term that brings back everything in the search results (like "article" does) is useless as a search term and secondly because these terms are often for internal use and shouldn't be exposed to users.  The advanced search mode provides drop-downs so that users can search using the taxonomies (content maps) so it isn't necessary to have the taxonomy node values in the terms index too.

### Summary of Changes
Removed code that adds taxonomy node values to the terms index.

### Testing Instructions
Make sure Smart Search is set up and you've indexed the content.  Now, on the front-end, use Smart Search (not the old search) to search for terms such as "Article", "Category" and "Super User".

[EDIT] After applying this PR you will need to do Clear Index and then Index (or equivalently do `php cli/finder_indexer.php --purge` on the command line) in order to completely rebuild the index.

### Expected result
Search results should actually contain the terms/phrases that you entered.

### Actual result
Depending on what content you have, each of these terms/phrases will return results which don't actually contain these terms/phrases (as well as results that do).

### Documentation Changes Required
None.
