### PR TITLE
[4.0] Fix codemiror, use original css files

### DIFF
--- a/plugins/editors/codemirror/layouts/editors/codemirror/element.php
+++ b/plugins/editors/codemirror/layouts/editors/codemirror/element.php
@@ -22,7 +22,6 @@ $cols            = $displayData->cols;
 $rows            = $displayData->rows;
 $content         = $displayData->content;
 $extJS           = JDEBUG ? '.js' : '.min.js';
-$extCSS          = JDEBUG ? '.css' : '.min.css';
 $modifier        = $params->get('fullScreenMod', array()) ? implode(' + ', $params->get('fullScreenMod', array())) . ' + ' : '';
 $basePath        = $displayData->basePath;
 $modePath        = $displayData->modePath;
@@ -36,8 +35,8 @@ $editor          = 'editor="' . ltrim(HTMLHelper::_('script',  $basePath . 'lib/
 $addons          = 'addons="' . ltrim(HTMLHelper::_('script', $basePath . 'lib/addons' . $extJS, ['version' => 'auto', 'pathOnly' => true]), '/') . '"';
 
 Factory::getDocument()->getWebAssetManager()
-	->registerAndUseStyle('codemirror.lib.main', $basePath . 'lib/codemirror' . $extCSS)
-	->registerAndUseStyle('codemirror.lib.addons', $basePath . 'lib/addons' . $extCSS, [], [], ['codemirror.lib.main'])
+	->registerAndUseStyle('codemirror.lib.main', $basePath . 'lib/codemirror.css' )
+	->registerAndUseStyle('codemirror.lib.addons', $basePath . 'lib/addons.css', [], [], ['codemirror.lib.main'])
 	->registerAndUseScript(
 		'webcomponent.editor-codemirror',
 		'plg_editors_codemirror/joomla-editor-codemirror.min.js',

--- a/plugins/editors/codemirror/layouts/editors/codemirror/element.php
+++ b/plugins/editors/codemirror/layouts/editors/codemirror/element.php
@@ -35,7 +35,7 @@ $editor          = 'editor="' . ltrim(HTMLHelper::_('script',  $basePath . 'lib/
 $addons          = 'addons="' . ltrim(HTMLHelper::_('script', $basePath . 'lib/addons' . $extJS, ['version' => 'auto', 'pathOnly' => true]), '/') . '"';
 
 Factory::getDocument()->getWebAssetManager()
-	->registerAndUseStyle('codemirror.lib.main', $basePath . 'lib/codemirror.css' )
+	->registerAndUseStyle('codemirror.lib.main', $basePath . 'lib/codemirror.css')
 	->registerAndUseStyle('codemirror.lib.addons', $basePath . 'lib/addons.css', [], [], ['codemirror.lib.main'])
 	->registerAndUseScript(
 		'webcomponent.editor-codemirror',


### PR DESCRIPTION
Pull Request for Issue #27832 .

### Summary of Changes

I have changed codemiror layout to use original css files. 


### Testing Instructions
Pleas look for original issue #27832


### Expected result
codemiror works


### Actual result
codemiror does not works


