### PR TITLE
[4.0] Tests: Delay creating a category

### DIFF
--- a/tests/Codeception/_support/Step/Acceptance/Administrator/Category.php
+++ b/tests/Codeception/_support/Step/Acceptance/Administrator/Category.php
@@ -26,6 +26,7 @@ class Category extends Admin
 	{
 		$this->amOnPage(ContentCategoryListPage::$url);
 		$this->waitForText("Articles: Categories", TIMEOUT, "//h1");
+		$this->waitForJsOnPageLoad();
 		$this->clickToolbarButton("New");
 		$this->waitForElement(ContentCategoryListPage::$title);
 		$this->fillField(ContentCategoryListPage::$title, $title);


### PR DESCRIPTION
The tests currently don't pass and an assumption is, that this is due to not enough wait time between page changes. This should help a bit with that. 