### PR TITLE
[4.0] Trigger events on Finder actions (index, delete, purge)

### DIFF
--- a/administrator/components/com_finder/src/Indexer/Adapter.php
+++ b/administrator/components/com_finder/src/Indexer/Adapter.php
@@ -362,6 +362,8 @@ abstract class Adapter extends CMSPlugin
 		// Check the items.
 		if (empty($items))
 		{
+			Factory::getApplication()->triggerEvent('onFinderIndexAfterDelete', array($id));
+
 			return true;
 		}
 

--- a/administrator/components/com_finder/src/Indexer/Adapter.php
+++ b/administrator/components/com_finder/src/Indexer/Adapter.php
@@ -362,8 +362,6 @@ abstract class Adapter extends CMSPlugin
 		// Check the items.
 		if (empty($items))
 		{
-			Factory::getApplication()->triggerEvent('onFinderIndexAfterDelete', array($id));
-
 			return true;
 		}
 

--- a/administrator/components/com_finder/src/Indexer/Adapter.php
+++ b/administrator/components/com_finder/src/Indexer/Adapter.php
@@ -363,6 +363,7 @@ abstract class Adapter extends CMSPlugin
 		if (empty($items))
 		{
 			Factory::getApplication()->triggerEvent('onFinderIndexAfterDelete', array($id));
+
 			return true;
 		}
 

--- a/administrator/components/com_finder/src/Indexer/Adapter.php
+++ b/administrator/components/com_finder/src/Indexer/Adapter.php
@@ -362,6 +362,7 @@ abstract class Adapter extends CMSPlugin
 		// Check the items.
 		if (empty($items))
 		{
+			Factory::getApplication()->triggerEvent('onFinderIndexAfterDelete', array($id));
 			return true;
 		}
 

--- a/administrator/components/com_finder/src/Indexer/Driver/Mysql.php
+++ b/administrator/components/com_finder/src/Indexer/Driver/Mysql.php
@@ -13,6 +13,7 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Filesystem\File;
+use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\Component\Finder\Administrator\Indexer\Helper;
 use Joomla\Component\Finder\Administrator\Indexer\Indexer;
 use Joomla\Component\Finder\Administrator\Indexer\Taxonomy;
@@ -394,6 +395,10 @@ class Mysql extends Indexer
 
 		// Mark afterTruncating in the profiler.
 		static::$profiler ? static::$profiler->mark('afterTruncating') : null;
+
+		// Trigger a plugin event after indexing
+		PluginHelper::importPlugin('finder');
+		Factory::getApplication()->triggerEvent('onFinderIndexAfterIndex', array($item, $linkId));
 
 		return $linkId;
 	}

--- a/administrator/components/com_finder/src/Indexer/Driver/Postgresql.php
+++ b/administrator/components/com_finder/src/Indexer/Driver/Postgresql.php
@@ -13,6 +13,7 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Filesystem\File;
+use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\Component\Finder\Administrator\Indexer\Helper;
 use Joomla\Component\Finder\Administrator\Indexer\Indexer;
 use Joomla\Component\Finder\Administrator\Indexer\Taxonomy;
@@ -402,6 +403,10 @@ class Postgresql extends Indexer
 
 		// Mark afterTruncating in the profiler.
 		static::$profiler ? static::$profiler->mark('afterTruncating') : null;
+
+		// Trigger a plugin event after indexing
+		PluginHelper::importPlugin('finder');
+		Factory::getApplication()->triggerEvent('onFinderIndexAfterIndex', array($item, $linkId));
 
 		return $linkId;
 	}

--- a/administrator/components/com_finder/src/Indexer/Indexer.php
+++ b/administrator/components/com_finder/src/Indexer/Indexer.php
@@ -15,6 +15,7 @@ use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Object\CMSObject;
+use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Profiler\Profiler;
 use Joomla\Database\ParameterType;
 use Joomla\String\StringHelper;
@@ -324,6 +325,9 @@ abstract class Indexer
 		{
 			Taxonomy::removeOrphanNodes();
 		}
