### PR TITLE
[4.0] pink

### DIFF
--- a/administrator/templates/atum/scss/_variables.scss
+++ b/administrator/templates/atum/scss/_variables.scss
@@ -24,7 +24,7 @@ $light-blue:                       #1757A1; //is the atum-link-color
 $blue:                             hsl(207, 61%, 26%); // base color for calculation, Primary-color
 $indigo:                           #0377be; //used in bootstrap
 $purple:                           #6f42c1; //used in bootstrap
-$pink:                             #e83e8c; //used in bootstrap
+$pink:                             #971250; //used in bootstrap
 $red:                              #c52827; //used in bootstrap
 $red-dark:                         #3b0d0c; //used for alerts error
 $yellow:                           #ffb107; //used in bootstrap


### PR DESCRIPTION
The color used for `<code>` is $pink which was failing accessibility contrast checks. This PR tweaks the colour so it doesn't fail.

Spotted this while testing #26744 which wraps the download key in `<code>`