### PR TITLE
[4.0] Privacy Quick Icon adapt message to languages

### DIFF
--- a/administrator/language/en-GB/en-GB.plg_quickicon_privacycheck.ini
+++ b/administrator/language/en-GB/en-GB.plg_quickicon_privacycheck.ini
@@ -10,6 +10,6 @@ PLG_QUICKICON_PRIVACYCHECK_GROUP_DESC="The group of this plugin (this value is c
 PLG_QUICKICON_PRIVACYCHECK_GROUP_LABEL="Group"
 PLG_QUICKICON_PRIVACYCHECK_REQUESTFOUND="Urgent Privacy Requests"
 PLG_QUICKICON_PRIVACYCHECK_REQUESTFOUND_BUTTON="View Requests"
-PLG_QUICKICON_PRIVACYCHECK_REQUESTFOUND_MESSAGE="Urgent Privacy Request(s) to manage."
+PLG_QUICKICON_PRIVACYCHECK_REQUESTFOUND_MESSAGE="%s Urgent Privacy Request(s) to manage."
 PLG_QUICKICON_PRIVACYCHECK_NOREQUEST="No Urgent Requests."
 PLG_QUICKICON_PRIVACYCHECK_XML_DESCRIPTION="Checks for privacy requests that need to be handled and notifies you when you visit the Control Panel page."

--- a/build/media_source/plg_quickicon_privacycheck/js/privacycheck.es6.js
+++ b/build/media_source/plg_quickicon_privacycheck/js/privacycheck.es6.js
@@ -47,9 +47,7 @@
             const messages = {
               warning: [
                 `<div class="message-alert">
-<span class="badge badge-pill badge-danger">
-  ${privacyRequestsList.data.number_urgent_requests}
-</span>&nbsp;${languageStrings.REQUESTFOUND_MESSAGE}
+  ${languageStrings.REQUESTFOUND_MESSAGE.replace ('%s', `<span class="badge badge-pill badge-danger">${privacyRequestsList.data.number_urgent_requests}</span>`)}
 <button class="btn btn-sm btn-primary" onclick="document.location='${options.plg_quickicon_privacycheck_url}'">
   ${languageStrings.REQUESTFOUND_BUTTON}
 </button>

--- a/build/media_source/plg_quickicon_privacycheck/js/privacycheck.es6.js
+++ b/build/media_source/plg_quickicon_privacycheck/js/privacycheck.es6.js
@@ -47,7 +47,7 @@
             const messages = {
               warning: [
                 `<div class="message-alert">
-  ${languageStrings.REQUESTFOUND_MESSAGE.replace ('%s', `<span class="badge badge-pill badge-danger">${privacyRequestsList.data.number_urgent_requests}</span>`)}
+  ${languageStrings.REQUESTFOUND_MESSAGE.replace('%s', `<span class="badge badge-pill badge-danger">${privacyRequestsList.data.number_urgent_requests}</span>`)}
 <button class="btn btn-sm btn-primary" onclick="document.location='${options.plg_quickicon_privacycheck_url}'">
   ${languageStrings.REQUESTFOUND_BUTTON}
 </button>


### PR DESCRIPTION
### Summary of Changes
Added variable in string to cope with various languages.


### Testing Instructions
See https://github.com/joomla/joomla-cms/pull/24882

Allow the placement of the  the number of Urgent requests where the language needs it, as done for Extensions Update, through the use of a variable `%s`.

### After patch
No change for en-GB as the variable is placed at the beginning.
`PLG_QUICKICON_PRIVACYCHECK_REQUESTFOUND_MESSAGE="%s Urgent Privacy Request(s) to manage."`

@wilsonge 