### PR TITLE
Bump minimum PHP version to 7.2.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "config": {
         "optimize-autoloader": true,
         "platform": {
-            "php": "7.2"
+            "php": "7.2.5"
         },
         "preferred-install": {
             "joomla/application": "dist",
@@ -51,7 +51,7 @@
         }
     },
     "require": {
-        "php": ">=7.2",
+        "php": ">=7.2.5",
         "joomla/application": "~2.0@dev",
         "joomla/archive": "~1.1.5",
         "joomla/authentication": "~2.0@dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a885da972a3f235d5b139b7d34fa7542",
+    "content-hash": "c82df6ccb38650998b7bc8b674d61b01",
     "packages": [
         {
             "name": "algo26-matthias/idna-convert",
@@ -3974,6 +3974,7 @@
                 "selenium",
                 "webdriver"
             ],
+            "abandoned": "php-webdriver/webdriver",
             "time": "2019-06-13T08:02:18+00:00"
         },
         {
@@ -7183,13 +7184,13 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.2",
+        "php": ">=7.2.5",
         "ext-json": "*",
         "ext-simplexml": "*",
         "ext-gd": "*"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.2"
+        "php": "7.2.5"
     }
 }


### PR DESCRIPTION
### Summary of Changes
Bumps minimum PHP version from 7.2.0 to 7.2.5.

The reason for this is simple. Symfony's new major version requires that version: https://github.com/symfony/symfony/issues/34442

By using this major version we get a bonus two years of symfony support in exchange for 5 patch versions which are likely to be more buggy.

This has been approved at Production level already.