### PR TITLE
[4.0] [com_messages] Message recipient field broken

### DIFF
--- a/administrator/components/com_messages/forms/message.xml
+++ b/administrator/components/com_messages/forms/message.xml
@@ -3,7 +3,7 @@
 	<fieldset>
 		<field
 			name="user_id_to"
-			type="usermessages"
+			type="UserMessages"
 			label="COM_MESSAGES_FIELD_USER_ID_TO_LABEL"
 			default="0"
 			required="true"


### PR DESCRIPTION
Pull Request for Issue #26677.

### Summary of Changes

Corrects field type casing.

### Testing Instructions

Only reproducible on case-sensitive filesystem (e.g. Linux).
Create a new Private Message.
Inspect `Recipient` field.

### Expected result

Modal field appears.

### Actual result

Text field appears.

### Documentation Changes Required

No.