### PR TITLE
[4.0] Badge padding

### DIFF
--- a/administrator/templates/atum/scss/_variables.scss
+++ b/administrator/templates/atum/scss/_variables.scss
@@ -185,7 +185,7 @@ $state-error-bg:                   lighten($red-dark, 70%);
 $state-error-border:               lighten($red-dark, 30%);
 
 // Badges
-$badge-padding-x:                  .3rem;
+$badge-padding-x:                  .2rem;
 $badge-padding-y:                  .3rem;
 $badge-border-radius:              .2rem;
 

--- a/administrator/templates/atum/scss/_variables.scss
+++ b/administrator/templates/atum/scss/_variables.scss
@@ -186,7 +186,7 @@ $state-error-border:               lighten($red-dark, 30%);
 
 // Badges
 $badge-padding-x:                  .3rem;
-$badge-padding-y:                  .1rem;
+$badge-padding-y:                  .3rem;
 $badge-border-radius:              .2rem;
 
 $success-bg:                       $green;


### PR DESCRIPTION
This pr adjust the padding on badges to improve legibility. To test npm i or node build.js --compile-css and then check the badges as per the examples below

### before
![image](https://user-images.githubusercontent.com/1296369/77586199-a9928100-6edd-11ea-9eb6-1324e97b7b97.png)



### after
![image](https://user-images.githubusercontent.com/1296369/77586003-56b8c980-6edd-11ea-8546-470f54c35d95.png)
![image](https://user-images.githubusercontent.com/1296369/77586155-98e20b00-6edd-11ea-9669-5ef28152a6eb.png)

