### PR TITLE
[4.0] fix newsfeeds class name for displaying Associations

### DIFF
--- a/administrator/components/com_newsfeeds/tmpl/newsfeeds/default.php
+++ b/administrator/components/com_newsfeeds/tmpl/newsfeeds/default.php
@@ -159,7 +159,7 @@ if ($saveOrder && !empty($this->items))
 								<?php if ($assoc) : ?>
 								<td class="d-none d-md-table-cell text-center">
 									<?php if ($item->association) : ?>
-										<?php echo HTMLHelper::_('newsfeed.association', $item->id); ?>
+										<?php echo HTMLHelper::_('newsfeedsadministrator.association', $item->id); ?>
 									<?php endif; ?>
 								</td>
 								<?php endif; ?>


### PR DESCRIPTION
Associations couldn't be displayed in Newsfeeds as there occured an error with 'JHtml newsfeed not found' as the class name were not updated in this place after a new classname were registered.

### Summary of Changes
Changed classname from 'newsfeed.association' to 'newsfeedsadministrator.association'

### Testing Instructions
Have at least two languages installed and enable the languagefilter plugin.
Create two news feeds in different languages and associate them with each other.
Return to the News Feeds list view.

### Expected result
The list should be displayed with associations and without errors.
![image](https://user-images.githubusercontent.com/31204883/58671117-ad975600-8341-11e9-8dac-dafdad5858ac.png)


### Actual result
An error is displayed.
![image](https://user-images.githubusercontent.com/31204883/58671141-c6077080-8341-11e9-8481-be55b00d664d.png)


### Documentation Changes Required
No
