### PR TITLE
[4.0] Remove reference to obsolete language string

### DIFF
--- a/components/com_contact/tmpl/contact/default.xml
+++ b/components/com_contact/tmpl/contact/default.xml
@@ -308,7 +308,6 @@
 				name="show_profile"
 				type="list"
 				label="COM_CONTACT_FIELD_PROFILE_SHOW_LABEL"
-				description="COM_CONTACT_FIELD_PROFILE_SHOW_DESC"
 				useglobal="true"
 				class="chzn-color"
 				>


### PR DESCRIPTION
### Summary of Changes
Remove description attribute that references an obsolete language string.


### Testing Instructions
Create a menu item of Single Contact.
Scroll to `User Profile`.
See language constant.