### PR TITLE
[4.0] Use native array_column() function

### DIFF
--- a/administrator/components/com_banners/Model/ClientsModel.php
+++ b/administrator/components/com_banners/Model/ClientsModel.php
@@ -13,7 +13,6 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\MVC\Model\ListModel;
-use Joomla\Utilities\ArrayHelper;
 
 /**
  * Methods supporting a list of banner records.
@@ -211,7 +210,7 @@ class ClientsModel extends ListModel
 
 		// Get the clients in the list.
 		$db = $this->getDbo();
-		$clientIds = ArrayHelper::getColumn($items, 'id');
+		$clientIds = array_column($items, 'id');
 
 		// Quote the strings.
 		$clientIds = implode(

--- a/administrator/components/com_content/Model/ArticlesModel.php
+++ b/administrator/components/com_content/Model/ArticlesModel.php
@@ -533,7 +533,7 @@ class ArticlesModel extends ListModel
 			return false;
 		}
 
-		$ids = ArrayHelper::getColumn($items, 'stage_id');
+		$ids = array_column($items, 'stage_id');
 		$ids = ArrayHelper::toInteger($ids);
 		$ids = array_unique(array_filter($ids));
 

--- a/administrator/components/com_menus/Helper/MenusHelper.php
+++ b/administrator/components/com_menus/Helper/MenusHelper.php
@@ -21,7 +21,6 @@ use Joomla\CMS\Menu\MenuItem;
 use Joomla\CMS\Table\Table;
 use Joomla\Database\DatabaseInterface;
 use Joomla\Registry\Registry;
-use Joomla\Utilities\ArrayHelper;
 
 /**
  * Menus component helper.
@@ -445,7 +444,7 @@ class MenusHelper extends ContentHelper
 		{
 			$query->select('extension_id, element')->from('#__extensions')->where('type = ' . $db->quote('component'));
 			$components = $db->setQuery($query)->loadObjectList();
-			$components = ArrayHelper::getColumn((array) $components, 'element', 'extension_id');
+			$components = array_column((array) $components, 'element', 'extension_id');
 		}
 
 		Factory::getApplication()->triggerEvent('onPreprocessMenuItems', array('com_menus.administrator.import', &$items, null, true));

--- a/administrator/components/com_menus/Model/MenusModel.php
+++ b/administrator/components/com_menus/Model/MenusModel.php
@@ -13,7 +13,6 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
 use Joomla\CMS\MVC\Model\ListModel;
-use Joomla\Utilities\ArrayHelper;
 
 /**
  * Menu List Model for Menus.
@@ -78,7 +77,7 @@ class MenusModel extends ListModel
 
 		// Get the menu types of menus in the list.
 		$db = $this->getDbo();
-		$menuTypes = ArrayHelper::getColumn((array) $items, 'menutype');
+		$menuTypes = array_column((array) $items, 'menutype');
 
 		// Quote the strings.
 		$menuTypes = implode(

--- a/administrator/modules/mod_menu/Menu/CssMenu.php
+++ b/administrator/modules/mod_menu/Menu/CssMenu.php
@@ -201,8 +201,8 @@ class CssMenu
 		}
 
 		$items      = $node->getChildren(true);
-		$types      = ArrayHelper::getColumn($items, 'type');
-		$elements   = ArrayHelper::getColumn($items, 'element');
+		$types      = array_column($items, 'type');
+		$elements   = array_column($items, 'element');
 		$rMenu      = $authMenus && !\in_array('com_menus', $elements);
 		$rModule    = $authModules && !\in_array('com_modules', $elements);
 		$rContainer = !\in_array('container', $types);

--- a/plugins/content/joomla/joomla.php
+++ b/plugins/content/joomla/joomla.php
@@ -356,7 +356,7 @@ class PlgContentJoomla extends CMSPlugin
 
 		$stages = $model->getItems();
 
-		$stage_ids = ArrayHelper::getColumn($stages, 'id');
+		$stage_ids = array_column($stages, 'id');
 
 		$result = $this->_countItemsInStage($stage_ids, $table->extension);
 


### PR DESCRIPTION
### Summary of Changes

`Joomla\Utilities\ArrayHelper::getColumn()` is now a proxy to `array_column()`. Let's use it directly.

### Testing Instructions

Code review.

### Documentation Changes Required

No.