### PR TITLE
[3.10] Deprecate some JHtmlBehavior methods

### DIFF
--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -205,7 +205,7 @@ abstract class JHtmlBehavior
 	 *
 	 * @since   1.5
 	 *
-	 * @deprecated   4.0
+	 * @deprecated   4.0  No replacement, only used in Hathor.
 	 */
 	public static function switcher()
 	{
@@ -283,7 +283,7 @@ abstract class JHtmlBehavior
 	 *
 	 * @since   1.5
 	 *
-	 * @deprecated   4.0
+	 * @deprecated   4.0  Use JHtmlBootstrap::tooltip() instead.
 	 */
 	public static function tooltip($selector = '.hasTip', $params = array())
 	{
@@ -516,7 +516,7 @@ abstract class JHtmlBehavior
 	 *
 	 * @since   1.5
 	 *
-	 * @deprecated   4.0
+	 * @deprecated   4.0  No replacement, not used since 3.0.
 	 */
 	public static function tree($id, $params = array(), $root = array())
 	{

--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -204,6 +204,8 @@ abstract class JHtmlBehavior
 	 * @return  void
 	 *
 	 * @since   1.5
+	 *
+	 * @deprecated   4.0
 	 */
 	public static function switcher()
 	{
@@ -280,6 +282,8 @@ abstract class JHtmlBehavior
 	 * @return  void
 	 *
 	 * @since   1.5
+	 *
+	 * @deprecated   4.0
 	 */
 	public static function tooltip($selector = '.hasTip', $params = array())
 	{
@@ -511,6 +515,8 @@ abstract class JHtmlBehavior
 	 * @return  void
 	 *
 	 * @since   1.5
+	 *
+	 * @deprecated   4.0
 	 */
 	public static function tree($id, $params = array(), $root = array())
 	{


### PR DESCRIPTION
# Summary of Changes

Marks methods to be removed in https://github.com/joomla/joomla-cms/pull/27335 as deprecated.

### Testing Instructions

Code review.

### Documentation Changes Required

Some methods deprecated.