### PR TITLE
[4.0] Translate com_finder modal titles

### DIFF
--- a/administrator/components/com_finder/View/Filters/HtmlView.php
+++ b/administrator/components/com_finder/View/Filters/HtmlView.php
@@ -145,7 +145,7 @@ class HtmlView extends BaseHtmlView
 		}
 
 		ToolbarHelper::divider();
-		$toolbar->appendButton('Popup', 'bars', 'COM_FINDER_STATISTICS', 'index.php?option=com_finder&view=statistics&tmpl=component', 550, 350, '', '', '', 'COM_FINDER_STATISTICS_TITLE');
+		$toolbar->appendButton('Popup', 'bars', 'COM_FINDER_STATISTICS', 'index.php?option=com_finder&view=statistics&tmpl=component', 550, 350, '', '', '', Text::_('COM_FINDER_STATISTICS_TITLE'));
 		ToolbarHelper::divider();
 
 		if ($canDo->get('core.delete'))

--- a/administrator/components/com_finder/View/Maps/HtmlView.php
+++ b/administrator/components/com_finder/View/Maps/HtmlView.php
@@ -144,7 +144,7 @@ class HtmlView extends BaseHtmlView
 		}
 
 		ToolbarHelper::divider();
-		$toolbar->appendButton('Popup', 'bars', 'COM_FINDER_STATISTICS', 'index.php?option=com_finder&view=statistics&tmpl=component', 550, 350, '', '', '', 'COM_FINDER_STATISTICS_TITLE');
+		$toolbar->appendButton('Popup', 'bars', 'COM_FINDER_STATISTICS', 'index.php?option=com_finder&view=statistics&tmpl=component', 550, 350, '', '', '', Text::_('COM_FINDER_STATISTICS_TITLE'));
 		ToolbarHelper::divider();
 
 		if ($canDo->get('core.delete'))


### PR DESCRIPTION
Fix modal titles not translated.

### Testing Instructions
Go to Smart Search > Content Maps
Click Statistics button
See modal title not translated
Go to Smart Search > Filters
Click Statistics button
See modal title not translated
Apply PR
Modal titles translated