### PR TITLE
[4.0] TinyMCE toggle editor

### DIFF
--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -670,7 +670,10 @@ class PlgEditorTinymce extends CMSPlugin
 	 */
 	private function _toogleButton($name)
 	{
-		return LayoutHelper::render('joomla.tinymce.togglebutton', $name);
+		if (!$this->app->client->mobile)
+		{
+			return LayoutHelper::render('joomla.tinymce.togglebutton', $name);
+		}
 	}
 
 	/**


### PR DESCRIPTION
Because of changes in the tinymce mobile experience we have to disable the toggle editor button on a mobile device. Otherwise it floats on top of the editor.

### Before

![image](https://user-images.githubusercontent.com/1296369/72226014-28854800-3584-11ea-85c2-efa5e2d86132.png)

### After

![image](https://user-images.githubusercontent.com/1296369/72226100-0b04ae00-3585-11ea-9261-f121ca496bb1.png)
