### PR TITLE
[4.0]  Remove header SVG curve in error page

### DIFF
--- a/templates/cassiopeia/error.php
+++ b/templates/cassiopeia/error.php
@@ -107,13 +107,6 @@ $this->setMetaData('viewport', 'width=device-width, initial-scale=1');
 			<jdoc:include type="modules" name="banner" style="xhtml" />
 		</div>
 		<?php endif; ?>
-		<div class="header-shadow"></div>
-		<div class="header-shape-bottom">
-			<canvas width="736" height="15"></canvas>
-			<svg class="" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 736 15">
-				<path d="M1040,301V285s-75,12-214,12-284-26-524,0v4Z" transform="translate(-302 -285)" fill="#fafafa"/>
-			</svg>
-		</div>
 	</header>
 
 	<?php if ($this->countModules('top-a')) : ?>


### PR DESCRIPTION
As the SVG curve has been removed from the template it should be removed from the error page as well.

## Steps to reproduce the issue
Go to the front end
Go to a nonexistent page
See error page with curve in header

## Apply PR
Go to the front end
Go to a nonexistent page
See error page with NO curve in header

Pull Request for Issue #27709