### PR TITLE
[4.0] Correct module quick task link

### DIFF
--- a/administrator/components/com_menus/presets/content.xml
+++ b/administrator/components/com_menus/presets/content.xml
@@ -83,7 +83,7 @@
 			type="component"
 			element="com_modules"
 			link="index.php?option=com_modules&amp;view=modules&amp;client_id=0"
-			quicktask="index.php?option=com_modules&amp;view=select"
+			quicktask="index.php?option=com_modules&amp;view=select&amp;client_id=0"
 		/>
 
 		<menuitem

--- a/administrator/components/com_menus/presets/default.xml
+++ b/administrator/components/com_menus/presets/default.xml
@@ -88,7 +88,7 @@
 			type="component"
 			element="com_modules"
 			link="index.php?option=com_modules&amp;view=modules&amp;client_id=0"
-			quicktask="index.php?option=com_modules&amp;view=select"
+			quicktask="index.php?option=com_modules&amp;view=select&amp;client_id=0"
 		/>
 
 		<menuitem


### PR DESCRIPTION
Pull Request for Issue #26414 .

### Summary of Changes

Adds client filter to module quick task link in admin menu presets.

### Testing Instructions

View administrator modules in backend.
In menu click + icon next to Site Modules.

### Expected result

A list of site modules opens up.

### Actual result

A list of administrator modules opens up.

### Documentation Changes Required

No.