### PR TITLE
[4.0] Get the dbtype from the DatabaseDriver Instance

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -93,7 +93,6 @@ class JoomlaInstallerScript
 		// This needs to stay for 2.5 update compatibility
 		$this->deleteUnexistingFiles();
 		$this->updateManifestCaches();
-		$this->updateDbType();
 		$this->updateDatabase();
 		$this->updateAssets($installer);
 		$this->clearStatsCache();
@@ -162,40 +161,6 @@ class JoomlaInstallerScript
 
 			return;
 		}
-	}
-
-	/**
-	 * Method to update dbtype in the configuration file
-	 *
-	 * @return  boolean True on success
-	 */
-	protected function updateDbType()
-	{
-		$model = new \Joomla\Component\Config\Administrator\Model\ApplicationModel;
-
-		try
-		{
-			$data = $model->getData();
-		}
-		catch (Exception $e)
-		{
-			echo Text::sprintf('JLIB_DATABASE_ERROR_FUNCTION_FAILED', $e->getCode(), $e->getMessage()) . '<br>';
-
-			return false;
-		}
-
-		switch ($data['dbtype'])
-		{
-			case 'pdomysql':
-				$data['dbtype'] = 'mysql';
-				break;
-
-			case 'postgresql':
-				$data['dbtype'] = 'pgsql';
-				break;
-		}
-
-		return $model->save($data);
 	}
 
 	/**

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -177,7 +177,7 @@ class JoomlaInstallerScript
 		{
 			$data = $model->getData();
 		}
-		catch(Exception $e)
+		catch (Exception $e)
 		{
 			echo Text::sprintf('JLIB_DATABASE_ERROR_FUNCTION_FAILED', $e->getCode(), $e->getMessage()) . '<br>';
 

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -93,6 +93,7 @@ class JoomlaInstallerScript
 		// This needs to stay for 2.5 update compatibility
 		$this->deleteUnexistingFiles();
 		$this->updateManifestCaches();
+		$this->updateDbType();
 		$this->updateDatabase();
 		$this->updateAssets($installer);
 		$this->clearStatsCache();
@@ -161,6 +162,40 @@ class JoomlaInstallerScript
 
 			return;
 		}
+	}
+
+	/**
+	 * Method to update dbtype in the configuration file
+	 *
+	 * @return  boolean True on success
+	 */
+	protected function updateDbType()
+	{
+		$model = new \Joomla\Component\Config\Administrator\Model\ApplicationModel;
+
+		try
+		{
+			$data = $model->getData();
+		}
+		catch(Exception $e)
+		{
+			echo Text::sprintf('JLIB_DATABASE_ERROR_FUNCTION_FAILED', $e->getCode(), $e->getMessage()) . '<br>';
+
+			return false;
+		}
+
+		switch ($data['dbtype'])
+		{
+			case 'pdomysql':
+				$data['dbtype'] = 'mysql';
+				break;
+
+			case 'postgresql':
+				$data['dbtype'] = 'pgsql';
+				break;
+		}
+
+		return $model->save($data);
 	}
 
 	/**

--- a/administrator/components/com_config/Model/ApplicationModel.php
+++ b/administrator/components/com_config/Model/ApplicationModel.php
@@ -84,18 +84,6 @@ class ApplicationModel extends FormModel
 		// Prime the asset_id for the rules.
 		$data['asset_id'] = 1;
 
-		// Get the corresponding database driver
-		switch ($data['dbtype'])
-		{
-			case 'pdomysql':
-				$data['dbtype'] = 'mysql';
-				break;
-
-			case 'postgresql':
-				$data['dbtype'] = 'pgsql';
-				break;
-		}
-
 		// Get the text filter data
 		$params          = ComponentHelper::getParams('com_config');
 		$data['filters'] = ArrayHelper::fromObject($params->get('filters'));

--- a/administrator/components/com_config/Model/ApplicationModel.php
+++ b/administrator/components/com_config/Model/ApplicationModel.php
@@ -84,6 +84,18 @@ class ApplicationModel extends FormModel
 		// Prime the asset_id for the rules.
 		$data['asset_id'] = 1;
 
+		// Get the corresponding database driver
+		switch ($data['dbtype'])
+		{
+			case 'pdomysql':
+				$data['dbtype'] = 'mysql';
+				break;
+
+			case 'postgresql':
+				$data['dbtype'] = 'pgsql';
+				break;
+		}
+
 		// Get the text filter data
 		$params          = ComponentHelper::getParams('com_config');
 		$data['filters'] = ArrayHelper::fromObject($params->get('filters'));

--- a/administrator/components/com_config/Model/ApplicationModel.php
+++ b/administrator/components/com_config/Model/ApplicationModel.php
@@ -81,6 +81,9 @@ class ApplicationModel extends FormModel
 		$config = new \JConfig;
 		$data   = ArrayHelper::fromObject($config);
 
+		// Get the correct driver at runtime
+		$data['dbtype'] = Factory::getDbo()->getName();
+
 		// Prime the asset_id for the rules.
 		$data['asset_id'] = 1;
 


### PR DESCRIPTION
Pull Request for Issue in Comment https://github.com/joomla/joomla-cms/pull/25507#issuecomment-513839455 .

### Summary of Changes
In Joomla! 3.x and earlier the `mysql` type was used for the `ext/mysql` PHP extension, which is no longer supported. The `pdomysql` type represented the PDO MySQL adapter.  With the Framework's package in use, the PDO MySQL adapter is now the `mysql` type.
Also the PDO PostgreSQL is only supported.

The configuration file is saved according to these requirements.


### Testing Instructions
Install Joomla 3.9.x with postgresql or pdomysql driver.
Update Joomla with the build of this PR.
Check Global Configuration -> Server -> Database Type.
Save to update the configuration file with the correct dbtype.


### Expected result
postgresql driver is replaced by pgsql (PDO driver).
pdomysql driver is replaced by mysql (PDO driver).


### Actual result
As expected.


### Documentation Changes Required

