### PR TITLE
Implement and add validate="filepath"

### DIFF
--- a/administrator/components/com_banners/models/forms/banner.xml
+++ b/administrator/components/com_banners/models/forms/banner.xml
@@ -339,7 +339,7 @@
 				directory="banners"
 				hide_none="1"
 				size="40"
-				validate="filepath"
+				validate="filePath"
 			/>
 
 			<field

--- a/administrator/components/com_banners/models/forms/banner.xml
+++ b/administrator/components/com_banners/models/forms/banner.xml
@@ -339,6 +339,7 @@
 				directory="banners"
 				hide_none="1"
 				size="40"
+				validate="filepath"
 			/>
 
 			<field

--- a/administrator/components/com_categories/models/forms/category.xml
+++ b/administrator/components/com_categories/models/forms/category.xml
@@ -263,6 +263,7 @@
 				type="media"
 				label="COM_CATEGORIES_FIELD_IMAGE_LABEL"
 				description="COM_CATEGORIES_FIELD_IMAGE_DESC"
+				validate="filepath"
 			/>
 
 			<field

--- a/administrator/components/com_categories/models/forms/category.xml
+++ b/administrator/components/com_categories/models/forms/category.xml
@@ -263,7 +263,7 @@
 				type="media"
 				label="COM_CATEGORIES_FIELD_IMAGE_LABEL"
 				description="COM_CATEGORIES_FIELD_IMAGE_DESC"
-				validate="filepath"
+				validate="filePath"
 			/>
 
 			<field

--- a/administrator/components/com_config/model/form/application.xml
+++ b/administrator/components/com_config/model/form/application.xml
@@ -1080,6 +1080,7 @@
 			label="COM_CONFIG_FIELD_OFFLINE_IMAGE_LABEL"
 			description="COM_CONFIG_FIELD_OFFLINE_IMAGE_DESC"
 			showon="offline:1"
+			validate="filepath"
 		/>
 
 		<field

--- a/administrator/components/com_config/model/form/application.xml
+++ b/administrator/components/com_config/model/form/application.xml
@@ -1080,7 +1080,7 @@
 			label="COM_CONFIG_FIELD_OFFLINE_IMAGE_LABEL"
 			description="COM_CONFIG_FIELD_OFFLINE_IMAGE_DESC"
 			showon="offline:1"
-			validate="filepath"
+			validate="filePath"
 		/>
 
 		<field

--- a/administrator/components/com_contact/config.xml
+++ b/administrator/components/com_contact/config.xml
@@ -291,6 +291,7 @@
 			description="COM_CONTACT_FIELD_PARAMS_IMAGE_DESC"
 			default=""
 			showon="show_info:1[AND]show_image:1"
+			validate="filepath"
 		/>
 
 		<field
@@ -467,6 +468,7 @@
 			hide_none="1"
 			default=""
 			showon="contact_icons:0"
+			validate="filepath"
 		/>
 
 		<field
@@ -477,6 +479,7 @@
 			hide_none="1"
 			default=""
 			showon="contact_icons:0"
+			validate="filepath"
 		/>
 
 		<field
@@ -487,6 +490,7 @@
 			hide_none="1"
 			default=""
 			showon="contact_icons:0"
+			validate="filepath"
 		/>
 
 		<field
@@ -497,6 +501,7 @@
 			hide_none="1"
 			default=""
 			showon="contact_icons:0"
+			validate="filepath"
 		/>
 
 		<field
@@ -507,6 +512,7 @@
 			hide_none="1"
 			default=""
 			showon="contact_icons:0"
+			validate="filepath"
 		/>
 
 		<field
@@ -517,6 +523,7 @@
 			hide_none="1"
 			default=""
 			showon="contact_icons:0"
+			validate="filepath"
 		/>
 	</fieldset>
 

--- a/administrator/components/com_contact/config.xml
+++ b/administrator/components/com_contact/config.xml
@@ -291,7 +291,7 @@
 			description="COM_CONTACT_FIELD_PARAMS_IMAGE_DESC"
 			default=""
 			showon="show_info:1[AND]show_image:1"
-			validate="filepath"
+			validate="filePath"
 		/>
 
 		<field
@@ -468,7 +468,7 @@
 			hide_none="1"
 			default=""
 			showon="contact_icons:0"
-			validate="filepath"
+			validate="filePath"
 		/>
 
 		<field
