### PR TITLE
[4.0] Multiple Select Lists

### DIFF
--- a/administrator/components/com_content/tmpl/articles/default.xml
+++ b/administrator/components/com_content/tmpl/articles/default.xml
@@ -43,6 +43,7 @@
 				label="COM_MENUS_ADMIN_AUTHOR_LABEL"
 				description="COM_MENUS_ADMIN_AUTHOR_DESC"
 				multiple="true"
+				layout="joomla.form.field.list-fancy-select"
 				class="multipleAuthors"
 				filter="int_array"
 				>
@@ -64,6 +65,7 @@
 				label="COM_MENUS_ADMIN_ACCESS_LABEL"
 				description="COM_MENUS_ADMIN_ACCESS_DESC"
 				multiple="true"
+				layout="joomla.form.field.list-fancy-select"
 				filter="int_array"
 			/>
 

--- a/components/com_content/tmpl/archive/default.xml
+++ b/components/com_content/tmpl/archive/default.xml
@@ -19,8 +19,8 @@
 				type="category"
 				extension="com_content"
 				multiple="true"
-				size="5"
 				label="JCATEGORY"
+				layout="joomla.form.field.list-fancy-select"
 			>
 				<option value="">JOPTION_ALL_CATEGORIES</option>
 			</field>

--- a/components/com_content/tmpl/featured/default.xml
+++ b/components/com_content/tmpl/featured/default.xml
@@ -18,7 +18,7 @@
 				label="COM_CONTENT_FEATURED_CATEGORIES_LABEL"
 				extension="com_content"
 				multiple="true"
-				size="10"
+				layout="joomla.form.field.list-fancy-select"
 				default=""
 				>
 				<option value="">JOPTION_ALL_CATEGORIES</option>

--- a/modules/mod_articles_category/mod_articles_category.xml
+++ b/modules/mod_articles_category/mod_articles_category.xml
@@ -98,6 +98,7 @@
 					label="JCATEGORY"
 					extension="com_content"
 					multiple="true"
+					layout="joomla.form.field.list-fancy-select"
 					filter="int_array"
 					class="multipleCategories"
 				/>
@@ -163,6 +164,7 @@
 					type="author"
 					label="MOD_ARTICLES_CATEGORY_FIELD_AUTHOR_LABEL"
 					multiple="true"
+					layout="joomla.form.field.list-fancy-select"
 					filter="int_array"
 					class="multipleAuthors"
 				/>
@@ -190,6 +192,7 @@
 					type="sql"
 					label="MOD_ARTICLES_CATEGORY_FIELD_AUTHORALIAS_LABEL"
 					multiple="true"
+					layout="joomla.form.field.list-fancy-select"
 					query="select distinct(created_by_alias) from #__content where created_by_alias != '' order by created_by_alias ASC"
 					key_field="created_by_alias"
 					value_field="created_by_alias"

--- a/modules/mod_articles_latest/mod_articles_latest.xml
+++ b/modules/mod_articles_latest/mod_articles_latest.xml
@@ -29,6 +29,7 @@
 					label="JCATEGORY"
 					extension="com_content"
 					multiple="true"
+					layout="joomla.form.field.list-fancy-select"
 					filter="int_array"
 				/>
 
@@ -81,8 +82,8 @@
 					name="author"
 					type="author"
 					label="MOD_LATEST_NEWS_FIELD_AUTHOR_LABEL"
-					description="MOD_LATEST_NEWS_FIELD_AUTHOR_DESC"
 					multiple="true"
+					layout="joomla.form.field.list-fancy-select"
 					showon="user_id:created_by"
 				/>
 			</fieldset>

--- a/modules/mod_articles_news/mod_articles_news.xml
+++ b/modules/mod_articles_news/mod_articles_news.xml
@@ -31,6 +31,7 @@
 					multiple="true"
 					filter="int_array"
 					class="multipleCategories"
+					layout="joomla.form.field.list-fancy-select"
 				/>
 
 				<field

--- a/modules/mod_banners/mod_banners.xml
+++ b/modules/mod_banners/mod_banners.xml
@@ -65,6 +65,7 @@
 					multiple="true"
 					filter="int_array"
 					class="multipleCategories"
+					layout="joomla.form.field.list-fancy-select"
 				/>
 
 				<field

--- a/plugins/fields/editor/editor.xml
+++ b/plugins/fields/editor/editor.xml
@@ -39,6 +39,7 @@
 					label="PLG_FIELDS_EDITOR_PARAMS_BUTTONS_HIDE_LABEL"
 					folder="editors-xtd"
 					multiple="true"
+					layout="joomla.form.field.list-fancy-select"
 				/>
 
 				<field

--- a/plugins/fields/editor/params/editor.xml
+++ b/plugins/fields/editor/params/editor.xml
@@ -19,6 +19,7 @@
 				label="PLG_FIELDS_EDITOR_PARAMS_BUTTONS_HIDE_LABEL"
 				folder="editors-xtd"
 				multiple="true"
+				layout="joomla.form.field.list-fancy-select"
 			/>
 
 			<field

--- a/plugins/fields/url/params/url.xml
+++ b/plugins/fields/url/params/url.xml
@@ -7,6 +7,7 @@
 				type="list"
 				label="PLG_FIELDS_URL_PARAMS_SCHEMES_LABEL"
 				multiple="true"
+				layout="joomla.form.field.list-fancy-select"
 				>
 				<option value="http">HTTP</option>
 				<option value="https">HTTPS</option>

--- a/plugins/fields/url/url.xml
+++ b/plugins/fields/url/url.xml
@@ -26,6 +26,7 @@
 					type="list"
 					label="PLG_FIELDS_URL_PARAMS_SCHEMES_LABEL"
 					multiple="true"
+					layout="joomla.form.field.list-fancy-select"
 					>
 					<option value="http">HTTP</option>
 					<option value="https">HTTPS</option>

--- a/plugins/system/debug/debug.xml
+++ b/plugins/system/debug/debug.xml
@@ -38,6 +38,7 @@
 					type="usergrouplist"
 					label="PLG_DEBUG_FIELD_ALLOWED_GROUPS_LABEL"
 					multiple="true"
+					layout="joomla.form.field.accesslevel-fancy-select"
 					filter="int_array"
 					size="10"
 				/>
@@ -234,6 +235,7 @@
 					type="list"
 					label="PLG_DEBUG_FIELD_LOG_PRIORITIES_LABEL"
 					multiple="true"
+					layout="joomla.form.field.list-fancy-select"
 					default="all"
 					>
 					<option value="all">PLG_DEBUG_FIELD_LOG_PRIORITIES_ALL</option>

--- a/plugins/system/debug/debug.xml
+++ b/plugins/system/debug/debug.xml
@@ -40,7 +40,6 @@
 					multiple="true"
 					layout="joomla.form.field.accesslevel-fancy-select"
 					filter="int_array"
-					size="10"
 				/>
 
 				<field


### PR DESCRIPTION
This PR makes sure that we are using the `joomla.form.field.list-fancy-select` layout when we have a **multiple** select list field

### Before
![image](https://user-images.githubusercontent.com/1296369/60172060-d0fbd680-9803-11e9-8740-27eed67a6966.png)


### After
![image](https://user-images.githubusercontent.com/1296369/60172029-bd507000-9803-11e9-9876-a83c53d1db5b.png)
