### PR TITLE
[4.0] joomlaupdate accessible progress

### DIFF
--- a/administrator/components/com_joomlaupdate/tmpl/update/default.php
+++ b/administrator/components/com_joomlaupdate/tmpl/update/default.php
@@ -48,7 +48,7 @@ $this->document->addScriptOptions(
 		</div>
 		<div class="extprogrow">
 			<span class="extlabel"><?php echo Text::_('COM_JOOMLAUPDATE_VIEW_UPDATE_PERCENT'); ?></span>
-			<span class="extvalue" id="extpercent"></span>
+			<span class="extvalue" id="extpercent" aria-live="polite"></span>
 		</div>
 		<div class="extprogrow">
 			<span class="extlabel"><?php echo Text::_('COM_JOOMLAUPDATE_VIEW_UPDATE_BYTESREAD'); ?></span>


### PR DESCRIPTION
When you are doing an update or reload etc of joomla you will see a progress bar and then a progress list, % complete, bytes extracted etc.

This PR adds aria-live to the value of %complete so that every time the value updates it is announced to users of screen readers.

It deliberately does not announce the bytes extracted etc as that would be information overload.

To test apply the pr, then do an update. When the update starts and you see the % complete change view the source for that and you will see it has "aria-live=polite" OR test with a screen reader and you will hear 5%, 6% etc

Note - obviously after the update the changes in this PR will be lost and you will need to apply them again if you want to test for a secnd time.