@@ -479,7 +479,7 @@
 			hide_none="1"
 			default=""
 			showon="contact_icons:0"
-			validate="filepath"
+			validate="filePath"
 		/>
 
 		<field
@@ -490,7 +490,7 @@
 			hide_none="1"
 			default=""
 			showon="contact_icons:0"
-			validate="filepath"
+			validate="filePath"
 		/>
 
 		<field
@@ -501,7 +501,7 @@
 			hide_none="1"
 			default=""
 			showon="contact_icons:0"
-			validate="filepath"
+			validate="filePath"
 		/>
 
 		<field
@@ -512,7 +512,7 @@
 			hide_none="1"
 			default=""
 			showon="contact_icons:0"
-			validate="filepath"
+			validate="filePath"
 		/>
 
 		<field
@@ -523,7 +523,7 @@
 			hide_none="1"
 			default=""
 			showon="contact_icons:0"
-			validate="filepath"
+			validate="filePath"
 		/>
 	</fieldset>
 

--- a/administrator/components/com_contact/models/forms/contact.xml
+++ b/administrator/components/com_contact/models/forms/contact.xml
@@ -253,6 +253,7 @@
 			label="COM_CONTACT_FIELD_ICONS_ADDRESS_LABEL"
 			description="COM_CONTACT_FIELD_ICONS_ADDRESS_DESC"
 			hide_none="1"
+			validate="filepath"
 		/>
 
 		<field
@@ -261,6 +262,7 @@
 			label="COM_CONTACT_FIELD_ICONS_EMAIL_LABEL"
 			description="COM_CONTACT_FIELD_ICONS_EMAIL_DESC"
 			hide_none="1"
+			validate="filepath"
 		/>
 
 		<field
@@ -269,6 +271,7 @@
 			label="COM_CONTACT_FIELD_ICONS_TELEPHONE_LABEL"
 			description="COM_CONTACT_FIELD_ICONS_TELEPHONE_DESC"
 			hide_none="1"
+			validate="filepath"
 		/>
 
 		<field
@@ -277,6 +280,7 @@
 			label="COM_CONTACT_FIELD_ICONS_MOBILE_LABEL"
 			description="COM_CONTACT_FIELD_ICONS_MOBILE_DESC"
 			hide_none="1"
+			validate="filepath"
 		/>
 
 		<field
@@ -285,6 +289,7 @@
 			label="COM_CONTACT_FIELD_ICONS_FAX_LABEL"
 			description="COM_CONTACT_FIELD_ICONS_FAX_DESC"
 			hide_none="1"
+			validate="filepath"
 		/>
 
 		<field
@@ -293,6 +298,7 @@
 			label="COM_CONTACT_FIELD_ICONS_MISC_LABEL"
 			description="COM_CONTACT_FIELD_ICONS_MISC_DESC"
 			hide_none="1"
+			validate="filepath"
 		/>
 	</fieldset>
 
@@ -311,6 +317,7 @@
 			label="COM_CONTACT_FIELD_PARAMS_IMAGE_LABEL"
 			description="COM_CONTACT_FIELD_PARAMS_IMAGE_DESC"
 			hide_none="1"
+			validate="filepath"
 		/>
 
 		<field

--- a/administrator/components/com_content/models/forms/article.xml
+++ b/administrator/components/com_content/models/forms/article.xml
@@ -824,7 +824,7 @@
 			type="media"
 			label="COM_CONTENT_FIELD_INTRO_LABEL"
 			description="COM_CONTENT_FIELD_INTRO_DESC" 
-			validate="filepath"
+			validate="filePath"
 		/>
 
 		<field
@@ -866,7 +866,7 @@
 			type="media"
 			label="COM_CONTENT_FIELD_FULL_LABEL"
 			description="COM_CONTENT_FIELD_FULL_DESC"
-			validate="filepath"
+			validate="filePath"
 		/>
 
 		<field

--- a/administrator/components/com_content/models/forms/article.xml
+++ b/administrator/components/com_content/models/forms/article.xml
@@ -824,8 +824,9 @@
 			type="media"
 			label="COM_CONTENT_FIELD_INTRO_LABEL"
 			description="COM_CONTENT_FIELD_INTRO_DESC" 
+			validate="filepath"
 		/>
-		
+
 		<field
 			name="float_intro"
 			type="list"
