### PR TITLE
[4.0] Fix search tooltip in modal

### DIFF
--- a/administrator/components/com_associations/tmpl/associations/modal.php
+++ b/administrator/components/com_associations/tmpl/associations/modal.php
@@ -41,127 +41,123 @@ $iconStates = array(
 $this->document->addScriptOptions('assosiations-modal', ['func' => $function]);
 HTMLHelper::_('script', 'com_associations/admin-associations-modal.min.js', ['version' => 'auto', 'relative' => true]);
 ?>
-<form action="<?php echo Route::_('index.php?option=com_associations&view=associations&layout=modal&tmpl=component&function='
-. $function . '&' . Session::getFormToken() . '=1'); ?>" method="post" name="adminForm" id="adminForm">
-	<div class="row">
-		<div class="col-md-12">
-			<div id="j-main-container">
-				<?php echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
-				<?php if (empty($this->items)) : ?>
-					<div class="alert alert-info">
-						<span class="fa fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
-						<?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
-					</div>
-				<?php else : ?>
-					<table class="table" id="associationsList">
-						<caption id="captionTable" class="sr-only">
-							<?php echo Text::_('COM_ASSOCIATIONS_TABLE_CAPTION'); ?>, <?php echo Text::_('JGLOBAL_SORTED_BY'); ?>
-						</caption>
-					<thead>
-						<tr>
-							<?php if (!empty($this->typeSupports['state'])) : ?>
-								<th scope="col" style="width:1%" class="center">
-									<?php echo HTMLHelper::_('searchtools.sort', 'JSTATUS', 'state', $listDirn, $listOrder); ?>
-								</th>
-							<?php endif; ?>
-							<th scope="col">
-								<?php echo HTMLHelper::_('searchtools.sort', 'JGLOBAL_TITLE', 'title', $listDirn, $listOrder); ?>
-							</th>
-							<th scope="col" style="width:15%">
-								<?php echo Text::_('JGRID_HEADING_LANGUAGE'); ?>
-							</th>
-							<th scope="col" style="width:5%">
-								<?php echo HTMLHelper::_('searchtools.sort', 'COM_ASSOCIATIONS_HEADING_ASSOCIATION', 'association', $listDirn, $listOrder); ?>
-							</th>
-							<?php if (!empty($this->typeFields['menutype'])) : ?>
-								<th scope="col" style="width:10%">
-									<?php echo HTMLHelper::_('searchtools.sort', 'COM_ASSOCIATIONS_HEADING_MENUTYPE', 'menutype_title', $listDirn, $listOrder); ?>
-								</th>
-							<?php endif; ?>
-							<?php if (!empty($this->typeSupports['acl'])) : ?>
-								<th scope="col" style="width:5%" class="d-none d-sm-table-cell">
-									<?php echo HTMLHelper::_('searchtools.sort', 'JGRID_HEADING_ACCESS', 'access_level', $listDirn, $listOrder); ?>
-								</th>
-							<?php endif; ?>
-							<th scope="col" style="width:1%" class="d-none d-sm-table-cell">
-								<?php echo HTMLHelper::_('searchtools.sort', 'JGRID_HEADING_ID', 'id', $listDirn, $listOrder); ?>
-							</th>
-						</tr>
-					</thead>
-					<tbody>
-					<?php foreach ($this->items as $i => $item) :
-						$canEdit    = AssociationsHelper::allowEdit($this->extensionName, $this->typeName, $item->id);
-						$canCheckin = $canManageCheckin || AssociationsHelper::canCheckinItem($this->extensionName, $this->typeName, $item->id);
-						$isCheckout = AssociationsHelper::isCheckoutItem($this->extensionName, $this->typeName, $item->id);
-						?>
-						<tr class="row<?php echo $i % 2; ?>">
-							<?php if (!empty($this->typeSupports['state'])) : ?>
-								<td class="text-center tbody-icon">
-									<span class="<?php echo $iconStates[$this->escape($item->state)]; ?>" aria-hidden="true"></span>
-								</td>
-							<?php endif; ?>
-							<th scope="row" class="has-context">
-								<?php if (isset($item->level)) : ?>
-									<?php echo LayoutHelper::render('joomla.html.treeprefix', array('level' => $item->level)); ?>
-								<?php endif; ?>
-								<?php if (($canEdit && !$isCheckout) || ($canEdit && $canCheckin && $isCheckout)) : ?>
-									<a class="select-link" href="javascript:void(0);" data-id="<?php echo $item->id; ?>">
-									<?php echo $this->escape($item->title); ?></a>
-								<?php elseif ($canEdit && $isCheckout) : ?>
-									<?php echo HTMLHelper::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, 'associations.'); ?>
-									<span title="<?php echo Text::sprintf('JFIELD_ALIAS_LABEL', $this->escape($item->alias)); ?>">
-									<?php echo $this->escape($item->title); ?></span>
-								<?php else : ?>
-									<span title="<?php echo Text::sprintf('JFIELD_ALIAS_LABEL', $this->escape($item->alias)); ?>">
-									<?php echo $this->escape($item->title); ?></span>
-								<?php endif; ?>
-								<?php if (!empty($this->typeFields['alias'])) : ?>
-									<span class="small">
-										<?php echo Text::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->alias)); ?>
-									</span>
-								<?php endif; ?>
-								<?php if (!empty($this->typeFields['catid'])) : ?>
-									<div class="small">
-										<?php echo Text::_('JCATEGORY') . ": " . $this->escape($item->category_title); ?>
-									</div>
-								<?php endif; ?>
-							</th>
-							<td class="small">
-								<?php echo LayoutHelper::render('joomla.content.language', $item); ?>
-							</td>
-							<td>
-								<?php if (true || $item->association) : ?>
-									<?php echo AssociationsHelper::getAssociationHtmlList($this->extensionName, $this->typeName, (int) $item->id, $item->language, false, false); ?>
-								<?php endif; ?>
-							</td>
-							<?php if (!empty($this->typeFields['menutype'])) : ?>
-								<td class="small">
-									<?php echo $this->escape($item->menutype_title); ?>
-								</td>
-							<?php endif; ?>
-							<?php if (!empty($this->typeSupports['acl'])) : ?>
-								<td class="small d-none d-sm-table-cell">
-									<?php echo $this->escape($item->access_level); ?>
-								</td>
-							<?php endif; ?>
-							<td class="d-none d-sm-table-cell">
-								<?php echo $item->id; ?>
-							</td>
-						</tr>
-						<?php endforeach; ?>
-					</tbody>
-				</table>
-
-				<?php // load the pagination. ?>
-				<?php echo $this->pagination->getListFooter(); ?>
-
-				<?php endif; ?>
-
-				<input type="hidden" name="task" value="">
-				<input type="hidden" name="forcedItemType" value="<?php echo $app->input->get('forcedItemType', '', 'string'); ?>">
-				<input type="hidden" name="forcedLanguage" value="<?php echo $app->input->get('forcedLanguage', '', 'cmd'); ?>">
-				<?php echo HTMLHelper::_('form.token'); ?>
+<div class="container-popup">
+	<form action="<?php echo Route::_('index.php?option=com_associations&view=associations&layout=modal&tmpl=component&function='
+	. $function . '&' . Session::getFormToken() . '=1'); ?>" method="post" name="adminForm" id="adminForm">
+		<?php echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
+		<?php if (empty($this->items)) : ?>
+			<div class="alert alert-info">
+				<span class="fa fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+				<?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
 			</div>
