### PR TITLE
[4.0] Html in descriptions

### DIFF
--- a/layouts/joomla/form/renderfield.php
+++ b/layouts/joomla/form/renderfield.php
@@ -41,7 +41,7 @@ $hide  = empty($options['hiddenLabel']) ? '' : ' sr-only';
 	<?php if (!empty($description)) : ?>
 		<div id="<?php echo $id; ?>">
 			<small class="form-text text-muted">
-				<?php echo htmlspecialchars(($description), ENT_COMPAT, 'UTF-8'); ?>
+				<?php echo $description; ?>
 			</small>
 		</div>
 	<?php endif; ?>


### PR DESCRIPTION
Do not use htmlspecialchars on descriptions as we have html markup in the text :(

### Example Before
![image](https://user-images.githubusercontent.com/1296369/61158114-f2411000-a4ef-11e9-8745-aee2a573e2f1.png)

### After
![image](https://user-images.githubusercontent.com/1296369/61158092-e5bcb780-a4ef-11e9-8a5e-8442c70dbdb3.png)
