### PR TITLE
[4.0] Update core extensions list in extension helper

### DIFF
--- a/libraries/src/Extension/ExtensionHelper.php
+++ b/libraries/src/Extension/ExtensionHelper.php
@@ -67,7 +67,8 @@ class ExtensionHelper
 		array('component', 'com_joomlaupdate', '', 1),
 		array('component', 'com_languages', '', 1),
 		array('component', 'com_login', '', 1),
-		array('component', 'com_mailto', '', 0),
+		array('component', 'com_mails', '', 1),
+		array('component', 'com_mailto', '', 1),
 		array('component', 'com_media', '', 1),
 		array('component', 'com_menus', '', 1),
 		array('component', 'com_messages', '', 1),
@@ -81,7 +82,7 @@ class ExtensionHelper
 		array('component', 'com_templates', '', 1),
 		array('component', 'com_users', '', 1),
 		array('component', 'com_workflow', '', 1),
-		array('component', 'com_wrapper', '', 0),
+		array('component', 'com_wrapper', '', 1),
 
 		// Core file extensions
 		array('file', 'joomla', '', 0),


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Add missing mail templates extension `com_mails` to the list of core extensions in ExtensionHelper.

Change client_id from 0 to 1 for `com_mailto` and `com_wrapper` as it was changed for J4 in database with commit [https://github.com/joomla/joomla-cms/commit/024d943c104f6a489403d42fcdf12590960a6673](https://github.com/joomla/joomla-cms/commit/024d943c104f6a489403d42fcdf12590960a6673).

### Testing Instructions

Code review: Verify that the changes are consistent with the corresponding records in the `#__extensions` table in database.

For `com_mails` (Mail Templates): Go to Manage -> Extensions in backend, filter by core extensions and check if "Mail Templates" is shown, then filter by non-core extensions and check the same.

### Expected result

`com_mails` is a core extension and shown when filtering in backend in extension list for core extensions. It is not shown when filtering for non-core extensions.

### Actual result

`com_mails` is a core extension, but it is not shown when filtering in backend in extension list for core extensions, it is shown when filtering for non-core extensions.

### Documentation Changes Required

None.