### PR TITLE
[4.0] Tag field description

### DIFF
--- a/components/com_content/tmpl/category/blog.xml
+++ b/components/com_content/tmpl/category/blog.xml
@@ -28,7 +28,6 @@
 				name="filter_tag"
 				type="tag"
 				label="JTAG"
-				description="JTAG_FIELD_SELECT_DESC"
 				multiple="true"
 			/>
 		</fieldset>

--- a/modules/mod_articles_category/mod_articles_category.xml
+++ b/modules/mod_articles_category/mod_articles_category.xml
@@ -133,7 +133,6 @@
 					name="filter_tag"
 					type="tag"
 					label="JTAG"
-					description="JTAG_FIELD_SELECT_DESC"
 					mode="nested"
 					multiple="true"
 					filter="int_array"


### PR DESCRIPTION
In two places the tags field was still displaying a useless description.

Category Blog menu item
Articles Category module

This simple PR removes the display of that string. The string is kept as I have tried not to remove strings from any of the generic language files as they may be used by non-core extensions

### before
![image](https://user-images.githubusercontent.com/1296369/67625440-4d480a00-f836-11e9-8ae5-164351d83707.png)

### after
![image](https://user-images.githubusercontent.com/1296369/67625442-59cc6280-f836-11e9-8daa-a120c2a03c7c.png)
