### PR TITLE
[4.0] Change class to allow closing of menus when opening another

### DIFF
--- a/build/media_source/mod_menu/js/admin-menu.es6.js
+++ b/build/media_source/mod_menu/js/admin-menu.es6.js
@@ -152,9 +152,9 @@
           const firstLevel = closest(link, '.collapse-level-1');
           const secondLevel = closest(link, '.collapse-level-2');
           if (firstLevel) firstLevel.parentNode.classList.add('mm-active');
-          if (firstLevel) firstLevel.classList.add('mm-collapsed');
+          if (firstLevel) firstLevel.classList.add('mm-show');
           if (secondLevel) secondLevel.parentNode.classList.add('mm-active');
-          if (secondLevel) secondLevel.classList.add('mm-collapsed');
+          if (secondLevel) secondLevel.classList.add('mm-show');
         }
       }
     });


### PR DESCRIPTION
Pull Request for Issue #26536 

### Summary of Changes
Use the show class to allow the menu to be closed when opening another menu

### Testing Instructions
1. Compile the JS
2. Login to the backend
3. Open a menu and select an item
4. Now the menu that you opened is open by default, click another toplevel menu
5. The active menu should be closed and the clicked menu open

### Expected result
The only open menu is the one clicked

Not sure if this is what the expected outcome is as no desired outcome is mentioned in issue #26536 

### Actual result
There are 2 open menus, the one clicked and the active menu


### Documentation Changes Required
None

@infograf768 @brianteeman 
