### PR TITLE
[#26930] fix: Usergroup field plugin - Plugin option 'Multiple' - Des…

### DIFF
--- a/administrator/language/en-GB/en-GB.plg_fields_usergrouplist.ini
+++ b/administrator/language/en-GB/en-GB.plg_fields_usergrouplist.ini
@@ -8,4 +8,5 @@ PLG_FIELDS_USERGROUPLIST_DEFAULT_VALUE_DESC="A comma separated list of user grou
 PLG_FIELDS_USERGROUPLIST_DEFAULT_VALUE_LABEL="Default User Groups"
 PLG_FIELDS_USERGROUPLIST_LABEL="User Groups (%s)"
 PLG_FIELDS_USERGROUPLIST_PARAMS_MULTIPLE_LABEL="Multiple"
+PLG_FIELDS_USERGROUPLIST_PARAMS_MULTIPLE_DESC="Allow multiple values to be selected."
 PLG_FIELDS_USERGROUPLIST_XML_DESCRIPTION="This plugin lets you create new fields of type 'usergrouplist' in any extensions where custom fields are supported."

--- a/plugins/fields/usergrouplist/usergrouplist.xml
+++ b/plugins/fields/usergrouplist/usergrouplist.xml
@@ -25,6 +25,7 @@
 					name="multiple"
 					type="radio"
 					label="PLG_FIELDS_USERGROUPLIST_PARAMS_MULTIPLE_LABEL"
+					description="PLG_FIELDS_USERGROUPLIST_PARAMS_MULTIPLE_DESC"
 					class="switcher"
 					default="0"
 					filter="integer"


### PR DESCRIPTION
…cription of the field is missing

Pull Request for Issue # .

### Summary of Changes
1: Change in language fine(en-GB.plg_fields_usergrouplist.ini)
2: Change in xml file (usergrouplist.xml).


### Testing Instructions
1: Go to usergroup field plugin
2: Check plugin option multiple, what is the field for is missing.


### Expected result
Add a description for the multiple plugin option



### Actual result



### Documentation Changes Required

