### PR TITLE
[4.0] Meta Description character count

### DIFF
--- a/administrator/components/com_categories/forms/category.xml
+++ b/administrator/components/com_categories/forms/category.xml
@@ -143,6 +143,8 @@
 		label="JFIELD_META_DESCRIPTION_LABEL"
 		rows="3"
 		cols="40"
+		maxlength="160"
+		charcounter="true"
 	/>
 
 	<field

--- a/administrator/components/com_config/forms/application.xml
+++ b/administrator/components/com_config/forms/application.xml
@@ -646,6 +646,8 @@
 			filter="string"
 			cols="60"
 			rows="3"
+			maxlength="160"
+			charcounter="true"
 		/>
 
 		<field
@@ -655,8 +657,6 @@
 			filter="string"
 			cols="60"
 			rows="3"
-			maxlength="160"
-			charcounter="true"
 		/>
 
 		<field

--- a/administrator/components/com_config/forms/application.xml
+++ b/administrator/components/com_config/forms/application.xml
@@ -655,6 +655,8 @@
 			filter="string"
 			cols="60"
 			rows="3"
+			maxlength="160"
+			charcounter="true"
 		/>
 
 		<field

--- a/administrator/components/com_contact/forms/contact.xml
+++ b/administrator/components/com_contact/forms/contact.xml
@@ -181,6 +181,8 @@
 			label="JFIELD_META_DESCRIPTION_LABEL"
 			rows="3"
 			cols="30"
+			maxlength="160"
+			charcounter="true"
 		/>
 
 		<field

--- a/administrator/components/com_content/forms/article.xml
+++ b/administrator/components/com_content/forms/article.xml
@@ -187,6 +187,8 @@
 			label="JFIELD_META_DESCRIPTION_LABEL"
 			rows="3"
 			cols="30"
+			maxlength="160"
+			charcounter="true"
 		/>
 
 		<field

--- a/administrator/components/com_languages/forms/language.xml
+++ b/administrator/components/com_languages/forms/language.xml
@@ -103,6 +103,8 @@
 			label="JFIELD_META_DESCRIPTION_LABEL"
 			rows="3"
 			cols="30"
+			maxlength="160"
+			charcounter="true"
 		/>
 	</fieldset>
 	<fieldset name="site_name" label="COM_LANGUAGES_FIELDSET_SITE_NAME_LABEL">

--- a/administrator/components/com_newsfeeds/forms/newsfeed.xml
+++ b/administrator/components/com_newsfeeds/forms/newsfeed.xml
@@ -228,6 +228,8 @@
 			label="JFIELD_META_DESCRIPTION_LABEL"
 			rows="3"
 			cols="30"
+			maxlength="160"
+			charcounter="true"
 		/>
 
 		<fields name="images">

--- a/administrator/components/com_tags/forms/tag.xml
+++ b/administrator/components/com_tags/forms/tag.xml
@@ -121,6 +121,8 @@
 		label="JFIELD_META_DESCRIPTION_LABEL"
 		rows="3"
 		cols="40"
+		maxlength="160"
+		charcounter="true"
 	/>
 
 	<field

--- a/administrator/language/en-GB/com_config.ini
+++ b/administrator/language/en-GB/com_config.ini
@@ -176,6 +176,8 @@ COM_CONFIG_MAIL_SETTINGS="Mail"
 COM_CONFIG_MAIL_TEST_MAIL_DESC="This mail is sent when you click the &quot;Send Test Mail&quot; button in the Global Configuration. It is sent to the sending mail address that is set in the mail settings."
 COM_CONFIG_MAIL_TEST_MAIL_TITLE="Global Configuration: Test Mail"
 COM_CONFIG_METADATA_SETTINGS="Metadata"
+; Do not translate the text between the {}
+COM_CONFIG_METADESC_COUNTER="{remaining} characters remaining of {maxlength} characters."
 COM_CONFIG_PAGE_EDIT_MAIL="Global Configuration: Edit Mail Template"
 COM_CONFIG_PERMISSION_SETTINGS="Permissions"
 COM_CONFIG_PERMISSIONS="Permissions"

