### PR TITLE
[4.0] [com_content] Missing import

### DIFF
--- a/administrator/components/com_content/src/Service/HTML/AdministratorService.php
+++ b/administrator/components/com_content/src/Service/HTML/AdministratorService.php
@@ -17,6 +17,7 @@ use Joomla\CMS\Language\LanguageHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
+use Joomla\Database\ParameterType;
 
 /**
  * Content HTML helper


### PR DESCRIPTION
### Summary of Changes

Adds missing import

### Testing Instructions

Code review or set up a multilingual site and go to articles list in backend.

### Expected result

No errors.

### Actual result

>Class 'Joomla\Component\Content\Administrator\Service\HTML\ParameterType' not found 

### Documentation Changes Required

No.