### PR TITLE
Use plugin name for path lookup

### DIFF
--- a/administrator/components/com_fields/libraries/fieldsplugin.php
+++ b/administrator/components/com_fields/libraries/fieldsplugin.php
@@ -123,6 +123,7 @@ abstract class FieldsPlugin extends JPlugin
 
 		// Get the path for the layout file
 		$path = JPluginHelper::getLayoutPath('fields', $field->type, $field->type);
+
 		if (!file_exists($path))
 		{
 			$path = JPluginHelper::getLayoutPath('fields', $this->_name, $field->type);

--- a/administrator/components/com_fields/libraries/fieldsplugin.php
+++ b/administrator/components/com_fields/libraries/fieldsplugin.php
@@ -123,6 +123,10 @@ abstract class FieldsPlugin extends JPlugin
 
 		// Get the path for the layout file
 		$path = JPluginHelper::getLayoutPath('fields', $field->type, $field->type);
+		if (!file_exists($path))
+		{
+			$path = JPluginHelper::getLayoutPath('fields', $this->_name, $field->type);
+		}
 
 		// Render the layout
 		ob_start();


### PR DESCRIPTION
### Summary of Changes
com_fields does support multiple custom fields in one plugin. Unfortunately the layout path lookup doesn't work as intended. This pr adds an additional lookup for the plugin, which is actually the correct way.

### Testing Instructions
- Copy the file /plugins/fields/text/tmpl/text.php to /plugins/fields/text/tmpl/text2.php
- Create a new article custom field of type text 2
- Create an article and set a value for the field text 2
- Open the article on the front

### Expected result
The value of text 2 is displayed.

### Actual result
An error is thrown:
/plugins/fields/text2/tmpl/default.php: failed to open stream: No such file or directory in /administrator/components/com_fields/libraries/fieldsplugin.php