### PR TITLE
[4.0] Improve cache check

### DIFF
--- a/libraries/cms/html/uitab.php
+++ b/libraries/cms/html/uitab.php
@@ -84,7 +84,7 @@ abstract class JHtmlUiTab
 	 */
 	public static function addTab($selector, $id, $title)
 	{
-		$active = (static::$loaded['JHtmlUiTab::startTabSet'][$selector]['active'] == $id) ? ' active' : '';
+		$active = (static::$loaded[__CLASS__ . '::startTabSet'][$selector]['active'] == $id) ? ' active' : '';
 
 		return '<section id="' . $id . '"' . $active . ' name="' . htmlspecialchars($title, ENT_COMPAT, 'UTF-8') . '">';
 


### PR DESCRIPTION
### Summary of Changes
Fixes the cache check to always use the active class in PHP instead of a hardcoded value. We set the value using the `__METHOD__` value two lines above but then hardcode the check here. This makes the class "dynamic" as per best practice in anticipation of namespacing at a soon to be point in time.

### Testing Instructions
Code review

### Documentation Changes Required
N/A
