### PR TITLE
[4.0] API change PUT to PATCH

### DIFF
--- a/api/includes/app.php
+++ b/api/includes/app.php
@@ -35,7 +35,7 @@ $container = \Joomla\CMS\Factory::getContainer();
  * Alias the session service keys to the web session service as that is the primary session backend for this application
  *
  * In addition to aliasing "common" service keys, we also create aliases for the PHP classes to ensure autowiring objects
- * is supported.  This includes aliases for aliased class names, and the keys for alised class names should be considered
+ * is supported.  This includes aliases for aliased class names, and the keys for aliased class names should be considered
  * deprecated to be removed when the class name alias is removed as well.
  */
 $container->alias('session', 'session.cli')

--- a/libraries/src/Router/ApiRouter.php
+++ b/libraries/src/Router/ApiRouter.php
@@ -66,7 +66,7 @@ class ApiRouter extends Router
 			new Route(['GET'], $baseName, $controller . '.displayList', [], $getDefaults),
 			new Route(['GET'], $baseName . '/:id', $controller . '.displayItem', ['id' => '(\d+)'], $getDefaults),
 			new Route(['POST'], $baseName, $controller . '.add', [], $defaults),
-			new Route(['PUT'], $baseName . '/:id', $controller . '.edit', ['id' => '(\d+)'], $defaults),
+			new Route(['PATCH'], $baseName . '/:id', $controller . '.edit', ['id' => '(\d+)'], $defaults),
 			new Route(['DELETE'], $baseName . '/:id', $controller . '.delete', ['id' => '(\d+)'], $defaults),
 		];
 

--- a/plugins/webservices/banners/banners.php
+++ b/plugins/webservices/banners/banners.php
@@ -72,7 +72,7 @@ class PlgWebservicesBanners extends CMSPlugin
 
 		$routes = [
 			new Route(['GET'], 'v1/banners/contenthistory/:id', 'history.displayList', ['id' => '(\d+)'], $getDefaults),
-			new Route(['PUT'], 'v1/banners/contenthistory/keep/:id', 'history.keep', ['id' => '(\d+)'], $defaults),
+			new Route(['PATCH'], 'v1/banners/contenthistory/keep/:id', 'history.keep', ['id' => '(\d+)'], $defaults),
 			new Route(['DELETE'], 'v1/banners/contenthistory/:id', 'history.delete', ['id' => '(\d+)'], $defaults),
 		];
 

--- a/plugins/webservices/config/config.php
+++ b/plugins/webservices/config/config.php
@@ -44,9 +44,9 @@ class PlgWebservicesConfig extends CMSPlugin
 
 		$routes = [
 			new Route(['GET'], 'v1/config/application', 'application.displayList', [], $getDefaults),
-			new Route(['PUT'], 'v1/config/application', 'application.edit', [], $defaults),
+			new Route(['PATCH'], 'v1/config/application', 'application.edit', [], $defaults),
 			new Route(['GET'], 'v1/config/:component_name', 'component.displayList', ['component_name' => '([A-Za-z_]+)'], $getDefaults),
-			new Route(['PUT'], 'v1/config/:component_name', 'component.edit', ['component_name' => '([A-Za-z_]+)'], $defaults)
+			new Route(['PATCH'], 'v1/config/:component_name', 'component.edit', ['component_name' => '([A-Za-z_]+)'], $defaults)
 		];
 
 		$router->addRoutes($routes);

--- a/plugins/webservices/contact/contact.php
+++ b/plugins/webservices/contact/contact.php
@@ -130,7 +130,7 @@ class PlgWebservicesContact extends CMSPlugin
 
 		$routes = [
 			new Route(['GET'], 'v1/contact/contenthistory/:id', 'history.displayList', ['id' => '(\d+)'], $getDefaults),
-			new Route(['PUT'], 'v1/contact/contenthistory/keep/:id', 'history.keep', ['id' => '(\d+)'], $defaults),
+			new Route(['PATCH'], 'v1/contact/contenthistory/keep/:id', 'history.keep', ['id' => '(\d+)'], $defaults),
 			new Route(['DELETE'], 'v1/contact/contenthistory/:id', 'history.delete', ['id' => '(\d+)'], $defaults),
 		];
 

