### PR TITLE
[4.0] Sample data fix - Tags ids need to be sent as a string to the helper

### DIFF
--- a/plugins/sampledata/testing/testing.php
+++ b/plugins/sampledata/testing/testing.php
@@ -999,7 +999,7 @@ class PlgSampledataTesting extends CMSPlugin
 			),
 			array(
 				'catid'    => $catIdsLevel5[0],
-				'tags'     => array_map('strval', array($tagIds[0], $tagIds[1], $tagIds[2])),
+				'tags'     => array_map('strval', array_slice($tagIds, 0, 3)),
 				'ordering' => 0,
 			),
 			array(

--- a/plugins/sampledata/testing/testing.php
+++ b/plugins/sampledata/testing/testing.php
@@ -757,7 +757,7 @@ class PlgSampledataTesting extends CMSPlugin
 			array(
 				'catid'    => $catIdsLevel2[0],
 				'ordering' => 2,
-				'tags'     => $tagIds,
+				'tags'     => array_map('strval', $tagIds),
 				'featured' => 1
 			),
 			array(
@@ -999,7 +999,7 @@ class PlgSampledataTesting extends CMSPlugin
 			),
 			array(
 				'catid'    => $catIdsLevel5[0],
-				'tags'     => array($tagIds[0], $tagIds[1], $tagIds[2]),
+				'tags'     => array_map('strval', array($tagIds[0], $tagIds[1], $tagIds[2])),
 				'ordering' => 0,
 			),
 			array(


### PR DESCRIPTION
Tags need to be submitted as a string to the model rather than as an integer. So simply mapping them to a string here. To test install sample data. Before patch there are integers in the main homepage article tags. After patch they are the expected colours from Joomla 3.