### PR TITLE
[4.0] [plg_sampledata_multilang] Use MVC Factory to get tables

### DIFF
--- a/plugins/sampledata/multilang/multilang.php
+++ b/plugins/sampledata/multilang/multilang.php
@@ -20,6 +20,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\CMS\Session\Session;
 use Joomla\CMS\Table\Table;
+use Joomla\Component\Menus\Administrator\Table\MenuTable;
+use Joomla\Component\Menus\Administrator\Table\MenuTypeTable;
 use Joomla\Database\Exception\ExecutionFailureException;
 use Joomla\Database\ParameterType;
 
@@ -709,10 +711,8 @@ class PlgSampledataMultilang extends CMSPlugin
 	 */
 	private function addMenuGroup($itemLanguage)
 	{
-		Table::addIncludePath(JPATH_ADMINISTRATOR . '/components/com_menus/Table/');
-
 		// Add Menu Group.
-		$menuTable = new \Joomla\Component\Menus\Administrator\Table\MenuTypeTable($this->db);
+		$menuTable = new MenuTypeTable($this->db);
 
 		$menuData = array(
 			'id'          => 0,
@@ -754,10 +754,8 @@ class PlgSampledataMultilang extends CMSPlugin
 
 	private function addAllCategoriesMenuItem($itemLanguage)
 	{
-		Table::addIncludePath(JPATH_ADMINISTRATOR . '/components/com_menus/Table/');
-
 		// Add Menu Item.
-		$tableItem = new \Joomla\Component\Menus\Administrator\Table\MenuTable($this->db);
+		$tableItem = new MenuTable($this->db);
 
 		$newlanguage = new Language($itemLanguage->language, false);
 		$newlanguage->load('joomla', JPATH_ADMINISTRATOR, $itemLanguage->language, true);
@@ -835,10 +833,8 @@ class PlgSampledataMultilang extends CMSPlugin
 	 */
 	private function addBlogMenuItem($itemLanguage, $categoryId)
 	{
-		Table::addIncludePath(JPATH_ADMINISTRATOR . '/components/com_menus/Table/');
-
 		// Add Menu Item.
-		$tableItem = new \Joomla\Component\Menus\Administrator\Table\MenuTable($this->db);
+		$tableItem = new MenuTable($this->db);
 
 		$newlanguage = new Language($itemLanguage->language, false);
 		$newlanguage->load('com_languages', JPATH_ADMINISTRATOR, $itemLanguage->language, true);

--- a/plugins/sampledata/multilang/multilang.php
+++ b/plugins/sampledata/multilang/multilang.php
@@ -20,8 +20,6 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\CMS\Session\Session;
 use Joomla\CMS\Table\Table;
-use Joomla\Component\Menus\Administrator\Table\MenuTable;
-use Joomla\Component\Menus\Administrator\Table\MenuTypeTable;
 use Joomla\Database\Exception\ExecutionFailureException;
 use Joomla\Database\ParameterType;
 
@@ -712,7 +710,7 @@ class PlgSampledataMultilang extends CMSPlugin
 	private function addMenuGroup($itemLanguage)
 	{
 		// Add Menu Group.
-		$menuTable = new MenuTypeTable($this->db);
+		$menuTable = $this->app->bootComponent('com_menus')->getMVCFactory()->createTable('MenuType', 'Administrator', ['dbo' => $this->db]);
 
 		$menuData = array(
 			'id'          => 0,
@@ -755,7 +753,7 @@ class PlgSampledataMultilang extends CMSPlugin
 	private function addAllCategoriesMenuItem($itemLanguage)
 	{
 		// Add Menu Item.
-		$tableItem = new MenuTable($this->db);
+		$tableItem = $this->app->bootComponent('com_menus')->getMVCFactory()->createTable('Menu', 'Administrator', ['dbo' => $this->db]);
 
 		$newlanguage = new Language($itemLanguage->language, false);
 		$newlanguage->load('joomla', JPATH_ADMINISTRATOR, $itemLanguage->language, true);
@@ -834,7 +832,7 @@ class PlgSampledataMultilang extends CMSPlugin
 	private function addBlogMenuItem($itemLanguage, $categoryId)
 	{
 		// Add Menu Item.
-		$tableItem = new MenuTable($this->db);
+		$tableItem = $this->app->bootComponent('com_menus')->getMVCFactory()->createTable('Menu', 'Administrator', ['dbo' => $this->db]);
 
 		$newlanguage = new Language($itemLanguage->language, false);
 		$newlanguage->load('com_languages', JPATH_ADMINISTRATOR, $itemLanguage->language, true);
@@ -1013,7 +1011,7 @@ class PlgSampledataMultilang extends CMSPlugin
 		}
 
 		// Initialize a new category.
-		$category = Table::getInstance('CategoryTable', '\\Joomla\\Component\\Categories\\Administrator\\Table\\');
+		$category = $this->app->bootComponent('com_categories')->getMVCFactory()->createTable('Category', 'Administrator', ['dbo' => $this->db]);
 
 		$data = array(
 			'extension'       => 'com_content',
@@ -1089,7 +1087,7 @@ class PlgSampledataMultilang extends CMSPlugin
 		}
 
 		// Initialize a new article.
-		$article = Table::getInstance('ArticleTable', '\\Joomla\\Component\\Content\\Administrator\\Table\\');
+		$article = $this->app->bootComponent('com_content')->getMVCFactory()->createTable('Article', 'Administrator', ['dbo' => $this->db]);
 
 		$data = array(
 			'title'            => $title . ' (' . strtolower($itemLanguage->language) . ')',
@@ -1184,8 +1182,6 @@ class PlgSampledataMultilang extends CMSPlugin
 	 */
 	private function publishContentLanguages()
 	{
-		$app = Factory::getApplication();
-
 		// Publish the Content Languages.
 		$tableLanguage = Table::getInstance('Language');
 
@@ -1196,7 +1192,7 @@ class PlgSampledataMultilang extends CMSPlugin
 		{
 			if ($tableLanguage->load(array('lang_code' => $siteLang->language, 'published' => 0)) && !$tableLanguage->publish())
 			{
-				$app->enqueueMessage(Text::sprintf('INSTL_DEFAULTLANGUAGE_COULD_NOT_CREATE_CONTENT_LANGUAGE', $siteLang->name), 'warning');
+				$this->app->enqueueMessage(Text::sprintf('INSTL_DEFAULTLANGUAGE_COULD_NOT_CREATE_CONTENT_LANGUAGE', $siteLang->name), 'warning');
 
 				continue;
 			}


### PR DESCRIPTION
### Summary of Changes

Remove obsolete `JTable::addIncludePath()` calls.
Use MVC Factory to get component tables.

### Testing Instructions

Install 2 or more languages.
Install mutlilingual sample data.
Inspect installed multilingual sample data.

### Expected result

Same as before.

### Documentation Changes Required

No.