### PR TITLE
[4.0] Use created date in mod popular if publish_up is nulldate

### DIFF
--- a/administrator/modules/mod_latest/tmpl/default.php
+++ b/administrator/modules/mod_latest/tmpl/default.php
@@ -50,7 +50,7 @@ $nulldate = Factory::getDbo()->getNullDate();
 					<span class="small">
 						<span class="icon-calendar" aria-hidden="true"></span>
 							<?php 
-								$date = $item->publish_up === $nulldate() ? $item->created : $item->publish_up; 
+								$date = $item->publish_up === $nulldate ? $item->created : $item->publish_up; 
 								echo HTMLHelper::_('date', $date, Text::_('DATE_FORMAT_LC4')); 
 							?>
 					</span>

--- a/administrator/modules/mod_latest/tmpl/default.php
+++ b/administrator/modules/mod_latest/tmpl/default.php
@@ -9,10 +9,13 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
 HTMLHelper::_('bootstrap.framework');
+
+$nulldate = Factory::getDbo()->getNullDate();
 ?>
 <table class="table" id="<?php echo str_replace(' ', '', $module->title) . $module->id; ?>">
 	<caption class="sr-only"><?php echo $module->title; ?></caption>
@@ -46,7 +49,10 @@ HTMLHelper::_('bootstrap.framework');
 				<span class="badge badge-secondary badge-pill">
 					<span class="small">
 						<span class="icon-calendar" aria-hidden="true"></span>
-						<?php echo HTMLHelper::_('date', $item->publish_up, Text::_('DATE_FORMAT_LC4')); ?>
+							<?php 
+								$date = $item->publish_up === $nulldate() ? $item->created : $item->publish_up; 
+								echo HTMLHelper::_('date', $date, Text::_('DATE_FORMAT_LC4')); 
+							?>
 					</span>
 				</span>
 			</td>

--- a/administrator/modules/mod_latest/tmpl/default.php
+++ b/administrator/modules/mod_latest/tmpl/default.php
@@ -15,7 +15,7 @@ use Joomla\CMS\Language\Text;
 
 HTMLHelper::_('bootstrap.framework');
 
-$nulldate = Factory::getDbo()->getNullDate();
+$nullDate = Factory::getDbo()->getNullDate();
 ?>
 <table class="table" id="<?php echo str_replace(' ', '', $module->title) . $module->id; ?>">
 	<caption class="sr-only"><?php echo $module->title; ?></caption>
@@ -50,7 +50,7 @@ $nulldate = Factory::getDbo()->getNullDate();
 					<span class="small">
 						<span class="icon-calendar" aria-hidden="true"></span>
 							<?php 
-								$date = $item->publish_up === $nulldate ? $item->created : $item->publish_up; 
+								$date = $item->publish_up === $nullDate ? $item->created : $item->publish_up; 
 								echo HTMLHelper::_('date', $date, Text::_('DATE_FORMAT_LC4')); 
 							?>
 					</span>

--- a/administrator/modules/mod_popular/Helper/PopularHelper.php
+++ b/administrator/modules/mod_popular/Helper/PopularHelper.php
@@ -41,7 +41,7 @@ abstract class PopularHelper
 
 		// Set List SELECT
 		$model->setState('list.select', 'a.id, a.title, a.checked_out, a.checked_out_time, ' .
-				' a.publish_up, a.hits');
+				' a.publish_up, a.created, a.hits');
 
 		// Set Ordering filter
 		$model->setState('list.ordering', 'a.hits');

--- a/administrator/modules/mod_popular/tmpl/default.php
+++ b/administrator/modules/mod_popular/tmpl/default.php
@@ -14,6 +14,8 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
 HTMLHelper::_('bootstrap.framework');
+
+$nulldate = Factory::getDbo()->getNullDate();
 ?>
 <table class="table" id="<?php echo str_replace(' ', '', $module->title) . $module->id; ?>">
 	<caption class="sr-only"><?php echo $module->title; ?></caption>
@@ -51,8 +53,7 @@ HTMLHelper::_('bootstrap.framework');
 						<span class="small">
 							<span class="icon-calendar" aria-hidden="true"></span>
 							<?php 
-								$nulldate = Factory::getDbo()->getNullDate();
-								$date = $item->publish_up == $nulldate ? $item->created : $item->publish_up; 
+								$date = $item->publish_up === $nulldate() ? $item->created : $item->publish_up; 
 								echo HTMLHelper::_('date', $date, Text::_('DATE_FORMAT_LC4')); 
 							?>
 						</span>

--- a/administrator/modules/mod_popular/tmpl/default.php
+++ b/administrator/modules/mod_popular/tmpl/default.php
@@ -9,6 +9,7 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
@@ -49,7 +50,11 @@ HTMLHelper::_('bootstrap.framework');
 					<span class="badge badge-secondary badge-pill">
 						<span class="small">
 							<span class="icon-calendar" aria-hidden="true"></span>
-							<?php echo HTMLHelper::_('date', $item->publish_up, Text::_('DATE_FORMAT_LC4')); ?>
+							<?php 
+								$nulldate = Factory::getDbo()->getNullDate();
+								$date = $item->publish_up == $nulldate ? $item->created : $item->publish_up; 
+								echo HTMLHelper::_('date', $date, Text::_('DATE_FORMAT_LC4')); 
+							?>
 						</span>
 					</span>
 				</td>

--- a/administrator/modules/mod_popular/tmpl/default.php
+++ b/administrator/modules/mod_popular/tmpl/default.php
@@ -15,7 +15,7 @@ use Joomla\CMS\Language\Text;
 
 HTMLHelper::_('bootstrap.framework');
 
-$nulldate = Factory::getDbo()->getNullDate();
+$nullDate = Factory::getDbo()->getNullDate();
 ?>
 <table class="table" id="<?php echo str_replace(' ', '', $module->title) . $module->id; ?>">
 	<caption class="sr-only"><?php echo $module->title; ?></caption>
@@ -53,7 +53,7 @@ $nulldate = Factory::getDbo()->getNullDate();
 						<span class="small">
 							<span class="icon-calendar" aria-hidden="true"></span>
 							<?php 
-								$date = $item->publish_up === $nulldate() ? $item->created : $item->publish_up; 
+								$date = $item->publish_up === $nullDate ? $item->created : $item->publish_up; 
 								echo HTMLHelper::_('date', $date, Text::_('DATE_FORMAT_LC4')); 
 							?>
 						</span>


### PR DESCRIPTION
### Summary of Changes
Use created date in mod_popular and mod_latest if publish_up is nulldate.

### Testing Instructions
Add a new article, then have a look on molule popular articles and mod_latest on the administrator panel. 

### Expected result
Dates are correct


### Actual result
![popular-publish_up](https://user-images.githubusercontent.com/1035262/58078780-d421f800-7baf-11e9-9ec2-3dcf5a35f8a5.PNG)



### Documentation Changes Required

