### PR TITLE
[4.0] Atum sidebar border

### DIFF
--- a/administrator/templates/atum/scss/blocks/_sidebar.scss
+++ b/administrator/templates/atum/scss/blocks/_sidebar.scss
@@ -124,6 +124,7 @@
 
     > a {
       flex-grow: 2;
+      border-bottom: solid 1px transparent;
 
       &:hover {
         border-bottom: solid 1px var(--atum-bg-light);

--- a/administrator/templates/atum/scss/blocks/_sidebar.scss
+++ b/administrator/templates/atum/scss/blocks/_sidebar.scss
@@ -121,11 +121,13 @@
     position: relative;
     display: flex;
     flex-wrap: wrap;
-    border-bottom:solid 1px var(--atum-bg-light);
 
     > a {
       flex-grow: 2;
 
+      &:hover {
+        border-bottom: solid 1px var(--atum-bg-light);
+      }
     }
 
     .menu-dashboard,


### PR DESCRIPTION
Pull Request for Issue #28043

This Pr moves the border bottom on the sidebar items so that it only appears on hover.

As can be seen below where I have changed the border to red for clarity it was on the wrong element

requires npm i or node build.js --compile-css to test

 ### before
![before](https://user-images.githubusercontent.com/1296369/75140428-cd985200-56e6-11ea-8dd2-42207b015847.gif)

### after
![after](https://user-images.githubusercontent.com/1296369/75140608-25cf5400-56e7-11ea-85ac-7aff2d636463.gif)


