### PR TITLE
[4.0] Add "disabled" attribute to switcher

### DIFF
--- a/administrator/templates/atum/scss/blocks/_switcher.scss
+++ b/administrator/templates/atum/scss/blocks/_switcher.scss
@@ -12,3 +12,6 @@
       box-shadow: $focusshadow;
     }
   }
+  .disabled {
+	  opacity: $btn-disabled-opacity;
+  }

--- a/layouts/joomla/form/field/radio/switcher.php
+++ b/layouts/joomla/form/field/radio/switcher.php
@@ -63,12 +63,16 @@ $input = '<input type="radio" id="%1$s" name="%2$s" value="%3$s" %4$s>';
 $attr = 'id="' . $id . '"';
 $attr .= $onchange ? ' onchange="' . $onchange . '"' : '';
 
+if (!empty($disabled) || !empty($readonly))
+{
+	$disabled = 'disabled="disabled"';
+}
 ?>
 <fieldset <?php echo $attr; ?>>
 	<legend class="switcher__legend sr-only">
 		<?php echo $label; ?>
 	</legend>
-	<div class="switcher">
+	<div class="switcher<?php echo ($readonly || $disabled ? ' disabled' : ''); ?>">
 	<?php foreach ($options as $i => $option) : ?>
 		<?php
 		// False value casting as string returns an empty string so assign it 0
@@ -82,7 +86,7 @@ $attr .= $onchange ? ' onchange="' . $onchange . '"' : '';
 		$active		= ((string) $option->value == $value) ? 'class="active"' : '';
 		$oid		= $id . $i;
 		$ovalue		= htmlspecialchars($option->value, ENT_COMPAT, 'UTF-8');
-		$attributes	= array_filter([$checked, $active]);
+		$attributes	= array_filter([$checked, $active, $disabled]);
 		$text		= $options[$i]->text;
 		?>
 		<?php echo sprintf($input, $oid, $name, $ovalue, implode(' ', $attributes)); ?>


### PR DESCRIPTION
Pull Request for Issue #27760 .

### Summary of Changes
Adds the `disabled` attribute to the switcher fields if in the XML either `readonly` or `disabled` is set.
Since `readonly` isn't a valid attribute for radios (which technically a switcher still is), I just add `disabled` in that case.

I haven't touched CSS as I leave that to people who have a clue about design.
Imho it should be made visible somehow that the field is disabled.

### Testing Instructions
See Issue #27760


### Expected result
"Locked" Switcher


### Actual result
Switcher can be toggled


### Documentation Changes Required
None
