### PR TITLE
[4.0] remove individual credits from templates

### DIFF
--- a/administrator/templates/atum/templateDetails.xml
+++ b/administrator/templates/atum/templateDetails.xml
@@ -3,7 +3,7 @@
 	<name>atum</name>
 	<version>1.0</version>
 	<creationDate>16/09/2016</creationDate>
-	<author>Charlie Lodder, Dimitris Grammatikogiannis, Ciaran Walsh, Elisa Foltyn</author>
+	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<copyright>Copyright (C) 2005 - 2019 Open Source Matters, Inc. All rights reserved.</copyright>
 	<description>TPL_ATUM_XML_DESCRIPTION</description>

--- a/templates/cassiopeia/templateDetails.xml
+++ b/templates/cassiopeia/templateDetails.xml
@@ -3,7 +3,7 @@
 	<name>cassiopeia</name>
 	<version>1.0</version>
 	<creationDate>30/02/2017</creationDate>
-	<author>Charlie Lodder / Ciarán Walsh</author>
+	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<copyright>Copyright (C) 2005 - 2019 Open Source Matters, Inc. All rights reserved.</copyright>
 	<description>TPL_CASSIOPEIA_XML_DESCRIPTION</description>


### PR DESCRIPTION
Pull Request for Issue #25237 .

### Summary of Changes
removed the individual credits from templates manifest, i.e the author tag now is:
`<author>Joomla! Project</author>`

like all over the core code