### PR TITLE
[com_users] Confirmation window shown when no users in group

### DIFF
--- a/build/media_source/com_users/js/admin-users-groups.es6.js
+++ b/build/media_source/com_users/js/admin-users-groups.es6.js
@@ -13,7 +13,7 @@ Joomla = window.Joomla || {};
       if (task === 'groups.delete') {
         const cids = document.getElementsByName('cid[]');
         for (let i = 0; i < cids.length; i += 1) {
-          if (cids[i].checked && cids[i].parentNode.getAttribute('data-usercount') !== 0) {
+          if (cids[i].checked && cids[i].parentNode.getAttribute('data-usercount') !== '0') {
             // TODO replace with joomla-alert
             if (window.confirm(Joomla.JText._('COM_USERS_GROUPS_CONFIRM_DELETE'))) {
               Joomla.submitform(task);


### PR DESCRIPTION
Fixes #26935

### Summary of Changes

Fixes "Are you sure you wish to delete groups that have users?" confirmation window appearing when deleting a user group with no users in it.

### Testing Instructions

Create a user group.
Do not assign any users to that group.
Delete the group.


### Expected result

The above confirmation window not shown.

### Actual result

The confirmation is shown.

### Documentation Changes Required

No.