### PR TITLE
[4.0] Alias menu item types not working in admin menus

### DIFF
--- a/administrator/components/com_menus/Helper/MenusHelper.php
+++ b/administrator/components/com_menus/Helper/MenusHelper.php
@@ -701,7 +701,7 @@ class MenusHelper extends ContentHelper
 			$query->select('a.id, a.link, a.type, e.element')
 				->from('#__menu a')
 				->where('a.id = ' . (int) $aliasTo)
-				->join('left', '#__extensions e ON e.id = a.component_id = e.id');
+				->join('left', '#__extensions e ON e.extension_id = a.component_id');
 
 			try
 			{


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Fixes query error preventing alias menu item types from showing in admin menus.

### Testing Instructions

Create admin menu.
Create a menu item.
Create an alias for that menu item.
Publish a menu module.

### Expected result

Menu item and its alias are showing.

### Actual result

Only first menu item is shown.

### Documentation Changes Required

No.