### PR TITLE
[3.x] send emails to dotless domains

### DIFF
--- a/libraries/src/Mail/Mail.php
+++ b/libraries/src/Mail/Mail.php
@@ -65,16 +65,23 @@ class Mail extends \PHPMailer
 		// Don't disclose the PHPMailer version
 		$this->XMailer = ' ';
 
-		/*
-		 * PHPMailer 5.2 can't validate e-mail addresses with the new regex library used in PHP 7.3+
-		 * Setting $validator to "php" uses the native php function filter_var
-		 *
-		 * @see https://github.com/joomla/joomla-cms/issues/24707
-		 */
-		if (version_compare(PHP_VERSION, '7.3.0', '>='))
-		{
-			\PHPMailer::$validator = 'php';
-		}
+		/**
+		* Which validator to use by default when validating email addresses.
+		* Validation patterns supported:
+		* `auto` Pick best pattern automatically;
+		* `pcre8` Use the squiloople.com pattern, requires PCRE > 8.0;
+		* `pcre` Use old PCRE implementation;
+		* `php` Use PHP built-in FILTER_VALIDATE_EMAIL;
+		* `html5` Use the pattern given by the HTML5 spec for 'email' type form input elements.
+		* `noregex` Don't use a regex: super fast, really dumb.
+		*
+		* The default used by phpmailer is `php` but this does not support dotless domains so instead we use `html5`
+		*
+		* @see PHPMailer::validateAddress()
+		*
+		* @var string|callable
+		*/
+		PHPMailer::$validator = 'html5';
 	}
 
 	/**

--- a/libraries/src/Mail/Mail.php
+++ b/libraries/src/Mail/Mail.php
@@ -65,6 +65,7 @@ class Mail extends \PHPMailer
 		// Don't disclose the PHPMailer version
 		$this->XMailer = ' ';
 
+
 		/**
 		* Which validator to use by default when validating email addresses.
 		* Validation patterns supported:
@@ -81,7 +82,7 @@ class Mail extends \PHPMailer
 		*
 		* @var string|callable
 		*/
-		PHPMailer::$validator = 'html5';
+		\PHPMailer::$validator = 'html5';
 	}
 
 	/**


### PR DESCRIPTION
~Now that we are using phpmailer 6'+ this code block is not needed as it is now the default. However it does not support dotless domains which joomla supports so we still need to set a validator.~

It was an error to change from using auto to php for email address validation as the php validation does not support dotless domains which joomla supports so we have to use html5 as the validator.

this is a backport of #28574

technically this pr is a b/c break as it allows dotless domains and it has not allowed allowed dotless domains since #24726 was merged but its much more of a bug fix as we should have allowed dotless domains and that pr broke it

### Testing Instructions
see #28574

