### PR TITLE
GPL Compliant change to FOF Dispatcher for PHP 7.3 Compatibility

### DIFF
--- a/libraries/fof/dispatcher/dispatcher.php
+++ b/libraries/fof/dispatcher/dispatcher.php
@@ -4,6 +4,8 @@
  * @subpackage  dispatcher
  * @copyright   Copyright (C) 2010-2016 Nicholas K. Dionysopoulos / Akeeba Ltd. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ *
+ * @note        This file has been modified by the Joomla! Project in early 2019, replacing `continue` with `continue 2`, to ensure PHP 7.3+ compatibility.
  */
 // Protect from unauthorized access
 defined('FOF_INCLUDED') or die;
@@ -521,22 +523,22 @@ class FOFDispatcher extends FOFUtilsObject
 
 					if (empty($this->fofAuth_Key))
 					{
-						continue;
+						continue 2;
 					}
 
 					if (!isset($_SERVER['PHP_AUTH_USER']))
 					{
-						continue;
+						continue 2;
 					}
 
 					if (!isset($_SERVER['PHP_AUTH_PW']))
 					{
-						continue;
+						continue 2;
 					}
 
 					if ($_SERVER['PHP_AUTH_USER'] != '_fof_auth')
 					{
-						continue;
+						continue 2;
 					}
 
 					$encryptedData = $_SERVER['PHP_AUTH_PW'];
@@ -549,7 +551,7 @@ class FOFDispatcher extends FOFUtilsObject
 
 					if (empty($encryptedData))
 					{
-						continue;
+						continue 2;
 					}
 
 					$authInfo = $this->_decryptWithTOTP($encryptedData);
@@ -558,12 +560,12 @@ class FOFDispatcher extends FOFUtilsObject
 				case 'HTTPBasicAuth_Plaintext':
 					if (!isset($_SERVER['PHP_AUTH_USER']))
 					{
-						continue;
+						continue 2;
 					}
 
 					if (!isset($_SERVER['PHP_AUTH_PW']))
 					{
-						continue;
+						continue 2;
 					}
 
 					$authInfo = array(
@@ -577,7 +579,7 @@ class FOFDispatcher extends FOFUtilsObject
 
 					if (empty($jsonencoded))
 					{
-						continue;
+						continue 2;
 					}
 
 					$authInfo = json_decode($jsonencoded, true);
@@ -606,7 +608,7 @@ class FOFDispatcher extends FOFUtilsObject
 					break;
 
 				default:
-					continue;
+					continue 2;
 
 					break;
 			}


### PR DESCRIPTION
Closes #23338

### Summary of Changes

GPL Compliant change to FOF Dispatcher for PHP 7.3 Compatibility

s/continue/continue 2/

### Testing Instructions

Run PHP 7.3.2
Access Post Install Messages or anything that invokes the old fof dispatcher

### Expected result

No warnings

### Actual result

```
Warning: "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in /var/www/.../libraries/fof/dispatcher/dispatcher.php on line 524

Warning: "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in /var/www/.../libraries/fof/dispatcher/dispatcher.php on line 529

Warning: "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in /var/www/.../libraries/fof/dispatcher/dispatcher.php on line 534

Warning: "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in /var/www/.../libraries/fof/dispatcher/dispatcher.php on line 539

Warning: "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in /var/www/.../libraries/fof/dispatcher/dispatcher.php on line 552

Warning: "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in /var/www/.../libraries/fof/dispatcher/dispatcher.php on line 561

Warning: "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in /var/www/.../libraries/fof/dispatcher/dispatcher.php on line 566

Warning: "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in /var/www/.../libraries/fof/dispatcher/dispatcher.php on line 580

Warning: "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in /var/www/.../libraries/fof/dispatcher/dispatcher.php on line 609
```

### Documentation Changes Required

None

### Note

The GPL required change to the file header is non-negotiable, if you dont like my wording, write your own and PR that. I shall not be going back and forth changing it.  I have not specified the exact date of the change as that will be when the PR is merged, and that can be from hours, to years from now. It is not required for me personally to be named in the GPL required statement

- [X] - "You must cause the modified files to carry" - Done.
- [X] - "modified files to carry prominent notices" - Done.
- [X] - "stating that you changed the files" (assuming you can mean "The Joomla Project") 
- [X] - "the date of any change" (early 2019 is good enough).

@nikosdion 