### PR TITLE
[4.0] Search inputmode

### DIFF
--- a/administrator/components/com_actionlogs/forms/filter_actionlogs.xml
+++ b/administrator/components/com_actionlogs/forms/filter_actionlogs.xml
@@ -4,6 +4,7 @@
 		<field
 			name="search"
 			type="text"
+			inputmode="search"
 			label="COM_ACTIONLOGS_FILTER_SEARCH_DESC"
 			description="COM_ACTIONLOGS_SEARCH_IN_NAME"
 			hint="JSEARCH_FILTER"

--- a/administrator/components/com_associations/forms/filter_associations.xml
+++ b/administrator/components/com_associations/forms/filter_associations.xml
@@ -24,6 +24,7 @@
 		<field
 			name="search"
 			type="text"
+			inputmode="search"
 			label="COM_ASSOCIATIONS_FILTER_SEARCH_LABEL"
 			description="COM_ASSOCIATIONS_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"

--- a/administrator/components/com_banners/forms/filter_banners.xml
+++ b/administrator/components/com_banners/forms/filter_banners.xml
@@ -4,6 +4,7 @@
 		<field
 			name="search"
 			type="text"
+			inputmode="search"
 			label="COM_BANNERS_BANNERS_FILTER_SEARCH_LABEL"
 			description="COM_BANNERS_BANNERS_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"

--- a/administrator/components/com_banners/forms/filter_clients.xml
+++ b/administrator/components/com_banners/forms/filter_clients.xml
@@ -4,6 +4,7 @@
 		<field
 			name="search"
 			type="text"
+			inputmode="search"
 			label="COM_BANNERS_CLIENTS_FILTER_SEARCH_LABEL"
 			description="COM_BANNERS_CLIENTS_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"

--- a/administrator/components/com_banners/forms/filter_tracks.xml
+++ b/administrator/components/com_banners/forms/filter_tracks.xml
@@ -4,6 +4,7 @@
 		<field
 			name="search"
 			type="text"
+			inputmode="search"
 			label="COM_BANNERS_TRACKS_FILTER_SEARCH_LABEL"
 			description="COM_BANNERS_TRACKS_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"

--- a/administrator/components/com_cache/forms/filter_cache.xml
+++ b/administrator/components/com_cache/forms/filter_cache.xml
@@ -4,6 +4,7 @@
 		<field
 			name="search"
 			type="text"
+			inputmode="search"
 			label="COM_CACHE_FILTER_SEARCH_LABEL"
 			description="COM_CACHE_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"

--- a/administrator/components/com_categories/forms/filter_categories.xml
+++ b/administrator/components/com_categories/forms/filter_categories.xml
@@ -6,6 +6,7 @@
 		<field
 			name="search"
 			type="text"
+			inputmode="search"
 			label="COM_CATEGORIES_FILTER_SEARCH_LABEL"
 			description="COM_CATEGORIES_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"

--- a/administrator/components/com_checkin/forms/filter_checkin.xml
+++ b/administrator/components/com_checkin/forms/filter_checkin.xml
@@ -4,6 +4,7 @@
 		<field
 			name="search"
 			type="text"
+			inputmode="search"
 			label="COM_CHECKIN_FILTER_SEARCH_LABEL"
 			description="COM_CHECKIN_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"
@@ -23,7 +24,7 @@
 			<option value="table DESC">COM_CHECKIN_DATABASE_TABLE_DESC</option>
 			<option value="count ASC">COM_CHECKIN_ITEMS_TO_CHECK_IN_ASC</option>
 			<option value="count DESC">COM_CHECKIN_ITEMS_TO_CHECK_IN_DESC</option>
-		</field> 
+		</field>
 		<field
 			name="limit"
 			type="limitbox"

--- a/administrator/components/com_contact/forms/filter_contacts.xml
+++ b/administrator/components/com_contact/forms/filter_contacts.xml
@@ -6,6 +6,7 @@
 		<field
 			name="search"
 			type="text"
+			inputmode="search"
 			label="COM_CONTACT_FILTER_SEARCH_LABEL"
 			description="COM_CONTACT_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"

