### PR TITLE
[4.0] Fixed login error color

### DIFF
--- a/administrator/templates/atum/scss/blocks/_login.scss
+++ b/administrator/templates/atum/scss/blocks/_login.scss
@@ -58,7 +58,7 @@
 
       span {
         font-size: .9rem;
-        color: #c6d2de;
+        color: #d4d4d4;
       }
     }
   }

--- a/administrator/templates/atum/scss/blocks/_login.scss
+++ b/administrator/templates/atum/scss/blocks/_login.scss
@@ -58,7 +58,7 @@
 
       span {
         font-size: .9rem;
-        color: #d4d4d4;
+        color: var(--white-offset);
       }
     }
   }


### PR DESCRIPTION
Pull Request for Issue #23790 

### Summary of Changes
Changed color from ```#c6d2de``` to```#d4d4d4``` of ```span``` tag in ```administrator/templates/atum/scss/blocks/_login.scss```


### Testing Instructions
On the login page, without filling any credentials click ```Log In```


### Expected result
The color of the text 'Field value cannot be empty ' should be```#d4d4d4```



### Actual result
The color of the text 'Field value cannot be empty ' was ```#c6d2de```


### Documentation Changes Required
None 
