### PR TITLE
[4.0] Fix notice sitename in error_login.php

### DIFF
--- a/administrator/templates/atum/error_login.php
+++ b/administrator/templates/atum/error_login.php
@@ -102,7 +102,7 @@ HTMLHelper::_('atum.rootcolors', $this->params);
 	<?php // Sidebar ?>
 	<div id="sidebar-wrapper" class="sidebar-wrapper">
 		<div id="main-brand" class="main-brand">
-			<h2><?php echo $sitename; ?></h2>
+			<h2><?php echo $app->get('sitename'); ?></h2>
 			<a href="<?php echo Uri::root(); ?>"><?php echo Text::_('TPL_ATUM_LOGIN_SIDEBAR_VIEW_WEBSITE'); ?></a>
 		</div>
 		<div id="sidebar">


### PR DESCRIPTION
### Summary of Changes
Fix notice in atum error-login.php 
Notice: Undefined variable: sitename in administrator\templates\atum\error_login.php on line 105


### Testing Instructions
Inspect code.
Or delete line 22 in login.php, so enforcing the output of the error_login.php. 

