### PR TITLE
[4.0] Permission rules - accessibility etc

### DIFF
--- a/administrator/language/en-GB/en-GB.lib_joomla.ini
+++ b/administrator/language/en-GB/en-GB.lib_joomla.ini
@@ -719,7 +719,7 @@ JLIB_RULES_SELECT_ALLOW_DENY_GROUP="Allow or deny %s for users in the %s group."
 JLIB_RULES_SELECT_SETTING="Select New Setting"
 JLIB_RULES_SETTING_NOTES="If you change the setting, it will apply to this and all child groups, components and content. Note that <em><strong>Denied</strong></em> will overrule any inherited setting and also the setting in any child group, component or content. In the case of a setting conflict, <em><strong>Deny</strong></em> will take precedence. <em><strong>Not Set</strong></em> is equivalent to <em><strong>Denied</strong></em> but can be changed in child groups, components and content."
 JLIB_RULES_SETTING_NOTES_ITEM="If you change the setting, it will apply to this item. Note that:<br><em><strong>Inherited</strong></em> means that the permissions from global configuration, parent group and category will be used.<br><em><strong>Denied</strong></em> means that no matter what the global configuration, parent group or category settings are, the group being edited can't take this action on this item.<br><em><strong>Allowed</strong></em> means that the group being edited will be able to take this action for this item (but if this is in conflict with the global configuration, parent group or category it will have no impact; a conflict will be indicated by <em><strong>Not Allowed (Inherited)</strong></em> under Calculated Settings)."
-JLIB_RULES_SETTINGS_DESC="Manage the permission settings for the user groups below. See notes at the bottom."
+JLIB_RULES_SETTINGS_DESC="Expand for notes about setting the permissions."
 
 JLIB_STEMMER_INVALID_STEMMER="Invalid stemmer type %s"
 

--- a/administrator/templates/atum/scss/pages/_com_config.scss
+++ b/administrator/templates/atum/scss/pages/_com_config.scss
@@ -17,6 +17,7 @@
   .filter-notes {
     padding: 1em;
     background-color: $white;
+    margin-bottom: 1em;
   }
 
   .revert-controls .controls {

--- a/language/en-GB/en-GB.lib_joomla.ini
+++ b/language/en-GB/en-GB.lib_joomla.ini
@@ -712,7 +712,7 @@ JLIB_RULES_SELECT_ALLOW_DENY_GROUP="Allow or deny %s for users in the %s group."
 JLIB_RULES_SELECT_SETTING="Select New Setting"
 JLIB_RULES_SETTING_NOTES="If you change the setting, it will apply to this and all child groups, components and content. Note that <em><strong>Denied</strong></em> will overrule any inherited setting and also the setting in any child group, component or content. In the case of a setting conflict, <em><strong>Deny</strong></em> will take precedence. <em><strong>Not Set</strong></em> is equivalent to <em><strong>Denied</strong></em> but can be changed in child groups, components and content."
 JLIB_RULES_SETTING_NOTES_ITEM="If you change the setting, it will apply to this item. Note that:<br><em><strong>Inherited</strong></em> means that the permissions from global configuration, parent group and category will be used.<br><em><strong>Denied</strong></em> means that no matter what the global configuration, parent group or category settings are, the group being edited can't take this action on this item.<br><em><strong>Allowed</strong></em> means that the group being edited will be able to take this action for this item (but if this is in conflict with the global configuration, parent group or category it will have no impact; a conflict will be indicated by <em><strong>Not Allowed (Inherited)</strong></em> under Calculated Settings)."
-JLIB_RULES_SETTINGS_DESC="Manage the permission settings for the user groups below. See notes at the bottom."
+JLIB_RULES_SETTINGS_DESC="Expand for notes about setting the permissions."
 
 JLIB_STEMMER_INVALID_STEMMER="Invalid stemmer type %s"
 

--- a/layouts/joomla/form/field/rules.php
+++ b/layouts/joomla/form/field/rules.php
@@ -73,7 +73,23 @@ $ajaxUri = Route::_('index.php?option=com_config&task=application.store&format=j
 ?>
 
 <?php // Description ?>
-<p class="rule-desc"><?php echo Text::_('JLIB_RULES_SETTINGS_DESC'); ?></p>
+<details>
+	<summary class="rule-notes">
+		<?php echo Text::_('JLIB_RULES_SETTINGS_DESC'); ?>
+	</summary>
+	<div class="rule-notes">
+	<?php
+	if ($section === 'component' || !$section)
+	{
+		echo Text::_('JLIB_RULES_SETTING_NOTES');
+	}
+	else
+	{
+		echo Text::_('JLIB_RULES_SETTING_NOTES_ITEM');
+	}
+	?>
+	</div>
+</details>
 <?php // Begin tabs ?>
 <joomla-field-permissions class="row mb-2" data-uri="<?php echo $ajaxUri; ?>">
 	<joomla-tab orientation="vertical" id="permissions-sliders">
@@ -225,15 +241,3 @@ $ajaxUri = Route::_('index.php?option=com_config&task=application.store&format=j
 	</joomla-tab>
 </joomla-field-permissions>
 
-<div class="rule-notes">
-	<?php
-	if ($section === 'component' || !$section)
-	{
-		echo Text::_('JLIB_RULES_SETTING_NOTES');
-	}
-	else
-	{
-		echo Text::_('JLIB_RULES_SETTING_NOTES_ITEM');
-	}
-	?>
-</div>


### PR DESCRIPTION
We have a large block of text on every permissions tab right at the bottom. Among the many problems with a large block of text like this is accessibility. Text like "see notes at the bottom" just doesn't work for assistive tech. Luckily there is a really easy solution. Using the html elements `<summary>` and `<details>`. The `<details>` element generates a simple no-JavaScript widget to show/hide element contents, optionally by clicking on its child `<summary>` element. It is fully accessible as the summary element is presented as a button to the accessibility tree.

### Notes
1. these elements are not supported in IE11 (who cares) or EDGE (pre chromium) but by the time J4 will be released it wont be an issue ;)
2. If accepted we can do the same for text-filters

### Testing instructions
npm i is needed "only" to check my bad scss ;) You can still test with patchtester you just wont get all the styling

### Demo
![perms](https://user-images.githubusercontent.com/1296369/60382044-49a5a180-9a55-11e9-81e7-f1dd094d74ef.gif)
