### PR TITLE
[4.0] Fix warning in Smart Search results

### DIFF
--- a/components/com_finder/View/Search/HtmlView.php
+++ b/components/com_finder/View/Search/HtmlView.php
@@ -137,7 +137,7 @@ class HtmlView extends BaseHtmlView
 		\JDEBUG ? Profiler::getInstance('Application')->mark('afterFinderPagination') : null;
 
 		// Flag indicates to not add limitstart=0 to URL
-		$pagination->hideEmptyLimitstart = true;
+		$this->pagination->hideEmptyLimitstart = true;
 
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/pull/25040#issuecomment-497462464.

### Summary of Changes

Use correct variable.

### Testing Instructions

Search for something using Smart Search (`com_finder`).

### Expected result

No warnings o result page.

### Actual result

Warning: Creating default object from empty value in \components\com_finder\View\Search\HtmlView.php on line 140

### Documentation Changes Required
No.
