### PR TITLE
Fix for folder size on mobile re issue #27537

### DIFF
--- a/administrator/components/com_media/resources/styles/components/_media-browser.scss
+++ b/administrator/components/com_media/resources/styles/components/_media-browser.scss
@@ -42,7 +42,7 @@
 
 .media-browser-item-preview {
   position: relative;
-  font-size: 60px;
+  font-size: 10vw;
   color: #007eb7;
   border-radius: $grid-item-border-radius;
   &::after {


### PR DESCRIPTION
Fix for the UI size issue described in
[4.0] [backend-template] Media Manager unusable on mobile #27537

Pull Request for Issue # .

### Summary of Changes
Small CSS / SCSS change to make the folder icon in the media manager work better on mobile screen size

### Testing Instructions
1. Use small window or mobile device, like 375 x 667 pixels (iPhone6)
2. Login to admin and go administrator
3. Go to media manager
4. Look at size of folder

Also repeat on other screen sizes

### Expected result
Should be able to click on the folders


### Actual result
Can't click on the folders because they're too big and overlap each other

### Documentation Changes Required
None


### Further notes...
Screen grab of issue...
![Screen Shot 2020-01-19 at 18 21 05](https://user-images.githubusercontent.com/91541/72686097-b616e980-3ae8-11ea-99c6-85d935f99232.png)

Screen grab after fix...
![Screen Shot 2020-01-19 at 18 20 50](https://user-images.githubusercontent.com/91541/72686104-e2cb0100-3ae8-11ea-944d-ff8ec4a0c269.png)

