### PR TITLE
[4.0] choices scss

### DIFF
--- a/administrator/templates/atum/scss/vendor/choicesjs/choices.scss
+++ b/administrator/templates/atum/scss/vendor/choicesjs/choices.scss
@@ -147,11 +147,24 @@
 
   .choices__inner {
     padding: .4rem 1rem .256rem;
+
+    [dir=ltr] & {
+      background: url("../../../images/select-bg.svg") no-repeat right center / $custom-select-bg-size;
+      background-color: $custom-select-bg;
+    }
+
+    [dir=rtl] & {
+      background: url("../../../images/select-bg-rtl.svg") no-repeat left center / $custom-select-bg-size;
+      background-color: $custom-select-bg;
+    }
   }
 
   .choices__input {
     padding: .2rem 0 .356rem;
-    color: $custom-select-color;
+
+    &::placeholder {
+      color: $custom-select-color;
+    }
   }
 }
 
@@ -187,6 +200,7 @@
 .choices__inner,
 .choices__input {
   background-color: var(--white);
+  border-radius: $border-radius;
 }
 
 .choices__list--single {

--- a/administrator/templates/atum/scss/vendor/choicesjs/choices.scss
+++ b/administrator/templates/atum/scss/vendor/choicesjs/choices.scss
@@ -18,7 +18,6 @@
 
 .choices__inner {
   border: $input-border;
-  border-color: $gray-400;
   box-shadow: $input-box-shadow;
 }
 


### PR DESCRIPTION
The aim of this PR is to make the selects created with choices have the same styling as the selects without

## Border color
the border color is defined twice as $input-border defines the color and then it is defined again by border-color

The first one in the variable is the correct one to use as it makes the choices select have the same color border as everything else.

## Border radius
Uses the standard variable for the border radius

## Placeholder text
Choices uses placeholder text which is gray and regular select uses $custom-select-color;

## Dropdown arrows
Adds the arrows 

### Before
![image](https://user-images.githubusercontent.com/1296369/77597167-e23e5480-6ef5-11ea-99ff-eee07f10a66c.png)

### After
![image](https://user-images.githubusercontent.com/1296369/77597122-c2a72c00-6ef5-11ea-80be-4bc659ca971b.png)
