### PR TITLE
[4.0] Finder missing class

### DIFF
--- a/administrator/components/com_finder/tmpl/maps/default.php
+++ b/administrator/components/com_finder/tmpl/maps/default.php
@@ -122,7 +122,7 @@ HTMLHelper::_('script', 'com_finder/maps.js', ['version' => 'auto', 'relative' =
 							</td>
 							<td class="text-center btns">
 							<?php if ($item->level > 1) : ?>
-								<a class="badge <?php if ((int) $item->count_unpublished > 0) echo 'badge-danger'; ?>" title="<?php echo Text::_('COM_FINDER_MAPS_COUNT_UNPUBLISHED_ITEMS'); ?>" href="<?php echo Route::_('index.php?option=com_finder&view=index&filter[state]=0&filter[content_map]=' . $item->id); ?>">
+								<a class="badge <?php echo ((int) $item->count_unpublished > 0) ? 'badge-danger' : 'badge-secondary'; ?>" title="<?php echo Text::_('COM_FINDER_MAPS_COUNT_UNPUBLISHED_ITEMS'); ?>" href="<?php echo Route::_('index.php?option=com_finder&view=index&filter[state]=0&filter[content_map]=' . $item->id); ?>">
 								<?php echo (int) $item->count_unpublished; ?></a>
 							<?php else : ?>
 								-


### PR DESCRIPTION
In Finder Maps there was no class to give a background when the value was 0. For consistency with similar views this PR adds the class.

### Before
![image](https://user-images.githubusercontent.com/1296369/56504949-279e1900-6512-11e9-822a-d7852f043b05.png)

### After
![image](https://user-images.githubusercontent.com/1296369/56504934-194ffd00-6512-11e9-89ec-cc9e539de75d.png)

