### PR TITLE
[4.0]Update sites missing string

### DIFF
--- a/administrator/components/com_installer/forms/filter_updatesites.xml
+++ b/administrator/components/com_installer/forms/filter_updatesites.xml
@@ -12,6 +12,7 @@
 		<field
 			name="enabled"
 			type="list"
+			label="JOPTION_SELECT_PUBLISHED"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_PUBLISHED</option>


### PR DESCRIPTION
There was no label on the first filter for select state

To test view source on the select state selector and see that the label is not "enabled" or code review
