### PR TITLE
Send proper MariaDB database version to the stats server

### DIFF
--- a/plugins/system/stats/stats.php
+++ b/plugins/system/stats/stats.php
@@ -324,7 +324,7 @@ class PlgSystemStats extends JPlugin
 	 */
 	private function getStatsData()
 	{
-		return array(
+		$data = array(
 			'unique_id'   => $this->getUniqueId(),
 			'php_version' => PHP_VERSION,
 			'db_type'     => $this->db->name,
@@ -332,6 +332,14 @@ class PlgSystemStats extends JPlugin
 			'cms_version' => JVERSION,
 			'server_os'   => php_uname('s') . ' ' . php_uname('r')
 		);
+
+		// Check if we have a MariaDB version string and extract the proper version from it
+		if (preg_match('/^(?:5\.5\.5-)?(mariadb-)?(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)/i', $data['db_version'], $versionParts))
+		{
+			$data['db_version'] = $versionParts['major'] . '.' . $versionParts['minor'] . '.' . $versionParts['patch'];
+		}
+
+		return $data;
 	}
 
 	/**


### PR DESCRIPTION
### Summary of Changes

Right now, when reporting stats for MariaDB users the CMS sends either a version string like "10.1.29-MariaDB" or "5.5.5-10.1.29-MariaDB" to the stats server when reporting data, which through the sanitization routines the latter ends up in an entry being tracked as "5.5.5".  In order to better track MariaDB usage, this pull request changes the string sent forward in the "5.5.5-10.1.29-MariaDB" case so that it is the MariaDB version number only (i.e. 10.1.29) without any of the extra cruft (note, the "10.1.29-MariaDB" case does get correctly sanitized down and stored as 10.1.29; the stats server's sanitization step for version strings basically removes everything after a SemVer compliant `<major>.<minor>.<patch>` matching segment, this is what removes the stability bit from the CMS version, or changes something like "5.5.9-1ubuntu4.11" into "5.5.9", and if you were using a Google Cloud SQL database their "5.7.14-google-log" string would be stored as "5.7.14").

This utilizes [the regex check](https://github.com/doctrine/dbal/blob/90f79c8b39fa451264537440ead0fe1ab1c751b8/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php#L173) from Doctrine that was referenced in https://github.com/joomla/joomla-cms/issues/25245#issuecomment-503479226

### Testing Instructions

Apply the patch to a Joomla installation which uses a MariaDB backend.  Then, check the data that the stats plugin will send to the server (you can see this info on the "System - Joomla! Statistics" plugin's edit screen).  Pre-patch, the database version should be whatever it is now; post-patch, if it has the "5.5.5-" prefix and "-MariaDB" suffix, it should be only the MariaDB version string (the stuff in the middle of the `*fix` bits).