### PR TITLE
Remove  SECURITY.md from $doNotPackage array

### DIFF
--- a/build/build.php
+++ b/build/build.php
@@ -156,7 +156,6 @@ $doNotPackage = array(
 	'.php_cs',
 	'.travis.yml',
 	'README.md',
-	'SECURITY.md',
 	'appveyor-phpunit.xml',
 	'build',
 	'build.xml',


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Remove  SECURITY.md from $doNotPackage array in build/build.php after https://github.com/joomla/joomla-cms/pull/24994 is merged.
### Testing Instructions
code review