### PR TITLE
[4.0] Fix Mobile toolbar and filters alignment RTL and LTR

### DIFF
--- a/administrator/templates/atum/scss/blocks/_toolbar.scss
+++ b/administrator/templates/atum/scss/blocks/_toolbar.scss
@@ -385,9 +385,17 @@ joomla-toolbar-button {
         }
       }
     }
+
+    @include media-breakpoint-down(xs) {
+      [dir=ltr] & {
+        margin-right: 0 !important;
+      }
+
+      [dir=rtl] & {
+        margin-left: 0 !important;
+      }
+    }
   }
-
-
 }
 
 .js-stools {
@@ -416,7 +424,7 @@ joomla-toolbar-button {
     }
 
     .ordering-select {
-      margin-right: .5rem;
+      margin-right: 0;
 
       @include media-breakpoint-down(sm) {
         [dir=rtl] & {

--- a/administrator/templates/atum/scss/system/searchtools/searchtools.scss
+++ b/administrator/templates/atum/scss/system/searchtools/searchtools.scss
@@ -141,7 +141,9 @@
       }
 
       @include media-breakpoint-down(xs) {
-        margin-right: .5rem;
+        [dir=ltr] & {
+          margin-right: 0;
+        }
 
         [dir=rtl] & {
           margin-left: 0;
@@ -171,7 +173,6 @@
       }
 
       [dir=rtl] & {
-        //margin-right: 0;
         margin-left: 0;
       }
     }
@@ -180,14 +181,6 @@
       @include media-breakpoint-down(sm) {
         max-width: 100%;
         margin-right: 0;
-
-        [dir=rtl] & {
-          margin-right: 0;
-        }
-      }
-
-      @include media-breakpoint-down(xs) {
-        margin-right: .5rem;
 
         [dir=rtl] & {
           margin-right: 0;
@@ -256,6 +249,10 @@
         }
 
         @include media-breakpoint-down(sm) {
+          [dir=ltr] & {
+            margin-right: 0 !important;
+          }
+
           [dir=rtl] & {
             margin-left: 0 !important;
           }


### PR DESCRIPTION
See parts here https://github.com/joomla/joomla-cms/pull/27816#issuecomment-583031406

### Summary of Changes
As title says.


### Testing Instructions
Install Persian language.
Reduce window width to mobile view
Switch between english and persian
Check the alignment of toolbars and filters in RTL and LTR
Example:
Articles Manager
Article edit
Installed language manager
Associations component

Patch and use NPM

### After patch
All buttons are aligned correctly

Examples:
<img width="488" alt="Screen Shot 2020-02-07 at 09 48 44" src="https://user-images.githubusercontent.com/869724/74014509-2352c780-498f-11ea-931d-57b6981f63b6.png">
<img width="488" alt="Screen Shot 2020-02-07 at 09 48 01" src="https://user-images.githubusercontent.com/869724/74014512-25b52180-498f-11ea-95f4-3ea40ef4a13e.png">
<img width="489" alt="Screen Shot 2020-02-07 at 09 47 21" src="https://user-images.githubusercontent.com/869724/74014517-277ee500-498f-11ea-9713-2e9d013dc8c7.png">
<img width="491" alt="Screen Shot 2020-02-07 at 09 46 50" src="https://user-images.githubusercontent.com/869724/74014520-2948a880-498f-11ea-96b8-8a30934577f8.png">
<img width="489" alt="Screen Shot 2020-02-07 at 09 46 21" src="https://user-images.githubusercontent.com/869724/74014526-2b126c00-498f-11ea-8d19-945de4f1e39a.png">
<img width="486" alt="Screen Shot 2020-02-07 at 09 45 52" src="https://user-images.githubusercontent.com/869724/74014532-2cdc2f80-498f-11ea-9376-e6206b8d303d.png">


@Subhang23 @Quy @brianteeman 
