### PR TITLE
[4.0] remove invalid aria

### DIFF
--- a/administrator/components/com_cpanel/tmpl/cpanel/default.php
+++ b/administrator/components/com_cpanel/tmpl/cpanel/default.php
@@ -40,9 +40,9 @@ echo HTMLHelper::_(
 		'url'         => Route::_('index.php?option=com_cpanel&task=addModule&function=jSelectModuleType&position=' . $this->escape($this->position)),
 		'bodyHeight'  => '70',
 		'modalWidth'  => '80',
-		'footer'      => '<button type="button" class="button-cancel btn btn-sm btn-danger" data-dismiss="modal" data-target="#closeBtn" aria-hidden="true"><span class="icon-cancel" aria-hidden="true"></span>'
+		'footer'      => '<button type="button" class="button-cancel btn btn-sm btn-danger" data-dismiss="modal" data-target="#closeBtn"><span class="icon-cancel" aria-hidden="true"></span>'
 			. Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>'
-			. '<button type="button" class="button-save btn btn-sm btn-success hidden" data-target="#saveBtn" aria-hidden="true"><span class="icon-save" aria-hidden="true"></span>'
+			. '<button type="button" class="button-save btn btn-sm btn-success hidden" data-target="#saveBtn"><span class="icon-save" aria-hidden="true"></span>'
 			. Text::_('JSAVE') . '</button>',
 	)
 );


### PR DESCRIPTION
The buttons in the add module modal accessed from the dashboard incorrectly have aria-hidden attributes. This is not correct because there is focusable content inside

#### Issue
`ARIA hidden element must not contain focusable elements` ([aria-hidden-focus](https://dequeuniversity.com/rules/axe/3.3/aria-hidden-focus?application=msftAI))
#### Target application
[Control Panel - 4.0 Test Site - Administration](http://localhost/joomla-cms/administrator/index.php)
#### Element path
.button-cancel
#### Snippet
`<button type="button" class="button-cancel btn btn-sm btn-danger" data-dismiss="modal" data-target="#closeBtn" aria-hidden="true"><span class="icon-cancel" aria-hidden="true"></span>Close</button>`