### PR TITLE
[4.0] Missing J installation error language string

### DIFF
--- a/installation/language/en-GB/joomla.ini
+++ b/installation/language/en-GB/joomla.ini
@@ -270,6 +270,7 @@ JLIB_INSTALLER_ABORT_PACK_INSTALL_ERROR_EXTENSION="Package %1$s: There was an er
 JLIB_INSTALLER_ABORT_PACK_INSTALL_NO_FILES="Package %s: There were no files to install!"
 JLIB_INSTALLER_ERROR_FAIL_COPY_FILE="JInstaller: :Install: Failed to copy file %1$s to %2$s."
 JLIB_INSTALLER_NOT_ERROR="If the error is related to the installation of TinyMCE language files it has no effect on the installation of the language(s). Some language packs created prior to Joomla 3.2.0 may try to install separate TinyMCE language files. As these are now included in the core they no longer need to be installed."
+JLIB_INSTALLER_WARNING_UNABLE_TO_INSTALL_CONTENT_LANGUAGE="Unable to create a content language for %s language: %s"
 JLIB_UPDATER_ERROR_OPEN_UPDATE_SITE="Update: Could not open update site #%d &quot;%s&quot;, URL: %s"
 JLIB_UTIL_ERROR_CONNECT_DATABASE="JDatabase: :getInstance: Could not connect to database <br>joomla.library: %1$s - %2$s"
 

--- a/installation/language/en-US/joomla.ini
+++ b/installation/language/en-US/joomla.ini
@@ -270,6 +270,7 @@ JLIB_INSTALLER_ABORT_PACK_INSTALL_ERROR_EXTENSION="Package %1$s: There was an er
 JLIB_INSTALLER_ABORT_PACK_INSTALL_NO_FILES="Package %s: There were no files to install!"
 JLIB_INSTALLER_ERROR_FAIL_COPY_FILE="JInstaller: :Install: Failed to copy file %1$s to %2$s."
 JLIB_INSTALLER_NOT_ERROR="If the error is related to the installation of TinyMCE language files it has no effect on the installation of the language(s). Some language packs created prior to Joomla 3.2.0 may try to install separate TinyMCE language files. As these are now included in the core they no longer need to be installed."
+JLIB_INSTALLER_WARNING_UNABLE_TO_INSTALL_CONTENT_LANGUAGE="Unable to create a content language for %s language: %s"
 JLIB_UPDATER_ERROR_OPEN_UPDATE_SITE="Update: Could not open update site #%d &quot;%s&quot;, URL: %s"
 JLIB_UTIL_ERROR_CONNECT_DATABASE="JDatabase: :getInstance: Could not connect to database <br>joomla.library: %1$s - %2$s"
 


### PR DESCRIPTION
### Summary of Changes 
Adding missing string in case a content language can't be created when installing a language during J installation

Saw this when testing https://github.com/joomla/joomla-cms/pull/25258#issuecomment-583731167 on a clean install.

Issue will normally be solved by https://github.com/joomla/joomla-cms/pull/27854 but better be safe in case a Content Language can't be created at J installation time.

@richard67 