### PR TITLE
[4.0] Fix saving custom fields without params

### DIFF
--- a/administrator/components/com_fields/Table/FieldTable.php
+++ b/administrator/components/com_fields/Table/FieldTable.php
@@ -132,6 +132,11 @@ class FieldTable extends Table
 			$this->type = 'text';
 		}
 
+		if (empty($this->fieldparams))
+		{
+			$this->fieldparams = '{}';
+		}
+
 		$date = Factory::getDate();
 		$user = Factory::getUser();
 


### PR DESCRIPTION
Pull Request for Issue #25080 .

### Summary of Changes

Sets `fieldparams` value if no value is set.

### Testing Instructions

Create a new `Color` custom field.

### Expected result

Field saved. 

### Actual result

Save failed with the following error: Field 'fieldparams' doesn't have a default value

### Documentation Changes Required

No.