### PR TITLE
[4.0] jumping tabs

### DIFF
--- a/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-tab.scss
+++ b/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-tab.scss
@@ -58,7 +58,7 @@ joomla-tab {
         background-image: none;
         border-radius: 0;
         box-shadow: none;
-              margin-bottom: -1px;
+        margin: -1px;
         border:1px solid  var(--bluegray);
         border-bottom: solid 1px #fff;
         &::after {


### PR DESCRIPTION
Fixes the tab titles jumping around
as always with css changes run npm i or node build.js --compile-css

### before
![before](https://user-images.githubusercontent.com/1296369/75117884-6a1e0e00-566d-11ea-9f39-c585a38dad58.gif)

### after
![after](https://user-images.githubusercontent.com/1296369/75117888-6d18fe80-566d-11ea-8b81-f747f816b502.gif)
