### PR TITLE
[4.0] Fix layout for formfield usergrouplist

### DIFF
--- a/plugins/system/debug/debug.xml
+++ b/plugins/system/debug/debug.xml
@@ -39,7 +39,7 @@
 					type="usergrouplist"
 					label="PLG_DEBUG_FIELD_ALLOWED_GROUPS_LABEL"
 					multiple="true"
-					layout="joomla.form.field.accesslevel-fancy-select"
+					layout="joomla.form.field.list-fancy-select"
 					filter="intarray"
 				/>
 


### PR DESCRIPTION
### Summary of Changes
Change layout for formfield usergrouplist tp joomla.form.field.list-fancy-select


### Testing Instructions
Open the plugin system-debug and watch the field "Allowed Usergroups"


### Expected result
There is a input field for allowed user groups


### Actual result
No field


### Documentation Changes Required
maybe screenshot
