### PR TITLE
[4.0] WIP on adding back ability to set site + admin languages in installer

### DIFF
--- a/installation/forms/defaultlanguage.xml
+++ b/installation/forms/defaultlanguage.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<form>
+	<fieldset>
+		<field
+			name="activateMultilanguage"
+			type="radio"
+			label="INSTL_DEFAULTLANGUAGE_ACTIVATE_MULTILANGUAGE"
+			description="INSTL_DEFAULTLANGUAGE_ACTIVATE_MULTILANGUAGE_DESC"
+			id="activateMultilanguage"
+			class="switcher"
+			filter="integer"
+			default="0"
+			>
+			<option value="0">JNO</option>
+			<option value="1">JYES</option>
+		</field>
+
+		<field
+			name="installLocalisedContent"
+			type="radio"
+			label="INSTL_DEFAULTLANGUAGE_INSTALL_LOCALISED_CONTENT"
+			description="INSTL_DEFAULTLANGUAGE_INSTALL_LOCALISED_CONTENT_DESC"
+			id="installLocalisedContent"
+			class="switcher"
+			filter="integer"
+			default="1"
+			>
+			<option value="0">JNO</option>
+			<option value="1">JYES</option>
+		</field>
+
+		<field
+			name="activatePluginLanguageCode"
+			type="radio"
+			label="INSTL_DEFAULTLANGUAGE_ACTIVATE_LANGUAGE_CODE_PLUGIN"
+			description="INSTL_DEFAULTLANGUAGE_ACTIVATE_LANGUAGE_CODE_PLUGIN_DESC"
+			id="activatePluginLanguageCode"
+			class="switcher"
+			filter="integer"
+			default="0"
+			>
+			<option value="0">JNO</option>
+			<option value="1">JYES</option>
+		</field>
+	</fieldset>
+</form>

--- a/installation/language/en-GB/joomla.ini
+++ b/installation/language/en-GB/joomla.ini
@@ -255,6 +255,7 @@ JUSERNAME="Username"
 JYES="Yes"
 
 ; Framework strings necessary when no lang pack is available
+JLIB_APPLICATION_ERROR_VIEW_NOT_FOUND="View not found [name, type, prefix]: %1$s, %2$s, %3$s"
 JLIB_DATABASE_ERROR_CONNECT_MYSQL="Could not connect to MySQL."
 JLIB_DATABASE_ERROR_DATABASE="A Database error occurred."
 JLIB_DATABASE_ERROR_LOAD_DATABASE_DRIVER="Unable to load Database Driver: %s"

--- a/installation/language/en-US/joomla.ini
+++ b/installation/language/en-US/joomla.ini
@@ -255,6 +255,7 @@ JUSERNAME="Username"
 JYES="Yes"
 
 ; Framework strings necessary when no lang pack is available
+JLIB_APPLICATION_ERROR_VIEW_NOT_FOUND="View not found [name, type, prefix]: %1$s, %2$s, %3$s"
 JLIB_DATABASE_ERROR_CONNECT_MYSQL="Could not connect to MySQL."
 JLIB_DATABASE_ERROR_DATABASE="A Database error occurred."
 JLIB_DATABASE_ERROR_LOAD_DATABASE_DRIVER="Unable to load Database Driver: %s"

--- a/installation/src/Controller/JSONController.php
+++ b/installation/src/Controller/JSONController.php
@@ -71,6 +71,11 @@ abstract class JSONController extends BaseController
 	public function checkValidToken()
 	{
 		// Check for request forgeries.
-		Session::checkToken() or $this->sendJsonResponse(new \Exception(Text::_('JINVALID_TOKEN_NOTICE'), 403));
+		if (!Session::checkToken())
+		{
+			$this->sendJsonResponse(new \Exception(Text::_('JINVALID_TOKEN_NOTICE'), 403));
+
+			$this->app->close();
+		}
 	}
 }

--- a/installation/src/Controller/LanguageController.php
+++ b/installation/src/Controller/LanguageController.php
@@ -16,7 +16,6 @@ use Joomla\CMS\Installation\Model\SetupModel;
 use Joomla\CMS\Language\Language;
 use Joomla\CMS\Language\LanguageHelper;
 use Joomla\CMS\Language\Text;
