### PR TITLE
[4.0] Correct styles renderer for nonce generation

### DIFF
--- a/libraries/src/Document/Renderer/Html/StylesRenderer.php
+++ b/libraries/src/Document/Renderer/Html/StylesRenderer.php
@@ -126,7 +126,7 @@ class StylesRenderer extends DocumentRenderer
 
 				if ($this->_doc->cspNonce)
 				{
-					$buffer = ' nonce="' . $this->_doc->cspNonce . '"';
+					$buffer .= ' nonce="' . $this->_doc->cspNonce . '"';
 				}
 
 				$buffer .= '>' . $lnEnd;


### PR DESCRIPTION
Pull Request for Issue #25787 cc @brianteeman 

### Summary of Changes

make sure nonce is appended and dont overwrite the buffer

### Steps to reproduce the issue
1. Enable the Security Headers plugin with default options

2. Try to create a new field of any of the following types

- checkboxes
- radio
- list
Which I believe are the only fields with the layout `"joomla.form.field.subform.repeatable-table"`

### Expected result
page refreshes and you can create a field


### Actual result
the template doesn't load and checking the source you can see the code in the head is broken
![image](https://user-images.githubusercontent.com/1296369/62498666-de7b8780-b7d7-11e9-95e3-f9d8bfdb37fb.png)


### Documentation Changes Required

none