### PR TITLE
[4.0] Fix tags creation

### DIFF
--- a/build/media_source/system/js/fields/joomla-field-fancy-select.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-fancy-select.w-c.es6.js
@@ -105,7 +105,8 @@ window.customElements.define('joomla-field-fancy-select', class extends HTMLElem
     // Handle typing of custom term
     if (this.allowCustom) {
       this.addEventListener('keydown', (event) => {
-        if (event.keyCode !== this.keyCode.ENTER || event.target !== this.choicesInstance.input.element) {
+        if (event.keyCode !== this.keyCode.ENTER
+            || event.target !== this.choicesInstance.input.element) {
           return;
         }
         event.preventDefault();

--- a/build/media_source/system/js/fields/joomla-field-fancy-select.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-fancy-select.w-c.es6.js
@@ -105,7 +105,7 @@ window.customElements.define('joomla-field-fancy-select', class extends HTMLElem
     // Handle typing of custom term
     if (this.allowCustom) {
       this.addEventListener('keydown', (event) => {
-        if (event.keyCode !== this.keyCode.ENTER || event.target !== this.choicesInstance.input) {
+        if (event.keyCode !== this.keyCode.ENTER || event.target !== this.choicesInstance.input.element) {
           return;
         }
         event.preventDefault();
@@ -115,7 +115,7 @@ window.customElements.define('joomla-field-fancy-select', class extends HTMLElem
         }
 
         // Make sure nothing is highlighted
-        const highlighted = this.choicesInstance.dropdown.querySelector(`.${this.choicesInstance.config.classNames.highlightedState}`);
+        const highlighted = this.choicesInstance.dropdown.element.querySelector(`.${this.choicesInstance.config.classNames.highlightedState}`);
         if (highlighted) {
           return;
         };


### PR DESCRIPTION
### Summary of Changes
Currently the creation of dynamic tags is broken in the 4.0 branch. This fixes it (has been the case since we merged the update of choices 7)

### Testing Instructions
Type a tag with a new value into the tags box and hit enter

### Expected result
Tag is created

### Actual result
It isn't

### Documentation Changes Required
none
