### PR TITLE
[4.0] Fix inconsistency in order of toolbar buttons in com_users

### DIFF
--- a/administrator/components/com_modules/View/Modules/HtmlView.php
+++ b/administrator/components/com_modules/View/Modules/HtmlView.php
@@ -163,7 +163,7 @@ class HtmlView extends BaseHtmlView
 		{
 			$toolbar->standardButton('new', 'JTOOLBAR_NEW')
 				->onclick("location.href='index.php?option=com_modules&amp;view=select'");
-		}	
+		}
 
 		if ($canDo->get('core.edit.state') || Factory::getUser()->authorise('core.admin'))
 		{

--- a/administrator/components/com_modules/View/Modules/HtmlView.php
+++ b/administrator/components/com_modules/View/Modules/HtmlView.php
@@ -163,12 +163,7 @@ class HtmlView extends BaseHtmlView
 		{
 			$toolbar->standardButton('new', 'JTOOLBAR_NEW')
 				->onclick("location.href='index.php?option=com_modules&amp;view=select'");
-
-			$toolbar->standardButton('copy')
-				->text('JTOOLBAR_DUPLICATE')
-				->task('modules.duplicate')
-				->listCheck(true);
-		}
+		}	
 
 		if ($canDo->get('core.edit.state') || Factory::getUser()->authorise('core.admin'))
 		{
@@ -206,6 +201,14 @@ class HtmlView extends BaseHtmlView
 			$toolbar->popupButton('batch')
 				->text('JTOOLBAR_BATCH')
 				->selector('collapseModal')
+				->listCheck(true);
+		}
+
+		if ($canDo->get('core.create'))
+		{
+			$toolbar->standardButton('copy')
+				->text('JTOOLBAR_DUPLICATE')
+				->task('modules.duplicate')
 				->listCheck(true);
 		}
 

--- a/administrator/components/com_users/View/Users/HtmlView.php
+++ b/administrator/components/com_users/View/Users/HtmlView.php
@@ -166,14 +166,6 @@ class HtmlView extends BaseHtmlView
 					->listCheck(true);
 		}
 
-		if ($canDo->get('core.delete'))
-		{
-			$toolbar->delete('users.delete')
-				->text('JTOOLBAR_DELETE')
-				->message('JGLOBAL_CONFIRM_DELETE')
-				->listCheck(true);
-		}
-
 		// Add a batch button
 		if ($user->authorise('core.create', 'com_users')
 			&& $user->authorise('core.edit', 'com_users')
@@ -182,6 +174,14 @@ class HtmlView extends BaseHtmlView
 			$toolbar->popupButton('batch')
 				->text('JTOOLBAR_BATCH')
 				->selector('collapseModal')
+				->listCheck(true);
+		}
+
+		if ($canDo->get('core.delete'))
+		{
+			$toolbar->delete('users.delete')
+				->text('JTOOLBAR_DELETE')
+				->message('JGLOBAL_CONFIRM_DELETE')
 				->listCheck(true);
 		}
 


### PR DESCRIPTION
### This PR solves the following issue
All the toolbars are ordered "new - status - batch"

But the toolbar for com_users was "new - status - delete - batch"
The ```delete``` button was in between ```status``` and ```batch``` buttons in this case, which was inconsistent with other toolbars

### Testing Instructions
In the control panel
Go to Users => Manage



### Expected result
![toolbarBtn_new](https://user-images.githubusercontent.com/34353697/54477666-c3f84000-482f-11e9-9790-307ae907c612.png)



### Actual result
![toolbarBtn_old](https://user-images.githubusercontent.com/34353697/54477668-c8245d80-482f-11e9-827b-06df05af8e7c.png)



### Documentation Changes Required
None
