### PR TITLE
[4.0] Revert #26056, solving dropdown batch icon and add module icon

### DIFF
--- a/administrator/templates/atum/scss/blocks/_form.scss
+++ b/administrator/templates/atum/scss/blocks/_form.scss
@@ -148,9 +148,7 @@ legend {
 }
 
 [class^="icon-"]:not(.input-group-text),
-[class*=" icon-"]:not(.input-group-text),
-[class^='#{$fa-css-prefix}-']:not(.input-group-text),
-[class*=' #{$fa-css-prefix}-']:not(.input-group-text) {
+[class*=" icon-"]:not(.input-group-text) {
   margin-right: 0.5em;
 }
 

--- a/administrator/templates/atum/scss/pages/_com_cpanel.scss
+++ b/administrator/templates/atum/scss/pages/_com_cpanel.scss
@@ -147,8 +147,8 @@
 
     .cpanel-add-module-icon {
       position: absolute;
-      top: 0;
-      left: 0;
+      top: -0.25rem;
+      left: 12rem;
       right: 0;
       bottom: 0;
 

--- a/administrator/templates/atum/scss/vendor/bootstrap/_dropdown.scss
+++ b/administrator/templates/atum/scss/vendor/bootstrap/_dropdown.scss
@@ -5,6 +5,13 @@
   box-shadow: $dropdown-box-shadow;
   min-width: 100%;
 
+  [class^='icon-'],
+  [class*=' icon-'],
+  [class^='fa '],
+  [class*='fa'] {
+    width: 26px;
+  }
+
   joomla-toolbar-button {
     border: none;
   }

--- a/build/media_source/system/scss/_icomoon.scss
+++ b/build/media_source/system/scss/_icomoon.scss
@@ -1,22 +1,18 @@
 // IcoMoon Conversion
 
 [class^="icon-"]:not(.input-group-text),
-[class*=" icon-"]:not(.input-group-text),
-[class^='#{$fa-css-prefix}-']:not(.input-group-text),
-[class*=' #{$fa-css-prefix}-']:not(.input-group-text) {
+[class*=" icon-"]:not(.input-group-text) {
     display: inline-block;
     width: 14px;
     height: 14px;
     line-height: 14px;
 }
-
 [class^="icon-"]::before,
 [class*=" icon-"]::before {
     font-family: "Font Awesome 5 Free";
     font-style: normal;
     speak: none;
 }
-
 [class^="icon-"].disabled,
 [class*=" icon-"].disabled {
     font-weight: normal;

--- a/libraries/src/Toolbar/Button/PopupButton.php
+++ b/libraries/src/Toolbar/Button/PopupButton.php
@@ -65,7 +65,7 @@ class PopupButton extends ToolbarButton
 	 */
 	protected function prepareOptions(array &$options)
 	{
-		$options['icon'] = $options['icon'] ?? 'fa fa-square';
+		$options['icon'] = $options['icon'] ?? 'icon-square';
 
 		parent::prepareOptions($options);
 


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/26741

### Summary of Changes
Reverts https://github.com/joomla/joomla-cms/pull/26056
Changed `fa fa-square` to `icon-square` to solve that batch dropdown icon display issue. THanks @Quy :)
Correct alignment of the Dashboard add module

### Testing Instructions
Patch. Run npm.
Display `/administrator/index.php` and ckeck quickicons alignment are correctly centered as well as the Add module to the dashboard icon.

Display the Content Dashboard and check the alignment of the + icon

Display the Article manager, select an article and check the alignment of the Batch icon.

### Before patch
See https://github.com/joomla/joomla-cms/issues/26741

### After patch
<img width="861" alt="Screen Shot 2019-10-22 at 08 14 36" src="https://user-images.githubusercontent.com/869724/67262158-08be1680-f4a4-11e9-9e9e-a3b863135d0f.png">
<img width="435" alt="Screen Shot 2019-10-22 at 08 15 54" src="https://user-images.githubusercontent.com/869724/67262199-32773d80-f4a4-11e9-8b40-79f5e6aac5ab.png">
<img width="463" alt="Screen Shot 2019-10-22 at 08 15 04" src="https://user-images.githubusercontent.com/869724/67262177-196e8c80-f4a4-11e9-9581-a592246356bc.png">

<img width="364" alt="Screen Shot 2019-10-22 at 08 16 22" src="https://user-images.githubusercontent.com/869724/67262218-43c04a00-f4a4-11e9-8a17-224c6f381fc0.png">


