### PR TITLE
[4.0][cli] - delete user command fix bind paramenter

### DIFF
--- a/libraries/src/Console/DeleteUserCommand.php
+++ b/libraries/src/Console/DeleteUserCommand.php
@@ -104,7 +104,7 @@ class DeleteUserCommand extends AbstractCommand
 						)
 						->where($db->quoteName('g.group_id') . " = :groupId")
 						->where($db->quoteName('u.block') . " = 0")
-						->bind(':groupId', $groupId);
+						->bind(':groupId', $groupId, ParameterType::INTEGER);
 
 					$db->setQuery($queryUser);
 					$activeSuperUser = $db->loadResult();


### PR DESCRIPTION
looking at #26337 discovered  this...
the field `group_id` of  `#__user_usergroup_map` table is declared as INTEGER see:

https://github.com/joomla/joomla-cms/blob/4.0-dev/installation/sql/mysql/joomla.sql#L2135



### Summary of Changes
fixed the bind


### Testing Instructions

run php\joomla.php user:delete username