@@ -865,6 +866,7 @@
 			type="media"
 			label="COM_CONTENT_FIELD_FULL_LABEL"
 			description="COM_CONTENT_FIELD_FULL_DESC"
+			validate="filepath"
 		/>
 
 		<field

--- a/administrator/components/com_menus/models/forms/item_alias.xml
+++ b/administrator/components/com_menus/models/forms/item_alias.xml
@@ -55,6 +55,7 @@
 				type="media"
 				label="COM_MENUS_ITEM_FIELD_MENU_IMAGE_LABEL"
 				description="COM_MENUS_ITEM_FIELD_MENU_IMAGE_DESC"
+				validate="filepath"
 			/>
 
 			<field

--- a/administrator/components/com_menus/models/forms/item_alias.xml
+++ b/administrator/components/com_menus/models/forms/item_alias.xml
@@ -55,7 +55,7 @@
 				type="media"
 				label="COM_MENUS_ITEM_FIELD_MENU_IMAGE_LABEL"
 				description="COM_MENUS_ITEM_FIELD_MENU_IMAGE_DESC"
-				validate="filepath"
+				validate="filePath"
 			/>
 
 			<field

--- a/administrator/components/com_menus/models/forms/item_component.xml
+++ b/administrator/components/com_menus/models/forms/item_component.xml
@@ -23,6 +23,7 @@
 				type="media"
 				label="COM_MENUS_ITEM_FIELD_MENU_IMAGE_LABEL"
 				description="COM_MENUS_ITEM_FIELD_MENU_IMAGE_DESC" 
+				validate="filepath"
 			/>
 
 			<field 

--- a/administrator/components/com_menus/models/forms/item_component.xml
+++ b/administrator/components/com_menus/models/forms/item_component.xml
@@ -23,7 +23,7 @@
 				type="media"
 				label="COM_MENUS_ITEM_FIELD_MENU_IMAGE_LABEL"
 				description="COM_MENUS_ITEM_FIELD_MENU_IMAGE_DESC" 
-				validate="filepath"
+				validate="filePath"
 			/>
 
 			<field 

--- a/administrator/components/com_menus/models/forms/item_heading.xml
+++ b/administrator/components/com_menus/models/forms/item_heading.xml
@@ -23,6 +23,7 @@
 				type="media"
 				label="COM_MENUS_ITEM_FIELD_MENU_IMAGE_LABEL"
 				description="COM_MENUS_ITEM_FIELD_MENU_IMAGE_DESC" 
+				validate="filepath"
 			/>
 
 			<field 

--- a/administrator/components/com_menus/models/forms/item_heading.xml
+++ b/administrator/components/com_menus/models/forms/item_heading.xml
@@ -23,7 +23,7 @@
 				type="media"
 				label="COM_MENUS_ITEM_FIELD_MENU_IMAGE_LABEL"
 				description="COM_MENUS_ITEM_FIELD_MENU_IMAGE_DESC" 
-				validate="filepath"
+				validate="filePath"
 			/>
 
 			<field 

--- a/administrator/components/com_menus/models/forms/item_separator.xml
+++ b/administrator/components/com_menus/models/forms/item_separator.xml
@@ -17,6 +17,7 @@
 				type="media"
 				label="COM_MENUS_ITEM_FIELD_MENU_IMAGE_LABEL"
 				description="COM_MENUS_ITEM_FIELD_MENU_IMAGE_DESC" 
+				validate="filepath"
 			/>
 
 			<field 

--- a/administrator/components/com_menus/models/forms/item_separator.xml
+++ b/administrator/components/com_menus/models/forms/item_separator.xml
@@ -17,7 +17,7 @@
 				type="media"
 				label="COM_MENUS_ITEM_FIELD_MENU_IMAGE_LABEL"
 				description="COM_MENUS_ITEM_FIELD_MENU_IMAGE_DESC" 
-				validate="filepath"
+				validate="filePath"
 			/>
 
 			<field 

--- a/administrator/components/com_menus/models/forms/item_url.xml
+++ b/administrator/components/com_menus/models/forms/item_url.xml
@@ -45,7 +45,7 @@
 				type="media"
 				label="COM_MENUS_ITEM_FIELD_MENU_IMAGE_LABEL"
 				description="COM_MENUS_ITEM_FIELD_MENU_IMAGE_DESC" 
-				validate="filepath"
+				validate="filePath"
 			/>
 
 			<field 

