### PR TITLE
[4.0] Switcher rounded etc

### DIFF
--- a/administrator/templates/atum/scss/blocks/_switcher.scss
+++ b/administrator/templates/atum/scss/blocks/_switcher.scss
@@ -1,0 +1,14 @@
+.switcher {
+  .toggle-outside {
+    border: $input-border;
+    border-radius: $border-radius;
+
+    &:focus {
+      box-shadow: $input-box-shadow;
+    }
+  }
+  input:focus ~ .toggle-outside {
+      border-color: $focuscolor;
+      box-shadow: $focusshadow;
+    }
+  }

--- a/administrator/templates/atum/scss/template.scss
+++ b/administrator/templates/atum/scss/template.scss
@@ -44,6 +44,7 @@
 @import "blocks/lists";
 @import "blocks/sidebar";
 @import "blocks/sidebar-nav";
+@import "blocks/switcher";
 @import "blocks/toolbar";
 @import "blocks/treeselect";
 @import "blocks/utilities";


### PR DESCRIPTION
With the change to rounded corners this changes the switcher so that the corners are rounded, border is darker and the box shadow is blue not grey

npm i or node build.js --compile-css

### before
![before](https://user-images.githubusercontent.com/1296369/76209065-e598c700-61f8-11ea-8040-716e1ff3a8c3.gif)


### after
![after](https://user-images.githubusercontent.com/1296369/76208975-aec2b100-61f8-11ea-9a29-9cf0a83bcb9c.gif)
