### PR TITLE
[4.0] Banner clients missing class

### DIFF
--- a/administrator/components/com_banners/tmpl/clients/default.php
+++ b/administrator/components/com_banners/tmpl/clients/default.php
@@ -129,19 +129,19 @@ $params     = $this->state->params ?? new JObject;
 										<?php echo $item->contact; ?>
 									</td>
 									<td class="center btns d-none d-lg-table-cell">
-										<a class="badge <?php if ($item->count_published > 0) echo 'badge-success'; ?>" href="<?php echo Route::_('index.php?option=com_banners&view=banners&filter[client_id]=' . (int) $item->id . '&filter[published]=1'); ?>">
+										<a class="badge <?php echo ($item->count_published > 0) ? 'badge-success' : 'badge-secondary'; ?>" href="<?php echo Route::_('index.php?option=com_banners&view=banners&filter[client_id]=' . (int) $item->id . '&filter[published]=1'); ?>">
 											<?php echo $item->count_published; ?></a>
 									</td>
 									<td class="center btns d-none d-lg-table-cell">
-										<a class="badge <?php if ($item->count_unpublished > 0) echo 'badge-danger'; ?>" href="<?php echo Route::_('index.php?option=com_banners&view=banners&filter[client_id]=' . (int) $item->id . '&filter[published]=0'); ?>">
+										<a class="badge <?php echo ($item->count_unpublished > 0) ? 'badge-danger' : 'badge-secondary'; ?>" href="<?php echo Route::_('index.php?option=com_banners&view=banners&filter[client_id]=' . (int) $item->id . '&filter[published]=0'); ?>">
 											<?php echo $item->count_unpublished; ?></a>
 									</td>
 									<td class="center btns d-none d-lg-table-cell">
-										<a class="badge <?php if ($item->count_archived > 0) echo 'badge-info'; ?>" href="<?php echo Route::_('index.php?option=com_banners&view=banners&filter[client_id]=' . (int) $item->id . '&filter[published]=2'); ?>">
+										<a class="badge <?php echo ($item->count_archived > 0) ? 'badge-info' : 'badge-secondary'; ?>" href="<?php echo Route::_('index.php?option=com_banners&view=banners&filter[client_id]=' . (int) $item->id . '&filter[published]=2'); ?>">
 											<?php echo $item->count_archived; ?></a>
 									</td>
 									<td class="center btns d-none d-lg-table-cell">
-										<a class="badge <?php if ($item->count_trashed > 0) echo 'badge-inverse'; ?>" href="<?php echo Route::_('index.php?option=com_banners&view=banners&filter[client_id]=' . (int) $item->id . '&filter[published]=-2'); ?>">
+										<a class="badge <?php echo ($item->count_trashed > 0) ? 'badge-inverse' : 'badge-secondary'; ?>" href="<?php echo Route::_('index.php?option=com_banners&view=banners&filter[client_id]=' . (int) $item->id . '&filter[published]=-2'); ?>">
 											<?php echo $item->count_trashed; ?></a>
 									</td>
 									<td class="small d-none d-md-table-cell">


### PR DESCRIPTION
In banner clients there was no class to give a background when the value was 0. For consistency with similar views this PR adds the class.

### Before
![image](https://user-images.githubusercontent.com/1296369/56501006-03880b00-6505-11e9-8a94-c257259cf75b.png)

### After
![image](https://user-images.githubusercontent.com/1296369/56500992-f5d28580-6504-11e9-8d0f-84826519fad7.png)
