### PR TITLE
 [4.0] Keep Script/Style Declarations as an array instead of merge to one string

### DIFF
--- a/libraries/src/Document/Document.php
+++ b/libraries/src/Document/Document.php
@@ -543,6 +543,13 @@ class Document
 	 */
 	public function addScriptDeclaration($content, $type = 'text/javascript')
 	{
+		$type = strtolower($type);
+
+		if (empty($this->_script[$type]))
+		{
+			$this->_script[$type] = array();
+		}
+
 		$this->_script[$type][md5($content)] = $content;
 
 		return $this;
@@ -644,6 +651,13 @@ class Document
 	 */
 	public function addStyleDeclaration($content, $type = 'text/css')
 	{
+		$type = strtolower($type);
+
+		if (empty($this->_style[$type]))
+		{
+			$this->_style[$type] = array();
+		}
+
 		$this->_style[$type][md5($content)] = $content;
 
 		return $this;

--- a/libraries/src/Document/Document.php
+++ b/libraries/src/Document/Document.php
@@ -543,14 +543,7 @@ class Document
 	 */
 	public function addScriptDeclaration($content, $type = 'text/javascript')
 	{
-		if (!isset($this->_script[strtolower($type)]))
-		{
-			$this->_script[strtolower($type)] = $content;
-		}
-		else
-		{
-			$this->_script[strtolower($type)] .= chr(13) . $content;
-		}
+		$this->_script[$type][md5($content)] = $content;
 
 		return $this;
 	}
@@ -651,14 +644,7 @@ class Document
 	 */
 	public function addStyleDeclaration($content, $type = 'text/css')
 	{
-		if (!isset($this->_style[strtolower($type)]))
-		{
-			$this->_style[strtolower($type)] = $content;
-		}
-		else
-		{
-			$this->_style[strtolower($type)] .= chr(13) . $content;
-		}
+		$this->_style[$type][md5($content)] = $content;
 
 		return $this;
 	}

--- a/libraries/src/Document/Renderer/Html/ScriptsRenderer.php
+++ b/libraries/src/Document/Renderer/Html/ScriptsRenderer.php
@@ -123,35 +123,38 @@ class ScriptsRenderer extends DocumentRenderer
 		// Generate script declarations
 		foreach ($this->_doc->_script as $type => $contents)
 		{
-			$buffer .= $tab . '<script';
-
-			if (!is_null($type) && (!$this->_doc->isHtml5() || !in_array($type, $defaultJsMimes)))
+			foreach ($contents as $content)
 			{
-				$buffer .= ' type="' . $type . '"';
+				$buffer .= $tab . '<script';
+
+				if (!is_null($type) && (!$this->_doc->isHtml5() || !in_array($type, $defaultJsMimes)))
+				{
+					$buffer .= ' type="' . $type . '"';
+				}
+
+				if ($this->_doc->cspNonce)
+				{
+					$buffer .= ' nonce="' . $this->_doc->cspNonce . '"';
+				}
+
+				$buffer .= '>' . $lnEnd;
+
+				// This is for full XHTML support.
+				if ($this->_doc->_mime != 'text/html')
+				{
+					$buffer .= $tab . $tab . '//<![CDATA[' . $lnEnd;
+				}
+
+				$buffer .= $content . $lnEnd;
+
+				// See above note
+				if ($this->_doc->_mime != 'text/html')
+				{
+					$buffer .= $tab . $tab . '//]]>' . $lnEnd;
+				}
+
+				$buffer .= $tab . '</script>' . $lnEnd;
 			}
-
-			if ($this->_doc->cspNonce)
-			{
-				$buffer .= ' nonce="' . $this->_doc->cspNonce . '"';
-			}
-
-			$buffer .= '>' . $lnEnd;
-
-			// This is for full XHTML support.
-			if ($this->_doc->_mime != 'text/html')
-			{
-				$buffer .= $tab . $tab . '//<![CDATA[' . $lnEnd;
-			}
-
-			$buffer .= $contents . $lnEnd;
-
-			// See above note
-			if ($this->_doc->_mime != 'text/html')
-			{
-				$buffer .= $tab . $tab . '//]]>' . $lnEnd;
-			}
-
-			$buffer .= $tab . '</script>' . $lnEnd;
 		}
 
 

--- a/libraries/src/Document/Renderer/Html/ScriptsRenderer.php
+++ b/libraries/src/Document/Renderer/Html/ScriptsRenderer.php
@@ -123,6 +123,12 @@ class ScriptsRenderer extends DocumentRenderer
 		// Generate script declarations
 		foreach ($this->_doc->_script as $type => $contents)
 		{
+			// Test for B.C. in case someone still store script declarations as single string
+			if (is_string($contents))
+			{
+				$contents = [$contents];
+			}
+
 			foreach ($contents as $content)
 			{
 				$buffer .= $tab . '<script';

--- a/libraries/src/Document/Renderer/Html/StylesRenderer.php
+++ b/libraries/src/Document/Renderer/Html/StylesRenderer.php
@@ -109,35 +109,38 @@ class StylesRenderer extends DocumentRenderer
 		// Generate stylesheet declarations
 		foreach ($this->_doc->_style as $type => $contents)
 		{
-			$buffer .= $tab . '<style';
-
-			if (!is_null($type) && (!$this->_doc->isHtml5() || !in_array($type, $defaultCssMimes)))
+			foreach ($contents as $content)
 			{
-				$buffer .= ' type="' . $type . '"';
+				$buffer .= $tab . '<style';
+
+				if (!is_null($type) && (!$this->_doc->isHtml5() || !in_array($type, $defaultCssMimes)))
+				{
+					$buffer .= ' type="' . $type . '"';
+				}
+
+				if ($this->_doc->cspNonce)
+				{
+					$buffer = ' nonce="' . $this->_doc->cspNonce . '"';
+				}
+
+				$buffer .= '>' . $lnEnd;
+
+				// This is for full XHTML support.
+				if ($this->_doc->_mime != 'text/html')
+				{
+					$buffer .= $tab . $tab . '/*<![CDATA[*/' . $lnEnd;
+				}
+
+				$buffer .= $content . $lnEnd;
+
+				// See above note
+				if ($this->_doc->_mime != 'text/html')
+				{
+					$buffer .= $tab . $tab . '/*]]>*/' . $lnEnd;
+				}
+
+				$buffer .= $tab . '</style>' . $lnEnd;
 			}
-
-			if ($this->_doc->cspNonce)
-			{
-				$nonce = ' nonce="' . $this->_doc->cspNonce . '"';
-			}
-
-			$buffer .= '>' . $lnEnd;
-
-			// This is for full XHTML support.
-			if ($this->_doc->_mime != 'text/html')
-			{
-				$buffer .= $tab . $tab . '/*<![CDATA[*/' . $lnEnd;
-			}
-
-			$buffer .= $contents . $lnEnd;
-
-			// See above note
-			if ($this->_doc->_mime != 'text/html')
-			{
-				$buffer .= $tab . $tab . '/*]]>*/' . $lnEnd;
-			}
-
-			$buffer .= $tab . '</style>' . $lnEnd;
 		}
 
 		// Generate scripts options

--- a/libraries/src/Document/Renderer/Html/StylesRenderer.php
+++ b/libraries/src/Document/Renderer/Html/StylesRenderer.php
@@ -109,6 +109,12 @@ class StylesRenderer extends DocumentRenderer
 		// Generate stylesheet declarations
 		foreach ($this->_doc->_style as $type => $contents)
 		{
+			// Test for B.C. in case someone still store stylesheet declarations as single string
+			if (is_string($contents))
+			{
+				$contents = [$contents];
+			}
+
 			foreach ($contents as $content)
 			{
 				$buffer .= $tab . '<style';


### PR DESCRIPTION
### Summary of Changes

Keep Script/Style Declarations as an array instead of merge to one string.
For long time `JDocument` merge all Script/Styles declarations to a single string, which not allow to use it for stuff like `type="module"` (which has `import` statement), or micro-data `type="application/ld+json"`, and for other types that get broken when they merged.

This patch introduce a little B.C. (for extensions which use `$doc->_script` directly) but I think it not very critical, and better we do it now than never.

Additionally after little changes in #25301 this patch will allow to remove specific Script/Styles declarations without parsing whole `$doc->_script/_style`. 


### Testing Instructions

Apply the patch and make sure all still works as before.



### Documentation Changes Required

This is potential B.C. and need to be described https://docs.joomla.org/Potential_backward_compatibility_issues_in_Joomla_4

The `Document::_script`, `Document::_style` store Script/Styles declarations as an array, instead of string.
