### PR TITLE
Update to default.php: removed nowrap class to allow wrapping title...

### DIFF
--- a/administrator/components/com_contact/views/contacts/tmpl/default.php
+++ b/administrator/components/com_contact/views/contacts/tmpl/default.php
@@ -135,7 +135,7 @@ if ($saveOrder)
 								?>
 							</div>
 						</td>
-						<td class="nowrap has-context">
+						<td class="has-context">
 							<div class="pull-left">
 								<?php if ($item->checked_out) : ?>
 									<?php echo JHtml::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, 'contacts.', $canCheckin); ?>


### PR DESCRIPTION
…and alias

Pull Request for Issue #24650.

### Testing Instructions

Create a contact with a name/title of 200+ characters

### Expected result

The title and the alias will wrap.

### Actual result

The title and the alias does not wrap and pushes other parameters (access, hits, language, ID) behind the right edge of the screen.

### Documentation Changes Required

IDK about any.