### PR TITLE
[4.0] Optimize imports in modules

### DIFF
--- a/modules/mod_menu/tmpl/default.php
+++ b/modules/mod_menu/tmpl/default.php
@@ -9,8 +9,8 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Helper\ModuleHelper;
+use Joomla\CMS\HTML\HTMLHelper;
 
 HTMLHelper::_('script', 'mod_menu/menu.min.js', array('version' => 'auto', 'relative' => true));
 

--- a/modules/mod_tags_similar/tmpl/default.php
+++ b/modules/mod_tags_similar/tmpl/default.php
@@ -9,7 +9,6 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 
 if (!$list)


### PR DESCRIPTION
### Summary of Changes
Optimizes the imports of PHP classes for the front end modules. This is done by PHPStorm's "Optimize Imports" function. It alpha orders the imports and removes the ones which are not used.

### Testing Instructions
- Create a tags module and publish it on all sites
- Open the front end
- Click on the menu module

### Expected result
All is working as expected.

### Actual result
All is working as expected.