### PR TITLE
[3.x] Fix errors about int and tinyint columns shown in database schema check on MySQL 8

### DIFF
--- a/libraries/src/Schema/ChangeItem/MysqlChangeItem.php
+++ b/libraries/src/Schema/ChangeItem/MysqlChangeItem.php
@@ -266,6 +266,7 @@ class MysqlChangeItem extends ChangeItem
 		elseif (strtolower(substr($type1, 0, 7)) === 'tinyint')
 		{
 			$result = 'tinyint';
+		}
 		elseif (strtolower(substr($type1, 0, 3)) === 'int')
 		{
 			$result = 'int';

--- a/libraries/src/Schema/ChangeItem/MysqlChangeItem.php
+++ b/libraries/src/Schema/ChangeItem/MysqlChangeItem.php
@@ -232,8 +232,9 @@ class MysqlChangeItem extends ChangeItem
 
 	/**
 	 * Fix up integer. Fixes problem with MySQL integer descriptions.
-	 * If you change a column to "integer unsigned" it shows
-	 * as "int(10) unsigned" in the check query.
+	 * On MySQL 8 display length is not shown anymore.
+	 * This means we have to match e.g. both "int(10) unsigned" and
+	 * "int unsigned", or both "int(11)" and "int" and so on.
 	 *
 	 * @param   string  $type1  the column type
 	 * @param   string  $type2  the column attributes
@@ -246,13 +247,20 @@ class MysqlChangeItem extends ChangeItem
 	{
 		$result = $type1;
 
-		if (strtolower($type1) === 'integer' && strtolower(substr($type2, 0, 8)) === 'unsigned')
+		if (strtolower(substr($type2, 0, 8)) === 'unsigned')
 		{
-			$result = 'int(10) unsigned';
+			if (strtolower(substr($type1, 0, 3)) === 'int')
+			{
+				$result = 'int unsigned';
+			}
+			else
+			{
+				$result = $type1 . ' unsigned';
+			}
 		}
-		elseif (strtolower(substr($type2, 0, 8)) === 'unsigned')
+		elseif (strtolower(substr($type1, 0, 3)) === 'int')
 		{
-			$result = $type1 . ' unsigned';
+			$result = 'int';
 		}
 
 		return $result;
@@ -281,7 +289,8 @@ class MysqlChangeItem extends ChangeItem
 	/**
 	 * Make check query for column changes/modifications tolerant
 	 * for automatic type changes of text columns, e.g. from TEXT
-	 * to MEDIUMTEXT, after comnversion from utf8 to utf8mb4
+	 * to MEDIUMTEXT, after comnversion from utf8 to utf8mb4, and
+	 * fix integer columns without display length for MySQL 8.
 	 *
 	 * @param   string  $type  The column type found in the update query
 	 *
@@ -293,7 +302,16 @@ class MysqlChangeItem extends ChangeItem
 	{
 		$uType = strtoupper(str_replace(';', '', $type));
 
-		if ($this->db->hasUTF8mb4Support())
+		if ($uType === 'INT UNSIGNED')
+		{
+			$typeCheck = 'UPPER(LEFT(type, 3)) = ' . $this->db->quote('INT')
+				. ' AND UPPER(RIGHT(type, 9)) = ' . $this->db->quote(' UNSIGNED');
+		}
+		elseif ($uType === 'INT')
+		{
+			$typeCheck = 'UPPER(LEFT(type, 3)) = ' . $this->db->quote('INT');
+		}
+		elseif ($this->db->hasUTF8mb4Support())
 		{
 			if ($uType === 'TINYTEXT')
 			{


### PR DESCRIPTION
Pull Request for Issue #28367 .

### Summary of Changes

This Pull Request (PR) changes the database schema checker for MySQL so that any display width is ignored for integer (`int` or `tinyint`) columns when checking these columns.

The reason for this is that beginning with MySQL 8.0.19, the `type` in a `SHOW COLUMNS` statement doesn't include anymore the display width if the database has been created in that version, while on previous versions it is included. E.g. on MySQL 5.7 or 8.0.18 the `type` value is "int(11)" or "int(10) unsigned" or "tinyint(3)" while on mySQL 8.0.19 it is just "int" or "int unsigned" or "tinyint".

The display width doesn't have any impact on value range or storage size for an integer column, it only determines how a value would be left-padded with zeros if that would be done, but this padding is deprecated anyway. See [https://dev.mysql.com/doc/refman/8.0/en/numeric-type-attributes.html](https://dev.mysql.com/doc/refman/8.0/en/numeric-type-attributes.html) for details.

### Testing Instructions

#### Requirements

Have a MySQL database with version 8.0.19 and another one with an older version, e.g. 5.7 or 8.0.18 or a MariaDB. If you don't have both but only one of these 2, report back with which version you have tested. At the end it needs each 2 tests for the following cases:
- MySQL 8.0.19: Test that this PR fixes the issue.
- MySQL lower than 8.0.19 or MariaDB: Test that this PR doesn't create a new issue.

#### Instructions

Install a clean staging without the patch of this PR applied on MySQL 8.0.19, using a database which you have created on that database version or creating a new one during installation.

Then go to the database checker.

Result: You see errors about columns of type `int(11)` and `int(10)` and `tinyint(3)` and similar. See section "Actual result" below.

Now apply the patch of this PR and go again to the database checker or reload the page if still there.

Result: No errors are shown, see section "Expected result" below.

Now delete configuration.php and install the staging with the patch of this PR applied on a MySQL version prior to 8.0.19, e.g. 5.7 or 8.0.18.

Then go to the database checker.

Result: With this PR applied it works as before for MySQL prior to 8.0.19, i.e. there are no database errors after a clean install.

### Expected result

All database table structures are up to date.

No problems were found.

### Actual result

![j3-error-database-checker-int-display-width](https://user-images.githubusercontent.com/7413183/77834913-ac44de80-7148-11ea-8de6-08cce1496d32.png)

Using the "Fix" button does not fix these false errors.

### Documentation Changes Required

None.

### Additional information

I found following statement here [https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-19.html](https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-19.html) in section "Deprecation and Removal Notes":

`For DESCRIBE statements and INFORMATION_SCHEMA queries, output is unaffected for objects created in previous MySQL 8.0 versions because information already stored in the data dictionary remains unchanged. This exception does not apply for upgrades from MySQL 5.7 to 8.0, for which all data dictionary information is re-created such that data type definitions do not include display width.`

I.e. if you have updated e.g. an 8.0.18 to an 8.0.19, previously present databases still will show the display width in their integer data types, and so you can't reproduce the issue. But as soon as using a newly created database, you can reproduce it.