### PR TITLE
[4.0] Privacy Dashboard

### DIFF
--- a/administrator/components/com_privacy/Service/HTML/Privacy.php
+++ b/administrator/components/com_privacy/Service/HTML/Privacy.php
@@ -21,7 +21,7 @@ use Joomla\CMS\Language\Text;
 class Privacy
 {
 	/**
-	 * Render a status label
+	 * Render a status badge
 	 *
 	 * @param   integer  $status  The item status
 	 *
@@ -34,17 +34,17 @@ class Privacy
 		switch ($status)
 		{
 			case 2:
-				return '<span class="label label-success">' . Text::_('COM_PRIVACY_STATUS_COMPLETED') . '</span>';
+				return '<span class="badge badge-success">' . JText::_('COM_PRIVACY_STATUS_COMPLETED') . '</span>';
 
 			case 1:
-				return '<span class="label label-info">' . Text::_('COM_PRIVACY_STATUS_CONFIRMED') . '</span>';
+				return '<span class="badge badge-info">' . JText::_('COM_PRIVACY_STATUS_CONFIRMED') . '</span>';
 
 			case -1:
-				return '<span class="label label-important">' . Text::_('COM_PRIVACY_STATUS_INVALID') . '</span>';
+				return '<span class="badge badge-important">' . JText::_('COM_PRIVACY_STATUS_INVALID') . '</span>';
 
 			default:
 			case 0:
-				return '<span class="label label-warning">' . Text::_('COM_PRIVACY_STATUS_PENDING') . '</span>';
+				return '<span class="badge badge-warning">' . JText::_('COM_PRIVACY_STATUS_PENDING') . '</span>';
 		}
 	}
 }

--- a/administrator/components/com_privacy/Service/HTML/Privacy.php
+++ b/administrator/components/com_privacy/Service/HTML/Privacy.php
@@ -34,13 +34,13 @@ class Privacy
 		switch ($status)
 		{
 			case 2:
-				return '<span class="badge badge-success">' . JText::_('COM_PRIVACY_STATUS_COMPLETED') . '</span>';
+				return '<span class="badge badge-success">' . Text::_('COM_PRIVACY_STATUS_COMPLETED') . '</span>';
 
 			case 1:
-				return '<span class="badge badge-info">' . JText::_('COM_PRIVACY_STATUS_CONFIRMED') . '</span>';
+				return '<span class="badge badge-info">' . Text::_('COM_PRIVACY_STATUS_CONFIRMED') . '</span>';
 
 			case -1:
-				return '<span class="badge badge-important">' . JText::_('COM_PRIVACY_STATUS_INVALID') . '</span>';
+				return '<span class="badge badge-important">' . Text::_('COM_PRIVACY_STATUS_INVALID') . '</span>';
 
 			default:
 			case 0:

--- a/administrator/components/com_privacy/Service/HTML/Privacy.php
+++ b/administrator/components/com_privacy/Service/HTML/Privacy.php
@@ -44,7 +44,7 @@ class Privacy
 
 			default:
 			case 0:
-				return '<span class="badge badge-warning">' . JText::_('COM_PRIVACY_STATUS_PENDING') . '</span>';
+				return '<span class="badge badge-warning">' . Text::_('COM_PRIVACY_STATUS_PENDING') . '</span>';
 		}
 	}
 }

--- a/administrator/components/com_privacy/helpers/html/helper.php
+++ b/administrator/components/com_privacy/helpers/html/helper.php
@@ -17,7 +17,7 @@ defined('_JEXEC') or die;
 class PrivacyHtmlHelper
 {
 	/**
-	 * Render a status label
+	 * Render a status badge
 	 *
 	 * @param   integer  $status  The item status
 	 *
@@ -30,17 +30,17 @@ class PrivacyHtmlHelper
 		switch ($status)
 		{
 			case 2:
-				return '<span class="label label-success">' . JText::_('COM_PRIVACY_STATUS_COMPLETED') . '</span>';
+				return '<span class="badge badge-success">' . JText::_('COM_PRIVACY_STATUS_COMPLETED') . '</span>';
 
 			case 1:
-				return '<span class="label label-info">' . JText::_('COM_PRIVACY_STATUS_CONFIRMED') . '</span>';
+				return '<span class="badge badge-info">' . JText::_('COM_PRIVACY_STATUS_CONFIRMED') . '</span>';
 
 			case -1:
-				return '<span class="label label-important">' . JText::_('COM_PRIVACY_STATUS_INVALID') . '</span>';
+				return '<span class="badge badge-important">' . JText::_('COM_PRIVACY_STATUS_INVALID') . '</span>';
 
 			default:
 			case 0:
-				return '<span class="label label-warning">' . JText::_('COM_PRIVACY_STATUS_PENDING') . '</span>';
+				return '<span class="badge badge-warning">' . JText::_('COM_PRIVACY_STATUS_PENDING') . '</span>';
 		}
 	}
 }

--- a/administrator/modules/mod_privacy_dashboard/tmpl/default.php
+++ b/administrator/modules/mod_privacy_dashboard/tmpl/default.php
@@ -9,43 +9,57 @@
 
 defined('_JEXEC') or die;
 
-JHtml::_('bootstrap.tooltip');
+use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Language\Text;
+use Joomla\CMS\Router\Route;
 
 $totalRequests  = 0;
 $activeRequests = 0;
 
 ?>
-<div class="row-striped">
-	<?php if (count($list)) : ?>
-		<div class="row-fluid">
-			<div class="span5"><strong><?php echo JText::_('COM_PRIVACY_DASHBOARD_HEADING_REQUEST_TYPE'); ?></strong></div>
-			<div class="span5"><strong><?php echo JText::_('COM_PRIVACY_DASHBOARD_HEADING_REQUEST_STATUS'); ?></strong></div>
-			<div class="span2"><strong><?php echo JText::_('COM_PRIVACY_DASHBOARD_HEADING_REQUEST_COUNT'); ?></strong></div>
-		</div>
-		<?php foreach ($list as $row) : ?>
-			<div class="row-fluid">
-				<div class="span5">
-					<a class="hasTooltip" href="<?php echo JRoute::_('index.php?option=com_privacy&view=requests&filter[request_type]=' . $row->request_type . '&filter[status]=' . $row->status); ?>" data-original-title="<?php echo JText::_('COM_PRIVACY_DASHBOARD_VIEW_REQUESTS'); ?>">
-						<strong><?php echo JText::_('COM_PRIVACY_HEADING_REQUEST_TYPE_TYPE_' . $row->request_type); ?></strong>
+
+<table class="table" id="<?php echo str_replace(' ', '', $module->title) . $module->id; ?>">
+	<caption class="sr-only"><?php echo $module->title; ?></caption>
+	<thead>
+		<tr>
+			<th scope="col" style="width:40%"><?php echo Text::_('COM_PRIVACY_DASHBOARD_HEADING_REQUEST_TYPE'); ?></th>
+			<th scope="col" style="width:40%"><?php echo Text::_('COM_PRIVACY_DASHBOARD_HEADING_REQUEST_STATUS'); ?></th>
+			<th scope="col" style="width:20%"><?php echo Text::_('COM_PRIVACY_DASHBOARD_HEADING_REQUEST_COUNT'); ?></th>
+		</tr>
+	</thead>
+	<tbody>
+		<?php if (count($list)) : ?>
+			<?php foreach ($list as $i => $item) : ?>
+			<tr>
+				<th scope="row">
+					<a href="<?php echo Route::_('index.php?option=com_privacy&view=requests&filter[request_type]=' . $item->request_type . '&filter[status]=' . $item->status); ?>">
+						<?php echo Text::_('COM_PRIVACY_HEADING_REQUEST_TYPE_TYPE_' . $item->request_type); ?>
 					</a>
-				</div>
-				<div class="span5"><?php echo JHtml::_('PrivacyHtml.helper.statusLabel', $row->status); ?></div>
-				<div class="span2"><span class="badge badge-info"><?php echo $row->count; ?></span></div>
-			</div>
-			<?php if (in_array($row->status, array(0, 1))) : ?>
-				<?php $activeRequests += $row->count; ?>
-			<?php endif; ?>
-			<?php $totalRequests += $row->count; ?>
-		<?php endforeach; ?>
-		<div class="row-fluid">
-			<div class="span5"><?php echo JText::plural('COM_PRIVACY_DASHBOARD_BADGE_TOTAL_REQUESTS', $totalRequests); ?></div>
-			<div class="span7"><?php echo JText::plural('COM_PRIVACY_DASHBOARD_BADGE_ACTIVE_REQUESTS', $activeRequests); ?></div>
-		</div>
-	<?php else : ?>
-		<div class="row-fluid">
-			<div class="span12">
-				<div class="alert"><?php echo JText::_('COM_PRIVACY_DASHBOARD_NO_REQUESTS'); ?></div>
-			</div>
-		</div>
+				</td>
+				<td>
+					<?php echo HTMLHelper::_('PrivacyHtml.helper.statusLabel', $item->status); ?>
+				</td>
+				<td>
+					<span class="badge badge-info"><?php echo $item->count; ?></span>
+				</td>
+			</tr>
+			<?php endforeach; ?>
+		<?php else : ?>
+		<tr>
+			<td colspan="3">
+				<?php echo Text::_('COM_PRIVACY_DASHBOARD_NO_REQUESTS'); ?>
+			</td>
+		</tr>
+		<?php endif; ?>
+	</tbody>
+</table>
+<?php if (count($list)) : ?>
+	<?php if (in_array($item->status, array(0, 1))) : ?>
+		<?php $activeRequests += $item->count; ?>
 	<?php endif; ?>
-</div>
+	<?php $totalRequests += $item->count; ?>
+	<div class="row">
+		<div class="col-md-6"><?php echo Text::plural('COM_PRIVACY_DASHBOARD_BADGE_TOTAL_REQUESTS', $totalRequests); ?></div>
+		<div class="col-md-6"><?php echo Text::plural('COM_PRIVACY_DASHBOARD_BADGE_ACTIVE_REQUESTS', $activeRequests); ?></div>
+	</div>
+<?php endif; ?>

--- a/administrator/modules/mod_privacy_dashboard/tmpl/default.php
+++ b/administrator/modules/mod_privacy_dashboard/tmpl/default.php
@@ -37,7 +37,7 @@ $activeRequests = 0;
 					</a>
 				</td>
 				<td>
-					<?php echo HTMLHelper::_('PrivacyHtml.helper.statusLabel', $item->status); ?>
+					<?php echo HTMLHelper::_('privacy.statusLabel', $item->status); ?>
 				</td>
 				<td>
 					<span class="badge badge-info"><?php echo $item->count; ?></span>

--- a/administrator/modules/mod_privacy_dashboard/tmpl/default.php
+++ b/administrator/modules/mod_privacy_dashboard/tmpl/default.php
@@ -9,43 +9,58 @@
 
 defined('_JEXEC') or die;
 
-JHtml::_('bootstrap.tooltip');
+use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Language\Text;
+use Joomla\CMS\Router\Route;
 
 $totalRequests  = 0;
 $activeRequests = 0;
 
 ?>
-<div class="row-striped">
-	<?php if (count($list)) : ?>
-		<div class="row-fluid">
-			<div class="span5"><strong><?php echo JText::_('COM_PRIVACY_DASHBOARD_HEADING_REQUEST_TYPE'); ?></strong></div>
-			<div class="span5"><strong><?php echo JText::_('COM_PRIVACY_DASHBOARD_HEADING_REQUEST_STATUS'); ?></strong></div>
-			<div class="span2"><strong><?php echo JText::_('COM_PRIVACY_DASHBOARD_HEADING_REQUEST_COUNT'); ?></strong></div>
-		</div>
-		<?php foreach ($list as $row) : ?>
-			<div class="row-fluid">
-				<div class="span5">
-					<a class="hasTooltip" href="<?php echo JRoute::_('index.php?option=com_privacy&view=requests&filter[request_type]=' . $row->request_type . '&filter[status]=' . $row->status); ?>" data-original-title="<?php echo JText::_('COM_PRIVACY_DASHBOARD_VIEW_REQUESTS'); ?>">
-						<strong><?php echo JText::_('COM_PRIVACY_HEADING_REQUEST_TYPE_TYPE_' . $row->request_type); ?></strong>
+
+<table class="table" id="<?php echo str_replace(' ', '', $module->title) . $module->id; ?>">
+	<caption class="sr-only"><?php echo $module->title; ?></caption>
+	<thead>
+		<tr>
+			<th scope="col" style="width:40%"><?php echo Text::_('COM_PRIVACY_DASHBOARD_HEADING_REQUEST_TYPE'); ?></th>
+			<th scope="col" style="width:40%"><?php echo Text::_('COM_PRIVACY_DASHBOARD_HEADING_REQUEST_STATUS'); ?></th>
+			<th scope="col" style="width:20%"><?php echo Text::_('COM_PRIVACY_DASHBOARD_HEADING_REQUEST_COUNT'); ?></th>
+		</tr>
+	</thead>
+	<tbody>
+		<?php if (count($list)) : ?>
+			<?php foreach ($list as $i => $item) : ?>
+			<tr>
+				<th scope="row">
+					<a href="<?php echo Route::_('index.php?option=com_privacy&view=requests&filter[request_type]=' . $item->request_type . '&filter[status]=' . $item->status); ?>">
+						<?php echo Text::_('COM_PRIVACY_HEADING_REQUEST_TYPE_TYPE_' . $item->request_type); ?>
 					</a>
-				</div>
-				<div class="span5"><?php echo JHtml::_('privacy.statusLabel', $row->status); ?></div>
-				<div class="span2"><span class="badge badge-info"><?php echo $row->count; ?></span></div>
-			</div>
-			<?php if (in_array($row->status, array(0, 1))) : ?>
-				<?php $activeRequests += $row->count; ?>
-			<?php endif; ?>
-			<?php $totalRequests += $row->count; ?>
-		<?php endforeach; ?>
-		<div class="row-fluid">
-			<div class="span5"><?php echo JText::plural('COM_PRIVACY_DASHBOARD_BADGE_TOTAL_REQUESTS', $totalRequests); ?></div>
-			<div class="span7"><?php echo JText::plural('COM_PRIVACY_DASHBOARD_BADGE_ACTIVE_REQUESTS', $activeRequests); ?></div>
-		</div>
-	<?php else : ?>
-		<div class="row-fluid">
-			<div class="span12">
-				<div class="alert"><?php echo JText::_('COM_PRIVACY_DASHBOARD_NO_REQUESTS'); ?></div>
-			</div>
-		</div>
+
+				</td>
+				<td>
+					<?php echo HTMLHelper::_('PrivacyHtml.helper.statusLabel', $item->status); ?>
+				</td>
+				<td>
+					<span class="badge badge-info"><?php echo $item->count; ?></span>
+				</td>
+			</tr>
+			<?php endforeach; ?>
+		<?php else : ?>
+		<tr>
+			<td colspan="3">
+				<?php echo Text::_('COM_PRIVACY_DASHBOARD_NO_REQUESTS'); ?>
+			</td>
+		</tr>
+		<?php endif; ?>
+	</tbody>
+</table>
+<?php if (count($list)) : ?>
+	<?php if (in_array($item->status, array(0, 1))) : ?>
+		<?php $activeRequests += $item->count; ?>
 	<?php endif; ?>
-</div>
+	<?php $totalRequests += $item->count; ?>
+	<div class="row">
+		<div class="col-md-6"><?php echo Text::plural('COM_PRIVACY_DASHBOARD_BADGE_TOTAL_REQUESTS', $totalRequests); ?></div>
+		<div class="col-md-6"><?php echo Text::plural('COM_PRIVACY_DASHBOARD_BADGE_ACTIVE_REQUESTS', $activeRequests); ?></div>
+	</div>
+<?php endif; ?>


### PR DESCRIPTION
Adapt mod_privacy_dashboard to j4 ensuring that we use tables only for tabular data and not for display purposes. 

The class on the div might need to be changed as I am not familiar yet with the bs4 options

### With requests

<img width="330" alt="chrome_2019-04-16_10-42-07" src="https://user-images.githubusercontent.com/1296369/56200245-4eea7700-6036-11e9-80ab-f8e4fea8c181.png">

### No requests
<img width="533" alt="chrome_2019-04-16_10-48-05" src="https://user-images.githubusercontent.com/1296369/56200247-4eea7700-6036-11e9-9570-136006f427d6.png">
