### PR TITLE
[4.0] Fix No User button not clickable

### DIFF
--- a/administrator/components/com_users/tmpl/users/modal.php
+++ b/administrator/components/com_users/tmpl/users/modal.php
@@ -30,7 +30,7 @@ $onClick         = "window.parent.jSelectUser(this);window.parent.Joomla.Modal.g
 <div class="container-popup">
 	<form action="<?php echo Route::_('index.php?option=com_users&view=users&layout=modal&tmpl=component&groups=' . $input->get('groups', '', 'BASE64') . '&excluded=' . $input->get('excluded', '', 'BASE64')); ?>" method="post" name="adminForm" id="adminForm">
 		<?php if (!$userRequired) : ?>
-		<div class="float-left mx-2 mt-2">
+		<div>
 			<button type="button" class="btn btn-primary button-select" data-user-value="0" data-user-name="<?php echo $this->escape(Text::_('JLIB_FORM_SELECT_USER')); ?>"
 				data-user-field="<?php echo $this->escape($field); ?>"><?php echo Text::_('JOPTION_NO_USER'); ?></button>&nbsp;
 		</div>


### PR DESCRIPTION
Pull Request for Issue #26929.

### Summary of Changes
The  `No User` button is overlapped by the search tools container, thus, it is not clickable.
Remove float-left.

The `No User` button is above the search tools container which is not ideal.
This can be a temporary solution until there is another PR to align it with the search tools container.


### Testing Instructions
- Edit an article.
- Go to the Publishing section.
- Select the user for created by field.
- Click `No User` button.


### Actual result

![no-user](https://user-images.githubusercontent.com/368084/68078375-40756a00-fd92-11e9-83ae-f6afb2d4b356.jpg)
