### PR TITLE
[4.0] com_action_logs options

### DIFF
--- a/administrator/components/com_actionlogs/config.xml
+++ b/administrator/components/com_actionlogs/config.xml
@@ -9,7 +9,7 @@
 			class="switcher"
 			default="0"
 			filter="integer"
-		       >
+			>
 			<option value="0">JNO</option>
 			<option value="1">JYES</option>
 		</field>

--- a/administrator/components/com_actionlogs/config.xml
+++ b/administrator/components/com_actionlogs/config.xml
@@ -8,7 +8,8 @@
 			description="COM_ACTIONLOGS_IP_LOGGING_DESC"
 			class="switcher"
 			default="0"
-			>
+			filter="integer"
+		       >
 			<option value="0">JNO</option>
 			<option value="1">JYES</option>
 		</field>

--- a/administrator/components/com_actionlogs/config.xml
+++ b/administrator/components/com_actionlogs/config.xml
@@ -6,12 +6,11 @@
 			type="radio"
 			label="COM_ACTIONLOGS_IP_LOGGING_LABEL"
 			description="COM_ACTIONLOGS_IP_LOGGING_DESC"
-			class="btn-group btn-group-yesno"
+			class="switcher"
 			default="0"
-			filter="integer"
 			>
-			<option value="1">JYES</option>
 			<option value="0">JNO</option>
+			<option value="1">JYES</option>
 		</field>
 		<field
 			name="csv_delimiter"


### PR DESCRIPTION
Simple pr to change the IP logging option to use the switcher instead of the old style yes/no

### Before
![image](https://user-images.githubusercontent.com/1296369/56474623-1d2d4200-6474-11e9-9169-10c11c4a6623.png)

### After
![image](https://user-images.githubusercontent.com/1296369/56474615-10a8e980-6474-11e9-950d-b8161c87c1d1.png)
