### PR TITLE
Use namespaces and accept multiple filters values

### DIFF
--- a/libraries/joomla/form/fields/sql.php
+++ b/libraries/joomla/form/fields/sql.php
@@ -246,12 +246,12 @@ class JFormFieldSQL extends JFormFieldList
 					}
 					else
 					{
-						$query->where($db->quoteName($value) . ' = ' .$db->quote($html_filters[$value]));
+						$query->where($db->quoteName($value) . ' = ' . $db->quote($html_filters[$value]));
 					}
 				}
 				elseif (!empty($defaults[$value]))
 				{
-					$query->where($db->quoteName($value) . ' = ' .$db->quote($defaults[$value]));
+					$query->where($db->quoteName($value) . ' = ' . $db->quote($defaults[$value]));
 				}
 			}
 		}
@@ -278,8 +278,8 @@ class JFormFieldSQL extends JFormFieldList
 		$options = array();
 
 		// Initialize some field attributes.
-		$key   = $this->keyField;
-		$value = $this->valueField;
+		$key    = $this->keyField;
+		$value  = $this->valueField;
 		$header = $this->header;
 
 		if ($this->query)
@@ -304,7 +304,7 @@ class JFormFieldSQL extends JFormFieldList
 		if (!empty($header))
 		{
 			$header_title = Text::_($header);
-			$options[] = HTMLHelper::_('select.option', '', $header_title);
+			$options[]    = HTMLHelper::_('select.option', '', $header_title);
 		}
 
 		// Build the field options.

--- a/libraries/joomla/form/fields/sql.php
+++ b/libraries/joomla/form/fields/sql.php
@@ -9,7 +9,12 @@
 
 defined('JPATH_PLATFORM') or die;
 
