### PR TITLE
[4.0] Exception handler with debug enabled, second try

### DIFF
--- a/administrator/includes/framework.php
+++ b/administrator/includes/framework.php
@@ -45,35 +45,30 @@ switch ($config->error_reporting)
 {
 	case 'default':
 	case '-1':
-		$errorHandler->scopeAt(0, true);
 
 		break;
 
 	case 'none':
 	case '0':
 		error_reporting(0);
-		$errorHandler->scopeAt(0, true);
 
 		break;
 
 	case 'simple':
 		error_reporting(E_ERROR | E_WARNING | E_PARSE);
 		ini_set('display_errors', 1);
-		$errorHandler->scopeAt(E_ERROR | E_WARNING | E_PARSE, true);
 
 		break;
 
 	case 'maximum':
 		error_reporting(E_ALL);
 		ini_set('display_errors', 1);
-		$errorHandler->scopeAt(E_ALL, true);
 
 		break;
 
 	case 'development':
 		error_reporting(-1);
 		ini_set('display_errors', 1);
-		$errorHandler->scopeAt(E_ALL, true);
 
 		break;
 
@@ -81,20 +76,20 @@ switch ($config->error_reporting)
 		error_reporting($config->error_reporting);
 		ini_set('display_errors', 1);
 
-		if (is_int($config->error_reporting))
-		{
-			$errorHandler->scopeAt($config->error_reporting, true);
-		}
-
 		break;
 }
 
 define('JDEBUG', $config->debug);
 
-if (JDEBUG)
+if (JDEBUG || $config->error_reporting === 'maximum')
 {
-	// Restore ErrorHandler default level
-	$errorHandler->scopeAt(0x1FFF, true);
+	// Set new Exception handler with debug enabled
+	$errorHandler->setExceptionHandler(
+		[
+			new \Symfony\Component\ErrorHandler\ErrorHandler(null, true),
+			'renderException'
+		]
+	);
 }
 
 unset($config);

--- a/api/includes/framework.php
+++ b/api/includes/framework.php
@@ -86,4 +86,15 @@ switch ($config->error_reporting)
 
 define('JDEBUG', $config->debug);
 
+if (JDEBUG || $config->error_reporting === 'maximum')
+{
+	// Set new Exception handler with debug enabled
+	$errorHandler->setExceptionHandler(
+		[
+			new \Symfony\Component\ErrorHandler\ErrorHandler(null, true),
+			'renderException'
+		]
+	);
+}
+
 unset($config);

--- a/includes/framework.php
+++ b/includes/framework.php
@@ -45,46 +45,36 @@ switch ($config->error_reporting)
 {
 	case 'default':
 	case '-1':
-		$errorHandler->scopeAt(0, true);
 
 		break;
 
 	case 'none':
 	case '0':
 		error_reporting(0);
-		$errorHandler->scopeAt(0, true);
 
 		break;
 
 	case 'simple':
 		error_reporting(E_ERROR | E_WARNING | E_PARSE);
 		ini_set('display_errors', 1);
-		$errorHandler->scopeAt(E_ERROR | E_WARNING | E_PARSE, true);
 
 		break;
 
 	case 'maximum':
 		error_reporting(E_ALL);
 		ini_set('display_errors', 1);
-		$errorHandler->scopeAt(E_ALL, true);
 
 		break;
 
 	case 'development':
 		error_reporting(-1);
 		ini_set('display_errors', 1);
-		$errorHandler->scopeAt(E_ALL, true);
 
 		break;
 
 	default:
 		error_reporting($config->error_reporting);
 		ini_set('display_errors', 1);
-
-		if (is_int($config->error_reporting))
-		{
-			$errorHandler->scopeAt($config->error_reporting, true);
-		}
 
 		break;
 }
@@ -94,10 +84,15 @@ if (!defined('JDEBUG'))
 	define('JDEBUG', $config->debug);
 }
 
-if (JDEBUG)
+if (JDEBUG || $config->error_reporting === 'maximum')
 {
-	// Restore ErrorHandler default level
-	$errorHandler->scopeAt(0x1FFF, true);
+	// Set new Exception handler with debug enabled
+	$errorHandler->setExceptionHandler(
+		[
+			new \Symfony\Component\ErrorHandler\ErrorHandler(null, true),
+			'renderException'
+		]
+	);
 }
 
 unset($config);

--- a/libraries/bootstrap.php
+++ b/libraries/bootstrap.php
@@ -58,9 +58,6 @@ require_once JPATH_LIBRARIES . '/classmap.php';
  */
 $errorHandler = \Symfony\Component\ErrorHandler\ErrorHandler::register();
 
-// Use server default error level, initially
-$errorHandler->scopeAt(error_reporting(), true);
-
 // Register the error handler which processes E_USER_DEPRECATED errors
 set_error_handler(['JErrorPage', 'handleUserDeprecatedErrors'], E_USER_DEPRECATED);
 


### PR DESCRIPTION
### Summary of Changes
Fix for #27632 

Since [internal changes in](https://github.com/symfony/error-handler/commit/d2721499ffcaf246a743e01cdf6696d3d5dd74c1#diff-b91ca53d6ab50b804cb5783aaf1f9740) `Symfony\Component\ErrorHandler\ErrorHandler` my previous changes #27632 make no sense anymore :smiley: 

@wilsonge sorry for confusing


### Testing Instructions
Please repeat test from #27632


### Expected result
You should be able to see exception message with trace when Debug enabled


### Actual result
You see only "Oops! An Error Occurred"



