### PR TITLE
[4.0] Field groups switcher

### DIFF
--- a/administrator/components/com_fields/forms/group.xml
+++ b/administrator/components/com_fields/forms/group.xml
@@ -146,11 +146,11 @@
 				type="radio"
 				label="JFIELD_DISPLAY_READONLY_LABEL"
 				description="JFIELD_DISPLAY_READONLY_DESC"
-				class="btn-group btn-group-yesno"
+				class="switcher"
 				default="1"
 				>
-				<option value="1">JYES</option>
 				<option value="0">JNO</option>
+				<option value="1">JYES</option>
 			</field>
 		</fieldset>
 	</fields>


### PR DESCRIPTION
Use the switcher class instead of the btn yes-no

![image](https://user-images.githubusercontent.com/1296369/57195213-f7aa3900-6f47-11e9-97a4-efa5bf00f1b5.png)


css alignment will be in a seperate pr