### PR TITLE
[4.0] Fix undefined variable with export csv in user actions log

### DIFF
--- a/administrator/components/com_actionlogs/controllers/actionlogs.php
+++ b/administrator/components/com_actionlogs/controllers/actionlogs.php
@@ -119,8 +119,8 @@ class ActionlogsControllerActionlogs extends JControllerAdmin
 			}
 
 			fclose($output);
-			$app->triggerEvent('onAfterLogExport', array());
-			$app->close();
+			$this->app->triggerEvent('onAfterLogExport', array());
+			$this->app->close();
 		}
 		else
 		{


### PR DESCRIPTION
See https://github.com/joomla/joomla-cms/pull/24936#issuecomment-506950107

### Summary of Changes
Fix undefined variable: app in PHP error log.


### Testing Instructions
Go to Users > User Actions Log
Click Export All as CSV button.

