### PR TITLE
[4.0] WebAsset for plugins

### DIFF
--- a/plugins/captcha/recaptcha/recaptcha.php
+++ b/plugins/captcha/recaptcha/recaptcha.php
@@ -33,6 +33,14 @@ class PlgCaptchaRecaptcha extends CMSPlugin
 	protected $autoloadLanguage = true;
 
 	/**
+	 * Application object.
+	 *
+	 * @var    \Joomla\CMS\Application\CMSApplication
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $app;
+
+	/**
 	 * Reports the privacy related capabilities for this plugin to site administrators.
 	 *
 	 * @return  array
@@ -72,11 +80,9 @@ class PlgCaptchaRecaptcha extends CMSPlugin
 		$apiSrc = 'https://www.google.com/recaptcha/api.js?onload=Joomla.initReCaptcha2&render=explicit&hl='
 			. Factory::getLanguage()->getTag();
 
-		/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
-		$wa = Factory::getApplication()->getDocument()->getWebAssetManager();
-
 		// Load assets, the callback should be first
-		$wa->registerAndUseScript('plg_captcha_recaptcha', 'plg_captcha_recaptcha/recaptcha.min.js', [], ['defer' => true])
+		$this->app->getDocument()->getWebAssetManager()
+			->registerAndUseScript('plg_captcha_recaptcha', 'plg_captcha_recaptcha/recaptcha.min.js', [], ['defer' => true])
 			->registerAndUseScript('plg_captcha_recaptcha.api', $apiSrc, [], ['defer' => true], ['plg_captcha_recaptcha']);
 
 		return true;

--- a/plugins/captcha/recaptcha/recaptcha.php
+++ b/plugins/captcha/recaptcha/recaptcha.php
@@ -11,7 +11,6 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Captcha\Google\HttpBridgePostRequestMethod;
 use Joomla\CMS\Factory;
-use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\Utilities\IpHelper;
@@ -70,13 +69,14 @@ class PlgCaptchaRecaptcha extends CMSPlugin
 			throw new \RuntimeException(Text::_('PLG_RECAPTCHA_ERROR_NO_PUBLIC_KEY'));
 		}
 
-		// Load callback first for browser compatibility
-		HTMLHelper::_('script', 'plg_captcha_recaptcha/recaptcha.min.js', array('version' => 'auto', 'relative' => true));
+		$apiSrc = 'https://www.google.com/recaptcha/api.js?onload=Joomla.initReCaptcha2&render=explicit&hl=' . Factory::getLanguage()->getTag();
 
-		HTMLHelper::_(
-			'script',
-			'https://www.google.com/recaptcha/api.js?onload=Joomla.initReCaptcha2&render=explicit&hl=' . Factory::getLanguage()->getTag()
-		);
+		/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+		$wa = Factory::getApplication()->getDocument()->getWebAssetManager();
+
+		// Load assets, the callback should be first
+		$wa->registerAndUseScript('plg_captcha_recaptcha', 'plg_captcha_recaptcha/recaptcha.min.js', [], ['defer' => true])
+			->registerAndUseScript('plg_captcha_recaptcha.api', $apiSrc, [], ['defer' => true], ['plg_captcha_recaptcha']);
 
 		return true;
 	}

--- a/plugins/captcha/recaptcha/recaptcha.php
+++ b/plugins/captcha/recaptcha/recaptcha.php
@@ -69,7 +69,8 @@ class PlgCaptchaRecaptcha extends CMSPlugin
 			throw new \RuntimeException(Text::_('PLG_RECAPTCHA_ERROR_NO_PUBLIC_KEY'));
 		}
 
-		$apiSrc = 'https://www.google.com/recaptcha/api.js?onload=Joomla.initReCaptcha2&render=explicit&hl=' . Factory::getLanguage()->getTag();
+		$apiSrc = 'https://www.google.com/recaptcha/api.js?onload=Joomla.initReCaptcha2&render=explicit&hl='
+			. Factory::getLanguage()->getTag();
 
 		/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 		$wa = Factory::getApplication()->getDocument()->getWebAssetManager();

--- a/plugins/captcha/recaptcha_invisible/recaptcha_invisible.php
+++ b/plugins/captcha/recaptcha_invisible/recaptcha_invisible.php
@@ -67,7 +67,8 @@ class PlgCaptchaRecaptcha_Invisible extends CMSPlugin
 			throw new \RuntimeException(Text::_('PLG_RECAPTCHA_INVISIBLE_ERROR_NO_PUBLIC_KEY'));
 		}
 
-		$apiSrc = 'https://www.google.com/recaptcha/api.js?onload=Joomla.initReCaptchaInvisible&render=explicit&hl=' . Factory::getLanguage()->getTag();
+		$apiSrc = 'https://www.google.com/recaptcha/api.js?onload=Joomla.initReCaptchaInvisible&render=explicit&hl='
+			. Factory::getLanguage()->getTag();
 
 		/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 		$wa = Factory::getApplication()->getDocument()->getWebAssetManager();

--- a/plugins/captcha/recaptcha_invisible/recaptcha_invisible.php
+++ b/plugins/captcha/recaptcha_invisible/recaptcha_invisible.php
@@ -31,6 +31,14 @@ class PlgCaptchaRecaptcha_Invisible extends CMSPlugin
 	protected $autoloadLanguage = true;
 
 	/**
+	 * Application object.
+	 *
+	 * @var    \Joomla\CMS\Application\CMSApplication
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $app;
+
+	/**
 	 * Reports the privacy related capabilities for this plugin to site administrators.
 	 *
 	 * @return  array
@@ -70,11 +78,9 @@ class PlgCaptchaRecaptcha_Invisible extends CMSPlugin
 		$apiSrc = 'https://www.google.com/recaptcha/api.js?onload=Joomla.initReCaptchaInvisible&render=explicit&hl='
 			. Factory::getLanguage()->getTag();
 
-		/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
-		$wa = Factory::getApplication()->getDocument()->getWebAssetManager();
-
 		// Load assets, the callback should be first
-		$wa->registerAndUseScript('plg_captcha_recaptchainvisible', 'plg_captcha_recaptcha_invisible/recaptcha.min.js', [], ['defer' => true])
+		$this->app->getDocument()->getWebAssetManager()
+			->registerAndUseScript('plg_captcha_recaptchainvisible', 'plg_captcha_recaptcha_invisible/recaptcha.min.js', [], ['defer' => true])
 			->registerAndUseScript('plg_captcha_recaptchainvisible.api', $apiSrc, [], ['defer' => true], ['plg_captcha_recaptchainvisible']);
 
 		return true;

--- a/plugins/captcha/recaptcha_invisible/recaptcha_invisible.php
+++ b/plugins/captcha/recaptcha_invisible/recaptcha_invisible.php
@@ -11,7 +11,6 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Captcha\Google\HttpBridgePostRequestMethod;
 use Joomla\CMS\Factory;
-use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\Utilities\IpHelper;
@@ -68,25 +67,14 @@ class PlgCaptchaRecaptcha_Invisible extends CMSPlugin
 			throw new \RuntimeException(Text::_('PLG_RECAPTCHA_INVISIBLE_ERROR_NO_PUBLIC_KEY'));
 		}
 
-		// Load callback first for browser compatibility
-		HTMLHelper::_(
-			'script',
-			'plg_captcha_recaptcha_invisible/recaptcha.min.js',
-			array('version' => 'auto', 'relative' => true),
-			array('async' => 'async', 'defer' => 'defer')
-		);
+		$apiSrc = 'https://www.google.com/recaptcha/api.js?onload=Joomla.initReCaptchaInvisible&render=explicit&hl=' . Factory::getLanguage()->getTag();
 
-		// Load Google reCAPTCHA api js
-		$file = 'https://www.google.com/recaptcha/api.js'
-			. '?onload=Joomla.initReCaptchaInvisible'
-			. '&render=explicit'
-			. '&hl=' . Factory::getLanguage()->getTag();
-		HTMLHelper::_(
-			'script',
-			$file,
-			array(),
-			array('async' => 'async', 'defer' => 'defer')
-		);
+		/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+		$wa = Factory::getApplication()->getDocument()->getWebAssetManager();
+
+		// Load assets, the callback should be first
+		$wa->registerAndUseScript('plg_captcha_recaptchainvisible', 'plg_captcha_recaptcha_invisible/recaptcha.min.js', [], ['defer' => true])
+			->registerAndUseScript('plg_captcha_recaptchainvisible.api', $apiSrc, [], ['defer' => true], ['plg_captcha_recaptchainvisible']);
 
 		return true;
 	}

--- a/plugins/editors-xtd/readmore/readmore.php
+++ b/plugins/editors-xtd/readmore/readmore.php
@@ -9,7 +9,6 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Plugin\CMSPlugin;
@@ -30,6 +29,14 @@ class PlgButtonReadmore extends CMSPlugin
 	protected $autoloadLanguage = true;
 
 	/**
+	 * Application object.
+	 *
+	 * @var    \Joomla\CMS\Application\CMSApplication
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $app;
+
+	/**
 	 * Readmore button
 	 *
 	 * @param   string  $name  The name of the button to add
@@ -40,8 +47,7 @@ class PlgButtonReadmore extends CMSPlugin
 	 */
 	public function onDisplay($name)
 	{
-		/** @var Joomla\CMS\Document\HtmlDocument $doc */
-		$doc = Factory::getApplication()->getDocument();
+		$doc = $this->app->getDocument();
 		$doc->getWebAssetManager()
 			->registerAndUseScript('com_content.admin-article-readmore', 'com_content/admin-article-readmore.min.js', [], ['defer' => true], ['core']);
 

--- a/plugins/editors-xtd/readmore/readmore.php
+++ b/plugins/editors-xtd/readmore/readmore.php
@@ -41,10 +41,13 @@ class PlgButtonReadmore extends CMSPlugin
 	 */
 	public function onDisplay($name)
 	{
-		HTMLHelper::_('script', 'com_content/admin-article-readmore.min.js', array('version' => 'auto', 'relative' => true));
+		/** @var Joomla\CMS\Document\HtmlDocument $doc */
+		$doc = Factory::getApplication()->getDocument();
+		$doc->getWebAssetManager()
+			->registerAndUseScript('com_content.admin-article-readmore', 'com_content/admin-article-readmore.min.js', [], ['defer' => true], ['core']);
 
 		// Pass some data to javascript
-		Factory::getDocument()->addScriptOptions(
+		$doc->addScriptOptions(
 			'xtd-readmore',
 			array(
 				'exists' => Text::_('PLG_READMORE_ALREADY_EXISTS', true),

--- a/plugins/editors-xtd/readmore/readmore.php
+++ b/plugins/editors-xtd/readmore/readmore.php
@@ -10,7 +10,6 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
-use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Plugin\CMSPlugin;

--- a/plugins/editors/codemirror/codemirror.php
+++ b/plugins/editors/codemirror/codemirror.php
@@ -57,6 +57,14 @@ class PlgEditorCodemirror extends CMSPlugin
 	protected $modePath = 'media/vendor/codemirror/mode/%N/%N';
 
 	/**
+	 * Application object.
+	 *
+	 * @var    \Joomla\CMS\Application\CMSApplication
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $app;
+
+	/**
 	 * Initialises the Editor.
 	 *
 	 * @return  void
@@ -74,13 +82,13 @@ class PlgEditorCodemirror extends CMSPlugin
 		$done = true;
 
 		// Most likely need this later
-		$doc = Factory::getDocument();
+		$doc = $this->app->getDocument();
 
 		// Codemirror shall have its own group of plugins to modify and extend its behavior
 		PluginHelper::importPlugin('editors_codemirror');
 
 		// At this point, params can be modified by a plugin before going to the layout renderer.
-		Factory::getApplication()->triggerEvent('onCodeMirrorBeforeInit', array(&$this->params, &$this->basePath, &$this->modePath));
+		$this->app->triggerEvent('onCodeMirrorBeforeInit', array(&$this->params, &$this->basePath, &$this->modePath));
 
 		$displayData = (object) array('params' => $this->params);
 		$font = $this->params->get('fontFamily', '0');
@@ -104,7 +112,7 @@ class PlgEditorCodemirror extends CMSPlugin
 		LayoutHelper::render('editors.codemirror.styles', $displayData, __DIR__ . '/layouts');
 		ob_end_clean();
 
-		Factory::getApplication()->triggerEvent('onCodeMirrorAfterInit', array(&$this->params, &$this->basePath, &$this->modePath));
+		$this->app->triggerEvent('onCodeMirrorAfterInit', array(&$this->params, &$this->basePath, &$this->modePath));
 	}
 
 	/**
@@ -198,9 +206,8 @@ class PlgEditorCodemirror extends CMSPlugin
 		{
 			$options->theme = $theme;
 
-			/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
-			$wa = Factory::getApplication()->getDocument()->getWebAssetManager();
-			$wa->registerAndUseStyle('codemirror.theme', $this->basePath . 'theme/' . $theme . '.css');
+			$this->app->getDocument()->getWebAssetManager()
+				->registerAndUseStyle('codemirror.theme', $this->basePath . 'theme/' . $theme . '.css');
 		}
 
 		// Special options for tagged modes (xml/html).
@@ -253,11 +260,11 @@ class PlgEditorCodemirror extends CMSPlugin
 		);
 
 		// At this point, displayData can be modified by a plugin before going to the layout renderer.
-		$results = Factory::getApplication()->triggerEvent('onCodeMirrorBeforeDisplay', array(&$displayData));
+		$results = $this->app->triggerEvent('onCodeMirrorBeforeDisplay', array(&$displayData));
 
 		$results[] = LayoutHelper::render('editors.codemirror.element', $displayData, __DIR__ . '/layouts');
 
-		foreach (Factory::getApplication()->triggerEvent('onCodeMirrorAfterDisplay', array(&$displayData)) as $result)
+		foreach ($this->app->triggerEvent('onCodeMirrorAfterDisplay', array(&$displayData)) as $result)
 		{
 			$results[] = $result;
 		}
@@ -322,8 +329,12 @@ class PlgEditorCodemirror extends CMSPlugin
 	 */
 	protected function loadKeyMap($keyMap)
 	{
-		/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
-		$wa = Factory::getApplication()->getDocument()->getWebAssetManager();
-		$wa->registerAndUseScript('codemirror.keymap.' . $keyMap, $this->basePath . 'keymap/' . $keyMap . '.min.js', [], ['defer' => true]);
+		$this->app->getDocument()->getWebAssetManager()
+			->registerAndUseScript(
+				'codemirror.keymap.' . $keyMap,
+				$this->basePath . 'keymap/' . $keyMap . '.min.js',
+				[],
+				['defer' => true]
+			);
 	}
 }

--- a/plugins/editors/codemirror/codemirror.php
+++ b/plugins/editors/codemirror/codemirror.php
@@ -199,7 +199,9 @@ class PlgEditorCodemirror extends CMSPlugin
 		{
 			$options->theme = $theme;
 
-			HTMLHelper::_('stylesheet', $this->basePath . 'theme/' . $theme . '.css', array('version' => 'auto'));
+			/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+			$wa = Factory::getApplication()->getDocument()->getWebAssetManager();
+			$wa->registerAndUseStyle('codemirror.theme', $this->basePath . 'theme/' . $theme . '.css');
 		}
 
 		// Special options for tagged modes (xml/html).
@@ -321,7 +323,8 @@ class PlgEditorCodemirror extends CMSPlugin
 	 */
 	protected function loadKeyMap($keyMap)
 	{
-		$ext = JDEBUG ? '.js' : '.min.js';
-		HTMLHelper::_('script', $this->basePath . 'keymap/' . $keyMap . $ext, array('version' => 'auto'));
+		/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+		$wa = Factory::getApplication()->getDocument()->getWebAssetManager();
+		$wa->registerAndUseScript('codemirror.keymap.' . $keyMap, $this->basePath . 'keymap/' . $keyMap . '.min.js', [], ['defer' => true]);
 	}
 }

--- a/plugins/editors/codemirror/codemirror.php
+++ b/plugins/editors/codemirror/codemirror.php
@@ -11,7 +11,6 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
-use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\CMS\Plugin\PluginHelper;

--- a/plugins/editors/codemirror/codemirror.php
+++ b/plugins/editors/codemirror/codemirror.php
@@ -10,7 +10,6 @@
 // No direct access
 defined('_JEXEC') or die;
 
-use Joomla\CMS\Factory;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\CMS\Plugin\PluginHelper;

--- a/plugins/editors/codemirror/layouts/editors/codemirror/styles.php
+++ b/plugins/editors/codemirror/layouts/editors/codemirror/styles.php
@@ -11,7 +11,6 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
-use Joomla\CMS\HTML\HTMLHelper;
 
 $params     = $displayData->params;
 $fontFamily = $displayData->fontFamily ?? 'monospace';
@@ -32,9 +31,10 @@ $g                   = hexdec($color[3] . $color[4]);
 $b                   = hexdec($color[5] . $color[6]);
 $highlightMatchColor = 'rgba(' . $r . ', ' . $g . ', ' . $b . ', .5)';
 
-HTMLHelper::_('stylesheet', 'plg_editors_codemirror/codemirror.css', array('version' => 'auto', 'relative' => true));
-
-Factory::getDocument()->addStyleDeclaration(
+/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+$wa = Factory::getApplication()->getDocument()->getWebAssetManager();
+$wa->registerAndUseStyle('plg_editors_codemirror', 'plg_editors_codemirror/codemirror.css');
+$wa->addInlineStyle(
 <<<CSS
 		.CodeMirror {
 			font-family: $fontFamily;

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -14,7 +14,6 @@ use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Filesystem\Folder;
 use Joomla\CMS\Filter\InputFilter;
-use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Log\Log;
@@ -62,9 +61,20 @@ class PlgEditorTinymce extends CMSPlugin
 	 */
 	public function onInit()
 	{
-		HTMLHelper::_('behavior.core');
-		HTMLHelper::_('script', $this->_basePath . '/tinymce.min.js', array('version' => 'auto'));
-		HTMLHelper::_('script', 'plg_editors_tinymce/tinymce.min.js', array('version' => 'auto', 'relative' => true));
+		$wa = $this->app->getDocument()->getWebAssetManager();
+
+		if (!$wa->assetExists('script', 'tinymce'))
+		{
+			$wa->registerScript('tinymce', $this->_basePath . '/tinymce.min.js', [], ['defer' => true]);
+		}
+
+		if (!$wa->assetExists('script', 'plg_editors_tinymce'))
+		{
+			$wa->registerScript('plg_editors_tinymce', 'plg_editors_tinymce/tinymce.min.js', [], ['defer' => true], ['core', 'tinymce']);
+		}
+
+		$wa->useScript('tinymce')
+			->useScript('plg_editors_tinymce');
 	}
 
 	/**

--- a/plugins/installer/webinstaller/webinstaller.php
+++ b/plugins/installer/webinstaller/webinstaller.php
@@ -89,7 +89,13 @@ class PlgInstallerWebinstaller extends CMSPlugin
 
 		$doc->getWebAssetManager()
 			->registerAndUseStyle('plg_installer_webinstaller.client', 'plg_installer_webinstaller/client.min.css')
-			->registerAndUseScript('plg_installer_webinstaller.client', 'plg_installer_webinstaller/client.min.js', [], ['defer' => true], ['core', 'jquery']);
+			->registerAndUseScript(
+				'plg_installer_webinstaller.client',
+				'plg_installer_webinstaller/client.min.js',
+				[],
+				['defer' => true],
+				['core', 'jquery']
+			);
 
 		$devLevel = Version::PATCH_VERSION;
 

--- a/plugins/installer/webinstaller/webinstaller.php
+++ b/plugins/installer/webinstaller/webinstaller.php
@@ -77,6 +77,8 @@ class PlgInstallerWebinstaller extends CMSPlugin
 	public function onInstallerAddInstallationTab()
 	{
 		$installfrom = $this->getInstallFrom();
+		$doc         = Factory::getDocument();
+		$lang        = Factory::getLanguage();
 
 		// Push language strings to the JavaScript store
 		Text::script('PLG_INSTALLER_WEBINSTALLER_CANNOT_INSTALL_EXTENSION_IN_PLUGIN');
@@ -84,8 +86,10 @@ class PlgInstallerWebinstaller extends CMSPlugin
 
 		// TEMPORARY - Make sure Bootstrap is booted so that our client initialisation scripts can find the tab
 		HTMLHelper::_('bootstrap.framework');
-		HTMLHelper::_('script', 'plg_installer_webinstaller/client.min.js', ['version' => 'auto', 'relative' => true]);
-		HTMLHelper::_('stylesheet', 'plg_installer_webinstaller/client.min.css', ['version' => 'auto', 'relative' => true]);
+
+		$doc->getWebAssetManager()
+			->registerAndUseStyle('plg_installer_webinstaller.client', 'plg_installer_webinstaller/client.min.css')
+			->registerAndUseScript('plg_installer_webinstaller.client', 'plg_installer_webinstaller/client.min.js', [], ['defer' => true], ['core', 'jquery']);
 
 		$devLevel = Version::PATCH_VERSION;
 
@@ -93,9 +97,6 @@ class PlgInstallerWebinstaller extends CMSPlugin
 		{
 			$devLevel .= '-' . Version::EXTRA_VERSION;
 		}
-
-		$doc  = Factory::getDocument();
-		$lang = Factory::getLanguage();
 
 		$doc->addScriptOptions(
 			'plg_installer_webinstaller',

--- a/plugins/installer/webinstaller/webinstaller.php
+++ b/plugins/installer/webinstaller/webinstaller.php
@@ -10,7 +10,6 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Application\CMSApplication;
-use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Rule\UrlRule;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
@@ -77,8 +76,8 @@ class PlgInstallerWebinstaller extends CMSPlugin
 	public function onInstallerAddInstallationTab()
 	{
 		$installfrom = $this->getInstallFrom();
-		$doc         = Factory::getDocument();
-		$lang        = Factory::getLanguage();
+		$doc         = $this->app->getDocument();
+		$lang        = $this->app->getLanguage();
 
 		// Push language strings to the JavaScript store
 		Text::script('PLG_INSTALLER_WEBINSTALLER_CANNOT_INSTALL_EXTENSION_IN_PLUGIN');
@@ -142,7 +141,7 @@ class PlgInstallerWebinstaller extends CMSPlugin
 	{
 		if ($this->rtl === null)
 		{
-			$this->rtl = strtolower(Factory::getDocument()->getDirection()) === 'rtl' ? 1 : 0;
+			$this->rtl = strtolower($this->app->getDocument()->getDirection()) === 'rtl' ? 1 : 0;
 		}
 
 		return $this->rtl;

--- a/plugins/quickicon/extensionupdate/extensionupdate.php
+++ b/plugins/quickicon/extensionupdate/extensionupdate.php
@@ -74,7 +74,13 @@ class PlgQuickiconExtensionupdate extends CMSPlugin
 		Text::script('WARNING');
 
 		$this->app->getDocument()->getWebAssetManager()
-			->registerAndUseScript('plg_quickicon_extensionupdate', 'plg_quickicon_extensionupdate/extensionupdatecheck.min.js', [], ['defer' => true], ['core']);
+			->registerAndUseScript(
+				'plg_quickicon_extensionupdate',
+				'plg_quickicon_extensionupdate/extensionupdatecheck.min.js',
+				[],
+				['defer' => true],
+				['core']
+			);
 
 		return array(
 			array(

--- a/plugins/quickicon/extensionupdate/extensionupdate.php
+++ b/plugins/quickicon/extensionupdate/extensionupdate.php
@@ -10,7 +10,6 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Extension\ExtensionHelper;
-use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\CMS\Session\Session;
@@ -74,8 +73,8 @@ class PlgQuickiconExtensionupdate extends CMSPlugin
 		Text::script('INFO');
 		Text::script('WARNING');
 
-		HTMLHelper::_('behavior.core');
-		HTMLHelper::_('script', 'plg_quickicon_extensionupdate/extensionupdatecheck.min.js', array('version' => 'auto', 'relative' => true));
+		$this->app->getDocument()->getWebAssetManager()
+			->registerAndUseScript('plg_quickicon_extensionupdate', 'plg_quickicon_extensionupdate/extensionupdatecheck.min.js', [], ['defer' => true], ['core']);
 
 		return array(
 			array(

--- a/plugins/quickicon/joomlaupdate/src/Extension/Joomlaupdate.php
+++ b/plugins/quickicon/joomlaupdate/src/Extension/Joomlaupdate.php
@@ -122,7 +122,7 @@ class Joomlaupdate extends CMSPlugin implements SubscriberInterface
 			]
 		);
 
-		$this->app->getDocument()->getWebAssetManager()
+		$this->document->getWebAssetManager()
 			->registerAndUseScript('plg_quickicon_joomlaupdate', 'plg_quickicon_joomlaupdate/jupdatecheck.min.js', [], ['defer' => true], ['core']);
 
 		// Add the icon to the result array

--- a/plugins/quickicon/joomlaupdate/src/Extension/Joomlaupdate.php
+++ b/plugins/quickicon/joomlaupdate/src/Extension/Joomlaupdate.php
@@ -13,7 +13,6 @@ namespace Joomla\Plugin\Quickicon\Joomlaupdate\Extension;
 
 use Joomla\CMS\Document\Document;
 use Joomla\CMS\Extension\ExtensionHelper;
-use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\CMS\Session\Session;
@@ -123,8 +122,8 @@ class Joomlaupdate extends CMSPlugin implements SubscriberInterface
 			]
 		);
 
-		HTMLHelper::_('behavior.core');
-		HTMLHelper::_('script', 'plg_quickicon_joomlaupdate/jupdatecheck.min.js', array('version' => 'auto', 'relative' => true));
+		$this->app->getDocument()->getWebAssetManager()
+			->registerAndUseScript('plg_quickicon_joomlaupdate', 'plg_quickicon_joomlaupdate/jupdatecheck.min.js', [], ['defer' => true], ['core']);
 
 		// Add the icon to the result array
 		$result = $event->getArgument('result', []);

--- a/plugins/quickicon/overridecheck/overridecheck.php
+++ b/plugins/quickicon/overridecheck/overridecheck.php
@@ -9,7 +9,6 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\CMS\Session\Session;
@@ -80,8 +79,8 @@ class PlgQuickiconOverrideCheck extends CMSPlugin
 		Text::script('PLG_QUICKICON_OVERRIDECHECK_UPTODATE', true);
 		Text::script('PLG_QUICKICON_OVERRIDECHECK_OVERRIDEFOUND', true);
 
-		HTMLHelper::_('behavior.core');
-		HTMLHelper::_('script', 'plg_quickicon_overridecheck/overridecheck.js', array('version' => 'auto', 'relative' => true));
+		$this->app->getDocument()->getWebAssetManager()
+			->registerAndUseScript('plg_quickicon_overridecheck', 'plg_quickicon_overridecheck/overridecheck.js', [], ['defer' => true], ['core']);
 
 		return array(
 			array(

--- a/plugins/quickicon/privacycheck/privacycheck.php
+++ b/plugins/quickicon/privacycheck/privacycheck.php
@@ -9,7 +9,6 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\CMS\Session\Session;
@@ -69,8 +68,8 @@ class PlgQuickiconPrivacyCheck extends CMSPlugin
 
 		$this->app->getDocument()->addScriptOptions('js-privacy-check', $options);
 
-		HTMLHelper::_('behavior.core');
-		HTMLHelper::_('script', 'plg_quickicon_privacycheck/privacycheck.js', array('version' => 'auto', 'relative' => true));
+		$this->app->getDocument()->getWebAssetManager()
+			->registerAndUseScript('plg_quickicon_privacycheck', 'plg_quickicon_privacycheck/privacycheck.js', [], ['defer' => true], ['core']);
 
 		return array(
 			array(

--- a/plugins/system/stats/layouts/field/data.php
+++ b/plugins/system/stats/layouts/field/data.php
@@ -9,6 +9,7 @@
 
 defined('JPATH_BASE') or die;
 
+use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */

--- a/plugins/system/stats/layouts/field/data.php
+++ b/plugins/system/stats/layouts/field/data.php
@@ -9,10 +9,11 @@
 
 defined('JPATH_BASE') or die;
 
-use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
-HTMLHelper::_('script', 'plg_system_stats/stats.js', ['version' => 'auto', 'relative' => true]);
+/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+$wa = Factory::getApplication()->getDocument()->getWebAssetManager();
+$wa->registerAndUseScript('plg_system_stats.stats', 'plg_system_stats/stats.js', [], ['defer' => true], ['core']);
 
 extract($displayData);
 

--- a/plugins/system/stats/stats.php
+++ b/plugins/system/stats/stats.php
@@ -11,7 +11,6 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Cache\Cache;
 use Joomla\CMS\Factory;
-use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Http\HttpFactory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\FileLayout;
@@ -143,7 +142,8 @@ class PlgSystemStats extends CMSPlugin
 			return;
 		}
 
-		HTMLHelper::_('script', 'plg_system_stats/stats-message.js', ['version' => 'auto', 'relative' => true]);
+		$this->app->getDocument()->getWebAssetManager()
+			->registerAndUseScript('plg_system_stats.message', 'plg_system_stats/stats-message.js', [], ['defer' => true], ['core']);
 	}
 
 	/**

--- a/plugins/system/webauthn/src/Field/WebauthnField.php
+++ b/plugins/system/webauthn/src/Field/WebauthnField.php
@@ -13,7 +13,6 @@ namespace Joomla\Plugin\System\Webauthn\Field;
 defined('_JEXEC') or die();
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\FormField;
-use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\User\UserFactoryInterface;
 use Joomla\Plugin\System\Webauthn\CredentialRepository;
@@ -52,12 +51,6 @@ class WebauthnField extends FormField
 			return Text::_('PLG_SYSTEM_WEBAUTHN_ERR_NOUSER');
 		}
 
-		HTMLHelper::_('script', 'plg_system_webauthn/management.js', [
-			'relative'  => true,
-			'framework' => true,
-			]
-		);
-
 		Text::script('PLG_SYSTEM_WEBAUTHN_ERR_NO_BROWSER_SUPPORT', true);
 		Text::script('PLG_SYSTEM_WEBAUTHN_MANAGE_BTN_SAVE_LABEL', true);
 		Text::script('PLG_SYSTEM_WEBAUTHN_MANAGE_BTN_CANCEL_LABEL', true);
@@ -66,6 +59,9 @@ class WebauthnField extends FormField
 
 		$app                  = Factory::getApplication();
 		$credentialRepository = new CredentialRepository;
+
+		$app->getDocument()->getWebAssetManager()
+			->registerAndUseScript('plg_system_webauthn.management', 'plg_system_webauthn/management.js', [], ['defer' => true], ['core']);
 
 		return Joomla::renderLayout('plugins.system.webauthn.manage', [
 			'user'        => Factory::getContainer()->get(UserFactoryInterface::class)->loadUserById($userId),

--- a/plugins/system/webauthn/src/PluginTraits/AdditionalLoginButtons.php
+++ b/plugins/system/webauthn/src/PluginTraits/AdditionalLoginButtons.php
@@ -15,7 +15,6 @@ defined('_JEXEC') or die();
 use Exception;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Helper\AuthenticationHelper;
-use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Uri\Uri;
 use Joomla\CMS\User\UserHelper;
@@ -175,17 +174,21 @@ trait AdditionalLoginButtons
 		// Set the "don't load again" flag
 		$this->injectedCSSandJS = true;
 
-		// Load the CSS
-		HTMLHelper::_('stylesheet', 'plg_system_webauthn/button.css', [
-			'relative' => true,
-			]
-		);
+		/** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
+		$wa = Factory::getApplication()->getDocument()->getWebAssetManager();
 
-		// Load the JavaScript
-		HTMLHelper::_('script', 'plg_system_webauthn/login.js', [
-			'relative'  => true,
-			]
-		);
+		if (!$wa->assetExists('style', 'plg_system_webauthn.button'))
+		{
+			$wa->registerStyle('plg_system_webauthn.button', 'plg_system_webauthn/button.css');
+		}
+
+		if (!$wa->assetExists('script', 'plg_system_webauthn.login'))
+		{
+			$wa->registerScript('plg_system_webauthn.login', 'plg_system_webauthn/login.js', [], ['defer' => true], ['core']);
+		}
+
+		$wa->useStyle('plg_system_webauthn.button')
+			->useScript('plg_system_webauthn.login');
 
 		// Load language strings client-side
 		Text::script('PLG_SYSTEM_WEBAUTHN_ERR_CANNOT_FIND_USERNAME');


### PR DESCRIPTION
### Summary of Changes
This replaces htmlhelper to webaset for plugins

Updated plugins:
```
quickicon/overridecheck
quickicon/extensionupdate
quickicon/privacycheck
quickicon/joomlaupdate
system/webauthn
system/stats
editors-xtd/readmore
editors/codemirror
editors/tinymce
installer/webinstaller
```

### Testing Instructions
Apply patch.
Review all updated plugins


### Expected result
All works


### Actual result
All works


### Documentation Changes Required
nope 

ref #22435
