### PR TITLE
[4.0] add module to dashboard background

### DIFF
--- a/administrator/templates/atum/scss/pages/_com_cpanel.scss
+++ b/administrator/templates/atum/scss/pages/_com_cpanel.scss
@@ -126,6 +126,7 @@
     border: 0.125rem dashed var(--atum-link-color);
     position: relative;
     transition: all .3s ease-in;
+    background-color: transparent;
 
     @include hover-focus-active() {
       border-color: var(--atum-bg-dark);


### PR DESCRIPTION
The fix in #27468 wasn't enough.

Apply the PR - rebuild the css

check that the add module backgrouond is transparent