### PR TITLE
Add HTML5 elements and WAI-ARIA to error.php.

### DIFF
--- a/templates/protostar/error.php
+++ b/templates/protostar/error.php
@@ -110,7 +110,7 @@ else
 	. ($this->direction === 'rtl' ? ' rtl' : '');
 ?>">
 	<!-- Body -->
-	<div class="body">
+	<div class="body" id="top">
 		<div class="container<?php echo ($params->get('fluidContainer') ? '-fluid' : ''); ?>">
 			<!-- Header -->
 			<header class="header" role="banner">
@@ -124,16 +124,16 @@ else
 					</div>
 				</div>
 			</header>
-			<div class="navigation">
+			<nav class="navigation" role="navigation">
 				<?php // Display position-1 modules ?>
 				<?php echo $this->getBuffer('modules', 'position-1', array('style' => 'none')); ?>
-			</div>
+			</nav>
 			<!-- Banner -->
 			<div class="banner">
 				<?php echo $this->getBuffer('modules', 'banner', array('style' => 'xhtml')); ?>
 			</div>
 			<div class="row-fluid">
-				<div id="content" class="span12">
+				<main id="content" role="main" class="span12">
 					<!-- Begin Content -->
 					<h1 class="page-header"><?php echo JText::_('JERROR_LAYOUT_PAGE_NOT_FOUND'); ?></h1>
 					<div class="well">
@@ -192,12 +192,12 @@ else
 						<?php endif; ?>
 					</div>
 					<!-- End Content -->
-				</div>
+				</main>
 			</div>
 		</div>
 	</div>
 	<!-- Footer -->
-	<div class="footer">
+	<footer class="footer" role="contentinfo">
 		<div class="container<?php echo ($params->get('fluidContainer') ? '-fluid' : ''); ?>">
 			<hr />
 			<?php echo $this->getBuffer('modules', 'footer', array('style' => 'none')); ?>
@@ -210,7 +210,7 @@ else
 				&copy; <?php echo date('Y'); ?> <?php echo $sitename; ?>
 			</p>
 		</div>
-	</div>
+	</footer>
 	<?php echo $this->getBuffer('modules', 'debug', array('style' => 'none')); ?>
 </body>
 </html>


### PR DESCRIPTION
Original report by user Gerry77 at https://forum.joomla.de/thread/11519-protostar-footer-in-error-php-und-index-php-unterschiedlich/?postID=69810#post69810.

### Summary of Changes
When comparing Protostar's `error.php` to `index.php`, you see that some changes like https://github.com/joomla/joomla-cms/commit/1892d43fa2d5fc825c07d2e8e43e76f27c61666c and https://github.com/joomla/joomla-cms/pull/1037 have been made to `index.php`, but not to `error.php`. This PR adapts these changes to use HTML5 elements like `footer` and ARIA roles in the `error.php`, too.


### Testing Instructions
Check the changed HTML output. Make sure that the display doesn't change on error pages (except maybe the "back to top" link working better now in some browsers).
