### PR TITLE
Make sure the item ids are integers and use the same variable like in the rest of the code

### DIFF
--- a/administrator/components/com_menus/controllers/items.php
+++ b/administrator/components/com_menus/controllers/items.php
@@ -275,10 +275,15 @@ class MenusControllerItems extends JControllerAdmin
 		// Check for request forgeries.
 		$this->checkToken();
 
-		$ids = JFactory::getApplication()->input->post->get('cid', array(), 'array');
+		// Read the Ids from the post data
+		$cid = JFactory::getApplication()->input->post->get('cid', array(), 'array');
 
-		$model = $this->getModel();
-		$return = $model->checkin($ids);
+		// Make sure the item ids are integers
+		$cid = ArrayHelper::toInteger($cid);
+
+		// Run the model
+		$model  = $this->getModel();
+		$return = $model->checkin($cid);
 
 		if ($return === false)
 		{
@@ -299,7 +304,7 @@ class MenusControllerItems extends JControllerAdmin
 		else
 		{
 			// Checkin succeeded.
-			$message = JText::plural($this->text_prefix . '_N_ITEMS_CHECKED_IN', count($ids));
+			$message = JText::plural($this->text_prefix . '_N_ITEMS_CHECKED_IN', count($cid));
 			$this->setRedirect(
 				JRoute::_(
 					'index.php?option=' . $this->option . '&view=' . $this->view_list


### PR DESCRIPTION
### Summary of Changes

Make sure the item ids are integers and use the same variable like in the rest of the code for the menus checkin method

### Testing Instructions

- make sure the com_menus check in still works.

### Expected result

the passed ids are now checked to be integer

### Actual result

the passed ids where not checked whether they where integers or not.

### Documentation Changes Required

none