### PR TITLE
Fix  allowAdd attribute of the JFormField categoryedit

### DIFF
--- a/administrator/components/com_categories/models/fields/categoryedit.php
+++ b/administrator/components/com_categories/models/fields/categoryedit.php
@@ -56,7 +56,7 @@ class JFormFieldCategoryEdit extends JFormFieldList
 
 		if ($return)
 		{
-			$this->allowAdd = isset($this->element['allowAdd']) ? $this->element['allowAdd'] : '';
+			$this->allowAdd = isset($this->element['allowAdd']) ? (bool)filter_var((((array)$this->element->attributes())['@attributes']['allowAdd']), FILTER_VALIDATE_BOOLEAN) : '';
 		}
 
 		return $return;

--- a/administrator/components/com_categories/models/fields/categoryedit.php
+++ b/administrator/components/com_categories/models/fields/categoryedit.php
@@ -56,7 +56,7 @@ class JFormFieldCategoryEdit extends JFormFieldList
 
 		if ($return)
 		{
-			$this->allowAdd = isset($this->element['allowAdd']) ? (bool)filter_var((((array)$this->element->attributes())['@attributes']['allowAdd']), FILTER_VALIDATE_BOOLEAN) : '';
+			$this->allowAdd = isset($this->element['allowAdd']) ? (bool) filter_var((((array)$this->element->attributes())['@attributes']['allowAdd']), FILTER_VALIDATE_BOOLEAN) : '';
 		}
 
 		return $return;


### PR DESCRIPTION
Pull Request for Issue #24566 

### Summary of Changes
Changed

 ```php
$this->allowAdd = isset($this->element['allowAdd']) ? $this->element['allowAdd'] : '';
``` 
to 
```php
$this->allowAdd = isset($this->element['allowAdd']) ? (bool)filter_var((((array)$this->element->attributes())['@attributes']['allowAdd']), FILTER_VALIDATE_BOOLEAN) : '';
```
in ``` administrator/components/com_categories/models/fields/categoryedit.php```



### Testing Instructions
Code Inspection


### Documentation Changes Required
None
