### PR TITLE
[4.0] webauthn plugin as core

### DIFF
--- a/libraries/src/Extension/ExtensionHelper.php
+++ b/libraries/src/Extension/ExtensionHelper.php
@@ -282,6 +282,7 @@ class ExtensionHelper
 		array('plugin', 'skipto', 'system', 0),
 		array('plugin', 'stats', 'system', 0),
 		array('plugin', 'updatenotification', 'system', 0),
+		array('plugin', 'webauthn', 'system', 0),
 
 		// Core plugin extensions - two factor authentication
 		array('plugin', 'totp', 'twofactorauth', 0),


### PR DESCRIPTION
Simple PR to add the new webauthn plugin to the list of core extensions.

To test go to Extensions manage and filter on non-core extensions
