### PR TITLE
Remove unnecessary where clause to avoid SQL error on PostgreSQL databases

### DIFF
--- a/administrator/components/com_finder/models/maps.php
+++ b/administrator/components/com_finder/models/maps.php
@@ -398,8 +398,7 @@ class FinderModelMaps extends JModelList
 		$db->execute();
 
 		$query->clear()
-			->delete($db->quoteName('#__finder_taxonomy_map'))
-			->where('1');
+			->delete($db->quoteName('#__finder_taxonomy_map'));
 		$db->setQuery($query);
 		$db->execute();
 


### PR DESCRIPTION
Pull Request for Issue # [https://github.com/joomla/joomla-cms/issues/24679#issuecomment-485399441](https://github.com/joomla/joomla-cms/issues/24679#issuecomment-485399441) .

### Summary of Changes

Remove unnecessary where clause from delete statement when purging finder taxonomy maps to avoid SQL error on PostgreSQL databases.

There is no need for a where clause in that SQL statement, and the existing where clause `1` will cause an error on PostgreSQL databases, see issue #24679 and PR #24682 for another issue caused by the same kind of condition `1` in a where clause.

### Testing Instructions

Code review: There is no need for a where clause in that SQL statement.

### Documentation Changes Required

None.