### PR TITLE
Allow JSON Document caching

### DIFF
--- a/components/com_ajax/ajax.php
+++ b/components/com_ajax/ajax.php
@@ -18,8 +18,9 @@ defined('_JEXEC') or die;
  * - https://groups.google.com/d/msg/joomla-dev-cms/WsC0nA9Fixo/Ur-gPqpqh-EJ
  */
 
-// Reference global application object
+/** @var \Joomla\CMS\Application\CMSApplication $app */
 $app = JFactory::getApplication();
+$app->allowCache(false);
 
 // JInput object
 $input = $app->input;

--- a/components/com_config/controller/display.php
+++ b/components/com_config/controller/display.php
@@ -106,6 +106,7 @@ class ConfigControllerDisplay extends JControllerBase
 			// Reply for service requests
 			if ($viewFormat === 'json')
 			{
+				$this->app->allowCache(false);
 				return $view->render();
 			}
 

--- a/components/com_finder/controllers/suggestions.json.php
+++ b/components/com_finder/controllers/suggestions.json.php
@@ -25,8 +25,12 @@ class FinderControllerSuggestions extends JControllerLegacy
 	 */
 	public function suggest()
 	{
+		/** @var \Joomla\CMS\Application\CMSApplication $app */
 		$app = JFactory::getApplication();
 		$app->mimeType = 'application/json';
+
+		// Ensure caching is disabled as it depends on the query param in the model
+		$app->allowCache(false);
 
 		$suggestions = $this->getSuggestions();
 
@@ -50,8 +54,12 @@ class FinderControllerSuggestions extends JControllerLegacy
 	 */
 	public function display($cachable = false, $urlparams = false)
 	{
+		/** @var \Joomla\CMS\Application\CMSApplication $app */
 		$app = JFactory::getApplication();
 		$app->mimeType = 'application/json';
+
+		// Ensure caching is disabled as it depends on the query param in the model
+		$app->allowCache(false);
 
 		$suggestions = $this->getSuggestions();
 

--- a/libraries/src/Document/ErrorDocument.php
+++ b/libraries/src/Document/ErrorDocument.php
@@ -174,7 +174,7 @@ class ErrorDocument extends Document
 		// Load
 		$data = $this->_loadTemplate($directory . '/' . $template, $file);
 
-		parent::render();
+		parent::render($cache, $params);
 
 		return $data;
 	}

--- a/libraries/src/Document/FeedDocument.php
+++ b/libraries/src/Document/FeedDocument.php
@@ -222,7 +222,7 @@ class FeedDocument extends Document
 		// Render the feed
 		$data .= $renderer->render();
 
-		parent::render();
+		parent::render($cache, $params);
 
 		return $data;
 	}

--- a/libraries/src/Document/HtmlDocument.php
+++ b/libraries/src/Document/HtmlDocument.php
@@ -555,7 +555,7 @@ class HtmlDocument extends Document
 		}
 
 		$data = $this->_renderTemplate();
-		parent::render();
+		parent::render($caching, $params);
 
 		return $data;
 	}

--- a/libraries/src/Document/ImageDocument.php
+++ b/libraries/src/Document/ImageDocument.php
@@ -67,7 +67,7 @@ class ImageDocument extends Document
 
 		$this->_charset = null;
 
-		parent::render();
+		parent::render($cache, $params);
 
 		return $this->getBuffer();
 	}

--- a/libraries/src/Document/JsonDocument.php
+++ b/libraries/src/Document/JsonDocument.php
@@ -66,9 +66,10 @@ class JsonDocument extends Document
 	 */
 	public function render($cache = false, $params = array())
 	{
+		/** @var \Joomla\CMS\Application\CMSApplication $app **/
 		$app = \JFactory::getApplication();
 
-		$app->allowCache(false);
+		$app->allowCache($cache);
 
 		if ($this->_mime == 'application/json')
 		{
@@ -76,7 +77,7 @@ class JsonDocument extends Document
 			$app->setHeader('Content-Disposition', 'attachment; filename="' . $this->getName() . '.json"', true);
 		}
 
-		parent::render();
+		parent::render($cache, $params);
 
 		return $this->getBuffer();
 	}

--- a/libraries/src/Document/OpensearchDocument.php
+++ b/libraries/src/Document/OpensearchDocument.php
@@ -176,7 +176,7 @@ class OpensearchDocument extends Document
 		}
 
 		$xml->appendChild($elOs);
-		parent::render();
+		parent::render($cache, $params);
 
 		return $xml->saveXml();
 	}

--- a/libraries/src/Document/RawDocument.php
+++ b/libraries/src/Document/RawDocument.php
@@ -47,7 +47,7 @@ class RawDocument extends Document
 	 */
 	public function render($cache = false, $params = array())
 	{
-		parent::render();
+		parent::render($cache, $params);
 
 		return $this->getBuffer();
 	}

--- a/libraries/src/Document/XmlDocument.php
+++ b/libraries/src/Document/XmlDocument.php
@@ -63,7 +63,7 @@ class XmlDocument extends Document
 	 */
 	public function render($cache = false, $params = array())
 	{
-		parent::render();
+		parent::render($cache, $params);
 
 		$disposition = $this->isDownload ? 'attachment' : 'inline';
 


### PR DESCRIPTION
# Summary of Changes
Allows the caching of JSON Documents if something requests it. In webservice custom applications  (e.g. the Joomla Downloads Site) this is an important optimisation (and will be required in J4 whether accepted in j3 or not)

In order to keep behaviour I've ensured that both com_config and com_finder do not cache the response under any circumstance

### Testing Instructions
N/A - There's no change in behaviour for core components. Ensure finder works the same before and after patch

### Documentation Changes Required
JSON Responses can be cached