+
+		PluginHelper::importPlugin('finder');
+		Factory::getApplication()->triggerEvent('onFinderIndexAfterDelete', array($linkId));
 
 		return true;
 	}

--- a/administrator/components/com_finder/src/Model/IndexModel.php
+++ b/administrator/components/com_finder/src/Model/IndexModel.php
@@ -42,6 +42,14 @@ class IndexModel extends ListModel
 	protected $event_before_delete = 'onContentBeforeDelete';
 
 	/**
+	 * The event to trigger after purging the data.
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $event_after_purge = 'onFinderIndexAfterPurge';
+
+	/**
 	 * Constructor.
 	 *
 	 * @param   array                $config   An optional associative array of configuration settings.
@@ -386,6 +394,10 @@ class IndexModel extends ListModel
 
 		// Truncate the tokens aggregate table.
 		$db->truncateTable('#__finder_tokens_aggregate');
+
+		// Include the finder plugins for the on purge events.
+		PluginHelper::importPlugin('finder');
+		Factory::getApplication()->triggerEvent($this->event_after_purge);
 
 		return true;
 	}


### PR DESCRIPTION
### Summary of Changes
It triggers events after performing the basic finder indexer's actions.
The Indexer performs 3 tasks  (index, delete, purge), though no any event triggered after they are finished.

Performing further actions can be very useful in cases like: 
Caching, Meta-data generation, Filters generation, Logging.

### Testing Instructions
Lets generate some log records for each event.

Open the file: plugins/finder/content/content.php

Within the class add/append the following code:
~~~~
      	/**
	 * Triggered after saving an item or after running the indexer.
	 *
	 * @param   Result  $item
	 * @param   Int     $linkid
	 *
	 */
	public function onFinderIndexAfterIndex(Result $item, $linkId)
	{
		\Joomla\CMS\Log\Log::addLogger(array('text_file' => 'finder.log.php'), \Joomla\CMS\Log\Log::ALL, array('finder_plugin'));
		\Joomla\CMS\Log\Log::add('onFinderIndexAfterIndex Run after:' . $linkId, \Joomla\CMS\Log\Log::INFO, 'finder_plugin');
	}

	/**
	 * Triggered after deleting an item or pressing 'Delete' in com_finder.
	 * @param int $linkId
	 *
	 */
	public function onFinderIndexAfterDelete($linkId)
	{
		\Joomla\CMS\Log\Log::addLogger(array('text_file' => 'finder.log.php'), \Joomla\CMS\Log\Log::ALL, array('finder_plugin'));
		\Joomla\CMS\Log\Log::add('onFinderIndexAfterDelete Run after:' . $linkId, \Joomla\CMS\Log\Log::INFO, 'finder_plugin');
	}

	/**
	 * Triggered after purging (press 'Clear Index') in com_finder.
	 */
	public function onFinderIndexAfterPurge()
	{
		\Joomla\CMS\Log\Log::addLogger(array('text_file' => 'finder.log.php'), \Joomla\CMS\Log\Log::ALL, array('finder_plugin'));
		\Joomla\CMS\Log\Log::add('onFinderIndexAfterPurge Run after', \Joomla\CMS\Log\Log::INFO, 'finder_plugin');
	}
~~~~

### Expected result
After appending the above code, log events will be created for each Indexer's actions.
You can check the log records in the file: **administrator/logs/finder.log.php**

1. **Saving** an existing article in com_content, 2 log records should be created:
a. One with the message: _onFinderIndexAfterDelete Run after_ 
b. One with the message: _onFinderIndexAfterIndex Run after_ 

2. **Pressing the "Clear Index"** in the com_finder, 1 log record should be created with the message: _onFinderIndexAfterPurge_

3. **Deleting** an item in com_finder, 1 log record should be created, with the message: _onFinderIndexAfterDelete Run after_

4. **Pressing the "Index"** in the com_finder, multiple log records (as many as the indexed articles) should be created with the message: _onFinderIndexAfterIndex Run after_

*As it is clear all the above is just for testing purpose.

### Documentation Changes Required
Not sure
