### PR TITLE
[4.0] TagsHelperRoute not found in tags view

### DIFF
--- a/components/com_tags/tmpl/tags/default_items.php
+++ b/components/com_tags/tmpl/tags/default_items.php
@@ -14,6 +14,7 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
+use Joomla\Component\Tags\Site\Helper\TagsHelperRoute;
 
 HTMLHelper::_('behavior.core');
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Adds missing import.

### Testing Instructions

Create at least one tag.
Open tags view in frontend (`index.php?option=com_tags&view=tags`).

### Expected result

No errors.

### Actual result

Error

> Class 'TagsHelperRoute' not found 

### Documentation Changes Required

No.