### PR TITLE
[4.0] Adding checks for synced .lock files

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -23,6 +23,7 @@ steps:
     image: joomlaprojects/docker-tools:develop
     depends_on: [ restore-cache ]
     commands:
+      - composer validate --no-check-all --strict
       - composer install --no-progress --no-suggest
 
   - name: phpcs
@@ -40,7 +41,7 @@ steps:
     image: joomlaprojects/docker-tools:develop
     depends_on: [ phpcs ]
     commands:
-      - npm install --unsafe-perm
+      - npm ci --unsafe-perm
 
   - name: rebuild-cache
     image: drillster/drone-volume-cache
@@ -256,6 +257,6 @@ services:
 
 ---
 kind: signature
-hmac: 357290c302111f50af569691d21a182373f8138f7fe8ae1d9b62323b54ae80b9
+hmac: 25e452206bc4a115142bddb1758d1dfb6c056977ffbabc7d0b87afa432d60d28
 
 ...

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     },
     "support": {
         "issues": "https://issues.joomla.org",
-        "irc": "https://irc.lc/freenode/joomla/",
+        "irc": "irc://chat.freenode.net/joomla/",
         "forum": "https://forum.joomla.org/",
         "docs": "https://docs.joomla.org"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -348,12 +348,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-framework/application.git",
-                "reference": "5b201a71bf587c20141db94be40a0dec0f331353"
+                "reference": "cb7e310fef06529063ec6891fdba6c5895c1bd99"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/application/zipball/5b201a71bf587c20141db94be40a0dec0f331353",
-                "reference": "5b201a71bf587c20141db94be40a0dec0f331353",
+                "url": "https://api.github.com/repos/joomla-framework/application/zipball/cb7e310fef06529063ec6891fdba6c5895c1bd99",
+                "reference": "cb7e310fef06529063ec6891fdba6c5895c1bd99",
                 "shasum": ""
             },
             "require": {
@@ -371,16 +371,16 @@
                 "joomla/di": "~1.5|~2.0",
                 "joomla/router": "~2.0",
                 "joomla/session": "~2.0",
-                "joomla/test": "~1.1",
-                "joomla/uri": "~1.1",
-                "phpunit/phpunit": "~6.3"
+                "joomla/test": "~2.0",
+                "joomla/uri": "~1.1|~2.0",
+                "phpunit/phpunit": "~8.2"
             },
             "suggest": {
-                "joomla/controller": "To support resolving ControllerInterface objects in ControllerResolverInterface, install joomla/controller",
-                "joomla/router": "To use WebApplication or ControllerResolverInterface implementations, install joomla/router",
-                "joomla/session": "To use AbstractWebApplication with session support, install joomla/session",
-                "joomla/uri": "To use AbstractWebApplication, install joomla/uri",
-                "psr/container": "To use the ContainerControllerResolver, install any PSR-11 compatible container"
+                "joomla/controller": "~1.0|~2.0 To support resolving ControllerInterface objects in ControllerResolverInterface, install joomla/controller",
+                "joomla/router": "~2.0 To use WebApplication or ControllerResolverInterface implementations, install joomla/router",
+                "joomla/session": "~2.0 To use AbstractWebApplication with session support, install joomla/session",
+                "joomla/uri": "~1.1|~2.0 To use AbstractWebApplication, install joomla/uri",
+                "psr/container": "~1.0 To use the ContainerControllerResolver, install any PSR-11 compatible container"
             },
             "type": "joomla-package",
             "extra": {
@@ -404,7 +404,7 @@
                 "framework",
                 "joomla"
             ],
-            "time": "2019-07-06T16:26:04+00:00"
+            "time": "2019-07-14T19:44:25+00:00"
         },
         {
             "name": "joomla/archive",
@@ -516,12 +516,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-framework/console.git",
-                "reference": "2d4ceaaa49336f672d09e8d05faf8df6501a2754"
+                "reference": "85fd3b5b46d86f61fa3d129d19cabcabee44bc6c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/console/zipball/2d4ceaaa49336f672d09e8d05faf8df6501a2754",
-                "reference": "2d4ceaaa49336f672d09e8d05faf8df6501a2754",
+                "url": "https://api.github.com/repos/joomla-framework/console/zipball/85fd3b5b46d86f61fa3d129d19cabcabee44bc6c",
+                "reference": "85fd3b5b46d86f61fa3d129d19cabcabee44bc6c",
                 "shasum": ""
             },
             "require": {
@@ -533,7 +533,7 @@
             },
             "require-dev": {
                 "joomla/coding-standards": "~2.0@alpha",
-                "phpunit/phpunit": "~6.3",
+                "phpunit/phpunit": "~8.2",
                 "psr/container": "~1.0"
             },
             "suggest": {
@@ -561,7 +561,7 @@
                 "framework",
                 "joomla"
             ],
