### PR TITLE
[4.0] Set data directly into state rather than faking a proxy into the input

### DIFF
--- a/api/components/com_categories/Controller/CategoriesController.php
+++ b/api/components/com_categories/Controller/CategoriesController.php
@@ -47,7 +47,7 @@ class CategoriesController extends ApiController
 	 */
 	public function displayItem($id = null)
 	{
-		$this->input->set('model_state', ['filter.extension' => $this->getExtensionFromInput()]);
+		$this->modelState->set('filter.extension', $this->getExtensionFromInput());
 
 		return parent::displayItem($id);
 	}
@@ -60,7 +60,7 @@ class CategoriesController extends ApiController
 	 */
 	public function displayList()
 	{
-		$this->input->set('model_state', ['filter.extension' => $this->getExtensionFromInput()]);
+		$this->modelState->set('filter.extension', $this->getExtensionFromInput());
 
 		return parent::displayList();
 	}

--- a/api/components/com_contenthistory/Controller/HistoryController.php
+++ b/api/components/com_contenthistory/Controller/HistoryController.php
@@ -48,14 +48,11 @@ class HistoryController extends ApiController
 	 */
 	public function displayList()
 	{
-		$this->input->set('model_state', [
-				'type_alias'     => $this->getTypeAliasFromInput(),
-				'type_id'        => $this->getTypeIdFromInput(),
-				'item_id'        => $this->getItemIdFromInput(),
-				'list.ordering'  => 'h.save_date',
-				'list.direction' => 'DESC',
-			]
-		);
+		$this->modelState->set('type_alias', $this->getTypeAliasFromInput());
+		$this->modelState->set('type_id', $this->getTypeIdFromInput());
+		$this->modelState->set('item_id', $this->getItemIdFromInput());
+		$this->modelState->set('list.ordering', 'h.save_date');
+		$this->modelState->set('list.direction', 'DESC');
 
 		return parent::displayList();
 	}

--- a/api/components/com_fields/Controller/FieldsController.php
+++ b/api/components/com_fields/Controller/FieldsController.php
@@ -47,7 +47,7 @@ class FieldsController extends ApiController
 	 */
 	public function displayItem($id = null)
 	{
-		$this->input->set('model_state', ['filter.context' => $this->getContextFromInput()]);
+		$this->modelState->set('filter.context', $this->getContextFromInput());
 
 		return parent::displayItem($id);
 	}
@@ -61,7 +61,7 @@ class FieldsController extends ApiController
 	 */
 	public function displayList()
 	{
-		$this->input->set('model_state', ['filter.context' => $this->getContextFromInput()]);
+		$this->modelState->set('filter.context', $this->getContextFromInput());
 
 		return parent::displayList();
 	}

--- a/api/components/com_fields/Controller/GroupsController.php
+++ b/api/components/com_fields/Controller/GroupsController.php
@@ -47,7 +47,7 @@ class GroupsController extends ApiController
 	 */
 	public function displayItem($id = null)
 	{
-		$this->input->set('model_state', ['filter.context' => $this->getContextFromInput()]);
+		$this->modelState->set('filter.context', $this->getContextFromInput());
 
 		return parent::displayItem($id);
 	}
@@ -61,7 +61,7 @@ class GroupsController extends ApiController
 	 */
 	public function displayList()
 	{
-		$this->input->set('model_state', ['filter.context' => $this->getContextFromInput()]);
+		$this->modelState->set('filter.context', $this->getContextFromInput());
 
 		return parent::displayList();
 	}

--- a/api/components/com_languages/Controller/OverridesController.php
+++ b/api/components/com_languages/Controller/OverridesController.php
@@ -52,11 +52,8 @@ class OverridesController extends ApiController
 	 */
 	public function displayItem($id = null)
 	{
-		$this->input->set('model_state', [
-				'filter.language' => $this->getLanguageFromInput(),
-				'filter.client'   => $this->getClientFromInput(),
-			]
-		);
+		$this->modelState->set('filter.language', $this->getLanguageFromInput());
+		$this->modelState->set('filter.client', $this->getClientFromInput());
 
 		return parent::displayItem($id);
 	}
