### PR TITLE
[4.0][Backend Template]Increasing admin menu width to let longer menu titles display correctly

### DIFF
--- a/administrator/templates/atum/scss/_variables.scss
+++ b/administrator/templates/atum/scss/_variables.scss
@@ -102,7 +102,7 @@ $header-height:                    3.5rem;
 $atum-toolbar-line-height:         2.45rem;
 
 // Sidebar
-$sidebar-width:                    15.625rem;
+$sidebar-width:                    18rem;
 $sidebar-width-login:              28.75rem;
 $sidebar-width-closed:             3rem;
 $main-brand-height:                3rem;

--- a/administrator/templates/atum/scss/blocks/_header.scss
+++ b/administrator/templates/atum/scss/blocks/_header.scss
@@ -53,7 +53,7 @@
     svg, img {
       margin-left: 0.8rem;
       max-height: 1.3rem;
-      max-width: calc(15.625rem - 0.8rem);
+      max-width: calc(18rem - 0.8rem);
 
       &.logo-small {
         display: none;

--- a/administrator/templates/atum/scss/template-rtl.scss
+++ b/administrator/templates/atum/scss/template-rtl.scss
@@ -129,16 +129,16 @@ body {
     transform: rotate(180deg) translate(0, -180%);
   }
 
-  ul a::before {
-    right: 18px;
+  ul a {
+    padding: 0 1.4rem 0 0;
   }
 
   .active .no-dropdown .sidebar-item-title {
-    margin-right: 28px;
+    margin-right: 1rem;
   }
 
   .dropdown-submenu .sidebar-item-title {
-    margin-right: 28px;
+    margin-right: 1rem;
   }
 
   .dropdown-submenu .no-dropdown .sidebar-item-title {


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/25852

### Summary of Changes
As title says. 
Also corrects RTL display (Needs more work as some css are not needed any more or are in px)
Basically changing width from 15.625rem to 18rem

### Before patch
LTR
<img width="273" alt="Screen Shot 2019-08-17 at 17 25 42" src="https://user-images.githubusercontent.com/869724/63214080-1eb20280-c114-11e9-9d65-ff4c91338b80.png">

RTL
<img width="272" alt="Screen Shot 2019-08-17 at 17 25 21" src="https://user-images.githubusercontent.com/869724/63214180-376ee800-c115-11e9-8ee9-f4783d071974.png">



### After patch
LTR
<img width="300" alt="Screen Shot 2019-08-17 at 17 19 13" src="https://user-images.githubusercontent.com/869724/63214029-903d8100-c113-11e9-92bb-702c35ef6028.png">

RTL
<img width="297" alt="Screen Shot 2019-08-17 at 17 22 48" src="https://user-images.githubusercontent.com/869724/63214042-b8c57b00-c113-11e9-87af-a2f944041bde.png">

-------------------------------------------
@chmst
@coolcat-creations 

I have absolutely no idea why `15.625rem` had been chosen for this sidebar width.
Therefore my proposal here does solve the issue but may have to be completed.
