### PR TITLE
[4.0] com_finder change status button group

### DIFF
--- a/administrator/components/com_finder/View/Filters/HtmlView.php
+++ b/administrator/components/com_finder/View/Filters/HtmlView.php
@@ -146,21 +146,28 @@ class HtmlView extends BaseHtmlView
 
 		if ($canDo->get('core.edit.state'))
 		{
-			ToolbarHelper::publishList('filters.publish');
-			ToolbarHelper::unpublishList('filters.unpublish');
-			ToolbarHelper::checkin('filters.checkin');
-			ToolbarHelper::divider();
+			$dropdown = $toolbar->dropdownButton('status-group')
+			->text('JTOOLBAR_CHANGE_STATUS')
+			->toggleSplit(false)
+			->icon('fa fa-globe')
+			->buttonClass('btn btn-info')
+			->listCheck(true);
+
+			$childBar = $dropdown->getChildToolbar();
+
+			$childBar->publish('filters.publish')->listCheck(true);
+			$childBar->unpublish('filters.unpublish')->listCheck(true);
+			$childBar->checkin('filters.checkin')->listCheck(true);
+
+			if ($canDo->get('core.delete'))
+			{
+				$childBar->delete('filters.delete')->listCheck(true);
+			}
 		}
 
 		ToolbarHelper::divider();
 		$toolbar->appendButton('Popup', 'bars', 'COM_FINDER_STATISTICS', 'index.php?option=com_finder&view=statistics&tmpl=component', 550, 350);
 		ToolbarHelper::divider();
-
-		if ($canDo->get('core.delete'))
-		{
-			ToolbarHelper::deleteList('', 'filters.delete');
-			ToolbarHelper::divider();
-		}
 
 		if ($canDo->get('core.admin') || $canDo->get('core.options'))
 		{

--- a/administrator/components/com_finder/View/Filters/HtmlView.php
+++ b/administrator/components/com_finder/View/Filters/HtmlView.php
@@ -158,16 +158,17 @@ class HtmlView extends BaseHtmlView
 			$childBar->publish('filters.publish')->listCheck(true);
 			$childBar->unpublish('filters.unpublish')->listCheck(true);
 			$childBar->checkin('filters.checkin')->listCheck(true);
-
-			if ($canDo->get('core.delete'))
-			{
-				$childBar->delete('filters.delete')->listCheck(true);
-			}
 		}
 
 		ToolbarHelper::divider();
 		$toolbar->appendButton('Popup', 'bars', 'COM_FINDER_STATISTICS', 'index.php?option=com_finder&view=statistics&tmpl=component', 550, 350);
 		ToolbarHelper::divider();
