### PR TITLE
[4.0] system plugin to add translate no html5 attribute

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/4.0.0-2020-03-09.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.0.0-2020-03-09.sql
@@ -1,0 +1,2 @@
+INSERT INTO `#__extensions` (`package_id`, `name`, `type`, `element`, `folder`, `client_id`, `enabled`, `access`, `protected`, `manifest_cache`, `params`, `checked_out`, `checked_out_time`, `ordering`, `state`) VALUES
+(0, 'plg_system_donttranslate', 'plugin', 'donttranslate', 'system', 0, 1, 1, 0, '', '{}', 0, NULL, 0, 0);

--- a/administrator/components/com_admin/sql/updates/mysql/4.0.0-2020-03-09.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.0.0-2020-03-09.sql
@@ -1,2 +1,2 @@
 INSERT INTO `#__extensions` (`package_id`, `name`, `type`, `element`, `folder`, `client_id`, `enabled`, `access`, `protected`, `manifest_cache`, `params`, `checked_out`, `checked_out_time`, `ordering`, `state`) VALUES
-(0, 'plg_system_donttranslate', 'plugin', 'donttranslate', 'system', 0, 1, 1, 0, '', '{}', 0, NULL, 0, 0);
+(0, 'plg_system_donttranslate', 'plugin', 'donttranslate', 'system', 0, 0, 1, 0, '', '{}', 0, NULL, 0, 0);

