### PR TITLE
[4.0] Fix undefined property when editing stages/transitions

### DIFF
--- a/administrator/components/com_workflow/Model/StageModel.php
+++ b/administrator/components/com_workflow/Model/StageModel.php
@@ -156,7 +156,14 @@ class StageModel extends AdminModel
 	{
 		$user = Factory::getUser();
 		$app = Factory::getApplication();
-		$extension = $app->getUserStateFromRequest('com_workflow.state.filter.extension', 'extension', null, 'cmd');
+		$context = $this->option . '.' . $this->name;
+		$extension = $app->getUserStateFromRequest($context . '.filter.extension', 'extension', null, 'cmd');
+
+		if (!\property_exists($record, 'workflow_id'))
+		{
+			$workflowID          = $app->getUserStateFromRequest($context . '.filter.workflow_id', 'workflow_id', 0, 'int');
+			$record->workflow_id = $workflowID;
+		}
 
 		$table = $this->getTable('Workflow', 'Administrator');
 

--- a/administrator/components/com_workflow/Model/TransitionModel.php
+++ b/administrator/components/com_workflow/Model/TransitionModel.php
@@ -82,7 +82,14 @@ class TransitionModel extends AdminModel
 	{
 		$user = Factory::getUser();
 		$app = Factory::getApplication();
-		$extension = $app->getUserStateFromRequest('com_workflow.transition.filter.extension', 'extension', null, 'cmd');
+		$context = $this->option . '.' . $this->name;
+		$extension = $app->getUserStateFromRequest($context . '.filter.extension', 'extension', null, 'cmd');
+
+		if (!\property_exists($record, 'workflow_id'))
+		{
+			$workflowID          = $app->getUserStateFromRequest($context . '.filter.workflow_id', 'workflow_id', 0, 'int');
+			$record->workflow_id = $workflowID;
+		}
 
 		$table = $this->getTable('Workflow', 'Administrator');
 
@@ -234,7 +241,7 @@ class TransitionModel extends AdminModel
 			$data = (object) $this->loadFormData();
 		}
 
-		if (!$this->canEditState($data))
+		if (!$this->canEditState((object) $data))
 		{
 			// Disable fields for display.
 			$form->setFieldAttribute('published', 'disabled', 'true');


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/26306

### Summary of Changes
Fixes undefined property in error logs when editing a stage or transition.

### Testing Instructions
Create a new workflow.
Under Stages column, click the count badge.
Edit Unpublished.
Click Save & Close.
View PHP error log.

`Trying to get property 'workflow_id' of non-object in 
 \administrator\components\com_workflow\Model\StageModel.php on line 163`

Do the same under the Transitions column.

`Trying to get property 'workflow_id' of non-object in \administrator\components\com_workflow\Model\TransitionModel.php on line 89`

After patching neither entries will be added to the error log

### Documentation Changes Required
None