### PR TITLE
[4.0] Add author to output and filter options to com_content API

### DIFF
--- a/api/components/com_content/src/Controller/ArticlesController.php
+++ b/api/components/com_content/src/Controller/ArticlesController.php
@@ -11,6 +11,7 @@ namespace Joomla\Component\Content\Api\Controller;
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\MVC\Controller\ApiController;
 use Joomla\Component\Fields\Administrator\Helper\FieldsHelper;
 
@@ -36,6 +37,41 @@ class ArticlesController extends ApiController
 	 * @since  3.0
 	 */
 	protected $default_view = 'articles';
+
+	/**
+	 * Article list view amended to add filtering of data
+	 *
+	 * @return  static  A BaseController object to support chaining.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function displayList()
+	{
+		$apiFilterInfo = $this->input->get('filter', [], 'array');
+		$filter        = InputFilter::getInstance();
+
+		if (array_key_exists('author', $apiFilterInfo))
+		{
+			$this->modelState->set('filter.author_id', $filter->clean($apiFilterInfo['author'], 'INT'));
+		}
+
+		if (array_key_exists('category', $apiFilterInfo))
+		{
+			$this->modelState->set('filter.category_id', $filter->clean($apiFilterInfo['category'], 'INT'));
+		}
+
+		if (array_key_exists('search', $apiFilterInfo))
+		{
+			$this->modelState->set('filter.search', $filter->clean($apiFilterInfo['search'], 'STRING'));
+		}
+
+		if (array_key_exists('state', $apiFilterInfo))
+		{
+			$this->modelState->set('filter.condition', $filter->clean($apiFilterInfo['state'], 'INT'));
+		}
+
+		return parent::displayList();
+	}
 
 	/**
 	 * Method to save a record.

--- a/api/components/com_content/src/Serializer/ContentSerializer.php
+++ b/api/components/com_content/src/Serializer/ContentSerializer.php
@@ -27,9 +27,9 @@ class ContentSerializer extends JoomlaSerializer
 	/**
 	 * Build content relationships by associations
 	 *
-	 * @param   \stdClass  $model Item model
+	 * @param   \stdClass  $model  Item model
 	 *
-	 * @return Relationship
+	 * @return  Relationship
 	 *
 	 * @since 4.0
 	 */
@@ -52,21 +52,39 @@ class ContentSerializer extends JoomlaSerializer
 	}
 
 	/**
-	 * Build content relationships by associations
+	 * Build category relationship
 	 *
-	 * @param   \stdClass  $model Item model
+	 * @param   \stdClass  $model  Item model
 	 *
-	 * @return Relationship
+	 * @return  Relationship
 	 *
 	 * @since 4.0
 	 */
 	public function category($model)
 	{
-		// TODO: This can't be hardcoded in the future?
-		$serializer = new JoomlaSerializer($this->type);
+		$serializer = new JoomlaSerializer('categories');
 
 		$resource = (new Resource($model->catid, $serializer))
 			->addLink('self', Route::link('site', Uri::root() . 'api/index.php/v1/content/categories/' . $model->catid));
+
+		return new Relationship($resource);
+	}
+
+	/**
+	 * Build category relationship
+	 *
+	 * @param   \stdClass  $model  Item model
+	 *
+	 * @return  Relationship
+	 *
+	 * @since 4.0
+	 */
+	public function author($model)
+	{
+		$serializer = new JoomlaSerializer('users');
+
+		$resource = (new Resource($model->created_by, $serializer))
+			->addLink('self', Route::link('site', Uri::root() . 'api/index.php/v1/users/' . $model->created_by));
 
 		return new Relationship($resource);
 	}

--- a/api/components/com_content/src/View/Articles/JsonapiView.php
+++ b/api/components/com_content/src/View/Articles/JsonapiView.php
@@ -42,6 +42,7 @@ class JsonapiView extends BaseApiView
 		'state',
 		'category',
 		'created',
+		'author',
 	];
 
 	/**
@@ -61,6 +62,7 @@ class JsonapiView extends BaseApiView
 		'state',
 		'category',
 		'created',
+		'author',
 	];
 
 	/**
@@ -71,6 +73,7 @@ class JsonapiView extends BaseApiView
 	 */
 	protected $relationship = [
 		'category',
+		'author',
 	];
 
 	/**

--- a/libraries/src/MVC/View/JsonApiView.php
+++ b/libraries/src/MVC/View/JsonApiView.php
@@ -166,6 +166,11 @@ abstract class JsonApiView extends JsonView
 		$collection = (new Collection($items, $this->serializer))
 			->fields([$this->type => $this->fieldsToRenderList]);
 
+		if (!empty($this->relationship))
+		{
+			$collection->with($this->relationship);
+		}
+
 		// Set the data into the document and render it
 		$this->document->addMeta('total-pages', $pagination->pagesTotal)
 			->setData($collection)


### PR DESCRIPTION
### Summary of Changes
- Allows relations to be shown in the list view of the API
- Adds filters for author id, category id, state and search into the articles api (for now starting with these and we can expand and move them to other components)
- Adds author relationship to the output of articles
- Fixes category relationship being shown as an `articles` type instead of `categories` type

### Testing Instructions
1. Test the filters endpoint with e.g.

JROOT_URL/api/index.php/v1/content/article?filter[search]=tag

which will search for the string 'tag'

JROOT_URL/api/index.php/v1/content/article?filter[state]=0

will search for unpublished articles

2. Test the relationships for category and author are output in both the item and list views of the article output and have the correct type.

### Documentation Changes Required
Yes:
1. How to implement filters in APIs
2. What filters are available in core components
