### PR TITLE
Issue#26679 fix: Created tags are not available in article, category

### DIFF
--- a/layouts/joomla/form/field/tag.php
+++ b/layouts/joomla/form/field/tag.php
@@ -54,6 +54,9 @@ extract($displayData);
 $html = array();
 $attr = '';
 
+// To get published tags
+$options = HTMLHelper::_('tag.tags', array('filter.published' => array(1)));
+
 // Initialize some field attributes.
 $attr .= $multiple ? ' multiple' : '';
 $attr .= $autofocus ? ' autofocus' : '';


### PR DESCRIPTION
Pull Request for Issue #23589, #26679.
Create one or more tags in the Tags component.
Go to the Content component
Edit an article.
Select tags

### Expected result
Get a tag list when clicking into the article Tags field.

### Actual result
Get a "No results match" message.


### Documentation Changes Required
NA
