### PR TITLE
[4.0] Fixed lost request parameters on save

### DIFF
--- a/administrator/components/com_menus/Controller/ItemController.php
+++ b/administrator/components/com_menus/Controller/ItemController.php
@@ -401,7 +401,6 @@ class ItemController extends FormController
 			}
 
 			$data['link'] = 'index.php?' . urldecode(http_build_query($args, '', '&'));
-			unset($data['request']);
 		}
 
 		// Check for validation errors.


### PR DESCRIPTION
Pull Request for Issue #26657.

### Summary of Changes
On menu save, reloading form request values missing on error.
Screenshot, see issue #26657

### Testing Instructions
See issue #26657

### Expected result
See issue #26657

### Actual result
See issue #26657

### Documentation Changes Required
Nope
