### PR TITLE
[4.0] [PoC] Leverage access check form the plugin loader in to the plugin

### DIFF
--- a/administrator/components/com_plugins/Model/PluginModel.php
+++ b/administrator/components/com_plugins/Model/PluginModel.php
@@ -314,6 +314,16 @@ class PluginModel extends AdminModel
 			$this->helpURL = $helpURL ?: $this->helpURL;
 		}
 
+		$accessField = $xml->xpath('//config/field[name=access]');
+
+		if (!empty($accessField))
+		{
+			if ((string)$accessField[0]['type'] === 'hidden')
+			{
+				$data['access'] = Factory::getApplication()->getConfig('access');
+			}
+		}
+
 		// Trigger the default form events.
 		parent::preprocessForm($form, $data, $group);
 	}

--- a/administrator/components/com_plugins/Model/PluginModel.php
+++ b/administrator/components/com_plugins/Model/PluginModel.php
@@ -318,7 +318,7 @@ class PluginModel extends AdminModel
 
 		if (!empty($accessField))
 		{
-			if ((string)$accessField[0]['type'] === 'hidden')
+			if ((string) $accessField[0]['type'] === 'hidden')
 			{
 				// Override the default access field
 				$form->load($xml, true, '//config/field[@name="access"]');

--- a/administrator/components/com_plugins/Model/PluginModel.php
+++ b/administrator/components/com_plugins/Model/PluginModel.php
@@ -314,13 +314,17 @@ class PluginModel extends AdminModel
 			$this->helpURL = $helpURL ?: $this->helpURL;
 		}
 
-		$accessField = $xml->xpath('//config/field[name=access]');
+		$accessField = $xml->xpath('//config/field[name="access"]');
 
 		if (!empty($accessField))
 		{
 			if ((string)$accessField[0]['type'] === 'hidden')
 			{
-				$data['access'] = Factory::getApplication()->getConfig('access');
+				// Override the default access field
+				$form->load($xml, true, '//config/field[@name="access"]');
+
+				// Always set the value to public if we hide the access field
+				$data->access = Factory::getApplication()->getConfig()->get('access');
 			}
 		}
 

--- a/libraries/src/Extension/ExtensionManagerTrait.php
+++ b/libraries/src/Extension/ExtensionManagerTrait.php
@@ -160,7 +160,7 @@ trait ExtensionManagerTrait
 					$publicAccessLevel = (int) $this->config->get('access');
 					$pluginAccessLevel = (int) PluginHelper::getPlugin($pluginType, $pluginName)->access;
 
-					// if the accesss level is public we don't need to load the user session
+					// If the accesss level is public we don't need to load the user session
 					if ($publicAccessLevel !== $pluginAccessLevel)
 					{
 						$userAccessLevels = $this->getIdentity()->getAuthorisedViewLevels();

--- a/libraries/src/Extension/ExtensionManagerTrait.php
+++ b/libraries/src/Extension/ExtensionManagerTrait.php
@@ -157,11 +157,10 @@ trait ExtensionManagerTrait
 				case PluginInterface::class:
 					list($pluginName, $pluginType) = explode(':', $extensionName);
 
-					$publicAccessLevel = (int) $this->config->get('access');
 					$pluginAccessLevel = (int) PluginHelper::getPlugin($pluginType, $pluginName)->access;
 
 					// If the accesss level is public we don't need to load the user session
-					if ($publicAccessLevel !== $pluginAccessLevel)
+					if ($pluginAccessLevel !== 1)
 					{
 						$userAccessLevels = $this->getIdentity()->getAuthorisedViewLevels();
 

--- a/libraries/src/Plugin/CMSPlugin.php
+++ b/libraries/src/Plugin/CMSPlugin.php
@@ -198,7 +198,7 @@ abstract class CMSPlugin implements DispatcherAwareInterface, PluginInterface
 		$publicAccessLevel = $this->app->getConfig()->get('access');
 		$accessLevel       = $this->params->get('access');
 
-		// if no accesss level is set for the plugin we execute the listener
+		// If no accesss level is set for the plugin we execute the listener
 		if ($publicAccessLevel === $accessLevel)
 		{
 			return $this->accessCheckCache;

--- a/libraries/src/Plugin/CMSPlugin.php
+++ b/libraries/src/Plugin/CMSPlugin.php
@@ -198,7 +198,7 @@ abstract class CMSPlugin implements DispatcherAwareInterface, PluginInterface
 		$publicAccessLevel = $this->app->getConfig()->get('access');
 		$accessLevel       = $this->params->get('access');
 
-		// if no accesss level is set for the plugin we execute the listner
+		// if no accesss level is set for the plugin we execute the listener
 		if ($publicAccessLevel === $accessLevel)
 		{
 			return $this->accessCheckCache;

--- a/libraries/src/Plugin/CMSPlugin.php
+++ b/libraries/src/Plugin/CMSPlugin.php
@@ -201,7 +201,7 @@ abstract class CMSPlugin implements DispatcherAwareInterface, PluginInterface
 		$accessLevel       = $this->params->get('access');
 
 		// if no accesss level is set for the plugin we execute the listner
-		if ($publicAccessLevel = $accessLevel)
+		if ($publicAccessLevel === $accessLevel)
 		{
 			return $this->accessCheckCache;
 		}

--- a/libraries/src/Plugin/CMSPlugin.php
+++ b/libraries/src/Plugin/CMSPlugin.php
@@ -75,6 +75,14 @@ abstract class CMSPlugin implements DispatcherAwareInterface, PluginInterface
 	protected $allowLegacyListeners = true;
 
 	/**
+	 * This is a cache for accessCheck
+	 *
+	 * @var    boolean
+	 * @since  4.0
+	 */
+	private $accessCheckCache = null;
+
+	/**
 	 * Constructor
 	 *
 	 * @param   DispatcherInterface  &$subject  The object to observe
@@ -171,6 +179,41 @@ abstract class CMSPlugin implements DispatcherAwareInterface, PluginInterface
 
 		return $lang->load($extension, $basePath, null, false, true)
 			|| $lang->load($extension, JPATH_PLUGINS . '/' . $this->_type . '/' . $this->_name, null, false, true);
+	}
+
+	/**
+	 * Check the access level of the user.
+	 *
+	 * @param $event
+	 *
+	 * @return bool
+	 */
+	protected function accessCheck($event)
+	{
+		if (!is_null($this->accessCheckCache))
+		{
+			return $this->accessCheckCache;
+		}
+
+		$this->accessCheckCache = true;
+
+		$publicAccessLevel = $this->app->getConfig()->get('access');
+		$accessLevel       = $this->params->get('access');
+
+		// if no accesss level is set for the plugin we execute the listner
+		if ($publicAccessLevel = $accessLevel)
+		{
+			return $this->accessCheckCache;
+		}
+
+		$levels = $this->app->getIdentity()->getAuthorisedViewLevels();
+
+		if (in_array($pluginParams->access, $levels, true) === false)
+		{
+			$this->accessCheckCache = false;
+		}
+
+		return $this->accessCheckCache;
 	}
 
 	/**

--- a/libraries/src/Plugin/CMSPlugin.php
+++ b/libraries/src/Plugin/CMSPlugin.php
@@ -184,11 +184,9 @@ abstract class CMSPlugin implements DispatcherAwareInterface, PluginInterface
 	/**
 	 * Check the access level of the user.
 	 *
-	 * @param $event
-	 *
 	 * @return bool
 	 */
-	protected function accessCheck($event)
+	protected function accessCheck()
 	{
 		if (!is_null($this->accessCheckCache))
 		{

--- a/libraries/src/Plugin/CMSPlugin.php
+++ b/libraries/src/Plugin/CMSPlugin.php
@@ -195,11 +195,10 @@ abstract class CMSPlugin implements DispatcherAwareInterface, PluginInterface
 
 		$this->accessCheckCache = true;
 
-		$publicAccessLevel = $this->app->getConfig()->get('access');
-		$accessLevel       = $this->params->get('access');
+		$accessLevel = $this->params->get('access');
 
 		// If no accesss level is set for the plugin we execute the listener
-		if ($publicAccessLevel === $accessLevel)
+		if ($accessLevel === 1)
 		{
 			return $this->accessCheckCache;
 		}

--- a/libraries/src/Plugin/PluginHelper.php
+++ b/libraries/src/Plugin/PluginHelper.php
@@ -292,7 +292,7 @@ abstract class PluginHelper
 
 		try
 		{
-			static::$plugins = $cache->get($loader, array(), false);
+			static::$plugins = $cache->get($loader, [], true,false);
 		}
 		catch (CacheExceptionInterface $cacheException)
 		{

--- a/libraries/src/Plugin/PluginHelper.php
+++ b/libraries/src/Plugin/PluginHelper.php
@@ -255,12 +255,10 @@ abstract class PluginHelper
 			return static::$plugins;
 		}
 
-		$levels = implode(',', Factory::getUser()->getAuthorisedViewLevels());
-
 		/** @var \JCacheControllerCallback $cache */
 		$cache = Factory::getCache('com_plugins', 'callback');
 
-		$loader = function () use ($levels)
+		$loader = function ()
 		{
 			$db = Factory::getDbo();
 			$query = $db->getQuery(true)
@@ -270,13 +268,15 @@ abstract class PluginHelper
 							'folder',
 							'element',
 							'params',
-							'extension_id'
+							'extension_id',
+							'access'
 						),
 						array(
 							'type',
 							'name',
 							'params',
-							'id'
+							'id',
+							'access'
 						)
 					)
 				)
@@ -284,7 +284,6 @@ abstract class PluginHelper
 				->where('enabled = 1')
 				->where('type = ' . $db->quote('plugin'))
 				->where('state IN (0,1)')
-				->where('access IN (' . $levels . ')')
 				->order('ordering');
 			$db->setQuery($query);
 
@@ -293,7 +292,7 @@ abstract class PluginHelper
 
 		try
 		{
-			static::$plugins = $cache->get($loader, array(), md5($levels), false);
+			static::$plugins = $cache->get($loader, array(), false);
 		}
 		catch (CacheExceptionInterface $cacheException)
 		{

--- a/libraries/src/Plugin/PluginHelper.php
+++ b/libraries/src/Plugin/PluginHelper.php
@@ -282,7 +282,7 @@ abstract class PluginHelper
 				)
 				->from($db->quoteName('#__extensions'))
 				->where($db->quoteName('enabled') . ' = 1')
-				->where($db->quoteName('type') . '  = ' . $db->quote('plugin'))
+				->where($db->quoteName('type') . ' = ' . $db->quote('plugin'))
 				->whereIn($db->quoteName('state'), [0, 1])
 				->order($db->quoteName('ordering'));
 			$db->setQuery($query);

--- a/libraries/src/Plugin/PluginHelper.php
+++ b/libraries/src/Plugin/PluginHelper.php
@@ -264,27 +264,27 @@ abstract class PluginHelper
 			$query = $db->getQuery(true)
 				->select(
 					$db->quoteName(
-						array(
+						[
 							'folder',
 							'element',
 							'params',
 							'extension_id',
 							'access'
-						),
-						array(
+						],
+						[
 							'type',
 							'name',
 							'params',
 							'id',
 							'access'
-						)
+						]
 					)
 				)
-				->from('#__extensions')
-				->where('enabled = 1')
-				->where('type = ' . $db->quote('plugin'))
-				->where('state IN (0,1)')
-				->order('ordering');
+				->from($db->quoteName('#__extensions'))
+				->where($db->quoteName('enabled') . ' = 1')
+				->where($db->quoteName('type') . '  = ' . $db->quote('plugin'))
+				->whereIn($db->quoteName('state'), [0, 1])
+				->order($db->quoteName('ordering'));
 			$db->setQuery($query);
 
 			return $db->loadObjectList();
@@ -292,7 +292,7 @@ abstract class PluginHelper
 
 		try
 		{
-			static::$plugins = $cache->get($loader, [], true,false);
+			static::$plugins = $cache->get($loader, [], true);
 		}
 		catch (CacheExceptionInterface $cacheException)
 		{

--- a/plugins/quickicon/joomlaupdate/Extension/Joomlaupdate.php
+++ b/plugins/quickicon/joomlaupdate/Extension/Joomlaupdate.php
@@ -99,6 +99,11 @@ class Joomlaupdate extends CMSPlugin implements SubscriberInterface
 	 */
 	public function getCoreUpdateNotification(QuickIconsEvent $event)
 	{
+		if (!$this->accessCheck())
+		{
+			return;
+		}
+
 		$context = $event->getContext();
 
 		if ($context !== $this->params->get('context', 'mod_quickicon') || !$this->app->getIdentity()->authorise('core.manage', 'com_installer'))

--- a/plugins/quickicon/joomlaupdate/joomlaupdate.xml
+++ b/plugins/quickicon/joomlaupdate/joomlaupdate.xml
@@ -19,6 +19,10 @@
 		<language tag="en-GB">en-GB.plg_quickicon_joomlaupdate.sys.ini</language>
 	</languages>
 	<config>
+		<field
+			name="access"
+			type="hidden"
+		/>
 		<fields name="params">
 			<fieldset name="basic">
 				<field


### PR DESCRIPTION
This is a proof of concept to remove the "always session creation" because of loading plugins incl. full b/c.

I know that this could be done better, this is only to get some feedback.

### Summary of Changes
* Removed the access level check from the plugin load query.
* Add a combat layer for all plugins not being loaded with a service handler
* Only load the user session if the plugin is not public (legacy and new)
* Add support to override the access field in the plugin manager
* Added a helper function in CMSPlugin to check the access level with less overhead

The quickicon joomlaupdate plugin is the only plugin at the moment that uses the service helper. I changed this to support access check on event trigger and disabled the access field as example. (make no sense to do both).

### before patch
```
#0  Joomla\CMS\User\User::getInstance(0) called at [/libraries/src/Access/Access.php:997]
#1  Joomla\CMS\Access\Access::getAuthorisedViewLevels(0) called at [/libraries/src/User/User.php:445]
#2  Joomla\CMS\User\User->getAuthorisedViewLevels() called at [/libraries/src/Plugin/PluginHelper.php:258]
#3  Joomla\CMS\Plugin\PluginHelper::load() called at [/libraries/src/Plugin/PluginHelper.php:180]
#4  Joomla\CMS\Plugin\PluginHelper::importPlugin(system) called at [/libraries/src/Application/CMSApplication.php:229]
#5  Joomla\CMS\Application\CMSApplication->execute() called at [/includes/app.php:63]
#6  require_once(/includes/app.php) called at [/index.php:36]
```

### after patch
```
#0  Joomla\CMS\User\User::getInstance(0) called at [/libraries/src/Access/Access.php:997]
#1  Joomla\CMS\Access\Access::getAuthorisedViewLevels(0) called at [/libraries/src/User/User.php:445]
#2  Joomla\CMS\User\User->getAuthorisedViewLevels() called at [/libraries/src/Menu/AbstractMenu.php:322]
#3  Joomla\CMS\Menu\AbstractMenu->authorise(101) called at [/libraries/src/Application/SiteApplication.php:97]
#4  Joomla\CMS\Application\SiteApplication->authorise(101) called at [/libraries/src/Application/SiteApplication.php:771]
#5  Joomla\CMS\Application\SiteApplication->route() called at [/libraries/src/Application/SiteApplication.php:235]
#6  Joomla\CMS\Application\SiteApplication->doExecute() called at [/libraries/src/Application/CMSApplication.php:241]
#7  Joomla\CMS\Application\CMSApplication->execute() called at [/includes/app.php:63]
#8  require_once(/includes/app.php) called at [/index.php:36]
```

This mean we are not finished decoupling the cms from the user session, we have to do something similar to the menu. The simplest is to check for public access before loading the user.

### Documentation Changes Required
Plugin authors has to do the access check on each event listener
```php
if (!$this->accessCheck())
{
  return;
}
```
If the plugin doesn't need support for access levels it can override the access field with a hidden field in the config file.
```xml
<config>
  <field name="access" type="hidden" />
</config>
```
