### PR TITLE
[4.0] Language labels uppercase

### DIFF
--- a/components/com_contact/tmpl/featured/default.xml
+++ b/components/com_contact/tmpl/featured/default.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <metadata>
-	<layout title="com_contact_featured_view_default_title" option="com_contact_featured_view_default_option">
+	<layout title="COM_CONTACT_FEATURED_VIEW_DEFAULT_TITLE" option="COM_CONTACT_FEATURED_VIEW_DEFAULT_OPTION">
 		<help
 			key = "JHELP_MENUS_MENU_ITEM_CONTACT_FEATURED"
 		/>

--- a/components/com_content/tmpl/archive/default.xml
+++ b/components/com_content/tmpl/archive/default.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-	<layout title="com_content_archive_view_default_title" option="com_content_archive_view_default_option">
+	<layout title="COM_CONTENT_ARCHIVE_VIEW_DEFAULT_TITLE" option="COM_CONTENT_ARCHIVE_VIEW_DEFAULT_OPTION">
 		<help
 			key = "JHELP_MENUS_MENU_ITEM_ARTICLE_ARCHIVED"
 		/>
 		<message>
-			<![CDATA[com_content_archive_view_default_desc]]>
+			<![CDATA[COM_CONTENT_ARCHIVE_VIEW_DEFAULT_DESC]]>
 		</message>
 	</layout>
 

--- a/components/com_content/tmpl/article/default.xml
+++ b/components/com_content/tmpl/article/default.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-	<layout title="com_content_article_view_default_title" option="com_content_article_view_default_option">
+	<layout title="COM_CONTENT_ARTICLE_VIEW_DEFAULT_TITLE" option="COM_CONTENT_ARTICLE_VIEW_DEFAULT_OPTION">
 		<help
 			key = "JHELP_MENUS_MENU_ITEM_ARTICLE_SINGLE_ARTICLE"
 		/>
 		<message>
-			<![CDATA[com_content_article_view_default_desc]]>
+			<![CDATA[COM_CONTENT_ARTICLE_VIEW_DEFAULT_DESC]]>
 		</message>
 	</layout>
 
@@ -14,8 +14,8 @@
 		<fieldset name="request"
 			addfieldprefix="Joomla\Component\Content\Administrator\Field" >
 
-			<field 
-				name="id" 
+			<field
+				name="id"
 				type="modal_article"
 				label="COM_CONTENT_FIELD_SELECT_ARTICLE_LABEL"
 				required="true"

--- a/components/com_privacy/tmpl/confirm/default.xml
+++ b/components/com_privacy/tmpl/confirm/default.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-	<layout title="com_privacy_confirm_view_default_title" option="com_privacy_confirm_view_default_option">
+	<layout title="COM_PRIVACY_CONFIRM_VIEW_DEFAULT_TITLE" option="COM_PRIVACY_CONFIRM_VIEW_DEFAULT_OPTION">
 		<help
 			key="JHELP_MENUS_MENU_ITEM_PRIVACY_CONFIRM_REQUEST"
 		/>

--- a/components/com_privacy/tmpl/remind/default.xml
+++ b/components/com_privacy/tmpl/remind/default.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-	<layout title="com_privacy_remind_view_default_title" option="com_privacy_remind_view_default_option">
+	<layout title="COM_PRIVACY_REMIND_VIEW_DEFAULT_TITLE" option="COM_PRIVACY_REMIND_VIEW_DEFAULT_OPTION">
 		<help
 			key="JHELP_MENUS_MENU_ITEM_PRIVACY_REMIND_REQUEST"
 		/>

--- a/components/com_privacy/tmpl/request/default.xml
+++ b/components/com_privacy/tmpl/request/default.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-	<layout title="com_privacy_request_view_default_title" option="com_privacy_request_view_default_option">
+	<layout title="COM_PRIVACY_REQUEST_VIEW_DEFAULT_TITLE" option="COM_PRIVACY_REQUEST_VIEW_DEFAULT_OPTION">
 		<help
 			key="JHELP_MENUS_MENU_ITEM_PRIVACY_CREATE_REQUEST"
 		/>

--- a/components/com_tags/tmpl/tag/default.xml
+++ b/components/com_tags/tmpl/tag/default.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-	<layout title="com_tags_tag_view_default_title" option="com_tags_tag_view_default_option">
+	<layout title="COM_TAGS_TAG_VIEW_DEFAULT_TITLE" option="COM_TAGS_TAG_VIEW_DEFAULT_OPTION">
 		<help
 			key="JHELP_MENUS_MENU_ITEM_TAGS_ITEMS_LIST"
 		/>
 		<message>
