### PR TITLE
[4.0] Fix index name for finder_terms_common everywhere

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/4.0.0-2018-07-29.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.0.0-2018-07-29.sql
@@ -86,7 +86,7 @@ CREATE TABLE `#__finder_terms_common` (
   `term` varchar(75) NOT NULL DEFAULT '',
   `language` char(7) NOT NULL DEFAULT '',
   `custom` int(11) NOT NULL DEFAULT '0',
-  UNIQUE KEY `idx_word_lang` (`term`,`language`),
+  UNIQUE KEY `idx_term_language` (`term`,`language`),
   KEY `idx_lang` (`language`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_bin;
 INSERT INTO `#__finder_terms_common` (`term`, `language`, `custom`) VALUES

--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2018-07-29.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2018-07-29.sql
@@ -90,9 +90,8 @@ CREATE TABLE "#__finder_terms_common" (
   "term" varchar(75) NOT NULL,
   "language" varchar(7) DEFAULT '' NOT NULL,
   "custom" integer DEFAULT 0 NOT NULL,
-  CONSTRAINT "#__finder_terms_idx_term" UNIQUE ("term", "language")
+  CONSTRAINT "#__finder_terms_common_idx_term_language" UNIQUE ("term", "language")
 );
-CREATE INDEX "#__finder_terms_common_idx_word_lang" on "#__finder_terms_common" ("term", "language");
 CREATE INDEX "#__finder_terms_common_idx_lang" on "#__finder_terms_common" ("language");
 INSERT INTO "#__finder_terms_common" ("term", "language", "custom") VALUES
 	('i', 'en', 0),

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -999,7 +999,7 @@ CREATE TABLE IF NOT EXISTS `#__finder_terms_common` (
   `term` varchar(75) NOT NULL DEFAULT '',
   `language` char(7) NOT NULL DEFAULT '',
   `custom` int(11) NOT NULL DEFAULT '0',
-  UNIQUE KEY `idx_word_lang` (`term`,`language`),
+  UNIQUE KEY `idx_term_language` (`term`,`language`),
   KEY `idx_lang` (`language`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_bin;
 


### PR DESCRIPTION
Pull Request for Issue [https://github.com/joomla/joomla-cms/pull/26351#issuecomment-533783699](https://github.com/joomla/joomla-cms/pull/26351#issuecomment-533783699) .

### Summary of Changes

This Pull Request (PR) does the same change as PR #26351 in postgresql/joomla.sql also for the update sql script "4.0.0-2018-07-29.sql" so there is no database error shown about missing index after a new installation of J4 on a PostgreSQL database.

Furthermore, the index name of the same index for MySQL is changed so it also fits to our naming scheme and is consistent with PostgreSQL (except that the latter has the table name as beginning of the index name), i.e. if someone searches for "idx_term_language" in sql files, he/she will find it in both MySQL and PostgreSQL joomla.sql and 4.0.0-2018-07-29.sql files.

**Note on updating old 4.0 sql update scripts**

Since we are not in Beta phase yet and so don't have to support updates from 4.0-Alpha-x to 4.0-Alpha-y or between nightly builds, we can change the existing 4.0 update scripts (but of course not pre-4.0 scripts). Later when in beta this will not be allowed anymore because we have to support updating from Beta-x to Beta-y (with y > x of course), so now is a good time to fix them.

### Testing Instructions

**For PostgreSQL**

1. Make a new installation of current 4.0-dev on a PostgreSQL database.
2. After installation has finished, go to Extensions -> Manage -> Database and check if there are database errors shown.
3. Verify that the change in file 4.0.0-2018-07-29.sql for PostgreSQL is the same change as PR #26351 has made in joomla.sql for this database type.

**For MySQL**

1. Make a new installation of current 4.0-dev on a MySQL database.
2. After installation has finished, go to Extensions -> Manage -> Database and check if there are database errors shown.
3. Check e.g. in PhpMyAdmin the name of the index on columns `term` and `language` of the `#__finder_terms_common` table.

### Expected result

**On PostgreSQL**

No database errors shown.

**On MySQL**

No database errors shown.

Index name is consistent with PostgreSQL (except that the latter has the table name as beginning of the index name).

### Actual result

**On PostgreSQL**

Database error shown, see [https://github.com/joomla/joomla-cms/pull/26351#issuecomment-533783699](https://github.com/joomla/joomla-cms/pull/26351#issuecomment-533783699) .

**On MySQL**

No database errors shown.

Index name is not consistent with PostgreSQL and our naming scheme "idx_column1_column2" for an index over 2 columns.

### Documentation Changes Required

None.