### PR TITLE
[4.0] Cassiopeia Duplicate scss

### DIFF
--- a/templates/cassiopeia/scss/blocks/_css-grid.scss
+++ b/templates/cassiopeia/scss/blocks/_css-grid.scss
@@ -3,18 +3,17 @@
 @supports (display: grid) {
   .site-grid {
     display: grid;
-    grid-template-areas:
-      ". head head head head ."
-      ". banner banner banner banner ."
-      ". comp comp comp comp ."
-      ". side-l side-l side-l side-l ."
-      ". side-r side-r side-r side-r ."
-      ". top-a top-a top-a top-a ."
-      ". top-b top-b top-b top-b ."
-      ". bot-a bot-a bot-a bot-a ."
-      ". bot-b bot-b bot-b bot-b ."
-      ". footer footer footer footer ."
-      ". debug debug debug debug .";
+    grid-template-areas: ". head head head head ."
+    ". banner banner banner banner ."
+    ". top-a top-a top-a top-a ."
+    ". top-b top-b top-b top-b ."
+    ". comp comp comp comp ."
+    ". side-r side-r side-r side-r ."
+    ". side-l side-l side-l side-l ."
+    ". bot-a bot-a bot-a bot-a ."
+    ". bot-b bot-b bot-b bot-b ."
+    ". footer footer footer footer ."
+    ". debug debug debug debug .";
     grid-template-columns: [full-start] minmax(0, 1fr) [main-start] repeat(4, minmax(0, 270px)) [main-end] minmax(0, 1fr) [full-end];
     grid-gap: 0 $cassiopeia-grid-gutter;
 
@@ -47,18 +46,6 @@
     > .full-width {
       grid-column: full-start / full-end;
     }
-
-    grid-template-areas: ". head head head head ."
-    ". banner banner banner banner ."
-    ". top-a top-a top-a top-a ."
-    ". top-b top-b top-b top-b ."
-    ". comp comp comp comp ."
-    ". side-r side-r side-r side-r ."
-    ". side-l side-l side-l side-l ."
-    ". bot-a bot-a bot-a bot-a ."
-    ". bot-b bot-b bot-b bot-b ."
-    ". footer footer footer footer ."
-    ". debug debug debug debug .";
 
     @include media-breakpoint-up(md) {
       grid-template-areas:


### PR DESCRIPTION
Removes the duplicate grid-template-areas code as discussed in #28084

(Nice result from getting the lint working again)

codereview and lint test results