### PR TITLE
[4.0] Enable utf8mb4 in database connections

### DIFF
--- a/libraries/src/Service/Provider/Database.php
+++ b/libraries/src/Service/Provider/Database.php
@@ -93,12 +93,12 @@ class Database implements ServiceProviderInterface
 				// Enable utf8mb4 connections for mysql adapters
 				if (strtolower($dbtype) === 'mysqli')
 				{
-					$config['utf8mb4'] = true;
+					$options['utf8mb4'] = true;
 				}
 
 				if (strtolower($dbtype) === 'mysql')
 				{
-					$config['charset'] = 'utf8mb4';
+					$options['charset'] = 'utf8mb4';
 				}
 
 				if (JDEBUG)

--- a/libraries/src/Service/Provider/Database.php
+++ b/libraries/src/Service/Provider/Database.php
@@ -90,6 +90,17 @@ class Database implements ServiceProviderInterface
 					'prefix'   => $conf->get('dbprefix'),
 				];
 
+				// Enable utf8mb4 connections for mysql adapters
+				if (strtolower($dbtype) === 'mysqli')
+				{
+					$config['utf8mb4'] = true;
+				}
+
+				if (strtolower($dbtype) === 'mysql')
+				{
+					$config['charset'] = 'utf8mb4';
+				}
+
 				if (JDEBUG)
 				{
 					$options['monitor'] = new \Joomla\Database\Monitor\DebugMonitor;


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/24697

Enables UTF8MB4 support in the database drivers when available