### PR TITLE
Extend the attribs field to mediumtext/text in MySql and Postgres

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/3.9.7-2019-05-20.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.9.7-2019-05-20.sql
@@ -1,0 +1,5 @@
+--
+-- Increase attribs field to text
+--
+
+ALTER TABLE `#__content` MODIFY `attribs` text NOT NULL

--- a/administrator/components/com_admin/sql/updates/postgresql/3.9.7-2019-05-20.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.9.7-2019-05-20.sql
@@ -1,0 +1,5 @@
+--
+-- Increase attribs column to text
+--
+
+ALTER TABLE "#__content" ALTER COLUMN "attribs" TYPE TEXT;

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -339,7 +339,7 @@ CREATE TABLE IF NOT EXISTS `#__content` (
   `publish_down` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
   `images` text NOT NULL,
   `urls` text NOT NULL,
-  `attribs` mediumtext NOT NULL,
+  `attribs` text NOT NULL,
   `version` int(10) unsigned NOT NULL DEFAULT 1,
   `ordering` int(11) NOT NULL DEFAULT 0,
   `metakey` text NOT NULL,

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -339,7 +339,7 @@ CREATE TABLE IF NOT EXISTS `#__content` (
   `publish_down` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
   `images` text NOT NULL,
   `urls` text NOT NULL,
-  `attribs` varchar(5120) NOT NULL,
+  `attribs` mediumtext NOT NULL,
   `version` int(10) unsigned NOT NULL DEFAULT 1,
   `ordering` int(11) NOT NULL DEFAULT 0,
   `metakey` text NOT NULL,

--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -344,7 +344,7 @@ CREATE TABLE "#__content" (
   "publish_down" timestamp without time zone DEFAULT '1970-01-01 00:00:00' NOT NULL,
   "images" text NOT NULL,
   "urls" text NOT NULL,
-  "attribs" varchar(5120) NOT NULL,
+  "attribs" text NOT NULL,
   "version" bigint DEFAULT 1 NOT NULL,
   "ordering" bigint DEFAULT 0 NOT NULL,
   "metakey" text NOT NULL,


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
When using a content-plugin to add fields to the core content of joomla, if the user adds more content than 5160 characters, the attribs json will be truncated.
Since in the most cases using a plugin is necessary (the Field Groups / Fields ecc. do not have all functionality wich is needed on many sites), i extended the two db-fields to mediumtext / text.