### PR TITLE
[3] com_tags. view=tag. If 1 tag displayed => adapt metadata (e.g. robots) of this tag

### DIFF
--- a/components/com_tags/views/tag/view.html.php
+++ b/components/com_tags/views/tag/view.html.php
@@ -99,13 +99,6 @@ class TagsViewTag extends JViewLegacy
 		// Flag indicates to not add limitstart=0 to URL
 		$pagination->hideEmptyLimitstart = true;
 
-		/*
-		 * // Change to catch
-		 * if (count($errors = $this->get('Errors'))) {
-		 * JError::raiseError(500, implode("\n", $errors));
-		 * return false;
-		 */
-
 		// Check whether access level allows access.
 		// @TODO: Should already be computed in $item->params->get('access-view')
 		$user   = JFactory::getUser();
@@ -122,9 +115,10 @@ class TagsViewTag extends JViewLegacy
 			if (!empty($itemElement))
 			{
 				$temp = new Registry($itemElement->params);
-				$itemElement->params = clone $params;
+				$itemElement->params   = clone $params;
 				$itemElement->params->merge($temp);
-				$itemElement->params = (array) json_decode($itemElement->params);
+				$itemElement->params   = (array) json_decode($itemElement->params);
+				$itemElement->metadata = new Registry($itemElement->metadata);
 			}
 		}
 
@@ -327,8 +321,16 @@ class TagsViewTag extends JViewLegacy
 			}
 		}
 
-		// @TODO: create tag feed document
-		// Add alternative feed link
+		if (count($this->item) === 1)
+		{
+			foreach ($this->item[0]->metadata->toArray() as $k => $v)
+			{
+				if ($v)
+				{
+					$this->document->setMetadata($k, $v);
+				}
+			}
+		}
 
 		if ($this->params->get('show_feed_link', 1) == 1)
 		{


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/20128

### Testing Instructions
- Create a tag `TagA`
- Go to tabulator "Publishing" and set "Robots" to `noindex,nofollow`
- Add `TagA` to an article, set "Show Tags": `Show`

- Open article in front-end and click the linked tag `TagA` to open a com_tags view with just 1 tag.

OR

- Create a menu item of type `Tagged Items` with only `TagA` selected and open it in front-end.
With this variation you can test more detailled. Robots of menu item overritten? Nothiung changes when 2 Tags selected?

### Expected result
- `<meta name="robots" content="noindex, nofollow" />` (view source code of page)
- Comparable to the behavior of a single article view.

### Actual result
- Not the robots meta-tag defined for the `TagA`