--- a/administrator/components/com_content/forms/filter_articles.xml
+++ b/administrator/components/com_content/forms/filter_articles.xml
@@ -4,6 +4,7 @@
 		<field
 			name="search"
 			type="text"
+			inputmode="search"
 			label="COM_CONTENT_FILTER_SEARCH_LABEL"
 			description="COM_CONTENT_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"

--- a/administrator/components/com_content/forms/filter_featured.xml
+++ b/administrator/components/com_content/forms/filter_featured.xml
@@ -4,6 +4,7 @@
 		<field
 			name="search"
 			type="text"
+			inputmode="search"
 			label="COM_CONTENT_FILTER_SEARCH_LABEL"
 			description="COM_CONTENT_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"

--- a/administrator/components/com_csp/forms/filter_reports.xml
+++ b/administrator/components/com_csp/forms/filter_reports.xml
@@ -4,6 +4,7 @@
 		<field
 			name="search"
 			type="text"
+			inputmode="search"
 			label="COM_CSP_FILTER_SEARCH_LABEL"
 			description="COM_CSP_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"

--- a/administrator/components/com_fields/forms/filter_fields.xml
+++ b/administrator/components/com_fields/forms/filter_fields.xml
@@ -12,6 +12,7 @@
 		<field
 			name="search"
 			type="text"
+			inputmode="search"
 			label=""
 			hint="JSEARCH_FILTER"
 			class="js-stools-search-string"

--- a/administrator/components/com_fields/forms/filter_groups.xml
+++ b/administrator/components/com_fields/forms/filter_groups.xml
@@ -12,6 +12,7 @@
 		<field
 			name="search"
 			type="text"
+			inputmode="search"
 			hint="JSEARCH_FILTER"
 			class="js-stools-search-string"
 		/>

--- a/administrator/components/com_finder/forms/filter_filters.xml
+++ b/administrator/components/com_finder/forms/filter_filters.xml
@@ -4,6 +4,7 @@
 		<field
 			name="search"
 			type="text"
+			inputmode="search"
 			label="COM_FINDER_SEARCH_FILTER_SEARCH_LABEL"
 			description="COM_FINDER_SEARCH_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"

--- a/administrator/components/com_finder/forms/filter_index.xml
+++ b/administrator/components/com_finder/forms/filter_index.xml
@@ -4,6 +4,7 @@
 		<field
 			name="search"
 			type="text"
+			inputmode="search"
 			label="COM_FINDER_INDEX_SEARCH_LABEL"
 			description="COM_FINDER_INDEX_SEARCH_DESC"
 			hint="JSEARCH_FILTER"

--- a/administrator/components/com_finder/forms/filter_maps.xml
+++ b/administrator/components/com_finder/forms/filter_maps.xml
@@ -4,6 +4,7 @@
 		<field
 			name="search"
 			type="text"
+			inputmode="search"
 			label="COM_FINDER_SEARCH_SEARCH_QUERY_LABEL"
 			description="COM_FINDER_SEARCH_SEARCH_QUERY_DESC"
 			hint="JSEARCH_FILTER"

--- a/administrator/components/com_finder/forms/filter_searches.xml
+++ b/administrator/components/com_finder/forms/filter_searches.xml
@@ -4,6 +4,7 @@
 		<field
 			name="search"
 			type="text"
+			inputmode="search"
 			label="COM_FINDER_SEARCH_IN_PHRASE_LABEL"
 			description="COM_FINDER_SEARCH_IN_PHRASE_DESC"
 			hint="JSEARCH_FILTER"

--- a/administrator/components/com_installer/forms/filter_database.xml
+++ b/administrator/components/com_installer/forms/filter_database.xml
@@ -4,6 +4,7 @@
 		<field
 			name="search"
 			type="text"
+			inputmode="search"
 			label="COM_INSTALLER_MANAGE_FILTER_SEARCH_LABEL"
 			description="COM_INSTALLER_MANAGE_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"

--- a/administrator/components/com_installer/forms/filter_discover.xml
+++ b/administrator/components/com_installer/forms/filter_discover.xml
@@ -4,6 +4,7 @@
 		<field
 			name="search"
 			type="text"
