### PR TITLE
[4.0] Simplify ACL Check

### DIFF
--- a/administrator/components/com_banners/src/Controller/BannerController.php
+++ b/administrator/components/com_banners/src/Controller/BannerController.php
@@ -43,17 +43,11 @@ class BannerController extends FormController
 	{
 		$filter     = $this->input->getInt('filter_category_id');
 		$categoryId = ArrayHelper::getValue($data, 'catid', $filter, 'int');
-		$allow      = null;
 
 		if ($categoryId)
 		{
 			// If the category has been passed in the URL check it.
-			$allow = $this->app->getIdentity()->authorise('core.create', $this->option . '.category.' . $categoryId);
-		}
-
-		if ($allow !== null)
-		{
-			return $allow;
+			return $this->app->getIdentity()->authorise('core.create', $this->option . '.category.' . $categoryId);
 		}
 
 		// In the absence of better information, revert to the component permissions.

--- a/administrator/components/com_contact/src/Controller/ContactController.php
+++ b/administrator/components/com_contact/src/Controller/ContactController.php
@@ -40,8 +40,7 @@ class ContactController extends FormController
 			// If the category has been passed in the URL check it.
 			return $this->app->getIdentity()->authorise('core.create', $this->option . '.category.' . $categoryId);
 		}
-
-
+		
 		// In the absence of better information, revert to the component permissions.
 		return parent::allowAdd($data);
 	}

--- a/administrator/components/com_contact/src/Controller/ContactController.php
+++ b/administrator/components/com_contact/src/Controller/ContactController.php
@@ -34,21 +34,16 @@ class ContactController extends FormController
 	protected function allowAdd($data = array())
 	{
 		$categoryId = ArrayHelper::getValue($data, 'catid', $this->input->getInt('filter_category_id'), 'int');
-		$allow = null;
 
 		if ($categoryId)
 		{
 			// If the category has been passed in the URL check it.
-			$allow = $this->app->getIdentity()->authorise('core.create', $this->option . '.category.' . $categoryId);
+			return $this->app->getIdentity()->authorise('core.create', $this->option . '.category.' . $categoryId);
 		}
 
-		if ($allow === null)
-		{
-			// In the absense of better information, revert to the component permissions.
-			return parent::allowAdd($data);
-		}
 
-		return $allow;
+		// In the absence of better information, revert to the component permissions.
+		return parent::allowAdd($data);
 	}
 
 	/**

--- a/administrator/components/com_contact/src/Controller/ContactController.php
+++ b/administrator/components/com_contact/src/Controller/ContactController.php
@@ -40,7 +40,7 @@ class ContactController extends FormController
 			// If the category has been passed in the URL check it.
 			return $this->app->getIdentity()->authorise('core.create', $this->option . '.category.' . $categoryId);
 		}
-		
+
 		// In the absence of better information, revert to the component permissions.
 		return parent::allowAdd($data);
 	}

--- a/administrator/components/com_content/src/Controller/ArticleController.php
+++ b/administrator/components/com_content/src/Controller/ArticleController.php
@@ -101,21 +101,15 @@ class ArticleController extends FormController
 	protected function allowAdd($data = array())
 	{
 		$categoryId = ArrayHelper::getValue($data, 'catid', $this->input->getInt('filter_category_id'), 'int');
-		$allow = null;
 
 		if ($categoryId)
 		{
 			// If the category has been passed in the data or URL check it.
-			$allow = $this->app->getIdentity()->authorise('core.create', 'com_content.category.' . $categoryId);
+			return $this->app->getIdentity()->authorise('core.create', 'com_content.category.' . $categoryId);
 		}
 
-		if ($allow === null)
-		{
-			// In the absense of better information, revert to the component permissions.
-			return parent::allowAdd();
-		}
-
-		return $allow;
+		// In the absence of better information, revert to the component permissions.
+		return parent::allowAdd();
 	}
 
 	/**

--- a/administrator/components/com_content/tmpl/articles/default.php
+++ b/administrator/components/com_content/tmpl/articles/default.php
@@ -157,7 +157,6 @@ HTMLHelper::_('script', 'com_content/admin-articles-workflow-buttons.js', ['rela
 						<?php foreach ($this->items as $i => $item) :
 							$item->max_ordering = 0;
 							$ordering   = ($listOrder == 'a.ordering');
-							$canCreate  = $user->authorise('core.create', 'com_content.category.' . $item->catid);
 							$canEdit    = $user->authorise('core.edit', 'com_content.article.' . $item->id);
 							$canCheckin = $user->authorise('core.manage', 'com_checkin') || $item->checked_out == $userId || $item->checked_out == 0;
 							$canEditOwn = $user->authorise('core.edit.own', 'com_content.article.' . $item->id) && $item->created_by == $userId;

--- a/administrator/components/com_content/tmpl/articles/default.php
+++ b/administrator/components/com_content/tmpl/articles/default.php
@@ -156,7 +156,6 @@ HTMLHelper::_('script', 'com_content/admin-articles-workflow-buttons.js', ['rela
 						<tbody <?php if ($saveOrder) :?> class="js-draggable" data-url="<?php echo $saveOrderingUrl; ?>" data-direction="<?php echo strtolower($listDirn); ?>" data-nested="true"<?php endif; ?>>
 						<?php foreach ($this->items as $i => $item) :
 							$item->max_ordering = 0;
-							$ordering   = ($listOrder == 'a.ordering');
 							$canEdit    = $user->authorise('core.edit', 'com_content.article.' . $item->id);
 							$canCheckin = $user->authorise('core.manage', 'com_checkin') || $item->checked_out == $userId || $item->checked_out == 0;
 							$canEditOwn = $user->authorise('core.edit.own', 'com_content.article.' . $item->id) && $item->created_by == $userId;


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
- In administrator/components/com_content/tmpl/articles/default.php, $canCreate permission is not used at all, so no need to calculate it for each article
- In other controller classes, no need for define and and use $allow variable. The logic for checking add permission is simple: If Category ID is passed, check add permission of the category, otherwise, fallback to component permissio

### Testing Instructions
Code review should be enough.

### Documentation Changes Required
None

