### PR TITLE
[4.0] Fix clicking on title to edit a field group

### DIFF
--- a/administrator/components/com_fields/tmpl/groups/default.php
+++ b/administrator/components/com_fields/tmpl/groups/default.php
@@ -121,7 +121,7 @@ $context = $this->escape($this->state->get('filter.context'));
 												<?php echo HTMLHelper::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, 'groups.', $canCheckin); ?>
 											<?php endif; ?>
 											<?php if ($canEdit || $canEditOwn) : ?>
-												<a href="<?php echo Route::_('index.php?option=com_fields&task=group.edit&id=' . $item->id); ?>" title="<?php echo Text::_('JACTION_EDIT'); ?> <?php echo $this->escape(addslashes($item->title)); ?>">
+												<a href="<?php echo Route::_('index.php?option=com_fields&task=group.edit&id=' . $item->id . '&context=' . $context); ?>" title="<?php echo Text::_('JACTION_EDIT'); ?> <?php echo $this->escape(addslashes($item->title)); ?>">
 													<?php echo $this->escape($item->title); ?></a>
 											<?php else : ?>
 												<?php echo $this->escape($item->title); ?>


### PR DESCRIPTION
# Summary of Changes
Fixes a bug introduced in #24801 where you can't edit a field group by clicking on it's title

### Testing Instructions
Create a field group, close it, then try to edit it by clicking the link on it's title

### Expected result
The field group opens to edit

### Actual result
Error

### Documentation Changes Required
None
