### PR TITLE
[4.0] [WIP] Basic attributes for a tree structure in media manager

### DIFF
--- a/administrator/components/com_media/resources/scripts/components/app.vue
+++ b/administrator/components/com_media/resources/scripts/components/app.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="media-container row">
         <div class="media-sidebar col-md-2 d-none d-md-block">
-            <media-disk v-for="(disk, index) in disks" :key="index" :disk="disk"></media-disk>
+            <media-disk v-for="(disk, index) in disks" :uid="index" :key="index" :disk="disk"></media-disk>
         </div>
         <div class="col-md-10">
             <div class="media-main">

--- a/administrator/components/com_media/resources/scripts/components/tree/disk.vue
+++ b/administrator/components/com_media/resources/scripts/components/tree/disk.vue
@@ -1,13 +1,18 @@
 <template>
     <div class="media-disk">
-        <div class="media-disk-name">{{ disk.displayName }}</div>
-        <media-drive v-for="(drive, index) in disk.drives" :key="index" :drive="drive"></media-drive>
+        <h2 class="media-disk-name" :id="diskId">{{ disk.displayName }}</h2>
+        <media-drive v-for="(drive, index) in disk.drives" :diskId="diskId" :counter="index" :key="index" :drive="drive" :total="disk.drives.length"></media-drive>
     </div>
 </template>
 
 <script>
     export default {
         name: 'media-disk',
-        props: ['disk'],
+        props: ['disk', 'uid'],
+        computed: {
+            diskId() {
+                return 'disk-' + (this.uid + 1);
+            }
+        }
     }
 </script>

--- a/administrator/components/com_media/resources/scripts/components/tree/drive.vue
+++ b/administrator/components/com_media/resources/scripts/components/tree/drive.vue
@@ -1,7 +1,13 @@
 <template>
     <div class="media-drive" @click.stop.prevent="onDriveClick()">
-        <div class="media-drive-name">{{ drive.displayName }}</div>
-        <media-tree :root="drive.root"></media-tree>
+        <ul class="media-tree" role="tree" :aria-labelledby="diskId">
+            <li :class="{active: isActive, 'media-tree-item': true, 'media-drive-name': true}" role="treeitem" aria-level="1" :aria-setsize="counter" :aria-posinset="1" :tabindex="getTabindex">
+                <a>
+                    <span class="item-name">{{ drive.displayName }}</span>
+                </a>
+                <media-tree :root="drive.root" :level=2></media-tree>
+            </li>
+        </ul>
     </div>
 </template>
 
@@ -10,12 +16,21 @@
 
     export default {
         name: 'media-drive',
-        props: ['drive'],
+        props: ['drive', 'total', 'diskId', 'counter'],
         mixins: [navigable],
         methods: {
             /* Handle the on drive click event */
             onDriveClick() {
                 this.navigateTo(this.drive.root);
+            }
+        },
+        computed: {
+            /* Whether or not the item is active */
+            isActive() {
+                return (this.$store.state.selectedDirectory === this.drive.root);
+            },
+            getTabindex() {
+                return this.isActive ? 0 : -1;
             }
         }
     }

--- a/administrator/components/com_media/resources/scripts/components/tree/item.vue
+++ b/administrator/components/com_media/resources/scripts/components/tree/item.vue
@@ -1,11 +1,11 @@
 <template>
-    <li class="media-tree-item" :class="{active: isActive}">
+    <li class="media-tree-item" :class="{active: isActive}" role="treeitem" :aria-level="level" :aria-setsize="size" :aria-posinset="counter" :tabindex="getTabindex">
         <a @click.stop.prevent="onItemClick()">
             <span class="item-icon"><span :class="iconClass"></span></span>
             <span class="item-name">{{ item.name }}</span>
         </a>
         <transition name="slide-fade">
-            <media-tree v-if="hasChildren" v-show="isOpen" :root="item.path"></media-tree>
+            <media-tree v-if="hasChildren" v-show="isOpen" :aria-expanded="isOpen ? 'true' : 'false'" :root="item.path" :level=(level+1)></media-tree>
         </transition>
     </li>
 </template>
