### PR TITLE
[4.0][a11y] Extra column for icon featured in Featured Articles

### DIFF
--- a/administrator/components/com_content/tmpl/featured/default.php
+++ b/administrator/components/com_content/tmpl/featured/default.php
@@ -104,6 +104,9 @@ HTMLHelper::_('script', 'com_content/admin-articles-workflow-buttons.js', ['rela
 								<td style="width:1%" class="text-center">
 									<?php echo HTMLHelper::_('grid.checkall'); ?>
 								</td>
+								<th scope="col" style="width:1%" class="text-center">
+									<?php echo HTMLHelper::_('searchtools.sort', 'JFEATURED', 'a.featured', $listDirn, $listOrder); ?>
+								</th>
 								<th scope="col" style="width:1%; min-width:85px" class="text-center">
 									<?php echo JText::_('JSTATUS'); ?>
 								</th>
@@ -207,10 +210,12 @@ HTMLHelper::_('script', 'com_content/admin-articles-workflow-buttons.js', ['rela
 								<td class="text-center">
 									<?php echo HTMLHelper::_('grid.id', $i, $item->id); ?>
 								</td>
+								<td class="text-center">
+									<?php echo $featuredButton->render($item->featured, $i, ['disabled' => !$canChange]); ?>
+								</td>
 								<td class="article-status">
 									<div class="d-flex">
 										<div class="btn-group tbody-icon mr-1">
-										<?php echo $featuredButton->render($item->featured, $i, ['disabled' => !$canChange]); ?>
 										<?php
 
 											$options = [


### PR DESCRIPTION
### Summary of Changes
This PR adds a separate column for featured icon in ```Featured Articles``` thereby increasing accessibility


### Testing Instructions
Go to Control Panel
Click Content => Featured Articles


### Expected result
![FA_new](https://user-images.githubusercontent.com/34353697/54303015-09c2c780-45e8-11e9-9159-e8e86f66a3fd.png)



### Actual result
![FA_old](https://user-images.githubusercontent.com/34353697/54303012-04fe1380-45e8-11e9-8807-bc05a1f6b989.png)



### Documentation Changes Required
None
