### PR TITLE
[4.0] [com_modules] Batch language broken

### DIFF
--- a/administrator/components/com_modules/tmpl/modules/default_batch_body.php
+++ b/administrator/components/com_modules/tmpl/modules/default_batch_body.php
@@ -41,24 +41,18 @@ HTMLHelper::_('webcomponent', 'system/fields/joomla-field-fancy-select.min.js', 
 <div class="container">
 	<div class="row">
 		<?php if ($clientId != 1) : ?>
-            <div class="form-group col-md-6">
-                <div class="controls">
+			<div class="form-group col-md-6">
+				<div class="controls">
 					<?php echo LayoutHelper::render('joomla.html.batch.language', array()); ?>
-                </div>
-            </div>
-		<?php elseif ($clientId == 1 && ModuleHelper::isAdminMultilang()) : ?>
-            <div class="form-group col-md-6">
-                <div class="controls">
-					<?php echo LayoutHelper::render('joomla.html.batch.adminlanguage', array()); ?>
-                </div>
-            </div>
-		<?php endif; ?>
-
-        <div class="form-group col-md-6">
-			<div class="controls">
-				<?php echo LayoutHelper::render('joomla.html.batch.language', []); ?>
+				</div>
 			</div>
-		</div>
+		<?php elseif ($clientId == 1 && ModuleHelper::isAdminMultilang()) : ?>
+			<div class="form-group col-md-6">
+				<div class="controls">
+					<?php echo LayoutHelper::render('joomla.html.batch.adminlanguage', array()); ?>
+				</div>
+			</div>
+		<?php endif; ?>
 		<div class="form-group col-md-6">
 			<div class="controls">
 				<?php echo LayoutHelper::render('joomla.html.batch.access', []); ?>


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/24264

### Summary of Changes
Taking of the duplicate div displaying the Language field when using batch language for site modules.
Correcting cs (spaces instead of tabs)

### Testing Instructions
Load Modules Manager. Select a module. Click on the Batch button.

### Before patch
<img width="845" alt="Screen Shot 2019-03-21 at 09 11 39" src="https://user-images.githubusercontent.com/869724/54739716-69f1d480-4bb9-11e9-9b47-d5ef363a6c67.png">

### After patch
<img width="845" alt="Screen Shot 2019-03-21 at 09 10 35" src="https://user-images.githubusercontent.com/869724/54739738-79711d80-4bb9-11e9-931d-3ef9b8e1a2e8.png">

