### PR TITLE
Allow to offer a different reinstall url than the full download URL

### DIFF
--- a/administrator/components/com_installer/models/update.php
+++ b/administrator/components/com_installer/models/update.php
@@ -403,8 +403,9 @@ class InstallerModelUpdate extends JModelList
 			return false;
 		}
 
-		$url     = trim($update->downloadurl->_data);
-		$sources = $update->get('downloadSources', array());
+		$url         = trim($update->downloadurl->_data);
+		$packageType = trim($update->downloadurl->type);
+		$sources     = $update->get('downloadSources', array());
 
 		if ($extra_query = $update->get('extra_query'))
 		{
@@ -416,8 +417,9 @@ class InstallerModelUpdate extends JModelList
 
 		while (!($p_file = InstallerHelper::downloadPackage($url)) && isset($sources[$mirror]))
 		{
-			$name = $sources[$mirror];
-			$url  = trim($name->url);
+			$name        = $sources[$mirror];
+			$url         = trim($name->url);
+			$packageType = trim($name->type);
 
 			if ($extra_query)
 			{
@@ -447,7 +449,7 @@ class InstallerModelUpdate extends JModelList
 		$update->set('type', $package['type']);
 
 		// Check the package
-		$check = InstallerHelper::isChecksumValid($package['packagefile'], $update);
+		$check = InstallerHelper::isChecksumValid($package['packagefile'], $update, $packageType);
 
 		// The validation was not successful. Just a warning for now.
 		// TODO: In Joomla 4 this will abort the installation

--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -291,7 +291,6 @@ class JoomlaupdateModelDefault extends JModelLegacy
 			$packageURL  = trim($updateInfo['object']->reinstallurl->_data);
 			$packageType = trim($updateInfo['object']->reinstallurl->type);
 			$sources     = $updateInfo['object']->get('reinstallSources', array());
-
 		}
 
 		$headers = get_headers($packageURL, 1);

--- a/administrator/components/com_joomlaupdate/views/default/tmpl/default_reinstall.php
+++ b/administrator/components/com_joomlaupdate/views/default/tmpl/default_reinstall.php
@@ -24,7 +24,7 @@ defined('_JEXEC') or die;
 	</div>
 
 	<?php if (is_object($this->updateInfo['object']) && ($this->updateInfo['object'] instanceof JUpdate)) : ?>
-	<?php $reinstallUrl = isset($this->updateInfo['object']->reinstallurl->_data) ? $this->updateInfo['object']->reinstallurl->_data : $this->updateInfo['object']->downloadurl->_data; ?>
+		<?php $reinstallUrl = isset($this->updateInfo['object']->reinstallurl->_data) ? $this->updateInfo['object']->reinstallurl->_data : $this->updateInfo['object']->downloadurl->_data; ?>
 		<table class="table table-striped">
 			<tbody>
 			<tr>

--- a/administrator/components/com_joomlaupdate/views/default/tmpl/default_reinstall.php
+++ b/administrator/components/com_joomlaupdate/views/default/tmpl/default_reinstall.php
@@ -23,8 +23,8 @@ defined('_JEXEC') or die;
 		<?php echo JText::sprintf('COM_JOOMLAUPDATE_VIEW_DEFAULT_NOUPDATESNOTICE', JVERSION); ?>
 	</div>
 
-<?php $reinstallUrl = isset($this->updateInfo['object']->reinstallurl->_data) ? $this->updateInfo['object']->reinstallurl->_data : $this->updateInfo['object']->downloadurl->_data; ?>
 	<?php if (is_object($this->updateInfo['object']) && ($this->updateInfo['object'] instanceof JUpdate)) : ?>
+	<?php $reinstallUrl = isset($this->updateInfo['object']->reinstallurl->_data) ? $this->updateInfo['object']->reinstallurl->_data : $this->updateInfo['object']->downloadurl->_data; ?>
 		<table class="table table-striped">
 			<tbody>
 			<tr>

--- a/administrator/components/com_joomlaupdate/views/default/tmpl/default_reinstall.php
+++ b/administrator/components/com_joomlaupdate/views/default/tmpl/default_reinstall.php
@@ -23,6 +23,7 @@ defined('_JEXEC') or die;
 		<?php echo JText::sprintf('COM_JOOMLAUPDATE_VIEW_DEFAULT_NOUPDATESNOTICE', JVERSION); ?>
 	</div>
 
+<?php $reinstallUrl = isset($this->updateInfo['object']->reinstallurl->_data) ? $this->updateInfo['object']->reinstallurl->_data : $this->updateInfo['object']->downloadurl->_data; ?>
 	<?php if (is_object($this->updateInfo['object']) && ($this->updateInfo['object'] instanceof JUpdate)) : ?>
 		<table class="table table-striped">
 			<tbody>
@@ -31,8 +32,8 @@ defined('_JEXEC') or die;
 					<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_PACKAGE_REINSTALL'); ?>
 				</td>
 				<td>
-					<a href="<?php echo $this->updateInfo['object']->downloadurl->_data; ?>" target="_blank" rel="noopener noreferrer">
-						<?php echo $this->updateInfo['object']->downloadurl->_data; ?>
+					<a href="<?php echo $reinstallUrl ?>" target="_blank" rel="noopener noreferrer">
+						<?php echo $reinstallUrl ?>
 						<span class="icon-out-2" aria-hidden="true"></span>
 						<span class="element-invisible"><?php echo JText::_('JBROWSERTARGET_NEW'); ?></span>
 					</a>
@@ -111,6 +112,7 @@ defined('_JEXEC') or die;
 					<button class="btn btn-warning" type="submit">
 						<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_INSTALLAGAIN'); ?>
 					</button>
+					<input type="hidden" name="updatetype" value="reinstall" />
 				</td>
 			</tr>
 			</tfoot>

--- a/administrator/components/com_joomlaupdate/views/default/tmpl/default_update.php
+++ b/administrator/components/com_joomlaupdate/views/default/tmpl/default_update.php
@@ -122,6 +122,7 @@ defined('_JEXEC') or die;
 				<button class="btn btn-primary" type="submit">
 					<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_INSTALLUPDATE'); ?>
 				</button>
+				<input type="hidden" name="updatetype" value="update" />
 			</td>
 		</tr>
 		</tfoot>

--- a/libraries/src/Updater/Hashes.php
+++ b/libraries/src/Updater/Hashes.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  Copyright (C) 2005 - 2019 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Updater;
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * Data object representing a Hashes given as part of an update's `<shaXXX>` element
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class Hashes
+{
+	/**
+	 * Defines a hash for a full package
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	const TYPE_FULL = 'full';
+
+	/**
+	 * Defines a hash for a patch package
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	const TYPE_PATCH = 'patch';
+
+	/**
+	 * Defines a hash for a upgrade package
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	const TYPE_UPGRADE = 'upgrade';
+
+	/**
+	 * The hash type
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public $type = self::TYPE_FULL;
+
+	/**
+	 * The hash value
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public $value;
+}

--- a/libraries/src/Updater/Update.php
+++ b/libraries/src/Updater/Update.php
@@ -415,6 +415,18 @@ class Update extends \JObject
 						$dbVersion    = $db->getVersion();
 						$supportedDbs = $this->currentUpdate->supported_databases;
 
+						// MySQL and MariaDB use the same database driver but not the same version numbers
+						if ($dbType === 'mysql')
+						{
+							// Check whether we have a MariaDB version string and extract the proper version from it
+							if (stripos($dbVersion, 'mariadb') !== false)
+							{
+								// MariaDB: Strip off any leading '5.5.5-', if present
+								$dbVersion = preg_replace('/^5\.5\.5-/', '', $dbVersion);
+								$dbType    = 'mariadb';
+							}
+						}
+
 						// Do we have an entry for the database?
 						if (isset($supportedDbs->$dbType))
 						{

--- a/libraries/src/Updater/Update.php
+++ b/libraries/src/Updater/Update.php
@@ -109,7 +109,7 @@ class Update extends \JObject
 	 * Update manifest `<reinstallsource>` elements
 	 *
 	 * @var    DownloadSource[]
-	 * @since  3.8.3
+	 * @since  __DEPLOY_VERION__
 	 */
 	protected $reinstallSources = array();
 

--- a/libraries/src/Updater/Update.php
+++ b/libraries/src/Updater/Update.php
@@ -530,7 +530,7 @@ class Update extends \JObject
 
 		if (in_array($tag, array('sha256','sha384','sha512')))
 		{
-			// Grab the last source so we can append the hash value
+			// Grab the last hash so we can append the hash value
 			$hash = end($this->$tag);
 			$hash->value = $data;
 


### PR DESCRIPTION
### Summary of Changes

Allow to offer a different reinstall url than the download URL

### Testing Instructions

#### First test
- install an outdated version
- apply this patch
- make sure the update works
- re-apply this patch
- make sure the reinstall works too

#### Seccond test
- install an outdated version
- apply this patch
- use this update server: https://www.jah-tz.de/downloads/core/reinstall/reinstall_list.xml
- make sure the update works (It should point to the patch update)
- re-apply this patch
- make sure that reinstall works too. (It should point to the full update)

### Expected result

You can use a different reinstall url than the download url that allows us on updates to ship only the patch update and not always the full update. This should reduce the traffic we get on downloads.joomla.org as well as for the users that don't need to download the full package on any update, this should also make the updates faster for that reason.

### Actual result

You can only use the download url and this forces everyone to download the full package on any update.

### How is this archived?

```
<updates>
[...]
	<update>
[...]
		<downloads>
			<downloadurl type="patch" format="zip">https://downloads.joomla.org/cms/joomla3/3-9-12/Joomla_3-9-x_to_3-9-12-Stable-Patch_Package.zip</downloadurl>
			<downloadsource type="patch" format="zip">https://github.com/joomla/joomla-cms/releases/download/3.9.12/Joomla_3-9-x_to_3-9-12-Stable-Patch_Package.zip</downloadsource>
			<downloadsource type="patch" format="zip">https://update.joomla.org/releases/3.9.12/Joomla_3-9-x_to_3-9-12-Stable-Patch_Package.zip</downloadsource>
			<reinstallurl type="full" format="zip">https://downloads.joomla.org/cms/joomla3/3-9-12/Joomla_3.9.12-Stable-Update_Package.zip</reinstallurl>
			<reinstallsource type="full" format="zip">https://github.com/joomla/joomla-cms/releases/download/3.9.12/Joomla_3.9.12-Stable-Update_Package.zip</reinstallsource>
			<reinstallsource type="full" format="zip">https://update.joomla.org/releases/3.9.12/Joomla_3.9.12-Stable-Update_Package.zip</reinstallsource>
		</downloads>
[...]
		<sha256 type="patch">4bf360e449049efeab3a1f7ae24f49311a611bb4564e5fd30dce22ac4fced261</sha256>
		<sha384 type="patch">41f0596cdcf6bed2e5fda7f6d5092320fab75b9a8fbd3e1ae2f01d8c6f5a8ab73190341f475dd2aee21f63ba0316581e</sha384>
		<sha512 type="patch">4afd4870ff0433e4a4dd96cacb913758c4958d19431b45b3aa835b6bc5aa5286e840709502d4e9bb00801e727f9712b8b28cd8379ef18c629489ce2bd5ca57f7</sha512>
		<sha256 type="full">39c24efc5a4a811359f92d261d20426ee392cc1799af15dce6fe14fc7c49de20</sha256>
		<sha384 type="full">896d32d51b9573b74c4b2f01adc7c5c28db172ce5f2c05c97278a418dd14b45fbe164c789337550f2458716f4bae4bd1</sha384>
		<sha512 type="full">8b9216cd381f07b675bdc3fafdad6fc30725555e652f02bcdf8faa31225cca81b9fc9b7a24fd33805185b8065c9e06c51dd7583c6b9e7d050d823bafe902d04d</sha512>
[...]
	</update>
</updates>
```

### Documentation Changes Required

The new reinstallurl and reinstallSource tags as well as the type attributes for that tags as well as the hash tags needs to be documented and will be by me. Label added.

As requested by @HLeithner and @wilsonge 