### PR TITLE
Revert "Fix batchSelector is undefined (#27390)"

### DIFF
--- a/build/media_source/layouts/js/joomla/html/batch/batch-language.es6.js
+++ b/build/media_source/layouts/js/joomla/html/batch/batch-language.es6.js
@@ -34,7 +34,9 @@
 
     if (batchCopyMove) {
       batchCopyMove.classList.add('hidden');
-      batchSelector = batchCopyMove;
+    }
+
+    if (batchCopyMove) {
       batchSelector.addEventListener('change', onChange);
     }
 


### PR DESCRIPTION
This reverts commit 6842a9eec27e64d3a49ec816fa4ca87f582aca88.

### Summary of Changes
Reverting as the radio buttons for copy/move no longer displays in the batch window.


