### PR TITLE
[4.0] Use textfield for descriptions in workflow views

### DIFF
--- a/administrator/components/com_workflow/forms/stage.xml
+++ b/administrator/components/com_workflow/forms/stage.xml
@@ -19,8 +19,10 @@
 		/>
 		<field
 			name="description"
-			type="text"
+			type="textarea"
 			label="COM_WORKFLOW_STAGE_NOTE"
+			rows="3"
+			cols="60"
 		/>
 		<field
 			name="condition"

--- a/administrator/components/com_workflow/forms/transition.xml
+++ b/administrator/components/com_workflow/forms/transition.xml
@@ -41,8 +41,10 @@
 		/>
 		<field
 			name="description"
-			type="text"
+			type="textarea"
 			label="COM_WORKFLOW_TRANSITION_NOTE"
+			rows="3"
+			cols="60"
 		/>
 	</fieldset>
 

--- a/administrator/components/com_workflow/forms/workflow.xml
+++ b/administrator/components/com_workflow/forms/workflow.xml
@@ -23,8 +23,10 @@
 		/>
 		<field
 			name="description"
-			type="text"
+			type="textarea"
 			label="COM_WORKFLOW_WORKFLOW_NOTE"
+			rows="3"
+			cols="60"
 		/>
 	</fieldset>
 


### PR DESCRIPTION
### Summary of Changes
The textfield for descriptions in workflow edit views is to short for good informative texts.

![transition-description](https://user-images.githubusercontent.com/1035262/58011514-b3479d00-7af2-11e9-8c1e-ecae122e19f2.PNG)



### Testing Instructions
Go to content-workflow. Compare the edit screens of workflow, stage and transition befor and after patch.
