### PR TITLE
Suppress get_magic_quotes_gpc() deprecation notices

### DIFF
--- a/administrator/components/com_joomlaupdate/restore.php
+++ b/administrator/components/com_joomlaupdate/restore.php
@@ -123,7 +123,7 @@ function getQueryParam($key, $default = null)
 		$value = $_REQUEST[$key];
 	}
 
-	if (get_magic_quotes_gpc() && !is_null($value))
+	if (@get_magic_quotes_gpc() && !is_null($value))
 	{
 		$value = stripslashes($value);
 	}

--- a/administrator/components/com_joomlaupdate/restore.php
+++ b/administrator/components/com_joomlaupdate/restore.php
@@ -123,7 +123,7 @@ function getQueryParam($key, $default = null)
 		$value = $_REQUEST[$key];
 	}
 
-	if (@get_magic_quotes_gpc() && !is_null($value))
+	if (PHP_VERSION_ID < 50400 && get_magic_quotes_gpc() && !is_null($value))
 	{
 		$value = stripslashes($value);
 	}

--- a/libraries/fof/input/input.php
+++ b/libraries/fof/input/input.php
@@ -4,6 +4,7 @@
  * @subpackage  input
  * @copyright   Copyright (C) 2010-2016 Nicholas K. Dionysopoulos / Akeeba Ltd. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ * @note        This file has been modified by the Joomla! Project and no longer reflects the original work of its author.
  */
 // Protect from unauthorized access
 defined('FOF_INCLUDED') or die;
@@ -99,7 +100,7 @@ class FOFInput extends JInput
 
 		// Magic quotes GPC handling (something JInput simply can't handle at all)
 
-		if (($hash == 'REQUEST') && get_magic_quotes_gpc() && class_exists('JRequest', true))
+		if (($hash == 'REQUEST') && @get_magic_quotes_gpc() && class_exists('JRequest', true))
 		{
 			$source = JRequest::get('REQUEST', 2);
 		}

--- a/libraries/fof/input/input.php
+++ b/libraries/fof/input/input.php
@@ -100,7 +100,7 @@ class FOFInput extends JInput
 
 		// Magic quotes GPC handling (something JInput simply can't handle at all)
 
-		if (($hash == 'REQUEST') && @get_magic_quotes_gpc() && class_exists('JRequest', true))
+		if (($hash == 'REQUEST') && PHP_VERSION_ID < 50400 && get_magic_quotes_gpc() && class_exists('JRequest', true))
 		{
 			$source = JRequest::get('REQUEST', 2);
 		}

--- a/libraries/src/Application/AdministratorApplication.php
+++ b/libraries/src/Application/AdministratorApplication.php
@@ -123,7 +123,7 @@ class AdministratorApplication extends CMSApplication
 		$this->initialiseApp($options);
 
 		// Test for magic quotes
-		if (@get_magic_quotes_gpc())
+		if (PHP_VERSION_ID < 50400 && get_magic_quotes_gpc())
 		{
 			$lang = $this->getLanguage();
 

--- a/libraries/src/Application/AdministratorApplication.php
+++ b/libraries/src/Application/AdministratorApplication.php
@@ -123,7 +123,7 @@ class AdministratorApplication extends CMSApplication
 		$this->initialiseApp($options);
 
 		// Test for magic quotes
-		if (get_magic_quotes_gpc())
+		if (@get_magic_quotes_gpc())
 		{
 			$lang = $this->getLanguage();
 


### PR DESCRIPTION
Partial Pull Request for Issue #26607.

### Summary of Changes

`get_magic_quotes_gpc()` emits a deprecation notice on PHP 7.4:
>Deprecated: Function get_magic_quotes_gpc() is deprecated

This suppresses the notice.

### Testing Instructions

Code review.

### Documentation Changes Required

No.