### PR TITLE
[3.10] Add extension set support to the Joomla Update Component's pre-update checker for extensions

### DIFF
--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -1450,21 +1450,39 @@ ENDDATA;
 	 */
 	public function fetchCompatibility($extensionID, $joomlaTargetVersion)
 	{
-		$updateFileUrls = $this->getUpdateSiteLocations($extensionID);
+		$updateSites = $this->getUpdateSitesInfo($extensionID);
 
-		if (!$updateFileUrls)
+		if (empty($updateSites))
 		{
 			return (object) array('state' => 2);
 		}
 
-		foreach ($updateFileUrls as $updateFileUrl)
+		foreach ($updateSites as $updateSite)
 		{
-			$compatibleVersion = $this->checkCompatibility($updateFileUrl, $joomlaTargetVersion);
-
-			if ($compatibleVersion)
+			if ($updateSite['type'] === 'collection')
 			{
-				// Return the compatible version
-				return (object) array('state' => 1, 'compatibleVersion' => $compatibleVersion->_data);
+				$updateFileUrls = $this->getCollectionDetailsUrls($updateSite, $joomlaTargetVersion);
+
+				foreach ($updateFileUrls as $updateFileUrl)
+				{
+					$compatibleVersion = $this->checkCompatibility(updateFileUrl, $joomlaTargetVersion);
+
+					if ($compatibleVersion)
+					{
+						// Return the compatible version
+						return (object) array('state' => 1, 'compatibleVersion' => $compatibleVersion->_data);
+					}
+				}
+			}
+			else
+			{
+				$compatibleVersion = $this->checkCompatibility($updateSite['location'], $joomlaTargetVersion);
+
+				if ($compatibleVersion)
+				{
+					// Return the compatible version
+					return (object) array('state' => 1, 'compatibleVersion' => $compatibleVersion->_data);
+				}
 			}
 		}
 
@@ -1473,32 +1491,91 @@ ENDDATA;
 	}
 
 	/**
-	 * Get the URL to the update server for a given extension ID
+	 * Returns the update site records for an extension with ID $extensionID.
 	 *
 	 * @param   int  $extensionID  The extension ID
 	 *
-	 * @return  mixed  array of Update URLs or false
+	 * @return  array
 	 *
 	 * @since __DEPLOY_VERSION__
 	 */
