### PR TITLE
[4.0] Uninstall extension error

### DIFF
--- a/libraries/src/Installer/Installer.php
+++ b/libraries/src/Installer/Installer.php
@@ -757,7 +757,7 @@ class Installer extends \JAdapter
 		PluginHelper::importPlugin('extension');
 		Factory::getApplication()->triggerEvent(
 			'onExtensionBeforeUninstall',
-			array('eid' => $identifier)
+			array('installer' => clone $this, 'eid' => $identifier, 'removed' => $result)
 		);
 
 		// Run the uninstall


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/24155

### Summary of Changes
Too few arguments.


### Testing Instructions
Install any extension. A simple plugin is OK.
Make sure the Extension - Finder plugin is enabled.
Uninstall the extension you just installed.


### Result
Too few arguments to function PlgExtensionFinder::onExtensionBeforeUninstall(), 1 passed in ROOT/libraries/src/Plugin/CMSPlugin.php on line 287 and exactly 3 expected 



### Patch and test again