### PR TITLE
Fix invalid argument supplied & undefined index: id

### DIFF
--- a/components/com_tags/views/tag/view.feed.php
+++ b/components/com_tags/views/tag/view.feed.php
@@ -27,7 +27,7 @@ class TagsViewTag extends JViewLegacy
 	{
 		$app       = JFactory::getApplication();
 		$document  = JFactory::getDocument();
-		$ids       = $app->input->get('id');
+		$ids       = (array) $app->input->get('id');
 		$i         = 0;
 		$tagIds    = '';
 		$filter    = new JFilterInput;

--- a/components/com_tags/views/tag/view.feed.php
+++ b/components/com_tags/views/tag/view.feed.php
@@ -27,7 +27,7 @@ class TagsViewTag extends JViewLegacy
 	{
 		$app       = JFactory::getApplication();
 		$document  = JFactory::getDocument();
-		$ids       = (array) $app->input->get('id');
+		$ids       = $app->input->get('id', array(), 'array');
 		$i         = 0;
 		$tagIds    = '';
 		$filter    = new JFilterInput;


### PR DESCRIPTION
Pull Request for Issue #23999, #24039

Thanks @ReLater for the fix.

### Summary of Changes
Cast the value to an array.


### Testing Instructions
Install test demo.
On the frontend, click `All Tags`.
Click `Lime`.
Click `Feed Entries`.
Check PHP error log to see warning and notices.



### Actual result
PHP Warning:  Invalid argument supplied for foreach() in \components\com_tags\views\tag\view.feed.php on line 35
PHP Notice:  Undefined index: id in \components\com_tags\router.php on line 79
PHP Notice:  Undefined index: id in \components\com_tags\router.php on line 84
PHP Notice:  Undefined index: id in \components\com_tags\router.php on line 84

