### PR TITLE
Isis template login form - logo centering

### DIFF
--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -8403,6 +8403,10 @@ html[dir=rtl] .quick-icons .nav-list [class*=" icon-"] {
 .j-toggle-sidebar-button:hover {
 	color: #1f496e;
 }
+#element-box img {
+	display: block;
+	margin: 0 auto;
+}
 #system-message-container,
 #j-main-container {
 	padding: 0 0 0 5px;

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -8403,6 +8403,10 @@ html[dir=rtl] .quick-icons .nav-list [class*=" icon-"] {
 .j-toggle-sidebar-button:hover {
 	color: #1f496e;
 }
+#element-box img {
+	display: block;
+	margin: 0 auto;
+}
 #system-message-container,
 #j-main-container {
 	padding: 0 0 0 5px;


### PR DESCRIPTION
Joomla 3.9.12.

A small suggestion: center the logo in the authorization form.
If the logo size exceeds a certain value, then everything looks good. If the logo size is small (see screenshot), perfectionists suffer a lot :).

### Testing Instructions
1. In the template settings, select a logo (for example, 300 * 100 pixels).
2. See how the logo is located in the authorization form.
3. Apply the patch and repeat the procedure.

### BEFORE the patch
![Screenshot_2](https://user-images.githubusercontent.com/8440661/65794015-e7515f80-e16f-11e9-848c-d2560344641f.png)

### AFTER the patch
![Screenshot_3](https://user-images.githubusercontent.com/8440661/65794041-f3d5b800-e16f-11e9-93f7-119d372378f5.png)