+			inputmode="search"
 			label="COM_INSTALLER_DISCOVER_FILTER_SEARCH_LABEL"
 			description="COM_INSTALLER_DISCOVER_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"

--- a/administrator/components/com_installer/forms/filter_languages.xml
+++ b/administrator/components/com_installer/forms/filter_languages.xml
@@ -4,6 +4,7 @@
 		<field
 			name="search"
 			type="text"
+			inputmode="search"
 			label="COM_INSTALLER_LANGUAGES_FILTER_SEARCH_LABEL"
 			description="COM_INSTALLER_LANGUAGES_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"

--- a/administrator/components/com_installer/forms/filter_manage.xml
+++ b/administrator/components/com_installer/forms/filter_manage.xml
@@ -4,6 +4,7 @@
 		<field
 			name="search"
 			type="text"
+			inputmode="search"
 			label="COM_INSTALLER_MANAGE_FILTER_SEARCH_LABEL"
 			description="COM_INSTALLER_MANAGE_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"

--- a/administrator/components/com_installer/forms/filter_update.xml
+++ b/administrator/components/com_installer/forms/filter_update.xml
@@ -4,6 +4,7 @@
 		<field
 			name="search"
 			type="text"
+			inputmode="search"
 			label="COM_INSTALLER_UPDATE_FILTER_SEARCH_LABEL"
 			description="COM_INSTALLER_UPDATE_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"

--- a/administrator/components/com_installer/forms/filter_updatesites.xml
+++ b/administrator/components/com_installer/forms/filter_updatesites.xml
@@ -4,6 +4,7 @@
 		<field
 			name="search"
 			type="text"
+			inputmode="search"
 			label="COM_INSTALLER_UPDATESITES_FILTER_SEARCH_LABEL"
 			description="COM_INSTALLER_UPDATESITES_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"

--- a/administrator/components/com_languages/forms/filter_installed.xml
+++ b/administrator/components/com_languages/forms/filter_installed.xml
@@ -14,6 +14,7 @@
 		<field
 			name="search"
 			type="text"
+			inputmode="search"
 			label="COM_LANGUAGES_INSTALLED_FILTER_SEARCH_LABEL"
 			description="COM_LANGUAGES_INSTALLED_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"

--- a/administrator/components/com_languages/forms/filter_languages.xml
+++ b/administrator/components/com_languages/forms/filter_languages.xml
@@ -4,6 +4,7 @@
 		<field
 			name="search"
 			type="text"
+			inputmode="search"
 			label="JSEARCH_FILTER"
 			description="COM_LANGUAGES_SEARCH_IN_TITLE"
 			hint="JSEARCH_FILTER"

--- a/administrator/components/com_languages/forms/filter_overrides.xml
+++ b/administrator/components/com_languages/forms/filter_overrides.xml
@@ -14,6 +14,7 @@
 		<field
 			name="search"
 			type="text"
+			inputmode="search"
 			label="JSEARCH_FILTER"
 			description="COM_LANGUAGES_SEARCH_IN_TITLE"
 			hint="JSEARCH_FILTER"

--- a/administrator/components/com_mails/Model/TemplateModel.php
+++ b/administrator/components/com_mails/Model/TemplateModel.php
@@ -15,7 +15,6 @@ use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\MVC\Model\AdminModel;
 use Joomla\CMS\Object\CMSObject;
-use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Table\Table;
 use Joomla\Registry\Registry;
 use Joomla\Utilities\ArrayHelper;
@@ -287,7 +286,7 @@ class TemplateModel extends AdminModel
 		$isNew = true;
 
 		// Include the plugins for the save events.
-		PluginHelper::importPlugin($this->events_map['save']);
+		\JPluginHelper::importPlugin($this->events_map['save']);
 
 		// Allow an exception to be thrown.
 		try

--- a/administrator/components/com_mails/forms/filter_templates.xml
+++ b/administrator/components/com_mails/forms/filter_templates.xml
@@ -4,6 +4,7 @@
 		<field
 			name="search"
 			type="text"
+			inputmode="search"
 			label="COM_MAILS_FILTER_SEARCH_LABEL"
 			description="COM_MAILS_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"

