### PR TITLE
[3.9] Added language constant INFO

### DIFF
--- a/administrator/language/en-GB/en-GB.ini
+++ b/administrator/language/en-GB/en-GB.ini
@@ -40,6 +40,7 @@ JH5="h5"
 JH6="h6"
 
 ERROR="Error"
+INFO="Info"
 MESSAGE="Message"
 NOTICE="Notice"
 WARNING="Warning"

--- a/language/en-GB/en-GB.ini
+++ b/language/en-GB/en-GB.ini
@@ -9,8 +9,8 @@
 ; Keep this string on top
 JERROR_PARSING_LANGUAGE_FILE="&#160;: error(s) in line(s) %s"
 
-
 ERROR="Error"
+INFO="Info"
 MESSAGE="Message"
 NOTICE="Notice"
 WARNING="Warning"


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
When the user has confirmed the request to export personal data (for example), the Privacy component displays a message:

> 
> INFO
> Your information request has been confirmed.

The constant **INFO** is not added to the language files and, accordingly, is not translated into other languages.

![__01__en-GB](https://user-images.githubusercontent.com/8440661/77835769-aa831700-7158-11ea-83d3-18ff7bca6d4a.png)

I suggest adding a line for compatibility and possible further use in other components.

### Documentation Changes Required
Not necessary.