### PR TITLE
[4.0] Fix fatal error in HTMLHelper

### DIFF
--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -146,7 +146,7 @@ abstract class HTMLHelper
 
 			if (!\is_callable($toCall))
 			{
-				throw new \InvalidArgumentException(sprintf('%s::%s not found.', $service, $func), 500);
+				throw new \InvalidArgumentException(sprintf('%s::%s not found.', get_class($service), $func), 500);
 			}
 
 			static::register($key, $toCall);

--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -146,7 +146,7 @@ abstract class HTMLHelper
 
 			if (!\is_callable($toCall))
 			{
-				throw new \InvalidArgumentException(sprintf('%s::%s not found.', get_class($service), $func), 500);
+				throw new \InvalidArgumentException(sprintf('%s::%s not found.', $file, $func), 500);
 			}
 
 			static::register($key, $toCall);


### PR DESCRIPTION
### Summary of Changes

Fixes fatal error when method does not exists in service.

### Testing Instructions

Add `JHtml::_('contenticon.whatever');` to `templates/cassiopeia/index.php`
View articles in frontend.

### Expected result

Joomla error page:
> contenticon::whatever not found. 

### Actual result

Fatal error:
>Catchable fatal error: Object of class Joomla\Component\Content\Administrator\Service\HTML\Icon could not be converted to string 

### Documentation Changes Required

No.