### PR TITLE
[4.0] Remove unneeded tooltip on post installation messages

### DIFF
--- a/administrator/modules/mod_post_installation_messages/tmpl/default.php
+++ b/administrator/modules/mod_post_installation_messages/tmpl/default.php
@@ -45,9 +45,8 @@ $hideLinks = $app->input->getBool('hidemainmenu');
 			<?php endif; ?>
 			<?php foreach ($messages as $message) : ?>
 				<?php $route = 'index.php?option=com_postinstall&amp;eid=' . $joomlaFilesExtensionId; ?>
-				<?php $title = Text::_($message->title_key); ?>
-				<a class="dropdown-item" href="<?php echo Route::_($route); ?>" title="<?php echo $title; ?>">
-					<?php echo $title; ?>
+				<a class="dropdown-item" href="<?php echo Route::_($route); ?>">
+					<?php echo Text::_($message->title_key); ?>
 				</a>
 			<?php endforeach; ?>
 		</div>


### PR DESCRIPTION
### Summary of Changes
Remove the tooltip that is identical to the post installation message.

![27622](https://user-images.githubusercontent.com/368084/73077641-6718dd80-3e75-11ea-835c-7846ba643922.jpg)



### Testing Instructions
Click the Post Installation Message icon in the upper right-hand corner.
Hover over the post installation messages.
See tooltip.
Apply PR.
No tooltip.