### PR TITLE
[4.0] joomla-toolbar-button-min.js disconnectedCallback

### DIFF
--- a/build/media_source/system/js/joomla-toolbar-button.w-c.es6.js
+++ b/build/media_source/system/js/joomla-toolbar-button.w-c.es6.js
@@ -26,8 +26,7 @@ window.customElements.define('joomla-toolbar-button', class extends HTMLElement 
     }
 
     this.onChange = this.onChange.bind(this);
-
-    this.addEventListener('click', event => this.executeTask(event));
+    this.executeTask = this.executeTask.bind(this);
   }
 
   /**
@@ -37,6 +36,8 @@ window.customElements.define('joomla-toolbar-button', class extends HTMLElement 
     // We need a button to support button behavior,
     // because we cannot currently extend HTMLButtonElement
     this.buttonElement = this.querySelector('button, a');
+
+    this.addEventListener('click', this.executeTask);
 
     // Check whether we have a form
     const formSelector = this.form || 'adminForm';
@@ -65,6 +66,8 @@ window.customElements.define('joomla-toolbar-button', class extends HTMLElement 
     if (this.formElement.boxchecked) {
       this.formElement.boxchecked.removeEventListener('change', this.onChange);
     }
+
+    this.removeEventListener('click', this.executeTask);
   }
 
   onChange(event) {

--- a/build/media_source/system/js/joomla-toolbar-button.w-c.es6.js
+++ b/build/media_source/system/js/joomla-toolbar-button.w-c.es6.js
@@ -65,8 +65,6 @@ window.customElements.define('joomla-toolbar-button', class extends HTMLElement 
     if (this.formElement.boxchecked) {
       this.formElement.boxchecked.removeEventListener('change', this.onChange);
     }
-
-    this.removeEventListener('click');
   }
 
   onChange(event) {


### PR DESCRIPTION
Pull Request for Issue #24333 

### Summary of Changes
removed ```this.removeEventListener('click');``` in ```build/media_source/system/js/joomla-toolbar-button.w-c.es6.js``` as suggested in the issue


### Testing Instructions
Code Inspection