--- a/administrator/language/en-GB/com_config.ini
+++ b/administrator/language/en-GB/com_config.ini
@@ -176,8 +176,6 @@ COM_CONFIG_MAIL_SETTINGS="Mail"
 COM_CONFIG_MAIL_TEST_MAIL_DESC="This mail is sent when you click the &quot;Send Test Mail&quot; button in the Global Configuration. It is sent to the sending mail address that is set in the mail settings."
 COM_CONFIG_MAIL_TEST_MAIL_TITLE="Global Configuration: Test Mail"
 COM_CONFIG_METADATA_SETTINGS="Metadata"
-; Do not translate the text between the {}
-COM_CONFIG_METADESC_COUNTER="{remaining} characters remaining of {maxlength} characters."
 COM_CONFIG_PAGE_EDIT_MAIL="Global Configuration: Edit Mail Template"
 COM_CONFIG_PERMISSION_SETTINGS="Permissions"
 COM_CONFIG_PERMISSIONS="Permissions"

--- a/administrator/language/en-GB/joomla.ini
+++ b/administrator/language/en-GB/joomla.ini
@@ -231,6 +231,8 @@ JFIELD_LOGOUT_REDIRECT_URL_DESC="If a URL is entered here, users will be redirec
 JFIELD_LOGOUT_REDIRECT_URL_LABEL="Logout Redirect"
 JFIELD_LOGOUT_REDIRECT_PAGE_DESC="Select or create the page the user will be redirected to after ending their current session by logging out. The default is to stay on the same page."
 JFIELD_LOGOUT_REDIRECT_PAGE_LABEL="Logout Redirection Page"
+; Do not translate the text between the {}
+JFIELD_META_DESCRIPTION_COUNTER="{remaining} characters remaining of {maxlength} characters."
 JFIELD_META_DESCRIPTION_DESC="An optional paragraph to be used as the description of the page in the HTML output. This will generally display in the results of search engines."
 JFIELD_META_DESCRIPTION_LABEL="Meta Description"
 JFIELD_META_KEYWORDS_DESC="An optional comma-separated list of keywords and/or phrases to be used in the HTML output."

--- a/api/language/en-GB/joomla.ini
+++ b/api/language/en-GB/joomla.ini
@@ -231,6 +231,8 @@ JFIELD_LOGOUT_REDIRECT_URL_DESC="If a URL is entered here, users will be redirec
 JFIELD_LOGOUT_REDIRECT_URL_LABEL="Logout Redirect"
 JFIELD_LOGOUT_REDIRECT_PAGE_DESC="Select or create the page the user will be redirected to after ending their current session by logging out. The default is to stay on the same page."
 JFIELD_LOGOUT_REDIRECT_PAGE_LABEL="Logout Redirection Page"
+; Do not translate the text between the {}
+JFIELD_META_DESCRIPTION_COUNTER="{remaining} characters remaining of {maxlength} characters."
 JFIELD_META_DESCRIPTION_DESC="An optional paragraph to be used as the description of the page in the HTML output. This will generally display in the results of search engines."
 JFIELD_META_DESCRIPTION_LABEL="Meta Description"
 JFIELD_META_KEYWORDS_DESC="An optional comma-separated list of keywords and/or phrases to be used in the HTML output."

