### PR TITLE
[4.0] Include resize modal markup for image type only

### DIFF
--- a/administrator/components/com_templates/tmpl/template/default.php
+++ b/administrator/components/com_templates/tmpl/template/default.php
@@ -436,7 +436,7 @@ $folderModalData = array(
 );
 ?>
 <?php echo LayoutHelper::render('joomla.modal.main', $folderModalData); ?>
-<?php if ($this->type != 'home') : ?>
+<?php if ($this->type == 'image') : ?>
 	<?php // Resize Modal
 	$resizeModalData = array(
 		'selector' => 'resizeModal',


### PR DESCRIPTION
Pull Request for Issue #27846.

### Summary of Changes
Resize modal markup outputs for all file types where height/width values were null for non-image types. This PR restricts markup to image type only.

Affected on PHP 7.4+

### Testing Instructions
Go to System > Site Templates
Click Cassiopeia Details and Files
Edit a file that is not an image.
View page source
Find `id="resizeModal"`
See errors in PHP log
Apply PR
View page source
Find `id="resizeModal"` but not found
No errors in PHP log


### Actual result
> PHP Notice: Trying to access array offset on value of type null in \administrator\components\com_templates\tmpl\template\default_modal_resize_body.php on line 25

> PHP Notice: Trying to access array offset on value of type null in\administrator\components\com_templates\tmpl\template\default_modal_resize_body.php on line 35

