### PR TITLE
[4.0] Fix saving an item in a modal

### DIFF
--- a/build/media_source/system/js/fields/modal-fields.es5.js
+++ b/build/media_source/system/js/fields/modal-fields.es5.js
@@ -123,7 +123,7 @@
 		// Set frame id.
 		iframe.id = 'Frame_' + modalId;
 
-		var iframeDocument = iframe.contentDocument || iframe.contentWindow.document;
+		var iframeDocument = iframe.contentDocument;
 
 		// If Close (cancel task), close the modal.
 		if (task === 'cancel')
@@ -140,7 +140,7 @@
 			iframe.addEventListener('load', function()
 			{
 				// Reload iframe document var value.
-				iframeDocument = this.contentDocument || this.contentWindow.document;
+				iframeDocument = this.contentDocument;
 
 				// Validate the child form and update parent form.
 				if (iframeDocument.getElementById(idFieldId) && iframeDocument.getElementById(idFieldId).value != '0')

--- a/build/media_source/system/js/fields/modal-fields.es5.js
+++ b/build/media_source/system/js/fields/modal-fields.es5.js
@@ -123,7 +123,7 @@
 		// Set frame id.
 		iframe.id = 'Frame_' + modalId;
 
-		var iframeDocument = iframe.firstChild;
+		var iframeDocument = iframe.contentDocument || iframe.contentWindow.document;
 
 		// If Close (cancel task), close the modal.
 		if (task === 'cancel')
@@ -140,7 +140,7 @@
 			iframe.addEventListener('load', function()
 			{
 				// Reload iframe document var value.
-				iframeDocument = this.firstChild;
+				iframeDocument = this.contentDocument || this.contentWindow.document;
 
 				// Validate the child form and update parent form.
 				if (iframeDocument.getElementById(idFieldId) && iframeDocument.getElementById(idFieldId).value != '0')


### PR DESCRIPTION
### Summary of Changes
Fixes saving items in modals (e.g. creating a new item in com_menus, creating a new menu item for an article)

### Testing Instructions
Open an article and try saving it. Before patch it doesn't save/validate, after patch it does (both save and save close)

This is a bug introduced by https://github.com/joomla/joomla-cms/pull/22308 which I somehow missed at the time.

### Documentation Changes Required
None