### PR TITLE
[4.0] mod_banners does not load 'bannerclient' field type

### DIFF
--- a/modules/mod_banners/mod_banners.xml
+++ b/modules/mod_banners/mod_banners.xml
@@ -24,7 +24,7 @@
 		<fields name="params">
 			<fieldset
 				name="basic"
-				addfieldpath="/administrator/components/com_banners/models/fields"
+				addfieldprefix="Joomla\Component\Banners\Administrator\Field"
 				>
 
 				<field


### PR DESCRIPTION
### Summary of Changes
As title says


### Testing Instructions
Edit mod_banners module
Client field is displaying a text field.


### Before patch
![Screen Shot 2019-06-03 at 11 24 21](https://user-images.githubusercontent.com/869724/58791320-4522d000-85f2-11e9-9a83-4337f3743911.png)

### After patch
![Screen Shot 2019-06-03 at 11 23 04](https://user-images.githubusercontent.com/869724/58791338-4f44ce80-85f2-11e9-94ce-b1c3938c3e25.png)




### Documentation Changes Required

