### PR TITLE
[4.0] Fix catid (catid 1 is root)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -5438,12 +5438,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-projects/joomla-browser.git",
-                "reference": "c3098ca8c942a85a27ec044679a4bf4b19adf839"
+                "reference": "37538d099e74134b7daa6c6c9ea1571f4837407c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-projects/joomla-browser/zipball/c3098ca8c942a85a27ec044679a4bf4b19adf839",
-                "reference": "c3098ca8c942a85a27ec044679a4bf4b19adf839",
+                "url": "https://api.github.com/repos/joomla-projects/joomla-browser/zipball/37538d099e74134b7daa6c6c9ea1571f4837407c",
+                "reference": "37538d099e74134b7daa6c6c9ea1571f4837407c",
                 "shasum": ""
             },
             "require": {
@@ -5481,7 +5481,7 @@
                 "acceptance testing",
                 "joomla"
             ],
-            "time": "2019-08-04T11:01:36+00:00"
+            "time": "2019-08-25T06:37:27+00:00"
         },
         {
             "name": "joomla-projects/robo-joomla",

--- a/tests/Codeception/api/ContentCest.php
+++ b/tests/Codeception/api/ContentCest.php
@@ -63,7 +63,7 @@ class ContentCest
 
 		$testarticle = [
 			'title' => 'Just for you',
-			'catid' => 1,
+			'catid' => 2,
 			'articletext' => 'A dummy article to save to the database',
 			'metakey' => '',
 			'metadesc' => '',


### PR DESCRIPTION
We've had issues with the system tests lately. While the specific issue is not precisely known, this fixes one error in the test. The catid with ID 1 is the root node and is not allowed to be used. catid 2 is the ID of uncategorised and should at least reduce the errors given.

While this fixes one error, this also masks the issue that you can provoke an uncaught error by sending a 1 for catid. What to do, what to do?