### PR TITLE
[4.0] Displays hint alongside action buttons in com_media

### DIFF
--- a/administrator/components/com_media/resources/scripts/components/browser/items/directory.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/directory.vue
@@ -11,23 +11,23 @@
         <div class="media-browser-item-info">
             {{ item.name }}
         </div>
-        <a href="#" class="media-browser-select"
+        <a href="#" class="media-browser-select" title="Select"
           @click.stop="toggleSelect()"
           :aria-label="translate('COM_MEDIA_TOGGLE_SELECT_ITEM')">
         </a>
         <div class="media-browser-actions" :class="{'active': showActions}">
-            <a href="#" class="action-toggle"
+            <a href="#" class="action-toggle" title="Actions"
               :aria-label="translate('COM_MEDIA_OPEN_ITEM_ACTIONS')">
                 <span class="image-browser-action fa fa-ellipsis-h" aria-hidden="true"
                       @click.stop="showActions = true"></span>
             </a>
             <div class="media-browser-actions-list">
-                <a href="#" class="action-rename"
+                <a href="#" class="action-rename" title="Rename"
                   :aria-label="translate('COM_MEDIA_ACTIN_RENAME')">
                     <span class="image-browser-action fa fa-text-width" aria-hidden="true"
                           @click.stop="openRenameModal()"></span>
                 </a>
-                <a href="#" class="action-delete"
+                <a href="#" class="action-delete" title="Delete"
                   :aria-label="translate('COM_MEDIA_ACTION_DELETE')">
                     <span class="image-browser-action fa fa-trash" aria-hidden="true" @click.stop="openConfirmDeleteModal()"></span>
                 </a>

--- a/administrator/components/com_media/resources/scripts/components/browser/items/directory.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/directory.vue
@@ -11,23 +11,23 @@
         <div class="media-browser-item-info">
             {{ item.name }}
         </div>
-        <a href="#" class="media-browser-select" title="Select"
+        <a href="#" class="media-browser-select" :title="translate('COM_MEDIA_TOGGLE_SELECT_ITEM')"
           @click.stop="toggleSelect()"
           :aria-label="translate('COM_MEDIA_TOGGLE_SELECT_ITEM')">
         </a>
         <div class="media-browser-actions" :class="{'active': showActions}">
-            <a href="#" class="action-toggle" title="Actions"
+            <a href="#" class="action-toggle" :title="translate('COM_MEDIA_OPEN_ITEM_ACTIONS')"
               :aria-label="translate('COM_MEDIA_OPEN_ITEM_ACTIONS')">
                 <span class="image-browser-action fa fa-ellipsis-h" aria-hidden="true"
                       @click.stop="showActions = true"></span>
             </a>
             <div class="media-browser-actions-list">
-                <a href="#" class="action-rename" title="Rename"
+                <a href="#" class="action-rename" :title="translate('COM_MEDIA_ACTIN_RENAME')"
                   :aria-label="translate('COM_MEDIA_ACTIN_RENAME')">
                     <span class="image-browser-action fa fa-text-width" aria-hidden="true"
                           @click.stop="openRenameModal()"></span>
                 </a>
-                <a href="#" class="action-delete" title="Delete"
+                <a href="#" class="action-delete" :title="translate('COM_MEDIA_ACTION_DELETE')"
                   :aria-label="translate('COM_MEDIA_ACTION_DELETE')">
                     <span class="image-browser-action fa fa-trash" aria-hidden="true" @click.stop="openConfirmDeleteModal()"></span>
                 </a>

--- a/administrator/components/com_media/resources/scripts/components/browser/items/file.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/file.vue
@@ -10,32 +10,32 @@
         <div class="media-browser-item-info">
             {{ item.name }} {{ item.filetype }}
         </div>
-        <a href="#" class="media-browser-select"
+        <a href="#" class="media-browser-select" title="Select"
           @click.stop="toggleSelect()"
           :aria-label="translate('COM_MEDIA_TOGGLE_SELECT_ITEM')">
         </a>
         <div class="media-browser-actions" :class="{'active': showActions}">
