### PR TITLE
[4.0] Correct ID in ordering field

### DIFF
--- a/libraries/cms/html/list.php
+++ b/libraries/cms/html/list.php
@@ -136,12 +136,13 @@ abstract class JHtmlList
 	 * @param   string   $attribs   HTML tag attributes
 	 * @param   string   $selected  The selected item
 	 * @param   integer  $neworder  1 if new and first, -1 if new and last, 0  or null if existing item
+	 * @param   string   $id        ID attribute for the resulting <select> element
 	 *
 	 * @return  string   HTML markup for the select list
 	 *
 	 * @since   1.6
 	 */
-	public static function ordering($name, $query, $attribs = null, $selected = null, $neworder = null)
+	public static function ordering($name, $query, $attribs = null, $selected = null, $neworder = null, ?string $id = null)
 	{
 		if (empty($attribs))
 		{
@@ -151,7 +152,7 @@ abstract class JHtmlList
 		if (empty($neworder))
 		{
 			$orders = HTMLHelper::_('list.genericordering', $query);
-			$html = HTMLHelper::_('select.genericlist', $orders, $name, array('list.attr' => $attribs, 'list.select' => (int) $selected));
+			$html = HTMLHelper::_('select.genericlist', $orders, $name, ['list.attr' => $attribs, 'list.select' => (int) $selected, 'id' => $id]);
 		}
 		else
 		{

--- a/libraries/cms/html/list.php
+++ b/libraries/cms/html/list.php
@@ -105,7 +105,7 @@ abstract class JHtmlList
 			return $options;
 		}
 
-		$options[] = HTMLHelper::_('select.option', 0, '0 ' . Text::_('JOPTION_ORDER_FIRST'));
+		$options[] = HTMLHelper::_('select.option', 0, '0. ' . Text::_('JOPTION_ORDER_FIRST'));
 
 		for ($i = 0, $n = count($items); $i < $n; $i++)
 		{
@@ -123,7 +123,7 @@ abstract class JHtmlList
 			$options[] = HTMLHelper::_('select.option', $items[$i]->value, $items[$i]->value . '. ' . $text);
 		}
 
-		$options[] = HTMLHelper::_('select.option', $items[$i - 1]->value + 1, ($items[$i - 1]->value + 1) . ' ' . Text::_('JOPTION_ORDER_LAST'));
+		$options[] = HTMLHelper::_('select.option', $items[$i - 1]->value + 1, ($items[$i - 1]->value + 1) . '. ' . Text::_('JOPTION_ORDER_LAST'));
 
 		return $options;
 	}

--- a/libraries/cms/html/list.php
+++ b/libraries/cms/html/list.php
@@ -152,7 +152,12 @@ abstract class JHtmlList
 		if (empty($neworder))
 		{
 			$orders = HTMLHelper::_('list.genericordering', $query);
-			$html = HTMLHelper::_('select.genericlist', $orders, $name, ['list.attr' => $attribs, 'list.select' => (int) $selected, 'id' => $id]);
+			$html   = HTMLHelper::_(
+				'select.genericlist',
+				$orders,
+				$name,
+				['list.attr' => $attribs, 'list.select' => (int) $selected, 'id' => $id ?? false]
+			);
 		}
 		else
 		{

--- a/libraries/src/Form/Field/OrderingField.php
+++ b/libraries/src/Form/Field/OrderingField.php
@@ -136,13 +136,13 @@ class OrderingField extends FormField
 		// Create a read-only list (no name) with a hidden input to store the value.
 		if ($this->readonly)
 		{
-			$html[] = HTMLHelper::_('list.ordering', '', $query, trim($attr), $this->value, $itemId ? 0 : 1);
+			$html[] = HTMLHelper::_('list.ordering', '', $query, trim($attr), $this->value, $itemId ? 0 : 1, $this->id);
 			$html[] = '<input type="hidden" name="' . $this->name . '" value="' . $this->value . '">';
 		}
 		else
 		{
 			// Create a regular list.
-			$html[] = HTMLHelper::_('list.ordering', $this->name, $query, trim($attr), $this->value, $itemId ? 0 : 1);
+			$html[] = HTMLHelper::_('list.ordering', $this->name, $query, trim($attr), $this->value, $itemId ? 0 : 1, $this->id);
 		}
 
 		return implode($html);


### PR DESCRIPTION
Pull Request for Issue #27514.

### Summary of Changes

Corrects `<select>` element IDs in ordering fields.

### Testing Instructions

Edit a plugin.
Inspect markup of Ordering field.

### Expected result

`<select>` element has `id="jform_ordering"`.

### Actual result

Element has `id="jformordering"`.

### Documentation Changes Required

New argument added to `JHtmlList::ordering()`.