### PR TITLE
[4.0] com_csp word break

### DIFF
--- a/administrator/components/com_csp/tmpl/reports/default.php
+++ b/administrator/components/com_csp/tmpl/reports/default.php
@@ -104,7 +104,7 @@ $saveOrder = $listOrder == 'a.id';
 											<?php echo HTMLHelper::_('jgrid.published', $item->published, $i, 'reports.', $canChange, 'cb'); ?>
 										</div>
 									</td>
-									<th scope="row" class="small d-none d-md-table-cell">
+									<th scope="row" class="small d-none d-md-table-cell text-break">
 										<?php echo $item->document_uri; ?>
 									</th>
 									<td class="small d-none d-md-table-cell">


### PR DESCRIPTION
Add a class to ensure that a long url will be split across multiple lines instead breaking the ui

### Before
![image](https://user-images.githubusercontent.com/1296369/59181768-09db5080-8b60-11e9-92e4-1bd929b44b0b.png)


### After

![image](https://user-images.githubusercontent.com/1296369/59181709-ef08dc00-8b5f-11e9-9201-66450be4a27d.png)
