### PR TITLE
[4.0] edit banner missing div

### DIFF
--- a/administrator/components/com_banners/tmpl/banner/edit.php
+++ b/administrator/components/com_banners/tmpl/banner/edit.php
@@ -63,7 +63,7 @@ HTMLHelper::_('script', 'com_contenthistory/admin-history-versions.js', ['versio
 			<fieldset id="fieldset-otherparams" class="form-no-margin options-grid-form">
 				<legend><?php echo Text::_('COM_BANNERS_GROUP_LABEL_BANNER_DETAILS'); ?></legend>
 				<div>
-				<?php echo $this->form->renderFieldset('otherparams'); ?>
+					<?php echo $this->form->renderFieldset('otherparams'); ?>
 				</div>
 			</fieldset>
 		<?php echo HTMLHelper::_('uitab.endTab'); ?>
@@ -73,7 +73,9 @@ HTMLHelper::_('script', 'com_contenthistory/admin-history-versions.js', ['versio
 			<div class="col-md-6">
 				<fieldset id="fieldset-publishingdata" class="options-grid-form options-grid-form-full">
 					<legend><?php echo Text::_('JGLOBAL_FIELDSET_PUBLISHING'); ?></legend>
-					<?php echo LayoutHelper::render('joomla.edit.publishingdata', $this); ?>
+					<div>
+						<?php echo LayoutHelper::render('joomla.edit.publishingdata', $this); ?>
+					</div>
 				</fieldset>
 			</div>
 			<div class="col-md-6">


### PR DESCRIPTION
The publishing fields are missing a tab which results in the label and input being misaligned.


### Before
![image](https://user-images.githubusercontent.com/1296369/63650904-a2d53d00-c747-11e9-8516-95a260209fbd.png)

### After
![image](https://user-images.githubusercontent.com/1296369/63650890-89cc8c00-c747-11e9-96f9-6b6b8b5c3306.png)
