### PR TITLE
[4.0] Move columns out of list.select default value

### DIFF
--- a/administrator/components/com_banners/Model/BannersModel.php
+++ b/administrator/components/com_banners/Model/BannersModel.php
@@ -125,6 +125,11 @@ class BannersModel extends ListModel
 					$db->quoteName('a.language'),
 					$db->quoteName('a.publish_up'),
 					$db->quoteName('a.publish_down'),
+				]
+			)
+		)
+			->select(
+				[
 					$db->quoteName('l.title', 'language_title'),
 					$db->quoteName('l.image', 'language_image'),
 					$db->quoteName('uc.name', 'editor'),
@@ -133,7 +138,6 @@ class BannersModel extends ListModel
 					$db->quoteName('cl.purchase_type', 'client_purchase_type'),
 				]
 			)
-		)
 			->from($db->quoteName('#__banners', 'a'))
 			->join('LEFT', $db->quoteName('#__languages', 'l'), $db->quoteName('l.lang_code') . ' = ' . $db->quoteName('a.language'))
 			->join('LEFT', $db->quoteName('#__users', 'uc'), $db->quoteName('uc.id') . ' = ' . $db->quoteName('a.checked_out'))

--- a/administrator/components/com_banners/Model/ClientsModel.php
+++ b/administrator/components/com_banners/Model/ClientsModel.php
@@ -116,11 +116,15 @@ class ClientsModel extends ListModel
 					$db->quoteName('a.state'),
 					$db->quoteName('a.metakey'),
 					$db->quoteName('a.purchase_type'),
+				]
+			)
+		)
+			->select(
+				[
 					'COUNT(' . $db->quoteName('b.id') . ') AS ' . $db->quoteName('nbanners'),
 					$db->quoteName('uc.name', 'editor'),
 				]
-			)
-		);
+			);
 
 		$query->from($db->quoteName('#__banner_clients', 'a'));
 

--- a/administrator/components/com_languages/Model/LanguagesModel.php
+++ b/administrator/components/com_languages/Model/LanguagesModel.php
@@ -117,11 +117,15 @@ class LanguagesModel extends ListModel
 			$this->getState('list.select',
 				[
 					$db->quoteName('a') . '.*',
+				]
+			)
+		)
+			->select(
+				[
 					$db->quoteName('l.home'),
 					$db->quoteName('ag.title', 'access_level'),
 				]
 			)
-		)
 			->from($db->quoteName('#__languages', 'a'))
 			->join('LEFT', $db->quoteName('#__viewlevels', 'ag'), $db->quoteName('ag.id') . ' = ' . $db->quoteName('a.access'))
 			->join(

--- a/administrator/components/com_menus/Model/ItemsModel.php
+++ b/administrator/components/com_menus/Model/ItemsModel.php
@@ -286,6 +286,11 @@ class ItemsModel extends ListModel
 					$db->quoteName('a.client_id'),
 					$db->quoteName('a.publish_up'),
 					$db->quoteName('a.publish_down'),
+				]
+			)
+		)
+			->select(
+				[
 					$db->quoteName('l.title', 'language_title'),
 					$db->quoteName('l.image', 'language_image'),
 					$db->quoteName('l.sef', 'language_sef'),
@@ -296,13 +301,10 @@ class ItemsModel extends ListModel
 					$db->quoteName('mt.title', 'menutype_title'),
 					$db->quoteName('e.enabled'),
 					$db->quoteName('e.name'),
+					'CASE WHEN ' . $db->quoteName('a.type') . ' = ' . $db->quote('component')
+					. ' THEN ' . $db->quoteName('a.published') . ' +2 * (' . $db->quoteName('e.enabled') . ' -1)'
+					. ' ELSE ' . $db->quoteName('a.published') . ' END AS ' . $db->quoteName('published'),
 				]
-			)
-		)
-			->select(
-				'CASE WHEN ' . $db->quoteName('a.type') . ' = ' . $db->quote('component')
-				. ' THEN ' . $db->quoteName('a.published') . ' +2 * (' . $db->quoteName('e.enabled') . ' -1)'
-				. ' ELSE ' . $db->quoteName('a.published') . ' END AS ' . $db->quoteName('published')
 			)
 			->from($db->quoteName('#__menu', 'a'));
 

--- a/administrator/components/com_newsfeeds/Model/NewsfeedsModel.php
+++ b/administrator/components/com_newsfeeds/Model/NewsfeedsModel.php
@@ -171,6 +171,11 @@ class NewsfeedsModel extends ListModel
 					$db->quoteName('a.language'),
 					$db->quoteName('a.publish_up'),
 					$db->quoteName('a.publish_down'),
+				]
+			)
+		)
+			->select(
+				[
 					$db->quoteName('l.title', 'language_title'),
 					$db->quoteName('l.image', 'language_image'),
 					$db->quoteName('uc.name', 'editor'),
@@ -178,7 +183,6 @@ class NewsfeedsModel extends ListModel
 					$db->quoteName('c.title', 'category_title'),
 				]
 			)
-		)
 			->from($db->quoteName('#__newsfeeds', 'a'))
 			->join('LEFT', $db->quoteName('#__languages', 'l'), $db->quoteName('l.lang_code') . ' = ' . $db->quoteName('a.language'))
 			->join('LEFT', $db->quoteName('#__users', 'uc'), $db->quoteName('uc.id') . ' = ' . $db->quoteName('a.checked_out'))

--- a/administrator/components/com_templates/Model/StylesModel.php
+++ b/administrator/components/com_templates/Model/StylesModel.php
@@ -134,11 +134,15 @@ class StylesModel extends ListModel
 					$db->quoteName('l.title', 'language_title'),
 					$db->quoteName('l.image'),
 					$db->quoteName('l.sef', 'language_sef'),
+				]
+			)
+		)
+			->select(
+				[
 					'COUNT(' . $db->quoteName('m.template_style_id') . ') AS assigned',
 					$db->quoteName('extension_id', 'e_id'),
 				]
 			)
-		)
 			->from($db->quoteName('#__template_styles', 'a'))
 			->where($db->quoteName('a.client_id') . ' = :clientid')
 			->bind(':clientid', $clientId, ParameterType::INTEGER);


### PR DESCRIPTION
### Summary of Changes

As part of query cleanup in I moved all unconditionally selected columns to `list.select` state property's default value. This improves performance when using custom `list.select` values (e.g. in modules) by not selecting unneeded columns but can also cause a small break in case those columns are expected to be selected anyways.

This reverts that for now.

### Testing Instructions

Code review.
Or view banners, banner clients, content languages, menu items, newsfeeds and template styles in backend.

### Expected result

Works like before.

### Documentation Changes Required

No.