### PR TITLE
[4.0]Added placeholder for tag

### DIFF
--- a/administrator/components/com_tags/forms/tag.xml
+++ b/administrator/components/com_tags/forms/tag.xml
@@ -136,6 +136,7 @@
 		name="alias"
 		type="text"
 		label="JFIELD_ALIAS_LABEL"
+		hint="JFIELD_ALIAS_PLACEHOLDER"
 		size="40"
 	/>
 


### PR DESCRIPTION
Signed-off-by: Nitish Bahl <nitishbahl24@gmail.com>

Pull Request for Issue - Place holder missing in alias field in com_tag .

### Summary of Changes
Added placeholder


### Testing Instructions
Components -> Tag -> New


### Expected result
![screenshot from 2019-02-19 14-27-51](https://user-images.githubusercontent.com/36095178/53002457-c21aa700-3452-11e9-93a5-b6910124abdc.png)



### Actual result
![screenshot from 2019-02-19 14-28-31](https://user-images.githubusercontent.com/36095178/53002466-c47d0100-3452-11e9-84b5-2a978a74cac1.png)




