### PR TITLE
[4.0] Batch button as CE

### DIFF
--- a/libraries/src/MVC/View/ListView.php
+++ b/libraries/src/MVC/View/ListView.php
@@ -252,8 +252,8 @@ class ListView extends HtmlView
 		{
 			$title = Text::_('JTOOLBAR_BATCH');
 
-			// Instantiate a new LayoutFile instance and render the batch button
-			$layout = new FileLayout('joomla.toolbar.batch');
+			// Instantiate a new LayoutFile instance and render the popup button
+			$layout = new FileLayout('joomla.toolbar.popup');
 
 			$dhtml = $layout->render(array('title' => $title));
 			$bar->appendButton('Custom', $dhtml, 'batch');


### PR DESCRIPTION
Many of the toolbar buttons use a regular button layout but the majority are using the joomla-toolbar-button element

For consistency and to make styling easier this changes the batch button to use the popup layout instead of the batch layout so that the button uses the custom element.

Partial fix for #24850
