### PR TITLE
[4.0] changes npm to use the cache instead of clean install

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lint:js": "npx eslint .",
     "test": "npx karma start tests/javascript/karma.conf.js --single-run",
     "install": "node build.js --copy-assets && node build.js --build-pages",
-    "postinstall": "node build.js --compile-js && node build.js --compile-css && cd administrator/components/com_media && npm install && npm run build",
+    "postinstall": "node build.js --compile-js && node build.js --compile-css && cd administrator/components/com_media && npm ci && npm run build",
     "update": "node build.js --copy-assets && node build.js --build-pages && node build.js --compile-js && node build.js --compile-css",
     "gzip": "node -e 'require(\"./build/build-modules-js/gzip-assets.es6.js\").gzipFiles()'"
   },


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes



### Testing Instructions
run npm ci 
you'll see package-lock.json is created for com_media
add patch
run npm ci
file is no longer created.


### Expected result
doesn't create a new package-lock.json for com_media after each npm ci


### Actual result
creates package-lock.json in com_media each time.


### Documentation Changes Required

