### PR TITLE
[com_fields] Fix language strings/unknown columns/sorting

### DIFF
--- a/administrator/components/com_fields/models/fields.php
+++ b/administrator/components/com_fields/models/fields.php
@@ -44,7 +44,7 @@ class FieldsModelFields extends JModelList
 				'checked_out_time', 'a.checked_out_time',
 				'created_time', 'a.created_time',
 				'created_user_id', 'a.created_user_id',
-				'category_title',
+				'category_title', 'g.title',
 				'category_id', 'a.category_id',
 				'group_id', 'a.group_id',
 				'assigned_cat_ids'

--- a/administrator/components/com_fields/models/fields.php
+++ b/administrator/components/com_fields/models/fields.php
@@ -44,7 +44,7 @@ class FieldsModelFields extends JModelList
 				'checked_out_time', 'a.checked_out_time',
 				'created_time', 'a.created_time',
 				'created_user_id', 'a.created_user_id',
-				'category_title', 'g.title',
+				'group_title', 'g.title',
 				'category_id', 'a.category_id',
 				'group_id', 'a.group_id',
 				'assigned_cat_ids'

--- a/administrator/components/com_fields/views/fields/tmpl/modal.php
+++ b/administrator/components/com_fields/views/fields/tmpl/modal.php
@@ -57,7 +57,7 @@ $editor    = JFactory::getApplication()->input->get('editor', '', 'cmd');
 							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ACCESS', 'a.access', $listDirn, $listOrder); ?>
 						</th>
 						<th width="10%" class="nowrap hidden-phone">
-							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'language', $listDirn, $listOrder); ?>
+							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'a.language', $listDirn, $listOrder); ?>
 						</th>
 						<th width="1%" class="nowrap hidden-phone">
 							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>

--- a/administrator/components/com_fields/views/fields/tmpl/modal.php
+++ b/administrator/components/com_fields/views/fields/tmpl/modal.php
@@ -48,7 +48,7 @@ $editor    = JFactory::getApplication()->input->get('editor', '', 'cmd');
 							<?php echo JHtml::_('searchtools.sort', 'JGLOBAL_TITLE', 'a.title', $listDirn, $listOrder); ?>
 						</th>
 						<th width="15%" class="nowrap hidden-phone">
-							<?php echo JHtml::_('searchtools.sort', 'COM_FIELDS_FIELD_GROUP_LABEL', 'group_title', $listDirn, $listOrder); ?>
+							<?php echo JHtml::_('searchtools.sort', 'COM_FIELDS_FIELD_GROUP_LABEL', 'g.title', $listDirn, $listOrder); ?>
 						</th>
 						<th width="10%" class="nowrap hidden-phone">
 							<?php echo JHtml::_('searchtools.sort', 'COM_FIELDS_FIELD_TYPE_LABEL', 'a.type', $listDirn, $listOrder); ?>

--- a/administrator/components/com_fields/views/fields/view.html.php
+++ b/administrator/components/com_fields/views/fields/view.html.php
@@ -204,7 +204,7 @@ class FieldsViewFields extends JViewLegacy
 			'a.title'    => JText::_('JGLOBAL_TITLE'),
 			'a.type'     => JText::_('COM_FIELDS_FIELD_TYPE_LABEL'),
 			'a.access'   => JText::_('JGRID_HEADING_ACCESS'),
-			'language'   => JText::_('JGRID_HEADING_LANGUAGE'),
+			'a.language' => JText::_('JGRID_HEADING_LANGUAGE'),
 			'a.id'       => JText::_('JGRID_HEADING_ID'),
 		);
 	}

--- a/components/com_fields/models/forms/filter_fields.xml
+++ b/components/com_fields/models/forms/filter_fields.xml
@@ -78,8 +78,8 @@
 			<option value="a.title DESC">JGLOBAL_TITLE_DESC</option>
 			<option value="a.type ASC">COM_FIELDS_VIEW_FIELDS_SORT_TYPE_ASC</option>
 			<option value="a.type DESC">COM_FIELDS_VIEW_FIELDS_SORT_TYPE_DESC</option>
-			<option value="category_title ASC">COM_FIELDS_VIEW_FIELDS_SORT_GROUP_ASC</option>
-			<option value="category_title DESC">COM_FIELDS_VIEW_FIELDS_SORT_GROUP_DESC</option>
+			<option value="g.title ASC">COM_FIELDS_VIEW_FIELDS_SORT_GROUP_ASC</option>
+			<option value="g.title DESC">COM_FIELDS_VIEW_FIELDS_SORT_GROUP_DESC</option>
 			<option value="a.access ASC">JGRID_HEADING_ACCESS_ASC</option>
 			<option value="a.access DESC">JGRID_HEADING_ACCESS_DESC</option>
 			<option value="language ASC">JGRID_HEADING_LANGUAGE_ASC</option>

--- a/components/com_fields/models/forms/filter_fields.xml
+++ b/components/com_fields/models/forms/filter_fields.xml
@@ -82,8 +82,8 @@
 			<option value="g.title DESC">COM_FIELDS_VIEW_FIELDS_SORT_GROUP_DESC</option>
 			<option value="a.access ASC">JGRID_HEADING_ACCESS_ASC</option>
 			<option value="a.access DESC">JGRID_HEADING_ACCESS_DESC</option>
-			<option value="language ASC">JGRID_HEADING_LANGUAGE_ASC</option>
-			<option value="language DESC">JGRID_HEADING_LANGUAGE_DESC</option>
+			<option value="a.language ASC">JGRID_HEADING_LANGUAGE_ASC</option>
+			<option value="a.language DESC">JGRID_HEADING_LANGUAGE_DESC</option>
 			<option value="a.id ASC">JGRID_HEADING_ID_ASC</option>
 			<option value="a.id DESC">JGRID_HEADING_ID_DESC</option>
 		</field>

--- a/components/com_fields/models/forms/filter_fields.xml
+++ b/components/com_fields/models/forms/filter_fields.xml
@@ -78,8 +78,8 @@
 			<option value="a.title DESC">JGLOBAL_TITLE_DESC</option>
 			<option value="a.type ASC">COM_FIELDS_VIEW_FIELDS_SORT_TYPE_ASC</option>
 			<option value="a.type DESC">COM_FIELDS_VIEW_FIELDS_SORT_TYPE_DESC</option>
-			<option value="category_title ASC">COM_FIELDS_FIELD_GROUP_LABEL</option>
-			<option value="category_title DESC">COM_FIELDS_FIELD_GROUP_LABEL</option>
+			<option value="category_title ASC">COM_FIELDS_VIEW_FIELDS_SORT_GROUP_ASC</option>
+			<option value="category_title DESC">COM_FIELDS_VIEW_FIELDS_SORT_GROUP_DESC</option>
 			<option value="a.access ASC">JGRID_HEADING_ACCESS_ASC</option>
 			<option value="a.access DESC">JGRID_HEADING_ACCESS_DESC</option>
 			<option value="language ASC">JGRID_HEADING_LANGUAGE_ASC</option>


### PR DESCRIPTION
### Summary of Changes
Fix language strings and columns.
Fix Field Group header not sorting.

### Testing Instructions
Go to front end.
Edit an article.
Click on the Field button.
Right click on the modal to bring up a contextual menu to open `This Frame > Open Frame in New Tab`.
View the dropdown in the upper right corner.
Click on the Field Group header. 

Go to back end.
Go to Content > Fields
Make sure there are fields assigned to field groups.
Click on Field Group header.
Click on Language header.