### PR TITLE
[4.0] Remove bottom margin

### DIFF
--- a/administrator/components/com_templates/tmpl/template/default_modal_file_body.php
+++ b/administrator/components/com_templates/tmpl/template/default_modal_file_body.php
@@ -47,11 +47,9 @@ $input = Factory::getApplication()->input;
 									<option value="txt">.txt</option>
 								</select>
 							</div>
-							<div class="form-group">
-								<input type="hidden" class="address" name="address">
-								<?php echo HTMLHelper::_('form.token'); ?>
-								<button type="submit" class="btn btn-primary"><?php echo Text::_('COM_TEMPLATES_BUTTON_CREATE'); ?></button>
-							</div>
+							<input type="hidden" class="address" name="address">
+							<?php echo HTMLHelper::_('form.token'); ?>
+							<button type="submit" class="btn btn-primary"><?php echo Text::_('COM_TEMPLATES_BUTTON_CREATE'); ?></button>
 						</form>
 					</div>
 				</div>


### PR DESCRIPTION
### Summary of Changes
Don't wrap button with `form-group` to remove bottom margin.


### Testing Instructions
Go to System > Site Templates > Cassiopeia Details and Files
Click `New File` button
See extra margin below `Create` button
Apply PR
No extra margin below `Create` button


