### PR TITLE
[4.0] Fix frontend menu editing

### DIFF
--- a/modules/mod_menu/tmpl/default.php
+++ b/modules/mod_menu/tmpl/default.php
@@ -27,7 +27,7 @@ if ($tagId = $params->get('tag_id', ''))
 <?php foreach ($list as $i => &$item)
 {
 	$itemParams = $item->getParams();
-	$class      = 'nav-item';
+	$class      = 'nav-item item-' . $item->id;
 
 	if ($item->id == $default_id)
 	{


### PR DESCRIPTION
### Summary of Changes

Joomla's frontend editing script searches for the item ID within the list item class.
It appeared to be missing in J4, so this simply re-adds it.

### Testing Instructions

1. Go to your Global Configuration in the backend
2. Set `Inline Editing` to `Modules & Menus`
3. Hover over any menu item in the frontend

### Expected result

A button should appear allowing you to edit the menu item

![screeny](https://user-images.githubusercontent.com/2019801/77170120-7ea9c680-6ab2-11ea-8e96-ff11ad40a2a3.png)

