### PR TITLE
[4.0] Convert plugin system stats to prepared statements

### DIFF
--- a/plugins/system/stats/stats.php
+++ b/plugins/system/stats/stats.php
@@ -143,7 +143,7 @@ class PlgSystemStats extends CMSPlugin
 			return;
 		}
 
-		HTMLHelper::_('script', 'plg_system_stats/stats-message.js', array('version' => 'auto', 'relative' => true));
+		HTMLHelper::_('script', 'plg_system_stats/stats-message.js', ['version' => 'auto', 'relative' => true]);
 	}
 
 	/**
@@ -172,7 +172,7 @@ class PlgSystemStats extends CMSPlugin
 
 		$this->sendStats();
 
-		echo json_encode(array('sent' => 1));
+		echo json_encode(['sent' => 1]);
 	}
 
 	/**
@@ -199,7 +199,7 @@ class PlgSystemStats extends CMSPlugin
 			throw new RuntimeException('Unable to save plugin settings', 500);
 		}
 
-		echo json_encode(array('sent' => 0));
+		echo json_encode(['sent' => 0]);
 	}
 
 	/**
@@ -228,7 +228,7 @@ class PlgSystemStats extends CMSPlugin
 
 		$this->sendStats();
 
-		echo json_encode(array('sent' => 1));
+		echo json_encode(['sent' => 1]);
 	}
 
 	/**
@@ -252,10 +252,10 @@ class PlgSystemStats extends CMSPlugin
 		// User has not selected the mode. Show message.
 		if ((int) $this->params->get('mode') !== static::MODE_ALLOW_ALWAYS)
 		{
-			$data = array(
+			$data = [
 				'sent' => 0,
 				'html' => $this->getRenderer('message')->render($this->getLayoutData())
-			);
+			];
 
 			echo json_encode($data);
 
@@ -269,7 +269,7 @@ class PlgSystemStats extends CMSPlugin
 
 		$this->sendStats();
 
-		echo json_encode(array('sent' => 1));
+		echo json_encode(['sent' => 1]);
 	}
 
 	/**
@@ -296,7 +296,7 @@ class PlgSystemStats extends CMSPlugin
 	 *
 	 * @since   3.5
 	 */
