### PR TITLE
[4.0] Toolbar button creation ignores task

### DIFF
--- a/libraries/src/Toolbar/Toolbar.php
+++ b/libraries/src/Toolbar/Toolbar.php
@@ -483,7 +483,8 @@ class Toolbar
 			$button = $this->factory->createButton($this, $type);
 
 			$button->name($args[0] ?? '')
-				->text($args[1] ?? '');
+				->text($args[1] ?? '')
+				->task($args[2] ?? '');
 
 			return $this->appendButton($button);
 		}


### PR DESCRIPTION
In J4.0 we have a new Toolbar class which helps creating the buttons in the various backend views.
In core, it is used like this to create a button
````
$toolbar->standardButton('refresh')
	->text('JTOOLBAR_REBUILD')
	->task('categories.rebuild');
````
Now the IDE and also the class itself suggest a different writing like this:
`standardButton(string $name = '', string $text = '', string $task = '')`

So the above code would look like this;
`$toolbar->standardButton('refresh', 'JTOOLBAR_REBUILD', 'categories.rebuild');`

However this currently only works partially: Name and text works, but task is ignored.

### Summary of Changes
This PR just adds the task from the arguments to the button


### Testing Instructions
Adjust for example the code in the categories view to the alternative way like above. The example button would be here:
https://github.com/joomla/joomla-cms/blob/f5f840b665b61a1675e75e4c9d6e4ccdcd62d34b/administrator/components/com_categories/View/Categories/HtmlView.php#L232-L234


### Expected result
Works the same, regardless of style.


### Actual result
Only the original code works, the adjusted like above just reloads the page without triggering the task.


### Documentation Changes Required
None.
