### PR TITLE
Fix actionlogs when making a state change in the content list view

### DIFF
--- a/administrator/components/com_content/Model/ArticleModel.php
+++ b/administrator/components/com_content/Model/ArticleModel.php
@@ -1348,7 +1348,7 @@ class ArticleModel extends AdminModel
 		PluginHelper::importPlugin($this->events_map['change_state']);
 
 		// Trigger the change stage event.
-		Factory::getApplication()->triggerEvent($this->event_change_state, [$context, [$pk], $transition_id]);
+		Factory::getApplication()->triggerEvent($this->event_change_state, [$context, [$pk], $workflow->getConditionForTransition($transition_id)]);
 
 		return true;
 	}

--- a/libraries/src/Workflow/Workflow.php
+++ b/libraries/src/Workflow/Workflow.php
@@ -11,6 +11,7 @@ namespace Joomla\CMS\Workflow;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Factory;
+use Joomla\Database\ParameterType;
 use Joomla\Utilities\ArrayHelper;
 
 /**
@@ -225,6 +226,27 @@ class Workflow
 		}
 
 		return $success;
+	}
+
+	/**
+	 * Gets the condition (i.e. state value) for a transition
+	 *
+	 * @param   integer  $transition_id  The transition id to get the condition of
+	 *
+	 * @return  null|int  Integer if transition exists. Otherwise null
+	 */
+	public function getConditionForTransition($transition_id)
+	{
+		$db = Factory::getDbo();
+		$query = $db->getQuery(true);
+		$query->select($db->quoteName('s.condition'))
+			->from($db->quoteName('#__workflow_transitions', 't'))
+			->join('LEFT', $db->quoteName('#__workflow_stages', 's'), $db->quoteName('s.id') . ' = ' . $db->quoteName('t.to_stage_id'))
+			->where($db->quoteName('t.id') . ' = :transition_id')
+			->bind(':transition_id', $transition_id, ParameterType::INTEGER);
+		$db->setQuery($query);
+
+		return $db->loadResult();
 	}
 
 	/**


### PR DESCRIPTION
### Summary of Changes
Fixes the incorrect parameter being passed to the `onContentChangeState` event where we passed the transition ID instead of the state value to the event as the 3rd param.

### Testing Instructions
Make a state change in the list view of com_content - before you get non-sensical results (sometimes empty string - sometimes the wrong state - depending on which transition you run) in the action log menu in the dashboard - after patch appliedyou get the correct messages for the state transition

### Documentation Changes Required
None
