### PR TITLE
[4.0] select category buttons

### DIFF
--- a/administrator/templates/atum/scss/template-rtl.scss
+++ b/administrator/templates/atum/scss/template-rtl.scss
@@ -292,3 +292,7 @@ body {
   @include border-left-radius($border-radius);
   @include border-right-radius(0);
 }
+
+.input-group > .input-group-append > .btn:nth-of-type(odd):not(.hidden):not(:last-child) {
+  @include border-left-radius(0 !important);
+}

--- a/administrator/templates/atum/scss/vendor/bootstrap/_buttons.scss
+++ b/administrator/templates/atum/scss/vendor/bootstrap/_buttons.scss
@@ -30,3 +30,12 @@
   background-color: var(--atum-bg-dark);
   border-color: var(--atum-bg-dark);
 }
+
+.input-group > .input-group-append {
+  [dir=ltr] & {
+    .btn:nth-of-type(even):not(.hidden) {
+      @include border-right-radius($border-radius);
+    }
+  }
+}
+


### PR DESCRIPTION
PR for #28363

npm i or node build.js --compile-css

![image](https://user-images.githubusercontent.com/1296369/76735447-d962bb80-675c-11ea-9f07-b4c60f2c236d.png)

The second button should have rounded corners top-right and bottom-right. But the css only applies that rule to the last-child.

In this case its not the last-child because there are two additional children that are hidden
![image](https://user-images.githubusercontent.com/1296369/76736198-475bb280-675e-11ea-955f-63a93c499282.png)
