### PR TITLE
[4.0] Privavcy dashboard module display

### DIFF
--- a/administrator/components/com_privacy/Service/HTML/Privacy.php
+++ b/administrator/components/com_privacy/Service/HTML/Privacy.php
@@ -21,7 +21,7 @@ use Joomla\CMS\Language\Text;
 class Privacy
 {
 	/**
-	 * Render a status label
+	 * Render a status badge
 	 *
 	 * @param   integer  $status  The item status
 	 *
@@ -34,17 +34,17 @@ class Privacy
 		switch ($status)
 		{
 			case 2:
-				return '<span class="label label-success">' . Text::_('COM_PRIVACY_STATUS_COMPLETED') . '</span>';
+				return '<span class="badge badge-success">' . Text::_('COM_PRIVACY_STATUS_COMPLETED') . '</span>';
 
 			case 1:
-				return '<span class="label label-info">' . Text::_('COM_PRIVACY_STATUS_CONFIRMED') . '</span>';
+				return '<span class="badge badge-info">' . Text::_('COM_PRIVACY_STATUS_CONFIRMED') . '</span>';
 
 			case -1:
-				return '<span class="label label-important">' . Text::_('COM_PRIVACY_STATUS_INVALID') . '</span>';
+				return '<span class="badge badge-important">' . Text::_('COM_PRIVACY_STATUS_INVALID') . '</span>';
 
 			default:
 			case 0:
-				return '<span class="label label-warning">' . Text::_('COM_PRIVACY_STATUS_PENDING') . '</span>';
+				return '<span class="badge badge-warning">' . Text::_('COM_PRIVACY_STATUS_PENDING') . '</span>';
 		}
 	}
 }

--- a/administrator/modules/mod_privacy_dashboard/tmpl/default.php
+++ b/administrator/modules/mod_privacy_dashboard/tmpl/default.php
@@ -9,43 +9,53 @@
 
 defined('_JEXEC') or die;
 
-JHtml::_('bootstrap.tooltip');
+use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Language\Text;
+use Joomla\CMS\Router\Route;
+
+HTMLHelper::_('bootstrap.framework');
 
 $totalRequests  = 0;
 $activeRequests = 0;
 
 ?>
-<div class="row-striped">
-	<?php if (count($list)) : ?>
-		<div class="row-fluid">
-			<div class="span5"><strong><?php echo JText::_('COM_PRIVACY_DASHBOARD_HEADING_REQUEST_TYPE'); ?></strong></div>
-			<div class="span5"><strong><?php echo JText::_('COM_PRIVACY_DASHBOARD_HEADING_REQUEST_STATUS'); ?></strong></div>
-			<div class="span2"><strong><?php echo JText::_('COM_PRIVACY_DASHBOARD_HEADING_REQUEST_COUNT'); ?></strong></div>
-		</div>
+<table class="table" id="<?php echo str_replace(' ', '', $module->title) . $module->id; ?>">
+	<caption class="sr-only"><?php echo $module->title; ?></caption>
+	<thead>
+		<tr>
+			<th scope="col" style="width:40%"><?php echo Text::_('COM_PRIVACY_DASHBOARD_HEADING_REQUEST_TYPE'); ?></th>
+			<th scope="col" style="width:30%"><?php echo Text::_('COM_PRIVACY_DASHBOARD_HEADING_REQUEST_STATUS'); ?></th>
+			<th scope="col" style="width:30%"><?php echo Text::_('COM_PRIVACY_DASHBOARD_HEADING_REQUEST_COUNT'); ?></th>
+		</tr>
+	</thead>
+	<tbody>
+		<?php if (count($list)) : ?>
 		<?php foreach ($list as $row) : ?>
-			<div class="row-fluid">
-				<div class="span5">
-					<a class="hasTooltip" href="<?php echo JRoute::_('index.php?option=com_privacy&view=requests&filter[request_type]=' . $row->request_type . '&filter[status]=' . $row->status); ?>" data-original-title="<?php echo JText::_('COM_PRIVACY_DASHBOARD_VIEW_REQUESTS'); ?>">
-						<strong><?php echo JText::_('COM_PRIVACY_HEADING_REQUEST_TYPE_TYPE_' . $row->request_type); ?></strong>
-					</a>
-				</div>
-				<div class="span5"><?php echo JHtml::_('privacy.statusLabel', $row->status); ?></div>
-				<div class="span2"><span class="badge badge-info"><?php echo $row->count; ?></span></div>
-			</div>
+		<tr>
+			<td>
+				<a href="<?php echo Route::_('index.php?option=com_privacy&view=requests&filter[request_type]=' . $row->request_type . '&filter[status]=' . $row->status); ?>" data-original-title="<?php echo Text::_('COM_PRIVACY_DASHBOARD_VIEW_REQUESTS'); ?>">
+					<strong><?php echo Text::_('COM_PRIVACY_HEADING_REQUEST_TYPE_TYPE_' . $row->request_type); ?></strong>
+				</a>
+			</td>
+			<td><?php echo HTMLHelper::_('privacy.statusLabel', $row->status); ?></td>
+			<td><span class="badge badge-info"><?php echo $row->count; ?></span></td>
 			<?php if (in_array($row->status, array(0, 1))) : ?>
 				<?php $activeRequests += $row->count; ?>
 			<?php endif; ?>
 			<?php $totalRequests += $row->count; ?>
+		</tr>
 		<?php endforeach; ?>
-		<div class="row-fluid">
-			<div class="span5"><?php echo JText::plural('COM_PRIVACY_DASHBOARD_BADGE_TOTAL_REQUESTS', $totalRequests); ?></div>
-			<div class="span7"><?php echo JText::plural('COM_PRIVACY_DASHBOARD_BADGE_ACTIVE_REQUESTS', $activeRequests); ?></div>
-		</div>
-	<?php else : ?>
-		<div class="row-fluid">
-			<div class="span12">
-				<div class="alert"><?php echo JText::_('COM_PRIVACY_DASHBOARD_NO_REQUESTS'); ?></div>
-			</div>
-		</div>
-	<?php endif; ?>
-</div>
+		<tr>
+			<td><?php echo Text::plural('COM_PRIVACY_DASHBOARD_BADGE_TOTAL_REQUESTS', $totalRequests); ?></td>
+			<td><?php echo Text::plural('COM_PRIVACY_DASHBOARD_BADGE_ACTIVE_REQUESTS', $activeRequests); ?></td>
+			<td></td>
+		</tr>
+		<?php else : ?>
+		<tr>
+			<td colspan="3">
+				<?php echo Text::_('COM_PRIVACY_DASHBOARD_NO_REQUESTS'); ?>
+			</td>
+		</tr>
+		<?php endif; ?>
+	</tbody>
+</table>

--- a/administrator/modules/mod_privacy_dashboard/tmpl/default.php
+++ b/administrator/modules/mod_privacy_dashboard/tmpl/default.php
@@ -23,22 +23,22 @@ $activeRequests = 0;
 	<caption class="sr-only"><?php echo $module->title; ?></caption>
 	<thead>
 		<tr>
-			<th scope="col" style="width:40%"><?php echo Text::_('COM_PRIVACY_DASHBOARD_HEADING_REQUEST_TYPE'); ?></th>
-			<th scope="col" style="width:30%"><?php echo Text::_('COM_PRIVACY_DASHBOARD_HEADING_REQUEST_STATUS'); ?></th>
-			<th scope="col" style="width:30%"><?php echo Text::_('COM_PRIVACY_DASHBOARD_HEADING_REQUEST_COUNT'); ?></th>
+			<th colspan="2" scope="col" style="width:40%"><?php echo Text::_('COM_PRIVACY_DASHBOARD_HEADING_REQUEST_TYPE'); ?></th>
+			<th colspan="2" scope="col" style="width:30%"><?php echo Text::_('COM_PRIVACY_DASHBOARD_HEADING_REQUEST_STATUS'); ?></th>
+			<th colspan="2" scope="col" style="width:30%"><?php echo Text::_('COM_PRIVACY_DASHBOARD_HEADING_REQUEST_COUNT'); ?></th>
 		</tr>
 	</thead>
 	<tbody>
 		<?php if (count($list)) : ?>
 		<?php foreach ($list as $row) : ?>
 		<tr>
-			<td>
-				<a href="<?php echo Route::_('index.php?option=com_privacy&view=requests&filter[request_type]=' . $row->request_type . '&filter[status]=' . $row->status); ?>" data-original-title="<?php echo Text::_('COM_PRIVACY_DASHBOARD_VIEW_REQUESTS'); ?>">
+			<td colspan="2">
+				<a href="<?php echo Route::_('index.php?option=com_privacy&view=requests&filter[request_type]=' . $row->request_type . '&filter[status]=' . $row->status); ?>">
 					<strong><?php echo Text::_('COM_PRIVACY_HEADING_REQUEST_TYPE_TYPE_' . $row->request_type); ?></strong>
 				</a>
 			</td>
-			<td><?php echo HTMLHelper::_('privacy.statusLabel', $row->status); ?></td>
-			<td><span class="badge badge-info"><?php echo $row->count; ?></span></td>
+			<td colspan="2"><?php echo HTMLHelper::_('privacy.statusLabel', $row->status); ?></td>
+			<td colspan="2"><span class="badge badge-info"><?php echo $row->count; ?></span></td>
 			<?php if (in_array($row->status, array(0, 1))) : ?>
 				<?php $activeRequests += $row->count; ?>
 			<?php endif; ?>
@@ -46,13 +46,12 @@ $activeRequests = 0;
 		</tr>
 		<?php endforeach; ?>
 		<tr>
-			<td><?php echo Text::plural('COM_PRIVACY_DASHBOARD_BADGE_TOTAL_REQUESTS', $totalRequests); ?></td>
-			<td><?php echo Text::plural('COM_PRIVACY_DASHBOARD_BADGE_ACTIVE_REQUESTS', $activeRequests); ?></td>
-			<td></td>
+			<td colspan="2" style="text-align:center"><?php echo Text::plural('COM_PRIVACY_DASHBOARD_BADGE_TOTAL_REQUESTS', $totalRequests); ?></td>
+			<td colspan="4" style="text-align:center"><?php echo Text::plural('COM_PRIVACY_DASHBOARD_BADGE_ACTIVE_REQUESTS', $activeRequests); ?></td>
 		</tr>
 		<?php else : ?>
 		<tr>
-			<td colspan="3">
+			<td colspan="6">
 				<?php echo Text::_('COM_PRIVACY_DASHBOARD_NO_REQUESTS'); ?>
 			</td>
 		</tr>


### PR DESCRIPTION
Replaces https://github.com/joomla/joomla-cms/pull/24573 as com_privacy structure is now namespaced

### Summary of Changes
Adapt mod_privacy_dashboard to j4 as was done here: #24563


### Before patch
<img width="660" alt="Screen Shot 2019-04-13 at 10 28 36" src="https://user-images.githubusercontent.com/869724/56076983-f36e7e00-5dd6-11e9-86c8-08359f74d56e.png">
### After patch
<img width="660" alt="Screen Shot 2019-04-13 at 10 15 55" src="https://user-images.githubusercontent.com/869724/56076968-c1f5b280-5dd6-11e9-8e0c-04049837fd2c.png">

@alikon @ghazal 