### PR TITLE
[4.0] Selected language in Backend Login has no effect (Ref #26148)

### DIFF
--- a/build/media_source/mod_login/js/admin-login.es6.js
+++ b/build/media_source/mod_login/js/admin-login.es6.js
@@ -39,6 +39,8 @@
 
           if (element.hasAttribute('name') && element.nodeName === 'INPUT') {
             segments.push(`${encodeURIComponent(element.name)}=${encodeURIComponent(element.value)}`);
+          } else if (element.hasAttribute('name') && (element.nodeName === 'SELECT') && element.value.length > 0) {
+            segments.push(`${encodeURIComponent(element.name)}=${encodeURIComponent(element.value)}`);
           }
         }
 

--- a/build/media_source/mod_login/js/admin-login.es6.js
+++ b/build/media_source/mod_login/js/admin-login.es6.js
@@ -39,7 +39,7 @@
 
           if (element.hasAttribute('name') && element.nodeName === 'INPUT') {
             segments.push(`${encodeURIComponent(element.name)}=${encodeURIComponent(element.value)}`);
-          } else if (element.hasAttribute('name') && (element.nodeName === 'SELECT') && element.value.length > 0) {
+          } else if (element.hasAttribute('name') && element.nodeName === 'SELECT' && element.value.length > 0) {
             segments.push(`${encodeURIComponent(element.name)}=${encodeURIComponent(element.value)}`);
           }
         }


### PR DESCRIPTION
Pull Request for Issue #26148.

### Summary of Changes
The login module posts now also section values if the value is not empty.


### Testing Instructions
1. Apply the patch
1. Rebuild the JavaScript (`npm run build:js`)
1. Install at least your a second language, i.e. "German"
1. Log out from the backend and open the backend login mask
1. Select another langauge as the default one, i.e. "German"
1. The backend should now be translated correctly. 
1. Log out and in again with the default language. The backend should be default translated.


### Expected result
If I selected a langauge in the login mask, this language should be the backend language for this login.

### Actual result
Change of language has no effect.


### Documentation Changes Required
As I can see, no. But I am not sure.