### PR TITLE
Clean article cache after voting

### DIFF
--- a/components/com_content/models/article.php
+++ b/components/com_content/models/article.php
@@ -353,11 +353,34 @@ class ContentModelArticle extends JModelItem
 				}
 			}
 
+			$this->cleanCache();
+
 			return true;
 		}
 
 		JError::raiseWarning(500, JText::sprintf('COM_CONTENT_INVALID_RATING', $rate), "JModelArticle::storeVote($rate)");
 
 		return false;
+	}
+
+	/**
+	 * Cleans the cache of com_content and content modules
+	 *
+	 * @param   string   $group     The cache group
+	 * @param   integer  $clientId  The ID of the client
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function cleanCache($group = null, $clientId = 0)
+	{
+		parent::cleanCache('com_content');
+		parent::cleanCache('mod_articles_archive');
+		parent::cleanCache('mod_articles_categories');
+		parent::cleanCache('mod_articles_category');
+		parent::cleanCache('mod_articles_latest');
+		parent::cleanCache('mod_articles_news');
+		parent::cleanCache('mod_articles_popular');
 	}
 }


### PR DESCRIPTION
Pull Request for Issue #22858.

### Summary of Changes

Cleans cache after voting.

### Testing Instructions

Enable `Content -  Vote` plugin.
Enable `Show Voting` option in `com_content` configuration.
Enable `System Cache` in Global Configuration.
View an article and submit a vote.

### Expected result

Article rating updated after voting.

### Actual result

Article rating not updated.

### Documentation Changes Required

No.