### PR TITLE
[4.0] Left-aligned Hide all messages button

### DIFF
--- a/administrator/components/com_postinstall/src/View/Messages/HtmlView.php
+++ b/administrator/components/com_postinstall/src/View/Messages/HtmlView.php
@@ -67,16 +67,16 @@ class HtmlView extends BaseHtmlView
 	 */
 	private function toolbar()
 	{
+		if (!empty($this->items))
+		{
+			ToolbarHelper::custom('message.hideAll', 'unpublish.png', 'unpublish_f2.png', 'COM_POSTINSTALL_HIDE_ALL_MESSAGES', false);
+		}
+
 		// Options button.
 		if (Factory::getUser()->authorise('core.admin', 'com_postinstall'))
 		{
 			ToolbarHelper::preferences('com_postinstall', 550, 875);
 			ToolbarHelper::help('JHELP_COMPONENTS_POST_INSTALLATION_MESSAGES');
-		}
-
-		if (!empty($this->items))
-		{
-			ToolbarHelper::custom('message.hideAll', 'unpublish.png', 'unpublish_f2.png', 'COM_POSTINSTALL_HIDE_ALL_MESSAGES', false);
 		}
 	}
 }


### PR DESCRIPTION
### Summary of Changes
Move `Hide all messages` button left-aligned.


### Testing Instructions
Click Post Installation Messages icon
`Hide all messages` button is right-aligned after the `Help` button


