### PR TITLE
[4.0] Replace HTMLHelper to WebAsset for media/vendor/ assets

### DIFF
--- a/administrator/components/com_contenthistory/tmpl/compare/compare.php
+++ b/administrator/components/com_contenthistory/tmpl/compare/compare.php
@@ -9,7 +9,6 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Session\Session;
 
@@ -21,7 +20,7 @@ $object1  = $version1->data;
 $object2  = $version2->data;
 
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
-$wa = Factory::getApplication()->getDocument()->getWebAssetManager();
+$wa = $this->document->getWebAssetManager();
 $wa->useScript('diff')
 	->registerAndUseScript('contenthistory.admin-compare', 'com_contenthistory/admin-compare-compare.min.js', [], ['defer' => true], ['diff']);
 

--- a/administrator/components/com_contenthistory/tmpl/compare/compare.php
+++ b/administrator/components/com_contenthistory/tmpl/compare/compare.php
@@ -23,7 +23,7 @@ $object2  = $version2->data;
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = Factory::getApplication()->getDocument()->getWebAssetManager();
 $wa->useScript('diff')
-	->registerAndUseScript('contenthistory.admin.compare', 'com_contenthistory/admin-compare-compare.min.js', [], ['defer' => true], ['diff']);
+	->registerAndUseScript('contenthistory.admin-compare', 'com_contenthistory/admin-compare-compare.min.js', [], ['defer' => true], ['diff']);
 
 ?>
 <div role="main">

--- a/administrator/components/com_contenthistory/tmpl/compare/compare.php
+++ b/administrator/components/com_contenthistory/tmpl/compare/compare.php
@@ -9,7 +9,7 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Session\Session;
 
@@ -20,8 +20,11 @@ $version1 = $this->items[1];
 $object1  = $version1->data;
 $object2  = $version2->data;
 
-HTMLHelper::_('script', 'vendor/diff/diff.min.js', array('version' => 'auto', 'relative' => true));
-HTMLHelper::_('script', 'com_contenthistory/admin-compare-compare.min.js', array('version' => 'auto', 'relative' => true));
+/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+$wa = Factory::getApplication()->getDocument()->getWebAssetManager();
+$wa->useScript('diff')
+	->registerAndUseScript('contenthistory.admin.compare', 'com_contenthistory/admin-compare-compare.min.js', [], ['defer' => true], ['diff']);
+
 ?>
 <div role="main">
 	<h1 class="mb-3"><?php echo Text::_('COM_CONTENTHISTORY_COMPARE_TITLE'); ?></h1>

--- a/administrator/components/com_templates/tmpl/template/default.php
+++ b/administrator/components/com_templates/tmpl/template/default.php
@@ -16,15 +16,18 @@ use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
 
-HTMLHelper::_('script', 'vendor/diff/diff.min.js', array('version' => 'auto', 'relative' => true));
-HTMLHelper::_('script', 'com_templates/admin-template-compare.min.js', array('version' => 'auto', 'relative' => true));
-HTMLHelper::_('script', 'com_templates/admin-template-toggle-switch.min.js', array('version' => 'auto', 'relative' => true));
-
-HTMLHelper::_('behavior.formvalidator');
-HTMLHelper::_('behavior.keepalive');
 HTMLHelper::_('behavior.multiselect', 'updateForm');
 
+/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+$wa    = $this->document->getWebAssetManager();
 $input = Factory::getApplication()->input;
+
+// Enable assets
+$wa->useScript('form.validate')
+	->useScript('keepalive')
+	->useScript('diff')
+	->registerAndUseScript('templates.admin-template-compare', 'com_templates/admin-template-compare.min.js', [], ['defer' => true], ['diff', 'core'])
+	->registerAndUseScript('templates.admin-template-toggle-switch', 'com_templates/admin-template-toggle-switch.min.js', [], ['defer' => true], ['core']);
 
 // No access if not global SuperUser
 if (!Factory::getUser()->authorise('core.admin'))
