### PR TITLE
[4.0] Missing field classes in forms

### DIFF
--- a/administrator/components/com_content/tmpl/articles/default.xml
+++ b/administrator/components/com_content/tmpl/articles/default.xml
@@ -7,9 +7,10 @@
 	</layout>
 		<!-- Add fields to the request variables for the layout. -->
 	<fields name="request">
-		<fieldset name="request"
-			addfieldpath="/administrator/components/com_categories/models/fields"
-		>
+		<fieldset
+			name="request"
+			addfieldprefix="Joomla\Component\Categories\Administrator\Field"
+			>
 			<field
 				name="filter_category_id"
 				type="modal_category"

--- a/administrator/components/com_privacy/forms/filter_consents.xml
+++ b/administrator/components/com_privacy/forms/filter_consents.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <form>
-	<fieldset addfieldpath="/administrator/components/com_privacy/models/fields" />
-
 	<fields name="filter">
 		<field
 			name="search"

--- a/administrator/components/com_privacy/forms/request.xml
+++ b/administrator/components/com_privacy/forms/request.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <form>
-	<fieldset addfieldpath="/administrator/components/com_privacy/models/fields">
+	<fieldset>
 		<field
 			name="email"
 			type="email"

--- a/administrator/modules/mod_menu/mod_menu.xml
+++ b/administrator/modules/mod_menu/mod_menu.xml
@@ -37,7 +37,6 @@
 					type="menuPreset"
 					label="MOD_MENU_FIELD_PRESET_LABEL"
 					description="MOD_MENU_FIELD_PRESET_DESC"
-					addfieldpath="administrator/components/com_menus/models/fields"
 					showon="menutype:*"
 				/>
 

--- a/administrator/modules/mod_submenu/mod_submenu.xml
+++ b/administrator/modules/mod_submenu/mod_submenu.xml
@@ -36,7 +36,6 @@
 					name="preset"
 					type="menuPreset"
 					label="MOD_SUBMENU_FIELD_PRESET_LABEL"
-					addfieldpath="administrator/components/com_menus/models/fields"
 					showon="menutype:*"
 				/>
 			</fieldset>

--- a/components/com_contact/forms/filter_contacts.xml
+++ b/components/com_contact/forms/filter_contacts.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <form>
-<fieldset addfieldpath="/administrator/components/com_contacts/models/fields" />
 	<fields name="filter">
 
 		<field

--- a/components/com_contact/tmpl/category/default.xml
+++ b/components/com_contact/tmpl/category/default.xml
@@ -10,12 +10,11 @@
 	</layout>
 
 	<!-- Add fields to the request variables for the layout. -->
-	<fields name="request"
-		addfieldprefix="Joomla\Component\Categories\Administrator\Field"
-	>
-		<fieldset name="request"
-			addfieldpath="/administrator/components/com_contact/models/fields"
-		>
+	<fields name="request">
+		<fieldset
+			name="request"
+			addfieldprefix="Joomla\Component\Categories\Administrator\Field"
+			>
 			<field
 				name="id"
 				type="modal_category"
@@ -29,7 +28,6 @@
 			/>
 		</fieldset>
 	</fields>
-
 
 	<!-- Add fields to the parameters object for the layout. -->
 	<fields name="params">

--- a/components/com_content/tmpl/archive/default.xml
+++ b/components/com_content/tmpl/archive/default.xml
@@ -11,9 +11,7 @@
 
 	<!-- Add fields to the request variables for the layout. -->
 	<fields name="request">
-		<fieldset name="request"
-			addfieldpath="/administrator/components/com_categories/models/fields"
-		>
+		<fieldset name="request">
 			<field
 				name="catid"
 				type="category"

--- a/components/com_fields/forms/filter_fields.xml
+++ b/components/com_fields/forms/filter_fields.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <form>
-	<fieldset name="group"
-		addfieldpath="/administrator/components/com_fields/models/fields">
+	<fieldset
+		name="group"
+		addfieldprefix="Joomla\Component\Fields\Administrator\Field"
+		>
 		<field
 			name="context"
 			type="fieldcontexts"

--- a/components/com_menus/forms/filter_items.xml
+++ b/components/com_menus/forms/filter_items.xml
@@ -1,96 +1,95 @@
 <?xml version="1.0" encoding="utf-8"?>
 <form>
