### PR TITLE
[4.0] Add a writable command loader

### DIFF
--- a/libraries/src/Console/Loader/WritableContainerLoader.php
+++ b/libraries/src/Console/Loader/WritableContainerLoader.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  Copyright (C) 2005 - 2019 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Console\Loader;
+
+use Joomla\Console\Command\AbstractCommand;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\Console\Exception\CommandNotFoundException;
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * PSR-11 compatible writable command loader.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+final class WritableContainerLoader implements WritableLoaderInterface
+{
+	/**
+	 * The service container.
+	 *
+	 * @var    ContainerInterface
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $container;
+
+	/**
+	 * The command name to service ID map.
+	 *
+	 * @var    string[]
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $commandMap;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param   ContainerInterface  $container   A container from which to load command services.
+	 * @param   array               $commandMap  An array with command names as keys and service IDs as values.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function __construct(ContainerInterface $container, array $commandMap)
+	{
+		$this->container  = $container;
+		$this->commandMap = $commandMap;
+	}
+
+	/**
+	 * Adds a command to the loader.
+	 *
+	 * @param   string  $commandName  The name of the command to load.
+	 * @param   string  $className    The fully qualified class name of the command.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function add(string $commandName, string $className)
+	{
+		$this->commandMap[$commandName] = $className;
+	}
+
+	/**
+	 * Loads a command.
+	 *
+	 * @param   string  $name  The command to load.
+	 *
+	 * @return  AbstractCommand
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  CommandNotFoundException
+	 */
+	public function get(string $name): AbstractCommand
+	{
+		if (!$this->has($name))
+		{
+			throw new CommandNotFoundException(sprintf('Command "%s" does not exist.', $name));
+		}
+
+		return $this->container->get($this->commandMap[$name]);
+	}
+
+	/**
+	 * Get the names of the registered commands.
+	 *
+	 * @return  string[]
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getNames(): array
+	{
+		return array_keys($this->commandMap);
+	}
+
+	/**
+	 * Checks if a command exists.
+	 *
+	 * @param   string  $name  The command to check.
+	 *
+	 * @return  boolean
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function has($name): bool
+	{
+		return isset($this->commandMap[$name]) && $this->container->has($this->commandMap[$name]);
+	}
+}

--- a/libraries/src/Console/Loader/WritableLoaderInterface.php
+++ b/libraries/src/Console/Loader/WritableLoaderInterface.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  Copyright (C) 2005 - 2019 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Console\Loader;
+
+use Joomla\Console\Loader\LoaderInterface;
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * Interface defining a writable command loader.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+interface WritableLoaderInterface extends LoaderInterface
+{
+	/**
+	 * Adds a command to the loader.
+	 *
+	 * @param   string  $commandName  The name of the command to load.
+	 * @param   string  $className    The fully qualified class name of the command.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function add(string $commandName, string $className);
+}

--- a/libraries/src/Service/Provider/Application.php
+++ b/libraries/src/Service/Provider/Application.php
@@ -15,11 +15,12 @@ use Joomla\CMS\Application\AdministratorApplication;
 use Joomla\CMS\Application\ApiApplication;
 use Joomla\CMS\Application\ConsoleApplication;
 use Joomla\CMS\Application\SiteApplication;
+use Joomla\CMS\Console\Loader\WritableContainerLoader;
+use Joomla\CMS\Console\Loader\WritableLoaderInterface;
 use Joomla\CMS\Console\SessionGcCommand;
 use Joomla\CMS\Console\SessionMetadataGcCommand;
 use Joomla\CMS\Factory;
 use Joomla\Console\Application as BaseConsoleApplication;
-use Joomla\Console\Loader\ContainerLoader;
 use Joomla\Console\Loader\LoaderInterface;
 use Joomla\DI\Container;
 use Joomla\DI\ServiceProviderInterface;
@@ -113,7 +114,8 @@ class Application implements ServiceProviderInterface
 				true
 			);
 
-		$container->alias(ContainerLoader::class, LoaderInterface::class)
+		$container->alias(WritableContainerLoader::class, LoaderInterface::class)
+			->alias(WritableLoaderInterface::class, LoaderInterface::class)
 			->share(
 				LoaderInterface::class,
 				function (Container $container)
@@ -123,7 +125,7 @@ class Application implements ServiceProviderInterface
 						SessionMetadataGcCommand::getDefaultName() => SessionMetadataGcCommand::class,
 					];
 
-					return new ContainerLoader($container, $mapping);
+					return new WritableContainerLoader($container, $mapping);
 				},
 				true
 			);

--- a/tests/Unit/Libraries/Cms/Console/Loader/WritableContainerLoaderTest.php
+++ b/tests/Unit/Libraries/Cms/Console/Loader/WritableContainerLoaderTest.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * @package     Joomla.UnitTest
+ * @subpackage  Console
+ *
+ * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\Tests\Unit\Libraries\Cms\Console\Loader;
+
+use Joomla\CMS\Console\Loader\WritableContainerLoader;
+use Joomla\Console\Command\AbstractCommand;
+use Joomla\Tests\Unit\UnitTestCase;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Test class for Joomla\CMS\Console\Loader\WritableContainerLoader.
+ */
+class WritableContainerLoaderTest extends UnitTestCase
+{
+	/**
+	 * @var  ContainerInterface|\PHPUnit_Framework_MockObject_MockObject
+	 */
+	protected $container;
+
+	/**
+	 * Sets up the fixture, for example, opens a network connection.
+	 * This method is called before a test is executed.
+	 *
+	 * @return  void
+	 */
+	protected function setUp()
+	{
+		$this->container = $this->createMock(ContainerInterface::class);
+	}
+
+	public function testTheLoaderCanBeWrittenTo()
+	{
+		$command = $this->createMock(AbstractCommand::class);
+
+		$commandName = 'test:command';
+		$serviceId   = 'test.loader';
+
+		$this->container->expects($this->once())
+			->method('has')
+			->with($serviceId)
+			->willReturn(true);
+
+		$loader = new WritableContainerLoader($this->container, []);
+		$loader->add($commandName, $serviceId);
+
+		$this->assertTrue($loader->has($commandName));
+	}
+
+	public function testTheLoaderRetrievesACommand()
+	{
+		$command = $this->createMock(AbstractCommand::class);
+
+		$commandName = 'test:command';
+		$serviceId   = 'test.loader';
+
+		$this->container->expects($this->once())
+			->method('has')
+			->with($serviceId)
+			->willReturn(true);
+
+		$this->container->expects($this->once())
+			->method('get')
+			->with($serviceId)
+			->willReturn($command);
+
+		$this->assertSame(
+			$command,
+			(new WritableContainerLoader($this->container, [$commandName => $serviceId]))->get($commandName)
+		);
+	}
+
+	/**
+	 * @expectedException  \Symfony\Component\Console\Exception\CommandNotFoundException
+	 */
+	public function testTheLoaderDoesNotRetrieveAnUnknownCommand()
+	{
+		$commandName = 'test:loader';
+		$serviceId   = 'test.loader';
+
+		$this->container->expects($this->once())
+			->method('has')
+			->with($serviceId)
+			->willReturn(false);
+
+		$this->container->expects($this->never())
+			->method('get');
+
+		(new WritableContainerLoader($this->container, [$commandName => $serviceId]))->get($commandName);
+	}
+
+	public function testTheLoaderHasACommand()
+	{
+		$commandName = 'test:loader';
+		$serviceId   = 'test.loader';
+
+		$this->container->expects($this->once())
+			->method('has')
+			->with($serviceId)
+			->willReturn(true);
+
+		$this->assertTrue(
+			(new WritableContainerLoader($this->container, [$commandName => $serviceId]))->has($commandName)
+		);
+	}
+}


### PR DESCRIPTION
### Summary of Changes

To register commands to the console application, the best practice is to have a console plugin catching the `Joomla\Application\ApplicationEvents::BEFORE_EXECUTE` event and adding the command via `$event->getApplication()->addCommand()`.  However, this comes with a performance penalty of having instantiated a `Joomla\Console\Command\AbstractCommand` class object.  This issue is in part caused by the design of `Joomla\Console\Loader\LoaderInterface` which in essence specifies a read-only API once the loader is instantiated, which is suitable for the environments that Symfony applications are built for (and where the `joomla/console` package design came from, in addition to internally using it to the extent practical) or less dynamic Joomla! Framework applications.  This read-only API isn't a great fit for the CMS environment.

To bypass this performance penalty, a new `Joomla\CMS\Console\Loader\WritableLoaderInterface` is introduced with a `Joomla\CMS\Console\Loader\WritableContainerLoader` implementation of it, and the console application adjusted to use this writable loader.  This means plugins would now be able to add the command to the lazy loader and have it instantiated as late as possible as a container service instead of requiring the command class always be instantiated (and yes, even though this is a CLI thing, you still don't want a performance trade-off of potentially instantiating 50 unused classes).

### Testing Instructions

Running `php cli/joomla.php` with this patch applied still works.  Unit tests for the new class pass.  If creating a console plugin to add a command, this snippet is the gist of what you'd do to register a command.

```php
use Joomla\Application\Event\ApplicationEvent;
use Joomla\CMS\Console\Loader\WritableLoaderInterface;
use Joomla\CMS\Factory;
use Joomla\DI\Container;

public function onBeforeExecute(ApplicationEvent $event): void
{
    $serviceId = 'my.command';

    Factory::getContainer()->share(
        $serviceId,
        function (Container $container) {
            // do stuff to create command class and return it
        },
        true
    );

    Factory::getContainer()->get(WritableLoaderInterface::class)->add('my:command', $serviceId);
}
```