### PR TITLE
[4.0] Additional fields available to display in Search Results + Date ordering fix

### DIFF
--- a/plugins/search/content/content.php
+++ b/plugins/search/content/content.php
@@ -282,7 +282,7 @@ class PlgSearchContent extends CMSPlugin
 				$order = ' relevance DESC, ' . $order;
 			}
 
-			$query->select('a.id AS id, a.title AS title, a.metadesc AS metadesc, a.metakey AS metakey, a.created AS created, a.publish_up AS publish_up, a.images AS images, a.language AS language, a.catid AS catid')
+			$query->select('a.id AS id, a.title AS title, a.metadesc AS metadesc, a.metakey AS metakey, a.created AS created, a.publish_up AS publish_up, a.images AS images, a.introtext AS introtext, a.language AS language, a.catid AS catid')
 				->select($query->concatenate(array('a.introtext', 'a.fulltext')) . ' AS text')
 				->select('c.title AS section')
 				->select($case_when)
@@ -354,7 +354,7 @@ class PlgSearchContent extends CMSPlugin
 				$order = ' relevance DESC, ' . $order;
 			}
 
-			$query->select('a.id AS id, a.title AS title, a.metadesc AS metadesc, a.metakey AS metakey, a.created AS created, a.publish_up AS publish_up, a.images AS images, a.language AS language, a.catid AS catid')
+			$query->select('a.id AS id, a.title AS title, a.metadesc AS metadesc, a.metakey AS metakey, a.created AS created, a.publish_up AS publish_up, a.images AS images, a.introtext AS introtext, a.language AS language, a.catid AS catid')
 				->select($query->concatenate(array('a.introtext', 'a.fulltext')) . ' AS text')
 				->select($case_when)
 				->select($case_when1)

--- a/plugins/search/content/content.php
+++ b/plugins/search/content/content.php
@@ -284,7 +284,7 @@ class PlgSearchContent extends CMSPlugin
 
 			$query->select('a.id AS id, a.title AS title, a.metadesc AS metadesc, a.metakey AS metakey,
 				a.created AS created, a.publish_up AS publish_up, a.images AS images,
-				a.introtext AS introtext, a.language AS language, a.catid AS catid')
+				a.language AS language, a.catid AS catid')
 				->select($query->concatenate(array('a.introtext', 'a.fulltext')) . ' AS text')
 				->select('c.title AS section')
 				->select($case_when)
@@ -358,7 +358,7 @@ class PlgSearchContent extends CMSPlugin
 
 			$query->select('a.id AS id, a.title AS title, a.metadesc AS metadesc, a.metakey AS metakey,
 				a.created AS created, a.publish_up AS publish_up, a.images AS images,
-				a.introtext AS introtext, a.language AS language, a.catid AS catid')
+				a.language AS language, a.catid AS catid')
 				->select($query->concatenate(array('a.introtext', 'a.fulltext')) . ' AS text')
 				->select($case_when)
 				->select($case_when1)

--- a/plugins/search/content/content.php
+++ b/plugins/search/content/content.php
@@ -282,7 +282,9 @@ class PlgSearchContent extends CMSPlugin
 				$order = ' relevance DESC, ' . $order;
 			}
 
-			$query->select('a.id AS id, a.title AS title, a.metadesc AS metadesc, a.metakey AS metakey, a.created AS created, a.publish_up AS publish_up, a.images AS images, a.introtext AS introtext, a.language AS language, a.catid AS catid')
+			$query->select('a.id AS id, a.title AS title, a.metadesc AS metadesc, a.metakey AS metakey,
+				a.created AS created, a.publish_up AS publish_up, a.images AS images,
+				a.introtext AS introtext, a.language AS language, a.catid AS catid')
 				->select($query->concatenate(array('a.introtext', 'a.fulltext')) . ' AS text')
 				->select('c.title AS section')
 				->select($case_when)
@@ -354,7 +356,9 @@ class PlgSearchContent extends CMSPlugin
 				$order = ' relevance DESC, ' . $order;
 			}
 
-			$query->select('a.id AS id, a.title AS title, a.metadesc AS metadesc, a.metakey AS metakey, a.created AS created, a.publish_up AS publish_up, a.images AS images, a.introtext AS introtext, a.language AS language, a.catid AS catid')
+			$query->select('a.id AS id, a.title AS title, a.metadesc AS metadesc, a.metakey AS metakey,
+				a.created AS created, a.publish_up AS publish_up, a.images AS images,
+				a.introtext AS introtext, a.language AS language, a.catid AS catid')
 				->select($query->concatenate(array('a.introtext', 'a.fulltext')) . ' AS text')
 				->select($case_when)
 				->select($case_when1)

--- a/plugins/search/content/content.php
+++ b/plugins/search/content/content.php
@@ -282,7 +282,7 @@ class PlgSearchContent extends CMSPlugin
 				$order = ' relevance DESC, ' . $order;
 			}
 
-			$query->select('a.title AS title, a.metadesc, a.metakey, a.created AS created, a.language, a.catid')
+			$query->select('a.id AS id, a.title AS title, a.metadesc AS metadesc, a.metakey AS metakey, a.created AS created, a.publish_up AS publish_up, a.images AS images, a.language AS language, a.catid AS catid')
 				->select($query->concatenate(array('a.introtext', 'a.fulltext')) . ' AS text')
 				->select('c.title AS section')
 				->select($case_when)
@@ -354,7 +354,7 @@ class PlgSearchContent extends CMSPlugin
 				$order = ' relevance DESC, ' . $order;
 			}
 
-			$query->select('a.title AS title, a.metadesc, a.metakey, a.created AS created')
+			$query->select('a.id AS id, a.title AS title, a.metadesc AS metadesc, a.metakey AS metakey, a.created AS created, a.publish_up AS publish_up, a.images AS images, a.language AS language, a.catid AS catid')
 				->select($query->concatenate(array('a.introtext', 'a.fulltext')) . ' AS text')
 				->select($case_when)
 				->select($case_when1)

--- a/plugins/search/content/content.php
+++ b/plugins/search/content/content.php
@@ -239,7 +239,7 @@ class PlgSearchContent extends CMSPlugin
 		switch ($ordering)
 		{
 			case 'oldest':
-				$order = 'a.created ASC';
+				$order = 'a.publish_up ASC';
 				break;
 
 			case 'popular':
@@ -256,7 +256,7 @@ class PlgSearchContent extends CMSPlugin
 
 			case 'newest':
 			default:
-				$order = 'a.created DESC';
+				$order = 'a.publish_up DESC';
 				break;
 		}
 


### PR DESCRIPTION
This serves a similar purpose as this: https://github.com/joomla/joomla-cms/pull/24897
But pertains to Search Results Articles instead of Contact Articles.

### Summary of Changes

- More Fields are made available to be used and displayed in search results for articles. This adds the ability to use the id, publish_up, introtext and images.

- Also made sure that all of the fields have an AS alias. This wasn't the case before, where some had an alias and some didn't.

- Finally, this makes the search results use the publish_up date instead of the created date when sorting by newest/oldest. The publish_up date makes more sense to use because it's the actual date of the article being published rather than when it was created.

### Testing Instructions

None needed. Just little tweaks.

### Documentation Changes Required

None.