-use Joomla\CMS\Table\Table;
 
 /**
  * Language controller class for the Joomla Installer.
@@ -168,8 +167,6 @@ class LanguageController extends JSONController
 			}
 
 			// Add menus
-			Table::addIncludePath(JPATH_ADMINISTRATOR . '/components/com_menus/tables/');
-
 			$siteLanguages       = $model->getInstalledlangsFrontend();
 			$groupedAssociations = array();
 

--- a/installation/src/View/DefaultLanguage/HtmlView.php
+++ b/installation/src/View/DefaultLanguage/HtmlView.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * @package     Joomla.Installation
+ * @subpackage  View
+ *
+ * @copyright   Copyright (C) 2005 - 2019 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Installation\View\DefaultLanguage;
+
+defined('_JEXEC') or die;
+
+use Joomla\CMS\Installation\View\DefaultView;
+
+/**
+ * The Installation Default Language View
+ *
+ * @since  3.1
+ */
+class HtmlView extends DefaultView
+{
+	/**
+	 * Container with all installed languages
+	 *
+	 * @var    array
+	 * @since  3.1
+	 */
+	public $items;
+
+	/**
+	 * The default model
+	 *
+	 * @var	   string
+	 * @since  3.0
+	 */
+	protected $_defaultModel = 'languages';
+
+	/**
+	 * Execute and display a template script.
+	 *
+	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
+	 *
+	 * @return  mixed  A string if successful, otherwise an Error object.
+	 *
+	 * @since   4.0.0
+	 */
+	public function display($tpl = null)
+	{
+		$this->items                = new \stdClass;
+		$this->items->administrator = $this->get('InstalledlangsAdministrator');
+		$this->items->frontend      = $this->get('InstalledlangsFrontend');
+
+		return parent::display($tpl);
+	}
+}

--- a/installation/template/js/template.js
+++ b/installation/template/js/template.js
@@ -56,10 +56,9 @@
     Joomla.removeMessages();
 
     Joomla.request({
-      type     : "POST",
-      url      : Jooomla.baseUrl,
-      data     : data,
-      dataType : 'json',
+      method : "POST",
+      url    : Joomla.installationBaseUrl,
+      data   : data,
       onSuccess: function (response, xhr) {
         response = JSON.parse(response);
         var spinnerElement = document.querySelector('joomla-core-loader');
@@ -74,7 +73,7 @@
         } else {
           spinnerElement.parentNode.removeChild(spinnerElement);
           if (response.data && response.data.view) {
-            Install.goToPage(response.data.view, true);
+            Joomla.goToPage(response.data.view, true);
           }
         }
       },
@@ -228,6 +227,16 @@
         }
       }
     });
+  };
+
+  Joomla.changeVisibilityFromCheckbox = function(id, el, value) {
+    const val = document.querySelector('input[name="jform[' + el + ']"]:checked').value;
+    const id_element = document.getElementById(id);
+    if (val === value.toString()) {
+      id_element.style.display = 'block';
+    } else {
+      id_element.style.display = 'none';
+    }
   };
 
   /* Load scripts async */

--- a/installation/template/scss/template.scss
+++ b/installation/template/scss/template.scss
@@ -256,3 +256,7 @@ caption {
   z-index: $zindex-header;
   background-color: $white;
 }
+
+#installLocalisedContent, #activatePluginLanguageCode {
+  display:none;
+}

