### PR TITLE
[4.0] user notes category delete

### DIFF
--- a/plugins/content/joomla/joomla.php
+++ b/plugins/content/joomla/joomla.php
@@ -255,6 +255,7 @@ class PlgContentJoomla extends CMSPlugin
 			'com_contact' => array('table_name' => '#__contact_details'),
 			'com_content' => array('table_name' => '#__content'),
 			'com_newsfeeds' => array('table_name' => '#__newsfeeds'),
+			'com_users' => array('table_name' => '#__user_notes'),
 			'com_weblinks' => array('table_name' => '#__weblinks'),
 		);
 


### PR DESCRIPTION
This PR prevents you from deleting a user notes category if there are any notes in that category.

It also resolves the situation in #26917

![image](https://user-images.githubusercontent.com/1296369/68183987-c9a8be80-ff95-11e9-8a47-a361bc693074.png)
