### PR TITLE
[4.0] Add alias and rename the action log plugin base class

### DIFF
--- a/administrator/components/com_actionlogs/Plugin/ActionLogPlugin.php
+++ b/administrator/components/com_actionlogs/Plugin/ActionLogPlugin.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-namespace Joomla\Component\Actionlogs\Administrator\Libraries;
+namespace Joomla\Component\Actionlogs\Administrator\Plugin;
 
 defined('_JEXEC') or die;
 

--- a/libraries/extensions.classmap.php
+++ b/libraries/extensions.classmap.php
@@ -10,6 +10,8 @@
 defined('_JEXEC') or die;
 
 // Class map of the core extensions
+JLoader::registerAlias('ActionLogPlugin', '\\Joomla\\Component\\Actionlogs\\Administrator\\Plugin\\ActionLogPlugin', '5.0');
+
 JLoader::registerAlias('FieldsPlugin',     '\\Joomla\\Component\\Fields\\Administrator\\Plugin\\FieldsPlugin', '4.0');
 JLoader::registerAlias('FieldsListPlugin', '\\Joomla\\Component\\Fields\\Administrator\\Plugin\\FieldsListPlugin', '4.0');
 

--- a/plugins/actionlog/joomla/joomla.php
+++ b/plugins/actionlog/joomla/joomla.php
@@ -13,7 +13,7 @@ use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\User\User;
 use Joomla\Component\Actionlogs\Administrator\Helper\ActionlogsHelper;
-use Joomla\Component\Actionlogs\Administrator\Libraries\ActionLogPlugin;
+use Joomla\Component\Actionlogs\Administrator\Plugin\ActionLogPlugin;
 use Joomla\Utilities\ArrayHelper;
 
 /**


### PR DESCRIPTION
Rename the class for the action log plugin (and add's an extension alias for that new class)

- The current name just upper cases the old file name - this causes case sensitivity issues when upgrading from Joomla 3 to Joomla 4
- Therefore rename it in a consistent way with the privacy components plugin https://github.com/joomla/joomla-cms/blob/4.0-dev/administrator/components/com_privacy/Plugin/PrivacyPlugin.php