### PR TITLE
[4.0] fuzzy border

### DIFF
--- a/administrator/templates/atum/scss/vendor/bootstrap/_table.scss
+++ b/administrator/templates/atum/scss/vendor/bootstrap/_table.scss
@@ -16,7 +16,7 @@
       color: var(--atum-link-color);
       white-space: nowrap;
       border-top: 0;
-      border-bottom: 3px solid var(--atum-bg-light);
+      border-bottom: 0;
 
       @include media-breakpoint-down(xs) {
         white-space: normal;
@@ -67,8 +67,6 @@
   th,
   td {
     padding: 1rem;
-    border-top: 0;
-    border-bottom: 3px solid var(--atum-bg-light);
 
     label {
       margin-bottom: 0;


### PR DESCRIPTION
Pull Request for Issue #28069 

When you hover on a row in a list such as the article manager the background changes to a grey colour. Unfortunately the light blue border merges into the grey and produces a "blurred" image. Following the suggestion of @chmst this PR changes it to a thinner darker border

### before
![image](https://user-images.githubusercontent.com/1296369/75199747-cf502d00-575b-11ea-9b3c-a181e2aa0d71.png)

### after
![image](https://user-images.githubusercontent.com/1296369/75972975-52942000-5ecc-11ea-9d8b-2d4cc2cf0279.png)

![image](https://user-images.githubusercontent.com/1296369/75973080-80796480-5ecc-11ea-817e-c0db28957387.png)

as it is a css change - npm -i or node build.js --compile-css