### PR TITLE
[4.0] Remove the deprecated QQ place holder for double quotes

### DIFF
--- a/administrator/language/en-GB/en-GB.plg_captcha_recaptcha.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_captcha_recaptcha.sys.ini
@@ -3,5 +3,5 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 
-PLG_CAPTCHA_RECAPTCHA_XML_DESCRIPTION="This CAPTCHA plugin uses the reCAPTCHA service to prevent spammers while it helps to digitize books, newspapers and old radio shows. To get a site and secret key for your domain, go to <a href="_QQ_"https://www.google.com/recaptcha"_QQ_" target="_QQ_"_blank"_QQ_">https://www.google.com/recaptcha</a>. To use this for new account registration, go to Options in the User Manager and select CAPTCHA - reCAPTCHA as the CAPTCHA."
+PLG_CAPTCHA_RECAPTCHA_XML_DESCRIPTION="This CAPTCHA plugin uses the reCAPTCHA service to prevent spammers while it helps to digitize books, newspapers and old radio shows. To get a site and secret key for your domain, go to <a href=\"https://www.google.com/recaptcha\" target=\"_blank\">https://www.google.com/recaptcha</a>. To use this for new account registration, go to Options in the User Manager and select CAPTCHA - reCAPTCHA as the CAPTCHA."
 PLG_CAPTCHA_RECAPTCHA="CAPTCHA - reCAPTCHA"

--- a/administrator/language/en-GB/en-GB.plg_captcha_recaptcha_invisible.ini
+++ b/administrator/language/en-GB/en-GB.plg_captcha_recaptcha_invisible.ini
@@ -4,7 +4,7 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_CAPTCHA_RECAPTCHA_INVISIBLE="CAPTCHA - Invisible reCAPTCHA"
-PLG_CAPTCHA_RECAPTCHA_INVISIBLE_XML_DESCRIPTION="This CAPTCHA plugin uses the Invisible reCAPTCHA service. To get a site and secret key for your domain, go to <a href="_QQ_"https://www.google.com/recaptcha"_QQ_" target="_QQ_"_blank"_QQ_">https://www.google.com/recaptcha</a>."
+PLG_CAPTCHA_RECAPTCHA_INVISIBLE_XML_DESCRIPTION="This CAPTCHA plugin uses the Invisible reCAPTCHA service. To get a site and secret key for your domain, go to <a href=\"https://www.google.com/recaptcha\" target=\"_blank\">https://www.google.com/recaptcha</a>."
 ; Params
 PLG_RECAPTCHA_INVISIBLE_BADGE_BOTTOMLEFT="Bottom left"
 PLG_RECAPTCHA_INVISIBLE_BADGE_BOTTOMRIGHT="Bottom right"

--- a/administrator/language/en-GB/en-GB.plg_captcha_recaptcha_invisible.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_captcha_recaptcha_invisible.sys.ini
@@ -4,4 +4,4 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_CAPTCHA_RECAPTCHA_INVISIBLE="CAPTCHA - Invisible reCAPTCHA"
-PLG_CAPTCHA_RECAPTCHA_INVISIBLE_XML_DESCRIPTION="This CAPTCHA plugin uses the Invisible reCAPTCHA service. To get a site and secret key for your domain, go to <a href="_QQ_"https://www.google.com/recaptcha"_QQ_" target="_QQ_"_blank"_QQ_">https://www.google.com/recaptcha</a>."
+PLG_CAPTCHA_RECAPTCHA_INVISIBLE_XML_DESCRIPTION="This CAPTCHA plugin uses the Invisible reCAPTCHA service. To get a site and secret key for your domain, go to <a href=\"https://www.google.com/recaptcha\" target=\"_blank\">https://www.google.com/recaptcha</a>."

--- a/libraries/src/Language/Language.php
+++ b/libraries/src/Language/Language.php
@@ -847,16 +847,7 @@ class Language
 				continue;
 			}
 
-			// Remove the "_QQ_" from the equation
-			$line = str_replace('"_QQ_"', '', $line);
 			$realNumber = $lineNumber + 1;
-
-			// Check for any incorrect uses of _QQ_.
-			if (strpos($line, '_QQ_') !== false)
-			{
-				$errors[] = $realNumber;
-				continue;
-			}
 
 			// Check for odd number of double quotes.
 			if (substr_count($line, '"') % 2 != 0)

--- a/libraries/src/Language/LanguageHelper.php
+++ b/libraries/src/Language/LanguageHelper.php
@@ -437,19 +437,6 @@ class LanguageHelper
 			return array();
 		}
 
-		// @deprecated 3.9.0 Usage of "_QQ_" is deprecated. Use escaped double quotes (\") instead.
-		if (!defined('_QQ_'))
-		{
-			/**
-			 * Defines a placeholder for a double quote character (") in a language file
-			 *
-			 * @var    string
-			 * @since  1.6
-			 * @deprecated  4.0 Use escaped double quotes (\") instead.
-			 */
-			define('_QQ_', '"');
-		}
-
 		// Capture hidden PHP errors from the parsing.
 		if ($debug === true)
 		{
@@ -468,7 +455,6 @@ class LanguageHelper
 		if (!function_exists('parse_ini_file') || $isParseIniFileDisabled)
 		{
 			$contents = file_get_contents($fileName);
-			$contents = str_replace('_QQ_', '"\""', $contents);
 			$strings = @parse_ini_string($contents);
 		}
 		else


### PR DESCRIPTION
Pull Request for pr #20321.

### Summary of Changes
Removes the support for _QQ_ placeholder for double quotes (use `\"` instead) in ini files as it got deprecated in #20321 for version 4. This needs probably some cleanup in translations too.

### Testing Instructions
Just open the back end and front end.

### Expected result
All strings are properly displayed. Indicates that the ini parser still works as expected.

### Actual result
All strings are properly displayed.

### Documentation Changes Required
Needs to be added to the migration document that an extension dev can't use _QQ_ as placeholder anymore.
