### PR TITLE
[4.0]fix change undefined $cspValue to $row in method compileAutomaticCspH…

### DIFF
--- a/plugins/system/httpheaders/httpheaders.php
+++ b/plugins/system/httpheaders/httpheaders.php
@@ -409,13 +409,13 @@ class PlgSystemHttpHeaders extends CMSPlugin implements SubscriberInterface
 			}
 
 			// Append the script hashes placeholder
-			if ($scriptHashesEnabled && strpos($cspValue->directive, 'script-src') === 0)
+			if ($scriptHashesEnabled && strpos($row->directive, 'script-src') === 0)
 			{
 				$cspHeaderValue = '{script-hashes} ' . $cspHeaderValue;
 			}
 
 			// Append the style hashes placeholder
-			if ($styleHashesEnabled && strpos($cspValue->directive, 'style-src') === 0)
+			if ($styleHashesEnabled && strpos($row->directive, 'style-src') === 0)
 			{
 				$cspHeaderValue = '{style-hashes} ' . $cspHeaderValue;
 			}


### PR DESCRIPTION
This PR solves the problem of an undefined variable $cspValue copied from the method setCspHeader to compileAutomaticCspHeaderRules.