### PR TITLE
[4.0] Alerts color accessibility

### DIFF
--- a/administrator/templates/atum/scss/_variables.scss
+++ b/administrator/templates/atum/scss/_variables.scss
@@ -27,11 +27,11 @@ $purple:                           #6f42c1; //used in bootstrap
 $pink:                             #971250; //used in bootstrap
 $red:                              #c52827; //used in bootstrap
 $red-dark:                         #3b0d0c; //used for alerts error
-$yellow:                           #ffb107; //used in bootstrap
+$yellow:                           #ffb514; //used in bootstrap
 $green:                            #2f7d32; //used in bootstrap
 $green-dark:                       #0f2f21; //used for alert success
 $teal:                             #20c997; //used in bootstrap
-$cyan:                             #108193; //used in bootstrap
+$cyan:                             #107D8E; //used in bootstrap
 
 $base-color:                       $blue;
 


### PR DESCRIPTION
A very subtle change to the colours
## Info
Element path:` joomla-alert[type="info"] > .alert-heading`

Snippet: `<div class="alert-heading">Notice</div>`

Element has insufficient color contrast of 4.29 (foreground color: #f3f9fa, background color: #108193, font size: 15.6pt (20.8px), font weight: normal). Expected contrast ratio of 4.5:1

## Warning
Element path:` joomla-alert[type="warning"] > .alert-heading`

Snippet: `<div class="alert-heading">Warning</div>`

Element has insufficient color contrast of 4.49 (foreground color: #495057, background color: #ffb107, font size: 15.6pt (20.8px), font weight: normal). Expected contrast ratio of 4.5:1

### Before
![image](https://user-images.githubusercontent.com/1296369/71556052-6e41fc80-2a2b-11ea-8061-c4e2f413cb97.png)

### After
![image](https://user-images.githubusercontent.com/1296369/71556065-ad704d80-2a2b-11ea-883f-333eee4ab8b9.png)

### Testing Instructions
Check colors with https://webaim.org/resources/contrastchecker/
