### PR TITLE
[4.0] Fix filter to use condition

### DIFF
--- a/administrator/modules/mod_stats_admin/Helper/StatsAdminHelper.php
+++ b/administrator/modules/mod_stats_admin/Helper/StatsAdminHelper.php
@@ -119,7 +119,7 @@ class StatsAdminHelper
 				$rows[$i]->title = Text::_('MOD_STATS_ARTICLES');
 				$rows[$i]->icon  = 'file';
 				$rows[$i]->data  = $items;
-				$rows[$i]->link  = Route::_('index.php?option=com_content&view=articles&filter[published]=1');
+				$rows[$i]->link  = Route::_('index.php?option=com_content&view=articles&filter[condition]=1');
 				$i++;
 			}
 		}


### PR DESCRIPTION
### Summary of Changes
Change link to filter from publish to condition.


### Testing Instructions
Go to back end dashboard.
In Statistics box, click the button next to Articles.
See the `Select Condition` not selected.
Apply PR.
See the `Select Condition` dropdown selected on `Published`.