-	public function debug($layoutId, $data = array())
+	public function debug($layoutId, $data = [])
 	{
 		$data = array_merge($this->getLayoutData(), $data);
 
@@ -312,11 +312,11 @@ class PlgSystemStats extends CMSPlugin
 	 */
 	protected function getLayoutData()
 	{
-		return array(
+		return [
 			'plugin'       => $this,
 			'pluginParams' => $this->params,
 			'statsData'    => $this->getStatsData()
-		);
+		];
 	}
 
 	/**
@@ -330,10 +330,10 @@ class PlgSystemStats extends CMSPlugin
 	{
 		$template = Factory::getApplication()->getTemplate();
 
-		return array(
+		return [
 			JPATH_ADMINISTRATOR . '/templates/' . $template . '/html/layouts/plugins/' . $this->_type . '/' . $this->_name,
 			__DIR__ . '/layouts',
-		);
+		];
 	}
 
 	/**
@@ -363,14 +363,14 @@ class PlgSystemStats extends CMSPlugin
 	 */
 	private function getStatsData()
 	{
-		return array(
+		return [
 			'unique_id'   => $this->getUniqueId(),
 			'php_version' => PHP_VERSION,
 			'db_type'     => $this->db->name,
 			'db_version'  => $this->db->getVersion(),
 			'cms_version' => JVERSION,
 			'server_os'   => php_uname('s') . ' ' . php_uname('r')
-		);
+		];
 	}
 
 	/**
@@ -463,7 +463,7 @@ class PlgSystemStats extends CMSPlugin
 	 *
 	 * @since   3.5
 	 */
-	public function render($layoutId, $data = array())
+	public function render($layoutId, $data = [])
 	{
 		$data = array_merge($this->getLayoutData(), $data);
 
@@ -485,17 +485,21 @@ class PlgSystemStats extends CMSPlugin
 		$interval = (int) $this->params->get('interval', 12);
 		$this->params->set('interval', $interval ?: 12);
 
-		$query = $this->db->getQuery(true)
-			->update($this->db->quoteName('#__extensions'))
-			->set($this->db->quoteName('params') . ' = ' . $this->db->quote($this->params->toString('JSON')))
-			->where($this->db->quoteName('type') . ' = ' . $this->db->quote('plugin'))
-			->where($this->db->quoteName('folder') . ' = ' . $this->db->quote('system'))
-			->where($this->db->quoteName('element') . ' = ' . $this->db->quote('stats'));
+		$paramsJson = $this->params->toString('JSON');
+		$db         = $this->db;
+
+		$query = $db->getQuery(true)
+			->update($db->quoteName('#__extensions'))
+			->set($db->quoteName('params') . ' = :params')
+			->where($db->quoteName('type') . ' = ' . $db->quote('plugin'))
+			->where($db->quoteName('folder') . ' = ' . $db->quote('system'))
+			->where($db->quoteName('element') . ' = ' . $db->quote('stats'))
+			->bind(':params', $paramsJson);
 
 		try
 		{
 			// Lock the tables to prevent multiple plugin executions causing a race condition
-			$this->db->lockTable('#__extensions');
+			$db->lockTable('#__extensions');
 		}
 		catch (Exception $e)
 		{
@@ -506,21 +510,21 @@ class PlgSystemStats extends CMSPlugin
 		try
 		{
 			// Update the plugin parameters
-			$result = $this->db->setQuery($query)->execute();
+			$result = $db->setQuery($query)->execute();
 
-			$this->clearCacheGroups(array('com_plugins'));
+			$this->clearCacheGroups(['com_plugins']);
 		}
 		catch (Exception $exc)
 		{
 			// If we failed to execute
-			$this->db->unlockTables();
+			$db->unlockTables();
 			$result = false;
 		}
 
 		try
 		{
 			// Unlock the tables after writing
-			$this->db->unlockTables();
+			$db->unlockTables();
 		}
 		catch (Exception $e)
 		{
@@ -588,10 +592,10 @@ class PlgSystemStats extends CMSPlugin
 		{
 			try
 			{
-				$options = array(
+				$options = [
 					'defaultgroup' => $group,
 					'cachebase'    => $this->app->get('cache_path', JPATH_CACHE)
-				);
+				];
 
 				$cache = Cache::getInstance('callback', $options);
 				$cache->clean();

--- a/plugins/system/stats/stats.php
+++ b/plugins/system/stats/stats.php
@@ -254,7 +254,7 @@ class PlgSystemStats extends CMSPlugin
 		{
 			$data = [
 				'sent' => 0,
-				'html' => $this->getRenderer('message')->render($this->getLayoutData())
+				'html' => $this->getRenderer('message')->render($this->getLayoutData()),
 			];
 
 			echo json_encode($data);
@@ -315,7 +315,7 @@ class PlgSystemStats extends CMSPlugin
 		return [
 			'plugin'       => $this,
 			'pluginParams' => $this->params,
-			'statsData'    => $this->getStatsData()
+			'statsData'    => $this->getStatsData(),
 		];
 	}
 
@@ -369,7 +369,7 @@ class PlgSystemStats extends CMSPlugin
 			'db_type'     => $this->db->name,
 			'db_version'  => $this->db->getVersion(),
 			'cms_version' => JVERSION,
-			'server_os'   => php_uname('s') . ' ' . php_uname('r')
+			'server_os'   => php_uname('s') . ' ' . php_uname('r'),
 		];
 	}
 
@@ -594,7 +594,7 @@ class PlgSystemStats extends CMSPlugin
 			{
 				$options = [
 					'defaultgroup' => $group,
-					'cachebase'    => $this->app->get('cache_path', JPATH_CACHE)
+					'cachebase'    => $this->app->get('cache_path', JPATH_CACHE),
 				];
 
 				$cache = Cache::getInstance('callback', $options);


### PR DESCRIPTION
# Summary of Changes
Updated SQL queries to prepared statements and made some cleanups around the queries.


### Testing Instructions
Use the plugin in all ways you can think of.

This Plugin sent statistics to Joomla.org, so using, prepared statements changes in the parameter save function. So saving the plugin settings should be one part.

### Expected result
Nothing changed.
