### PR TITLE
[4.0] Installer improvements

### DIFF
--- a/installation/src/Model/DatabaseModel.php
+++ b/installation/src/Model/DatabaseModel.php
@@ -822,19 +822,9 @@ class DatabaseModel extends BaseInstallationModel
 		// Create the ID for the root user.
 		$userId = self::getUserId();
 
-		// Update all core tables created_by fields of the tables with the random user id.
+		// Update created_by fields with the random user id.
 		$updatesArray = array(
-			'#__banners'         => array('created_by', 'modified_by'),
-			'#__categories'      => array('created_user_id', 'modified_user_id'),
-			'#__contact_details' => array('created_by', 'modified_by'),
-			'#__content'         => array('created_by', 'modified_by'),
-			'#__fields'          => array('created_user_id', 'modified_by'),
-			'#__finder_filters'  => array('created_by', 'modified_by'),
-			'#__newsfeeds'       => array('created_by', 'modified_by'),
-			'#__tags'            => array('created_user_id', 'modified_user_id'),
-			'#__ucm_content'     => array('core_created_user_id', 'core_modified_user_id'),
-			'#__ucm_history'     => array('editor_user_id'),
-			'#__user_notes'      => array('created_user_id', 'modified_user_id'),
+			'#__categories'      => array('created_user_id'),
 		);
 
 		foreach ($updatesArray as $table => $fields)
@@ -843,9 +833,7 @@ class DatabaseModel extends BaseInstallationModel
 			{
 				$query = $db->getQuery(true)
 					->update($db->quoteName($table))
-					->set($db->quoteName($field) . ' = ' . $db->quote($userId))
-					->where($db->quoteName($field) . ' != 0')
-					->where($db->quoteName($field) . ' IS NOT NULL');
+					->set($db->quoteName($field) . ' = ' . $db->quote($userId));
 
 				$db->setQuery($query);
 
@@ -874,7 +862,6 @@ class DatabaseModel extends BaseInstallationModel
 	{
 		// Get the current date.
 		$currentDate = Factory::getDate()->toSql();
-		$nullDate    = $db->getNullDate();
 
 		// Update date fields with the current date.
 		$updatesArray = array(

--- a/installation/src/Model/DatabaseModel.php
+++ b/installation/src/Model/DatabaseModel.php
@@ -876,26 +876,10 @@ class DatabaseModel extends BaseInstallationModel
 		$currentDate = Factory::getDate()->toSql();
 		$nullDate    = $db->getNullDate();
 
-		// Update all core tables date fields of the tables with the current date.
+		// Update date fields with the current date.
 		$updatesArray = array(
-			'#__banners'             => array('publish_up', 'publish_down', 'reset', 'created', 'modified'),
-			'#__banner_tracks'       => array('track_date'),
-			'#__categories'          => array('created_time', 'modified_time'),
-			'#__contact_details'     => array('publish_up', 'publish_down', 'created', 'modified'),
-			'#__content'             => array('publish_up', 'publish_down', 'created', 'modified'),
-			'#__contentitem_tag_map' => array('tag_date'),
-			'#__fields'              => array('created_time', 'modified_time'),
-			'#__finder_filters'      => array('created', 'modified'),
-			'#__finder_links'        => array('indexdate', 'publish_start_date', 'publish_end_date', 'start_date', 'end_date'),
-			'#__messages'            => array('date_time'),
-			'#__modules'             => array('publish_up', 'publish_down'),
-			'#__newsfeeds'           => array('publish_up', 'publish_down', 'created', 'modified'),
-			'#__redirect_links'      => array('created_date', 'modified_date'),
-			'#__tags'                => array('publish_up', 'publish_down', 'created_time', 'modified_time'),
-			'#__ucm_content'         => array('core_created_time', 'core_modified_time', 'core_publish_up', 'core_publish_down'),
-			'#__ucm_history'         => array('save_date'),
-			'#__users'               => array('registerDate', 'lastvisitDate', 'lastResetTime'),
-			'#__user_notes'          => array('publish_up', 'publish_down', 'created_time', 'modified_time'),
+			'#__categories'          => array('created_time'),
+			'#__modules'             => array('publish_up'),
 		);
 
 		foreach ($updatesArray as $table => $fields)
@@ -904,9 +888,7 @@ class DatabaseModel extends BaseInstallationModel
 			{
 				$query = $db->getQuery(true)
 					->update($db->quoteName($table))
-					->set($db->quoteName($field) . ' = ' . $db->quote($currentDate))
-					->where($db->quoteName($field) . ' IS NOT NULL')
-					->where($db->quoteName($field) . ' != ' . $db->quote($nullDate));
+					->set($db->quoteName($field) . ' = ' . $db->quote($currentDate));
 
 				$db->setQuery($query);
 


### PR DESCRIPTION
Pull Request for Issue #26387 .

### Summary of Changes
Don't perform update queries where they are not needed. 
Make sure that the queries performed are correct


### Testing Instructions
Perform a clean install
Check the db table and you will see that modules have no start publishing date

Export the database

apply the pr 

Perform a clean install
Check the db table and you will see that modules have a start publishing date

Export the database

Compare the two database exports

The only differences between the two exports will be sessions, admin password and the timestamps.

There should be no difference for the userid
There should be a difference with the modules publish_up date which should be the time of the install and not 0000

### Benefits
Less queries performed that are not needed reduces the installation time etc