-	private function getUpdateSiteLocations($extensionID)
+	private function getUpdateSitesInfo($extensionID)
 	{
 		$db = $this->getDbo();
 		$query = $db->getQuery(true);
 
-		$query->select($db->qn('us.location'))
-			->from($db->qn('#__update_sites', 'us'))
-			->leftJoin(
-				$db->qn('#__update_sites_extensions', 'e')
-				. ' ON ' . $db->qn('e.update_site_id') . ' = ' . $db->qn('us.update_site_id')
-			)
-			->where($db->qn('e.extension_id') . ' = ' . (int) $extensionID);
+		$query->select(
+			$db->qn('us.type') . ', ' .
+			$db->qn('us.location') . ', ' .
+			$db->qn('e.element') . ' AS ' . $db->quoteName('ext_element') . ', ' .
+			$db->qn('e.type') . ' AS ' . $db->quoteName('ext_type') . ', ' .
+			$db->qn('e.folder') . ' AS ' . $db->quoteName('ext_folder')
+		)->from(
+			$db->qn('#__update_sites', 'us')
+		)->leftJoin(
+				$db->qn('#__update_sites_extensions', 'ue')
+				. ' ON ' . $db->qn('ue.update_site_id') . ' = ' . $db->qn('us.update_site_id')
+		)->leftJoin(
+				$db->qn('#__extensions', 'e')
+				. ' ON ' . $db->qn('e.extension_id') . ' = ' . $db->qn('ue.extension_id')
+		)->where($db->qn('e.extension_id') . ' = ' . (int) $extensionID);
 
 		$db->setQuery($query);
 
-		$rows = $db->loadColumn();
+		$result = $db->loadAssocList();
 
-		return $rows ?: false;
+		if (!is_array($result))
+		{
+			return array();
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Method to get details URLs from a colletion update site for given extension and Joomla target version.
+	 *
+	 * @param   array   $updateSiteInfo       The update site and extension information record to process
+	 * @param   string  $joomlaTargetVersion  The Joomla! version to test against,
+	 *
+	 * @return  array  An array of URLs.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	private function getCollectionDetailsUrls($updateSiteInfo, $joomlaTargetVersion)
+	{
+		$return = array();
+
+		$http = new JHttp;
+
+		try
+		{
+			$response = $http->get($updateSiteInfo['location']);
+		}
+		catch (RuntimeException $e)
+		{
+			$response = null;
+		}
+
+		if ($response === null || $response->code !== 200)
+		{
+			return $return;
+		}
+
+		$updateSiteXML = simplexml_load_string($response->body);
+
+		foreach ($updateSiteXML->extension as $extension)
+		{
+			if ($extension->element === $updateSiteInfo['ext_element']
+			&& $extension->type === $updateSiteInfo['ext_type']
+			&& $extension->folder === $updateSiteInfo['ext_folder']
+			&& preg_match('/^' . $extension->targetplatformversion . '/', $joomlaTargetVersion))
+			{
+				$return[] = $extension->detailsurl;
+			}
+		}
+
+		return $return;
 	}
 
 	/**

--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -1491,7 +1491,7 @@ ENDDATA;
 	}
 
 	/**
-	 * Returns the update site records for an extension with ID $extensionID.
+	 * Returns records with update sites and extension information for a given extension ID.
 	 *
 	 * @param   int  $extensionID  The extension ID
 	 *

--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -1566,10 +1566,22 @@ ENDDATA;
 
 		foreach ($updateSiteXML->extension as $extension)
 		{
-			if ((string) $extension['element'] === $updateSiteInfo['ext_element']
-				&& (string) $extension['type'] === $updateSiteInfo['ext_type']
-				&& (string) $extension['folder'] === $updateSiteInfo['ext_folder']
-				&& preg_match('/^' . (string) $extension['targetplatformversion'] . '/', $joomlaTargetVersion))
+			$attribs = new stdClass;
+
+			$attribs->element               = '';
+			$attribs->type                  = '';
+			$attribs->folder                = '';
+			$attribs->targetplatformversion = '';
+
+			foreach ($extension->attributes() as $key => $value)
+			{
+				$attribs->$key = (string) $value;
+			}
+
+			if ($attribs->element === $updateSiteInfo['ext_element']
+				&& $attribs->type === $updateSiteInfo['ext_type']
+				&& $attribs->folder === $updateSiteInfo['ext_folder']
+				&& preg_match('/^' . $attribs->targetplatformversion . '/', $joomlaTargetVersion))
 			{
 				$return[] = (string) $extension['detailsurl'];
 			}

--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -1465,7 +1465,7 @@ ENDDATA;
 
 				foreach ($updateFileUrls as $updateFileUrl)
 				{
-					$compatibleVersion = $this->checkCompatibility(updateFileUrl, $joomlaTargetVersion);
+					$compatibleVersion = $this->checkCompatibility($updateFileUrl, $joomlaTargetVersion);
 
 					if ($compatibleVersion)
 					{
@@ -1507,9 +1507,9 @@ ENDDATA;
 		$query->select(
 			$db->qn('us.type') . ', ' .
 			$db->qn('us.location') . ', ' .
-			$db->qn('e.element') . ' AS ' . $db->quoteName('ext_element') . ', ' .
-			$db->qn('e.type') . ' AS ' . $db->quoteName('ext_type') . ', ' .
-			$db->qn('e.folder') . ' AS ' . $db->quoteName('ext_folder')
+			$db->qn('e.element') . ' AS ' . $db->qn('ext_element') . ', ' .
+			$db->qn('e.type') . ' AS ' . $db->qn('ext_type') . ', ' .
+			$db->qn('e.folder') . ' AS ' . $db->qn('ext_folder')
 		)->from(
 			$db->qn('#__update_sites', 'us')
 		)->leftJoin(
@@ -1566,12 +1566,12 @@ ENDDATA;
 
 		foreach ($updateSiteXML->extension as $extension)
 		{
-			if ($extension->element === $updateSiteInfo['ext_element']
-				&& $extension->type === $updateSiteInfo['ext_type']
-				&& $extension->folder === $updateSiteInfo['ext_folder']
-				&& preg_match('/^' . $extension->targetplatformversion . '/', $joomlaTargetVersion))
+			if ((string) $extension['element'] === $updateSiteInfo['ext_element']
+				&& (string) $extension['type'] === $updateSiteInfo['ext_type']
+				&& (string) $extension['folder'] === $updateSiteInfo['ext_folder']
+				&& preg_match('/^' . $extension['targetplatformversion'] . '/', $joomlaTargetVersion))
 			{
-				$return[] = $extension->detailsurl;
+				$return[] = (string) $extension['detailsurl'];
 			}
 		}
 

--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -1569,7 +1569,7 @@ ENDDATA;
 			if ((string) $extension['element'] === $updateSiteInfo['ext_element']
 				&& (string) $extension['type'] === $updateSiteInfo['ext_type']
 				&& (string) $extension['folder'] === $updateSiteInfo['ext_folder']
-				&& preg_match('/^' . $extension['targetplatformversion'] . '/', $joomlaTargetVersion))
+				&& preg_match('/^' . (string) $extension['targetplatformversion'] . '/', $joomlaTargetVersion))
 			{
 				$return[] = (string) $extension['detailsurl'];
 			}

--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -1567,9 +1567,9 @@ ENDDATA;
 		foreach ($updateSiteXML->extension as $extension)
 		{
 			if ($extension->element === $updateSiteInfo['ext_element']
-			&& $extension->type === $updateSiteInfo['ext_type']
-			&& $extension->folder === $updateSiteInfo['ext_folder']
-			&& preg_match('/^' . $extension->targetplatformversion . '/', $joomlaTargetVersion))
+				&& $extension->type === $updateSiteInfo['ext_type']
+				&& $extension->folder === $updateSiteInfo['ext_folder']
+				&& preg_match('/^' . $extension->targetplatformversion . '/', $joomlaTargetVersion))
 			{
 				$return[] = $extension->detailsurl;
 			}


### PR DESCRIPTION
Pull Request for Issue #27319 .

### Summary of Changes

This Pull Request (PR) extends the pre-update checker for extensions in the Joomla Update Component so it can handle extension set XML files (i.e. update sites of type "collection"), too.

Not sure if this is the most elegant way to fix the issue, but I've tried to do it with little impact on existing code.

### Testing Instructions

1. On a clean 3.10-dev branch or latest 3.10 nightly build, go to the "Server" section of Global Configuration and set "Error Reporting" to "Maximum" or "Development".
2. Install @zero-24 's extension "JUEP für Joomla 3" using the zip file from following download: [JUEP.fur.Joomla.3.zip](https://github.com/joomla/joomla-cms/files/3984192/JUEP.fur.Joomla.3.zip).
3. Go to the Joomla Update Component's options and change the update channel to "Custom URL".
4. Enter the update URL for the 4.0 nightlies as custom URL: `https://update.joomla.org/core/nightlies/next_major_list.xml`.
5. Select "Save & Close".
6. Scroll down to the "Extensions Pre-Update Check" section.
Result: Unknown error shown in column "Compatibility", see section "Actual result" below.
7. Check PHP log.
Result: PHP warning, see section "Actual result" below.
8. Apply the patch of this PR.
9. Reload or go again to the Joomla Update Component page and check again the "Extensions Pre-Update Check" section.
Result: The installed version of the extension is shown as not compatible with 4.0, see "Case 1" in section "Expected result" below. The PHP log doesn't show the warning mentioned in section "Actual result" below.
10. Check the update sites for the extension .
Result: There are 2 updates sites with name "JUEP Updates" for extension "System - Joomla Update Email Plugin":
- **1st update site** with URL `https://www.jah-tz.de/downloads/extensions/juep/update.xml` - this is an extension set XML, and the type of the update site is "collection" (not visible in the Update Sites view in backend but in database and in the extensions's XML file `plugins/system/updateemail/updateemail.xml`).
- **2nd update site** with URL `http://www.jah-tz.de/downloads/extensions/juep/sts/update.xml` - this is a "normal" (i.e. not extension set) XML, and the type of the update site is "extension" (not visible in the Update Sites view in backend but in database and in the extensions's XML file `plugins/system/updateemail/updateemail.xml`).
11. Using tools like e.g. PhpMyAdmin or PhpPgAdmin (depending on your db type), change the URL of the **1st update site** in field `location` of the `#__update_sites` table to `https://test5.richard-fath.de/test-pr27410_update.xml`. This will make it point to a modified extension set xml file so that the target platform version of the extension's current version is 4.0, and this points then to an update XML also having a target platform version of 4.0 for the extension's current version.
12. Reload the Joomla Update Component page and check again the "Extensions Pre-Update Check" section.
Result: The installed version of the extension is shown as compatible with 4.0, see "Case 2" in section "Expected result" below. The PHP log doesn't show the warning mentioned in section "Actual result" below.
13. Change in database the URL of the **1st update site** in field `location` of the `#__update_sites` table to `https://test5.richard-fath.de/test-pr27410_update_2.xml`. This will make it point to a modified extension set xml file so that the target platform version of an available update for the extension is 4.0, and this points then to an update XML also having a target platform version of 4.0.
14. Reload the Joomla Update Component page and check again the "Extensions Pre-Update Check" section.
Result: An available update version of the extension is shown as compatible with 4.0, see "Case 3" in section "Expected result" below. The PHP log doesn't show the warning mentioned in section "Actual result" below.
15. Change in database the URL of the **1st update site** in field `location` of the `#__update_sites` table to like it was at the beginning, i.e. `https://www.jah-tz.de/downloads/extensions/juep/update.xml`.
16. Change in database the URL of the **2nd update site** in field `location` of the `#__update_sites` table to `https://test5.richard-fath.de/test-pr27410_update-sts.xml` This is a modified "normal" update xml with an available target platform version 4.0 for the extension's current version.
17. Reload the Joomla Update Component page and check again the "Extensions Pre-Update Check" section.
Result: The installed version of the extension is shown as compatible with 4.0, see "Case 2" in section "Expected result" below. The PHP log doesn't show anything new.
18. Change in database the URL of the **2nd update site** in field `location` of the `#__update_sites` table to `https://test5.richard-fath.de/test-pr27410_update-sts_2.xml` This is a modified "normal" update xml with an available target platform version 4.0 for an available update for the extension.
19. Reload the Joomla Update Component page and check again the "Extensions Pre-Update Check" section.
Result: An available update version of the extension is shown as compatible with 4.0, see "Case 3" in section "Expected result" below.

### Expected result

Case 1. For an extension with installed version not compatible to 4.0 and no compatible update available:
![snap-02](https://user-images.githubusercontent.com/7413183/71783028-619c4600-2fe1-11ea-8c83-32ced007358b.png)

Case 2. For an extension with installed version compatible to 4.0:
![snap-03](https://user-images.githubusercontent.com/7413183/71783491-c2c71800-2fe7-11ea-9549-589bb7c85f5d.png)

Case 3. For an extension with installed version not compatible to 4.0 but a compatible update available:
![snap-04](https://user-images.githubusercontent.com/7413183/71783487-be026400-2fe7-11ea-9155-e3978c8d4c22.png)

In all cases: The pre-update checker can handle extension set update servers. The PHP log doesn't show the warning mentioned in section "Actual result" below. For "normal" (i.e. not extension set) update servers everything works with this PR as well as without it.

### Actual result

The pre-update checker can not handle extension set update servers:

![snap-01](https://user-images.githubusercontent.com/7413183/71782921-f7cf6c80-2fdf-11ea-9f87-8613db2f771f.png)

In PHP log: `PHP Warning:  Creating default object from empty value in /home/richard/lamp/public_html/joomla-cms-3.10-dev/libraries/src/Updater/Update.php on line 297`

### Aditional information

The pre-update checker currently doesn't care if an update site is enabled or not, it uses it anyway for the checks. This PR here doesn't change that.

I don't know if this is intended or if it's a bug. If it's a bug, a new issue should be opened and/or a new PR should be made.

### Documentation Changes Required

None.