### PR TITLE
[4.0] Load webcomponents with asset manager

### DIFF
--- a/administrator/components/com_associations/tmpl/association/edit.php
+++ b/administrator/components/com_associations/tmpl/association/edit.php
@@ -22,7 +22,9 @@ HTMLHelper::_('jquery.framework');
 
 HTMLHelper::_('script', 'com_associations/sidebyside.js', ['version' => 'auto', 'relative' => true]);
 HTMLHelper::_('stylesheet', 'com_associations/sidebyside.css', ['version' => 'auto', 'relative' => true]);
-HTMLHelper::_('webcomponent', 'system/joomla-core-loader.min.js', ['version' => 'auto', 'relative' => true]);
+
+$this->document->getWebAssetManager()
+	->useScript('webcomponent.core-loader');
 
 $options = [
 	'layout'   => $this->app->input->get('layout', '', 'string'),

--- a/administrator/components/com_categories/layouts/joomla/form/field/categoryedit.php
+++ b/administrator/components/com_categories/layouts/joomla/form/field/categoryedit.php
@@ -131,7 +131,9 @@ if ($refreshPage === true)
 	$attr2 .= ' onchange="Joomla.categoryHasChanged(this)"';
 
 	HTMLHelper::_('script', 'layouts/joomla/form/field/category-change.min.js', ['version' => 'auto', 'relative' => true], ['defer' => true]);
-	HTMLHelper::_('webcomponent', 'system/joomla-core-loader.min.js', ['relative' => true, 'version' => 'auto']);
+
+	Factory::getDocument()->getWebAssetManager()
+		->useScript('webcomponent.core-loader');
 
 	// Pass the element id to the javascript
 	Factory::getDocument()->addScriptOptions('category-change', $id);
@@ -144,9 +146,9 @@ else
 Text::script('JGLOBAL_SELECT_NO_RESULTS_MATCH');
 Text::script('JGLOBAL_SELECT_PRESS_TO_SELECT');
 
-Factory::getDocument()->getWebAssetManager()->usePreset('choicesjs');
-
-HTMLHelper::_('webcomponent', 'system/fields/joomla-field-fancy-select.min.js', ['version' => 'auto', 'relative' => true]);
+Factory::getDocument()->getWebAssetManager()
+	->usePreset('choicesjs')
+	->useScript('webcomponent.field-fancy-select');
 ?>
 
 <joomla-field-fancy-select <?php echo $attr2; ?>><?php echo implode($html); ?></joomla-field-fancy-select>

--- a/administrator/components/com_config/tmpl/application/default_mail.php
+++ b/administrator/components/com_config/tmpl/application/default_mail.php
@@ -16,7 +16,8 @@ use Joomla\CMS\Session\Session;
 defined('_JEXEC') or die;
 
 HTMLHelper::_('form.csrf');
-HTMLHelper::_('webcomponent', 'system/fields/joomla-field-send-test-mail.min.js', ['version' => 'auto', 'relative' => true]);
+$this->document->getWebAssetManager()
+	->useScript('webcomponent.field-send-test-mail');
 
 // Load JavaScript message titles
 Text::script('ERROR');

--- a/administrator/components/com_fields/Field/TypeField.php
+++ b/administrator/components/com_fields/Field/TypeField.php
@@ -77,8 +77,9 @@ class TypeField extends ListField
 			}
 		);
 
-		// Loadd the Joomla spinner
-		HTMLHelper::_('webcomponent', 'system/joomla-core-loader.min.js', ['relative' => true, 'version' => 'auto']);
+		// Load the Joomla spinner
+		Factory::getDocument()->getWebAssetManager()
+			->useScript('webcomponent.core-loader');
 
 		// Load the field interactivity script
 		HTMLHelper::_('script', 'com_fields/admin-field-typehaschanged.min.js', ['relative' => true, 'version' => 'auto']);

