### PR TITLE
[4.0] Make sure the function matches the parent return type

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1389,12 +1389,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-framework/session.git",
-                "reference": "a112526bf86cdb5066abce08e904278cac02cac0"
+                "reference": "33aabeb73c1dfb9fc210199a6e542404d4984151"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/session/zipball/a112526bf86cdb5066abce08e904278cac02cac0",
-                "reference": "a112526bf86cdb5066abce08e904278cac02cac0",
+                "url": "https://api.github.com/repos/joomla-framework/session/zipball/33aabeb73c1dfb9fc210199a6e542404d4984151",
+                "reference": "33aabeb73c1dfb9fc210199a6e542404d4984151",
                 "shasum": ""
             },
             "require": {
@@ -1443,7 +1443,7 @@
                 "joomla",
                 "session"
             ],
-            "time": "2019-06-18T00:21:14+00:00"
+            "time": "2019-06-18T18:25:46+00:00"
         },
         {
             "name": "joomla/string",
@@ -2438,7 +2438,7 @@
                 },
                 {
                     "name": "Gert de Pagter",
-                    "email": "backendtea@gmail.com"
+                    "email": "BackEndTea@gmail.com"
                 }
             ],
             "description": "Symfony polyfill for ctype functions",
@@ -5401,7 +5401,7 @@
                     "email": "puneet.kala@community.joomla.org"
                 },
                 {
-                    "name": "Javier Gomez",
+                    "name": "Javier Gómez",
                     "email": "javier.gomez@community.joomla.org"
                 }
             ],
@@ -5489,7 +5489,7 @@
                     "email": "puneet.kala@community.joomla.org"
                 },
                 {
-                    "name": "Javier Gomez",
+                    "name": "Javier Gómez",
                     "email": "javier.gomez@community.joomla.org"
                 }
             ],

--- a/libraries/src/Session/Session.php
+++ b/libraries/src/Session/Session.php
@@ -201,7 +201,7 @@ class Session extends BaseSession
 	 *
 	 * @since   1.5
 	 */
-	public function clear(): void
+	public function clear()
 	{
 		// Handle B/C by checking if parameters were passed to this method; if so proxy to the new remove() method, will be removed at 5.0
 		if (func_num_args() >= 1)
@@ -230,10 +230,10 @@ class Session extends BaseSession
 					$name = $args[1] . '.' . $name;
 				}
 
-				$this->remove($name);
+				return $this->remove($name);
 			}
 		}
 
-		parent::clear();
+		return parent::clear();
 	}
 }

--- a/libraries/src/Session/Session.php
+++ b/libraries/src/Session/Session.php
@@ -201,7 +201,7 @@ class Session extends BaseSession
 	 *
 	 * @since   1.5
 	 */
-	public function clear()
+	public function clear(): void
 	{
 		// Handle B/C by checking if parameters were passed to this method; if so proxy to the new remove() method, will be removed at 5.0
 		if (func_num_args() >= 1)
@@ -230,10 +230,10 @@ class Session extends BaseSession
 					$name = $args[1] . '.' . $name;
 				}
 
-				return $this->remove($name);
+				$this->remove($name);
 			}
 		}
 
-		return parent::clear();
+		parent::clear();
 	}
 }

--- a/libraries/src/Session/Storage/JoomlaStorage.php
+++ b/libraries/src/Session/Storage/JoomlaStorage.php
@@ -267,7 +267,7 @@ class JoomlaStorage extends NativeStorage
 	 * @see     http://php.net/session.configuration
 	 * @since   4.0
 	 */
-	public function setOptions(array $options)
+	public function setOptions(array $options): NativeStorage
 	{
 		if (isset($options['force_ssl']))
 		{


### PR DESCRIPTION
### Summary of Changes
This fixes a fatal error when accessing the site

`Fatal error: Declaration of Joomla\CMS\Session\Storage\JoomlaStorage::setOptions(array $options) must be compatible with Joomla\Session\Storage\NativeStorage::setOptions(array $options): Joomla\Session\Storage\NativeStorage in libraries/src/Session/Storage/JoomlaStorage.php on line 23`

### Testing Instructions
1. Checkout the current Joomla 4 branch
2. Open the site and you get this fatal error:
```
Fatal error: Declaration of Joomla\CMS\Session\Storage\JoomlaStorage::setOptions(array $options) must be compatible with Joomla\Session\Storage\NativeStorage::setOptions(array $options): Joomla\Session\Storage\NativeStorage in libraries/src/Session/Storage/JoomlaStorage.php on line 23
```
3. Apply this pull request
4. Run `composer update`
5. Reload the site
6. Site now loads

### Expected result
The site loads

### Actual result
The site doesn't load

### Documentation Changes Required
None

Pinging @wilsonge 
