### PR TITLE
[4.0] fix wrong color of edit article

### DIFF
--- a/administrator/components/com_content/forms/article.xml
+++ b/administrator/components/com_content/forms/article.xml
@@ -61,7 +61,7 @@
 			type="transition"
 			component="com_content"
 			label="COM_CONTENT_TRANSITION"
-            class="custom-select-color-state"
+			class="custom-select-color-state"
 		>
 		</field>
 

--- a/administrator/components/com_content/forms/article.xml
+++ b/administrator/components/com_content/forms/article.xml
@@ -61,6 +61,7 @@
 			type="transition"
 			component="com_content"
 			label="COM_CONTENT_TRANSITION"
+            class="custom-select-color-state"
 		>
 		</field>
 


### PR DESCRIPTION
Signed-off-by: Nitish Bahl <nitishbahl24@gmail.com>

Pull Request for Issue #23781  .

### Summary of Changes
Added class `custom-select-color-state`.







### Expected result
![screenshot from 2019-02-06 21-43-43](https://user-images.githubusercontent.com/36095178/52356552-759a9900-2a5a-11e9-94d0-9d9189437174.png)



### Actual result
The values of different options is wrong due to which no color is displayed.
![screenshot from 2019-02-06 22-06-34](https://user-images.githubusercontent.com/36095178/52357079-7aac1800-2a5b-11e9-96b8-39eed32e2f10.png)


### Documentation Changes Required
no
