### PR TITLE
[4.0] Template Preview button

### DIFF
--- a/administrator/components/com_templates/View/Template/HtmlView.php
+++ b/administrator/components/com_templates/View/Template/HtmlView.php
@@ -263,12 +263,11 @@ class HtmlView extends BaseHtmlView
 		// Add a Template preview button
 		if ($this->preview->client_id == 0)
 		{
-			$bar->popupButton('preview')
+			$bar->linkButton('preview')
 				->icon('icon-picture')
 				->text('COM_TEMPLATES_BUTTON_PREVIEW')
 				->url(Uri::root() . 'index.php?tp=1&templateStyle=' . $this->preview->id)
-				->iframeWidth(800)
-				->iframeHeight(520);
+				->attributes(['target' => '_new']);
 		}
 
 		// Only show file manage buttons for global SuperUser


### PR DESCRIPTION
The template preview opens in a popup. The problem is that its a small popup so you only get a preview of the template in a mobile view.

This PR changes the popupbutton to a linkbutton and opens the link in a new window

![image](https://user-images.githubusercontent.com/1296369/67897785-feacaf80-fb56-11e9-9541-d9424b69ad90.png)
