### PR TITLE
Use absolute URLs in action logs

### DIFF
--- a/administrator/components/com_actionlogs/helpers/actionlogs.php
+++ b/administrator/components/com_actionlogs/helpers/actionlogs.php
@@ -224,7 +224,7 @@ class ActionlogsHelper
 			{
 				if (!isset($links[$value]))
 				{
-					$links[$value] = Route::link('administrator', $value, false, $linkMode);
+					$links[$value] = Route::link('administrator', $value, false, $linkMode, true);
 				}
 
 				$value = $links[$value];


### PR DESCRIPTION
Fixes #27431.

### Summary of Changes

Use absolute URLs for links in action log emails.

### Testing Instructions

Make sure `Force HTTPS` option in Global Configuration is disabled.
As super admin, edit your profile. Enable `Send notifications for User Actions Log` option.
Perform a loggable action (e.g. edit an article).
Try clicking the links in the action notification email.

### Expected result

Links take you to your Joomla! website.

### Actual result

Links don't work.

### Documentation Changes Required

No.