### PR TITLE
[4.0] Load fields of context `com_contact.contact` instead of instead of `com_contact.contact` in Contact Controller in Api

### DIFF
--- a/api/components/com_contact/src/Controller/ContactController.php
+++ b/api/components/com_contact/src/Controller/ContactController.php
@@ -66,7 +66,7 @@ class ContactController extends ApiController
 	{
 		$data = (array) json_decode($this->input->json->getRaw(), true);
 
-		foreach (FieldsHelper::getFields('com_content.article') as $field)
+		foreach (FieldsHelper::getFields('com_contact.contact') as $field)
 		{
 			if (isset($data[$field->name]))
 			{


### PR DESCRIPTION
### Summary of Changes
Load fields of context `com_contact.contact` instead of `com_contact.contact` in Contact Controller of Api should be correct. Typo?


### Testing Instructions
Code review
