### PR TITLE
[3.10] Remove random links from updater view

### DIFF
--- a/administrator/components/com_joomlaupdate/views/default/tmpl/default_update.php
+++ b/administrator/components/com_joomlaupdate/views/default/tmpl/default_update.php
@@ -29,10 +29,7 @@ defined('_JEXEC') or die;
 				<?php echo '&#x200E;' . $this->updateInfo['installed']; ?>
 			</td>
 		</tr>
-		<tr>- New Joomla! Installations [.tar.bz2](https://github.com/joomla/joomla-cms/releases/download/3.9.7/Joomla_3.9.7-Stable-Full_Package.tar.bz2) | [.tar.gz](https://github.com/joomla/joomla-cms/releases/download/3.9.7/Joomla_3.9.7-Stable-Full_Package.tar.gz) | [.zip](https://github.com/joomla/joomla-cms/releases/download/3.9.7/Joomla_3.9.7-Stable-Full_Package.zip)
-- Update from Joomla! 3.9.6 [.tar.bz2](https://github.com/joomla/joomla-cms/releases/download/3.9.7/Joomla_3.9.6_to_3.9.7-Stable-Patch_Package.tar.bz2) | [.tar.gz](https://github.com/joomla/joomla-cms/releases/download/3.9.7/Joomla_3.9.6_to_3.9.7-Stable-Patch_Package.tar.gz) | [.zip](https://github.com/joomla/joomla-cms/releases/download/3.9.7/Joomla_3.9.6_to_3.9.7-Stable-Patch_Package.zip)
-- Update from Joomla! 3.9.x [.tar.bz2](https://github.com/joomla/joomla-cms/releases/download/3.9.7/Joomla_3.9.x_to_3.9.7-Stable-Patch_Package.tar.bz2) | [.tar.gz](https://github.com/joomla/joomla-cms/releases/download/3.9.7/Joomla_3.9.x_to_3.9.7-Stable-Patch_Package.tar.gz) | [.zip](https://github.com/joomla/joomla-cms/releases/download/3.9.7/Joomla_3.9.x_to_3.9.7-Stable-Patch_Package.zip)
-- Update from Joomla! 2.5 or previous 3.x releases [.tar.bz2](https://github.com/joomla/joomla-cms/releases/download/3.9.7/Joomla_3.9.7-Stable-Update_Package.tar.bz2) | [.tar.gz](https://github.com/joomla/joomla-cms/releases/download/3.9.7/Joomla_3.9.7-Stable-Update_Package.tar.gz) | [.zip](https://github.com/joomla/joomla-cms/releases/download/3.9.7/Joomla_3.9.7-Stable-Update_Package.zip)
+		<tr>
 			<td>
 				<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_LATEST'); ?>
 			</td>


### PR DESCRIPTION
### Summary of Changes

Remove random links from updater view introduced possibly by mistake here: https://github.com/joomla/joomla-cms/commit/0cb5283862beb6521736f257bba20cff61673ba2 cc @HLeithner 

### Testing Instructions

- install 3.10
- apply this patch: https://github.com/joomla/joomla-cms/pull/26079
- use this update server: https://www.jah-tz.de/downloads/core/nightlies/next_major_list.xml
- try to install the update

### Expected result

![image](https://user-images.githubusercontent.com/2596554/63987005-b6313100-cad6-11e9-8242-0f689268ff5d.png)

### Actual result

![image](https://user-images.githubusercontent.com/2596554/63986981-9dc11680-cad6-11e9-9cee-ae65906e1faf.png)

### Documentation Changes Required

none