### PR TITLE
Fix warnings in layouts on PHP 7.4

### DIFF
--- a/components/com_contact/views/featured/tmpl/default_items.php
+++ b/components/com_contact/views/featured/tmpl/default_items.php
@@ -13,8 +13,6 @@ JHtml::_('behavior.core');
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
 
-// Create a shortcut for params.
-$params = &$this->item->params;
 ?>
 
 <?php if (empty($this->items)) : ?>

--- a/components/com_content/views/category/tmpl/default_articles.php
+++ b/components/com_content/views/category/tmpl/default_articles.php
@@ -15,7 +15,6 @@ use Joomla\CMS\Language\Multilanguage;
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
 // Create some shortcuts.
-$params     = &$this->item->params;
 $n          = count($this->items);
 $listOrder  = $this->escape($this->state->get('list.ordering'));
 $listDirn   = $this->escape($this->state->get('list.direction'));
@@ -271,7 +270,7 @@ $tableClass = $this->params->get('show_headings') != 1 ? ' table-noheader' : '';
 			<?php if ($isEditable) : ?>
 				<td headers="categorylist_header_edit" class="list-edit">
 					<?php if ($article->params->get('access-edit')) : ?>
-						<?php echo JHtml::_('icon.edit', $article, $params); ?>
+						<?php echo JHtml::_('icon.edit', $article, $article->params); ?>
 					<?php endif; ?>
 				</td>
 			<?php endif; ?>

--- a/templates/beez3/html/com_content/category/blog_links.php
+++ b/templates/beez3/html/com_content/category/blog_links.php
@@ -9,9 +9,6 @@
 
 defined('_JEXEC') or die;
 
-$params = &$this->item->params;
-$app = JFactory::getApplication();
-
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers');
 
 ?>

--- a/templates/beez3/html/com_content/category/default_articles.php
+++ b/templates/beez3/html/com_content/category/default_articles.php
@@ -14,7 +14,6 @@ $app = JFactory::getApplication();
 JHtml::addIncludePath(JPATH_COMPONENT.'/helpers/html');
 JHtml::_('behavior.framework');
 
-$params    = &$this->item->params;
 $n         = count($this->items);
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
@@ -186,7 +185,7 @@ if (!empty($this->items))
 					<?php if ($isEditable) : ?>
 						<td class="list-edit">
 							<?php if ($article->params->get('access-edit')) : ?>
-								<?php echo JHtml::_('icon.edit', $article, $params, array(), true); ?>
+								<?php echo JHtml::_('icon.edit', $article, $article->params, array(), true); ?>
 							<?php endif; ?>
 						</td>
 					<?php endif; ?>

--- a/templates/beez3/html/com_weblinks/category/default_items.php
+++ b/templates/beez3/html/com_weblinks/category/default_items.php
@@ -10,8 +10,6 @@
 defined('_JEXEC') or die;
 
 // Code to support edit links for weblinks
-// Create a shortcut for params.
-$params = &$this->item->params;
 JHtml::addIncludePath(JPATH_COMPONENT.'/helpers/html');
 JHtml::_('behavior.framework');
 
@@ -125,7 +123,7 @@ $listDirn     = $this->escape($this->state->get('list.direction'));
 						<?php if ($canEdit) : ?>
 							<ul class="actions">
 								<li class="edit-icon">
-									<?php echo JHtml::_('icon.edit', $item, $params); ?>
+									<?php echo JHtml::_('icon.edit', $item, $item->params); ?>
 								</li>
 							</ul>
 						<?php endif; ?>


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/27259.

### Summary of Changes

Removes some misplaced code.

### Testing Instructions

Create Article Category List menu item and Featured Contacts menu items. View them in frontend.

### Expected result

No warnings.

### Actual result

>Warning: Creating default object from empty value

### Documentation Changes Required

No.