--- a/administrator/components/com_menus/models/forms/item_url.xml
+++ b/administrator/components/com_menus/models/forms/item_url.xml
@@ -45,6 +45,7 @@
 				type="media"
 				label="COM_MENUS_ITEM_FIELD_MENU_IMAGE_LABEL"
 				description="COM_MENUS_ITEM_FIELD_MENU_IMAGE_DESC" 
+				validate="filepath"
 			/>
 
 			<field 

--- a/administrator/components/com_menus/models/forms/itemadmin_alias.xml
+++ b/administrator/components/com_menus/models/forms/itemadmin_alias.xml
@@ -41,6 +41,7 @@
 				type="media"
 				label="COM_MENUS_ITEM_FIELD_MENU_IMAGE_LABEL"
 				description="COM_MENUS_ITEM_FIELD_MENU_IMAGE_DESC"
+				validate="filepath"
 			/>
 
 			<field 

--- a/administrator/components/com_menus/models/forms/itemadmin_alias.xml
+++ b/administrator/components/com_menus/models/forms/itemadmin_alias.xml
@@ -41,7 +41,7 @@
 				type="media"
 				label="COM_MENUS_ITEM_FIELD_MENU_IMAGE_LABEL"
 				description="COM_MENUS_ITEM_FIELD_MENU_IMAGE_DESC"
-				validate="filepath"
+				validate="filePath"
 			/>
 
 			<field 

--- a/administrator/components/com_menus/models/forms/itemadmin_component.xml
+++ b/administrator/components/com_menus/models/forms/itemadmin_component.xml
@@ -24,6 +24,7 @@
 				type="media"
 				label="COM_MENUS_ITEM_FIELD_MENU_IMAGE_LABEL"
 				description="COM_MENUS_ITEM_FIELD_MENU_IMAGE_DESC" 
+				validate="filepath"
 			/>
 
 			<field 

--- a/administrator/components/com_menus/models/forms/itemadmin_component.xml
+++ b/administrator/components/com_menus/models/forms/itemadmin_component.xml
@@ -24,7 +24,7 @@
 				type="media"
 				label="COM_MENUS_ITEM_FIELD_MENU_IMAGE_LABEL"
 				description="COM_MENUS_ITEM_FIELD_MENU_IMAGE_DESC" 
-				validate="filepath"
+				validate="filePath"
 			/>
 
 			<field 

--- a/administrator/components/com_menus/models/forms/itemadmin_container.xml
+++ b/administrator/components/com_menus/models/forms/itemadmin_container.xml
@@ -35,6 +35,7 @@
 				type="media"
 				label="COM_MENUS_ITEM_FIELD_MENU_IMAGE_LABEL"
 				description="COM_MENUS_ITEM_FIELD_MENU_IMAGE_DESC"
+				validate="filepath"
 			/>
 
 			<field 

--- a/administrator/components/com_menus/models/forms/itemadmin_container.xml
+++ b/administrator/components/com_menus/models/forms/itemadmin_container.xml
@@ -35,7 +35,7 @@
 				type="media"
 				label="COM_MENUS_ITEM_FIELD_MENU_IMAGE_LABEL"
 				description="COM_MENUS_ITEM_FIELD_MENU_IMAGE_DESC"
-				validate="filepath"
+				validate="filePath"
 			/>
 
 			<field 

--- a/administrator/components/com_menus/models/forms/itemadmin_heading.xml
+++ b/administrator/components/com_menus/models/forms/itemadmin_heading.xml
@@ -35,6 +35,7 @@
 				type="media"
 				label="COM_MENUS_ITEM_FIELD_MENU_IMAGE_LABEL"
 				description="COM_MENUS_ITEM_FIELD_MENU_IMAGE_DESC"
+				validate="filepath"
 			/>
 
 			<field 

--- a/administrator/components/com_menus/models/forms/itemadmin_heading.xml
+++ b/administrator/components/com_menus/models/forms/itemadmin_heading.xml
@@ -35,7 +35,7 @@
 				type="media"
 				label="COM_MENUS_ITEM_FIELD_MENU_IMAGE_LABEL"
 				description="COM_MENUS_ITEM_FIELD_MENU_IMAGE_DESC"
-				validate="filepath"
+				validate="filePath"
 			/>
 
 			<field 

