### PR TITLE
[4.0] Fix obvious typo "htmlnody" in TemplatesModel.php

### DIFF
--- a/administrator/components/com_mails/Model/TemplatesModel.php
+++ b/administrator/components/com_mails/Model/TemplatesModel.php
@@ -40,7 +40,7 @@ class TemplatesModel extends ListModel
 				'language', 'a.language',
 				'subject', 'a.subject',
 				'body', 'a.body',
-				'htmlnody', 'a.htmlbody'
+				'htmlbody', 'a.htmlbody'
 			);
 		}
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Obvious.

### Testing Instructions

Code review: Check that the word "htmlnody" appears nowhere else except at the place fixed by this PR.

### Expected result

htmlbody

### Actual result

htmlnody

### Documentation Changes Required

None.