### PR TITLE
[4.0] Update ApiRouter.php

### DIFF
--- a/libraries/src/Router/ApiRouter.php
+++ b/libraries/src/Router/ApiRouter.php
@@ -115,7 +115,7 @@ class ApiRouter extends Router
 		// Remove the base URI path.
 		$path = substr_replace($path, '', 0, \strlen($baseUri));
 
-		if (!$this->app->get('sef_rewrite'))
+		if ($this->app->get('sef_rewrite'))
 		{
 			// Transform the route
 			if ($path === 'index.php')


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
A quick fix to allow joomla 4 webservices to work and not returning 404 resource not found.
I just removed an ! to invert the logic. To me it seemed like a typo. But before finding this I had to debug using Postman and PhpStorm.
With this fix:  it returns list of articles as expected.
@wilsonge I debugged it really deep using PhpStorm. Tell me what you think if it works for you too. Hope it helps.

### Testing Instructions
Try to access the article webservice using curl or Postman 
GET  /api/index.php/v1/content/article

### Expected result
GET  /api/index.php/v1/content/article should return a list of articles json-api response.


### Actual result

GET  /api/index.php/v1/content/article returns Resource not found json response.

### Documentation Changes Required
no
