### PR TITLE
[4.0] Add clickjacking protection frame-ancestors to the CSP tooling

### DIFF
--- a/administrator/components/com_csp/config.xml
+++ b/administrator/components/com_csp/config.xml
@@ -72,6 +72,18 @@
 			<option value="1">JENABLED</option>
 		</field>
 		<field
+			name="frame_ancestors_self_enabled"
+			type="radio"
+			label="COM_CSP_CONTENTSECURITYPOLICY_FRAME_ANCESTORS_SELF_ENABLED"
+			description="COM_CSP_CONTENTSECURITYPOLICY_FRAME_ANCESTORS_SELF_ENABLED_DESC"
+			layout="joomla.form.field.radio.switcher"
+			default="1"
+			showon="contentsecuritypolicy:1[AND]contentsecuritypolicy_mode!:detect"
+			>
+			<option value="0">JDISABLED</option>
+			<option value="1">JENABLED</option>
+		</field>
+		<field
 			name="contentsecuritypolicy_values"
 			type="subform"
 			label="COM_CSP_CONTENTSECURITYPOLICY_VALUES"

--- a/administrator/language/en-GB/com_csp.ini
+++ b/administrator/language/en-GB/com_csp.ini
@@ -8,6 +8,7 @@ COM_CSP_COLLECTING_TRASH_WARNING="The Content Security Policy is in detect mode.
 COM_CSP_CONFIGURATION="Content Security Policy: Options"
 ; Please do not translate the following language string
 COM_CSP_CONTENTSECURITYPOLICY="<a href='https://scotthelme.co.uk/content-security-policy-an-introduction' target='_blank' rel='noopener noreferrer'>Content Security Policy (CSP)</a>"
+; Please do not translate the following language string
 COM_CSP_CONTENTSECURITYPOLICY_FRAME_ANCESTORS_SELF_ENABLED="frame-ancestors 'self'"
 COM_CSP_CONTENTSECURITYPOLICY_FRAME_ANCESTORS_SELF_ENABLED_DESC="Enable the CSP clickjacking protection frame-ancestors and only allow the origin 'self'. Please use the form below to allow origins other than 'self'."
 COM_CSP_CONTENTSECURITYPOLICY_MODE="Mode"

--- a/administrator/language/en-GB/com_csp.ini
+++ b/administrator/language/en-GB/com_csp.ini
@@ -8,6 +8,8 @@ COM_CSP_COLLECTING_TRASH_WARNING="The Content Security Policy is in detect mode.
 COM_CSP_CONFIGURATION="Content Security Policy: Options"
 ; Please do not translate the following language string
 COM_CSP_CONTENTSECURITYPOLICY="<a href='https://scotthelme.co.uk/content-security-policy-an-introduction' target='_blank' rel='noopener noreferrer'>Content Security Policy (CSP)</a>"
+COM_CSP_CONTENTSECURITYPOLICY_FRAME_ANCESTORS_SELF_ENABLED="frame-ancestors 'self'"
+COM_CSP_CONTENTSECURITYPOLICY_FRAME_ANCESTORS_SELF_ENABLED_DESC="Enable the CSP clickjacking protection frame-ancestors and only allow the origin 'self'. Please use the form below to allow origins other than 'self'."
 COM_CSP_CONTENTSECURITYPOLICY_MODE="Mode"
 COM_CSP_CONTENTSECURITYPOLICY_MODE_AUTO="Automatic"
 COM_CSP_CONTENTSECURITYPOLICY_MODE_CUSTOM="Custom"

--- a/plugins/system/httpheaders/httpheaders.php
+++ b/plugins/system/httpheaders/httpheaders.php
@@ -397,7 +397,6 @@ class PlgSystemHttpHeaders extends CMSPlugin implements SubscriberInterface
 		// Add the frame-ancestors when not done already
 		if (!isset($cspHeaderCollection['frame-ancestors']) && $frameAncestorsSelfEnabled)
 		{
-			// Default value is set later
 			$cspHeaderCollection = array_merge($cspHeaderCollection, array_fill_keys(['frame-ancestors'], ''));
 		}
 

--- a/plugins/system/httpheaders/httpheaders.php
+++ b/plugins/system/httpheaders/httpheaders.php
@@ -394,6 +394,13 @@ class PlgSystemHttpHeaders extends CMSPlugin implements SubscriberInterface
 			$cspHeaderCollection[$row->directive] .= ' ' . $row->blocked_uri;
 		}
 
+		// Add the frame-ancestors when not done already
+		if (!isset($cspHeaderCollection['frame-ancestors']) && $frameAncestorsSelfEnabled)
+		{
+			// Default value is set later
+			$cspHeaderCollection = array_merge($cspHeaderCollection, array_fill_keys(['frame-ancestors'], ''));
+		}
+
 		// We should have a default-src, script-src and style-src rule
 		if (!empty($cspHeaderCollection))
 		{
@@ -411,13 +418,6 @@ class PlgSystemHttpHeaders extends CMSPlugin implements SubscriberInterface
 			{
 				$cspHeaderCollection = array_merge($cspHeaderCollection, array_fill_keys(['style-src'], ''));
 			}
-		}
-
-		// Add the frame-ancestors when not done already
-		if (!isset($cspHeaderCollection['frame-ancestors']) && $frameAncestorsSelfEnabled)
-		{
-			// Default value is set later
-			$cspHeaderCollection = array_merge($cspHeaderCollection, array_fill_keys(['frame-ancestors'], ''));
 		}
 
 		foreach ($cspHeaderCollection as $cspHeaderkey => $cspHeaderValue)

