### PR TITLE
[4.0] Fix broken Fontawesome icons on installation pages

### DIFF
--- a/installation/template/scss/template.scss
+++ b/installation/template/scss/template.scss
@@ -7,6 +7,7 @@ $fa-font-path: "../../../media/vendor/fontawesome-free/webfonts";
 
 // "Font Awesome 5 Free"
 @import "../../../media/vendor/fontawesome-free/scss/fontawesome";
+@import "../../../media/vendor/fontawesome-free/scss/solid";
 
 body {
   background-color: #1c3d5c;

--- a/installation/template/scss/template.scss
+++ b/installation/template/scss/template.scss
@@ -8,6 +8,7 @@ $fa-font-path: "../../../media/vendor/fontawesome-free/webfonts";
 // "Font Awesome 5 Free"
 @import "../../../media/vendor/fontawesome-free/scss/fontawesome";
 @import "../../../media/vendor/fontawesome-free/scss/solid";
+@import "../../../media/vendor/fontawesome-free/scss/brands";
 
 body {
   background-color: #1c3d5c;


### PR DESCRIPTION
Pull Request for Issue #24659 .

### Summary of Changes

Add missing import for solid fa icons to installation template.scss.

For consistency with other template.scss, also add import for brands fa icons, even if not used (yet) for the installation pages.

### Testing Instructions

See issue #24659 .

### Expected result

Icons ok.

### Actual result

Icons missing.

### Documentation Changes Required

None.