### PR TITLE
[4.0][a11y] Incorrectly named ARIA attribute

### DIFF
--- a/build/media_source/system/js/fields/joomla-field-switcher.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-switcher.w-c.es6.js
@@ -72,7 +72,7 @@
         this.spans[1].classList.add('active');
 
         // Aria-label ONLY in the container span!
-        this.inputsContainer.setAttribute('aria-labeledby', `${this.id}-lbl`); // this.spans[1].innerHTML);
+        this.inputsContainer.setAttribute('aria-labelledby', `${this.id}-lbl`); // this.spans[1].innerHTML);
       } else {
         this.spans[0].classList.add('active');
 


### PR DESCRIPTION
Problem diagnosed by the JAT team.
All switches have a non-existent name aria attribute: `aria-labeledby`. Should be: `aria-labelledby` (two letters "l") 

If the developer uses a non-existent or misspelled ARIA attribute, the attribute will not be able to perform the accessibility function intended by the developer.

### Summary of Changes
Invalid attribute replaced with correct attribute

### Testing Instructions
Code review 

### Note
This may be the reason that labels are not announced by the screen reader. 