### PR TITLE
[4.0] Fix PHP 7.4 notice in readmore plugin

### DIFF
--- a/plugins/editors-xtd/readmore/readmore.php
+++ b/plugins/editors-xtd/readmore/readmore.php
@@ -14,7 +14,6 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Plugin\CMSPlugin;
-use Joomla\Event\Event;
 
 /**
  * Editor Readmore button

--- a/plugins/editors-xtd/readmore/readmore.php
+++ b/plugins/editors-xtd/readmore/readmore.php
@@ -42,21 +42,12 @@ class PlgButtonReadmore extends CMSPlugin
 	 */
 	public function onDisplay($name)
 	{
-		// Button is not active in specific content components
-		$event = new Event(
-			'getContent',
-			['name' => $name]
-		);
-
-		$getContentResult = $this->getDispatcher()->dispatch('getContent', $event);
-		$getContent = $getContentResult['result'][0];
 		HTMLHelper::_('script', 'com_content/admin-article-readmore.min.js', array('version' => 'auto', 'relative' => true));
 
 		// Pass some data to javascript
 		Factory::getDocument()->addScriptOptions(
 			'xtd-readmore',
 			array(
-				'editor' => $getContent,
 				'exists' => Text::_('PLG_READMORE_ALREADY_EXISTS', true),
 			)
 		);


### PR DESCRIPTION
### Summary of Changes
Fixes notice shown in the readmore plugin in PHP 7.4 The editor option hasn't been used for a long time - so the event is actually useless. It also doesn't return anything hence the PHP Notice

### Testing Instructions
Check no notice in PHP 7.4 - Readmore plugin continues to work.

### Documentation Changes Required
None
