### PR TITLE
[4.0][api][com_content] remove notice when Multilingual

### DIFF
--- a/administrator/components/com_content/src/Model/ArticlesModel.php
+++ b/administrator/components/com_content/src/Model/ArticlesModel.php
@@ -228,6 +228,7 @@ class ArticlesModel extends ListModel
 					$db->quoteName('a.publish_up'),
 					$db->quoteName('a.publish_down'),
 					$db->quoteName('a.introtext'),
+					$db->quoteName('a.fulltext'),
 					$db->quoteName('a.note'),
 				]
 			)

--- a/api/components/com_content/src/View/Articles/JsonapiView.php
+++ b/api/components/com_content/src/View/Articles/JsonapiView.php
@@ -157,7 +157,7 @@ class JsonapiView extends BaseApiView
 			$item->{$field->name} = isset($field->apivalue) ? $field->apivalue : $field->rawvalue;
 		}
 
-		if (Multilanguage::isEnabled())
+		if (Multilanguage::isEnabled() && !empty($item->associations))
 		{
 			$associations = [];
 


### PR DESCRIPTION
redo of #27071 .

### Summary of Changes

- added fulltext field to the articles model select list
- fixed multilanguage



### Testing Instructions

1. install a multingual site 
2. run Multilingual Sample Data 
3. call the api api/index.php/v1/content/article

### Expected result
no notice


### Actual result
PHP Notice:  Undefined property: stdClass::$fulltext in ../api/components/com_content/src/View/Articles/JsonapiView.php on line 149

PHP Notice:  Undefined property: stdClass::$associations in /var/www/html/jbs4/api/components/com_content/src/View/Articles/JsonapiView.php on line 164


cc @wilsonge
