### PR TITLE
[4.0] Dashboards

### DIFF
--- a/administrator/components/com_cpanel/tmpl/cpanel/default.php
+++ b/administrator/components/com_cpanel/tmpl/cpanel/default.php
@@ -61,11 +61,11 @@ echo HTMLHelper::_(
 			echo ModuleHelper::renderModule($module, array('style' => 'well'));
 		}
 		?>
-		<?php if ($user->authorise('core.create', 'com_modules')) : ?>
-
 		</div>
 	</div>
 </div>
+
+<?php if ($user->authorise('core.create', 'com_modules')) : ?>
 <div class="row">
 	<div class="col-md-6">
 		<button type="button" data-toggle="modal" data-target="#moduleDashboardAddModal" class="cpanel-add-module text-center py-5 w-100 d-block">
@@ -75,5 +75,5 @@ echo HTMLHelper::_(
 			<span><?php echo Text::_('COM_CPANEL_ADD_DASHBOARD_MODULE'); ?></span>
 		</button>
 	</div>
-	<?php endif; ?>
 </div>
+<?php endif; ?>

--- a/administrator/components/com_cpanel/tmpl/cpanel/default.php
+++ b/administrator/components/com_cpanel/tmpl/cpanel/default.php
@@ -48,23 +48,14 @@ echo HTMLHelper::_(
 );
 ?>
 <div id="cpanel-modules">
-	<?php if ($this->quickicons) : ?>
-	<div class="cpanel-modules <?php echo $this->position; ?>-quickicons">
+	<div class="cpanel-modules <?php echo $this->position; ?>">
 		<div class="card-columns">
-			<?php // Display the icon position modules
+		<?php if ($this->quickicons) :
 			foreach ($this->quickicons as $iconmodule)
 			{
 				echo ModuleHelper::renderModule($iconmodule, array('style' => 'well'));
 			}
-		?>
-		</div>
-	</div>
-	<?php endif; ?>
-
-	<div class="cpanel-modules <?php echo $this->position; ?>">
-		<div class="card-columns">
-
-		<?php
+		endif;
 		foreach ($this->modules as $module)
 		{
 			echo ModuleHelper::renderModule($module, array('style' => 'well'));

--- a/administrator/modules/mod_submenu/tmpl/default.php
+++ b/administrator/modules/mod_submenu/tmpl/default.php
@@ -17,69 +17,71 @@ use Joomla\CMS\Router\Route;
 ?>
 <?php foreach ($root->getChildren() as $child) : ?>
 	<?php if ($child->hasChildren()) : ?>
-		<div class="card">
-			<h2 class="card-header">
-				<?php if ($child->icon) : ?><span class="fas fa-<?php echo $child->icon; ?>" aria-hidden="true"></span><?php endif; ?>
-				<?php echo Text::_($child->title); ?>
-			</h2>
-			<ul class="list-group list-group-flush">
-				<?php foreach ($child->getChildren() as $item) : ?>
-					<li class="list-group-item d-flex align-items-center">
-						<?php $params = $item->getParams(); ?>
-						<?php // Only if Menu-show = true
-							if ($params->get('menu_show', 1)) : ?>
-							<a class="flex-grow-1" href="<?php echo $item->link; ?>"<?php echo $item->target ? ' target="' . $item->target . '"' : ''; ?>>
-								<?php if (!empty($params->get('menu_image'))) : ?>
-									<?php
-									$image = htmlspecialchars($params->get('menu_image'), ENT_QUOTES, 'UTF-8');
-									$class = htmlspecialchars($params->get('menu_image_css'), ENT_QUOTES, 'UTF-8');
-									$alt   = $params->get('menu_text') ? '' : htmlspecialchars(Text::_($item->title), ENT_QUOTES, 'UTF-8');
-									?>
-									<?php echo HTMLHelper::_('image', $image, $alt, 'class="' . $class . '"'); ?>
-								<?php endif; ?>
-								<?php echo ($params->get('menu_text', 1)) ? htmlspecialchars(Text::_($item->title), ENT_QUOTES, 'UTF-8') . $item->iconImage : ''; ?>
-								<?php if ($item->ajaxbadge) : ?>
-									<span class="menu-badge">
-										<span class="fas fa-spin fa-spinner mt-1 system-counter" data-url="<?php echo $item->ajaxbadge; ?>"></span>
-									</span>
-								<?php endif; ?>
-							</a>
-							<?php if ($params->get('menu-quicktask', false)) : ?>
-								<?php $permission = $params->get('menu-quicktask-permission'); ?>
-								<?php $scope = $item->scope !== 'default' ? $item->scope : null; ?>
-								<?php if (!$permission || $user->authorise($permission, $scope)) : ?>
-									<span class="menu-quicktask">
+		<div class="module-wrapper">
+			<div class="card">
+				<h2 class="card-header">
+					<?php if ($child->icon) : ?><span class="fas fa-<?php echo $child->icon; ?>" aria-hidden="true"></span><?php endif; ?>
+					<?php echo Text::_($child->title); ?>
+				</h2>
+				<ul class="list-group list-group-flush">
+					<?php foreach ($child->getChildren() as $item) : ?>
+						<li class="list-group-item d-flex align-items-center">
+							<?php $params = $item->getParams(); ?>
+							<?php // Only if Menu-show = true
+								if ($params->get('menu_show', 1)) : ?>
+								<a class="flex-grow-1" href="<?php echo $item->link; ?>"<?php echo $item->target ? ' target="' . $item->target . '"' : ''; ?>>
+									<?php if (!empty($params->get('menu_image'))) : ?>
 										<?php
-										$link = $params->get('menu-quicktask-link');
-										$icon = $params->get('menu-quicktask-icon', 'plus');
-
-										$title = Text::_($params->get('menu-quicktask-title'));
-
-										if (empty($params->get('menu-quicktask-title')))
-										{
-											$title = Text::_('MOD_MENU_QUICKTASK_NEW');
-										}
-
-										$sronly = Text::_($item->title) . ' - ' . $title;
+										$image = htmlspecialchars($params->get('menu_image'), ENT_QUOTES, 'UTF-8');
+										$class = htmlspecialchars($params->get('menu_image_css'), ENT_QUOTES, 'UTF-8');
+										$alt   = $params->get('menu_text') ? '' : htmlspecialchars(Text::_($item->title), ENT_QUOTES, 'UTF-8');
 										?>
-										<a href="<?php echo $link; ?>">
-											<span class="fas fa-<?php echo $icon; ?> fa-xs" title="<?php echo htmlentities($title); ?>" aria-hidden="true"></span>
-											<span class="sr-only"><?php echo htmlentities($sronly); ?></span>
+										<?php echo HTMLHelper::_('image', $image, $alt, 'class="' . $class . '"'); ?>
+									<?php endif; ?>
+									<?php echo ($params->get('menu_text', 1)) ? htmlspecialchars(Text::_($item->title), ENT_QUOTES, 'UTF-8') . $item->iconImage : ''; ?>
+									<?php if ($item->ajaxbadge) : ?>
+										<span class="menu-badge">
+											<span class="fas fa-spin fa-spinner mt-1 system-counter" data-url="<?php echo $item->ajaxbadge; ?>"></span>
+										</span>
+									<?php endif; ?>
+								</a>
+								<?php if ($params->get('menu-quicktask', false)) : ?>
+									<?php $permission = $params->get('menu-quicktask-permission'); ?>
+									<?php $scope = $item->scope !== 'default' ? $item->scope : null; ?>
+									<?php if (!$permission || $user->authorise($permission, $scope)) : ?>
+										<span class="menu-quicktask">
+											<?php
+											$link = $params->get('menu-quicktask-link');
+											$icon = $params->get('menu-quicktask-icon', 'plus');
+
+											$title = Text::_($params->get('menu-quicktask-title'));
+
+											if (empty($params->get('menu-quicktask-title')))
+											{
+												$title = Text::_('MOD_MENU_QUICKTASK_NEW');
+											}
+
+											$sronly = Text::_($item->title) . ' - ' . $title;
+											?>
+											<a href="<?php echo $link; ?>">
+												<span class="fas fa-<?php echo $icon; ?> fa-xs" title="<?php echo htmlentities($title); ?>" aria-hidden="true"></span>
+												<span class="sr-only"><?php echo htmlentities($sronly); ?></span>
+											</a>
+										</span>
+									<?php endif; ?>
+								<?php endif; ?>
+								<?php if ($item->dashboard) : ?>
+									<span class="menu-dashboard">
+										<a href="<?php echo Route::_('index.php?option=com_cpanel&view=cpanel&dashboard=' . $item->dashboard); ?>">
+											<span class="fas fa-th-large" title="<?php echo htmlentities(Text::_('MOD_MENU_DASHBOARD_LINK')); ?>"></span>
 										</a>
 									</span>
 								<?php endif; ?>
 							<?php endif; ?>
-							<?php if ($item->dashboard) : ?>
-								<span class="menu-dashboard">
-									<a href="<?php echo Route::_('index.php?option=com_cpanel&view=cpanel&dashboard=' . $item->dashboard); ?>">
-										<span class="fas fa-th-large" title="<?php echo htmlentities(Text::_('MOD_MENU_DASHBOARD_LINK')); ?>"></span>
-									</a>
-								</span>
-							<?php endif; ?>
-						<?php endif; ?>
-					</li>
-				<?php endforeach; ?>
-			</ul>
+						</li>
+					<?php endforeach; ?>
+				</ul>
+			</div>
 		</div>
 	<?php endif; ?>
 <?php endforeach; ?>

--- a/administrator/templates/atum/scss/blocks/_global.scss
+++ b/administrator/templates/atum/scss/blocks/_global.scss
@@ -225,14 +225,20 @@ a[target="_blank"]::before {
 .card-columns {
   display: grid;
   grid-gap: 0 15px;
-  grid-template-columns: repeat(auto-fill, minmax(700px,1fr));
+  grid-template-columns: 1fr;
+
+  @include media-breakpoint-up(md) {
+    grid-template-columns: 1fr 1fr;
+  }
 }
 
 .cpanel-help,
 .cpanel-system {
 
   .card-columns {
-    grid-template-columns: repeat(auto-fill, minmax(500px, 1fr));
+    @include media-breakpoint-up(md) {
+      grid-template-columns: 1fr 1fr 1fr;
+    }
   }
 }
 

--- a/administrator/templates/atum/scss/blocks/_global.scss
+++ b/administrator/templates/atum/scss/blocks/_global.scss
@@ -224,15 +224,17 @@ a[target="_blank"]::before {
 
 .card-columns {
   display: grid;
-  grid-gap: 10px;
-  grid-template-columns: repeat(auto-fill, minmax(40%,1fr));
-  grid-auto-rows: 10px;
+  grid-gap: 0 15px;
+  grid-template-columns: repeat(auto-fill, minmax(700px,1fr));
 }
 
-.cpanel-help .card-columns,
-.cpanel-system .card-columns {
-  grid-template-columns: repeat(auto-fill, minmax(30%,1fr));
+.cpanel-help,
+.cpanel-system {
+
+  .card-columns {
+    grid-template-columns: repeat(auto-fill, minmax(500px, 1fr));
   }
+}
 
 .tiny {
   font-size: $font-size-vsm;

--- a/administrator/templates/atum/scss/blocks/_global.scss
+++ b/administrator/templates/atum/scss/blocks/_global.scss
@@ -222,18 +222,17 @@ a[target="_blank"]::before {
   min-width: 1rem;
 }
 
-.cpanel-help .card-columns,
-.cpanel-system .card-columns {
-  @include media-breakpoint-up(md) {
-    column-count: 3;
-  }
+.card-columns {
+  display: grid;
+  grid-gap: 10px;
+  grid-template-columns: repeat(auto-fill, minmax(40%,1fr));
+  grid-auto-rows: 10px;
 }
 
-.card-columns {
-  @include media-breakpoint-up(md) {
-    column-count: 2;
+.cpanel-help .card-columns,
+.cpanel-system .card-columns {
+  grid-template-columns: repeat(auto-fill, minmax(30%,1fr));
   }
-}
 
 .tiny {
   font-size: $font-size-vsm;

--- a/administrator/templates/atum/scss/blocks/_quickicons.scss
+++ b/administrator/templates/atum/scss/blocks/_quickicons.scss
@@ -231,22 +231,6 @@
   }
 }
 
-#cpanel-modules {
-
-  .cpanel-quickicons,
-  .cpanel {
-    .card-columns {
-      @include media-breakpoint-down(md) {
-        column-count: 2;
-      }
-
-      @include media-breakpoint-down(sm) {
-        column-count: 1;
-      }
-    }
-  }
-}
-
 #wrapper.closed {
   .quick-icons {
 

--- a/build/media_source/com_cpanel/js/admin-cpanel-default.es6.js
+++ b/build/media_source/com_cpanel/js/admin-cpanel-default.es6.js
@@ -79,26 +79,27 @@
     $gridBox: null,
 
     // Calculate "grid-row-end" property
-    resizeGridItem: function($cell, rowHeight, rowGap) {
+    resizeGridItem ($cell, rowHeight, rowGap) {
       const $content = $cell.querySelector('.card');
-      const rowSpan  = Math.ceil(($content.getBoundingClientRect().height + rowGap) / (rowHeight + rowGap));
+      const contentHeight = $content.getBoundingClientRect().height + rowGap;
+      const rowSpan = Math.ceil(contentHeight / (rowHeight + rowGap));
 
-      $cell.style.gridRowEnd = `span ${rowSpan}`
+      $cell.style.gridRowEnd = `span ${rowSpan}`;
     },
 
     // Check a size of every cell in the grid
-    resizeAllGridItems: function() {
-      const $gridCells   = [].slice.call(MasonryLayout.$gridBox.children);
-      const gridStyle    = window.getComputedStyle(MasonryLayout.$gridBox);
-      const gridAutoRows = parseInt(gridStyle.getPropertyValue('grid-auto-rows')) || 0;
-      const gridRowGap   = parseInt(gridStyle.getPropertyValue('grid-row-gap')) || 10;
+    resizeAllGridItems () {
+      const $gridCells = [].slice.call(MasonryLayout.$gridBox.children);
+      const gridStyle = window.getComputedStyle(MasonryLayout.$gridBox);
+      const gridAutoRows = parseInt(gridStyle.getPropertyValue('grid-auto-rows'), 10) || 0;
+      const gridRowGap = parseInt(gridStyle.getPropertyValue('grid-row-gap'), 10) || 10;
 
       $gridCells.forEach(($cell) => {
         MasonryLayout.resizeGridItem($cell, gridAutoRows, gridRowGap);
       });
     },
 
-    initialise: function() {
+    initialise () {
       MasonryLayout.$gridBox = document.querySelector('#cpanel-modules .card-columns');
       MasonryLayout.resizeAllGridItems();
 
@@ -111,6 +112,8 @@
     }
   };
 
-  // Initialise Masonry layout on full load, to be sure all images/fonts are loaded, and so cards have a "final" size
+  // Initialise Masonry layout on full load,
+  // to be sure all images/fonts are loaded, and so cards have a "final" size
   window.addEventListener('load', MasonryLayout.initialise);
+
 })(window, document, window.Joomla);

--- a/build/media_source/com_cpanel/js/admin-cpanel-default.es6.js
+++ b/build/media_source/com_cpanel/js/admin-cpanel-default.es6.js
@@ -79,7 +79,7 @@
     $gridBox: null,
 
     // Calculate "grid-row-end" property
-    resizeGridItem ($cell, rowHeight, rowGap) {
+    resizeGridItem($cell, rowHeight, rowGap) {
       const $content = $cell.querySelector('.card');
       const contentHeight = $content.getBoundingClientRect().height + rowGap;
       const rowSpan = Math.ceil(contentHeight / (rowHeight + rowGap));
@@ -88,7 +88,7 @@
     },
 
     // Check a size of every cell in the grid
-    resizeAllGridItems () {
+    resizeAllGridItems() {
       const $gridCells = [].slice.call(MasonryLayout.$gridBox.children);
       const gridStyle = window.getComputedStyle(MasonryLayout.$gridBox);
       const gridAutoRows = parseInt(gridStyle.getPropertyValue('grid-auto-rows'), 10) || 0;
@@ -99,7 +99,7 @@
       });
     },
 
-    initialise () {
+    initialise() {
       MasonryLayout.$gridBox = document.querySelector('#cpanel-modules .card-columns');
       MasonryLayout.resizeAllGridItems();
 
@@ -109,7 +109,7 @@
         window.clearTimeout(resizeTimer);
         resizeTimer = window.setTimeout(MasonryLayout.resizeAllGridItems, 300);
       });
-    }
+    },
   };
 
   // Initialise Masonry layout on full load,

--- a/build/media_source/com_cpanel/js/admin-cpanel-default.es6.js
+++ b/build/media_source/com_cpanel/js/admin-cpanel-default.es6.js
@@ -71,28 +71,28 @@
     document.removeEventListener('DOMContentLoaded', onBoot);
   };
 
-  function resizeGridItem(item){
-    grid = document.getElementsByClassName("card-columns")[0];
+  function resizeGridItem(item) {
+    grid = document.getElementsByClassName('card-columns')[0];
     rowHeight = parseInt(window.getComputedStyle(grid).getPropertyValue('grid-auto-rows'));
     rowGap = parseInt(window.getComputedStyle(grid).getPropertyValue('grid-row-gap'));
-    rowSpan = Math.ceil((item.querySelector('.card').getBoundingClientRect().height+rowGap)/(rowHeight+rowGap));
-      item.style.gridRowEnd = "span "+rowSpan;
+    rowSpan = Math.ceil((item.querySelector('.card').getBoundingClientRect().height + rowGap) / (rowHeight + rowGap));
+    item.style.gridRowEnd = `span ${rowSpan}`;
   }
 
-  function resizeAllGridItems(){
-    allItems = document.getElementsByClassName("module-wrapper");
-    for(x=0;x<allItems.length;x++){
+  function resizeAllGridItems() {
+    allItems = document.getElementsByClassName('module-wrapper');
+    for (x = 0; x < allItems.length; x++) {
       resizeGridItem(allItems[x]);
     }
   }
 
-  function resizeInstance(instance){
+  function resizeInstance(instance) {
     item = instance.elements[0];
     resizeGridItem(item);
   }
 
   window.onload = resizeAllGridItems();
-  window.addEventListener("resize", resizeAllGridItems);
+  window.addEventListener('resize', resizeAllGridItems);
 
   // Initialise
   document.addEventListener('DOMContentLoaded', onBoot);

--- a/build/media_source/com_cpanel/js/admin-cpanel-default.es6.js
+++ b/build/media_source/com_cpanel/js/admin-cpanel-default.es6.js
@@ -71,6 +71,29 @@
     document.removeEventListener('DOMContentLoaded', onBoot);
   };
 
+  function resizeGridItem(item){
+    grid = document.getElementsByClassName("card-columns")[0];
+    rowHeight = parseInt(window.getComputedStyle(grid).getPropertyValue('grid-auto-rows'));
+    rowGap = parseInt(window.getComputedStyle(grid).getPropertyValue('grid-row-gap'));
+    rowSpan = Math.ceil((item.querySelector('.card').getBoundingClientRect().height+rowGap)/(rowHeight+rowGap));
+      item.style.gridRowEnd = "span "+rowSpan;
+  }
+
+  function resizeAllGridItems(){
+    allItems = document.getElementsByClassName("module-wrapper");
+    for(x=0;x<allItems.length;x++){
+      resizeGridItem(allItems[x]);
+    }
+  }
+
+  function resizeInstance(instance){
+    item = instance.elements[0];
+    resizeGridItem(item);
+  }
+
+  window.onload = resizeAllGridItems();
+  window.addEventListener("resize", resizeAllGridItems);
+
   // Initialise
   document.addEventListener('DOMContentLoaded', onBoot);
 })(window, document, window.Joomla);

--- a/build/media_source/com_cpanel/js/admin-cpanel-default.es6.js
+++ b/build/media_source/com_cpanel/js/admin-cpanel-default.es6.js
@@ -115,5 +115,4 @@
   // Initialise Masonry layout on full load,
   // to be sure all images/fonts are loaded, and so cards have a "final" size
   window.addEventListener('load', MasonryLayout.initialise);
-
 })(window, document, window.Joomla);


### PR DESCRIPTION
Before this PR In the dashboards of joomla 4 we have a situation where sometimes there is a large space between _modules_

This is because the _modules_ generated by the system are in a different div than that of the more traditional modules.

By moving them all into the same div that problem disappears. I can't see any reason for them to be in different divs

### Example Home Before
![image](https://user-images.githubusercontent.com/1296369/73615375-2f413100-45ff-11ea-9c08-e3e475bb2e85.png)

### Example Home After
![image](https://user-images.githubusercontent.com/1296369/73615379-38320280-45ff-11ea-8284-9162facf3b88.png)
