### PR TITLE
[4.0] Extension Update Sources

### DIFF
--- a/administrator/components/com_installer/tmpl/updatesites/default.php
+++ b/administrator/components/com_installer/tmpl/updatesites/default.php
@@ -86,9 +86,12 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 									</label>
 								</th>
 								<td class="d-none d-md-table-cell">
-									<span class="bold hasTooltip" title="<?php echo HTMLHelper::_('tooltipText', $item->name, $item->description, 0); ?>">
+									<span tabindex="0">
 										<?php echo $item->name; ?>
 									</span>
+									<div role="tooltip" id="tip<?php echo $i; ?>">
+										<?php echo $item->description; ?>
+									</div>
 								</td>
 								<td class="d-none d-md-table-cell">
 									<?php echo $item->client_translated; ?>


### PR DESCRIPTION
Following similar PR this replaces the non-accessible tooltip with the new style div.

![image](https://user-images.githubusercontent.com/1296369/59566766-89838680-905c-11e9-89ab-a8c01bada23a.png)
