### PR TITLE
[4.0] Remove HTMLHelper

### DIFF
--- a/layouts/joomla/button/action-button.php
+++ b/layouts/joomla/button/action-button.php
@@ -7,10 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
-
-HTMLHelper::_('bootstrap.popover');
 
 /**
  * @var $icon    string


### PR DESCRIPTION
Cleanup for #23718.

### Summary of Changes
Use of HTMLHelper was removed in #23718. This PR removes the remainder.


### Testing Instructions
Code review.

or

Go to Content > Articles. 
Works as before.


