### PR TITLE
[4.0] Menu description

### DIFF
--- a/administrator/components/com_menus/tmpl/menus/default.php
+++ b/administrator/components/com_menus/tmpl/menus/default.php
@@ -104,6 +104,11 @@ HTMLHelper::_('script', 'com_menus/admin-menus-default.min.js', array('version' 
 										<?php else : ?>
 											<?php echo $this->escape($item->title); ?>
 										<?php endif; ?>
+										<?php if (!empty($item->description)) : ?>
+											<div class="small">
+												(<?php echo $this->escape($item->description); ?>)
+											</div>
+										<?php endif; ?>
 									</div>
 								</td>
 								<td class="text-center btns">


### PR DESCRIPTION
We have a field called Menu Description which as the name implies is used to provide an optional description of the menu. But we only display it on the menu edit form.

This field really is functionally the same as the "note" field that we have elsewhere which is displayed on the list views.

So this simple PR adds the display of the description below the menu name

### After
![image](https://user-images.githubusercontent.com/1296369/62004538-584bab00-b11e-11e9-9181-a195f77416fb.png)
