### PR TITLE
[4.0] Add module dashboard button

### DIFF
--- a/administrator/components/com_cpanel/tmpl/cpanel/default.php
+++ b/administrator/components/com_cpanel/tmpl/cpanel/default.php
@@ -77,12 +77,12 @@ echo HTMLHelper::_(
 </div>
 <div class="row">
 	<div class="col-md-6">
-		<a href="#moduleEditModal" data-toggle="modal" data-target="#moduleDashboardAddModal" role="button" class="cpanel-add-module text-center py-5 w-100 d-block">
+		<button type="button" data-toggle="modal" data-target="#moduleDashboardAddModal" class="cpanel-add-module text-center py-5 w-100 d-block">
 			<div class="cpanel-add-module-icon text-center">
 				<span class="fa fa-plus-square text-light mt-2"></span>
 			</div>
 			<span><?php echo Text::_('COM_CPANEL_ADD_DASHBOARD_MODULE'); ?></span>
-		</a>
+		</button>
 	</div>
 	<?php endif; ?>
 </div>


### PR DESCRIPTION
This should be a button and not a link.

This is important for accessibility.

A link can be selected with a mouse or the enter key
A button can also be selected with the spacebar

role="button" does not add that functionality even though it will make assistive tech think its a button