### PR TITLE
[4.0] Double Translation

### DIFF
--- a/libraries/src/Toolbar/Button/PopupButton.php
+++ b/libraries/src/Toolbar/Button/PopupButton.php
@@ -132,7 +132,7 @@ class PopupButton extends ToolbarButton
 		{
 			// Build the options array for the modal
 			$params = array();
-			$params['title']      = Text::_($options['title'] ?? $options['text']);
+			$params['title']      = $options['title'] ?? $options['text'];
 			$params['url']        = $this->getUrl();
 			$params['height']     = $options['iframeHeight'] ?? 480;
 			$params['width']      = $options['iframeWidth'] ?? 640;


### PR DESCRIPTION
Enable debug languages
Open an article for editing
Click on the Preview button
You will see that the title of the popup is getting passed twice through JText and therefore failing once

Apply patch - problem gone

### Before
![image](https://user-images.githubusercontent.com/1296369/72388614-51414500-371e-11ea-9fcc-46ed5d595b4b.png)

### After
![image](https://user-images.githubusercontent.com/1296369/72388602-4a1a3700-371e-11ea-8e86-9e907cb3c7cd.png)
