### PR TITLE
Make sure the Itemid get calls are always casted to integer

### DIFF
--- a/administrator/templates/isis/error.php
+++ b/administrator/templates/isis/error.php
@@ -31,7 +31,7 @@ $option   = $input->getCmd('option', '');
 $view     = $input->getCmd('view', '');
 $layout   = $input->getCmd('layout', '');
 $task     = $input->getCmd('task', '');
-$itemid   = $input->getInt('Itemid', 0);
+$itemid   = (int) $input->getInt('Itemid', 0);
 $sitename = htmlspecialchars($app->get('sitename'), ENT_QUOTES, 'UTF-8');
 
 $cpanel = ($option === 'com_cpanel');

--- a/administrator/templates/isis/error.php
+++ b/administrator/templates/isis/error.php
@@ -27,11 +27,11 @@ $frontEndUri->setScheme(((int) $app->get('force_ssl', 0) === 2) ? 'https' : 'htt
 $mainPageUri = $frontEndUri->toString();
 
 // Detecting Active Variables
-$option   = $input->get('option', '');
-$view     = $input->get('view', '');
-$layout   = $input->get('layout', '');
-$task     = $input->get('task', '');
-$itemid   = $input->get('Itemid', 0, 'int');
+$option   = $input->getCmd('option', '');
+$view     = $input->getCmd('view', '');
+$layout   = $input->getCmd('layout', '');
+$task     = $input->getCmd('task', '');
+$itemid   = $input->getInt('Itemid', 0);
 $sitename = htmlspecialchars($app->get('sitename'), ENT_QUOTES, 'UTF-8');
 
 $cpanel = ($option === 'com_cpanel');

--- a/administrator/templates/isis/error.php
+++ b/administrator/templates/isis/error.php
@@ -27,10 +27,10 @@ $frontEndUri->setScheme(((int) $app->get('force_ssl', 0) === 2) ? 'https' : 'htt
 $mainPageUri = $frontEndUri->toString();
 
 // Detecting Active Variables
-$option   = $input->getCmd('option', '');
-$view     = $input->getCmd('view', '');
-$layout   = $input->getCmd('layout', '');
-$task     = $input->getCmd('task', '');
+$option   = $input->get('option', '', 'cmd');
+$view     = $input->get('view', '', 'cmd');
+$layout   = $input->get('layout', '', 'cmd');
+$task     = $input->get('task', '', 'cmd');
 $itemid   = (int) $input->getInt('Itemid', 0);
 $sitename = htmlspecialchars($app->get('sitename'), ENT_QUOTES, 'UTF-8');
 

--- a/administrator/templates/isis/index.php
+++ b/administrator/templates/isis/index.php
@@ -49,10 +49,10 @@ JHtml::_('stylesheet', 'responsive.css', array('version' => 'auto', 'relative' =
 
 
 // Detecting Active Variables
-$option   = $input->getCmd('option', '');
-$view     = $input->getCmd('view', '');
-$layout   = $input->getCmd('layout', '');
-$task     = $input->getCmd('task', '');
+$option   = $input->get('option', '', 'cmd');
+$view     = $input->get('view', '', 'cmd');
+$layout   = $input->get('layout', '', 'cmd');
+$task     = $input->get('task', '', 'cmd');
 $itemid   = (int) $input->getInt('Itemid', 0);
 $sitename = htmlspecialchars($app->get('sitename', ''), ENT_QUOTES, 'UTF-8');
 $cpanel   = $option === 'com_cpanel';

--- a/administrator/templates/isis/index.php
+++ b/administrator/templates/isis/index.php
@@ -49,11 +49,11 @@ JHtml::_('stylesheet', 'responsive.css', array('version' => 'auto', 'relative' =
 
 
 // Detecting Active Variables
-$option   = $input->get('option', '');
-$view     = $input->get('view', '');
-$layout   = $input->get('layout', '');
-$task     = $input->get('task', '');
-$itemid   = $input->get('Itemid', 0, 'int');
+$option   = $input->getCmd('option', '');
+$view     = $input->getCmd('view', '');
+$layout   = $input->getCmd('layout', '');
+$task     = $input->getCmd('task', '');
+$itemid   = $input->getInt('Itemid', 0);
 $sitename = htmlspecialchars($app->get('sitename', ''), ENT_QUOTES, 'UTF-8');
 $cpanel   = $option === 'com_cpanel';
 

--- a/administrator/templates/isis/index.php
+++ b/administrator/templates/isis/index.php
@@ -53,7 +53,7 @@ $option   = $input->getCmd('option', '');
 $view     = $input->getCmd('view', '');
 $layout   = $input->getCmd('layout', '');
 $task     = $input->getCmd('task', '');
-$itemid   = $input->getInt('Itemid', 0);
+$itemid   = (int) $input->getInt('Itemid', 0);
 $sitename = htmlspecialchars($app->get('sitename', ''), ENT_QUOTES, 'UTF-8');
 $cpanel   = $option === 'com_cpanel';
 

--- a/administrator/templates/isis/login.php
+++ b/administrator/templates/isis/login.php
@@ -45,10 +45,10 @@ JHtml::_('stylesheet', 'administrator/language/' . $lang->getTag() . '/' . $lang
 JHtml::_('stylesheet', 'custom.css', array('version' => 'auto', 'relative' => true));
 
 // Detecting Active Variables
-$option   = $app->input->getCmd('option', '');
-$view     = $app->input->getCmd('view', '');
-$layout   = $app->input->getCmd('layout', '');
-$task     = $app->input->getCmd('task', '');
+$option   = $app->input->get('option', '', 'cmd');
+$view     = $app->input->get('view', '', 'cmd');
+$layout   = $app->input->get('layout', '', 'cmd');
+$task     = $app->input->get('task', '', 'cmd');
 $itemid   = (int) $app->input->getInt('Itemid', 0);
 $sitename = htmlspecialchars($app->get('sitename', ''), ENT_QUOTES, 'UTF-8');
 

--- a/administrator/templates/isis/login.php
+++ b/administrator/templates/isis/login.php
@@ -49,7 +49,7 @@ $option   = $app->input->getCmd('option', '');
 $view     = $app->input->getCmd('view', '');
 $layout   = $app->input->getCmd('layout', '');
 $task     = $app->input->getCmd('task', '');
-$itemid   = $app->input->getInt('Itemid', 0);
+$itemid   = (int) $app->input->getInt('Itemid', 0);
 $sitename = htmlspecialchars($app->get('sitename', ''), ENT_QUOTES, 'UTF-8');
 
 function colorIsLight($color)

--- a/administrator/templates/isis/login.php
+++ b/administrator/templates/isis/login.php
@@ -49,7 +49,7 @@ $option   = $app->input->getCmd('option', '');
 $view     = $app->input->getCmd('view', '');
 $layout   = $app->input->getCmd('layout', '');
 $task     = $app->input->getCmd('task', '');
-$itemid   = $app->input->getCmd('Itemid', '');
+$itemid   = $app->input->getInt('Itemid', 0);
 $sitename = htmlspecialchars($app->get('sitename', ''), ENT_QUOTES, 'UTF-8');
 
 function colorIsLight($color)

--- a/components/com_contact/models/category.php
+++ b/components/com_contact/models/category.php
@@ -255,7 +255,7 @@ class ContactModelCategory extends JModelList
 		$this->setState('list.start', $limitstart);
 
 		// Optional filter text
-		$itemid = $app->input->get('Itemid', 0, 'int');
+		$itemid = $app->input->getInt('Itemid', 0);
 		$search = $app->getUserStateFromRequest('com_contact.category.list.' . $itemid . '.filter-search', 'filter-search', '', 'string');
 		$this->setState('list.filter', $search);
 

--- a/components/com_contact/models/category.php
+++ b/components/com_contact/models/category.php
@@ -255,7 +255,7 @@ class ContactModelCategory extends JModelList
 		$this->setState('list.start', $limitstart);
 
 		// Optional filter text
-		$itemid = $app->input->getInt('Itemid', 0);
+		$itemid = (int) $app->input->getInt('Itemid', 0);
 		$search = $app->getUserStateFromRequest('com_contact.category.list.' . $itemid . '.filter-search', 'filter-search', '', 'string');
 		$this->setState('list.filter', $search);
 

--- a/components/com_content/controllers/article.php
+++ b/components/com_content/controllers/article.php
@@ -295,7 +295,7 @@ class ContentControllerArticle extends JControllerForm
 			$append .= '&' . $urlVar . '=' . $recordId;
 		}
 
-		$itemId = $this->input->getInt('Itemid', 0);
+		$itemId = (int) $this->input->getInt('Itemid', 0);
 		$return = $this->getReturnPage();
 		$catId  = $this->input->getInt('catid');
 

--- a/components/com_content/controllers/article.php
+++ b/components/com_content/controllers/article.php
@@ -295,7 +295,7 @@ class ContentControllerArticle extends JControllerForm
 			$append .= '&' . $urlVar . '=' . $recordId;
 		}
 
-		$itemId = $this->input->getInt('Itemid');
+		$itemId = $this->input->getInt('Itemid', 0);
 		$return = $this->getReturnPage();
 		$catId  = $this->input->getInt('catid');
 

--- a/components/com_content/models/archive.php
+++ b/components/com_content/models/archive.php
@@ -59,7 +59,7 @@ class ContentModelArchive extends ContentModelArticles
 		$this->setState('list.filter', $app->input->getString('filter-search'));
 
 		// Get list limit
-		$itemid = $app->input->get('Itemid', 0, 'int');
+		$itemid = $app->input->getInt('Itemid', 0);
 		$limit = $app->getUserStateFromRequest('com_content.archive.list' . $itemid . '.limit', 'limit', $params->get('display_num'), 'uint');
 		$this->setState('list.limit', $limit);
 

--- a/components/com_content/models/archive.php
+++ b/components/com_content/models/archive.php
@@ -59,7 +59,7 @@ class ContentModelArchive extends ContentModelArticles
 		$this->setState('list.filter', $app->input->getString('filter-search'));
 
 		// Get list limit
-		$itemid = $app->input->getInt('Itemid', 0);
+		$itemid = (int) $app->input->getInt('Itemid', 0);
 		$limit = $app->getUserStateFromRequest('com_content.archive.list' . $itemid . '.limit', 'limit', $params->get('display_num'), 'uint');
 		$this->setState('list.limit', $limit);
 

--- a/components/com_content/models/category.php
+++ b/components/com_content/models/category.php
@@ -156,7 +156,7 @@ class ContentModelCategory extends JModelList
 			$this->setState('filter.access', false);
 		}
 
-		$itemid = $app->input->get('id', 0, 'int') . ':' . $app->input->get('Itemid', 0, 'int');
+		$itemid = $app->input->get('id', 0, 'int') . ':' . $app->input->getInt('Itemid', 0);
 
 		$value = $this->getUserStateFromRequest('com_content.category.filter.' . $itemid . '.tag', 'filter_tag', 0, 'int', false);
 		$this->setState('filter.tag', $value);
@@ -280,7 +280,7 @@ class ContentModelCategory extends JModelList
 		$app       = JFactory::getApplication('site');
 		$db        = $this->getDbo();
 		$params    = $this->state->params;
-		$itemid    = $app->input->get('id', 0, 'int') . ':' . $app->input->get('Itemid', 0, 'int');
+		$itemid    = $app->input->get('id', 0, 'int') . ':' . $app->input->getInt('Itemid', 0);
 		$orderCol  = $app->getUserStateFromRequest('com_content.category.list.' . $itemid . '.filter_order', 'filter_order', '', 'string');
 		$orderDirn = $app->getUserStateFromRequest('com_content.category.list.' . $itemid . '.filter_order_Dir', 'filter_order_Dir', '', 'cmd');
 		$orderby   = ' ';

--- a/components/com_content/models/category.php
+++ b/components/com_content/models/category.php
@@ -156,7 +156,7 @@ class ContentModelCategory extends JModelList
 			$this->setState('filter.access', false);
 		}
 
-		$itemid = $app->input->get('id', 0, 'int') . ':' . $app->input->getInt('Itemid', 0);
+		$itemid = $app->input->get('id', 0, 'int') . ':' . (int) $app->input->getInt('Itemid', 0);
 
 		$value = $this->getUserStateFromRequest('com_content.category.filter.' . $itemid . '.tag', 'filter_tag', 0, 'int', false);
 		$this->setState('filter.tag', $value);
@@ -280,7 +280,7 @@ class ContentModelCategory extends JModelList
 		$app       = JFactory::getApplication('site');
 		$db        = $this->getDbo();
 		$params    = $this->state->params;
-		$itemid    = $app->input->get('id', 0, 'int') . ':' . $app->input->getInt('Itemid', 0);
+		$itemid    = $app->input->get('id', 0, 'int') . ':' . (int) $app->input->getInt('Itemid', 0);
 		$orderCol  = $app->getUserStateFromRequest('com_content.category.list.' . $itemid . '.filter_order', 'filter_order', '', 'string');
 		$orderDirn = $app->getUserStateFromRequest('com_content.category.list.' . $itemid . '.filter_order_Dir', 'filter_order_Dir', '', 'cmd');
 		$orderby   = ' ';

--- a/components/com_search/controller.php
+++ b/components/com_search/controller.php
@@ -78,7 +78,7 @@ class SearchController extends JControllerLegacy
 		}
 
 		// The Itemid from the request, we will use this if it's a search page or if there is no search page available
-		$post['Itemid'] = $this->input->getInt('Itemid', 0);
+		$post['Itemid'] = (int) $this->input->getInt('Itemid', 0);
 
 		// Set Itemid id for links from menu
 		$app  = JFactory::getApplication();

--- a/components/com_search/controller.php
+++ b/components/com_search/controller.php
@@ -78,7 +78,7 @@ class SearchController extends JControllerLegacy
 		}
 
 		// The Itemid from the request, we will use this if it's a search page or if there is no search page available
-		$post['Itemid'] = $this->input->getInt('Itemid');
+		$post['Itemid'] = $this->input->getInt('Itemid', 0);
 
 		// Set Itemid id for links from menu
 		$app  = JFactory::getApplication();

--- a/components/com_tags/models/tag.php
+++ b/components/com_tags/models/tag.php
@@ -227,7 +227,7 @@ class TagsModelTag extends JModelList
 		$offset = $app->input->get('limitstart', 0, 'uint');
 		$this->setState('list.start', $offset);
 
-		$itemid = $pkString . ':' . $app->input->get('Itemid', 0, 'int');
+		$itemid = $pkString . ':' . $app->input->getInt('Itemid', 0);
 		$orderCol = $app->getUserStateFromRequest('com_tags.tag.list.' . $itemid . '.filter_order', 'filter_order', '', 'string');
 		$orderCol = !$orderCol ? $this->state->params->get('tag_list_orderby', 'c.core_title') : $orderCol;
 

--- a/components/com_tags/models/tag.php
+++ b/components/com_tags/models/tag.php
@@ -227,7 +227,7 @@ class TagsModelTag extends JModelList
 		$offset = $app->input->get('limitstart', 0, 'uint');
 		$this->setState('list.start', $offset);
 
-		$itemid = $pkString . ':' . $app->input->getInt('Itemid', 0);
+		$itemid = $pkString . ':' . (int) $app->input->getInt('Itemid', 0);
 		$orderCol = $app->getUserStateFromRequest('com_tags.tag.list.' . $itemid . '.filter_order', 'filter_order', '', 'string');
 		$orderCol = !$orderCol ? $this->state->params->get('tag_list_orderby', 'c.core_title') : $orderCol;
 

--- a/components/com_tags/models/tags.php
+++ b/components/com_tags/models/tags.php
@@ -69,7 +69,7 @@ class TagsModelTags extends JModelList
 		}
 
 		// Optional filter text
