### PR TITLE
[4.0] Border color between tabs on hover

### DIFF
--- a/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-tab.scss
+++ b/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-tab.scss
@@ -198,7 +198,7 @@ joomla-tab {
           width: calc(100% + 2px);
           height: 8px;
           opacity: .8;
-          background-color: var(--atum-text-light);
+          background-color: var(--atum-contrast);
         }
       }
     }


### PR DESCRIPTION
Pull Request for Issue #27533  .

The report was that there was a weird space between the tabs on mobile when you hover. 

It wasn't actually a space it was the wrong colour ;)

### Before on the right - After on the left

![tabs](https://user-images.githubusercontent.com/1296369/74093636-901fac00-4acc-11ea-9377-8c397114638c.gif)



apply the pr run `npm i` or `node build.js --compile-css`


