### PR TITLE
[4.0] Menu Container Setup [a11y]

### DIFF
--- a/administrator/components/com_menus/tmpl/item/edit_container.php
+++ b/administrator/components/com_menus/tmpl/item/edit_container.php
@@ -45,63 +45,62 @@ HTMLHelper::_('script', 'legacy/treeselectmenu.min.js', ['version' => 'auto', 'r
 			<span class="fa fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 			<?php echo Text::_('COM_MENUS_ITEM_FIELD_COMPONENTS_CONTAINER_HIDE_ITEMS_DESC'); ?>
 		</div>
-		<ul class="treeselect">
 			<?php if (count($menuLinks)) : ?>
-				<?php $prevlevel = 0; ?>
-
-				<li>
-				<?php
-				$params      = new Registry($this->item->params);
-				$hiddenLinks = (array) $params->get('hideitems');
-
-				foreach ($menuLinks as $i => $link) : ?>
+				<ul class="treeselect">
+					<?php $prevlevel = 0; ?>
+					<li>
 					<?php
-					if ($extension = $link->element):
-						$lang->load("$extension.sys", JPATH_ADMINISTRATOR, null, false, true)
-						|| $lang->load("$extension.sys", JPATH_ADMINISTRATOR . '/components/' . $extension, null, false, true);
-					endif;
+					$params      = new Registry($this->item->params);
+					$hiddenLinks = (array) $params->get('hideitems');
 
-					if ($prevlevel < $link->level)
-					{
-						echo '<ul class="treeselect-sub">';
-					}
-					elseif ($prevlevel > $link->level)
-					{
-						echo str_repeat('</li></ul>', $prevlevel - $link->level);
-					}
-					else
-					{
-						echo '</li>';
-					}
+					foreach ($menuLinks as $i => $link) : ?>
+						<?php
+						if ($extension = $link->element):
+							$lang->load("$extension.sys", JPATH_ADMINISTRATOR, null, false, true)
+							|| $lang->load("$extension.sys", JPATH_ADMINISTRATOR . '/components/' . $extension, null, false, true);
+						endif;
 
-					$selected = in_array($link->value, $hiddenLinks) ? 1 : 0;
-					?>
-						<li>
-							<div class="treeselect-item">
-								<input type="checkbox" <?php echo $link->value > 1 ? ' name="jform[params][hideitems][]" ' : ''; ?>
-									   id="<?php echo $id . $link->value; ?>" value="<?php echo (int) $link->value; ?>" class="novalidate checkbox-toggle"
-									<?php echo $selected ? ' checked="checked"' : ''; ?>>
+						if ($prevlevel < $link->level)
+						{
+							echo '<ul class="treeselect-sub">';
+						}
+						elseif ($prevlevel > $link->level)
+						{
+							echo str_repeat('</li></ul>', $prevlevel - $link->level);
+						}
+						else
+						{
+							echo '</li>';
+						}
 
-								<?php if ($link->value == 1): ?>
-									<label for="<?php echo $id . $link->value; ?>" class="btn btn-sm btn-info"><?php echo Text::_('JALL') ?></label>
-								<?php else: ?>
-									<label for="<?php echo $id . $link->value; ?>" class="btn btn-sm btn-danger btn-hide"><?php echo Text::_('JHIDE') ?></label>
-									<label for="<?php echo $id . $link->value; ?>" class="btn btn-sm btn-success btn-show"><?php echo Text::_('JSHOW') ?></label>
-									<label for="<?php echo $id . $link->value; ?>"><?php echo Text::_($link->text); ?></label>
-								<?php endif; ?>
-							</div>
-					<?php
+						$selected = in_array($link->value, $hiddenLinks) ? 1 : 0;
+						?>
+							<li>
+								<div class="treeselect-item">
+									<input type="checkbox" <?php echo $link->value > 1 ? ' name="jform[params][hideitems][]" ' : ''; ?>
+										id="<?php echo $id . $link->value; ?>" value="<?php echo (int) $link->value; ?>" class="novalidate checkbox-toggle"
+										<?php echo $selected ? ' checked="checked"' : ''; ?>>
 
-					if (!isset($menuLinks[$i + 1]))
-					{
-						echo str_repeat('</li></ul>', $link->level);
-					}
-					$prevlevel = $link->level;
-					?>
-					<?php endforeach; ?>
-				</li>
-				<?php endif; ?>
-		</ul>
+									<?php if ($link->value == 1): ?>
+										<label for="<?php echo $id . $link->value; ?>" class="btn btn-sm btn-info"><?php echo Text::_('JALL') ?></label>
+									<?php else: ?>
+										<label for="<?php echo $id . $link->value; ?>" class="btn btn-sm btn-danger btn-hide"><?php echo Text::_('JHIDE') ?></label>
+										<label for="<?php echo $id . $link->value; ?>" class="btn btn-sm btn-success btn-show"><?php echo Text::_('JSHOW') ?></label>
+										<label for="<?php echo $id . $link->value; ?>"><?php echo Text::_($link->text); ?></label>
+									<?php endif; ?>
+								</div>
+						<?php
+
+						if (!isset($menuLinks[$i + 1]))
+						{
+							echo str_repeat('</li></ul>', $link->level);
+						}
+						$prevlevel = $link->level;
+						?>
+						<?php endforeach; ?>
+					</li>
+				</ul>
+			<?php endif; ?>
 		<joomla-alert id="noresultsfound" type="warning" class="hidden"><?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?></joomla-alert>
 		<?php endif; ?>
 	</div>

--- a/administrator/components/com_menus/tmpl/item/edit_container.php
+++ b/administrator/components/com_menus/tmpl/item/edit_container.php
@@ -41,14 +41,14 @@ HTMLHelper::_('script', 'legacy/treeselectmenu.min.js', ['version' => 'auto', 'r
 		</div>
 
 		<hr>
-
+		<div class="alert alert-info">
+			<span class="fa fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+			<?php echo Text::_('COM_MENUS_ITEM_FIELD_COMPONENTS_CONTAINER_HIDE_ITEMS_DESC'); ?>
+		</div>
 		<ul class="treeselect">
 			<?php if (count($menuLinks)) : ?>
 				<?php $prevlevel = 0; ?>
-				<div class="alert alert-info">
-					<span class="fa fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
-					<?php echo Text::_('COM_MENUS_ITEM_FIELD_COMPONENTS_CONTAINER_HIDE_ITEMS_DESC'); ?>
-				</div>
+
 				<li>
 				<?php
 				$params      = new Registry($this->item->params);


### PR DESCRIPTION
#### Issue
`Ensures that lists are structured correctly` ([list](https://dequeuniversity.com/rules/axe/3.3/list?application=msftAI))

You can not have a div inside a ul

#### Target application
[Menus: New Item - 4.0 Test Site - Administration](http://localhost/joomla-cms/administrator/index.php?option=com_menus&view=item&client_id=1&menutype=admin-bt&layout=edit)
#### Element path
.treeselect
#### Snippet
```
<ul class="treeselect">
<div class="alert alert-info">
```

### Solution
This PR simply moves the div to directly above the `<ul>`

There is no visual change
