### PR TITLE
[4.0] Redirect to CPanel when module in cpanel position has been edited

### DIFF
--- a/administrator/components/com_modules/Controller/ModuleController.php
+++ b/administrator/components/com_modules/Controller/ModuleController.php
@@ -81,6 +81,11 @@ class ModuleController extends FormController
 		$this->app->setUserState('com_modules.add.module.extension_id', null);
 		$this->app->setUserState('com_modules.add.module.params', null);
 
+		if ($return = $this->input->get('return', '', 'BASE64'))
+		{
+			$this->app->redirect(base64_decode($return));
+		}
+
 		return $result;
 	}
 

--- a/administrator/components/com_modules/tmpl/module/edit.php
+++ b/administrator/components/com_modules/tmpl/module/edit.php
@@ -194,6 +194,7 @@ $tmpl    = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=c
 		<?php echo HTMLHelper::_('uitab.endTabSet'); ?>
 
 		<input type="hidden" name="task" value="">
+		<input type="hidden" name="return" value="<?php echo $input->getCmd('return'); ?>">
 		<?php echo HTMLHelper::_('form.token'); ?>
 		<?php echo $this->form->getInput('module'); ?>
 		<?php echo $this->form->getInput('client_id'); ?>

--- a/administrator/templates/atum/html/modules.php
+++ b/administrator/templates/atum/html/modules.php
@@ -12,6 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
+use Joomla\CMS\Uri\Uri;
 
 /**
  * This is a file to add template specific chrome to module rendering.  To use it you would
@@ -72,12 +73,15 @@ function modChrome_well($module, &$params, &$attribs)
 
 		if ($canEdit)
 		{
+			$uri = Uri::getInstance();
+			$url = Route::_('index.php?option=com_modules&task=module.edit&id=' . $id . '&return=' . base64_encode($uri));
+
 			$dropdownPosition = Factory::getLanguage()->isRTL() ? 'left' : 'right';
 
 			echo '<div class="module-actions dropdown">';
 			echo '<a data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" id="dropdownMenuButton-' . $id . '"><span class="fa fa-cog"><span class="sr-only">' . Text::_('JACTION_EDIT') . ' ' . $module->title . '</span></span></a>';
 			echo '<div class="dropdown-menu dropdown-menu-' . $dropdownPosition . '" aria-labelledby="dropdownMenuButton-' . $id . '">';
-			echo '<a class="dropdown-item" href="' . Route::_('index.php?option=com_modules&task=module.edit&id=' . $id) . '">' . Text::_('JACTION_EDIT') . '</a>';
+			echo '<a class="dropdown-item" href="' . $url . '">' . Text::_('JACTION_EDIT') . '</a>';
 			echo '<a class="dropdown-item unpublish-module" data-module-id="' . $id . '">' . Text::_('JACTION_UNPUBLISH') . '</a>';
 			echo '</div>';
 			echo '</div>';
@@ -120,12 +124,15 @@ function modChrome_body($module, &$params, &$attribs)
 
 		if ($canEdit)
 		{
+			$uri = Uri::getInstance();
+			$url = Route::_('index.php?option=com_modules&task=module.edit&id=' . $id . '&return=' . base64_encode($uri));
+
 			$dropdownPosition = Factory::getLanguage()->isRTL() ? 'left' : 'right';
 
 			echo '<div class="module-actions dropdown">';
 			echo '<a data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" id="dropdownMenuButton-' . $id . '"><span class="fa fa-cog"><span class="sr-only">' . Text::_('JACTION_EDIT') . ' ' . $module->title . '</span></span></a>';
 			echo '<div class="dropdown-menu dropdown-menu-' . $dropdownPosition . '" aria-labelledby="dropdownMenuButton-' . $id . '">';
-			echo '<a class="dropdown-item" href="' . Route::_('index.php?option=com_modules&task=module.edit&id=' . $id) . '">' . Text::_('JACTION_EDIT') . '</a>';
+			echo '<a class="dropdown-item" href="' . $url . '">' . Text::_('JACTION_EDIT') . '</a>';
 			echo '<a class="dropdown-item unpublish-module" data-module-id="' . $id . '">' . Text::_('JACTION_UNPUBLISH') . '</a>';
 			echo '</div>';
 			echo '</div>';


### PR DESCRIPTION
Completing https://github.com/joomla/joomla-cms/pull/23934
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/24109

### Summary of Changes
Let's redirect to CPanel when a module has been edited from CPanel

### Testing Instructions
Clean 4.0 branch install.
In CPanel edit a module via the dropdown

<img width="701" alt="Screen Shot 2019-03-21 at 07 48 29" src="https://user-images.githubusercontent.com/869724/54736938-dbc42100-4bad-11e9-9c0e-c2745f220cf6.png">

The module edit page is displayed

### Before patch
Save and Close or Cancel redirects to the Admin Module Manager

### After patch
The redirection is to the CPanel

Note: There may be other places in core where a redirect of this type should be done.

@chmst @C-Lodder 