--- a/plugins/webservices/content/content.php
+++ b/plugins/webservices/content/content.php
@@ -108,7 +108,7 @@ class PlgWebservicesContent extends CMSPlugin
 
 		$routes = [
 			new Route(['GET'], 'v1/content/article/contenthistory/:id', 'history.displayList', ['id' => '(\d+)'], $getDefaults),
-			new Route(['PUT'], 'v1/content/article/contenthistory/keep/:id', 'history.keep', ['id' => '(\d+)'], $defaults),
+			new Route(['PATCH'], 'v1/content/article/contenthistory/keep/:id', 'history.keep', ['id' => '(\d+)'], $defaults),
 			new Route(['DELETE'], 'v1/content/article/contenthistory/:id', 'history.delete', ['id' => '(\d+)'], $defaults),
 		];
 

--- a/plugins/webservices/languages/languages.php
+++ b/plugins/webservices/languages/languages.php
@@ -81,7 +81,7 @@ class PlgWebservicesLanguages extends CMSPlugin
 				new Route(['GET'], $baseName, $controller . '.displayList', [], $getDefaults),
 				new Route(['GET'], $baseName . '/:id', $controller . '.displayItem', ['id' => '([A-Z0-9_]+)'], $getDefaults),
 				new Route(['POST'], $baseName, $controller . '.add', [], $overridesDefaults),
-				new Route(['PUT'], $baseName . '/:id', $controller . '.edit', ['id' => '([A-Z0-9_]+)'], $overridesDefaults),
+				new Route(['PATCH'], $baseName . '/:id', $controller . '.edit', ['id' => '([A-Z0-9_]+)'], $overridesDefaults),
 				new Route(['DELETE'], $baseName . '/:id', $controller . '.delete', ['id' => '([A-Z0-9_]+)'], $overridesDefaults),
 			];
 
@@ -95,7 +95,7 @@ class PlgWebservicesLanguages extends CMSPlugin
 				new Route(['GET'], $baseName, $controller . '.displayList', [], $getDefaults),
 				new Route(['GET'], $baseName . '/:id', $controller . '.displayItem', ['id' => '([A-Z0-9_]+)'], $getDefaults),
 				new Route(['POST'], $baseName, $controller . '.add', [], $overridesDefaults),
-				new Route(['PUT'], $baseName . '/:id', $controller . '.edit', ['id' => '([A-Z0-9_]+)'], $overridesDefaults),
+				new Route(['PATCH'], $baseName . '/:id', $controller . '.edit', ['id' => '([A-Z0-9_]+)'], $overridesDefaults),
 				new Route(['DELETE'], $baseName . '/:id', $controller . '.delete', ['id' => '([A-Z0-9_]+)'], $overridesDefaults),
 			];
 

--- a/plugins/webservices/plugins/plugins.php
+++ b/plugins/webservices/plugins/plugins.php
@@ -45,7 +45,7 @@ class PlgWebservicesPlugins extends CMSPlugin
 		$routes = [
 			new Route(['GET'], 'v1/plugins', 'plugins.displayList', [], $getDefaults),
 			new Route(['GET'], 'v1/plugins/:id', 'plugins.displayItem', ['id' => '(\d+)'], $getDefaults),
-			new Route(['PUT'], 'v1/plugins/:id', 'plugins.edit', ['id' => '(\d+)'], $defaults)
+			new Route(['PATCH'], 'v1/plugins/:id', 'plugins.edit', ['id' => '(\d+)'], $defaults)
 		];
 
 		$router->addRoutes($routes);


### PR DESCRIPTION
The specification says that updating a record should use the verb PATCH

This PR simply swaps the verb

To test ensure that a json request to update a record that worked with PU now works instead with PATCH

### Documentation

The docs will need to be updated - I will do this once the PR is merged

### Testing Instructions
https://docs.joomla.org/J4.x:Joomla_Core_APIs