### PR TITLE
[4.0] Increase API Test Coverage

### DIFF
--- a/administrator/components/com_contact/src/Model/ContactModel.php
+++ b/administrator/components/com_contact/src/Model/ContactModel.php
@@ -130,7 +130,8 @@ class ContactModel extends AdminModel
 	 */
 	protected function canDelete($record)
 	{
-		if (empty($record->id) || $record->published != -2)
+		// We ignore the requirement for an item to be trashed when calling delete from the API
+		if (empty($record->id) || ($record->published != -2 && !Factory::getApplication()->isClient('api')))
 		{
 			return false;
 		}

--- a/administrator/components/com_contact/src/Model/ContactModel.php
+++ b/administrator/components/com_contact/src/Model/ContactModel.php
@@ -130,7 +130,6 @@ class ContactModel extends AdminModel
 	 */
 	protected function canDelete($record)
 	{
-		// We ignore the requirement for an item to be trashed when calling delete from the API
 		if (empty($record->id) || $record->published != -2)
 		{
 			return false;

--- a/administrator/components/com_contact/src/Model/ContactModel.php
+++ b/administrator/components/com_contact/src/Model/ContactModel.php
@@ -131,7 +131,7 @@ class ContactModel extends AdminModel
 	protected function canDelete($record)
 	{
 		// We ignore the requirement for an item to be trashed when calling delete from the API
-		if (empty($record->id) || ($record->published != -2 && !Factory::getApplication()->isClient('api')))
+		if (empty($record->id) || $record->published != -2)
 		{
 			return false;
 		}

--- a/api/components/com_categories/src/Controller/CategoriesController.php
+++ b/api/components/com_categories/src/Controller/CategoriesController.php
@@ -47,7 +47,12 @@ class CategoriesController extends ApiController
 	 */
 	protected function preprocessSaveData(array $data): array
 	{
-		$data['extension'] = $this->getExtensionFromInput();
+		$extension = $this->getExtensionFromInput();
+		$data['extension'] = $extension;
+
+		// TODO: This is a hack to drop the extension into the global input object - to satisfy how state is built
+		//       we should be able to improve this in the future
+		$this->input->set('extension', $extension);
 
 		return $data;
 	}

--- a/tests/Codeception/api/com_banners/BannerCest.php
+++ b/tests/Codeception/api/com_banners/BannerCest.php
@@ -132,6 +132,7 @@ class BannerCest
 
 		$I->seeResponseCodeIs(HttpCode::OK);
 		$categoryId = $I->grabDataFromResponseByJsonPath('$.data[0].id');
+		var_dump($categoryId);die;
 
 		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');

--- a/tests/Codeception/api/com_banners/BannerCest.php
+++ b/tests/Codeception/api/com_banners/BannerCest.php
@@ -132,6 +132,7 @@ class BannerCest
 
 		$I->seeResponseCodeIs(HttpCode::OK);
 		$categoryId = $I->grabDataFromResponseByJsonPath('$.data.id');
+var_dump($categoryId);die;
 
 		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');

--- a/tests/Codeception/api/com_banners/BannerCest.php
+++ b/tests/Codeception/api/com_banners/BannerCest.php
@@ -135,7 +135,7 @@ class BannerCest
 
 		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
-		$I->sendGET('/banners/categories/' + $categoryId);
+		$I->sendGET('/banners/categories/' . $categoryId);
 		$I->seeResponseCodeIs(HttpCode::OK);
 
 		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');
@@ -143,12 +143,12 @@ class BannerCest
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
 
 		// Unpublish in order to allow the delete in the next step
-		$I->sendPATCH('/banners/categories/' + $categoryId, ['title' => 'Another Title', 'published' => -2]);
+		$I->sendPATCH('/banners/categories/' . $categoryId, ['title' => 'Another Title', 'published' => -2]);
 		$I->seeResponseCodeIs(HttpCode::OK);
 
 		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
-		$I->sendDELETE('/banners/categories/' + $categoryId);
+		$I->sendDELETE('/banners/categories/' . $categoryId);
 		$I->seeResponseCodeIs(HttpCode::NO_CONTENT);
 	}
 }

--- a/tests/Codeception/api/com_banners/BannerCest.php
+++ b/tests/Codeception/api/com_banners/BannerCest.php
@@ -131,10 +131,11 @@ class BannerCest
 		$I->sendPOST('/banners/categories', $testarticle);
 
 		$I->seeResponseCodeIs(HttpCode::OK);
+		$categoryId = $I->grabDataFromResponseByJsonPath('$.data[0].id');
 
 		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
-		$I->sendGET('/banners/categories/8');
+		$I->sendGET('/banners/categories/' + $categoryId);
 		$I->seeResponseCodeIs(HttpCode::OK);
 
 		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');
@@ -142,12 +143,12 @@ class BannerCest
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
 
 		// Unpublish in order to allow the delete in the next step
-		$I->sendPATCH('/banners/categories/8', ['title' => 'Another Title', 'published' => -2]);
+		$I->sendPATCH('/banners/categories/' + $categoryId, ['title' => 'Another Title', 'published' => -2]);
 		$I->seeResponseCodeIs(HttpCode::OK);
 
 		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
-		$I->sendDELETE('/banners/categories/8');
+		$I->sendDELETE('/banners/categories/' + $categoryId);
 		$I->seeResponseCodeIs(HttpCode::NO_CONTENT);
 	}
 }

