### PR TITLE
[4.0] Fix SQL error "Column 'checked_out_time' cannot be null" when updating the CMS

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/4.0.0-2019-07-02.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.0.0-2019-07-02.sql
@@ -10,4 +10,4 @@ CREATE TABLE IF NOT EXISTS `#__webauthn_credentials` (
   DEFAULT COLLATE = utf8mb4_unicode_ci;
 
 INSERT INTO `#__extensions` (`package_id`, `name`, `type`, `element`, `folder`, `client_id`, `enabled`, `access`, `protected`, `manifest_cache`, `params`, `checked_out`, `checked_out_time`, `ordering`, `state`) VALUES
-(0, 'plg_system_webauthn', 'plugin', 'webauthn', 'system', 0, 1, 1, 0, '', '{}', 0, NULL, 0, 0);
+(0, 'plg_system_webauthn', 'plugin', 'webauthn', 'system', 0, 1, 1, 0, '', '{}', 0, '0000-00-00 00:00:00', 0, 0);

--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2019-07-02.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2019-07-02.sql
@@ -9,4 +9,4 @@ CREATE TABLE IF NOT EXISTS "#__webauthn_credentials" (
 CREATE INDEX "#__webauthn_credentials_user_id" ON "#__webauthn_credentials" ("user_id");
 
 INSERT INTO "#__extensions" ("package_id", "name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "manifest_cache", "params", "checked_out", "checked_out_time", "ordering", "state") VALUES
-(0, 'plg_system_webauthn', 'plugin', 'webauthn', 'system', 0, 1, 1, 0, '', '{}', 0, NULL, 8, 0);
+(0, 'plg_system_webauthn', 'plugin', 'webauthn', 'system', 0, 1, 1, 0, '', '{}', 0, '1970-01-01 00:00:00', 8, 0);


### PR DESCRIPTION
Pull Request for Issue #28385 .

### Summary of Changes

Use old pseudo null date in update script `4.0.0-2019-07-02.sql` for checked out time, because the real null date value change is done with script `4.0.0-2019-10-06.sql`, which runs after the previously mentioned one.

### Testing Instructions

Has to be tested with MySQL (or MariaDB) and PostgreSQL.

Testers please report back which of these database types you have tested.

1. Install a fresh copy of 3.10 nightly or a git clone of the current 3.10-dev branch (it doesn't matter if with or without any testing sample data).
2. Go to the Joomla Update Component component config and set the URL to following custom URL: [https://test5.richard-fath.de/next_major_list_pr-28391.xml](https://test5.richard-fath.de/next_major_list_pr-28391.xml), and the status to "development".
4. Update to Joomla 4.0.
5. When the update has finished, log in to backend.

### Expected result

Update succeeds (except of the missing template message at the first login to the backend, which is normal).

### Actual result

Update fails with SQL error "Column 'checked_out_time' cannot be null", and the CMS is broken, see issue #28385 .

### Additional information

The diff clearly shows a difference between the update script for MySQL and the one for PostgreSQL in the ordering value for the inserted record.

For fixing such differences I am already on the way to prepare a PR, but it might be weekend until it will be ready.

### Documentation Changes Required

None.