### PR TITLE
[4.0][api][com_content] - Add languages filter options to com_content

### DIFF
--- a/api/components/com_content/src/Controller/ArticlesController.php
+++ b/api/components/com_content/src/Controller/ArticlesController.php
@@ -70,6 +70,11 @@ class ArticlesController extends ApiController
 			$this->modelState->set('filter.condition', $filter->clean($apiFilterInfo['state'], 'INT'));
 		}
 
+		if (array_key_exists('language', $apiFilterInfo))
+		{
+			$this->modelState->set('filter.language', $filter->clean($apiFilterInfo['language'], 'STRING'));
+		}
+
 		return parent::displayList();
 	}
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
after the merge  of #28382
add the option to filter content by language

### Testing Instructions
on a multiligual site install Frech and German for example
run  Multilingual Sample Data 
call JROOT_URL/api/index.php/v1/content/article?filter[language]=de-DE

### Expected result
the api response is filtered by language


### Actual result
N/A


### Documentation Changes Required
yes
