### PR TITLE
[4.0] useCoreUI

### DIFF
--- a/components/com_content/tmpl/form/edit.php
+++ b/components/com_content/tmpl/form/edit.php
@@ -23,6 +23,7 @@ HTMLHelper::_('script', 'com_content/form-edit.js', ['version' => 'auto', 'relat
 
 $this->tab_name = 'com-content-form';
 $this->ignore_fieldsets = array('image-intro', 'image-full', 'jmetadata', 'item_associations');
+$this->useCoreUI = true;
 
 // Create shortcut to parameters.
 $params = $this->state->get('params');


### PR DESCRIPTION
If we are using uitab and using the joomla.edit.params layout we need to set `$this->useCoreUI = true;
` to allow rendering extra tabs

See https://github.com/joomla/joomla-cms/pull/25100#discussion_r289882872
