### PR TITLE
Remove PHP 7.4 as an allowed failure

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,10 +30,6 @@ environment:
   - php_ver_target: 7.3
   - php_ver_target: 7.4
 
-matrix:
-  allow_failures:
-  - php_ver_target: 7.4
-
 init:
   - SET PATH=C:\Program Files\OpenSSL;C:\tools\php;%PATH%
   - SET COMPOSER_NO_INTERACTION=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ matrix:
     - php: 7.1
     - php: 7.2
     - php: 7.3
-    - php: 7.4snapshot
+    - php: 7.4
     - php: nightly
   allow_failures:
     - php: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,6 @@ matrix:
     - php: 7.4snapshot
     - php: nightly
   allow_failures:
-    - php: 7.4snapshot
     - php: nightly
 
 services:


### PR DESCRIPTION
Hannes just got PHP 7.4 tests working working. So this:
- Removes PHP 7.4 as an allowed failure
- Moves travis to use stable instead of snapshot PHP 7.4