### PR TITLE
[4.0] Fix display of Installed Languages on Mobile

### DIFF
--- a/administrator/components/com_languages/tmpl/installed/default.php
+++ b/administrator/components/com_languages/tmpl/installed/default.php
@@ -44,7 +44,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 							<th scope="col" style="width:15%">
 								<?php echo HTMLHelper::_('searchtools.sort', 'JGLOBAL_TITLE', 'name', $listDirn, $listOrder); ?>
 							</th>
-							<th scope="col" style="width:15%" class="d-none d-sm-table-cell">
+							<th scope="col" style="width:15%" class="d-none d-md-table-cell">
 								<?php echo HTMLHelper::_('searchtools.sort', 'COM_LANGUAGES_HEADING_TITLE_NATIVE', 'nativeName', $listDirn, $listOrder); ?>
 							</th>
 							<th scope="col" class="text-center">
@@ -88,7 +88,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 									<?php echo $this->escape($row->name); ?>
 								</label>
 							</th>
-							<td class="hidden-md-down">
+							<td class="d-none d-md-table-cell">
 								<?php echo $this->escape($row->nativeName); ?>
 							</td>
 							<td class="text-center">


### PR DESCRIPTION
### Summary of Changes 
As title says


### Testing Instructions
Display the Installed Language manager.
Reduce the browser window to mobile view.


### Before patch
<img width="486" alt="Screen Shot 2019-10-22 at 09 55 51" src="https://user-images.githubusercontent.com/869724/67267372-6f4a3100-f4b2-11e9-8a3a-bc82ed2f3b56.png">




### After patch
<img width="490" alt="Screen Shot 2019-10-22 at 09 54 56" src="https://user-images.githubusercontent.com/869724/67267396-7b35f300-f4b2-11e9-8c74-50d7df0f00e9.png">

