### PR TITLE
Fix Frontend Site Configuration error on save

### DIFF
--- a/components/com_config/model/form.php
+++ b/components/com_config/model/form.php
@@ -153,6 +153,8 @@ abstract class ConfigModelForm extends ConfigModelCms
 		// Get the form.
 		// Register the paths for the form -- failing here
 		$paths = new SplPriorityQueue;
+		$paths->insert(JPATH_COMPONENT_ADMINISTRATOR . '/model/form', 'normal');
+		$paths->insert(JPATH_COMPONENT_ADMINISTRATOR . '/model/field', 'normal');
 		$paths->insert(JPATH_COMPONENT . '/model/form', 'normal');
 		$paths->insert(JPATH_COMPONENT . '/model/field', 'normal');
 		$paths->insert(JPATH_COMPONENT . '/model/rule', 'normal');
@@ -165,6 +167,8 @@ abstract class ConfigModelForm extends ConfigModelCms
 		// Solution until JForm supports splqueue
 		JForm::addFormPath(JPATH_COMPONENT . '/models/forms');
 		JForm::addFieldPath(JPATH_COMPONENT . '/models/fields');
+		JForm::addFormPath(JPATH_COMPONENT_ADMINISTRATOR . '/model/form');
+		JForm::addFieldPath(JPATH_COMPONENT_ADMINISTRATOR . '/model/field');
 		JForm::addFormPath(JPATH_COMPONENT . '/model/form');
 		JForm::addFieldPath(JPATH_COMPONENT . '/model/field');
 


### PR DESCRIPTION
Pull Request for Issue #25385 .

### Summary of Changes

Add admin paths to the search paths for form and its fields for loading the configuration form for frontend editing of site configuration options.

### Testing Instructions

Create a menu type "Configuration manager", "Site Configuration options", access "Super User". Go to FrontEnd and log as superuser. Site Configutration is displayed and may be updated. Click on Save button.

### Expected result

Configuration saved.

### Actual result

Error 0 - Call to a member function filter() on boolean.

### Documentation Changes Required

None.