### PR TITLE
[4.0] PredefinedlistField conflicting filter attribute

### DIFF
--- a/administrator/components/com_csp/forms/filter_reports.xml
+++ b/administrator/components/com_csp/forms/filter_reports.xml
@@ -14,7 +14,7 @@
 			name="published"
 			type="status"
 			label="JOPTION_SELECT_PUBLISHED"
-			filter="*,0,1,-2"
+			optionsFilter="*,0,1,-2"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_PUBLISHED</option>

--- a/administrator/components/com_finder/forms/filter_filters.xml
+++ b/administrator/components/com_finder/forms/filter_filters.xml
@@ -14,7 +14,7 @@
 			name="state"
 			type="status"
 			label="JOPTION_SELECT_PUBLISHED"
-			filter="0,1"
+			optionsFilter="0,1"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_PUBLISHED</option>

--- a/administrator/components/com_finder/forms/filter_index.xml
+++ b/administrator/components/com_finder/forms/filter_index.xml
@@ -14,7 +14,7 @@
 			name="state"
 			type="status"
 			label="JOPTION_SELECT_PUBLISHED"
-			filter="0,1"
+			optionsFilter="0,1"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_PUBLISHED</option>

--- a/administrator/components/com_finder/forms/filter_maps.xml
+++ b/administrator/components/com_finder/forms/filter_maps.xml
@@ -14,7 +14,7 @@
 			name="state"
 			type="status"
 			label="JOPTION_SELECT_PUBLISHED"
-			filter="0,1"
+			optionsFilter="0,1"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_PUBLISHED</option>

--- a/administrator/components/com_languages/forms/filter_languages.xml
+++ b/administrator/components/com_languages/forms/filter_languages.xml
@@ -13,7 +13,7 @@
 			name="published"
 			type="status"
 			label="JOPTION_SELECT_PUBLISHED"
-			filter="1,0,-2,*"
+			optionsFilter="1,0,-2,*"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_PUBLISHED</option>

--- a/administrator/components/com_menus/forms/filter_items.xml
+++ b/administrator/components/com_menus/forms/filter_items.xml
@@ -34,7 +34,7 @@
 			name="published"
 			type="status"
 			label="JOPTION_SELECT_PUBLISHED"
-			filter="*,0,1,-2"
+			optionsFilter="*,0,1,-2"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_PUBLISHED</option>

--- a/administrator/components/com_menus/forms/filter_itemsadmin.xml
+++ b/administrator/components/com_menus/forms/filter_itemsadmin.xml
@@ -37,7 +37,7 @@
 			name="published"
 			type="status"
 			label="JOPTION_SELECT_PUBLISHED"
-			filter="*,0,1,-2"
+			optionsFilter="*,0,1,-2"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_PUBLISHED</option>

--- a/administrator/components/com_modules/forms/filter_modules.xml
+++ b/administrator/components/com_modules/forms/filter_modules.xml
@@ -24,7 +24,7 @@
 			name="state"
 			type="status"
 			label="JOPTION_SELECT_PUBLISHED"
-			filter="*,-2,0,1"
+			optionsFilter="*,-2,0,1"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_PUBLISHED</option>

--- a/administrator/components/com_modules/forms/filter_modulesadmin.xml
+++ b/administrator/components/com_modules/forms/filter_modulesadmin.xml
@@ -26,7 +26,7 @@
 			name="state"
 			type="status"
 			label="JOPTION_SELECT_PUBLISHED"
-			filter="*,-2,0,1"
+			optionsFilter="*,-2,0,1"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_PUBLISHED</option>

--- a/components/com_menus/forms/filter_items.xml
+++ b/components/com_menus/forms/filter_items.xml
@@ -14,7 +14,7 @@
 			type="status"
 			label="COM_MENUS_FILTER_PUBLISHED"
 			description="COM_MENUS_FILTER_PUBLISHED_DESC"
-			filter="*,0,1,-2"
+			optionsFilter="*,0,1,-2"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_PUBLISHED</option>

--- a/libraries/src/Form/Field/PredefinedlistField.php
+++ b/libraries/src/Form/Field/PredefinedlistField.php
@@ -52,6 +52,41 @@ abstract class PredefinedlistField extends ListField
 	protected $translate = true;
 
 	/**
+	 * Allows to use only specific values of the predefined list
+	 *
+	 * @var  array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $optionsFilter = [];
+
+	/**
+	 * Method to attach a Form object to the field.
+	 *
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
+	 * @param   mixed             $value    The form field value to validate.
+	 * @param   string            $group    The field name group control value. This acts as an array container for the field.
+	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the
+	 *                                      full field name would end up being "bar[foo]".
+	 *
+	 * @return  boolean  True on success.
+	 *
+	 * @see     \Joomla\CMS\Form\FormField::setup()
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function setup(\SimpleXMLElement $element, $value, $group = null)
+	{
+		$return = parent::setup($element, $value, $group);
+
+		if ($return)
+		{
+			// Note: $this->element['optionsFilter'] is not cast to string here to allow empty string value.
+			$this->optionsFilter = $this->element['optionsFilter'] ? explode(',', (string) $this->element['optionsFilter']) : [];
+		}
+
+		return $return;
+	}
+
+	/**
 	 * Method to get the options to populate list
 	 *
 	 * @return  array  The field option objects.
@@ -70,12 +105,9 @@ abstract class PredefinedlistField extends ListField
 
 			$options = array();
 
-			// Allow to only use specific values of the predefined list
-			$filter = isset($this->element['filter']) ? explode(',', $this->element['filter']) : array();
-
 			foreach ($this->predefinedOptions as $value => $text)
 			{
-				if (empty($filter) || \in_array($value, $filter))
+				if (empty($this->optionsFilter) || \in_array($value, $this->optionsFilter))
 				{
 					$text = $this->translate ? Text::_($text) : $text;
 


### PR DESCRIPTION
### Summary of Changes

Introduced `optionsFilter` property to solve `filter` attribute conflict in `Joomla\CMS\Form\Field\PredefinedlistField` field.

### Testing Instructions

Go to a page containing the affected field. E.g. module list in backend.
Expand search tools.
Check that `Archived` option doesn't appear in `- Select Status -` field.

### Expected result

Works like before.

### Documentation Changes Required

Yes. The B/C break should be listed here https://docs.joomla.org/Potential_backward_compatibility_issues_in_Joomla_4#Form.