### PR TITLE
Added event onContentValidateData (Joomla #19584)

### DIFF
--- a/administrator/components/com_installer/Model/UpdateModel.php
+++ b/administrator/components/com_installer/Model/UpdateModel.php
@@ -459,6 +459,7 @@ class UpdateModel extends ListModel
 		if ($package === false || !isset($package['type']) || $package['type'] === false)
 		{
 			$app->enqueueMessage(JText::sprintf('COM_INSTALLER_MSG_UPDATE_INVALID_PKG', $url));
+
 			return false;
 		}
 

--- a/administrator/components/com_installer/Model/UpdateModel.php
+++ b/administrator/components/com_installer/Model/UpdateModel.php
@@ -456,6 +456,12 @@ class UpdateModel extends ListModel
 		// Unpack the downloaded package file
 		$package = InstallerHelper::unpack($tmp_dest . '/' . $p_file);
 
+		if ($package === false || !isset($package['type']) || $package['type'] === false)
+		{
+			$app->enqueueMessage(JText::sprintf('COM_INSTALLER_MSG_UPDATE_INVALID_PKG', $url));
+			return false;
+		}
+
 		// Get an installer instance
 		$installer = Installer::getInstance();
 		$update->set('type', $package['type']);

--- a/administrator/language/en-GB/en-GB.com_installer.ini
+++ b/administrator/language/en-GB/en-GB.com_installer.ini
@@ -151,6 +151,7 @@ COM_INSTALLER_MSG_MANAGE_NOUPDATESITE="There are no update sites matching your q
 COM_INSTALLER_MSG_N_DATABASE_ERROR_PANEL="%d Database Problems Found."
 COM_INSTALLER_MSG_N_DATABASE_ERROR_PANEL_1="1 Database Problem Found."
 COM_INSTALLER_MSG_UPDATE_ERROR="Error updating %s."
+COM_INSTALLER_MSG_UPDATE_INVALID_PKG="Invalid package: %s"
 COM_INSTALLER_MSG_UPDATE_NODESC="No description available for this item."
 COM_INSTALLER_MSG_UPDATE_NOUPDATES="There are no updates available at the moment. Please check again later."
 COM_INSTALLER_MSG_UPDATE_SITES_COUNT_CHECK="Some update sites are disabled. You may want to check the <a href=\"%s\">Update Sites Manager</a>."

--- a/libraries/src/MVC/Model/FormModel.php
+++ b/libraries/src/MVC/Model/FormModel.php
@@ -193,6 +193,7 @@ abstract class FormModel extends BaseDatabaseModel implements FormFactoryAwareIn
 		PluginHelper::importPlugin($this->events_map['validate']);
 
 		$dispatcher = \JFactory::getContainer()->get('dispatcher');
+
 		if (!empty($dispatcher->getListeners('onUserBeforeDataValidation')))
 		{
 			@trigger_error('The `onUserBeforeDataValidation` event is deprecated and will be removed in 5.0, ' .

--- a/libraries/src/MVC/Model/FormModel.php
+++ b/libraries/src/MVC/Model/FormModel.php
@@ -192,8 +192,17 @@ abstract class FormModel extends BaseDatabaseModel implements FormFactoryAwareIn
 		// Include the plugins for the delete events.
 		PluginHelper::importPlugin($this->events_map['validate']);
 
-		Factory::getApplication()->triggerEvent('onUserBeforeDataValidation', array($form, &$data));
+		$dispatcher = \JFactory::getContainer()->get('dispatcher');
+		if (!empty($dispatcher->getListeners('onUserBeforeDataValidation')))
+		{
+			@trigger_error('The `onUserBeforeDataValidation` event is deprecated and will be removed in 5.0, ' .
+				'use the `onContentValidateData` event instead.', E_USER_DEPRECATED
+			);
+			\JFactory::getApplication()->triggerEvent('onUserBeforeDataValidation', array($form, &$data));
+		}
 
+		\JFactory::getApplication()->triggerEvent('onContentValidateData', array($form, &$data));
+		
 		// Filter and validate the form data.
 		$data = $form->filter($data);
 		$return = $form->validate($data, $group);


### PR DESCRIPTION
Pull Request for Issue #19584 .

### Summary of Changes

Added event onContentValidateData

### Testing Instructions

Create a field plugin which implements onContentValidateData function like this...
public function onContentValidateData($form, &$data) {
// Change the data in some way
}

### Expected result

The data get's changed.

### Actual result

The data get's changed.

### Documentation Changes Required

Add documentation for onContentValidateData event.
Add documentation for the existing, but undocumented and now deprecated, onUserBeforeDataValidation event.
This event will only get triggered when validate() overridden by a user component model.