### PR TITLE
[4.0] mod_login icon

### DIFF
--- a/administrator/modules/mod_login/tmpl/default.php
+++ b/administrator/modules/mod_login/tmpl/default.php
@@ -72,7 +72,7 @@ Text::script('JHIDE');
 				</label>
 				<div class="input-group">
 					<span class="input-group-prepend">
-						<span class="input-group-text"><span class="fa fa-shield" aria-hidden="true"></span></span>
+						<span class="input-group-text"><span class="fa fa-shield-alt" aria-hidden="true"></span></span>
 					</span>
 					<input
 						name="secretkey"


### PR DESCRIPTION
the icon used for the security key field on the admin login page has been changed with the upgrade from fontawesome 4 to 5


###before
![image](https://user-images.githubusercontent.com/1296369/60466729-635d0980-9c4c-11e9-9465-295cd9425792.png)

###after
![image](https://user-images.githubusercontent.com/1296369/60466710-52ac9380-9c4c-11e9-8c5a-51e98609f37e.png)
