### PR TITLE
[4.0] Install language field: Fixing codestyle

### DIFF
--- a/installation/src/Form/Field/Installation/LanguageField.php
+++ b/installation/src/Form/Field/Installation/LanguageField.php
@@ -78,7 +78,7 @@ class LanguageField extends ListField
 			}
 		}
 
-		if (!$options || $options  instanceof \Exception)
+		if (!$options || $options instanceof \Exception)
 		{
 			$options = array();
 		}


### PR DESCRIPTION
This fixes the codestyle of the file. Without this, #26566 fails.