### PR TITLE
[4.0] Admin modules with no content

### DIFF
--- a/administrator/modules/mod_custom/tmpl/default.php
+++ b/administrator/modules/mod_custom/tmpl/default.php
@@ -8,5 +8,8 @@
  */
 
 defined('_JEXEC') or die;
+?>
 
-echo $module->content;
+<div class="mod-custom custom">
+	<?php echo $module->content; ?>
+</div>


### PR DESCRIPTION
`### Summary of Changes
Custom admin modules with no content (just a title) do not appear on the dashboard


### Testing Instructions
Use the add module to dashboard box to create a new custom module
Give the module a title and some content, make sure its published and then save and return to the dashboard. Your new module is on the dashboard as expected

Repeat above but this time only enter a title. Your new module does not appear on the dashboard

Apply this PR and the module will now appear

![image](https://user-images.githubusercontent.com/1296369/64981858-dd4c7880-d8b4-11e9-865f-e64879cfb158.png)

