### PR TITLE
remove outdated link

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,5 @@ Do you want to improve Joomla?
 Copyright
 ---------------------
 * Copyright (C) 2005 - 2019 Open Source Matters. All rights reserved.
-* [Special Thanks](https://docs.joomla.org/Special:MyLanguage/Joomla!_Credits_and_Thanks)
 * Distributed under the GNU General Public License version 2 or later
 * See [License details](https://docs.joomla.org/Special:MyLanguage/Joomla_Licenses)

--- a/README.txt
+++ b/README.txt
@@ -67,6 +67,5 @@
 
 Copyright:
 	* Copyright (C) 2005 - 2019 Open Source Matters. All rights reserved.
-	* Special Thanks: https://docs.joomla.org/Special:MyLanguage/Joomla!_Credits_and_Thanks
 	* Distributed under the GNU General Public License version 2 or later
-	* See Licenses details at https://docs.joomla.org/Special:MyLanguage/Joomla_Licenses
+	* See License details at https://docs.joomla.org/Special:MyLanguage/Joomla_Licenses


### PR DESCRIPTION
The linked page is very out of date. It doesnt represent joomla sponsors or joomla partners. 

My 2c is that linking to them doesnt belong in the file.

But if its decided that it should be there then it should at least be accurate and fixes a typo