### PR TITLE
[4.0] Always load System - Actionlogs plugin language files

### DIFF
--- a/plugins/system/actionlogs/actionlogs.php
+++ b/plugins/system/actionlogs/actionlogs.php
@@ -65,12 +65,7 @@ class PlgSystemActionLogs extends CMSPlugin
 	 */
 	public function onAfterInitialise()
 	{
-		if (!$this->app->isClient('administrator'))
-		{
-			return;
-		}
-
-		// Load plugin language files only when needed (ex: they are not needed in site client).
+		// Load plugin language files.
 		$this->loadLanguage();
 	}
 


### PR DESCRIPTION
Pull Request for Issue #25534.

### Summary of Changes

Always load System - Actionlogs plugin language files

### Testing Instructions

Make sure System - Actionlogs plugin is enabled.
Log in as super user in frontend.
Edit profile.

### Expected result

No untranslated strings.

### Actual result

Untranslated language strings like `PLG_SYSTEM_ACTIONLOGS_OPTIONS`.

### Documentation Changes Required

No.