### PR TITLE
[4.0] URL parameters lost when changing menu type

### DIFF
--- a/administrator/components/com_menus/Controller/DisplayController.php
+++ b/administrator/components/com_menus/Controller/DisplayController.php
@@ -56,6 +56,12 @@ class DisplayController extends BaseController
 			if ($uri->getVar('menutype') !== $menuType)
 			{
 				$uri->setVar('menutype', $menuType);
+
+				if ($forcedLanguage = $this->input->post->get('forcedLanguage'))
+				{
+					$uri->setVar('forcedLanguage', $forcedLanguage);
+				}
+
 				$this->setRedirect(Route::_('index.php' . $uri->toString(['query']), false));
 
 				return parent::display();

--- a/administrator/components/com_menus/Controller/DisplayController.php
+++ b/administrator/components/com_menus/Controller/DisplayController.php
@@ -55,7 +55,8 @@ class DisplayController extends BaseController
 
 			if ($uri->getVar('menutype') !== $menuType)
 			{
-				$this->setRedirect(Route::_('index.php?option=com_menus&view=items&menutype=' . $menuType, false));
+				$uri->setVar('menutype', $menuType);
+				$this->setRedirect(Route::_('index.php' . $uri->toString(['query']), false));
 
 				return parent::display();
 			}


### PR DESCRIPTION
Pull Request for Issue #25342.

### Summary of Changes

Use current URL parameters when redirecting.

### Testing Instructions

Make sure you have at least 2 site menu types.
Edit an article in backend.
In editor, click CMS Content -> Menu.
In the modal, change menu type (by selecting value in `- Select Menu -` field).

### Expected result

Modal shows only a list of menu items.

### Actual result

Modal shows entire site, with modules, sidebar, etc.

### Documentation Changes Required

No.