### PR TITLE
[4.0] com_fields render front end

### DIFF
--- a/components/com_fields/layouts/fields/render.php
+++ b/components/com_fields/layouts/fields/render.php
@@ -69,7 +69,7 @@ foreach ($fields as $field)
 		continue;
 	}
 
-	$output[] = '<dd class="field-entry ' . $class . '">' . $content . '</dd>';
+	$output[] = '<li class="field-entry ' . $class . '">' . $content . '</li>';
 }
 
 if (empty($output))
@@ -77,6 +77,6 @@ if (empty($output))
 	return;
 }
 ?>
-<dl class="fields-container">
+<ul class="fields-container">
 	<?php echo implode("\n", $output); ?>
-</dl>
+</ul>


### PR DESCRIPTION
These are currently incorrectly rendered as a definition list. After discussions in spain we agreed that this is semantically wrong and should be an unordered list.

In addition the definition list markup that was being used was wrong see #27567 for details
