### PR TITLE
[4.0] Featured icon display

### DIFF
--- a/layouts/joomla/button/action-button.php
+++ b/layouts/joomla/button/action-button.php
@@ -26,7 +26,7 @@ $taskPrefix = $options['task_prefix'];
 $checkboxName = $options['checkbox_name'];
 ?>
 <button type="submit" class="tbody-icon data-state-<?php echo $this->escape($value ?? ''); ?>" 
-	<?php echo $this->escape(!empty($disabled) ? 'disabled' : null); ?>
+	<?php echo !empty($disabled) ? 'disabled' : ''; ?>
 	<?php if (!empty($task) && empty($disabled)) : ?>
 		onclick="return Joomla.listItemTask('<?php echo $checkboxName . $this->escape($row ?? ''); ?>', '<?php echo $this->escape(isset($task) ? $taskPrefix . $task : ''); ?>')"
 	<?php endif; ?>

--- a/layouts/joomla/button/action-button.php
+++ b/layouts/joomla/button/action-button.php
@@ -25,11 +25,12 @@ $disabled = !empty($options['disabled']);
 $taskPrefix = $options['task_prefix'];
 $checkboxName = $options['checkbox_name'];
 ?>
-	<button type="submit" class="tbody-icon data-state-<?php echo $this->escape($value ?? ''); ?>" <?php echo $this->escape(!empty($disabled) ? 'disabled' : null); ?>
-		<?php if(!empty($task) && empty($disabled)): ?>
-			onclick="return Joomla.listItemTask('<?php echo $checkboxName . $this->escape($row ?? ''); ?>', '<?php echo $this->escape(isset($task) ? $taskPrefix . $task : ''); ?>')"
-		<?php endif; ?>
-	>
-		<span class="<?php echo $this->escape($icon ?? ''); ?>" aria-hidden="true"></span>
-		<span class="sr-only"><?php echo Text::_($title); ?></span>
-	</button>
+<button type="submit" class="tbody-icon data-state-<?php echo $this->escape($value ?? ''); ?>" 
+	<?php echo $this->escape(!empty($disabled) ? 'disabled' : null); ?>
+	<?php if(!empty($task) && empty($disabled)): ?>
+		onclick="return Joomla.listItemTask('<?php echo $checkboxName . $this->escape($row ?? ''); ?>', '<?php echo $this->escape(isset($task) ? $taskPrefix . $task : ''); ?>')"
+	<?php endif; ?>
+>
+	<span class="<?php echo $this->escape($icon ?? ''); ?>" aria-hidden="true"></span>
+	<span class="sr-only"><?php echo Text::_($title); ?></span>
+</button>

--- a/layouts/joomla/button/action-button.php
+++ b/layouts/joomla/button/action-button.php
@@ -25,11 +25,7 @@ $disabled = !empty($options['disabled']);
 $taskPrefix = $options['task_prefix'];
 $checkboxName = $options['checkbox_name'];
 ?>
-<?php if(!empty($disabled)): ?>
-		<span class="<?php echo $this->escape($icon ?? ''); ?>" aria-hidden="true"></span>
-		<span class="sr-only"><?php echo Text::_($title); ?></span>
-<?php else: ?>
-	<button type="submit" class="tbody-icon data-state-<?php echo $this->escape($value ?? ''); ?> <?php echo $this->escape(!empty($disabled) ? 'disabled' : null); ?>"
+	<button type="submit" class="tbody-icon data-state-<?php echo $this->escape($value ?? ''); ?>" <?php echo $this->escape(!empty($disabled) ? 'disabled' : null); ?>
 		<?php if(!empty($task) && empty($disabled)): ?>
 			onclick="return Joomla.listItemTask('<?php echo $checkboxName . $this->escape($row ?? ''); ?>', '<?php echo $this->escape(isset($task) ? $taskPrefix . $task : ''); ?>')"
 		<?php endif; ?>
@@ -37,4 +33,3 @@ $checkboxName = $options['checkbox_name'];
 		<span class="<?php echo $this->escape($icon ?? ''); ?>" aria-hidden="true"></span>
 		<span class="sr-only"><?php echo Text::_($title); ?></span>
 	</button>
-<?php endif; ?>

--- a/layouts/joomla/button/action-button.php
+++ b/layouts/joomla/button/action-button.php
@@ -27,7 +27,7 @@ $checkboxName = $options['checkbox_name'];
 ?>
 <button type="submit" class="tbody-icon data-state-<?php echo $this->escape($value ?? ''); ?>" 
 	<?php echo $this->escape(!empty($disabled) ? 'disabled' : null); ?>
-	<?php if(!empty($task) && empty($disabled)): ?>
+	<?php if (!empty($task) && empty($disabled)) : ?>
 		onclick="return Joomla.listItemTask('<?php echo $checkboxName . $this->escape($row ?? ''); ?>', '<?php echo $this->escape(isset($task) ? $taskPrefix . $task : ''); ?>')"
 	<?php endif; ?>
 >


### PR DESCRIPTION
If you have a user who does **not** have core.edit.state permissions for com_content.article then the icon displayed for "featured/unfeatured" is wrong and you cannot differentiate between  "featured/unfeatured" . 

The problem is that the style comes from the `tbody-icon` on the button and the code in the joomla.icons.action-button layout has two bugs.

The first bug is that **disabled** was in the class attribute - it should be its own attribute. This meant that the button was never disabled. Which is probably why the second bug was introduced - the entire `if(!empty($disabled))` test is not required and because it is not wrapped in a button it never gets the `tbody-icon` class and looks **wrong**

### Testing instructions
Create a new user at the manager level. In article options change the permissions for manager so that **Edit State** is disabled.

Login as that user and go to the list of articles.

### Before PR
![image](https://user-images.githubusercontent.com/1296369/60495556-ed3ac000-9ca8-11e9-8df4-cbea0cb2eafc.png)

### After PR
![image](https://user-images.githubusercontent.com/1296369/60495418-a64cca80-9ca8-11e9-9a3c-81711cf04d0d.png)
