### PR TITLE
Add PHP 7.4 to PHP version check

### DIFF
--- a/plugins/quickicon/phpversioncheck/phpversioncheck.php
+++ b/plugins/quickicon/phpversioncheck/phpversioncheck.php
@@ -137,6 +137,10 @@ class PlgQuickiconPhpVersionCheck extends JPlugin
 				'security' => '2020-12-06',
 				'eos'      => '2021-12-06',
 			),
+			'7.4' => array(
+				'security' => '2021-11-28',
+				'eos'      => '2022-11-28',
+			),
 		);
 
 		// Fill our return array with default values


### PR DESCRIPTION
### Summary of Changes

PHP 7.4 was released.  Its support dates should be included in the plugin determining when to start showing nag messages.

### Testing Instructions

Make sure there are no parse errors introduced.  Or invent a time machine and apply this patch 3 years in the future.

### Expected result

PHP 7.4 EOL is known by the version check plugin.

### Actual result

PHP 7.4 EOL is not known by the version check plugin.

### Documentation Changes Required

Make sure someone knows to update this next year 😉 