### PR TITLE
[4.0] Fix contact and newsfeed association propagate functionality

### DIFF
--- a/administrator/components/com_contact/src/Controller/AjaxController.php
+++ b/administrator/components/com_contact/src/Controller/AjaxController.php
@@ -17,7 +17,6 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Controller\BaseController;
 use Joomla\CMS\Response\JsonResponse;
 use Joomla\CMS\Session\Session;
-use Joomla\CMS\Table\Table;
 
 /**
  * The contact controller for ajax requests
@@ -62,8 +61,7 @@ class AjaxController extends BaseController
 			unset($associations[$excludeLang]);
 
 			// Add the title to each of the associated records
-			Table::addIncludePath(JPATH_ADMINISTRATOR . '/components/com_contact/tables');
-			$contactTable = Table::getInstance('Contact', 'ContactTable');
+			$contactTable = $this->factory->createTable('Contact', 'Administrator');
 
 			foreach ($associations as $lang => $association)
 			{

--- a/administrator/components/com_newsfeeds/src/Controller/AjaxController.php
+++ b/administrator/components/com_newsfeeds/src/Controller/AjaxController.php
@@ -17,7 +17,6 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Controller\BaseController;
 use Joomla\CMS\Response\JsonResponse;
 use Joomla\CMS\Session\Session;
-use Joomla\CMS\Table\Table;
 
 /**
  * The newsfeed controller for ajax requests
@@ -62,8 +61,7 @@ class AjaxController extends BaseController
 			unset($associations[$excludeLang]);
 
 			// Add the title to each of the associated records
-			Table::addIncludePath(JPATH_ADMINISTRATOR . '/components/com_newsfeeds/tables');
-			$newsfeedsTable = Table::getInstance('Newsfeed', 'NewsfeedsTable');
+			$newsfeedsTable = $this->factory->createTable('Newsfeed', 'Administrator');
 
 			foreach ($associations as $lang => $association)
 			{


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/27037.

### Summary of Changes

Fixes table class loading.

### Testing Instructions

Set up a multilingual site with 3 languages (English, German, French).
Create a contact/newsfeed for each language.
Associate German contact/newsfeed with French and save.
Edit English contact/newsfeed.
Add an association and click `Propagate`.

### Expected result

Associated with German and French.
>All existing associations have been set.

### Actual result

>Failed propagating associations. You may have to select or create them manually.

### Documentation Changes Required

No.