### PR TITLE
removed redundant/invalid css prop

### DIFF
--- a/administrator/templates/atum/scss/template.scss
+++ b/administrator/templates/atum/scss/template.scss
@@ -80,7 +80,6 @@
 
 .content {
   padding-top: 15px;
-  border-radius: $border-radius;
 
   > .row {
     margin-right: 0;


### PR DESCRIPTION
Pull Request for Issue - border radius property is invalid as there is no border or background.
![Screenshot from 2019-03-27 21-58-30](https://user-images.githubusercontent.com/36095178/55094309-2ed13300-50dc-11e9-9e2d-6fdb9828d9c4.png)

### Summary of Changes
Removed border-radius prop for content class.


### Documentation Changes Required
None
