### PR TITLE
[4.0] Smart Search content maps filters

### DIFF
--- a/administrator/components/com_finder/Model/MapsModel.php
+++ b/administrator/components/com_finder/Model/MapsModel.php
@@ -219,18 +219,8 @@ class MapsModel extends ListModel
 			$query->where('a.title LIKE ' . $search);
 		}
 
-		// Handle the list ordering.
-		$listOrdering = $this->getState('list.ordering', 'a.lft');
-		$listDirn     = $this->getState('list.direction', 'ASC');
-
-		if ($listOrdering === 'a.state')
-		{
-			$query->order("a.state $listDirn, a.lft $listDirn, level ASC");
-		}
-		else
-		{
-			$query->order($listOrdering . ' ' . $listDirn);
-		}
+		// Add the list ordering clause.
+		$query->order($db->escape($this->getState('list.ordering', 'd.branch_title')) . ' ' . $db->escape($this->getState('list.direction', 'ASC')));
 
 		return $query;
 	}
@@ -302,7 +292,7 @@ class MapsModel extends ListModel
 	 *
 	 * @since   2.5
 	 */
-	protected function populateState($ordering = 'a.lft', $direction = 'ASC')
+	protected function populateState($ordering = 'branch_title', $direction = 'ASC')
 	{
 		// Load the filter state.
 		$this->setState('filter.search', $this->getUserStateFromRequest($this->context . '.filter.search', 'filter_search', '', 'string'));

--- a/administrator/components/com_finder/forms/filter_maps.xml
+++ b/administrator/components/com_finder/forms/filter_maps.xml
@@ -47,11 +47,11 @@
 			type="list"
 			label="JGLOBAL_SORT_BY"
 			onchange="this.form.submit();"
-			default="d.branch_title ASC"
+			default="branch_title ASC"
 			>
 			<option value="">JGLOBAL_SORT_BY</option>
-			<option value="d.branch_title ASC">JGLOBAL_TITLE_ASC</option>
-			<option value="d.branch_title DESC">JGLOBAL_TITLE_DESC</option>
+			<option value="branch_title ASC">JGLOBAL_TITLE_ASC</option>
+			<option value="branch_title DESC">JGLOBAL_TITLE_DESC</option>
 			<option value="a.state ASC">JSTATUS_ASC</option>
 			<option value="a.state DESC">JSTATUS_DESC</option>
 		</field>

--- a/administrator/components/com_finder/tmpl/maps/default.php
+++ b/administrator/components/com_finder/tmpl/maps/default.php
@@ -51,7 +51,7 @@ HTMLHelper::_('script', 'com_finder/maps.js', ['version' => 'auto', 'relative' =
 								<?php echo HTMLHelper::_('searchtools.sort', 'JSTATUS', 'a.state', $listDirn, $listOrder); ?>
 							</th>
 							<th scope="col">
-								<?php echo HTMLHelper::_('searchtools.sort', 'JGLOBAL_TITLE', 'd.branch_title', $listDirn, $listOrder); ?>
+								<?php echo HTMLHelper::_('searchtools.sort', 'JGLOBAL_TITLE', 'branch_title', $listDirn, $listOrder); ?>
 							</th>
 							<?php if (!$branchFilter) : ?>
 								<th scope="col" style="width:1%" class="text-center">


### PR DESCRIPTION
Filtering on the content maps page of smart search was broken

1. On load the arrow indicator which should show which column the table is being sorted by doesnt show (they are all double arrows)
2. The accessibility code in the caption (sr-only) doent say which column  the table is being sorted by
3. If you try to filter by Title from the filter selects you will get a 500

This PR fixes all of that

Note if you get a 500 before applying the pr you _may_ need to clear your cookies before you can test the new code