### PR TITLE
[4.0] Fix errors during upgrade (PostgreSQL)

### DIFF
--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2016-10-02.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2016-10-02.sql
@@ -4,8 +4,8 @@ ALTER TABLE "#__user_keys" DROP COLUMN "invalid";
 -- Insert the new templates into the database. Set as home if the old template is the active one
 --
 INSERT INTO "#__extensions" ("name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "manifest_cache", "params", "custom_data", "system_data", "checked_out", "checked_out_time", "ordering", "state") VALUES
-('atum', 'template', 'atum', '', 1, 1, 1, 0, '{}', '{}', '', '', 0, '0000-00-00 00:00:00', 0, 0),
-('cassiopeia', 'template', 'cassiopeia', '', 0, 1, 1, 0, '{}', '{}', '', '', 0, '0000-00-00 00:00:00', 0, 0);
+('atum', 'template', 'atum', '', 1, 1, 1, 0, '{}', '{}', '', '', 0, '1970-01-01 00:00:00', 0, 0),
+('cassiopeia', 'template', 'cassiopeia', '', 0, 1, 1, 0, '{}', '{}', '', '', 0, '1970-01-01 00:00:00', 0, 0);
 
 INSERT INTO "#__template_styles" ("template", "client_id", "home", "title", "params") VALUES
 ('atum', 1, (CASE WHEN (SELECT count FROM (SELECT count("id") AS count FROM "#__template_styles" WHERE home = '1' AND client_id = 1 AND "template" IN ('isis', 'hathor')) as c) = 0 THEN '0' ELSE '1' END), 'atum - Default', '{}'),

--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2016-10-02.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2016-10-02.sql
@@ -8,8 +8,8 @@ INSERT INTO "#__extensions" ("name", "type", "element", "folder", "client_id", "
 ('cassiopeia', 'template', 'cassiopeia', '', 0, 1, 1, 0, '{}', '{}', '', '', 0, '1970-01-01 00:00:00', 0, 0);
 
 INSERT INTO "#__template_styles" ("template", "client_id", "home", "title", "params") VALUES
-('atum', 1, (CASE WHEN (SELECT count FROM (SELECT count("id") AS count FROM "#__template_styles" WHERE home = '1' AND client_id = 1 AND "template" IN ('isis', 'hathor')) as c) = 0 THEN '0' ELSE '1' END), 'atum - Default', '{}'),
-('cassiopeia', 0, (CASE WHEN (SELECT count FROM (SELECT count("id") AS count FROM "#__template_styles" WHERE home = '1' AND client_id = 0 AND "template" IN ('protostar', 'beez3')) as c) = 0 THEN '0' ELSE '1' END), 'cassiopeia - Default', '{}');
+('atum', 1, (CASE WHEN (SELECT count FROM (SELECT count("id") AS count FROM "#__template_styles" WHERE home = 1 AND client_id = 1 AND "template" IN ('isis', 'hathor')) as c) = 0 THEN 0 ELSE 1 END), 'atum - Default', '{}'),
+('cassiopeia', 0, (CASE WHEN (SELECT count FROM (SELECT count("id") AS count FROM "#__template_styles" WHERE home = 1 AND client_id = 0 AND "template" IN ('protostar', 'beez3')) as c) = 0 THEN 0 ELSE 1 END), 'cassiopeia - Default', '{}');
 
 --
 -- Now we can clean up the old templates

--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2016-10-03.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2016-10-03.sql
@@ -1,1 +1,1 @@
-DELETE FROM "#__extensions" WHERE "name" = "mod_submenu";
+DELETE FROM "#__extensions" WHERE "name" = 'mod_submenu';

--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2017-04-25.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2017-04-25.sql
@@ -2,4 +2,4 @@ INSERT INTO "#__extensions" ("name", "type", "element", "folder", "client_id", "
 ('plg_filesystem_local', 'plugin', 'local', 'filesystem', 0, 1, 1, 0, '', '{}', 0, '1970-01-01 00:00:00', 0, 0),
 ('plg_media-action_crop', 'plugin', 'crop', 'media-action', 0, 1, 1, 0, '', '{}', 0, '1970-01-01 00:00:00', 0, 0),
 ('plg_media-action_resize', 'plugin', 'resize', 'media-action', 0, 1, 1, 0, '', '{}', 0, '1970-01-01 00:00:00', 0, 0),
-('plg_media-action_rotate', 'plugin', 'rotate', 'media-action', 0, 1, 1, 0, '', '{}', 0, '1970-01-01 00:00:00', 0, 0),;
+('plg_media-action_rotate', 'plugin', 'rotate', 'media-action', 0, 1, 1, 0, '', '{}', 0, '1970-01-01 00:00:00', 0, 0);

--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2017-10-10.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2017-10-10.sql
@@ -1,4 +1,4 @@
-INSERT INTO "#__extensions" (name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "manifest_cache", "params", "checked_out", "checked_out_time", "ordering", "state") VALUES
+INSERT INTO "#__extensions" ("name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "manifest_cache", "params", "checked_out", "checked_out_time", "ordering", "state") VALUES
 ('plg_system_httpheaders', 'plugin', 'httpheaders', 'system', 0, 0, 1, 0, '', '{}', 0, '1970-01-01 00:00:00', 0, 0);
 
 INSERT INTO "#__postinstall_messages" ("extension_id", "title_key", "description_key", "action_key", "language_extension", "language_client_id", "type", "action_file", "action", "condition_file", "condition_method", "version_introduced", "enabled")

--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2018-07-29.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2018-07-29.sql
@@ -81,7 +81,6 @@ ALTER TABLE "#__finder_terms" ALTER COLUMN "soundex" SET DEFAULT '';
 CREATE INDEX "#__finder_terms_idx_stem" on "#__finder_terms" ("stem");
 CREATE INDEX "#__finder_terms_idx_language" on "#__finder_terms" ("language");
 ALTER TABLE "#__finder_terms"	DROP CONSTRAINT "#__finder_terms_idx_term",	ADD CONSTRAINT "#__finder_terms_idx_term_language" UNIQUE ("term", "language");
-CREATE INDEX "#__finder_terms_idx_language" on "#__finder_terms" ("language");
 
 DROP TABLE IF EXISTS "#__finder_terms_common";
 CREATE TABLE "#__finder_terms_common" (

--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2019-02-03.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2019-02-03.sql
@@ -1,3 +1,3 @@
-DELETE FROM "#__menu" WHERE "link" = "index.php?option=com_postinstall" AND "menutype" = "main";
-DELETE FROM "#__menu" WHERE "link" = "index.php?option=com_redirect" AND "menutype" = "main";
-DELETE FROM "#__menu" WHERE "link" = "index.php?option=com_joomlaupdate" AND "menutype" = "main";
+DELETE FROM "#__menu" WHERE "link" = 'index.php?option=com_postinstall' AND "menutype" = 'main';
+DELETE FROM "#__menu" WHERE "link" = 'index.php?option=com_redirect' AND "menutype" = 'main';
+DELETE FROM "#__menu" WHERE "link" = 'index.php?option=com_joomlaupdate' AND "menutype" = 'main';


### PR DESCRIPTION
Pull Request for Issue #25467 .

### Summary of Changes
Fix errors of sql files in administrator/components/com_admin/sql/updates/postgresql.
See the commit comments.


### Testing Instructions
1. Install a copy of Joomla 3.x (I was using 3.9.9 RC) on postgres
2. Apply this PR to your joomla source directory.
3. Build an update package to your joomla-4.0-dev source directory:
- `git tag 4.0.0-alpha11-dev`
- `php build/build.php`
- Update Joomla 3.9.x with the new update package.
4. Check if Joomla upgrades successfully


### Expected result
No Warning or Error.


### Actual result

> Error
The template for this display is not available.

is going away.

![database_check](https://user-images.githubusercontent.com/26852967/60860079-36dd5a80-a215-11e9-8975-95894e39ad76.png)


### Documentation Changes Required

