### PR TITLE
Catch broken confirmConsent configuration

### DIFF
--- a/plugins/content/confirmconsent/fields/consentbox.php
+++ b/plugins/content/confirmconsent/fields/consentbox.php
@@ -235,6 +235,15 @@ class JFormFieldConsentBox extends JFormFieldCheckboxes
 			);
 		}
 
+		if (!is_object($article))
+		{
+			// We have not found the article object lets show a 404 to the user
+			return Route::_(
+				'index.php?option=com_content&view=article&id='
+				. $this->articleid . '&tmpl=component'
+			);
+		}
+
 		// Register ContentHelperRoute
 		JLoader::register('ContentHelperRoute', JPATH_BASE . '/components/com_content/helpers/route.php');
 


### PR DESCRIPTION
Pull Request for Issue raised here: https://forum.joomla.de/thread/8188-dsgvo-anfrageformular-bringt-fehlermeldung/ (german)

### Summary of Changes

Make sure there is an article object. When not forward to an 404 error as the article ID does not exists.

### Testing Instructions

configure confirm consent
show it in the frontend
remove the article
try to show it in the frontend again

### Expected result

404

### Actual result

```
Notice: Trying to get property 'id' of non-object in /plugins/content/confirmconsent/fields/consentbox.php on line 252
Notice: Trying to get property 'language' of non-object in /plugins/content/confirmconsent/fields/consentbox.php on line 255
Notice: Trying to get property 'id' of non-object in /plugins/content/confirmconsent/fields/consentbox.php on line 269
Notice: Trying to get property 'catid' of non-object in /plugins/content/confirmconsent/fields/consentbox.php on line 269
Notice: Trying to get property 'language' of non-object in /plugins/content/confirmconsent/fields/consentbox.php on line 270
```

### Documentation Changes Required

none