### PR TITLE
Allows for the ability to have icons instead of image in menu

### DIFF
--- a/modules/mod_menu/tmpl/default_component.php
+++ b/modules/mod_menu/tmpl/default_component.php
@@ -45,6 +45,11 @@ if ($item->menu_image)
 		$linktype .= '<span class="image-title">' . $item->title . '</span>';
 	}
 }
+// Allow icon instead of image.
+elseif ($item->menu_image_css)
+{
+	$linktype = '<i class="' . $item->menu_image_css . '"></i>' . $linktype;
+}
 
 if ($item->browserNav == 1)
 {

--- a/modules/mod_menu/tmpl/default_heading.php
+++ b/modules/mod_menu/tmpl/default_heading.php
@@ -31,6 +31,11 @@ if ($item->menu_image)
 		$linktype .= '<span class="image-title">' . $item->title . '</span>';
 	}
 }
+// Allow icon instead of image.
+elseif ($item->menu_image_css)
+{
+	$linktype = '<i class="' . $item->menu_image_css . '"></i>' . $linktype;
+}
 
 ?>
 <span class="nav-header <?php echo $anchor_css; ?>"<?php echo $title; ?>><?php echo $linktype; ?></span>

--- a/modules/mod_menu/tmpl/default_separator.php
+++ b/modules/mod_menu/tmpl/default_separator.php
@@ -31,6 +31,10 @@ if ($item->menu_image)
 		$linktype .= '<span class="image-title">' . $item->title . '</span>';
 	}
 }
-
+// Allow icon instead of image.
+elseif ($item->menu_image_css)
+{
+	$linktype = '<i class="' . $item->menu_image_css . '"></i>' . $linktype;
+}
 ?>
 <span class="separator <?php echo $anchor_css; ?>"<?php echo $title; ?>><?php echo $linktype; ?></span>

--- a/modules/mod_menu/tmpl/default_url.php
+++ b/modules/mod_menu/tmpl/default_url.php
@@ -45,6 +45,11 @@ if ($item->menu_image)
 		$linktype .= '<span class="image-title">' . $item->title . '</span>';
 	}
 }
+// Allow icon instead of image.
+elseif ($item->menu_image_css)
+{
+	$linktype = '<i class="' . $item->menu_image_css . '"></i>' . $linktype;
+}
 
 if ($item->browserNav == 1)
 {


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Adds the ability to use menu image css for icons when menu image is not used.


### Testing Instructions
add "icon-home" to the menu image css option.
view page.  You should see icon then title.
![image](https://user-images.githubusercontent.com/1850089/65336197-83d19b80-db8b-11e9-9b88-ce16cfd7b316.png)

### Expected result
![image](https://user-images.githubusercontent.com/1850089/65336272-afed1c80-db8b-11e9-8f25-a2430745d977.png)

### Actual result
![image](https://user-images.githubusercontent.com/1850089/65336297-bda2a200-db8b-11e9-862a-baa63af3abed.png)

### Documentation Changes Required
Add explanation stating the the menu image class can also be an icon class.