### PR TITLE
[4.x] Drone: debug system test setup

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -248,7 +248,7 @@ steps:
         - 4.0-dev
     commands:
       - export RIPS_BASE_URI='https://api.rips.joomla.org'
-      - rips-cli rips:scan:start -a 3 -t 1 -R -k -p $(pwd) -t 1 -T $DRONE_REPO_NAMESPACE-$DRONE_BRANCH ||  { echo "Please contact the security team at security@joomla.org"; exit 1; }
+      - rips-cli rips:scan:start -a 2 -t 1 -R -k -p $(pwd) -t 1 -T $DRONE_REPO_NAMESPACE-$DRONE_BRANCH ||  { echo "Please contact the security team at security@joomla.org"; exit 1; }
     environment:
       RIPS_EMAIL:
         from_secret: RIPS_EMAIL
@@ -301,6 +301,6 @@ services:
 
 ---
 kind: signature
-hmac: ce8abdc11b0c027d819feab9037f86a08806f6feca30cc1be262dc8725d0dde9
+hmac: f9e707b8a9668a599058c4fa59cd7325b5a9978c7ecfe5e41b61b59c0a2b2724
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -239,7 +239,7 @@ steps:
       - bash tests/Codeception/drone-api-run.sh "$(pwd)"
 
   - name: analysis4x
-    image: rips/rips-cli:1.2.1
+    image: rips/rips-cli:3.2.2
     depends_on: [ api-tests ]
     when:
       repo:
@@ -250,8 +250,8 @@ steps:
       - export RIPS_BASE_URI='https://api.rips.joomla.org'
       - rips-cli rips:scan:start -a 3 -t 1 -R -k -p $(pwd) -t 1 -T $DRONE_REPO_NAMESPACE-$DRONE_BRANCH ||  { echo "Please contact the security team at security@joomla.org"; exit 1; }
     environment:
-      RIPS_USERNAME:
-        from_secret: RIPS_USERNAME
+      RIPS_EMAIL:
+        from_secret: RIPS_EMAIL
       RIPS_PASSWORD:
         from_secret: RIPS_PASSWORD
 
@@ -301,6 +301,6 @@ services:
 
 ---
 kind: signature
-hmac: f17f253b02d7a16535d706a31f99d678dcdc595d5bc2ca1e8c2889c3eae2a51b
+hmac: ce8abdc11b0c027d819feab9037f86a08806f6feca30cc1be262dc8725d0dde9
 
 ...

--- a/administrator/components/com_media/resources/styles/components/_media-modal.scss
+++ b/administrator/components/com_media/resources/styles/components/_media-modal.scss
@@ -2,7 +2,7 @@
   position: fixed;
   top: 0;
   left: 0;
-  z-index: 1070;
+  z-index: 1049;
   display: table;
   width: 100%;
   height: 100%;

--- a/administrator/components/com_media/resources/styles/components/_media-modal.scss
+++ b/administrator/components/com_media/resources/styles/components/_media-modal.scss
@@ -2,7 +2,7 @@
   position: fixed;
   top: 0;
   left: 0;
-  z-index: 1049;
+  z-index: 1070;
   display: table;
   width: 100%;
   height: 100%;

--- a/tests/Codeception/acceptance.suite.yml
+++ b/tests/Codeception/acceptance.suite.yml
@@ -17,7 +17,7 @@ modules:
             window_size: false
             capabilities:
               'goog:chromeOptions':
-                args: ["headless", "disable-gpu", "no-sandbox", "window-size=1920x1080"]
+                args: ["headless", "disable-gpu", "no-sandbox", "window-size=1920x1080", "--disable-dev-shm-usage"]
             name: 'jane doe'                       # Name for the Administrator
             username: 'admin'                      # UserName for the Administrator
             password: 'admin'                      # Password for the Administrator

--- a/tests/Codeception/acceptance/administrator/components/com_media/MediaListCest.php
+++ b/tests/Codeception/acceptance/administrator/components/com_media/MediaListCest.php
@@ -490,18 +490,19 @@ class MediaListCest
 		$I->amOnPage(MediaListPage::$url . $this->testDirectory);
 		$I->uploadFile('com_media/' . $testFileName);
 		$I->waitForElement($testFileItem);
+        $I->wait(1);
 		$I->clickOnActionInMenuOf($testFileName, MediaListPage::$renameAction);
 		$I->waitForElement(MediaListPage::$renameInputField);
 		$I->seeElement(MediaListPage::$renameInputField);
 		$I->seeElement(MediaListPage::$modalConfirmButton);
 
 		// Sometimes the modal is still fading in
-		$I->wait(0.5);
+		$I->wait(1);
 		$I->fillField(MediaListPage::$renameInputField, 'test-image-1-renamed');
 		$I->click(MediaListPage::$modalConfirmButton);
 
 		// Ensure the modal has closed
-		$I->wait(0.5);
+		$I->wait(1);
 		$I->seeSystemMessage('Item renamed.');
 		$I->dontSeeElement($testFileItem);
 		$I->seeElement(MediaListPage::item('test-image-1-renamed.png'));

--- a/tests/Codeception/acceptance/administrator/components/com_media/MediaListCest.php
+++ b/tests/Codeception/acceptance/administrator/components/com_media/MediaListCest.php
@@ -490,7 +490,7 @@ class MediaListCest
 		$I->amOnPage(MediaListPage::$url . $this->testDirectory);
 		$I->uploadFile('com_media/' . $testFileName);
 		$I->waitForElement($testFileItem);
-        $I->wait(1);
+		$I->wait(1);
 		$I->clickOnActionInMenuOf($testFileName, MediaListPage::$renameAction);
 		$I->waitForElement(MediaListPage::$renameInputField);
 		$I->seeElement(MediaListPage::$renameInputField);
@@ -566,12 +566,12 @@ class MediaListCest
 		$I->seeElement(MediaListPage::$modalConfirmButton);
 
 		// Sometimes the modal is still fading in
-		$I->wait(0.5);
+		$I->wait(1);
 		$I->fillField(MediaListPage::$renameInputField, $testFolderName . '-renamed');
 		$I->click(MediaListPage::$modalConfirmButton);
 
 		// Ensure the modal has closed
-		$I->wait(0.5);
+		$I->wait(1);
 		$I->seeSystemMessage('Item renamed.');
 		$I->dontSeeElement($testFolderItem);
 		$I->seeElement(MediaListPage::item($testFolderName . '-renamed'));

--- a/tests/Codeception/acceptance/administrator/components/com_media/MediaListCest.php
+++ b/tests/Codeception/acceptance/administrator/components/com_media/MediaListCest.php
@@ -560,6 +560,7 @@ class MediaListCest
 		$I->createDirectory('images/' . $this->testDirectory . '/' . $testFolderName);
 		$I->amOnPage(MediaListPage::$url . $this->testDirectory);
 		$I->waitForElement($testFolderItem);
+		$I->wait(1);
 		$I->clickOnActionInMenuOf($testFolderName, MediaListPage::$renameAction);
 		$I->waitForElement(MediaListPage::$renameInputField);
 		$I->seeElement(MediaListPage::$renameInputField);


### PR DESCRIPTION
Make 4.x builds pass again by:
* Adding a chrome flag to make selenium work without crashes on debian buster
* add / increase wait times to avoid race conditions on the new, more powerful Drone worker nodes
* adjust drone yaml to RIPS 3.x
* adjust z-index to work around a weird chromedriver bug