### PR TITLE
[4.0] Correcting privacy quickicon display + typo

### DIFF
--- a/build/media_source/plg_quickicon_privacycheck/js/privacycheck.es6.js
+++ b/build/media_source/plg_quickicon_privacycheck/js/privacycheck.es6.js
@@ -29,7 +29,7 @@
         }
       };
 
-      const langaugeStrings = options.plg_quickicon_privacycheck_text;
+      const languageStrings = options.plg_quickicon_privacycheck_text;
 
       Joomla.request({
         url: options.plg_quickicon_privacycheck_ajax_url,
@@ -41,17 +41,19 @@
 
           if (privacyRequestsList.data.number_urgent_requests === 0) {
             // No requests
-            update('success', langaugeStrings.NOREQUEST, '');
+            update('success', languageStrings.NOREQUEST, '');
           } else {
             // Requests
             const messages = {
               warning: [
-                `<span class="badge badge-pill badge-danger">
+                `<div class="message-alert">
+<span class="badge badge-pill badge-danger">
   ${privacyRequestsList.data.number_urgent_requests}
-</span>&nbsp;${langaugeStrings.REQUESTFOUND_MESSAGE}
+</span>&nbsp;${languageStrings.REQUESTFOUND_MESSAGE}
 <button class="btn btn-sm btn-primary" onclick="document.location='${options.plg_quickicon_privacycheck_url}'">
-  ${langaugeStrings.REQUESTFOUND_BUTTON}
-</button>`,
+  ${languageStrings.REQUESTFOUND_BUTTON}
+</button>
+</div>`,
               ],
             };
 
@@ -59,14 +61,14 @@
 
             update(
               'danger',
-              `${langaugeStrings.REQUESTFOUND}&nbsp;<span class="badge badge-light">${privacyRequestsList.data.number_urgent_requests}</span>`,
+              `${languageStrings.REQUESTFOUND}&nbsp;<span class="badge badge-light">${privacyRequestsList.data.number_urgent_requests}</span>`,
               options.plg_quickicon_privacycheck_url,
             );
           }
         },
         onError: () => {
           // An error occurred
-          update('danger', langaugeStrings.ERROR, '');
+          update('danger', languageStrings.ERROR, '');
         },
       });
     }


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/pull/24875#issuecomment-491742087

### Summary of Changes
Corrected typo. Added the necessary div for correct alignment on the model of extension update and Joomla update.


### Testing Instructions
Create a Privacy request. Make it urgent.


### Before patch

<img width="766" alt="Screen Shot 2019-05-13 at 11 04 50" src="https://user-images.githubusercontent.com/869724/57609466-3c992580-756f-11e9-9bcc-8457bb0aa443.png">

### After patch
<img width="618" alt="Screen Shot 2019-05-13 at 11 44 34" src="https://user-images.githubusercontent.com/869724/57612128-85071200-7574-11e9-9e58-91a4465bac29.png">

@wilsonge 

Note: it is OK for rtl