### PR TITLE
[4.0][com_menu] fix blank space in menu type

### DIFF
--- a/administrator/components/com_menus/Controller/MenuController.php
+++ b/administrator/components/com_menus/Controller/MenuController.php
@@ -72,7 +72,7 @@ class MenuController extends FormController
 		}
 
 		$data['menutype'] = InputFilter::getInstance()->clean($data['menutype'], 'TRIM');
-		
+
 		// Populate the row id from the session.
 		$data['id'] = $recordId;
 

--- a/administrator/components/com_menus/Controller/MenuController.php
+++ b/administrator/components/com_menus/Controller/MenuController.php
@@ -11,8 +11,8 @@ namespace Joomla\Component\Menus\Administrator\Controller;
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\Language\Text;
 use Joomla\CMS\Filter\InputFilter;
+use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Controller\FormController;
 use Joomla\CMS\Router\Route;
 use Joomla\Component\Menus\Administrator\Helper\MenusHelper;

--- a/administrator/components/com_menus/Controller/MenuController.php
+++ b/administrator/components/com_menus/Controller/MenuController.php
@@ -12,6 +12,7 @@ namespace Joomla\Component\Menus\Administrator\Controller;
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\MVC\Controller\FormController;
 use Joomla\CMS\Router\Route;
 use Joomla\Component\Menus\Administrator\Helper\MenusHelper;
@@ -70,6 +71,8 @@ class MenuController extends FormController
 			return false;
 		}
 
+		$data['menutype'] = InputFilter::getInstance()->clean($data['menutype'], 'TRIM');
+		
 		// Populate the row id from the session.
 		$data['id'] = $recordId;
 


### PR DESCRIPTION
Pull Request for Issue #26948 .

### Summary of Changes
credit to @infograf768 
added trim filter
https://github.com/joomla/joomla-cms/issues/26948#issuecomment-549110826

### Testing Instructions

1. Go to Menu -> Create menu.
2. Add Title.
3. Add blank space in the Unique Name field.
4. Click on the Save button.


### Expected result
 Field required: Unique Name


### Actual result
Menu Type empty


