### PR TITLE
[4.0] RTL : Correcting browsers buttons in Media manager

### DIFF
--- a/administrator/components/com_media/resources/styles/components/_media-browser.scss
+++ b/administrator/components/com_media/resources/styles/components/_media-browser.scss
@@ -446,3 +446,21 @@
     }
   }
 }
+
+/* RTL override */
+
+html[dir=rtl] .media-browser-select {
+  right: 6px;
+  left: 0;
+}
+
+html[dir=rtl] .media-browser-select:after {
+  right: 0;
+  left: auto;
+}
+
+html[dir=rtl] .media-browser-actions {
+  right: auto;
+  left: 0;
+}
+


### PR DESCRIPTION
### Summary of Changes

Adding specific rtl overrides in media-browser.scss

### Testing Instructions
To test, patch and use NPM
Install Persian Language.
Display the Media Manager


### Before patch
The edit buttons display in RTL the same way as in LTR
<img width="227" alt="Screen Shot 2019-03-31 at 10 18 51" src="https://user-images.githubusercontent.com/869724/55287005-98cf2e00-53a3-11e9-839c-3853c628a0c8.png">


### After patch
The buttons are aligned correctly for RTL

<img width="463" alt="Screen Shot 2019-03-31 at 10 19 32" src="https://user-images.githubusercontent.com/869724/55287006-a97fa400-53a3-11e9-8bbf-71b3bf9269fa.png">

**Note**: compatible with https://github.com/joomla/joomla-cms/pull/24423