### PR TITLE
[4.0] Fix errors about int columns shown in database schema check on MySQL 8

### DIFF
--- a/libraries/src/Schema/ChangeItem/MysqlChangeItem.php
+++ b/libraries/src/Schema/ChangeItem/MysqlChangeItem.php
@@ -307,8 +307,8 @@ class MysqlChangeItem extends ChangeItem
 
 		if ($uType === 'INT UNSIGNED')
 		{
-			$typeCheck = '(UPPER(LEFT(type, 3)) = ' . $this->db->quote('INT')
-				. ' AND UPPER(RIGHT(type, 9)) = ' . $this->db->quote(' UNSIGNED') . ')';
+			$typeCheck = 'UPPER(LEFT(type, 3)) = ' . $this->db->quote('INT')
+				. ' AND UPPER(RIGHT(type, 9)) = ' . $this->db->quote(' UNSIGNED');
 		}
 		elseif ($uType === 'INT')
 		{

--- a/libraries/src/Schema/ChangeItem/MysqlChangeItem.php
+++ b/libraries/src/Schema/ChangeItem/MysqlChangeItem.php
@@ -236,8 +236,8 @@ class MysqlChangeItem extends ChangeItem
 	/**
 	 * Fix up integer. Fixes problem with MySQL integer descriptions.
 	 * On MySQL 8 display length is not shown anymore.
-	 * This means we have to match both "int(10) unsigned" and
-	 * "int unsigned", or both "int(10)" and "int".
+	 * This means we have to match e.g. both "int(10) unsigned" and
+	 * "int unsigned", or both "int(11)" and "int" and so on.
 	 *
 	 * @param   string  $type1  the column type
 	 * @param   string  $type2  the column attributes

--- a/libraries/src/Schema/ChangeItem/MysqlChangeItem.php
+++ b/libraries/src/Schema/ChangeItem/MysqlChangeItem.php
@@ -293,7 +293,7 @@ class MysqlChangeItem extends ChangeItem
 	 * Make check query for column changes/modifications tolerant
 	 * for automatic type changes of text columns, e.g. from TEXT
 	 * to MEDIUMTEXT, after comnversion from utf8 to utf8mb4, and
-	 * fix integer columns without display lenght for MySQL 8.
+	 * fix integer columns without display length for MySQL 8.
 	 *
 	 * @param   string  $type  The column type found in the update query
 	 *


### PR DESCRIPTION
Pull Request for Issue #28367 .

### Summary of Changes

This Pull Request (PR) changes the database schema checker for MySQL so that any display size is ignored for integer (`int`) columns when checking these columns.

The reason for this is that beginning with MySQL 8.0.19, the `type` in a `SHOW COLUMNS` statement doesn't include anymore the display size if the database has been created in that version, while on previous versions it is included. E.g. on MySQL 5.7 or 8.0.18 the `type` value is "int(11)" or "int(10) unsigned" while on mySQL 8.0.19 it is just "int" or "int unsigned".

The display size doesn't have any impact on value range or storage size for an integer column, it only determines how a value would be left-padded with zeros if that would be done, but this padding is deprecated anyway. See [https://dev.mysql.com/doc/refman/8.0/en/numeric-type-attributes.html](https://dev.mysql.com/doc/refman/8.0/en/numeric-type-attributes.html) for details.

### Testing Instructions

#### Requirements

Have a MySQL database with version 8.0.19 and another one with an older version, e.g. 5.7 or 8.0.18.

#### Instructions

Install a clean 4.0-dev without the patch of this PR applied on MySQL 8.0.19.

Then go to the database checker.

Result: You see errors about columns of type `int(10)` and `int(5)` and similar. See section "Actual result" below.

Now apply the patch of this PR and go again to the database checker or reload the page if still there.

Result: No errors are shown, see section "Expected result" below.

Now delete configuration.php and install the 4.0-dev with the patch of this PR applied on a MySQL version prior to 8.0.19, e.g. 5.7 or 8.0.18.

Then go to the database checker.

Result: With this PR applied it works as before for MySQL prior to 8.0.19, i.e. there are no database errors after a clean install.

### Expected result

All database table structures are up to date.

No problems were found.

### Actual result

![modified](https://user-images.githubusercontent.com/181681/76739124-171b1080-676c-11ea-89a5-1d8b99967366.png)

### Documentation Changes Required

None.

### Additional information

I found following statement here [https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-19.html](https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-19.html) in section "Deprecation and Removal Notes":

`For DESCRIBE statements and INFORMATION_SCHEMA queries, output is unaffected for objects created in previous MySQL 8.0 versions because information already stored in the data dictionary remains unchanged. This exception does not apply for upgrades from MySQL 5.7 to 8.0, for which all data dictionary information is re-created such that data type definitions do not include display width.`

I.e. if you have updated e.g. a 8.0.18 to an 8.0.19, previously present databases still will show the display width in their integer data types.