### PR TITLE
[4.0] Remove getSortFields from components- part 1

### DIFF
--- a/administrator/components/com_banners/View/Banners/HtmlView.php
+++ b/administrator/components/com_banners/View/Banners/HtmlView.php
@@ -208,26 +208,4 @@ class HtmlView extends BaseHtmlView
 
 		$toolbar->help('JHELP_COMPONENTS_BANNERS_BANNERS');
 	}
-
-	/**
-	 * Returns an array of fields the table can be sorted by
-	 *
-	 * @return  array  Array containing the field name to sort by as the key and display text as value
-	 *
-	 * @since   3.0
-	 */
-	protected function getSortFields(): array
-	{
-		return [
-			'ordering'    => Text::_('JGRID_HEADING_ORDERING'),
-			'a.state'     => Text::_('JSTATUS'),
-			'a.name'      => Text::_('COM_BANNERS_HEADING_NAME'),
-			'a.sticky'    => Text::_('COM_BANNERS_HEADING_STICKY'),
-			'client_name' => Text::_('COM_BANNERS_HEADING_CLIENT'),
-			'impmade'     => Text::_('COM_BANNERS_HEADING_IMPRESSIONS'),
-			'clicks'      => Text::_('COM_BANNERS_HEADING_CLICKS'),
-			'a.language'  => Text::_('JGRID_HEADING_LANGUAGE'),
-			'a.id'        => Text::_('JGRID_HEADING_ID'),
-		];
-	}
 }

--- a/administrator/components/com_banners/View/Clients/HtmlView.php
+++ b/administrator/components/com_banners/View/Clients/HtmlView.php
@@ -163,23 +163,4 @@ class HtmlView extends BaseHtmlView
 
 		$toolbar->help('JHELP_COMPONENTS_BANNERS_CLIENTS');
 	}
-
-	/**
-	 * Returns an array of fields the table can be sorted by
-	 *
-	 * @return  array  Array containing the field name to sort by as the key and display text as value
-	 *
-	 * @since   3.0
-	 */
-	protected function getSortFields(): array
-	{
-		return [
-			'a.status'    => Text::_('JSTATUS'),
-			'a.name'      => Text::_('COM_BANNERS_HEADING_CLIENT'),
-			'contact'     => Text::_('COM_BANNERS_HEADING_CONTACT'),
-			'client_name' => Text::_('COM_BANNERS_HEADING_CLIENT'),
-			'nbanners'    => Text::_('COM_BANNERS_HEADING_ACTIVE'),
-			'a.id'        => Text::_('JGRID_HEADING_ID')
-		];
-	}
 }

--- a/administrator/components/com_banners/View/Tracks/HtmlView.php
+++ b/administrator/components/com_banners/View/Tracks/HtmlView.php
@@ -144,22 +144,4 @@ class HtmlView extends BaseHtmlView
 
 		ToolbarHelper::help('JHELP_COMPONENTS_BANNERS_TRACKS');
 	}
-
-	/**
-	 * Returns an array of fields the table can be sorted by
-	 *
-	 * @return  array  Array containing the field name to sort by as the key and display text as value
-	 *
-	 * @since   3.0
-	 */
-	protected function getSortFields(): array
-	{
-		return [
-			'b.name'     => Text::_('COM_BANNERS_HEADING_NAME'),
-			'cl.name'    => Text::_('COM_BANNERS_HEADING_CLIENT'),
-			'track_type' => Text::_('COM_BANNERS_HEADING_TYPE'),
-			'count'      => Text::_('COM_BANNERS_HEADING_COUNT'),
-			'track_date' => Text::_('JDATE')
-		];
-	}
 }

--- a/administrator/components/com_contact/View/Contacts/HtmlView.php
+++ b/administrator/components/com_contact/View/Contacts/HtmlView.php
@@ -209,26 +209,4 @@ class HtmlView extends BaseHtmlView
 
 		$toolbar->help('JHELP_COMPONENTS_CONTACTS_CONTACTS');
 	}
-
-	/**
-	 * Returns an array of fields the table can be sorted by
-	 *
-	 * @return  array  Array containing the field name to sort by as the key and display text as value
-	 *
-	 * @since   3.0
-	 */
-	protected function getSortFields()
-	{
-		return array(
-			'a.ordering'     => Text::_('JGRID_HEADING_ORDERING'),
-			'a.published'    => Text::_('JSTATUS'),
-			'a.name'         => Text::_('JGLOBAL_TITLE'),
-			'category_title' => Text::_('JCATEGORY'),
-			'ul.name'        => Text::_('COM_CONTACT_FIELD_LINKED_USER_LABEL'),
-			'a.featured'     => Text::_('JFEATURED'),
-			'a.access'       => Text::_('JGRID_HEADING_ACCESS'),
-			'a.language'     => Text::_('JGRID_HEADING_LANGUAGE'),
-			'a.id'           => Text::_('JGRID_HEADING_ID'),
-		);
-	}
 }

--- a/administrator/components/com_csp/View/Reports/HtmlView.php
+++ b/administrator/components/com_csp/View/Reports/HtmlView.php
@@ -150,24 +150,4 @@ class HtmlView extends BaseHtmlView
 
 		ToolbarHelper::help('JHELP_COMPONENTS_CSP_REPORTS');
 	}
