### PR TITLE
[4.0] Fix Configuration change has no effect.

### DIFF
--- a/administrator/components/com_config/src/Model/ApplicationModel.php
+++ b/administrator/components/com_config/src/Model/ApplicationModel.php
@@ -812,7 +812,7 @@ class ApplicationModel extends FormModel
 		// Invalidates the cached configuration file
 		if (function_exists('opcache_invalidate'))
 		{
-			opcache_invalidate($file);
+			\opcache_invalidate($file);
 		}
 
 		// Attempt to make the file unwriteable if using FTP.

--- a/administrator/components/com_joomlaupdate/restore.php
+++ b/administrator/components/com_joomlaupdate/restore.php
@@ -8313,15 +8313,15 @@ if (!defined('KICKSTART'))
 					// opcode cache busting before including the filename
 					if (function_exists('opcache_invalidate'))
 					{
-						opcache_invalidate($filename);
+						\opcache_invalidate($filename);
 					}
 					if (function_exists('apc_compile_file'))
 					{
-						apc_compile_file($filename);
+						\apc_compile_file($filename);
 					}
 					if (function_exists('wincache_refresh_if_changed'))
 					{
-						wincache_refresh_if_changed(array($filename));
+						\wincache_refresh_if_changed(array($filename));
 					}
 					if (function_exists('xcache_asm'))
 					{

--- a/administrator/components/com_joomlaupdate/restore_finalisation.php
+++ b/administrator/components/com_joomlaupdate/restore_finalisation.php
@@ -78,7 +78,7 @@ namespace
 			// Clear OPcache
 			if (function_exists('opcache_reset'))
 			{
-				opcache_reset();
+				\opcache_reset();
 			}
 		}
 	}


### PR DESCRIPTION
Pull Request for Issue #27947  .

### Summary of Changes
Use the `opcache_invalidate` PHP function to save global configuration.


### Testing Instructions
Change the global configuration and save it.


### Expected result
The Configuration file is updated.


### Actual result
The configuration file is not updated. The new configuration is only saved in the session. If you log out and log in again, the changed configuration is lost.

### Documentation Changes Required

