### PR TITLE
[4.0] [a11y] Remove redundant title from layouts and plugins

### DIFF
--- a/administrator/components/com_media/layouts/toolbar/create-folder.php
+++ b/administrator/components/com_media/layouts/toolbar/create-folder.php
@@ -14,5 +14,5 @@ use Joomla\CMS\Language\Text;
 $title = Text::_('COM_MEDIA_CREATE_NEW_FOLDER');
 ?>
 <button class="btn btn-sm btn-info" onclick="MediaManager.Event.fire('onClickCreateFolder');">
-    <span class="icon-folder-close" title="<?php echo $title; ?>"></span> <?php echo $title; ?>
+    <span class="icon-folder-close"></span> <?php echo $title; ?>
 </button>

--- a/administrator/components/com_media/layouts/toolbar/delete.php
+++ b/administrator/components/com_media/layouts/toolbar/delete.php
@@ -14,5 +14,5 @@ use Joomla\CMS\Language\Text;
 $title = Text::_('JTOOLBAR_DELETE');
 ?>
 <button id="mediaDelete" class="btn btn-sm btn-danger" onclick="MediaManager.Event.fire('onClickDelete');">
-    <span class="icon-delete" title="<?php echo $title; ?>"></span> <?php echo $title; ?>
+    <span class="icon-delete"></span> <?php echo $title; ?>
 </button>

--- a/administrator/components/com_media/layouts/toolbar/upload.php
+++ b/administrator/components/com_media/layouts/toolbar/upload.php
@@ -14,5 +14,5 @@ use Joomla\CMS\Language\Text;
 $title = Text::_('JTOOLBAR_UPLOAD');
 ?>
 <button class="btn btn-sm btn-success" onclick="MediaManager.Event.fire('onClickUpload');">
-	<span class="icon-upload" title="<?php echo $title; ?>"></span> <?php echo $title; ?>
+	<span class="icon-upload"></span> <?php echo $title; ?>
 </button>

--- a/administrator/components/com_modules/layouts/toolbar/cancelselect.php
+++ b/administrator/components/com_modules/layouts/toolbar/cancelselect.php
@@ -13,6 +13,6 @@ use Joomla\CMS\Language\Text;
 
 $text = Text::_('JTOOLBAR_CANCEL');
 ?>
-<button onclick="location.href='index.php?option=com_modules'" class="btn btn-sm btn-danger" title="<?php echo $text; ?>">
+<button onclick="location.href='index.php?option=com_modules'" class="btn btn-sm btn-danger">
 	<span class="icon-cancel" aria-hidden="true"></span> <?php echo $text; ?>
 </button>

--- a/layouts/joomla/form/field/contenthistory.php
+++ b/layouts/joomla/form/field/contenthistory.php
@@ -63,7 +63,7 @@ echo HTMLHelper::_(
 );
 
 ?>
-<button type="button" onclick="document.getElementById('versionsModal').open()" class="btn btn-secondary" data-toggle="modal" title="<?php echo $label; ?>">
+<button type="button" onclick="document.getElementById('versionsModal').open()" class="btn btn-secondary" data-toggle="modal">
 	<span class="fa fa-code-fork" aria-hidden="true"></span>
 	<?php echo $label; ?>
 </button>

--- a/layouts/joomla/pagination/link.php
+++ b/layouts/joomla/pagination/link.php
@@ -64,7 +64,6 @@ if ($displayData['active'])
 	}
 
 	$class = 'active';
-	$title = 'title="' . $item->text . '"';
 	$onClick = 'document.adminForm.' . $item->prefix . 'limitstart.value=' . ($item->base > 0 ? $item->base : '0') . '; Joomla.submitform();return false;';
 }
 else
@@ -74,7 +73,7 @@ else
 ?>
 <?php if ($displayData['active']) : ?>
 	<li class="<?php echo $class; ?> page-link">
-		<a <?php echo $title; ?> aria-label="<?php echo $aria; ?>" href="#" onclick="<?php echo $onClick; ?>">
+		<a aria-label="<?php echo $aria; ?>" href="#" onclick="<?php echo $onClick; ?>">
 			<?php echo $display; ?>
 		</a>
 	</li>

--- a/layouts/joomla/searchtools/default/bar.php
+++ b/layouts/joomla/searchtools/default/bar.php
@@ -43,7 +43,7 @@ $filters = $data['view']->filterForm->getGroup('filter');
 					</label>
 					<?php echo $filters['filter_search']->input; ?>
 					<span class="input-group-append">
-						<button type="submit" class="btn btn-primary hasTooltip" aria-label="<?php echo Text::_('JSEARCH_FILTER_SUBMIT'); ?>">
+						<button type="submit" class="btn btn-primary" aria-label="<?php echo Text::_('JSEARCH_FILTER_SUBMIT'); ?>">
 							<span class="fa fa-search" aria-hidden="true"></span>
 						</button>
 					</span>

