### PR TITLE
[4.0] Change background from span to btn

### DIFF
--- a/administrator/templates/atum/scss/blocks/_toolbar.scss
+++ b/administrator/templates/atum/scss/blocks/_toolbar.scss
@@ -310,11 +310,10 @@ joomla-toolbar-button {
 
     &.btn-success {
       padding: 0;
-      background-color: $white;
+      background-color: theme-color("success");
 
       span {
         color: rgba(255, 255, 255, .90);
-        background-color: theme-color("success");
       }
 
       &::after {


### PR DESCRIPTION
### Summary of Changes

In Firefox under Ubuntu I see a small gap in the upper area in the dropdowns. At least with Firefox on Ubuntu. You have to look very closely. My change corrects this.

### Testing Instructions
1. Create an article and look at the button to open the actions. You can see a small gap in the upper area.
2. Apply this patch
3. run `npm ci`
4. See, that there is no small gap in the upper area anymore.

### Expected result
![Articles  New   test   Administration(1)](https://user-images.githubusercontent.com/9974686/76003028-cb649d80-5f07-11ea-9e49-a11bfaaabc60.png)




### Actual result
![Screenshot from 2020 03 05 17 06 44(1)](https://user-images.githubusercontent.com/9974686/76003025-ca337080-5f07-11ea-9cab-eee9f9316329.png)



### Documentation Changes Required

