### PR TITLE
[4.0] Allow setting admin menuitem params during component installation

### DIFF
--- a/libraries/src/Installer/Adapter/ComponentAdapter.php
+++ b/libraries/src/Installer/Adapter/ComponentAdapter.php
@@ -23,6 +23,7 @@ use Joomla\CMS\Table\Extension;
 use Joomla\CMS\Table\Table;
 use Joomla\CMS\Table\Update;
 use Joomla\Database\ParameterType;
+use Joomla\Registry\Registry;
 
 /**
  * Component installer
@@ -1112,6 +1113,13 @@ class ComponentAdapter extends InstallerAdapter
 			$data['path']         = '';
 			$data['params']       = '';
 
+			if ($params = $menuElement->params)
+			{
+				// Pass $params through Registry to convert to JSON.
+				$params = new Registry($params);
+				$data['params'] = $params->toString();
+			}
+
 			// Set the menu link
 			$request = [];
 
@@ -1178,6 +1186,14 @@ class ComponentAdapter extends InstallerAdapter
 			$data['component_id'] = $component_id;
 			$data['img']          = ((string) $child->attributes()->img) ?: 'class:component';
 			$data['home']         = 0;
+			$data['params']       = '';
+
+			if ($params = $child->params)
+			{
+				// Pass $params through Registry to convert to JSON.
+				$params = new Registry($params);
+				$data['params'] = $params->toString();
+			}
 
 			// Set the sub menu link
 			if ((string) $child->attributes()->link)


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/27765.

### Summary of Changes
This changes the Installer ComponentAdapter so it reads optional menuitem parameters from the XML and puts them into the #__menu table.

This allows to set menuitem params for the admin menu during component installation.
This is especially interesting so we can add dashboard and quicktask links to our component submenus.
The XML structure for params in a menu or submenu will look like this
````
<administration>
	<menu>
		COM_FOO
		<params>
			<param1>value1</param1>
		</params>
	</menu>
	<submenu>
		<menu view="bar">
			COM_FOO_MENU_BAR
			<params>
				<param2>value2</param2>
				<param3>value3</param3>
			</params>
		</menu>
	</submenu>
</administration>
````

### Testing Instructions
You can either adjust the XML manifest of a component of your choice, or use my SermonSpeaker component where I added params to show a dashboard link and a quicktask link.
[com_sermonspeaker.zip](https://github.com/joomla/joomla-cms/files/4171497/com_sermonspeaker.zip)

### Expected result
With my component you'll see dashboard and quicktask icons in the component submenu:
![image](https://user-images.githubusercontent.com/1018684/74041673-62503f80-49c6-11ea-8843-846217178cc0.png)

If you do it with another component, you can also check the #__menu table entry and see if the `params` column got an entry like you specified it.



### Actual result
There is no possibility to add params during installation (without a scriptfile)


### Documentation Changes Required
That should be added to the "Develop a 4.0 component" (or how that is called) doc. If there is another doc for the component manifest, it should be added there as well.