### PR TITLE
[4.0] Remove duplicate items from list and filtering by language in mail templates list display

### DIFF
--- a/administrator/components/com_mails/Model/TemplatesModel.php
+++ b/administrator/components/com_mails/Model/TemplatesModel.php
@@ -129,7 +129,7 @@ class TemplatesModel extends ListModel
 							'a.body',
 							'a.htmlbody',
 							'a.attachments',
-							'a.params'
+							'a.params',
 						]
 					)
 				)

--- a/administrator/components/com_mails/Model/TemplatesModel.php
+++ b/administrator/components/com_mails/Model/TemplatesModel.php
@@ -90,6 +90,7 @@ class TemplatesModel extends ListModel
 			->select($db->quoteName('language'))
 			->from($db->quoteName('#__mail_templates'))
 			->where($db->quoteName('template_id') . ' = :id')
+			->where($db->quoteName('language') . ' != ' . $db->quote(''))
 			->order($db->quoteName('language') . ' ASC')
 			->bind(':id', $id);
 
@@ -120,8 +121,7 @@ class TemplatesModel extends ListModel
 		$query->select(
 			$this->getState(
 				'list.select',
-				'DISTINCT '
-				. implode(
+				implode(
 					',',
 					$db->quoteName(
 						[
@@ -137,16 +137,7 @@ class TemplatesModel extends ListModel
 			)
 		);
 		$query->from($db->quoteName('#__mail_templates', 'a'))
-			->group(
-				[
-					$db->quoteName('a.template_id'),
-					$db->quoteName('a.subject'),
-					$db->quoteName('a.body'),
-					$db->quoteName('a.htmlbody'),
-					$db->quoteName('a.attachments'),
-					$db->quoteName('a.params'),
-				]
-			);
+			->where($db->quoteName('a.language') . ' = ' . $db->quote(''));
 
 		// Filter by search in title.
 		if ($search = trim($this->getState('filter.search')))

--- a/administrator/components/com_mails/Model/TemplatesModel.php
+++ b/administrator/components/com_mails/Model/TemplatesModel.php
@@ -120,18 +120,15 @@ class TemplatesModel extends ListModel
 		$query->select(
 			$this->getState(
 				'list.select',
-				implode(
-					',',
-					$db->quoteName(
-						[
-							'a.template_id',
-							'a.subject',
-							'a.body',
-							'a.htmlbody',
-							'a.attachments',
-							'a.params'
-						]
-					)
+				$db->quoteName(
+					[
+						'a.template_id',
+						'a.subject',
+						'a.body',
+						'a.htmlbody',
+						'a.attachments',
+						'a.params'
+					]
 				)
 			)
 		);

--- a/administrator/components/com_mails/Model/TemplatesModel.php
+++ b/administrator/components/com_mails/Model/TemplatesModel.php
@@ -120,14 +120,26 @@ class TemplatesModel extends ListModel
 		$query->select(
 			$this->getState(
 				'list.select',
-				$db->quoteName('a') . '.*'
+				'DISTINCT '
+				. implode(
+					',',
+					$db->quoteName(
+						[
+							'a.template_id',
+							'a.subject',
+							'a.body',
+							'a.htmlbody',
+							'a.attachments',
+							'a.params'
+						]
+					)
+				)
 			)
 		);
 		$query->from($db->quoteName('#__mail_templates', 'a'))
 			->group(
 				[
 					$db->quoteName('a.template_id'),
-					$db->quoteName('a.language'),
 					$db->quoteName('a.subject'),
 					$db->quoteName('a.body'),
 					$db->quoteName('a.htmlbody'),

--- a/administrator/components/com_mails/Model/TemplatesModel.php
+++ b/administrator/components/com_mails/Model/TemplatesModel.php
@@ -37,7 +37,6 @@ class TemplatesModel extends ListModel
 		{
 			$config['filter_fields'] = array(
 				'template_id', 'a.template_id',
-				'language', 'a.language',
 				'subject', 'a.subject',
 				'body', 'a.body',
 				'htmlbody', 'a.htmlbody'
@@ -167,13 +166,6 @@ class TemplatesModel extends ListModel
 			$extension .= '.%';
 			$query->where($db->quoteName('a.template_id') . ' LIKE :extension')
 				->bind(':extension', $extension);
-		}
-
-		// Filter on the language.
-		if ($language = $this->getState('filter.language'))
-		{
-			$query->where($db->quoteName('a.language') . ' = :language')
-				->bind(':language', $language);
 		}
 
 		return $query;

--- a/administrator/components/com_mails/forms/filter_templates.xml
+++ b/administrator/components/com_mails/forms/filter_templates.xml
@@ -10,16 +10,6 @@
 		/>
 
 		<field
-			name="language"
-			type="contentlanguage"
-			label="JOPTION_SELECT_LANGUAGE"
-			onchange="this.form.submit();"
-			>
-			<option value="">JOPTION_SELECT_LANGUAGE</option>
-			<option value="*">JALL</option>
-		</field>
-
-		<field
 			name="extension"
 			type="sql"
 			label="COM_MAILS_FILTER_OPTION_SELECT_EXTENSION"


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This Pull Request (PR) changes the list query for the mail templates list so that no duplicates are shown anymore in the list. This is done by removing the language column from both the result set and the group by. The languages is later be glued to the result with another query in PHP and so not needed for this query.

Somehow this changes fixes also the editing of mail subject and content, which did not work for me without this PR but works now.

Furthermore, this PR removes filtering by language from the list because it does not make sense.

The reason for this is that while in database there is 1 record for each language + 1 with empty language, which is used for diplay of the common properties of all mail templates of this kind (`template_id`, which is not unique in the table but unique per language) and uses flags to link to the edit form for the reord for that particular language.

This is not the way how other things work regarding languages, but it makes sense here and is explained in a [comment of the PR which added this new feature](https://github.com/joomla/joomla-cms/pull/22126#issuecomment-456622531).

### Testing Instructions

Please report back if tested with MySQL (or MariaDB) or PostgreSQL. I've tested both with success of course.

1. Install clean 4.0-dev.
2. Install some languages and publish their content languages. (optional)
3. Go to the mail template list as shown by the red marks in following screenshot.

![Snap 1](https://user-images.githubusercontent.com/7413183/65991903-6dcab180-e48e-11e9-8c51-4d69304b5e3c.png)

4. Edit the mail template and toggle the body switcher element and enter any random text.
5. Do the same with the title.
6. Save and close.
7. Edit again the same mail template for the same language to see if the changes have been applied.

Result: See section "Actual result" below.

8. Apply the patch of this PR and refresh the page.
9. Edit the mail template and toggle the body switcher element and enter any random text.
10. Do the same with the title.
11. Save and close.
12. Edit again the same mail template for the same language to see if the changes have been applied.

Result: See section "Expected result" below.

### Expected result

There is **one record** shown with ID "com_config.test_mail", which has for each language (content or site, not sure) 1 flag. By clicking on the flag you can edit the mail template for that particular language.

The filter options don't contain an option for filtering by language, same as the sort options, because that would not make sense in this kind of view for reasons stated in description above.

![Unbenannt-3](https://user-images.githubusercontent.com/7413183/66003290-f43ebd80-e4a5-11e9-9eb7-3f475126eeca.png)

Changing mail subject and content for a particular language works, i.e. you can see the real text and not only the language string when the edit toggle has been changed, and changes are saved and still there when editing again.

### Actual result

There are **two (in case if no language installed) or maybe more (in case if some languages installed) records** shown with ID "com_config.test_mail", which has for each language (content or site, not sure) 1 flag. By clicking on the flag you can edit the mail template for that particular language.

The filter options contain an option for filtering by language, which does not make sense in this kind of view for reasons stated in description above. In opposite to that, the sort options don't contain an option to sort by language. Both together is inconsistent.

![Unbenannt-4](https://user-images.githubusercontent.com/7413183/66003298-fb65cb80-e4a5-11e9-9648-b84306896357.png)

Changing mail subject and content for a particular language doesn't work, i.e. changes are not there when editing again.

### Documentation Changes Required

None.