### PR TITLE
[4.0][Atum] Main container cropping tooltips

### DIFF
--- a/administrator/templates/atum/scss/blocks/_global.scss
+++ b/administrator/templates/atum/scss/blocks/_global.scss
@@ -104,7 +104,7 @@ body .container-main {
   min-height: calc(100vh - #{$header-height} - 3px);
   padding-right: 0;
   padding-left: 0;
-  overflow: auto;
+
   &::before,
   &::after {
     position: fixed;


### PR DESCRIPTION
Pull Request for an issue mentioned in #28246 

### Summary of Changes
Reverts overflow hidden on main container which causes some tooltips to be cropped.


### Testing Instructions
Go to any list view with filter in backend.
Hover over search input.



