### PR TITLE
Fix pagination when uninstalling extensions

### DIFF
--- a/administrator/components/com_installer/models/extension.php
+++ b/administrator/components/com_installer/models/extension.php
@@ -117,10 +117,10 @@ class InstallerModel extends JModelList
 			$total = count($result);
 			$this->cache[$this->getStoreId('getTotal')] = $total;
 
-			if ($total < $limitstart)
+			if ($total <= $limitstart)
 			{
 				$limitstart = 0;
-				$this->setState('list.start', 0);
+				$this->setState('list.limitstart', 0);
 			}
 
 			return array_slice($result, $limitstart, $limit ?: null);


### PR DESCRIPTION
Pull Request for Issue #22906.

### Summary of Changes

Corrects pagination behavior when uninstalling extensions.

### Testing Instructions

Install JCE (https://extensions.joomla.org/extension/jce/) or some other extension package with multiple (at least 6) extensions.
Go to Extensions -> Manage.
Set list limit to 5.
Search for `JCE`.
Click once on `Type` header to order by type so that `JCE Extension Package` ends up on first result page.
Go to page 2.
Uninstall the extensions on page 2.

### Expected result

You are brought back to the first result page where remaining 5 extensions are shown.

### Actual result
You remain on the second page and see this message:

>There are no extensions installed matching your query. 

### Documentation Changes Required

No.