### PR TITLE
[4.0] Download Keys quick icon could crash the site

### DIFF
--- a/administrator/components/com_installer/Helper/InstallerHelper.php
+++ b/administrator/components/com_installer/Helper/InstallerHelper.php
@@ -160,7 +160,7 @@ class InstallerHelper
 
 		$xmlElement = simplexml_load_file($path);
 
-		return is_object($xmlElement) ? $xmlElement : null;
+		return ($xmlElement !== false) ? $xmlElement : null;
 	}
 
 	/**

--- a/administrator/components/com_installer/Helper/InstallerHelper.php
+++ b/administrator/components/com_installer/Helper/InstallerHelper.php
@@ -130,7 +130,7 @@ class InstallerHelper
 	 */
 	public static function getInstallationXML(string $element, string $type, int $clientId = 1,
 		?string $folder = null
-	): SimpleXMLElement
+	): ?SimpleXMLElement
 	{
 		$path = $clientId ? JPATH_ADMINISTRATOR : JPATH_ROOT;
 
@@ -158,7 +158,9 @@ class InstallerHelper
 				$path = JPATH_ADMINISTRATOR . '/manifests/packages/' . $element . '.xml';
 		}
 
-		return simplexml_load_file($path);
+		$xmlElement = simplexml_load_file($path);
+
+		return is_object($xmlElement) ? $xmlElement : null;
 	}
 
 	/**


### PR DESCRIPTION
### Summary of Changes

If there is a leftover update site from an extension you've removed or, more generally, the extension's XML manifest is no longer present the site breaks because of the Download Keys quick icon plugin. 

The problem is that InstallerHelper::getInstallationXML() calls simplexml_load_file and always expect a SimpleXMLElement object. On load failure the simplexml_load_file function returns false.

Fixed by changing the method signature to expect SimpleXMLElement or null and converting a false result into null. The rest of the core works as-is.

### Testing Instructions

Install an extension with an update site.

Delete its manifest XML file.

### Expected result

The site continues to work.

### Actual result

The site crashes with a PHP error.

### Documentation Changes Required

None.