### PR TITLE
[4.0] com_finder indexed content accessible tooltip

### DIFF
--- a/administrator/components/com_finder/tmpl/index/default.php
+++ b/administrator/components/com_finder/tmpl/index/default.php
@@ -17,8 +17,6 @@ use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\Component\Finder\Administrator\Helper\FinderHelperLanguage;
 
-HTMLHelper::_('bootstrap.popover');
-
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
 $lang      = Factory::getLanguage();
@@ -100,8 +98,13 @@ HTMLHelper::_('script', 'com_finder/index.js', ['version' => 'auto', 'relative' 
 							<?php endif; ?>
 							<td class="text-center d-none d-md-table-cell text-center">
 								<?php if ((int) $item->publish_start_date or (int) $item->publish_end_date or (int) $item->start_date or (int) $item->end_date) : ?>
-									<span class="icon-calendar pop hasPopover" aria-hidden="true" data-placement="left" title="<?php echo Text::_('COM_FINDER_INDEX_DATE_INFO_TITLE'); ?>" data-content="<?php echo Text::sprintf('COM_FINDER_INDEX_DATE_INFO', $item->publish_start_date, $item->publish_end_date, $item->start_date, $item->end_date); ?>"></span>
-									<span class="sr-only"><?php echo Text::sprintf('COM_FINDER_INDEX_DATE_INFO', $item->publish_start_date, $item->publish_end_date, $item->start_date, $item->end_date); ?></span>
+									<span tabindex="0">
+										<span class="icon-calendar" aria-hidden="true"></span>
+										<span class="sr-only"><?php echo Text::_('COM_FINDER_INDEX_DATE_INFO_TITLE'); ?></span>
+									</span>
+									<div role="tooltip" id="tip<?php echo $i; ?>">
+										<?php echo Text::sprintf('COM_FINDER_INDEX_DATE_INFO', $item->publish_start_date, $item->publish_end_date, $item->start_date, $item->end_date); ?>
+									</div>
 								<?php endif; ?>
 							</td>
 							<td class="small break-word d-none d-md-table-cell">


### PR DESCRIPTION
Continues the work to remove the popover with an accessible tip.

### Test
Hover over icon
Tab to icon

Styling of the tip is beyond the scope of this PR

### Before
![image](https://user-images.githubusercontent.com/1296369/61204947-91c7f380-a6e6-11e9-8d70-941685fa8579.png)

### After
![image](https://user-images.githubusercontent.com/1296369/61204963-9d1b1f00-a6e6-11e9-8413-0b17f2f02000.png)
