### PR TITLE
For real, stop allowing CI fails on PHP 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,6 @@ matrix:
     - php: 7.3
     - php: nightly
   allow_failures:
-    - php: 7.3
     - php: nightly
 
 services:


### PR DESCRIPTION
I remember at some point last year pointing out that the [temporarily allowed failing of PHP 7.3 on Travis](https://github.com/joomla/joomla-cms/commit/e5157f2db1e4c9b0160e60b14eb536b725a8d17f#diff-354f30a63fb0907d4ad57269548329e3) would become permanent.  And well, 10 months later, I'm right.  Who woulda thunk it?  Or maybe because it's Travis and not Drone nobody really cared to look.  Either way, with what little testing actually exists in Joomla the project's stance right now is CI does not ensure compatibility with PHP 7.3 and issues with that PHP branch may be expected.  It's the stable PHP version, it should be supported, so no more temporary permanent failing.