### PR TITLE
[4.0] Menutype Filters

### DIFF
--- a/administrator/components/com_menus/forms/filter_items.xml
+++ b/administrator/components/com_menus/forms/filter_items.xml
@@ -5,7 +5,7 @@
 		type="list"
 		label="JSITEADMIN"
 		filtermode="selector"
-		onchange="this.form.submit();"
+		onchange="Joomla.resetFilters(this)"
 		>
 		<option value="0">JSITE</option>
 		<option value="1">JADMINISTRATOR</option>

--- a/administrator/components/com_menus/forms/filter_itemsadmin.xml
+++ b/administrator/components/com_menus/forms/filter_itemsadmin.xml
@@ -5,7 +5,7 @@
 		type="list"
 		label="JSITEADMIN"
 		filtermode="selector"
-		onchange="this.form.submit();"
+		onchange="Joomla.resetFilters(this)"
 		>
 		<option value="0">JSITE</option>
 		<option value="1">JADMINISTRATOR</option>


### PR DESCRIPTION
### Steps to reproduce the issue
Create an admin menu
Create at least one item in the new admin menu
Select any menu (site or admin)
Try to change the Site/Admin filter

### Expected result
List of menu items changes

### Actual result
Nothing happens. Unless you deselect the Menu filter as well

### Apply This PR
When you switch between Site and Administrator the menu filter is reset

Pull Request for Issue #27447
