### PR TITLE
[4.0] Correct implode() argument order

### DIFF
--- a/layouts/joomla/form/field/moduleorder.php
+++ b/layouts/joomla/form/field/moduleorder.php
@@ -78,4 +78,4 @@ if ($onchange)
 
 HTMLHelper::_('webcomponent', 'system/fields/joomla-field-module-order.min.js', ['version' => 'auto', 'relative' => true]);
 ?>
-<joomla-field-module-order <?php echo implode($attributes, ' '); ?>></joomla-field-module-order>
+<joomla-field-module-order <?php echo implode(' ', $attributes); ?>></joomla-field-module-order>


### PR DESCRIPTION
### Summary of Changes

Changes `implode()` argument order to solve deprecation messages in PHP 7.4:

>Deprecated: implode(): Passing glue string after array is deprecated.

### Testing Instructions

Code review.

### Documentation Changes Required

No.