### PR TITLE
Small generic cleanups

### DIFF
--- a/components/com_banners/Controller/DisplayController.php
+++ b/components/com_banners/Controller/DisplayController.php
@@ -33,6 +33,7 @@ class DisplayController extends BaseController
 
 		if ($id)
 		{
+			/** @var \Joomla\Component\Banners\Site\Model\BannerModel $model */
 			$model = $this->getModel('Banner', 'Site', array('ignore_request' => true));
 			$model->setState('banner.id', $id);
 			$model->click();

--- a/components/com_banners/Model/BannerModel.php
+++ b/components/com_banners/Model/BannerModel.php
@@ -38,6 +38,7 @@ class BannerModel extends BaseDatabaseModel
 	 * @return  void
 	 *
 	 * @since   1.5
+	 * @throws  \Exception
 	 */
 	public function click()
 	{
@@ -45,7 +46,7 @@ class BannerModel extends BaseDatabaseModel
 
 		if (empty($item))
 		{
-			throw new Exception(Text::_('JERROR_PAGE_NOT_FOUND'), 404);
+			throw new \Exception(Text::_('JERROR_PAGE_NOT_FOUND'), 404);
 		}
 
 		$id = $this->getState('banner.id');
@@ -154,7 +155,7 @@ class BannerModel extends BaseDatabaseModel
 	{
 		if (!isset($this->_item))
 		{
-			/** @var \JCacheControllerCallback $cache */
+			/** @var \Joomla\CMS\Cache\Controller\CallbackController $cache */
 			$cache = Factory::getCache('com_banners', 'callback');
 
 			$id = $this->getState('banner.id');

--- a/components/com_banners/Model/BannersModel.php
+++ b/components/com_banners/Model/BannersModel.php
@@ -224,6 +224,7 @@ class BannersModel extends ListModel
 	 * @return  void
 	 *
 	 * @since   1.6
+	 * @throws  \Exception
 	 */
 	public function impress()
 	{

--- a/libraries/src/MVC/Controller/BaseController.php
+++ b/libraries/src/MVC/Controller/BaseController.php
@@ -381,7 +381,7 @@ class BaseController implements ControllerInterface
 		}
 
 		// Determine the methods to exclude from the base class.
-		$xMethods = get_class_methods('\JControllerLegacy');
+		$xMethods = get_class_methods('\\Joomla\\CMS\\MVC\\Controller\\BaseController');
 
 		// Get the public methods in this class using reflection.
 		$r = new \ReflectionClass($this);

--- a/libraries/src/Table/Category.php
+++ b/libraries/src/Table/Category.php
@@ -14,8 +14,6 @@ use Joomla\CMS\Access\Rules;
 use Joomla\CMS\Application\ApplicationHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
-use Joomla\CMS\Table\Observer\ContentHistory;
-use Joomla\CMS\Table\Observer\Tags;
 use Joomla\Database\DatabaseDriver;
 use Joomla\Registry\Registry;
 


### PR DESCRIPTION
- Removes unused imports in the CategoryTable for the removed tags/content history observers
- Adds some typehints in Banners
- Fixes a fatal in banners because we missed the global namespace call from the Exception
- Uses the namespaced class in the BaseController to find the methods