### PR TITLE
[4.0] Replace deprecated Joomla\DI\Container::exists() calls

### DIFF
--- a/libraries/joomla/base/adapter.php
+++ b/libraries/joomla/base/adapter.php
@@ -168,7 +168,7 @@ class JAdapter extends JObject
 		}
 
 		// Check for a possible service from the container otherwise manually instantiate the class
-		if (Factory::getContainer()->exists($class))
+		if (Factory::getContainer()->has($class))
 		{
 			$this->_adapters[$name] = Factory::getContainer()->get($class);
 		}

--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -406,7 +406,7 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
 				$container = Factory::getContainer();
 			}
 
-			if ($container->exists($classname))
+			if ($container->has($classname))
 			{
 				static::$instances[$name] = $container->get($classname);
 			}

--- a/libraries/src/Factory.php
+++ b/libraries/src/Factory.php
@@ -395,7 +395,7 @@ abstract class Factory
 
 		if (!self::$database)
 		{
-			if (self::getContainer()->exists('DatabaseDriver'))
+			if (self::getContainer()->has('DatabaseDriver'))
 			{
 				self::$database = self::getContainer()->get('DatabaseDriver');
 			}

--- a/libraries/src/Installer/Installer.php
+++ b/libraries/src/Installer/Installer.php
@@ -2412,7 +2412,7 @@ class Installer extends \JAdapter
 		$options['type'] = $adapter;
 
 		// Check for a possible service from the container otherwise manually instantiate the class
-		if (Factory::getContainer()->exists($class))
+		if (Factory::getContainer()->has($class))
 		{
 			return Factory::getContainer()->get($class);
 		}

--- a/libraries/src/MVC/Controller/BaseController.php
+++ b/libraries/src/MVC/Controller/BaseController.php
@@ -339,7 +339,7 @@ class BaseController implements ControllerInterface
 		}
 
 		// Check for a possible service from the container otherwise manually instantiate the class
-		if (Factory::getContainer()->exists($class))
+		if (Factory::getContainer()->has($class))
 		{
 			self::$instance = Factory::getContainer()->get($class);
 		}

--- a/libraries/src/Router/Router.php
+++ b/libraries/src/Router/Router.php
@@ -110,7 +110,7 @@ class Router
 			}
 
 			// Check for a possible service from the container otherwise manually instantiate the class
-			if (Factory::getContainer()->exists($classname))
+			if (Factory::getContainer()->has($classname))
 			{
 				self::$instances[$client] = Factory::getContainer()->get($classname);
 			}

--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -312,7 +312,7 @@ abstract class Table extends CMSObject implements \JTableInterface, DispatcherAw
 		$db = $config['dbo'] ?? Factory::getDbo();
 
 		// Check for a possible service from the container otherwise manually instantiate the class
-		if (Factory::getContainer()->exists($tableClass))
+		if (Factory::getContainer()->has($tableClass))
 		{
 			return Factory::getContainer()->get($tableClass);
 		}


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Replace deprecated `Joomla\DI\Container::exists()` calls with `Joomla\DI\Container::has()`.

### Testing Instructions

Code review.

### Documentation Changes Required
No.
