### PR TITLE
[4.0] Fix Atum heights

### DIFF
--- a/administrator/modules/mod_title/tmpl/default.php
+++ b/administrator/modules/mod_title/tmpl/default.php
@@ -10,7 +10,7 @@
 defined('_JEXEC') or die;
 ?>
 <?php if (!empty($title)) : ?>
-<div class="d-flex px-3">
+<div class="d-flex align-items-center px-3">
 	<div class="container-title">
 		<?php echo $title; ?>
 	</div>

--- a/administrator/templates/atum/error_full.php
+++ b/administrator/templates/atum/error_full.php
@@ -84,7 +84,7 @@ HTMLHelper::_('atum.rootcolors', $this->params);
 <header id="header" class="header">
 	<div class="d-flex">
 		<div class="header-title d-flex">
-			<div class="d-flex">
+			<div class="d-flex align-items-center">
 				<a class="logo" href="<?php echo Route::_('index.php'); ?>"
 				   aria-label="<?php echo Text::_('TPL_ATUM_BACK_TO_CONTROL_PANEL'); ?>">
 					<img src="<?php echo $siteLogo; ?>" alt="">

--- a/administrator/templates/atum/error_login.php
+++ b/administrator/templates/atum/error_login.php
@@ -82,7 +82,7 @@ HTMLHelper::_('atum.rootcolors', $this->params);
 <header id="header" class="header">
 	<div class="d-flex">
 		<div class="header-title d-flex mr-auto">
-			<div class="d-flex">
+			<div class="d-flex align-items-center">
 				<?php // No home link in edit mode (so users can not jump out) and control panel (for a11y reasons) ?>
 				<div class="logo">
 					<img src="<?php echo $siteLogo; ?>" alt="<?php echo $logoAlt; ?>">

--- a/administrator/templates/atum/index.php
+++ b/administrator/templates/atum/index.php
@@ -92,7 +92,7 @@ HTMLHelper::_('atum.rootcolors', $this->params);
 <header id="header" class="header">
 	<div class="d-flex">
 		<div class="header-title d-flex">
-			<div class="d-flex">
+			<div class="d-flex align-items-center">
 				<?php // No home link in edit mode (so users can not jump out) and control panel (for a11y reasons) ?>
 				<?php if ($hiddenMenu || $cpanel) : ?>
 					<div class="logo">

--- a/administrator/templates/atum/login.php
+++ b/administrator/templates/atum/login.php
@@ -91,7 +91,7 @@ Text::script('JGLOBAL_WARNCOOKIES');
 <header id="header" class="header">
 	<div class="d-flex">
 		<div class="header-title d-flex">
-			<div class="d-flex">
+			<div class="d-flex align-items-center">
 				<?php // No home link in edit mode (so users can not jump out) and control panel (for a11y reasons) ?>
 				<div class="logo">
 					<img src="<?php echo $siteLogo; ?>" alt="<?php echo $logoAlt; ?>">

--- a/administrator/templates/atum/scss/_variables.scss
+++ b/administrator/templates/atum/scss/_variables.scss
@@ -100,9 +100,6 @@ $input-btn-padding-x:              1rem;
 $input-max-width:                  100%;
 $btn-disabled-opacity:             .4;
 
-// Header
-$header-height:                    3.5rem;
-
 // Toolbar
 $atum-toolbar-line-height:         2.45rem;
 

--- a/administrator/templates/atum/scss/blocks/_global.scss
+++ b/administrator/templates/atum/scss/blocks/_global.scss
@@ -10,11 +10,10 @@ html {
 
 body {
   min-height: 100%;
-}
-
-body {
+  display: flex;
   padding: 0;
   margin: 0;
+  flex-direction: column;
 
   &.monochrome {
     filter: grayscale(1);
@@ -101,7 +100,6 @@ caption {
 
 body .container-main {
   position: relative;
-  min-height: calc(100vh - #{$header-height} - 3px);
   padding-right: 0;
   padding-left: 0;
 

--- a/administrator/templates/atum/scss/blocks/_header.scss
+++ b/administrator/templates/atum/scss/blocks/_header.scss
@@ -31,7 +31,6 @@
   .logo {
     display: inline-block;
     width: $sidebar-width;
-    line-height: $header-height;
     transition: width .3s ease;
 
     &.small {
@@ -81,7 +80,6 @@
     margin: 0;
     overflow: hidden;
     font-size: 1.2rem;
-    line-height: $header-height;
     color: $white;
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/administrator/templates/atum/scss/blocks/_sidebar.scss
+++ b/administrator/templates/atum/scss/blocks/_sidebar.scss
@@ -1,6 +1,7 @@
 // Sidebar
 
 .wrapper {
+  flex-grow: 1;
   transition: all .3s ease;
 
   @include media-breakpoint-down(sm) {
@@ -95,11 +96,6 @@
       }
     }
   }
-}
-
-.menu-toggle-icon {
-  width: $header-height;
-  font-size: 1.7rem;
 }
 
 // Sidebar navigation


### PR DESCRIPTION
Pull Request for Issue #28276

### Summary of Changes

This fixes how the height of container is managed. Before, we used CSS's `calc` method but this posed problems. Now, we use flexbox and instruct the container to use up the remaining space.

### Testing Instructions

View the admin login and dashboard pages. Both should be the same with the exception of the login on desktop, which shoud now not have a scrollbar.
