### PR TITLE
[4.0] Display units for size and dimensions in com_media

### DIFF
--- a/administrator/components/com_media/resources/scripts/components/browser/items/row.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/row.vue
@@ -6,7 +6,7 @@
             {{ item.name }}
         </th>
         <td class="size">
-            {{ item.size }}
+            {{ size }}
         </td>
         <td class="dimension">
             {{ dimension }}
@@ -34,11 +34,18 @@
                 if (!this.item.width) {
                     return '';
                 }
-                return `${this.item.width} x ${this.item.height}`;
+                return `${this.item.width}px * ${this.item.height}px`;
             },
             isDir() {
                 return (this.item.type === 'dir');
-            }
+            },
+			/* The size of a file in KB */
+			size() {
+				if (!this.item.size) {
+					return '';
+				}
+				return `${(this.item.size / 1024).toFixed(2)} KB`;
+			},
         },
 
         methods: {

--- a/administrator/components/com_media/resources/scripts/components/browser/items/row.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/row.vue
@@ -39,13 +39,13 @@
             isDir() {
                 return (this.item.type === 'dir');
             },
-			/* The size of a file in KB */
-			size() {
-				if (!this.item.size) {
-					return '';
-				}
-				return `${(this.item.size / 1024).toFixed(2)} KB`;
-			},
+            /* The size of a file in KB */
+            size() {
+                if (!this.item.size) {
+                    return '';
+                }
+                return `${(this.item.size / 1024).toFixed(2)} KB`;
+            },
         },
 
         methods: {

--- a/administrator/components/com_media/resources/scripts/components/infobar/infobar.vue
+++ b/administrator/components/com_media/resources/scripts/components/infobar/infobar.vue
@@ -21,11 +21,12 @@
                 <dd>{{ item.modified_date_formatted }}</dd>
 
                 <dt>{{ translate('COM_MEDIA_MEDIA_DIMENSION') }}</dt>
-                <dd v-if="item.width || item.height">{{ item.width }} x {{ item.height}}</dd>
+                <dd v-if="item.width || item.height">{{ item.width }}px * {{ item.height}}px</dd>
                 <dd v-else>-</dd>
 
                 <dt>{{ translate('COM_MEDIA_MEDIA_SIZE') }}</dt>
-                <dd>{{ item.size || '-' }}</dd>
+                <dd v-if="item.size">{{ (item.size / 1024).toFixed(2) }} KB</dd>
+				<dd v-else>-</dd>
 
                 <dt>{{ translate('COM_MEDIA_MEDIA_MIME_TYPE') }}</dt>
                 <dd>{{ item.mime_type }}</dd>

--- a/administrator/components/com_media/resources/scripts/components/infobar/infobar.vue
+++ b/administrator/components/com_media/resources/scripts/components/infobar/infobar.vue
@@ -21,7 +21,7 @@
                 <dd>{{ item.modified_date_formatted }}</dd>
 
                 <dt>{{ translate('COM_MEDIA_MEDIA_DIMENSION') }}</dt>
-                <dd v-if="item.width || item.height">{{ item.width }}px * {{ item.height}}px</dd>
+                <dd v-if="item.width || item.height">{{ item.width }}px * {{ item.height }}px</dd>
                 <dd v-else>-</dd>
 
                 <dt>{{ translate('COM_MEDIA_MEDIA_SIZE') }}</dt>

--- a/administrator/components/com_media/resources/scripts/components/infobar/infobar.vue
+++ b/administrator/components/com_media/resources/scripts/components/infobar/infobar.vue
@@ -26,7 +26,7 @@
 
                 <dt>{{ translate('COM_MEDIA_MEDIA_SIZE') }}</dt>
                 <dd v-if="item.size">{{ (item.size / 1024).toFixed(2) }} KB</dd>
-				<dd v-else>-</dd>
+                <dd v-else>-</dd>
 
                 <dt>{{ translate('COM_MEDIA_MEDIA_MIME_TYPE') }}</dt>
                 <dd>{{ item.mime_type }}</dd>

--- a/administrator/components/com_media/resources/styles/components/_media-browser.scss
+++ b/administrator/components/com_media/resources/styles/components/_media-browser.scss
@@ -297,6 +297,7 @@
   }
   .size {
     width: 15%;
+    text-align: right;
   }
   .dimension {
     width: 15%;


### PR DESCRIPTION
PR for #26696

1. Displays the dimension as 123px * 321px instead of 123 x 321
2. Displays the size in KB not bytes and right align in the list

as this is js dont forget to do `npm i`

### Before
![image](https://user-images.githubusercontent.com/1296369/73888835-46ce2300-4866-11ea-8362-d3392d8c808b.png)

### After 
![image](https://user-images.githubusercontent.com/1296369/73888679-fbb41000-4865-11ea-81c4-020d7c577afc.png)
![image](https://user-images.githubusercontent.com/1296369/73888733-0e2e4980-4866-11ea-91c9-d76f9a45a430.png)
