### PR TITLE
[4.0]com_finder index missing string

### DIFF
--- a/administrator/components/com_finder/forms/filter_index.xml
+++ b/administrator/components/com_finder/forms/filter_index.xml
@@ -41,6 +41,7 @@
 		<field
 			name="language"
 			type="contentlanguage"
+			label="JOPTION_SELECT_LANGUAGE"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_LANGUAGE</option>


### PR DESCRIPTION
There was no label on the language filter

To test view source on the language and see that the label is not "language" or code review
