### PR TITLE
[4.0] Header icon dropdown now  visible on small screens

### DIFF
--- a/administrator/templates/atum/scss/blocks/_header.scss
+++ b/administrator/templates/atum/scss/blocks/_header.scss
@@ -116,6 +116,7 @@
     position: sticky;
     top: 0;
     width: 100%;
+    z-index: 100000;
 
     > div {
       flex-direction: column;

--- a/administrator/templates/atum/scss/blocks/_header.scss
+++ b/administrator/templates/atum/scss/blocks/_header.scss
@@ -116,7 +116,7 @@
     position: sticky;
     top: 0;
     width: 100%;
-    z-index: 100000;
+    z-index: 1000;
 
     > div {
       flex-direction: column;


### PR DESCRIPTION
Pull Request for Issue #23827 

### Summary of Changes
Added a high z-index to ```.header``` selector in ```administrator/templates/atum/scss/blocks/_header.scss```


### Testing Instructions
Click on a header icon to have a dropdrown (on small screens)



### Expected result
![23827 1](https://user-images.githubusercontent.com/34353697/52537129-0f2eb700-2d89-11e9-8f5c-9a74e6ed9790.png)




### Actual result
![23827 2](https://user-images.githubusercontent.com/34353697/52537133-15249800-2d89-11e9-815e-70080cbf8720.png)



### Documentation Changes Required
None
