### PR TITLE
[4.0][api][com_plugins] - Add filter options

### DIFF
--- a/api/components/com_plugins/src/Controller/PluginsController.php
+++ b/api/components/com_plugins/src/Controller/PluginsController.php
@@ -109,9 +109,9 @@ class PluginsController extends ApiController
 			$this->modelState->set('filter.element', $filter->clean($apiFilterInfo['element'], 'STRING'));
 		}
 
-		if (array_key_exists('enabled', $apiFilterInfo))
+		if (array_key_exists('status', $apiFilterInfo))
 		{
-			$this->modelState->set('filter.enabled', $filter->clean($apiFilterInfo['enabled'], 'INT'));
+			$this->modelState->set('filter.enabled', $filter->clean($apiFilterInfo['status'], 'INT'));
 		}
 
 		if (array_key_exists('search', $apiFilterInfo))
@@ -119,9 +119,9 @@ class PluginsController extends ApiController
 			$this->modelState->set('filter.search', $filter->clean($apiFilterInfo['search'], 'STRING'));
 		}
 
-		if (array_key_exists('folder', $apiFilterInfo))
+		if (array_key_exists('type', $apiFilterInfo))
 		{
-			$this->modelState->set('filter.folder', $filter->clean($apiFilterInfo['folder'], 'STRING'));
+			$this->modelState->set('filter.folder', $filter->clean($apiFilterInfo['type'], 'STRING'));
 		}
 
 		return parent::displayList();

--- a/api/components/com_plugins/src/Controller/PluginsController.php
+++ b/api/components/com_plugins/src/Controller/PluginsController.php
@@ -11,6 +11,7 @@ namespace Joomla\Component\Plugins\Api\Controller;
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Controller\ApiController;
 use Joomla\String\Inflector;
@@ -89,5 +90,40 @@ class PluginsController extends ApiController
 		$this->input->set('data', $data);
 
 		return parent::edit();
+	}
+
+	/**
+	 * Plugin list view with filtering of data
+	 *
+	 * @return  static  A BaseController object to support chaining.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function displayList()
+	{
+		$apiFilterInfo = $this->input->get('filter', [], 'array');
+		$filter        = InputFilter::getInstance();
+
+		if (array_key_exists('element', $apiFilterInfo))
+		{
+			$this->modelState->set('filter.element', $filter->clean($apiFilterInfo['element'], 'STRING'));
+		}
+
+		if (array_key_exists('enabled', $apiFilterInfo))
+		{
+			$this->modelState->set('filter.enabled', $filter->clean($apiFilterInfo['enabled'], 'INT'));
+		}
+
+		if (array_key_exists('search', $apiFilterInfo))
+		{
+			$this->modelState->set('filter.search', $filter->clean($apiFilterInfo['search'], 'STRING'));
+		}
+
+		if (array_key_exists('folder', $apiFilterInfo))
+		{
+			$this->modelState->set('filter.folder', $filter->clean($apiFilterInfo['folder'], 'STRING'));
+		}
+
+		return parent::displayList();
 	}
 }


### PR DESCRIPTION
### Summary of Changes
added the option to filter plugins by element, state, search,folder


### Testing Instructions
call `JROOT_URL/api/index.php/v1/plugins?filter[element]=privacyconsent`
call `JROOT_URL/api/index.php/v1/plugins?filter[type]=system`
call `JROOT_URL/api/index.php/v1/plugins?filter[search]=Web Services`
call `JROOT_URL/api/index.php/v1/plugins?filter[status]=0`
or any combination like : 
`JROOT_URL/api/index.php/v1/plugins?filter[type]=system&filter[status]=0`
etc

### Expected result
the api response is filtered 


### Actual result
N/A


### Documentation Changes Required
Yes
