### PR TITLE
[4.0] fix toolbar button

### DIFF
--- a/build/media_source/system/scss/joomla-toolbar-button.scss
+++ b/build/media_source/system/scss/joomla-toolbar-button.scss
@@ -1,4 +1,4 @@
 joomla-toolbar-button .dropdown-item:focus,
 joomla-toolbar-button .dropdown-item:hover {
-	color: #fff;
+	color: #000;
 }


### PR DESCRIPTION
The drop-down items of change status button  in com_users was not visible on hover. This PR fixes that. 

### Summary of Changes
Made the drop-down items visible on hover


### Testing Instructions
After applying the patch, run ```npm run build:css``` then
Go to Users => Manage
Select any user 
Click on the change status button


### Before Patch
![Screenshot from 2019-03-27 17-44-58](https://user-images.githubusercontent.com/34353697/55075900-17814e00-50ba-11e9-8a0c-06f1ed61687d.png)




### After patch
![Screenshot from 2019-03-27 17-43-16](https://user-images.githubusercontent.com/34353697/55075923-26680080-50ba-11e9-9ec3-2dcbc02ce774.png)




### Documentation Changes Required
None
