### PR TITLE
Fix Notice on Joomla update with PHP 7.4

### DIFF
--- a/administrator/components/com_joomlaupdate/views/default/view.html.php
+++ b/administrator/components/com_joomlaupdate/views/default/view.html.php
@@ -63,7 +63,7 @@ class JoomlaupdateViewDefault extends JViewLegacy
 		$this->loadHelper('select');
 
 		// Assign view variables.
-		$this->ftp           = $model->getFTPOptions();
+		$this->ftp     = $model->getFTPOptions();
 		$defaultMethod = $this->ftp['enabled'] ? 'hybrid' : 'direct';
 
 		$this->updateInfo         = $model->getUpdateInformation();

--- a/administrator/components/com_joomlaupdate/views/default/view.html.php
+++ b/administrator/components/com_joomlaupdate/views/default/view.html.php
@@ -63,8 +63,8 @@ class JoomlaupdateViewDefault extends JViewLegacy
 		$this->loadHelper('select');
 
 		// Assign view variables.
-		$ftp           = $model->getFTPOptions();
-		$defaultMethod = $ftp['enabled'] ? 'hybrid' : 'direct';
+		$this->ftp           = $model->getFTPOptions();
+		$defaultMethod = $this->ftp['enabled'] ? 'hybrid' : 'direct';
 
 		$this->updateInfo         = $model->getUpdateInformation();
 		$this->methodSelect       = JoomlaupdateHelperSelect::getMethods($defaultMethod);


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
A PHP Notice will be shown on Joomla Update with PHP 7.4.
This Patch solves this notice.

### Testing Instructions
Needs Joomla 3.9.13 and PHP 7.4 installed
Go to Joomla administration -> Components -> Joomla! Update and -> Check for Updates

### Expected result
An Update or the actual version for reinstallation will bi shown, without any PHP notices


### Actual result
PHP Notice will shown
