### PR TITLE
Bug fix. Language files are not loaded correctly

### DIFF
--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -503,7 +503,15 @@ class PlgSystemLanguageFilter extends JPlugin
 					continue;
 				}
 
-				$language_new->load($extension);
+				// detect basepath for the extension language folder
+				$loaded = [];
+				foreach($files as $_filePath => $_has_been_loaded){
+					$_basePath = explode(DIRECTORY_SEPARATOR ."language". DIRECTORY_SEPARATOR, $_filePath);
+					$_basePath = $_basePath[0];
+					if(isset($loaded[$_basePath])) continue;
+
+					$loaded[$_basePath] = $language_new->load($extension, $_basePath, true);
+				}
 			}
 
 			JFactory::$language = $language_new;


### PR DESCRIPTION
Scenario:
extension: com_xlz
extension language folder: ROOT/components/com_xlz/language

when the language filter plugin is enabled, the language files already loaded for the component com_xyz are completely removed, that's due to the missing basepath when the function [JLanguage->load](https://api.joomla.org/cms-2.5/classes/JLanguage.html#method_load) is called.

Pull Request for Issue # .

### Summary of Changes



### Testing Instructions



### Expected result



### Actual result



### Documentation Changes Required

