### PR TITLE
[4.0] Mail Templates - list view and mobile

### DIFF
--- a/administrator/components/com_mails/tmpl/templates/default.php
+++ b/administrator/components/com_mails/tmpl/templates/default.php
@@ -40,13 +40,13 @@ $listDirn = $this->escape($this->state->get('list.direction'));
 								<th scope="col" style="width:15%" class="d-none d-md-table-cell">
 									<?php echo HTMLHelper::_('searchtools.sort', 'COM_MAILS_HEADING_COMPONENT', 'a.component', $listDirn, $listOrder); ?>
 								</th>
-								<th scope="col" style="width:15%"  class="d-none d-md-table-cell">
+								<th scope="col" style="width:15%"  class="d-md-table-cell">
 									<?php echo Text::_('COM_MAILS_HEADING_LANGUAGES'); ?>
 								</th>
-								<th scope="col" class="d-none d-md-table-cell">
+								<th scope="col" style="width:30%" class="d-none d-md-table-cell">
 									<?php echo Text::_('COM_MAILS_HEADING_DESCRIPTION'); ?>
 								</th>
-								<th scope="col" style="width:5%" class="d-none d-md-table-cell">
+								<th scope="col" style="width:10%" class="d-none d-md-table-cell">
 									<?php echo HTMLHelper::_('searchtools.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>
 								</th>
 							</tr>
@@ -56,13 +56,13 @@ $listDirn = $this->escape($this->state->get('list.direction'));
 							list($component, $sub_id) = explode('.', $item->template_id, 2);
 							?>
 							<tr class="row<?php echo $i % 2; ?>">
-								<td>
+								<td class="break-word">
 									<?php echo Text::_($component . '_MAIL_' . $sub_id . '_TITLE'); ?>
 								</td>
-								<td>
+								<td class="d-none d-md-table-cell">
 									<?php echo Text::_($component); ?>
 								</td>
-								<td>
+								<td class="d-md-table-cell">
 									<?php foreach ($this->languages as $language) : ?>
 										<?php $exists = in_array($language->lang_code, $item->languages); ?>
 										<a href="<?php echo JRoute::_('index.php?option=com_mails&task=template.edit&template_id=' . $item->template_id . '&language=' . $language->lang_code); ?>"
@@ -75,10 +75,10 @@ $listDirn = $this->escape($this->state->get('list.direction'));
 										</a>
 									<?php endforeach; ?>
 								</td>
-								<td>
+								<td class="d-none d-md-table-cell">
 									<?php echo Text::_($component . '_MAIL_' . $sub_id . '_DESC'); ?>
 								</td>
-								<td>
+								<td class="d-none d-md-table-cell">
 									<?php echo $item->template_id; ?>
 								</td>
 							</tr>


### PR DESCRIPTION
This PR adjust the column widths slightly but more importantly it applies the cell class to all cells not just the ones in the header. (Otherwise what happens is that the column headers are hidden on mobile but the column data is still displayed

The real easy way to test this PR is to open the mail templates list view on a mobile (or emulator)

You might find it helpful when testing to create some dummy records in #__mail_templates with fields of various length text strings - but not essential to do this.

### Before and After mobile views

![image](https://user-images.githubusercontent.com/1296369/66276636-fb424300-e88c-11e9-8c9a-9fe226b4204e.png)
![image](https://user-images.githubusercontent.com/1296369/66276626-e5cd1900-e88c-11e9-9a2d-e4530a679a75.png)


Pull Request for Issue # .

