### PR TITLE
[4.0] Missing language constants in 'User Actions Log => Export Selected / All as CSV' #pbf19 #codepatch

### DIFF
--- a/administrator/components/com_actionlogs/Controller/ActionlogsController.php
+++ b/administrator/components/com_actionlogs/Controller/ActionlogsController.php
@@ -51,6 +51,9 @@ class ActionlogsController extends AdminController
 	{
 		parent::__construct($config, $factory, $app, $input);
 
+		// Load all actionlog plugins language files
+		ActionlogsHelper::loadActionLogPluginsLanguage();
+
 		$this->registerTask('exportSelectedLogs', 'exportLogs');
 	}
 


### PR DESCRIPTION
Pull Request for Issue #26661 .

### Summary of Changes
Load actionlog group plugin's language files


### Testing Instructions
- Apply patch
- Verify lang constants not seen in exported CSV


### Expected result
Lang constants not seen in exported CSV

### Actual result
Lang constants not seen in exported CSV

### Documentation Changes Required
No
