### PR TITLE
[4.0] RTL: fix searchtools rounded styling

### DIFF
--- a/administrator/templates/atum/scss/template-rtl.scss
+++ b/administrator/templates/atum/scss/template-rtl.scss
@@ -267,10 +267,8 @@ body {
 .input-group > .input-group-append:not(:last-child) > .input-group-text,
 .input-group > .input-group-append:last-child > .btn:not(:last-child):not(.dropdown-toggle),
 .input-group > .input-group-append:last-child > .input-group-text:not(:last-child) {
-  border-top-left-radius: .25rem;
-  border-bottom-left-radius: .25rem;
-  border-top-right-radius: 0;
-  border-bottom-right-radius: 0;
+  @include border-left-radius($border-radius);
+  @include border-right-radius(0);
 }
 
 .input-group > .input-group-append > .btn,
@@ -279,32 +277,24 @@ body {
 .input-group > .input-group-prepend:not(:first-child) > .input-group-text,
 .input-group > .input-group-prepend:first-child > .btn:not(:first-child),
 .input-group > .input-group-prepend:first-child > .input-group-text:not(:first-child) {
-  border-top-left-radius: .25rem;
-  border-bottom-left-radius: .25rem;
-  border-top-right-radius: 0;
-  border-bottom-right-radius: 0;
+  @include border-left-radius($border-radius);
+  @include border-right-radius(0);
 }
 
 .input-group > .form-control:not(:last-child),
 .input-group > .custom-select:not(:last-child) {
-  border-top-left-radius: 0;
-  border-bottom-left-radius: 0;
-  border-top-right-radius: .25rem;
-  border-bottom-right-radius: .25rem;
+  @include border-left-radius(0);
+  @include border-right-radius($border-radius);
 }
 
 .btn-group > .btn:not(:last-child):not(.dropdown-toggle),
 .btn-group > .btn-group:not(:last-child) > .btn {
-  border-top-left-radius: 0;
-  border-bottom-left-radius: 0;
-  border-top-right-radius: .25rem;
-  border-bottom-right-radius: .25rem;
+  @include border-left-radius(0);
+  @include border-right-radius($border-radius);
 }
 
 .btn-group > .btn:not(:first-child),
 .btn-group > .btn-group:not(:first-child) {
-  border-top-left-radius: .25rem;
-  border-bottom-left-radius: .25rem;
-  border-top-right-radius: 0;
-  border-bottom-right-radius: 0;
+  @include border-left-radius($border-radius);
+  @include border-right-radius(0);
 }

--- a/administrator/templates/atum/scss/template-rtl.scss
+++ b/administrator/templates/atum/scss/template-rtl.scss
@@ -259,3 +259,52 @@ body {
   text-align: right;
   direction: ltr;
 }
+
+// SearchTools rounded corners
+.input-group > .input-group-prepend > .btn,
+.input-group > .input-group-prepend > .input-group-text,
+.input-group > .input-group-append:not(:last-child) > .btn,
+.input-group > .input-group-append:not(:last-child) > .input-group-text,
+.input-group > .input-group-append:last-child > .btn:not(:last-child):not(.dropdown-toggle),
+.input-group > .input-group-append:last-child > .input-group-text:not(:last-child) {
+  border-top-left-radius: .25rem;
+  border-bottom-left-radius: .25rem;
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.input-group > .input-group-append > .btn,
+.input-group > .input-group-append > .input-group-text,
+.input-group > .input-group-prepend:not(:first-child) > .btn,
+.input-group > .input-group-prepend:not(:first-child) > .input-group-text,
+.input-group > .input-group-prepend:first-child > .btn:not(:first-child),
+.input-group > .input-group-prepend:first-child > .input-group-text:not(:first-child) {
+  border-top-left-radius: .25rem;
+  border-bottom-left-radius: .25rem;
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.input-group > .form-control:not(:last-child),
+.input-group > .custom-select:not(:last-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  border-top-right-radius: .25rem;
+  border-bottom-right-radius: .25rem;
+}
+
+.btn-group > .btn:not(:last-child):not(.dropdown-toggle),
+.btn-group > .btn-group:not(:last-child) > .btn {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  border-top-right-radius: .25rem;
+  border-bottom-right-radius: .25rem;
+}
+
+.btn-group > .btn:not(:first-child),
+.btn-group > .btn-group:not(:first-child) {
+  border-top-left-radius: .25rem;
+  border-bottom-left-radius: .25rem;
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/pull/28048#issuecomment-592930436

### Summary of Changes
Creating rtl bootstrap overrides in template-rtl.scss


### Testing Instructions
Install Persian language. 
Select Persian for back-end.
Display Articles Manager


### Before patch
<img width="921" alt="Screen Shot 2020-02-29 at 18 56 11" src="https://user-images.githubusercontent.com/869724/75612628-b82b8980-5b25-11ea-9ec5-2ae7059cc718.png">



### After patch
<img width="932" alt="Screen Shot 2020-02-29 at 18 54 56" src="https://user-images.githubusercontent.com/869724/75612631-bcf03d80-5b25-11ea-8a4d-a7cde74cb59d.png">



### Documentation Changes Required

