### PR TITLE
[4.0] onContentPrepare to return void

### DIFF
--- a/plugins/content/contact/contact.php
+++ b/plugins/content/contact/contact.php
@@ -38,7 +38,7 @@ class PlgContentContact extends CMSPlugin
 	 * @param   mixed    $params   Additional parameters. See {@see PlgContentContent()}.
 	 * @param   integer  $page     Optional page number. Unused. Defaults to zero.
 	 *
-	 * @return  boolean	True on success.
+	 * @return  void
 	 */
 	public function onContentPrepare($context, &$row, $params, $page = 0)
 	{
@@ -46,25 +46,25 @@ class PlgContentContact extends CMSPlugin
 
 		if (!in_array($context, $allowed_contexts))
 		{
-			return true;
+			return;
 		}
 
 		// Return if we don't have valid params or don't link the author
 		if (!($params instanceof Registry) || !$params->get('link_author'))
 		{
-			return true;
+			return;
 		}
 
 		// Return if an alias is used
 		if ((int) $this->params->get('link_to_alias', 0) === 0 && $row->created_by_alias != '')
 		{
-			return true;
+			return;
 		}
 
 		// Return if we don't have a valid article id
 		if (!isset($row->id) || !(int) $row->id)
 		{
-			return true;
+			return;
 		}
 
 		$contact        = $this->getContactData($row->created_by);
@@ -90,8 +90,6 @@ class PlgContentContact extends CMSPlugin
 		{
 			$row->contact_link = '';
 		}
-
-		return true;
 	}
 
 	/**

--- a/plugins/content/emailcloak/emailcloak.php
+++ b/plugins/content/emailcloak/emailcloak.php
@@ -28,22 +28,24 @@ class PlgContentEmailcloak extends CMSPlugin
 	 * @param   mixed    &$params  Additional parameters. See {@see PlgContentEmailcloak()}.
 	 * @param   integer  $page     Optional page number. Unused. Defaults to zero.
 	 *
-	 * @return  boolean	True on success.
+	 * @return  void
 	 */
 	public function onContentPrepare($context, &$row, &$params, $page = 0)
 	{
 		// Don't run this plugin when the content is being indexed
 		if ($context === 'com_finder.indexer')
 		{
-			return true;
+			return;
 		}
 
 		if (is_object($row))
 		{
-			return $this->_cloak($row->text, $params);
+			$this->_cloak($row->text, $params);
+
+			return;
 		}
 
-		return $this->_cloak($row, $params);
+		$this->_cloak($row, $params);
 	}
 
 	/**
@@ -68,7 +70,7 @@ class PlgContentEmailcloak extends CMSPlugin
 	 * @param   mixed   &$params  Additional parameters. Parameter "mode" (integer, default 1)
 	 *                             replaces addresses with "mailto:" links if nonzero.
 	 *
-	 * @return  boolean  True on success.
+	 * @return  void
 	 */
 	protected function _cloak(&$text, &$params)
 	{
@@ -80,13 +82,13 @@ class PlgContentEmailcloak extends CMSPlugin
 		{
 			$text = StringHelper::str_ireplace('{emailcloak=off}', '', $text);
 
-			return true;
+			return;
 		}
 
 		// Simple performance check to determine whether bot should process further.
 		if (StringHelper::strpos($text, '@') === false)
 		{
-			return true;
+			return;
 		}
 
 		$mode = (int) $this->params->def('mode', 1);
@@ -426,6 +428,6 @@ class PlgContentEmailcloak extends CMSPlugin
 			$text = substr_replace($text, $replacement, $regs[1][1], strlen($mail));
 		}
 
-		return true;
+		return;
 	}
 }

--- a/plugins/content/loadmodule/loadmodule.php
+++ b/plugins/content/loadmodule/loadmodule.php
@@ -33,7 +33,7 @@ class PlgContentLoadmodule extends CMSPlugin
 	 * @param   mixed    &$params   The article params
 	 * @param   integer  $page      The 'page' number
 	 *
-	 * @return  mixed   true if there is an error. Void otherwise.
+	 * @return  void
 	 *
 	 * @since   1.6
 	 */
@@ -42,13 +42,13 @@ class PlgContentLoadmodule extends CMSPlugin
 		// Don't run this plugin when the content is being indexed
 		if ($context === 'com_finder.indexer')
 		{
-			return true;
+			return;
 		}
 
 		// Simple performance check to determine whether bot should process further
 		if (strpos($article->text, 'loadposition') === false && strpos($article->text, 'loadmodule') === false)
 		{
-			return true;
+			return;
 		}
 
 		// Expression to search for (positions)

--- a/plugins/content/pagebreak/pagebreak.php
+++ b/plugins/content/pagebreak/pagebreak.php
@@ -46,7 +46,7 @@ class PlgContentPagebreak extends CMSPlugin
 	 * @param   mixed    &$params  The article params
 	 * @param   integer  $page     The 'page' number
 	 *
-	 * @return  mixed  Always returns void or true
+	 * @return  void
 	 *
 	 * @since   1.6
 	 */
@@ -78,7 +78,7 @@ class PlgContentPagebreak extends CMSPlugin
 		{
 			$row->text = preg_replace($regex, '<br>', $row->text);
 
-			return true;
+			return;
 		}
 
 		// Simple performance check to determine whether bot should process further.
@@ -89,7 +89,7 @@ class PlgContentPagebreak extends CMSPlugin
 				throw new Exception(Text::_('JERROR_PAGE_NOT_FOUND'), 404);
 			}
 
-			return true;
+			return;
 		}
 
 		$view = $input->getString('view');
@@ -131,7 +131,7 @@ class PlgContentPagebreak extends CMSPlugin
 
 			$row->text = preg_replace($regex, '<br>', $row->text);
 
-			return true;
+			return;
 		}
 
 		// Split the text around the plugin.
@@ -278,8 +278,6 @@ class PlgContentPagebreak extends CMSPlugin
 				$row->text = implode(' ', $t);
 			}
 		}
-
-		return true;
 	}
 
 	/**


### PR DESCRIPTION
### Summary of Changes

`onContentPrepare` should return void.

### Testing Instructions

Code review.

### Documentation Changes Required
Maybe remove reference to boolean here https://docs.joomla.org/Plugin/Events/Content#Return_Value.
