### PR TITLE
[4.0] Make quickicon's class attribute default to null

### DIFF
--- a/administrator/modules/mod_quickicon/Helper/QuickIconHelper.php
+++ b/administrator/modules/mod_quickicon/Helper/QuickIconHelper.php
@@ -268,7 +268,7 @@ abstract class QuickIconHelper
 						'name'    => null,
 						'linkadd' => null,
 						'access'  => true,
-						'class'   => true,
+						'class'   => null,
 						'group'   => 'MOD_QUICKICON',
 					);
 


### PR DESCRIPTION
### Summary of Changes
The `class` attribute of a quickicon defaults to `true`. 
It will output as `1`.
Change it to `null` so it can be tested if empty.


### Testing Instructions
Log in to the back end.
View page source.
Search `pulse`.
Next to it there is a `1`.
Apply PR.
No more `1`.