### PR TITLE
[4.0] Added missing target attribute to parseXmlNode

### DIFF
--- a/administrator/components/com_menus/Helper/MenusHelper.php
+++ b/administrator/components/com_menus/Helper/MenusHelper.php
@@ -859,6 +859,7 @@ class MenusHelper extends ContentHelper
 		$item->type       = (string) $node['type'];
 		$item->title      = (string) $node['title'];
 		$item->link       = (string) $node['link'];
+		$item->target     = (string) $node['target'];
 		$item->element    = (string) $node['element'];
 		$item->class      = (string) $node['class'];
 		$item->icon       = (string) $node['icon'];

--- a/administrator/components/com_menus/Helper/MenusHelper.php
+++ b/administrator/components/com_menus/Helper/MenusHelper.php
@@ -859,7 +859,7 @@ class MenusHelper extends ContentHelper
 		$item->type       = (string) $node['type'];
 		$item->title      = (string) $node['title'];
 		$item->link       = (string) $node['link'];
-		$item->target     = (string) $node['target'];
+		$item->target     = (string) $node['target'] ?: '_self';
 		$item->element    = (string) $node['element'];
 		$item->class      = (string) $node['class'];
 		$item->icon       = (string) $node['icon'];

--- a/administrator/components/com_menus/Helper/MenusHelper.php
+++ b/administrator/components/com_menus/Helper/MenusHelper.php
@@ -859,7 +859,7 @@ class MenusHelper extends ContentHelper
 		$item->type       = (string) $node['type'];
 		$item->title      = (string) $node['title'];
 		$item->link       = (string) $node['link'];
-		$item->target     = (string) $node['target'] ?: '_self';
+		$item->target     = (string) $node['target'];
 		$item->element    = (string) $node['element'];
 		$item->class      = (string) $node['class'];
 		$item->icon       = (string) $node['icon'];


### PR DESCRIPTION
Required for the backend template for external links, like menuitem type url!

Pull Request for Issue # .

### Summary of Changes

Added missing target attribute to parseXmlNode() method

### Documentation Changes Required

No
