### PR TITLE
[4.0] show pass not working in edit account

### DIFF
--- a/administrator/components/com_admin/forms/profile.xml
+++ b/administrator/components/com_admin/forms/profile.xml
@@ -21,7 +21,7 @@
 			name="password2" 
 			type="password"
 			label="JGLOBAL_PASSWORD"
-			autocomplete="off"
+			autocomplete="new-password"
 			class="validate-password"
 			field="password"
 			filter="raw"

--- a/administrator/components/com_admin/tmpl/profile/edit.php
+++ b/administrator/components/com_admin/tmpl/profile/edit.php
@@ -29,9 +29,6 @@ $fieldsets = $this->form->getFieldsets();
 				<?php echo $field->label; ?>
 			</div>
 			<div class="controls">
-				<?php if ($field->fieldname == 'password2') : ?>
-					<?php // Disables autocomplete ?> <input type="password" style="display:none">
-				<?php endif; ?>
 				<?php echo $field->input; ?>
 			</div>
 		</div>


### PR DESCRIPTION
Signed-off-by: Nitish Bahl <nitishbahl24@gmail.com>

Pull Request for Issue - Go to user menu at top right corner -> Edit account -> see that show pass icon alongside password doesn't work while that alongside confirm pass works.

### Summary of Changes
Autocomplete is already false thus extra condition is not required

### Expected result
Show pass field works like that in com_users


### Actual result
Nothing happens when icon is clicked


### Documentation Changes Required
No
