### PR TITLE
[4.0] Search button in the toolbar

### DIFF
--- a/administrator/templates/atum/scss/blocks/_toolbar.scss
+++ b/administrator/templates/atum/scss/blocks/_toolbar.scss
@@ -331,13 +331,6 @@ joomla-toolbar-button {
 }
 
 .btn-toolbar{
-
-  .input-group-append {
-    .btn-primary {
-      background-color: var(--atum-bg-dark-70);
-      color:rgba(255,255,255,0.90);
-    }
-  }
   > joomla-toolbar-button,
   > .btn-group {
     @include media-breakpoint-down(lg) {


### PR DESCRIPTION
Removes the css that changed the colour of the search button in the toolbar - it is not consistent with the blue used elsewhere in the toolbar such as list and direction
