### PR TITLE
[4.0] Update manifest cache after testing sampledata plugin installation

### DIFF
--- a/installation/src/Model/DatabaseModel.php
+++ b/installation/src/Model/DatabaseModel.php
@@ -962,8 +962,6 @@ class DatabaseModel extends BaseInstallationModel
 				Text::sprintf('INSTL_DATABASE_COULD_NOT_REFRESH_MANIFEST_CACHE', $testingPlugin->name),
 				'error'
 			);
-
-			return;
 		}
 	}
 

--- a/installation/src/Model/DatabaseModel.php
+++ b/installation/src/Model/DatabaseModel.php
@@ -929,7 +929,7 @@ class DatabaseModel extends BaseInstallationModel
 	 *
 	 * @return  void
 	 *
-	 * @since   4.0.0
+	 * @since   __DEPLOY_VERSION__
 	 */
 	public function checkTestingSampledata($db)
 	{
@@ -941,6 +941,7 @@ class DatabaseModel extends BaseInstallationModel
 		}
 
 		$testingPlugin = new \stdClass;
+		$testingPlugin->extension_id = null;
 		$testingPlugin->name = 'plg_sampledata_testing';
 		$testingPlugin->type = 'plugin';
 		$testingPlugin->element = 'testing';
@@ -951,7 +952,19 @@ class DatabaseModel extends BaseInstallationModel
 		$testingPlugin->manifest_cache = '';
 		$testingPlugin->params = '{}';
 
-		$db->insertObject('#__extensions', $testingPlugin);
+		$db->insertObject('#__extensions', $testingPlugin, 'extension_id');
+
+		$installer = new Installer;
+
+		if (!$installer->refreshManifestCache($testingPlugin->extension_id))
+		{
+			Factory::getApplication()->enqueueMessage(
+				Text::sprintf('INSTL_DATABASE_COULD_NOT_REFRESH_MANIFEST_CACHE', $testingPlugin->name),
+				'error'
+			);
+
+			return;
+		}
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue [https://github.com/joomla/joomla-cms/pull/25910#issuecomment-522141663](https://github.com/joomla/joomla-cms/pull/25910#issuecomment-522141663) by @brianteeman , thanks for catching that .

In addition, it very likely also fixes issue #25888 . Please report back when testing if it solves both or only the comment mentioned above.

Thanks to @SharkyKZ for pointing me to the right way to fix it.

### Summary of Changes

This Pull Request (PR) adds the update of manifest cache for the testing sample data plugin to the installation routine for that plugin, which is function `checkTestingSampledata` in file `installation/src/Model/DatabaseModel.php`. It works the same way as manifest cache update of all other core extensions, which happens in function `createTables` in the same file, except that a new installer class is used as suggested by @mbabker , so that there is nothing messed up with the currently used installer instance.

This fixes the PHP notices described in [https://github.com/joomla/joomla-cms/pull/25910#issuecomment-522141663](https://github.com/joomla/joomla-cms/pull/25910#issuecomment-522141663), which happen when having the testing sample data plugin available, like is is when using the gihub repository clone and not an unzipped nightly build, and then going to the Extension Manager view.

It seems to fix also the PHP notices described in issue #25888 , which happen under the same conditions as mentioned above but on the Joomla Update Component view, but that's not 100% clear yet. There were different test results regarding that for @SharkyKZ and me.

### Testing Instructions

1. Checkout latest 4.0-dev, do `composer install` and `npm install`.

2. Make a new clean installation into an empty database.

3. After successful installation, login to backend, click away the statistics dialog, go to global config, switch PHP error reporting to maximum or deveopment.

4. Now go to "Manage - Extensions" (or "Extensions - Manage", however is called) view. If you log PHP erros into a log file, check that log file, otherwise have display errors on so check if there is a PHP notice shown on the current page.

Result: See section "Actual result" below, item 1.

5. Now go to the Home Dashboard and click the Joomla Update button to go to the Joomla Update view.

Result: See section "Actual result" below, item 2.

6. Now apply the changes made by this PR, delete configuration.php and the database tables and repeat steps 2 to 5 of the above procedure.

Result: See section "Expected result" below.

### Expected result

No PHP notices.

### Actual result

1. On  "Manage - Extensions" view 2 PHP notices as follows:

> PHP Notice:  Undefined property: stdClass::$version in /home/richard/lamp/public_html/joomla-cms-4.0-dev/administrator/components/com_installer/tmpl/manage/default.php on line 108
> PHP Notice:  Undefined property: stdClass::$version in /home/richard/lamp/public_html/joomla-cms-4.0-dev/administrator/components/com_installer/tmpl/manage/default.php on line 124

This belongs to [https://github.com/joomla/joomla-cms/pull/25910#issuecomment-522141663](https://github.com/joomla/joomla-cms/pull/25910#issuecomment-522141663).

2. On Joomla Update Component view multiple PHP notices as follows:

> PHP Notice: Trying to get property 'version' of non-object in /home/richard/lamp/public_html/joomla-cms/administrator/components/com_joomlaupdate/Model/UpdateModel.php on line 1357

This belongs to issue #25888 .

### Documentation Changes Required

No.