### PR TITLE
[4.0] TFA google authenticator

### DIFF
--- a/administrator/components/com_users/tmpl/user/edit.php
+++ b/administrator/components/com_users/tmpl/user/edit.php
@@ -76,8 +76,7 @@ $this->useCoreUI = true;
 	</div>
 	<div id="com_users_twofactor_forms_container">
 		<?php foreach ($this->tfaform as $form) : ?>
-		<?php $style = $form['method'] == $this->otpConfig->method ? 'display: block' : 'display: none'; ?>
-		<div id="com_users_twofactor_<?php echo $form['method'] ?>" style="<?php echo $style; ?>">
+		<div id="com_users_twofactor_<?php echo $form['method'] ?>" class="hidden">
 			<?php echo $form['form'] ?>
 		</div>
 		<?php endforeach; ?>


### PR DESCRIPTION
I am not going to pretend to understand the line that was removed. Other than it being an inline style that we dont want anyway for CSP reasons.


### Summary of Changes
Make it possible to see the google tfa options for a user


### Testing Instructions
enable the google tfa plugin
go to your user setting and you will now see a Two factor Authentication tab
Change the setting from Disabled to Google Authenticator


### Expected result
![tfanew](https://user-images.githubusercontent.com/1296369/71551229-03b4a080-29da-11ea-814b-5f484539f6c7.gif)



### Actual result
The hidden div is never revealed


### Documentation Changes Required
none
