### PR TITLE
The model should be used

### DIFF
--- a/administrator/components/com_actionlogs/View/Actionlogs/HtmlView.php
+++ b/administrator/components/com_actionlogs/View/Actionlogs/HtmlView.php
@@ -101,7 +101,7 @@ class HtmlView extends BaseHtmlView
 		$params              = ComponentHelper::getParams('com_actionlogs');
 		$this->showIpColumn  = (bool) $params->get('ip_logging', 0);
 
-		if (count($errors = $this->get('Errors')))
+		if (count($errors = $model->getErrors()))
 		{
 			throw new GenericDataException(implode("\n", $errors), 500);
 		}


### PR DESCRIPTION
This is a very simple change, we should use the model directly. This got missed in an earlier PR.