### PR TITLE
[4.0] Line Break missing in checked out articles/category

### DIFF
--- a/libraries/cms/html/jgrid.php
+++ b/libraries/cms/html/jgrid.php
@@ -353,7 +353,7 @@ abstract class JHtmlJGrid
 			$prefix = array_key_exists('prefix', $options) ? $options['prefix'] : '';
 		}
 
-		$text = $editorName . '<br>' . HTMLHelper::_('date', $time, Text::_('DATE_FORMAT_LC')) . '<br>' . HTMLHelper::_('date', $time, 'H:i');
+		$text = $editorName . "\n" . HTMLHelper::_('date', $time, Text::_('DATE_FORMAT_LC')) . "\n" . HTMLHelper::_('date', $time, 'H:i');
 		$active_title = HTMLHelper::_('tooltipText', Text::_('JLIB_HTML_CHECKIN'), $text, 0);
 		$inactive_title = HTMLHelper::_('tooltipText', Text::_('JLIB_HTML_CHECKED_OUT'), $text, 0);
 

--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -1028,12 +1028,12 @@ abstract class HTMLHelper
 			// Use only the title, if title and text are the same.
 			elseif ($title === $content)
 			{
-				$result = '<strong>' . $title . '</strong>';
+				$result = $title;
 			}
 			// Use a formatted string combining the title and content.
 			elseif ($content !== '')
 			{
-				$result = '<strong>' . $title . '</strong><br>' . $content;
+				$result = $title . "\n" . $content;
 			}
 			else
 			{


### PR DESCRIPTION
Signed-off-by: Nitish Bahl <nitishbahl24@gmail.com>

Pull Request for Issue - Intended line break is does not work in checked out articles/categories etc .

### Testing Instructions
Checkout any article or category.
Tested in chrome and firefox.

### Expected result
![capture19-2](https://user-images.githubusercontent.com/36095178/53023281-e8f0d180-3482-11e9-80db-bb10b030865b.PNG)



### Actual result
![capturewr](https://user-images.githubusercontent.com/36095178/53023299-f1e1a300-3482-11e9-98bc-068824ac467c.PNG)



### Documentation Changes Required- No

