### PR TITLE
[4.0] [Cassiopeia] Remove header SVG curve

### DIFF
--- a/templates/cassiopeia/index.php
+++ b/templates/cassiopeia/index.php
@@ -67,9 +67,6 @@ if ($this->countModules('sidebar-right'))
 	$hasClass .= ' has-sidebar-right';
 }
 
-// Header bottom margin
-$headerMargin = !$this->countModules('banner') ? ' mb-4' : '';
-
 // Container
 $wrapper = $this->params->get('fluidContainer') ? 'wrapper-fluid' : 'wrapper-static';
 
@@ -125,13 +122,6 @@ $this->setMetaData('viewport', 'width=device-width, initial-scale=1');
 				<jdoc:include type="modules" name="banner" style="xhtml" />
 			</div>
 			<?php endif; ?>
-			<div class="header-shadow"></div>
-			<div class="header-shape-bottom">
-				<canvas width="736" height="15"></canvas>
-				<svg class="" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 736 15">
-					<path d="M1040,301V285s-75,12-214,12-284-26-524,0v4Z" transform="translate(-302 -285)" fill="#fafafa"/>
-				</svg>
-			</div>
 		</header>
 	</div>
 

--- a/templates/cassiopeia/index.php
+++ b/templates/cassiopeia/index.php
@@ -119,7 +119,7 @@ $this->setMetaData('viewport', 'width=device-width, initial-scale=1');
 			</nav>
 			<?php if ($this->countModules('banner')) : ?>
 			<div class="grid-child container-banner">
-				<jdoc:include type="modules" name="banner" style="xhtml" />
+				<jdoc:include type="modules" name="banner" style="html5" />
 			</div>
 			<?php endif; ?>
 		</header>

--- a/templates/cassiopeia/scss/blocks/_banner.scss
+++ b/templates/cassiopeia/scss/blocks/_banner.scss
@@ -1,6 +1,7 @@
 // Banner
 
 .container-banner {
+  color: white;
 
   img {
     display: block;

--- a/templates/cassiopeia/scss/blocks/_banner.scss
+++ b/templates/cassiopeia/scss/blocks/_banner.scss
@@ -3,8 +3,8 @@
 .container-banner {
 
   img {
-    width: 100%;
-    box-shadow: 0 2px 15px rgba(0, 0, 0, .8);
+    display: block;
+    margin: auto;
   }
 
 }

--- a/templates/cassiopeia/scss/blocks/_css-grid.scss
+++ b/templates/cassiopeia/scss/blocks/_css-grid.scss
@@ -80,11 +80,6 @@
 
   .container-banner {
     padding: 0 ($cassiopeia-grid-gutter / 2);
-
-    p {
-      margin-bottom: 0;
-    }
-
   }
 }
 

--- a/templates/cassiopeia/scss/blocks/_css-grid.scss
+++ b/templates/cassiopeia/scss/blocks/_css-grid.scss
@@ -73,32 +73,18 @@
         ". debug debug debug debug .";
     }
 
-    .container-header {
-      margin-top: 0;
-      margin-bottom: 20px;
-
-      + div:not(.container-banner):not(.container-sidebar-left):not(.container-component) {
-        margin-top: $cassiopeia-grid-gutter;
-      }
-    }
-
     &.wrapper-fluid {
       grid-template-columns: [full-start] minmax(0, 1fr) [main-start] repeat(4, minmax(0, 25%)) [main-end] minmax(0, 1fr) [full-end];
     }
   }
 
   .container-banner {
-    z-index: 5;
-    margin: -2rem 0 0;
     padding: 0 ($cassiopeia-grid-gutter / 2);
 
     p {
       margin-bottom: 0;
     }
 
-    @include media-breakpoint-up(xl) {
-      margin-top: -3rem;
-    }
   }
 }
 

--- a/templates/cassiopeia/scss/blocks/_header.scss
+++ b/templates/cassiopeia/scss/blocks/_header.scss
@@ -17,12 +17,7 @@
   }
 
   nav {
-    padding: 2.5rem ($cassiopeia-grid-gutter / 2) 4.5rem;
-
-    @include media-breakpoint-up(xl) {
-      padding-bottom: 5.5rem;
-    }
-
+    padding: 2.5rem ($cassiopeia-grid-gutter / 2) 2.5rem;
   }
 
   .site-description {
@@ -165,43 +160,4 @@
 
   }
 
-}
-
-.header-shadow {
-  display: none;
-  pointer-events: none;
-
-  .container-banner + & {
-    position: absolute;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    display: block;
-    height: 180px;
-    content: "";
-    background-image: linear-gradient(0deg, rgba(0, 0, 0, .5) 0%, transparent 100%);
-
-  }
-
-}
-
-.header-shape-bottom {
-  position: absolute;
-  right: 0;
-  bottom: -20px;
-  left: 0;
-  border-bottom: 20px solid #fafafa;
-
-  canvas {
-    display: block;
-    width: 100%;
-    visibility: hidden;
-  }
-
-  svg {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    width: 100%;
-  }
 }

--- a/templates/cassiopeia/scss/blocks/_layout.scss
+++ b/templates/cassiopeia/scss/blocks/_layout.scss
@@ -28,7 +28,7 @@ header {
 
 .container-banner {
   display: block;
-  margin: -15px 0 -5px;
+  margin: 0 0 2rem;
 }
 
 .container-top-a,


### PR DESCRIPTION
Pull Request for Issue #27565 .

### Summary of Changes
Removes the SVG curve from the frontend template header

### Testing Instructions
Apply patch and run `node build.js --compile-css` to update the changed SCSS.

Add banner module to banner position

### Before PR
Banner cropped by SVG


### After PR
Banner is visible


### Documentation Changes Required
No
