### PR TITLE
[4.0] Don't output checkbox for protected status

### DIFF
--- a/administrator/components/com_installer/tmpl/manage/default.php
+++ b/administrator/components/com_installer/tmpl/manage/default.php
@@ -86,7 +86,9 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 						<?php foreach ($this->items as $i => $item) : ?>
 							<tr class="row<?php echo $i % 2; if ($item->status == 2) echo ' protected'; ?>">
 								<td class="text-center">
-									<?php echo HTMLHelper::_('grid.id', $i, $item->extension_id); ?>
+									<?php if ($item->status != 2) : ?>
+										<?php echo HTMLHelper::_('grid.id', $i, $item->extension_id); ?>
+									<?php endif; ?>
 								</td>
 								<td class="text-center">
 									<?php if (!$item->element) : ?>


### PR DESCRIPTION
### Summary of Changes
Enable/disable/uninstall do not apply to protected status, thus, no point in making them selectable.


### Testing Instructions
Go to System > Extensions
Filter on `Protected` status
No checkbox under the 1st column