### PR TITLE
[4.0] com_workflows actions button

### DIFF
--- a/administrator/components/com_workflow/View/Stages/HtmlView.php
+++ b/administrator/components/com_workflow/View/Stages/HtmlView.php
@@ -185,8 +185,8 @@ class HtmlView extends BaseHtmlView
 				$dropdown = $toolbar->dropdownButton('status-group')
 					->text('JTOOLBAR_CHANGE_STATUS')
 					->toggleSplit(false)
-					->icon('fa fa-globe')
-					->buttonClass('btn btn-info')
+					->icon('fa fa-ellipsis-h')
+					->buttonClass('btn btn-action')
 					->listCheck(true);
 
 				$childBar = $dropdown->getChildToolbar();

--- a/administrator/components/com_workflow/View/Transitions/HtmlView.php
+++ b/administrator/components/com_workflow/View/Transitions/HtmlView.php
@@ -173,8 +173,8 @@ class HtmlView extends BaseHtmlView
 				$dropdown = $toolbar->dropdownButton('status-group')
 					->text('JTOOLBAR_CHANGE_STATUS')
 					->toggleSplit(false)
-					->icon('fa fa-globe')
-					->buttonClass('btn btn-info')
+					->icon('fa fa-ellipsis-h')
+					->buttonClass('btn btn-action')
 					->listCheck(true);
 
 				$childBar = $dropdown->getChildToolbar();


### PR DESCRIPTION
The actions button on the stages and transitions pages is using the wrong icon and the wrong class so the hover and active styling is also messed up

### after
![image](https://user-images.githubusercontent.com/1296369/64069029-3f607900-cc39-11e9-96ee-8671ca94c4c8.png)
