### PR TITLE
[4.0] Remove menuitem letter-spacing

### DIFF
--- a/administrator/templates/atum/scss/blocks/_sidebar.scss
+++ b/administrator/templates/atum/scss/blocks/_sidebar.scss
@@ -349,7 +349,6 @@
   .menuitem-group {
     margin-top: 0.65rem;
     font-size: .75rem;
-    letter-spacing: 2px;
     padding-left: 2.4rem;
     [dir=rtl] & {
       padding-left: 0;


### PR DESCRIPTION
Really not a fan of changing the letter spacing on a font. Especially as it can cause undesired issues with non latin characters or when the user has _zoomed_ on the page to increase the text size for accessibility. The font designers are pretty good and know more about typography than we do.

It is used here for the word "site"
![image](https://user-images.githubusercontent.com/1296369/63577335-0fa0d980-c586-11e9-974c-f89dca55a4d8.png)

After
![image](https://user-images.githubusercontent.com/1296369/63577357-1deef580-c586-11e9-8ee8-fb6004731cac.png)


