### PR TITLE
[4.0] Fix Module XTD position and type filters by adding client property to these fields

### DIFF
--- a/administrator/components/com_modules/forms/filter_modules.xml
+++ b/administrator/components/com_modules/forms/filter_modules.xml
@@ -33,6 +33,7 @@
 			name="position"
 			type="ModulesPosition"
 			label="COM_MODULES_OPTION_SELECT_POSITION"
+			client="site"
 			onchange="this.form.submit();"
 			>
 			<option value="">COM_MODULES_OPTION_SELECT_POSITION</option>
@@ -41,6 +42,7 @@
 			name="module"
 			type="ModulesModule"
 			label="COM_MODULES_OPTION_SELECT_MODULE"
+			client="site"
 			onchange="this.form.submit();"
 			>
 			<option value="">COM_MODULES_OPTION_SELECT_MODULE</option>

--- a/administrator/components/com_modules/forms/filter_modulesadmin.xml
+++ b/administrator/components/com_modules/forms/filter_modulesadmin.xml
@@ -35,6 +35,7 @@
 			name="position"
 			type="ModulesPosition"
 			label="COM_MODULES_FIELD_POSITION_LABEL"
+			client="administrator"
 			onchange="this.form.submit();"
 			>
 			<option value="">COM_MODULES_OPTION_SELECT_POSITION</option>
@@ -43,6 +44,7 @@
 			name="module"
 			type="ModulesModule"
 			label="COM_MODULES_OPTION_SELECT_MODULE"
+			client="administrator"
 			onchange="this.form.submit();"
 			>
 			<option value="">COM_MODULES_OPTION_SELECT_MODULE</option>

--- a/administrator/components/com_modules/src/Field/ModulesModuleField.php
+++ b/administrator/components/com_modules/src/Field/ModulesModuleField.php
@@ -11,7 +11,6 @@ namespace Joomla\Component\Modules\Administrator\Field;
 
 defined('JPATH_BASE') or die;
 
-use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Field\ListField;
 use Joomla\Component\Modules\Administrator\Helper\ModulesHelper;
 
@@ -31,6 +30,83 @@ class ModulesModuleField extends ListField
 	protected $type = 'ModulesModule';
 
 	/**
+	 * Client name.
+	 *
+	 * @var    string
+	 * @since  4.0.0
+	 */
+	protected $client;
+
+	/**
+	 * Method to get certain otherwise inaccessible properties from the form field object.
+	 *
+	 * @param   string  $name  The property name for which to get the value.
+	 *
+	 * @return  mixed  The property value or null.
+	 *
+	 * @since   4.0.0
+	 */
+	public function __get($name)
+	{
+		switch ($name)
+		{
+			case 'client':
+				return $this->$name;
+		}
+
+		return parent::__get($name);
+	}
+
+	/**
+	 * Method to set certain otherwise inaccessible properties of the form field object.
+	 *
+	 * @param   string  $name   The property name for which to set the value.
+	 * @param   mixed   $value  The value of the property.
+	 *
+	 * @return  void
+	 *
+	 * @since   4.0.0
+	 */
+	public function __set($name, $value)
+	{
+		switch ($name)
+		{
+			case 'client':
+				$this->$name = (string) $value;
+				break;
+
+			default:
+				parent::__set($name, $value);
+		}
+	}
+
+	/**
+	 * Method to attach a Form object to the field.
+	 *
+	 * @param   \SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
+	 * @param   mixed              $value    The form field value to validate.
+	 * @param   string             $group    The field name group control value. This acts as an array container for the field.
+	 *                                       For example if the field has name="foo" and the group value is set to "bar" then the
+	 *                                       full field name would end up being "bar[foo]".
+	 *
+	 * @return  boolean  True on success.
+	 *
+	 * @see     FormField::setup()
+	 * @since   4.0.0
+	 */
+	public function setup(\SimpleXMLElement $element, $value, $group = null)
+	{
+		$result = parent::setup($element, $value, $group);
+
+		if ($result === true)
+		{
+			$this->client = $this->element['client'] ? (string) $this->element['client'] : 'site';
+		}
+
+		return $result;
+	}
+
+	/**
 	 * Method to get the field options.
 	 *
 	 * @return  array  The field option objects.
@@ -39,7 +115,8 @@ class ModulesModuleField extends ListField
 	 */
 	public function getOptions()
 	{
-		$options = ModulesHelper::getModules(Factory::getApplication()->getUserState('com_modules.modules.client_id', 0));
+		$clientId  = $this->client === 'administrator' ? 1 : 0;
+		$options   = ModulesHelper::getModules($clientId);
 
 		return array_merge(parent::getOptions(), $options);
 	}

--- a/administrator/components/com_modules/src/Field/ModulesModuleField.php
+++ b/administrator/components/com_modules/src/Field/ModulesModuleField.php
@@ -115,8 +115,8 @@ class ModulesModuleField extends ListField
 	 */
 	public function getOptions()
 	{
-		$clientId  = $this->client === 'administrator' ? 1 : 0;
-		$options   = ModulesHelper::getModules($clientId);
+		$clientId = $this->client === 'administrator' ? 1 : 0;
+		$options  = ModulesHelper::getModules($clientId);
 
 		return array_merge(parent::getOptions(), $options);
 	}

