### PR TITLE
[4.0][com_content featured] Remove redundant intro_image check

### DIFF
--- a/components/com_content/tmpl/featured/default_item.php
+++ b/components/com_content/tmpl/featured/default_item.php
@@ -19,7 +19,6 @@ use Joomla\CMS\Workflow\Workflow;
 
 // Create a shortcut for params.
 $params  = &$this->item->params;
-$images  = json_decode($this->item->images);
 $canEdit = $this->item->params->get('access-edit');
 $info    = $this->item->params->get('info_block_position', 0);
 

--- a/components/com_content/tmpl/featured/default_item.php
+++ b/components/com_content/tmpl/featured/default_item.php
@@ -27,9 +27,7 @@ $info    = $this->item->params->get('info_block_position', 0);
 $assocParam = (Associations::isEnabled() && $params->get('show_associations'));
 ?>
 
-<?php if (isset($images->image_intro) && !empty($images->image_intro)) : ?>
-	<?php echo LayoutHelper::render('joomla.content.intro_image', $this->item); ?>
-<?php endif; ?>
+<?php echo LayoutHelper::render('joomla.content.intro_image', $this->item); ?>
 
 <div class="item-content">
 	<?php if ($this->item->state == Workflow::CONDITION_UNPUBLISHED || strtotime($this->item->publish_up) > strtotime(Factory::getDate())


### PR DESCRIPTION
### Summary of Changes
- Remove lines for check if intro image exists because this is done in JLayout already.

### Testing Instructions
Code review in pr plus code of JLayout `joomla.content.intro_image` https://github.com/joomla/joomla-cms/blob/4.0-dev/layouts/joomla/content/intro_image.php#L17

Or:
- Create some featured articles with and without intro images.
- Test that nothing has changed after applying the patch. Intro images are displayed or not.

### Expected result
- Nothing has changed.

### Actual result
- Unnecessary/redundant code.