### PR TITLE
[4.0] Open in new window

### DIFF
--- a/administrator/language/en-GB/joomla.ini
+++ b/administrator/language/en-GB/joomla.ini
@@ -161,9 +161,9 @@ JACTION_UNPUBLISH="Unpublish"
 
 JBROWSERTARGET_MODAL="Modal"
 JBROWSERTARGET_NEW="Open in new window"
+JBROWSERTARGET_NEW_TITLE="Open %s in new window"
 JBROWSERTARGET_PARENT="Open in parent window"
 JBROWSERTARGET_POPUP="Open in popup"
-JBROWSERTARGET_NEW_TITLE="Open %s in new window"
 
 JENFORCE_2FA_REDIRECT_MESSAGE="You were redirected because you are required to set up Two Factor Authentication to continue."
 

--- a/administrator/language/en-GB/joomla.ini
+++ b/administrator/language/en-GB/joomla.ini
@@ -163,6 +163,7 @@ JBROWSERTARGET_MODAL="Modal"
 JBROWSERTARGET_NEW="Open in new window"
 JBROWSERTARGET_PARENT="Open in parent window"
 JBROWSERTARGET_POPUP="Open in popup"
+JBROWSERTARGET_NEW_TITLE="Open %s in new window"
 
 JENFORCE_2FA_REDIRECT_MESSAGE="You were redirected because you are required to set up Two Factor Authentication to continue."
 

--- a/administrator/modules/mod_submenu/tmpl/default.php
+++ b/administrator/modules/mod_submenu/tmpl/default.php
@@ -51,7 +51,9 @@ use Joomla\CMS\Router\Route;
 							<?php $params = $item->getParams(); ?>
 							<?php // Only if Menu-show = true
 								if ($params->get('menu_show', 1)) : ?>
-								<a class="flex-grow-1" href="<?php echo $item->link; ?>"<?php echo $item->target ? ' target="' . $item->target . '"' : ''; ?>>
+								<a class="flex-grow-1" href="<?php echo $item->link; ?>"
+									<?php echo $item->target = "_blank" ? ' title="' . Text::sprintf('JBROWSERTARGET_NEW_TITLE', (Text::_($item->title))) . '"' : ''; ?>
+									<?php echo $item->target ? ' target="' . $item->target . '"' : ''; ?>>
 									<?php if (!empty($params->get('menu_image'))) : ?>
 										<?php
 										$image = htmlspecialchars($params->get('menu_image'), ENT_QUOTES, 'UTF-8');

--- a/administrator/modules/mod_submenu/tmpl/default.php
+++ b/administrator/modules/mod_submenu/tmpl/default.php
@@ -52,7 +52,7 @@ use Joomla\CMS\Router\Route;
 							<?php // Only if Menu-show = true
 								if ($params->get('menu_show', 1)) : ?>
 								<a class="flex-grow-1" href="<?php echo $item->link; ?>"
-									<?php echo $item->target = "_blank" ? ' title="' . Text::sprintf('JBROWSERTARGET_NEW_TITLE', (Text::_($item->title))) . '"' : ''; ?>
+									<?php echo $item->target === '_blank' ? ' title="' . Text::sprintf('JBROWSERTARGET_NEW_TITLE', Text::_($item->title)) . '"' : ''; ?>
 									<?php echo $item->target ? ' target="' . $item->target . '"' : ''; ?>>
 									<?php if (!empty($params->get('menu_image'))) : ?>
 										<?php

--- a/language/en-GB/joomla.ini
+++ b/language/en-GB/joomla.ini
@@ -131,6 +131,7 @@ JYES="Yes"
 
 JBROWSERTARGET_MODAL="Modal"
 JBROWSERTARGET_NEW="Open in new window"
+JBROWSERTARGET_NEW_TITLE="Open %s in new window"
 JBROWSERTARGET_PARENT="Open in parent window"
 JBROWSERTARGET_POPUP="Open in popup"
 


### PR DESCRIPTION
There are a million and one reasons why links should not open in a new window [link targets](https://adrianroselli.com/2020/02/link-targets-and-3-2-5.html)

> TL;DR: Regardless of what accessibility conformance level you target, do not arbitrarily open links in a new window or tab. If you are required to do so anyway, inform users in text.

We are currently visually indicating this but we are not indicating it to screen readers.

This PR changes that and will now add a "title=open LINKNAME in new window" to the links on the help dashboard.
![image](https://user-images.githubusercontent.com/1296369/74922592-58b3d800-53c7-11ea-962f-f7e6f808b391.png)

You might think that screen readers were intelligent enough to recognise a target=_blank and say something to the user but they don't [powermapper results](https://www.powermapper.com/tests/screen-readers/navigation/a-target-blank/)


