### PR TITLE
[4.0] Fix warning with cache enabled

### DIFF
--- a/libraries/src/Document/Renderer/Html/ModuleRenderer.php
+++ b/libraries/src/Document/Renderer/Html/ModuleRenderer.php
@@ -87,7 +87,7 @@ class ModuleRenderer extends DocumentRenderer
 			// Default to itemid creating method and workarounds on
 			$cacheparams = new \stdClass;
 			$cacheparams->cachemode = $cachemode;
-			$cacheparams->class = 'ModuleHelper';
+			$cacheparams->class = ModuleHelper::class;
 			$cacheparams->method = 'renderModule';
 			$cacheparams->methodparams = array($module, $attribs);
 


### PR DESCRIPTION
### Summary of Changes

Fixes warning with cache enabled.

### Testing Instructions

Enable conservative cache in global configuration.

### Expected result

No warnings.

### Actual result

> Warning: call_user_func_array() expects parameter 1 to be a valid callback, class 'ModuleHelper' not found in libraries\src\Cache\Controller\CallbackController.php

### Documentation Changes Required

No.