### PR TITLE
clean path in HTMLHelper:: & prevent duplicate /

### DIFF
--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -12,7 +12,6 @@ defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Environment\Browser;
 use Joomla\CMS\Factory;
-use Joomla\CMS\Filesystem\File;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Log\Log;
 use Joomla\CMS\Uri\Uri;

--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -332,11 +332,11 @@ abstract class HTMLHelper
 		// Extract extension and strip the file
 		$strip = \JFile::stripExt($file);
 		$ext   = \JFile::getExt($file);
-		
+
 		// Strip any preceding / or \ from outside filename
 		$strip = preg_replace('/^\W+|\W+$/', '', $strip);
-		
-		// Prepare array of files		
+
+		// Prepare array of files
 		$includes = array();
 
 		// Detect browser and compute potential files

--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -330,14 +330,14 @@ abstract class HTMLHelper
 			return array($file);
 		}
 
-		// Strip any preceding / or \ from filename
-		$file = File::makeSafe($file);
-
 		// Extract extension and strip the file
 		$strip = \JFile::stripExt($file);
 		$ext   = \JFile::getExt($file);
-
-		// Prepare array of files
+		
+		// Strip any preceding / or \ from outside filename
+		$strip = preg_replace('/^\W+|\W+$/', '', $strip);
+		
+		// Prepare array of files		
 		$includes = array();
 
 		// Detect browser and compute potential files

--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -12,6 +12,7 @@ defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Environment\Browser;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Filesystem\File;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Log\Log;
 use Joomla\CMS\Uri\Uri;
@@ -329,6 +330,9 @@ abstract class HTMLHelper
 			return array($file);
 		}
 
+		// Strip any preceding / or \ from filename
+		$file = File::makeSafe($file);
+		
 		// Extract extension and strip the file
 		$strip = \JFile::stripExt($file);
 		$ext   = \JFile::getExt($file);

--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -94,8 +94,8 @@ abstract class HTMLHelper
 	 *
 	 * @return  mixed  Result of HTMLHelper::call($function, $args)
 	 *
-	 * @throws  \InvalidArgumentException
 	 * @since   1.5
