### PR TITLE
[4.0] Edit Field: Remove class from field published

### DIFF
--- a/administrator/components/com_fields/forms/field.xml
+++ b/administrator/components/com_fields/forms/field.xml
@@ -87,7 +87,6 @@
 			name="state"
 			type="list"
 			label="JSTATUS"
-			class="custom-select-color-state"
 			default="1"
 			size="1"
 			>


### PR DESCRIPTION
### Summary of Changes
Remove class custom-select-color-state form field published. 


### Testing Instructions
Go to Fields, make a new field or open an existing one.
Have a look on the he field published before and after patch,
Compare it with the edit screen of an article



### Expected result
The field published looks the same as in com_articles


### Actual result
![field-published](https://user-images.githubusercontent.com/1035262/76700833-c4821b80-66bb-11ea-8f68-6361aead6b10.JPG)


### Documentation Changes Required
screenshot