--- a/layouts/joomla/searchtools/default/bar.php
+++ b/layouts/joomla/searchtools/default/bar.php
@@ -49,7 +49,7 @@ $filters = $data['view']->filterForm->getGroup('filter');
 					</span>
 				</div>
 			</div>
-			<button type="button" class="btn btn-primary hasTooltip js-stools-btn-clear mr-2">
+			<button type="button" class="btn btn-primary js-stools-btn-clear mr-2">
 				<?php echo Text::_('JSEARCH_FILTER_CLEAR'); ?>
 			</button>
 			<div class="btn-group">

--- a/layouts/joomla/searchtools/default/bar.php
+++ b/layouts/joomla/searchtools/default/bar.php
@@ -9,7 +9,6 @@
 
 defined('JPATH_BASE') or die;
 
-use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\Registry\Registry;
 
@@ -44,13 +43,13 @@ $filters = $data['view']->filterForm->getGroup('filter');
 					</label>
 					<?php echo $filters['filter_search']->input; ?>
 					<span class="input-group-append">
-						<button type="submit" class="btn btn-primary hasTooltip" title="<?php echo HTMLHelper::_('tooltipText', 'JSEARCH_FILTER_SUBMIT'); ?>"  aria-label="<?php echo Text::_('JSEARCH_FILTER_SUBMIT'); ?>">
+						<button type="submit" class="btn btn-primary hasTooltip" aria-label="<?php echo Text::_('JSEARCH_FILTER_SUBMIT'); ?>">
 							<span class="fa fa-search" aria-hidden="true"></span>
 						</button>
 					</span>
 				</div>
 			</div>
-			<button type="button" class="btn btn-primary hasTooltip js-stools-btn-clear mr-2" title="<?php echo HTMLHelper::_('tooltipText', 'JSEARCH_FILTER_CLEAR'); ?>">
+			<button type="button" class="btn btn-primary hasTooltip js-stools-btn-clear mr-2">
 				<?php echo Text::_('JSEARCH_FILTER_CLEAR'); ?>
 			</button>
 			<div class="btn-group">

--- a/layouts/joomla/tinymce/togglebutton.php
+++ b/layouts/joomla/tinymce/togglebutton.php
@@ -18,7 +18,6 @@ $name = $displayData;
 	<div class="btn-group">
 		<button type="button" class="btn btn-secondary" href="#"
 			onclick="tinyMCE.execCommand('mceToggleEditor', false, '<?php echo $name; ?>');return false;"
-			title="<?php echo Text::_('PLG_TINY_BUTTON_TOGGLE_EDITOR'); ?>"
 		>
 			<span class="icon-eye" aria-hidden="true"></span>
 			<?php echo Text::_('PLG_TINY_BUTTON_TOGGLE_EDITOR'); ?>

--- a/layouts/joomla/toolbar/modal.php
+++ b/layouts/joomla/toolbar/modal.php
@@ -48,7 +48,7 @@ echo HTMLHelper::_('bootstrap.renderModal',
 	]
 );
 ?>
-<button<?php echo $id; ?> onclick="document.getElementById('modal_<?php echo $selector; ?>').open()" class="<?php echo $class; ?>" data-toggle="modal" title="<?php echo $text; ?>">
+<button<?php echo $id; ?> onclick="document.getElementById('modal_<?php echo $selector; ?>').open()" class="<?php echo $class; ?>" data-toggle="modal">
 	<span class="<?php echo $icon; ?>" aria-hidden="true"></span>
 	<?php echo $text; ?>
 </button>

--- a/layouts/joomla/toolbar/versions.php
+++ b/layouts/joomla/toolbar/versions.php
@@ -51,7 +51,6 @@ echo HTMLHelper::_(
 <button<?php echo $id ?? ''; ?>
 	onclick="document.getElementById('versionsModal').open()"
 	class="btn btn-primary"
-	data-toggle="modal"
-	title="<?php echo $title; ?>">
+	data-toggle="modal">
 	<span class="fa fa-code-fork" aria-hidden="true"></span><?php echo $title; ?>
 </button>

--- a/plugins/user/profile/field/tos.php
+++ b/plugins/user/profile/field/tos.php
@@ -64,7 +64,6 @@ class JFormFieldTos extends \Joomla\CMS\Form\Field\RadioField
 		// If a description is specified, use it to build a tooltip.
 		if (!empty($this->description))
 		{
-			$label .= ' title="' . htmlspecialchars(trim($text, ':'), ENT_COMPAT, 'UTF-8') . '"';
 			$label .= ' data-content="' . htmlspecialchars(
 				$this->translateDescription ? Text::_($this->description) : $this->description,
 				ENT_COMPAT,


### PR DESCRIPTION
The title attribute is generally not very accessible. Keyboard users and touch screen users will never see it.

It is particularly useless to add a title which is the same as other text already present as that can result in a screen reader announcing the same text twice.

This PR removes the redundant title attribute where the same text is already displayed

NOTE this is just a first pass at removing the low hanging fruit and a further pr will be needed when the tooltips are reviewed
