### PR TITLE
[4.0] gray-600 Cassiopeia template

### DIFF
--- a/templates/cassiopeia/scss/_variables.scss
+++ b/templates/cassiopeia/scss/_variables.scss
@@ -17,7 +17,7 @@ $gray-200:                           #e9ecef;
 $gray-300:                           #dee2e6;
 $gray-400:                           #ced4da;
 $gray-500:                           #adb5bd;
-$gray-600:                           #868e96;
+$gray-600:                           #6c757d;
 $gray-700:                           #495057;
 $gray-800:                           #343a40;
 $gray-900:                           #212529;


### PR DESCRIPTION
I have no idea why the value for gray-600 is different to the default bootstrap value but as a result it is failing the contrast checks.

You can see this in action on the article info fields.

This PR changes the value back to the bootstrap default which passes the accessibility contrast check and its almost impossible to visually differentiate

For testing don't forget to npm -i
