### PR TITLE
[4.0] Fix History Versions Modal display

### DIFF
--- a/administrator/components/com_banners/tmpl/banner/edit.php
+++ b/administrator/components/com_banners/tmpl/banner/edit.php
@@ -17,6 +17,7 @@ use Joomla\CMS\Router\Route;
 HTMLHelper::_('behavior.formvalidator');
 
 HTMLHelper::_('script', 'com_banners/admin-banner-edit.min.js', array('version' => 'auto', 'relative' => true));
+HTMLHelper::_('script', 'com_contenthistory/admin-history-versions.js', ['version' => 'auto', 'relative' => true]);
 ?>
 
 <form action="<?php echo Route::_('index.php?option=com_banners&layout=edit&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="banner-form" class="form-validate">

--- a/administrator/components/com_banners/tmpl/client/edit.php
+++ b/administrator/components/com_banners/tmpl/client/edit.php
@@ -15,6 +15,7 @@ use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
 HTMLHelper::_('behavior.formvalidator');
+HTMLHelper::_('script', 'com_contenthistory/admin-history-versions.js', ['version' => 'auto', 'relative' => true]);
 ?>
 
 <form action="<?php echo Route::_('index.php?option=com_banners&layout=edit&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="client-form" class="form-validate">

--- a/administrator/components/com_categories/tmpl/category/edit.php
+++ b/administrator/components/com_categories/tmpl/category/edit.php
@@ -19,6 +19,8 @@ use Joomla\CMS\Router\Route;
 HTMLHelper::_('behavior.formvalidator');
 HTMLHelper::_('behavior.keepalive');
 
+HTMLHelper::_('script', 'com_contenthistory/admin-history-versions.js', ['version' => 'auto', 'relative' => true]);
+
 $app = Factory::getApplication();
 $input = $app->input;
 

--- a/administrator/components/com_contact/tmpl/contact/edit.php
+++ b/administrator/components/com_contact/tmpl/contact/edit.php
@@ -19,6 +19,8 @@ use Joomla\CMS\Router\Route;
 HTMLHelper::_('behavior.formvalidator');
 HTMLHelper::_('behavior.keepalive');
 
+HTMLHelper::_('script', 'com_contenthistory/admin-history-versions.js', ['version' => 'auto', 'relative' => true]);
+
 $app = Factory::getApplication();
 $input = $app->input;
 

--- a/administrator/components/com_content/tmpl/article/edit.php
+++ b/administrator/components/com_content/tmpl/article/edit.php
@@ -20,6 +20,8 @@ use Joomla\Registry\Registry;
 HTMLHelper::_('behavior.formvalidator');
 HTMLHelper::_('behavior.keepalive');
 
+HTMLHelper::_('script', 'com_contenthistory/admin-history-versions.js', ['version' => 'auto', 'relative' => true]);
+
 $this->configFieldsets  = array('editorConfig');
 $this->hiddenFieldsets  = array('basic-limited');
 $this->ignore_fieldsets = array('jmetadata', 'item_associations');

--- a/administrator/components/com_newsfeeds/tmpl/newsfeed/edit.php
+++ b/administrator/components/com_newsfeeds/tmpl/newsfeed/edit.php
@@ -18,6 +18,7 @@ use Joomla\CMS\Router\Route;
 
 HTMLHelper::_('behavior.formvalidator');
 HTMLHelper::_('behavior.keepalive');
+HTMLHelper::_('script', 'com_contenthistory/admin-history-versions.js', ['version' => 'auto', 'relative' => true]);
 
 $app   = Factory::getApplication();
 $input = $app->input;

--- a/administrator/components/com_tags/tmpl/tag/edit.php
+++ b/administrator/components/com_tags/tmpl/tag/edit.php
@@ -18,6 +18,8 @@ HTMLHelper::_('behavior.formvalidator');
 HTMLHelper::_('behavior.keepalive');
 HTMLHelper::_('behavior.tabstate');
 
+HTMLHelper::_('script', 'com_contenthistory/admin-history-versions.js', ['version' => 'auto', 'relative' => true]);
+
 // Fieldsets to not automatically render by /layouts/joomla/edit/params.php
 $this->ignore_fieldsets = array('jmetadata');
 $this->useCoreUI = true;

--- a/administrator/components/com_users/tmpl/note/edit.php
+++ b/administrator/components/com_users/tmpl/note/edit.php
@@ -13,6 +13,8 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Router\Route;
 
 HTMLHelper::_('behavior.formvalidator');
+
+HTMLHelper::_('script', 'com_contenthistory/admin-history-versions.js', ['version' => 'auto', 'relative' => true]);
 ?>
 <form action="<?php echo Route::_('index.php?option=com_users&view=note&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="note-form" class="form-validate">
 	<fieldset class="adminform">

--- a/build/media_source/com_contenthistory/js/admin-history-versions.es5.js
+++ b/build/media_source/com_contenthistory/js/admin-history-versions.es5.js
@@ -1,0 +1,7 @@
+/**
+ * @copyright  Copyright (C) 2005 - 2019 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+window.addEventListener('DOMContentLoaded', function() {
+	document.body.appendChild(document.getElementById('versionsModal'));
+});


### PR DESCRIPTION
Alternative to https://github.com/joomla/joomla-cms/pull/24369

### Summary of Changes
Adding a new com_contenthistory js to prevent the modal from being hidden by back.
Loading the js ONLY when necessary (i.e. in edit views)
com_banner banner
com_banner client
com_categories category
com_contacts contact
com_content article
com_newsfeeds newsfeed
com_tags tag
com_users note


### Testing Instructions
patch and npm ci


### Before patch
<img width="1177" alt="Screen Shot 2019-06-09 at 09 12 20" src="https://user-images.githubusercontent.com/869724/59156132-bd780e00-8a96-11e9-8a8c-7532a2d6c6ca.png">


### After patch


<img width="1165" alt="Screen Shot 2019-06-09 at 09 10 10" src="https://user-images.githubusercontent.com/869724/59156115-6d994700-8a96-11e9-8b43-4bbd5314c6dc.png">

### Note 
did it as es5.js Welcome help doing it as es6.js
