### PR TITLE
[4.0] Use setLimit() to set query limit

### DIFF
--- a/administrator/components/com_privacy/Model/ExportModel.php
+++ b/administrator/components/com_privacy/Model/ExportModel.php
@@ -84,9 +84,8 @@ class ExportModel extends BaseDatabaseModel
 			$db->getQuery(true)
 				->select('id')
 				->from($db->quoteName('#__users'))
-				->where($db->quoteName('email') . ' = ' . $db->quote($table->email)),
-			0,
-			1
+				->where($db->quoteName('email') . ' = ' . $db->quote($table->email))
+				->setLimit(1)
 		)->loadResult();
 
 		$user = $userId ? User::getInstance($userId) : null;

--- a/administrator/components/com_privacy/Model/RemoveModel.php
+++ b/administrator/components/com_privacy/Model/RemoveModel.php
@@ -80,9 +80,8 @@ class RemoveModel extends BaseDatabaseModel
 			$db->getQuery(true)
 				->select('id')
 				->from($db->quoteName('#__users'))
-				->where($db->quoteName('email') . ' = ' . $db->quote($table->email)),
-			0,
-			1
+				->where($db->quoteName('email') . ' = ' . $db->quote($table->email))
+				->setLimit(1)
 		)->loadResult();
 
 		$user = $userId ? User::getInstance($userId) : null;

--- a/administrator/components/com_privacy/Model/RequestModel.php
+++ b/administrator/components/com_privacy/Model/RequestModel.php
@@ -265,9 +265,8 @@ class RequestModel extends AdminModel
 			$db->getQuery(true)
 				->select('id')
 				->from($db->quoteName('#__users'))
-				->where($db->quoteName('email') . ' = ' . $db->quote($table->email)),
-			0,
-			1
+				->where($db->quoteName('email') . ' = ' . $db->quote($table->email))
+				->setLimit(1)
 		)->loadResult();
 
 		if ($userId)


### PR DESCRIPTION
### Summary of Changes

Limit and offset arguments of `Joomla\Database\DatabaseInterface::setQuery()` are deprecated. Use `Joomla\Database\Query\LimitableInterface::setLimit()` instead.

### Testing Instructions

Code review.

### Documentation Changes Required

No.