### PR TITLE
[4.0] [SmartSearch] Index: formatting tooltip date display

### DIFF
--- a/administrator/components/com_finder/tmpl/index/default.php
+++ b/administrator/components/com_finder/tmpl/index/default.php
@@ -107,10 +107,10 @@ HTMLHelper::_('script', 'com_finder/index.js', ['version' => 'auto', 'relative' 
 									</span>
 									<div role="tooltip" id="tip<?php echo $i; ?>">
 										<?php
-											$publishStartDate = $item->publish_start_date != NULL ? HTMLHelper::_('date', $item->publish_start_date, Text::_('DATE_FORMAT_LC5'), 'UTC') : '';
-											$publishEndDate   = $item->publish_end_date != NULL ? HTMLHelper::_('date', $item->publish_end_date, Text::_('DATE_FORMAT_LC5'), 'UTC') : '';
-											$startDate        = $item->start_date != NULL ? HTMLHelper::_('date', $item->start_date, Text::_('DATE_FORMAT_LC5'), 'UTC') : '';
-											$endDate          = $item->end_date != NULL ? HTMLHelper::_('date', $item->end_date, Text::_('DATE_FORMAT_LC5'), 'UTC') : '';
+											$publishStartDate = $item->publish_start_date !== null ? HTMLHelper::_('date', $item->publish_start_date, Text::_('DATE_FORMAT_LC5'), 'UTC') : '';
+											$publishEndDate   = $item->publish_end_date !== null ? HTMLHelper::_('date', $item->publish_end_date, Text::_('DATE_FORMAT_LC5'), 'UTC') : '';
+											$startDate        = $item->start_date !== null ? HTMLHelper::_('date', $item->start_date, Text::_('DATE_FORMAT_LC5'), 'UTC') : '';
+											$endDate          = $item->end_date !== null ? HTMLHelper::_('date', $item->end_date, Text::_('DATE_FORMAT_LC5'), 'UTC') : '';
 										?>
 										<?php echo Text::sprintf('COM_FINDER_INDEX_DATE_INFO', $publishStartDate, $publishEndDate, $startDate, $endDate); ?>
 									</div>

--- a/administrator/components/com_finder/tmpl/index/default.php
+++ b/administrator/components/com_finder/tmpl/index/default.php
@@ -107,12 +107,12 @@ HTMLHelper::_('script', 'com_finder/index.js', ['version' => 'auto', 'relative' 
 									</span>
 									<div role="tooltip" id="tip<?php echo $i; ?>">
 										<?php
-											$publishStartDate = HTMLHelper::_('date', $item->publish_start_date, Text::_('DATE_FORMAT_LC5'), 'UTC');
-											$publishEndDate   = HTMLHelper::_('date', $item->publish_end_date, Text::_('DATE_FORMAT_LC5'), 'UTC');
-											$publishStartDate = HTMLHelper::_('date', $item->start_date, Text::_('DATE_FORMAT_LC5'), 'UTC');
-											$publishEndDate   = HTMLHelper::_('date', $item->end_date, Text::_('DATE_FORMAT_LC5'), 'UTC');
+											$publishStartDate = $item->publish_start_date != NULL ? HTMLHelper::_('date', $item->publish_start_date, Text::_('DATE_FORMAT_LC5'), 'UTC') : '';
+											$publishEndDate   = $item->publish_end_date != NULL ? HTMLHelper::_('date', $item->publish_end_date, Text::_('DATE_FORMAT_LC5'), 'UTC') : '';
+											$startDate        = $item->start_date != NULL ? HTMLHelper::_('date', $item->start_date, Text::_('DATE_FORMAT_LC5'), 'UTC') : '';
+											$endDate          = $item->end_date != NULL ? HTMLHelper::_('date', $item->end_date, Text::_('DATE_FORMAT_LC5'), 'UTC') : '';
 										?>
-										<?php echo Text::sprintf('COM_FINDER_INDEX_DATE_INFO', $publishStartDate, $publishEndDate, $publishStartDate, $publishEndDate); ?>
+										<?php echo Text::sprintf('COM_FINDER_INDEX_DATE_INFO', $publishStartDate, $publishEndDate, $startDate, $endDate); ?>
 									</div>
 								<?php endif; ?>
 								</td>

--- a/administrator/components/com_finder/tmpl/index/default.php
+++ b/administrator/components/com_finder/tmpl/index/default.php
@@ -106,7 +106,13 @@ HTMLHelper::_('script', 'com_finder/index.js', ['version' => 'auto', 'relative' 
 										<span class="sr-only"><?php echo Text::_('COM_FINDER_INDEX_DATE_INFO_TITLE'); ?></span>
 									</span>
 									<div role="tooltip" id="tip<?php echo $i; ?>">
-										<?php echo Text::sprintf('COM_FINDER_INDEX_DATE_INFO', $item->publish_start_date, $item->publish_end_date, $item->start_date, $item->end_date); ?>
+										<?php
+											$publishStartDate = HTMLHelper::_('date', $item->publish_start_date, Text::_('DATE_FORMAT_LC5'), 'UTC');
+											$publishEndDate   = HTMLHelper::_('date', $item->publish_end_date, Text::_('DATE_FORMAT_LC5'), 'UTC');
+											$publishStartDate = HTMLHelper::_('date', $item->start_date, Text::_('DATE_FORMAT_LC5'), 'UTC');
+											$publishEndDate   = HTMLHelper::_('date', $item->end_date, Text::_('DATE_FORMAT_LC5'), 'UTC');
+										?>
+										<?php echo Text::sprintf('COM_FINDER_INDEX_DATE_INFO', $publishStartDate, $publishEndDate, $publishStartDate, $publishEndDate); ?>
 									</div>
 								<?php endif; ?>
 								</td>


### PR DESCRIPTION
### Summary of Changes 
As title says. Dates are displayed as entered in db, i.e. not "translated" to the format used by the language, contrary to articles for example (see `PublishedButton.php` ).

Therefore this PR adds the correct `HtmlHelper` method.

### Testing Instructions
Best way to test is using in admin the fa-IR (Persian) language, as the format there should be jalali.
Display `administrator/index.php?option=com_finder&view=index`after indexing.

The screenshot below are captured after applying https://github.com/joomla/joomla-cms/pull/27554#issuecomment-575871283 (and using npm) as it corrects the text alignment.
It is not necessary to do so to see the results of this PR.
### Before patch
<img width="1083" alt="Screen Shot 2020-01-18 at 07 11 11" src="https://user-images.githubusercontent.com/869724/72660069-d3549680-39c8-11ea-894d-02c793efa19c.png">


### After patch
<img width="911" alt="Screen Shot 2020-01-18 at 08 36 07" src="https://user-images.githubusercontent.com/869724/72660430-1402de80-39ce-11ea-8c24-92a0f9d0f8cf.png">


