### PR TITLE
[4.0] Assign module to menu

### DIFF
--- a/administrator/templates/atum/scss/vendor/bootstrap/_dropdown.scss
+++ b/administrator/templates/atum/scss/vendor/bootstrap/_dropdown.scss
@@ -22,7 +22,6 @@
 }
 
 .dropdown-item {
-  cursor: pointer;
   border-bottom: 1px solid rgba(0, 0, 0, 0.1);
 
   &:hover,
@@ -33,6 +32,7 @@
 
     .btn-secondary + .dropdown-menu & {
       background-color: theme-color("secondary");
+      color: var(--atum-text-light);
     }
 
     .btn-danger + .dropdown-menu & {


### PR DESCRIPTION
Go to the menu and try to assign it to a module and you will see the dropdown when hovered has grey on grey

### before
![mod1](https://user-images.githubusercontent.com/1296369/64133116-03a9e880-cdcc-11e9-8834-4c926b2944eb.gif)

### after
![mod2](https://user-images.githubusercontent.com/1296369/64133085-de1cdf00-cdcb-11e9-836f-952b9792e40a.gif)

