### PR TITLE
[4.0] Fix register date together with last visit date range filter in users model

### DIFF
--- a/administrator/components/com_users/Model/UsersModel.php
+++ b/administrator/components/com_users/Model/UsersModel.php
@@ -390,19 +390,19 @@ class UsersModel extends ListModel
 
 				if ($dates['dNow'] === false)
 				{
-					$query->where($db->quoteName('a.registerDate') . ' < :dStart');
-					$query->bind(':dStart', $dStart);
+					$query->where($db->quoteName('a.registerDate') . ' < :registerDate');
+					$query->bind(':registerDate', $dStart);
 				}
 				else
 				{
 					$dNow = $dates['dNow']->format('Y-m-d H:i:s');
 
 					$query->where(
-						$db->quoteName('a.registerDate') . ' >= :dStart' .
-						' AND ' . $db->quoteName('a.registerDate') . ' <= :dNow'
+						$db->quoteName('a.registerDate') . ' >= :registerDate1' .
+						' AND ' . $db->quoteName('a.registerDate') . ' <= :registerDate2'
 					);
-					$query->bind(':dStart', $dStart);
-					$query->bind(':dNow', $dNow);
+					$query->bind(':registerDate1', $dStart);
+					$query->bind(':registerDate2', $dNow);
 				}
 			}
 		}
@@ -441,11 +441,11 @@ class UsersModel extends ListModel
 					$dNow   = $dates['dNow']->format('Y-m-d H:i:s');
 
 					$query->where(
-						$db->quoteName('a.lastvisitDate') . ' >= :dStart' .
-						' AND ' . $db->quoteName('a.lastvisitDate') . ' <= :dNow'
+						$db->quoteName('a.lastvisitDate') . ' >= :lastvisitDate1' .
+						' AND ' . $db->quoteName('a.lastvisitDate') . ' <= :lastvisitDate2'
 					);
-					$query->bind(':dStart', $dStart);
-					$query->bind(':dNow', $dNow);
+					$query->bind(':lastvisitDate1', $dStart);
+					$query->bind(':lastvisitDate2', $dNow);
 				}
 			}
 		}


### PR DESCRIPTION
Pull Request for Issue [https://github.com/joomla/joomla-cms/pull/26964#issuecomment-549175823](https://github.com/joomla/joomla-cms/pull/26964#issuecomment-549175823).

### Summary of Changes

Change names of bind variables in users model so they still are unambiguous when range filters are used for both columns register date and last visit date.

### Testing Instructions

In the users list view having more than 1 user, set any datetime filter like e.g. "today" on each of the columns "Registration Date" and "Last Visit Date", so that for both columns a filter is applied.

### Expected result

No error, filter is applied.

### Actual result

HTTP code 500, no further error message in UI. In PHP log with error log into file on and error reporting = maximum following message 2 times:

> PHP Warning:  mysqli_stmt::bind_param(): Number of variables doesn't match number of parameters in prepared statement in /home/richard/lamp/public_html/joomla-cms-4.0-dev/libraries/vendor/joomla/database/src/Mysqli/MysqliStatement.php on line 430

### Documentation Changes Required

None.