-		$itemid = $pid . ':' . $app->input->getInt('Itemid', 0);
+		$itemid = $pid . ':' . (int) $app->input->getInt('Itemid', 0);
 		$filterSearch = $app->getUserStateFromRequest('com_tags.tags.list.' . $itemid . '.filter_search', 'filter-search', '', 'string');
 		$this->setState('list.filter', $filterSearch);
 	}

--- a/layouts/joomla/edit/frontediting_modules.php
+++ b/layouts/joomla/edit/frontediting_modules.php
@@ -18,7 +18,7 @@ $menusEditing = $displayData['menusediting'];
 $parameters   = JComponentHelper::getParams('com_modules');
 $redirectUri  = '&return=' . urlencode(base64_encode(JUri::getInstance()->toString()));
 $target       = '_blank';
-$itemid       = JFactory::getApplication()->input->get('Itemid', '0', 'int');
+$itemid       = JFactory::getApplication()->input->getInt('Itemid', 0);
 
 if (preg_match('/<(?:div|span|nav|ul|ol|h\d) [^>]*class="[^"]* jmoddiv"/', $moduleHtml))
 {
@@ -42,7 +42,7 @@ $moduleHtml = preg_replace(
 	'/^(\s*<(?:div|span|nav|ul|ol|h\d|section|aside|nav|address|article) [^>]*class="[^"]*)"/',
 	// By itself, adding class jmoddiv and data attributes for the URL and tooltip:
 	'\\1 jmoddiv" data-jmodediturl="' . $editUrl . '" data-target="' . $target . '" data-jmodtip="'
-	.	JHtml::_('tooltipText', 
+	.	JHtml::_('tooltipText',
 			JText::_('JLIB_HTML_EDIT_MODULE'),
 			htmlspecialchars($mod->title, ENT_COMPAT, 'UTF-8') . '<br />' . sprintf(JText::_('JLIB_HTML_EDIT_MODULE_IN_POSITION'), htmlspecialchars($position, ENT_COMPAT, 'UTF-8')),
 			0

--- a/layouts/joomla/edit/frontediting_modules.php
+++ b/layouts/joomla/edit/frontediting_modules.php
@@ -18,7 +18,7 @@ $menusEditing = $displayData['menusediting'];
 $parameters   = JComponentHelper::getParams('com_modules');
 $redirectUri  = '&return=' . urlencode(base64_encode(JUri::getInstance()->toString()));
 $target       = '_blank';
-$itemid       = JFactory::getApplication()->input->getInt('Itemid', 0);
+$itemid       = (int) JFactory::getApplication()->input->getInt('Itemid', 0);
 
 if (preg_match('/<(?:div|span|nav|ul|ol|h\d) [^>]*class="[^"]* jmoddiv"/', $moduleHtml))
 {

--- a/libraries/fof/controller/controller.php
+++ b/libraries/fof/controller/controller.php
@@ -3296,7 +3296,7 @@ class FOFController extends FOFUtilsObject
 	 */
 	public function getItemidURLSuffix()
 	{
-		if (FOFPlatform::getInstance()->isFrontend() && ($this->input->getCmd('Itemid', 0) != 0))
+		if (FOFPlatform::getInstance()->isFrontend() && ($this->input->getInt('Itemid', 0) != 0))
 		{
 			return '&Itemid=' . $this->input->getInt('Itemid', 0);
 		}

--- a/libraries/fof/controller/controller.php
+++ b/libraries/fof/controller/controller.php
@@ -3298,7 +3298,7 @@ class FOFController extends FOFUtilsObject
 	{
 		if (FOFPlatform::getInstance()->isFrontend() && ($this->input->getInt('Itemid', 0) != 0))
 		{
-			return '&Itemid=' . $this->input->getInt('Itemid', 0);
+			return '&Itemid=' . (int) $this->input->getInt('Itemid', 0);
 		}
 		else
 		{

--- a/libraries/fof/form/field/list.php
+++ b/libraries/fof/form/field/list.php
@@ -359,7 +359,7 @@ class FOFFormFieldList extends JFormFieldList implements FOFFormField
 		$ret = str_replace('[ITEM:ID]', $replace, $ret);
 
 		// Replace the [ITEMID] in the URL with the current Itemid parameter
-		$ret = str_replace('[ITEMID]', JFactory::getApplication()->input->getInt('Itemid', 0), $ret);
+		$ret = str_replace('[ITEMID]', (int) JFactory::getApplication()->input->getInt('Itemid', 0), $ret);
 
 		// Replace other field variables in the URL
 		$fields = $this->item->getTableFields();

--- a/libraries/fof/form/field/model.php
+++ b/libraries/fof/form/field/model.php
@@ -266,7 +266,7 @@ class FOFFormFieldModel extends FOFFormFieldList implements FOFFormField
 		$ret = str_replace('[ITEM:ID]', $replace, $ret);
 
 		// Replace the [ITEMID] in the URL with the current Itemid parameter
-		$ret = str_replace('[ITEMID]', JFactory::getApplication()->input->getInt('Itemid', 0), $ret);
+		$ret = str_replace('[ITEMID]', (int) JFactory::getApplication()->input->getInt('Itemid', 0), $ret);
 
 		// Replace other field variables in the URL
 		$fields = $this->item->getTableFields();

--- a/libraries/fof/form/field/relation.php
+++ b/libraries/fof/form/field/relation.php
@@ -167,7 +167,7 @@ class FOFFormFieldRelation extends FOFFormFieldList
 		$ret = str_replace('[ITEM:ID]', $replace, $ret);
 
 		// Replace the [ITEMID] in the URL with the current Itemid parameter
-		$ret = str_replace('[ITEMID]', JFactory::getApplication()->input->getInt('Itemid', 0), $ret);
+		$ret = str_replace('[ITEMID]', (int) JFactory::getApplication()->input->getInt('Itemid', 0), $ret);
 
 		// Replace the [RELATION:ID] in the URL with the relation's key value
 		$ret = str_replace('[RELATION:ID]', $this->_relationId, $ret);

--- a/libraries/fof/form/field/text.php
+++ b/libraries/fof/form/field/text.php
@@ -222,7 +222,7 @@ class FOFFormFieldText extends JFormFieldText implements FOFFormField
 		$ret = str_replace('[ITEM:ID]', $replace, $ret);
 
 		// Replace the [ITEMID] in the URL with the current Itemid parameter
-		$ret = str_replace('[ITEMID]', JFactory::getApplication()->input->getInt('Itemid', 0), $ret);
+		$ret = str_replace('[ITEMID]', (int) JFactory::getApplication()->input->getInt('Itemid', 0), $ret);
 
 		// Replace other field variables in the URL
 		$fields = $this->item->getTableFields();

--- a/libraries/fof/render/joomla.php
+++ b/libraries/fof/render/joomla.php
@@ -172,9 +172,9 @@ class FOFRenderJoomla extends FOFRenderAbstract
 		$filter_order_Dir	 = $form->getView()->getLists()->order_Dir;
         $actionUrl           = FOFPlatform::getInstance()->isBackend() ? 'index.php' : JUri::root().'index.php';
 
-		if (FOFPlatform::getInstance()->isFrontend() && ($input->getCmd('Itemid', 0) != 0))
+		if (FOFPlatform::getInstance()->isFrontend() && ($input->getInt('Itemid', 0) != 0))
 		{
-			$itemid = $input->getCmd('Itemid', 0);
+			$itemid = $input->getInt('Itemid', 0);
 			$uri = new JUri($actionUrl);
 
 			if ($itemid)

--- a/libraries/fof/render/joomla.php
+++ b/libraries/fof/render/joomla.php
@@ -174,7 +174,7 @@ class FOFRenderJoomla extends FOFRenderAbstract
 
 		if (FOFPlatform::getInstance()->isFrontend() && ($input->getInt('Itemid', 0) != 0))
 		{
-			$itemid = $input->getInt('Itemid', 0);
+			$itemid = (int) $input->getInt('Itemid', 0);
 			$uri = new JUri($actionUrl);
 
 			if ($itemid)

--- a/libraries/src/Application/SiteApplication.php
+++ b/libraries/src/Application/SiteApplication.php
@@ -795,7 +795,7 @@ final class SiteApplication extends CMSApplication
 		// Execute the parent method
 		parent::route();
 
-		$Itemid = $this->input->getInt('Itemid', null);
+		$Itemid = (int) $this->input->getInt('Itemid', null);
 		$this->authorise($Itemid);
 	}
 

--- a/libraries/src/Application/SiteApplication.php
+++ b/libraries/src/Application/SiteApplication.php
@@ -795,7 +795,7 @@ final class SiteApplication extends CMSApplication
 		// Execute the parent method
 		parent::route();
 
-		$Itemid = (int) $this->input->getInt('Itemid', null);
+		$Itemid = (int) $this->input->getInt('Itemid', 0);
 		$this->authorise($Itemid);
 	}
 

--- a/libraries/src/Helper/ModuleHelper.php
+++ b/libraries/src/Helper/ModuleHelper.php
@@ -452,7 +452,7 @@ abstract class ModuleHelper
 	{
 		// Apply negative selections and eliminate duplicates
 		$Itemid = (int) \JFactory::getApplication()->input->getInt('Itemid', 0);
-		$negId = $Itemid ? -(int) $Itemid : false;
+		$negId = $Itemid ? -$Itemid : false;
 		$clean = array();
 		$dupes = array();
 

--- a/libraries/src/Helper/ModuleHelper.php
+++ b/libraries/src/Helper/ModuleHelper.php
@@ -379,7 +379,7 @@ abstract class ModuleHelper
 	public static function getModuleList()
 	{
 		$app = \JFactory::getApplication();
-		$Itemid = $app->input->getInt('Itemid', 0);
+		$Itemid = (int) $app->input->getInt('Itemid', 0);
 		$groups = implode(',', \JFactory::getUser()->getAuthorisedViewLevels());
 		$lang = \JFactory::getLanguage()->getTag();
 		$clientId = (int) $app->getClientId();
@@ -451,7 +451,7 @@ abstract class ModuleHelper
 	public static function cleanModuleList($modules)
 	{
 		// Apply negative selections and eliminate duplicates
-		$Itemid = \JFactory::getApplication()->input->getInt('Itemid', 0);
+		$Itemid = (int) \JFactory::getApplication()->input->getInt('Itemid', 0);
 		$negId = $Itemid ? -(int) $Itemid : false;
 		$clean = array();
 		$dupes = array();
@@ -618,7 +618,7 @@ abstract class ModuleHelper
 				$ret = $cache->get(
 					array($cacheparams->class, $cacheparams->method),
 					$cacheparams->methodparams,
-					$module->id . $view_levels . \JFactory::getApplication()->input->getInt('Itemid', null),
+					$module->id . $view_levels . (int) \JFactory::getApplication()->input->getInt('Itemid', null),
 					$wrkarounds,
 					$wrkaroundoptions
 				);

--- a/libraries/src/Helper/ModuleHelper.php
+++ b/libraries/src/Helper/ModuleHelper.php
@@ -451,7 +451,7 @@ abstract class ModuleHelper
 	public static function cleanModuleList($modules)
 	{
 		// Apply negative selections and eliminate duplicates
-		$Itemid = \JFactory::getApplication()->input->getInt('Itemid');
+		$Itemid = \JFactory::getApplication()->input->getInt('Itemid', 0);
 		$negId = $Itemid ? -(int) $Itemid : false;
 		$clean = array();
 		$dupes = array();

--- a/modules/mod_articles_category/helper.php
+++ b/modules/mod_articles_category/helper.php
@@ -268,10 +268,10 @@ abstract class ModArticlesCategoryHelper
 				{
 					$Itemid = $menuitems[0]->id;
 				}
-				elseif ($app->input->getInt('Itemid') > 0)
+				elseif ($app->input->getInt('Itemid', 0) > 0)
 				{
 					// Use Itemid from requesting page only if there is no existing menu
-					$Itemid = $app->input->getInt('Itemid');
+					$Itemid = $app->input->getInt('Itemid', 0);
 				}
 
 				$item->link = JRoute::_('index.php?option=com_users&view=login&Itemid=' . $Itemid);

--- a/modules/mod_articles_category/helper.php
+++ b/modules/mod_articles_category/helper.php
@@ -271,7 +271,7 @@ abstract class ModArticlesCategoryHelper
 				elseif ($app->input->getInt('Itemid', 0) > 0)
 				{
 					// Use Itemid from requesting page only if there is no existing menu
-					$Itemid = $app->input->getInt('Itemid', 0);
+					$Itemid = (int) $app->input->getInt('Itemid', 0);
 				}
 
 				$item->link = JRoute::_('index.php?option=com_users&view=login&Itemid=' . $Itemid);

--- a/modules/mod_search/mod_search.php
+++ b/modules/mod_search/mod_search.php
@@ -15,7 +15,7 @@ JLoader::register('ModSearchHelper', __DIR__ . '/helper.php');
 $lang       = JFactory::getLanguage();
 $app        = JFactory::getApplication();
 $set_Itemid = (int) $params->get('set_itemid', 0);
-$mitemid    = $set_Itemid > 0 ? $set_Itemid : $app->input->getInt('Itemid');
+$mitemid    = $set_Itemid > 0 ? $set_Itemid : $app->input->getInt('Itemid', 0);
 
 if ($params->get('opensearch', 1))
 {

--- a/modules/mod_search/mod_search.php
+++ b/modules/mod_search/mod_search.php
@@ -15,7 +15,7 @@ JLoader::register('ModSearchHelper', __DIR__ . '/helper.php');
 $lang       = JFactory::getLanguage();
 $app        = JFactory::getApplication();
 $set_Itemid = (int) $params->get('set_itemid', 0);
-$mitemid    = $set_Itemid > 0 ? $set_Itemid : $app->input->getInt('Itemid', 0);
+$mitemid    = $set_Itemid > 0 ? $set_Itemid : (int) $app->input->getInt('Itemid', 0);
 
 if ($params->get('opensearch', 1))
 {

--- a/templates/protostar/error.php
+++ b/templates/protostar/error.php
@@ -18,10 +18,10 @@ $user = JFactory::getUser();
 $params = $app->getTemplate(true)->params;
 
 // Detecting Active Variables
-$option   = $app->input->getCmd('option', '');
-$view     = $app->input->getCmd('view', '');
-$layout   = $app->input->getCmd('layout', '');
-$task     = $app->input->getCmd('task', '');
+$option   = $app->input->get('option', '', 'cmd');
+$view     = $app->input->get('view', '', 'cmd');
+$layout   = $app->input->get('layout', '', 'cmd');
+$task     = $app->input->get('task', '', 'cmd');
 $itemid   = (int) $app->input->getInt('Itemid', 0);
 $format   = $app->input->getCmd('format', 'html');
 $sitename = htmlspecialchars($app->get('sitename'), ENT_QUOTES, 'UTF-8');

--- a/templates/protostar/error.php
+++ b/templates/protostar/error.php
@@ -22,7 +22,7 @@ $option   = $app->input->getCmd('option', '');
 $view     = $app->input->getCmd('view', '');
 $layout   = $app->input->getCmd('layout', '');
 $task     = $app->input->getCmd('task', '');
-$itemid   = $app->input->getCmd('Itemid', '');
+$itemid   = $app->input->getInt('Itemid', '');
 $format   = $app->input->getCmd('format', 'html');
 $sitename = htmlspecialchars($app->get('sitename'), ENT_QUOTES, 'UTF-8');
 

--- a/templates/protostar/error.php
+++ b/templates/protostar/error.php
@@ -22,7 +22,7 @@ $option   = $app->input->getCmd('option', '');
 $view     = $app->input->getCmd('view', '');
 $layout   = $app->input->getCmd('layout', '');
 $task     = $app->input->getCmd('task', '');
-$itemid   = $app->input->getInt('Itemid', '');
+$itemid   = (int) $app->input->getInt('Itemid', 0);
 $format   = $app->input->getCmd('format', 'html');
 $sitename = htmlspecialchars($app->get('sitename'), ENT_QUOTES, 'UTF-8');
 

--- a/templates/protostar/index.php
+++ b/templates/protostar/index.php
@@ -21,10 +21,10 @@ $this->setHtml5(true);
 $params = $app->getTemplate(true)->params;
 
 // Detecting Active Variables
-$option   = $app->input->getCmd('option', '');
-$view     = $app->input->getCmd('view', '');
-$layout   = $app->input->getCmd('layout', '');
-$task     = $app->input->getCmd('task', '');
+$option   = $app->input->get('option', '', 'cmd');
+$view     = $app->input->get('view', '', 'cmd');
+$layout   = $app->input->get('layout', '', 'cmd');
+$task     = $app->input->get('task', '', 'cmd');
 $itemid   = (int) $app->input->getInt('Itemid', 0);
 $sitename = htmlspecialchars($app->get('sitename'), ENT_QUOTES, 'UTF-8');
 

--- a/templates/protostar/index.php
+++ b/templates/protostar/index.php
@@ -25,7 +25,7 @@ $option   = $app->input->getCmd('option', '');
 $view     = $app->input->getCmd('view', '');
 $layout   = $app->input->getCmd('layout', '');
 $task     = $app->input->getCmd('task', '');
-$itemid   = $app->input->getInt('Itemid', '');
+$itemid   = (int) $app->input->getInt('Itemid', 0);
 $sitename = htmlspecialchars($app->get('sitename'), ENT_QUOTES, 'UTF-8');
 
 if ($task === 'edit' || $layout === 'form')

--- a/templates/protostar/index.php
+++ b/templates/protostar/index.php
@@ -25,7 +25,7 @@ $option   = $app->input->getCmd('option', '');
 $view     = $app->input->getCmd('view', '');
 $layout   = $app->input->getCmd('layout', '');
 $task     = $app->input->getCmd('task', '');
-$itemid   = $app->input->getCmd('Itemid', '');
+$itemid   = $app->input->getInt('Itemid', '');
 $sitename = htmlspecialchars($app->get('sitename'), ENT_QUOTES, 'UTF-8');
 
 if ($task === 'edit' || $layout === 'form')


### PR DESCRIPTION
### Summary of Changes

Make sure the Itemid filter always casts to integer, when the itemid get passed an array of items the current [getint filter (`int`, `integer`)](https://github.com/joomla/joomla-cms/blob/staging/libraries/src/Filter/InputFilter.php#L117) returns an array but the itemid should never be an array.

### Testing Instructions

Make sure the usual Frontend and backend still works and the correct itemid is in the html classes.

### Expected result

We type cast the itemid to integer

### Actual result

Passing an array would result into the itemId not to be an actual ID any more but an array.

### Documentation Changes Required

None cc @SniperSister @HLeithner 

Reported by: https://twitter.com/paulosyibelo