### PR TITLE
[4.0] admin login module

### DIFF
--- a/administrator/modules/mod_login/tmpl/default.php
+++ b/administrator/modules/mod_login/tmpl/default.php
@@ -40,7 +40,7 @@ Text::script('MESSAGE');
 						name="username"
 						id="mod-login-username"
 						type="text"
-						class="form-control input-full"
+						class="form-control"
 						required="required"
 						autofocus
 				>
@@ -83,7 +83,7 @@ Text::script('MESSAGE');
 							autocomplete="off"
 							id="mod-login-secretkey"
 							type="text"
-							class="form-control input-full"
+							class="form-control"
 					>
 				</div>
 			</div>


### PR DESCRIPTION
the class input-full is an old b2 class not present in atum or bs4. simply removed as it had no impact on the style

### testing
compare the admin login screen before and after applying the pr
or code review
