### PR TITLE
[4.0] Remove redundant array element

### DIFF
--- a/layouts/joomla/form/field/radio/switcher.php
+++ b/layouts/joomla/form/field/radio/switcher.php
@@ -73,7 +73,7 @@ $input    = '<input type="radio" id="%1$s" name="%2$s" value="%3$s" %4$s>';
 		$active		= ((string) $option->value == $value) ? 'class="active"' : '';
 		$oid		= $id . $i;
 		$ovalue		= htmlspecialchars($option->value, ENT_COMPAT, 'UTF-8');
-		$attributes	= array_filter(array($checked, $active, null));
+		$attributes	= array_filter([$checked, $active]);
 		$text		= $options[$i]->text;
 		?>
 		<?php echo sprintf($input, $oid, $name, $ovalue, implode(' ', $attributes)); ?>


### PR DESCRIPTION
### Summary of Changes

Simple change to remove hardcoded null value which gets filtered out by `array_filter()`.

### Testing Instructions

Code review.

### Documentation Changes Required

No.