### PR TITLE
[4.0] Newsfeed Definition List

### DIFF
--- a/components/com_newsfeeds/tmpl/category/default_children.php
+++ b/components/com_newsfeeds/tmpl/category/default_children.php
@@ -33,14 +33,10 @@ defined('_JEXEC') or die;
 						<?php endif; ?>
 					<?php endif; ?>
 					<?php if ($this->params->get('show_cat_items') == 1) : ?>
-						<dl class="newsfeed-count">
-							<dt>
-								<?php echo Text::_('COM_NEWSFEEDS_CAT_NUM'); ?>
-							</dt>
-							<dd>
-								<?php echo $child->numitems; ?>
-							</dd>
-						</dl>
+						<span class="badge badge-info">
+							<?php echo Text::_('COM_NEWSFEEDS_CAT_NUM'); ?>&nbsp;
+							<?php echo $child->numitems; ?>
+						</span>
 					<?php endif; ?>
 					<?php if (count($child->getChildren()) > 0) : ?>
 						<?php $this->children[$child->id] = $child->getChildren(); ?>


### PR DESCRIPTION
The child count of items is using a definition list. This is completely the wrong markup to use as a number is not the description of the term in this use.

This PR changes it to a span **exactly** the same as every other use of show_cat_items
