### PR TITLE
[4.0] tab and sidebar active

### DIFF
--- a/administrator/templates/atum/scss/_variables.scss
+++ b/administrator/templates/atum/scss/_variables.scss
@@ -75,7 +75,7 @@ $colors: (
   atum-special-color:              $dark-blue,
   atum-link-color:                 $light-blue,
   atum-link-hover-color:           darken($light-blue, 20%),
-  atum-contrast:                   adjust-color($base-color, $hue: -40deg, $lightness: +16%),
+  atum-contrast:                   $light-blue,
   atum-bg-dark-5:                  adjust-color($base-color, $hue: -6%, $saturation: -85%, $lightness: +65.1%),
   atum-bg-dark-10:                 adjust-color($base-color, $hue: -6%, $saturation: -80%, $lightness: +59.4%),
   atum-bg-dark-20:                 adjust-color($base-color, $hue: -6%, $saturation: -75%, $lightness: +47.3%),


### PR DESCRIPTION
When a tab or sidebar item is active it has a green coloured stripe. For consistency and because we dont need a million colours this changes the value of $atum-contrast to be $light-blue which is the same colour used elsewhere - notably the solid blue sidebar header

as this is a css change npm i or node build.js --compile-css

### before
![image](https://user-images.githubusercontent.com/1296369/75974305-76586580-5ece-11ea-8031-2c4df3bc6d12.png)

![image](https://user-images.githubusercontent.com/1296369/75974310-78babf80-5ece-11ea-8984-1b9696cb4459.png)


### after
![image](https://user-images.githubusercontent.com/1296369/75974203-4dd06b80-5ece-11ea-9b8b-5af21bf04fc1.png)

![image](https://user-images.githubusercontent.com/1296369/75974247-5d4fb480-5ece-11ea-85f4-788d12a5a3c5.png)