--- a/administrator/components/com_modules/src/Field/ModulesPositionField.php
+++ b/administrator/components/com_modules/src/Field/ModulesPositionField.php
@@ -115,8 +115,8 @@ class ModulesPositionField extends ListField
 	 */
 	public function getOptions()
 	{
-		$clientId  = $this->client === 'administrator' ? 1 : 0;
-		$options   = ModulesHelper::getPositions($clientId);
+		$clientId = $this->client === 'administrator' ? 1 : 0;
+		$options  = ModulesHelper::getPositions($clientId);
 
 		return array_merge(parent::getOptions(), $options);
 	}

--- a/administrator/components/com_modules/src/Field/ModulesPositionField.php
+++ b/administrator/components/com_modules/src/Field/ModulesPositionField.php
@@ -11,7 +11,6 @@ namespace Joomla\Component\Modules\Administrator\Field;
 
 defined('JPATH_BASE') or die;
 
-use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Field\ListField;
 use Joomla\Component\Modules\Administrator\Helper\ModulesHelper;
 
@@ -31,6 +30,83 @@ class ModulesPositionField extends ListField
 	protected $type = 'ModulesPosition';
 
 	/**
+	 * Client name.
+	 *
+	 * @var    string
+	 * @since  4.0.0
+	 */
+	protected $client;
+
+	/**
+	 * Method to get certain otherwise inaccessible properties from the form field object.
+	 *
+	 * @param   string  $name  The property name for which to get the value.
+	 *
+	 * @return  mixed  The property value or null.
+	 *
+	 * @since   4.0.0
+	 */
+	public function __get($name)
+	{
+		switch ($name)
+		{
+			case 'client':
+				return $this->$name;
+		}
+
+		return parent::__get($name);
+	}
+
+	/**
+	 * Method to set certain otherwise inaccessible properties of the form field object.
+	 *
+	 * @param   string  $name   The property name for which to set the value.
+	 * @param   mixed   $value  The value of the property.
+	 *
+	 * @return  void
+	 *
+	 * @since   4.0.0
+	 */
+	public function __set($name, $value)
+	{
+		switch ($name)
+		{
+			case 'client':
+				$this->$name = (string) $value;
+				break;
+
+			default:
+				parent::__set($name, $value);
+		}
+	}
+
+	/**
+	 * Method to attach a Form object to the field.
+	 *
+	 * @param   \SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
+	 * @param   mixed              $value    The form field value to validate.
+	 * @param   string             $group    The field name group control value. This acts as an array container for the field.
+	 *                                       For example if the field has name="foo" and the group value is set to "bar" then the
+	 *                                       full field name would end up being "bar[foo]".
+	 *
+	 * @return  boolean  True on success.
+	 *
+	 * @see     FormField::setup()
+	 * @since   4.0.0
+	 */
+	public function setup(\SimpleXMLElement $element, $value, $group = null)
+	{
+		$result = parent::setup($element, $value, $group);
+
+		if ($result === true)
+		{
+			$this->client = $this->element['client'] ? (string) $this->element['client'] : 'site';
+		}
+
+		return $result;
+	}
+
+	/**
 	 * Method to get the field options.
 	 *
 	 * @return  array  The field option objects.
@@ -39,7 +115,8 @@ class ModulesPositionField extends ListField
 	 */
 	public function getOptions()
 	{
-		$options = ModulesHelper::getPositions(Factory::getApplication()->getUserState('com_modules.modules.client_id', 0));
+		$clientId  = $this->client === 'administrator' ? 1 : 0;
+		$options   = ModulesHelper::getPositions($clientId);
 
 		return array_merge(parent::getOptions(), $options);
 	}

--- a/components/com_modules/forms/filter_modules.xml
+++ b/components/com_modules/forms/filter_modules.xml
@@ -16,6 +16,7 @@
 			name="position"
 			type="modulesposition"
 			label="COM_MODULES_FIELD_POSITION_LABEL"
+			client="site"
 			onchange="this.form.submit();"
 			>
 			<option value="">COM_MODULES_OPTION_SELECT_POSITION</option>
@@ -24,6 +25,7 @@
 			name="module"
 			type="ModulesModule"
 			label="COM_MODULES_OPTION_SELECT_MODULE"
+			client="site"
 			onchange="this.form.submit();"
 			>
 			<option value="">COM_MODULES_OPTION_SELECT_MODULE</option>


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/28119
Replaces https://github.com/joomla/joomla-cms/issues/28220 which was not sufficient

### Summary of Changes
Forcing correct list of modules positions and type in module xtd searchtools filters by adding client property to the fields as done in https://github.com/joomla/joomla-cms/pull/24698 (Thanks @SharkyKZ for the idea)


### Testing Instructions
Display Administrator Modules Manager.
Edit/create an article in backend.
Select CMS Content => Module
Display filters 

Then patch and test again

### Before patch
Wrong type and positions in the filters
<img width="567" alt="Screen Shot 2020-03-04 at 11 05 12" src="https://user-images.githubusercontent.com/869724/75869790-61b29980-5e0a-11ea-99a1-4ec6d9d3abe4.png">
<img width="1054" alt="Screen Shot 2020-03-04 at 11 04 40" src="https://user-images.githubusercontent.com/869724/75869796-6414f380-5e0a-11ea-88ca-3940fd6379b6.png">


### After patch

<img width="362" alt="Screen Shot 2020-03-04 at 11 50 05" src="https://user-images.githubusercontent.com/869724/75872400-5c574e00-5e0e-11ea-82a6-4cbb379b6772.png">
<img width="480" alt="Screen Shot 2020-03-04 at 11 49 57" src="https://user-images.githubusercontent.com/869724/75872401-5cefe480-5e0e-11ea-90fb-ffa3a36d5e6c.png">
