### PR TITLE
[4.0] Fix subform filtering

### DIFF
--- a/libraries/src/Form/Field/SubformField.php
+++ b/libraries/src/Form/Field/SubformField.php
@@ -13,6 +13,7 @@ namespace Joomla\CMS\Form\Field;
 use Joomla\CMS\Filesystem\Path;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Form\FormField;
+use Joomla\Registry\Registry;
 
 /**
  * The Field to load the form inside current form
@@ -407,5 +408,57 @@ class SubformField extends FormField
 		}
 
 		return $forms;
+	}
+
+	/**
+	 * Method to filter a field value.
+	 *
+	 * @param   mixed     $value  The optional value to use as the default for the field.
+	 * @param   string    $group  The optional dot-separated form group path on which to find the field.
+	 * @param   Registry  $input  An optional Registry object with the entire data set to filter
+	 *                            against the entire form.
+	 *
+	 * @return  mixed   The filtered value.
+	 *
+	 * @since   4.0.0
+	 * @throws  \UnexpectedValueException
+	 */
+	public function filter($value, $group = null, Registry $input = null)
+	{
+		// Make sure there is a valid SimpleXMLElement.
+		if (!($this->element instanceof \SimpleXMLElement))
+		{
+			throw new \UnexpectedValueException(sprintf('%s::filter `element` is not an instance of SimpleXMLElement', \get_class($this)));
+		}
+
+		// Get the field filter type.
+		$filter = (string) $this->element['filter'];
+
+		if ($filter !== '')
+		{
+			return parent::filter($value, $group, $input);
+		}
+
+		// Dirty way of ensuring required fields in subforms are submitted and filtered the way other fields are
+		$subForm = $this->loadSubForm();
+
+		if ($this->multiple)
+		{
+			$return = [];
+
+			if ($value)
+			{
+				foreach ($value as $key => $val)
+				{
+					$return[$key] = $subForm->filter($val);
+				}
+			}
+		}
+		else
+		{
+			$return = $subForm->filter($value);
+		}
+
+		return $return;
 	}
 }

--- a/libraries/src/Form/FormField.php
+++ b/libraries/src/Form/FormField.php
@@ -991,6 +991,7 @@ abstract class FormField
 	 * @return  mixed   The filtered value.
 	 *
 	 * @since   4.0.0
+	 * @throws  \UnexpectedValueException
 	 */
 	public function filter($value, $group = null, Registry $input = null)
 	{
@@ -1003,35 +1004,13 @@ abstract class FormField
 		// Get the field filter type.
 		$filter = (string) $this->element['filter'];
 
-		if ($filter != '')
+		if ($filter !== '')
 		{
 			$required = ((string) $this->element['required'] === 'true' || (string) $this->element['required'] === 'required');
 
 			if (($value === '' || $value === null) && !$required)
 			{
 				return '';
-			}
-
-			// Dirty way of ensuring required fields in subforms are submitted and filtered the way other fields are
-			if ($this instanceof SubformField)
-			{
-				$subForm = $this->loadSubForm();
-
-				if ($this->multiple && !empty($value))
-				{
-					$return = array();
-
-					foreach ($value as $key => $val)
-					{
-						$return[$key] = $subForm->filter($val);
-					}
-				}
-				else
-				{
-					$return = $subForm->filter($value);
-				}
-
-				return $return;
 			}
 
 			// Check for a callback filter


### PR DESCRIPTION
### Summary of Changes

Moves subform filtering logic from base `FormField` to `SubformField` and fixes subform filtering.

### Testing Instructions

Edit `System - Redirect` plugin.
In `Exclude URLs` form add some rows.
In `Term` fields enter HTML content, e.g. `<script>alert(1);</script>`.
Save the plugin and inspect the field content.

### Expected result

HTML stripped out, e.g. `alert(1);` remains.

### Actual result

HTML not stripped out.

### Documentation Changes Required

No.