### PR TITLE
[4.0] codemirror update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2859,9 +2859,9 @@
       "dev": true
     },
     "codemirror": {
-      "version": "5.40.0",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.40.0.tgz",
-      "integrity": "sha512-plTYonQ8SwbtS4m9n88mPDR+G7JwFrAL6774VjvoNH8wQJNSJOx5JdWmgRe3pCyuDI4s+vvi4CIuQnoduUTVug=="
+      "version": "5.51.0",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.51.0.tgz",
+      "integrity": "sha512-vyuYYRv3eXL0SCuZA4spRFlKNzQAewHcipRQCOKgRy7VNAvZxTKzbItdbCl4S5AgPZ5g3WkHp+ibWQwv9TLG7Q=="
     },
     "color": {
       "version": "3.1.1",
@@ -5891,7 +5891,7 @@
       "dependencies": {
         "semver": {
           "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
           "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
           "dev": true
         }
@@ -5945,7 +5945,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -8133,7 +8133,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "bootstrap": "^4.4.1",
     "choices.js": "^9.0.1",
     "chosen-js": "1.6.2",
-    "codemirror": "5.40.0",
+    "codemirror": "^5.51.0",
     "cropperjs": "^1.5.6",
     "css-vars-ponyfill": "^1.17.2",
     "diff": "3.4.0",

--- a/plugins/editors/codemirror/codemirror.xml
+++ b/plugins/editors/codemirror/codemirror.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension version="3.2" type="plugin" group="editors" method="upgrade">
 	<name>plg_editors_codemirror</name>
-	<version>5.40.0</version>
+	<version>5.51.0</version>
 	<creationDate>28 March 2011</creationDate>
 	<author>Marijn Haverbeke</author>
 	<authorEmail>marijnh@gmail.com</authorEmail>

--- a/plugins/editors/tinymce/tinymce.xml
+++ b/plugins/editors/tinymce/tinymce.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension version="3.2" type="plugin" group="editors" method="upgrade">
 	<name>plg_editors_tinymce</name>
-	<version>5.1.5</version>
+	<version>5.1.6</version>
 	<creationDate>2005-2019</creationDate>
 	<author>Tiny Technologies, Inc</author>
 	<authorEmail>N/A</authorEmail>


### PR DESCRIPTION
Codemirror was locked at a specific version that is now very old.

This PR changes the setting in package.json so that it follows semver

Codemirror has always been very good at following semver so this should be totally safe.

(the update process also updated tinymce at the same time)

Our implementation of codemirror is currently broken #27832 and that is unrelated to this. Check that the codemirror and tinymce xml files are updated with the correct version
