### PR TITLE
Remove @package tag from library doc blocks

### DIFF
--- a/libraries/src/Captcha/Captcha.php
+++ b/libraries/src/Captcha/Captcha.php
@@ -19,7 +19,7 @@ use Joomla\Registry\Registry;
  * Joomla! Captcha base object
  *
  * @abstract
- * @since       2.5
+ * @since  2.5
  */
 class Captcha extends \JObject
 {

--- a/libraries/src/Captcha/Captcha.php
+++ b/libraries/src/Captcha/Captcha.php
@@ -19,8 +19,6 @@ use Joomla\Registry\Registry;
  * Joomla! Captcha base object
  *
  * @abstract
- * @package     Joomla.Libraries
- * @subpackage  Captcha
  * @since       2.5
  */
 class Captcha extends \JObject

--- a/libraries/src/Client/ClientWrapper.php
+++ b/libraries/src/Client/ClientWrapper.php
@@ -13,8 +13,6 @@ defined('JPATH_PLATFORM') or die;
 /**
  * Wrapper class for ClientHelper
  *
- * @package     Joomla.Platform
- * @subpackage  Client
  * @since       3.4
  * @deprecated  4.0 Will be removed without replacement
  */

--- a/libraries/src/Filesystem/Wrapper/FileWrapper.php
+++ b/libraries/src/Filesystem/Wrapper/FileWrapper.php
@@ -15,8 +15,6 @@ defined('JPATH_PLATFORM') or die;
 /**
  * Wrapper class for File
  *
- * @package     Joomla.Platform
- * @subpackage  Filesystem
  * @since       3.4
  * @deprecated  4.0 Use \Joomla\CMS\Filesystem\File instead
  */

--- a/libraries/src/Filesystem/Wrapper/FolderWrapper.php
+++ b/libraries/src/Filesystem/Wrapper/FolderWrapper.php
@@ -15,8 +15,6 @@ defined('JPATH_PLATFORM') or die;
 /**
  * Wrapper class for Folder
  *
- * @package     Joomla.Platform
- * @subpackage  Filesystem
  * @since       3.4
  * @deprecated  4.0 Use \Joomla\CMS\Filesystem\Folder instead
  */

--- a/libraries/src/Filesystem/Wrapper/PathWrapper.php
+++ b/libraries/src/Filesystem/Wrapper/PathWrapper.php
@@ -15,8 +15,6 @@ defined('JPATH_PLATFORM') or die;
 /**
  * Wrapper class for Path
  *
- * @package     Joomla.Platform
- * @subpackage  Filesystem
  * @since       3.4
  * @deprecated  4.0 Use \Joomla\CMS\Filesystem\Path instead
  */

--- a/libraries/src/Http/Wrapper/FactoryWrapper.php
+++ b/libraries/src/Http/Wrapper/FactoryWrapper.php
@@ -18,9 +18,7 @@ use Joomla\CMS\Http\TransportInterface;
 /**
  * Wrapper class for HttpFactory
  *
- * @package     Joomla.Platform
- * @subpackage  Http
- * @since       3.4
+ * @since  3.4
  */
 class FactoryWrapper
 {

--- a/libraries/src/Mail/MailWrapper.php
+++ b/libraries/src/Mail/MailWrapper.php
@@ -13,8 +13,6 @@ defined('JPATH_PLATFORM') or die;
 /**
  * Wrapper class for MailHelper
  *
- * @package     Joomla.Platform
- * @subpackage  Mail
  * @since       3.4
  * @deprecated  4.0 Will be removed without replacement
  */

--- a/libraries/src/Mail/language/phpmailer.lang-en_gb.php
+++ b/libraries/src/Mail/language/phpmailer.lang-en_gb.php
@@ -1,7 +1,6 @@
 <?php
 /**
- * @package     Joomla.Platform
- * @subpackage  Mail
+ * Joomla! Content Management System
  *
  * @copyright   Copyright (C) 2005 - 2019 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt

--- a/libraries/src/Mail/language/phpmailer.lang-en_gb.php
+++ b/libraries/src/Mail/language/phpmailer.lang-en_gb.php
@@ -2,8 +2,8 @@
 /**
  * Joomla! Content Management System
  *
- * @copyright   Copyright (C) 2005 - 2019 Open Source Matters, Inc. All rights reserved.
- * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ * @copyright  Copyright (C) 2005 - 2019 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
 
 defined('JPATH_PLATFORM') or die;

--- a/libraries/src/Table/UpdateSite.php
+++ b/libraries/src/Table/UpdateSite.php
@@ -14,9 +14,7 @@ defined('JPATH_PLATFORM') or die;
  * Update site table
  * Stores the update sites for extensions
  *
- * @package     Joomla.Platform
- * @subpackage  Table
- * @since       3.4
+ * @since  3.4
  */
 class UpdateSite extends Table
 {

--- a/libraries/src/Toolbar/ToolbarHelper.php
+++ b/libraries/src/Toolbar/ToolbarHelper.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @package    Joomla.Administrator
+ * Joomla! Content Management System
  *
  * @copyright  Copyright (C) 2005 - 2019 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE.txt


### PR DESCRIPTION
Pull Request for Issue #26395.

### Summary of Changes

Removes `@package` and `@subpackage` tags from core library files.

### Testing Instructions

Code review.

### Documentation Changes Required

No.