### PR TITLE
[4.0] [com_users] Set layout only when on Profile menu item

### DIFF
--- a/components/com_users/src/View/Profile/HtmlView.php
+++ b/components/com_users/src/View/Profile/HtmlView.php
@@ -152,12 +152,13 @@ class HtmlView extends BaseHtmlView
 		Factory::getApplication()->triggerEvent('onContentPrepare', array ('com_users.user', &$this->data, &$this->data->params, 0));
 		unset($this->data->text);
 
-		// Check for layout override
-		$active = Factory::getApplication()->getMenu()->getActive();
+		// Check for layout from menu item.
+		$query = Factory::getApplication()->getMenu()->getActive()->query;
 
-		if (isset($active->query['layout']))
+		if (isset($query['layout']) && isset($query['option']) && $query['option'] === 'com_users'
+			&& isset($query['view']) && $query['view'] === 'profile')
 		{
-			$this->setLayout($active->query['layout']);
+			$this->setLayout($query['layout']);
 		}
 
 		// Escape strings for HTML output


### PR DESCRIPTION
### Summary of Changes

Fixes incorrect layout being used when trying to edit profile in some cases.

Couple of things that might need to be discussed. This was done with assumptions that:

1.  Routing changes in 4.0 are correct and the active menu item must always be set.

2. We don't want users changing the layout via input.

If both assumptions are wrong we can remove this code from the view and let the controller handle it.

### Testing Instructions

Create `Articles - Category Blog` menu item. Set it as Home page.
Enable `System - Privacy Consent` plugin.
Log in to frontend.

### Expected result

Redirected to user profile form.

### Actual result

Redirected to profile page. Clicking `Edit Profile` leaves us on the same page.

### Documentation Changes Required

No.