### PR TITLE
[4.0]changes class of radio in com_actionlogs

### DIFF
--- a/administrator/components/com_actionlogs/config.xml
+++ b/administrator/components/com_actionlogs/config.xml
@@ -6,7 +6,7 @@
 			type="radio"
 			label="COM_ACTIONLOGS_IP_LOGGING"
 			description="COM_ACTIONLOGS_IP_LOGGING_DESC"
-			class="btn-group btn-group-yesno"
+			class="switcher"
 			default="0"
 			>
 			<option value="1">JYES</option>


### PR DESCRIPTION
Pull Request for Issue - Radio should have same layout in com_config.

### Summary of Changes
Changed class of radio button


### Testing Instructions
Open config settings of com_actionlogs


### Expected result
![Screenshot from 2019-03-29 06-21-30](https://user-images.githubusercontent.com/36095178/55202224-924a8600-51ec-11e9-9ccd-707f2354feaa.png)

### Actual result
![Screenshot from 2019-03-29 06-30-24](https://user-images.githubusercontent.com/36095178/55202234-98406700-51ec-11e9-8ab8-9e7fb2aa126d.png)
