### PR TITLE
[4.0] Module feed display options

### DIFF
--- a/modules/mod_feed/mod_feed.xml
+++ b/modules/mod_feed/mod_feed.xml
@@ -76,8 +76,8 @@
 					class="switcher"
 					default="0"
 					>
-					<option value="1">JYES</option>
 					<option value="0">JNO</option>
+					<option value="1">JYES</option>
 				</field>
 
 				<field
@@ -120,8 +120,8 @@
 					default="0"
 					filter="integer"
 					>
-					<option value="1">JYES</option>
 					<option value="0">JNO</option>
+					<option value="1">JYES</option>
 				</field>
 
 				<field


### PR DESCRIPTION
This PR ensures that the switcher options are displayed consistently ie green for positive options

### Before
![image](https://user-images.githubusercontent.com/1296369/56566412-7ac3aa80-65aa-11e9-94d1-ec18970ff985.png)

### After
![image](https://user-images.githubusercontent.com/1296369/56566387-68e20780-65aa-11e9-8bf6-02b7a982e407.png)
