### PR TITLE
[4.0] Fix creating plugin overrides

### DIFF
--- a/administrator/components/com_templates/tmpl/template/default.php
+++ b/administrator/components/com_templates/tmpl/template/default.php
@@ -280,7 +280,7 @@ if ($this->type == 'font')
 	</div>
 	<div class="col-md-3">
 		<legend><?php echo Text::_('COM_TEMPLATES_OVERRIDES_PLUGINS'); ?></legend>
-		<ul class="nav nav-list">
+		<ul class="list-unstyled">
 			<?php $token = Session::getFormToken() . '=' . 1; ?>
 			<?php foreach ($this->overridesList['plugins'] as $key => $group) : ?>
 				<li class="plugin-folder">

--- a/build/media_source/com_templates/js/admin-templates-default.es6.js
+++ b/build/media_source/com_templates/js/admin-templates-default.es6.js
@@ -6,7 +6,7 @@
   'use strict';
 
   document.addEventListener('DOMContentLoaded', () => {
-    const folders = [].slice.call(document.querySelectorAll('.folder-url, .component-folder-url, .plugin-folder ul, .layout-folder-url'));
+    const folders = [].slice.call(document.querySelectorAll('.folder-url, .component-folder-url, .plugin-folder-url, .layout-folder-url'));
     const innerLists = [].slice.call(document.querySelectorAll('.folder ul, .component-folder ul, .plugin-folder ul, .layout-folder ul'));
     const openLists = [].slice.call(document.querySelectorAll('.show > ul'));
     const fileModalFolders = [].slice.call(document.querySelectorAll('#fileModal .folder-url'));


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Fixes plugin display and override creation in `com_templates`.

### Testing Instructions

Edit a template.
Switch to `Create Overrides` tab.
Click on a plugin group.

### Expected result

Plugin group is expanded to show plugins.

### Actual result

Nothing happens.

### Documentation Changes Required
No.
