### PR TITLE
[4.0] Unpublish admin modules from dashboard

### DIFF
--- a/build/media_source/com_cpanel/js/admin-cpanel-default.es6.js
+++ b/build/media_source/com_cpanel/js/admin-cpanel-default.es6.js
@@ -59,7 +59,7 @@
       return false;
     });
 
-    const cpanelModules = document.getElementById('cpanel-modules');
+    const cpanelModules = document.getElementById('content');
     if (cpanelModules) {
       const links = [].slice.call(cpanelModules.querySelectorAll('.unpublish-module'));
       links.forEach((link) => {


### PR DESCRIPTION
PR for #26652

#### Steps to reproduce the issue
Add a module to a dashboard on a position != cpanel.
Use chrome "well".
The module is rendered on the dashboard. And the cog for edit / unpublish appears.
Now click unpublish

### Expected result
The module is unpublished

### Actual result
Nothing happens

### After PR
Module is unpublished as expected

### Testing Notes
As this is a javascript change either `npm i` or `node build.js compile-js` are required after applying the patch
