### PR TITLE
Added deprecated JArchive class to classmap

### DIFF
--- a/libraries/classmap.php
+++ b/libraries/classmap.php
@@ -435,3 +435,5 @@ JLoader::registerAlias('JStringController',                 '\\Joomla\\CMS\\File
 JLoader::registerAlias('JFilesystemWrapperFile',            '\\Joomla\\CMS\\Filesystem\\Wrapper\\FileWrapper', '5.0');
 JLoader::registerAlias('JFilesystemWrapperFolder',          '\\Joomla\\CMS\\Filesystem\\Wrapper\\FolderWrapper', '5.0');
 JLoader::registerAlias('JFilesystemWrapperPath',            '\\Joomla\\CMS\\Filesystem\\Wrapper\\PathWrapper', '5.0');
+
+JLoader::registerAlias('JArchive',                          '\\Joomla\\Archive\\Archive', '4.0');


### PR DESCRIPTION
Pull Request for Issue: 
The JArchive class has been marked deprecated for Joomla 4.0 but it's not listed in libraries/classmap.php

### Summary of Changes
This PR adds JArchive to libraries/classmap.php
