### PR TITLE
[4.0] Site name on login

### DIFF
--- a/administrator/templates/atum/login.php
+++ b/administrator/templates/atum/login.php
@@ -143,7 +143,8 @@ Text::script('JGLOBAL_WARNCOOKIES');
 	<?php // Sidebar ?>
 	<div id="sidebar-wrapper" class="sidebar-wrapper order-0">
 		<div id="main-brand" class="main-brand">
-			<h1><?php echo Text::_('TPL_ATUM_BACKEND_LOGIN'); ?></h1>
+			<h1><?php echo $app->get('sitename'); ?></h1>
+			<h2><?php echo Text::_('TPL_ATUM_BACKEND_LOGIN'); ?></h2>
 		</div>
 		<div id="sidebar">
 			<jdoc:include type="modules" name="sidebar" style="body" />


### PR DESCRIPTION
Somewhere along the way the j4 template lost the display of the sitename on the login page

Amongst other things this resulted in an accessibility error as there was an H1 and H3 but no H2

Pull Request for Issue #26313 

### Sidebar of login page after applying the patch
![image](https://user-images.githubusercontent.com/1296369/65429408-08cbe780-de0e-11e9-9af3-f20ebe5e7505.png)
