### PR TITLE
[4.0] Template Manager directory tree icons not clickable

### DIFF
--- a/build/media_source/com_templates/js/admin-templates-default.es6.js
+++ b/build/media_source/com_templates/js/admin-templates-default.es6.js
@@ -26,7 +26,7 @@
       folder.addEventListener('click', (event) => {
         event.preventDefault();
 
-        const list = event.target.parentNode.querySelector('ul');
+        const list = folder.parentNode.querySelector('ul');
 
         if (list.style.display !== 'none') {
           list.style.display = 'none';


### PR DESCRIPTION
Pull Request for Issue #25835.

### Summary of Changes

Fixes directory tree not expanding when clicking on folder icon.

### Testing Instructions

Select System > Templates > Site Templates > open Cassiopeia
Click on a folder icon

### Expected result

The folder/directory tree should open.

### Actual result

The tree does not open. Only if you click on the adjacent word, e.g. 'css' or 'html'.

### Documentation Changes Required

No.