### PR TITLE
[4.0] Menu Item associations: do not display same language

### DIFF
--- a/administrator/components/com_menus/Field/Modal/MenuField.php
+++ b/administrator/components/com_menus/Field/Modal/MenuField.php
@@ -448,6 +448,6 @@ class MenuField extends FormField
 	 */
 	protected function getLabel()
 	{
-		return str_replace($this->id, $this->id . '_id', parent::getLabel());
+		return str_replace($this->id, $this->id . '_name', parent::getLabel());
 	}
 }


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/25327

### Summary of Changes
See https://github.com/joomla/joomla-cms/pull/24775
`_id` should have been changed to `_name` in MenuField

### After patch
No more extraneous field with same language as edited item in the Association tab when editing a menu item in multilingual.
@richard67 