### PR TITLE
[4.0] batch category accessibility

### DIFF
--- a/layouts/joomla/html/batch/item.php
+++ b/layouts/joomla/html/batch/item.php
@@ -28,7 +28,7 @@ $options = array(
 );
 HTMLHelper::_('script', 'layouts/joomla/html/batch/batch-language.min.js', ['version' => 'auto', 'relative' => true]);
 ?>
-<label id="batch-choose-action-lbl" for="batch-choose-action">
+<label id="batch-choose-action-lbl" for="batch-category-id">
 	<?php echo Text::_('JLIB_HTML_BATCH_MENU_LABEL'); ?>
 </label>
 <div id="batch-choose-action" class="control-group">


### PR DESCRIPTION
The select for changing the category in the batch actions in the article manager has the wrong id on the label

instead of being label for the select it is label for the id

this is an accessibility failure
