### PR TITLE
[4.0] Info_block associations icon misssing

### DIFF
--- a/layouts/joomla/content/info_block/associations.php
+++ b/layouts/joomla/content/info_block/associations.php
@@ -19,6 +19,7 @@ use Joomla\CMS\Router\Route;
 <?php $associations = $displayData['item']->associations; ?>
 
 <dd class="association">
+	<span class="fas fa-globe" aria-hidden="true"></span>
 	<?php echo Text::_('JASSOCIATIONS'); ?>
 	<?php foreach ($associations as $association) : ?>
 		<?php if ($displayData['item']->params->get('flags', 1) && $association['language']->image) : ?>


### PR DESCRIPTION
On the model of https://github.com/joomla/joomla-cms/pull/26943

### Summary of Changes
Adding globe icon when associations are displayed in the article info-block.


### Testing Instructions
Create multilingual site with sample data.
In Articles Global Options, set Associations to Show.
Display frontend. Look at the "Also available:" line


### Before patch
<img width="902" alt="Screen Shot 2019-11-03 at 08 12 29" src="https://user-images.githubusercontent.com/869724/68081746-2fb90880-fe13-11e9-9d10-50cab0165ec3.png">



### After patch
<img width="898" alt="Screen Shot 2019-11-03 at 08 10 34" src="https://user-images.githubusercontent.com/869724/68081752-3c3d6100-fe13-11e9-8b3a-83164a483393.png">
