### PR TITLE
[4.0] Add checkbox field layout

### DIFF
--- a/layouts/joomla/form/field/checkbox.php
+++ b/layouts/joomla/form/field/checkbox.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   Copyright (C) 2005 - 2019 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('JPATH_BASE') or die;
+
+extract($displayData);
+
+/**
+ * Layout variables
+ * -----------------
+ * @var   string   $autocomplete    Autocomplete attribute for the field.
+ * @var   boolean  $autofocus       Is autofocus enabled?
+ * @var   string   $class           Classes for the input.
+ * @var   string   $description     Description of the field.
+ * @var   boolean  $disabled        Is this field disabled?
+ * @var   string   $group           Group the field belongs to. <fields> section in form XML.
+ * @var   boolean  $hidden          Is this field hidden in the form?
+ * @var   string   $hint            Placeholder for the field.
+ * @var   string   $id              DOM id of the field.
+ * @var   string   $label           Label of the field.
+ * @var   string   $labelclass      Classes to apply to the label.
+ * @var   boolean  $multiple        Does this field support multiple values?
+ * @var   string   $name            Name of the input field.
+ * @var   string   $onchange        Onchange attribute for the field.
+ * @var   string   $onclick         Onclick attribute for the field.
+ * @var   string   $pattern         Pattern (Reg Ex) of value of the form field.
+ * @var   boolean  $readonly        Is this field read only?
+ * @var   boolean  $repeat          Allows extensions to duplicate elements.
+ * @var   boolean  $required        Is this field required?
+ * @var   integer  $size            Size attribute of the input.
+ * @var   boolean  $spellcheck      Spellcheck state for the form field.
+ * @var   string   $validate        Validation rules to apply.
+ * @var   string   $value           Value attribute of the field.
+ * @var   array    $checkedOptions  Options that will be set as checked.
+ * @var   boolean  $hasValue        Has this field a value assigned?
+ * @var   array    $options         Options available for this field.
+ * @var   array    $inputType       Options available for this field.
+ * @var   string   $accept          File types that are accepted.
+ * @var   boolean  $checked         Whether the checkbox should be checked.
+ */
+
+// Initialize some field attributes.
+$class     = $class ? ' ' . $class : '';
+$disabled  = $disabled ? ' disabled' : '';
+$required  = $required ? ' required' : '';
+$autofocus = $autofocus ? ' autofocus' : '';
+$checked   = $checked ? ' checked' : '';
+
+// Initialize JavaScript field attributes.
+$onclick  = $onclick ? ' onclick="' . $onclick . '"' : '';
+$onchange = $onchange ? ' onchange="' . $onchange . '"' : '';
+
+?>
+<div class="form-check form-check-inline">
+	<input
+		type="checkbox"
+		name="<?php echo $name; ?>"
+		id="<?php echo $id; ?>"
+		class="form-check-input<?php echo $class; ?>"
+		value="<?php echo htmlspecialchars($value, ENT_QUOTES, 'UTF-8'); ?>"
+		<?php echo $checked . $disabled . $onclick . $onchange . $required . $autofocus; ?>
+	>
+</div>

--- a/layouts/joomla/form/field/checkbox.php
+++ b/layouts/joomla/form/field/checkbox.php
@@ -9,40 +9,39 @@
 
 defined('JPATH_BASE') or die;
 
+use Joomla\CMS\Form\Field\CheckboxField;
+
 extract($displayData);
 
 /**
  * Layout variables
  * -----------------
- * @var   string   $autocomplete    Autocomplete attribute for the field.
- * @var   boolean  $autofocus       Is autofocus enabled?
- * @var   string   $class           Classes for the input.
- * @var   string   $description     Description of the field.
- * @var   boolean  $disabled        Is this field disabled?
- * @var   string   $group           Group the field belongs to. <fields> section in form XML.
- * @var   boolean  $hidden          Is this field hidden in the form?
- * @var   string   $hint            Placeholder for the field.
- * @var   string   $id              DOM id of the field.
- * @var   string   $label           Label of the field.
- * @var   string   $labelclass      Classes to apply to the label.
- * @var   boolean  $multiple        Does this field support multiple values?
- * @var   string   $name            Name of the input field.
- * @var   string   $onchange        Onchange attribute for the field.
- * @var   string   $onclick         Onclick attribute for the field.
- * @var   string   $pattern         Pattern (Reg Ex) of value of the form field.
- * @var   boolean  $readonly        Is this field read only?
- * @var   boolean  $repeat          Allows extensions to duplicate elements.
- * @var   boolean  $required        Is this field required?
- * @var   integer  $size            Size attribute of the input.
- * @var   boolean  $spellcheck      Spellcheck state for the form field.
- * @var   string   $validate        Validation rules to apply.
- * @var   string   $value           Value attribute of the field.
- * @var   array    $checkedOptions  Options that will be set as checked.
- * @var   boolean  $hasValue        Has this field a value assigned?
- * @var   array    $options         Options available for this field.
- * @var   array    $inputType       Options available for this field.
- * @var   string   $accept          File types that are accepted.
- * @var   boolean  $checked         Whether the checkbox should be checked.
+ * @var   string         $autocomplete    Autocomplete attribute for the field.
+ * @var   boolean        $autofocus       Is autofocus enabled?
+ * @var   string         $class           Classes for the input.
+ * @var   string|null    $description     Description of the field.
+ * @var   boolean        $disabled        Is this field disabled?
+ * @var   CheckboxField  $field           The form field object.
+ * @var   string|null    $group           Group the field belongs to. <fields> section in form XML.
+ * @var   boolean        $hidden          Is this field hidden in the form?
+ * @var   string         $hint            Placeholder for the field.
+ * @var   string         $id              DOM id of the field.
+ * @var   string         $label           Label of the field.
+ * @var   string         $labelclass      Classes to apply to the label.
+ * @var   boolean        $multiple        Does this field support multiple values?
+ * @var   string         $name            Name of the input field.
+ * @var   string         $onchange        Onchange attribute for the field.
+ * @var   string         $onclick         Onclick attribute for the field.
+ * @var   string         $pattern         Pattern (Reg Ex) of value of the form field.
+ * @var   string         $validationtext  The validation text of invalid value of the form field.
+ * @var   boolean        $readonly        Is this field read only?
+ * @var   boolean        $repeat          Allows extensions to duplicate elements.
+ * @var   boolean        $required        Is this field required?
+ * @var   integer        $size            Size attribute of the input.
+ * @var   boolean        $spellcheck      Spellcheck state for the form field.
+ * @var   string         $validate        Validation rules to apply.
+ * @var   string         $value           Value attribute of the field.
+ * @var   boolean        $checked         Whether the checkbox should be checked.
  */
 
 // Initialize some field attributes.

