### PR TITLE
[4.0] disabled navigation buttons

### DIFF
--- a/administrator/templates/atum/scss/blocks/_layout.scss
+++ b/administrator/templates/atum/scss/blocks/_layout.scss
@@ -17,8 +17,8 @@
   }
 
   &.disabled {
-	color: var(--atum-bg-dark-10);
-	cursor: not-allowed;
+    color: var(--atum-bg-dark-10);
+    cursor: not-allowed;
 
     &:hover {
       background: transparent;

--- a/administrator/templates/atum/scss/blocks/_layout.scss
+++ b/administrator/templates/atum/scss/blocks/_layout.scss
@@ -17,7 +17,8 @@
   }
 
   &.disabled {
-    color: var(--atum-text-dark);
+	color: var(--atum-bg-dark-10);
+	cursor: not-allowed;
 
     &:hover {
       background: transparent;


### PR DESCRIPTION
The disabled page navigation buttons had black text which when compared to the enabled buttons with blue text did not indicate that it was disabled as it was hard to see the difference.
### before
![image](https://user-images.githubusercontent.com/1296369/64110649-a5a0e500-cd7a-11e9-9b45-589c05b08eea.png)


### after
![image](https://user-images.githubusercontent.com/1296369/64110610-8b670700-cd7a-11e9-947f-691fed90b5f1.png)
