### PR TITLE
[4.0] Drag and Drop styling

### DIFF
--- a/administrator/templates/atum/scss/vendor/_dragula.scss
+++ b/administrator/templates/atum/scss/vendor/_dragula.scss
@@ -6,7 +6,7 @@
   z-index: 9999 !important;
   margin: 0 !important;
   cursor: move;
-  background-color: $teal #90ee90;
+  background-color: $teal;
   opacity: .8;
 
   &.table {


### PR DESCRIPTION
When you try to do a drag and drop reordering there is supposed to be a color applied to the row as you drag it. Due to a bug when @variables support was added to the scss file this wasnt working because there were TWO colours.

The choice of colour is beyond the scope of this PR

### Testing Instructions
Code review or by applying patch and then npm i


### Expected result
![menu](https://user-images.githubusercontent.com/1296369/60402423-41e61a00-9b87-11e9-83fb-30e5fa1145b2.gif)
