### PR TITLE
[4.0] Added option 'order' to method addStyleSheet

### DIFF
--- a/libraries/src/Document/Document.php
+++ b/libraries/src/Document/Document.php
@@ -610,7 +610,7 @@ class Document
 	 * Adds a linked stylesheet to the page
 	 *
 	 * @param   string  $url      URL to the linked style sheet
-	 * @param   array   $options  Array of options. Example: array('version' => 'auto', 'conditional' => 'lt IE 9', 'preload' => array('preload'))
+	 * @param   array   $options  Array of options. Example: array('version' => 'auto', 'conditional' => 'lt IE 9', 'preload' => array('preload'), 'order' => 2)
 	 * @param   array   $attribs  Array of attributes. Example: array('id' => 'stylesheet', 'data-test' => 1)
 	 *
 	 * @return  Document instance of $this to allow chaining

--- a/libraries/src/Document/Renderer/Html/StylesRenderer.php
+++ b/libraries/src/Document/Renderer/Html/StylesRenderer.php
@@ -42,6 +42,18 @@ class StylesRenderer extends DocumentRenderer
 
 		$defaultCssMimes = array('text/css');
 
+		// Reorder stylesheet links
+		uasort($this->_doc->_styleSheets, function($attribs1, $attribs2) {
+			$styleSheet1 = isset($attribs1['options']['order']) ? (int)$attribs1['options']['order'] : 1;
+			$styleSheet2 = isset($attribs2['options']['order']) ? (int)$attribs2['options']['order'] : 1;
+
+			if ($styleSheet1 === $styleSheet2) {
+				return 0;
+			}
+
+			return ($styleSheet1 < $styleSheet2) ? -1 : 1;
+		});
+
 		// Generate stylesheet links
 		foreach ($this->_doc->_styleSheets as $src => $attribs)
 		{


### PR DESCRIPTION
### Summary of Changes
Added a code that will reorder stylesheet links if you provide an option 'order' to the method addStyleSheet().
That will be useful if you would like to overwrite default template styles.

### Testing Instructions
Include CSS file from your view and set option 'order'.
For example:
`$this->document->addStyleSheet('../media/fixform.css', ['order' => 6]);`

![addstylesheet_order](https://user-images.githubusercontent.com/1272206/52877653-47f0d680-3163-11e9-82ef-567b5e787747.png)

I am going to attach the file *_fixform.css_*, if you would like to use it for test.
### Result
Without option 'order'.
![before](https://user-images.githubusercontent.com/1272206/52877688-622ab480-3163-11e9-9ba9-d6f7194f8f3a.png)

With option 'order'.
![after](https://user-images.githubusercontent.com/1272206/52877693-6525a500-3163-11e9-829f-4a3c0f5b999e.png)

**fixform.css**
[fixform.zip](https://github.com/joomla/joomla-cms/files/2870438/fixform.zip)

