### PR TITLE
#27744 allow showing ucm_content items with core_access=0. Similar fi…

### DIFF
--- a/modules/mod_tags_popular/helper.php
+++ b/modules/mod_tags_popular/helper.php
@@ -86,7 +86,7 @@ abstract class ModTagsPopularHelper
 
 		// Only return tags connected to published and authorised items
 		$query->where($db->quoteName('c.core_state') . ' = 1')
-			->where('(' . $db->quoteName('c.core_access') . ' IN (' . $groups . ') OR c.core_access = 0)')
+			->where('(' . $db->quoteName('c.core_access') . ' IN (' . $groups . ') OR ' . $db->quoteName('c.core_access') . ' = 0)')
 			->where('(' . $db->quoteName('c.core_publish_up') . ' = ' . $nullDate
 				. ' OR ' . $db->quoteName('c.core_publish_up') . ' <= ' . $db->quote($nowDate) . ')')
 			->where('(' . $db->quoteName('c.core_publish_down') . ' = ' . $nullDate

--- a/modules/mod_tags_popular/helper.php
+++ b/modules/mod_tags_popular/helper.php
@@ -86,7 +86,7 @@ abstract class ModTagsPopularHelper
 
 		// Only return tags connected to published and authorised items
 		$query->where($db->quoteName('c.core_state') . ' = 1')
-			->where($db->quoteName('c.core_access') . ' IN (' . $groups . ')')
+			->where('(' . $db->quoteName('c.core_access') . ' IN (' . $groups . ') OR c.core_access = 0)')
 			->where('(' . $db->quoteName('c.core_publish_up') . ' = ' . $nullDate
 				. ' OR ' . $db->quoteName('c.core_publish_up') . ' <= ' . $db->quote($nowDate) . ')')
 			->where('(' . $db->quoteName('c.core_publish_down') . ' = ' . $nullDate


### PR DESCRIPTION
…x for the similar tags module: https://github.com/joomla/joomla-cms/pull/996/commits/04161600e69ebed68ffcc6fa5619dc249323cc0e

Pull Request for Issue #27744 

### Summary of Changes

Allow displaying items with core_access=0 from _ucm_content in the Popular Tags module. The zero value is the result if a component does not use an access column.

### Testing Instructions

- create the popular tags module
- create an article
- create a content tag
- assign that tag to the article
- change the core_access value for the article representation in _ucm_content to 0


### Expected result
I see my tag in the popular tags module.


### Actual result
I don't see my tag in the popular tags module.


### Documentation Changes Required
No.
