### PR TITLE
Don't require _JEXEC for proxy library

### DIFF
--- a/libraries/phputf8/mbstring/core.php
+++ b/libraries/phputf8/mbstring/core.php
@@ -1,5 +1,5 @@
 <?php
-defined('_JEXEC') or die;
+defined('JPATH_LIBRARIES') or die;
 
 if (class_exists('JLog'))
 {

--- a/libraries/phputf8/native/core.php
+++ b/libraries/phputf8/native/core.php
@@ -1,5 +1,5 @@
 <?php
-defined('_JEXEC') or die;
+defined('JPATH_LIBRARIES') or die;
 
 if (class_exists('JLog'))
 {

--- a/libraries/phputf8/ord.php
+++ b/libraries/phputf8/ord.php
@@ -1,5 +1,5 @@
 <?php
-defined('_JEXEC') or die;
+defined('JPATH_LIBRARIES') or die;
 
 if (class_exists('JLog'))
 {

--- a/libraries/phputf8/str_ireplace.php
+++ b/libraries/phputf8/str_ireplace.php
@@ -1,5 +1,5 @@
 <?php
-defined('_JEXEC') or die;
+defined('JPATH_LIBRARIES') or die;
 
 if (class_exists('JLog'))
 {

--- a/libraries/phputf8/str_pad.php
+++ b/libraries/phputf8/str_pad.php
@@ -1,5 +1,5 @@
 <?php
-defined('_JEXEC') or die;
+defined('JPATH_LIBRARIES') or die;
 
 if (class_exists('JLog'))
 {

--- a/libraries/phputf8/str_split.php
+++ b/libraries/phputf8/str_split.php
@@ -1,5 +1,5 @@
 <?php
-defined('_JEXEC') or die;
+defined('JPATH_LIBRARIES') or die;
 
 if (class_exists('JLog'))
 {

--- a/libraries/phputf8/strcasecmp.php
+++ b/libraries/phputf8/strcasecmp.php
@@ -1,5 +1,5 @@
 <?php
-defined('_JEXEC') or die;
+defined('JPATH_LIBRARIES') or die;
 
 if (class_exists('JLog'))
 {

--- a/libraries/phputf8/strcspn.php
+++ b/libraries/phputf8/strcspn.php
@@ -1,5 +1,5 @@
 <?php
-defined('_JEXEC') or die;
+defined('JPATH_LIBRARIES') or die;
 
 if (class_exists('JLog'))
 {

--- a/libraries/phputf8/stristr.php
+++ b/libraries/phputf8/stristr.php
@@ -1,5 +1,5 @@
 <?php
-defined('_JEXEC') or die;
+defined('JPATH_LIBRARIES') or die;
 
 if (class_exists('JLog'))
 {

--- a/libraries/phputf8/strrev.php
+++ b/libraries/phputf8/strrev.php
@@ -1,5 +1,5 @@
 <?php
-defined('_JEXEC') or die;
+defined('JPATH_LIBRARIES') or die;
 
 if (class_exists('JLog'))
 {

--- a/libraries/phputf8/strspn.php
+++ b/libraries/phputf8/strspn.php
@@ -1,5 +1,5 @@
 <?php
-defined('_JEXEC') or die;
+defined('JPATH_LIBRARIES') or die;
 
 if (class_exists('JLog'))
 {

--- a/libraries/phputf8/substr_replace.php
+++ b/libraries/phputf8/substr_replace.php
@@ -1,5 +1,5 @@
 <?php
-defined('_JEXEC') or die;
+defined('JPATH_LIBRARIES') or die;
 
 if (class_exists('JLog'))
 {

--- a/libraries/phputf8/trim.php
+++ b/libraries/phputf8/trim.php
@@ -1,5 +1,5 @@
 <?php
-defined('_JEXEC') or die;
+defined('JPATH_LIBRARIES') or die;
 
 if (class_exists('JLog'))
 {

--- a/libraries/phputf8/ucfirst.php
+++ b/libraries/phputf8/ucfirst.php
@@ -1,5 +1,5 @@
 <?php
-defined('_JEXEC') or die;
+defined('JPATH_LIBRARIES') or die;
 
 if (class_exists('JLog'))
 {

--- a/libraries/phputf8/ucwords.php
+++ b/libraries/phputf8/ucwords.php
@@ -1,5 +1,5 @@
 <?php
-defined('_JEXEC') or die;
+defined('JPATH_LIBRARIES') or die;
 
 if (class_exists('JLog'))
 {

--- a/libraries/phputf8/utf8.php
+++ b/libraries/phputf8/utf8.php
@@ -1,5 +1,5 @@
 <?php
-defined('_JEXEC') or die;
+defined('JPATH_LIBRARIES') or die;
 
 if (class_exists('JLog'))
 {

--- a/libraries/phputf8/utils/ascii.php
+++ b/libraries/phputf8/utils/ascii.php
@@ -1,5 +1,5 @@
 <?php
-defined('_JEXEC') or die;
+defined('JPATH_LIBRARIES') or die;
 
 if (class_exists('JLog'))
 {

--- a/libraries/phputf8/utils/bad.php
+++ b/libraries/phputf8/utils/bad.php
@@ -1,5 +1,5 @@
 <?php
-defined('_JEXEC') or die;
+defined('JPATH_LIBRARIES') or die;
 
 if (class_exists('JLog'))
 {

--- a/libraries/phputf8/utils/patterns.php
+++ b/libraries/phputf8/utils/patterns.php
@@ -1,5 +1,5 @@
 <?php
-defined('_JEXEC') or die;
+defined('JPATH_LIBRARIES') or die;
 
 if (class_exists('JLog'))
 {

--- a/libraries/phputf8/utils/position.php
+++ b/libraries/phputf8/utils/position.php
@@ -1,5 +1,5 @@
 <?php
-defined('_JEXEC') or die;
+defined('JPATH_LIBRARIES') or die;
 
 if (class_exists('JLog'))
 {

--- a/libraries/phputf8/utils/specials.php
+++ b/libraries/phputf8/utils/specials.php
@@ -1,5 +1,5 @@
 <?php
-defined('_JEXEC') or die;
+defined('JPATH_LIBRARIES') or die;
 
 if (class_exists('JLog'))
 {

--- a/libraries/phputf8/utils/unicode.php
+++ b/libraries/phputf8/utils/unicode.php
@@ -1,5 +1,5 @@
 <?php
-defined('_JEXEC') or die;
+defined('JPATH_LIBRARIES') or die;
 
 if (class_exists('JLog'))
 {

--- a/libraries/phputf8/utils/validation.php
+++ b/libraries/phputf8/utils/validation.php
@@ -1,5 +1,5 @@
 <?php
-defined('_JEXEC') or die;
+defined('JPATH_LIBRARIES') or die;
 
 if (class_exists('JLog'))
 {


### PR DESCRIPTION
Pull Request for Issue #26995 .

### Summary of Changes
Change _JEXEC check to JPATH_LIBRARIES for maximum b/c. 
This library has already been deprecated since Joomla 3.6 and is removed in Joomla 4.0.

### Testing Instructions
Code Review.


### Expected result
Works


### Actual result
Works
