### PR TITLE
[4.0] Removing broken CSS rule

### DIFF
--- a/templates/cassiopeia/scss/blocks/_css-grid.scss
+++ b/templates/cassiopeia/scss/blocks/_css-grid.scss
@@ -118,11 +118,6 @@
 .container-footer         { grid-area: footer; }
 .system-debug             { grid-area: debug; }
 
-.container-component {
-  /* autoprefixer: off */
-  grid-column: auto 2fr;
-}
-
 .container-top-a,
 .container-top-b,
 .container-bottom-a,


### PR DESCRIPTION
Pull Request for Issue #19476.

The deleted CSS rule is invalid. grid-column doesn't allow for a unit for integers and the template doesn't need this rule anyway.