### PR TITLE
[4.0] Load JS message titles on login

### DIFF
--- a/administrator/modules/mod_login/tmpl/default.php
+++ b/administrator/modules/mod_login/tmpl/default.php
@@ -22,7 +22,11 @@ HTMLHelper::_('script', 'mod_login/admin-login.min.js', ['version' => 'auto', 'r
 
 Text::script('JSHOW');
 Text::script('JHIDE');
-
+// Load JS message titles
+Text::script('ERROR');
+Text::script('WARNING');
+Text::script('NOTICE');
+Text::script('MESSAGE');
 ?>
 <form class="login-initial form-validate" action="<?php echo Route::_('index.php', true); ?>" method="post" id="form-login">
 	<fieldset>


### PR DESCRIPTION
If you get an error on login eg by hitting login without filling any field then the resulting error message has an untranslatable and lowercase "error" as the title

This PR fixes that

For completeness, consistency and future proof I added the other error message strings

### Before
![image](https://user-images.githubusercontent.com/1296369/60823401-5b96eb00-a19f-11e9-97e1-2fdc8f274070.png)


### After
![image](https://user-images.githubusercontent.com/1296369/60823368-47eb8480-a19f-11e9-84b4-2d5ab457ed53.png)
