### PR TITLE
[4.0] Error in admin login screen

### DIFF
--- a/administrator/modules/mod_login/Helper/LoginHelper.php
+++ b/administrator/modules/mod_login/Helper/LoginHelper.php
@@ -11,6 +11,7 @@ namespace Joomla\Module\Login\Administrator\Helper;
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\LanguageHelper;
 use Joomla\CMS\Language\Text;
@@ -46,7 +47,7 @@ abstract class LoginHelper
 		);
 
 		// Fix wrongly set parentheses in RTL languages
-		if ($app->getLanguage()->isRtl())
+		if (Factory::getApplication()->getLanguage()->isRtl())
 		{
 			foreach ($languages as &$language)
 			{


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Fixes error introduced in #25681.

### Testing Instructions

Install multiple languages.
Logout. View admin's login screen.

### Expected result

No errors.

### Actual result

>Call to a member function getLanguage() on null

### Documentation Changes Required

No.