### PR TITLE
[4.0] Reset controller name in administrator's com_login

### DIFF
--- a/administrator/components/com_login/Dispatcher/Dispatcher.php
+++ b/administrator/components/com_login/Dispatcher/Dispatcher.php
@@ -37,6 +37,9 @@ class Dispatcher extends ComponentDispatcher
 			$this->input->set('task', '');
 		}
 
+		// Reset controller name
+		$this->input->set('controller', null);
+
 		parent::dispatch();
 	}
 


### PR DESCRIPTION
### Summary of Changes

`Joomla\CMS\Application\AdministratorApplication::findOption` method changes value of `option` to `com_login` for expired sessions, but it keeps other query params. That's why controller should be reset there to avoid "Invalid controller class: ..." error message displayed in the case of such a `findOption`-redirecting from actual extension page with specified `controller` in the URL.

### Testing Instructions

In the `/administrator` area, open any 3rdparty extension page with specified `controller` parameter in the URL and clear cookies (or wait for session cookie expiration), and then refresh the page.

### Expected result

Login form is displayed.

### Actual result

"Invalid controller class: ..." message is displayed.

### Comments

Core components are not affected as they are not use multiple display controllers.