### PR TITLE
[4.0] Add Edge (chromium) support

### DIFF
--- a/libraries/src/Environment/Browser.php
+++ b/libraries/src/Environment/Browser.php
@@ -262,14 +262,10 @@ class Browser
 			}
 			/*
 			 * We have to check for Edge as the first browser, because Edge has something like:
-			 * Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.79 Safari/537.36 Edge/14.14393
+			 * Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3738.0 Safari/537.36 Edg/75.0.107.0
 			 */
 			elseif (preg_match('|Edg\/([0-9.]+)|', $this->agent, $version))
 			{
-				/*
-				 * We have to check for Edge as the first browser, because Edge has something like:
-				 * Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3738.0 Safari/537.36 Edg/75.0.107.0
-				 */
 				$this->setBrowser('edg');
 
 				list($this->majorVersion, $this->minorVersion) = explode('.', $version[1]);

--- a/libraries/src/Environment/Browser.php
+++ b/libraries/src/Environment/Browser.php
@@ -260,6 +260,20 @@ class Browser
 					$this->minorVersion = 0;
 				}
 			}
+			/*
+			 * We have to check for Edge as the first browser, because Edge has something like:
+			 * Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.79 Safari/537.36 Edge/14.14393
+			 */
+			elseif (preg_match('|Edg\/([0-9.]+)|', $this->agent, $version))
+			{
+				/*
+				 * We have to check for Edge as the first browser, because Edge has something like:
+				 * Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3738.0 Safari/537.36 Edg/75.0.107.0
+				 */
+				$this->setBrowser('edg');
+
+				list($this->majorVersion, $this->minorVersion) = explode('.', $version[1]);
+			}
 			elseif (preg_match('|Opera[\/ ]([0-9.]+)|', $this->agent, $version))
 			{
 				$this->setBrowser('opera');

--- a/tests/Unit/Libraries/Cms/Environment/BrowserTest.php
+++ b/tests/Unit/Libraries/Cms/Environment/BrowserTest.php
@@ -63,6 +63,13 @@ class BrowserTest extends UnitTestCase
 	public function dataMatch(): array
 	{
 		return [
+			'Edge 75' => [
+				'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3738.0 Safari/537.36 Edg/75.0.107.0',
+				'edg',
+				'win',
+				'75',
+				false,
+			],
 			'Edge 14' => [
 				'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.79 Safari/537.36 Edge/14.14393',
 				'edge',


### PR DESCRIPTION
Pull Request for Issue # .
none

### Summary of Changes

Support the new Edge Browser based on chromium.

### Testing Instructions

code check

### Expected result



### Actual result



### Documentation Changes Required

agent is now:

````Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3738.0 Safari/537.36 Edg/75.0.107.0````