--- a/administrator/components/com_menus/forms/filter_items.xml
+++ b/administrator/components/com_menus/forms/filter_items.xml
@@ -26,6 +26,7 @@
 		<field
 			name="search"
 			type="text"
+			inputmode="search"
 			hint="JSEARCH_FILTER"
 			noresults="JGLOBAL_NO_MATCHING_RESULTS"
 		/>

--- a/administrator/components/com_menus/forms/filter_itemsadmin.xml
+++ b/administrator/components/com_menus/forms/filter_itemsadmin.xml
@@ -27,6 +27,7 @@
 		<field
 			name="search"
 			type="text"
+			inputmode="search"
 			label="COM_MENUS_ITEMS_SEARCH_FILTER_LABEL"
 			description="COM_MENUS_ITEMS_SEARCH_FILTER"
 			hint="JSEARCH_FILTER"

--- a/administrator/components/com_menus/forms/filter_menus.xml
+++ b/administrator/components/com_menus/forms/filter_menus.xml
@@ -14,6 +14,7 @@
 		<field
 			name="search"
 			type="text"
+			inputmode="search"
 			label="COM_MENUS_MENUS_FILTER_SEARCH_LABEL"
 			description="COM_MENUS_MENUS_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"

--- a/administrator/components/com_messages/forms/filter_messages.xml
+++ b/administrator/components/com_messages/forms/filter_messages.xml
@@ -4,6 +4,7 @@
 		<field
 			name="search"
 			type="text"
+			inputmode="search"
 			label="COM_MESSAGES_FILTER_SEARCH_LABEL"
 			description="COM_MESSAGES_SEARCH_IN_SUBJECT"
 			hint="JSEARCH_FILTER"
@@ -35,7 +36,7 @@
 			<option value="a.user_id_from DESC">COM_MESSAGES_HEADING_FROM_DESC</option>
 			<option value="a.date_time ASC">JDATE_ASC</option>
 			<option value="a.date_time DESC">JDATE_DESC</option>
-		</field> 
+		</field>
 		<field
 			name="limit"
 			type="limitbox"

--- a/administrator/components/com_modules/forms/filter_modules.xml
+++ b/administrator/components/com_modules/forms/filter_modules.xml
@@ -14,6 +14,7 @@
 		<field
 			name="search"
 			type="text"
+			inputmode="search"
 			label="COM_MODULES_MODULES_FILTER_SEARCH_LABEL"
 			description="COM_MODULES_MODULES_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"

--- a/administrator/components/com_modules/forms/filter_modulesadmin.xml
+++ b/administrator/components/com_modules/forms/filter_modulesadmin.xml
@@ -16,6 +16,7 @@
 		<field
 			name="search"
 			type="text"
+			inputmode="search"
 			label="COM_MODULES_MODULES_FILTER_SEARCH_LABEL"
 			description="COM_MODULES_MODULES_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"

--- a/administrator/components/com_newsfeeds/forms/filter_newsfeeds.xml
+++ b/administrator/components/com_newsfeeds/forms/filter_newsfeeds.xml
@@ -6,6 +6,7 @@
 		<field
 			name="search"
 			type="text"
+			inputmode="search"
 			label="COM_NEWSFEEDS_FILTER_SEARCH_LABEL"
 			description="COM_NEWSFEEDS_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"

--- a/administrator/components/com_plugins/forms/filter_plugins.xml
+++ b/administrator/components/com_plugins/forms/filter_plugins.xml
@@ -4,6 +4,7 @@
 		<field
 			name="search"
 			type="text"
+			inputmode="search"
 			label="COM_PLUGINS_FILTER_SEARCH_LABEL"
 			description="COM_PLUGINS_SEARCH_IN_TITLE"
 			hint="JSEARCH_FILTER"

--- a/administrator/components/com_privacy/forms/filter_consents.xml
+++ b/administrator/components/com_privacy/forms/filter_consents.xml
@@ -6,6 +6,7 @@
 		<field
 			name="search"
 			type="text"
+			inputmode="search"
 			label="COM_PRIVACY_FILTER_SEARCH_LABEL"
 			description="COM_PRIVACY_SEARCH_IN_USERNAME"
 			hint="JSEARCH_FILTER"

