### PR TITLE
[4.0] Fix PostgreSQL update SQL scripts for the database schema checker/fixer

### DIFF
--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2018-07-29.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2018-07-29.sql
@@ -8,7 +8,8 @@ ALTER TABLE "#__finder_filters" ALTER COLUMN "created_by_alias" SET DEFAULT '';
 TRUNCATE TABLE "#__finder_links";
 ALTER TABLE "#__finder_links" ALTER COLUMN "state" SET NOT NULL;
 ALTER TABLE "#__finder_links" ALTER COLUMN "access" SET NOT NULL;
-ALTER TABLE "#__finder_links" ALTER COLUMN "language" TYPE VARCHAR(7), ALTER COLUMN "language" SET DEFAULT '';
+ALTER TABLE "#__finder_links" ALTER COLUMN "language" TYPE character varying(7);
+ALTER TABLE "#__finder_links" ALTER COLUMN "language" SET DEFAULT '';
 CREATE INDEX "#__finder_links_idx_language" on "#__finder_links" ("language");
 
 CREATE TABLE "#__finder_links_terms" (
@@ -75,7 +76,7 @@ INSERT INTO "#__finder_taxonomy" ("id", "parent_id", "lft", "rgt", "level", "pat
 SELECT setval('#__finder_taxonomy_id_seq', 2, false);
 
 TRUNCATE TABLE "#__finder_terms";
-ALTER TABLE "#__finder_terms" ALTER COLUMN "language" TYPE CHAR(7);
+ALTER TABLE "#__finder_terms" ALTER COLUMN "language" TYPE character varying(7);
 ALTER TABLE "#__finder_terms" ALTER COLUMN "language" SET DEFAULT '';
 ALTER TABLE "#__finder_terms" ALTER COLUMN "stem" SET DEFAULT '';
 ALTER TABLE "#__finder_terms" ALTER COLUMN "soundex" SET DEFAULT '';
@@ -269,12 +270,13 @@ INSERT INTO "#__finder_terms_common" ("term", "language", "custom") VALUES
 	('too', 'en', 0),
 	('very', 'en', 0);
 
-ALTER TABLE "#__finder_tokens" ALTER COLUMN "language" TYPE VARCHAR(7), ALTER COLUMN "language" SET DEFAULT '';
+ALTER TABLE "#__finder_tokens" ALTER COLUMN "language" TYPE character varying(7);
+ALTER TABLE "#__finder_tokens" ALTER COLUMN "language" SET DEFAULT '';
 ALTER TABLE "#__finder_tokens" ALTER COLUMN "stem" SET DEFAULT '';
 CREATE INDEX "#__finder_tokens_idx_stem" on "#__finder_tokens" ("stem");
 CREATE INDEX "#__finder_tokens_idx_language" on "#__finder_tokens" ("language");
 
-ALTER TABLE "#__finder_tokens_aggregate" ALTER COLUMN "language" TYPE VARCHAR(7);
+ALTER TABLE "#__finder_tokens_aggregate" ALTER COLUMN "language" TYPE character varying(7);
 ALTER TABLE "#__finder_tokens_aggregate" ALTER COLUMN "language" SET DEFAULT '';
 ALTER TABLE "#__finder_tokens_aggregate" DROP COLUMN "map_suffix";
 ALTER TABLE "#__finder_tokens_aggregate" ALTER COLUMN "stem" SET DEFAULT '';

--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2018-07-29.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2018-07-29.sql
@@ -75,12 +75,14 @@ INSERT INTO "#__finder_taxonomy" ("id", "parent_id", "lft", "rgt", "level", "pat
 SELECT setval('#__finder_taxonomy_id_seq', 2, false);
 
 TRUNCATE TABLE "#__finder_terms";
-ALTER TABLE "#__finder_terms"	ALTER COLUMN "language" TYPE CHAR(7),	ALTER COLUMN "language" SET DEFAULT '';
+ALTER TABLE "#__finder_terms" ALTER COLUMN "language" TYPE CHAR(7);
+ALTER TABLE "#__finder_terms" ALTER COLUMN "language" SET DEFAULT '';
 ALTER TABLE "#__finder_terms" ALTER COLUMN "stem" SET DEFAULT '';
 ALTER TABLE "#__finder_terms" ALTER COLUMN "soundex" SET DEFAULT '';
 CREATE INDEX "#__finder_terms_idx_stem" on "#__finder_terms" ("stem");
 CREATE INDEX "#__finder_terms_idx_language" on "#__finder_terms" ("language");
-ALTER TABLE "#__finder_terms"	DROP CONSTRAINT "#__finder_terms_idx_term",	ADD CONSTRAINT "#__finder_terms_idx_term_language" UNIQUE ("term", "language");
+ALTER TABLE "#__finder_terms" DROP CONSTRAINT "#__finder_terms_idx_term";
+ALTER TABLE "#__finder_terms" ADD CONSTRAINT "#__finder_terms_idx_term_language" UNIQUE ("term", "language");
 
 DROP TABLE IF EXISTS "#__finder_terms_common";
 CREATE TABLE "#__finder_terms_common" (
@@ -272,7 +274,8 @@ ALTER TABLE "#__finder_tokens" ALTER COLUMN "stem" SET DEFAULT '';
 CREATE INDEX "#__finder_tokens_idx_stem" on "#__finder_tokens" ("stem");
 CREATE INDEX "#__finder_tokens_idx_language" on "#__finder_tokens" ("language");
 
-ALTER TABLE "#__finder_tokens_aggregate" ALTER COLUMN "language" TYPE VARCHAR(7), ALTER COLUMN "language" SET DEFAULT '';
+ALTER TABLE "#__finder_tokens_aggregate" ALTER COLUMN "language" TYPE VARCHAR(7);
+ALTER TABLE "#__finder_tokens_aggregate" ALTER COLUMN "language" SET DEFAULT '';
 ALTER TABLE "#__finder_tokens_aggregate" DROP COLUMN "map_suffix";
 ALTER TABLE "#__finder_tokens_aggregate" ALTER COLUMN "stem" SET DEFAULT '';
 ALTER TABLE "#__finder_tokens_aggregate" ALTER COLUMN "term_weight" SET DEFAULT 0;

--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2019-05-20.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2019-05-20.sql
@@ -1,1 +1,1 @@
-ALTER TABLE "#__extensions" ADD COLUMN "note" varchar(255);
+ALTER TABLE "#__extensions" ADD COLUMN "note" character varying(255);

--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2019-08-03.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2019-08-03.sql
@@ -1,2 +1,2 @@
-ALTER TABLE `#__update_sites` ADD COLUMN `checked_out` bigint DEFAULT 0 NOT NULL;
-ALTER TABLE `#__update_sites` ADD COLUMN `checked_out_time` timestamp without time zone DEFAULT NULL;
+ALTER TABLE "#__update_sites" ADD COLUMN "checked_out" bigint DEFAULT 0 NOT NULL;
+ALTER TABLE "#__update_sites" ADD COLUMN "checked_out_time" timestamp without time zone DEFAULT NULL;


### PR DESCRIPTION
Pull Request (PR) for new issue.

### Summary of Changes

**Fix no. 1**

See fix no. 2 of PR #26216 .

The database schema checker/fixer does not understand `ALTER TABLE` which handle multiple changes, separated by comma. This is valid SQL of course, but not supported by the database schema checker/fixer. If we are lucky it checks the first statement, if we are unlucky it can result in an SQL syntax error, or the statements is not checked, depending if some spaces before and after these commas or not. For the checker/fixer there has to be one single `ALTER TABLE` statement for each change.

**Fix no. 2**

In the same update SQL script `postgresql/4.0.0-2018-07-29.sql`, type `char(7)` or `varchar(7)` is used, where it should be `character varying(7)`. I don't remember now the other PR where we found out that this has to be used instead of `varchar(7)` in schema updates in `ALTER TABLE` statements due to restrictions of the schema checker/fixer. (In `CREATE TABLE` it is ok to use `varchar(7)` in update SQL scripts.)

The same problem exists in update SQL script `postgresql/4.0.0-2019-05-20.sql` for the `#__extensions` table. No idea why the database schema checker did not report this, but it is safer to change it also here.

**Fix no. 3**

Another update SQL script `postgresql/4.0.0-2019-08-03.sql` has MySQL names quoting. This is also fixed by this PR.

**General remark on changing the SQL update script**

Since we are not in beta yet and so don't have to support updates from 4.0-Alpha-x to 4.0-Alpha-y or between nightly builds, we can change the existing 4.0 update scripts (but of course not pre-4.0 scripts). Later when in beta this will not be allowed anymore, so now is a good time to fix it.

### Testing Instructions

Either code review, or test as follows, or both.

1. Install clean 4.0-dev using a PostgreSQL database.

2. Go to `administrator/index.php?option=com_installer&view=database`.

Result: See section "Actual result" below.

3. Apply patch.

4. Realod page `administrator/index.php?option=com_installer&view=database`.

Result: See section "Expected result" below.

### Expected result

No database errors shown.

### Actual result

Database errors shown for some com_finder tables and for table `#__update_sites`.

### Documentation Changes Required

None.