### PR TITLE
[4.0] Article Options

### DIFF
--- a/administrator/components/com_content/tmpl/article/edit.php
+++ b/administrator/components/com_content/tmpl/article/edit.php
@@ -104,8 +104,9 @@ $tmpl    = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=c
 			<?php echo HTMLHelper::_('uitab.endTab'); ?>
 		<?php endif; ?>
 
-		<?php $this->show_options = $params->get('show_article_options', 1); ?>
-		<?php echo LayoutHelper::render('joomla.edit.params', $this); ?>
+		<?php if ($params->get('show_article_options', 1) == 1) : ?>
+			<?php echo LayoutHelper::render('joomla.edit.params', $this); ?>
+		<?php endif; ?>
 
 		<?php // Do not show the publishing options if the edit form is configured not to. ?>
 		<?php if ($params->get('show_publishing_options', 1) == 1) : ?>


### PR DESCRIPTION
There is an option for com_content to hide the article options tab for the editing layout of individual articles - I'll be honest and say I never knew it was there.

Unfortunately it didn't have any effect.

This PR fixes that

### Testing

Set Show Article Options to hide
![image](https://user-images.githubusercontent.com/1296369/66998360-03d81c00-f0cc-11e9-9520-5de732659170.png)


### Expected behaviour with this PR
The Options tab is not present any more
![image](https://user-images.githubusercontent.com/1296369/66998298-e905a780-f0cb-11e9-9d5d-7b851195dbf5.png)

