### PR TITLE
[4.0] Throw exception when sending mail with mail disabled

### DIFF
--- a/administrator/components/com_actionlogs/Model/ActionlogModel.php
+++ b/administrator/components/com_actionlogs/Model/ActionlogModel.php
@@ -11,7 +11,6 @@ namespace Joomla\Component\Actionlogs\Administrator\Model;
 
 defined('_JEXEC') or die;
 
-use Exception;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
@@ -43,7 +42,7 @@ class ActionlogModel extends BaseDatabaseModel
 	 *
 	 * @since   3.9.0
 	 *
-	 * @throws  Exception
+	 * @throws  \Exception
 	 */
 	public function addLog($messages, $messageLanguageKey, $context, $userId = null)
 	{

--- a/administrator/components/com_actionlogs/Model/ActionlogModel.php
+++ b/administrator/components/com_actionlogs/Model/ActionlogModel.php
@@ -11,16 +11,15 @@ namespace Joomla\Component\Actionlogs\Administrator\Model;
 
 defined('_JEXEC') or die;
 
+use Exception;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\FileLayout;
-use Joomla\CMS\Mail\Exception\MailDisabledException;
 use Joomla\CMS\MVC\Model\BaseDatabaseModel;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\Component\Actionlogs\Administrator\Helper\ActionlogsHelper;
 use Joomla\Utilities\IpHelper;
-use PHPMailer\PHPMailer\Exception as phpMailerException;
 
 /**
  * Methods supporting a list of Actionlog records.
@@ -42,7 +41,7 @@ class ActionlogModel extends BaseDatabaseModel
 	 *
 	 * @since   3.9.0
 	 *
-	 * @throws  \Exception
+	 * @throws  Exception
 	 */
 	public function addLog($messages, $messageLanguageKey, $context, $userId = null)
 	{
@@ -89,15 +88,8 @@ class ActionlogModel extends BaseDatabaseModel
 			}
 		}
 
-		try
-		{
-			// Send notification email to users who choose to be notified about the action logs
-			$this->sendNotificationEmails($loggedMessages, $user->name, $context);
-		}
-		catch (MailDisabledException | phpMailerException $exception)
-		{
-			// Ignore it
-		}
+		// Send notification email to users who choose to be notified about the action logs
+		$this->sendNotificationEmails($loggedMessages, $user->name, $context);
 	}
 
 	/**
@@ -111,8 +103,7 @@ class ActionlogModel extends BaseDatabaseModel
 	 *
 	 * @since   3.9.0
 	 *
-	 * @throws  MailDisabledException
-	 * @throws  phpMailerException
+	 * @throws  Exception
 	 */
 	protected function sendNotificationEmails($messages, $username, $context)
 	{
@@ -174,6 +165,10 @@ class ActionlogModel extends BaseDatabaseModel
 		$mailer->isHTML(true);
 		$mailer->Encoding = 'base64';
 		$mailer->setBody($body);
-		$mailer->Send();
+
+		if (!$mailer->Send())
+		{
+			throw new GenericDataException(Text::_('JERROR_SENDING_EMAIL'), 500);
+		}
 	}
 }

--- a/administrator/components/com_messages/Model/MessageModel.php
+++ b/administrator/components/com_messages/Model/MessageModel.php
@@ -18,12 +18,14 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Language;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
+use Joomla\CMS\Mail\Exception\MailDisabledException;
 use Joomla\CMS\MVC\Model\AdminModel;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Table\Asset;
 use Joomla\CMS\Table\Table;
 use Joomla\CMS\User\User;
 use Joomla\Database\ParameterType;