-            "time": "2019-06-17T23:29:39+00:00"
+            "time": "2019-07-14T18:55:56+00:00"
         },
         {
             "name": "joomla/controller",
@@ -839,12 +839,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-framework/event.git",
-                "reference": "99da78349149cbd74529221769e454c3e037cb16"
+                "reference": "dd9f0179ee8a6a68dfe970bc43fe5ed3a712ecee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/event/zipball/99da78349149cbd74529221769e454c3e037cb16",
-                "reference": "99da78349149cbd74529221769e454c3e037cb16",
+                "url": "https://api.github.com/repos/joomla-framework/event/zipball/dd9f0179ee8a6a68dfe970bc43fe5ed3a712ecee",
+                "reference": "dd9f0179ee8a6a68dfe970bc43fe5ed3a712ecee",
                 "shasum": ""
             },
             "require": {
@@ -880,7 +880,7 @@
                 "framework",
                 "joomla"
             ],
-            "time": "2019-07-06T16:31:34+00:00"
+            "time": "2019-07-12T00:49:37+00:00"
         },
         {
             "name": "joomla/filesystem",
@@ -989,12 +989,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-framework/http.git",
-                "reference": "3367e57dd2bdc2de9eadd51cde31c138ca14319a"
+                "reference": "cb6e8bcad6bbf7be3f1b21b6868116636c97e727"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/http/zipball/3367e57dd2bdc2de9eadd51cde31c138ca14319a",
-                "reference": "3367e57dd2bdc2de9eadd51cde31c138ca14319a",
+                "url": "https://api.github.com/repos/joomla-framework/http/zipball/cb6e8bcad6bbf7be3f1b21b6868116636c97e727",
+                "reference": "cb6e8bcad6bbf7be3f1b21b6868116636c97e727",
                 "shasum": ""
             },
             "require": {
@@ -1007,8 +1007,8 @@
             },
             "require-dev": {
                 "joomla/coding-standards": "~2.0@alpha",
-                "joomla/test": "~1.0",
-                "phpunit/phpunit": "~6.3"
+                "joomla/test": "~2.0",
+                "phpunit/phpunit": "~8.2"
             },
             "suggest": {
                 "ext-curl": "To use cURL for HTTP connections"
@@ -1035,7 +1035,7 @@
                 "http",
                 "joomla"
             ],
-            "time": "2019-06-18T00:00:18+00:00"
+            "time": "2019-07-14T18:24:22+00:00"
         },
         {
             "name": "joomla/image",
@@ -1185,12 +1185,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-framework/oauth1.git",
-                "reference": "45411832afee327df4fdd10adbed1738828e712d"
+                "reference": "36da2b80c5e525a724e59a2c54515fdedca90bd1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/oauth1/zipball/45411832afee327df4fdd10adbed1738828e712d",
-                "reference": "45411832afee327df4fdd10adbed1738828e712d",
+                "url": "https://api.github.com/repos/joomla-framework/oauth1/zipball/36da2b80c5e525a724e59a2c54515fdedca90bd1",
+                "reference": "36da2b80c5e525a724e59a2c54515fdedca90bd1",
                 "shasum": ""
             },
             "require": {
@@ -1204,8 +1204,8 @@
             "require-dev": {
                 "joomla/coding-standards": "~2.0@alpha",
                 "joomla/event": "~2.0",
-                "joomla/test": "~1.0",
-                "phpunit/phpunit": "~6.3"
+                "joomla/test": "~2.0",
+                "phpunit/phpunit": "~8.2"
             },
             "type": "joomla-package",
             "extra": {
@@ -1229,7 +1229,7 @@
                 "joomla",
                 "oauth1"
             ],
-            "time": "2019-06-17T22:39:00+00:00"
+            "time": "2019-07-14T17:33:47+00:00"
         },
         {
             "name": "joomla/oauth2",
@@ -1237,12 +1237,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-framework/oauth2.git",
-                "reference": "58689a3dfddaba4d1c04b17ae341197040429e06"
+                "reference": "98ff49808169523339cc8fd072aec9fe8c5f892b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/oauth2/zipball/58689a3dfddaba4d1c04b17ae341197040429e06",
-                "reference": "58689a3dfddaba4d1c04b17ae341197040429e06",
+                "url": "https://api.github.com/repos/joomla-framework/oauth2/zipball/98ff49808169523339cc8fd072aec9fe8c5f892b",
+                "reference": "98ff49808169523339cc8fd072aec9fe8c5f892b",
                 "shasum": ""
             },
             "require": {
@@ -1255,7 +1255,7 @@
             },
             "require-dev": {
                 "joomla/coding-standards": "~2.0@alpha",
-                "phpunit/phpunit": "~6.3"
+                "phpunit/phpunit": "~8.2"
             },
             "type": "joomla-package",
             "extra": {
@@ -1279,7 +1279,7 @@
                 "joomla",
                 "oauth2"
             ],
