### PR TITLE
Fix for menu items containing nested field groups and no immediate fields in request

### DIFF
--- a/administrator/components/com_menus/controllers/item.php
+++ b/administrator/components/com_menus/controllers/item.php
@@ -358,7 +358,7 @@ class MenusControllerItem extends JControllerForm
 		$data = $model->validate($form, $data);
 
 		// Preprocess request fields to ensure that we remove not set or empty request params
-		$request = $form->getGroup('request');
+		$request = $form->getGroup('request', true);
 
 		// Check for the special 'request' entry.
 		if ($data['type'] == 'component' && !empty($request))


### PR DESCRIPTION
Pull Request for Issue #25211.

### Summary of Changes

Get `request` group fields recursively.

### Testing Instructions

Create/modify view layout XML file to contain a nested field group but no immediate fields in `request` field group, e.g.:

```
<fields name="request">
	<fieldset name="request">
		<fields name="filter">
			<field
				name="id"
				type="category"
				label="JGLOBAL_FIELD_CATEGORIES_CHOOSE_CATEGORY_LABEL"
				description="JGLOBAL_FIELD_CATEGORIES_CHOOSE_CATEGORY_DESC"
				extension="com_content"
				show_root="true"
				required="true"
			/>
		</fields>
	</fieldset>
</fields>
```
Create a menu item for the view.
Inspect `Link`  field value.
### Expected result

Nested group field parameters included, e.g.:

    index.php?option=com_content&view=categories&filter[id]=0

### Actual result

Nested group field parameters not included, e.g.:

    index.php?option=com_content&view=categories

### Documentation Changes Required

No.