### PR TITLE
[4.0] Changelog: Correcting RTL display for the changelog modal

### DIFF
--- a/administrator/templates/atum/scss/template-rtl.scss
+++ b/administrator/templates/atum/scss/template-rtl.scss
@@ -298,3 +298,21 @@ body {
   border-left: 0 !important;
   border-right: 1px solid var(--border);
 }
+
+// Changelog modal override
+.changelog {
+  text-align: right !important;
+
+  &__tag {
+    text-align: left;
+  }
+
+  &__list {
+
+    ul {
+      padding-left: auto;
+      padding-right: 15px;
+    }
+  }
+}
+

--- a/administrator/templates/atum/scss/template-rtl.scss
+++ b/administrator/templates/atum/scss/template-rtl.scss
@@ -310,8 +310,8 @@ body {
   &__list {
 
     ul {
-      padding-left: auto;
       padding-right: 15px;
+      padding-left: auto;
     }
   }
 }


### PR DESCRIPTION
### Summary of Changes
Adding overrides to Atum rtl.css to correct the display of the changelog modal


### Testing Instructions
Install the component https://github.com/roland-d/component_joomla/releases/tag/v0.0.2
Install Persian language (fa-IR)
Then go to `administrator/index.php?option=com_installer&view=update` and click on the Changelog button
First with en-GB as backend language, then with Persian

### LTR Reference display  (with en-GB)
<img width="872" alt="Screen Shot 2019-05-31 at 17 00 29" src="https://user-images.githubusercontent.com/869724/58714734-a2860980-83c5-11e9-8e2b-df95fa89f5e6.png">


### RTL Before patch (Changelog string added in fa-IR)
<img width="930" alt="Screen Shot 2019-05-31 at 16 56 42" src="https://user-images.githubusercontent.com/869724/58714526-33101a00-83c5-11e9-8110-701fec66a5d1.png">


### RTL After patch
<img width="882" alt="Screen Shot 2019-05-31 at 16 54 55" src="https://user-images.githubusercontent.com/869724/58714557-44592680-83c5-11e9-8540-3a53c77f206d.png">


@roland-d @SharkyKZ 
