### PR TITLE
[4.0] Correct the display of enabled/blocked

### DIFF
--- a/administrator/components/com_users/forms/user.xml
+++ b/administrator/components/com_users/forms/user.xml
@@ -116,8 +116,8 @@
 			class="switcher"
 			default="0"
 			>
-			<option value="0">COM_USERS_USER_FIELD_ENABLE</option>
 			<option value="1">COM_USERS_USER_FIELD_BLOCK</option>
+			<option value="0">COM_USERS_USER_FIELD_ENABLE</option>
 		</field>
 
 		<field


### PR DESCRIPTION
As identified by @mbabker here https://github.com/joomla/joomla-cms/pull/25570#issuecomment-511452573

When editing a user the user status toggle should be green when the user is enabled not when they are blocked

### before
![image](https://user-images.githubusercontent.com/1296369/61239193-476e6300-a736-11e9-9102-aeb0c9295b88.png)

### after
![image](https://user-images.githubusercontent.com/1296369/61239215-548b5200-a736-11e9-899d-53262daaa684.png)
