### PR TITLE
[RFC] First draft of deleted file check

### DIFF
--- a/build/.gitignore
+++ b/build/.gitignore
@@ -11,3 +11,4 @@
 
 # Ignore the deleted file script output
 /deleted_files.txt
+/deleted_folders.txt

--- a/build/.gitignore
+++ b/build/.gitignore
@@ -12,3 +12,4 @@
 # Ignore the deleted file script output
 /deleted_files.txt
 /deleted_folders.txt
+/renamed_files.txt

--- a/build/deleted_file_check.php
+++ b/build/deleted_file_check.php
@@ -65,10 +65,10 @@ $previousReleaseExclude = [
 	$options['from'] . '/administrator/components/com_search',
 	$options['from'] . '/components/com_search',
 	$options['from'] . '/images/sampledata',
+	$options['from'] . '/installation',
 	$options['from'] . '/modules/mod_search',
-	$options['from'] . '/plugins/search',
 	$options['from'] . '/plugins/fields/repeatable',
-	$options['from'] . '/installation'
+	$options['from'] . '/plugins/search',
 ];
 
 /**
@@ -154,9 +154,10 @@ $foldersDifference = array_diff($previousReleaseFolders, $newReleaseFolders);
 $filesToKeep = [
 	"'/administrator/language/en-GB/en-GB.com_search.ini',",
 	"'/administrator/language/en-GB/en-GB.com_search.sys.ini',",
+	"'/administrator/language/en-GB/en-GB.plg_editors-xtd_weblink.ini',",
+	"'/administrator/language/en-GB/en-GB.plg_editors-xtd_weblink.sys.ini',",
 	"'/administrator/language/en-GB/en-GB.plg_fields_repeatable.ini',",
 	"'/administrator/language/en-GB/en-GB.plg_fields_repeatable.sys.ini',",
-	"'/language/en-GB/en-GB.com_search.ini',",
 	"'/administrator/language/en-GB/en-GB.plg_search_categories.ini',",
 	"'/administrator/language/en-GB/en-GB.plg_search_categories.sys.ini',",
 	"'/administrator/language/en-GB/en-GB.plg_search_contacts.ini',",
@@ -169,10 +170,9 @@ $filesToKeep = [
 	"'/administrator/language/en-GB/en-GB.plg_search_tags.sys.ini',",
 	"'/administrator/language/en-GB/en-GB.plg_search_weblinks.ini',",
 	"'/administrator/language/en-GB/en-GB.plg_search_weblinks.sys.ini',",
-	"'/administrator/language/en-GB/en-GB.plg_editors-xtd_weblink.ini',",
-	"'/administrator/language/en-GB/en-GB.plg_editors-xtd_weblink.sys.ini',",
 	"'/administrator/language/en-GB/en-GB.plg_system_weblinks.ini',",
 	"'/administrator/language/en-GB/en-GB.plg_system_weblinks.sys.ini',",
+	"'/language/en-GB/en-GB.com_search.ini',",
 	"'/language/en-GB/en-GB.mod_search.ini',",
 	"'/language/en-GB/en-GB.mod_search.sys.ini',",
 ];

--- a/build/deleted_file_check.php
+++ b/build/deleted_file_check.php
@@ -209,6 +209,7 @@ foreach ($filesDifference as $file)
 		}
 	}
 
+	// File has been really deleted and not just renamed
 	$deletedFiles[] = $file;
 }
 

--- a/build/deleted_file_check.php
+++ b/build/deleted_file_check.php
@@ -177,6 +177,19 @@ $filesToKeep = [
 	"'/language/en-GB/en-GB.mod_search.sys.ini',",
 ];
 
+// Specific folders that we want to keep on upgrade
+$foldersToKeep = [
+	"'/bin',",
+];
+
+// Remove folders from the results which we want to keep on upgrade
+foreach ($foldersToKeep as $folder)
+{
+	if (($key = array_search($folder, $foldersDifference)) !== false) {
+		unset($foldersDifference[$key]);
+	}
+}
+
 asort($filesDifference);
 rsort($foldersDifference);
 

--- a/build/deleted_file_check.php
+++ b/build/deleted_file_check.php
@@ -64,6 +64,7 @@ if (empty($options['to']))
 $previousReleaseExclude = [
 	$options['from'] . '/administrator/components/com_search',
 	$options['from'] . '/components/com_search',
+	$options['from'] . '/modules/mod_search',
 	$options['from'] . '/plugins/search',
 	$options['from'] . '/plugins/fields/repeatable',
 	$options['from'] . '/installation'
@@ -171,6 +172,8 @@ $filesToRemove = [
 	"'/administrator/language/en-GB/en-GB.plg_editors-xtd_weblink.sys.ini',",
 	"'/administrator/language/en-GB/en-GB.plg_system_weblinks.ini',",
 	"'/administrator/language/en-GB/en-GB.plg_system_weblinks.sys.ini',",
+	"'/language/en-GB/en-GB.mod_search.ini',",
+	"'/language/en-GB/en-GB.mod_search.sys.ini',",
 ];
 
 foreach ($filesToRemove as $file)

--- a/build/deleted_file_check.php
+++ b/build/deleted_file_check.php
@@ -64,6 +64,7 @@ if (empty($options['to']))
 $previousReleaseExclude = [
 	$options['from'] . '/administrator/components/com_search',
 	$options['from'] . '/components/com_search',
+	$options['from'] . '/images/sampledata',
 	$options['from'] . '/modules/mod_search',
 	$options['from'] . '/plugins/search',
 	$options['from'] . '/plugins/fields/repeatable',

--- a/build/deleted_file_check.php
+++ b/build/deleted_file_check.php
@@ -65,6 +65,7 @@ $previousReleaseExclude = [
 	$options['from'] . '/administrator/components/com_search',
 	$options['from'] . '/components/com_search',
 	$options['from'] . '/plugins/search',
+	$options['from'] . '/plugins/fields/repeatable',
 	$options['from'] . '/installation'
 ];
 
@@ -151,6 +152,8 @@ $foldersDifference = array_diff($previousReleaseFolders, $newReleaseFolders);
 $filesToRemove = [
 	"'/administrator/language/en-GB/en-GB.com_search.ini',",
 	"'/administrator/language/en-GB/en-GB.com_search.sys.ini',",
+	"'/administrator/language/en-GB/en-GB.plg_fields_repeatable.ini',",
+	"'/administrator/language/en-GB/en-GB.plg_fields_repeatable.sys.ini',",
 	"'/language/en-GB/en-GB.com_search.ini',",
 	"'/administrator/language/en-GB/en-GB.plg_search_categories.ini',",
 	"'/administrator/language/en-GB/en-GB.plg_search_categories.sys.ini',",

--- a/build/deleted_file_check.php
+++ b/build/deleted_file_check.php
@@ -43,7 +43,9 @@ if (empty($options['from']))
 {
 	echo PHP_EOL;
 	echo 'Missing starting directory' . PHP_EOL;
+
 	usage($argv[0]);
+
 	exit(1);
 }
 
@@ -52,7 +54,9 @@ if (empty($options['to']))
 {
 	echo PHP_EOL;
 	echo 'Missing ending directory' . PHP_EOL;
+
 	usage($argv[0]);
+
 	exit(1);
 }
 

--- a/build/deleted_file_check.php
+++ b/build/deleted_file_check.php
@@ -147,6 +147,32 @@ $filesDifference = array_diff($previousReleaseFiles, $newReleaseFiles);
 
 $foldersDifference = array_diff($previousReleaseFolders, $newReleaseFolders);
 
+// Remove any specific files (e.g. language files) that we want to keep on upgrade
+$filesToRemove = [
+	"'/administrator/language/en-GB/en-GB.com_search.ini',",
+	"'/administrator/language/en-GB/en-GB.com_search.sys.ini',",
+	"'/language/en-GB/en-GB.com_search.ini',",
+	"'/administrator/language/en-GB/en-GB.plg_search_categories.ini',",
+	"'/administrator/language/en-GB/en-GB.plg_search_categories.sys.ini',",
+	"'/administrator/language/en-GB/en-GB.plg_search_contacts.ini',",
+	"'/administrator/language/en-GB/en-GB.plg_search_contacts.sys.ini',",
+	"'/administrator/language/en-GB/en-GB.plg_search_content.ini',",
+	"'/administrator/language/en-GB/en-GB.plg_search_content.sys.ini',",
+	"'/administrator/language/en-GB/en-GB.plg_search_newsfeeds.ini',",
+	"'/administrator/language/en-GB/en-GB.plg_search_newsfeeds.sys.ini',",
+	"'/administrator/language/en-GB/en-GB.plg_search_tags.ini',",
+	"'/administrator/language/en-GB/en-GB.plg_search_tags.sys.ini',",
+	"'/administrator/language/en-GB/en-GB.plg_search_weblinks.ini',",
+	"'/administrator/language/en-GB/en-GB.plg_search_weblinks.sys.ini',",
+];
+
+foreach ($filesToRemove as $file)
+{
+	if (($key = array_search($file, $filesDifference)) !== false) {
+		unset($filesDifference[$key]);
+	}
+}
+
 asort($filesDifference);
 rsort($foldersDifference);
 

--- a/build/deleted_file_check.php
+++ b/build/deleted_file_check.php
@@ -33,8 +33,8 @@ function usage($command)
 }
 
 /*
-* This is where the magic happens
-*/
+ * This is where the magic happens
+ */
 
 $options = getopt('', array('from:', 'to::'));
 

