### PR TITLE
[4.0] Fixing smartsearch issue with some multibytes characters

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/4.0.0-2018-07-29.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.0.0-2018-07-29.sql
@@ -98,8 +98,8 @@ ALTER TABLE `#__finder_terms` DROP INDEX `idx_term`;
 ALTER TABLE `#__finder_terms` ADD INDEX `idx_stem` (`stem`);
 ALTER TABLE `#__finder_terms` ADD INDEX `idx_language` (`language`);
 ALTER TABLE `#__finder_terms` ADD UNIQUE INDEX `idx_term_language` (`term`, `language`);
-ALTER TABLE `#__finder_terms` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-ALTER TABLE `#__finder_terms` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE `#__finder_terms` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
+ALTER TABLE `#__finder_terms` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
 
 DROP TABLE IF EXISTS `#__finder_terms_common`;
 CREATE TABLE `#__finder_terms_common` (
@@ -290,8 +290,8 @@ ALTER TABLE `#__finder_tokens` CHANGE `language` `language` CHAR(7) NOT NULL DEF
 ALTER TABLE `#__finder_tokens` MODIFY `stem` varchar(75) NOT NULL DEFAULT '';
 ALTER TABLE `#__finder_tokens` ADD INDEX `idx_stem` (`stem`);
 ALTER TABLE `#__finder_tokens` ADD INDEX `idx_language` (`language`);
-ALTER TABLE `#__finder_tokens` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-ALTER TABLE `#__finder_tokens` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE `#__finder_tokens` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
+ALTER TABLE `#__finder_tokens` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
 
 TRUNCATE TABLE `#__finder_tokens_aggregate`;
 ALTER TABLE `#__finder_tokens_aggregate` DROP COLUMN `map_suffix`;
@@ -300,8 +300,8 @@ ALTER TABLE `#__finder_tokens_aggregate` MODIFY `stem` varchar(75) NOT NULL DEFA
 ALTER TABLE `#__finder_tokens_aggregate` MODIFY `term_weight` float unsigned NOT NULL DEFAULT 0;
 ALTER TABLE `#__finder_tokens_aggregate` MODIFY `context_weight` float unsigned NOT NULL DEFAULT 0;
 ALTER TABLE `#__finder_tokens_aggregate` MODIFY `total_weight` float unsigned NOT NULL DEFAULT 0;
-ALTER TABLE `#__finder_tokens_aggregate` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-ALTER TABLE `#__finder_tokens_aggregate` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE `#__finder_tokens_aggregate` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
+ALTER TABLE `#__finder_tokens_aggregate` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
 
 ALTER TABLE `#__finder_types` MODIFY `mime` varchar(100) NOT NULL DEFAULT '';
 ALTER TABLE `#__finder_types` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;

--- a/administrator/components/com_finder/sql/install.mysql.sql
+++ b/administrator/components/com_finder/sql/install.mysql.sql
@@ -147,7 +147,7 @@ CREATE TABLE IF NOT EXISTS `#__finder_terms` (
   KEY `idx_stem_phrase` (`stem`,`phrase`),
   KEY `idx_soundex_phrase` (`soundex`,`phrase`),
   KEY `idx_language` (`language`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_bin;
 
 --
 -- Table structure for table `#__finder_terms_common`
@@ -357,7 +357,7 @@ CREATE TABLE IF NOT EXISTS `#__finder_tokens` (
   KEY `idx_stem` (`stem`),
   KEY `idx_context` (`context`),
   KEY `idx_language` (`language`)
-) ENGINE=MEMORY DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
+) ENGINE=MEMORY DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_bin;
 
 --
 -- Table structure for table `#__finder_tokens_aggregate`
@@ -376,7 +376,7 @@ CREATE TABLE IF NOT EXISTS `#__finder_tokens_aggregate` (
   `language` char(7) NOT NULL DEFAULT '',
   KEY `token` (`term`),
   KEY `keyword_id` (`term_id`)
-) ENGINE=MEMORY DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
+) ENGINE=MEMORY DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_bin;
 
 --
 -- Table structure for table `#__finder_types`

--- a/installation/sql/mysql/extensions.sql
+++ b/installation/sql/mysql/extensions.sql
@@ -389,7 +389,7 @@ CREATE TABLE IF NOT EXISTS `#__finder_terms` (
   KEY `idx_stem_phrase` (`stem`,`phrase`),
   KEY `idx_soundex_phrase` (`soundex`,`phrase`),
   KEY `idx_language` (`language`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_bin;
 
 -- --------------------------------------------------------
 
@@ -603,7 +603,7 @@ CREATE TABLE IF NOT EXISTS `#__finder_tokens` (
   KEY `idx_stem` (`stem`),
   KEY `idx_context` (`context`),
   KEY `idx_language` (`language`)
-) ENGINE=MEMORY DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
+) ENGINE=MEMORY DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_bin;
 
 -- --------------------------------------------------------
 
@@ -624,7 +624,7 @@ CREATE TABLE IF NOT EXISTS `#__finder_tokens_aggregate` (
   `language` char(7) NOT NULL DEFAULT '',
   KEY `token` (`term`),
   KEY `keyword_id` (`term_id`)
-) ENGINE=MEMORY DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
+) ENGINE=MEMORY DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_bin;
 
 -- --------------------------------------------------------
 


### PR DESCRIPTION
Pull Request for remaining part of Issue https://github.com/joomla/joomla-cms/pull/28493

### Summary of Changes
Changing 3 tables ( finder_terms, finder_tokens and finder_aggregates) to the `utf8mb4_bin` collation, including in the specific J4 update.sql


### Testing Instructions
See below because of drone sensibility. GRRR!!


### Result 
Result OK and hightlighting is correct.
<img width="873" alt="Screen Shot 2020-04-06 at 12 16 14" src="https://user-images.githubusercontent.com/869724/78548096-76ff5700-7800-11ea-91a0-5b5caf3bab54.png">
