### PR TITLE
[com_joomlaupdate] Make sure the purge updates button works reliability

### DIFF
--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -217,7 +217,7 @@ class JoomlaupdateModelDefault extends JModelLegacy
 		// Reset the last update check timestamp
 		$query = $db->getQuery(true)
 			->update($db->quoteName('#__update_sites'))
-			->set($db->quoteName('last_check_timestamp') . ' = ' . $db->quote(0));
+			->set($db->quoteName('last_check_timestamp') . ' = 0');
 		$db->setQuery($query);
 		$db->execute();
 

--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -214,16 +214,18 @@ class JoomlaupdateModelDefault extends JModelLegacy
 	{
 		$db = $this->getDbo();
 
-		// Modify the database record
-		$update_site = new stdClass;
-		$update_site->last_check_timestamp = 0;
-		$update_site->enabled = 1;
-		$update_site->update_site_id = 1;
-		$db->updateObject('#__update_sites', $update_site, 'update_site_id');
+		// Reset the last update check timestamp
+		$query = $db->getQuery(true)
+			->update($db->quoteName('#__update_sites'))
+			->set($db->quoteName('last_check_timestamp') . ' = ' . $db->quote(0));
+		$db->setQuery($query);
+		$db->execute();
 
+		// We should delete all core updates here
 		$query = $db->getQuery(true)
 			->delete($db->quoteName('#__updates'))
-			->where($db->quoteName('update_site_id') . ' = ' . $db->quote('1'));
+			->where($db->quoteName('element') . ' = ' . $db->quote('joomla'))
+			->where($db->quoteName('type') . ' = ' . $db->quote('file'));
 		$db->setQuery($query);
 
 		if ($db->execute())

--- a/libraries/src/Updater/Updater.php
+++ b/libraries/src/Updater/Updater.php
@@ -366,6 +366,13 @@ class Updater extends \JAdapter
 					{
 						$update->load($uid);
 
+						// We already have an update in the database lets check whether it has an extension_id
+						if ((int) $update->extension_id === 0 && $eid)
+						{
+							// The current update does not have an extension_id but we found one let's use them
+							$current_update->extension_id = $eid;
+						}
+
 						// If there is an update, check that the version is newer then replaces
 						if (version_compare($current_update->version, $update->version, $operator) == 1)
 						{


### PR DESCRIPTION
Pull Request for Issue raised in different forums like https://forum.joomla.de/thread/8220-joomla-version-wird-nicht-korrekt-angezeigt/?pageNo=1 about not seeing the update and even `pruge updates` did not help in some very also sites.

### Summary of Changes

- As of today the com_joomlaupdate purge button only checks for the update site id 1. Which is fine for new systems but it is not for older systems where might different update_site id's are used or used in parallel.
- As of today when an update exists in the database without an extension_id we never try to assign the correct extension id later in the process.

So this PR fixes the mention problem by making sure all update sites gets checked again (we can not be sure which is joomla core) and that altleast all updates assigned to joomla core are removed from the #__updates table. We might also try truncate #__updates as the com_installer purge button does? Throughts?

### Testing Instructions

- install 3.9.10
- go to com_joomlaupdate
- clear the database table #__updates 
- run the following SQL (and replace the prefix `#__` please):

```sql
INSERT INTO `#__updates` (`update_id`, `update_site_id`, `extension_id`, `name`, `description`, `element`, `type`, `folder`, `client_id`, `version`, `data`, `detailsurl`, `infourl`, `extra_query`) VALUES
(1, 1, 0, 'Joomla', '', 'joomla', 'file', '', 0, '3.9.11', '', 'https://update.joomla.org/core/sts/extension_sts.xml', '', ''),
(2, 11, 0, 'Joomla', '', 'joomla', 'file', '', 0, '3.9.11', '', 'https://update.joomla.org/core/sts/extension_sts.xml', '', '');

```

Please note that we have here an not assigned (extension_id === 0) update on update_site id 1 and 11 (as this is an older system where for some reason also a different update site id exits)

### Expected result

Joomla shows the latest version as of writing 3.9.11 in com_joomlaupdate

### Actual result

Joomla claims that 3.9.10 in the current version even when we hit the pruge button.

### Documentation Changes Required

none. 