### PR TITLE
Contact and Newsfeed title not incremented during batch copy

### DIFF
--- a/administrator/components/com_contact/models/contact.php
+++ b/administrator/components/com_contact/models/contact.php
@@ -527,35 +527,6 @@ class ContactModelContact extends JModelAdmin
 	}
 
 	/**
-	 * Method to change the title & alias.
-	 *
-	 * @param   integer  $category_id  The id of the parent.
-	 * @param   string   $alias        The alias.
-	 * @param   string   $name         The title.
-	 *
-	 * @return  array  Contains the modified title and alias.
-	 *
-	 * @since   3.1
-	 */
-	protected function generateNewTitle($category_id, $alias, $name)
-	{
-		// Alter the title & alias
-		$table = $this->getTable();
-
-		while ($table->load(array('alias' => $alias, 'catid' => $category_id)))
-		{
-			if ($name == $table->name)
-			{
-				$name = StringHelper::increment($name);
-			}
-
-			$alias = StringHelper::increment($alias, 'dash');
-		}
-
-		return array($name, $alias);
-	}
-
-	/**
 	 * Is the user allowed to create an on the fly category?
 	 *
 	 * @return  boolean

--- a/administrator/components/com_contact/tables/contact.php
+++ b/administrator/components/com_contact/tables/contact.php
@@ -38,6 +38,8 @@ class ContactTableContact extends JTable
 	{
 		parent::__construct('#__contact_details', 'id', $db);
 
+		$this->setColumnAlias('title', 'name');
+
 		JTableObserverTags::createObserver($this, array('typeAlias' => 'com_contact.contact'));
 		JTableObserverContenthistory::createObserver($this, array('typeAlias' => 'com_contact.contact'));
 	}

--- a/administrator/components/com_newsfeeds/models/newsfeed.php
+++ b/administrator/components/com_newsfeeds/models/newsfeed.php
@@ -451,35 +451,6 @@ class NewsfeedsModelNewsfeed extends JModelAdmin
 	}
 
 	/**
-	 * Method to change the title & alias.
-	 *
-	 * @param   integer  $category_id  The id of the parent.
-	 * @param   string   $alias        The alias.
-	 * @param   string   $name         The title.
-	 *
-	 * @return  array  Contains the modified title and alias.
-	 *
-	 * @since   3.1
-	 */
-	protected function generateNewTitle($category_id, $alias, $name)
-	{
-		// Alter the title & alias
-		$table = $this->getTable();
-
-		while ($table->load(array('alias' => $alias, 'catid' => $category_id)))
-		{
-			if ($name == $table->name)
-			{
-				$name = StringHelper::increment($name);
-			}
-
-			$alias = StringHelper::increment($alias, 'dash');
-		}
-
-		return array($name, $alias);
-	}
-
-	/**
 	 * Is the user allowed to create an on the fly category?
 	 *
 	 * @return  boolean

--- a/administrator/components/com_newsfeeds/tables/newsfeed.php
+++ b/administrator/components/com_newsfeeds/tables/newsfeed.php
@@ -35,6 +35,8 @@ class NewsfeedsTableNewsfeed extends JTable
 	{
 		parent::__construct('#__newsfeeds', 'id', $db);
 
+		$this->setColumnAlias('title', 'name');
+
 		JTableObserverTags::createObserver($this, array('typeAlias' => 'com_newsfeeds.newsfeed'));
 		JTableObserverContenthistory::createObserver($this, array('typeAlias' => 'com_newsfeeds.newsfeed'));
 	}

--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -913,9 +913,11 @@ abstract class AdminModel extends FormModel
 	protected function generateNewTitle($category_id, $alias, $title)
 	{
 		// Alter the title & alias
-		$table = $this->getTable();
+		$table      = $this->getTable();
+		$aliasField = $table->getColumnAlias('alias');
+		$catidField = $table->getColumnAlias('catid');
 
-		while ($table->load(array('alias' => $alias, 'catid' => $category_id)))
+		while ($table->load(array($aliasField => $alias, $catidField => $category_id)))
 		{
 			$title = StringHelper::increment($title);
 			$alias = StringHelper::increment($alias, 'dash');
@@ -1531,9 +1533,11 @@ abstract class AdminModel extends FormModel
 	public function generateTitle($categoryId, $table)
 	{
 		// Alter the title & alias
-		$data = $this->generateNewTitle($categoryId, $table->alias, $table->title);
-		$table->title = $data['0'];
-		$table->alias = $data['1'];
+		$titleField         = $table->getColumnAlias('title');
+		$aliasField         = $table->getColumnAlias('alias');
+		$data               = $this->generateNewTitle($categoryId, $table->$aliasField, $table->$titleField);
+		$table->$titleField = $data['0'];
+		$table->$aliasField = $data['1'];
 	}
 
 	/**

--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -916,10 +916,15 @@ abstract class AdminModel extends FormModel
 		$table      = $this->getTable();
 		$aliasField = $table->getColumnAlias('alias');
 		$catidField = $table->getColumnAlias('catid');
+		$titleField = $table->getColumnAlias('title');
 
 		while ($table->load(array($aliasField => $alias, $catidField => $category_id)))
 		{
-			$title = StringHelper::increment($title);
+			if ($title === $table->$titleField)
+			{
+				$title = StringHelper::increment($title);
+			}
+
 			$alias = StringHelper::increment($alias, 'dash');
 		}
 


### PR DESCRIPTION
Pull Request for Issue #25255.

### Summary of Changes

Set title column alias in `ContactTable` and `NewsfeedTable` table.
Use column aliases in `Joomla\CMS\MVC\Model\AdminModel::generateTitle()` and `Joomla\CMS\MVC\Model\AdminModel::generateNewTitle()`.
### Testing Instructions

Go to contacts or newsfeeds list in backend.
Select a contact/newsfeed.
Click Batch button.
Perform batch copy to the same category.

### Expected result

Contact/newsfeed title incremented, e.g. `Sample Contact` becomes `Sample Contact (2)`.

### Actual result

Contact/newsfeed title not incremented.

### Documentation Changes Required

No.