--- a/administrator/components/com_media/layouts/toolbar/create-folder.php
+++ b/administrator/components/com_media/layouts/toolbar/create-folder.php
@@ -9,10 +9,11 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 
-HTMLHelper::_('webcomponent', 'system/joomla-toolbar-button.min.js', ['version' => 'auto', 'relative' => true]);
+Factory::getDocument()->getWebAssetManager()
+	->useScript('webcomponent.toolbar-button');
 
 $title = Text::_('COM_MEDIA_CREATE_NEW_FOLDER');
 ?>

--- a/administrator/components/com_media/layouts/toolbar/delete.php
+++ b/administrator/components/com_media/layouts/toolbar/delete.php
@@ -9,10 +9,11 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 
-HTMLHelper::_('webcomponent', 'system/joomla-toolbar-button.min.js', ['version' => 'auto', 'relative' => true]);
+Factory::getDocument()->getWebAssetManager()
+	->useScript('webcomponent.toolbar-button');
 
 $title = Text::_('JTOOLBAR_DELETE');
 ?>

--- a/administrator/components/com_media/layouts/toolbar/upload.php
+++ b/administrator/components/com_media/layouts/toolbar/upload.php
@@ -9,10 +9,11 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 
-HTMLHelper::_('webcomponent', 'system/joomla-toolbar-button.min.js', ['version' => 'auto', 'relative' => true]);
+Factory::getDocument()->getWebAssetManager()
+	->useScript('webcomponent.toolbar-button');
 
 $title = Text::_('JTOOLBAR_UPLOAD');
 ?>

--- a/administrator/components/com_modules/layouts/joomla/form/field/modulespositionedit.php
+++ b/administrator/components/com_modules/layouts/joomla/form/field/modulespositionedit.php
@@ -72,8 +72,9 @@ if ($required)
 Text::script('JGLOBAL_SELECT_NO_RESULTS_MATCH');
 Text::script('JGLOBAL_SELECT_PRESS_TO_SELECT');
 
-Factory::getDocument()->getWebAssetManager()->usePreset('choicesjs');
-HTMLHelper::_('webcomponent', 'system/fields/joomla-field-fancy-select.min.js', ['version' => 'auto', 'relative' => true]);
+Factory::getDocument()->getWebAssetManager()
+	->usePreset('choicesjs')
+	->useScript('webcomponent.field-fancy-select');
 
 ?>
 <joomla-field-fancy-select <?php echo implode(' ', $attributes); ?>><?php

--- a/administrator/components/com_modules/tmpl/modules/default_batch_body.php
+++ b/administrator/components/com_modules/tmpl/modules/default_batch_body.php
@@ -31,8 +31,9 @@ $attr = array(
 Text::script('JGLOBAL_SELECT_NO_RESULTS_MATCH');
 Text::script('JGLOBAL_SELECT_PRESS_TO_SELECT');
 
-$this->document->getWebAssetManager()->usePreset('choicesjs');
-HTMLHelper::_('webcomponent', 'system/fields/joomla-field-fancy-select.min.js', ['version' => 'auto', 'relative' => true]);
+$this->document->getWebAssetManager()
+	->usePreset('choicesjs')
+	->useScript('webcomponent.field-fancy-select');
 
 ?>
 

--- a/build/build-modules-js/settings.json
+++ b/build/build-modules-js/settings.json
@@ -310,24 +310,28 @@
         },
         "provideAssets": [
           {
-            "name": "joomla-alert",
+            "name": "webcomponent.joomla-alert",
             "type": "style",
-            "uri": "joomla-alert.min.css"
+            "uri": "joomla-alert.min.css",
+            "webcomponent": true
           },
           {
-            "name": "joomla-tab",
+            "name": "webcomponent.joomla-tab",
             "type": "style",
-            "uri": "joomla-tab.min.css"
+            "uri": "joomla-tab.min.css",
+            "webcomponent": true
           },
           {
-            "name": "joomla-alert",
-            "type": "webcomponent",
-            "uri": "joomla-alert.min.js"
+            "name": "webcomponent.joomla-alert",
+            "type": "script",
+            "uri": "joomla-alert.min.js",
+            "webcomponent": true
           },
           {
-            "name": "joomla-tab",
-            "type": "webcomponent",
-            "uri": "joomla-tab.min.js"
+            "name": "webcomponent.joomla-tab",
+            "type": "script",
+            "uri": "joomla-tab.min.js",
+            "webcomponent": true
           }
         ],
         "dependencies": [],

