### PR TITLE
[RFC] Display error when permission to write is denied

### DIFF
--- a/libraries/src/Filesystem/File.php
+++ b/libraries/src/Filesystem/File.php
@@ -447,7 +447,15 @@ class File
 			else
 			{
 				$file = $pathObject->clean($file);
-				$ret = is_int(file_put_contents($file, $buffer)) ? true : false;
+				if(is_writable($file))
+				{
+					$ret = is_int(file_put_contents($file, $buffer)) ? true : false;
+				}
+				else
+				{
+					echo dirname($file) . ": Permission denied";
+					$ret = false;
+				}
 			}
 
 			return $ret;


### PR DESCRIPTION
Pull Request for Issue - Currently if we provide wrong userid/password Joomla attempts to write the error in log file. If the permission is denied, call stack is shown instead of telling for which dir permissions are denied.
![screenshot from 2019-03-02 10-45-51](https://user-images.githubusercontent.com/36095178/53677607-c65b8580-3cd8-11e9-888e-7eb90ab9c2d9.png)


### Summary of Changes
Checks if log dir is writable or not, if not displays for which dir permission is denied so that site admin can rectify it.


### Testing Instructions
1. Ensure that you don't have permission for log dir
2. Try logging with incorrect password

### Expected result
![screenshot from 2019-03-02 10-56-23](https://user-images.githubusercontent.com/36095178/53677669-d7f15d00-3cd9-11e9-9ad4-f4cdef2d9ab2.png)

### Actual result
Error with call stack
