### PR TITLE
[4.0] Fix user creation error no group

### DIFF
--- a/administrator/components/com_users/Model/GroupsModel.php
+++ b/administrator/components/com_users/Model/GroupsModel.php
@@ -207,7 +207,7 @@ class GroupsModel extends ListModel
 		// Count the objects in the user group.
 		$query->select('map.group_id, COUNT(DISTINCT map.user_id) AS user_count')
 			->from($db->quoteName('#__user_usergroup_map', 'map'))
-			->join('LEFT', $db->quoteName('#__users', 'u') . ' ON ' . $db->quoteName('u.id') . ' = ' . $db->quoteName('map.user_id'))
+			->join('LEFT', $db->quoteName('#__users', 'u'), $db->quoteName('u.id') . ' = ' . $db->quoteName('map.user_id'))
 			->whereIn($db->quoteName('map.group_id'), $groupIds)
 			->where($db->quoteName('u.block') . ' = 0')
 			->group($db->quoteName('map.group_id'));
@@ -230,7 +230,8 @@ class GroupsModel extends ListModel
 			->from($db->quoteName('#__user_usergroup_map', 'map'))
 			->join('LEFT', $db->quoteName('#__users', 'u'), $db->quoteName('u.id') . ' = ' . $db->quoteName('map.user_id'))
 			->whereIn($db->quoteName('map.group_id'), $groupIds)
-			->where($db->quoteName('u.block') . ' = 1');
+			->where($db->quoteName('u.block') . ' = 1')
+			->group($db->quoteName('map.group_id'));
 		$db->setQuery($query);
 
 		try


### PR DESCRIPTION
Pull Request for Issue "popstgresql and mysql 8 system test fail since #25090 has been merged" .

### Summary of Changes

See the diff: With the changes of PR #25090 , the group by was missing in the 2nd changed statement. The join syntax of the 1st statement I change to the one used in the 2nd statement for consistenty and because that's the new J4 way to do it.

### Testing Instructions

Code review, or install a clean 4.0-dev on Postgresql and then try to create a user.

### Expected result

All ok.

### Actual result

![Unbenannt](https://user-images.githubusercontent.com/7413183/67148955-cb8c3580-f2a5-11e9-9f8a-df5bd8d2de91.png)

### Documentation Changes Required

None.