### PR TITLE
[4.0] JFactory class not found in Associations view

### DIFF
--- a/administrator/components/com_associations/View/Associations/HtmlView.php
+++ b/administrator/components/com_associations/View/Associations/HtmlView.php
@@ -172,7 +172,7 @@ class HtmlView extends BaseHtmlView
 					if ($this->getLayout() == 'modal')
 					{
 						// We need to change the category filter to only show categories tagged to All or to the forced language.
-						if ($forcedLanguage = JFactory::getApplication()->input->get('forcedLanguage', '', 'CMD'))
+						if ($forcedLanguage = Factory::getApplication()->input->get('forcedLanguage', '', 'CMD'))
 						{
 							$this->filterForm->setFieldAttribute('category_id', 'language', '*,' . $forcedLanguage, 'filter');
 						}


### PR DESCRIPTION
### Summary of Changes
Changed to `Factory`


### Testing Instructions
Mutilingual site.
Display the associations manager, select articles and a language.
Click on an article in the left column to open ethe side by side view
On the right, click on the Target button
<img width="811" alt="Screen Shot 2019-04-12 at 16 29 27" src="https://user-images.githubusercontent.com/869724/56045283-43026a80-5d41-11e9-97ba-e94ecbc3d678.png">

### Corrected after patch
Can be merged on review
@wilsonge 