### PR TITLE
[4.0] Rename Contact and Newsfeeds route helpers

### DIFF
--- a/administrator/components/com_contact/tmpl/contacts/modal.php
+++ b/administrator/components/com_contact/tmpl/contacts/modal.php
@@ -16,6 +16,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
+use Joomla\Component\Contact\Site\Helper\RouteHelper;
 
 $app = Factory::getApplication();
 
@@ -23,8 +24,6 @@ if ($app->isClient('site'))
 {
 	Session::checkToken('get') or die(Text::_('JINVALID_TOKEN'));
 }
-
-JLoader::register('ContactHelperRoute', JPATH_ROOT . '/components/com_contact/helpers/route.php');
 
 HTMLHelper::_('behavior.core');
 HTMLHelper::_('script', 'com_contact/admin-contacts-modal.min.js', array('version' => 'auto', 'relative' => true));
@@ -115,7 +114,7 @@ if (!empty($editor))
 							<span class="<?php echo $iconStates[$this->escape($item->published)]; ?>" aria-hidden="true"></span>
 						</td>
 						<th scope="row">
-							<a class="select-link" href="javascript:void(0)" data-function="<?php echo $this->escape($onclick); ?>" data-id="<?php echo $item->id; ?>" data-title="<?php echo $this->escape($item->name); ?>" data-uri="<?php echo $this->escape(ContactHelperRoute::getContactRoute($item->id, $item->catid, $item->language)); ?>" data-language="<?php echo $this->escape($lang); ?>">
+							<a class="select-link" href="javascript:void(0)" data-function="<?php echo $this->escape($onclick); ?>" data-id="<?php echo $item->id; ?>" data-title="<?php echo $this->escape($item->name); ?>" data-uri="<?php echo $this->escape(RouteHelper::getContactRoute($item->id, $item->catid, $item->language)); ?>" data-language="<?php echo $this->escape($lang); ?>">
 								<?php echo $this->escape($item->name); ?>
 							</a>
 							<div class="small">

--- a/administrator/components/com_newsfeeds/tmpl/newsfeeds/modal.php
+++ b/administrator/components/com_newsfeeds/tmpl/newsfeeds/modal.php
@@ -15,8 +15,7 @@ use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
-
-JLoader::register('NewsfeedsHelperRoute', JPATH_ROOT . '/components/com_newsfeeds/helpers/route.php');
+use Joomla\Component\Newsfeeds\Site\Helper\RouteHelper;
 
 HTMLHelper::_('behavior.core');
 
@@ -96,7 +95,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 							<span class="<?php echo $iconStates[$this->escape($item->published)]; ?>" aria-hidden="true"></span>
 						</td>
 						<th scope="row">
-							<a href="javascript:void(0)" onclick="if (window.parent) window.parent.<?php echo $this->escape($function); ?>('<?php echo $item->id; ?>', '<?php echo $this->escape(addslashes($item->name)); ?>', '<?php echo $this->escape($item->catid); ?>', null, '<?php echo $this->escape(NewsfeedsHelperRoute::getNewsfeedRoute($item->id, $item->catid, $item->language)); ?>', '<?php echo $this->escape($lang); ?>', null);">
+							<a href="javascript:void(0)" onclick="if (window.parent) window.parent.<?php echo $this->escape($function); ?>('<?php echo $item->id; ?>', '<?php echo $this->escape(addslashes($item->name)); ?>', '<?php echo $this->escape($item->catid); ?>', null, '<?php echo $this->escape(RouteHelper::getNewsfeedRoute($item->id, $item->catid, $item->language)); ?>', '<?php echo $this->escape($lang); ?>', null);">
 							<?php echo $this->escape($item->name); ?></a>
 							<div class="small">
 								<?php echo Text::_('JCATEGORY') . ': ' . $this->escape($item->category_title); ?>

