### PR TITLE
[4.0] Return correct validation result to form.

### DIFF
--- a/libraries/src/Form/FormField.php
+++ b/libraries/src/Form/FormField.php
@@ -1112,7 +1112,7 @@ abstract class FormField
 			return new \UnexpectedValueException($message);
 		}
 
-		return true;
+		return $valid;
 	}
 
 	/**


### PR DESCRIPTION
As far as I see, #12414 seems to have broken the form validation for some fields (except those components which do their own validation after the form validation, like com_users). Please check and inform me if I'm mistaken.

### Summary of Changes
The method `FormField::validate` checks whether the return value of `FormRule::test` is false and handles errors only in this particular case, returning a simple `true` for all other cases. The problem here is that `FormRule::test` might also return an Exception on failure, which doesn't evaluate to `false`. 
A quick glance through the different validation rules shows that this is the case for `EmailRule` and under some circumstances maybe also for `NotequalsRule`.

I suppose that this bug can be solved by not naively returning true, but the very result of the validation instead. Of course, another method would be to unify the way we want to treat validation errors by deciding on either returning booleans, returning exceptions or throwing exceptions.

### Testing Instructions
- Navigate to a form that has an email field using server-side validation.
  The error doesn't really occur for creating/editing a user (it occurs, but is only visible in the different styling of the error message), because com_users does another validation when saving. I tested it with the "From Email" field in the global configuration under "Server - Mail Settings".
- Enter an invalid value like "test".
- Save / submit the form.

### Expected result
The form should not be saved and return an error.


### Actual result
The form is saved.

Please also test that valid form submissions are still valid!