### PR TITLE
[4.0] Associations Toolbar missing in article edit

### DIFF
--- a/administrator/components/com_content/View/Article/HtmlView.php
+++ b/administrator/components/com_content/View/Article/HtmlView.php
@@ -145,7 +145,7 @@ class HtmlView extends BaseHtmlView
 		if ($isNew && (count($user->getAuthorisedCategories('com_content', 'core.create')) > 0))
 		{
 			$apply = $toolbar->apply('article.apply');
-			
+
 			$saveGroup = $toolbar->dropdownButton('save-group');
 
 			$saveGroup->configure(
@@ -266,7 +266,9 @@ class HtmlView extends BaseHtmlView
 
 		if (Associations::isEnabled() && ComponentHelper::isEnabled('com_associations'))
 		{
-			$toolbar->customButton('contract', 'JTOOLBAR_ASSOCIATIONS', 'article.editAssociations');
+			$toolbar->standardButton('contract')
+			->text('JTOOLBAR_ASSOCIATIONS')
+			->task('article.editAssociations');
 		}
 
 		$toolbar->cancel('article.cancel', 'JTOOLBAR_CLOSE');


### PR DESCRIPTION
### Summary of Changes
Adapting code to Toolbar class.

### Testing Instructions
Multilingual site.
Associations set to Yes.
Edit an article which is tagged to one of the Content languages.


### Before patch
The Associations Toolbar does not display as the code is wrong.
(Reminder: this Associations Toolbar lets open com_associations side by side page with the edited article as reference to create new associations.)

<img width="1021" alt="Screen Shot 2019-04-16 at 06 16 24" src="https://user-images.githubusercontent.com/869724/56182141-0b314680-6011-11e9-9e26-f61076e484d8.png">

### After Patch

<img width="1292" alt="Screen Shot 2019-04-16 at 06 17 31" src="https://user-images.githubusercontent.com/869724/56182152-171d0880-6011-11e9-8ec9-4c0caf0c301e.png">

