### PR TITLE
[4.0] Fixing badge display and default home menu item star alignment

### DIFF
--- a/administrator/templates/atum/scss/blocks/_sidebar.scss
+++ b/administrator/templates/atum/scss/blocks/_sidebar.scss
@@ -144,7 +144,7 @@
         > .fas {
           display: flex;
           align-items: center;
-          padding: 1rem;
+          padding: .9rem;
           margin: 0;
         }
 
@@ -361,7 +361,11 @@
   }
 
   .home-image {
-    padding: .8rem 0 !important;
+    padding: 0;
+
+    &.fa-star {
+      padding: .8rem 0;
+    }
   }
 
   .mm-collapse {

--- a/administrator/templates/atum/scss/blocks/_sidebar.scss
+++ b/administrator/templates/atum/scss/blocks/_sidebar.scss
@@ -183,7 +183,7 @@
   }
 
   span.fas {
-    padding: 1rem 0;
+    padding: 0.9rem 0;
   }
 
   .sidebar-item-title {
@@ -361,7 +361,7 @@
   }
 
   .home-image {
-    padding: .7rem .4rem;
+    padding: .8rem 0 !important;
   }
 
   .mm-collapse {
@@ -442,7 +442,7 @@
 
   .badge {
     align-self: center;
-    margin: 0 4px;
+    margin: 0 .3rem .25rem;
   }
 }
 

--- a/administrator/templates/atum/scss/pages/_com_cpanel.scss
+++ b/administrator/templates/atum/scss/pages/_com_cpanel.scss
@@ -182,6 +182,19 @@
     }
   }
 
+  .list-group-item a > span.home-image.fas {
+    display: inline;
+    padding: 0;
+    font-size: .9rem;
+    color: rgba(1, 1, 1, 1);
+    background: var(--white-offset);
+    box-shadow: none;
+
+    &:hover {
+      background: var(--atum-link-hover-color);
+    }
+  }
+
   h2 {
     font-size: $h4-font-size;
   }

--- a/administrator/templates/atum/scss/vendor/bootstrap/_badge.scss
+++ b/administrator/templates/atum/scss/vendor/bootstrap/_badge.scss
@@ -4,7 +4,7 @@
 .badge {
   padding: .1rem .3rem;
   font-size: $badge-font-size;
-  border-radius: 0;
+  border-radius: .2rem;
 
   @include media-breakpoint-down(xs) {
     white-space: normal;


### PR DESCRIPTION
### Summary of Changes
Correcting home menu items badges by rounding them and star display.


### Testing Instructions
Install a multilingual site.
Display the sidebar menu.
Display the Menus Dashboard
Open com_associations, and look at the language badges


### Before patch
com_associations

<img width="526" alt="Screen Shot 2020-02-27 at 11 04 52_before" src="https://user-images.githubusercontent.com/869724/75603328-8d154b80-5acd-11ea-9aba-9e76547fe663.png">

Sidebar menu

<img width="283" alt="Screen Shot 2020-02-29 at 08 34 13" src="https://user-images.githubusercontent.com/869724/75603417-555ad380-5ace-11ea-854f-8f0935fb17e2.png">

Menus Dashboard

<img width="692" alt="Screen Shot 2020-02-29 at 08 35 33" src="https://user-images.githubusercontent.com/869724/75603435-7e7b6400-5ace-11ea-8218-2d65cc75ad33.png">




### After patch
com_associations

<img width="677" alt="Screen Shot 2020-02-27 at 11 04 23" src="https://user-images.githubusercontent.com/869724/75603341-a8805680-5acd-11ea-9ab9-0018e9f7b28e.png">

Sidebar menu

<img width="468" alt="home after" src="https://user-images.githubusercontent.com/869724/75603443-9fdc5000-5ace-11ea-8df7-57865a3dd4f8.png">

Menus  Dashboard
<img width="706" alt="Screen Shot 2020-02-29 at 08 40 31" src="https://user-images.githubusercontent.com/869724/75603506-3f99de00-5acf-11ea-92af-61b4e0c8bb34.png">



