### PR TITLE
[4.0] Quicktask for custom adminmenu

### DIFF
--- a/administrator/components/com_categories/tmpl/categories/default.xml
+++ b/administrator/components/com_categories/tmpl/categories/default.xml
@@ -5,8 +5,8 @@
 			<![CDATA[COM_CATEGORIES_CATEGORIES_VIEW_DEFAULT_DESC]]>
 		</message>
 	</layout>
-	<fieldset name="request">
-		<fields name="request">
+	<fields name="request">
+		<fieldset name="request">
 			<field
 				name="extension"
 				type="ComponentsCategory"
@@ -15,13 +15,6 @@
 			>
 				<option value="">COM_MENUS_OPTION_SELECT_COMPONENT</option>
 			</field>
-		</fields>
-	</fieldset>
-	<field name="params">
-		<field
-			name="menu-quicktask"
-			type="hidden"
-			value="index.php?option=com_categories&amp;extension=com_content&amp;task=category.add"
-		/>
-	</field>
+		</fieldset>
+	</fields>
 </metadata>

--- a/administrator/components/com_content/tmpl/articles/default.xml
+++ b/administrator/components/com_content/tmpl/articles/default.xml
@@ -82,5 +82,24 @@
 
 		</fieldset>
 	</fields>
-
+	<fields
+		name="params">
+		<fieldset
+			name="basic">
+			<field
+				name="menu-quicktask"
+				type="radio"
+				class="switcher"
+				label="MOD_MENU_FIELD_SHOWNEW"
+			>
+				<option value="">JHIDE</option>
+				<option value="index.php?option=com_content&amp;task=article.add">JSHOW</option>
+			</field>
+			<field
+				name="menu-quicktask-title"
+				type="hidden"
+				default="MOD_MENU_COM_CONTENT_NEW_ARTICLE"
+			/>
+		</fieldset>
+	</fields>
 </metadata>

--- a/administrator/components/com_content/tmpl/articles/default.xml
+++ b/administrator/components/com_content/tmpl/articles/default.xml
@@ -98,7 +98,7 @@
 			<field
 				name="menu-quicktask-title"
 				type="hidden"
-				default="MOD_MENU_COM_CONTENT_NEW_ARTICLE"
+				default="COM_CONTENT_MENUS_NEW_ARTICLE"
 			/>
 
 		</fieldset>

--- a/administrator/components/com_content/tmpl/articles/default.xml
+++ b/administrator/components/com_content/tmpl/articles/default.xml
@@ -90,7 +90,7 @@
 				type="radio"
 				class="switcher"
 				label="MOD_MENU_FIELD_SHOWNEW"
-			>
+				>
 				<option value="">JHIDE</option>
 				<option value="index.php?option=com_content&amp;task=article.add">JSHOW</option>
 			</field>

--- a/administrator/components/com_content/tmpl/articles/default.xml
+++ b/administrator/components/com_content/tmpl/articles/default.xml
@@ -88,8 +88,8 @@
 			<field
 				name="menu-quicktask"
 				type="radio"
-				class="switcher"
 				label="MOD_MENU_FIELD_SHOWNEW"
+				class="switcher"
 				>
 				<option value="">JHIDE</option>
 				<option value="index.php?option=com_content&amp;task=article.add">JSHOW</option>

--- a/administrator/components/com_content/tmpl/articles/default.xml
+++ b/administrator/components/com_content/tmpl/articles/default.xml
@@ -82,10 +82,9 @@
 
 		</fieldset>
 	</fields>
-	<fields
-		name="params">
-		<fieldset
-			name="basic">
+	<fields name="params">
+		<fieldset name="basic">
+
 			<field
 				name="menu-quicktask"
 				type="radio"
@@ -95,11 +94,13 @@
 				<option value="">JHIDE</option>
 				<option value="index.php?option=com_content&amp;task=article.add">JSHOW</option>
 			</field>
+
 			<field
 				name="menu-quicktask-title"
 				type="hidden"
 				default="MOD_MENU_COM_CONTENT_NEW_ARTICLE"
 			/>
+
 		</fieldset>
 	</fields>
 </metadata>

--- a/administrator/components/com_content/tmpl/articles/default.xml
+++ b/administrator/components/com_content/tmpl/articles/default.xml
@@ -89,7 +89,7 @@
 				name="menu-quicktask"
 				type="radio"
 				label="MOD_MENU_FIELD_SHOWNEW"
-				class="switcher"
+				layout="joomla.form.field.radio.switcher"
 				>
 				<option value="">JHIDE</option>
 				<option value="index.php?option=com_content&amp;task=article.add">JSHOW</option>