@@ -70,11 +67,8 @@ class OverridesController extends ApiController
 	 */
 	public function displayList()
 	{
-		$this->input->set('model_state', [
-				'filter.language' => $this->getLanguageFromInput(),
-				'filter.client'   => $this->getClientFromInput(),
-			]
-		);
+		$this->modelState->set('filter.language', $this->getLanguageFromInput());
+		$this->modelState->set('filter.client', $this->getClientFromInput());
 
 		return parent::displayList();
 	}
@@ -168,11 +162,8 @@ class OverridesController extends ApiController
 
 		$this->input->set('model', $this->contentType);
 
-		$this->input->set('model_state', [
-				'filter.language' => $this->getLanguageFromInput(),
-				'filter.client'   => $this->getClientFromInput(),
-			]
-		);
+		$this->modelState->set('filter.language', $this->getLanguageFromInput());
+		$this->modelState->set('filter.client', $this->getClientFromInput());
 
 		parent::delete($id);
 	}

--- a/api/components/com_menus/Controller/ItemsController.php
+++ b/api/components/com_menus/Controller/ItemsController.php
@@ -51,7 +51,7 @@ class ItemsController extends ApiController
 	 */
 	public function displayItem($id = null)
 	{
-		$this->input->set('model_state', ['filter.client_id' => $this->getClientIdFromInput()]);
+		$this->modelState->set('filter.client_id', $this->getClientIdFromInput());
 
 		return parent::displayItem($id);
 	}
@@ -65,7 +65,7 @@ class ItemsController extends ApiController
 	 */
 	public function displayList()
 	{
-		$this->input->set('model_state', ['filter.client_id' => $this->getClientIdFromInput()]);
+		$this->modelState->set('filter.client_id', $this->getClientIdFromInput());
 
 		return parent::displayList();
 	}

--- a/api/components/com_menus/Controller/MenusController.php
+++ b/api/components/com_menus/Controller/MenusController.php
@@ -47,7 +47,7 @@ class MenusController extends ApiController
 	 */
 	public function displayItem($id = null)
 	{
-		$this->input->set('model_state', ['client_id' => $this->getClientIdFromInput()]);
+		$this->modelState->set('filter.client_id', $this->getClientIdFromInput());
 
 		return parent::displayItem($id);
 	}
@@ -61,7 +61,7 @@ class MenusController extends ApiController
 	 */
 	public function displayList()
 	{
-		$this->input->set('model_state', ['client_id' => $this->getClientIdFromInput()]);
+		$this->modelState->set('filter.client_id', $this->getClientIdFromInput());
 
 		return parent::displayList();
 	}

--- a/api/components/com_modules/Controller/ModulesController.php
+++ b/api/components/com_modules/Controller/ModulesController.php
@@ -50,7 +50,7 @@ class ModulesController extends ApiController
 	 */
 	public function displayItem($id = null)
 	{
-		$this->input->set('model_state', ['client_id' => $this->getClientIdFromInput()]);
+		$this->modelState->set('filter.client_id', $this->getClientIdFromInput());
 
 		return parent::displayItem($id);
 	}
@@ -64,7 +64,7 @@ class ModulesController extends ApiController
 	 */
 	public function displayList()
 	{
-		$this->input->set('model_state', ['client_id' => $this->getClientIdFromInput()]);
+		$this->modelState->set('filter.client_id', $this->getClientIdFromInput());
 
 		return parent::displayList();
 	}

--- a/api/components/com_templates/Controller/StylesController.php
+++ b/api/components/com_templates/Controller/StylesController.php
@@ -47,7 +47,7 @@ class StylesController extends ApiController
 	 */
 	public function displayItem($id = null)
 	{
-		$this->input->set('model_state', ['client_id' => $this->getClientIdFromInput()]);
+		$this->modelState->set('client_id', $this->getClientIdFromInput());
 
 		return parent::displayItem($id);
 	}
@@ -61,7 +61,7 @@ class StylesController extends ApiController
 	 */
 	public function displayList()
 	{
-		$this->input->set('model_state', ['client_id' => $this->getClientIdFromInput()]);
+		$this->modelState->set('client_id', $this->getClientIdFromInput());
 
 		return parent::displayList();
 	}

--- a/libraries/src/MVC/Controller/ApiController.php
+++ b/libraries/src/MVC/Controller/ApiController.php
@@ -18,6 +18,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Factory\MvcFactoryInterface;
 use Joomla\CMS\MVC\Model\ListModel;
 use Joomla\CMS\MVC\View\JsonApiView;
