### PR TITLE
[4.0] Move Finder class aliases to extension classmap

### DIFF
--- a/libraries/classmap.php
+++ b/libraries/classmap.php
@@ -500,13 +500,4 @@ JLoader::registerAlias('JStream',                           '\\Joomla\\CMS\\File
 JLoader::registerAlias('JStreamString',                     '\\Joomla\\CMS\\Filesystem\\Streams\\StreamString', '5.0');
 JLoader::registerAlias('JStringController',                 '\\Joomla\\CMS\\Filesystem\\Support\\StringController', '5.0');
 
-JLoader::registerAlias('FinderIndexerAdapter',          '\\Joomla\\Component\\Finder\\Administrator\\Indexer\\Adapter', '5.0');
-JLoader::registerAlias('FinderIndexerHelper',                 '\\Joomla\\Component\\Finder\\Administrator\\Indexer\\Helper', '5.0');
-JLoader::registerAlias('FinderIndexer',                 '\\Joomla\\Component\\Finder\\Administrator\\Indexer\\Indexer', '5.0');
-JLoader::registerAlias('FinderIndexerParser',                 '\\Joomla\\Component\\Finder\\Administrator\\Indexer\\Parser', '5.0');
-JLoader::registerAlias('FinderIndexerQuery',                 '\\Joomla\\Component\\Finder\\Administrator\\Indexer\\Query', '5.0');
-JLoader::registerAlias('FinderIndexerResult',                 '\\Joomla\\Component\\Finder\\Administrator\\Indexer\\Result', '5.0');
-JLoader::registerAlias('FinderIndexerTaxonomy',                 '\\Joomla\\Component\\Finder\\Administrator\\Indexer\\Taxonomy', '5.0');
-JLoader::registerAlias('FinderIndexerToken',                 '\\Joomla\\Component\\Finder\\Administrator\\Indexer\\Token', '5.0');
-
 JLoader::registerAlias('JClassLoader',                      '\\Joomla\\CMS\\Autoload\\ClassLoader', '5.0');

--- a/libraries/extensions.classmap.php
+++ b/libraries/extensions.classmap.php
@@ -21,3 +21,12 @@ JLoader::registerAlias('PrivacyRemovalStatus', '\\Joomla\\Component\\Privacy\\Ad
 JLoader::registerAlias('PrivacyTableRequest', '\\Joomla\\Component\\Privacy\\Administrator\\Table\\RequestTable', '5.0');
 
 JLoader::registerAlias('TagsTableTag',     '\\Joomla\\Component\\Tags\\Administrator\\Table\\TagTable', '4.0');
+
+JLoader::registerAlias('FinderIndexerAdapter',  '\\Joomla\\Component\\Finder\\Administrator\\Indexer\\Adapter', '5.0');
+JLoader::registerAlias('FinderIndexerHelper',   '\\Joomla\\Component\\Finder\\Administrator\\Indexer\\Helper', '5.0');
+JLoader::registerAlias('FinderIndexer',         '\\Joomla\\Component\\Finder\\Administrator\\Indexer\\Indexer', '5.0');
+JLoader::registerAlias('FinderIndexerParser',   '\\Joomla\\Component\\Finder\\Administrator\\Indexer\\Parser', '5.0');
+JLoader::registerAlias('FinderIndexerQuery',    '\\Joomla\\Component\\Finder\\Administrator\\Indexer\\Query', '5.0');
+JLoader::registerAlias('FinderIndexerResult',   '\\Joomla\\Component\\Finder\\Administrator\\Indexer\\Result', '5.0');
+JLoader::registerAlias('FinderIndexerTaxonomy', '\\Joomla\\Component\\Finder\\Administrator\\Indexer\\Taxonomy', '5.0');
+JLoader::registerAlias('FinderIndexerToken',    '\\Joomla\\Component\\Finder\\Administrator\\Indexer\\Token', '5.0');


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This just moves Finder class aliases to extension classmap, where they belong.

### Testing Instructions

Smart Search still works.

### Documentation Changes Required

No.