### PR TITLE
[4.0][api][com_users] - Add filter options

### DIFF
--- a/administrator/components/com_users/src/Model/UsersModel.php
+++ b/administrator/components/com_users/src/Model/UsersModel.php
@@ -378,13 +378,26 @@ class UsersModel extends ListModel
 			}
 		}
 
-		// Add filter for registration time ranges select list
+		// Add filter for registration time ranges select list. UI Visitors get a range of predefined
+		// values. API users can do a full range based on ISO8601
 		$range = $this->getState('filter.range');
+		$registrationStart = $this->getState('filter.registrationStart');
+		$registrationEnd = $this->getState('filter.registrationEnd');
 
 		// Apply the range filter.
-		if ($range)
+		if ($range || ($registrationStart && $registrationEnd))
 		{
-			$dates = $this->buildDateRange($range);
+			if ($range)
+			{
+				$dates = $this->buildDateRange($range);
+			}
+			else
+			{
+				$dates = [
+					'dNow'   => $registrationStart,
+					'dStart' => $registrationEnd,
+				];
+			}
 
 			if ($dates['dStart'] !== false)
 			{
@@ -406,13 +419,26 @@ class UsersModel extends ListModel
 			}
 		}
 
-		// Add filter for last visit time ranges select list
+		// Add filter for last visit time ranges select list. UI Visitors get a range of predefined
+		// values. API users can do a full range based on ISO8601
 		$lastvisitrange = $this->getState('filter.lastvisitrange');
+		$lastVisitStart = $this->getState('filter.lastVisitStart');
+		$lastVisitEnd = $this->getState('filter.lastVisitEnd');
 
 		// Apply the range filter.
