### PR TITLE
[4.0] mod_languages php notice on error page

### DIFF
--- a/modules/mod_languages/Helper/LanguagesHelper.php
+++ b/modules/mod_languages/Helper/LanguagesHelper.php
@@ -75,14 +75,8 @@ abstract class LanguagesHelper
 			}
 			else
 			{
-				// Load component associations
-				if (!defined('JPATH_COMPONENT_SITE'))
-				{
-					define('JPATH_COMPONENT_SITE', JPATH_SITE . '/components/' . $app->input->get('option'));
-				}
-
 				$class = str_replace('com_', '', $app->input->get('option')) . 'HelperAssociation';
-				\JLoader::register($class, JPATH_COMPONENT_SITE . '/helpers/association.php');
+				\JLoader::register($class, JPATH_SITE . '/components/' . $app->input->get('option') . '/helpers/association.php');
 
 				if (class_exists($class) && is_callable(array($class, 'getAssociations')))
 				{

--- a/modules/mod_languages/Helper/LanguagesHelper.php
+++ b/modules/mod_languages/Helper/LanguagesHelper.php
@@ -76,6 +76,11 @@ abstract class LanguagesHelper
 			else
 			{
 				// Load component associations
+				if (!defined('JPATH_COMPONENT_SITE'))
+				{
+					define('JPATH_COMPONENT_SITE', JPATH_SITE . '/components/' . $app->input->get('option'));
+				}	
+
 				$class = str_replace('com_', '', $app->input->get('option')) . 'HelperAssociation';
 				\JLoader::register($class, JPATH_COMPONENT_SITE . '/helpers/association.php');
 

--- a/modules/mod_languages/Helper/LanguagesHelper.php
+++ b/modules/mod_languages/Helper/LanguagesHelper.php
@@ -79,7 +79,7 @@ abstract class LanguagesHelper
 				if (!defined('JPATH_COMPONENT_SITE'))
 				{
 					define('JPATH_COMPONENT_SITE', JPATH_SITE . '/components/' . $app->input->get('option'));
-				}	
+				}
 
 				$class = str_replace('com_', '', $app->input->get('option')) . 'HelperAssociation';
 				\JLoader::register($class, JPATH_COMPONENT_SITE . '/helpers/association.php');


### PR DESCRIPTION
If you have the language switcher module published and you go to a 404 error page then you will see this
![image](https://user-images.githubusercontent.com/1296369/54719793-b277a680-4b55-11e9-88b5-b96f90a7f419.png)

Apply the patch and the php warning is gone
