### PR TITLE
Fix broken submit if disabled fields are prefilled

### DIFF
--- a/libraries/src/Form/Form.php
+++ b/libraries/src/Form/Form.php
@@ -2106,9 +2106,10 @@ class Form
 			$fieldMatchWithValueBeforeSend = ($value == $fieldValueBeforeSend);
 
 			// Compare submitted value with default value before submit, if value is empty
-			if (empty($value) && isset($element->default))
+			if ($fieldMatchWithValueBeforeSend === false && isset($element->default))
 			{
-				$fieldMatchWithValueBeforeSend = ($element->default == $fieldValueBeforeSend);
+				$fieldMatchWithValueBeforeSend = ($element->default == $value
+					|| (empty($value) && $element->default == $fieldValueBeforeSend));
 			}
 
 			// If the field is disabled but it is passed in the request this is invalid as disabled fields are not added to the request

--- a/libraries/src/Form/Form.php
+++ b/libraries/src/Form/Form.php
@@ -2094,10 +2094,25 @@ class Form
 		{
 			$disabled = ((string) $element['disabled'] == 'true' || (string) $element['disabled'] == 'disabled');
 
-			$fieldExistsInRequestData = $input->exists((string) $element['name']) || $input->exists($group . '.' . (string) $element['name']);
+			// Get value before submit form
+			$fieldValueBeforeSend = $this->getData()->get((string) $element['name'], null);
+
+			if (empty($fieldValueBeforeSend))
+			{
+				$fieldValueBeforeSend = $this->getData()->get($group . '.' . (string) $element['name'], null);
+			}
+
+			// Compare submitted value with the value before submit
+			$fieldMatchWithValueBeforeSend = ($value == $fieldValueBeforeSend);
+
+			// Compare submitted value with default value before submit, if value is empty
+			if (empty($value) && isset($element->default))
+			{
+				$fieldMatchWithValueBeforeSend = ($element->default == $fieldValueBeforeSend);
+			}
 
 			// If the field is disabled but it is passed in the request this is invalid as disabled fields are not added to the request
-			if ($disabled && $fieldExistsInRequestData)
+			if ($disabled && $fieldMatchWithValueBeforeSend === false)
 			{
 				return new \RuntimeException(\JText::sprintf('JLIB_FORM_VALIDATE_FIELD_INVALID', $element['name']));
 			}


### PR DESCRIPTION
Fixed on #25682

### Summary of Changes
Fix broken submit if disabled fields are prefilled by comparing submitted value with the value filled before.


### Testing Instructions
1. Create a custom field from the type media and disable the permission to edit custom field value for the group Manager.
2. Edit in backend the article with this custom field as a super user and as an example select an image.
3. Login in frontend with the user in the group Manager and edit the article with this custom field and safe it without any changes.

### Expected result
The article will be submitted and saved.

### Actual result
This will show a warning with invalid field.
