### PR TITLE
[4.0] Move description label

### DIFF
--- a/administrator/components/com_contact/tmpl/contact/edit.php
+++ b/administrator/components/com_contact/tmpl/contact/edit.php
@@ -80,7 +80,8 @@ $tmpl    = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=c
 		<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'misc', Text::_('JGLOBAL_FIELDSET_MISCELLANEOUS')); ?>
 		<div class="row">
 			<div class="col-md-12">
-				<?php echo $this->form->renderField('misc'); ?>
+				<?php echo $this->form->getLabel('misc'); ?>
+				<?php echo $this->form->getInput('misc'); ?>
 			</div>
 		</div>
 		<?php echo HTMLHelper::_('uitab.endTab'); ?>

--- a/administrator/components/com_tags/tmpl/tag/edit.php
+++ b/administrator/components/com_tags/tmpl/tag/edit.php
@@ -35,7 +35,8 @@ $this->useCoreUI = true;
 		<div class="row">
 			<div class="col-md-9">
 				<div class="form-vertical">
-					<?php echo $this->form->renderField('description'); ?>
+					<?php echo $this->form->getLabel('description'); ?>
+					<?php echo $this->form->getInput('description'); ?>
 				</div>
 			</div>
 			<div class="col-md-3">


### PR DESCRIPTION
PR for #23874

When the only content of a tab is an editor there is no need to have the label displayed next to the editor instead it can be displayed above the editor. This is already the case for categories. This PR adds the same for tags and contacts (miscellaneous information)
