### PR TITLE
[4.0] Select options font-size

### DIFF
--- a/administrator/templates/atum/scss/blocks/_searchtools.scss
+++ b/administrator/templates/atum/scss/blocks/_searchtools.scss
@@ -62,6 +62,7 @@
       option {
         color: var(--atum-text-dark);
         background-color: var(--white);
+        font-size: 0.875rem;
       }
     }
   }


### PR DESCRIPTION
Pull Request for Issue #26918  

### Summary of Changes
reduce the font size used in the regular select so that it is the same (smaller) size as the one from choices.

