### PR TITLE
[4.0] Fix table heading sort whitespace

### DIFF
--- a/layouts/joomla/searchtools/grid/sort.php
+++ b/layouts/joomla/searchtools/grid/sort.php
@@ -35,6 +35,8 @@ endif;
 	<?php if (!empty($sort)) : ?>
 		data-sort="<?php echo $sort; ?>"
 	<?php endif; ?>>
+	<?php // The following statement has been concatenated purposely to remove whitespace. ?>
+	<?php // Please leave as is. ?>
 	<?php if (!empty($data->title)) : ?><span><?php echo Text::_($data->title); ?></span><?php endif; ?><span
 		class="ml-1 <?php echo $icon; ?>"
 		aria-hidden="true"></span>

--- a/layouts/joomla/searchtools/grid/sort.php
+++ b/layouts/joomla/searchtools/grid/sort.php
@@ -35,12 +35,9 @@ endif;
 	<?php if (!empty($sort)) : ?>
 		data-sort="<?php echo $sort; ?>"
 	<?php endif; ?>>
-	<?php if (!empty($data->title)) : ?>
-		<span>
-			<?php echo Text::_($data->title); ?>
-		</span>
-	<?php endif; ?>
-	<span class="<?php echo $icon; ?>" aria-hidden="true"></span>
+	<?php if (!empty($data->title)) : ?><span><?php echo Text::_($data->title); ?></span><?php endif; ?><span
+		class="ml-1 <?php echo $icon; ?>"
+		aria-hidden="true"></span>
 	<span class="sr-only">
 		<?php echo Text::_('JGLOBAL_SORT_BY'); ?>
 		<?php echo (!empty($data->title)) ? Text::_($data->title) : Text::_('JGRID_HEADING_ORDERING'); ?>


### PR DESCRIPTION
Pull Request for Issue #28207

### Summary of Changes

Fix the whitespace in table heading sort links

### Testing Instructions

1. Go to any table view
2. Hover over one of the table headings

You've notice the link becomes underlined, however there is a blank space at the end that also contains the underline.

### Expected result

No trailing whitespace

### Actual result

![75819955-6d16ae00-5d93-11ea-820d-e2d86665801e](https://user-images.githubusercontent.com/2019801/75893404-a817f080-5e2a-11ea-8602-8059db416102.png)