### PR TITLE
Make com_joomlaupdate info and download URL opening a new page

### DIFF
--- a/administrator/components/com_joomlaupdate/views/default/tmpl/default_reinstall.php
+++ b/administrator/components/com_joomlaupdate/views/default/tmpl/default_reinstall.php
@@ -34,7 +34,7 @@ defined('_JEXEC') or die;
 					<a href="<?php echo $this->updateInfo['object']->downloadurl->_data; ?>" target="_blank" rel="noopener noreferrer">
 						<?php echo $this->updateInfo['object']->downloadurl->_data; ?>
 						<span class="icon-out-2" aria-hidden="true"></span>
-						<span class="sr-only"><?php echo JText::_('JBROWSERTARGET_NEW'); ?></span>
+						<span class="element-invisible"><?php echo JText::_('JBROWSERTARGET_NEW'); ?></span>
 					</a>
 				</td>
 			</tr>
@@ -48,7 +48,7 @@ defined('_JEXEC') or die;
 						<a href="<?php echo $this->updateInfo['object']->get('infourl')->_data; ?>" target="_blank" rel="noopener noreferrer">
 							<?php echo $this->updateInfo['object']->get('infourl')->title; ?>
 							<span class="icon-out-2" aria-hidden="true"></span>
-							<span class="sr-only"><?php echo JText::_('JBROWSERTARGET_NEW'); ?></span>
+							<span class="element-invisible"><?php echo JText::_('JBROWSERTARGET_NEW'); ?></span>
 						</a>
 					</td>
 				</tr>

--- a/administrator/components/com_joomlaupdate/views/default/tmpl/default_reinstall.php
+++ b/administrator/components/com_joomlaupdate/views/default/tmpl/default_reinstall.php
@@ -31,7 +31,7 @@ defined('_JEXEC') or die;
 					<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_PACKAGE_REINSTALL'); ?>
 				</td>
 				<td>
-					<a href="<?php echo $this->updateInfo['object']->downloadurl->_data; ?>">
+					<a href="<?php echo $this->updateInfo['object']->downloadurl->_data; ?>" target="_blank" rel="noopener noreferrer">
 						<?php echo $this->updateInfo['object']->downloadurl->_data; ?>
 					</a>
 				</td>
@@ -43,7 +43,7 @@ defined('_JEXEC') or die;
 						<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_INFOURL'); ?>
 					</td>
 					<td>
-						<a href="<?php echo $this->updateInfo['object']->get('infourl')->_data; ?>">
+						<a href="<?php echo $this->updateInfo['object']->get('infourl')->_data; ?>" target="_blank" rel="noopener noreferrer">
 							<?php echo $this->updateInfo['object']->get('infourl')->title; ?>
 						</a>
 					</td>

--- a/administrator/components/com_joomlaupdate/views/default/tmpl/default_reinstall.php
+++ b/administrator/components/com_joomlaupdate/views/default/tmpl/default_reinstall.php
@@ -33,7 +33,7 @@ defined('_JEXEC') or die;
 				<td>
 					<a href="<?php echo $this->updateInfo['object']->downloadurl->_data; ?>" target="_blank" rel="noopener noreferrer">
 						<?php echo $this->updateInfo['object']->downloadurl->_data; ?>
-						<span class="icon-out-2" aria-hidden="true"></span>#
+						<span class="icon-out-2" aria-hidden="true"></span>
 						<span class="sr-only"><?php echo JText::_('JBROWSERTARGET_NEW'); ?></span>
 					</a>
 				</td>

--- a/administrator/components/com_joomlaupdate/views/default/tmpl/default_reinstall.php
+++ b/administrator/components/com_joomlaupdate/views/default/tmpl/default_reinstall.php
@@ -33,6 +33,8 @@ defined('_JEXEC') or die;
 				<td>
 					<a href="<?php echo $this->updateInfo['object']->downloadurl->_data; ?>" target="_blank" rel="noopener noreferrer">
 						<?php echo $this->updateInfo['object']->downloadurl->_data; ?>
+						<span class="icon-out-2" aria-hidden="true"></span>#
+						<span class="sr-only"><?php echo JText::_('JBROWSERTARGET_NEW'); ?></span>
 					</a>
 				</td>
 			</tr>
@@ -45,6 +47,8 @@ defined('_JEXEC') or die;
 					<td>
 						<a href="<?php echo $this->updateInfo['object']->get('infourl')->_data; ?>" target="_blank" rel="noopener noreferrer">
 							<?php echo $this->updateInfo['object']->get('infourl')->title; ?>
