### PR TITLE
[4.0] Removing menu items filter from Administrator template styles

### DIFF
--- a/administrator/components/com_templates/View/Styles/HtmlView.php
+++ b/administrator/components/com_templates/View/Styles/HtmlView.php
@@ -88,7 +88,7 @@ class HtmlView extends BaseHtmlView
 		$this->preview       = ComponentHelper::getParams('com_templates')->get('template_positions_display');
 
 		// Remove the menu item filter for administrator styles.
-		if ((int) $this->state->get('client_id') === 1)
+		if ((int) $this->state->get('client_id') !== 0)
 		{
 			unset($this->activeFilters['menuitem']);
 			$this->filterForm->removeField('menuitem', 'filter');

--- a/administrator/components/com_templates/View/Styles/HtmlView.php
+++ b/administrator/components/com_templates/View/Styles/HtmlView.php
@@ -87,6 +87,13 @@ class HtmlView extends BaseHtmlView
 		$this->activeFilters = $this->get('ActiveFilters');
 		$this->preview       = ComponentHelper::getParams('com_templates')->get('template_positions_display');
 
+		// Remove the menu item filter for administrator styles.
+		if ((int) $this->state->get('client_id') === 1)
+		{
+			unset($this->activeFilters['menuitem']);
+			$this->filterForm->removeField('menuitem', 'filter');
+		}
+
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{


### PR DESCRIPTION
### Summary of Changes 
Template styles manager can be filtered by menu item (new in J4).
This should only be available for site templates and not admin templates


### Testing Instructions
Load the template styles, switch client, Click on Filter Options.

Patch


### Before patch
Client is site = OK

<img width="1049" alt="Screen Shot 2019-11-05 at 11 18 46" src="https://user-images.githubusercontent.com/869724/68199450-5a939000-ffbe-11e9-9c45-fba431bfed99.png">

Client is administrator = wrong

<img width="952" alt="Screen Shot 2019-11-05 at 11 19 38" src="https://user-images.githubusercontent.com/869724/68199498-70a15080-ffbe-11e9-9fe5-05de7cce32f7.png">


### After patch
Client administrator is OK

<img width="1018" alt="Screen Shot 2019-11-05 at 11 19 02" src="https://user-images.githubusercontent.com/869724/68199583-97f81d80-ffbe-11e9-9f93-6e6dc9c6e93b.png">
