### PR TITLE
[4.0] Add Zstandard as optional packaging option to the build script

### DIFF
--- a/build/build.php
+++ b/build/build.php
@@ -29,10 +29,11 @@ function usage(string $command)
 	echo PHP_EOL;
 	echo 'Usage: php ' . $command . ' [options]' . PHP_EOL;
 	echo PHP_TAB . '[options]:'.PHP_EOL;
-	echo PHP_TAB . PHP_TAB . '--remote <remote>:' . PHP_TAB . 'The git remote reference to build from (ex: `tags/3.8.6`, `4.0-dev`), defaults to the most recent tag for the repository' . PHP_EOL;
+	echo PHP_TAB . PHP_TAB . '--remote=<remote>:' . PHP_TAB . 'The git remote reference to build from (ex: `tags/3.8.6`, `4.0-dev`), defaults to the most recent tag for the repository' . PHP_EOL;
 	echo PHP_TAB . PHP_TAB . '--exclude-zip:' . PHP_TAB . PHP_TAB . 'Exclude the generation of .zip packages' . PHP_EOL;
 	echo PHP_TAB . PHP_TAB . '--exclude-gzip:' . PHP_TAB . PHP_TAB . 'Exclude the generation of .tar.gz packages' . PHP_EOL;
 	echo PHP_TAB . PHP_TAB . '--exclude-bzip2:' . PHP_TAB . 'Exclude the generation of .tar.bz2 packages' . PHP_EOL;
+	echo PHP_TAB . PHP_TAB . '--include-zstd:' . PHP_TAB . 'Include the generation of .tar.zst packages' . PHP_EOL;
 	echo PHP_TAB . PHP_TAB . '--help:' . PHP_TAB . PHP_TAB . PHP_TAB . 'Show this help output' . PHP_EOL;
 	echo PHP_EOL;
 }
@@ -164,12 +165,13 @@ $tmp      = $here . '/tmp';
 $fullpath = $tmp . '/' . $time;
 
 // Parse input options
-$options = getopt('', ['help', 'remote::', 'exclude-zip', 'exclude-gzip', 'exclude-bzip2']);
+$options = getopt('', ['help', 'remote::', 'exclude-zip', 'exclude-gzip', 'exclude-bzip2', 'include-zstd']);
 
 $remote       = $options['remote'] ?? false;
 $excludeZip   = isset($options['exclude-zip']);
 $excludeGzip  = isset($options['exclude-gzip']);
 $excludeBzip2 = isset($options['exclude-bzip2']);
+$excludeZstd  = !isset($options['include-zstd']);
 $showHelp     = isset($options['help']);
 
 if ($showHelp)
@@ -448,23 +450,38 @@ for ($num = $release - 1; $num >= 0; $num--)
 	if (!$excludeBzip2)
 	{
 		$packageName = 'Joomla_' . $version . '.' . $fromName . '_to_' . $fullVersion . '-' . $packageStability . '-Patch_Package.tar.bz2';
+		echo "Building " . $packageName . "... ";
 		system('tar --create --bzip2 --no-recursion --directory ' . $time . ' --file packages/' . $packageName . ' --files-from diffconvert/' . $version . '.' . $num . '> /dev/null');
+		echo "done.\n";
 		$checksums[$packageName] = array();
 	}
 
 	if (!$excludeGzip)
 	{
 		$packageName = 'Joomla_' . $version . '.' . $fromName . '_to_' . $fullVersion . '-' . $packageStability . '-Patch_Package.tar.gz';
+		echo "Building " . $packageName . "... ";
 		system('tar --create --gzip  --no-recursion --directory ' . $time . ' --file packages/' . $packageName . ' --files-from diffconvert/' . $version . '.' . $num . '> /dev/null');
+		echo "done.\n";
 		$checksums[$packageName] = array();
 	}
 
 	if (!$excludeZip)
 	{
 		$packageName = 'Joomla_' . $version . '.' . $fromName . '_to_' . $fullVersion . '-' . $packageStability . '-Patch_Package.zip';
+		echo "Building " . $packageName . "... ";
 		chdir($time);
 		system('zip ../packages/' . $packageName . ' -@ < ../diffconvert/' . $version . '.' . $num . '> /dev/null');
 		chdir('..');
+		echo "done.\n";
+		$checksums[$packageName] = array();
+	}
+
+	if (!$excludeZstd)
+	{
+		$packageName = 'Joomla_' . $version . '.' . $fromName . '_to_' . $fullVersion . '-' . $packageStability . '-Patch_Package.tar.zst';
+		echo "Building " . $packageName . "... ";
+		system('tar --create --use-compress-program=zstd --no-recursion --directory ' . $time . ' --file packages/' . $packageName . ' --files-from diffconvert/' . $version . '.' . $num . '> /dev/null');
+		echo "done.\n";
 		$checksums[$packageName] = array();
 	}
 }
