### PR TITLE
Update default.php

### DIFF
--- a/modules/mod_breadcrumbs/tmpl/default.php
+++ b/modules/mod_breadcrumbs/tmpl/default.php
@@ -9,7 +9,7 @@
 
 defined('_JEXEC') or die;
 ?>
-<div aria-label="<?php echo $module->name; ?>" role="navigation">
+<div aria-label="<?php echo $module->title; ?>" role="navigation">
 	<ul itemscope itemtype="https://schema.org/BreadcrumbList" class="breadcrumb<?php echo $moduleclass_sfx; ?>">
 		<?php if ($params->get('showHere', 1)) : ?>
 			<li>


### PR DESCRIPTION
I have found this PHP Notice:  Undefined property: stdClass::$name in /modules/mod_breadcrumbs/tmpl/default.php on line 12. I have changed the name property to title to solve the error.

Pull Request for Issue # .

### Summary of Changes



### Testing Instructions



### Expected result



### Actual result



### Documentation Changes Required

