### PR TITLE
[4.0] com_cache

### DIFF
--- a/administrator/components/com_cache/tmpl/cache/default.php
+++ b/administrator/components/com_cache/tmpl/cache/default.php
@@ -54,7 +54,7 @@ HTMLHelper::_('script', 'com_cache/admin-cache-default.js', ['version' => 'auto'
 								</td>
 								<th scope="row">
 									<label for="cb<?php echo $i; ?>">
-										<strong><?php echo $this->escape($item->group); ?></strong>
+										<?php echo $this->escape($item->group); ?>
 									</label>
 								</th>
 								<td class="text-center">


### PR DESCRIPTION
We don't need the <strong wrapping the item as it already has a font weight of 700.

### before
![image](https://user-images.githubusercontent.com/1296369/57070921-c542d680-6cd0-11e9-9f36-a9efbb49a8c2.png)


### after
![image](https://user-images.githubusercontent.com/1296369/57070894-b65c2400-6cd0-11e9-9852-1413a79cc2bb.png)
