### PR TITLE
[3.9] Fix possible parent loop issues user groups

### DIFF
--- a/administrator/components/com_users/models/fields/groupparent.php
+++ b/administrator/components/com_users/models/fields/groupparent.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Administrator
  * @subpackage  com_users
  *
- * @copyright   Copyright (C) 2005 - 2018 Open Source Matters, Inc. All rights reserved.
+ * @copyright   Copyright (C) 2005 - 2019 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/administrator/components/com_users/models/fields/groupparent.php
+++ b/administrator/components/com_users/models/fields/groupparent.php
@@ -32,7 +32,7 @@ class JFormFieldGroupParent extends JFormFieldList
 	protected $type = 'GroupParent';
 
 	/**
-	 * Method to clean the Usergroup Options from all children starting by an given father
+	 * Method to clean the Usergroup Options from all children starting by a given father
 	 *
 	 * @param   array    $userGroupsOptions  The usergroup options to clean
 	 * @param   integer  $fatherId           The father ID to start with

--- a/administrator/components/com_users/models/fields/groupparent.php
+++ b/administrator/components/com_users/models/fields/groupparent.php
@@ -34,8 +34,8 @@ class JFormFieldGroupParent extends JFormFieldList
 	/**
 	 * Method to clean the Usergroup Options from all children starting by an given father
 	 *
-	 * @param   array    The usergroup options to clean
-	 * @param   integer  The father ID to start with
+	 * @param   array    $userGroupsOptions  The usergroup options to clean
+	 * @param   integer  $fatherId           The father ID to start with
 	 *
 	 * @return  array  The cleaned field options
 	 *

--- a/administrator/components/com_users/models/fields/groupparent.php
+++ b/administrator/components/com_users/models/fields/groupparent.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Administrator
  * @subpackage  com_users
  *
- * @copyright   Copyright (C) 2005 - 2019 Open Source Matters, Inc. All rights reserved.
+ * @copyright   Copyright (C) 2005 - 2018 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
@@ -32,6 +32,31 @@ class JFormFieldGroupParent extends JFormFieldList
 	protected $type = 'GroupParent';
 
 	/**
+	 * Method to clean the Usergroup Options from all children starting by an given father
+	 *
+	 * @param   array    The usergroup options to clean
+	 * @param   integer  The father ID to start with
+	 *
+	 * @return  array  The cleaned field options
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	private function cleanOptionsChildrenByFather($userGroupsOptions, $fatherId)
+	{
+		foreach ($userGroupsOptions as $userGroupsOptionsId => $userGroupsOptionsData)
+		{
+			if ((int) $userGroupsOptionsData->parent_id === (int) $fatherId)
+			{
+				unset($userGroupsOptions[$userGroupsOptionsId]);
+
+				$userGroupsOptions = $this->checkTheChildren($userGroupsOptions, $userGroupsOptionsId);
+			}
+		}
+
+		return $userGroupsOptions;
+	}
+
+	/**
 	 * Method to get the field options.
 	 *
 	 * @return  array  The field option objects
@@ -49,21 +74,11 @@ class JFormFieldGroupParent extends JFormFieldList
 			unset($options[$currentGroupId]);
 		}
 
-		// Prevent parenting direct children and children of children of this item.
-		foreach ($options as $optionsId => $optionsData)
+		// We should not remove any groups when we are creating a new group
+		if (!is_null($currentGroupId))
 		{
-			if ((int) $optionsData->parent_id === (int) $currentGroupId)
-			{
-				unset($options[$optionsId]);
-
-				foreach ($options as $subOptionsId => $subOptionsData)
-				{
-					if ((int) $subOptionsData->parent_id === $optionsId)
-					{
-						unset($options[$subOptionsId]);
-					}
-				}
-			}
+			// Prevent parenting direct children and children of children of this item.
+			$options = $this->cleanOptionsChildrenByFather($options, $currentGroupId);
 		}
 
 		$options      = array_values($options);

--- a/administrator/components/com_users/models/fields/groupparent.php
+++ b/administrator/components/com_users/models/fields/groupparent.php
@@ -49,7 +49,7 @@ class JFormFieldGroupParent extends JFormFieldList
 			{
 				unset($userGroupsOptions[$userGroupsOptionsId]);
 
-				$userGroupsOptions = $this->checkTheChildren($userGroupsOptions, $userGroupsOptionsId);
+				$userGroupsOptions = $this->cleanOptionsChildrenByFather($userGroupsOptions, $userGroupsOptionsId);
 			}
 		}
 


### PR DESCRIPTION
Pull Request for Issue #23933 cc @rolandalsace

### Summary of Changes

With this changes we make sure you can not configure an child group as your parent. As well as now use the namespaced classes.

### Testing Instructions

- Install Joomla using testing sample data (or create a few nested groups)
- check that the groups hierachie looks like this:
![image](https://user-images.githubusercontent.com/2596554/53414593-5fd02200-39cf-11e9-8fe0-50a3c4fe0499.png)
- now open the author group and check the allowed parent dropdown

### Expected result

After applying the patch anything this are children of the current group is going to be removed from that list.
![image](https://user-images.githubusercontent.com/2596554/53414815-e7b62c00-39cf-11e9-8f05-13d471002c95.png)

### Actual result

Only the current group itself is removed from the list any other child is still there.
![image](https://user-images.githubusercontent.com/2596554/53414894-192ef780-39d0-11e9-9a87-a0ee2dedf8f4.png)


### Documentation Changes Required

None.