### PR TITLE
Use published date in the category feed view

### DIFF
--- a/libraries/src/MVC/View/CategoryFeedView.php
+++ b/libraries/src/MVC/View/CategoryFeedView.php
@@ -38,17 +38,20 @@ class CategoryFeedView extends HtmlView
 		$ucmRow = $ucmType->getTypeByAlias($contentType);
 		$ucmMapCommon = json_decode($ucmRow->field_mappings)->common;
 		$createdField = null;
+		$publishedField = null;
 		$titleField = null;
 
 		if (is_object($ucmMapCommon))
 		{
 			$createdField = $ucmMapCommon->core_created_time;
 			$titleField = $ucmMapCommon->core_title;
+			$publishedField = $ucmMapCommon->core_publish_up;
 		}
 		elseif (is_array($ucmMapCommon))
 		{
 			$createdField = $ucmMapCommon[0]->core_created_time;
 			$titleField = $ucmMapCommon[0]->core_title;
+			$publishedField = $ucmMapCommon[0]->core_publish_up;
 		}
 
 		$document->link = \JRoute::_(\JHelperRoute::getCategoryRoute($app->input->getInt('id'), $language = 0, $extension));
@@ -97,7 +100,11 @@ class CategoryFeedView extends HtmlView
 			$description = $item->description;
 			$author      = $item->created_by_alias ?: $item->author;
 
-			if ($createdField)
+			if ($publishedField && isset($item->$publishedField) && $item->$publishedField !== \JFactory::getDbo()->getNullDate())
+			{
+				$date = date('r', strtotime($item->$publishedField));
+			}
+			elseif ($createdField)
 			{
 				$date = isset($item->$createdField) ? date('r', strtotime($item->$createdField)) : '';
 			}


### PR DESCRIPTION
Pull Request for Issue #20885 .
Recreated [#21684 PR](https://github.com/joomla/joomla-cms/pull/21684) for 3.10-dev branch.
(Also old PR was suddeny closed)

### Summary of Changes

`libraries/src/MVC/View/CategoryFeedView.php`

### Testing Instructions

Access feed and check published date is used instead of creation date (when set) and that it falls back to creation date when the published date isn't set

### Expected result

Use published date in the category feed view instead of creation date. For example, for RSS 2.0, in `<pubDate>` creation date is used.

### Actual result

Use published date in the category feed, for eaxample, for RSS 2.0, in `<pubDate>`.

### Documentation Changes Required

Nothing to change