--- a/build/deleted_file_check.php
+++ b/build/deleted_file_check.php
@@ -148,7 +148,7 @@ $filesDifference = array_diff($previousReleaseFiles, $newReleaseFiles);
 $foldersDifference = array_diff($previousReleaseFolders, $newReleaseFolders);
 
 asort($filesDifference);
-asort($foldersDifference);
+rsort($foldersDifference);
 
 // Write the deleted files list to a file for later reference
 file_put_contents(__DIR__ . '/deleted_files.txt', implode("\n", $filesDifference));

--- a/build/deleted_file_check.php
+++ b/build/deleted_file_check.php
@@ -1,16 +1,6 @@
 <?php
 /**
- * This file is used to build the list of deleted files between two reference points.
- *
- * This script requires one parameter:
- *
- * --from - The git commit reference to use as the starting point for the comparison.
- *
- * This script has one additional optional parameter:
- *
- * --to - The git commit reference to use as the ending point for the comparison.
- *
- * The reference parameters may be any valid identifier (i.e. a branch, tag, or commit SHA)
+ * This file is used to build the list of deleted files and folders between two reference points.
  *
  * @package    Joomla.Build
  *
@@ -18,128 +8,49 @@
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-// Detect the native operating system type.
-$os = strtoupper(substr(PHP_OS, 0, 3));
+// TODO: Make these directories dynamic or clone from git
+$previousReleaseDir = __DIR__ . '/joomla390';
+$newReleaseDir = __DIR__ . '/joomla400';
 
-if ($os === 'WIN')
+$previousReleaseDirIterator = new RecursiveDirectoryIterator($previousReleaseDir, RecursiveDirectoryIterator::SKIP_DOTS);
+$previousReleaseIterator = new RecursiveIteratorIterator($previousReleaseDirIterator, RecursiveIteratorIterator::SELF_FIRST);
+$previousReleaseFiles = [];
+$previousReleaseFolders = [];
+
+foreach ($previousReleaseIterator as $info)
 {
-	echo 'Sorry, this script is not supported on Windows.' . PHP_EOL;
-
-	exit(1);
-}
-
-/*
- * Constants
- */
-
-const PHP_TAB = "\t";
-
-/*
- * Globals
- */
-
-global $currentDir;
-$currentDir = getcwd();
-
-global $changedFiles;
-$changedFiles = array();
-
-global $deletedFiles;
-$deletedFiles = array();
-
-global $gitBinary;
-ob_start();
-passthru('which git', $gitBinary);
-$gitBinary = trim(ob_get_clean());
-
-/*
- * Functions
- */
-
-function run_git_command($command)
-{
-	global $currentDir;
-
-	chdir(dirname(__DIR__));
-
-	ob_start();
-	passthru($command);
-	$return = trim(ob_get_clean());
-
-	chdir($currentDir);
-
-	return $return;
-}
-
-function usage($command)
-{
-	echo PHP_EOL;
-	echo 'Usage: php ' . $command . ' [options]' . PHP_EOL;
-	echo PHP_TAB . '--from <ref>:' . PHP_TAB . 'Starting commit reference (branch/tag)' . PHP_EOL;
-	echo PHP_TAB . '--to <ref>:' . PHP_TAB . 'Ending commit reference (branch/tag) [optional]' . PHP_EOL;
-	echo PHP_EOL;
-}
-
-/*
- * This is where the magic happens
- */
-
-$options = getopt('', array('from:', 'to::'));
-
-// We need the from reference, otherwise we're doomed to fail
-if (empty($options['from']))
-{
-	echo PHP_EOL;
-	echo 'Missing starting commit reference' . PHP_EOL;
-
-	usage($argv[0]);
-
-	exit(1);
-}
-
-// Missing the to reference?  No problem, grab the current HEAD
-if (empty($options['to']))
-{
-	$options['to'] = run_git_command("$gitBinary rev-parse HEAD");
-}
-
-// Parse the git diff to know what files have been added, removed, or renamed
-$fileDiff = explode("\n", run_git_command("$gitBinary diff --name-status {$options['from']} {$options['to']}"));
-
-$deletedFiles = array();
-
-foreach ($fileDiff as $file)
-{
-	$fileName = substr($file, 2);
-
-	// Act on the file based on the action
-	switch (substr($file, 0, 1))
+	if ($info->isDir())
 	{
-		// This is a new case with git 2.9 to handle renamed files
-		case 'R':
-			// Explode the file on the tab character; key 0 is the action (rename), key 1 is the old filename, and key 2 is the new filename
-			$renamedFileData = explode("\t", $file);
-
-			// And flag the old file as deleted
-			$deletedFiles[] = "'/{$renamedFileData[1]}',";
-
-			break;
-
-		case 'D':
-			$deletedFiles[] = "'/$fileName',";
-
-			break;
-
-		default:
-			// Ignore file additions and modifications
-			break;
+		$previousReleaseFolders[] = "'" . str_replace($previousReleaseDir, '', $info->getPathname()) . "',";
+		continue;
 	}
+
+	$previousReleaseFiles[] = "'" . str_replace($previousReleaseDir, '', $info->getPathname()) . "',";
 }
 
