### PR TITLE
[4.0] Optimize imports in libraries

### DIFF
--- a/libraries/src/Application/SiteApplication.php
+++ b/libraries/src/Application/SiteApplication.php
@@ -19,7 +19,6 @@ use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\Input\Input;
 use Joomla\CMS\Language\LanguageHelper;
 use Joomla\CMS\Language\Text;
-use Joomla\CMS\Menu\AbstractMenu;
 use Joomla\CMS\Pathway\Pathway;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Router\Route;

--- a/libraries/src/Authentication/Authentication.php
+++ b/libraries/src/Authentication/Authentication.php
@@ -13,7 +13,6 @@ defined('JPATH_PLATFORM') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
-use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\Event\DispatcherAwareTrait;
 use Joomla\Event\DispatcherInterface;

--- a/libraries/src/Categories/CategoryServiceTrait.php
+++ b/libraries/src/Categories/CategoryServiceTrait.php
@@ -10,7 +10,6 @@ namespace Joomla\CMS\Categories;
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Helper\ContentHelper;
 

--- a/libraries/src/Changelog/Changelog.php
+++ b/libraries/src/Changelog/Changelog.php
@@ -10,8 +10,6 @@ namespace Joomla\CMS\Changelog;
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\CMS\Factory;
-use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\Http\HttpFactory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;

--- a/libraries/src/Component/ComponentHelper.php
+++ b/libraries/src/Component/ComponentHelper.php
@@ -19,7 +19,6 @@ use Joomla\CMS\Dispatcher\ComponentDispatcher;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\Language\Text;
-use Joomla\CMS\Log\Log;
 use Joomla\CMS\Profiler\Profiler;
 use Joomla\Registry\Registry;
 

--- a/libraries/src/Installer/Adapter/LibraryAdapter.php
+++ b/libraries/src/Installer/Adapter/LibraryAdapter.php
@@ -12,8 +12,6 @@ defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Filesystem\File;
 use Joomla\CMS\Filesystem\Folder;
-use Joomla\CMS\Filesystem\Path;
-use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\Installer\Installer;
 use Joomla\CMS\Installer\InstallerAdapter;
 use Joomla\CMS\Installer\Manifest\LibraryManifest;

--- a/libraries/src/Installer/InstallerHelper.php
+++ b/libraries/src/Installer/InstallerHelper.php
@@ -19,8 +19,8 @@ use Joomla\CMS\Http\HttpFactory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
 use Joomla\CMS\Plugin\PluginHelper;
-use Joomla\CMS\Version;
 use Joomla\CMS\Updater\Update;
