### PR TITLE
[4.0] copy paste error in comments

### DIFF
--- a/administrator/components/com_fields/Dispatcher/Dispatcher.php
+++ b/administrator/components/com_fields/Dispatcher/Dispatcher.php
@@ -16,7 +16,7 @@ use Joomla\CMS\Dispatcher\ComponentDispatcher;
 use Joomla\Component\Fields\Administrator\Helper\FieldsHelper;
 
 /**
- * ComponentDispatcher class for com_content
+ * ComponentDispatcher class for com_fields
  *
  * @since  4.0.0
  */


### PR DESCRIPTION
Comments are used to build the docs so they must be correct

code review only
