### PR TITLE
[4.0]  namespacemap plugin

### DIFF
--- a/administrator/language/en-GB/plg_extension_namespacemap.ini
+++ b/administrator/language/en-GB/plg_extension_namespacemap.ini
@@ -4,4 +4,4 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_EXTENSION_NAMESPACEMAP="Extension - Namespace Updater"
-PLG_EXTENSION_NAMESPACEMAP_XML_DESCRIPTION="Automatically builds and updates the <strong>libraries\autoload_psr4.php</strong> file that is used to autoload extensions.<br><strong>Warning! This plugin must be enabled</strong> it runs on extension install, update and deletion."
+PLG_EXTENSION_NAMESPACEMAP_XML_DESCRIPTION="Automatically builds and updates the <strong>libraries/autoload_psr4.php</strong> file that is used to autoload extensions.<br><strong>Warning! This plugin must be enabled</strong> as it runs on extension install, update and deletion."

--- a/administrator/language/en-GB/plg_extension_namespacemap.sys.ini
+++ b/administrator/language/en-GB/plg_extension_namespacemap.sys.ini
@@ -4,4 +4,4 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_EXTENSION_NAMESPACEMAP="Extension - Namespace Updater"
-PLG_EXTENSION_NAMESPACEMAP_XML_DESCRIPTION="Automatically builds and updates the <strong>libraries\autoload_psr4.php</strong> file that is used to autoload extensions.<br><strong>Warning! This plugin must be enabled</strong> it runs on extension install, update and deletion."
+PLG_EXTENSION_NAMESPACEMAP_XML_DESCRIPTION="Automatically builds and updates the <strong>libraries/autoload_psr4.php</strong> file that is used to autoload extensions.<br><strong>Warning! This plugin must be enabled</strong> as it runs on extension install, update and deletion."


### PR DESCRIPTION
Replaces the windows style \ directory separator for the *nix style / which is more common when referring to server paths

Fixes a typo to improve readability
