### PR TITLE
[4.0] TinyMCE new features

### DIFF
--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -612,6 +612,7 @@ class PlgEditorTinymce extends CMSPlugin
 				'branding'   => false,
 			)
 		);
+
 		if ($levelParams->get('newlines'))
 		{
 			// Break

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -610,7 +610,6 @@ class PlgEditorTinymce extends CMSPlugin
 
 				// Disable TinyMCE Branding
 				'branding'   => false,
-
 			)
 		);
 		if ($levelParams->get('newlines'))

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -552,6 +552,9 @@ class PlgEditorTinymce extends CMSPlugin
 			$toolbar1  = array_merge($toolbar1, explode($separator, $custom_button));
 		}
 
+		// Merge the two toolbars for backwards compatibility
+		$toolbar = array_merge($toolbar1, $toolbar2);
+
 		// Build the final options set
 		$scriptOptions   = array_merge(
 			$scriptOptions,
@@ -567,8 +570,7 @@ class PlgEditorTinymce extends CMSPlugin
 
 				// Toolbars
 				'menubar'  => empty($menubar)  ? false : implode(' ', array_unique($menubar)),
-				'toolbar1' => empty($toolbar1) ? null  : implode(' ', $toolbar1) . ' jxtdbuttons',
-				'toolbar2' => empty($toolbar2) ? null  : implode(' ', $toolbar2),
+				'toolbar' => empty($toolbar) ? null  : 'jxtdbuttons ' . implode(' ', $toolbar),
 
 				'plugins'  => implode(',', array_unique($plugins)),
 
@@ -600,15 +602,17 @@ class PlgEditorTinymce extends CMSPlugin
 				'image_advtab'       => (bool) $levelParams->get('image_advtab', false),
 				'external_plugins'   => empty($externalPlugins) ? null  : $externalPlugins,
 				'contextmenu'        => (bool) $levelParams->get('contextmenu', true) ? null : false,
+				'toolbar_sticky'     => true,
+				'toolbar_drawer'     => 'sliding',
 
 				// Drag and drop specific
 				'dndEnabled' => $dragdrop,
 
 				// Disable TinyMCE Branding
 				'branding'   => false,
+
 			)
 		);
-
 		if ($levelParams->get('newlines'))
 		{
 			// Break
@@ -1010,7 +1014,7 @@ class PlgEditorTinymce extends CMSPlugin
 
 		$preset['simple'] = [
 			'menu' => [],
-			'toolbar1' => [
+			'toolbar' => [
 				'bold', 'underline', 'strikethrough', '|',
 				'undo', 'redo', '|',
 				'bullist', 'numlist', '|',


### PR DESCRIPTION
With the release of tinymcec 5.1 we have some extra features available. This PR adds the [toolbar drawer](https://www.tiny.cloud/docs/configure/editor-appearance/#toolbar_drawer) and the [sticky toolbar](https://www.tiny.cloud/docs/configure/editor-appearance/#toolbar_sticky)

### Sticky Toolbar
If you have a very long editor area then as you scroll the toolbar becomes sticky at the top of the screen so that it is always available

### Toolbar Drawer
This restricts the toolbar to only display one row (depending on the screen size) and if there are buttons that can not fit on the row then a `...` button appears which can be used to open and close the drawer to the other buttons.

To ensure that our `CMS Content` buttons are always displayed I moved them from the end to the beginning.

The Toolbar Drawer does not support the creation of multiple toolbars so to maintain backwards compatibility I merge the two toolbars into one.

Note: None of the presets were using the second toolbar

TinyMCE 5.2 will expand on this feature and allow greater customisation but they have not revealed how yet.

I have not made either of these as configurable settings - there are enough of those already.

## Drawer Demo
### Before
![tiny-before](https://user-images.githubusercontent.com/1296369/74342249-1b38c480-4da1-11ea-9f18-f41e690c7fa0.gif)


### After
![tiny-after](https://user-images.githubusercontent.com/1296369/74342373-4d4a2680-4da1-11ea-9d8c-4e9d10c06042.gif)


