### PR TITLE
Update the AppVeyor badge to project changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Build Status
 ---------------------
 | Travis-CI  | Drone-CI | AppVeyor |
 | ------------- | ------------- | ------------- |
-| [![Build Status](https://travis-ci.org/joomla/joomla-cms.svg?branch=staging)](https://travis-ci.org/joomla/joomla-cms)  | [![Build Status](https://ci.joomla.org/api/badges/joomla/joomla-cms/status.svg)](https://ci.joomla.org/joomla/joomla-cms)  | [![Build status](https://ci.appveyor.com/api/projects/status/bpcxulw6nnxlv8kb/branch/staging?svg=true)](https://ci.appveyor.com/project/joomla/joomla-cms)  |
+| [![Build Status](https://travis-ci.org/joomla/joomla-cms.svg?branch=staging)](https://travis-ci.org/joomla/joomla-cms)  | [![Build Status](https://ci.joomla.org/api/badges/joomla/joomla-cms/status.svg)](https://ci.joomla.org/joomla/joomla-cms)  | [![Build status](https://ci.appveyor.com/api/projects/status/bpcxulw6nnxlv8kb/branch/staging?svg=true)](https://ci.appveyor.com/project/release-joomla/joomla-cms)  |
 
 What is this?
 ---------------------

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Build Status
 ---------------------
 | Travis-CI  | Drone-CI | AppVeyor |
 | ------------- | ------------- | ------------- |
-| [![Build Status](https://travis-ci.org/joomla/joomla-cms.svg?branch=staging)](https://travis-ci.org/joomla/joomla-cms)  | [![Build Status](https://ci.joomla.org/api/badges/joomla/joomla-cms/status.svg)](https://ci.joomla.org/joomla/joomla-cms)  | [![Build status](https://ci.appveyor.com/api/projects/status/bpcxulw6nnxlv8kb/branch/staging?svg=true)](https://ci.appveyor.com/project/release-joomla/joomla-cms)  |
+| [![Build Status](https://travis-ci.org/joomla/joomla-cms.svg?branch=staging)](https://travis-ci.org/joomla/joomla-cms)  | [![Build Status](https://ci.joomla.org/api/badges/joomla/joomla-cms/status.svg)](https://ci.joomla.org/joomla/joomla-cms)  | [![Build status](https://ci.appveyor.com/api/projects/status/ru6sxal8jmfckvjc/branch/staging?svg=true)](https://ci.appveyor.com/project/release-joomla/joomla-cms)  |
 
 What is this?
 ---------------------


### PR DESCRIPTION
Pull Request for Issue #25274 .

### Summary of Changes

Correct the appveyor badge for staging:

- Changed `project/joomla/joomla-cms` to `project/release-joomla/joomla-cms`.
- Changed token.

Thanks to @blastoise186 for reporting that issue.

### Testing Instructions

Check colour of the AppVeyor badge.

Click the AppVeyor badge on README.md.

### Expected result

Colour fits to current build status for staging.

After click, AppVeyor activity shown for the latest commits.

[https://github.com/richard67/joomla-cms/blob/patch-1/README.md](https://github.com/richard67/joomla-cms/blob/patch-1/README.md)

### Actual result

Colour fits to build status in neolithicum.

AppVeyor activity shown for commits from 9 months ago and older.

[https://github.com/joomla/joomla-cms/blob/staging/README.md](https://github.com/joomla/joomla-cms/blob/staging/README.md)

### Documentation Changes Required

None.