### PR TITLE
[4.0] Media Info

### DIFF
--- a/administrator/components/com_media/resources/scripts/components/browser/browser.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/browser.vue
@@ -31,7 +31,7 @@
                 </div>
             </div>
         </div>
-        <media-infobar v-if="!this.isModal" ref="infobar"></media-infobar>
+        <media-infobar ref="infobar"></media-infobar>
     </div>
 </template>
 


### PR DESCRIPTION
Pull Request for Issue #26690 .

### Summary of Changes
The button for image information was being displayed in both the modal and full component view but the actual information had a conditional statement not to be loaded in a modal. As I couldn't see any reason for that condition I removed it so that the information is displayed

### Expected result
Clicking on the information icon will display information in both the com_media view and the modal

![image](https://user-images.githubusercontent.com/1296369/68162796-c6d7aa80-ff50-11e9-881d-2095f1456c9d.png)

![image](https://user-images.githubusercontent.com/1296369/68162819-dfe05b80-ff50-11e9-9e21-6f18fc3c7dd1.png)

@wilsonge please check - maybe the condition was there for a reason i cannot see