### PR TITLE
[4.0] minicolors

### DIFF
--- a/administrator/templates/atum/scss/template.scss
+++ b/administrator/templates/atum/scss/template.scss
@@ -13,8 +13,10 @@
 // Fonts
 @import "../../../../media/vendor/roboto-fontface/scss/roboto/sass/roboto-fontface";
 
-
 @import "blocks/global"; // Leave this first
+
+// jQuery Minicolors
+@import "../../../../build/media_source/system/scss/jquery-minicolors";
 
 // Vendor overrides
 @import "vendor/bootstrap/badge";

--- a/build/media_source/system/scss/_jquery-minicolors.scss
+++ b/build/media_source/system/scss/_jquery-minicolors.scss
@@ -1,8 +1,12 @@
 // Overrides for jQuery Minicolors
 
-.minicolors-theme-bootstrap .minicolors-swatch {
+.minicolors-theme-bootstrap .minicolors-swatch>.minicolors-sprite {
   top: 50%;
   left: 8px;
   border-radius: 0;
   transform: translateY(-50%);
+}
+
+span.minicolors-swatch-color {
+  cursor: pointer;
 }


### PR DESCRIPTION
This PR ensures that the position of the colorpicker is positioned correctly by increasing the specificity of the css AND making sure it is actually imported. It also ensures that the pointer is used and not the I-beam

PR for #27538
npm -i as it is a css change

Further details in the report #27538 