### PR TITLE
fix to allow hyphen in MySQL database name

### DIFF
--- a/installation/src/Model/DatabaseModel.php
+++ b/installation/src/Model/DatabaseModel.php
@@ -180,7 +180,7 @@ class DatabaseModel extends BaseInstallationModel
 		}
 
 		// Validate database name.
-		if (!preg_match('#^[a-zA-Z][0-9a-zA-Z_$]*$#', $options->db_name))
+		if (!preg_match('#^[a-zA-Z][0-9a-zA-Z_\-$]*$#', $options->db_name))
 		{
 			Factory::getApplication()->enqueueMessage(Text::_('INSTL_DATABASE_NAME_MSG'), 'warning');
 

--- a/installation/src/Model/SetupModel.php
+++ b/installation/src/Model/SetupModel.php
@@ -317,7 +317,7 @@ class SetupModel extends BaseInstallationModel
 		}
 
 		// Validate database name.
-		if (!preg_match('#^[a-zA-Z][0-9a-zA-Z_$]*$#', $options->db_name))
+		if (!preg_match('#^[a-zA-Z][0-9a-zA-Z_\-$]*$#', $options->db_name))
 		{
 			Factory::getApplication()->enqueueMessage(Text::_('INSTL_DATABASE_NAME_MSG'), 'warning');
 


### PR DESCRIPTION
Pull Request for Issue #24657 [installation] Hyphen not allowed anymore in MySQL database name? 

### Summary of Changes
This PR allows you to **use a hyphen in** the **database name** when installing Joomla. 

### Testing Instructions
When installing Joomla 4.0 try to use a database name with hyphen, like "joomla-cms"

### Expected result
In Joomla 3.x it was possible to use a hyphen in the database name. 
I would expect to be able to use a database name with hyphen in Joomla 4 as well.

### Actual result
Using a MySQL database name with a hyphen (like "joomla-cms") results in a warning:
_The database name is invalid. It must start with a letter, followed by alphanumeric characters._
and you have to change the name to something without a hyphen to continue.
