### PR TITLE
[4.0] Fix progressive cache

### DIFF
--- a/libraries/src/Document/HtmlDocument.php
+++ b/libraries/src/Document/HtmlDocument.php
@@ -470,8 +470,9 @@ class HtmlDocument extends Document
 
 		if ($this->_caching == true && $type == 'modules')
 		{
+			/** @var  \Joomla\CMS\Document\Renderer\Html\ModulesRenderer  $renderer */
 			$cache = CmsFactory::getCache('com_modules', '');
-			$hash = md5(serialize(array($name, $attribs, null, $renderer)));
+			$hash = md5(serialize(array($name, $attribs, null, get_class($renderer))));
 			$cbuffer = $cache->get('cbuffer_' . $type);
 
 			if (isset($cbuffer[$hash]))


### PR DESCRIPTION
Successor Pull Request for Issue https://github.com/joomla/joomla-cms/pull/26262 .

### Summary of Changes
Only uses the class of the object to serialize for the cache key. With some help from @mbabker (thankyou!!) debugging this it turned out to be an indirect issue from the introduction of Web Assets as they sit in JDocument (a property of the DocumentRenderer class which in turn has a child of the dispatcher which contains Closures).

There's no relevant in the class contents for the module rendering at this point so no issues with this.

### Testing Instructions
Go into your websites backend

Go to the Global Configuration

Go to the system tag

Set the System Cache to "ON-Progressive Caching"

Go to your sites frontend

Now you should get an error-message

Now apply patch and redo the Testing Instructions

### Documentation Changes Required
N/A