--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2020-03-09.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2020-03-09.sql
@@ -1,2 +1,2 @@
 INSERT INTO "#__extensions" ("package_id", "name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "manifest_cache", "params", "checked_out", "checked_out_time", "ordering", "state") VALUES
-(0, 'plg_system_donttranslate', 'plugin', 'donttranslate', 'system', 0, 1, 1, 0, '', '{}', 0, NULL, 0, 0);
+(0, 'plg_system_donttranslate', 'plugin', 'donttranslate', 'system', 0, 0, 1, 0, '', '{}', 0, NULL, 0, 0);

--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2020-03-09.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2020-03-09.sql
@@ -1,0 +1,2 @@
+INSERT INTO "#__extensions" ("package_id", "name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "manifest_cache", "params", "checked_out", "checked_out_time", "ordering", "state") VALUES
+(0, 'plg_system_donttranslate', 'plugin', 'donttranslate', 'system', 0, 1, 1, 0, '', '{}', 0, NULL, 0, 0);

--- a/administrator/language/en-GB/plg_system_donttranslate.ini
+++ b/administrator/language/en-GB/plg_system_donttranslate.ini
@@ -3,5 +3,5 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt
 ; Note : All ini files need to be saved as UTF-8
 
-PLG_SYSTEM_DONTTRANSLATE="System - Dont Translate"
+PLG_SYSTEM_DONTTRANSLATE="System - Don't Translate"
 PLG_DONTTRANSLATE_XML_DESCRIPTION="This plugin add the translate='no' attribute, Syntax: {dontTranslate text}"

--- a/administrator/language/en-GB/plg_system_donttranslate.ini
+++ b/administrator/language/en-GB/plg_system_donttranslate.ini
@@ -4,4 +4,5 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_SYSTEM_DONTTRANSLATE="System - Don't Translate"
-PLG_DONTTRANSLATE_XML_DESCRIPTION="This plugin add the translate='no' attribute, Syntax: {dontTranslate text}"
+PLG_SYSTEM_DONTTRANSLATE_XML_DESCRIPTION="This plugin add the translate='no' attribute, Syntax: {dontTranslate}Text{/dontTranslate}"
+

--- a/administrator/language/en-GB/plg_system_donttranslate.ini
+++ b/administrator/language/en-GB/plg_system_donttranslate.ini
@@ -1,0 +1,7 @@
+; Joomla! Project
+; Copyright (C) 2005 - 2020 Open Source Matters. All rights reserved.
+; License GNU General Public License version 2 or later; see LICENSE.txt
+; Note : All ini files need to be saved as UTF-8
+
+PLG_SYSTEM_DONTTRANSLATE="System - Dont Translate"
+PLG_DONTTRANSLATE_XML_DESCRIPTION="This plugin add the translate='no' attribute, Syntax: {dontTranslate text}"

--- a/administrator/language/en-GB/plg_system_donttranslate.sys.ini
+++ b/administrator/language/en-GB/plg_system_donttranslate.sys.ini
@@ -3,5 +3,6 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt
 ; Note : All ini files need to be saved as UTF-8
 
-PLG_SYSTEM_DONTTRANSLATE="System - Dont Translate"
-PLG_DONTTRANSLATE_XML_DESCRIPTION="This plugin adds the translate='no' attribute, Syntax: {dontTranslate text}"
+PLG_SYSTEM_DONTTRANSLATE="System - Don't Translate"
+PLG_SYSTEM_DONTTRANSLATE_XML_DESCRIPTION="This plugin add the translate='no' attribute, Syntax: {dontTranslate}Text{/dontTranslate}"
+

--- a/administrator/language/en-GB/plg_system_donttranslate.sys.ini
+++ b/administrator/language/en-GB/plg_system_donttranslate.sys.ini
@@ -4,4 +4,4 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_SYSTEM_DONTTRANSLATE="System - Dont Translate"
-PLG_DONTTRANSLATE_XML_DESCRIPTION="This plugin add the translate='no' attribute, Syntax: {dontTranslate text}"
+PLG_DONTTRANSLATE_XML_DESCRIPTION="This plugin adds the translate='no' attribute, Syntax: {dontTranslate text}"

--- a/administrator/language/en-GB/plg_system_donttranslate.sys.ini
+++ b/administrator/language/en-GB/plg_system_donttranslate.sys.ini
@@ -1,0 +1,7 @@
+; Joomla! Project
+; Copyright (C) 2005 - 2020 Open Source Matters. All rights reserved.
+; License GNU General Public License version 2 or later; see LICENSE.txt
+; Note : All ini files need to be saved as UTF-8
+
+PLG_SYSTEM_DONTTRANSLATE="System - Dont Translate"
+PLG_DONTTRANSLATE_XML_DESCRIPTION="This plugin add the translate='no' attribute, Syntax: {dontTranslate text}"

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -724,7 +724,7 @@ INSERT INTO `#__extensions` (`package_id`, `name`, `type`, `element`, `folder`, 
 (0, 'files_joomla', 'file', 'joomla', '', 0, 1, 1, 1, '', '', 0, NULL, 0, 0),
 (0, 'English (en-GB) Language Pack', 'package', 'pkg_en-GB', '', 0, 1, 1, 1, '', '', 0, NULL, 0, 0),
 (0, 'plg_system_webauthn', 'plugin', 'webauthn', 'system', 0, 1, 1, 0, '', '{}', 0, NULL, 0, 0),
-(0, 'plg_system_donttranslate', 'plugin', 'donttranslate', 'system', 0, 1, 1, 0, '', '{}', 0, NULL, 0, 0);
+(0, 'plg_system_donttranslate', 'plugin', 'donttranslate', 'system', 0, 0, 1, 0, '', '{}', 0, NULL, 0, 0);
 
 INSERT INTO `#__extensions` (`package_id`, `name`, `type`, `element`, `folder`, `client_id`, `enabled`, `access`, `protected`, `manifest_cache`, `params`, `checked_out`, `checked_out_time`, `ordering`, `state`)
 SELECT `extension_id`, 'English (en-GB)', 'language', 'en-GB', '', 0, 1, 1, 1, '', '', 0, NULL, 0, 0 FROM `#__extensions` WHERE `name` = 'English (en-GB) Language Pack';

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -723,7 +723,8 @@ INSERT INTO `#__extensions` (`package_id`, `name`, `type`, `element`, `folder`, 
 (0, 'plg_fields_subfields', 'plugin', 'subfields', 'fields', 0, 1, 1, 0, '', '', 0, NULL, 0, 0),
 (0, 'files_joomla', 'file', 'joomla', '', 0, 1, 1, 1, '', '', 0, NULL, 0, 0),
 (0, 'English (en-GB) Language Pack', 'package', 'pkg_en-GB', '', 0, 1, 1, 1, '', '', 0, NULL, 0, 0),
-(0, 'plg_system_webauthn', 'plugin', 'webauthn', 'system', 0, 1, 1, 0, '', '{}', 0, NULL, 0, 0);
+(0, 'plg_system_webauthn', 'plugin', 'webauthn', 'system', 0, 1, 1, 0, '', '{}', 0, NULL, 0, 0),
+(0, 'plg_system_donttranslate', 'plugin', 'donttranslate', 'system', 0, 1, 1, 0, '', '{}', 0, NULL, 0, 0);
 
 INSERT INTO `#__extensions` (`package_id`, `name`, `type`, `element`, `folder`, `client_id`, `enabled`, `access`, `protected`, `manifest_cache`, `params`, `checked_out`, `checked_out_time`, `ordering`, `state`)
 SELECT `extension_id`, 'English (en-GB)', 'language', 'en-GB', '', 0, 1, 1, 1, '', '', 0, NULL, 0, 0 FROM `#__extensions` WHERE `name` = 'English (en-GB) Language Pack';

--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -735,7 +735,7 @@ INSERT INTO "#__extensions" ("package_id", "name", "type", "element", "folder", 
 (0, 'files_joomla', 'file', 'joomla', '', 0, 1, 1, 1, '', '', 0, NULL, 0, 0),
 (0, 'English (en-GB) Language Pack', 'package', 'pkg_en-GB', '', 0, 1, 1, 1, '', '', 0, NULL, 0, 0),
 (0, 'plg_system_webauthn', 'plugin', 'webauthn', 'system', 0, 1, 1, 0, '', '{}', 0, NULL, 8, 0),
-(0, 'plg_system_donttranslate', 'plugin', 'donttranslate', 'system', 0, 1, 1, 0, '', '{}', 0, NULL, 0, 0);
+(0, 'plg_system_donttranslate', 'plugin', 'donttranslate', 'system', 0, 0, 1, 0, '', '{}', 0, NULL, 0, 0);
 
 
 INSERT INTO "#__extensions" ("package_id", "name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "manifest_cache", "params", "checked_out", "checked_out_time", "ordering", "state")

--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -734,7 +734,8 @@ INSERT INTO "#__extensions" ("package_id", "name", "type", "element", "folder", 
 (0, 'plg_fields_subfields', 'plugin', 'subfields', 'fields', 0, 1, 1, 0, '', '', 0, NULL, 0, 0),
 (0, 'files_joomla', 'file', 'joomla', '', 0, 1, 1, 1, '', '', 0, NULL, 0, 0),
 (0, 'English (en-GB) Language Pack', 'package', 'pkg_en-GB', '', 0, 1, 1, 1, '', '', 0, NULL, 0, 0),
-(0, 'plg_system_webauthn', 'plugin', 'webauthn', 'system', 0, 1, 1, 0, '', '{}', 0, NULL, 8, 0);
+(0, 'plg_system_webauthn', 'plugin', 'webauthn', 'system', 0, 1, 1, 0, '', '{}', 0, NULL, 8, 0),
+(0, 'plg_system_donttranslate', 'plugin', 'donttranslate', 'system', 0, 1, 1, 0, '', '{}', 0, NULL, 0, 0);
 
 
 INSERT INTO "#__extensions" ("package_id", "name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "manifest_cache", "params", "checked_out", "checked_out_time", "ordering", "state")

--- a/libraries/src/MVC/Controller/FormController.php
+++ b/libraries/src/MVC/Controller/FormController.php
@@ -753,6 +753,11 @@ class FormController extends BaseController implements FormFactoryAwareInterface
 			$validData['tags'] = array();
 		}
 
+		$app->triggerEvent(
+			'onContentBeforeSaveData',
+			array($this->option . '.' . $this->context, $objData, $form)
+		);
+
 		// Attempt to save the data.
 		if (!$model->save($validData))
 		{

--- a/plugins/system/donttranslate/donttranslate.php
+++ b/plugins/system/donttranslate/donttranslate.php
@@ -154,7 +154,7 @@ class PlgSystemDontTranslate extends CMSPlugin
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function onContentBeforeSave($context, $table, $isNew=false, $data=[]) : void
+	public function onContentBeforeSave($context, $table, $isNew = false, $data = []) : void
 	{
 		if (isset($table->alias))
 		{

--- a/plugins/system/donttranslate/donttranslate.php
+++ b/plugins/system/donttranslate/donttranslate.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * @package     Joomla.Plugin
+ * @subpackage  System.dontTranslate
+ *
+ * @copyright   Copyright (C) 2005 - 2020 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+use Joomla\CMS\Factory;
+use Joomla\CMS\Plugin\CMSPlugin;
+
+/**
+ * Plugin to enable adding the translate HTML5 attribute
+ * This uses the {dontTranslate text} syntax
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class PlgSystemDontTranslate extends CMSPlugin
+{
+	/**
+	 * Plugin that add the translate="no" attribute
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function onAfterRender() : void
+	{
+		if (!Factory::getApplication()->isClient('site'))
+		{
+			return;
+		}
+
+		$body = Factory::getApplication()->getBody();
+
+		// Expression to search for {dontTranslate}
+		$regex = '/{dontTranslate\s(.*?)}/i';
+
+		// Find all instances of plugin and put in $matches for dontTranslate
+		// $matches[0] is full pattern match, $matches[1] is the position
+		preg_match_all($regex, $body, $matches, PREG_SET_ORDER);
+
+		// No matches, skip this
+		if ($matches)
+		{
+			foreach ($matches as $match)
+			{
+				$matcheslist = explode(',', $match[1]);
+
+				$text = $matcheslist[0];
+
+				$output = '<span translate="no">' . $text . '</span>';
+
+				$body = preg_replace("|$match[0]|", addcslashes($output, '\\$'), $body, 1);
+				Factory::getApplication()->setBody($body);
+			}
+		}
+	}
+}

--- a/plugins/system/donttranslate/donttranslate.php
+++ b/plugins/system/donttranslate/donttranslate.php
@@ -62,8 +62,8 @@ class PlgSystemDontTranslate extends CMSPlugin
 		$page = Factory::getApplication()->input;
 
 		if (($page->request->getWord('option') === 'com_content')
-			&&	($page->request->getWord('view') === 'form')
-			&&	($page->request->getWord('layout') === 'edit'))
+			&& ($page->request->getWord('view') === 'form')
+			&& ($page->request->getWord('layout') === 'edit'))
 		{
 			return;
 		}

--- a/plugins/system/donttranslate/donttranslate.php
+++ b/plugins/system/donttranslate/donttranslate.php
@@ -49,6 +49,11 @@ class PlgSystemDontTranslate extends CMSPlugin
 	 */
 	public function onAfterRender() : void
 	{
+		if (Factory::getApplication()->isClient('administrator'))
+		{
+			$this->cleanAlias();
+		}
+
 		if (!Factory::getApplication()->isClient('site'))
 		{
 			return;
@@ -77,6 +82,33 @@ class PlgSystemDontTranslate extends CMSPlugin
 				$body = preg_replace("|$match[0]|", addcslashes($output, '\\$'), $body, 1);
 				Factory::getApplication()->setBody($body);
 			}
+		}
+	}
+
+	/**
+	 * Clean the alias
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	private function cleanAlias() : void
+	{
+		$body = Factory::getApplication()->getBody();
+		$dom = new DOMDocument;
+		libxml_use_internal_errors(true);
+		$dom->loadHTML($body);
+		libxml_use_internal_errors(false);
+
+		if ($dom->getElementById('jform_alias'))
+		{
+			$alias = $dom->getElementById('jform_alias');
+			$string = $alias->attributes->getNamedItem('value')->nodeValue;
+			$string = str_replace('donttranslate-', '', $string);
+			$string = str_replace('-donttranslate', '', $string);
+			$alias->attributes->getNamedItem('value')->nodeValue = $string;
+			$body = $dom->saveHTML();
+			Factory::getApplication()->setBody($body);
 		}
 	}
 }

--- a/plugins/system/donttranslate/donttranslate.php
+++ b/plugins/system/donttranslate/donttranslate.php
@@ -35,8 +35,7 @@ class PlgSystemDontTranslate extends CMSPlugin
 		}
 
 		$title = Factory::getDocument()->getTitle();
-		$title = str_replace('{dontTranslate}', '', $title);
-		$title = str_replace('{/dontTranslate}', '', $title);
+		$title = str_replace(['{dontTranslate}', '{/dontTranslate}'], '', $title);
 		Factory::getDocument()->setTitle($title);
 	}
 
@@ -100,8 +99,8 @@ class PlgSystemDontTranslate extends CMSPlugin
 		{
 			$alias = $dom->getElementById('jform_alias');
 			$string = $alias->attributes->getNamedItem('value')->nodeValue;
-			$string = str_replace(['{donttranslate}', 'donttranslate-'], ['', ''], $string);
-			$string = str_replace(['{-donttranslate}', '-donttranslate'], ['', ''], $string);
+			$string = str_replace(['{donttranslate}', 'donttranslate-'], '', $string);
+			$string = str_replace(['{-donttranslate}', '-donttranslate'], '', $string);
 			$alias->attributes->getNamedItem('value')->nodeValue = $string;
 			$body = $dom->saveHTML();
 			Factory::getApplication()->setBody($body);
@@ -131,16 +130,14 @@ class PlgSystemDontTranslate extends CMSPlugin
 
 			if (strpos($string, '{dontTranslate}') !== false)
 			{
-				$string = str_replace('{dontTranslate}', '', $string);
-				$string = str_replace('{/dontTranslate}', '', $string);
+				$string = str_replace(['{dontTranslate}', '{/dontTranslate}'], '', $string);
 				$link->setAttribute('title', $string);
 				$found = true;
 			}
 
 			if (strpos($value, '{dontTranslate}') !== false)
 			{
-				$value = str_replace('{dontTranslate}', '', $value);
-				$value = str_replace('{/dontTranslate}', '', $value);
+				$value = str_replace(['{dontTranslate}', '{/dontTranslate}'], '', $value);
 				$link->nodeValue = $value;
 				$found = true;
 			}
@@ -167,7 +164,7 @@ class PlgSystemDontTranslate extends CMSPlugin
 	 */
 	public function onContentBeforeSave($context, $table, $isNew) : void
 	{
-		$table->alias = str_replace(['{donttranslate}', 'donttranslate-'], ['', ''], $table->alias);
-		$table->alias = str_replace(['{-donttranslate}', '-donttranslate'], ['', ''], $table->alias);
+		$table->alias = str_replace(['{donttranslate}', 'donttranslate-'], '', $table->alias);
+		$table->alias = str_replace(['{-donttranslate}', '-donttranslate'], '', $table->alias);
 	}
 }

--- a/plugins/system/donttranslate/donttranslate.php
+++ b/plugins/system/donttranslate/donttranslate.php
@@ -52,6 +52,7 @@ class PlgSystemDontTranslate extends CMSPlugin
 		if (Factory::getApplication()->isClient('administrator'))
 		{
 			$this->cleanAlias();
+			$this->cleanList();
 		}
 
 		if (!Factory::getApplication()->isClient('site'))
@@ -109,6 +110,51 @@ class PlgSystemDontTranslate extends CMSPlugin
 			$alias->attributes->getNamedItem('value')->nodeValue = $string;
 			$body = $dom->saveHTML();
 			Factory::getApplication()->setBody($body);
+		}
+	}
+
+	/**
+	 * Clean the list
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	private function cleanList() : void
+	{
+		$body = Factory::getApplication()->getBody();
+		$dom = new DOMDocument;
+		libxml_use_internal_errors(true);
+		$dom->loadHTML($body);
+		libxml_use_internal_errors(false);
+
+		foreach ($dom->getElementsByTagName('a') as $link)
+		{
+			$string = $link->getAttribute('title');
+			$found = false;
+			$value = $link->nodeValue;
+
+			if (strpos($string, '{dontTranslate}') !== false)
+			{
+				$string = str_replace('{dontTranslate}', '', $string);
+				$string = str_replace('{/dontTranslate}', '', $string);
+				$link->setAttribute('title', $string);
+				$found = true;
+			}
+
+			if (strpos($value, '{dontTranslate}') !== false)
+			{
+				$value = str_replace('{dontTranslate}', '', $value);
+				$value = str_replace('{/dontTranslate}', '', $value);
+				$link->nodeValue = $value;
+				$found = true;
+			}
+
+			if ($found)
+			{
+				$body = $dom->saveHTML();
+				Factory::getApplication()->setBody($body);
+			}
 		}
 	}
 }

--- a/plugins/system/donttranslate/donttranslate.php
+++ b/plugins/system/donttranslate/donttranslate.php
@@ -21,7 +21,7 @@ use Joomla\CMS\Plugin\CMSPlugin;
 class PlgSystemDontTranslate extends CMSPlugin
 {
 	/**
-	 * Plugin that add the translate="no" attribute
+	 * Plugin that adds the translate="no" attribute
 	 *
 	 * @return  void
 	 *

--- a/plugins/system/donttranslate/donttranslate.php
+++ b/plugins/system/donttranslate/donttranslate.php
@@ -14,12 +14,32 @@ use Joomla\CMS\Plugin\CMSPlugin;
 
 /**
  * Plugin to enable adding the translate HTML5 attribute
- * This uses the {dontTranslate text} syntax
+ * This uses the {dontTranslate}Text{/dontTranslate} syntax
  *
  * @since  __DEPLOY_VERSION__
  */
 class PlgSystemDontTranslate extends CMSPlugin
 {
+	/**
+	 * Clean the browser page title
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function onBeforeRender() : void
+	{
+		if (!Factory::getApplication()->isClient('site'))
+		{
+			return;
+		}
+
+		$title = Factory::getDocument()->getTitle();
+		$title = str_replace('{dontTranslate}', '', $title);
+		$title = str_replace('{/dontTranslate}', '', $title);
+		Factory::getDocument()->setTitle($title);
+	}
+
 	/**
 	 * Plugin that adds the translate="no" attribute
 	 *
@@ -36,8 +56,8 @@ class PlgSystemDontTranslate extends CMSPlugin
 
 		$body = Factory::getApplication()->getBody();
 
-		// Expression to search for {dontTranslate}
-		$regex = '/{dontTranslate\s(.*?)}/i';
+		// Expression to search for {dontTranslate}Text{/dontTranslate}
+		$regex = '/{dontTranslate}(.*?){\/dontTranslate}/i';
 
 		// Find all instances of plugin and put in $matches for dontTranslate
 		// $matches[0] is full pattern match, $matches[1] is the position

--- a/plugins/system/donttranslate/donttranslate.xml
+++ b/plugins/system/donttranslate/donttranslate.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<extension type="plugin" group="system" method="upgrade">
+	<name>plg_system_donttranslate</name>
+	<author>Joomla! Project</author>
+	<creationDate>March 2020</creationDate>
+	<copyright>Copyright (C) 2005 - 2020 Open Source Matters. All rights reserved.</copyright>
+	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
+	<authorEmail>admin@joomla.org</authorEmail>
+	<authorUrl>www.joomla.org</authorUrl>
+	<version>4.0.0</version>
+	<description>PLG_DONTTRANSLATE_XML_DESCRIPTION</description>
+	<files>
+		<filename plugin="donttranslate">donttranslate.php</filename>
+	</files>
+	<languages>
+		<language tag="en-GB">en-GB.plg_system_donttranslate.ini</language>
+		<language tag="en-GB">en-GB.plg_system_donttranslate.sys.ini</language>
+	</languages>
+	<config>
+		<fields name="params">
+			<fieldset name="basic">
+			</fieldset>
+		</fields>
+	</config>
+</extension>

--- a/plugins/system/donttranslate/donttranslate.xml
+++ b/plugins/system/donttranslate/donttranslate.xml
@@ -8,7 +8,7 @@
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>4.0.0</version>
-	<description>PLG_DONTTRANSLATE_XML_DESCRIPTION</description>
+	<description>PLG_SYSTEM_DONTTRANSLATE_XML_DESCRIPTION</description>
 	<files>
 		<filename plugin="donttranslate">donttranslate.php</filename>
 	</files>

--- a/plugins/system/donttranslate/donttranslate.xml
+++ b/plugins/system/donttranslate/donttranslate.xml
@@ -13,7 +13,7 @@
 		<filename plugin="donttranslate">donttranslate.php</filename>
 	</files>
 	<languages>
-		<language tag="en-GB">en-GB.plg_system_donttranslate.ini</language>
+		<language tag="en-GB">en-GB/plg_system_donttranslate.ini</language>
 		<language tag="en-GB">en-GB.plg_system_donttranslate.sys.ini</language>
 	</languages>
 	<config>

--- a/plugins/system/donttranslate/donttranslate.xml
+++ b/plugins/system/donttranslate/donttranslate.xml
@@ -14,7 +14,7 @@
 	</files>
 	<languages>
 		<language tag="en-GB">en-GB/plg_system_donttranslate.ini</language>
-		<language tag="en-GB">en-GB.plg_system_donttranslate.sys.ini</language>
+		<language tag="en-GB">en-GB/plg_system_donttranslate.sys.ini</language>
 	</languages>
 	<config>
 		<fields name="params">


### PR DESCRIPTION
Pull Request for Issue #28238 .

### Summary of Changes
added a system plugin that replace this markup `{dontTranslate}Text{/dontTranslate}`
with `<span translate="no">Text</span> `

### Testing Instructions
apply pr
discover the plugin 
and publish
add the markup `{dontTranslate}Text{/dontTranslate}` in articles content, article title menu item title ect

### Expected result
look at the html of the page
the translate attribute `<span translate="no">Text</span> `


### Actual result
NA


### Todo
~~add the sql~~
~~manage better the alias field if the markup is used in the title~~