### PR TITLE
[4.0] Load Bootstrap JS in some modules

### DIFF
--- a/administrator/modules/mod_post_installation_messages/tmpl/default.php
+++ b/administrator/modules/mod_post_installation_messages/tmpl/default.php
@@ -9,11 +9,12 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 
 // Load Bootstrap JS for dropdowns.
-$app->getDocument()->getWebAssetManager()->useScript('bootstrap.js.bundle');
+HTMLHelper::_('bootstrap.framework');
 
 $hideLinks = $app->input->getBool('hidemainmenu');
 ?>

--- a/administrator/modules/mod_post_installation_messages/tmpl/default.php
+++ b/administrator/modules/mod_post_installation_messages/tmpl/default.php
@@ -12,6 +12,9 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 
+// Load Bootstrap JS for dropdowns.
+$app->getDocument()->getWebAssetManager()->useScript('bootstrap.js.bundle');
+
 $hideLinks = $app->input->getBool('hidemainmenu');
 ?>
 <?php if ($app->getIdentity()->authorise('core.manage', 'com_postinstall')) : ?>

--- a/administrator/modules/mod_user/tmpl/default.php
+++ b/administrator/modules/mod_user/tmpl/default.php
@@ -9,13 +9,14 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
 use Joomla\CMS\Uri\Uri;
 
 // Load Bootstrap JS for dropdowns.
-$app->getDocument()->getWebAssetManager()->useScript('bootstrap.js.bundle');
+HTMLHelper::_('bootstrap.framework');
 
 $hideLinks = $app->input->getBool('hidemainmenu');
 ?>

--- a/administrator/modules/mod_user/tmpl/default.php
+++ b/administrator/modules/mod_user/tmpl/default.php
@@ -14,9 +14,11 @@ use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
 use Joomla\CMS\Uri\Uri;
 
+// Load Bootstrap JS for dropdowns.
+$app->getDocument()->getWebAssetManager()->useScript('bootstrap.js.bundle');
+
 $hideLinks = $app->input->getBool('hidemainmenu');
 ?>
-
 <div class="header-item-content dropdown header-profile d-flex">
 	<button class="dropdown-toggle d-flex flex-column align-items-stretch <?php echo ($hideLinks ? 'disabled' : ''); ?>" data-toggle="dropdown" type="button" <?php echo ($hideLinks ? 'disabled' : ''); ?>
 		title="<?php echo Text::_('MOD_USER_MENU'); ?>">


### PR DESCRIPTION
### Summary of Changes

Loads Bootstrap JS in some modules that use BS dropdowns.

### Testing Instructions

Cause an error in administrator. E.g. modify `administrator/templates/atum/index.php` to have a syntax error.
In Joomla error page click `User Menu` or `Post-Installation Messages` at the top bar.

### Expected result

Dropdown opens.

### Actual result

Nothing happens.

### Documentation Changes Required

No.