### PR TITLE
[4.0] Remove deprecated *_dev_level attributes from update server manifests

### DIFF
--- a/libraries/src/Updater/Adapter/ExtensionAdapter.php
+++ b/libraries/src/Updater/Adapter/ExtensionAdapter.php
@@ -109,31 +109,9 @@ class ExtensionAdapter extends UpdateAdapter
 				// Lower case and remove the exclamation mark
 				$product = strtolower(InputFilter::getInstance()->clean(Version::PRODUCT, 'cmd'));
 
-				// Support for the min_dev_level and max_dev_level attributes is deprecated, a regexp should be used instead
-				if (isset($this->currentUpdate->targetplatform->min_dev_level) || isset($this->currentUpdate->targetplatform->max_dev_level))
-				{
-					Log::add(
-						'Support for the min_dev_level and max_dev_level attributes of an update\'s <targetplatform> tag is deprecated and'
-						. ' will be removed in 4.0. The full version should be specified in the version attribute and may optionally be a regexp.',
-						Log::WARNING,
-						'deprecated'
-					);
-				}
-
-				/*
-				 * Check that the product matches and that the version matches (optionally a regexp)
-				 *
-				 * Check for optional min_dev_level and max_dev_level attributes to further specify targetplatform (e.g., 3.0.1)
-				 */
-				$patchMinimumSupported = !isset($this->currentUpdate->targetplatform->min_dev_level)
-					|| Version::PATCH_VERSION >= $this->currentUpdate->targetplatform->min_dev_level;
-				$patchMaximumSupported = !isset($this->currentUpdate->targetplatform->max_dev_level)
-					|| Version::PATCH_VERSION <= $this->currentUpdate->targetplatform->max_dev_level;
-
+				// Check that the product matches and that the version matches (optionally a regexp)
 				if ($product == $this->currentUpdate->targetplatform['NAME']
-					&& preg_match('/^' . $this->currentUpdate->targetplatform['VERSION'] . '/', JVERSION)
-					&& $patchMinimumSupported
-					&& $patchMaximumSupported)
+					&& preg_match('/^' . $this->currentUpdate->targetplatform['VERSION'] . '/', JVERSION))
 				{
 					// Check if PHP version supported via <php_minimum> tag, assume true if tag isn't present
 					if (!isset($this->currentUpdate->php_minimum) || version_compare(PHP_VERSION, $this->currentUpdate->php_minimum, '>='))

--- a/libraries/src/Updater/Update.php
+++ b/libraries/src/Updater/Update.php
@@ -331,34 +331,10 @@ class Update extends CMSObject
 			case 'UPDATE':
 				$product = strtolower(InputFilter::getInstance()->clean(Version::PRODUCT, 'cmd'));
 
-				// Support for the min_dev_level and max_dev_level attributes is deprecated, a regexp should be used instead
-				if (isset($this->currentUpdate->targetplatform->min_dev_level) || isset($this->currentUpdate->targetplatform->max_dev_level))
-				{
-					Log::add(
-						'Support for the min_dev_level and max_dev_level attributes of an update\'s <targetplatform> tag is deprecated and'
-						. ' will be removed in 4.0. The full version should be specified in the version attribute and may optionally be a regexp.',
-						Log::WARNING,
-						'deprecated'
-					);
-				}
-
-				/*
-				 * Check that the product matches and that the version matches (optionally a regexp)
-				 *
-				 * Check for optional min_dev_level and max_dev_level attributes to further specify targetplatform (e.g., 3.0.1)
-				 */
-				$patchVersion = $this->get('jversion.dev_level', Version::PATCH_VERSION);
-				$patchMinimumSupported = !isset($this->currentUpdate->targetplatform->min_dev_level)
-					|| $patchVersion >= $this->currentUpdate->targetplatform->min_dev_level;
-
-				$patchMaximumSupported = !isset($this->currentUpdate->targetplatform->max_dev_level)
-					|| $patchVersion <= $this->currentUpdate->targetplatform->max_dev_level;
-
+				// Check that the product matches and that the version matches (optionally a regexp)
 				if (isset($this->currentUpdate->targetplatform->name)
 					&& $product == $this->currentUpdate->targetplatform->name
-					&& preg_match('/^' . $this->currentUpdate->targetplatform->version . '/', $this->get('jversion.full', JVERSION))
-					&& $patchMinimumSupported
-					&& $patchMaximumSupported)
+					&& preg_match('/^' . $this->currentUpdate->targetplatform->version . '/', $this->get('jversion.full', JVERSION)))
 				{
 					$phpMatch = false;
 


### PR DESCRIPTION
### Summary of Changes

As of 3.5 the `version` attribute of the `<targetplatform>` tag has supported a regex comparing the full Joomla version (previously this did not support the patch version) and the `min_dev_level` and `max_dev_level` attributes were deprecated.  This code has not yet been removed from 4.0, it is now moved to `/dev/null` to rest peacefully.

### Testing Instructions

Find an extension that claims compatibility with 4.0 and ensure that its updates continue to be correctly shown in the Joomla administrator user interface

### Documentation Changes Required

- [ ] Update the update server documentation to note these attributes are not supported in 4.0
    - [ ] If necessary, ensure the regex constraints are properly explained
- [ ] Update the B/C break documentation to note these attributes are not supported in 4.0