### PR TITLE
[4.0] RTL: fix display of max size for extension install and template new file

### DIFF
--- a/administrator/components/com_templates/tmpl/template/default_modal_file_body.php
+++ b/administrator/components/com_templates/tmpl/template/default_modal_file_body.php
@@ -66,7 +66,7 @@ $input = Factory::getApplication()->input;
 							</div>
 							<?php $cMax    = $this->state->get('params')->get('upload_limit'); ?>
 							<?php $maxSize = HTMLHelper::_('number.bytes', Utility::getMaxUploadSize($cMax . 'MB')); ?>
-							<span class="mt-2"><?php echo Text::sprintf('JGLOBAL_MAXIMUM_UPLOAD_SIZE_LIMIT', $maxSize); ?></span>
+							<span class="mt-2"><?php echo Text::sprintf('JGLOBAL_MAXIMUM_UPLOAD_SIZE_LIMIT', '&#x200E;' . $maxSize); ?></span>
 						</form>
 					</div>
 				</div>

--- a/plugins/installer/packageinstaller/tmpl/default.php
+++ b/plugins/installer/packageinstaller/tmpl/default.php
@@ -73,7 +73,7 @@ $maxSize = HTMLHelper::_('number.bytes', $maxSizeBytes);
 					</button>
 				</p>
 				<p>
-					<?php echo Text::sprintf('JGLOBAL_MAXIMUM_UPLOAD_SIZE_LIMIT', $maxSize); ?>
+					<?php echo Text::sprintf('JGLOBAL_MAXIMUM_UPLOAD_SIZE_LIMIT', '&#x200E;' . $maxSize); ?>
 				</p>
 			</div>
 		</div>


### PR DESCRIPTION
Similar to https://github.com/joomla/joomla-cms/pull/28549

### Summary of Changes
As title says. 
Will display 32 MB and 10 MB instead of MB 32 and MB 10


### Testing Instructions
Install Persian. Switch to Persian in backend.
Edit template. Cick on New File

Also go to Extension Install


### After patch
<img width="790" alt="Screen Shot 2020-04-07 at 09 40 19" src="https://user-images.githubusercontent.com/869724/78644068-93110000-78b5-11ea-9fc4-04e6af722784.png">
<img width="582" alt="Screen Shot 2020-04-07 at 09 45 44" src="https://user-images.githubusercontent.com/869724/78644076-999f7780-78b5-11ea-81f8-a9616c1ee160.png">

