### PR TITLE
Multibyte safe search

### DIFF
--- a/administrator/components/com_banners/models/tracks.php
+++ b/administrator/components/com_banners/models/tracks.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 use Joomla\Archive\Archive;
+use Joomla\String\StringHelper;
 
 JLoader::register('BannersHelper', JPATH_ADMINISTRATOR . '/components/com_banners/helpers/banners.php');
 
@@ -167,7 +168,7 @@ class BannersModelTracks extends JModelList
 
 		if (!empty($search))
 		{
-			$search = $db->quote('%' . strtolower($search) . '%');
+			$search = $db->quote('%' . StringHelper::strtolower($search) . '%');
 			$query->where('(LOWER(b.name) LIKE ' . $search . ' OR LOWER(cl.name) LIKE ' . $search . ')');
 		}
 

--- a/administrator/components/com_modules/models/modules.php
+++ b/administrator/components/com_modules/models/modules.php
@@ -9,6 +9,7 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\String\StringHelper;
 use Joomla\Utilities\ArrayHelper;
 
 /**
@@ -403,7 +404,7 @@ class ModulesModelModules extends JModelList
 			}
 			else
 			{
-				$search = $db->quote('%' . strtolower($search) . '%');
+				$search = $db->quote('%' . StringHelper::strtolower($search) . '%');
 				$query->where('(LOWER(a.title) LIKE ' . $search . ' OR LOWER(a.note) LIKE ' . $search . ')');
 			}
 		}

--- a/administrator/components/com_templates/models/styles.php
+++ b/administrator/components/com_templates/models/styles.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\String\StringHelper;
+
 /**
  * Methods supporting a list of template style records.
  *
@@ -186,7 +188,7 @@ class TemplatesModelStyles extends JModelList
 			}
 			else
 			{
-				$search = $db->quote('%' . strtolower($search) . '%');
+				$search = $db->quote('%' . StringHelper::strtolower($search) . '%');
 				$query->where('(' . ' LOWER(a.template) LIKE ' . $search . ' OR LOWER(a.title) LIKE ' . $search . ')');
 			}
 		}

--- a/administrator/components/com_templates/models/templates.php
+++ b/administrator/components/com_templates/models/templates.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\String\StringHelper;
+
 /**
  * Methods supporting a list of template extension records.
  *
@@ -98,7 +100,7 @@ class TemplatesModelTemplates extends JModelList
 			}
 			else
 			{
-				$search = $db->quote('%' . strtolower($search) . '%');
+				$search = $db->quote('%' . StringHelper::strtolower($search) . '%');
 				$query->where('(' . ' LOWER(a.element) LIKE ' . $search . ' OR LOWER(a.name) LIKE ' . $search . ')');
 			}
 		}


### PR DESCRIPTION
Fixes https://github.com/joomla/joomla-cms/issues/28408.

### Summary of Changes

Use multibyte safe `strtolower()` in some components.

### Testing Instructions

Create a module containing multibyte characters, e.g. `Ačiū`.
In module search field enter `Ačiū` and submit.

### Expected result

Module found.

### Actual result

Module not found.

### Documentation Changes Required

No.