### PR TITLE
[4.0] searchtools focus

### DIFF
--- a/administrator/templates/atum/scss/system/searchtools/searchtools.scss
+++ b/administrator/templates/atum/scss/system/searchtools/searchtools.scss
@@ -55,6 +55,11 @@
     joomla-field-fancy-select .choices,
     .custom-select {
       min-width: 15rem;
+
+      &.is-focused {
+        border-color: $focuscolor;
+        box-shadow: $focusshadow;
+      }
     }
 
     .chzn-container-single {

--- a/administrator/templates/atum/scss/system/searchtools/searchtools.scss
+++ b/administrator/templates/atum/scss/system/searchtools/searchtools.scss
@@ -88,6 +88,11 @@
         }
       }
 
+      &:focus {
+        border-color: $focuscolor;
+        box-shadow: $focusshadow;
+      }
+
       option {
         font-size: .875rem;
         color: var(--atum-text-dark);


### PR DESCRIPTION
Adds the focus shadow to the searchtools filters

~NOTE: this doesn't add focus shadow to the choices based selects (I tried and failed so someone else can do that ion another PR)~

Requires node build-js compile-css

## after PR 
Focus on first field
![image](https://user-images.githubusercontent.com/1296369/75612687-dd1bfe80-5b1d-11ea-878e-a831a7c9c8f5.png)
