### PR TITLE
[4.0] Fix not set getListQuery in finder plugin

### DIFF
--- a/administrator/components/com_finder/src/Indexer/Adapter.php
+++ b/administrator/components/com_finder/src/Indexer/Adapter.php
@@ -583,6 +583,14 @@ abstract class Adapter extends CMSPlugin
 	 */
 	protected function getItems($offset, $limit, $query = null)
 	{
+		$query = $this->getListQuery($query);
+
+		// The query maybe empty if not set in the finder plugin.
+		if ((string) $query == '')
+		{
+			return [];
+		}
+
 		// Get the content items to index.
 		$this->db->setQuery($this->getListQuery($query)->setLimit($limit, $offset));
 		$items = $this->db->loadAssocList();

--- a/administrator/components/com_finder/src/Indexer/Adapter.php
+++ b/administrator/components/com_finder/src/Indexer/Adapter.php
@@ -592,7 +592,7 @@ abstract class Adapter extends CMSPlugin
 		}
 
 		// Get the content items to index.
-		$this->db->setQuery($this->getListQuery($query)->setLimit($limit, $offset));
+		$this->db->setQuery($query->setLimit($limit, $offset));
 		$items = $this->db->loadAssocList();
 
 		foreach ($items as &$item)


### PR DESCRIPTION
### Summary of Changes
The class: _administrator/components/com_finder/src/Indexer/Adapter.php_ 
is extended by the finder plugins. 

It contains the function: `getListQuery` which in most cases is overwritten by the finder plugins.
Though if it is not overwritten, an exception is thrown, since it executes an empty query, which in turn generates an sql error.

In that case the Indexer's index will never finish.

Do note that this function is not abstract, hence should work even if it is not declared in the plugins.
Also the finder plugins do not necessarily return items (e.g. onFinderIndexAfterPurge event).

### Testing Instructions
Remove the function: `getListQuery` from the file: **plugins/finder/content/content.php**

Then go to com_finder and press the "Index" btn
### Expected result
Index to finish

### Actual result
Will never finish

### Documentation Changes Required
No
