### PR TITLE
[4.0] Remove ComponentRecord params property uses

### DIFF
--- a/administrator/components/com_config/src/View/Component/HtmlView.php
+++ b/administrator/components/com_config/src/View/Component/HtmlView.php
@@ -83,9 +83,9 @@ class HtmlView extends BaseHtmlView
 		}
 
 		// Bind the form to the data.
-		if ($form && $component->params)
+		if ($form)
 		{
-			$form->bind($component->params);
+			$form->bind($component->getParams());
 		}
 
 		$this->fieldsets   = $form ? $form->getFieldsets() : null;

--- a/plugins/system/updatenotification/updatenotification.php
+++ b/plugins/system/updatenotification/updatenotification.php
@@ -78,7 +78,7 @@ class PlgSystemUpdatenotification extends CMSPlugin
 		$component = ComponentHelper::getComponent('com_installer');
 
 		/** @var \Joomla\Registry\Registry $params */
-		$params        = $component->params;
+		$params        = $component->getParams();
 		$cache_timeout = (int) $params->get('cachetimeout', 6);
 		$cache_timeout = 3600 * $cache_timeout;
 


### PR DESCRIPTION
### Summary of Changes

Access to protected `Joomla\CMS\Component\ComponentRecord::$params` property is deprecated. Use `Joomla\CMS\Component\ComponentRecord::getParams()` instead.

### Testing Instructions

Edit some component options. Check that correct data is shown in the form.

### Expected result

Works like before.

### Documentation Changes Required

No.