-		if ($lastvisitrange)
+		if ($lastvisitrange || ($lastVisitStart && $lastVisitEnd))
 		{
-			$dates = $this->buildDateRange($lastvisitrange);
+			if ($lastvisitrange)
+			{
+				$dates = $this->buildDateRange($lastvisitrange);
+			}
+			else
+			{
+				$dates = [
+					'dNow'   => $lastVisitStart,
+					'dStart' => $lastVisitEnd,
+				];
+			}
 
 			if ($dates['dStart'] === false)
 			{

--- a/administrator/components/com_users/src/Model/UsersModel.php
+++ b/administrator/components/com_users/src/Model/UsersModel.php
@@ -381,8 +381,8 @@ class UsersModel extends ListModel
 		// Add filter for registration time ranges select list. UI Visitors get a range of predefined
 		// values. API users can do a full range based on ISO8601
 		$range = $this->getState('filter.range');
-		$registrationStart = $this->getState('filter.registrationStart');
-		$registrationEnd = $this->getState('filter.registrationEnd');
+		$registrationStart = $this->getState('filter.registrationDateStart');
+		$registrationEnd = $this->getState('filter.registrationDateEnd');
 
 		// Apply the range filter.
 		if ($range || ($registrationStart && $registrationEnd))
@@ -394,8 +394,8 @@ class UsersModel extends ListModel
 			else
 			{
 				$dates = [
-					'dNow'   => $registrationStart,
-					'dStart' => $registrationEnd,
+					'dNow'   => $registrationEnd,
+					'dStart' => $registrationStart,
 				];
 			}
 
@@ -435,8 +435,8 @@ class UsersModel extends ListModel
 			else
 			{
 				$dates = [
-					'dNow'   => $lastVisitStart,
-					'dStart' => $lastVisitEnd,
+					'dNow'   => $lastVisitEnd,
+					'dStart' => $lastVisitStart,
 				];
 			}
 

--- a/api/components/com_users/src/Controller/UsersController.php
+++ b/api/components/com_users/src/Controller/UsersController.php
@@ -36,7 +36,7 @@ class UsersController extends ApiController
 	 * The default view for the display method.
 	 *
 	 * @var    string
-	 * @since  3.0
+	 * @since  4.0.0
 	 */
 	protected $default_view = 'users';
 
@@ -44,7 +44,7 @@ class UsersController extends ApiController
 	 * The default view for the display method.
 	 *
 	 * @var    array
-	 * @since  3.0
+	 * @since  4.0.0
 	 */
 	protected $supportedRange = [
 		'past_week',

--- a/api/components/com_users/src/Controller/UsersController.php
+++ b/api/components/com_users/src/Controller/UsersController.php
@@ -11,6 +11,7 @@ namespace Joomla\Component\Users\Api\Controller;
 
 \defined('_JEXEC') or die;
 
+use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\MVC\Controller\ApiController;
 use Joomla\Component\Fields\Administrator\Helper\FieldsHelper;
 
@@ -64,5 +65,50 @@ class UsersController extends ApiController
 		$this->input->set('data', $data);
 
 		return parent::save($recordKey);
+	}
+
+	/**
+	 * User list view with filtering of data
+	 *
+	 * @return  static  A BaseController object to support chaining.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function displayList()
+	{
+		$apiFilterInfo = $this->input->get('filter', [], 'array');
+		$filter        = InputFilter::getInstance();
+
+		if (array_key_exists('state', $apiFilterInfo))
+		{
+			$this->modelState->set('filter.state', $filter->clean($apiFilterInfo['state'], 'INT'));
+		}
+
+		if (array_key_exists('active', $apiFilterInfo))
+		{
+			$this->modelState->set('filter.active', $filter->clean($apiFilterInfo['active'], 'INT'));
+		}
+
+		if (array_key_exists('groupid', $apiFilterInfo))
+		{
+			$this->modelState->set('filter.group_id', $filter->clean($apiFilterInfo['groupid'], 'INT'));
+		}
+
+		if (array_key_exists('search', $apiFilterInfo))
+		{
+			$this->modelState->set('filter.search', $filter->clean($apiFilterInfo['search'], 'STRING'));
+		}
+
+		if (array_key_exists('registrationdate', $apiFilterInfo))
+		{
+			$this->modelState->set('filter.range', $filter->clean($apiFilterInfo['registrationdate'], 'STRING'));
+		}
+
+		if (array_key_exists('lastvisitdate', $apiFilterInfo))
+		{
+			$this->modelState->set('filter.lastvisitrange', $filter->clean($apiFilterInfo['lastvisitdate'], 'STRING'));
+		}
+
+		return parent::displayList();
 	}
 }

--- a/api/components/com_users/src/Controller/UsersController.php
+++ b/api/components/com_users/src/Controller/UsersController.php
@@ -128,7 +128,7 @@ class UsersController extends ApiController
 			{
 				// Send the error response
 				$error = Text::sprintf('JLIB_FORM_VALIDATE_FIELD_INVALID', 'registrationdate');
-				throw new InvalidParameterException($error);
+				throw new InvalidParameterException($error, 400);
 			}
 
 			$this->modelState->set('filter.range', $rangeFilter);
@@ -142,7 +142,7 @@ class UsersController extends ApiController
 			{
 				// Send the error response
 				$error = Text::sprintf('JLIB_FORM_VALIDATE_FIELD_INVALID', 'lastvisitdate');
-				throw new InvalidParameterException($error);
+				throw new InvalidParameterException($error, 400);
 			}
 
 			$this->modelState->set('filter.lastvisitrange', $rangeFilter);

--- a/api/components/com_users/src/Controller/UsersController.php
+++ b/api/components/com_users/src/Controller/UsersController.php
@@ -124,7 +124,7 @@ class UsersController extends ApiController
 		{
 			$rangeFilter = $filter->clean($apiFilterInfo['registrationdate'], 'STRING');
 
-			if (!array_key_exists($rangeFilter, $this->supportedRange))
+			if (!in_array($rangeFilter, $this->supportedRange))
 			{
 				// Send the error response
 				$this->sendResponse('registrationdate', 400);
@@ -137,7 +137,7 @@ class UsersController extends ApiController
 		{
 			$rangeFilter = $filter->clean($apiFilterInfo['lastvisitdate'], 'STRING');
 
-			if (!array_key_exists($rangeFilter, $this->supportedRange))
+			if (!in_array($rangeFilter, $this->supportedRange))
 			{
 				// Send the error response
 				$this->sendResponse('lastvisitdate', 400);

--- a/api/components/com_users/src/Controller/UsersController.php
+++ b/api/components/com_users/src/Controller/UsersController.php
@@ -126,7 +126,7 @@ class UsersController extends ApiController
 			{
 				// Send the error response
 				$error = Text::sprintf('JLIB_FORM_VALIDATE_FIELD_INVALID', 'registrationdate');
-				throw new InvalidParameterException($error, 400);
+				throw new InvalidParameterException($error, 400, null, 'registrationdate');
 			}
 
 			$this->modelState->set('filter.range', $rangeFilter);
@@ -140,7 +140,7 @@ class UsersController extends ApiController
 			{
 				// Send the error response
 				$error = Text::sprintf('JLIB_FORM_VALIDATE_FIELD_INVALID', 'lastvisitdate');
-				throw new InvalidParameterException($error, 400);
+				throw new InvalidParameterException($error, 400, null, 'lastvisitdate');
 			}
 
 			$this->modelState->set('filter.lastvisitrange', $rangeFilter);

--- a/api/components/com_users/src/Controller/UsersController.php
+++ b/api/components/com_users/src/Controller/UsersController.php
@@ -52,7 +52,7 @@ class UsersController extends ApiController
 		'past_3month',
 		'past_6month',
 		'past_year',
-		'post_year',
+		'past_year',
 		'today',
 		'never',
 	];

--- a/api/components/com_users/src/Controller/UsersController.php
+++ b/api/components/com_users/src/Controller/UsersController.php
@@ -52,7 +52,6 @@ class UsersController extends ApiController
 			'past_1month',
 			'past_3month',
 			'past_6month',
-			'past_6month',
 			'past_year',
 			'post_year',
 			'today',

--- a/api/components/com_users/src/Controller/UsersController.php
+++ b/api/components/com_users/src/Controller/UsersController.php
@@ -116,7 +116,7 @@ class UsersController extends ApiController
 				throw new InvalidParameterException($error, 400, null, 'registrationDateStart');
 			}
 
-			$this->modelState->set('filter.range', $registrationStartDate);
+			$this->modelState->set('filter.registrationDateStart', $registrationStartDate);
 		}
 
 		if (array_key_exists('registrationDateEnd', $apiFilterInfo))
@@ -131,13 +131,13 @@ class UsersController extends ApiController
 				throw new InvalidParameterException($error, 400, null, 'registrationDateEnd');
 			}
 
-			$this->modelState->set('filter.range', $registrationEndDate);
+			$this->modelState->set('filter.registrationDateEnd', $registrationEndDate);
 		}
 		elseif (array_key_exists('registrationDateStart', $apiFilterInfo)
 			&& !array_key_exists('registrationDateEnd', $apiFilterInfo))
 		{
 			// If no end date specified the end date is now
-			$this->modelState->set('filter.range', new Date);
+			$this->modelState->set('filter.registrationDateEnd', new Date);
 		}
 
 		if (array_key_exists('lastVisitDateStart', $apiFilterInfo))

--- a/api/components/com_users/src/Controller/UsersController.php
+++ b/api/components/com_users/src/Controller/UsersController.php
@@ -14,8 +14,8 @@ namespace Joomla\Component\Users\Api\Controller;
 use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Controller\ApiController;
-use Joomla\CMS\Response\JsonResponse;
 use Joomla\Component\Fields\Administrator\Helper\FieldsHelper;
+use Tobscure\JsonApi\Exception\InvalidParameterException;
 
 /**
  * The users controller
@@ -41,10 +41,10 @@ class UsersController extends ApiController
 	protected $default_view = 'users';
 
 	/**
-	 * The supported filter values for date range.
+	 * The default view for the display method.
 	 *
 	 * @var    array
-	 * @since  4.0
+	 * @since  3.0
 	 */
 	protected $supportedRange
 		= [
@@ -127,7 +127,8 @@ class UsersController extends ApiController
 			if (!in_array($rangeFilter, $this->supportedRange))
 			{
 				// Send the error response
-				$this->sendResponse('registrationdate', 400);
+				$error = Text::sprintf('JLIB_FORM_VALIDATE_FIELD_INVALID', 'registrationdate');
+				throw new InvalidParameterException($error);
 			}
 
 			$this->modelState->set('filter.range', $rangeFilter);
@@ -140,38 +141,13 @@ class UsersController extends ApiController
 			if (!in_array($rangeFilter, $this->supportedRange))
 			{
 				// Send the error response
-				$this->sendResponse('lastvisitdate', 400);
+				$error = Text::sprintf('JLIB_FORM_VALIDATE_FIELD_INVALID', 'lastvisitdate');
+				throw new InvalidParameterException($error);
 			}
 
 			$this->modelState->set('filter.lastvisitrange', $rangeFilter);
 		}
 
 		return parent::displayList();
-	}
-
-	/**
-	 * Send the given data as JSON response in the following format:
-	 *
-	 * {"success":true,"message":"ok","messages":null,"data":[{"type":"dir","name":"banners","path":"//"}]}
-	 *
-	 * @param   string   $field         The wrong field
-	 * @param   integer  $responseCode  The response code
-	 *
-	 * @return  void
-	 *
-	 * @since   4.0.0
-	 */
-	private function sendResponse(string $field = null, int $responseCode = 200): void
-	{
-		// Set the correct content type
-		$this->app->setHeader('Content-Type', 'application/json');
-
-		// Set the status code for the response
-		http_response_code($responseCode);
-
-		// Send the data
-		echo new JsonResponse(null, Text::sprintf('JLIB_FORM_VALIDATE_FIELD_INVALID', $field), true);
-
-		$this->app->close();
 	}
 }

