### PR TITLE
Update default.php

### DIFF
--- a/modules/mod_menu/tmpl/default.php
+++ b/modules/mod_menu/tmpl/default.php
@@ -18,7 +18,7 @@ if ($tagId = $params->get('tag_id', ''))
 
 // The menu class is deprecated. Use nav instead
 ?>
-<ul class="nav menu<?php echo $class_sfx; ?> mod-list"<?php echo $id; ?>>
+<ul class="nav menu <?php echo $class_sfx; ?> mod-list"<?php echo $id; ?>>
 <?php foreach ($list as $i => &$item)
 {
 	$class = 'item-' . $item->id;


### PR DESCRIPTION
Currently there is a bug that requires you to add a space in the box before any css classes in mod_menu > Advanced > Menu Class Suffix.  Adding a space to line 21 fixes it.

Pull Request for Issue # .

### Summary of Changes



### Testing Instructions



### Expected result



### Actual result



### Documentation Changes Required

