### PR TITLE
[4.0] Removing eslint from hound and adding to drone CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -65,6 +65,12 @@ steps:
       branch:
       - 4.0-dev
 
+  - name: eslint
+    image: node:current-alpine
+    depends_on: [ npm ]
+    commands:
+      - ./node_modules/.bin/eslint -c .eslintrc --ignore-path .eslintignore **/*.js
+
   - name: rebuild-cache
     image: drillster/drone-volume-cache
     depends_on: [ npm ]
@@ -308,6 +314,6 @@ services:
 
 ---
 kind: signature
-hmac: 6e49e42776ccca0ae4ccfef5ec153134f8d97d069983715e2a3cea327f8f5398
+hmac: e05a8b303777b35f7b113bc66185ae69b9182952a0c1f0d0ad0306ee2f44f914
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -69,7 +69,7 @@ steps:
     image: node:current-alpine
     depends_on: [ npm ]
     commands:
-      - ./node_modules/.bin/eslint -c .eslintrc --ignore-path .eslintignore **/*.js
+      - ./node_modules/.bin/eslint -c .eslintrc --ignore-path .eslintignore "**/*.js"
 
   - name: rebuild-cache
     image: drillster/drone-volume-cache
@@ -314,6 +314,6 @@ services:
 
 ---
 kind: signature
-hmac: e05a8b303777b35f7b113bc66185ae69b9182952a0c1f0d0ad0306ee2f44f914
+hmac: 8267577b8d55e4af5986fdf9dee3d0b2ecdd20b8709b9c817755799470615c96
 
 ...

--- a/.hound.yml
+++ b/.hound.yml
@@ -8,9 +8,7 @@ scss-lint:
   version: 0.59.0
 
 eslint:
-  enabled: true
-  config_file: .eslintrc
-  ignore_file: .eslintignore
+  enabled: false
 
 # Disable hound default linters
 jshint:


### PR DESCRIPTION
Pull Request for Issue #28100.

### Summary of Changes
This moves eslint from hound to drone CI, thus using the eslint from our package.json.