### PR TITLE
[4.0] Trigger a plugin event on getListQuery

### DIFF
--- a/libraries/src/MVC/Model/ListModel.php
+++ b/libraries/src/MVC/Model/ListModel.php
@@ -143,6 +143,8 @@ class ListModel extends BaseDatabaseModel implements ListModelInterface
 			$this->query = $this->getListQuery();
 		}
 
+		Factory::getApplication()->triggerEvent('onAfterGetListQuery', array($this->context, &$this->query));
+
 		return $this->query;
 	}
 


### PR DESCRIPTION
### The problem
Filtering the returned items is an essential functionality.
Trying to add some filters to the returned content (articles), it turns out that there is no way to have any control over the *getList* query that returns the items of a component.

Although plugin events are triggered for other basic functions (save, delete), there is no such an event for the read functionality, that returns a set of items 

### Suggested Solution
Added a plugin trigger at the end of *_getListQuery* function in the ListModel class. The function allows plugins to edit the query by adding their own conditions.
Since this is an abstract function that is called by all the components (at least those that do not overwritte that), this covers all the components.


### Testing Instructions
Add a  *public function onAfterGetListQuery($context, $query)* in a system plugin and check if it is triggered.










