### PR TITLE
[4.0] Automatically order the switcher options by value

### DIFF
--- a/layouts/joomla/form/field/radio/switcher.php
+++ b/layouts/joomla/form/field/radio/switcher.php
@@ -63,6 +63,8 @@ $input    = '<input type="radio" id="%1$s" name="%2$s" value="%3$s" %4$s>';
 $attr = 'id="' . $id . '"';
 $attr .= $onchange ? ' onchange="' . $onchange . '"' : '';
 
+// Make sure the options are first value 0 and then value 1.
+usort($options, function($a, $b) {return $a->value - $b->value;});
 ?>
 <fieldset <?php echo $attr; ?>>
 	<legend class="switcher__legend">


### PR DESCRIPTION
When adjusting a J3 extension to the new J4 UI style, we face the issue that in J3 the radio options in the XML are usually ordered with values descending (so "Yes" is defined first and appears left), while the switcher expects the options ascending (so "Yes" is defined last and appears right).
This is quite a bit of work which we could ease by adding one line into the switcher JLayout.
Since the switcher looks quite unexpected with "wrong" ordering, I don't see a disadvantage in forcing the "correct" ordering. But maybe I miss a usecase where an inversed order would be desired.

### Summary of Changes
This PR automatically orders the switcher options, so it doesn't matter in which order they are written in the XML.

### Testing Instructions
Change the order of the options of a radio switcher field (eg in /administrator/components/com_content/config.xml) and check how the switcher appears (in this example in the article manager options).

### Expected result
![image](https://user-images.githubusercontent.com/1018684/73167230-c4bc5c80-40f7-11ea-99bf-b292e4cdf6bb.png)![image](https://user-images.githubusercontent.com/1018684/73167254-d4d43c00-40f7-11ea-89e1-f6fca997bd31.png)




### Actual result
![image](https://user-images.githubusercontent.com/1018684/73167124-8fb00a00-40f7-11ea-9475-aa720334eeef.png)![image](https://user-images.githubusercontent.com/1018684/73167157-9d658f80-40f7-11ea-8b2c-b52abf0afe0f.png)





### Documentation Changes Required
If there is a documentation on this switcher, it should be added that the order of the options is ignored.