### PR TITLE
[4.0] Changes in Toolbar, separate Save (and stay) button from Save button …

### DIFF
--- a/administrator/components/com_admin/View/Profile/HtmlView.php
+++ b/administrator/components/com_admin/View/Profile/HtmlView.php
@@ -89,14 +89,10 @@ class HtmlView extends BaseHtmlView
 
 		ToolbarHelper::title(Text::_('COM_ADMIN_VIEW_PROFILE_TITLE'), 'user user-profile');
 
-		ToolbarHelper::saveGroup(
-			[
-				['apply', 'profile.apply'],
-				['save', 'profile.save']
-			],
-			'btn-success'
-		);
-
+		ToolbarHelper::apply('profile.apply');
+		ToolbarHelper::divider();
+		ToolbarHelper::save('profile.save');
+		ToolbarHelper::divider();
 		ToolbarHelper::cancel('profile.cancel', 'JTOOLBAR_CLOSE');
 		ToolbarHelper::divider();
 		ToolbarHelper::help('JHELP_ADMIN_USER_PROFILE_EDIT');

--- a/administrator/components/com_banners/View/Banner/HtmlView.php
+++ b/administrator/components/com_banners/View/Banner/HtmlView.php
@@ -97,7 +97,7 @@ class HtmlView extends BaseHtmlView
 		// If not checked out, can save the item.
 		if (!$checkedOut && ($canDo->get('core.edit') || count($user->getAuthorisedCategories('com_banners', 'core.create')) > 0))
 		{
-			$toolbarButtons[] = ['apply', 'banner.apply'];
+			ToolbarHelper::apply('banner.apply');
 			$toolbarButtons[] = ['save', 'banner.save'];
 
 			if ($canDo->get('core.create'))

--- a/administrator/components/com_banners/View/Client/HtmlView.php
+++ b/administrator/components/com_banners/View/Client/HtmlView.php
@@ -104,7 +104,7 @@ class HtmlView extends BaseHtmlView
 		// If not checked out, can save the item.
 		if (!$checkedOut && ($canDo->get('core.edit') || $canDo->get('core.create')))
 		{
-			$toolbarButtons[] = ['apply', 'client.apply'];
+			ToolbarHelper::apply('client.apply');
 			$toolbarButtons[] = ['save', 'client.save'];
 		}
 

--- a/administrator/components/com_categories/View/Category/HtmlView.php
+++ b/administrator/components/com_categories/View/Category/HtmlView.php
@@ -186,9 +186,9 @@ class HtmlView extends BaseHtmlView
 		// For new records, check the create permission.
 		if ($isNew && (count($user->getAuthorisedCategories($component, 'core.create')) > 0))
 		{
+			ToolbarHelper::apply('category.apply');
 			ToolbarHelper::saveGroup(
 				[
-					['apply', 'category.apply'],
 					['save', 'category.save'],
 					['save2new', 'category.save2new']
 				],
@@ -209,7 +209,8 @@ class HtmlView extends BaseHtmlView
 			// Can't save the record if it's checked out and editable
 			if (!$checkedOut && $itemEditable)
 			{
-				$toolbarButtons[] = ['apply', 'category.apply'];
+				ToolbarHelper::apply('category.apply');
+
 				$toolbarButtons[] = ['save', 'category.save'];
 
 				if ($canDo->get('core.create'))

--- a/administrator/components/com_config/View/Application/HtmlView.php
+++ b/administrator/components/com_config/View/Application/HtmlView.php
@@ -101,13 +101,9 @@ class HtmlView extends BaseHtmlView
 	protected function addToolbar()
 	{
 		ToolbarHelper::title(Text::_('COM_CONFIG_GLOBAL_CONFIGURATION'), 'equalizer config');
-		ToolbarHelper::saveGroup(
-			[
-				['apply', 'application.apply'],
-				['save', 'application.save']
-			],
-			'btn-success'
-		);
+		ToolbarHelper::apply('application.apply');
+		ToolbarHelper::divider();
+		ToolbarHelper::save('application.save');
 		ToolbarHelper::divider();
 		ToolbarHelper::cancel('application.cancel', 'JTOOLBAR_CLOSE');
 		ToolbarHelper::divider();

--- a/administrator/components/com_config/View/Component/HtmlView.php
+++ b/administrator/components/com_config/View/Component/HtmlView.php
@@ -103,13 +103,9 @@ class HtmlView extends BaseHtmlView
 	protected function addToolbar()
 	{
 		ToolbarHelper::title(Text::_($this->component->option . '_configuration'), 'equalizer config');
-		ToolbarHelper::saveGroup(
-			[
-				['apply', 'component.apply'],
-				['save', 'component.save']
-			],
-			'btn-success'
-		);
+		ToolbarHelper::apply('component.apply');
+		ToolbarHelper::divider();
+		ToolbarHelper::save('component.save');
 		ToolbarHelper::divider();
 		ToolbarHelper::cancel('component.cancel', 'JTOOLBAR_CLOSE');
 		ToolbarHelper::divider();

--- a/administrator/components/com_contact/View/Contact/HtmlView.php
+++ b/administrator/components/com_contact/View/Contact/HtmlView.php
@@ -112,9 +112,10 @@ class HtmlView extends BaseHtmlView
 			// For new records, check the create permission.
 			if ($isNew && (count($user->getAuthorisedCategories('com_contact', 'core.create')) > 0))
 			{
+				ToolbarHelper::apply('contact.apply');
+
 				ToolbarHelper::saveGroup(
 					[
-						['apply', 'contact.apply'],
 						['save', 'contact.save'],
 						['save2new', 'contact.save2new']
 					],
@@ -134,7 +135,8 @@ class HtmlView extends BaseHtmlView
 			// Can't save the record if it's checked out and editable
 			if (!$checkedOut && $itemEditable)
 			{
-				$toolbarButtons[] = ['apply', 'contact.apply'];
+				ToolbarHelper::apply('contact.apply');
+
 				$toolbarButtons[] = ['save', 'contact.save'];
 
 				// We can save this record, but check the create permission to see if we can return to make a new one.

--- a/administrator/components/com_content/View/Article/HtmlView.php
+++ b/administrator/components/com_content/View/Article/HtmlView.php
@@ -138,15 +138,16 @@ class HtmlView extends BaseHtmlView
 			'pencil-2 article-add'
 		);
 
-		$saveGroup = $toolbar->dropdownButton('save-group');
-
 		// For new records, check the create permission.
 		if ($isNew && (count($user->getAuthorisedCategories('com_content', 'core.create')) > 0))
 		{
+			$apply = $toolbar->apply('article.apply');
+			
+			$saveGroup = $toolbar->dropdownButton('save-group');
+
 			$saveGroup->configure(
 				function (Toolbar $childBar)
 				{
-					$childBar->apply('article.apply');
 					$childBar->save('article.save');
 					$childBar->save2new('article.save2new');
 				}
@@ -157,13 +158,18 @@ class HtmlView extends BaseHtmlView
 			// Since it's an existing record, check the edit permission, or fall back to edit own if the owner.
 			$itemEditable = $canDo->get('core.edit') || ($canDo->get('core.edit.own') && $this->item->created_by == $userId);
 
+			if (!$checkedOut && $itemEditable)
+			{
+				$toolbar->apply('article.apply');
+			}
+			$saveGroup = $toolbar->dropdownButton('save-group');
+
 			$saveGroup->configure(
 				function (Toolbar $childBar) use ($checkedOut, $itemEditable, $canDo)
 				{
 					// Can't save the record if it's checked out and editable
 					if (!$checkedOut && $itemEditable)
 					{
-						$childBar->apply('article.apply');
 						$childBar->save('article.save');
 
 						// We can save this record, but check the create permission to see if we can return to make a new one.

--- a/administrator/components/com_content/View/Article/HtmlView.php
+++ b/administrator/components/com_content/View/Article/HtmlView.php
@@ -138,15 +138,16 @@ class HtmlView extends BaseHtmlView
 			'pencil-2 article-add'
 		);
 
-		$saveGroup = $toolbar->dropdownButton('save-group');
-
 		// For new records, check the create permission.
 		if ($isNew && (count($user->getAuthorisedCategories('com_content', 'core.create')) > 0))
 		{
+			$apply = $toolbar->apply('article.apply');
+			
+			$saveGroup = $toolbar->dropdownButton('save-group');
+
 			$saveGroup->configure(
 				function (Toolbar $childBar)
 				{
-					$childBar->apply('article.apply');
 					$childBar->save('article.save');
 					$childBar->save2new('article.save2new');
 				}
@@ -157,13 +158,18 @@ class HtmlView extends BaseHtmlView
 			// Since it's an existing record, check the edit permission, or fall back to edit own if the owner.
 			$itemEditable = $canDo->get('core.edit') || ($canDo->get('core.edit.own') && $this->item->created_by == $userId);
 
+			if (!$checkedOut && $itemEditable)
+			{
+				$toolbar->apply('article.apply');
+			}
+ 			$saveGroup = $toolbar->dropdownButton('save-group');
+
 			$saveGroup->configure(
 				function (Toolbar $childBar) use ($checkedOut, $itemEditable, $canDo)
 				{
 					// Can't save the record if it's checked out and editable
 					if (!$checkedOut && $itemEditable)
 					{
-						$childBar->apply('article.apply');
 						$childBar->save('article.save');
 
 						// We can save this record, but check the create permission to see if we can return to make a new one.

--- a/administrator/components/com_fields/View/Field/HtmlView.php
+++ b/administrator/components/com_fields/View/Field/HtmlView.php
@@ -117,9 +117,10 @@ class HtmlView extends BaseHtmlView
 		// For new records, check the create permission.
 		if ($isNew)
 		{
+			ToolbarHelper::apply('field.apply');
+			
 			ToolbarHelper::saveGroup(
 				[
-					['apply', 'field.apply'],
 					['save', 'field.save'],
 					['save2new', 'field.save2new']
 				],
@@ -138,7 +139,8 @@ class HtmlView extends BaseHtmlView
 			// Can't save the record if it's checked out and editable
 			if (!$checkedOut && $itemEditable)
 			{
-				$toolbarButtons[] = ['apply', 'field.apply'];
+				ToolbarHelper::apply('field.apply');
+				
 				$toolbarButtons[] = ['save', 'field.save'];
 
 				// We can save this record, but check the create permission to see if we can return to make a new one.

--- a/administrator/components/com_fields/View/Group/HtmlView.php
+++ b/administrator/components/com_fields/View/Group/HtmlView.php
@@ -144,9 +144,10 @@ class HtmlView extends BaseHtmlView
 		// For new records, check the create permission.
 		if ($isNew)
 		{
+			ToolbarHelper::apply('group.apply');
+			
 			ToolbarHelper::saveGroup(
 				[
-					['apply', 'group.apply'],
 					['save', 'group.save'],
 					['save2new', 'group.save2new']
 				],
@@ -165,7 +166,8 @@ class HtmlView extends BaseHtmlView
 			// Can't save the record if it's checked out and editable
 			if (!$checkedOut && $itemEditable)
 			{
-				$toolbarButtons[] = ['apply', 'group.apply'];
+				ToolbarHelper::apply('group.apply');
+
 				$toolbarButtons[] = ['save', 'group.save'];
 
 				// We can save this record, but check the create permission to see if we can return to make a new one.

--- a/administrator/components/com_finder/View/Filter/HtmlView.php
+++ b/administrator/components/com_finder/View/Filter/HtmlView.php
@@ -123,9 +123,10 @@ class HtmlView extends BaseHtmlView
 			// For new records, check the create permission.
 			if ($canDo->get('core.create'))
 			{
+				ToolbarHelper::apply('filter.apply');
+				
 				ToolbarHelper::saveGroup(
 					[
-						['apply', 'filter.apply'],
 						['save', 'filter.save'],
 						['save2new', 'filter.save2new']
 					],
@@ -143,7 +144,8 @@ class HtmlView extends BaseHtmlView
 			// Since it's an existing record, check the edit permission.
 			if (!$checkedOut && $canDo->get('core.edit'))
 			{
-				$toolbarButtons[] = ['apply', 'filter.apply'];
+				ToolbarHelper::apply('filter.apply');
+				
 				$toolbarButtons[] = ['save', 'filter.save'];
 
 				// We can save this record, but check the create permission to see if we can return to make a new one.

--- a/administrator/components/com_languages/View/Language/HtmlView.php
+++ b/administrator/components/com_languages/View/Language/HtmlView.php
@@ -98,7 +98,8 @@ class HtmlView extends BaseHtmlView
 
 		if (($isNew && $canDo->get('core.create')) || (!$isNew && $canDo->get('core.edit')))
 		{
-			$toolbarButtons[] = ['apply', 'language.apply'];
+			ToolbarHelper::apply('language.apply');
+				
 			$toolbarButtons[] = ['save', 'language.save'];
 		}
 

--- a/administrator/components/com_languages/View/Override/HtmlView.php
+++ b/administrator/components/com_languages/View/Override/HtmlView.php
@@ -107,7 +107,8 @@ class HtmlView extends BaseHtmlView
 
 		if ($canDo->get('core.edit'))
 		{
-			$toolbarButtons[] = ['apply', 'override.apply'];
+			ToolbarHelper::apply('override.apply');
+				
 			$toolbarButtons[] = ['save', 'override.save'];
 		}
 

--- a/administrator/components/com_menus/View/Item/HtmlView.php
+++ b/administrator/components/com_menus/View/Item/HtmlView.php
@@ -138,7 +138,7 @@ class HtmlView extends BaseHtmlView
 		{
 			if ($canDo->get('core.edit'))
 			{
-				$toolbarButtons[] = ['apply', 'item.apply'];
+				ToolbarHelper::apply('item.apply');
 			}
 
 			$toolbarButtons[] = ['save', 'item.save'];
@@ -147,7 +147,8 @@ class HtmlView extends BaseHtmlView
 		// If not checked out, can save the item.
 		if (!$isNew && !$checkedOut && $canDo->get('core.edit'))
 		{
-			$toolbarButtons[] = ['apply', 'item.apply'];
+			ToolbarHelper::apply('item.apply');
+
 			$toolbarButtons[] = ['save', 'item.save'];
 		}
 

--- a/administrator/components/com_menus/View/Menu/HtmlView.php
+++ b/administrator/components/com_menus/View/Menu/HtmlView.php
@@ -102,7 +102,7 @@ class HtmlView extends BaseHtmlView
 		{
 			if ($this->canDo->get('core.edit'))
 			{
-				$toolbarButtons[] = ['apply', 'menu.apply'];
+				ToolbarHelper::apply('menu.apply');
 			}
 
 			$toolbarButtons[] = ['save', 'menu.save'];
@@ -111,7 +111,8 @@ class HtmlView extends BaseHtmlView
 		// If user can edit, can save the item.
 		if (!$isNew && $this->canDo->get('core.edit'))
 		{
-			$toolbarButtons[] = ['apply', 'menu.apply'];
+			ToolbarHelper::apply('menu.apply');
+
 			$toolbarButtons[] = ['save', 'menu.save'];
 		}
 

--- a/administrator/components/com_modules/View/Module/HtmlView.php
+++ b/administrator/components/com_modules/View/Module/HtmlView.php
@@ -98,9 +98,10 @@ class HtmlView extends BaseHtmlView
 		// For new records, check the create permission.
 		if ($isNew && $canDo->get('core.create'))
 		{
+			ToolbarHelper::apply('module.apply');
+
 			ToolbarHelper::saveGroup(
 				[
-					['apply', 'module.apply'],
 					['save', 'module.save'],
 					['save2new', 'module.save2new']
 				],
@@ -119,7 +120,8 @@ class HtmlView extends BaseHtmlView
 				// Since it's an existing record, check the edit permission.
 				if ($canDo->get('core.edit'))
 				{
-					$toolbarButtons[] = ['apply', 'module.apply'];
+					ToolbarHelper::apply('module.apply');
+
 					$toolbarButtons[] = ['save', 'module.save'];
 
 					// We can save this record, but check the create permission to see if we can return to make a new one.

--- a/administrator/components/com_newsfeeds/View/Newsfeed/HtmlView.php
+++ b/administrator/components/com_newsfeeds/View/Newsfeed/HtmlView.php
@@ -114,7 +114,8 @@ class HtmlView extends BaseHtmlView
 		// If not checked out, can save the item.
 		if (!$checkedOut && ($canDo->get('core.edit') || count($user->getAuthorisedCategories('com_newsfeeds', 'core.create')) > 0))
 		{
-			$toolbarButtons[] = ['apply', 'newsfeed.apply'];
+			ToolbarHelper::apply('newsfeed.apply');
+
 			$toolbarButtons[] = ['save', 'newsfeed.save'];
 		}
 

--- a/administrator/components/com_plugins/View/Plugin/HtmlView.php
+++ b/administrator/components/com_plugins/View/Plugin/HtmlView.php
@@ -86,13 +86,10 @@ class HtmlView extends BaseHtmlView
 		// If not checked out, can save the item.
 		if ($canDo->get('core.edit'))
 		{
-			ToolbarHelper::saveGroup(
-				[
-					['apply', 'plugin.apply'],
-					['save', 'plugin.save']
-				],
-				'btn-success'
-			);
+			ToolbarHelper::apply('plugin.apply');
+
+			ToolbarHelper::save('plugin.save');
+
 		}
 
 		ToolbarHelper::cancel('plugin.cancel', 'JTOOLBAR_CLOSE');

--- a/administrator/components/com_redirect/View/Link/HtmlView.php
+++ b/administrator/components/com_redirect/View/Link/HtmlView.php
@@ -91,7 +91,7 @@ class HtmlView extends BaseHtmlView
 		// If not checked out, can save the item.
 		if ($canDo->get('core.edit'))
 		{
-			$toolbarButtons[] = ['apply', 'link.apply'];
+			ToolbarHelper::apply('link.apply');
 			$toolbarButtons[] = ['save', 'link.save'];
 		}
 

--- a/administrator/components/com_tags/View/Tag/HtmlView.php
+++ b/administrator/components/com_tags/View/Tag/HtmlView.php
@@ -108,9 +108,9 @@ class HtmlView extends BaseHtmlView
 		// Build the actions for new and existing records.
 		if ($isNew)
 		{
+			ToolbarHelper::apply('tag.apply');
 			ToolbarHelper::saveGroup(
 				[
-					['apply', 'tag.apply'],
 					['save', 'tag.save'],
 					['save2new', 'tag.save2new']
 				],
@@ -129,7 +129,7 @@ class HtmlView extends BaseHtmlView
 			// Can't save the record if it's checked out and editable
 			if (!$checkedOut && $itemEditable)
 			{
-				$toolbarButtons[] = ['apply', 'tag.apply'];
+				ToolbarHelper::apply('tag.apply');
 				$toolbarButtons[] = ['save', 'tag.save'];
 
 				// We can save this record, but check the create permission to see if we can return to make a new one.

--- a/administrator/components/com_templates/View/Style/HtmlView.php
+++ b/administrator/components/com_templates/View/Style/HtmlView.php
@@ -111,7 +111,7 @@ class HtmlView extends BaseHtmlView
 		// If not checked out, can save the item.
 		if ($canDo->get('core.edit'))
 		{
-			$toolbarButtons[] = ['apply', 'style.apply'];
+			ToolbarHelper::apply('style.apply');
 			$toolbarButtons[] = ['save', 'style.save'];
 		}
 

--- a/administrator/components/com_templates/View/Template/HtmlView.php
+++ b/administrator/components/com_templates/View/Template/HtmlView.php
@@ -237,13 +237,8 @@ class HtmlView extends BaseHtmlView
 			// Add an Apply and save button
 			if ($this->type == 'file')
 			{
-				ToolbarHelper::saveGroup(
-					[
-						['apply', 'template.apply'],
-						['save', 'template.save']
-					],
-					'btn-success'
-				);
+				ToolbarHelper::apply('template.apply');
+				ToolbarHelper::save('template.save');
 			}
 			// Add a Crop and Resize button
 			elseif ($this->type == 'image')

--- a/administrator/components/com_users/View/Group/HtmlView.php
+++ b/administrator/components/com_users/View/Group/HtmlView.php
@@ -92,7 +92,7 @@ class HtmlView extends BaseHtmlView
 
 		if ($canDo->get('core.edit') || $canDo->get('core.create'))
 		{
-			$toolbarButtons[] = ['apply', 'group.apply'];
+			ToolbarHelper::apply('group.apply');
 			$toolbarButtons[] = ['save', 'group.save'];
 		}
 

--- a/administrator/components/com_users/View/Level/HtmlView.php
+++ b/administrator/components/com_users/View/Level/HtmlView.php
@@ -92,7 +92,7 @@ class HtmlView extends BaseHtmlView
 
 		if ($canDo->get('core.edit') || $canDo->get('core.create'))
 		{
-			$toolbarButtons[] = ['apply', 'level.apply'];
+			ToolbarHelper::apply('level.apply');
 			$toolbarButtons[] = ['save', 'level.save'];
 		}
 

--- a/administrator/components/com_users/View/Note/HtmlView.php
+++ b/administrator/components/com_users/View/Note/HtmlView.php
@@ -104,7 +104,7 @@ class HtmlView extends BaseHtmlView
 		// If not checked out, can save the item.
 		if (!$checkedOut && ($canDo->get('core.edit') || count($user->getAuthorisedCategories('com_users', 'core.create'))))
 		{
-			$toolbarButtons[] = ['apply', 'note.apply'];
+			ToolbarHelper::apply('note.apply');
 			$toolbarButtons[] = ['save', 'note.save'];
 		}
 

--- a/administrator/components/com_users/View/User/HtmlView.php
+++ b/administrator/components/com_users/View/User/HtmlView.php
@@ -145,7 +145,7 @@ class HtmlView extends BaseHtmlView
 
 		if ($canDo->get('core.edit') || $canDo->get('core.create'))
 		{
-			$toolbarButtons[] = ['apply', 'user.apply'];
+			ToolbarHelper::apply('user.apply');
 			$toolbarButtons[] = ['save', 'user.save'];
 		}
 

--- a/administrator/components/com_workflow/View/Stage/HtmlView.php
+++ b/administrator/components/com_workflow/View/Stage/HtmlView.php
@@ -111,7 +111,8 @@ class HtmlView extends BaseHtmlView
 			// For new records, check the create permission.
 			if ($canDo->get('core.edit'))
 			{
-				$toolbarButtons = [['apply', 'stage.apply'], ['save', 'stage.save'], ['save2new', 'stage.save2new']];
+				ToolbarHelper::apply('stage.apply');
+				$toolbarButtons = [['save', 'stage.save'], ['save2new', 'stage.save2new']];
 			}
 
 			ToolbarHelper::saveGroup(
@@ -126,7 +127,8 @@ class HtmlView extends BaseHtmlView
 
 			if ($itemEditable)
 			{
-				$toolbarButtons = [['apply', 'stage.apply'], ['save', 'stage.save']];
+				ToolbarHelper::apply('stage.apply');
+				$toolbarButtons = [['save', 'stage.save']];
 
 				// We can save this record, but check the create permission to see if we can return to make a new one.
 				if ($canDo->get('core.create'))

--- a/administrator/components/com_workflow/View/Transition/HtmlView.php
+++ b/administrator/components/com_workflow/View/Transition/HtmlView.php
@@ -133,7 +133,8 @@ class HtmlView extends BaseHtmlView
 			// For new records, check the create permission.
 			if ($canDo->get('core.edit'))
 			{
-				$toolbarButtons = [['apply', 'transition.apply'], ['save', 'transition.save'], ['save2new', 'transition.save2new']];
+				ToolbarHelper::apply('transition.apply');
+				$toolbarButtons = [['save', 'transition.save'], ['save2new', 'transition.save2new']];
 			}
 
 			ToolbarHelper::saveGroup(
@@ -148,7 +149,8 @@ class HtmlView extends BaseHtmlView
 
 			if ($itemEditable)
 			{
-				$toolbarButtons = [['apply', 'transition.apply'], ['save', 'transition.save']];
+				ToolbarHelper::apply('transition.apply');
+				$toolbarButtons = [['save', 'transition.save']];
 
 				// We can save this record, but check the create permission to see if we can return to make a new one.
 				if ($canDo->get('core.create'))

--- a/administrator/components/com_workflow/View/Workflow/HtmlView.php
+++ b/administrator/components/com_workflow/View/Workflow/HtmlView.php
@@ -117,7 +117,8 @@ class HtmlView extends BaseHtmlView
 			// For new records, check the create permission.
 			if ($canDo->get('core.edit'))
 			{
-				$toolbarButtons = [['apply', 'workflow.apply'], ['save', 'workflow.save'], ['save2new', 'workflow.save2new']];
+				ToolbarHelper::apply('workflow.apply');
+				$toolbarButtons = [['save', 'workflow.save'], ['save2new', 'workflow.save2new']];
 			}
 
 			ToolbarHelper::saveGroup(
@@ -132,7 +133,8 @@ class HtmlView extends BaseHtmlView
 
 			if ($itemEditable && !$this->item->core)
 			{
-				$toolbarButtons = [['apply', 'workflow.apply'], ['save', 'workflow.save']];
+				ToolbarHelper::apply('workflow.apply');
+				$toolbarButtons = [['save', 'workflow.save']];
 
 				// We can save this record, but check the create permission to see if we can return to make a new one.
 				if ($canDo->get('core.create'))


### PR DESCRIPTION
…group

Pull Request for Issue #21989

### Summary of Changes

All edit views were changed to separate Save (and stay) button from Save button group

### Testing Instructions



### Expected result

A "Save" button and a "Save & Close" / "Save & New" button group

### Actual result

Save is integrated in the grouped button

### Documentation Changes Required

