### PR TITLE
[4.0] Admin custom menu item

### DIFF
--- a/administrator/components/com_menus/tmpl/item/edit.php
+++ b/administrator/components/com_menus/tmpl/item/edit.php
@@ -50,13 +50,15 @@ if ($clientId === 1)
 
 	<?php // Add the translation of the menu item title when client is administrator ?>
 	<?php if ($clientId === 1 && $this->item->id != 0) : ?>
-		<div class="form-inline form-inline-header">
-			<div class="control-group">
-				<div class="control-label">
-					<label for="menus_title_translation"><?php echo Text::sprintf('COM_MENUS_TITLE_TRANSLATION', $lang); ?></label>
-				</div>
-				<div class="controls">
-					<input id="menus_title_translation" class="form-control" value="<?php echo Text::_($this->item->title); ?>" readonly="readonly" type="text">
+		<div class="row title-alias form-vertical form-no-margin mb-3">
+			<div class="col-12">
+				<div class="control-group">
+					<div class="control-label">
+						<label for="menus_title_translation"><?php echo Text::sprintf('COM_MENUS_TITLE_TRANSLATION', $lang); ?></label>
+					</div>
+					<div class="controls">
+						<input id="menus_title_translation" class="form-control" value="<?php echo Text::_($this->item->title); ?>" readonly="readonly" type="text">
+					</div>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
When you create a custom admin menu there is the possibility to add translations for each menu item using the language override system.

The actual text that will be displayed for the menu item is displayed in a read only field.

This PR gives it some styling love and care

Pull Request for Issue #27448 .

### Before

![image](https://user-images.githubusercontent.com/1296369/72067642-277dbd80-32db-11ea-97bb-95dca51d6f71.png)



### After
![image](https://user-images.githubusercontent.com/1296369/72190962-bdf3d100-33f8-11ea-93ed-34656664844e.png)
