### PR TITLE
[4.0] Remove the meanwhile obsolete updateDates routine from installation database model

### DIFF
--- a/installation/src/Model/DatabaseModel.php
+++ b/installation/src/Model/DatabaseModel.php
@@ -801,9 +801,6 @@ class DatabaseModel extends BaseInstallationModel
 		// Update the cms data user ids.
 		$this->updateUserIds($db);
 
-		// Update the cms data dates.
-		$this->updateDates($db);
-
 		// Check for testing sampledata plugin.
 		$this->checkTestingSampledata($db);
 	}
@@ -846,67 +843,6 @@ class DatabaseModel extends BaseInstallationModel
 					->set($db->quoteName($field) . ' = ' . $db->quote($userId))
 					->where($db->quoteName($field) . ' != 0')
 					->where($db->quoteName($field) . ' IS NOT NULL');
-
-				$db->setQuery($query);
-
-				try
-				{
-					$db->execute();
-				}
-				catch (\RuntimeException $e)
-				{
-					Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');
-				}
-			}
-		}
-	}
-
-	/**
-	 * Method to update the dates of sql data content to the current date.
-	 *
-	 * @param   DatabaseDriver  $db  Database connector object $db*.
-	 *
-	 * @return  void
-	 *
-	 * @since   3.7.0
-	 */
-	protected function updateDates($db)
-	{
-		// Get the current date.
-		$currentDate = Factory::getDate()->toSql();
-		$nullDate    = $db->getNullDate();
-
-		// Update all core tables date fields of the tables with the current date.
-		$updatesArray = array(
-			'#__banners'             => array('publish_up', 'publish_down', 'reset', 'created', 'modified'),
-			'#__banner_tracks'       => array('track_date'),
-			'#__categories'          => array('created_time', 'modified_time'),
-			'#__contact_details'     => array('publish_up', 'publish_down', 'created', 'modified'),
-			'#__content'             => array('publish_up', 'publish_down', 'created', 'modified'),
-			'#__contentitem_tag_map' => array('tag_date'),
-			'#__fields'              => array('created_time', 'modified_time'),
-			'#__finder_filters'      => array('created', 'modified'),
-			'#__finder_links'        => array('indexdate', 'publish_start_date', 'publish_end_date', 'start_date', 'end_date'),
-			'#__messages'            => array('date_time'),
-			'#__modules'             => array('publish_up', 'publish_down'),
-			'#__newsfeeds'           => array('publish_up', 'publish_down', 'created', 'modified'),
-			'#__redirect_links'      => array('created_date', 'modified_date'),
-			'#__tags'                => array('publish_up', 'publish_down', 'created_time', 'modified_time'),
-			'#__ucm_content'         => array('core_created_time', 'core_modified_time', 'core_publish_up', 'core_publish_down'),
-			'#__ucm_history'         => array('save_date'),
-			'#__users'               => array('registerDate', 'lastvisitDate', 'lastResetTime'),
-			'#__user_notes'          => array('publish_up', 'publish_down', 'created_time', 'modified_time'),
-		);
-
-		foreach ($updatesArray as $table => $fields)
-		{
-			foreach ($fields as $field)
-			{
-				$query = $db->getQuery(true)
-					->update($db->quoteName($table))
-					->set($db->quoteName($field) . ' = ' . $db->quote($currentDate))
-					->where($db->quoteName($field) . ' IS NOT NULL')
-					->where($db->quoteName($field) . ' != ' . $db->quote($nullDate));
 
 				$db->setQuery($query);
 


### PR DESCRIPTION
Pull Request for Issue #26387 , datetime part.

The user ID part is done in PR #26745 (added missing workflow table to routine `updateUserIds`) .

### Summary of Changes

This Pull Request (PR) removes the routine `updateDates` from the installation database model.

The routine is used to set datetime fields in database to current date and time if they are not null and not equal to the old nulldate, i.e. when something was inserted with a hard-coded creation time at new installation.

With recently merged PR's for the datetimes things the joomla.sql scripts have been changed so there is not any data inserted anymore with such hardcoded times. Instead of this, `CURRENT_TIMESTAMP` is used.

So the `updateDates` routine is not needed anymore for the core.

For custom installation SQL scripts like `localise.sql` or `custom.sql` which might be used by some customized installations, it is recommended to use `CURRENT_TIMESTAMP` too in SQL scripts, but it is preferred to insert new content using the appropriate PHP API like we do in our diverse sample data.

See also comments here [https://github.com/joomla/joomla-cms/pull/26399#issuecomment-534529800](https://github.com/joomla/joomla-cms/pull/26399#issuecomment-534529800) and here [https://github.com/joomla/joomla-cms/pull/26399#issuecomment-546527159](https://github.com/joomla/joomla-cms/pull/26399#issuecomment-546527159).

### Testing Instructions

**Attention:** Do this only on a testing environment where your data can be thrown away.

Testers please report back in any case (success or failure) which kind of database (MySQL/MariaDB or PostgreSQL) you've used for testing. If you have several and enough time, please test with all of them.

1. Apply this PR on a clean, up-to-date 4.0-dev branch or latest nightly 4.0 build.
2. If using an existing installation, remove configuration.php and delete all database table of that installation in order to be ready for the next step.
3. Make a new installation.
4. Do **not** log in to backend after the installation has finished. This makes the test easier, otherwise after login you may have some datetime set to a later value than the one to be tested for.
5. Check in your database with tools like eg PhpMyAdmin for MySQL or PhpPgAdmin for PostgreSQL that in tables which are not empty all columns of type `datetime` (MySQL) or `timestamp without time zone` (PostgreSQL) have either value NULL or the date and time of installation in UTC, but not anything else in past or future. Such columns are eg all columns like `created_time` or `modified_time` (with different named here and there, but you will find them).

### Expected result

All datetimes in database which don't allow null values have as value the date and time in UTC when the installation has been finished, ie there is no other fixed datetime given in past or future for columns like `created_time` or `modified_time`.

There is one exception the lastResetTime of users, which will be fixed when PR #26611 is merged.

### Actual result

Same as expected, but one useless routine more in the installation database model.

### Documentation Changes Required

Maybe somewhere inform developers of customized installations that they shall use `CURRENT_TIMESTAMP` in SQL scripts but better insert new content using the appropriate PHP API like we do in our diverse sample data.