### PR TITLE
[4.0] Fix reference in tos field

### DIFF
--- a/plugins/user/profile/field/tos.php
+++ b/plugins/user/profile/field/tos.php
@@ -97,7 +97,7 @@ class JFormFieldTos extends \Joomla\CMS\Form\Field\RadioField
 
 			if (Associations::isEnabled())
 			{
-				$tosAssociated = Associations::getAssociations('com_content', '#__content', 'com_content.item', $tosarticle);
+				$tosAssociated = Associations::getAssociations('com_content', '#__content', 'com_content.item', $tosArticle);
 			}
 
 			$currentLang = Factory::getLanguage()->getTag();


### PR DESCRIPTION
While doing #22295, PHPStorm reported this variable as not existent, its camelcase.