### PR TITLE
[4.0] Fix menu access check for PDO

### DIFF
--- a/libraries/src/Menu/AbstractMenu.php
+++ b/libraries/src/Menu/AbstractMenu.php
@@ -319,13 +319,15 @@ abstract class AbstractMenu
 
 		if ($menu)
 		{
+			$access = (int) $menu->access;
+
 			// If the accesss level is public we don't need to load the user session
-			if ($menu->access === 1)
+			if ($access === 1)
 			{
 				return true;
 			}
 
-			return in_array($menu->access, $this->user->getAuthorisedViewLevels(), true);
+			return in_array($access, $this->user->getAuthorisedViewLevels(), true);
 		}
 
 		return true;


### PR DESCRIPTION
Pull Request for Issue #25170 .

### Summary of Changes

Cast `access` property as integer.

### Testing Instructions

Use `MySQL (PDO)` database driver.
Create a menu item with `Registered` access level.
Login to frontend. Try to view the menu item.

### Expected result

Menu item accessible.

### Actual result

> Error
> You are not authorised to view this resource.

### Documentation Changes Required

No.