### PR TITLE
[4.0] Fix nested tabs not working in com_config

### DIFF
--- a/administrator/components/com_config/tmpl/component/default.php
+++ b/administrator/components/com_config/tmpl/component/default.php
@@ -96,7 +96,7 @@ $xml = $this->form->getXml();
 
 						<?php if (!$hasChildren) : ?>
 
-						<fieldset id="fieldset-<?php echo $this->escape($name); ?>" class="options-grid-form options-grid-form-full">
+						<fieldset id="fieldset-<?php echo $this->escape($name); ?>" class="options-grid-form options-grid-form-full options-menu">
 							<legend><?php echo Text::_($fieldSet->label); ?></legend>
 							<div>
 						<?php $opentab = 2; ?>

--- a/administrator/components/com_config/tmpl/component/default.php
+++ b/administrator/components/com_config/tmpl/component/default.php
@@ -75,7 +75,7 @@ $xml = $this->form->getXml();
 					<?php $label = empty($fieldSet->label) ? 'COM_CONFIG_' . $name . '_FIELDSET_LABEL' : $fieldSet->label; ?>
 
 					<?php if (!$isGrandchild && $hasParent) : ?>
-						<fieldset id="fieldset-<?php echo $this->escape($name); ?>" class="options-grid-form options-grid-form-full">
+						<fieldset id="fieldset-<?php echo $this->escape($name); ?>" class="options-grid-form options-grid-form-full options-menu">
 							<legend><?php echo Text::_($fieldSet->label); ?></legend>
 							<div>
 					<?php elseif (!$hasParent) : ?>

--- a/administrator/components/com_config/tmpl/component/default.php
+++ b/administrator/components/com_config/tmpl/component/default.php
@@ -54,17 +54,16 @@ $xml = $this->form->getXml();
 		<?php // End Sidebar ?>
 
 		<div class="col-md-9" id="config">
-			<?php if ($this->fieldsets): ?>
+			<?php if ($this->fieldsets) : ?>
+				<?php $opentab = 0; ?>
 
 				<?php echo HTMLHelper::_('uitab.startTabSet', 'configTabs'); ?>
 
 				<?php foreach ($this->fieldsets as $name => $fieldSet) : ?>
-
 					<?php
-					// Only show first level fieldsets as tabs
-					if ($xml->xpath('//fieldset/fieldset[@name="' . $name . '"]')) :
-						continue;
-					endif;
+					$hasChildren = $xml->xpath('//fieldset[@name="' . $name . '"]/fieldset');
+					$hasParent = $xml->xpath('//fieldset/fieldset[@name="' . $name . '"]');
+					$isGrandchild = $xml->xpath('//fieldset/fieldset/fieldset[@name="' . $name . '"]');
 					?>
 
 					<?php $dataShowOn = ''; ?>
@@ -74,34 +73,65 @@ $xml = $this->form->getXml();
 					<?php endif; ?>
 
 					<?php $label = empty($fieldSet->label) ? 'COM_CONFIG_' . $name . '_FIELDSET_LABEL' : $fieldSet->label; ?>
-					<?php $hasChildren = $xml->xpath('//fieldset[@name="' . $name . '"]/fieldset'); ?>
 
-					<?php echo HTMLHelper::_('uitab.addTab', 'configTabs', $name, Text::_($label)); ?>
+					<?php if (!$isGrandchild && $hasParent) : ?>
+						<fieldset id="fieldset-<?php echo $this->escape($name); ?>" class="options-grid-form options-grid-form-full">
+							<legend><?php echo Text::_($fieldSet->label); ?></legend>
+							<div>
+					<?php elseif (!$hasParent) : ?>
+						<?php if ($opentab) : ?>
 
-
-					<fieldset id="fieldset-<?php echo $this->escape($name); ?>" class="options-grid-form options-grid-form-full options-menu">
-						<legend><?php echo Text::_($fieldSet->label); ?></legend>
-						<div>
-							<?php if (!empty($fieldSet->description)) : ?>
-								<div class="tab-description alert alert-info">
-									<span class="fa fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
-									<?php echo Text::_($fieldSet->description); ?>
+							<?php if ($opentab > 1) : ?>
 								</div>
+								</fieldset>
 							<?php endif; ?>
 
-							<?php if (!$hasChildren) : ?>
-								<?php echo $this->form->renderFieldset($name, $name === 'permissions' ? ['hiddenLabel' => true, 'class' => 'revert-controls'] : []); ?>
-							<?php endif; ?>
+							<?php echo HTMLHelper::_('uitab.endTab'); ?>
+
+						<?php endif; ?>
+
+						<?php echo HTMLHelper::_('uitab.addTab', 'configTabs', $name, Text::_($label)); ?>
+
+						<?php $opentab = 1; ?>
+
+						<?php if (!$hasChildren) : ?>
+
+						<fieldset id="fieldset-<?php echo $this->escape($name); ?>" class="options-grid-form options-grid-form-full">
+							<legend><?php echo Text::_($fieldSet->label); ?></legend>
+							<div>
+						<?php $opentab = 2; ?>
+						<?php endif; ?>
+					<?php endif; ?>
+
+					<?php if (!empty($fieldSet->description)) : ?>
+						<div class="tab-description alert alert-info">
+							<span class="fa fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+							<?php echo Text::_($fieldSet->description); ?>
+						</div>
+					<?php endif; ?>
+
+					<?php if (!$hasChildren) : ?>
+						<?php echo $this->form->renderFieldset($name, $name === 'permissions' ? ['hiddenLabel' => true, 'class' => 'revert-controls'] : []); ?>
+					<?php endif; ?>
+
+					<?php if (!$isGrandchild && $hasParent) : ?>
 						</div>
 					</fieldset>
-
-					<?php echo HTMLHelper::_('uitab.endTab'); ?>
-
+					<?php endif; ?>
 				<?php endforeach; ?>
+
+				<?php if ($opentab) : ?>
+
+					<?php if ($opentab > 1) : ?>
+						</div>
+						</fieldset>
+					<?php endif; ?>
+					<?php echo HTMLHelper::_('uitab.endTab'); ?>
+				<?php endif; ?>
 
 			<?php echo HTMLHelper::_('uitab.endTabSet'); ?>
 
-			<?php else: ?>
+			<?php else : ?>
 				<div class="alert alert-info">
 					<span class="fa fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 					<?php echo Text::_('COM_CONFIG_COMPONENT_NO_CONFIG_FIELDS_MESSAGE'); ?>


### PR DESCRIPTION
Pull Request for Issue #27188

### Summary of Changes

Fix the com_config view so that nested fieldsets are displayed properly.

### Testing Instructions

1. Go to `administrator/index.php?option=com_config`
2. Select "Articles" from the sidebar menu
3. Go to the "Integrations" tab

### Expected result
![72211043-31124b80-34bc-11ea-86a9-672dce975e65](https://user-images.githubusercontent.com/2019801/72288141-4e702280-3640-11ea-89c0-dc6d9daddade.png)


### Actual result
![72211050-3ff8fe00-34bc-11ea-9989-62f4b731f379](https://user-images.githubusercontent.com/2019801/72288146-50d27c80-3640-11ea-96f6-0606daa611c9.png)

