### PR TITLE
[4.0] Fatal error in Smart Search

### DIFF
--- a/plugins/finder/categories/categories.php
+++ b/plugins/finder/categories/categories.php
@@ -81,6 +81,18 @@ class PlgFinderCategories extends FinderIndexerAdapter
 	protected $autoloadLanguage = true;
 
 	/**
+	 * Method to setup the indexer to be run.
+	 *
+	 * @return  boolean  True on success.
+	 *
+	 * @since   2.5
+	 */
+	protected function setup()
+	{
+		return true;
+	}
+
+	/**
 	 * Method to remove the link information for items that have been deleted.
 	 *
 	 * @param   string  $context  The context of the action being performed.

--- a/plugins/finder/content/content.php
+++ b/plugins/finder/content/content.php
@@ -73,6 +73,18 @@ class PlgFinderContent extends FinderIndexerAdapter
 	protected $autoloadLanguage = true;
 
 	/**
+	 * Method to setup the indexer to be run.
+	 *
+	 * @return  boolean  True on success.
+	 *
+	 * @since   2.5
+	 */
+	protected function setup()
+	{
+		return true;
+	}
+
+	/**
 	 * Method to update the item link information when the item category is
 	 * changed. This is fired when the item category is published or unpublished
 	 * from the list view.


### PR DESCRIPTION
Pull Request for Issues #25287, #25380 .

### Summary of Changes

Adds back a required method to `Finder - Categories` plugin.

### Testing Instructions

Use smart search in front end or run indexer in backend.

### Expected result

No errors.

### Actual result

>PHP Fatal error: Class PlgFinderCategories contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (Joomla\Component\Finder\Administrator\Indexer\Adapter::setup) in \plugins\finder\categories\categories.php on line 458

### Documentation Changes Required

No.