### PR TITLE
[4.0] Fix featured up and down null date checks in content table

### DIFF
--- a/libraries/src/Table/Content.php
+++ b/libraries/src/Table/Content.php
@@ -265,18 +265,6 @@ class Content extends Table
 			$this->publish_down = null;
 		}
 
-		// Set featured_up to null if not set
-		if (!isset($this->featured_up))
-		{
-			$this->featured_up = null;
-		}
-
-		// Set featured_down to null if not set
-		if (!isset($this->featured_down))
-		{
-			$this->featured_down = null;
-		}
-
 		// Check the publish down date is not earlier than publish up.
 		if (!is_null($this->publish_up) && !is_null($this->publish_down) && $this->publish_down < $this->publish_up)
 		{
@@ -284,15 +272,6 @@ class Content extends Table
 			$temp = $this->publish_up;
 			$this->publish_up = $this->publish_down;
 			$this->publish_down = $temp;
-		}
-
-		// Check the featured down date is not earlier than featured up.
-		if (!is_null($this->featured_up) && !is_null($this->featured_down) && $this->featured_down < $this->featured_up)
-		{
-			// Swap the dates.
-			$temp = $this->featured_up;
-			$this->featured_up = $this->featured_down;
-			$this->featured_down = $temp;
 		}
 
 		// Clean up keywords -- eliminate extra spaces between phrases

--- a/libraries/src/Table/Content.php
+++ b/libraries/src/Table/Content.php
@@ -275,7 +275,7 @@ class Content extends Table
 		}
 
 		// Check the featured down date is not earlier than featured up.
-		if ($this->featured_up && $this->featured_down && $this->featured_down < $this->featured_up)
+		if (!is_null($this->featured_up) && !is_null($this->featured_down) && $this->featured_down < $this->featured_up)
 		{
 			// Swap the dates.
 			$temp = $this->featured_up;

--- a/libraries/src/Table/Content.php
+++ b/libraries/src/Table/Content.php
@@ -265,6 +265,18 @@ class Content extends Table
 			$this->publish_down = null;
 		}
 
+		// Set featured_up to null if not set
+		if (!isset($this->featured_up))
+		{
+			$this->featured_up = null;
+		}
+
+		// Set featured_down to null if not set
+		if (!isset($this->featured_down))
+		{
+			$this->featured_down = null;
+		}
+
 		// Check the publish down date is not earlier than publish up.
 		if (!is_null($this->publish_up) && !is_null($this->publish_down) && $this->publish_down < $this->publish_up)
 		{


### PR DESCRIPTION
Pull Request for Issue #26828 .

### Summary of Changes

Remove the check for `featured_up` and `featured_down` times in the content table class.

The `featured_up` and `featured_down` columns have been added to database table `#__content_frontpage` with PR #25979 , thanks @eshiol for that new functionality and your patience.

During development, the new database columns first were added to table `#__content` and later have been mode to table `#__content_frontpage`.

This PR here removes a remainder of that change which causes the issue described in #26828 .

Thanks @Quy for having discovered the issue.

### Testing Instructions

1. Set php error reporting to `E_ALL` in your php.ini and switch on error logging to file or display of errors.
2. Make a fresh installation of a clean, current 4.0-dev branch.
3. When loging in to admin (backend) for the very first time, watch the PHP error log / error display.

### Expected result

No errors or warnings or notices.

### Actual result

> PHP Notice:  Undefined property: Joomla\Component\Content\Administrator\Table\ArticleTable::$featured_up in \libraries\src\Table\Content.php on line 278
> PHP Notice:  Undefined index: featured_up in \administrator\components\com_content\Model\ArticleModel.php on line 950
> PHP Notice:  Undefined index: featured_down in \administrator\components\com_content\Model\ArticleModel.php on line 950

### Documentation Changes Required

None.