### PR TITLE
[4.0] Fixing multilingual sample data en-GB items creation

### DIFF
--- a/plugins/sampledata/multilang/multilang.php
+++ b/plugins/sampledata/multilang/multilang.php
@@ -1249,7 +1249,13 @@ class PlgSampledataMultilang extends CMSPlugin
 
 		foreach ($langlist as $lang)
 		{
-			$file          = $path . '/' . $lang . '/' . $lang . '.xml';
+			$file = $path . '/' . $lang . '/' . $lang . '.xml';
+
+			if (!is_file($file))
+			{
+				$file = $path . '/' . $lang . '/langmetadata.xml';
+			}
+
 			$info          = Installer::parseXMLInstallFile($file);
 			$row           = new stdClass;
 			$row->language = $lang;


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/pull/27111#issuecomment-559591782 (towards end of post)

### Summary of Changes
Since en-GB lang files have been renamed without the lang prefix, getting installed en-GB language was impossible in the plugin as it was not looking also for the `langmetadata.xml` file.


### Testing Instructions
Install a clean joomla and patch.
Make sure you install some languages (fr-FR, de-DE, fa-IR)
Install multingual sample data via the module in CPanel.

### Before patch
The en-GB items were not created.

### After patch
All is fine.

@richard67 