### PR TITLE
[4.0] Correct CSP frame-ancestors

### DIFF
--- a/plugins/system/httpheaders/httpheaders.php
+++ b/plugins/system/httpheaders/httpheaders.php
@@ -323,7 +323,7 @@ class PlgSystemHttpHeaders extends CMSPlugin implements SubscriberInterface
 
 		if ($frameAncestorsSelfEnabled && !$frameAncestorsSet)
 		{
-			$newCspValues[] = 'frame-ancestors "self"';
+			$newCspValues[] = 'frame-ancestors \'self\'';
 		}
 
 		if (empty($newCspValues))


### PR DESCRIPTION
### Summary of Changes

Corrects syntax. Fixes this warning:

>Content Security Policy: Interpreting self as a hostname, not a keyword. If you intended this to be a keyword, use ‘self’ (wrapped in single quotes).

### Testing Instructions

@zero-24 can be merged on your review.

### Documentation Changes Required

No.