### PR TITLE
[4.0][a11y] Extra column for icon featured in com_contact

### DIFF
--- a/administrator/components/com_contact/tmpl/contacts/default.php
+++ b/administrator/components/com_contact/tmpl/contacts/default.php
@@ -134,7 +134,7 @@ if ($saveOrder && !empty($this->items))
 								</td>	
 								<td class="text-center">
 									<div class="btn-group">
-								    <?php echo HTMLHelper::_('jgrid.published', $item->published, $i, 'contacts.', $canChange, 'cb', $item->publish_up, $item->publish_down); ?>
+										<?php echo HTMLHelper::_('jgrid.published', $item->published, $i, 'contacts.', $canChange, 'cb', $item->publish_up, $item->publish_down); ?>
 									</div>	
 								</td>
 								

--- a/administrator/components/com_contact/tmpl/contacts/default.php
+++ b/administrator/components/com_contact/tmpl/contacts/default.php
@@ -129,7 +129,7 @@ if ($saveOrder && !empty($this->items))
 								</td>
 								<td class="text-center">
 									<div class="btn-group">
-									<?php echo HTMLHelper::_('contactadministrator.featured', $item->featured, $i, $canChange); ?>
+									        <?php echo HTMLHelper::_('contactadministrator.featured', $item->featured, $i, $canChange); ?>
 								   	</div>
 								</td>	
 								<td class="text-center">

--- a/administrator/components/com_contact/tmpl/contacts/default.php
+++ b/administrator/components/com_contact/tmpl/contacts/default.php
@@ -61,6 +61,9 @@ if ($saveOrder && !empty($this->items))
 								<td style="width:1%" class="text-center">
 									<?php echo HTMLHelper::_('grid.checkall'); ?>
 								</td>
+								<th scope="col" style="width:1%" class="text-center">
+									<?php echo HTMLHelper::_('searchtools.sort', 'JFEATURED', 'a.featured', $listDirn, $listOrder); ?>
+								</th>
 								<th scope="col" style="width:1%; min-width:85px" class="text-center">
 									<?php echo HTMLHelper::_('searchtools.sort', 'JSTATUS', 'a.published', $listDirn, $listOrder); ?>
 								</th>
@@ -126,10 +129,15 @@ if ($saveOrder && !empty($this->items))
 								</td>
 								<td class="text-center">
 									<div class="btn-group">
-										<?php echo HTMLHelper::_('jgrid.published', $item->published, $i, 'contacts.', $canChange, 'cb', $item->publish_up, $item->publish_down); ?>
-										<?php echo HTMLHelper::_('contactadministrator.featured', $item->featured, $i, $canChange); ?>
-									</div>
+									<?php echo HTMLHelper::_('contactadministrator.featured', $item->featured, $i, $canChange); ?>
+								   	</div>
+								</td>	
+								<td class="text-center">
+								    <div class="btn-group">
+								    <?php echo HTMLHelper::_('jgrid.published', $item->published, $i, 'contacts.', $canChange, 'cb', $item->publish_up, $item->publish_down); ?>
+									</div>	
 								</td>
+								
 								<th scope="row" class="has-context">
 									<div>
 										<?php if ($item->checked_out) : ?>

--- a/administrator/components/com_contact/tmpl/contacts/default.php
+++ b/administrator/components/com_contact/tmpl/contacts/default.php
@@ -133,7 +133,7 @@ if ($saveOrder && !empty($this->items))
 								   	</div>
 								</td>	
 								<td class="text-center">
-								    <div class="btn-group">
+									<div class="btn-group">
 								    <?php echo HTMLHelper::_('jgrid.published', $item->published, $i, 'contacts.', $canChange, 'cb', $item->publish_up, $item->publish_down); ?>
 									</div>	
 								</td>


### PR DESCRIPTION
### Summary of Changes
An extra column has been added for the icon featured in com_contact


### Testing Instructions
Go to Components -> Contacts
In the dropdown menu of Contacts, click on Contacts


### Expected result

![com_contact 1](https://user-images.githubusercontent.com/34353697/52659771-25bd4580-2f24-11e9-861b-6766c0af3f8f.png)


### Actual result
![com_contact 2](https://user-images.githubusercontent.com/34353697/52660112-f78c3580-2f24-11e9-8275-bcd7007ca3a6.png)



### Documentation Changes Required
New Screen
