### PR TITLE
Missing Strings

### DIFF
--- a/administrator/language/en-GB/en-GB.lib_joomla.ini
+++ b/administrator/language/en-GB/en-GB.lib_joomla.ini
@@ -668,6 +668,10 @@ JLIB_JS_AJAX_ERROR_TIMEOUT="A timeout has occurred while fetching the JSON data.
 JLIB_LANGUAGE_ERROR_CANNOT_LOAD_METAFILE="Could not load %s language XML file from %s."
 JLIB_LANGUAGE_ERROR_CANNOT_LOAD_METADATA="Could not load %s metadata from %s."
 
+JLIB_LOGIN_AUTHORISATION="Your access has been authorised."
+JLIB_LOGIN_DENIED="Your access has been denied."
+JLIB_LOGIN_EXPIRED="Your authentication has expired."
+
 JLIB_MAIL_FUNCTION_DISABLED="The mail() function has been disabled and the mail can't be sent."
 JLIB_MAIL_FUNCTION_OFFLINE="The mail function has been disabled by an administrator."
 JLIB_MAIL_INVALID_EMAIL_SENDER="JMail: : Invalid email Sender: %s, JMail: :setSender(%s)."

--- a/language/en-GB/en-GB.lib_joomla.ini
+++ b/language/en-GB/en-GB.lib_joomla.ini
@@ -668,6 +668,10 @@ JLIB_JS_AJAX_ERROR_TIMEOUT="A timeout has occurred while fetching the JSON data.
 JLIB_LANGUAGE_ERROR_CANNOT_LOAD_METAFILE="Could not load %s language XML file from %s."
 JLIB_LANGUAGE_ERROR_CANNOT_LOAD_METADATA="Could not load %s metadata from %s."
 
+JLIB_LOGIN_AUTHORISATION="Your access has been authorised."
+JLIB_LOGIN_DENIED="Your access has been denied."
+JLIB_LOGIN_EXPIRED="Your authentication has expired."
+
 JLIB_MAIL_FUNCTION_DISABLED="The mail() function has been disabled and the mail can't be sent."
 JLIB_MAIL_FUNCTION_OFFLINE="The mail function has been disabled by an administrator."
 JLIB_MAIL_INVALID_EMAIL_SENDER="JMail: : Invalid email Sender: %s, JMail: :setSender(%s)."


### PR DESCRIPTION
The following keys had no translation
JLIB_LOGIN_AUTHORISATION="Your access has been authorised."
JLIB_LOGIN_DENIED="Your access has been denied."
JLIB_LOGIN_EXPIRED="Your authentication has expired."

From the relevant section in the codebase it is not very clear exactly what they should be

> 			// Validate that the user should be able to login (different to being authenticated).
> 			// This permits authentication plugins blocking the user

So these are fairly generic and the plugin creator can override them if they want. Nothing in core will trigger them to be displayed so I wouldn't waste much time on them.

Pull Request for Issue #25930  .

### Testing Instructions
Code review only
