### PR TITLE
[4.0] Redundant tip debugusers and debuggroups

### DIFF
--- a/administrator/components/com_users/tmpl/debuggroup/default.php
+++ b/administrator/components/com_users/tmpl/debuggroup/default.php
@@ -35,7 +35,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 						</th>
 						<?php foreach ($this->actions as $key => $action) : ?>
 						<th style="width:6%" class="text-center" scope="col">
-							<span class="hasTooltip" title="<?php echo HTMLHelper::_('tooltipText', $key, $action[1]); ?>"><?php echo Text::_($key); ?></span>
+							<?php echo Text::_($key); ?>
 						</th>
 						<?php endforeach; ?>
 						<th style="width:6%" scope="col">

--- a/administrator/components/com_users/tmpl/debuguser/default.php
+++ b/administrator/components/com_users/tmpl/debuguser/default.php
@@ -35,7 +35,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 						</th>
 						<?php foreach ($this->actions as $key => $action) : ?>
 						<th style="width:6%" class="text-center" scope="col">
-							<span class="hasTooltip" title="<?php echo HTMLHelper::_('tooltipText', $key, $action[1]); ?>"><?php echo Text::_($key); ?></span>
+							<?php echo Text::_($key); ?>
 						</th>
 						<?php endforeach; ?>
 						<th style="width:6%" scope="col">


### PR DESCRIPTION
This PR removes the redundant titles from the column headers

administraator/index.php?option=com_users&view=debuguser
administrator/index.php?option=com_users&view=debuggroup