-		</div>
-	</div>
-</form>
+		<?php else : ?>
+			<table class="table" id="associationsList">
+				<caption id="captionTable" class="sr-only">
+					<?php echo Text::_('COM_ASSOCIATIONS_TABLE_CAPTION'); ?>, <?php echo Text::_('JGLOBAL_SORTED_BY'); ?>
+				</caption>
+			<thead>
+				<tr>
+					<?php if (!empty($this->typeSupports['state'])) : ?>
+						<th scope="col" style="width:1%" class="center">
+							<?php echo HTMLHelper::_('searchtools.sort', 'JSTATUS', 'state', $listDirn, $listOrder); ?>
+						</th>
+					<?php endif; ?>
+					<th scope="col">
+						<?php echo HTMLHelper::_('searchtools.sort', 'JGLOBAL_TITLE', 'title', $listDirn, $listOrder); ?>
+					</th>
+					<th scope="col" style="width:15%">
+						<?php echo Text::_('JGRID_HEADING_LANGUAGE'); ?>
+					</th>
+					<th scope="col" style="width:5%">
+						<?php echo HTMLHelper::_('searchtools.sort', 'COM_ASSOCIATIONS_HEADING_ASSOCIATION', 'association', $listDirn, $listOrder); ?>
+					</th>
+					<?php if (!empty($this->typeFields['menutype'])) : ?>
+						<th scope="col" style="width:10%">
+							<?php echo HTMLHelper::_('searchtools.sort', 'COM_ASSOCIATIONS_HEADING_MENUTYPE', 'menutype_title', $listDirn, $listOrder); ?>
+						</th>
+					<?php endif; ?>
+					<?php if (!empty($this->typeSupports['acl'])) : ?>
+						<th scope="col" style="width:5%" class="d-none d-sm-table-cell">
+							<?php echo HTMLHelper::_('searchtools.sort', 'JGRID_HEADING_ACCESS', 'access_level', $listDirn, $listOrder); ?>
+						</th>
+					<?php endif; ?>
+					<th scope="col" style="width:1%" class="d-none d-sm-table-cell">
+						<?php echo HTMLHelper::_('searchtools.sort', 'JGRID_HEADING_ID', 'id', $listDirn, $listOrder); ?>
+					</th>
+				</tr>
+			</thead>
+			<tbody>
+			<?php foreach ($this->items as $i => $item) :
+				$canEdit    = AssociationsHelper::allowEdit($this->extensionName, $this->typeName, $item->id);
+				$canCheckin = $canManageCheckin || AssociationsHelper::canCheckinItem($this->extensionName, $this->typeName, $item->id);
+				$isCheckout = AssociationsHelper::isCheckoutItem($this->extensionName, $this->typeName, $item->id);
+				?>
+				<tr class="row<?php echo $i % 2; ?>">
+					<?php if (!empty($this->typeSupports['state'])) : ?>
+						<td class="text-center tbody-icon">
+							<span class="<?php echo $iconStates[$this->escape($item->state)]; ?>" aria-hidden="true"></span>
+						</td>
+					<?php endif; ?>
+					<th scope="row" class="has-context">
+						<?php if (isset($item->level)) : ?>
+							<?php echo LayoutHelper::render('joomla.html.treeprefix', array('level' => $item->level)); ?>
+						<?php endif; ?>
+						<?php if (($canEdit && !$isCheckout) || ($canEdit && $canCheckin && $isCheckout)) : ?>
+							<a class="select-link" href="javascript:void(0);" data-id="<?php echo $item->id; ?>">
+							<?php echo $this->escape($item->title); ?></a>
+						<?php elseif ($canEdit && $isCheckout) : ?>
+							<?php echo HTMLHelper::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, 'associations.'); ?>
+							<span title="<?php echo Text::sprintf('JFIELD_ALIAS_LABEL', $this->escape($item->alias)); ?>">
+							<?php echo $this->escape($item->title); ?></span>
+						<?php else : ?>
+							<span title="<?php echo Text::sprintf('JFIELD_ALIAS_LABEL', $this->escape($item->alias)); ?>">
+							<?php echo $this->escape($item->title); ?></span>
+						<?php endif; ?>
+						<?php if (!empty($this->typeFields['alias'])) : ?>
+							<span class="small">
+								<?php echo Text::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->alias)); ?>
+							</span>
+						<?php endif; ?>
+						<?php if (!empty($this->typeFields['catid'])) : ?>
+							<div class="small">
+								<?php echo Text::_('JCATEGORY') . ": " . $this->escape($item->category_title); ?>
+							</div>
+						<?php endif; ?>
+					</th>
+					<td class="small">
+						<?php echo LayoutHelper::render('joomla.content.language', $item); ?>
+					</td>
+					<td>
+						<?php if (true || $item->association) : ?>
+							<?php echo AssociationsHelper::getAssociationHtmlList($this->extensionName, $this->typeName, (int) $item->id, $item->language, false, false); ?>
+						<?php endif; ?>
+					</td>
+					<?php if (!empty($this->typeFields['menutype'])) : ?>
+						<td class="small">
+							<?php echo $this->escape($item->menutype_title); ?>
+						</td>
+					<?php endif; ?>
+					<?php if (!empty($this->typeSupports['acl'])) : ?>
+						<td class="small d-none d-sm-table-cell">
+							<?php echo $this->escape($item->access_level); ?>
+						</td>
+					<?php endif; ?>
+					<td class="d-none d-sm-table-cell">
+						<?php echo $item->id; ?>
+					</td>
+				</tr>
+				<?php endforeach; ?>
+			</tbody>
+		</table>
+
+		<?php // load the pagination. ?>
+		<?php echo $this->pagination->getListFooter(); ?>
+
+		<?php endif; ?>
+
+		<input type="hidden" name="task" value="">
+		<input type="hidden" name="forcedItemType" value="<?php echo $app->input->get('forcedItemType', '', 'string'); ?>">
+		<input type="hidden" name="forcedLanguage" value="<?php echo $app->input->get('forcedLanguage', '', 'cmd'); ?>">
+		<?php echo HTMLHelper::_('form.token'); ?>
+	</form>
+</div

