### PR TITLE
[4.0] joomla_update new window

### DIFF
--- a/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_reinstall.php
+++ b/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_reinstall.php
@@ -37,10 +37,9 @@ use Joomla\CMS\Updater\Update;
 					<?php echo Text::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_PACKAGE_REINSTALL'); ?>
 				</td>
 				<td>
-					<a href="<?php echo $this->updateInfo['object']->downloadurl->_data; ?>" target="_blank" rel="noopener noreferrer">
+					<a href="<?php echo $this->updateInfo['object']->downloadurl->_data; ?>" target="_blank" rel="noopener noreferrer"
+						title="<?php echo TEXT::sprintf('JBROWSERTARGET_NEW_TITLE', $this->updateInfo['object']->downloadurl->_data); ?>">
 						<?php echo $this->updateInfo['object']->downloadurl->_data; ?>
-						<span class="fas fa-external-link-alt" aria-hidden="true"></span>
-						<span class="sr-only"><?php echo Text::_('JBROWSERTARGET_NEW'); ?></span>
 					</a>
 				</td>
 			</tr>
@@ -51,10 +50,9 @@ use Joomla\CMS\Updater\Update;
 						<?php echo Text::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_INFOURL'); ?>
 					</td>
 					<td>
-						<a href="<?php echo $this->updateInfo['object']->get('infourl')->_data; ?>" target="_blank" rel="noopener noreferrer">
+						<a href="<?php echo $this->updateInfo['object']->get('infourl')->_data; ?>" target="_blank" rel="noopener noreferrer"
+							title="<?php echo TEXT::sprintf('JBROWSERTARGET_NEW_TITLE', $this->updateInfo['object']->get('infourl')->title); ?>">
 							<?php echo $this->updateInfo['object']->get('infourl')->title; ?>
-							<span class="fas fa-external-link-alt" aria-hidden="true"></span>
-							<span class="sr-only"><?php echo Text::_('JBROWSERTARGET_NEW'); ?></span>
 						</a>
 					</td>
 				</tr>

--- a/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_update.php
+++ b/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_update.php
@@ -45,10 +45,9 @@ use Joomla\CMS\Language\Text;
 					<?php echo Text::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_PACKAGE'); ?>
 				</td>
 				<td>
-					<a href="<?php echo $this->updateInfo['object']->downloadurl->_data; ?>" target="_blank" rel="noopener noreferrer">
+					<a href="<?php echo $this->updateInfo['object']->downloadurl->_data; ?>" target="_blank" rel="noopener noreferrer"
+						title="<?php echo TEXT::sprintf('JBROWSERTARGET_DOWNLOAD', $this->updateInfo['object']->downloadurl->_data); ?>">
 						<?php echo $this->updateInfo['object']->downloadurl->_data; ?>
-						<span class="fas fa-external-link-alt" aria-hidden="true"></span>
-						<span class="sr-only"><?php echo Text::_('JBROWSERTARGET_NEW'); ?></span>
 					</a>
 				</td>
 			</tr>
@@ -59,10 +58,9 @@ use Joomla\CMS\Language\Text;
 						<?php echo Text::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_INFOURL'); ?>
 					</td>
 					<td>
-						<a href="<?php echo $this->updateInfo['object']->get('infourl')->_data; ?>" target="_blank" rel="noopener noreferrer">
+						<a href="<?php echo $this->updateInfo['object']->get('infourl')->_data; ?>" target="_blank" rel="noopener noreferrer"
+							title="<?php echo TEXT::sprintf('JBROWSERTARGET_NEW_TITLE', $this->updateInfo['object']->get('infourl')->title); ?>">
 							<?php echo $this->updateInfo['object']->get('infourl')->title; ?>
-							<span class="fas fa-external-link-alt" aria-hidden="true"></span>
-							<span class="sr-only"><?php echo Text::_('JBROWSERTARGET_NEW'); ?></span>
 						</a>
 					</td>
 				</tr>

--- a/administrator/language/en-GB/joomla.ini
+++ b/administrator/language/en-GB/joomla.ini
@@ -159,6 +159,7 @@ JACTION_MANAGE="Access Administration Interface"
 JACTION_OPTIONS="Configure Options Only"
 JACTION_UNPUBLISH="Unpublish"
 
+JBROWSERTARGET_DOWNLOAD="Download %s in new window"
 JBROWSERTARGET_MODAL="Modal"
 JBROWSERTARGET_NEW="Open in new window"
 JBROWSERTARGET_NEW_TITLE="Open %s in new window"

--- a/api/language/en-GB/joomla.ini
+++ b/api/language/en-GB/joomla.ini
@@ -158,6 +158,7 @@ JACTION_MANAGE="Access Administration Interface"
 JACTION_OPTIONS="Configure Options Only"
 JACTION_UNPUBLISH="Unpublish"
 
+JBROWSERTARGET_DOWNLOAD="Download %s in new window"
 JBROWSERTARGET_MODAL="Modal"
 JBROWSERTARGET_NEW="Open in new window"
 JBROWSERTARGET_PARENT="Open in parent window"

--- a/language/en-GB/joomla.ini
+++ b/language/en-GB/joomla.ini
@@ -129,6 +129,7 @@ JVISIT_WEBSITE="Visit Website"
 JYEAR="Year"
 JYES="Yes"
 
+JBROWSERTARGET_DOWNLOAD="Download %s in new window"
 JBROWSERTARGET_MODAL="Modal"
 JBROWSERTARGET_NEW="Open in new window"
 JBROWSERTARGET_NEW_TITLE="Open %s in new window"


### PR DESCRIPTION
There are a million and one reasons why links should not open in a new window [link targets](https://adrianroselli.com/2020/02/link-targets-and-3-2-5.html)

> TL;DR: Regardless of what accessibility conformance level you target, do not arbitrarily open links in a new window or tab. If you are required to do so anyway, inform users in text.

We are currently visually indicating this but we are not indicating it to screen readers and here in joomla_update we indicated it visually twice.

![image](https://user-images.githubusercontent.com/1296369/75370252-b7dc8580-58bc-11ea-8125-a6c5e23c7ae6.png)


This PR changes that and will now add a "title=open LINKNAME in new window" to the web links and title =download LINKNAME in new window.


You might think that screen readers were intelligent enough to recognise a target=_blank and say something to the user but they don't [powermapper results](https://www.powermapper.com/tests/screen-readers/navigation/a-target-blank/)


