### PR TITLE
[4.0] iframes must have a title

### DIFF
--- a/layouts/joomla/modal/iframe.php
+++ b/layouts/joomla/modal/iframe.php
@@ -40,6 +40,7 @@ $iframeAttributes = array(
 if (isset($params['title']))
 {
 	$iframeAttributes['name'] = addslashes($params['title']);
+	$iframeAttributes['title'] = addslashes($params['title']);
 }
 
 if (isset($params['height']))


### PR DESCRIPTION
It is part of the a11y requirements to ensure that an iframe has a title attribute

This simple PR fixes that for the modal iframe layout
