### PR TITLE
[4.0] Dashboard module options button

### DIFF
--- a/administrator/templates/atum/html/layouts/chromes/body.php
+++ b/administrator/templates/atum/html/layouts/chromes/body.php
@@ -40,7 +40,7 @@ if ($module->content) :
 			<?php if ($canEdit || $canChange) : ?>
 				<?php $dropdownPosition = Factory::getLanguage()->isRTL() ? 'left' : 'right'; ?>
 				<div class="module-actions dropdown">
-					<button type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" class="btn btn-link" id="dropdownMenuButton-<?php echo $id; ?>">
+					<button type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" class="btn" id="dropdownMenuButton-<?php echo $id; ?>">
 						<span class="fa fa-cog" aria-hidden="true"></span>
 						<span class="sr-only"><?php echo Text::sprintf('JACTION_EDIT_MODULE', $module->title); ?></span>
 					</button>

--- a/administrator/templates/atum/html/layouts/chromes/well.php
+++ b/administrator/templates/atum/html/layouts/chromes/well.php
@@ -52,7 +52,7 @@ if ($module->content) :
 					<?php if ($canEdit || $canChange) : ?>
 						<?php $dropdownPosition = Factory::getLanguage()->isRTL() ? 'left' : 'right'; ?>
 						<div class="module-actions dropdown">
-							<button type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" class="btn btn-link" id="dropdownMenuButton-<?php echo $id; ?>">
+							<button type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" class="btn" id="dropdownMenuButton-<?php echo $id; ?>">
 								<span class="fa fa-cog" aria-hidden="true"></span>
 								<span class="sr-only"><?php echo Text::sprintf('JACTION_EDIT_MODULE', $module->title); ?></span>
 							</button>

--- a/administrator/templates/atum/scss/blocks/_global.scss
+++ b/administrator/templates/atum/scss/blocks/_global.scss
@@ -71,6 +71,14 @@ textarea {
   }
 }
 
+// Default focus highlighting
+.btn {
+
+  &.focus {
+  outline: auto 2px var(--focus);
+  }
+}
+
 // Break up text in cells to prevent overflow
 .break-word {
   word-break: break-all;

--- a/administrator/templates/atum/scss/blocks/_global.scss
+++ b/administrator/templates/atum/scss/blocks/_global.scss
@@ -71,14 +71,6 @@ textarea {
   }
 }
 
-// Default focus highlighting
-.btn {
-
-  &.focus {
-  outline: auto 2px var(--focus);
-  }
-}
-
 // Break up text in cells to prevent overflow
 .break-word {
   word-break: break-all;


### PR DESCRIPTION
I have no idea why but this cog icon button was given a class of btn-link. This meant that there was no visible indicator of focus. Removal of that class now means that you can visibly tab around the dashboard and see where you are. Not just an a11y issue but a usability one as well

### Before
![before](https://user-images.githubusercontent.com/1296369/72423459-330a3200-377c-11ea-932d-83e6fbf7cb68.gif)

### After
![after](https://user-images.githubusercontent.com/1296369/72423388-153ccd00-377c-11ea-953e-b5631f709a03.gif)
