### PR TITLE
[4.0] Add getLanguage to application interface and cleanup console/cli apps

### DIFF
--- a/cli/finder_indexer.php
+++ b/cli/finder_indexer.php
@@ -78,6 +78,8 @@ $lang->load('finder_cli', JPATH_SITE, null, false, false)
  */
 class FinderCli extends \Joomla\CMS\Application\CliApplication
 {
+	use \Joomla\CMS\Application\ExtensionNamespaceMapper;
+
 	/**
 	 * Start time for the index process
 	 *
@@ -142,6 +144,8 @@ class FinderCli extends \Joomla\CMS\Application\CliApplication
 	 */
 	protected function doExecute()
 	{
+		$this->createExtensionNamespaceMap();
+
 		// Print a blank line.
 		$this->out(Text::_('FINDER_CLI'));
 		$this->out('============================');
@@ -326,6 +330,18 @@ class FinderCli extends \Joomla\CMS\Application\CliApplication
 	}
 
 	/**
+	 * Gets the name of the current running application.
+	 *
+	 * @return  string  The name of the application.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getName()
+	{
+		return 'finder-cli';
+	}
+
+	/**
 	 * Purge the index.
 	 *
 	 * @return  void
@@ -485,7 +501,14 @@ Factory::getContainer()->share(
 		);
 	},
 	true
-);
+)
+	->alias('session.web', 'session.cli')
+		->alias('session', 'session.cli')
+		->alias('JSession', 'session.cli')
+		->alias(\Joomla\CMS\Session\Session::class, 'session.cli')
+		->alias(\Joomla\Session\Session::class, 'session.cli')
+		->alias(\Joomla\Session\SessionInterface::class, 'session.cli');
+
 $app = Factory::getContainer()->get('FinderCli');
 Factory::$application = $app;
 $app->execute();

--- a/libraries/src/Application/CMSApplicationInterface.php
+++ b/libraries/src/Application/CMSApplicationInterface.php
@@ -10,6 +10,7 @@ namespace Joomla\CMS\Application;
 
 use Joomla\Application\ConfigurationAwareApplicationInterface;
 use Joomla\CMS\Extension\ExtensionManagerInterface;
+use Joomla\CMS\Language\Language;
 use Joomla\CMS\Menu\AbstractMenu;
 use Joomla\CMS\User\User;
 use Joomla\Input\Input;
@@ -148,6 +149,15 @@ interface CMSApplicationInterface extends ExtensionManagerInterface, Configurati
 	 * @since   __DEPLOY_VERSION__
 	 */
 	public function getInput(): Input;
+
+	/**
+	 * Method to get the application language object.
+	 *
+	 * @return  Language  The language object
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getLanguage();
 
 	/**
 	 * Gets the name of the current running application.

--- a/libraries/src/Application/CliApplication.php
+++ b/libraries/src/Application/CliApplication.php
@@ -16,6 +16,8 @@ use Joomla\CMS\Application\CLI\CliOutput;
 use Joomla\CMS\Application\CLI\Output\Stdout;
 use Joomla\CMS\Extension\ExtensionManagerTrait;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Language\Language;
+use Joomla\CMS\Language\LanguageFactoryInterface;
 use Joomla\DI\Container;
 use Joomla\DI\ContainerAwareTrait;
 use Joomla\Event\DispatcherAwareInterface;
@@ -45,12 +47,36 @@ abstract class CliApplication extends AbstractApplication implements DispatcherA
 	protected $output;
 
 	/**
+	 * The input.
+	 *
+	 * @var    \Joomla\Input\Input
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $input = null;
+
+	/**
 	 * CLI Input object
 	 *
 	 * @var    CliInput
 	 * @since  4.0.0
 	 */
 	protected $cliInput;
+
+	/**
+	 * The application language object.
+	 *
+	 * @var    Language
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $language;
+
+	/**
+	 * The application message queue.
+	 *
+	 * @var    array
+	 * @since  4.0
+	 */
+	protected $messages = [];
 
 	/**
 	 * The application instance.
@@ -92,6 +118,8 @@ abstract class CliApplication extends AbstractApplication implements DispatcherA
 		$container = $container ?: Factory::getContainer();
 		$this->setContainer($container);
 
+		$this->input    = new \Joomla\CMS\Input\Cli;
+		$this->language = Factory::getLanguage();
 		$this->output   = $output ?: new Stdout;
 		$this->cliInput = $cliInput ?: new CliInput;
 
@@ -107,6 +135,66 @@ abstract class CliApplication extends AbstractApplication implements DispatcherA
 
 		// Set up the environment
 		$this->input->set('format', 'cli');
+	}
+
+	/**
+	 * Magic method to access properties of the application.
+	 *
+	 * @param   string  $name  The name of the property.
+	 *
+	 * @return  mixed   A value if the property name is valid, null otherwise.
+	 *
+	 * @since       __DEPLOY_VERSION__
+	 * @deprecated  3.0  This is a B/C proxy for deprecated read accesses
+	 */
+	public function __get($name)
+	{
+		switch ($name)
+		{
+			case 'input':
+				@trigger_error(
+					'Accessing the input property of the application is deprecated, use the getInput() method instead.',
+					E_USER_DEPRECATED
+				);
+
+				return $this->getInput();
+
+			default:
+				$trace = debug_backtrace();
+				trigger_error(
+					sprintf(
+						'Undefined property via __get(): %1$s in %2$s on line %3$s',
+						$name,
+						$trace[0]['file'],
+						$trace[0]['line']
+					),
+					E_USER_NOTICE
+				);
+		}
+	}
+
+	/**
+	 * Method to get the application input object.
+	 *
+	 * @return  Input
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getInput(): Input
+	{
+		return $this->input;
+	}
+
+	/**
+	 * Method to get the application language object.
+	 *
+	 * @return  Language  The language object
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getLanguage()
+	{
+		return $this->language;
 	}
 
 	/**
@@ -148,7 +236,7 @@ abstract class CliApplication extends AbstractApplication implements DispatcherA
 	public function execute()
 	{
 		// Trigger the onBeforeExecute event
-		$this->triggerEevent('onBeforeExecute');
+		$this->triggerEvent('onBeforeExecute');
 
 		// Perform application routines.
 		$this->doExecute();

--- a/libraries/src/Application/CliApplication.php
+++ b/libraries/src/Application/CliApplication.php
@@ -128,7 +128,7 @@ abstract class CliApplication extends AbstractApplication implements DispatcherA
 			$this->setDispatcher($dispatcher);
 		}
 
-		parent::__construct($input ?: new Cli, $config);
+		parent::__construct($config);
 
 		// Set the current directory.
 		$this->set('cwd', getcwd());

--- a/libraries/src/Application/ConsoleApplication.php
+++ b/libraries/src/Application/ConsoleApplication.php
@@ -13,6 +13,7 @@ namespace Joomla\CMS\Application;
 use Joomla\CMS\Console;
 use Joomla\CMS\Extension\ExtensionManagerTrait;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Language\Language;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\Console\Application;
 use Joomla\DI\Container;
@@ -51,6 +52,14 @@ class ConsoleApplication extends Application implements DispatcherAwareInterface
 	 * @since  4.0.0
 	 */
 	protected $name = null;
+
+	/**
+	 * The application language object.
+	 *
+	 * @var    Language
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $language;
 
 	/**
 	 * The application message queue.
@@ -97,7 +106,8 @@ class ConsoleApplication extends Application implements DispatcherAwareInterface
 	)
 	{
 		// Set up a Input object for Controllers etc to use
-		$this->input = new \Joomla\CMS\Input\Cli;
+		$this->input    = new \Joomla\CMS\Input\Cli;
+		$this->language = Factory::getLanguage();
 
 		parent::__construct($input, $output, $config);
 
@@ -298,6 +308,18 @@ class ConsoleApplication extends Application implements DispatcherAwareInterface
 	public function getInput(): Input
 	{
 		return $this->input;
+	}
+
+	/**
+	 * Method to get the application language object.
+	 *
+	 * @return  Language  The language object
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getLanguage()
+	{
+		return $this->language;
 	}
 
 	/**


### PR DESCRIPTION
Partial Pull Request for Issue https://github.com/joomla/joomla-cms/issues/24587 .
Fixes #27007 

This ones a bit long - i started by adding the interface and then realised how broken CliApplication was when actually implementing/testing it

### Summary of Changes
- Adds `getLanguage` to the CMSApplicationInterface
- Adds these methods to the two cli applications which previously didn't have them
- Adds missing `getInput` method to the CliApplication which was in the interface but missing
- Fixes typo in `triggerEvent` function inCliApplication
- Adds property `messages` used for `enqueueMessage` in the CliApplication but wasn't defined
- Fix CliApplication calling wrong parent method
- Various fixes to finder indexer plugin to make it work

### Testing Instructions
Check CLI application - see commands below If you want you can access any web page too to ensure the interface in the web applications doesn't error too.

Commands to run:
`php cli/joomla.php` (you can also run as many of the commands from here as you'd like to prove this)
`php cli/finder_indexer.php`

### Expected result
Working console apps when new method added to interface

### Actual result
Finder Indexer Broken

### Documentation Changes Required
Yup interface documentation
