### PR TITLE
[4.0] Move addIncludePath() back to trait

### DIFF
--- a/libraries/src/MVC/Model/BaseDatabaseModel.php
+++ b/libraries/src/MVC/Model/BaseDatabaseModel.php
@@ -16,7 +16,6 @@ use Joomla\CMS\Cache\Exception\CacheExceptionInterface;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Extension\ComponentInterface;
 use Joomla\CMS\Factory;
-use Joomla\CMS\Filesystem\Path;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Factory\LegacyFactory;
 use Joomla\CMS\MVC\Factory\MVCFactoryAwareTrait;

--- a/libraries/src/MVC/Model/BaseModel.php
+++ b/libraries/src/MVC/Model/BaseModel.php
@@ -10,7 +10,6 @@ namespace Joomla\CMS\MVC\Model;
 
 \defined('JPATH_PLATFORM') or die;
 
-use Joomla\CMS\Filesystem\Path;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Object\CMSObject;
 
@@ -31,14 +30,6 @@ abstract class BaseModel extends CMSObject implements ModelInterface, StatefulMo
 	 * @since  4.0.0
 	 */
 	protected $name;
-
-	/**
-	 * The include paths
-	 *
-	 * @var   array
-	 * @since  4.0.0
-	 */
-	protected static $paths;
 
 	/**
 	 * Constructor
@@ -74,54 +65,6 @@ abstract class BaseModel extends CMSObject implements ModelInterface, StatefulMo
 		{
 			$this->__state_set = true;
 		}
-	}
-
-	/**
-	 * Add a directory where \JModelLegacy should search for models. You may
-	 * either pass a string or an array of directories.
-	 *
-	 * @param   mixed   $path    A path or array[sting] of paths to search.
-	 * @param   string  $prefix  A prefix for models.
-	 *
-	 * @return  array  An array with directory elements. If prefix is equal to '', all directories are returned.
-	 *
-	 * @since       3.0
-	 * @deprecated  5.0 See LeagcyModelLoaderTrait\getInstance
-	 */
-	public static function addIncludePath($path = '', $prefix = '')
-	{
-		if (!isset(self::$paths))
-		{
-			self::$paths = array();
-		}
-
-		if (!isset(self::$paths[$prefix]))
-		{
-			self::$paths[$prefix] = array();
-		}
-
-		if (!isset(self::$paths['']))
-		{
-			self::$paths[''] = array();
-		}
-
-		if (!empty($path))
-		{
-			foreach ((array) $path as $includePath)
-			{
-				if (!\in_array($includePath, self::$paths[$prefix]))
-				{
-					array_unshift(self::$paths[$prefix], Path::clean($includePath));
-				}
-
-				if (!\in_array($includePath, self::$paths['']))
-				{
-					array_unshift(self::$paths[''], Path::clean($includePath));
-				}
-			}
-		}
-
-		return self::$paths[$prefix];
 	}
 
 	/**

--- a/libraries/src/MVC/Model/LegacyModelLoaderTrait.php
+++ b/libraries/src/MVC/Model/LegacyModelLoaderTrait.php
@@ -42,7 +42,7 @@ trait LegacyModelLoaderTrait
 	 * @return  array  An array with directory elements. If prefix is equal to '', all directories are returned.
 	 *
 	 * @since       3.0
-	 * @deprecated  5.0 See LeagcyModelLoaderTrait\getInstance
+	 * @deprecated  5.0 See LegacyModelLoaderTrait\getInstance
 	 */
 	public static function addIncludePath($path = '', $prefix = '')
 	{

--- a/libraries/src/MVC/Model/LegacyModelLoaderTrait.php
+++ b/libraries/src/MVC/Model/LegacyModelLoaderTrait.php
@@ -23,6 +23,56 @@ use Joomla\CMS\Table\Table;
  */
 trait LegacyModelLoaderTrait
 {
+	/**
+	 * The include paths
+	 *
+	 * @var   array
+	 * @since  4.0.0
+	 */
+	protected static $paths = [];
+
+	/**
+	 * Add a directory where \JModelLegacy should search for models. You may
+	 * either pass a string or an array of directories.
+	 *
+	 * @param   mixed   $path    A path or array[string] of paths to search.
+	 * @param   string  $prefix  A prefix for models.
+	 *
+	 * @return  array  An array with directory elements. If prefix is equal to '', all directories are returned.
+	 *
+	 * @since       3.0
+	 * @deprecated  5.0 See LeagcyModelLoaderTrait\getInstance
+	 */
+	public static function addIncludePath($path = '', $prefix = '')
+	{
+		if (!isset(self::$paths[$prefix]))
+		{
+			self::$paths[$prefix] = array();
+		}
+
+		if (!isset(self::$paths['']))
+		{
+			self::$paths[''] = array();
+		}
+
+		if (!empty($path))
+		{
+			foreach ((array) $path as $includePath)
+			{
+				if (!\in_array($includePath, self::$paths[$prefix]))
+				{
+					array_unshift(self::$paths[$prefix], Path::clean($includePath));
+				}
+
+				if (!\in_array($includePath, self::$paths['']))
+				{
+					array_unshift(self::$paths[''], Path::clean($includePath));
+				}
+			}
+		}
+
+		return self::$paths[$prefix];
+	}
 
 	/**
 	 * Create the filename for a resource

--- a/libraries/src/MVC/Model/LegacyModelLoaderTrait.php
+++ b/libraries/src/MVC/Model/LegacyModelLoaderTrait.php
@@ -26,8 +26,9 @@ trait LegacyModelLoaderTrait
 	/**
 	 * The include paths
 	 *
-	 * @var   array
-	 * @since  4.0.0
+	 * @var         array
+	 * @since       4.0.0
+	 * @deprecated  5.0 Will be removed without replacement
 	 */
 	protected static $paths = [];
 


### PR DESCRIPTION
### Summary of Changes

Moves the `addIncludePath()` method back to `Joomla\CMS\MVC\Model\LegacyModelLoaderTrait`.

### Testing Instructions

Install Weblinks https://github.com/joomla-extensions/weblinks/releases/tag/3.7.0
Run this code somewhere:
```
\JModelLegacy::addIncludePath(JPATH_SITE . '/components/com_weblinks/models');
$model = \JModelLegacy::getInstance('Weblink', 'WeblinksModel', ['ignore_request' => true]);
```
Check the value of `$model`.

### Expected result

It's an instance of `WeblinksModelWeblink`.

### Documentation Changes Required

No.