### PR TITLE
[4.0] Fix Codemirror fullscreen

### DIFF
--- a/administrator/templates/atum/scss/template.scss
+++ b/administrator/templates/atum/scss/template.scss
@@ -46,6 +46,7 @@
 @import "vendor/bootstrap/nav";
 @import "vendor/bootstrap/pagination";
 @import "vendor/bootstrap/table";
+@import "vendor/codemirror";
 @import "vendor/chosen";
 @import "vendor/choicesjs";
 @import "vendor/dragula";

--- a/administrator/templates/atum/scss/vendor/_codemirror.scss
+++ b/administrator/templates/atum/scss/vendor/_codemirror.scss
@@ -1,0 +1,5 @@
+// Codemirror
+
+.CodeMirror-fullscreen {
+  top: 63px;
+}

--- a/build/media_source/plg_editors_codemirror/js/joomla-editor-codemirror.w-c.es6.js
+++ b/build/media_source/plg_editors_codemirror/js/joomla-editor-codemirror.w-c.es6.js
@@ -152,7 +152,7 @@ customElements.define('joomla-editor-codemirror', class extends HTMLElement {
 
     const header = document.getElementById('header');
     if (header) {
-      document.getElementById('header').classList.remove('hidden');
+      header.classList.remove('hidden');
     }
   }
 

--- a/build/media_source/plg_editors_codemirror/js/joomla-editor-codemirror.w-c.es6.js
+++ b/build/media_source/plg_editors_codemirror/js/joomla-editor-codemirror.w-c.es6.js
@@ -139,11 +139,21 @@ customElements.define('joomla-editor-codemirror', class extends HTMLElement {
   /* eslint-enable */
   toggleFullScreen() {
     this.instance.setOption('fullScreen', !this.instance.getOption('fullScreen'));
+
+    const header = document.getElementById('header');
+    if (header) {
+      header.classList.toggle('hidden');
+    }
   }
 
   closeFullScreen() {
     this.instance.getOption('fullScreen');
     this.instance.setOption('fullScreen', false);
+
+    const header = document.getElementById('header');
+    if (header) {
+      document.getElementById('header').classList.remove('hidden');
+    }
   }
 
   static makeMarker() {


### PR DESCRIPTION
Pull Request for Issue #24530

### Summary of Changes

Fix the fullscreen mode in Codemirror, by hiding the header and adjusting the `top` position.

### Testing Instructions

- Set codemirror as your editor
- Open any article
- Press `F10` or `CTRL+Q` to enable fullscreen mode
- Press `F10` or `CTRL+Q` or `ESC` to close fullscreen

