### PR TITLE
[4.0] Null date corrections for Jgrid and Published buttons

### DIFF
--- a/libraries/cms/html/jgrid.php
+++ b/libraries/cms/html/jgrid.php
@@ -194,13 +194,13 @@ abstract class JHtmlJGrid
 		// Special state for dates
 		if ($publish_up || $publish_down)
 		{
-			$nullDate = null;
+			$nullDate = Factory::getDbo()->getNullDate();
 			$nowDate = Factory::getDate()->toUnix();
 
 			$tz = Factory::getUser()->getTimezone();
 
-			$publish_up = ($publish_up != $nullDate) ? Factory::getDate($publish_up, 'UTC')->setTimeZone($tz) : false;
-			$publish_down = ($publish_down != $nullDate) ? Factory::getDate($publish_down, 'UTC')->setTimeZone($tz) : false;
+			$publish_up = ($publish_up !== null && $publish_up !== $nullDate) ? Factory::getDate($publish_up, 'UTC')->setTimeZone($tz) : false;
+			$publish_down = ($publish_down !== null && $publish_down !== $nullDate) ? Factory::getDate($publish_down, 'UTC')->setTimeZone($tz) : false;
 
 			// Create tip text, only we have publish up or down settings
 			$tips = array();

--- a/libraries/cms/html/jgrid.php
+++ b/libraries/cms/html/jgrid.php
@@ -194,7 +194,7 @@ abstract class JHtmlJGrid
 		// Special state for dates
 		if ($publish_up || $publish_down)
 		{
-			$nullDate = Factory::getDbo()->getNullDate();
+			$nullDate = null;
 			$nowDate = Factory::getDate()->toUnix();
 
 			$tz = Factory::getUser()->getTimezone();

--- a/libraries/src/Button/PublishedButton.php
+++ b/libraries/src/Button/PublishedButton.php
@@ -55,7 +55,7 @@ class PublishedButton extends ActionButton
 			$bakState = $this->getState($value);
 			$default  = $this->getState($value) ? : $this->getState('_default');
 
-			$nullDate = Factory::getDbo()->getNullDate();
+			$nullDate = null;
 			$nowDate = Factory::getDate()->toUnix();
 
 			$tz = Factory::getUser()->getTimezone();

--- a/libraries/src/Button/PublishedButton.php
+++ b/libraries/src/Button/PublishedButton.php
@@ -55,13 +55,13 @@ class PublishedButton extends ActionButton
 			$bakState = $this->getState($value);
 			$default  = $this->getState($value) ? : $this->getState('_default');
 
-			$nullDate = null;
+			$nullDate = Factory::getDbo()->getNullDate();
 			$nowDate = Factory::getDate()->toUnix();
 
 			$tz = Factory::getUser()->getTimezone();
 
-			$publishUp   = ($publishUp !== $nullDate) ? Factory::getDate($publishUp, 'UTC')->setTimeZone($tz) : null;
-			$publishDown = ($publishDown !== $nullDate) ? Factory::getDate($publishDown, 'UTC')->setTimeZone($tz) : null;
+			$publishUp   = ($publishUp !== null && $publishUp !== $nullDate) ? Factory::getDate($publishUp, 'UTC')->setTimeZone($tz) : false;
+			$publishDown = ($publishDown !== null && $publishDown !== $nullDate) ? Factory::getDate($publishDown, 'UTC')->setTimeZone($tz) : false;
 
 			// Add tips and special titles
 			// Create special titles for published items
@@ -86,13 +86,13 @@ class PublishedButton extends ActionButton
 
 				$options['tip_title'] = 'JLIB_HTML_PUBLISHED_ITEM';
 
-				if ($publishUp > $nullDate && $nowDate < $publishUp->toUnix())
+				if ($publishUp && $nowDate < $publishUp->toUnix())
 				{
 					$options['tip_title'] = 'JLIB_HTML_PUBLISHED_PENDING_ITEM';
 					$default['icon'] = 'pending';
 				}
 
-				if ($publishDown > $nullDate && $nowDate > $publishDown->toUnix())
+				if ($publishDown && $nowDate > $publishDown->toUnix())
 				{
 					$options['tip_title'] = 'JLIB_HTML_PUBLISHED_EXPIRED_ITEM';
 					$default['icon'] = 'expired';


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/26660

### Summary of Changes

Null Date is now defined by `null` and no more by `Factory::getDbo()->getNullDate()`

### Testing Instructions
Create a site or admin module and enter a date for the Start Publishing.
Although no Finish Publishing date is set, the tooltip will display a wrong finish date.

### Before patch

![Screen Shot 2019-10-21 at 11 17 21](https://user-images.githubusercontent.com/869724/67192737-6561f880-f3f4-11e9-9fec-7b7a41841aa6.png)

### After patch
![Screen Shot 2019-10-21 at 11 16 05](https://user-images.githubusercontent.com/869724/67192645-3c416800-f3f4-11e9-8f4c-c19335051a4b.png)

### Note:
Remains in core 3 files with instances of `Factory::getDbo()->getNullDate()`
```
/layouts/joomla/content/icons/edit.php:25: 		|| ((strtotime($article->publish_down) < strtotime(Factory::getDate())) && $article->publish_down != Factory::getDbo()->getNullDate()))
/layouts/joomla/content/icons/edit.php:35: 		|| ((strtotime($article->publish_down) < strtotime(Factory::getDate())) && $article->publish_down != Factory::getDbo()->getNullDate()))
/libraries/src/Form/Field/CalendarField.php:228: 				if ($this->value && $this->value != Factory::getDbo()->getNullDate())
/libraries/src/Form/Field/CalendarField.php:240: 				if ($this->value && $this->value != Factory::getDbo()->getNullDate())
/libraries/src/Form/Field/CalendarField.php:253: 		if ($this->value && $this->value != Factory::getDbo()->getNullDate() && strtotime($this->value) !== false)
/libraries/src/HTML/HTMLHelper.php:1115: 		if ($value && $value !== Factory::getDbo()->getNullDate() && strtotime($value) !== false)
```

I did not touch these as I was not sure where to test them.
