### PR TITLE
[3.10] Fix Discover Language for non-prefixed packs

### DIFF
--- a/libraries/src/Installer/Adapter/LanguageAdapter.php
+++ b/libraries/src/Installer/Adapter/LanguageAdapter.php
@@ -754,9 +754,18 @@ class LanguageAdapter extends InstallerAdapter
 
 		foreach ($site_languages as $language)
 		{
-			if (file_exists(JPATH_SITE . '/language/' . $language . '/' . $language . '.xml'))
+			$manifestfile = JPATH_SITE . '/language/' . $language . '/langmetadata.xml';
+
+			if (!is_file($manifestfile))
 			{
-				$manifest_details = Installer::parseXMLInstallFile(JPATH_SITE . '/language/' . $language . '/' . $language . '.xml');
+				$manifestfile = JPATH_SITE . '/language/' . $language . '/' . $language . '.xml';
+
+				if (!is_file($manifestfile))
+				{
+					continue;
+				}
+
+				$manifest_details = Installer::parseXMLInstallFile($manifestfile);
 				$extension = Table::getInstance('extension');
 				$extension->set('type', 'language');
 				$extension->set('client_id', 0);
@@ -772,9 +781,18 @@ class LanguageAdapter extends InstallerAdapter
 
 		foreach ($admin_languages as $language)
 		{
-			if (file_exists(JPATH_ADMINISTRATOR . '/language/' . $language . '/' . $language . '.xml'))
+			$manifestfile = JPATH_ADMINISTRATOR . '/language/' . $language . '/langmetadata.xml';
+
+			if (!is_file($manifestfile))
 			{
-				$manifest_details = Installer::parseXMLInstallFile(JPATH_ADMINISTRATOR . '/language/' . $language . '/' . $language . '.xml');
+				$manifestfile = JPATH_ADMINISTRATOR . '/language/' . $language . '/' . $language . '.xml';
+
+				if (!is_file($manifestfile))
+				{
+					continue;
+				}
+
+				$manifest_details = Installer::parseXMLInstallFile($manifestfile);
 				$extension = Table::getInstance('extension');
 				$extension->set('type', 'language');
 				$extension->set('client_id', 1);
@@ -804,7 +822,13 @@ class LanguageAdapter extends InstallerAdapter
 		// Need to find to find where the XML file is since we don't store this normally
 		$client = ApplicationHelper::getClientInfo($this->parent->extension->client_id);
 		$short_element = $this->parent->extension->element;
-		$manifestPath = $client->path . '/language/' . $short_element . '/' . $short_element . '.xml';
+		$manifestPath = $client->path . '/language/' . $short_element . '/langmetadata.xml';
+
+		if (!is_file($manifestPath))
+		{
+			$manifestPath = $client->path . '/language/' . $short_element . '/' . $short_element . '.xml';
+		}
+
 		$this->parent->manifest = $this->parent->isManifest($manifestPath);
 		$this->parent->setPath('manifest', $manifestPath);
 		$this->parent->setPath('source', $client->path . '/language/' . $short_element);

--- a/libraries/src/Installer/Adapter/LanguageAdapter.php
+++ b/libraries/src/Installer/Adapter/LanguageAdapter.php
@@ -764,19 +764,19 @@ class LanguageAdapter extends InstallerAdapter
 				{
 					continue;
 				}
-
-				$manifest_details = Installer::parseXMLInstallFile($manifestfile);
-				$extension = Table::getInstance('extension');
-				$extension->set('type', 'language');
-				$extension->set('client_id', 0);
-				$extension->set('element', $language);
-				$extension->set('folder', '');
-				$extension->set('name', $language);
-				$extension->set('state', -1);
-				$extension->set('manifest_cache', json_encode($manifest_details));
-				$extension->set('params', '{}');
-				$results[] = $extension;
 			}
+
+			$manifest_details = Installer::parseXMLInstallFile($manifestfile);
+			$extension = Table::getInstance('extension');
+			$extension->set('type', 'language');
+			$extension->set('client_id', 0);
+			$extension->set('element', $language);
+			$extension->set('folder', '');
+			$extension->set('name', $language);
+			$extension->set('state', -1);
+			$extension->set('manifest_cache', json_encode($manifest_details));
+			$extension->set('params', '{}');
+			$results[] = $extension;
 		}
 
 		foreach ($admin_languages as $language)
@@ -791,19 +791,19 @@ class LanguageAdapter extends InstallerAdapter
 				{
 					continue;
 				}
-
-				$manifest_details = Installer::parseXMLInstallFile($manifestfile);
-				$extension = Table::getInstance('extension');
-				$extension->set('type', 'language');
-				$extension->set('client_id', 1);
-				$extension->set('element', $language);
-				$extension->set('folder', '');
-				$extension->set('name', $language);
-				$extension->set('state', -1);
-				$extension->set('manifest_cache', json_encode($manifest_details));
-				$extension->set('params', '{}');
-				$results[] = $extension;
 			}
+
+			$manifest_details = Installer::parseXMLInstallFile($manifestfile);
+			$extension = Table::getInstance('extension');
+			$extension->set('type', 'language');
+			$extension->set('client_id', 1);
+			$extension->set('element', $language);
+			$extension->set('folder', '');
+			$extension->set('name', $language);
+			$extension->set('state', -1);
+			$extension->set('manifest_cache', json_encode($manifest_details));
+			$extension->set('params', '{}');
+			$results[] = $extension;
 		}
 
 		return $results;


### PR DESCRIPTION
This backports https://github.com/joomla/joomla-cms/pull/28178 to 3.10

### Summary of Changes
This PR adds support for the new langmetadata.xml to the discovering methods so an already present language may be discovered and installed.



### Testing Instructions
Install a language which doesn't use the prefixes anymore (unlikely to find currently) or adjust an existing one by renaming the metadata file (eg en-GB.xml) to the new name langmetadata.xml

After that, you need to delete the entries in the database table #__extensions for that language

Then go to the discover extension view and check if the language appears.

### Expected result
Language appears twice, once for Site and for Admin.
Language can be installed.


### Actual result
Language doesn't appear.


### Documentation Changes Required
None
