### PR TITLE
[4.0] Move close button closer to save

### DIFF
--- a/administrator/components/com_banners/src/View/Banner/HtmlView.php
+++ b/administrator/components/com_banners/src/View/Banner/HtmlView.php
@@ -142,7 +142,6 @@ class HtmlView extends BaseHtmlView
 			{
 				ToolbarHelper::versions('com_banners.banner', $this->item->id);
 			}
-
 		}
 
 		ToolbarHelper::divider();

--- a/administrator/components/com_banners/src/View/Banner/HtmlView.php
+++ b/administrator/components/com_banners/src/View/Banner/HtmlView.php
@@ -136,12 +136,13 @@ class HtmlView extends BaseHtmlView
 		}
 		else
 		{
+			ToolbarHelper::cancel('banner.cancel', 'JTOOLBAR_CLOSE');
+
 			if (ComponentHelper::isEnabled('com_contenthistory') && $this->state->params->get('save_history', 0) && $canDo->get('core.edit'))
 			{
 				ToolbarHelper::versions('com_banners.banner', $this->item->id);
 			}
 
-			ToolbarHelper::cancel('banner.cancel', 'JTOOLBAR_CLOSE');
 		}
 
 		ToolbarHelper::divider();

--- a/administrator/components/com_banners/src/View/Client/HtmlView.php
+++ b/administrator/components/com_banners/src/View/Client/HtmlView.php
@@ -147,12 +147,12 @@ class HtmlView extends BaseHtmlView
 		}
 		else
 		{
+			ToolbarHelper::cancel('client.cancel', 'JTOOLBAR_CLOSE');
+
 			if (ComponentHelper::isEnabled('com_contenthistory') && $this->state->params->get('save_history', 0) && $canDo->get('core.edit'))
 			{
 				ToolbarHelper::versions('com_banners.client', $this->item->id);
 			}
-
-			ToolbarHelper::cancel('client.cancel', 'JTOOLBAR_CLOSE');
 		}
 
 		ToolbarHelper::divider();

--- a/administrator/components/com_categories/src/View/Category/HtmlView.php
+++ b/administrator/components/com_categories/src/View/Category/HtmlView.php
@@ -232,6 +232,8 @@ class HtmlView extends BaseHtmlView
 				'btn-success'
 			);
 
+			ToolbarHelper::cancel('category.cancel', 'JTOOLBAR_CLOSE');
+
 			if (ComponentHelper::isEnabled('com_contenthistory') && $componentParams->get('save_history', 0) && $itemEditable)
 			{
 				$typeAlias = $extension . '.category';
@@ -242,8 +244,6 @@ class HtmlView extends BaseHtmlView
 			{
 				ToolbarHelper::custom('category.editAssociations', 'contract', 'contract', 'JTOOLBAR_ASSOCIATIONS', false, false);
 			}
-
-			ToolbarHelper::cancel('category.cancel', 'JTOOLBAR_CLOSE');
 		}
 
 		ToolbarHelper::divider();

--- a/administrator/components/com_contact/src/View/Contact/HtmlView.php
+++ b/administrator/components/com_contact/src/View/Contact/HtmlView.php
@@ -159,6 +159,8 @@ class HtmlView extends BaseHtmlView
 				'btn-success'
 			);
 
+			ToolbarHelper::cancel('contact.cancel', 'JTOOLBAR_CLOSE');
+
 			if (ComponentHelper::isEnabled('com_contenthistory') && $this->state->params->get('save_history', 0) && $itemEditable)
 			{
 				ToolbarHelper::versions('com_contact.contact', $this->item->id);
@@ -168,8 +170,6 @@ class HtmlView extends BaseHtmlView
 			{
 				ToolbarHelper::custom('contact.editAssociations', 'contract', 'contract', 'JTOOLBAR_ASSOCIATIONS', false, false);
 			}
-
-			ToolbarHelper::cancel('contact.cancel', 'JTOOLBAR_CLOSE');
 		}
 
 		ToolbarHelper::divider();

--- a/administrator/components/com_content/src/View/Article/HtmlView.php
+++ b/administrator/components/com_content/src/View/Article/HtmlView.php
@@ -144,7 +144,7 @@ class HtmlView extends BaseHtmlView
 		// For new records, check the create permission.
 		if ($isNew && (count($user->getAuthorisedCategories('com_content', 'core.create')) > 0))
 		{
-			$apply = $toolbar->apply('article.apply');
+			$toolbar->apply('article.apply');
 
 			$saveGroup = $toolbar->dropdownButton('save-group');
 
@@ -156,6 +156,8 @@ class HtmlView extends BaseHtmlView
 					$childBar->save2new('article.save2new');
 				}
 			);
+
+			$toolbar->cancel('article.cancel', 'JTOOLBAR_CLOSE');
 		}
 		else
 		{
@@ -193,6 +195,8 @@ class HtmlView extends BaseHtmlView
 				}
 			);
 
