### PR TITLE
Disable password reset requirement when user resets password

### DIFF
--- a/components/com_users/models/reset.php
+++ b/components/com_users/models/reset.php
@@ -212,6 +212,7 @@ class UsersModelReset extends JModelForm
 		$user->password = JUserHelper::hashPassword($data['password1']);
 		$user->activation = '';
 		$user->password_clear = $data['password1'];
+		$user->requireReset = 0;
 
 		// Save the user to the database.
 		if (!$user->save(true))

--- a/components/com_users/models/reset.php
+++ b/components/com_users/models/reset.php
@@ -208,11 +208,15 @@ class UsersModelReset extends JModelForm
 			return false;
 		}
 
+		// Prepare user data.
+		$data['password']   = $data['password1'];
+		$data['activation'] = '';
+
 		// Update the user object.
-		$user->password = JUserHelper::hashPassword($data['password1']);
-		$user->activation = '';
-		$user->password_clear = $data['password1'];
-		$user->requireReset = 0;
+		if (!$user->bind($data))
+		{
+			return new \Exception($user->getError(), 500);
+		}
 
 		// Save the user to the database.
 		if (!$user->save(true))


### PR DESCRIPTION
Closes #27147.

### Summary of Changes

Disable `Password Reset Required` flag when after users complete password reset.

### Testing Instructions

Create a user. Set "Require Password Reset" to `Yes`.
In frontend, use password reset form for that user.
Reset the password.
Login.

### Expected result

Not required to reset password again.

### Actual result

Required to reset password again.

### Documentation Changes Required

No.