### PR TITLE
Issue #26662: Admin section modal buttons do not have had any visual effects on hover. Added CSS to highlight the hovering.

### DIFF
--- a/administrator/components/com_menus/tmpl/menus/default.php
+++ b/administrator/components/com_menus/tmpl/menus/default.php
@@ -178,10 +178,10 @@ HTMLHelper::_('script', 'com_menus/admin-menus-default.min.js', ['version' => 'a
 															'width'       => '800px',
 															'bodyHeight'  => 70,
 															'modalWidth'  => 80,
-															'footer'      => '<button type="button" class="btn btn-secondary" data-dismiss="modal"'
+															'footer'      => '<button type="button" class="btn btn-danger" data-dismiss="modal"'
 																	. ' onclick="Joomla.iframeButtonClick({iframeSelector: \'#moduleEdit' . $module->id . 'Modal\', buttonSelector: \'#closeBtn\'})">'
 																	. Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>'
-																	. '<button type="button" class="btn btn-primary"'
+																	. '<button type="button" class="btn btn-success"'
 																	. ' onclick="Joomla.iframeButtonClick({iframeSelector: \'#moduleEdit' . $module->id . 'Modal\', buttonSelector: \'#saveBtn\'})">'
 																	. Text::_('JSAVE') . '</button>'
 																	. '<button type="button" class="btn btn-success"'

--- a/administrator/templates/atum/scss/blocks/_modals.scss
+++ b/administrator/templates/atum/scss/blocks/_modals.scss
@@ -26,11 +26,30 @@
 
   }
 
+  .btn-primary:not([href])
+  {
+    &:hover {
+      color: var(--white);
+      background:var(--primary);
+      border-color: var(--primary);
+    }
+  }
+
+  .btn-secondary:not([href])
+  {
+    &:hover {
+      color: var(--white);
+      background:var(--secondary);
+      border-color: var(--secondary);
+    }
+  }
+
   .btn-success:not([href])
   {
     &:hover {
       color: var(--white);
       background:var(--success);
+      border-color: var(--success);
     }
   }
 
@@ -39,6 +58,7 @@
     &:hover {
       color: var(--white);
       background:var(--danger);
+      border-color: var(--danger);
     }
   }
 


### PR DESCRIPTION
Pull Request for Issue #26662

### Summary of Changes

Admin section modal buttons do not have had any visual effects on hover. Added CSS to highlight the hovering.

### Testing Instructions

- Go to manage menu
- Click on edit module
- Hover on the Cancel, Save & close option


### Expected result

On the button hovering, it should highlight based on its type. Close should be red, save buttons should be green.

### Actual result

On the button hovering, colors are not changing.

### Documentation Changes Required

No