### PR TITLE
[4.0] com_tags options

### DIFF
--- a/administrator/templates/atum/scss/pages/_com_tags.scss
+++ b/administrator/templates/atum/scss/pages/_com_tags.scss
@@ -1,7 +1,9 @@
 .com_tags {
 	#fieldset-image-intro,
 	#fieldset-image-fulltext {
-		grid-template-columns: 1fr;
+		> div {
+			grid-template-columns: 1fr;
+		}
 		@include media-breakpoint-up(md) {
 			width: calc(50% - 15px);
 			display: inline-block;


### PR DESCRIPTION
Fix the css so that the image  fields are displayed in one column as intended


### Before
![image](https://user-images.githubusercontent.com/1296369/63650122-1757ae00-c73f-11e9-9ee0-bcd84063fe06.png)


### After
![image](https://user-images.githubusercontent.com/1296369/63650104-e7a8a600-c73e-11e9-8e1b-ccaae5a9b05c.png)
