### PR TITLE
[4.0][com_finder] Add modal title

### DIFF
--- a/administrator/components/com_finder/View/Filters/HtmlView.php
+++ b/administrator/components/com_finder/View/Filters/HtmlView.php
@@ -161,7 +161,7 @@ class HtmlView extends BaseHtmlView
 		}
 
 		ToolbarHelper::divider();
-		$toolbar->appendButton('Popup', 'bars', 'COM_FINDER_STATISTICS', 'index.php?option=com_finder&view=statistics&tmpl=component', 550, 350);
+		$toolbar->appendButton('Popup', 'bars', 'COM_FINDER_STATISTICS', 'index.php?option=com_finder&view=statistics&tmpl=component', 550, 350, '', '', '', 'COM_FINDER_STATISTICS_TITLE');
 		ToolbarHelper::divider();
 
 		if ($canDo->get('core.delete'))

--- a/administrator/components/com_finder/View/Maps/HtmlView.php
+++ b/administrator/components/com_finder/View/Maps/HtmlView.php
@@ -160,14 +160,7 @@ class HtmlView extends BaseHtmlView
 		}
 
 		ToolbarHelper::divider();
-		Toolbar::getInstance('toolbar')->appendButton(
-			'Popup',
-			'bars',
-			'COM_FINDER_STATISTICS',
-			'index.php?option=com_finder&view=statistics&tmpl=component',
-			550,
-			350
-		);
+		$toolbar->appendButton('Popup', 'bars', 'COM_FINDER_STATISTICS', 'index.php?option=com_finder&view=statistics&tmpl=component', 550, 350, '', '', '', 'COM_FINDER_STATISTICS_TITLE');
 		ToolbarHelper::divider();
 
 		if ($canDo->get('core.delete'))


### PR DESCRIPTION
### Summary of Changes
Add missing title to Statistics modal.


### Testing Instructions
Go to Components > Smart Search > Content Maps
Click Statistics button.
Modal missing title.

Go to Components > Smart Search > Search Filters
Click Statistics button.
Modal missing title.


