### PR TITLE
Improved error messages when the manifest retrieves an invalid manife…

### DIFF
--- a/administrator/components/com_installer/Model/UpdateModel.php
+++ b/administrator/components/com_installer/Model/UpdateModel.php
@@ -456,6 +456,13 @@ class UpdateModel extends ListModel
 		// Unpack the downloaded package file
 		$package = InstallerHelper::unpack($tmp_dest . '/' . $p_file);
 
+		if ($package === false || !isset($package['type']) || $package['type'] === false)
+		{
+			$app->enqueueMessage(JText::sprintf('COM_INSTALLER_MSG_UPDATE_INVALID_PKG', $url));
+
+			return false;
+		}
+
 		// Get an installer instance
 		$installer = Installer::getInstance();
 		$update->set('type', $package['type']);

--- a/administrator/language/en-GB/en-GB.com_installer.ini
+++ b/administrator/language/en-GB/en-GB.com_installer.ini
@@ -151,6 +151,7 @@ COM_INSTALLER_MSG_MANAGE_NOUPDATESITE="There are no update sites matching your q
 COM_INSTALLER_MSG_N_DATABASE_ERROR_PANEL="%d Database Problems Found."
 COM_INSTALLER_MSG_N_DATABASE_ERROR_PANEL_1="1 Database Problem Found."
 COM_INSTALLER_MSG_UPDATE_ERROR="Error updating %s."
+COM_INSTALLER_MSG_UPDATE_INVALID_PKG="Invalid package: %s"
 COM_INSTALLER_MSG_UPDATE_NODESC="No description available for this item."
 COM_INSTALLER_MSG_UPDATE_NOUPDATES="There are no updates available at the moment. Please check again later."
 COM_INSTALLER_MSG_UPDATE_SITES_COUNT_CHECK="Some update sites are disabled. You may want to check the <a href=\"%s\">Update Sites Manager</a>."


### PR DESCRIPTION
Pull Request for Issue ##22762.
Summary of Changes

Improved error messages when the manifest retrieves and invalid manifest file.
Testing Instructions

Get update site to include an invalid download URL - or get a valid one to fail.
For example.
http://thisisinvalid/donotuse.zip
Expected result

Get sensible message pointing to problem.
Actual result

Currently get message
Error updating COM_INSTALLER_TYPE_TYPE_.
Documentation Changes Required

None