### PR TITLE
[4.0] Drone: Allowing diff-build to fail

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -43,6 +43,7 @@ steps:
   - name: publish-diff
     image: joomlaprojects/docker-images:patchtester
     depends_on: [ npm ]
+    failure: ignore
     environment:
       CMP_ARCHIVE_NAME: "build"
       CMP_MASTER_FOLDER: "/reference"

--- a/.drone.yml
+++ b/.drone.yml
@@ -302,6 +302,6 @@ services:
 
 ---
 kind: signature
-hmac: f17f253b02d7a16535d706a31f99d678dcdc595d5bc2ca1e8c2889c3eae2a51b
+hmac: d0176d829d9f2441e79ee7f5f68bc2a938d4d7f01ccc1bb4609e4e8f066238a4
 
 ...


### PR DESCRIPTION
The build of the diff for the patchtester should not fail a build.