### PR TITLE
[4.0] - unistall extension fix

### DIFF
--- a/plugins/extension/finder/finder.php
+++ b/plugins/extension/finder/finder.php
@@ -64,15 +64,13 @@ class PlgExtensionFinder extends CMSPlugin
 	/**
 	 * Remove common words to finder after language got uninstalled
 	 *
-	 * @param   JInstaller  $installer  Installer instance
-	 * @param   integer     $eid        Extension id
-	 * @param   boolean     $removed    Installation result
+	 * @param   integer  $eid  Extension id
 	 *
 	 * @return  void
 	 *
 	 * @since   4.0.0
 	 */
-	public function onExtensionBeforeUninstall($installer, $eid, $removed)
+	public function onExtensionBeforeUninstall($eid)
 	{
 		$extension = $this->getLanguage($eid);
 


### PR DESCRIPTION
Pull Request for Issue #24155 .

### Summary of Changes
use the correct method parameter


### Testing Instructions
install an extension  (i.e com_patchtester)
uninstall the previous one


### Expected result
Extension is uninstalled correctly


### Actual result
`Error 'Too few arguments' passed to the function 'onExtensionBeforeUninstall' of the new plugin 'extension/finder/finder.php'`
