### PR TITLE
[4.0] Fix missing onchange events on switcher fields

### DIFF
--- a/layouts/joomla/form/field/radio/switcher.php
+++ b/layouts/joomla/form/field/radio/switcher.php
@@ -60,8 +60,17 @@ Factory::getApplication()->getDocument()->getWebAssetManager()->enableAsset('swi
  */
 $input    = '<input type="radio" id="%1$s" name="%2$s" value="%3$s" %4$s>';
 
+$attr = 'id="' . $id . '"';
+$attr .= $onchange ? ' onchange="' . $onchange . '"' : '';
+
+// To avoid user's confusion, readonly="readonly" should imply disabled="disabled".
+if ($readonly || $disabled)
+{
+	$attr .= ' disabled="disabled"';
+}
+
 ?>
-<fieldset>
+<fieldset <?php echo $attr; ?>>
 	<legend class="switcher__legend">
 		<?php echo $label; ?>
 	</legend>

--- a/layouts/joomla/form/field/radio/switcher.php
+++ b/layouts/joomla/form/field/radio/switcher.php
@@ -63,12 +63,6 @@ $input    = '<input type="radio" id="%1$s" name="%2$s" value="%3$s" %4$s>';
 $attr = 'id="' . $id . '"';
 $attr .= $onchange ? ' onchange="' . $onchange . '"' : '';
 
-// To avoid user's confusion, readonly="readonly" should imply disabled="disabled".
-if ($readonly || $disabled)
-{
-	$attr .= ' disabled="disabled"';
-}
-
 ?>
 <fieldset <?php echo $attr; ?>>
 	<legend class="switcher__legend">


### PR DESCRIPTION
Pull Request for Issue #20853 .

### Summary of Changes

Make it possible to use "onchange" events for switcher fields (type="radio", class="switcher").

There was once opened issue #20853 for "onchange" and "onclick" events, which was closed because PR #20931 was made for the CMS.

This PR then was closed because a PR against the backend template repo was made: [joomla/40-backend-template#446](https://github.com/joomla/40-backend-template/pull/446).

This then was merged into the backend template but either never found the way to the CMS or was later removed by some other change.

This PR here brings the correction back, but only for "onchange", not for "onclick", because to click on a switcher always means to change the value, and because we also don't have the "onclick" event on list fields.

The change does it in a bit different way than #20931 and [joomla/40-backend-template#446](https://github.com/joomla/40-backend-template/pull/446), so it is closer to the existing implementation in other field layouts.

In addition to the "onchange" property, this PR also adds the "id" property.

### Testing Instructions

1. Make sure that your web browser allows popup alerts for your Joomla backend.

2. Edit some form XML and add an onchange event to a switcher field.
E.g. you can edit file "administrator/components/com_config/forms/application.xml" and modify field name="gzip" by adding an "onchange" property for a javascript alert as follows:
```
<field
	name="gzip"
	type="radio"
	label="COM_CONFIG_FIELD_GZIP_COMPRESSION_LABEL"
	class="switcher"
	default="0"
	filter="boolean"
	onchange="alert('Hello, I am a switcher field.')"
	>
	<option value="0">JNO</option>
	<option value="1">JYES</option>
</field>
```

3. Go to a page where you can see the switcher field modified in step 2 and toggle the field.
E.g. if you used the field suggested in step 2: Go to the "Server" tab of "Global Configuration" in backend and toggle the "Gzip Page Compression" switcher field.
Result: No browser alert, see section "Actual result" below..

4. In developer tools of your web browser, inspect html of the switcher element ("fieldset" html element).
Result: No "onchange" property added to fieldset, see section "Actual result" below.

4. Apply the patch of this PR.

5. Go to some other page and then back, e.g. if you used "Global Configuration" close it and then open it again, and toggle the switcher field.
Result: See section "Expected result" below.

6. In developer tools of your web browser, inspect html of the switcher element ("fieldset" html element).
Result: See section "Expected result" below.

### Expected result

Onchange event works:

![switcher-3](https://user-images.githubusercontent.com/7413183/71533617-135cb800-28fa-11ea-9957-52d9026de1f1.png)

Fieldset has "id" and "onchange" properties:

![switcher-2](https://user-images.githubusercontent.com/7413183/71533726-ccbb8d80-28fa-11ea-8425-08466d6d24af.png)

### Actual result

Onchange event doesn't work.

Fieldset doesn't have "id" and "onchange" properties:

![switcher-1](https://user-images.githubusercontent.com/7413183/71533733-d218d800-28fa-11ea-821a-4db5a8e6247c.png)

### Documentation Changes Required

Not sure. Maybe some doc about fields tells onchange is not supported for switchers?