### PR TITLE
Revert "[4.0] Wrong order for attachActiveAssetsToDocument in MetasRenderer.php"

### DIFF
--- a/libraries/src/Document/Renderer/Html/MetasRenderer.php
+++ b/libraries/src/Document/Renderer/Html/MetasRenderer.php
@@ -49,13 +49,13 @@ class MetasRenderer extends DocumentRenderer
 			HTMLHelper::_('behavior.core');
 		}
 
-		// Trigger the onBeforeCompileHead event
-		$app = Factory::getApplication();
-		$app->triggerEvent('onBeforeCompileHead');
-		
 		// Attach Assets
 		$wa = $this->_doc->getWebAssetManager();
 		$wa->attachActiveAssetsToDocument($this->_doc);
+
+		// Trigger the onBeforeCompileHead event
+		$app = Factory::getApplication();
+		$app->triggerEvent('onBeforeCompileHead');
 
 		// Get line endings
 		$lnEnd        = $this->_doc->_getLineEnd();


### PR DESCRIPTION
Reverts joomla/joomla-cms#24848

That changes has more drawback than actually fixing (https://github.com/joomla/joomla-cms/pull/24848#issuecomment-491492252)

Critical to me: the changes in #24848 not allow to alter $doc anymore, because at `onBeforeCompileHead` $doc has incomplete set of js/css/options.

To enable an asset there many way, they can be enabled in layout, in all events between `route` and `render`.
But alter $doc js/css/options possible only at `onBeforeCompileHead`.

### Testing

Add to any system plugin an event:
```php
function onBeforeCompileHead()
{
	var_dump(array_keys(JFactory::getDocument()->_scripts));
}
```

**Expected:**

You should see `paths/to/core.min.js` In the dump output.

**Actual:**

`paths/to/core.min.js` not exist in the output
