### PR TITLE
Fix database schema checker for MySQL 8 on staging branch

### DIFF
--- a/libraries/src/Schema/ChangeItem/MysqlChangeItem.php
+++ b/libraries/src/Schema/ChangeItem/MysqlChangeItem.php
@@ -291,12 +291,10 @@ class MysqlChangeItem extends ChangeItem
 	 */
 	private function fixUtf8mb4TypeChecks($type)
 	{
-		$fixedType = str_replace(';', '', $type);
+		$uType = strtoupper(str_replace(';', '', $type));
 
 		if ($this->db->hasUTF8mb4Support())
 		{
-			$uType = strtoupper($fixedType);
-
 			if ($uType === 'TINYTEXT')
 			{
 				$typeCheck = 'type IN (' . $this->db->quote('TINYTEXT') . ',' . $this->db->quote('TEXT') . ')';
@@ -311,12 +309,12 @@ class MysqlChangeItem extends ChangeItem
 			}
 			else
 			{
-				$typeCheck = 'type = ' . $this->db->quote($fixedType);
+				$typeCheck = 'type = ' . $this->db->quote($uType);
 			}
 		}
 		else
 		{
-			$typeCheck = 'type = ' . $this->db->quote($fixedType);
+			$typeCheck = 'type = ' . $this->db->quote($uType);
 		}
 
 		return $typeCheck;

--- a/libraries/src/Schema/ChangeItem/MysqlChangeItem.php
+++ b/libraries/src/Schema/ChangeItem/MysqlChangeItem.php
@@ -291,12 +291,10 @@ class MysqlChangeItem extends ChangeItem
 	 */
 	private function fixUtf8mb4TypeChecks($type)
 	{
-		$fixedType = str_replace(';', '', $type);
+		$uType = strtoupper(str_replace(';', '', $type));
 
 		if ($this->db->hasUTF8mb4Support())
 		{
-			$uType = strtoupper($fixedType);
-
 			if ($uType === 'TINYTEXT')
 			{
 				$typeCheck = 'UPPER(type) IN (' . $this->db->quote('TINYTEXT') . ',' . $this->db->quote('TEXT') . ')';
@@ -311,12 +309,12 @@ class MysqlChangeItem extends ChangeItem
 			}
 			else
 			{
-				$typeCheck = 'UPPER(type) = ' . $this->db->quote($fixedType);
+				$typeCheck = 'UPPER(type) = ' . $this->db->quote($uType);
 			}
 		}
 		else
 		{
-			$typeCheck = 'UPPER(type) = ' . $this->db->quote($fixedType);
+			$typeCheck = 'UPPER(type) = ' . $this->db->quote($uType);
 		}
 
 		return $typeCheck;

--- a/libraries/src/Schema/ChangeItem/MysqlChangeItem.php
+++ b/libraries/src/Schema/ChangeItem/MysqlChangeItem.php
@@ -291,30 +291,32 @@ class MysqlChangeItem extends ChangeItem
 	 */
 	private function fixUtf8mb4TypeChecks($type)
 	{
-		$uType = strtoupper(str_replace(';', '', $type));
+		$fixedType = str_replace(';', '', $type);
 
 		if ($this->db->hasUTF8mb4Support())
 		{
+			$uType = strtoupper($fixedType);
+
 			if ($uType === 'TINYTEXT')
 			{
-				$typeCheck = 'type IN (' . $this->db->quote('TINYTEXT') . ',' . $this->db->quote('TEXT') . ')';
+				$typeCheck = 'UPPER(type) IN (' . $this->db->quote('TINYTEXT') . ',' . $this->db->quote('TEXT') . ')';
 			}
 			elseif ($uType === 'TEXT')
 			{
-				$typeCheck = 'type IN (' . $this->db->quote('TEXT') . ',' . $this->db->quote('MEDIUMTEXT') . ')';
+				$typeCheck = 'UPPER(type) IN (' . $this->db->quote('TEXT') . ',' . $this->db->quote('MEDIUMTEXT') . ')';
 			}
 			elseif ($uType === 'MEDIUMTEXT')
 			{
-				$typeCheck = 'type IN (' . $this->db->quote('MEDIUMTEXT') . ',' . $this->db->quote('LONGTEXT') . ')';
+				$typeCheck = 'UPPER(type) IN (' . $this->db->quote('MEDIUMTEXT') . ',' . $this->db->quote('LONGTEXT') . ')';
 			}
 			else
 			{
-				$typeCheck = 'type = ' . $this->db->quote($uType);
+				$typeCheck = 'UPPER(type) = ' . $this->db->quote($fixedType);
 			}
 		}
 		else
 		{
-			$typeCheck = 'type = ' . $this->db->quote($uType);
+			$typeCheck = 'UPPER(type) = ' . $this->db->quote($fixedType);
 		}
 
 		return $typeCheck;


### PR DESCRIPTION
Pull Request for Issue #25452 for staging.

### Summary of Changes

Fix case in column type check of database schema checker for MySQL 8.

When you enter e.g. the SQL statement

`SHOW COLUMNS IN #__extensions WHERE field = 'enabled' AND type = 'TINYINT(3)';`

(using your db prefix of course and not `#__`)

in PhpMyAdmin on a Joomla 3.9.10 or staging database, you will get a result in MySQL 5.7 but not in MySQL 8.

But when you enter

`SHOW COLUMNS IN #__extensions WHERE field = 'enabled' AND UPPER(type) = 'TINYINT(3)';`

you get a result on both MySQL versions.

In both cases type names are lowercase in the result, but on MySQL 8 the search seems to be case-sensitive, while it is case-insensitive e.g. on MySQL 5.7.

### Testing Instructions

1. Install current staging using a MySQL db of version 8.0.something. After successsful finish, login on backend and go to "Extensions -> Manage -> Database".

Result: See section "Actual result" below.

2. Apply this patch, navigate to somwhere else in backend and then back to "Extensions -> Manage -> Database".

Result: See section "Expected result" below.

### Expected result

No database errors.

### Actual result

Database errors shown as described in issue #25452 , but when you check in the database and the schema update SQL mentioned in the error message, you will not see any reason because the data types match in all details those set by the schema update and also those in joomla.sql.

### Documentation Changes Required

None.