### PR TITLE
[4.0] Systemtests: Fixing Chrome options

### DIFF
--- a/tests/Codeception/acceptance.suite.yml
+++ b/tests/Codeception/acceptance.suite.yml
@@ -16,8 +16,8 @@ modules:
             browser: 'chrome'
             window_size: false
             capabilities:
-              chromeOptions:
-                args: ["--headless", "--disable-gpu", "--no-sandbox", "window-size=1920x1080"]
+              'goog:chromeOptions':
+                args: ["headless", "disable-gpu", "no-sandbox", "window-size=1920x1080"]
             username: 'admin'                      # UserName for the Administrator
             password: 'admin'                      # Password for the Administrator
             database host: 'mysql'                 # place where the Application is Hosted #server Address


### PR DESCRIPTION
In Selenium 3.8, the options for Google Chrome have been renamed from ```chromeOptions``` to ```goog:chromeOptions```. We are using Selenium 3.14. Also the args are supposed to be written without the ```--``` in front. This PR fixes that. Still hoping that this contributes to fixing the stability issues that we have... 