### PR TITLE
[4.0] Remove cross-env dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
     "postinstall": "node build.js --compile-js && node build.js --compile-css && npm run build:com_media",
     "update": "node build.js --copy-assets && node build.js --build-pages && node build.js --compile-js && node build.js --compile-css",
     "gzip": "node -e 'require(\"./build/build-modules-js/gzip-assets.es6.js\").gzipFiles()'",
-    "watch:com_media": "cross-env NODE_ENV=development webpack --progress --hide-modules --watch",
-    "dev:com_media": "cross-env NODE_ENV=development webpack --progress --hide-modules",
-    "build:com_media": "cross-env NODE_ENV=production webpack --progress --hide-modules"
+    "watch:com_media": "webpack --progress --hide-modules --watch --development",
+    "dev:com_media": "webpack --progress --hide-modules --development",
+    "build:com_media": "webpack --progress --hide-modules --production"
   },
   "browserslist": [
     "last 1 version",
@@ -75,7 +75,6 @@
     "browserify": "^16.5.0",
     "commander": "^2.20.3",
     "copy-dir": "^0.4.0",
-    "cross-env": "^3.0.0",
     "css-loader": "^3.0.0",
     "cssnano": "^4.1.10",
     "eslint": "^5.15.3",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,7 +5,7 @@ const VueLoaderPlugin = require('vue-loader/lib/plugin');
 const environment = process.argv.includes('--development') ? 'development' : 'production';
 
 module.exports = {
-    mode: nvironment === 'production' ? 'production' : 'none',
+    mode: environment === 'production' ? 'production' : 'none',
     entry: [
         './administrator/components/com_media/resources/scripts/mediamanager.js',
         './administrator/components/com_media/resources/styles/mediamanager.scss',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,7 +5,7 @@ const VueLoaderPlugin = require('vue-loader/lib/plugin');
 const environment = process.argv.includes('--development') ? 'development' : 'production';
 
 module.exports = {
-    mode: environment,
+    mode: nvironment === 'production' ? 'production' : 'none',
     entry: [
         './administrator/components/com_media/resources/scripts/mediamanager.js',
         './administrator/components/com_media/resources/styles/mediamanager.scss',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,9 +2,10 @@ const path = require('path');
 const webpack = require('webpack');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const VueLoaderPlugin = require('vue-loader/lib/plugin');
+const environment = process.argv.includes('--development') ? 'development' : 'production';
 
 module.exports = {
-    mode: process.env.NODE_ENV,
+    mode: environment,
     entry: [
         './administrator/components/com_media/resources/scripts/mediamanager.js',
         './administrator/components/com_media/resources/styles/mediamanager.scss',
@@ -61,11 +62,8 @@ module.exports = {
         new MiniCssExtractPlugin({
             filename: './../css/mediamanager.min.css',
         }),
-        new webpack.DefinePlugin({
-            'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV)
-        }),
         new webpack.LoaderOptionsPlugin({
-            minimize: process.env.NODE_ENV === 'production'
+            minimize: environment === 'production'
         }),
         new VueLoaderPlugin()
     ],
@@ -77,5 +75,5 @@ module.exports = {
     performance: {
         hints: false
     },
-    devtool: process.env.NODE_ENV === 'production' ? 'source-map' : 'eval-source-map'
+    devtool: environment === 'production' ? 'source-map' : 'eval-source-map'
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,7 +5,7 @@ const VueLoaderPlugin = require('vue-loader/lib/plugin');
 const environment = process.argv.includes('--development') ? 'development' : 'production';
 
 module.exports = {
-    mode: environment === 'production' ? 'production' : 'none',
+    mode: environment === 'production' ? 'production' : 'development',
     entry: [
         './administrator/components/com_media/resources/scripts/mediamanager.js',
         './administrator/components/com_media/resources/styles/mediamanager.scss',


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

NPM scripts support arguments, so can can simply use `--development` and `--production` for the Media Manager tasks, so there's no need for the `cross-env` dependency

### Testing Instructions

1. Run `npm run build:com_media` and ensure you get a minified JS file
1. Run `npm run dev:com_media` and ensure you an uncompressed JS file

### Expected result

Same as before
