### PR TITLE
[4.0] Tooltip cut off cont

### DIFF
--- a/administrator/components/com_users/tmpl/notes/default.php
+++ b/administrator/components/com_users/tmpl/notes/default.php
@@ -72,9 +72,7 @@ $listDirn   = $this->escape($this->state->get('list.direction'));
 								<?php echo HTMLHelper::_('grid.id', $i, $item->id); ?>
 							</td>
 							<td class="text-center">
-								<div class="btn-group">
-									<?php echo HTMLHelper::_('jgrid.published', $item->state, $i, 'notes.', $canChange, 'cb', $item->publish_up, $item->publish_down); ?>
-								</div>
+								<?php echo HTMLHelper::_('jgrid.published', $item->state, $i, 'notes.', $canChange, 'cb', $item->publish_up, $item->publish_down); ?>
 							</td>
 							<th scope="row">
 								<?php if ($item->checked_out) : ?>


### PR DESCRIPTION
Additional PR to #25355

### Summary of Changes
Remove .btn-group that is styling of series of buttons which does not apply here and affects display of tooltips.

### Testing Instructions
Go to Users > User Notes
Make sure you have at least one note
Hover mouse over icon under Status column.

or

code review.

### Expected result
Tooltip displays properly
