### PR TITLE
[4.0] Show formatted error message on build errors

### DIFF
--- a/build/build-modules-js/compilecss.es6.js
+++ b/build/build-modules-js/compilecss.es6.js
@@ -83,7 +83,7 @@ module.exports.compile = (options, path) => {
               },
               (error) => {
                 // eslint-disable-next-line no-console
-                console.error(`something exploded ${error}`);
+                console.error(error.formatted);
               },
             );
 

--- a/build/build-modules-js/compilejs.es6.js
+++ b/build/build-modules-js/compilejs.es6.js
@@ -48,7 +48,7 @@ module.exports.compileJS = (options, path) => {
               },
               (error) => {
                 // eslint-disable-next-line no-console
-                console.error(`something exploded ${error}`);
+                console.error(error.formatted);
               },
             );
           },

--- a/build/build-modules-js/stylesheets/scss-transform.es6.js
+++ b/build/build-modules-js/stylesheets/scss-transform.es6.js
@@ -17,7 +17,7 @@ module.exports.compile = (file, options) => {
   (error, result) => {
     if (error) {
       // eslint-disable-next-line no-console
-      console.error(`something exploded ${error.column}`, error.message, error.line);
+      console.error(error.formatted);
       process.exit(1);
     } else {
       // Auto prefixing


### PR DESCRIPTION
Use the formatted debug info to throw errors during the build process of Joomla.

Especially the `scss-transform.es6.js` error at the moment is not useful, as it does not display what file is causing the issue. By using `error.formatted` an error is displayed like:

```
Error: Invalid CSS after "}": expected "}", was ""
        on line 32 of administrator/templates/atum/scss/pages/_com_config.scss
        from line 67 of administrator/templates/atum/scss/template.scss
>> }

   -^

Segmentation fault: 11
```
Instead of:
```
something exploded 2 Invalid CSS after "}": expected "}", was "" 32
Segmentation fault: 11
```