### PR TITLE
[4.0] Custom Field Groups: Fix query for state

### DIFF
--- a/administrator/components/com_fields/Model/GroupsModel.php
+++ b/administrator/components/com_fields/Model/GroupsModel.php
@@ -182,12 +182,12 @@ class GroupsModel extends ListModel
 		if (is_numeric($state))
 		{
 			$state = (int) $state;
-			$query->where($db->quoteName('a.access') . ' = :state')
+			$query->where($db->quoteName('a.state') . ' = :state')
 				->bind(':state', $state, ParameterType::INTEGER);
 		}
 		elseif (!$state)
 		{
-			$query->whereIn($db->quoteName('a.access'), [0, 1]);
+			$query->whereIn($db->quoteName('a.state'), [0, 1]);
 		}
 
 		// Filter by search in title


### PR DESCRIPTION
### Summary of Changes
Fix Query for state in Custom Fields Group


### Testing Instructions
Make a Custom Field Group.
Then Trash it.


### Expected result
The group disappears from the list and can be found via searchtools / state = trashed


### Actual result
The group remains in the list.

![field-group-state](https://user-images.githubusercontent.com/1035262/74349717-ec2c4e00-4db4-11ea-8fd1-d0dc3d8cab9d.JPG)



### Documentation Changes Required

