### PR TITLE
[com_fields] Field type Repeatable. Editor and Textarea subfields remove HTML since J 3.9.7

### DIFF
--- a/plugins/fields/repeatable/params/repeatable.xml
+++ b/plugins/fields/repeatable/params/repeatable.xml
@@ -37,30 +37,30 @@
 								description="PLG_FIELDS_TEXT_PARAMS_FILTER_DESC"
 								class="btn-group"
 								validate="options"
-								showon="fieldtype!:media[AND]fieldtype!:number"
+								showon="fieldtype!:media,number"
 								>
 								<option value="">COM_FIELDS_FIELD_USE_GLOBAL</option>
 								<option value="0">JNO</option>
 								<option
-									showon="fieldtype:editor[OR]fieldtype:text[OR]fieldtype:textarea"
+									showon="fieldtype:editor,text,textarea"
 									value="raw">JLIB_FILTER_PARAMS_RAW</option>
 								<option
-									showon="fieldtype:editor[OR]fieldtype:text[OR]fieldtype:textarea"
+									showon="fieldtype:editor,text,textarea"
 									value="safehtml">JLIB_FILTER_PARAMS_SAFEHTML</option>
 								<option
-									showon="fieldtype:editor[OR]fieldtype:text[OR]fieldtype:textarea"
+									showon="fieldtype:editor,text,textarea"
 									value="JComponentHelper::filterText">JLIB_FILTER_PARAMS_TEXT</option>
 								<option
-									showon="fieldtype:text[OR]fieldtype:textarea"
+									showon="fieldtype:text,textarea"
 									value="alnum">JLIB_FILTER_PARAMS_ALNUM</option>
 								<option
-									showon="fieldtype:text[OR]fieldtype:textarea"
+									showon="fieldtype:text,textarea"
 									value="integer">JLIB_FILTER_PARAMS_INTEGER</option>
 								<option
-									showon="fieldtype:text[OR]fieldtype:textarea"
+									showon="fieldtype:text,textarea"
 									value="float">JLIB_FILTER_PARAMS_FLOAT</option>
 								<option
-									showon="fieldtype:text[OR]fieldtype:textarea"
+									showon="fieldtype:text,textarea"
 									value="tel">JLIB_FILTER_PARAMS_TEL</option>
 							</field>
 						</fieldset>

--- a/plugins/fields/repeatable/params/repeatable.xml
+++ b/plugins/fields/repeatable/params/repeatable.xml
@@ -30,6 +30,20 @@
 								<option value="text">PLG_FIELDS_REPEATABLE_PARAMS_FIELDNAME_TYPE_TEXT</option>
 								<option value="textarea">PLG_FIELDS_REPEATABLE_PARAMS_FIELDNAME_TYPE_TEXTAREA</option>
 							</field>
+							<field
+								name="fieldfilter"
+								type="list"
+								label="PLG_FIELDS_TEXT_PARAMS_FILTER_LABEL"
+								description="PLG_FIELDS_TEXT_PARAMS_FILTER_DESC"
+								class="btn-group"
+								validate="options"
+								>
+								<option value="">COM_FIELDS_FIELD_USE_GLOBAL</option>
+								<option value="0">JNO</option>
+								<option value="raw">JLIB_FILTER_PARAMS_RAW</option>
+								<option value="safehtml">JLIB_FILTER_PARAMS_SAFEHTML</option>
+								<option value="JComponentHelper::filterText">JLIB_FILTER_PARAMS_TEXT</option>
+							</field>
 						</fieldset>
 					</fields>
 				</form>

--- a/plugins/fields/repeatable/params/repeatable.xml
+++ b/plugins/fields/repeatable/params/repeatable.xml
@@ -39,7 +39,6 @@
 								validate="options"
 								showon="fieldtype!:media,number"
 								>
-								<option value="">COM_FIELDS_FIELD_USE_GLOBAL</option>
 								<option value="0">JNO</option>
 								<option
 									showon="fieldtype:editor,text,textarea"

--- a/plugins/fields/repeatable/params/repeatable.xml
+++ b/plugins/fields/repeatable/params/repeatable.xml
@@ -37,12 +37,31 @@
 								description="PLG_FIELDS_TEXT_PARAMS_FILTER_DESC"
 								class="btn-group"
 								validate="options"
+								showon="fieldtype!:media[AND]fieldtype!:number"
 								>
 								<option value="">COM_FIELDS_FIELD_USE_GLOBAL</option>
 								<option value="0">JNO</option>
