### PR TITLE
[4.0] Add OutputFilter tests

### DIFF
--- a/libraries/src/Filter/OutputFilter.php
+++ b/libraries/src/Filter/OutputFilter.php
@@ -52,7 +52,16 @@ class OutputFilter extends BaseOutputFilter
 
 		foreach ($chars as $chr)
 		{
-			$new_str .= '\\u' . str_pad(dechex(StringHelper::ord($chr)), 4, '0', STR_PAD_LEFT);
+			$code = str_pad(dechex(StringHelper::ord($chr)), 4, '0', STR_PAD_LEFT);
+
+			if (strlen($code) < 5)
+			{
+				$new_str .= '\\u' . $code;
+			}
+			else
+			{
+				$new_str .= '\\u{' . $code . '}';
+			}
 		}
 
 		return $new_str;

--- a/tests/Unit/Libraries/Cms/Filter/OutputFilterTest.php
+++ b/tests/Unit/Libraries/Cms/Filter/OutputFilterTest.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * @package     Joomla.UnitTest
+ * @subpackage  Access
+ *
+ * @copyright   Copyright (C) 2005 - 2019 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+namespace Joomla\Tests\Unit\Libraries\Cms\Filter;
+
+use Joomla\CMS\Filter\OutputFilter;
+use Joomla\Tests\Unit\UnitTestCase;
+
+/**
+ * Test class for \Joomla\CMS\Filter\OutputFilter.
+ *
+ * @package  Joomla.Platform
+ *
+ * @since    __DEPLOY_VERSION__
+ */
+class OutputFilterTest extends UnitTestCase
+{
+	/**
+	 * Tests enforcing XHTML links.
+	 *
+	 * @return  void
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testLinkXHTMLSafe()
+	{
+		$this->assertEquals(
+			'<a href="http://www.example.com/index.frd?one=1&amp;two=2&amp;three=3">This & That</a>',
+			OutputFilter::linkXHTMLSafe('<a href="http://www.example.com/index.frd?one=1&two=2&three=3">This & That</a>'),
+			'Should clean ampersands only out of link, not out of link text'
+		);
+	}
+
+	/**
+	 * Tests enforcing JS safe output.
+	 *
+	 * @return  void
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testStringJSSafe()
+	{
+		$this->assertEquals(
+			'\u0054\u0065\u0073\u0074\u0022\u003e\u0027\u0020\u00e4\u00f6\u0020\u6d4b\u8bd5\u{28207}',
+			OutputFilter::stringJSSafe('Test">\' äö 测试𨈇'),
+			'Should convert all input to escaped unicode notation'
+		);
+	}
+
+	/**
+	 * Tests filtering strings down to ASCII-7 lowercase URL text
+	 *
+	 * @return  void
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testStringURLSafe()
+	{
+		$this->assertEquals(
+			'1234567890-qwertyuiop-qwertyuiop-asdfghjkl-asdfghjkl-zxcvbnm-zxcvbnm',
+			OutputFilter::stringURLSafe('`1234567890-=~!@#$%^&*()_+	qwertyuiop[]\QWERTYUIOP{}|asdfghjkl;\'ASDFGHJKL:"zxcvbnm,./ZXCVBNM<>?'),
+			'Should clean keyboard string down to ASCII-7'
+		);
+	}
+
+	/**
+	 * Tests replacing single ampersands with the entity, but leaving double ampersands
+	 * and ampsersand-octothorpe combinations intact.
+	 *
+	 * @return  void
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testAmpReplace()
+	{
+		$this->assertEquals(
+			'&&george&amp;mary&#3son',
+			OutputFilter::ampReplace('&&george&mary&#3son'),
+			'Should replace single ampersands with HTML entity'
+		);
+
+		$this->assertEquals(
+			'index.php?&&george&amp;mary&#3son&amp;this=that',
+			OutputFilter::ampReplace('index.php?&&george&mary&#3son&this=that'),
+			'Should replace single ampersands with HTML entity'
+		);
+
+		$this->assertEquals(
+			'index.php?&&george&amp;mary&#3son&&&this=that',
+			OutputFilter::ampReplace('index.php?&&george&mary&#3son&&&this=that'),
+			'Should replace single ampersands with HTML entity'
+		);
+
+		$this->assertEquals(
+			'index.php?&amp;this="this &amp; and that"',
+			OutputFilter::ampReplace('index.php?&this="this & and that"'),
+			'Should replace single ampersands with HTML entity'
+		);
+
+		$this->assertEquals(
+			'index.php?&amp;this="this &amp; &amp; &&amp; and that"',
+			OutputFilter::ampReplace('index.php?&this="this &amp; & &&amp; and that"'),
+			'Should replace single ampersands with HTML entity'
+		);
+	}
+}


### PR DESCRIPTION
This adds unittests for the OutputFilter class. The code is half copied over from 3.x. Nothing special to look at. The chinese symbol should mean "test" and be a 4-byte-unicode character.

This is related to #25845.