### PR TITLE
Function Redis::delete() is deprecated

### DIFF
--- a/libraries/src/Cache/Storage/RedisStorage.php
+++ b/libraries/src/Cache/Storage/RedisStorage.php
@@ -302,7 +302,7 @@ class RedisStorage extends CacheStorage
 			return false;
 		}
 
-		return (bool) static::$_redis->delete($this->_getCacheId($id, $group));
+		return (bool) static::$_redis->del($this->_getCacheId($id, $group));
 	}
 
 	/**
@@ -338,12 +338,12 @@ class RedisStorage extends CacheStorage
 		{
 			if (strpos($key, $secret . '-cache-' . $group . '-') === 0 && $mode == 'group')
 			{
-				static::$_redis->delete($key);
+				static::$_redis->del($key);
 			}
 
 			if (strpos($key, $secret . '-cache-' . $group . '-') !== 0 && $mode != 'group')
 			{
-				static::$_redis->delete($key);
+				static::$_redis->del($key);
 			}
 		}
 


### PR DESCRIPTION
### Summary of Changes

Function `Redis::delete()` is deprecated in phpredis 5

### Testing Instructions

Install phpredis 5, it trows a deprecated warning. As `delete` is an alias for `del`, this is backards compatible.

See the note at https://github.com/phpredis/phpredis#del-delete-unlink

### Expected result

No PHP warnings.

### Actual result

PHP deprecated warning.
`Deprecated: Function Redis::delete() is deprecated in /libraries/src/Cache/Storage/RedisStorage.php on line 341`

