### PR TITLE
[4.0] Remove featured action from featured view

### DIFF
--- a/administrator/components/com_content/View/Featured/HtmlView.php
+++ b/administrator/components/com_content/View/Featured/HtmlView.php
@@ -186,10 +186,6 @@ class HtmlView extends BaseHtmlView
 
 			if ($canDo->get('core.edit.state'))
 			{
-				$childBar->standardButton('featured')
-					->text('JFEATURE')
-					->task('articles.featured')
-					->listCheck(true);
 				$childBar->standardButton('unfeatured')
 					->text('JUNFEATURE')
 					->task('articles.unfeatured')


### PR DESCRIPTION
This PR removes the "feature" link from the actions dropdown in the "featured articles" view as it is never possible in this view to feature an article
