### PR TITLE
[4.0] Media plugin backgrounds

### DIFF
--- a/administrator/components/com_media/resources/styles/components/_media-edit.scss
+++ b/administrator/components/com_media/resources/styles/components/_media-edit.scss
@@ -27,7 +27,7 @@
   > div {
     padding: 0 $gutter-width;
     > img {
-      padding:0 15px;
+      padding: 0 15px;
       background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAACusAAArrAYKLDVoAAAA1SURBVDhPY2xoaPjPgAc8e/YMysIOmKA02WDUgMFgAGNaWhredCAlJQVlYQejgTgMDGBgAAD6KwfPUN9TLQAAAABJRU5ErkJggg==');
     }
   }

--- a/administrator/components/com_media/resources/styles/components/_media-edit.scss
+++ b/administrator/components/com_media/resources/styles/components/_media-edit.scss
@@ -26,6 +26,10 @@
 .media-manager-edit {
   > div {
     padding: 0 $gutter-width;
+    > img {
+      padding:0 15px;
+      background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAACusAAArrAYKLDVoAAAA1SURBVDhPY2xoaPjPgAc8e/YMysIOmKA02WDUgMFgAGNaWhredCAlJQVlYQejgTgMDGBgAAD6KwfPUN9TLQAAAABJRU5ErkJggg==');
+    }
   }
   h3 {
     padding: 3px;


### PR DESCRIPTION
There is a background for the cropper plugin but none for the resize or rotate plugins. This creates issues if you have a transparent image

To test `npm i` or `node build.js --compile-css`

Pull Request for Issue #24662 .

### Before 
![image](https://user-images.githubusercontent.com/1296369/73646019-71568b00-4670-11ea-9d0b-ffc8b5c8ed8b.png)

### After 
![image](https://user-images.githubusercontent.com/1296369/73645995-61d74200-4670-11ea-8b38-562d2b888db8.png)
