### PR TITLE
[4.0] Hide filter bar in featured view if no filter is active.

### DIFF
--- a/administrator/components/com_content/src/Model/FeaturedModel.php
+++ b/administrator/components/com_content/src/Model/FeaturedModel.php
@@ -43,7 +43,6 @@ class FeaturedModel extends ArticlesModel
 				'created_by', 'a.created_by',
 				'created_by_alias', 'a.created_by_alias',
 				'ordering', 'a.ordering',
-				'featured', 'a.featured',
 				'featured_up', 'fp.featured_up',
 				'featured_down', 'fp.featured_down',
 				'language', 'a.language',


### PR DESCRIPTION
In the articles featured view, the filter bar is currently always open.
It should only be open when a filter is active.

### Summary of Changes
This PR removes "featured" from the allowed filters.
This filter doesn't make sense in that view anyway since filtering hardcoded by featured. So that condition isn't optional.


### Testing Instructions
Open the featured view in the articles manager
Apply some filters and clear them again.


### Expected result
Filter bar is closed by default
Filter bar is open by default if a filter is active.


### Actual result
Filter bar is always open by default


### Documentation Changes Required
None
