### PR TITLE
[4.0] Fix a console application fail with the debug plugin active. 

### DIFF
--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -174,7 +174,12 @@ class PlgSystemDebug extends CMSPlugin
 			$this->db->setMonitor(null);
 		}
 
-		$storagePath = JPATH_CACHE . '/plg_system_debug_' . $this->app->getClientId();
+		// Prepare a storage location. Should be separated per App.
+		$appName = get_class($this->app);
+		$appName = ($pos = strrpos($appName, '\\')) ? substr($appName, $pos + 1, strlen($appName)) : $appName;
+		$appName = str_replace('Application', '', $appName);
+
+		$storagePath = JPATH_CACHE . '/plg_system_debug_' . $appName;
 
 		$this->debugBar = new DebugBar;
 		$this->debugBar->setStorage(new FileStorage($storagePath));


### PR DESCRIPTION
Pull Request for Issue #23845

### Summary of Changes
The patch correcting the storage location of a debug plugin.
Now it separated by App name instead of use `getClientId`


### Testing Instructions
please look #23845

