### PR TITLE
[4.0] Add admin module quicktask in content preset

### DIFF
--- a/administrator/components/com_content/presets/content.xml
+++ b/administrator/components/com_content/presets/content.xml
@@ -94,6 +94,8 @@
 			type="component"
 			element="com_modules"
 			link="index.php?option=com_modules&amp;view=modules&amp;client_id=1"
+			quicktask="index.php?option=com_modules&amp;view=select&amp;client_id=1"
+			quicktask-title="COM_CONTENT_MENUS_NEW_ADMIN_MODULE"
 		/>
 	</menuitem>
 </menu>


### PR DESCRIPTION
### Summary of Changes
As title says. 
Adding an admin module exists in all presets except in the content one.


### Testing Instructions
Display Content Dashboard


### Before patch
No plus sign to directly add an administrator module


### After patch

<img width="1005" alt="Screen Shot 2020-02-19 at 11 34 03" src="https://user-images.githubusercontent.com/869724/74826410-d6b2a900-530b-11ea-9bce-5237e0b2ba08.png">
