### PR TITLE
[4.0][Backend Template] Correcting custom admin menu items edit display

### DIFF
--- a/administrator/components/com_menus/forms/itemadmin_alias.xml
+++ b/administrator/components/com_menus/forms/itemadmin_alias.xml
@@ -19,6 +19,7 @@
 		<fieldset
 			name="menu-options"
 			label="COM_MENUS_LINKTYPE_OPTIONS_LABEL"
+			class="options-grid-form-half"
 		>
 
 			<field

--- a/administrator/components/com_menus/forms/itemadmin_component.xml
+++ b/administrator/components/com_menus/forms/itemadmin_component.xml
@@ -3,6 +3,7 @@
 	<fields name="params" label="COM_MENUS_LINKTYPE_OPTIONS_LABEL">
 		<fieldset name="menu-options"
 			label="COM_MENUS_LINKTYPE_OPTIONS_LABEL"
+			class="options-grid-form-half"
 		>
 
 			<field 

--- a/administrator/components/com_menus/forms/itemadmin_container.xml
+++ b/administrator/components/com_menus/forms/itemadmin_container.xml
@@ -15,7 +15,10 @@
 	</fieldset>
 
 	<fields name="params">
-		<fieldset name="menu-options" label="COM_MENUS_LINKTYPE_OPTIONS_LABEL">
+		<fieldset name="menu-options"
+			label="COM_MENUS_LINKTYPE_OPTIONS_LABEL"
+			class="options-grid-form-half"
+		>
 			<field
 				name="menu-anchor_title"
 				type="text"

--- a/administrator/components/com_menus/forms/itemadmin_heading.xml
+++ b/administrator/components/com_menus/forms/itemadmin_heading.xml
@@ -15,7 +15,10 @@
 	</fieldset>
 
 	<fields name="params">
-		<fieldset name="menu-options" label="COM_MENUS_LINKTYPE_OPTIONS_LABEL">
+		<fieldset name="menu-options"
+			label="COM_MENUS_LINKTYPE_OPTIONS_LABEL"
+			class="options-grid-form-half"
+		>
 			<field
 				name="menu-anchor_title"
 				type="text"

--- a/administrator/components/com_menus/forms/itemadmin_url.xml
+++ b/administrator/components/com_menus/forms/itemadmin_url.xml
@@ -6,6 +6,7 @@
 				name="menu-anchor_title"
 				type="text" 
 				label="COM_MENUS_ITEM_FIELD_ANCHOR_TITLE_LABEL"
+				class="options-grid-form-half"
 			/>
 
 			<field 


### PR DESCRIPTION
### Summary of Changes
Setting the class in the specific admin custom menu items xml (same as done for the site ones) in order to get 2 columns on larger size screens instead of 3.


### Testing Instructions
Create a custom AdminMenu.
Create a menu item for this admin menu
Display Link Type tab


### Before patch
We get 3 columns and stuff is not aligned correctly

<img width="1035" alt="Screen Shot 2019-08-16 at 18 39 32-before" src="https://user-images.githubusercontent.com/869724/63184488-b271c900-c057-11e9-8459-f51a1a8fdf0c.png">


### After patch
Now it is OK.

<img width="1041" alt="Screen Shot 2019-08-16 at 18 42 51" src="https://user-images.githubusercontent.com/869724/63184498-b867aa00-c057-11e9-8bae-e9d9360f3523.png">

