### PR TITLE
[4.0] Alignment of question in batch modal

### DIFF
--- a/layouts/joomla/html/batch/item.php
+++ b/layouts/joomla/html/batch/item.php
@@ -38,6 +38,8 @@ HTMLHelper::_('script', 'layouts/joomla/html/batch/batch-language.min.js', ['ver
 	</select>
 </div>
 <div id="batch-copy-move" class="control-group radio">
-	<?php echo Text::_('JLIB_HTML_BATCH_MOVE_QUESTION'); ?>
+	<label id="batch-copy-move-lbl" for="batch-copy-move-id" class="control-label">
+		<?php echo Text::_('LIB_HTML_BATCH_MOVE_QUESTION'); ?>
+	</label>
 	<?php echo HTMLHelper::_('select.radiolist', $options, 'batch[move_copy]', '', 'value', 'text', 'm'); ?>
 </div>

--- a/layouts/joomla/html/batch/item.php
+++ b/layouts/joomla/html/batch/item.php
@@ -38,6 +38,6 @@ HTMLHelper::_('script', 'layouts/joomla/html/batch/batch-language.min.js', ['ver
 	</select>
 </div>
 <div id="batch-copy-move" class="control-group radio">
-	<?php echo Text::_('JLIB_HTML_BATCH_MOVE_QUESTION'); ?>
-	<?php echo HTMLHelper::_('select.radiolist', $options, 'batch[move_copy]', '', 'value', 'text', 'm'); ?>
+	<p><?php echo Text::_('JLIB_HTML_BATCH_MOVE_QUESTION'); ?></p>
+	<p><?php echo HTMLHelper::_('select.radiolist', $options, 'batch[move_copy]', '', 'value', 'text', 'm'); ?></p>
 </div>

--- a/layouts/joomla/html/batch/item.php
+++ b/layouts/joomla/html/batch/item.php
@@ -41,5 +41,7 @@ HTMLHelper::_('script', 'layouts/joomla/html/batch/batch-language.min.js', ['ver
 	<label id="batch-copy-move-lbl" for="batch-copy-move-id" class="control-label">
 		<?php echo Text::_('JLIB_HTML_BATCH_MOVE_QUESTION'); ?>
 	</label>
-	<?php echo HTMLHelper::_('select.radiolist', $options, 'batch[move_copy]', '', 'value', 'text', 'm'); ?>
+	<fieldset id="batch-copy-move-id">
+		<?php echo HTMLHelper::_('select.radiolist', $options, 'batch[move_copy]', '', 'value', 'text', 'm'); ?>
+	</fieldset>
 </div>

--- a/layouts/joomla/html/batch/item.php
+++ b/layouts/joomla/html/batch/item.php
@@ -39,7 +39,7 @@ HTMLHelper::_('script', 'layouts/joomla/html/batch/batch-language.min.js', ['ver
 </div>
 <div id="batch-copy-move" class="control-group radio">
 	<label id="batch-copy-move-lbl" for="batch-copy-move-id" class="control-label">
-		<?php echo Text::_('LIB_HTML_BATCH_MOVE_QUESTION'); ?>
+		<?php echo Text::_('JLIB_HTML_BATCH_MOVE_QUESTION'); ?>
 	</label>
 	<?php echo HTMLHelper::_('select.radiolist', $options, 'batch[move_copy]', '', 'value', 'text', 'm'); ?>
 </div>

--- a/layouts/joomla/html/batch/item.php
+++ b/layouts/joomla/html/batch/item.php
@@ -38,6 +38,6 @@ HTMLHelper::_('script', 'layouts/joomla/html/batch/batch-language.min.js', ['ver
 	</select>
 </div>
 <div id="batch-copy-move" class="control-group radio">
-	<p><?php echo Text::_('JLIB_HTML_BATCH_MOVE_QUESTION'); ?></p>
-	<p><?php echo HTMLHelper::_('select.radiolist', $options, 'batch[move_copy]', '', 'value', 'text', 'm'); ?></p>
+	<?php echo Text::_('JLIB_HTML_BATCH_MOVE_QUESTION'); ?>
+	<?php echo HTMLHelper::_('select.radiolist', $options, 'batch[move_copy]', '', 'value', 'text', 'm'); ?>
 </div>

--- a/plugins/editors-xtd/readmore/readmore.php
+++ b/plugins/editors-xtd/readmore/readmore.php
@@ -49,6 +49,12 @@ class PlgButtonReadmore extends CMSPlugin
 		);
 
 		$getContentResult = $this->getDispatcher()->dispatch('getContent', $event);
+		
+		if (empty($getContentResult['result']))
+		{
+			return;
+		}
+		
 		$getContent = $getContentResult['result'][0];
 		HTMLHelper::_('script', 'com_content/admin-article-readmore.min.js', array('version' => 'auto', 'relative' => true));
 

--- a/plugins/editors-xtd/readmore/readmore.php
+++ b/plugins/editors-xtd/readmore/readmore.php
@@ -49,12 +49,6 @@ class PlgButtonReadmore extends CMSPlugin
 		);
 
 		$getContentResult = $this->getDispatcher()->dispatch('getContent', $event);
-		
-		if (empty($getContentResult['result']))
-		{
-			return;
-		}
-		
 		$getContent = $getContentResult['result'][0];
 		HTMLHelper::_('script', 'com_content/admin-article-readmore.min.js', array('version' => 'auto', 'relative' => true));
 


### PR DESCRIPTION
### Summary of Changes
In the match modal of categories, the move-or-copy question is a text, followed by a select typr radio.
The text ist not tagged as label, which is an a11y issue
and it gives a alignment issue if the text is short - see PR 28447

### Testing Instructions
You need a few categories. 
mark them, go to action batch 
and move or copy categories.

Watch the alignment of the question and the related radio buttons.

Make sure that copy and move works as before.