-asort($deletedFiles);
+$newReleaseDirIterator = new RecursiveDirectoryIterator($newReleaseDir, RecursiveDirectoryIterator::SKIP_DOTS);
+$newReleaseIterator = new RecursiveIteratorIterator($newReleaseDirIterator, RecursiveIteratorIterator::SELF_FIRST);
+$newReleaseFiles = [];
+$newReleaseFolders = [];
+
+foreach ($newReleaseIterator as $info)
+{
+	if ($info->isDir())
+	{
+		$newReleaseFolders[] = "'" . str_replace($newReleaseDir, '', $info->getPathname()) . "',";
+		continue;
+	}
+
+	$newReleaseFiles[] = "'" . str_replace($newReleaseDir, '', $info->getPathname()) . "',";
+}
+
+$filesDifference = array_diff($previousReleaseFiles, $newReleaseFiles);
+
+$foldersDifference = array_diff($previousReleaseFolders, $newReleaseFolders);
+
+asort($filesDifference);
+asort($foldersDifference);
 
 // Write the deleted files list to a file for later reference
-file_put_contents(__DIR__ . '/deleted_files.txt', implode("\n", $deletedFiles));
-
-echo PHP_EOL;
-echo 'There are ' . count($deletedFiles) . ' deleted files in comparison to "' . $options['from'] . '"' . PHP_EOL;
+file_put_contents(__DIR__ . '/deleted_files.txt', implode("\n", $filesDifference));
+file_put_contents(__DIR__ . '/deleted_folders.txt', implode("\n", $foldersDifference));

