### PR TITLE
[4.0] Install languages - old version info

### DIFF
--- a/administrator/components/com_installer/tmpl/languages/default.php
+++ b/administrator/components/com_installer/tmpl/languages/default.php
@@ -79,7 +79,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 										<?php // Display a Note if language pack version is not equal to Joomla version ?>
 										<?php if (strpos($language->version, $minorVersion) !== 0 || strpos($language->version, $currentShortVersion) !== 0) : ?>
 											<span class="badge badge-warning"><?php echo $language->version; ?></span>
-											<span class="fa fa-info-circle" aria-hidden="true" tabindex="0"> </span>
+											<span class="fa fa-info-circle" aria-hidden="true" tabindex="0"></span>
 											<div role="tooltip" class="text-left" id="tip<?php echo $language->code; ?>">
 											<?php echo Text::_('JGLOBAL_LANGUAGE_VERSION_NOT_PLATFORM'); ?>
 											</div>

--- a/administrator/components/com_installer/tmpl/languages/default.php
+++ b/administrator/components/com_installer/tmpl/languages/default.php
@@ -78,7 +78,11 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 										<?php $minorVersion = $version::MAJOR_VERSION . '.' . $version::MINOR_VERSION; ?>
 										<?php // Display a Note if language pack version is not equal to Joomla version ?>
 										<?php if (strpos($language->version, $minorVersion) !== 0 || strpos($language->version, $currentShortVersion) !== 0) : ?>
-											<span class="badge badge-warning hasTooltip" title="<?php echo Text::_('JGLOBAL_LANGUAGE_VERSION_NOT_PLATFORM'); ?>"><?php echo $language->version; ?></span>
+											<span class="badge badge-warning"><?php echo $language->version; ?></span>
+											<span class="fa fa-info-circle" aria-hidden="true" tabindex="0"> </span>
+											<div role="tooltip" class="text-left" id="tip<?php echo $language->code; ?>">
+											<?php echo Text::_('JGLOBAL_LANGUAGE_VERSION_NOT_PLATFORM'); ?>
+											</div>
 										<?php else : ?>
 											<span class="badge badge-success"><?php echo $language->version; ?></span>
 										<?php endif; ?>


### PR DESCRIPTION
PR for #25612

accessible "tooltip" for out of date language packs

Obviously at the moment this appears on every language - but the code is written so that the icon and info do not display if the language pack is up to date
