### PR TITLE
Fix some issues when saving menus

### DIFF
--- a/administrator/components/com_menus/controllers/menu.php
+++ b/administrator/components/com_menus/controllers/menu.php
@@ -59,7 +59,7 @@ class MenusControllerMenu extends JControllerForm
 			JFactory::getApplication()->enqueueMessage($msg, 'error');
 
 			// Redirect back to the edit screen.
-			$this->setRedirect(JRoute::_('index.php?option=com_menus&view=menu&layout=edit', false));
+			$this->setRedirect(JRoute::_('index.php?option=com_menus&view=menu&layout=edit' . $this->getRedirectToItemAppend($recordId), false));
 
 			return false;
 		}
@@ -103,7 +103,7 @@ class MenusControllerMenu extends JControllerForm
 			$app->setUserState($context . '.data', $data);
 
 			// Redirect back to the edit screen.
-			$this->setRedirect(JRoute::_('index.php?option=com_menus&view=menu&layout=edit', false));
+			$this->setRedirect(JRoute::_('index.php?option=com_menus&view=menu&layout=edit' . $this->getRedirectToItemAppend($recordId), false));
 
 			return false;
 		}
@@ -123,7 +123,7 @@ class MenusControllerMenu extends JControllerForm
 
 			// Redirect back to the edit screen.
 			$this->setMessage(JText::sprintf('JLIB_APPLICATION_ERROR_SAVE_FAILED', $model->getError()), 'error');
-			$this->setRedirect(JRoute::_('index.php?option=com_menus&view=menu&layout=edit', false));
+			$this->setRedirect(JRoute::_('index.php?option=com_menus&view=menu&layout=edit' . $this->getRedirectToItemAppend($recordId), false));
 
 			return false;
 		}
@@ -155,6 +155,7 @@ class MenusControllerMenu extends JControllerForm
 				// Set the record data in the session.
 				$recordId = $model->getState($this->context . '.id');
 				$this->holdEditId($context, $recordId);
+				$app->setUserState($context . '.data', null);
 
 				// Redirect back to the edit screen.
 				$this->setRedirect(JRoute::_('index.php?option=com_menus&view=menu&layout=edit' . $this->getRedirectToItemAppend($recordId), false));


### PR DESCRIPTION
Fixes https://github.com/joomla/joomla-cms/issues/27828 and https://github.com/joomla/joomla-cms/issues/26947.

### Summary of Changes

Append ID to redirect URL so it doesn't get lost.
Clear session data when applying changes to load data from database.

### Testing Instructions

1)

Create two menus (menu1 and menu2).
Edit menu2.
Change its Menu Type to menu1.
Click Save.
After saving fails, change its menu type to menu3 and save.
View menus.

2)

Edit a menu.
Remove its menu type.
Use browser tools to circumvent JS validation (remove `required` class and attribute from menu type field).
Click Save.
After saving fails, edit menu type back to what it was.
Save.

### Expected result

1) menu2 type changed to menu3.
2) Menu saved.

### Actual result

1) A new menu with type menu3 is created.
2) Saving fails with error: `Save failed with the following error: Menu type exists:...`

### Documentation Changes Required

No.