### PR TITLE
[4.0] Fix edge case PHP Notice in com_finder

### DIFF
--- a/administrator/components/com_finder/Indexer/Helper.php
+++ b/administrator/components/com_finder/Indexer/Helper.php
@@ -113,7 +113,10 @@ class Helper
 
 		$tokens = array();
 		$terms = $language->tokenise($input);
+
+		// TODO: array_filter removes any number 0's from the terms. Not sure this is entirely intended
 		$terms = array_filter($terms);
+		$terms = array_values($terms);
 
 		/*
 		 * If we have to handle the input as a phrase, that means we don't


### PR DESCRIPTION
### Summary of Changes
Fixes an edge case in com_finder which gave a PHP Notice

### Testing Instructions
Create a category in Joomla such as "Article 0 of 1" and save it. Then check your PHP error log (note due to the redirect to the list view you won't see this in the UI) and you'll find a PHP Notice. Apply patch. After patch the notice is gone.

Alternatively you can code review array_filter PHP documentation which tells you array keys are preserved. Which is bad for our for loop later on line 131 here https://github.com/joomla/joomla-cms/compare/4.0-dev...wilsonge:patch-finder#diff-6f122d9d8749e848d0ea1343cf256cd1L131.

### Documentation Changes Required
None