### PR TITLE
[4.0] Disable pointer events on .header-shadow

### DIFF
--- a/templates/cassiopeia/scss/blocks/_header.scss
+++ b/templates/cassiopeia/scss/blocks/_header.scss
@@ -163,6 +163,7 @@
 
 .header-shadow {
   display: none;
+  pointer-events: none;
 
   .container-banner + & {
     position: absolute;


### PR DESCRIPTION
Pull Request for Issue #24761.

### Summary of Changes
.header-shadow DIV in the template Cassiopeia takes over the content and then creates a layer where the user can not click the buttons


### Testing Instructions
Add login module to the banner position. 
On the front end, click the Login  button.


### Expected result
Able to click the button


### Actual result
Unable to click the button
