### PR TITLE
[4.0] Missing layout in notes

### DIFF
--- a/administrator/components/com_users/tmpl/note/edit.php
+++ b/administrator/components/com_users/tmpl/note/edit.php
@@ -14,7 +14,7 @@ use Joomla\CMS\Router\Route;
 
 HTMLHelper::_('behavior.formvalidator');
 ?>
-<form action="<?php echo Route::_('index.php?option=com_users&view=note&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="note-form" class="form-validate">
+<form action="<?php echo Route::_('index.php?option=com_users&view=note&layout=edit&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="note-form" class="form-validate">
 	<fieldset class="adminform">
 		<div class="control-group">
 			<div class="control-label">


### PR DESCRIPTION
This is a bit tricky to test. Create a new note and keep it open until the session dies.

When you log back in you will be redirected to `index.php?option=com_users&view=note&id=0`

This will give a 500 Layout default not found.

Apply the pr and retest. The note will now be opened correctly as expected
