### PR TITLE
Fix Joomla Update undefined variable

### DIFF
--- a/administrator/components/com_joomlaupdate/View/Joomlaupdate/HtmlView.php
+++ b/administrator/components/com_joomlaupdate/View/Joomlaupdate/HtmlView.php
@@ -140,7 +140,7 @@ class HtmlView extends BaseHtmlView
 			Factory::getApplication()->enqueueMessage(Text::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_UPDATE_NOTICE'), 'warning');
 		}
 
-		$this->ftpFieldsDisplay = $this->ftp['enabled'] ? '' : 'style = "display: none"';
+		$this->ftpFieldsDisplay = $ftp['enabled'] ? '' : 'style = "display: none"';
 		$params                 = ComponentHelper::getParams('com_joomlaupdate');
 
 		switch ($params->get('updatesource', 'default'))


### PR DESCRIPTION
Pull Request for Issue #27649 .

### Summary of Changes
Fixes us using an undefined variable causing a PHP notice (correctly) in PHP 7.4


### Testing Instructions
Check Joomla Update in PHP 7.4 before patch php notice, after patch no notice (else code review - variable `ftp` doesn't exist in the class but `$ftp` does exist and is used in a similar way further up in the code

### Documentation Changes Required
None
