### PR TITLE
[4.0] [a11y] Remove redundant title from admin components

### DIFF
--- a/administrator/components/com_menus/Field/MenutypeField.php
+++ b/administrator/components/com_menus/Field/MenutypeField.php
@@ -90,8 +90,7 @@ class MenutypeField extends ListField
 		$link = Route::_('index.php?option=com_menus&view=menutypes&tmpl=component&client_id=' . $clientId . '&recordId=' . $recordId);
 		$html[] = '<span class="input-group"><input type="text" ' . $required . ' readonly="readonly" id="' . $this->id
 			. '" value="' . $value . '"' . $size . $class . '>';
-		$html[] = '<span class="input-group-append"><button type="button" data-target="#menuTypeModal" class="btn btn-primary" data-toggle="modal" title="'
-			. Text::_('JSELECT') . '">' . '<span class="icon-list icon-white" aria-hidden="true"></span> '
+		$html[] = '<span class="input-group-append"><button type="button" data-target="#menuTypeModal" class="btn btn-primary" data-toggle="modal"' . '<span class="icon-list icon-white" aria-hidden="true"></span> '
 			. Text::_('JSELECT') . '</button></span></span>';
 		$html[] = HTMLHelper::_(
 			'bootstrap.renderModal',

--- a/administrator/components/com_menus/Field/MenutypeField.php
+++ b/administrator/components/com_menus/Field/MenutypeField.php
@@ -90,7 +90,8 @@ class MenutypeField extends ListField
 		$link = Route::_('index.php?option=com_menus&view=menutypes&tmpl=component&client_id=' . $clientId . '&recordId=' . $recordId);
 		$html[] = '<span class="input-group"><input type="text" ' . $required . ' readonly="readonly" id="' . $this->id
 			. '" value="' . $value . '"' . $size . $class . '>';
-		$html[] = '<span class="input-group-append"><button type="button" data-target="#menuTypeModal" class="btn btn-primary" data-toggle="modal"' . '<span class="icon-list icon-white" aria-hidden="true"></span> '
+		$html[] = '<span class="input-group-append"><button type="button" data-target="#menuTypeModal" class="btn btn-primary" data-toggle="modal" '
+			. '<span class="icon-list icon-white" aria-hidden="true"></span> '
 			. Text::_('JSELECT') . '</button></span></span>';
 		$html[] = HTMLHelper::_(
 			'bootstrap.renderModal',

--- a/administrator/components/com_menus/tmpl/menutypes/default.php
+++ b/administrator/components/com_menus/tmpl/menutypes/default.php
@@ -30,7 +30,7 @@ HTMLHelper::_('script', 'com_menus/admin-item-modal.js', ['version' => 'auto', '
 				<?php foreach ($list as $title => $item) : ?>
 					<?php $menutype = array('id' => $this->recordId, 'title' => $item->type ?? $item->title, 'request' => $item->request); ?>
 					<?php $menutype = base64_encode(json_encode($menutype)); ?>
-					<a class="choose_type list-group-item list-group-item-action" href="#" title="<?php echo Text::_($item->description); ?>"
+					<a class="choose_type list-group-item list-group-item-action" href="#" 
 						onclick="Joomla.setMenuType('<?php echo $menutype; ?>', '<?php echo $tmpl; ?>')">
 						<div class="pr-2">
 							<?php echo $title; ?>

--- a/administrator/components/com_users/Service/HTML/Users.php
+++ b/administrator/components/com_users/Service/HTML/Users.php
@@ -63,7 +63,7 @@ class Users
 		$title = Text::_('COM_USERS_ADD_NOTE');
 
 		return '<a href="' . Route::_('index.php?option=com_users&task=note.add&u_id=' . (int) $userId)
-			. '" class="hasTooltip btn btn-secondary btn-sm" title="' . $title . '"><span class="fa fa-plus" aria-hidden="true">'
+			. '" class="hasTooltip btn btn-secondary btn-sm"><span class="fa fa-plus" aria-hidden="true">'
 			. '</span> ' . $title . '</a>';
 	}
 

--- a/administrator/components/com_users/tmpl/user/edit.php
+++ b/administrator/components/com_users/tmpl/user/edit.php
@@ -60,8 +60,7 @@ $this->useCoreUI = true;
 		<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'twofactorauth', Text::_('COM_USERS_USER_TWO_FACTOR_AUTH')); ?>
 		<div class="control-group">
 			<div class="control-label">
-				<label id="jform_twofactor_method-lbl" for="jform_twofactor_method" class="hasTooltip"
-					title="<?php echo '<strong>' . Text::_('COM_USERS_USER_FIELD_TWOFACTOR_LABEL') . '</strong>'; ?>">
+				<label id="jform_twofactor_method-lbl" for="jform_twofactor_method">
 					<?php echo Text::_('COM_USERS_USER_FIELD_TWOFACTOR_LABEL'); ?>
 				</label>
 			</div>


### PR DESCRIPTION
The title attribute is generally not very accessible. Keyboard users and touch screen users will never see it.

It is particularly useless to add a title which is the same as other text already present as that can result in a screen reader announcing the same text twice.

This PR removes the redundant title attribute where the same text is already displayed.

NOTE this is just a first pass at removing the low hanging fruit and a MUCH LARGER further pr will be needed when the tooltips are reviewed

