### PR TITLE
[4.0] Load showon js only once

### DIFF
--- a/components/com_contact/layouts/joomla/form/renderfield.php
+++ b/components/com_contact/layouts/joomla/form/renderfield.php
@@ -10,7 +10,6 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
-use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
 extract($displayData);

--- a/components/com_contact/layouts/joomla/form/renderfield.php
+++ b/components/com_contact/layouts/joomla/form/renderfield.php
@@ -9,10 +9,14 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
 extract($displayData);
+
+/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+$wa = Factory::getApplication()->getDocument()->getWebAssetManager();
 
 /**
  * Layout variables
@@ -24,7 +28,7 @@ extract($displayData);
 
 if (!empty($options['showonEnabled']))
 {
-	HTMLHelper::_('script', 'system/showon.min.js', array('version' => 'auto', 'relative' => true));
+	$wa->useScript('showon');
 }
 
 $class = empty($options['class']) ? '' : ' ' . $options['class'];

--- a/components/com_users/layouts/joomla/form/renderfield.php
+++ b/components/com_users/layouts/joomla/form/renderfield.php
@@ -10,7 +10,6 @@
 defined('JPATH_BASE') or die;
 
 use Joomla\CMS\Factory;
-use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
 extract($displayData);

--- a/components/com_users/layouts/joomla/form/renderfield.php
+++ b/components/com_users/layouts/joomla/form/renderfield.php
@@ -9,10 +9,14 @@
 
 defined('JPATH_BASE') or die;
 
+use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
 extract($displayData);
+
+/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+$wa = Factory::getApplication()->getDocument()->getWebAssetManager();
 
 /**
  * Layout variables
@@ -24,8 +28,7 @@ extract($displayData);
 
 if (!empty($options['showonEnabled']))
 {
-	HTMLHelper::_('jquery.framework');
-	HTMLHelper::_('script', 'jui/cms.js', array('version' => 'auto', 'relative' => true));
+	$wa->useScript('showon');
 }
 
 $class = empty($options['class']) ? '' : ' ' . $options['class'];

--- a/layouts/joomla/content/options_default.php
+++ b/layouts/joomla/content/options_default.php
@@ -9,10 +9,11 @@
 
 defined('JPATH_BASE') or die;
 
+use Joomla\CMS\Factory;
 use Joomla\CMS\Form\FormHelper;
-use Joomla\CMS\HTML\HTMLHelper;
 
-HTMLHelper::_('script', 'system/showon.min.js', array('version' => 'auto', 'relative' => true));
+/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+$wa = Factory::getApplication()->getDocument()->getWebAssetManager();
 ?>
 
 <fieldset class="<?php echo !empty($displayData->formclass) ? $displayData->formclass : ''; ?>">
@@ -27,6 +28,7 @@ HTMLHelper::_('script', 'system/showon.min.js', array('version' => 'auto', 'rela
 				<?php $datashowon = ''; ?>
 				<?php $groupClass = $field->type === 'Spacer' ? ' field-spacer' : ''; ?>
 				<?php if ($field->showon) : ?>
+					<?php $wa->useScript('showon'); ?>
 					<?php $datashowon = ' data-showon=\'' . json_encode(FormHelper::parseShowOnConditions($field->showon, $field->formControl, $field->group)) . '\''; ?>
 				<?php endif; ?>
 

--- a/layouts/joomla/content/options_default.php
+++ b/layouts/joomla/content/options_default.php
@@ -12,7 +12,7 @@ defined('JPATH_BASE') or die;
 use Joomla\CMS\Form\FormHelper;
 use Joomla\CMS\HTML\HTMLHelper;
 
-HTMLHelper::_('script', 'system/showon.min.js', array('version' => 'auto', 'relative' => true)); 
+HTMLHelper::_('script', 'system/showon.min.js', array('version' => 'auto', 'relative' => true));
 ?>
 
 <fieldset class="<?php echo !empty($displayData->formclass) ? $displayData->formclass : ''; ?>">

--- a/layouts/joomla/content/options_default.php
+++ b/layouts/joomla/content/options_default.php
@@ -12,6 +12,7 @@ defined('JPATH_BASE') or die;
 use Joomla\CMS\Form\FormHelper;
 use Joomla\CMS\HTML\HTMLHelper;
 
+HTMLHelper::_('script', 'system/showon.min.js', array('version' => 'auto', 'relative' => true)); 
 ?>
 
 <fieldset class="<?php echo !empty($displayData->formclass) ? $displayData->formclass : ''; ?>">
@@ -26,7 +27,6 @@ use Joomla\CMS\HTML\HTMLHelper;
 				<?php $datashowon = ''; ?>
 				<?php $groupClass = $field->type === 'Spacer' ? ' field-spacer' : ''; ?>
 				<?php if ($field->showon) : ?>
-					<?php HTMLHelper::_('script', 'system/showon.min.js', array('version' => 'auto', 'relative' => true)); ?>
 					<?php $datashowon = ' data-showon=\'' . json_encode(FormHelper::parseShowOnConditions($field->showon, $field->formControl, $field->group)) . '\''; ?>
 				<?php endif; ?>
 

--- a/layouts/joomla/form/renderfield.php
+++ b/layouts/joomla/form/renderfield.php
@@ -10,7 +10,6 @@
 defined('JPATH_BASE') or die;
 
 use Joomla\CMS\Factory;
-use Joomla\CMS\HTML\HTMLHelper;
 
 extract($displayData);
 

--- a/layouts/joomla/form/renderfield.php
+++ b/layouts/joomla/form/renderfield.php
@@ -9,9 +9,13 @@
 
 defined('JPATH_BASE') or die;
 
+use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 
 extract($displayData);
+
+/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+$wa = Factory::getApplication()->getDocument()->getWebAssetManager();
 
 /**
  * Layout variables
@@ -25,7 +29,7 @@ extract($displayData);
 
 if (!empty($options['showonEnabled']))
 {
-	HTMLHelper::_('script', 'system/showon.min.js', array('version' => 'auto', 'relative' => true));
+	$wa->useScript('showon');
 }
 $class = empty($options['class']) ? '' : ' ' . $options['class'];
 $rel   = empty($options['rel']) ? '' : ' ' . $options['rel'];

--- a/layouts/joomla/searchtools/default/filters.php
+++ b/layouts/joomla/searchtools/default/filters.php
@@ -14,6 +14,9 @@ use Joomla\CMS\HTML\HTMLHelper;
 
 $data = $displayData;
 
+/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+$wa = Factory::getApplication()->getDocument()->getWebAssetManager();
+
 // Load the form filters
 $filters = $data['view']->filterForm->getGroup('filter');
 ?>
@@ -22,7 +25,7 @@ $filters = $data['view']->filterForm->getGroup('filter');
 		<?php if ($fieldName !== 'filter_search') : ?>
 			<?php $dataShowOn = ''; ?>
 			<?php if ($field->showon) : ?>
-				<?php HTMLHelper::_('script', 'system/showon.min.js', array('version' => 'auto', 'relative' => true)); ?>
+				<?php $wa->useScript('showon'); ?>
 				<?php $dataShowOn = " data-showon='" . json_encode(FormHelper::parseShowOnConditions($field->showon, $field->formControl, $field->group)) . "'"; ?>
 			<?php endif; ?>
 			<div class="js-stools-field-filter"<?php echo $dataShowOn; ?>>

--- a/layouts/joomla/searchtools/default/filters.php
+++ b/layouts/joomla/searchtools/default/filters.php
@@ -9,8 +9,8 @@
 
 defined('JPATH_BASE') or die;
 
+use Joomla\CMS\Factory;
 use Joomla\CMS\Form\FormHelper;
-use Joomla\CMS\HTML\HTMLHelper;
 
 $data = $displayData;
 


### PR DESCRIPTION
### Summary of Changes
Take loading the script for showon fields out of the foreach loop 

### Testing Instructions
Go to a view with showon fields, i.e. com_config. 
Showon fields must work before and after the patch.
