### PR TITLE
fix styling for rating button

### DIFF
--- a/plugins/content/vote/tmpl/vote.php
+++ b/plugins/content/vote/tmpl/vote.php
@@ -36,7 +36,7 @@ for ($i = 1; $i < 6; $i++)
 	<span class="content_vote">
 		<label class="unseen element-invisible" for="content_vote_<?php echo (int) $row->id; ?>"><?php echo JText::_('PLG_VOTE_LABEL'); ?></label>
 		<?php echo JHtml::_('select.genericlist', $options, 'user_rating', null, 'value', 'text', '5', 'content_vote_' . (int) $row->id); ?>
-		&#160;<input class="btn btn-mini" type="submit" name="submit_vote" value="<?php echo JText::_('PLG_VOTE_RATE'); ?>" />
+		&#160;<input class="btn btn-mini btn-default btn-vote" type="submit" name="submit_vote" value="<?php echo JText::_('PLG_VOTE_RATE'); ?>" />
 		<input type="hidden" name="task" value="article.vote" />
 		<input type="hidden" name="hitcount" value="0" />
 		<input type="hidden" name="url" value="<?php echo htmlspecialchars($uri->toString(), ENT_COMPAT, 'UTF-8'); ?>" />


### PR DESCRIPTION
The rating button disappears on hover and doesn't appear to be a button. adding some css resolves that but I'm not sure where to put it.
```css
.btn-vote {
    margin-top: -2px;
    font-size: 12px;
    padding: 0 4px;
    margin-left: -2px;
}
```

Pull Request for Issue # .

### Summary of Changes
added btn-vote class to rating button.

### Testing Instructions

go to plugins->content->voting->tmpl->vote.php and add "btn-default btn-vote" to line 39. ( next to btn-mini )

### Expected result
![image](https://user-images.githubusercontent.com/1850089/70550419-54ec1580-1b3b-11ea-8ffe-7ef18b3be0b5.png)


### Actual result

![image](https://user-images.githubusercontent.com/1850089/70550480-70572080-1b3b-11ea-87f3-73bedc619657.png)
![image](https://user-images.githubusercontent.com/1850089/70550509-7b11b580-1b3b-11ea-87c0-438cd00f5d85.png)


### Documentation Changes Required
none