+use PHPMailer\PHPMailer\Exception as phpMailerException;
 
 /**
  * Private Message model.
@@ -432,7 +434,7 @@ class MessageModel extends AdminModel
 
 				$mailer->Send();
 			}
-			catch (\Exception $exception)
+			catch (MailDisabledException | phpMailerException $exception)
 			{
 				try
 				{

--- a/administrator/components/com_privacy/Model/RequestModel.php
+++ b/administrator/components/com_privacy/Model/RequestModel.php
@@ -16,6 +16,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Language\Language;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Mail\Exception\MailDisabledException;
 use Joomla\CMS\MVC\Model\AdminModel;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Table\Table;
@@ -367,7 +368,7 @@ class RequestModel extends AdminModel
 
 			return true;
 		}
-		catch (phpmailerException $exception)
+		catch (MailDisabledException | phpmailerException $exception)
 		{
 			$this->setError($exception->getMessage());
 

--- a/administrator/components/com_users/Model/MailModel.php
+++ b/administrator/components/com_users/Model/MailModel.php
@@ -18,8 +18,10 @@ use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
+use Joomla\CMS\Mail\Exception\MailDisabledException;
 use Joomla\CMS\MVC\Model\AdminModel;
 use Joomla\Database\ParameterType;
+use PHPMailer\PHPMailer\Exception as phpMailerException;
 
 /**
  * Users mail model.
@@ -199,7 +201,7 @@ class MailModel extends AdminModel
 			// Send the Mail
 			$rs = $mailer->Send();
 		}
-		catch (\Exception $exception)
+		catch (MailDisabledException | phpMailerException $exception)
 		{
 			try
 			{

--- a/api/components/com_contact/Controller/ContactController.php
+++ b/api/components/com_contact/Controller/ContactController.php
@@ -16,6 +16,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
+use Joomla\CMS\Mail\Exception\MailDisabledException;
 use Joomla\CMS\MVC\Controller\Exception\SendEmail;
 use Joomla\CMS\String\PunycodeHelper;
 use Joomla\CMS\Uri\Uri;
@@ -26,6 +27,7 @@ use Joomla\CMS\Router\Exception\RouteNotFoundException;
 use Joomla\Component\Fields\Administrator\Helper\FieldsHelper;
 use Joomla\Registry\Registry;
 use Joomla\String\Inflector;
+use PHPMailer\PHPMailer\Exception as phpMailerException;
 use Tobscure\JsonApi\Exception\InvalidParameterException;
 
 /**
@@ -267,7 +269,7 @@ class ContactController extends ApiController
 				$sent = $mail->Send();
 			}
 		}
-		catch (\Exception $exception)
+		catch (MailDisabledException | phpMailerException $exception)
 		{
 			try
 			{

--- a/components/com_contact/Controller/ContactController.php
+++ b/components/com_contact/Controller/ContactController.php
@@ -14,6 +14,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
+use Joomla\CMS\Mail\Exception\MailDisabledException;
 use Joomla\CMS\MVC\Controller\FormController;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Router\Route;
@@ -21,6 +22,7 @@ use Joomla\CMS\String\PunycodeHelper;
 use Joomla\CMS\Uri\Uri;
 use Joomla\CMS\User\User;
 use Joomla\Component\Fields\Administrator\Helper\FieldsHelper;
+use PHPMailer\PHPMailer\Exception as phpMailerException;
 
 /**
  * Controller for single contact view
@@ -280,7 +282,7 @@ class ContactController extends FormController
 				$sent = $mail->Send();
 			}
 		}
-		catch (\Exception $exception)
+		catch (MailDisabledException | phpMailerException $exception)
 		{
 			try
 			{

--- a/components/com_privacy/Model/RequestModel.php
+++ b/components/com_privacy/Model/RequestModel.php
@@ -15,6 +15,7 @@ use Joomla\CMS\Application\ApplicationHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Mail\Exception\MailDisabledException;
 use Joomla\CMS\MVC\Model\AdminModel;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\String\PunycodeHelper;
@@ -217,7 +218,7 @@ class RequestModel extends AdminModel
 			// The email sent and the record is saved, everything is good to go from here
 			return true;
 		}
-		catch (phpmailerException $exception)
+		catch (MailDisabledException | phpmailerException $exception)
 		{
 			$this->setError($exception->getMessage());
 

--- a/libraries/src/Mail/Exception/MailDisabledException.php
+++ b/libraries/src/Mail/Exception/MailDisabledException.php
@@ -23,7 +23,7 @@ final class MailDisabledException extends \RuntimeException
 	 * @var    string
 	 * @since  __DEPLOY_VERSION__
 	 */
-    public const REASON_USER_DISABLED = 'user_disabled';
+	public const REASON_USER_DISABLED = 'user_disabled';
 
 	/**
 	 * Mail() function is not available on the system.
@@ -31,7 +31,7 @@ final class MailDisabledException extends \RuntimeException
 	 * @var    string
 	 * @since  __DEPLOY_VERSION__
 	 */
-    public const REASON_MAIL_FUNCTION_NOT_AVAILABLE = 'mail_function_not_available';
+	public const REASON_MAIL_FUNCTION_NOT_AVAILABLE = 'mail_function_not_available';
 
 	/**
 	 * Reason mail is disabled.
@@ -39,7 +39,7 @@ final class MailDisabledException extends \RuntimeException
 	 * @var    string
 	 * @since  __DEPLOY_VERSION__
 	 */
