### PR TITLE
[4.0] Fix Class 'Uri' not found

### DIFF
--- a/administrator/templates/atum/html/layouts/chromes/body.php
+++ b/administrator/templates/atum/html/layouts/chromes/body.php
@@ -12,6 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
+use Joomla\CMS\Uri\Uri;
 
 $module  = $displayData['module'];
 $params  = $displayData['params'];


### PR DESCRIPTION
### Summary of Changes

Add `use Joomla\CMS\Uri\Uri;` to the `body` chrome to prevent an undefined class error

### Testing Instructions

Code review
