### PR TITLE
Fix fatal error on repeatable-table.php

### DIFF
--- a/layouts/joomla/form/field/subform/repeatable-table.php
+++ b/layouts/joomla/form/field/subform/repeatable-table.php
@@ -55,11 +55,11 @@ else
 {
 	foreach ($tmpl->getGroup('') as $field) {
 		$table_head .= '<th>' . strip_tags($field->label);
-		$description = JText::_($field->description);
+		$head_description = JText::_($field->description);
 
-		if (!empty($description))
+		if (!empty($head_description))
 		{
-			$table_head .= '<br /><small style="font-weight:normal">' . $description . '</small>';
+			$table_head .= '<br /><small style="font-weight:normal">' . $head_description . '</small>';
 		}
 
 		$table_head .= '</th>';

--- a/layouts/joomla/form/field/subform/repeatable-table.php
+++ b/layouts/joomla/form/field/subform/repeatable-table.php
@@ -41,7 +41,7 @@ if (!empty($groupByFieldset))
 	foreach ($tmpl->getFieldsets() as $fieldset) {
 		$table_head .= '<th>' . JText::_($fieldset->label);
 
-		if (!empty($fieldset->description))
+		if ($fieldset->description)
 		{
 			$table_head .= '<br /><small style="font-weight:normal">' . JText::_($fieldset->description) . '</small>';
 		}
@@ -55,11 +55,10 @@ else
 {
 	foreach ($tmpl->getGroup('') as $field) {
 		$table_head .= '<th>' . strip_tags($field->label);
-		$head_description = JText::_($field->description);
 
-		if (!empty($head_description))
+		if ($field->description)
 		{
-			$table_head .= '<br /><small style="font-weight:normal">' . $head_description . '</small>';
+			$table_head .= '<br /><small style="font-weight:normal">' . JText::_($field->description) . '</small>';
 		}
 
 		$table_head .= '</th>';

--- a/layouts/joomla/form/field/subform/repeatable-table.php
+++ b/layouts/joomla/form/field/subform/repeatable-table.php
@@ -55,10 +55,11 @@ else
 {
 	foreach ($tmpl->getGroup('') as $field) {
 		$table_head .= '<th>' . strip_tags($field->label);
+		$description = JText::_($field->description);
 
-		if (!empty(JText::_($field->description)))
+		if (!empty($description))
 		{
-			$table_head .= '<br /><small style="font-weight:normal">' . JText::_($field->description) . '</small>';
+			$table_head .= '<br /><small style="font-weight:normal">' . $description . '</small>';
 		}
 
 		$table_head .= '</th>';


### PR DESCRIPTION
Pull Request for Issue #23982

### Summary of Changes
Prior to PHP 5.5, empty() only supports variables; anything else will result in a parse error


### Testing Instructions
Use Joomla subform on PHP older than 5.5

### Actual result
Fatal error: Can't use function return value in write context in /home/content/76/10380776/html/imbarcoimmediato/layouts/joomla/form/field/subform/repeatable-table.php on line 59

