### PR TITLE
[4.0]Create User Group - Group parent dropdown gets blank.#pbf19 #bug

### DIFF
--- a/administrator/components/com_users/Field/GroupparentField.php
+++ b/administrator/components/com_users/Field/GroupparentField.php
@@ -75,7 +75,7 @@ class GroupparentField extends ListField
 		}
 
 		// We should not remove any groups when we are creating a new group
-		if (!empty($currentGroupId))
+		if ($currentGroupId !== null && $currentGroupId !== 0)
 		{
 			// Prevent parenting direct children and children of children of this item.
 			$options = $this->cleanOptionsChildrenByFather($options, $currentGroupId);

--- a/administrator/components/com_users/Field/GroupparentField.php
+++ b/administrator/components/com_users/Field/GroupparentField.php
@@ -75,7 +75,7 @@ class GroupparentField extends ListField
 		}
 
 		// We should not remove any groups when we are creating a new group
-		if (!is_null($currentGroupId))
+		if (!empty($currentGroupId))
 		{
 			// Prevent parenting direct children and children of children of this item.
 			$options = $this->cleanOptionsChildrenByFather($options, $currentGroupId);


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
changes in groupparentfield.php

### Testing Instructions
1: Open new create a user group form.
2: Leave the required field blank and click on the save button.
3: Check parent group dropdown.

### Expected result
The options should display in a dropdown

### Actual result



### Documentation Changes Required

