### PR TITLE
Removing unused services in drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -32,6 +32,11 @@ steps:
     depends_on: [ restore-cache ]
     commands:
       - composer install --no-progress --no-suggest
+      # needed for system testing
+      - composer update joomla/test-system --no-progress --no-suggest
+      - composer update joomla/test-api --no-progress --no-suggest
+      - composer update joomla-projects/selenium-server-standalone --no-progress --no-suggest
+      - composer update joomla-projects/joomla-browser --no-progress --no-suggest
       - npm install --unsafe-perm
 
   - name: rebuild-cache
@@ -102,25 +107,22 @@ steps:
     depends_on: [ javascript-tests ]
     image: joomlaprojects/docker-systemtests:develop
     commands:
-      - bash tests/Codeception/drone-system-run.sh "$(pwd)"
-    shm_size: 1024000000  
+      - bash libraries/vendor/joomla/test-system/src/drone-run.sh "$(pwd)"
 
   - name: api-tests
     depends_on: [ system-tests ]
     image: joomlaprojects/docker-systemtests:latest
     commands:
-      - bash tests/Codeception/drone-api-run.sh "$(pwd)"
+      - bash libraries/vendor/joomla/test-api/drone-run.sh "$(pwd)"
 
   - name: analysis4x
     image: rips/rips-cli:1.2.1
     depends_on: [ api-tests ]
     when:
-      repo:
-        - joomla/joomla-cms
-      branch: 
-        - 4.0-dev
+      branch: 4.0-dev
     commands:
       - export RIPS_BASE_URI='https://api.rips.joomla.org'
+      - if [ $DRONE_REPO_NAMESPACE != 'joomla' ]; then echo "The analysis check only run on the main repos"; exit 0; fi
       - rips-cli rips:scan:start -a 3 -t 1 -R -k -p $(pwd) -t 1 -T $DRONE_REPO_NAMESPACE-$DRONE_BRANCH ||  { echo "Please contact the security team at security@joomla.org"; exit 1; }
     environment:
       RIPS_USERNAME:
@@ -146,17 +148,8 @@ services:
       MYSQL_ROOT_PASSWORD: joomla_ut
       MYSQL_DATABASE: test_joomla
 
-  - name: memcached
-    image: memcached:alpine
-
-  - name: redis
-    image: redis:alpine
-
-  - name: postgres
-    image: postgres
-
 ---
 kind: signature
-hmac: 95c208fa999c1f2f00b942b4c5cade9b5bcd2a87695eff53a6f189c2e554c509
+hmac: a4b2205d30ef598f1adb3e9f18f2e904d116586b52216fcf290db6c96dfa1a4d
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -32,11 +32,6 @@ steps:
     depends_on: [ restore-cache ]
     commands:
       - composer install --no-progress --no-suggest
-      # needed for system testing
-      - composer update joomla/test-system --no-progress --no-suggest
-      - composer update joomla/test-api --no-progress --no-suggest
-      - composer update joomla-projects/selenium-server-standalone --no-progress --no-suggest
-      - composer update joomla-projects/joomla-browser --no-progress --no-suggest
       - npm install --unsafe-perm
 
   - name: rebuild-cache
@@ -107,22 +102,25 @@ steps:
     depends_on: [ javascript-tests ]
     image: joomlaprojects/docker-systemtests:develop
     commands:
-      - bash libraries/vendor/joomla/test-system/src/drone-run.sh "$(pwd)"
+      - bash tests/Codeception/drone-system-run.sh "$(pwd)"
+    shm_size: 1024000000  
 
   - name: api-tests
     depends_on: [ system-tests ]
     image: joomlaprojects/docker-systemtests:latest
     commands:
-      - bash libraries/vendor/joomla/test-api/drone-run.sh "$(pwd)"
+      - bash tests/Codeception/drone-api-run.sh "$(pwd)"
 
   - name: analysis4x
     image: rips/rips-cli:1.2.1
     depends_on: [ api-tests ]
     when:
-      branch: 4.0-dev
+      repo:
+        - joomla/joomla-cms
+      branch: 
+        - 4.0-dev
     commands:
       - export RIPS_BASE_URI='https://api.rips.joomla.org'
-      - if [ $DRONE_REPO_NAMESPACE != 'joomla' ]; then echo "The analysis check only run on the main repos"; exit 0; fi
       - rips-cli rips:scan:start -a 3 -t 1 -R -k -p $(pwd) -t 1 -T $DRONE_REPO_NAMESPACE-$DRONE_BRANCH ||  { echo "Please contact the security team at security@joomla.org"; exit 1; }
     environment:
       RIPS_USERNAME:
@@ -150,6 +148,6 @@ services:
 
 ---
 kind: signature
-hmac: a4b2205d30ef598f1adb3e9f18f2e904d116586b52216fcf290db6c96dfa1a4d
+hmac: 95c208fa999c1f2f00b942b4c5cade9b5bcd2a87695eff53a6f189c2e554c509
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -148,6 +148,6 @@ services:
 
 ---
 kind: signature
-hmac: 95c208fa999c1f2f00b942b4c5cade9b5bcd2a87695eff53a6f189c2e554c509
+hmac: 06e47311254aa51920ff7e891a2ba7e83583757ec28f3b1d7128866ad8f59f70
 
 ...


### PR DESCRIPTION
Drone currently instantiates Postgres, Memcached and Redis services even though our testsetup doesn't use them (yet). To keep this clean(er), I'm removing them here for now. Even if we pull in tests for these right now, we would have to rewrite drone.yml, since they are not configured. Thus lets remove it and add it again when we need it.