### PR TITLE
2FA - Joomla Secret Key  - autocomplete="one-time-code"

### DIFF
--- a/administrator/components/com_joomlaupdate/views/update/tmpl/finaliseconfirm.php
+++ b/administrator/components/com_joomlaupdate/views/update/tmpl/finaliseconfirm.php
@@ -65,7 +65,7 @@ $twofactormethods = JAuthenticationHelper::getTwoFactorMethods();
 								<?php echo JText::_('JGLOBAL_SECRETKEY'); ?>
 							</label>
 						</span>
-						<input name="secretkey" autocomplete="off" tabindex="3" id="mod-login-secretkey" type="text" class="input-medium" placeholder="<?php echo JText::_('JGLOBAL_SECRETKEY'); ?>" size="15"/>
+						<input name="secretkey" autocomplete="one-time-code" tabindex="3" id="mod-login-secretkey" type="text" class="input-medium" placeholder="<?php echo JText::_('JGLOBAL_SECRETKEY'); ?>" size="15"/>
 						<span class="btn width-auto hasTooltip" title="<?php echo JText::_('JGLOBAL_SECRETKEY_HELP'); ?>">
 							<span class="icon-help" aria-hidden="true"></span>
 						</span>

--- a/administrator/components/com_joomlaupdate/views/upload/tmpl/captive.php
+++ b/administrator/components/com_joomlaupdate/views/upload/tmpl/captive.php
@@ -64,7 +64,7 @@ $twofactormethods = JAuthenticationHelper::getTwoFactorMethods();
 								<?php echo JText::_('JGLOBAL_SECRETKEY'); ?>
 							</label>
 						</span>
-						<input name="secretkey" autocomplete="off" tabindex="3" id="mod-login-secretkey" type="text" class="input-medium" placeholder="<?php echo JText::_('JGLOBAL_SECRETKEY'); ?>" size="15"/>
+						<input name="secretkey" autocomplete="one-time-code" tabindex="3" id="mod-login-secretkey" type="text" class="input-medium" placeholder="<?php echo JText::_('JGLOBAL_SECRETKEY'); ?>" size="15"/>
 						<span class="btn width-auto hasTooltip" title="<?php echo JText::_('JGLOBAL_SECRETKEY_HELP'); ?>">
 							<span class="icon-help" aria-hidden="true"></span>
 						</span>

--- a/administrator/modules/mod_login/tmpl/default.php
+++ b/administrator/modules/mod_login/tmpl/default.php
@@ -62,7 +62,7 @@ if ($langs)
 							<?php echo JText::_('JGLOBAL_SECRETKEY'); ?>
 						</label>
 					</span>
-					<input name="secretkey" autocomplete="off" tabindex="3" id="mod-login-secretkey" type="text" class="input-medium" placeholder="<?php echo JText::_('JGLOBAL_SECRETKEY'); ?>" size="15"/>
+					<input name="secretkey" autocomplete="one-time-code" tabindex="3" id="mod-login-secretkey" type="text" class="input-medium" placeholder="<?php echo JText::_('JGLOBAL_SECRETKEY'); ?>" size="15"/>
 					<span class="btn width-auto hasTooltip" title="<?php echo JText::_('JGLOBAL_SECRETKEY_HELP'); ?>">
 						<span class="icon-help"></span>
 					</span>

--- a/administrator/modules/mod_login/tmpl/default.php
+++ b/administrator/modules/mod_login/tmpl/default.php
@@ -62,7 +62,7 @@ if ($langs)
 							<?php echo JText::_('JGLOBAL_SECRETKEY'); ?>
 						</label>
 					</span>
-					<input name="secretkey" autocomplete="one-time-code" tabindex="3" id="mod-login-one-time-code" type="text" class="input-medium" placeholder="<?php echo JText::_('JGLOBAL_SECRETKEY'); ?>" size="15"/>
+					<input name="secretkey" autocomplete="one-time-code" tabindex="3" id="mod-login-secretkey" type="text" class="input-medium" placeholder="<?php echo JText::_('JGLOBAL_SECRETKEY'); ?>" size="15"/>
 					<span class="btn width-auto hasTooltip" title="<?php echo JText::_('JGLOBAL_SECRETKEY_HELP'); ?>">
 						<span class="icon-help"></span>
 					</span>

--- a/administrator/modules/mod_login/tmpl/default.php
+++ b/administrator/modules/mod_login/tmpl/default.php
@@ -62,7 +62,7 @@ if ($langs)
 							<?php echo JText::_('JGLOBAL_SECRETKEY'); ?>
 						</label>
 					</span>
-					<input name="secretkey" autocomplete="one-time-code" tabindex="3" id="mod-login-secretkey" type="text" class="input-medium" placeholder="<?php echo JText::_('JGLOBAL_SECRETKEY'); ?>" size="15"/>
+					<input name="secretkey" autocomplete="one-time-code" tabindex="3" id="mod-login-one-time-code" type="text" class="input-medium" placeholder="<?php echo JText::_('JGLOBAL_SECRETKEY'); ?>" size="15"/>
 					<span class="btn width-auto hasTooltip" title="<?php echo JText::_('JGLOBAL_SECRETKEY_HELP'); ?>">
 						<span class="icon-help"></span>
 					</span>

--- a/administrator/templates/hathor/html/mod_login/default.php
+++ b/administrator/templates/hathor/html/mod_login/default.php
@@ -25,7 +25,7 @@ JHtml::_('behavior.keepalive');
 					<label for="mod-login-secretkey">
 						<?php echo JText::_('JGLOBAL_SECRETKEY'); ?>
 					</label>
