### PR TITLE
[4.0] Active tab

### DIFF
--- a/libraries/cms/html/uitab.php
+++ b/libraries/cms/html/uitab.php
@@ -81,7 +81,7 @@ abstract class JHtmlUiTab
 	{
 		$active = (static::$loaded['JHtmlUiTab::startTabSet'][$selector]['active'] == $id) ? ' active' : '';
 
-		return '<section id="' . $id . '" ' . $active . ' name="' . htmlspecialchars($title, ENT_COMPAT, 'UTF-8') . '">';
+		return '<section id="' . $id . '"' . $active . ' name="' . htmlspecialchars($title, ENT_COMPAT, 'UTF-8') . '">';
 
 	}
 

--- a/libraries/cms/html/uitab.php
+++ b/libraries/cms/html/uitab.php
@@ -81,7 +81,7 @@ abstract class JHtmlUiTab
 	{
 		$active = (static::$loaded['JHtmlUiTab::startTabSet'][$selector]['active'] == $id) ? ' active' : '';
 
-		return '<section id="' . $id . '" class="' . $active . '" name="' . htmlspecialchars($title, ENT_COMPAT, 'UTF-8') . '">';
+		return '<section id="' . $id . '" ' . $active . ' name="' . htmlspecialchars($title, ENT_COMPAT, 'UTF-8') . '">';
 
 	}
 


### PR DESCRIPTION
This is a little hard to test. You must always be testing by opening a module - refresh doesnt work

Step 1 open a module (make sure it opened on the first tab - if not move to first tab, close the module and start again)
Step 2 view source and locate the code shown in the image below

You will see that
1. all the <section have aria-hidden=true
2. the first has class="active" and the rest have an empty class
![image](https://user-images.githubusercontent.com/1296369/56581486-f59dbd00-65cc-11e9-9bed-b17048c8b01c.png)


Step 3 close the module and apply the patch and repeat step 1 and 2
Now You will see that
![image](https://user-images.githubusercontent.com/1296369/56581390-c6874b80-65cc-11e9-8e21-96e620587fd1.png)

1. the first <section has an attribute of "active" and the rest do not
2. all but the first <section have aria-hidden=true
3. none of the <section have a class
