### PR TITLE
[4.0] modal toolbar layout

### DIFF
--- a/layouts/joomla/toolbar/modal.php
+++ b/layouts/joomla/toolbar/modal.php
@@ -27,8 +27,16 @@ $id       = isset($displayData['id']) ? $displayData['id'] : '';
 $class    = isset($displayData['class']) ? $displayData['class'] : 'btn btn-secondary';
 $icon     = isset($displayData['icon']) ? $displayData['icon'] : 'fa fa-download';
 $text     = isset($displayData['text']) ? $displayData['text'] : '';
+?>
 
-// Render the modal
+<!-- Render the button -->
+<button<?php echo $id; ?> onclick="document.getElementById('modal_<?php echo $selector; ?>').open()" class="<?php echo $class; ?>" data-toggle="modal">
+	<span class="<?php echo $icon; ?>" aria-hidden="true"></span>
+	<?php echo $text; ?>
+</button>
+
+<!-- Render the modal -->
+<?php 
 echo HTMLHelper::_('bootstrap.renderModal',
 	'modal_' . $selector,
 	[
@@ -48,7 +56,4 @@ echo HTMLHelper::_('bootstrap.renderModal',
 	]
 );
 ?>
-<button<?php echo $id; ?> onclick="document.getElementById('modal_<?php echo $selector; ?>').open()" class="<?php echo $class; ?>" data-toggle="modal">
-	<span class="<?php echo $icon; ?>" aria-hidden="true"></span>
-	<?php echo $text; ?>
-</button>
+


### PR DESCRIPTION
As far as I can tell this layout is only used `administrator/index.php?option=com_banners&view=tracks` for the export button.

If you look at the screenshots you will see that the export button is indented more than the new button. 

![image](https://user-images.githubusercontent.com/1296369/58517001-c36e1500-81a1-11e9-90fb-a15e76beac0a.png)
![image](https://user-images.githubusercontent.com/1296369/58517030-e6002e00-81a1-11e9-99e1-a2bbabfa7563.png)

This is because there is some css for the first button.

`.subhead .btn-toolbar>:first-child {
    margin-left: 0;
}`

This should be applied to the export button as well but its not hence the indentation.

This is caused by the layout rendering the div for the modal before the button. This means that the button is no longer the `first-child`

This simple PR changes the order of the div and the button to resolve this.
### After PR
![image](https://user-images.githubusercontent.com/1296369/58517090-147e0900-81a2-11e9-8a33-16dc37c2a3b8.png)



NOTE any issues with the rendering of the modal are beyond the scope of this PR