--- a/administrator/components/com_menus/models/forms/itemadmin_url.xml
+++ b/administrator/components/com_menus/models/forms/itemadmin_url.xml
@@ -43,7 +43,7 @@
 				type="media"
 				label="COM_MENUS_ITEM_FIELD_MENU_IMAGE_LABEL"
 				description="COM_MENUS_ITEM_FIELD_MENU_IMAGE_DESC" 
-				validate="filepath"
+				validate="filePath"
 			/>
 
 			<field 

--- a/administrator/components/com_menus/models/forms/itemadmin_url.xml
+++ b/administrator/components/com_menus/models/forms/itemadmin_url.xml
@@ -43,6 +43,7 @@
 				type="media"
 				label="COM_MENUS_ITEM_FIELD_MENU_IMAGE_LABEL"
 				description="COM_MENUS_ITEM_FIELD_MENU_IMAGE_DESC" 
+				validate="filepath"
 			/>
 
 			<field 

--- a/administrator/components/com_newsfeeds/models/forms/newsfeed.xml
+++ b/administrator/components/com_newsfeeds/models/forms/newsfeed.xml
@@ -279,7 +279,7 @@
 					type="media"
 					label="COM_NEWSFEEDS_FIELD_FIRST_LABEL"
 					description="COM_NEWSFEEDS_FIELD_FIRST_DESC"
-					validate="filepath"
+					validate="filePath"
 				/>
 
 				<field
@@ -321,7 +321,7 @@
 					type="media"
 					label="COM_NEWSFEEDS_FIELD_SECOND_LABEL"
 					description="COM_NEWSFEEDS_FIELD_SECOND_DESC"
-					validate="filepath"
+					validate="filePath"
 				/>
 
 				<field

--- a/administrator/components/com_newsfeeds/models/forms/newsfeed.xml
+++ b/administrator/components/com_newsfeeds/models/forms/newsfeed.xml
@@ -279,6 +279,7 @@
 					type="media"
 					label="COM_NEWSFEEDS_FIELD_FIRST_LABEL"
 					description="COM_NEWSFEEDS_FIELD_FIRST_DESC"
+					validate="filepath"
 				/>
 
 				<field
@@ -320,6 +321,7 @@
 					type="media"
 					label="COM_NEWSFEEDS_FIELD_SECOND_LABEL"
 					description="COM_NEWSFEEDS_FIELD_SECOND_DESC"
+					validate="filepath"
 				/>
 
 				<field

--- a/administrator/components/com_tags/config.xml
+++ b/administrator/components/com_tags/config.xml
@@ -78,6 +78,7 @@
 			type="media"
 			label="COM_TAGS_TAG_LIST_MEDIA_LABEL"
 			description="COM_TAGS_TAG_LIST_MEDIA_DESC"
+			validate="filepath"
 		/>
 
 		<field

--- a/administrator/components/com_tags/config.xml
+++ b/administrator/components/com_tags/config.xml
@@ -78,7 +78,7 @@
 			type="media"
 			label="COM_TAGS_TAG_LIST_MEDIA_LABEL"
 			description="COM_TAGS_TAG_LIST_MEDIA_DESC"
-			validate="filepath"
+			validate="filePath"
 		/>
 
 		<field

--- a/administrator/components/com_tags/models/forms/tag.xml
+++ b/administrator/components/com_tags/models/forms/tag.xml
@@ -258,6 +258,7 @@
 				label="COM_TAGS_FIELD_INTRO_LABEL"
 				description="COM_TAGS_FIELD_INTRO_DESC"
 				labelclass="control-label"
+				validate="filepath"
 			/>
 
 			<field
@@ -303,6 +304,7 @@
 				label="COM_TAGS_FIELD_FULL_LABEL"
 				description="COM_TAGS_FIELD_FULL_DESC"
 				labelclass="control-label"
+				validate="filepath"
 			/>
 
 			<field

--- a/administrator/components/com_tags/models/forms/tag.xml
+++ b/administrator/components/com_tags/models/forms/tag.xml
@@ -258,7 +258,7 @@
 				label="COM_TAGS_FIELD_INTRO_LABEL"
 				description="COM_TAGS_FIELD_INTRO_DESC"
 				labelclass="control-label"
-				validate="filepath"
+				validate="filePath"
 			/>
 
 			<field
@@ -304,7 +304,7 @@
 				label="COM_TAGS_FIELD_FULL_LABEL"
 				description="COM_TAGS_FIELD_FULL_DESC"
 				labelclass="control-label"
