### PR TITLE
[4.0] Missing icon in com_banners

### DIFF
--- a/administrator/components/com_banners/View/Tracks/HtmlView.php
+++ b/administrator/components/com_banners/View/Tracks/HtmlView.php
@@ -99,7 +99,7 @@ class HtmlView extends BaseHtmlView
 		$dhtml  = $layout->render(
 			array(
 				'selector' => 'downloadModal',
-				'icon'     => 'download',
+				'icon'     => 'icon-download',
 				'text'     => Text::_('JTOOLBAR_EXPORT'),
 				'doTask'   => Route::_('index.php?option=com_banners&view=download&tmpl=component'),
 			)


### PR DESCRIPTION
Not sure how it happened or why but the icon for export tracks was wrong (nothing to do with the recent fontawesome changes)

### Before
![image](https://user-images.githubusercontent.com/1296369/56500408-91aec200-6502-11e9-9fd8-eede64a33883.png)


### After
![image](https://user-images.githubusercontent.com/1296369/56500399-865b9680-6502-11e9-8807-51c3bdf8e04d.png)
