### PR TITLE
[4.0] Tooltip cut off cont 2

### DIFF
--- a/administrator/components/com_tags/tmpl/tags/default.php
+++ b/administrator/components/com_tags/tmpl/tags/default.php
@@ -180,9 +180,7 @@ if ($saveOrder && !empty($this->items))
 								<?php echo HTMLHelper::_('grid.id', $i, $item->id); ?>
 							</td>
 							<td class="text-center">
-								<div class="btn-group">
-									<?php echo HTMLHelper::_('jgrid.published', $item->published, $i, 'tags.', $canChange); ?>
-								</div>
+								<?php echo HTMLHelper::_('jgrid.published', $item->published, $i, 'tags.', $canChange); ?>
 							</td>
 							<th scope="row">
 								<?php echo LayoutHelper::render('joomla.html.treeprefix', array('level' => $item->level)); ?>


### PR DESCRIPTION
Additional PR to #25355

### Summary of Changes
Remove .btn-group that is styling of series of buttons which does not apply here and affects display of tooltips.

### Testing Instructions
Go to Tags > Tags
Make sure you have at least one tag
Hover mouse over icon under Status column.

or

code review.

### Expected result
Tooltip displays properly
