### PR TITLE
Move editAssociations code to regular save method

### DIFF
--- a/libraries/src/MVC/Controller/FormController.php
+++ b/libraries/src/MVC/Controller/FormController.php
@@ -134,6 +134,7 @@ class FormController extends BaseController
 		$this->registerTask('apply', 'save');
 		$this->registerTask('save2new', 'save');
 		$this->registerTask('save2copy', 'save');
+		$this->registerTask('editAssociations', 'save');
 	}
 
 	/**
@@ -935,6 +936,8 @@ class FormController extends BaseController
 	 * @return  void
 	 *
 	 * @since   3.9.0
+	 *
+	 * @deprecated 5.0  It is handled by regular save method now.
 	 */
 	public function editAssociations()
 	{

--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -1223,6 +1223,7 @@ abstract class AdminModel extends FormModel
 		$dispatcher = \JEventDispatcher::getInstance();
 		$table      = $this->getTable();
 		$context    = $this->option . '.' . $this->name;
+		$app        = \JFactory::getApplication();
 
 		if (!empty($data['tags']) && $data['tags'][0] != '')
 		{
@@ -1322,7 +1323,7 @@ abstract class AdminModel extends FormModel
 			// Show a warning if the item isn't assigned to a language but we have associations.
 			if ($associations && $table->language === '*')
 			{
-				\JFactory::getApplication()->enqueueMessage(
+				$app->enqueueMessage(
 					\JText::_(strtoupper($this->option) . '_ERROR_ALL_LANGUAGE_ASSOCIATED'),
 					'warning'
 				);
@@ -1377,6 +1378,86 @@ abstract class AdminModel extends FormModel
 				$db->setQuery($query);
 				$db->execute();
 			}
+		}
+
+		if ($app->input->get('task') == 'editAssociations')
+		{
+			$id = $data['id'];
+
+			// Deal with categories associations
+			if ($this->text_prefix === 'COM_CATEGORIES')
+			{
+				$extension       = $app->input->get('extension', 'com_content');
+				$this->typeAlias = $extension . '.category';
+				$component       = strtolower($this->text_prefix);
+				$view            = 'category';
+			}
+			else
+			{
+				$aliasArray = explode('.', $this->typeAlias);
+				$component  = $aliasArray[0];
+				$view       = $aliasArray[1];
+				$extension  = '';
+			}
+
+			// Menu item redirect needs admin client
+			$client = $component === 'com_menus' ? '&client_id=0' : '';
+
+			if ($id == 0)
+			{
+				$app->enqueueMessage(\JText::_('JGLOBAL_ASSOCIATIONS_NEW_ITEM_WARNING'), 'error');
+				$app->redirect(
+					\JRoute::_('index.php?option=' . $component . '&view=' . $view . $client . '&layout=edit&id=' . $id . $extension, false)
+				);
+
+				return false;
+			}
+
+			if ($data['language'] === '*')
+			{
+				$app->enqueueMessage(\JText::_('JGLOBAL_ASSOC_NOT_POSSIBLE'), 'notice');
+				$app->redirect(
+					\JRoute::_('index.php?option=' . $component . '&view=' . $view . $client . '&layout=edit&id=' . $id . $extension, false)
+				);
+
+				return false;
+			}
+
+			$languages = LanguageHelper::getContentLanguages(array(0, 1));
+			$target    = '';
+
+			/* If the site contains only 2 languages and an association exists for the item
+			   load directly the associated target item in the side by side view
+			   otherwise select already the target language
+			*/
+			if (count($languages) === 2)
+			{
+				foreach ($languages as $language)
+				{
+					$lang_code[] = $language->lang_code;
+				}
+
+				$refLang    = array($data['language']);
+				$targetLang = array_diff($lang_code, $refLang);
+				$targetLang = implode(',', $targetLang);
+				$targetId   = $data['associations'][$targetLang];
+
+				if ($targetId)
+				{
+					$target = '&target=' . $targetLang . '%3A' . $targetId . '%3Aedit';
+				}
+				else
+				{
+					$target = '&target=' . $targetLang . '%3A0%3Aadd';
+				}
+			}
+
+			$app->redirect(
+				\JRoute::_(
+					'index.php?option=com_associations&view=association&layout=edit&itemtype=' . $this->typeAlias
+					. '&task=association.edit&id=' . $id . $target, false
+				)
+			);
 		}
 
 		return true;
@@ -1608,90 +1689,12 @@ abstract class AdminModel extends FormModel
 	 * @return  boolean  True if successful, false otherwise.
 	 *
 	 * @since   3.9.0
+	 *
+	 * @deprecated 5.0  It is handled by regular save method now.
 	 */
 	public function editAssociations($data)
 	{
 		// Save the item
 		$this->save($data);
-
-		$app = \JFactory::getApplication();
-		$id  = $data['id'];
-
-		// Deal with categories associations
-		if ($this->text_prefix === 'COM_CATEGORIES')
-		{
-			$extension       = $app->input->get('extension', 'com_content');
-			$this->typeAlias = $extension . '.category';
-			$component       = strtolower($this->text_prefix);
-			$view            = 'category';
-		}
-		else
-		{
-			$aliasArray = explode('.', $this->typeAlias);
-			$component  = $aliasArray[0];
-			$view       = $aliasArray[1];
-			$extension  = '';
-		}
-
-		// Menu item redirect needs admin client
-		$client = $component === 'com_menus' ? '&client_id=0' : '';
-
-		if ($id == 0)
-		{
-			$app->enqueueMessage(\JText::_('JGLOBAL_ASSOCIATIONS_NEW_ITEM_WARNING'), 'error');
-			$app->redirect(
-				\JRoute::_('index.php?option=' . $component . '&view=' . $view . $client . '&layout=edit&id=' . $id . $extension, false)
-			);
-
-			return false;
-		}
-
-		if ($data['language'] === '*')
-		{
-			$app->enqueueMessage(\JText::_('JGLOBAL_ASSOC_NOT_POSSIBLE'), 'notice');
-			$app->redirect(
-				\JRoute::_('index.php?option=' . $component . '&view=' . $view . $client . '&layout=edit&id=' . $id . $extension, false)
-			);
-
-			return false;
-		}
-
-		$languages = LanguageHelper::getContentLanguages(array(0, 1));
-		$target    = '';
-
-		/* If the site contains only 2 languages and an association exists for the item
-		   load directly the associated target item in the side by side view
-		   otherwise select already the target language
-		*/
-		if (count($languages) === 2)
-		{
-			foreach ($languages as $language)
-			{
-				$lang_code[] = $language->lang_code;
-			}
-
-			$refLang    = array($data['language']);
-			$targetLang = array_diff($lang_code, $refLang);
-			$targetLang = implode(',', $targetLang);
-			$targetId   = $data['associations'][$targetLang];
-
-			if ($targetId)
-			{
-				$target = '&target=' . $targetLang . '%3A' . $targetId . '%3Aedit';
-			}
-			else
-			{
-				$target = '&target=' . $targetLang . '%3A0%3Aadd';
-			}
-		}
-
-		$app->redirect(
-			\JRoute::_(
-				'index.php?option=com_associations&view=association&layout=edit&itemtype=' . $this->typeAlias
-				. '&task=association.edit&id=' . $id . $target, false
-			)
-		);
-
-		return true;
 	}
 }


### PR DESCRIPTION
Pull Request for Issue #27921

### Summary of Changes
The associations button in the article edit form triggered the `editAssocations` task. That task invoked a save method in the model and then redirected to the association manager.
Unfortunately that save method bypassed everything done in the controller->save method. Resulting beside other potential issues in the issue above where the dateformat wasn't properly translated back.

This PR moves the code from the editAssociations method to the save method with a conditional on the active task.
in the controller, the "editAssociations" task is registered as a variant of the save method.

I have left the old "editAssociations" methods in the controller and model to keep B/C and added a deprecation note for 5.0.

### Testing Instructions
* Test in the administrator backend using a language that doesn't use the regular english date format YYYY-MM-DD, for example german or russian.
* In a multilingual site, create an article assigned to a specific language.
* After saving the article, click on the "Associations" button in the edit form.
* It will redirect to the Associations Manager. In the new side-by-side form, check the created date of the article.


### Expected result
Date is still there


### Actual result
Date is empty


### Documentation Changes Required
None