### PR TITLE
[4.0] Add missing license header to passwordstrength.es5.js

### DIFF
--- a/build/media_source/system/js/fields/passwordstrength.es5.js
+++ b/build/media_source/system/js/fields/passwordstrength.es5.js
@@ -4,6 +4,28 @@
  * PasswordStrength script by Thomas Kjaergaard
  * License: MIT
  * Repo: https://github.com/tkjaergaard/Password-Strength
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014 Thomas Kjærgaard
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
 var PasswordStrength;
 


### PR DESCRIPTION
Add the missing MIT License to the file.