-            <a href="#" class="action-toggle"
+            <a href="#" class="action-toggle" title="Actions"
               :aria-label="translate('COM_MEDIA_OPEN_ITEM_ACTIONS')">
                 <span class="image-browser-action fa fa-ellipsis-h" aria-hidden="true"
                       @click.stop="showActions = true"></span>
             </a>
             <div class="media-browser-actions-list">
-                <a href="#" class="action-download"
+                <a href="#" class="action-download" title="Download"
                    :aria-label="translate('COM_MEDIA_ACTION_DOWNLOAD')">
                     <span class="image-browser-action fa fa-download" aria-hidden="true"
                           @click.stop="download()"></span>
                 </a>
-                <a href="#" class="action-rename"
+                <a href="#" class="action-rename" title="Rename"
                   :aria-label="translate('COM_MEDIA_ACTIN_RENAME')">
                     <span class="image-browser-action fa fa-text-width" aria-hidden="true"
                           @click.stop="openRenameModal()"></span>
                 </a>
-                <a href="#" class="action-url"
+                <a href="#" class="action-url" title="Share"
                   :aria-label="translate('COM_MEDIA_ACTION_SHARE')">
                     <span class="image-browser-action fa fa-link" aria-hidden="true" @click.stop="openShareUrlModal()"></span>
                 </a>
-                <a href="#" class="action-delete"
+                <a href="#" class="action-delete" title="Delete"
                   :aria-label="translate('COM_MEDIA_ACTION_DELETE')">
                     <span class="image-browser-action fa fa-trash" aria-hidden="true" @click.stop="openConfirmDeleteModal()"></span>
                 </a>

--- a/administrator/components/com_media/resources/scripts/components/browser/items/file.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/file.vue
@@ -10,32 +10,32 @@
         <div class="media-browser-item-info">
             {{ item.name }} {{ item.filetype }}
         </div>
-        <a href="#" class="media-browser-select" title="Select"
+        <a href="#" class="media-browser-select" :title="translate('COM_MEDIA_TOGGLE_SELECT_ITEM')"
           @click.stop="toggleSelect()"
           :aria-label="translate('COM_MEDIA_TOGGLE_SELECT_ITEM')">
         </a>
         <div class="media-browser-actions" :class="{'active': showActions}">
-            <a href="#" class="action-toggle" title="Actions"
+            <a href="#" class="action-toggle" :title="translate('COM_MEDIA_OPEN_ITEM_ACTIONS')"
               :aria-label="translate('COM_MEDIA_OPEN_ITEM_ACTIONS')">
                 <span class="image-browser-action fa fa-ellipsis-h" aria-hidden="true"
                       @click.stop="showActions = true"></span>
             </a>
             <div class="media-browser-actions-list">
-                <a href="#" class="action-download" title="Download"
+                <a href="#" class="action-download" :title="translate('COM_MEDIA_ACTION_DOWNLOAD')"
                    :aria-label="translate('COM_MEDIA_ACTION_DOWNLOAD')">
                     <span class="image-browser-action fa fa-download" aria-hidden="true"
                           @click.stop="download()"></span>
                 </a>
-                <a href="#" class="action-rename" title="Rename"
+                <a href="#" class="action-rename" :title="translate('COM_MEDIA_ACTIN_RENAME')"
                   :aria-label="translate('COM_MEDIA_ACTIN_RENAME')">
                     <span class="image-browser-action fa fa-text-width" aria-hidden="true"
                           @click.stop="openRenameModal()"></span>
                 </a>
-                <a href="#" class="action-url" title="Share"
+                <a href="#" class="action-url" :title="translate('COM_MEDIA_ACTION_SHARE')"
                   :aria-label="translate('COM_MEDIA_ACTION_SHARE')">
                     <span class="image-browser-action fa fa-link" aria-hidden="true" @click.stop="openShareUrlModal()"></span>
                 </a>
-                <a href="#" class="action-delete" title="Delete"
+                <a href="#" class="action-delete" :title="translate('COM_MEDIA_ACTION_DELETE')"
                   :aria-label="translate('COM_MEDIA_ACTION_DELETE')">
                     <span class="image-browser-action fa fa-trash" aria-hidden="true" @click.stop="openConfirmDeleteModal()"></span>
                 </a>

