### PR TITLE
Issue #26619 fix: Cassiopeia site sidebar - responsiveness is broken

### DIFF
--- a/templates/cassiopeia/scss/blocks/_css-grid.scss
+++ b/templates/cassiopeia/scss/blocks/_css-grid.scss
@@ -48,7 +48,21 @@
       grid-column: full-start / full-end;
     }
 
-    @include media-breakpoint-up(xs) {
+     grid-template-areas:
+       ". head head head head ."
+       ". banner banner banner banner ."
+       ". top-a top-a top-a top-a ."
+       ". top-b top-b top-b top-b ."
+       ". comp comp comp comp ."
+       ". side-r side-r side-r side-r ."
+       ". side-l side-l side-l side-l ."
+       ". bot-a bot-a bot-a bot-a ."
+       ". bot-b bot-b bot-b bot-b ."
+       ". footer footer footer footer ."
+       ". debug debug debug debug .";
+    }
+
+    @include media-breakpoint-up(md) {
       grid-template-areas:
         ". head head head head ."
         ". banner banner banner banner ."
@@ -82,7 +96,7 @@
 
       > .grid-child {
         padding-right: ($cassiopeia-grid-gutter * 2);
-        padding-left: ($cassiopeia-grid-gutter * 2);     
+        padding-left: ($cassiopeia-grid-gutter * 2);
       }
 
       .container-main {

--- a/templates/cassiopeia/scss/blocks/_css-grid.scss
+++ b/templates/cassiopeia/scss/blocks/_css-grid.scss
@@ -60,7 +60,6 @@
        ". bot-b bot-b bot-b bot-b ."
        ". footer footer footer footer ."
        ". debug debug debug debug .";
-    }
 
     @include media-breakpoint-up(md) {
       grid-template-areas:


### PR DESCRIPTION
Pull Request for Issue #26619.

### Summary of Changes

CSS fixes for grid responsiveness.

### Testing Instructions

Open Homepage on small screen or on mobile device.


### Expected result

Sidebar should go below main content in mobile screens. In desktop screens it should stay in sides.

### Actual result

In Mobile screens sidebar stays in side due to which it looks bad.

### Documentation Changes Required

No.