### PR TITLE
[4.0] Remove hack from  debug plugin - we now have an autoloader

### DIFF
--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -150,9 +150,6 @@ class PlgSystemDebug extends CMSPlugin
 		ob_start();
 		ob_implicit_flush(false);
 
-		// @todo Remove when a standard autoloader is available.
-		JLoader::registerNamespace('Joomla\\Plugin\\System\\Debug', __DIR__, false, false, 'psr4');
-
 		/** @var \Joomla\Database\Monitor\DebugMonitor */
 		$this->queryMonitor = $this->db->getMonitor();
 

--- a/plugins/system/debug/debug.xml
+++ b/plugins/system/debug/debug.xml
@@ -9,6 +9,7 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
 	<description>PLG_DEBUG_XML_DESCRIPTION</description>
+	<namespace>Joomla\Plugin\System\Debug</namespace>
 	<files>
 		<filename plugin="debug">debug.php</filename>
 		<filename>debugmonitor.php</filename>


### PR DESCRIPTION
### Summary of Changes
Remove debug plugin hack to autoload files - we now have a standard Joomla Autoloader mechanism for plugins

### Testing Instructions
Debug plugin continues to work without any issues with tabs working as before patch. Remember to delete `libraries/autoload_psr4.php` to force it to regenerate with the debug plugin namespace in

### Documentation Changes Required
None
