### PR TITLE
[4.0] menu dashboard

### DIFF
--- a/administrator/components/com_menus/presets/menus.xml
+++ b/administrator/components/com_menus/presets/menus.xml
@@ -52,6 +52,7 @@
 			icon="{sql:icon}"
 			class="class:menu"
 			quicktask="index.php?option=com_menus&amp;task=item.add&amp;menutype={sql:menutype}"
+			quicktask-title="MOD_MENU_MENU_MANAGER_NEW_SITE_MENU_ITEM"
 		/>
 	</menuitem>
 
@@ -73,6 +74,7 @@
 			link="index.php?option=com_menus&amp;view=items&amp;menutype={sql:menutype}"
 			class="class:menu"
 			quicktask="index.php?option=com_menus&amp;task=item.add&amp;client_id=1&amp;menutype={sql:menutype}"
+			quicktask-title="MOD_MENU_MENU_MANAGER_NEW_ADMIN_MENU_ITEM"
 		/>
 	</menuitem>
 </menu>


### PR DESCRIPTION
Add the missing title to the add new site and new admin menu items on the menus dashboard

![image](https://user-images.githubusercontent.com/1296369/70913783-933b7600-200e-11ea-840b-29487638b723.png)
