### PR TITLE
[4.0] Fix language files deleted before uninstall execution

### DIFF
--- a/libraries/src/Installer/Adapter/ComponentAdapter.php
+++ b/libraries/src/Installer/Adapter/ComponentAdapter.php
@@ -851,7 +851,7 @@ class ComponentAdapter extends InstallerAdapter
 		}
 
 		// Attempt to load the admin language file; might have uninstall strings
-		$this->loadLanguage(JPATH_ADMINISTRATOR . '/components/' . $this->element);
+		$this->loadLanguage(JPATH_ADMINISTRATOR . '/components/' . $this->extension->element);
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue #17931.

### Summary of Changes
Use right property.


### Testing Instructions
Uninstall an extension on Joomla 4


### Expected result
The script file is executed and the function 'uninstall' is called inside the class com_xxxxInstallerScript, when the function 'uninstall' is called it's still possible to use JText::_('...'); loading language files included under the component folder such as:
Joomla40/administrator/components/com_xxx/language/en-GB/en-GB.com_xxx.ini


### Actual result
Files are already deleted at this stage compared to the current Joomla 3 and Joomla 2.5
Thus the JText won't translate strings anymore because it's no more possible to load language files already deleted. It works only if the component was using language files under:
Joomla40/administrator/language/en-GB/en-GB.com_xxx.ini
