### PR TITLE
[4.0] Error on privacy request page

### DIFF
--- a/administrator/components/com_privacy/tmpl/request/default.php
+++ b/administrator/components/com_privacy/tmpl/request/default.php
@@ -12,6 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
+use Joomla\Component\Actionlogs\Administrator\Helper\ActionlogsHelper;
 
 /** @var PrivacyViewRequest $this */
 


### PR DESCRIPTION
### Summary of Changes

Adds missing import.

### Testing Instructions

Create a privacy request in backend.
View the request.

### Expected result

No errors.

### Actual result

>An error has occurred.
>0 Class 'ActionlogsHelper' not found 

### Documentation Changes Required

No.