### PR TITLE
[4.0] Searchtools Descriptions

### DIFF
--- a/administrator/templates/atum/scss/blocks/_form.scss
+++ b/administrator/templates/atum/scss/blocks/_form.scss
@@ -105,3 +105,27 @@ legend {
 [aria-grabbed='true'] {
   box-shadow: 0 0 2px 1px theme-color("primary");
 }
+
+// Search Input Tooltip
+/* make the containers relative */
+.control-group > .controls {
+  position: relative;
+}
+
+ /* set up hidden tooltip */
+[role="tooltip"] {
+  display: none;
+  padding: 0.25em;
+  margin: 0.25em;
+  color: $white;
+  background: $black;
+  max-width: 100%;
+  z-index: $zindex-tooltip;
+}
+
+ /* reveal associated tooltip on focus */
+:focus + [role="tooltip"] {
+  display: block;
+  position: absolute;
+  bottom: 100%;
+}

--- a/layouts/joomla/form/renderfield.php
+++ b/layouts/joomla/form/renderfield.php
@@ -41,7 +41,9 @@ $id    = $name . '-desc';
 	</div>
 	<?php if (!empty($description)) : ?>
 		<div id="<?php echo $id; ?>">
-			<small class="form-text text-muted"><?php echo $description; ?></small>
+			<small class="form-text text-muted">
+				<?php echo htmlspecialchars(($description), ENT_COMPAT, 'UTF-8'); ?>
+			</small>
 		</div>
 	<?php endif; ?>
 </div>

--- a/layouts/joomla/searchtools/default/bar.php
+++ b/layouts/joomla/searchtools/default/bar.php
@@ -42,6 +42,11 @@ $filters = $data['view']->filterForm->getGroup('filter');
 						<?php endif; ?>
 					</label>
 					<?php echo $filters['filter_search']->input; ?>
+					<?php if ($filters['filter_search']->description) : ?>
+					<div role="tooltip" id="<?php echo $filters['filter_search']->name . '-desc'; ?>">
+						<?php echo htmlspecialchars(Text::_($filters['filter_search']->description), ENT_COMPAT, 'UTF-8'); ?>
+					</div>
+					<?php endif; ?>
 					<span class="input-group-append">
 						<button type="submit" class="btn btn-primary" aria-label="<?php echo Text::_('JSEARCH_FILTER_SUBMIT'); ?>">
 							<span class="fa fa-search" aria-hidden="true"></span>


### PR DESCRIPTION
In Joomla 3 all the search boxes in the list views in the admin had a descriptive tooltip. This was added by javascript. This tooltip is missing in J4 as we dont have the same js. As a temporary measure the descriptions for the search boxes was not displayed.

This PR puts the descriptive tooltip back WITHOUT using any js and in a fully accessible way. The description is displayed when the field gets focus.

This is fully backwards compatible with the tooltips displaying descriptions in J3 including when there is html in the string.

As the css has changed testing will require npm i

In addition the descriptions rendered on screen for other fields is now escaped properly.

https://user-images.githubusercontent.com/1296369/55327022-0bfaa200-5481-11e9-9ab1-1a3c9434f418.png

/cc @SniperSister and @bembelimen for help getting this resolved