+
+		if ($canDo->get('core.delete'))
+		{
+			ToolbarHelper::deleteList('', 'filters.delete');
+			ToolbarHelper::divider();
+		}
 
 		if ($canDo->get('core.admin') || $canDo->get('core.options'))
 		{

--- a/administrator/components/com_finder/View/Filters/HtmlView.php
+++ b/administrator/components/com_finder/View/Filters/HtmlView.php
@@ -147,11 +147,11 @@ class HtmlView extends BaseHtmlView
 		if ($canDo->get('core.edit.state'))
 		{
 			$dropdown = $toolbar->dropdownButton('status-group')
-			->text('JTOOLBAR_CHANGE_STATUS')
-			->toggleSplit(false)
-			->icon('fa fa-globe')
-			->buttonClass('btn btn-info')
-			->listCheck(true);
+				->text('JTOOLBAR_CHANGE_STATUS')
+				->toggleSplit(false)
+				->icon('fa fa-globe')
+				->buttonClass('btn btn-info')
+				->listCheck(true);
 
 			$childBar = $dropdown->getChildToolbar();
 

--- a/administrator/components/com_finder/View/Index/HtmlView.php
+++ b/administrator/components/com_finder/View/Index/HtmlView.php
@@ -175,9 +175,11 @@ class HtmlView extends BaseHtmlView
 	{
 		$canDo = ContentHelper::getActions('com_finder');
 
+		// Get the toolbar object instance
+		$toolbar = Toolbar::getInstance('toolbar');
+
 		ToolbarHelper::title(Text::_('COM_FINDER_INDEX_TOOLBAR_TITLE'), 'zoom-in finder');
 
-		$toolbar = Toolbar::getInstance('toolbar');
 		$toolbar->appendButton(
 			'Popup', 'archive', 'COM_FINDER_INDEX', 'index.php?option=com_finder&view=indexer&tmpl=component', 500, 210, 0, 0,
 			'window.parent.location.reload()', 'COM_FINDER_HEADING_INDEXER'
@@ -185,16 +187,25 @@ class HtmlView extends BaseHtmlView
 
 		if ($canDo->get('core.edit.state'))
 		{
-			ToolbarHelper::publishList('index.publish');
-			ToolbarHelper::unpublishList('index.unpublish');
+			$dropdown = $toolbar->dropdownButton('status-group')
+			->text('JTOOLBAR_CHANGE_STATUS')
+			->toggleSplit(false)
+			->icon('fa fa-globe')
+			->buttonClass('btn btn-info')
+			->listCheck(true);
+
+			$childBar = $dropdown->getChildToolbar();
+
+			$childBar->publish('index.publish')->listCheck(true);
+			$childBar->unpublish('index.unpublish')->listCheck(true);
+
+			if ($canDo->get('core.delete'))
+			{
+				$childBar->delete('index.delete')->listCheck(true);
+			}
 		}
 
 		$toolbar->appendButton('Popup', 'bars', 'COM_FINDER_STATISTICS', 'index.php?option=com_finder&view=statistics&tmpl=component', 550, 350);
-
-		if ($canDo->get('core.delete'))
-		{
-			ToolbarHelper::deleteList('', 'index.delete');
-		}
 
 		if ($canDo->get('core.edit.state'))
 		{

--- a/administrator/components/com_finder/View/Index/HtmlView.php
+++ b/administrator/components/com_finder/View/Index/HtmlView.php
@@ -188,11 +188,11 @@ class HtmlView extends BaseHtmlView
 		if ($canDo->get('core.edit.state'))
 		{
 			$dropdown = $toolbar->dropdownButton('status-group')
-			->text('JTOOLBAR_CHANGE_STATUS')
-			->toggleSplit(false)
-			->icon('fa fa-globe')
-			->buttonClass('btn btn-info')
-			->listCheck(true);
+				->text('JTOOLBAR_CHANGE_STATUS')
+				->toggleSplit(false)
+				->icon('fa fa-globe')
+				->buttonClass('btn btn-info')
+				->listCheck(true);
 
 			$childBar = $dropdown->getChildToolbar();
 

--- a/administrator/components/com_finder/View/Index/HtmlView.php
+++ b/administrator/components/com_finder/View/Index/HtmlView.php
@@ -198,14 +198,15 @@ class HtmlView extends BaseHtmlView
 
 			$childBar->publish('index.publish')->listCheck(true);
 			$childBar->unpublish('index.unpublish')->listCheck(true);
-
-			if ($canDo->get('core.delete'))
-			{
-				$childBar->delete('index.delete')->listCheck(true);
-			}
 		}
 
 		$toolbar->appendButton('Popup', 'bars', 'COM_FINDER_STATISTICS', 'index.php?option=com_finder&view=statistics&tmpl=component', 550, 350);
+
+		if ($canDo->get('core.delete'))
+		{
+			ToolbarHelper::deleteList('', 'index.delete');
+			ToolbarHelper::divider();
+		}
 
 		if ($canDo->get('core.edit.state'))
 		{

--- a/administrator/components/com_finder/View/Maps/HtmlView.php
+++ b/administrator/components/com_finder/View/Maps/HtmlView.php
@@ -170,10 +170,10 @@ class HtmlView extends BaseHtmlView
 		);
 		ToolbarHelper::divider();
 
-		if ($canDo->get('core.delete'))	
-		{	
-			ToolbarHelper::deleteList('', 'maps.delete');	
-			ToolbarHelper::divider();	
+		if ($canDo->get('core.delete'))
+		{
+			ToolbarHelper::deleteList('', 'maps.delete');
+			ToolbarHelper::divider();
 		}
 
 		if ($canDo->get('core.admin') || $canDo->get('core.options'))

--- a/administrator/components/com_finder/View/Maps/HtmlView.php
+++ b/administrator/components/com_finder/View/Maps/HtmlView.php
@@ -147,21 +147,16 @@ class HtmlView extends BaseHtmlView
 		if ($canDo->get('core.edit.state'))
 		{
 			$dropdown = $toolbar->dropdownButton('status-group')
-			->text('JTOOLBAR_CHANGE_STATUS')
-			->toggleSplit(false)
-			->icon('fa fa-globe')
-			->buttonClass('btn btn-info')
-			->listCheck(true);
+				->text('JTOOLBAR_CHANGE_STATUS')
+				->toggleSplit(false)
+				->icon('fa fa-globe')
+				->buttonClass('btn btn-info')
+				->listCheck(true);
 
 			$childBar = $dropdown->getChildToolbar();
 
 			$childBar->publish('maps.publish')->listCheck(true);
 			$childBar->unpublish('maps.unpublish')->listCheck(true);
-
-			if ($canDo->get('core.delete'))
-			{
-				$childBar->delete('maps.delete')->listCheck(true);
-			}
 		}
 
 		ToolbarHelper::divider();
@@ -174,6 +169,12 @@ class HtmlView extends BaseHtmlView
 			350
 		);
 		ToolbarHelper::divider();
+
+		if ($canDo->get('core.delete'))	
+		{	
+			ToolbarHelper::deleteList('', 'maps.delete');	
+			ToolbarHelper::divider();	
+		}
 
 		if ($canDo->get('core.admin') || $canDo->get('core.options'))
 		{

--- a/administrator/components/com_finder/View/Maps/HtmlView.php
+++ b/administrator/components/com_finder/View/Maps/HtmlView.php
@@ -141,11 +141,27 @@ class HtmlView extends BaseHtmlView
 
 		ToolbarHelper::title(Text::_('COM_FINDER_MAPS_TOOLBAR_TITLE'), 'zoom-in finder');
 
+		// Get the toolbar object instance
+		$toolbar = Toolbar::getInstance('toolbar');
+
 		if ($canDo->get('core.edit.state'))
 		{
-			ToolbarHelper::publishList('maps.publish');
-			ToolbarHelper::unpublishList('maps.unpublish');
-			ToolbarHelper::divider();
+			$dropdown = $toolbar->dropdownButton('status-group')
+			->text('JTOOLBAR_CHANGE_STATUS')
+			->toggleSplit(false)
+			->icon('fa fa-globe')
+			->buttonClass('btn btn-info')
+			->listCheck(true);
+
+			$childBar = $dropdown->getChildToolbar();
+
+			$childBar->publish('maps.publish')->listCheck(true);
+			$childBar->unpublish('maps.unpublish')->listCheck(true);
+
+			if ($canDo->get('core.delete'))
+			{
+				$childBar->delete('maps.delete')->listCheck(true);
+			}
 		}
 
 		ToolbarHelper::divider();
@@ -158,12 +174,6 @@ class HtmlView extends BaseHtmlView
 			350
 		);
 		ToolbarHelper::divider();
-
-		if ($canDo->get('core.delete'))
-		{
-			ToolbarHelper::deleteList('', 'maps.delete');
-			ToolbarHelper::divider();
-		}
 
 		if ($canDo->get('core.admin') || $canDo->get('core.options'))
 		{


### PR DESCRIPTION
This PR adds the new change status button group to the toolbar to be consistent with all other views to
com_finder&view=index
com_finder&view=maps
com_finder&view=filters

### Example Before
![image](https://user-images.githubusercontent.com/1296369/61207438-000fb480-a6ed-11e9-8b5d-19d0543d2124.png)

### Example After
![image](https://user-images.githubusercontent.com/1296369/61207402-ed957b00-a6ec-11e9-84aa-ae67bc30b1c7.png)
