### PR TITLE
[4.0] Typo in Installer JavaScript File 

### DIFF
--- a/installation/template/js/setup.js
+++ b/installation/template/js/setup.js
@@ -30,7 +30,7 @@ Joomla.setlanguage = function(form) {
 
       if (response.error) {
         loaderElement.parentNode.removeChild(loaderElement);
-        Joomla.renderMessages({'error': [response.message]});
+        Joomla.renderMessages({'error': [response.error]});
       } else {
         loaderElement.parentNode.removeChild(loaderElement);
         Joomla.goToPage(response.data.view, true);


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Since the `if query` checks whether `response.error` exists, it should also be output. I corrected that.


### Testing Instructions
Code review

