### PR TITLE
[4.0] Fix undefined variable notice

### DIFF
--- a/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_upload.php
+++ b/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_upload.php
@@ -33,7 +33,7 @@ Text::script('JGLOBAL_SELECTED_UPLOAD_FILE_SIZE', true);
 			<h4 class="alert-heading">
 				<span class="fas fa-exclamation-triangle" aria-hidden="true"></span>
 				<span class="sr-only"><?php echo Text::_('WARNING'); ?></span>
-				<?php echo $message['message']; ?>
+				<?php echo $warning['message']; ?>
 			</h4>
 			<p class="mb-0"><?php echo $warning['description']; ?></p>
 		</div>


### PR DESCRIPTION
Fixes https://github.com/joomla/joomla-cms/issues/28111.

### Summary of Changes

Fixes undefined variable notice.

### Testing Instructions

Set your `upload_max_filesize` and/or `post_max_size` to under 8MB.
Go to Joomla! Update -> Upload & Update.

### Expected result

No PHP notices.

### Actual result

>Notice: Undefined variable: message in administrator\components\com_joomlaupdate\tmpl\joomlaupdate\default_upload.php on line 36

### Documentation Changes Required

No.