### PR TITLE
[4.0] Update null date check in blog layout

### DIFF
--- a/layouts/joomla/content/blog_style_default_item_title.php
+++ b/layouts/joomla/content/blog_style_default_item_title.php
@@ -42,9 +42,7 @@ $canEdit = $displayData->params->get('access-edit');
 			<span class="badge badge-warning"><?php echo Text::_('JNOTPUBLISHEDYET'); ?></span>
 		<?php endif; ?>
 
-		<?php if ($displayData->publish_down != Factory::getDbo()->getNullDate()
-			&& (strtotime($displayData->publish_down) < strtotime(Factory::getDate()))
-		) : ?>
+		<?php if ($displayData->publish_down !== null && strtotime($displayData->publish_down) < strtotime(Factory::getDate())) : ?>
 			<span class="badge badge-warning"><?php echo Text::_('JEXPIRED'); ?></span>
 		<?php endif; ?>
 	</div>


### PR DESCRIPTION
Pull Request for Issue #26515

### Summary of Changes

Updates layout to check for real null date.

### Testing Instructions

Create some articles without publish down date.
Open category blog view.

### Expected result

No `Expired` badge under article title.

### Actual result

`Expired` badge shown.

### Documentation Changes Required

No.