### PR TITLE
[4.0] Move Session's getHandlers method from Framework to CMS

### DIFF
--- a/libraries/src/Form/Field/SessionhandlerField.php
+++ b/libraries/src/Form/Field/SessionhandlerField.php
@@ -12,7 +12,7 @@ namespace Joomla\CMS\Form\Field;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
-use Joomla\Session\Session;
+use Joomla\CMS\Session\Session;
 
 /**
  * Form Field class for the Joomla Platform.

--- a/libraries/src/Session/Session.php
+++ b/libraries/src/Session/Session.php
@@ -81,6 +81,50 @@ class Session extends BaseSession
 	}
 
 	/**
+	 * Get the available session handlers
+	 *
+	 * @return  array  An array of available session handlers
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public static function getHandlers(): array
+	{
+		$connectors = [];
+
+		// Get an iterator and loop trough the handler classes.
+		$iterator = new \DirectoryIterator(JPATH_LIBRARIES . '/vendor/joomla/session/src/Handler');
+
+		foreach ($iterator as $file)
+		{
+			$fileName = $file->getFilename();
+
+			// Only load for PHP files.
+			if (!$file->isFile() || $file->getExtension() != 'php')
+			{
+				continue;
+			}
+
+			// Derive the class name from the type.
+			$class = str_ireplace('.php', '', '\\Joomla\\Session\\Handler\\' . $fileName);
+
+			// If the class doesn't exist we have nothing left to do but look at the next type. We did our best.
+			if (!class_exists($class))
+			{
+				continue;
+			}
+
+			// Sweet!  Our class exists, so now we just need to know if it passes its test method.
+			if ($class::isSupported())
+			{
+				// Connector names should not have file the handler suffix or the file extension.
+				$connectors[] = str_ireplace('Handler.php', '', $fileName);
+			}
+		}
+
+		return $connectors;
+	}
+
+	/**
 	 * Returns the global session object.
 	 *
 	 * @return  static  The Session object.


### PR DESCRIPTION
### Summary of Changes

To finish https://github.com/joomla-framework/session/pull/42 the CMS needs some place to pull in the supported handler list for the form field to not break.  To keep things as simple as possible for CMS users, the method is just added into `Joomla\CMS\Session\Session`.

### Testing Instructions

The "Session Handler" field in the global configuration still populates correctly.