### PR TITLE
[4.0] Fix update to 4.0-beta1-dev failing with SQL error when updating from 3.9 or 3.10 with testing sample data

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/4.0.0-2018-08-01.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.0.0-2018-08-01.sql
@@ -3,6 +3,10 @@ ALTER TABLE `#__ucm_content` MODIFY `core_modified_time` datetime NOT NULL;
 
 ALTER TABLE `#__ucm_content` MODIFY `core_publish_up` datetime NULL DEFAULT NULL;
 ALTER TABLE `#__ucm_content` MODIFY `core_publish_down` datetime NULL DEFAULT NULL;
+
+-- Only on MySQL: Update empty stings to null date before converting the column from varchar to datetime
+UPDATE `#__ucm_content` SET `core_checked_out_time` = '0000-00-00 00:00:00' WHERE `core_checked_out_time` = '';
+
 ALTER TABLE `#__ucm_content` MODIFY `core_checked_out_time` datetime NULL DEFAULT NULL;
 
 ALTER TABLE `#__ucm_history` MODIFY `save_date` datetime NOT NULL;

--- a/administrator/components/com_admin/sql/updates/mysql/4.0.0-2018-08-01.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.0.0-2018-08-01.sql
@@ -4,7 +4,7 @@ ALTER TABLE `#__ucm_content` MODIFY `core_modified_time` datetime NOT NULL;
 ALTER TABLE `#__ucm_content` MODIFY `core_publish_up` datetime NULL DEFAULT NULL;
 ALTER TABLE `#__ucm_content` MODIFY `core_publish_down` datetime NULL DEFAULT NULL;
 
--- Only on MySQL: Update empty stings to null date before converting the column from varchar to datetime
+-- Only on MySQL: Update empty strings to null date before converting the column from varchar to datetime
 UPDATE `#__ucm_content` SET `core_checked_out_time` = '0000-00-00 00:00:00' WHERE `core_checked_out_time` = '';
 
 ALTER TABLE `#__ucm_content` MODIFY `core_checked_out_time` datetime NULL DEFAULT NULL;


### PR DESCRIPTION
Pull Request for Issue [https://github.com/joomla/joomla-cms/pull/27032#issuecomment-558256110](https://github.com/joomla/joomla-cms/pull/27032#issuecomment-558256110).

See also [https://github.com/joomla/joomla-cms/pull/27032#issuecomment-562997615](https://github.com/joomla/joomla-cms/pull/27032#issuecomment-562997615).

### Summary of Changes

On J 3.9 and 3.10, the column `core_checked_out_time` of database table `#__ucm_content` has data type `varchar(255)` and not `datetime` like it should be in MySQL databases, see here: [https://github.com/joomla/joomla-cms/blob/staging/installation/sql/mysql/joomla.sql#L1883](https://github.com/joomla/joomla-cms/blob/staging/installation/sql/mysql/joomla.sql#L1883).

On PostgreSQL it already has the right data type `timestamp without time zone`, see here: [https://github.com/joomla/joomla-cms/blob/staging/installation/sql/postgresql/joomla.sql#L1851](https://github.com/joomla/joomla-cms/blob/staging/installation/sql/postgresql/joomla.sql#L1851).

When a current staging or 3.9.x or 3.10 is installed with English testing sampla date, records are added to table `#__ucm_content` with value `''` (empty sting) for column `core_checked_out_time` on MySQL.

This makes the following SQL statement to convert the database column to `datetime` data type fail on certain MySQL databases (5.7 and later with default settings, e.g. some strict modes on): [https://github.com/joomla/joomla-cms/blob/4.0-dev/administrator/components/com_admin/sql/updates/mysql/4.0.0-2018-08-01.sql#L6](https://github.com/joomla/joomla-cms/blob/4.0-dev/administrator/components/com_admin/sql/updates/mysql/4.0.0-2018-08-01.sql#L6).

This PR here adds before the failing statement an update statement which changes an empty string to a sting literal for the (old) MySQL null date, so when converting the column to `datetime` the string will be converted correctly.

The old null date is then later converted correctly to a real null value here: [https://github.com/joomla/joomla-cms/blob/4.0-dev/administrator/components/com_admin/sql/updates/mysql/4.0.0-2019-09-14.sql#L24-L26](https://github.com/joomla/joomla-cms/blob/4.0-dev/administrator/components/com_admin/sql/updates/mysql/4.0.0-2019-09-14.sql#L24-L26).

One may say maybe better fix the testing sample data installation, but there might be other sources where empty string values for the `core_checked_out_time` might come from, and these also would be fixed by this PR here, so it makes sense, and testing sample data might be fixed later independently of this PR.

### Testing Instructions

1. Install staging or 3.9.13 or a current nightly build of 3.10 with English testing sample data.

![j3-install-with-testing-sample-data](https://user-images.githubusercontent.com/7413183/70397704-d1d09f80-1a14-11ea-9ab7-2d5bc2ce5a63.png)

2. In backend, go to Global Configuration, tab "Server", and set error reporting to "Maximum" or "Development".

3. Download the Joomla 4 nightly build update package "Joomla_4.0.0-beta1-dev-Development-Update_Package.zip" from here: [https://developer.joomla.org/nightly-builds.html](https://developer.joomla.org/nightly-builds.html).

4. Update your installation to 4.0-beta1-dev using the Joomla Update Component's "Upload & Update" tab, uploading the zip package downloaded before in step 3.

5. At the end of the update, login to the backend.

Result: See section "Actual result" below.

6. Repeat steps 1 to 5, but in step 3 download following zip package instead of the regular nightly build: [https://test5.richard-fath.de/Joomla_4.0.0-beta1-dev-Development-Update_Package_2019-12-08_pr-27228.zip](https://test5.richard-fath.de/Joomla_4.0.0-beta1-dev-Development-Update_Package_2019-12-08_pr-27228.zip), and in step 4 upload this package instead of the regular one.
The zip package here is the update package of nightly build of last night plus the change from this PR here applied.

Result: See section "Expected result" below.

### Expected result

Update finishs without SQL error.

There might be many untranslated language strings shown, but this is not related to this PR here, it happens also with the regular, i.e. unmodified update package from last nightly build.

### Actual result

After the first login to backend after end of the update:

![J4-update-from-staging-with-testing-sample-data](https://user-images.githubusercontent.com/7413183/70397232-ce3b1980-1a10-11ea-992b-016374e9df69.png)

But there is no further hint in PHP error log or the MySQL log file about the source of this error.

There might be many untranslated language strings shown, but this is a separate issue not related to the issue handled by this PR here.

### Documentation Changes Required

None.