### PR TITLE
[4.0] Remove deprecated int_array form filter uses

### DIFF
--- a/administrator/components/com_content/tmpl/articles/default.xml
+++ b/administrator/components/com_content/tmpl/articles/default.xml
@@ -45,7 +45,7 @@
 				multiple="true"
 				layout="joomla.form.field.list-fancy-select"
 				class="multipleAuthors"
-				filter="int_array"
+				filter="intarray"
 				>
 				<option value="0">JNONE</option>
 			</field>
@@ -56,7 +56,7 @@
 				label="COM_MENUS_ADMIN_TAGS_LABEL"
 				description="COM_MENUS_ADMIN_TAGS_DESC"
 				multiple="true"
-				filter="int_array"
+				filter="intarray"
 				mode="nested"
 			/>
 
@@ -67,7 +67,7 @@
 				description="COM_MENUS_ADMIN_ACCESS_DESC"
 				multiple="true"
 				layout="joomla.form.field.list-fancy-select"
-				filter="int_array"
+				filter="intarray"
 			/>
 
 			<field

--- a/administrator/components/com_users/forms/level.xml
+++ b/administrator/components/com_users/forms/level.xml
@@ -28,7 +28,7 @@
 		<field
 			name="rules"
 			type="hidden"
-			filter="int_array"
+			filter="intarray"
 		/>
 	</fieldset>
 </form>

--- a/modules/mod_articles_category/mod_articles_category.xml
+++ b/modules/mod_articles_category/mod_articles_category.xml
@@ -99,7 +99,7 @@
 					extension="com_content"
 					multiple="true"
 					layout="joomla.form.field.list-fancy-select"
-					filter="int_array"
+					filter="intarray"
 					class="multipleCategories"
 				/>
 
@@ -136,7 +136,7 @@
 					label="JTAG"
 					mode="nested"
 					multiple="true"
-					filter="int_array"
+					filter="intarray"
 					class="multipleTags"
 				/>
 
@@ -164,7 +164,7 @@
 					label="MOD_ARTICLES_CATEGORY_FIELD_AUTHOR_LABEL"
 					multiple="true"
 					layout="joomla.form.field.list-fancy-select"
-					filter="int_array"
+					filter="intarray"
 					class="multipleAuthors"
 				/>
 

--- a/modules/mod_articles_latest/mod_articles_latest.xml
+++ b/modules/mod_articles_latest/mod_articles_latest.xml
@@ -30,7 +30,7 @@
 					extension="com_content"
 					multiple="true"
 					layout="joomla.form.field.list-fancy-select"
-					filter="int_array"
+					filter="intarray"
 				/>
 
 				<field

--- a/modules/mod_articles_news/mod_articles_news.xml
+++ b/modules/mod_articles_news/mod_articles_news.xml
@@ -29,7 +29,7 @@
 					label="JCATEGORY"
 					extension="com_content"
 					multiple="true"
-					filter="int_array"
+					filter="intarray"
 					class="multipleCategories"
 					layout="joomla.form.field.list-fancy-select"
 				/>
@@ -40,7 +40,7 @@
 					label="JTAG"
 					mode="nested"
 					multiple="true"
-					filter="int_array"
+					filter="intarray"
 					class="multipleTags"
 				/>
 

--- a/modules/mod_articles_popular/mod_articles_popular.xml
+++ b/modules/mod_articles_popular/mod_articles_popular.xml
@@ -29,7 +29,7 @@
 					label="JCATEGORY"
 					extension="com_content"
 					multiple="true"
-					filter="int_array"
+					filter="intarray"
 				/>
 
 				<field

--- a/modules/mod_banners/mod_banners.xml
+++ b/modules/mod_banners/mod_banners.xml
@@ -63,7 +63,7 @@
 					label="JCATEGORY"
 					extension="com_banners"
 					multiple="true"
-					filter="int_array"
+					filter="intarray"
 					class="multipleCategories"
 					layout="joomla.form.field.list-fancy-select"
 				/>

--- a/modules/mod_tags_popular/mod_tags_popular.xml
+++ b/modules/mod_tags_popular/mod_tags_popular.xml
@@ -29,7 +29,7 @@
 					label="MOD_TAGS_POPULAR_PARENT_TAG_LABEL"
 					description="MOD_TAGS_POPULAR_PARENT_TAG_DESC"
 					multiple="true"
-					filter="int_array"
+					filter="intarray"
 					mode="nested"
 				/>
 

--- a/plugins/system/cache/cache.xml
+++ b/plugins/system/cache/cache.xml
@@ -36,7 +36,7 @@
 					type="menuitem"
 					label="PLG_CACHE_FIELD_EXCLUDE_MENU_ITEMS_LABEL"
 					multiple="multiple"
-					filter="int_array"
+					filter="intarray"
 				/>
 
 			</fieldset>

--- a/plugins/system/debug/debug.xml
+++ b/plugins/system/debug/debug.xml
@@ -40,7 +40,7 @@
 					label="PLG_DEBUG_FIELD_ALLOWED_GROUPS_LABEL"
 					multiple="true"
 					layout="joomla.form.field.accesslevel-fancy-select"
-					filter="int_array"
+					filter="intarray"
 				/>
 
 				<field


### PR DESCRIPTION
Followup to https://github.com/joomla/joomla-cms/pull/28072.

### Summary of Changes

Replaces uses of deprecated `int_array` form filter.

### Testing Instructions

Code review.

### Documentation Changes Required

No.