### PR TITLE
[4.0] tinymce new minor release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7779,9 +7779,9 @@
       "dev": true
     },
     "tinymce": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-5.1.6.tgz",
-      "integrity": "sha512-QDFLqHhYyHaY8e6nWLeM5zrkWOzPA3FqcBKbhEin47cna/0jNHL4DzNqmZpmA7ch9AWBF24Nzvhf1gzUFkE4aQ=="
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-5.2.0.tgz",
+      "integrity": "sha512-Q7KAu9sLB6TBhKFdb2LHPGy770zkSEjpN1VRqZ6pxNuVQ0mbGWgMocHDvM9XL9yJaOhFrJP6s9XM7zG2gapGpA=="
     },
     "tmp": {
       "version": "0.0.33",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "roboto-fontface": "^0.10.0",
     "short-and-sweet": "^1.0.2",
     "skipto": "^2.1.1",
-    "tinymce": "^5.1.6"
+    "tinymce": "^5.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.8.4",

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -598,7 +598,7 @@ class PlgEditorTinymce extends CMSPlugin
 				'external_plugins'   => empty($externalPlugins) ? null  : $externalPlugins,
 				'contextmenu'        => (bool) $levelParams->get('contextmenu', true) ? null : false,
 				'toolbar_sticky'     => true,
-				'toolbar_drawer'     => 'sliding',
+				'toolbar_mode'       => 'sliding',
 
 				// Drag and drop specific
 				'dndEnabled' => $dragdrop,

--- a/plugins/editors/tinymce/tinymce.xml
+++ b/plugins/editors/tinymce/tinymce.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension version="3.2" type="plugin" group="editors" method="upgrade">
 	<name>plg_editors_tinymce</name>
-	<version>5.1.6</version>
+	<version>5.2.0</version>
 	<creationDate>2005-2019</creationDate>
 	<author>Tiny Technologies, Inc</author>
 	<authorEmail>N/A</authorEmail>


### PR DESCRIPTION
Bumped npm to now be ^5.2.0

CHANGED toolbar_drawer setting to toolbar_mode. toolbar_drawer has been deprecated.

This was a new feature only just added to our implementation of tinymce

https://www.tiny.cloud/docs/changelog/