### PR TITLE
[4.0] Add shm_size and limit rips to run on main repo

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -103,6 +103,7 @@ steps:
     image: joomlaprojects/docker-systemtests:develop
     commands:
       - bash tests/Codeception/drone-system-run.sh "$(pwd)"
+    shm_size: 1024000000  
 
   - name: api-tests
     depends_on: [ system-tests ]
@@ -114,10 +115,12 @@ steps:
     image: rips/rips-cli:1.2.1
     depends_on: [ api-tests ]
     when:
-      branch: 4.0-dev
+      repo:
+        - joomla/joomla-cms
+      branch: 
+        - 4.0-dev
     commands:
       - export RIPS_BASE_URI='https://api.rips.joomla.org'
-      - if [ $DRONE_REPO_NAMESPACE != 'joomla' ]; then echo "The analysis check only run on the main repos"; exit 0; fi
       - rips-cli rips:scan:start -a 3 -t 1 -R -k -p $(pwd) -t 1 -T $DRONE_REPO_NAMESPACE-$DRONE_BRANCH ||  { echo "Please contact the security team at security@joomla.org"; exit 1; }
     environment:
       RIPS_USERNAME:
@@ -154,6 +157,6 @@ services:
 
 ---
 kind: signature
-hmac: b3612d74787777acabd3dde88d2a002b0c893d054831525464f4db51e31493b8
+hmac: 95c208fa999c1f2f00b942b4c5cade9b5bcd2a87695eff53a6f189c2e554c509
 
 ...


### PR DESCRIPTION
Because of the backend template our system test are failing and this is a fix to make this run again. I have also limited RIPS to only run on the main repo