### PR TITLE
[4.0] Aria-current on active admin menu item [accessibility]

### DIFF
--- a/build/media_source/mod_menu/js/admin-menu.es6.js
+++ b/build/media_source/mod_menu/js/admin-menu.es6.js
@@ -144,6 +144,7 @@
     // Set active class
     allLinks.forEach((link) => {
       if (currentUrl === link.href) {
+        link.setAttribute('aria-current', 'page');
         link.classList.add('active');
         // Auto Expand Levels
         if (!link.parentNode.classList.contains('parent')) {


### PR DESCRIPTION
Sighted users can see the active/current menu item as it is visually styled. This PR adds the ability for screen readers to identify the active/current menu item.

This adds the following attribute and value  `aria-current="page"` to the current menu item in the atum admin menu. 

### reference
  https://tink.uk/using-the-aria-current-attribute/

### test
npm -i
inspect the generated source of any page and see that the aria-current attribute has been added

![image](https://user-images.githubusercontent.com/1296369/64928077-031d4300-d80b-11e9-9358-eba560225203.png)
