### PR TITLE
[4.0] [mod_tags_popular] Array to string conversion

### DIFF
--- a/modules/mod_tags_popular/src/Helper/TagsPopularHelper.php
+++ b/modules/mod_tags_popular/src/Helper/TagsPopularHelper.php
@@ -97,12 +97,17 @@ abstract class TagsPopularHelper
 
 		// Only return tags connected to published and authorised items
 		$query->where($db->quoteName('c.core_state') . ' = 1')
-			->where('(' . $db->quoteName('c.core_access') . ' IN (' . implode(',', $query->bindArray($groups)) . ') OR ' . $db->quoteName('c.core_access') . ' = 0)')
-			->where('(' . $db->quoteName('c.core_publish_up') . ' IS NULL'
+			->where(
+				'(' . $db->quoteName('c.core_access') . ' IN (' . implode(',', $query->bindArray($groups)) . ')'
+				. ' OR ' . $db->quoteName('c.core_access') . ' = 0)'
+			)
+			->where(
+				'(' . $db->quoteName('c.core_publish_up') . ' IS NULL'
 				. ' OR ' . $db->quoteName('c.core_publish_up') . ' = :nullDate2'
 				. ' OR ' . $db->quoteName('c.core_publish_up') . ' <= :nowDate2)'
 			)
-			->where('(' . $db->quoteName('c.core_publish_down') . ' IS NULL'
+			->where(
+				'(' . $db->quoteName('c.core_publish_down') . ' IS NULL'
 				. ' OR ' . $db->quoteName('c.core_publish_down') . ' = :nullDate3'
 				. ' OR ' . $db->quoteName('c.core_publish_down') . ' >= :nowDate3)'
 			)

--- a/modules/mod_tags_popular/src/Helper/TagsPopularHelper.php
+++ b/modules/mod_tags_popular/src/Helper/TagsPopularHelper.php
@@ -97,7 +97,7 @@ abstract class TagsPopularHelper
 
 		// Only return tags connected to published and authorised items
 		$query->where($db->quoteName('c.core_state') . ' = 1')
-			->where('(' . $db->quoteName('c.core_access') . ' IN (' . $groups . ') OR ' . $db->quoteName('c.core_access') . ' = 0)')
+			->where('(' . $db->quoteName('c.core_access') . ' IN (' . implode(',', $query->bindArray($groups)) . ') OR ' . $db->quoteName('c.core_access') . ' = 0)')
 			->where('(' . $db->quoteName('c.core_publish_up') . ' IS NULL'
 				. ' OR ' . $db->quoteName('c.core_publish_up') . ' = :nullDate2'
 				. ' OR ' . $db->quoteName('c.core_publish_up') . ' <= :nowDate2)'


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/28378.

### Summary of Changes

Fixes error in query.

### Testing Instructions

Publish Tags - Popular module.

### Expected result

Works.

### Actual result

> Notice: Array to string conversion in modules\mod_tags_popular\src\Helper\TagsPopularHelper.php on line 100
>Error: Unknown column 'Array' in 'where clause': Unknown column 'Array' in 'where clause'

### Documentation Changes Required

No.