### PR TITLE
[4.0] Fix module and article XTD frontend (follow-up)

### DIFF
--- a/components/com_content/forms/filter_articles.xml
+++ b/components/com_content/forms/filter_articles.xml
@@ -23,11 +23,11 @@
 		<field
 			name="category_id"
 			type="category"
-			label="JOPTION_FILTER_CATEGORY"
-			description="JOPTION_FILTER_CATEGORY_DESC"
+			label="JOPTION_SELECT_CATEGORY"
 			multiple="true"
-			class="multipleCategories"
 			extension="com_content"
+			layout="joomla.form.field.list-fancy-select"
+			hint="JOPTION_SELECT_CATEGORY"
 			onchange="this.form.submit();"
 			published="0,1,2"
 		/>
@@ -35,20 +35,20 @@
 		<field
 			name="access"
 			type="accesslevel"
-			label="JOPTION_FILTER_ACCESS"
-			description="JOPTION_FILTER_ACCESS_DESC"
+			label="JOPTION_SELECT_ACCESS"
 			multiple="true"
-			class="multipleAccessLevels"
+			layout="joomla.form.field.list-fancy-select"
+			hint="JOPTION_SELECT_ACCESS"
 			onchange="this.form.submit();"
 		/>
 
 		<field
 			name="author_id"
 			type="author"
-			label="COM_CONTENT_FILTER_AUTHOR"
-			description="COM_CONTENT_FILTER_AUTHOR_DESC"
+			label="JOPTION_SELECT_AUTHOR"
 			multiple="true"
-			class="multipleAuthors"
+			layout="joomla.form.field.list-fancy-select"
+			hint="JOPTION_SELECT_AUTHOR"
 			onchange="this.form.submit();"
 			>
 			<option value="0">JNONE</option>

--- a/components/com_modules/forms/filter_modules.xml
+++ b/components/com_modules/forms/filter_modules.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<form>
-	<fieldset addfieldprefix="Joomla\Component\Modules\Administrator\Field" />
-
+<form addfieldprefix="Joomla\Component\Modules\Administrator\Field">
 	<fields name="filter">
 		<field
 			name="search"


### PR DESCRIPTION
Follow-up on https://github.com/joomla/joomla-cms/pull/28248

### Summary of Changes
Fixing the frontend filters xml for the Module and Article XTD

### Testing Instructions

(Make sure both https://github.com/joomla/joomla-cms/pull/28248 and https://github.com/joomla/joomla-cms/pull/28259 have already updated your test site)

Edit an article in frontend. Select CMS Content and then Module ad also Article

### Before patch
<img width="1308" alt="Screen Shot 2020-03-06 at 10 42 19_after" src="https://user-images.githubusercontent.com/869724/76072763-d74c7000-5f98-11ea-9b90-7b1786606313.png">
<img width="1340" alt="Screen Shot 2020-03-06 at 10 41 59" src="https://user-images.githubusercontent.com/869724/76072774-da476080-5f98-11ea-8e2c-a2b6b946edf6.png">


### After patch
<img width="1438" alt="Screen Shot 2020-03-09 at 11 04 48" src="https://user-images.githubusercontent.com/869724/76203746-6eaefe80-61f7-11ea-85d4-f2832c5d9e63.png">
<img width="1435" alt="Screen Shot 2020-03-09 at 11 04 29" src="https://user-images.githubusercontent.com/869724/76203756-71a9ef00-61f7-11ea-8d7e-49c52571afaa.png">

### Note
After this is merged, we will need to deal with CSS tweaks (RTL) but not only as the fancy select fields do not have the same height as the "normal" custom-select ones.

Will try but may need help. I count on you @angieradtke @chmst @ciar4n :)