-				validate="filepath"
+				validate="filePath"
 			/>
 
 			<field

--- a/administrator/templates/hathor/templateDetails.xml
+++ b/administrator/templates/hathor/templateDetails.xml
@@ -66,6 +66,7 @@
 					description="TPL_HATHOR_LOGO_DESC" 
 					class=""
 					default=""
+					validate="filepath"
 				/>
 
 				<field

--- a/administrator/templates/hathor/templateDetails.xml
+++ b/administrator/templates/hathor/templateDetails.xml
@@ -66,7 +66,7 @@
 					description="TPL_HATHOR_LOGO_DESC" 
 					class=""
 					default=""
-					validate="filepath"
+					validate="filePath"
 				/>
 
 				<field

--- a/administrator/templates/isis/templateDetails.xml
+++ b/administrator/templates/isis/templateDetails.xml
@@ -104,6 +104,7 @@
 					description="TPL_ISIS_LOGO_DESC"
 					class="" 
 					default=""
+					validate="filepath"
 				 />
 
 				<field 
@@ -113,6 +114,7 @@
 					description="TPL_ISIS_LOGIN_LOGO_DESC"
 					class="" 
 					default=""
+					validate="filepath"
 				 />
 
 				<field 

--- a/administrator/templates/isis/templateDetails.xml
+++ b/administrator/templates/isis/templateDetails.xml
@@ -104,7 +104,7 @@
 					description="TPL_ISIS_LOGO_DESC"
 					class="" 
 					default=""
-					validate="filepath"
+					validate="filePath"
 				 />
 
 				<field 
@@ -114,7 +114,7 @@
 					description="TPL_ISIS_LOGIN_LOGO_DESC"
 					class="" 
 					default=""
-					validate="filepath"
+					validate="filePath"
 				 />
 
 				<field 

--- a/components/com_content/models/forms/article.xml
+++ b/components/com_content/models/forms/article.xml
@@ -239,7 +239,7 @@
 				type="media"
 				label="COM_CONTENT_FIELD_INTRO_LABEL"
 				description="COM_CONTENT_FIELD_INTRO_DESC" 
-				validate="filepath"
+				validate="filePath"
 			/>
 			
 			<field 
@@ -278,7 +278,7 @@
 				type="media"
 				label="COM_CONTENT_FIELD_FULL_LABEL"
 				description="COM_CONTENT_FIELD_FULL_DESC" 
-				validate="filepath"
+				validate="filePath"
 			/>
 			
 			<field 

--- a/components/com_content/models/forms/article.xml
+++ b/components/com_content/models/forms/article.xml
@@ -239,6 +239,7 @@
 				type="media"
 				label="COM_CONTENT_FIELD_INTRO_LABEL"
 				description="COM_CONTENT_FIELD_INTRO_DESC" 
+				validate="filepath"
 			/>
 			
 			<field 
@@ -277,6 +278,7 @@
 				type="media"
 				label="COM_CONTENT_FIELD_FULL_LABEL"
 				description="COM_CONTENT_FIELD_FULL_DESC" 
+				validate="filepath"
 			/>
 			
 			<field 

--- a/components/com_tags/views/tag/tmpl/default.xml
+++ b/components/com_tags/views/tag/tmpl/default.xml
@@ -91,6 +91,7 @@
 				type="media"
 				label="COM_TAGS_TAG_LIST_MEDIA_LABEL"
 				description="COM_TAGS_TAG_LIST_MEDIA_DESC"
+				validate="filepath"
 			/>
 
 			<field

--- a/components/com_tags/views/tag/tmpl/default.xml
+++ b/components/com_tags/views/tag/tmpl/default.xml
@@ -91,7 +91,7 @@
 				type="media"
 				label="COM_TAGS_TAG_LIST_MEDIA_LABEL"
 				description="COM_TAGS_TAG_LIST_MEDIA_DESC"
-				validate="filepath"
+				validate="filePath"
 			/>
 
 			<field

--- a/components/com_tags/views/tag/tmpl/list.xml
+++ b/components/com_tags/views/tag/tmpl/list.xml
@@ -90,6 +90,7 @@
 				type="media"
 				label="COM_TAGS_TAG_LIST_MEDIA_LABEL"
 				description="COM_TAGS_TAG_LIST_MEDIA_DESC"
+				validate="filepath"
 			/>
 
 			<field

