### PR TITLE
[4.0] Remove jQuery and boostrap.js deps for templates (redo of #23742)

### DIFF
--- a/administrator/templates/atum/joomla.asset.json
+++ b/administrator/templates/atum/joomla.asset.json
@@ -55,7 +55,6 @@
       "type": "preset",
       "dependencies": [
         "core#script",
-        "bootstrap.js.bundle#script",
         "css-vars-ponyfill#script",
         "focus-visible#script",
         "template.atum#script"

--- a/templates/cassiopeia/joomla.asset.json
+++ b/templates/cassiopeia/joomla.asset.json
@@ -49,9 +49,7 @@
       "type": "script",
       "uri": "template.js",
       "dependencies": [
-        "core",
-        "jquery",
-        "bootstrap.js.bundle"
+        "core"
       ]
     },
     {

--- a/templates/cassiopeia/joomla.asset.json
+++ b/templates/cassiopeia/joomla.asset.json
@@ -49,7 +49,8 @@
       "type": "script",
       "uri": "template.js",
       "dependencies": [
-        "core"
+        "core",
+        "bootstrap.js.bundle"
       ]
     },
     {


### PR DESCRIPTION
### Summary of Changes
Remove jQuery and boostrap.js dependencies for a templates. 
Partial redo of #23742, that lost somewhere while waiting for #25775


### Testing Instructions

Apply patch, and make sure all still works.

### Expected result
Works


### Actual result
Works


### Documentation Changes Required

nope