### PR TITLE
[4.0] Site/Admin select in searchtools

### DIFF
--- a/administrator/templates/atum/scss/blocks/_searchtools.scss
+++ b/administrator/templates/atum/scss/blocks/_searchtools.scss
@@ -70,7 +70,7 @@
   .js-stools-container-selector,
   .js-stools-container-selector-first  {
      @include media-breakpoint-down(md){
-        float:none;
+        float:none !important;
         width:100%;
         margin-right:0.5rem;
     }

--- a/build/media_source/system/css/searchtools.css
+++ b/build/media_source/system/css/searchtools.css
@@ -28,7 +28,7 @@
 	margin-right: 8px;
 }
 html[dir=rtl] .js-stools .js-stools-container-selector {
-	float: none;
+	float: right;
 	margin-left: auto;
 	margin-right: 0;
 }


### PR DESCRIPTION
see screenshots for changes

If we wait for an expert to fix it then it will never happen

On pages where we still have an admin/site select such as `/administrator/index.php?option=com_languages&view=installed&client=1` there is an error in the RTL css that forces it to be full width

### Before
![image](https://user-images.githubusercontent.com/1296369/71596355-25776a00-2b37-11ea-86bc-393f19d3adb5.png)

### After
![image](https://user-images.githubusercontent.com/1296369/71596333-0a0c5f00-2b37-11ea-899f-3f07e13be80e.png)

