### PR TITLE
Reorganize Travis PHP environment variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,35 +6,37 @@ language: php
 env:
   global:
     - RUN_UNIT_TESTS="yes"
-    - INSTALL_MEMCACHE="yes"
+    - INSTALL_APCU="yes"
     - INSTALL_MEMCACHED="yes"
     - INSTALL_REDIS="yes"
 
 matrix:
   fast_finish: true
   include:
-    - php: 7.0
-      env: INSTALL_APCU="yes" INSTALL_MEMCACHE="no"
-    - php: 7.1
-      env: INSTALL_APCU="yes" INSTALL_MEMCACHE="no"
     # Requires older Precise image
     - php: 5.3
-      env: INSTALL_APC="yes"
+      env:
+        - INSTALL_APC="yes"
+        - INSTALL_APCU="no"
+        - INSTALL_MEMCACHE="yes"
       sudo: true
       dist: precise
     # The new Trusty image has issues with running APC, do not enable it here
     - php: 5.4
-      env: INSTALL_APC="no"
+      env:
+        - INSTALL_APCU="no"
+        - INSTALL_MEMCACHE="yes"
     - php: 5.5
-      env: INSTALL_APCU="yes"
+      env:
+        - INSTALL_MEMCACHE="yes"
     - php: 5.6
-      env: INSTALL_APCU="yes"
+      env:
+        - INSTALL_MEMCACHE="yes"
+    - php: 7.0
+    - php: 7.1
     - php: 7.2
-      env: INSTALL_APCU="yes" INSTALL_MEMCACHE="no"
     - php: 7.3
-      env: INSTALL_APCU="yes" INSTALL_MEMCACHE="no" INSTALL_MEMCACHED="no"
     - php: nightly
-      env: INSTALL_APCU="no" INSTALL_MEMCACHE="no" INSTALL_MEMCACHED="no"
   allow_failures:
     - php: 7.3
     - php: nightly

--- a/build/travis/phpenv/apcu-7.4.ini
+++ b/build/travis/phpenv/apcu-7.4.ini
@@ -1,0 +1,2 @@
+apc.enabled=true
+apc.enable_cli=true


### PR DESCRIPTION
### Summary of Changes
This changes the defaults of supported PECL extensions in Travis.
Newer versions are tend to prefer `memcached` over `memcache` and `APCu` over `APC`.
Tests for `memcached` and `APCu` in PHP 7.3 and 7.4/nightly have been restored. Referring to their changelogs the current versions should work up to PHP 8.0.
I also sorted the list by extension name and PHP version to enhance readability.

There are no changes expected and no further testing is required to apply this patch. 