### PR TITLE
[4.0] Enable utf8mb4 connections for mysql adapters on installation

### DIFF
--- a/installation/src/Helper/DatabaseHelper.php
+++ b/installation/src/Helper/DatabaseHelper.php
@@ -52,6 +52,17 @@ abstract class DatabaseHelper
 				'select'   => $select,
 			];
 
+			// Enable utf8mb4 connections for mysql adapters
+			if (strtolower($driver) === 'mysqli')
+			{
+				$options['utf8mb4'] = true;
+			}
+
+			if (strtolower($driver) === 'mysql')
+			{
+				$options['charset'] = 'utf8mb4';
+			}
+
 			// Get a database object.
 			$db = DatabaseDriver::getInstance($options);
 		}


### PR DESCRIPTION
Pull Request for issue described below.

### Summary of Changes

This is the same as PR #24704 but for the installation.

### Testing Instructions

1. Make a new, clean installation on 4.0-dev or with latest nightly 4.0.* build on a MySQL database using the PDO driver.
2. Goto system panel in backend and check if some database error.
3. Check database view and check which database error it is.
4. Check with PhpMyAdmin table charsets and collations.

### Expected result

No database error, all tables are created with utf8mb4 charset and collations.

### Actual result

One database error about tables not having been converted to utf8mb4, all tables are created with utf8 charset and collations.

What is funny: When connecting to the backend after installation, connection shows utf8mb4 support.

But using the "fix" button to run the utf8mb4 conversion does not help (which makes sense because 4.0 should have all converted already), so you have to live with that database error and wrong collation in db until the end of your life.

When using the MySQLi driver, everything is ok, i.e. this issue is only for the MySQL PDO driver.

But this might be just lucky circumstance, or to be more precise, inconsistency between the drivers regarding initial value for utf8mb4 support, and so this PR also adds the right default for the MySQLi driver.

At the end it is just the same for the installation as PR #24704 was for the installed J4.

With staging this issue does not exist, it exists only in 4.0-dev.

### Documentation Changes Required

None.