### PR TITLE
[4.0] Fix broken link

### DIFF
--- a/administrator/components/com_installer/Helper/InstallerHelper.php
+++ b/administrator/components/com_installer/Helper/InstallerHelper.php
@@ -23,6 +23,59 @@ use Joomla\CMS\Language\Text;
 class InstallerHelper
 {
 	/**
+	 * Configure the Linkbar.
+	 *
+	 * @param   string  $vName  The name of the active view.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.6
+	 */
+	public static function addSubmenu($vName = 'install')
+	{
+		\JHtmlSidebar::addEntry(
+			Text::_('COM_INSTALLER_SUBMENU_INSTALL'),
+			'index.php?option=com_installer',
+			$vName == 'install'
+		);
+		\JHtmlSidebar::addEntry(
+			Text::_('COM_INSTALLER_SUBMENU_UPDATE'),
+			'index.php?option=com_installer&view=update',
+			$vName == 'update'
+		);
+		\JHtmlSidebar::addEntry(
+			Text::_('COM_INSTALLER_SUBMENU_MANAGE'),
+			'index.php?option=com_installer&view=manage',
+			$vName == 'manage'
+		);
+		\JHtmlSidebar::addEntry(
+			Text::_('COM_INSTALLER_SUBMENU_DISCOVER'),
+			'index.php?option=com_installer&view=discover',
+			$vName == 'discover'
+		);
+		\JHtmlSidebar::addEntry(
+			Text::_('COM_INSTALLER_SUBMENU_DATABASE'),
+			'index.php?option=com_installer&view=database',
+			$vName == 'database'
+		);
+		\JHtmlSidebar::addEntry(
+			Text::_('COM_INSTALLER_SUBMENU_WARNINGS'),
+			'index.php?option=com_installer&view=warnings',
+			$vName == 'warnings'
+		);
+		\JHtmlSidebar::addEntry(
+			Text::_('COM_INSTALLER_SUBMENU_LANGUAGES'),
+			'index.php?option=com_installer&view=languages',
+			$vName == 'languages'
+		);
+		\JHtmlSidebar::addEntry(
+			Text::_('COM_INSTALLER_SUBMENU_UPDATESITES'),
+			'index.php?option=com_installer&view=updatesites',
+			$vName == 'updatesites'
+		);
+	}
+
+	/**
 	 * Get a list of filter options for the extension types.
 	 *
 	 * @return  array  An array of \stdClass objects.


### PR DESCRIPTION
The page ```administrator/index.php?option=com_installer&view=update``` was broken after removal of ```addSubmenu``` function

![com_intaller](https://user-images.githubusercontent.com/34353697/54767353-fd132480-4c22-11e9-9c1c-1f62addca910.png)


### Summary of Changes
Included addSubmenu function in this patch


### Testing Instructions
Go to ```administrator/index.php?option=com_installer&view=update```


### Expected result
Link not broken


### Actual result
Broken link


### Documentation Changes Required
None
