### PR TITLE
[4.0] Implement getMenu() in ConsoleApplication class

### DIFF
--- a/libraries/src/Application/ConsoleApplication.php
+++ b/libraries/src/Application/ConsoleApplication.php
@@ -273,4 +273,19 @@ class ConsoleApplication extends Application implements DispatcherAwareInterface
 
 		return $this;
 	}
+
+	/**
+	 * Returns the application \JMenu object.
+	 *
+	 * @param   string  $name     The name of the application/client.
+	 * @param   array   $options  An optional associative array of configuration settings.
+	 *
+	 * @return  AbstractMenu
+	 *
+	 * @since   3.2
+	 */
+	public function getMenu($name = null, $options = array())
+	{
+		return null;
+	}
 }

--- a/libraries/src/Application/ConsoleApplication.php
+++ b/libraries/src/Application/ConsoleApplication.php
@@ -282,7 +282,7 @@ class ConsoleApplication extends Application implements DispatcherAwareInterface
 	 *
 	 * @return  null
 	 *
-	 * @since   DEPLOY_VERSION
+	 * @since   __DEPLOY_VERSION__
 	 */
 	public function getMenu($name = null, $options = array())
 	{

--- a/libraries/src/Application/ConsoleApplication.php
+++ b/libraries/src/Application/ConsoleApplication.php
@@ -280,9 +280,9 @@ class ConsoleApplication extends Application implements DispatcherAwareInterface
 	 * @param   string  $name     The name of the application/client.
 	 * @param   array   $options  An optional associative array of configuration settings.
 	 *
-	 * @return  AbstractMenu
+	 * @return  null
 	 *
-	 * @since   3.2
+	 * @since   DEPLOY_VERSION
 	 */
 	public function getMenu($name = null, $options = array())
 	{


### PR DESCRIPTION
### Summary of Changes
#24803 added the getMenu() method to the CMSApplicationInterface, this PR impements it in the ConsoleApplication by returning null as suggested by @wilsonge .


### Testing Instructions
Apply patch, try calling cli/joomla.php 
