### PR TITLE
[4.0] Moving Toggle Editor to top

### DIFF
--- a/administrator/templates/atum/scss/blocks/_form.scss
+++ b/administrator/templates/atum/scss/blocks/_form.scss
@@ -155,3 +155,8 @@ legend {
 joomla-field-user [class*=" icon-"]:not(.input-group-text) {
   margin-right: 0;
 }
+
+html[dir=rtl] .toggle-tiny {
+  margin-right: 0;
+  padding-left: 1.5rem;
+}

--- a/layouts/joomla/tinymce/togglebutton.php
+++ b/layouts/joomla/tinymce/togglebutton.php
@@ -14,12 +14,12 @@ use Joomla\CMS\Language\Text;
 $name = $displayData;
 
 ?>
-<div class="toggle-editor btn-toolbar float-right clearfix mt-3">
+<div class="toggle-editor btn-toolbar clearfix mt-3">
 	<div class="btn-group">
 		<button type="button" class="btn btn-secondary" href="#"
 			onclick="tinyMCE.execCommand('mceToggleEditor', false, '<?php echo $name; ?>');return false;"
 		>
-			<span class="icon-eye" aria-hidden="true"></span>
+			<span class="toggle-tiny icon-eye" aria-hidden="true"></span>
 			<?php echo Text::_('PLG_TINY_BUTTON_TOGGLE_EDITOR'); ?>
 		</button>
 	</div>

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -129,9 +129,9 @@ class PlgEditorTinymce extends CMSPlugin
 		$textarea->readonly = !empty($params['readonly']);
 
 		// Render Editor markup
-		$editor = '<div class="js-editor-tinymce">';
+		$editor = $this->_toogleButton($id);
+		$editor .= '<div class="js-editor-tinymce">';
 		$editor .= LayoutHelper::render('joomla.tinymce.textarea', $textarea);
-		$editor .= $this->_toogleButton($id);
 		$editor .= '</div>';
 
 		// Prepare the instance specific options, actually the ext-buttons


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/24076

### Summary of Changes
Modifying order and place Toggle Editor button to top of textarea, next to the other Tiny buttons.
Correcting rtl button display in backend.


### Testing Instructions
Apply patch and edit an article with TinyMce in backend and frontend


### After patch
**LTR**
<img width="931" alt="Screen Shot 2019-08-31 at 18 10 12" src="https://user-images.githubusercontent.com/869724/64066557-9bb4a000-cc1b-11e9-98ef-0125d51dde18.png">
<img width="1145" alt="Screen Shot 2019-08-31 at 18 09 35" src="https://user-images.githubusercontent.com/869724/64066558-9bb4a000-cc1b-11e9-9da0-50a2a836dc77.png">

**RTL**
<img width="864" alt="Screen Shot 2019-08-31 at 18 08 30" src="https://user-images.githubusercontent.com/869724/64066564-b25af700-cc1b-11e9-9836-4ba30c130308.png">
<img width="1225" alt="Screen Shot 2019-08-31 at 18 08 13" src="https://user-images.githubusercontent.com/869724/64066565-b25af700-cc1b-11e9-8506-2d823812b453.png">
