### PR TITLE
[4.0] Replace non-existent language constants with globals

### DIFF
--- a/administrator/components/com_actionlogs/forms/filter_actionlogs.xml
+++ b/administrator/components/com_actionlogs/forms/filter_actionlogs.xml
@@ -37,8 +37,7 @@
 		<field
 			name="fullordering"
 			type="list"
-			label="COM_ACTIONLOGS_LIST_FULL_ORDERING"
-			description="COM_ACTIONLOGS_LIST_FULL_ORDERING_DESC"
+			label="JGLOBAL_SORT_BY"
 			onchange="this.form.submit();"
 			default="a.id DESC"
 			>
@@ -59,8 +58,7 @@
 		<field
 			name="limit"
 			type="limitbox"
-			label="COM_ACTIONLOGS_LIST_LIMIT"
-			description="COM_ACTIONLOGS_LIST_LIMIT_DESC"
+			label="JGLOBAL_LIST_LIMIT"
 			class="input-mini"
 			onchange="this.form.submit();"
 			default="25"


### PR DESCRIPTION
### Summary of Changes
Delete/replace non-existent language constants with globals.


### Testing Instructions
Code review.
or
Go to Users > User Actions Log
View page source
Search COM_ACTIONLOGS_LIST_FULL_ORDERING
Search COM_ACTIONLOGS_LIST_LIMIT
Apply PR
Above constants translated


