### PR TITLE
[4.0] Fix failing sample data installation caused by unset featured_up and featured_down

### DIFF
--- a/administrator/components/com_content/Model/ArticleModel.php
+++ b/administrator/components/com_content/Model/ArticleModel.php
@@ -947,7 +947,12 @@ class ArticleModel extends AdminModel
 		{
 			if (isset($data['featured']))
 			{
-				$this->featured($this->getState($this->getName() . '.id'), $data['featured'], $data['featured_up'], $data['featured_down']);
+				$this->featured(
+					$this->getState($this->getName() . '.id'),
+					$data['featured'],
+					$data['featured_up'] ?? null,
+					$data['featured_down'] ?? null
+				);
 			}
 
 			// Let's check if we have workflow association (perhaps something went wrong before)


### PR DESCRIPTION
Pull Request for Issue #27001 .

### Summary of Changes

Check if featured up and down are set in data before calling the featured routine.

With PR #25979 scheduling of featuring articles has been implemented.

During development of this PR, the 2 new database columns have been moved from table `#__content` to table `#__content_frontpage`. This change introduced errors which obviously have not been noticed when testing that PR. Some other errors caused by this have already been fixed, see e.g. PR #26829 . This PR here fixes another of these errors.

The error happens with blog sample data and testing sample data. But testing sample data needs in addition PR #26392 , so the test of blog sample data is easier and should be sufficient. The error fixed here is the same for both.

### Testing Instructions

1. Install Blog Sample Data and watch the PHP error log (with error reporting set to "maximum" or "development").

2. Edit an article or create a new one, set the featured option to "Yes", and in the fields for feature start and end which appear then, enter some times. Click "save and close" to save the article and close the edit view.

3. Edit the article again which you have edited in step 2. Check if the dates and times entered in step 2 for featured start and end are still the same.

### Expected result

For step 1: No PHP notices.

For step 3: The dates and times are still the same, i.e. they were correctly saved in database. 

### Actual result

For step 1: There are 2 PHP Notices:

> PHP Notice: Undefined index: featured_up in \administrator\components\com_content\Model\ArticleModel.php on line 950
> PHP Notice: Undefined index: featured_down in \administrator\components\com_content\Model\ArticleModel.php on line 950
>

For step 3: See expected result.

### Documentation Changes Required

None.