### PR TITLE
Don't filter form data on reload

### DIFF
--- a/libraries/src/MVC/Controller/FormController.php
+++ b/libraries/src/MVC/Controller/FormController.php
@@ -924,7 +924,7 @@ class FormController extends BaseController
 		}
 
 		// Save the data in the session.
-		$app->setUserState($this->option . '.edit.' . $this->context . '.data', $form->filter($data));
+		$app->setUserState($this->option . '.edit.' . $this->context . '.data', $data);
 
 		$this->setRedirect($redirectUrl);
 		$this->redirect();

--- a/libraries/src/MVC/Controller/FormController.php
+++ b/libraries/src/MVC/Controller/FormController.php
@@ -911,18 +911,6 @@ class FormController extends BaseController
 			false
 		);
 
-		// Validate the posted data.
-		// Sometimes the form needs some posted data, such as for plugins and modules.
-		$form = $model->getForm($data, false);
-
-		if (!$form)
-		{
-			$app->enqueueMessage($model->getError(), 'error');
-
-			$this->setRedirect($redirectUrl);
-			$this->redirect();
-		}
-
 		// Save the data in the session.
 		$app->setUserState($this->option . '.edit.' . $this->context . '.data', $data);
 


### PR DESCRIPTION
Pull Request for Issue #27919.

### Summary of Changes

`Joomla\CMS\MVC\Controller\FormController::reload()` method filters form data before storing it to user state. This is different from behavior in `save()` method where we store unfiltered data. Filtering data at this point causes some issues, e.g. form values disappearing if `unset` filter is used.

This removes filtering.

### Testing Instructions

Create two or more categories.
Create a custom field for articles.
Edit an article.
Change its category.
After page is reloaded, check `Hits` and `Revision` fields.

### Expected result

Values are present.

### Actual result

Values are missing.

### Documentation Changes Required

IDK.