### PR TITLE
Make sure Joomla always points to the latest release and don't fill up the #__updates table

### DIFF
--- a/libraries/src/Updater/Updater.php
+++ b/libraries/src/Updater/Updater.php
@@ -159,8 +159,8 @@ class Updater extends \JAdapter
 			// Make sure there is no update left over in the database.
 			$db = $this->getDbo();
 			$query = $db->getQuery(true)
-			->delete($db->quoteName('#__updates'))
-			->where($db->quoteName('update_site_id') . ' = ' . $db->quote($result['update_site_id']));
+				->delete($db->quoteName('#__updates'))
+				->where($db->quoteName('update_site_id') . ' = ' . $db->quote($result['update_site_id']));
 			$db->setQuery($query);
 			$db->execute();
 

--- a/libraries/src/Updater/Updater.php
+++ b/libraries/src/Updater/Updater.php
@@ -156,6 +156,14 @@ class Updater extends \JAdapter
 				continue;
 			}
 
+			// Make sure there is no update left over in the database.
+			$db = $this->getDbo();
+			$query = $db->getQuery(true)
+			->delete($db->quoteName('#__updates'))
+			->where($db->quoteName('update_site_id') . ' = ' . $db->quote($result['update_site_id']));
+			$db->setQuery($query);
+			$db->execute();
+
 			$updateObjects = $this->getUpdateObjectsForSite($result, $minimum_stability, $includeCurrent);
 
 			if (!empty($updateObjects))


### PR DESCRIPTION
Pull Request for Issue #25920 

### Summary of Changes

As explained here #25920 we never delete the #__updates table and only add new entries. In some cases this lead to long list of duplicates, especial for language updates with different versions etc. Example:
![image](https://user-images.githubusercontent.com/2596554/63217075-cb55a980-c13f-11e9-807d-42653332a3b2.png)

For this reason I propose to make sure, before we checking for new updates on a specific update site, that we remove all updates associated to that update site from the #__updates table. This way we make sure only the latest version is added there and no duplicates should be in the database any more.

### Testing Instructions

#### First Test

- Install 3.9.11
- Apply this patch
- install an outdated language pack like this on: https://github.com/joomlagerman/joomla/releases/download/3.9.9v1/de-DE_joomla_lang_full_3.9.9v1.zip
- Check for updates
- make sure the update to 3.9.11.1 is proposed
- make sure you can install that update

#### Seccond Test

- Install 3.9.11
- don't apply this patch
- install an outdated language pack like this on: https://github.com/joomlagerman/joomla/releases/download/3.9.9v1/de-DE_joomla_lang_full_3.9.9v1.zip
- check for updates (Extensions -> Mange ->Update)
- Check the #__updates table
- notice there is only one entry for the German DE Update.
- got to #__update_sites table
- set the last checked timestamp for the language update server to `0` (this way we force the updater to check again)
- got to the #__updates table and set the version of the found update for the pkg_de-DE to `3.9.10.1` this way we fake that there is a old cached version in the database already. 
- check for updates from the extension manager
- check the #__updates table again
- notice there are now two entries for the latest update
- notice also that Joomla still points to 3.9.10 as latest version.

##### Third Test

Do the steps of the second test again but now with this patch applied. Please note that there are no duplicate entries in the database anymore and Joomla always points to the latest version.

### Expected result

Updates still work than expected

### Actual result

Updates work but under some conditions duplicate entries in the #__updates database happend, that never get deleted by Joomla unless you hit the `Clear Cache` button that in the end just runs a truncate on the table.

### Documentation Changes Required

None