### PR TITLE
[4.0] Menus preset should include Custom Administrator Menus

### DIFF
--- a/administrator/components/com_menus/presets/menus.xml
+++ b/administrator/components/com_menus/presets/menus.xml
@@ -58,19 +58,21 @@
 	<menuitem
 		type="separator"
 		title="JADMINISTRATOR"
+		icon="desktop"
 		hidden="false"
 		sql_select="title, menutype"
 		sql_from="#__menu_types"
 		sql_where="client_id = 1"
 		sql_order="id DESC"
+		sql_target="self"
 		>
 		<menuitem
 			title="{sql:title}"
 			type="component"
 			element="com_menus"
 			link="index.php?option=com_menus&amp;view=items&amp;menutype={sql:menutype}"
-			icon="{sql:icon}"
 			class="class:menu"
+			quicktask="index.php?option=com_menus&amp;task=item.add&amp;client_id=1&amp;menutype={sql:menutype}"
 		/>
 	</menuitem>
 </menu>


### PR DESCRIPTION
### Summary of Changes 
As title says. There is no reason to not include these in the dashboard.
Correcting useless `icon="{sql:icon}"` which is certainly due to a copypaste and lack of real test.
Note: that last one will also have to be deleted from alternate and default preset for Adminitrator menuitem (will be another PR).

### Testing Instructions
Create a custom admin menu.
It will now display. Here its title is `myown menu`

<img width="289" alt="Screen Shot 2019-11-13 at 09 51 04" src="https://user-images.githubusercontent.com/869724/68748018-f72be280-05fb-11ea-8fa1-976b19da7d76.png">

Get the Menus Dashboard 
`administrator/index.php?option=com_cpanel&view=cpanel&dashboard=menus`

### Before patch

<img width="1576" alt="Screen Shot 2019-11-13 at 10 03 05" src="https://user-images.githubusercontent.com/869724/68748516-dadc7580-05fc-11ea-9b20-416d5e9d61e8.png">



### After patch


<img width="643" alt="Screen Shot 2019-11-13 at 09 44 48" src="https://user-images.githubusercontent.com/869724/68748326-876a2780-05fc-11ea-8682-dc659ab0e21b.png">