--- a/administrator/components/com_media/resources/scripts/components/browser/items/image.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/image.vue
@@ -8,42 +8,42 @@
         <div class="media-browser-item-info">
             {{ item.name }} {{ item.filetype }}
         </div>
-        <a href="#" class="media-browser-select"
+        <a href="#" class="media-browser-select" title="Select"
           @click.stop="toggleSelect()"
           :aria-label="translate('COM_MEDIA_TOGGLE_SELECT_ITEM')">
         </a>
         <div class="media-browser-actions" :class="{'active': showActions}">
-            <a href="#" class="action-toggle"
+            <a href="#" class="action-toggle" title="Actions"
               :aria-label="translate('COM_MEDIA_OPEN_ITEM_ACTIONS')">
                 <span class="image-browser-action fa fa-ellipsis-h" aria-hidden="true"
                       @click.stop="showActions = true"></span>
             </a>
             <div class="media-browser-actions-list">
-                <a href="#" class="action-preview"
+                <a href="#" class="action-preview" title="Preview"
                   :aria-label="translate('COM_MEDIA_ACTION_PREVIEW')">
                     <span class="image-browser-action fa fa-search-plus" aria-hidden="true"
                           @click.stop="openPreview()"></span>
                 </a>
-                <a href="#" class="action-download"
+                <a href="#" class="action-download" title="Download"
                   :aria-label="translate('COM_MEDIA_ACTION_DOWNLOAD')">
                     <span class="image-browser-action fa fa-download" aria-hidden="true"
                           @click.stop="download()"></span>
                 </a>
-                <a href="#" class="action-rename"
+                <a href="#" class="action-rename" title="Rename"
                   :aria-label="translate('COM_MEDIA_ACTIN_RENAME')">
                     <span class="image-browser-action fa fa-text-width" aria-hidden="true"
                           @click.stop="openRenameModal()"></span>
                 </a>
-                <a href="#" class="action-edit"
+                <a href="#" class="action-edit" title="Edit"
                   v-if="canEdit"
                     :aria-label="translate('COM_MEDIA_ACTION_EDIT')">
                     <span class="image-browser-action fa fa-pencil" aria-hidden="true" @click.stop="editItem()"></span>
                 </a>
-                <a href="#" class="action-url"
+                <a href="#" class="action-url" title="Share"
                   :aria-label="translate('COM_MEDIA_ACTION_SHARE')">
                     <span class="image-browser-action fa fa-link" aria-hidden="true" @click.stop="openShareUrlModal()"></span>
                 </a>
-                <a href="#" class="action-delete"
+                <a href="#" class="action-delete" title="Delete"
                   :aria-label="translate('COM_MEDIA_ACTION_DELETE')">
                     <span class="image-browser-action fa fa-trash" aria-hidden="true" @click.stop="openConfirmDeleteModal()"></span>
                 </a>

--- a/administrator/components/com_media/resources/scripts/components/browser/items/image.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/image.vue
@@ -8,42 +8,42 @@
         <div class="media-browser-item-info">
             {{ item.name }} {{ item.filetype }}
         </div>
-        <a href="#" class="media-browser-select" title="Select"
+        <a href="#" class="media-browser-select" :title="translate('COM_MEDIA_TOGGLE_SELECT_ITEM')"
           @click.stop="toggleSelect()"
           :aria-label="translate('COM_MEDIA_TOGGLE_SELECT_ITEM')">
         </a>
         <div class="media-browser-actions" :class="{'active': showActions}">
-            <a href="#" class="action-toggle" title="Actions"
+            <a href="#" class="action-toggle" :title="translate('COM_MEDIA_OPEN_ITEM_ACTIONS')"
               :aria-label="translate('COM_MEDIA_OPEN_ITEM_ACTIONS')">
                 <span class="image-browser-action fa fa-ellipsis-h" aria-hidden="true"
                       @click.stop="showActions = true"></span>
             </a>
             <div class="media-browser-actions-list">
-                <a href="#" class="action-preview" title="Preview"
+                <a href="#" class="action-preview" :title="translate('COM_MEDIA_ACTION_PREVIEW')"
                   :aria-label="translate('COM_MEDIA_ACTION_PREVIEW')">
                     <span class="image-browser-action fa fa-search-plus" aria-hidden="true"
                           @click.stop="openPreview()"></span>
                 </a>
