### PR TITLE
[4.0] Correcting switcher alignment when col is md-3

### DIFF
--- a/build/media_source/system/scss/fields/switcher.scss
+++ b/build/media_source/system/scss/fields/switcher.scss
@@ -71,11 +71,10 @@ padding-top: 5px;
 padding-right: 5px;
 text-align: left;
 }
-.col-md-3 .switcher__legend {
-  margin-left: 0;
-}
-
 .col-md-9 .switcher__legend,
 .col-md-12 .switcher__legend {
   margin-left: -220px;
+}
+.col-md-3 .switcher__legend {
+  margin-left: 0;
 }


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/pull/24802#issuecomment-495115347

### Summary of Changes
Loading the child of the class in the right order to prevent col_md-12 to override col_md-3

### Testing Instructions
Edit an article.
Look at the Featured label

### After patch
It will now display correctly over the switcher.
<img width="453" alt="Screen Shot 2019-05-23 at 16 30 42" src="https://user-images.githubusercontent.com/869724/58261239-362d5980-7d78-11e9-965f-dd1d0643b779.png">
