### PR TITLE
[4.0][Atum] Redundant CSS - '.login-box'

### DIFF
--- a/administrator/templates/atum/scss/blocks/_login.scss
+++ b/administrator/templates/atum/scss/blocks/_login.scss
@@ -83,15 +83,6 @@
     }
   }
 
-  .login-box {
-    background: var(--login-main-bg);
-    box-shadow: 0 0 20px var(--atum-bg-dark);
-
-    a {
-      color: $white;
-    }
-  }
-
   .form-group {
 
     label {


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This appears to be redundant CSS. No sign of such a class in the login markup.

### Testing Instructions
Apply this patch and run `node build.js --compile-css` for updating the changed SCSS. Check login page displays correctly.