### PR TITLE
[4.0] Remove accordion

### DIFF
--- a/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_upload.php
+++ b/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_upload.php
@@ -36,7 +36,7 @@ Text::script('COM_INSTALLER_MSG_INSTALL_PLEASE_SELECT_A_PACKAGE', true);
 	<?php endforeach; ?>
 	<div class="alert alert-info">
 		<h4 class="alert-heading"><?php echo Text::_('COM_INSTALLER_MSG_WARNINGFURTHERINFO'); ?></h4>
-		<p class="m-b-0"><?php echo Text::_('COM_INSTALLER_MSG_WARNINGFURTHERINFODESC'); ?></p>
+		<p class="mb-0"><?php echo Text::_('COM_INSTALLER_MSG_WARNINGFURTHERINFODESC'); ?></p>
 	</div>
 <?php endif; ?>
 

--- a/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_upload.php
+++ b/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_upload.php
@@ -27,23 +27,17 @@ Text::script('COM_INSTALLER_MSG_INSTALL_PLEASE_SELECT_A_PACKAGE', true);
 </div>
 
 <?php if (count($this->warnings)) : ?>
-<fieldset>
-	<legend>
-		<?php echo Text::_('COM_INSTALLER_SUBMENU_WARNINGS'); ?>
-	</legend>
-
-	<?php $i = 0; ?>
-	<?php echo HTMLHelper::_('bootstrap.startAccordion', 'warnings', array('active' => 'warning' . $i)); ?>
-	<?php foreach ($this->warnings as $message) : ?>
-		<?php echo HTMLHelper::_('bootstrap.addSlide', 'warnings', $message['message'], 'warning' . ($i++)); ?>
-		<?php echo $message['description']; ?>
-		<?php echo HTMLHelper::_('bootstrap.endSlide'); ?>
+	<h3><?php echo Text::_('COM_INSTALLER_SUBMENU_WARNINGS'); ?></h3>
+	<?php foreach ($this->warnings as $warning) : ?>
+		<div class="alert alert-warning">
+			<h4 class="alert-heading"><?php echo $warning['message']; ?></h4>
+			<p class="m-b-0"><?php echo $warning['description']; ?></p>
+		</div>
 	<?php endforeach; ?>
-	<?php echo HTMLHelper::_('bootstrap.addSlide', 'warnings', Text::_('COM_INSTALLER_MSG_WARNINGFURTHERINFO'), 'furtherinfo'); ?>
-	<?php echo Text::_('COM_INSTALLER_MSG_WARNINGFURTHERINFODESC'); ?>
-	<?php echo HTMLHelper::_('bootstrap.endSlide'); ?>
-	<?php echo HTMLHelper::_('bootstrap.endAccordion'); ?>
-</fieldset>
+	<div class="alert alert-info">
+		<h4 class="alert-heading"><?php echo Text::_('COM_INSTALLER_MSG_WARNINGFURTHERINFO'); ?></h4>
+		<p class="m-b-0"><?php echo Text::_('COM_INSTALLER_MSG_WARNINGFURTHERINFODESC'); ?></p>
+	</div>
 <?php endif; ?>
 
 <form enctype="multipart/form-data" action="index.php" method="post" id="uploadForm">

--- a/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_upload.php
+++ b/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_upload.php
@@ -31,7 +31,7 @@ Text::script('COM_INSTALLER_MSG_INSTALL_PLEASE_SELECT_A_PACKAGE', true);
 	<?php foreach ($this->warnings as $warning) : ?>
 		<div class="alert alert-warning">
 			<h4 class="alert-heading"><?php echo $warning['message']; ?></h4>
-			<p class="m-b-0"><?php echo $warning['description']; ?></p>
+			<p class="mb-0"><?php echo $warning['description']; ?></p>
 		</div>
 	<?php endforeach; ?>
 	<div class="alert alert-info">


### PR DESCRIPTION
The Upload and Update tab of com_joomlaupdate displays any warnings in an unstyled bootstrap accordion. This PR removes the accordion and displays the warnings in the same way as com_installer&view=warnings it also removes the fieldset wrapper on the warnings as it is not a fieldset and therefore changes the legend to a heading

### Before
![upload](https://user-images.githubusercontent.com/1296369/57763552-7e55d780-76f9-11e9-8710-c8112e27c5ca.gif)



### After
![image](https://user-images.githubusercontent.com/1296369/57763428-4189e080-76f9-11e9-9466-e27e6a6695e4.png)