--- a/tests/Codeception/api/com_banners/BannerCest.php
+++ b/tests/Codeception/api/com_banners/BannerCest.php
@@ -95,7 +95,9 @@ class BannerCest
 		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');
 		$I->haveHttpHeader('Content-Type', 'application/json');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
-		$I->sendPATCH('/banners/1', ['name' => 'Different Custom Advert', 'state' => -2]);
+
+		// Category is a required field for this patch request for now TODO: Remove this dependency
+		$I->sendPATCH('/banners/1', ['name' => 'Different Custom Advert', 'state' => -2, 'catid' => 3]);
 		$I->seeResponseCodeIs(HttpCode::OK);
 
 		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');

--- a/tests/Codeception/api/com_banners/BannerCest.php
+++ b/tests/Codeception/api/com_banners/BannerCest.php
@@ -131,8 +131,7 @@ class BannerCest
 		$I->sendPOST('/banners/categories', $testarticle);
 
 		$I->seeResponseCodeIs(HttpCode::OK);
-		$categoryId = $I->grabDataFromResponseByJsonPath('$.data[0].id');
-		var_dump($categoryId);die;
+		$categoryId = $I->grabDataFromResponseByJsonPath('$.data.id');
 
 		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');

--- a/tests/Codeception/api/com_banners/BannerCest.php
+++ b/tests/Codeception/api/com_banners/BannerCest.php
@@ -140,7 +140,9 @@ class BannerCest
 		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');
 		$I->haveHttpHeader('Content-Type', 'application/json');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
-		$I->sendPATCH('/banners/categories/8', ['title' => 'Another Title']);
+
+		// Unpublish in order to allow the delete in the next step
+		$I->sendPATCH('/banners/categories/8', ['title' => 'Another Title', 'published' => -2]);
 		$I->seeResponseCodeIs(HttpCode::OK);
 
 		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');