--- a/components/com_tags/views/tag/tmpl/list.xml
+++ b/components/com_tags/views/tag/tmpl/list.xml
@@ -90,7 +90,7 @@
 				type="media"
 				label="COM_TAGS_TAG_LIST_MEDIA_LABEL"
 				description="COM_TAGS_TAG_LIST_MEDIA_DESC"
-				validate="filepath"
+				validate="filePath"
 			/>
 
 			<field

--- a/components/com_tags/views/tags/tmpl/default.xml
+++ b/components/com_tags/views/tags/tmpl/default.xml
@@ -78,6 +78,7 @@
 				type="media"
 				label="COM_TAGS_ALL_TAGS_MEDIA_LABEL"
 				description="COM_TAGS_ALL_TAGS_MEDIA_DESC"
+				validate="filepath"
 			/>
 
 			<field

--- a/components/com_tags/views/tags/tmpl/default.xml
+++ b/components/com_tags/views/tags/tmpl/default.xml
@@ -78,7 +78,7 @@
 				type="media"
 				label="COM_TAGS_ALL_TAGS_MEDIA_LABEL"
 				description="COM_TAGS_ALL_TAGS_MEDIA_DESC"
-				validate="filepath"
+				validate="filePath"
 			/>
 
 			<field

--- a/components/com_users/views/login/tmpl/default.xml
+++ b/components/com_users/views/login/tmpl/default.xml
@@ -83,6 +83,7 @@
 			type="media"
 			label="JFIELD_LOGIN_IMAGE_LABEL"
 			description="JFIELD_LOGIN_IMAGE_DESC"
+			validate="filepath"
 		/>
 
 		<field 
@@ -159,6 +160,7 @@
 			type="media"
 			label="JFIELD_LOGOUT_IMAGE_LABEL"
 			description="JFIELD_LOGOUT_IMAGE_DESC"
+			validate="filepath"
 		/>
 
 		</fieldset>

--- a/components/com_users/views/login/tmpl/default.xml
+++ b/components/com_users/views/login/tmpl/default.xml
@@ -83,7 +83,7 @@
 			type="media"
 			label="JFIELD_LOGIN_IMAGE_LABEL"
 			description="JFIELD_LOGIN_IMAGE_DESC"
-			validate="filepath"
+			validate="filePath"
 		/>
 
 		<field 
@@ -160,7 +160,7 @@
 			type="media"
 			label="JFIELD_LOGOUT_IMAGE_LABEL"
 			description="JFIELD_LOGOUT_IMAGE_DESC"
-			validate="filepath"
+			validate="filePath"
 		/>
 
 		</fieldset>

