### PR TITLE
[4.0] module assignments to menu item class

### DIFF
--- a/administrator/components/com_menus/layouts/joomla/menu/edit_modules.php
+++ b/administrator/components/com_menus/layouts/joomla/menu/edit_modules.php
@@ -47,7 +47,7 @@ if (!$saveHistory)
 }
 
 $html   = array();
-$html[] = '<fieldset><ul class="horizontal-buttons unstyled">';
+$html[] = '<fieldset><ul class="horizontal-buttons list-unstyled">';
 
 foreach ($fields as $field)
 {


### PR DESCRIPTION
the class unstyled is an old b2 class not present in atum or bs4. simply replaced it with list-unstyled

### testing
There is no visible difference
