### PR TITLE
[4.0] Cast XML element as string

### DIFF
--- a/libraries/src/Form/Filter/UrlFilter.php
+++ b/libraries/src/Form/Filter/UrlFilter.php
@@ -58,8 +58,8 @@ class UrlFilter implements FormFilterInterface
 
 		// If there is no protocol and the relative option is not specified,
 		// we assume that it is an external URL and prepend http://.
-		if (($element['type'] === 'url' && !$protocol && !$element['relative'])
-			|| (!$element['type'] === 'url' && !$protocol))
+		if (((string) $element['type'] === 'url' && !$protocol && !$element['relative'])
+			|| (!(string) $element['type'] === 'url' && !$protocol))
 		{
 			$protocol = 'http';
 

--- a/libraries/src/Form/Rule/EmailRule.php
+++ b/libraries/src/Form/Rule/EmailRule.php
@@ -107,7 +107,7 @@ class EmailRule extends FormRule
 		 * This allows different components and contexts to use different lists.
 		 * If value is incomplete, com_users.domains is used as fallback.
 		 */
-		$validDomains = (isset($element['validDomains']) && $element['validDomains'] !== 'false');
+		$validDomains = (string) $element['validDomains'] !== '' && (string) $element['validDomains'] !== 'false';
 
 		if ($validDomains && !$multiple)
 		{


### PR DESCRIPTION
### Summary of Changes

Missed these in https://github.com/joomla/joomla-cms/pull/27194. Casts XML element as string so strict comparison works properly.

### Testing Instructions

Code review.
Or edit `System - SEF` plugin. In canonical domain field enter a URL without protocol (e.g. `localhost`).

### Expected result

Value saved as `http://localhost`.

### Actual result

Saving fails with error:

>Invalid URL: URL schema is missing in localhost. Please add one of the following at the beginning: http, https, ftp, ftps, gopher, mailto, news, prospero, telnet, rlogin, sftp, tn3270, wais, mid, cid, nntp, tel, urn, ldap, file, fax, modem, git.

### Documentation Changes Required

No.