### PR TITLE
[4.0][RFC] Shortkut for quick access to Factory::getApplication()->getDocument()->getWebAssetManager()

### DIFF
--- a/layouts/joomla/form/field/list-fancy-select.php
+++ b/layouts/joomla/form/field/list-fancy-select.php
@@ -9,7 +9,6 @@
 
 defined('JPATH_BASE') or die;
 
-use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
@@ -104,7 +103,7 @@ else
 Text::script('JGLOBAL_SELECT_NO_RESULTS_MATCH');
 Text::script('JGLOBAL_SELECT_PRESS_TO_SELECT');
 
-Factory::getDocument()->getWebAssetManager()
+HTMLHelper::webAsset()
 	->usePreset('choicesjs')
 	->useScript('webcomponent.field-fancy-select');
 

--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -738,6 +738,18 @@ abstract class HTMLHelper
 	}
 
 	/**
+	 * Helper method to quick access to Web Asset Manager
+	 *
+	 * @return \Joomla\CMS\WebAsset\WebAssetManager
+	 *
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static function webAsset()
+	{
+		return Factory::getApplication()->getDocument()->getWebAssetManager();
+	}
+
+	/**
 	 * Loads the path of a custom element or webcomponent into the scriptOptions object
 	 *
 	 * @param   string  $file     The path of the web component (expects the ES6 version). File need to have also an


### PR DESCRIPTION
### Summary of Changes 

It would be good to have some Shortkut for `Factory::getApplication()->getDocument()->getWebAssetManager()`, to use it in layouts.
In a template it is enough to have `$this->getWebAssetManager()`, but in layouts and other parts it a bit to complex to use `Factory::getApplication()->getDocument()->getWebAssetManager()`.

I am not sure what is good place/name for it. For now I made it as `HTMLHelper::webAsset()`
That should be used as `HTMLHelper::webAsset()` (not `HTMLHelper::_('webAsset')`), it is important to support code navigation and auto-completion.

But I am afraid it can be confusing, because historically all HTML helpers methods should be called as `HTMLHelper::_('foobar')`.

@wilsonge maybe you have a better idea, to make it nicer and not much confusing? ;)
What other place/approach can be for it?


### Documentation Changes Required
Add info about this.
