### PR TITLE
[4.0] Update joomla/database package from framework

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -757,12 +757,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-framework/database.git",
-                "reference": "29c007d2706dd5f2f237a23e87755a93a2a34de9"
+                "reference": "8ab606d267f8464fb765dbd3e9c4cc6494a303e4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/database/zipball/29c007d2706dd5f2f237a23e87755a93a2a34de9",
-                "reference": "29c007d2706dd5f2f237a23e87755a93a2a34de9",
+                "url": "https://api.github.com/repos/joomla-framework/database/zipball/8ab606d267f8464fb765dbd3e9c4cc6494a303e4",
+                "reference": "8ab606d267f8464fb765dbd3e9c4cc6494a303e4",
                 "shasum": ""
             },
             "require": {
@@ -814,7 +814,7 @@
                 "framework",
                 "joomla"
             ],
-            "time": "2019-05-07T11:36:04+00:00"
+            "time": "2019-06-15T17:44:26+00:00"
         },
         {
             "name": "joomla/di",


### PR DESCRIPTION
Pull Request for Issue #25229 .

### Summary of Changes

Update the database package from framework so it contains the database function "WhereNotIn" needed by 4.0-dev since PR #25055 has been merged and needed also for PR #25090 .

### Testing Instructions

An easier and faster test you can find below in section "Alternative Testing Instructions".

1. Install clean 4.0-dev, i.e. checkout latest 4.0-dev, run `composer install` and `npm install`.
2. In backend, install some extension which has an update site, e.g. one of the supported languages for 4.0, e.g. German DE.
3. Try to uninstall the extension. Result: See section "Actual result" below.
4. Log out from backend.
5. Apply this PR by manually applying the changes in the composer.lock file.
6. Run `composer install`.
7. Log in again at backend and try to uninstall the extension (or remaining parts, or install again another language and try to uninstall that if there is no remaining part to be uninstalled). Result: See section "Expected result" below.

### Expected result

Extension is uninstalled.

### Actual result

![screen shot 2019-06-16 at 10 43 42](https://issues.joomla.org/uploads/1/de1c14d1509a3edc48ee9469fba24cda.png)

### Alternative Testing Instructions

1. Install clean 4.0-dev, i.e. checkout latest 4.0-dev, run `composer install` and `npm install`.
2. Check which files contain string "wherenotin" (case-insentitive).
E.g. on Linux:
```
richard@vmkubu01:~/lamp/public_html/joomla-cms-4.0-dev$ find ./ -type f -name "*\.php" -exec grep -il "wherenotin" {} \;
./plugins/extension/joomla/joomla.php
richard@vmkubu01:~/lamp/public_html/joomla-cms-4.0-dev$
```
On Windows command line, use `findstr /s /m /i /c:"wherenotin" *.php`

3. Apply this PR by manually applying the changes in the composer.lock file.
4. Run `composer install`.
5. Check again which files contain string "wherenotin" (case-insentitive).
E.g. on Linux:
```
richard@vmkubu01:~/lamp/public_html/joomla-cms-4.0-dev$ find ./ -type f -name "*\.php" -exec grep -il "wherenotin" {} \;
./libraries/vendor/joomla/database/src/QueryInterface.php
./libraries/vendor/joomla/database/src/DatabaseQuery.php
./plugins/extension/joomla/joomla.php
richard@vmkubu01:~/lamp/public_html/joomla-cms-4.0-dev$
```
On Windows command line, use `findstr /s /m /i /c:"wherenotin" *.php`
