### PR TITLE
[4.0] Load extension namespaces in CLI console

### DIFF
--- a/libraries/src/Application/ConsoleApplication.php
+++ b/libraries/src/Application/ConsoleApplication.php
@@ -31,7 +31,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  */
 class ConsoleApplication extends Application implements DispatcherAwareInterface, CMSApplicationInterface
 {
-	use DispatcherAwareTrait, EventAware, IdentityAware, ContainerAwareTrait, ExtensionManagerTrait;
+	use DispatcherAwareTrait, EventAware, IdentityAware, ContainerAwareTrait, ExtensionManagerTrait, ExtensionNamespaceMapper;
 
 	/**
 	 * The application message queue.
@@ -88,6 +88,9 @@ class ConsoleApplication extends Application implements DispatcherAwareInterface
 		{
 			$this->setDispatcher($dispatcher);
 		}
+
+		// Load extension namespaces
+		$this->createExtensionNamespaceMap();
 
 		// Set the execution datetime and timestamp;
 		$this->set('execution.datetime', gmdate('Y-m-d H:i:s'));


### PR DESCRIPTION
### Summary of Changes
Right now, it's not possible to load extension classes from the CLI commands because the extension classmap isn't loaded in the CLI console application.


### Testing Instructions
Add `var_dump(class_exists("Joomla\\Component\\Fields\\Administrator\\Helper\\FieldsHelper"));die();` to a console command of your choice. Call command, result will be false. Apply patch, result is now true.




