### PR TITLE
[4.0] Change default tinymce fontsize

### DIFF
--- a/templates/system/css/editor.css
+++ b/templates/system/css/editor.css
@@ -7,7 +7,7 @@ body {
 	background: #fff;
 	font-family: Tahoma, Helvetica, Arial, sans-serif;
 	line-height: 1.3em;
-	font-size: 76%;
+	font-size: 12px;
 	color: #333;
 }
 


### PR DESCRIPTION
The font size that is displayed in the tinymce toolbar on page load is 12.16px

After a lot of research I found that it is coming from 	`font-size: 76%;` on the body element in `templates\system\css\editor.css`

This PR changes it to a more logical display of 12px

### Before
![image](https://user-images.githubusercontent.com/1296369/56475449-4784fc80-6480-11e9-84bb-0b0a2bf959dc.png)

### After
![image](https://user-images.githubusercontent.com/1296369/56475439-36d48680-6480-11e9-8825-9f0480ef2fe6.png)
