### PR TITLE
[4.0] fix when error on massmail

### DIFF
--- a/administrator/components/com_users/Model/MailModel.php
+++ b/administrator/components/com_users/Model/MailModel.php
@@ -218,7 +218,7 @@ class MailModel extends AdminModel
 		if ($rs !== true)
 		{
 			$app->setUserState('com_users.display.mail.data', $data);
-			$this->setError(Text::_('COM_USERS_MAIL_THE_MAIL_COULD_NOT_BE_SENT'));
+			$this->setError($mailer->ErrorInfo);
 
 			return false;
 		}

--- a/administrator/components/com_users/Model/MailModel.php
+++ b/administrator/components/com_users/Model/MailModel.php
@@ -218,7 +218,7 @@ class MailModel extends AdminModel
 		if ($rs !== true)
 		{
 			$app->setUserState('com_users.display.mail.data', $data);
-			$this->setError($rs->getError());
+			$this->setError(Text::_('COM_USERS_MAIL_THE_MAIL_COULD_NOT_BE_SENT'));
 
 			return false;
 		}


### PR DESCRIPTION
Pull Request for Issue #26680 .

### Summary of Changes
fixed call on boolean


### Testing Instructions
Login to Joomla Admin with admin accounts.

Go to Admin => Mass Mail Users

Enter Subject with a space at the end e.g: "Test Subject "

Enter at Send mail button

or disable sendmail
### Expected result



### Actual result

`Call to member function getError() on bool`

### Documentation Changes Required

