### PR TITLE
[4.0] Seo note heading

### DIFF
--- a/administrator/components/com_config/forms/application.xml
+++ b/administrator/components/com_config/forms/application.xml
@@ -707,6 +707,7 @@
 		<field
 			name="sef_note"
 			type="note"
+			heading="p"
 			label="COM_CONFIG_FIELD_SEF_REWRITE_DESC"
 			showon="sef:1[AND]sef_rewrite:1"
 		/>

--- a/administrator/components/com_config/forms/application.xml
+++ b/administrator/components/com_config/forms/application.xml
@@ -707,9 +707,9 @@
 		<field
 			name="sef_note"
 			type="note"
+			label="COM_CONFIG_FIELD_SEF_REWRITE_DESC"
 			heading="p"
 			class="small"
-			label="COM_CONFIG_FIELD_SEF_REWRITE_DESC"
 			showon="sef:1[AND]sef_rewrite:1"
 		/>
 

--- a/administrator/components/com_config/forms/application.xml
+++ b/administrator/components/com_config/forms/application.xml
@@ -708,6 +708,7 @@
 			name="sef_note"
 			type="note"
 			heading="p"
+			class="small"
 			label="COM_CONFIG_FIELD_SEF_REWRITE_DESC"
 			showon="sef:1[AND]sef_rewrite:1"
 		/>


### PR DESCRIPTION
### Summary of Changes
Set Tag p for information in SEO settings

### Testing Instructions
Have a look fo on configuration, the part SEO.
When setting url-rewite to yes, a note appears.

### Expected result
The note is an information only. 

### Actual result
The note is tagged as heading, per default by h4

### Documentation Changes Required
nope
