### PR TITLE
[4.0] Remove negative margin in tinymce builder

### DIFF
--- a/build/media_source/plg_editors_tinymce/scss/tinymce-builder.scss
+++ b/build/media_source/plg_editors_tinymce/scss/tinymce-builder.scss
@@ -12,7 +12,6 @@
       min-height: 2.5rem;
 	  }
   }
-  margin-left: -220px;
 }
 
 // Drag & Drop Handler


### PR DESCRIPTION
### Summary of Changes
Revert #27466 

#### Currently
![grafik](https://user-images.githubusercontent.com/1229869/74094746-8c008800-4ae6-11ea-99ef-c9af1975abae.png)

#### After patch + npm
![grafik](https://user-images.githubusercontent.com/1229869/74094756-b5211880-4ae6-11ea-8418-c046bedaacd2.png)


### Testing Instructions
Open the TinyMCE plugin and check the position of the elements.



### Expected result
Everything aligned


### Actual result
Everything is left outside

@brianteeman could you please check, because you added the margin for a reason. Perhaps my settings are wrong (latest Firefox)

