### PR TITLE
[3] [com_users] Fix for fields output being loaded in edit form

### DIFF
--- a/components/com_users/views/profile/view.html.php
+++ b/components/com_users/views/profile/view.html.php
@@ -85,17 +85,21 @@ class UsersViewProfile extends JViewLegacy
 			return false;
 		}
 
-		JPluginHelper::importPlugin('content');
-		$this->data->text = '';
-		JEventDispatcher::getInstance()->trigger('onContentPrepare', array ('com_users.user', &$this->data, &$this->data->params, 0));
-		unset($this->data->text);
-
 		// Check for layout override
 		$active = JFactory::getApplication()->getMenu()->getActive();
 
 		if (isset($active->query['layout']))
 		{
 			$this->setLayout($active->query['layout']);
+		}
+		
+		// Check layout type
+		if ($this->getLayout() == 'default')
+		{
+			JPluginHelper::importPlugin('content');
+			$this->data->text = '';
+			JEventDispatcher::getInstance()->trigger('onContentPrepare', ['com_users.user', &$this->data, &$this->data->params, 0]);
+			unset($this->data->text);
 		}
 
 		// Escape strings for HTML output


### PR DESCRIPTION
### Summary of Changes

Before this PR, the frontend "edit" layout (edit form) of the user profile (com_users), would also load in the background the fields output that is only meant to be displayed in the frontend result of the profile. 

This PR makes sure the code to get the fields output is only loaded in the actual output profile page, not in the input edit form.

### Before result

Loading the edit form is slower because it's actually loading the fields output as well, despite not using them

### After result

Loading the edit form is faster because it doesn't load unnecessary data in the background

### Documentation Changes Required

None