### PR TITLE
[4.0] Heading is missing on "Template Preview" Popup

### DIFF
--- a/administrator/components/com_templates/View/Template/HtmlView.php
+++ b/administrator/components/com_templates/View/Template/HtmlView.php
@@ -14,8 +14,10 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Filter\InputFilter;
+use Joomla\CMS\Form\Form;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
+use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
@@ -31,7 +33,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The Model state
 	 *
-	 * @var  \JObject
+	 * @var  CMSObject
 	 */
 	protected $state;
 
@@ -45,7 +47,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * For loading the source form
 	 *
-	 * @var  \JForm
+	 * @var  Form
 	 */
 	protected $form;
 
@@ -261,7 +263,12 @@ class HtmlView extends BaseHtmlView
 		// Add a Template preview button
 		if ($this->preview->client_id == 0)
 		{
-			$bar->appendButton('Popup', 'picture', 'COM_TEMPLATES_BUTTON_PREVIEW', Uri::root() . 'index.php?tp=1&templateStyle=' . $this->preview->id, 800, 520);
+			$bar->popupButton('preview')
+				->icon('icon-picture')
+				->text('COM_TEMPLATES_BUTTON_PREVIEW')
+				->url(Uri::root() . 'index.php?tp=1&templateStyle=' . $this->preview->id)
+				->iframeWidth(800)
+				->iframeHeight(520);
 		}
 
 		// Only show file manage buttons for global SuperUser


### PR DESCRIPTION
Pull Request for Issue #26691 .

### Summary of Changes
Uses new style syntax for the template preview button which correctly sets the title in the the popup modal


### Testing Instructions
Open the template preview modal. Before the patch there is a missing title (see image in the original issue). After patch the title now shows and the close button is correctly spaced

### Documentation Changes Required
None
