### PR TITLE
[4.0] Document: deprecate direct use of $_scripts and $_styleSheets

### DIFF
--- a/libraries/src/Document/Document.php
+++ b/libraries/src/Document/Document.php
@@ -140,6 +140,8 @@ class Document
 	 *
 	 * @var    array
 	 * @since  1.7.0
+	 *
+	 * @deprecated  5.0  Will be renamed to $scripts with private visibility
 	 */
 	public $_scripts = array();
 
@@ -148,6 +150,8 @@ class Document
 	 *
 	 * @var    array
 	 * @since  1.7.0
+	 *
+	 * @deprecated  5.0  Will be renamed to $script with private visibility
 	 */
 	public $_script = array();
 
@@ -155,6 +159,8 @@ class Document
 	 * Array of scripts options
 	 *
 	 * @var    array
+	 *
+	 * @since   3.5
 	 */
 	protected $scriptOptions = array();
 
@@ -163,6 +169,8 @@ class Document
 	 *
 	 * @var    array
 	 * @since  1.7.0
+	 *
+	 * @deprecated  5.0  Will be renamed to $styleSheets with private visibility
 	 */
 	public $_styleSheets = array();
 
@@ -171,6 +179,8 @@ class Document
 	 *
 	 * @var    array
 	 * @since  1.7.0
+	 *
+	 * @deprecated  5.0  Will be renamed to $style with private visibility
 	 */
 	public $_style = array();
 
@@ -532,6 +542,18 @@ class Document
 	}
 
 	/**
+	 * Return list of linked scripts
+	 *
+	 * @return  array
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getScripts()
+	{
+		return $this->_scripts;
+	}
+
+	/**
 	 * Adds a script to the page
 	 *
 	 * @param   string  $content  Script
@@ -553,6 +575,18 @@ class Document
 		}
 
 		return $this;
+	}
+
+	/**
+	 * Return list of scripts placed in the header
+	 *
+	 * @return  array
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getScriptDeclarations()
+	{
+		return $this->_script;
 	}
 
 	/**
@@ -640,6 +674,18 @@ class Document
 	}
 
 	/**
+	 * Return list of linked stylesheets
+	 *
+	 * @return  array
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getStyleSheets()
+	{
+		return $this->_styleSheets;
+	}
+
+	/**
 	 * Adds a stylesheet declaration to the page
 	 *
 	 * @param   string  $content  Style declarations
@@ -661,6 +707,18 @@ class Document
 		}
 
 		return $this;
+	}
+
+	/**
+	 * Return list of stylesheet declarations
+	 *
+	 * @return  array
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getStyleDeclarations()
+	{
+		return $this->_styleSheets;
 	}
 
 	/**

--- a/libraries/src/Document/Document.php
+++ b/libraries/src/Document/Document.php
@@ -517,7 +517,7 @@ class Document
 	}
 
 	/**
-	 * Adds a linked script to the page
+	 * Adds a linked script to the page. If the script already exists then merges its options and attributes.
 	 *
 	 * @param   string  $url      URL to the linked script.
 	 * @param   array   $options  Array of options. Example: array('version' => 'auto', 'conditional' => 'lt IE 9', 'preload' => array('preload'))
@@ -590,7 +590,7 @@ class Document
 	}
 
 	/**
-	 * Add option for script
+	 * Add option for script. By default merge with existing options or replace them when $merge = false.
 	 *
 	 * @param   string  $key      Name in Storage
 	 * @param   mixed   $options  Scrip options as array or string
@@ -641,7 +641,7 @@ class Document
 	}
 
 	/**
-	 * Adds a linked stylesheet to the page
+	 * Adds a linked stylesheet to the page. If the StyleSheet already exists then merges its options and attributes.
 	 *
 	 * @param   string  $url      URL to the linked style sheet
 	 * @param   array   $options  Array of options. Example: array('version' => 'auto', 'conditional' => 'lt IE 9', 'preload' => array('preload'))

--- a/libraries/src/Document/Document.php
+++ b/libraries/src/Document/Document.php
@@ -718,7 +718,7 @@ class Document
 	 */
 	public function getStyleDeclarations()
 	{
-		return $this->_styleSheets;
+		return $this->_style;
 	}
 
 	/**

--- a/libraries/src/Document/Document.php
+++ b/libraries/src/Document/Document.php
@@ -542,6 +542,29 @@ class Document
 	}
 
 	/**
+	 * Remove previously added script. If no URL provided then remove all scripts.
+	 *
+	 * @param   string  $url      URL of the linked script to be removed
+	 *
+	 * @return  Document instance of $this to allow chaining
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function removeScript($url = null)
+	{
+		if ($url === null)
+		{
+			$this->_scripts = array();
+		}
+		else
+		{
+			unset($this->_scripts[$url]);
+		}
+
+		return $this;
+	}
+
+	/**
 	 * Return list of linked scripts
 	 *
 	 * @return  array
@@ -572,6 +595,29 @@ class Document
 		else
 		{
 			$this->_script[strtolower($type)] .= chr(13) . $content;
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Reset script declaration by type. If no Type provided then reset all types.
+	 *
+	 * @param   string  $type      Script mime
+	 *
+	 * @return  Document instance of $this to allow chaining
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function resetScriptDeclaration($type = null)
+	{
+		if ($type === null)
+		{
+			$this->_script = array();
+		}
+		else
+		{
+			unset($this->_script[$type]);
 		}
 
 		return $this;
@@ -674,6 +720,29 @@ class Document
 	}
 
 	/**
+	 * Remove previously added stylesheet. If no URL provided then remove all stylesheets.
+	 *
+	 * @param   string  $url      URL of the linked stylesheet to be removed
+	 *
+	 * @return  Document instance of $this to allow chaining
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function removeStyleSheet($url = null)
+	{
+		if ($url === null)
+		{
+			$this->_styleSheets = array();
+		}
+		else
+		{
+			unset($this->_styleSheets[$url]);
+		}
+
+		return $this;
+	}
+
+	/**
 	 * Return list of linked stylesheets
 	 *
 	 * @return  array
@@ -704,6 +773,29 @@ class Document
 		else
 		{
 			$this->_style[strtolower($type)] .= chr(13) . $content;
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Reset style declaration by type. If no Type provided then reset all types.
+	 *
+	 * @param   string  $type      Type of stylesheet
+	 *
+	 * @return  Document instance of $this to allow chaining
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function resetStyleDeclaration($type = null)
+	{
+		if ($type === null)
+		{
+			$this->_style = array();
+		}
+		else
+		{
+			unset($this->_style[$type]);
 		}
 
 		return $this;

--- a/libraries/src/Document/Document.php
+++ b/libraries/src/Document/Document.php
@@ -1255,7 +1255,7 @@ class Document
 	protected function preloadAssets()
 	{
 		// Process stylesheets first
-		foreach ($this->_styleSheets as $link => $properties)
+		foreach ($this->getStyleSheets() as $link => $properties)
 		{
 			if (empty($properties['options']['preload']))
 			{
@@ -1281,7 +1281,7 @@ class Document
 		}
 
 		// Now process scripts
-		foreach ($this->_scripts as $link => $properties)
+		foreach ($this->getScripts() as $link => $properties)
 		{
 			if (empty($properties['options']['preload']))
 			{

--- a/libraries/src/Document/Document.php
+++ b/libraries/src/Document/Document.php
@@ -141,7 +141,7 @@ class Document
 	 * @var    array
 	 * @since  1.7.0
 	 *
-	 * @deprecated  5.0  Will be renamed to $scripts with private visibility
+	 * @deprecated  5.0  Will be renamed to $scripts with protected visibility
 	 */
 	public $_scripts = array();
 