-								<option value="raw">JLIB_FILTER_PARAMS_RAW</option>
-								<option value="safehtml">JLIB_FILTER_PARAMS_SAFEHTML</option>
-								<option value="JComponentHelper::filterText">JLIB_FILTER_PARAMS_TEXT</option>
+								<option
+									showon="fieldtype:editor[OR]fieldtype:text[OR]fieldtype:textarea"
+									value="raw">JLIB_FILTER_PARAMS_RAW</option>
+								<option
+									showon="fieldtype:editor[OR]fieldtype:text[OR]fieldtype:textarea"
+									value="safehtml">JLIB_FILTER_PARAMS_SAFEHTML</option>
+								<option
+									showon="fieldtype:editor[OR]fieldtype:text[OR]fieldtype:textarea"
+									value="JComponentHelper::filterText">JLIB_FILTER_PARAMS_TEXT</option>
+								<option
+									showon="fieldtype:text[OR]fieldtype:textarea"
+									value="alnum">JLIB_FILTER_PARAMS_ALNUM</option>
+								<option
+									showon="fieldtype:text[OR]fieldtype:textarea"
+									value="integer">JLIB_FILTER_PARAMS_INTEGER</option>
+								<option
+									showon="fieldtype:text[OR]fieldtype:textarea"
+									value="float">JLIB_FILTER_PARAMS_FLOAT</option>
+								<option
+									showon="fieldtype:text[OR]fieldtype:textarea"
+									value="tel">JLIB_FILTER_PARAMS_TEL</option>
 							</field>
 						</fieldset>
 					</fields>

--- a/plugins/fields/repeatable/repeatable.php
+++ b/plugins/fields/repeatable/repeatable.php
@@ -64,8 +64,12 @@ class PlgFieldsRepeatable extends FieldsPlugin
 			$child = $fields->addChild('field');
 			$child->addAttribute('name', $formField->fieldname);
 			$child->addAttribute('type', $formField->fieldtype);
-			$child->addAttribute('filter', $formField->fieldfilter);
 			$child->addAttribute('readonly', $readonly);
+			
+			if (isset($formField->fieldfilter))
+			{
+				$child->addAttribute('filter', $formField->fieldfilter);
+			}
 		}
 
 		$fieldNode->setAttribute('formsource', $fieldsXml->asXML());

--- a/plugins/fields/repeatable/repeatable.php
+++ b/plugins/fields/repeatable/repeatable.php
@@ -65,7 +65,7 @@ class PlgFieldsRepeatable extends FieldsPlugin
 			$child->addAttribute('name', $formField->fieldname);
 			$child->addAttribute('type', $formField->fieldtype);
 			$child->addAttribute('readonly', $readonly);
-			
+
 			if (isset($formField->fieldfilter))
 			{
 				$child->addAttribute('filter', $formField->fieldfilter);

--- a/plugins/fields/repeatable/repeatable.php
+++ b/plugins/fields/repeatable/repeatable.php
@@ -64,6 +64,7 @@ class PlgFieldsRepeatable extends FieldsPlugin
 			$child = $fields->addChild('field');
 			$child->addAttribute('name', $formField->fieldname);
 			$child->addAttribute('type', $formField->fieldtype);
+			$child->addAttribute('filter', $formField->fieldfilter);
 			$child->addAttribute('readonly', $readonly);
 		}
 


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/25187

### Summary of Changes
- Since Joomla 3.9.7 `subform` child fields are validated. So a minimum validation happens like known from "normal" form fields if no `filter` attribute is set for them.
- Because the com_fileds `repeatable` field uses a `subform` HTML tags are removed e.g. from editor or textarea contents during validation. This PR adds a filter field to any subfield row of `repeatable` fields.

### Testing Instructions
- Create a new com_fields field for Articles of type `repeatable` .
- Add a subfield of type Editor.
- Edit an article and enter some paragraphs in that editor.
- Save the article => paragraphs removed.

- Apply patch.
- Open above field.
- You'll see a new filter field for any row but for rows with type `Media` or `Number`:

![12-06-_2019_15-48-04](https://user-images.githubusercontent.com/20780646/59357130-8c177080-8d2a-11e9-9916-785b76da2ad3.jpg)

- Set Filter "Text" or "Safe Html."
- Save field.
- Open and edit article again or use a new one and enter some paragraphs => Save article  => paragraphs NOT removed.

- Test if filters are applied and work as expected for any field types.
- The filter options change depending on your selection in Type