-	<fieldset addfieldpath="/administrator/components/com_menus/models/fields" />
-		<fields name="filter">
-			<field
-				name="search"
-				type="text"
-				inputmode="search"
-				label="COM_MENUS_ITEMS_SEARCH_FILTER_LABEL"
-				description="COM_MENUS_ITEMS_SEARCH_FILTER"
-				hint="JSEARCH_FILTER"
-			/>
-			<field
-				name="published"
-				type="status"
-				label="COM_MENUS_FILTER_PUBLISHED"
-				description="COM_MENUS_FILTER_PUBLISHED_DESC"
-				filter="*,0,1,-2"
-				onchange="this.form.submit();"
-				>
-				<option value="">JOPTION_SELECT_PUBLISHED</option>
-			</field>
-			<field
-				name="access"
-				type="accesslevel"
-				label="JOPTION_FILTER_ACCESS"
-				description="JOPTION_FILTER_ACCESS_DESC"
-				onchange="this.form.submit();"
-				>
-				<option value="">JOPTION_SELECT_ACCESS</option>
-			</field>
-			<field
-				name="language"
-				type="contentlanguage"
-				label="JOPTION_FILTER_LANGUAGE"
-				description="JOPTION_FILTER_LANGUAGE_DESC"
-				onchange="this.form.submit();"
-				>
-				<option value="">JOPTION_SELECT_LANGUAGE</option>
-				<option value="*">JALL</option>
-			</field>
-			<field
-				name="level"
-				type="integer"
-				label="JOPTION_FILTER_LEVEL"
-				description="JOPTION_FILTER_LEVEL_DESC"
-				first="1"
-				last="10"
-				step="1"
-				languages="*"
-				onchange="this.form.submit();"
-				>
-				<option value="">JOPTION_SELECT_MAX_LEVELS</option>
-			</field>
-		</fields>
-		<fields name="list">
-			<field
-				name="fullordering"
-				type="list"
-				label="JGLOBAL_SORT_BY"
-				description="JGLOBAL_SORT_BY"
-				statuses="*,0,1,2,-2"
-				onchange="this.form.submit();"
-				default="a.lft ASC"
-				validate="options"
-				>
-				<option value="">JGLOBAL_SORT_BY</option>
-				<option value="a.lft ASC">JGRID_HEADING_ORDERING_ASC</option>
-				<option value="a.lft DESC">JGRID_HEADING_ORDERING_DESC</option>
-				<option value="a.published ASC">JSTATUS_ASC</option>
-				<option value="a.published DESC">JSTATUS_DESC</option>
-				<option value="a.title ASC">JGLOBAL_TITLE_ASC</option>
-				<option value="a.title DESC">JGLOBAL_TITLE_DESC</option>
-				<option value="menutype_title ASC">COM_MENUS_HEADING_MENU_ASC</option>
-				<option value="menutype_title DESC">COM_MENUS_HEADING_MENU_DESC</option>
-				<option value="a.home ASC">COM_MENUS_HEADING_HOME_ASC</option>
-				<option value="a.home DESC">COM_MENUS_HEADING_HOME_DESC</option>
-				<option value="a.access ASC">JGRID_HEADING_ACCESS_ASC</option>
-				<option value="a.access DESC">JGRID_HEADING_ACCESS_DESC</option>
-				<option value="association ASC" requires="associations">JASSOCIATIONS_ASC</option>
-				<option value="association DESC" requires="associations">JASSOCIATIONS_DESC</option>
-				<option value="language ASC" requires="multilanguage">JGRID_HEADING_LANGUAGE_ASC</option>
-				<option value="language DESC" requires="multilanguage">JGRID_HEADING_LANGUAGE_DESC</option>
-				<option value="a.id ASC">JGRID_HEADING_ID_ASC</option>
-				<option value="a.id DESC">JGRID_HEADING_ID_DESC</option>
-			</field>
-			<field
-				name="limit"
-				type="limitbox"
-				label="COM_MENUS_LIST_LIMIT"
-				description="COM_MENUS_LIST_LIMIT_DESC"
-				default="25"
-				onchange="this.form.submit();"
-			/>
-		</fields>
+	<fields name="filter">
+		<field
+			name="search"
+			type="text"
+			inputmode="search"
+			label="COM_MENUS_ITEMS_SEARCH_FILTER_LABEL"
+			description="COM_MENUS_ITEMS_SEARCH_FILTER"
+			hint="JSEARCH_FILTER"
+		/>
+		<field
+			name="published"
+			type="status"
+			label="COM_MENUS_FILTER_PUBLISHED"
+			description="COM_MENUS_FILTER_PUBLISHED_DESC"
+			filter="*,0,1,-2"
+			onchange="this.form.submit();"
+			>
+			<option value="">JOPTION_SELECT_PUBLISHED</option>
+		</field>
+		<field
+			name="access"
+			type="accesslevel"
+			label="JOPTION_FILTER_ACCESS"
+			description="JOPTION_FILTER_ACCESS_DESC"
+			onchange="this.form.submit();"
+			>
+			<option value="">JOPTION_SELECT_ACCESS</option>
+		</field>
+		<field
+			name="language"
+			type="contentlanguage"
+			label="JOPTION_FILTER_LANGUAGE"
+			description="JOPTION_FILTER_LANGUAGE_DESC"
+			onchange="this.form.submit();"
+			>
+			<option value="">JOPTION_SELECT_LANGUAGE</option>
+			<option value="*">JALL</option>
+		</field>
+		<field
+			name="level"
+			type="integer"
+			label="JOPTION_FILTER_LEVEL"
+			description="JOPTION_FILTER_LEVEL_DESC"
+			first="1"
+			last="10"
+			step="1"
+			languages="*"
+			onchange="this.form.submit();"
+			>
+			<option value="">JOPTION_SELECT_MAX_LEVELS</option>
+		</field>
+	</fields>
+	<fields name="list">
+		<field
+			name="fullordering"
+			type="list"
+			label="JGLOBAL_SORT_BY"
+			description="JGLOBAL_SORT_BY"
+			statuses="*,0,1,2,-2"
+			onchange="this.form.submit();"
+			default="a.lft ASC"
+			validate="options"
+			>
+			<option value="">JGLOBAL_SORT_BY</option>
+			<option value="a.lft ASC">JGRID_HEADING_ORDERING_ASC</option>
+			<option value="a.lft DESC">JGRID_HEADING_ORDERING_DESC</option>
+			<option value="a.published ASC">JSTATUS_ASC</option>
+			<option value="a.published DESC">JSTATUS_DESC</option>
+			<option value="a.title ASC">JGLOBAL_TITLE_ASC</option>
+			<option value="a.title DESC">JGLOBAL_TITLE_DESC</option>
+			<option value="menutype_title ASC">COM_MENUS_HEADING_MENU_ASC</option>
+			<option value="menutype_title DESC">COM_MENUS_HEADING_MENU_DESC</option>
+			<option value="a.home ASC">COM_MENUS_HEADING_HOME_ASC</option>
+			<option value="a.home DESC">COM_MENUS_HEADING_HOME_DESC</option>
+			<option value="a.access ASC">JGRID_HEADING_ACCESS_ASC</option>
+			<option value="a.access DESC">JGRID_HEADING_ACCESS_DESC</option>
+			<option value="association ASC" requires="associations">JASSOCIATIONS_ASC</option>
+			<option value="association DESC" requires="associations">JASSOCIATIONS_DESC</option>
+			<option value="language ASC" requires="multilanguage">JGRID_HEADING_LANGUAGE_ASC</option>
+			<option value="language DESC" requires="multilanguage">JGRID_HEADING_LANGUAGE_DESC</option>
+			<option value="a.id ASC">JGRID_HEADING_ID_ASC</option>
+			<option value="a.id DESC">JGRID_HEADING_ID_DESC</option>
+		</field>
+		<field
+			name="limit"
+			type="limitbox"
+			label="COM_MENUS_LIST_LIMIT"
+			description="COM_MENUS_LIST_LIMIT_DESC"
+			default="25"
+			onchange="this.form.submit();"
+		/>
+	</fields>
 </form>

