### PR TITLE
[4.0] Update Button API typehints

### DIFF
--- a/administrator/components/com_content/tmpl/articles/default.php
+++ b/administrator/components/com_content/tmpl/articles/default.php
@@ -228,7 +228,7 @@ HTMLHelper::_('script', 'com_content/admin-articles-workflow-buttons.js', ['rela
 										];
 
 										echo (new FeaturedButton)
-											->render($item->featured, $i, $options, $item->featured_up, $item->featured_down);
+											->render((int) $item->featured, $i, $options, $item->featured_up, $item->featured_down);
 									?>
 								</td>
 								<td class="article-status">
@@ -252,7 +252,7 @@ HTMLHelper::_('script', 'com_content/admin-articles-workflow-buttons.js', ['rela
 												->addState(ContentComponent::CONDITION_ARCHIVED, '', 'archive', Text::_('COM_CONTENT_CHANGE_STAGE'), ['tip_title' => Text::_('JARCHIVED')])
 												->addState(ContentComponent::CONDITION_TRASHED, '', 'trash', Text::_('COM_CONTENT_CHANGE_STAGE'), ['tip_title' => Text::_('JTRASHED')])
 												->setLayout('joomla.button.transition-button')
-												->render($item->stage_condition, $i, $options, $item->publish_up, $item->publish_down);
+												->render((int) $item->stage_condition, $i, $options, $item->publish_up, $item->publish_down);
 										?>
 										</div>
 									</div>

--- a/administrator/components/com_content/tmpl/featured/default.php
+++ b/administrator/components/com_content/tmpl/featured/default.php
@@ -214,7 +214,7 @@ HTMLHelper::_('script', 'com_content/admin-articles-workflow-buttons.js', ['rela
 										];
 
 										echo (new FeaturedButton)
-											->render($item->featured, $i, $options, $item->featured_up, $item->featured_down);
+											->render((int) $item->featured, $i, $options, $item->featured_up, $item->featured_down);
 									?>
 								</td>
 								<td class="article-status">
@@ -238,7 +238,7 @@ HTMLHelper::_('script', 'com_content/admin-articles-workflow-buttons.js', ['rela
 													->addState(ContentComponent::CONDITION_ARCHIVED, '', 'archive', Text::_('COM_CONTENT_CHANGE_STAGE'), ['tip_title' => Text::_('JARCHIVED')])
 													->addState(ContentComponent::CONDITION_TRASHED, '', 'trash', Text::_('COM_CONTENT_CHANGE_STAGE'), ['tip_title' => Text::_('JTRASHED')])
 													->setLayout('joomla.button.transition-button')
-													->render($item->stage_condition, $i, $options, $item->publish_up, $item->publish_down);
+													->render((int) $item->stage_condition, $i, $options, $item->publish_up, $item->publish_down);
 										?>
 										</div>
 									</div>

--- a/libraries/src/Button/ActionButton.php
+++ b/libraries/src/Button/ActionButton.php
@@ -172,7 +172,7 @@ class ActionButton
 	 *
 	 * @throws  \InvalidArgumentException
 	 */
-	public function render(?int $value = null, int $row = null, array $options = []): string
+	public function render(?int $value = null, ?int $row = null, array $options = []): string
 	{
 		$data = $this->getState($value) ?? $this->unknownState;
 

--- a/libraries/src/Button/ActionButton.php
+++ b/libraries/src/Button/ActionButton.php
@@ -102,17 +102,17 @@ class ActionButton
 	/**
 	 * Add a state profile.
 	 *
-	 * @param   string  $value    The value of this state.
-	 * @param   string  $task     The task you want to execute after click this button.
-	 * @param   string  $icon     The icon to display for user.
-	 * @param   string  $title    Title text will show if we enable tooltips.
-	 * @param   array   $options  The button options, will override group options.
+	 * @param   integer  $value    The value of this state.
+	 * @param   string   $task     The task you want to execute after click this button.
+	 * @param   string   $icon     The icon to display for user.
+	 * @param   string   $title    Title text will show if we enable tooltips.
+	 * @param   array    $options  The button options, will override group options.
 	 *
 	 * @return  static  Return self to support chaining.
 	 *
 	 * @since   4.0.0
 	 */
-	public function addState(string $value, string $task, string $icon = 'ok', string $title = '', array $options = []): self
+	public function addState(int $value, string $task, string $icon = 'ok', string $title = '', array $options = []): self
 	{
 		// Force type to prevent null data
 		$this->states[$value] = [
@@ -129,13 +129,13 @@ class ActionButton
 	/**
 	 * Get state profile by value name.
 	 *
-	 * @param   string|integer  $value  The value name we want to get.
+	 * @param   integer  $value  The value name we want to get.
 	 *
 	 * @return  array  Return state profile or NULL.
 	 *
 	 * @since   4.0.0
 	 */
-	public function getState(string $value): array
+	public function getState(int $value): array
 	{
 		// PHP 7.0 does not allow nullable return values so we return empty array if not exists.
 		return $this->states[$value] ?? [];
@@ -144,13 +144,13 @@ class ActionButton
 	/**
 	 * Remove a state by value name.
 	 *
-	 * @param   string  $value  Remove state by this value.
+	 * @param   integer  $value  Remove state by this value.
 	 *
 	 * @return  static  Return to support chaining.
 	 *
 	 * @since   4.0.0
 	 */
-	public function removeState(string $value): self
+	public function removeState(int $value): self
 	{
 		if (isset($this->states[$value]))
 		{
@@ -163,9 +163,9 @@ class ActionButton
 	/**
 	 * Render action button by item value.
 	 *
-	 * @param   mixed   $value    Current value of this item.
-	 * @param   string  $row      The row number of this item.
-	 * @param   array   $options  The options to override group options.
+	 * @param   integer|null  $value    Current value of this item.
+	 * @param   integer|null  $row      The row number of this item.
+	 * @param   array         $options  The options to override group options.
 	 *
 	 * @return  string  Rendered HTML.
 	 *
@@ -173,7 +173,7 @@ class ActionButton
 	 *
 	 * @throws  \InvalidArgumentException
 	 */
-	public function render(string $value = '', string $row = null, array $options = []): string
+	public function render(?int $value = null, int $row = null, array $options = []): string
 	{
 		$data = $this->getState($value) ?: $this->defaultState;
 

--- a/libraries/src/Button/ActionButton.php
+++ b/libraries/src/Button/ActionButton.php
@@ -31,13 +31,13 @@ class ActionButton
 	protected $states = [];
 
 	/**
-	 * The fallback state.
+	 * Default options for unknown state.
 	 *
 	 * @var  array
 	 *
 	 * @since  4.0.0
 	 */
-	protected $defaultState = [
+	protected $unknownState = [
 		'value'     => null,
 		'task'      => '',
 		'icon'      => 'question',
@@ -82,7 +82,7 @@ class ActionButton
 		$this->options = new Registry($options);
 
 		// Replace some dynamic values
-		$this->defaultState['title'] = Text::_('JLIB_HTML_UNKNOWN_STATE');
+		$this->unknownState['title'] = Text::_('JLIB_HTML_UNKNOWN_STATE');
 
 		$this->preprocess();
 	}
@@ -175,10 +175,10 @@ class ActionButton
 	 */
 	public function render(?int $value = null, int $row = null, array $options = []): string
 	{
-		$data = $this->getState($value) ?: $this->defaultState;
+		$data = $this->getState($value) ?: $this->unknownState;
 
 		$data = ArrayHelper::mergeRecursive(
-			$this->defaultState,
+			$this->unknownState,
 			$data,
 			[
 				'options' => $this->options->toArray()

--- a/libraries/src/Button/ActionButton.php
+++ b/libraries/src/Button/ActionButton.php
@@ -38,11 +38,11 @@ class ActionButton
 	 * @since  4.0.0
 	 */
 	protected $unknownState = [
-		'value'     => null,
-		'task'      => '',
-		'icon'      => 'question',
-		'title'     => 'Unknown state',
-		'options'   => [
+		'value'   => null,
+		'task'    => '',
+		'icon'    => 'question',
+		'title'   => 'Unknown state',
+		'options' => [
 			'disabled'  => false,
 			'only_icon' => false,
 			'tip' => true,

--- a/libraries/src/Button/ActionButton.php
+++ b/libraries/src/Button/ActionButton.php
@@ -28,21 +28,28 @@ class ActionButton
 	 *
 	 * @since  4.0.0
 	 */
-	protected $states = [
-		'_default' => [
-			'value'     => '_default',
-			'task'      => '',
-			'icon'      => 'question',
-			'title'     => 'Unknown state',
-			'options'   => [
-				'disabled'  => false,
-				'only_icon' => false,
-				'tip' => true,
-				'tip_title' => '',
-				'task_prefix' => '',
-				'checkbox_name' => 'cb'
-			]
-		]
+	protected $states = [];
+
+	/**
+	 * The fallback state.
+	 *
+	 * @var  array
+	 *
+	 * @since  4.0.0
+	 */
+	protected $defaultState = [
+		'value'     => null,
+		'task'      => '',
+		'icon'      => 'question',
+		'title'     => 'Unknown state',
+		'options'   => [
+			'disabled'  => false,
+			'only_icon' => false,
+			'tip' => true,
+			'tip_title' => '',
+			'task_prefix' => '',
+			'checkbox_name' => 'cb',
+		],
 	];
 
 	/**
@@ -75,7 +82,7 @@ class ActionButton
 		$this->options = new Registry($options);
 
 		// Replace some dynamic values
-		$this->states['_default']['title'] = Text::_('JLIB_HTML_UNKNOWN_STATE');
+		$this->defaultState['title'] = Text::_('JLIB_HTML_UNKNOWN_STATE');
 
 		$this->preprocess();
 	}
@@ -168,12 +175,10 @@ class ActionButton
 	 */
 	public function render(string $value = '', string $row = null, array $options = []): string
 	{
-		$data = $this->getState($value);
-
-		$data = $data ?: $this->getState('_default');
+		$data = $this->getState($value) ?: $this->defaultState;
 
 		$data = ArrayHelper::mergeRecursive(
-			$this->getState('_default'),
+			$this->defaultState,
 			$data,
 			[
 				'options' => $this->options->toArray()

--- a/libraries/src/Button/ActionButton.php
+++ b/libraries/src/Button/ActionButton.php
@@ -131,14 +131,13 @@ class ActionButton
 	 *
 	 * @param   integer  $value  The value name we want to get.
 	 *
-	 * @return  array  Return state profile or NULL.
+	 * @return  array|null  Return state profile or NULL.
 	 *
 	 * @since   4.0.0
 	 */
-	public function getState(int $value): array
+	public function getState(int $value): ?array
 	{
-		// PHP 7.0 does not allow nullable return values so we return empty array if not exists.
-		return $this->states[$value] ?? [];
+		return $this->states[$value] ?? null;
 	}
 
 	/**
@@ -175,7 +174,7 @@ class ActionButton
 	 */
 	public function render(?int $value = null, int $row = null, array $options = []): string
 	{
-		$data = $this->getState($value) ?: $this->unknownState;
+		$data = $this->getState($value) ?? $this->unknownState;
 
 		$data = ArrayHelper::mergeRecursive(
 			$this->unknownState,

--- a/libraries/src/Button/FeaturedButton.php
+++ b/libraries/src/Button/FeaturedButton.php
@@ -51,7 +51,7 @@ class FeaturedButton extends ActionButton
 		if ($featuredUp || $featuredDown)
 		{
 			$bakState = $this->getState($value);
-			$default  = $this->getState($value) ?: $this->defaultState;
+			$default  = $this->getState($value) ?: $this->unknownState;
 
 			$nowDate  = Factory::getDate()->toUnix();
 

--- a/libraries/src/Button/FeaturedButton.php
+++ b/libraries/src/Button/FeaturedButton.php
@@ -51,7 +51,7 @@ class FeaturedButton extends ActionButton
 		if ($featuredUp || $featuredDown)
 		{
 			$bakState = $this->getState($value);
-			$default  = $this->getState($value) ?: $this->unknownState;
+			$default  = $this->getState($value) ?? $this->unknownState;
 
 			$nowDate  = Factory::getDate()->toUnix();
 

--- a/libraries/src/Button/FeaturedButton.php
+++ b/libraries/src/Button/FeaturedButton.php
@@ -51,7 +51,7 @@ class FeaturedButton extends ActionButton
 		if ($featuredUp || $featuredDown)
 		{
 			$bakState = $this->getState($value);
-			$default  = $this->getState($value) ?: $this->getState('_default');
+			$default  = $this->getState($value) ?: $this->defaultState;
 
 			$nowDate  = Factory::getDate()->toUnix();
 

--- a/libraries/src/Button/FeaturedButton.php
+++ b/libraries/src/Button/FeaturedButton.php
@@ -36,17 +36,17 @@ class FeaturedButton extends ActionButton
 	/**
 	 * Render action button by item value.
 	 *
-	 * @param   mixed        $value         Current value of this item.
-	 * @param   string       $row           The row number of this item.
-	 * @param   array        $options       The options to override group options.
-	 * @param   string|Date  $featuredUp    The date which item featured up.
-	 * @param   string|Date  $featuredDown  The date which item featured down.
+	 * @param   integer|null  $value         Current value of this item.
+	 * @param   integer|null  $row           The row number of this item.
+	 * @param   array         $options       The options to override group options.
+	 * @param   string|Date   $featuredUp    The date which item featured up.
+	 * @param   string|Date   $featuredDown  The date which item featured down.
 	 *
 	 * @return  string  Rendered HTML.
 	 *
 	 * @since  4.0.0
 	 */
-	public function render(string $value = null, string $row = null, array $options = [], $featuredUp = null, $featuredDown = null): string
+	public function render(?int $value = null, ?int $row = null, array $options = [], $featuredUp = null, $featuredDown = null): string
 	{
 		if ($featuredUp || $featuredDown)
 		{
@@ -69,7 +69,7 @@ class FeaturedButton extends ActionButton
 
 			// Add tips and special titles
 			// Create special titles for featured items
-			if ($value === '1')
+			if ($value === 1)
 			{
 				// Create tip text, only we have featured up or down settings
 				$tips = [];

--- a/libraries/src/Button/PublishedButton.php
+++ b/libraries/src/Button/PublishedButton.php
@@ -38,17 +38,17 @@ class PublishedButton extends ActionButton
 	/**
 	 * Render action button by item value.
 	 *
-	 * @param   mixed        $value        Current value of this item.
-	 * @param   string       $row          The row number of this item.
-	 * @param   array        $options      The options to override group options.
-	 * @param   string|Date  $publishUp    The date which item publish up.
-	 * @param   string|Date  $publishDown  The date which item publish down.
+	 * @param   integer|null  $value        Current value of this item.
+	 * @param   integer|null  $row          The row number of this item.
+	 * @param   array         $options      The options to override group options.
+	 * @param   string|Date   $publishUp    The date which item publish up.
+	 * @param   string|Date   $publishDown  The date which item publish down.
 	 *
 	 * @return  string  Rendered HTML.
 	 *
 	 * @since  4.0.0
 	 */
-	public function render(string $value = null, string $row = null, array $options = [], $publishUp = null, $publishDown = null): string
+	public function render(?int $value = null, ?int $row = null, array $options = [], $publishUp = null, $publishDown = null): string
 	{
 		if ($publishUp || $publishDown)
 		{
@@ -65,7 +65,7 @@ class PublishedButton extends ActionButton
 
 			// Add tips and special titles
 			// Create special titles for published items
-			if ($value === '1')
+			if ($value === 1)
 			{
 				// Create tip text, only we have publish up or down settings
 				$tips = array();

--- a/libraries/src/Button/PublishedButton.php
+++ b/libraries/src/Button/PublishedButton.php
@@ -53,7 +53,7 @@ class PublishedButton extends ActionButton
 		if ($publishUp || $publishDown)
 		{
 			$bakState = $this->getState($value);
-			$default  = $this->getState($value) ? : $this->getState('_default');
+			$default  = $this->getState($value) ?: $this->defaultState;
 
 			$nullDate = Factory::getDbo()->getNullDate();
 			$nowDate = Factory::getDate()->toUnix();

--- a/libraries/src/Button/PublishedButton.php
+++ b/libraries/src/Button/PublishedButton.php
@@ -53,7 +53,7 @@ class PublishedButton extends ActionButton
 		if ($publishUp || $publishDown)
 		{
 			$bakState = $this->getState($value);
-			$default  = $this->getState($value) ?: $this->unknownState;
+			$default  = $this->getState($value) ?? $this->unknownState;
 
 			$nullDate = Factory::getDbo()->getNullDate();
 			$nowDate = Factory::getDate()->toUnix();

--- a/libraries/src/Button/PublishedButton.php
+++ b/libraries/src/Button/PublishedButton.php
@@ -53,7 +53,7 @@ class PublishedButton extends ActionButton
 		if ($publishUp || $publishDown)
 		{
 			$bakState = $this->getState($value);
-			$default  = $this->getState($value) ?: $this->defaultState;
+			$default  = $this->getState($value) ?: $this->unknownState;
 
 			$nullDate = Factory::getDbo()->getNullDate();
 			$nowDate = Factory::getDate()->toUnix();


### PR DESCRIPTION
### Summary of Changes

As discussed in https://github.com/joomla/joomla-cms/pull/24305, this updates state value type to integer.

### Testing Instructions

Go to article list in backend. Inspect featured/transition icons.
Go to database, manually edit `featured` value of some article in `#__content` table. Change it to `2` or more. View the article in the article list.

### Expected result

Works like before.
Article with modified `featured` value shows `Unknown State` icon.

### Documentation Changes Required

IDK.