### PR TITLE
Fix error in custom field form on PHP 5.3

### DIFF
--- a/administrator/components/com_fields/models/fields/fieldlayout.php
+++ b/administrator/components/com_fields/models/fields/fieldlayout.php
@@ -36,7 +36,8 @@ class JFormFieldFieldlayout extends JFormField
 	 */
 	protected function getInput()
 	{
-		$extension = explode('.', $this->form->getValue('context'))[0];
+		$extension = explode('.', $this->form->getValue('context'));
+		$extension = $extension[0];
 
 		if ($extension)
 		{


### PR DESCRIPTION
### Summary of Changes

Fixes error on PHP 5.3.

### Testing Instructions

Create a custom field.

### Expected result

No errors.

### Actual result

>Parse error: syntax error, unexpected '[' in administrator\components\com_fields\models\fields\fieldlayout.php on line 39

### Documentation Changes Required

No.