### PR TITLE
[4.0.] Remove obsolete and outdated trigger

### DIFF
--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -1320,9 +1320,6 @@ abstract class Table extends CMSObject implements \JTableInterface, DispatcherAw
 		);
 		$this->getDispatcher()->dispatch('onTableAfterCheckin', $event);
 
-		$dispatcher = \JEventDispatcher::getInstance();
-		$dispatcher->trigger('onAfterCheckin', array($this->_tbl));
-
 		return true;
 	}
 

--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -1320,6 +1320,8 @@ abstract class Table extends CMSObject implements \JTableInterface, DispatcherAw
 		);
 		$this->getDispatcher()->dispatch('onTableAfterCheckin', $event);
 
+		Factory::getApplication()->triggerEvent('onAfterCheckin', array($this->_tbl));
+
 		return true;
 	}
 


### PR DESCRIPTION
### Summary of Changes
This removes the outdated and obsolete trigger. The correct trigger happens the line above.


### Testing Instructions
1. Go to Systems
2. Go to Plugins
3. Open plugin `Action Log - Joomla`
4. Click on `Save`
5. Notice you get the following error:
<img width="348" alt="image" src="https://user-images.githubusercontent.com/359377/57967519-6e8bfc80-7960-11e9-94b5-17f640a2ad3c.png">
6. Apply the patch
7. Reload the page
8. Click on `Save`
9. Plugin is now saved


### Expected result
Plugin is saved


### Actual result
Class 'JEventDispatcher' not found error


### Documentation Changes Required
None
