### PR TITLE
[4.0] Fix language constant

### DIFF
--- a/administrator/modules/mod_frontend/mod_frontend.xml
+++ b/administrator/modules/mod_frontend/mod_frontend.xml
@@ -8,7 +8,7 @@
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>4.0.0</version>
-	<description>MOD_STATUS_FRONTEND_XML_DESCRIPTION</description>
+	<description>MOD_FRONTEND_XML_DESCRIPTION</description>
 	<files>
 		<filename module="mod_frontend">mod_frontend.php</filename>
 		<folder>tmpl</folder>


### PR DESCRIPTION
Pull Request for Issue #25959.

### Summary of Changes
Fix language constant.

### Testing Instructions
1. Log in into Joomla 4.x Alpha 12dev administration
2. Click on Add Module to the Dashboard in any admin dashboard

### Actual result
String not translated.
