### PR TITLE
[4.0] Debug settings not respected

### DIFF
--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -153,12 +153,12 @@ class PlgSystemDebug extends CMSPlugin
 		$this->debugLang = $this->app->get('debug_lang');
 
 		// Skip the plugin if debug is off
-		if ($this->debugLang === '0' && $this->app->get('debug') === '0')
+		if (!$this->debugLang && !$this->app->get('debug'))
 		{
 			return;
 		}
 
-		$this->app->getConfig()->set('gzip', 0);
+		$this->app->getConfig()->set('gzip', false);
 		ob_start();
 		ob_implicit_flush(false);
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Changes configuration value comparison.

### Testing Instructions

Make sure `System - Debug` plugin is enabled.

In Global Configuration disable `Debug System` and `Debug Language` options.

Enable `Gzip Page Compression`.

Check that GZip is enabled. This can be done in browser by checking that Joomla pages send `X-Content-Encoded-By:"Joomla"` header.

### Expected result

GZip is enabled.

### Actual result

GZip is disabled.

### Documentation Changes Required
No.
