### PR TITLE
Removing unnecessary clone step in drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,8 +1,4 @@
 pipeline:
-  clone:
-    image: plugins/git
-    depth: 1
-
   phpcs:
     image: joomlaprojects/docker-phpcs
     commands:


### PR DESCRIPTION
This step should not be necessary. Drone automatically and always clones your repo.