### PR TITLE
"Edit Category" string

### DIFF
--- a/administrator/components/com_content/views/articles/tmpl/default.php
+++ b/administrator/components/com_content/views/articles/tmpl/default.php
@@ -201,7 +201,7 @@ $assoc = JLanguageAssociations::isEnabled();
 									<?php
 									$ParentCatUrl = JRoute::_('index.php?option=com_categories&task=category.edit&id=' . $item->parent_category_id . '&extension=com_content');
 									$CurrentCatUrl = JRoute::_('index.php?option=com_categories&task=category.edit&id=' . $item->catid . '&extension=com_content');
-									$EditCatTxt = JText::_('JACTION_EDIT') . ' ' . JText::_('JCATEGORY');
+									$EditCatTxt = JText::_('COM_CONTENT_EDIT_CATEGORY');
 
 										echo JText::_('JCATEGORY') . ': ';
 

--- a/administrator/components/com_content/views/featured/tmpl/default.php
+++ b/administrator/components/com_content/views/featured/tmpl/default.php
@@ -175,8 +175,7 @@ if ($saveOrder)
 										<?php echo JHtml::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, 'articles.', $canCheckin); ?>
 									<?php endif; ?>
 									<?php if ($canEdit) : ?>
-										<a class="hasTooltip" href="<?php echo JRoute::_('index.php?option=com_content&task=article.edit&return=featured&id=' . $item->id); ?>" title="<?php echo JText::_('
-										_EDIT'); ?>">
+										<a class="hasTooltip" href="<?php echo JRoute::_('index.php?option=com_content&task=article.edit&return=featured&id=' . $item->id); ?>" title="<?php echo JText::_('JACTION_EDIT'); ?>">
 											<?php echo $this->escape($item->title); ?></a>
 									<?php else : ?>
 										<span title="<?php echo JText::sprintf('JFIELD_ALIAS_LABEL', $this->escape($item->alias)); ?>"><?php echo $this->escape($item->title); ?></span>

--- a/administrator/components/com_content/views/featured/tmpl/default.php
+++ b/administrator/components/com_content/views/featured/tmpl/default.php
@@ -175,7 +175,8 @@ if ($saveOrder)
 										<?php echo JHtml::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, 'articles.', $canCheckin); ?>
 									<?php endif; ?>
 									<?php if ($canEdit) : ?>
-										<a class="hasTooltip" href="<?php echo JRoute::_('index.php?option=com_content&task=article.edit&return=featured&id=' . $item->id); ?>" title="<?php echo JText::_('JACTION_EDIT'); ?>">
+										<a class="hasTooltip" href="<?php echo JRoute::_('index.php?option=com_content&task=article.edit&return=featured&id=' . $item->id); ?>" title="<?php echo JText::_('
+										_EDIT'); ?>">
 											<?php echo $this->escape($item->title); ?></a>
 									<?php else : ?>
 										<span title="<?php echo JText::sprintf('JFIELD_ALIAS_LABEL', $this->escape($item->alias)); ?>"><?php echo $this->escape($item->title); ?></span>
@@ -191,7 +192,7 @@ if ($saveOrder)
 										<?php
 										$ParentCatUrl = JRoute::_('index.php?option=com_categories&task=category.edit&id=' . $item->parent_category_id . '&extension=com_content');
 										$CurrentCatUrl = JRoute::_('index.php?option=com_categories&task=category.edit&id=' . $item->catid . '&extension=com_content');
-										$EditCatTxt = JText::_('JACTION_EDIT') . ' ' . JText::_('JCATEGORY');
+										$EditCatTxt = JText::_('COM_CONTENT_EDIT_CATEGORY');
 
 										echo JText::_('JCATEGORY') . ': ';
 

--- a/administrator/language/en-GB/en-GB.com_content.ini
+++ b/administrator/language/en-GB/en-GB.com_content.ini
@@ -41,6 +41,7 @@ COM_CONTENT_DRILL_CATEGORIES_LABEL="List or Blog: after choosing the display,<br
 COM_CONTENT_DRILL_DOWN_LAYOUT_DESC="When drilling down to a category, show articles in a list or blog layout."
 COM_CONTENT_DRILL_DOWN_LAYOUT_LABEL="List or Blog Layout"
 COM_CONTENT_EDIT_ARTICLE="Edit Article"
+COM_CONTENT_EDIT_CATEGORY="Edit Category"
 COM_CONTENT_EDITORCONFIG_FIELDSET_LABEL="Configure Edit Screen"
 COM_CONTENT_EDITING_LAYOUT="Editing Layout"
 COM_CONTENT_ERROR_ALL_LANGUAGE_ASSOCIATED="A content item set to All languages can't be associated. Associations have not been set."


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Currently "Edit Category" string used in articles/featured view is glued out of two separate strings. This is not translatable in some languages.

### Testing Instructions

"Edit Category" text still appears when hovering over category in articles/featured view in backend.

### Documentation Changes Required

No.