### PR TITLE
[4.0] Allow to use a custom filter with subform field

### DIFF
--- a/libraries/src/Form/FormField.php
+++ b/libraries/src/Form/FormField.php
@@ -1012,6 +1012,26 @@ abstract class FormField
 				return '';
 			}
 
+			// Check for a callback filter
+			if (strpos($filter, '::') !== false && \is_callable(explode('::', $filter)))
+			{
+				return \call_user_func(explode('::', $filter), $value);
+			}
+
+			// Load the FormRule object for the field. FormRule objects take precedence over PHP functions
+			$obj = FormHelper::loadFilterType($filter);
+
+			// Run the filter rule.
+			if ($obj)
+			{
+				return $obj->filter($this->element, $value, $group, $input, $this->form);
+			}
+
+			if (\function_exists($filter))
+			{
+				return \call_user_func($filter, $value);
+			}
+
 			// Dirty way of ensuring required fields in subforms are submitted and filtered the way other fields are
 			if ($this instanceof SubformField)
 			{
@@ -1032,26 +1052,6 @@ abstract class FormField
 				}
 
 				return $return;
-			}
-
-			// Check for a callback filter
-			if (strpos($filter, '::') !== false && \is_callable(explode('::', $filter)))
-			{
-				return \call_user_func(explode('::', $filter), $value);
-			}
-
-			// Load the FormRule object for the field. FormRule objects take precedence over PHP functions
-			$obj = FormHelper::loadFilterType($filter);
-
-			// Run the filter rule.
-			if ($obj)
-			{
-				return $obj->filter($this->element, $value, $group, $input, $this->form);
-			}
-
-			if (\function_exists($filter))
-			{
-				return \call_user_func($filter, $value);
 			}
 		}
 


### PR DESCRIPTION

### Summary of Changes

Allow to use a custom filter with subform field.
The same as #27561 but for Joomla 4.0


### Testing Instructions

Apply patch, create a subform field , somwhere in CustomHTML module, with custom filter:
```xml
<field name="test_fields" type="subform" label="test_fields" 
filter="FooBar::filterTest" multiple="true" min="1">
  <form>
    <field name="test_field" type="text" label="TESTFIELD1"/>
  </form>
</field>
```

Add custom filter class, somwhere in bottom of `plugins/system/debug/debug.php`:
```php
class FooBar
{
	static function filterTest($value)
	{
		JFactory::getApplication()
		 ->enqueueMessage('Filter works: ' . json_encode($value));
		return $value;
	}
}
```

Then create a Custom module in backed, and try save it.
Look for the message you got


### Expected result
You should get 2 message:
`Filter works: {"test_fields0":{"test_field":""}}`
and
`Module saved`


### Actual result
You get 1 message
`Module saved`
that means the custom filter was ignored

