### PR TITLE
[4.0] Language module

### DIFF
--- a/modules/mod_languages/tmpl/default.php
+++ b/modules/mod_languages/tmpl/default.php
@@ -77,7 +77,7 @@ HTMLHelper::_('stylesheet', 'mod_languages/template.css', array('version' => 'au
 						<?php if ($language->image) : ?>
 							<?php echo HTMLHelper::_('image', 'mod_languages/' . $language->image . '.gif', $language->title_native, array('title' => $language->title_native), true); ?>
 						<?php else : ?>
-							<span class="label"><?php echo strtoupper($language->sef); ?></span>
+							<span class="label" title="<?php echo $language->title_native; ?>"><?php echo strtoupper($language->sef); ?></span>
 						<?php endif; ?>
 					<?php else : ?>
 						<?php echo $params->get('full_name', 1) ? $language->title_native : strtoupper($language->sef); ?>


### PR DESCRIPTION
When the language switcher is set to display flags a title is set for each image with the full language name.

But if a language is set not to have a flag then we get the SEF value instead of the flag but there is no title.

This simple PR adds the title in that situation.

### To test
Create a multilingual site
Open one of the content languages and set the image value to none
Make sure the language switcher module is set to use image flags
Hover over the images and the text in the language switcher module in the front end
After this PR all languages will display the title

### Expected behaviour
![flag](https://user-images.githubusercontent.com/1296369/73451421-7a3d1900-435f-11ea-8551-712b33d95611.gif)
