### PR TITLE
Change travis to use trusty for PHP 5.4-5.6 and add services mysql, postgresql

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ matrix:
     - php: 5.6
       env:
         - INSTALL_MEMCACHE="yes"
+      dist: trusty
     - php: 7.0
     - php: 7.1
     - php: 7.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,11 @@ matrix:
       env:
         - INSTALL_APCU="no"
         - INSTALL_MEMCACHE="yes"
+      dist: trusty
     - php: 5.5
       env:
         - INSTALL_MEMCACHE="yes"
+      dist: trusty
     - php: 5.6
       env:
         - INSTALL_MEMCACHE="yes"
@@ -45,6 +47,7 @@ services:
   - memcache
   - memcached
   - redis-server
+  - mysql
 
 before_script:
   # Make sure all dev dependencies are installed

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,7 @@ services:
   - memcached
   - redis-server
   - mysql
+  - postgresql
 
 before_script:
   # Make sure all dev dependencies are installed


### PR DESCRIPTION
PHP 5.4 and 5.5 doesn't run on Ubuntu Xenial. Now we use Ubuntu trusty for PHP 5.4 and 5.3.

Also it seams mysql must be added as service.