### PR TITLE
[4.0] Use the right branch for AppVeyor badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Build Status
 ---------------------
 | Drone-CI | AppVeyor |
 | ------------- | ------------- |
-| [![Build Status](https://ci.joomla.org/api/badges/joomla/joomla-cms/status.svg?branch=4.0-dev)](https://ci.joomla.org/joomla/joomla-cms)  | [![Build status](https://ci.appveyor.com/api/projects/status/bpcxulw6nnxlv8kb/branch/staging?svg=true)](https://ci.appveyor.com/project/joomla/joomla-cms)  |
+| [![Build Status](https://ci.joomla.org/api/badges/joomla/joomla-cms/status.svg?branch=4.0-dev)](https://ci.joomla.org/joomla/joomla-cms)  | [![Build status](https://ci.appveyor.com/api/projects/status/bpcxulw6nnxlv8kb/branch/4.0-dev?svg=true)](https://ci.appveyor.com/project/joomla/joomla-cms)  |
 
 What is this?
 ---------------------


### PR DESCRIPTION
What the title says. This just fixes the badge.