### PR TITLE
[3] - JFormFieldPredefinedList fix if filter present

### DIFF
--- a/libraries/joomla/form/fields/predefinedlist.php
+++ b/libraries/joomla/form/fields/predefinedlist.php
@@ -77,7 +77,7 @@ abstract class JFormFieldPredefinedList extends JFormFieldList
 				
 				$val = (string) $value;
 	
-				if (empty($filter) || in_array($value, $filter, TRUE))
+				if (empty($filter) || in_array($value, $filter, true))
 				{
 					$text = $this->translate ? JText::_($text) : $text;
 

--- a/libraries/joomla/form/fields/predefinedlist.php
+++ b/libraries/joomla/form/fields/predefinedlist.php
@@ -74,7 +74,10 @@ abstract class JFormFieldPredefinedList extends JFormFieldList
 
 			foreach ($this->predefinedOptions as $value => $text)
 			{
-				if (empty($filter) || in_array($value, $filter))
+				
+				$val = (string) $value;
+	
+				if (empty($filter) || in_array($value, $filter, TRUE))
 				{
 					$text = $this->translate ? JText::_($text) : $text;
 

--- a/libraries/joomla/form/fields/predefinedlist.php
+++ b/libraries/joomla/form/fields/predefinedlist.php
@@ -74,7 +74,6 @@ abstract class JFormFieldPredefinedList extends JFormFieldList
 
 			foreach ($this->predefinedOptions as $value => $text)
 			{
-				
 				$val = (string) $value;
 	
 				if (empty($filter) || in_array($value, $filter, true))

--- a/libraries/joomla/form/fields/predefinedlist.php
+++ b/libraries/joomla/form/fields/predefinedlist.php
@@ -76,7 +76,7 @@ abstract class JFormFieldPredefinedList extends JFormFieldList
 			{
 				$val = (string) $value;
 	
-				if (empty($filter) || in_array($value, $filter, true))
+				if (empty($filter) || in_array($val, $filter, true))
 				{
 					$text = $this->translate ? JText::_($text) : $text;
 

--- a/libraries/src/Form/Field/StatusField.php
+++ b/libraries/src/Form/Field/StatusField.php
@@ -36,10 +36,10 @@ class StatusField extends \JFormFieldPredefinedList
 	 * @since  3.2
 	 */
 	protected $predefinedOptions = array(
-		'-2' =>	'JTRASHED',
-		'0'  => 'JUNPUBLISHED',
-		'1'  => 'JPUBLISHED',
-		'2'  => 'JARCHIVED',
+		-2   =>	'JTRASHED',
+		0    => 'JUNPUBLISHED',
+		1    => 'JPUBLISHED',
+		2    => 'JARCHIVED',
 		'*'  => 'JALL',
 	);
 }

--- a/libraries/src/Form/Field/StatusField.php
+++ b/libraries/src/Form/Field/StatusField.php
@@ -36,10 +36,10 @@ class StatusField extends \JFormFieldPredefinedList
 	 * @since  3.2
 	 */
 	protected $predefinedOptions = array(
-		-2   =>	'JTRASHED',
-		0    => 'JUNPUBLISHED',
-		1    => 'JPUBLISHED',
-		2    => 'JARCHIVED',
-		'*'  => 'JALL',
+		-2  => 'JTRASHED',
+		0   => 'JUNPUBLISHED',
+		1   => 'JPUBLISHED',
+		2   => 'JARCHIVED',
+		'*' => 'JALL',
 	);
 }


### PR DESCRIPTION
Pull Request for Issue #27889 .

### Summary of Changes
added strict comparison for let `in_array` do the correct work

### Testing Instructions
see #27889
or  change this line
https://github.com/joomla/joomla-cms/blob/fe798dd4bd2023047707053ae7a91a3ad5e9fa35/administrator/components/com_languages/models/forms/filter_languages.xml#L15

to something like 
` filter="1,-2,*" `
then go `administrator/index.php?option=com_languages&view=languages`

### Expected result
![Screenshot from 2020-02-24 21-11-05](https://user-images.githubusercontent.com/181681/75187374-37961300-574a-11ea-8e78-c26762e741af.png)

no more unpblished status "0" cause is not present in the filter



### Actual result

always the predefined option are showed


