### PR TITLE
[4.0] Fix com_privacy prepared statements

### DIFF
--- a/administrator/components/com_privacy/Model/ExportModel.php
+++ b/administrator/components/com_privacy/Model/ExportModel.php
@@ -85,7 +85,7 @@ class ExportModel extends BaseDatabaseModel
 				->select($db->quoteName('id'))
 				->from($db->quoteName('#__users'))
 				->where($db->quoteName('email') . ' = :email')
-				->bind(':email', $table->email),
+				->bind(':email', $table->email)
 				->setLimit(1)
 		)->loadResult();
 

--- a/administrator/components/com_privacy/Model/RemoveModel.php
+++ b/administrator/components/com_privacy/Model/RemoveModel.php
@@ -81,7 +81,7 @@ class RemoveModel extends BaseDatabaseModel
 				->select($db->quoteName('id'))
 				->from($db->quoteName('#__users'))
 				->where($db->quoteName('email') . ' = :email')
-				->bind(':email', $table->email),
+				->bind(':email', $table->email)
 				->setLimit(1)
 		)->loadResult();
 

--- a/administrator/components/com_privacy/Model/RequestModel.php
+++ b/administrator/components/com_privacy/Model/RequestModel.php
@@ -266,7 +266,7 @@ class RequestModel extends AdminModel
 				->select($db->quoteName('id'))
 				->from($db->quoteName('#__users'))
 				->where($db->quoteName('email') . ' = :email')
-				->bind(':email', $table->email),
+				->bind(':email', $table->email)
 				->setLimit(1)
 		)->loadResult();
 


### PR DESCRIPTION
Pull Request for Issue [https://github.com/joomla/joomla-cms/pull/26017#issuecomment-552189613](https://github.com/joomla/joomla-cms/pull/26017#issuecomment-552189613).

### Summary of Changes

Corrects PHP syntax error coming from merge conflicts between PR #26017 and #26407 .

### Testing Instructions

1. Make a new installation with current 4.0-dev. Don't use any recent alpla release or nightly build, those will not contain the error.
2. Go to "Users -> Privacy -> Requests" and click the "New" button to create a new request.
Result: See section "Actual result" below.
3. Go back to the control panel.
4. Apply the changes in this PR.
5. Go to "Users -> Privacy -> Requests" and click the "New" button to create a new request.
Result: See section "Expected result" below.

This PR fixes the same error at 2 other places, too:
- Exporting privacy requests to CSV,
- Removing privacy requests.

These fixes can be tested in the same way, but code review should be sufficient.

### Expected result

![privacy-request-ok-1](https://user-images.githubusercontent.com/7413183/68544098-e42cce80-03bf-11ea-8d1b-597fe356c10f.png)

### Actual result

![privacy-request-error-1](https://user-images.githubusercontent.com/7413183/68544102-eb53dc80-03bf-11ea-99b8-15aa90359a2a.png)

### Documentation Changes Required

None.