### PR TITLE
[4.0] Change width to display labels on one line

### DIFF
--- a/administrator/templates/atum/scss/pages/_com_config.scss
+++ b/administrator/templates/atum/scss/pages/_com_config.scss
@@ -2,13 +2,13 @@
 
 .com_config {
 
-	#fieldset-permissions {
-		grid-template-columns: 1fr;
-	}
+  #fieldset-permissions {
+    grid-template-columns: 1fr;
+  }
 
-	.tab-description {
-		grid-column: 1 / -1;
-	}
+  .tab-description {
+    grid-column: 1 / -1;
+  }
 
   .rule-notes,
   .filter-notes {
@@ -21,5 +21,17 @@
     .revert-controls .controls {
       margin-left: 0;
     }
+  }
+  
+  .control-group .control-label {
+    width: auto;
+  }
+
+  .switcher__legend {
+    width: auto;
+  }
+  
+  .spacer label {
+    width: auto;
   }
 }


### PR DESCRIPTION
### Summary of Changes
Change `width` to auto instead of hard coded values to display labels on one line.


### Testing Instructions
Go to Global Configuration > Banners
Go to Global Configuration > Media
See labels on two lines
Apply PR
Run npm i
Clear browser's cache

### Actual result

![config1](https://user-images.githubusercontent.com/368084/68098600-5b1f1000-fe72-11e9-9220-50bd1e4e2299.jpg)

![config2](https://user-images.githubusercontent.com/368084/68098603-5eb29700-fe72-11e9-8a63-d63a99b0e8a9.jpg)


