### PR TITLE
Fixing unittests on PHP 7.4

### DIFF
--- a/tests/unit/core/mock/language.php
+++ b/tests/unit/core/mock/language.php
@@ -30,6 +30,7 @@ class TestMockLanguage
 			'_',
 			'getInstance',
 			'getTag',
+			'isRTL',
 			'test',
 		);
 
@@ -46,6 +47,7 @@ class TestMockLanguage
 			$mockObject, array(
 				'getInstance' => $mockObject,
 				'getTag' => 'en-GB',
+				'isRTL' => false,
 				// An additional 'test' method for confirming this object is successfully mocked.
 				'test' => 'ok',
 			)

--- a/tests/unit/suites/libraries/joomla/form/fields/JFormFieldCheckboxesTest.php
+++ b/tests/unit/suites/libraries/joomla/form/fields/JFormFieldCheckboxesTest.php
@@ -350,7 +350,7 @@ class JFormFieldCheckboxesTest extends TestCaseDatabase
 			->method('getOptions')
 			->will($this->returnValue($optionsReturn));
 
-		TestReflection::setValue($formFieldCheckboxes, 'element', new SimpleXMLElement('field'));
+		TestReflection::setValue($formFieldCheckboxes, 'element', new SimpleXMLElement('<field />'));
 		TestReflection::setValue($formFieldCheckboxes, 'id', 'myTestId');
 		TestReflection::setValue($formFieldCheckboxes, 'name', 'myTestName');
 		TestReflection::setValue($formFieldCheckboxes, 'checkedOptions', 'blue');
@@ -429,7 +429,7 @@ class JFormFieldCheckboxesTest extends TestCaseDatabase
 			->will($this->returnValue($optionsReturn));
 
 		// Test with nothing checked, two values in checked element
-		TestReflection::setValue($formFieldCheckboxes, 'element', new SimpleXMLElement('field'));
+		TestReflection::setValue($formFieldCheckboxes, 'element', new SimpleXMLElement('<field />'));
 		TestReflection::setValue($formFieldCheckboxes, 'id', 'myTestId');
 		TestReflection::setValue($formFieldCheckboxes, 'name', 'myTestName');
 		TestReflection::setValue($formFieldCheckboxes, 'value', '""');
@@ -509,7 +509,7 @@ class JFormFieldCheckboxesTest extends TestCaseDatabase
 			->will($this->returnValue($optionsReturn));
 
 		// Test with one item checked, a different value in checked element
-		TestReflection::setValue($formFieldCheckboxes, 'element', new SimpleXMLElement('field'));
+		TestReflection::setValue($formFieldCheckboxes, 'element', new SimpleXMLElement('<field />'));
 		TestReflection::setValue($formFieldCheckboxes, 'id', 'myTestId');
 		TestReflection::setValue($formFieldCheckboxes, 'value', 'red');
 		TestReflection::setValue($formFieldCheckboxes, 'name', 'myTestName');

--- a/tests/unit/suites/libraries/joomla/form/fields/JFormFieldCheckboxesTest.php
+++ b/tests/unit/suites/libraries/joomla/form/fields/JFormFieldCheckboxesTest.php
@@ -350,6 +350,7 @@ class JFormFieldCheckboxesTest extends TestCaseDatabase
 			->method('getOptions')
 			->will($this->returnValue($optionsReturn));
 
+		TestReflection::setValue($formFieldCheckboxes, 'element', new SimpleXMLElement('field'));
 		TestReflection::setValue($formFieldCheckboxes, 'id', 'myTestId');
 		TestReflection::setValue($formFieldCheckboxes, 'name', 'myTestName');
 		TestReflection::setValue($formFieldCheckboxes, 'checkedOptions', 'blue');
@@ -428,6 +429,7 @@ class JFormFieldCheckboxesTest extends TestCaseDatabase
 			->will($this->returnValue($optionsReturn));
 
 		// Test with nothing checked, two values in checked element
+		TestReflection::setValue($formFieldCheckboxes, 'element', new SimpleXMLElement('field'));
 		TestReflection::setValue($formFieldCheckboxes, 'id', 'myTestId');
 		TestReflection::setValue($formFieldCheckboxes, 'name', 'myTestName');
 		TestReflection::setValue($formFieldCheckboxes, 'value', '""');
@@ -507,6 +509,7 @@ class JFormFieldCheckboxesTest extends TestCaseDatabase
 			->will($this->returnValue($optionsReturn));
 
 		// Test with one item checked, a different value in checked element
+		TestReflection::setValue($formFieldCheckboxes, 'element', new SimpleXMLElement('field'));
 		TestReflection::setValue($formFieldCheckboxes, 'id', 'myTestId');
 		TestReflection::setValue($formFieldCheckboxes, 'value', 'red');
 		TestReflection::setValue($formFieldCheckboxes, 'name', 'myTestName');
@@ -586,6 +589,7 @@ class JFormFieldCheckboxesTest extends TestCaseDatabase
 			->will($this->returnValue($optionsReturn));
 
 		// Test with two values checked, no checked element