-
-	/**
-	 * Returns an array of fields the table can be sorted by
-	 *
-	 * @return  array  Array containing the field name to sort by as the key and display text as value
-	 *
-	 * @since   4.0.0
-	 */
-	protected function getSortFields()
-	{
-		return [
-			'a.state'        => Text::_('JSTATUS'),
-			'a.blocked_uri'  => Text::_('COM_CSP_HEADING_BLOCKED_URI'),
-			'a.document_uri' => Text::_('COM_CSP_HEADING_DOCUMENT_URI'),
-			'a.directive'    => Text::_('COM_CSP_HEADING_DIRECTIVE'),
-			'a.client'       => Text::_('JCLIENT'),
-			'a.id'           => Text::_('JGRID_HEADING_ID'),
-			'a.created'      => Text::_('COM_CSP_HEADING_CREATED'),
-		];
-	}
 }

--- a/administrator/components/com_newsfeeds/View/Newsfeeds/HtmlView.php
+++ b/administrator/components/com_newsfeeds/View/Newsfeeds/HtmlView.php
@@ -182,26 +182,4 @@ class HtmlView extends BaseHtmlView
 
 		$toolbar->help('JHELP_COMPONENTS_NEWSFEEDS_FEEDS');
 	}
-
-	/**
-	 * Returns an array of fields the table can be sorted by
-	 *
-	 * @return  array  Array containing the field name to sort by as the key and display text as value
-	 *
-	 * @since   3.0
-	 */
-	protected function getSortFields()
-	{
-		return array(
-			'a.ordering'     => Text::_('JGRID_HEADING_ORDERING'),
-			'a.published'    => Text::_('JSTATUS'),
-			'a.name'         => Text::_('JGLOBAL_TITLE'),
-			'category_title' => Text::_('JCATEGORY'),
-			'a.access'       => Text::_('JGRID_HEADING_ACCESS'),
-			'numarticles'    => Text::_('COM_NEWSFEEDS_NUM_ARTICLES_HEADING'),
-			'a.cache_time'   => Text::_('COM_NEWSFEEDS_CACHE_TIME_HEADING'),
-			'a.language'     => Text::_('JGRID_HEADING_LANGUAGE'),
-			'a.id'           => Text::_('JGRID_HEADING_ID')
-		);
-	}
 }

--- a/administrator/components/com_plugins/View/Plugins/HtmlView.php
+++ b/administrator/components/com_plugins/View/Plugins/HtmlView.php
@@ -128,24 +128,4 @@ class HtmlView extends BaseHtmlView
 		$toolbar->help('JHELP_EXTENSIONS_PLUGIN_MANAGER');
 
 	}
-
-	/**
-	 * Returns an array of fields the table can be sorted by.
-	 *
-	 * @return  array  Array containing the field name to sort by as the key and display text as value.
-	 *
-	 * @since   3.0
-	 */
-	protected function getSortFields()
-	{
-		return array(
-			'ordering'     => Text::_('JGRID_HEADING_ORDERING'),
-			'enabled'      => Text::_('JSTATUS'),
-			'name'         => Text::_('JGLOBAL_TITLE'),
-			'folder'       => Text::_('COM_PLUGINS_FOLDER_HEADING'),
-			'element'      => Text::_('COM_PLUGINS_ELEMENT_HEADING'),
-			'access'       => Text::_('JGRID_HEADING_ACCESS'),
-			'extension_id' => Text::_('JGRID_HEADING_ID'),
-		);
-	}
 }

--- a/administrator/components/com_tags/View/Tags/HtmlView.php
+++ b/administrator/components/com_tags/View/Tags/HtmlView.php
@@ -182,23 +182,4 @@ class HtmlView extends BaseHtmlView
 
 		$toolbar->help('JHELP_COMPONENTS_TAGS_MANAGER');
 	}
-
-	/**
-	 * Returns an array of fields the table can be sorted by
-	 *
-	 * @return  array  Array containing the field name to sort by as the key and display text as value
-	 *
-	 * @since   3.0
-	 */
-	protected function getSortFields()
-	{
-		return array(
-			'a.lft'      => Text::_('JGRID_HEADING_ORDERING'),
-			'a.state'    => Text::_('JSTATUS'),
-			'a.title'    => Text::_('JGLOBAL_TITLE'),
-			'a.access'   => Text::_('JGRID_HEADING_ACCESS'),
-			'a.language' => Text::_('JGRID_HEADING_LANGUAGE'),
-			'a.id'       => Text::_('JGRID_HEADING_ID')
-		);
-	}
 }


### PR DESCRIPTION
### Summary of Changes
List Views have a method getSortFields().
This Method is not used in the core. The names of the table headers are in the respective tables as language keys.
Testing Instructions for com_banners, Com_plugnis, com_csp, com_newsfeeds


### Testing Instructions
Code Inspect. Testing this can only be playing around with table headers in list views.
Are all texts displayed corretly, does sorting work as before? Also with open search tools?

### Expected result
Everything works as before



