### PR TITLE
[4.0] Fix active filters not collapsing

### DIFF
--- a/administrator/templates/atum/scss/system/searchtools/searchtools.scss
+++ b/administrator/templates/atum/scss/system/searchtools/searchtools.scss
@@ -61,10 +61,6 @@
       min-width: 15rem;
     }
 
-    &.js-filters-show {
-      display: flex;
-    }
-
     .chzn-container-single {
       display: block;
 
@@ -214,7 +210,7 @@
   }
 
   .js-stools-container-filters-visible {
-    display: inline-block;
+    display: flex;
   }
 
   .chzn-container-single .chzn-single span {

--- a/build/media_source/system/js/searchtools.es6.js
+++ b/build/media_source/system/js/searchtools.es6.js
@@ -333,19 +333,19 @@ Joomla = window.Joomla || {};
     // eslint-disable-next-line class-methods-use-this
     hideContainer(container) {
       if (container) {
-        container.classList.remove('js-filters-show');
+        container.classList.remove('js-stools-container-filters-visible');
         document.body.classList.remove('filters-shown');
       }
     }
 
     // eslint-disable-next-line class-methods-use-this
     showContainer(container) {
-      container.classList.add('js-filters-show');
+      container.classList.add('js-stools-container-filters-visible');
       document.body.classList.add('filters-shown');
     }
 
     toggleContainer(container) {
-      if (container.classList.contains('js-filters-show')) {
+      if (container.classList.contains('js-stools-container-filters-visible')) {
         this.hideContainer(container);
       } else {
         this.showContainer(container);


### PR DESCRIPTION
### Summary of Changes

Fixes search filters not collapsing.

### Testing Instructions

Go to any list view with filters.
Use the filters.
Once a filter is active, click `Filter Options` button.

### Expected result

Filters get hidden.

### Actual result

Some padding is added above filters.

### Documentation Changes Required

No.