### PR TITLE
[4.0] Fix sticky positioning with RTL in Edge

### DIFF
--- a/administrator/templates/atum/scss/blocks/_toolbar.scss
+++ b/administrator/templates/atum/scss/blocks/_toolbar.scss
@@ -505,3 +505,10 @@ joomla-toolbar-button {
     }
   }
 }
+
+// In Microsoft Edge, sticky positioning doesn't work when combined with dir "rtl" attribute
+@supports (-ms-ime-align: auto) {
+  [dir=rtl] .subhead {
+    position: relative;
+  } 
+}


### PR DESCRIPTION
Pull Request for Issue #27831.

### Summary of Changes
In Microsoft Edge, sticky positioning doesn't work when combined with dir "rtl" attribute.

@ciar4n Thanks for the code!


### Testing Instructions
Use Microsoft EdgeHTML 18.18363 (non-chromium).
Install Persian language.
Edit account.
Switch to Persian language for the backend language.
Click Save & Close.
Edit account.
See missing toolbar.
This is happening with toolbars in other areas.


### Expected result
![73986383-572bdf80-48f2-11ea-8455-83407b442064-after](https://user-images.githubusercontent.com/368084/74267572-29acb080-4cbb-11ea-8c9a-a8e8ece82f4c.jpg)



### Actual result
![73986388-598e3980-48f2-11ea-877f-4e1d931a8b7d](https://user-images.githubusercontent.com/368084/74267578-2ca7a100-4cbb-11ea-9e7c-77bfd89900e6.jpg)

