### PR TITLE
[4.0] Initialize the debug plugin when the first event is triggered

### DIFF
--- a/libraries/src/Plugin/CMSPlugin.php
+++ b/libraries/src/Plugin/CMSPlugin.php
@@ -10,7 +10,6 @@ namespace Joomla\CMS\Plugin;
 
 \defined('JPATH_PLATFORM') or die;
 
-use Joomla\CMS\Event\AbstractImmutableEvent;
 use Joomla\CMS\Extension\PluginInterface;
 use Joomla\CMS\Factory;
 use Joomla\Event\AbstractEvent;
@@ -287,11 +286,7 @@ abstract class CMSPlugin implements DispatcherAwareInterface, PluginInterface
 
 				// Restore the old results and add the new result from our method call
 				array_push($allResults, $result);
-
-				if (!$event instanceof AbstractImmutableEvent)
-				{
-					$event['result'] = $allResults;
-				}
+				$event['result'] = $allResults;
 			}
 		);
 	}

--- a/libraries/src/Plugin/CMSPlugin.php
+++ b/libraries/src/Plugin/CMSPlugin.php
@@ -10,6 +10,7 @@ namespace Joomla\CMS\Plugin;
 
 \defined('JPATH_PLATFORM') or die;
 
+use Joomla\CMS\Event\AbstractImmutableEvent;
 use Joomla\CMS\Extension\PluginInterface;
 use Joomla\CMS\Factory;
 use Joomla\Event\AbstractEvent;
@@ -286,7 +287,11 @@ abstract class CMSPlugin implements DispatcherAwareInterface, PluginInterface
 
 				// Restore the old results and add the new result from our method call
 				array_push($allResults, $result);
-				$event['result'] = $allResults;
+
+				if (!$event instanceof AbstractImmutableEvent)
+				{
+					$event['result'] = $allResults;
+				}
 			}
 		);
 	}

--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -127,17 +127,14 @@ class PlgSystemDebug extends CMSPlugin
 	protected $isAjax = false;
 
 	/**
-	 * Constructor.
+	 * Initializes the plugin.
 	 *
-	 * @param   DispatcherInterface  &$subject  The object to observe.
-	 * @param   array                $config    An optional associative array of configuration settings.
+	 * @return  void
 	 *
-	 * @since   1.5
+	 * @since   __DEPLOY_VERSION__
 	 */
-	public function __construct(&$subject, $config)
+	public function onBeforeExecute()
 	{
-		parent::__construct($subject, $config);
-
 		$this->debugLang = $this->app->get('debug_lang');
 
 		// Skip the plugin if debug is off

--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -127,14 +127,24 @@ class PlgSystemDebug extends CMSPlugin
 	protected $isAjax = false;
 
 	/**
-	 * Initializes the plugin.
+	 * Registers legacy Listeners to the Dispatcher, emulating how plugins worked under Joomla! 3.x and below.
+	 *
+	 * By default, this method will look for all public methods whose name starts with "on". It will register
+	 * lambda functions (closures) which try to unwrap the arguments of the dispatched Event into method call
+	 * arguments and call your on<Something> method. The result will be passed back to the Event into its 'result'
+	 * argument.
+	 *
+	 * This method additionally supports Joomla\Event\SubscriberInterface and plugins implementing this will be
+	 * registered to the dispatcher as a subscriber.
 	 *
 	 * @return  void
 	 *
-	 * @since   __DEPLOY_VERSION__
+	 * @since   4.0
 	 */
-	public function onBeforeExecute()
+	public function registerListeners()
 	{
+		parent::registerListeners();
+
 		$this->debugLang = $this->app->get('debug_lang');
 
 		// Skip the plugin if debug is off


### PR DESCRIPTION
Pull Request for Issue #25675.

### Summary of Changes
Initialize the debug plugin ~~in the onBeforeExecute event~~ ~~when the listeners are registered~~ when the first event is triggered and not in the constructor.

### Testing Instructions
- Enable "Debug System" in Global Configuration.
- Enable "System - Debug" plugin.
- In the plugin, enable "Log Deprecated API" in the "Logging" tab.
- Save the plugin.
- Open the Debug bar and click on "Deprecated".

### Expected result
Multiple deprecated entries.

### Actual result
No deprecated entries.