-                <a href="#" class="action-download" title="Download"
+                <a href="#" class="action-download" :title="translate('COM_MEDIA_ACTION_DOWNLOAD')"
                   :aria-label="translate('COM_MEDIA_ACTION_DOWNLOAD')">
                     <span class="image-browser-action fa fa-download" aria-hidden="true"
                           @click.stop="download()"></span>
                 </a>
-                <a href="#" class="action-rename" title="Rename"
+                <a href="#" class="action-rename" :title="translate('COM_MEDIA_ACTIN_RENAME')"
                   :aria-label="translate('COM_MEDIA_ACTIN_RENAME')">
                     <span class="image-browser-action fa fa-text-width" aria-hidden="true"
                           @click.stop="openRenameModal()"></span>
                 </a>
-                <a href="#" class="action-edit" title="Edit"
+                <a href="#" class="action-edit" :title="translate('COM_MEDIA_ACTION_EDIT')"
                   v-if="canEdit"
                     :aria-label="translate('COM_MEDIA_ACTION_EDIT')">
                     <span class="image-browser-action fa fa-pencil" aria-hidden="true" @click.stop="editItem()"></span>
                 </a>
-                <a href="#" class="action-url" title="Share"
+                <a href="#" class="action-url" :title="translate('COM_MEDIA_ACTION_SHARE')"
                   :aria-label="translate('COM_MEDIA_ACTION_SHARE')">
                     <span class="image-browser-action fa fa-link" aria-hidden="true" @click.stop="openShareUrlModal()"></span>
                 </a>
-                <a href="#" class="action-delete" title="Delete"
+                <a href="#" class="action-delete" :title="translate('COM_MEDIA_ACTION_DELETE')"
                   :aria-label="translate('COM_MEDIA_ACTION_DELETE')">
                     <span class="image-browser-action fa fa-trash" aria-hidden="true" @click.stop="openConfirmDeleteModal()"></span>
                 </a>

--- a/administrator/components/com_media/resources/scripts/components/browser/items/video.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/video.vue
@@ -10,37 +10,37 @@
         <div class="media-browser-item-info">
             {{ item.name }} {{ item.filetype }}
         </div>
-        <a href="#" class="media-browser-select" title="Select"
+        <a href="#" class="media-browser-select" :title="translate('COM_MEDIA_TOGGLE_SELECT_ITEM')"
           @click.stop="toggleSelect()"
           :aria-label="translate('COM_MEDIA_TOGGLE_SELECT_ITEM')">
         </a>
         <div class="media-browser-actions" :class="{'active': showActions}">
-            <a href="#" class="action-toggle" title="Actions"
+            <a href="#" class="action-toggle" :title="translate('COM_MEDIA_OPEN_ITEM_ACTIONS')"
               :aria-label="translate('COM_MEDIA_OPEN_ITEM_ACTIONS')">
                 <span class="image-browser-action fa fa-ellipsis-h" aria-hidden="true"
                       @click.stop="showActions = true"></span>
             </a>
             <div class="media-browser-actions-list">
-                <a href="#" class="action-preview" title="Preview"
+                <a href="#" class="action-preview" :title="translate('COM_MEDIA_ACTION_PREVIEW')"
                   :aria-label="translate('COM_MEDIA_ACTION_PREVIEW')">
                     <span class="image-browser-action fa fa-search-plus" aria-hidden="true"
                           @click.stop="openPreview()"></span>
                 </a>
-                <a href="#" class="action-download" title="Download"
+                <a href="#" class="action-download" :title="translate('COM_MEDIA_ACTION_DOWNLOAD')"
                    :aria-label="translate('COM_MEDIA_ACTION_DOWNLOAD')">
                     <span class="image-browser-action fa fa-download" aria-hidden="true"
                           @click.stop="download()"></span>
                 </a>
-                <a href="#" class="action-rename" title="Rename"
+                <a href="#" class="action-rename" :title="translate('COM_MEDIA_ACTIN_RENAME')"
                   :aria-label="translate('COM_MEDIA_ACTIN_RENAME')">
                     <span class="image-browser-action fa fa-text-width" aria-hidden="true"
                           @click.stop="openRenameModal()"></span>
                 </a>
