### PR TITLE
[4.0] Fix query in User Debug

### DIFF
--- a/administrator/components/com_users/Model/DebuggroupModel.php
+++ b/administrator/components/com_users/Model/DebuggroupModel.php
@@ -265,7 +265,7 @@ class DebuggroupModel extends ListModel
 		if ($this->getState('filter.component'))
 		{
 			$component  = $this->getState('filter.component');
-			$lcomponent = $component . '%';
+			$lcomponent = $component . '.%';
 			$query->where(
 				'(' . $db->quoteName('a.name') . ' = :component'
 				. ' OR ' . $db->quoteName('a.name') . ' LIKE :lcomponent)'

--- a/administrator/components/com_users/Model/DebuguserModel.php
+++ b/administrator/components/com_users/Model/DebuguserModel.php
@@ -246,7 +246,7 @@ class DebuguserModel extends ListModel
 		if ($this->getState('filter.component'))
 		{
 			$component  = $this->getState('filter.component');
-			$lcomponent = $component . '%';
+			$lcomponent = $component . '.%';
 			$query->where(
 				'(' . $db->quoteName('a.name') . ' = :component'
 				. ' OR ' . $db->quoteName('a.name') . ' LIKE :lcomponent)'

--- a/administrator/components/com_users/Model/DebuguserModel.php
+++ b/administrator/components/com_users/Model/DebuguserModel.php
@@ -247,13 +247,9 @@ class DebuguserModel extends ListModel
 		{
 			$component  = $this->getState('filter.component');
 			$lcomponent = $component . '%';
-			$query->extendWhere(
-				'AND',
-				[
-					$db->quoteName('a.name') . ' = :component',
-					$db->quoteName('a.name') . ' LIKE :lcomponent'
-				],
-				'OR'
+			$query->where(
+				'(' . $db->quoteName('a.name') . ' = :component'
+				. ' OR ' . $db->quoteName('a.name') . ' LIKE :lcomponent)'
 			)
 				->bind(':component', $component)
 				->bind(':lcomponent', $lcomponent);


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/27594.

### Summary of Changes

Fixes query error and filtering by component.

### Testing Instructions

Go to Users. Click on an icon to view Permissions.
Filter by Articles component.

### Expected result

No error and only `com_content` entries are shown.

### Actual result

>Error: Call to a member function setName() on null

And `com_contenthistory` entry is also shown.

### Documentation Changes Required

No.