### PR TITLE
[4.0] Fix joomla.edit.params when render subform with fieldset

### DIFF
--- a/layouts/joomla/edit/params.php
+++ b/layouts/joomla/edit/params.php
@@ -110,8 +110,8 @@ foreach ($fieldSets as $name => $fieldSet)
 		$label = Text::_($label);
 	}
 
-	$hasChildren = $xml->xpath('//fieldset[@name="' . $name . '"]//fieldset');
-	$hasParent = $xml->xpath('//fieldset//fieldset[@name="' . $name . '"]');
+	$hasChildren  = $xml->xpath('//fieldset[@name="' . $name . '"]//fieldset[not(ancestor::field/form/*)]');
+	$hasParent    = $xml->xpath('//fieldset//fieldset[@name="' . $name . '"]');
 	$isGrandchild = $xml->xpath('//fieldset//fieldset//fieldset[@name="' . $name . '"]');
 
 	if (!$isGrandchild && $hasParent)


### PR DESCRIPTION
### Summary of Changes

This fix a bug, when the params tab become empty if one of the field is a subform with own fieldset


### Testing Instructions
Apply patch.
Add next subform field to Custom HTML module (in `<fieldset name="options"`):
```xml
<field name="test_fields" type="subform" label="test_fields"
  filter="FooBar::filterTest" multiple="true" min="1" groupByFieldset="true">
   <form>
    <fieldset name="test1" label="fieldset 1">
     <field name="test_field" type="text" label="TESTFIELD1"/>
    </fieldset>
    <fieldset name="test2" label="fieldset 2">
     <field name="test_field2" type="text" label="TESTFIELD2"/>
    </fieldset>
   </form>
</field>
```
Open the module for editing, check the options tab (or where field was added)

### Expected result
you see there all fields, and subform field also


### Actual result
the tab are empty


