### PR TITLE
[4.0] Cassiopea: fix smartsearch results display

### DIFF
--- a/build/media_source/com_finder/css/finder.css
+++ b/build/media_source/com_finder/css/finder.css
@@ -45,8 +45,14 @@
 
 span.highlight {
 	background-color: #ffffcc;
-	font-weight: bold;
-	padding: 1px 0;
+	font-weight: 900;
+	padding: 1px 4px;
+	color: #343a40;
+}
+
+.result-taxonomy .badge {
+	padding: 0.45em 0.8em;
+	font-size: 85%;
 }
 
 ul.autocompleter-choices {


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/27824

### Summary of Changes
Makes highlighted taxonomy legible
Increase fontsize in badge as well as padding
Add dark color to highlighted terms in badge and increase padding

### Testing Instructions
Display a smartsearch module in frontend.
Use category name as keyword


### Before patch

<img width="913" alt="Screen Shot 2020-02-13 at 09 51 12" src="https://user-images.githubusercontent.com/869724/74417138-81c3ee00-4e46-11ea-8a46-994b491ce0b5.png">


### After patch
<img width="911" alt="Screen Shot 2020-02-13 at 09 00 53" src="https://user-images.githubusercontent.com/869724/74416800-f0547c00-4e45-11ea-9169-fb752e11ffa7.png">

