### PR TITLE
Use the php native function to validate email addresses in php 7.3+

### DIFF
--- a/libraries/src/Mail/Mail.php
+++ b/libraries/src/Mail/Mail.php
@@ -65,9 +65,12 @@ class Mail extends \PHPMailer
 		// Don't disclose the PHPMailer version
 		$this->XMailer = ' ';
 
-		// PHPMailer 5.2 can't validate e-mail addresses with the new regex library used in PHP 7.3+
-		// Setting $validator to "php" uses the native php function filter_var
-		// @see https://github.com/joomla/joomla-cms/issues/24707
+		/*
+		 * PHPMailer 5.2 can't validate e-mail addresses with the new regex library used in PHP 7.3+
+		 * Setting $validator to "php" uses the native php function filter_var
+		 *
+		 * @see https://github.com/joomla/joomla-cms/issues/24707
+		 */
 		if (version_compare(PHP_VERSION, '7.3.0', '>='))
 		{
 			\PHPMailer::$validator = 'php';

--- a/libraries/src/Mail/Mail.php
+++ b/libraries/src/Mail/Mail.php
@@ -64,6 +64,14 @@ class Mail extends \PHPMailer
 
 		// Don't disclose the PHPMailer version
 		$this->XMailer = ' ';
+
+		// PHPMailer 5.2 can't validate e-mail addresses with the new regex library used in PHP 7.3+
+		// Setting $validator to "php" uses the native php function filter_var
+		// @see https://github.com/joomla/joomla-cms/issues/24707
+		if (version_compare(PHP_VERSION, '7.3.0', '>='))
+		{
+			\PHPMailer::$validator = 'php';
+		}
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue #24707.

### Summary of Changes
Changes e-mail validator from auto detect to php native function filtar_var for php 7.3+

### Testing Instructions
1. Use php 5.3-7.3
2. Send an email.

### Expected result
Works

### Actual result
Doesn't work on some hosts with php 7.3, maybe because the upgrade to PCRE2

https://www.php.net/manual/en/migration73.other-changes.php#migration73.other-changes.pcre
