### PR TITLE
[4.0] Allow 3rd party components to easily create the dashboard menu module

### DIFF
--- a/administrator/language/en-GB/lib_joomla.ini
+++ b/administrator/language/en-GB/lib_joomla.ini
@@ -629,6 +629,7 @@ JLIB_INSTALLER_ERROR_COMP_INSTALL_DIR_ADMIN="Component Install: Another componen
 JLIB_INSTALLER_ERROR_COMP_INSTALL_DIR_SITE="Component Install: Another component is already using folder: %s"
 JLIB_INSTALLER_ERROR_COMP_INSTALL_FAILED_TO_CREATE_DIRECTORY_ADMIN="Component Install: Failed to create administrator folder: %s"
 JLIB_INSTALLER_ERROR_COMP_INSTALL_FAILED_TO_CREATE_DIRECTORY_SITE="Component Install: Failed to create site folder: %s"
+JLIB_INSTALLER_ERROR_COMP_INSTALL_FAILED_TO_CREATE_DASHBOARD="Component Install: Failed to create extension dashboard: %s"
 JLIB_INSTALLER_ERROR_COMP_REFRESH_MANIFEST_CACHE="Component Refresh manifest cache: Failed to store component details."
 JLIB_INSTALLER_ERROR_COMP_REMOVING_ADMIN_MENUS_FAILED="Could not delete the Administrator menus."
 JLIB_INSTALLER_ERROR_COMP_UNINSTALL_CUSTOM="Component Uninstall: Custom Uninstall script unsuccessful."

--- a/language/en-GB/lib_joomla.ini
+++ b/language/en-GB/lib_joomla.ini
@@ -629,6 +629,7 @@ JLIB_INSTALLER_ERROR_COMP_INSTALL_DIR_ADMIN="Component Install: Another componen
 JLIB_INSTALLER_ERROR_COMP_INSTALL_DIR_SITE="Component Install: Another component is already using folder: %s"
 JLIB_INSTALLER_ERROR_COMP_INSTALL_FAILED_TO_CREATE_DIRECTORY_ADMIN="Component Install: Failed to create administrator folder: %s"
 JLIB_INSTALLER_ERROR_COMP_INSTALL_FAILED_TO_CREATE_DIRECTORY_SITE="Component Install: Failed to create site folder: %s"
+JLIB_INSTALLER_ERROR_COMP_INSTALL_FAILED_TO_CREATE_DASHBOARD="Component Install: Failed to create extension dashboard: %s"
 JLIB_INSTALLER_ERROR_COMP_REFRESH_MANIFEST_CACHE="Component Refresh manifest cache: Failed to store component details."
 JLIB_INSTALLER_ERROR_COMP_REMOVING_ADMIN_MENUS_FAILED="Could not delete the Administrator menus."
 JLIB_INSTALLER_ERROR_COMP_UNINSTALL_CUSTOM="Component Uninstall: Custom Uninstall script unsuccessful."

--- a/libraries/src/Installer/InstallerScript.php
+++ b/libraries/src/Installer/InstallerScript.php
@@ -15,7 +15,6 @@ use Joomla\CMS\Filesystem\File;
 use Joomla\CMS\Filesystem\Folder;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
-use Joomla\Component\Modules\Administrator\Model\ModuleModel;
 use Joomla\Database\ParameterType;
 
 /**

--- a/libraries/src/Installer/InstallerScript.php
+++ b/libraries/src/Installer/InstallerScript.php
@@ -383,7 +383,7 @@ class InstallerScript
 	 */
 	public function addDashboardMenu(string $dashboard, string $preset)
 	{
-		$model = JFactory::getApplication()->bootComponent('com_modules')->getMVCFactory()->createModel('Module', 'Administrator', ['ignore_request' => true]);
+		$model  = Factory::getApplication()->bootComponent('com_modules')->getMVCFactory()->createModel('Module', 'Administrator', ['ignore_request' => true]);
 		$module = array(
 			'id'         => 0,
 			'asset_id'   => 0,
@@ -412,7 +412,7 @@ class InstallerScript
 
 		if (!$model->save($module))
 		{
-			Factory::getApplication()->enqueueMessage($model->getError());
+			Factory::getApplication()->enqueueMessage(Text::sprintf('JLIB_INSTALLER_ERROR_COMP_INSTALL_FAILED_TO_CREATE_DASHBOARD', $model->getError()));
 		}
 	}
 }

