### PR TITLE
[4.0] Multilingual associations - notices

### DIFF
--- a/administrator/components/com_associations/View/Associations/HtmlView.php
+++ b/administrator/components/com_associations/View/Associations/HtmlView.php
@@ -82,10 +82,6 @@ class HtmlView extends BaseHtmlView
 			$link = Route::_('index.php?option=com_plugins&task=plugin.edit&extension_id=' . AssociationsHelper::getLanguagefilterPluginId());
 			Factory::getApplication()->enqueueMessage(Text::sprintf('COM_ASSOCIATIONS_ERROR_NO_ASSOC', $link), 'warning');
 		}
-		elseif ($this->state->get('itemtype') == '' || $this->state->get('language') == '')
-		{
-			Factory::getApplication()->enqueueMessage(Text::_('COM_ASSOCIATIONS_NOTICE_NO_SELECTORS'), 'notice');
-		}
 		else
 		{
 			$type = null;

--- a/administrator/components/com_associations/View/Associations/HtmlView.php
+++ b/administrator/components/com_associations/View/Associations/HtmlView.php
@@ -82,7 +82,7 @@ class HtmlView extends BaseHtmlView
 			$link = Route::_('index.php?option=com_plugins&task=plugin.edit&extension_id=' . AssociationsHelper::getLanguagefilterPluginId());
 			Factory::getApplication()->enqueueMessage(Text::sprintf('COM_ASSOCIATIONS_ERROR_NO_ASSOC', $link), 'warning');
 		}
-		else
+		elseif ($this->state->get('itemtype') != '' && $this->state->get('language') != '')
 		{
 			$type = null;
 

--- a/administrator/components/com_associations/tmpl/associations/default.php
+++ b/administrator/components/com_associations/tmpl/associations/default.php
@@ -37,7 +37,12 @@ HTMLHelper::_('script', 'com_associations/admin-associations-default.min.js', ['
 		<div class="col-md-12">
 			<div id="j-main-container" class="j-main-container">
 				<?php echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
-				<?php if (empty($this->items)) : ?>
+				<?php if ($this->state->get('itemtype') == '' || $this->state->get('language') == '') : ?>
+					<div class="alert alert-info">
+						<span class="fa fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+						<?php echo Text::_('COM_ASSOCIATIONS_NOTICE_NO_SELECTORS'); ?>
+					</div>
+				<?php elseif (empty($this->items)) : ?>
 					<div class="alert alert-info">
 						<span class="fa fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 						<?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>


### PR DESCRIPTION
It's really annoying to have the alert popping up constantly

This pr moves it from an alert to an inline message

### Before
![mla2](https://user-images.githubusercontent.com/1296369/64117658-a4c57e80-cd8d-11e9-9794-3ad911595dae.gif)

### After
![mla](https://user-images.githubusercontent.com/1296369/64117719-cd4d7880-cd8d-11e9-8bc6-aade61a7c9b1.gif)