--- a/administrator/components/com_privacy/forms/filter_requests.xml
+++ b/administrator/components/com_privacy/forms/filter_requests.xml
@@ -4,6 +4,7 @@
 		<field
 			name="search"
 			type="text"
+			inputmode="search"
 			label="COM_PRIVACY_FILTER_SEARCH_LABEL"
 			description="COM_PRIVACY_SEARCH_IN_EMAIL"
 			hint="JSEARCH_FILTER"

--- a/administrator/components/com_redirect/forms/filter_links.xml
+++ b/administrator/components/com_redirect/forms/filter_links.xml
@@ -4,6 +4,7 @@
 		<field
 			name="search"
 			type="text"
+			inputmode="search"
 			label="COM_REDIRECT_FILTER_SEARCH_LABEL"
 			description="COM_REDIRECT_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"

--- a/administrator/components/com_tags/forms/filter_tags.xml
+++ b/administrator/components/com_tags/forms/filter_tags.xml
@@ -4,6 +4,7 @@
 		<field
 			name="search"
 			type="text"
+			inputmode="search"
 			label="COM_TAGS_FILTER_SEARCH_LABEL"
 			description="COM_TAGS_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"

--- a/administrator/components/com_templates/forms/filter_styles.xml
+++ b/administrator/components/com_templates/forms/filter_styles.xml
@@ -14,6 +14,7 @@
 		<field
 			name="search"
 			type="text"
+			inputmode="search"
 			label="JSEARCH_FILTER"
 			description="COM_TEMPLATES_STYLES_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"

--- a/administrator/components/com_templates/forms/filter_templates.xml
+++ b/administrator/components/com_templates/forms/filter_templates.xml
@@ -14,6 +14,7 @@
 		<field
 			name="search"
 			type="text"
+			inputmode="search"
 			label="JSEARCH_FILTER"
 			description="COM_TEMPLATES_TEMPLATES_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"

--- a/administrator/components/com_users/forms/filter_debuggroup.xml
+++ b/administrator/components/com_users/forms/filter_debuggroup.xml
@@ -4,6 +4,7 @@
 		<field
 			name="search"
 			type="text"
+			inputmode="search"
 			label="COM_USERS_SEARCH_ASSETS"
 			description="COM_USERS_SEARCH_IN_ASSETS"
 			hint="JSEARCH_FILTER"

--- a/administrator/components/com_users/forms/filter_debuguser.xml
+++ b/administrator/components/com_users/forms/filter_debuguser.xml
@@ -4,6 +4,7 @@
 		<field
 			name="search"
 			type="text"
+			inputmode="search"
 			label="COM_USERS_SEARCH_ASSETS"
 			description="COM_USERS_SEARCH_IN_ASSETS"
 			hint="JSEARCH_FILTER"

--- a/administrator/components/com_users/forms/filter_groups.xml
+++ b/administrator/components/com_users/forms/filter_groups.xml
@@ -4,6 +4,7 @@
 		<field
 			name="search"
 			type="text"
+			inputmode="search"
 			label="COM_USERS_SEARCH_GROUPS_LABEL"
 			description="COM_USERS_SEARCH_IN_GROUPS"
 			hint="JSEARCH_FILTER"

--- a/administrator/components/com_users/forms/filter_levels.xml
+++ b/administrator/components/com_users/forms/filter_levels.xml
@@ -4,6 +4,7 @@
 		<field
 			name="search"
 			type="text"
+			inputmode="search"
 			label="COM_USERS_SEARCH_ACCESS_LEVELS"
 			description="COM_USERS_SEARCH_IN_LEVEL_NAME"
 			hint="JSEARCH_FILTER"

--- a/administrator/components/com_users/forms/filter_notes.xml
+++ b/administrator/components/com_users/forms/filter_notes.xml
@@ -4,6 +4,7 @@
 		<field
 			name="search"
 			type="text"
+			inputmode="search"
 			label="COM_USERS_SEARCH_USER_NOTES"
 			description="COM_USERS_SEARCH_IN_NOTE_TITLE"
 			hint="JSEARCH_FILTER"