@@ -151,7 +151,7 @@ class Document
 	 * @var    array
 	 * @since  1.7.0
 	 *
-	 * @deprecated  5.0  Will be renamed to $script with private visibility
+	 * @deprecated  5.0  Will be renamed to $script with protected visibility
 	 */
 	public $_script = array();
 
@@ -170,7 +170,7 @@ class Document
 	 * @var    array
 	 * @since  1.7.0
 	 *
-	 * @deprecated  5.0  Will be renamed to $styleSheets with private visibility
+	 * @deprecated  5.0  Will be renamed to $styleSheets with protected visibility
 	 */
 	public $_styleSheets = array();
 
@@ -180,7 +180,7 @@ class Document
 	 * @var    array
 	 * @since  1.7.0
 	 *
-	 * @deprecated  5.0  Will be renamed to $style with private visibility
+	 * @deprecated  5.0  Will be renamed to $style with protected visibility
 	 */
 	public $_style = array();
 

--- a/libraries/src/Document/HtmlDocument.php
+++ b/libraries/src/Document/HtmlDocument.php
@@ -148,10 +148,10 @@ class HtmlDocument extends Document
 		$data['link']        = $this->link;
 		$data['metaTags']    = $this->_metaTags;
 		$data['links']       = $this->_links;
-		$data['styleSheets'] = $this->_styleSheets;
-		$data['style']       = $this->_style;
-		$data['scripts']     = $this->_scripts;
-		$data['script']      = $this->_script;
+		$data['styleSheets'] = $this->getStyleSheets();
+		$data['style']       = $this->getStyleDeclarations();
+		$data['scripts']     = $this->getScripts();
+		$data['script']      = $this->getScriptDeclarations();
 		$data['custom']      = $this->_custom;
 		$data['scriptText']  = Text::getScriptStrings();
 

--- a/libraries/src/Document/HtmlDocument.php
+++ b/libraries/src/Document/HtmlDocument.php
@@ -176,11 +176,12 @@ class HtmlDocument extends Document
 			$this->link         = '';
 			$this->_metaTags    = array();
 			$this->_links       = array();
-			$this->_styleSheets = array();
-			$this->_style       = array();
-			$this->_scripts     = array();
-			$this->_script      = array();
 			$this->_custom      = array();
