### PR TITLE
[4.0] Fix error message shown once after first login to backend after update from 3.10.

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -1943,8 +1943,6 @@ class JoomlaInstallerScript
 			'/administrator/language/en-GB/en-GB.plg_fields_media.sys.ini',
 			'/administrator/language/en-GB/en-GB.plg_fields_radio.ini',
 			'/administrator/language/en-GB/en-GB.plg_fields_radio.sys.ini',
-			'/administrator/language/en-GB/en-GB.plg_fields_repeatable.ini',
-			'/administrator/language/en-GB/en-GB.plg_fields_repeatable.sys.ini',
 			'/administrator/language/en-GB/en-GB.plg_fields_sql.ini',
 			'/administrator/language/en-GB/en-GB.plg_fields_sql.sys.ini',
 			'/administrator/language/en-GB/en-GB.plg_fields_text.ini',
@@ -4715,10 +4713,6 @@ class JoomlaInstallerScript
 			'/plugins/content/confirmconsent/fields/consentbox.php',
 			'/plugins/editors/codemirror/layouts/editors/codemirror/init.php',
 			'/plugins/editors/tinymce/field/skins.php',
-			'/plugins/fields/repeatable/params/repeatable.xml',
-			'/plugins/fields/repeatable/repeatable.php',
-			'/plugins/fields/repeatable/repeatable.xml',
-			'/plugins/fields/repeatable/tmpl/repeatable.php',
 			'/plugins/quickicon/joomlaupdate/joomlaupdate.php',
 			'/plugins/system/languagecode/language/en-GB/en-GB.plg_system_languagecode.ini',
 			'/plugins/system/languagecode/language/en-GB/en-GB.plg_system_languagecode.sys.ini',
@@ -6097,9 +6091,6 @@ class JoomlaInstallerScript
 			'/administrator/components/com_actionlogs/libraries',
 			'/administrator/components/com_actionlogs/helpers',
 			'/administrator/components/com_actionlogs/controllers',
-			'/plugins/fields/repeatable/params',
-			'/plugins/fields/repeatable/tmpl',
-			'/plugins/fields/repeatable',
 		);
 
 		foreach ($files as $file)


### PR DESCRIPTION
Pull Request for Issue #28432 .

### Summary of Changes

Remove repeatable fields plugin files and folders from lists to be deleted in script.php.

The plugin is later uninstalled by script.php using the extensions installer, so that's ok.

### Testing Instructions

1. Install a fresh copy of 3.10 nightly.
2. Go to the Joomla Update Component component config, set the update channel to "Custom URL" to custom and minimum stability to "Development".
3. Use following custom URL
- To reproduce the issue: [https://update.joomla.org/core/nightlies/next_major_list.xml](https://update.joomla.org/core/nightlies/next_major_list.xml)
- To test the patch of this PR: [https://test5.richard-fath.de/next_major_list_issue-28432.xml](https://test5.richard-fath.de/next_major_list_issue-28432.xml)
4. Update to Joomla 4.0
5. After files are successfully written and you re-authenticate (with a known issue about incorrect templates warnings when you do this) and then have logged in to backend:

### Expected result

![j4-no-error-after-update-from-3-10](https://user-images.githubusercontent.com/7413183/77255645-44365a00-6c69-11ea-9dc1-d8b0ed846ae2.png)

### Actual result

You get following error shown after the first login to backend:
![j4-error-after-update-from-3-10](https://user-images.githubusercontent.com/7413183/77250871-1a6e3a80-6c4b-11ea-986c-4e66528c2aa7.png)

When then navigating through the backend, all is ok. Frontend works, too. The error message never appears again.

### Documentation Changes Required

None.