### PR TITLE
[4.0] Category field notices

### DIFF
--- a/administrator/components/com_categories/Field/CategoryeditField.php
+++ b/administrator/components/com_categories/Field/CategoryeditField.php
@@ -364,6 +364,7 @@ class CategoryeditField extends ListField
 
 		$data['options']        = $this->getOptions();
 		$data['allowCustom']    = $this->allowAdd;
+		$data['customPrefix']   = $this->customPrefix;
 		$data['refreshPage']    = (boolean) $this->element['refresh-enabled'];
 		$data['refreshCatId']   = (string) $this->element['refresh-cat-id'];
 		$data['refreshSection'] = (string) $this->element['refresh-section'];

--- a/administrator/components/com_categories/layouts/joomla/form/field/categoryedit.php
+++ b/administrator/components/com_categories/layouts/joomla/form/field/categoryedit.php
@@ -72,9 +72,9 @@ if ($allowCustom)
 {
 	$attr2 .= ' allow-custom';
 
-	if ($this->customPrefix !== '')
+	if ($customPrefix !== '')
 	{
-		$attr2 .= ' data-custom_value_prefix="' . $this->customPrefix . '" ';
+		$attr2 .= ' new-item-prefix="' . $customPrefix . '" ';
 	}
 }
 

--- a/administrator/components/com_categories/layouts/joomla/form/field/categoryedit.php
+++ b/administrator/components/com_categories/layouts/joomla/form/field/categoryedit.php
@@ -46,6 +46,7 @@ extract($displayData);
  * @var   array    $options         Options available for this field.
  * @var   array    $inputType       Options available for this field.
  * @var   string   $accept          File types that are accepted.
+ * @var   string   $customPrefix    Optional prefix for new categories.
  */
 
 $html    = array();

--- a/administrator/components/com_content/Model/ArticleModel.php
+++ b/administrator/components/com_content/Model/ArticleModel.php
@@ -780,8 +780,6 @@ class ArticleModel extends AdminModel
 			$data['images'] = (string) $registry;
 		}
 
-		\JLoader::register('CategoriesHelper', JPATH_ADMINISTRATOR . '/components/com_categories/helpers/categories.php');
-
 		// Create new category, if needed.
 		$createCategory = true;
 


### PR DESCRIPTION
Pull Request for Issue #26113.

### Summary of Changes

Fixes notices in category edit field.

### Testing Instructions

Edit an article.

### Expected result

No notices.

### Actual result

> Notice: Undefined property: Joomla\CMS\Layout\FileLayout::$customPrefix in administrator\components\com_categories\layouts\joomla\form\field\categoryedit.php on line 75
> Notice: Undefined property: Joomla\CMS\Layout\FileLayout::$customPrefix in administrator\components\com_categories\layouts\joomla\form\field\categoryedit.php on line 77

### Documentation Changes Required

No.