### PR TITLE
#26664 - Onhover text is not completed for workflows menu

### DIFF
--- a/administrator/components/com_workflow/tmpl/workflows/default.php
+++ b/administrator/components/com_workflow/tmpl/workflows/default.php
@@ -132,9 +132,7 @@ $userId = $user->id;
 									<?php endif; ?>
 								</td>
 								<td class="text-center">
-									<div class="btn-group">
-										<?php echo HTMLHelper::_('jgrid.published', $item->published, $i, 'workflows.', $canChange && !$isCore); ?>
-									</div>
+									<?php echo HTMLHelper::_('jgrid.published', $item->published, $i, 'workflows.', $canChange && !$isCore); ?>
 								</td>
 								<th scope="row">
 									<?php if (!$isCore && ($canEdit || $canEditOwn)) : ?>


### PR DESCRIPTION
Pull Request for Issue # .
[#26664] - Onhover text is not completed for workflows menu

### Expected result
Onhover text should be displayed completely


### Actual result
Onhover text should be displayed partially


### Documentation Changes Required

