### PR TITLE
[4.0] Main menu add new shortcuts

### DIFF
--- a/administrator/modules/mod_menu/tmpl/default_submenu.php
+++ b/administrator/modules/mod_menu/tmpl/default_submenu.php
@@ -147,8 +147,7 @@ else
 {
 	echo '<span>' . Text::_($current->title) . '</span>' . $ajax;
 }
-
-if ($currentParams->get('menu-quicktask', false))
+if ($currentParams->get('menu-quicktask', false) && $this->params->get('shownew', 1) === 1)
 {
 	$params = $current->getParams();
 	$user = $this->application->getIdentity();

--- a/administrator/modules/mod_menu/tmpl/default_submenu.php
+++ b/administrator/modules/mod_menu/tmpl/default_submenu.php
@@ -147,6 +147,7 @@ else
 {
 	echo '<span>' . Text::_($current->title) . '</span>' . $ajax;
 }
+
 if ($currentParams->get('menu-quicktask', false) && $this->params->get('shownew', 1) === 1)
 {
 	$params = $current->getParams();


### PR DESCRIPTION
The admin menu module has options to show/hide the "add new" shortcuts on the menu. This option was not working. It is now

 Partial Pull Request for Issue #26050

![image](https://user-images.githubusercontent.com/1296369/73650878-1a09e800-467b-11ea-9f98-e0081e0632d4.png)
