### PR TITLE
[4.0] Include the mediamanager npm depedencies in the drone cache

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -20,7 +20,8 @@ steps:
       mount:
         - ./node_modules
         - ./libraries/vendor
-      cache_key: [ DRONE_REPO_NAMESPACE, DRONE_REPO_NAME, DRONE_BRANCH, DRONE_STAGE_NUMBER ]
+        - ./administrator/components/com_media/node_modules
+     cache_key: [ DRONE_REPO_NAMESPACE, DRONE_REPO_NAME, DRONE_BRANCH, DRONE_STAGE_NUMBER ]
     volumes:
       - name: cache
         path: /cache
@@ -43,6 +44,7 @@ steps:
       mount:
         - ./node_modules
         - ./libraries/vendor
+        - ./administrator/components/com_media/node_modules
       cache_key: [ DRONE_REPO_NAMESPACE, DRONE_REPO_NAME, DRONE_BRANCH, DRONE_STAGE_NUMBER ]
     volumes:
       - name: cache

--- a/.drone.yml
+++ b/.drone.yml
@@ -21,7 +21,7 @@ steps:
         - ./node_modules
         - ./libraries/vendor
         - ./administrator/components/com_media/node_modules
-     cache_key: [ DRONE_REPO_NAMESPACE, DRONE_REPO_NAME, DRONE_BRANCH, DRONE_STAGE_NUMBER ]
+      cache_key: [ DRONE_REPO_NAMESPACE, DRONE_REPO_NAME, DRONE_BRANCH, DRONE_STAGE_NUMBER ]
     volumes:
       - name: cache
         path: /cache
@@ -139,6 +139,6 @@ services:
 
 ---
 kind: signature
-hmac: 2112baeb140bcfc7f7137fa633704ca31a88bbafacb363fa258a8a6a17b79899
+hmac: 8aa5446bfea3fbb295ae9ca362c72f82738cca714f5670f9bf70da1c02d1ad45
 
 ...

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lint:js": "npx eslint .",
     "test": "npx karma start tests/javascript/karma.conf.js --single-run",
     "install": "node build.js --copy-assets && node build.js --build-pages",
-    "postinstall": "node build.js --compile-js && node build.js --compile-css && cd administrator/components/com_media && npm ci && npm run build",
+    "postinstall": "node build.js --compile-js && node build.js --compile-css && cd administrator/components/com_media && npm install && npm run build",
     "update": "node build.js --copy-assets && node build.js --build-pages && node build.js --compile-js && node build.js --compile-css",
     "gzip": "node -e 'require(\"./build/build-modules-js/gzip-assets.es6.js\").gzipFiles()'"
   },


### PR DESCRIPTION
### Summary of Changes
This PR adds the npm dependencies of com_media to the drone cache to speed up builds by eliminating the need to fetch packages via network.
