### PR TITLE
[4.0] Fix safari mouse out event in media manager

### DIFF
--- a/administrator/components/com_media/resources/scripts/components/browser/items/directory.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/directory.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="media-browser-item-directory" @mouseleave="hideActions()">
+    <div class="media-browser-item-directory" @mouseleave="hideActions">
         <div class="media-browser-item-preview"
              @dblclick.stop.prevent="onPreviewDblClick()">
             <div class="file-background">
@@ -29,7 +29,7 @@
                     <li>
                         <button type="button" class="action-rename" ref="actionRename" @keyup.enter="openRenameModal()"
                           :aria-label="translate('COM_MEDIA_ACTION_RENAME')" @keyup.space="openRenameModal()"
-                          @focus="focused(true)" @blur="focused(false)" @keyup.esc="hideActions()"
+                          @focus="focused(true)" @blur="focused(false)" @keyup.esc="hideActions"
                           @keyup.up="$refs.actionDelete.focus()" @keyup.down="$refs.actionDelete.focus()">
                             <span class="image-browser-action fa fa-text-width" aria-hidden="true"
                                   @click.stop="openRenameModal()"></span>
@@ -38,7 +38,7 @@
                     <li>
                         <button type="button" class="action-delete" ref="actionDelete" @keyup.enter="openConfirmDeleteModal()"
                           :aria-label="translate('COM_MEDIA_ACTION_DELETE')" @keyup.space="openConfirmDeleteModal()"
-                           @focus="focused(true)" @blur="focused(false)" @keyup.esc="hideActions()"
+                           @focus="focused(true)" @blur="focused(false)" @keyup.esc="hideActions"
                            @keyup.up="$refs.actionRename.focus()" @keyup.down="$refs.actionRename.focus()">
                             <span class="image-browser-action fa fa-trash" aria-hidden="true" @click.stop="openConfirmDeleteModal()"></span>
                         </button>
@@ -92,7 +92,16 @@
                this.$nextTick(() => this.$refs.actionDelete.focus());
            },
            /* Hide actions dropdown */
-           hideActions() {
+           hideActions(event) {
+               // In safari there's a mouse leave event when going into the list of items. This shouldn't hide the
+               // dropdown. So check we are coming in from a mouse event (keyboard is fine), we're going somewhere
+               // in the window (toElement is not null) and then check the class list to check if it's one of the
+               // actions
+               if (event instanceof MouseEvent && event.toElement &&
+                   event.toElement.classList.contains('image-browser-action')) {
+                   return;
+               }
+
                this.showActions = false;
                this.$nextTick(() => this.$refs.actionToggle.focus());
            },

--- a/administrator/components/com_media/resources/scripts/components/browser/items/file.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/file.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="media-browser-item-file" @mouseleave="hideActions()">
+    <div class="media-browser-item-file" @mouseleave="hideActions">
         <div class="media-browser-item-preview">
             <div class="file-background">
                 <div class="file-icon">
@@ -36,7 +36,7 @@
                     <li>
                         <button type="button" class="action-rename" ref="actionRename" @keyup.space="openRenameModal()"
                           :aria-label="translate('COM_MEDIA_ACTION_RENAME')" @keyup.enter="openRenameModal()"
-                          @focus="focused(true)" @blur="focused(false)" @keyup.esc="hideActions()"
+                          @focus="focused(true)" @blur="focused(false)" @keyup.esc="hideActions"
                           @keyup.up="$refs.actionDownload.focus()" @keyup.down="$refs.actionUrl.focus()">
                             <span class="image-browser-action fa fa-text-width" aria-hidden="true"
                                   @click.stop="openRenameModal()"></span>
@@ -45,7 +45,7 @@
                     <li>
                         <button type="button" class="action-url" ref="actionUrl" @keyup.space="openShareUrlModal()"
                           :aria-label="translate('COM_MEDIA_ACTION_SHARE')" @keyup.enter="openShareUrlModal()"
-                          @focus="focused(true)" @blur="focused(false)" @keyup.esc="hideActions()"
+                          @focus="focused(true)" @blur="focused(false)" @keyup.esc="hideActions"
                           @keyup.up="$refs.actionRename.focus()" @keyup.down="$refs.actionDelete.focus()">
                             <span class="image-browser-action fa fa-link" aria-hidden="true" @click.stop="openShareUrlModal()"></span>
                         </button>
@@ -53,7 +53,7 @@
                     <li>
                         <button type="button" class="action-delete" ref="actionDelete" @keyup.space="openConfirmDeleteModal()"
                           :aria-label="translate('COM_MEDIA_ACTION_DELETE')" @keyup.enter="openConfirmDeleteModal()"
-                          @focus="focused(true)" @blur="focused(false)" @keyup.esc="hideActions()"
+                          @focus="focused(true)" @blur="focused(false)" @keyup.esc="hideActions"
                           @keyup.up="$refs.actionUrl.focus()" @keyup.down="$refs.actionDownload.focus()">
                             <span class="image-browser-action fa fa-trash" aria-hidden="true" @click.stop="openConfirmDeleteModal()"></span>
                         </button>
@@ -111,7 +111,16 @@
                 this.$nextTick(() => this.$refs.actionDelete.focus());
             },
             /* Hide actions dropdown */
