### PR TITLE
[4.0] [a11y] Remove redundant title from templates

### DIFF
--- a/templates/cassiopeia/offline.php
+++ b/templates/cassiopeia/offline.php
@@ -53,7 +53,7 @@ elseif ($this->params->get('siteTitle'))
 }
 else
 {
-	$logo = '<span class="site-title" title="' . $sitename . '">' . $sitename . '</span>';
+	$logo = '<span class="site-title">' . $sitename . '</span>';
 }
 ?>
 <!DOCTYPE html>
@@ -96,14 +96,14 @@ else
 				<form action="<?php echo Route::_('index.php', true); ?>" method="post" id="form-login">
 					<fieldset>
 						<label for="username"><?php echo Text::_('JGLOBAL_USERNAME'); ?></label>
-						<input name="username" class="form-control" id="username" type="text" title="<?php echo Text::_('JGLOBAL_USERNAME'); ?>">
+						<input name="username" class="form-control" id="username" type="text">
 
 						<label for="password"><?php echo Text::_('JGLOBAL_PASSWORD'); ?></label>
-						<input name="password" class="form-control" id="password" type="password" title="<?php echo Text::_('JGLOBAL_PASSWORD'); ?>">
+						<input name="password" class="form-control" id="password" type="password">
 
 						<?php if (count($twofactormethods) > 1) : ?>
 						<label for="secretkey"><?php echo Text::_('JGLOBAL_SECRETKEY'); ?></label>
-						<input name="secretkey" class="form-control" id="secretkey" type="text" title="<?php echo Text::_('JGLOBAL_SECRETKEY'); ?>">
+						<input name="secretkey" class="form-control" id="secretkey" type="text">
 						<?php endif; ?>
 
 						<input type="submit" name="Submit" class="btn btn-primary" value="<?php echo Text::_('JLOGIN'); ?>">

--- a/templates/system/error.php
+++ b/templates/system/error.php
@@ -55,7 +55,7 @@ $this->setTitle($this->error->getCode() . ' - ' . htmlspecialchars($this->error-
 			</ol>
 			<p><strong><?php echo JText::_('JERROR_LAYOUT_PLEASE_TRY_ONE_OF_THE_FOLLOWING_PAGES'); ?></strong></p>
 			<ul>
-				<li><a href="<?php echo JUri::root(true); ?>/index.php" title="<?php echo JText::_('JERROR_LAYOUT_GO_TO_THE_HOME_PAGE'); ?>"><?php echo JText::_('JERROR_LAYOUT_HOME_PAGE'); ?></a></li>
+				<li><a href="<?php echo JUri::root(true); ?>/index.php"><?php echo JText::_('JERROR_LAYOUT_HOME_PAGE'); ?></a></li>
 			</ul>
 			<p><?php echo JText::_('JERROR_LAYOUT_PLEASE_CONTACT_THE_SYSTEM_ADMINISTRATOR'); ?></p>
 			<div id="techinfo">


### PR DESCRIPTION
The title attribute is generally not very accessible. Keyboard users and touch screen users will never see it.

It is particularly useless to add a title which is the same as other text already present as that can result in a screen reader announcing the same text twice.

This PR removes the redundant title attribute where the same text is already present.
