### PR TITLE
[4.0] Systemtests: Add delays to wait for JS to be loaded

### DIFF
--- a/tests/Codeception/_support/AcceptanceTester.php
+++ b/tests/Codeception/_support/AcceptanceTester.php
@@ -73,5 +73,8 @@ class AcceptanceTester extends \Codeception\Actor
 		$I = $this;
 
 		$I->waitForJS('return document.readyState == "complete"', $timeout);
+
+		// Wait an additional 500ms to make sure that really all JS is loaded
+		$I->wait(0.5);
 	}
 }

--- a/tests/Codeception/_support/AcceptanceTester.php
+++ b/tests/Codeception/_support/AcceptanceTester.php
@@ -58,4 +58,20 @@ class AcceptanceTester extends \Codeception\Actor
 		$I->dontSeeInPageSource('<b>Strict standards</b>:');
 		$I->dontSeeInPageSource('The requested page can\'t be found');
 	}
+
+	/**
+	 * Function to wait for JS to be properly loaded on page change
+	 *
+	 * @param   int|float  $timeout  Time to wait for JS to be ready
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @return  void
+	 */
+	public function waitForJsOnPageLoad($timeout = 1)
+	{
+		$I = $this;
+
+		$I->waitForJS('return document.readyState == "complete"', $timeout);
+	}
 }

--- a/tests/Codeception/_support/Step/Acceptance/Administrator/Media.php
+++ b/tests/Codeception/_support/Step/Acceptance/Administrator/Media.php
@@ -27,7 +27,7 @@ class Media extends Admin
 			$I->waitForElementNotVisible(MediaListPage::$loader);
 
 			// Add a small timeout to wait for rendering (otherwise it will fail when executed in headless browser)
-			$I->wait(0.2);
+			$I->wait(0.5);
 		}
 		catch (NoSuchElementException $e)
 		{

--- a/tests/Codeception/acceptance/administrator/components/com_media/MediaListCest.php
+++ b/tests/Codeception/acceptance/administrator/components/com_media/MediaListCest.php
@@ -344,9 +344,11 @@ class MediaListCest
 		$I->amOnPage(MediaListPage::$url . $this->testDirectory);
 		$I->uploadFile('com_media/' . $testFileName);
 		$I->waitForElement($testFileItem);
+		$I->waitForJsOnPageLoad();
 		$I->click($testFileItem);
 		$I->click(MediaListPage::$toolbarDeleteButton);
 		$I->waitForElement(MediaListPage::$toolbarModalDeleteButton);
+		$I->waitForJsOnPageLoad();
 		$I->click(MediaListPage::$toolbarModalDeleteButton);
 		$I->seeSystemMessage('Item deleted.');
 		$I->waitForElementNotVisible($testFileItem);
@@ -372,6 +374,7 @@ class MediaListCest
 		$I->click($testFolderItem);
 		$I->click(MediaListPage::$toolbarDeleteButton);
 		$I->waitForElement(MediaListPage::$toolbarModalDeleteButton);
+		$I->waitForJsOnPageLoad();
 		$I->click(MediaListPage::$toolbarModalDeleteButton);
 		$I->seeSystemMessage('Item deleted.');
 		$I->waitForElementNotVisible($testFolderItem);
@@ -583,6 +586,7 @@ class MediaListCest
 		$I->waitForMediaLoaded();
 		$I->doubleClick(MediaListPage::item('powered_by.png'));
 		$I->waitForElement(MediaListPage::$previewModal);
+		$I->waitForJsOnPageLoad();
 		$I->seeElement(MediaListPage::$previewModalCloseButton);
 		$I->click(MediaListPage::$previewModalCloseButton);
 		$I->dontSeeElement(MediaListPage::$previewModal);
@@ -602,6 +606,7 @@ class MediaListCest
 		$I->waitForMediaLoaded();
 		$I->doubleClick(MediaListPage::item('powered_by.png'));
 		$I->waitForElement(MediaListPage::$previewModal);
+		$I->waitForJsOnPageLoad();
 		$I->pressKey('body', \Facebook\WebDriver\WebDriverKeys::ESCAPE);
 		$I->dontSeeElement(MediaListPage::$previewModal);
 	}

--- a/tests/Codeception/acceptance/administrator/components/com_menu/MenuCest.php
+++ b/tests/Codeception/acceptance/administrator/components/com_menu/MenuCest.php
@@ -36,6 +36,7 @@ class MenuCest
 		$I->checkForPhpNoticesOrWarnings();
 
 		$I->waitForText(MenuListPage::$pageTitleText);
+		$I->waitForJsOnPageLoad();
 		$I->click('#menu-collapse-icon');
 
 		$I->clickToolbarButton('new');

--- a/tests/Codeception/acceptance/administrator/components/com_users/UserListCest.php
+++ b/tests/Codeception/acceptance/administrator/components/com_users/UserListCest.php
@@ -44,7 +44,7 @@ class UserListCest
 		$I->checkForPhpNoticesOrWarnings();
 
 		$I->waitForText(UserListPage::$pageTitleText);
-
+		$I->waitForJsOnPageLoad();
 		$I->clickToolbarButton('new');
 
 		$I->waitForElement(UserListPage::$accountDetailsTab);
@@ -82,6 +82,7 @@ class UserListCest
 		$I->click($this->name);
 
 		$I->waitForElement(UserListPage::$accountDetailsTab);
+		$I->waitForJsOnPageLoad();
 		$I->checkForPhpNoticesOrWarnings();
 
 		$this->fillUserForm($I, $this->name, $this->username, $this->password, $this->email);


### PR DESCRIPTION
The systemtests right now are rather unreliable and that seems to be mainly due to the JS not being completely loaded after a page change. Specifically our tests seem to fail because we are on a list view and then directly do some action (like clicking "new" in the toolbar) and the JS not having attached the events to the buttons yet. This PR introduces a check if the JS is ready.