### PR TITLE
[4.0] Fix Language Code plugin

### DIFF
--- a/plugins/system/languagecode/languagecode.php
+++ b/plugins/system/languagecode/languagecode.php
@@ -70,7 +70,7 @@ class PlgSystemLanguagecode extends CMSPlugin
 			}
 
 			// Replace codes in <link hreflang="" /> attributes.
-			preg_match_all(chr(1) . '(<link.*\s+hreflang=")([0-9a-z\-]*)(".*\s+rel="alternate".*/>)' . chr(1) . 'i', $body, $matches);
+			preg_match_all(chr(1) . '(<link.*\s+hreflang=")([0-9a-z\-]*)(".*\s+rel="alternate".*>)' . chr(1) . 'i', $body, $matches);
 
 			foreach ($matches[2] as $match)
 			{
@@ -78,12 +78,12 @@ class PlgSystemLanguagecode extends CMSPlugin
 
 				if ($new_code)
 				{
-					$patterns[] = chr(1) . '(<link.*\s+hreflang=")(' . $match . ')(".*\s+rel="alternate".*/>)' . chr(1) . 'i';
+					$patterns[] = chr(1) . '(<link.*\s+hreflang=")(' . $match . ')(".*\s+rel="alternate".*>)' . chr(1) . 'i';
 					$replace[] = '${1}' . $new_code . '${3}';
 				}
 			}
 
-			preg_match_all(chr(1) . '(<link.*\s+rel="alternate".*\s+hreflang=")([0-9A-Za-z\-]*)(".*/>)' . chr(1) . 'i', $body, $matches);
+			preg_match_all(chr(1) . '(<link.*\s+rel="alternate".*\s+hreflang=")([0-9A-Za-z\-]*)(".*>)' . chr(1) . 'i', $body, $matches);
 
 			foreach ($matches[2] as $match)
 			{
@@ -91,13 +91,13 @@ class PlgSystemLanguagecode extends CMSPlugin
 
 				if ($new_code)
 				{
-					$patterns[] = chr(1) . '(<link.*\s+rel="alternate".*\s+hreflang=")(' . $match . ')(".*/>)' . chr(1) . 'i';
+					$patterns[] = chr(1) . '(<link.*\s+rel="alternate".*\s+hreflang=")(' . $match . ')(".*>)' . chr(1) . 'i';
 					$replace[] = '${1}' . $new_code . '${3}';
 				}
 			}
 
 			// Replace codes in itemprop content
-			preg_match_all(chr(1) . '(<meta.*\s+itemprop="inLanguage".*\s+content=")([0-9A-Za-z\-]*)(".*/>)' . chr(1) . 'i', $body, $matches);
+			preg_match_all(chr(1) . '(<meta.*\s+itemprop="inLanguage".*\s+content=")([0-9A-Za-z\-]*)(".*>)' . chr(1) . 'i', $body, $matches);
 
 			foreach ($matches[2] as $match)
 			{
@@ -105,7 +105,7 @@ class PlgSystemLanguagecode extends CMSPlugin
 
 				if ($new_code)
 				{
-					$patterns[] = chr(1) . '(<meta.*\s+itemprop="inLanguage".*\s+content=")(' . $match . ')(".*/>)' . chr(1) . 'i';
+					$patterns[] = chr(1) . '(<meta.*\s+itemprop="inLanguage".*\s+content=")(' . $match . ')(".*>)' . chr(1) . 'i';
 					$replace[] = '${1}' . $new_code . '${3}';
 				}
 			}

--- a/plugins/system/languagecode/languagecode.php
+++ b/plugins/system/languagecode/languagecode.php
@@ -9,7 +9,6 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Language\LanguageHelper;
 use Joomla\CMS\Language\Text;
@@ -23,6 +22,14 @@ use Joomla\CMS\Plugin\CMSPlugin;
 class PlgSystemLanguagecode extends CMSPlugin
 {
 	/**
+	 * Application object
+	 *
+	 * @var    \Joomla\CMS\Application\CMSApplication
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $app;	
+
+	/**
 	 * Plugin that changes the language code used in the <html /> tag.
 	 *
 	 * @return  void
@@ -31,16 +38,14 @@ class PlgSystemLanguagecode extends CMSPlugin
 	 */
 	public function onAfterRender()
 	{
-		$app = Factory::getApplication();
-
 		// Use this plugin only in site application.
-		if ($app->isClient('site'))
+		if ($this->app->isClient('site'))
 		{
 			// Get the response body.
-			$body = $app->getBody();
+			$body = $this->app->getBody();
 
 			// Get the current language code.
-			$code = Factory::getDocument()->getLanguage();
+			$code = $this->app->getDocument()->getLanguage();
 
 			// Get the new code.
 			$new_code  = $this->params->get($code);
@@ -105,7 +110,7 @@ class PlgSystemLanguagecode extends CMSPlugin
 				}
 			}
 
-			$app->setBody(preg_replace($patterns, $replace, $body));
+			$this->app->setBody(preg_replace($patterns, $replace, $body));
 		}
 	}
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Use injected application.
Remove closing slashes from regex as they have been removed from markup.

### Testing Instructions

On multilingual installation with sample data.
Enable `System - Language Code` plugin and set up alternative language codes.
Open article page and inspect source code.

### Expected result

Original language codes replaced with those set in the plugin.

### Actual result

Language codes not replaced.

### Documentation Changes Required

No.