### PR TITLE
[4.0] Checkboxes field

### DIFF
--- a/layouts/joomla/form/field/checkboxes.php
+++ b/layouts/joomla/form/field/checkboxes.php
@@ -58,7 +58,7 @@ $alt = preg_replace('/[^a-zA-Z0-9_\-]/', '_', $name);
 <fieldset id="<?php echo $id; ?>" class="<?php echo trim($class . ' checkboxes'); ?>"
 	<?php echo $required ? 'required' : ''; ?>
 	<?php echo $autofocus ? 'autofocus' : ''; ?>>
-	<legend><?php echo $label; ?></legend>
+	<legend class="sr-only"><?php echo $label; ?></legend>
 
 	<?php foreach ($options as $i => $option) : ?>
 		<?php

--- a/plugins/editors/codemirror/codemirror.xml
+++ b/plugins/editors/codemirror/codemirror.xml
@@ -182,7 +182,6 @@
 					name="fullScreenMod"
 					type="checkboxes"
 					label="PLG_CODEMIRROR_FIELD_FULLSCREEN_MOD_LABEL"
-					hiddenLabel="true"
 					>
 					<option value="Shift">PLG_CODEMIRROR_FIELD_VALUE_FULLSCREEN_MOD_SHIFT</option>
 					<option value="Cmd">PLG_CODEMIRROR_FIELD_VALUE_FULLSCREEN_MOD_CMD</option>


### PR DESCRIPTION
Change the field layout so that the `<legend>` is set to be sr-only and that the field label is rendered.

An example of this in use can be seen in the codemirror plugin options

### Before
![image](https://user-images.githubusercontent.com/1296369/63045383-28472a80-bec8-11e9-8a4e-61fbe9415857.png)

### After
![image](https://user-images.githubusercontent.com/1296369/63045329-11083d00-bec8-11e9-94a2-ee9e78c6be56.png)
