### PR TITLE
[4.0] com_finder actions button

### DIFF
--- a/administrator/components/com_finder/View/Filters/HtmlView.php
+++ b/administrator/components/com_finder/View/Filters/HtmlView.php
@@ -149,8 +149,8 @@ class HtmlView extends BaseHtmlView
 			$dropdown = $toolbar->dropdownButton('status-group')
 				->text('JTOOLBAR_CHANGE_STATUS')
 				->toggleSplit(false)
-				->icon('fa fa-globe')
-				->buttonClass('btn btn-info')
+				->icon('fa fa-ellipsis-h')
+				->buttonClass('btn btn-action')
 				->listCheck(true);
 
 			$childBar = $dropdown->getChildToolbar();

--- a/administrator/components/com_finder/View/Index/HtmlView.php
+++ b/administrator/components/com_finder/View/Index/HtmlView.php
@@ -190,8 +190,8 @@ class HtmlView extends BaseHtmlView
 			$dropdown = $toolbar->dropdownButton('status-group')
 				->text('JTOOLBAR_CHANGE_STATUS')
 				->toggleSplit(false)
-				->icon('fa fa-globe')
-				->buttonClass('btn btn-info')
+				->icon('fa fa-ellipsis-h')
+				->buttonClass('btn btn-action')
 				->listCheck(true);
 
 			$childBar = $dropdown->getChildToolbar();

--- a/administrator/components/com_finder/View/Maps/HtmlView.php
+++ b/administrator/components/com_finder/View/Maps/HtmlView.php
@@ -149,8 +149,8 @@ class HtmlView extends BaseHtmlView
 			$dropdown = $toolbar->dropdownButton('status-group')
 				->text('JTOOLBAR_CHANGE_STATUS')
 				->toggleSplit(false)
-				->icon('fa fa-globe')
-				->buttonClass('btn btn-info')
+				->icon('fa fa-ellipsis-h')
+				->buttonClass('btn btn-action')
 				->listCheck(true);
 
 			$childBar = $dropdown->getChildToolbar();


### PR DESCRIPTION
same as #26105

The actions button on the smart search pages is using the wrong icon and the wrong class so the hover and active styling is also messed up
