### PR TITLE
[4.0] Fix PHP error on Joomla Update and Manage Extension pages

### DIFF
--- a/installation/src/Model/DatabaseModel.php
+++ b/installation/src/Model/DatabaseModel.php
@@ -954,7 +954,7 @@ class DatabaseModel extends BaseInstallationModel
 
 		$db->insertObject('#__extensions', $testingPlugin, 'extension_id');
 
-		$installer = Installer::getInstance();
+		$installer = new Installer;
 
 		if (!$installer->refreshManifestCache($testingPlugin->extension_id))
 		{

--- a/installation/src/Model/DatabaseModel.php
+++ b/installation/src/Model/DatabaseModel.php
@@ -962,6 +962,7 @@ class DatabaseModel extends BaseInstallationModel
 				Text::sprintf('INSTL_DATABASE_COULD_NOT_REFRESH_MANIFEST_CACHE', $testingPlugin->name),
 				'error'
 			);
+
 			return;
 		}
 	}

--- a/installation/src/Model/DatabaseModel.php
+++ b/installation/src/Model/DatabaseModel.php
@@ -941,6 +941,7 @@ class DatabaseModel extends BaseInstallationModel
 		}
 
 		$testingPlugin = new \stdClass;
+		$testingPlugin->extension_id = null;
 		$testingPlugin->name = 'plg_sampledata_testing';
 		$testingPlugin->type = 'plugin';
 		$testingPlugin->element = 'testing';
@@ -951,7 +952,18 @@ class DatabaseModel extends BaseInstallationModel
 		$testingPlugin->manifest_cache = '';
 		$testingPlugin->params = '{}';
 
