### PR TITLE
[4.0] Shorthand CSS

### DIFF
--- a/administrator/templates/system/css/error.css
+++ b/administrator/templates/system/css/error.css
@@ -4,7 +4,7 @@
  */
 
 .outline {
-	margin: 0 auto; 
+	margin: 0 auto;
 	width: 550px;
 	border: 1px solid #cccccc;
 	background: #ffffff;
@@ -40,9 +40,7 @@ h1 {
 }
 
 td {
-	padding: 3px;
-	padding-left: 5px;
-	padding-right: 5px;
+	padding: 3px 5px;
 	border: solid 1px #bbbbbb;
 	font-size: 10px;
 }


### PR DESCRIPTION
Redo of #26860.

Thanks @spahno

### Summary of Changes
Use the shorthand CSS for padding.

The font-family change in the original PR can be done in a separate PR to not hold up this PR.

### Testing Instructions
Code review


