### PR TITLE
[4.0]fix error during a new category creation

### DIFF
--- a/administrator/components/com_fields/forms/group.xml
+++ b/administrator/components/com_fields/forms/group.xml
@@ -73,12 +73,15 @@
 		/>
 
 		<field
-			name="modified"
-			type="text"
+			nname="modified"
+			type="calendar"
 			label="JGLOBAL_FIELD_MODIFIED_LABEL"
+			translateformat="true"
+			showtime="true"
+			size="22"
 			class="readonly"
-			filter="unset"
 			readonly="true"
+			filter="user_utc"
 		/>
 
 		<field

--- a/administrator/components/com_fields/forms/group.xml
+++ b/administrator/components/com_fields/forms/group.xml
@@ -74,7 +74,7 @@
 
 		<field
 			name="modified"
-			type="text"
+			type="calender"
 			label="JGLOBAL_FIELD_MODIFIED_LABEL"
 			default="0000-00-00 00:00:00"
 			class="readonly"

--- a/administrator/components/com_fields/forms/group.xml
+++ b/administrator/components/com_fields/forms/group.xml
@@ -73,12 +73,10 @@
 		/>
 
 		<field
-			nname="modified"
-			type="calendar"
+			name="modified"
+			type="text"
 			label="JGLOBAL_FIELD_MODIFIED_LABEL"
-			translateformat="true"
-			showtime="true"
-			size="22"
+			default="0000-00-00 00:00:00"
 			class="readonly"
 			readonly="true"
 			filter="user_utc"


### PR DESCRIPTION
Pull Request for Issue #24202  .

### Summary of Changes
Fixed xml file to match with the correct sql table structure.


### Testing Instructions
Content->Field Groups->New->Save & close


### Expected result
No error and field is saved.


### Actual result
Save failed with the following error: Incorrect datetime value: '' for column 'modified' at row 1
