### PR TITLE
[4.0][backend template] Create opacity for disabled top menu items

### DIFF
--- a/administrator/templates/atum/scss/blocks/_header.scss
+++ b/administrator/templates/atum/scss/blocks/_header.scss
@@ -112,6 +112,7 @@
           background-color: transparent;
           color: var(--atum-special-color);
           box-shadow: none;
+          opacity: 0.3;
         }
       }
       .dropdown-toggle {

--- a/administrator/templates/atum/scss/blocks/_header.scss
+++ b/administrator/templates/atum/scss/blocks/_header.scss
@@ -113,6 +113,7 @@
           color: var(--atum-special-color);
           box-shadow: none;
           opacity: 0.3;
+          pointer-events: none;
         }
       }
       .dropdown-toggle {


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/25872

### Summary of Changes
As title says. There is no way to differentiate top menu items when they are disabled.


### Testing Instructions
Edit an article.


### before patch
<img width="605" alt="Screen Shot 2019-08-16 at 18 03 56-before" src="https://user-images.githubusercontent.com/869724/63181968-a6830880-c051-11e9-934c-a188bb793df2.png">


### After patch
<img width="578" alt="Screen Shot 2019-08-16 at 18 06 18-after" src="https://user-images.githubusercontent.com/869724/63181985-b00c7080-c051-11e9-872b-879bedf6fcc0.png">

@C-Lodder 