-                <a href="#" class="action-url" title="Share"
+                <a href="#" class="action-url" :title="translate('COM_MEDIA_ACTION_SHARE')"
                   :aria-label="translate('COM_MEDIA_ACTION_SHARE')">
                     <span class="image-browser-action fa fa-link" aria-hidden="true" @click.stop="openShareUrlModal()"></span>
                 </a>
-                <a href="#" class="action-delete" title="Delete"
+                <a href="#" class="action-delete" :title="translate('COM_MEDIA_ACTION_DELETE')"
                   :aria-label="translate('COM_MEDIA_ACTION_DELETE')">
                     <span class="image-browser-action fa fa-trash" aria-hidden="true" @click.stop="openConfirmDeleteModal()"></span>
                 </a>

--- a/administrator/components/com_media/resources/scripts/components/browser/items/video.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/video.vue
@@ -10,37 +10,37 @@
         <div class="media-browser-item-info">
             {{ item.name }} {{ item.filetype }}
         </div>
-        <a href="#" class="media-browser-select"
+        <a href="#" class="media-browser-select" title="Select"
           @click.stop="toggleSelect()"
           :aria-label="translate('COM_MEDIA_TOGGLE_SELECT_ITEM')">
         </a>
         <div class="media-browser-actions" :class="{'active': showActions}">
-            <a href="#" class="action-toggle"
+            <a href="#" class="action-toggle" title="Actions"
               :aria-label="translate('COM_MEDIA_OPEN_ITEM_ACTIONS')">
                 <span class="image-browser-action fa fa-ellipsis-h" aria-hidden="true"
                       @click.stop="showActions = true"></span>
             </a>
             <div class="media-browser-actions-list">
-                <a href="#" class="action-preview"
+                <a href="#" class="action-preview" title="Preview"
                   :aria-label="translate('COM_MEDIA_ACTION_PREVIEW')">
                     <span class="image-browser-action fa fa-search-plus" aria-hidden="true"
                           @click.stop="openPreview()"></span>
                 </a>
-                <a href="#" class="action-download"
+                <a href="#" class="action-download" title="Download"
                    :aria-label="translate('COM_MEDIA_ACTION_DOWNLOAD')">
                     <span class="image-browser-action fa fa-download" aria-hidden="true"
                           @click.stop="download()"></span>
                 </a>
-                <a href="#" class="action-rename"
+                <a href="#" class="action-rename" title="Rename"
                   :aria-label="translate('COM_MEDIA_ACTIN_RENAME')">
                     <span class="image-browser-action fa fa-text-width" aria-hidden="true"
                           @click.stop="openRenameModal()"></span>
                 </a>
-                <a href="#" class="action-url"
+                <a href="#" class="action-url" title="Share"
                   :aria-label="translate('COM_MEDIA_ACTION_SHARE')">
                     <span class="image-browser-action fa fa-link" aria-hidden="true" @click.stop="openShareUrlModal()"></span>
                 </a>
-                <a href="#" class="action-delete"
+                <a href="#" class="action-delete" title="Delete"
                   :aria-label="translate('COM_MEDIA_ACTION_DELETE')">
                     <span class="image-browser-action fa fa-trash" aria-hidden="true" @click.stop="openConfirmDeleteModal()"></span>
                 </a>


### PR DESCRIPTION
Pull Request for Issue -It is often confusing to figure out what each media-browser-action button does, this PR adds title to each button which makes media manager easier to use .

### Summary of Changes
Added title for preview, select, download etc. buttons

### Expected result
Open content -> media to get into images folder and hover above select and action button of any image/directory/video. See hints alongside each action button such as preview, select, download.
![capture1](https://user-images.githubusercontent.com/36095178/52724126-c3704d80-2fd4-11e9-9af9-ce6a8c23a673.PNG)


### Actual result
No hints were displayed earlier
![screenshot from 2019-02-13 20-47-32](https://user-images.githubusercontent.com/36095178/52722604-f9f89900-2fd1-11e9-8f1c-2d020a18075c.png)