### PR TITLE
Fix broken action link check

### DIFF
--- a/administrator/modules/mod_menu/tmpl/default_submenu.php
+++ b/administrator/modules/mod_menu/tmpl/default_submenu.php
@@ -148,7 +148,7 @@ else
 	echo '<span>' . Text::_($current->title) . '</span>' . $ajax;
 }
 
-if ($currentParams->get('menu-quicktask') && $this->params->get('shownew', 1) === 1)
+if ($currentParams->get('menu-quicktask') && (int) $this->params->get('shownew', 1) === 1)
 {
 	$params = $current->getParams();
 	$user = $this->application->getIdentity();


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
I inserted (int) before $this->params->get('shownew', 1) in line 151 


### Testing Instructions
The plus button for creating a new article or menu item in the menu on the left is missing. They are displayed again with the PR.


### Expected result



### Actual result
The problem is probably that the parameter is loaded from an XML file, so it's a string and not an integer.


### Documentation Changes Required

