### PR TITLE
[subform] Validation of multiple subform. Fix Invalid argument supplied

### DIFF
--- a/libraries/src/Form/Form.php
+++ b/libraries/src/Form/Form.php
@@ -1551,7 +1551,7 @@ class Form
 					$field   = $this->loadField($element);
 					$subForm = $field->loadSubForm();
 
-					if ($field->multiple)
+					if ($field->multiple && !empty($value))
 					{
 						$return = array();
 


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/25308

### Summary of Changes
- Add check for empty $value when a multiple subform without rows is sent through validation.

### Testing Instructions
- See issue https://github.com/joomla/joomla-cms/issues/25308

### Expected result
- No PHP warning

### Actual result
`PHP Warning: Invalid argument supplied for foreach() in \libraries\src\Form\Form.php on line 1558`
