### PR TITLE
[4.0] Featured articles filter

### DIFF
--- a/administrator/components/com_content/src/View/Featured/HtmlView.php
+++ b/administrator/components/com_content/src/View/Featured/HtmlView.php
@@ -77,7 +77,6 @@ class HtmlView extends BaseHtmlView
 		$this->pagination    = $this->get('Pagination');
 		$this->state         = $this->get('State');
 		$this->filterForm    = $this->get('FilterForm');
-		$this->activeFilters = $this->get('ActiveFilters');
 		$this->transitions   = $this->get('Transitions');
 		$this->vote          = PluginHelper::isEnabled('content', 'vote');
 


### PR DESCRIPTION
Prevent the featured articles page from opening with the filters expanded and ensure that they can be collapsed etc

## Before
![featured](https://user-images.githubusercontent.com/1296369/74669841-e4e3b680-519f-11ea-98d7-d46e8e7b092e.gif)

## After
![featured](https://user-images.githubusercontent.com/1296369/74669783-c67dbb00-519f-11ea-91f5-ea676bc72c1c.gif)
