### PR TITLE
[4.0] Remove the deprecated save function in the editor form field

### DIFF
--- a/libraries/src/Form/Field/EditorField.php
+++ b/libraries/src/Form/Field/EditorField.php
@@ -320,25 +320,4 @@ class EditorField extends TextareaField
 
 		return $this->editor;
 	}
-
-	/**
-	 * Method to get the JEditor output for an onSave event.
-	 *
-	 * @return  string  The JEditor object output.
-	 *
-	 * @since       1.6
-	 * @deprecated  4.0  Will be removed without replacement
-	 * @see         Editor::save()
-	 */
-	public function save()
-	{
-		$editor = $this->getEditor();
-
-		if (!method_exists($editor, 'save'))
-		{
-			return '';
-		}
-
-		return $editor->save($this->id);
-	}
 }


### PR DESCRIPTION
### Summary of Changes
Removes the deprecated editor form field save function.

### Testing Instructions
Save an article.

### Expected result
Article is saved.

### Actual result
Article is saved.