### PR TITLE
[3.10] Make sure notices in updater does not lead to unknown error

### DIFF
--- a/libraries/src/Updater/Update.php
+++ b/libraries/src/Updater/Update.php
@@ -423,11 +423,6 @@ class Update extends \JObject
 							$this->latest = $this->currentUpdate;
 						}
 					}
-					else
-					{
-						$this->latest = new \stdClass;
-						$this->latest->php_minimum = $this->currentUpdate->php_minimum;
-					}
 				}
 				break;
 			case 'UPDATES':


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/pull/17849

### Summary of Changes

In this PR: https://github.com/joomla/joomla-cms/pull/17849 this else statement has been added without beeing used. In some cases this can lead to an notice when `$this->currentUpdate->php_minimum;` is not set.

### Testing Instructions

- Install 3.10-dev
- install com_patchtester
- apply this patch: https://github.com/joomla/joomla-cms/pull/27410
- point the update server to https://update.joomla.org/core/nightlies/next_major_list.xml
- notice the `unknown error` message for the patchtester update

### Expected result

`No`

### Actual result

`unknown error`

### Documentation Changes Required

none

### Additional Infos

Yes I know that com_patchtester has an update for Joomla 4.0 but this has been marked as `beta` update the pre-update checker does not support that right now.