### PR TITLE
Fix language debug on multilingual sites

### DIFF
--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -489,7 +489,7 @@ class PlgSystemLanguageFilter extends JPlugin
 
 		if ($language->getTag() !== $lang_code)
 		{
-			$language_new = JLanguage::getInstance($lang_code);
+			$language_new = JLanguage::getInstance($lang_code, (bool) $this->app->get('debug_lang'));
 
 			foreach ($language->getPaths() as $extension => $files)
 			{


### PR DESCRIPTION
### Summary of Changes

Pass language debug setting to new language instance.

### Testing Instructions

Set up a multilingual site.
Enable `Debug Language` option in Global Configuration.
View frontend in any language other than default.

### Expected result

Language debug working, i.e. translatable strings are wrapped with `**`.

### Actual result

Language debug not working.

### Documentation Changes Required

No.