### PR TITLE
[4.0] Fix History Versions Modal display (.es6.js instead of .es5)

### DIFF
--- a/build/media_source/com_contenthistory/js/admin-history-versions.es6.js
+++ b/build/media_source/com_contenthistory/js/admin-history-versions.es6.js
@@ -4,5 +4,8 @@
  */
 
 window.addEventListener('DOMContentLoaded', () => {
-  document.body.appendChild(document.getElementById('versionsModal'));
+  const versionsModal = document.getElementById('versionsModal');
+  if (versionsModal) {
+    document.body.appendChild(versionsModal);
+  }
 });

--- a/build/media_source/com_contenthistory/js/admin-history-versions.es6.js
+++ b/build/media_source/com_contenthistory/js/admin-history-versions.es6.js
@@ -2,6 +2,7 @@
  * @copyright  Copyright (C) 2005 - 2019 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
-window.addEventListener('DOMContentLoaded', function() {
-	document.body.appendChild(document.getElementById('versionsModal'));
+
+window.addEventListener('DOMContentLoaded', () => {
+  document.body.appendChild(document.getElementById('versionsModal'));
 });


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/pull/25147#issuecomment-500205316

### Summary of Changes
Changing js to .es6.js

### Testing Instructions
See https://github.com/joomla/joomla-cms/pull/25147
Apply patch
Make sure the admin-history-versions.es5.js has been deleted in build before running npm

### Expected result
Same as https://github.com/joomla/joomla-cms/pull/25147

@C-Lodder @wilsonge @richard67 