-		$db->insertObject('#__extensions', $testingPlugin);
+		$db->insertObject('#__extensions', $testingPlugin, 'extension_id');
+
+		$installer = Installer::getInstance();
+
+		if (!$installer->refreshManifestCache($testingPlugin->extension_id))
+		{
+			Factory::getApplication()->enqueueMessage(
+				Text::sprintf('INSTL_DATABASE_COULD_NOT_REFRESH_MANIFEST_CACHE', $testingPlugin->name),
+				'error'
+			);
+			return;
+		}
 	}
 
 	/**

--- a/libraries/src/Extension/ExtensionHelper.php
+++ b/libraries/src/Extension/ExtensionHelper.php
@@ -259,7 +259,6 @@ class ExtensionHelper
 		// Core plugin extensions - sample data
 		array('plugin', 'blog', 'sampledata', 0),
 		array('plugin', 'multilang', 'sampledata', 0),
-		array('plugin', 'testing', 'sampledata', 0),
 
 		// Core plugin extensions - system
 		array('plugin', 'actionlogs', 'system', 0),
@@ -280,6 +279,7 @@ class ExtensionHelper
 		array('plugin', 'sessiongc', 'system', 0),
 		array('plugin', 'skipto', 'system', 0),
 		array('plugin', 'stats', 'system', 0),
+		array('plugin', 'sessiongc', 'system', 0),
 		array('plugin', 'updatenotification', 'system', 0),
 
 		// Core plugin extensions - two factor authentication

--- a/libraries/src/Extension/ExtensionHelper.php
+++ b/libraries/src/Extension/ExtensionHelper.php
@@ -259,6 +259,7 @@ class ExtensionHelper
 		// Core plugin extensions - sample data
 		array('plugin', 'blog', 'sampledata', 0),
 		array('plugin', 'multilang', 'sampledata', 0),
+		array('plugin', 'testing', 'sampledata', 0),
 
 		// Core plugin extensions - system
 		array('plugin', 'actionlogs', 'system', 0),
@@ -279,7 +280,6 @@ class ExtensionHelper
 		array('plugin', 'sessiongc', 'system', 0),
 		array('plugin', 'skipto', 'system', 0),
 		array('plugin', 'stats', 'system', 0),
-		array('plugin', 'sessiongc', 'system', 0),
 		array('plugin', 'updatenotification', 'system', 0),
 
 		// Core plugin extensions - two factor authentication


### PR DESCRIPTION
Pull Request for Issue #25888 .

### Summary of Changes

This PR adds the testing sample data plugin to the list of core extensions in the ExtensionHelper class.

This is necessary to avoid PHP notice as described in issue #25888 when going to the Joomla Update Component view.

The reason is that update site checks are made all update sites, i.e. also for 3rd party extensions, and also when going to the Joomla Update Component, and for a core extension this fails because it has no own update site.

The testing sample data plugin is not shipped with Joomla CMS packages, it is only present on a cloned GitHub repository. So it is necessary to double-check that the change in this PR does not do harm when that plugin is not present. See testing instructions below for checking this with a nightly build.

Furthermore, this PR adds code to update the manifest cache of the testing sample data plugin after it has been installed.

This fixes the PHP notices you get when going to "Manage - Extensions", see comment here: [https://github.com/joomla/joomla-cms/pull/25910#issuecomment-522141663](https://github.com/joomla/joomla-cms/pull/25910#issuecomment-522141663). Thanks @brianteeman for discovering these.

Finally, this PR remove a duplicate entry for the "sessiongc" system plugin. This change does not have any effect except code is clean, because duplicate entries don't do harm for the same reason as for having extensions in the list which are not present.

### Testing Instructions

1. Install 4.0-dev from a cloned GitHub repository where testing sample data is present.

2. After installation has finished with success, login to backend and go to /administrator/index.php?option=com_joomlaupdate while watching the php error log.

Result: Multiple times PHP notice as follows:

> PHP Notice: Trying to get property 'version' of non-object in /home/richard/lamp/public_html/joomla-cms/administrator/components/com_joomlaupdate/Model/UpdateModel.php on line 1357

3. Now go to "Manage - Extensions" while watching the php error log.

Result: 2 PHP notices as follows:

> PHP Notice:  Undefined property: stdClass::$version in /home/richard/lamp/public_html/joomla-cms-4.0-dev/administrator/components/com_installer/tmpl/manage/default.php on line 108
> PHP Notice:  Undefined property: stdClass::$version in /home/richard/lamp/public_html/joomla-cms-4.0-dev/administrator/components/com_installer/tmpl/manage/default.php on line 124

4. Apply this PR e.g with patchtester.

5. Remove configuration.php, delete all database tables and install again.

6. Go again to /administrator/index.php?option=com_joomlaupdate while watching the php error log.

Result: No PHP notice.

7. Now go again to "Manage - Extensions" while watching the php error log.

Result: No PHP notice.

8. Repeat steps 1 and 2, but this time using a nightly build unpacked into an empty folder. In opposite to a cloned GitHub repository, this does not ship with testing sample data.

Result: No PHP notice.

8. Continue with steps 3 to 7, still using the nightly build.

Results: Same as before in steps 3 to 7, i.e. without patch notice, with patch no notice.

### Expected result

No PHP notice on the Joomla Update Component view.

No PHP notice on the "Manage - Extensions" view.

### Actual result

When using a cloned GitHub repository, multiple times PHP notice as follows when going to the the Joomla Update Component view :

> Notice: Trying to get property 'version' of non-object in /home/richard/lamp/public_html/joomla-cms/administrator/components/com_joomlaupdate/Model/UpdateModel.php on line 1357

No PHP error or warning or notice for that view when using a nightly build.

In any case on the "Manage - Extensions" view 2 PHP notices as follows:

> PHP Notice:  Undefined property: stdClass::$version in /home/richard/lamp/public_html/joomla-cms-4.0-dev/administrator/components/com_installer/tmpl/manage/default.php on line 108
> PHP Notice:  Undefined property: stdClass::$version in /home/richard/lamp/public_html/joomla-cms-4.0-dev/administrator/components/com_installer/tmpl/manage/default.php on line 124

### Additional information

I have investigated where the list of core extensions is used in which way.

Either it is used to build a where clause for a database query where there will not be returned any result when a listed core extension is not really present in database, like is when using a normal Joomla package, or it is used for checking if an existing extension is in the list, which does also not happen when the extension is not present.

So I think it does not do any harm to have the testing sample data plugin in the list of core extensions in case that plugin is not present.

### Documentation Changes Required

No.