### PR TITLE
[4.0] Made Non CE tabs responsive

### DIFF
--- a/administrator/templates/atum/scss/vendor/bootstrap/_nav.scss
+++ b/administrator/templates/atum/scss/vendor/bootstrap/_nav.scss
@@ -34,6 +34,6 @@
  
 @media (max-width: 1290px) {
   .nav.nav-tabs {
-    flex-wrap:wrap;
+    flex-wrap: wrap;
   }
 }

--- a/administrator/templates/atum/scss/vendor/bootstrap/_nav.scss
+++ b/administrator/templates/atum/scss/vendor/bootstrap/_nav.scss
@@ -22,7 +22,7 @@
     height: 100%;
     padding: .75em 1em;
     color: $white;
-    box-shadow: -1px 0 0 rgba(0, 0, 0, .1);
+    box-shadow: 1px 0 0 rgba(0, 0, 0, .1);
   }
 }
 

--- a/administrator/templates/atum/scss/vendor/bootstrap/_nav.scss
+++ b/administrator/templates/atum/scss/vendor/bootstrap/_nav.scss
@@ -3,7 +3,6 @@
 .nav.nav-tabs {
   flex-wrap: unset;
   align-items: stretch;
-  justify-content: space-around;
   padding: 0;
   margin: 0 0 1rem;
   text-align: center;
@@ -12,9 +11,8 @@
   @include media-breakpoint-down(sm) {
     flex-direction: column;
   }
-
+ 
   .nav-item {
-    width: 100%;
     margin-bottom: 0;
     margin-left: 0;
   }
@@ -32,4 +30,10 @@
   padding: 0;
   background: transparent;
   border: 0;
+}
+ 
+@media (max-width: 1290px) {
+  .nav.nav-tabs {
+    flex-wrap:wrap;
+  }
 }


### PR DESCRIPTION
Pull Request for Issue #23819 

### Summary of Changes
Added ```flex-wrap: wrap``` in media queries. 
Changing ```flex-wrap: unset```  to ```flex-wrap: wrap``` in ```.nav .nav-tabs ``` selector was wrapping the tabs in desktop mode also, to avoid this media queries were added to achieve the effect 


### Testing Instructions
Go to Content ->Articles -> Options



### Expected result
![23819 1](https://user-images.githubusercontent.com/34353697/52524753-bac30300-2cc6-11e9-80b3-43bb01fe1dd8.png)




### Actual result
![23819 2](https://user-images.githubusercontent.com/34353697/52524791-15f4f580-2cc7-11e9-90fa-a365e255a1ef.png)



### Documentation Changes Required
None
