### PR TITLE
[4.0] Multilingual: Correcting display of Associations Select fields

### DIFF
--- a/build/media_source/com_associations/js/associations-edit.es6.js
+++ b/build/media_source/com_associations/js/associations-edit.es6.js
@@ -17,7 +17,7 @@ Joomla = window.Joomla || {};
       if (el) {
         const attribute = el.getAttribute('for');
 
-        if (attribute.replace('_id', '') === `${formControl}_associations_${languageCode.replace('-', '_')}`) {
+        if (attribute.replace('_name', '') === `${formControl}_associations_${languageCode.replace('-', '_')}`) {
           element.style.display = 'none';
         }
       }
@@ -169,13 +169,13 @@ Joomla = window.Joomla || {};
 
         controlGroup.forEach((element) => {
           const attribute = element.querySelector('.control-label label').getAttribute('for');
-          const languageCode = attribute.replace('_id', '').replace('jform_associations_', '');
+          const languageCode = attribute.replace('_name', '').replace('jform_associations_', '');
 
           // Show the association fields
           element.style.display = 'block';
 
           // Check if there was an association selected for this language
-          if (!existsAssociations && document.getElementById(`${formControl}_associations_${languageCode}_id`).value !== '') {
+          if (!existsAssociations && document.getElementById(`${formControl}_associations_${languageCode}_name`).value !== '') {
             existsAssociations = true;
           }
 


### PR DESCRIPTION
https://github.com/joomla/joomla-cms/pull/24775 has modified the label id for modal select fields, therefore breaking the display of these fields in the associations tab when editing an item

### Summary of Changes
Replacing `_id` by `_name` in the associations-edit js file

### Testing Instructions
Multilingual site.
Install at least 2 languages (from fr-FR, de-DE, fa-IR)
Use the Multilingual Sample Data module to set a basic multilingual site.
Edit an article, for example `Article (en-GB)` and display the Associations tab

### Before patch
The language select field used by the article edited `English (en-GB)` displays although it should not.

<img width="695" alt="Screen Shot 2019-05-30 at 08 43 49" src="https://user-images.githubusercontent.com/869724/58613858-1a194300-82b7-11e9-83cc-3035be954289.png">

### After patch
Issue solved.

<img width="722" alt="Screen Shot 2019-05-30 at 08 40 03" src="https://user-images.githubusercontent.com/869724/58613886-2c937c80-82b7-11e9-92d0-5810b8f58fd1.png">





### Documentation Changes Required