--- a/tests/Codeception/api/com_banners/BannerCest.php
+++ b/tests/Codeception/api/com_banners/BannerCest.php
@@ -29,6 +29,14 @@ class BannerCest
 	 */
 	public function _before(ApiTester $I)
 	{
+		// TODO: Improve this to retrieve a specific ID to replace with a known ID
+		$desiredUserId = 3;
+		$I->updateInDatabase('users', ['id' => 3], []);
+		$I->updateInDatabase('user_usergroup_map', ['user_id' => 3], []);
+		$enabledData = ['user_id' => $desiredUserId, 'profile_key' => 'joomlatoken.enabled', 'profile_value' => 1];
+		$tokenData = ['user_id' => $desiredUserId, 'profile_key' => 'joomlatoken.token', 'profile_value' => 'dOi2m1NRrnBHlhaWK/WWxh3B5tqq1INbdf4DhUmYTI4='];
+		$I->haveInDatabase('user_profiles', $enabledData);
+		$I->haveInDatabase('user_profiles', $tokenData);
 	}
 
 	/**
@@ -57,7 +65,7 @@ class BannerCest
 	 */
 	public function testCrudOnBanner(ApiTester $I)
 	{
-		$I->amHttpAuthenticated('admin', 'admin');
+		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');
 		$I->haveHttpHeader('Content-Type', 'application/json');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
 
@@ -79,18 +87,18 @@ class BannerCest
 
 		$I->seeResponseCodeIs(HttpCode::OK);
 
-		$I->amHttpAuthenticated('admin', 'admin');
+		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
 		$I->sendGET('/banners/1');
 		$I->seeResponseCodeIs(HttpCode::OK);
 
-		$I->amHttpAuthenticated('admin', 'admin');
+		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');
 		$I->haveHttpHeader('Content-Type', 'application/json');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
 		$I->sendPATCH('/banners/1', ['name' => 'Different Custom Advert', 'state' => -2]);
 		$I->seeResponseCodeIs(HttpCode::OK);
 
-		$I->amHttpAuthenticated('admin', 'admin');
+		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
 		$I->sendDELETE('/banners/1');
 		$I->seeResponseCodeIs(HttpCode::NO_CONTENT);
@@ -109,7 +117,7 @@ class BannerCest
 	 */
 	public function testCrudOnCategory(ApiTester $I)
 	{
-		$I->amHttpAuthenticated('admin', 'admin');
+		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');
 		$I->haveHttpHeader('Content-Type', 'application/json');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
 
@@ -122,18 +130,18 @@ class BannerCest
 
 		$I->seeResponseCodeIs(HttpCode::OK);
 
-		$I->amHttpAuthenticated('admin', 'admin');
+		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
 		$I->sendGET('/banners/categories/8');
 		$I->seeResponseCodeIs(HttpCode::OK);
 
-		$I->amHttpAuthenticated('admin', 'admin');
+		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');
 		$I->haveHttpHeader('Content-Type', 'application/json');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
 		$I->sendPATCH('/banners/categories/8', ['title' => 'Another Title']);
 		$I->seeResponseCodeIs(HttpCode::OK);
 
-		$I->amHttpAuthenticated('admin', 'admin');
+		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
 		$I->sendDELETE('/banners/categories/8');
 		$I->seeResponseCodeIs(HttpCode::NO_CONTENT);

--- a/tests/Codeception/api/com_banners/BannerCest.php
+++ b/tests/Codeception/api/com_banners/BannerCest.php
@@ -10,13 +10,13 @@
 use Codeception\Util\HttpCode;
 
 /**
- * Class ContactCest.
+ * Class BannerCest.
  *
- * Basic com_contact (contact) tests.
+ * Basic com_banners (banner) tests.
  *
  * @since   4.0.0
  */
-class ContactCest
+class BannerCest
 {
 	/**
 	 * Api test before running.
@@ -45,7 +45,7 @@ class ContactCest
 	}
 
 	/**
-	 * Test the crud endpoints of com_contact from the API.
+	 * Test the crud endpoints of com_banners from the API.
 	 *
 	 * @param   mixed   ApiTester  $I  Api tester
 	 *
@@ -53,44 +53,51 @@ class ContactCest
 	 *
 	 * @since   4.0.0
 	 *
-	 * @TODO: Make these separate tests but requires sample data being installed so there are existing contacts
+	 * @TODO: Make these separate tests but requires sample data being installed so there are existing banners
 	 */
-	public function testCrudOnContact(ApiTester $I)
+	public function testCrudOnBanner(ApiTester $I)
 	{
 		$I->amHttpAuthenticated('admin', 'admin');
 		$I->haveHttpHeader('Content-Type', 'application/json');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
 
-		$testarticle = [
-			'alias' => 'contact-the-ceo',
-			'catid' => 4,
-			'language' => '*',
-			'name' => 'Francine Blogs'
+		$testBanner = [
+			'name' => 'My Custom Advert',
+			'catid' => 3,
+			'description' => '',
+			'custombannercode' => '',
+			'metakey' => '',
+			'params' => [
+				'imageurl' => '',
+				'width' => '',
+				'height' => '',
+				'alt' => ''
+			],
 		];
 
-		$I->sendPOST('/contact', $testarticle);
+		$I->sendPOST('/banners', $testBanner);
 
 		$I->seeResponseCodeIs(HttpCode::OK);
 
 		$I->amHttpAuthenticated('admin', 'admin');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
-		$I->sendGET('/contact/1');
+		$I->sendGET('/banners/1');
 		$I->seeResponseCodeIs(HttpCode::OK);
 
 		$I->amHttpAuthenticated('admin', 'admin');
 		$I->haveHttpHeader('Content-Type', 'application/json');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
-		$I->sendPATCH('/contact/1', ['name' => 'Frankie Blogs', 'state' => -2]);
+		$I->sendPATCH('/banners/1', ['name' => 'Different Custom Advert', 'state' => -2]);
 		$I->seeResponseCodeIs(HttpCode::OK);
 
 		$I->amHttpAuthenticated('admin', 'admin');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
-		$I->sendDELETE('/contact/1');
+		$I->sendDELETE('/banners/1');
 		$I->seeResponseCodeIs(HttpCode::NO_CONTENT);
 	}
 
 	/**
-	 * Test the category crud endpoints of com_contact from the API.
+	 * Test the category crud endpoints of com_banners from the API.
 	 *
 	 * @param   mixed   ApiTester  $I  Api tester
 	 *
@@ -106,32 +113,29 @@ class ContactCest
 		$I->haveHttpHeader('Content-Type', 'application/json');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
 
-		$testContact = [
+		$testarticle = [
 			'title' => 'A test category',
-			'parent_id' => 4,
-			'params' => [
-				'workflow_id' => 'inherit'
-			]
+			'parent_id' => 3
 		];
 
-		$I->sendPOST('/contact/categories', $testContact);
+		$I->sendPOST('/banners/categories', $testarticle);
 
 		$I->seeResponseCodeIs(HttpCode::OK);
 
 		$I->amHttpAuthenticated('admin', 'admin');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
-		$I->sendGET('/contact/categories/8');
+		$I->sendGET('/banners/categories/8');
 		$I->seeResponseCodeIs(HttpCode::OK);
 
 		$I->amHttpAuthenticated('admin', 'admin');
 		$I->haveHttpHeader('Content-Type', 'application/json');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
-		$I->sendPATCH('/contact/categories/8', ['title' => 'Another Title']);
+		$I->sendPATCH('/banners/categories/8', ['title' => 'Another Title']);
 		$I->seeResponseCodeIs(HttpCode::OK);
 
 		$I->amHttpAuthenticated('admin', 'admin');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
-		$I->sendDELETE('/contact/categories/8');
+		$I->sendDELETE('/banners/categories/8');
 		$I->seeResponseCodeIs(HttpCode::NO_CONTENT);
 	}
 }

--- a/tests/Codeception/api/com_banners/BannerCest.php
+++ b/tests/Codeception/api/com_banners/BannerCest.php
@@ -131,8 +131,7 @@ class BannerCest
 		$I->sendPOST('/banners/categories', $testarticle);
 
 		$I->seeResponseCodeIs(HttpCode::OK);
-		$categoryId = $I->grabDataFromResponseByJsonPath('$.data.id');
-var_dump($categoryId);die;
+		$categoryId = $I->grabDataFromResponseByJsonPath('$.data.id')[0];
 
 		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');

--- a/tests/Codeception/api/com_contact/ContactCest.php
+++ b/tests/Codeception/api/com_contact/ContactCest.php
@@ -127,7 +127,7 @@ class ContactCest
 		$I->sendPOST('/contact/categories', $testContact);
 
 		$I->seeResponseCodeIs(HttpCode::OK);
-		$categoryId = $I->grabDataFromResponseByJsonPath('$.data.id');
+		$categoryId = $I->grabDataFromResponseByJsonPath('$.data.id')[0];
 
 		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');

--- a/tests/Codeception/api/com_contact/ContactCest.php
+++ b/tests/Codeception/api/com_contact/ContactCest.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * @package     Joomla.Tests
+ * @subpackage  Api.tests
+ *
+ * @copyright   Copyright (C) 2005 - 2019 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+use Codeception\Util\HttpCode;
+
+/**
+ * Class ContactCest.
+ *
+ * Basic com_contact (contact) tests.
+ *
+ * @since   4.0.0
+ */
+class ContactCest
+{
+	/**
+	 * Api test before running.
+	 *
+	 * @param   mixed   ApiTester  $I  Api tester
+	 *
+	 * @return void
+	 *
+	 * @since   4.0.0
+	 */
+	public function _before(ApiTester $I)
+	{
+	}
+
+	/**
+	 * Api test after running.
+	 *
+	 * @param   mixed   ApiTester  $I  Api tester
+	 *
+	 * @return void
+	 *
+	 * @since   4.0.0
+	 */
+	public function _after(ApiTester $I)
+	{
+	}
+
+	/**
+	 * Test the crud endpoints of com_contact from the API.
+	 *
+	 * @param   mixed   ApiTester  $I  Api tester
+	 *
+	 * @return void
+	 *
+	 * @since   4.0.0
+	 *
+	 * @TODO: Make these separate tests but requires sample data being installed so there are existing contacts
+	 */
+	public function testCrudOnArticle(ApiTester $I)
+	{
+		$I->amHttpAuthenticated('admin', 'admin');
+		$I->haveHttpHeader('Content-Type', 'application/json');
+		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
+
+		$testarticle = [
+			'alias' => 'contact-the-ceo',
+			'catid' => 4,
+			'language' => '*',
+			'name' => 'Francine Blogs'
+		];
+
+		$I->sendPOST('/contact', $testarticle);
+
+		$I->seeResponseCodeIs(HttpCode::OK);
+
+		$I->amHttpAuthenticated('admin', 'admin');
+		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
+		$I->sendGET('/contact/1');
+		$I->seeResponseCodeIs(HttpCode::OK);
+
+		$I->amHttpAuthenticated('admin', 'admin');
+		$I->haveHttpHeader('Content-Type', 'application/json');
+		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
+		$I->sendGET('/contact/1', ['name' => 'Frankie Blogs']);
+		$I->seeResponseCodeIs(HttpCode::OK);
+
+		$I->amHttpAuthenticated('admin', 'admin');
+		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
+		$I->sendDELETE('/contact/1');
+		$I->seeResponseCodeIs(HttpCode::NO_CONTENT);
+	}
+}

--- a/tests/Codeception/api/com_contact/ContactCest.php
+++ b/tests/Codeception/api/com_contact/ContactCest.php
@@ -131,18 +131,18 @@ class ContactCest
 
 		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
-		$I->sendGET('/contact/categories/' + $categoryId);
+		$I->sendGET('/contact/categories/' . $categoryId);
 		$I->seeResponseCodeIs(HttpCode::OK);
 
 		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');
 		$I->haveHttpHeader('Content-Type', 'application/json');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
-		$I->sendPATCH('/contact/categories/' + $categoryId, ['title' => 'Another Title', 'published' => -2]);
+		$I->sendPATCH('/contact/categories/' . $categoryId, ['title' => 'Another Title', 'published' => -2]);
 		$I->seeResponseCodeIs(HttpCode::OK);
 
 		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
-		$I->sendDELETE('/contact/categories/' + $categoryId);
+		$I->sendDELETE('/contact/categories/' . $categoryId);
 		$I->seeResponseCodeIs(HttpCode::NO_CONTENT);
 	}
 }

--- a/tests/Codeception/api/com_contact/ContactCest.php
+++ b/tests/Codeception/api/com_contact/ContactCest.php
@@ -134,7 +134,7 @@ class ContactCest
 		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');
 		$I->haveHttpHeader('Content-Type', 'application/json');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
-		$I->sendPATCH('/contact/categories/8', ['title' => 'Another Title']);
+		$I->sendPATCH('/contact/categories/8', ['title' => 'Another Title', 'published' => -2]);
 		$I->seeResponseCodeIs(HttpCode::OK);
 
 		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');

--- a/tests/Codeception/api/com_contact/ContactCest.php
+++ b/tests/Codeception/api/com_contact/ContactCest.php
@@ -127,21 +127,22 @@ class ContactCest
 		$I->sendPOST('/contact/categories', $testContact);
 
 		$I->seeResponseCodeIs(HttpCode::OK);
+		$categoryId = $I->grabDataFromResponseByJsonPath('$.data[0].id');
 
 		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
-		$I->sendGET('/contact/categories/8');
+		$I->sendGET('/contact/categories/' + $categoryId);
 		$I->seeResponseCodeIs(HttpCode::OK);
 
 		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');
 		$I->haveHttpHeader('Content-Type', 'application/json');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
-		$I->sendPATCH('/contact/categories/8', ['title' => 'Another Title', 'published' => -2]);
+		$I->sendPATCH('/contact/categories/' + $categoryId, ['title' => 'Another Title', 'published' => -2]);
 		$I->seeResponseCodeIs(HttpCode::OK);
 
 		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
-		$I->sendDELETE('/contact/categories/8');
+		$I->sendDELETE('/contact/categories/' + $categoryId);
 		$I->seeResponseCodeIs(HttpCode::NO_CONTENT);
 	}
 }

