### PR TITLE
[4.0] Add client property to module positions field

### DIFF
--- a/administrator/components/com_modules/Field/ModulesPositioneditField.php
+++ b/administrator/components/com_modules/Field/ModulesPositioneditField.php
@@ -39,6 +39,83 @@ class ModulesPositioneditField extends FormField
 	protected $layout = 'joomla.form.field.modulespositionedit';
 
 	/**
+	 * Client name.
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $client;
+
+	/**
+	 * Method to get certain otherwise inaccessible properties from the form field object.
+	 *
+	 * @param   string  $name  The property name for which to get the value.
+	 *
+	 * @return  mixed  The property value or null.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function __get($name)
+	{
+		switch ($name)
+		{
+			case 'client':
+				return $this->$name;
+		}
+
+		return parent::__get($name);
+	}
+
+	/**
+	 * Method to set certain otherwise inaccessible properties of the form field object.
+	 *
+	 * @param   string  $name   The property name for which to set the value.
+	 * @param   mixed   $value  The value of the property.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function __set($name, $value)
+	{
+		switch ($name)
+		{
+			case 'client':
+				$this->$name = (string) $value;
+				break;
+
+			default:
+				parent::__set($name, $value);
+		}
+	}
+
+	/**
+	 * Method to attach a Form object to the field.
+	 *
+	 * @param   \SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
+	 * @param   mixed              $value    The form field value to validate.
+	 * @param   string             $group    The field name group control value. This acts as an array container for the field.
+	 *                                       For example if the field has name="foo" and the group value is set to "bar" then the
+	 *                                       full field name would end up being "bar[foo]".
+	 *
+	 * @return  boolean  True on success.
+	 *
+	 * @see     FormField::setup()
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function setup(\SimpleXMLElement $element, $value, $group = null)
+	{
+		$result = parent::setup($element, $value, $group);
+
+		if ($result === true)
+		{
+			$this->client = $this->element['client'] ? (string) $this->element['client'] : 'site';
+		}
+
+		return $result;
+	}
+
+	/**
 	 * Method to get the field input markup.
 	 *
 	 * @return  string  The field input markup.
@@ -49,7 +126,7 @@ class ModulesPositioneditField extends FormField
 	{
 		$data = $this->getLayoutData();
 
-		$clientId  = Factory::getApplication()->getUserState('com_modules.modules.client_id', 0);
+		$clientId  = $this->client === 'administrator' ? 1 : 0;
 		$positions = HTMLHelper::_('modules.positions', $clientId, 1, $this->value);
 
 		$data['client']    = $clientId;

--- a/administrator/components/com_modules/Model/ModuleModel.php
+++ b/administrator/components/com_modules/Model/ModuleModel.php
@@ -572,8 +572,6 @@ class ModuleModel extends AdminModel
 			return false;
 		}
 
-		$form->setFieldAttribute('position', 'client', $this->getState('item.client_id') == 0 ? 'site' : 'administrator');
-
 		$user = Factory::getUser();
 
 		/**

--- a/administrator/components/com_modules/forms/module.xml
+++ b/administrator/components/com_modules/forms/module.xml
@@ -92,6 +92,7 @@
 			label="COM_MODULES_FIELD_POSITION_LABEL"
 			default=""
 			maxlength="50"
+			client="site"
 		/>
 
 		<field

--- a/administrator/components/com_modules/forms/moduleadmin.xml
+++ b/administrator/components/com_modules/forms/moduleadmin.xml
@@ -94,6 +94,7 @@
 			label="COM_MODULES_FIELD_POSITION_LABEL"
 			default=""
 			maxlength="50"
+			client="administrator"
 		/>
 
 		<field

--- a/components/com_config/Model/ModulesModel.php
+++ b/components/com_config/Model/ModulesModel.php
@@ -64,8 +64,6 @@ class ModulesModel extends FormModel
 			return false;
 		}
 
-		$form->setFieldAttribute('position', 'client',  'site');
-
 		return $form;
 	}
 

--- a/components/com_config/forms/modules.xml
+++ b/components/com_config/forms/modules.xml
@@ -93,6 +93,7 @@
 			addfieldprefix="Joomla\Component\Modules\Administrator\Field"
 			default=""
 			maxlength="50"
+			client="site"
 		/>
 
 		<field


### PR DESCRIPTION
Pull Request for Issue #24575.

### Summary of Changes

Alternative PR to #24583. Adds client property to module position edit field. 

### Testing Instructions

Edit a module from:

1) Control Panel
2) From module list in backend
3) From frontend

Inspect positions in `Position` field.

### Expected result

Positions should be shown based on whether site or admin module is being edited.

### Actual result

When editing an admin module from Control Panel, site positions are shown.

### Documentation Changes Required

IDK.