### PR TITLE
[4.0] Permissions - title

### DIFF
--- a/build/media_source/system/js/fields/joomla-field-permissions.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-permissions.w-c.es6.js
@@ -24,7 +24,6 @@ window.customElements.define('joomla-field-permissions', class extends HTMLEleme
     this.extension = this.getUrlParam('extension');
     this.option = this.getUrlParam('option');
     this.view = this.getUrlParam('view');
-    this.title = this.component;
     this.asset = 'not';
     this.context = '';
   }


### PR DESCRIPTION
Go to any page that is displaying the page for setting the permissions of a component

Pretty much wherever you hover you will see the title of the component being displayed which is obviously not correct

This PR removes the title attribute (it's not needed) and now you no longer see the title being displayed

### Testing Instructions
requires npm -i
