### PR TITLE
[4.0] Toolbar buttons

### DIFF
--- a/administrator/templates/atum/scss/_variables.scss
+++ b/administrator/templates/atum/scss/_variables.scss
@@ -1,7 +1,7 @@
 // Variables
 @import "../../../../media/vendor/bootstrap/scss/functions";
 
-$white:                            #ffffff;
+$white:                            #fff;
 $whiteoffset:                      #fefefe;
 $gray-100:                         #f8f9fa;
 $gray-200:                         #e8e8e8; //used in bootstrap .badge-inverse
@@ -14,8 +14,8 @@ $gray-800:                         #343a40; //used for badges-inverse
 $gray-900:                         #212529; //used for tree header, badge-inverse border
 $bluegray:                         #b2bfcd; // used for borders
 $black:                            #000;    //used for shadows
-$focuscolor:                       #39f;   //used for focus color
-$dark-blue:                        #001B4C; //is the atum-special-color
+$focuscolor:                       #39f;    //used for focus color
+$dark-blue:                        #001b4c; //is the atum-special-color
 $light-blue:                       #2a69b8; //is the atum-link-color
 $focusshadow:                      0 0 0 .2rem #d3e2f5;
 
@@ -30,7 +30,7 @@ $yellow:                           #ffb514; //used in bootstrap
 $green:                            #2f7d32; //used in bootstrap
 $green-dark:                       #0f2f21; //used for alert success
 $teal:                             #20c997; //used in bootstrap
-$cyan:                             #107D8E; //used in bootstrap
+$cyan:                             #107d8e; //used in bootstrap
 $darkblue:                         #3b4a5c;
 $base-color:                       $darkblue;
 
