### PR TITLE
[4.0] Fix showon error in com_menus

### DIFF
--- a/administrator/components/com_menus/Field/MenutypeField.php
+++ b/administrator/components/com_menus/Field/MenutypeField.php
@@ -107,8 +107,10 @@ class MenutypeField extends ListField
 						. Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>'
 			)
 		);
+
+		// This hidden field has an ID so it can be used for showon attributes
 		$html[] = '<input type="hidden" name="' . $this->name . '" value="'
-			. htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '">';
+			. htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '" id="' . $this->id .'_val">';
 
 		return implode("\n", $html);
 	}

--- a/administrator/components/com_menus/Field/MenutypeField.php
+++ b/administrator/components/com_menus/Field/MenutypeField.php
@@ -110,7 +110,7 @@ class MenutypeField extends ListField
 
 		// This hidden field has an ID so it can be used for showon attributes
 		$html[] = '<input type="hidden" name="' . $this->name . '" value="'
-			. htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '" id="' . $this->id .'_val">';
+			. htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '" id="' . $this->id . '_val">';
 
 		return implode("\n", $html);
 	}


### PR DESCRIPTION
### Summary of Changes
showon was broken in com_menus. this fixes it by adding an id to the hidden field for menu type which was failing

### Testing Instructions
Before patch see console error when editing a menu item. after patch it's gone and showon attributes work correctly (publish up/down based on home page and template style based on menu item)

### Documentation Changes Required
none
