### PR TITLE
[4.0] Remove the min attribute from the com csp csp values xml

### DIFF
--- a/administrator/components/com_csp/config.xml
+++ b/administrator/components/com_csp/config.xml
@@ -76,7 +76,6 @@
 			type="subform"
 			label="COM_CSP_CONTENTSECURITYPOLICY_VALUES"
 			multiple="true"
-			min="1"
 			showon="contentsecuritypolicy:1[AND]contentsecuritypolicy_mode:custom"
 			>
 			<form>


### PR DESCRIPTION
Pull Request for Issue partial #28171 

### Summary of Changes

Remove the min attribute from the com csp csp values xml

### Testing Instructions

Go to System > Manage > Content Security Policy > Options
set the CSP Mode to custom
add directive below
add 2nd directive
try delete all directives...

### Expected result

all directives are deleted

### Actual result

Actual result: I can delete all, until one directive (first) still remain. I can't delete it.

### Documentation Changes Required

none