### PR TITLE
[4.0] Remove selenium.log from final build

### DIFF
--- a/build/build.php
+++ b/build/build.php
@@ -173,6 +173,7 @@ $doNotPackage = array(
 	'RoboFile.php',
 	'RoboFile.dist.ini',
 	'CODE_OF_CONDUCT.md',
+	'selenium.log',
 	// Remove the testing sample data from all packages
 	'installation/sql/mysql/sample_testing.sql',
 	'installation/sql/postgresql/sample_testing.sql',


### PR DESCRIPTION
### Summary of Changes

Remove selenium.log from final build

### Testing Instructions

download current beta https://developer.joomla.org/nightly-builds.html
notice the selenium.log file
apply this PR and run the build script again

### Expected result

no selenium.log

### Actual result

selenium.log

### Documentation Changes Required

none