### PR TITLE
[4.0] [com_associations] Fix filters display in Target modal

### DIFF
--- a/administrator/components/com_associations/layouts/joomla/searchtools/default.php
+++ b/administrator/components/com_associations/layouts/joomla/searchtools/default.php
@@ -46,7 +46,7 @@ $filtersClass = isset($data['view']->activeFilters) && $data['view']->activeFilt
 ?>
 <div class="js-stools" role="search">
 	<?php // Add the itemtype and language selectors before the form filters. Do not display in modal. ?>
-	<?php $app = JFactory::getApplication(); ?>
+	<?php $app = Factory::getApplication(); ?>
 	<?php if ($app->input->get('forcedItemType', '', 'string') == '') : ?>
 		<?php $itemTypeField = $data['view']->filterForm->getField('itemtype'); ?>
 		<div class="js-stools-container-selector-first">

--- a/administrator/components/com_associations/layouts/joomla/searchtools/default.php
+++ b/administrator/components/com_associations/layouts/joomla/searchtools/default.php
@@ -45,20 +45,24 @@ HTMLHelper::_('searchtools.form', $data['options']['formSelector'], $data['optio
 $filtersClass = isset($data['view']->activeFilters) && $data['view']->activeFilters ? ' js-stools-container-filters-visible' : '';
 ?>
 <div class="js-stools" role="search">
-	<?php $itemTypeField = $data['view']->filterForm->getField('itemtype'); ?>
-	<?php $languageField = $data['view']->filterForm->getField('language'); ?>
-
-	<?php // Add the itemtype and language selectors before the form filters. ?>
-	<div class="js-stools-container-selector-first">
-		<div class="js-stools-field-selector js-stools-itemtype">
-			<?php echo $itemTypeField->input; ?>
+	<?php // Add the itemtype and language selectors before the form filters. Do not display in modal. ?>
+	<?php $app = JFactory::getApplication(); ?>
+	<?php if ($app->input->get('forcedItemType', '', 'string') == '') : ?>
+		<?php $itemTypeField = $data['view']->filterForm->getField('itemtype'); ?>
+		<div class="js-stools-container-selector-first">
+			<div class="js-stools-field-selector js-stools-itemtype">
+				<?php echo $itemTypeField->input; ?>
+			</div>
 		</div>
-	</div>
-	<div class="js-stools-container-selector">
-		<div class="js-stools-field-selector js-stools-language">
-			<?php echo $languageField->input; ?>
+	<?php endif; ?>
+	<?php if ($app->input->get('forcedLanguage', '', 'cmd') == '') : ?>
+		<?php $languageField = $data['view']->filterForm->getField('language'); ?>
+		<div class="js-stools-container-selector">
+			<div class="js-stools-field-selector js-stools-language">
+				<?php echo $languageField->input; ?>
+			</div>
 		</div>
-	</div>
+	<?php endif; ?>
 
 	<div class="js-stools-container-bar">
 		<?php echo $this->sublayout('bar', $data); ?>


### PR DESCRIPTION
### Summary of Changes
When choosing a new target in the side by side view, it opens a modal.
This modal should **not display the filters for item type or language** as these are forced.


### Testing Instructions
Create a multingual site using the multilingual sample data module.
Load Multilingual Associations, select an Item Type and a language.
Load the side by side for an item and then click on the "Change Target" button.
The modal should not display anymore the Item Type and Language filters after patch.


### Before patch
<img width="1167" alt="Screen Shot 2019-06-20 at 09 40 47" src="https://user-images.githubusercontent.com/869724/59830301-a57a7700-933f-11e9-8eb6-77983fea4b0e.png">



### After patch
<img width="1189" alt="Screen Shot 2019-06-20 at 09 39 24" src="https://user-images.githubusercontent.com/869724/59830313-ae6b4880-933f-11e9-9491-db37c5106f9b.png">

@Quy @travisrisner 
