### PR TITLE
[4.0] Creation date format

### DIFF
--- a/administrator/templates/atum/templateDetails.xml
+++ b/administrator/templates/atum/templateDetails.xml
@@ -2,7 +2,7 @@
 <extension version="4.0" type="template" client="administrator">
 	<name>atum</name>
 	<version>1.0</version>
-	<creationDate>16/09/2016</creationDate>
+	<creationDate>September 2016</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<copyright>Copyright (C) 2005 - 2019 Open Source Matters, Inc. All rights reserved.</copyright>

--- a/plugins/installer/webinstaller/webinstaller.xml
+++ b/plugins/installer/webinstaller/webinstaller.xml
@@ -2,7 +2,7 @@
 <extension version="3.2" type="plugin" group="installer" method="upgrade">
 	<name>plg_installer_webinstaller</name>
 	<author>Joomla! Project</author>
-	<creationDate>28 April 2017</creationDate>
+	<creationDate>April 2017</creationDate>
 	<copyright>Copyright (C) 2013-2017 Open Source Matters. All rights reserved.</copyright>
 	<license>http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL</license>
 	<authorEmail>admin@joomla.org</authorEmail>

--- a/plugins/system/skipto/skipto.xml
+++ b/plugins/system/skipto/skipto.xml
@@ -2,7 +2,7 @@
 <extension version="4.0" type="plugin" group="system" method="upgrade">
 	<name>plg_system_skipto</name>
 	<author>Joomla! Project</author>
-	<creationDate>2019-2-27</creationDate>
+	<creationDate>February 2019</creationDate>
 	<copyright>(C) 2005 - 2019 Open Source Matters. All rights reserved.</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>admin@joomla.org</authorEmail>

--- a/templates/cassiopeia/templateDetails.xml
+++ b/templates/cassiopeia/templateDetails.xml
@@ -2,7 +2,7 @@
 <extension version="4.0" type="template" client="site">
 	<name>cassiopeia</name>
 	<version>1.0</version>
-	<creationDate>30/02/2017</creationDate>
+	<creationDate>February 2017</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<copyright>Copyright (C) 2005 - 2019 Open Source Matters, Inc. All rights reserved.</copyright>


### PR DESCRIPTION
All the core _extensions_ created by Joomla use the date format of "Month Year" for the created date which is displayed in extensions->manage

This simple PR corrects a few that were not in that format

### Testing
Apply the pr and then you will need to rebuild the cache in extensions>manage
