### PR TITLE
[4.0] [com_content] Get asset_id from #__content table

### DIFF
--- a/administrator/components/com_content/Model/ArticlesModel.php
+++ b/administrator/components/com_content/Model/ArticlesModel.php
@@ -205,7 +205,7 @@ class ArticlesModel extends ListModel
 		$query->select(
 			$this->getState(
 				'list.select',
-				'a.id, a.title, a.alias, a.checked_out, a.checked_out_time, a.catid' .
+				'a.id, a.asset_id, a.title, a.alias, a.checked_out, a.checked_out_time, a.catid' .
 				', a.state, a.access, a.created, a.created_by, a.created_by_alias, a.modified, a.ordering, a.featured, a.language, a.hits' .
 				', a.publish_up, a.publish_down, a.introtext, a.note'
 			)
@@ -603,7 +603,7 @@ class ArticlesModel extends ListModel
 
 	/**
 	 * Method to get a list of articles.
-	 * Overridden to add a check for access levels.
+	 * Overridden to add item type alias.
 	 *
 	 * @return  mixed  An array of data items on success, false on failure.
 	 *
@@ -613,16 +613,9 @@ class ArticlesModel extends ListModel
 	{
 		$items = parent::getItems();
 
-		$asset = new \Joomla\CMS\Table\Asset($this->getDbo());
-
-		foreach (array_keys($items) as $x)
+		foreach ($items as $item)
 		{
-			$items[$x]->typeAlias = 'com_content.article';
-
-			$asset->loadByName('com_content.article.' . $items[$x]->id);
-
-			// Re-inject the asset id.
-			$items[$x]->asset_id = $asset->id;
+			$item->typeAlias = 'com_content.article';
 		}
 
 		return $items;


### PR DESCRIPTION
### Summary of Changes

This removes multiple queries by getting `asset_id` from `#__content` table.
Also simplifies item loop.

### Testing Instructions
Code review?

### Documentation Changes Required

No.