### PR TITLE
[4.0] [plg_system_httpheaders] Add context check

### DIFF
--- a/plugins/system/httpheaders/httpheaders.php
+++ b/plugins/system/httpheaders/httpheaders.php
@@ -198,7 +198,7 @@ class PlgSystemHttpHeaders extends CMSPlugin implements SubscriberInterface
 		$isNew   = $event->getArgument('2');
 
 		// When the updated extension is not PLG_SYSTEM_HTTPHEADERS we don't do anything
-		if ($table->element != $this->_name || $table->folder != $this->_type)
+		if ($context !== 'com_plugins.plugin' || $table->element !== $this->_name || $table->folder !== $this->_type)
 		{
 			return;
 		}


### PR DESCRIPTION
Pull Request for Issue #25726 .

### Summary of Changes

Checks that we're saving a plugin before continuing.

### Testing Instructions

On a clean install try to install the "Testing Sample Data"

### Expected result

Sample data completes all 8 steps successfully

### Actual result

Sample data "hangs" after step 7 and console shows the following error

>VM701:1 Uncaught SyntaxError: Unexpected token < in JSON at position 0
    at JSON.parse (<anonymous>)
    at onSuccess (sampledata-process.min.js?988a0f8a06606e444ef81cacee8fef3d:1)
    at XMLHttpRequest.c.onreadystatechange (core.min.js?988a0f8a06606e444ef81cacee8fef3d:1)
onSuccess @ sampledata-process.min.js?988a0f8a06606e444ef81cacee8fef3d:1
c.onreadystatechange @ core.min.js?988a0f8a06606e444ef81cacee8fef3d:1
XMLHttpRequest.send (async)
a.request @ core.min.js?988a0f8a06606e444ef81cacee8fef3d:1
c.sampledataAjax @ sampledata-process.min.js?988a0f8a06606e444ef81cacee8fef3d:1
onSuccess @ sampledata-process.min.js?988a0f8a06606e444ef81cacee8fef3d:1
c.onreadystatechange @ core.min.js?988a0f8a06606e444ef81cacee8fef3d:1
XMLHttpRequest.send (async)
a.request @ core.min.js?988a0f8a06606e444ef81cacee8fef3d:1
c.sampledataAjax @ sampledata-process.min.js?988a0f8a06606e444ef81cacee8fef3d:1
onSuccess @ sampledata-process.min.js?988a0f8a06606e444ef81cacee8fef3d:1
c.onreadystatechange @ core.min.js?988a0f8a06606e444ef81cacee8fef3d:1
XMLHttpRequest.send (async)
a.request @ core.min.js?988a0f8a06606e444ef81cacee8fef3d:1
c.sampledataAjax @ sampledata-process.min.js?988a0f8a06606e444ef81cacee8fef3d:1
onSuccess @ sampledata-process.min.js?988a0f8a06606e444ef81cacee8fef3d:1
c.onreadystatechange @ core.min.js?988a0f8a06606e444ef81cacee8fef3d:1


### Documentation Changes Required

No.