### PR TITLE
[com_actionlogs] username vs name on checkin

### DIFF
--- a/plugins/actionlog/joomla/joomla.php
+++ b/plugins/actionlog/joomla/joomla.php
@@ -935,10 +935,10 @@ class PlgActionlogJoomla extends ActionLogPlugin
 			'action'      => 'checkin',
 			'type'        => 'PLG_ACTIONLOG_JOOMLA_TYPE_USER',
 			'id'          => $user->id,
-			'title'       => $user->name,
+			'title'       => $user->username,
 			'itemlink'    => 'index.php?option=com_users&task=user.edit&id=' . $user->id,
 			'userid'      => $user->id,
-			'username'    => $user->name,
+			'username'    => $user->username,
 			'accountlink' => 'index.php?option=com_users&task=user.edit&id=' . $user->id,
 			'table'       => $table,
 		);


### PR DESCRIPTION
Pull Request for PR #23526 supercedes #23848

### Summary of Changes
username instead of name on checkin


### Testing Instructions
checkin an item and see actionlogs


### Expected result


User **username** performed a check in to table #__content

### Actual result

User **Super User** performed a check in to table #__content


