### PR TITLE
[4.0] options padding

### DIFF
--- a/administrator/templates/atum/scss/blocks/_layout.scss
+++ b/administrator/templates/atum/scss/blocks/_layout.scss
@@ -34,11 +34,10 @@
 
 .options-form {
   width: 100%;
-  padding: 2vw;
+  padding: 1vw 2vw;
   margin-bottom: 1rem;
   color: var(--atum-text-dark);
   background-color: $white;
- /*  box-shadow: $atum-box-shadow; */
   border: 1px solid var(--bluegray);
 
   > legend {


### PR DESCRIPTION
Reduces the top and bottom padding on the boxes around the options.

npm i or node build.js --compile-css

### Before
![image](https://user-images.githubusercontent.com/1296369/76172037-6fa94700-6189-11ea-9441-a7b8c369bff4.png)

### After

![image](https://user-images.githubusercontent.com/1296369/76172028-586a5980-6189-11ea-9a36-97cf44222615.png)
