### PR TITLE
[4.0] Role = switch

### DIFF
--- a/layouts/joomla/form/field/radio/switcher.php
+++ b/layouts/joomla/form/field/radio/switcher.php
@@ -66,7 +66,7 @@ $input    = '<input type="radio" id="%1$s" name="%2$s" value="%3$s" %4$s>';
 	<legend class="switcher__legend">
 		<?php echo $label; ?>
 	</legend>
-	<div class="switcher" role="switch">
+	<div class="switcher">
 	<?php foreach ($options as $i => $option) : ?>
 		<?php
 		// Initialize some option attributes.


### PR DESCRIPTION
After extensive testing last night it became apparent that the role=switch is not correct and not needed for this code. It is not well supported and we don't need it. This pr removes it from the switcher buttons. You will only notice a change if you are using a screen reader where the content is announced more correctly