+	 * @throws  \InvalidArgumentException
 	 */
 	public static function _($key)
 	{
@@ -218,9 +218,9 @@ abstract class HTMLHelper
 	 *
 	 * @return  mixed   Function result or false on error.
 	 *
-	 * @throws  \InvalidArgumentException
-	 * @since   1.6
 	 * @link    https://www.php.net/manual/en/function.call-user-func-array.php
+	 * @since   1.6
+	 * @throws  \InvalidArgumentException
 	 */
 	protected static function call($function, $args)
 	{
@@ -290,7 +290,7 @@ abstract class HTMLHelper
 	 *
 	 * @return  string  Query string to add.
 	 *
-	 * @since        3.7.0
+	 * @since   3.7.0
 	 *
 	 * @deprecated   4.0  Usage of MD5SUM files is deprecated, use version instead.
 	 */
@@ -583,7 +583,7 @@ abstract class HTMLHelper
 		if ($returnPath !== -1)
 		{
 			$includes = static::includeRelativeFiles('images', $file, $relative, false, false);
-			$file     = count($includes) ? $includes[0] : null;
+			$file = count($includes) ? $includes[0] : null;
 		}
 
 		// If only path is required
@@ -604,8 +604,8 @@ abstract class HTMLHelper
 	 *
 	 * @return  array|string|null  nothing if $returnPath is false, null, path or array of path if specific CSS browser files were detected
 	 *
-	 * @see        Browser
-	 * @since      1.5
+	 * @see     Browser
+	 * @since   1.5
 	 * @deprecated 4.0  The (file, attribs, relative, pathOnly, detectBrowser, detectDebug) method signature is deprecated,
 	 *                  use (file, options, attributes) instead.
 	 */
@@ -676,8 +676,8 @@ abstract class HTMLHelper
 	 *
 	 * @return  array|string|null  Nothing if $returnPath is false, null, path or array of path if specific JavaScript browser files were detected
 	 *
-	 * @see        HTMLHelper::stylesheet()
-	 * @since      1.5
+	 * @see     HTMLHelper::stylesheet()
+	 * @since   1.5
 	 * @deprecated 4.0  The (file, framework, relative, pathOnly, detectBrowser, detectDebug) method signature is deprecated,
 	 *                  use (file, options, attributes) instead.
 	 */
@@ -878,7 +878,7 @@ abstract class HTMLHelper
 
 		if (!$text)
 		{
-			$alt  = htmlspecialchars($alt, ENT_COMPAT, 'UTF-8');
+			$alt = htmlspecialchars($alt, ENT_COMPAT, 'UTF-8');
 			$text = static::image($image, $alt, null, true);
 		}
 
@@ -898,7 +898,7 @@ abstract class HTMLHelper
 
 			if ($title)
 			{
-				$title   = htmlspecialchars($title, ENT_COMPAT, 'UTF-8');
+				$title = htmlspecialchars($title, ENT_COMPAT, 'UTF-8');
 				$tooltip = $title . '::' . $tooltip;
 			}
 		}
@@ -939,7 +939,7 @@ abstract class HTMLHelper
 			// Pass texts through JText if required.
 			if ($translate)
 			{
-				$title   = \JText::_($title);
+				$title = \JText::_($title);
 				$content = \JText::_($content);
 			}
 
@@ -1122,7 +1122,7 @@ abstract class HTMLHelper
 	 *
 	 * @return  string  JavaScript object notation representation of the array
 	 *
-	 * @since       3.0
+	 * @since   3.0
 	 * @deprecated  4.0 Use `json_encode()` or `Joomla\Registry\Registry::toString('json')` instead
 	 */
 	public static function getJSObject(array $array = array())

--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -12,6 +12,7 @@ defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Environment\Browser;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Filesystem\File;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Log\Log;
 use Joomla\CMS\Uri\Uri;
@@ -93,8 +94,8 @@ abstract class HTMLHelper
 	 *
 	 * @return  mixed  Result of HTMLHelper::call($function, $args)
 	 *
-	 * @since   1.5
 	 * @throws  \InvalidArgumentException
+	 * @since   1.5
 	 */
 	public static function _($key)
 	{
@@ -217,9 +218,9 @@ abstract class HTMLHelper
 	 *
 	 * @return  mixed   Function result or false on error.
 	 *
-	 * @link    https://www.php.net/manual/en/function.call-user-func-array.php
-	 * @since   1.6
 	 * @throws  \InvalidArgumentException
+	 * @since   1.6
+	 * @link    https://www.php.net/manual/en/function.call-user-func-array.php
 	 */
 	protected static function call($function, $args)
 	{
@@ -289,7 +290,7 @@ abstract class HTMLHelper
 	 *
 	 * @return  string  Query string to add.
 	 *
-	 * @since   3.7.0
+	 * @since        3.7.0
 	 *
 	 * @deprecated   4.0  Usage of MD5SUM files is deprecated, use version instead.
 	 */
@@ -330,11 +331,12 @@ abstract class HTMLHelper
 		}
 
 		// Extract extension and strip the file
-		$strip = \JFile::stripExt($file);
-		$ext   = \JFile::getExt($file);
+		$strip = File::stripExt($file);
 
 		// Strip any preceding / or \ from outside filename
-		$strip = preg_replace('/^\W+|\W+$/', '', $strip);
+		$strip = trim($strip, '\\/');
+
+		$ext = File::getExt($file);
 
 		// Prepare array of files
 		$includes = array();
@@ -581,7 +583,7 @@ abstract class HTMLHelper
 		if ($returnPath !== -1)
 		{
 			$includes = static::includeRelativeFiles('images', $file, $relative, false, false);
-			$file = count($includes) ? $includes[0] : null;
+			$file     = count($includes) ? $includes[0] : null;
 		}
 
 		// If only path is required
@@ -602,8 +604,8 @@ abstract class HTMLHelper
 	 *
 	 * @return  array|string|null  nothing if $returnPath is false, null, path or array of path if specific CSS browser files were detected
 	 *
-	 * @see     Browser
-	 * @since   1.5
+	 * @see        Browser
+	 * @since      1.5
 	 * @deprecated 4.0  The (file, attribs, relative, pathOnly, detectBrowser, detectDebug) method signature is deprecated,
 	 *                  use (file, options, attributes) instead.
 	 */
@@ -674,8 +676,8 @@ abstract class HTMLHelper
 	 *
 	 * @return  array|string|null  Nothing if $returnPath is false, null, path or array of path if specific JavaScript browser files were detected
 	 *
-	 * @see     HTMLHelper::stylesheet()
-	 * @since   1.5
+	 * @see        HTMLHelper::stylesheet()
+	 * @since      1.5
 	 * @deprecated 4.0  The (file, framework, relative, pathOnly, detectBrowser, detectDebug) method signature is deprecated,
 	 *                  use (file, options, attributes) instead.
 	 */
@@ -876,7 +878,7 @@ abstract class HTMLHelper
 
 		if (!$text)
 		{
-			$alt = htmlspecialchars($alt, ENT_COMPAT, 'UTF-8');
+			$alt  = htmlspecialchars($alt, ENT_COMPAT, 'UTF-8');
 			$text = static::image($image, $alt, null, true);
 		}
 
@@ -896,7 +898,7 @@ abstract class HTMLHelper
 
 			if ($title)
 			{
-				$title = htmlspecialchars($title, ENT_COMPAT, 'UTF-8');
+				$title   = htmlspecialchars($title, ENT_COMPAT, 'UTF-8');
 				$tooltip = $title . '::' . $tooltip;
 			}
 		}
@@ -937,7 +939,7 @@ abstract class HTMLHelper
 			// Pass texts through JText if required.
 			if ($translate)
 			{
-				$title = \JText::_($title);
+				$title   = \JText::_($title);
 				$content = \JText::_($content);
 			}
 
@@ -1120,7 +1122,7 @@ abstract class HTMLHelper
 	 *
 	 * @return  string  JavaScript object notation representation of the array
 	 *
-	 * @since   3.0
+	 * @since       3.0
 	 * @deprecated  4.0 Use `json_encode()` or `Joomla\Registry\Registry::toString('json')` instead
 	 */
 	public static function getJSObject(array $array = array())

--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -332,7 +332,7 @@ abstract class HTMLHelper
 
 		// Strip any preceding / or \ from filename
 		$file = File::makeSafe($file);
-		
+
 		// Extract extension and strip the file
 		$strip = \JFile::stripExt($file);
 		$ext   = \JFile::getExt($file);


### PR DESCRIPTION
Pull Request for Issue # .
#19048 

### Summary of Changes
cleans all template paths to ensure proper directory separator(s)
no extra '/'  nor '\' in path,

### Testing Instructions
in the protostar css folder add
dummy.css & dummy2.css files ( empty is fine )
![image](https://user-images.githubusercontent.com/1850089/64927618-c03f7900-d7d2-11e9-85ea-e469167b09fe.png)

in the protostar js folder add dummy.js file ( empty is fine )
![image](https://user-images.githubusercontent.com/1850089/64927498-17dce500-d7d1-11e9-925e-b5d5fcac1240.png)

Modify protostar index.php as follows.<hr>

below 
// Add template js
`JHtml::_('script', 'template.js', array('version' => 'auto', 'relative' => true));`

add 
`HTMLHelper::_('script', '/classes.js', array('version' => 'auto', 'relative' => true ));`
`HTMLHelper::_('script', '\/dummy.js', array('version' => 'auto', 'relative' => true ));`
`HTMLHelper::_('script', '\application.js', array('version' => 'auto', 'relative' => true ));`

below
// Add Stylesheets
`JHtml::_('stylesheet', 'template.css', array('version' => 'auto', 'relative' => true));`

add
`HTMLHelper::_('stylesheet', '/offline.css', array('version' => 'auto', 'relative' => true ));`
`HTMLHelper::_('stylesheet', '\/dummy.css', array('version' => 'auto', 'relative' => true ));`
`HTMLHelper::_('stylesheet', '\dummy2.css', array('version' => 'auto', 'relative' => true ));`

it should look like this.
![image](https://user-images.githubusercontent.com/1850089/64927633-e49b5580-d7d2-11e9-873e-f520208fa0fc.png)

view frontend of site.
 using code inspector or view source.  It should match this image.
![image](https://user-images.githubusercontent.com/1850089/64927657-4065de80-d7d3-11e9-8362-a6b7a686d910.png)

apply patch and retest.

### Expected result
![image](https://user-images.githubusercontent.com/1850089/64927670-5a072600-d7d3-11e9-9897-581290e5a5e0.png)
verify there are no backslashes ( \ ) nor double forward slashes ( / ) like before.



### Actual result
![image](https://user-images.githubusercontent.com/1850089/64927657-4065de80-d7d3-11e9-8362-a6b7a686d910.png)

### Documentation Changes Required
none.

This will help insure platform universalness and was the reason for JPath::clean() being created to begin with.
