### PR TITLE
[4.0] Remove horizontal scrollbar in media modal

### DIFF
--- a/administrator/components/com_media/resources/scripts/components/app.vue
+++ b/administrator/components/com_media/resources/scripts/components/app.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="media-container row">
+    <div class="media-container">
         <div class="media-sidebar col-md-2 d-none d-md-block">
             <media-disk v-for="(disk, index) in disks" :uid="index" :key="index" :disk="disk"></media-disk>
         </div>


### PR DESCRIPTION
Pull Request for Issue #26703 .

### Summary of Changes

![26703](https://user-images.githubusercontent.com/368084/68176569-2e363000-ff3a-11e9-93e1-93b0c995d3a5.jpg)

PR fixes margins causing the horizontal scrollbar in medial modal.
`.row` and `.media-container` are essentially the same except for margins.
Ideally, use `.row` in Media page and use `.media-container` in media modal.


### Testing Instructions
Go to Content > Articles
Edit an article
Click Images and Links tab
Click Select button
See horizontal scrollbar
Apply PR
Run `npm i`
Clear browser's cache
No horizontal scrollbar