-            hideActions() {
+            hideActions(event) {
+                // In safari there's a mouse leave event when going into the list of items. This shouldn't hide the
+                // dropdown. So check we are coming in from a mouse event (keyboard is fine), we're going somewhere
+                // in the window (toElement is not null) and then check the class list to check if it's one of the
+                // actions
+                if (event instanceof MouseEvent && event.toElement &&
+                    event.toElement.classList.contains('image-browser-action')) {
+                    return;
+                }
+
                 this.showActions = false;
                 this.$nextTick(() => this.$refs.actionToggle.focus());
             },

--- a/administrator/components/com_media/resources/scripts/components/browser/items/image.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/image.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="media-browser-image" @dblclick="openPreview()" @mouseleave="hideActions()">
+    <div class="media-browser-image" @dblclick="openPreview()" @mouseleave="hideActions">
         <div class="media-browser-item-preview">
             <div class="image-background">
                 <div class="image-cropped" :style="{ backgroundImage: 'url(' + thumbUrl + ')' }"></div>
@@ -26,7 +26,7 @@
                     <li>
                         <button type="button" class="action-preview" ref="actionPreview" @keyup.enter="openPreview()"
                             :aria-label="translate('COM_MEDIA_ACTION_PREVIEW')" @keyup.space="openPreview()"
-                            @focus="focused(true)" @blur="focused(false)" @keyup.esc="hideActions()"
+                            @focus="focused(true)" @blur="focused(false)" @keyup.esc="hideActions"
                             @keyup.up="$refs.actionDelete.focus()" @keyup.down="$refs.actionDownload.focus()">
                             <span class="image-browser-action fa fa-search-plus" aria-hidden="true"
                                   @click.stop="openPreview()"></span>
@@ -35,7 +35,7 @@
                     <li>
                         <button type="button" class="action-download" ref="actionDownload" @keyup.enter="download()"
                             :aria-label="translate('COM_MEDIA_ACTION_DOWNLOAD')" @keyup.space="download()"
-                            @focus="focused(true)" @blur="focused(false)" @keyup.esc="hideActions()"
+                            @focus="focused(true)" @blur="focused(false)" @keyup.esc="hideActions"
                             @keyup.up="$refs.actionPreview.focus()" @keyup.down="$refs.actionRename.focus()">
                             <span class="image-browser-action fa fa-download" aria-hidden="true"
                                   @click.stop="download()"></span>
@@ -44,7 +44,7 @@
                     <li>
                         <button type="button" class="action-rename" ref="actionRename" @keyup.enter="openRenameModal()"
                             :aria-label="translate('COM_MEDIA_ACTION_RENAME')" @keyup.space="openRenameModal()"
-                            @focus="focused(true)" @blur="focused(false)" @keyup.esc="hideActions()"
+                            @focus="focused(true)" @blur="focused(false)" @keyup.esc="hideActions"
                             @keyup.up="$refs.actionDownload.focus()" @keyup.down="canEdit ? $refs.actionEdit.focus() : $refs.actionShare.focus()">
                             <span class="image-browser-action fa fa-text-width" aria-hidden="true"
                                   @click.stop="openRenameModal()"></span>
@@ -53,7 +53,7 @@
                     <li v-if="canEdit">
                         <button type="button" class="action-edit" ref="actionEdit"
                             :aria-label="translate('COM_MEDIA_ACTION_EDIT')" @keyup.enter="editItem()" @keyup.space="editItem()"
-                            @focus="focused(true)" @blur="focused(false)" @keyup.esc="hideActions()"
+                            @focus="focused(true)" @blur="focused(false)" @keyup.esc="hideActions"
                             @keyup.up="$refs.actionRename.focus()" @keyup.down="$refs.actionShare.focus()">
                             <span class="image-browser-action fa fa-pencil" aria-hidden="true" @click.stop="editItem()"></span>
                         </button>
@@ -61,7 +61,7 @@
                     <li>
                         <button type="button" class="action-url" ref="actionShare" @keyup.enter="openShareUrlModal()"
                           :aria-label="translate('COM_MEDIA_ACTION_SHARE')" @keyup.space="openShareUrlModal()"
-                          @focus="focused(true)" @blur="focused(false)" @keyup.esc="hideActions()"
+                          @focus="focused(true)" @blur="focused(false)" @keyup.esc="hideActions"
                           @keyup.up="canEdit ? $refs.actionEdit.focus() : $refs.actionRename.focus()" @keyup.down="$refs.actionDelete.focus()">
                             <span class="image-browser-action fa fa-link" aria-hidden="true" @click.stop="openShareUrlModal()"></span>
                         </button>
@@ -69,7 +69,7 @@
                     <li>
                         <button type="button" class="action-delete" ref="actionDelete" @keyup.enter="openConfirmDeleteModal()"
                           :aria-label="translate('COM_MEDIA_ACTION_DELETE')" @keyup.space="openConfirmDeleteModal()"
-                           @focus="focused(true)" @blur="focused(false)" @keyup.esc="hideActions()"
+                           @focus="focused(true)" @blur="focused(false)" @keyup.esc="hideActions"
                            @keyup.up="$refs.actionShare.focus()" @keyup.down="$refs.actionPreview.focus()">
                             <span class="image-browser-action fa fa-trash" aria-hidden="true" @click.stop="openConfirmDeleteModal()"></span>
                         </button>
@@ -149,7 +149,16 @@
                 this.$nextTick(() => this.$refs.actionDelete.focus());
             },
             /* Hide actions dropdown */
