### PR TITLE
[4.0] Cleanup Component Dispatchers

### DIFF
--- a/libraries/src/Dispatcher/ApiDispatcher.php
+++ b/libraries/src/Dispatcher/ApiDispatcher.php
@@ -10,8 +10,6 @@ namespace Joomla\CMS\Dispatcher;
 
 \defined('_JEXEC') or die;
 
-use Joomla\CMS\Application\CMSApplication;
-
 /**
  * API Implementation for our dispatcher. It loads a component's administrator language files, and calls the API
  * Controller so that components that haven't implemented web services can add their own handling.
@@ -20,41 +18,6 @@ use Joomla\CMS\Application\CMSApplication;
  */
 final class ApiDispatcher extends ComponentDispatcher
 {
-	/**
-	 * The URL option for the component.
-	 *
-	 * @var    string
-	 * @since  1.6
-	 */
-	protected $option;
-
-	/**
-	 * The extension namespace
-	 *
-	 * @var    string
-	 *
-	 * @since  4.0.0
-	 */
-	protected $namespace;
-
-	/**
-	 * The CmsApplication instance
-	 *
-	 * @var    CMSApplication
-	 *
-	 * @since  4.0.0
-	 */
-	protected $app;
-
-	/**
-	 * The JApplication instance
-	 *
-	 * @var    \JInput
-	 *
-	 * @since  4.0.0
-	 */
-	protected $input;
-
 	/**
 	 * Load the component's administrator language
 	 *
@@ -71,7 +34,7 @@ final class ApiDispatcher extends ComponentDispatcher
 	}
 
 	/**
-	 * Dispatch a controller task. Redirecting the user if appropriate.
+	 * Dispatch a controller task. API Overrides to ensure there is no redirects.
 	 *
 	 * @return  void
 	 *

--- a/libraries/src/Dispatcher/ComponentDispatcher.php
+++ b/libraries/src/Dispatcher/ComponentDispatcher.php
@@ -11,7 +11,7 @@ namespace Joomla\CMS\Dispatcher;
 \defined('_JEXEC') or die;
 
 use Joomla\CMS\Access\Exception\NotAllowed;
-use Joomla\CMS\Application\CMSApplication;
+use Joomla\CMS\Application\CMSApplicationInterface;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Controller\BaseController;
@@ -48,13 +48,13 @@ class ComponentDispatcher extends Dispatcher
 	/**
 	 * Constructor for ComponentDispatcher
 	 *
-	 * @param   CMSApplication       $app         The application instance
-	 * @param   Input                $input       The input instance
-	 * @param   MVCFactoryInterface  $mvcFactory  The MVC factory instance
+	 * @param   CMSApplicationInterface  $app         The application instance
+	 * @param   Input                    $input       The input instance
+	 * @param   MVCFactoryInterface      $mvcFactory  The MVC factory instance
 	 *
 	 * @since   4.0.0
 	 */
-	public function __construct(CMSApplication $app, Input $input, MVCFactoryInterface $mvcFactory)
+	public function __construct(CMSApplicationInterface $app, Input $input, MVCFactoryInterface $mvcFactory)
 	{
 		parent::__construct($app, $input);
 

--- a/libraries/src/Dispatcher/Dispatcher.php
+++ b/libraries/src/Dispatcher/Dispatcher.php
@@ -10,7 +10,7 @@ namespace Joomla\CMS\Dispatcher;
 
 \defined('_JEXEC') or die;
 
-use Joomla\CMS\Application\CMSApplication;
+use Joomla\CMS\Application\CMSApplicationInterface;
 use Joomla\Input\Input;
 
 /**
@@ -23,7 +23,7 @@ abstract class Dispatcher implements DispatcherInterface
 	/**
 	 * The application instance
 	 *
-	 * @var    CMSApplication
+	 * @var    CMSApplicationInterface
 	 * @since  4.0.0
 	 */
 	protected $app;
@@ -39,12 +39,12 @@ abstract class Dispatcher implements DispatcherInterface
 	/**
 	 * Constructor for Dispatcher
 	 *
-	 * @param   CMSApplication  $app    The application instance
-	 * @param   Input           $input  The input instance
+	 * @param   CMSApplicationInterface  $app    The application instance
+	 * @param   Input                    $input  The input instance
 	 *
 	 * @since   4.0.0
 	 */
-	public function __construct(CMSApplication $app, Input $input)
+	public function __construct(CMSApplicationInterface $app, Input $input)
 	{
 		$this->app   = $app;
 		$this->input = $input;
@@ -53,11 +53,11 @@ abstract class Dispatcher implements DispatcherInterface
 	/**
 	 * The application the dispatcher is working with.
 	 *
-	 * @return  CMSApplication
+	 * @return  CMSApplicationInterface
 	 *
 	 * @since   4.0.0
 	 */
-	protected function getApplication(): CMSApplication
+	protected function getApplication(): CMSApplicationInterface
 	{
 		return $this->app;
 	}


### PR DESCRIPTION
### Summary of Changes
- Cleans up the dispatchers to use the `CMSApplicationInterface` rather than the concrete `CMSApplication` class (the module dispatcher was incorrectly using it already but after #28506 is merged all will be fine there).
- Removes duplicated declared properties in ApiDispatcher that were left over from earlier incarnations of the class. Cleaned up a doc block in ApiDispatcher too to correctly reflect why we override the method.

### Testing Instructions
Check the Joomla components still load correctly. No changes expected in the interface

### Documentation Changes Required
Nothing new - docs will be added when the dispatcher class itself is documented
