### PR TITLE
[sqlsrv] database name with dot

### DIFF
--- a/libraries/joomla/database/driver/sqlsrv.php
+++ b/libraries/joomla/database/driver/sqlsrv.php
@@ -772,7 +772,7 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 			return false;
 		}
 
-		if (!sqlsrv_query($this->connection, 'USE ' . $database, null, array('scrollable' => SQLSRV_CURSOR_STATIC)))
+		if (!sqlsrv_query($this->connection, 'USE [' . $database .']', null, array('scrollable' => SQLSRV_CURSOR_STATIC)))
 		{
 			throw new JDatabaseExceptionConnecting('Could not connect to SQL Server database.');
 		}

--- a/libraries/joomla/database/driver/sqlsrv.php
+++ b/libraries/joomla/database/driver/sqlsrv.php
@@ -772,7 +772,7 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 			return false;
 		}
 
-		if (!sqlsrv_query($this->connection, 'USE [' . $database .']', null, array('scrollable' => SQLSRV_CURSOR_STATIC)))
+		if (!sqlsrv_query($this->connection, 'USE [' . $database . ']', null, array('scrollable' => SQLSRV_CURSOR_STATIC)))
 		{
 			throw new JDatabaseExceptionConnecting('Could not connect to SQL Server database.');
 		}


### PR DESCRIPTION
Pull Request for Issue #27438
all credits to @dawe78
see #27462
### Summary of Changes
use `[]`


### Testing Instructions
Connect to a MSSQL database using sqlsrv-driver; database name contains dots: database.v.3.2.4



### Expected result
connect to database server, select database


### Actual result
Error message "Could not connect to SQL Server database."

