### PR TITLE
[4.0] Remove alert container background

### DIFF
--- a/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-alert.scss
+++ b/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-alert.scss
@@ -12,9 +12,6 @@
 @import "../../../../../../node_modules/joomla-ui-custom-elements/dist/css/joomla-alert";
 
 #system-message-container {
-  background: var(--atum-bg-light);
-  box-shadow: 3px 3px 11px 0px rgba(0, 0, 0, 0.3);
-
   joomla-alert {
     display: block;
     min-width: 16rem;


### PR DESCRIPTION
Replaces PR #26855 for Issue #26817 .

### Summary of Changes
Remove alert container background.

Does not fix issue #25850.

### Testing Instructions
Go to `\administrator\templates\atum\scss\vendor\joomla-custom-elements\joomla-alert.scss`
Change `--atum-bg-light` to `--atum-bg-dark` to see the alert container background
Run `npm i`
Under Joomla Patch Tester, install a patch to see multiple alerts with blue background between alerts.
Apply PR
Run `npm i`


### Expected result
Transparent background.


### Actual result
![26817-before](https://user-images.githubusercontent.com/368084/71694403-f3971b00-2d63-11ea-8d66-08fc68d201aa.jpg)


