### PR TITLE
[4.0] Remove zero opacity from Atum error files

### DIFF
--- a/administrator/templates/atum/error_full.php
+++ b/administrator/templates/atum/error_full.php
@@ -60,19 +60,6 @@ $this->setMetaData('theme-color', '#1c3d5c');
 $this->getWebAssetManager()
 	->addInlineScript('cssVars();', ['position' => 'after'], ['type' => 'module'], ['css-vars-ponyfill']);
 
-// Opacity must be set before displaying the DOM, so don't move to a CSS file
-$css = '
-	.container-main > * {
-		opacity: 0;
-	}
-	.sidebar-wrapper > * {
-		opacity: 0;
-	}
-';
-
-$this->getWebAssetManager()
-	->addInlineStyle($css);
-
 $monochrome = (bool) $this->params->get('monochrome');
 
 HTMLHelper::getServiceRegistry()->register('atum', 'JHtmlAtum');

--- a/administrator/templates/atum/error_login.php
+++ b/administrator/templates/atum/error_login.php
@@ -59,19 +59,6 @@ $this->setMetaData('theme-color', '#1c3d5c');
 $this->getWebAssetManager()
 	->addInlineScript('cssVars();', ['position' => 'after'], ['type' => 'module'], ['css-vars-ponyfill']);
 
-// Opacity must be set before displaying the DOM, so don't move to a CSS file
-$css = '
-	.container-main > * {
-		opacity: 0;
-	}
-	.sidebar-wrapper > * {
-		opacity: 0;
-	}
-';
-
-$this->getWebAssetManager()
-	->addInlineStyle($css);
-
 $monochrome = (bool) $this->params->get('monochrome');
 
 HTMLHelper::getServiceRegistry()->register('atum', 'JHtmlAtum');


### PR DESCRIPTION
### Summary of Changes

Removes some leftovers of fade code.

### Testing Instructions

Cause Joomla! error page to appear.

### Expected result

Joomla! error page.

### Actual result

Mostly empty page:

![Screenshot_2020-02-10 Error 0](https://user-images.githubusercontent.com/7325021/74128655-593db900-4be6-11ea-97c4-b644d7b88fef.png)


### Documentation Changes Required

No.