### PR TITLE
[4.0] Fix Contact Creator plugin

### DIFF
--- a/plugins/user/contactcreator/contactcreator.php
+++ b/plugins/user/contactcreator/contactcreator.php
@@ -178,17 +178,12 @@ class PlgUserContactCreator extends CMSPlugin
 	/**
 	 * Get an instance of the contact table
 	 *
-	 * @return  ContactTable|false
+	 * @return  ContactTable|null
 	 *
 	 * @since   3.2.3
 	 */
 	protected function getContactTable()
 	{
-		if (!class_exists(ContactTable::class))
-		{
-			return false;
-		}
-
-		return new ContactTable($this->db);
+		return $this->app->bootComponent('com_contact')->getMVCFactory()->createTable('Contact', 'Administrator', ['dbo' => $this->db]);
 	}
 }

--- a/plugins/user/contactcreator/contactcreator.php
+++ b/plugins/user/contactcreator/contactcreator.php
@@ -12,6 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\CMS\Table\Table;
+use Joomla\Component\Contact\Administrator\Table\ContactTable;
 use Joomla\String\StringHelper;
 
 /**
@@ -32,12 +33,20 @@ class PlgUserContactCreator extends CMSPlugin
 	protected $autoloadLanguage = true;
 
 	/**
-	 * Application object
+	 * Application Instance
 	 *
 	 * @var    \Joomla\CMS\Application\CMSApplication
 	 * @since  __DEPLOY_VERSION__
 	 */
 	protected $app;
+
+	/**
+	 * Database Driver Instance
+	 *
+	 * @var    \Joomla\Database\DatabaseDriver
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $db;
 
 	/**
 	 * Utility method to act on a user after it has been saved.
@@ -169,12 +178,17 @@ class PlgUserContactCreator extends CMSPlugin
 	/**
 	 * Get an instance of the contact table
 	 *
-	 * @return  \Joomla\Component\Contact\Administrator\Table\ContactTable|false
+	 * @return  ContactTable|false
 	 *
 	 * @since   3.2.3
 	 */
 	protected function getContactTable()
 	{
-		return Table::getInstance('ContactTable', '\\Joomla\\Component\\Contact\\Administrator\\Table\\');
+		if (!class_exists(ContactTable::class))
+		{
+			return false;
+		}
+
+		return new ContactTable($this->db);
 	}
 }

--- a/plugins/user/contactcreator/contactcreator.php
+++ b/plugins/user/contactcreator/contactcreator.php
@@ -162,14 +162,12 @@ class PlgUserContactCreator extends CMSPlugin
 	/**
 	 * Get an instance of the contact table
 	 *
-	 * @return  ContactTableContact
+	 * @return  \Joomla\Component\Contact\Administrator\Table\ContactTable|false
 	 *
 	 * @since   3.2.3
 	 */
 	protected function getContactTable()
 	{
-		Table::addIncludePath(JPATH_ADMINISTRATOR . '/components/com_contact/tables');
-
-		return Table::getInstance('contact', 'ContactTable');
+		return Table::getInstance('ContactTable', '\\Joomla\\Component\\Contact\\Administrator\\Table\\');
 	}
 }

--- a/plugins/user/contactcreator/contactcreator.php
+++ b/plugins/user/contactcreator/contactcreator.php
@@ -9,7 +9,6 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\CMS\Table\Table;
@@ -31,6 +30,14 @@ class PlgUserContactCreator extends CMSPlugin
 	 * @since  3.1
 	 */
 	protected $autoloadLanguage = true;
+
+	/**
+	 * Application object
+	 *
+	 * @var    \Joomla\CMS\Application\CMSApplication
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $app;
 
 	/**
 	 * Utility method to act on a user after it has been saved.
@@ -73,7 +80,7 @@ class PlgUserContactCreator extends CMSPlugin
 
 		if (empty($categoryId))
 		{
-			Factory::getApplication()->enqueueMessage(Text::_('PLG_CONTACTCREATOR_ERR_NO_CATEGORY'), 'error');
+			$this->app->enqueueMessage(Text::_('PLG_CONTACTCREATOR_ERR_NO_CATEGORY'), 'error');
 
 			return false;
 		}
@@ -93,7 +100,7 @@ class PlgUserContactCreator extends CMSPlugin
 			$contact->user_id  = $user_id;
 			$contact->email_to = $user['email'];
 			$contact->catid    = $categoryId;
-			$contact->access   = (int) Factory::getApplication()->get('access');
+			$contact->access   = (int) $this->app->get('access');
 			$contact->language = '*';
 			$contact->generateAlias();
 
@@ -126,7 +133,7 @@ class PlgUserContactCreator extends CMSPlugin
 			}
 		}
 
-		Factory::getApplication()->enqueueMessage(Text::_('PLG_CONTACTCREATOR_ERR_FAILED_CREATING_CONTACT'), 'error');
+		$this->app->enqueueMessage(Text::_('PLG_CONTACTCREATOR_ERR_FAILED_CREATING_CONTACT'), 'error');
 
 		return false;
 	}


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Corrects table path.

### Testing Instructions

Enable `User - Contact Creator` plugin.
Create a user in backend.

### Expected result

User and associated contact created.

### Actual result

User created but creating contact fails:

>Automatic contact creation failed. Please contact a site administrator.

### Documentation Changes Required

No.