--- a/plugins/system/httpheaders/httpheaders.php
+++ b/plugins/system/httpheaders/httpheaders.php
@@ -276,10 +276,11 @@ class PlgSystemHttpHeaders extends CMSPlugin implements SubscriberInterface
 		}
 
 		// In custom mode we compile the header from the values configured
-		$cspValues           = $this->comCspParams->get('contentsecuritypolicy_values', []);
-		$nonceEnabled        = (int) $this->comCspParams->get('nonce_enabled', 0);
-		$scriptHashesEnabled = (int) $this->comCspParams->get('script_hashes_enabled', 0);
-		$styleHashesEnabled  = (int) $this->comCspParams->get('style_hashes_enabled', 0);
+		$cspValues                 = $this->comCspParams->get('contentsecuritypolicy_values', []);
+		$nonceEnabled              = (int) $this->comCspParams->get('nonce_enabled', 0);
+		$scriptHashesEnabled       = (int) $this->comCspParams->get('script_hashes_enabled', 0);
+		$styleHashesEnabled        = (int) $this->comCspParams->get('style_hashes_enabled', 0);
+		$frameAncestorsSelfEnabled = (int) $this->comCspParams->get('frame_ancestors_self_enabled', 1);
 
 		foreach ($cspValues as $cspValue)
 		{
@@ -311,6 +312,13 @@ class PlgSystemHttpHeaders extends CMSPlugin implements SubscriberInterface
 				}
 
 				$newCspValues[] = trim($cspValue->directive) . ' ' . trim($cspValue->value);
+
+				continue;
+			}
+
+			if ($frameAncestorsSelfEnabled)
+			{
+				$newCspValues[] = 'frame-ancestors "self"';
 			}
 		}
 
@@ -350,11 +358,12 @@ class PlgSystemHttpHeaders extends CMSPlugin implements SubscriberInterface
 			return [];
 		}
 
-		$automaticCspHeader  = [];
-		$cspHeaderCollection = [];
-		$nonceEnabled        = (int) $this->comCspParams->get('nonce_enabled', 0);
-		$scriptHashesEnabled = (int) $this->comCspParams->get('script_hashes_enabled', 0);
-		$styleHashesEnabled  = (int) $this->comCspParams->get('style_hashes_enabled', 0);
+		$automaticCspHeader        = [];
+		$cspHeaderCollection       = [];
+		$nonceEnabled              = (int) $this->comCspParams->get('nonce_enabled', 0);
+		$scriptHashesEnabled       = (int) $this->comCspParams->get('script_hashes_enabled', 0);
+		$styleHashesEnabled        = (int) $this->comCspParams->get('style_hashes_enabled', 0);
+		$frameAncestorsSelfEnabled = (int) $this->comCspParams->get('frame_ancestors_self_enabled', 1);
 
 		foreach ($rows as $row)
 		{
@@ -397,6 +406,12 @@ class PlgSystemHttpHeaders extends CMSPlugin implements SubscriberInterface
 			{
 				$cspHeaderCollection = array_merge($cspHeaderCollection, array_fill_keys(['style-src'], ''));
 			}
+		}
+
+		// Add the frame-ancestors when not done already
+		if (!isset($cspHeaderCollection['frame-ancestors']) && $frameAncestorsSelfEnabled)
+		{
+			$cspHeaderCollection = array_merge($cspHeaderCollection, array_fill_keys(['frame-ancestors'], '"self"'));
 		}
 
 		foreach ($cspHeaderCollection as $cspHeaderkey => $cspHeaderValue)


### PR DESCRIPTION
### Summary of Changes

Add clickjacking protection frame-ancestors to the CSP tooling. cc @SniperSister 

### Testing Instructions

- Apply this patch
- go to System -> Content Security Policy -> Options
- enable Content Security Policy
- enable report only mode
- enable the auto or custom mode of the csp.
- save.
- open the frontend
- check the browser console
- set an individual frame-ancestors directive. Example:
![image](https://user-images.githubusercontent.com/2596554/75194975-636cc500-5759-11ea-8c3a-2f8bbd46bb66.png)
- make sure only your directive is added to the header.

### Expected result

![image](https://user-images.githubusercontent.com/2596554/75194725-f8bb8980-5758-11ea-98f4-f57a5a2986e9.png)

### Actual result

you have to manually set the frame-ancestors

### Documentation Changes Required

This new option has to be documented here: https://docs.joomla.org/J4.x:Http_Header_Management. Will do this after the merge.