--- a/build/build-modules-js/init.es6.js
+++ b/build/build-modules-js/init.es6.js
@@ -272,16 +272,14 @@ const copyFiles = (options) => {
     // Add provided Assets to a registry, if any
     if (vendor.provideAssets && vendor.provideAssets.length) {
       vendor.provideAssets.forEach((assetInfo) => {
-        const registryItem = {
+        const registryItemBase = {
           package: packageName,
           name: assetInfo.name || vendorName,
           version: moduleOptions.version,
           type: assetInfo.type,
         };
 
-        if (assetInfo.dependencies && assetInfo.dependencies.length) {
-          registryItem.dependencies = assetInfo.dependencies;
-        }
+        const registryItem = Object.assign(assetInfo, registryItemBase);
 
         // Update path to file
         if (assetInfo.uri && (assetInfo.type === 'script' || assetInfo.type === 'style' || assetInfo.type === 'webcomponent')) {

--- a/build/build-modules-js/init.es6.js
+++ b/build/build-modules-js/init.es6.js
@@ -259,6 +259,16 @@ const copyFiles = (options) => {
       Fs.writeFileSync(chosenPath, ChosenJs, { encoding: 'UTF-8' });
     }
 
+    // Append initialising code to the end of the Short-and-Sweet javascript
+    if (packageName === 'short-and-sweet') {
+      const dest = Path.join(mediaVendorPath, vendorName);
+      const shortandsweetPath = `${dest}/${options.settings.vendors[packageName].js['dist/short-and-sweet.min.js']}`;
+      let ShortandsweetJs = Fs.readFileSync(shortandsweetPath, { encoding: 'UTF-8' });
+      ShortandsweetJs = ShortandsweetJs.concat(`document.addEventListener('DOMContentLoaded', function()`
+          + `{shortAndSweet('textarea.charcount', {counterClassName: 'small text-muted'}); });`);
+      Fs.writeFileSync(shortandsweetPath, ShortandsweetJs, { encoding: 'UTF-8' });
+    }
+
     // Add provided Assets to a registry, if any
     if (vendor.provideAssets && vendor.provideAssets.length) {
       vendor.provideAssets.forEach((assetInfo) => {

--- a/build/build-modules-js/init.es6.js
+++ b/build/build-modules-js/init.es6.js
@@ -264,8 +264,8 @@ const copyFiles = (options) => {
       const dest = Path.join(mediaVendorPath, vendorName);
       const shortandsweetPath = `${dest}/${options.settings.vendors[packageName].js['dist/short-and-sweet.min.js']}`;
       let ShortandsweetJs = Fs.readFileSync(shortandsweetPath, { encoding: 'UTF-8' });
-      ShortandsweetJs = ShortandsweetJs.concat(`document.addEventListener('DOMContentLoaded', function()`
-          + `{shortAndSweet('textarea.charcount', {counterClassName: 'small text-muted'}); });`);
+      ShortandsweetJs = ShortandsweetJs.concat('document.addEventListener(\'DOMContentLoaded\', function()'
+          + '{shortAndSweet(\'textarea.charcount\', {counterClassName: \'small text-muted\'}); });');
       Fs.writeFileSync(shortandsweetPath, ShortandsweetJs, { encoding: 'UTF-8' });
     }
 

--- a/build/build-modules-js/settings.json
+++ b/build/build-modules-js/settings.json
@@ -499,14 +499,7 @@
         "licenseFilename": "LICENSE",
         "js": {
           "dist/short-and-sweet.min.js": "js/short-and-sweet.min.js"
-        },
-        "provideAssets": [
-          {
-            "name": "short-and-sweet",
-            "type": "script",
-            "uri": ["short-and-sweet.min.js"]
-          }
-        ]
+        }
       },
       "skipto": {
         "name": "skipto",

--- a/build/build-modules-js/settings.json
+++ b/build/build-modules-js/settings.json
@@ -499,7 +499,17 @@
         "licenseFilename": "LICENSE",
         "js": {
           "dist/short-and-sweet.min.js": "js/short-and-sweet.min.js"
-        }
+        },
+        "provideAssets": [
+          {
+            "name": "short-and-sweet",
+            "type": "script",
+            "uri": "short-and-sweet.min.js",
+            "attributes": {
+              "defer": true
+            }
+          }
+        ]
       },
       "skipto": {
         "name": "skipto",

--- a/build/build-modules-js/settings.json
+++ b/build/build-modules-js/settings.json
@@ -493,7 +493,7 @@
           "dist/metismenujs.min.js": "js/metismenujs.min.js",
           "dist/metismenujs.min.js.map": "js/metismenujs.min.js.map"
         }
-			},
+      },
       "short-and-sweet": {
         "name": "short-and-sweet",
         "licenseFilename": "LICENSE",

--- a/build/build-modules-js/settings.json
+++ b/build/build-modules-js/settings.json
@@ -502,8 +502,9 @@
         },
         "provideAssets": [
           {
-            "name": null,
-            "js": ["short-and-sweet.min.js"]
+            "name": "short-and-sweet",
+            "type": "script",
+            "uri": ["short-and-sweet.min.js"]
           }
         ]
       },

--- a/build/build-modules-js/settings.json
+++ b/build/build-modules-js/settings.json
@@ -493,6 +493,19 @@
           "dist/metismenujs.min.js": "js/metismenujs.min.js",
           "dist/metismenujs.min.js.map": "js/metismenujs.min.js.map"
         }
+			},
+      "short-and-sweet": {
+        "name": "short-and-sweet",
+        "licenseFilename": "LICENSE",
+        "js": {
+          "dist/short-and-sweet.min.js": "js/short-and-sweet.min.js"
+        },
+        "provideAssets": [
+          {
+            "name": null,
+            "js": ["short-and-sweet.min.js"]
+          }
+        ]
       },
       "skipto": {
         "name": "skipto",

--- a/components/com_config/forms/config.xml
+++ b/components/com_config/forms/config.xml
@@ -10,6 +10,8 @@
 			filter="string"
 			cols="60"
 			rows="3"
+			maxlength="160"
+			charcounter="true"
 		/>
 
 		<field

--- a/components/com_content/forms/article.xml
+++ b/components/com_content/forms/article.xml
@@ -80,7 +80,7 @@
 			translateformat="true"
 			showtime="true"
 			size="22"
-			filter="user_utc" 
+			filter="user_utc"
 			showon="featured:1"
 		/>
 
@@ -91,7 +91,7 @@
 			translateformat="true"
 			showtime="true"
 			size="22"
-			filter="user_utc" 
+			filter="user_utc"
 			showon="featured:1"
 		/>
 
@@ -197,6 +197,8 @@
 			id="metadesc"
 			rows="5"
 			cols="50"
+			maxlength="160"
+			charcounter="true"
 		/>
 
 		<field

--- a/language/en-GB/joomla.ini
+++ b/language/en-GB/joomla.ini
@@ -177,6 +177,8 @@ JFIELD_COLOR_VALUE="Colour with hexadecimal value of"
 JFIELD_FIELDS_CATEGORY_DESC="Select the category that this field is assigned to."
 JFIELD_LANGUAGE_DESC="Assign a language to this article."
 JFIELD_LANGUAGE_LABEL="Language"
+; Do not translate the text between the {}
+JFIELD_META_DESCRIPTION_COUNTER="{remaining} characters remaining of {maxlength} characters."
 JFIELD_META_DESCRIPTION_DESC="Metadata description."
 JFIELD_META_DESCRIPTION_LABEL="Meta Description"
 JFIELD_META_KEYWORDS_DESC="Keywords describing the content."

--- a/layouts/joomla/form/field/textarea.php
+++ b/layouts/joomla/form/field/textarea.php
@@ -10,7 +10,6 @@
 defined('JPATH_BASE') or die;
 
 use Joomla\CMS\Factory;
-use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
 extract($displayData);
@@ -53,11 +52,14 @@ extract($displayData);
 if ($charcounter)
 {
 	// Load the js file
-	HTMLHelper::_('script', 'vendor/short-and-sweet/short-and-sweet.js', ['version' => 'auto', 'relative' => true], ['defer' => true]);
+	/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+	$wa = Factory::getApplication()->getDocument()->getWebAssetManager();
+	$wa->useScript('short-and-sweet');
+
 	// Set the css class to be used as the trigger
 	$charcounter = ' charcount';
 	// Set the text
-	$counterlabel = 'data-counter-label="' . Text::_('JFIELD_META_DESCRIPTION_COUNTER') . '"';
+	$counterlabel = 'data-counter-label="' . $this->escape(Text::_('JFIELD_META_DESCRIPTION_COUNTER')) . '"';
 }
 
 $attributes = array(

--- a/layouts/joomla/form/field/textarea.php
+++ b/layouts/joomla/form/field/textarea.php
@@ -57,7 +57,7 @@ if ($charcounter)
 	// Set the css class to be used as the trigger
 	$charcounter = ' charcount';
 	// Set the text
-	$counterlabel = 'data-counter-label="' . Text::_('COM_CONFIG_METADESC_COUNTER') . '"';
+	$counterlabel = 'data-counter-label="' . Text::_('JFIELD_META_DESCRIPTION_COUNTER') . '"';
 }
 
 $attributes = array(

--- a/layouts/joomla/form/field/textarea.php
+++ b/layouts/joomla/form/field/textarea.php
@@ -9,6 +9,9 @@
 
 defined('JPATH_BASE') or die;
 
+use Joomla\CMS\Factory;
+use Joomla\CMS\Language\Text;
+
 extract($displayData);
 
 /**
@@ -42,12 +45,23 @@ extract($displayData);
  * @var   array    $options         Options available for this field.
  * @var   array    $inputType       Options available for this field.
  * @var   string   $accept          File types that are accepted.
+ * @var   boolean  $charcounter     Does this field support a character counter?
  */
 
+ // Initialize some field attributes.
+if ($charcounter)
+{
+	// Load the js file
+	Factory::getDocument()->getWebAssetManager()->enableAsset('short-and-sweet');
+	// Set the css class to be used as the trigger
+	$charcounter = 'charcount';
+	// Set the text
+	$counterlabel = 'data-counter-label="' . Text::_('COM_CONFIG_METADESC_COUNTER') . '"';
+}
 $attributes = array(
 	$columns ?: '',
 	$rows ?: '',
-	!empty($class) ? 'class="form-control ' . $class . '"' : 'class="form-control"',
+	!empty($class) ? 'class="form-control ' . $class . $charcounter . '"' : 'class="form-control ' . $charcounter . '"',
 	!empty($description) ? 'aria-describedby="' . $name . '-desc"' : '',
 	strlen($hint) ? 'placeholder="' . htmlspecialchars($hint, ENT_COMPAT, 'UTF-8') . '"' : '',
 	$disabled ? 'disabled' : '',
@@ -58,7 +72,8 @@ $attributes = array(
 	!empty($autocomplete) ? 'autocomplete="' . $autocomplete . '"' : '',
 	$autofocus ? 'autofocus' : '',
 	$spellcheck ? '' : 'spellcheck="false"',
-	$maxlength ? $maxlength: ''
+	$maxlength ? $maxlength: '',
+	!empty($counterlabel) ? $counterlabel : ''
 );
 ?>
 <textarea name="<?php

--- a/layouts/joomla/form/field/textarea.php
+++ b/layouts/joomla/form/field/textarea.php
@@ -10,6 +10,7 @@
 defined('JPATH_BASE') or die;
 
 use Joomla\CMS\Factory;
+use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
 extract($displayData);
@@ -52,9 +53,9 @@ extract($displayData);
 if ($charcounter)
 {
 	// Load the js file
-	Factory::getDocument()->getWebAssetManager()->enableAsset('short-and-sweet');
+	HTMLHelper::_('script', 'vendor/short-and-sweet/short-and-sweet.js', ['version' => 'auto', 'relative' => true], ['defer' => true]);
 	// Set the css class to be used as the trigger
-	$charcounter = 'charcount';
+	$charcounter = ' charcount';
 	// Set the text
 	$counterlabel = 'data-counter-label="' . Text::_('COM_CONFIG_METADESC_COUNTER') . '"';
 }

--- a/layouts/joomla/form/field/textarea.php
+++ b/layouts/joomla/form/field/textarea.php
@@ -59,6 +59,7 @@ if ($charcounter)
 	// Set the text
 	$counterlabel = 'data-counter-label="' . Text::_('COM_CONFIG_METADESC_COUNTER') . '"';
 }
+
 $attributes = array(
 	$columns ?: '',
 	$rows ?: '',

--- a/layouts/joomla/form/field/textarea.php
+++ b/layouts/joomla/form/field/textarea.php
@@ -74,7 +74,7 @@ $attributes = array(
 	!empty($autocomplete) ? 'autocomplete="' . $autocomplete . '"' : '',
 	$autofocus ? 'autofocus' : '',
 	$spellcheck ? '' : 'spellcheck="false"',
-	$maxlength ? $maxlength: '',
+	$maxlength ?: '',
 	!empty($counterlabel) ? $counterlabel : ''
 );
 ?>

--- a/layouts/joomla/form/field/textarea.php
+++ b/layouts/joomla/form/field/textarea.php
@@ -62,7 +62,7 @@ if ($charcounter)
 $attributes = array(
 	$columns ?: '',
 	$rows ?: '',
-	!empty($class) ? 'class="form-control ' . $class . $charcounter . '"' : 'class="form-control ' . $charcounter . '"',
+	!empty($class) ? 'class="form-control ' . $class . $charcounter . '"' : 'class="form-control' . $charcounter . '"',
 	!empty($description) ? 'aria-describedby="' . $name . '-desc"' : '',
 	strlen($hint) ? 'placeholder="' . htmlspecialchars($hint, ENT_COMPAT, 'UTF-8') . '"' : '',
 	$disabled ? 'disabled' : '',

--- a/libraries/src/Form/Field/TextareaField.php
+++ b/libraries/src/Form/Field/TextareaField.php
@@ -54,6 +54,14 @@ class TextareaField extends FormField
 	protected $maxlength;
 
 	/**
+	 * Does this field support a character counter?
+	 *
+	 * @var    boolean
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $charcounter = false;
+
+	/**
 	 * Name of the layout being used to render the field
 	 *
 	 * @var    string
@@ -77,6 +85,7 @@ class TextareaField extends FormField
 			case 'rows':
 			case 'columns':
 			case 'maxlength':
+			case 'charcounter':
 				return $this->$name;
 		}
 
@@ -101,6 +110,10 @@ class TextareaField extends FormField
 			case 'columns':
 			case 'maxlength':
 				$this->$name = (int) $value;
+				break;
+
+			case 'charcounter':
+				$this->charcounter = strtolower($value) === 'true';
 				break;
 
 			default:
@@ -128,9 +141,10 @@ class TextareaField extends FormField
 
 		if ($return)
 		{
-			$this->rows      = isset($this->element['rows']) ? (int) $this->element['rows'] : false;
-			$this->columns   = isset($this->element['cols']) ? (int) $this->element['cols'] : false;
-			$this->maxlength = isset($this->element['maxlength']) ? (int) $this->element['maxlength'] : false;
+			$this->rows        = isset($this->element['rows']) ? (int) $this->element['rows'] : false;
+			$this->columns     = isset($this->element['cols']) ? (int) $this->element['cols'] : false;
+			$this->maxlength   = isset($this->element['maxlength']) ? (int) $this->element['maxlength'] : false;
+			$this->charcounter = isset($this->element['charcounter']) ? strtolower($this->element['charcounter']) === 'true' : false;
 		}
 
 		return $return;
@@ -169,7 +183,8 @@ class TextareaField extends FormField
 		$extraData = array(
 			'maxlength'    => $maxlength,
 			'rows'         => $rows,
-			'columns'      => $columns
+			'columns'      => $columns,
+			'charcounter'  => $this->charcounter
 		);
 
 		return array_merge($data, $extraData);

--- a/package-lock.json
+++ b/package-lock.json
@@ -7037,6 +7037,11 @@
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
     },
+    "short-and-sweet": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/short-and-sweet/-/short-and-sweet-1.0.2.tgz",
+      "integrity": "sha512-uGGsxoTZvFHlrWo9OySSiK2og6qgSYkXLfcgziA5OvHBtsCsU+Yi7mnxN3KOEytYPzC0RyiWv+iZg/zzAqU6YA=="
+    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "punycode": "1.4.1",
     "qrcode-generator": "^1.4.3",
     "roboto-fontface": "^0.10.0",
+    "short-and-sweet": "^1.0.2",
     "skipto": "^2.0.4",
     "tinymce": "5.0.14"
   },


### PR DESCRIPTION
redo of #25262 and #27359

A request was made to have a character count when entering a meta description.  I have done this and applied it to the Site Meta Description in the global configuration as shown in the screenshot and all the meta description fields)

![image](https://user-images.githubusercontent.com/1296369/71545212-84df4980-2980-11ea-8091-e0e99934bf17.png)


This can be applied to any textarea field by adding `charcounter="true"` to the field definition in the xml.

The character count has a default maximum of 200 characters but this can be configured in the field xml by adding `maxlength="160"` 

Accessibility is obviously very important and this PR addresses this as well. The meta description text is announced when the user focuses on the input together with the string to indicate the characters used. Obviously a live count announced by the screenreader would be distracting so it waits 2000 milliseconds before updating the user with the screen reader user with the current count.

The string `86 characters remaining of 160 characters.` is a regular joomla language string except the numbers are replaced  by the script. In this example I chose
`"{remaining} characters remaining of {maxlength} characters."`. Available placeholders are {remaining}, {maxlength}, {length}

### Documentation
Needs updating to document the new charcounter option