### PR TITLE
[4.0] clear button border

### DIFF
--- a/administrator/templates/atum/scss/blocks/_searchtools.scss
+++ b/administrator/templates/atum/scss/blocks/_searchtools.scss
@@ -98,7 +98,6 @@
         background-color: var(--atum-bg-dark);
         color: var(--atum-text-light);
         border:1px solid var(--border);
-        border-left: 1px solid var(--atum-text-light);
 
         [dir=rtl] & {
           margin-left: 5px;
@@ -114,7 +113,6 @@
         &.disabled,
         &:disabled{
             background-color: rgba($gray-300, 0.8);
-            border-color: rgba($gray-500, 0.8);
             opacity:1;
             color:var(--atum-text-dark);
             cursor: not-allowed;


### PR DESCRIPTION
### Summary of Changes
The border colour of the clear button on the filter button in the admin should not have a different colour to the rest of the button

### Before - disabled
![image](https://user-images.githubusercontent.com/1296369/70644823-a7146000-1c3b-11ea-8a34-9a75a64003bc.png)

### Before - enabled
![image](https://user-images.githubusercontent.com/1296369/70644849-b5627c00-1c3b-11ea-9989-8d0cc1bb72b8.png)

### After - disabled
![image](https://user-images.githubusercontent.com/1296369/70644772-8e0baf00-1c3b-11ea-8716-cbd59dbca9e6.png)

### After - enabled
![image](https://user-images.githubusercontent.com/1296369/70644737-7f24fc80-1c3b-11ea-8557-4947ff7af4c7.png)
