### PR TITLE
[4.0] Fix content history modal

### DIFF
--- a/administrator/components/com_contenthistory/tmpl/history/modal.php
+++ b/administrator/components/com_contenthistory/tmpl/history/modal.php
@@ -43,7 +43,7 @@ HTMLHelper::_('script', 'com_contenthistory/admin-history-modal.min.js', array('
 ?>
 <div class="container-popup">
 	<nav aria-label="toolbar">
-		<div class="btn-group float-right mb-3">
+		<div class="float-right mb-3">
 			<button id="toolbar-load" type="submit" class="btn btn-secondary" aria-label="<?php echo Text::_('COM_CONTENTHISTORY_BUTTON_LOAD_DESC'); ?>" title="<?php echo Text::_('COM_CONTENTHISTORY_BUTTON_LOAD_DESC'); ?>" data-url="<?php echo Route::_($loadUrl); ?>">
 				<span class="fas fa-upload" aria-hidden="true"></span>
 				<span class="d-none d-md-inline"><?php echo Text::_('COM_CONTENTHISTORY_BUTTON_LOAD'); ?></span>

--- a/templates/cassiopeia/scss/blocks/_modals.scss
+++ b/templates/cassiopeia/scss/blocks/_modals.scss
@@ -48,3 +48,8 @@
 .contentpane {
   padding: 15px;
 }
+
+// Content History
+.container-popup .mb-3 {
+  margin: 1rem;
+}


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/24491

### Summary of Changes
This PR takes off the btn-group class as it does not bring anything useful and breaks the RTL border-radius settings. Buttons will now be separated and much more readable anyway.
It also adds margins when displaying the Versions Modal in frontend.


### Before patch

<img width="835" alt="Screen Shot 2020-03-20 at 10 50 15" src="https://user-images.githubusercontent.com/869724/77153201-a80a2880-6a99-11ea-92b5-67dde59d6b79.png">
<img width="834" alt="Screen Shot 2020-03-20 at 10 49 14" src="https://user-images.githubusercontent.com/869724/77153206-a93b5580-6a99-11ea-8444-20af4b544b50.png">
<img width="834" alt="Screen Shot 2020-03-20 at 10 48 29" src="https://user-images.githubusercontent.com/869724/77153210-a9d3ec00-6a99-11ea-9f14-1cfb9ff103b3.png">
<img width="860" alt="Screen Shot 2020-03-20 at 10 47 05" src="https://user-images.githubusercontent.com/869724/77153211-ab9daf80-6a99-11ea-9fa3-c958110d3959.png">



### After patch
<img width="846" alt="Screen Shot 2020-03-20 at 10 42 20after" src="https://user-images.githubusercontent.com/869724/77153269-c839e780-6a99-11ea-8418-2d332aeba21b.png">
<img width="849" alt="Screen Shot 2020-03-20 at 10 42 09after" src="https://user-images.githubusercontent.com/869724/77153272-c96b1480-6a99-11ea-9fef-5b103d60e8be.png">
<img width="844" alt="Screen Shot 2020-03-20 at 10 41 17after" src="https://user-images.githubusercontent.com/869724/77153277-ca9c4180-6a99-11ea-9f1a-0819730b2668.png">
<img width="1001" alt="Screen Shot 2020-03-20 at 11 05 24" src="https://user-images.githubusercontent.com/869724/77154357-d12bb880-6a9b-11ea-94cf-b6f62b02de7b.png">

### Note
Remains to solve a Atum behavior
a float-right in LTR should give a float-left in RTL as it righfully does in Cassiopea

The scss in Cassiopea is correct
```
.float-right {
    float: left !important;
}
```
But not in Atum.
It looks like 

```
.float-right {
  float: left !important;
}

.float-left {
  float: right !important;
}
```
was not added in ATUM template-rtl.scss because of the use of flex-start and flex-end.
As the code for the contenthistory modal does not use searchtools but directly uses float-right and not flex we may have to add these in rtl.

Should be discussed and solved in another PR I guess.

