### PR TITLE
[4.0] Add space between Word in Menu Items

### DIFF
--- a/administrator/modules/mod_menu/tmpl/default_submenu.php
+++ b/administrator/modules/mod_menu/tmpl/default_submenu.php
@@ -107,7 +107,7 @@ if ($iconImage)
 	if (substr($iconImage, 0, 6) == 'class:' && substr($iconImage, 6) == 'icon-home')
 	{
 		$iconImage = '<span class="home-image fas fa-star" aria-hidden="true"></span>';
-		$iconImage .= '<span class="sr-only">' . Text::_('JDEFAULT') . '</span>';
+		$iconImage .= ' <span class="sr-only">' . Text::_('JDEFAULT') . '</span>';
 	}
 	elseif (substr($iconImage, 0, 6) == 'image:')
 	{
@@ -162,7 +162,7 @@ if ($currentParams->get('menu-quicktask') && (int) $this->params->get('shownew',
 	{
 		echo '<span class="menu-quicktask"><a href="' . $link . '">';
 		echo '<span class="fas fa-' . $icon . '" title="' . htmlentities(Text::_($title)) . '" aria-hidden="true"></span>';
-		echo '<span class="sr-only">' . Text::_($title) . '</span>';
+		echo ' <span class="sr-only">' . Text::_($title) . '</span>';
 		echo '</a></span>';
 	}
 }
@@ -173,7 +173,7 @@ if ($current->dashboard)
 	echo '<span class="menu-dashboard"><a href="'
 		. Route::_('index.php?option=com_cpanel&view=cpanel&dashboard=' . $current->dashboard) . '">'
 		. '<span class="fas fa-th-large" title="' . $titleDashboard . '" aria-hidden="true"></span>'
-		. '<span class="sr-only">' . $titleDashboard . '</span>'
+		. ' <span class="sr-only">' . $titleDashboard . '</span>'
 		. '</a></span>';
 }
 


### PR DESCRIPTION
### Summary of Changes
If you disable the styles in your browser you can see that we have menu items in the backend with words without a space between. This is not good when using the site with screen reader.

#### Before Patch
![6A66821C-6D28-41B0-B369-4A9349A0E460](https://user-images.githubusercontent.com/467356/75357549-d6894f00-58b1-11ea-8458-1c1e618217f3.png)

#### After Patch
![96F2488D-8992-4E72-9771-6D1A0BA535CB](https://user-images.githubusercontent.com/467356/75357556-d8eba900-58b1-11ea-8278-8f06e7d4bd57.png)

### Testing Instructions
* Disable Styles
* See that there is no space
* Apply Patch
* Disable Styles
* There are spaces now e.g. between "Content" and "Content Dashboard"

### Expected result
Spaces between words

### Actual result
No spaces between some words 

### Documentation Changes Required
no
