### PR TITLE
[4.0] missing icon

### DIFF
--- a/components/com_content/tmpl/form/edit.php
+++ b/components/com_content/tmpl/form/edit.php
@@ -158,7 +158,7 @@ if (!$editoroptions)
 				<?php echo Text::_('JSAVE'); ?>
 			</button>
 			<button type="button" class="btn btn-danger" data-submit-task="article.cancel">
-				<span class="fa fa-times-cancel" aria-hidden="true"></span>
+				<span class="fa fa-times" aria-hidden="true"></span>
 				<?php echo Text::_('JCANCEL'); ?>
 			</button>
 			<?php if ($params->get('save_history', 0) && $this->item->id) : ?>


### PR DESCRIPTION
in font awesome 5 there is no fa-times-close

This PR changes it to fa-times which is what is used elsewhere

### Before
![image](https://user-images.githubusercontent.com/1296369/67273345-28f6d100-f4b6-11e9-909e-c518c4893284.png)

### After
![image](https://user-images.githubusercontent.com/1296369/67273313-1bd9e200-f4b6-11e9-9782-cb42c8c3855f.png)
