### PR TITLE
[4.0] Center modal on mobile

### DIFF
--- a/administrator/templates/atum/scss/vendor/bootstrap/_modal.scss
+++ b/administrator/templates/atum/scss/vendor/bootstrap/_modal.scss
@@ -96,3 +96,9 @@
     max-width: none;
   }
 }
+
+.modal-dialog {
+  @include media-breakpoint-down(xs) {
+    margin: 1.75rem auto;
+  }
+}


### PR DESCRIPTION
Pull Request for Issue #27536 .

### Summary of Changes
Bizarrely bootstrap does not center modals on devices smaller than 567px eg mobile phones


### Testing Instructions
Go to the admin dashboard
Reduce viewport width down to a mobile size
Click the "Add module to the dashboard" button at the bottom of the page

### Expected result
Horizontally aligned modal

### Actual result
Modal aligned to the left

apply the pr run `npm i` or `node build.js --compile-css`