### PR TITLE
Add Package preparePreUpdate handler

### DIFF
--- a/administrator/components/com_installer/models/update.php
+++ b/administrator/components/com_installer/models/update.php
@@ -568,12 +568,15 @@ class InstallerModelUpdate extends JModelList
 		switch ($table->type)
 		{
 			// Components could have a helper which adds additional data
+			// Packages will fall back to the component helper (if present)
 			case 'component':
-				$ename = str_replace('com_', '', $table->element);
+			case 'package':
+				$pname = str_replace('pkg_', 'com_', $table->element);
+				$ename = str_replace('com_', '', $pname);
 				$fname = $ename . '.php';
 				$cname = ucfirst($ename) . 'Helper';
 
-				$path = JPATH_ADMINISTRATOR . '/components/' . $table->element . '/helpers/' . $fname;
+				$path = JPATH_ADMINISTRATOR . '/components/' . $pname . '/helpers/' . $fname;
 
 				if (JFile::exists($path))
 				{


### PR DESCRIPTION
Pull Request for improved / added functionality

### Summary of Changes
the Joomla Updater has a preparePreUpdate method that can handle updates to components, modules and plugins. This method can be used to for example dynamically add a download key to the download URL for the updated component, module, plugin.

This change extends the functionality to also be able to handle updating of packages as this is currently missing. Recommendation here is that the package holds a component with the same name as the package (so pkg_myextension holds com_myextension). The prepareUpdate function in the component will then be called to handle the preparePreUpdate actions needed for the package.


### Testing Instructions
Update a package where a download ID needs to be added to the download URL


### Expected result
The download ID is added via the page component helper function prepareUpdate and the download (and update) is successful


### Actual result
The package update doesn't call the helper function prepareUpdate and the download and update is unsuccessful as the required download id is missing.


### Documentation Changes Required
-