+
+			$this->removeStyleSheet();
+			$this->resetStyleDeclaration();
+			$this->removeScript();
+			$this->resetScriptDeclaration();
 		}
 
 		if (is_array($types))
@@ -220,13 +221,25 @@ class HtmlDocument extends Document
 
 			case 'metaTags':
 			case 'links':
-			case 'styleSheets':
-			case 'style':
-			case 'scripts':
-			case 'script':
 			case 'custom':
 				$realType = '_' . $type;
 				$this->{$realType} = array();
+				break;
+
+			case 'styleSheets':
+				$this->removeStyleSheet();
+				break;
+
+			case 'style':
+				$this->resetStyleDeclaration();
+				break;
+
+			case 'scripts':
+				$this->removeScript();
+				break;
+
+			case 'script':
+				$this->resetScriptDeclaration();
 				break;
 		}
 	}

--- a/libraries/src/Document/Renderer/Html/ScriptsRenderer.php
+++ b/libraries/src/Document/Renderer/Html/ScriptsRenderer.php
@@ -43,7 +43,7 @@ class ScriptsRenderer extends DocumentRenderer
 		$html5NoValueAttributes = array('defer', 'async');
 
 		// Generate script file links
-		foreach ($this->_doc->_scripts as $src => $attribs)
+		foreach ($this->_doc->getScripts() as $src => $attribs)
 		{
 			// Check if script uses IE conditional statements.
 			$conditional = isset($attribs['options']) && isset($attribs['options']['conditional']) ? $attribs['options']['conditional'] : null;
@@ -121,7 +121,7 @@ class ScriptsRenderer extends DocumentRenderer
 		}
 
 		// Generate script declarations
-		foreach ($this->_doc->_script as $type => $contents)
+		foreach ($this->_doc->getScriptDeclarations() as $type => $contents)
 		{
 			$buffer .= $tab . '<script';
 

--- a/libraries/src/Document/Renderer/Html/StylesRenderer.php
+++ b/libraries/src/Document/Renderer/Html/StylesRenderer.php
@@ -43,7 +43,7 @@ class StylesRenderer extends DocumentRenderer
 		$defaultCssMimes = array('text/css');
 
 		// Generate stylesheet links
-		foreach ($this->_doc->_styleSheets as $src => $attribs)
+		foreach ($this->_doc->getStyleSheets() as $src => $attribs)
 		{
 			// Check if stylesheet uses IE conditional statements.
 			$conditional = isset($attribs['options']) && isset($attribs['options']['conditional']) ? $attribs['options']['conditional'] : null;
@@ -107,7 +107,7 @@ class StylesRenderer extends DocumentRenderer
 		}
 
 		// Generate stylesheet declarations
-		foreach ($this->_doc->_style as $type => $contents)
+		foreach ($this->_doc->getStyleDeclarations() as $type => $contents)
 		{
 			$buffer .= $tab . '<style';
 

--- a/libraries/src/WebAsset/WebAssetManager.php
+++ b/libraries/src/WebAsset/WebAssetManager.php
@@ -356,8 +356,8 @@ class WebAssetManager implements WebAssetManagerInterface, DispatcherAwareInterf
 		$this->assetsAttached = true;
 
 		// Pre-save existing Scripts, and attach them after requested assets.
-		$jsBackup = $doc->_scripts;
-		$doc->_scripts = [];
+		$jsBackup = $doc->getScripts();
+		$doc->resetHeadData('scripts');
 
 		// Attach active assets to the document
 		foreach ($assets as $asset)
@@ -386,7 +386,10 @@ class WebAssetManager implements WebAssetManagerInterface, DispatcherAwareInterf
 		}
 
 		// Merge with previously added scripts
-		$doc->_scripts = array_replace($doc->_scripts, $jsBackup);
+		foreach ($jsBackup as $url => $attribs)
+		{
+			$doc->addScript($url, [], $attribs);
+		}
 
 		return $this;
 	}

--- a/libraries/src/WebAsset/WebAssetManager.php
+++ b/libraries/src/WebAsset/WebAssetManager.php
@@ -357,7 +357,7 @@ class WebAssetManager implements WebAssetManagerInterface, DispatcherAwareInterf
 
 		// Pre-save existing Scripts, and attach them after requested assets.
 		$jsBackup = $doc->getScripts();
-		$doc->resetHeadData('scripts');
+		$doc->removeScript();
 
 		// Attach active assets to the document
 		foreach ($assets as $asset)


### PR DESCRIPTION
### Summary of Changes

Deprecate direct use of `$_scripts`, `$_script` and `$_styleSheets`, `$_style`.
Introduce `Document::getScripts()` `Document::getStyleSheets()` etc.


### Testing Instructions

Apply the patch and make sure everything still works as before the patch.


### Documentation Changes Required

If   `$_scripts`, `$_script` and `$_styleSheets`, `$_style` mentioned somewhere, then it should be changed to `Document::getScripts()`, `Document::getScriptDeclarations()`, `Document::getStyleSheets()`,  `Document::getStyleDeclarations()`.