--- a/api/components/com_users/src/Controller/UsersController.php
+++ b/api/components/com_users/src/Controller/UsersController.php
@@ -52,7 +52,7 @@ class UsersController extends ApiController
 		'past_3month',
 		'past_6month',
 		'past_year',
-		'past_year',
+		'post_year',
 		'today',
 		'never',
 	];

--- a/api/components/com_users/src/Controller/UsersController.php
+++ b/api/components/com_users/src/Controller/UsersController.php
@@ -46,17 +46,16 @@ class UsersController extends ApiController
 	 * @var    array
 	 * @since  3.0
 	 */
-	protected $supportedRange
-		= [
-			'past_week',
-			'past_1month',
-			'past_3month',
-			'past_6month',
-			'past_year',
-			'post_year',
-			'today',
-			'never',
-		];
+	protected $supportedRange = [
+		'past_week',
+		'past_1month',
+		'past_3month',
+		'past_6month',
+		'past_year',
+		'post_year',
+		'today',
+		'never',
+	];
 
 	/**
 	 * Method to save a record.


### PR DESCRIPTION
### Summary of Changes
added the option to filter users by:

- active
- state
- search
- groupid 
- registration date 
- last visit date


### Testing Instructions

call `JROOT_URL/api/index.php/v1/users?filter[groupid]=8`
call `JROOT_URL/api/index.php/v1/users?filter[lastVisitDateStart]=2020-01-29T20:36:01Z`
call `JROOT_URL/api/index.php/v1/users?filter[search]=myName`
call `JROOT_URL/api/index.php/v1/users?filter[state]=0`
call `JROOT_URL/api/index.php/v1/users?filter[active]=1`
call `JROOT_URL/api/index.php/v1/users?filter[registrationDateStart]=2018-01-29T20:36:01Z`
call `JROOT_URL/api/index.php/v1/users?filter[registrationDateEnd]=2020-01-29T20:36:01Z`
or any combination like :
`JROOT_URL/api/index.php/v1/users?filter[groupid]=8&filter[state]=0`
etc

Expected values for **registrationDateStart** , **registrationDateEnd** and **lastVisitDateStart**,**lastVisitDateEnd**  are:

2020-03-29T20:36:01Z
2020-03-29T20:36:01+00:00
### Expected result


the api response is filtered


### Actual result
N/A


### Documentation Changes Required
yes

