### PR TITLE
[4.0] Admin modules - edit links

### DIFF
--- a/administrator/modules/mod_latest/tmpl/default.php
+++ b/administrator/modules/mod_latest/tmpl/default.php
@@ -32,7 +32,7 @@ HTMLHelper::_('bootstrap.framework');
 					<?php echo HTMLHelper::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time); ?>
 				<?php endif; ?>
 				<?php if ($item->link) : ?>
-					<a href="<?php echo $item->link; ?>">
+					<a href="<?php echo $item->link; ?>" title="<?php echo Text::_('JACTION_EDIT'); ?> <?php echo htmlspecialchars($item->title, ENT_QUOTES, 'UTF-8'); ?>">
 						<?php echo htmlspecialchars($item->title, ENT_QUOTES, 'UTF-8'); ?>
 					</a>
 				<?php else : ?>

--- a/administrator/modules/mod_logged/tmpl/default.php
+++ b/administrator/modules/mod_logged/tmpl/default.php
@@ -34,7 +34,7 @@ HTMLHelper::_('bootstrap.framework');
 			<tr>
 				<th scope="row">
 					<?php if (isset($user->editLink)) : ?>
-						<a href="<?php echo $user->editLink; ?>">
+						<a href="<?php echo $item->editLink; ?>" title="<?php echo Text::_('JACTION_EDIT'); ?> <?php echo htmlspecialchars($user->name, ENT_QUOTES, 'UTF-8'); ?>">
 							<?php echo htmlspecialchars($user->name, ENT_QUOTES, 'UTF-8'); ?>
 						</a>
 					<?php else : ?>

--- a/administrator/modules/mod_logged/tmpl/default.php
+++ b/administrator/modules/mod_logged/tmpl/default.php
@@ -34,7 +34,7 @@ HTMLHelper::_('bootstrap.framework');
 			<tr>
 				<th scope="row">
 					<?php if (isset($user->editLink)) : ?>
-						<a href="<?php echo $item->editLink; ?>" title="<?php echo Text::_('JACTION_EDIT'); ?> <?php echo htmlspecialchars($user->name, ENT_QUOTES, 'UTF-8'); ?>">
+						<a href="<?php echo $user->editLink; ?>" title="<?php echo Text::_('JACTION_EDIT'); ?> <?php echo htmlspecialchars($user->name, ENT_QUOTES, 'UTF-8'); ?>">
 							<?php echo htmlspecialchars($user->name, ENT_QUOTES, 'UTF-8'); ?>
 						</a>
 					<?php else : ?>

--- a/administrator/modules/mod_popular/tmpl/default.php
+++ b/administrator/modules/mod_popular/tmpl/default.php
@@ -35,7 +35,7 @@ HTMLHelper::_('bootstrap.framework');
 						<?php echo HTMLHelper::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time); ?>
 					<?php endif; ?>
 					<?php if ($item->link) : ?>
-						<a href="<?php echo $item->link; ?>">
+						<a href="<?php echo $item->link; ?>" title="<?php echo Text::_('JACTION_EDIT'); ?> <?php echo htmlspecialchars($item->title, ENT_QUOTES, 'UTF-8'); ?>">
 							<?php echo htmlspecialchars($item->title, ENT_QUOTES, 'UTF-8'); ?>
 						</a>
 					<?php else : ?>


### PR DESCRIPTION
Pull Request for Issue #26322

### Summary of Changes
On the home page of the backend there are several modules that display information.

- Logged in User
- Popular Articles
- Recently Added Articles

...
In these modules the link is missing a title attribute, which describes to the user where the link is leading to. In the manage overviews there is a title attribute on the links, which is only called e.g. "edit test".

I believe the thinking behind the current text was that it "made sense" in the context of the row. I appreciate that it makes less sense in the context of a list of links that a screen reader might generate

The same issue is present with actionlogs but that's a bigger issue and needs its own pr