### PR TITLE
- Fixed "answer provided by user" issue on reCAPTCHA

### DIFF
--- a/plugins/captcha/recaptcha/recaptcha.php
+++ b/plugins/captcha/recaptcha/recaptcha.php
@@ -146,13 +146,13 @@ class PlgCaptchaRecaptcha extends JPlugin
 		{
 			case '1.0':
 				$challenge = $input->get('recaptcha_challenge_field', '', 'string');
-				$response  = $input->get('recaptcha_response_field', '', 'string');
+				$response  = ($code) ? $code : $input->get('recaptcha_response_field', '', 'string');
 				$spam      = ($challenge === '' || $response === '');
 				break;
 			case '2.0':
 				// Challenge Not needed in 2.0 but needed for getResponse call
 				$challenge = null;
-				$response  = $input->get('g-recaptcha-response', '', 'string');
+				$response  = ($code) ? $code : $input->get('g-recaptcha-response', '', 'string');
 				$spam      = ($response === '');
 				break;
 		}


### PR DESCRIPTION
Pull Request for Issue # .
"answer provided by user" issue on reCAPTCHA, Specially it's conflicting if multiple reCAPTCHA found on the respective page.

### Summary of Changes
Worked on "onCheckAnswer" function. The "$code" parameter's value wasn't implementing inside the function. While you call "onCheckAnswer" function, it used to take "response" from the form which was conflicting if multiple reCAPTCHA found on the respective page.


### Testing Instructions
Create multiple contact form in one page with reCAPTCHA (it should be ajax contact form, We tested by SP Page Builder) and submit the second or third form with complete reCAPTCHA.

### Expected result
if anyone sends any value to "$code" parameter on "onCheckAnswer" function, it should take the "$code" parameter's value "$code" as "response".


### Actual result
Worked on "onCheckAnswer" function. The "$code" parameter's value wasn't implementing inside the function. While you call "onCheckAnswer" function, it used to take "response" from the form which was conflicting if multiple reCAPTCHA found on the respective page.

### Documentation Changes Required
No