### PR TITLE
Fallback com_users new_usertype to guest_usergroup or public and not hardcode group id's

### DIFF
--- a/administrator/components/com_users/models/user.php
+++ b/administrator/components/com_users/models/user.php
@@ -938,9 +938,9 @@ class UsersModelUser extends JModelAdmin
 			}
 			else
 			{
-				$config = JComponentHelper::getParams('com_users');
+				$params = JComponentHelper::getParams('com_users');
 
-				if ($groupId = $config->get('new_usertype'))
+				if ($groupId = $params->get('new_usertype', $params->get('guest_usergroup', 1)))
 				{
 					$result[] = $groupId;
 				}

--- a/components/com_users/models/registration.php
+++ b/components/com_users/models/registration.php
@@ -278,7 +278,7 @@ class UsersModelRegistration extends JModelForm
 			// Get the groups the user should be added to after registration.
 			$this->data->groups = array();
 
-			// Get the default new user group, Registered if not specified.
+			// Get the default new user group, guest or public group if not specified.
 			$system = $params->get('new_usertype', $params->get('guest_usergroup', 1));
 
 			$this->data->groups[] = $system;

--- a/components/com_users/models/registration.php
+++ b/components/com_users/models/registration.php
@@ -279,7 +279,7 @@ class UsersModelRegistration extends JModelForm
 			$this->data->groups = array();
 
 			// Get the default new user group, Registered if not specified.
-			$system = $params->get('new_usertype', 2);
+			$system = $params->get('new_usertype', $params->get('guest_usergroup', 1));
 
 			$this->data->groups[] = $system;
 

--- a/plugins/user/joomla/joomla.php
+++ b/plugins/user/joomla/joomla.php
@@ -367,10 +367,10 @@ class PlgUserJoomla extends JPlugin
 		}
 
 		// TODO : move this out of the plugin
-		$config = ComponentHelper::getParams('com_users');
+		$params = ComponentHelper::getParams('com_users');
 
-		// Hard coded default to match the default value from com_users.
-		$defaultUserGroup = $config->get('new_usertype', 2);
+		// Read the default user group option from com_users
+		$defaultUserGroup = $params->get('new_usertype', $params->get('guest_usergroup', 1));
 
 		$instance->id = 0;
 		$instance->name = $user['fullname'];


### PR DESCRIPTION
Pull Request for an issue raised by @bembelimen

### Summary of Changes

Make sure the new_usertype is not hardcoded and in case it does not exists falls back to the guest_usergroup or the static id 1 / public.

### Testing Instructions

Clear the default value for new_usertype and check that guest_usergroup or 1 is used.

### Expected result

guest_usergroup or 1 is used when new_usertype is not configured

### Actual result

fallback is hardcoded

### Documentation Changes Required

none

cc @bembelimen  @SniperSister @HLeithner 