### PR TITLE
[4.0] Export of Banner Tracks not possible

### DIFF
--- a/layouts/joomla/toolbar/modal.php
+++ b/layouts/joomla/toolbar/modal.php
@@ -31,13 +31,9 @@ $icon     = isset($displayData['icon']) ? $displayData['icon'] : 'fa fa-download
 $text     = isset($displayData['text']) ? $displayData['text'] : '';
 ?>
 
-?>
-<!-- Move Modal to body -->
-<script> function appendToBody(){$("#modal_<?php echo $selector; ?>").appendTo("body");
-}</script>
-
 <!-- Render the button -->
-<joomla-toolbar-button<?php echo $id; ?> onclick="document.getElementById('modal_<?php echo $selector; ?>').open();appendToBody(); "
+<joomla-toolbar-button<?php echo $id; ?> onclick="document.getElementById('modal_<?php echo $selector; ?>').open();
+	$(document.getElementById('modal_<?php echo $selector; ?>')).appendTo('body');"
 										 class="<?php echo $class; ?>" data-toggle="modal">
 
 	<span class="<?php echo $icon; ?>" aria-hidden="true"></span>

--- a/layouts/joomla/toolbar/modal.php
+++ b/layouts/joomla/toolbar/modal.php
@@ -31,13 +31,18 @@ $icon     = isset($displayData['icon']) ? $displayData['icon'] : 'fa fa-download
 $text     = isset($displayData['text']) ? $displayData['text'] : '';
 ?>
 
+<!-- Move Modal to body -->
+<script> function appendToBody(){
+        $("#modal_<?php echo $selector; ?>").appendTo("body");
+    }</script>
+
 <!-- Render the button -->
-<joomla-toolbar-button<?php echo $id; ?> onclick="document.getElementById('modal_<?php echo $selector; ?>').open()" class="<?php echo $class; ?>" data-toggle="modal">
+<joomla-toolbar-button<?php echo $id; ?> onclick="document.getElementById('modal_<?php echo $selector; ?>').open();appendToBody(); " class="<?php echo $class; ?>" data-toggle="modal">
+
 	<span class="<?php echo $icon; ?>" aria-hidden="true"></span>
 	<?php echo $text; ?>
 </joomla-toolbar-button>
 
-<!-- Render the modal -->
 <?php
 echo HTMLHelper::_('bootstrap.renderModal',
 	'modal_' . $selector,
@@ -50,11 +55,11 @@ echo HTMLHelper::_('bootstrap.renderModal',
 		'bodyHeight'  => 60,
 		'closeButton' => true,
 		'footer'      => '<a class="btn btn-secondary" data-dismiss="modal" type="button"'
-						. ' onclick="window.parent.Joomla.Modal.getCurrent().close();">'
-						. Text::_('COM_BANNERS_CANCEL') . '</a>'
-						. '<button class="btn btn-success" type="button"'
-						. ' onclick="Joomla.iframeButtonClick({iframeSelector: \'#modal_downloadModal\', buttonSelector: \'#exportBtn\'})">'
-						. Text::_('COM_BANNERS_TRACKS_EXPORT') . '</button>',
+			. ' onclick="window.parent.Joomla.Modal.getCurrent().close();">'
+			. Text::_('COM_BANNERS_CANCEL') . '</a>'
+			. '<button class="btn btn-success" type="button"'
+			. ' onclick="Joomla.iframeButtonClick({iframeSelector: \'#modal_downloadModal\', buttonSelector: \'#exportBtn\'})">'
+			. Text::_('COM_BANNERS_TRACKS_EXPORT') . '</button>',
 	]
 );
 ?>

--- a/layouts/joomla/toolbar/modal.php
+++ b/layouts/joomla/toolbar/modal.php
@@ -31,13 +31,14 @@ $icon     = isset($displayData['icon']) ? $displayData['icon'] : 'fa fa-download
 $text     = isset($displayData['text']) ? $displayData['text'] : '';
 ?>
 
+?>
 <!-- Move Modal to body -->
-<script> function appendToBody(){
-        $("#modal_<?php echo $selector; ?>").appendTo("body");
-    }</script>
+<script> function appendToBody(){$("#modal_<?php echo $selector; ?>").appendTo("body");
+}</script>
 
 <!-- Render the button -->
-<joomla-toolbar-button<?php echo $id; ?> onclick="document.getElementById('modal_<?php echo $selector; ?>').open();appendToBody(); " class="<?php echo $class; ?>" data-toggle="modal">
+<joomla-toolbar-button<?php echo $id; ?> onclick="document.getElementById('modal_<?php echo $selector; ?>').open();appendToBody(); "
+										 class="<?php echo $class; ?>" data-toggle="modal">
 
 	<span class="<?php echo $icon; ?>" aria-hidden="true"></span>
 	<?php echo $text; ?>


### PR DESCRIPTION
Pull Request for Issue #26818.
Export of Banner Tracks wasn't possible because the Modal Window was in the background.
### Summary of Changes
Fixed by changing the the Position of the Modal to Body.
For this, the Buttons that opens the Modal also changes the Position of the Modal.

### Testing Instructions
Go to Components -> Banners -> Tracks
Click on Export

### Actual result
![image](https://user-images.githubusercontent.com/38781555/67704992-71caf000-f9b6-11e9-8ebb-e8fe67c9623a.png)