### PR TITLE
[4.0] fix quirky systemmessage handling in system tests

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4728,12 +4728,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-projects/joomla-browser.git",
-                "reference": "2d92374195b13bfab1a352a3fba302b84ead699b"
+                "reference": "9cd0f0360300b87f55f1535ee3697a5c8f5bd2e2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-projects/joomla-browser/zipball/2d92374195b13bfab1a352a3fba302b84ead699b",
-                "reference": "2d92374195b13bfab1a352a3fba302b84ead699b",
+                "url": "https://api.github.com/repos/joomla-projects/joomla-browser/zipball/9cd0f0360300b87f55f1535ee3697a5c8f5bd2e2",
+                "reference": "9cd0f0360300b87f55f1535ee3697a5c8f5bd2e2",
                 "shasum": ""
             },
             "require": {
@@ -4771,7 +4771,7 @@
                 "acceptance testing",
                 "joomla"
             ],
-            "time": "2019-10-12T15:41:31+00:00"
+            "time": "2019-10-12T18:23:47+00:00"
         },
         {
             "name": "joomla/cms-coding-standards",

--- a/tests/Codeception/_support/Page/Acceptance/Administrator/AdminPage.php
+++ b/tests/Codeception/_support/Page/Acceptance/Administrator/AdminPage.php
@@ -136,7 +136,8 @@ class AdminPage extends AcceptanceTester
 		$I = $this;
 
 		$I->waitForPageTitle($title);
-		$I->see($message, self::$systemMessageContainer);
+		$I->waitForElementVisible(self::$systemMessageContainer, TIMEOUT);
+		$I->see($message, );
 	}
 
 	/**

--- a/tests/Codeception/_support/Page/Acceptance/Administrator/AdminPage.php
+++ b/tests/Codeception/_support/Page/Acceptance/Administrator/AdminPage.php
@@ -137,7 +137,7 @@ class AdminPage extends AcceptanceTester
 
 		$I->waitForPageTitle($title);
 		$I->waitForElementVisible(self::$systemMessageContainer, TIMEOUT);
-		$I->see($message, );
+		$I->see($message, self::$systemMessageContainer);
 	}
 
 	/**

--- a/tests/Codeception/acceptance/administrator/components/com_users/UserListCest.php
+++ b/tests/Codeception/acceptance/administrator/components/com_users/UserListCest.php
@@ -154,6 +154,7 @@ class UserListCest
 		$I->clickToolbarButton("Save");
 		$I->comment('I wait for global configuration being saved');
 		$I->waitForText('Global Configuration', TIMEOUT, ['css' => '.page-title']);
+        $I->waitForElementVisible(['id' => 'system-message-container'], TIMEOUT);
 		$I->see('Configuration saved.', ['id' => 'system-message-container']);
 	}
 }

--- a/tests/Codeception/acceptance/administrator/components/com_users/UserListCest.php
+++ b/tests/Codeception/acceptance/administrator/components/com_users/UserListCest.php
@@ -154,7 +154,7 @@ class UserListCest
 		$I->clickToolbarButton("Save");
 		$I->comment('I wait for global configuration being saved');
 		$I->waitForText('Global Configuration', TIMEOUT, ['css' => '.page-title']);
-        $I->waitForElementVisible(['id' => 'system-message-container'], TIMEOUT);
+		$I->waitForElementVisible(['id' => 'system-message-container'], TIMEOUT);
 		$I->see('Configuration saved.', ['id' => 'system-message-container']);
 	}
 }


### PR DESCRIPTION
System messages are  nicely faded in using a transition, however in some places of our testing suite we are not properly checking if the system messages are completly visible or not before running the "see"-check, causing failed tests like this one:
https://ci.joomla.org:444/artifacts/joomla/joomla-cms/4.0-dev/26568/system-tests/24615/UserListCest.createUser.mysql.fail.png