### PR TITLE
[4.0] Add tooltip to sidebar icons

### DIFF
--- a/administrator/modules/mod_menu/tmpl/default_submenu.php
+++ b/administrator/modules/mod_menu/tmpl/default_submenu.php
@@ -92,7 +92,7 @@ $itemImage = $currentParams->get('menu_image');
 
 // Get the menu icon
 $icon      = $this->getIconClass($current);
-$iconClass = ($icon != '' && $current->level == 1) ? '<span class="' . $icon . '" aria-hidden="true"></span>' : '';
+$iconClass = ($icon != '' && $current->level == 1) ? '<span class="' . $icon . '" aria-hidden="true" title="' . Text::_($current->title) . '"></span>' : '';
 $ajax      = $current->ajaxbadge ? '<span class="menu-badge"><span class="fa fa-spin fa-spinner mt-1 system-counter" data-url="' . $current->ajaxbadge . '"></span></span>' : '';
 $iconImage = $current->icon;
 $homeImage = '';
@@ -123,19 +123,19 @@ $itemImage = (empty($itemIconClass) && $itemImage) ? '&nbsp;<img src="' . Uri::r
 
 if ($link != '' && $current->target != '')
 {
-	echo "<a" . $linkClass . $dataToggle . " href=\"" . $link . "\" target=\"" . $current->target . "\">"
+	echo '<a' . $linkClass . $dataToggle . ' href="' . $link . '" target="' . $current->target . '">'
 		. $iconClass
 		. '<span class="sidebar-item-title">' . $itemImage . Text::_($current->title) . '</span>' . $ajax . '</a>';
 }
 elseif ($link != '' && $current->type !== 'separator')
 {
-	echo "<a" . $linkClass . $dataToggle . " href=\"" . $link . "\">"
+	echo '<a' . $linkClass . $dataToggle . ' href="' . $link . '">'
 		. $iconClass
 		. '<span class="sidebar-item-title">' . $itemImage . Text::_($current->title) . '</span>' . $iconImage . '</a>';
 }
 elseif ($current->title != '' && $current->type !== 'separator')
 {
-	echo "<a" . $linkClass . $dataToggle . ">"
+	echo '<a' . $linkClass . $dataToggle . '>'
 		. $iconClass
 		. '<span class="sidebar-item-title">'. $itemImage . Text::_($current->title) . '</span>' . $ajax . '</a>';
 }

--- a/administrator/templates/atum/index.php
+++ b/administrator/templates/atum/index.php
@@ -145,7 +145,7 @@ HTMLHelper::_('atum.rootcolors', $this->params);
 			<div id="sidebarmenu">
 				<div class="sidebar-toggle">
 					<a id="menu-collapse" href="#">
-						<span id="menu-collapse-icon" class="fa fa-toggle-off fa-fw" aria-hidden="true"></span>
+						<span id="menu-collapse-icon" class="fa fa-toggle-off fa-fw" aria-hidden="true" title="<?php echo Text::_('JTOGGLE_SIDEBAR_MENU'); ?>"></span>
 						<span class="sidebar-item-title"><?php echo Text::_('JTOGGLE_SIDEBAR_MENU'); ?></span>
 					</a>
 				</div>


### PR DESCRIPTION
Pull Request for Issue #26667 .

### Summary of Changes
Display tooltip on hover of sidebar icons.


### Testing Instructions
Login to backend.
Click on toggle menu.
Hover over an icon.
No tooltip.
Apply PR.
Hover over an to display tooltip.