### PR TITLE
[4.0] Fix show full description link in modules/templates

### DIFF
--- a/administrator/components/com_modules/tmpl/module/edit.php
+++ b/administrator/components/com_modules/tmpl/module/edit.php
@@ -105,9 +105,8 @@ $tmpl    = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=c
 							?>
 							<p><?php echo $short_description; ?></p>
 							<?php if ($long_description) : ?>
-							<?php // @todo Remove jQuery ?>
 								<p class="readmore">
-									<a href="#" onclick="jQuery('.nav-tabs a[href=\'#description\']').tab('show');">
+									<a href="#" onclick="document.querySelector('#tab-description').click();">
 										<?php echo Text::_('JGLOBAL_SHOW_FULL_DESCRIPTION'); ?>
 									</a>
 								</p>

--- a/administrator/components/com_plugins/tmpl/plugin/edit.php
+++ b/administrator/components/com_plugins/tmpl/plugin/edit.php
@@ -86,7 +86,6 @@ $tmpl     = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=
 							?>
 							<p><?php echo $short_description; ?></p>
 							<?php if ($long_description) : ?>
-							<?php // @todo Remove jQuery ?>
 								<p class="readmore">
 									<a href="#" onclick="document.querySelector('#tab-description').click();">
 										<?php echo Text::_('JGLOBAL_SHOW_FULL_DESCRIPTION'); ?>

--- a/administrator/components/com_templates/tmpl/style/edit.php
+++ b/administrator/components/com_templates/tmpl/style/edit.php
@@ -51,7 +51,7 @@ $user = Factory::getUser();
 					?>
 					<?php if ($description) : ?>
 						<p class="readmore">
-							<a href="#" onclick="jQuery('.nav-tabs a[href=\'#description\']').tab('show');">
+							<a href="#" onclick="document.querySelector('#tab-description').click();">
 								<?php echo Text::_('JGLOBAL_SHOW_FULL_DESCRIPTION'); ?>
 							</a>
 						</p>


### PR DESCRIPTION
### Summary of Changes
Fixes the changing of tab when viewing a long module description

### Testing Instructions
Create a module description over 500 characters long and then click the "show full description..." link. before patch nothing happens. after patch it changes over.

### Documentation Changes Required
none
