### PR TITLE
[4.0] Remove getsortfields from views of com_fields, categories, languages

### DIFF
--- a/administrator/components/com_categories/View/Categories/HtmlView.php
+++ b/administrator/components/com_categories/View/Categories/HtmlView.php
@@ -272,23 +272,4 @@ class HtmlView extends BaseHtmlView
 
 		$toolbar->help($ref_key, ComponentHelper::getParams($component)->exists('helpURL'), $url);
 	}
-
-	/**
-	 * Returns an array of fields the table can be sorted by
-	 *
-	 * @return  array  Array containing the field name to sort by as the key and display text as value
-	 *
-	 * @since   3.0
-	 */
-	protected function getSortFields()
-	{
-		return array(
-			'a.lft'       => Text::_('JGRID_HEADING_ORDERING'),
-			'a.published' => Text::_('JSTATUS'),
-			'a.title'     => Text::_('JGLOBAL_TITLE'),
-			'a.access'    => Text::_('JGRID_HEADING_ACCESS'),
-			'language'    => Text::_('JGRID_HEADING_LANGUAGE'),
-			'a.id'        => Text::_('JGRID_HEADING_ID'),
-		);
-	}
 }

--- a/administrator/components/com_fields/View/Fields/HtmlView.php
+++ b/administrator/components/com_fields/View/Fields/HtmlView.php
@@ -203,24 +203,4 @@ class HtmlView extends BaseHtmlView
 
 		$toolbar->help('JHELP_COMPONENTS_FIELDS_FIELDS');
 	}
-
-	/**
-	 * Returns the sort fields.
-	 *
-	 * @return  array
-	 *
-	 * @since   3.7.0
-	 */
-	protected function getSortFields()
-	{
-		return array(
-			'a.ordering' => Text::_('JGRID_HEADING_ORDERING'),
-			'a.state'    => Text::_('JSTATUS'),
-			'a.title'    => Text::_('JGLOBAL_TITLE'),
-			'a.type'     => Text::_('COM_FIELDS_FIELD_TYPE_LABEL'),
-			'a.access'   => Text::_('JGRID_HEADING_ACCESS'),
-			'a.language' => Text::_('JGRID_HEADING_LANGUAGE'),
-			'a.id'       => Text::_('JGRID_HEADING_ID'),
-		);
-	}
 }

--- a/administrator/components/com_fields/View/Groups/HtmlView.php
+++ b/administrator/components/com_fields/View/Groups/HtmlView.php
@@ -208,24 +208,4 @@ class HtmlView extends BaseHtmlView
 
 		$toolbar->help('JHELP_COMPONENTS_FIELDS_FIELD_GROUPS');
 	}
-
-	/**
-	 * Returns the sort fields.
-	 *
-	 * @return  array
-	 *
-	 * @since   3.7.0
-	 */
-	protected function getSortFields()
-	{
-		return array(
-			'a.ordering'  => Text::_('JGRID_HEADING_ORDERING'),
-			'a.state'     => Text::_('JSTATUS'),
-			'a.title'     => Text::_('JGLOBAL_TITLE'),
-			'a.access'    => Text::_('JGRID_HEADING_ACCESS'),
-			'language'    => Text::_('JGRID_HEADING_LANGUAGE'),
-			'a.context'   => Text::_('JGRID_HEADING_CONTEXT'),
-			'a.id'        => Text::_('JGRID_HEADING_ID'),
-		);
-	}
 }

--- a/administrator/components/com_languages/View/Languages/HtmlView.php
+++ b/administrator/components/com_languages/View/Languages/HtmlView.php
@@ -151,26 +151,4 @@ class HtmlView extends BaseHtmlView
 
 		ToolbarHelper::help('JHELP_EXTENSIONS_LANGUAGE_MANAGER_CONTENT');
 	}
-
-	/**
-	 * Returns an array of fields the table can be sorted by.
-	 *
-	 * @return  array  Array containing the field name to sort by as the key and display text as value.
-	 *
-	 * @since   3.0
-	 */
-	protected function getSortFields()
-	{
-		return array(
-			'a.ordering'     => Text::_('JGRID_HEADING_ORDERING'),
-			'a.published'    => Text::_('JSTATUS'),
-			'a.title'        => Text::_('JGLOBAL_TITLE'),
-			'a.title_native' => Text::_('COM_LANGUAGES_HEADING_TITLE_NATIVE'),
-			'a.lang_code'    => Text::_('COM_LANGUAGES_FIELD_LANG_TAG_LABEL'),
-			'a.sef'          => Text::_('COM_LANGUAGES_FIELD_LANG_CODE_LABEL'),
-			'a.image'        => Text::_('COM_LANGUAGES_HEADING_LANG_IMAGE'),
-			'a.access'       => Text::_('JGRID_HEADING_ACCESS'),
-			'a.lang_id'      => Text::_('JGRID_HEADING_ID')
-		);
-	}
 }


### PR DESCRIPTION
### Summary of Changes
List Views have a method getSortFields(), here multiple used views: com_fields,com_categories.
This Method is not used in the core. The names of the table headers are in the respective tables as language keys.

### Testing Instructions
Code Inspect. Testing this can only be playing around with table headers in list views.
Are all texts displayed corretly, does sorting work as before? Also with open search tools?

### Expected result
Everything works as before

### Note
There are several similiar PRs, hopefully reducin the risk of conflicts
