### PR TITLE
[4.0] Replace "hidden" class with "d-none"

### DIFF
--- a/administrator/components/com_modules/tmpl/module/modal.php
+++ b/administrator/components/com_modules/tmpl/module/modal.php
@@ -10,9 +10,9 @@
 defined('_JEXEC') or die;
 
 ?>
-<button id="applyBtn" type="button" class="hidden" onclick="Joomla.submitbutton('module.apply');"></button>
-<button id="saveBtn" type="button" class="hidden" onclick="Joomla.submitbutton('module.save');"></button>
-<button id="closeBtn" type="button" class="hidden" onclick="Joomla.submitbutton('module.cancel');"></button>
+<button id="applyBtn" type="button" class="d-none" onclick="Joomla.submitbutton('module.apply');"></button>
+<button id="saveBtn" type="button" class="d-none" onclick="Joomla.submitbutton('module.save');"></button>
+<button id="closeBtn" type="button" class="d-none" onclick="Joomla.submitbutton('module.cancel');"></button>
 
 <div class="container-popup">
 	<?php $this->setLayout('edit'); ?>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Simple change is classes. Both do exactly the same.

Not sure why there is a duplicate class that does exactly the same and also has a pointless `visibility: hidden;` when `display:none` will supersede and replace the allocated space.

### Testing Instructions

Code review
