### PR TITLE
[4.0] Remove button from readonly/disabled calendar fields

### DIFF
--- a/layouts/joomla/form/field/calendar.php
+++ b/layouts/joomla/form/field/calendar.php
@@ -105,7 +105,7 @@ HTMLHelper::_('stylesheet', 'system/fields/calendar' . $cssFileExt, ['version' =
 <div class="field-calendar">
 	<?php if (!$readonly && !$disabled) : ?>
 	<div class="input-group">
-		<?php endif; ?>
+	<?php endif; ?>
 		<input
 			type="text"
 			id="<?php echo $id; ?>"
@@ -115,26 +115,28 @@ HTMLHelper::_('stylesheet', 'system/fields/calendar' . $cssFileExt, ['version' =
 			<?php echo $attributes; ?>
 			<?php echo !empty($hint) ? 'placeholder="' . htmlspecialchars($hint, ENT_COMPAT, 'UTF-8') . '"' : ''; ?>
 			data-alt-value="<?php echo htmlspecialchars($value, ENT_COMPAT, 'UTF-8'); ?>" autocomplete="off">
-		<span class="input-group-append">
-			<button type="button" class="<?php echo ($readonly || $disabled) ? 'hidden ' : ''; ?>btn btn-primary"
-				id="<?php echo $id; ?>_btn"
-				data-inputfield="<?php echo $id; ?>"
-				data-dayformat="<?php echo $format; ?>"
-				data-button="<?php echo $id; ?>_btn"
-				data-firstday="<?php echo Factory::getLanguage()->getFirstDay(); ?>"
-				data-weekend="<?php echo Factory::getLanguage()->getWeekEnd(); ?>"
-				data-today-btn="<?php echo $todaybutton; ?>"
-				data-week-numbers="<?php echo $weeknumbers; ?>"
-				data-show-time="<?php echo $showtime; ?>"
-				data-show-others="<?php echo $filltable; ?>"
-				data-time-24="<?php echo $timeformat; ?>"
-				data-only-months-nav="<?php echo $singleheader; ?>"
-				<?php echo isset($minYear) && strlen($minYear) ? 'data-min-year="' . $minYear . '"' : ''; ?>
-				<?php echo isset($maxYear) && strlen($maxYear) ? 'data-max-year="' . $maxYear . '"' : ''; ?>
-				title="<?php echo Text::_('JLIB_HTML_BEHAVIOR_OPEN_CALENDAR'); ?>"
-			><span class="fa fa-calendar" aria-hidden="true"></span></button>
-		</span>
 		<?php if (!$readonly && !$disabled) : ?>
+			<span class="input-group-append">
+				<button type="button" class="btn btn-primary"
+					id="<?php echo $id; ?>_btn"
+					data-inputfield="<?php echo $id; ?>"
+					data-dayformat="<?php echo $format; ?>"
+					data-button="<?php echo $id; ?>_btn"
+					data-firstday="<?php echo Factory::getLanguage()->getFirstDay(); ?>"
+					data-weekend="<?php echo Factory::getLanguage()->getWeekEnd(); ?>"
+					data-today-btn="<?php echo $todaybutton; ?>"
+					data-week-numbers="<?php echo $weeknumbers; ?>"
+					data-show-time="<?php echo $showtime; ?>"
+					data-show-others="<?php echo $filltable; ?>"
+					data-time-24="<?php echo $timeformat; ?>"
+					data-only-months-nav="<?php echo $singleheader; ?>"
+					<?php echo isset($minYear) && strlen($minYear) ? 'data-min-year="' . $minYear . '"' : ''; ?>
+					<?php echo isset($maxYear) && strlen($maxYear) ? 'data-max-year="' . $maxYear . '"' : ''; ?>
+					title="<?php echo Text::_('JLIB_HTML_BEHAVIOR_OPEN_CALENDAR'); ?>"
+				><span class="fa fa-calendar" aria-hidden="true"></span></button>
+			</span>
+		<?php endif; ?>
+	<?php if (!$readonly && !$disabled) : ?>
 	</div>
-<?php endif; ?>
+	<?php endif; ?>
 </div>

--- a/layouts/joomla/form/field/calendar.php
+++ b/layouts/joomla/form/field/calendar.php
@@ -103,9 +103,7 @@ HTMLHelper::_('script', 'system/fields/calendar.min.js', ['version' => 'auto', '
 HTMLHelper::_('stylesheet', 'system/fields/calendar' . $cssFileExt, ['version' => 'auto', 'relative' => true]);
 ?>
 <div class="field-calendar">
-	<?php if (!$readonly && !$disabled) : ?>
 	<div class="input-group">
-	<?php endif; ?>
 		<input
 			type="text"
 			id="<?php echo $id; ?>"
@@ -136,7 +134,5 @@ HTMLHelper::_('stylesheet', 'system/fields/calendar' . $cssFileExt, ['version' =
 				><span class="fa fa-calendar" aria-hidden="true"></span></button>
 			</span>
 		<?php endif; ?>
-	<?php if (!$readonly && !$disabled) : ?>
 	</div>
-	<?php endif; ?>
 </div>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

When a calendar field is `readonly` or `disabled`, the button next to the input to open the calendar popup is not needed. Currently, a `hidden` class is added to the button to make it invisible, but this PR removes it from the DOM....seeing as it's not required at all.

### Testing Instructions

1. Go to create a new article
2. Go to the "Publishing" tab
3. Look at the "Modified Date" field

There **shouldn't** be a button next to the input field and the markup for it shouldn't be part of the DOM.