### PR TITLE
[4.0] Hiding the overflow of container.main class

### DIFF
--- a/administrator/templates/atum/scss/blocks/_global.scss
+++ b/administrator/templates/atum/scss/blocks/_global.scss
@@ -109,7 +109,7 @@ body .container-main {
   min-height: calc(100vh - #{$header-height} - 3px);
   padding-left: 0;
   padding-right: 0;
-  overflow: hidden;
+  overflow: auto;
   &::before,
   &::after {
     content: '';

--- a/administrator/templates/atum/scss/blocks/_global.scss
+++ b/administrator/templates/atum/scss/blocks/_global.scss
@@ -109,6 +109,7 @@ body .container-main {
   min-height: calc(100vh - #{$header-height} - 3px);
   padding-left: 0;
   padding-right: 0;
+  overflow: hidden;
 
   &::before,
   &::after {

--- a/administrator/templates/atum/scss/blocks/_global.scss
+++ b/administrator/templates/atum/scss/blocks/_global.scss
@@ -109,7 +109,7 @@ body .container-main {
   min-height: calc(100vh - #{$header-height} - 3px);
   padding-left: 0;
   padding-right: 0;
-
+  overflow: hidden;
   &::before,
   &::after {
     content: '';

--- a/administrator/templates/atum/scss/blocks/_global.scss
+++ b/administrator/templates/atum/scss/blocks/_global.scss
@@ -109,7 +109,6 @@ body .container-main {
   min-height: calc(100vh - #{$header-height} - 3px);
   padding-left: 0;
   padding-right: 0;
-  overflow: hidden;
 
   &::before,
   &::after {


### PR DESCRIPTION
Pull Request for Issue #27674  .

### Summary of Changes

I have set the overflow of container-main class as auto because under articles, it had too many options and two scroll bars can be seen on the page. Also, on expanding the sidebar, the content on the RHS wasn't getting diminished.

### Testing Instructions

Run npm build run:css after merging changes and clear browser's cache

### Expected result

No additional Scroll Bar

### Actual result

Expected Result Achived

### Documentation Changes Required

None.