### PR TITLE
Making PHPUnit 4.8 run on PHP 8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,9 @@ matrix:
     - php: 7.3
     - php: 7.4snapshot
     - php: nightly
+      env:
+        - INSTALL_MEMCACHED="no"
+        - INSTALL_REDIS="no"
   allow_failures:
     - php: 7.4snapshot
     - php: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ before_script:
   - if [[ $RUN_UNIT_TESTS == "yes" ]]; then bash build/travis/unit-tests.sh $PWD; fi
 
 script:
-  - if [[ $RUN_UNIT_TESTS == "yes" ]]; then libraries/vendor/bin/phpunit --configuration travisci-phpunit.xml; fi
+  - if [[ $RUN_UNIT_TESTS == "yes" ]]; then php tests/unit/phpunit-starter.php --configuration travisci-phpunit.xml; fi
 
 branches:
   except:

--- a/tests/unit/phpunit-starter.php
+++ b/tests/unit/phpunit-starter.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Prepares the environment for PHPUnit.
+ *
+ * @package    Joomla.UnitTest
+ *
+ * @copyright  Copyright (C) 2005 - 2020 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @link       http://www.phpunit.de/manual/current/en/installation.html
+ */
+
+/**
+ * For Joomla 3.x we use PHPUnit 4.8, which uses each().
+ * On PHP 7.2 this has been deprecated and removed in PHP 8.0
+ * We are providing a shim for that here and then call the original
+ * PHPUnit.
+ */
+if (!function_exists('each'))
+{
+	function each(&$array)
+	{
+		$return = array(
+			1 => current($array),
+			'value' => current($array),
+			0 => key($array),
+			'key' => key($array)
+		);
+		next($array);
+
+		if (is_null($return['key']))
+		{
+			return false;
+		}
+
+		return $return;
+	}
+}
+
+include_once '../../libraries/vendor/phpunit/phpunit/phpunit';

--- a/tests/unit/phpunit-starter.php
+++ b/tests/unit/phpunit-starter.php
@@ -36,4 +36,8 @@ if (!function_exists('each'))
 	}
 }
 
-include_once '../../libraries/vendor/phpunit/phpunit/phpunit';
+define('PHPUNIT_COMPOSER_INSTALL', __DIR__ . '/../../libraries/vendor/autoload.php');
+
+require_once PHPUNIT_COMPOSER_INSTALL;
+
+PHPUnit_TextUI_Command::main();


### PR DESCRIPTION
What the title says. This tries to get our unittests to run on PHP 8.0