### PR TITLE
[4.0] Discover Language

### DIFF
--- a/libraries/src/Installer/Adapter/LanguageAdapter.php
+++ b/libraries/src/Installer/Adapter/LanguageAdapter.php
@@ -783,20 +783,29 @@ class LanguageAdapter extends InstallerAdapter
 
 			foreach ($languages as $language)
 			{
-				if (file_exists($basePath . '/language/' . $language . '/' . $language . '.xml'))
+				$manifestfile = $basePath . '/language/' . $language . '/langmetadata.xml';
+
+				if (!is_file($manifestfile))
 				{
-					$manifest_details = Installer::parseXMLInstallFile($basePath . '/language/' . $language . '/' . $language . '.xml');
-					$extension = Table::getInstance('extension');
-					$extension->set('type', 'language');
-					$extension->set('client_id', $clientId);
-					$extension->set('element', $language);
-					$extension->set('folder', '');
-					$extension->set('name', $language);
-					$extension->set('state', -1);
-					$extension->set('manifest_cache', json_encode($manifest_details));
-					$extension->set('params', '{}');
-					$results[] = $extension;
+					$manifestfile = $basePath . '/language/' . $language . '/' . $language . '.xml';
+
+					if (!is_file($manifestfile))
+					{
+						continue;
+					}
 				}
+
+				$manifest_details = Installer::parseXMLInstallFile($manifestfile);
+				$extension = Table::getInstance('extension');
+				$extension->set('type', 'language');
+				$extension->set('client_id', $clientId);
+				$extension->set('element', $language);
+				$extension->set('folder', '');
+				$extension->set('name', $language);
+				$extension->set('state', -1);
+				$extension->set('manifest_cache', json_encode($manifest_details));
+				$extension->set('params', '{}');
+				$results[] = $extension;
 			}
 		}
 
@@ -816,7 +825,13 @@ class LanguageAdapter extends InstallerAdapter
 		// Need to find to find where the XML file is since we don't store this normally
 		$client                 = ApplicationHelper::getClientInfo($this->parent->extension->client_id);
 		$short_element          = $this->parent->extension->element;
-		$manifestPath           = $client->path . '/language/' . $short_element . '/' . $short_element . '.xml';
+		$manifestPath           = $client->path . '/language/' . $short_element . '/langmetadata.xml';
+
+		if (!is_file($manifestPath))
+		{
+			$manifestPath = $client->path . '/language/' . $short_element . '/' . $short_element . '.xml';
+		}
+
 		$this->parent->manifest = $this->parent->isManifest($manifestPath);
 		$this->parent->setPath('manifest', $manifestPath);
 		$this->parent->setPath('source', $client->path . '/language/' . $short_element);


### PR DESCRIPTION
When I wrote https://github.com/joomla/joomla-cms/pull/19353, I apparently forgot to take care of the discovering path.

### Summary of Changes
This PR adds support for the new `langmetadata.xml` to the discovering methods so an already present language may be discovered and installed.


### Testing Instructions
Install a language which doesn't use the prefixes anymore. For that you have to manually fetch the language pack from Crowdin. A good language to test is usually Dutch (https://crowdin.com/backend/download/project/joomla-cms/nl.zip) or Danish (https://crowdin.com/backend/download/project/joomla-cms/da.zip) as they are usually 100% translated and approved (or close to). You can try to install the downloaded zip directly. If it fails, you need to extract the zip and only zip the 4.0-dev folder again. Then use that zipped 4.0-dev file.

After that, you need to delete the entries in the database table `#__extensions` for that language

Then go to the discover extension view and check if the language appears.

### Expected result
Language appears twice, once for Site and for Admin.
Language can be installed.


### Actual result
Language doesn't appear.


### Documentation Changes Required
None
