### PR TITLE
[4.0] Remove control-label class from form field labels

### DIFF
--- a/administrator/components/com_banners/forms/banner.xml
+++ b/administrator/components/com_banners/forms/banner.xml
@@ -73,7 +73,6 @@
 			label="JGLOBAL_FIELD_VERSION_NOTE_LABEL"
 			maxlength="255"
 			size="45"
-			labelclass="control-label"
 		/>
 
 		<field

--- a/administrator/components/com_banners/forms/client.xml
+++ b/administrator/components/com_banners/forms/client.xml
@@ -54,7 +54,6 @@
 			label="JGLOBAL_FIELD_VERSION_NOTE_LABEL"
 			maxlength="255"
 			size="45"
-			labelclass="control-label"
 		/>
 
 		<field

--- a/administrator/components/com_contact/forms/contact.xml
+++ b/administrator/components/com_contact/forms/contact.xml
@@ -32,7 +32,6 @@
 			name="version_note"
 			type="text"
 			label="JGLOBAL_FIELD_VERSION_NOTE_LABEL"
-			labelclass="control-label"
 			size="45"
 			maxlength="255"
 		/>

--- a/administrator/components/com_newsfeeds/forms/newsfeed.xml
+++ b/administrator/components/com_newsfeeds/forms/newsfeed.xml
@@ -71,7 +71,6 @@
 			name="version_note"
 			type="text"
 			label="JGLOBAL_FIELD_VERSION_NOTE_LABEL"
-			labelclass="control-label"
 			size="45"
 			maxlength="255"
 		/>

--- a/administrator/components/com_tags/forms/tag.xml
+++ b/administrator/components/com_tags/forms/tag.xml
@@ -150,7 +150,6 @@
 		name="created_by_alias"
 		type="text"
 		label="JGLOBAL_FIELD_CREATED_BY_ALIAS_LABEL"
-		labelclass="control-label"
 		size="20"
 	/>
 
@@ -199,7 +198,6 @@
 		label="JGLOBAL_FIELD_VERSION_NOTE_LABEL"
 		maxlength="255"
 		size="45"
-		labelclass="control-label"
 	/>
 
 	<fields name="params" label="JGLOBAL_FIELDSET_DISPLAY_OPTIONS">
@@ -213,7 +211,6 @@
 				type="componentlayout"
 				label="JFIELD_ALT_LAYOUT_LABEL"
 				class="custom-select"
-				labelclass="control-label"
 				useglobal="true"
 				extension="com_tags"
 				view="tag"
@@ -223,7 +220,6 @@
 				name="tag_link_class"
 				type="text"
 				label="COM_TAGS_FIELD_TAG_LINK_CLASS"
-				labelclass="control-label"
 				size="20"
 				default="label label-info"
 			/>
@@ -237,14 +233,12 @@
 				name="image_intro"
 				type="media"
 				label="COM_TAGS_FIELD_INTRO_LABEL"
-				labelclass="control-label"
 			/>
 
 			<field
 				name="float_intro"
 				type="list"
 				label="COM_TAGS_FLOAT_LABEL"
-				labelclass="control-label"
 				>
 				<option value="">JGLOBAL_SELECT_AN_OPTION</option>
 				<option value="right">COM_TAGS_RIGHT</option>
@@ -256,7 +250,6 @@
 				name="image_intro_alt"
 				type="text"
 				label="COM_TAGS_FIELD_IMAGE_ALT_LABEL"
-				labelclass="control-label"
 				size="20"
 			/>
 
@@ -265,7 +258,6 @@
 				type="text"
 				label="COM_TAGS_FIELD_IMAGE_CAPTION_LABEL"
 				size="20"
-				labelclass="control-label"
 			/>
 
 			<field
@@ -278,14 +270,12 @@
 				name="image_fulltext"
 				type="media"
 				label="COM_TAGS_FIELD_FULL_LABEL"
-				labelclass="control-label"
 			/>
 
 			<field
 				name="float_fulltext"
 				type="list"
 				label="COM_TAGS_FLOAT_LABEL"
