### PR TITLE
Consistent "name" value in language manifest

### DIFF
--- a/administrator/language/en-GB/en-GB.xml
+++ b/administrator/language/en-GB/en-GB.xml
@@ -10,7 +10,7 @@
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<description><![CDATA[en-GB administrator language]]></description>
 	<metadata>
-		<name>English (en-GB)</name>
+		<name>English (United Kingdom)</name>
 		<nativeName>English (United Kingdom)</nativeName>
 		<tag>en-GB</tag>
 		<rtl>0</rtl>

--- a/language/en-GB/en-GB.xml
+++ b/language/en-GB/en-GB.xml
@@ -10,7 +10,7 @@
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<description><![CDATA[en-GB site language]]></description>
 	<metadata>
-		<name>English (en-GB)</name>
+		<name>English (United Kingdom)</name>
 		<nativeName>English (United Kingdom)</nativeName>
 		<tag>en-GB</tag>
 		<rtl>0</rtl>

--- a/tests/unit/suites/libraries/joomla/language/JLanguageTest.php
+++ b/tests/unit/suites/libraries/joomla/language/JLanguageTest.php
@@ -832,7 +832,7 @@ class JLanguageTest extends \PHPUnit\Framework\TestCase
 
 		// Note: property = name, returns English (en-GB) (default language)
 		$this->assertEquals(
-			'English (en-GB)',
+			'English (United Kingdom)',
 			$this->object->get('name')
 		);
 	}
@@ -845,7 +845,7 @@ class JLanguageTest extends \PHPUnit\Framework\TestCase
 	public function testGetName()
 	{
 		$this->assertEquals(
-			'English (en-GB)',
+			'English (United Kingdom)',
 			$this->object->getName()
 		);
 	}
@@ -1031,7 +1031,7 @@ class JLanguageTest extends \PHPUnit\Framework\TestCase
 		// In this case, returns array with default language
 		// - same operation of get method with metadata property
 		$options = array(
-			'name'       => 'English (en-GB)',
+			'name'       => 'English (United Kingdom)',
 			'nativeName' => 'English (United Kingdom)',
 			'tag'        => 'en-GB',
 			'rtl'        => '0',


### PR DESCRIPTION
The translators were asked to make the "name" tag in the language manifest files consistent with the "nativeName" one. The latter being a translation of the former (english) one.

### Summary of Changes
Changes `<name>` tag in en-GB.xml files to "English (United Kingdom)"


### Testing Instructions
Review should be enough.
