### PR TITLE
MySql 8 EXPLAIN syntax

### DIFF
--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -1533,6 +1533,12 @@ class PlgSystemDebug extends JPlugin
 			foreach ($log as $k => $query)
 			{
 				$dbVersion56 = $db->getServerType() === 'mysql' && version_compare($db->getVersion(), '5.6', '>=');
+				$dbVersion80 = $db->getServerType() === 'mysql' && version_compare($db->getVersion(), '8.0', '>=');
+
+				if ($dbVersion80)
+				{
+					$dbVersion56 = false; 
+				}
 
 				if ((stripos($query, 'select') === 0) || ($dbVersion56 && ((stripos($query, 'delete') === 0) || (stripos($query, 'update') === 0))))
 				{


### PR DESCRIPTION
Pull Request for Issue #27217 .

### Summary of Changes

used correct syntax for EXPLAIN if mysql8  (no EXTEND)
https://dev.mysql.com/doc/refman/8.0/en/explain.html

### Testing Instructions
On a server with mysql 8 enable debug
Check the debug queries output


### Expected result
no false errors


### Actual result
false errors



