### PR TITLE
[4.0] Remove duplicate buttons in installation

### DIFF
--- a/installation/tmpl/remove/default.php
+++ b/installation/tmpl/remove/default.php
@@ -187,10 +187,6 @@ use Joomla\CMS\Uri\Uri;
 			</legend>
 			<div class="j-install-step-form">
 				<p><?php echo Text::_('INSTL_COMPLETE_FINAL_DESC'); ?></p>
-				<div class="form-group">
-					<a class="btn btn-primary btn-block" href="<?php echo Uri::root(); ?>"><span class="fa fa-eye" aria-hidden="true"></span> <?php echo Text::_('INSTL_COMPLETE_SITE_BTN'); ?></a>
-					<a class="btn btn-primary btn-block" href="<?php echo Uri::root(); ?>administrator/"><span class="fa fa-lock" aria-hidden="true"></span> <?php echo Text::_('INSTL_COMPLETE_ADMIN_BTN'); ?></a>
-				</div>
 			</div>
 		</fieldset>
 


### PR DESCRIPTION
Pull Request for Issue #26412.

### Summary of Changes
After customizing installation, there are duplicate buttons. Remove duplicate buttons.


### Testing Instructions
Apply PR.
Reinstall.
Customize installation.
Click Skip button.


### Expected result
![26412PR](https://user-images.githubusercontent.com/368084/69905905-ae03be80-136f-11ea-9bc0-e85f48cf83d4.jpg)


### Actual result
![26412](https://user-images.githubusercontent.com/368084/69905877-43eb1980-136f-11ea-99ad-e664fa283d1e.jpg)





