### PR TITLE
[4.0] Quickicons a11y

### DIFF
--- a/administrator/templates/atum/scss/blocks/_quickicons.scss
+++ b/administrator/templates/atum/scss/blocks/_quickicons.scss
@@ -167,6 +167,7 @@
     &.danger {
       background: $danger-bg;
       border: 1px solid lighten($danger-txt, 30%);
+      color: $danger-txt;
 
       .fa,
       .fab {


### PR DESCRIPTION
Probably my fault but the contrast for the text on the update icons on the dashboard was failing.

Testing will require having an outofdate extension installed - perhaps a language and then running a contrast check on the dashboard



![image](https://user-images.githubusercontent.com/1296369/73490856-4684e200-43a5-11ea-906f-5cb5e11e6d55.png)
