### PR TITLE
[4.0] Correcting #24833 to add the space in the php and not in the lang string

### DIFF
--- a/administrator/language/en-GB/en-GB.plg_system_skipto.ini
+++ b/administrator/language/en-GB/en-GB.plg_system_skipto.ini
@@ -4,8 +4,7 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_SYSTEM_SKIPTO="System - Skip-To Navigation"
-; The following string begins with a space
-PLG_SYSTEM_SKIPTO_CONTENT=" Content"
+PLG_SYSTEM_SKIPTO_CONTENT="Content"
 PLG_SYSTEM_SKIPTO_PAGE_OUTLINE="Page Outline"
 PLG_SYSTEM_SKIPTO_SECTION="Site Section"
 PLG_SYSTEM_SKIPTO_SECTION_ADMIN="Administrator (Backend)"

--- a/plugins/system/skipto/skipto.php
+++ b/plugins/system/skipto/skipto.php
@@ -68,6 +68,7 @@ class PlgSystemSkipto extends CMSPlugin
 						'menuLabel'      => Text::_('PLG_SYSTEM_SKIPTO_SKIP_TO_AND_PAGE_OUTLINE'),
 						'landmarksLabel' => Text::_('PLG_SYSTEM_SKIPTO_SKIP_TO'),
 						'headingsLabel'	 => Text::_('PLG_SYSTEM_SKIPTO_PAGE_OUTLINE'),
+						// The following string begins with a space
 						'contentLabel'   => ' ' . Text::_('PLG_SYSTEM_SKIPTO_CONTENT'),
 					]
 				]

--- a/plugins/system/skipto/skipto.php
+++ b/plugins/system/skipto/skipto.php
@@ -68,7 +68,7 @@ class PlgSystemSkipto extends CMSPlugin
 						'menuLabel'      => Text::_('PLG_SYSTEM_SKIPTO_SKIP_TO_AND_PAGE_OUTLINE'),
 						'landmarksLabel' => Text::_('PLG_SYSTEM_SKIPTO_SKIP_TO'),
 						'headingsLabel'	 => Text::_('PLG_SYSTEM_SKIPTO_PAGE_OUTLINE'),
-						'contentLabel'   => Text::_('PLG_SYSTEM_SKIPTO_CONTENT'),
+						'contentLabel'   => ' ' . Text::_('PLG_SYSTEM_SKIPTO_CONTENT'),
 					]
 				]
 			]


### PR DESCRIPTION
See https://github.com/joomla/joomla-cms/pull/24833#issuecomment-490376846

### After patch
same results as in #24833 without modifying the lang string and adding a comment