### PR TITLE
[4.0] Add Cross-Origin-Resource-Policy header to the core htaccess

### DIFF
--- a/htaccess.txt
+++ b/htaccess.txt
@@ -16,6 +16,10 @@
 # set it here.
 ##
 
+## Can be commented out if causes errors, see notes above.
+Options +FollowSymlinks
+Options -Indexes
+
 ## No directory listings
 <IfModule autoindex>
   IndexIgnore *
@@ -31,10 +35,6 @@ Header always set X-Content-Type-Options "nosniff"
 #<IfModule mod_headers.c>
 #Header always set Cross-Origin-Resource-Policy "same-origin"
 #</IfModule>
-
-## Can be commented out if causes errors, see notes above.
-Options +FollowSymlinks
-Options -Indexes
 
 ## These directives are only enabled if the Apache mod_rewrite module is enabled
 <IfModule mod_rewrite.c>

--- a/htaccess.txt
+++ b/htaccess.txt
@@ -26,7 +26,7 @@
 Header always set X-Content-Type-Options "nosniff"
 </IfModule>
 
-## Protect against certain cross-origin requests more information can be found here:
+## Protect against certain cross-origin requests. More information can be found here:
 ## https://developer.mozilla.org/en-US/docs/Web/HTTP/Cross-Origin_Resource_Policy_(CORP)
 #<IfModule mod_headers.c>
 #Header always set Cross-Origin-Resource-Policy "same-origin"

--- a/htaccess.txt
+++ b/htaccess.txt
@@ -26,7 +26,7 @@
 Header always set X-Content-Type-Options "nosniff"
 </IfModule>
 
-## Opt in to protect against certain cross-origin requests more information can be found here:
+## Protect against certain cross-origin requests more information can be found here:
 ## https://developer.mozilla.org/en-US/docs/Web/HTTP/Cross-Origin_Resource_Policy_(CORP)
 <IfModule mod_headers.c>
 Header always set Cross-Origin-Resource-Policy "same-origin"

--- a/htaccess.txt
+++ b/htaccess.txt
@@ -26,6 +26,12 @@
 Header always set X-Content-Type-Options "nosniff"
 </IfModule>
 
+## Opt in to protect against certain cross-origin requests more information can be found here:
+## https://developer.mozilla.org/en-US/docs/Web/HTTP/Cross-Origin_Resource_Policy_(CORP)
+<IfModule mod_headers.c>
+Header always set Cross-Origin-Resource-Policy "same-origin"
+</IfModule>
+
 ## Can be commented out if causes errors, see notes above.
 Options +FollowSymlinks
 Options -Indexes

--- a/htaccess.txt
+++ b/htaccess.txt
@@ -28,9 +28,9 @@ Header always set X-Content-Type-Options "nosniff"
 
 ## Protect against certain cross-origin requests more information can be found here:
 ## https://developer.mozilla.org/en-US/docs/Web/HTTP/Cross-Origin_Resource_Policy_(CORP)
-<IfModule mod_headers.c>
-Header always set Cross-Origin-Resource-Policy "same-origin"
-</IfModule>
+#<IfModule mod_headers.c>
+#Header always set Cross-Origin-Resource-Policy "same-origin"
+#</IfModule>
 
 ## Can be commented out if causes errors, see notes above.
 Options +FollowSymlinks

--- a/web.config.txt
+++ b/web.config.txt
@@ -29,6 +29,8 @@
        <httpProtocol>
            <customHeaders>
                <add name="X-Content-Type-Options" value="nosniff" />
+               <!-- Protect against certain cross-origin requests. More information can be found here: -->
+               <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/Cross-Origin_Resource_Policy_(CORP) -->
                <!-- <add name="Cross-Origin-Resource-Policy" value="same-origin" /> -->
            </customHeaders>
        </httpProtocol>

--- a/web.config.txt
+++ b/web.config.txt
@@ -29,6 +29,7 @@
        <httpProtocol>
            <customHeaders>
                <add name="X-Content-Type-Options" value="nosniff" />
+               <add name="Cross-Origin-Resource-Policy" value="same-origin" />
            </customHeaders>
        </httpProtocol>
    </system.webServer>

--- a/web.config.txt
+++ b/web.config.txt
@@ -29,7 +29,7 @@
        <httpProtocol>
            <customHeaders>
                <add name="X-Content-Type-Options" value="nosniff" />
-               <add name="Cross-Origin-Resource-Policy" value="same-origin" />
+               <!-- <add name="Cross-Origin-Resource-Policy" value="same-origin" /> -->
            </customHeaders>
        </httpProtocol>
    </system.webServer>


### PR DESCRIPTION
### Summary of Changes

Add Cross-Origin-Resource-Policy header to the core htaccess it protect against certain cross-origin requests. More information can be found here: https://developer.mozilla.org/en-US/docs/Web/HTTP/Cross-Origin_Resource_Policy_(CORP)

cc @SniperSister @mikewest 

### Testing Instructions

- Apply the header to your htaccess
- notice the header is set

### Expected result

The header is set

### Actual result

The header is not set