### PR TITLE
[4.0] Reverse loading order of language files

### DIFF
--- a/administrator/components/com_languages/Controller/InstalledController.php
+++ b/administrator/components/com_languages/Controller/InstalledController.php
@@ -84,12 +84,12 @@ class InstalledController extends BaseController
 		$cid   = $this->input->get('cid', '');
 		$model = $this->getModel('installed');
 
-		// Fetching the language name from the xx-XX.xml or langmetadata.xml respectively.
-		$file = JPATH_ADMINISTRATOR . '/language/' . $cid . '/' . $cid . '.xml';
+		// Fetching the language name from the langmetadata.xml or xx-XX.xml respectively.
+		$file = JPATH_ADMINISTRATOR . '/language/' . $cid . '/langmetadata.xml';
 
 		if (!is_file($file))
 		{
-			$file = JPATH_ADMINISTRATOR . '/language/' . $cid . '/langmetadata.xml';
+			$file = JPATH_ADMINISTRATOR . '/language/' . $cid . '/' . $cid . '.xml';
 		}
 
 		$info         = Installer::parseXMLInstallFile($file);

--- a/installation/src/Model/LanguagesModel.php
+++ b/installation/src/Model/LanguagesModel.php
@@ -336,11 +336,11 @@ class LanguagesModel extends BaseInstallationModel
 
 		foreach ($langlist as $lang)
 		{
-			$file = $path . '/' . $lang . '/' . $lang . '.xml';
+			$file = $path . '/' . $lang . '/langmetadata.xml';
 
 			if (!is_file($file))
 			{
-				$file = $path . '/' . $lang . '/langmetadata.xml';
+				$file = $path . '/' . $lang . '/' . $lang . '.xml';
 			}
 
 			$info = Installer::parseXMLInstallFile($file);

--- a/libraries/src/Installer/Adapter/LanguageAdapter.php
+++ b/libraries/src/Installer/Adapter/LanguageAdapter.php
@@ -520,11 +520,11 @@ class LanguageAdapter extends InstallerAdapter
 		// Create an unpublished content language.
 		if ((int) $clientId === 0)
 		{
-			$manifestfile = JPATH_SITE . '/language/' . $this->tag . '/' . $this->tag . '.xml';
+			$manifestfile = JPATH_SITE . '/language/' . $this->tag . '/langmetadata.xml';
 
 			if (!is_file($manifestfile))
 			{
-				$manifestfile = JPATH_SITE . '/language/' . $this->tag . '/langmetadata.xml';
+				$manifestfile = JPATH_SITE . '/language/' . $this->tag . '/' . $this->tag . '.xml';
 			}
 
 			// Load the site language manifest.
@@ -545,11 +545,11 @@ class LanguageAdapter extends InstallerAdapter
 			// Try to load a language string from the installation language var. Will be removed in 4.0.
 			if ($contentLanguageNativeTitle === $contentLanguageTitle)
 			{
-				$manifestfile = JPATH_INSTALLATION . '/language/' . $this->tag . '/' . $this->tag . '.xml';
+				$manifestfile = JPATH_INSTALLATION . '/language/' . $this->tag . '/langmetadata.xml';
 
 				if (!is_file($manifestfile))
 				{
-					$manifestfile = JPATH_INSTALLATION . '/language/' . $this->tag . '/langmetadata.xml';
+					$manifestfile = JPATH_INSTALLATION . '/language/' . $this->tag . '/' . $this->tag . '.xml';
 				}
 
 				if (file_exists($manifestfile))
@@ -914,11 +914,11 @@ class LanguageAdapter extends InstallerAdapter
 	public function refreshManifestCache()
 	{
 		$client       = ApplicationHelper::getClientInfo($this->parent->extension->client_id);
-		$manifestPath = $client->path . '/language/' . $this->parent->extension->element . '/' . $this->parent->extension->element . '.xml';
+		$manifestPath = $client->path . '/language/' . $this->parent->extension->element . '/langmetadata.xml';
 
 		if (!is_file($manifestPath))
 		{
-			$manifestPath = $client->path . '/language/' . $this->parent->extension->element . '/langmetadata.xml';
+			$manifestPath = $client->path . '/language/' . $this->parent->extension->element . '/' . $this->parent->extension->element . '.xml';
 		}
 
 		$this->parent->manifest = $this->parent->isManifest($manifestPath);

--- a/libraries/src/Language/Language.php
+++ b/libraries/src/Language/Language.php
@@ -203,16 +203,16 @@ class Language
 		{
 			// Note: Manual indexing to enforce load order.
 			$paths[0] = JPATH_SITE . "/language/overrides/$lang.localise.php";
-			$paths[2] = JPATH_SITE . "/language/$lang/$lang.localise.php";
-			$paths[4] = JPATH_SITE . "/language/$lang/localise.php";
+			$paths[2] = JPATH_SITE . "/language/$lang/localise.php";
+			$paths[4] = JPATH_SITE . "/language/$lang/$lang.localise.php";
 		}
 
 		if (\defined('JPATH_ADMINISTRATOR'))
 		{
 			// Note: Manual indexing to enforce load order.
 			$paths[1] = JPATH_ADMINISTRATOR . "/language/overrides/$lang.localise.php";
-			$paths[3] = JPATH_ADMINISTRATOR . "/language/$lang/$lang.localise.php";
-			$paths[5] = JPATH_ADMINISTRATOR . "/language/$lang/localise.php";
+			$paths[3] = JPATH_ADMINISTRATOR . "/language/$lang/localise.php";
+			$paths[5] = JPATH_ADMINISTRATOR . "/language/$lang/$lang.localise.php";
 		}
 
 		ksort($paths);
@@ -704,14 +704,14 @@ class Language
 
 		if ($internal)
 		{
-			$filenames[] = "$path/$lang.ini";
 			$filenames[] = "$path/joomla.ini";
+			$filenames[] = "$path/$lang.ini";
 		}
 		else
 		{
-			// Try first with a language-prefixed filename.
-			$filenames[] = "$path/$lang.$extension.ini";
+			// Try first without a language-prefixed filename.
 			$filenames[] = "$path/$extension.ini";
+			$filenames[] = "$path/$lang.$extension.ini";
 		}
 
 		foreach ($filenames as $filename)

--- a/libraries/src/Language/LanguageHelper.php
+++ b/libraries/src/Language/LanguageHelper.php
@@ -253,11 +253,11 @@ class LanguageHelper
 			if ($processMetaData || $processManifest)
 			{
 				$clientPath = (int) $language->client_id === 0 ? JPATH_SITE : JPATH_ADMINISTRATOR;
-				$metafile   = self::getLanguagePath($clientPath, $language->element) . '/' . $language->element . '.xml';
+				$metafile   = self::getLanguagePath($clientPath, $language->element) . '/langmetadata.xml';
 
 				if (!is_file($metafile))
 				{
-					$metafile = self::getLanguagePath($clientPath, $language->element) . '/langmetadata.xml';
+					$metafile = self::getLanguagePath($clientPath, $language->element) . '/' . $language->element . '.xml';
 				}
 
 				// Process the language metadata.
@@ -560,11 +560,11 @@ class LanguageHelper
 	 */
 	public static function getMetadata($lang)
 	{
-		$file = self::getLanguagePath(JPATH_BASE, $lang) . '/' . $lang . '.xml';
+		$file = self::getLanguagePath(JPATH_BASE, $lang) . '/langmetadata.xml';
 
 		if (!is_file($file))
 		{
-			$file = self::getLanguagePath(JPATH_BASE, $lang) . '/langmetadata.xml';
+			$file = self::getLanguagePath(JPATH_BASE, $lang) . '/' . $lang . '.xml';
 		}
 
 		$result = null;
@@ -631,11 +631,11 @@ class LanguageHelper
 			if (preg_match('#/[a-z]{2,3}-[A-Z]{2}$#', $directory))
 			{
 				$dirPathParts = pathinfo($directory);
-				$file         = $directory . '/' . $dirPathParts['filename'] . '.xml';
+				$file         = $directory . '/langmetadata.xml';
 
 				if (!is_file($file))
 				{
-					$file = $directory . '/langmetadata.xml';
+					$file = $directory . '/' . $dirPathParts['filename'] . '.xml';
 				}
 
 				if (!is_file($file))


### PR DESCRIPTION
With https://github.com/joomla/joomla-cms/pull/19353 we added support for non-prefixed language files into J3.10. The loading behavior was set to keep loading prefixed files first so backward compatibility wasn't affected.
With https://github.com/joomla/joomla-cms/pull/27130, the prefixed were removed from language files in 4.0.
Now this PR will change the loading order in 4.0 so non-prefixed files have priority over prefixed ones.

### Summary of Changes
This PR changes the lookup order for language files so non-prefixed ones have precedence over prefixed ones.


### Testing Instructions
Copy a language file (eg com_content.ini) and prefix the copy with the language code (eg en-GB.com_content.ini).
Now change a know string in there to a different value.


### Expected result
The changed value will not be visible as com_content.ini is loaded first with this PR.


### Actual result
The changed value will be used since currently the prefixed files is looked up first.


### Documentation Changes Required
The change in default behavior should be noted if language file loading is documented anywhere.