### PR TITLE
[4.0] Correcting Notice in menu modal

### DIFF
--- a/administrator/components/com_menus/layouts/joomla/searchtools/default.php
+++ b/administrator/components/com_menus/layouts/joomla/searchtools/default.php
@@ -93,11 +93,13 @@ HTMLHelper::_('searchtools.form', $data['options']['formSelector'], $data['optio
 	<?php // Add the itemtype and language selectors before the form filters. Do not display in modal. ?>
 	<?php $app = Factory::getApplication(); ?>
 		<?php $clientIdField = $data['view']->filterForm->getField('client_id'); ?>
+		<?php if ($clientIdField) : ?>
 		<div class="js-stools-container-selector-first">
 			<div class="js-stools-field-selector js-stools-client_id">
 				<?php echo $clientIdField->input; ?>
 			</div>
 		</div>
+		<?php endif; ?>
 	<?php endif; ?>
 	<?php if ($data['options']['showSelector']) : ?>
 	<div class="js-stools-container-selector">


### PR DESCRIPTION
#26208  Summary of Changes

Conditional was forgotten in searchtools menu custom layout

### Testing Instructions
Create a new menu item of type login form.
In the Options Tab, Select a `Menu Item Login Redirect`


### Before patch
We get a Notice
`Notice: Trying to get property 'input' of non-object in /Applications/MAMP/htdocs/installmulti/joomla40/administrator/components/com_menus/layouts/joomla/searchtools/default.php on line 98`



### After patch
All is fine
