### PR TITLE
[4.0] Fix schema updates for com_finder with PostgreSQL database

### DIFF
--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2018-07-29.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2018-07-29.sql
@@ -7,8 +7,7 @@ ALTER TABLE "#__finder_filters" ALTER COLUMN "created_by_alias" SET DEFAULT '';
 TRUNCATE TABLE "#__finder_links";
 ALTER TABLE "#__finder_links" ALTER COLUMN "state" SET NOT NULL;
 ALTER TABLE "#__finder_links" ALTER COLUMN "access" SET NOT NULL;
-ALTER TABLE "#__finder_links" ALTER COLUMN "language" TYPE VARCHAR(7);
-ALTER TABLE "#__finder_links" ALTER COLUMN "language" SET DEFAULT '';
+ALTER TABLE "#__finder_links" ALTER COLUMN "language" TYPE VARCHAR(7), ALTER COLUMN "language" SET DEFAULT '';
 CREATE INDEX "#__finder_links_idx_language" on "#__finder_links" ("language");
 
 CREATE TABLE "#__finder_links_terms" (

--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2018-07-29.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2018-07-29.sql
@@ -7,7 +7,7 @@ ALTER TABLE "#__finder_filters" ALTER COLUMN "created_by_alias" SET DEFAULT '';
 TRUNCATE TABLE "#__finder_links";
 ALTER TABLE "#__finder_links" ALTER COLUMN "state" SET NOT NULL;
 ALTER TABLE "#__finder_links" ALTER COLUMN "access" SET NOT NULL;
-ALTER TABLE "#__finder_links" ALTER COLUMN "language" TYPE CHAR(7);
+ALTER TABLE "#__finder_links" ALTER COLUMN "language" TYPE VARCHAR(7);
 ALTER TABLE "#__finder_links" ALTER COLUMN "language" SET DEFAULT '';
 CREATE INDEX "#__finder_links_idx_language" on "#__finder_links" ("language");
 
@@ -17,8 +17,8 @@ CREATE TABLE "#__finder_links_terms" (
 	"weight" REAL NOT NULL DEFAULT 0,
 	PRIMARY KEY ("link_id", "term_id")
 );
-CREATE INDEX "idx_term_weight" ("term_id", "weight");
-CREATE INDEX "idx_link_term_weight" ("link_id", "term_id", "weight");
+CREATE INDEX "#__finder_links_terms_idx_term_weight" on "#__finder_links_terms" ("term_id", "weight");
+CREATE INDEX "#__finder_links_terms_idx_link_term_weight" on "#__finder_links_terms" ("link_id", "term_id", "weight");
 
 DROP TABLE "#__finder_links_terms0" CASCADE;
 DROP TABLE "#__finder_links_terms1" CASCADE;

--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2018-07-29.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2018-07-29.sql
@@ -267,12 +267,12 @@ INSERT INTO "#__finder_terms_common" ("term", "language", "custom") VALUES
 	('too', 'en', 0),
 	('very', 'en', 0);
 
-ALTER TABLE "#__finder_tokens" ALTER COLUMN "language" TYPE CHAR(7), ALTER COLUMN "language" SET DEFAULT '';
+ALTER TABLE "#__finder_tokens" ALTER COLUMN "language" TYPE VARCHAR(7), ALTER COLUMN "language" SET DEFAULT '';
 ALTER TABLE "#__finder_tokens" ALTER COLUMN "stem" SET DEFAULT '';
 CREATE INDEX "#__finder_tokens_idx_stem" on "#__finder_tokens" ("stem");
 CREATE INDEX "#__finder_tokens_idx_language" on "#__finder_tokens" ("language");
 
-ALTER TABLE "#__finder_tokens_aggregate" ALTER COLUMN "language" TYPE CHAR(7), ALTER COLUMN "language" SET DEFAULT '';
+ALTER TABLE "#__finder_tokens_aggregate" ALTER COLUMN "language" TYPE VARCHAR(7), ALTER COLUMN "language" SET DEFAULT '';
 ALTER TABLE "#__finder_tokens_aggregate" DROP COLUMN "map_suffix";
 ALTER TABLE "#__finder_tokens_aggregate" ALTER COLUMN "stem" SET DEFAULT '';
 ALTER TABLE "#__finder_tokens_aggregate" ALTER COLUMN "term_weight" SET DEFAULT 0;


### PR DESCRIPTION
Pull Request for Issue #24769 .

### Summary of Changes

Fix the schema update changes from PR #20561 for PostgreSQL so they are consistent with a new installation.

### Testing Instructions

1. Pull current (May 1, 2019) 4.0-dev branch and do `composer install` and `npm ci`, or use nightly build from tonight. Both include PR #24747, which is needed to install on PostgreSQL. Alpha 8 does not include that yet, so please don't use Alpha 8.
2. Run installation using a PostgreSQL database.
3. After installation has finished with success, login to backend, confirm the statistics dialog, then goto the system panel and check section "Information - Database". Result: You see that there is 1 database problem.
4. Click "Database" to get to the Database view. Result: See section "Actual result" below.
5. Apply changes from this PR.
6. Leave database view and go back to it again. Result: See section "Expected result" below.

### Expected result

No database problems.

### Actual result

![screen shot 2019-05-01 at 09 59 15](https://issues.joomla.org/uploads/1/cf9d34b84d4bb5b3a7834023f1e289dd.png)

### Documentation Changes Required

None.