-            hideActions() {
+            hideActions(event) {
+                // In safari there's a mouse leave event when going into the list of items. This shouldn't hide the
+                // dropdown. So check we are coming in from a mouse event (keyboard is fine), we're going somewhere
+                // in the window (toElement is not null) and then check the class list to check if it's one of the
+                // actions
+                if (event instanceof MouseEvent && event.toElement &&
+                    event.toElement.classList.contains('image-browser-action')) {
+                    return;
+                }
+
                 this.showActions = false;
                 this.$nextTick(() => this.$refs.actionToggle.focus());
             },

--- a/administrator/components/com_media/resources/scripts/components/browser/items/video.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/video.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="media-browser-image" @dblclick="openPreview()" @mouseleave="hideActions()">
+    <div class="media-browser-image" @dblclick="openPreview()" @mouseleave="hideActions">
         <div class="media-browser-item-preview">
             <div class="file-background">
                 <div class="file-icon">
@@ -27,7 +27,7 @@
                     <li>
                         <button type="button" class="action-preview" ref="actionPreview" @keyup.enter="openPreview()"
                            :aria-label="translate('COM_MEDIA_ACTION_PREVIEW')" @keyup.space="openPreview()"
-                           @focus="focused(true)" @blur="focused(false)" @keyup.esc="hideActions()"
+                           @focus="focused(true)" @blur="focused(false)" @keyup.esc="hideActions"
                            @keyup.up="$refs.actionDelete.focus()" @keyup.down="$refs.actionDownload.focus()">
                             <span class="image-browser-action fa fa-search-plus" aria-hidden="true"
                                   @click.stop="openPreview()"></span>
@@ -36,7 +36,7 @@
                     <li>
                         <button type="button" class="action-download" ref="actionDownload" @keyup.enter="download()"
                            :aria-label="translate('COM_MEDIA_ACTION_DOWNLOAD')" @keyup.space="download()"
-                           @focus="focused(true)" @blur="focused(false)" @keyup.esc="hideActions()"
+                           @focus="focused(true)" @blur="focused(false)" @keyup.esc="hideActions"
                            @keyup.up="$refs.actionPreview.focus()" @keyup.down="$refs.actionRename.focus()">
                             <span class="image-browser-action fa fa-download" aria-hidden="true"
                                   @click.stop="download()"></span>
@@ -45,7 +45,7 @@
                     <li>
                         <button type="button" class="action-rename" ref="actionRename" @keyup.enter="openRenameModal()"
                           :aria-label="translate('COM_MEDIA_ACTION_RENAME')" @keyup.space="openRenameModal()"
-                          @focus="focused(true)" @blur="focused(false)" @keyup.esc="hideActions()"
+                          @focus="focused(true)" @blur="focused(false)" @keyup.esc="hideActions"
                           @keyup.up="$refs.actionDownload.focus()" @keyup.down="$refs.actionShare.focus()">
                             <span class="image-browser-action fa fa-text-width" aria-hidden="true"
                                   @click.stop="openRenameModal()"></span>
@@ -54,7 +54,7 @@
                     <li>
                         <button type="button" class="action-url" ref="actionShare" @keyup.enter="openShareUrlModal()"
                           :aria-label="translate('COM_MEDIA_ACTION_SHARE')" @keyup.space="openShareUrlModal()"
-                          @focus="focused(true)" @blur="focused(false)" @keyup.esc="hideActions()"
+                          @focus="focused(true)" @blur="focused(false)" @keyup.esc="hideActions"
                           @keyup.up="$refs.actionRename.focus()" @keyup.down="$refs.actionDelete.focus()">
                             <span class="image-browser-action fa fa-link" aria-hidden="true" @click.stop="openShareUrlModal()"></span>
                         </button>
@@ -62,7 +62,7 @@
                     <li>
                         <button type="button" class="action-delete" ref="actionDelete" @keyup.enter="openConfirmDeleteModal()"
                           :aria-label="translate('COM_MEDIA_ACTION_DELETE')" @keyup.space="openConfirmDeleteModal()"
-                           @focus="focused(true)" @blur="focused(false)" @keyup.esc="hideActions()"
+                           @focus="focused(true)" @blur="focused(false)" @keyup.esc="hideActions"
                            @keyup.up="$refs.actionShare.focus()" @keyup.down="$refs.actionPreview.focus()">
                             <span class="image-browser-action fa fa-trash" aria-hidden="true" @click.stop="openConfirmDeleteModal()"></span>
                         </button>
@@ -121,7 +121,16 @@
                 this.$nextTick(() => this.$refs.actionDelete.focus());
             },
             /* Hide actions dropdown */
-            hideActions() {
+            hideActions(event) {
+                // In safari there's a mouse leave event when going into the list of items. This shouldn't hide the
+                // dropdown. So check we are coming in from a mouse event (keyboard is fine), we're going somewhere
+                // in the window (toElement is not null) and then check the class list to check if it's one of the
+                // actions
+                if (event instanceof MouseEvent && event.toElement &&
+                    event.toElement.classList.contains('image-browser-action')) {
+                    return;
+                }
+
                 this.showActions = false;
                 this.$nextTick(() => this.$refs.actionToggle.focus());
             },


### PR DESCRIPTION
Fixes opening the actions dropdown for any item on safari. Before patch it appears for a moment then immediately goes away again. After patch it remains open