### PR TITLE
[4.0] batch process fields accessibility

### DIFF
--- a/administrator/components/com_fields/tmpl/fields/default_batch_body.php
+++ b/administrator/components/com_fields/tmpl/fields/default_batch_body.php
@@ -38,7 +38,9 @@ $context   = $this->escape($this->state->get('filter.context'));
 					HTMLHelper::_('select.option', 'm', Text::_('JLIB_HTML_BATCH_MOVE'))
 				);
 				?>
-				<label id="batch-choose-action-lbl" for="batch-choose-action"><?php echo Text::_('COM_FIELDS_BATCH_GROUP_LABEL'); ?></label>
+				<label id="batch-choose-action-lbl" for="batch-group-id">
+					<?php echo Text::_('COM_FIELDS_BATCH_GROUP_LABEL'); ?>
+				</label>
 				<div id="batch-choose-action" class="control-group">
 					<select name="batch[group_id]" class="custom-select" id="batch-group-id">
 						<option value=""><?php echo Text::_('JLIB_HTML_BATCH_NO_CATEGORY'); ?></option>


### PR DESCRIPTION
just like #26141 the label for= was for the wrong id for the batch move and copy

easy test is to try and click on the label. the field should be highlighted/selected if the id is correct
