### PR TITLE
[4.0] search button border

### DIFF
--- a/administrator/templates/atum/scss/blocks/_searchtools.scss
+++ b/administrator/templates/atum/scss/blocks/_searchtools.scss
@@ -142,6 +142,12 @@
     .input-append {
       margin-bottom: 0;
     }
+
+    .input-group-append {
+      .btn {
+        border-color: var(--border);
+      }
+    }
   }
 }
 


### PR DESCRIPTION
### Summary of Changes
The border colour of the appended button on the search button in the admin should not have a different colour to the rest of the button

### Before
![image](https://user-images.githubusercontent.com/1296369/70648042-286ef100-1c42-11ea-9ce1-d80537b3906e.png)

### After
![image](https://user-images.githubusercontent.com/1296369/70648005-19883e80-1c42-11ea-8669-17b89fe65bbd.png)
