### PR TITLE
[4.0] Add user note - Validation

### DIFF
--- a/layouts/joomla/form/field/user.php
+++ b/layouts/joomla/form/field/user.php
@@ -136,7 +136,7 @@ if (!$readonly)
 	</div>
 	<?php // Create the real field, hidden, that stored the user id. ?>
 	<?php if (!$readonly) : ?>
-		<input type="hidden" id="<?php echo $id; ?>_id" name="<?php echo $name; ?>" value="<?php echo (int) $value; ?>"
+		<input type="hidden" id="<?php echo $id; ?>_id" name="<?php echo $name; ?>" value="<?php echo $value; ?>"
 				class="field-user-input <?php echo $class ? (string) $class : ''?>"
 				data-onchange="<?php echo $this->escape($onchange); ?>">
 	<?php endif; ?>


### PR DESCRIPTION
PR for #26907

See #26907 for steps to replicate the issue

The problem is because the value had a default of 0 and therefore was not empty

This was caused by  `value="<?php echo (int) $value; ?>"`

Casting to integer results in 0 as an empty value and therefore is not empty as the validation expects