### PR TITLE
[4.0] Fix undefined constant JPATH_CLI

### DIFF
--- a/installation/includes/defines.php
+++ b/installation/includes/defines.php
@@ -25,4 +25,4 @@ define('JPATH_THEMES',        JPATH_BASE);
 define('JPATH_CACHE',         JPATH_ADMINISTRATOR . DIRECTORY_SEPARATOR . 'cache');
 define('JPATH_MANIFESTS',     JPATH_ADMINISTRATOR . DIRECTORY_SEPARATOR . 'manifests');
 define('JPATH_API',           JPATH_ROOT . DIRECTORY_SEPARATOR . 'api');
-
+define('JPATH_CLI',           JPATH_ROOT . DIRECTORY_SEPARATOR . 'cli');


### PR DESCRIPTION
Related Issue #25376.

### Summary of Changes
> PHP Warning:  Use of undefined constant JPATH_CLI - assumed 'JPATH_CLI' (this will throw an Error in a future version of PHP) in \libraries\src\Application\ApplicationHelper.php on line 157

### Testing Instructions
Install 4.0-dev
Check PHP error log.


