### PR TITLE
[4.0] Fix various instances where we were doing bad things in vuex

### DIFF
--- a/administrator/components/com_media/resources/scripts/components/modals/confirm-delete-modal.vue
+++ b/administrator/components/com_media/resources/scripts/components/modals/confirm-delete-modal.vue
@@ -20,7 +20,6 @@
         name: 'media-share-modal',
         computed: {
             item() {
-                // TODO @DN this is not allowed in vuex strict mode!
                 return this.$store.state.selectedItems[this.$store.state.selectedItems.length - 1];
             }
         },

--- a/administrator/components/com_media/resources/scripts/components/modals/rename-modal.vue
+++ b/administrator/components/com_media/resources/scripts/components/modals/rename-modal.vue
@@ -34,7 +34,6 @@
         },
         computed: {
             item() {
-                // TODO @DN this is not allowed in vuex strict mode!
                 return this.$store.state.selectedItems[this.$store.state.selectedItems.length - 1];
             },
             name: {
@@ -45,11 +44,10 @@
                     return this.item.name.replace('.' + this.item.extension, '');
                 },
                 set(value) {
-                    // TODO @DN this is not allowed in vuex strict mode!
                     if (this.extension.length) {
                         value += '.' + this.item.extension;
                     }
-                    this.$store.state.selectedItems[this.$store.state.selectedItems.length - 1].name = value;
+                    this.$store.commit(types.CHANGE_NAME, value);
                 }
             },
             extension() {
@@ -64,8 +62,7 @@
             /* Close the modal instance */
             close() {
                 // Reset state
-                // TODO @DN this is not allowed in vuex strict mode!
-                this.$store.state.selectedItems[this.$store.state.selectedItems.length - 1].name = this.originalName;
+                this.$store.commit(types.CHANGE_NAME, this.originalName);
                 this.originalName = '';
 
                 this.$store.commit(types.HIDE_RENAME_MODAL);

--- a/administrator/components/com_media/resources/scripts/components/modals/rename-modal.vue
+++ b/administrator/components/com_media/resources/scripts/components/modals/rename-modal.vue
@@ -6,9 +6,8 @@
                 <div class="form-group">
                     <label for="name">{{ translate('COM_MEDIA_NAME') }}</label>
                     <div :class="{'input-group': extension.length}">
-                        <input id="name" class="form-control" placeholder="Name"
-                               v-model.trim="name" @input="name = $event.target.value"
-                               required autocomplete="off">
+                        <input id="name" class="form-control" :placeholder="translate('COM_MEDIA_NAME')"
+                               :value="name" required autocomplete="off" ref="nameField">
                         <span class="input-group-addon" v-if="extension.length">{{extension }}</span>
                     </div>
                 </div>
@@ -27,28 +26,12 @@
 
     export default {
         name: 'media-rename-modal',
-        data() {
-            return {
-                originalName: '',
-            }
-        },
         computed: {
             item() {
                 return this.$store.state.selectedItems[this.$store.state.selectedItems.length - 1];
             },
-            name: {
-                get() {
-                    if (this.originalName.length === 0) {
-                        this.originalName = this.item.name;
-                    }
-                    return this.item.name.replace('.' + this.item.extension, '');
-                },
-                set(value) {
-                    if (this.extension.length) {
-                        value += '.' + this.item.extension;
-                    }
-                    this.$store.commit(types.CHANGE_NAME, value);
-                }
+            name() {
+                return this.item.name.replace('.' + this.item.extension, '');
             },
             extension() {
                 return this.item.extension;
@@ -61,10 +44,6 @@
             },
             /* Close the modal instance */
             close() {
-                // Reset state
-                this.$store.commit(types.CHANGE_NAME, this.originalName);
-                this.originalName = '';
-
                 this.$store.commit(types.HIDE_RENAME_MODAL);
             },
             /* Save the form and create the folder */
@@ -74,20 +53,22 @@
                     // TODO mark the field as invalid
                     return;
                 }
+                let newName = this.$refs.nameField.value;
+                if (this.extension.length) {
+                    newName += '.' + this.item.extension;
+                }
 
                 let newPath = this.item.directory;
                 if (newPath.substr(-1) !== '/') {
                     newPath += '/';
                 }
-                newPath += this.item.name;
 
                 // Rename the item
                 this.$store.dispatch('renameItem', {
                     path: this.item.path,
-                    newPath: newPath,
+                    newPath: newPath + newName,
+                    newName: newName,
                 });
-
-                this.originalName = '';
             },
         }
     }

--- a/administrator/components/com_media/resources/scripts/components/modals/share-modal.vue
+++ b/administrator/components/com_media/resources/scripts/components/modals/share-modal.vue
@@ -37,7 +37,6 @@
         name: 'media-share-modal',
         computed: {
             item() {
-                // TODO @DN this is not allowed in vuex strict mode!
                 return this.$store.state.selectedItems[this.$store.state.selectedItems.length - 1];
             },
 

--- a/administrator/components/com_media/resources/scripts/store/actions.js
+++ b/administrator/components/com_media/resources/scripts/store/actions.js
@@ -174,6 +174,7 @@ export const renameItem = (context, payload) => {
             context.commit(types.RENAME_SUCCESS, {
                 item: item,
                 oldPath: payload.path,
+                newName: payload.newName,
             });
             context.commit(types.HIDE_RENAME_MODAL);
             context.commit(types.SET_IS_LOADING, false);

--- a/administrator/components/com_media/resources/scripts/store/mutation-types.js
+++ b/administrator/components/com_media/resources/scripts/store/mutation-types.js
@@ -43,7 +43,6 @@ export const HIDE_PREVIEW_MODAL = 'HIDE_PREVIEW_MODAL';
 // Rename modal
 export const SHOW_RENAME_MODAL = 'SHOW_RENAME_MODAL';
 export const HIDE_RENAME_MODAL = 'HIDE_RENAME_MODAL';
-export const CHANGE_NAME = 'CHANGE_NAME';
 export const RENAME_SUCCESS = 'RENAME_SUCCESS';
 
 // Share model

--- a/administrator/components/com_media/resources/scripts/store/mutation-types.js
+++ b/administrator/components/com_media/resources/scripts/store/mutation-types.js
@@ -43,6 +43,7 @@ export const HIDE_PREVIEW_MODAL = 'HIDE_PREVIEW_MODAL';
 // Rename modal
 export const SHOW_RENAME_MODAL = 'SHOW_RENAME_MODAL';
 export const HIDE_RENAME_MODAL = 'HIDE_RENAME_MODAL';
+export const CHANGE_NAME = 'CHANGE_NAME';
 export const RENAME_SUCCESS = 'RENAME_SUCCESS';
 
 // Share model

--- a/administrator/components/com_media/resources/scripts/store/mutations.js
+++ b/administrator/components/com_media/resources/scripts/store/mutations.js
@@ -343,6 +343,14 @@ export default {
     },
 
     /**
+     * Show the rename modal
+     * @param state
+     */
+    [types.CHANGE_NAME]: (state, new_name) => {
+        state.selectedItems[state.selectedItems.length - 1].name = new_name;
+    },
+
+    /**
      * Hide the rename modal
      * @param state
      */

--- a/administrator/components/com_media/resources/scripts/store/mutations.js
+++ b/administrator/components/com_media/resources/scripts/store/mutations.js
@@ -187,7 +187,7 @@ export default {
      * @param payload
      */
     [types.RENAME_SUCCESS]: (state, payload) => {
-
+        state.selectedItems[state.selectedItems.length - 1].name = payload.newName;
         const item = payload.item;
         const oldPath = payload.oldPath;
         if (item.type === 'file') {
@@ -340,14 +340,6 @@ export default {
      */
     [types.SHOW_RENAME_MODAL]: (state) => {
         state.showRenameModal = true;
-    },
-
-    /**
-     * Show the rename modal
-     * @param state
-     */
-    [types.CHANGE_NAME]: (state, new_name) => {
-        state.selectedItems[state.selectedItems.length - 1].name = new_name;
     },
 
     /**

--- a/administrator/components/com_media/resources/scripts/store/store.js
+++ b/administrator/components/com_media/resources/scripts/store/store.js
@@ -16,5 +16,5 @@ export default new Vuex.Store({
     actions,
     mutations,
     plugins: [createPersistedState(persistedStateOptions)],
-    strict: false
+    strict: (process.env.NODE_ENV !== 'production'),
 })

--- a/administrator/components/com_media/webpack.config.js
+++ b/administrator/components/com_media/webpack.config.js
@@ -1,5 +1,5 @@
-var path = require('path')
-var webpack = require('webpack')
+var path = require('path');
+var webpack = require('webpack');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 
 module.exports = {
@@ -51,6 +51,9 @@ module.exports = {
             filename: './../../../media/com_media/css/mediamanager.min.css',
             allChunks: true,
         }),
+        new webpack.DefinePlugin({
+            'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV)
+        }),
     ],
     resolve: {
         alias: {
@@ -60,18 +63,13 @@ module.exports = {
     performance: {
         hints: false
     },
-    devtool: '#eval-source-map'
-}
+    devtool: process.env.NODE_ENV === 'production' ? '#source-map' : '#eval-source-map'
+};
 
+// Add plugins for minification when in build mode
 if (process.env.NODE_ENV === 'production') {
-    module.exports.devtool = '#source-map'
     // http://vue-loader.vuejs.org/en/workflow/production.html
     module.exports.plugins = (module.exports.plugins || []).concat([
-        new webpack.DefinePlugin({
-            'process.env': {
-                NODE_ENV: '"production"'
-            }
-        }),
         new webpack.optimize.UglifyJsPlugin({
             sourceMap: true,
             compress: {


### PR DESCRIPTION
This is harder to test but is cleaning up some tech debt in the code base. In some places we were directly manipulating the vuex state, which as documented in the code shouldn't be done. I've cleaned that up to correctly use a mutator. To test ensure that the rename modal works before and after the patch in media manager

In addition if you now build media manager in dev mode (or watch which is dev mode by default) we now enable vuex strict mode (note as per the docs you shouldn't use strict mode in production https://vuex.vuejs.org/guide/strict.html). This means in the future when people do dev work they should get warnings when they do such bad things.

@dneukirchen are you able to do a code review here please