### PR TITLE
[4.0] HTMLHelper script(). 0 - Call to a member function addScript() on null

### DIFF
--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -777,7 +777,7 @@ abstract class HTMLHelper
 			return;
 		}
 
-		$document = Factory::getApplication()->getDocument();
+		$document = Factory::getDocument();
 		$version  = '';
 
 		if (isset($options['version']))

--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -671,7 +671,7 @@ abstract class HTMLHelper
 		}
 
 		// If inclusion is required
-		$document = Factory::getApplication()->getDocument();
+		$document = Factory::getDocument();
 
 		foreach ($includes as $include)
 		{


### PR DESCRIPTION
# Testing Instructions
- Deactivate system cache plugin.
- Add the following code lines in plugins/system/cache/cache.php in method onAfterRoute()

```
	public function onAfterRoute()
	{
		$file = 'com_banners/admin-banner-edit.min.js';
	
		Joomla\CMS\HTML\HTMLHelper::_('script', $file,
		 array('version' => 'auto', 'relative' => true)
		);

		return;

...and so on...
```
- Activate the plugin. => Error.

- Deactivate plugin by renaming folder plugins/system/cachexxxx/
- Apply patch.
- Rename back folder plugins/system/cache/ to activate it.
- Reload backend ==> No error.

### Expected result
- No error and $file loaded.

### Actual result
Error:
```
0 - Call to a member function addScript() on null

1 | ( ) | JROOT/libraries/src/HTML/HTMLHelper.php:736
2 | Joomla\CMS\HTML\HTMLHelper::script()
```