### PR TITLE
[4.0] [com_csp] Show a warning in case we are collecting but there are trashed itms

### DIFF
--- a/administrator/components/com_csp/Helper/ReporterHelper.php
+++ b/administrator/components/com_csp/Helper/ReporterHelper.php
@@ -52,7 +52,7 @@ class ReporterHelper
 	/**
 	 * Check the com_csp trash to show a warning in this case
 	 *
-	 * @return  boolean  The status of the trash; Does items exists in the trash
+	 * @return  boolean  The status of the trash; Do items exists in the trash
 	 *
 	 * @since   4.0.0
 	 */

--- a/administrator/components/com_csp/Helper/ReporterHelper.php
+++ b/administrator/components/com_csp/Helper/ReporterHelper.php
@@ -48,4 +48,32 @@ class ReporterHelper
 
 		return $result;
 	}
+
+	/**
+	 * Check the com_csp trash to show a warning in this case
+	 *
+	 * @return  boolean  The status of the trash; Does items exists in the trash
+	 *
+	 * @since   4.0.0
+	 */
+	public static function getCspTrashStatus()
+	{
+		$db = Factory::getDbo();
+		$query = $db->getQuery(true)
+			->select('COUNT(*)')
+			->from($db->quoteName('#__csp'))
+			->where($db->quoteName('published') . ' = ' . $db->quote('-2'));
+		$db->setQuery($query);
+
+		try
+		{
+			$result = (int) $db->loadResult();
+		}
+		catch (\RuntimeException $e)
+		{
+			Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');
+		}
+
+		return boolval($result);
+	}
 }

--- a/administrator/components/com_csp/View/Reports/HtmlView.php
+++ b/administrator/components/com_csp/View/Reports/HtmlView.php
@@ -11,6 +11,7 @@ namespace Joomla\Component\Csp\Administrator\View\Reports;
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Helper\ContentHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
@@ -100,6 +101,13 @@ class HtmlView extends BaseHtmlView
 		if (!(PluginHelper::isEnabled('system', 'httpheaders')))
 		{
 			$this->httpHeadersId = ReporterHelper::getHttpHeadersPluginId();
+		}
+
+		if (ComponentHelper::getParams('com_csp')->get('contentsecuritypolicy_mode', 'custom') === 'detect'
+			&& ComponentHelper::getParams('com_csp')->get('contentsecuritypolicy', 0)
+			&& ReporterHelper::getCspTrashStatus())
+		{
+			$this->trashWarningMessage = Text::_('COM_CSP_COLLECTING_TRASH_WARNING');
 		}
 
 		$this->addToolbar();

--- a/administrator/components/com_csp/tmpl/reports/default.php
+++ b/administrator/components/com_csp/tmpl/reports/default.php
@@ -55,6 +55,9 @@ $saveOrder = $listOrder == 'a.id';
 						)
 					); ?>
 				<?php endif; ?>
+				<?php if (isset($this->trashWarningMessage)) : ?>
+					<?php Factory::getApplication()->enqueueMessage($this->trashWarningMessage, 'warning'); ?>
+				<?php endif; ?>
 				<?php if (empty($this->items)) : ?>
 					<div class="alert alert-info">
 						<span class="fa fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>

--- a/administrator/language/en-GB/en-GB.com_csp.ini
+++ b/administrator/language/en-GB/en-GB.com_csp.ini
@@ -4,6 +4,7 @@
 ; Note : All ini files need to be saved as UTF-8
 
 COM_CSP="Content Security Policy"
+COM_CSP_COLLECTING_TRASH_WARNING="You are running your rules in the collect mode. Please note that there are trashed items that don't get colleted here again untill fully deleted."
 COM_CSP_CONFIGURATION="Content Security Policy: Options"
 ; Please do not translate the following language string
 COM_CSP_CONTENTSECURITYPOLICY="<a href='https://scotthelme.co.uk/content-security-policy-an-introduction' target='_blank' rel='noopener noreferrer'>Content Security Policy (CSP)</a>"

--- a/administrator/language/en-GB/en-GB.com_csp.ini
+++ b/administrator/language/en-GB/en-GB.com_csp.ini
@@ -4,7 +4,7 @@
 ; Note : All ini files need to be saved as UTF-8
 
 COM_CSP="Content Security Policy"
-COM_CSP_COLLECTING_TRASH_WARNING="You are running your rules in the collect mode. Please note that there are trashed items that don't get colleted here again untill fully deleted."
+COM_CSP_COLLECTING_TRASH_WARNING="The Content Security Policy is in detect mode. Items that have been trashed will not be detected again until they are removed from the trash."
 COM_CSP_CONFIGURATION="Content Security Policy: Options"
 ; Please do not translate the following language string
 COM_CSP_CONTENTSECURITYPOLICY="<a href='https://scotthelme.co.uk/content-security-policy-an-introduction' target='_blank' rel='noopener noreferrer'>Content Security Policy (CSP)</a>"


### PR DESCRIPTION
Pull Request for Issue #25594 cc @brianteeman 

### Summary of Changes

show a warning in case we are collecting but there are trashed itms

### Testing Instructions

- Enable the collecting mode of com_csp
- collect some reports
- trash a few or all of them
- refresh the reports list

### Expected result

You should now get a warning indicating that we are collecting but have also trashed items

### Actual result

No indication that we have trashed items.

### Documentation Changes Required

none.

### Additional Info

@brianteeman  I'm not happy with the warning message yet, you might can suggest a bettwer wording here? Thanks.