### PR TITLE
Web service login fix

### DIFF
--- a/plugins/api-authentication/basic/basic.php
+++ b/plugins/api-authentication/basic/basic.php
@@ -54,7 +54,7 @@ class PlgApiAuthenticationBasic extends CMSPlugin
 		$response->type = 'Basic';
 
 		$username = $this->app->input->server->get('PHP_AUTH_USER');
-		$password = $this->app->input->server->get('PHP_AUTH_PW');
+		$password = $this->app->input->server->get('PHP_AUTH_PW', null, 'string');
 
 		if (empty($password))
 		{


### PR DESCRIPTION
Pull Request for Issue #27372.

### Summary of Changes
Change input filter for password in basic api authentication plugin from default 'cmd' to 'string'.

### Testing Instructions
Create a user with a password containing spaces.
Send a valid API request, authenticated by the above mentioned user's name and password.

### Expected result
200 response

### Actual result
200 response

### Documentation Changes Required
n/a