--- a/build/deleted_file_check.php
+++ b/build/deleted_file_check.php
@@ -167,6 +167,10 @@ $filesToRemove = [
 	"'/administrator/language/en-GB/en-GB.plg_search_tags.sys.ini',",
 	"'/administrator/language/en-GB/en-GB.plg_search_weblinks.ini',",
 	"'/administrator/language/en-GB/en-GB.plg_search_weblinks.sys.ini',",
+	"'/administrator/language/en-GB/en-GB.plg_editors-xtd_weblink.ini',",
+	"'/administrator/language/en-GB/en-GB.plg_editors-xtd_weblink.sys.ini',",
+	"'/administrator/language/en-GB/en-GB.plg_system_weblinks.ini',",
+	"'/administrator/language/en-GB/en-GB.plg_system_weblinks.sys.ini',",
 ];
 
 foreach ($filesToRemove as $file)

--- a/build/deleted_file_check.php
+++ b/build/deleted_file_check.php
@@ -201,7 +201,7 @@ foreach ($filesDifference as $file)
 			if (dirname($match) === dirname($file) && strtolower(basename($match)) === strtolower(basename($file)))
 			{
 				// File has been renamed only: Add to renamed files list
-				$renamedFiles[] = $file . ' => ' . $match;
+				$renamedFiles[] = substr($file, 0, -1) . ' => ' . $match;
 
 				// Go on with the next file in $filesDifference
 				continue 2;


### PR DESCRIPTION
Pull Request for *some of* Issue #16458 .

### Summary of Changes
Reworks our deleted file script onto something more rudimentary however that takes into account our npm and composer deps are no longer stored in the repo.

#### Things left to do
- [ ] Make the folder paths dynamic at minimum - better to use git to build them ourselves
- [x] Don't trash any installation removed files
- [x] Don't trash search folders or files
- [x] Reverse order the folders list so we delete the nested directories first

### Testing Instructions
This script has been used to generate the existing deleted files list - which are already usable for update - but has had a few modifications since.

Basically in the build create a tmp folder grab a copy of two joomla versions - the 3.x version goes into the a `joomla390` folder and the 4.x into `joomla400` folder (i picked 3.9.13 and 4.0.0 alpha 12) to generate the list in this PR). Then run the script - it should match what's in the com_admin script

### Documentation Changes Required
n/a