### PR TITLE
[4.0] readmore with php7.4

### DIFF
--- a/plugins/editors-xtd/readmore/readmore.php
+++ b/plugins/editors-xtd/readmore/readmore.php
@@ -49,7 +49,7 @@ class PlgButtonReadmore extends CMSPlugin
 		);
 
 		$getContentResult = $this->getDispatcher()->dispatch('getContent', $event);
-		$getContent = $getContentResult['result'][0];
+		$getContent = isset($getContentResult['result'][0]);
 		HTMLHelper::_('script', 'com_content/admin-article-readmore.min.js', array('version' => 'auto', 'relative' => true));
 
 		// Pass some data to javascript

--- a/plugins/editors-xtd/readmore/readmore.php
+++ b/plugins/editors-xtd/readmore/readmore.php
@@ -49,6 +49,7 @@ class PlgButtonReadmore extends CMSPlugin
 		);
 
 		$getContentResult = $this->getDispatcher()->dispatch('getContent', $event);
+		$getContent = isset($getContentResult['result'][0]);
 		HTMLHelper::_('script', 'com_content/admin-article-readmore.min.js', array('version' => 'auto', 'relative' => true));
 
 		// Pass some data to javascript

--- a/plugins/editors-xtd/readmore/readmore.php
+++ b/plugins/editors-xtd/readmore/readmore.php
@@ -49,7 +49,6 @@ class PlgButtonReadmore extends CMSPlugin
 		);
 
 		$getContentResult = $this->getDispatcher()->dispatch('getContent', $event);
-		$getContent = isset($getContentResult['result'][0]);
 		HTMLHelper::_('script', 'com_content/admin-article-readmore.min.js', array('version' => 'auto', 'relative' => true));
 
 		// Pass some data to javascript


### PR DESCRIPTION
Pull request for #27239

Fixes a b/c breaking change from php 7.4

### Steps to reproduce the issue
Create a new article with full php errors displayed **_using php7.4_**

### Actual result
Notice: Trying to access array offset on value of type null in C:\htdocs\joomla-cms\plugins\editors-xtd\readmore\readmore.php on line 52

After applying the PR the notice is gone and readmore plugin works normally