### PR TITLE
[4.0] Wrong toolbar preferences for com_contact

### DIFF
--- a/administrator/components/com_contact/View/Contacts/HtmlView.php
+++ b/administrator/components/com_contact/View/Contacts/HtmlView.php
@@ -219,7 +219,7 @@ class HtmlView extends BaseHtmlView
 
 		if ($user->authorise('core.admin', 'com_contact') || $user->authorise('core.options', 'com_contact'))
 		{
-			$toolbar->preferences('com_menus');
+			$toolbar->preferences('com_contact');
 		}
 
 		$toolbar->help('JHELP_COMPONENTS_CONTACTS_CONTACTS');


### PR DESCRIPTION
### Summary of Changes
com_contact Options toolbar loads com_menus  preferences instead of com_contact

### Testing Instructions
Display Contacts Manager and click on the Options button before and after patch


can be merged on review