### PR TITLE
[4.0]skipToMenuInit method not found

### DIFF
--- a/plugins/system/skipto/skipto.php
+++ b/plugins/system/skipto/skipto.php
@@ -102,7 +102,6 @@ class PlgSystemSkipto extends CMSPlugin
 
 		$document->addScriptDeclaration("document.addEventListener('DOMContentLoaded', function() {
 			window.SkipToConfig = Joomla.getOptions('skipto-settings');
-			window.skipToMenuInit();
 		});");
 	}
 }


### PR DESCRIPTION
Pull Request for Issue - window.skipToMenuInit is not a function error in console in index.php
![Screenshot from 2019-03-28 20-13-04](https://user-images.githubusercontent.com/36095178/55167095-57b5fe80-5196-11e9-9693-34ab0692cfaa.png)
.

### Summary of Changes
Removed the function as could not find any method skipToMenuInit() in J4 code.


### Testing Instructions
Login -> Control Panel(index.php) -> check console error


### Expected result
No error


### Actual result
window.skipToMenuInit is not a function error


### Documentation Changes Required
No
