### PR TITLE
[4.0] Fix dropdown icon from disappearing when changing article state

### DIFF
--- a/layouts/joomla/button/transition-button.php
+++ b/layouts/joomla/button/transition-button.php
@@ -63,7 +63,7 @@ $checkboxName = $options['checkbox_name'];
 			$attribs = [
 				'id'        => 'transition-select_' . (int) $id,
 				'list.attr' => [
-					'class'    => 'custom-select custom-select-sm form-control form-control-sm',
+					'class'    => 'custom-select custom-select-sm w-auto',
 					'onchange' => "Joomla.listItemTask('" . $checkboxName . $this->escape($row ?? '') . "', 'articles.runTransition')"]
 				];
 


### PR DESCRIPTION
Pull Request for Issue #26705.

### Summary of Changes
When changing the article state, fix dropdown icon from disappearing.


### Testing Instructions

* Go to Articles.
* Click on Published icon, then open the dropdown icon disappears.



### Expected result

![67145869-d4c7d300-f2a2-11e9-9b0e-2168ba23f5cd](https://user-images.githubusercontent.com/368084/69681995-d1272900-1064-11ea-8805-e0c63ba484b9.png)


### Actual result

![67145892-18224180-f2a3-11e9-8e60-f22ac79ff4bd](https://user-images.githubusercontent.com/368084/69682004-da17fa80-1064-11ea-8d7b-cead625423bd.png)


