### PR TITLE
[4.0] [com_config] Add missing doc blocks

### DIFF
--- a/administrator/components/com_config/src/View/Application/HtmlView.php
+++ b/administrator/components/com_config/src/View/Application/HtmlView.php
@@ -26,10 +26,28 @@ use Joomla\Component\Config\Administrator\Helper\ConfigHelper;
  */
 class HtmlView extends BaseHtmlView
 {
+	/**
+	 * The model state
+	 *
+	 * @var    \Joomla\CMS\Object\CMSObject
+	 * @since  3.2
+	 */
 	public $state;
 
+	/**
+	 * The form object
+	 *
+	 * @var    \Joomla\CMS\Form\Form
+	 * @since  3.2
+	 */
 	public $form;
 
+	/**
+	 * The data to be displayed in the form
+	 *
+	 * @var   array
+	 * @since 3.2
+	 */
 	public $data;
 
 	/**

--- a/administrator/components/com_config/src/View/Component/HtmlView.php
+++ b/administrator/components/com_config/src/View/Component/HtmlView.php
@@ -24,10 +24,28 @@ use Joomla\Component\Config\Administrator\Helper\ConfigHelper;
  */
 class HtmlView extends BaseHtmlView
 {
+	/**
+	 * The model state
+	 *
+	 * @var    \Joomla\CMS\Object\CMSObject
+	 * @since  3.2
+	 */
 	public $state;
 
+	/**
+	 * The form object
+	 *
+	 * @var    \Joomla\CMS\Form\Form
+	 * @since  3.2
+	 */
 	public $form;
 
+	/**
+	 * An object with the information for the component
+	 *
+	 * @var    \Joomla\CMS\Component\ComponentRecord
+	 * @since  3.2
+	 */
 	public $component;
 
 	/**


### PR DESCRIPTION
### Summary of Changes

Adds some missing doc blocks reported by PHPCS.

### Testing Instructions

View Drone/PHPCS results.

### Expected result

No errors.

### Actual result

```
FILE: ...istrator/components/com_config/src/View/Application/HtmlView.php
----------------------------------------------------------------------
FOUND 3 ERRORS AFFECTING 3 LINES
----------------------------------------------------------------------
 29 | ERROR | Missing member variable doc comment
    |       | (Squiz.Commenting.VariableComment.Missing)
 31 | ERROR | Missing member variable doc comment
    |       | (Squiz.Commenting.VariableComment.Missing)
 33 | ERROR | Missing member variable doc comment
    |       | (Squiz.Commenting.VariableComment.Missing)
----------------------------------------------------------------------


FILE: ...inistrator/components/com_config/src/View/Component/HtmlView.php
----------------------------------------------------------------------
FOUND 3 ERRORS AFFECTING 3 LINES
----------------------------------------------------------------------
 27 | ERROR | Missing member variable doc comment
    |       | (Squiz.Commenting.VariableComment.Missing)
 29 | ERROR | Missing member variable doc comment
    |       | (Squiz.Commenting.VariableComment.Missing)
 31 | ERROR | Missing member variable doc comment
    |       | (Squiz.Commenting.VariableComment.Missing)
----------------------------------------------------------------------
```

### Documentation Changes Required

No.