### PR TITLE
[4.0] Articles - Category display options

### DIFF
--- a/modules/mod_articles_category/mod_articles_category.xml
+++ b/modules/mod_articles_category/mod_articles_category.xml
@@ -452,14 +452,13 @@
 				<field
 					name="show_tags"
 					type="radio"
+					class="switcher"
 					label="JTAG"
-					description="MOD_ARTICLES_CATEGORY_FIELD_SHOWTAGS_DESC"
 					default="0"
 					filter="integer"
-					class="btn-group btn-group-yesno"
 					>
-					<option value="1">JSHOW</option>
 					<option value="0">JHIDE</option>
+					<option value="1">JSHOW</option>
 				</field>
 
 				<field


### PR DESCRIPTION
Make sure we use the switcher not the old yes/no style and remove reference to missing string


### Before

<img width="417" alt="chrome_2019-04-22_21-57-31" src="https://user-images.githubusercontent.com/1296369/56530294-0ce79680-654a-11e9-8e41-062a836811ea.png">


### After

![image](https://user-images.githubusercontent.com/1296369/56530328-17a22b80-654a-11e9-86a6-f59cef8e6afc.png)