--- a/libraries/src/Form/Field/CheckboxField.php
+++ b/libraries/src/Form/Field/CheckboxField.php
@@ -32,20 +32,20 @@ class CheckboxField extends FormField
 	protected $type = 'Checkbox';
 
 	/**
-	 * The checked state of checkbox field.
-	 *
-	 * @var    boolean
-	 * @since  3.2
-	 */
-	protected $checked = false;
-
-	/**
 	 * Name of the layout being used to render the field
 	 *
 	 * @var    string
 	 * @since  __DEPLOY_VERSION__
 	 */
 	protected $layout = 'joomla.form.field.checkbox';
+
+	/**
+	 * The checked state of checkbox field.
+	 *
+	 * @var    boolean
+	 * @since  3.2
+	 */
+	protected $checked = false;
 
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.

--- a/libraries/src/Form/Field/CheckboxField.php
+++ b/libraries/src/Form/Field/CheckboxField.php
@@ -40,6 +40,14 @@ class CheckboxField extends FormField
 	protected $checked = false;
 
 	/**
+	 * Name of the layout being used to render the field
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $layout = 'joomla.form.field.checkbox';
+
+	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
 	 * @param   string  $name  The property name for which to get the value.
@@ -123,33 +131,18 @@ class CheckboxField extends FormField
 	}
 
 	/**
-	 * Method to get the field input markup.
-	 * The checked element sets the field to selected.
+	 * Method to get the data to be passed to the layout for rendering.
 	 *
-	 * @return  string  The field input markup.
+	 * @return  array
 	 *
-	 * @since   1.7.0
+	 * @since   __DEPLOY_VERSION__
 	 */
-	protected function getInput()
+	protected function getLayoutData()
 	{
-		// Initialize some field attributes.
-		$class     = !empty($this->class) ? ' class="form-check-input ' . $this->class . '"' : ' class="form-check-input"';
-		$disabled  = $this->disabled ? ' disabled' : '';
-		$value     = !empty($this->default) ? $this->default : '1';
-		$required  = $this->required ? ' required' : '';
-		$autofocus = $this->autofocus ? ' autofocus' : '';
-		$checked   = $this->checked || !empty($this->value) ? ' checked' : '';
+		$data            = parent::getLayoutData();
+		$data['value']   = $this->default ?: '1';
+		$data['checked'] = $this->checked || $this->value;
 
-		// Initialize JavaScript field attributes.
-		$onclick  = !empty($this->onclick) ? ' onclick="' . $this->onclick . '"' : '';
-		$onchange = !empty($this->onchange) ? ' onchange="' . $this->onchange . '"' : '';
-
-		$html = '<div class="form-check form-check-inline">';
-		$html .= '<input type="checkbox" name="' . $this->name . '" id="' . $this->id . '" value="'
-				. htmlspecialchars($value, ENT_COMPAT, 'UTF-8') . '"' . $class . $checked . $disabled . $onclick . $onchange
-				. $required . $autofocus . '>';
-		$html .= '</div>';
-
-		return $html;
+		return $data;
 	}
 }


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This adds an overridable layout to `Joomla\CMS\Form\Field\CheckboxField`.

### Testing Instructions

Open a form containing a checkbox field, e.g. Language Override form for Administrator. Inspect the checkbox field. Check/uncheck the field, save the override, etc.

### Expected result

Works like before.

### Documentation Changes Required

🤷‍♂ 