### PR TITLE
[4.0][mod_tags_popular] fix query

### DIFF
--- a/modules/mod_tags_popular/Helper/TagsPopularHelper.php
+++ b/modules/mod_tags_popular/Helper/TagsPopularHelper.php
@@ -97,7 +97,7 @@ abstract class TagsPopularHelper
 
 		// Only return tags connected to published and authorised items
 		$query->where($db->quoteName('c.core_state') . ' = 1')
-			->where($db->quoteName('c.core_access') . ' IN (' . $groups . ')')
+			->whereIn($db->quoteName('c.core_access'), $groups)
 			->where('(' . $db->quoteName('c.core_publish_up') . ' = :nullDate2'
 				. ' OR ' . $db->quoteName('c.core_publish_up') . ' <= :nowDate2)'
 			)


### PR DESCRIPTION
### Summary of Changes

Fix PHP Notice: Array to string conversion  using` whereIn()`

### Testing Instructions
publish mod_tags_popular on page and visit that page


### Expected result
No error


### Actual result

`Error 42S22, 1054, Unknown column 'Array' in 'where clause'`




