### PR TITLE
[4.0] Modal select fields

### DIFF
--- a/administrator/components/com_categories/Field/Modal/CategoryField.php
+++ b/administrator/components/com_categories/Field/Modal/CategoryField.php
@@ -141,7 +141,7 @@ class CategoryField extends FormField
 			$html .= '<span class="input-group">';
 		}
 
-		$html .= '<input class="form-control" id="' . $this->id . '_name" type="text" value="' . $title . '" disabled="disabled" size="35">';
+		$html .= '<input class="form-control" id="' . $this->id . '_name" type="text" value="' . $title . '" readonly="readonly" size="35">';
 
 		if ($allowSelect || $allowNew || $allowEdit || $allowClear)
 		{
@@ -319,6 +319,6 @@ class CategoryField extends FormField
 	 */
 	protected function getLabel()
 	{
-		return str_replace($this->id, $this->id . '_id', parent::getLabel());
+		return str_replace($this->id, $this->id . '_name', parent::getLabel());
 	}
 }

--- a/administrator/components/com_categories/Field/Modal/CategoryField.php
+++ b/administrator/components/com_categories/Field/Modal/CategoryField.php
@@ -141,7 +141,7 @@ class CategoryField extends FormField
 			$html .= '<span class="input-group">';
 		}
 
-		$html .= '<input class="form-control" id="' . $this->id . '_name" type="text" value="' . $title . '" readonly="readonly" size="35">';
+		$html .= '<input class="form-control" id="' . $this->id . '_name" type="text" value="' . $title . '" readonly size="35">';
 
 		if ($allowSelect || $allowNew || $allowEdit || $allowClear)
 		{

--- a/administrator/components/com_contact/Field/Modal/ContactField.php
+++ b/administrator/components/com_contact/Field/Modal/ContactField.php
@@ -130,7 +130,7 @@ class ContactField extends FormField
 			$html .= '<span class="input-group">';
 		}
 
-		$html .= '<input class="form-control" id="' . $this->id . '_name" type="text" value="' . $title . '" disabled="disabled" size="35">';
+		$html .= '<input class="form-control" id="' . $this->id . '_name" type="text" value="' . $title . '" readonly size="35">';
 
 		if ($allowSelect || $allowNew || $allowEdit || $allowClear)
 		{
@@ -314,6 +314,6 @@ class ContactField extends FormField
 	 */
 	protected function getLabel()
 	{
-		return str_replace($this->id, $this->id . '_id', parent::getLabel());
+		return str_replace($this->id, $this->id . '_name', parent::getLabel());
 	}
 }

--- a/administrator/components/com_content/Field/Modal/ArticleField.php
+++ b/administrator/components/com_content/Field/Modal/ArticleField.php
@@ -133,7 +133,7 @@ class ArticleField extends FormField
 			$html .= '<span class="input-group">';
 		}
 
-		$html .= '<input class="form-control" id="' . $this->id . '_name" type="text" value="' . $title . '" disabled="disabled" size="35">';
+		$html .= '<input class="form-control" id="' . $this->id . '_name" type="text" value="' . $title . '" readonly size="35">';
 
 		if ($allowSelect || $allowNew || $allowEdit || $allowClear)
 		{
@@ -311,6 +311,6 @@ class ArticleField extends FormField
 	 */
 	protected function getLabel()
 	{
-		return str_replace($this->id, $this->id . '_id', parent::getLabel());
+		return str_replace($this->id, $this->id . '_name', parent::getLabel());
 	}
 }

--- a/administrator/components/com_newsfeeds/Field/Modal/NewsfeedField.php
+++ b/administrator/components/com_newsfeeds/Field/Modal/NewsfeedField.php
@@ -131,7 +131,7 @@ class NewsfeedField extends FormField
 			$html .= '<span class="input-group">';
 		}
 
-		$html .= '<input class="form-control" id="' . $this->id . '_name" type="text" value="' . $title . '" disabled="disabled" size="35">';
+		$html .= '<input class="form-control" id="' . $this->id . '_name" type="text" value="' . $title . '" readonly size="35">';
 
 		if ($allowSelect || $allowNew || $allowEdit || $allowClear)
 		{
@@ -315,6 +315,6 @@ class NewsfeedField extends FormField
 	 */
 	protected function getLabel()
 	{
-		return str_replace($this->id, $this->id . '_id', parent::getLabel());
+		return str_replace($this->id, $this->id . '_name', parent::getLabel());
 	}
 }


### PR DESCRIPTION
The following fields were identified by @zwiastunsw as not having labels associated with the element

There were TWO different problems that this PR fixes
1. the label was being associated with the hidden input and not the visible input
2. The visible input was set to disabled - it should have been readonly because 

When applied to a form field, the disabled attribute means that the field does not receive focus. resulting in the screen reader ignoring the field and not announcing the value of the field

Basically the fields that look like 
![image](https://user-images.githubusercontent.com/1296369/57098753-ba109a80-6d12-11e9-9885-fec7ebd6d38b.png)

Menus: Edit Item page, Single Article menu item type
Details tab: Select Article field

Menus: Edit Item page, Category blog menu item type
Details tab: Choose a Category field

Menus: Edit Item page, Single Contact menu item type
Details tab: Select Contact field

Menus: Edit Item page, Contact Single Category menu item type
Details tab: Select a Category field

Menus: Edit Item page, Single News Feed menu item type
Details tab: Feed field

