### PR TITLE
[4.0] TinyMCE element_path

### DIFF
--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -391,7 +391,7 @@ class PlgEditorTinymce extends CMSPlugin
 		}
 
 		// Check if the elementpath should be displayed
-		$elementpath       = (bool) $levelParams->get('element_path', true);
+		$elementpath = (bool) $levelParams->get('element_path', true);
 
 		// Set of always available plugins
 		$plugins  = array(

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -390,6 +390,9 @@ class PlgEditorTinymce extends CMSPlugin
 			$resizing = 'both';
 		}
 
+		// Check if the elementpath should be displayed
+		$elementpath       = (bool) $levelParams->get('element_path', true);
+
 		// Set of always available plugins
 		$plugins  = array(
 			'autolink',
@@ -594,6 +597,7 @@ class PlgEditorTinymce extends CMSPlugin
 				'image_title'        => true,
 				'height'             => $html_height,
 				'width'              => $html_width,
+				'elementpath'        => $elementpath,
 				'resize'             => $resizing,
 				'templates'          => $templates,
 				'image_advtab'       => (bool) $levelParams->get('image_advtab', false),

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -390,9 +390,6 @@ class PlgEditorTinymce extends CMSPlugin
 			$resizing = 'both';
 		}
 
-		// Check if the elementpath should be displayed
-		$elementpath = (bool) $levelParams->get('element_path', true);
-
 		// Set of always available plugins
 		$plugins  = array(
 			'autolink',
@@ -597,7 +594,7 @@ class PlgEditorTinymce extends CMSPlugin
 				'image_title'        => true,
 				'height'             => $html_height,
 				'width'              => $html_width,
-				'elementpath'        => $elementpath,
+				'elementpath'        => (bool) $levelParams->get('element_path', true),
 				'resize'             => $resizing,
 				'templates'          => $templates,
 				'image_advtab'       => (bool) $levelParams->get('image_advtab', false),


### PR DESCRIPTION
Tinymce has an option in the plugin called Element Path but it doesn't do anything as there is no code to do anything.
![image](https://user-images.githubusercontent.com/1296369/72219027-77f25680-3539-11ea-977f-b45e605b5ef8.png)

With this PR you can no disable/enable the display of the current element in the bottom left hand corner
![image](https://user-images.githubusercontent.com/1296369/72219035-86d90900-3539-11ea-833e-784fcde5b2c0.png)

### Testing
Make sure that you set the option to be enabled/disabled in the correct set. Default for a super user is set 0

### Additional Note
This is also broken in Joomla 3
