### PR TITLE
[4.0] Use only plugin name for path lookup

### DIFF
--- a/administrator/components/com_fields/src/Plugin/FieldsPlugin.php
+++ b/administrator/components/com_fields/src/Plugin/FieldsPlugin.php
@@ -146,7 +146,7 @@ abstract class FieldsPlugin extends CMSPlugin
 		$fieldParams->merge($field->fieldparams);
 
 		// Get the path for the layout file
-		$path = PluginHelper::getLayoutPath('fields', $field->type, $field->type);
+		$path = PluginHelper::getLayoutPath('fields', $this->_name, $field->type);
 
 		// Render the layout
 		ob_start();


### PR DESCRIPTION
Followup pr for #28516.

### Summary of Changes
#28516 is done in a BC way. But the initial lookup is not really correct. This one removes the original call. See discussion in pr for more information.

### Testing Instructions
- Copy the file /plugins/fields/text/tmpl/text.php to /plugins/fields/text/tmpl/text2.php
- Create a new article custom field of type text 2
- Create an article and set a value for the field text 2
- Open the article on the front

### Expected result
The value of text 2 is displayed.

### Actual result
An error is thrown:
/plugins/fields/text2/tmpl/default.php: failed to open stream: No such file or directory in /administrator/components/com_fields/libraries/fieldsplugin.php