### PR TITLE
[4.0] Fix contact submission query

### DIFF
--- a/components/com_contact/Controller/ContactController.php
+++ b/components/com_contact/Controller/ContactController.php
@@ -71,6 +71,13 @@ class ContactController extends FormController
 		$model->setState('filter.published', 1);
 		$contact = $model->getItem($id);
 
+		if ($contact === false)
+		{
+			$this->setMessage($model->getError(), 'error');
+
+			return false;
+		}
+
 		// Get item params, take menu parameters into account if necessary
 		$active = $app->getMenu()->getActive();
 		$stateParams = clone $model->getState()->get('params');

--- a/components/com_contact/Model/ContactModel.php
+++ b/components/com_contact/Model/ContactModel.php
@@ -195,11 +195,11 @@ class ContactModel extends FormModel
 
 					// Join on category table.
 					->select('c.title AS category_title, c.alias AS category_alias, c.access AS category_access')
-					->join('LEFT', $db->quoteName('#__categories', 'c'), 'c.id = a.catid')
+					->leftJoin($db->quoteName('#__categories', 'c'), 'c.id = a.catid')
 
 					// Join over the categories to get parent category titles
 					->select('parent.title AS parent_title, parent.id AS parent_id, parent.path AS parent_route, parent.alias AS parent_alias')
-					->join('LEFT', $db->quoteName('#__categories', 'parent'), 'parent.id = c.parent_id')
+					->leftJoin($db->quoteName('#__categories', 'parent'), 'parent.id = c.parent_id')
 					->where($db->quoteName('a.id') . ' = :id')
 					->bind(':id', $pk, ParameterType::INTEGER);
 

--- a/components/com_contact/Model/ContactModel.php
+++ b/components/com_contact/Model/ContactModel.php
@@ -21,6 +21,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Model\FormModel;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\Database\ParameterType;
+use Joomla\Database\QueryInterface;
 use Joomla\Registry\Registry;
 
 /**
@@ -194,16 +195,15 @@ class ContactModel extends FormModel
 
 					// Join on category table.
 					->select('c.title AS category_title, c.alias AS category_alias, c.access AS category_access')
-					->leftJoin($db->quoteName('#__categories', 'c') . ' ON c.id = a.catid')
+					->join('LEFT', $db->quoteName('#__categories', 'c'), 'c.id = a.catid')
 
 					// Join over the categories to get parent category titles
 					->select('parent.title AS parent_title, parent.id AS parent_id, parent.path AS parent_route, parent.alias AS parent_alias')
-					->leftJoin($db->quoteName('#__categories', 'parent') . ' ON parent.id = c.parent_id')
+					->join('LEFT', $db->quoteName('#__categories', 'parent'), 'parent.id = c.parent_id')
 					->where($db->quoteName('a.id') . ' = :id')
 					->bind(':id', $pk, ParameterType::INTEGER);
 
 				// Filter by start and end dates.
-				$nullDate = $db->quote($db->getNullDate());
 				$nowDate = Factory::getDate()->toSql();
 
 				// Filter by published state.
@@ -212,11 +212,18 @@ class ContactModel extends FormModel
 
 				if (is_numeric($published))
 				{
-					$query->where('(a.published = :published OR a.published = :archived)')
+					$queryString = 'a.published = :published';
+
+					if ($archived !== null)
+					{
+						$queryString = '(' . $queryString . ' OR a.published = :archived)';
+						$query->bind(':archived', $archived, ParameterType::INTEGER);
+					}
+
+					$query->where($queryString)
 						->where('(' . $query->isNullDatetime('a.publish_up') . ' OR a.publish_up <= :publish_up)')
 						->where('(' . $query->isNullDatetime('a.publish_down') . ' OR a.publish_down >= :publish_down)')
 						->bind(':published', $published, ParameterType::INTEGER)
-						->bind(':archived', $archived, ParameterType::INTEGER)
 						->bind(':publish_up', $nowDate)
 						->bind(':publish_down', $nowDate);
 				}
@@ -405,9 +412,9 @@ class ContactModel extends FormModel
 	/**
 	* Generate column expression for slug or catslug.
 	*
-	* @param   \JDatabaseQuery  $query  Current query instance.
-	* @param   string           $id     Column id name.
-	* @param   string           $alias  Column alias name.
+	* @param   QueryInterface  $query  Current query instance.
+	* @param   string          $id     Column id name.
+	* @param   string          $alias  Column alias name.
 	*
 	* @return  string
 	*

--- a/components/com_contact/Model/ContactModel.php
+++ b/components/com_contact/Model/ContactModel.php
@@ -212,17 +212,17 @@ class ContactModel extends FormModel
 
 				if (is_numeric($published))
 				{
-					$queryString = 'a.published = :published';
+					$queryString = $db->quoteName('a.published') . ' = :published';
 
 					if ($archived !== null)
 					{
-						$queryString = '(' . $queryString . ' OR a.published = :archived)';
+						$queryString = '(' . $queryString . ' OR ' . $db->quoteName('a.published') . ' = :archived)';
 						$query->bind(':archived', $archived, ParameterType::INTEGER);
 					}
 
 					$query->where($queryString)
-						->where('(' . $query->isNullDatetime('a.publish_up') . ' OR a.publish_up <= :publish_up)')
-						->where('(' . $query->isNullDatetime('a.publish_down') . ' OR a.publish_down >= :publish_down)')
+						->where('(' . $query->isNullDatetime('a.publish_up') . ' OR ' . $db->quoteName('a.publish_up') . ' <= :publish_up)')
+						->where('(' . $query->isNullDatetime('a.publish_down') . ' OR ' . $db->quoteName('a.publish_down') . ' >= :publish_down)')
 						->bind(':published', $published, ParameterType::INTEGER)
 						->bind(':publish_up', $nowDate)
 						->bind(':publish_down', $nowDate);
@@ -349,7 +349,7 @@ class ContactModel extends FormModel
 			if (Multilanguage::isEnabled())
 			{
 				$language = [Factory::getLanguage()->getTag(), $db->quote('*')];
-				$query->whereIn($db->quoteName('a.language'), $language);
+				$query->whereIn($db->quoteName('a.language'), $language, ParameterType::STRING);
 			}
 
 			if (is_numeric($published))


### PR DESCRIPTION
### Summary
This patch both fixes the query (fixing the case where the archived filter is null) and adds error handling so the fatal error can't happen again (see the part in contact model) even if we manage to reintroduce this bug and instead adds a happy error message.

### Testing Instructions
Create a contact in the frontend and try and submit a contact. Before you get a fatal error in JRegistry. After patch contact submission successfully sends.
