### PR TITLE
[4.0] send email to dotless domains

### DIFF
--- a/libraries/src/Mail/Mail.php
+++ b/libraries/src/Mail/Mail.php
@@ -69,16 +69,24 @@ class Mail extends PHPMailer
 		// Don't disclose the PHPMailer version
 		$this->XMailer = ' ';
 
-		/*
-		 * PHPMailer 5.2 can't validate e-mail addresses with the new regex library used in PHP 7.3+
-		 * Setting $validator to "php" uses the native php function filter_var
+		/**
+		 * Which validator to use by default when validating email addresses.
+		 * Validation patterns supported:
+		 * `auto` Pick best pattern automatically;
+		 * `pcre8` Use the squiloople.com pattern, requires PCRE > 8.0;
+		 * `pcre` Use old PCRE implementation;
+		 * `php` Use PHP built-in FILTER_VALIDATE_EMAIL;
+		 * `html5` Use the pattern given by the HTML5 spec for 'email' type form input elements.
+		 * `noregex` Don't use a regex: super fast, really dumb.
 		 *
-		 * @see https://github.com/joomla/joomla-cms/issues/24707
+		 * The default used by phpmailer is `php` but this does not support dotless domains so instead we use `html5`
+		 *
+		 * @see PHPMailer::validateAddress()
+		 *
+		 * @var string|callable
 		 */
-		if (version_compare(PHP_VERSION, '7.3.0', '>='))
-		{
-			PHPMailer::$validator = 'php';
-		}
+		PHPMailer::$validator = 'html5';
+
 	}
 
 	/**

--- a/libraries/src/Mail/Mail.php
+++ b/libraries/src/Mail/Mail.php
@@ -86,7 +86,6 @@ class Mail extends PHPMailer
 		 * @var string|callable
 		 */
 		PHPMailer::$validator = 'html5';
-
 	}
 
 	/**


### PR DESCRIPTION
It is perfectly valid to have a dotless email address eg brian@example and all our validation rules allow it.

phpmailerdefaults to use PHP built-in FILTER_VALIDATE_EMAIL but this does not support dotless domain names

This PR removes an outdated comment and sets the validtop
r to be html5. This is the same validator used when submitting an email address and supports dotless domains.

The easiest way to test this is with the global config

Set the from email to anything@example and then click the `send test mail` button

You will get an error message `Invalid address (to): anything@example`

Apply this PR and you no longer get the error

Pull Request for Issue #27948