### PR TITLE
Fixing Exception message in Nested::_getNode()

### DIFF
--- a/libraries/src/Table/Nested.php
+++ b/libraries/src/Table/Nested.php
@@ -1648,7 +1648,7 @@ class Nested extends Table
 		// Check for no $row returned
 		if (empty($row))
 		{
-			$e = new \UnexpectedValueException(sprintf('%s::_getNode(%d, %s) failed.', \get_class($this), $id, $key));
+			$e = new \UnexpectedValueException(sprintf('%s::_getNode(%d, %s) failed.', \get_class($this), $id, $k));
 			$this->setError($e);
 
 			return false;


### PR DESCRIPTION
The $key variable used here most of the time is empty and the default is used. In order to get a meaningfull error message, I'm not using that parameter, but the $k variable, which is always filled at this point.