### PR TITLE
Load global admin language file in Editors-XTD modals

### DIFF
--- a/components/com_contact/controller.php
+++ b/components/com_contact/controller.php
@@ -35,6 +35,8 @@ class ContactController extends JControllerLegacy
 		{
 			JHtml::_('stylesheet', 'system/adminlist.css', array(), true);
 			$config['base_path'] = JPATH_COMPONENT_ADMINISTRATOR;
+
+			// Load global backend language file.
 			$app->getLanguage()->load('joomla', JPATH_ADMINISTRATOR);
 		}
 

--- a/components/com_contact/controller.php
+++ b/components/com_contact/controller.php
@@ -27,13 +27,15 @@ class ContactController extends JControllerLegacy
 	 */
 	public function __construct($config = array())
 	{
-		$this->input = JFactory::getApplication()->input;
+		$app = JFactory::getApplication();
+		$this->input = $app->input;
 
 		// Contact frontpage Editor contacts proxying:
 		if ($this->input->get('view') === 'contacts' && $this->input->get('layout') === 'modal')
 		{
 			JHtml::_('stylesheet', 'system/adminlist.css', array(), true);
 			$config['base_path'] = JPATH_COMPONENT_ADMINISTRATOR;
+			$app->getLanguage()->load('joomla', JPATH_ADMINISTRATOR);
 		}
 
 		parent::__construct($config);

--- a/components/com_content/controller.php
+++ b/components/com_content/controller.php
@@ -29,7 +29,8 @@ class ContentController extends JControllerLegacy
 	 */
 	public function __construct($config = array())
 	{
-		$this->input = JFactory::getApplication()->input;
+		$app = JFactory::getApplication();
+		$this->input = $app->input;
 
 		// Article frontpage Editor pagebreak proxying:
 		if ($this->input->get('view') === 'article' && $this->input->get('layout') === 'pagebreak')
@@ -41,6 +42,7 @@ class ContentController extends JControllerLegacy
 		{
 			JHtml::_('stylesheet', 'system/adminlist.css', array('version' => 'auto', 'relative' => true));
 			$config['base_path'] = JPATH_COMPONENT_ADMINISTRATOR;
+			$app->getLanguage()->load('joomla', JPATH_ADMINISTRATOR);
 		}
 
 		parent::__construct($config);

--- a/components/com_content/controller.php
+++ b/components/com_content/controller.php
@@ -42,6 +42,8 @@ class ContentController extends JControllerLegacy
 		{
 			JHtml::_('stylesheet', 'system/adminlist.css', array('version' => 'auto', 'relative' => true));
 			$config['base_path'] = JPATH_COMPONENT_ADMINISTRATOR;
+
+			// Load global backend language file.
 			$app->getLanguage()->load('joomla', JPATH_ADMINISTRATOR);
 		}
 

--- a/components/com_fields/controller.php
+++ b/components/com_fields/controller.php
@@ -31,7 +31,7 @@ class FieldsController extends JControllerLegacy
 		// Frontpage Editor Fields Button proxying:
 		if ($this->input->get('view') === 'fields' && $this->input->get('layout') === 'modal')
 		{
-			// Load the backend language file.
+			// Load backend language files.
 			$lang = JFactory::getLanguage();
 			$lang->load('joomla', JPATH_ADMINISTRATOR);
 			$lang->load('com_fields', JPATH_ADMINISTRATOR);

--- a/components/com_fields/controller.php
+++ b/components/com_fields/controller.php
@@ -33,6 +33,7 @@ class FieldsController extends JControllerLegacy
 		{
 			// Load the backend language file.
 			$lang = JFactory::getLanguage();
+			$lang->load('joomla', JPATH_ADMINISTRATOR);
 			$lang->load('com_fields', JPATH_ADMINISTRATOR);
 
 			$config['base_path'] = JPATH_COMPONENT_ADMINISTRATOR;


### PR DESCRIPTION
Pull Request for Issue #25344 .

### Summary of Changes

Loads global administrator language file when viewing backend view in frontend (i.e. in Editors-XTD modals).

### Testing Instructions

Enable `Debug Language` in Global Configuration.
Edit an article in frontend.
In editor, use `Contact`, `Field` and `Article` buttons.

### Expected result

No untranslated strings.

### Actual result

Untranslated strings:

```
# JROOT\libraries\src\Language\Text.php

JAUTHOR_ASC="ASC"
JAUTHOR_DESC="DESC"
JCATEGORY_ASC="ASC"
JCATEGORY_DESC="DESC"
JDATE_ASC="ASC"
JDATE_DESC="DESC"
JFEATURED_ASC="ASC"
JFEATURED_DESC="DESC"
JGLOBAL_HITS_ASC="HITS ASC"
JGLOBAL_HITS_DESC="HITS DESC"
JGLOBAL_LIST_ALIAS="LIST ALIAS"
JGLOBAL_LIST_ALIAS_NOTE="LIST ALIAS NOTE"
JGLOBAL_SORT_BY="SORT BY"
JGLOBAL_TITLE_ASC="TITLE ASC"
JGLOBAL_TITLE_DESC="TITLE DESC"
JGRID_HEADING_ACCESS_ASC="HEADING ACCESS ASC"
JGRID_HEADING_ACCESS_DESC="HEADING ACCESS DESC"
JGRID_HEADING_ID_ASC="HEADING ID ASC"
JGRID_HEADING_ID_DESC="HEADING ID DESC"
JGRID_HEADING_LANGUAGE_ASC="HEADING LANGUAGE ASC"
JGRID_HEADING_LANGUAGE_DESC="HEADING LANGUAGE DESC"
JGRID_HEADING_ORDERING_ASC="HEADING ORDERING ASC"
JGRID_HEADING_ORDERING_DESC="HEADING ORDERING DESC"
JSTATUS_ASC="ASC"
JSTATUS_DESC="DESC"
```

### Documentation Changes Required

No.