### PR TITLE
[4.0] Fix JMail workaround for opportunistic tls

### DIFF
--- a/libraries/src/Mail/Mail.php
+++ b/libraries/src/Mail/Mail.php
@@ -133,11 +133,11 @@ class Mail extends PHPMailer
 			 */
 			if (!$result && $this->SMTPAutoTLS)
 			{
-				$this->SMTPAutoTLS = true;
+				$this->SMTPAutoTLS = false;
 				$result = parent::send();
 
 				// Reset the value for any future emails
-				$this->SMTPAutoTLS = false;
+				$this->SMTPAutoTLS = true;
 			}
 
 			return $result;

--- a/libraries/src/Mail/Mail.php
+++ b/libraries/src/Mail/Mail.php
@@ -100,7 +100,7 @@ class Mail extends PHPMailer
 	 * @since   1.7.0
 	 *
 	 * @throws  \RuntimeException   if the mail function is disabled
-	 * @throws  phpmailerException  if sending failed and exception throwing is enabled
+	 * @throws  phpmailerException  if sending failed
 	 */
 	public function Send()
 	{
@@ -133,7 +133,11 @@ class Mail extends PHPMailer
 			 */
 			if (!$result && $this->SMTPAutoTLS)
 			{
-				throw new \RuntimeException(Text::_($this->ErrorInfo), 500);
+				$this->SMTPAutoTLS = true;
+				$result = parent::send();
+
+				// Reset the value for any future emails
+				$this->SMTPAutoTLS = false;
 			}
 
 			return $result;

--- a/libraries/src/Mail/Mail.php
+++ b/libraries/src/Mail/Mail.php
@@ -134,10 +134,16 @@ class Mail extends PHPMailer
 			if (!$result && $this->SMTPAutoTLS)
 			{
 				$this->SMTPAutoTLS = false;
-				$result = parent::send();
 
-				// Reset the value for any future emails
-				$this->SMTPAutoTLS = true;
+				try
+				{
+					$result = parent::send();
+				}
+				finally
+				{
+					// Reset the value for any future emails
+					$this->SMTPAutoTLS = true;
+				}
 			}
 
 			return $result;


### PR DESCRIPTION
Pull Request for Issue #24885 .

### Summary of Changes
Fix the JMail workaround for opportunistic tls (which was accidentally removed as part of https://github.com/joomla/joomla-cms/pull/21320 )

### How to reproduce
Try sending emails to a server with a bad email tls certificate. Before patch it will fail. After patch a happy error message (hopefully) or a successful email send