### PR TITLE
Add noopener option to link rel attribute

### DIFF
--- a/administrator/components/com_menus/models/forms/item_url.xml
+++ b/administrator/components/com_menus/models/forms/item_url.xml
@@ -33,6 +33,7 @@
 				<option value="license"/>
 				<option value="next"/>
 				<option value="nofollow"/>
+				<option value="noopener"/>
 				<option value="noreferrer"/>
 				<option value="prefetch"/>
 				<option value="prev"/>


### PR DESCRIPTION
Pull Request for Issue #27990.

### Summary of Changes
Add `noopener` option to link rel attribute of external URL menu type.


### Testing Instructions
Add new menu item
Select System Links > URL
Click `Link Type` tab
Click `Link Rel Attribute` dropdown
See `noopener` option