### PR TITLE
[4.0] Adding additional PHP versions to drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -41,7 +41,7 @@ pipeline:
 
   php70-unit:
     group: unit
-    image: php:7.0-dev
+    image: joomlaprojects/docker-php70:develop
     commands:
       - ./libraries/vendor/bin/phpunit
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -41,19 +41,19 @@ pipeline:
 
   php70-unit:
     group: unit
-    image: joomlaprojects/docker-php70:develop
+    image: phpdaily/php:7.0-dev
     commands:
       - ./libraries/vendor/bin/phpunit
 
   php71-unit:
     group: unit
-    image: joomlaprojects/docker-php71:develop
+    image: phpdaily/php:7.1-dev
     commands:
       - ./libraries/vendor/bin/phpunit
 
   php72-unit:
     group: unit
-    image: joomlaprojects/docker-php72:develop
+    image: phpdaily/php:7.2-dev
     commands:
       - ./libraries/vendor/bin/phpunit
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -57,6 +57,24 @@ pipeline:
     commands:
       - ./libraries/vendor/bin/phpunit
 
+  php73-unit:
+    group: unit
+    image: phpdaily/php:7.3-dev
+    commands:
+      - ./libraries/vendor/bin/phpunit
+
+  php74-unit:
+    group: unit
+    image: phpdaily/php:7.4-dev
+    commands:
+      - ./libraries/vendor/bin/phpunit
+
+  php80-unit:
+    group: unit
+    image: phpdaily/php:8.0-dev
+    commands:
+      - ./libraries/vendor/bin/phpunit
+
   javascript-cs:
     image: joomlaprojects/docker-systemtests:develop
     commands:

--- a/.drone.yml
+++ b/.drone.yml
@@ -41,7 +41,7 @@ pipeline:
 
   php70-unit:
     group: unit
-    image: phpdaily/php:7.0-dev
+    image: php:7.0-dev
     commands:
       - ./libraries/vendor/bin/phpunit
 


### PR DESCRIPTION
We are currently using our own Docker images to run the PHP unittests. Those images currently only support PHP 7.0, 7.1 and 7.2, but there are also 7.3, 7.4 and 8.0. I think we don't need to reinvent the wheel again and again and instead should simply use images from another project. A short and non-exhaustive research lead me to https://github.com/phpdaily/php, which seems to have all the new necessary images that we need.