### PR TITLE
Fix for Issue #26480 (strip default language tag in URL of Language Switcher)

### DIFF
--- a/modules/mod_languages/helper.php
+++ b/modules/mod_languages/helper.php
@@ -33,6 +33,10 @@ abstract class ModLanguagesHelper
 		$app		= JFactory::getApplication();
 		$menu		= $app->getMenu();
 		$active		= $menu->getActive();
+		$plugin		= JPluginHelper::getPlugin('system', 'languagefilter');
+		$params		= new JRegistry($plugin->params);
+		$remove_def_prefix	= (boolean) $params->get('remove_default_prefix', 0);
+		$defLang			= JComponentHelper::getParams('com_languages')->get('site');
 
 		// Get menu home items
 		$homes = array();
@@ -139,6 +143,12 @@ abstract class ModLanguagesHelper
 				else
 				{
 					$language->link = JRoute::_('&Itemid=' . $homes['*']->id);
+				}
+
+				// strip default language tag if requested
+				if ($remove_def_prefix && $language->lang_code === $defLang)
+				{
+					$language->link = preg_replace('|/' . $language->sef . '/|', '/', $language->link, 1);
 				}
 			}
 		}

--- a/modules/mod_languages/helper.php
+++ b/modules/mod_languages/helper.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Site
  * @subpackage  mod_languages
  *
- * @copyright   Copyright (C) 2005 - 2019 Open Source Matters, Inc. All rights reserved.
+ * @copyright   Copyright (C) 2005 - 2020 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
@@ -34,8 +34,8 @@ abstract class ModLanguagesHelper
 		$menu		= $app->getMenu();
 		$active		= $menu->getActive();
 		$plugin		= JPluginHelper::getPlugin('system', 'languagefilter');
-		$params		= new JRegistry($plugin->params);
-		$remove_def_prefix	= (boolean) $params->get('remove_default_prefix', 0);
+		$fltParams	= new JRegistry($plugin->params);
+		$remove_def_prefix	= (boolean) $fltParams->get('remove_default_prefix', 0);
 		$defLang			= JComponentHelper::getParams('com_languages')->get('site');
 
 		// Get menu home items


### PR DESCRIPTION
Remove default language SEF tag (e.g. "en") from URL in mod_languages helper when "Language Filter" plugin configuration is set to do that (_Remove URL Language Code_ = YES).
This is a proposed fix for Issue #26480.

### Summary of Changes
When building the list of URLs in the existing languages for the mod_languages, strip the default language prefix from the source code in the switcher with a regexpr in the case the _Remove URL Language Code_ setting in the Language Filter system plugin is set to YES.

### Testing Instructions
Create a multilanguage site with English as default language and LANG2, with language switcher module published, SEF enabled and all other stuff to have a multilingual site.
In the Language Filter plugin, set _Remove URL Language Code_ = YES .
Create for example two articles in the two languages and associate one each other.
In front end, go to the article in LANG2 and look at the source link for English in the language switcher module.

### Expected result
With this PR, the URL is without the "en" tag in the URL.

### Actual result
Without this PR, the URL has the "en" tag in the URL even if the option in the language filter plugins requires it to be removed.

### Documentation Changes Required

