### PR TITLE
[com_fields] - don't traverse the tree

### DIFF
--- a/administrator/components/com_fields/models/fields.php
+++ b/administrator/components/com_fields/models/fields.php
@@ -181,42 +181,7 @@ class FieldsModelFields extends JModelList
 		if (($categories = $this->getState('filter.assigned_cat_ids')) && $context)
 		{
 			$categories = (array) $categories;
-			$categories = ArrayHelper::toInteger($categories);
-			$parts = FieldsHelper::extract($context);
-
-			if ($parts)
-			{
-				// Get the category
-				$cat = JCategories::getInstance(str_replace('com_', '', $parts[0]) . '.' . $parts[1]);
-
-				// If there is no category for the component and section, so check the component only
-				if (!$cat)
-				{
-					$cat = JCategories::getInstance(str_replace('com_', '', $parts[0]));
-				}
-
-				if ($cat)
-				{
-					foreach ($categories as $assignedCatIds)
-					{
-						// Check if we have the actual category
-						$parent = $cat->get($assignedCatIds);
-
-						if ($parent)
-						{
-							$categories[] = (int) $parent->id;
-
-							// Traverse the tree up to get all the fields which are attached to a parent
-							while ($parent->getParent() && $parent->getParent()->id != 'root')
-							{
-								$parent = $parent->getParent();
-								$categories[] = (int) $parent->id;
-							}
-						}
-					}
-				}
-			}
-
+			$categories = ArrayHelper::toInteger($categories);			
 			$categories = array_unique($categories);
 
 			// Join over the assigned categories


### PR DESCRIPTION
Pull Request for Issue #24361 .

### Summary of Changes
we don't need to traverse the tree


### Testing Instructions
make a category tree like this
A
-> B
-> -> C
-> -> -> D

create an article field and assign to previous categories (a,b,c,d)
create an article in the D category 

visit that artilce you'll see 4 times the same field

see #24361 for more details


### Expected result


to see the field once
### Actual result



### Note 

same happens on administrator side if you filter for category before patch
![Screenshot from 2019-04-06 09-22-08](https://user-images.githubusercontent.com/181681/55666328-92cac880-584d-11e9-85ef-3734b23166a4.png)



