### PR TITLE
Update joomla/string from framework to fix Appveyor

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -773,25 +773,25 @@
         },
         {
             "name": "joomla/string",
-            "version": "1.4.1",
+            "version": "1.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-framework/string.git",
-                "reference": "66363d317e6c020f30a70265c129281c77c43ca0"
+                "reference": "64ed484157262578b8daddb488bb9bd3552bc4fe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/string/zipball/66363d317e6c020f30a70265c129281c77c43ca0",
-                "reference": "66363d317e6c020f30a70265c129281c77c43ca0",
+                "url": "https://api.github.com/repos/joomla-framework/string/zipball/64ed484157262578b8daddb488bb9bd3552bc4fe",
+                "reference": "64ed484157262578b8daddb488bb9bd3552bc4fe",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.3.10|~7.0"
             },
             "require-dev": {
+                "joomla/coding-standards": "~2.0@alpha",
                 "joomla/test": "~1.0",
-                "phpunit/phpunit": "~4.8|~5.0",
-                "squizlabs/php_codesniffer": "1.*"
+                "phpunit/phpunit": "^4.8.35|^5.4.3|~6.0"
             },
             "suggest": {
                 "ext-mbstring": "For improved processing"
@@ -826,7 +826,7 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "GPL-2.0+"
+                "GPL-2.0-or-later"
             ],
             "description": "Joomla String Package",
             "homepage": "https://github.com/joomla-framework/string",
@@ -835,7 +835,7 @@
                 "joomla",
                 "string"
             ],
