### PR TITLE
[4.0] Removing base tag from frontend

### DIFF
--- a/libraries/src/Application/SiteApplication.php
+++ b/libraries/src/Application/SiteApplication.php
@@ -171,11 +171,6 @@ final class SiteApplication extends CMSApplication
 
 				$document->setMetaData('rights', $this->get('MetaRights'));
 
-				if ($this->get('sef'))
-				{
-					$document->setBase(htmlspecialchars(Uri::current()));
-				}
-
 				// Get the template
 				$template = $this->getTemplate(true);
 

--- a/libraries/src/Application/SiteApplication.php
+++ b/libraries/src/Application/SiteApplication.php
@@ -183,6 +183,7 @@ final class SiteApplication extends CMSApplication
 					->addRegistryFile('media/' . $component . '/joomla.asset.json')
 					->addRegistryFile('templates/' . $template->template . '/joomla.asset.json');
 
+
 				break;
 
 			case 'feed':


### PR DESCRIPTION
Pull Request for Issue #9010.

This is a new version of #25077, since the CI system somehow fails with that earlier PR.

### Summary of Changes
This removes the base tag from the frontend. The idea of the base tag is to define a base for relative URLs. Consider you have the site http://www.example.com/this/is/index.php/with/more/content and all requests should go to the folder http://www.example.com/this/is/, you would set the base tag to exactly that URL. However, we are setting that base tag always to the current URL, which simply is wrong. Even worse, we aren't doing it correctly, because we are forgetting the query part. So we are not setting it to a special path, but are just using the current URL. Now guess what the default value is, when that base tag is NOT set at all. The answer is not "42", but: The current URL. 

A quick check shows that neither Wordpress nor Drupal or Typo3 seem to have a base tag in their default output. We are just oh-so-special... Sorry...

### Testing Instructions
Apply this change and then check if everything on your site still works as expected. 

This would be a fix for an issue that is over 3 years old and that has been discussed several times in the Joomla project... Would be nice to finally solve that.