### PR TITLE
[4.0] Article options record hits

### DIFF
--- a/administrator/components/com_content/config.xml
+++ b/administrator/components/com_content/config.xml
@@ -332,11 +332,11 @@
 			type="radio"
 			label="JGLOBAL_RECORD_HITS_LABEL"
 			description="JGLOBAL_RECORD_HITS_DESC"
-			class="btn-group btn-group-yesno"
+			class="switcher"
 			default="1"
 			>
-			<option value="1">JYES</option>
 			<option value="0">JNO</option>
+			<option value="1">JYES</option>
 		</field>
 
 		<field


### PR DESCRIPTION
Changes the option to use the switcher instead of the old style yes/no

### Before
![image](https://user-images.githubusercontent.com/1296369/56474501-a8a5d380-6472-11e9-90ca-a9eb7579d84e.png)


### After
![image](https://user-images.githubusercontent.com/1296369/56474494-a04d9880-6472-11e9-9a7f-e493ac5ceaf1.png)
