### PR TITLE
[4.0] Break up tags code from category interface

### DIFF
--- a/administrator/components/com_banners/src/Extension/BannersComponent.php
+++ b/administrator/components/com_banners/src/Extension/BannersComponent.php
@@ -18,6 +18,8 @@ use Joomla\CMS\Component\Router\RouterServiceTrait;
 use Joomla\CMS\Extension\BootableExtensionInterface;
 use Joomla\CMS\Extension\MVCComponent;
 use Joomla\CMS\HTML\HTMLRegistryAwareTrait;
+use Joomla\CMS\Tag\TagServiceInterface;
+use Joomla\CMS\Tag\TagServiceTrait;
 use Joomla\Component\Banners\Administrator\Service\Html\Banner;
 use Psr\Container\ContainerInterface;
 
@@ -26,11 +28,15 @@ use Psr\Container\ContainerInterface;
  *
  * @since  4.0.0
  */
-class BannersComponent extends MVCComponent implements BootableExtensionInterface, CategoryServiceInterface, RouterServiceInterface
+class BannersComponent extends MVCComponent implements BootableExtensionInterface, CategoryServiceInterface, RouterServiceInterface,
+	TagServiceInterface
 {
-	use CategoryServiceTrait;
 	use HTMLRegistryAwareTrait;
 	use RouterServiceTrait;
+	use CategoryServiceTrait, TagServiceTrait {
+		CategoryServiceTrait::getTableNameForSection insteadof TagServiceTrait;
+		CategoryServiceTrait::getStateColumnForSection insteadof TagServiceTrait;
+	}
 
 	/**
 	 * Booting the extension. This is the function to set up the environment of the extension like

--- a/administrator/components/com_contact/src/Extension/ContactComponent.php
+++ b/administrator/components/com_contact/src/Extension/ContactComponent.php
@@ -25,6 +25,8 @@ use Joomla\CMS\Fields\FieldsServiceInterface;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\HTML\HTMLRegistryAwareTrait;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Tag\TagServiceInterface;
+use Joomla\CMS\Tag\TagServiceTrait;
 use Joomla\Component\Contact\Administrator\Service\HTML\AdministratorService;
 use Joomla\Component\Contact\Administrator\Service\HTML\Icon;
 use Psr\Container\ContainerInterface;
@@ -35,12 +37,16 @@ use Psr\Container\ContainerInterface;
  * @since  4.0.0
  */
 class ContactComponent extends MVCComponent implements
-	BootableExtensionInterface, CategoryServiceInterface, FieldsServiceInterface, AssociationServiceInterface, RouterServiceInterface
+	BootableExtensionInterface, CategoryServiceInterface, FieldsServiceInterface, AssociationServiceInterface, RouterServiceInterface,
+	TagServiceInterface
 {
-	use CategoryServiceTrait;
 	use AssociationServiceTrait;
 	use HTMLRegistryAwareTrait;
 	use RouterServiceTrait;
+	use CategoryServiceTrait, TagServiceTrait {
+		CategoryServiceTrait::getTableNameForSection insteadof TagServiceTrait;
+		CategoryServiceTrait::getStateColumnForSection insteadof TagServiceTrait;
+	}
 
 	/**
 	 * Booting the extension. This is the function to set up the environment of the extension like

--- a/administrator/components/com_content/src/Extension/ContentComponent.php
+++ b/administrator/components/com_content/src/Extension/ContentComponent.php
@@ -26,6 +26,8 @@ use Joomla\CMS\Form\Form;
 use Joomla\CMS\Helper\ContentHelper as LibraryContentHelper;
 use Joomla\CMS\HTML\HTMLRegistryAwareTrait;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Tag\TagServiceInterface;
+use Joomla\CMS\Tag\TagServiceTrait;
 use Joomla\CMS\Workflow\WorkflowServiceInterface;
 use Joomla\CMS\Workflow\WorkflowServiceTrait;
 use Joomla\Component\Content\Administrator\Helper\ContentHelper;
@@ -40,13 +42,16 @@ use Psr\Container\ContainerInterface;
  */
 class ContentComponent extends MVCComponent implements
 	BootableExtensionInterface, CategoryServiceInterface, FieldsServiceInterface, AssociationServiceInterface,
-	WorkflowServiceInterface, RouterServiceInterface
+	WorkflowServiceInterface, RouterServiceInterface, TagServiceInterface
 {
-	use CategoryServiceTrait;
 	use AssociationServiceTrait;
 	use RouterServiceTrait;
 	use HTMLRegistryAwareTrait;
 	use WorkflowServiceTrait;
+	use CategoryServiceTrait, TagServiceTrait {
+		CategoryServiceTrait::getTableNameForSection insteadof TagServiceTrait;
+		CategoryServiceTrait::getStateColumnForSection insteadof TagServiceTrait;
+	}
 
 	/**
 	 * The trashed condition

--- a/administrator/components/com_newsfeeds/src/Extension/NewsfeedsComponent.php
+++ b/administrator/components/com_newsfeeds/src/Extension/NewsfeedsComponent.php
@@ -20,6 +20,8 @@ use Joomla\CMS\Component\Router\RouterServiceTrait;
 use Joomla\CMS\Extension\BootableExtensionInterface;
 use Joomla\CMS\Extension\MVCComponent;
 use Joomla\CMS\HTML\HTMLRegistryAwareTrait;
+use Joomla\CMS\Tag\TagServiceInterface;
+use Joomla\CMS\Tag\TagServiceTrait;
 use Joomla\Component\Newsfeeds\Administrator\Service\HTML\AdministratorService;
 use Psr\Container\ContainerInterface;
 
@@ -29,12 +31,16 @@ use Psr\Container\ContainerInterface;
  * @since  4.0.0
  */
 class NewsfeedsComponent extends MVCComponent implements
-	BootableExtensionInterface, CategoryServiceInterface, AssociationServiceInterface, RouterServiceInterface
+	BootableExtensionInterface, CategoryServiceInterface, AssociationServiceInterface, RouterServiceInterface,
+	TagServiceInterface
 {
-	use CategoryServiceTrait;
 	use AssociationServiceTrait;
 	use HTMLRegistryAwareTrait;
 	use RouterServiceTrait;
+	use CategoryServiceTrait, TagServiceTrait {
+		CategoryServiceTrait::getTableNameForSection insteadof TagServiceTrait;
+		CategoryServiceTrait::getStateColumnForSection insteadof TagServiceTrait;
+	}
 
 	/**
 	 * Booting the extension. This is the function to set up the environment of the extension like

--- a/administrator/components/com_tags/src/Model/TagsModel.php
+++ b/administrator/components/com_tags/src/Model/TagsModel.php
@@ -11,11 +11,11 @@ namespace Joomla\Component\Tags\Administrator\Model;
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\Categories\CategoryServiceInterface;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
 use Joomla\CMS\MVC\Model\ListModel;
+use Joomla\CMS\Tag\TagServiceInterface;
 use Joomla\Database\ParameterType;
 
 /**
@@ -294,7 +294,7 @@ class TagsModel extends ListModel
 
 		$component = Factory::getApplication()->bootComponent($parts[0]);
 
-		if ($component instanceof CategoryServiceInterface)
+		if ($component instanceof TagServiceInterface)
 		{
 			$component->countTagItems($items, $extension);
 		}

--- a/libraries/src/Categories/CategoryServiceInterface.php
+++ b/libraries/src/Categories/CategoryServiceInterface.php
@@ -46,19 +46,6 @@ interface CategoryServiceInterface
 	public function countItems(array $items, string $section);
 
 	/**
-	 * Adds Count Items for Tag Manager.
-	 *
-	 * @param   \stdClass[]  $items      The content objects
-	 * @param   string       $extension  The name of the active view.
-	 *
-	 * @return  void
-	 *
-	 * @since   4.0.0
-	 * @throws  \Exception
-	 */
-	public function countTagItems(array $items, string $extension);
-
-	/**
 	 * Prepares the category form
 	 *
 	 * @param   \Joomla\CMS\Categories\Form  $form  The form to change

--- a/libraries/src/Categories/CategoryServiceTrait.php
+++ b/libraries/src/Categories/CategoryServiceTrait.php
@@ -83,32 +83,6 @@ trait CategoryServiceTrait
 	}
 
 	/**
-	 * Adds Count Items for Tag Manager.
-	 *
-	 * @param   \stdClass[]  $items      The content objects
-	 * @param   string       $extension  The name of the active view.
-	 *
-	 * @return  void
-	 *
-	 * @since   4.0.0
-	 */
-	public function countTagItems(array $items, string $extension)
-	{
-		$parts   = explode('.', $extension);
-		$section = \count($parts) > 1 ? $parts[1] : null;
-
-		$config = (object) array(
-			'related_tbl'   => $this->getTableNameForSection($section),
-			'state_col'     => $this->getStateColumnForSection($section),
-			'group_col'     => 'tag_id',
-			'extension'     => $extension,
-			'relation_type' => 'tag_assigments',
-		);
-
-		ContentHelper::countRelations($items, $config);
-	}
-
-	/**
 	 * Prepares the category form
 	 *
 	 * @param   Form          $form  The form to change

--- a/libraries/src/Extension/LegacyComponent.php
+++ b/libraries/src/Extension/LegacyComponent.php
@@ -26,6 +26,8 @@ use Joomla\CMS\Menu\AbstractMenu;
 use Joomla\CMS\MVC\Factory\LegacyFactory;
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
 use Joomla\CMS\MVC\Factory\MVCFactoryServiceInterface;
+use Joomla\CMS\Tag\TagServiceInterface;
+use Joomla\CMS\Tag\TagServiceTrait;
 
 /**
  * Access to component specific services.
@@ -33,9 +35,13 @@ use Joomla\CMS\MVC\Factory\MVCFactoryServiceInterface;
  * @since  4.0.0
  */
 class LegacyComponent
-	implements ComponentInterface, MVCFactoryServiceInterface, CategoryServiceInterface, FieldsServiceInterface, RouterServiceInterface
+	implements ComponentInterface, MVCFactoryServiceInterface, CategoryServiceInterface, FieldsServiceInterface, RouterServiceInterface,
+	TagServiceInterface
 {
-	use CategoryServiceTrait;
+	use CategoryServiceTrait, TagServiceTrait {
+		CategoryServiceTrait::getTableNameForSection insteadof TagServiceTrait;
+		CategoryServiceTrait::getStateColumnForSection insteadof TagServiceTrait;
+	}
 
 	/**
 	 * @var string

--- a/libraries/src/Tag/TagServiceInterface.php
+++ b/libraries/src/Tag/TagServiceInterface.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  Copyright (C) 2005 - 2019 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Tag;
+
+\defined('JPATH_PLATFORM') or die;
+
+use Joomla\CMS\Form\Form;
+
+/**
+ * Access to component specific tagging information.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+interface TagServiceInterface
+{
+	/**
+	 * Adds Count Items for Tag Manager.
+	 *
+	 * @param   \stdClass[]  $items      The content objects
+	 * @param   string       $extension  The name of the active view.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  \Exception
+	 */
+	public function countTagItems(array $items, string $extension);
+}

--- a/libraries/src/Tag/TagServiceTrait.php
+++ b/libraries/src/Tag/TagServiceTrait.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  Copyright (C) 2005 - 2019 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\CMS\Tag;
+
+\defined('JPATH_PLATFORM') or die;
+
+use Joomla\CMS\Helper\ContentHelper;
+
+/**
+ * Trait for component tags service.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+trait TagServiceTrait
+{
+	/**
+	 * Adds Count Items for Tag Manager.
+	 *
+	 * @param   \stdClass[]  $items      The content objects
+	 * @param   string       $extension  The name of the active view.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function countTagItems(array $items, string $extension)
+	{
+		$parts   = explode('.', $extension);
+		$section = \count($parts) > 1 ? $parts[1] : null;
+
+		$config = (object) array(
+			'related_tbl'   => $this->getTableNameForSection($section),
+			'state_col'     => $this->getStateColumnForSection($section),
+			'group_col'     => 'tag_id',
+			'extension'     => $extension,
+			'relation_type' => 'tag_assigments',
+		);
+
+		ContentHelper::countRelations($items, $config);
+	}
+
+	/**
+	 * Returns the table for the count items functions for the given section.
+	 *
+	 * @param   string  $section  The section
+	 *
+	 * @return  string|null
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function getTableNameForSection(string $section = null)
+	{
+		return null;
+	}
+
+	/**
+	 * Returns the state column for the count items functions for the given section.
+	 *
+	 * @param   string  $section  The section
+	 *
+	 * @return  string|null
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function getStateColumnForSection(string $section = null)
+	{
+		return 'state';
+	}
+}


### PR DESCRIPTION
Pull Request for Issue #24587 .

### Summary of Changes
Breaks up tags code from the interface and adds a corresponding trait.

Note as it shares methods with the CategoryServiceTrait we have to choose to prioritize one of the methods (as they are identical I've arbitrarily chosen `CategoryServiceTrait` but there's no deeper reasoning for that decison)

### Testing Instructions
Check the count of items associated with a tag continues to work in the tags component when you filter by a tag type (e.g. article)

### Documentation Changes Required
Yup. New tag interface needs to be documented
