### PR TITLE
[4.0] Checkboxes [a11y]

### DIFF
--- a/layouts/joomla/form/field/checkboxes.php
+++ b/layouts/joomla/form/field/checkboxes.php
@@ -58,6 +58,7 @@ $alt = preg_replace('/[^a-zA-Z0-9_\-]/', '_', $name);
 <fieldset id="<?php echo $id; ?>" class="<?php echo trim($class . ' checkboxes'); ?>"
 	<?php echo $required ? 'required' : ''; ?>
 	<?php echo $autofocus ? 'autofocus' : ''; ?>>
+	<legend><?php echo $label; ?></legend>
 
 	<?php foreach ($options as $i => $option) : ?>
 		<?php
@@ -78,8 +79,8 @@ $alt = preg_replace('/[^a-zA-Z0-9_\-]/', '_', $name);
 			$attributes = array_filter(array($checked, $optionClass, $optionDisabled, $onchange, $onclick));
 		?>
 		<div class="form-check form-check-inline">
+		<?php echo sprintf($format, $oid, $name, $value, implode(' ', $attributes)); ?>
 			<label for="<?php echo $oid; ?>" class="form-check-label">
-				<?php echo sprintf($format, $oid, $name, $value, implode(' ', $attributes)); ?>
 				<?php echo $option->text; ?>
 			</label>
 		</div>

--- a/plugins/editors/codemirror/codemirror.xml
+++ b/plugins/editors/codemirror/codemirror.xml
@@ -184,6 +184,7 @@
 					name="fullScreenMod"
 					type="checkboxes"
 					label="PLG_CODEMIRROR_FIELD_FULLSCREEN_MOD_LABEL"
+					hiddenLabel="true"
 					filter="options"
 					>
 					<option value="Shift">PLG_CODEMIRROR_FIELD_VALUE_FULLSCREEN_MOD_SHIFT</option>


### PR DESCRIPTION
As it is a group of checkboxes then it should be a fieldset and have a legend instead of a label

I could only find one use of checkboxes and that is in the codemirror plugin at the bottom

@zwiastunsw please check this - its based on https://www.w3.org/WAI/tutorials/forms/grouping/
