### PR TITLE
[4.0] [com_redirect] Fix error on saving automatically created redirect links with MySQL DB in strict mode

### DIFF
--- a/plugins/system/redirect/redirect.php
+++ b/plugins/system/redirect/redirect.php
@@ -249,13 +249,16 @@ class PlgSystemRedirect extends CMSPlugin implements SubscriberInterface
 					$url = $urlRel;
 				}
 
+				$nowDate = Factory::getDate()->toSql();
+
 				$data = (object) array(
 					'id' => 0,
 					'old_url' => $url,
 					'referer' => $app->input->server->getString('HTTP_REFERER', ''),
 					'hits' => 1,
 					'published' => 0,
-					'created_date' => Factory::getDate()->toSql()
+					'created_date' => $nowDate,
+					'modified_date' => $nowDate
 				);
 
 				try


### PR DESCRIPTION
Pull Request for Issue #26782 .

### Summary of Changes

Set also modified date for new redirect links because that database column does not have a default value anymore.

### Testing Instructions

See issue #26782 .

Has to be tested on MySQL 8 or an earlier version where strict mode is switched on.

### Expected result

No error, redirect link is created.

### Actual result

Error "500 PLG_SYSTEM_REDIRECT_ERROR_UPDATING_DATABASE".

### Documentation Changes Required

None.