### PR TITLE
Added filtering by access level if user is not admin

### DIFF
--- a/libraries/cms/html/category.php
+++ b/libraries/cms/html/category.php
@@ -57,7 +57,10 @@ abstract class JHtmlCategory
 			$query->where('extension = ' . $db->quote($extension));
 
 			// Filter on user access level
-			$query->where('a.access IN (' . $groups . ')');
+			if (!$user->authorise('core.admin'))
+			{
+				$query->where('a.access IN (' . $groups . ')');
+			}
 
 			// Filter on the published state
 			if (isset($config['filter.published']))


### PR DESCRIPTION
Pull Request for Issue #22884 .

### Summary of Changes
Added a condition if user is not admin before filtering by access level


### Testing Instructions
Instructions copied from [issue](https://github.com/joomla/joomla-cms/issues/22884) by franz-wohlkoenig:

- Set the status of an article category to Guest, 
- add a Guest status article to the category, 
- use the Search Tool in Article Manager to filter for the category in Select Category.


### Expected result
The Guest status article category to show in the results.