### PR TITLE
[4.0] Fix fields javascript failure

### DIFF
--- a/administrator/components/com_fields/Field/TypeField.php
+++ b/administrator/components/com_fields/Field/TypeField.php
@@ -77,17 +77,17 @@ class TypeField extends ListField
 			}
 		);
 
+		// Preload the Loading indication
+		HTMLHelper::_('webcomponent', 'system/joomla-core-loader.min.js', ['relative' => true, 'version' => 'auto']);
+
 		$js = <<<JS
 (function () {
   window.typeHasChanged = function(element) {
-    Joomla.loadingLayer('show');
+    // Display the loading indication
+    document.body.appendChild(document.createElement('joomla-core-loader'));
     document.querySelector('input[name=task]').value = 'field.reload';
     element.form.submit();
   };
-
-  document.addEventListener('DOMContentLaoded', function() {
-    Joomla.loadingLayer('load');
-  });
 })();
 JS;
 


### PR DESCRIPTION
Pull Request for Issue #26133

### Summary of Changes

The problem was caused by using the outdated Joomla.loadingLayer function, which was replaced by a better approach but that approach hasn't been used here yet. This commit integrates that approach.

### Testing Instructions

Try to create a Custom Field and change the Type of it.

### Expected result

The page should reload with the specific field type options available then.

### Actual result

No page reload, instead a JS error.