### PR TITLE
[4.0] main menu icon size

### DIFF
--- a/administrator/templates/atum/scss/blocks/_sidebar.scss
+++ b/administrator/templates/atum/scss/blocks/_sidebar.scss
@@ -183,7 +183,8 @@
   }
 
   span.fas {
-    padding: 0.9rem 0;
+    padding: .9rem 0;
+    transform: scale(1.3);
   }
 
   .sidebar-item-title {
@@ -462,11 +463,6 @@
 
 // Sidebar Closed
 .closed {
-
-  .main-nav span.fas {
-    transform: scale(1.3);
-
-  }
 
   .sidebar-wrapper {
     flex: 1 0 $sidebar-width-closed;


### PR DESCRIPTION
Currently the size of the icon is different when the sidebar is open and closed. This "seems" wrong to me - but its a design decision - so I offer this PR for consideration

requires npm i or node build.js --compile-css for testing

### Before
![image](https://user-images.githubusercontent.com/1296369/75813131-61bd8580-5d87-11ea-846b-29589d8007d8.png)

### Before and After (no change)
![image](https://user-images.githubusercontent.com/1296369/75813134-62eeb280-5d87-11ea-8056-fd27cbfce290.png)

### After
![image](https://user-images.githubusercontent.com/1296369/75813138-64b87600-5d87-11ea-94ba-bf45a5c74f1b.png)
