### PR TITLE
Add new "sponsored" and "ugc" options to rel attribute for external links

### DIFF
--- a/administrator/components/com_menus/models/forms/item_url.xml
+++ b/administrator/components/com_menus/models/forms/item_url.xml
@@ -35,6 +35,8 @@
 				<option value="nofollow"/>
 				<option value="noopener"/>
 				<option value="noreferrer"/>
+				<option value="sponsored"/>
+				<option value="ugc"/>
 				<option value="prefetch"/>
 				<option value="prev"/>
 				<option value="search"/>

--- a/administrator/components/com_menus/models/forms/item_url.xml
+++ b/administrator/components/com_menus/models/forms/item_url.xml
@@ -35,12 +35,12 @@
 				<option value="nofollow"/>
 				<option value="noopener"/>
 				<option value="noreferrer"/>
-				<option value="sponsored"/>
-				<option value="ugc"/>
 				<option value="prefetch"/>
 				<option value="prev"/>
 				<option value="search"/>
+				<option value="sponsored"/>
 				<option value="tag"/>
+				<option value="ugc"/>
 			</field>
 
 			<field 


### PR DESCRIPTION
Pull Request for issue #26312

### Why
https://support.google.com/webmasters/answer/96569?hl=en
Advanced users (copywriters, bloggers, etc.) are very concerned about SEO.
Their projects often live thanks to affiliation, sponsorship and advertising.
It is important to provide them with all the tools necessary for a correct supply of information to the search engine, so as not to be penalized and to constantly improve aspects such as indexing and positioning.
These two options specifically help Google identify the behavior of outbound links from Joomla sites, thus providing correct information on what to expect from the connected external source.

### Summary of Changes
Add new "sponsored" and "ugc" options to rel attribute of external URL menu type.

### Testing Instructions
Add new menu item
Select System Links > URL
Click **Link Type** tab
Click **Link Rel Attribute** dropdown
See **spondored** and **ugc** option

### Next Step (not in this PR)
Users should select more than one option for "rel" attribute.
https://www.w3.org/TR/html401/struct/links.html#adef-rel
> rel = link-types [CI]
> This attribute describes the relationship from the current document to the anchor specified by the href attribute.
> The value of this attribute is a space-separated list of link types.
