### PR TITLE
Correct SQL error when deleting banner tracks on PostgreSQL databases

### DIFF
--- a/administrator/components/com_banners/models/tracks.php
+++ b/administrator/components/com_banners/models/tracks.php
@@ -228,7 +228,7 @@ class BannersModelTracks extends JModelList
 				$query->where('track_date <= ' . $db->quote($end));
 			}
 
-			$where = '1';
+			$where = '1 = 1';
 
 			// Filter by client
 			$clientId = $this->getState('filter.client_id');


### PR DESCRIPTION
Pull Request for Issue #24679 .

### Summary of Changes

Correct the initial where clause so it resolves to a boolean true on every kind of SQL database before other conditions are concatenated with " AND ...".

### Testing Instructions

See issue #24679 + some testers with MySQL database test if things work like before.

### Documentation Changes Required

None.