### PR TITLE
[3.9] Slight improvement for tpl (View Request)

### DIFF
--- a/administrator/components/com_privacy/views/request/tmpl/default.php
+++ b/administrator/components/com_privacy/views/request/tmpl/default.php
@@ -30,7 +30,7 @@ JFactory::getDocument()->addScriptDeclaration($js);
 
 <form action="<?php echo JRoute::_('index.php?option=com_privacy&view=request&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="item-form" class="form-validate">
 	<div class="row-fluid">
-		<div class="span6">
+		<div class="span4">
 			<h3><?php echo JText::_('COM_PRIVACY_HEADING_REQUEST_INFORMATION'); ?></h3>
 			<dl class="dl-horizontal">
 				<dt><?php echo JText::_('JGLOBAL_EMAIL'); ?>:</dt>
@@ -46,7 +46,7 @@ JFactory::getDocument()->addScriptDeclaration($js);
 				<dd><?php echo JHtml::_('date', $this->item->requested_at, JText::_('DATE_FORMAT_LC6')); ?></dd>
 			</dl>
 		</div>
-		<div class="span6">
+		<div class="span8">
 			<h3><?php echo JText::_('COM_PRIVACY_HEADING_ACTION_LOG'); ?></h3>
 			<?php if (empty($this->actionlogs)) : ?>
 				<div class="alert alert-no-items">


### PR DESCRIPTION
### Summary of Changes
Slight improvement for tpl (Privacy: Review Information Request).

When viewing any request, we have a lot of empty space in the middle of the page, and the information on the right is “compressed” (for example, in Russian due to the length of the translation).

![Screenshot_1](https://user-images.githubusercontent.com/8440661/78453134-7b106500-7698-11ea-8354-07a4d20c7426.png)

I think there are many other languages with similar translation length :). And I suggest moving the columns a bit.

### Testing Instructions
Apply the patch, view any request - nothing is broken.

### Before patch / After patch
### English language:

![en__do](https://user-images.githubusercontent.com/8440661/78453254-1e617a00-7699-11ea-9768-9b90df73ee47.png)

![en__posle](https://user-images.githubusercontent.com/8440661/78453257-228d9780-7699-11ea-8e34-efb3d50cd1cb.png)

### And, for example, the Russian language:

![ru__do](https://user-images.githubusercontent.com/8440661/78453281-523c9f80-7699-11ea-8388-2f29dd95b720.png)

![ru__posle](https://user-images.githubusercontent.com/8440661/78453287-58328080-7699-11ea-8bd8-ac80d882b814.png)

### Documentation Changes Required
Not necessary.