### PR TITLE
[Draft][4.0] Fix background shorthand compatibility with Safari/Edge

### DIFF
--- a/administrator/templates/atum/scss/system/searchtools/searchtools.scss
+++ b/administrator/templates/atum/scss/system/searchtools/searchtools.scss
@@ -87,11 +87,13 @@
 
       &.active {
         color: var(--white);
-        background: $custom-select-bg $custom-select-indicator-active no-repeat right center;
+        background: $custom-select-indicator-active no-repeat right center;
+        background-color: $custom-select-bg;
         background-size: $custom-select-bg-size;
 
         [dir=rtl] & {
-          background: $custom-select-bg $custom-select-indicator-active-rtl no-repeat left center;
+          background: $custom-select-indicator-active-rtl no-repeat left center;
+          background-color: $custom-select-bg;
         }
       }
 

--- a/administrator/templates/atum/scss/vendor/bootstrap/_custom-forms.scss
+++ b/administrator/templates/atum/scss/vendor/bootstrap/_custom-forms.scss
@@ -2,6 +2,8 @@
 
 .custom-select {
   max-width: $input-max-width;
+  background: $custom-select-background;
+  background-color: $custom-select-bg;
 
   [dir=rtl] & {
     padding: $custom-select-padding-y $custom-select-padding-x $custom-select-padding-y ($custom-select-padding-x + $custom-select-indicator-padding);


### PR DESCRIPTION
Pull Request for Issue #27572.

### Summary of Changes
Microsoft Edge and Safari don't display custom select correctly when background-color is specified in background shorthand. This PR separates background-color to its own property.

### Testing Instructions
Use Safari or Windows Edge.
Log in administration area.

Go to Articles.
Click Filter Options.
Click Select Condition dropdown and select a condition.
Selected item has no down arrow.
Apply PR.
Repeat steps above.
Selected item has down arrow.
Confirm with other browsers such as Firefox, Chrome work correctly as before.

Repeat for RTL.

### Expected result
![27572-pr](https://user-images.githubusercontent.com/368084/73796489-2fa60d00-4762-11ea-9298-1564e86c5421.jpg)


### Actual result
![27572-before](https://user-images.githubusercontent.com/368084/73796472-20bf5a80-4762-11ea-8474-fa970c47dc17.jpg)
