### PR TITLE
[4.0] [libraries] Add check for real null datetimes to CoreContent table class

### DIFF
--- a/libraries/src/Table/CoreContent.php
+++ b/libraries/src/Table/CoreContent.php
@@ -145,7 +145,10 @@ class CoreContent extends Table
 		}
 
 		// Check the publish down date is not earlier than publish up.
-		if ($this->core_publish_down < $this->core_publish_up && $this->core_publish_down > $this->_db->getNullDate())
+		if ($this->core_publish_up !== null
+			&& $this->core_publish_down !== null
+			&& $this->core_publish_down < $this->core_publish_up
+			&& $this->core_publish_down > $this->_db->getNullDate())
 		{
 			// Swap the dates.
 			$temp = $this->core_publish_up;


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This is a follow up to recently merged PR's which changed datetime columns in database for real null values.

Because core content (table `ucm_content`) shall be usable not only for core components', the checks for the old (preudo-)null datetimes are kept and just extended by the check for real null values.

Like for several other components, the table class for core content swaps publish up and down times if they are given and the down time is earlier than the up time. This is not a good thing in my opinion but to change that is outside the scope of this PR.

The check for the condition when to swap is extecned by the check for real null values.

### Testing Instructions

Code review should be sufficient: Make sure that in the file modified by this PR there are no other places where old (preudo-)null datetimes are checked without checking for real null values, too.

### Expected result

No check of published up and down time for old (preudo-)null datetimes without checking for real null values, too.

### Actual result

Check for null values is missing.

### Documentation Changes Required

None.