### PR TITLE
[4.0] Remove title tooltip overlapping tooltip

### DIFF
--- a/administrator/components/com_associations/Helper/AssociationsHelper.php
+++ b/administrator/components/com_associations/Helper/AssociationsHelper.php
@@ -337,7 +337,7 @@ class AssociationsHelper extends ContentHelper
 				. htmlspecialchars($title, ENT_QUOTES, 'UTF-8') . '<br><br>' . $additional;
 			$classes = 'badge ' . $labelClass;
 
-			$items[$langCode]['link'] = '<a href="' . $url . '" title="' . $language->title . '" class="' . $classes . '">' . $text . '</a>'
+			$items[$langCode]['link'] = '<a href="' . $url . '" class="' . $classes . '">' . $text . '</a>'
 				. '<div role="tooltip">' . $tooltip . '</div>';
 		}
 

--- a/administrator/components/com_categories/Service/HTML/AdministratorService.php
+++ b/administrator/components/com_categories/Service/HTML/AdministratorService.php
@@ -96,7 +96,7 @@ class AdministratorService
 							. htmlspecialchars($item->title, ENT_QUOTES, 'UTF-8');
 						$classes  = 'badge badge-secondary';
 
-						$item->link = '<a href="' . $url . '" title="' . $item->language_title . '" class="' . $classes . '">' . $text . '</a>'
+						$item->link = '<a href="' . $url . '" class="' . $classes . '">' . $text . '</a>'
 							. '<div role="tooltip" id="tip-' . (int) $catid . '-' . (int) $item->id . '">' . $tooltip . '</div>';
 					}
 					else

--- a/administrator/components/com_contact/Service/HTML/AdministratorService.php
+++ b/administrator/components/com_contact/Service/HTML/AdministratorService.php
@@ -95,7 +95,7 @@ class AdministratorService
 							. htmlspecialchars($item->title, ENT_QUOTES, 'UTF-8') . '<br>' . Text::sprintf('JCATEGORY_SPRINTF', $item->category_title);
 						$classes = 'badge badge-secondary';
 
-						$item->link = '<a href="' . $url . '" title="' . $item->language_title . '" class="' . $classes . '">' . $text . '</a>'
+						$item->link = '<a href="' . $url . '" class="' . $classes . '">' . $text . '</a>'
 							. '<div role="tooltip" id="tip-' . (int) $contactid . '-' . (int) $item->id . '">' . $tooltip . '</div>';
 					}
 					else

--- a/administrator/components/com_content/Service/HTML/AdministratorService.php
+++ b/administrator/components/com_content/Service/HTML/AdministratorService.php
@@ -88,7 +88,7 @@ class AdministratorService
 							. htmlspecialchars($item->title, ENT_QUOTES, 'UTF-8') . '<br>' . Text::sprintf('JCATEGORY_SPRINTF', $item->category_title);
 						$classes = 'badge badge-secondary';
 
-						$item->link = '<a href="' . $url . '" title="' . $item->language_title . '" class="' . $classes . '">' . $text . '</a>'
+						$item->link = '<a href="' . $url . '" class="' . $classes . '">' . $text . '</a>'
 							. '<div role="tooltip" id="tip-' . (int) $articleid . '-' . (int) $item->id . '">' . $tooltip . '</div>';
 					}
 					else

--- a/administrator/components/com_menus/Service/HTML/Menus.php
+++ b/administrator/components/com_menus/Service/HTML/Menus.php
@@ -95,7 +95,7 @@ class Menus
 							. htmlspecialchars($item->title, ENT_QUOTES, 'UTF-8') . '<br>' . Text::sprintf('COM_MENUS_MENU_SPRINTF', $item->menu_title);
 						$classes = 'badge badge-secondary';
 
-						$item->link = '<a href="' . $url . '" title="' . $item->language_title . '" class="' . $classes . '">' . $text . '</a>'
+						$item->link = '<a href="' . $url . '" class="' . $classes . '">' . $text . '</a>'
 							. '<div role="tooltip" id="tip-' . (int) $itemid . '-' . (int) $item->id . '">' . $tooltip . '</div>';
 					}
 					else

--- a/administrator/components/com_newsfeeds/Service/HTML/AdministratorService.php
+++ b/administrator/components/com_newsfeeds/Service/HTML/AdministratorService.php
@@ -99,7 +99,7 @@ class AdministratorService
 							. htmlspecialchars($item->title, ENT_QUOTES, 'UTF-8') . '<br>' . Text::sprintf('JCATEGORY_SPRINTF', $item->category_title);
 						$classes = 'badge badge-secondary';
 
-						$item->link = '<a href="' . $url . '" title="' . $item->language_title . '" class="' . $classes . '">' . $text . '</a>'
+						$item->link = '<a href="' . $url . '" class="' . $classes . '">' . $text . '</a>'
 							. '<div role="tooltip" id="tip-' . (int) $newsfeedid . '-' . (int) $item->id . '">' . $tooltip . '</div>';
 					}
 					else


### PR DESCRIPTION
### Summary of Changes
Remove title tooltip that has redundant info overlapping tooltip.


### Testing Instructions
Install Multilingual Sample Data.
Go to Articles list.
Under Association column, hover over a badge.
See tooltip overlapping tooltip.

Do the same for Categories, Contacts, News Feeds, and Menus.



### Actual result
![tooltip](https://user-images.githubusercontent.com/368084/72635475-c3c64680-3911-11ea-8be5-6004cd041e79.jpg)
