### PR TITLE
[4.0] Admin link to the front end

### DIFF
--- a/administrator/language/en-GB/mod_frontend.ini
+++ b/administrator/language/en-GB/mod_frontend.ini
@@ -4,5 +4,5 @@
 ; Note : All ini files need to be saved as UTF-8
 
 MOD_FRONTEND="Frontend Link"
-MOD_FRONTEND_PREVIEW="Preview %s"
+MOD_FRONTEND_PREVIEW="Open frontend of %s in a new window."
 MOD_FRONTEND_XML_DESCRIPTION="This module shows a link to the frontend."


### PR DESCRIPTION
Clarifies the title text for this link. It's not a preview as that implies it is something not generally available yet.

This link is present in the top right of the admin login screen and every admin page

### Before
Preview <sitename>

### After
Open frontend of `<sitename>` in a new window.

Pull Request for Issue #26316