### PR TITLE
[4.0] Fix Custom Administrator Menu using Presets.

### DIFF
--- a/administrator/components/com_menus/Controller/MenuController.php
+++ b/administrator/components/com_menus/Controller/MenuController.php
@@ -11,6 +11,7 @@ namespace Joomla\Component\Menus\Administrator\Controller;
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Application\ApplicationHelper;
 use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Controller\FormController;
@@ -141,9 +142,12 @@ class MenuController extends FormController
 		// Import the preset selected
 		if (isset($preset) && $data['client_id'] == 1)
 		{
+			// Menu Type has not been saved yet. Make sure items get the real menutype.
+			$menutype = ApplicationHelper::stringURLSafe($data['menutype']);
+
 			try
 			{
-				MenusHelper::installPreset($preset, $data['menutype']);
+				MenusHelper::installPreset($preset, $menutype);
 
 				$this->setMessage(Text::_('COM_MENUS_PRESET_IMPORT_SUCCESS'));
 			}

--- a/administrator/components/com_menus/Helper/MenusHelper.php
+++ b/administrator/components/com_menus/Helper/MenusHelper.php
@@ -11,6 +11,7 @@ namespace Joomla\Component\Menus\Administrator\Helper;
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Application\ApplicationHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Filesystem\Folder;
 use Joomla\CMS\Helper\ContentHelper;
@@ -493,6 +494,11 @@ class MenusHelper extends ContentHelper
 			$table = Table::getInstance('Menu');
 
 			$item->alias = $menutype . '-' . $item->title;
+
+			// Temporarily set unicodeslugs if a menu item has an unicode alias
+			$unicode     = Factory::getConfig()->set('unicodeslugs', 1);
+			$item->alias = ApplicationHelper::stringURLSafe($item->alias);
+			Factory::getConfig()->set('unicodeslugs', $unicode);
 
 			if ($item->type == 'separator')
 			{


### PR DESCRIPTION
### Summary of Changes
**1_** Fix the menutype for presets menu items.
As the menutype is not saved yet when installing a preset and **if the menu type `Unique Name` created contains spaces**, the menutype assigned to the presets menu items is wrong.
To correct this error, the patch already passes it through`stringURLSafe`.

**2_** Fix installing presets menu items containing unicode aliases when unicode slugs is not set.
This happens when some menu items have been created with unicode slugs and unicode slugs is not set any more in Global Config. As done in the sample data plugins this PR temporarily set unicodeslugs ON if not done yet in Global Config.

### Testing Instructions
1. This test does not need multilingual.
Just install the Blog sample data in English.
Go to `administrator/index.php?option=com_menus&view=menus` and Filter by Administrator.
Create a new administrator menu.
Title: Custom admin menu title
Unique Name: My custom menu  // IMPORTANT: must contain spaces!
Import a Preset: choose `Preset - Joomla Main Menu` OR `Preset - Alternative Main Menu`
Save and close

Then switch to the menu items for this menu type `administrator/index.php?option=com_menus&view=items&menutype=`
Select the menutype you just created.
The menu items are not displayed.
They are displayed if you do not filter by this menu type i.e. if you let the filter to `- Select Menu -`

In PHPMyadmin, look at the menu table.
All the new menu items (Easy to find as their titles are lang constants) have `My custom menu` as menutype.
Look at the menutypes table: the new menutype is correctly `my-custom-menu`

After patching, this will be solved and items will show and displayed in the menu position by the specific module created for this Menu.

2. This test needs to install a multilingual site with at least Persian language installed.
Set Unicode Slugs to No in Global Configuration.
Install Multilingual sample Data. Some menu items for Persian will contain unicode Persian characters in their aliases.

Now create a new Menu as explained in **1. ** and save.
It will throw an error (Screenshot below the menu type I had created was `Myadminmenu`)

<img width="1455" alt="Screen Shot 2020-02-02 at 07 46 34" src="https://user-images.githubusercontent.com/869724/73726453-e046e900-472f-11ea-9766-911068416fde.png">

Delete the menu.

patch:
all will be fine. 