### PR TITLE
[4.0] Empty rule

### DIFF
--- a/administrator/templates/atum/scss/blocks/_sidebar.scss
+++ b/administrator/templates/atum/scss/blocks/_sidebar.scss
@@ -207,9 +207,6 @@
   // 1st level items
   > li {
 
-    > ul {
-     }
-
     > a {
       padding: 0 .35rem;
 


### PR DESCRIPTION
Removes an empty rule from the css.

CodeReview and lint results