--- a/tests/Codeception/api/com_contact/ContactCest.php
+++ b/tests/Codeception/api/com_contact/ContactCest.php
@@ -90,7 +90,7 @@ class ContactCest
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
 
 		// Category is a required field for this patch request for now TODO: Remove this dependency
-		$I->sendPATCH('/contact/1', ['name' => 'Frankie Blogs', 'catid' => 4, 'state' => -2]);
+		$I->sendPATCH('/contact/1', ['name' => 'Frankie Blogs', 'catid' => 4, 'published' => -2]);
 		$I->seeResponseCodeIs(HttpCode::OK);
 
 		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');

--- a/tests/Codeception/api/com_contact/ContactCest.php
+++ b/tests/Codeception/api/com_contact/ContactCest.php
@@ -127,7 +127,7 @@ class ContactCest
 		$I->sendPOST('/contact/categories', $testContact);
 
 		$I->seeResponseCodeIs(HttpCode::OK);
-		$categoryId = $I->grabDataFromResponseByJsonPath('$.data[0].id');
+		$categoryId = $I->grabDataFromResponseByJsonPath('$.data.id');
 
 		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');

--- a/tests/Codeception/api/com_contact/ContactCest.php
+++ b/tests/Codeception/api/com_contact/ContactCest.php
@@ -29,6 +29,14 @@ class ContactCest
 	 */
 	public function _before(ApiTester $I)
 	{
+		// TODO: Improve this to retrieve a specific ID to replace with a known ID
+		$desiredUserId = 3;
+		$I->updateInDatabase('users', ['id' => 3], []);
+		$I->updateInDatabase('user_usergroup_map', ['user_id' => 3], []);
+		$enabledData = ['user_id' => $desiredUserId, 'profile_key' => 'joomlatoken.enabled', 'profile_value' => 1];
+		$tokenData = ['user_id' => $desiredUserId, 'profile_key' => 'joomlatoken.token', 'profile_value' => 'dOi2m1NRrnBHlhaWK/WWxh3B5tqq1INbdf4DhUmYTI4='];
+		$I->haveInDatabase('user_profiles', $enabledData);
+		$I->haveInDatabase('user_profiles', $tokenData);
 	}
 
 	/**
@@ -57,7 +65,7 @@ class ContactCest
 	 */
 	public function testCrudOnContact(ApiTester $I)
 	{
-		$I->amHttpAuthenticated('admin', 'admin');
+		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');
 		$I->haveHttpHeader('Content-Type', 'application/json');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
 
@@ -72,18 +80,18 @@ class ContactCest
 
 		$I->seeResponseCodeIs(HttpCode::OK);
 
-		$I->amHttpAuthenticated('admin', 'admin');
+		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
 		$I->sendGET('/contact/1');
 		$I->seeResponseCodeIs(HttpCode::OK);
 
-		$I->amHttpAuthenticated('admin', 'admin');
+		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');
 		$I->haveHttpHeader('Content-Type', 'application/json');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
 		$I->sendPATCH('/contact/1', ['name' => 'Frankie Blogs', 'state' => -2]);
 		$I->seeResponseCodeIs(HttpCode::OK);
 
-		$I->amHttpAuthenticated('admin', 'admin');
+		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
 		$I->sendDELETE('/contact/1');
 		$I->seeResponseCodeIs(HttpCode::NO_CONTENT);
@@ -102,7 +110,7 @@ class ContactCest
 	 */
 	public function testCrudOnCategory(ApiTester $I)
 	{
-		$I->amHttpAuthenticated('admin', 'admin');
+		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');
 		$I->haveHttpHeader('Content-Type', 'application/json');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
 
@@ -118,18 +126,18 @@ class ContactCest
 
 		$I->seeResponseCodeIs(HttpCode::OK);
 
-		$I->amHttpAuthenticated('admin', 'admin');
+		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
 		$I->sendGET('/contact/categories/8');
 		$I->seeResponseCodeIs(HttpCode::OK);
 
-		$I->amHttpAuthenticated('admin', 'admin');
+		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');
 		$I->haveHttpHeader('Content-Type', 'application/json');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
 		$I->sendPATCH('/contact/categories/8', ['title' => 'Another Title']);
 		$I->seeResponseCodeIs(HttpCode::OK);
 
-		$I->amHttpAuthenticated('admin', 'admin');
+		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
 		$I->sendDELETE('/contact/categories/8');
 		$I->seeResponseCodeIs(HttpCode::NO_CONTENT);

--- a/tests/Codeception/api/com_contact/ContactCest.php
+++ b/tests/Codeception/api/com_contact/ContactCest.php
@@ -80,7 +80,7 @@ class ContactCest
 		$I->amHttpAuthenticated('admin', 'admin');
 		$I->haveHttpHeader('Content-Type', 'application/json');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
-		$I->sendGET('/contact/1', ['name' => 'Frankie Blogs']);
+		$I->sendPATCH('/contact/1', ['name' => 'Frankie Blogs', 'state' => -2]);
 		$I->seeResponseCodeIs(HttpCode::OK);
 
 		$I->amHttpAuthenticated('admin', 'admin');

--- a/tests/Codeception/api/com_contact/ContactCest.php
+++ b/tests/Codeception/api/com_contact/ContactCest.php
@@ -88,7 +88,9 @@ class ContactCest
 		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');
 		$I->haveHttpHeader('Content-Type', 'application/json');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
-		$I->sendPATCH('/contact/1', ['name' => 'Frankie Blogs', 'state' => -2]);
+
+		// Category is a required field for this patch request for now TODO: Remove this dependency
+		$I->sendPATCH('/contact/1', ['name' => 'Frankie Blogs', 'catid' => 4, 'state' => -2]);
 		$I->seeResponseCodeIs(HttpCode::OK);
 
 		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');

--- a/tests/Codeception/api/com_content/ContentCest.php
+++ b/tests/Codeception/api/com_content/ContentCest.php
@@ -53,7 +53,7 @@ class ContentCest
 	}
 
 	/**
-	 * Test the crud endpoints of com_content from the API.
+	 * Test the article crud endpoints of com_content from the API.
 	 *
 	 * @param   mixed   ApiTester  $I  Api tester
 	 *
@@ -99,7 +99,7 @@ class ContentCest
 	}
 
 	/**
-	 * Test the crud endpoints of com_content from the API.
+	 * Test the category crud endpoints of com_content from the API.
 	 *
 	 * @param   mixed   ApiTester  $I  Api tester
 	 *
@@ -116,13 +116,31 @@ class ContentCest
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
 
 		$testarticle = [
-			'title' => 'Just for you',
-			'catid' => 2,
-			'articletext' => 'A dummy article to save to the database',
-			'language' => '*',
-			'alias' => 'tobias'
+			'title' => 'A test category',
+			'parent_id' => 2,
+			'params' => [
+				'workflow_id' => 'inherit'
+			]
 		];
 
-		$I->sendPOST('/content/article', $testarticle);
+		$I->sendPOST('/content/categories', $testarticle);
+
+		$I->seeResponseCodeIs(HttpCode::OK);
+
+		$I->amHttpAuthenticated('admin', 'admin');
+		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
+		$I->sendGET('/content/categories/8');
+		$I->seeResponseCodeIs(HttpCode::OK);
+
+		$I->amHttpAuthenticated('admin', 'admin');
+		$I->haveHttpHeader('Content-Type', 'application/json');
+		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
+		$I->sendPATCH('/content/categories/8', ['title' => 'Another Title']);
+		$I->seeResponseCodeIs(HttpCode::OK);
+
+		$I->amHttpAuthenticated('admin', 'admin');
+		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
+		$I->sendDELETE('/content/categories/8');
+		$I->seeResponseCodeIs(HttpCode::NO_CONTENT);
 	}
 }

--- a/tests/Codeception/api/com_content/ContentCest.php
+++ b/tests/Codeception/api/com_content/ContentCest.php
@@ -137,7 +137,7 @@ class ContentCest
 		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');
 		$I->haveHttpHeader('Content-Type', 'application/json');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
-		$I->sendPATCH('/content/categories/' . $categoryId, ['title' => 'Another Title', 'params' => ['workflow_id' => 'inherit']]);
+		$I->sendPATCH('/content/categories/' . $categoryId, ['title' => 'Another Title', 'params' => ['workflow_id' => 'inherit'], 'published' => -2]);
 		$I->seeResponseCodeIs(HttpCode::OK);
 
 		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');

--- a/tests/Codeception/api/com_content/ContentCest.php
+++ b/tests/Codeception/api/com_content/ContentCest.php
@@ -130,18 +130,18 @@ class ContentCest
 
 		$I->amHttpAuthenticated('admin', 'admin');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
-		$I->sendGET('/content/categories/' + $categoryId);
+		$I->sendGET('/content/categories/' . $categoryId);
 		$I->seeResponseCodeIs(HttpCode::OK);
 
 		$I->amHttpAuthenticated('admin', 'admin');
 		$I->haveHttpHeader('Content-Type', 'application/json');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
-		$I->sendPATCH('/content/categories/' + $categoryId, ['title' => 'Another Title']);
+		$I->sendPATCH('/content/categories/' . $categoryId, ['title' => 'Another Title']);
 		$I->seeResponseCodeIs(HttpCode::OK);
 
 		$I->amHttpAuthenticated('admin', 'admin');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
-		$I->sendDELETE('/content/categories/' + $categoryId);
+		$I->sendDELETE('/content/categories/' . $categoryId);
 		$I->seeResponseCodeIs(HttpCode::NO_CONTENT);
 	}
 }

--- a/tests/Codeception/api/com_content/ContentCest.php
+++ b/tests/Codeception/api/com_content/ContentCest.php
@@ -137,7 +137,7 @@ class ContentCest
 		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');
 		$I->haveHttpHeader('Content-Type', 'application/json');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
-		$I->sendPATCH('/content/categories/' . $categoryId, ['title' => 'Another Title']);
+		$I->sendPATCH('/content/categories/' . $categoryId, ['title' => 'Another Title', 'params' => ['workflow_id' => 'inherit']]);
 		$I->seeResponseCodeIs(HttpCode::OK);
 
 		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');

--- a/tests/Codeception/api/com_content/ContentCest.php
+++ b/tests/Codeception/api/com_content/ContentCest.php
@@ -126,21 +126,22 @@ class ContentCest
 		$I->sendPOST('/content/categories', $testarticle);
 
 		$I->seeResponseCodeIs(HttpCode::OK);
+		$categoryId = $I->grabDataFromResponseByJsonPath('$.data[0].id');
 
 		$I->amHttpAuthenticated('admin', 'admin');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
-		$I->sendGET('/content/categories/8');
+		$I->sendGET('/content/categories/' + $categoryId);
 		$I->seeResponseCodeIs(HttpCode::OK);
 
 		$I->amHttpAuthenticated('admin', 'admin');
 		$I->haveHttpHeader('Content-Type', 'application/json');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
-		$I->sendPATCH('/content/categories/8', ['title' => 'Another Title']);
+		$I->sendPATCH('/content/categories/' + $categoryId, ['title' => 'Another Title']);
 		$I->seeResponseCodeIs(HttpCode::OK);
 
 		$I->amHttpAuthenticated('admin', 'admin');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
-		$I->sendDELETE('/content/categories/8');
+		$I->sendDELETE('/content/categories/' + $categoryId);
 		$I->seeResponseCodeIs(HttpCode::NO_CONTENT);
 	}
 }

--- a/tests/Codeception/api/com_content/ContentCest.php
+++ b/tests/Codeception/api/com_content/ContentCest.php
@@ -111,7 +111,8 @@ class ContentCest
 	 */
 	public function testCrudOnCategory(ApiTester $I)
 	{
-		$I->amHttpAuthenticated('admin', 'admin');
+
+		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');
 		$I->haveHttpHeader('Content-Type', 'application/json');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
 
@@ -128,18 +129,18 @@ class ContentCest
 		$I->seeResponseCodeIs(HttpCode::OK);
 		$categoryId = $I->grabDataFromResponseByJsonPath('$.data.id')[0];
 
-		$I->amHttpAuthenticated('admin', 'admin');
+		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
 		$I->sendGET('/content/categories/' . $categoryId);
 		$I->seeResponseCodeIs(HttpCode::OK);
 
-		$I->amHttpAuthenticated('admin', 'admin');
+		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');
 		$I->haveHttpHeader('Content-Type', 'application/json');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
 		$I->sendPATCH('/content/categories/' . $categoryId, ['title' => 'Another Title']);
 		$I->seeResponseCodeIs(HttpCode::OK);
 
-		$I->amHttpAuthenticated('admin', 'admin');
+		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
 		$I->sendDELETE('/content/categories/' . $categoryId);
 		$I->seeResponseCodeIs(HttpCode::NO_CONTENT);

--- a/tests/Codeception/api/com_content/ContentCest.php
+++ b/tests/Codeception/api/com_content/ContentCest.php
@@ -126,7 +126,7 @@ class ContentCest
 		$I->sendPOST('/content/categories', $testarticle);
 
 		$I->seeResponseCodeIs(HttpCode::OK);
-		$categoryId = $I->grabDataFromResponseByJsonPath('$.data.id');
+		$categoryId = $I->grabDataFromResponseByJsonPath('$.data.id')[0];
 
 		$I->amHttpAuthenticated('admin', 'admin');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');

--- a/tests/Codeception/api/com_content/ContentCest.php
+++ b/tests/Codeception/api/com_content/ContentCest.php
@@ -89,12 +89,40 @@ class ContentCest
 		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');
 		$I->haveHttpHeader('Content-Type', 'application/json');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
-		$I->sendGET('/content/article/1', ['title' => 'Another Title']);
+		$I->sendPATCH('/content/article/1', ['title' => 'Another Title']);
 		$I->seeResponseCodeIs(HttpCode::OK);
 
 		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
 		$I->sendDELETE('/content/article/1');
 		$I->seeResponseCodeIs(HttpCode::NO_CONTENT);
+	}
+
+	/**
+	 * Test the crud endpoints of com_content from the API.
+	 *
+	 * @param   mixed   ApiTester  $I  Api tester
+	 *
+	 * @return void
+	 *
+	 * @since   4.0.0
+	 *
+	 * @TODO: Make these separate tests but requires sample data being installed so there are existing categories
+	 */
+	public function testCrudOnCategory(ApiTester $I)
+	{
+		$I->amHttpAuthenticated('admin', 'admin');
+		$I->haveHttpHeader('Content-Type', 'application/json');
+		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
+
+		$testarticle = [
+			'title' => 'Just for you',
+			'catid' => 2,
+			'articletext' => 'A dummy article to save to the database',
+			'language' => '*',
+			'alias' => 'tobias'
+		];
+
+		$I->sendPOST('/content/article', $testarticle);
 	}
 }