@@ -476,21 +493,36 @@ chdir($time);
 if (!$excludeBzip2)
 {
 	$packageName = 'Joomla_' . $fullVersion . '-' . $packageStability . '-Full_Package.tar.bz2';
+	echo "Building " . $packageName . "... ";
 	system('tar --create --bzip2 --file ../packages/' . $packageName . ' * > /dev/null');
+	echo "done.\n";
 	$checksums[$packageName] = array();
 }
 
 if (!$excludeGzip)
 {
 	$packageName = 'Joomla_' . $fullVersion . '-' . $packageStability . '-Full_Package.tar.gz';
+	echo "Building " . $packageName . "... ";
 	system('tar --create --gzip --file ../packages/' . $packageName . ' * > /dev/null');
+	echo "done.\n";
 	$checksums[$packageName] = array();
 }
 
 if (!$excludeZip)
 {
 	$packageName = 'Joomla_' . $fullVersion . '-' . $packageStability . '-Full_Package.zip';
+	echo "Building " . $packageName . "... ";
 	system('zip -r ../packages/' . $packageName . ' * > /dev/null');
+	echo "done.\n";
+	$checksums[$packageName] = array();
+}
+
+if (!$excludeZstd)
+{
+	$packageName = 'Joomla_' . $fullVersion . '-' . $packageStability . '-Full_Package.tar.zst';
+	echo "Building " . $packageName . "... ";
+	system('tar --create --use-compress-program=zstd --file ../packages/' . $packageName . ' * > /dev/null');
+	echo "done.\n";
 	$checksums[$packageName] = array();
 }
 
@@ -507,21 +539,36 @@ system('rm images/powered_by.png');
 if (!$excludeBzip2)
 {
 	$packageName = 'Joomla_' . $fullVersion . '-' . $packageStability . '-Update_Package.tar.bz2';
+	echo "Building " . $packageName . "... ";
 	system('tar --create --bzip2 --file ../packages/' . $packageName . ' * > /dev/null');
+	echo "done.\n";
 	$checksums[$packageName] = array();
 }
 
 if (!$excludeGzip)
 {
 	$packageName = 'Joomla_' . $fullVersion . '-' . $packageStability . '-Update_Package.tar.gz';
+	echo "Building " . $packageName . "... ";
 	system('tar --create --gzip --file ../packages/' . $packageName . ' * > /dev/null');
+	echo "done.\n";
 	$checksums[$packageName] = array();
 }
 
 if (!$excludeZip)
 {
 	$packageName = 'Joomla_' . $fullVersion . '-' . $packageStability . '-Update_Package.zip';
+	echo "Building " . $packageName . "... ";
 	system('zip -r ../packages/' . $packageName . ' * > /dev/null');
+	echo "done.\n";
+	$checksums[$packageName] = array();
+}
+
+if (!$excludeZstd)
+{
+	$packageName = 'Joomla_' . $fullVersion . '-' . $packageStability . '-Update_Package.tar.zst';
+	echo "Building " . $packageName . "... ";
+	system('tar --create --use-compress-program=zstd --file ../packages/' . $packageName . ' * > /dev/null');
+	echo "done.\n";
 	$checksums[$packageName] = array();
 }
 


### PR DESCRIPTION
### Summary of Changes
This PR adds the new option '--include-zstd' to the build script and some debug information.

This option will be used in the upcoming PR for packaging each PR with ready to install and upgrade .zip and .tar.zst files.

Zstandard is much faster on decompression and has a comparable compression ration then bzip2.

Benchmark and more information about Zstandard could be found at:

https://github.com/inikep/lzbench
https://facebook.github.io/zstd/

### Testing Instructions
Build Joomla with --include-zstd and without this option

### Expected result
With option: Get packages with .tar.zst
Without option: Don't get additional packages

### Actual result
The same as Expected


