### PR TITLE
Fix doc block to use correct element order

### DIFF
--- a/libraries/joomla/github/package/data.php
+++ b/libraries/joomla/github/package/data.php
@@ -12,11 +12,6 @@ defined('JPATH_PLATFORM') or die;
 /**
  * GitHub API DB class for the Joomla Platform.
  *
- * @documentation https://developer.github.com/v3/git/
- *
- * @since       3.1.4
- * @deprecated  4.0  Use the `joomla/github` package via Composer instead
- *
  * https://developer.github.com/v3/git/
  * Git DB API
  *
@@ -46,6 +41,11 @@ defined('JPATH_PLATFORM') or die;
  *
  * It might seem complex, but it’s actually pretty simple when you understand the model and it opens up a ton of
  * things you could potentially do with the API.
+ *
+ * @documentation https://developer.github.com/v3/git/
+ *
+ * @since       3.1.4
+ * @deprecated  4.0  Use the `joomla/github` package via Composer instead
  */
 class JGithubPackageData extends JGithubPackage
 {


### PR DESCRIPTION
Doc blocks should generally be in this order:

- Short description
- Long description
- Tags (order specified in coding standards validators)

The doc block for JGithubPackageData is in the wrong order, which results in incorrect output when parsing the doc blocks for the API documentation, see https://api.joomla.org/cms-3/deprecated.html#joomla/github/package/data.php and https://api.joomla.org/cms-3/classes/JGithubPackageData.html (the long description for the deprecation is actually the class' description).  Putting things in the right order will ensure the parser correctly handles this file.