### PR TITLE
[4.0] Update scss_lint to 0.59.0

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -4,6 +4,9 @@ scss:
   enabled: true
   config_file: scss-lint.yml
 
+scss-lint:
+  version: 0.59.0
+
 eslint:
   enabled: true
   config_file: .eslintrc

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'scss_lint', '~> 0.57.0'
+gem 'scss_lint', '~> 0.59.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,25 +1,25 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    ffi (1.9.25)
-    rake (12.3.1)
+    ffi (1.12.2)
+    ffi (1.12.2-x64-mingw32)
     rb-fsevent (0.10.3)
-    rb-inotify (0.9.10)
-      ffi (>= 0.5.0, < 2)
-    sass (3.5.7)
+    rb-inotify (0.10.1)
+      ffi (~> 1.0)
+    sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    scss_lint (0.57.0)
-      rake (>= 0.9, < 13)
-      sass (~> 3.5.5)
+    scss_lint (0.59.0)
+      sass (~> 3.5, >= 3.5.5)
 
 PLATFORMS
   ruby
+  x64-mingw32
 
 DEPENDENCIES
-  scss_lint (~> 0.57.0)
+  scss_lint (~> 0.59.0)
 
 BUNDLED WITH
-   1.16.4
+   1.17.2


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Updates scss_lint to 0.59.0.

Should resolve the CSS grid 'unknown' lint errors from hound and locally.

