### PR TITLE
[4.0] Fixing drone clone step

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,8 +1,9 @@
-pipeline:
-  clone:
+clone:
+  git:
     image: plugins/git
     depth: 1
 
+pipeline:
   phpcs:
     image: joomlaprojects/docker-phpcs
     commands:


### PR DESCRIPTION
Drone automatically has a default clone step and for some reason we are overriding that clone step in our pipeline, even though you should be able to configure that the way I did this here. This PR should remove that greyed out clone step in our builds and it makes upgrading drone to 1.0 easier, since the current .drone.yml fails in 1.0, while this here should work.