### PR TITLE
[4.0] a11y contrast on danger-bg

### DIFF
--- a/administrator/templates/atum/scss/_variables.scss
+++ b/administrator/templates/atum/scss/_variables.scss
@@ -188,7 +188,7 @@ $success-txt:                      #114b0c;
 $warning-bg:                       #fcd9b6;
 $warning-txt:                      #462a16;
 
-$danger-bg:                        #f9acaa;
+$danger-bg:                        #F5B9B7;
 $danger-txt:                       #3b0d0c;
 
 // Input Group


### PR DESCRIPTION
Title: WCAG 1.4.3: Elements must have sufficient color contrast (.j-links-link)
Tags: Accessibility, WCAG 1.4.3, color-contrast

Issue: Elements must have sufficient color contrast (color-contrast - https://dequeuniversity.com/rules/axe/3.3/color-contrast?application=msftAI)
 Element has insufficient color contrast of 4.48 (foreground color: #495057, background color: #f9acaa, font size: 10.5pt (14px), font weight: normal). Expected contrast ratio of 4.5:1

Target application: Control Panel - 4.0 Evaluar - Administration - http://localhost/joomla-cms/administrator/index.php

Element path: #plg_quickicon_extensionupdate > .quickicon-text.align-items-center.d-flex > .j-links-link

Snippet: `<span class="j-links-link">Updates are available! <span class="badge badge-light">2</span></span>
`
### Testing Instructions
npm i

there is almost no visible difference
### Before
![image](https://user-images.githubusercontent.com/1296369/71544496-17c7b600-2978-11ea-8c04-810919ae0c91.png)

### After
![image](https://user-images.githubusercontent.com/1296369/71544495-14ccc580-2978-11ea-861c-e9a94ba99020.png)
