### PR TITLE
[RFC][4.0] Full Screen Content edit

### DIFF
--- a/administrator/components/com_content/src/Service/HTML/Icon.php
+++ b/administrator/components/com_content/src/Service/HTML/Icon.php
@@ -175,7 +175,7 @@ class Icon
 		}
 
 		$contentUrl = RouteHelper::getArticleRoute($article->slug, $article->catid, $article->language);
-		$url        = $contentUrl . '&task=article.edit&a_id=' . $article->id . '&return=' . base64_encode($uri);
+		$url        = $contentUrl . '&task=article.edit&a_id=' . $article->id . '&return=' . base64_encode($uri) . '&tmpl=component';
 
 		if ($article->state == Workflow::CONDITION_UNPUBLISHED)
 		{

--- a/layouts/joomla/edit/frontediting_modules.php
+++ b/layouts/joomla/edit/frontediting_modules.php
@@ -37,7 +37,7 @@ $editUrl = Uri::base() . 'administrator/index.php?option=com_modules&task=module
 
 if ($parameters->get('redirect_edit', 'site') === 'site')
 {
-	$editUrl = Uri::base() . 'index.php?option=com_config&view=modules&id=' . (int) $mod->id . '&Itemid=' . $itemid . $redirectUri;
+	$editUrl = Uri::base() . 'index.php?option=com_config&view=modules&id=' . (int) $mod->id . '&Itemid=' . $itemid . $redirectUri . '&tmpl=component';
 	$target  = '_self';
 }
 


### PR DESCRIPTION
This is a POC and request for feedback

### Introduction
Front end editing is a second class experience in joomla. Depending on your template the available area to edit your content can be very narrow. It is also distracting to have the rest of the site visible when trying to edit the content.

This incredibly simple pull request makes the edit form open full screen with nothing else to distract you.

When you save or cancel the edit you are correctly returned to the previous page.

It's so simple that I am wondering if I missed something obvious

### Demo video before this PR
![after](https://user-images.githubusercontent.com/1296369/73741495-40468b00-4742-11ea-999b-587a249c0be1.gif)

### Demo video with this PR
![after](https://user-images.githubusercontent.com/1296369/73741321-e9d94c80-4741-11ea-8030-3a87bb11cf27.gif)
