### PR TITLE
[4.0] Searchtools ordering select

### DIFF
--- a/administrator/templates/atum/scss/system/searchtools/searchtools.scss
+++ b/administrator/templates/atum/scss/system/searchtools/searchtools.scss
@@ -271,7 +271,12 @@
     }
 
     .js-stools-field-list {
+      margin-right: .25rem;
       margin-bottom: 0;
+
+      &:last-child {
+        margin-right:0;
+      }
     }
 
     .input-append {

--- a/administrator/templates/atum/scss/system/searchtools/searchtools.scss
+++ b/administrator/templates/atum/scss/system/searchtools/searchtools.scss
@@ -271,11 +271,22 @@
     }
 
     .js-stools-field-list {
-      margin-right: .25rem;
       margin-bottom: 0;
 
-      &:last-child {
-        margin-right: 0;
+      [dir=ltr] & {
+        margin-right: .25rem;
+
+        &:last-child {
+          margin-right: 0;
+        }
+      }
+
+      [dir=rtl] & {
+        margin-left: .25rem;
+
+        &:last-child {
+          margin-left: 0;
+        }
       }
     }
 

--- a/administrator/templates/atum/scss/system/searchtools/searchtools.scss
+++ b/administrator/templates/atum/scss/system/searchtools/searchtools.scss
@@ -275,7 +275,7 @@
       margin-bottom: 0;
 
       &:last-child {
-        margin-right:0;
+        margin-right: 0;
       }
     }
 


### PR DESCRIPTION
Simple PR to adjust the gap between the ordering select and the quantity so that it is the same as the gap between search and clear etc

This is a css change so needs node build.js --compile-css

### before
![image](https://user-images.githubusercontent.com/1296369/75617344-bf6a8b80-5b55-11ea-9eab-9e9cf46f89b8.png)

### after
![image](https://user-images.githubusercontent.com/1296369/75617335-b4aff680-5b55-11ea-98c7-dfd9c8c31b33.png)
