### PR TITLE
[4.0] Fix missing asset in ErrorDocument

### DIFF
--- a/libraries/src/Error/Renderer/HtmlRenderer.php
+++ b/libraries/src/Error/Renderer/HtmlRenderer.php
@@ -49,6 +49,10 @@ class HtmlRenderer extends AbstractRenderer
 		// Push the error object into the document
 		$this->getDocument()->setError($error);
 
+		// Add registry file for the template asset
+		$this->getDocument()->getWebAssetManager()->getRegistry()
+			->addRegistryFile('templates/' . $template . '/joomla.asset.json');
+
 		if (ob_get_contents())
 		{
 			ob_end_clean();


### PR DESCRIPTION
Pull Request for Issue #27414 .

### Summary of Changes
The error happen because ErrorDocument does not know assets of the active template.


### Testing Instructions
Please look in #27414



