### PR TITLE
[4.0] Allow extensions to manipulate data in API on save

### DIFF
--- a/api/components/com_categories/Controller/CategoriesController.php
+++ b/api/components/com_categories/Controller/CategoriesController.php
@@ -45,7 +45,7 @@ class CategoriesController extends ApiController
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	protected function preprocessSaveData(array $data)
+	protected function preprocessSaveData(array $data): array
 	{
 		$data['extension'] = $this->getExtensionFromInput();
 

--- a/api/components/com_categories/Controller/CategoriesController.php
+++ b/api/components/com_categories/Controller/CategoriesController.php
@@ -37,6 +37,22 @@ class CategoriesController extends ApiController
 	protected $default_view = 'categories';
 
 	/**
+	 * Method to allow extended classes to manipulate the data to be saved for an extension.
+	 *
+	 * @param   array  $data  An array of input data.
+	 *
+	 * @return  array
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function preprocessSaveData(array $data)
+	{
+		$data['extension'] = $this->getExtensionFromInput();
+
+		return $data;
+	}
+
+	/**
 	 * Basic display of an item view
 	 *
 	 * @param   integer  $id  The primary key to display. Leave empty if you want to retrieve data from the request

--- a/libraries/src/MVC/Controller/ApiController.php
+++ b/libraries/src/MVC/Controller/ApiController.php
@@ -436,6 +436,8 @@ class ApiController extends BaseController
 		$checkin    = property_exists($table, $table->getColumnAlias('checked_out'));
 		$data[$key] = $recordKey;
 
+		$data = $this->preprocessSaveData($data);
+
 		// TODO: Not the cleanest thing ever but it works...
 		Form::addFormPath(JPATH_COMPONENT_ADMINISTRATOR . '/forms');
 
@@ -542,5 +544,19 @@ class ApiController extends BaseController
 		$user = $this->app->getIdentity();
 
 		return $user->authorise('core.create', $this->option) || \count($user->getAuthorisedCategories($this->option, 'core.create'));
+	}
+
+	/**
+	 * Method to allow extended classes to manipulate the data to be saved for an extension.
+	 *
+	 * @param   array  $data  An array of input data.
+	 *
+	 * @return  array
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function preprocessSaveData(array $data)
+	{
+		return $data;
 	}
 }

--- a/libraries/src/MVC/Controller/ApiController.php
+++ b/libraries/src/MVC/Controller/ApiController.php
@@ -555,7 +555,7 @@ class ApiController extends BaseController
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	protected function preprocessSaveData(array $data)
+	protected function preprocessSaveData(array $data): array
 	{
 		return $data;
 	}


### PR DESCRIPTION
Using it in a concrete way in the categories view

### Summary of Changes
When creating a category from the API you no longer need to specify the extension that it will belong to - it will be automatically picked up from the URL the same way we do in the list view.

This makes this functionality available in a generic way so other extensions can do any manipulation of the data before it's sent to the admin model

### Testing Instructions
Create category before patch - extension property required. After patch - it's not.

### Documentation Changes Required
None
