### PR TITLE
[4.0] User profile text

### DIFF
--- a/language/en-GB/en-GB.com_users.ini
+++ b/language/en-GB/en-GB.com_users.ini
@@ -85,7 +85,7 @@ COM_USERS_PROFILE_TWOFACTOR_LABEL="Authentication Method"
 COM_USERS_PROFILE_TWOFACTOR_DESC="Which two factor authentication method you want to activate on the user account."
 COM_USERS_PROFILE_USERNAME_LABEL="Username"
 COM_USERS_PROFILE_USERNAME_MESSAGE="The username you entered is not available. Please pick another username."
-COM_USERS_PROFILE_VALUE_NOT_FOUND="No Information Entered"
+COM_USERS_PROFILE_VALUE_NOT_FOUND="Website default"
 COM_USERS_REGISTER_EMAIL1_LABEL="Email Address"
 ; The following string is deprecated and will be removed with 4.0
 COM_USERS_REGISTER_EMAIL1_MESSAGE="The email address you entered is already in use or invalid. Please enter another email address."


### PR DESCRIPTION
When viewing a user profile on the frontend you see the text
"No information entered" on any of the basic settings that have not been changed

Far better to say "Website default" as at least that way there is no confusion to the user. In the form they "selected" the -use default - option so to their understanding they have made a selection

### before
![image](https://user-images.githubusercontent.com/1296369/61783071-114c7580-adff-11e9-97e6-283fffbc0257.png)

### after
![image](https://user-images.githubusercontent.com/1296369/61783027-02fe5980-adff-11e9-94f8-4c2813111e25.png)

### edit form - (not changed but showing the settings)
![image](https://user-images.githubusercontent.com/1296369/61783127-27f2cc80-adff-11e9-956c-e56a9f2cd531.png)
