### PR TITLE
[com_banners] Remove onchange submit from calendar fields

### DIFF
--- a/administrator/components/com_banners/models/forms/filter_tracks.xml
+++ b/administrator/components/com_banners/models/forms/filter_tracks.xml
@@ -64,7 +64,6 @@
 			format="%Y-%m-%d"
 			size="10"
 			filter="user_utc"
-			onchange="this.form.submit();"
 		/>
 
 		<field
@@ -76,7 +75,6 @@
 			format="%Y-%m-%d"
 			size="10"
 			filter="user_utc"
-			onchange="this.form.submit();"
 		/>
     </fields>
 	<fields name="list">


### PR DESCRIPTION
Fixes https://github.com/joomla/joomla-cms/issues/26738.

### Summary of Changes

Removes form submit onchange when selecting date in calendar field.

### Testing Instructions

Go to Banners -> Tracks.
Click on Search Tools.
Try to select date in Begin date and End date fields.

### Expected result

Being able to use calendar field normally.

### Actual result

Not being able to use calendar field normally because form keeps submitting.

### Documentation Changes Required

No.