-			<![CDATA[com_tags_tag_view_default_desc]]>
+			<![CDATA[COM_TAGS_TAG_VIEW_DEFAULT_DESC]]>
 		</message>
 	</layout>
 

--- a/components/com_tags/tmpl/tag/list.xml
+++ b/components/com_tags/tmpl/tag/list.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-	<layout title="com_tags_tag_view_list_compact_title" option="com_tags_tag_view_list_compact_option">
+	<layout title="COM_TAGS_TAG_VIEW_LIST_COMPACT_TITLE" option="COM_TAGS_TAG_VIEW_LIST_COMPACT_OPTION">
 		<help
 			key="JHELP_MENUS_MENU_ITEM_TAGS_ITEMS_COMPACT_LIST"
 		/>
 		<message>
-			<![CDATA[com_tags_tag_view_list_desc]]>
+			<![CDATA[COM_TAGS_TAG_VIEW_LIST_DESC]]>
 		</message>
 	</layout>
 

--- a/components/com_tags/tmpl/tags/default.xml
+++ b/components/com_tags/tmpl/tags/default.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-	<layout title="com_tags_tags_view_default_title" option="com_tags_tag_view_default_option">
+	<layout title="COM_TAGS_TAGS_VIEW_DEFAULT_TITLE" option="COM_TAGS_TAG_VIEW_DEFAULT_OPTION">
 		<help
 			key="JHELP_MENUS_MENU_ITEM_TAGS_ITEMS_LIST_ALL"
 		/>
 		<message>
-			<![CDATA[com_tags_tags_view_default_desc]]>
+			<![CDATA[COM_TAGS_TAGS_VIEW_DEFAULT_DESC]]>
 		</message>
 	</layout>
 	<!-- Add fields to the request variables for the layout. -->

--- a/components/com_users/tmpl/login/default.xml
+++ b/components/com_users/tmpl/login/default.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-	<layout title="com_user_login_view_default_title" option="com_user_login_view_default_option">
+	<layout title="COM_USER_LOGIN_VIEW_DEFAULT_TITLE" option="COM_USER_LOGIN_VIEW_DEFAULT_OPTION">
 		<help
 			key = "JHELP_MENUS_MENU_ITEM_USER_LOGIN"
 		/>

--- a/components/com_users/tmpl/profile/default.xml
+++ b/components/com_users/tmpl/profile/default.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-	<layout title="com_user_profile_view_default_title" option="com_user_profile_view_default_option">
+	<layout title="COM_USER_PROFILE_VIEW_DEFAULT_TITLE" option="COM_USER_PROFILE_VIEW_DEFAULT_OPTION">
 		<help
 			key = "JHELP_MENUS_MENU_ITEM_USER_PROFILE"
 		/>
 		<message>
-			<![CDATA[com_user_profile_view_default_desc]]>
+			<![CDATA[COM_USER_PROFILE_VIEW_DEFAULT_DESC]]>
 		</message>
 	</layout>
 </metadata>

--- a/components/com_users/tmpl/profile/edit.xml
+++ b/components/com_users/tmpl/profile/edit.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-	<layout title="com_user_profile_edit_default_title" option="com_user_profile_edit_default_option">
+	<layout title="COM_USER_PROFILE_EDIT_DEFAULT_TITLE" option="COM_USER_PROFILE_EDIT_DEFAULT_OPTION">
 		<help
 			key = "JHELP_MENUS_MENU_ITEM_USER_PROFILE_EDIT"
 		/>
 		<message>
-			<![CDATA[com_user_profile_edit_default_desc]]>
+			<![CDATA[COM_USER_PROFILE_EDIT_DEFAULT_DESC]]>
 		</message>
 	</layout>
 </metadata>

--- a/components/com_users/tmpl/reset/default.xml
+++ b/components/com_users/tmpl/reset/default.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-	<layout title="com_user_reset_view_default_title" option="com_user_reset_view_default_option">
+	<layout title="COM_USER_RESET_VIEW_DEFAULT_TITLE" option="COM_USER_RESET_VIEW_DEFAULT_OPTION">
 		<help
 			key="JHELP_MENUS_MENU_ITEM_USER_PASSWORD_RESET"
 		/>


### PR DESCRIPTION
Codestyle fix for language labels in.xml files

### Summary of Changes
Some language labels in .xml files were written in lowercase.
This PR is to change them to UPPERCASE.