### PR TITLE
[4.0] Touch keyboard support

### DIFF
--- a/layouts/joomla/form/field/email.php
+++ b/layouts/joomla/form/field/email.php
@@ -67,6 +67,7 @@ $attributes = array(
 ?>
 <input
 	type="email"
+	inputmode="email"
 	name="<?php echo $name; ?>"
 	<?php echo !empty($class) ? ' class="form-control validate-email ' . $class . '"' : ' class="form-control validate-email"'; ?>
 	id="<?php echo $id; ?>"

--- a/layouts/joomla/form/field/number.php
+++ b/layouts/joomla/form/field/number.php
@@ -74,6 +74,7 @@ else
 ?>
 <input
 	type="number"
+	inputmode="numeric"
 	name="<?php echo $name; ?>"
 	id="<?php echo $id; ?>"
 	value="<?php echo htmlspecialchars($value, ENT_COMPAT, 'UTF-8'); ?>"

--- a/layouts/joomla/form/field/tel.php
+++ b/layouts/joomla/form/field/tel.php
@@ -64,6 +64,7 @@ $attributes = array(
 ?>
 <input
 	type="tel"
+	inputmode="url"
 	name="<?php echo $name; ?>"
 	<?php echo !empty($class) ? ' class="form-control ' . $class . '"' : 'class="form-control"'; ?>
 	id="<?php echo $id; ?>"

--- a/layouts/joomla/form/field/tel.php
+++ b/layouts/joomla/form/field/tel.php
@@ -64,7 +64,7 @@ $attributes = array(
 ?>
 <input
 	type="tel"
-	inputmode="url"
+	inputmode="tel"
 	name="<?php echo $name; ?>"
 	<?php echo !empty($class) ? ' class="form-control ' . $class . '"' : 'class="form-control"'; ?>
 	id="<?php echo $id; ?>"

--- a/layouts/joomla/form/field/url.php
+++ b/layouts/joomla/form/field/url.php
@@ -65,6 +65,7 @@ $attributes = array(
 ?>
 <input
 	<?php echo $inputType; ?>
+	inputmode="url"
 	name="<?php echo $name; ?>"
 	<?php echo !empty($class) ? ' class="form-control ' . $class . '"' : 'class="form-control"'; ?>
 	id="<?php echo $id; ?>"


### PR DESCRIPTION
Unlike with a physical keyboard a mobile or touch device has multiple different keyboards. This PR ensures that joomla uses the correct mobile keyboard which greatly increases usability on mobile/touch. Although support is not 100% on desktop touchscreen browsers it is really mainly for devices with no physical keyboards

This PR adds an attribute as appropriate  `inputmode="xxxxxx"` for the field types url, tel, number and email.


This can be tested on any mobile/touch device.

Android screenshots below. iOS is a little different with some extra keys
### Url (/) key
![Screenshot_20190701-161939](https://user-images.githubusercontent.com/1296369/60448730-1bbf8900-9c1e-11e9-8a02-47774d7a5c99.png)

### Email (@) key
![Screenshot_20190701-161822](https://user-images.githubusercontent.com/1296369/60448731-1bbf8900-9c1e-11e9-9caf-7045baeecc67.png)

### Number
![Screenshot_20190701-162115](https://user-images.githubusercontent.com/1296369/60448732-1bbf8900-9c1e-11e9-9409-091857547d78.png)

### Tel (not used in core)
![Screenshot_20190701-162031](https://user-images.githubusercontent.com/1296369/60448733-1bbf8900-9c1e-11e9-965b-1413d37dbbd6.png)
