### PR TITLE
[4.0] com_finder accessibility

### DIFF
--- a/components/com_finder/tmpl/search/default_form.php
+++ b/components/com_finder/tmpl/search/default_form.php
@@ -51,7 +51,7 @@ if ($this->params->get('show_autosuggest', 1))
 					</button>
 				<?php endif; ?>
 				<?php if ($this->params->get('show_advanced', 1)) : ?>
-					<a href="#advancedSearch" data-toggle="collapse" class="btn btn-secondary" aria-hidden="true">
+					<a href="#advancedSearch" data-toggle="collapse" class="btn btn-secondary">
 						<span class="fa fa-search-plus" aria-hidden="true"></span>
 						<?php echo Text::_('COM_FINDER_ADVANCED_SEARCH_TOGGLE'); ?></a>
 				<?php endif; ?>


### PR DESCRIPTION
The front end component for com_finder aka smart search has an incorrect attribute on the advanced search button. aria-hidden should not be here as it is making a focusable element invisible which is obviously not correct

> Using the aria-hidden="true" attribute on an element removes the element and ALL of its child nodes from the accessibility API making it completely inaccessible to screen readers and other assistive technologies. Aria-hidden may be used with extreme caution to hide visibly rendered content from assistive technologies only if the act of hiding this content is intended to improve the experience for users of assistive technologies by removing redundant or extraneous content. If aria-hidden is used to hide visible content from screen readers, the identical or equivalent meaning and functionality must be exposed to assistive technologies.


testing by code review