--- a/administrator/components/com_menus/Helper/MenusHelper.php
+++ b/administrator/components/com_menus/Helper/MenusHelper.php
@@ -980,8 +980,7 @@ class MenusHelper extends ContentHelper
 
 		if ((string) $node['quicktask'])
 		{
-			$params->set('menu-quicktask', true);
-			$params->set('menu-quicktask-link', (string) $node['quicktask']);
+			$params->set('menu-quicktask', (string) $node['quicktask']);
 			$params->set('menu-quicktask-title', (string) $node['quicktask-title']);
 			$params->set('menu-quicktask-icon', (string) $node['quicktask-icon']);
 			$params->set('menu-quicktask-permission', (string) $node['quicktask-permission']);
@@ -995,7 +994,7 @@ class MenusHelper extends ContentHelper
 			$item->link    = str_replace("{sql:$var}", $val, $item->link);
 			$item->class   = str_replace("{sql:$var}", $val, $item->class);
 			$item->icon    = str_replace("{sql:$var}", $val, $item->icon);
-			$params->set('menu-quicktask-link', str_replace("{sql:$var}", $val, $params->get('menu-quicktask-link')));
+			$params->set('menu-quicktask', str_replace("{sql:$var}", $val, $params->get('menu-quicktask')));
 		}
 
 		$item->setParams($params);

--- a/administrator/modules/mod_menu/tmpl/default_submenu.php
+++ b/administrator/modules/mod_menu/tmpl/default_submenu.php
@@ -148,11 +148,11 @@ else
 	echo '<span>' . Text::_($current->title) . '</span>' . $ajax;
 }
 
-if ($currentParams->get('menu-quicktask', false) && $this->params->get('shownew', 1) === 1)
+if ($currentParams->get('menu-quicktask') && $this->params->get('shownew', 1) === 1)
 {
 	$params = $current->getParams();
 	$user = $this->application->getIdentity();
-	$link = $params->get('menu-quicktask-link');
+	$link = $params->get('menu-quicktask');
 	$icon = $params->get('menu-quicktask-icon', 'plus');
 	$title = $params->get('menu-quicktask-title', 'MOD_MENU_QUICKTASK_NEW');
 	$permission = $params->get('menu-quicktask-permission');

--- a/administrator/modules/mod_submenu/tmpl/default.php
+++ b/administrator/modules/mod_submenu/tmpl/default.php
@@ -45,13 +45,13 @@ use Joomla\CMS\Router\Route;
 										</span>
 									<?php endif; ?>
 								</a>
-								<?php if ($params->get('menu-quicktask', false)) : ?>
+								<?php if ($params->get('menu-quicktask')) : ?>
 									<?php $permission = $params->get('menu-quicktask-permission'); ?>
 									<?php $scope = $item->scope !== 'default' ? $item->scope : null; ?>
 									<?php if (!$permission || $user->authorise($permission, $scope)) : ?>
 										<span class="menu-quicktask">
 											<?php
-											$link = $params->get('menu-quicktask-link');
+											$link = $params->get('menu-quicktask');
 											$icon = $params->get('menu-quicktask-icon', 'plus');
 
 											$title = Text::_($params->get('menu-quicktask-title'));


### PR DESCRIPTION
Currently, a custom admin menu can't have a quicktask icon like used in the default menu.
![image](https://user-images.githubusercontent.com/1018684/74185974-0695e880-4c4a-11ea-99f1-b2c73a06e9de.png)

### Summary of Changes
This adds this feature to the custom menuitem "List All Articles".
After applying this PR, you'll see a new tab "Options" with a new parameter
![image](https://user-images.githubusercontent.com/1018684/74186166-5ffe1780-4c4a-11ea-8b3a-1c54de4c0589.png)

This PR also simplyfies the code related to the quicktask a bit as we don't need two parameters `menu-quicktask` and `menu-quicktask-link`. I've merged that into one switcher parameter which when enabled holds the quicktask link directly.

I've also removed the quicktask parameter from the categories menuitem. First reason is that it didn't work to begin with, second one is that the link was hardcoded to com_content, but the menuitem allows to select the "category scope". So even if I fixed the parameter in the XML, it still wouldn't work as expected. So I removed it.

### Testing Instructions
Create a custom admin menu and add a "List All Articles" menuitem to it.
Check options and how the menuitem appears.


### Expected result
An option to show/hide the "Add New" button
Depending on setting, the "Add New" button appears


### Actual result
No way of using that feature in the custom menu.


### Documentation Changes Required
None