### PR TITLE
[4.0] Fix missing method getDocument()

### DIFF
--- a/libraries/src/Application/CMSApplicationInterface.php
+++ b/libraries/src/Application/CMSApplicationInterface.php
@@ -195,7 +195,7 @@ interface CMSApplicationInterface extends ExtensionManagerInterface
 	 *
 	 * @return  Document object
 	 *
-	 * @since   4.0.0
+	 * @since   __DEPLOY_VERSION__
 	 */
 	public function getDocument();
 }

--- a/libraries/src/Application/CMSApplicationInterface.php
+++ b/libraries/src/Application/CMSApplicationInterface.php
@@ -8,6 +8,7 @@
 
 namespace Joomla\CMS\Application;
 
+use Joomla\CMS\Document\Document;
 use Joomla\CMS\Extension\ExtensionManagerInterface;
 use Joomla\CMS\Menu\AbstractMenu;
 use Joomla\CMS\User\User;
@@ -186,4 +187,15 @@ interface CMSApplicationInterface extends ExtensionManagerInterface
 	 * @since   4.0.0
 	 */
 	public function loadIdentity(User $identity = null);
+
+	/**
+	 * Get a document object.
+	 *
+	 * Returns the global {@link \Joomla\CMS\Document\Document} object, only creating it if it doesn't already exist.
+	 *
+	 * @return  Document object
+	 *
+	 * @since   4.0.0
+	 */
+	public function getDocument();
 }


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

When i updating the methods, im getting a notice that the new methode is missing.
`Factory::getApplication()->getDocument();`

### Testing Instructions

Update `Factory::getDocument();`
to `Factory::getApplication()->getDocument();`

### Expected result

no deprecated message 

### Actual result

method 'getDocument' not found in Joomla\CMS\Application\CMSApplicationInterface

### Documentation Changes Required