### PR TITLE
[4.0] Fix Category select is missing/broken for fields

### DIFF
--- a/administrator/components/com_fields/Model/FieldModel.php
+++ b/administrator/components/com_fields/Model/FieldModel.php
@@ -967,18 +967,16 @@ class FieldModel extends AdminModel
 				}
 				catch (SectionNotFoundException $e)
 				{
-					// Not found for component and section -> do nothing yet...
-				}
-
-				// Now try once more without the section, so only component
-				try
-				{
-					$cat = $componentObject->getCategory();
-				}
-				catch (SectionNotFoundException $e)
-				{
-					// If we haven't found it now, return (no categories available for this component)
-					return null;
+					// Not found for component and section -> Now try once more without the section, so only component
+					try
+					{
+						$cat = $componentObject->getCategory();
+					}
+					catch (SectionNotFoundException $e)
+					{
+						// If we haven't found it now, return (no categories available for this component)
+						return null;
+					}
 				}
 
 				// So we found categories for at least the component, return them

--- a/administrator/components/com_fields/Model/FieldModel.php
+++ b/administrator/components/com_fields/Model/FieldModel.php
@@ -956,7 +956,7 @@ class FieldModel extends AdminModel
 				throw new SectionNotFoundException;
 			}
 
-			$cat = $componentObject->getCategory([], $section ?: '');
+			$cat = $componentObject->getCategory();
 
 			if ($cat->get('root')->hasChildren())
 			{

--- a/administrator/components/com_fields/Model/FieldModel.php
+++ b/administrator/components/com_fields/Model/FieldModel.php
@@ -947,41 +947,44 @@ class FieldModel extends AdminModel
 		}
 
 		// Get the categories for this component (and optionally this section, if available)
-		$cat = (function() use ($component, $section) {
-			// Get the CategoryService for this component
-			$componentObject = $this->bootComponent($component);
+		$cat = (
+			function () use ($component, $section) {
+				// Get the CategoryService for this component
+				$componentObject = $this->bootComponent($component);
 
-			if (!$componentObject instanceof CategoryServiceInterface)
-			{
-				// No CategoryService -> no categories
-				return null;
-			}
+				if (!$componentObject instanceof CategoryServiceInterface)
+				{
+					// No CategoryService -> no categories
+					return null;
+				}
 
-			// Try to get the categories for this component and section
-			$cat = null;
-			try
-			{
-				$cat = $componentObject->getCategory([], $section ?: '');
-			}
-			catch (SectionNotFoundException $e)
-			{
-				// Not found for component and section -> do nothing yet...
-			}
+				$cat = null;
 
-			// Now try once more without the section, so only component
-			try
-			{
-				$cat = $componentObject->getCategory();
-			}
-			catch (SectionNotFoundException $e)
-			{
-				// If we haven't found it now, return (no categories available for this component)
-				return null;
-			}
+				// Try to get the categories for this component and section
+				try
+				{
+					$cat = $componentObject->getCategory([], $section ?: '');
+				}
+				catch (SectionNotFoundException $e)
+				{
+					// Not found for component and section -> do nothing yet...
+				}
 
-			// So we found categories for at least the component, return them
-			return $cat;
-		})();
+				// Now try once more without the section, so only component
+				try
+				{
+					$cat = $componentObject->getCategory();
+				}
+				catch (SectionNotFoundException $e)
+				{
+					// If we haven't found it now, return (no categories available for this component)
+					return null;
+				}
+
+				// So we found categories for at least the component, return them
+				return $cat;
+			}
+		)();
 
 		// If we found categories, and if the root category has children, set them in the form
 		if ($cat && $cat->get('root')->hasChildren())
@@ -990,6 +993,7 @@ class FieldModel extends AdminModel
 		}
 		else
 		{
+			// Else remove the field from the form
 			$form->removeField('assigned_cat_ids');
 		}
 


### PR DESCRIPTION
Pull Request for Issue #24782

### Summary of Changes

The problem is that we were passing $section to the category service, which always ends up bailing with a SectionNotFoundException - while we just wanted to get all categories at this point.

It basically reverts the change made to this line in commit https://github.com/joomla/joomla-cms/commit/c7789733ec2c04fecbe497391af80b149f7f0596 but that is a merge commit
and none of the merged parents have that change, and the commit does not give an explanation why
that change is needed. It is not needed at all from my point of view, so reverting it here.

This fixes #24782 and should not have any side effects, as the CategoryService is being instanciated
with a correct context (the component), so passing the $section is not needed. We want all categories.

### Testing Instructions

Try to create a new Custom Field in e.g. the Content group.

### Expected result

You should be able to set a category for that field on the right hand side.

### Actual result

Without this change, you are not able to set a category.

### Additional info

Poking @wilsonge You are the author of the original commit creating the problem, do you remember why you changed that line, and are you OK with this PR changing it back, or do you see any problems?