### PR TITLE
FieldsHelper::getFields() bug - assigned_cat_ids is prepopulated by previous call

### DIFF
--- a/administrator/components/com_fields/helpers/fields.php
+++ b/administrator/components/com_fields/helpers/fields.php
@@ -112,6 +112,7 @@ class FieldsHelper
 		}
 
 		self::$fieldsCache->setState('filter.context', $context);
+		self::$fieldsCache->setState('filter.assigned_cat_ids', array());
 
 		/*
 		 * If item has assigned_cat_ids parameter display only fields which


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Reset filter.assigned_cat_ids because another call of FieldsHelper::getFields() with no second parameter will still use the previous filter.assigned_cat_ids state.
Basically if you make two subsequent calls, one with the $item parameters supplied and the other one without any parameter:

FieldsHelper::getFields('com_content.article', $item);
FieldsHelper::getFields('com_content.article');

The second call will always have filter.assigned_cat_ids prepopulated by the previous call, causing it to return an incorrect value.


### Testing Instructions
- Content > Articles > Add New Article. Name it "Test Article" and assign it to "Uncategorised";
- Content > Categories > Add New Category. Name it "Other Category";
- Content > Articles > Add New Article. Name it "Other Article" and assign it to "Other Category";
- Content > Fields > click on New to create a new field. It doesn't matter which type, just make sure to assign it to the "Other Category" only;
- Create a new menu item - Menus > Main Menu > Add New Menu Item > set Menu Item Type to Articles > Single Article. Select the "Test Article";
- Open components/com_content/views/article/tmpl/default.php and add the following code after `defined('_JEXEC') or die;`:

`var_dump(FieldsHelper::getFields('com_content.article'));`

- View your article in the frontend.

### Expected result
You should be able to see an array of ALL article fields since that's what you've requested.


### Actual result
Either an empty array if the current article has no fields assigned or only current article's fields.


### Documentation Changes Required

