### PR TITLE
[4.0] Changing format handling in Smart Search

### DIFF
--- a/administrator/components/com_finder/helpers/indexer/driver/mysql.php
+++ b/administrator/components/com_finder/helpers/indexer/driver/mysql.php
@@ -27,7 +27,7 @@ class FinderIndexerDriverMysql extends FinderIndexer
 	/**
 	 * Method to index a content item.
 	 *
-	 * @param   FinderIndexerResult  $item    The content item to index.
+	 * @param   FinderIndexerResult  $item  The content item to index.
 	 *
 	 * @return  integer  The ID of the record in the links table.
 	 *

--- a/administrator/components/com_finder/helpers/indexer/driver/mysql.php
+++ b/administrator/components/com_finder/helpers/indexer/driver/mysql.php
@@ -28,14 +28,13 @@ class FinderIndexerDriverMysql extends FinderIndexer
 	 * Method to index a content item.
 	 *
 	 * @param   FinderIndexerResult  $item    The content item to index.
-	 * @param   string               $format  The format of the content. [optional]
 	 *
 	 * @return  integer  The ID of the record in the links table.
 	 *
 	 * @since   3.0
 	 * @throws  Exception on database error.
 	 */
-	public function index($item, $format = 'html')
+	public function index($item)
 	{
 		// Mark beforeIndexing in the profiler.
 		static::$profiler ? static::$profiler->mark('beforeIndexing') : null;
@@ -158,39 +157,21 @@ class FinderIndexerDriverMysql extends FinderIndexer
 			foreach ($properties as $property)
 			{
 				// Check if the property exists in the item.
-				if (empty($item->$property))
+				if (empty($item->{$property['property']}))
 				{
 					continue;
 				}
 
 				// Tokenize the property.
-				if (is_array($item->$property))
+				$ips = $item->{$property['property']};
+
+				if (!is_array($ips))
 				{
-					// Tokenize an array of content and add it to the database.
-					foreach ($item->$property as $ip)
-					{
-						/*
-						 * If the group is path, we need to a few extra processing
-						 * steps to strip the extension and convert slashes and dashes
-						 * to spaces.
-						 */
-						if ($group === static::PATH_CONTEXT)
-						{
-							$ip = JFile::stripExt($ip);
-							$ip = str_replace(array('/', '-'), ' ', $ip);
-						}
-
-						// Tokenize a string of content and add it to the database.
-						$count += $this->tokenizeToDb($ip, $group, $item->language, $format);
-
-						// Check if we're approaching the memory limit of the token table.
-						if ($count > static::$state->options->get('memory_table_limit', 30000))
-						{
-							$this->toggleTables(false);
-						}
-					}
+					$ips = [$ips];
 				}
-				else
+
+				// Tokenize an array of content and add it to the database.
+				foreach ($ips as $ip)
 				{
 					/*
 					 * If the group is path, we need to a few extra processing
@@ -199,13 +180,12 @@ class FinderIndexerDriverMysql extends FinderIndexer
 					 */
 					if ($group === static::PATH_CONTEXT)
 					{
-						$item->$property = JFile::stripExt($item->$property);
-						$item->$property = str_replace('/', ' ', $item->$property);
-						$item->$property = str_replace('-', ' ', $item->$property);
+						$ip = JFile::stripExt($ip);
+						$ip = str_replace(array('/', '-'), ' ', $ip);
 					}
 
 					// Tokenize a string of content and add it to the database.
-					$count += $this->tokenizeToDb($item->$property, $group, $item->language, $format);
+					$count += $this->tokenizeToDb($ip, $group, $item->language, $property['format']);
 
 					// Check if we're approaching the memory limit of the token table.
 					if ($count > static::$state->options->get('memory_table_limit', 30000))
@@ -240,7 +220,7 @@ class FinderIndexerDriverMysql extends FinderIndexer
 				$node->id = $nodeId;
 
 				// Tokenize the node title and add them to the database.
-				$count += $this->tokenizeToDb($node->title, static::META_CONTEXT, $item->language, $format);
+				$count += $this->tokenizeToDb($node->title, static::META_CONTEXT, $item->language, 'txt');
 			}
 		}
 

--- a/administrator/components/com_finder/helpers/indexer/driver/postgresql.php
+++ b/administrator/components/com_finder/helpers/indexer/driver/postgresql.php
@@ -19,7 +19,7 @@ class FinderIndexerDriverPostgresql extends FinderIndexer
 	/**
 	 * Method to index a content item.
 	 *
-	 * @param   FinderIndexerResult  $item    The content item to index.
+	 * @param   FinderIndexerResult  $item  The content item to index.
 	 *
 	 * @return  integer  The ID of the record in the links table.
 	 *

--- a/administrator/components/com_finder/helpers/indexer/indexer.php
+++ b/administrator/components/com_finder/helpers/indexer/indexer.php
@@ -264,14 +264,13 @@ abstract class FinderIndexer
 	 * Method to index a content item.
 	 *
 	 * @param   FinderIndexerResult  $item    The content item to index.
-	 * @param   string               $format  The format of the content. [optional]
 	 *
 	 * @return  integer  The ID of the record in the links table.
 	 *
 	 * @since   2.5
 	 * @throws  Exception on database error.
 	 */
-	abstract public function index($item, $format = 'html');
+	abstract public function index($item);
 
 	/**
 	 * Method to remove a link from the index.

--- a/administrator/components/com_finder/helpers/indexer/indexer.php
+++ b/administrator/components/com_finder/helpers/indexer/indexer.php
@@ -263,7 +263,7 @@ abstract class FinderIndexer
 	/**
 	 * Method to index a content item.
 	 *
-	 * @param   FinderIndexerResult  $item    The content item to index.
+	 * @param   FinderIndexerResult  $item  The content item to index.
 	 *
 	 * @return  integer  The ID of the record in the links table.
 	 *

--- a/administrator/components/com_finder/helpers/indexer/result.php
+++ b/administrator/components/com_finder/helpers/indexer/result.php
@@ -40,11 +40,21 @@ class FinderIndexerResult implements Serializable
 	 * @since  2.5
 	 */
 	protected $instructions = array(
-		FinderIndexer::TITLE_CONTEXT => array('title', 'subtitle', 'id'),
-		FinderIndexer::TEXT_CONTEXT  => array('summary', 'body'),
-		FinderIndexer::META_CONTEXT  => array('meta', 'list_price', 'sale_price'),
-		FinderIndexer::PATH_CONTEXT  => array('path', 'alias'),
-		FinderIndexer::MISC_CONTEXT  => array('comments'),
+		FinderIndexer::TITLE_CONTEXT => [
+			['property' => 'title', 'format' => 'txt'],
+			['property' => 'subtitle', 'format' => 'txt'],
+			['property' => 'id', 'format' => 'txt']],
+		FinderIndexer::TEXT_CONTEXT  => [
+			['property' => 'summary', 'format' => 'html'],
+			['property' => 'body', 'format' => 'html']],
+		FinderIndexer::META_CONTEXT  => [
+			['property' => 'meta', 'format' => 'txt'],
+			['property' => 'list_price', 'format' => 'txt'],
+			['property' => 'sale_price', 'format' => 'txt']],
+		FinderIndexer::PATH_CONTEXT  => [
+			['property' => 'path', 'format' => 'txt'],
+			['property' => 'alias', 'format' => 'txt']],
+		FinderIndexer::MISC_CONTEXT  => [['property' => 'comments', 'format' => 'txt']]
 	);
 
 	/**
@@ -317,19 +327,20 @@ class FinderIndexerResult implements Serializable
 	 *
 	 * @param   string  $group     The group to associate the property with.
 	 * @param   string  $property  The property to process.
+	 * @param   string  $format    The format of the property.
 	 *
 	 * @return  void
 	 *
 	 * @since   2.5
 	 */
-	public function addInstruction($group, $property)
+	public function addInstruction($group, $property, $format = 'txt')
 	{
 		// Check if the group exists. We can't add instructions for unknown groups.
 		// Check if the property exists in the group.
-		if (array_key_exists($group, $this->instructions) && !in_array($property, $this->instructions[$group], true))
+		if (array_key_exists($group, $this->instructions) && !isset($this->instructions[$group][$property]))
 		{
 			// Add the property to the group.
-			$this->instructions[$group][] = $property;
+			$this->instructions[$group][$property] = ['property' => $property, 'format' => $format];
 		}
 	}
 
@@ -348,14 +359,7 @@ class FinderIndexerResult implements Serializable
 		// Check if the group exists. We can't remove instructions for unknown groups.
 		if (array_key_exists($group, $this->instructions))
 		{
-			// Search for the property in the group.
-			$key = array_search($property, $this->instructions[$group]);
-
-			// If the property was found, remove it.
-			if ($key !== false)
-			{
-				unset($this->instructions[$group][$key]);
-			}
+			unset($this->instructions[$group][$property]);
 		}
 	}
 
