### PR TITLE
Only collect contacts when requested

### DIFF
--- a/components/com_contact/views/contact/view.html.php
+++ b/components/com_contact/views/contact/view.html.php
@@ -71,6 +71,7 @@ class ContactViewContact extends JViewLegacy
 
 		$item = $this->get('Item');
 		$state = $this->get('State');
+		$contacts = array();
 
 		// Get submitted values
 		$data = $app->getUserState('com_contact.contact.data', array());
@@ -112,7 +113,8 @@ class ContactViewContact extends JViewLegacy
 			$item->params = $temp;
 		}
 
-		if ($item)
+		// Collect extra contact information when this information is required
+		if ($item && $item->params->get('show_contact_list'))
 		{
 			// Get Category Model data
 			$categoryModel = JModelLegacy::getInstance('Category', 'ContactModel', array('ignore_request' => true));
@@ -122,11 +124,7 @@ class ContactViewContact extends JViewLegacy
 			$categoryModel->setState('list.direction', 'asc');
 			$categoryModel->setState('filter.published', 1);
 
-			// Only collect that information when this information is required
-			if ($item->params->get('show_contact_list'))
-			{
-				$contacts = $categoryModel->getItems();
-			}
+			$contacts = $categoryModel->getItems();
 		}
 
 		// Check for errors.

--- a/components/com_contact/views/contact/view.html.php
+++ b/components/com_contact/views/contact/view.html.php
@@ -122,7 +122,11 @@ class ContactViewContact extends JViewLegacy
 			$categoryModel->setState('list.direction', 'asc');
 			$categoryModel->setState('filter.published', 1);
 
-			$contacts = $categoryModel->getItems();
+			// Only collect that information when this information is required
+			if ($item->params->get('show_contact_list'))
+			{
+				$contacts = $categoryModel->getItems();
+			}
 		}
 
 		// Check for errors.


### PR DESCRIPTION
Pull Request for Issue #28074

### Summary of Changes

Only collect contacts when requested to avoid looking over all contacts

### Testing Instructions

- create more than one contact
- create a single contact menu item
- open the item
- apply this patch
- see the page again 
- enable the option "show_contact_list"
- make sure that still works

### Expected result

everything works than expected and no more longstanding 90% of the time useless loop over all contacts.

### Actual result

A long standing loop over all contacts even on the single contact page.

### Documentation Changes Required

None.