### PR TITLE
[3.9] com_media. Show full video filename and preview icon

### DIFF
--- a/administrator/components/com_media/views/medialist/tmpl/details_videos.php
+++ b/administrator/components/com_media/views/medialist/tmpl/details_videos.php
@@ -36,13 +36,13 @@ jQuery(document).ready(function($){
 
 		<td>
 			<a class="video-preview" href="<?php echo COM_MEDIA_BASEURL, '/', rawurlencode($video->name); ?>" title="<?php echo $this->escape($video->title); ?>">
-				<?php JHtml::_('image', $video->icon_16, $this->escape($video->title), null, true); ?>
+				<?php echo JHtml::_('image', $video->icon_16, $this->escape($video->title), null, true); ?>
 			</a>
 		</td>
 
 		<td class="description">
 			<a class="video-preview" href="<?php echo COM_MEDIA_BASEURL, '/', rawurlencode($video->name); ?>" title="<?php echo $this->escape($video->name); ?>">
-				<?php echo JHtml::_('string.truncate', $this->escape($video->name), 10, false); ?>
+				<?php echo $this->escape($video->name); ?>
 			</a>
 		</td>
 


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/27221

### Summary of Changes
- Remove `truncate(...)` for video filename.
- Add missing `echo` for preview image (icon).

### Actual result
- See first post of https://github.com/joomla/joomla-cms/issues/27221

### Testing Instructions
- See first post of https://github.com/joomla/joomla-cms/issues/27221
- Apply patch.

### Expected result
- Check if full videeo filename is displayed.
- Check if Video preview icon is displayed.


