### PR TITLE
[4.0]  Reorder fields, remove duplicate fields for caching

### DIFF
--- a/administrator/components/com_config/forms/application.xml
+++ b/administrator/components/com_config/forms/application.xml
@@ -5,6 +5,18 @@
 		label="COM_CONFIG_CACHE_SETTINGS_LABEL">
 
 		<field
+			name="caching"
+			type="list"
+			label="COM_CONFIG_FIELD_CACHE_LABEL"
+			default="2"
+			filter="integer"
+			>
+			<option value="0">COM_CONFIG_FIELD_VALUE_CACHE_OFF</option>
+			<option value="1">COM_CONFIG_FIELD_VALUE_CACHE_CONSERVATIVE</option>
+			<option value="2">COM_CONFIG_FIELD_VALUE_CACHE_PROGRESSIVE</option>
+		</field>
+		
+		<field
 			name="cache_handler"
 			type="cachehandler"
 			label="COM_CONFIG_FIELD_CACHE_HANDLER_LABEL"
@@ -41,9 +53,9 @@
 			name="cache_path"
 			type="text"
 			label="COM_CONFIG_FIELD_CACHE_PATH_LABEL"
-			showon="cache_handler:file"
 			filter="path"
 			size="50"
+			showon="cache_handler:file[AND]caching:1,2"
 		/>
 
 		<field
@@ -147,40 +159,6 @@
 			filter="integer"
 			showon="cache_handler:redis"
 		/>
-
-		<field
-			name="cachetime"
-			type="number"
-			label="COM_CONFIG_FIELD_CACHE_TIME_LABEL"
-			min="1"
-			default="15"
-			filter="integer"
-			validate="number"
-		/>
-
-		<field
-			name="cache_platformprefix"
-			type="radio"
-			label="COM_CONFIG_FIELD_CACHE_PLATFORMPREFIX_LABEL"
-			class="switcher"
-			default="0"
-			filter="boolean"
-			>
-			<option value="0">JNO</option>
-			<option value="1">JYES</option>
-		</field>
-
-		<field
-			name="caching"
-			type="list"
-			label="COM_CONFIG_FIELD_CACHE_LABEL"
-			default="2"
-			filter="integer"
-			>
-			<option value="0">COM_CONFIG_FIELD_VALUE_CACHE_OFF</option>
-			<option value="1">COM_CONFIG_FIELD_VALUE_CACHE_CONSERVATIVE</option>
-			<option value="2">COM_CONFIG_FIELD_VALUE_CACHE_PROGRESSIVE</option>
-		</field>
 
 	</fieldset>
 


### PR DESCRIPTION
### Summary of Changes
Global configuration has a fieldset cache. This field set is confusing. 
If the cache is off, there are fields to be filled and two of them are twice in the xml file.
If cache is set on, there appears a new input field on top of the fieldset.
The field for path is always visible, due to it's showon which is always true, also if caching is off.

I have made changes as I think it makes sense. This requires a review by system specialists,.

### Testing Instructions
Look at the field set cache, set the caching on and of.

### Expected result
After patch

![cache-imaybe](https://user-images.githubusercontent.com/1035262/73795644-6bb19000-47ab-11ea-94f6-aaa2d3bc8223.JPG)

### Actual result
![cache-is](https://user-images.githubusercontent.com/1035262/73795602-52104880-47ab-11ea-9fb8-de813ff7b437.JPG)


### Documentation Changes Required
yes
