### PR TITLE
[4.0] WebAsset for template/system

### DIFF
--- a/administrator/templates/system/error.php
+++ b/administrator/templates/system/error.php
@@ -9,14 +9,13 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 
-/** @var JDocumentError $this */
+/** @var Joomla\CMS\Document\ErrorDocument $this */
 
 // Load template CSS file
-HTMLHelper::_('stylesheet', 'error.css', ['version' => 'auto', 'relative' => true]);
+$this->getWebAssetManager()->registerAndUseStyle('template.system.error', 'error.css');
 
 // Set page title
 $this->setTitle($this->error->getCode() . ' - ' . htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'));

--- a/administrator/templates/system/error.php
+++ b/administrator/templates/system/error.php
@@ -15,7 +15,7 @@ use Joomla\CMS\Router\Route;
 /** @var Joomla\CMS\Document\ErrorDocument $this */
 
 // Load template CSS file
-$this->getWebAssetManager()->registerAndUseStyle('template.system.error', 'error.css');
+$this->getWebAssetManager()->registerAndUseStyle('template.system.error', 'administrator/templates/system/css/error.css');
 
 // Set page title
 $this->setTitle($this->error->getCode() . ' - ' . htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'));

--- a/templates/system/component.php
+++ b/templates/system/component.php
@@ -9,12 +9,11 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\HTML\HTMLHelper;
-
-/** @var JDocumentHtml $this */
+/** @var Joomla\CMS\Document\HtmlDocument $this */
 
 // Styles
-HTMLHelper::_('stylesheet', 'general.css', ['version' => 'auto', 'relative' => true]);
+$this->getWebAssetManager()->registerAndUseStyle('template.system.general', 'templates/system/css/general.css');
+
 ?>
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">

--- a/templates/system/error.php
+++ b/templates/system/error.php
@@ -9,11 +9,10 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Uri\Uri;
 
-/** @var JDocumentError $this */
+/** @var Joomla\CMS\Document\ErrorDocument  $this */
 
 if (!isset($this->error))
 {
@@ -22,11 +21,11 @@ if (!isset($this->error))
 }
 
 // Load template CSS file
-HTMLHelper::_('stylesheet', 'error.css', ['version' => 'auto', 'relative' => true]);
+$this->getWebAssetManager()->registerAndUseStyle('template.system.error', 'templates/system/css/error.css');
 
 if ($this->direction === 'rtl')
 {
-	HTMLHelper::_('stylesheet', 'error_rtl.css', ['version' => 'auto', 'relative' => true]);
+	$this->getWebAssetManager()->registerAndUseStyle('template.system.error_rtl', 'templates/system/css/error_rtl.css');
 }
 
 // Set page title

--- a/templates/system/offline.php
+++ b/templates/system/offline.php
@@ -16,24 +16,23 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
 
-/** @var JDocumentHtml $this */
+/** @var Joomla\CMS\Document\HtmlDocument $this */
 
 $app = Factory::getApplication();
+$wa  = $this->getWebAssetManager();
 
 // Styles
-HTMLHelper::_('stylesheet', 'templates/system/css/offline.css', ['version' => 'auto']);
+$wa->registerAndUseStyle('template.system.offline', 'templates/system/css/offline.css');
 
 if ($this->direction === 'rtl')
 {
-	HTMLHelper::_('stylesheet', 'templates/system/css/offline_rtl.css', ['version' => 'auto']);
+	$wa->registerAndUseStyle('template.system.offline_rtl', 'templates/system/css/offline_rtl.css');
 }
 
-HTMLHelper::_('stylesheet', 'templates/system/css/general.css', ['version' => 'auto']);
-
-// Add JavaScript Frameworks
-HTMLHelper::_('bootstrap.framework');
+$wa->registerAndUseStyle('template.system.general', 'templates/system/css/general.css');
 
 $twofactormethods = AuthenticationHelper::getTwoFactorMethods();
+
 ?>
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">


### PR DESCRIPTION
### Summary of Changes
This replaces htmlhelper to webaset for template/system


### Testing Instructions
Apply path
Remove or rename next files in Cassiopeia/Atum:
error.php
component.php
offline.php

Then: 
- On the site/admin, try make some error with non existing links/components. eg `index.php?option=com_foobar`
- Turn On/Off Offline mode.
- Append `?tmpl=component` to existing url.

### Expected result
All works
You should see some old school styling for those pages.


### Actual result
All works


### Documentation Changes Required
no

ref  #22435