### PR TITLE
Fix display of subform repeatable on IE

### DIFF
--- a/layouts/joomla/form/field/subform/repeatable-table.php
+++ b/layouts/joomla/form/field/subform/repeatable-table.php
@@ -120,7 +120,7 @@ else
 			</table>
 
 			<?php if ($multiple) : ?>
-				<template class="subform-repeatable-template-section"><?php echo trim(
+				<template class="subform-repeatable-template-section" style="display:none"><?php echo trim(
 					$this->sublayout(
 						$sublayout,
 						array(

--- a/layouts/joomla/form/field/subform/repeatable.php
+++ b/layouts/joomla/form/field/subform/repeatable.php
@@ -70,7 +70,7 @@ $sublayout = empty($groupByFieldset) ? 'section' : 'section-byfieldsets';
 		endforeach;
 		?>
 		<?php if ($multiple) : ?>
-			<template class="subform-repeatable-template-section"><?php echo trim(
+			<template class="subform-repeatable-template-section" style="display:none"><?php echo trim(
 				$this->sublayout(
 					$sublayout,
 					array(


### PR DESCRIPTION
Replace PR #25200

Thanks @Fedik for the suggested code.

### Summary of Changes
Hide subform template on IE11.


### Testing Instructions
Use IE11

Go System > Global Configuration > Users > Email Domain Options
Template should not be displayed in the bottom left corner.

Go Extensions > Plugins > System - Redirect
Template should not be displayed at the bottom initially.

### Expected result
Subform template should not be displayed