### PR TITLE
Escape return to homepage url in isis and hathor

### DIFF
--- a/administrator/templates/hathor/login.php
+++ b/administrator/templates/hathor/login.php
@@ -105,7 +105,9 @@ else
 					<div class="login-inst">
 					<p><?php echo JText::_('COM_LOGIN_VALID') ?></p>
 					<div id="lock"></div>
-					<a href="<?php echo $frontEndUri->toString(); ?>" target="_blank"><?php echo JText::_('COM_LOGIN_RETURN_TO_SITE_HOME_PAGE'); ?></a>
+					<a href="<?php echo htmlspecialchars($frontEndUri->toString(), ENT_COMPAT, 'UTF-8'); ?>" target="_blank">
+						<?php echo JText::_('COM_LOGIN_RETURN_TO_SITE_HOME_PAGE'); ?>
+					</a>
 					</div>
 					<!-- Login Component -->
 					<div class="login-box">

--- a/administrator/templates/isis/login.php
+++ b/administrator/templates/isis/login.php
@@ -132,7 +132,10 @@ if (JPluginHelper::isEnabled('system', 'debug') && ($app->get('debug_lang', 0) |
 			&copy; <?php echo date('Y'); ?> <?php echo $sitename; ?>
 		</p>
 		<a class="login-joomla hasTooltip" href="https://www.joomla.org" target="_blank"  rel="noopener noreferrer" title="<?php echo JHtml::_('tooltipText', 'TPL_ISIS_ISFREESOFTWARE'); ?>"><span class="icon-joomla"></span></a>
-		<a href="<?php echo $frontEndUri->toString(); ?>" target="_blank" class="pull-left"><span class="icon-out-2"></span><?php echo JText::_('COM_LOGIN_RETURN_TO_SITE_HOME_PAGE'); ?></a>
+		<a href="<?php echo htmlspecialchars($frontEndUri->toString(), ENT_COMPAT, 'UTF-8'); ?>" target="_blank" class="pull-left">
+			<span class="icon-out-2"></span>
+			<?php echo JText::_('COM_LOGIN_RETURN_TO_SITE_HOME_PAGE'); ?>
+		</a>
 	</div>
 	<jdoc:include type="modules" name="debug" style="none" />
 </body>


### PR DESCRIPTION
### Summary of Changes

Escape return to homepage url in isis and hathor

### Testing Instructions

- install this patch
- make sure the link to homepage still works as expected

### Expected result

homepage url is escaped

### Actual result

homepage url is not escaped

### Documentation Changes Required

none

cc @SniperSister 