### PR TITLE
[4.0] Use native php transliterate method when available (stringURLSafe)

### DIFF
--- a/libraries/src/Language/Language.php
+++ b/libraries/src/Language/Language.php
@@ -388,15 +388,20 @@ class Language
 	 */
 	public function transliterate($string)
 	{
+		// Override custom and core transliterate method with native php function if enabled
+		if (function_exists('transliterator_transliterate') && function_exists('iconv'))
+		{
+			return iconv("UTF-8", "ASCII//TRANSLIT//IGNORE", transliterator_transliterate('Any-Latin; Latin-ASCII; Lower()', $string));
+		}
+
 		if ($this->transliterator !== null)
 		{
 			return \call_user_func($this->transliterator, $string);
 		}
 
 		$string = Transliterate::utf8_latin_to_ascii($string);
-		$string = StringHelper::strtolower($string);
 
-		return $string;
+		return StringHelper::strtolower($string);
 	}
 
 	/**


### PR DESCRIPTION
Replaces https://github.com/joomla/joomla-cms/pull/16880 which was refused for J3

See comment by @HLeithner https://github.com/joomla/joomla-cms/pull/16880#issuecomment-569548949

### Summary of Changes
This PR lets override any custom transliterate method form the languages xx-XX.localise.php and create automatic ascii alias **whatever the language used in the title of the item** when the alias field is empty/emptied.

It takes advantage of the PHP extension `intl` **when it is enabled** to use the `transliterator_transliterate()` method, itself using `ICU` library.

The php extension is available since **php 5.4.0**, but may not be enabled on some hosts.
If disabled, former behavior is used, i.e. depending of the language in use or the item language or the site language (Depending on situation).

Using `iconv` and `IGNORE` let's get rid of some prime-characters that can't be transliterated, like the Cyrillic letter `ь`.

It is totally B/C as existing aliases are not modified.

### Testing Instructions
Check in System Information => PHP Information that the extension is enabled:
You should get something like this:

<img width="1302" alt="Screen Shot 2020-02-18 at 08 08 42" src="https://user-images.githubusercontent.com/869724/74712171-f7a0ce80-5225-11ea-809f-233c0f307364.png">

If it is not enabled on your local environment, try to modify your PHP.ini.

After patch, create or modify an item (menu item, article, category).
Leave the alias field empty or empty it and save.
For the same item, change its content language, empty alias field and save again.

Example with title `完 成`

![screen shot 2017-06-27 at 12 00 12](https://user-images.githubusercontent.com/869724/27582145-3b33c142-5b30-11e7-9f46-7f9a9defd6e8.png)

