### PR TITLE
[4.0] Fix wrong class

### DIFF
--- a/administrator/components/com_finder/Indexer/Query.php
+++ b/administrator/components/com_finder/Indexer/Query.php
@@ -769,7 +769,7 @@ class Query
 		foreach (Taxonomy::getBranchTitles() as $branch)
 		{
 			// Add the pattern.
-			$patterns[$branch] = StringHelper::strtolower(Text::_(Language::branchSingular($branch)));
+			$patterns[$branch] = StringHelper::strtolower(Text::_(FinderHelperLanguage::branchSingular($branch)));
 		}
 
 		// Container for search terms and phrases.


### PR DESCRIPTION
### Summary of Changes
Fix `Error: Call to undefined method Joomla\Component\Finder\Administrator\Indexer\Language::branchSingular()`

### Testing Instructions
Enable Smart Search module.
Visit front end.

