### PR TITLE
[4.0] Fix Warning in repeatable field

### DIFF
--- a/plugins/fields/repeatable/params/repeatable.xml
+++ b/plugins/fields/repeatable/params/repeatable.xml
@@ -6,7 +6,8 @@
 				name="fields"
 				type="subform"
 				label="PLG_FIELDS_REPEATABLE_PARAMS_FIELDS_LABEL"
-				multiple="true">
+				multiple="true"
+				required="true">
 				<form>
 					<fields>
 						<fieldset>

--- a/plugins/fields/repeatable/params/repeatable.xml
+++ b/plugins/fields/repeatable/params/repeatable.xml
@@ -6,8 +6,7 @@
 				name="fields"
 				type="subform"
 				label="PLG_FIELDS_REPEATABLE_PARAMS_FIELDS_LABEL"
-				multiple="true"
-				required="true">
+				multiple="true">
 				<form>
 					<fields>
 						<fieldset>

--- a/plugins/fields/repeatable/repeatable.php
+++ b/plugins/fields/repeatable/repeatable.php
@@ -85,17 +85,20 @@ class PlgFieldsRepeatable extends FieldsPlugin
 		// Get the form settings
 		$formFields = $field->fieldparams->get('fields');
 
-		// Add the fields to the form
-		foreach ($formFields as $index => $formField)
+		if (!empty($formFields))
 		{
-			$child = $fields->addChild('field');
-			$child->addAttribute('name', $formField->fieldname);
-			$child->addAttribute('type', $formField->fieldtype);
-			$child->addAttribute('readonly', $readonly);
-
-			if (isset($formField->fieldfilter))
+			// Add the fields to the form
+			foreach ($formFields as $index => $formField)
 			{
-				$child->addAttribute('filter', $formField->fieldfilter);
+				$child = $fields->addChild('field');
+				$child->addAttribute('name', $formField->fieldname);
+				$child->addAttribute('type', $formField->fieldtype);
+				$child->addAttribute('readonly', $readonly);
+
+				if (isset($formField->fieldfilter))
+				{
+					$child->addAttribute('filter', $formField->fieldfilter);
+				}
 			}
 		}
 


### PR DESCRIPTION
### Summary of Changes
A repeatable field without content causes a warning in  an article.

### Testing Instructions
Make a custom field of type repeatable and save it without adding a field.
Then open an article.

### Expected result
The article is displayed

### Actual result
Warning: Invalid argument supplied for foreach() in plugins\fields\repeatable\repeatable.php on line 89



### Documentation Changes Required
idk 
