### PR TITLE
[4.0] Correcting com_fields created and modified dates

### DIFF
--- a/administrator/components/com_fields/Table/FieldTable.php
+++ b/administrator/components/com_fields/Table/FieldTable.php
@@ -150,7 +150,7 @@ class FieldTable extends Table
 
 			if (!(int) $this->modified_time)
 			{
-				$this->modified_time = $date->toSql();
+				$this->modified_time = $this->_db->getNullDate();
 			}
 
 			if (empty($this->created_user_id))

--- a/administrator/components/com_fields/Table/GroupTable.php
+++ b/administrator/components/com_fields/Table/GroupTable.php
@@ -107,6 +107,11 @@ class GroupTable extends Table
 				$this->created = $date->toSql();
 			}
 
+			if (!(int) $this->modified)
+			{
+				$this->modified = $date->toSql();
+			}
+
 			if (empty($this->created_by))
 			{
 				$this->created_by = $user->get('id');

--- a/administrator/components/com_fields/Table/GroupTable.php
+++ b/administrator/components/com_fields/Table/GroupTable.php
@@ -109,7 +109,7 @@ class GroupTable extends Table
 
 			if (!(int) $this->modified)
 			{
-				$this->modified = $date->toSql();
+				$this->modified = $this->_db->getNullDate();
 			}
 
 			if (empty($this->created_by))

--- a/administrator/components/com_fields/forms/field.xml
+++ b/administrator/components/com_fields/forms/field.xml
@@ -122,11 +122,12 @@
 
 		<field
 			name="created_time"
-			type="text"
+			type="calendar"
 			label="JGLOBAL_CREATED_DATE"
-			class="readonly"
-			filter="unset"
-			readonly="true"
+			translateformat="true"
+			showtime="true"
+			size="22"
+			filter="user_utc"
 		/>
 
 		<field
@@ -140,11 +141,14 @@
 
 		<field
 			name="modified_time"
-			type="text"
+			type="calendar"
 			label="JGLOBAL_FIELD_MODIFIED_LABEL"
 			class="readonly"
-			filter="unset"
+			translateformat="true"
+			showtime="true"
+			size="22"
 			readonly="true"
+			filter="user_utc"
 		/>
 
 		<field

--- a/administrator/components/com_fields/forms/group.xml
+++ b/administrator/components/com_fields/forms/group.xml
@@ -74,11 +74,14 @@
 
 		<field
 			name="modified"
-			type="text"
+			type="calendar"
 			label="JGLOBAL_FIELD_MODIFIED_LABEL"
+			translateformat="true"
+			showtime="true"
+			size="22"
 			class="readonly"
-			filter="unset"
 			readonly="true"
+			filter="user_utc"
 		/>
 
 		<field


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/24202

### Summary of Changes
Correcting error when creating a new fieldgroup
`Error
Save failed with the following error: Incorrect datetime value: '' for column 'modified' at row 1`

Normalize date fields for Field groups and Fields to use calendar and therefore allow translate format and user_utc, jalali date, etc. ,  on the model of 3.x
Corrected missing code in GroupTable.php (which created the original error)

### Testing Instructions
Create a new Field Group. **No more error after patch**
Create a new Field. Look at the created date field.


### Expected result
Both field groups and fields are created fine.
For fields the created date is now using calendar.
<img width="561" alt="Screen Shot 2019-03-18 at 17 44 01" src="https://user-images.githubusercontent.com/869724/54547265-afd64f00-49a5-11e9-8e32-71379255cb3a.png">



@bahl24
@SharkyKZ 
@nitesh-solanki 