### PR TITLE
[3.x] Post installation newsfeed

### DIFF
--- a/administrator/components/com_postinstall/views/messages/tmpl/default.php
+++ b/administrator/components/com_postinstall/views/messages/tmpl/default.php
@@ -22,6 +22,7 @@ $param    = array(
 	'rssimage'    => 1,
 	'rssitems'    => 5,
 	'rssitemdesc' => 1,
+	'rssitemdate' => 1,
 	'rssrtl'      => $lang->isRtl() ? 1 : 0,
 	'word_count'  => 200,
 	'cache'       => 0,


### PR DESCRIPTION
The feed on the post installation messages screen is hard coded. This PR adds the display of the feed-item-date. Without it the content of the feed is meaningless.

Backport of #28478 as requested by @zero-24
