### PR TITLE
JSON.parse fail on multiline itemval

### DIFF
--- a/media/jui/js/cms-uncompressed.js
+++ b/media/jui/js/cms-uncompressed.js
@@ -79,8 +79,12 @@ Joomla = window.Joomla || {};
 						// select lists, textarea etc. Note that multiple-select list returns an Array here
 						// se we can always tream 'itemval' as an array
 						itemval = $field.val();
+						// a <textarea> $field is stored as array with only one element
+						if ($field.prop("tagName").toLowerCase() == "textarea"){
+							itemval = [ itemval ];
+						} 
 						// a multi-select <select> $field  will return null when no elements are selected so we need to define itemval accordingly
-						if (itemval == null && $field.prop("tagName").toLowerCase() == "select") {
+						else if (itemval == null && $field.prop("tagName").toLowerCase() == "select") {
 							itemval = [];
 						}
 					}


### PR DESCRIPTION
if Itemval was fill from multilne textarea, on line 91 on uncompressed original cms file, fail.
Preprocessing it doesnt happen.

Pull Request for Issue # .

### Summary of Changes 
Add a check before of error, and transform textarea itemval into an array with only one element without using JSON.parse.


### Testing Instructions (tested on Joomla3.10 to 3.10.15
create a custom field with more than one line on textarea


### Expected result
create a item with textarea value


### Actual result
page stop processing on line 91


### Documentation Changes Required

