### PR TITLE
[4.0] Remove default class from tag form

### DIFF
--- a/administrator/components/com_tags/forms/tag.xml
+++ b/administrator/components/com_tags/forms/tag.xml
@@ -225,7 +225,6 @@
 				label="COM_TAGS_FIELD_TAG_LINK_CLASS"
 				labelclass="control-label"
 				size="20"
-				default="label label-info"
 			/>
 
 		</fieldset>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This removes default `label label-info` class from tag form. No reason to force a class for every tag to be saved, we use a fallback in the layout anyways.

### Testing Instructions

Can be merged on review.

### Documentation Changes Required

IDK.