--- a/libraries/src/Form/Rule/FilePathRule.php
+++ b/libraries/src/Form/Rule/FilePathRule.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  Copyright (C) 2005 - 2019 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Form\Rule;
+
+defined('JPATH_PLATFORM') or die;
+
+use Joomla\CMS\Filesystem\Path;
+use Joomla\CMS\Form\Form;
+use Joomla\CMS\Form\FormRule;
+use Joomla\Registry\Registry;
+
+/**
+ * Form Rule class for the Joomla Platform.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class FilePathRule extends FormRule
+{
+	/**
+	 * Method to test if the file path is valid
+	 *
+	 * @param   \SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
+	 * @param   mixed              $value    The form field value to validate.
+	 * @param   string             $group    The field name group control value. This acts as an array container for the field.
+	 *                                       For example if the field has name="foo" and the group value is set to "bar" then the
+	 *                                       full field name would end up being "bar[foo]".
+	 * @param   Registry           $input    An optional Registry object with the entire data set to validate against the entire form.
+	 * @param   Form               $form     The form object for which the field is being tested.
+	 *
+	 * @return  boolean  True if the value is valid, false otherwise.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function test(\SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
+	{
+		// Append the root path
+		$value = JPATH_ROOT . '/' . $value;
+
+		try
+		{
+			$path = Path::check($value);
+		}
+		catch (\Exception $e)
+		{
+			// When there is an exception in the check method this is not valid
+			return false;
+		}
+
+		// Check whether this is a valid file
+		if (is_file($path))
+		{
+			return true;
+		}
+
+		return false;
+	}
+}

--- a/libraries/src/Form/Rule/FilePathRule.php
+++ b/libraries/src/Form/Rule/FilePathRule.php
@@ -39,6 +39,16 @@ class FilePathRule extends FormRule
 	 */
 	public function test(\SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
 	{
+		$value = trim($value);
+
+		// If the field is empty and not required, the field is valid.
+		$required = ((string) $element['required'] == 'true' || (string) $element['required'] == 'required');
+
+		if (!$required && empty($value))
+		{
+			return true;
+		}
+
 		// Append the root path
 		$value = JPATH_ROOT . '/' . $value;
 

--- a/modules/mod_custom/mod_custom.xml
+++ b/modules/mod_custom/mod_custom.xml
@@ -43,7 +43,7 @@
 					type="media"
 					label="MOD_CUSTOM_FIELD_BACKGROUNDIMAGE_LABEL"
 					description="MOD_BACKGROUNDIMAGE_FIELD_LOGO_DESC"
-					validate="filepath"
+					validate="filePath"
 				/>
 			</fieldset>
 			<fieldset name="advanced">

--- a/modules/mod_custom/mod_custom.xml
+++ b/modules/mod_custom/mod_custom.xml
@@ -43,6 +43,7 @@
 					type="media"
 					label="MOD_CUSTOM_FIELD_BACKGROUNDIMAGE_LABEL"
 					description="MOD_BACKGROUNDIMAGE_FIELD_LOGO_DESC"
+					validate="filepath"
 				/>
 			</fieldset>
 			<fieldset name="advanced">

--- a/templates/beez3/templateDetails.xml
+++ b/templates/beez3/templateDetails.xml
@@ -81,7 +81,7 @@
 					type="media"
 					label="TPL_BEEZ3_FIELD_LOGO_LABEL" 
 					description="TPL_BEEZ3_FIELD_LOGO_DESC" 
-					validate="filepath"
+					validate="filePath"
 				/>
 
 				<field 
@@ -144,7 +144,7 @@
 					label="TPL_BEEZ3_FIELD_HEADER_IMAGE_LABEL" 
 					description="TPL_BEEZ3_FIELD_HEADER_IMAGE_DESC" 
 					showon="templatecolor:image" 
-					validate="filepath"
+					validate="filePath"
 				/>
 
 				<field 

--- a/templates/beez3/templateDetails.xml
+++ b/templates/beez3/templateDetails.xml
@@ -81,6 +81,7 @@
 					type="media"
 					label="TPL_BEEZ3_FIELD_LOGO_LABEL" 
 					description="TPL_BEEZ3_FIELD_LOGO_DESC" 
+					validate="filepath"
 				/>
 
 				<field 
@@ -143,6 +144,7 @@
 					label="TPL_BEEZ3_FIELD_HEADER_IMAGE_LABEL" 
 					description="TPL_BEEZ3_FIELD_HEADER_IMAGE_DESC" 
 					showon="templatecolor:image" 
+					validate="filepath"
 				/>
 
 				<field 

--- a/templates/protostar/templateDetails.xml
+++ b/templates/protostar/templateDetails.xml
@@ -77,7 +77,7 @@
 					description="TPL_PROTOSTAR_LOGO_DESC" 
 					class="" 
 					default=""
-					validate="filepath"
+					validate="filePath"
 				/>
 
 				<field 

--- a/templates/protostar/templateDetails.xml
+++ b/templates/protostar/templateDetails.xml
@@ -77,6 +77,7 @@
 					description="TPL_PROTOSTAR_LOGO_DESC" 
 					class="" 
 					default=""
+					validate="filepath"
 				/>
 
 				<field 


### PR DESCRIPTION
Pull Request to add validate="filepath" for the media form field.

### Summary of Changes

Implement and add validate="filepath"

### Testing Instructions

- visit one media field for example in the default templates where we have login and logout images.
- Click "Select" button for logo
- Scroll down to "Image URL" input box
- input an invalid file path example: `images/joomla_black_invalid.png`
- Click "Insert"
- Click "Save"
- notice that the invalid file path is saved
- apply the patch
- please also retry the checks with the path `images/joomla_black.png` that should work before and after the patch.

### Expected result

error message of invalid path

![image](https://user-images.githubusercontent.com/2596554/65624323-e67ec900-dfc9-11e9-8f9e-e2cdf6c1f6fb.png)

### Actual result

invalid paths is saved to the media field.

### Documentation Changes Required

new field needs to be documented ;)

### Additional Info

cc @SniperSister @wilsonge @joomla/security 