### PR TITLE
[4.0] [mod_articles_latest] Remove unneccesary check of null date for modified time

### DIFF
--- a/modules/mod_articles_latest/Helper/ArticlesLatestHelper.php
+++ b/modules/mod_articles_latest/Helper/ArticlesLatestHelper.php
@@ -111,7 +111,7 @@ abstract class ArticlesLatestHelper
 		// Set ordering
 		$order_map = array(
 			'm_dsc'  => 'a.modified DESC, a.created',
-			'mc_dsc' => 'CASE WHEN (a.modified = ' . $db->quote($db->getNullDate()) . ') THEN a.created ELSE a.modified END',
+			'mc_dsc' => 'a.modified',
 			'c_dsc'  => 'a.created',
 			'p_dsc'  => 'a.publish_up',
 			'random' => $db->getQuery(true)->rand(),


### PR DESCRIPTION
Pull Request for Issue PR #26295 - follow up.

### Summary of Changes

This PR removes the check for the modified time being a null date in the latest articles module.

The check has become obsolete with PR #26295 .

### Testing Instructions

Can be merged by review.

### Expected result

`mod_articles_latest` works as before.

### Actual result

`mod_articles_latest` works.

### Documentation Changes Required

None.