### PR TITLE
[4.0] Move the autoload file into the cache. Document in README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@
 /cache
 /installation/cache
 /installation/sessions
-/libraries/autoload_psr4.php
 /tmp
 /configuration.php
 /.htaccess

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ npm ci
 
 **Things to be aware of when pulling:**
 Joomla creates a cache of the namespaces of its extensions in `JOOMLA_ROOT/administrator/cache/autoload_psr4.php`. If
-extensions are created, deleted or removed in git then this file needs to be re-created. You can simply delete the file
+extensions are created, deleted or removed in git then this file needs to be recreated. You can simply delete the file
 and it will be regenerated on the next call to Joomla.
 
 Do you want to improve Joomla?

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ npm ci
 ```
 
 **Things to be aware of when pulling:**
-Joomla creates a cache of its extensions namespaces into `JOOMLA_ROOT/administrator/cache/autoload_psr4.php`. If
+Joomla creates a cache of the namespaces of its extensions in `JOOMLA_ROOT/administrator/cache/autoload_psr4.php`. If
 extensions are created, deleted or removed in git then this file needs to be re-created. You can simply delete the file
 and it will be regenerated on the next call to Joomla.
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ composer install
 npm ci
 ```
 
+**Things to be aware of when pulling:**
+Joomla creates a cache of it's extensions namespaces into `JOOMLA_ROOT/administrator/cache/autoload_psr4.php`. If
+extensions are created, deleted or removed in git then this file needs to be re-created. You can simply delete the file
+and it will be regenerated on the next call to Joomla.
+
 Do you want to improve Joomla?
 --------------------
 * Where to [request a feature](https://issues.joomla.org)?

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ npm ci
 ```
 
 **Things to be aware of when pulling:**
-Joomla creates a cache of it's extensions namespaces into `JOOMLA_ROOT/administrator/cache/autoload_psr4.php`. If
+Joomla creates a cache of its extensions namespaces into `JOOMLA_ROOT/administrator/cache/autoload_psr4.php`. If
 extensions are created, deleted or removed in git then this file needs to be re-created. You can simply delete the file
 and it will be regenerated on the next call to Joomla.
 

--- a/libraries/namespacemap.php
+++ b/libraries/namespacemap.php
@@ -24,7 +24,7 @@ class JNamespacePsr4Map
 	 * @var    string
 	 * @since  4.0.0
 	 */
-	protected $file = JPATH_LIBRARIES . '/autoload_psr4.php';
+	protected $file = JPATH_CACHE . '/autoload_psr4.php';
 
 	/**
 	 * Check if the file exists


### PR DESCRIPTION
### Summary of Changes
Moves the libraries autoloader into the cache directory. It's been suggested as it's a more transient file and can safely be deleted - like other files in the cache. In the future we can even consider fully storing it in the cache.

It's also now documented in the README.md for those who might be cloning from github for the first time.

### Testing Instructions
Check autoloader file is present in `administrator/cache/autoload_psr4.php`

### Documentation Changes Required
Yes - once the page is created.
