### PR TITLE
[4.0] Pull left permission field for com_config

### DIFF
--- a/layouts/joomla/content/options_default.php
+++ b/layouts/joomla/content/options_default.php
@@ -25,18 +25,18 @@ use Joomla\CMS\HTML\HTMLHelper;
 			<?php foreach ($displayData->form->getFieldset($fieldname) as $field) : ?>
 				<?php $datashowon = ''; ?>
 				<?php $groupClass = $field->type === 'Spacer' ? ' field-spacer' : ''; ?>
+				<?php $groupClass .= $fieldname == 'permissions' ? 'revert-controls' : ''; ?>
 				<?php if ($field->showon) : ?>
 					<?php HTMLHelper::_('script', 'system/showon.min.js', array('version' => 'auto', 'relative' => true)); ?>
 					<?php $datashowon = ' data-showon=\'' . json_encode(FormHelper::parseShowOnConditions($field->showon, $field->formControl, $field->group)) . '\''; ?>
 				<?php endif; ?>
-
-					<?php if (isset($displayData->showlabel)) : ?>
+				<?php if (isset($displayData->showlabel)) : ?>
 					<div class="control-group<?php echo $groupClass; ?>"<?php echo $datashowon; ?>>
 						<div class="controls"><?php echo $field->input; ?></div>
 					</div>
-					<?php else : ?>
-						<?php echo $field->renderField(); ?>
-					<?php endif; ?>
+				<?php else : ?>
+					<?php echo $field->renderField(); ?>
+				<?php endif; ?>
 			<?php endforeach; ?>
 		<?php endforeach; ?>
 		</div>


### PR DESCRIPTION
Pull left the Permissions Field of com_config.

### Testing Instructions
Have a look on Global Configuration, Tab permission. Before and after applying the patch.
The field has some space at the left. 
In all other components there is no space.

### Expected result
All Permission tabs look equal

### Actual result

![com_config_permissions](https://user-images.githubusercontent.com/1035262/73544400-61a13180-4439-11ea-9e91-5e53db7bfc85.JPG)


### Documentation Changes Required

