### PR TITLE
[4.0][com_tag] - class not found

### DIFF
--- a/components/com_tags/Model/TagModel.php
+++ b/components/com_tags/Model/TagModel.php
@@ -18,6 +18,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
 use Joomla\CMS\MVC\Model\ListModel;
 use Joomla\CMS\Object\CMSObject;
+use Joomla\Component\Tags\Site\Helper\TagsHelperRoute;
 use Joomla\Utilities\ArrayHelper;
 
 /**


### PR DESCRIPTION
Pull Request for Issue 
`Class 'Joomla\Component\Tags\Site\Model\TagsHelperRoute' not found `

### Summary of Changes
added missed class 


### Testing Instructions
tag an article, view  on frontend the article and click on the tag

### Expected result
no error


### Actual result

Class 'Joomla\Component\Tags\Site\Model\TagsHelperRoute' not found 




