### PR TITLE
[4.0] Fix quickicon and dashboard in privacy component

### DIFF
--- a/plugins/privacy/actionlogs/actionlogs.php
+++ b/plugins/privacy/actionlogs/actionlogs.php
@@ -13,7 +13,7 @@ use Joomla\Utilities\ArrayHelper;
 
 JLoader::register('ActionlogsHelper', JPATH_COMPONENT . '/helpers/actionlogs.php');
 JLoader::register('PrivacyPlugin', JPATH_ADMINISTRATOR . '/components/com_privacy/helpers/plugin.php');
-
+JLoader::register('PrivacyTableRequest', JPATH_ADMINISTRATOR . '/components/com_privacy/tables/request.php');
 
 /**
  * Privacy plugin managing Joomla actionlogs data

--- a/plugins/privacy/contact/contact.php
+++ b/plugins/privacy/contact/contact.php
@@ -13,6 +13,7 @@ use Joomla\Utilities\ArrayHelper;
 
 JLoader::register('FieldsHelper', JPATH_ADMINISTRATOR . '/components/com_fields/helpers/fields.php');
 JLoader::register('PrivacyPlugin', JPATH_ADMINISTRATOR . '/components/com_privacy/helpers/plugin.php');
+JLoader::register('PrivacyTableRequest', JPATH_ADMINISTRATOR . '/components/com_privacy/tables/request.php');
 
 /**
  * Privacy plugin managing Joomla user contact data

--- a/plugins/privacy/content/content.php
+++ b/plugins/privacy/content/content.php
@@ -13,6 +13,7 @@ use Joomla\Utilities\ArrayHelper;
 
 JLoader::register('FieldsHelper', JPATH_ADMINISTRATOR . '/components/com_fields/helpers/fields.php');
 JLoader::register('PrivacyPlugin', JPATH_ADMINISTRATOR . '/components/com_privacy/helpers/plugin.php');
+JLoader::register('PrivacyTableRequest', JPATH_ADMINISTRATOR . '/components/com_privacy/tables/request.php');
 
 /**
  * Privacy plugin managing Joomla user content data

--- a/plugins/privacy/message/message.php
+++ b/plugins/privacy/message/message.php
@@ -13,6 +13,7 @@ use Joomla\Utilities\ArrayHelper;
 
 JLoader::register('FieldsHelper', JPATH_ADMINISTRATOR . '/components/com_fields/helpers/fields.php');
 JLoader::register('PrivacyPlugin', JPATH_ADMINISTRATOR . '/components/com_privacy/helpers/plugin.php');
+JLoader::register('PrivacyTableRequest', JPATH_ADMINISTRATOR . '/components/com_privacy/tables/request.php');
 
 /**
  * Privacy plugin managing Joomla user messages

--- a/plugins/privacy/user/user.php
+++ b/plugins/privacy/user/user.php
@@ -14,6 +14,7 @@ use Joomla\Utilities\ArrayHelper;
 JLoader::register('FieldsHelper', JPATH_ADMINISTRATOR . '/components/com_fields/helpers/fields.php');
 JLoader::register('PrivacyPlugin', JPATH_ADMINISTRATOR . '/components/com_privacy/helpers/plugin.php');
 JLoader::register('PrivacyRemovalStatus', JPATH_ADMINISTRATOR . '/components/com_privacy/helpers/removal/status.php');
+JLoader::register('PrivacyTableRequest', JPATH_ADMINISTRATOR . '/components/com_privacy/tables/request.php');
 
 /**
  * Privacy plugin managing Joomla user data


### PR DESCRIPTION
This fixes both the privacy component dashboard view and the quick icon on the cpanel page. This fix is required because of the rework of the (we use a reflection class on type hints which means typed variables must be resolvable on plugin construction - not currently the case in j3 - this should be documented!). It also shouldn't cause merge conflicts looking at what I have coming up - else I only have myself to blame

//cc @infograf768 