### PR TITLE
Fix: Creating Multilingual sample data warning when only one language is installed

### DIFF
--- a/installation/controller/setdefaultlanguage.php
+++ b/installation/controller/setdefaultlanguage.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Language\LanguageHelper;
+
 /**
  * Controller class to set the default application languages for the Joomla Installer.
  *
@@ -96,6 +98,17 @@ class InstallationControllerSetdefaultlanguage extends JControllerBase
 
 		if ((int) $data['activateMultilanguage'])
 		{
+			if (count(LanguageHelper::getInstalledLanguages(0)) < 2)
+			{
+				$app->enqueueMessage(JText::_('INSTL_DEFAULTLANGUAGE_COULD_NOT_INSTALL_MULTILANG'), 'warning');
+
+				$r = new stdClass;
+
+				// Redirect to the same page.
+				$r->view = 'defaultlanguage';
+				$app->sendJsonResponse($r);
+			}
+
 			if (!$model->enablePlugin('plg_system_languagefilter'))
 			{
 				$app->enqueueMessage(JText::sprintf('INSTL_DEFAULTLANGUAGE_COULD_NOT_ENABLE_PLG_LANGUAGEFILTER', $frontend_lang), 'warning');

--- a/installation/language/en-GB/en-GB.ini
+++ b/installation/language/en-GB/en-GB.ini
@@ -168,6 +168,7 @@ INSTL_DEFAULTLANGUAGE_COULD_NOT_ENABLE_MODULESWHITCHER_LANGUAGECODE="Joomla was 
 INSTL_DEFAULTLANGUAGE_COULD_NOT_ENABLE_PLG_LANGUAGECODE="Joomla was unable to automatically enable the Language Code Plugin."
 INSTL_DEFAULTLANGUAGE_COULD_NOT_ENABLE_PLG_LANGUAGEFILTER="Joomla was unable to automatically enable the Language Filter Plugin."
 INSTL_DEFAULTLANGUAGE_COULD_NOT_INSTALL_LANGUAGE="Joomla was unable to install %s language."
+INSTL_DEFAULTLANGUAGE_COULD_NOT_INSTALL_MULTILANG="Joomla was unable to install the multilingual sample data as only one language is installed. To activate the multilingual feature, you need to install more languages, press the 'Previous' button and choose the desired languages from the list."
 INSTL_DEFAULTLANGUAGE_COULD_NOT_PUBLISH_MOD_MULTILANGSTATUS="Joomla was unable to automatically publish the language status module."
 INSTL_DEFAULTLANGUAGE_COULD_NOT_UNPUBLISH_MOD_DEFAULTMENU="Joomla was unable to automatically unpublish the default menu module."
 INSTL_DEFAULTLANGUAGE_DESC="Joomla has installed the following languages. Please select your desired default language for the Joomla Administrator."


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/26139

### Summary of Changes
See title.


### Testing Instructions
Patch.
Install a new staging.
During installation, when getting to `Install Language packages`, DO NOT INSTALL any language, click Next.
Set `Activate the multilingual feature` to Yes. Click Next.


### Before patch
The installation proceeds without any error.

### After patch
A Warning is displayed and the user can act accordingly.
The `Activate the multilingual feature` is reset to `No`

<img width="1176" alt="Screen Shot 2019-09-04 at 10 45 39" src="https://user-images.githubusercontent.com/869724/64240263-ee36da80-cf01-11e9-87d5-8076e75310be.png">

@coolcat-creations
@alikon 