### PR TITLE
Privacy consent plugin is in system group

### DIFF
--- a/plugins/system/privacyconsent/privacyconsent.xml
+++ b/plugins/system/privacyconsent/privacyconsent.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<extension version="3.9" type="plugin" group="user" method="upgrade">
+<extension version="3.9" type="plugin" group="system" method="upgrade">
 	<name>plg_system_privacyconsent</name>
 	<author>Joomla! Project</author>
 	<creationDate>April 2018</creationDate>


### PR DESCRIPTION
The XML file for the system privacy consent plugin states that it belongs to the user plugin group, but actually it's a system plugin.