### PR TITLE
Prevent timezone difference to be applied twice

### DIFF
--- a/administrator/components/com_fields/models/field.php
+++ b/administrator/components/com_fields/models/field.php
@@ -343,34 +343,6 @@ class FieldsModelField extends JModelAdmin
 
 			$db->setQuery($query);
 			$result->assigned_cat_ids = $db->loadColumn() ?: array(0);
-
-			// Convert the created and modified dates to local user time for
-			// display in the form.
-			$tz = new DateTimeZone(JFactory::getApplication()->get('offset'));
-
-			if ((int) $result->created_time)
-			{
-				$date = new JDate($result->created_time);
-				$date->setTimezone($tz);
-
-				$result->created_time = $date->toSql(true);
-			}
-			else
-			{
-				$result->created_time = null;
-			}
-
-			if ((int) $result->modified_time)
-			{
-				$date = new JDate($result->modified_time);
-				$date->setTimezone($tz);
-
-				$result->modified_time = $date->toSql(true);
-			}
-			else
-			{
-				$result->modified_time = null;
-			}
 		}
 
 		return $result;

--- a/administrator/components/com_fields/models/group.php
+++ b/administrator/components/com_fields/models/group.php
@@ -325,31 +325,6 @@ class FieldsModelGroup extends JModelAdmin
 			{
 				$item->params = new Registry($item->params);
 			}
-
-			// Convert the created and modified dates to local user time for display in the form.
-			$tz = new DateTimeZone(JFactory::getApplication()->get('offset'));
-
-			if ((int) $item->created)
-			{
-				$date = new JDate($item->created);
-				$date->setTimezone($tz);
-				$item->created = $date->toSql(true);
-			}
-			else
-			{
-				$item->created = null;
-			}
-
-			if ((int) $item->modified)
-			{
-				$date = new JDate($item->modified);
-				$date->setTimezone($tz);
-				$item->modified = $date->toSql(true);
-			}
-			else
-			{
-				$item->modified = null;
-			}
 		}
 
 		return $item;


### PR DESCRIPTION
### Summary of Changes
When creating fields or field groups, the timezone for the display in the date fields (created, modified) is already taken care of in the xmls by the use of `filter="user_utc"`.
Therefore the code is useless in the models as it applies this timezone a second time.

### Testing Instructions
Select a time zone and check the results displayed for a new field and a new field group (save twice to obtain the modified date)

Can be merged on review.

@Bakual @HLeithner @alikon 