### PR TITLE
[4.0][com_banners] fix nowdate double quoted

### DIFF
--- a/components/com_banners/Model/BannersModel.php
+++ b/components/com_banners/Model/BannersModel.php
@@ -68,7 +68,7 @@ class BannersModel extends ListModel
 		$categoryId = $this->getState('filter.category_id');
 		$keywords   = $this->getState('filter.keywords');
 		$randomise  = ($ordering === 'random');
-		$nowDate    = $db->quote(Factory::getDate()->toSql());
+		$nowDate    = Factory::getDate()->toSql();
 
 		$query->select(
 			'a.id as id,'


### PR DESCRIPTION
Pull Request for Issue #26763 .

### Summary of Changes
`$nowdate` should be quoted once


### Testing Instructions
Create a banner and publish the banner module


### Expected result

banner shows

### Actual result
`Warning: Invalid argument supplied for foreach() `



