### PR TITLE
Change alert type for mail disabled notification

### DIFF
--- a/libraries/src/Mail/Mail.php
+++ b/libraries/src/Mail/Mail.php
@@ -146,7 +146,7 @@ class Mail extends \PHPMailer
 			return $result;
 		}
 
-		Factory::getApplication()->enqueueMessage(\JText::_('JLIB_MAIL_FUNCTION_OFFLINE'));
+		Factory::getApplication()->enqueueMessage(\JText::_('JLIB_MAIL_FUNCTION_OFFLINE'), 'warning');
 
 		return false;
 	}


### PR DESCRIPTION
Pull Request for Issue #22960 .

### Summary of Changes
Change alert type from message to warning for mail disabled notification.


### Testing Instructions
Go to System > Global Configuration > Server
Set `Send Mail` to No.
Click `Send Test Mail` button.


### Expected result
Warning alert


### Actual result
Message alert