-            "time": "2016-12-10T18:13:42+00:00"
+            "time": "2019-06-16T18:18:09+00:00"
         },
         {
             "name": "joomla/uri",

--- a/libraries/vendor/composer/installed.json
+++ b/libraries/vendor/composer/installed.json
@@ -798,31 +798,31 @@
     },
     {
         "name": "joomla/string",
-        "version": "1.4.1",
-        "version_normalized": "1.4.1.0",
+        "version": "1.4.2",
+        "version_normalized": "1.4.2.0",
         "source": {
             "type": "git",
             "url": "https://github.com/joomla-framework/string.git",
-            "reference": "66363d317e6c020f30a70265c129281c77c43ca0"
+            "reference": "64ed484157262578b8daddb488bb9bd3552bc4fe"
         },
         "dist": {
             "type": "zip",
-            "url": "https://api.github.com/repos/joomla-framework/string/zipball/66363d317e6c020f30a70265c129281c77c43ca0",
-            "reference": "66363d317e6c020f30a70265c129281c77c43ca0",
+            "url": "https://api.github.com/repos/joomla-framework/string/zipball/64ed484157262578b8daddb488bb9bd3552bc4fe",
+            "reference": "64ed484157262578b8daddb488bb9bd3552bc4fe",
             "shasum": ""
         },
         "require": {
             "php": "^5.3.10|~7.0"
         },
         "require-dev": {
+            "joomla/coding-standards": "~2.0@alpha",
             "joomla/test": "~1.0",
-            "phpunit/phpunit": "~4.8|~5.0",
-            "squizlabs/php_codesniffer": "1.*"
+            "phpunit/phpunit": "^4.8.35|^5.4.3|~6.0"
         },
         "suggest": {
             "ext-mbstring": "For improved processing"
         },
-        "time": "2016-12-10T18:13:42+00:00",
+        "time": "2019-06-16T18:18:09+00:00",
         "type": "joomla-package",
         "extra": {
             "branch-alias": {
@@ -854,7 +854,7 @@
         },
         "notification-url": "https://packagist.org/downloads/",
         "license": [
-            "GPL-2.0+"
+            "GPL-2.0-or-later"
         ],
         "description": "Joomla String Package",
         "homepage": "https://github.com/joomla-framework/string",

--- a/libraries/vendor/joomla/string/src/Inflector.php
+++ b/libraries/vendor/joomla/string/src/Inflector.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Framework String Package
  *
- * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2019 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
@@ -35,35 +35,35 @@ class Inflector
 	 */
 	private $rules = array(
 		'singular' => array(
-			'/(matr)ices$/i' => '\1ix',
-			'/(vert|ind)ices$/i' => '\1ex',
+			'/(matr)ices$/i'                                                          => '\1ix',
+			'/(vert|ind)ices$/i'                                                      => '\1ex',
 			'/(alumn|bacill|cact|foc|fung|nucle|radi|stimul|syllab|termin|viri?)i$/i' => '\1us',
-			'/([ftw]ax)es/i' => '\1',
-			'/(cris|ax|test)es$/i' => '\1is',
-			'/(shoe|slave)s$/i' => '\1',
-			'/(o)es$/i' => '\1',
-			'/([^aeiouy]|qu)ies$/i' => '\1y',
-			'/$1ses$/i' => '\s',
-			'/ses$/i' => '\s',
-			'/eaus$/' => 'eau',
-			'/^(.*us)$/' => '\\1',
-			'/s$/i' => '',
+			'/([ftw]ax)es/i'                                                          => '\1',
+			'/(cris|ax|test)es$/i'                                                    => '\1is',
+			'/(shoe|slave)s$/i'                                                       => '\1',
+			'/(o)es$/i'                                                               => '\1',
+			'/([^aeiouy]|qu)ies$/i'                                                   => '\1y',
+			'/$1ses$/i'                                                               => '\s',
+			'/ses$/i'                                                                 => '\s',
+			'/eaus$/'                                                                 => 'eau',
+			'/^(.*us)$/'                                                              => '\\1',
+			'/s$/i'                                                                   => '',
 		),
 		'plural' => array(
-			'/([m|l])ouse$/i' => '\1ice',
-			'/(matr|vert|ind)(ix|ex)$/i'  => '\1ices',
-			'/(x|ch|ss|sh)$/i' => '\1es',
-			'/([^aeiouy]|qu)y$/i' => '\1ies',
-			'/([^aeiouy]|qu)ies$/i' => '\1y',
-			'/(?:([^f])fe|([lr])f)$/i' => '\1\2ves',
-			'/sis$/i' => 'ses',
-			'/([ti])um$/i' => '\1a',
-			'/(buffal|tomat)o$/i' => '\1\2oes',
+			'/([m|l])ouse$/i'                                                        => '\1ice',
+			'/(matr|vert|ind)(ix|ex)$/i'                                             => '\1ices',
+			'/(x|ch|ss|sh)$/i'                                                       => '\1es',
+			'/([^aeiouy]|qu)y$/i'                                                    => '\1ies',
+			'/([^aeiouy]|qu)ies$/i'                                                  => '\1y',
+			'/(?:([^f])fe|([lr])f)$/i'                                               => '\1\2ves',
+			'/sis$/i'                                                                => 'ses',
+			'/([ti])um$/i'                                                           => '\1a',
+			'/(buffal|tomat)o$/i'                                                    => '\1\2oes',
 			'/(alumn|bacill|cact|foc|fung|nucle|radi|stimul|syllab|termin|vir)us$/i' => '\1i',
-			'/us$/i' => 'uses',
-			'/(ax|cris|test)is$/i' => '\1es',
-			'/s$/i' => 's',
-			'/$/' => 's',
+			'/us$/i'                                                                 => 'uses',
+			'/(ax|cris|test)is$/i'                                                   => '\1es',
+			'/s$/i'                                                                  => 's',
+			'/$/'                                                                    => 's',
 		),
 		'countable' => array(
 			'id',
@@ -77,7 +77,7 @@ class Inflector
 	 *
 	 * The array is in the form [singular => plural]
 	 *
-	 * @var    array
+	 * @var    string[]
 	 * @since  1.0
 	 */
 	private $cache = array();
@@ -129,11 +129,11 @@ class Inflector
 	 */
 	private function addRule($data, $ruleType)
 	{
-		if (is_string($data))
+		if (\is_string($data))
 		{
 			$data = array($data);
 		}
-		elseif (!is_array($data))
+		elseif (!\is_array($data))
 		{
 			// Do not translate.
 			throw new InvalidArgumentException('Invalid inflector rule data.');
@@ -151,7 +151,7 @@ class Inflector
 	 *
 	 * @param   string  $singular  A singular form of a word.
 	 *
-	 * @return  mixed  The cached inflection or false if none found.
+	 * @return  string|boolean  The cached inflection or false if none found.
 	 *
 	 * @since   1.0
 	 */
@@ -173,7 +173,7 @@ class Inflector
 	 *
 	 * @param   string  $plural  A plural form of a word.
 	 *
-	 * @return  mixed  The cached inflection or false if none found.
+	 * @return  string|boolean  The cached inflection or false if none found.
 	 *
 	 * @since   1.0
 	 */
@@ -193,7 +193,7 @@ class Inflector
 	 * @param   string  $word      The string input.
 	 * @param   string  $ruleType  String (eg, singular|plural)
 	 *
-	 * @return  mixed  An inflected string, or false if no rule could be applied.
+	 * @return  string|boolean  An inflected string, or false if no rule could be applied.
 	 *
 	 * @since   1.0
 	 */
@@ -202,7 +202,7 @@ class Inflector
 		// Cycle through the regex rules.
 		foreach ($this->rules[$ruleType] as $regex => $replacement)
 		{
-			$matches = 0;
+			$matches     = 0;
 			$matchedWord = preg_replace($regex, $replacement, $word, -1, $matches);
 
 			if ($matches > 0)
@@ -321,7 +321,8 @@ class Inflector
 		{
 			return new static;
 		}
-		elseif (!is_object(self::$instance))
+
+		if (!\is_object(self::$instance))
 		{
 			self::$instance = new static;
 		}
@@ -340,7 +341,7 @@ class Inflector
 	 */
 	public function isCountable($word)
 	{
-		return (boolean) in_array($word, $this->rules['countable']);
+		return \in_array($word, $this->rules['countable']);
 	}
 
 	/**
@@ -354,7 +355,7 @@ class Inflector
 	 */
 	public function isPlural($word)
 	{
-		// Try the cache for an known inflection.
+		// Try the cache for a known inflection.
 		$inflection = $this->getCachedSingular($word);
 
 		if ($inflection !== false)
@@ -384,7 +385,7 @@ class Inflector
 	 */
 	public function isSingular($word)
 	{
-		// Try the cache for an known inflection.
+		// Try the cache for a known inflection.
 		$inflection = $this->getCachedPlural($word);
 
 		if ($inflection !== false)
@@ -408,7 +409,7 @@ class Inflector
 	 *
 	 * @param   string  $word  The singular word to pluralise.
 	 *
-	 * @return  mixed  An inflected string, or false if no rule could be applied.
+	 * @return  string|boolean  An inflected string, or false if no rule could be applied.
 	 *
 	 * @since   1.0
 	 */
@@ -447,7 +448,7 @@ class Inflector
 	 *
 	 * @param   string  $word  The plural word to singularise.
 	 *
-	 * @return  mixed  An inflected string, or false if no rule could be applied.
+	 * @return  string|boolean  An inflected string, or false if no rule could be applied.
 	 *
 	 * @since   1.0
 	 */

--- a/libraries/vendor/joomla/string/src/Normalise.php
+++ b/libraries/vendor/joomla/string/src/Normalise.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Framework String Package
  *
- * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2019 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 

--- a/libraries/vendor/joomla/string/src/String.php
+++ b/libraries/vendor/joomla/string/src/String.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Framework String Package
  *
- * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2019 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 

--- a/libraries/vendor/joomla/string/src/StringHelper.php
+++ b/libraries/vendor/joomla/string/src/StringHelper.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Framework String Package
  *
- * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2019 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
@@ -16,7 +16,7 @@ if (version_compare(PHP_VERSION, '5.6', '>='))
 else
 {
 	// Check if mbstring extension is loaded and attempt to load it if not present except for windows
-	if (extension_loaded('mbstring'))
+	if (\extension_loaded('mbstring'))
 	{
 		@ini_set('mbstring.internal_encoding', 'UTF-8');
 		@ini_set('mbstring.http_input', 'UTF-8');
@@ -24,7 +24,7 @@ else
 	}
 
 	// Same for iconv
-	if (function_exists('iconv'))
+	if (\function_exists('iconv'))
 	{
 		iconv_set_encoding('internal_encoding', 'UTF-8');
 		iconv_set_encoding('input_encoding', 'UTF-8');
@@ -48,7 +48,7 @@ abstract class StringHelper
 	protected static $incrementStyles = array(
 		'dash' => array(
 			'#-(\d+)$#',
-			'-%d'
+			'-%d',
 		),
 		'default' => array(
 			array('#\((\d+)\)$#', '#\(\d+\)$#'),
@@ -77,9 +77,9 @@ abstract class StringHelper
 		$styleSpec = isset(static::$incrementStyles[$style]) ? static::$incrementStyles[$style] : static::$incrementStyles['default'];
 
 		// Regular expression search and replace patterns.
-		if (is_array($styleSpec[0]))
+		if (\is_array($styleSpec[0]))
 		{
-			$rxSearch = $styleSpec[0][0];
+			$rxSearch  = $styleSpec[0][0];
 			$rxReplace = $styleSpec[0][1];
 		}
 		else
@@ -88,7 +88,7 @@ abstract class StringHelper
 		}
 
 		// New and old (existing) sprintf formats.
-		if (is_array($styleSpec[1]))
+		if (\is_array($styleSpec[1]))
 		{
 			$newFormat = $styleSpec[1][0];
 			$oldFormat = $styleSpec[1][1];
@@ -101,7 +101,7 @@ abstract class StringHelper
 		// Check if we are incrementing an existing pattern, or appending a new one.
 		if (preg_match($rxSearch, $string, $matches))
 		{
-			$n = empty($n) ? ($matches[1] + 1) : $n;
+			$n      = empty($n) ? ($matches[1] + 1) : $n;
 			$string = preg_replace($rxReplace, sprintf($oldFormat, $n), $string);
 		}
 		else
@@ -151,7 +151,7 @@ abstract class StringHelper
 	 *
 	 * @return  integer Unicode ordinal for the character
 	 *
-	 * @see     http://www.php.net/ord
+	 * @link    https://www.php.net/ord
 	 * @since   1.4.0
 	 */
 	public static function ord($chr)
@@ -168,9 +168,9 @@ abstract class StringHelper
 	 * @param   string   $search  String being searched for
 	 * @param   integer  $offset  Optional, specifies the position from which the search should be performed
 	 *
-	 * @return  mixed  Number of characters before the first match or FALSE on failure
+	 * @return  integer|boolean  Number of characters before the first match or FALSE on failure
 	 *
-	 * @see     http://www.php.net/strpos
+	 * @link    https://www.php.net/strpos
 	 * @since   1.3.0
 	 */
 	public static function strpos($str, $search, $offset = false)
@@ -192,9 +192,9 @@ abstract class StringHelper
 	 * @param   string   $search  String being searched for.
 	 * @param   integer  $offset  Offset from the left of the string.
 	 *
-	 * @return  mixed  Number of characters before the last match or false on failure
+	 * @return  integer|boolean  Number of characters before the last match or false on failure
 	 *
-	 * @see     http://www.php.net/strrpos
+	 * @link    https://www.php.net/strrpos
 	 * @since   1.3.0
 	 */
 	public static function strrpos($str, $search, $offset = 0)
@@ -211,9 +211,9 @@ abstract class StringHelper
 	 * @param   integer  $offset  Number of UTF-8 characters offset (from left)
 	 * @param   integer  $length  Optional length in UTF-8 characters from offset
 	 *
-	 * @return  mixed string or FALSE if failure
+	 * @return  string|boolean
 	 *
-	 * @see     http://www.php.net/substr
+	 * @link    https://www.php.net/substr
 	 * @since   1.3.0
 	 */
 	public static function substr($str, $offset, $length = false)
@@ -236,9 +236,9 @@ abstract class StringHelper
 	 *
 	 * @param   string  $str  String being processed
 	 *
-	 * @return  mixed  Either string in lowercase or FALSE is UTF-8 invalid
+	 * @return  string|boolean  Either string in lowercase or FALSE is UTF-8 invalid
 	 *
-	 * @see http://www.php.net/strtolower
+	 * @link    https://www.php.net/strtolower
 	 * @since   1.3.0
 	 */
 	public static function strtolower($str)
@@ -256,9 +256,9 @@ abstract class StringHelper
 	 *
 	 * @param   string  $str  String being processed
 	 *
-	 * @return  mixed  Either string in uppercase or FALSE is UTF-8 invalid
+	 * @return  string|boolean  Either string in uppercase or FALSE is UTF-8 invalid
 	 *
-	 * @see     http://www.php.net/strtoupper
+	 * @link    https://www.php.net/strtoupper
 	 * @since   1.3.0
 	 */
 	public static function strtoupper($str)
@@ -275,7 +275,7 @@ abstract class StringHelper
 	 *
 	 * @return  integer  Number of UTF-8 characters in string.
 	 *
-	 * @see     http://www.php.net/strlen
+	 * @link    https://www.php.net/strlen
 	 * @since   1.3.0
 	 */
 	public static function strlen($str)
@@ -295,7 +295,7 @@ abstract class StringHelper
 	 *
 	 * @return  string  UTF-8 String
 	 *
-	 * @see     http://www.php.net/str_ireplace
+	 * @link    https://www.php.net/str_ireplace
 	 * @since   1.3.0
 	 */
 	public static function str_ireplace($search, $replace, $str, $count = null)
@@ -321,7 +321,7 @@ abstract class StringHelper
 	 *
 	 * @return  string
 	 *
-	 * @see     http://www.php.net/str_pad
+	 * @link    https://www.php.net/str_pad
 	 * @since   1.4.0
 	 */
 	public static function str_pad($input, $length, $padStr = ' ', $type = STR_PAD_RIGHT)
@@ -334,17 +334,17 @@ abstract class StringHelper
 	 *
 	 * Convert a string to an array.
 	 *
-	 * @param   string   $str        UTF-8 encoded string to process
-	 * @param   integer  $split_len  Number to characters to split string by
+	 * @param   string   $str       UTF-8 encoded string to process
+	 * @param   integer  $splitLen  Number to characters to split string by
 	 *
 	 * @return  array
 	 *
-	 * @see     http://www.php.net/str_split
+	 * @link    https://www.php.net/str_split
 	 * @since   1.3.0
 	 */
-	public static function str_split($str, $split_len = 1)
+	public static function str_split($str, $splitLen = 1)
 	{
-		return utf8_str_split($str, $split_len);
+		return utf8_str_split($str, $splitLen);
 	}
 
 	/**
@@ -358,9 +358,9 @@ abstract class StringHelper
 	 *
 	 * @return  integer   < 0 if str1 is less than str2; > 0 if str1 is greater than str2, and 0 if they are equal.
 	 *
-	 * @see     http://www.php.net/strcasecmp
-	 * @see     http://www.php.net/strcoll
-	 * @see     http://www.php.net/setlocale
+	 * @link    https://www.php.net/strcasecmp
+	 * @link    https://www.php.net/strcoll
+	 * @link    https://www.php.net/setlocale
 	 * @since   1.3.0
 	 */
 	public static function strcasecmp($str1, $str2, $locale = false)
@@ -415,9 +415,9 @@ abstract class StringHelper
 	 *
 	 * @return  integer  < 0 if str1 is less than str2; > 0 if str1 is greater than str2, and 0 if they are equal.
 	 *
-	 * @see     http://www.php.net/strcmp
-	 * @see     http://www.php.net/strcoll
-	 * @see     http://www.php.net/setlocale
+	 * @link    https://www.php.net/strcmp
+	 * @link    https://www.php.net/strcoll
+	 * @link    https://www.php.net/setlocale
 	 * @since   1.3.0
 	 */
 	public static function strcmp($str1, $str2, $locale = false)
@@ -470,7 +470,7 @@ abstract class StringHelper
 	 *
 	 * @return  integer  The length of the initial segment of str1 which does not contain any of the characters in str2
 	 *
-	 * @see     http://www.php.net/strcspn
+	 * @link    https://www.php.net/strcspn
 	 * @since   1.3.0
 	 */
 	public static function strcspn($str, $mask, $start = null, $length = null)
@@ -499,7 +499,7 @@ abstract class StringHelper
 	 *
 	 * @return string the sub string
 	 *
-	 * @see     http://www.php.net/stristr
+	 * @link    https://www.php.net/stristr
 	 * @since   1.3.0
 	 */
 	public static function stristr($str, $search)
@@ -516,7 +516,7 @@ abstract class StringHelper
 	 *
 	 * @return  string   The string in reverse character order
 	 *
-	 * @see     http://www.php.net/strrev
+	 * @link    https://www.php.net/strrev
 	 * @since   1.3.0
 	 */
 	public static function strrev($str)
@@ -536,7 +536,7 @@ abstract class StringHelper
 	 *
 	 * @return  integer
 	 *
-	 * @see     http://www.php.net/strspn
+	 * @link    https://www.php.net/strspn
 	 * @since   1.3.0
 	 */
 	public static function strspn($str, $mask, $start = null, $length = null)
@@ -566,7 +566,7 @@ abstract class StringHelper
 	 *
 	 * @return  string
 	 *
-	 * @see     http://www.php.net/substr_replace
+	 * @link    https://www.php.net/substr_replace
 	 * @since   1.3.0
 	 */
 	public static function substr_replace($str, $repl, $start, $length = null)
@@ -591,7 +591,7 @@ abstract class StringHelper
 	 *
 	 * @return  string  The trimmed string
 	 *
-	 * @see     http://www.php.net/ltrim
+	 * @link    https://www.php.net/ltrim
 	 * @since   1.3.0
 	 */
 	public static function ltrim($str, $charlist = false)
@@ -620,7 +620,7 @@ abstract class StringHelper
 	 *
 	 * @return  string  The trimmed string
 	 *
-	 * @see     http://www.php.net/rtrim
+	 * @link    https://www.php.net/rtrim
 	 * @since   1.3.0
 	 */
 	public static function rtrim($str, $charlist = false)
@@ -649,7 +649,7 @@ abstract class StringHelper
 	 *
 	 * @return  string  The trimmed string
 	 *
-	 * @see     http://www.php.net/trim
+	 * @link    https://www.php.net/trim
 	 * @since   1.3.0
 	 */
 	public static function trim($str, $charlist = false)
@@ -680,7 +680,7 @@ abstract class StringHelper
 	 *                  else consider the string of words separated by the delimiter, apply the ucfirst to each words
 	 *                  and return the string with the new delimiter
 	 *
-	 * @see     http://www.php.net/ucfirst
+	 * @link    https://www.php.net/ucfirst
 	 * @since   1.3.0
 	 */
 	public static function ucfirst($str, $delimiter = null, $newDelimiter = null)
@@ -707,7 +707,7 @@ abstract class StringHelper
 	 *
 	 * @return  string  String with first char of each word uppercase
 	 *
-	 * @see     http://www.php.net/ucwords
+	 * @link    https://www.php.net/ucwords
 	 * @since   1.3.0
 	 */
 	public static function ucwords($str)
@@ -718,9 +718,9 @@ abstract class StringHelper
 	/**
 	 * Transcode a string.
 	 *
-	 * @param   string  $source         The string to transcode.
-	 * @param   string  $from_encoding  The source encoding.
-	 * @param   string  $to_encoding    The target encoding.
+	 * @param   string  $source        The string to transcode.
+	 * @param   string  $fromEncoding  The source encoding.
+	 * @param   string  $toEncoding    The target encoding.
 	 *
 	 * @return  mixed  The transcoded string, or null if the source was not a string.
 	 *
@@ -728,22 +728,20 @@ abstract class StringHelper
 	 *
 	 * @since   1.3.0
 	 */
-	public static function transcode($source, $from_encoding, $to_encoding)
+	public static function transcode($source, $fromEncoding, $toEncoding)
 	{
-		if (is_string($source))
+		if (\is_string($source))
 		{
 			switch (ICONV_IMPL)
 			{
 				case 'glibc':
-					return @iconv($from_encoding, $to_encoding . '//TRANSLIT,IGNORE', $source);
+					return @iconv($fromEncoding, $toEncoding . '//TRANSLIT,IGNORE', $source);
 
 				case 'libiconv':
 				default:
-					return iconv($from_encoding, $to_encoding . '//IGNORE//TRANSLIT', $source);
+					return iconv($fromEncoding, $toEncoding . '//IGNORE//TRANSLIT', $source);
 			}
 		}
-
-		return null;
 	}
 
 	/**
@@ -756,7 +754,7 @@ abstract class StringHelper
 	 * @return  boolean  true if valid
 	 *
 	 * @author  <hsivonen@iki.fi>
-	 * @see     http://hsivonen.iki.fi/php-utf8/
+	 * @link    https://hsivonen.fi/php-utf8/
 	 * @see     compliant
 	 * @since   1.3.0
 	 */
@@ -778,7 +776,7 @@ abstract class StringHelper
 	 * @return  boolean  TRUE if string is valid UTF-8
 	 *
 	 * @see     StringHelper::valid
-	 * @see     http://www.php.net/manual/en/reference.pcre.pattern.modifiers.php#54805
+	 * @link    https://www.php.net/manual/en/reference.pcre.pattern.modifiers.php#54805
 	 * @since   1.3.0
 	 */
 	public static function compliant($str)
@@ -797,7 +795,7 @@ abstract class StringHelper
 	 */
 	public static function unicode_to_utf8($str)
 	{
-		if (extension_loaded('mbstring'))
+		if (\extension_loaded('mbstring'))
 		{
 			return preg_replace_callback(
 				'/\\\\u([0-9a-fA-F]{4})/',
@@ -823,7 +821,7 @@ abstract class StringHelper
 	 */
 	public static function unicode_to_utf16($str)
 	{
-		if (extension_loaded('mbstring'))
+		if (\extension_loaded('mbstring'))
 		{
 			return preg_replace_callback(
 				'/\\\\u([0-9a-fA-F]{4})/',

--- a/libraries/vendor/joomla/string/src/phputf8/utf8.php
+++ b/libraries/vendor/joomla/string/src/phputf8/utf8.php
@@ -35,7 +35,14 @@ if ( !defined('UTF8') ) {
 * encoding
 */
 if ( extension_loaded('mbstring')) {
-    if ( ini_get('mbstring.func_overload') & MB_OVERLOAD_STRING ) {
+    /*
+     * Joomla modification - As of PHP 8, the `mbstring.func_overload` configuration has been removed and the
+     * MB_OVERLOAD_STRING constant will no longer be present, so this check only runs for PHP 7 and older
+     * See https://github.com/php/php-src/commit/331e56ce38a91e87a6fb8e88154bb5bde445b132
+     * and https://github.com/php/php-src/commit/97df99a6d7d96a886ac143337fecad775907589a
+     * for additional references
+     */
+    if ( PHP_VERSION_ID < 80000 && ((int) ini_get('mbstring.func_overload')) & MB_OVERLOAD_STRING ) {
         trigger_error('String functions are overloaded by mbstring',E_USER_ERROR);
     }
     mb_internal_encoding('UTF-8');


### PR DESCRIPTION
Pull Request for Issue #25234 .

### Summary of Changes

Update joomla/string package from framework.

### Testing Instructions

See [https://github.com/joomla/joomla-cms/pull/25234#issuecomment-502453650](https://github.com/joomla/joomla-cms/pull/25234#issuecomment-502453650) .

### Expected result

String package up to date.

Appveyor does not fail for the reason described below for actual result.

### Actual result

String package not up to date.

Appveyor tests failed here:
[https://github.com/joomla/joomla-cms/blob/staging/libraries/vendor/joomla/string/src/phputf8/utf8.php#L38](https://github.com/joomla/joomla-cms/blob/staging/libraries/vendor/joomla/string/src/phputf8/utf8.php#L38 "https://github.com/joomla/joomla-cms/blob/staging/libraries/vendor/joomla/string/src/phputf8/utf8.php#L38")
with error
> Warning: A non-numeric value encountered in C:\projects\joomla-cms\libraries\vendor\joomla\string\src\phputf8\utf8.php on line 38

### Documentation Changes Required

None.