### PR TITLE
[4.0] Deleting unused joomlaupdate strings

### DIFF
--- a/plugins/quickicon/joomlaupdate/Extension/Joomlaupdate.php
+++ b/plugins/quickicon/joomlaupdate/Extension/Joomlaupdate.php
@@ -106,8 +106,6 @@ class Joomlaupdate extends CMSPlugin implements SubscriberInterface
 		}
 
 		Text::script('PLG_QUICKICON_JOOMLAUPDATE_ERROR');
-		Text::script('PLG_QUICKICON_JOOMLAUPDATE_UPDATEFOUND_BUTTON');
-		Text::script('PLG_QUICKICON_JOOMLAUPDATE_UPDATEFOUND_MESSAGE');
 		Text::script('PLG_QUICKICON_JOOMLAUPDATE_UPDATEFOUND');
 		Text::script('PLG_QUICKICON_JOOMLAUPDATE_UPTODATE');
 		Text::script('MESSAGE');


### PR DESCRIPTION
### Summary of Changes 
Lang strings not used anymore in J4 appear as untranslated when debug lang is on.


### Testing Instructions
Set debug lang in Global Config. Show untranslated strings.

PLG_QUICKICON_JOOMLAUPDATE_UPDATEFOUND_BUTTON
PLG_QUICKICON_JOOMLAUPDATE_UPDATEFOUND_MESSAGE

display as untranslated.

patch and look again
