### PR TITLE
[4.0] ContentHelper prepared statements

### DIFF
--- a/libraries/src/Helper/ContentHelper.php
+++ b/libraries/src/Helper/ContentHelper.php
@@ -68,7 +68,7 @@ class ContentHelper
 
 		$usesWorkflows = (isset($config->uses_workflows) && $config->uses_workflows === true);
 
-			// Index category objects by their ID
+		// Index category objects by their ID
 		$records = array();
 
 		foreach ($items as $item)
@@ -86,28 +86,31 @@ class ContentHelper
 		}
 
 		// Table alias for related data table below will be 'c', and state / condition column is inside related data table
-		$related_tbl = $db->quoteName('#__' . $config->related_tbl, 'c');
-		$state_col_prefix = $usesWorkflows ? 's.' : 'c.';
-		$state_col   = $db->quoteName($state_col_prefix . $config->state_col);
+		$related_tbl = '#__' . $config->related_tbl;
+		$state_col   = ($usesWorkflows ? 's.' : 'c.') . $config->state_col;
 
 		// Supported cases
 		switch ($config->relation_type)
 		{
 			case 'tag_assigments':
-				$recid_col = $db->quoteName('ct.' . $config->group_col);
+				$recid_col = 'ct.' . $config->group_col;
 
 				$query = $db->getQuery(true)
 					->from($db->quoteName('#__contentitem_tag_map', 'ct'))
-					->join('INNER', $related_tbl . ' ON ' . $db->quoteName('ct.content_item_id') . ' = ' . $db->quoteName('c.id') . ' AND ' .
-						$db->quoteName('ct.type_alias') . ' = ' . $db->quote($config->extension)
-					);
+					->join(
+						'INNER',
+						$db->quoteName($related_tbl, 'c'),
+						$db->quoteName('ct.content_item_id') . ' = ' . $db->quoteName('c.id')
+						. ' AND ' . $db->quoteName('ct.type_alias') . ' = :extension'
+					)
+					->bind(':extension', $config->extension);
 				break;
 
 			case 'category_or_group':
-				$recid_col = $db->quoteName('c.' . $config->group_col);
+				$recid_col = 'c.' . $config->group_col;
 
 				$query = $db->getQuery(true)
-					->from($related_tbl);
+					->from($db->quoteName($related_tbl, 'c'));
 				break;
 
 			default:
@@ -119,8 +122,9 @@ class ContentHelper
 			$query->from($db->quoteName('#__workflow_stages', 's'))
 				->from($db->quoteName('#__workflow_associations', 'a'))
 				->where($db->quoteName('s.id') . ' = ' . $db->quoteName('a.stage_id'))
-				->where($db->quoteName('a.extension') . '= ' . $db->quote($config->workflows_component))
-				->where($db->quoteName('a.item_id') . ' = ' . $db->quoteName('c.id'));
+				->where($db->quoteName('a.extension') . ' = :component')
+				->where($db->quoteName('a.item_id') . ' = ' . $db->quoteName('c.id'))
+				->bind(':component', $config->workflows_component);
 		}
 
 		/**
@@ -128,10 +132,12 @@ class ContentHelper
 		 * NOTE: 'state IN', allows counting specific states / conditions only, also prevents warnings with custom states / conditions, do not remove
 		 */
 		$query
-			->select($recid_col . ' AS catid, ' . $state_col . ' AS state, COUNT(*) AS count')
-			->where($recid_col . ' IN (' . implode(',', array_keys($records)) . ')')
-			->where($state_col . ' IN (' . implode(',', array_keys($counter_names)) . ')')
-			->group($recid_col . ', ' . $state_col);
+			->select($db->quoteName($recid_col, 'catid'))
+			->select($db->quoteName($state_col, 'state'))
+			->select('COUNT(*) AS ' . $db->quoteName('count'))
+			->whereIn($db->quoteName($recid_col), array_keys($records))
+			->whereIn($db->quoteName($state_col), array_keys($counter_names))
+			->group($db->quoteName([$recid_col, $state_col]));
 
 		$relationsAll = $db->setQuery($query)->loadObjectList();
 
@@ -257,9 +263,10 @@ class ContentHelper
 	{
 		$db    = Factory::getDbo();
 		$query = $db->getQuery(true)
-			->select('lang_id')
-			->from('#__languages')
-			->where($db->quoteName('lang_code') . ' = ' . $db->quote($langCode));
+			->select($db->quoteName('lang_id'))
+			->from($db->quoteName('#__languages'))
+			->where($db->quoteName('lang_code') . ' = :language')
+			->bind(':language', $langCode);
 		$db->setQuery($query);
 
 		return $db->loadResult();

--- a/libraries/src/Helper/ContentHelper.php
+++ b/libraries/src/Helper/ContentHelper.php
@@ -119,11 +119,19 @@ class ContentHelper
 
 		if ($usesWorkflows)
 		{
-			$query->from($db->quoteName('#__workflow_stages', 's'))
-				->from($db->quoteName('#__workflow_associations', 'a'))
-				->where($db->quoteName('s.id') . ' = ' . $db->quoteName('a.stage_id'))
-				->where($db->quoteName('a.extension') . ' = :component')
-				->where($db->quoteName('a.item_id') . ' = ' . $db->quoteName('c.id'))
+			$query->from(
+				[
+					$db->quoteName('#__workflow_stages', 's'),
+					$db->quoteName('#__workflow_associations', 'a'),
+				]
+			)
+				->where(
+					[
+						$db->quoteName('s.id') . ' = ' . $db->quoteName('a.stage_id'),
+						$db->quoteName('a.extension') . ' = :component',
+						$db->quoteName('a.item_id') . ' = ' . $db->quoteName('c.id'),
+					]
+				)
 				->bind(':component', $config->workflows_component);
 		}
 
@@ -132,9 +140,13 @@ class ContentHelper
 		 * NOTE: 'state IN', allows counting specific states / conditions only, also prevents warnings with custom states / conditions, do not remove
 		 */
 		$query
-			->select($db->quoteName($recid_col, 'catid'))
-			->select($db->quoteName($state_col, 'state'))
-			->select('COUNT(*) AS ' . $db->quoteName('count'))
+			->select(
+				[
+					$db->quoteName($recid_col, 'catid'),
+					$db->quoteName($state_col, 'state'),
+					'COUNT(*) AS ' . $db->quoteName('count'),
+				]
+			)
 			->whereIn($db->quoteName($recid_col), array_keys($records))
 			->whereIn($db->quoteName($state_col), array_keys($counter_names))
 			->group($db->quoteName([$recid_col, $state_col]));


### PR DESCRIPTION
### Summary of Changes

Adds prepared statements to `Joomla\CMS\Helper\ContentHelper`.

### Testing Instructions

Install sample data.
Go to article categories view in backend. Inspect item count.
Go to tags view in backend. Under `Select Tag Type` in search tools select `Article`. Inspect item count.

### Expected result

Works like before.

### Documentation Changes Required

No.