### PR TITLE
[4.0] Fix login module input border radius

### DIFF
--- a/modules/mod_login/tmpl/default.php
+++ b/modules/mod_login/tmpl/default.php
@@ -51,9 +51,9 @@ Text::script('JHIDEPASSWORD');
 		<div class="mod-login__password form-group">
 			<?php if (!$params->get('usetext', 0)) : ?>
 				<div class="input-group">
-					<label for="modlgn-passwd-<?php echo $module->id; ?>" class="sr-only"><?php echo Text::_('JGLOBAL_PASSWORD'); ?></label>
 					<input id="modlgn-passwd-<?php echo $module->id; ?>" type="password" name="password" autocomplete="current-password" class="form-control" placeholder="<?php echo Text::_('JGLOBAL_PASSWORD'); ?>">
 					<span class="input-group-append">
+						<label for="modlgn-passwd-<?php echo $module->id; ?>" class="sr-only"><?php echo Text::_('JGLOBAL_PASSWORD'); ?></label>
 						<button type="button" class="btn btn-secondary input-password-toggle">
 							<span class="fas fa-eye" aria-hidden="true"></span>
 							<span class="sr-only"><?php echo Text::_('JSHOWPASSWORD'); ?></span>


### PR DESCRIPTION
# Summary of Changes 

The label was prevent the input border radius from being applied because it's still technically a visible element. This PR simply moves it down a little so the styling isn't affected

![before-after](https://user-images.githubusercontent.com/2019801/77164798-ece98b80-6aa8-11ea-9bb5-2f44e8c5bd25.png)
