### PR TITLE
[4.0[ Login screen

### DIFF
--- a/administrator/templates/atum/scss/blocks/_login.scss
+++ b/administrator/templates/atum/scss/blocks/_login.scss
@@ -209,7 +209,6 @@ label {
 
 .com_login .sidebar-wrapper .main-brand {
   margin-top: 100px;
-  color: var(--atum-text-light);
   text-align: center;
   flex: 1;
   flex-basis: auto;
@@ -223,7 +222,6 @@ label {
   margin-bottom: 0.2rem;
 }
 
-.com_login .sidebar-wrapper .main-brand h1,
 .com_login .sidebar-wrapper .main-brand a,
 .com_login .sidebar-wrapper #sidebar,
 .com_login .sidebar-wrapper #sidebar a {


### PR DESCRIPTION
makes the page headings visible on the login screen on the new iteration of the template

### Before
![image](https://user-images.githubusercontent.com/1296369/75114285-c886c480-564c-11ea-8cfa-8fee0cce5e5d.png)

### After

![image](https://user-images.githubusercontent.com/1296369/75114301-e7855680-564c-11ea-8161-328de62a38a6.png)

npm i or node build.js --compile-css