### PR TITLE
[4.0] fix template menu editor overlap

### DIFF
--- a/build/media_source/plg_editors_codemirror/css/codemirror.css
+++ b/build/media_source/plg_editors_codemirror/css/codemirror.css
@@ -10,7 +10,7 @@
 
 /* In order to hide the Joomla menu */
 .CodeMirror-fullscreen {
-	z-index: 1040;
+	z-index: 1200 !important;
 }
 
 /* Make the fold marker a little more visible/nice */


### PR DESCRIPTION
Pull Request for Issue #23512 

### Summary of Changes
Changes in ```z-index``` as suggested in the issue


### Testing Instructions
1.Open the template files
2.Select a file and click into the editor
3.Go to full-screen editor

### Expected result
Editor menu above the file contents


### Actual result
Editor menu overlaps the top few lines of the file being edited and it's not possible to see these lines. If the screen is narrowed a bit the editor menu moves down a couple of lines


### Documentation Changes Required
None
