### PR TITLE
[3.9] Wrong language string. Menu item type content/featured

### DIFF
--- a/components/com_content/views/featured/tmpl/default.xml
+++ b/components/com_content/views/featured/tmpl/default.xml
@@ -371,7 +371,7 @@
 				name="show_item_navigation" 
 				type="list"
 				label="JGLOBAL_SHOW_NAVIGATION_LABEL"
-				description="JGLOBAL_SHOW_PUBLISH_DATE_DESC"
+				description="JGLOBAL_SHOW_NAVIGATION_DESC"
 				useglobal="true"
 				class="chzn-color"
 				>


### PR DESCRIPTION
### Summary of Changes
- Exchanged language string for field show_item_navigation

### Testing Instructions
Code review (it's obvious) or:
- Go into a menu item of type `Articles » Featured Articles` > Tabulator `Options`
- Hover the label of `Show Navigation` to see the description.

### Expected result
- Correct one

### Actual result
- Wrong one
