### PR TITLE
[4.0] Media Manager typo

### DIFF
--- a/administrator/components/com_media/resources/scripts/components/browser/items/directory.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/directory.vue
@@ -23,7 +23,7 @@
             </a>
             <div class="media-browser-actions-list">
                 <a href="#" class="action-rename"
-                  :aria-label="translate('COM_MEDIA_ACTIN_RENAME')">
+                  :aria-label="translate('COM_MEDIA_ACTION_RENAME')">
                     <span class="image-browser-action fa fa-text-width" aria-hidden="true"
                           @click.stop="openRenameModal()"></span>
                 </a>

--- a/administrator/components/com_media/resources/scripts/components/browser/items/file.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/file.vue
@@ -27,7 +27,7 @@
                           @click.stop="download()"></span>
                 </a>
                 <a href="#" class="action-rename"
-                  :aria-label="translate('COM_MEDIA_ACTIN_RENAME')">
+                  :aria-label="translate('COM_MEDIA_ACTION_RENAME')">
                     <span class="image-browser-action fa fa-text-width" aria-hidden="true"
                           @click.stop="openRenameModal()"></span>
                 </a>

--- a/administrator/components/com_media/resources/scripts/components/browser/items/image.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/image.vue
@@ -30,7 +30,7 @@
                           @click.stop="download()"></span>
                 </a>
                 <a href="#" class="action-rename"
-                  :aria-label="translate('COM_MEDIA_ACTIN_RENAME')">
+                  :aria-label="translate('COM_MEDIA_ACTION_RENAME')">
                     <span class="image-browser-action fa fa-text-width" aria-hidden="true"
                           @click.stop="openRenameModal()"></span>
                 </a>

--- a/administrator/components/com_media/resources/scripts/components/browser/items/video.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/video.vue
@@ -32,7 +32,7 @@
                           @click.stop="download()"></span>
                 </a>
                 <a href="#" class="action-rename"
-                  :aria-label="translate('COM_MEDIA_ACTIN_RENAME')">
+                  :aria-label="translate('COM_MEDIA_ACTION_RENAME')">
                     <span class="image-browser-action fa fa-text-width" aria-hidden="true"
                           @click.stop="openRenameModal()"></span>
                 </a>

--- a/administrator/components/com_media/tmpl/media/default_texts.php
+++ b/administrator/components/com_media/tmpl/media/default_texts.php
@@ -10,7 +10,7 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 
-Text::script('COM_MEDIA_ACTIN_RENAME', true);
+Text::script('COM_MEDIA_ACTION_RENAME', true);
 Text::script('COM_MEDIA_ACTION_DELETE', true);
 Text::script('COM_MEDIA_ACTION_EDIT', true);
 Text::script('COM_MEDIA_ACTION_PREVIEW', true);

--- a/administrator/language/en-GB/en-GB.com_media.ini
+++ b/administrator/language/en-GB/en-GB.com_media.ini
@@ -4,10 +4,10 @@
 ; Note : All ini files need to be saved as UTF-8
 
 COM_MEDIA="Media"
-COM_MEDIA_ACTION_RENAME="Rename item"
 COM_MEDIA_ACTION_DELETE="Delete item"
 COM_MEDIA_ACTION_EDIT="Edit item"
 COM_MEDIA_ACTION_PREVIEW="Preview item"
+COM_MEDIA_ACTION_RENAME="Rename item"
 COM_MEDIA_ACTION_SHARE="Get a sharable link"
 COM_MEDIA_CONFIGURATION="Media: Options"
 COM_MEDIA_CONFIRM_DELETE_MODEL_DESC="Are you sure you want to delete this item?"

--- a/administrator/language/en-GB/en-GB.com_media.ini
+++ b/administrator/language/en-GB/en-GB.com_media.ini
@@ -4,7 +4,7 @@
 ; Note : All ini files need to be saved as UTF-8
 
 COM_MEDIA="Media"
-COM_MEDIA_ACTIN_RENAME="Rename item"
+COM_MEDIA_ACTION_RENAME="Rename item"
 COM_MEDIA_ACTION_DELETE="Delete item"
 COM_MEDIA_ACTION_EDIT="Edit item"
 COM_MEDIA_ACTION_PREVIEW="Preview item"

--- a/language/en-GB/en-GB.com_media.ini
+++ b/language/en-GB/en-GB.com_media.ini
@@ -3,10 +3,10 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 
-COM_MEDIA_ACTION_RENAME="Rename item"
 COM_MEDIA_ACTION_DELETE="Delete item"
 COM_MEDIA_ACTION_EDIT="Edit item"
 COM_MEDIA_ACTION_PREVIEW="Preview item"
+COM_MEDIA_ACTION_RENAME="Rename item"
 COM_MEDIA_ACTION_SHARE="Get a sharable link"
 COM_MEDIA_ALIGN="Image Float"
 COM_MEDIA_ALIGN_DESC="This will apply the classes 'float-left', 'pull-center' or 'float-right' to the '<figure>' or '<img>' element."

--- a/language/en-GB/en-GB.com_media.ini
+++ b/language/en-GB/en-GB.com_media.ini
@@ -3,7 +3,7 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 
-COM_MEDIA_ACTIN_RENAME="Rename item"
+COM_MEDIA_ACTION_RENAME="Rename item"
 COM_MEDIA_ACTION_DELETE="Delete item"
 COM_MEDIA_ACTION_EDIT="Edit item"
 COM_MEDIA_ACTION_PREVIEW="Preview item"


### PR DESCRIPTION
COM_MEDIA_ACTIN_RENAME
==>
COM_MEDIA_ACTION_RENAME

Might as well get it right from the beginning or forever have a broken constant
