### PR TITLE
[4.0] Add SVG check for logo

### DIFF
--- a/build/media_source/templates/atum/js/template.es6.js
+++ b/build/media_source/templates/atum/js/template.es6.js
@@ -73,6 +73,12 @@
       const imgClass = img.getAttribute('class');
       const imgURL = img.getAttribute('src');
 
+      // Check if we're manipulating a SVG file.
+      if (imgURL.substr(imgURL.length - 4).toLowerCase() !== '.svg')
+      {
+        return;
+      }
+
       Joomla.request({
         url: imgURL,
         method: 'GET',

--- a/build/media_source/templates/atum/js/template.es6.js
+++ b/build/media_source/templates/atum/js/template.es6.js
@@ -74,8 +74,7 @@
       const imgURL = img.getAttribute('src');
 
       // Check if we're manipulating a SVG file.
-      if (imgURL.substr(imgURL.length - 4).toLowerCase() !== '.svg')
-      {
+      if (imgURL.substr(imgURL.length - 4).toLowerCase() !== '.svg') {
         return;
       }
 


### PR DESCRIPTION
Pull Request for Issue #28226.

### Summary of Changes

Adds file extension check to prevent issues when logo is not SVG.

### Testing Instructions
`node build.js --compile-js` required.

Edit Atum template style.
Select a logo.
Inspect browser console.

### Expected result

No errors.

### Actual result

>XML Parsing Error: not well-formed
Location: http://localhost/joomla-cms/administrator/index.php?option=com_templates&view=style&layout=edit&id=10
Line Number 1, Column 1: index.php:1:1
>TypeError: svg is undefined template.js:95:11


### Documentation Changes Required

No.

### Additional Comments

I've picked what I think is the cleanest approach as it avoids unnecessary request when image is not SVG. It's somewhat limiting (the file doesn't need to have an extension) but works for our case. Alternatively, we could make the request but wrap it in try/catch or try to figure out the response some other way.