### PR TITLE
Add the category first to the ordering when sorting by "ordering"

### DIFF
--- a/administrator/components/com_content/models/articles.php
+++ b/administrator/components/com_content/models/articles.php
@@ -388,6 +388,11 @@ class ContentModelArticles extends JModelList
 		$orderCol  = $this->state->get('list.ordering', 'a.id');
 		$orderDirn = $this->state->get('list.direction', 'DESC');
 
+		if ($orderCol == 'a.ordering' || $orderCol == 'category_title')
+		{
+			$orderCol = $db->quoteName('c.title') . ' ' . $orderDirn . ', ' . $db->quoteName('a.ordering');
+		}
+
 		$query->order($db->escape($orderCol) . ' ' . $db->escape($orderDirn));
 
 		return $query;


### PR DESCRIPTION
### Summary of Changes
In backend when sorting the articles by "Ordering", it will now first order by the category title and only after that it sorts by ordering.
This is consistent with other core components (eg contacts, banners, newsfeeds) and makes drag-and-drop ordering more reliable.


### Testing Instructions
* Create multiple articles in multiple categories.
* Order by "Ordering"
* Check if items from the same category are grouped.
* Move the items around - reload the page and verify that they "stick" to your order.

### Expected result
Items aren't grouped by category.
Items keep in place after reloading.


### Actual result
Items of the same category are right beside them.
The items jump around seemingly randomingly


### Documentation Changes Required
None
