### PR TITLE
[4.0] Remove vendor prefixes from SCSS

### DIFF
--- a/administrator/components/com_media/resources/styles/components/_media-browser.scss
+++ b/administrator/components/com_media/resources/styles/components/_media-browser.scss
@@ -22,8 +22,6 @@
   margin-right: $grid-gutter-width;
   margin-bottom: $grid-gutter-width;
   cursor: pointer;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   .media-browser-items-xs & {
     width: calc(#{$grid-item-width-xs} - #{$grid-gutter-width});

--- a/administrator/templates/atum/scss/blocks/_global.scss
+++ b/administrator/templates/atum/scss/blocks/_global.scss
@@ -46,8 +46,7 @@ button,
 input,
 textarea {
 
-  &:focus,
-  &:-moz-focusring {
+  &:focus {
     outline: auto 2px var(--focus);
   }
 }

--- a/administrator/templates/atum/scss/pages/_com_cpanel.scss
+++ b/administrator/templates/atum/scss/pages/_com_cpanel.scss
@@ -36,7 +36,6 @@
 
     &__category {
       margin-bottom: 1.5em;
-      -webkit-column-break-inside: avoid;
       page-break-inside: avoid;
       break-inside: avoid;
     }

--- a/administrator/templates/atum/scss/vendor/_choicesjs.scss
+++ b/administrator/templates/atum/scss/vendor/_choicesjs.scss
@@ -12,8 +12,6 @@
   cursor: pointer;
   background: none;
   border: 0;
-  -moz-appearance: none;
-  -webkit-appearance: none;
   appearance: none;
 
   &::before {

--- a/administrator/templates/atum/scss/vendor/_chosen.scss
+++ b/administrator/templates/atum/scss/vendor/_chosen.scss
@@ -19,8 +19,6 @@ $chosen-select-padding-y: $custom-select-padding-y + .21;
     background-size: $custom-select-bg-size;
     border: $custom-select-border-width solid $custom-select-border-color;
     box-shadow: none;
-    -moz-appearance: none;
-    -webkit-appearance: none;
     @if $enable-rounded {
       border-radius: $custom-select-border-radius;
     } @else {

--- a/build/build-modules-js/settings.json
+++ b/build/build-modules-js/settings.json
@@ -2,7 +2,7 @@
   "settings": {
     "browsers": [
       "last 1 version",
-      "not ie < 11"
+      "not ie 11"
     ],
     "vendors": {
       "awesomplete": {

--- a/build/media_source/system/scss/fields/joomla-field-simple-color.scss
+++ b/build/media_source/system/scss/fields/joomla-field-simple-color.scss
@@ -24,7 +24,6 @@ joomla-field-simple-color {
     background: none;
     border: solid 1px #ccc;
     border-radius: 3px;
-    -webkit-appearence: none;
   }
 
   .btn-close {

--- a/templates/cassiopeia/scss/template-rtl.scss
+++ b/templates/cassiopeia/scss/template-rtl.scss
@@ -36,10 +36,6 @@ body, .dropdown-item {
   right: -1px;
 }
 
-dd {
-  -webkit-margin-start: 0;
-}
-
 .form-check {
   padding-right: 1.25rem;
   padding-left: 0;

--- a/templates/cassiopeia/scss/vendor/_choicesjs.scss
+++ b/templates/cassiopeia/scss/vendor/_choicesjs.scss
@@ -12,8 +12,6 @@
   cursor: pointer;
   background: none;
   border: 0;
-  -moz-appearance: none;
-  -webkit-appearance: none;
   appearance: none;
 
   &::before {

--- a/templates/cassiopeia/scss/vendor/_chosen.scss
+++ b/templates/cassiopeia/scss/vendor/_chosen.scss
@@ -19,8 +19,6 @@ $chosen-select-padding-y: $custom-select-padding-y + .21;
     background-size: $custom-select-bg-size;
     border: $custom-select-border-width solid $custom-select-border-color;
     box-shadow: none;
-    -moz-appearance: none;
-    -webkit-appearance: none;
     @if $enable-rounded {
       border-radius: $custom-select-border-radius;
     } @else {


### PR DESCRIPTION
Vendor prefixes are not required in the scss as the `autoprefixer` package deals with it
