### PR TITLE
Load module by id should also get the style

### DIFF
--- a/plugins/content/loadmodule/loadmodule.php
+++ b/plugins/content/loadmodule/loadmodule.php
@@ -136,6 +136,7 @@ class PlgContentLoadmodule extends JPlugin
 				{
 					$matchesidlist[1] = $style;
 				}
+
 				$style    = trim($matchesidlist[1]);
 				$output = $this->_loadid($id, $style);
 

--- a/plugins/content/loadmodule/loadmodule.php
+++ b/plugins/content/loadmodule/loadmodule.php
@@ -224,7 +224,7 @@ class PlgContentLoadmodule extends JPlugin
 	 *
 	 * @since   3.9.0
 	 */
-	protected function _loadid($id $style = 'none')
+	protected function _loadid($id, $style = 'none')
 	{
 		self::$modules[$id] = '';
 		$document = JFactory::getDocument();

--- a/plugins/content/loadmodule/loadmodule.php
+++ b/plugins/content/loadmodule/loadmodule.php
@@ -130,7 +130,7 @@ class PlgContentLoadmodule extends JPlugin
 			foreach ($matchesmodid as $match)
 			{
 				$matchesidlist = explode(',', $match[1]);
-				$id     = trim($matchesidlist[0]);
+				$id            = trim($matchesidlist[0]);
 				// We may not have a module style so fall back to the plugin default.
 				if (!array_key_exists(1, $matchesidlist))
 				{

--- a/plugins/content/loadmodule/loadmodule.php
+++ b/plugins/content/loadmodule/loadmodule.php
@@ -231,7 +231,7 @@ class PlgContentLoadmodule extends JPlugin
 		$document = JFactory::getDocument();
 		$renderer = $document->loadRenderer('module');
 		$modules  = JModuleHelper::getModuleById($id);
-		$params = array('style' => $style);
+		$params   = array('style' => $style);
 		ob_start();
 
 		if ($modules->id > 0)

--- a/plugins/content/loadmodule/loadmodule.php
+++ b/plugins/content/loadmodule/loadmodule.php
@@ -56,7 +56,7 @@ class PlgContentLoadmodule extends JPlugin
 		$stylemod = $this->params->def('style', 'none');
 
 		// Expression to search for(id)
-		$regexmodid = '/{loadmoduleid\s([1-9][0-9]*)}/i';
+		$regexmodid = '/{loadmoduleid\s([1-9][0-9]*.*?)}/i';
 
 		// Find all instances of plugin and put in $matches for loadposition
 		// $matches[0] is full pattern match, $matches[1] is the position
@@ -129,8 +129,15 @@ class PlgContentLoadmodule extends JPlugin
 		{
 			foreach ($matchesmodid as $match)
 			{
-				$id     = trim($match[1]);
-				$output = $this->_loadid($id);
+				$matchesidlist = explode(',', $match[1]);
+				$id     = trim($matchesidlist[0]);
+				// We may not have a module style so fall back to the plugin default.
+				if (!array_key_exists(1, $matchesidlist))
+				{
+					$matchesidlist[1] = $style;
+				}
+				$style    = trim($matchesidlist[1]);
+				$output = $this->_loadid($id, $style);
 
 				// We should replace only first occurrence in order to allow positions with the same name to regenerate their content:
 				$article->text = preg_replace("|$match[0]|", addcslashes($output, '\\$'), $article->text, 1);
@@ -217,13 +224,13 @@ class PlgContentLoadmodule extends JPlugin
 	 *
 	 * @since   3.9.0
 	 */
-	protected function _loadid($id)
+	protected function _loadid($id $style = 'none')
 	{
 		self::$modules[$id] = '';
 		$document = JFactory::getDocument();
 		$renderer = $document->loadRenderer('module');
 		$modules  = JModuleHelper::getModuleById($id);
-		$params   = array('style' => 'none');
+		$params = array('style' => $style);
 		ob_start();
 
 		if ($modules->id > 0)


### PR DESCRIPTION
loadmoduleid plugin keyword changed to get the module chrome style.

Pull Request for Issue # .

### Summary of Changes

Changed to allow the chrome style with loadmoduleid keyword

### Testing Instructions



### Expected result
The chrome style should change if the plugin parameter changes or a 2nd argument is defined. 


### Actual result

Nothing changes always the none chrome is render.

### Documentation Changes Required
