### PR TITLE
[4.0] com_csp status filter

### DIFF
--- a/administrator/components/com_csp/forms/filter_reports.xml
+++ b/administrator/components/com_csp/forms/filter_reports.xml
@@ -13,6 +13,7 @@
 			name="published"
 			type="status"
 			label="JOPTION_SELECT_PUBLISHED"
+			filter="*,0,1,-2"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_PUBLISHED</option>


### PR DESCRIPTION
It is not possible for a csp report to be archived. This PR removes the archive option from the filter state options

//cc @zero-24
