### PR TITLE
[4.0] action button

### DIFF
--- a/administrator/templates/atum/scss/blocks/_toolbar.scss
+++ b/administrator/templates/atum/scss/blocks/_toolbar.scss
@@ -349,10 +349,6 @@ joomla-toolbar-button {
         background-color: var(--atum-bg-dark);
       }
 
-      &:hover:not([disabled]) {
-        background-color: var(--atum-bg-dark-80);
-      }
-
       &::after {
         width: 2.375rem;
         height: 100%;


### PR DESCRIPTION
Removes an extra class from the css for the action button that prevented the standard two tone design

it's css so npm i or node build.js --compile-css

### before
![image](https://user-images.githubusercontent.com/1296369/76153752-715f0600-60c8-11ea-8eda-912ef873fbef.png)

### after
![image](https://user-images.githubusercontent.com/1296369/76153747-5ab8af00-60c8-11ea-8dd5-c212a1ecd1a1.png)
