### PR TITLE
Get the dynamic database driver for the configuration.

### DIFF
--- a/administrator/components/com_config/model/application.php
+++ b/administrator/components/com_config/model/application.php
@@ -59,6 +59,9 @@ class ConfigModelApplication extends ConfigModelForm
 		$config = new JConfig;
 		$data   = ArrayHelper::fromObject($config);
 
+		// Get the correct driver at runtime
+		$data['dbtype'] = JFactory::getDbo()->getName();
+
 		// Prime the asset_id for the rules.
 		$data['asset_id'] = 1;
 


### PR DESCRIPTION
Pull Request for deprecated database driver:
The PHP `ext/mysql` extension is removed in PHP 7, cannot use the `mysql` driver.
https://github.com/twister65/joomla-cms/blob/0346c2fc3668984b3b85ecb4a4941c6752c13f9c/libraries/joomla/database/driver.php#L257

See PR #25729 

### Summary of Changes
Get the actual database driver loaded at run time and fill in the `dbtype` parameter in the configuration form. You must save the configuration to update the file.

### Testing Instructions



### Expected result



### Actual result



### Documentation Changes Required

