### PR TITLE
[4.0] mod_quickicons unused class

### DIFF
--- a/administrator/modules/mod_quickicon/tmpl/default.php
+++ b/administrator/modules/mod_quickicon/tmpl/default.php
@@ -18,7 +18,7 @@ $html = HTMLHelper::_('icons.buttons', $buttons);
 ?>
 <?php if (!empty($html)) : ?>
 	<nav class="quick-icons" aria-label="<?php echo Text::_('MOD_QUICKICON_NAV_LABEL') . ' ' . $module->title; ?>">
-		<ul class="nav flex-wrap row-fluid">
+		<ul class="nav flex-wrap">
 			<?php echo $html; ?>
 		</ul>
 	</nav>


### PR DESCRIPTION
The class row-fluid is an old bs2 class that was removed in bs3 and replaced with just row

In this case we can just remove it as the flex-wrap already does what is needed.
