### PR TITLE
fix issue in com_joomlaupdate cc @hleinthner

### DIFF
--- a/administrator/components/com_joomlaupdate/views/default/tmpl/default.php
+++ b/administrator/components/com_joomlaupdate/views/default/tmpl/default.php
@@ -62,7 +62,7 @@ JS
 			<?php JFactory::getApplication()->enqueueMessage(JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_INSTALL_SELF_UPDATE_FIRST'), 'error'); ?>
 			<?php echo $this->loadTemplate('updatemefirst'); ?>
 		<?php else : ?>
-			<?php if (!isset($this->updateInfo['object']->downloadurl->_data)
+			<?php if ((!isset($this->updateInfo['object']->downloadurl->_data)
 				&& !$this->updateInfo['hasUpdate'])
 				|| !$this->getModel()->isDatabaseTypeSupported()
 				|| !$this->getModel()->isPhpVersionSupported()) : ?>


### PR DESCRIPTION
Pull Request for Issue #26587

### Summary of Changes

Add missing opening `(` after the merge conflict.

### Testing Instructions

apply the patch notice is gone and the updater page shows up

### Expected result

notice is gone and the updater page shows up

### Actual result

syntax error, unexpected '||' (T_BOOLEAN_OR)

### Documentation Changes Required

none

cc @hleinthner