### PR TITLE
[4.0] [DRAFT] Convert icon-new to fa-plus

### DIFF
--- a/administrator/components/com_categories/Field/Modal/CategoryField.php
+++ b/administrator/components/com_categories/Field/Modal/CategoryField.php
@@ -173,7 +173,7 @@ class CategoryField extends FormField
 				. ' data-toggle="modal"'
 				. ' type="button"'
 				. ' data-target="#ModalNew' . $modalId . '">'
-				. '<span class="icon-new" aria-hidden="true"></span> ' . Text::_('JACTION_CREATE')
+				. '<span class="fas fa-plus" aria-hidden="true"></span> ' . Text::_('JACTION_CREATE')
 				. '</button>';
 		}
 

--- a/administrator/components/com_contact/Field/Modal/ContactField.php
+++ b/administrator/components/com_contact/Field/Modal/ContactField.php
@@ -162,7 +162,7 @@ class ContactField extends FormField
 				. ' data-toggle="modal"'
 				. ' type="button"'
 				. ' data-target="#ModalNew' . $modalId . '">'
-				. '<span class="icon-new" aria-hidden="true"></span> ' . Text::_('JACTION_CREATE')
+				. '<span class="fas fa-plus" aria-hidden="true"></span> ' . Text::_('JACTION_CREATE')
 				. '</button>';
 		}
 

--- a/administrator/components/com_content/Field/Modal/ArticleField.php
+++ b/administrator/components/com_content/Field/Modal/ArticleField.php
@@ -163,7 +163,7 @@ class ArticleField extends FormField
 				. ' data-toggle="modal"'
 				. ' type="button"'
 				. ' data-target="#ModalNew' . $modalId . '">'
-				. '<span class="icon-new" aria-hidden="true"></span> ' . Text::_('JACTION_CREATE')
+				. '<span class="fas fa-plus" aria-hidden="true"></span> ' . Text::_('JACTION_CREATE')
 				. '</button>';
 		}
 

--- a/administrator/components/com_menus/Field/Modal/MenuField.php
+++ b/administrator/components/com_menus/Field/Modal/MenuField.php
@@ -295,7 +295,7 @@ class MenuField extends FormField
 				. ' data-toggle="modal"'
 				. ' type="button"'
 				. ' data-target="#ModalNew' . $modalId . '">'
-				. '<span class="icon-new" aria-hidden="true"></span> ' . Text::_('JACTION_CREATE')
+				. '<span class="fas fa-plus" aria-hidden="true"></span> ' . Text::_('JACTION_CREATE')
 				. '</button>';
 		}
 

--- a/administrator/components/com_newsfeeds/Field/Modal/NewsfeedField.php
+++ b/administrator/components/com_newsfeeds/Field/Modal/NewsfeedField.php
@@ -164,7 +164,7 @@ class NewsfeedField extends FormField
 				. ' data-toggle="modal"'
 				. ' type="button"'
 				. ' data-target="#ModalNew' . $modalId . '">'
-				. '<span class="icon-new" aria-hidden="true"></span> ' . Text::_('JACTION_CREATE')
+				. '<span class="fas fa-plus" aria-hidden="true"></span> ' . Text::_('JACTION_CREATE')
 				. '</button>';
 		}
 

--- a/templates/cassiopeia/scss/blocks/_header.scss
+++ b/templates/cassiopeia/scss/blocks/_header.scss
@@ -117,7 +117,7 @@
     cursor: default;
     border: 1px solid $white-offset;
 
-    .fa {
+    .fa, .fas, .far, .fab {
       font-size: 24px;
     }
   }


### PR DESCRIPTION
Pull Request for Issue #27333 

### Summary of Changes
change icon-new 
![image](https://user-images.githubusercontent.com/1850089/73229224-9e6ddf80-413e-11ea-8f6f-d5c3b7e1f32b.png)
to fa-plus 
![image](https://user-images.githubusercontent.com/1850089/73229239-a9287480-413e-11ea-8d1d-fd08eae23890.png)
to be consistent with using fontawesome 5 classes.


### Testing Instructions
apply pr verify that icons have changed properly and none are missing.


### Expected result
icons become 
![image](https://user-images.githubusercontent.com/1850089/73229285-d2490500-413e-11ea-9695-d9a153d81f41.png)


### Actual result



### Documentation Changes Required

none