### PR TITLE
Fix format of time in user note

### DIFF
--- a/administrator/components/com_users/models/forms/note.xml
+++ b/administrator/components/com_users/models/forms/note.xml
@@ -75,6 +75,7 @@
 			description="COM_USERS_FIELD_REVIEW_TIME_DESC"
 			default="NOW"
 			translateformat="true"
+			filter="user_utc"
 		/>
 
 		<field


### PR DESCRIPTION
Pull Request for Issue #24462.

### Summary of Changes
Add filter utc to the input field.
If the date is entered in for example german, the date in the input field has the format i.e. 21.3.2019 which is not integer and therefor is reset to Nulldate.

### Testing Instructions
Use a backend language which does not use the YYYY-MM-DD format, for example German. 
Add a date into the chek date.

### Expected result
The date is stored.


### Actual result
The date is empty


### Documentation Changes Required