--- a/build/media_source/system/joomla.asset.json
+++ b/build/media_source/system/joomla.asset.json
@@ -83,6 +83,118 @@
         "punycode"
       ],
       "uri": "media/system/js/fields/validate.min.js"
+    },
+
+    {
+      "name": "webcomponent.field-fancy-select",
+      "type": "script",
+      "uri": "system/fields/joomla-field-fancy-select.min.js",
+      "webcomponent": true,
+      "dependencies": [
+        "choicesjs"
+      ]
+    },
+    {
+      "name": "webcomponent.field-media",
+      "type": "style",
+      "uri": "system/fields/joomla-field-media.min.css",
+      "webcomponent": true
+    },
+    {
+      "name": "webcomponent.field-media",
+      "type": "script",
+      "uri": "system/fields/joomla-field-media.min.js",
+      "webcomponent": true
+    },
+    {
+      "name": "webcomponent.field-module-order",
+      "type": "script",
+      "uri": "system/fields/joomla-field-module-order.min.js",
+      "webcomponent": true
+    },
+    {
+      "name": "webcomponent.field-permissions",
+      "type": "style",
+      "uri": "system/fields/joomla-field-permissions.min.css",
+      "webcomponent": true
+    },
+    {
+      "name": "webcomponent.field-permissions",
+      "type": "script",
+      "uri": "system/fields/joomla-field-permissions.min.js",
+      "webcomponent": true
+    },
+    {
+      "name": "webcomponent.field-send-test-mail",
+      "type": "script",
+      "uri": "system/fields/joomla-field-send-test-mail.min.js",
+      "webcomponent": true
+    },
+    {
+      "name": "webcomponent.field-simple-color",
+      "type": "style",
+      "uri": "system/fields/joomla-field-simple-color.min.css",
+      "webcomponent": true
+    },
+    {
+      "name": "webcomponent.field-simple-color",
+      "type": "script",
+      "uri": "system/fields/joomla-field-simple-color.min.js",
+      "webcomponent": true
+    },
+    {
+      "name": "webcomponent.field-subform",
+      "type": "script",
+      "uri": "system/fields/joomla-field-subform.min.js",
+      "webcomponent": true
+    },
+    {
+      "name": "webcomponent.field-user",
+      "type": "script",
+      "uri": "system/fields/joomla-field-user.min.js",
+      "webcomponent": true
+    },
+    {
+      "name": "webcomponent.core-loader",
+      "type": "script",
+      "uri": "system/joomla-core-loader.min.js",
+      "webcomponent": true
+    },
+    {
+      "name": "webcomponent.hidden-mail",
+      "type": "script",
+      "uri": "system/joomla-hidden-mail.min.js",
+      "webcomponent": true
+    },
+    {
+      "name": "webcomponent.toolbar-button",
+      "type": "script",
+      "uri": "system/joomla-toolbar-button.min.js",
+      "webcomponent": true
+    },
+    {
+      "name": "webcomponent.joomla-alert",
+      "type": "style",
+      "uri": "vendor/joomla-custom-elements/joomla-alert.min.css",
+      "webcomponent": true
+    },
+    {
+      "name": "webcomponent.joomla-alert",
+      "type": "script",
+      "uri": "vendor/joomla-custom-elements/joomla-alert.min.js",
+      "webcomponent": true
+    },
+    {
+      "name": "webcomponent.joomla-tab",
+      "type": "style",
+      "uri": "vendor/joomla-custom-elements/joomla-tab.min.css",
+      "webcomponent": true
+    },
+    {
+      "name": "webcomponent.joomla-tab",
+      "type": "script",
+      "uri": "vendor/joomla-custom-elements/joomla-tab.min.js",
+      "webcomponent": true
     }
   ]
 }

