### PR TITLE
[4.0] Add margin to back-top

### DIFF
--- a/templates/cassiopeia/scss/_mixin.scss
+++ b/templates/cassiopeia/scss/_mixin.scss
@@ -1,0 +1,18 @@
+// Mixins
+
+@mixin margin($position, $size) {
+  margin-#{$position}: $size;
+
+  $rtl-position: null;
+  @if $position == 'left' {
+    $rtl-position: right;
+  } @else if $position == 'right' {
+    $rtl-position: left;
+  }
+
+  @if $rtl-position != null {
+    [dir=rtl] & {
+      margin-#{$rtl-position}: $size;
+    }
+  }
+}

--- a/templates/cassiopeia/scss/blocks/_footer.scss
+++ b/templates/cassiopeia/scss/blocks/_footer.scss
@@ -7,6 +7,8 @@
     color: #fff;
     background: $cassiopeia-template-color;
     border-radius: 3px;
+
+    @include margin('right', 5px);
   }
 
 }

--- a/templates/cassiopeia/scss/template.scss
+++ b/templates/cassiopeia/scss/template.scss
@@ -5,6 +5,9 @@
 // Variables
 @import "variables";
 
+// Mixins
+@import "mixin";
+
 // Bootstrap
 @import "../../../media/vendor/bootstrap/scss/variables";
 @import "../../../media/vendor/bootstrap/scss/bootstrap";


### PR DESCRIPTION
Redo #27315 using mixin.

Thanks @C-Lodder for the tip/code

### Summary of Changes
Add margin to the  back top icon.

Using mixin, it will generate LTR/RTL margin code.


### Testing Instructions
Install Blog Sample Data 
Apply PR
Run npm i
Go to front end and scroll to the bottom

