### PR TITLE
[4.0] Update deprecated license

### DIFF
--- a/administrator/templates/atum/joomla.asset.json
+++ b/administrator/templates/atum/joomla.asset.json
@@ -3,7 +3,7 @@
   "name": "atum",
   "version": "4.0.0",
   "description": "Atum is the Joomla 4 administrator template",
-  "license": "GPL-2.0+",
+  "license": "GPL-2.0-or-later",
   "assets": [
     {
       "name": "template.atum.base",

--- a/build/media_source/legacy/joomla.asset.json
+++ b/build/media_source/legacy/joomla.asset.json
@@ -3,7 +3,7 @@
   "name": "joomla",
   "version": "4.0.0",
   "description": "Joomla CMS",
-  "license": "GPL-2.0+",
+  "license": "GPL-2.0-or-later",
   "assets": [
     {
       "name": "jquery-noconflict",

--- a/build/media_source/system/joomla.asset.json
+++ b/build/media_source/system/joomla.asset.json
@@ -3,7 +3,7 @@
   "name": "joomla",
   "version": "4.0.0",
   "description": "Joomla CMS",
-  "license": "GPL-2.0+",
+  "license": "GPL-2.0-or-later",
   "assets": [
     {
       "name": "core",

--- a/drone-package.json
+++ b/drone-package.json
@@ -16,5 +16,5 @@
     "@webcomponents/webcomponentsjs": "2.0.3",
     "joomla-javascript-tests": "joomla/test-javascript#4.0-dev"
   },
-  "license": "GPL-2.0+"
+  "license": "GPL-2.0-or-later"
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "joomla",
   "version": "4.0.0",
   "description": "Joomla CMS",
-  "license": "GPL-2.0+",
+  "license": "GPL-2.0-or-later",
   "repository": {
     "type": "git",
     "url": "https://github.com/joomla/joomla-cms.git"

--- a/templates/cassiopeia/joomla.asset.json
+++ b/templates/cassiopeia/joomla.asset.json
@@ -3,7 +3,7 @@
   "name": "cassiopeia",
   "version": "4.0.0",
   "description": "Cassiopeia is the Joomla 4 site template",
-  "license": "GPL-2.0+",
+  "license": "GPL-2.0-or-later",
   "assets": [
     {
       "name": "template.cassiopeia.base",


### PR DESCRIPTION

The spdx have deprecated the short license identifier GPL-2.0+ and we should use GPL-2.0-or-later
https://spdx.org/licenses/