### PR TITLE
[4.0][Atum] Redundant CSS - '.login-bg-grad'

### DIFF
--- a/administrator/templates/atum/scss/blocks/_login.scss
+++ b/administrator/templates/atum/scss/blocks/_login.scss
@@ -21,16 +21,6 @@
     }
   }
 
-  .login-bg-grad {
-    position: fixed;
-    z-index: $zindex-negative;
-    width: 100vw;
-    height: 100vh;
-    background-image: linear-gradient(45deg,
-        rgba(var(--atum-bg-dark), .9) 30%,
-        rgba(color("atum-bg-light"), .2) 100%);
-  }
-
   .login-logo {
     width: 200px;
     margin: 0 auto 2rem;


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This appears to be redundant CSS. No sign of such a class in the login markup.

### Testing Instructions
Apply this patch and run `node build.js --compile-css` for updating the changed SCSS. Check login page displays correctly.