### PR TITLE
[4.0] Align Batch label in Actions dropdown

### DIFF
--- a/libraries/src/Toolbar/Button/PopupButton.php
+++ b/libraries/src/Toolbar/Button/PopupButton.php
@@ -65,7 +65,7 @@ class PopupButton extends ToolbarButton
 	 */
 	protected function prepareOptions(array &$options)
 	{
-		$options['icon'] = $options['icon'] ?? 'fa fa-square';
+		$options['icon'] = $options['icon'] ?? 'icon-square';
 
 		parent::prepareOptions($options);
 


### PR DESCRIPTION
### Summary of Changes
Replace Fontawesome icon to fix Batch label alignment in Actions dropdown


### Testing Instructions
Go to Content > Articles
Select an article
Click `Actions` dropdown
`Batch` is misaligned



