### PR TITLE
[4.0] Fix accessibility and html errors

### DIFF
--- a/layouts/joomla/form/field/user.php
+++ b/layouts/joomla/form/field/user.php
@@ -111,22 +111,25 @@ if (!$readonly)
 		<input <?php echo ArrayHelper::toString($inputAttributes); ?> readonly>
 		<?php if (!$readonly) : ?>
 			<span class="input-group-append">
-					<button type="button" class="btn btn-primary button-select" title="<?php echo Text::_('JLIB_FORM_CHANGE_USER') ?>"><span class="fa fa-user icon-white" aria-hidden="true"></span></button>
-				<?php echo HTMLHelper::_(
-					'bootstrap.renderModal',
-					'userModal_' . $id,
-					array(
-						'url'         => $uri,
-						'title'       => Text::_('JLIB_FORM_CHANGE_USER'),
-						'closeButton' => true,
-						'height'      => '100%',
-						'width'       => '100%',
-						'modalWidth'  => 80,
-						'bodyHeight'  => 60,
-						'footer'      => '<button type="button" class="btn btn-secondary" data-dismiss="modal">' . Text::_('JCANCEL') . '</button>'
-					)
-				); ?>
-				</span>
+				<button type="button" class="btn btn-primary button-select" title="<?php echo Text::_('JLIB_FORM_CHANGE_USER'); ?>">
+					<span class="fa fa-user icon-white" aria-hidden="true"></span>
+					<span class="sr-only"><?php echo Text::_('JLIB_FORM_CHANGE_USER'); ?></span>
+				</button>
+			</span>
+			<?php echo HTMLHelper::_(
+				'bootstrap.renderModal',
+				'userModal_' . $id,
+				array(
+					'url'         => $uri,
+					'title'       => Text::_('JLIB_FORM_CHANGE_USER'),
+					'closeButton' => true,
+					'height'      => '100%',
+					'width'       => '100%',
+					'modalWidth'  => 80,
+					'bodyHeight'  => 60,
+					'footer'      => '<button type="button" class="btn btn-secondary" data-dismiss="modal">' . Text::_('JCANCEL') . '</button>'
+				)
+			); ?>
 		<?php endif; ?>
 	</div>
 	<?php // Create the real field, hidden, that stored the user id. ?>


### PR DESCRIPTION
Pull Request for Issue #22497.
Supersedes PR #22878

### Summary of Changes
The button only has a title available for screenreaders. The W3 recommend not relying on a title alone https://www.w3.org/TR/html/dom.html#the-title-attribute.

The generated code puts a div inside a span which is invalid html.

### Testing Instructions
Edit an article.
Go to Publishing tab.
Click the button next to Created By.
Button works and view page source to see that div is outside of span.
