### PR TITLE
[4.0] Fix radio buttons markup

### DIFF
--- a/layouts/joomla/form/field/radio/buttons.php
+++ b/layouts/joomla/form/field/radio/buttons.php
@@ -111,7 +111,7 @@ if ($readonly || $disabled)
 			$onchange   = !empty($option->onchange) ? 'onchange="' . $option->onchange . '"' : '';
 			$oid        = $id . $i;
 			$ovalue     = htmlspecialchars($option->value, ENT_COMPAT, 'UTF-8');
-			$attributes = array_filter(array($checked, $optionClass, $disabled, $style, $onchange, $onclick));
+			$attributes = array_filter(array($checked, $disabled, $style, $onchange, $onclick));
 			?>
 			<?php if ($required) : ?>
 				<?php $attributes[] = 'required'; ?>


### PR DESCRIPTION
### Summary of Changes
Fix markup. Class values should not be included as an attribute.


### Testing Instructions
Go to Content > Media
Edit an image
Click Rotate tab
View page source

`btn btn-outline-secondary` is in the `label` and `input` tags.


### Expected result
```
<label for="jform_rotate_distinct0" class="btn btn-outline-secondary">
				<input type="radio" id="jform_rotate_distinct0" name="jform[rotate_distinct]" value="0" >
				0			</label>
```


### Actual result
```
<label for="jform_rotate_distinct0" class="btn btn-outline-secondary">
				<input type="radio" id="jform_rotate_distinct0" name="jform[rotate_distinct]" value="0" btn btn-outline-secondary>
				0			</label>
```

