### PR TITLE
[4.0] optgroup color

### DIFF
--- a/administrator/templates/atum/scss/vendor/bootstrap/_custom-forms.scss
+++ b/administrator/templates/atum/scss/vendor/bootstrap/_custom-forms.scss
@@ -32,7 +32,7 @@
     &.custom-select-danger {
       color: theme-color("danger");
       background-color: theme-color("danger");
-    border-color: theme-color("danger");
+      border-color: theme-color("danger");
 
       option {
         color: $custom-select-color;
@@ -42,5 +42,6 @@
   }
   optgroup, option {
     background-color: $white;
+    color: var(--atum-text-dark);
   }
 }


### PR DESCRIPTION
Pull Request for Issue #26928 .

### Testing Instructions
1. Open the filter options for articles and  check the **stage** dropdown - you should see the name of the workflow and the stages
2. Select a stage, the page reloads and repeat step 1

### Expected result
you should see the name of the workflow and the stages in both scenario



### Actual result
You cannot see the name of the workflow once a state has been selected


After applying this PR the workflow name will always be visible