### PR TITLE
[4.0] skip to show joomla token on registration

### DIFF
--- a/components/com_users/tmpl/registration/default.php
+++ b/components/com_users/tmpl/registration/default.php
@@ -29,6 +29,9 @@ HTMLHelper::_('behavior.formvalidator');
 		<?php foreach ($this->form->getFieldsets() as $fieldset) : ?>
 			<?php $fields = $this->form->getFieldset($fieldset->name); ?>
 			<?php if (count($fields)) : ?>
+				<?php if ($fieldset->name === 'joomlatoken') : ?>
+					<?php continue; ?>
+				<?php endif; ?>
 				<fieldset>
 					<?php // If the fieldset has a label set, display it as the legend. ?>
 					<?php if (isset($fieldset->label)) : ?>

--- a/components/com_users/tmpl/registration/default.php
+++ b/components/com_users/tmpl/registration/default.php
@@ -29,9 +29,6 @@ HTMLHelper::_('behavior.formvalidator');
 		<?php foreach ($this->form->getFieldsets() as $fieldset) : ?>
 			<?php $fields = $this->form->getFieldset($fieldset->name); ?>
 			<?php if (count($fields)) : ?>
-				<?php if ($fieldset->name === 'joomlatoken') : ?>
-					<?php continue; ?>
-				<?php endif; ?>
 				<fieldset>
 					<?php // If the fieldset has a label set, display it as the legend. ?>
 					<?php if (isset($fieldset->label)) : ?>

--- a/plugins/user/token/token.php
+++ b/plugins/user/token/token.php
@@ -55,7 +55,7 @@ class PlgUserToken extends CMSPlugin
 	 * @since   4.0.0
 	 */
 	private $allowedContexts = [
-		'com_users.profile', 'com_users.user', 'com_users.registration',
+		'com_users.profile', 'com_users.user',
 	];
 
 	/**
@@ -192,10 +192,6 @@ class PlgUserToken extends CMSPlugin
 			return true;
 		}
 
-		if ($this->app->isClient('site'))
-		{
-			return true;
-		}
 		// If we are on the save command, no data is passed to $data variable, we need to get it directly from request
 		$jformData = $this->app->input->get('jform', [], 'array');
 

--- a/plugins/user/token/token.php
+++ b/plugins/user/token/token.php
@@ -192,6 +192,10 @@ class PlgUserToken extends CMSPlugin
 			return true;
 		}
 
+		if ($this->app->isClient('site'))
+		{
+			return true;
+		}
 		// If we are on the save command, no data is passed to $data variable, we need to get it directly from request
 		$jformData = $this->app->input->get('jform', [], 'array');
 


### PR DESCRIPTION
Pull Request for Issue #28567 .

### Summary of Changes
skip the display of joomlatoken when on registration


### Testing Instructions
Enable the user joomla token plugin
Enable api authentication plugin
Enable registration on the front end
Register a new user


### Expected result
no  Joomla token shown


### Actual result
![Screenshot from 2020-04-06 10-40-39](https://user-images.githubusercontent.com/181681/78539583-174e7f00-77f3-11ea-95d3-586a579d3b4a.png)


