### PR TITLE
[4.0] Fix language override search

### DIFF
--- a/administrator/components/com_languages/Model/StringsModel.php
+++ b/administrator/components/com_languages/Model/StringsModel.php
@@ -66,20 +66,20 @@ class StringsModel extends BaseDatabaseModel
 		// Parse common language directory.
 		if (is_dir($path))
 		{
-			$files = Folder::files($path, $language . '.*ini$', false, true);
+			$files = Folder::files($path, '.*ini$', false, true);
 		}
 
 		// Parse language directories of components.
-		$files = array_merge($files, Folder::files($base . '/components', $language . '.*ini$', 3, true));
+		$files = array_merge($files, Folder::files($base . '/components', '.*ini$', 3, true));
 
 		// Parse language directories of modules.
-		$files = array_merge($files, Folder::files($base . '/modules', $language . '.*ini$', 3, true));
+		$files = array_merge($files, Folder::files($base . '/modules', '.*ini$', 3, true));
 
 		// Parse language directories of templates.
-		$files = array_merge($files, Folder::files($base . '/templates', $language . '.*ini$', 3, true));
+		$files = array_merge($files, Folder::files($base . '/templates', '.*ini$', 3, true));
 
 		// Parse language directories of plugins.
-		$files = array_merge($files, Folder::files(JPATH_PLUGINS, $language . '.*ini$', 4, true));
+		$files = array_merge($files, Folder::files(JPATH_PLUGINS, '.*ini$', 4, true));
 
 		// Parse all found ini files and add the strings to the database cache.
 		foreach ($files as $file)


### PR DESCRIPTION
Pull Request for Issue #27275

### Summary of Changes
The Language Override Manager didn't recognise the non-prefixed language files.
This PR changes the language file loading logic in the StringsModel->refresh() function so it doesn't require a prefix anymore. It now just loads all INI files in a specific folder.


### Testing Instructions
Try to create a new language override and check in the search if the string appears. Eg search fo "Articles" which should yield you several results for en-GB in the administrator client.


### Expected result
Search yields all appropriate results.


### Actual result
Search yields only results from files that are language prefixed. In core that is only the sampledata testing plugin.


### Documentation Changes Required
None