### PR TITLE
[4.0] Fix custom select missing icon on focus

### DIFF
--- a/administrator/components/com_postinstall/tmpl/messages/default.php
+++ b/administrator/components/com_postinstall/tmpl/messages/default.php
@@ -38,7 +38,7 @@ $params = array('params' => json_encode($param));
 	<input type="hidden" name="option" value="com_postinstall">
 	<input type="hidden" name="task" value="">
 	<label for="eid" class="mr-sm-2"><?php echo Text::_('COM_POSTINSTALL_MESSAGES_FOR'); ?></label>
-	<?php echo HTMLHelper::_('select.genericlist', $this->extension_options, 'eid', array('onchange' => 'this.form.submit()', 'class' => 'form-control custom-select'), 'value', 'text', $this->eid, 'eid'); ?>
+	<?php echo HTMLHelper::_('select.genericlist', $this->extension_options, 'eid', array('onchange' => 'this.form.submit()', 'class' => 'custom-select'), 'value', 'text', $this->eid, 'eid'); ?>
 </form>
 
 <?php if ($this->eid == $this->joomlaFilesExtensionId) : ?>


### PR DESCRIPTION
Pull Request for Issue #27543.

### Summary of Changes
Fix custom select missing icon on focus.


### Testing Instructions
Click Post Installation in the upper right corner
Look at the `Showing messages for` dropdown
Click it
You'll notice the arrow icon disappears