### PR TITLE
[4.0] Tinymce column widths frontend

### DIFF
--- a/templates/cassiopeia/scss/vendor/_tinymce.scss
+++ b/templates/cassiopeia/scss/vendor/_tinymce.scss
@@ -17,3 +17,7 @@
   }
 
 }
+
+.tox {
+  white-space: nowrap!important;
+}


### PR DESCRIPTION
This PR resolves the release blocker #26944

It is a css change so you will need to npm i or node build.js --compile-css or use a prebuilt package from the download link below.

I believe that the root cause may be related to the use of grid but if it is then I don't know how to fix that. Maybe someone else is able to.

### before
![image](https://user-images.githubusercontent.com/1296369/78469482-953e5780-7719-11ea-8a60-c1f031e8d6ff.png)

### after
![image](https://user-images.githubusercontent.com/1296369/78469444-4c869e80-7719-11ea-90c7-029fea0f78e0.png)