-            "time": "2019-06-17T22:39:15+00:00"
+            "time": "2019-07-14T17:24:53+00:00"
         },
         {
             "name": "joomla/registry",
@@ -1287,12 +1287,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-framework/registry.git",
-                "reference": "c7f0c490ad178853c693e4139317c118a95ff61a"
+                "reference": "e3bf30e95849d29f9c446e350916b27bbe69c0ad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/registry/zipball/c7f0c490ad178853c693e4139317c118a95ff61a",
-                "reference": "c7f0c490ad178853c693e4139317c118a95ff61a",
+                "url": "https://api.github.com/repos/joomla-framework/registry/zipball/e3bf30e95849d29f9c446e350916b27bbe69c0ad",
+                "reference": "e3bf30e95849d29f9c446e350916b27bbe69c0ad",
                 "shasum": ""
             },
             "require": {
@@ -1301,7 +1301,7 @@
             },
             "require-dev": {
                 "joomla/coding-standards": "~2.0@alpha",
-                "phpunit/phpunit": "~6.3",
+                "phpunit/phpunit": "~8.2",
                 "symfony/yaml": "~3.4|~4.0"
             },
             "suggest": {
@@ -1329,7 +1329,7 @@
                 "joomla",
                 "registry"
             ],
-            "time": "2019-06-17T22:41:38+00:00"
+            "time": "2019-07-14T17:12:29+00:00"
         },
         {
             "name": "joomla/router",
@@ -1710,16 +1710,16 @@
         },
         {
             "name": "paragonie/sodium_compat",
-            "version": "v1.10.0",
+            "version": "v1.10.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paragonie/sodium_compat.git",
-                "reference": "228a9fc64cf4ba84c7967c1076d94209db03e0ee"
+                "reference": "5115fa44886d1c2785d2f135ef4626db868eac4b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/sodium_compat/zipball/228a9fc64cf4ba84c7967c1076d94209db03e0ee",
-                "reference": "228a9fc64cf4ba84c7967c1076d94209db03e0ee",
+                "url": "https://api.github.com/repos/paragonie/sodium_compat/zipball/5115fa44886d1c2785d2f135ef4626db868eac4b",
+                "reference": "5115fa44886d1c2785d2f135ef4626db868eac4b",
                 "shasum": ""
             },
             "require": {
@@ -1788,7 +1788,7 @@
                 "secret-key cryptography",
                 "side-channel resistant"
             ],
-            "time": "2019-05-13T16:04:50+00:00"
+            "time": "2019-07-12T16:36:59+00:00"
         },
         {
             "name": "phpmailer/phpmailer",
@@ -6288,16 +6288,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "8.2.4",
+            "version": "8.2.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "25fe0b5031b24722f66a75ad479a074cccc1bb37"
+                "reference": "c1b8534b3730f20f58600124129197bf1183dc92"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/25fe0b5031b24722f66a75ad479a074cccc1bb37",
-                "reference": "25fe0b5031b24722f66a75ad479a074cccc1bb37",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c1b8534b3730f20f58600124129197bf1183dc92",
+                "reference": "c1b8534b3730f20f58600124129197bf1183dc92",
                 "shasum": ""
             },
             "require": {
@@ -6367,7 +6367,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2019-07-03T08:30:33+00:00"
+            "time": "2019-07-15T06:26:24+00:00"
         },
         {
             "name": "ralouphie/getallheaders",


### PR DESCRIPTION
Pull Request for Issue #25571.

### Summary of Changes
This adds checks for composer and npm for their respective .lock files. When someone makes changes to composer.json or package.json without updating the respective .lock file, the build should fail.

### Testing Instructions
Right now the repo seems to have an out-of-date composer.lock, so this should fail now. So when this fails for the right reasons, we can then update the .lock files and merge this one.