### PR TITLE
Better check mime type of uploaded file

### DIFF
--- a/libraries/src/Helper/MediaHelper.php
+++ b/libraries/src/Helper/MediaHelper.php
@@ -75,8 +75,8 @@ class MediaHelper
 			if (!$mime && function_exists('finfo_open'))
 			{
 				$finfo = finfo_open(FILEINFO_MIME_TYPE);
-				// Check if fileinfo database was found
 
+				// Check if fileinfo database was found
 				if ($finfo)
 				{
 					$mime = finfo_file($finfo, $file);

--- a/libraries/src/Helper/MediaHelper.php
+++ b/libraries/src/Helper/MediaHelper.php
@@ -66,38 +66,47 @@ class MediaHelper
 
 		try
 		{
-			if ($isImage && function_exists('exif_imagetype'))
+			// Note: mime_content_type() can return false (e.g. when mime database is empty)
+			if (function_exists('mime_content_type'))
 			{
-				$mime = image_type_to_mime_type(exif_imagetype($file));
-			}
-			elseif ($isImage && function_exists('getimagesize'))
-			{
-				$imagesize = getimagesize($file);
-				$mime      = isset($imagesize['mime']) ? $imagesize['mime'] : false;
-			}
-			elseif (function_exists('mime_content_type'))
-			{
-				// We have mime magic.
 				$mime = mime_content_type($file);
 			}
-			elseif (function_exists('finfo_open'))
+
+			if (!$mime && function_exists('finfo_open'))
 			{
-				// We have fileinfo
 				$finfo = finfo_open(FILEINFO_MIME_TYPE);
-				$mime  = finfo_file($finfo, $file);
-				finfo_close($finfo);
+				// Check if fileinfo database was found
+
+				if ($finfo)
+				{
+					$mime = finfo_file($finfo, $file);
+					finfo_close($finfo);
+				}
+			}
+
+			if (!$mime && $isImage)
+			{
+				if (function_exists('exif_imagetype'))
+				{
+					$type = exif_imagetype($file);
+
+					if ($type)
+					{
+						$mime = image_type_to_mime_type($type);
+					}
+				}
+
+				if (!$mime)
+				{
+					$imagesize = getimagesize($file);
+					$mime      = isset($imagesize['mime']) ? $imagesize['mime'] : false;
+				}
 			}
 		}
 		catch (\Exception $e)
 		{
 			// If we have any kind of error here => false;
 			return false;
-		}
-
-		// If we can't detect the mime try it again
-		if ($mime === 'application/octet-stream' && $isImage === true)
-		{
-			$mime = $this->getMimeType($file, false);
 		}
 
 		// We have a mime here


### PR DESCRIPTION
Pull Request for Issue #16086

Credits go to @csthomas for PR #20968

### Summary of Changes
A better way to check the MIME file type if the operating system is incorrectly configured.

If you still have a problem and your server is not running on Windows, test the following patch:

```
diff --git a/libraries/src/Helper/MediaHelper.php b/libraries/src/Helper/MediaHelper.php
index 60f7fab83d..99cb1d80e1 100644
--- a/libraries/src/Helper/MediaHelper.php
+++ b/libraries/src/Helper/MediaHelper.php
@@ -102,6 +102,12 @@ class MediaHelper
                                        $mime      = isset($imagesize['mime']) ? $imagesize['mime'] : false;
                                }
                        }
+
+                       // Last chance to get to know the type of mime
+                       if (!$mime && IS_UNIX && function_exists('exec') && function_exists('escapeshellarg'))
+                       {
+                               $mime = strtok(exec('file -bi ' . escapeshellarg($file)), ';');
+                       }
                }
                catch (\Exception $e)
                {
```

### Testing Instructions
Try to upload pdf or image file.
Take a look at #16086

Please test if you still interested @goforitweb, @uglyeoin, @edthenet, @OrignlCin


### Expected result
PDF file is recognized.


### Actual result
#16086


### Documentation Changes Required
No
