### PR TITLE
[4.0] Clear cache - no items

### DIFF
--- a/administrator/components/com_cache/tmpl/cache/default.php
+++ b/administrator/components/com_cache/tmpl/cache/default.php
@@ -26,7 +26,12 @@ HTMLHelper::_('script', 'com_cache/admin-cache-default.js', ['version' => 'auto'
 		<div class="col-md-12">
 			<div id="j-main-container" class="j-main-container">
 				<?php echo LayoutHelper::render('joomla.searchtools.default', ['view' => $this]); ?>
-				<?php if (count($this->data) > 0) : ?>
+				<?php if (empty($this->items)) : ?>
+					<div class="alert alert-info">
+						<span class="fa fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+						<?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
+					</div>
+				<?php else : ?>
 				<table class="table">
 					<caption id="captionTable" class="sr-only">
 						<?php echo Text::_('COM_CACHE_TABLE_CAPTION'); ?>, <?php echo Text::_('JGLOBAL_SORTED_BY'); ?>


### PR DESCRIPTION
Unlike every other list view com_cache does not display any message if there are no items - it just displays nothing.

this simple PR make com_cache consistent with all other lists

### Before
![image](https://user-images.githubusercontent.com/1296369/64175193-b58bf800-ce52-11e9-91ec-95ee19002e21.png)

### After
![image](https://user-images.githubusercontent.com/1296369/64175141-9e4d0a80-ce52-11e9-9a45-61a746de0db6.png)
