### PR TITLE
[4.0] Removed Reloading On disabled buttons

### DIFF
--- a/build/media_source/com_content/js/admin-articles-workflow-buttons.es6.js
+++ b/build/media_source/com_content/js/admin-articles-workflow-buttons.es6.js
@@ -234,18 +234,6 @@ Joomla.toggleAllNextElements = (element, className) => {
             countChecked += 1;
           }
         });
-        const stateAfter = [publishBool, unpublishBool, archiveBool, trashBool];
-        const stateBefore = stateAfter.slice(0);
-        stateBefore.forEach((el, index) => {
-          if (!el) {
-            stateBefore.forEach((elBefore, indexBefore) => {
-              if (indexBefore !== index) {
-                stateAfter[indexBefore] = true;
-              }
-            });
-          }
-        });
-        [publishBool, unpublishBool, archiveBool, trashBool] = stateAfter;
         disableButtons();
         countChecked = 0;
       });

--- a/build/media_source/com_content/js/admin-articles-workflow-buttons.es6.js
+++ b/build/media_source/com_content/js/admin-articles-workflow-buttons.es6.js
@@ -193,11 +193,11 @@ Joomla.toggleAllNextElements = (element, className) => {
     });
 
     function setOrRemDisabled(btn, set) {
-      var buttonText;
+      let buttonText;
       if (set) {
         btn.classList.remove('disabled');
-        buttonText=btn.parentElement.id.replace(/status-group-children-/g, '');
-        btn.parentElement.setAttribute('task', 'articles.' + buttonText);
+        buttonText=btn.parentElement.id.replace( /status-group-children-/g , '');
+        btn.parentElement.setAttribute('task', `articles.${buttonText}`);
       } else {
         btn.classList.add('disabled');
         btn.parentElement.removeAttribute('task');

--- a/build/media_source/com_content/js/admin-articles-workflow-buttons.es6.js
+++ b/build/media_source/com_content/js/admin-articles-workflow-buttons.es6.js
@@ -196,12 +196,11 @@ Joomla.toggleAllNextElements = (element, className) => {
       let buttonText;
       if (set) {
         btn.classList.remove('disabled');
-        buttonText=btn.parentElement.id.replace( /status-group-children-/g , '');
+        buttonText=btn.parentElement.id.replace(/ status-group-children- /g, '');
         btn.parentElement.setAttribute('task', `articles.${buttonText}`);
       } else {
         btn.classList.add('disabled');
         btn.parentElement.removeAttribute('task');
-
       }
     }
 

--- a/build/media_source/com_content/js/admin-articles-workflow-buttons.es6.js
+++ b/build/media_source/com_content/js/admin-articles-workflow-buttons.es6.js
@@ -195,8 +195,13 @@ Joomla.toggleAllNextElements = (element, className) => {
     function setOrRemDisabled(btn, set) {
       if (set) {
         btn.classList.remove('disabled');
+        var buttonText=btn.parentElement.id.replace(/status-group-children-/g,'');
+        console.log(buttonText);
+        btn.parentElement.setAttribute("task", "articles."+buttonText);
       } else {
         btn.classList.add('disabled');
+        btn.parentElement.removeAttribute("task"); 
+
       }
     }
 

--- a/build/media_source/com_content/js/admin-articles-workflow-buttons.es6.js
+++ b/build/media_source/com_content/js/admin-articles-workflow-buttons.es6.js
@@ -193,14 +193,14 @@ Joomla.toggleAllNextElements = (element, className) => {
     });
 
     function setOrRemDisabled(btn, set) {
+      var buttonText;
       if (set) {
         btn.classList.remove('disabled');
-        var buttonText=btn.parentElement.id.replace(/status-group-children-/g,'');
-        console.log(buttonText);
-        btn.parentElement.setAttribute("task", "articles."+buttonText);
+        buttonText=btn.parentElement.id.replace(/status-group-children-/g, '');
+        btn.parentElement.setAttribute('task', 'articles.' + buttonText);
       } else {
         btn.classList.add('disabled');
-        btn.parentElement.removeAttribute("task"); 
+        btn.parentElement.removeAttribute('task');
 
       }
     }
@@ -234,6 +234,18 @@ Joomla.toggleAllNextElements = (element, className) => {
             countChecked += 1;
           }
         });
+        const stateAfter = [publishBool, unpublishBool, archiveBool, trashBool];
+        const stateBefore = stateAfter.slice(0);
+        stateBefore.forEach((el, index) => {
+          if (!el) {
+            stateBefore.forEach((elBefore, indexBefore) => {
+              if (indexBefore !== index) {
+                stateAfter[indexBefore] = true;
+              }
+            });
+          }
+        });
+        [publishBool, unpublishBool, archiveBool, trashBool] = stateAfter;
         disableButtons();
         countChecked = 0;
       });

--- a/build/media_source/com_content/js/admin-articles-workflow-buttons.es6.js
+++ b/build/media_source/com_content/js/admin-articles-workflow-buttons.es6.js
@@ -196,7 +196,7 @@ Joomla.toggleAllNextElements = (element, className) => {
       let buttonText;
       if (set) {
         btn.classList.remove('disabled');
-        buttonText=btn.parentElement.id.replace(/ status-group-children- /g, '');
+        buttonText = btn.parentElement.id.replace(/status-group-children-/g, '');
         btn.parentElement.setAttribute('task', `articles.${buttonText}`);
       } else {
         btn.classList.add('disabled');


### PR DESCRIPTION
Pull Request for Issue #24518

### Summary of Changes

Removal Of task attribute when button is disabled and re-add when enabled.

### Testing Instructions
go to already created articles in the backend administrator
Select a check-box of a published article
open change status toolbar list and click on publish

### Expected result
Page is Not Reloaded


### Actual result
Same as Expected


### Documentation Changes Required
No

### Additional Comments

Setting button to disable or readonly did not work for this Issue.

Currently,If One Published and one Unpublished articles are selected, Both buttons become disabled.
But the issue is resolved after merging PR [#24517](https://github.com/joomla/joomla-cms/pull/24517#issue-268028695).

