### PR TITLE
[4.0] Warning in repeatable custom field

### DIFF
--- a/plugins/fields/repeatable/repeatable.php
+++ b/plugins/fields/repeatable/repeatable.php
@@ -7,12 +7,12 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-use Joomla\CMS\MVC\Model\BaseDatabaseModel;
-use Joomla\Component\Fields\Administrator\Helper\FieldsHelper;
-
 defined('_JEXEC') or die;
 
-JLoader::import('components.com_fields.libraries.fieldsplugin', JPATH_ADMINISTRATOR);
+use Joomla\CMS\Form\Form;
+use Joomla\CMS\MVC\Model\BaseDatabaseModel;
+use Joomla\Component\Fields\Administrator\Helper\FieldsHelper;
+use Joomla\Component\Fields\Administrator\Plugin\FieldsPlugin;
 
 /**
  * Repeatable plugin.
@@ -26,13 +26,13 @@ class PlgFieldsRepeatable extends FieldsPlugin
 	 *
 	 * @param   stdClass    $field   The field.
 	 * @param   DOMElement  $parent  The field node parent.
-	 * @param   JForm       $form    The form.
+	 * @param   Form        $form    The form.
 	 *
 	 * @return  DOMElement
 	 *
 	 * @since   3.9.0
 	 */
-	public function onCustomFieldsPrepareDom($field, DOMElement $parent, JForm $form)
+	public function onCustomFieldsPrepareDom($field, DOMElement $parent, Form $form)
 	{
 		$fieldNode = parent::onCustomFieldsPrepareDom($field, $parent, $form);
 

--- a/plugins/fields/repeatable/repeatable.php
+++ b/plugins/fields/repeatable/repeatable.php
@@ -10,7 +10,6 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Form\Form;
-use Joomla\CMS\MVC\Model\BaseDatabaseModel;
 use Joomla\Component\Fields\Administrator\Helper\FieldsHelper;
 use Joomla\Component\Fields\Administrator\Plugin\FieldsPlugin;
 


### PR DESCRIPTION
Pull Request for Issue #25066 .

### Summary of Changes

Fixes a warning in custom field form.

### Testing Instructions

Create a new custom field for content

### Expected result

Form with no errors

### Actual result

> Warning: Declaration of PlgFieldsRepeatable::onCustomFieldsPrepareDom($field, DOMElement $parent, JForm $form) should be compatible with Joomla\Component\Fields\Administrator\Plugin\FieldsPlugin::onCustomFieldsPrepareDom($field, DOMElement $parent, Joomla\CMS\Form\Form $form) in C:\htdocs\joomla-cms\plugins\fields\repeatable\repeatable.php on line 76

### Documentation Changes Required

No.