### PR TITLE
[4.0] Fix composer no-dev (and nightly generation)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
     },
     "scripts": {
         "post-install-cmd": [
-            "phpcs --config-set installed_paths ../../joomla/cms-coding-standards/lib,../../joomla/coding-standards"
+            "[ $COMPOSER_DEV_MODE -eq 0 ] || phpcs --config-set installed_paths ../../joomla/cms-coding-standards/lib,../../joomla/coding-standards"
         ]
     },
     "require": {


### PR DESCRIPTION
Fixes running `composer install --no-dev`

This currently breaks the build script - see: https://build.joomla.org:8443/job/cms_packaging/job/nightly_build_40/431/console

To test just run `composer install` and `composer install --no-dev`. Before patch the latter fails. After patch both work