### PR TITLE
[4.0] Toolbar button consistency

### DIFF
--- a/administrator/components/com_menus/View/Items/HtmlView.php
+++ b/administrator/components/com_menus/View/Items/HtmlView.php
@@ -395,13 +395,6 @@ class HtmlView extends BaseHtmlView
 			}
 		}
 
-		if (Factory::getUser()->authorise('core.admin'))
-		{
-			$toolbar->standardButton('refresh')
-				->text('JTOOLBAR_REBUILD')
-				->task('items.rebuild');
-		}
-
 		// Add a batch button
 		if (!$protected && $user->authorise('core.create', 'com_menus')
 			&& $user->authorise('core.edit', 'com_menus')
@@ -411,6 +404,13 @@ class HtmlView extends BaseHtmlView
 				->text('JTOOLBAR_BATCH')
 				->selector('collapseModal')
 				->listCheck(true);
+		}
+
+		if (Factory::getUser()->authorise('core.admin'))
+		{
+			$toolbar->standardButton('refresh')
+				->text('JTOOLBAR_REBUILD')
+				->task('items.rebuild');
 		}
 
 		if (!$protected && $this->state->get('filter.published') == -2 && $canDo->get('core.delete'))


### PR DESCRIPTION
All the toolbars are ordered "new - status - batch - rebuild"

The toolbar for menus was "new - status - rebuild - batch"

This simple PR makes them all consistent


### After PR
![image](https://user-images.githubusercontent.com/1296369/53578845-5e8a2b00-3b70-11e9-802e-8df1a9bc0d49.png)
