### PR TITLE
[4.0] Optimize imports in components

### DIFF
--- a/components/com_contact/tmpl/contact/default_links.php
+++ b/components/com_contact/tmpl/contact/default_links.php
@@ -9,7 +9,6 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
 ?>

--- a/components/com_contact/tmpl/contact/default_user_custom_fields.php
+++ b/components/com_contact/tmpl/contact/default_user_custom_fields.php
@@ -10,7 +10,6 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Application\ApplicationHelper;
-use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
 $params             = $this->item->params;

--- a/components/com_tags/Model/TagsModel.php
+++ b/components/com_tags/Model/TagsModel.php
@@ -15,7 +15,6 @@ use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Helper\ContentHelper;
 use Joomla\CMS\MVC\Model\ListModel;
-use Joomla\Registry\Registry;
 
 /**
  * This models supports retrieving a list of tags.

--- a/components/com_tags/View/Tag/FeedView.php
+++ b/components/com_tags/View/Tag/FeedView.php
@@ -14,7 +14,6 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Router\Route;
-use Joomla\Component\Tags\Site\Helper\TagsHelperRoute;
 
 defined('_JEXEC') or die;
 

--- a/components/com_users/Controller/ProfileController.php
+++ b/components/com_users/Controller/ProfileController.php
@@ -10,16 +10,9 @@ namespace Joomla\Component\Users\Site\Controller;
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\Client\ClientHelper;
 use Joomla\CMS\Factory;
-use Joomla\CMS\Filesystem\File;
-use Joomla\CMS\Help\Help;
-use Joomla\CMS\Helper\TagsHelper;
-use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Controller\BaseController;
-use Joomla\CMS\MVC\Model\BaseDatabaseModel;
-use Joomla\CMS\Response\JsonResponse;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
 

--- a/components/com_users/Model/ProfileModel.php
+++ b/components/com_users/Model/ProfileModel.php
@@ -16,7 +16,6 @@ use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Form\FormFactoryInterface;
-use Joomla\CMS\Helper\TagsHelper;
 use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;

--- a/components/com_users/View/Profile/HtmlView.php
+++ b/components/com_users/View/Profile/HtmlView.php
@@ -12,7 +12,6 @@ namespace Joomla\Component\Users\Site\View\Profile;
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
-use Joomla\CMS\Helper\TagsHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;


### PR DESCRIPTION
### Summary of Changes
Optimizes the imports of PHP classes for the front end components. This is done by PHPStorm's "Optimize Imports" function. It alpha orders the imports and removes the ones which are not used.

### Testing Instructions
- Create a contact menu item
- Create a tags menu item
- Create a users profile menu item
- Open these new links

### Expected result
All is working as expected.

### Actual result
All is working as expected.