### PR TITLE
[mod_tags_popular] Exclude restricted items from count

### DIFF
--- a/modules/mod_tags_popular/helper.php
+++ b/modules/mod_tags_popular/helper.php
@@ -84,7 +84,7 @@ abstract class ModTagsPopularHelper
 
 		$query->where($db->quoteName('m.type_alias') . ' = ' . $db->quoteName('c.core_type_alias'));
 
-		// Only return tags connected to published articles
+		// Only return tags connected to published and authorised items
 		$query->where($db->quoteName('c.core_state') . ' = 1')
 			->where($db->quoteName('c.core_access') . ' IN (' . $groups . ')')
 			->where('(' . $db->quoteName('c.core_publish_up') . ' = ' . $nullDate

--- a/modules/mod_tags_popular/helper.php
+++ b/modules/mod_tags_popular/helper.php
@@ -86,6 +86,7 @@ abstract class ModTagsPopularHelper
 
 		// Only return tags connected to published articles
 		$query->where($db->quoteName('c.core_state') . ' = 1')
+			->where($db->quoteName('c.core_access') . ' IN (' . $groups . ')')
 			->where('(' . $db->quoteName('c.core_publish_up') . ' = ' . $nullDate
 				. ' OR ' . $db->quoteName('c.core_publish_up') . ' <= ' . $db->quote($nowDate) . ')')
 			->where('(' . $db->quoteName('c.core_publish_down') . ' = ' . $nullDate


### PR DESCRIPTION
Pull Request for Issue #23582 .

### Summary of Changes

Adds access filter when counting items.

### Testing Instructions

Create two articles.
Assign them the same tag.
Set access of one article to `Registered`.
Publish `Tags - Popular` module.
In the module enable `Display Number of Items` option.
View the module in frontend. Inspect the number of items next to the tag:
a) As guest.
b) As logged in user.

### Expected result

a) 1
b) 2

### Actual result

a) 2
b) 2

### Documentation Changes Required

No.