### PR TITLE
[4.0] Remove 'legacy' checks from content->icons layouts

### DIFF
--- a/layouts/joomla/content/icons/create.php
+++ b/layouts/joomla/content/icons/create.php
@@ -16,7 +16,6 @@ $params = $displayData['params'];
 
 ?>
 <?php if ($params->get('show_icons')) : ?>
-	<?php echo HTMLHelper::_('image', 'system/new.png', Text::_('JNEW'), null, true); ?>
 	<span class="fas fa-plus" aria-hidden="true"></span>
 	<?php echo Text::_('JNEW'); ?>
 <?php else : ?>

--- a/layouts/joomla/content/icons/create.php
+++ b/layouts/joomla/content/icons/create.php
@@ -9,7 +9,6 @@
 
 defined('JPATH_BASE') or die;
 
-use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
 $params = $displayData['params'];

--- a/layouts/joomla/content/icons/create.php
+++ b/layouts/joomla/content/icons/create.php
@@ -13,16 +13,12 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
 $params = $displayData['params'];
-$legacy = $displayData['legacy'];
 
 ?>
 <?php if ($params->get('show_icons')) : ?>
-	<?php if ($legacy) : ?>
-		<?php echo HTMLHelper::_('image', 'system/new.png', Text::_('JNEW'), null, true); ?>
-	<?php else : ?>
-		<span class="fas fa-plus" aria-hidden="true"></span>
-		<?php echo Text::_('JNEW'); ?>
-	<?php endif; ?>
+	<?php echo HTMLHelper::_('image', 'system/new.png', Text::_('JNEW'), null, true); ?>
+	<span class="fas fa-plus" aria-hidden="true"></span>
+	<?php echo Text::_('JNEW'); ?>
 <?php else : ?>
 	<?php echo Text::_('JNEW') . '&#160;'; ?>
 <?php endif; ?>

--- a/layouts/joomla/content/icons/edit.php
+++ b/layouts/joomla/content/icons/edit.php
@@ -15,7 +15,6 @@ use Joomla\CMS\Language\Text;
 
 $article = $displayData['article'];
 $overlib = $displayData['overlib'];
-$legacy  = $displayData['legacy'];
 $nowDate = strtotime(Factory::getDate());
 
 if ($legacy)
@@ -42,9 +41,5 @@ else
 }
 
 ?>
-<?php if ($legacy) : ?>
-	<?php echo HTMLHelper::_('image', 'system/' . $icon, Text::_('JGLOBAL_EDIT'), null, true); ?>
-<?php else : ?>
 	<span class="hasTooltip fas fa-<?php echo $icon; ?>" title="<?php echo HTMLHelper::tooltipText(Text::_('COM_CONTENT_EDIT_ITEM'), $overlib, 0, 0); ?>"></span>
 	<?php echo Text::_('JGLOBAL_EDIT'); ?>
-<?php endif; ?>

--- a/layouts/joomla/content/icons/edit.php
+++ b/layouts/joomla/content/icons/edit.php
@@ -17,27 +17,13 @@ $article = $displayData['article'];
 $overlib = $displayData['overlib'];
 $nowDate = strtotime(Factory::getDate());
 
-if ($legacy)
-{
-	$icon = $article->state ? 'edit.png' : 'edit_unpublished.png';
+$icon = $article->state ? 'edit' : 'eye-slash';
 
-	if (($article->publish_up !== null && strtotime($article->publish_up) > $nowDate)
-		|| ($article->publish_down !== null && strtotime($article->publish_down) < $nowDate
-			&& $article->publish_down !== Factory::getDbo()->getNullDate()))
-	{
-		$icon = 'edit_unpublished.png';
-	}
-}
-else
+if (($article->publish_up !== null && strtotime($article->publish_up) > $nowDate)
+	|| ($article->publish_down !== null && strtotime($article->publish_down) < $nowDate
+		&& $article->publish_down !== Factory::getDbo()->getNullDate()))
 {
-	$icon = $article->state ? 'edit' : 'eye-slash';
-
-	if (($article->publish_up !== null && strtotime($article->publish_up) > $nowDate)
-		|| ($article->publish_down !== null && strtotime($article->publish_down) < $nowDate
-			&& $article->publish_down !== Factory::getDbo()->getNullDate()))
-	{
-		$icon = 'eye-slash';
-	}
+	$icon = 'eye-slash';
 }
 
 ?>

--- a/layouts/joomla/content/icons/edit.php
+++ b/layouts/joomla/content/icons/edit.php
@@ -27,5 +27,5 @@ if (($article->publish_up !== null && strtotime($article->publish_up) > $nowDate
 }
 
 ?>
-	<span class="hasTooltip fas fa-<?php echo $icon; ?>" title="<?php echo HTMLHelper::tooltipText(Text::_('COM_CONTENT_EDIT_ITEM'), $overlib, 0, 0); ?>"></span>
-	<?php echo Text::_('JGLOBAL_EDIT'); ?>
+<span class="hasTooltip fas fa-<?php echo $icon; ?>" title="<?php echo HTMLHelper::tooltipText(Text::_('COM_CONTENT_EDIT_ITEM'), $overlib, 0, 0); ?>"></span>
+<?php echo Text::_('JGLOBAL_EDIT'); ?>

--- a/layouts/joomla/content/icons/edit_lock.php
+++ b/layouts/joomla/content/icons/edit_lock.php
@@ -15,5 +15,5 @@ use Joomla\CMS\Language\Text;
 $tooltip = $displayData['tooltip'];
 
 ?>
-	<span class="hasTooltip fas fa-lock" title="<?php echo HTMLHelper::tooltipText($tooltip . '', 0); ?>"></span>
-	<?php echo Text::_('JLIB_HTML_CHECKED_OUT'); ?>
+<span class="hasTooltip fas fa-lock" title="<?php echo HTMLHelper::tooltipText($tooltip . '', 0); ?>"></span>
+<?php echo Text::_('JLIB_HTML_CHECKED_OUT'); ?>

--- a/layouts/joomla/content/icons/edit_lock.php
+++ b/layouts/joomla/content/icons/edit_lock.php
@@ -13,15 +13,7 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
 $tooltip = $displayData['tooltip'];
-$legacy  = $displayData['legacy'];
 
 ?>
-<?php if ($legacy) : ?>
-	<span class="hasTooltip" title="<?php echo HTMLHelper::tooltipText($tooltip . '', 0); ?>">
-		<?php echo HTMLHelper::_('image', 'system/checked_out.png', null, null, true); ?>
-	</span>
-	<?php echo Text::_('JLIB_HTML_CHECKED_OUT'); ?>
-<?php else : ?>
 	<span class="hasTooltip fas fa-lock" title="<?php echo HTMLHelper::tooltipText($tooltip . '', 0); ?>"></span>
 	<?php echo Text::_('JLIB_HTML_CHECKED_OUT'); ?>
-<?php endif; ?>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
I presume the legacy checks in the content->icons layouts are no longer required? This PR removes them. 

### Testing Instructions
Code review. 