--- a/installation/tmpl/defaultlanguage/default.php
+++ b/installation/tmpl/defaultlanguage/default.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * @package    Joomla.Installation
+ *
+ * @copyright  Copyright (C) 2005 - 2019 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Language\Text;
+
+\Joomla\CMS\Factory::getDocument()->addScriptDeclaration(
+<<<JS
+    document.querySelectorAll('input[name="jform[activateMultilanguage]"]').forEach((el) => {
+	el.addEventListener('click', () => {
+		Joomla.changeVisibilityFromCheckbox('installLocalisedContent', 'activateMultilanguage', 1);
+		Joomla.changeVisibilityFromCheckbox('activatePluginLanguageCode', 'activateMultilanguage', 1);
+	});
+        Joomla.changeVisibilityFromCheckbox('installLocalisedContent', 'activateMultilanguage', 1);
+        Joomla.changeVisibilityFromCheckbox('activatePluginLanguageCode', 'activateMultilanguage', 1);
+    });
+JS
+);
+
+/** @var Joomla\CMS\Installation\View\DefaultLanguage\HtmlView */
+?>
+<form action="index.php" method="post" id="adminForm" class="form-validate form-horizontal">
+	<h3><?php echo Text::_('INSTL_DEFAULTLANGUAGE_MULTILANGUAGE_TITLE'); ?></h3>
+	<hr class="hr-condensed" />
+	<p><?php echo Text::_('INSTL_DEFAULTLANGUAGE_MULTILANGUAGE_DESC'); ?></p>
+	<?php echo $this->form->renderField('activateMultilanguage'); ?>
+	<div id="multilanguageOptions">
+		<div id="installLocalisedContent">
+			<?php echo $this->form->renderField('installLocalisedContent'); ?>
+		</div>
+		<div id="activatePluginLanguageCode">
+			<?php echo $this->form->renderField('activatePluginLanguageCode'); ?>
+		</div>
+	</div>
+	<h3><?php echo Text::_('INSTL_DEFAULTLANGUAGE_ADMINISTRATOR'); ?></h3>
+	<hr class="hr-condensed" />
+	<p><?php echo Text::_('INSTL_DEFAULTLANGUAGE_DESC'); ?></p>
+	<table class="table table-striped table-condensed">
+		<thead>
+		<tr>
+			<th>
+				<?php echo Text::_('INSTL_DEFAULTLANGUAGE_COLUMN_HEADER_SELECT'); ?>
+			</th>
+			<th>
+				<?php echo Text::_('INSTL_DEFAULTLANGUAGE_COLUMN_HEADER_LANGUAGE'); ?>
+			</th>
+			<th>
+				<?php echo Text::_('INSTL_DEFAULTLANGUAGE_COLUMN_HEADER_TAG'); ?>
+			</th>
+		</tr>
+		</thead>
+		<tbody>
+		<?php foreach ($this->items->administrator as $i => $lang) : ?>
+			<tr>
+				<td>
+					<input
+						id="admin-language-cb<?php echo $i; ?>"
+						type="radio"
+						name="administratorlang"
+						value="<?php echo $lang->language; ?>"
+						<?php if ($lang->published) echo 'checked="checked"'; ?>
+					/>
+				</td>
+				<td align="center">
+					<label for="admin-language-cb<?php echo $i; ?>">
+						<?php echo $lang->name; ?>
+					</label>
+				</td>
+				<td align="center">
+					<?php echo $lang->language; ?>
+				</td>
+			</tr>
+		<?php endforeach; ?>
+		</tbody>
+	</table>
+	<h3><?php echo Text::_('INSTL_DEFAULTLANGUAGE_FRONTEND'); ?></h3>
+	<hr class="hr-condensed" />
+	<p><?php echo Text::_('INSTL_DEFAULTLANGUAGE_DESC_FRONTEND'); ?></p>
+	<table class="table table-striped table-condensed">
+		<thead>
+		<tr>
+			<th>
+				<?php echo Text::_('INSTL_DEFAULTLANGUAGE_COLUMN_HEADER_SELECT'); ?>
+			</th>
+			<th>
+				<?php echo Text::_('INSTL_DEFAULTLANGUAGE_COLUMN_HEADER_LANGUAGE'); ?>
+			</th>
+			<th>
+				<?php echo Text::_('INSTL_DEFAULTLANGUAGE_COLUMN_HEADER_TAG'); ?>
+			</th>
+		</tr>
+		</thead>
+		<tbody>
+		<?php foreach ($this->items->frontend as $i => $lang) : ?>
+			<tr>
+				<td>
+					<input
+						id="site-language-cb<?php echo $i; ?>"
+						type="radio"
+						name="frontendlang"
+						value="<?php echo $lang->language; ?>"
+						<?php if ($lang->published) echo 'checked="checked"'; ?>
+					/>
+				</td>
+				<td align="center">
+					<label for="site-language-cb<?php echo $i; ?>">
+						<?php echo $lang->name; ?>
+					</label>
+				</td>
+				<td align="center">
+					<?php echo $lang->language; ?>
+				</td>
+			</tr>
+		<?php endforeach; ?>
+		</tbody>
+	</table>
+	<div class="row-fluid">
+		<div class="btn-toolbar">
+			<div class="btn-group pull-right">
+				<a
+					class="btn"
+					href="#"
+					onclick="return Joomla.goToPage('languages');"
+					rel="prev"
+					title="<?php echo Text::_('JPREVIOUS'); ?>">
+					<span class="icon-arrow-left"></span>
+					<?php echo Text::_('JPREVIOUS'); ?>
+				</a>
+				<?php // Check if there are languages in the list, if not you cannot move forward ?>
+				<?php if ($this->items->administrator) : ?>
+					<a
+						class="btn btn-primary"
+						href="#"
+						onclick="Joomla.submitform(document.getElementById('adminForm'));"
+						rel="next"
+						title="<?php echo Text::_('JNEXT'); ?>">
+						<span class="icon-arrow-right icon-white"></span>
+						<?php echo Text::_('JNEXT'); ?>
+					</a>
+				<?php endif; ?>
+			</div>
+		</div>
+	</div>
+	<?php echo HtmlHelper::_('form.token'); ?>
+    <input type="hidden" name="task" value="language.setdefault">
+    <input type="hidden" name="format" value="json">
+</form>


### PR DESCRIPTION
Related issue: https://github.com/joomla/joomla-cms/issues/27059 

### Summary of Changes
WIP Work on adding back the ability to set site + admin languages in the installer. For now use the installer, install an extra language there. Then once installed successfully change your URL in the browser to <YOUR_JOOMLA_ROOT_URL>/installation/index.php?view=defaultlanguage (obviously this needs to be integrated into the flow see steps left below)

This reinstates back the old view for configuring the default site + admin languages - so that people who don't speak english as a native language are able to set the admin default language before they start to configure things.

#### Things left to do
- [ ] Remove the installLocalisedContent options + related code - this will still belong in the administrator area
- [ ] Figure out the flow of accessing this view (after installing a language an autoredirect or?)
- [ ] Should this new view be merged with the existing installation install languages view
- [ ] General Styling/ HTML Structure (This is give or take the same thing from J3 - I've just tweaked things to render via JForm and swapped to switcher)

### Testing Instructions
TODO

### Documentation Changes Required
N/A
