### PR TITLE
[4.0] Make sure only global headers are written to the file

### DIFF
--- a/plugins/system/httpheaders/httpheaders.php
+++ b/plugins/system/httpheaders/httpheaders.php
@@ -535,7 +535,8 @@ class PlgSystemHttpHeaders extends CMSPlugin implements SubscriberInterface
 		{
 			$headerAndClient = explode('#', $headerAndClient);
 
-			if (!in_array(strtolower($headerAndClient[0]), ['content-security-policy', 'content-security-policy-report-only']))
+			if (!in_array(strtolower($headerAndClient[0]), ['content-security-policy', 'content-security-policy-report-only'])
+				&& $headerAndClient[1] === 'both')
 			{
 				$newHtaccessBuffer .= '    Header set ' . $headerAndClient[0] . ' "' . $value . '"' . PHP_EOL;
 			}
@@ -593,7 +594,8 @@ class PlgSystemHttpHeaders extends CMSPlugin implements SubscriberInterface
 			{
 				$headerAndClient = explode('#', $headerAndClient);
 
-				if (!in_array(strtolower($headerAndClient[0]), ['content-security-policy', 'content-security-policy-report-only']))
+				if (!in_array(strtolower($headerAndClient[0]), ['content-security-policy', 'content-security-policy-report-only'])
+					&& $headerAndClient[1] === 'both')
 				{
 					$newHeader = $webConfigDomDoc->createElement('add');
 
@@ -615,7 +617,8 @@ class PlgSystemHttpHeaders extends CMSPlugin implements SubscriberInterface
 			{
 				$headerAndClient = explode('#', $headerAndClient);
 
-				if (!in_array(strtolower($headerAndClient[0]), ['content-security-policy', 'content-security-policy-report-only']))
+				if (!in_array(strtolower($headerAndClient[0]), ['content-security-policy', 'content-security-policy-report-only'])
+					&& $headerAndClient[1] === 'both')
 				{
 					$newHeader = $webConfigDomDoc->createElement('add');
 
@@ -660,7 +663,8 @@ class PlgSystemHttpHeaders extends CMSPlugin implements SubscriberInterface
 				// The header wasn't found we need to create it
 				if (!$found)
 				{
-					if (!in_array(strtolower($headerAndClient[0]), ['content-security-policy', 'content-security-policy-report-only']))
+					if (!in_array(strtolower($headerAndClient[0]), ['content-security-policy', 'content-security-policy-report-only'])
+						&& $headerAndClient[1] === 'both')
 					{
 						// Generate the new header Element
 						$newHeader = $webConfigDomDoc->createElement('add');


### PR DESCRIPTION
Pull Request for Issue #25716

### Summary of Changes

Make sure only global rules are written to the file. Thanks for the report @brianteeman 

### Testing Instructions

make sure only rules marked as `both` getting added.

### Expected result

only rules marked as `both` getting added.

### Actual result

all static rules getting added.