### PR TITLE
[4.0] Fix error with database alias functions

### DIFF
--- a/administrator/components/com_finder/Model/MapsModel.php
+++ b/administrator/components/com_finder/Model/MapsModel.php
@@ -172,8 +172,8 @@ class MapsModel extends ListModel
 			->where('a.parent_id != 0');
 
 		// Join to get the branch title
-		$query->select([$db->quote('b.id', 'branch_id'), $db->quote('b.title', 'branch_title')])
-			->leftJoin($db->quote('#__finder_taxonomy', 'b') . ' ON b.level = 1 AND b.lft <= a.lft AND a.rgt <= b.rgt');
+		$query->select([$db->quoteName('b.id', 'branch_id'), $db->quoteName('b.title', 'branch_title')])
+			->leftJoin($db->quoteName('#__finder_taxonomy', 'b') . ' ON b.level = 1 AND b.lft <= a.lft AND a.rgt <= b.rgt');
 
 		// Join to get the map links.
 		$stateQuery = $db->getQuery(true)


### PR DESCRIPTION

### Summary of Changes
#26223 by @SharkyKZ and merged (without tests) by @wilsonge introduced at least one error 



### Testing Instructions
administrator/index.php?option=com_finder&view=maps


### Expected result
list of maps


### Actual result
syntax error in the query

### Summary
The original query was
```
$query->select([$query->qn('b.id', 'branch_id'), $query->qn('b.title', 'branch_title')])
			->leftJoin($query->qn('#__finder_taxonomy', 'b') . ' ON b.level = 1 AND b.lft <= a.lft AND a.rgt <= b.rgt');
```

This was changed to
```
$query->select([$db->quote('b.id', 'branch_id'), $db->quote('b.title', 'branch_title')])
			->leftJoin($db->quote('#__finder_taxonomy', 'b') . ' ON b.level = 1 AND b.lft <= a.lft AND a.rgt <= b.rgt');
```

Which is obviously incorrect as qn==> quoteName not quote

This PR fixes that