### PR TITLE
[4.0] Skip to plugin tweak

### DIFF
--- a/administrator/language/en-GB/en-GB.plg_system_skipto.ini
+++ b/administrator/language/en-GB/en-GB.plg_system_skipto.ini
@@ -4,7 +4,8 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_SYSTEM_SKIPTO="System - Skip-To Navigation"
-PLG_SYSTEM_SKIPTO_CONTENT="Content"
+; The following string begins with a space
+PLG_SYSTEM_SKIPTO_CONTENT=" Content"
 PLG_SYSTEM_SKIPTO_PAGE_OUTLINE="Page Outline"
 PLG_SYSTEM_SKIPTO_SECTION="Site Section"
 PLG_SYSTEM_SKIPTO_SECTION_ADMIN="Administrator (Backend)"


### PR DESCRIPTION
The string PLG_SYSTEM_SKIPTO_CONTENT needs to begin with a space. Updated the string and added a comment to the language file

### Before
![image](https://user-images.githubusercontent.com/1296369/57330263-6c7aa000-710d-11e9-86f5-33a980f366c0.png)

### After
![image](https://user-images.githubusercontent.com/1296369/57330230-5240c200-710d-11e9-9073-3597e682b2cf.png)
