### PR TITLE
[4.0] behavior.hastooltip

### DIFF
--- a/administrator/components/com_workflow/tmpl/stages/default.php
+++ b/administrator/components/com_workflow/tmpl/stages/default.php
@@ -18,7 +18,6 @@ use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
 
-HTMLHelper::_('behavior.tooltip');
 HTMLHelper::_('behavior.multiselect');
 
 $user      = Factory::getUser();

--- a/administrator/components/com_workflow/tmpl/transitions/default.php
+++ b/administrator/components/com_workflow/tmpl/transitions/default.php
@@ -19,7 +19,6 @@ use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
 use Joomla\CMS\Workflow\Workflow;
 
-HTMLHelper::_('behavior.tooltip');
 HTMLHelper::_('behavior.multiselect');
 
 $user	= Factory::getUser();

--- a/administrator/components/com_workflow/tmpl/workflows/default.php
+++ b/administrator/components/com_workflow/tmpl/workflows/default.php
@@ -18,7 +18,6 @@ use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
 
-HTMLHelper::_('behavior.tooltip');
 HTMLHelper::_('behavior.multiselect');
 
 $listOrder = $this->escape($this->state->get('list.ordering'));


### PR DESCRIPTION
This PR removes the remaining instances of `HTMLHelper::_('behavior.tooltip');`

It doesn't do anything at all as can be seen
https://github.com/joomla/joomla-cms/blob/42067d565666ac51d01b8b96d422e294cc494da4/libraries/cms/html/behavior.php#L112

It is just a copy/paste error
