### PR TITLE
[4.0] [Admin template] RTL: Correcting display of quicktask

### DIFF
--- a/administrator/templates/atum/scss/blocks/_quickicons.scss
+++ b/administrator/templates/atum/scss/blocks/_quickicons.scss
@@ -211,24 +211,30 @@
 #content {
   .menu-quicktask {
     position: absolute;
-    right: 1.25rem;
+
+    [dir=ltr] & {
+      right: 1.25rem;
+    }
+
+    [dir=rtl] & {
+      left: 1.25rem;
+    }
   }
 }
 
-#cpanel-modules{
-	.cpanel-quickicons,
-	.cpanel{
+#cpanel-modules {
+  .cpanel-quickicons,
+  .cpanel {
+    .card-columns {
+      @include media-breakpoint-down(md) {
+        column-count: 2;
+      }
 
-	  .card-columns {
-		@include media-breakpoint-down(md) {
-		  column-count: 2;
-		}
-
-		@include media-breakpoint-down(sm) {
-		  column-count: 1;
-		}
-	  }
-	}
+      @include media-breakpoint-down(sm) {
+        column-count: 1;
+      }
+    }
+  }
 }
 
 #wrapper.closed {
@@ -240,11 +246,13 @@
         max-width: calc(50% - 1rem);
         flex: 1 1 calc(50% - 1rem);
       }
+
       @media (max-width: 950px) {
         width: calc(100% - 1rem);
         max-width: calc(100% - 1rem);
         flex: 1 1 calc(100% - 1rem);
       }
+
       @media (max-width: 767px) {
         width: calc(33% - 1rem);
         max-width: calc(33% - 1rem);


### PR DESCRIPTION
### Summary of Changes 
As title says.
Also corrected some cs in the scss file.


### Testing Instructions
Install a multilingual site including Persian (fa-IR)
Use the multilingual sample data 
Display the cpanel menu dashboard menu, then switch to Persian as admin lanaguage.

After patch run npm.


### Before patch
For en-GB LTR, we righfully have

<img width="1352" alt="Screen Shot 2019-12-30 at 09 20 36_ltr" src="https://user-images.githubusercontent.com/869724/71575452-4fa43a00-2aed-11ea-8bd3-28c078d5bb09.png">

but for RTL (Persian), we have

<img width="1175" alt="Screen Shot 2019-12-30 at 09 25 59_badrtl" src="https://user-images.githubusercontent.com/869724/71575496-72cee980-2aed-11ea-86e0-9567c7aa83b5.png">


### After patch
Display corrected

<img width="1657" alt="Screen Shot 2019-12-30 at 09 19 57goodrtl" src="https://user-images.githubusercontent.com/869724/71575523-8c703100-2aed-11ea-9fd0-85fc9ea065ec.png">


