### PR TITLE
[4.0] content associations

### DIFF
--- a/administrator/components/com_content/src/View/Article/HtmlView.php
+++ b/administrator/components/com_content/src/View/Article/HtmlView.php
@@ -220,14 +220,14 @@ class HtmlView extends BaseHtmlView
 				$toolbar->preview($url, 'JGLOBAL_PREVIEW')
 					->bodyHeight(80)
 					->modalWidth(90);
-			}
-		}
 
-		if (Associations::isEnabled() && ComponentHelper::isEnabled('com_associations'))
-		{
-			$toolbar->standardButton('contract')
-				->text('JTOOLBAR_ASSOCIATIONS')
-				->task('article.editAssociations');
+				if (Associations::isEnabled() && ComponentHelper::isEnabled('com_associations'))
+				{
+					$toolbar->standardButton('contract')
+						->text('JTOOLBAR_ASSOCIATIONS')
+						->task('article.editAssociations');
+				}
+			}
 		}
 
 		$toolbar->divider();


### PR DESCRIPTION
Moves the associations **button** so that it only appears when it can be used ie not on an unsaved article which is the same behaviour as versions and preview.

