### PR TITLE
[4.0] Batch Move or Copy Fields

### DIFF
--- a/build/media_source/com_fields/js/admin-fields-default-batch.es6.js
+++ b/build/media_source/com_fields/js/admin-fields-default-batch.es6.js
@@ -10,7 +10,7 @@ document.addEventListener('DOMContentLoaded', () => {
   batchCopyMove.style.display = 'none';
 
   batchSelector.addEventListener('change', () => {
-    if (batchSelector.value === 'nogroup') {
+    if (batchSelector.value === 'nogroup' || batchSelector.value !=='') {
       batchCopyMove.style.display = 'block';
     } else {
       batchCopyMove.style.display = 'none';

--- a/build/media_source/com_fields/js/admin-fields-default-batch.es6.js
+++ b/build/media_source/com_fields/js/admin-fields-default-batch.es6.js
@@ -10,7 +10,7 @@ document.addEventListener('DOMContentLoaded', () => {
   batchCopyMove.style.display = 'none';
 
   batchSelector.addEventListener('change', () => {
-    if (batchSelector.value === 'nogroup' || batchSelector.value !=='') {
+    if (batchSelector.value === 'nogroup' || batchSelector.value !== '') {
       batchCopyMove.style.display = 'block';
     } else {
       batchCopyMove.style.display = 'none';


### PR DESCRIPTION
Make sure that the move or copy field message is displayed when `nogroup` or a specified group is selected

To test you will need to rebuild the javascript using `npm i`

Pull Request for Issue #26726 