### PR TITLE
[4.0] Missing fontawesome icon

### DIFF
--- a/layouts/joomla/form/field/subform/repeatable-table/section-byfieldsets.php
+++ b/layouts/joomla/form/field/subform/repeatable-table/section-byfieldsets.php
@@ -36,7 +36,7 @@ extract($displayData);
 		<div class="btn-group">
 			<?php if (!empty($buttons['add'])) : ?><a class="group-add btn btn-sm button btn-success" aria-label="<?php echo Text::_('JGLOBAL_FIELD_ADD'); ?>" tabindex="0"><span class="fa fa-plus icon-white" aria-hidden="true"></span> </a><?php endif; ?>
 			<?php if (!empty($buttons['remove'])) : ?><a class="group-remove btn btn-sm button btn-danger" aria-label="<?php echo Text::_('JGLOBAL_FIELD_REMOVE'); ?>" tabindex="0"><span class="fa fa-minus icon-white" aria-hidden="true"></span> </a><?php endif; ?>
-			<?php if (!empty($buttons['move'])) : ?><a class="group-move btn btn-sm button btn-primary" aria-label="<?php echo Text::_('JGLOBAL_FIELD_MOVE'); ?>"><span class="fa fa-arrows icon-white" aria-hidden="true"></span> </a><?php endif; ?>
+			<?php if (!empty($buttons['move'])) : ?><a class="group-move btn btn-sm button btn-primary" aria-label="<?php echo Text::_('JGLOBAL_FIELD_MOVE'); ?>"><span class="fa fa-arrows-alt icon-white" aria-hidden="true"></span> </a><?php endif; ?>
 		</div>
 	</td>
 	<?php endif; ?>

--- a/layouts/joomla/form/field/subform/repeatable-table/section.php
+++ b/layouts/joomla/form/field/subform/repeatable-table/section.php
@@ -34,7 +34,7 @@ extract($displayData);
 		<div class="btn-group">
 			<?php if (!empty($buttons['add'])) : ?><a class="group-add btn btn-sm button btn-success" aria-label="<?php echo Text::_('JGLOBAL_FIELD_ADD'); ?>" tabindex="0"><span class="fa fa-plus icon-white" aria-hidden="true"></span> </a><?php endif; ?>
 			<?php if (!empty($buttons['remove'])) : ?><a class="group-remove btn btn-sm button btn-danger" aria-label="<?php echo Text::_('JGLOBAL_FIELD_REMOVE'); ?>" tabindex="0"><span class="fa fa-minus icon-white" aria-hidden="true"></span> </a><?php endif; ?>
-			<?php if (!empty($buttons['move'])) : ?><a class="group-move btn btn-sm button btn-primary" aria-label="<?php echo Text::_('JGLOBAL_FIELD_MOVE'); ?>"><span class="fa fa-arrows icon-white" aria-hidden="true"></span> </a><?php endif; ?>
+			<?php if (!empty($buttons['move'])) : ?><a class="group-move btn btn-sm button btn-primary" aria-label="<?php echo Text::_('JGLOBAL_FIELD_MOVE'); ?>"><span class="fa fa-arrows-alt icon-white" aria-hidden="true"></span> </a><?php endif; ?>
 		</div>
 	</td>
 	<?php endif; ?>

--- a/layouts/joomla/form/field/subform/repeatable/section-byfieldsets.php
+++ b/layouts/joomla/form/field/subform/repeatable/section-byfieldsets.php
@@ -28,7 +28,7 @@ extract($displayData);
 		<div class="btn-group">
 			<?php if (!empty($buttons['add'])) : ?><a class="group-add btn btn-sm button btn-success" aria-label="<?php echo Text::_('JGLOBAL_FIELD_ADD'); ?>" tabindex="0"><span class="fa fa-plus icon-white" aria-hidden="true"></span> </a><?php endif; ?>
 			<?php if (!empty($buttons['remove'])) : ?><a class="group-remove btn btn-sm button btn-danger" aria-label="<?php echo Text::_('JGLOBAL_FIELD_REMOVE'); ?>" tabindex="0"><span class="fa fa-minus icon-white" aria-hidden="true"></span> </a><?php endif; ?>
-			<?php if (!empty($buttons['move'])) : ?><a class="group-move btn btn-sm button btn-primary" aria-label="<?php echo Text::_('JGLOBAL_FIELD_MOVE'); ?>"><span class="fa fa-arrows icon-white" aria-hidden="true"></span> </a><?php endif; ?>
+			<?php if (!empty($buttons['move'])) : ?><a class="group-move btn btn-sm button btn-primary" aria-label="<?php echo Text::_('JGLOBAL_FIELD_MOVE'); ?>"><span class="fa fa-arrows-alt icon-white" aria-hidden="true"></span> </a><?php endif; ?>
 		</div>
 	</div>
 	<?php endif; ?>

--- a/layouts/joomla/form/field/subform/repeatable/section.php
+++ b/layouts/joomla/form/field/subform/repeatable/section.php
@@ -29,7 +29,7 @@ extract($displayData);
 		<div class="btn-group">
 			<?php if (!empty($buttons['add'])) : ?><a class="group-add btn btn-sm button btn-success" aria-label="<?php echo Text::_('JGLOBAL_FIELD_ADD'); ?>" tabindex="0"><span class="fa fa-plus icon-white" aria-hidden="true"></span> </a><?php endif; ?>
 			<?php if (!empty($buttons['remove'])) : ?><a class="group-remove btn btn-sm button btn-danger" aria-label="<?php echo Text::_('JGLOBAL_FIELD_REMOVE'); ?>" tabindex="0"><span class="fa fa-minus icon-white" aria-hidden="true"></span> </a><?php endif; ?>
-			<?php if (!empty($buttons['move'])) : ?><a class="group-move btn btn-sm button btn-primary" aria-label="<?php echo Text::_('JGLOBAL_FIELD_MOVE'); ?>"><span class="fa fa-arrows icon-white" aria-hidden="true"></span> </a><?php endif; ?>
+			<?php if (!empty($buttons['move'])) : ?><a class="group-move btn btn-sm button btn-primary" aria-label="<?php echo Text::_('JGLOBAL_FIELD_MOVE'); ?>"><span class="fa fa-arrows-alt icon-white" aria-hidden="true"></span> </a><?php endif; ?>
 		</div>
 	</div>
 	<?php endif; ?>


### PR DESCRIPTION
Another icon has been renamed in fontawesome5 - we use it in the repeatable fields

### Before
![image](https://user-images.githubusercontent.com/1296369/56496246-7cc93300-64f0-11e9-8b64-49723a3da2a9.png)

### After
![image](https://user-images.githubusercontent.com/1296369/56496231-6e7b1700-64f0-11e9-956d-6522970d44a2.png)