@@ -457,9 +461,9 @@ class FinderIndexerResult implements Serializable
 
 	/**
 	 * Helper function to serialise the data of a FinderIndexerResult object
-	 * 
+	 *
 	 * @return  string  The serialised data
-	 * 
+	 *
 	 * @since   4.0.0
 	 */
 	public function serialize()
@@ -512,11 +516,11 @@ class FinderIndexerResult implements Serializable
 
 	/**
 	 * Helper function to unserialise the data for this object
-	 * 
+	 *
 	 * @param   string  $serialized  Serialised data to unserialise
-	 * 
+	 *
 	 * @return  void
-	 * 
+	 *
 	 * @since   4.0.0
 	 */
 	public function unserialize($serialized)


### PR DESCRIPTION
Smart Search has the ability to parse different formats of data, be it HTML, TXT or RTF. And in theory you could extend that to parse also PDFs or DOCX. Unfortunately, right now you are forced to decide which format the whole result item is in for all properties when calling index() in your finder plugin. This prevents us from having results that contain normal HTML and then maybe a file in PDF and another in DOCX format. It is a bit the Highlander issue...

This PR changes that so that you can set the format of the property when telling the indexer how to index that part.

### How to test?
In core Joomla, this should not have any impact at all. So simply run the indexer and/or use finder how you did before and you should not notice a difference. I'm asking however for a codereview on this to make sure that my idea is sane. Thus I'm calling for the powers of @chrisdavenport and @wilsonge 😉 

In another PR, I would also like to add the possibility to point to a file path. If we really want to allow indexing of PDF files for example, we have to change the system a bit to not add the whole file to the result object, too.