### PR TITLE
[4.0] Correcting broken multilingual

### DIFF
--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -171,8 +171,8 @@ class PlgSystemLanguageFilter extends CMSPlugin
 			$router->attachBuildRule(array($this, 'postprocessNonSEFBuildRule'), Router::PROCESS_AFTER);
 		}
 
-		// Attach parse rules for language SEF.
-		$router->attachParseRule(array($this, 'parseRule'), Router::PROCESS_DURING);
+		// Attach parse rule.
+		$router->attachParseRule(array($this, 'parseRule'), Router::PROCESS_BEFORE);
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/24292

### Summary of Changes
Thanks @Fedik 


### Testing Instructions
J clean install.
Create a multilingual site using the multilingual sample data module for at least 2 languages.
Make sure SEF is on.
Also install the blog sample data for any admin language or all.
Load frontend and switch languages.

All should now be OK.


### Note
I have no idea why the change in the DI for `CMSApplication::getInstance` in 4.0 vs 3.9 forces to modify `Router::PROCESS_DURING` to `Router::PROCESS_BEFORE` but my tests here show that all works fine with that change and the `SiteRouter` is correctly used.