### PR TITLE
[4.0] RTL Header logo

### DIFF
--- a/administrator/templates/atum/scss/template-rtl.scss
+++ b/administrator/templates/atum/scss/template-rtl.scss
@@ -64,6 +64,8 @@ body {
     margin-right: 0;
     margin-left: 15px;
   }
+
+  .logo svg,
   .logo img {
     margin-right: .8rem;
     margin-left: auto;


### PR DESCRIPTION
Fixes a missing class for the logo on rtl so that there is a margin right.

### Testing Instructions
dont forget npm -

### Before
![image](https://user-images.githubusercontent.com/1296369/72244480-45526780-35e6-11ea-9a10-9861ee37ae1c.png)

### After
![image](https://user-images.githubusercontent.com/1296369/72244455-353a8800-35e6-11ea-8a86-c513fda94e44.png)

