### PR TITLE
[4.0] fix warning 1280 for mysql/mariadb

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/4.0.0-2018-07-29.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.0.0-2018-07-29.sql
@@ -51,7 +51,7 @@ CREATE TABLE IF NOT EXISTS `#__finder_logging` (
   `query` BLOB NOT NULL,
   `hits` INT(11) NOT NULL DEFAULT 1,
   `results` INT(11) NOT NULL DEFAULT 0,
-  PRIMARY KEY `md5sum` (`md5sum`),
+  PRIMARY KEY (`md5sum`),
   INDEX `searchterm` (`searchterm`(191))
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_general_ci;
 

--- a/administrator/components/com_finder/sql/install.mysql.sql
+++ b/administrator/components/com_finder/sql/install.mysql.sql
@@ -77,7 +77,7 @@ CREATE TABLE IF NOT EXISTS `#__finder_logging` (
   `query` BLOB NOT NULL,
   `hits` INT(11) NOT NULL DEFAULT 1,
   `results` INT(11) NOT NULL DEFAULT 0,
-  PRIMARY KEY `md5sum` (`md5sum`),
+  PRIMARY KEY (`md5sum`),
   INDEX `searchterm` (`searchterm`(191))
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_general_ci;
 

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -914,7 +914,7 @@ CREATE TABLE IF NOT EXISTS `#__finder_logging` (
   `query` BLOB NOT NULL,
   `hits` INT(11) NOT NULL DEFAULT 1,
   `results` INT(11) NOT NULL DEFAULT 0,
-  PRIMARY KEY `md5sum` (`md5sum`),
+  PRIMARY KEY (`md5sum`),
   INDEX `searchterm` (`searchterm`(191))
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_general_ci;
 


### PR DESCRIPTION
Pull Request for Issue #28125 .

### Summary of Changes
fixed warning 1280 cause
there is no [symbol] after PRIMARY KEY.

### Testing Instructions
install joomla and look for warnings
and run `SHOW WARNINGS;`
code review

### Expected result
no warnings


### Actual result
Warning: #1280 Name 'md5sum' ignored for PRIMARY key.



