### PR TITLE
[4.0] Real null dates for mod_latestactions and mod_privacy_dashboard on new installation

### DIFF
--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -1433,8 +1433,8 @@ INSERT INTO `#__modules` (`id`, `asset_id`, `title`, `note`, `content`, `orderin
 (79, 52, 'Multilanguage status', '', '', 1, '', 0, NULL, NULL, NULL, 0, 'mod_multilangstatus', 3, 1, '{"layout":"_:default","moduleclass_sfx":"","cache":"0"}', 1, '*'),
 (86, 53, 'Joomla Version', '', '', 1, 'status', 0, NULL, NULL, NULL, 1, 'mod_version', 3, 1, '{"layout":"_:default","moduleclass_sfx":"","cache":"0"}', 1, '*'),
 (87, 55, 'Sample Data', '', '', 0, 'cpanel', 0, NULL, NULL, NULL, 1, 'mod_sampledata', 6, 1, '{"bootstrap_size": "6"}', 1, '*'),
-(88, 58, 'Latest Actions', '', '', 0, 'cpanel', 0, '0000-00-00 00:00:00', '0000-00-00 00:00:00', '0000-00-00 00:00:00', 1, 'mod_latestactions', 6, 1, '{}', 1, '*'),
-(89, 59, 'Privacy Dashboard', '', '', 0, 'cpanel', 0, '0000-00-00 00:00:00', '0000-00-00 00:00:00', '0000-00-00 00:00:00', 1, 'mod_privacy_dashboard', 6, 1, '{}', 1, '*');
+(88, 58, 'Latest Actions', '', '', 0, 'cpanel', 0, NULL, NULL, NULL, 1, 'mod_latestactions', 6, 1, '{}', 1, '*'),
+(89, 59, 'Privacy Dashboard', '', '', 0, 'cpanel', 0, NULL, NULL, NULL, 1, 'mod_privacy_dashboard', 6, 1, '{}', 1, '*');
 
 -- --------------------------------------------------------
 

--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -1432,8 +1432,8 @@ INSERT INTO "#__modules" ("id", "asset_id", "title", "note", "content", "orderin
 (79, 52, 'Multilanguage status', '', '', 1, '', 0, NULL, NULL, NULL, 0, 'mod_multilangstatus', 3, 1, '{"layout":"_:default","moduleclass_sfx":"","cache":"0"}', 1, '*'),
 (86, 53, 'Joomla Version', '', '', 1, 'status', 0, NULL, NULL, NULL, 1, 'mod_version', 3, 1, '{"layout":"_:default","moduleclass_sfx":"","cache":"0"}', 1, '*'),
 (87, 55, 'Sample Data', '', '', 0, 'cpanel', 0, NULL, NULL, NULL, 1, 'mod_sampledata', 6, 1, '{"bootstrap_size": "6"}', 1, '*'),
-(88, 58, 'Latest Actions', '', '', 0, 'cpanel', 0, '1970-01-01 00:00:00', '1970-01-01 00:00:00', '1970-01-01 00:00:00', 1, 'mod_latestactions', 6, 1, '{}', 1, '*'),
-(89, 59, 'Privacy Dashboard', '', '', 0, 'cpanel', 0, '1970-01-01 00:00:00', '1970-01-01 00:00:00', '1970-01-01 00:00:00', 1, 'mod_privacy_dashboard', 6, 1, '{}', 1, '*');
+(88, 58, 'Latest Actions', '', '', 0, 'cpanel', 0, NULL, NULL, NULL, 1, 'mod_latestactions', 6, 1, '{}', 1, '*'),
+(89, 59, 'Privacy Dashboard', '', '', 0, 'cpanel', 0, NULL, NULL, NULL, 1, 'mod_privacy_dashboard', 6, 1, '{}', 1, '*');
 
 SELECT setval('#__modules_id_seq', 90, false);
 


### PR DESCRIPTION
Pull Request for new issue.

### Summary of Changes

With pull request (PR) #21901 , columns `checked_out_time`, `publish_up` and `publish_down` of database table `#__modules` have been changed to use real null values instead of the stone-aged null date value. Again thanks @csthomas for that.

Later then new stuff from 3.9 was merged into 4.0-dev, which included modules `mod_latestactions` and `mod_privacy_dashboard`, but it was not adapted to the changes from the PR mentioned above.

The schema update provided with that PR already cares for updating existing records in the modules table, which will include the modules mentioned before, so this PR here only has to correct joomla.sql for new installations.

### Testing Instructions

Code review.

Or if you have more time: Update a 3.9.x to 4.0 nightly and look up values for columns `checked_out_time`, `publish_up` and `publish_down` in PhpMyAdmin or PhpPgAdmin (whatever db you have).

Then make a new installation of 4.0 nightly and check the same.

### Expected result

New installation and after update: Module table content consistent regarding null values for columns `checked_out_time`, `publish_up` and `publish_down`. All records are inserted with real null values for these columns.

### Actual result

New installation: Module table content inconsistent regarding null values for columns `checked_out_time`, `publish_up` and `publish_down`. All records are inserted with real null values for these columns, except of the last 2 records for modules `mod_latestactions` and `mod_privacy_dashboard`, those still use '0000-00-00 00:00:00'.

After update: See expected result.

### Documentation Changes Required

None.