### PR TITLE
[4.0] Fix index names of `#__finder_terms` table for new installs and updates on MySQL databases

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/4.0.0-2018-07-29.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.0.0-2018-07-29.sql
@@ -76,7 +76,10 @@ TRUNCATE TABLE `#__finder_terms`;
 ALTER TABLE `#__finder_terms` CHANGE `language` `language` CHAR(7) NOT NULL DEFAULT '' AFTER `links`;
 ALTER TABLE `#__finder_terms` MODIFY `stem` varchar(75) NOT NULL DEFAULT '';
 ALTER TABLE `#__finder_terms` MODIFY `soundex` varchar(75) NOT NULL DEFAULT '';
-ALTER TABLE `#__finder_terms` DROP INDEX `idx_term`, ADD INDEX `idx_stem` (`stem`), ADD INDEX `idx_language` (`language`), ADD UNIQUE INDEX `idx_term_language` (`term`, `language`);
+ALTER TABLE `#__finder_terms` DROP INDEX `idx_term`;
+ALTER TABLE `#__finder_terms` ADD INDEX `idx_stem` (`stem`);
+ALTER TABLE `#__finder_terms` ADD INDEX `idx_language` (`language`);
+ALTER TABLE `#__finder_terms` ADD UNIQUE INDEX `idx_term_language` (`term`, `language`);
 
 DROP TABLE IF EXISTS `#__finder_terms_common`;
 CREATE TABLE `#__finder_terms_common` (

--- a/administrator/components/com_admin/sql/updates/mysql/4.0.0-2018-07-29.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.0.0-2018-07-29.sql
@@ -76,7 +76,7 @@ TRUNCATE TABLE `#__finder_terms`;
 ALTER TABLE `#__finder_terms` CHANGE `language` `language` CHAR(7) NOT NULL DEFAULT '' AFTER `links`;
 ALTER TABLE `#__finder_terms` MODIFY `stem` varchar(75) NOT NULL DEFAULT '';
 ALTER TABLE `#__finder_terms` MODIFY `soundex` varchar(75) NOT NULL DEFAULT '';
-ALTER TABLE `#__finder_terms` DROP INDEX `idx_term`, ADD INDEX `idx_stem` (`stem`), ADD INDEX `idx_language` (`language`), ADD INDEX `language` (`language`), ADD UNIQUE INDEX `idx_term` (`term`, `language`);
+ALTER TABLE `#__finder_terms` DROP INDEX `idx_term`, ADD INDEX `idx_stem` (`stem`), ADD INDEX `idx_language` (`language`), ADD INDEX `idx_language` (`language`), ADD UNIQUE INDEX `idx_term_language` (`term`, `language`);
 
 DROP TABLE IF EXISTS `#__finder_terms_common`;
 CREATE TABLE `#__finder_terms_common` (

--- a/administrator/components/com_admin/sql/updates/mysql/4.0.0-2018-07-29.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.0.0-2018-07-29.sql
@@ -76,7 +76,7 @@ TRUNCATE TABLE `#__finder_terms`;
 ALTER TABLE `#__finder_terms` CHANGE `language` `language` CHAR(7) NOT NULL DEFAULT '' AFTER `links`;
 ALTER TABLE `#__finder_terms` MODIFY `stem` varchar(75) NOT NULL DEFAULT '';
 ALTER TABLE `#__finder_terms` MODIFY `soundex` varchar(75) NOT NULL DEFAULT '';
-ALTER TABLE `#__finder_terms` DROP INDEX `idx_term`, ADD INDEX `idx_stem` (`stem`), ADD INDEX `idx_language` (`language`), ADD INDEX `idx_language` (`language`), ADD UNIQUE INDEX `idx_term_language` (`term`, `language`);
+ALTER TABLE `#__finder_terms` DROP INDEX `idx_term`, ADD INDEX `idx_stem` (`stem`), ADD INDEX `idx_language` (`language`), ADD UNIQUE INDEX `idx_term_language` (`term`, `language`);
 
 DROP TABLE IF EXISTS `#__finder_terms_common`;
 CREATE TABLE `#__finder_terms_common` (

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -967,7 +967,7 @@ CREATE TABLE IF NOT EXISTS `#__finder_terms` (
   `links` int(10) NOT NULL DEFAULT 0,
   `language` char(7) NOT NULL DEFAULT '',
   PRIMARY KEY (`term_id`),
-  UNIQUE KEY `idx_term` (`term`,`language`),
+  UNIQUE KEY `idx_term_language` (`term`,`language`),
   KEY `idx_stem` (`stem`),
   KEY `idx_term_phrase` (`term`,`phrase`),
   KEY `idx_stem_phrase` (`stem`,`phrase`),


### PR DESCRIPTION
Pull Request (PR) for new issue.

### Summary of Changes

**Fix no. 1:**

This PR changes the index name of the combined index over columns (`term`,`language`) of table `#__finder_terms` from `idx_term` to `idx_term_language` for new installations on MySQL databases, i.e. in file `mysql/joomla.sql`, so it is consistent with how we name combined indexes over columns in general, and also consistent how it is done for PostgreSQL.

This also fixes the problem that an index with name `idx_term` is dropped and then added back with the same name in the update sql script `mysql/4.0.0-2018-07-29.sql`. The database schema checker does not support drop and and back an index with the same name, and it would end in a ping pong of `index exists but should not` and `index does not exist but it should` error from `fix` to next `fix` button run.

**Fix no. 2:**

The problem that the ping pong mentioned with the previous fix doesn't happen right now is because of another mistake in the same update script: The `ALTER TABLE` statement which contains the index changes handled here combines several changes, separated by comma. This is valid SQL of course, but not supported by the database schema checker/fixer. If we are lucky it checks the first statement, if we are unlucky it can result in an SQL syntax error, or the statements is not checked, depending if some spaces before and after these commas or not. For the checker/fixer there has to be one single `ALTER TABLE` statement for each change. This is also fixed by this PR here for MySQL. For PostgreSQL this has to be fixed, too. This is done in PR #26219 .

**Fix no. 3:**

In the same update sql script is another mistake: It adds an index with name `language` over the `language` column, in addition to the index `idx_language` on the same column. In file `mysql/joomla.sql` there is only index `idx_language`, so the additional index with name `language` in the update sql could be some copy and pase remainder. This PR fixes also this.

**General remark on changing the SQL update script**

Since we are not in beta yet and so don't have to support updates from 4.0-Alpha-x to 4.0-Alpha-y or between nightly builds, we can change the existing 4.0 update scripts (but of course not pre-4.0 scripts). Later when in beta this will not be allowed anymore, so now is a good time to fix it.

### Testing Instructions

Code review.

I will see if I can add some instructions for a real test, if I get feedback that code review is not enough.

### Expected result

Index names of table `#__finder_terms` are consistent in files `mysql/joomla.sql` and `mysql/4.0.0-2018-07-29.sql`, and the new index over columns (`term`,`language`) is added with the right, new name in file `mysql/4.0.0-2018-07-29.sql`, like it is already done for PostgreSQL.

For each index change of table `#__finder_terms`, one separate `ALTER TABLE` statement is used. 

### Actual result

See summary of changes at the top.

### Documentation Changes Required

None.