### PR TITLE
Codeception: Enable logging of JS errors

### DIFF
--- a/tests/Codeception/acceptance.suite.yml
+++ b/tests/Codeception/acceptance.suite.yml
@@ -31,7 +31,7 @@ modules:
             sample data: 'Default English (GB) Sample Data'    # Default Sample Data
             admin email: 'admin@mydomain.com'      # email Id of the Admin
             language: 'English (United Kingdom)'   # Language in which you want the Application to be Installed
-			log_js_errors: true
+            log_js_errors: true
         Helper\JoomlaDb:
             dsn: 'mysql:host=mysql;dbname=test_joomla'
             user: 'root'

--- a/tests/Codeception/acceptance.suite.yml
+++ b/tests/Codeception/acceptance.suite.yml
@@ -31,6 +31,7 @@ modules:
             sample data: 'Default English (GB) Sample Data'    # Default Sample Data
             admin email: 'admin@mydomain.com'      # email Id of the Admin
             language: 'English (United Kingdom)'   # Language in which you want the Application to be Installed
+			log_js_errors: true
         Helper\JoomlaDb:
             dsn: 'mysql:host=mysql;dbname=test_joomla'
             user: 'root'

--- a/tests/Codeception/acceptance.suite.yml
+++ b/tests/Codeception/acceptance.suite.yml
@@ -17,7 +17,7 @@ modules:
             window_size: false
             capabilities:
               'goog:chromeOptions':
-                args: ["headless", "disable-gpu", "no-sandbox", "window-size=1920x1080"]
+                args: ["headless", "whitelisted-ips", "disable-gpu", "no-sandbox", "window-size=1920x1080"]
             name: 'jane doe'                       # Name for the Administrator
             username: 'admin'                      # UserName for the Administrator
             password: 'admin'                      # Password for the Administrator

--- a/tests/Codeception/acceptance/install/InstallCest.php
+++ b/tests/Codeception/acceptance/install/InstallCest.php
@@ -41,7 +41,7 @@ class InstallCest
 	public function configureJoomla(AcceptanceTester $I)
 	{
 		$I->am('Administrator');
-		$I->doAdministratorLogin();
+		$I->doAdministratorLogin(null, null, false);
 		$I->disableStatistics();
 		$I->setErrorReportingToDevelopment();
 	}


### PR DESCRIPTION
Enable logging JS errors option in Selenium for acceptance tests.