### PR TITLE
[4.0] Correct com_config links in testing sample data

### DIFF
--- a/plugins/sampledata/testing/testing.php
+++ b/plugins/sampledata/testing/testing.php
@@ -2624,7 +2624,7 @@ class PlgSampledataTesting extends CMSPlugin
 			array(
 				'menutype'     => $menuTypes[6],
 				'title'        => Text::_('PLG_SAMPLEDATA_TESTING_SAMPLEDATA_MENUS_ITEM_78_TITLE'),
-				'link'         => 'index.php?option=com_config&view=config&controller=config.display.config',
+				'link'         => 'index.php?option=com_config&view=config',
 				'component_id' => ComponentHelper::getComponent('com_config')->id,
 				'access'       => 6,
 				'params'       => array(
@@ -2636,7 +2636,7 @@ class PlgSampledataTesting extends CMSPlugin
 			array(
 				'menutype'     => $menuTypes[6],
 				'title'        => Text::_('PLG_SAMPLEDATA_TESTING_SAMPLEDATA_MENUS_ITEM_79_TITLE'),
-				'link'         => 'index.php?option=com_config&view=templates&controller=config.display.templates',
+				'link'         => 'index.php?option=com_config&view=templates',
 				'component_id' => ComponentHelper::getComponent('com_config')->id,
 				'access'       => 6,
 				'params'       => array(


### PR DESCRIPTION
### Summary of Changes

Corrects com_config links in Sample Data - Testing plugin.

### Testing Instructions

Install Testing sample data.
Login to frontend as admin.
In `All Front End Views` module click `Site Settings` or `Template Settings`

### Expected result

Works.

### Actual result
Errors:
>Invalid controller class: config.display.config
>Invalid controller class: config.display.templates

### Documentation Changes Required

No.