### PR TITLE
[4.0]fixed language of 'insert image' to 'Insert Image'

### DIFF
--- a/administrator/language/en-GB/en-GB.plg_editors-xtd_image.ini
+++ b/administrator/language/en-GB/en-GB.plg_editors-xtd_image.ini
@@ -6,4 +6,4 @@
 PLG_EDITORS-XTD_IMAGE="Button - Image"
 PLG_IMAGE_BUTTON_IMAGE="Image"
 PLG_IMAGE_XML_DESCRIPTION="Displays a button to insert images into an Article. Displays a popup allowing you to configure an image's properties and upload new image files."
-
+PLG_IMAGE_BUTTON_INSERT = "Insert Image"

--- a/administrator/language/en-GB/en-GB.plg_editors-xtd_image.ini
+++ b/administrator/language/en-GB/en-GB.plg_editors-xtd_image.ini
@@ -5,5 +5,5 @@
 
 PLG_EDITORS-XTD_IMAGE="Button - Image"
 PLG_IMAGE_BUTTON_IMAGE="Image"
+PLG_IMAGE_BUTTON_INSERT="Insert Image"
 PLG_IMAGE_XML_DESCRIPTION="Displays a button to insert images into an Article. Displays a popup allowing you to configure an image's properties and upload new image files."
-PLG_IMAGE_BUTTON_INSERT = "Insert Image"

--- a/plugins/editors-xtd/image/image.php
+++ b/plugins/editors-xtd/image/image.php
@@ -76,7 +76,7 @@ class PlgButtonImage extends CMSPlugin
 				'modalWidth' => '80',
 				'tinyPath'   => $link,
 				'confirmCallback' => 'Joomla.getImage(Joomla.selectedFile, \'' . $name . '\')',
-				'confirmText' => 'insert image' // Needs to be translated
+				'confirmText' => 'Insert Image' // Needs to be translated
 			];
 
 			return $button;

--- a/plugins/editors-xtd/image/image.php
+++ b/plugins/editors-xtd/image/image.php
@@ -76,7 +76,7 @@ class PlgButtonImage extends CMSPlugin
 				'modalWidth' => '80',
 				'tinyPath'   => $link,
 				'confirmCallback' => 'Joomla.getImage(Joomla.selectedFile, \'' . $name . '\')',
-				'confirmText' => 'Insert Image' // Needs to be translated
+				'confirmText' => Text::_('PLG_IMAGE_BUTTON_INSERT') // Needs to be translated
 			];
 
 			return $button;

--- a/plugins/editors-xtd/image/image.php
+++ b/plugins/editors-xtd/image/image.php
@@ -76,7 +76,7 @@ class PlgButtonImage extends CMSPlugin
 				'modalWidth' => '80',
 				'tinyPath'   => $link,
 				'confirmCallback' => 'Joomla.getImage(Joomla.selectedFile, \'' . $name . '\')',
-				'confirmText' => Text::_('PLG_IMAGE_BUTTON_INSERT') // Needs to be translated
+				'confirmText' => Text::_('PLG_IMAGE_BUTTON_INSERT')
 			];
 
 			return $button;


### PR DESCRIPTION
Signed-off-by: Nitish Bahl <nitishbahl24@gmail.com>

Pull Request for Issue - 'insert image' should have capital first char
1. New article->cms content

### Expected result
![screenshot from 2019-02-11 23-52-26](https://user-images.githubusercontent.com/36095178/52584434-140e6c00-2e58-11e9-9eb8-9224ff320ae6.png)
### Actual result
![screenshot from 2019-02-11 23-53-55](https://user-images.githubusercontent.com/36095178/52584538-48822800-2e58-11e9-8093-d4e936ef4a11.png)

**Should I add a language def which might help in translation in future**