### PR TITLE
[4.0] field / label descriptions

### DIFF
--- a/layouts/joomla/form/renderfield.php
+++ b/layouts/joomla/form/renderfield.php
@@ -37,12 +37,12 @@ $hide  = empty($options['hiddenLabel']) ? '' : ' sr-only';
 	<div class="control-label<?php echo $hide; ?>"><?php echo $label; ?></div>
 	<div class="controls">
 		<?php echo $input; ?>
+		<?php if (!empty($description)) : ?>
+			<div id="<?php echo $id; ?>">
+				<small class="form-text text-muted">
+					<?php echo $description; ?>
+				</small>
+			</div>
+		<?php endif; ?>
 	</div>
-	<?php if (!empty($description)) : ?>
-		<div id="<?php echo $id; ?>">
-			<small class="form-text text-muted">
-				<?php echo $description; ?>
-			</small>
-		</div>
-	<?php endif; ?>
 </div>


### PR DESCRIPTION
Super simple pr to change the markup so that field / label descriptions appear directly below the field and not the label

### before
![image](https://user-images.githubusercontent.com/1296369/77706413-3ad72580-6fba-11ea-9c82-bc54d24de837.png)

### after
![image](https://user-images.githubusercontent.com/1296369/77706393-2a26af80-6fba-11ea-98dc-d5c079639fc1.png)
