### PR TITLE
Fix articles view with workflow stage change

### DIFF
--- a/build/media_source/com_content/js/admin-articles-workflow-buttons.es6.js
+++ b/build/media_source/com_content/js/admin-articles-workflow-buttons.es6.js
@@ -152,9 +152,9 @@ Joomla.toggleAllNextElements = (element, className) => {
       }
     }
 
-    publishBtn.addEventListener('click', (e) => {
-      if (e.target.classList.contains('disabled')) {
-        e.stopPropagation();
+    publishBtn.parentElement.addEventListener('click', (e) => {
+      if (publishBtn.classList.contains('disabled')) {
+        e.stopImmediatePropagation();
 
         Joomla.renderMessages({ error: [Joomla.JText._('COM_CONTENT_ERROR_CANNOT_PUBlISH')] });
       } else {
@@ -162,9 +162,9 @@ Joomla.toggleAllNextElements = (element, className) => {
       }
     });
 
-    unpublishBtn.addEventListener('click', (e) => {
-      if (e.target.classList.contains('disabled')) {
-        e.stopPropagation();
+    unpublishBtn.parentElement.addEventListener('click', (e) => {
+      if (unpublishBtn.classList.contains('disabled')) {
+        e.stopImmediatePropagation();
 
         Joomla.renderMessages({ error: [Joomla.JText._('COM_CONTENT_ERROR_CANNOT_UNPUBlISH')] });
       } else {
@@ -172,9 +172,9 @@ Joomla.toggleAllNextElements = (element, className) => {
       }
     });
 
-    archiveBtn.addEventListener('click', (e) => {
-      if (e.target.classList.contains('disabled')) {
-        e.stopPropagation();
+    archiveBtn.parentElement.addEventListener('click', (e) => {
+      if (archiveBtn.classList.contains('disabled')) {
+        e.stopImmediatePropagation();
 
         Joomla.renderMessages({ error: [Joomla.JText._('COM_CONTENT_ERROR_CANNOT_ARCHIVE')] });
       } else {
@@ -182,9 +182,9 @@ Joomla.toggleAllNextElements = (element, className) => {
       }
     });
 
-    trashBtn.addEventListener('click', (e) => {
-      if (e.target.classList.contains('disabled')) {
-        e.stopPropagation();
+    trashBtn.parentElement.addEventListener('click', (e) => {
+      if (trashBtn.classList.contains('disabled')) {
+        e.stopImmediatePropagation();
 
         Joomla.renderMessages({ error: [Joomla.JText._('COM_CONTENT_ERROR_CANNOT_TRASH')] });
       } else {

--- a/build/media_source/system/js/fields/joomla-field-fancy-select.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-fancy-select.w-c.es6.js
@@ -141,7 +141,7 @@ window.customElements.define('joomla-field-fancy-select', class extends HTMLElem
     // Handle remote search
     if (this.remoteSearch && this.url) {
       // Cache existing
-      this.choicesInstance.presetChoices.forEach((choiceItem) => {
+      this.choicesInstance.config.choices.forEach((choiceItem) => {
         this.choicesCache[choiceItem.value] = choiceItem.label;
       });
 


### PR DESCRIPTION
### Summary of Changes
At the moment, if you go to the articles view and select an article, the "Change Status" (and the sub-buttons) button becomes active/disabled depending on the available transitions, but clicking a disable status change does not prevent the execution.
Also multiple possibilities are not recognized anymore (should show a modal).

Reason: there are new event listeners which conflicts with the workflow listener.


### Testing Instructions
- Select an article and click on a disabled dropdown option
or
- Select an article and click on a dropdown option with different transitions

### Expected result
Warning message or modal to select the correct transition


### Actual result
Form will be submitted

