### PR TITLE
[4.0] fix display of item association popover

### DIFF
--- a/administrator/templates/atum/scss/blocks/_form.scss
+++ b/administrator/templates/atum/scss/blocks/_form.scss
@@ -113,7 +113,7 @@ legend {
 }
 
  /* set up hidden tooltip */
-[role="tooltip"] {
+[role="tooltip"]:not(.show) {
   display: none;
   padding: 0.25em;
   margin: 0.25em;


### PR DESCRIPTION
### Summary of Changes
Since the tooltips are hidden by default (#24892) and are only displayed when the previous sibling element is focused in the DOM, tooltips that have the same role and are applied as popovers using bootstrap can no longer be displayed because they do not have a previous focusable sibling element as they are added at the end of the DOM. They differ in that they get the class '.show' when activated.

So, to fix the problem, the css statements do not apply to tooltips with the role that have the class 'show'.

I guess that's not the right solution? Now that I've discovered that #24899 is still working on the tooltips. 
Should the bootstrap popover still be used or will the HTML also be adapted for associations?


### Testing Instructions
Run npm i as a scss file changed.
Install at least two languages and install the multilingual sample Data. Go to a view where Associations are displayed, for example in Multilingual Associations. 
Hover or focus on an item-association-language.

### Expected result
The tooltip is displayed:
![image](https://user-images.githubusercontent.com/31204883/59210000-e2f73b80-8bac-11e9-86ea-7e372478ec93.png)

### Actual result
No tooltip is displayed

### Documentation Changes Required
No
