### PR TITLE
[4.0][a11y] Fix 'High Contrast' option - currently inverts

### DIFF
--- a/administrator/templates/atum/scss/blocks/_global.scss
+++ b/administrator/templates/atum/scss/blocks/_global.scss
@@ -18,7 +18,7 @@ body {
     filter: grayscale(1);
   }
   &.a11y_contrast {
-    filter: invert(100%);
+    filter: contrast(115%);
   }
   &.a11y_highlight {
     a {


### PR DESCRIPTION
Pull Request for Issue #27112 .

### Summary of Changes
Currently, the 'High Contrast' option inverts the colors instead of increasing contrast. This PR fixes that


### Testing Instructions
Navigate to User Menu -> Accessibility Settings. Apply High Contrast option.


### Before PR
![image](https://user-images.githubusercontent.com/2803503/69499870-7075e000-0eee-11ea-9eb5-9d8f51316356.png)



### With PR
![image](https://user-images.githubusercontent.com/2803503/69499864-65bb4b00-0eee-11ea-8dd1-476ecf8f400b.png)



### Documentation Changes Required

