### PR TITLE
Use unset filter for hits field

### DIFF
--- a/administrator/components/com_categories/models/forms/category.xml
+++ b/administrator/components/com_categories/models/forms/category.xml
@@ -19,6 +19,7 @@
 		default="0"
 		class="readonly"
 		readonly="true"
+		filter="unset"
 	/>
 
 	<field

--- a/administrator/components/com_tags/models/forms/tag.xml
+++ b/administrator/components/com_tags/models/forms/tag.xml
@@ -18,6 +18,7 @@
 		class="readonly"
 		default="0"
 		readonly="true"
+		filter="unset"
 	/>
 
 	<field


### PR DESCRIPTION
### Summary of Changes

Adds `unset` filter to hits field where missing to prevent editing the value.

### Testing Instructions
1)
Edit a tag in backend. Memorize number of hits. Keep the form open.
In a different tab view the tag in frontend. Refresh the page a few times.
Save the backend form. Inspect the number of hits.

2) Test that creating and editing categories still works.

### Expected result

1) Number of hits was increased by viewing tag in frontend.
2) Works like before.

### Actual result

1) Number of hits is the same as when the tag form was first opened.

### Documentation Changes Required

No.