### PR TITLE
[4.0] Fix install error: JInstallerHelper' not found

### DIFF
--- a/administrator/components/com_installer/Model/InstallModel.php
+++ b/administrator/components/com_installer/Model/InstallModel.php
@@ -188,20 +188,20 @@ class InstallModel extends BaseDatabaseModel
 
 		foreach ($children as $child)
 		{
-			$check = JInstallerHelper::isChecksumValid($package['packagefile'], (string) $child);
+			$check = InstallerHelper::isChecksumValid($package['packagefile'], (string) $child);
 
 			switch ($check)
 			{
 				case 0:
-					$app->enqueueMessage(\JText::_('COM_INSTALLER_INSTALL_CHECKSUM_WRONG'), 'warning');
+					$app->enqueueMessage(Text::_('COM_INSTALLER_INSTALL_CHECKSUM_WRONG'), 'warning');
 					break;
 
 				case 1:
-					$app->enqueueMessage(\JText::_('COM_INSTALLER_INSTALL_CHECKSUM_CORRECT'), 'message');
+					$app->enqueueMessage(Text::_('COM_INSTALLER_INSTALL_CHECKSUM_CORRECT'), 'message');
 					break;
 
 				case 2:
-					$app->enqueueMessage(\JText::_('COM_INSTALLER_INSTALL_CHECKSUM_NOT_FOUND'), 'notice');
+					$app->enqueueMessage(Text::_('COM_INSTALLER_INSTALL_CHECKSUM_NOT_FOUND'), 'notice');
 					break;
 			}
 		}


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/24198

### Summary of Changes
- Changed `JInstallerHelper::` to `InstallerHelper::`
- Changed `JText::` to `Text::`

### Testing Instructions
- See https://github.com/joomla/joomla-cms/issues/24198
- or code review (it's obvious)

### Expected result
- Installation without error.

### Actual result
- `Class 'Joomla\Component\Installer\Administrator\Model\JInstallerHelper' not found`
