### PR TITLE
[4.0] Adding Read More link when there is no content yet

### DIFF
--- a/build/media_source/com_content/js/admin-article-readmore.es6.js
+++ b/build/media_source/com_content/js/admin-article-readmore.es6.js
@@ -15,7 +15,9 @@
 
     const content = window.Joomla.editors.instances[editor].getValue();
 
-    if (content && !content.match(/<hr\s+id=("|')system-readmore("|')\s*\/*>/i)) {
+    if (!content) {
+      Joomla.editors.instances[editor].replaceSelection('<hr id="system-readmore">');
+    } else if (content && !content.match(/<hr\s+id=("|')system-readmore("|')\s*\/*>/i)) {
       Joomla.editors.instances[editor].replaceSelection('<hr id="system-readmore">');
     } else {
       // TODO replace with joomla-alert


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/25873

### Summary of Changes
Allow adding Read More when textarea is empty by adding in the js the case when there is no content yet, as done in 3.x.


### Testing Instructions
See https://github.com/joomla/joomla-cms/issues/25873


### Before patch
We get the alert.


### After patch
Read More is inserted. No more alert.

