### PR TITLE
[4.0] Clear Cache toolbar

### DIFF
--- a/administrator/components/com_cache/View/Cache/HtmlView.php
+++ b/administrator/components/com_cache/View/Cache/HtmlView.php
@@ -71,8 +71,8 @@ class HtmlView extends BaseHtmlView
 
 		$toolbar = Toolbar::getInstance();
 		ToolbarHelper::custom('delete', 'delete.png', 'delete_f2.png', 'JTOOLBAR_DELETE', true);
-		$toolbar->appendButton('Confirm', 'COM_CACHE_RESOURCE_INTENSIVE_WARNING', 'delete', 'COM_CACHE_PURGE_EXPIRED', 'purge', false);
 		ToolbarHelper::custom('deleteAll', 'remove.png', 'delete_f2.png', 'JTOOLBAR_DELETE_ALL', false);
+		$toolbar->appendButton('Confirm', 'COM_CACHE_RESOURCE_INTENSIVE_WARNING', 'delete', 'COM_CACHE_PURGE_EXPIRED', 'purge', false);
 		ToolbarHelper::divider();
 
 		if (Factory::getUser()->authorise('core.admin', 'com_cache'))


### PR DESCRIPTION
Cosmetic change to put delete and delete all buttons together and expired cache at the end as it is a more logical order

### Before
![image](https://user-images.githubusercontent.com/1296369/59551223-0b48b680-8f6e-11e9-9d50-0ecb4bd308b6.png)

### After
![image](https://user-images.githubusercontent.com/1296369/59551213-ea806100-8f6d-11e9-9c6a-7d6871fac8b7.png)
