### PR TITLE
ComponentLayout and ModuleLayout - Do not limit by template style

### DIFF
--- a/libraries/legacy/form/field/componentlayout.php
+++ b/libraries/legacy/form/field/componentlayout.php
@@ -61,13 +61,6 @@ class JFormFieldComponentlayout extends JFormField
 		$template = (string) $this->element['template'];
 		$template = preg_replace('#\W#', '', $template);
 
-		$template_style_id = '';
-		if ($this->form instanceof JForm)
-		{
-			$template_style_id = $this->form->getValue('template_style_id');
-			$template_style_id = preg_replace('#\W#', '', $template_style_id);
-		}
-
 		$view = (string) $this->element['view'];
 		$view = preg_replace('#\W#', '', $view);
 
@@ -93,12 +86,6 @@ class JFormFieldComponentlayout extends JFormField
 			if ($template)
 			{
 				$query->where('e.element = ' . $db->quote($template));
-			}
-
-			if ($template_style_id)
-			{
-				$query->join('LEFT', '#__template_styles as s on s.template=e.element')
-					->where('s.id=' . (int) $template_style_id);
 			}
 
 			// Set the query and load the templates.

--- a/libraries/legacy/form/field/modulelayout.php
+++ b/libraries/legacy/form/field/modulelayout.php
@@ -61,14 +61,6 @@ class JFormFieldModulelayout extends JFormField
 		$template = (string) $this->element['template'];
 		$template = preg_replace('#\W#', '', $template);
 
-		// Get the style.
-		$template_style_id = '';
-		if ($this->form instanceof JForm)
-		{
-			$template_style_id = $this->form->getValue('template_style_id');
-			$template_style_id = preg_replace('#\W#', '', $template_style_id);
-		}
-
 		// If an extension and view are present build the options.
 		if ($module && $client)
 		{
@@ -91,12 +83,6 @@ class JFormFieldModulelayout extends JFormField
 			if ($template)
 			{
 				$query->where('e.element = ' . $db->quote($template));
-			}
-
-			if ($template_style_id)
-			{
-				$query->join('LEFT', '#__template_styles as s on s.template=e.element')
-					->where('s.id=' . (int) $template_style_id);
 			}
 
 			// Set the query and load the templates.


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Both `ComponentLayout` and `ModuleLayout` field types check their form for a `template_style_id` setting and then, if it is found, limit their options to layouts within the selected template.

Since there are perfectly legit reasons why you might want to use a style from one template and a layout from another, I have removed this unnecessary limitation.

### Testing Instructions

1) Have multiple templates installed. Each with various layout overrides.
2) Create a category menu item. Can default or blog type doesn't matter. The point is to get a form with a `ComponentLayout` field in it. 
3) Select a specific `Template Style` (not default) and save.
4) Go to the `Options` tab where you can choose a layout for article pages. 

### Expected result

You would want the `Choose a Layout` field to give you all the options. 

### Actual result

Prior to this change, you would get all options only if your `Template Style` is set to default. Any other setting will limit options to layouts from the component or the selected template. 

### Documentation Changes Required

Probably not.