### PR TITLE
[4.0] Improve menu item list performance on multilingual sites

### DIFF
--- a/administrator/components/com_menus/Model/ItemsModel.php
+++ b/administrator/components/com_menus/Model/ItemsModel.php
@@ -62,9 +62,7 @@ class ItemsModel extends ListModel
 				'a.ordering'
 			);
 
-			$assoc = Associations::isEnabled();
-
-			if ($assoc)
+			if (Associations::isEnabled())
 			{
 				$config['filter_fields'][] = 'association';
 			}
@@ -308,53 +306,20 @@ class ItemsModel extends ListModel
 			->join('LEFT', $db->quoteName('#__menu_types', 'mt') . ' ON ' . $db->quoteName('mt.menutype') . ' = ' . $db->quoteName('a.menutype'));
 
 		// Join over the associations.
-		$assoc = Associations::isEnabled();
-
-		if ($assoc)
+		if (Associations::isEnabled())
 		{
-			$query->select('COUNT(asso2.id)>1 as association')
-				->join('LEFT', '#__associations AS asso ON asso.id = a.id AND asso.context=' . $db->quote('com_menus.item'))
-				->join('LEFT', '#__associations AS asso2 ON asso2.key = asso.key')
-				->group(
-					$db->quoteName(
-						array(
-							'a.id',
-							'a.menutype',
-							'a.title',
-							'a.alias',
-							'a.note',
-							'a.path',
-							'a.link',
-							'a.type',
-							'a.parent_id',
-							'a.level',
-							'a.published',
-							'a.component_id',
-							'a.checked_out',
-							'a.checked_out_time',
-							'a.browserNav',
-							'a.access',
-							'a.img',
-							'a.template_style_id',
-							'a.params',
-							'a.lft',
-							'a.rgt',
-							'a.home',
-							'a.language',
-							'a.client_id',
-							'l.title',
-							'l.image',
-							'l.sef',
-							'u.name',
-							'c.element',
-							'ag.title',
-							'e.enabled',
-							'e.name',
-							'mt.id',
-							'mt.title',
-						)
-					)
+			$subQuery = $db->getQuery(true)
+				->select('CASE WHEN COUNT(' . $db->quoteName('asso1.id') . ') > 1 THEN 1 ELSE 0 END')
+				->from($db->quoteName('#__associations', 'asso1'))
+				->join('INNER', $db->quoteName('#__associations', 'asso2'), $db->quoteName('asso1.key') . ' = ' . $db->quoteName('asso2.key'))
+				->where(
+					[
+						$db->quoteName('asso1.id') . ' = ' . $db->quoteName('a.id'),
+						$db->quoteName('asso1.context') . ' = ' . $db->quote('com_menus.item'),
+					]
 				);
+
+			$query->select('(' . $subQuery . ') AS ' . $db->quoteName('association'));
 		}
 
 		// Join over the extensions


### PR DESCRIPTION
### Summary of Changes

Replaces `JOIN` and `GROUP` clauses in query with a subquery for improved performance.

### Testing Instructions

Set up a multilingual site.
Enable language associations.
Create some menu items with and without associations
View menu item list in backend.

### Expected result

Works like before.

### Documentation Changes Required

No.