-JFormHelper::loadFieldClass('list');
+use Joomla\CMS\Factory;
+use Joomla\CMS\Form\FormHelper;
+use Joomla\CMS\Language\Text;
+use Joomla\CMS\HTML\HTMLHelper;
+
+FormHelper::loadFieldClass('list');
 
 /**
  * Supports a custom SQL select list
@@ -125,6 +130,9 @@ class JFormFieldSQL extends JFormFieldList
 	{
 		$return = parent::setup($element, $value, $group);
 
+		// Set context for filters
+		$this->context = !empty($this->element['context']) ? (string) $this->element['context'] : '';
+
 		if ($return)
 		{
 			// Check if its using the old way
@@ -194,7 +202,7 @@ class JFormFieldSQL extends JFormFieldList
 	protected function processQuery($conditions, $filters, $defaults)
 	{
 		// Get the database object.
-		$db = JFactory::getDbo();
+		$db = Factory::getDbo();
 
 		// Get the query object
 		$query = $db->getQuery(true);
@@ -226,15 +234,22 @@ class JFormFieldSQL extends JFormFieldList
 		// Process the filters
 		if (is_array($filters))
 		{
-			$html_filters = JFactory::getApplication()->getUserStateFromRequest($this->context . '.filter', 'filter', array(), 'array');
+			$html_filters = Factory::getApplication()->getUserStateFromRequest($this->context . '.filter', 'filter', array(), 'array');
 
 			foreach ($filters as $k => $value)
 			{
 				if (!empty($html_filters[$value]))
 				{
-					$escape = $db->quote($db->escape($html_filters[$value]), false);
-
-					$query->where("{$value} = {$escape}");
+					if (is_array($html_filters[$value]))
+					{
+						$in = implode(',', $html_filters[$value]);
+						$query->where($db->qn($value) . ' IN (' . $in . ')');
+					}
+					else
+					{
+						$escape = $db->quote($db->escape($html_filters[$value]), false);
+						$query->where("{$value} = {$escape}");
+					}
 				}
 				elseif (!empty($defaults[$value]))
 				{
@@ -274,7 +289,7 @@ class JFormFieldSQL extends JFormFieldList
 		if ($this->query)
 		{
 			// Get the database object.
-			$db = JFactory::getDbo();
+			$db = Factory::getDbo();
 
 			// Set the query and get the result list.
 			$db->setQuery($this->query);
@@ -285,15 +300,15 @@ class JFormFieldSQL extends JFormFieldList
 			}
 			catch (JDatabaseExceptionExecuting $e)
 			{
-				JFactory::getApplication()->enqueueMessage(JText::_('JERROR_AN_ERROR_HAS_OCCURRED'), 'error');
+				Factory::getApplication()->enqueueMessage(Text::_('JERROR_AN_ERROR_HAS_OCCURRED'), 'error');
 			}
 		}
 
 		// Add header.
 		if (!empty($header))
 		{
-			$header_title = JText::_($header);
-			$options[] = JHtml::_('select.option', '', $header_title);
+			$header_title = Text::_($header);
+			$options[] = HTMLHelper::_('select.option', '', $header_title);
 		}
 
 		// Build the field options.
@@ -303,11 +318,11 @@ class JFormFieldSQL extends JFormFieldList
 			{
 				if ($this->translate == true)
 				{
-					$options[] = JHtml::_('select.option', $item->$key, JText::_($item->$value));
+					$options[] = HTMLHelper::_('select.option', $item->$key, Text::_($item->$value));
 				}
 				else
 				{
-					$options[] = JHtml::_('select.option', $item->$key, $item->$value);
+					$options[] = HTMLHelper::_('select.option', $item->$key, $item->$value);
 				}
 			}
 		}

--- a/libraries/joomla/form/fields/sql.php
+++ b/libraries/joomla/form/fields/sql.php
@@ -246,7 +246,7 @@ class JFormFieldSQL extends JFormFieldList
 					}
 					else
 					{
-						$query->where($db->quoteName($value) . " = " .$db->quote($html_filters[$value]));
+						$query->where($db->quoteName($value) . ' = ' .$db->quote($html_filters[$value]));
 					}
 				}
 				elseif (!empty($defaults[$value]))

--- a/libraries/joomla/form/fields/sql.php
+++ b/libraries/joomla/form/fields/sql.php
@@ -11,8 +11,8 @@ defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\FormHelper;
-use Joomla\CMS\Language\Text;
 use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Language\Text;
 
 FormHelper::loadFieldClass('list');
 
@@ -234,7 +234,7 @@ class JFormFieldSQL extends JFormFieldList
 		// Process the filters
 		if (is_array($filters))
 		{
-			$html_filters = Factory::getApplication()->getUserStateFromRequest($this->context . '.filter', 'filter', array(), 'array');
+			$html_filters = Factory::getApplication()->getUserState($this->context . '.filter', 'filter');
 
 			foreach ($filters as $k => $value)
 			{

--- a/libraries/joomla/form/fields/sql.php
+++ b/libraries/joomla/form/fields/sql.php
@@ -251,7 +251,7 @@ class JFormFieldSQL extends JFormFieldList
 				}
 				elseif (!empty($defaults[$value]))
 				{
-					$query->where($db->quoteName($value) . " = " .$db->quote($defaults[$value]));
+					$query->where($db->quoteName($value) . ' = ' .$db->quote($defaults[$value]));
 				}
 			}
 		}

--- a/libraries/joomla/form/fields/sql.php
+++ b/libraries/joomla/form/fields/sql.php
@@ -242,20 +242,16 @@ class JFormFieldSQL extends JFormFieldList
 				{
 					if (is_array($html_filters[$value]))
 					{
-						$in = implode(',', $html_filters[$value]);
-						$query->where($db->qn($value) . ' IN (' . $in . ')');
+						$query->where($db->quoteName($value) . ' IN (' . implode(',', $db->quote($html_filters[$value])) . ')');
 					}
 					else
 					{
-						$escape = $db->quote($db->escape($html_filters[$value]), false);
-						$query->where("{$value} = {$escape}");
+						$query->where($db->quoteName($value) . " = " .$db->quote($html_filters[$value]));
 					}
 				}
 				elseif (!empty($defaults[$value]))
 				{
-					$escape = $db->quote($db->escape($defaults[$value]), false);
-
-					$query->where("{$value} = {$escape}");
+					$query->where($db->quoteName($value) . " = " .$db->quote($defaults[$value]));
 				}
 			}
 		}


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This patch use namespaces to load Joomla! libraries and accept multiple values as array for filtering. 

Also add the option to set context value in the xml fields. For example:

```
        <field
                name="article"
                type="sql"
                label="COM_EXAMPLE_FORM_ARTICLE"
                sql_select="c.id, c.title"
                sql_from="#__content AS c"
                sql_order="c.id ASC"
                sql_filter="catid"
                key_field="id"
                value_field="title"
                context="com_example.list_view_example"
        />
```

Into the [documentation](https://docs.joomla.org/Special:MyLanguage/SQL_form_field_type) for custom fields is well explained how to use default filters setting sql_default_{field} and a static value but is not explained how to set dynamic variables using user states for filtering. (see testing)

### Testing Instructions

Using the last field example, we can see that we set **sql_filter** as **catid** . For filtering we must to set into our **view.html.php** file, using the **setUserState** method a value or an array for multiple values. For example:

```
$multiple_values = array(3, 5, 7); 
Factory::getApplication()->setUserState("com_example.list_view_example.filter.catid",  $multiple_values);
```
This is going to filter into the **catid** field using the values declared in the variable **$multiple_values**

### Expected result

We should get the list filtered correctly using the static or dynamic values.

### Documentation Changes Required

Dynamic filtering must to be added to:

https://docs.joomla.org/Special:MyLanguage/SQL_form_field_type