### PR TITLE
[4.0] Add focus highlight to switcher

### DIFF
--- a/build/media_source/system/scss/fields/switcher.scss
+++ b/build/media_source/system/scss/fields/switcher.scss
@@ -33,6 +33,11 @@ $switcher-height: 28px;
   opacity: 0;
 }
 
+.switcher input:focus ~ .toggle-outside {
+  border-color: var(--focus);
+  box-shadow: 0 0 0 .2rem rgba(26,70,107,.25);
+}
+
 .switcher label {
   line-height: $switcher-height;
   display: inline-block;


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Adds a focus highlight to the switcher field when in focus.

### Testing Instructions
Apply this patch and run `node build.js --compile-css` for updating the changed SCSS. Alternatively, you can run `npm i`.

Navgiate to a page using the switcher (global config). Tab until switcher in focus.

### Before
![image](https://user-images.githubusercontent.com/2803503/65389095-39e2e400-dd4a-11e9-9075-676d9dbaf29d.png)



### After
![image](https://user-images.githubusercontent.com/2803503/65389098-46673c80-dd4a-11e9-9933-fef3ea5cdb1f.png)



### Documentation Changes Required

