### PR TITLE
[4.0] wrong icon

### DIFF
--- a/build/media_source/system/scss/_icomoon.scss
+++ b/build/media_source/system/scss/_icomoon.scss
@@ -235,7 +235,7 @@
 
 .icon-edit::before,
 .icon-pencil::before {
-  @extend .#{$fa-css-prefix}-pen-square:before;
+  @extend .#{$fa-css-prefix}-edit:before;
 }
 
 .icon-pencil-2::before {


### PR DESCRIPTION
Instead of pencil square the icon should be edit 

Requires npm i or node build.js --compile-css

### Before
![before](https://user-images.githubusercontent.com/1296369/75625193-9aa50100-5bb3-11ea-9d91-8c6e93b0cb39.gif)

### After
![after](https://user-images.githubusercontent.com/1296369/75625195-9f69b500-5bb3-11ea-97b9-8da037494216.gif)
