### PR TITLE
Don't repeat restriction of not accessing the root folder of the web if the open_basedir php directive is enabled and well configured

### DIFF
--- a/libraries/src/Filesystem/Path.php
+++ b/libraries/src/Filesystem/Path.php
@@ -319,10 +319,6 @@ class Path
 			if (strpos($path, '://') === false)
 			{
 				// Not a stream, so do a realpath() to avoid directory
-				// traversal attempts on the local file system.
-
-				// Needed for substr() later
-				$path = realpath($path);
 				$fullname = realpath($fullname);
 			}
 
@@ -332,7 +328,7 @@ class Path
 			 * non-registered directories are not accessible via directory
 			 * traversal attempts.
 			 */
-			if (file_exists($fullname) && substr($fullname, 0, strlen($path)) == $path)
+			if (file_exists($fullname))
 			{
 				return $fullname;
 			}


### PR DESCRIPTION
Don't repeat restriction of not accessing the root folder of the web if the open_basedir php directive is enabled and well configured

### Expected result

Allowing to edit the framework from another directory that is not the webroot.


### Actual result

Allowed editing from another directory that is not the webroot.

