### PR TITLE
[4.0] Media Manager icons in 2 columns

### DIFF
--- a/administrator/components/com_media/resources/styles/components/_media-browser.scss
+++ b/administrator/components/com_media/resources/styles/components/_media-browser.scss
@@ -137,6 +137,8 @@
     list-style: none;
     padding: 0;
     margin: 0;
+    columns: 2;
+    column-gap: 5px;
   }
 }
 


### PR DESCRIPTION
Alternative PR to #24423

With the icons in 1 column they break out of the image and hover over the next row. This pr splits the list into 2 columns. This is done purely with css. It is still just one list so there is no a11y issue.

### Testing Instructions
can not be tested with patchtester - requires npm to rebuild the css
dont forget to clear the browser cache


### Expected result
![image](https://user-images.githubusercontent.com/1296369/58918048-9af59600-8720-11e9-8aee-c35ce1b54711.png)

