### PR TITLE
[4.0] Menus Manager: Fix system links menu items Status icon and add back tip

### DIFF
--- a/administrator/components/com_menus/tmpl/items/default.php
+++ b/administrator/components/com_menus/tmpl/items/default.php
@@ -170,7 +170,11 @@ $assoc   = Associations::isEnabled() && $this->state->get('filter.client_id') ==
 									<?php echo HTMLHelper::_('grid.id', $i, $item->id); ?>
 								</td>
 								<td class="text-center">
-									<?php echo HTMLHelper::_('jgrid.published', $item->published, $i, 'items.', $canChange, 'cb', $item->publish_up, $item->publish_down); ?>
+									<?php
+										// Show protected items as published always. We don't allow state change for them. Show/Hide is the module's job.
+										$published = $item->protected ? 3 : $item->published;
+										echo HTMLHelper::_('menus.state', $published, $i, $canChange && !$item->protected, 'cb', $item->publish_up, $item->publish_down);
+									?>
 								</td>
 								<th scope="row">
 									<?php $prefix = LayoutHelper::render('joomla.html.treeprefix', array('level' => $item->level)); ?>


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/24721

### Summary of Changes
Using the override `administrator/components/com_menus/Service/HTML/Menus.php` for `jgrid.published` in the Menu items Manager.
In 3.x this is done by `/administrator/components/com_menus/helpers/html/menus.php`

This will display again the correct Status icon for System Links menu items as well as using the specific tip for each menu item icon.

**NOTE: This will not modify the display of the tooltip as this requires a specific PR for `jgrid`.**

### Testing Instructions
Make sure you have created a System Links menu item (URL, Heading, Separator, Alias).

Display the Menu Items Manager and try to modify the status of these menu items
Although they may be Published, the icon the grey cross
If one uses the toolbar to Unpublish the item, the icon displays a black folder instead of the grey cross

The tip is the default tip used by `jgrid` and NOT the specific menu items tip.

Patch and test again.

### Before patch
For a URL menu item
<img width="563" alt="Screen Shot 2019-06-12 at 11 47 36" src="https://user-images.githubusercontent.com/869724/59341353-fcf96100-8d07-11e9-80e8-63ea25ba4549.png">

For a non system links menu item
<img width="568" alt="Screen Shot 2019-06-12 at 11 47 52" src="https://user-images.githubusercontent.com/869724/59341401-0e426d80-8d08-11e9-8988-f43486317306.png">


### After patch
For a URL menu item:
The icon reflect the Published status and the specific tip
<img width="530" alt="Screen Shot 2019-06-12 at 11 43 17" src="https://user-images.githubusercontent.com/869724/59341016-5ad97900-8d07-11e9-9888-8493325978d4.png">

and for a non system links menu item, the specific tip
<img width="543" alt="Screen Shot 2019-06-12 at 11 43 05" src="https://user-images.githubusercontent.com/869724/59341104-8ceadb00-8d07-11e9-8ed9-3f97959d0abe.png">

### Note2
I have not modified the existing language strings for the tips. They represent an action and not the existing status. This can be discussed elsewhere.
