### PR TITLE
[4.0] frontend en-GB fix alpha ordering

### DIFF
--- a/language/en-GB/en-GB.ini
+++ b/language/en-GB/en-GB.ini
@@ -12,8 +12,8 @@ JERROR_PARSING_LANGUAGE_FILE="&#160;: error(s) in line(s) %s"
 
 ERROR="Error"
 INFO="Info"
-NOTICE="Notice"
 MESSAGE="Message"
+NOTICE="Notice"
 WARNING="Warning"
 
 J1="1"


### PR DESCRIPTION
The string **M**essage should precede the string **N**otice.