### PR TITLE
[4.0]added minor styles for easy nav in sidebar-nav

### DIFF
--- a/administrator/templates/atum/scss/blocks/_sidebar-nav.scss
+++ b/administrator/templates/atum/scss/blocks/_sidebar-nav.scss
@@ -4,6 +4,17 @@
 
   ul {
     padding-left: .5rem;
+
+    .active{
+
+      a{
+        color: #fff;
+      }
+    }
+  }
+
+  .active{
+    background-color: #3071a9;
   }
 
   li {
@@ -25,6 +36,11 @@
 
     a {
       color: darken(theme-color("primary"), 12%);
+    }
+
+    .active {
+      text-decoration: underline;
+      color: #fff;
     }
   }
 }


### PR DESCRIPTION
Pull Request for Issue - It is quite difficult to know which component settings are open in com_config. This feature was there in J3.

### Summary of Changes
Highlights selected option

![screenshot from 2019-03-01 16-45-45](https://user-images.githubusercontent.com/36095178/53635317-b5f8cb80-3c42-11e9-8c3a-98bb1663d92d.png)

![screenshot from 2019-03-01 16-45-45](https://user-images.githubusercontent.com/36095178/53635798-3f5ccd80-3c44-11e9-8e4b-2a4e9e1fcf2d.png)

### Testing Instructions
Open com_config