-				labelclass="control-label"
 				>
 				<option value="">JGLOBAL_SELECT_AN_OPTION</option>
 				<option value="right">COM_TAGS_RIGHT</option>
@@ -297,7 +287,6 @@
 				name="image_fulltext_alt"
 				type="text"
 				label="COM_TAGS_FIELD_IMAGE_ALT_LABEL"
-				labelclass="control-label"
 				size="20"
 			/>
 
@@ -305,7 +294,6 @@
 				name="image_fulltext_caption"
 				type="text"
 				label="COM_TAGS_FIELD_IMAGE_CAPTION_LABEL"
-				labelclass="control-label"
 				size="20"
 			/>
 		</fieldset>

--- a/administrator/components/com_users/forms/note.xml
+++ b/administrator/components/com_users/forms/note.xml
@@ -134,7 +134,6 @@
 			label="JGLOBAL_FIELD_VERSION_NOTE_LABEL"
 			maxlength="255"
 			size="45"
-			labelclass="control-label"
 		/>
 	</fieldset>
 </form>

--- a/components/com_content/forms/article.xml
+++ b/components/com_content/forms/article.xml
@@ -9,7 +9,7 @@
 			id="id"
 			size="10"
 			default="0"
-			readonly="true" 
+			readonly="true"
 		/>
 
 		<field
@@ -23,7 +23,7 @@
 		<field
 			name="asset_id"
 			type="hidden"
-			filter="unset" 
+			filter="unset"
 		/>
 
 		<field
@@ -33,7 +33,7 @@
 			id="title"
 			class="inputbox"
 			size="30"
-			required="true" 
+			required="true"
 		/>
 
 		<field
@@ -43,7 +43,7 @@
 			id="alias"
 			hint="JFIELD_ALIAS_PLACEHOLDER"
 			class="inputbox"
-			size="45" 
+			size="45"
 		/>
 
 		<field
@@ -93,14 +93,14 @@
 			type="calendar"
 			translateformat="true"
 			id="created"
-			filter="unset" 
+			filter="unset"
 		/>
 
 		<field
 			name="created_by"
 			type="text"
 			id="created_by"
-			filter="unset" 
+			filter="unset"
 		/>
 
 		<field
@@ -109,7 +109,7 @@
 			label="JGLOBAL_FIELD_CREATED_BY_ALIAS_LABEL"
 			id="created_by_alias"
 			class="inputbox"
-			size="20" 
+			size="20"
 		/>
 
 		<field
@@ -128,7 +128,6 @@
 			class="inputbox"
 			maxlength="255"
 			size="45"
-			labelclass="control-label" 
 		/>
 
 		<field
@@ -164,7 +163,7 @@
 			<option value="*">JALL</option>
 		</field>
 
-		<field 
+		<field
 			name="tags"
 			type="tag"
 			label="JTAG"
@@ -190,7 +189,7 @@
 			id="metadesc"
 			class="inputbox"
 			rows="5"
-			cols="50" 
+			cols="50"
 		/>
 
 		<field
@@ -199,7 +198,7 @@
 			label="JFIELD_ACCESS_LABEL"
 			id="access"
 			class="inputbox"
-			size="1" 
+			size="1"
 		/>
 
 		<field
@@ -207,7 +206,7 @@
 			type="captcha"
 			label="COM_CONTENT_CAPTCHA_LABEL"
 			validate="captcha"
-			namespace="article" 
+			namespace="article"
 		/>
 	</fieldset>
 		<fields name="images">
@@ -217,23 +216,23 @@
 				type="media"
 				label="COM_CONTENT_FIELD_INTRO_LABEL"
 			/>
-			
-			<field 
+
+			<field
 				name="image_intro_alt"
 				type="text"
 				label="COM_CONTENT_FIELD_IMAGE_ALT_LABEL"
 				class="inputbox"
-				size="20" 
+				size="20"
 			/>
