### PR TITLE
[FIX] Imagelist custom field default image broken

### DIFF
--- a/plugins/fields/imagelist/imagelist.php
+++ b/plugins/fields/imagelist/imagelist.php
@@ -9,14 +9,14 @@
 
 defined('_JEXEC') or die;
 
-JLoader::import('components.com_fields.libraries.fieldslistplugin', JPATH_ADMINISTRATOR);
+JLoader::import('components.com_fields.libraries.fieldsplugin', JPATH_ADMINISTRATOR);
 
 /**
  * Fields Imagelist Plugin
  *
  * @since  3.7.0
  */
-class PlgFieldsImagelist extends FieldsListPlugin
+class PlgFieldsImagelist extends FieldsPlugin
 {
 	/**
 	 * Transforms the field into a DOM XML element and appends it as a child on the given parent.


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/26350

Redoing https://github.com/joomla/joomla-cms/pull/24643 Thanks @ReLater 

### Summary of Changes

Add a default image in the custom field.
Saves OK now and displays OK in frontend.



### Testing Instructions
See https://github.com/joomla/joomla-cms/issues/26350#issuecomment-532592098

### Before patch
<img width="454" alt="Screen Shot 2019-09-18 at 10 55 58" src="https://user-images.githubusercontent.com/869724/65138594-7d1c1a80-da0b-11e9-8788-638d75c7ab0f.png">

### After patch

It saves OK and the default image is displayed when editing an article
<img width="473" alt="Screen Shot 2019-09-18 at 11 02 10" src="https://user-images.githubusercontent.com/869724/65138390-33333480-da0b-11e9-8089-ef65d41deea3.png">

and also displays in the article in frontend

<img width="767" alt="Screen Shot 2019-09-18 at 11 39 14" src="https://user-images.githubusercontent.com/869724/65138560-742b4900-da0b-11e9-96a8-6a53593d0071.png">

@SharkyKZ @EJBJane
We need this tested fast to get it in 3.9.12
