### PR TITLE
[4.0] Media manager: Transliteration of UTF8 file names when uploading (makeSafe)

### DIFF
--- a/libraries/src/Filesystem/File.php
+++ b/libraries/src/Filesystem/File.php
@@ -73,6 +73,13 @@ class File
 		// Remove any trailing dots, as those aren't ever valid file names.
 		$file = rtrim($file, '.');
 
+		// Try transiterating the file name using the native php function
+		if (function_exists('transliterator_transliterate') && function_exists('iconv'))
+		{
+			// Using iconv to ignore characters that can't be transliterated
+			$file = iconv("UTF-8", "ASCII//TRANSLIT//IGNORE", transliterator_transliterate('Any-Latin; Latin-ASCII; Lower()', $file));
+		}
+
 		$regex = array('#(\.){2,}#', '#[^A-Za-z0-9\.\_\- ]#', '#^\.#');
 
 		return trim(preg_replace($regex, '', $file));


### PR DESCRIPTION
Redo of https://github.com/joomla/joomla-cms/pull/16878 for J4 as we do not have the same problems.
https://github.com/joomla/joomla-cms/pull/16878#issuecomment-586713012

### Summary of Changes
Similar to https://github.com/joomla/joomla-cms/pull/27974 but for media files upload

It takes advantage of the PHP extension `intl` **when it is enabled** to use the `transliterator_transliterate()` method, itself using `ICU` library.

The php extension is available since **php 5.4.0**, but may not be enabled on some hosts.
If disabled, former behavior is used which does not accept to upload files with UTF8 names and displays an error. This PR is therefore totally BC.

Using `iconv` and `IGNORE` let's get rid of some prime-characters that can't be transliterated, like the Cyrillic letter `ь`.


### Testing Instructions
Check in System Information => PHP Information that the extension is enabled:
You should get something like this:

<img width="1302" alt="Screen Shot 2020-02-18 at 08 08 42" src="https://user-images.githubusercontent.com/869724/74712171-f7a0ce80-5225-11ea-809f-233c0f307364.png">

If it is not enabled on your local environment, try to modify your PHP.ini.

Change an image file name to utf8.
I used here `'完 成'".png` to be sure we also get rid of unwanted characters.

Go to Media Manager =>Upload, select the file and click upload.

!['完 成'](https://user-images.githubusercontent.com/869724/75019064-831d9800-5490-11ea-97c8-17ced5b952f4.png)

In the case above I get a pure ascii name wan-cheng.png:


![media_utf8](https://user-images.githubusercontent.com/869724/75019024-726d2200-5490-11ea-8161-ace3f47644bf.gif)

