### PR TITLE
[4.0] [com_users] Correct path to form

### DIFF
--- a/administrator/components/com_users/config.xml
+++ b/administrator/components/com_users/config.xml
@@ -122,7 +122,7 @@
 			description="COM_USERS_CONFIG_FIELD_DOMAINS_DESC"
 			multiple="true"
 			layout="joomla.form.field.subform.repeatable-table"
-			formsource="administrator/components/com_users/models/forms/config_domain.xml"
+			formsource="administrator/components/com_users/forms/config_domain.xml"
 		/>
 	</fieldset>
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Corrects path to subform.

### Testing Instructions

Configure `com_users` options in backend. Switch to `Email Domain Options` tab.

### Expected result

No errors, form loaded.

### Actual result
```
Joomla\CMS\Form\Form::getInstance() could not load file 
```
### Documentation Changes Required
No.
