### PR TITLE
Added the "item-heading" for strong selector.

### DIFF
--- a/layouts/joomla/content/blog_style_default_item_title.php
+++ b/layouts/joomla/content/blog_style_default_item_title.php
@@ -18,7 +18,7 @@ JHtml::addIncludePath(JPATH_COMPONENT.'/helpers/html');
 <?php if ($displayData->state == 0 || $params->get('show_title') || ($params->get('show_author') && !empty($displayData->author ))) : ?>
 	<div class="page-header">
 		<?php if ($params->get('show_title')) : ?>
-			<h2 itemprop="name">
+			<h2 class="item-heading" itemprop="name">
 				<?php if ($params->get('link_titles') && ($params->get('access-view') || $params->get('show_noauth', '0') == '1')) : ?>
 					<a href="<?php echo JRoute::_(
 						ContentHelperRoute::getArticleRoute($displayData->slug, $displayData->catid, $displayData->language)


### PR DESCRIPTION
Pull Request for Issue #.

### Summary of Changes
This is very helpful. If a user wants to change the typography. He/She can never create the stong CSS selector.

**Before selector like this.**
`.page-header h2 {}`
This is not a good selector. If the user changed the **h2** tag with other heading tags like **h4**. In this case, the above selector is not working. But if we add a class with h2 tag. Then it is very helpful. The user creates a strong selector. No matter if **h2** tag changed with another heading tags.

Now, the selector will be.
`.page-header .item-heading {}`
