### PR TITLE
[4.0] webauthn description

### DIFF
--- a/administrator/language/en-GB/plg_system_webauthn.ini
+++ b/administrator/language/en-GB/plg_system_webauthn.ini
@@ -4,7 +4,7 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_SYSTEM_WEBAUTHN="System - WebAuthn Passwordless Login"
-PLG_SYSTEM_WEBAUTHN_DESCRIPTION="Enables passwordless authentication using the W3C Web Authentication (WebAuthn) API."
+PLG_SYSTEM_WEBAUTHN_DESCRIPTION="Enables passwordless authentication using the W3C Web Authentication (WebAuthn) API. Please note that the WebAuthn tab in the user profile editor and the WebAuthn login buttons will only be displayed if the user is accessing the site over HTTPS. Furthermore, registering WebAuthn authenticators and using them to log into your site will only work when your site is using a valid certificate, signed by a Certificate Authority the user's browser trusts."
 
 PLG_SYSTEM_WEBAUTHN_LOGIN_LABEL="Web Authentication"
 PLG_SYSTEM_WEBAUTHN_LOGIN_DESC="Login without a password using the W3C Web Authentication (WebAuthn) standard in compatible browsers. You need to have already set up WebAuthn authentication in your user profile."


### PR DESCRIPTION
This simple PR syncs the plugin description from the sys.ini to the .ini language files.

This is really important because otherwise we dont see the essential message about https in the plugin manager

The actual text can be tweaked etc in a later PR - this is just about displaying it