--- a/components/com_contact/Helper/AssociationHelper.php
+++ b/components/com_contact/Helper/AssociationHelper.php
@@ -14,7 +14,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Associations;
 use Joomla\Component\Categories\Administrator\Helper\CategoryAssociationHelper;
-use Joomla\Component\Contact\Site\Helper\RouteHelper as ContactHelperRoute;
+use Joomla\Component\Contact\Site\Helper\RouteHelper;
 
 /**
  * Contact Component Association Helper
@@ -49,7 +49,7 @@ abstract class AssociationHelper extends CategoryAssociationHelper
 
 				foreach ($associations as $tag => $item)
 				{
-					$return[$tag] = ContactHelperRoute::getContactRoute($item->id, (int) $item->catid, $item->language);
+					$return[$tag] = RouteHelper::getContactRoute($item->id, (int) $item->catid, $item->language);
 				}
 
 				return $return;

--- a/components/com_contact/Helper/AssociationHelper.php
+++ b/components/com_contact/Helper/AssociationHelper.php
@@ -14,7 +14,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Associations;
 use Joomla\Component\Categories\Administrator\Helper\CategoryAssociationHelper;
-use Joomla\Component\Contact\Site\Helper\Route as ContactHelperRoute;
+use Joomla\Component\Contact\Site\Helper\RouteHelper as ContactHelperRoute;
 
 /**
  * Contact Component Association Helper

--- a/components/com_contact/Helper/RouteHelper.php
+++ b/components/com_contact/Helper/RouteHelper.php
@@ -22,7 +22,7 @@ use Joomla\CMS\Language\Multilanguage;
  * @subpackage  com_contact
  * @since       1.5
  */
