### PR TITLE
[4.0] Status Module: Edit Account redirection

### DIFF
--- a/administrator/components/com_users/Controller/UserController.php
+++ b/administrator/components/com_users/Controller/UserController.php
@@ -58,6 +58,27 @@ class UserController extends FormController
 	}
 
 	/**
+	 * Override parent cancel to redirect when using status edit account.
+	 *
+	 * @param   string  $key  The name of the primary key of the URL variable.
+	 *
+	 * @return  boolean  True if access level checks pass, false otherwise.
+	 *
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public function cancel($key = null)
+	{
+		$result = parent::cancel();
+
+		if ($return = $this->input->get('return', '', 'BASE64'))
+		{
+			$this->app->redirect(base64_decode($return));
+		}
+
+		return $result;
+	}
+
+	/**
 	 * Method to run batch operations.
 	 *
 	 * @param   object  $model  The model.

--- a/administrator/components/com_users/tmpl/user/edit.php
+++ b/administrator/components/com_users/tmpl/user/edit.php
@@ -9,6 +9,7 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
@@ -17,6 +18,8 @@ use Joomla\Component\Users\Administrator\Helper\UsersHelper;
 
 HTMLHelper::_('behavior.formvalidator');
 HTMLHelper::_('script', 'com_users/admin-users-user.min.js', array('version' => 'auto', 'relative' => true));
+
+$input = Factory::getApplication()->input;
 
 // Get the form fieldsets.
 $fieldsets = $this->form->getFieldsets();
@@ -105,5 +108,6 @@ $this->useCoreUI = true;
 	</fieldset>
 
 	<input type="hidden" name="task" value="">
+	<input type="hidden" name="return" value="<?php echo $input->getCmd('return'); ?>">
 	<?php echo HTMLHelper::_('form.token'); ?>
 </form>

--- a/administrator/modules/mod_status/tmpl/default.php
+++ b/administrator/modules/mod_status/tmpl/default.php
@@ -97,7 +97,8 @@ $hideLinks = $app->input->getBool('hidemainmenu');
 						<span class="fa fa-user-o" aria-hidden="true"></span>
 						<?php echo $user->name; ?>
 					</div>
-					<?php $route = 'index.php?option=com_users&amp;task=user.edit&amp;id=' . $user->id; ?>
+					<?php $uri   = Uri::getInstance(); ?>
+					<?php $route = 'index.php?option=com_users&amp;task=user.edit&amp;id=' . $user->id . '&return=' . base64_encode($uri); ?>
 					<a class="dropdown-item" href="<?php echo Route::_($route); ?>">
 						<?php echo Text::_('MOD_STATUS_EDIT_ACCOUNT'); ?></a>
 					<a class="dropdown-item" href="<?php echo Route::_('index.php?option=com_login&task=logout&'

--- a/administrator/modules/mod_status/tmpl/default.php
+++ b/administrator/modules/mod_status/tmpl/default.php
@@ -98,7 +98,7 @@ $hideLinks = $app->input->getBool('hidemainmenu');
 						<?php echo $user->name; ?>
 					</div>
 					<?php $uri   = Uri::getInstance(); ?>
-					<?php $route = 'index.php?option=com_users&amp;task=user.edit&amp;id=' . $user->id . '&return=' . base64_encode($uri); ?>
+					<?php $route = 'index.php?option=com_users&task=user.edit&id=' . $user->id . '&return=' . base64_encode($uri); ?>
 					<a class="dropdown-item" href="<?php echo Route::_($route); ?>">
 						<?php echo Text::_('MOD_STATUS_EDIT_ACCOUNT'); ?></a>
 					<a class="dropdown-item" href="<?php echo Route::_('index.php?option=com_login&task=logout&'


### PR DESCRIPTION
### Summary of Changes
On the model of  https://github.com/joomla/joomla-cms/pull/24271
When using the `Edit Account` status link, redirecting to the page we come from.
Added a Cancel method in the UserController.

### Testing Instructions
Load for example the Articles manager
Click on the `Edit Account` in the dropdown.
<img width="317" alt="Screen Shot 2019-03-21 at 12 42 48" src="https://user-images.githubusercontent.com/869724/54750274-68370980-4bd7-11e9-9f32-968a5d0ffe4b.png">

Save & Close or Cancel


### Before patch
User is redirected to the Users manager


### After patch
User is redirected to the page he comes from.
In this example, the Articles manager.

