### PR TITLE
[3.10] Mark jQuery UI as deprecated in j3.10 for 4

### DIFF
--- a/libraries/cms/html/jquery.php
+++ b/libraries/cms/html/jquery.php
@@ -78,7 +78,8 @@ abstract class JHtmlJquery
 	 *
 	 * @return  void
 	 *
-	 * @since   3.0
+	 * @since       3.0
+	 * @deprecated  4.0  jQuery UI will be removed from Joomla 4 without replacement.
 	 */
 	public static function ui(array $components = array('core'), $debug = null)
 	{

--- a/libraries/cms/html/sortablelist.php
+++ b/libraries/cms/html/sortablelist.php
@@ -12,7 +12,8 @@ defined('JPATH_PLATFORM') or die;
 /**
  * HTML utility class for creating a sortable table list
  *
- * @since  3.0
+ * @since       3.0
+ * @deprecated  5.0  Sortable List will be deprecated in favour of a new dragula script in 4.0
  */
 abstract class JHtmlSortablelist
 {
@@ -37,6 +38,7 @@ abstract class JHtmlSortablelist
 	 * @since   3.0
 	 *
 	 * @throws  InvalidArgumentException
+	 * @deprecated  5.0  In Joomla 4 call JHtml::_('dragablelist.dragable') and add a class of js-draggable to the tbody element of the table
 	 */
 	public static function sortable($tableId, $formId, $sortDir = 'asc', $saveOrderingUrl = null, $proceedSaveOrderButton = true, $nestedList = false)
 	{

--- a/libraries/cms/html/sortablelist.php
+++ b/libraries/cms/html/sortablelist.php
@@ -20,6 +20,7 @@ abstract class JHtmlSortablelist
 	/**
 	 * @var    array  Array containing information for loaded files
 	 * @since  3.0
+	 * @deprecated  4.0  This property will be removed without replacement
 	 */
 	protected static $loaded = array();
 


### PR DESCRIPTION
Deprecation for PR in https://github.com/joomla/joomla-cms/pull/28341

### Summary of Changes
Marks jQuery.UI as deprecated for J4 (merge this once the PR mentioned above is merged.

### Testing Instructions
Code Review

### Documentation Changes Required
N/A