### PR TITLE
[3] Fix wrong delete file entry

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -2028,6 +2028,9 @@ class JoomlaInstallerScript
 			 */
 			'/administrator/components/com_joomlaupdate/access.xml',
 
+			// Joomla! 3.9.13
+			'/libraries/vendor/phpmailer/phpmailer/composer.lock',
+
 			// Joomla! 3.9.17
 			'/administrator/components/com_templates/controllers/template.php.orig',
 		);
@@ -2270,7 +2273,6 @@ class JoomlaInstallerScript
 			'/libraries/joomla/filesystem/support',
 			'/libraries/joomla/filesystem/wrapper',
 			'/libraries/joomla/filesystem',
-			'/libraries/vendor/phpmailer/phpmailer/composer.lock',
 		);
 
 		jimport('joomla.filesystem.file');


### PR DESCRIPTION
Fixed error made in release process of 3.9.13

### Summary of Changes
Move the delete entry for `/libraries/vendor/phpmailer/phpmailer/composer.lock` from folder to file array.


### Testing Instructions
Update


### Expected result
Works


### Actual result
Works

