### PR TITLE
[4.0]fixed error of dropdown not closing

### DIFF
--- a/build/media_source/templates/atum/js/template.es6.js
+++ b/build/media_source/templates/atum/js/template.es6.js
@@ -284,4 +284,14 @@
       });
     }
   });
+  document.getElementById('wrapper').addEventListener('click', () => {
+    if (document.querySelector('.active')) {
+      document.getElementById('header-more-items').classList.toggle('active');
+    }
+  });
+  document.getElementsByClassName('header-title')[0].addEventListener('click', () => {
+    if (document.querySelector('.active')) {
+      document.getElementById('header-more-items').classList.toggle('active');
+    }
+  });
 })(window.Joomla, document);

--- a/build/media_source/templates/atum/js/template.es6.js
+++ b/build/media_source/templates/atum/js/template.es6.js
@@ -284,8 +284,8 @@
       });
     }
   });
-  document.getElementsByClassName('admin')[0].addEventListener('click', (event) => {
-    if (document.querySelector('.active') && !document.querySelector('.header-item-more').contains(event.target)) {
+  document.addEventListener('click', (event) => {
+    if (document.getElementById('header-more-itemste').querySelector('.active') && !document.querySelector('.header-item-more').contains(event.target)) {
       document.getElementById('header-more-items').classList.remove('active');
     }
   });

--- a/build/media_source/templates/atum/js/template.es6.js
+++ b/build/media_source/templates/atum/js/template.es6.js
@@ -289,7 +289,7 @@
       document.getElementById('header-more-items').classList.remove('active');
     }
   });
-  document.querySelector('header').querySelectorAll('button.dropdown-toggle').forEach((selector)=>{
+  document.querySelector('header').querySelectorAll('button.dropdown-toggle').forEach((selector) => {
     selector.addEventListener('click', (event) => {
       if (document.querySelector('.header-item-more') && document.querySelector('header').querySelector('.active') && !document.querySelector('.header-item-more').contains(event.target)) {
         document.getElementById('header-more-items').classList.remove('active');

--- a/build/media_source/templates/atum/js/template.es6.js
+++ b/build/media_source/templates/atum/js/template.es6.js
@@ -285,7 +285,12 @@
     }
   });
   document.addEventListener('click', (event) => {
-    if (document.getElementById('header-more-items') && document.querySelector('.active') && !document.querySelector('.header-item-more').contains(event.target)) {
+    if (document.querySelector('.header-item-more') && document.querySelector('header').querySelector('.active') && !document.querySelector('.header-item-more').contains(event.target)) {
+      document.getElementById('header-more-items').classList.remove('active');
+    }
+  });
+  document.querySelector('header').querySelector('button.dropdown-toggle').addEventListener('click', (event) => {
+    if (document.querySelector('.header-item-more') && document.querySelector('header').querySelector('.active') && !document.querySelector('.header-item-more').contains(event.target)) {
       document.getElementById('header-more-items').classList.remove('active');
     }
   });

--- a/build/media_source/templates/atum/js/template.es6.js
+++ b/build/media_source/templates/atum/js/template.es6.js
@@ -285,7 +285,7 @@
     }
   });
   document.addEventListener('click', (event) => {
-    if (document.getElementById('header-more-items').querySelector('.active') && !document.querySelector('.header-item-more').contains(event.target)) {
+    if (document.getElementById('header-more-items') && document.querySelector('.active') && !document.querySelector('.header-item-more').contains(event.target)) {
       document.getElementById('header-more-items').classList.remove('active');
     }
   });

--- a/build/media_source/templates/atum/js/template.es6.js
+++ b/build/media_source/templates/atum/js/template.es6.js
@@ -284,14 +284,9 @@
       });
     }
   });
-  document.getElementById('wrapper').addEventListener('click', () => {
-    if (document.querySelector('.active')) {
-      document.getElementById('header-more-items').classList.toggle('active');
-    }
-  });
-  document.getElementsByClassName('header-title')[0].addEventListener('click', () => {
-    if (document.querySelector('.active')) {
-      document.getElementById('header-more-items').classList.toggle('active');
+  document.getElementsByClassName('admin')[0].addEventListener('click', (event) => {
+    if (document.querySelector('.active') && !document.querySelector('.header-item-more').contains(event.target)) {
+      document.getElementById('header-more-items').classList.remove('active');
     }
   });
 })(window.Joomla, document);

--- a/build/media_source/templates/atum/js/template.es6.js
+++ b/build/media_source/templates/atum/js/template.es6.js
@@ -285,7 +285,7 @@
     }
   });
   document.addEventListener('click', (event) => {
-    if (document.getElementById('header-more-itemste').querySelector('.active') && !document.querySelector('.header-item-more').contains(event.target)) {
+    if (document.getElementById('header-more-items').querySelector('.active') && !document.querySelector('.header-item-more').contains(event.target)) {
       document.getElementById('header-more-items').classList.remove('active');
     }
   });

--- a/build/media_source/templates/atum/js/template.es6.js
+++ b/build/media_source/templates/atum/js/template.es6.js
@@ -289,9 +289,11 @@
       document.getElementById('header-more-items').classList.remove('active');
     }
   });
-  document.querySelector('header').querySelector('button.dropdown-toggle').addEventListener('click', (event) => {
-    if (document.querySelector('.header-item-more') && document.querySelector('header').querySelector('.active') && !document.querySelector('.header-item-more').contains(event.target)) {
-      document.getElementById('header-more-items').classList.remove('active');
-    }
+  document.querySelector('header').querySelectorAll('button.dropdown-toggle').forEach((selector)=>{
+    selector.addEventListener('click', (event) => {
+      if (document.querySelector('.header-item-more') && document.querySelector('header').querySelector('.active') && !document.querySelector('.header-item-more').contains(event.target)) {
+        document.getElementById('header-more-items').classList.remove('active');
+      }
+    });
   });
 })(window.Joomla, document);


### PR DESCRIPTION
Pull Request for Issue #27530 .

### Summary of Changes
Added event listeners for certain areas and on checking if the dropdown is active it removes the active class


### Testing Instructions
Open the administrator/index.php page and check the dropdown on top navbar after reducing the width of screen to a suitable size.


### Expected result
The dropdown should close without having to click on the same place from where it was opened.


### Actual result
Closes the dropdown on clicking on other regions also



### Documentation Changes Required

