### PR TITLE
[4.0] Remove module class suffix from module files

### DIFF
--- a/administrator/modules/mod_feed/mod_feed.php
+++ b/administrator/modules/mod_feed/mod_feed.php
@@ -9,9 +9,8 @@
 
 defined('_JEXEC') or die;
 
-$feed            = \Joomla\Module\Feed\Administrator\Helper\FeedHelper::getFeed($params);
-$rssurl          = $params->get('rssurl', '');
-$rssrtl          = $params->get('rssrtl', 0);
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
+$feed   = \Joomla\Module\Feed\Administrator\Helper\FeedHelper::getFeed($params);
+$rssurl = $params->get('rssurl', '');
+$rssrtl = $params->get('rssrtl', 0);
 
 require \Joomla\CMS\Helper\ModuleHelper::getLayoutPath('mod_feed', $params->get('layout', 'default'));

--- a/administrator/modules/mod_feed/tmpl/default.php
+++ b/administrator/modules/mod_feed/tmpl/default.php
@@ -65,7 +65,7 @@ else
 		$iUrl   = $feed->image ?? null;
 		$iTitle = $feed->imagetitle ?? null;
 		?>
-		<div style="direction: <?php echo $rssrtl ? 'rtl' :'ltr'; ?>; text-align: <?php echo $rssrtl ? 'right' :'left'; ?> !important" class="feed<?php echo $moduleclass_sfx; ?>">
+		<div style="direction: <?php echo $rssrtl ? 'rtl' :'ltr'; ?>; text-align: <?php echo $rssrtl ? 'right' :'left'; ?> !important" class="feed">
 		<?php
 
 		// Feed title
@@ -95,7 +95,7 @@ else
 
 	<?php // Show items ?>
 	<?php if (!empty($feed)) : ?>
-		<ul class="newsfeed<?php echo $params->get('moduleclass_sfx'); ?> list-group">
+		<ul class="newsfeed list-group">
 		<?php for ($i = 0; $i < $params->get('rssitems', 3); $i++) :
 
 			if (!$feed->offsetExists($i)) :

--- a/administrator/modules/mod_feed/tmpl/default.php
+++ b/administrator/modules/mod_feed/tmpl/default.php
@@ -65,7 +65,7 @@ else
 		$iUrl   = $feed->image ?? null;
 		$iTitle = $feed->imagetitle ?? null;
 		?>
-		<div style="direction: <?php echo $rssrtl ? 'rtl' :'ltr'; ?>; text-align: <?php echo $rssrtl ? 'right' :'left'; ?> !important" class="feed">
+		<div style="direction: <?php echo $rssrtl ? 'rtl' : 'ltr'; ?>; text-align: <?php echo $rssrtl ? 'right' : 'left'; ?> !important" class="feed">
 		<?php
 
 		// Feed title

--- a/administrator/modules/mod_privacy_dashboard/mod_privacy_dashboard.php
+++ b/administrator/modules/mod_privacy_dashboard/mod_privacy_dashboard.php
@@ -31,7 +31,6 @@ HTMLHelper::addIncludePath(JPATH_ADMINISTRATOR . '/components/com_privacy/helper
 
 JLoader::register('ModPrivacyDashboardHelper', __DIR__ . '/helper.php');
 
-$list            = ModPrivacyDashboardHelper::getData();
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
+$list = ModPrivacyDashboardHelper::getData();
 
 require ModuleHelper::getLayoutPath('mod_privacy_dashboard', $params->get('layout', 'default'));

--- a/administrator/modules/mod_stats_admin/mod_stats_admin.php
+++ b/administrator/modules/mod_stats_admin/mod_stats_admin.php
@@ -14,9 +14,8 @@ use Joomla\CMS\Helper\ModuleHelper;
 use Joomla\Database\DatabaseInterface;
 use Joomla\Module\StatsAdmin\Administrator\Helper\StatsAdminHelper;
 
-$serverinfo      = $params->get('serverinfo');
-$siteinfo        = $params->get('siteinfo');
-$list            = StatsAdminHelper::getStats($params, $app, Factory::getContainer()->get(DatabaseInterface::class));
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
+$serverinfo = $params->get('serverinfo');
+$siteinfo   = $params->get('siteinfo');
+$list       = StatsAdminHelper::getStats($params, $app, Factory::getContainer()->get(DatabaseInterface::class));
 
 require ModuleHelper::getLayoutPath('mod_stats_admin', $params->get('layout', 'default'));

--- a/administrator/modules/mod_stats_admin/tmpl/default.php
+++ b/administrator/modules/mod_stats_admin/tmpl/default.php
@@ -29,7 +29,7 @@ Factory::getDocument()->addScriptDeclaration('
 	});
 ');
 ?>
-<ul class="list-group list-group-flush stats-module <?php echo $moduleclass_sfx ?>">
+<ul class="list-group list-group-flush stats-module">
 	<?php foreach ($list as $item) : ?>
 		<li class="list-group-item">
 			<span class="mr-2 fa-fw fa fa-<?php echo $item->icon; ?>" aria-hidden="true"></span> <?php echo $item->title; ?>

--- a/modules/mod_related_items/mod_related_items.php
+++ b/modules/mod_related_items/mod_related_items.php
@@ -26,7 +26,6 @@ if (!count($list))
 	return;
 }
 
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
-$showDate        = $params->get('showDate', 0);
+$showDate = $params->get('showDate', 0);
 
 require ModuleHelper::getLayoutPath('mod_related_items', $params->get('layout', 'default'));

--- a/modules/mod_related_items/tmpl/default.php
+++ b/modules/mod_related_items/tmpl/default.php
@@ -13,7 +13,7 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
 ?>
-<ul class="mod-relateditems relateditems<?php echo $moduleclass_sfx; ?> mod-list">
+<ul class="mod-relateditems relateditems mod-list">
 <?php foreach ($list as $item) : ?>
 <li>
 	<a href="<?php echo $item->route; ?>">


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Removes module class suffix uses from module files. Suffix should now be handled by module chromes, see #17447.

### Testing Instructions

Code review.


### Documentation Changes Required

IDK.