### PR TITLE
[4.0] Fatal error when editing FileSystem - Local plugin

### DIFF
--- a/plugins/filesystem/local/local.xml
+++ b/plugins/filesystem/local/local.xml
@@ -30,7 +30,7 @@
 					multiple="true"
 					layout="joomla.form.field.subform.repeatable-table"
 					buttons="add,remove,move"
-					default='[{"directory":{"directory": "images"}}]'
+					default='{"directories0":{"directory":"images"}}'
 				>
 					<form>
 						<field


### PR DESCRIPTION
Pull Request for Issue #24102 .

### Summary of Changes

Fixes default value in manifest file.

### Testing Instructions

Edit `FileSystem - Local` plugin.

### Expected result

No error. 

### Actual result

```
Recoverable fatal error: Object of class stdClass could not be converted to string in /libraries/cms/html/select.php on line 647
```
### Documentation Changes Required

No.