### PR TITLE
[4.0] Get document from application in HTMLHelper

### DIFF
--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -671,7 +671,7 @@ abstract class HTMLHelper
 		}
 
 		// If inclusion is required
-		$document = Factory::getDocument();
+		$document = Factory::getApplication()->getDocument();
 
 		foreach ($includes as $include)
 		{
@@ -730,7 +730,7 @@ abstract class HTMLHelper
 		}
 
 		// If inclusion is required
-		$document = Factory::getDocument();
+		$document = Factory::getApplication()->getDocument();
 
 		foreach ($includes as $include)
 		{
@@ -768,8 +768,8 @@ abstract class HTMLHelper
 		// Script core.js is responsible for the polyfills and the async loading of the web components
 		static::_('behavior.core');
 
-		$version      = '';
-		$mediaVersion = Factory::getDocument()->getMediaVersion();
+		$document = Factory::getApplication()->getDocument();
+		$version  = '';
 
 		// Add the css if exists
 		self::_('stylesheet', str_replace('.js', '.css', $file), $options);
@@ -791,7 +791,7 @@ abstract class HTMLHelper
 		{
 			if ($options['version'] === 'auto')
 			{
-				$version = '?' . $mediaVersion;
+				$version = '?' . $document->getMediaVersion();
 			}
 			else
 			{
@@ -799,10 +799,11 @@ abstract class HTMLHelper
 			}
 		}
 
+		$components = $document->getScriptOptions('webcomponents');
+
 		foreach ($includes as $include)
 		{
 			$potential = $include . ((strpos($include, '?') === false) ? $version : '');
-			$components = Factory::getDocument()->getScriptOptions('webcomponents');
 
 			if (in_array($potential, $components))
 			{
@@ -810,8 +811,9 @@ abstract class HTMLHelper
 			}
 
 			$components[] = $potential;
-			Factory::getDocument()->addScriptOptions('webcomponents', $components);
 		}
+
+		$document->addScriptOptions('webcomponents', $components);
 	}
 
 	/**
@@ -1067,7 +1069,7 @@ abstract class HTMLHelper
 	{
 		$tag       = Factory::getLanguage()->getTag();
 		$calendar  = Factory::getLanguage()->getCalendar();
-		$direction = strtolower(Factory::getDocument()->getDirection());
+		$direction = strtolower(Factory::getApplication()->getDocument()->getDirection());
 
 		// Get the appropriate file for the current language date helper
 		$helperPath = 'system/fields/calendar-locales/date/gregorian/date-helper.min.js';

--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -768,9 +768,6 @@ abstract class HTMLHelper
 		// Script core.js is responsible for the polyfills and the async loading of the web components
 		static::_('behavior.core');
 
-		$document = Factory::getApplication()->getDocument();
-		$version  = '';
-
 		// Add the css if exists
 		self::_('stylesheet', str_replace('.js', '.css', $file), $options);
 
@@ -786,6 +783,9 @@ abstract class HTMLHelper
 		{
 			return;
 		}
+
+		$document = Factory::getApplication()->getDocument();
+		$version  = '';
 
 		if (isset($options['version']))
 		{


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

`Joomla\CMS\Factory::getDocument()` is deprecated, get document from application instead.

### Testing Instructions

Navigate the frontent and baclend. Check that scripts, stylesheets and webcomponents continue to be loaded properly.