### PR TITLE
[4.x] Clean up used docker images in drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -18,7 +18,7 @@ steps:
         path: /cache
 
   - name: composer
-    image: joomlaprojects/docker-tools:develop
+    image: joomlaprojects/docker-images:php7.3-composer
     depends_on: [ restore-cache ]
     commands:
       - composer validate --no-check-all --strict
@@ -170,7 +170,7 @@ steps:
 
   - name: javascript-cs
     depends_on: [ npm ]
-    image: joomlaprojects/docker-systemtests:latest
+    image: joomlaprojects/docker-images:systemtests
     commands:
       - export DISPLAY=:0
       - Xvfb -screen 0 1024x768x24 -ac +extension GLX +render -noreset > /dev/null 2>&1 &
@@ -180,7 +180,7 @@ steps:
 
   - name: javascript-tests
     depends_on: [ npm ]
-    image: joomlaprojects/docker-systemtests:latest
+    image: joomlaprojects/docker-images:systemtests
     commands:
       - export DISPLAY=:0
       - Xvfb -screen 0 1024x768x24 -ac +extension GLX +render -noreset > /dev/null 2>&1 &
@@ -190,26 +190,26 @@ steps:
 
   - name: system-tests-mysql
     depends_on: [ javascript-tests ]
-    image: joomlaprojects/docker-systemtests:latest
+    image: joomlaprojects/docker-images:systemtests
     commands:
       - bash tests/Codeception/drone-system-run.sh "$(pwd)" mysql
 
   - name: system-tests-mysql8
     depends_on: [ system-tests-mysql ]
-    image: joomlaprojects/docker-systemtests:latest
+    image: joomlaprojects/docker-images:systemtests
     failure: ignore
     commands:
       - bash tests/Codeception/drone-system-run.sh "$(pwd)" mysql8
 
   - name: system-tests-postgres
     depends_on: [ system-tests-mysql8 ]
-    image: joomlaprojects/docker-systemtests:latest
+    image: joomlaprojects/docker-images:systemtests
     commands:
       - bash tests/Codeception/drone-system-run.sh "$(pwd)" postgres
 
   - name: api-tests
     depends_on: [ system-tests-postgres ]
-    image: joomlaprojects/docker-systemtests:latest
+    image: joomlaprojects/docker-images:systemtests
     commands:
       - bash tests/Codeception/drone-api-run.sh "$(pwd)"
 
@@ -298,6 +298,6 @@ services:
 
 ---
 kind: signature
-hmac: 4690de3a080ec5aa572a520fa334703015f2fc89d51cede7179d8b239ab200c2
+hmac: 1f8eaa619ff21c79d04d71f2323bb2600024fb54ae56e57a9238d8da0e63255c
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -33,7 +33,7 @@ steps:
       - echo $(date)
 
   - name: npm
-    image: joomlaprojects/docker-tools:develop
+    image: node:current-apline
     depends_on: [ phpcs ]
     commands:
       - npm ci --unsafe-perm
@@ -298,6 +298,6 @@ services:
 
 ---
 kind: signature
-hmac: bf61935fbad0fe4548f7adc70d54eb7839521ff46106794555074b344a0af4db
+hmac: 2a5c4ceaeac4d170d34181f293bdb9d728078081cfc18d737fb2a066e9e482bf
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -33,7 +33,7 @@ steps:
       - echo $(date)
 
   - name: npm
-    image: node:current-apline
+    image: node:current-alpine
     depends_on: [ phpcs ]
     commands:
       - npm ci --unsafe-perm
@@ -298,6 +298,6 @@ services:
 
 ---
 kind: signature
-hmac: 2a5c4ceaeac4d170d34181f293bdb9d728078081cfc18d737fb2a066e9e482bf
+hmac: 4690de3a080ec5aa572a520fa334703015f2fc89d51cede7179d8b239ab200c2
 
 ...


### PR DESCRIPTION
### Summary of Changes
* Use official node image for npm install setup, removing the need to maintain our own image
* get rid of the docker-tools image by adding a new composer image to the docker-images repo which is based on our existing php 7.3 image
* move systemtests image to docker-images repo