### PR TITLE
RTL Text align right for select Modules list

### DIFF
--- a/administrator/components/com_modules/views/select/tmpl/default.php
+++ b/administrator/components/com_modules/views/select/tmpl/default.php
@@ -23,20 +23,11 @@ $document = JFactory::getDocument();
 	<?php $name       = $this->escape($item->name); ?>
 	<?php $desc       = JHtml::_('string.truncate', $this->escape(strip_tags($item->desc)), 200); ?>
 	<?php $short_desc = JHtml::_('string.truncate', $this->escape(strip_tags($item->desc)), 90); ?>
-
-	<?php if ($document->direction != 'rtl') : ?>
 	<li>
 		<a href="<?php echo JRoute::_($link); ?>">
 			<strong><?php echo $name; ?></strong></a>
 		<small class="hasPopover" data-placement="right" title="<?php echo $name; ?>" data-content="<?php echo $desc; ?>"><?php echo $short_desc; ?></small>
 	</li>
-	<?php else : ?>
-	<li>
-		<small rel="popover" data-placement="left" title="<?php echo $name; ?>" data-content="<?php echo $desc; ?>"><?php echo $short_desc; ?></small>
-		<a href="<?php echo JRoute::_($link); ?>">
-			<strong><?php echo $name; ?></strong></a>
-	</li>
-	<?php endif; ?>
 <?php endforeach; ?>
 </ul>
 <div class="clr"></div>


### PR DESCRIPTION
### Summary of Changes
Displaying correctly the list of Modules when selecting a new module.

The existing display code dated back from 2012 when it was necessary to order stuff differently.


### Testing Instructions
Install Arabic or Persian language.
Switch to that language in admin
administrator/index.php?option=com_modules&view=select

### Before patch

<img width="491" alt="Screen Shot 2019-04-24 at 16 16 17" src="https://user-images.githubusercontent.com/869724/56666774-cbbbc780-66ac-11e9-994c-1749a3e5932b.png">


### After patch

<img width="755" alt="Screen Shot 2019-04-24 at 16 02 25" src="https://user-images.githubusercontent.com/869724/56666781-d0807b80-66ac-11e9-9816-b85b746157c9.png">

