### PR TITLE
[3] Fix undesired escaping of single quote in lang string

### DIFF
--- a/administrator/components/com_content/models/fields/modal/article.php
+++ b/administrator/components/com_content/models/fields/modal/article.php
@@ -277,7 +277,7 @@ class JFormFieldModal_Article extends JFormField
 		$class = $this->required ? ' class="required modal-value"' : '';
 
 		$html .= '<input type="hidden" id="' . $this->id . '_id" ' . $class . ' data-required="' . (int) $this->required . '" name="' . $this->name
-			. '" data-text="' . htmlspecialchars(JText::_('COM_CONTENT_SELECT_AN_ARTICLE', true), ENT_COMPAT, 'UTF-8') . '" value="' . $value . '" />';
+			. '" data-text="' . htmlspecialchars(JText::_('COM_CONTENT_SELECT_AN_ARTICLE'), ENT_COMPAT, 'UTF-8') . '" value="' . $value . '" />';
 
 		return $html;
 	}


### PR DESCRIPTION
### Summary of Changes 
As title says.


### Testing Instructions
Install French Language and switch to French in backend.
Create a single article menu item.

The string used in French to select an article is
`COM_CONTENT_SELECT_AN_ARTICLE="Sélection d'un article"`

It contains a single quote.


### Before patch

<img width="468" alt="Screen Shot 2020-03-04 at 08 39 05" src="https://user-images.githubusercontent.com/869724/75856562-e2ff3180-5df4-11ea-9558-0280f09b94e3.png">


### After patch

<img width="577" alt="Screen Shot 2020-03-04 at 08 36 48" src="https://user-images.githubusercontent.com/869724/75856585-ee525d00-5df4-11ea-98bc-0b32d33d376c.png">


