### PR TITLE
[4.0] Missing behavior.keepalive

### DIFF
--- a/administrator/components/com_banners/tmpl/banner/edit.php
+++ b/administrator/components/com_banners/tmpl/banner/edit.php
@@ -17,6 +17,7 @@ use Joomla\CMS\Router\Route;
 /** @var \Joomla\Component\Banners\Administrator\View\Banner\HtmlView $this */
 
 HTMLHelper::_('behavior.formvalidator');
+HTMLHelper::_('behavior.keepalive');
 
 HTMLHelper::_('script', 'com_banners/admin-banner-edit.min.js', array('version' => 'auto', 'relative' => true));
 HTMLHelper::_('script', 'com_contenthistory/admin-history-versions.js', ['version' => 'auto', 'relative' => true]);

--- a/administrator/components/com_banners/tmpl/client/edit.php
+++ b/administrator/components/com_banners/tmpl/client/edit.php
@@ -17,6 +17,8 @@ use Joomla\CMS\Router\Route;
 /** @var \Joomla\Component\Banners\Administrator\View\Client\HtmlView $this */
 
 HTMLHelper::_('behavior.formvalidator');
+HTMLHelper::_('behavior.keepalive');
+
 HTMLHelper::_('script', 'com_contenthistory/admin-history-versions.js', ['version' => 'auto', 'relative' => true]);
 ?>
 

--- a/administrator/components/com_languages/tmpl/language/edit.php
+++ b/administrator/components/com_languages/tmpl/language/edit.php
@@ -15,6 +15,7 @@ use Joomla\CMS\Router\Route;
 
 HTMLHelper::_('behavior.formvalidator');
 HTMLHelper::_('behavior.tabstate');
+HTMLHelper::_('behavior.keepalive');
 
 HTMLHelper::_('script', 'com_languages/admin-language-edit-change-flag.js', ['version' => 'auto', 'relative' => true]);
 ?>

--- a/administrator/components/com_menus/tmpl/menu/edit.php
+++ b/administrator/components/com_menus/tmpl/menu/edit.php
@@ -16,6 +16,7 @@ use Joomla\CMS\Router\Route;
 
 HTMLHelper::_('behavior.core');
 HTMLHelper::_('behavior.formvalidator');
+HTMLHelper::_('behavior.keepalive');
 HTMLHelper::_('behavior.tabstate');
 
 Text::script('ERROR');

--- a/administrator/components/com_users/tmpl/group/edit.php
+++ b/administrator/components/com_users/tmpl/group/edit.php
@@ -15,6 +15,7 @@ use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
 HTMLHelper::_('behavior.formvalidator');
+HTMLHelper::_('behavior.keepalive');
 
 $this->useCoreUI = true;
 ?>

--- a/administrator/components/com_users/tmpl/level/edit.php
+++ b/administrator/components/com_users/tmpl/level/edit.php
@@ -14,6 +14,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 
 HTMLHelper::_('behavior.formvalidator');
+HTMLHelper::_('behavior.keepalive');
+
 ?>
 
 <form action="<?php echo Route::_('index.php?option=com_users&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="level-form" class="form-validate">

--- a/administrator/components/com_users/tmpl/note/edit.php
+++ b/administrator/components/com_users/tmpl/note/edit.php
@@ -13,6 +13,7 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Router\Route;
 
 HTMLHelper::_('behavior.formvalidator');
+HTMLHelper::_('behavior.keepalive');
 
 HTMLHelper::_('script', 'com_contenthistory/admin-history-versions.js', ['version' => 'auto', 'relative' => true]);
 ?>

--- a/administrator/components/com_users/tmpl/user/edit.php
+++ b/administrator/components/com_users/tmpl/user/edit.php
@@ -17,6 +17,7 @@ use Joomla\CMS\Router\Route;
 use Joomla\Component\Users\Administrator\Helper\UsersHelper;
 
 HTMLHelper::_('behavior.formvalidator');
+HTMLHelper::_('behavior.keepalive');
 HTMLHelper::_('script', 'com_users/admin-users-user.min.js', array('version' => 'auto', 'relative' => true));
 
 $input = Factory::getApplication()->input;


### PR DESCRIPTION
> I'd go with a guideline of if a form gets submitted through POST then it should in most cases have keepalive since that form should have a CSRF check behind it (forms like a create item form, edit form, login form, contact form, etc.), and if it gets submitted through GET it doesn't need a keepalive behavior because these types of forms should essentially be nothing more than query filters for a page. I say this also realizing the backend views are in kind of a FUBAR state because the search filters trigger a POST form submission, and it looks like the frontend com_content.archive view has the same "issue" which means Joomla isn't always using the appropriate HTTP action to do things sadly.

This PR is a result of checking all admin edit.php files and checking that if they have a form submitted through POST they have a behavior.keepalive and a form.token

**Partial** Pull Request for Issue #25634  .
