### PR TITLE
Add a prefix to the sessionname

### DIFF
--- a/libraries/src/Session/Session.php
+++ b/libraries/src/Session/Session.php
@@ -917,7 +917,7 @@ class Session implements \IteratorAggregate
 		// Set name
 		if (isset($options['name']))
 		{
-			$this->_handler->setName(md5($options['name']));
+			$this->_handler->setName('joomla_' . md5($options['name']));
 		}
 
 		// Set id


### PR DESCRIPTION
### Summary of Changes
Add a prefix to the session name, so that the session can be identified more easily. I found out that the requirement exists during a conversation at the Forum for the Future with a web host.

### Testing Instructions
1. Check the name of the cookies in the frontend and in the backend using the developer tools.

![Screenshot from 2020 01 22 12 59 28](https://user-images.githubusercontent.com/9974686/72893041-61f24c00-3d18-11ea-809a-0a6c6eb7d35d.png)
-
![Screenshot from 2020 01 22 12 57 00](https://user-images.githubusercontent.com/9974686/72893042-61f24c00-3d18-11ea-8dd2-2cc37c649250.png)

### Expected result

With the change made here, web hosts can recognize that the cookie has been set by Joomla.

### Actual result

Without the change made here in PR, the name is a hash encrypted with md5, which gives no information about the origin.


### Documentation Changes Required
No
