### PR TITLE
[4.0] Codestyle: Cleaning up Generic.Strings.UnnecessaryStringConcat

### DIFF
--- a/libraries/src/Helper/ContentHistoryHelper.php
+++ b/libraries/src/Helper/ContentHistoryHelper.php
@@ -168,7 +168,7 @@ class ContentHistoryHelper extends CMSHelper
 
 		$context = $aliasParts[1] ?? '';
 
-		$maxVersionsContext = ComponentHelper::getParams($aliasParts[0])->get('history_limit' . '_' . $context, 0);
+		$maxVersionsContext = ComponentHelper::getParams($aliasParts[0])->get('history_limit_' . $context, 0);
 
 		if ($maxVersionsContext)
 		{

--- a/libraries/src/Helper/TagsHelper.php
+++ b/libraries/src/Helper/TagsHelper.php
@@ -371,7 +371,7 @@ class TagsHelper extends CMSHelper
 			$query->select($db->quoteName('t') . '.*');
 		}
 
-		$query->join('INNER', $db->quoteName('#__tags') . ' AS t ' . ' ON ' . $db->quoteName('m.tag_id') . ' = ' . $db->quoteName('t.id'));
+		$query->join('INNER', $db->quoteName('#__tags') . ' AS t ON ' . $db->quoteName('m.tag_id') . ' = ' . $db->quoteName('t.id'));
 
 		$db->setQuery($query);
 		$this->itemTags = $db->loadObjectList();
@@ -490,18 +490,18 @@ class TagsHelper extends CMSHelper
 		$query
 			->select(
 				'm.type_alias'
-				. ', ' . 'm.content_item_id'
-				. ', ' . 'm.core_content_id'
-				. ', ' . 'count(m.tag_id) AS match_count'
-				. ', ' . 'MAX(m.tag_date) as tag_date'
-				. ', ' . 'MAX(c.core_title) AS core_title'
-				. ', ' . 'MAX(c.core_params) AS core_params'
+				. ', m.content_item_id'
+				. ', m.core_content_id'
+				. ', count(m.tag_id) AS match_count'
+				. ', MAX(m.tag_date) as tag_date'
+				. ', MAX(c.core_title) AS core_title'
+				. ', MAX(c.core_params) AS core_params'
 			)
 			->select('MAX(c.core_alias) AS core_alias, MAX(c.core_body) AS core_body, MAX(c.core_state) AS core_state, MAX(c.core_access) AS core_access')
 			->select(
 				'MAX(c.core_metadata) AS core_metadata'
-				. ', ' . 'MAX(c.core_created_user_id) AS core_created_user_id'
-				. ', ' . 'MAX(c.core_created_by_alias) AS core_created_by_alias'
+				. ', MAX(c.core_created_user_id) AS core_created_user_id'
+				. ', MAX(c.core_created_by_alias) AS core_created_by_alias'
 			)
 			->select('MAX(c.core_created_time) as core_created_time, MAX(c.core_images) as core_images')
 			->select('CASE WHEN c.core_modified_time = ' . $nullDate . ' THEN c.core_created_time ELSE c.core_modified_time END as core_modified_time')

--- a/libraries/src/Table/Nested.php
+++ b/libraries/src/Table/Nested.php
@@ -1741,9 +1741,9 @@ class Nested extends Table
 
 		if ($this->_debug)
 		{
-			echo "\nRepositioning Data for $position" . "\n-----------------------------------" . "\nLeft Where:    $data->left_where"
-				. "\nRight Where:   $data->right_where" . "\nNew Lft:       $data->new_lft" . "\nNew Rgt:       $data->new_rgt"
-				. "\nNew Parent ID: $data->new_parent_id" . "\nNew Level:     $data->new_level" . "\n";
+			echo "\nRepositioning Data for $position\n-----------------------------------\nLeft Where:    $data->left_where"
+				. "\nRight Where:   $data->right_where\nNew Lft:       $data->new_lft\nNew Rgt:       $data->new_rgt"
+				. "\nNew Parent ID: $data->new_parent_id\nNew Level:     $data->new_level\n";
 		}
 
 		return $data;


### PR DESCRIPTION
This fixes a few exclusions from the joomla/cms-coding-standards. This should only be a codereview.