### PR TITLE
Make number of items as fallback instead of primary suffix

### DIFF
--- a/libraries/src/Language/Text.php
+++ b/libraries/src/Language/Text.php
@@ -217,7 +217,9 @@ class Text
 		// Try the key from the language plural potential suffixes
 		$found = false;
 		$suffixes = $lang->getPluralSuffixes((int) $n);
-		array_unshift($suffixes, (int) $n);
+
+		// Add the number of items to the list of potential suffixes.
+		$suffixes[] = (int) $n);
 
 		foreach ($suffixes as $suffix)
 		{

--- a/libraries/src/Language/Text.php
+++ b/libraries/src/Language/Text.php
@@ -219,7 +219,7 @@ class Text
 		$suffixes = $lang->getPluralSuffixes((int) $n);
 
 		// Add the number of items to the list of potential suffixes.
-		$suffixes[] = (int) $n);
+		$suffixes[] = (int) $n;
 
 		foreach ($suffixes as $suffix)
 		{


### PR DESCRIPTION
The Translator of the Welsh language pack noticed that his suffixes specified in the localise.php file are ignored by Joomla. Another suffix is used.
After investigation, we found that Joomla actually tries first to find a plural string with the actual number of items as suffix (eg for 3 items it tries with `_3`) and only if that doesn't exist it tries with the suffix specified by the language pack.

### Summary of Changes
This PR changes the behavior so the suffix from the language pack (localise.php) takes priority over the actual number.


### Testing Instructions
* Install the welsh language pack (http://www.joomla.cymru/downloads/cy-GB_joomla_lang_full_3.9.16v2.zip). This one has special strings in it for unpublishing categories
* Unpublish three categories


### Expected result
You should get the response `Wedi dad-gyhoeddi %d categori.(FEW)` from string `COM_CATEGORIES_N_ITEMS_UNPUBLISHED_4`


### Actual result
You get the response `Wedi dad-gyhoeddi %d gategori.(TWO)` from string `COM_CATEGORIES_N_ITEMS_UNPUBLISHED_3`


### Documentation Changes Required
Don't know.