### PR TITLE
Hiding .login-initial via class .hidden instead of display none

### DIFF
--- a/administrator/modules/mod_login/tmpl/default.php
+++ b/administrator/modules/mod_login/tmpl/default.php
@@ -27,7 +27,7 @@ Text::script('WARNING');
 Text::script('NOTICE');
 Text::script('MESSAGE');
 ?>
-<form class="login-initial form-validate" action="<?php echo Route::_('index.php', true); ?>" method="post"
+<form class="login-initial hidden form-validate" action="<?php echo Route::_('index.php', true); ?>" method="post"
 	id="form-login">
 	<fieldset>
 		<div class="form-group">

--- a/administrator/templates/atum/scss/blocks/_login.scss
+++ b/administrator/templates/atum/scss/blocks/_login.scss
@@ -31,10 +31,6 @@
             rgba(color("atum-bg-light"), .2) 100%);
   }
 
-  .login-initial {
-    display: none;
-  }
-
   .login-logo {
     width: 200px;
     margin: 0 auto 2rem;


### PR DESCRIPTION
Pull Request for Issue #27298 .

### Summary of Changes

The visibility of the initial login form would be controlled by standard means (class "hidden").

RE: https://github.com/joomla/joomla-cms/pull/27298#issuecomment-568512857