### PR TITLE
[4.0][Backend Template] Correcting plugin options duplication

### DIFF
--- a/administrator/components/com_plugins/tmpl/plugin/edit.php
+++ b/administrator/components/com_plugins/tmpl/plugin/edit.php
@@ -124,24 +124,6 @@ $tmpl     = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=
 							'note',
 						); ?>
 						<?php echo LayoutHelper::render('joomla.edit.global', $this); ?>
-						<div class="form-vertical form-no-margin">
-							<div class="form-group">
-								<?php echo $this->form->getLabel('ordering'); ?>
-								<?php echo $this->form->getInput('ordering'); ?>
-							</div>
-							<div class="form-group">
-								<?php echo $this->form->getLabel('folder'); ?>
-								<?php echo $this->form->getInput('folder'); ?>
-							</div>
-							<div class="form-group">
-								<?php echo $this->form->getLabel('element'); ?>
-								<?php echo $this->form->getInput('element'); ?>
-							</div>
-							<div class="control-group">
-								<?php echo $this->form->getLabel('note'); ?>
-								<?php echo $this->form->getInput('note'); ?>
-							</div>
-						</div>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/25899

### Summary of Changes
As title says. 


### Testing Instructions
Edit a plugin.
See https://github.com/joomla/joomla-cms/issues/25899 for screenshot.


### Before patch
Options are duplicated



### After patch
All fine
<img width="388" alt="Screen Shot 2019-08-17 at 07 20 30" src="https://user-images.githubusercontent.com/869724/63207002-8d18a580-c0bf-11e9-99cf-c4ffb0160c40.png">


