### PR TITLE
[4.0] Details/summary css

### DIFF
--- a/administrator/templates/atum/scss/blocks/_global.scss
+++ b/administrator/templates/atum/scss/blocks/_global.scss
@@ -234,8 +234,3 @@ details {
 summary {
   color: var(--atum-link-color);
 }
-
-div.rule-notes {
-  padding: 1rem;
-  background: var(--atum-bg-light);
-}

--- a/administrator/templates/atum/scss/pages/_com_config.scss
+++ b/administrator/templates/atum/scss/pages/_com_config.scss
@@ -16,8 +16,6 @@
 
   .rule-notes,
   .filter-notes {
-    padding: 1em;
-    margin-bottom: 1em;
     background-color: $white;
   }
 


### PR DESCRIPTION
Clean up the css to remove specific class from _global.scss and resolved the super big padding

as it is css you need to npm i or node build.js --compile-css after apply the patch

(the border is not in the code that was my browser highlighting)
### Before
![image](https://user-images.githubusercontent.com/1296369/76128955-c2ee8e80-5ffd-11ea-991b-5702cb789cab.png)

### After
![image](https://user-images.githubusercontent.com/1296369/76128865-7a36d580-5ffd-11ea-80ee-3096270d9821.png)
