### PR TITLE
[4.0] Fix menu access check

### DIFF
--- a/libraries/src/Menu/AbstractMenu.php
+++ b/libraries/src/Menu/AbstractMenu.php
@@ -319,8 +319,10 @@ abstract class AbstractMenu
 
 		if ($menu)
 		{
+			$menuAccessLevel = (int) $menu->access;
+
 			// If the accesss level is public we don't need to load the user session
-			if ((int) $menu->access === 1)
+			if ($menuAccessLevel === 1)
 			{
 				return true;
 			}

--- a/libraries/src/Menu/AbstractMenu.php
+++ b/libraries/src/Menu/AbstractMenu.php
@@ -322,7 +322,7 @@ abstract class AbstractMenu
 			$menuAccessLevel = (int) $menu->access;
 
 			// If the accesss level is public we don't need to load the user session
-			if ($menuAccessLevel === 1)
+			if ($menuAccessLevel === (int) $this->app->get('access'))
 			{
 				return true;
 			}

--- a/libraries/src/Menu/AbstractMenu.php
+++ b/libraries/src/Menu/AbstractMenu.php
@@ -322,7 +322,7 @@ abstract class AbstractMenu
 			$menuAccessLevel = (int) $menu->access;
 
 			// If the accesss level is public we don't need to load the user session
-			if ($menuAccessLevel === (int) $this->app->get('access'))
+			if ($menuAccessLevel === 1)
 			{
 				return true;
 			}


### PR DESCRIPTION
Pull Request for Issue #25158 .

### Summary of Changes

`$menuAccessLevel` was undefined.

### Testing Instructions

Create a menu item with `Registered` access level.
Login to frontend. Try to view the menu item.

### Expected result

Menu item works.

### Actual result

> Error
> You are not authorised to view this resource.

### Documentation Changes Required

No.