### PR TITLE
[4.0] Add text muted property to show verison is not clickable

### DIFF
--- a/administrator/modules/mod_version/tmpl/default.php
+++ b/administrator/modules/mod_version/tmpl/default.php
@@ -13,7 +13,7 @@ use Joomla\CMS\Language\Text;
 
 ?>
 <div class="header-item-content">
-	<div class="joomlaversion d-flex">
+	<div class="joomlaversion d-flex text-muted">
 		<div class="d-flex align-items-end mx-auto">
 			<span class="fab fa-joomla" aria-hidden="true"></span>
 		</div>


### PR DESCRIPTION
### Summary of Changes
Adds a text-muted property to the version to show it's not clickable. This is an alternative PR to that in #26447

### Testing Instructions
After patch Joomla version in the header of the backend is grayed out to show it's not clickable

### Documentation Changes Required
None
