### PR TITLE
[4.0] Sidebar drop down indicator

### DIFF
--- a/administrator/templates/atum/scss/blocks/_sidebar.scss
+++ b/administrator/templates/atum/scss/blocks/_sidebar.scss
@@ -403,6 +403,10 @@
       }
     }
 
+    &:hover::after {
+      color: $white;
+    }
+
     &::after {
       display: flex;
       align-items: center;
@@ -411,7 +415,6 @@
       color: var(--atum-sidebar-font-color) ;
       font-weight: 900;
       font-family: "Font Awesome 5 Free";
-
 
       [dir=ltr] & {
         content: "\f054";


### PR DESCRIPTION
It is not possible to see the drop down indicator on hover. This PR fixes that so it looks like this
![video](https://user-images.githubusercontent.com/1296369/75116927-f11ab880-5664-11ea-9d69-df23007d485c.gif)
