### PR TITLE
[4.0] Add target attribute to display link icon

### DIFF
--- a/administrator/components/com_menus/presets/help.xml
+++ b/administrator/components/com_menus/presets/help.xml
@@ -20,12 +20,14 @@
 		<menuitem
 			title="MOD_MENU_HELP_SUPPORT_OFFICIAL_LANGUAGE_FORUM"
 			type="component"
+			target="_blank"
 			link="index.php?option=com_admin&amp;view=help&amp;layout=langforum"
 		/>
 
 		<menuitem
 			title="MOD_MENU_HELP_JOOMLA"
 			type="component"
+			target="_blank"
 			link="index.php?option=com_admin&amp;view=help"
 		/>
 


### PR DESCRIPTION
Pull Request for Issue #25889.

### Summary of Changes
Add target attribute to display link icon.
This will make it consistent with the alternate preset.


### Testing Instructions
Log in to backend.
Go to Help.
No link icons.
Apply PR.
Link icons shown.