-    private $reason;
+	private $reason;
 
 	/**
 	 * Constructor.
@@ -51,12 +51,12 @@ final class MailDisabledException extends \RuntimeException
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-    public function __construct(string $reason, string $message = '', int $code = 0, \Throwable $previous = null)
-    {
-        parent::__construct($message, $code, $previous);
+	public function __construct(string $reason, string $message = '', int $code = 0, \Throwable $previous = null)
+	{
+		parent::__construct($message, $code, $previous);
 
-        $this->reason = $reason;
-    }
+		$this->reason = $reason;
+	}
 
 	/**
 	 * Method to return the reason why mail is disabled.
@@ -65,8 +65,8 @@ final class MailDisabledException extends \RuntimeException
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-    public function getReason(): string
-    {
-        return $this->reason;
-    }
+	public function getReason(): string
+	{
+		return $this->reason;
+	}
 }

--- a/libraries/src/Mail/Exception/MailDisabledException.php
+++ b/libraries/src/Mail/Exception/MailDisabledException.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  Copyright (C) 2005 - 2020 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Mail\Exception;
+
+\defined('JPATH_PLATFORM') or die;
+
+/**
+ * Exception class defining an error for disabled mail functionality.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+final class MailDisabledException extends \RuntimeException
+{
+	/**
+	 * Send Mail option is disabled by the user.
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+    public const REASON_USER_DISABLED = 'user_disabled';
+
+	/**
+	 * Mail() function is not available on the system.
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+    public const REASON_MAIL_FUNCTION_NOT_AVAILABLE = 'mail_function_not_available';
+
+	/**
+	 * Reason mail is disabled.
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+    private $reason;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param   string      $reason    The reason why mail is disabled.
+	 * @param   string      $message   The Exception message to throw.
+	 * @param   integer     $code      The Exception code.
+	 * @param   \Throwable  $previous  The previous exception used for the exception chaining.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+    public function __construct(string $reason, string $message = '', int $code = 0, \Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+
+        $this->reason = $reason;
+    }
+
+	/**
+	 * Method to return the reason why mail is disabled.
+	 *
+	 * @return  string
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+    public function getReason(): string
+    {
+        return $this->reason;
+    }
+}

--- a/libraries/src/Mail/Mail.php
+++ b/libraries/src/Mail/Mail.php
@@ -110,8 +110,8 @@ class Mail extends PHPMailer
 	 *
 	 * @since   1.7.0
 	 *
-	 * @throws  \RuntimeException   if the mail function is disabled
-	 * @throws  phpmailerException  if sending failed
+	 * @throws  Exception\MailDisabledException  if the mail function is disabled
+	 * @throws  phpmailerException               if sending failed
 	 */
 	public function Send()
 	{
@@ -119,7 +119,11 @@ class Mail extends PHPMailer
 		{
 			if (($this->Mailer == 'mail') && !\function_exists('mail'))
 			{
-				throw new \RuntimeException(Text::_('JLIB_MAIL_FUNCTION_DISABLED'), 500);
+				throw new Exception\MailDisabledException(
+					Exception\MailDisabledException::REASON_MAIL_FUNCTION_NOT_AVAILABLE,
+					Text::_('JLIB_MAIL_FUNCTION_DISABLED'),
+					500
+				);
 			}
 
 			try
@@ -160,9 +164,11 @@ class Mail extends PHPMailer
 			return $result;
 		}
 
-		Factory::getApplication()->enqueueMessage(Text::_('JLIB_MAIL_FUNCTION_OFFLINE'), 'warning');
-
-		return false;
+		throw new Exception\MailDisabledException(
+			Exception\MailDisabledException::REASON_USER_DISABLED,
+			Text::_('JLIB_MAIL_FUNCTION_OFFLINE'),
+			500
+		);
 	}
 
 	/**
@@ -634,7 +640,8 @@ class Mail extends PHPMailer
 	 *
 	 * @since   1.7.0
 	 *
-	 * @throws  phpmailerException  if exception throwing is enabled
+	 * @throws  Exception\MailDisabledException  if the mail function is disabled
+	 * @throws  phpmailerException               if exception throwing is enabled
 	 */
 	public function sendMail($from, $fromName, $recipient, $subject, $body, $mode = false, $cc = null, $bcc = null, $attachment = null,
 		$replyTo = null, $replyToName = null

--- a/libraries/src/Mail/Mail.php
+++ b/libraries/src/Mail/Mail.php
@@ -13,6 +13,7 @@ namespace Joomla\CMS\Mail;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
+use Joomla\CMS\Mail\Exception\MailDisabledException;
 use PHPMailer\PHPMailer\Exception as phpmailerException;
 use PHPMailer\PHPMailer\PHPMailer;
 
@@ -110,8 +111,8 @@ class Mail extends PHPMailer
 	 *
 	 * @since   1.7.0
 	 *
-	 * @throws  Exception\MailDisabledException  if the mail function is disabled
-	 * @throws  phpmailerException               if sending failed
+	 * @throws  MailDisabledException  if the mail function is disabled
+	 * @throws  phpmailerException     if sending failed
 	 */
 	public function Send()
 	{
@@ -119,8 +120,8 @@ class Mail extends PHPMailer
 		{
 			if (($this->Mailer == 'mail') && !\function_exists('mail'))
 			{
-				throw new Exception\MailDisabledException(
-					Exception\MailDisabledException::REASON_MAIL_FUNCTION_NOT_AVAILABLE,
+				throw new MailDisabledException(
+					MailDisabledException::REASON_MAIL_FUNCTION_NOT_AVAILABLE,
 					Text::_('JLIB_MAIL_FUNCTION_DISABLED'),
 					500
 				);
@@ -164,8 +165,8 @@ class Mail extends PHPMailer
 			return $result;
 		}
 
-		throw new Exception\MailDisabledException(
-			Exception\MailDisabledException::REASON_USER_DISABLED,
+		throw new MailDisabledException(
+			MailDisabledException::REASON_USER_DISABLED,
 			Text::_('JLIB_MAIL_FUNCTION_OFFLINE'),
 			500
 		);
@@ -640,8 +641,8 @@ class Mail extends PHPMailer
 	 *
 	 * @since   1.7.0
 	 *
-	 * @throws  Exception\MailDisabledException  if the mail function is disabled
-	 * @throws  phpmailerException               if exception throwing is enabled
+	 * @throws  MailDisabledException  if the mail function is disabled
+	 * @throws  phpmailerException     if exception throwing is enabled
 	 */
 	public function sendMail($from, $fromName, $recipient, $subject, $body, $mode = false, $cc = null, $bcc = null, $attachment = null,
 		$replyTo = null, $replyToName = null

--- a/libraries/src/Mail/Mail.php
+++ b/libraries/src/Mail/Mail.php
@@ -125,7 +125,7 @@ class Mail extends PHPMailer
 			);
 		}
 
-		if (($this->Mailer == 'mail') && !\function_exists('mail'))
+		if ($this->Mailer === 'mail' && !\function_exists('mail'))
 		{
 			throw new MailDisabledException(
 				MailDisabledException::REASON_MAIL_FUNCTION_NOT_AVAILABLE,

--- a/libraries/src/Mail/MailTemplate.php
+++ b/libraries/src/Mail/MailTemplate.php
@@ -13,6 +13,7 @@ defined('JPATH_PLATFORM') or die;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Mail\Exception\MailDisabledException;
 use Joomla\Database\ParameterType;
 use Joomla\Registry\Registry;
 use PHPMailer\PHPMailer\Exception as phpmailerException;
@@ -151,6 +152,7 @@ class MailTemplate
 	 * @return  boolean  True on success
 	 *
 	 * @since   4.0.0
+	 * @throws  MailDisabledException
 	 * @throws  phpmailerException
 	 */
 	public function send()

--- a/plugins/system/privacyconsent/privacyconsent.php
+++ b/plugins/system/privacyconsent/privacyconsent.php
@@ -16,6 +16,7 @@ use Joomla\CMS\Form\Form;
 use Joomla\CMS\Form\FormHelper;
 use Joomla\CMS\Language\Associations;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Mail\Exception\MailDisabledException;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
@@ -618,11 +619,7 @@ class PlgSystemPrivacyconsent extends CMSPlugin
 
 				$mailResult = $mailer->Send();
 
-				if ($mailResult instanceof JException)
-				{
-					return false;
-				}
-				elseif ($mailResult === false)
+				if ($mailResult === false)
 				{
 					return false;
 				}
@@ -648,7 +645,7 @@ class PlgSystemPrivacyconsent extends CMSPlugin
 					return false;
 				}
 			}
-			catch (phpmailerException $exception)
+			catch (MailDisabledException | phpmailerException $exception)
 			{
 				return false;
 			}

--- a/plugins/system/updatenotification/updatenotification.php
+++ b/plugins/system/updatenotification/updatenotification.php
@@ -16,12 +16,14 @@ use Joomla\CMS\Extension\ExtensionHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
+use Joomla\CMS\Mail\Exception\MailDisabledException;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\CMS\Table\Table;
 use Joomla\CMS\Updater\Updater;
 use Joomla\CMS\Uri\Uri;
 use Joomla\CMS\Version;
 use Joomla\Database\ParameterType;
+use PHPMailer\PHPMailer\Exception as phpMailerException;
 
 // Uncomment the following line to enable debug mode (update notification email sent every single time)
 // define('PLG_SYSTEM_UPDATENOTIFICATION_DEBUG', 1);
@@ -283,7 +285,7 @@ class PlgSystemUpdatenotification extends CMSPlugin
 				$mailer->setBody($email_body);
 				$mailer->Send();
 			}
-			catch (\Exception $exception)
+			catch (MailDisabledException | phpMailerException $exception)
 			{
 				try
 				{


### PR DESCRIPTION
### Summary of Changes

Introduces `Joomla\CMS\Mail\Exception\MailDisabledException`.
`Joomla\CMS\Mail\Mail::send()` now throws it when mail is disabled.

### Testing Instructions

Mail functions should still work.

### Documentation Changes Required

Yes.