### PR TITLE
[4.0] Remove getSortFields from content views

### DIFF
--- a/administrator/components/com_content/View/Articles/HtmlView.php
+++ b/administrator/components/com_content/View/Articles/HtmlView.php
@@ -260,27 +260,4 @@ class HtmlView extends BaseHtmlView
 
 		$toolbar->help('JHELP_CONTENT_ARTICLE_MANAGER');
 	}
-
-	/**
-	 * Returns an array of fields the table can be sorted by
-	 *
-	 * @return  array  Array containing the field name to sort by as the key and display text as value
-	 *
-	 * @since   3.0
-	 */
-	protected function getSortFields()
-	{
-		return array(
-			'a.ordering'     => Text::_('JGRID_HEADING_ORDERING'),
-			'a.state'        => Text::_('JSTATUS'),
-			'a.title'        => Text::_('JGLOBAL_TITLE'),
-			'category_title' => Text::_('JCATEGORY'),
-			'access_level'   => Text::_('JGRID_HEADING_ACCESS'),
-			'a.created_by'   => Text::_('JAUTHOR'),
-			'language'       => Text::_('JGRID_HEADING_LANGUAGE'),
-			'a.created'      => Text::_('JDATE'),
-			'a.id'           => Text::_('JGRID_HEADING_ID'),
-			'a.featured'     => Text::_('JFEATURED')
-		);
-	}
 }

--- a/administrator/components/com_content/View/Featured/HtmlView.php
+++ b/administrator/components/com_content/View/Featured/HtmlView.php
@@ -223,26 +223,4 @@ class HtmlView extends BaseHtmlView
 
 		ToolbarHelper::help('JHELP_CONTENT_FEATURED_ARTICLES');
 	}
-
-	/**
-	 * Returns an array of fields the table can be sorted by
-	 *
-	 * @return  array  Array containing the field name to sort by as the key and display text as value
-	 *
-	 * @since   3.0
-	 */
-	protected function getSortFields()
-	{
-		return array(
-			'fp.ordering'    => Text::_('JGRID_HEADING_ORDERING'),
-			'a.state'        => Text::_('JSTATUS'),
-			'a.title'        => Text::_('JGLOBAL_TITLE'),
-			'category_title' => Text::_('JCATEGORY'),
-			'access_level'   => Text::_('JGRID_HEADING_ACCESS'),
-			'a.created_by'   => Text::_('JAUTHOR'),
-			'language'       => Text::_('JGRID_HEADING_LANGUAGE'),
-			'a.created'      => Text::_('JDATE'),
-			'a.id'           => Text::_('JGRID_HEADING_ID'),
-		);
-	}
 }

--- a/administrator/components/com_workflow/View/Stages/HtmlView.php
+++ b/administrator/components/com_workflow/View/Stages/HtmlView.php
@@ -210,20 +210,4 @@ class HtmlView extends BaseHtmlView
 
 		$toolbar->help('JHELP_WORKFLOW_STAGES_LIST');
 	}
-
-	/**
-	 * Returns an array of fields the table can be sorted by
-	 *
-	 * @return  array  Array containing the field name to sort by as the key and display text as value
-	 *
-	 * @since  4.0.0
-	 */
-	protected function getSortFields()
-	{
-		return array(
-			'a.published' => Text::_('JSTATUS'),
-			'a.title'     => Text::_('JGLOBAL_TITLE'),
-			'a.id'        => Text::_('JGRID_HEADING_ID'),
-		);
-	}
 }

--- a/administrator/components/com_workflow/View/Workflows/HtmlView.php
+++ b/administrator/components/com_workflow/View/Workflows/HtmlView.php
@@ -172,20 +172,4 @@ class HtmlView extends BaseHtmlView
 
 		$toolbar->help('JHELP_WORKFLOWS_LIST');
 	}
-
-	/**
-	 * Returns an array of fields the table can be sorted by
-	 *
-	 * @return  array  Array containing the field name to sort by as the key and display text as value
-	 *
-	 * @since  4.0.0
-	 */
-	protected function getSortFields()
-	{
-		return array(
-			'a.published' => Text::_('JSTATUS'),
-			'a.title'     => Text::_('JGLOBAL_TITLE'),
-			'a.id'        => Text::_('JGRID_HEADING_ID'),
-		);
-	}
 }


### PR DESCRIPTION
### Summary of Changes
List Views have a method getSortFields() - here in com_content.
This Method is not used in the core. The names of the table headers are in the respective tables as language keys.

### Testing Instructions
Code Inspect. Testing this can only be playing around with table headers in list views.
Are all texts displayed corretly, does sorting work as before? Also with open search tools?

### Expected result
Everything works as before

### Note
There are several similiar PRs, hopefully reducin the risk of conflicts