@@ -15,14 +15,35 @@
 
     export default {
         name: 'media-tree-item',
-        props: ['item'],
+        props: {
+            'item': {
+                type: Object,
+                required: true
+            },
+            'level': {
+                type: Number,
+                required: true
+            },
+            'counter': {
+                type: Number,
+                required: true
+            },
+            'size': {
+                type: Number,
+                required: true
+            }
+        },
         mixins: [navigable],
         computed: {
             /* Whether or not the item is active */
             isActive () {
                 return (this.item.path === this.$store.state.selectedDirectory);
             },
-            /* Whether or not the item is open */
+            /**
+             * Whether or not the item is open
+             *
+             * @return  boolean
+             */
             isOpen () {
                 return this.$store.state.selectedDirectory.includes(this.item.path);
             },
@@ -36,6 +57,9 @@
                     'fa-folder': !this.isOpen,
                     'fa-folder-open': this.isOpen,
                 }
+            },
+            getTabindex() {
+                return this.isActive ? 0 : -1;
             }
         },
         methods: {

--- a/administrator/components/com_media/resources/scripts/components/tree/tree.vue
+++ b/administrator/components/com_media/resources/scripts/components/tree/tree.vue
@@ -1,13 +1,22 @@
 <template>
-    <ul class="media-tree">
-        <media-tree-item v-for="item in directories" :key="item.path" :item="item"></media-tree-item>
+    <ul class="media-tree" role="group">
+        <media-tree-item v-for="(item, index) in directories" :counter="index" :key="item.path" :item="item" :size="directories.length" :level="level"></media-tree-item>
     </ul>
 </template>
 
 <script>
     export default {
         name: 'media-tree',
-        props: ['root'],
+        props: {
+            'root': {
+                type: String,
+                required: true
+            },
+            'level': {
+                type: Number,
+                required: true
+            }
+        },
         computed: {
             /* Get the directories */
             directories() {

--- a/administrator/components/com_media/resources/styles/components/_media-tree.scss
+++ b/administrator/components/com_media/resources/styles/components/_media-tree.scss
@@ -24,22 +24,6 @@ ul.media-tree {
   + .media-drive {
     border-top: 0;
   }
-  > ul > li {
-    padding-left: 25px;
-  }
-}
-
-.media-drive-name {
-  padding: 4px 10px;
-  &::before {
-    margin-right: 6px;
-    font-family:"Font Awesome 5 Free";
-    color: $sidebar-tree-icon-color;
-    content: $sidebar-tree-folder-icon;
-  }
-  &:hover {
-    cursor: pointer;
-  }
 }
 
 .media-disk-name {
@@ -59,7 +43,7 @@ ul.media-tree {
   &::before {
     position: absolute;
     top: ($sidebar-tree-line-height / 2);
-    left: 15px;
+    left: 0;
     width: 10px;
     height: 1px;
     margin: auto;
@@ -70,7 +54,7 @@ ul.media-tree {
     position: absolute;
     top: 0;
     bottom: 0;
-    left: 15px;
+    left: 0;
     width: 1px;
     height: 100%;
     content: "";
@@ -82,10 +66,23 @@ ul.media-tree {
     }
   }
   li {
-    padding-left: 25px;
+    padding-left: 10px;
     &::before, &::after {
-      left: 13px;
+      left: 5px;
     }
+  }
+}
+
+.media-drive-name {
+  padding: 4px 10px;
+  &::before {
+    content: none;
+  }
+  &::after {
+    content: none;
+  }
+  &:hover {
+    cursor: pointer;
   }
 }
 
@@ -127,35 +124,36 @@ ul.media-tree {
   vertical-align: middle;
 }
 
-/* RTL override */
-
 .media-tree-item.active > a .item-name {
   font-weight: bold;
 }
 
-html[dir=rtl] .media-tree-item::after, .media-tree-item::before {
-  left: 0;
-  right: 15px;
-}
+/* RTL override */
+html[dir=rtl] {
+  .media-browser-table .dimension, .media-browser-table .size {
+    direction: ltr;
+  }
 
-html[dir=rtl] .media-tree-item::before {
-  margin: 0;
-}
+  .media-browser-table .created, .media-browser-table .modified {
+    direction: ltr;
+  }
 
-html[dir=rtl] .media-browser-table .dimension, .media-browser-table .size {
-  direction: ltr;
-}
+  .media-drive-name {
+	padding-right: 2px;
+  }
 
-html[dir=rtl] .media-browser-table .created, .media-browser-table .modified {
-  direction: ltr;
-}
+  .media-tree-item li::before, .media-tree-item li::after {
+    left: 0;
+    right: 5px;
+    margin: 0;
+  }
 
-html[dir=rtl] .media-tree-item .item-icon {
-  padding-left: 2px;
-  padding-right: 24px;
-}
+  .media-tree-item .item-icon {
+	padding-left: 2px;
+    padding-right: 10px;
+  }
 
-html[dir=rtl] ul.media-tree ul {
-  margin-right: 24px;
+  ul.media-tree ul {
+    margin-right: 15px;
+  }
 }
-


### PR DESCRIPTION
This is a PR working on trying to implement at a basic level a tree view hierachy for the media manager to improve a11y as part of the issues raised in https://github.com/joomla/accessibility/issues/58

It also fixes the tree structure which was left broken after adding RTL support (note I have tested this PR in persian and it seems ok to me - it's not totally pixel perfect but more than usable)

https://www.w3.org/TR/wai-aria-practices/examples/treeview/treeview-1/treeview-1b.html

### What is in the scope of this
This is not trying to implement keyboard support buttons - just add the required attributes - I deliberately want to leave that for someone else to do so they can get a feel of how Vue.JS works based on the keyboard navigation I did here https://github.com/joomla/joomla-cms/commit/544c9c678fe26d186f0a881e4e3410328b2fa3f9
