### PR TITLE
[4.0] Removing the void return type declarations for PHP 7.0 compatibility

### DIFF
--- a/libraries/src/WebAsset/AssetItem/CoreAssetItem.php
+++ b/libraries/src/WebAsset/AssetItem/CoreAssetItem.php
@@ -33,7 +33,7 @@ class CoreAssetItem extends WebAssetItem implements WebAssetAttachBehaviorInterf
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function onAttachCallback(Document $doc): void
+	public function onAttachCallback(Document $doc)
 	{
 		// Add core and base uri paths so javascript scripts can use them.
 		$doc->addScriptOptions(

--- a/libraries/src/WebAsset/AssetItem/KeepaliveAssetItem.php
+++ b/libraries/src/WebAsset/AssetItem/KeepaliveAssetItem.php
@@ -33,7 +33,7 @@ class KeepaliveAssetItem extends WebAssetItem implements WebAssetAttachBehaviorI
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function onAttachCallback(Document $doc): void
+	public function onAttachCallback(Document $doc)
 	{
 		$app            = Factory::getApplication();
 		$sessionHandler = $app->get('session_handler', 'database');

--- a/libraries/src/WebAsset/WebAssetAttachBehaviorInterface.php
+++ b/libraries/src/WebAsset/WebAssetAttachBehaviorInterface.php
@@ -29,5 +29,5 @@ interface WebAssetAttachBehaviorInterface
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function onAttachCallback(Document $doc): void;
+	public function onAttachCallback(Document $doc);
 }


### PR DESCRIPTION
### Summary of Changes
Removed void return type declarations to fix the broken 7.0 compatibility of the current 4.0 builds. 
See https://github.com/joomla/joomla-cms/pull/23743

cc @wilsonge  