### PR TITLE
[4.0] Resolve LDAP Plugin Error

### DIFF
--- a/plugins/authentication/ldap/ldap.php
+++ b/plugins/authentication/ldap/ldap.php
@@ -179,7 +179,7 @@ class PlgAuthenticationLdap extends CMSPlugin
 		// Grab some details from LDAP and return them
 		$response->username = $entry->getAttribute($ldap_uid)[0] ?? false;
 		$response->email    = $entry->getAttribute($ldap_email)[0] ?? false;
-		$response->fullname = $entry->getAttribute($ldap_fullname)[0] ?? trim($entry->geAttribute($ldap_fullname)) ?: $credentials['username'];
+		$response->fullname = $entry->getAttribute($ldap_fullname)[0] ?? trim($entry->geAttribute($ldap_fullname)[0]) ?: $credentials['username'];
 
 		// Were good - So say so.
 		$response->status        = Authentication::STATUS_SUCCESS;

--- a/plugins/authentication/ldap/ldap.php
+++ b/plugins/authentication/ldap/ldap.php
@@ -177,8 +177,8 @@ class PlgAuthenticationLdap extends CMSPlugin
 		}
 
 		// Grab some details from LDAP and return them
-		$response->username = $entry->getAttribute($ldap_uid);
-		$response->email    = $entry->getAttribute($ldap_email);
+		$response->username = $entry->getAttribute($ldap_uid)[0] ?? false;
+		$response->email    = $entry->getAttribute($ldap_email)[0] ?? false;
 		$response->fullname = $entry->getAttribute($ldap_fullname) ?: $credentials['username'];
 
 		// Were good - So say so.

--- a/plugins/authentication/ldap/ldap.php
+++ b/plugins/authentication/ldap/ldap.php
@@ -179,7 +179,7 @@ class PlgAuthenticationLdap extends CMSPlugin
 		// Grab some details from LDAP and return them
 		$response->username = $entry->getAttribute($ldap_uid)[0] ?? false;
 		$response->email    = $entry->getAttribute($ldap_email)[0] ?? false;
-		$response->fullname = $entry->getAttribute($ldap_fullname) ?: $credentials['username'];
+		$response->fullname = $entry->getAttribute($ldap_fullname)[0] ?? trim($entry->geAttribute($ldap_fullname)) ?: $credentials['username'];
 
 		// Were good - So say so.
 		$response->status        = Authentication::STATUS_SUCCESS;


### PR DESCRIPTION
Pull Request for Issue #25180 .

### Summary of Changes
Ensure the username and email fields are using the 0 array key returned from the LDAP Symfony Package, otherwise. I tested this against an LDAP server I had setup.

I am unsure at this time how to write a test for this, but am reading up on it. If there's a specific team that needs to handle that, just let me know.

### Testing Instructions

See Issue #25180 .

About how to set up the plugin to use the public ldap server ldap.forumsys.com for a test see [this comment](https://issues.joomla.org/tracker/joomla-cms/25191#event-452938 "https://issues.joomla.org/tracker/joomla-cms/25191#event-452938").