+			$toolbar->cancel('article.cancel', 'JTOOLBAR_CLOSE');
+
 			if (ComponentHelper::isEnabled('com_contenthistory') && $this->state->params->get('save_history', 0) && $itemEditable)
 			{
 				$toolbar->versions('com_content.article', $this->item->id);
@@ -218,8 +222,6 @@ class HtmlView extends BaseHtmlView
 				->text('JTOOLBAR_ASSOCIATIONS')
 				->task('article.editAssociations');
 		}
-
-		$toolbar->cancel('article.cancel', 'JTOOLBAR_CLOSE');
 
 		$toolbar->divider();
 		$toolbar->help('JHELP_CONTENT_ARTICLE_MANAGER_EDIT');

--- a/administrator/components/com_newsfeeds/src/View/Newsfeed/HtmlView.php
+++ b/administrator/components/com_newsfeeds/src/View/Newsfeed/HtmlView.php
@@ -137,24 +137,25 @@ class HtmlView extends BaseHtmlView
 			'btn-success'
 		);
 
-		if (!$isNew && Associations::isEnabled() && ComponentHelper::isEnabled('com_associations'))
-		{
-			ToolbarHelper::custom('newsfeed.editAssociations', 'contract', 'contract', 'JTOOLBAR_ASSOCIATIONS', false, false);
-		}
-
 		if (empty($this->item->id))
 		{
 			ToolbarHelper::cancel('newsfeed.cancel');
 		}
 		else
 		{
+			ToolbarHelper::cancel('newsfeed.cancel', 'JTOOLBAR_CLOSE');
+
 			if (ComponentHelper::isEnabled('com_contenthistory') && $this->state->params->get('save_history', 0) && $canDo->get('core.edit'))
 			{
 				ToolbarHelper::versions('com_newsfeeds.newsfeed', $this->item->id);
 			}
-
-			ToolbarHelper::cancel('newsfeed.cancel', 'JTOOLBAR_CLOSE');
 		}
+
+		if (!$isNew && Associations::isEnabled() && ComponentHelper::isEnabled('com_associations'))
+		{
+			ToolbarHelper::custom('newsfeed.editAssociations', 'contract', 'contract', 'JTOOLBAR_ASSOCIATIONS', false, false);
+		}
+
 
 		ToolbarHelper::divider();
 		ToolbarHelper::help('JHELP_COMPONENTS_NEWSFEEDS_FEEDS_EDIT');

--- a/administrator/components/com_newsfeeds/src/View/Newsfeed/HtmlView.php
+++ b/administrator/components/com_newsfeeds/src/View/Newsfeed/HtmlView.php
@@ -156,7 +156,6 @@ class HtmlView extends BaseHtmlView
 			ToolbarHelper::custom('newsfeed.editAssociations', 'contract', 'contract', 'JTOOLBAR_ASSOCIATIONS', false, false);
 		}
 
-
 		ToolbarHelper::divider();
 		ToolbarHelper::help('JHELP_COMPONENTS_NEWSFEEDS_FEEDS_EDIT');
 	}

--- a/administrator/components/com_tags/src/View/Tag/HtmlView.php
+++ b/administrator/components/com_tags/src/View/Tag/HtmlView.php
@@ -151,12 +151,12 @@ class HtmlView extends BaseHtmlView
 				'btn-success'
 			);
 
+			ToolbarHelper::cancel('tag.cancel', 'JTOOLBAR_CLOSE');
+
 			if (ComponentHelper::isEnabled('com_contenthistory') && $this->state->params->get('save_history', 0) && $itemEditable)
 			{
 				ToolbarHelper::versions('com_tags.tag', $this->item->id);
 			}
-
-			ToolbarHelper::cancel('tag.cancel', 'JTOOLBAR_CLOSE');
 		}
 
 		ToolbarHelper::divider();

--- a/administrator/components/com_users/src/View/Note/HtmlView.php
+++ b/administrator/components/com_users/src/View/Note/HtmlView.php
@@ -131,12 +131,12 @@ class HtmlView extends BaseHtmlView
 		}
 		else
 		{
+			ToolbarHelper::cancel('note.cancel', 'JTOOLBAR_CLOSE');
+
 			if (ComponentHelper::isEnabled('com_contenthistory') && $this->state->params->get('save_history', 0) && $canDo->get('core.edit'))
 			{
 				ToolbarHelper::versions('com_users.note', $this->item->id);
 			}
-
-			ToolbarHelper::cancel('note.cancel', 'JTOOLBAR_CLOSE');
 		}
 
 		ToolbarHelper::divider();


### PR DESCRIPTION
Pull Request releated to  #27918 .

### Summary of Changes
In the UX improvement PR is was a change to move the close button from right to be more left and so closer to the save action buttons. This PR make this change consitend for all edit views (I hope I haven't missed one :-))

### Testing Instructions
Check if the close button is directly right from the save-actions or save button.

#### Before
![7C071FBD-BD60-4B92-B8AF-F144C1B9147D](https://user-images.githubusercontent.com/467356/75115236-d8a6a000-565c-11ea-978a-6be20fa8aa9d.png)

#### After
![1918ABBD-ACAA-4184-B4B5-2F11B1CF0616](https://user-images.githubusercontent.com/467356/75115239-dd6b5400-565c-11ea-91ab-0005ae9887a8.png)