+							<span class="icon-out-2" aria-hidden="true"></span>
+							<span class="sr-only"><?php echo JText::_('JBROWSERTARGET_NEW'); ?></span>
 						</a>
 					</td>
 				</tr>

--- a/administrator/components/com_joomlaupdate/views/default/tmpl/default_update.php
+++ b/administrator/components/com_joomlaupdate/views/default/tmpl/default_update.php
@@ -42,7 +42,7 @@ defined('_JEXEC') or die;
 				<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_PACKAGE'); ?>
 			</td>
 			<td>
-				<a href="<?php echo $this->updateInfo['object']->downloadurl->_data; ?>">
+				<a href="<?php echo $this->updateInfo['object']->downloadurl->_data; ?>" target="_blank" rel="noopener noreferrer">
 					<?php echo $this->updateInfo['object']->downloadurl->_data; ?>
 				</a>
 			</td>
@@ -54,7 +54,7 @@ defined('_JEXEC') or die;
 					<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_INFOURL'); ?>
 				</td>
 				<td>
-					<a href="<?php echo $this->updateInfo['object']->get('infourl')->_data; ?>">
+					<a href="<?php echo $this->updateInfo['object']->get('infourl')->_data; ?>" target="_blank" rel="noopener noreferrer">
 						<?php echo $this->updateInfo['object']->get('infourl')->title; ?>
 					</a>
 				</td>

--- a/administrator/components/com_joomlaupdate/views/default/tmpl/default_update.php
+++ b/administrator/components/com_joomlaupdate/views/default/tmpl/default_update.php
@@ -45,7 +45,7 @@ defined('_JEXEC') or die;
 				<a href="<?php echo $this->updateInfo['object']->downloadurl->_data; ?>" target="_blank" rel="noopener noreferrer">
 					<?php echo $this->updateInfo['object']->downloadurl->_data; ?>
 					<span class="icon-out-2" aria-hidden="true"></span>
-					<span class="sr-only"><?php echo JText::_('JBROWSERTARGET_NEW'); ?></span>
+					<span class="element-invisible"><?php echo JText::_('JBROWSERTARGET_NEW'); ?></span>
 				</a>
 			</td>
 		</tr>
@@ -59,7 +59,7 @@ defined('_JEXEC') or die;
 					<a href="<?php echo $this->updateInfo['object']->get('infourl')->_data; ?>" target="_blank" rel="noopener noreferrer">
 						<?php echo $this->updateInfo['object']->get('infourl')->title; ?>
 						<span class="icon-out-2" aria-hidden="true"></span>
-						<span class="sr-only"><?php echo JText::_('JBROWSERTARGET_NEW'); ?></span>
+						<span class="element-invisible"><?php echo JText::_('JBROWSERTARGET_NEW'); ?></span>
 					</a>
 				</td>
 			</tr>

--- a/administrator/components/com_joomlaupdate/views/default/tmpl/default_update.php
+++ b/administrator/components/com_joomlaupdate/views/default/tmpl/default_update.php
@@ -44,6 +44,8 @@ defined('_JEXEC') or die;
 			<td>
 				<a href="<?php echo $this->updateInfo['object']->downloadurl->_data; ?>" target="_blank" rel="noopener noreferrer">
 					<?php echo $this->updateInfo['object']->downloadurl->_data; ?>
+					<span class="icon-out-2" aria-hidden="true"></span>
+					<span class="sr-only"><?php echo JText::_('JBROWSERTARGET_NEW'); ?></span>
 				</a>
 			</td>
 		</tr>
@@ -56,6 +58,8 @@ defined('_JEXEC') or die;
 				<td>
 					<a href="<?php echo $this->updateInfo['object']->get('infourl')->_data; ?>" target="_blank" rel="noopener noreferrer">
 						<?php echo $this->updateInfo['object']->get('infourl')->title; ?>
+						<span class="icon-out-2" aria-hidden="true"></span>
+						<span class="sr-only"><?php echo JText::_('JBROWSERTARGET_NEW'); ?></span>
 					</a>
 				</td>
 			</tr>


### PR DESCRIPTION
Pull Request for Issue raised by Michael Melson on Facebook

### Summary of Changes

Make sure the download URL and info URL opens as a new page.

### Testing Instructions

click the update URL or the info url

### Expected result

new page opens as it is a remote site

### Actual result

the current page is closed and the new page is open in the same tab.

### Documentation Changes Required

none