### PR TITLE
[4.0] Fix webcomponents not being included on the page

### DIFF
--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -799,26 +799,19 @@ abstract class HTMLHelper
 			}
 		}
 
-		if (count($includes) === 1)
+		foreach ($includes as $include)
 		{
-			$potential = $includes[0] . ((strpos($includes[0], '?') === false) ? $version : '');
+			$potential = $include . ((strpos($include, '?') === false) ? $version : '');
+			$components = Factory::getDocument()->getScriptOptions('webcomponents');
 
-			if (!in_array($potential, Factory::getDocument()->getScriptOptions('webcomponents')))
+			if (in_array($potential, $components))
 			{
-				Factory::getDocument()->addScriptOptions('webcomponents', [$potential]);
-				return;
+				continue;
 			}
 
-			return;
+			$components[] = $potential;
+			Factory::getDocument()->addScriptOptions('webcomponents', $components);
 		}
-
-		$potential = $includes . ((strpos($includes, '?') === false) ? $version : '');
-
-		if (!in_array($potential, Factory::getDocument()->getScriptOptions('webcomponents')))
-		{
-			Factory::getDocument()->addScriptOptions('webcomponents', [$potential]);
-		}
-
 	}
 
 	/**


### PR DESCRIPTION
A b/c break in https://github.com/joomla/joomla-cms/pull/19972 has caused web components scripts to no longer be enqueued for use by core.js - this reworks the webcomponent jhtml call to be a bit cleaner and work around the b/c break