### PR TITLE
[4.0] Deleting apcu-7.3.ini

### DIFF
--- a/build/travis/phpenv/apcu-7.3.ini
+++ b/build/travis/phpenv/apcu-7.3.ini
@@ -1,2 +1,0 @@
-apc.enabled=true
-apc.enable_cli=true


### PR DESCRIPTION
We are not using Travis anymore, thus deleting this file.