### PR TITLE
[4.0] Change plugin statistics popup to be alertdialog

### DIFF
--- a/plugins/system/stats/layouts/message.php
+++ b/plugins/system/stats/layouts/message.php
@@ -22,7 +22,7 @@ extract($displayData);
  */
 ?>
 
-<joomla-alert type="info" dismiss="true" class="js-pstats-alert" style="display:none;">
+<joomla-alert type="info" dismiss="true" class="js-pstats-alert" style="display:none;" role="alertdialog">
 	<div class="alert-heading"><?php echo Text::_('PLG_SYSTEM_STATS_LABEL_MESSAGE_TITLE'); ?></div>
 	<div>
 		<p>


### PR DESCRIPTION
Pull Request for Issue #22507 .

### Summary of Changes
The plugin statistics popup should not have a `role=alert` as this role does not allow for a response by the user, instead it should have a `role=alertdialog`.


### Testing Instructions
Enable `System - Joomla! Statistics` plugin.
View markup of the popup.
See `role="alert"`.
Apply PR.
See `role="alertdialog"`.
