### PR TITLE
[4.0] TinyMCE image button

### DIFF
--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -989,6 +989,7 @@ class PlgEditorTinymce extends CMSPlugin
 			'nonbreaking'    => array('label' => 'Nonbreaking space', 'plugin' => 'nonbreaking'),
 			'emoticons'      => array('label' => 'Emoticons', 'plugin' => 'emoticons'),
 			'media'          => array('label' => 'Insert/edit video', 'plugin' => 'media'),
+			'image'          => array('label' => 'Insert/edit image', 'plugin' => 'image'),
 			'pagebreak'      => array('label' => 'Page break', 'plugin' => 'pagebreak'),
 			'print'          => array('label' => 'Print', 'plugin' => 'print'),
 			'preview'        => array('label' => 'Preview', 'plugin' => 'preview'),


### PR DESCRIPTION
Similar to #24765 but thus time it was the image button that was missing.

Apply the PR
Check that the image button appears in the wysiwyg editor in
1. Content item
2. Plugin options set 0
3. Plugin options list of available buttons

![image](https://user-images.githubusercontent.com/1296369/72167956-15c41500-33c4-11ea-8834-95c5d0c8b9be.png)
