### PR TITLE
[4.0] API language files

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/4.0.0-2020-09-03.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.0.0-2020-09-03.sql
@@ -1,0 +1,2 @@
+INSERT INTO `#__extensions` (`package_id`, `name`, `type`, `element`, `folder`, `client_id`, `enabled`, `access`, `protected`, `manifest_cache`, `params`, `checked_out`, `checked_out_time`, `ordering`, `state`)
+SELECT `extension_id`, 'English (en-GB)', 'language', 'en-GB', '', 3, 1, 1, 1, '', '', 0, NULL, 0, 0 FROM `#__extensions` WHERE `name` = 'English (en-GB) Language Pack';

--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2020-09-03.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2020-09-03.sql
@@ -1,0 +1,2 @@
+INSERT INTO "#__extensions" ("package_id", "name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "manifest_cache", "params", "checked_out", "checked_out_time", "ordering", "state")
+SELECT "extension_id", 'English (en-GB)', 'language', 'en-GB', '', 3, 1, 1, 1, '', '', 0, NULL, 0, 0 FROM "#__extensions" WHERE "name" = 'English (en-GB) Language Pack';

--- a/administrator/manifests/packages/pkg_en-GB.xml
+++ b/administrator/manifests/packages/pkg_en-GB.xml
@@ -17,6 +17,7 @@
 	<files>
 		<folder type="language" client="site" id="en-GB">language/en-GB</folder>
 		<folder type="language" client="administrator" id="en-GB">administrator/language/en-GB</folder>
+		<folder type="language" client="api" id="en-GB">api/language/en-GB</folder>
 	</files>
 	<updateservers>
 		<server type="collection" priority="1" name="Accredited Joomla! Translations">

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -15,6 +15,10 @@ files:
   - source: /api/language/en-GB/*.ini
     translation: /api/language/%locale%/%original_file_name%
     update_option: update_as_unapproved
+  - source: /api/language/en-GB/*.xml
+    translation: /language/%locale%/%original_file_name%
+    update_option: update_as_unapproved
+    content_segmentation: 0
   - source: /language/en-GB/*.ini
     translation: /language/%locale%/%original_file_name%
     update_option: update_as_unapproved

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -16,7 +16,7 @@ files:
     translation: /api/language/%locale%/%original_file_name%
     update_option: update_as_unapproved
   - source: /api/language/en-GB/*.xml
-    translation: /language/%locale%/%original_file_name%
+    translation: /api/language/%locale%/%original_file_name%
     update_option: update_as_unapproved
     content_segmentation: 0
   - source: /language/en-GB/*.ini

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -729,6 +729,8 @@ INSERT INTO `#__extensions` (`package_id`, `name`, `type`, `element`, `folder`, 
 SELECT `extension_id`, 'English (en-GB)', 'language', 'en-GB', '', 0, 1, 1, 1, '', '', 0, NULL, 0, 0 FROM `#__extensions` WHERE `name` = 'English (en-GB) Language Pack';
 INSERT INTO `#__extensions` (`package_id`, `name`, `type`, `element`, `folder`, `client_id`, `enabled`, `access`, `protected`, `manifest_cache`, `params`, `checked_out`, `checked_out_time`, `ordering`, `state`)
 SELECT `extension_id`, 'English (en-GB)', 'language', 'en-GB', '', 1, 1, 1, 1, '', '', 0, NULL, 0, 0 FROM `#__extensions` WHERE `name` = 'English (en-GB) Language Pack';
+INSERT INTO `#__extensions` (`package_id`, `name`, `type`, `element`, `folder`, `client_id`, `enabled`, `access`, `protected`, `manifest_cache`, `params`, `checked_out`, `checked_out_time`, `ordering`, `state`)
+SELECT `extension_id`, 'English (en-GB)', 'language', 'en-GB', '', 3, 1, 1, 1, '', '', 0, NULL, 0, 0 FROM `#__extensions` WHERE `name` = 'English (en-GB) Language Pack';
 -- --------------------------------------------------------
 
 --

--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -741,7 +741,8 @@ INSERT INTO "#__extensions" ("package_id", "name", "type", "element", "folder", 
 SELECT "extension_id", 'English (en-GB)', 'language', 'en-GB', '', 0, 1, 1, 1, '', '', 0, NULL, 0, 0 FROM "#__extensions" WHERE "name" = 'English (en-GB) Language Pack';
 INSERT INTO "#__extensions" ("package_id", "name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "manifest_cache", "params", "checked_out", "checked_out_time", "ordering", "state")
 SELECT "extension_id", 'English (en-GB)', 'language', 'en-GB', '', 1, 1, 1, 1, '', '', 0, NULL, 0, 0 FROM "#__extensions" WHERE "name" = 'English (en-GB) Language Pack';
-
+INSERT INTO "#__extensions" ("package_id", "name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "manifest_cache", "params", "checked_out", "checked_out_time", "ordering", "state")
+SELECT "extension_id", 'English (en-GB)', 'language', 'en-GB', '', 3, 1, 1, 1, '', '', 0, NULL, 0, 0 FROM "#__extensions" WHERE "name" = 'English (en-GB) Language Pack';
 --
 -- Table structure for table `#__fields`
 --


### PR DESCRIPTION
Adds the api language file to the extensions table and the manifest so it does not appear as discoverable on a new install

Probably just a code review

Pull Request for Issue #28270