### PR TITLE
[4.0] Fix console application booting namespace mapper

### DIFF
--- a/libraries/src/Application/ConsoleApplication.php
+++ b/libraries/src/Application/ConsoleApplication.php
@@ -101,9 +101,6 @@ class ConsoleApplication extends Application implements DispatcherAwareInterface
 			$this->setDispatcher($dispatcher);
 		}
 
-		// Load extension namespaces
-		$this->createExtensionNamespaceMap();
-
 		// Set the execution datetime and timestamp;
 		$this->set('execution.datetime', gmdate('Y-m-d H:i:s'));
 		$this->set('execution.timestamp', time());
@@ -162,6 +159,9 @@ class ConsoleApplication extends Application implements DispatcherAwareInterface
 	 */
 	public function execute()
 	{
+		// Load extension namespaces
+		$this->createExtensionNamespaceMap();
+
 		// Import CMS plugin groups to be able to subscribe to events
 		PluginHelper::importPlugin('system');
 		PluginHelper::importPlugin('console');


### PR DESCRIPTION
Pull Request for Issue #26266 .

### Summary of Changes
Fixes the console application when namespace file isn't present (there's a race condition between the constructor here of the console application and the app itself generating the namespace file - solution move it to execute (which is also what the CMSApplication class does anyhow)

### Testing Instructions
On a working J4 installation run 

```
rm libraries/autoload_psr4.php
php cli/joomla.php
```

see it crashes. Apply patch and run the two commands again. It works

### Expected result
Console application generates the file and works.

### Actual result
Console application crashes.

### Documentation Changes Required
None