### PR TITLE
[4.0] Media grid size buttons

### DIFF
--- a/administrator/components/com_media/resources/scripts/components/toolbar/toolbar.vue
+++ b/administrator/components/com_media/resources/scripts/components/toolbar/toolbar.vue
@@ -18,16 +18,14 @@
                v-if="isGridView"
                :class="{disabled: isGridSize('xs')}"
                @click.stop.prevent="decreaseGridSize()" 
-               :aria-label="translate('COM_MEDIA_DECREASE_GRID')"
-               aria-hidden="true">
+               :aria-label="translate('COM_MEDIA_DECREASE_GRID')">
                 <span class="fa fa-search-minus" aria-hidden="true"></span>
             </button>
             <button type="button" class="media-toolbar-icon media-toolbar-increase-grid-size"
                v-if="isGridView"
                :class="{disabled: isGridSize('xl')}"
                @click.stop.prevent="increaseGridSize()" 
-               :aria-label="translate('COM_MEDIA_INCREASE_GRID')"
-               aria-hidden="true">
+               :aria-label="translate('COM_MEDIA_INCREASE_GRID')">
                 <span class="fa fa-search-plus" aria-hidden="true"></span>
             </button>
             <button type="button" href="#" class="media-toolbar-icon media-toolbar-list-view"


### PR DESCRIPTION
The increase/decrease grid size buttons in the media manager have aria-hidden=true

This change was made in #23950 at the request of @zwiastunsw  https://github.com/joomla/joomla-cms/pull/23950#issuecomment-465628902

I dont understand why that request was made but at a minimum its implementation is wrong

A focusable element with aria-hidden="true" is ignored as part of the reading order, but still part of the focus order, making it’s state of visible or hidden unclear. ie you can focus on the button but dont get told anything about the button
