### PR TITLE
PHP 7.3.x Compatibility in FOF Dispatcher

### DIFF
--- a/libraries/fof/dispatcher/dispatcher.php
+++ b/libraries/fof/dispatcher/dispatcher.php
@@ -521,22 +521,22 @@ class FOFDispatcher extends FOFUtilsObject
 
 					if (empty($this->fofAuth_Key))
 					{
-						continue;
+						continue 2;
 					}
 
 					if (!isset($_SERVER['PHP_AUTH_USER']))
 					{
-						continue;
+						continue 2;
 					}
 
 					if (!isset($_SERVER['PHP_AUTH_PW']))
 					{
-						continue;
+						continue 2;
 					}
 
 					if ($_SERVER['PHP_AUTH_USER'] != '_fof_auth')
 					{
-						continue;
+						continue 2;
 					}
 
 					$encryptedData = $_SERVER['PHP_AUTH_PW'];
@@ -549,7 +549,7 @@ class FOFDispatcher extends FOFUtilsObject
 
 					if (empty($encryptedData))
 					{
-						continue;
+						continue 2;
 					}
 
 					$authInfo = $this->_decryptWithTOTP($encryptedData);
@@ -558,12 +558,12 @@ class FOFDispatcher extends FOFUtilsObject
 				case 'HTTPBasicAuth_Plaintext':
 					if (!isset($_SERVER['PHP_AUTH_USER']))
 					{
-						continue;
+						continue 2;
 					}
 
 					if (!isset($_SERVER['PHP_AUTH_PW']))
 					{
-						continue;
+						continue 2;
 					}
 
 					$authInfo = array(
@@ -577,7 +577,7 @@ class FOFDispatcher extends FOFUtilsObject
 
 					if (empty($jsonencoded))
 					{
-						continue;
+						continue 2;
 					}
 
 					$authInfo = json_decode($jsonencoded, true);
@@ -606,7 +606,7 @@ class FOFDispatcher extends FOFUtilsObject
 					break;
 
 				default:
-					continue;
+					continue 2;
 
 					break;
 			}


### PR DESCRIPTION
Closes #23338

### Summary of Changes

PHP 7.3.x Compatibility in FOF Dispatcher

s/continue/continue 2/

### Testing Instructions

Run PHP 7.3.2
Access Post Install Messages or anything that invokes the old fof dispatcher

### Expected result

No warnings

### Actual result

```
Warning: "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in /var/www/.../libraries/fof/dispatcher/dispatcher.php on line 524

Warning: "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in /var/www/.../libraries/fof/dispatcher/dispatcher.php on line 529

Warning: "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in /var/www/.../libraries/fof/dispatcher/dispatcher.php on line 534

Warning: "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in /var/www/.../libraries/fof/dispatcher/dispatcher.php on line 539

Warning: "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in /var/www/.../libraries/fof/dispatcher/dispatcher.php on line 552

Warning: "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in /var/www/.../libraries/fof/dispatcher/dispatcher.php on line 561

Warning: "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in /var/www/.../libraries/fof/dispatcher/dispatcher.php on line 566

Warning: "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in /var/www/.../libraries/fof/dispatcher/dispatcher.php on line 580

Warning: "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in /var/www/.../libraries/fof/dispatcher/dispatcher.php on line 609
```

### Documentation Changes Required

None