### PR TITLE
Fix submitting forms with empty repeatable subforms

### DIFF
--- a/libraries/src/Form/Form.php
+++ b/libraries/src/Form/Form.php
@@ -1564,13 +1564,16 @@ class Form
 					$field   = $this->loadField($element);
 					$subForm = $field->loadSubForm();
 
-					if ($field->multiple && !empty($value))
+					if ($field->multiple)
 					{
 						$return = array();
 
-						foreach ($value as $key => $val)
+						if ($value)
 						{
-							$return[$key] = $subForm->filter($val);
+							foreach ($value as $key => $val)
+							{
+								$return[$key] = $subForm->filter($val);
+							}
 						}
 					}
 					else
@@ -2155,17 +2158,20 @@ class Form
 			$field   = $this->loadField($element);
 			$subForm = $field->loadSubForm();
 
-			if ($field->multiple && $value)
+			if ($field->multiple)
 			{
-				foreach ($value as $key => $val)
+				if ($value)
 				{
-					$val = (array) $val;
-
-					$valid = $subForm->validate($val);
-
-					if ($valid === false)
+					foreach ($value as $key => $val)
 					{
-						break;
+						$val = (array) $val;
+
+						$valid = $subForm->validate($val);
+
+						if ($valid === false)
+						{
+							break;
+						}
 					}
 				}
 			}

--- a/libraries/src/Form/Form.php
+++ b/libraries/src/Form/Form.php
@@ -1559,7 +1559,7 @@ class Form
 					$return = call_user_func($filter, $value);
 				}
 
-				elseif ($element['type'] == 'subform')
+				elseif ((string) $element['type'] === 'subform')
 				{
 					$field   = $this->loadField($element);
 					$subForm = $field->loadSubForm();
@@ -2153,41 +2153,18 @@ class Form
 			}
 		}
 
-		if ($valid !== false && $element['type'] == 'subform')
+		if ($valid !== false && (string) $element['type'] === 'subform')
 		{
-			$field   = $this->loadField($element);
-			$subForm = $field->loadSubForm();
+			// Load the subform validation rule.
+			$rule = $this->loadRuleType('SubForm');
 
-			if ($field->multiple)
+			// Run the field validation rule test.
+			$valid = $rule->test($element, $value, $group, $input, $this);
+
+			// Check for an error in the validation test.
+			if ($valid instanceof \Exception)
 			{
-				if ($value)
-				{
-					foreach ($value as $key => $val)
-					{
-						$val = (array) $val;
-
-						$valid = $subForm->validate($val);
-
-						if ($valid === false)
-						{
-							break;
-						}
-					}
-				}
-			}
-			else
-			{
-				$valid = $subForm->validate($value);
-			}
-
-			if ($valid === false)
-			{
-				$errors = $subForm->getErrors();
-
-				foreach ($errors as $error)
-				{
-					return $error;
-				}
+				return $valid;
 			}
 		}
 


### PR DESCRIPTION
### Summary of Changes

Fixes a regression not allowing to submit forms containing repeatable subforms without any rows added.

### Testing Instructions

Try to save `Users` component or `System - Redirect` plugin configuration.

### Expected result

Form is saved.

### Actual result

Validation errors:

>Field required: Domain Name
>Field required: Term

### Documentation Changes Required

No.