### PR TITLE
[4.0] User select button

### DIFF
--- a/administrator/templates/atum/scss/blocks/_form.scss
+++ b/administrator/templates/atum/scss/blocks/_form.scss
@@ -146,7 +146,12 @@ legend {
     color: var(--atum-special-color);
     margin-bottom: 0;
 }
+
 [class^="icon-"]:not(.input-group-text),
 [class*=" icon-"]:not(.input-group-text) {
   margin-right: 0.5em;
+}
+
+joomla-field-user [class*=" icon-"]:not(.input-group-text) {
+  margin-right: 0;
 }


### PR DESCRIPTION
As can be seen from the screenshots the user select button is too wide. This was because it was picking up the css used when there is text and an icon such as with the select category button

### Before
![image](https://user-images.githubusercontent.com/1296369/63651984-b043f480-c752-11e9-82ef-2287d76c2b85.png)


### After
![image](https://user-images.githubusercontent.com/1296369/63651970-69ee9580-c752-11e9-9646-10ecfcc51788.png)
