### PR TITLE
[4.0] [a11y] Multilingual Associations buttons

### DIFF
--- a/administrator/components/com_associations/Field/Modal/AssociationField.php
+++ b/administrator/components/com_associations/Field/Modal/AssociationField.php
@@ -59,13 +59,13 @@ class AssociationField extends FormField
 		$urlSelect = $linkAssociations . '&amp;' . Session::getFormToken() . '=1';
 
 		// Select custom association button
-		$html[] = '<a'
+		$html[] = '<button'
 			. ' id="select-change"'
 			. ' class="btn btn-secondary' . ($value ? '' : ' hidden') . '"'
 			. ' data-toggle="modal"'
 			. ' data-select="' . Text::_('COM_ASSOCIATIONS_SELECT_TARGET') . '"'
 			. ' data-change="' . Text::_('COM_ASSOCIATIONS_CHANGE_TARGET') . '"'
-			. ' role="button"'
+			. ' type="button"'
 			. ' href="#associationSelect' . $this->id . 'Modal">'
 			. '<span class="icon-file" aria-hidden="true"></span> '
 			. '<span id="select-change-text"></span>'
@@ -75,6 +75,7 @@ class AssociationField extends FormField
 		$html[] = '<button'
 			. ' class="btn btn-secondary' . ($value ? '' : ' hidden') . '"'
 			. ' onclick="return Joomla.submitbutton(\'undo-association\');"'
+			. ' type="button"'
 			. ' id="remove-assoc">'
 			. '<span class="icon-remove" aria-hidden="true"></span> ' . Text::_('JCLEAR')
 			. '</button>';

--- a/administrator/components/com_associations/Field/Modal/AssociationField.php
+++ b/administrator/components/com_associations/Field/Modal/AssociationField.php
@@ -75,7 +75,6 @@ class AssociationField extends FormField
 		$html[] = '<button'
 			. ' class="btn btn-secondary' . ($value ? '' : ' hidden') . '"'
 			. ' onclick="return Joomla.submitbutton(\'undo-association\');"'
-			. ' type="button"'
 			. ' id="remove-assoc">'
 			. '<span class="icon-remove" aria-hidden="true"></span> ' . Text::_('JCLEAR')
 			. '</button>';


### PR DESCRIPTION
It it looks like a button and acts like a button then it should be a <button>

This PR makes sure that the two buttons to select and clear an association are real buttons

![image](https://user-images.githubusercontent.com/1296369/53265181-79265500-36d5-11e9-937c-28a64ad01bf3.png)

Any styling issues are beyond the scope of this PR