### PR TITLE
[4.0] Drone: Removing caching of npm

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -11,9 +11,7 @@ steps:
     settings:
       restore: true
       mount:
-        - ./node_modules
         - ./libraries/vendor
-        - ./administrator/components/com_media/node_modules
       cache_key: [ DRONE_REPO_NAMESPACE, DRONE_REPO_NAME, DRONE_BRANCH, DRONE_STAGE_NUMBER ]
     volumes:
       - name: cache
@@ -38,7 +36,7 @@ steps:
     image: joomlaprojects/docker-tools:develop
     depends_on: [ phpcs ]
     commands:
-      - npm ci --unsafe-perm
+      - npm install --unsafe-perm
 
   - name: publish-diff
     image: joomlaprojects/docker-images:patchtester
@@ -74,9 +72,7 @@ steps:
     settings:
       rebuild: true
       mount:
-        - ./node_modules
         - ./libraries/vendor
-        - ./administrator/components/com_media/node_modules
       cache_key: [ DRONE_REPO_NAMESPACE, DRONE_REPO_NAME, DRONE_BRANCH, DRONE_STAGE_NUMBER ]
     volumes:
       - name: cache
@@ -301,6 +297,6 @@ services:
 
 ---
 kind: signature
-hmac: f17f253b02d7a16535d706a31f99d678dcdc595d5bc2ca1e8c2889c3eae2a51b
+hmac: 18fe1c51adf4123f60550bec7dd255ee552b7f1568aba0e98cdd91ba7aef1674
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -36,7 +36,7 @@ steps:
     image: joomlaprojects/docker-tools:develop
     depends_on: [ phpcs ]
     commands:
-      - npm install --unsafe-perm
+      - npm ci --unsafe-perm
 
   - name: publish-diff
     image: joomlaprojects/docker-images:patchtester
@@ -297,6 +297,6 @@ services:
 
 ---
 kind: signature
-hmac: 18fe1c51adf4123f60550bec7dd255ee552b7f1568aba0e98cdd91ba7aef1674
+hmac: ad27cac6dfbc460a9caf00c36e0f2c8d34e0fd30189d97bc7902b8442ca9db9a
 
 ...


### PR DESCRIPTION
We have regular issues that the cache of npm is broken and this results in failed builds. Because of that we already used `npm ci` in the past to actually skip the cache. We then still had the issue with the media manager. So the logical consequence is to completely remove the cache for these folders. I left the ci parameter for npm in, since that validates the package.json against the package.lock.