### PR TITLE
[4.0] Select menu type

### DIFF
--- a/administrator/components/com_menus/Field/MenutypeField.php
+++ b/administrator/components/com_menus/Field/MenutypeField.php
@@ -90,7 +90,7 @@ class MenutypeField extends ListField
 		$link = Route::_('index.php?option=com_menus&view=menutypes&tmpl=component&client_id=' . $clientId . '&recordId=' . $recordId);
 		$html[] = '<span class="input-group"><input type="text" ' . $required . ' readonly="readonly" id="' . $this->id
 			. '" value="' . $value . '"' . $size . $class . '>';
-		$html[] = '<span class="input-group-append"><button type="button" data-target="#menuTypeModal" class="btn btn-primary" data-toggle="modal" '
+		$html[] = '<span class="input-group-append"><button type="button" data-target="#menuTypeModal" class="btn btn-primary" data-toggle="modal">'
 			. '<span class="icon-list icon-white" aria-hidden="true"></span> '
 			. Text::_('JSELECT') . '</button></span></span>';
 		$html[] = HTMLHelper::_(


### PR DESCRIPTION
Missing close on the span element resulted in missing icon and a11y errors

Can be tested by comparing the generated source and by seeing that the icon is now present

### Before PR
![image](https://user-images.githubusercontent.com/1296369/57068743-8447c380-6cca-11e9-9d53-2428a2cf1b9a.png)


### After PR
![image](https://user-images.githubusercontent.com/1296369/57068714-709c5d00-6cca-11e9-9319-d594478c995c.png)
