### PR TITLE
iFrameHeight() needs to be called with a reference to the iframe-object

### DIFF
--- a/components/com_wrapper/views/wrapper/view.html.php
+++ b/components/com_wrapper/views/wrapper/view.html.php
@@ -69,7 +69,7 @@ class WrapperViewWrapper extends JViewLegacy
 		// Auto height control
 		if ($params->def('height_auto'))
 		{
-			$wrapper->load = 'onload="iFrameHeight()"';
+			$wrapper->load = 'onload="iFrameHeight(this)"';
 		}
 		else
 		{


### PR DESCRIPTION
since #19136

Pull Request for Issue # .

### Summary of Changes
iFrameHeight() needs to be called with a reference to the iframe-object as declared in 
media/com_wrapper/js/iframe-height.js

### Testing Instructions
Create Menu-Item with type wrapper, set extended properties of menu-item to auto-size

### Expected result
Iframe should adapt it's size to the content height of it's document

### Actual result
size does not change

### Documentation Changes Required

