### PR TITLE
[4.0] Plugin name codestyle

### DIFF
--- a/plugins/actionlog/joomla/joomla.xml
+++ b/plugins/actionlog/joomla/joomla.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <extension version="3.9" type="plugin" group="actionlog" method="upgrade">
-	<name>PLG_ACTIONLOG_JOOMLA</name>
+	<name>plg_actionlog_joomla</name>
 	<author>Joomla! Project</author>
 	<creationDate>May 2018</creationDate>
 	<copyright>Copyright (C) 2005 - 2019 Open Source Matters. All rights reserved.</copyright>

--- a/plugins/system/actionlogs/actionlogs.xml
+++ b/plugins/system/actionlogs/actionlogs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <extension version="3.9" type="plugin" group="system" method="upgrade">
-	<name>PLG_SYSTEM_ACTIONLOGS</name>
+	<name>plg_system_actionlogs</name>
 	<author>Joomla! Project</author>
 	<creationDate>May 2018</creationDate>
 	<copyright>Copyright (C) 2005 - 2019 Open Source Matters. All rights reserved.</copyright>


### PR DESCRIPTION
If you look in the #__extensions table you will see that all the names are lowercase except for plg_actionlog_joomla and plg_system_actionlogs which are uppercase.

This pr changes them to lowercase for consistency

To test this - apply the patch, go to extensions->manage and refresh the manifest cache for these extensions and then check the db and you wil see the names are now lowercase
