### PR TITLE
[4.0] Remove sample data step from install

### DIFF
--- a/installation/template/js/remove.js
+++ b/installation/template/js/remove.js
@@ -18,25 +18,8 @@ if (document.getElementById('installAddFeatures')) {
 if (document.getElementById('skipLanguages')) {
 	document.getElementById('skipLanguages').addEventListener('click', function(e) {
 		e.preventDefault();
-		document.getElementById('installSampleData').classList.add('active');
-		document.getElementById('installLanguages').classList.remove('active');
-	})
-}
-
-if (document.getElementById('installSampleData')) {
-	document.getElementById('installSampleData').addEventListener('click', function(e) {
-		e.preventDefault();
-		document.getElementById('installSampleData').classList.add('active');
-		document.getElementById('installLanguages').classList.remove('active');
-	})
-}
-
-if (document.getElementById('skipSampleData')) {
-	document.getElementById('skipSampleData').addEventListener('click', function(e) {
-		e.preventDefault();
-		document.getElementById('installSampleData').classList.toggle('active');
-		document.getElementById('installSampleData').style.display = 'none';
 		document.getElementById('installFinal').classList.add('active');
+		document.getElementById('installLanguages').classList.remove('active');
 	})
 }
 
@@ -49,23 +32,8 @@ if (document.getElementById('installLanguagesButton')) {
 			// Install the extra languages
 			if (Joomla.install(['languages'], form)) {
 				document.getElementById('installLanguages').classList.remove('active');
-				document.getElementById('installSampleData').classList.add('active');
+				document.getElementById('installFinal').classList.add('active');
 			}
-		}
-	})
-}
-
-if (document.getElementById('installSampleDataButton')) {
-	document.getElementById('installSampleDataButton').addEventListener('click', function(e) {
-		e.preventDefault();
-		var form = document.getElementById('sampleDataForm');
-		if (form) {
-			// Install the extra languages
-			Joomla.install(['sample'], form);
-
-			document.getElementById('installSampleData').classList.toggle('active');
-			document.getElementById('installSampleData').style.display = 'none';
-			document.getElementById('installFinal').classList.add('active');
 		}
 	})
 }

--- a/installation/tmpl/remove/default.php
+++ b/installation/tmpl/remove/default.php
@@ -187,28 +187,6 @@ use Joomla\CMS\Uri\Uri;
 			</div>
 		</fieldset>
 
-		<fieldset id="installSampleData" class="j-install-step">
-			<legend class="j-install-step-header">
-				<span class="fa fa-cog" aria-hidden="true"></span> <?php echo Text::_('INSTL_SITE_INSTALL_SAMPLE'); ?>
-			</legend>
-			<div class="j-install-step-form">
-				<h2><?php echo Text::_('INSTL_SITE_INSTALL_SAMPLE_LABEL'); ?></h2>
-				<p><?php echo Text::_('INSTL_SITE_INSTALL_SAMPLE_DESC'); ?></p>
-
-
-				<form action="index.php" method="post" id="sampleDataForm" class="form-validate">
-					<div class="form-group">
-						<input type="hidden" name="sample_file" value="sample_testing.sql">
-						<?php echo HTMLHelper::_('form.token'); ?>
-						<button id="installSampleDataButton" class="btn btn-primary btn-block"><?php echo Text::_('INSTL_SITE_INSTALL_SAMPLE'); ?> <span class="fa fa-chevron-right" aria-hidden="true"></span></button>
-						<button id="skipSampleData" class="btn btn-block btn-secondary">
-							<?php echo Text::_('JSKIP'); ?>
-						</button>
-					</div>
-				</form>
-			</div>
-		</fieldset>
-
 		<fieldset id="installFinal" class="j-install-step">
 			<legend class="j-install-step-header">
 				<span class="fab fa-joomla" aria-hidden="true"></span> <?php echo Text::_('INSTL_COMPLETE_FINAL'); ?>


### PR DESCRIPTION
PR for #25813

**Steps to reproduce the issue**
Install a clean build.
Install or not some languages, then skip

**Expected result**
As there is no sample data to install any more you should just get the final screen of the install

**Actual result**
You still get the sample data install screen with missing lang strings

This PR fixes that by completing the removal of the sample data screen