### PR TITLE
[4.0] Cleanup formvalidation uses

### DIFF
--- a/administrator/components/com_associations/tmpl/association/edit.php
+++ b/administrator/components/com_associations/tmpl/association/edit.php
@@ -37,7 +37,7 @@ $options = [
 		data-hide-reference="<?php echo Text::_('COM_ASSOCIATIONS_EDIT_HIDE_REFERENCE'); ?>"><?php echo Text::_('COM_ASSOCIATIONS_EDIT_HIDE_REFERENCE'); ?>
 </button>
 
-<form action="<?php echo Route::_('index.php?option=com_associations&view=association&' . http_build_query($options)); ?>" method="post" name="adminForm" id="adminForm" data-associatedview="<?php echo $this->typeName; ?>">
+<form action="<?php echo Route::_('index.php?option=com_associations&view=association&' . http_build_query($options)); ?>" method="post" name="adminForm" id="adminForm" class="form-validate" data-associatedview="<?php echo $this->typeName; ?>">
 	<div class="sidebyside">
 		<div class="outer-panel" id="left-panel">
 			<div class="inner-panel">

--- a/administrator/components/com_banners/tmpl/download/default.php
+++ b/administrator/components/com_banners/tmpl/download/default.php
@@ -9,9 +9,12 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Router\Route;
 
 /** @var \Joomla\Component\Banners\Administrator\View\Download\HtmlView $this */
+
+HTMLHelper::_('behavior.formvalidator');
 
 ?>
 <div class="container-popup">

--- a/administrator/components/com_config/tmpl/application/default.php
+++ b/administrator/components/com_config/tmpl/application/default.php
@@ -26,7 +26,7 @@ Text::script('NOTICE');
 Text::script('MESSAGE');
 ?>
 
-<form action="<?php echo Route::_('index.php?option=com_config'); ?>" id="application-form" method="post" name="adminForm" class="form-validate" data-cancel-task="config.cancel.component">
+<form action="<?php echo Route::_('index.php?option=com_config'); ?>" id="application-form" method="post" name="adminForm" class="form-validate">
 	<div class="row">
 		<!-- Begin Sidebar -->
 		<div id="sidebar" class="col-md-3">

--- a/administrator/components/com_config/tmpl/component/default.php
+++ b/administrator/components/com_config/tmpl/component/default.php
@@ -35,7 +35,7 @@ if ($this->fieldsets)
 $xml = $this->form->getXml();
 ?>
 
-<form action="<?php echo Route::_('index.php?option=com_config'); ?>" id="component-form" method="post" class="form-validate" name="adminForm" autocomplete="off" data-cancel-task="config.cancel.component">
+<form action="<?php echo Route::_('index.php?option=com_config'); ?>" id="component-form" method="post" class="form-validate" name="adminForm" autocomplete="off">
 	<div class="row">
 
 		<?php // Begin Sidebar ?>

--- a/administrator/components/com_media/tmpl/file/default.php
+++ b/administrator/components/com_media/tmpl/file/default.php
@@ -27,9 +27,7 @@ HTMLHelper::_('script', 'com_media/edit-images.js', ['version' => 'auto', 'relat
 
 $params = ComponentHelper::getParams('com_media');
 
-/**
- * @var JForm $form
- */
+/** @var \Joomla\CMS\Form\Form $form */
 $form = $this->form;
 
 $tmpl = Factory::getApplication()->input->getCmd('tmpl');
@@ -60,7 +58,7 @@ $this->useCoreUI = true;
 	<?php $fieldSets = $form->getFieldsets(); ?>
 	<?php if ($fieldSets) : ?>
 		<?php echo HTMLHelper::_('uitab.startTabSet', 'myTab', array('active' => 'attrib-' . reset($fieldSets)->name)); ?>
-		<?php echo '<div id="media-manager-edit-container" class="media-manager-edit d-flex justify-content-around form-validate col-md-9 p-4"></div>'; ?>
+		<?php echo '<div id="media-manager-edit-container" class="media-manager-edit d-flex justify-content-around col-md-9 p-4"></div>'; ?>
 		<?php echo LayoutHelper::render('joomla.edit.params', $this); ?>
 		<?php echo HTMLHelper::_('uitab.endTabSet'); ?>
 	<?php endif; ?>

--- a/administrator/components/com_messages/tmpl/config/default.php
+++ b/administrator/components/com_messages/tmpl/config/default.php
@@ -16,7 +16,7 @@ HTMLHelper::_('behavior.formvalidator');
 HTMLHelper::_('behavior.keepalive');
 ?>
 <div class="container-popup">
-	<form action="<?php echo Route::_('index.php?option=com_messages&view=config'); ?>" method="post" name="adminForm" id="message-form">
+	<form action="<?php echo Route::_('index.php?option=com_messages&view=config'); ?>" method="post" name="adminForm" id="message-form" class="form-validate">
 		<fieldset>
 			<?php echo $this->form->renderField('lock'); ?>
 			<?php echo $this->form->renderField('mail_on_new'); ?>

--- a/administrator/components/com_privacy/tmpl/request/default.php
+++ b/administrator/components/com_privacy/tmpl/request/default.php
@@ -14,13 +14,13 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 use Joomla\Component\Actionlogs\Administrator\Helper\ActionlogsHelper;
 
-/** @var PrivacyViewRequest $this */
+/** @var \Joomla\Component\Privacy\Administrator\View\Request\HtmlView $this */
 
 HTMLHelper::_('behavior.formvalidator');
 HTMLHelper::_('behavior.keepalive');
 
 ?>
-<form action="<?php echo Route::_('index.php?option=com_privacy&view=request&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="item-form" class="form-validate" data-cancel-task="request.cancel">
+<form action="<?php echo Route::_('index.php?option=com_privacy&view=request&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="item-form" class="form-validate">
 	<div class="row mt-3">
 		<div class="col-12 col-md-6 mb-3">
 			<div class="card">

--- a/administrator/components/com_privacy/tmpl/request/edit.php
+++ b/administrator/components/com_privacy/tmpl/request/edit.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Router\Route;
 
-/** @var PrivacyViewRequest $this */
+/** @var \Joomla\Component\Privacy\Administrator\View\Request\HtmlView $this */
 
 HTMLHelper::_('behavior.formvalidator');
 HTMLHelper::_('behavior.keepalive');

--- a/components/com_config/tmpl/config/default.php
+++ b/components/com_config/tmpl/config/default.php
@@ -18,7 +18,7 @@ HTMLHelper::_('behavior.formvalidator');
 HTMLHelper::_('script', 'com_config/config-default.js', ['version' => 'auto', 'relative' => true]);
 ?>
 
-<form action="<?php echo Route::_('index.php?option=com_config'); ?>" id="application-form" method="post" name="adminForm" class="form-validate"  data-cancel-task="config.cancel.component">
+<form action="<?php echo Route::_('index.php?option=com_config'); ?>" id="application-form" method="post" name="adminForm" class="form-validate">
 
 	<div class="btn-toolbar" role="toolbar" aria-label="<?php echo Text::_('JTOOLBAR'); ?>">
 		<div class="btn-group mr-2">

--- a/components/com_config/tmpl/modules/default.php
+++ b/components/com_config/tmpl/modules/default.php
@@ -42,7 +42,7 @@ if (Multilanguage::isEnabled())
 }
 ?>
 
-<form action="<?php echo Route::_('index.php?option=com_config'); ?>" method="post" name="adminForm" id="modules-form" class="form-validate"  data-cancel-task="config.cancel.modules">
+<form action="<?php echo Route::_('index.php?option=com_config'); ?>" method="post" name="adminForm" id="modules-form" class="form-validate">
 	<div class="row">
 		<div class="col-md-12">
 

--- a/components/com_config/tmpl/templates/default.php
+++ b/components/com_config/tmpl/templates/default.php
@@ -21,7 +21,7 @@ $user = Factory::getUser();
 HTMLHelper::_('script', 'com_config/templates-default.js', ['version' => 'auto', 'relative' => true]);
 ?>
 
-<form action="<?php echo Route::_('index.php?option=com_config'); ?>" method="post" name="adminForm" id="templates-form" class="form-validate"  data-cancel-task="config.cancel.templates">
+<form action="<?php echo Route::_('index.php?option=com_config'); ?>" method="post" name="adminForm" id="templates-form" class="form-validate">
 
 	<div class="btn-toolbar" role="toolbar" aria-label="<?php echo Text::_('JTOOLBAR'); ?>">
 		<div class="btn-group mr-2">

--- a/components/com_privacy/tmpl/confirm/default.php
+++ b/components/com_privacy/tmpl/confirm/default.php
@@ -13,7 +13,7 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 
-/** @var PrivacyViewConfirm $this */
+/** @var \Joomla\Component\Privacy\Site\View\Confirm\HtmlView $this */
 
 HTMLHelper::_('behavior.keepalive');
 HTMLHelper::_('behavior.formvalidator');

--- a/components/com_privacy/tmpl/remind/default.php
+++ b/components/com_privacy/tmpl/remind/default.php
@@ -13,7 +13,7 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 
-/** @var PrivacyViewConfirm $this */
+/** @var \Joomla\Component\Privacy\Site\View\Remind\HtmlView $this */
 
 HTMLHelper::_('behavior.keepalive');
 HTMLHelper::_('behavior.formvalidator');

--- a/components/com_privacy/tmpl/request/default.php
+++ b/components/com_privacy/tmpl/request/default.php
@@ -13,7 +13,7 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 
-/** @var PrivacyViewRequest $this */
+/** @var \Joomla\Component\Privacy\Site\View\Request\HtmlView $this */
 
 HTMLHelper::_('behavior.keepalive');
 HTMLHelper::_('behavior.formvalidator');

--- a/installation/tmpl/preinstall/default.php
+++ b/installation/tmpl/preinstall/default.php
@@ -11,6 +11,8 @@ defined('_JEXEC') or die;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
+HTMLHelper::_('behavior.formvalidator');
+
 /** @var \Joomla\CMS\Installation\View\Preinstall\HtmlView $this */
 ?>
 <div id="installer-view" class="container" data-page-name="preinstall">

--- a/installation/tmpl/remove/default.php
+++ b/installation/tmpl/remove/default.php
@@ -12,6 +12,8 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Uri\Uri;
 
+HTMLHelper::_('behavior.formvalidator');
+
 /** @var \Joomla\CMS\Installation\View\Remove\HtmlView $this */
 ?>
 <div id="installer-view" data-page-name="remove">

--- a/installation/tmpl/setup/default.php
+++ b/installation/tmpl/setup/default.php
@@ -12,6 +12,8 @@ defined('_JEXEC') or die;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
+HTMLHelper::_('behavior.formvalidator');
+
 /** @var \Joomla\CMS\Installation\View\Setup\HtmlView $this */
 ?>
 


### PR DESCRIPTION
Partial Pull Request for Issue #25490 .

### Summary of Changes
- Adds the class `form-validate` to various forms so that they are correctly used by the validator.
- Adds the formvalidator javascript to the installer where we had the classes but not the JS
- Removes the `data-cancel-task` attribute from com_config where we now no longer use core mvc and it follows the "normal" task pattern

Basically every form using the formvalidator behaviour is now associated with a form containing the `form-validate` class. (The password field additionally includes the behaviour without the class but that is outside the scope of the PR as the JS has a hard dependency)

### Testing Instructions
Ensure form validation in forms continues to work especially in the forms affected in this  PR

### Documentation Changes Required
None
