### PR TITLE
[4.0] Remove jquery from modals field

### DIFF
--- a/build/media_source/system/js/fields/modal-fields.es5.js
+++ b/build/media_source/system/js/fields/modal-fields.es5.js
@@ -56,7 +56,7 @@
 			}
 			if (document.getElementById(fieldPrefix + '_propagate'))
 			{
-				jQuery('#' + fieldPrefix + '_propagate').removeClass('hidden');
+				document.getElementById(fieldPrefix + '_propagate').classList.remove('hidden');
 			}
 		}
 		else
@@ -82,7 +82,7 @@
 			}
 			if (document.getElementById(fieldPrefix + '_propagate'))
 			{
-				jQuery('#' + fieldPrefix + '_propagate').addClass('hidden');
+				document.getElementById(fieldPrefix + '_propagate').classList.add('hidden');
 			}
 		}
 


### PR DESCRIPTION
### Summary of Changes
Removes some jQuery introduced in https://github.com/joomla/joomla-cms/pull/21321 from the j4 branch which should be jQuery free

### Testing Instructions
Functionality should remain unchanged

### Documentation Changes Required
None