### PR TITLE
[3] Pagebreak navigation cosmetic. Icons, aria-label, title, tooltips and things

### DIFF
--- a/plugins/content/pagebreak/pagebreak.php
+++ b/plugins/content/pagebreak/pagebreak.php
@@ -284,7 +284,7 @@ class PlgContentPagebreak extends JPlugin
 		// TOC first Page link.
 		$this->list[1]          = new stdClass;
 		$this->list[1]->liClass = ($limitstart === 0 && $showall === 0) ? 'toclink active' : 'toclink';
-		$this->list[1]->class   = $list[1]->liClass;
+		$this->list[1]->class   = $this->list[1]->liClass;
 		$this->list[1]->link    = JRoute::_(ContentHelperRoute::getArticleRoute($row->slug, $row->catid, $row->language));
 		$this->list[1]->title   = $heading;
 

--- a/plugins/content/pagebreak/pagebreak.php
+++ b/plugins/content/pagebreak/pagebreak.php
@@ -33,6 +33,14 @@ JLoader::register('ContentHelperRoute', JPATH_SITE . '/components/com_content/he
 class PlgContentPagebreak extends JPlugin
 {
 	/**
+	 * The navigation list with all page objects if parameter 'multipage_toc' is active.
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $list = array();
+
+	/**
 	 * Plugin that adds a pagebreak into the text and truncates text at that point
 	 *
 	 * @param   string   $context  The context of the content being passed to the plugin.
@@ -262,7 +270,6 @@ class PlgContentPagebreak extends JPlugin
 		$limitstart  = $input->getUInt('limitstart', 0);
 		$showall     = $input->getInt('showall', 0);
 		$headingtext = '';
-		$list        = array();
 
 		if ($this->params->get('article_index', 1) == 1)
 		{
@@ -275,11 +282,11 @@ class PlgContentPagebreak extends JPlugin
 		}
 
 		// TOC first Page link.
-		$list[1]          = new stdClass;
-		$list[1]->liClass = ($limitstart === 0 && $showall === 0) ? 'toclink active' : 'toclink';
-		$list[1]->class   = $list[1]->liClass;
-		$list[1]->link    = JRoute::_(ContentHelperRoute::getArticleRoute($row->slug, $row->catid, $row->language));
-		$list[1]->title   = $heading;
+		$this->list[1]          = new stdClass;
+		$this->list[1]->liClass = ($limitstart === 0 && $showall === 0) ? 'toclink active' : 'toclink';
+		$this->list[1]->class   = $list[1]->liClass;
+		$this->list[1]->link    = JRoute::_(ContentHelperRoute::getArticleRoute($row->slug, $row->catid, $row->language));
+		$this->list[1]->title   = $heading;
 
 		$i = 2;
 
@@ -307,24 +314,25 @@ class PlgContentPagebreak extends JPlugin
 				$title = JText::sprintf('PLG_CONTENT_PAGEBREAK_PAGE_NUM', $i);
 			}
 
-			$list[$i]          = new stdClass;
-			$list[$i]->link    = JRoute::_(ContentHelperRoute::getArticleRoute($row->slug, $row->catid, $row->language) . '&limitstart=' . ($i - 1));
-			$list[$i]->title   = $title;
-			$list[$i]->liClass = ($limitstart === $i - 1) ? 'active' : '';
-			$list[$i]->class   = ($limitstart === $i - 1) ? 'toclink active' : 'toclink';
+			$this->list[$i]          = new stdClass;
+			$this->list[$i]->link    = JRoute::_(ContentHelperRoute::getArticleRoute($row->slug, $row->catid, $row->language) . '&limitstart=' . ($i - 1));
+			$this->list[$i]->title   = $title;
+			$this->list[$i]->liClass = ($limitstart === $i - 1) ? 'active' : '';
+			$this->list[$i]->class   = ($limitstart === $i - 1) ? 'toclink active' : 'toclink';
 
 			$i++;
 		}
 
 		if ($this->params->get('showall'))
 		{
-			$list[$i]          = new stdClass;
-			$list[$i]->link    = JRoute::_(ContentHelperRoute::getArticleRoute($row->slug, $row->catid, $row->language) . '&showall=1');
-			$list[$i]->liClass = ($showall === 1) ? 'active' : '';
-			$list[$i]->class   = ($showall === 1) ? 'toclink active' : 'toclink';
-			$list[$i]->title   = JText::_('PLG_CONTENT_PAGEBREAK_ALL_PAGES');
+			$this->list[$i]          = new stdClass;
+			$this->list[$i]->link    = JRoute::_(ContentHelperRoute::getArticleRoute($row->slug, $row->catid, $row->language) . '&showall=1');
+			$this->list[$i]->liClass = ($showall === 1) ? 'active' : '';
+			$this->list[$i]->class   = ($showall === 1) ? 'toclink active' : 'toclink';
+			$this->list[$i]->title   = JText::_('PLG_CONTENT_PAGEBREAK_ALL_PAGES');
 		}
 
+		$list = $this->list;
 		$path = JPluginHelper::getLayoutPath('content', 'pagebreak', 'toc');
 		ob_start();
 		include $path;
@@ -335,8 +343,8 @@ class PlgContentPagebreak extends JPlugin
 	 * Creates the navigation for the item
 	 *
 	 * @param   object  &$row  The article object.  Note $article->text is also available
-	 * @param   int     $page  The total number of pages
-	 * @param   int     $n     The page number
+	 * @param   int     $page  The page number
+	 * @param   int     $n     The total number of pages
 	 *
 	 * @return  void
 	 *

--- a/plugins/content/pagebreak/tmpl/navigation.php
+++ b/plugins/content/pagebreak/tmpl/navigation.php
@@ -20,7 +20,7 @@ $lang = JFactory::getLanguage();
 		$ariaLabel = JText::_('JPREVIOUS') . ': ' . $title . ' (' . JText::sprintf('JLIB_HTML_PAGE_CURRENT_OF_TOTAL', $page, $n) . ')';
 		?>
 		<a class="hasTooltip" href="<?php echo $links['previous']; ?>" title="<?php echo $title; ?>" aria-label="<?php echo $ariaLabel; ?>" rel="prev">
-			<?php echo '<span class="icon-chevron-' . $direction . '" aria-hidden="true"></span> <span aria-hidden="true">' . JText::_('JPREV') . '</span>'; ?>
+			<?php echo '<span class="icon-chevron-' . $direction . '" aria-hidden="true"></span> ' . JText::_('JPREV'); ?>
 		</a>
 		<?php endif; ?>
 	</li>
@@ -31,7 +31,7 @@ $lang = JFactory::getLanguage();
 		$ariaLabel = JText::_('JNEXT') . ': ' . $title . ' (' . JText::sprintf('JLIB_HTML_PAGE_CURRENT_OF_TOTAL', ($page + 2), $n) . ')';
 		?>
 		<a class="hasTooltip" href="<?php echo $links['next']; ?>" title="<?php echo $title; ?>" aria-label="<?php echo $ariaLabel; ?>" rel="next">
-			<?php echo '<span aria-hidden="true">' . JText::_('JNEXT') . '</span> <span class="icon-chevron-' . $direction . '" aria-hidden="true"></span>'; ?>
+			<?php echo JText::_('JNEXT') . ' <span class="icon-chevron-' . $direction . '" aria-hidden="true"></span>'; ?>
 		</a>
 		<?php endif; ?>
 	</li>

--- a/plugins/content/pagebreak/tmpl/navigation.php
+++ b/plugins/content/pagebreak/tmpl/navigation.php
@@ -8,24 +8,31 @@
  */
 
 defined('_JEXEC') or die;
+
+JHtml::_('bootstrap.tooltip');
+$lang = JFactory::getLanguage();
 ?>
 <ul>
 	<li>
-		<?php if ($links['previous']) : ?>
-		<a href="<?php echo $links['previous']; ?>">
-			<?php echo trim(str_repeat(JText::_('JGLOBAL_LT'), 2) . ' ' . JText::_('JPREV')); ?>
+		<?php if ($links['previous']) :
+		$direction = $lang->isRtl() ? 'right' : 'left';
+		$title = htmlspecialchars($this->list[$page]->title, ENT_QUOTES, 'UTF-8');
+		$ariaLabel = JText::_('JPREVIOUS') . ': ' . $title . ' (' . JText::sprintf('JLIB_HTML_PAGE_CURRENT_OF_TOTAL', $page, $n) . ')';
+		?>
+		<a class="hasTooltip" href="<?php echo $links['previous']; ?>" title="<?php echo $title; ?>" aria-label="<?php echo $ariaLabel; ?>" rel="prev">
+			<?php echo '<span class="icon-chevron-' . $direction . '" aria-hidden="true"></span> <span aria-hidden="true">' . JText::_('JPREV') . '</span>'; ?>
 		</a>
-		<?php else: ?>
-		<?php echo JText::_('JPREV'); ?>
 		<?php endif; ?>
 	</li>
 	<li>
-		<?php if ($links['next']) : ?>
-		<a href="<?php echo $links['next']; ?>">
-			<?php echo trim(JText::_('JNEXT') . ' ' . str_repeat(JText::_('JGLOBAL_GT'), 2)); ?>
+		<?php if ($links['next']) :
+		$direction = $lang->isRtl() ? 'left' : 'right';
+		$title = htmlspecialchars($this->list[$page + 2]->title, ENT_QUOTES, 'UTF-8');
+		$ariaLabel = JText::_('JNEXT') . ': ' . $title . ' (' . JText::sprintf('JLIB_HTML_PAGE_CURRENT_OF_TOTAL', ($page + 2), $n) . ')';
+		?>
+		<a class="hasTooltip" href="<?php echo $links['next']; ?>" title="<?php echo $title; ?>" aria-label="<?php echo $ariaLabel; ?>" rel="next">
+			<?php echo '<span aria-hidden="true">' . JText::_('JNEXT') . '</span> <span class="icon-chevron-' . $direction . '" aria-hidden="true"></span>'; ?>
 		</a>
-		<?php else: ?>
-		<?php echo JText::_('JNEXT'); ?>
 		<?php endif; ?>
 	</li>
 </ul>


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/27222

### Summary of Changes
- Add title, aria-label etc. like requested in https://github.com/joomla/joomla-cms/issues/27222
- Add new protected $list to avoid redundant code.
- Remove senseless Next/Previous if not linked (on first and last page).

### Comment
**- Please check if the aria-label should be changed!** I couldn't find any "nice" language strings.
#### Current HTML
```
<ul>
 <li>
  <a class="hasTooltip" href="/path/8-beginners" title="Beginners" aria-label="Previous: Beginners (Page 1 of 7)" rel="prev">
  <span class="icon-chevron-left" aria-hidden="true"></span> <span aria-hidden="true">Prev</span>
  </a>
 </li>
 <li>
  <a class="hasTooltip" href="/path/8-beginners?start=2" title="alias 1" aria-label="Next: alias 1 (Page 3 of 7)" rel="next">
   <span aria-hidden="true">Next</span> <span class="icon-chevron-right" aria-hidden="true"></span>
  </a>
 </li>
</ul>
```

### Testing Instructions
- Create a new article that contains several page breaks.
Mix page breaks with and without title, with and without alias and page breaks without title AND alias.
 
- Make sure that the plugin "Content - Page Break" is enabled and presentation style is set to "Pages".
Test also with setting "Show All" on and off if page numbering still correct.
- Open article in front-end with "Protostar" template.

- Check page break navigation and have also a look on the created HTML.
![03-01-_2020_22-01-09](https://user-images.githubusercontent.com/20780646/71749041-a5257180-2e74-11ea-8fb5-4cd7d90ae432.jpg)

- Has these ugly tooltips now?
- aria-labels; correct numbering?
- and so on

### Expected result
- No B\C break with existing overrides of toc.php ($list versus $this->list).
- No grave changes concerning look&feel etc.