@@ -34,16 +37,15 @@ if (!Factory::getUser()->authorise('core.admin'))
 
 if ($this->type == 'image')
 {
-	HTMLHelper::_('script', 'vendor/cropperjs/cropper.min.js', array('version' => 'auto', 'relative' => true));
-	HTMLHelper::_('stylesheet', 'vendor/cropperjs/cropper.min.css', array('version' => 'auto', 'relative' => true));
+	$wa->usePreset('cropperjs');
 }
 
-HTMLHelper::_('script', 'com_templates/admin-templates-default.min.js', array('version' => 'auto', 'relative' => true));
-HTMLHelper::_('stylesheet', 'com_templates/admin-templates-default.css', array('version' => 'auto', 'relative' => true));
+$wa->registerAndUseStyle('templates.admin-templates-default', 'com_templates/admin-templates-default.css')
+	->registerAndUseScript('templates.admin-templates-default', 'com_templates/admin-templates-default.min.js', [], ['defer' => true], ['core']);
 
 if ($this->type == 'font')
 {
-	$this->document->addStyleDeclaration("
+	$wa->addInlineStyle("
 		@font-face {
 			font-family: previewFont;
 			src: url('" . $this->font['address'] . "')

--- a/administrator/modules/mod_menu/tmpl/default.php
+++ b/administrator/modules/mod_menu/tmpl/default.php
@@ -16,8 +16,8 @@ use Joomla\CMS\Language\Text;
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = Factory::getApplication()->getDocument()->getWebAssetManager();
 $wa->useScript('metismenujs')
-	->registerAndUseScript('mod_menu.admin.menu', 'mod_menu/admin-menu.min.js', [], ['defer' => true], ['metismenujs'])
-	->registerAndUseScript('cpanel.system.loader', 'com_cpanel/admin-system-loader.js', [], ['defer' => true]);
+	->registerAndUseScript('mod_menu.admin-menu', 'mod_menu/admin-menu.min.js', [], ['defer' => true], ['metismenujs'])
+	->registerAndUseScript('cpanel.system-loader', 'com_cpanel/admin-system-loader.js', [], ['defer' => true]);
 
 $doc       = $app->getDocument();
 $direction = $doc->direction === 'rtl' ? 'float-right' : '';

--- a/administrator/modules/mod_menu/tmpl/default.php
+++ b/administrator/modules/mod_menu/tmpl/default.php
@@ -9,19 +9,18 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\Factory;
 use Joomla\CMS\Helper\ModuleHelper;
 use Joomla\CMS\Language\Text;
-
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
-$wa = Factory::getApplication()->getDocument()->getWebAssetManager();
-$wa->useScript('metismenujs')
-	->registerAndUseScript('mod_menu.admin-menu', 'mod_menu/admin-menu.min.js', [], ['defer' => true], ['metismenujs'])
-	->registerAndUseScript('cpanel.system-loader', 'com_cpanel/admin-system-loader.js', [], ['defer' => true]);
 
 $doc       = $app->getDocument();
 $direction = $doc->direction === 'rtl' ? 'float-right' : '';
 $class     = $enabled ? 'nav flex-column main-nav ' . $direction : 'nav flex-column main-nav disabled ' . $direction;
+
+/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+$wa = $doc->getWebAssetManager();
+$wa->useScript('metismenujs')
+	->registerAndUseScript('mod_menu.admin-menu', 'mod_menu/admin-menu.min.js', [], ['defer' => true], ['metismenujs'])
+	->registerAndUseScript('cpanel.system-loader', 'com_cpanel/admin-system-loader.js', [], ['defer' => true]);
 
 // Recurse through children of root node if they exist
 if ($root->hasChildren())

--- a/administrator/modules/mod_menu/tmpl/default.php
+++ b/administrator/modules/mod_menu/tmpl/default.php
@@ -9,13 +9,15 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Factory;
 use Joomla\CMS\Helper\ModuleHelper;
-use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
-HTMLHelper::_('script', 'vendor/metismenujs/metismenujs.min.js', ['version' => 'auto', 'relative' => true]);
-HTMLHelper::_('script', 'mod_menu/admin-menu.min.js', ['version' => 'auto', 'relative' => true], ['defer' => true]);
-HTMLHelper::_('script', 'com_cpanel/admin-system-loader.js', ['version' => 'auto', 'relative' => true]);
+/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+$wa = Factory::getApplication()->getDocument()->getWebAssetManager();
+$wa->useScript('metismenujs')
+	->registerAndUseScript('mod_menu.admin.menu', 'mod_menu/admin-menu.min.js', [], ['defer' => true], ['metismenujs'])
+	->registerAndUseScript('cpanel.system.loader', 'com_cpanel/admin-system-loader.js', [], ['defer' => true]);
 
 $doc       = $app->getDocument();
 $direction = $doc->direction === 'rtl' ? 'float-right' : '';

--- a/build/build-modules-js/settings.json
+++ b/build/build-modules-js/settings.json
@@ -110,7 +110,10 @@
           {
             "name": "cropperjs",
             "type": "script",
-            "uri": "cropper.min.js"
+            "uri": "cropper.min.js",
+            "attributes": {
+              "defer": true
+            }
           },
           {
             "name": "cropperjs",
@@ -195,7 +198,10 @@
           {
             "name": "dragula",
             "type": "script",
-            "uri": "dragula.min.js"
+            "uri": "dragula.min.js",
+            "attributes": {
+              "defer": true
+            }
           },
           {
             "name": "dragula",

--- a/build/build-modules-js/settings.json
+++ b/build/build-modules-js/settings.json
@@ -403,7 +403,10 @@
             "name": "minicolors",
             "type": "script",
             "uri": "jquery.minicolors.min.js",
-            "dependencies": ["jquery"]
+            "dependencies": ["jquery"],
+            "attributes": {
+              "defer": true
+            }
           },
           {
             "name": "minicolors",
@@ -533,7 +536,30 @@
         },
         "css": {
           "src/css/SkipTo.css": "css/SkipTo.css"
-        }
+        },
+        "provideAssets": [
+          {
+            "name": "skipto",
+            "type": "style",
+            "uri": "SkipTo.css"
+          },
+          {
+            "name": "skipto.dropmenu",
+            "type": "script",
+            "uri": "dropMenu.js",
+            "attributes": {
+              "defer": true
+            }
+          },
+          {
+            "name": "skipto",
+            "type": "script",
+            "uri": "skipTo.js",
+            "attributes": {
+              "defer": true
+            }
+          }
+        ]
       },
       "qrcode-generator": {
         "name": "qrcode",

--- a/build/build-modules-js/settings.json
+++ b/build/build-modules-js/settings.json
@@ -167,7 +167,10 @@
           {
             "name": "diff",
             "type": "script",
-            "uri": "diff.js"
+            "uri": "diff.js",
+            "attributes": {
+              "defer": true
+            }
           }
         ],
         "dependencies": [],
@@ -492,7 +495,17 @@
           "dist/metismenujs.js": "js/metismenujs.js",
           "dist/metismenujs.min.js": "js/metismenujs.min.js",
           "dist/metismenujs.min.js.map": "js/metismenujs.min.js.map"
-        }
+        },
+        "provideAssets": [
+          {
+            "name": "metismenujs",
+            "type": "script",
+            "uri": "metismenujs.min.js",
+            "attributes": {
+              "defer": true
+            }
+          }
+        ]
       },
       "short-and-sweet": {
         "name": "short-and-sweet",

--- a/build/media_source/system/joomla.asset.json
+++ b/build/media_source/system/joomla.asset.json
@@ -70,11 +70,25 @@
       "name": "form.validate",
       "type": "script",
       "class": "FormValidateAssetItem",
+      "attributes": {
+        "defer": true
+      },
       "dependencies": [
         "core",
         "punycode"
       ],
       "uri": "system/fields/validate.min.js"
+    },
+    {
+      "name": "field.color-adv",
+      "type": "script",
+      "uri": "system/fields/color-field-adv-init.min.js",
+      "attributes": {
+        "defer": true
+      },
+      "dependencies": [
+        "minicolors"
+      ]
     },
     {
       "name": "webcomponent.field-fancy-select",

--- a/build/media_source/system/joomla.asset.json
+++ b/build/media_source/system/joomla.asset.json
@@ -18,7 +18,10 @@
       "dependencies": [
         "core"
       ],
-      "uri": "system/keepalive.min.js"
+      "uri": "system/keepalive.min.js",
+      "attributes": {
+        "defer": true
+      }
     },
     {
       "name": "template.active",
@@ -38,7 +41,10 @@
       "dependencies": [
         "core"
       ],
-      "uri": "system/multiselect.min.js"
+      "uri": "system/multiselect.min.js",
+      "attributes": {
+        "defer": true
+      }
     },
     {
       "name": "searchtools",
@@ -46,7 +52,10 @@
       "dependencies": [
         "core"
       ],
-      "uri": "system/searchtools.min.js"
+      "uri": "system/searchtools.min.js",
+      "attributes": {
+        "defer": true
+      }
     },
     {
       "name": "searchtools",

--- a/build/media_source/system/joomla.asset.json
+++ b/build/media_source/system/joomla.asset.json
@@ -91,6 +91,17 @@
       ]
     },
     {
+      "name": "joomla.draggable",
+      "type": "script",
+      "uri": "system/draggable.min.js",
+      "attributes": {
+        "defer": true
+      },
+      "dependencies": [
+        "dragula"
+      ]
+    },
+    {
       "name": "webcomponent.field-fancy-select",
       "type": "script",
       "uri": "system/fields/joomla-field-fancy-select.min.js",

--- a/layouts/joomla/form/field/color/advanced.php
+++ b/layouts/joomla/form/field/color/advanced.php
@@ -9,7 +9,7 @@
 
 defined('JPATH_BASE') or die;
 
-use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Factory;
 
 extract($displayData);
 
@@ -71,10 +71,10 @@ $autocomplete = !empty($autocomplete) ? 'autocomplete="' . $autocomplete . '"' :
 // Force LTR input value in RTL, due to display issues with rgba/hex colors
 $direction = $lang->isRtl() ? ' dir="ltr" style="text-align:right"' : '';
 
-HTMLHelper::_('jquery.framework');
-HTMLHelper::_('script', 'vendor/minicolors/jquery.minicolors.min.js', array('version' => 'auto', 'relative' => true));
-HTMLHelper::_('stylesheet', 'vendor/minicolors/jquery.minicolors.css', array('version' => 'auto', 'relative' => true));
-HTMLHelper::_('script', 'system/fields/color-field-adv-init.min.js', array('version' => 'auto', 'relative' => true));
+/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+$wa = Factory::getApplication()->getDocument()->getWebAssetManager();
+$wa->useScript('field.color-adv');
+
 ?>
 <input type="text" name="<?php echo $name; ?>" id="<?php echo $id; ?>" value="<?php echo $this->escape($color); ?>"<?php
 	echo $hint,

--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -229,7 +229,9 @@ abstract class JHtmlBehavior
 			$scriptOptions = array('version' => 'auto', 'relative' => true);
 			$scriptOptions = $conditionalBrowser !== null ? array_replace($scriptOptions, array('conditional' => $conditionalBrowser)) : $scriptOptions;
 
-			HTMLHelper::_('script', 'vendor/polyfills/polyfill-' . $polyfillType . '.js', $scriptOptions);
+			/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+			$wa = Factory::getApplication()->getDocument()->getWebAssetManager();
+			$wa->registerAndUseScript('polyfill.' . $polyfillType, 'vendor/polyfills/polyfill-' . $polyfillType . '.js', $scriptOptions);
 
 			// Set static array
 			static::$loaded[__METHOD__][$sig] = true;

--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -11,7 +11,6 @@ defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Filter\OutputFilter;
-use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
 /**

--- a/libraries/cms/html/draggablelist.php
+++ b/libraries/cms/html/draggablelist.php
@@ -10,7 +10,6 @@
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Factory;
-use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Session\Session;
 
 /**

--- a/libraries/cms/html/draggablelist.php
+++ b/libraries/cms/html/draggablelist.php
@@ -71,13 +71,9 @@ abstract class JHtmlDraggablelist
 			);
 		}
 
-		// Depends on Joomla.getOptions()
-		HTMLHelper::_('behavior.core');
-
-		// Attach draggable to document
-		HTMLHelper::_('script', 'vendor/dragula/dragula.min.js', ['framework' => false, 'relative' => true]);
-		HTMLHelper::_('script', 'system/draggable.min.js', ['framework' => false, 'relative' => true]);
-		HTMLHelper::_('stylesheet', 'vendor/dragula/dragula.min.css', ['framework' => false, 'relative' => true, 'pathOnly' => false]);
+		$doc->getWebAssetManager()
+			->usePreset('dragula')
+			->useScript('joomla.draggable');
 
 		// Set static array
 		static::$loaded[__METHOD__] = true;

--- a/libraries/cms/html/formbehavior.php
+++ b/libraries/cms/html/formbehavior.php
@@ -87,22 +87,22 @@ abstract class JHtmlFormbehavior
 			$options['no_results_text'] = Text::_('JGLOBAL_SELECT_NO_RESULTS_MATCH');
 		}
 
-		// Include jQuery
-		HTMLHelper::_('jquery.framework');
-		HTMLHelper::_('script', 'vendor/chosen/chosen.jquery.js', ['version' => 'auto', 'relative' => true]);
-		HTMLHelper::_('script', 'legacy/joomla-chosen.min.js', ['version' => 'auto', 'relative' => true]);
-		HTMLHelper::_('stylesheet', 'vendor/chosen/chosen.css', ['version' => 'auto', 'relative' => true]);
-
 		// Options array to json options string
 		$options_str = json_encode($options, ($debug && defined('JSON_PRETTY_PRINT') ? JSON_PRETTY_PRINT : false));
 
-		Factory::getDocument()->addScriptDeclaration(
-			"
+		// Add chosen.js assets
+
+		/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+		$wa = Factory::getApplication()->getDocument()->getWebAssetManager();
+		$wa->usePreset('chosen')
+			->registerAndUseScript('joomla-chosen', 'legacy/joomla-chosen.min.js', [], [], ['chosen'])
+			->addInlineScript(
+				"
 		jQuery(document).ready(function (){
 			jQuery('" . $selector . "').jchosen(" . $options_str . ");
 		});
 	"
-		);
+			);
 
 		static::$loaded[__METHOD__][$selector] = true;
 	}

--- a/plugins/media-action/crop/crop.php
+++ b/plugins/media-action/crop/crop.php
@@ -30,7 +30,6 @@ class PlgMediaActionCrop extends \Joomla\Component\Media\Administrator\Plugin\Me
 		parent::loadJs();
 
 		Factory::getApplication()->getDocument()->getWebAssetManager()->useScript('cropperjs');
-
 	}
 
 	/**

--- a/plugins/media-action/crop/crop.php
+++ b/plugins/media-action/crop/crop.php
@@ -9,7 +9,7 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Factory;
 
 /**
  * Media Manager Crop Action
@@ -29,7 +29,8 @@ class PlgMediaActionCrop extends \Joomla\Component\Media\Administrator\Plugin\Me
 	{
 		parent::loadJs();
 
-		HTMLHelper::_('script', 'vendor/cropperjs/cropper.min.js', array('version' => 'auto', 'relative' => true));
+		Factory::getApplication()->getDocument()->getWebAssetManager()->useScript('cropperjs');
+
 	}
 
 	/**
@@ -43,6 +44,6 @@ class PlgMediaActionCrop extends \Joomla\Component\Media\Administrator\Plugin\Me
 	{
 		parent::loadCss();
 
-		HTMLHelper::_('stylesheet', 'vendor/cropperjs/cropper.min.css', array('version' => 'auto', 'relative' => true));
+		Factory::getApplication()->getDocument()->getWebAssetManager()->useStyle('cropperjs');
 	}
 }

--- a/plugins/system/skipto/skipto.php
+++ b/plugins/system/skipto/skipto.php
@@ -10,7 +10,6 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Application\CMSApplicationInterface;
-use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Plugin\CMSPlugin;
 
@@ -76,14 +75,14 @@ class PlgSystemSkipto extends CMSPlugin
 			]
 		);
 
-		HTMLHelper::_('script', 'vendor/skipto/dropMenu.js', ['version' => 'auto', 'relative' => true], ['defer' => true]);
-		HTMLHelper::_('script', 'vendor/skipto/skipTo.js', ['version' => 'auto', 'relative' => true], ['defer' => true]);
-		HTMLHelper::_('stylesheet', 'vendor/skipto/SkipTo.css', ['version' => 'auto', 'relative' => true]);
-
-		$document->addScriptDeclaration("document.addEventListener('DOMContentLoaded', function() {
-			window.SkipToConfig = Joomla.getOptions('skipto-settings');
-			window.skipToMenuInit();
-		});"
-		);
+		/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+		$wa = $document->getWebAssetManager();
+		$wa->useStyle('skipto')
+			->useScript('skipto.dropmenu')
+			->useScript('skipto')
+			->addInlineScript('document.addEventListener(\'DOMContentLoaded\', function() {
+				window.SkipToConfig = Joomla.getOptions(\'skipto-settings\');
+				window.skipToMenuInit();
+			});', [], ['type' => 'module'], ['skipto']);
 	}
 }

--- a/plugins/system/skipto/skipto.php
+++ b/plugins/system/skipto/skipto.php
@@ -80,9 +80,13 @@ class PlgSystemSkipto extends CMSPlugin
 		$wa->useStyle('skipto')
 			->useScript('skipto.dropmenu')
 			->useScript('skipto')
-			->addInlineScript('document.addEventListener(\'DOMContentLoaded\', function() {
-				window.SkipToConfig = Joomla.getOptions(\'skipto-settings\');
-				window.skipToMenuInit();
-			});', [], ['type' => 'module'], ['skipto']);
+			->addInlineScript(
+				'document.addEventListener(\'DOMContentLoaded\', function() {'
+				.'window.SkipToConfig = Joomla.getOptions(\'skipto-settings\');'
+				.'window.skipToMenuInit();});',
+				[],
+				['type' => 'module'],
+				['skipto']
+			);
 	}
 }

--- a/plugins/system/skipto/skipto.php
+++ b/plugins/system/skipto/skipto.php
@@ -82,8 +82,8 @@ class PlgSystemSkipto extends CMSPlugin
 			->useScript('skipto')
 			->addInlineScript(
 				'document.addEventListener(\'DOMContentLoaded\', function() {'
-				.'window.SkipToConfig = Joomla.getOptions(\'skipto-settings\');'
-				.'window.skipToMenuInit();});',
+				. 'window.SkipToConfig = Joomla.getOptions(\'skipto-settings\');'
+				. 'window.skipToMenuInit();});',
 				[],
 				['type' => 'module'],
 				['skipto']


### PR DESCRIPTION
### Summary of Changes

The patch replaces use HTMLHelper::_('script/stylesheet') that loads a files from `media/vendor/` folder, to use WebAsset


### Testing Instructions

Apply patch, run `npm install`.
And check that everything still works, the changes here affects next parts:
* history compare view
* admin mod_menu
* template style colors field
* template edit
* skipTo
* crop action in media manager
* chosen (why do we still have it? :) ) - I did not found where it used
* draggable - drag sorting - can test in menu items  table


### Expected result

All works

### Actual result

All works


### Documentation Changes Required
nope