@@ -39,7 +39,7 @@ $theme-colors: map-merge((
   primary:                         $base-color, //used only in bootstrap, please use $atum-bg-dark
   secondary:                       $gray-700, //used for btn-secondary
   success:                         $green,
-  info:                            $cyan,
+  info:                            $light-blue,
   warning:                         $yellow,
   danger:                          $red,
   light:                           $gray-100, //used in bootstrap
@@ -57,10 +57,10 @@ $colors: (
   bluegray:                        $bluegray,
   lightbluegray:                   #f6f9fc,
   toolbar-bg:                      $white,
-  success-border:                  theme-color("success"),
-  info-border:                     theme-color("info"),
-  warning-border:                  theme-color("warning"),
-  danger-border:                   theme-color("danger"),
+  success-border:                  theme-color('success'),
+  info-border:                     theme-color('info'),
+  warning-border:                  theme-color('warning'),
+  danger-border:                   theme-color('danger'),
   login-main-bg:                   darken($base-color, 8%), //used on login
   border:                          $gray-400,
   white-offset:                    $whiteoffset,
@@ -92,14 +92,14 @@ $alert-border-level:               0;
 $alert-color-level:                0;
 
 // Global
-$atum-box-shadow:                 0 2px 4px rgba(0,0,0,0.16), 0 2px 4px rgba(0,0,0,0.23);
+$atum-box-shadow:                  0 2px 4px rgba(0, 0, 0, 0.16), 0 2px 4px rgba(0, 0, 0, 0.23);
 $enable-rounded:                   false;
 $border-radius:                    3px;
-$input-box-shadow:                 inset 0 0 0 .1rem lighten(theme-color("atum-link-color"), 45%);
+$input-box-shadow:                 inset 0 0 0 .1rem lighten(theme-color('atum-link-color'), 45%);
 $input-btn-padding-y:              .6rem;
 $input-btn-padding-x:              1rem;
 $input-max-width:                  100%;
-$btn-disabled-opacity:             0.4;
+$btn-disabled-opacity:             .4;
 
 // Header
 $header-height:                    3.5rem;
@@ -125,10 +125,10 @@ $font-size-sm:                     .8rem;
 $font-size-vsm:                    .6rem;
 $display1-size:                    1rem;
 $display2-size:                    .875rem;
-$content-font-size:                0.875rem;
+$content-font-size:                .875rem;
 $label-font-size:                  1rem;
-$danger-bg:                        #990000;
-$badge-font-size:                  0.75rem;
+$danger-bg:                        #900;
+$badge-font-size:                  .75rem;
 $fa-css-prefix:                    fa;
 $fa-font-path:                     "../../../../media/vendor/fontawesome-free/webfonts";
 $roboto-font-path:                 "../../../../media/vendor/roboto-fontface/fonts";
@@ -193,9 +193,9 @@ $success-bg:                       $green;
 $success-txt:                      $white;
 
 $warning-bg:                       #f9d71c;
-$warning-txt:                      #000000;
+$warning-txt:                      #000;
 
-$danger-bg:                        #990000;
+$danger-bg:                        #900;
 $danger-txt:                       #fff;
 
 // Input Group

--- a/administrator/templates/atum/scss/blocks/_toolbar.scss
+++ b/administrator/templates/atum/scss/blocks/_toolbar.scss
@@ -98,11 +98,12 @@ joomla-toolbar-button {
         [class^='#{$fa-css-prefix}-'],
         [class*=' #{$fa-css-prefix}-'],
         span {
-          background: darken(theme-color("success"), 10%);
+          background: darken(theme-color('success'), 10%);
           color: rgba(255, 255, 255, 0.90);
         }
+
+        background-color: theme-color('success');
         color: rgba(255, 255, 255, 0.90);
-        background-color: theme-color("success");
       }
     }
 
@@ -151,7 +152,6 @@ joomla-toolbar-button {
       &:hover,
       &:active,
       &:focus {
-
         background-color: theme-color('info');
         color: rgba(255, 255, 255, 0.90);
 
@@ -184,19 +184,22 @@ joomla-toolbar-button {
     }
 
     &.btn-info {
+
+      background-color: $white;
+      border-radius: $border-radius;
+
       [class^='icon-'],
       [class*=' icon-'],
       [class^='#{$fa-css-prefix}-'],
       [class*=' #{$fa-css-prefix}-'],
       span {
-        color: var(--atum-bg-dark-80);
-        background-color: rgba(255, 255, 255, 0.90);
+        color: darken(theme-color('info'), 5%);
       }
 
       &:hover,
       &:active,
       &:focus {
-        background-color: var(--atum-bg-dark-80);
+        background-color: lighten(theme-color('info'), 10%);
         color: rgba(255, 255, 255, 0.90);
 
         [class^='icon-'],
@@ -204,7 +207,7 @@ joomla-toolbar-button {
         [class^='#{$fa-css-prefix}-'],
         [class*=' #{$fa-css-prefix}-'],
         span {
-          background-color: var(--atum-bg-dark-80);
+          background: lighten(theme-color('info'), 5%);
           color: rgba(255, 255, 255, 0.90);
         }
       }

--- a/administrator/templates/atum/scss/blocks/_toolbar.scss
+++ b/administrator/templates/atum/scss/blocks/_toolbar.scss
@@ -137,32 +137,32 @@ joomla-toolbar-button {
 
     &.btn-primary {
 
-     background-color: $white;
+      background-color: $white;
       border-radius: $border-radius;
+
       [class^='icon-'],
       [class*=' icon-'],
       [class^='#{$fa-css-prefix}-'],
       [class*=' #{$fa-css-prefix}-'],
       span {
-        color: var(--atum-link-color);
-        background-color: rgba(255, 255, 255, 0.90);
+        color: darken(theme-color('info'), 5%);
       }
 
       &:hover,
       &:active,
       &:focus {
 
+        background-color: theme-color('info');
+        color: rgba(255, 255, 255, 0.90);
+
         [class^='icon-'],
         [class*=' icon-'],
         [class^='#{$fa-css-prefix}-'],
         [class*=' #{$fa-css-prefix}-'],
         span {
-          background-color: var(--atum-link-color);
+          background: darken(theme-color('info'), 10%);
           color: rgba(255, 255, 255, 0.90);
         }
-
-        color:rgba(255, 255, 255, 0.90);
-        background-color: var(--atum-link-color);
       }
     }
 


### PR DESCRIPTION
Pull Request for Issue #28039 .

### Summary of Changes
Updated the css for btn-info (the blue button) so that it is duotone like the other toolbar buttons
Changed the themecolor:info to use the blue colour of the template and not cyan
minor code style changes according to code style rules


### Testing Instructions
npm i

check the toolbar buttons in any view eg articles

Screenshots show the normal and hover state
### before
![image](https://user-images.githubusercontent.com/1296369/75178335-d06b6500-572f-11ea-91dc-2d511a4e7cbf.png)



### after
![image](https://user-images.githubusercontent.com/1296369/75178131-65219300-572f-11ea-86a8-455ae3771515.png)



