### PR TITLE
[4.0] Tag menu description

### DIFF
--- a/components/com_tags/tmpl/tag/list.xml
+++ b/components/com_tags/tmpl/tag/list.xml
@@ -156,7 +156,6 @@
 				name="tag_list_item_maximum_characters"
 				type="number"
 				label="COM_TAGS_LIST_MAX_CHARACTERS_LABEL"
-				description="COM_TAGS_LIST_MAX_CHARACTERS_DESC"
 				filter="integer"
 				useglobal="true"
 			/>


### PR DESCRIPTION
removes reference to a description in the compact tagged items menu

### before
![image](https://user-images.githubusercontent.com/1296369/76598262-6ce88200-64fa-11ea-8bd8-b32729edb7e8.png)

### after
![image](https://user-images.githubusercontent.com/1296369/76598283-75d95380-64fa-11ea-8beb-5db6fe00ef83.png)
