### PR TITLE
[4.0] Update joomla/database package from framework for fixing undefined variable error when using MariaDB

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -723,12 +723,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-framework/database.git",
-                "reference": "b31e057a7d047782786dc255fdfa127fc0ef45f2"
+                "reference": "abd5763ecd492703590d3c5eee1af97eb40d6509"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/database/zipball/b31e057a7d047782786dc255fdfa127fc0ef45f2",
-                "reference": "b31e057a7d047782786dc255fdfa127fc0ef45f2",
+                "url": "https://api.github.com/repos/joomla-framework/database/zipball/abd5763ecd492703590d3c5eee1af97eb40d6509",
+                "reference": "abd5763ecd492703590d3c5eee1af97eb40d6509",
                 "shasum": ""
             },
             "require": {
@@ -780,7 +780,7 @@
                 "framework",
                 "joomla"
             ],
-            "time": "2019-06-21T14:08:22+00:00"
+            "time": "2019-06-25T12:06:44+00:00"
         },
         {
             "name": "joomla/di",


### PR DESCRIPTION
Pull Request for Issue [https://github.com/joomla-framework/database/pull/169](https://github.com/joomla-framework/database/pull/169) .

### Summary of Changes

Update joomla/database from framework to get the changes from the framework database PR linked above.

The PR fixes a silly copy and paste mistake made by me when introducing MariaDB compatibility.

Thanks @SharkyKZ for finding and fixing it.

The mistake creates an error with an undefined variable which happens only when installing recent 4.0-dev with MariaDB changes on a MariaDB.

But it should be fixed soon for the CMS by updating the DB package.

### Testing Instructions

Code review, or update composer.lock by the changes in this PR, do a `composer install` and check that the files from the database package contain the changes in [https://github.com/joomla-framework/database/pull/169](https://github.com/joomla-framework/database/pull/169).

### Expected result

Database package up to date.

### Actual result

Database package not up to date.

### Documentation Changes Required

None.