### PR TITLE
added tag filter to category list view

### DIFF
--- a/components/com_content/views/category/tmpl/default.xml
+++ b/components/com_content/views/category/tmpl/default.xml
@@ -26,6 +26,15 @@
 				edit="true"
 				clear="true"
 			/>
+
+			<field
+					name="filter_tag"
+					type="tag"
+					label="JTAG"
+					description="JTAG_FIELD_SELECT_DESC"
+					multiple="true"
+					mode="nested"
+			/>
 		</fieldset>
 	</fields>
 

--- a/components/com_content/views/category/tmpl/default.xml
+++ b/components/com_content/views/category/tmpl/default.xml
@@ -28,12 +28,12 @@
 			/>
 
 			<field
-					name="filter_tag"
-					type="tag"
-					label="JTAG"
-					description="JTAG_FIELD_SELECT_DESC"
-					multiple="true"
-					mode="nested"
+				name="filter_tag"
+				type="tag"
+				label="JTAG"
+				description="JTAG_FIELD_SELECT_DESC"
+				multiple="true"
+				mode="nested"
 			/>
 		</fieldset>
 	</fields>


### PR DESCRIPTION
Pull Request for Issue #24398, backported to 3.x as mentioned by @HLeithner in https://github.com/joomla/joomla-cms/pull/24550#issuecomment-577079969 .

### Summary of Changes
Added the missing field definition to the XML; no other changes required as the actual filtering logic is shared with the blog view and therefore available anyway. Only the UI was missing.


### Testing Instructions
* Create several articles in the same category using various tags
* Create several Category List menu items for the category using the various tags used previously

### Expected result
Filters are applied


### Actual result
No filter available


### Documentation Changes Required
See https://docs.joomla.org/Help39:Menus_Menu_Item_Article_Category_List

Screenshot needs an  update, new filter has to be described.
