### PR TITLE
[4.0] Fix styling of btn-group in RTL

### DIFF
--- a/administrator/templates/atum/scss/system/searchtools/searchtools.scss
+++ b/administrator/templates/atum/scss/system/searchtools/searchtools.scss
@@ -243,7 +243,6 @@
         border-left: 1px solid var(--atum-text-light);
 
         [dir=rtl] & {
-          margin-right: -1px !important;
           margin-left: 5px;
         }
 

--- a/administrator/templates/atum/scss/template-rtl.scss
+++ b/administrator/templates/atum/scss/template-rtl.scss
@@ -281,14 +281,21 @@ body {
   @include border-right-radius($border-radius);
 }
 
+.btn-group > .btn:first-child:not(.dropdown-toggle) {
+  @include border-right-radius($border-radius);
+}
+
 .btn-group > .btn:not(:last-child):not(.dropdown-toggle),
 .btn-group > .btn-group:not(:last-child) > .btn {
   @include border-left-radius(0);
-  @include border-right-radius($border-radius);
+  margin-left: -1px;
+}
+
+.btn-group > .btn:last-child:not(.dropdown-toggle) {
+  @include border-left-radius($border-radius);
 }
 
 .btn-group > .btn:not(:first-child),
 .btn-group > .btn-group:not(:first-child) {
-  @include border-left-radius($border-radius);
   @include border-right-radius(0);
 }

--- a/templates/cassiopeia/scss/system/searchtools/searchtools.scss
+++ b/templates/cassiopeia/scss/system/searchtools/searchtools.scss
@@ -242,7 +242,6 @@
         border-left: 1px solid $gray-100;
 
         [dir=rtl] & {
-          margin-right: -1px !important;
           margin-left: 5px;
         }
 

--- a/templates/cassiopeia/scss/template-rtl.scss
+++ b/templates/cassiopeia/scss/template-rtl.scss
@@ -72,14 +72,21 @@ dd {
   @include border-right-radius($border-radius);
 }
 
+.btn-group > .btn:first-child:not(.dropdown-toggle) {
+  @include border-right-radius($border-radius);
+}
+
 .btn-group > .btn:not(:last-child):not(.dropdown-toggle),
 .btn-group > .btn-group:not(:last-child) > .btn {
   @include border-left-radius(0);
-  @include border-right-radius($border-radius);
+  margin-left: -1px;
+}
+
+.btn-group > .btn:last-child:not(.dropdown-toggle) {
+  @include border-left-radius($border-radius);
 }
 
 .btn-group > .btn:not(:first-child),
 .btn-group > .btn-group:not(:first-child) {
-  @include border-left-radius($border-radius);
   @include border-right-radius(0);
 }


### PR DESCRIPTION
Alternative PR to #28405

### Summary of Changes
Whilst I don't mind removing the btn-group necessarily it made me realise the entire styling for it was broken in RTL when you had more than 1 item in the btn group. This fixes the btn group styling generally.

### Testing Instructions
Check the `btn-group` class functions in both searchtools and in the versions modal. Version modal before and after as below (note the border-radius and the padding on the right hand button)

#### Before Patch
<img width="746" alt="Screenshot 2020-03-25 at 22 00 31" src="https://user-images.githubusercontent.com/1986000/77589560-cb8f0200-6ee3-11ea-8fa6-1592aecdcc03.png">

#### After Patch
<img width="1112" alt="Screenshot 2020-03-25 at 21 59 52" src="https://user-images.githubusercontent.com/1986000/77589572-cfbb1f80-6ee3-11ea-89cc-afee59a00527.png">

### Documentation Changes Required
None

cc @infograf768 