### PR TITLE
[4.0] [Installation] Fix minimum required version check when creating a new database

### DIFF
--- a/installation/src/Helper/DatabaseHelper.php
+++ b/installation/src/Helper/DatabaseHelper.php
@@ -21,6 +21,33 @@ use Joomla\Database\DatabaseInterface;
 abstract class DatabaseHelper
 {
 	/**
+	 * The minimum database server version for MariaDB databases as required by the CMS.
+	 * This is not necessarily equal to what the database driver requires.
+	 *
+	 * @var    string
+	 * @since  4.0.0
+	 */
+	protected static $dbMinimumMariaDb = '10.1';
+
+	/**
+	 * The minimum database server version for MySQL databases as required by the CMS.
+	 * This is not necessarily equal to what the database driver requires.
+	 *
+	 * @var    string
+	 * @since  4.0.0
+	 */
+	protected static $dbMinimumMySql = '5.6';
+
+	/**
+	 * The minimum database server version for PostgreSQL databases as required by the CMS.
+	 * This is not necessarily equal to what the database driver requires.
+	 *
+	 * @var    string
+	 * @since  4.0.0
+	 */
+	protected static $dbMinimumPostgreSql = '11.0';
+
+	/**
 	 * Method to get a database driver.
 	 *
 	 * @param   string   $driver    The database driver to use.
@@ -108,5 +135,46 @@ abstract class DatabaseHelper
 			'dbsslca'               => $options->db_sslca,
 			'dbsslcipher'           => $options->db_sslcipher,
 		];
+	}
+
+	/**
+	 * Get the minimum required databse server version.
+	 *
+	 * @param   DatabaseDriver  $db       Database object
+	 * @param   \stdClass       $options  The session options
+	 *
+	 * @return  string  The minimum required database server version.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public static function getMinimumServerVersion($db, $options)
+	{
+		// Get minimum database version required by the database driver
+		$minDbVersionRequired = $db->getMinimum();
+
+		// Get minimum database version required by the CMS
+		if (in_array($options->db_type, ['mysql', 'mysqli']))
+		{
+			if ($db->isMariaDb())
+			{
+				$minDbVersionCms = self::$dbMinimumMariaDb;
+			}
+			else
+			{
+				$minDbVersionCms = self::$dbMinimumMySql;
+			}
+		}
+		else
+		{
+			$minDbVersionCms = self::$dbMinimumPostgreSql;
+		}
+
+		// Use most restrictive, i.e. largest minimum database version requirement
+		if (version_compare($minDbVersionCms, $minDbVersionRequired) > 0)
+		{
+			$minDbVersionRequired = $minDbVersionCms;
+		}
+
+		return $minDbVersionRequired;
 	}
 }

--- a/installation/src/Helper/DatabaseHelper.php
+++ b/installation/src/Helper/DatabaseHelper.php
@@ -138,7 +138,7 @@ abstract class DatabaseHelper
 	}
 
 	/**
-	 * Get the minimum required databse server version.
+	 * Get the minimum required database server version.
 	 *
 	 * @param   DatabaseDriver  $db       Database object
 	 * @param   \stdClass       $options  The session options

--- a/installation/src/Model/DatabaseModel.php
+++ b/installation/src/Model/DatabaseModel.php
@@ -475,7 +475,7 @@ class DatabaseModel extends BaseInstallationModel
 			{
 				throw new \RuntimeException(
 					Text::sprintf(
-						'INSTL_DATABASE_INVALID_' . strtoupper($options->db_type) . '_VERSION',
+						'INSTL_DATABASE_INVALID_' . strtoupper($type) . '_VERSION',
 						$minDbVersionRequired,
 						$db_version
 					)

--- a/installation/src/Model/DatabaseModel.php
+++ b/installation/src/Model/DatabaseModel.php
@@ -455,17 +455,44 @@ class DatabaseModel extends BaseInstallationModel
 			}
 		}
 
-		if (!$db->isMinimumVersion())
+		// Get required database version
+		$minDbVersionRequired = DatabaseHelper::getMinimumServerVersion($db, $options);
+
+		// Check minimum database version
+		if (version_compare($db_version, $minDbVersionRequired) < 0)
 		{
 			if (in_array($type, ['mysql', 'mysqli']) && $db->isMariaDb())
 			{
-				throw new \RuntimeException(Text::sprintf('INSTL_DATABASE_INVALID_MARIADB_VERSION', $db->getMinimum(), $db_version));
+				throw new \RuntimeException(
+					Text::sprintf(
+						'INSTL_DATABASE_INVALID_MARIADB_VERSION',
+						$minDbVersionRequired,
+						$db_version
+					)
+				);
 			}
 			else
 			{
 				throw new \RuntimeException(
-					Text::sprintf('INSTL_DATABASE_INVALID_' . strtoupper($type) . '_VERSION', $db->getMinimum(), $db_version)
+					Text::sprintf(
+						'INSTL_DATABASE_INVALID_' . strtoupper($options->db_type) . '_VERSION',
+						$minDbVersionRequired,
+						$db_version
+					)
 				);
+			}
+		}
+
+		// Check database connection encryption
+		if ($options->db_encryption !== 0 && empty($db->getConnectionEncryption()))
+		{
+			if ($db->isConnectionEncryptionSupported())
+			{
+				throw new \RuntimeException(Text::_('INSTL_DATABASE_ENCRYPTION_MSG_CONN_NOT_ENCRYPT'));
+			}
+			else
+			{
+				throw new \RuntimeException(Text::_('INSTL_DATABASE_ENCRYPTION_MSG_SRV_NOT_SUPPORTS'));
 			}
 		}
 

--- a/installation/src/Model/SetupModel.php
+++ b/installation/src/Model/SetupModel.php
@@ -29,33 +29,6 @@ use Joomla\Utilities\ArrayHelper;
 class SetupModel extends BaseInstallationModel
 {
 	/**
-	 * The minimum database server version for MariaDB databases as required by the CMS.
-	 * This is not necessarily equal to what the database driver requires.
-	 *
-	 * @var    string
-	 * @since  4.0.0
-	 */
-	protected static $dbMinimumMariaDb = '10.1';
-
-	/**
-	 * The minimum database server version for MySQL databases as required by the CMS.
-	 * This is not necessarily equal to what the database driver requires.
-	 *
-	 * @var    string
-	 * @since  4.0.0
-	 */
-	protected static $dbMinimumMySql = '5.6';
-
-	/**
-	 * The minimum database server version for PostgreSQL databases as required by the CMS.
-	 * This is not necessarily equal to what the database driver requires.
-	 *
-	 * @var    string
-	 * @since  4.0.0
-	 */
-	protected static $dbMinimumPostgreSql = '11.0';
-
-	/**
 	 * Get the current setup options from the session.
 	 *
 	 * @return  array  An array of options from the session.
@@ -556,57 +529,30 @@ class SetupModel extends BaseInstallationModel
 
 		$dbVersion = $db->getVersion();
 
-		// Get minimum database version required by the database driver
-		$minDbVersionRequired = $db->getMinimum();
-
-		// Get minimum database version required by the CMS
-		if (in_array($options->db_type, ['mysql', 'mysqli']))
-		{
-			if ($db->isMariaDb())
-			{
-				$minDbVersionCms = self::$dbMinimumMariaDb;
-			}
-			else
-			{
-				$minDbVersionCms = self::$dbMinimumMySql;
-			}
-		}
-		else
-		{
-			$minDbVersionCms = self::$dbMinimumPostgreSql;
-		}
-
-		// Use most restrictive minimum database version requirement
-		if (version_compare($minDbVersionCms, $minDbVersionRequired) > 0)
-		{
-			$minDbVersionRequired = $minDbVersionCms;
-		}
+		// Get required database version
+		$minDbVersionRequired = DatabaseHelper::getMinimumServerVersion($db, $options);
 
 		// Check minimum database version
 		if (version_compare($dbVersion, $minDbVersionRequired) < 0)
 		{
 			if (in_array($options->db_type, ['mysql', 'mysqli']) && $db->isMariaDb())
 			{
-				Factory::getApplication()->enqueueMessage(
-					Text::sprintf(
-						'INSTL_DATABASE_INVALID_MARIADB_VERSION',
-						$minDbVersionRequired,
-						$dbVersion
-					),
-					'error'
+				$errorMessage = Text::sprintf(
+					'INSTL_DATABASE_INVALID_MARIADB_VERSION',
+					$minDbVersionRequired,
+					$dbVersion
 				);
 			}
 			else
 			{
-				Factory::getApplication()->enqueueMessage(
-					Text::sprintf(
-						'INSTL_DATABASE_INVALID_' . strtoupper($options->db_type) . '_VERSION',
-						$minDbVersionRequired,
-						$dbVersion
-					),
-					'error'
+				$errorMessage = Text::sprintf(
+					'INSTL_DATABASE_INVALID_' . strtoupper($options->db_type) . '_VERSION',
+					$minDbVersionRequired,
+					$dbVersion
 				);
 			}
+
+			Factory::getApplication()->enqueueMessage($errorMessage, 'error');
 
 			$db->disconnect();
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

With Pull Request (PR) #28135 I have added the check for the CMS' minimum database server version requirement to the installation, because the CMS requirement is at least for PostgreSQL more strict than the database driver's requirement, which was the only checked one before that PR.

But that PR has fixed that only for the case when the database already exists in case of MySQL (PDO) and PostgreSQL (PDO). When creating a new database during installation and using these drivers, still only the database driver's requirement is checked. For MySQLi that is not a problem because there the check in the setup model (which respects the CMS' requirement) works also when the database doesn't exist (yet).

This PR here corrects this so it works for all 3 drivers.

In addition it adds the same checks for connection encryption after successful connection to the database model as I have added them with my PR #27348 when I had added the connection encryption feature to the installation. The reason for this change is the same: Without this PR here these checks take only place when the database already exists, but not when a new database is created. This change is harder to test, because it is only relevant for the special case that the server doesn't support encryption, or negotiating an encrypted connection fails, and the server is configured to allow to fall back to an unencrypted connection. _This part can only be tested by code review, I think._ 

### Testing Instructions

#### Requirements

1. You need a database server with a version which **does** fulfill the particular database **driver's** requirement on the minimum server version but **doesn't** fulfill the **CMS'** requirement on the minimum server version.

The minimum database server versions currently required by the _database drivers_ are:
- 5.6 for MySQLi and MySQL (PDO) drivers when using a MySQL database
- 10.0 for MySQLi and MySQL (PDO) drivers when using a MariaDB database
- 9.4.0 for PostgreSQL

The minimum database server versions currently required by the _CMS_ are:
- 5.6 for MySQL database
- 10.0 for MariaDB database
- 11.0 for PostgreSQL database

Because for MySQL and MariaDB the requirements of database driver and CMS are equal, you have to patch either the driver's or the CMS' requirement so that the above condition is fulfilled. For PostgreSQL you either use a server version 10 or have to patch some requirements, too.

The minimum version as required by the particular database _driver_ for the particular database type can be patched at the following places:

_For MySQL databases_

MySQLi driver - file `libraries/vendor/joomla/database/src/Mysqli/MysqliDriver.php`, line 86
MySQL (PDO) driver - file `libraries/vendor/joomla/database/src/Mysql/MysqlDriver.php`, line 72
```
protected static $dbMinimum = '5.6';
```

_For MariaDB databases_

MySQLi driver - file `libraries/vendor/joomla/database/src/Mysqli/MysqliDriver.php`, line 94
MySQL (PDO) driver - file `libraries/vendor/joomla/database/src/Mysql/MysqlDriver.php`, line 80
```
protected static $dbMinMariadb = '10.0';
```

_For PostgreSQL databases_

PostgreSQL (PDO) driver - file `libraries/vendor/joomla/database/src/Pgsql/PgsqlDriver.php`, line 54
```
protected static $dbMinimum = '9.4.0';
```

The minimum version as required by the _CMS_ for the particular database type can be patched here:
https://github.com/joomla/joomla-cms/blob/8925612077ef65e940090eb617b8e41e22642a7b/installation/src/Helper/DatabaseHelper.php#L23-L48

2. You need a database user who has the privilege to create a database on that server with that kind of connection, e.g. on a standard installation of
- MySql: user 'root' on host 'localhost'
- MariaDB: no idea
- PostgreSQL: user 'postgres'

3. You need an up-to-date 4.0-dev branch so it contains the recently merged PR #28338 , or when using a nightly build, wait until tomorrow so that PR is included.

4. This PR has to be tested with the PDO drivers, i.e. database type MySQL (PDO) or PosgreSQL (PDO). Of course if you have a MySQL or MariaDB database, you can test in addition if this PR doesn't break anything when using the MySQLi driver.

#### Instructions

Start a new Joomla 4 installation **without** the patch of this PR applied, using a database server and user combination which allows to create a new database, and a database name for which no database exists on that server, and make sure that for the server version the 1st point in section "Recuirements" above is fulfilled.

Result: See section "Actual result" below.

Do the same with the patch of this PR applied. When getting an error message about version requirement not being fulfilled, change database server or patch the requirement so that it will be fulfilled, and try again, using the "Install Jooma >" button again.

Result: See section "Expected result" below.

Finally check by code review that the checks for connection encryption added by this PR to here
https://github.com/joomla/joomla-cms/blob/8925612077ef65e940090eb617b8e41e22642a7b/installation/src/Model/DatabaseModel.php#L486-L497
are the same as already present here
https://github.com/joomla/joomla-cms/blob/8925612077ef65e940090eb617b8e41e22642a7b/installation/src/Model/SetupModel.php#L569-L584
except that in the database model they raise exceptions instead of enqueueing messages and returning, but the exception texts are equal to the message texts used in the setup model.

### Expected result

When creating a new database at installation, the CMS' requirement on the minimum database server version is checked, and if it is not fulfilled, the installation stops with an appropriate error message.

The user can correct database information in the installation form and then finish the installation by using the "Install Joomla >" button again.

### Actual result

When creating a new database at installation, the CMS' requirement on the minimum database server version is not checked, i.e. Joomla is installed in that database even if the server doesn't fulfill the version requirement by the CMS.

### Documentation Changes Required

None.

### Additional information

This PR doesn't fix the fact that a database will also be created with MySQL (PDO) or PosgreSQL (PDO) when the server doesn't fulfill the minimum version requirement because that version check is done after database creation. This issue I plan to fix with another, future PR.