### PR TITLE
[4.0] Fix order of uninstallation of repeatable fields plugin

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -92,7 +92,7 @@ class JoomlaInstallerScript
 			// Informational log only
 		}
 
-		// Ensure we delete the repeatable fields plugin before we remove it's files
+		// Ensure we delete the repeatable fields plugin before we remove its files
 		$this->uninstallRepeatableFieldsPlugin();
 
 		// This needs to stay for 2.5 update compatibility

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -92,6 +92,9 @@ class JoomlaInstallerScript
 			// Informational log only
 		}
 
+		// Ensure we delete the repeatable fields plugin before we remove it's files
+		$this->uninstallRepeatableFieldsPlugin();
+
 		// This needs to stay for 2.5 update compatibility
 		$this->deleteUnexistingFiles();
 		$this->updateManifestCaches();
@@ -99,7 +102,6 @@ class JoomlaInstallerScript
 		$this->updateAssets($installer);
 		$this->clearStatsCache();
 		$this->convertTablesToUtf8mb4(true);
-		$this->uninstallRepeatableFieldsPlugin();
 		$this->cleanJoomlaCache();
 
 		// VERY IMPORTANT! THIS METHOD SHOULD BE CALLED LAST, SINCE IT COULD


### PR DESCRIPTION
Fixes https://github.com/joomla/joomla-cms/issues/28385

### Summary of Changes
Fixes the update of Joomla 3.10 to Joomla 4.0

### Testing Instructions
Upgrade from 3.10 to 4.0. Before you get the error `0 Call to a member function attributes() on null` because the manifest file for the repeatable fields plugin has been removed in the `deleteUnexistingFiles` function before the `uninstallRepeatableFieldsPlugin`. So I've just moved the uninstallation up the pecking order.

### Documentation Changes Required
None
