### PR TITLE
[4.0] No default for created time of privacy consents for new installs.

### DIFF
--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -1670,7 +1670,7 @@ CREATE TABLE IF NOT EXISTS `#__privacy_consents` (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `user_id` int(10) unsigned NOT NULL DEFAULT 0,
   `state` INT(10) NOT NULL DEFAULT 1,
-  `created` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `created` datetime NOT NULL,
   `subject` varchar(255) NOT NULL DEFAULT '',
   `body` text NOT NULL,
   `remind` tinyint(4) NOT NULL DEFAULT 0,

--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -1673,7 +1673,7 @@ CREATE TABLE "#__privacy_consents" (
   "id" serial NOT NULL,
   "user_id" bigint DEFAULT 0 NOT NULL,
   "state" smallint DEFAULT 1 NOT NULL,
-  "created" timestamp without time zone DEFAULT '1970-01-01 00:00:00' NOT NULL,
+  "created" timestamp without time zone NOT NULL,
   "subject" varchar(255) DEFAULT '' NOT NULL,
   "body" text NOT NULL,
   "remind" smallint DEFAULT 0 NOT NULL,


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

With PR #26561, the datetime database colums have been fixed for com_privacy, but the changes done with this PR here have been forgotten.

### Testing Instructions

Code review: Check that the changes here fit to files `administrator/components/com_admin/sql/updates/mysql/4.0.0-2019-09-26.sql` and `administrator/components/com_admin/sql/updates/mysql/4.0.0-2019-09-26.sql` in the current 4.0-dev branch. 

### Expected result

No default value for column `created` of table `#__privacy_consents` after new installation.

### Actual result

Column `created` of table `#__privacy_consents` has a default value in file `joomla.sql` but would not have after an update due to file `4.0.0-2019-09-26.sql`.

### Documentation Changes Required

