### PR TITLE
[4.0] Media edit fields alignment

### DIFF
--- a/administrator/components/com_media/resources/styles/components/_media-edit.scss
+++ b/administrator/components/com_media/resources/styles/components/_media-edit.scss
@@ -3,7 +3,7 @@
     max-width: 100%;
   }
   .control-group {
-    display: flex;
+    display: inline-flex;
     flex-direction: column;
     .control-label {
       width: 100%;

--- a/administrator/templates/atum/scss/blocks/_utilities.scss
+++ b/administrator/templates/atum/scss/blocks/_utilities.scss
@@ -37,6 +37,7 @@
     flex-direction: column;
     width: 100%;
     break-inside: avoid;
+    page-break-inside: avoid;
 
     &.hidden {
       display: none;


### PR DESCRIPTION
Pull Request for Issue #28209 .

### Summary of Changes
Fixes alignment issues for fields in Media Manager -> Edit an Image -> Resize tab


### Testing Instructions
Apply PR and run `npm i` for updating the changed SCSS. Check login page displays correctly. Open Joomla admin in Firefox. Navigate to Media Manager -> Edit an Image -> Resize tab. Ensure fields are aligned correctly (check orignal issue).


### Expected result



### Actual result



### Documentation Changes Required

