### PR TITLE
Deprecate LanguageStemmer for 4.0

### DIFF
--- a/libraries/src/Language/LanguageStemmer.php
+++ b/libraries/src/Language/LanguageStemmer.php
@@ -13,7 +13,8 @@ defined('JPATH_PLATFORM') or die;
 /**
  * Stemmer base class.
  *
- * @since  3.0.0
+ * @since       3.0.0
+ * @deprecated  4.0 Use wamania/php-stemmer
  */
 abstract class LanguageStemmer
 {

--- a/libraries/src/Language/Stemmer/Porteren.php
+++ b/libraries/src/Language/Stemmer/Porteren.php
@@ -19,7 +19,8 @@ use Joomla\CMS\Language\LanguageStemmer;
  * This class was adapted from one written by Richard Heyes.
  * See copyright and link information above.
  *
- * @since  3.0.0
+ * @since       3.0.0
+ * @deprecated  4.0 Use wamania/php-stemmer
  */
 class Porteren extends LanguageStemmer
 {


### PR DESCRIPTION
This deprecates the stemmer for 4.0. This is a helper PR for #24716.