### PR TITLE
[plg_system_actionlogs] Render values in profile

### DIFF
--- a/plugins/system/actionlogs/actionlogs.php
+++ b/plugins/system/actionlogs/actionlogs.php
@@ -12,6 +12,8 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Cache\Cache;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;
+use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Language\Text;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\User\User;
 
@@ -190,6 +192,16 @@ class PlgSystemActionLogs extends JPlugin
 		$data->actionlogs                       = new StdClass;
 		$data->actionlogs->actionlogsNotify     = $values->notify;
 		$data->actionlogs->actionlogsExtensions = $values->extensions;
+
+		if (!HTMLHelper::isRegistered('users.actionlogsNotify'))
+		{
+			HTMLHelper::register('users.actionlogsNotify', array(__CLASS__, 'renderActionlogsNotify'));
+		}
+
+		if (!HTMLHelper::isRegistered('users.actionlogsExtensions'))
+		{
+			HTMLHelper::register('users.actionlogsExtensions', array(__CLASS__, 'renderActionlogsExtensions'));
+		}
 
 		return true;
 	}
@@ -460,5 +472,50 @@ class PlgSystemActionLogs extends JPlugin
 				}
 			}
 		}
+	}
+
+
+	/**
+	 * Method to render a value.
+	 *
+	 * @param   integer|string  $value  The value (0 or 1).
+	 *
+	 * @return  string  The rendered value.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public static function renderActionlogsNotify($value)
+	{
+		return Text::_($value ? 'JYES' : 'JNO');
+	}
+
+	/**
+	 * Method to render a list of extensions.
+	 *
+	 * @param   array|string  $extensions  Array of extensions or an empty string if none selected.
+	 *
+	 * @return  string  The rendered value.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public static function renderActionlogsExtensions($extensions)
+	{
+		// No extensions selected.
+		if (!$extensions)
+		{
+			return Text::_('JNONE');
+		}
+
+		// Load the helper.
+		JLoader::register('ActionlogsHelper', JPATH_ADMINISTRATOR . '/components/com_actionlogs/helpers/actionlogs.php');
+
+		foreach ($extensions as &$extension)
+		{
+			// Load extension language files and translate extension name.
+			ActionlogsHelper::loadTranslationFiles($extension);
+			$extension = Text::_($extension);
+		}
+
+		return implode(', ', $extensions);
 	}
 }

--- a/plugins/system/actionlogs/actionlogs.php
+++ b/plugins/system/actionlogs/actionlogs.php
@@ -474,7 +474,6 @@ class PlgSystemActionLogs extends JPlugin
 		}
 	}
 
-
 	/**
 	 * Method to render a value.
 	 *


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/22238.

### Summary of Changes

Register methods for rendering values added by Action Logs plugin in profile.

### Testing Instructions

As super user, login to frontend.
Save your profile once.
View your profile.

### Expected result

Profile values rendered normally:

![Screenshot_2020-02-02 User Profile-after](https://user-images.githubusercontent.com/7325021/73610179-45d69080-45dd-11ea-92eb-01ee8cda5801.png)


### Actual result

Profile values missing:

![Screenshot_2020-02-02 User Profile-before](https://user-images.githubusercontent.com/7325021/73610171-42430980-45dd-11ea-870d-24f9165df4e6.png)


### Documentation Changes Required

No.