### PR TITLE
[4.0] Add anchors to user menu

### DIFF
--- a/administrator/modules/mod_user/tmpl/default.php
+++ b/administrator/modules/mod_user/tmpl/default.php
@@ -34,12 +34,12 @@ $hideLinks = $app->input->getBool('hidemainmenu');
 	<div class="dropdown-menu dropdown-menu-right">
 		<div class="dropdown-header"><?php echo $user->name; ?></div>
 		<?php $uri   = Uri::getInstance(); ?>
-		<?php $route = 'index.php?option=com_users&task=user.edit&id=' . $user->id . '#details&return=' . base64_encode($uri); ?>
+		<?php $route = 'index.php?option=com_users&task=user.edit&id=' . $user->id . '&return=' . base64_encode($uri) . '#details'; ?>
 		<a class="dropdown-item" href="<?php echo Route::_($route); ?>">
 			<span class="fas fa-fw fa-user" aria-hidden="true"></span>
 			<?php echo Text::_('MOD_USER_EDIT_ACCOUNT'); ?>
 		</a>
-		<?php $route = 'index.php?option=com_users&task=user.edit&id=' . $user->id . '#attrib-accessibility&return=' . base64_encode($uri); ?>
+		<?php $route = 'index.php?option=com_users&task=user.edit&id=' . $user->id . '&return=' . base64_encode($uri) . '#attrib-accessibility'; ?>
 		<a class="dropdown-item" href="<?php echo Route::_($route); ?>">
 			<span class="fas fa-fw fa-universal-access" aria-hidden="true"></span>
 			<?php echo Text::_('MOD_USER_ACCESSIBILITY_SETTINGS'); ?>

--- a/administrator/modules/mod_user/tmpl/default.php
+++ b/administrator/modules/mod_user/tmpl/default.php
@@ -34,12 +34,12 @@ $hideLinks = $app->input->getBool('hidemainmenu');
 	<div class="dropdown-menu dropdown-menu-right">
 		<div class="dropdown-header"><?php echo $user->name; ?></div>
 		<?php $uri   = Uri::getInstance(); ?>
-		<?php $route = 'index.php?option=com_users&task=user.edit&id=' . $user->id . '&return=' . base64_encode($uri); ?>
+		<?php $route = 'index.php?option=com_users&task=user.edit&id=' . $user->id . '#details&return=' . base64_encode($uri); ?>
 		<a class="dropdown-item" href="<?php echo Route::_($route); ?>">
 			<span class="fas fa-fw fa-user" aria-hidden="true"></span>
 			<?php echo Text::_('MOD_USER_EDIT_ACCOUNT'); ?>
 		</a>
-		<?php $route = 'index.php?option=com_users&task=user.edit&id=' . $user->id . '&return=' . base64_encode($uri); ?>
+		<?php $route = 'index.php?option=com_users&task=user.edit&id=' . $user->id . '#attrib-accessibility&return=' . base64_encode($uri); ?>
 		<a class="dropdown-item" href="<?php echo Route::_($route); ?>">
 			<span class="fas fa-fw fa-universal-access" aria-hidden="true"></span>
 			<?php echo Text::_('MOD_USER_ACCESSIBILITY_SETTINGS'); ?>


### PR DESCRIPTION
### Summary of Changes
Add anchors to link directly to tabs in user menu.


### Testing Instructions
Click User Menu icon in the upper right corner.
Click on Edit Account / Accessibility Settings links.

The respective tab should be opened/active.