### PR TITLE
[4.0] Change btn-inverse to btn-dark

### DIFF
--- a/administrator/components/com_categories/tmpl/categories/default.php
+++ b/administrator/components/com_categories/tmpl/categories/default.php
@@ -221,7 +221,7 @@ if ($saveOrder && !empty($this->items))
 									<?php endif; ?>
 									<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_trashed')) : ?>
 										<td class="text-center btns d-none d-md-table-cell itemnumber">
-											<a class="btn <?php echo ($item->count_trashed > 0) ? 'btn-inverse' : 'btn-secondary'; ?>" title="<?php echo Text::_('COM_CATEGORY_COUNT_TRASHED_ITEMS'); ?>" href="<?php echo Route::_('index.php?option=' . $component . ($section ? '&view=' . $section : '') . '&filter[category_id]=' . (int) $item->id . '&filter[published]=-2' . '&filter[level]=1'); ?>">
+											<a class="btn <?php echo ($item->count_trashed > 0) ? 'btn-dark' : 'btn-secondary'; ?>" title="<?php echo Text::_('COM_CATEGORY_COUNT_TRASHED_ITEMS'); ?>" href="<?php echo Route::_('index.php?option=' . $component . ($section ? '&view=' . $section : '') . '&filter[category_id]=' . (int) $item->id . '&filter[published]=-2' . '&filter[level]=1'); ?>">
 												<?php echo $item->count_trashed; ?></a>
 										</td>
 									<?php endif; ?>


### PR DESCRIPTION
Pull Request for Issue #26449.

### Summary of Changes
Replace obsolete class.



### Testing Instructions
Go to Content >Articles.
Trash an article.
Go to Content > Categories.

### Expected result
![btn-dark](https://user-images.githubusercontent.com/368084/66061457-5e7e4f00-e4f4-11e9-95e3-e31d5d9947b1.jpg)



### Actual result
![66043484-2d634600-e517-11e9-913e-5dc66433bf01](https://user-images.githubusercontent.com/368084/66061491-6f2ec500-e4f4-11e9-9e1c-7518436c970b.png)