### PR TITLE
[4.0] Use icon to fix space in Help button

### DIFF
--- a/libraries/src/Toolbar/Button/HelpButton.php
+++ b/libraries/src/Toolbar/Button/HelpButton.php
@@ -41,7 +41,7 @@ class HelpButton extends BasicButton
 	protected function prepareOptions(array &$options)
 	{
 		$options['text'] = $options['text'] ?: 'JTOOLBAR_HELP';
-		$options['icon'] = $options['icon'] ?? 'fa fa-question';
+		$options['icon'] = $options['icon'] ?? 'icon-help';
 		$options['button_class'] = $options['button_class'] ?? 'btn btn-info';
 		$options['onclick'] = $options['onclick'] ?? $this->_getCommand();
 


### PR DESCRIPTION
Pull Request for Issue #25854 .

### Summary of Changes
Change the help button to use `icon-` instead of `fa-` to be consistent with the other buttons.

`Actions` button has the same issue. There isn't an equivalent icon for it so it will be handled in a separate PR.


### Testing Instructions
Go to Content > Articles
See space at the bottom of the Help button.




### Actual result
![62202085-89c3b100-b380-11e9-83f2-f82cb5a37ff9](https://user-images.githubusercontent.com/368084/71314088-27368480-23f7-11ea-90c2-f8f9a7395900.png)


