### PR TITLE
[RFC] Allow disabling tags and versions in the plugins

### DIFF
--- a/administrator/language/en-GB/plg_behaviour_taggable.ini
+++ b/administrator/language/en-GB/plg_behaviour_taggable.ini
@@ -5,3 +5,4 @@
 
 PLG_BEHAVIOUR_TAGGABLE="Behaviour - Taggable"
 PLG_BEHAVIOUR_TAGGABLE_XML_DESCRIPTION="Allows content items to be tagged."
+PLG_BEHAVIOUR_TAGGABLE_REMOVE_FROM="Remove tags from:"

--- a/administrator/language/en-GB/plg_behaviour_versionable.ini
+++ b/administrator/language/en-GB/plg_behaviour_versionable.ini
@@ -5,3 +5,4 @@
 
 PLG_BEHAVIOUR_VERSIONABLE="Behaviour - Versionable"
 PLG_BEHAVIOUR_VERSIONABLE_XML_DESCRIPTION="Allows content items to be versioned."
+PLG_BEHAVIOUR_VERSIONABLE_REMOVE_FROM="Remove content history from:"

--- a/libraries/src/Form/Field/ContenttypeField.php
+++ b/libraries/src/Form/Field/ContenttypeField.php
@@ -29,6 +29,83 @@ class ContenttypeField extends ListField
 	public $type = 'Contenttype';
 
 	/**
+	 * If true the uses the type_alias instead of the content type primary key as the field value.
+	 *
+	 * @var    boolean
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $useAliasAsValue = false;
+
+	/**
+	 * Method to attach a Form object to the field.
+	 *
+	 * @param   \SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
+	 * @param   mixed              $value    The form field value to validate.
+	 * @param   string             $group    The field name group control value. This acts as an array container for the field.
+	 *                                       For example if the field has name="foo" and the group value is set to "bar" then the
+	 *                                       full field name would end up being "bar[foo]".
+	 *
+	 * @return  boolean  True on success.
+	 *
+	 * @see     FormField::setup()
+	 * @since   3.2
+	 */
+	public function setup(\SimpleXMLElement $element, $value, $group = null)
+	{
+		$return = parent::setup($element, $value, $group);
+
+		if ($return)
+		{
+			$this->useAliasAsValue = (boolean) $this->element['useAliasAsValue'];
+		}
+
+		return $return;
+	}
+
+	/**
+	 * Method to get certain otherwise inaccessible properties from the form field object.
+	 *
+	 * @param   string  $name  The property name for which to get the value.
+	 *
+	 * @return  mixed  The property value or null.
+	 *
+	 * @since   3.2
+	 */
+	public function __get($name)
+	{
+		switch ($name)
+		{
+			case 'useAliasAsValue':
+				return $this->$name;
+		}
+
+		return parent::__get($name);
+	}
+
+	/**
+	 * Method to set certain otherwise inaccessible properties of the form field object.
+	 *
+	 * @param   string  $name   The property name for which to set the value.
+	 * @param   mixed   $value  The value of the property.
+	 *
+	 * @return  void
+	 *
+	 * @since   3.2
+	 */
+	public function __set($name, $value)
+	{
+		switch ($name)
+		{
+			case 'useAliasAsValue':
+				$this->$name = (boolean) $value;
+				break;
+
+			default:
+				parent::__set($name, $value);
+		}
+	}
+
+	/**
 	 * Method to get the field input for a list of content types.
 	 *
 	 * @return  string  The field input.
@@ -67,7 +144,7 @@ class ContenttypeField extends ListField
 		$query = $db->getQuery(true)
 			->select(
 				[
-					$db->quoteName('a.type_id', 'value'),
+					$db->quoteName($this->useAliasAsValue ? 'a.type_alias' : 'a.type_id', 'value'),
 					$db->quoteName('a.type_title', 'text'),
 					$db->quoteName('a.type_alias', 'alias'),
 				]

--- a/plugins/behaviour/taggable/taggable.php
+++ b/plugins/behaviour/taggable/taggable.php
@@ -65,6 +65,14 @@ class PlgBehaviourTaggable extends CMSPlugin
 			return;
 		}
 
+		$contentTypeFilter = $this->params->get('filterContentType');
+
+		// Check if the user has disabled tags for this content type
+		if (is_array($contentTypeFilter) && in_array($typeAlias, $contentTypeFilter))
+		{
+			return;
+		}
+
 		// If the table already has a tags helper we have nothing to do
 		if (property_exists($table, 'tagsHelper'))
 		{
@@ -104,6 +112,14 @@ class PlgBehaviourTaggable extends CMSPlugin
 
 		// If the table doesn't support UCM we can't use the Taggable behaviour
 		if (is_null($typeAlias))
+		{
+			return;
+		}
+
+		$contentTypeFilter = $this->params->get('filterContentType');
+
+		// Check if the user has disabled tags for this content type
+		if (is_array($contentTypeFilter) && in_array($typeAlias, $contentTypeFilter))
 		{
 			return;
 		}
@@ -165,6 +181,14 @@ class PlgBehaviourTaggable extends CMSPlugin
 			return;
 		}
 
+		$contentTypeFilter = $this->params->get('filterContentType');
+
+		// Check if the user has disabled tags for this content type
+		if (is_array($contentTypeFilter) && in_array($typeAlias, $contentTypeFilter))
+		{
+			return;
+		}
+
 		// If the table doesn't have a tags helper we can't proceed
 		if (!property_exists($table, 'tagsHelper'))
 		{
@@ -222,6 +246,14 @@ class PlgBehaviourTaggable extends CMSPlugin
 			return;
 		}
 
+		$contentTypeFilter = $this->params->get('filterContentType');
+
+		// Check if the user has disabled tags for this content type
+		if (is_array($contentTypeFilter) && in_array($typeAlias, $contentTypeFilter))
+		{
+			return;
+		}
+
 		// If the table doesn't have a tags helper we can't proceed
 		if (!property_exists($table, 'tagsHelper'))
 		{
@@ -256,6 +288,14 @@ class PlgBehaviourTaggable extends CMSPlugin
 
 		// If the table doesn't support UCM we can't use the Taggable behaviour
 		if (is_null($typeAlias))
+		{
+			return;
+		}
+
+		$contentTypeFilter = $this->params->get('filterContentType');
+
+		// Check if the user has disabled tags for this content type
+		if (is_array($contentTypeFilter) && in_array($typeAlias, $contentTypeFilter))
 		{
 			return;
 		}
@@ -301,6 +341,14 @@ class PlgBehaviourTaggable extends CMSPlugin
 			return;
 		}
 
+		$contentTypeFilter = $this->params->get('filterContentType');
+
+		// Check if the user has disabled tags for this content type
+		if (is_array($contentTypeFilter) && in_array($typeAlias, $contentTypeFilter))
+		{
+			return;
+		}
+
 		$table->tagsHelper = new TagsHelper;
 		$table->tagsHelper->typeAlias = $table->typeAlias;
 	}
@@ -325,6 +373,14 @@ class PlgBehaviourTaggable extends CMSPlugin
 
 		// If the table doesn't support UCM we can't use the Taggable behaviour
 		if (is_null($typeAlias))
+		{
+			return;
+		}
+
+		$contentTypeFilter = $this->params->get('filterContentType');
+
+		// Check if the user has disabled tags for this content type
+		if (is_array($contentTypeFilter) && in_array($typeAlias, $contentTypeFilter))
 		{
 			return;
 		}

--- a/plugins/behaviour/taggable/taggable.xml
+++ b/plugins/behaviour/taggable/taggable.xml
@@ -16,10 +16,13 @@
 	<fields name="params">
 		<fieldset name="basic">
 			<field
-				name="message"
-				type="note"
-				label="TODO: Implement a form field type which allows users to select which components / views to exclude"
-				/>
+				name="filterContentType"
+				type="Contenttype"
+				useAliasAsValue="true"
+				multiple="true"
+				label="PLG_BEHAVIOUR_TAGGABLE_REMOVE_FROM"
+				validate="options"
+			/>
 		</fieldset>
 	</fields>
 	</config>

--- a/plugins/behaviour/versionable/versionable.php
+++ b/plugins/behaviour/versionable/versionable.php
@@ -66,6 +66,14 @@ class PlgBehaviourVersionable extends CMSPlugin
 			return;
 		}
 
+		$contentTypeFilter = $this->params->get('filterContentType');
+
+		// Check if the user has disabled versions for this content type
+		if (is_array($contentTypeFilter) && in_array($typeAlias, $contentTypeFilter))
+		{
+			return;
+		}
+
 		// If the table already has a content history helper we have nothing to do
 		if (property_exists($table, 'contenthistoryHelper'))
 		{
@@ -111,6 +119,14 @@ class PlgBehaviourVersionable extends CMSPlugin
 			return;
 		}
 
+		$contentTypeFilter = $this->params->get('filterContentType');
+
+		// Check if the user has disabled versions for this content type
+		if (is_array($contentTypeFilter) && in_array($typeAlias, $contentTypeFilter))
+		{
+			return;
+		}
+
 		// If the table doesn't have a content history helper we can't proceed
 		if (!property_exists($table, 'contenthistoryHelper'))
 		{
@@ -148,6 +164,14 @@ class PlgBehaviourVersionable extends CMSPlugin
 
 		// If the table doesn't support UCM we can't use the Versionable behaviour
 		if (is_null($typeAlias))
+		{
+			return;
+		}
+
+		$contentTypeFilter = $this->params->get('filterContentType');
+
+		// Check if the user has disabled versions for this content type
+		if (is_array($contentTypeFilter) && in_array($typeAlias, $contentTypeFilter))
 		{
 			return;
 		}

--- a/plugins/behaviour/versionable/versionable.xml
+++ b/plugins/behaviour/versionable/versionable.xml
@@ -16,10 +16,13 @@
 	<fields name="params">
 		<fieldset name="basic">
 			<field
-				name="message"
-				type="note"
-				label="TODO: Implement a form field type which allows users to select which components / views to exclude"
-				/>
+				name="filterContentType"
+				type="Contenttype"
+				multiple="true"
+				label="PLG_BEHAVIOUR_VERSIONABLE_REMOVE_FROM"
+				validate="options"
+				useAliasAsValue="true"
+			/>
 		</fieldset>
 	</fields>
 	</config>


### PR DESCRIPTION
Relates to Issue #28474 .

### Summary of Changes
This adds a field to allow disabling the tags and version history plugins for specific content types per the original TODO by @nikosdion 

### Testing Instructions
![image](https://user-images.githubusercontent.com/1986000/77823594-28610700-70f4-11ea-9396-2cfe565f6554.png)

Note the plugin doesn't control the form fields - so the tags form field and content history modals will still render - however they will not ever save tags nor versions (nor will you be able to delete them - everything will effectively become readonly and in stasis)

Right now there is a "known" bug (part of the reason why this is a draft) which is that when you try and unselect all options from the new field you are unable to. I can work on that if people like the concept (see the next section) - however otherwise this is ready to be tested.

### Do we need this?
If we do this the logical thing would be to migrate this functionality away from the option we currently have in global config.

Obviously it would be nicer from a UX point if these plugins controlled the tags/versions plugins - but I'm not sure that's a b/c break we want to make at this point in the j4 lifecycle (i.e. looking to do beta before the end of May)

There is obviously the other option to leave this sorta thing for J5 and delete the TODO message in the meantime (probably the better option)

### Documentation Changes Required
Obviously will need documentation
