### PR TITLE
Added event onContentValidateData replacing onUserBeforeDataValidatio…

### DIFF
--- a/libraries/src/MVC/Model/FormModel.php
+++ b/libraries/src/MVC/Model/FormModel.php
@@ -192,7 +192,17 @@ abstract class FormModel extends BaseDatabaseModel implements FormFactoryAwareIn
 		// Include the plugins for the delete events.
 		PluginHelper::importPlugin($this->events_map['validate']);
 
-		Factory::getApplication()->triggerEvent('onUserBeforeDataValidation', array($form, &$data));
+		$dispatcher = JFactory::getContainer()->get('dispatcher');
+
+		if (!empty($dispatcher->getListeners('onUserBeforeDataValidation')))
+		{
+			@trigger_error('The `onUserBeforeDataValidation` event is deprecated and will be removed in 5.0, ' .
+				'use the `onContentValidateData` event instead.', E_USER_DEPRECATED
+			);
+			JFactory::getApplication()->triggerEvent('onUserBeforeDataValidation', array($form, &$data));
+		}
+
+		JFactory::getApplication()->triggerEvent('onContentValidateData', array($form, &$data));
 
 		// Filter and validate the form data.
 		$data = $form->filter($data);


### PR DESCRIPTION
Pull Request for Issue #19584 .
Summary of Changes

Added event onContentValidateData
Testing Instructions

Create a field plugin which implements onContentValidateData function like this...
public function onContentValidateData($form, &$data) {
// Change the data in some way
}
Expected result

The data get's changed.
Actual result

The data get's changed.
Documentation Changes Required

Add documentation for onContentValidateData event.
Add documentation for the existing, but undocumented and now deprecated, onUserBeforeDataValidation event.
This event will only get triggered when validate() overridden by a user component model.