### PR TITLE
[4.0] Rename Tags route helper class

### DIFF
--- a/components/com_tags/Helper/RouteHelper.php
+++ b/components/com_tags/Helper/RouteHelper.php
@@ -13,14 +13,14 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
-use Joomla\CMS\Helper\RouteHelper;
+use Joomla\CMS\Helper\RouteHelper as CMSRouteHelper;
 
 /**
  * Tags Component Route Helper.
  *
  * @since  3.1
  */
-class TagsHelperRoute extends RouteHelper
+class RouteHelper extends CMSRouteHelper
 {
 	/**
 	 * Lookup-table for menu items
@@ -71,7 +71,7 @@ class TagsHelperRoute extends RouteHelper
 		if ($link === '')
 		{
 			// Create a fallback link in case we can't find the component router
-			$router = new RouteHelper;
+			$router = new CMSRouteHelper;
 			$link = $router->getRoute($contentItemId, $typeAlias, $link, $language, $contentCatId);
 		}
 

--- a/components/com_tags/Model/TagModel.php
+++ b/components/com_tags/Model/TagModel.php
@@ -18,7 +18,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
 use Joomla\CMS\MVC\Model\ListModel;
 use Joomla\CMS\Object\CMSObject;
-use Joomla\Component\Tags\Site\Helper\TagsHelperRoute;
+use Joomla\Component\Tags\Site\Helper\RouteHelper;
 use Joomla\Utilities\ArrayHelper;
 
 /**
@@ -100,7 +100,7 @@ class TagModel extends ListModel
 		{
 			foreach ($items as $item)
 			{
-				$item->link = TagsHelperRoute::getItemRoute(
+				$item->link = RouteHelper::getItemRoute(
 					$item->content_item_id,
 					$item->core_alias,
 					$item->core_catid,

--- a/components/com_tags/helpers/route.php
+++ b/components/com_tags/helpers/route.php
@@ -9,11 +9,13 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Component\Tags\Site\Helper\RouteHelper;
+
 /**
  * Tags Component Route Helper.
  *
  * @since  3.1
  */
-class TagsHelperRoute extends \Joomla\Component\Tags\Site\Helper\TagsHelperRoute
+class TagsHelperRoute extends RouteHelper
 {
 }

--- a/components/com_tags/tmpl/tag/default_items.php
+++ b/components/com_tags/tmpl/tag/default_items.php
@@ -14,7 +14,7 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
-use Joomla\Component\Tags\Site\Helper\TagsHelperRoute;
+use Joomla\Component\Tags\Site\Helper\RouteHelper;
 
 HTMLHelper::_('behavior.core');
 
@@ -89,7 +89,7 @@ $canEditState = $user->authorise('core.edit.state', 'com_tags');
 				<?php echo $item->event->afterDisplayTitle; ?>
 				<?php $images  = json_decode($item->core_images); ?>
 				<?php if ($this->params->get('tag_list_show_item_image', 1) == 1 && !empty($images->image_intro)) : ?>
-					<a href="<?php echo Route::_(TagsHelperRoute::getItemRoute($item->content_item_id, $item->core_alias, $item->core_catid, $item->core_language, $item->type_alias, $item->router)); ?>" itemprop="url">
+					<a href="<?php echo Route::_(RouteHelper::getItemRoute($item->content_item_id, $item->core_alias, $item->core_catid, $item->core_language, $item->type_alias, $item->router)); ?>" itemprop="url">
 						<img src="<?php echo htmlspecialchars($images->image_intro); ?>"
 							alt="<?php echo htmlspecialchars($images->image_intro_alt); ?>" itemprop="image">
 					</a>

--- a/components/com_tags/tmpl/tags/default_items.php
+++ b/components/com_tags/tmpl/tags/default_items.php
@@ -14,7 +14,7 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
-use Joomla\Component\Tags\Site\Helper\TagsHelperRoute;
+use Joomla\Component\Tags\Site\Helper\RouteHelper;
 
 HTMLHelper::_('behavior.core');
 
@@ -96,7 +96,7 @@ $n         = count($this->items);
 			<li class="list-group-item list-group-item-action">
 				<?php if ((!empty($item->access)) && in_array($item->access, $this->user->getAuthorisedViewLevels())) : ?>
 					<h3 class="mb-0">
-						<a href="<?php echo Route::_(TagsHelperRoute::getTagRoute($item->id . ':' . $item->alias)); ?>">
+						<a href="<?php echo Route::_(RouteHelper::getTagRoute($item->id . ':' . $item->alias)); ?>">
 							<?php echo $this->escape($item->title); ?>
 						</a>
 					</h3>

--- a/layouts/joomla/content/tags.php
+++ b/layouts/joomla/content/tags.php
@@ -11,9 +11,8 @@ defined('JPATH_BASE') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Router\Route;
+use Joomla\Component\Tags\Site\Helper\RouteHelper;
 use Joomla\Registry\Registry;
-
-JLoader::register('TagsHelperRoute', JPATH_BASE . '/components/com_tags/helpers/route.php');
 
 $authorised = Factory::getUser()->getAuthorisedViewLevels();
 
@@ -25,7 +24,7 @@ $authorised = Factory::getUser()->getAuthorisedViewLevels();
 				<?php $tagParams = new Registry($tag->params); ?>
 				<?php $link_class = $tagParams->get('tag_link_class', 'badge badge-info'); ?>
 				<li class="list-inline-item tag-<?php echo $tag->tag_id; ?> tag-list<?php echo $i; ?>" itemprop="keywords">
-					<a href="<?php echo Route::_(TagsHelperRoute::getTagRoute($tag->tag_id . ':' . $tag->alias)); ?>" class="<?php echo $link_class; ?>">
+					<a href="<?php echo Route::_(RouteHelper::getTagRoute($tag->tag_id . ':' . $tag->alias)); ?>" class="<?php echo $link_class; ?>">
 						<?php echo $this->escape($tag->title); ?>
 					</a>
 				</li>

--- a/modules/mod_tags_popular/tmpl/cloud.php
+++ b/modules/mod_tags_popular/tmpl/cloud.php
@@ -11,11 +11,11 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
+use Joomla\Component\Tags\Site\Helper\RouteHelper;
 
 $minsize = $params->get('minsize', 1);
 $maxsize = $params->get('maxsize', 2);
 
-JLoader::register('TagsHelperRoute', JPATH_BASE . '/components/com_tags/helpers/route.php');
 ?>
 <div class="mod-tagspopular-cloud tagspopular tagscloud">
 <?php
@@ -49,7 +49,7 @@ if (!count($list)) : ?>
 		endif;
 ?>
 		<span class="tag">
-			<a class="tag-name" style="font-size: <?php echo $fontsize . 'em'; ?>" href="<?php echo Route::_(TagsHelperRoute::getTagRoute($item->tag_id . ':' . $item->alias)); ?>">
+			<a class="tag-name" style="font-size: <?php echo $fontsize . 'em'; ?>" href="<?php echo Route::_(RouteHelper::getTagRoute($item->tag_id . ':' . $item->alias)); ?>">
 				<?php echo htmlspecialchars($item->title, ENT_COMPAT, 'UTF-8'); ?></a>
 			<?php if ($display_count) : ?>
 				<span class="tag-count badge badge-info"><?php echo $item->count; ?></span>

--- a/modules/mod_tags_popular/tmpl/default.php
+++ b/modules/mod_tags_popular/tmpl/default.php
@@ -11,10 +11,9 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
+use Joomla\Component\Tags\Site\Helper\RouteHelper;
 
-JLoader::register('TagsHelperRoute', JPATH_BASE . '/components/com_tags/helpers/route.php');
 ?>
-
 <div class="mod-tagspopular tagspopular">
 <?php if (!count($list)) : ?>
 	<div class="alert alert-info">
@@ -25,7 +24,7 @@ JLoader::register('TagsHelperRoute', JPATH_BASE . '/components/com_tags/helpers/
 	<ul>
 	<?php foreach ($list as $item) : ?>
 	<li>
-		<a href="<?php echo Route::_(TagsHelperRoute::getTagRoute($item->tag_id . ':' . $item->alias)); ?>">
+		<a href="<?php echo Route::_(RouteHelper::getTagRoute($item->tag_id . ':' . $item->alias)); ?>">
 			<?php echo htmlspecialchars($item->title, ENT_COMPAT, 'UTF-8'); ?></a>
 		<?php if ($display_count) : ?>
 			<span class="tag-count badge badge-info"><?php echo $item->count; ?></span>

--- a/modules/mod_tags_similar/Helper/TagsSimilarHelper.php
+++ b/modules/mod_tags_similar/Helper/TagsSimilarHelper.php
@@ -16,10 +16,9 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Helper\ContentHelper;
 use Joomla\CMS\Helper\TagsHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\Component\Tags\Site\Helper\RouteHelper;
 use Joomla\Database\ParameterType;
 use Joomla\Registry\Registry;
-
-\JLoader::register('TagsHelperRoute', JPATH_BASE . '/components/com_tags/helpers/route.php');
 
 /**
  * Helper for mod_tags_similar
@@ -210,7 +209,7 @@ abstract class TagsSimilarHelper
 
 		foreach ($results as $result)
 		{
-			$result->link = \TagsHelperRoute::getItemRoute(
+			$result->link = RouteHelper::getItemRoute(
 				$result->content_item_id,
 				$result->core_alias,
 				$result->core_catid,

--- a/plugins/finder/tags/tags.php
+++ b/plugins/finder/tags/tags.php
@@ -11,6 +11,7 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
+use Joomla\Component\Tags\Site\Helper\RouteHelper;
 use Joomla\Database\DatabaseQuery;
 use Joomla\Registry\Registry;
 
@@ -228,7 +229,7 @@ class PlgFinderTags extends FinderIndexerAdapter
 		$item->url = $this->getUrl($item->id, $this->extension, $this->layout);
 
 		// Build the necessary route and path information.
-		$item->route = TagsHelperRoute::getTagRoute($item->slug);
+		$item->route = RouteHelper::getTagRoute($item->slug);
 
 		// Get the menu title if it exists.
 		$title = $this->getItemMenuTitle($item->url);
@@ -278,9 +279,6 @@ class PlgFinderTags extends FinderIndexerAdapter
 	 */
 	protected function setup()
 	{
-		// Load dependent classes.
-		JLoader::register('TagsHelperRoute', JPATH_SITE . '/components/com_tags/helpers/route.php');
-
 		return true;
 	}
 


### PR DESCRIPTION
### Summary of Changes

Renames `Joomla\Component\Tags\Site\Helper\TagsHelperRoute` to be consistent with other helper classes.

### Testing Instructions

Create an article. In the article create some tags on the fly.
View a list of tags and single in frontend.
Run Smart Search indexer.

### Expected result

Works like before.

### Documentation Changes Required

IDK.