### PR TITLE
[4.0] Show the correct modal for a given extension

### DIFF
--- a/administrator/components/com_installer/Model/ManageModel.php
+++ b/administrator/components/com_installer/Model/ManageModel.php
@@ -410,6 +410,7 @@ class ManageModel extends InstallerModel
 					array(
 						'extensions.element',
 						'extensions.type',
+						'extensions.folder',
 						'extensions.changelogurl',
 						'extensions.manifest_cache',
 						'extensions.client_id'

--- a/administrator/components/com_installer/tmpl/manage/default.php
+++ b/administrator/components/com_installer/tmpl/manage/default.php
@@ -106,13 +106,13 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 								<td class="d-none d-md-table-cell">
 									<?php if ($item->version !== '') : ?>
 										<?php if ($item->changelogurl !== null) : ?>
-											<a href="#changelogModal" onclick="Joomla.loadChangelog(<?php echo $item->extension_id; ?>, 'manage'); return false;" data-toggle="modal">
+											<a href="#changelogModal<?php echo $item->extension_id; ?>" onclick="Joomla.loadChangelog(<?php echo $item->extension_id; ?>, 'manage'); return false;" data-toggle="modal">
 												<?php echo $item->version?>
 											</a>
 											<?php
 											echo HTMLHelper::_(
 												'bootstrap.renderModal',
-												'changelogModal',
+												'changelogModal' . $item->extension_id,
 												array(
 													'title' => Text::sprintf('COM_INSTALLER_CHANGELOG_TITLE', $item->name, $item->version),
 												),

--- a/build/media_source/system/js/core.es6.js
+++ b/build/media_source/system/js/core.es6.js
@@ -933,7 +933,7 @@ window.Joomla.Modal = window.Joomla.Modal || {
       url: `index.php?option=com_installer&task=manage.loadChangelog&eid=${extensionId}&source=${view}&format=json`,
       onSuccess: (response) => {
         const result = JSON.parse(response);
-        document.querySelectorAll('#changelogModal' + extensionId + ' .modal-body')[0].innerHTML = result.data;
+        document.querySelectorAll(`#changelogModal${extensionId} .modal-body`)[0].innerHTML = result.data;
       },
     });
   };

--- a/build/media_source/system/js/core.es6.js
+++ b/build/media_source/system/js/core.es6.js
@@ -933,7 +933,7 @@ window.Joomla.Modal = window.Joomla.Modal || {
       url: `index.php?option=com_installer&task=manage.loadChangelog&eid=${extensionId}&source=${view}&format=json`,
       onSuccess: (response) => {
         const result = JSON.parse(response);
-        document.querySelectorAll('#changelogModal .modal-body')[0].innerHTML = result.data;
+        document.querySelectorAll('#changelogModal' + extensionId + ' .modal-body')[0].innerHTML = result.data;
       },
     });
   };


### PR DESCRIPTION
Pull Request for Issue #24744 .

### Summary of Changes
This fixes the issue of always showing the same modal.

### Testing Instructions
1. Go to the backend
2. Click on System -> Extensions -> Manage
3. Filter on Kunena
4. Click on the version number of multiple extensions and check the modal title. This will say `Kunena - AltaUserPoints Integration` for all extensions you click.
5. Install the Kunena 6 nightly build (https://www.kunena.org/download#joomla-60)
6. Click on System -> Extensions -> Manage
7. Filter on Kunena
8. Click on the version number of multiple extensions and check the modal title. This will say `Kunena - AltaUserPoints Integration` for all extensions you click.

### Expected result
Modal is showing the correct title

### Actual result
Modal is always showing the title of the first extension with a changelog


### Documentation Changes Required
None

@810 
