### PR TITLE
Delete wrong check for the no download message

### DIFF
--- a/administrator/components/com_joomlaupdate/views/default/tmpl/default.php
+++ b/administrator/components/com_joomlaupdate/views/default/tmpl/default.php
@@ -45,7 +45,7 @@ jQuery(document).ready(function($) {
 			<?php JFactory::getApplication()->enqueueMessage(JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_INSTALL_SELF_UPDATE_FIRST'), 'error'); ?>
 			<?php echo $this->loadTemplate('updatemefirst'); ?>
 		<?php else : ?>
-			<?php if (!isset($this->updateInfo['object']->downloadurl->_data) && $this->updateInfo['installed'] < $this->updateInfo['latest']) : ?>
+			<?php if (!isset($this->updateInfo['object']->downloadurl->_data)) : ?>
 				<?php // If we have no download URL we can't reinstall or update ?>
 				<?php echo $this->loadTemplate('nodownload'); ?>
 			<?php elseif (!$this->updateInfo['hasUpdate']) : ?>


### PR DESCRIPTION
Pull Request for Issue #25827 

### Summary of Changes

Make sure no download message is displayed in any case when the download URL is not set

### Testing Instructions

- install 3.9.12-dev (https://developer.joomla.org/nightlies/Joomla_3.9.12-dev-Development-Full_Package.zip)
- apply this custom update server: https://www.jah-tz.de/downloads/core/nightlies/next_minor_list.xml
- try to get an update
- see the errors from #25827 
- apply this patch
- check for updates again
- no download message is displayed

### Expected result

No download message is displayed.

### Actual result

```
PHP Notice:  Undefined property: Joomla\CMS\Updater\Update::$downloadurl in \administrator\components\com_joomlaupdate\views\default\tmpl\default_reinstall.php on line 34
PHP Notice:  Trying to get property '_data' of non-object in \administrator\components\com_joomlaupdate\views\default\tmpl\default_reinstall.php on line 34
PHP Notice:  Undefined property: Joomla\CMS\Updater\Update::$downloadurl in \administrator\components\com_joomlaupdate\views\default\tmpl\default_reinstall.php on line 35
PHP Notice:  Trying to get property '_data' of non-object in \administrator\components\com_joomlaupdate\views\default\tmpl\default_reinstall.php on line 35
```

### Documentation Changes Required

None.