### PR TITLE
[4.0] Moving workflow states strings from users to main ini file

### DIFF
--- a/administrator/language/en-GB/com_users.ini
+++ b/administrator/language/en-GB/com_users.ini
@@ -338,16 +338,6 @@ COM_USERS_VIEW_NOTES_TITLE="User Notes"
 COM_USERS_VIEW_USERS_TITLE="Users"
 COM_USERS_XML_DESCRIPTION="Component for managing users"
 
-; States assets translations used in debuguser
-ARCHIVE="Archive"
-ARCHIVED="Archived"
-PUBLISH="Publish"
-PUBLISHED="Published"
-TRASH="Trash"
-TRASHED="Trashed"
-UNPUBLISH="Unpublish"
-UNPUBLISHED="Unpublished"
-
 ; Alternate language strings for the rules form field
 JLIB_RULES_SETTING_NOTES_COM_USERS="Changes apply to this component only.<br><em><strong>Inherited</strong></em> - a Global Configuration setting or higher level setting is applied.<br><em><strong>Denied</strong></em> always wins - whatever is set at the Global or higher level and applies to all child elements.<br><em><strong>Allowed</strong></em> will enable the action for this component unless overruled by a Global Configuration setting."
 

--- a/administrator/language/en-GB/joomla.ini
+++ b/administrator/language/en-GB/joomla.ini
@@ -1090,3 +1090,14 @@ SQLITE="SQLite"
 JFILTER_OPTIONS="Filter Options"
 JTABLE_OPTIONS="Table Options"
 JTABLE_OPTIONS_ORDERING="Order by:"
+
+; States assets translations
+ARCHIVE="Archive"
+ARCHIVED="Archived"
+PUBLISH="Publish"
+PUBLISHED="Published"
+TRASH="Trash"
+TRASHED="Trashed"
+UNPUBLISH="Unpublish"
+UNPUBLISHED="Unpublished"
+


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/pull/23992#issuecomment-586858359

### Summary of Changes
As title says.
These strings are not only used for debug user but also in the Transitions page and should be available eventually in other pages in the future.


### Testing Instructions
Set Debug language on.
Go to the Transitions page.
`administrator/index.php?option=com_workflow&view=transitions&workflow_id=1&extension=com_content`

### Before patch
<img width="456" alt="Screen Shot 2020-02-18 at 12 11 53" src="https://user-images.githubusercontent.com/869724/74731739-f1701980-5248-11ea-8a4c-bade060251f8.png">



### After patch

<img width="822" alt="Screen Shot 2020-02-18 at 12 13 48" src="https://user-images.githubusercontent.com/869724/74731745-f765fa80-5248-11ea-811f-fddb86ab21cd.png">

@wilsonge
Can be merged on review.