### PR TITLE
[4.0] Prevent Filter Options button to display when unnecessary

### DIFF
--- a/layouts/joomla/searchtools/default/bar.php
+++ b/layouts/joomla/searchtools/default/bar.php
@@ -54,14 +54,17 @@ $filters = $data['view']->filterForm->getGroup('filter');
 			</div>
 		</div>
 		<div class="btn-group">
-			<button type="button" class="btn btn-primary hasTooltip js-stools-btn-filter">
-				<?php echo Text::_('JFILTER_OPTIONS'); ?>
-				<span class="fa fa-angle-down" aria-hidden="true"></span>
-			</button>
+		<div class="btn-group">
+			<?php if ($filterButton) : ?>
+				<button type="button" class="btn btn-primary hasTooltip js-stools-btn-filter">
+					<?php echo Text::_('JFILTER_OPTIONS'); ?>
+					<span class="fa fa-angle-down" aria-hidden="true"></span>
+				</button>
+			<?php endif; ?>
 			<button type="button" class="btn btn-primary js-stools-btn-clear mr-2">
 				<?php echo Text::_('JSEARCH_FILTER_CLEAR'); ?>
 			</button>
 		</div>
-		
+
 	<?php endif; ?>
 <?php endif;

--- a/layouts/joomla/searchtools/default/bar.php
+++ b/layouts/joomla/searchtools/default/bar.php
@@ -54,9 +54,8 @@ $filters = $data['view']->filterForm->getGroup('filter');
 			</div>
 		</div>
 		<div class="btn-group">
-		<div class="btn-group">
 			<?php if ($filterButton) : ?>
-				<button type="button" class="btn btn-primary hasTooltip js-stools-btn-filter">
+				<button type="button" class="btn btn-primary js-stools-btn-filter">
 					<?php echo Text::_('JFILTER_OPTIONS'); ?>
 					<span class="fa fa-angle-down" aria-hidden="true"></span>
 				</button>
@@ -65,6 +64,5 @@ $filters = $data['view']->filterForm->getGroup('filter');
 				<?php echo Text::_('JSEARCH_FILTER_CLEAR'); ?>
 			</button>
 		</div>
-
 	<?php endif; ?>
 <?php endif;


### PR DESCRIPTION
Pull Request for Issues #26529 and https://github.com/joomla/joomla-cms/issues/26199

### Summary of Changes
The `$filterButton` parameter was not used in bar.php layout


### Testing Instructions
Display various Managers which do not have `Filter Options`
administrator/index.php?option=com_languages&view=installed
administrator/index.php?option=com_templates&view=templates
administrator/index.php?option=com_users&view=levels
administrator/index.php?option=com_users&view=groups
administrator/index.php?option=com_finder&view=searches
administrator/index.php?option=com_menus&view=menus
administrator/index.php?option=com_actionlogs&view=actionlogs
administrator/index.php?option=com_checkin
administrator/index.php?option=com_cache

### Before patch
The button displays

![installedlanguagefilters](https://user-images.githubusercontent.com/869724/66476552-2d72c100-ea96-11e9-8d00-02dd7d4a3095.gif)



### After patch
The button does not display and the Clear button is still present

<img width="1285" alt="Screen Shot 2019-10-09 at 12 49 03" src="https://user-images.githubusercontent.com/869724/66476574-3ebbcd80-ea96-11e9-9a85-1f382638e950.png">
