### PR TITLE
[4.0] Fix filtering in users model

### DIFF
--- a/administrator/components/com_users/Model/UsersModel.php
+++ b/administrator/components/com_users/Model/UsersModel.php
@@ -397,10 +397,7 @@ class UsersModel extends ListModel
 				{
 					$dNow = $dates['dNow']->format('Y-m-d H:i:s');
 
-					$query->where(
-						$db->quoteName('a.registerDate') . ' >= :registerDate1' .
-						' AND ' . $db->quoteName('a.registerDate') . ' <= :registerDate2'
-					);
+					$query->where($db->quoteName('a.registerDate') . ' BETWEEN :registerDate1 AND :registerDate2');
 					$query->bind(':registerDate1', $dStart);
 					$query->bind(':registerDate2', $dNow);
 				}
@@ -427,19 +424,14 @@ class UsersModel extends ListModel
 
 				if ($dates['dNow'] === false)
 				{
-					$query->where(
-						$db->quoteName('a.lastvisitDate') . ' < :lastvisitDate'
-					);
+					$query->where($db->quoteName('a.lastvisitDate') . ' < :lastvisitDate');
 					$query->bind(':lastvisitDate', $dStart);
 				}
 				else
 				{
 					$dNow   = $dates['dNow']->format('Y-m-d H:i:s');
 
-					$query->where(
-						$db->quoteName('a.lastvisitDate') . ' >= :lastvisitDate1' .
-						' AND ' . $db->quoteName('a.lastvisitDate') . ' <= :lastvisitDate2'
-					);
+					$query->where($db->quoteName('a.lastvisitDate') . ' BETWEEN :lastvisitDate1 AND :lastvisitDate2');
 					$query->bind(':lastvisitDate1', $dStart);
 					$query->bind(':lastvisitDate2', $dNow);
 				}

--- a/administrator/components/com_users/Model/UsersModel.php
+++ b/administrator/components/com_users/Model/UsersModel.php
@@ -415,21 +415,18 @@ class UsersModel extends ListModel
 		{
 			$dates = $this->buildDateRange($lastvisitrange);
 
-			if ($dates['dStart'] !== false)
+			if ($dates['dStart'] === false)
+			{
+				$query->where($db->quoteName('a.lastvisitDate') . ' IS NULL');
+			}
+			else
 			{
 				$query->where($db->quoteName('a.lastvisitDate') . ' IS NOT NULL');
 
-				if (is_string($dates['dStart']))
-				{
-					$query->where(
-						$db->quoteName('a.lastvisitDate') . ' = :lastvisitDate'
-					);
-					$query->bind(':lastvisitDate', $dates['dStart']);
-				}
-				elseif ($dates['dNow'] === false)
-				{
-					$dStart = $dates['dStart']->format('Y-m-d H:i:s');
+				$dStart = $dates['dStart']->format('Y-m-d H:i:s');
 
+				if ($dates['dNow'] === false)
+				{
 					$query->where(
 						$db->quoteName('a.lastvisitDate') . ' < :lastvisitDate'
 					);
@@ -437,7 +434,6 @@ class UsersModel extends ListModel
 				}
 				else
 				{
-					$dStart = $dates['dStart']->format('Y-m-d H:i:s');
 					$dNow   = $dates['dNow']->format('Y-m-d H:i:s');
 
 					$query->where(

--- a/administrator/components/com_users/Model/UsersModel.php
+++ b/administrator/components/com_users/Model/UsersModel.php
@@ -368,10 +368,10 @@ class UsersModel extends ListModel
 
 				// Add the clauses to the query.
 				$query->where(
-						'(' . $db->quoteName('a.name') . ' LIKE :name'
-						. ' OR ' . $db->quoteName('a.username') . ' LIKE :username'
-						. ' OR ' . $db->quoteName('a.email') . ' LIKE :email)'
-					)
+					'(' . $db->quoteName('a.name') . ' LIKE :name'
+					. ' OR ' . $db->quoteName('a.username') . ' LIKE :username'
+					. ' OR ' . $db->quoteName('a.email') . ' LIKE :email)'
+				)
 					->bind(':name', $search)
 					->bind(':username', $search)
 					->bind(':email', $search);

--- a/administrator/components/com_users/Model/UsersModel.php
+++ b/administrator/components/com_users/Model/UsersModel.php
@@ -367,9 +367,11 @@ class UsersModel extends ListModel
 				$search = '%' . trim($search) . '%';
 
 				// Add the clauses to the query.
-				$query->where($db->quoteName('a.name') . ' LIKE :name')
-					->orWhere($db->quoteName('a.username') . ' LIKE :username')
-					->orWhere($db->quoteName('a.email') . ' LIKE :email')
+				$query->where(
+						'(' . $db->quoteName('a.name') . ' LIKE :name'
+						. ' OR ' . $db->quoteName('a.username') . ' LIKE :username'
+						. ' OR ' . $db->quoteName('a.email') . ' LIKE :email)'
+					)
 					->bind(':name', $search)
 					->bind(':username', $search)
 					->bind(':email', $search);


### PR DESCRIPTION
Pull Request for Issue [https://github.com/joomla/joomla-cms/pull/26970#issuecomment-549499004](https://github.com/joomla/joomla-cms/pull/26970#issuecomment-549499004), first sentence, and [https://github.com/joomla/joomla-cms/pull/26970#issuecomment-549506006](https://github.com/joomla/joomla-cms/pull/26970#issuecomment-549506006) .

### Summary of Changes

Correct check for "never" filter for last visit date which was broken by PR #26611 (blush).

Don't use "orWhere" for text search filters because this will result in further, later "where" clauses being appended with "OR", which are those of the date range filters, if used. Thanks @SharkyKZ for this fix.

Beside this, for other date range filter options where 2 dates are used, the 2 comparisons ">=" and "<=" are replaced by using "BETWEEN", which is standard SQL and gives the same result. This change can be tested by code review.

### Testing Instructions

Precondition: Have at least 2 users of which some visited the site and some others never visited the site.

1. Go to "Users -> Manage".

2. Click filter options.

3. Select "never" in the dropdown "- Select last visit date -". Check the result in the list.

4. Select any other date range for the last visit date. Check the result in the list.

5. Enter in the text search box the username of a user for which the date range filter selected in step 4 matches. Then click the "search" icon right of the search box. Check the result in the list.

6. Now either change the text in the search box or change the last visit date range so that there are users which match to one of these criteria but not to both. 

### Expected result

For step 3: Only users who never visited the site ("never" shown for last visit date in the list) are shown in the list.

For step 4: Only users with last visit date matching the selected range are shown in the list.

For step 5: Only those users are shown for which both criteria are true, the text search and the last visit date range.

For step 6: No user is shown.

Hint for testers: Please note that all these filters "today", "in the last week", "in the last month" and so on will always show a user who has registered or visited (depending on which filter) the site today, because today is in all these ranges (from 1 week ago until and including today, or from 1 month ago until and including today, and so on). This is desired behavior of these filters and was like this all the time. Only the filter "more than a year ago" excludes today, and for last visit date the "never" filter of course also does not include "today".

### Actual result

For step 3: All users are shown in the list.

For step 4: Same as expected result for step 4.

For step 5: Users are shown for which either the text box or the last visit date matches the criteria.

For step 6: Users are shown for which either the text box or the last visit date matches the criteria.

### Documentation Changes Required

None.