--- a/tests/Codeception/api/com_content/ContentCest.php
+++ b/tests/Codeception/api/com_content/ContentCest.php
@@ -89,7 +89,7 @@ class ContentCest
 		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');
 		$I->haveHttpHeader('Content-Type', 'application/json');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
-		$I->sendPATCH('/content/article/1', ['title' => 'Another Title']);
+		$I->sendPATCH('/content/article/1', ['title' => 'Another Title', 'catid' => 2]);
 		$I->seeResponseCodeIs(HttpCode::OK);
 
 		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');

--- a/tests/Codeception/api/com_content/ContentCest.php
+++ b/tests/Codeception/api/com_content/ContentCest.php
@@ -126,7 +126,7 @@ class ContentCest
 		$I->sendPOST('/content/categories', $testarticle);
 
 		$I->seeResponseCodeIs(HttpCode::OK);
-		$categoryId = $I->grabDataFromResponseByJsonPath('$.data[0].id');
+		$categoryId = $I->grabDataFromResponseByJsonPath('$.data.id');
 
 		$I->amHttpAuthenticated('admin', 'admin');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');


### PR DESCRIPTION
Continues work on adding tests for our APIs in J4

### Testing instructions
Try creating a category for a extension that is *not* com_content (contact or banners). Before patch you’ll get an error that the workflow is missing (despite banners doesn’t have workflows). After patch you can correctly create a category.

This PR also adds many api cases for banners, contacts and category api tests for content check that the api tests pass in drone