### PR TITLE
[4.0] Fix client filter for menu assignment

### DIFF
--- a/administrator/components/com_menus/Helper/MenusHelper.php
+++ b/administrator/components/com_menus/Helper/MenusHelper.php
@@ -139,7 +139,7 @@ class MenusHelper extends ContentHelper
 	 */
 	public static function getMenuLinks($menuType = null, $parentId = 0, $mode = 0, $published = array(), $languages = array(), $clientId = 0)
 	{
-		$hasClientId = $clientId === null;
+		$hasClientId = $clientId !== null;
 		$clientId    = (int) $clientId;
 
 		$db = Factory::getDbo();


### PR DESCRIPTION
Pull Request for Issue #27446.

### Summary of Changes

Fixes client filter condition.

### Testing Instructions

> Create an admin menu
> Create at least one item in the new admin menu
> Go to Module manager
> Open a site module and go to the menu assignment tab
> Select "Only on the selected pages" from the Module Assignment Tab

### Expected result

>Tree of all SITE menus and menu items

### Actual result

>Tree of ALL menus and menu items - including the admin menu you created in the steps to reproduce

### Documentation Changes Required

No.