### PR TITLE
Fix 0 value in range field

### DIFF
--- a/layouts/joomla/form/field/range.php
+++ b/layouts/joomla/form/field/range.php
@@ -60,8 +60,7 @@ $attributes = array(
 	$autofocus ? 'autofocus' : '',
 );
 
-$value = (float) $value;
-$value = empty($value) ? $min : $value;
+$value = is_numeric($value) ? (float) $value : $min;
 
 ?>
 <input type="range" name="<?php


### PR DESCRIPTION
Pull Request for Issue #24938 .

### Summary of Changes

Fixes 0 value usage in range field.

### Testing Instructions

Add range field with default value 0 to any form:

```
<field 
	name="testrange" 
	type="range" 
	label="Test Range" 
	description="Test range desc" 
	min="-10" 
	max="10"
	step="0.1" 
	class="" 
	default="0"
/>
```
View the form. Look at the field.

### Expected result

Slider is at 0 value (centered).

### Actual result

Slider is at -10 value (left).

### Documentation Changes Required

No.