--- a/layouts/joomla/form/field/color/simple.php
+++ b/layouts/joomla/form/field/color/simple.php
@@ -9,7 +9,7 @@
 
 defined('JPATH_BASE') or die;
 
-use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 
 extract($displayData, null);
@@ -53,7 +53,10 @@ $class    = ' class="custom-select ' . trim($class) . '"';
 $disabled = $disabled ? ' disabled' : '';
 $readonly = $readonly ? ' readonly' : '';
 
-HTMLHelper::_('webcomponent', 'system/fields/joomla-field-simple-color.min.js', ['version' => 'auto', 'relative' => true]);
+Factory::getDocument()->getWebAssetManager()
+	->useStyle('webcomponent.field-simple-color')
+	->useScript('webcomponent.field-simple-color');
+
 ?>
 <joomla-field-simple-color text-select="<?php echo Text::_('JFIELD_COLOR_SELECT'); ?>" text-color="<?php echo Text::_('JFIELD_COLOR_VALUE'); ?>" text-close="<?php echo Text::_('JLIB_HTML_BEHAVIOR_CLOSE'); ?>" text-transparent="<?php echo Text::_('JFIELD_COLOR_TRANSPARENT'); ?>">
 	<select name="<?php echo $name; ?>" id="<?php echo $id; ?>"<?php

--- a/layouts/joomla/form/field/list-fancy-select.php
+++ b/layouts/joomla/form/field/list-fancy-select.php
@@ -104,8 +104,9 @@ else
 Text::script('JGLOBAL_SELECT_NO_RESULTS_MATCH');
 Text::script('JGLOBAL_SELECT_PRESS_TO_SELECT');
 
-Factory::getDocument()->getWebAssetManager()->usePreset('choicesjs');
-HTMLHelper::_('webcomponent', 'system/fields/joomla-field-fancy-select.min.js', ['version' => 'auto', 'relative' => true]);
+Factory::getDocument()->getWebAssetManager()
+	->usePreset('choicesjs')
+	->useScript('webcomponent.field-fancy-select');
 
 ?>
 

--- a/layouts/joomla/form/field/media.php
+++ b/layouts/joomla/form/field/media.php
@@ -10,6 +10,7 @@
 defined('JPATH_BASE') or die;
 
 use Joomla\CMS\Component\ComponentHelper;
+use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Uri\Uri;
@@ -101,6 +102,11 @@ $url    = ($readonly ? ''
 		: 'index.php?option=com_media&amp;tmpl=component&amp;asset='
 		. $asset . '&amp;author=' . $authorId)
 	. '&amp;fieldid={field-media-id}&amp;path=local-0:/' . $folder);
+
+Factory::getDocument()->getWebAssetManager()
+	->useStyle('webcomponent.field-media')
+	->useScript('webcomponent.field-media');
+
 ?>
 <joomla-field-media class="field-media-wrapper"
 		type="image" <?php // @TODO add this attribute to the field in order to use it for all media types ?>
@@ -136,7 +142,6 @@ $url    = ($readonly ? ''
 		)
 	);
 
-	HTMLHelper::_('webcomponent', 'system/fields/joomla-field-media.min.js', ['version' => 'auto', 'relative' => true]);
 	Text::script('JLIB_FORM_MEDIA_PREVIEW_EMPTY', true);
 	?>
 	<?php if ($showPreview) : ?>

--- a/layouts/joomla/form/field/moduleorder.php
+++ b/layouts/joomla/form/field/moduleorder.php
@@ -9,7 +9,7 @@
 
 defined('JPATH_BASE') or die;
 
