### PR TITLE
[4.0 Extension update - tooltip and fixes

### DIFF
--- a/administrator/components/com_installer/Model/UpdateModel.php
+++ b/administrator/components/com_installer/Model/UpdateModel.php
@@ -180,6 +180,7 @@ class UpdateModel extends ListModel
 			$item->client_translated  = $item->client_id ? Text::_('JADMINISTRATOR') : Text::_('JSITE');
 			$manifest                 = json_decode($item->manifest_cache);
 			$item->current_version    = $manifest->version ?? Text::_('JLIB_UNKNOWN');
+			$item->description        = $manifest->description ?? Text::_('COM_INSTALLER_MSG_UPDATE_NODESC');
 			$item->type_translated    = Text::_('COM_INSTALLER_TYPE_' . strtoupper($item->type));
 			$item->folder_translated  = $item->folder ?: Text::_('COM_INSTALLER_TYPE_NONAPPLICABLE');
 			$item->install_type       = $item->extension_id ? Text::_('COM_INSTALLER_MSG_UPDATE_UPDATE') : Text::_('COM_INSTALLER_NEW_INSTALL');

--- a/administrator/components/com_installer/tmpl/update/default.php
+++ b/administrator/components/com_installer/tmpl/update/default.php
@@ -78,21 +78,15 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 							</thead>
 							<tbody>
 							<?php foreach ($this->items as $i => $item) : ?>
-								<?php
-								$client          = $item->client_id ? Text::_('JADMINISTRATOR') : Text::_('JSITE');
-								$manifest        = json_decode($item->manifest_cache);
-								$current_version = $manifest->version ?? Text::_('JLIB_UNKNOWN');
-								?>
 								<tr class="row<?php echo $i % 2; ?>">
 									<td class="text-center">
 										<?php echo HTMLHelper::_('grid.id', $i, $item->update_id); ?>
 									</td>
 									<th scope="row">
-										<label for="cb<?php echo $i; ?>">
-											<span class="editlinktip hasTooltip" title="<?php echo HTMLHelper::_('tooltipText', Text::_('JGLOBAL_DESCRIPTION'), $item->description ?: Text::_('COM_INSTALLER_MSG_UPDATE_NODESC'), 0); ?>">
-											<?php echo $this->escape($item->name); ?>
-											</span>
-										</label>
+										<span tabindex="0"><?php echo $this->escape($item->name); ?></span>
+										<div role="tooltip" id="tip<?php echo $i; ?>">
+											<?php echo $item->description; ?>
+										</div>
 									</th>
 									<td class="center">
 										<?php echo $item->client_translated; ?>


### PR DESCRIPTION
While writing the code to change the tooltip with the new accessible ones it was apparent that the view was broken. The extension description would always say "no description available"

### Test instructions
1. Install the Persian language pack
2. Go to the database and find the record in the extensions table for Persian Language Pack and then replace the contents of the manifest_cache with
`{"name":"Persian Language Pack","type":"package","creationDate":"July 2019","author":"Farsi translation team, joomlafarsi.com","copyright":"Copyright (C) 2005 - 2019 Joomlafarsi.com and Open Source Matters, Inc. All rights reserved.","authorEmail":"info@joomlafarsi.com","authorUrl":"www.joomlafarsi.com","version":"3.9.10.1","description":"\n\t\t<h3>\u0641\u0627\u0631\u0633\u06cc \u0633\u0627\u0632 \u062c\u0648\u0645\u0644\u0627 3.9 \u06a9\u0627\u0631\u06cc \u0627\u0632 \u062a\u06cc\u0645 \u0628\u0631\u06af\u0632\u06cc\u062f\u0647 \u062c\u0648\u0645\u0644\u0627 \u062f\u0631 \u0627\u06cc\u0631\u0627\u0646. \u062c\u0648\u0645\u0644\u0627 \u0641\u0627\u0631\u0633\u06cc \u062f\u0627\u062a \u06a9\u0627\u0645<\/h3>\n\t\t<h3>Joomla! 3.9 Full Farsi (fa-IR) Language Package version 3.9.10v1, JoomlaFarsi.com<\/h3>\n\t\t<br>","group":"","filename":"pkg_fa-IR"}`
3. Joomla should now see that an update is available if you go to Update-extensions and the description is shown as below
![image](https://user-images.githubusercontent.com/1296369/61536655-08d5f280-aa2d-11e9-87bd-2b85722cbffc.png)

If you dont see any updates try clicking on the clear cache and find updates buttons
