### PR TITLE
[4.0] Fix Undefined variable $class notice in Finder

### DIFF
--- a/administrator/components/com_finder/Indexer/Language.php
+++ b/administrator/components/com_finder/Indexer/Language.php
@@ -104,17 +104,17 @@ class Language
 		if ($language !== '*')
 		{
 			$locale = Helper::getPrimaryLanguage($language);
-			$class = '\\Joomla\\Component\\Finder\\Administrator\\Indexer\\Language\\' . ucfirst($locale);
+			$class  = '\\Joomla\\Component\\Finder\\Administrator\\Indexer\\Language\\' . ucfirst($locale);
+
+			if (class_exists($class))
+			{
+				self::$instances[$language] = new $class;
+
+				return self::$instances[$language];
+			}
 		}
 
-		if (class_exists($class))
-		{
-			self::$instances[$language] = new $class;
-		}
-		else
-		{
-			self::$instances[$language] = new self($locale);
-		}
+		self::$instances[$language] = new self($locale);
 
 		return self::$instances[$language];
 	}


### PR DESCRIPTION
Pull Request For Issue https://github.com/joomla/joomla-cms/issues/27623

### Summary of Changes

Fixes notice.

### Testing Instructions

Run Smart Search Indexer.
Check error log.

### Expected result

No notices.

### Actual result

>PHP Notice:  Undefined variable: class in C:\\xampp\\htdocs\\joomla-cms\\administrator\\components\\com_finder\\Indexer\\Language.php

### Documentation Changes Required

No.