### PR TITLE
[4.0] Smart Search Indexer [a11y]

### DIFF
--- a/administrator/components/com_finder/tmpl/indexer/default.php
+++ b/administrator/components/com_finder/tmpl/indexer/default.php
@@ -20,7 +20,7 @@ Factory::getDocument()->addScriptDeclaration('var msg = "' . Text::_('COM_FINDER
 
 <div class="text-center">
 	<h1 id="finder-progress-header m-t-2"><?php echo Text::_('COM_FINDER_INDEXER_HEADER_INIT'); ?></h1>
-	<p id="finder-progress-message"><?php echo Text::_('COM_FINDER_INDEXER_MESSAGE_INIT'); ?></p>
+	<p id="finder-progress-message" aria-live="assertive"><?php echo Text::_('COM_FINDER_INDEXER_MESSAGE_INIT'); ?></p>
 	<div id="progress" class="progress">
 		<div id="progress-bar" class="progress-bar bg-success" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
 	</div>

--- a/administrator/components/com_finder/tmpl/indexer/default.php
+++ b/administrator/components/com_finder/tmpl/indexer/default.php
@@ -19,8 +19,8 @@ Factory::getDocument()->addScriptDeclaration('var msg = "' . Text::_('COM_FINDER
 ?>
 
 <div class="text-center">
-	<h1 id="finder-progress-header m-t-2"><?php echo Text::_('COM_FINDER_INDEXER_HEADER_INIT'); ?></h1>
-	<p id="finder-progress-message" aria-live="assertive"><?php echo Text::_('COM_FINDER_INDEXER_MESSAGE_INIT'); ?></p>
+	<h1 id="finder-progress-header m-t-2" aria-live="assertive"><?php echo Text::_('COM_FINDER_INDEXER_HEADER_INIT'); ?></h1>
+	<p id="finder-progress-message" aria-live="polite"><?php echo Text::_('COM_FINDER_INDEXER_MESSAGE_INIT'); ?></p>
 	<div id="progress" class="progress">
 		<div id="progress-bar" class="progress-bar bg-success" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
 	</div>


### PR DESCRIPTION
The popup that is loaded when you index the content has a message that is updated during the index process

COM_FINDER_INDEXER_MESSAGE_INIT="The indexer is starting. Do not close this window."
COM_FINDER_INDEXER_MESSAGE_RUNNING="Your content is being indexed. Do not close this window."
COM_FINDER_INDEXER_MESSAGE_OPTIMIZE="The index tables are being optimised for the best possible performance. Do not close this window."
COM_FINDER_INDEXER_MESSAGE_COMPLETE="The indexing process is complete. It is now safe to close this window."

(Note the title should also update - it doesn't but that is fixed in #24759 
This changing message is invisible to screen readers unless we add an aria-live attribute to the enclosing element. 

By putting assertive on the title it ensures that the screen reader stops announcing the message when the title changes