### PR TITLE
[4.0] - sql fix when CAST using CASE

### DIFF
--- a/components/com_contact/Model/CategoryModel.php
+++ b/components/com_contact/Model/CategoryModel.php
@@ -474,7 +474,7 @@ class CategoryModel extends ListModel
 			. ' THEN '
 			. $query->concatenate(array($query->castAsChar($id), $alias), ':')
 			. ' ELSE '
-			. $id . ' END';
+			. $query->castAsChar($id) . ' END';
 	}
 
 	/**

--- a/components/com_contact/Model/ContactModel.php
+++ b/components/com_contact/Model/ContactModel.php
@@ -442,7 +442,7 @@ class ContactModel extends FormModel
 			. ' THEN '
 			. $query->concatenate(array($query->castAsChar($id), $alias), ':')
 			. ' ELSE '
-			. $id . ' END';
+			. $query->castAsChar($id) . ' END';
 	}
 
 	/**

--- a/components/com_content/Model/ArchiveModel.php
+++ b/components/com_content/Model/ArchiveModel.php
@@ -226,6 +226,6 @@ class ArchiveModel extends ArticlesModel
 			. ' THEN '
 			. $query->concatenate(array($query->castAsChar($id), $alias), ':')
 			. ' ELSE '
-			. $id . ' END';
+			. $query->castAsChar($id) . ' END';
 	}
 }


### PR DESCRIPTION
Pull Request for Issue #26355 .

### Summary of Changes
Fixed the wrong `CAST`  when using `CASE`

when using case the  return type must be always the same 


### Testing Instructions

#26355 

### Expected result
no error


### Actual result
error on Postgresql


