### PR TITLE
[4.0] Remove references to non-existant CSS file

### DIFF
--- a/layouts/joomla/edit/frontediting_modules.php
+++ b/layouts/joomla/edit/frontediting_modules.php
@@ -70,6 +70,5 @@ if ($count)
 	// Load stylesheet and javascript to head:
 	HTMLHelper::_('bootstrap.popover');
 
-	HTMLHelper::_('stylesheet', 'legacy/frontediting.css', array('version' => 'auto', 'relative' => true));
 	HTMLHelper::_('script', 'legacy/frontediting.min.js', array('version' => 'auto', 'relative' => true));
 }


### PR DESCRIPTION
### Summary of Changes

`frontediting.css` does not exist in Joomla 4.
This PR removes the reference to it.

### Testing Instructions

Code review.