### PR TITLE
[4.0] lint fractional units

### DIFF
--- a/scss-lint.yml
+++ b/scss-lint.yml
@@ -332,6 +332,7 @@ linters:
       'ch', 'em', 'ex', 'rem',                 # Font-relative lengths
       'cm', 'in', 'mm', 'pc', 'pt', 'px', 'q', # Absolute lengths
       'vh', 'vw', 'vmin', 'vmax',              # Viewport-percentage lengths
+      'fr',                                    # Grid fractional lengths
       'deg', 'grad', 'rad', 'turn',            # Angle
       'ms', 's',                               # Duration
       'Hz', 'kHz',                             # Frequency


### PR DESCRIPTION
Now that we finally have scss-lint running on this repo (after several years of it being ignored) #28076 has revealed several issues that are because of an outdated linter and rules

as of scss-lint 0.59 (there is a pr for this from @ciar4n ) support has been added to test for fractional units (the fr thing used in grids)

This PR adds the test for fr units to our scss lint rules

reference https://github.com/sds/scss-lint/blob/master/config/default.yml

### Testing Instructions
Code review