-abstract class Route
+abstract class RouteHelper
 {
 	/**
 	 * Get the URL route for a contact from a contact ID, contact category ID and language

--- a/components/com_contact/View/Category/HtmlView.php
+++ b/components/com_contact/View/Category/HtmlView.php
@@ -14,7 +14,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Mail\MailHelper;
 use Joomla\CMS\MVC\View\CategoryView;
-use Joomla\Component\Contact\Site\Helper\Route as ContactHelperRoute;
+use Joomla\Component\Contact\Site\Helper\RouteHelper as ContactHelperRoute;
 
 /**
  * HTML View class for the Contacts component

--- a/components/com_contact/View/Category/HtmlView.php
+++ b/components/com_contact/View/Category/HtmlView.php
@@ -14,7 +14,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Mail\MailHelper;
 use Joomla\CMS\MVC\View\CategoryView;
-use Joomla\Component\Contact\Site\Helper\RouteHelper as ContactHelperRoute;
+use Joomla\Component\Contact\Site\Helper\RouteHelper;
 
 /**
  * HTML View class for the Contacts component
@@ -111,7 +111,7 @@ class HtmlView extends CategoryView
 			while ((!isset($menu->query['option']) || $menu->query['option'] !== 'com_contact' || $menu->query['view'] === 'contact'
 				|| $id != $category->id) && $category->id > 1)
 			{
-				$path[] = array('title' => $category->title, 'link' => ContactHelperRoute::getCategoryRoute($category->id, $category->language));
+				$path[] = array('title' => $category->title, 'link' => RouteHelper::getCategoryRoute($category->id, $category->language));
 				$category = $category->getParent();
 			}
 

--- a/components/com_contact/View/Contact/HtmlView.php
+++ b/components/com_contact/View/Contact/HtmlView.php
@@ -20,7 +20,7 @@ use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Router\Route;
-use Joomla\Component\Contact\Site\Helper\RouteHelper as ContactHelperRoute;
+use Joomla\Component\Contact\Site\Helper\RouteHelper;
 
 /**
  * HTML Contact View class for the Contact component
@@ -365,10 +365,10 @@ class HtmlView extends BaseHtmlView
 		{
 			foreach ($contacts as &$contact)
 			{
-				$contact->link = Route::_(ContactHelperRoute::getContactRoute($contact->slug, $contact->catid, $contact->language));
+				$contact->link = Route::_(RouteHelper::getContactRoute($contact->slug, $contact->catid, $contact->language));
 			}
 
-			$item->link = Route::_(ContactHelperRoute::getContactRoute($item->slug, $item->catid, $item->language), false);
+			$item->link = Route::_(RouteHelper::getContactRoute($item->slug, $item->catid, $item->language), false);
 		}
 
 		// Process the content plugins.
@@ -508,7 +508,7 @@ class HtmlView extends BaseHtmlView
 			while ($category && (!isset($menu->query['option']) || $menu->query['option'] !== 'com_contact' || $menu->query['view'] === 'contact'
 				|| $id != $category->id) && $category->id > 1)
 			{
-				$path[] = array('title' => $category->title, 'link' => ContactHelperRoute::getCategoryRoute($category->id, $category->language));
+				$path[] = array('title' => $category->title, 'link' => RouteHelper::getCategoryRoute($category->id, $category->language));
 				$category = $category->getParent();
 			}
 

--- a/components/com_contact/View/Contact/HtmlView.php
+++ b/components/com_contact/View/Contact/HtmlView.php
@@ -20,7 +20,7 @@ use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Router\Route;
-use Joomla\Component\Contact\Site\Helper\Route as ContactHelperRoute;
+use Joomla\Component\Contact\Site\Helper\RouteHelper as ContactHelperRoute;
 
 /**
  * HTML Contact View class for the Contact component

--- a/components/com_contact/helpers/route.php
+++ b/components/com_contact/helpers/route.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Component\Contact\Site\Helper\RouteHelper;
+
 /**
  * Contact Component Route Helper
  *
@@ -17,6 +19,6 @@ defined('_JEXEC') or die;
  * @subpackage  com_contact
  * @since       1.5
  */
-abstract class ContactHelperRoute extends \Joomla\Component\Contact\Site\Helper\Route
+abstract class ContactHelperRoute extends RouteHelper
 {
 }

--- a/components/com_contact/tmpl/categories/default_items.php
+++ b/components/com_contact/tmpl/categories/default_items.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
-use Joomla\Component\Contact\Site\Helper\RouteHelper as ContactHelperRoute;
+use Joomla\Component\Contact\Site\Helper\RouteHelper;
 
 if ($this->maxLevelcat != 0 && count($this->items[$this->parent->id]) > 0) :
 ?>
@@ -20,7 +20,7 @@ if ($this->maxLevelcat != 0 && count($this->items[$this->parent->id]) > 0) :
 		<?php if ($this->params->get('show_empty_categories_cat') || $item->numitems || count($item->getChildren())) : ?>
 			<div class="com-contact-categories__items">
 				<h3 class="page-header item-title">
-					<a href="<?php echo Route::_(ContactHelperRoute::getCategoryRoute($item->id, $item->language)); ?>">
+					<a href="<?php echo Route::_(RouteHelper::getCategoryRoute($item->id, $item->language)); ?>">
 					<?php echo $this->escape($item->title); ?></a>
 					<?php if ($this->params->get('show_cat_items_cat') == 1) :?>
 						<span class="badge badge-info">

--- a/components/com_contact/tmpl/categories/default_items.php
+++ b/components/com_contact/tmpl/categories/default_items.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
-use Joomla\Component\Contact\Site\Helper\Route as ContactHelperRoute;
+use Joomla\Component\Contact\Site\Helper\RouteHelper as ContactHelperRoute;
 
 if ($this->maxLevelcat != 0 && count($this->items[$this->parent->id]) > 0) :
 ?>

--- a/components/com_contact/tmpl/category/default_children.php
+++ b/components/com_contact/tmpl/category/default_children.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
-use Joomla\Component\Contact\Site\Helper\Route as ContactHelperRoute;
+use Joomla\Component\Contact\Site\Helper\RouteHelper as ContactHelperRoute;
 
 if ($this->maxLevel != 0 && count($this->children[$this->category->id]) > 0) :
 ?>

--- a/components/com_contact/tmpl/category/default_children.php
+++ b/components/com_contact/tmpl/category/default_children.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
-use Joomla\Component\Contact\Site\Helper\RouteHelper as ContactHelperRoute;
+use Joomla\Component\Contact\Site\Helper\RouteHelper;
 
 if ($this->maxLevel != 0 && count($this->children[$this->category->id]) > 0) :
 ?>
@@ -21,7 +21,7 @@ if ($this->maxLevel != 0 && count($this->children[$this->category->id]) > 0) :
 	<?php if ($this->params->get('show_empty_categories') || $child->numitems || count($child->getChildren())) : ?>
 	<li>
 		<h4 class="item-title">
-			<a href="<?php echo Route::_(ContactHelperRoute::getCategoryRoute($child->id, $child->language)); ?>">
+			<a href="<?php echo Route::_(RouteHelper::getCategoryRoute($child->id, $child->language)); ?>">
 			<?php echo $this->escape($child->title); ?>
 			</a>
 

--- a/components/com_contact/tmpl/category/default_items.php
+++ b/components/com_contact/tmpl/category/default_items.php
@@ -13,7 +13,7 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
-use Joomla\Component\Contact\Site\Helper\Route as ContactHelperRoute;
+use Joomla\Component\Contact\Site\Helper\RouteHelper as ContactHelperRoute;
 
 HTMLHelper::_('behavior.core');
 ?>

--- a/components/com_contact/tmpl/category/default_items.php
+++ b/components/com_contact/tmpl/category/default_items.php
@@ -13,7 +13,7 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
-use Joomla\Component\Contact\Site\Helper\RouteHelper as ContactHelperRoute;
+use Joomla\Component\Contact\Site\Helper\RouteHelper;
 
 HTMLHelper::_('behavior.core');
 ?>
@@ -71,7 +71,7 @@ HTMLHelper::_('behavior.core');
 							<?php $contact_width = 7; ?>
 							<div class="col-md-2">
 								<?php if ($this->items[$i]->image) : ?>
-									<a href="<?php echo Route::_(ContactHelperRoute::getContactRoute($item->slug, $item->catid, $item->language)); ?>">
+									<a href="<?php echo Route::_(RouteHelper::getContactRoute($item->slug, $item->catid, $item->language)); ?>">
 										<?php echo HTMLHelper::_('image', $this->items[$i]->image, Text::_('COM_CONTACT_IMAGE_DETAILS'), array('class' => 'contact-thumbnail img-thumbnail')); ?></a>
 								<?php endif; ?>
 							</div>
@@ -80,7 +80,7 @@ HTMLHelper::_('behavior.core');
 						<?php endif; ?>
 
 						<div class="list-title col-md-<?php echo $contact_width; ?>">
-							<a href="<?php echo Route::_(ContactHelperRoute::getContactRoute($item->slug, $item->catid, $item->language)); ?>">
+							<a href="<?php echo Route::_(RouteHelper::getContactRoute($item->slug, $item->catid, $item->language)); ?>">
 								<?php echo $item->name; ?></a>
 							<?php if ($this->items[$i]->published == 0) : ?>
 								<span class="badge badge-warning"><?php echo Text::_('JUNPUBLISHED'); ?></span>

--- a/components/com_contact/tmpl/contact/default.php
+++ b/components/com_contact/tmpl/contact/default.php
@@ -15,7 +15,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\FileLayout;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Router\Route;
-use Joomla\Component\Contact\Site\Helper\RouteHelper as ContactHelperRoute;
+use Joomla\Component\Contact\Site\Helper\RouteHelper;
 
 $cparams = ComponentHelper::getParams('com_media');
 $tparams = $this->item->params;
@@ -46,7 +46,7 @@ $tparams = $this->item->params;
 			<span class="contact-category"><?php echo $this->item->category_title; ?></span>
 		</h3>
 	<?php elseif ($show_contact_category === 'show_with_link') : ?>
-		<?php $contactLink = ContactHelperRoute::getCategoryRoute($this->item->catid, $this->item->language); ?>
+		<?php $contactLink = RouteHelper::getCategoryRoute($this->item->catid, $this->item->language); ?>
 		<h3>
 			<span class="contact-category"><a href="<?php echo $contactLink; ?>">
 				<?php echo $this->escape($this->item->category_title); ?></a>

--- a/components/com_contact/tmpl/contact/default.php
+++ b/components/com_contact/tmpl/contact/default.php
@@ -15,7 +15,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\FileLayout;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Router\Route;
-use Joomla\Component\Contact\Site\Helper\Route as ContactHelperRoute;
+use Joomla\Component\Contact\Site\Helper\RouteHelper as ContactHelperRoute;
 
 $cparams = ComponentHelper::getParams('com_media');
 $tparams = $this->item->params;

--- a/components/com_contact/tmpl/featured/default_items.php
+++ b/components/com_contact/tmpl/featured/default_items.php
@@ -13,7 +13,7 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
-use Joomla\Component\Contact\Site\Helper\RouteHelper as ContactHelperRoute;
+use Joomla\Component\Contact\Site\Helper\RouteHelper;
 
 HTMLHelper::_('behavior.core');
 
@@ -116,7 +116,7 @@ $params = &$this->item->params;
 							<?php if ($this->items[$i]->published == 0) : ?>
 								<span class="badge badge-warning"><?php echo Text::_('JUNPUBLISHED'); ?></span>
 							<?php endif; ?>
-							<a href="<?php echo Route::_(ContactHelperRoute::getContactRoute($item->slug, $item->catid, $item->language)); ?>" itemprop="url">
+							<a href="<?php echo Route::_(RouteHelper::getContactRoute($item->slug, $item->catid, $item->language)); ?>" itemprop="url">
 								<span itemprop="name"><?php echo $item->name; ?></span>
 							</a>
 						</td>

--- a/components/com_contact/tmpl/featured/default_items.php
+++ b/components/com_contact/tmpl/featured/default_items.php
@@ -13,7 +13,7 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
-use Joomla\Component\Contact\Site\Helper\Route as ContactHelperRoute;
+use Joomla\Component\Contact\Site\Helper\RouteHelper as ContactHelperRoute;
 
 HTMLHelper::_('behavior.core');
 

--- a/components/com_newsfeeds/Helper/RouteHelper.php
+++ b/components/com_newsfeeds/Helper/RouteHelper.php
@@ -19,7 +19,7 @@ use Joomla\CMS\Language\Multilanguage;
  *
  * @since  1.5
  */
-abstract class Route
+abstract class RouteHelper
 {
 	/**
 	 * getNewsfeedRoute

--- a/components/com_newsfeeds/View/Category/HtmlView.php
+++ b/components/com_newsfeeds/View/Category/HtmlView.php
@@ -12,7 +12,7 @@ namespace Joomla\Component\Newsfeeds\Site\View\Category;
 defined('_JEXEC') or die;
 
 use Joomla\CMS\MVC\View\CategoryView;
-use Joomla\Component\Newsfeeds\Site\Helper\RouteHelper as NewsfeedsHelperRoute;
+use Joomla\Component\Newsfeeds\Site\Helper\RouteHelper;
 
 /**
  * HTML View class for the Newsfeeds component
@@ -87,7 +87,7 @@ class HtmlView extends CategoryView
 			while ((!isset($menu->query['option']) || $menu->query['option'] !== 'com_newsfeeds' || $menu->query['view'] === 'newsfeed'
 				|| $id != $category->id) && $category->id > 1)
 			{
-				$path[] = array('title' => $category->title, 'link' => NewsfeedsHelperRoute::getCategoryRoute($category->id, $category->language));
+				$path[] = array('title' => $category->title, 'link' => RouteHelper::getCategoryRoute($category->id, $category->language));
 				$category = $category->getParent();
 			}
 

--- a/components/com_newsfeeds/View/Category/HtmlView.php
+++ b/components/com_newsfeeds/View/Category/HtmlView.php
@@ -12,7 +12,7 @@ namespace Joomla\Component\Newsfeeds\Site\View\Category;
 defined('_JEXEC') or die;
 
 use Joomla\CMS\MVC\View\CategoryView;
-use Joomla\Component\Newsfeeds\Site\Helper\Route as NewsfeedsHelperRoute;
+use Joomla\Component\Newsfeeds\Site\Helper\RouteHelper as NewsfeedsHelperRoute;
 
 /**
  * HTML View class for the Newsfeeds component

--- a/components/com_newsfeeds/View/Newsfeed/HtmlView.php
+++ b/components/com_newsfeeds/View/Newsfeed/HtmlView.php
@@ -18,7 +18,7 @@ use Joomla\CMS\Helper\TagsHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\Component\Newsfeeds\Site\Helper\Route as NewsfeedsHelperRoute;
+use Joomla\Component\Newsfeeds\Site\Helper\RouteHelper as NewsfeedsHelperRoute;
 
 /**
  * HTML View class for the Newsfeeds component

--- a/components/com_newsfeeds/View/Newsfeed/HtmlView.php
+++ b/components/com_newsfeeds/View/Newsfeed/HtmlView.php
@@ -18,7 +18,7 @@ use Joomla\CMS\Helper\TagsHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\Component\Newsfeeds\Site\Helper\RouteHelper as NewsfeedsHelperRoute;
+use Joomla\Component\Newsfeeds\Site\Helper\RouteHelper;
 
 /**
  * HTML View class for the Newsfeeds component
@@ -290,7 +290,7 @@ class HtmlView extends BaseHtmlView
 			while ((!isset($menu->query['option']) || $menu->query['option'] !== 'com_newsfeeds' || $menu->query['view'] === 'newsfeed'
 				|| $id != $category->id) && $category->id > 1)
 			{
-				$path[] = array('title' => $category->title, 'link' => NewsfeedsHelperRoute::getCategoryRoute($category->id));
+				$path[] = array('title' => $category->title, 'link' => RouteHelper::getCategoryRoute($category->id));
 				$category = $category->getParent();
 			}
 

--- a/components/com_newsfeeds/helpers/route.php
+++ b/components/com_newsfeeds/helpers/route.php
@@ -9,11 +9,13 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Component\Newsfeeds\Site\Helper\RouteHelper;
+
 /**
  * Newsfeeds Component Route Helper
  *
  * @since  1.5
  */
-abstract class NewsfeedsHelperRoute extends \Joomla\Component\Newsfeeds\Site\Helper\Route
+abstract class NewsfeedsHelperRoute extends RouteHelper
 {
 }

--- a/components/com_newsfeeds/tmpl/categories/default_items.php
+++ b/components/com_newsfeeds/tmpl/categories/default_items.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
-use Joomla\Component\Newsfeeds\Site\Helper\RouteHelper as NewsfeedsHelperRoute;
+use Joomla\Component\Newsfeeds\Site\Helper\RouteHelper;
 
 ?>
 <?php if ($this->maxLevelcat != 0 && count($this->items[$this->parent->id]) > 0) : ?>
@@ -20,7 +20,7 @@ use Joomla\Component\Newsfeeds\Site\Helper\RouteHelper as NewsfeedsHelperRoute;
 		<?php if ($this->params->get('show_empty_categories_cat') || $item->numitems || count($item->getChildren())) : ?>
 			<div class="com-newsfeeds-categories__items">
 				<h3 class="page-header item-title">
-					<a href="<?php echo Route::_(NewsfeedsHelperRoute::getCategoryRoute($item->id, $item->language)); ?>">
+					<a href="<?php echo Route::_(RouteHelper::getCategoryRoute($item->id, $item->language)); ?>">
 						<?php echo $this->escape($item->title); ?>
 					</a>
 					<?php if ($this->params->get('show_cat_items_cat') == 1) : ?>

--- a/components/com_newsfeeds/tmpl/categories/default_items.php
+++ b/components/com_newsfeeds/tmpl/categories/default_items.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
-use Joomla\Component\Newsfeeds\Site\Helper\Route as NewsfeedsHelperRoute;
+use Joomla\Component\Newsfeeds\Site\Helper\RouteHelper as NewsfeedsHelperRoute;
 
 ?>
 <?php if ($this->maxLevelcat != 0 && count($this->items[$this->parent->id]) > 0) : ?>

--- a/components/com_newsfeeds/tmpl/category/default_children.php
+++ b/components/com_newsfeeds/tmpl/category/default_children.php
@@ -10,7 +10,7 @@
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
-use Joomla\Component\Newsfeeds\Site\Helper\Route as NewsfeedsHelperRoute;
+use Joomla\Component\Newsfeeds\Site\Helper\RouteHelper as NewsfeedsHelperRoute;
 
 defined('_JEXEC') or die;
 

--- a/components/com_newsfeeds/tmpl/category/default_children.php
+++ b/components/com_newsfeeds/tmpl/category/default_children.php
@@ -10,7 +10,7 @@
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
-use Joomla\Component\Newsfeeds\Site\Helper\RouteHelper as NewsfeedsHelperRoute;
+use Joomla\Component\Newsfeeds\Site\Helper\RouteHelper;
 
 defined('_JEXEC') or die;
 
@@ -21,7 +21,7 @@ defined('_JEXEC') or die;
 			<?php if ($this->params->get('show_empty_categories') || $child->numitems || count($child->getChildren())) : ?>
 				<li>
 					<span class="item-title">
-						<a href="<?php echo Route::_(NewsfeedsHelperRoute::getCategoryRoute($child->id, $child->language)); ?>">
+						<a href="<?php echo Route::_(RouteHelper::getCategoryRoute($child->id, $child->language)); ?>">
 							<?php echo $this->escape($child->title); ?>
 						</a>
 					</span>

--- a/components/com_newsfeeds/tmpl/category/default_items.php
+++ b/components/com_newsfeeds/tmpl/category/default_items.php
@@ -13,7 +13,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\String\PunycodeHelper;
 use Joomla\CMS\Uri\Uri;
-use Joomla\Component\Newsfeeds\Site\Helper\Route as NewsfeedsHelperRoute;
+use Joomla\Component\Newsfeeds\Site\Helper\RouteHelper as NewsfeedsHelperRoute;
 
 $n         = count($this->items);
 $listOrder = $this->escape($this->state->get('list.ordering'));

--- a/components/com_newsfeeds/tmpl/category/default_items.php
+++ b/components/com_newsfeeds/tmpl/category/default_items.php
@@ -13,7 +13,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\String\PunycodeHelper;
 use Joomla\CMS\Uri\Uri;
-use Joomla\Component\Newsfeeds\Site\Helper\RouteHelper as NewsfeedsHelperRoute;
+use Joomla\Component\Newsfeeds\Site\Helper\RouteHelper;
 
 $n         = count($this->items);
 $listOrder = $this->escape($this->state->get('list.ordering'));
@@ -62,7 +62,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 					<?php endif; ?>
 					<span class="list float-left">
 						<div class="list-title">
-							<a href="<?php echo Route::_(NewsfeedsHelperRoute::getNewsfeedRoute($item->slug, $item->catid)); ?>">
+							<a href="<?php echo Route::_(RouteHelper::getNewsfeedRoute($item->slug, $item->catid)); ?>">
 								<?php echo $item->name; ?>
 							</a>
 						</div>

--- a/plugins/content/contact/contact.php
+++ b/plugins/content/contact/contact.php
@@ -13,6 +13,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\CMS\Router\Route;
+use Joomla\Component\Contact\Site\Helper\RouteHelper;
 use Joomla\Database\ParameterType;
 use Joomla\Registry\Registry;
 
@@ -76,8 +77,7 @@ class PlgContentContact extends CMSPlugin
 
 		if ($row->contactid && $url === 'url')
 		{
-			JLoader::register('ContactHelperRoute', JPATH_SITE . '/components/com_contact/helpers/route.php');
-			$row->contact_link = Route::_(ContactHelperRoute::getContactRoute($contact->contactid . ':' . $contact->alias, $contact->catid));
+			$row->contact_link = Route::_(RouteHelper::getContactRoute($contact->contactid . ':' . $contact->alias, $contact->catid));
 		}
 		elseif ($row->webpage && $url === 'webpage')
 		{

--- a/plugins/finder/contacts/contacts.php
+++ b/plugins/finder/contacts/contacts.php
@@ -12,6 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Categories\Categories;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
+use Joomla\Component\Contact\Site\Helper\RouteHelper;
 use Joomla\Database\DatabaseQuery;
 use Joomla\Registry\Registry;
 
@@ -269,7 +270,7 @@ class PlgFinderContacts extends FinderIndexerAdapter
 		$item->url = $this->getUrl($item->id, $this->extension, $this->layout);
 
 		// Build the necessary route and path information.
-		$item->route = ContactHelperRoute::getContactRoute($item->slug, $item->catslug, $item->language);
+		$item->route = RouteHelper::getContactRoute($item->slug, $item->catslug, $item->language);
 
 		// Get the menu title if it exists.
 		$title = $this->getItemMenuTitle($item->url);
@@ -393,9 +394,6 @@ class PlgFinderContacts extends FinderIndexerAdapter
 	 */
 	protected function setup()
 	{
-		// Load dependent classes.
-		JLoader::register('ContactHelperRoute', JPATH_SITE . '/components/com_contact/helpers/route.php');
-
 		return true;
 	}
 

--- a/plugins/finder/newsfeeds/newsfeeds.php
+++ b/plugins/finder/newsfeeds/newsfeeds.php
@@ -12,6 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Categories\Categories;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
+use Joomla\Component\Newsfeeds\Site\Helper\RouteHelper;
 use Joomla\Database\DatabaseQuery;
 use Joomla\Registry\Registry;
 
@@ -271,7 +272,7 @@ class PlgFinderNewsfeeds extends FinderIndexerAdapter
 		$item->url = $this->getUrl($item->id, $this->extension, $this->layout);
 
 		// Build the necessary route and path information.
-		$item->route = NewsfeedsHelperRoute::getNewsfeedRoute($item->slug, $item->catslug, $item->language);
+		$item->route = RouteHelper::getNewsfeedRoute($item->slug, $item->catslug, $item->language);
 
 		/*
 		 * Add the metadata processing instructions based on the newsfeeds
@@ -317,9 +318,6 @@ class PlgFinderNewsfeeds extends FinderIndexerAdapter
 	 */
 	protected function setup()
 	{
-		// Load dependent classes.
-		JLoader::register('NewsfeedsHelperRoute', JPATH_SITE . '/components/com_newsfeeds/helpers/route.php');
-
 		return true;
 	}
 


### PR DESCRIPTION
### Summary of Changes

Renames `Joomla\Component\Contact\Site\Helper\Route` and `Joomla\Component\Newsfeeds\Site\Helper\Route` to be consistent with other helper classes.

### Testing Instructions

Create some contacts and newsfeeds.
View them in frontend.
Run Smart Search indexer.

### Expected result

Works like before.

### Documentation Changes Required

IDK.