+		TestReflection::setValue($formFieldCheckboxes, 'element', new SimpleXMLElement('field'));
 		TestReflection::setValue($formFieldCheckboxes, 'id', 'myTestId');
 		TestReflection::setValue($formFieldCheckboxes, 'value', 'yellow,green');
 		TestReflection::setValue($formFieldCheckboxes, 'name', 'myTestName');

--- a/tests/unit/suites/libraries/joomla/form/fields/JFormFieldCheckboxesTest.php
+++ b/tests/unit/suites/libraries/joomla/form/fields/JFormFieldCheckboxesTest.php
@@ -589,7 +589,7 @@ class JFormFieldCheckboxesTest extends TestCaseDatabase
 			->will($this->returnValue($optionsReturn));
 
 		// Test with two values checked, no checked element
-		TestReflection::setValue($formFieldCheckboxes, 'element', new SimpleXMLElement('field'));
+		TestReflection::setValue($formFieldCheckboxes, 'element', new SimpleXMLElement('<field />'));
 		TestReflection::setValue($formFieldCheckboxes, 'id', 'myTestId');
 		TestReflection::setValue($formFieldCheckboxes, 'value', 'yellow,green');
 		TestReflection::setValue($formFieldCheckboxes, 'name', 'myTestName');

--- a/tests/unit/suites/libraries/joomla/form/fields/JFormFieldNumberTest.php
+++ b/tests/unit/suites/libraries/joomla/form/fields/JFormFieldNumberTest.php
@@ -135,7 +135,7 @@ class JFormFieldNumberTest extends TestCaseDatabase
 	{
 		$formField = new JFormFieldNumber;
 
-		TestReflection::setValue($formField, 'element', new SimpleXMLElement('field'));
+		TestReflection::setValue($formField, 'element', new SimpleXMLElement('<field />'));
 
 		foreach ($data as $attr => $value)
 		{

--- a/tests/unit/suites/libraries/joomla/form/fields/JFormFieldNumberTest.php
+++ b/tests/unit/suites/libraries/joomla/form/fields/JFormFieldNumberTest.php
@@ -135,6 +135,8 @@ class JFormFieldNumberTest extends TestCaseDatabase
 	{
 		$formField = new JFormFieldNumber;
 
+		TestReflection::setValue($formField, 'element', new SimpleXMLElement('field'));
+
 		foreach ($data as $attr => $value)
 		{
 			TestReflection::setValue($formField, $attr, $value);

--- a/tests/unit/suites/libraries/joomla/form/fields/JFormFieldPasswordTest.php
+++ b/tests/unit/suites/libraries/joomla/form/fields/JFormFieldPasswordTest.php
@@ -206,7 +206,7 @@ class JFormFieldPasswordTest extends TestCase
 	{
 		$formField = new JFormFieldPassword;
 
-		TestReflection::setValue($formField, 'element', new SimpleXMLElement('field'));
+		TestReflection::setValue($formField, 'element', new SimpleXMLElement('<field />'));
 
 		foreach ($data as $attr => $value)
 		{

--- a/tests/unit/suites/libraries/joomla/form/fields/JFormFieldPasswordTest.php
+++ b/tests/unit/suites/libraries/joomla/form/fields/JFormFieldPasswordTest.php
@@ -206,6 +206,8 @@ class JFormFieldPasswordTest extends TestCase
 	{
 		$formField = new JFormFieldPassword;
 
+		TestReflection::setValue($formField, 'element', new SimpleXMLElement('field'));
+
 		foreach ($data as $attr => $value)
 		{
 			TestReflection::setValue($formField, $attr, $value);

--- a/tests/unit/suites/libraries/joomla/form/fields/JFormFieldTextareaTest.php
+++ b/tests/unit/suites/libraries/joomla/form/fields/JFormFieldTextareaTest.php
@@ -127,6 +127,8 @@ class JFormFieldTextareaTest extends TestCase
 	{
 		$formField = new JFormFieldTextarea;
 
+		TestReflection::setValue($formField, 'element', new SimpleXMLElement('field'));
+
 		foreach ($data as $attr => $value)
 		{
 			TestReflection::setValue($formField, $attr, $value);

--- a/tests/unit/suites/libraries/joomla/form/fields/JFormFieldTextareaTest.php
+++ b/tests/unit/suites/libraries/joomla/form/fields/JFormFieldTextareaTest.php
@@ -127,7 +127,7 @@ class JFormFieldTextareaTest extends TestCase
 	{
 		$formField = new JFormFieldTextarea;
 
-		TestReflection::setValue($formField, 'element', new SimpleXMLElement('field'));
+		TestReflection::setValue($formField, 'element', new SimpleXMLElement('<field />'));
 
 		foreach ($data as $attr => $value)
 		{


### PR DESCRIPTION
Tests on PHP 7.4 are currently failing and it seems this is due to an error in the tests. This tries to fix this.