### PR TITLE
Remove tooltip from pagebreak

### DIFF
--- a/plugins/content/pagebreak/tmpl/navigation.php
+++ b/plugins/content/pagebreak/tmpl/navigation.php
@@ -9,7 +9,6 @@
 
 defined('_JEXEC') or die;
 
-JHtml::_('bootstrap.tooltip');
 $lang = JFactory::getLanguage();
 ?>
 <ul>
@@ -19,7 +18,7 @@ $lang = JFactory::getLanguage();
 		$title = htmlspecialchars($this->list[$page]->title, ENT_QUOTES, 'UTF-8');
 		$ariaLabel = JText::_('JPREVIOUS') . ': ' . $title . ' (' . JText::sprintf('JLIB_HTML_PAGE_CURRENT_OF_TOTAL', $page, $n) . ')';
 		?>
-		<a class="hasTooltip" href="<?php echo $links['previous']; ?>" title="<?php echo $title; ?>" aria-label="<?php echo $ariaLabel; ?>" rel="prev">
+		<a href="<?php echo $links['previous']; ?>" title="<?php echo $title; ?>" aria-label="<?php echo $ariaLabel; ?>" rel="prev">
 			<?php echo '<span class="icon-chevron-' . $direction . '" aria-hidden="true"></span> ' . JText::_('JPREV'); ?>
 		</a>
 		<?php endif; ?>
@@ -30,7 +29,7 @@ $lang = JFactory::getLanguage();
 		$title = htmlspecialchars($this->list[$page + 2]->title, ENT_QUOTES, 'UTF-8');
 		$ariaLabel = JText::_('JNEXT') . ': ' . $title . ' (' . JText::sprintf('JLIB_HTML_PAGE_CURRENT_OF_TOTAL', ($page + 2), $n) . ')';
 		?>
-		<a class="hasTooltip" href="<?php echo $links['next']; ?>" title="<?php echo $title; ?>" aria-label="<?php echo $ariaLabel; ?>" rel="next">
+		<a href="<?php echo $links['next']; ?>" title="<?php echo $title; ?>" aria-label="<?php echo $ariaLabel; ?>" rel="next">
 			<?php echo JText::_('JNEXT') . ' <span class="icon-chevron-' . $direction . '" aria-hidden="true"></span>'; ?>
 		</a>
 		<?php endif; ?>


### PR DESCRIPTION
Pull Request for Issue #27400 .

### Summary of Changes
This PR removes Tooltips from pagebreak prev and next buttons. It continues the improvment made in #27398. 

### Testing Instructions
Make an article with one or more pagebreaks and inspect the behaviour and sourcecode before and after patch.


