### PR TITLE
[4.0] Categories can have sections

### DIFF
--- a/administrator/components/com_menus/src/Field/ComponentsCategoryField.php
+++ b/administrator/components/com_menus/src/Field/ComponentsCategoryField.php
@@ -41,47 +41,48 @@ class ComponentsCategoryField extends ListField
 	protected function getOptions()
 	{
 		// Initialise variable.
-		$db = Factory::getDbo();
-		$query = $db->getQuery(true)
-			->select(
-				[
-					'DISTINCT ' . $db->quoteName('a.name', 'text'),
-					$db->quoteName('a.element', 'value'),
-				]
-			)
-			->from($db->quoteName('#__extensions', 'a'))
-			->join('INNER', $db->quoteName('#__categories', 'b'), $db->quoteName('a.element') . ' = ' . $db->quoteName('b.extension'))
-			->where(
-				[
-					$db->quoteName('a.enabled') . ' >= 1',
-					$db->quoteName('a.type') . ' = ' . $db->quote('component'),
-				]
-			);
+		$db      = Factory::getDbo();
+		$options = array();
 
-		$items = $db->setQuery($query)->loadObjectList();
+		$query = $db->getQuery(true);
+		$query->select('DISTINCT ' . $db->quoteName('extension'))
+			->from('#__categories')
+			->where($db->quoteName('extension') . ' != ' . $db->quote('system'));
 
-		if (count($items))
+		$db->setQuery($query);
+		$categoryTypes = $db->loadColumn();
+
+		foreach ($categoryTypes as $categoryType)
 		{
+			$option        = new \stdClass();
+			$option->value = $categoryType;
+
+			// Extract the component name and optional section name
+			$parts     = explode('.', $categoryType);
+			$component = $parts[0];
+			$section   = (count($parts) > 1) ? $parts[1] : null;
+
+			// Load component language files
 			$lang = Factory::getLanguage();
+			$lang->load($component, JPATH_BASE)
+			|| $lang->load($component, JPATH_ADMINISTRATOR . '/components/' . $component);
 
-			foreach ($items as &$item)
+			// If the component section string exits, let's use it
+			if ($lang->hasKey($component_section_key = strtoupper($component . ($section ? "_$section" : ''))))
 			{
-				// Load language
-				$extension = $item->value;
-				$source = JPATH_ADMINISTRATOR . '/components/' . $extension;
-				$lang->load("$extension.sys", JPATH_ADMINISTRATOR)
-					|| $lang->load("$extension.sys", $source);
-
-				// Translate component name
-				$item->text = Text::_($item->text);
+				$option->text = Text::_($component_section_key);
+			}
+			else
+				// Else use the component title
+			{
+				$option->text = Text::_(strtoupper($component));
 			}
 
-			// Sort by component name
-			$items = ArrayHelper::sortObjects($items, 'text', 1, true, true);
+			$options[] = $option;
 		}
 
 		// Merge any additional options in the XML definition.
-		$options = array_merge(parent::getOptions(), $items);
+		$options = array_merge(parent::getOptions(), $options);
 
 		return $options;
 	}

--- a/administrator/components/com_menus/src/Field/ComponentsCategoryField.php
+++ b/administrator/components/com_menus/src/Field/ComponentsCategoryField.php
@@ -87,7 +87,6 @@ class ComponentsCategoryField extends ListField
 		// Merge any additional options in the XML definition.
 		$options = array_merge(parent::getOptions(), $options);
 
-
 		return $options;
 	}
 }

--- a/administrator/components/com_menus/src/Field/ComponentsCategoryField.php
+++ b/administrator/components/com_menus/src/Field/ComponentsCategoryField.php
@@ -81,8 +81,12 @@ class ComponentsCategoryField extends ListField
 			$options[] = $option;
 		}
 
+		// Sort by name
+		$options = ArrayHelper::sortObjects($options, 'text', 1, true, true);
+
 		// Merge any additional options in the XML definition.
 		$options = array_merge(parent::getOptions(), $options);
+
 
 		return $options;
 	}

--- a/administrator/components/com_menus/src/Field/ComponentsCategoryField.php
+++ b/administrator/components/com_menus/src/Field/ComponentsCategoryField.php
@@ -67,7 +67,7 @@ class ComponentsCategoryField extends ListField
 			$lang->load($component, JPATH_BASE)
 			|| $lang->load($component, JPATH_ADMINISTRATOR . '/components/' . $component);
 
-			// If the component section string exits, let's use it
+			// If the component section string exists, let's use it
 			if ($lang->hasKey($component_section_key = strtoupper($component . ($section ? "_$section" : ''))))
 			{
 				$option->text = Text::_($component_section_key);

--- a/administrator/components/com_menus/src/Field/ComponentsCategoryField.php
+++ b/administrator/components/com_menus/src/Field/ComponentsCategoryField.php
@@ -46,7 +46,7 @@ class ComponentsCategoryField extends ListField
 
 		$query = $db->getQuery(true);
 		$query->select('DISTINCT ' . $db->quoteName('extension'))
-			->from('#__categories')
+			->from($db->quoteName('#__categories'))
 			->where($db->quoteName('extension') . ' != ' . $db->quote('system'));
 
 		$db->setQuery($query);

--- a/administrator/components/com_menus/src/Field/ComponentsCategoryField.php
+++ b/administrator/components/com_menus/src/Field/ComponentsCategoryField.php
@@ -54,7 +54,7 @@ class ComponentsCategoryField extends ListField
 
 		foreach ($categoryTypes as $categoryType)
 		{
-			$option        = new \stdClass();
+			$option        = new \stdClass;
 			$option->value = $categoryType;
 
 			// Extract the component name and optional section name


### PR DESCRIPTION
When creating a new admin menuitem of the type "List All Categories", you need to select for which component the categories should be shown.
That list only shows categories where the `extension` field in the database is set to the component name. However categories can also have sections, eg instead of just `com_foo` that field then has `com_foo.bar`.
The current code will not let you select categories which have sections.

### Summary of Changes
This PR changes the code to populate the option list so it works also for categories with sections.
For the naming, it follows loosely the logic we have in the categories manager itself. See https://github.com/joomla/joomla-cms/blob/6da26fb6da4b3955c051924a0c7fbae672cabd51/administrator/components/com_categories/View/Categories/HtmlView.php#L161-L175

### Testing Instructions
To see a difference, you will need a component which uses categories with sections. Core doesn't use that but you can use my SermonSpeaker component (or any other that uses sections). 
[com_sermonspeaker.zip](https://github.com/joomla/joomla-cms/files/4188441/com_sermonspeaker.zip)
For core itself, you should see no difference before and after this PR.

To test:
* Create a custom admin menuitem of type "List All Categories"
* Check the "Choose a Component" dropdown if you see all category types.

### Expected result
![image](https://user-images.githubusercontent.com/1018684/74280952-d3bd2480-4d1d-11ea-8bb5-e52c3b3528cb.png)




### Actual result
![image](https://user-images.githubusercontent.com/1018684/74280699-55608280-4d1d-11ea-93cd-f723e45d76e6.png)



### Documentation Changes Required
None
