### PR TITLE
[4.0] Striped tables

### DIFF
--- a/administrator/components/com_actionlogs/tmpl/actionlogs/default.php
+++ b/administrator/components/com_actionlogs/tmpl/actionlogs/default.php
@@ -34,7 +34,7 @@ HTMLHelper::_('script', 'com_actionlogs/admin-actionlogs-default.js', ['relative
 				<?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
 			</div>
 		<?php else : ?>
-			<table class="table table-striped" id="logsList">
+			<table class="table" id="logsList">
 				<caption id="captionTable" class="sr-only">
 					<?php echo Text::_('COM_ACTIONLOGS_TABLE_CAPTION'); ?>, <?php echo Text::_('JGLOBAL_SORTED_BY'); ?>
 				</caption>

--- a/administrator/components/com_privacy/tmpl/request/default.php
+++ b/administrator/components/com_privacy/tmpl/request/default.php
@@ -52,7 +52,7 @@ HTMLHelper::_('behavior.keepalive');
 							<?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
 						</div>
 					<?php else : ?>
-						<table class="table table-striped table-hover">
+						<table class="table">
 							<thead>
 								<th>
 									<?php echo Text::_('COM_ACTIONLOGS_ACTION'); ?>


### PR DESCRIPTION
We dont use striped stables anymore in Joomla 4

This PR removes the striped class from  Privacy->Requests and the privacy action log that you can access by clicking on the email address of a privacy request
