### PR TITLE
[4.0] [mod_articles_category] Always render module layout

### DIFF
--- a/modules/mod_articles_category/mod_articles_category.php
+++ b/modules/mod_articles_category/mod_articles_category.php
@@ -59,41 +59,33 @@ $cacheparams->method       = 'getList';
 $cacheparams->methodparams = $params;
 $cacheparams->modeparams   = $cacheid;
 
-$list = ModuleHelper::moduleCache($module, $params, $cacheparams);
+$list                       = ModuleHelper::moduleCache($module, $params, $cacheparams);
+$article_grouping           = $params->get('article_grouping', 'none');
+$article_grouping_direction = $params->get('article_grouping_direction', 'ksort');
+$grouped                    = $article_grouping === 'none' ? false : true;
 
-if (!empty($list))
+if ($list && $grouped)
 {
-	$grouped                    = false;
-	$article_grouping           = $params->get('article_grouping', 'none');
-	$article_grouping_direction = $params->get('article_grouping_direction', 'ksort');
-
-	if ($article_grouping !== 'none')
+	switch ($article_grouping)
 	{
-		$grouped = true;
-
-		switch ($article_grouping)
-		{
-			case 'year' :
-			case 'month_year' :
-				$list = ArticlesCategoryHelper::groupByDate(
-					$list,
-					$article_grouping_direction,
-					$article_grouping,
-					$params->get('month_year_format', 'F Y'),
-					$params->get('date_grouping_field', 'created')
-				);
-				break;
-			case 'author' :
-			case 'category_title' :
-				$list = ArticlesCategoryHelper::groupBy($list, $article_grouping, $article_grouping_direction);
-				break;
-			case 'tags' :
-				$list = ModArticlesCategoryHelper::groupByTags($list, $article_grouping_direction);
-				break;
-			default:
-				break;
-		}
+		case 'year' :
+		case 'month_year' :
+			$list = ArticlesCategoryHelper::groupByDate(
+				$list,
+				$article_grouping_direction,
+				$article_grouping,
+				$params->get('month_year_format', 'F Y'),
+				$params->get('date_grouping_field', 'created')
+			);
+			break;
+		case 'author' :
+		case 'category_title' :
+			$list = ArticlesCategoryHelper::groupBy($list, $article_grouping, $article_grouping_direction);
+			break;
+		case 'tags' :
+			$list = ModArticlesCategoryHelper::groupByTags($list, $article_grouping_direction);
+			break;
 	}
-
-	require ModuleHelper::getLayoutPath('mod_articles_category', $params->get('layout', 'default'));
 }
+
+require ModuleHelper::getLayoutPath('mod_articles_category', $params->get('layout', 'default'));

--- a/modules/mod_articles_category/mod_articles_category.php
+++ b/modules/mod_articles_category/mod_articles_category.php
@@ -83,7 +83,7 @@ if ($list && $grouped)
 			$list = ArticlesCategoryHelper::groupBy($list, $article_grouping, $article_grouping_direction);
 			break;
 		case 'tags' :
-			$list = ModArticlesCategoryHelper::groupByTags($list, $article_grouping_direction);
+			$list = ArticlesCategoryHelper::groupByTags($list, $article_grouping_direction);
 			break;
 	}
 }

--- a/modules/mod_articles_category/tmpl/default.php
+++ b/modules/mod_articles_category/tmpl/default.php
@@ -12,6 +12,11 @@ defined('_JEXEC') or die;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
+if (!$list)
+{
+	return;
+}
+
 ?>
 <ul class="mod-articlescategory category-module mod-list">
 	<?php if ($grouped) : ?>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Per discussion in #20811, module layouts should always be rendered even if no items are available.

### Testing Instructions

Create `mod_articles_category` override which always displays some custom message/code.
Publish `Articles - Category` module. Configure filtering options so that no articles are displayed.
View the module in frontend.

### Expected result

Custom message shown.

### Actual result

Custom message not shown.

### Documentation Changes Required

No.