### PR TITLE
[4.0] joomla-field-module-order a11y

### DIFF
--- a/build/media_source/system/js/fields/joomla-field-module-order.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-module-order.w-c.es6.js
@@ -89,7 +89,7 @@ customElements.define('joomla-field-module-order', class extends HTMLElement {
     const originalOrder = this.getAttribute('data-ordering');
     const name = this.getAttribute('data-name');
     const attr = this.getAttribute('data-client-attr') ? this.getAttribute('data-client-attr') : 'custom-select';
-    const id = `${this.getAttribute('id')}_1`;
+    const id = `${this.getAttribute('data-id')}`;
     const orders = [];
     const that = this;
 

--- a/layouts/joomla/form/field/moduleorder.php
+++ b/layouts/joomla/form/field/moduleorder.php
@@ -48,7 +48,7 @@ extract($displayData);
  */
 
 // Initialize some field attributes.
-$attributes['id'] = 'id="' . $id . '"';
+$attributes['dataid'] = 'data-id="' . $id . '"';
 $attributes['data-url'] = 'data-url="index.php?option=com_modules&task=module.orderPosition&' . $token . '"';
 $attributes['data-element'] = 'data-element="parent_' . $id . '"';
 $attributes['data-ordering'] = 'data-ordering="' . $ordering . '"';


### PR DESCRIPTION
Pull Request for Issue #23888 .

### Summary of Changes
The id the label was for was the parent <joomla-field-module-order
it should have been on the select
To avoid having a duplicate id I changed it to data-id on the <joomla-field-module-order
so that the correct ID is on the select

### Testing Instructions
You will need to run npm i to rebuild the js

Go to Modules new/edit
Use screen reader (I use NVDA), move focus to Ordering field
or
Click on the Ordering label


### Expected result
screen reader should announce the role combobox and the label Ordering
or
you click on a label, the field should receive a focus

