### PR TITLE
[4.0] [com_content] Throw exception in archive view when errors occur

### DIFF
--- a/components/com_content/View/Archive/HtmlView.php
+++ b/components/com_content/View/Archive/HtmlView.php
@@ -14,6 +14,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Plugin\PluginHelper;
 
@@ -107,6 +108,11 @@ class HtmlView extends BaseHtmlView
 		$state      = $this->get('State');
 		$items      = $this->get('Items');
 		$pagination = $this->get('Pagination');
+
+		if ($errors = $this->getModel()->getErrors())
+		{
+			throw new GenericDataException(implode("\n", $errors), 500);
+		}
 
 		// Flag indicates to not add limitstart=0 to URL
 		$pagination->hideEmptyLimitstart = true;

--- a/components/com_content/View/Archive/HtmlView.php
+++ b/components/com_content/View/Archive/HtmlView.php
@@ -100,7 +100,9 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  mixed  A string if successful, otherwise an Error object.
+	 * @return  void
+	 *
+	 * @throws  GenericDataException
 	 */
 	public function display($tpl = null)
 	{


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Throw an exception on errors like in most views.

### Testing Instructions

Use PostgreSQL or cause an error in category model's `getListQuery()` query, open Archive view.

### Expected result

Error page rendered.

### Actual result
```
Warning
: Invalid argument supplied for foreach() in
components\com_content\Model\ArticlesModel.php
on line
619

Warning
: Invalid argument supplied for foreach() in
components\com_content\View\Archive\HtmlView.php
on line
125

Warning: Invalid argument supplied for foreach() in components\com_content\tmpl\archive\default_items.php on line 20
```

### Documentation Changes Required

IDK.