### PR TITLE
[4.0] Add closing </div>

### DIFF
--- a/layouts/joomla/edit/params.php
+++ b/layouts/joomla/edit/params.php
@@ -127,6 +127,7 @@ foreach ($fieldSets as $name => $fieldSet)
 		{
 			if ($opentab > 1)
 			{
+				echo '</div>';
 				echo '</fieldset>';
 			}
 


### PR DESCRIPTION
Pull Request for Issue #26827.

### Summary of Changes
Fix markup by adding closing `</div>`. 

![67619035-6fe11100-f7ab-11e9-8e6c-b8ce13e92d0a](https://user-images.githubusercontent.com/368084/68239835-94659600-ffc0-11e9-8ccf-f2b049d044db.jpg)


### Testing Instructions
Edit a user.
View page source.
Find `id="attrib-accessibility"`
Notice `</fieldset>` highlighted red
Apply PR
No more `</fieldset>` highlighted red


