### PR TITLE
[4.0] Smart Search Indexer title

### DIFF
--- a/administrator/components/com_finder/tmpl/indexer/default.php
+++ b/administrator/components/com_finder/tmpl/indexer/default.php
@@ -19,7 +19,7 @@ Factory::getDocument()->addScriptDeclaration('var msg = "' . Text::_('COM_FINDER
 ?>
 
 <div class="text-center">
-	<h1 id="finder-progress-header m-t-2"><?php echo Text::_('COM_FINDER_INDEXER_HEADER_INIT'); ?></h1>
+	<h1 id="finder-progress-header" class="m-t-2"><?php echo Text::_('COM_FINDER_INDEXER_HEADER_INIT'); ?></h1>
 	<p id="finder-progress-message"><?php echo Text::_('COM_FINDER_INDEXER_MESSAGE_INIT'); ?></p>
 	<div id="progress" class="progress">
 		<div id="progress-bar" class="progress-bar bg-success" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>


### PR DESCRIPTION
The title is supposed to change as the content is being indexed but it doesn't because of a silly little typo

This PR fixes that. You can easily test this by running the indexer and without this PR you will see that it always says "Starting Indexer"

After applying this PR you will see the title change
