### PR TITLE
[4.0] ModuleHelper prepared statements

### DIFF
--- a/libraries/src/Helper/ModuleHelper.php
+++ b/libraries/src/Helper/ModuleHelper.php
@@ -379,7 +379,6 @@ abstract class ModuleHelper
 					$db->quoteName('m.published') . ' = 1',
 					$db->quoteName('e.enabled') . ' = 1',
 					$db->quoteName('m.client_id') . ' = :clientId',
-
 				]
 			)
 			->bind(':clientId', $clientId, ParameterType::INTEGER)

--- a/libraries/src/Helper/ModuleHelper.php
+++ b/libraries/src/Helper/ModuleHelper.php
@@ -379,7 +379,7 @@ abstract class ModuleHelper
 					$db->quoteName('m.published') . ' = 1',
 					$db->quoteName('e.enabled') . ' = 1',
 					$db->quoteName('m.client_id') . ' = :clientId',
-					
+
 				]
 			)
 			->bind(':clientId', $clientId, ParameterType::INTEGER)


### PR DESCRIPTION
### Summary of Changes

Adds prepared statements and cleans up queries in `Joomla\CMS\Helper\ModuleHelper`.

### Testing Instructions

Create some modules with all sorts of different settings, e.g. different states, publishing times, menu assignments, languages, etc. Test that modules are rendered only when they should be, i.e. works like before.

### Expected result

Works like before.

### Documentation Changes Required

No.