-			
-			<field 
+
+			<field
 				name="image_intro_caption"
 				type="text"
 				label="COM_CONTENT_FIELD_IMAGE_CAPTION_LABEL"
 				class="inputbox"
-				size="20" 
+				size="20"
 			/>
-			
+
 			<field
 				name="float_intro"
 				type="list"
@@ -251,23 +250,23 @@
 				type="media"
 				label="COM_CONTENT_FIELD_FULL_LABEL"
 			/>
-			
-			<field 
+
+			<field
 				name="image_fulltext_alt"
 				type="text"
 				label="COM_CONTENT_FIELD_IMAGE_ALT_LABEL"
 				class="inputbox"
-				size="20" 
+				size="20"
 			/>
-			
-			<field 
+
+			<field
 				name="image_fulltext_caption"
 				type="text"
 				label="COM_CONTENT_FIELD_IMAGE_CAPTION_LABEL"
 				class="inputbox"
-				size="20" 
+				size="20"
 			/>
-			
+
 			<field
 				name="float_fulltext"
 				type="list"
@@ -290,14 +289,14 @@
 			relative="true"
 		/>
 
-		<field 
+		<field
 			name="urlatext"
 			type="text"
 			label="COM_CONTENT_FIELD_URLA_LINK_TEXT_LABEL"
 			class="inputbox"
-			size="20" 
+			size="20"
 		/>
-		
+
 		<field
 			name="targeta"
 			type="hidden"
@@ -312,19 +311,19 @@
 			relative="true"
 		/>
 
-		<field 
+		<field
 			name="urlbtext"
 			type="text"
 			label="COM_CONTENT_FIELD_URLB_LINK_TEXT_LABEL"
 			class="inputbox"
-			size="20" 
+			size="20"
 		/>
-		
+
 		<field
 			name="targetb"
 			type="hidden"
 		/>
-		
+
 		<field
 			name="urlc"
 			type="url"
@@ -339,25 +338,24 @@
 			type="text"
 			label="COM_CONTENT_FIELD_URLC_LINK_TEXT_LABEL"
 			class="inputbox"
-			size="20" 
+			size="20"
 		/>
-		
+
 		<field
 			name="targetc"
 			type="hidden"
 		/>
 	</fields>
 	<fields name="metadata">
-		<fieldset 
+		<fieldset
 			name="jmetadata"
 			label="JGLOBAL_FIELDSET_METADATA_OPTIONS">
 
-				<field 
+				<field
 					name="robots"
 					type="hidden"
 					label="JFIELD_METADATA_ROBOTS_LABEL"
 					filter="unset"
-					labelclass="control-label"
 					>
 					<option value="">JGLOBAL_USE_GLOBAL</option>
 					<option value="index, follow">JGLOBAL_INDEX_FOLLOW</option>
@@ -366,24 +364,22 @@
 					<option value="noindex, nofollow">JGLOBAL_NOINDEX_NOFOLLOW</option>
 				</field>
 
-				<field 
+				<field
 					name="author"
 					type="hidden"
 					label="JAUTHOR"
 					filter="unset"
 					size="20"
-					labelclass="control-label"
 				/>
 
-				<field 
+				<field
 					name="rights"
 					type="hidden"
 					label="JFIELD_META_RIGHTS_LABEL"
 					filter="unset"
-					labelclass="control-label"
 				/>
 
-				<field 
+				<field
 					name="xreference"
 					type="hidden"
 					label="COM_CONTENT_FIELD_XREFERENCE_LABEL"
@@ -391,7 +387,6 @@
 					filter="unset"
 					class="inputbox"
 					size="20"
-					labelclass="control-label" 
 				/>
 
 		</fieldset>


### PR DESCRIPTION
### Summary of Changes

This removes `control-label` class from field labels. We already use this class on label wrapper. Don't need to add it to label directly.

![labelclass](https://user-images.githubusercontent.com/7325021/58859400-5e8b5100-86b2-11e9-91fc-c641aae06823.png)

### Documentation Changes Required

No.