### PR TITLE
[4.0] Downgrade choco to a version that works

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -31,6 +31,9 @@ services:
 ## Install PHP and composer, and run the appropriate composer command
 install:
     - IF EXIST C:\tools\php (SET PHP=0)
+    # TODO: This is a workaround for https://github.com/chocolatey/choco/issues/1843. Once this is fixed we
+    #       should go back to latest version in appveyor saving ourselves test time
+    - ps: choco install chocolatey -y --version 0.10.13 --allow-downgrade
     - ps: >-
         If ($env:PHP -eq "1") {
           appveyor-retry cinst --params '""/InstallDir:C:\tools\php""' --ignore-checksums -y php --version ((choco search php --exact --all-versions -r | select-string -pattern $env:php_ver_target | sort { [version]($_ -split '\|' | select -last 1) } -Descending | Select-Object -first 1) -replace '[php|]','')


### PR DESCRIPTION
This is the PR for 4.0-dev of #25803

Recommended workaround to chocolatey/choco#1843

Check appveyor works after patch in versions that aren't 7.3.x