### PR TITLE
[4.0] Set breadcrumb on start of container

### DIFF
--- a/templates/cassiopeia/index.php
+++ b/templates/cassiopeia/index.php
@@ -149,10 +149,14 @@ $this->setMetaData('viewport', 'width=device-width, initial-scale=1');
 	<?php endif; ?>
 
 	<div class="grid-child container-component">
+		
+		<?php if ($this->countModules('breadcrumbs')) : ?>
+		<jdoc:include type="modules" name="breadcrumbs" style="none" />
+		<?php endif; ?>
+		
 		<jdoc:include type="modules" name="main-top" style="cardGrey" />
 		<jdoc:include type="message" />
 		<jdoc:include type="component" />
-		<jdoc:include type="modules" name="breadcrumbs" style="none" />
 		<jdoc:include type="modules" name="main-bottom" style="cardGrey" />
 	</div>
 

--- a/templates/cassiopeia/index.php
+++ b/templates/cassiopeia/index.php
@@ -149,13 +149,9 @@ $this->setMetaData('viewport', 'width=device-width, initial-scale=1');
 	<?php endif; ?>
 
 	<div class="grid-child container-component">
-		
-		<?php if ($this->countModules('breadcrumbs')) : ?>
-		<jdoc:include type="modules" name="breadcrumbs" style="none" />
-		<?php endif; ?>
-		
 		<jdoc:include type="modules" name="main-top" style="cardGrey" />
 		<jdoc:include type="message" />
+		<jdoc:include type="modules" name="breadcrumbs" style="none" />
 		<jdoc:include type="component" />
 		<jdoc:include type="modules" name="main-bottom" style="cardGrey" />
 	</div>


### PR DESCRIPTION
Pull Request for Issue # https://github.com/joomla/joomla-cms/issues/26195

### Summary of Changes
I changed the positioning of the breadcrumbs.

### Testing Instructions
Apply this patch an open the side in the front end. The breadcrumbs are now in front of the content.
![Home](https://user-images.githubusercontent.com/9974686/64479634-16e8f980-d1ba-11e9-91e8-867dc77c807d.png)



### Expected result
The breadcrumbs are in front of the content.


### Actual result
The breadcrumbs are under the content.


### Documentation Changes Required
No
