### PR TITLE
[3.10] Namespace JAdapter

### DIFF
--- a/libraries/classmap.php
+++ b/libraries/classmap.php
@@ -435,3 +435,6 @@ JLoader::registerAlias('JStringController',                 '\\Joomla\\CMS\\File
 JLoader::registerAlias('JFilesystemWrapperFile',            '\\Joomla\\CMS\\Filesystem\\Wrapper\\FileWrapper', '5.0');
 JLoader::registerAlias('JFilesystemWrapperFolder',          '\\Joomla\\CMS\\Filesystem\\Wrapper\\FolderWrapper', '5.0');
 JLoader::registerAlias('JFilesystemWrapperPath',            '\\Joomla\\CMS\\Filesystem\\Wrapper\\PathWrapper', '5.0');
+
+JLoader::registerAlias('JAdapter',                          '\\Joomla\\CMS\\Adapter\\Adapter', '5.0');
+JLoader::registerAlias('JAdapterInstance',                  '\\Joomla\\CMS\\Adapter\\AdapterInstance', '5.0');

--- a/libraries/src/Adapter/Adapter.php
+++ b/libraries/src/Adapter/Adapter.php
@@ -1,13 +1,16 @@
 <?php
 /**
- * @package     Joomla.Platform
- * @subpackage  Base
+ * Joomla! Content Management System
  *
- * @copyright   Copyright (C) 2005 - 2020 Open Source Matters, Inc. All rights reserved.
- * @license     GNU General Public License version 2 or later; see LICENSE
+ * @copyright  Copyright (C) 2005 - 2020 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
 
+namespace Joomla\CMS\Adapter;
+
 defined('JPATH_PLATFORM') or die;
+
+use Joomla\CMS\Object\CMSObject;
 
 /**
  * Adapter Class
@@ -17,12 +20,12 @@ defined('JPATH_PLATFORM') or die;
  * @since       1.6
  * @deprecated  5.0 Will be removed without replacement
  */
-class JAdapter extends JObject
+class Adapter extends CMSObject
 {
 	/**
 	 * Associative array of adapters
 	 *
-	 * @var    JAdapterInstance[]
+	 * @var    static[]
 	 * @since  1.6
 	 */
 	protected $_adapters = array();
@@ -54,7 +57,7 @@ class JAdapter extends JObject
 	/**
 	 * Database Connector Object
 	 *
-	 * @var    JDatabaseDriver
+	 * @var    \JDatabaseDriver
 	 * @since  1.6
 	 */
 	protected $_db;
@@ -74,13 +77,13 @@ class JAdapter extends JObject
 		$this->_classprefix = $classprefix ? $classprefix : 'J';
 		$this->_adapterfolder = $adapterfolder ? $adapterfolder : 'adapters';
 
-		$this->_db = JFactory::getDbo();
+		$this->_db = \JFactory::getDbo();
 	}
 
 	/**
 	 * Get the database connector object
 	 *
-	 * @return  JDatabaseDriver  Database connector object
+	 * @return  \JDatabaseDriver  Database connector object
 	 *
 	 * @since   1.6
 	 */
@@ -95,7 +98,7 @@ class JAdapter extends JObject
 	 * @param   string  $name     Name of adapter to return
 	 * @param   array   $options  Adapter options
 	 *
-	 * @return  JAdapterInstance|boolean  Adapter of type 'name' or false
+	 * @return  static|boolean  Adapter of type 'name' or false
 	 *
 	 * @since   1.6
 	 */
@@ -162,7 +165,7 @@ class JAdapter extends JObject
 		// Try to load the adapter object
 		$class = $this->_classprefix . ucfirst($name);
 
-		JLoader::register($class, $fullpath);
+		\JLoader::register($class, $fullpath);
 
 		if (!class_exists($class))
 		{
@@ -185,9 +188,9 @@ class JAdapter extends JObject
 	 */
 	public function loadAllAdapters($options = array())
 	{
-		$files = new DirectoryIterator($this->_basepath . '/' . $this->_adapterfolder);
+		$files = new \DirectoryIterator($this->_basepath . '/' . $this->_adapterfolder);
 
-		/* @type  $file  DirectoryIterator */
+		/* @type  $file  \DirectoryIterator */
 		foreach ($files as $file)
 		{
 			$fileName = $file->getFilename();

--- a/libraries/src/Adapter/AdapterInstance.php
+++ b/libraries/src/Adapter/AdapterInstance.php
@@ -1,13 +1,16 @@
 <?php
 /**
- * @package     Joomla.Platform
- * @subpackage  Base
+ * Joomla! Content Management System
  *
- * @copyright   Copyright (C) 2005 - 2020 Open Source Matters, Inc. All rights reserved.
- * @license     GNU General Public License version 2 or later; see LICENSE
+ * @copyright  Copyright (C) 2005 - 2020 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
 
+namespace Joomla\CMS\Adapter;
+
 defined('JPATH_PLATFORM') or die;
+
+use Joomla\CMS\Object\CMSObject;
 
 /**
  * Adapter Instance Class
@@ -15,12 +18,12 @@ defined('JPATH_PLATFORM') or die;
  * @since       1.6
  * @deprecated  5.0 Will be removed without replacement
  */
-class JAdapterInstance extends JObject
+class AdapterInstance extends CMSObject
 {
 	/**
 	 * Parent
 	 *
-	 * @var    JAdapter
+	 * @var    Adapter
 	 * @since  1.6
 	 */
 	protected $parent = null;
@@ -28,7 +31,7 @@ class JAdapterInstance extends JObject
 	/**
 	 * Database
 	 *
-	 * @var    JDatabaseDriver
+	 * @var    \JDatabaseDriver
 	 * @since  1.6
 	 */
 	protected $db = null;
@@ -36,13 +39,13 @@ class JAdapterInstance extends JObject
 	/**
 	 * Constructor
 	 *
-	 * @param   JAdapter         $parent   Parent object
-	 * @param   JDatabaseDriver  $db       Database object
-	 * @param   array            $options  Configuration Options
+	 * @param   Adapter           $parent   Parent object
+	 * @param   \JDatabaseDriver  $db       Database object
+	 * @param   array             $options  Configuration Options
 	 *
 	 * @since   1.6
 	 */
-	public function __construct(JAdapter $parent, JDatabaseDriver $db, array $options = array())
+	public function __construct(Adapter $parent, \JDatabaseDriver $db, array $options = array())
 	{
 		// Set the properties from the options array that is passed in
 		$this->setProperties($options);
@@ -51,13 +54,13 @@ class JAdapterInstance extends JObject
 		$this->parent = $parent;
 
 		// Pull in the global dbo in case something happened to it.
-		$this->db = $db ?: JFactory::getDbo();
+		$this->db = $db ?: \JFactory::getDbo();
 	}
 
 	/**
 	 * Retrieves the parent object
 	 *
-	 * @return  JAdapter
+	 * @return  Adapter
 	 *
 	 * @since   1.6
 	 */


### PR DESCRIPTION
### Summary of Changes
Namespaces the JAdapter classes for 3.10-dev (which will then be ported to 4.0-dev)


### Testing Instructions
Ensure functionality using these classes (the ability to install/uninstall/discover install extensions) continues to work the same as before.

### Expected result
Everything still works

### Documentation Changes Required
None
