### PR TITLE
[4.0] fix error of styling issue with save and close button

### DIFF
--- a/administrator/templates/atum/scss/blocks/_toolbar.scss
+++ b/administrator/templates/atum/scss/blocks/_toolbar.scss
@@ -477,7 +477,7 @@ joomla-toolbar-button {
       width:100%
     }
     .dropdown-toggle-split{
-      width:11%
+      width:auto
     }
 
     .btn {

--- a/administrator/templates/atum/scss/blocks/_toolbar.scss
+++ b/administrator/templates/atum/scss/blocks/_toolbar.scss
@@ -474,10 +474,10 @@ joomla-toolbar-button {
     joomla-toolbar-button,
     .btn-group,
     .btn {
-      width:100%
+      width: 100%;
     }
-    .dropdown-toggle-split{
-      width:auto
+    .dropdown-toggle-split {
+      width: auto;
     }
 
     .btn {

--- a/administrator/templates/atum/scss/blocks/_toolbar.scss
+++ b/administrator/templates/atum/scss/blocks/_toolbar.scss
@@ -476,7 +476,7 @@ joomla-toolbar-button {
     .btn {
       width:100%
     }
-    .dropdown-toggle{
+    .dropdown-toggle-split{
       width:11%
     }
 

--- a/administrator/templates/atum/scss/blocks/_toolbar.scss
+++ b/administrator/templates/atum/scss/blocks/_toolbar.scss
@@ -474,7 +474,6 @@ joomla-toolbar-button {
     joomla-toolbar-button,
     .btn-group,
     .btn {
-      width: 100%;
     }
 
     .btn {

--- a/administrator/templates/atum/scss/blocks/_toolbar.scss
+++ b/administrator/templates/atum/scss/blocks/_toolbar.scss
@@ -474,6 +474,10 @@ joomla-toolbar-button {
     joomla-toolbar-button,
     .btn-group,
     .btn {
+      width:100%
+    }
+    .dropdown-toggle{
+      width:11%
     }
 
     .btn {

--- a/administrator/templates/atum/scss/blocks/_toolbar.scss
+++ b/administrator/templates/atum/scss/blocks/_toolbar.scss
@@ -370,7 +370,7 @@ joomla-toolbar-button {
 
       @include media-breakpoint-down(sm) {
         [dir=rtl] & {
-          margin-left: 0.75rem;
+          margin-left: 0.75rem !important;
           margin-right: 0 !important;
         }
       }

--- a/administrator/templates/atum/scss/template-rtl.scss
+++ b/administrator/templates/atum/scss/template-rtl.scss
@@ -112,10 +112,6 @@ body {
     }
   }
 
-  .btn-group {
-    
-  }
-
   .btn-toolbar > * {
     margin-right: .75rem;
     margin-left: 0;

--- a/administrator/templates/atum/scss/template-rtl.scss
+++ b/administrator/templates/atum/scss/template-rtl.scss
@@ -113,7 +113,7 @@ body {
   }
 
   .btn-group {
-    margin-left: .75rem !important;
+    
   }
 
   .btn-toolbar > * {


### PR DESCRIPTION
Pull Request for Issue #26771 

### Summary of Changes

Fixed styling issue with Save & Close button on mobile on article page

### Testing Instructions


### Expected result
The content in  "Save and Close" button should be aligned properly.


### Actual result
![Screenshot from 2020-02-05 18-24-09](https://user-images.githubusercontent.com/43785080/73850132-234cad80-4851-11ea-8d4f-ebee973be1e4.png)



### Documentation Changes Required

