### PR TITLE
[4.0] Error in com_menus modal layout

### DIFF
--- a/administrator/components/com_menus/tmpl/items/modal.php
+++ b/administrator/components/com_menus/tmpl/items/modal.php
@@ -104,7 +104,7 @@ if (!empty($editor))
 					?>
 					<tr class="row<?php echo $i % 2; ?>">
 						<td class="text-center">
-							<?php echo HTMLHelper::_('menus.state', $item->published, $i, 0); ?>
+							<?php echo HTMLHelper::_('jgrid.published', $item->published, $i, 'items.', false, 'cb', $item->publish_up, $item->publish_down); ?>
 						</td>
 						<th scope="row">
 							<?php $prefix = LayoutHelper::render('joomla.html.treeprefix', array('level' => $item->level)); ?>
@@ -128,6 +128,13 @@ if (!empty($editor))
 								<span class="small" title="<?php echo isset($item->item_type_desc) ? htmlspecialchars($this->escape($item->item_type_desc), ENT_COMPAT, 'UTF-8') : ''; ?>">
 									<?php echo $this->escape($item->item_type); ?></span>
 							</div>
+							<?php if ($item->type === 'component' && !$item->enabled) : ?>
+								<div>
+									<span class="badge badge-secondary">
+										<?php echo Text::_($item->enabled === null ? 'JLIB_APPLICATION_ERROR_COMPONENT_NOT_FOUND' : 'COM_MENUS_LABEL_DISABLED'); ?>
+									</span>
+								</div>
+							<?php endif; ?>
 						</th>
 						<td class="small d-none d-md-table-cell">
 							<?php echo $this->escape($item->menutype_title); ?>


### PR DESCRIPTION
Pull Request for Issue #25336.

### Summary of Changes

Replaces call to non-existing method. Also adds component status badge from https://github.com/joomla/joomla-cms/pull/25197.

### Testing Instructions

Edit an article in backend.
In editor, click CMS Content -> Menus.

### Expected result

Modal with menu items show up, menu item status correctly shown.

### Actual result
Error in modal:
>Recoverable fatal error: Object of class Joomla\Component\Menus\Administrator\Service\HTML\Menus could not be converted to string in libraries\src\HTML\HTMLHelper.php on line 149

### Documentation Changes Required

No.