--- a/administrator/components/com_users/forms/filter_users.xml
+++ b/administrator/components/com_users/forms/filter_users.xml
@@ -4,6 +4,7 @@
 		<field
 			name="search"
 			type="text"
+			inputmode="search"
 			label="COM_USERS_SEARCH_USERS"
 			description="COM_USERS_SEARCH_IN_NAME"
 			hint="JSEARCH_FILTER"

--- a/administrator/components/com_workflow/forms/filter_stages.xml
+++ b/administrator/components/com_workflow/forms/filter_stages.xml
@@ -4,6 +4,7 @@
 		<field
 			name="search"
 			type="text"
+			inputmode="search"
 			label="COM_WORKFLOW_FILTER_SEARCH_LABEL"
 			hint="JSEARCH_FILTER"
 		/>

--- a/administrator/components/com_workflow/forms/filter_transitions.xml
+++ b/administrator/components/com_workflow/forms/filter_transitions.xml
@@ -4,6 +4,7 @@
 		<field
 			name="search"
 			type="text"
+			inputmode="search"
 			label="COM_WORKFLOW_FILTER_SEARCH_LABEL"
 			hint="JSEARCH_FILTER"
 		/>

--- a/administrator/components/com_workflow/forms/filter_workflows.xml
+++ b/administrator/components/com_workflow/forms/filter_workflows.xml
@@ -4,6 +4,7 @@
 		<field
 			name="search"
 			type="text"
+			inputmode="search"
 			label="COM_WORKFLOW_FILTER_SEARCH_LABEL"
 			description="COM_WORKFLOW_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"

--- a/components/com_contact/forms/filter_contacts.xml
+++ b/components/com_contact/forms/filter_contacts.xml
@@ -6,6 +6,7 @@
 		<field
 			name="search"
 			type="text"
+			inputmode="search"
 			label="COM_CONTACT_FILTER_SEARCH_LABEL"
 			description="COM_CONTACT_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"

--- a/components/com_content/forms/filter_articles.xml
+++ b/components/com_content/forms/filter_articles.xml
@@ -4,6 +4,7 @@
 		<field
 			name="search"
 			type="text"
+			inputmode="search"
 			label="COM_CONTENT_MODAL_FILTER_SEARCH_LABEL"
 			description="COM_CONTENT_MODAL_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"

--- a/components/com_fields/forms/filter_fields.xml
+++ b/components/com_fields/forms/filter_fields.xml
@@ -12,6 +12,7 @@
 		<field
 			name="search"
 			type="text"
+			inputmode="search"
 			label=""
 			hint="JSEARCH_FILTER"
 			class="js-stools-search-string"

--- a/components/com_menus/forms/filter_items.xml
+++ b/components/com_menus/forms/filter_items.xml
@@ -5,6 +5,7 @@
 			<field
 				name="search"
 				type="text"
+				inputmode="search"
 				label="COM_MENUS_ITEMS_SEARCH_FILTER_LABEL"
 				description="COM_MENUS_ITEMS_SEARCH_FILTER"
 				hint="JSEARCH_FILTER"

--- a/components/com_modules/forms/filter_modules.xml
+++ b/components/com_modules/forms/filter_modules.xml
@@ -6,6 +6,7 @@
 		<field
 			name="search"
 			type="text"
+			inputmode="search"
 			label="COM_MODULES_MODULES_FILTER_SEARCH_LABEL"
 			description="COM_MODULES_MODULES_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"


### PR DESCRIPTION
Mobile and touch devices will load a different keyboard depending on the inputmode. This is already implemented for several fields eg url and email

This PR enables it for search fields

As search fields are not a separate field type but type="text" we either have to create a new field type or it has to be added via the form xml. Support for the xml option  was (surprisingly) already implemented so I just had to add the inputmode=search to the xml.

To test this you will need either a mobile device or a touch enabled computer with a virtual keyboard.

When you enter the search field you will see a slightly different keyboard than normal - the actual layout of which is dependent on your device. On my touch screen it looks like this

![image](https://user-images.githubusercontent.com/1296369/71894820-3a5f8900-3147-11ea-81b8-215aed4700eb.png)
