### PR TITLE
[4.0] Component and Plugin libraries prepared statements

### DIFF
--- a/libraries/src/Component/ComponentHelper.php
+++ b/libraries/src/Component/ComponentHelper.php
@@ -407,14 +407,18 @@ class ComponentHelper
 		{
 			$db = Factory::getDbo();
 			$query = $db->getQuery(true)
-				->select($db->quoteName(array('extension_id', 'element', 'params', 'enabled'), array('id', 'option', null, null)))
+				->select($db->quoteName(['extension_id', 'element', 'params', 'enabled'], ['id', 'option', null, null]))
 				->from($db->quoteName('#__extensions'))
-				->where($db->quoteName('type') . ' = ' . $db->quote('component'))
-				->where($db->quoteName('state') . ' = 0')
-				->where($db->quoteName('enabled') . ' = 1');
+				->where(
+					[
+						$db->quoteName('type') . ' = ' . $db->quote('component'),
+						$db->quoteName('state') . ' = 0',
+						$db->quoteName('enabled') . ' = 1',
+					]
+				);
 			$db->setQuery($query);
 
-			return $db->loadObjectList('option', '\JComponentRecord');
+			return $db->loadObjectList('option', ComponentRecord::class);
 		};
 
 		/** @var CallbackController $cache */

--- a/libraries/src/Plugin/PluginHelper.php
+++ b/libraries/src/Plugin/PluginHelper.php
@@ -297,7 +297,7 @@ abstract class PluginHelper
 
 		try
 		{
-			static::$plugins = $cache->get($loader, array(), md5(implode(',', $levels)), false);
+			static::$plugins = $cache->get($loader, [], md5(implode(',', $levels)), false);
 		}
 		catch (CacheExceptionInterface $cacheException)
 		{

--- a/libraries/src/Plugin/PluginHelper.php
+++ b/libraries/src/Plugin/PluginHelper.php
@@ -255,7 +255,7 @@ abstract class PluginHelper
 			return static::$plugins;
 		}
 
-		$levels = implode(',', Factory::getUser()->getAuthorisedViewLevels());
+		$levels = Factory::getUser()->getAuthorisedViewLevels();
 
 		/** @var \JCacheControllerCallback $cache */
 		$cache = Factory::getCache('com_plugins', 'callback');
@@ -266,26 +266,30 @@ abstract class PluginHelper
 			$query = $db->getQuery(true)
 				->select(
 					$db->quoteName(
-						array(
+						[
 							'folder',
 							'element',
 							'params',
-							'extension_id'
-						),
-						array(
+							'extension_id',
+						],
+						[
 							'type',
 							'name',
 							'params',
-							'id'
-						)
+							'id',
+						]
 					)
 				)
-				->from('#__extensions')
-				->where('enabled = 1')
-				->where('type = ' . $db->quote('plugin'))
-				->where('state IN (0,1)')
-				->where('access IN (' . $levels . ')')
-				->order('ordering');
+				->from($db->quoteName('#__extensions'))
+				->where(
+					[
+						$db->quoteName('enabled') . ' = 1',
+						$db->quoteName('type') . ' = ' . $db->quote('plugin'),
+						$db->quoteName('state') . ' IN (0,1)',
+					]
+				)
+				->whereIn($db->quoteName('access'), $levels)
+				->order($db->quoteName('ordering'));
 			$db->setQuery($query);
 
 			return $db->loadObjectList();
@@ -293,7 +297,7 @@ abstract class PluginHelper
 
 		try
 		{
-			static::$plugins = $cache->get($loader, array(), md5($levels), false);
+			static::$plugins = $cache->get($loader, array(), md5(implode(',', $levels)), false);
 		}
 		catch (CacheExceptionInterface $cacheException)
 		{


### PR DESCRIPTION
### Summary of Changes

Adds prepared statements (whereIn) and cleans up queries in `Joomla\CMS\Component` and `Joomla\CMS\Plugin` namespaces.

### Testing Instructions

Test that plugins and component still work, e.g. you can still login and can still access components.

### Expected result

Works like before.

### Documentation Changes Required

No.