-use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Factory;
 
 extract($displayData);
 
@@ -76,6 +76,8 @@ if ($onchange)
 	$attributes['onchange'] = 'onchange="' . $onchange . '"';
 }
 
-HTMLHelper::_('webcomponent', 'system/fields/joomla-field-module-order.min.js', ['version' => 'auto', 'relative' => true]);
+Factory::getDocument()->getWebAssetManager()
+	->useScript('webcomponent.field-module-order');
+
 ?>
 <joomla-field-module-order <?php echo implode(' ', $attributes); ?>></joomla-field-module-order>

--- a/layouts/joomla/form/field/rules.php
+++ b/layouts/joomla/form/field/rules.php
@@ -53,8 +53,11 @@ $document = Factory::getDocument();
 
 // Add Javascript for permission change
 HTMLHelper::_('form.csrf');
-HTMLHelper::_('webcomponent', 'system/fields/joomla-field-permissions.min.js', ['version' => 'auto', 'relative' => true]);
-HTMLHelper::_('webcomponent', 'vendor/joomla-custom-elements/joomla-tab.min.js', ['version' => 'auto', 'relative' => true]);
+Factory::getDocument()->getWebAssetManager()
+	->useStyle('webcomponent.field-permissions')
+	->useScript('webcomponent.field-permissions')
+	->useStyle('webcomponent.joomla-tab')
+	->useScript('webcomponent.joomla-tab');
 
 // Load JavaScript message titles
 Text::script('ERROR');

