### PR TITLE
[4.0] Fix invalid argument for foreach

### DIFF
--- a/libraries/src/Form/FormField.php
+++ b/libraries/src/Form/FormField.php
@@ -1129,7 +1129,7 @@ abstract class FormField
 		{
 			$subForm = $this->loadSubForm();
 
-			if ($this->multiple)
+			if ($this->multiple && \is_array($value))
 			{
 				foreach ($value as $key => $val)
 				{

--- a/libraries/src/Form/FormField.php
+++ b/libraries/src/Form/FormField.php
@@ -1129,7 +1129,7 @@ abstract class FormField
 		{
 			$subForm = $this->loadSubForm();
 
-			if ($this->multiple && \is_array($value))
+			if ($this->multiple && $value)
 			{
 				foreach ($value as $key => $val)
 				{


### PR DESCRIPTION
### Summary of Changes
Fix `Invalid argument supplied for foreach() in \libraries\src\Form\FormField.php on line 1134` by checking that it is an array.


### Testing Instructions
* Create a text field.
* Create a subfield field.
* Edit an article (leave subfield field empty).
* Save the article.
* Check PHP error log.
* Apply PR.
* Check PHP error log for no errors.



