### PR TITLE
Fix being unable to save the user profile

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -87,7 +87,7 @@
         "symfony/debug": "3.4.*",
         "symfony/ldap": "3.4.*",
         "symfony/options-resolver": "3.4.*",
-		"symfony/polyfill-php71": "~1.10",
+        "symfony/polyfill-php71": "~1.10",
         "symfony/polyfill-php73": "^1.10",
         "symfony/web-link": "3.4.*",
         "symfony/yaml": "3.4.*",
@@ -95,7 +95,8 @@
         "maximebf/debugbar": "^1.15",
         "tobscure/json-api": "^0.4.1",
         "willdurand/negotiation": "^2.3",
-        "ext-json": "*"
+        "ext-json": "*",
+        "ext-simplexml": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "~6.0",

--- a/libraries/src/Form/Form.php
+++ b/libraries/src/Form/Form.php
@@ -1211,11 +1211,11 @@ class Form
 
 			$key = $attrGroup ? $attrGroup . '.' . $name : $name;
 
-			$fieldObj = $this->loadField($field, $group);
+			$fieldObj = $this->loadField($field, $attrGroup);
 
 			if ($fieldObj)
 			{
-				$valid = $fieldObj->validate($input->get($key), $group, $input);
+				$valid = $fieldObj->validate($input->get($key), $attrGroup, $input);
 
 				// Check for an error.
 				if ($valid instanceof \Exception)

--- a/plugins/system/actionlogs/actionlogs.php
+++ b/plugins/system/actionlogs/actionlogs.php
@@ -79,7 +79,6 @@ class PlgSystemActionLogs extends JPlugin
 
 		$allowedFormNames = array(
 			'com_users.profile',
-			'com_admin.profile',
 			'com_users.user',
 		);
 


### PR DESCRIPTION
- Removes the `com_admin.profile` which no longer exists in j4
- Adds the php extension `simplexml` as a hard dependency in composer (as without it none of our forms will work and my IDE moans at me whenever I look at any Form related class
- Fixes the group that is passed into the validate function

To test edit your user in the backend and hit save. Before patch it fails. After patch it works. Note there are various bugs related to the showon not working there and language strings not loaded (that's covered by https://github.com/joomla/joomla-cms/issues/17444). I'm calling that out of scope for this PR.