### PR TITLE
[4.0] Fix MetadataManager to set correct time

### DIFF
--- a/libraries/src/Session/MetadataManager.php
+++ b/libraries/src/Session/MetadataManager.php
@@ -288,7 +288,7 @@ final class MetadataManager
 	{
 		$query = $this->db->getQuery(true);
 
-		$time = $session->isNew() ? time() : $session->get('session.timer.start');
+		$time = time();
 
 		$setValues = [
 			$this->db->quoteName('guest') . ' = :guest',


### PR DESCRIPTION
Fix MetadataManager to set correctly the current time when the session is only updated and not created for the very first time

### Summary of Changes
As of now the session time is updated inconsistently in the updateSessionRecord function of the MetadataManager compared to the DatabaseHandler class.

The MetadataManager at first update the session time using the timer start value:
 $session->get('session.timer.start')
when the session is closed and wrote in the DatabaseHandler class instead the session time is updated again using correctly the current time


### Testing Instructions
Start a session and check the time value in the database just after the execution of the updateSessionRecord function of the MetadataManager, then check it again after the session has been closed


### Expected result
The time value is the current time in both cases


### Actual result
The time value is the initial session time after the first stage in the MetadataManager class, The time value is correctly the current time in the DatabaseHandler class


### Documentation Changes Required
This discrepancy in the start/end time of the session lifecycle brings some side effects that i experimented on my localhost. When a lot of concurrent requests are placed, for example ajax requests, it seems that the server increases the time required to write and close a session, as a result the time value in the database persists for several seconds with the initial session start time.
Due to this gap if an application queries the 'time' database field it gets  an old and wrong value.

Pinging @mbabker here