### PR TITLE
[4.0] Control Panel admin menu should always display

### DIFF
--- a/administrator/modules/mod_menu/Menu/CssMenu.php
+++ b/administrator/modules/mod_menu/Menu/CssMenu.php
@@ -349,7 +349,7 @@ class CssMenu
 
 				list($assetName) = isset($query['context']) ? explode('.', $query['context'], 2) : array('com_fields');
 			}
-			elseif ($item->element === 'com_cpanel' && $item->link === "index.php")
+			elseif ($item->element === 'com_cpanel' && $item->link === 'index.php')
 			{
 				continue;
 			}

--- a/administrator/modules/mod_menu/Menu/CssMenu.php
+++ b/administrator/modules/mod_menu/Menu/CssMenu.php
@@ -274,7 +274,6 @@ class CssMenu
 		 */
 		$this->application->triggerEvent('onPreprocessMenuItems', array('com_menus.administrator.module', $children, $this->params, $this->enabled));
 
-
 		foreach ($children as $item)
 		{
 			// Exclude item with menu item option set to exclude from menu modules
@@ -349,6 +348,10 @@ class CssMenu
 				}
 
 				list($assetName) = isset($query['context']) ? explode('.', $query['context'], 2) : array('com_fields');
+			}
+			elseif ($item->element === 'com_cpanel' && $item->link === "index.php")
+			{
+				continue;
 			}
 			elseif ($item->element === 'com_workflow')
 			{


### PR DESCRIPTION
Pull Request for Issue #25008

### Summary of Changes
As title says. Forcing the menu to display.


### Testing Instructions
Log in backend as a manager.
The Control Panel admin menu is not displayed.
It is therefore impossible to get back to it after displaying another page


### Before patch

<img width="596" alt="Screen Shot 2019-05-27 at 11 10 15" src="https://user-images.githubusercontent.com/869724/58409286-0c25b100-8070-11e9-95a9-25eb30329fa5.png">


### After patch

<img width="589" alt="Screen Shot 2019-05-27 at 11 09 41" src="https://user-images.githubusercontent.com/869724/58409302-121b9200-8070-11e9-84cb-126167b35621.png">
