### PR TITLE
Add nested mode to Tag fields where applicable

### DIFF
--- a/administrator/components/com_content/views/articles/tmpl/default.xml
+++ b/administrator/components/com_content/views/articles/tmpl/default.xml
@@ -56,6 +56,7 @@
 				description="COM_MENUS_ADMIN_TAGS_DESC"
 				multiple="true"
 				filter="int_array"
+				mode="nested"
 			/>
 
 			<field

--- a/components/com_content/views/category/tmpl/blog.xml
+++ b/components/com_content/views/category/tmpl/blog.xml
@@ -31,6 +31,7 @@
 				label="JTAG"
 				description="JTAG_FIELD_SELECT_DESC"
 				multiple="true"
+				mode="nested"
 			/>
 		</fieldset>
 	</fields>
@@ -156,7 +157,7 @@
 					<option value="1">JSHOW</option>
 				</field>
 
-				<field 
+				<field
 					name="show_cat_tags"
 					type="list"
 					label="COM_CONTENT_FIELD_SHOW_CAT_TAGS_LABEL"
@@ -178,7 +179,7 @@
 		</fieldset>
 
 		<fieldset name="advanced" label="JGLOBAL_BLOG_LAYOUT_OPTIONS">
-				<field 
+				<field
 					name="bloglayout"
 					type="spacer"
 					label="JGLOBAL_SUBSLIDER_BLOG_LAYOUT_LABEL"

--- a/components/com_tags/views/tag/tmpl/default.xml
+++ b/components/com_tags/views/tag/tmpl/default.xml
@@ -18,7 +18,7 @@
 				type="tag"
 				label="COM_TAGS_FIELD_TAG_LABEL"
 				description="COM_TAGS_FIELD_SELECT_TAG_DESC"
-				custom="deny"
+				mode="nested"
 				required="true"
 				multiple="true"
 			/>

--- a/components/com_tags/views/tag/tmpl/list.xml
+++ b/components/com_tags/views/tag/tmpl/list.xml
@@ -18,7 +18,7 @@
 				type="tag"
 				label="COM_TAGS_FIELD_TAG_LABEL"
 				description="COM_TAGS_FIELD_SELECT_TAG_DESC"
-				custom="deny"
+				mode="nested"
 				required="true"
 				multiple="true"
 			/>

--- a/modules/mod_tags_popular/mod_tags_popular.xml
+++ b/modules/mod_tags_popular/mod_tags_popular.xml
@@ -29,6 +29,7 @@
 					description="MOD_TAGS_POPULAR_PARENT_TAG_DESC"
 					multiple="true"
 					filter="int_array"
+					mode="nested"
 				/>
 
 				<field


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Adds `mode="nested"` attribute to tag fields to prevent data entry. Also changes some fields with `custom="deny"` to nested mode, for consistency.

### Testing Instructions

Create `Articles - Category Blog` menu item.
In `Tags` field try to create a tag on the fly.

### Expected result

Not possible to add a new tag.

### Actual result

Possible to add a new tag. It disappears after saving, but `Link` field contains such value:

    index.php?option=com_content&view=category&layout=blog&id=2&filter_tag[0]=#new#Newly Created Tag

### Documentation Changes Required

No.