### PR TITLE
[4.0] Wrong order for attachActiveAssetsToDocument in MetasRenderer.php

### DIFF
--- a/libraries/src/Document/Renderer/Html/MetasRenderer.php
+++ b/libraries/src/Document/Renderer/Html/MetasRenderer.php
@@ -49,13 +49,13 @@ class MetasRenderer extends DocumentRenderer
 			HTMLHelper::_('behavior.core');
 		}
 
-		// Attach Assets
-		$wa = $this->_doc->getWebAssetManager();
-		$wa->attachActiveAssetsToDocument($this->_doc);
-
 		// Trigger the onBeforeCompileHead event
 		$app = Factory::getApplication();
 		$app->triggerEvent('onBeforeCompileHead');
+		
+		// Attach Assets
+		$wa = $this->_doc->getWebAssetManager();
+		$wa->attachActiveAssetsToDocument($this->_doc);
 
 		// Get line endings
 		$lnEnd        = $this->_doc->_getLineEnd();


### PR DESCRIPTION
### Summary of Changes
The order  of execution for $wa->attachActiveAssetsToDocument and the onBeforeCompileHead event triggering is wrong.
Currrently it's no more possible to add assets during the onBeforeCompileHead event for example through a system plugin, indeed an exception is thrown:

![image](https://user-images.githubusercontent.com/17835460/57493545-a8f0fc00-72c5-11e9-98a9-1eef5d1faa9b.png)

### Testing Instructions
Include a call to:
$document->getWebAssetManager()->enableAsset('jquery');
inside the onBeforeCompileHead event of a system plugin

### Expected result
The 'jquery' asset is correctly added through the WebAssetManager (working in Alpha 8)


### Actual result
An exception is thrown because the WebAssetManager has already been attach to the document


The onBeforeCompileHead event is supposed to be used even to attach scripts to the head of the document, thus it must be executed before attaching the assets to the document

