### PR TITLE
[4.0] options grid

### DIFF
--- a/administrator/templates/atum/scss/pages/_com_config.scss
+++ b/administrator/templates/atum/scss/pages/_com_config.scss
@@ -7,7 +7,7 @@
 	}
 
 	.tab-description {
-		grid-column: 1 / 3;
+		grid-column: 1 / -1;
 	}
 
   .rule-notes,


### PR DESCRIPTION
Most of the options fieldsets have a css class of .options-grid-form-full which means that they should be in one column.

However as can be seen below they are in **two** uneven columns
![image](https://user-images.githubusercontent.com/1296369/66870244-ebb3b000-ef98-11e9-8711-e80e634b4b48.png)

The cause of this is the description div which is set to start at col 1 and end at col 3 even though at this resolution there is only 1 column.

```
.com_config .tab-description {
    grid-column: 1/3;
}
```

Pull Request for Issue #26605