### PR TITLE
[4.0][Atum] Redundant CSS - '.logo.small'

### DIFF
--- a/administrator/templates/atum/scss/blocks/_header.scss
+++ b/administrator/templates/atum/scss/blocks/_header.scss
@@ -34,28 +34,6 @@
     line-height: $header-height;
     transition: width .3s ease;
 
-    &.small {
-      width: $sidebar-width-closed;
-      transition: width .3s ease;
-
-      svg,
-      img {
-
-        &:not(.logo-small) {
-          display: none;
-        }
-
-        &.logo-small {
-          display: inline-block;
-        }
-
-        path {
-          fill: $white;
-        }
-
-      }
-    }
-
     svg,
     img {
       max-width: calc(18rem - .8rem);
@@ -70,6 +48,7 @@
 
     svg {
       height: 1.3rem;
+
       path {
         fill: $white;
       }


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This appears to be redundant CSS. I can find nowhere that a `.small` class is added to the logo.

### Testing Instructions
Apply this patch and run `node build.js --compile-css` for updating the changed SCSS. Check logo is displaying correctly