### PR TITLE
[4.0] Remove duplicate sessiongc from core extensions list of the ExtenshionHelper class

### DIFF
--- a/libraries/src/Extension/ExtensionHelper.php
+++ b/libraries/src/Extension/ExtensionHelper.php
@@ -279,7 +279,6 @@ class ExtensionHelper
 		array('plugin', 'sessiongc', 'system', 0),
 		array('plugin', 'skipto', 'system', 0),
 		array('plugin', 'stats', 'system', 0),
-		array('plugin', 'sessiongc', 'system', 0),
 		array('plugin', 'updatenotification', 'system', 0),
 
 		// Core plugin extensions - two factor authentication


### PR DESCRIPTION
Pull Request for new issue.

### Summary of Changes

Removes duplicate element from array with core extensions in the ExtensionHelper class.

### Testing Instructions

Code review: Verify that line 282 which will be removed by this PR is exactly the same as line 279, and that line 279 is correct regarding alphabetical order.

### Expected result

No duplicate elements in array with core extensions in the ExtensionHelper class.

System plugins section of that array is ordered ascending in alphabetical order by column `element`, i.e. the 2nd one.

### Actual result

Duplicate element `array('plugin', 'sessiongc', 'system', 0),` array with core extensions in the ExtensionHelper class in line 279 and 282 of file `ExtensionHelper.php`.

The one in line 279 is correct regarding alphabetical order, the other one is wrong.

### Documentation Changes Required

No.