### PR TITLE
[4.0] remove 3.8.x sql update scripts

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/3.8.0-2017-07-28.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.8.0-2017-07-28.sql
@@ -1,1 +1,0 @@
-ALTER TABLE `#__fields_groups` ADD COLUMN `params` TEXT  NOT NULL  AFTER `ordering`;

--- a/administrator/components/com_admin/sql/updates/mysql/3.8.0-2017-07-31.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.8.0-2017-07-31.sql
@@ -1,5 +1,0 @@
-INSERT INTO `#__extensions`
-(`package_id`, `name`, `type`, `element`, `folder`, `client_id`, `enabled`, `access`, `protected`, `manifest_cache`, `params`, `custom_data`, `system_data`, `checked_out`, `checked_out_time`, `ordering`, `state`)
-VALUES
-  (0, 'mod_sampledata', 'module', 'mod_sampledata', '', 1, 0, 1, 0, '', '{}', '', '', 0, '0000-00-00 00:00:00', 0, 0),
-  (0, 'plg_sampledata_blog', 'plugin', 'blog', 'sampledata', 0, 0, 1, 0, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0);

--- a/administrator/components/com_admin/sql/updates/mysql/3.8.2-2017-10-14.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.8.2-2017-10-14.sql
@@ -1,5 +1,0 @@
---
--- Add index for alias check #__content
---
-
-ALTER TABLE `#__content` ADD INDEX `idx_alias` (`alias`(191));

--- a/administrator/components/com_admin/sql/updates/mysql/3.8.4-2018-01-16.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.8.4-2018-01-16.sql
@@ -1,2 +1,0 @@
-ALTER TABLE `#__user_keys` DROP INDEX `series_2`;
-ALTER TABLE `#__user_keys` DROP INDEX `series_3`;

--- a/administrator/components/com_admin/sql/updates/mysql/3.8.8-2018-05-18.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.8.8-2018-05-18.sql
@@ -1,3 +1,0 @@
-INSERT INTO `#__postinstall_messages` (`extension_id`, `title_key`, `description_key`, `action_key`, `language_extension`, `language_client_id`, `type`, `action_file`, `action`, `condition_file`, `condition_method`, `version_introduced`, `enabled`)
-VALUES
-(700, 'COM_CPANEL_MSG_UPDATEDEFAULTSETTINGS_TITLE', 'COM_CPANEL_MSG_UPDATEDEFAULTSETTINGS_BODY', '', 'com_cpanel', 1, 'message', '', '', 'admin://components/com_admin/postinstall/updatedefaultsettings.php', 'admin_postinstall_updatedefaultsettings_condition', '3.8.8', 1);

--- a/administrator/components/com_admin/sql/updates/mysql/3.8.9-2018-06-19.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.8.9-2018-06-19.sql
@@ -1,2 +1,0 @@
--- Enable Sample Data Module.
-UPDATE `#__extensions` SET `enabled` = '1' WHERE `name` = 'mod_sampledata';

--- a/administrator/components/com_admin/sql/updates/postgresql/3.8.0-2017-07-28.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.8.0-2017-07-28.sql
@@ -1,1 +1,0 @@
-ALTER TABLE "#__fields_groups" ADD COLUMN "params" TEXT NOT NULL;

--- a/administrator/components/com_admin/sql/updates/postgresql/3.8.0-2017-07-31.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.8.0-2017-07-31.sql
@@ -1,5 +1,0 @@
-INSERT INTO "#__extensions"
-("package_id", "name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "manifest_cache", "params", "custom_data", "system_data", "checked_out", "checked_out_time", "ordering", "state")
-VALUES
-  (0, 'mod_sampledata', 'module', 'mod_sampledata', '', 1, 0, 1, 0, '', '{}', '', '', 0, '1970-01-01 00:00:00', 0, 0),
-  (0, 'plg_sampledata_blog', 'plugin', 'blog', 'sampledata', 0, 0, 1, 0, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0);

--- a/administrator/components/com_admin/sql/updates/postgresql/3.8.2-2017-10-14.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.8.2-2017-10-14.sql
@@ -1,5 +1,0 @@
---
--- Add index for alias check #__content
---
-
-CREATE INDEX "#__content_idx_alias" ON "#__content" ("alias");

--- a/administrator/components/com_admin/sql/updates/postgresql/3.8.4-2018-01-16.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.8.4-2018-01-16.sql
@@ -1,2 +1,0 @@
-DROP INDEX "#__user_keys_series_2";
-DROP INDEX "#__user_keys_series_3";

--- a/administrator/components/com_admin/sql/updates/postgresql/3.8.8-2018-05-18.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.8.8-2018-05-18.sql
@@ -1,3 +1,0 @@
-INSERT INTO "#__postinstall_messages" ("extension_id", "title_key", "description_key", "action_key", "language_extension", "language_client_id", "type", "action_file", "action", "condition_file", "condition_method", "version_introduced", "enabled")
-VALUES
-(700, 'COM_CPANEL_MSG_UPDATEDEFAULTSETTINGS_TITLE', 'COM_CPANEL_MSG_UPDATEDEFAULTSETTINGS_BODY', '', 'com_cpanel', 1, 'message', '', '', 'admin://components/com_admin/postinstall/updatedefaultsettings.php', 'admin_postinstall_updatedefaultsettings_condition', '3.8.8', 1);

--- a/administrator/components/com_admin/sql/updates/postgresql/3.8.9-2018-06-19.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.8.9-2018-06-19.sql
@@ -1,2 +1,0 @@
--- Enable Sample Data Module.
-UPDATE "#__extensions" SET "enabled" = '1' WHERE "name" = 'mod_sampledata';


### PR DESCRIPTION
follw-up discussion https://github.com/joomla/joomla-cms/pull/26297#issuecomment-531864131

### Summary of Changes

removed 3.8.x sql update scripts

