### PR TITLE
[plugin_actionlogs_joomla] - suppress logout log when user blocked

### DIFF
--- a/plugins/actionlog/joomla/joomla.php
+++ b/plugins/actionlog/joomla/joomla.php
@@ -847,7 +847,13 @@ class PlgActionlogJoomla extends ActionLogPlugin
 			return;
 		}
 
-		$loggedOutUser      = User::getInstance($user['id']);
+		$loggedOutUser = User::getInstance($user['id']);
+
+		if ($loggedOutUser->block)
+		{
+			return;
+		}
+
 		$messageLanguageKey = 'PLG_ACTIONLOG_JOOMLA_USER_LOGGED_OUT';
 
 		$message = array(


### PR DESCRIPTION
Pull Request for Issue #25694 .

### Summary of Changes
suppress logout log message when user blocked by anadmin
when a user is blocked from an admin the logout is forced for tecnical reason, so the user itself not have performed the logout action

### Testing Instructions
block an user



### Expected result
the message logged is only about the "update" action by the admin
![Screenshot from 2019-08-11 10-31-35](https://user-images.githubusercontent.com/181681/62831662-45a79a80-bc23-11e9-8a72-dc1b9e29e6f0.png)


### Actual result
the logged message says that the user is logged out