--- a/administrator/components/com_associations/tmpl/associations/modal.php
+++ b/administrator/components/com_associations/tmpl/associations/modal.php
@@ -38,7 +38,7 @@ $iconStates = array(
 	2  => 'icon-archive',
 );
 
-$this->document->addScriptOptions('assosiations-modal', ['func' => $function]);
+$this->document->addScriptOptions('associations-modal', ['func' => $function]);
 HTMLHelper::_('script', 'com_associations/admin-associations-modal.min.js', ['version' => 'auto', 'relative' => true]);
 ?>
 <div class="container-popup">

--- a/administrator/templates/atum/scss/blocks/_form.scss
+++ b/administrator/templates/atum/scss/blocks/_form.scss
@@ -141,10 +141,15 @@ legend {
   bottom: 100%;
 }
 
+.container-popup [id="filter[search]-desc"] {
+  top: 100%;
+  bottom: auto;
+}
+
 .switcher__legend {
-    font-size: $label-font-size;
-    color: var(--atum-special-color);
-    margin-bottom: 0;
+  font-size: $label-font-size;
+  color: var(--atum-special-color);
+  margin-bottom: 0;
 }
 
 [class^="icon-"]:not(.input-group-text),

--- a/administrator/templates/atum/scss/blocks/_global.scss
+++ b/administrator/templates/atum/scss/blocks/_global.scss
@@ -74,7 +74,8 @@ textarea {
   word-wrap: break-word;
 }
 
-.content {
+.content,
+.container-popup {
   font-size: $content-font-size;
 }
 


### PR DESCRIPTION
Pull Request for Issue #26914 #26909 #26906 #26900 #26916 .

### Summary of Changes
Fix display of tooltip in modal.


### Testing Instructions
* Go to the user notes page.
* Click on Users > User Notes
* Click New
* Click on the Select Category option
* Move the cursor in Search text field
* Apply PR
* Run npm i
* Clear browser's cache

Check other modals.


### Expected result
![modal-tooltip](https://user-images.githubusercontent.com/368084/68536062-981b5480-0301-11ea-8d0c-327d9175bf82.jpg)



### Actual result
![modal-tooltip-before](https://user-images.githubusercontent.com/368084/68536070-a79a9d80-0301-11ea-8a00-a3ccc78f4a75.jpg)

