### PR TITLE
[4.0] Double translation of template preview  button

### DIFF
--- a/layouts/joomla/button/transition-button.php
+++ b/layouts/joomla/button/transition-button.php
@@ -44,7 +44,7 @@ $checkboxName = $options['checkbox_name'];
 		<?php endif; ?>
 
 		title="<?php echo HTMLHelper::_('tooltipText', Text::_($tipTitle ? : $title), '', 0); ?>"
-		data-content="<?php echo HTMLHelper::_('tooltipText', $title, '', 0); ?>"
+		data-content="<?php echo HTMLHelper::_('tooltipText', Text::_($title), '', 0); ?>"
 		data-placement="top"
 		onclick="Joomla.toggleAllNextElements(this, 'd-none')"
 	>

--- a/layouts/joomla/button/transition-button.php
+++ b/layouts/joomla/button/transition-button.php
@@ -44,7 +44,7 @@ $checkboxName = $options['checkbox_name'];
 		<?php endif; ?>
 
 		title="<?php echo HTMLHelper::_('tooltipText', Text::_($tipTitle ? : $title), '', 0); ?>"
-		data-content="<?php echo HTMLHelper::_('tooltipText', Text::_($title), '', 0); ?>"
+		data-content="<?php echo HTMLHelper::_('tooltipText', $title, '', 0); ?>"
 		data-placement="top"
 		onclick="Joomla.toggleAllNextElements(this, 'd-none')"
 	>

--- a/libraries/src/Toolbar/Button/PopupButton.php
+++ b/libraries/src/Toolbar/Button/PopupButton.php
@@ -98,7 +98,7 @@ class PopupButton extends ToolbarButton
 	)
 	{
 		$this->name($name)
-			->text(Text::_($text))
+			->text($text)
 			->task($this->_getCommand($url))
 			->url($url)
 			->icon('icon-' . $name)


### PR DESCRIPTION
The text for the template preview button was being translated twice

To test enable language debug

Before this PR the button will display as `??**COM_TEMPLATES_BUTTON_PREVIEW**??`

After the PR it will be correctly displayed as `**COM_TEMPLATES_BUTTON_PREVIEW**`
