### PR TITLE
[4.0] logout module profile link

### DIFF
--- a/modules/mod_login/tmpl/default_logout.php
+++ b/modules/mod_login/tmpl/default_logout.php
@@ -26,7 +26,7 @@ HTMLHelper::_('behavior.keepalive');
 	</div>
 <?php endif; ?>
 <?php if ($params->get('profilelink', 0)) : ?>
-	<ul class="mod-login-logout__options unstyled">
+	<ul class="mod-login-logout__options list-unstyled">
 		<li>
 			<a href="<?php echo Route::_('index.php?option=com_users&view=profile'); ?>">
 			<?php echo Text::_('MOD_LOGIN_PROFILE'); ?></a>


### PR DESCRIPTION
the class unstyled is an old bs2 class not present in cassiopeia or bs4. replaced with list-unstyled so it has the desired impact

### testing
enable the show profile link in the site login module. Login and see the link above the logout button
it should be a link and not a bullet link
