### PR TITLE
[4.0] Move featured logic from content table

### DIFF
--- a/administrator/components/com_content/Model/ArticleModel.php
+++ b/administrator/components/com_content/Model/ArticleModel.php
@@ -539,6 +539,7 @@ class ArticleModel extends AdminModel
 						->from($db->quoteName('#__content_frontpage'))
 						->where($db->quoteName('content_id') . ' = :id')
 						->bind(':id', $item->id, ParameterType::INTEGER);
+
 					$featured = $db->setQuery($query)->loadObject();
 
 					if ($featured)

--- a/administrator/components/com_content/Model/ArticleModel.php
+++ b/administrator/components/com_content/Model/ArticleModel.php
@@ -101,9 +101,7 @@ class ArticleModel extends AdminModel
 			{
 				$query = $db->getQuery(true)
 					->insert($db->quoteName('#__content_frontpage'))
-					->values(
-						':newId, 0, :featuredUp, :featuredDown'
-					)
+					->values(':newId, 0, :featuredUp, :featuredDown')
 					->bind(':newId', $newId, ParameterType::INTEGER)
 					->bind(':featuredUp', $featured->featured_up, $featured->featured_up ? ParameterType::STRING : ParameterType::NULL)
 					->bind(':featuredDown', $featured->featured_down, $featured->featured_down ? ParameterType::STRING : ParameterType::NULL);

--- a/administrator/components/com_content/Model/ArticleModel.php
+++ b/administrator/components/com_content/Model/ArticleModel.php
@@ -31,6 +31,7 @@ use Joomla\Component\Content\Administrator\Extension\ContentComponent;
 use Joomla\Component\Content\Administrator\Helper\ContentHelper;
 use Joomla\Component\Fields\Administrator\Helper\FieldsHelper;
 use Joomla\Component\Workflow\Administrator\Table\StageTable;
+use Joomla\Database\ParameterType;
 use Joomla\Registry\Registry;
 use Joomla\Utilities\ArrayHelper;
 
@@ -84,15 +85,32 @@ class ArticleModel extends AdminModel
 		{
 			$db = $this->getDbo();
 			$query = $db->getQuery(true)
-				->insert($db->quoteName('#__content_frontpage'))
-				->values(
-					$newId . ', 0, '
-					. (empty($table->featured_up) ? 'NULL' : $db->quote($table->featured_up))
-					. ', '
-					. (empty($table->featured_down) ? 'NULL' : $db->quote($table->featured_down))
-				);
-			$db->setQuery($query);
-			$db->execute();
+				->select(
+					[
+						$db->quoteName('featured_up'),
+						$db->quoteName('featured_down'),
+					]
+				)
+				->from($db->quoteName('#__content_frontpage'))
+				->where($db->quoteName('content_id') . ' = :oldId')
+				->bind(':oldId', $oldId, ParameterType::INTEGER);
+
+			$featured = $db->setQuery($query)->loadObject();
+
+			if ($featured)
+			{
+				$query = $db->getQuery(true)
+					->insert($db->quoteName('#__content_frontpage'))
+					->values(
+						':newId, 0, :featuredUp, :featuredDown'
+					)
+					->bind(':newId', $newId, ParameterType::INTEGER)
+					->bind(':featuredUp', $featured->featured_up, $featured->featured_up ? ParameterType::STRING : ParameterType::NULL)
+					->bind(':featuredDown', $featured->featured_down, $featured->featured_down ? ParameterType::STRING : ParameterType::NULL);
+
+					$db->setQuery($query);
+					$db->execute();
+			}
 		}
 
 		// Copy workflow association
@@ -505,6 +523,32 @@ class ArticleModel extends AdminModel
 			{
 				$item->tags = new TagsHelper;
 				$item->tags->getTagIds($item->id, 'com_content.article');
+
+				$item->featured_up   = null;
+				$item->featured_down = null;
+
+				if ($item->featured)
+				{
+					// Get featured dates.
+					$db = $this->getDbo();
+					$query = $db->getQuery(true)
+						->select(
+							[
+								$db->quoteName('featured_up'),
+								$db->quoteName('featured_down'),
+							]
+						)
+						->from($db->quoteName('#__content_frontpage'))
+						->where($db->quoteName('content_id') . ' = :id')
+						->bind(':id', $item->id, ParameterType::INTEGER);
+					$featured = $db->setQuery($query)->loadObject();
+
+					if ($featured)
+					{
+						$item->featured_up   = $featured->featured_up;
+						$item->featured_down = $featured->featured_down;
+					}
+				}
 			}
 		}
 

--- a/libraries/src/Table/Content.php
+++ b/libraries/src/Table/Content.php
@@ -375,42 +375,4 @@ class Content extends Table
 
 		return parent::store($updateNulls);
 	}
-
-	/**
-	 * Overrides Table::store to load a row from the database.
-	 *
-	 * @param   mixed    $keys   An optional primary key value to load the row by, or an array of fields to match.
-	 *                           If not set the instance property value is used.
-	 * @param   boolean  $reset  True to reset the default values before loading the new row.
-	 *
-	 * @return  boolean  True if successful. False if row not found.
-	 *
-	 * @since   1.7.0
-	 * @throws  \InvalidArgumentException
-	 * @throws  \RuntimeException
-	 * @throws  \UnexpectedValueException
-	 */
-	public function load($keys = null, $reset = true)
-	{
-		if ($ret = parent::load($keys, $reset, false))
-		{
-			// Load featuerd dates
-			$query = $this->_db->getQuery(true)
-				->select('featured_up, featured_down')
-				->from('#__content_frontpage')
-				->where('content_id = ' . (int) $this->id);
-			$this->_db->setQuery($query);
-
-			$row = $this->_db->loadAssoc();
-
-			// Check that we have a result.
-			if (!empty($row))
-			{
-				$this->featured_up = $row['featured_up'];
-				$this->featured_down = $row['featured_down'];
-			}
-		}
-
-		return $ret;
-	}
 }


### PR DESCRIPTION
### Summary of Changes

This moves some code related to feature articles dates from `Joomla\CMS\Table\Content` to `Joomla\Component\Content\Model\Aministrator\ArticleModel`.

### Testing Instructions

Create a featured article. Set featured up/down dates.
Use batch copy to another category.
Edit the copied article. Check that featured status and featured up/down dates are copied correctly.

### Expected result

Works like before.

### Documentation Changes Required

No.