### PR TITLE
[4.0][Admin template] Correcting config permissions and text filters display

### DIFF
--- a/administrator/components/com_config/tmpl/application/default_filters.php
+++ b/administrator/components/com_config/tmpl/application/default_filters.php
@@ -14,6 +14,6 @@ defined('_JEXEC') or die;
 
 $this->name = Text::_('COM_CONFIG_TEXT_FILTER_SETTINGS');
 $this->fieldsname = 'filters';
-$this->formclass = 'options-grid-form options-grid-form-half';
+$this->formclass = 'options-grid-form options-grid-form-full';
 
 echo LayoutHelper::render('joomla.content.text_filters', $this);

--- a/administrator/components/com_config/tmpl/application/default_permissions.php
+++ b/administrator/components/com_config/tmpl/application/default_permissions.php
@@ -15,7 +15,7 @@ defined('_JEXEC') or die;
 $this->name        = Text::_('COM_CONFIG_PERMISSION_SETTINGS');
 $this->description = '';
 $this->fieldsname  = 'permissions';
-$this->formclass   = 'form-no-margin options-grid-form options-grid-form-half';
+$this->formclass   = 'form-no-margin options-grid-form options-grid-form-full';
 $this->showlabel   = false;
 
 echo LayoutHelper::render('joomla.content.options_default', $this);

--- a/administrator/components/com_config/tmpl/component/default.php
+++ b/administrator/components/com_config/tmpl/component/default.php
@@ -85,7 +85,7 @@ $xml = $this->form->getXml();
 					?>
 
 					<?php if (!$isGrandchild && $hasParent) : ?>
-						<fieldset id="fieldset-<?php echo $this->escape($name); ?>" class="options-grid-form options-grid-form-half">
+						<fieldset id="fieldset-<?php echo $this->escape($name); ?>" class="options-grid-form options-grid-form-full">
 							<legend><?php echo Text::_($fieldSet->label); ?></legend>
 							<div>
 					<?php elseif (!$hasParent) : ?>
@@ -106,7 +106,7 @@ $xml = $this->form->getXml();
 
 						<?php if (!$hasChildren) : ?>
 
-						<fieldset id="fieldset-<?php echo $this->escape($name); ?>" class="options-grid-form options-grid-form-half">
+						<fieldset id="fieldset-<?php echo $this->escape($name); ?>" class="options-grid-form options-grid-form-full">
 							<legend><?php echo Text::_($fieldSet->label); ?></legend>
 							<div>
 						<?php $opentab = 2; ?>


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/25887

### Summary of Changes
Correcting wrong grid


### Testing Instructions
Display Global Configuration Text Filters tab as well as Permissions.
Display Components Permissions.

! After patch, check that other configuration pages are OK for components !


### Before patch
![Screenshot_2019-08-16 Global Configuration - J4 - Administration](https://user-images.githubusercontent.com/2019801/63154725-289b0f00-c009-11e9-9369-1b46dd401e0d.png)

![Screenshot from 2019-08-16 10-39-24](https://user-images.githubusercontent.com/181681/63155081-386b2100-c012-11e9-9520-efd860f81e1d.png)



### After patch
<img width="1449" alt="Screen Shot 2019-08-19 at 11 23 04" src="https://user-images.githubusercontent.com/869724/63254539-36a09800-c274-11e9-96ca-75ba4e5fca35.png">

<img width="1472" alt="Screen Shot 2019-08-19 at 11 23 26" src="https://user-images.githubusercontent.com/869724/63254561-3f916980-c274-11e9-95b2-5357229d97ed.png">
