### PR TITLE
toggler burger correction and overlapping correction.

### DIFF
--- a/administrator/templates/atum/scss/blocks/_sidebar.scss
+++ b/administrator/templates/atum/scss/blocks/_sidebar.scss
@@ -517,11 +517,6 @@
     right: 10px;
     z-index: $zindex-mobile-toggle;
 
-    [dir=rtl] & {
-      right: auto;
-      left: 10px;
-    }
-
     .navbar-toggler-icon {
       color: var(--toggle-color);
 
@@ -532,7 +527,7 @@
       }
     }
 
-    &.mm-collapsed {
+    &.collapsed {
       .navbar-toggler-icon::before {
         content: "\f0c9";
       }

--- a/administrator/templates/atum/scss/blocks/_sidebar.scss
+++ b/administrator/templates/atum/scss/blocks/_sidebar.scss
@@ -517,6 +517,11 @@
     right: 10px;
     z-index: $zindex-mobile-toggle;
 
+    [dir=rtl] & {
+      right: auto;
+      left: 10px;
+    } 
+    
     .navbar-toggler-icon {
       color: var(--toggle-color);
 

--- a/administrator/templates/atum/scss/blocks/_toolbar.scss
+++ b/administrator/templates/atum/scss/blocks/_toolbar.scss
@@ -439,7 +439,7 @@ joomla-toolbar-button {
 
 @include media-breakpoint-down(xs) {
   .toggler-toolbar {
-    top: 20px;
+    top: 60px;
 
     .toggler-toolbar-icon::before {
       font: normal normal normal 30px/1 'Font Awesome 5 Free';


### PR DESCRIPTION
Pull Request for Issue #27699

### Summary of Changes
Fixed CSS issue as shown in.
### Testing Instructions
open alert it can be closed easily
navbar icon show both cross and hamburger icon at respective time.

### Problem statement
![Screenshot (29)](https://user-images.githubusercontent.com/44205807/73349790-d6e1fa80-42b1-11ea-9679-c566bdad2082.png)
![Screenshot (30)](https://user-images.githubusercontent.com/44205807/73349810-dfd2cc00-42b1-11ea-90fc-c921281b3489.png)
### Expected result
![Screenshot (31)](https://user-images.githubusercontent.com/44205807/73349827-e82b0700-42b1-11ea-8fa7-f7e43502472a.png)

### Actual result
Same as Expected result.


### Documentation Changes Required

no change required.