### PR TITLE
[4.0] Changing "attribs" in #__content table to text

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/4.0.0-2019-07-25.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.0.0-2019-07-25.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `#__content` CHANGE COLUMN `attribs` `attribs` TEXT NOT NULL;

--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2019-07-25.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2019-07-25.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "#__content" ALTER COLUMN "attribs" TYPE text;

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -346,7 +346,7 @@ CREATE TABLE IF NOT EXISTS `#__content` (
   `publish_down` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
   `images` text NOT NULL,
   `urls` text NOT NULL,
-  `attribs` varchar(5120) NOT NULL,
+  `attribs` text NOT NULL,
   `version` int(10) unsigned NOT NULL DEFAULT 1,
   `ordering` int(11) NOT NULL DEFAULT 0,
   `metakey` text NOT NULL,

--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -352,7 +352,7 @@ CREATE TABLE IF NOT EXISTS "#__content" (
   "publish_down" timestamp without time zone DEFAULT '1970-01-01 00:00:00' NOT NULL,
   "images" text NOT NULL,
   "urls" text NOT NULL,
-  "attribs" varchar(5120) NOT NULL,
+  "attribs" text NOT NULL,
   "version" bigint DEFAULT 1 NOT NULL,
   "ordering" bigint DEFAULT 0 NOT NULL,
   "metakey" text NOT NULL,


### PR DESCRIPTION
All our params fields are of type text, except for the #__content table. Is there more to say about this? 😉 