### PR TITLE
[4.0] Correct typo impode to implode

### DIFF
--- a/plugins/extension/finder/finder.php
+++ b/plugins/extension/finder/finder.php
@@ -168,7 +168,7 @@ class PlgExtensionFinder extends CMSPlugin
 		{
 			$bindNames = $query->bindArray([$word, $lang], ParameterType::STRING);
 
-			$query->values(impode(',', $bindNames) . ', 0');
+			$query->values(implode(',', $bindNames) . ', 0');
 		}
 
 		try


### PR DESCRIPTION
### Testing Instructions
- Code review. It's obvious.

- Several errors are possible during extension installations when Plugin "Extension - Finder" is activated

### Expected result
- No errors messages.
