### PR TITLE
Change doc blocks for constants to use var tags

### DIFF
--- a/libraries/joomla/github/http.php
+++ b/libraries/joomla/github/http.php
@@ -20,19 +20,25 @@ use Joomla\Registry\Registry;
 class JGithubHttp extends JHttp
 {
 	/**
-	 * @const  integer  Use no authentication for HTTP connections.
+	 * Use no authentication for HTTP connections.
+	 *
+	 * @var    integer
 	 * @since  1.7.3
 	 */
 	const AUTHENTICATION_NONE = 0;
 
 	/**
-	 * @const  integer  Use basic authentication for HTTP connections.
+	 * Use basic authentication for HTTP connections.
+	 *
+	 * @var    integer
 	 * @since  1.7.3
 	 */
 	const AUTHENTICATION_BASIC = 1;
 
 	/**
-	 * @const  integer  Use OAuth authentication for HTTP connections.
+	 * Use OAuth authentication for HTTP connections.
+	 *
+	 * @var    integer
 	 * @since  1.7.3
 	 */
 	const AUTHENTICATION_OAUTH = 2;

--- a/libraries/src/Authentication/Authentication.php
+++ b/libraries/src/Authentication/Authentication.php
@@ -22,7 +22,8 @@ class Authentication extends \JObject
 	// Shared success status
 	/**
 	 * This is the status code returned when the authentication is success (permit login)
-	 * @const  STATUS_SUCCESS successful response
+	 *
+	 * @var    integer
 	 * @since  1.7.0
 	 */
 	const STATUS_SUCCESS = 1;
@@ -30,14 +31,16 @@ class Authentication extends \JObject
 	// These are for authentication purposes (username and password is valid)
 	/**
 	 * Status to indicate cancellation of authentication (unused)
-	 * @const  STATUS_CANCEL cancelled request (unused)
+	 *
+	 * @var    integer
 	 * @since  1.7.0
 	 */
 	const STATUS_CANCEL = 2;
 
 	/**
 	 * This is the status code returned when the authentication failed (prevent login if no success)
-	 * @const  STATUS_FAILURE failed request
+	 *
+	 * @var    integer
 	 * @since  1.7.0
 	 */
 	const STATUS_FAILURE = 4;
@@ -45,21 +48,24 @@ class Authentication extends \JObject
 	// These are for authorisation purposes (can the user login)
 	/**
 	 * This is the status code returned when the account has expired (prevent login)
-	 * @const  STATUS_EXPIRED an expired account (will prevent login)
+	 *
+	 * @var    integer
 	 * @since  1.7.0
 	 */
 	const STATUS_EXPIRED = 8;
 
 	/**
 	 * This is the status code returned when the account has been denied (prevent login)
-	 * @const  STATUS_DENIED denied request (will prevent login)
+	 *
+	 * @var    integer
 	 * @since  1.7.0
 	 */
 	const STATUS_DENIED = 16;
 
 	/**
 	 * This is the status code returned when the account doesn't exist (not an error)
-	 * @const  STATUS_UNKNOWN unknown account (won't permit or prevent login)
+	 *
+	 * @var    integer
 	 * @since  1.7.0
 	 */
 	const STATUS_UNKNOWN = 32;

--- a/libraries/src/Captcha/Google/HttpBridgePostRequestMethod.php
+++ b/libraries/src/Captcha/Google/HttpBridgePostRequestMethod.php
@@ -25,7 +25,7 @@ final class HttpBridgePostRequestMethod implements RequestMethod
 	/**
 	 * URL to which requests are sent.
 	 *
-	 * @const  string
+	 * @var    string
 	 * @since  3.9.0
 	 */
 	const SITE_VERIFY_URL = 'https://www.google.com/recaptcha/api/siteverify';

--- a/libraries/src/Helper/UserGroupsHelper.php
+++ b/libraries/src/Helper/UserGroupsHelper.php
@@ -18,13 +18,17 @@ defined('JPATH_PLATFORM') or die;
 final class UserGroupsHelper
 {
 	/**
-	 * @const  integer
+	 * Indicates the current helper instance is the singleton instance.
+	 *
+	 * @var    integer
 	 * @since  3.6.3
 	 */
 	const MODE_SINGLETON = 1;
 
 	/**
-	 * @const  integer
+	 * Indicates the current helper instance is a standalone class instance.
+	 *
+	 * @var    integer
 	 * @since  3.6.3
 	 */
 	const MODE_INSTANCE = 2;

--- a/libraries/src/Updater/DownloadSource.php
+++ b/libraries/src/Updater/DownloadSource.php
@@ -20,7 +20,7 @@ class DownloadSource
 	/**
 	 * Defines a BZIP2 download package
 	 *
-	 * @const  string
+	 * @var    string
 	 * @since  3.8.4
 	 */
 	const FORMAT_TAR_BZIP = 'bz2';
@@ -28,7 +28,7 @@ class DownloadSource
 	/**
 	 * Defines a TGZ download package
 	 *
-	 * @const  string
+	 * @var    string
 	 * @since  3.8.4
 	 */
 	const FORMAT_TAR_GZ = 'gz';
@@ -36,7 +36,7 @@ class DownloadSource
 	/**
 	 * Defines a ZIP download package
 	 *
-	 * @const  string
+	 * @var    string
 	 * @since  3.8.3
 	 */
 	const FORMAT_ZIP = 'zip';
@@ -44,7 +44,7 @@ class DownloadSource
 	/**
 	 * Defines a full package download type
 	 *
-	 * @const  string
+	 * @var    string
 	 * @since  3.8.3
 	 */
 	const TYPE_FULL = 'full';
@@ -52,7 +52,7 @@ class DownloadSource
 	/**
 	 * Defines a patch package download type
 	 *
-	 * @const  string
+	 * @var    string
 	 * @since  3.8.4
 	 */
 	const TYPE_PATCH = 'patch';
@@ -60,7 +60,7 @@ class DownloadSource
 	/**
 	 * Defines an upgrade package download type
 	 *
-	 * @const  string
+	 * @var    string
 	 * @since  3.8.4
 	 */
 	const TYPE_UPGRADE = 'upgrade';

--- a/libraries/src/Updater/Updater.php
+++ b/libraries/src/Updater/Updater.php
@@ -28,7 +28,7 @@ class Updater extends \JAdapter
 	/**
 	 * Development snapshots, nightly builds, pre-release versions and so on
 	 *
-	 * @const  integer
+	 * @var    integer
 	 * @since  3.4
 	 */
 	const STABILITY_DEV = 0;
@@ -36,7 +36,7 @@ class Updater extends \JAdapter
 	/**
 	 * Alpha versions (work in progress, things are likely to be broken)
 	 *
-	 * @const  integer
+	 * @var    integer
 	 * @since  3.4
 	 */
 	const STABILITY_ALPHA = 1;
@@ -44,7 +44,7 @@ class Updater extends \JAdapter
 	/**
 	 * Beta versions (major functionality in place, show-stopper bugs are likely to be present)
 	 *
-	 * @const  integer
+	 * @var    integer
 	 * @since  3.4
 	 */
 	const STABILITY_BETA = 2;
@@ -52,7 +52,7 @@ class Updater extends \JAdapter
 	/**
 	 * Release Candidate versions (almost stable, minor bugs might be present)
 	 *
-	 * @const  integer
+	 * @var    integer
 	 * @since  3.4
 	 */
 	const STABILITY_RC = 3;
@@ -60,13 +60,15 @@ class Updater extends \JAdapter
 	/**
 	 * Stable versions (production quality code)
 	 *
-	 * @const  integer
+	 * @var    integer
 	 * @since  3.4
 	 */
 	const STABILITY_STABLE = 4;
 
 	/**
-	 * @var    Updater  Updater instance container.
+	 * Updater instance container.
+	 *
+	 * @var    Updater
 	 * @since  1.7.3
 	 */
 	protected static $instance;

--- a/plugins/system/stats/stats.php
+++ b/plugins/system/stats/stats.php
@@ -21,19 +21,25 @@ defined('_JEXEC') or die;
 class PlgSystemStats extends JPlugin
 {
 	/**
-	 * @const  integer
+	 * Indicates sending statistics is always allowed.
+	 *
+	 * @var    integer
 	 * @since  3.5
 	 */
 	const MODE_ALLOW_ALWAYS = 1;
 
 	/**
-	 * @const  integer
+	 * Indicates sending statistics is only allowed one time.
+	 *
+	 * @var    integer
 	 * @since  3.5
 	 */
 	const MODE_ALLOW_ONCE = 2;
 
 	/**
-	 * @const  integer
+	 * Indicates sending statistics is never allowed.
+	 *
+	 * @var    integer
 	 * @since  3.5
 	 */
 	const MODE_ALLOW_NEVER = 3;


### PR DESCRIPTION
### Summary of Changes

The APIs that phpDocumentor uses to parse doc blocks has special handling for certain tags (`@param`, `@property`, `@property-read`, `@property-write`, and `@var`) to extract type information from the tag if properly structured, otherwise all of the text is considered as part of a description (or depending on the tag type some other internal properties that we aren't going to get into here unless you really want to learn the internals of phpDocumentor's doc block parsing libraries).  So this pull request changes the doc blocks for constants in the API from `@const` tags to `@var` tags so that the type information is correctly extracted by the API.  Additional minor PHPCS tweaks are made in affected doc blocks as well to conform to suggested structure or add descriptions where they didn't previously exist.

### Testing Instructions

Code review; the changes made here are only going to impact the resulting output for https://api.joomla.org