+use Joomla\CMS\Version;
 
 /**
  * Installer helper class

--- a/libraries/src/MVC/Controller/AdminController.php
+++ b/libraries/src/MVC/Controller/AdminController.php
@@ -16,7 +16,6 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
 use Joomla\CMS\MVC\Model\BaseDatabaseModel;
 use Joomla\CMS\Router\Route;
-use Joomla\CMS\Session\Session;
 use Joomla\Utilities\ArrayHelper;
 
 /**

--- a/libraries/src/MVC/Factory/ApiMVCFactory.php
+++ b/libraries/src/MVC/Factory/ApiMVCFactory.php
@@ -8,8 +8,6 @@
 
 namespace Joomla\CMS\MVC\Factory;
 
-use Joomla\CMS\Factory;
-
 defined('JPATH_PLATFORM') or die;
 
 /**

--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -14,6 +14,7 @@ use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\FormFactoryInterface;
 use Joomla\CMS\Language\Associations;
+use Joomla\CMS\Language\LanguageHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
@@ -25,7 +26,6 @@ use Joomla\CMS\UCM\UCMType;
 use Joomla\Registry\Registry;
 use Joomla\String\StringHelper;
 use Joomla\Utilities\ArrayHelper;
-use Joomla\CMS\Language\LanguageHelper;
 
 /**
  * Prototype admin model.

--- a/libraries/src/MVC/Model/FormModel.php
+++ b/libraries/src/MVC/Model/FormModel.php
@@ -10,16 +10,15 @@ namespace Joomla\CMS\MVC\Model;
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\CMS\Factory;
 use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\Form\Form;
-use Joomla\CMS\Form\FormRule;
-use Joomla\CMS\Language\Text;
-use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
-use Joomla\CMS\Factory;
 use Joomla\CMS\Form\FormFactoryAwareInterface;
 use Joomla\CMS\Form\FormFactoryAwareTrait;
 use Joomla\CMS\Form\FormFactoryInterface;
-use Joomla\Utilities\ArrayHelper;
+use Joomla\CMS\Form\FormRule;
+use Joomla\CMS\Language\Text;
+use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
 use Joomla\CMS\Plugin\PluginHelper;
 
 /**

--- a/libraries/src/MVC/Model/ListModel.php
+++ b/libraries/src/MVC/Model/ListModel.php
@@ -17,7 +17,6 @@ use Joomla\CMS\Form\FormFactoryAwareTrait;
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
 use Joomla\CMS\Pagination\Pagination;
 use Joomla\Database\DatabaseQuery;
-use Joomla\Utilities\ArrayHelper;
 
 /**
  * Model class for handling lists of items.

--- a/libraries/src/Menu/MenuItem.php
+++ b/libraries/src/Menu/MenuItem.php
@@ -10,7 +10,6 @@ namespace Joomla\CMS\Menu;
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\CMS\Menu\AbstractMenu;
 use Joomla\CMS\Tree\NodeInterface;
 use Joomla\CMS\Tree\NodeTrait;
 use Joomla\Registry\Registry;

--- a/libraries/src/Router/ApiRouter.php
+++ b/libraries/src/Router/ApiRouter.php
@@ -13,8 +13,8 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Application\CMSApplicationInterface;
 use Joomla\CMS\Router\Exception\RouteNotFoundException;
 use Joomla\CMS\Uri\Uri;
-use Joomla\Router\Router;
 use Joomla\Router\Route;
+use Joomla\Router\Router;
 
 /**
  * Joomla! API Router class

--- a/libraries/src/Router/SiteRouter.php
+++ b/libraries/src/Router/SiteRouter.php
@@ -18,7 +18,6 @@ use Joomla\CMS\Component\Router\RouterServiceInterface;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Menu\AbstractMenu;
 use Joomla\CMS\Uri\Uri;
-use Joomla\String\StringHelper;
 
 /**
  * Class to create and parse routes for the site application

--- a/libraries/src/Table/Content.php
+++ b/libraries/src/Table/Content.php
@@ -10,7 +10,6 @@ namespace Joomla\CMS\Table;
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\CMS\Access\Access;
 use Joomla\CMS\Access\Rules;
 use Joomla\CMS\Application\ApplicationHelper;
 use Joomla\CMS\Factory;

--- a/libraries/src/Tree/NodeTrait.php
+++ b/libraries/src/Tree/NodeTrait.php
@@ -10,9 +10,6 @@ namespace Joomla\CMS\Tree;
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\CMS\Tree\ImmutableNodeTrait;
-use Joomla\CMS\Tree\NodeInterface;
-
 /**
  * Defines the trait for a Node Interface Trait Class.
  *

--- a/libraries/src/WebAsset/WebAssetManager.php
+++ b/libraries/src/WebAsset/WebAssetManager.php
@@ -12,8 +12,8 @@ defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Document\Document;
 use Joomla\CMS\Event\AbstractEvent;
-use Joomla\CMS\WebAsset\Exception\UnknownAssetException;
 use Joomla\CMS\WebAsset\Exception\InvalidActionException;
+use Joomla\CMS\WebAsset\Exception\UnknownAssetException;
 use Joomla\CMS\WebAsset\Exception\UnsatisfiedDependencyException;
 use Joomla\Event\DispatcherAwareInterface;
 use Joomla\Event\DispatcherAwareTrait;

--- a/libraries/src/WebAsset/WebAssetManagerInterface.php
+++ b/libraries/src/WebAsset/WebAssetManagerInterface.php
@@ -11,9 +11,9 @@ namespace Joomla\CMS\WebAsset;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Document\Document;
+use Joomla\CMS\WebAsset\Exception\InvalidActionException;
 use Joomla\CMS\WebAsset\Exception\UnknownAssetException;
 use Joomla\CMS\WebAsset\Exception\UnsatisfiedDependencyException;
-use Joomla\CMS\WebAsset\Exception\InvalidActionException;
 
 /**
  * Web Asset Manager Interface


### PR DESCRIPTION
### Summary of Changes
Optimizes the imports of PHP classes for the core libraries. This is done by PHPStorm's "Optimize Imports" function. It alpha orders the imports and removes the ones which are not used.

### Testing Instructions
Browse around in the back end.

### Expected result
All is working as expected.

### Actual result
All is working as expected.