### PR TITLE
[4.0] Rules - tooltips

### DIFF
--- a/layouts/joomla/form/field/rules.php
+++ b/layouts/joomla/form/field/rules.php
@@ -120,13 +120,15 @@ $ajaxUri = Route::_('index.php?option=com_config&task=application.store&format=j
 						<?php foreach ($actions as $action) : ?>
 							<tr>
 								<td headers="actions-th<?php echo $group->value; ?>">
-									<?php $description = (!empty($action->description)) ? ' class="hasTooltip" title="'
-										. HTMLHelper::_('tooltipText', $action->title, $action->description) . '"' : ''; ?>
-									<label for="<?php echo $id; ?>_<?php echo $action->name; ?>_<?php echo $group->value; ?>"<?php echo $description; ?>>
+									<label for="<?php echo $id; ?>_<?php echo $action->name; ?>_<?php echo $group->value; ?>">
 										<?php echo Text::_($action->title); ?>
 									</label>
+									<?php if (!empty($action->description)) : ?>
+										<div role="tooltip" id="tip-<?php echo $id; ?>">
+											<?php echo htmlspecialchars(Text::_($action->description)); ?>
+										</div>
+									<?php endif; ?>
 								</td>
-
 								<td headers="settings-th<?php echo $group->value; ?>">
 									<div class="d-flex align-items-center">
 										<select data-onchange-task="permissions.apply"


### PR DESCRIPTION
Although its never used in core it is documented that each access rule can have a description.

This PR makes sure that it is the new style accessible tip.

To test you will need to edit a components access.xml and add  `description="something here"` to one of the rules

### After
![image](https://user-images.githubusercontent.com/1296369/62005840-fb0d2500-b130-11e9-948f-90a6b4784642.png)
