### PR TITLE
[4.0] com_banners - remove unused submenu

### DIFF
--- a/administrator/components/com_banners/View/Banners/HtmlView.php
+++ b/administrator/components/com_banners/View/Banners/HtmlView.php
@@ -81,8 +81,6 @@ class HtmlView extends BaseHtmlView
 			throw new GenericDataException(implode("\n", $errors), 500);
 		}
 
-		BannersHelper::addSubmenu('banners');
-
 		$this->addToolbar();
 
 		// We do not need to filter by language when multilingual is disabled

--- a/administrator/components/com_banners/View/Banners/HtmlView.php
+++ b/administrator/components/com_banners/View/Banners/HtmlView.php
@@ -20,7 +20,6 @@ use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
-use Joomla\Component\Banners\Administrator\Helper\BannersHelper;
 
 /**
  * View class for a list of banners.

--- a/administrator/components/com_banners/View/Clients/HtmlView.php
+++ b/administrator/components/com_banners/View/Clients/HtmlView.php
@@ -68,8 +68,6 @@ class HtmlView extends BaseHtmlView
 			throw new GenericDataException(implode("\n", $errors), 500);
 		}
 
-		BannersHelper::addSubmenu('clients');
-
 		$this->addToolbar();
 
 		return parent::display($tpl);

--- a/administrator/components/com_banners/View/Clients/HtmlView.php
+++ b/administrator/components/com_banners/View/Clients/HtmlView.php
@@ -17,7 +17,6 @@ use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
-use Joomla\Component\Banners\Administrator\Helper\BannersHelper;
 
 /**
  * View class for a list of clients.

--- a/administrator/components/com_banners/View/Tracks/HtmlView.php
+++ b/administrator/components/com_banners/View/Tracks/HtmlView.php
@@ -70,8 +70,6 @@ class HtmlView extends BaseHtmlView
 			throw new GenericDataException(implode("\n", $errors), 500);
 		}
 
-		BannersHelper::addSubmenu('tracks');
-
 		$this->addToolbar();
 
 		return parent::display($tpl);

--- a/administrator/components/com_banners/View/Tracks/HtmlView.php
+++ b/administrator/components/com_banners/View/Tracks/HtmlView.php
@@ -19,7 +19,6 @@ use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
-use Joomla\Component\Banners\Administrator\Helper\BannersHelper;
 
 /**
  * View class for a list of tracks.


### PR DESCRIPTION
Remove unused references to `addSubmenu`in various views on com_banners