### PR TITLE
[4.0] Improve newsfeed list performance when filtering by tags

### DIFF
--- a/administrator/components/com_newsfeeds/Model/NewsfeedsModel.php
+++ b/administrator/components/com_newsfeeds/Model/NewsfeedsModel.php
@@ -16,6 +16,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Associations;
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
 use Joomla\CMS\MVC\Model\ListModel;
+use Joomla\Database\ParameterType;
 use Joomla\Utilities\ArrayHelper;
 
 /**
@@ -156,7 +157,7 @@ class NewsfeedsModel extends ListModel
 		$query->select(
 			$this->getState(
 				'list.select',
-				'DISTINCT a.id, a.name, a.alias, a.checked_out, a.checked_out_time, a.catid,' .
+				'a.id, a.name, a.alias, a.checked_out, a.checked_out_time, a.catid,' .
 				' a.numarticles, a.cache_time, a.created_by,' .
 				' a.published, a.access, a.ordering, a.language, a.publish_up, a.publish_down'
 			)
@@ -277,33 +278,47 @@ class NewsfeedsModel extends ListModel
 		}
 
 		// Filter by a single or group of tags.
-		$hasTag = false;
-		$tagId  = $this->getState('filter.tag');
+		$tag = $this->getState('filter.tag');
 
-		if (is_numeric($tagId))
+		// Run simplified query when filtering by one tag.
+		if (\is_array($tag) && \count($tag) === 1)
 		{
-			$hasTag = true;
-
-			$query->where($db->quoteName('tagmap.tag_id') . ' = ' . (int) $tagId);
-		}
-		elseif (is_array($tagId))
-		{
-			$tagId = implode(',', ArrayHelper::toInteger($tagId));
-
-			if (!empty($tagId))
-			{
-				$hasTag = true;
-
-				$query->where($db->quoteName('tagmap.tag_id') . ' IN (' . $tagId . ')');
-			}
+			$tag = $tag[0];
 		}
 
-		if ($hasTag)
+		if ($tag && \is_array($tag))
 		{
-			$query->join('LEFT', $db->quoteName('#__contentitem_tag_map', 'tagmap')
-				. ' ON ' . $db->quoteName('tagmap.content_item_id') . ' = ' . $db->quoteName('a.id')
-				. ' AND ' . $db->quoteName('tagmap.type_alias') . ' = ' . $db->quote('com_newsfeeds.newsfeed')
+			$tag = ArrayHelper::toInteger($tag);
+			$subQuery = $db->getQuery(true)
+				->select('DISTINCT ' . $db->quoteName('content_item_id'))
+				->from($db->quoteName('#__contentitem_tag_map'))
+				->where(
+					[
+						$db->quoteName('tag_id') . ' IN (' . implode(',', $query->bindArray($tag)) . ')',
+						$db->quoteName('type_alias') . ' = ' . $db->quote('com_newsfeeds.newsfeed'),
+					]
+				);
+
+			$query->join(
+				'INNER',
+				'(' . $subQuery . ') AS ' . $db->quoteName('tagmap'),
+				$db->quoteName('tagmap.content_item_id') . ' = ' . $db->quoteName('a.id')
 			);
+		}
+		elseif ($tag = (int) $tag)
+		{
+			$query->join(
+				'INNER',
+				$db->quoteName('#__contentitem_tag_map', 'tagmap'),
+				$db->quoteName('tagmap.content_item_id') . ' = ' . $db->quoteName('a.id')
+			)
+				->where(
+					[
+						$db->quoteName('tagmap.tag_id') . ' = :tag',
+						$db->quoteName('tagmap.type_alias') . ' = ' . $db->quote('com_newsfeeds.newsfeed'),
+					]
+				)
+				->bind(':tag', $tag, ParameterType::INTEGER);
 		}
 
 		// Add the list ordering clause.

--- a/administrator/components/com_newsfeeds/Model/NewsfeedsModel.php
+++ b/administrator/components/com_newsfeeds/Model/NewsfeedsModel.php
@@ -289,6 +289,7 @@ class NewsfeedsModel extends ListModel
 		if ($tag && \is_array($tag))
 		{
 			$tag = ArrayHelper::toInteger($tag);
+
 			$subQuery = $db->getQuery(true)
 				->select('DISTINCT ' . $db->quoteName('content_item_id'))
 				->from($db->quoteName('#__contentitem_tag_map'))


### PR DESCRIPTION
### Summary of Changes

This ports changes from #19284 to backend newsfeed list view.

### Testing Instructions

Create some newsfeeds with tags.
View newsfeed list in backend.
Filter newsfeeds by single and multiple tags.

### Expected result

Works like before.

### Documentation Changes Required

No.