### PR TITLE
[4.0] Fix notice when script hashes enabled

### DIFF
--- a/plugins/system/httpheaders/httpheaders.php
+++ b/plugins/system/httpheaders/httpheaders.php
@@ -159,9 +159,12 @@ class PlgSystemHttpHeaders extends CMSPlugin implements SubscriberInterface
 			// Generate the hashes for the script-src
 			$inlineScripts = is_array($headData['script']) ? $headData['script'] : [];
 
-			foreach ($inlineScripts as $type => $scriptContent)
+			foreach ($inlineScripts as $type => $scripts)
 			{
-				$scriptHashes[] = "'sha256-" . base64_encode(hash('sha256', $scriptContent, true)) . "'";
+				foreach ($scripts as $hash => $scriptContent)
+				{
+					$scriptHashes[] = "'sha256-" . base64_encode(hash('sha256', $scriptContent, true)) . "'";
+				}
 			}
 		}
 


### PR DESCRIPTION
### Summary of Changes
Fixes CSP Notice when script hashes enabled. This was caused by https://github.com/joomla/joomla-cms/pull/25357 which made the script content an array of scripts which we now need to loop through.

### Testing Instructions
Setup CSP Component Configuration as follows:
![image](https://user-images.githubusercontent.com/1986000/76704703-b8ee1f00-66d2-11ea-8f95-803a99bc5c67.png)

then navigate to the article list view.

### Expected result
No PHP Warning

### Actual result
```
Warning
: hash() expects parameter 2 to be string, array given in
JROOT/plugins/system/httpheaders/httpheaders.php
on line
164
```

### Documentation Changes Required
None
