### PR TITLE
[4.0] Password view toggle fixes

### DIFF
--- a/build/media_source/system/js/fields/passwordview.es6.js
+++ b/build/media_source/system/js/fields/passwordview.es6.js
@@ -26,7 +26,7 @@
           input.type = 'text';
 
           // Update the text for screenreaders
-          srText.innerText = Joomla.JText._('JSHOW');
+          srText.innerText = Joomla.Text._('JHIDE');
         } else if (target.classList.contains('icon-eye-close')) {
           // Update the icon class
           target.classList.add('icon-eye');
@@ -36,7 +36,7 @@
           input.type = 'password';
 
           // Update the text for screenreaders
-          srText.innerText = Joomla.JText._('JHIDE');
+          srText.innerText = Joomla.Text._('JSHOW');
         }
       });
     });

--- a/build/media_source/system/js/fields/passwordview.es6.js
+++ b/build/media_source/system/js/fields/passwordview.es6.js
@@ -15,7 +15,7 @@
 
       inputGroup.addEventListener('click', (e) => {
         const { target } = e;
-        const srText = target.previousSibling;
+        const srText = target.firstElementChild;
 
         if (target.classList.contains('icon-eye')) {
           // Update the icon class

--- a/layouts/joomla/form/field/password.php
+++ b/layouts/joomla/form/field/password.php
@@ -95,8 +95,9 @@ $attributes = array(
 			value="<?php echo htmlspecialchars($value, ENT_COMPAT, 'UTF-8'); ?>"
 			<?php echo implode(' ', $attributes); ?>>
 		<span class="input-group-append">
-			<span class="sr-only"><?php echo Text::_('JSHOW'); ?></span>
-			<span class="input-group-text icon-eye input-password-toggle" aria-hidden="true"></span>
+			<button type="button" class="input-group-text icon-eye input-password-toggle">
+				<span class="sr-only"><?php echo Text::_('JSHOW'); ?></span>
+			</button>
 		</span>
 	</div>
 </div>

--- a/modules/mod_login/tmpl/default.php
+++ b/modules/mod_login/tmpl/default.php
@@ -51,8 +51,9 @@ Text::script('JHIDE');
 				<div class="input-group">
 					<input id="modlgn-passwd-<?php echo $module->id; ?>" type="password" name="password" autocomplete="current-password" class="form-control" placeholder="<?php echo Text::_('JGLOBAL_PASSWORD'); ?>">
 					<span class="input-group-append">
-						<span class="sr-only"><?php echo Text::_('JSHOW'); ?></span>
-						<span class="input-group-text icon-eye" aria-hidden="true"></span>
+						<button type="button" class="input-group-text icon-eye input-password-toggle">
+							<span class="sr-only"><?php echo Text::_('JSHOW'); ?></span>
+						</button>
 					</span>
 				</div>
 			<?php else : ?>


### PR DESCRIPTION
Fixes #27401.

### Summary of Changes

Makes password view toggle markup consistent.
Fixes toggler in frontend login form.
Corrects selector in JS.

### Testing Instructions

Test that password view toggle works in admin login, frontend login (module) and registration forms. Check that Show/Hide text is toggled correctly (using screen reader or using browser dev tools).

### Documentation Changes Required

No.