### PR TITLE
[4.0] Disable Back to Control Panel link

### DIFF
--- a/administrator/templates/atum/index.php
+++ b/administrator/templates/atum/index.php
@@ -67,9 +67,15 @@ $this->addScriptDeclaration('cssVars();');
 		<div class="d-flex align-items-center">
 			<div class="header-title d-flex mr-auto">
 				<div class="d-flex">
+				<?php if (!$hidden) : ?>
 					<a class="logo" href="<?php echo Route::_('index.php'); ?>" aria-label="<?php echo Text::_('TPL_BACK_TO_CONTROL_PANEL'); ?>">
 						<img src="<?php echo $logoBlue; ?>" alt="">
 					</a>
+				<?php else : ?>
+					<a class="logo">
+						<img src="<?php echo $logoBlue; ?>" alt="">
+					</a>				
+				<?php endif; ?>
 				</div>
 				<jdoc:include type="modules" name="title" />
 			</div>

--- a/administrator/templates/atum/index.php
+++ b/administrator/templates/atum/index.php
@@ -74,7 +74,7 @@ $this->addScriptDeclaration('cssVars();');
 				<?php else : ?>
 					<a class="logo">
 						<img src="<?php echo $logoBlue; ?>" alt="">
-					</a>				
+					</a>
 				<?php endif; ?>
 				</div>
 				<jdoc:include type="modules" name="title" />


### PR DESCRIPTION
In Joomla 3.x we disabled the control panel link in the top left hand corner of the admin at the same time that we disabled the main menu. Amongst other reasons this was to prevent people from leaving an item checked out.

In Joomla 4 the link is always active :(

This PR fixes that.

### Test
Open an article and ensure that the control panel link in the top left hand corner of the admin does not work
Close the article and ensure that the link works

### Related PR
See #23752

### Note
The template design team might want to change the icon or styling when it is disabled but that's beyond the scope of this PR.
