### PR TITLE
[4.0] Handle forced password reset

### DIFF
--- a/libraries/src/Application/AdministratorApplication.php
+++ b/libraries/src/Application/AdministratorApplication.php
@@ -154,7 +154,7 @@ class AdministratorApplication extends CMSApplication
 		 * $this->input->getCmd('option'); or $this->input->getCmd('view');
 		 * ex: due of the sef urls
 		 */
-		$this->checkUserRequireReset('com_admin', 'profile', 'edit', 'com_admin/profile.save,com_admin/profile.apply,com_login/logout');
+		$this->checkUserRequireReset('com_users', 'user', 'edit', 'com_users/user.edit,com_users/user.save,com_users/user.apply,com_login/logout');
 
 		// Dispatch the application
 		$this->dispatch();

--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -353,7 +353,7 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
 				$url = Route::_('index.php?option=' . $option . '&view=' . $view . '&layout=' . $layout, false);
 
 				// In the administrator we need a different URL
-				if ($name === 'administrator')
+				if (strtolower($name) === 'administrator')
 				{
 					$user = Factory::getApplication()->getIdentity();
 					$url  = Route::_('index.php?option=' . $option . '&task=' . $view . '.' . $layout . '&id=' . $user->id, false);

--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -34,7 +34,7 @@ use Joomla\DI\Container;
 use Joomla\DI\ContainerAwareInterface;
 use Joomla\DI\ContainerAwareTrait;
 use Joomla\Registry\Registry;
-use Joomla\String\StringHelper;
+use Joomla\string\StringHelper;
 
 /**
  * Joomla! CMS Application class
@@ -292,6 +292,8 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
 	 * @param   string  $tasks   Permitted tasks
 	 *
 	 * @return  void
+	 *
+	 * @throws  \Exception
 	 */
 	protected function checkUserRequireReset($option, $view, $layout, $tasks)
 	{
@@ -310,9 +312,9 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
 			if ($this->get($name . '_reset_password_override', 0))
 			{
 				$option = $this->get($name . '_reset_password_option', '');
-				$view = $this->get($name . '_reset_password_view', '');
+				$view   = $this->get($name . '_reset_password_view', '');
 				$layout = $this->get($name . '_reset_password_layout', '');
-				$tasks = $this->get($name . '_reset_password_tasks', '');
+				$tasks  = $this->get($name . '_reset_password_tasks', '');
 			}
 
 			$task = $this->input->getCmd('task', '');
@@ -347,7 +349,17 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
 			{
 				// Redirect to the profile edit page
 				$this->enqueueMessage(Text::_('JGLOBAL_PASSWORD_RESET_REQUIRED'), 'notice');
-				$this->redirect(Route::_('index.php?option=' . $option . '&view=' . $view . '&layout=' . $layout, false));
+
+				$url = Route::_('index.php?option=' . $option . '&view=' . $view . '&layout=' . $layout, false);
+
+				// In the administrator we need a different URL
+				if ($name === 'administrator')
+				{
+					$user = Factory::getApplication()->getIdentity();
+					$url  = Route::_('index.php?option=' . $option . '&task=' . $view . '.' . $layout . '&id=' . $user->id, false);
+				}
+
+				$this->redirect($url);
 			}
 		}
 	}

--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -34,7 +34,7 @@ use Joomla\DI\Container;
 use Joomla\DI\ContainerAwareInterface;
 use Joomla\DI\ContainerAwareTrait;
 use Joomla\Registry\Registry;
-use Joomla\string\StringHelper;
+use Joomla\String\StringHelper;
 
 /**
  * Joomla! CMS Application class


### PR DESCRIPTION
### Summary of Changes
When forcing a password reset in the administrator section, you get a page not found as it redirects to an obsolete view


### Testing Instructions
1. Set the `Require Password Reset` to Yes for a user with access to the administrator section
2. Login with the user
3. Notice you get a page not found message
4. Logout
5. Apply the patch
6. Login with the user again
7. Now you are on the user edit page to reset the password


### Expected result
I am redirected to the user edit page


### Actual result
I get a page not found


### Documentation Changes Required
None
