### PR TITLE
Update Appveyor to test against PHP 7.4

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,6 +30,10 @@ environment:
   - php_ver_target: 7.3
   - php_ver_target: 7.4
 
+matrix:
+  allow_failures:
+  - php_ver_target: 7.4
+
 init:
   - SET PATH=C:\Program Files\OpenSSL;C:\tools\php;%PATH%
   - SET COMPOSER_NO_INTERACTION=1

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,7 +9,7 @@ branches:
 
 ## Build matrix for lowest and highest possible targets
 environment:
-  DLLVersion: "5.6.1"
+  DLLVersion: "5.8.0"
   PHPBuild: "x64"
   VC: "vc15"
   matrix:
@@ -28,6 +28,7 @@ environment:
   - php_ver_target: 7.2
     DLLVersion: "5.3.0"
   - php_ver_target: 7.3
+  - php_ver_target: 7.4
 
 init:
   - SET PATH=C:\Program Files\OpenSSL;C:\tools\php;%PATH%


### PR DESCRIPTION
Updates the SQLSrv extension to 5.8.0 which also supports PHP 7.4 https://pecl.php.net/package/sqlsrv/5.8.0

See appveyor tests pass on new version to test