### PR TITLE
[4.0] DebugBar use csp nonce

### DIFF
--- a/plugins/system/debug/JavascriptRenderer.php
+++ b/plugins/system/debug/JavascriptRenderer.php
@@ -70,6 +70,7 @@ class JavascriptRenderer extends DebugBarJavascriptRenderer
 		}
 
 		$nonce = '';
+
 		if ($doc->cspNonce)
 		{
 			$nonce = ' nonce="' . $doc->cspNonce . '"';
@@ -122,6 +123,7 @@ class JavascriptRenderer extends DebugBarJavascriptRenderer
 		$js .= $this->getAddDatasetCode($this->debugBar->getCurrentRequestId(), $this->debugBar->getData(), $suffix);
 
 		$nonce = '';
+
 		if ($doc->cspNonce)
 		{
 			$nonce = ' nonce="' . $doc->cspNonce . '"';

--- a/plugins/system/debug/JavascriptRenderer.php
+++ b/plugins/system/debug/JavascriptRenderer.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * @package     Joomla.Plugin
+ * @subpackage  System.Debug
+ *
+ * @copyright   Copyright (C) 2019 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\Plugin\System\Debug;
+
+use DebugBar\DebugBar;
+use DebugBar\JavascriptRenderer as DebugBarJavascriptRenderer;
+use Joomla\CMS\Factory;
+
+/**
+ * Custom JavascriptRenderer for DebugBar
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class JavascriptRenderer extends DebugBarJavascriptRenderer
+{
+	/**
+	 * Class constructor.
+	 *
+	 * @param   \DebugBar\DebugBar  $debugBar  DebugBar instance
+	 * @param   string              $baseUrl   The base URL from which assets will be served
+	 * @param   string              $basePath  The path which assets are relative to
+	 *
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public function __construct(DebugBar $debugBar, $baseUrl = null, $basePath = null)
+	{
+		parent::__construct($debugBar, $baseUrl, $basePath);
+
+		// Disable features that loaded by Joomla! API, or not in use
+		$this->setEnableJqueryNoConflict(false);
+		$this->disableVendor('jquery');
+		$this->disableVendor('fontawesome');
+	}
+
+	/**
+	 * Renders the html to include needed assets
+	 *
+	 * Only useful if Assetic is not used
+	 *
+	 * @return string
+	 *
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public function renderHead()
+	{
+		list($cssFiles, $jsFiles, $inlineCss, $inlineJs, $inlineHead) = $this->getAssets(null, self::RELATIVE_URL);
+		$html = '';
+		$doc  = Factory::getApplication()->getDocument();
+
+		foreach ($cssFiles as $file)
+		{
+			$html .= sprintf('<link rel="stylesheet" type="text/css" href="%s">' . "\n", $file);
+		}
+
+		foreach ($inlineCss as $content)
+		{
+			$html .= sprintf('<style type="text/css">%s</style>' . "\n", $content);
+		}
+
+		foreach ($jsFiles as $file)
+		{
+			$html .= sprintf('<script type="text/javascript" src="%s" defer></script>' . "\n", $file);
+		}
+
+		$nonce = '';
+		if ($doc->cspNonce)
+		{
+			$nonce = ' nonce="' . $doc->cspNonce . '"';
+		}
+
+		foreach ($inlineJs as $content)
+		{
+			$html .= sprintf('<script type="module"%s>%s</script>' . "\n", $nonce, $content);
+		}
+
+		foreach ($inlineHead as $content)
+		{
+			$html .= $content . "\n";
+		}
+
+		return $html;
+	}
+
+	/**
+	 * Returns the code needed to display the debug bar
+	 *
+	 * AJAX request should not render the initialization code.
+	 *
+	 * @param   boolean  $initialize         Whether or not to render the debug bar initialization code
+	 * @param   boolean  $renderStackedData  Whether or not to render the stacked data
+	 *
+	 * @return string
+	 *
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public function render($initialize = true, $renderStackedData = true)
+	{
+		$js  = '';
+		$doc = Factory::getApplication()->getDocument();
+
+		if ($initialize)
+		{
+			$js = $this->getJsInitializationCode();
+		}
+
+		if ($renderStackedData && $this->debugBar->hasStackedData())
+		{
+			foreach ($this->debugBar->getStackedData() as $id => $data)
+			{
+				$js .= $this->getAddDatasetCode($id, $data, '(stacked)');
+			}
+		}
+
+		$suffix = !$initialize ? '(ajax)' : null;
+		$js .= $this->getAddDatasetCode($this->debugBar->getCurrentRequestId(), $this->debugBar->getData(), $suffix);
+
+		$nonce = '';
+		if ($doc->cspNonce)
+		{
+			$nonce = ' nonce="' . $doc->cspNonce . '"';
+		}
+
+		if ($this->useRequireJs)
+		{
+			return "<script type=\"module\"$nonce>\nrequire(['debugbar'], function(PhpDebugBar){ $js });\n</script>\n";
+		}
+		else
+		{
+			return "<script type=\"module\"$nonce>\n$js\n</script>\n";
+		}
+	}
+}

--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -186,16 +186,21 @@ class PlgSystemDebug extends CMSPlugin
 		{
 			// Use our own jQuery and fontawesome instead of the debug bar shipped version
 			$assetManager = $this->app->getDocument()->getWebAssetManager();
-			$assetManager->getRegistry()->add(new Joomla\CMS\WebAsset\WebAssetItem('plg.system.debug', [
-				'dependencies' => ['jquery', 'fontawesome-free'],
-				'css' => ['plg_system_debug/debug.css'],
-				'js'  => ['plg_system_debug/debug.min.js'],
-				'attribute' => [
-					'plg_system_debug/debug.min.js' => [
-						'defer' => true,
-					],
-				]
-			]));
+			$assetManager->getRegistry()->add(
+				new Joomla\CMS\WebAsset\WebAssetItem(
+					'plg.system.debug',
+					[
+						'dependencies' => ['jquery', 'fontawesome-free'],
+						'css' => ['plg_system_debug/debug.css'],
+						'js'  => ['plg_system_debug/debug.min.js'],
+						'attribute' => [
+							'plg_system_debug/debug.min.js' => [
+								'defer' => true,
+							],
+						]
+					]
+				)
+			);
 			$assetManager->enableAsset('plg.system.debug');
 		}
 


### PR DESCRIPTION
### Summary of Changes
DebugBar use csp nonce


### Testing Instructions
Apply patch and make sure the debugbar still works.

Also can look at the source code of the page, at bottom, to check that inline script of DebugBar has `nonce="blabla"` attribute.


### Expected result
`nonce="blabla"` exist


### Actual result
`nonce="blabla"` not exist


