### PR TITLE
[4.0] Fix install sample data

### DIFF
--- a/administrator/components/com_content/Model/ArticleModel.php
+++ b/administrator/components/com_content/Model/ArticleModel.php
@@ -1087,7 +1087,7 @@ class ArticleModel extends AdminModel
 	}
 
 	/**
-	 * Allows preprocessing of the \JForm object.
+	 * Allows preprocessing of the Form object.
 	 *
 	 * @param   Form    $form   The form object
 	 * @param   array   $data   The data to be merged into the form object
@@ -1097,7 +1097,7 @@ class ArticleModel extends AdminModel
 	 *
 	 * @since   3.0
 	 */
-	protected function preprocessForm(\JForm $form, $data, $group = 'content')
+	protected function preprocessForm(Form $form, $data, $group = 'content')
 	{
 		if ($this->canCreateCategory())
 		{


### PR DESCRIPTION

### Summary of Changes
Fix installing blog sample data. 


### Testing Instructions
In the Control Panel, install `Blog Sample Data`.
Progress bar hangs.

Code review.

### Actual result
> PHP Warning:  Declaration of Joomla\Component\Content\Administrator\Model\ArticleModel::preprocessForm(JForm $form, $data, $group = 'content') should be compatible with Joomla\CMS\MVC\Model\FormModel::preprocessForm(Joomla\CMS\Form\Form $form, $data, $group = 'content') in \administrator\components\com_content\Model\ArticleModel.php on line 1355



### Documentation Changes Required