-					<input name="secretkey" autocomplete="off" tabindex="3" id="mod-login-secretkey" type="text" class="input-medium" size="15"/>
+					<input name="secretkey" autocomplete="one-time-code" tabindex="3" id="mod-login-secretkey" type="text" class="input-medium" size="15"/>
 				</div>
 			</div>
 		<?php endif; ?>

--- a/components/com_users/models/forms/login.xml
+++ b/components/com_users/models/forms/login.xml
@@ -28,6 +28,7 @@
 			name="secretkey"
 			type="text"
 			label="JGLOBAL_SECRETKEY"
+			autocomplete="one-time-code"
 			class=""
 			filter="int"
 			size="25"

--- a/modules/mod_login/tmpl/default.php
+++ b/modules/mod_login/tmpl/default.php
@@ -67,14 +67,14 @@ JHtml::_('bootstrap.tooltip');
 								<label for="modlgn-secretkey" class="element-invisible"><?php echo JText::_('JGLOBAL_SECRETKEY'); ?>
 							</label>
 						</span>
-						<input id="modlgn-secretkey" autocomplete="off" type="text" name="secretkey" class="input-small" tabindex="0" size="18" placeholder="<?php echo JText::_('JGLOBAL_SECRETKEY'); ?>" />
+						<input id="modlgn-secretkey" autocomplete="one-time-code" type="text" name="secretkey" class="input-small" tabindex="0" size="18" placeholder="<?php echo JText::_('JGLOBAL_SECRETKEY'); ?>" />
 						<span class="btn width-auto hasTooltip" title="<?php echo JText::_('JGLOBAL_SECRETKEY_HELP'); ?>">
 							<span class="icon-help"></span>
 						</span>
 				</div>
 				<?php else : ?>
 					<label for="modlgn-secretkey"><?php echo JText::_('JGLOBAL_SECRETKEY'); ?></label>
-					<input id="modlgn-secretkey" autocomplete="off" type="text" name="secretkey" class="input-small" tabindex="0" size="18" placeholder="<?php echo JText::_('JGLOBAL_SECRETKEY'); ?>" />
+					<input id="modlgn-secretkey" autocomplete="one-time-code" type="text" name="secretkey" class="input-small" tabindex="0" size="18" placeholder="<?php echo JText::_('JGLOBAL_SECRETKEY'); ?>" />
 					<span class="btn width-auto hasTooltip" title="<?php echo JText::_('JGLOBAL_SECRETKEY_HELP'); ?>">
 						<span class="icon-help"></span>
 					</span>

--- a/templates/beez3/html/mod_login/default.php
+++ b/templates/beez3/html/mod_login/default.php
@@ -33,11 +33,11 @@ JHtml::_('behavior.keepalive');
 			<?php if (!$params->get('usetext')) : ?>
 				<div class="input-prepend input-append">
 					<label for="modlgn-secretkey"><?php echo JText::_('JGLOBAL_SECRETKEY'); ?></label>
-					<input id="modlgn-secretkey" autocomplete="off" type="text" name="secretkey" class="input-small" tabindex="0" size="18" />
+					<input id="modlgn-secretkey" autocomplete="one-time-code" type="text" name="secretkey" class="input-small" tabindex="0" size="18" />
 				</div>
 			<?php else: ?>
 				<label for="modlgn-secretkey"><?php echo JText::_('JGLOBAL_SECRETKEY') ?></label>
-				<input id="modlgn-secretkey" autocomplete="off" type="text" name="secretkey" class="input-small" tabindex="0" size="18" />
+				<input id="modlgn-secretkey" autocomplete="one-time-code" type="text" name="secretkey" class="input-small" tabindex="0" size="18" />
 			<?php endif; ?>
 		</div>
 	</div>

--- a/templates/protostar/offline.php
+++ b/templates/protostar/offline.php
@@ -126,7 +126,7 @@ else
 
 						<?php if (count($twofactormethods) > 1) : ?>
 						<label for="secretkey"><?php echo JText::_('JGLOBAL_SECRETKEY'); ?></label>
-						<input type="text" name="secretkey" id="secretkey" title="<?php echo JText::_('JGLOBAL_SECRETKEY'); ?>" />
+						<input type="text" name="secretkey" autocomplete="one-time-code" id="secretkey" title="<?php echo JText::_('JGLOBAL_SECRETKEY'); ?>" />
 						<?php endif; ?>
 
 						<input type="submit" name="Submit" class="btn btn-primary" value="<?php echo JText::_('JLOGIN'); ?>" />

--- a/templates/system/offline.php
+++ b/templates/system/offline.php
@@ -71,7 +71,7 @@ $twofactormethods = JAuthenticationHelper::getTwoFactorMethods();
 		<?php if (count($twofactormethods) > 1) : ?>
 			<p id="form-login-secretkey">
 				<label for="secretkey"><?php echo JText::_('JGLOBAL_SECRETKEY'); ?></label>
-				<input type="text" name="secretkey" class="inputbox" alt="<?php echo JText::_('JGLOBAL_SECRETKEY'); ?>" id="secretkey" />
+				<input type="text" name="secretkey" autocomplete="one-time-code" class="inputbox" alt="<?php echo JText::_('JGLOBAL_SECRETKEY'); ?>" id="secretkey" />
 			</p>
 		<?php endif; ?>
 		<p id="submit-buton">


### PR DESCRIPTION
Pull Request for Issue #27580 .

### Summary of Changes
changed to `autocomplete="one-time-code"` for the 2fa or secret key


### Testing Instructions

Activate 2FA authentication on backend
save
Disconnect
Try to log in (on backend or frontend)using a password manager (i.e. 1Password or Lastpass)

### Expected result
The password manager recognize and fill the 3 fields


### Actual result
secret key not recognized



