### PR TITLE
[4.0] search stats accessibility

### DIFF
--- a/administrator/components/com_finder/View/Index/HtmlView.php
+++ b/administrator/components/com_finder/View/Index/HtmlView.php
@@ -200,7 +200,7 @@ class HtmlView extends BaseHtmlView
 			$childBar->unpublish('index.unpublish')->listCheck(true);
 		}
 
-		$toolbar->appendButton('Popup', 'bars', 'COM_FINDER_STATISTICS', 'index.php?option=com_finder&view=statistics&tmpl=component', 550, 350);
+		$toolbar->appendButton('Popup', 'bars', 'COM_FINDER_STATISTICS', 'index.php?option=com_finder&view=statistics&tmpl=component', 550, 350,'','','','COM_FINDER_STATISTICS_TITLE');
 
 		if ($canDo->get('core.delete'))
 		{

--- a/administrator/components/com_finder/View/Index/HtmlView.php
+++ b/administrator/components/com_finder/View/Index/HtmlView.php
@@ -200,7 +200,7 @@ class HtmlView extends BaseHtmlView
 			$childBar->unpublish('index.unpublish')->listCheck(true);
 		}
 
-		$toolbar->appendButton('Popup', 'bars', 'COM_FINDER_STATISTICS', 'index.php?option=com_finder&view=statistics&tmpl=component', 550, 350,'','','','COM_FINDER_STATISTICS_TITLE');
+		$toolbar->appendButton('Popup', 'bars', 'COM_FINDER_STATISTICS', 'index.php?option=com_finder&view=statistics&tmpl=component', 550, 350, '', '', '', 'COM_FINDER_STATISTICS_TITLE');
 
 		if ($canDo->get('core.delete'))
 		{

--- a/administrator/components/com_finder/tmpl/statistics/default.php
+++ b/administrator/components/com_finder/tmpl/statistics/default.php
@@ -12,10 +12,6 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Language\Text;
 
 ?>
-<h3>
-	<?php echo Text::_('COM_FINDER_STATISTICS_TITLE'); ?>
-</h3>
-
 <div class="row">
 	<div class="col-md-12">
 		<p class="tab-description"><?php echo Text::sprintf('COM_FINDER_STATISTICS_STATS_DESCRIPTION', number_format($this->data->term_count, 0, Text::_('DECIMALS_SEPARATOR'), Text::_('THOUSANDS_SEPARATOR')), number_format($this->data->link_count, 0, Text::_('DECIMALS_SEPARATOR'), Text::_('THOUSANDS_SEPARATOR')), number_format($this->data->taxonomy_node_count, 0, Text::_('DECIMALS_SEPARATOR'), Text::_('THOUSANDS_SEPARATOR')), number_format($this->data->taxonomy_branch_count, 0, Text::_('DECIMALS_SEPARATOR'), Text::_('THOUSANDS_SEPARATOR'))); ?></p>


### PR DESCRIPTION
An iframe is required to have a title. This PR ensures that there is a title for the popup that is loaded when you select Statistics on the smart search main page

### NOTE
There are lots of things wrong with the popup. Not the least the fact it is an iframe but they are all beyond the scope of this PR