### PR TITLE
[4.0] Outline none is evil

### DIFF
--- a/build/warning_page/template.css
+++ b/build/warning_page/template.css
@@ -24,7 +24,6 @@ ol, ul {
 a {
   color: #0084b4;
   text-decoration: none;
-  outline: 0
 }
 
 a:hover, a:focus {


### PR DESCRIPTION
https://medium.com/better-programming/a11y-never-remove-the-outlines-ee4efc7a9968

The build process 'Creates the error pages for unsupported PHP version & incomplete environment

The generated version of the files live in /templates/system

Look at the inline css in the generated files and you will see outline:0 

outline:0 should never be used as it is a massive accessibility break. We are committed to providing an accessible experience with joomla 4 and this must include our error pages.

Apply the pr
Run the build scripts
either npm -i or node build.js --build-pages

check the generated files ans see that the inline css no longer includes outline:0

Irrespective of if you can observe the outline or not setting it to zero should always be avoided.