### PR TITLE
[4.0] Small typo

### DIFF
--- a/administrator/modules/mod_version/tmpl/default.php
+++ b/administrator/modules/mod_version/tmpl/default.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Language\Text;
 
 ?>
-<diV class="header-item-content">
+<div class="header-item-content">
 	<div class="joomlaversion d-flex">
 		<div class="d-flex align-items-end mx-auto">
 			<span class="fab fa-joomla" aria-hidden="true"></span>
@@ -22,4 +22,4 @@ use Joomla\CMS\Language\Text;
 			<span aria-hidden="true"><?php echo $version; ?></span>
 		</div>
 	</div>
-</diV>
+</div>


### PR DESCRIPTION
I changed `diV` to `div` because it confused me.

### Testing Instructions
Code review