### PR TITLE
[4.0] Make readonly-mode for codemirror editable

### DIFF
--- a/administrator/components/com_templates/forms/source.xml
+++ b/administrator/components/com_templates/forms/source.xml
@@ -36,6 +36,7 @@
 			syntax="php"
 			filter="raw"
 			readonly="true"
+                        readonlymode="true"
 		/>
 
 		<field

--- a/libraries/src/Form/Field/EditorField.php
+++ b/libraries/src/Form/Field/EditorField.php
@@ -250,6 +250,7 @@ class EditorField extends \JFormFieldTextarea
 			'autofocus' => $this->autofocus,
 			'readonly'  => $this->readonly || $this->disabled,
 			'syntax'    => (string) $this->element['syntax'],
+			'readonlymode'    => (string) $this->element['readonlymode'],
 		);
 
 		return $editor->display(

--- a/libraries/src/Form/Field/EditorField.php
+++ b/libraries/src/Form/Field/EditorField.php
@@ -250,7 +250,7 @@ class EditorField extends \JFormFieldTextarea
 			'autofocus' => $this->autofocus,
 			'readonly'  => $this->readonly || $this->disabled,
 			'syntax'    => (string) $this->element['syntax'],
-			'readonlymode'    => (string) $this->element['readonlymode'],
+			'readonlymode' => (string) $this->element['readonlymode'],
 		);
 
 		return $editor->display(

--- a/plugins/editors/codemirror/codemirror.php
+++ b/plugins/editors/codemirror/codemirror.php
@@ -129,6 +129,10 @@ class PlgEditorCodemirror extends CMSPlugin
 		if (!empty($params['readonly']))
 		{
 			$options->readOnly = 'nocursor';
+			if (!empty($params['readonlymode']))
+			{
+				$options->readOnly = $params['readonlymode'];
+			}
 		}
 
 		// Should we focus on the editor on load?

--- a/plugins/editors/codemirror/codemirror.php
+++ b/plugins/editors/codemirror/codemirror.php
@@ -130,7 +130,6 @@ class PlgEditorCodemirror extends CMSPlugin
 		{
 			$options->readOnly = 'nocursor';
 
-
 			if (!empty($params['readonlymode']))
 			{
 				$options->readOnly = $params['readonlymode'];

--- a/plugins/editors/codemirror/codemirror.php
+++ b/plugins/editors/codemirror/codemirror.php
@@ -129,6 +129,7 @@ class PlgEditorCodemirror extends CMSPlugin
 		if (!empty($params['readonly']))
 		{
 			$options->readOnly = 'nocursor';
+
 			if (!empty($params['readonlymode']))
 			{
 				$options->readOnly = $params['readonlymode'];

--- a/plugins/editors/codemirror/codemirror.php
+++ b/plugins/editors/codemirror/codemirror.php
@@ -130,6 +130,7 @@ class PlgEditorCodemirror extends CMSPlugin
 		{
 			$options->readOnly = 'nocursor';
 
+
 			if (!empty($params['readonlymode']))
 			{
 				$options->readOnly = $params['readonlymode'];


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/23775

### Summary of Changes
Up to we set the readonly mode for the editor codemirror fix to `nocursor` 
https://github.com/joomla/joomla-cms/blob/ad2c673ac27c2fd19bbdf6003aee0451d068de16/plugins/editors/codemirror/codemirror.php#L131
Codemirror offers the readonly mode `true` where focusing is allowed: https://codemirror.net/doc/manual.html. In the mode `true` you can copy and past text.

I added the possibility to set a special mode for readonly. 

### Testing Instructions
1. Open the `view templates` in `template manager` administrator/index.php?option=com_templates&view=templates
2. Open the `template cassiopeia.`
3. Open the tab` Create Overrides`
4. Click on `com_content` and then on `article` to create an override for `com_content view article`
5. Open the tab `Editor` and open the just created override. For this you have to click on the left folder-tree on `com_content`, then on `article` and after that on `default.php`. Check if the switcher `show original` is active. See attached picture.
6. See that it is not possible to copy text from the original file in the editor with readonly mode to the clipboard.
![templates customise cassiopeia rsfd administration 2](https://user-images.githubusercontent.com/9974686/52532676-335aab80-2d29-11e9-9d1d-305635d6a8d4.png)

7. Apply this patch and check again. Now it is possible to copy text to the clipboard.


### Documentation Changes Required
Yes.
