### PR TITLE
[4.0] Error message typo

### DIFF
--- a/libraries/src/WebAsset/WebAssetRegistry.php
+++ b/libraries/src/WebAsset/WebAssetRegistry.php
@@ -129,7 +129,7 @@ class WebAssetRegistry implements WebAssetRegistryInterface, DispatcherAwareInte
 
 		if (empty($this->assets[$type][$name]))
 		{
-			throw new UnknownAssetException(sprintf('There is no a "%s" asset of a "%s" type in the registry.', $name, $type));
+			throw new UnknownAssetException(sprintf('There is no "%s" asset of a "%s" type in the registry.', $name, $type));
 		}
 
 		return $this->assets[$type][$name];


### PR DESCRIPTION
### Before
 There is no a "blablabla" asset of a "script" type in the registry.

### After
 There is no "blablabla" asset of a "script" type in the registry.

code review only
