### PR TITLE
Anchor text for the link

### DIFF
--- a/plugins/fields/url/tmpl/url.php
+++ b/plugins/fields/url/tmpl/url.php
@@ -12,7 +12,7 @@ $value = $field->value;
 $desc = $field->description;
 
 $mailto = "mailto:";
-$value_substring = htmlspecialchars(str_replace("mailto:","",$value));
+$value_substring = htmlspecialchars(str_replace("mailto:", "", $value));
 
 if ($value == '')
 {

--- a/plugins/fields/url/tmpl/url.php
+++ b/plugins/fields/url/tmpl/url.php
@@ -9,6 +9,10 @@
 defined('_JEXEC') or die;
 
 $value = $field->value;
+$desc = $field->description;
+
+$mailto = "mailto:";
+$value_substring = htmlspecialchars(str_replace("mailto:","",$value));
 
 if ($value == '')
 {
@@ -22,8 +26,17 @@ if (!JUri::isInternal($value))
 	$attributes = ' rel="nofollow noopener noreferrer" target="_blank"';
 }
 
+if ($desc =='')
+{ 
+	$linkdisplay = $value_substring;
+} 
+else
+{
+	$linkdisplay = $desc;
+}
+
 echo sprintf('<a href="%s"%s>%s</a>',
 	htmlspecialchars($value),
 	$attributes,
-	htmlspecialchars($value)
+	htmlspecialchars($linkdisplay)
 );


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/24739

### Summary of Changes
The URL field description is used as anchor text for the URL.
This PR is based on the work and the suggestion of Laura ( @rytechsites ): https://github.com/joomla/joomla-cms/issues/24739#issuecomment-487949280

PROs: links will have now an anchor text.
Cons: All the URLs will have the same anchor text.


### Testing Instructions
Create a field, choose type "URL", specify a Description for the URL field.
Create an article, fill the URL field.

### Expected result
In the frontend you won't see anymore the raw URL, but you will see the description of the field as anchor text for all the URLs using such field.


### Documentation Changes Required
Add this behavior to the URL field documentation page: https://docs.joomla.org/J3.x:Adding_custom_fields/Url_Field 