--- a/components/com_modules/forms/filter_modules.xml
+++ b/components/com_modules/forms/filter_modules.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <form>
-	<fieldset addfieldpath="/administrator/components/com_modules/models/fields" />
+	<fieldset addfieldprefix="Joomla\Component\Modules\Administrator\Field" />
 
 	<fields name="filter">
 		<field

--- a/components/com_newsfeeds/tmpl/category/default.xml
+++ b/components/com_newsfeeds/tmpl/category/default.xml
@@ -10,12 +10,11 @@
 	</layout>
 
 	<!-- Add fields to the request variables for the layout. -->
-	<fields name="request"
-		addfieldprefix="Joomla\Component\Categories\Administrator\Field"
-	>
-		<fieldset name="request"
-			addfieldpath="/administrator/components/com_newsfeeds/models/fields"
-		 >
+	<fields name="request">
+		<fieldset
+			name="request"
+			addfieldprefix="Joomla\Component\Categories\Administrator\Field"
+			>
 			<field
 				name="id"
 				type="modal_category"


### PR DESCRIPTION
### Summary of Changes

Replaces outdated `addfieldpath` uses with `addfieldprefix`, fixing class loading in some forms.
Also removes unneeded `addfieldpath` uses.

### Testing Instructions

Code review.
Or go to some of the affected forms.
Notice that before patch some fields appear as empty text field when they shouldn't.

### Documentation Changes Required

No.