### PR TITLE
[4.0] Tag menu items

### DIFF
--- a/components/com_tags/tmpl/tag/default.xml
+++ b/components/com_tags/tmpl/tag/default.xml
@@ -26,6 +26,7 @@
 				name="types"
 				type="contenttype"
 				label="COM_TAGS_FIELD_TYPE_LABEL"
+				layout="joomla.form.field.list-fancy-select"
 				multiple="true"
 			/>
 

--- a/components/com_tags/tmpl/tag/list.xml
+++ b/components/com_tags/tmpl/tag/list.xml
@@ -26,6 +26,7 @@
 				name="types"
 				type="contenttype"
 				label="COM_TAGS_FIELD_TYPE_LABEL"
+				layout="joomla.form.field.list-fancy-select"
 				multiple="true"
 			/>
 


### PR DESCRIPTION
These two menu items
- Compact list of all tags
- Tagged items
have an option to select the content type. This is a multiselect field so should be using the fancy-select layout for the list and not the regular list

### before
![image](https://user-images.githubusercontent.com/1296369/76557527-a89c3100-6493-11ea-899f-a293c49bdae4.png)

### after
![image](https://user-images.githubusercontent.com/1296369/76557508-9cb06f00-6493-11ea-8c54-efff21511625.png)
