### PR TITLE
JRoute::link() fails in CLI

### DIFF
--- a/libraries/src/Router/Route.php
+++ b/libraries/src/Router/Route.php
@@ -129,7 +129,7 @@ class Route
 		// Get the router instance, only attempt when a client name is given.
 		if ($client && !isset(self::$_router[$client]))
 		{
-			$app = Factory::getApplication();
+			$app = Factory::getApplication($client);
 
 			self::$_router[$client] = $app->getRouter($client);
 		}


### PR DESCRIPTION
### Summary of Changes

Use specified application instead of current application in `Joomla\CMS\Router\Route::link()`.

### Testing Instructions

1) Run this CLI application:

```
const _JEXEC = 1;

if (file_exists(dirname(__DIR__) . '/defines.php'))
{
	require_once dirname(__DIR__) . '/defines.php';
}

if (!defined('_JDEFINES'))
{
	define('JPATH_BASE', dirname(__DIR__));
	require_once JPATH_BASE . '/includes/defines.php';
}

require_once JPATH_LIBRARIES . '/import.legacy.php';
require_once JPATH_LIBRARIES . '/cms.php';
require_once JPATH_CONFIGURATION . '/configuration.php';

class Test extends JApplicationCli
{
	public function doExecute()
	{
		JLoader::register('ContentHelperRoute', JPATH_SITE . '/components/com_content/helpers/route.php');
		$url = JRoute::link('site', ContentHelperRoute::getCategoryRoute('8'));
		
		$this->out($url);
	}
}

JApplicationCli::getInstance('Test')->execute();
```
2) Check that links in frontend and backend work like before.

### Expected result

1) SEF URL is displayed.
2) Works like before.

### Actual result

1) >Error: Failed to start application

### Documentation Changes Required

No.