--- a/layouts/joomla/form/field/subform/repeatable-table.php
+++ b/layouts/joomla/form/field/subform/repeatable-table.php
@@ -10,7 +10,6 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
-use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
 /**
@@ -34,7 +33,8 @@ extract($displayData);
 // Add script
 if ($multiple)
 {
-	HTMLHelper::_('webcomponent', 'system/fields/joomla-field-subform.min.js', ['version' => 'auto', 'relative' => true]);
+	Factory::getDocument()->getWebAssetManager()
+		->useScript('webcomponent.field-subform');
 }
 
 // Build heading

--- a/layouts/joomla/form/field/subform/repeatable.php
+++ b/layouts/joomla/form/field/subform/repeatable.php
@@ -9,7 +9,7 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 
 /**
@@ -33,8 +33,10 @@ extract($displayData);
 // Add script
 if ($multiple)
 {
-	HTMLHelper::_('webcomponent', 'system/fields/joomla-field-subform.min.js', ['version' => 'auto', 'relative' => true]);
+	Factory::getDocument()->getWebAssetManager()
+		->useScript('webcomponent.field-subform');
 }
+
 $sublayout = empty($groupByFieldset) ? 'section' : 'section-byfieldsets';
 ?>
 

--- a/layouts/joomla/form/field/tag.php
+++ b/layouts/joomla/form/field/tag.php
@@ -121,8 +121,9 @@ else
 Text::script('JGLOBAL_SELECT_NO_RESULTS_MATCH');
 Text::script('JGLOBAL_SELECT_PRESS_TO_SELECT');
 
-Factory::getDocument()->getWebAssetManager()->usePreset('choicesjs');
-HTMLHelper::_('webcomponent', 'system/fields/joomla-field-fancy-select.min.js', ['version' => 'auto', 'relative' => true]);
+Factory::getDocument()->getWebAssetManager()
+	->usePreset('choicesjs')
+	->useScript('webcomponent.field-fancy-select');
 
 ?>
 

--- a/layouts/joomla/form/field/user.php
+++ b/layouts/joomla/form/field/user.php
@@ -9,6 +9,7 @@
 
 defined('JPATH_BASE') or die;
 
+use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Uri\Uri;
@@ -50,7 +51,8 @@ extract($displayData);
 
 if (!$readonly)
 {
-	HTMLHelper::_('webcomponent', 'system/fields/joomla-field-user.min.js', ['version' => 'auto', 'relative' => true]);
+	Factory::getDocument()->getWebAssetManager()
+		->useScript('webcomponent.field-user');
 }
 
 $uri = new Uri('index.php?option=com_users&view=users&layout=modal&tmpl=component&required=0');

--- a/layouts/joomla/system/message.php
+++ b/layouts/joomla/system/message.php
@@ -10,7 +10,7 @@
 defined('JPATH_BASE') or die;
 
 use Joomla\CMS\Application\CMSApplication;
-use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 
 $msgList = $displayData['msgList'];
@@ -28,7 +28,10 @@ $alert = [
 ];
 
 // Alerts progressive enhancement
-HTMLHelper::_('webcomponent', 'vendor/joomla-custom-elements/joomla-alert.min.js', ['version' => 'auto', 'relative' => true]);
+Factory::getDocument()->getWebAssetManager()
+	->useStyle('webcomponent.joomla-alert')
+	->useScript('webcomponent.joomla-alert');
+
 ?>
 <div id="system-message-container" aria-live="polite">
 	<div id="system-message">

--- a/layouts/joomla/toolbar/basic.php
+++ b/layouts/joomla/toolbar/basic.php
@@ -9,11 +9,12 @@
 
 defined('JPATH_BASE') or die;
 
-use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 
-HTMLHelper::_('behavior.core');
-HTMLHelper::_('webcomponent', 'system/joomla-toolbar-button.min.js', ['relative' => true, 'version' => 'auto', 'detectDebug' => true]);
+Factory::getDocument()->getWebAssetManager()
+	->useScript('core')
+	->useScript('webcomponent.toolbar-button');
 
 /**
  * @var  int     $id

--- a/layouts/joomla/toolbar/modal.php
+++ b/layouts/joomla/toolbar/modal.php
@@ -9,10 +9,12 @@
 
 defined('JPATH_BASE') or die;
 
+use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
-HTMLHelper::_('webcomponent', 'system/joomla-toolbar-button.min.js', ['version' => 'auto', 'relative' => true]);
+Factory::getDocument()->getWebAssetManager()
+	->useScript('webcomponent.toolbar-button');
 
 /**
  * Generic toolbar button layout to open a modal
@@ -57,4 +59,4 @@ echo HTMLHelper::_('bootstrap.renderModal',
 						. Text::_('COM_BANNERS_TRACKS_EXPORT') . '</button>',
 	]
 );
-?>
+

--- a/layouts/joomla/toolbar/popup.php
+++ b/layouts/joomla/toolbar/popup.php
@@ -9,11 +9,12 @@
 
 defined('JPATH_BASE') or die;
 
-use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Factory;
 use Joomla\Utilities\ArrayHelper;
 
-HTMLHelper::_('behavior.core');
-HTMLHelper::_('webcomponent', 'system/joomla-toolbar-button.min.js', ['version' => 'auto', 'relative' => true]);
+Factory::getDocument()->getWebAssetManager()
+	->useScript('core')
+	->useScript('webcomponent.toolbar-button');
 
 /**
  * @var  int     $id

--- a/layouts/joomla/toolbar/standard.php
+++ b/layouts/joomla/toolbar/standard.php
@@ -9,10 +9,11 @@
 
 defined('JPATH_BASE') or die;
 
-use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Factory;
 
-HTMLHelper::_('behavior.core');
-HTMLHelper::_('webcomponent', 'system/joomla-toolbar-button.min.js', ['version' => 'auto', 'relative' => true]);
+Factory::getDocument()->getWebAssetManager()
+	->useScript('core')
+	->useScript('webcomponent.toolbar-button');
 
 /**
  * @var  string  $id

--- a/layouts/joomla/toolbar/versions.php
+++ b/layouts/joomla/toolbar/versions.php
@@ -9,12 +9,14 @@
 
 defined('JPATH_BASE') or die;
 
+use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Session\Session;
 
-HTMLHelper::_('behavior.core');
-HTMLHelper::_('webcomponent', 'system/joomla-toolbar-button.min.js', ['version' => 'auto', 'relative' => true]);
+Factory::getDocument()->getWebAssetManager()
+	->useScript('core')
+	->useScript('webcomponent.toolbar-button');
 
 /**
  * @var  string  $id

--- a/libraries/cms/html/email.php
+++ b/libraries/cms/html/email.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\String\PunycodeHelper;
 use Joomla\CMS\Uri\Uri;
@@ -57,7 +57,8 @@ abstract class JHtmlEmail
 		$domain = @$mail[1];
 
 		// Include the email cloaking script
-		HTMLHelper::_('webcomponent', 'system/joomla-hidden-mail.js', ['version' => 'auto', 'relative' => true]);
+		Factory::getDocument()->getWebAssetManager()
+			->useScript('webcomponent.hidden-mail');
 
 		return '<joomla-hidden-mail '
 			. $attribsBefore . ' is-link="'

--- a/libraries/cms/html/uitab.php
+++ b/libraries/cms/html/uitab.php
@@ -9,7 +9,7 @@
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Factory;
 
 /**
  * Utility class for the Joomla core UI Tab element.
@@ -41,7 +41,9 @@ abstract class JHtmlUiTab
 		if (!isset(static::$loaded[__METHOD__][$sig]))
 		{
 			// Include the custom element
-			HTMLHelper::_('webcomponent', 'vendor/joomla-custom-elements/joomla-tab.min.js', ['version' => 'auto', 'relative' => true]);
+			Factory::getDocument()->getWebAssetManager()
+				->useStyle('webcomponent.joomla-tab')
+				->useScript('webcomponent.joomla-tab');
 
 			// Setup options object
 			$opt['active'] = (isset($params['active']) && ($params['active'])) ? (string) $params['active'] : '';

--- a/libraries/src/Document/Renderer/Html/MetasRenderer.php
+++ b/libraries/src/Document/Renderer/Html/MetasRenderer.php
@@ -14,7 +14,6 @@ namespace Joomla\CMS\Document\Renderer\Html;
 use Joomla\CMS\Document\DocumentRenderer;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Helper\TagsHelper;
-use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\WebAsset\WebAssetAttachBehaviorInterface;
 use Joomla\Utilities\ArrayHelper;
 
@@ -45,23 +44,31 @@ class MetasRenderer extends DocumentRenderer
 			$this->_doc->_metaTags['name']['tags'] = implode(', ', $tagsHelper->getTagNames($this->_doc->_metaTags['name']['tags']));
 		}
 
-		if ($this->_doc->getScriptOptions())
-		{
-			HTMLHelper::_('behavior.core');
-		}
-
 		/** @var \Joomla\CMS\Application\CMSApplication $app */
 		$app = Factory::getApplication();
 		$wa  = $this->_doc->getWebAssetManager();
