### PR TITLE
[4.0] Fix filtering categories and contacts by tags

### DIFF
--- a/administrator/components/com_categories/src/Model/CategoriesModel.php
+++ b/administrator/components/com_categories/src/Model/CategoriesModel.php
@@ -18,6 +18,7 @@ use Joomla\CMS\Language\Associations;
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
 use Joomla\CMS\MVC\Model\ListModel;
 use Joomla\Database\ParameterType;
+use Joomla\Utilities\ArrayHelper;
 
 /**
  * Categories Component Categories Model
@@ -305,21 +306,52 @@ class CategoriesModel extends ListModel
 				->bind(':language', $language);
 		}
 
-		// Filter by a single tag.
-		$tagId = $this->getState('filter.tag');
+		// Filter by a single or group of tags.
+		$tag       = $this->getState('filter.tag');
+		$typeAlias = $extension . '.category';
 
-		if (is_numeric($tagId))
+		// Run simplified query when filtering by one tag.
+		if (\is_array($tag) && \count($tag) === 1)
 		{
-			$tagId = (int) $tagId;
-			$typeAlias = $extension . '.category';
-			$query->where($db->quoteName('tagmap.tag_id') . ' = :tagid')
-				->bind(':tagid', $tagId, ParameterType::INTEGER)
-				->join(
-					'LEFT', $db->quoteName('#__contentitem_tag_map', 'tagmap')
-					. ' ON ' . $db->quoteName('tagmap.content_item_id') . ' = ' . $db->quoteName('a.id')
-					. ' AND ' . $db->quoteName('tagmap.type_alias') . ' = :typealias'
+			$tag = $tag[0];
+		}
+
+		if ($tag && \is_array($tag))
+		{
+			$tag = ArrayHelper::toInteger($tag);
+
+			$subQuery = $db->getQuery(true)
+				->select('DISTINCT ' . $db->quoteName('content_item_id'))
+				->from($db->quoteName('#__contentitem_tag_map'))
+				->where(
+					[
+						$db->quoteName('tag_id') . ' IN (' . implode(',', $query->bindArray($tag)) . ')',
+						$db->quoteName('type_alias') . ' = :typeAlias',
+					]
+				);
+
+			$query->join(
+				'INNER',
+				'(' . $subQuery . ') AS ' . $db->quoteName('tagmap'),
+				$db->quoteName('tagmap.content_item_id') . ' = ' . $db->quoteName('a.id')
+			)
+				->bind(':typeAlias', $typeAlias);
+		}
+		elseif ($tag = (int) $tag)
+		{
+			$query->join(
+				'INNER',
+				$db->quoteName('#__contentitem_tag_map', 'tagmap'),
+				$db->quoteName('tagmap.content_item_id') . ' = ' . $db->quoteName('a.id')
+			)
+				->where(
+					[
+						$db->quoteName('tagmap.tag_id') . ' = :tag',
+						$db->quoteName('tagmap.type_alias') . ' = :typeAlias',
+					]
 				)
-				->bind(':typealias', $typeAlias);
+				->bind(':tag', $tag, ParameterType::INTEGER)
+				->bind(':typeAlias', $typeAlias);
 		}
 
 		// Add the list ordering clause

--- a/administrator/components/com_categories/src/Model/CategoriesModel.php
+++ b/administrator/components/com_categories/src/Model/CategoriesModel.php
@@ -139,7 +139,7 @@ class CategoriesModel extends ListModel
 		$id .= ':' . $this->getState('filter.access');
 		$id .= ':' . $this->getState('filter.language');
 		$id .= ':' . $this->getState('filter.level');
-		$id .= ':' . $this->getState('filter.tag');
+		$id .= ':' . serialize($this->getState('filter.tag'));
 
 		return parent::getStoreId($id);
 	}


### PR DESCRIPTION
Pull Request for Issue #28008.

### Summary of Changes

Fixes filtering categories and contacts by tags in backend.

### Testing Instructions

Create some categories and contacts with tags.
Filter categories/contacts by single and multiple tags.

### Expected result

Categories/contacts filtered.

### Actual result

Categories/contacts not filtered.

### Documentation Changes Required

No.