### PR TITLE
Use correct language in search tooltip

### DIFF
--- a/administrator/components/com_languages/models/forms/filter_overrides.xml
+++ b/administrator/components/com_languages/models/forms/filter_overrides.xml
@@ -14,7 +14,7 @@
 			type="text"
 			inputmode="search"
 			label="JSEARCH_FILTER"
-			description="COM_LANGUAGES_SEARCH_IN_TITLE"
+			description="COM_LANGUAGES_VIEW_OVERRIDES_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"
 		/>
 


### PR DESCRIPTION
Pull Request for Issue #28590.

### Summary of Changes
Use the correct search tooltip.


### Testing Instructions
Go to Extensions -> Languages -> Overrides
Put cursor over Search field.
