### PR TITLE
[4.0] loadmodulebyid fix strict comparison

### DIFF
--- a/libraries/src/Helper/ModuleHelper.php
+++ b/libraries/src/Helper/ModuleHelper.php
@@ -658,7 +658,7 @@ abstract class ModuleHelper
 		for ($i = 0; $i < $total; $i++)
 		{
 			// Match the id of the module
-			if ($modules[$i]->id === $id)
+			if ($modules[$i]->id === (int) $id)
 			{
 				// Found it
 				return $modules[$i];


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
cast to int to fix strict comparison


### Testing Instructions
create/edit an article 
click on CMS Content and select 
select a module to embed in the article
save the article


### Expected result
the module output is showed in the article


### Actual result

no module output

