### PR TITLE
[4.0] Remove phpunit-pgsql.xml.dist from the final package

### DIFF
--- a/build/build.php
+++ b/build/build.php
@@ -326,6 +326,7 @@ $doNotPackage = array(
 	'codeception.yml',
 	'RoboFile.php',
 	'CODE_OF_CONDUCT.md',
+	'phpunit-pgsql.xml.dist',
 	// Remove the testing sample data from all packages
 	'installation/sql/mysql/sample_testing.sql',
 	'installation/sql/postgresql/sample_testing.sql',


### PR DESCRIPTION
### Summary of Changes

Remove phpunit-pgsql.xml.dist from the final package

### Testing Instructions

run build script

### Expected result

phpunit-pgsql.xml.dist is not in the package

### Actual result

phpunit-pgsql.xml.dist is in the package

### Documentation Changes Required

none