--- a/libraries/src/Installer/InstallerScript.php
+++ b/libraries/src/Installer/InstallerScript.php
@@ -15,6 +15,7 @@ use Joomla\CMS\Filesystem\File;
 use Joomla\CMS\Filesystem\Folder;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
+use Joomla\Component\Modules\Administrator\Model\ModuleModel;
 use Joomla\Database\ParameterType;
 
 /**
@@ -367,6 +368,52 @@ class InstallerScript
 					echo Text::sprintf('JLIB_INSTALLER_FILE_ERROR_MOVE', $name);
 				}
 			}
+		}
+	}
+
+	/**
+	 * Creates the dashboard menu module
+	 *
+	 * @param string $dashboard The name of the dashboard
+	 * @param string $preset    The name of the menu preset
+	 *
+	 * @return  void
+	 *
+	 * @throws \Exception
+	 * @since   4.0
+	 */
+	public function addDashboardMenu(string $dashboard, string $preset)
+	{
+		$model  = new ModuleModel;
+		$module = array(
+			'id'         => 0,
+			'asset_id'   => 0,
+			'language'   => '*',
+			'note'       => '',
+			'published'  => 1,
+			'assignment' => 0,
+			'client_id'  => 1,
+			'showtitle'  => 0,
+			'content'    => '',
+			'module'     => 'mod_submenu',
+			'position'   => 'cpanel-' . $dashboard,
+		);
+
+		// Try to get a translated module title, otherwise fall back to a fixed string.
+		$titleKey         = strtoupper('COM_' . $this->extension . '_DASHBOARD_' . $dashboard . '_TITLE');
+		$title            = Text::_($titleKey);
+		$module['title']  = ($title === $titleKey) ? ucfirst($dashboard) . ' Dashboard' : $title;
+
+		$module['access'] = (int) Factory::getApplication()->get('access', 1);
+		$module['params'] = array(
+			'menutype' => '*',
+			'preset'   => $preset,
+			'style'    => 'System-none',
+		);
+
+		if (!$model->save($module))
+		{
+			Factory::getApplication()->enqueueMessage($model->getError());
 		}
 	}
 }

--- a/libraries/src/Installer/InstallerScript.php
+++ b/libraries/src/Installer/InstallerScript.php
@@ -384,7 +384,7 @@ class InstallerScript
 	 */
 	public function addDashboardMenu(string $dashboard, string $preset)
 	{
-		$model  = new ModuleModel;
+		$model = JFactory::getApplication()->bootComponent('com_modules')->getMVCFactory()->createModel('Module', 'Administrator', ['ignore_request' => true]);
 		$module = array(
 			'id'         => 0,
 			'asset_id'   => 0,


### PR DESCRIPTION
Pull Request for Issue #27765

When a 3rd party component wants to use the dashboard, they would have to manually create the submenu module and assign the preset and all the needed parameters.
This PR tries to make that simpler by providing a function in the InstallerScript which can be called.

### Summary of Changes
Adds the method `addDashboardMenu` to the InstallerScript

To use it, an extension can simply call `$this->addDashboardMenu('foo', 'bar');` in it's custom install script. The first argument is the dashboard name as declared in the component adminmenu structure (see https://github.com/joomla/joomla-cms/pull/27849), the second argument is the name of the preset the submenu module should load.


### Testing Instructions
Eitehr adjust a 3rd party component to use a dashboard, or use my component where I added those calls for testing.
[com_sermonspeaker.zip](https://github.com/joomla/joomla-cms/files/4241262/com_sermonspeaker.zip)

Click on the dashboard icon next to the component name (or wherever you added the dashboard menuitem). In my component it is here:
![image](https://user-images.githubusercontent.com/1018684/75112621-d08f3600-5645-11ea-8b63-7f760b457e91.png)

Note: If you install my component more than once, you will get multiple menu modules. This is not a bug in this PR but one in my component script.

### Expected result
The dashboard has the dashboard menu with the correct preset loaded.


### Actual result
The dashboard is empty


### Documentation Changes Required
Dashboard related stuff needs to be documented in general.
