### PR TITLE
[3] prevent new user register as superadmin

### DIFF
--- a/administrator/language/en-GB/en-GB.plg_user_joomla.ini
+++ b/administrator/language/en-GB/en-GB.plg_user_joomla.ini
@@ -4,7 +4,7 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_USER_JOOMLA="User - Joomla!"
-PLG_USER_JOOMLA_CANNOT_BE_SUPERADMIN="New user cannont be Super User"
+PLG_USER_JOOMLA_CANNOT_BE_SUPERADMIN="New user cannot be Super User."
 PLG_USER_JOOMLA_FIELD_AUTOREGISTER_DESC="Automatically create Registered Users where possible."
 PLG_USER_JOOMLA_FIELD_AUTOREGISTER_LABEL="Auto-create Users"
 PLG_USER_JOOMLA_FIELD_FORCELOGOUT_DESC="Set to No to disable this."

--- a/administrator/language/en-GB/en-GB.plg_user_joomla.ini
+++ b/administrator/language/en-GB/en-GB.plg_user_joomla.ini
@@ -4,6 +4,7 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_USER_JOOMLA="User - Joomla!"
+PLG_USER_JOOMLA_CANNOT_BE_SUPERADMIN="New user cannont be Super User"
 PLG_USER_JOOMLA_FIELD_AUTOREGISTER_DESC="Automatically create Registered Users where possible."
 PLG_USER_JOOMLA_FIELD_AUTOREGISTER_LABEL="Auto-create Users"
 PLG_USER_JOOMLA_FIELD_FORCELOGOUT_DESC="Set to No to disable this."

--- a/plugins/user/joomla/joomla.php
+++ b/plugins/user/joomla/joomla.php
@@ -467,7 +467,7 @@ class PlgUserJoomla extends JPlugin
 			return true;
 		}
 
-		// Check that at i'm not a Super Admin
+		// Check that at I'm not a Super Admin
 		foreach ($data['groups'] as $group)
 		{
 			if (Access::checkGroup($group, 'core.admin'))

--- a/plugins/user/joomla/joomla.php
+++ b/plugins/user/joomla/joomla.php
@@ -468,19 +468,14 @@ class PlgUserJoomla extends JPlugin
 		}
 
 		// Check that at i'm not a Super Admin
-		$imSuperAdmin = false;
-		$myGroups     = $data['groups'];
-
-		foreach ($myGroups as $group)
+		foreach ($data['groups'] as $group)
 		{
-			$imSuperAdmin = $imSuperAdmin ?: Access::checkGroup($group, 'core.admin');
-		}
+			if (Access::checkGroup($group, 'core.admin'))
+			{
+				$this->app->enqueueMessage(Text::_('PLG_USER_JOOMLA_CANNOT_BE_SUPERADMIN'), 'error');
 
-		if ($imSuperAdmin)
-		{
-			$this->app->enqueueMessage(Text::_('PLG_USER_JOOMLA_CANNOT_BE_SUPERADMIN'), 'error');
-
-			return false;
+				return false;
+			}
 		}
 
 		return true;

--- a/plugins/user/joomla/joomla.php
+++ b/plugins/user/joomla/joomla.php
@@ -441,7 +441,7 @@ class PlgUserJoomla extends JPlugin
 		return $instance;
 	}
 
-		/**
+	/**
 	 * Method is called before user data is stored in the database
 	 * Prevent new user register themself as Super Admin in frontend
 	 *
@@ -451,7 +451,7 @@ class PlgUserJoomla extends JPlugin
 	 *
 	 * @return    boolean
 	 *
-	 * @since   3.8.6
+	 * @since   __DEPLOY_VERSION__
 	 */
 	public function onUserBeforeSave($user, $isnew, $data)
 	{


### PR DESCRIPTION
Pull Request for Issue #27262 .

### Summary of Changes

added a check  via joomla user plugin `onUserBeforeSave` event

### Testing Instructions

- Enable user registration.
- Set New User Registration Group to Super Users.
- Set Guest User Group to Super Users.

![Screenshot from 2020-01-25 10-24-26](https://user-images.githubusercontent.com/181681/73119061-09f85700-3f5d-11ea-9f98-68a9e6d77cea.png)


### Expected result
No one should be able to register as Super User on registration (frontend).


### Actual result
under these settings a new user can register as Super Users



