### PR TITLE
[4.0] Dashboard admin submenu modules

### DIFF
--- a/administrator/modules/mod_submenu/tmpl/default.php
+++ b/administrator/modules/mod_submenu/tmpl/default.php
@@ -36,7 +36,6 @@ $canChange  = $user->authorise('core.edit.state', 'com_modules.module.' . $id) &
 	<?php foreach ($root->getChildren() as $child) : ?>
 		<?php if ($child->hasChildren()) : ?>
 				<div class="card">
-					<h2 class="card-header">
 					<?php if ($canEdit || $canChange) : ?>
 						<?php $dropdownPosition = Factory::getLanguage()->isRTL() ? 'left' : 'right'; ?>
 						<div class="module-actions dropdown">
@@ -56,6 +55,7 @@ $canChange  = $user->authorise('core.edit.state', 'com_modules.module.' . $id) &
 							</div>
 						</div>
 					<?php endif; ?>
+					<h2 class="card-header">
 						<?php if ($child->icon) : ?><span class="fa fa-<?php echo $child->icon; ?>" aria-hidden="true"></span><?php endif; ?>
 						<?php echo Text::_($child->title); ?>
 					</h2>


### PR DESCRIPTION
The markup for these modules is incorrect. The h2 heading should only contain the title not the title plus dropdown menu.

In particular this causes issues for assistive technology as it doesn't understand what the title is. You can test this easily using the skip-to menu (hit tab) and you will see that the h2 has been truncated to nothing.

Apply this PR and its all good
### Before
![image](https://user-images.githubusercontent.com/1296369/63167189-7115f500-c028-11e9-9a0a-070353c27561.png)

### After
![image](https://user-images.githubusercontent.com/1296369/63167066-19778980-c028-11e9-8985-9c8aa7f9e798.png)
