### PR TITLE
[4.0] Fixing Module xtd filters

### DIFF
--- a/administrator/components/com_modules/src/View/Modules/HtmlView.php
+++ b/administrator/components/com_modules/src/View/Modules/HtmlView.php
@@ -115,6 +115,9 @@ class HtmlView extends BaseHtmlView
 			// Client id selector should not exist.
 			$this->filterForm->removeField('client_id', '');
 
+			// Forcing Client id to site to get the correct filters
+			$this->clientId = 0;
+
 			// If in the frontend state and language should not activate the search tools.
 			if (Factory::getApplication()->isClient('site'))
 			{


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/28220

### Summary of Changes
Forcing client id to site


### Testing Instructions
See https://github.com/joomla/joomla-cms/issues/28220


### Before patch
Wrong type and positions in the filters
<img width="567" alt="Screen Shot 2020-03-04 at 11 05 12" src="https://user-images.githubusercontent.com/869724/75869790-61b29980-5e0a-11ea-99a1-4ec6d9d3abe4.png">
<img width="1054" alt="Screen Shot 2020-03-04 at 11 04 40" src="https://user-images.githubusercontent.com/869724/75869796-6414f380-5e0a-11ea-88ca-3940fd6379b6.png">


### After patch

<img width="362" alt="Screen Shot 2020-03-04 at 11 50 05" src="https://user-images.githubusercontent.com/869724/75872400-5c574e00-5e0e-11ea-82a6-4cbb379b6772.png">
<img width="480" alt="Screen Shot 2020-03-04 at 11 49 57" src="https://user-images.githubusercontent.com/869724/75872401-5cefe480-5e0e-11ea-90fb-ffa3a36d5e6c.png">
