### PR TITLE
[3] Add workaround for calendar fields on reload and invalid save

### DIFF
--- a/libraries/src/MVC/Controller/FormController.php
+++ b/libraries/src/MVC/Controller/FormController.php
@@ -732,6 +732,26 @@ class FormController extends BaseController
 				}
 			}
 
+			/**
+			 * We need the filtered value of calendar fields because the UTC normalision is
+			 * done in the filter and on output. This would apply the Timezone offset on
+			 * reload. We set the calendar values we save to the processed date.
+			 */
+			$filteredData = $form->filter($data);
+
+			foreach ($form->getFieldset() as $field)
+			{
+				if ($field->type === 'Calendar')
+				{
+					$fieldName = $field->fieldname;
+
+					if (isset($filteredData[$fieldName]))
+					{
+						$data[$fieldName] = $filteredData[$fieldName];
+					}
+				}
+			}
+
 			// Save the data in the session.
 			$app->setUserState($context . '.data', $data);
 
@@ -910,6 +930,29 @@ class FormController extends BaseController
 			$this->getRedirectToItemAppend($recordId, $urlVar),
 			false
 		);
+
+		/* @var \JForm $form */
+		$form = $model->getForm($data, false);
+
+		/**
+		 * We need the filtered value of calendar fields because the UTC normalision is
+		 * done in the filter and on output. This would apply the Timezone offset on
+		 * reload. We set the calendar values we save to the processed date.
+		 */
+		$filteredData = $form->filter($data);
+
+		foreach ($form->getFieldset() as $field)
+		{
+			if ($field->type === 'Calendar')
+			{
+				$fieldName = $field->fieldname;
+
+				if (isset($filteredData[$fieldName]))
+				{
+					$data[$fieldName] = $filteredData[$fieldName];
+				}
+			}
+		}
 
 		// Save the data in the session.
 		$app->setUserState($this->option . '.edit.' . $this->context . '.data', $data);


### PR DESCRIPTION
Pull Request for Issue #28386 .

### Summary of Changes
Add an exception for calendar fields when we do a reload (for example on category change) and if the data validation fails.

In both cases we iterate thru all form fields and check for the field type Calendar, if found we use the filter data for the saved session data.


### Testing Instructions

* Set an UTC offset in the settings
* Create a custom field
* Create an article and enter a publish date.
* Save it.
* Check the date, should still be the same
* Change the category
* A page reload happens.
* Check the date, should still be the same

Second test
-------------
Do the same as in test one but add invalid field content

* Add a broken Url to a Link field (ex. broken://field)
* After save you get a error message and the publish date should still be the same


### Expected result
Same date as before


### Actual result
Date fields get changed by timezone offset after every save/reload


### Documentation Changes Required
no
