### PR TITLE
[4.0] add ordering to status column in featured articles

### DIFF
--- a/administrator/components/com_content/tmpl/featured/default.php
+++ b/administrator/components/com_content/tmpl/featured/default.php
@@ -108,7 +108,7 @@ HTMLHelper::_('script', 'com_content/admin-articles-workflow-buttons.js', ['rela
 									<?php echo JText::_('JFEATURED'); ?>
 								</th>
 								<th scope="col" style="width:1%; min-width:85px" class="text-center">
-									<?php echo JText::_('JSTATUS'); ?>
+									<?php echo HTMLHelper::_('searchtools.sort', 'JSTATUS', 'a.state', $listDirn, $listOrder); ?>
 								</th>
 								<th scope="col">
 									<?php echo HTMLHelper::_('searchtools.sort', 'JGLOBAL_TITLE', 'a.title', $listDirn, $listOrder); ?>


### PR DESCRIPTION
This PR adds ordering to status column in featured articles, so that the user can sort the featured articles based on their status

### Before Patch 
![featured_status1](https://user-images.githubusercontent.com/34353697/57175908-22748e80-6e6f-11e9-8a88-86522e541bf8.png)

### After Patch
![featured_status2](https://user-images.githubusercontent.com/34353697/57175915-2b656000-6e6f-11e9-87e4-c4de7adf0714.png)

### Documentation Changes Required
None