+		$wc  = $this->_doc->getScriptOptions('webcomponents');
 
-		// Check for AttachBehavior
+		if ($this->_doc->getScriptOptions())
+		{
+			$wa->useScript('core');
+		}
+
+		// Check for AttachBehavior and web components
 		foreach ($wa->getAssets('script', true) as $asset)
 		{
 			if ($asset instanceof WebAssetAttachBehaviorInterface)
 			{
 				$asset->onAttachCallback($this->_doc);
 			}
+
+			if ($asset->getOption('webcomponent'))
+			{
+				$wc[] = $asset->getUri();
+			}
 		}
+
+		$this->_doc->addScriptOptions('webcomponents', $wc);
 
 		// Trigger the onBeforeCompileHead event
 		$app->triggerEvent('onBeforeCompileHead');

--- a/libraries/src/Document/Renderer/Html/ScriptsRenderer.php
+++ b/libraries/src/Document/Renderer/Html/ScriptsRenderer.php
@@ -52,6 +52,11 @@ class ScriptsRenderer extends DocumentRenderer
 		{
 			$asset = $item instanceof WebAssetItemInterface ? $item : null;
 
+			if ($asset && $asset->getOption('webcomponent'))
+			{
+				continue;
+			}
+
 			if ($asset)
 			{
 				$src = $asset->getUri();

--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -750,6 +750,10 @@ abstract class HTMLHelper
 	 * @see     HTMLHelper::script()
 	 *
 	 * @return  void
+	 *
+	 * @deprecated 4.0
+	 *
+	 * @TODO: Remove the method after installation will use AssetManager
 	 */
 	public static function webcomponent(string $file, array $options = [])
 	{

--- a/plugins/editors/codemirror/layouts/editors/codemirror/element.php
+++ b/plugins/editors/codemirror/layouts/editors/codemirror/element.php
@@ -10,6 +10,7 @@
 // No direct access
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Uri\Uri;
 
@@ -34,9 +35,14 @@ $option          = 'options=\'' . json_encode($options) . '\'';
 $editor          = 'editor="' . ltrim(HTMLHelper::_('script',  $basePath . 'lib/codemirror' . $extJS, ['version' => 'auto', 'pathOnly' => true]), '/') . '"';
 $addons          = 'addons="' . ltrim(HTMLHelper::_('script', $basePath . 'lib/addons' . $extJS, ['version' => 'auto', 'pathOnly' => true]), '/') . '"';
 
-HTMLHelper::_('stylesheet', $basePath . 'lib/codemirror' . $extCSS, array('version' => 'auto'));
-HTMLHelper::_('stylesheet', $basePath . 'lib/addons' . $extCSS, array('version' => 'auto'));
-HTMLHelper::_('webcomponent', 'plg_editors_codemirror/joomla-editor-codemirror.min.js', array('version' => 'auto', 'relative' => true));
+Factory::getDocument()->getWebAssetManager()
+	->registerAndUseStyle('codemirror.lib.main', $basePath . 'lib/codemirror' . $extCSS)
+	->registerAndUseStyle('codemirror.lib.addons', $basePath . 'lib/addons' . $extCSS, [], [], ['codemirror.lib.main'])
+	->registerAndUseScript(
+		'webcomponent.editor-codemirror',
+		'plg_editors_codemirror/joomla-editor-codemirror.min.js',
+		['webcomponent' => true]
+	);
 
 ?>
 <joomla-editor-codemirror <?php echo $editor . ' ' . $addons . ' ' . $modPath . ' ' . $fsCombo . ' ' . $option; ?>>

--- a/plugins/editors/none/none.php
+++ b/plugins/editors/none/none.php
@@ -9,7 +9,7 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Factory;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\Event\Event;
@@ -59,7 +59,12 @@ class PlgEditorNone extends CMSPlugin
 
 		$readonly = !empty($params['readonly']) ? ' readonly disabled' : '';
 
-		HTMLHelper::_('webcomponent', 'plg_editors_none/joomla-editor-none.min.js', ['version' => 'auto', 'relative' => true]);
+		Factory::getDocument()->getWebAssetManager()
+			->registerAndUseScript(
+				'webcomponent.editor-none',
+				'plg_editors_none/joomla-editor-none.min.js',
+				['webcomponent' => true]
+			);
 
 		return '<joomla-editor-none>'
 			. '<textarea name="' . $name . '" id="' . $id . '" cols="' . $col . '" rows="' . $row


### PR DESCRIPTION
### Summary of Changes
This will load webcomponents with asset manager.


### Testing Instructions
Apply patch run `npm install`
Click around, try create/edit content, all should work as before.


### Expected result
Everything works


### Actual result
Everything works


### Documentation Changes Required
Need to update Asset documentation to describe how to add webcomponent to it.

ping @wilsonge 