### PR TITLE
[4.0] Create alias for INT_ARRAY form filter

### DIFF
--- a/libraries/classmap.php
+++ b/libraries/classmap.php
@@ -498,3 +498,5 @@ JLoader::registerAlias('JStreamString',                     '\\Joomla\\CMS\\File
 JLoader::registerAlias('JStringController',                 '\\Joomla\\CMS\\Filesystem\\Support\\StringController', '5.0');
 
 JLoader::registerAlias('JClassLoader',                      '\\Joomla\\CMS\\Autoload\\ClassLoader', '5.0');
+
+JLoader::registerAlias('JFormFilterInt_Array', '\\Joomla\\CMS\\Form\\Filter\\IntarrayFilter', '5.0');

--- a/libraries/src/Form/Filter/IntarrayFilter.php
+++ b/libraries/src/Form/Filter/IntarrayFilter.php
@@ -39,6 +39,11 @@ class IntarrayFilter implements FormFilterInterface
 	 */
 	public function filter(\SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
 	{
+		if (strtoupper((string) $element['filter']) === 'INT_ARRAY')
+		{
+			@trigger_error('`INT_ARRAY` form filter is deprecated and will be removed in 5.0. Use `Intarray` instead', E_USER_DEPRECATED);
+		}
+
 		if (\is_object($value))
 		{
 			$value = get_object_vars($value);


### PR DESCRIPTION
### Summary of Changes

Adds `JFormFilterInt_Array` alias proxied to `Joomla\CMS\Form\Filter\IntarrayFilter` so forms using `INT_ARRAY` filter continue to be filtered properly.

### Testing Instructions

Create `Articles - Category` module.
In `Filtering Options` select some categories.
Save the module.
Go to your database and find the module in `#__modules` table.
In `params` column inspect `catid` value.

### Expected result

Values are stored as integers: `"catid":[8,9]`

### Actual result

Values are stored as strings `"catid":["8","9"]`

### Documentation Changes Required

IDK.