### PR TITLE
[4.0][Cassiopeia] Remove IE11 support from blog layout classes

### DIFF
--- a/templates/cassiopeia/scss/blocks/_modifiers.scss
+++ b/templates/cassiopeia/scss/blocks/_modifiers.scss
@@ -59,70 +59,34 @@
 
 // com_content
 .blog-items {
-  display: flex;
-  flex-wrap: wrap;
-  margin-right: -($cassiopeia-grid-gutter / 2);
-  margin-bottom: $cassiopeia-grid-gutter;
-  margin-left: -($cassiopeia-grid-gutter / 2);
+  display: grid;
+  grid-gap: $cassiopeia-grid-gutter;
+  grid-template-columns: 1fr;
+  grid-auto-flow: row;
   padding: 0;
-  &.columns-2 {
-    > div {
-      width: 50%;
-    }
-  }
-  &.columns-3 {
-    > div {
-      width: 33.33333%;
-    }
-  }
-  &.columns-4 {
-    > div {
-      width: 25%;
-    }
+  margin: 0 0 $cassiopeia-grid-gutter;
+  .blog-item {
+    padding: 0;
   }
   &[class^='columns-'], &[class*=' columns-'] {
     > div {
-      @include media-breakpoint-down(md) {
-        width: 100%;
-      }
+      flex: 0 1 auto;
+      width: auto;
+      max-width: none;
     }
   }
-}
-
-.blog-item {
-  padding: 0 ($cassiopeia-grid-gutter / 2) $cassiopeia-grid-gutter ($cassiopeia-grid-gutter / 2);
-}
-
-@supports (display: grid) {
-  .blog-items {
-    display: grid;
-    grid-gap: $cassiopeia-grid-gutter;
-    grid-template-columns: 1fr;
-    grid-auto-flow: row;
-    margin: 0 0 $cassiopeia-grid-gutter;
-    .blog-item {
-      padding: 0;
-    }
-    &[class^='columns-'], &[class*=' columns-'] {
-      > div {
-        flex: 0 1 auto;
-        width: auto;
-        max-width: none;
-      }
-    }
-    &.columns-2 {
-      grid-template-columns: 1fr 1fr;
-    }
-    &.columns-3 {
-      grid-template-columns: 1fr 1fr 1fr;
-    }
-    &.columns-4 {
-      grid-template-columns: 1fr 1fr 1fr 1fr;
-    }
-    &[class^='columns-'], &[class*=' columns-'] {
-      @include media-breakpoint-down(md) {
-        grid-template-columns: 1fr;
-      }
+  &.columns-2 {
+    grid-template-columns: 1fr 1fr;
+  }
+  &.columns-3 {
+    grid-template-columns: 1fr 1fr 1fr;
+  }
+  &.columns-4 {
+    grid-template-columns: 1fr 1fr 1fr 1fr;
+  }
+  &[class^='columns-'], &[class*=' columns-'] {
+    @include media-breakpoint-down(md) {
+      grid-template-columns: 1fr;
     }
   }
 }


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Removes IE11 support from blog layout classes added in #18319

### Testing Instructions
Apply this patch and run `node build.js --compile-css` for updating the changed SCSS. Alternatively, you can run `npm i`.

Check that the layout classes in #18319 still function correctly (columns-2, columns-3, columns-4)
