### PR TITLE
[4.0] Fix last visit older than 1 year filter in users model

### DIFF
--- a/administrator/components/com_users/Model/UsersModel.php
+++ b/administrator/components/com_users/Model/UsersModel.php
@@ -428,6 +428,8 @@ class UsersModel extends ListModel
 				}
 				elseif ($dates['dNow'] === false)
 				{
+					$dStart = $dates['dStart']->format('Y-m-d H:i:s');
+
 					$query->where(
 						$db->quoteName('a.lastvisitDate') . ' < :lastvisitDate'
 					);


### PR DESCRIPTION
Pull Request for Issue [https://github.com/joomla/joomla-cms/pull/26611#issuecomment-549090252](https://github.com/joomla/joomla-cms/pull/26611#issuecomment-549090252).

### Summary of Changes

This Pull Request (PR) fixes the filter "More than 1 year go" in the users list view, which was broken with my PR #26611 (blush).

### Testing Instructions

1. On a clean installation of current 4.0-dev or the latest nightly 4.0-beta1-dev build of tonight, go to "Users -> Manage" in backend.
2. Click Filter Options and select "Last Visit Date -> More than a year ago".

### Expected result

List is shown with the selected filter applied.

### Actual result

Error "500 No data supplied for parameters in prepared statement No data supplied for parameters in prepared statement".

### Documentation Changes Required

None.