+use Joomla\CMS\Object\CMSObject;
 use Joomla\Input\Input;
 use Joomla\String\Inflector;
 use Tobscure\JsonApi\Exception\InvalidParameterException;
@@ -72,6 +73,13 @@ class ApiController extends BaseController
 	protected $itemsPerPage = 20;
 
 	/**
+	 * The model state to inject
+	 *
+	 * @var  CMSObject
+	 */
+	protected $modelState;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param   array                $config   An optional associative array of configuration settings.
@@ -86,6 +94,8 @@ class ApiController extends BaseController
 	 */
 	public function __construct($config = array(), MvcFactoryInterface $factory = null, $app = null, $input = null)
 	{
+		$this->modelState = new CMSObject;
+
 		parent::__construct($config, $factory, $app, $input);
 
 		// Guess the option as com_NameOfController
@@ -151,21 +161,12 @@ class ApiController extends BaseController
 
 		$modelName = $this->input->get('model', Inflector::singularize($this->contentType));
 
-		// Create the model, ignoring request data so we can safely set the state in the request, without it being
-		// reinitialised on the first getState call
-		$model = $this->getModel($modelName, '', ['ignore_request' => true]);
+		// Create the model, ignoring request data so we can safely set the state in the request from the controller
+		$model = $this->getModel($modelName, '', ['ignore_request' => true, 'state' => $this->modelState]);
 
 		if (!$model)
 		{
 			throw new \RuntimeException(Text::_('JLIB_APPLICATION_ERROR_MODEL_CREATE'));
-		}
-
-		if ($modelState = $this->input->get('model_state', false, 'array'))
-		{
-			foreach ($modelState as $property => $value)
-			{
-				$model->setState($property, $value);
-			}
 		}
 
 		try
@@ -199,19 +200,16 @@ class ApiController extends BaseController
 	{
 		// Assemble pagination information (using recommended JsonApi pagination notation for offset strategy)
 		$paginationInfo = $this->input->get('page', [], 'array');
-		$internalPaginationMapping = [];
 
 		if (\array_key_exists('offset', $paginationInfo))
 		{
-			$this->input->set('limitstart', $paginationInfo['offset']);
+			$this->modelState->set($this->context . '.limitstart', $paginationInfo['offset']);
 		}
 
 		if (\array_key_exists('limit', $paginationInfo))
 		{
-			$internalPaginationMapping['limit'] = $paginationInfo['limit'];
+			$this->modelState->set($this->context . '.list.limit', $paginationInfo['limit']);
 		}
-
-		$this->input->set('list', $internalPaginationMapping);
 
 		$viewType   = $this->app->getDocument()->getType();
 		$viewName   = $this->input->get('view', $this->default_view);
@@ -235,19 +233,11 @@ class ApiController extends BaseController
 		$modelName = $this->input->get('model', $this->contentType);
 
 		/** @var ListModel $model */
-		$model = $this->getModel($modelName, '', ['ignore_request' => true]);
+		$model = $this->getModel($modelName, '', ['ignore_request' => true, 'state' => $this->modelState]);
 
 		if (!$model)
 		{
 			throw new \RuntimeException(Text::_('JLIB_APPLICATION_ERROR_MODEL_CREATE'));
-		}
-
-		if ($modelState = $this->input->get('model_state', false, 'array'))
-		{
-			foreach ($modelState as $property => $value)
-			{
-				$model->setState($property, $value);
-			}
 		}
 
 		// Push the model into the view (as default)
@@ -303,14 +293,6 @@ class ApiController extends BaseController
 		if (!$model)
 		{
 			throw new \RuntimeException(Text::_('JLIB_APPLICATION_ERROR_MODEL_CREATE'));
-		}
-
-		if ($modelState = $this->input->get('model_state', false, 'array'))
-		{
-			foreach ($modelState as $property => $value)
-			{
-				$model->setState($property, $value);
-			}
 		}
 
 		// Remove the item.


### PR DESCRIPTION
### Summary of Changes
I missed in the GSOC project we'd started to store state fullblown in the input object which is obviously wrong. This changes it so we do webservices properly and build a state object to pass into the model. This is a moderate security fix to the unreleased webservices because potentially with this you can inject arbitrary state into the model directly from query parameters which is obviously bad.

### Testing Instructions
Affected webservices (e.g. categories) continue to function with no changes from before.

### Documentation Changes Required
Yes when webservices are documented
