### PR TITLE
[4.0] Fix modified time for new entries in fields and field groups

### DIFF
--- a/administrator/components/com_fields/Table/FieldTable.php
+++ b/administrator/components/com_fields/Table/FieldTable.php
@@ -143,10 +143,7 @@ class FieldTable extends Table
 		}
 		else
 		{
-			if (!(int) $this->created_time)
-			{
-				$this->created_time = $date->toSql();
-			}
+			$this->modified_time = $this->getDbo()->getNullDate();
 
 			if (!(int) $this->modified_time)
 			{

--- a/administrator/components/com_fields/Table/FieldTable.php
+++ b/administrator/components/com_fields/Table/FieldTable.php
@@ -144,10 +144,11 @@ class FieldTable extends Table
 		else
 		{
 			$this->modified_time = $this->getDbo()->getNullDate();
+			$this->modified_by = 0;
 
-			if (!(int) $this->modified_time)
+			if (!(int) $this->created_time)
 			{
-				$this->modified_time = $date->toSql();
+				$this->created_time = $date->toSql();
 			}
 
 			if (empty($this->created_user_id))

--- a/administrator/components/com_fields/Table/GroupTable.php
+++ b/administrator/components/com_fields/Table/GroupTable.php
@@ -102,6 +102,8 @@ class GroupTable extends Table
 		}
 		else
 		{
+			$this->modified = $this->getDbo()->getNullDate();
+
 			if (!(int) $this->created)
 			{
 				$this->created = $date->toSql();

--- a/administrator/components/com_fields/Table/GroupTable.php
+++ b/administrator/components/com_fields/Table/GroupTable.php
@@ -103,6 +103,7 @@ class GroupTable extends Table
 		else
 		{
 			$this->modified = $this->getDbo()->getNullDate();
+			$this->modified_by = 0;
 
 			if (!(int) $this->created)
 			{


### PR DESCRIPTION
### Summary of Changes
Fields and Field Grops have modified Time = nwo and modified user_id = 0 in new entries.
This PR sets modified Time to Null Date for new entries and fixes an error in saving Field Groups.


### Testing Instructions
Store a new Field.
Then store a new Field Group

### Expected result
Field Field group ist stored, modified time is = nulldate, modified user ID = 0


### Actual result
The Field has a modifiedd Time = now and modified_user_id = 0;
The Field group is not stored but ends with error.


### Documentation Changes Required

