### PR TITLE
Correct implode() argument order for PHP 7.4

### DIFF
--- a/libraries/cms/html/tel.php
+++ b/libraries/cms/html/tel.php
@@ -42,7 +42,7 @@ abstract class JHtmlTel
 			$display[0] = '+';
 			$display[1] = $countrycode;
 			$display[2] = ' ';
-			$display[3] = implode(str_split($number, 2), ' ');
+			$display[3] = implode(' ', str_split($number, 2));
 		}
 		elseif ($displayplan === 'NANP' || $displayplan === 'northamerica' || $displayplan === 'US')
 		{
@@ -62,7 +62,7 @@ abstract class JHtmlTel
 		}
 		elseif ($displayplan === 'ARPA' || $displayplan === 'ENUM')
 		{
-			$number = implode(str_split(strrev($number), 1), '.');
+			$number = implode('.', str_split(strrev($number), 1));
 			$display[0] = '+';
 			$display[1] = $number;
 			$display[2] = '.';
@@ -70,6 +70,6 @@ abstract class JHtmlTel
 			$display[4] = '.e164.arpa';
 		}
 
-		return implode($display, '');
+		return implode('', $display);
 	}
 }

--- a/libraries/fof/render/joomla.php
+++ b/libraries/fof/render/joomla.php
@@ -4,6 +4,7 @@
  * @subpackage  render
  * @copyright   Copyright (C) 2010-2016 Nicholas K. Dionysopoulos / Akeeba Ltd. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ * @note        This file has been modified by the Joomla! Project and no longer reflects the original work of its author.
  */
 defined('FOF_INCLUDED') or die;
 
@@ -106,7 +107,7 @@ class FOFRenderJoomla extends FOFRenderAbstract
 			);
 		}
 
-		echo '<div id="akeeba-renderjoomla" class="' . implode($classes, ' ') . "\">\n";
+		echo '<div id="akeeba-renderjoomla" class="' . implode(' ', $classes) . "\">\n";
 
 		// Render submenu and toolbar (only if asked to)
 		if ($input->getBool('render_toolbar', true))

--- a/libraries/fof/render/joomla3.php
+++ b/libraries/fof/render/joomla3.php
@@ -4,6 +4,7 @@
  * @subpackage  render
  * @copyright   Copyright (C) 2010-2016 Nicholas K. Dionysopoulos / Akeeba Ltd. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ * @note        This file has been modified by the Joomla! Project and no longer reflects the original work of its author.
  */
 defined('FOF_INCLUDED') or die;
 
@@ -79,15 +80,18 @@ class FOFRenderJoomla3 extends FOFRenderStrapper
 			$layout = $input->getCmd('layout', '');
 			$task = $input->getCmd('task', '');
 
-			$classes = ' class="' . implode(array(
-				'joomla-version-' . $majorVersion,
-				'joomla-version-' . $minorVersion,
-				'admin',
-				$option,
-				'view-' . $view,
-				'layout-' . $layout,
-				'task-' . $task,
-			), ' ') . '"';
+			$classes = ' class="' . implode(
+				' ',
+				array(
+					'joomla-version-' . $majorVersion,
+					'joomla-version-' . $minorVersion,
+					'admin',
+					$option,
+					'view-' . $view,
+					'layout-' . $layout,
+					'task-' . $task,
+				)
+			) . '"';
 		}
 		else
 		{

--- a/libraries/fof/render/strapper.php
+++ b/libraries/fof/render/strapper.php
@@ -4,6 +4,7 @@
  * @subpackage  render
  * @copyright   Copyright (C) 2010-2016 Nicholas K. Dionysopoulos / Akeeba Ltd. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ * @note        This file has been modified by the Joomla! Project and no longer reflects the original work of its author.
  */
 defined('FOF_INCLUDED') or die;
 
@@ -111,7 +112,7 @@ class FOFRenderStrapper extends FOFRenderAbstract
 		}
 
 		// Wrap output in divs
-		echo '<div id="akeeba-bootstrap" class="' . implode($classes, ' ') . "\">\n";
+		echo '<div id="akeeba-bootstrap" class="' . implode(' ', $classes) . "\">\n";
 		echo "<div class=\"akeeba-bootstrap\">\n";
 		echo "<div class=\"row-fluid\">\n";
 

--- a/libraries/joomla/google/data/picasa.php
+++ b/libraries/joomla/google/data/picasa.php
@@ -106,7 +106,7 @@ class JGoogleDataPicasa extends JGoogleData
 			$xml->addChild('gphoto:access', $access);
 			$xml->addChild('gphoto:timestamp', $time);
 			$media = $xml->addChild('media:group', '', 'http://search.yahoo.com/mrss/');
-			$media->addChild('media:keywords', implode($keywords, ', '));
+			$media->addChild('media:keywords', implode(', ', $keywords));
 			$cat = $xml->addChild('category', '');
 			$cat->addAttribute('scheme', 'http://schemas.google.com/g/2005#kind');
 			$cat->addAttribute('term', 'http://schemas.google.com/photos/2007#album');

--- a/libraries/src/Layout/BaseLayout.php
+++ b/libraries/src/Layout/BaseLayout.php
@@ -160,7 +160,7 @@ class BaseLayout implements LayoutInterface
 	 */
 	public function renderDebugMessages()
 	{
-		return implode($this->debugMessages, "\n");
+		return implode("\n", $this->debugMessages);
 	}
 
 	/**

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -840,7 +840,7 @@ class PlgEditorTinymce extends JPlugin
 				$btnsNames[] = $name . ' | ';
 
 				// The array with code for each button
-				$tinyBtns[] = implode($tempConstructor, '');
+				$tinyBtns[] = implode('', $tempConstructor);
 			}
 		}
 


### PR DESCRIPTION
### Summary of Changes

Changes `implode()` argument order to solve deprecation messages in PHP 7.4:

>Deprecated: implode(): Passing glue string after array is deprecated.

### Testing Instructions

Code review.

### Documentation Changes Required

No.