### PR TITLE
Fix cache logic in UsergrouplistField field type

### DIFF
--- a/libraries/src/Form/Field/UsergrouplistField.php
+++ b/libraries/src/Form/Field/UsergrouplistField.php
@@ -74,14 +74,12 @@ class UsergrouplistField extends \JFormFieldList
 	{
 		$options        = parent::getOptions();
 		$checkSuperUser = (int) $this->getAttribute('checksuperusergroup', 0);
-		$isSuperUser    = Factory::getUser()->authorise('core.admin');
 
-		// Hash for caching
-		$hash = $checkSuperUser . $isSuperUser;
-
-		if (!isset(static::$options[$hash]))
+		// Cache user groups base on checksuperusergroup attribute value
+		if (!isset(static::$options[$checkSuperUser]))
 		{
 			$groups       = UserGroupsHelper::getInstance()->getAll();
+			$isSuperUser  = Factory::getUser()->authorise('core.admin');
 			$cacheOptions = array();
 
 			foreach ($groups as $group)
@@ -99,9 +97,9 @@ class UsergrouplistField extends \JFormFieldList
 				);
 			}
 
-			static::$options[$hash] = $cacheOptions;
+			static::$options[$checkSuperUser] = $cacheOptions;
 		}
 
-		return array_merge($options, static::$options[$hash]);
+		return array_merge($options, static::$options[$checkSuperUser]);
 	}
 }


### PR DESCRIPTION
Pull Request for Issue #28013.

### Summary of Changes
This PR fixes wrong cache logic implemented in UsergrouplistField field type. Quote from @mbabker:

> Truthfully, that cache has some bad logic. The cache needs to account for the checksuperuser attribute and whether the current user is a super user and not just the element (whatever that actually is). Because THAT has more impact on whether the data should be different than whether the XML has a different structure. 

So instead of caching field options base on the field xml definition, we will just cache base on data of the checksuperuser attribute and whether the current user is a super user and not just the element (personal, I think on a page load, just cache it base on checksuperuser attribute value should be enough)

### Testing Instructions

1. Apply patch. Then go to Users -> Manage, click on Options button in the toolbar

2. Test case #1:  Check and make sure the user groups displayed in **New User Registration Group** and **Guest User Group** is still OK (basically, same as before)

3. Test case #2:  Test cache behavior:

- Open the file libraries/src/Form/Field/UsergrouplistField.php, add command **echo 'Run';** before 
this line of code https://github.com/joomdonation/joomla-cms/blob/patch-1/libraries/src/Form/Field/UsergrouplistField.php#L84

- Refresh the page, make sure you only see the word 'Run' one time.

- Now, modify this line https://github.com/joomla/joomla-cms/blob/staging/administrator/components/com_users/config.xml#L24 , change 1 to 0 (so that checksuperusergroup attribute is different for two fields. Refresh the page, make sure you see the words Run two times.

### Documentation Changes Required
No
