### PR TITLE
[4.0] a website menu is not role="menu"

### DIFF
--- a/administrator/modules/mod_menu/tmpl/default.php
+++ b/administrator/modules/mod_menu/tmpl/default.php
@@ -25,7 +25,7 @@ $class     = $enabled ? 'nav flex-column main-nav ' . $direction : 'nav flex-col
 if ($root->hasChildren())
 {
 	echo '<nav class="main-nav-container" aria-label="' . Text::_('MOD_MENU_ARIA_MAIN_MENU') . '">';
-	echo '<ul id="menu" class="' . $class . '" role="menu">' . "\n";
+	echo '<ul id="menu" class="' . $class . '">' . "\n";
 
 	// WARNING: Do not use direct 'include' or 'require' as it is important to isolate the scope for each call
 	$menu->renderSubmenu(ModuleHelper::getLayoutPath('mod_menu', 'default_submenu'), $root);

--- a/administrator/modules/mod_menu/tmpl/default_submenu.php
+++ b/administrator/modules/mod_menu/tmpl/default_submenu.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Router\Route;
 
 /**
  * =========================================================================================================
@@ -50,7 +51,7 @@ if ($current->type == 'separator')
 }
 else
 {
-	echo '<li' . $class . ' role="menuitem">';
+	echo '<li' . $class . '>';
 }
 
 // Print a link if it exists
@@ -129,7 +130,7 @@ if ($current->dashboard)
 {
 	$titleDashboard = Text::sprintf('MOD_MENU_DASHBOARD_LINK', Text::_($current->title));
 	echo '<span class="menu-dashboard"><a href="'
-		. JRoute::_('index.php?option=com_cpanel&view=cpanel&dashboard=' . $current->dashboard) . '">'
+		. Route::_('index.php?option=com_cpanel&view=cpanel&dashboard=' . $current->dashboard) . '">'
 		. '<span class="fa fa-th-large" title="' . $titleDashboard . '" aria-hidden="true"></span>'
 		. '<span class="sr-only">' . $titleDashboard . '</span>'
 		. '</a></span>';
@@ -146,7 +147,7 @@ if ($this->enabled && $current->hasChildren())
 	}
 	else
 	{
-		echo '<ul id="collapse' . $this->getCounter() . '" class="collapse-level-1 collapse" role="menu" aria-haspopup="true">' . "\n";
+		echo '<ul id="collapse' . $this->getCounter() . '" class="collapse-level-1 collapse">' . "\n";
 	}
 
 	// WARNING: Do not use direct 'include' or 'require' as it is important to isolate the scope for each call


### PR DESCRIPTION
I know it seems obvious to put role=menu, role=menuitem on our main menu but it is completely wrong. It is primarily for mimicking native OS menus not for navigation menus.

"Don’t Use ARIA Menu Roles for Site Nav" [Adrian Roselli](http://adrianroselli.com/2017/10/dont-use-aria-menu-roles-for-site-nav.html)
"Don’t use ARIA menu semantics in navigation menu systems." [inclusive design](https://inclusive-components.design/menus-menu-buttons/)

Also it is wrong to have aria-haspopup to indicate the presence of a collapsed submenu - the correct attribute is aria-expanded=true/false

"Use aria-expanded to indicate the open/closed state of a button-activated navigation menu." [inclusive design](https://inclusive-components.design/menus-menu-buttons/)

This also fixes the two critical accessibility errors reported #25855 

(PS there will be more PR to come as I check for other mis-uses of menu)