### PR TITLE
[4.0] RTL: fix Global Config database prefix display

### DIFF
--- a/administrator/templates/atum/scss/template-rtl.scss
+++ b/administrator/templates/atum/scss/template-rtl.scss
@@ -257,3 +257,9 @@ body {
 #new_url {
   text-align: left;
 }
+
+// Database prefix
+#jform_dbprefix {
+  direction: ltr;
+  text-align: right;
+}


### PR DESCRIPTION
### Summary of Changes
Database prefix should be displayed as LTR and aligned right, same as installing J with RTL language.


### Testing Instructions
Install Persian language, display Global Configuration Server tab.
In a new window switch backend language to Persian.

Then patch and NPM


### Before patch
<img width="710" alt="Screen Shot 2020-02-03 at 07 53 16" src="https://user-images.githubusercontent.com/869724/73632304-9c82af80-465b-11ea-8630-680dc7b3e0af.png">



### After patch

The underscore is correctly displayed to the right.

<img width="704" alt="Screen Shot 2020-02-03 at 07 53 51" src="https://user-images.githubusercontent.com/869724/73632315-a73d4480-465b-11ea-97d0-f0706bd8b472.png">
