### PR TITLE
[4.0]minor lang fixes in media manager

### DIFF
--- a/administrator/components/com_media/resources/scripts/components/browser/items/directory.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/directory.vue
@@ -23,7 +23,7 @@
             </a>
             <div class="media-browser-actions-list">
                 <a href="#" class="action-rename"
-                  :aria-label="translate('COM_MEDIA_ACTIN_RENAME')">
+                  :aria-label="translate('COM_MEDIA_ACTION_RENAME')">
                     <span class="image-browser-action fa fa-text-width" aria-hidden="true"
                           @click.stop="openRenameModal()"></span>
                 </a>

--- a/administrator/components/com_media/resources/scripts/components/browser/items/file.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/file.vue
@@ -27,7 +27,7 @@
                           @click.stop="download()"></span>
                 </a>
                 <a href="#" class="action-rename"
-                  :aria-label="translate('COM_MEDIA_ACTIN_RENAME')">
+                  :aria-label="translate('COM_MEDIA_ACTION_RENAME')">
                     <span class="image-browser-action fa fa-text-width" aria-hidden="true"
                           @click.stop="openRenameModal()"></span>
                 </a>

--- a/administrator/components/com_media/resources/scripts/components/browser/items/image.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/image.vue
@@ -30,7 +30,7 @@
                           @click.stop="download()"></span>
                 </a>
                 <a href="#" class="action-rename"
-                  :aria-label="translate('COM_MEDIA_ACTIN_RENAME')">
+                  :aria-label="translate('COM_MEDIA_ACTION_RENAME')">
                     <span class="image-browser-action fa fa-text-width" aria-hidden="true"
                           @click.stop="openRenameModal()"></span>
                 </a>

--- a/administrator/components/com_media/resources/scripts/components/browser/items/video.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/video.vue
@@ -32,7 +32,7 @@
                           @click.stop="download()"></span>
                 </a>
                 <a href="#" class="action-rename"
-                  :aria-label="translate('COM_MEDIA_ACTIN_RENAME')">
+                  :aria-label="translate('COM_MEDIA_ACTION_RENAME')">
                     <span class="image-browser-action fa fa-text-width" aria-hidden="true"
                           @click.stop="openRenameModal()"></span>
                 </a>

--- a/administrator/components/com_media/tmpl/media/default_texts.php
+++ b/administrator/components/com_media/tmpl/media/default_texts.php
@@ -10,8 +10,9 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 
-Text::script('COM_MEDIA_ACTIN_RENAME', true);
+Text::script('COM_MEDIA_ACTION_RENAME', true);
 Text::script('COM_MEDIA_ACTION_DELETE', true);
+Text::script('COM_MEDIA_ACTION_DOWNLOAD', true);
 Text::script('COM_MEDIA_ACTION_EDIT', true);
 Text::script('COM_MEDIA_ACTION_PREVIEW', true);
 Text::script('COM_MEDIA_CREATE_NEW_FOLDER', true);

--- a/administrator/language/en-GB/en-GB.com_media.ini
+++ b/administrator/language/en-GB/en-GB.com_media.ini
@@ -4,8 +4,9 @@
 ; Note : All ini files need to be saved as UTF-8
 
 COM_MEDIA="Media"
-COM_MEDIA_ACTIN_RENAME="Rename item"
+COM_MEDIA_ACTION_RENAME="Rename item"
 COM_MEDIA_ACTION_DELETE="Delete item"
+COM_MEDIA_ACTION_DOWNLOAD="Download"
 COM_MEDIA_ACTION_EDIT="Edit item"
 COM_MEDIA_ACTION_PREVIEW="Preview item"
 COM_MEDIA_ACTION_SHARE="Get a sharable link"

--- a/language/en-GB/en-GB.com_media.ini
+++ b/language/en-GB/en-GB.com_media.ini
@@ -3,8 +3,9 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 
-COM_MEDIA_ACTIN_RENAME="Rename item"
+COM_MEDIA_ACTION_RENAME="Rename item"
 COM_MEDIA_ACTION_DELETE="Delete item"
+COM_MEDIA_ACTION_DOWNLOAD="Download"
 COM_MEDIA_ACTION_EDIT="Edit item"
 COM_MEDIA_ACTION_PREVIEW="Preview item"
 COM_MEDIA_ACTION_SHARE="Get a sharable link"


### PR DESCRIPTION
Signed-off-by: Nitish Bahl <nitishbahl24@gmail.com>

Pull Request for Issue 
1. Typo error in `COM_MEDIA_ACTIN_RENAME`.
2. `COM_MEDIA_ACTION_DOWNLOAD` is not set in lang files

### Summary of Changes
Fixed typo
