### PR TITLE
Do not force jQuery and Bootstrap.js in Cassiopeia

### DIFF
--- a/modules/mod_menu/tmpl/default.php
+++ b/modules/mod_menu/tmpl/default.php
@@ -10,6 +10,9 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Helper\ModuleHelper;
+use Joomla\CMS\HTML\HTMLHelper;
+
+HTMLHelper::_('bootstrap.framework');
 
 $id = '';
 

--- a/templates/cassiopeia/component.php
+++ b/templates/cassiopeia/component.php
@@ -13,9 +13,6 @@ use Joomla\CMS\HTML\HTMLHelper;
 
 /** @var JDocumentHtml $this */
 
-// Add JavaScript Frameworks
-HTMLHelper::_('bootstrap.framework');
-
 // Add Stylesheets
 HTMLHelper::_('stylesheet', 'template.css', ['version' => 'auto', 'relative' => true]);
 

--- a/templates/cassiopeia/error.php
+++ b/templates/cassiopeia/error.php
@@ -29,9 +29,6 @@ $sitename = $app->get('sitename');
 $menu     = $app->getMenu()->getActive();
 $pageclass = $menu !== null ? $menu->params->get('pageclass_sfx', '') : '';
 
-// Add JavaScript Frameworks
-HTMLHelper::_('bootstrap.framework');
-
 // Add template js
 HTMLHelper::_('script', 'template.js', ['version' => 'auto', 'relative' => true]);
 

--- a/templates/cassiopeia/joomla.asset.json
+++ b/templates/cassiopeia/joomla.asset.json
@@ -8,9 +8,7 @@
       "name": "template.cassiopeia.base",
       "dependencies": [
         "core",
-        "jquery-noconflict",
-        "font-awesome",
-        "bootstrap.js.bundle"
+        "font-awesome"
       ],
       "js": [
         "template.js",


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
- Removed the dictated jQuery.js and Bootstrap.js from theCassiopeia template.
- Reason: almost ALL interactive components for Bootstrap are held by a PHP helper (HTMLHelper::_('bootstrap.something'...)) therefor there is zero benefit forcing these scripts in the index.php of the template. Also we've (as the Javascript team) put a huge amount of work to convert everything to vanilla javascript and quite frankly by forcing jQuery always makes all that work redundant.


### Testing Instructions
Check that everything still work as before in the front end


### Expected result



### Actual result



### Documentation Changes Required

No. jQuery and Bootstrap.js are still supported and can be loaded whenever they're needed but they're not forced anymore