### PR TITLE
Removing ltrim in folderlist form field

### DIFF
--- a/libraries/joomla/form/fields/folderlist.php
+++ b/libraries/joomla/form/fields/folderlist.php
@@ -184,7 +184,7 @@ class JFormFieldFolderList extends JFormFieldList
 	{
 		$options = array();
 
-		$path = ltrim($this->directory, '/');
+		$path = $this->directory;
 
 		if (!is_dir($path))
 		{

--- a/tests/unit/suites/libraries/joomla/form/fields/JFormFieldFolderListTest.php
+++ b/tests/unit/suites/libraries/joomla/form/fields/JFormFieldFolderListTest.php
@@ -49,6 +49,20 @@ class JFormFieldFolderListTest extends TestCase
 			'Line:' . __LINE__ . ' The getInput method should return something without error.'
 		);
 
+		$options = $field->options;
+		$this->assertThat(
+			count($options),
+			$this->greaterThan(0),
+			'Line:' . __LINE__ . ' The getOptions method should return several entries.'
+		);
+
+		$field->directory = JPATH_ROOT . '/modules';
+		$this->assertEquals(
+			$options,
+			$field->options,
+			'Line:' . __LINE__ . ' The getOptions method should return the same for relative and absolute paths.'
+		);
+
 		// TODO: Should check all the attributes have come in properly.
 	}
 }


### PR DESCRIPTION
Fixes regression of #16708/#20294

### Summary of Changes
The ltrim() breaks all absolute unix filesystem paths, which results in a bug in Fabrik with Joomla 3.9.16 https://fabrikar.com/forums/index.php?threads/error-after-joomla-update-to-3-9-16.51358/
