### PR TITLE
[4.0] Improve menu item access check

### DIFF
--- a/libraries/src/Menu/AbstractMenu.php
+++ b/libraries/src/Menu/AbstractMenu.php
@@ -322,7 +322,7 @@ abstract class AbstractMenu
 			$publicAccessLevel = (int) $this->app->getConfig()->get('access');
 			$menuAccessLevel = (int) $menu->access;
 
-			// if the accesss level is public we don't need to load the user session
+			// If the accesss level is public we don't need to load the user session
 			if ($publicAccessLevel === $menuAccessLevel)
 			{
 				return true;

--- a/libraries/src/Menu/AbstractMenu.php
+++ b/libraries/src/Menu/AbstractMenu.php
@@ -319,11 +319,8 @@ abstract class AbstractMenu
 
 		if ($menu)
 		{
-			$publicAccessLevel = (int) $this->app->getConfig()->get('access');
-			$menuAccessLevel = (int) $menu->access;
-
 			// If the accesss level is public we don't need to load the user session
-			if ($publicAccessLevel === $menuAccessLevel)
+			if ((int) $menu->access === 1)
 			{
 				return true;
 			}

--- a/libraries/src/Menu/AbstractMenu.php
+++ b/libraries/src/Menu/AbstractMenu.php
@@ -319,7 +319,16 @@ abstract class AbstractMenu
 
 		if ($menu)
 		{
-			return in_array((int) $menu->access, $this->user->getAuthorisedViewLevels());
+			$publicAccessLevel = (int) $this->app->getConfig()->get('access');
+			$menuAccessLevel = (int) $menu->access;
+
+			// if the accesss level is public we don't need to load the user session
+			if ($publicAccessLevel === $menuAccessLevel)
+			{
+				return true;
+			}
+
+			return in_array($menuAccessLevel, $this->user->getAuthorisedViewLevels(), true);
 		}
 
 		return true;


### PR DESCRIPTION
This PR optimizes the authorise function in the menu to not load an user object (and don't start a session if not needed) for menu items with the access level "public".

This PR in combination with PR #25152 using apcu (or any other session and cache handler except Database) and disabled session metadata brings Joomla! down to 0 database queries for cached pages.

Clearly not for all pages only for pages that doesn't require any user authentication.

### Summary of Changes
Check if the menu item access level is public and return early if true.


### Testing Instructions
Create menu items with different access levels.


### Expected result
Nothing changes, menu is protected and visible as before.


### Documentation Changes Required
No.
