### PR TITLE
[4.0] media manager duplicate selectors

### DIFF
--- a/administrator/components/com_media/resources/styles/components/_media-toolbar.scss
+++ b/administrator/components/com_media/resources/styles/components/_media-toolbar.scss
@@ -41,7 +41,6 @@
   }
 }
 
-
 .media-view-search-input {
   display: flex;
   align-items: center;

--- a/administrator/components/com_media/resources/styles/components/_media-toolbar.scss
+++ b/administrator/components/com_media/resources/styles/components/_media-toolbar.scss
@@ -31,18 +31,16 @@
 
 .media-view-icons {
   display: flex;
-}
-
-.media-view-icons {
-  .disabled {
-    span {
-      opacity: .3;
-    }
-    &:hover, span:hover {
-      cursor: default;
-    }
+    .disabled {
+      span {
+        opacity: .3;
+      }
+      &:hover, span:hover {
+        cursor: default;
+      }
   }
 }
+
 
 .media-view-search-input {
   display: flex;

--- a/administrator/components/com_media/resources/styles/components/_media-toolbar.scss
+++ b/administrator/components/com_media/resources/styles/components/_media-toolbar.scss
@@ -31,13 +31,13 @@
 
 .media-view-icons {
   display: flex;
-    .disabled {
-      span {
-        opacity: .3;
-      }
-      &:hover, span:hover {
-        cursor: default;
-      }
+  .disabled {
+    span {
+      opacity: .3;
+    }
+    &:hover, span:hover {
+      cursor: default;
+    }
   }
 }
 


### PR DESCRIPTION
the class media-view-icons should only be declared once in the scss file.

this is just a change for maintainability as the compiled css file that is generated is identical before and after this pr

the minified file can be located `media\com_media\css\mediamanager.min.css`
