### PR TITLE
Media Manager lacks support for SVG, WebP and WebM

### DIFF
--- a/administrator/components/com_media/config.xml
+++ b/administrator/components/com_media/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <config>
-	<fieldset 
+	<fieldset
 		name="component"
 		label="COM_MEDIA_FIELDSET_OPTIONS_LABEL">
 		<field
@@ -9,14 +9,14 @@
 			label="COM_MEDIA_FIELD_LEGAL_EXTENSIONS_LABEL"
 			description="COM_MEDIA_FIELD_LEGAL_EXTENSIONS_DESC"
 			size="50"
-			default="bmp,csv,doc,gif,ico,jpg,jpeg,odg,odp,ods,odt,pdf,png,ppt,txt,xcf,xls,BMP,CSV,DOC,GIF,ICO,JPG,JPEG,ODG,ODP,ODS,ODT,PDF,PNG,PPT,TXT,XCF,XLS"
+			default="bmp,csv,doc,gif,ico,jpg,jpeg,odg,odp,ods,odt,pdf,png,ppt,svg,txt,webp,webm,xcf,xls,BMP,CSV,DOC,GIF,ICO,JPG,JPEG,ODG,ODP,ODS,ODT,PDF,PNG,PPT,SVG,TXT,XCF,XLS,WEBP,WEBM"
 		/>
 
 		<field
 			name="upload_maxsize"
 			type="number"
 			label="COM_MEDIA_FIELD_MAXIMUM_SIZE_LABEL"
-			description="COM_MEDIA_FIELD_MAXIMUM_SIZE_DESC" 
+			description="COM_MEDIA_FIELD_MAXIMUM_SIZE_DESC"
 			validate="number"
 			min="0"
 			size="50"
@@ -24,8 +24,8 @@
 		/>
 
 		<field
-			name="spacer1" 
-			type="spacer" 
+			name="spacer1"
+			type="spacer"
 			label="COM_MEDIA_FOLDERS_PATH_LABEL"
 			class="text"
 		/>
@@ -34,7 +34,7 @@
 			name="file_path"
 			type="text"
 			label="COM_MEDIA_FIELD_PATH_FILE_FOLDER_LABEL"
-			description="COM_MEDIA_FIELD_PATH_FILE_FOLDER_DESC" 
+			description="COM_MEDIA_FIELD_PATH_FILE_FOLDER_DESC"
 			size="50"
 			default="images"
 		/>
@@ -79,7 +79,7 @@
 			label="COM_MEDIA_FIELD_LEGAL_IMAGE_EXTENSIONS_LABEL"
 			description="COM_MEDIA_FIELD_LEGAL_IMAGE_EXTENSIONS_DESC"
 			size="50"
-			default="bmp,gif,jpg,png"
+			default="bmp,gif,jpg,png,svg,webp"
 			showon="restrict_uploads:1"
 		/>
 
@@ -87,7 +87,7 @@
 			name="ignore_extensions"
 			type="text"
 			label="COM_MEDIA_FIELD_IGNORED_EXTENSIONS_LABEL"
-			description="COM_MEDIA_FIELD_IGNORED_EXTENSIONS_DESC" 
+			description="COM_MEDIA_FIELD_IGNORED_EXTENSIONS_DESC"
 			size="50"
 		/>
 
@@ -97,7 +97,7 @@
 			label="COM_MEDIA_FIELD_LEGAL_MIME_TYPES_LABEL"
 			description="COM_MEDIA_FIELD_LEGAL_MIME_TYPES_DESC"
 			size="50"
-			default="image/jpeg,image/gif,image/png,image/bmp,application/msword,application/excel,application/pdf,application/powerpoint,text/plain,application/x-zip"
+			default="image/jpeg,image/gif,image/png,image/bmp,application/msword,application/excel,application/pdf,application/powerpoint,text/plain,application/x-zip,image/svg+xml,image/webp,video/webm"
 			showon="restrict_uploads:1"
 		/>
 

--- a/administrator/components/com_media/models/list.php
+++ b/administrator/components/com_media/models/list.php
@@ -163,7 +163,9 @@ class MediaModelList extends JModelLegacy
 						case 'bmp':
 						case 'jpeg':
 						case 'ico':
-							$info = @getimagesize($tmp->path);
+						case 'svg':
+						case 'webp':
+						$info = @getimagesize($tmp->path);
 							$tmp->width  = @$info[0];
 							$tmp->height = @$info[1];
 							$tmp->type   = @$info[2];
@@ -198,6 +200,7 @@ class MediaModelList extends JModelLegacy
 
 						// Video
 						case 'mp4':
+						case 'webm':
 							$tmp->icon_32 = 'media/mime-icon-32/' . $ext . '.png';
 							$tmp->icon_16 = 'media/mime-icon-16/' . $ext . '.png';
 							$videos[] = $tmp;


### PR DESCRIPTION
Joomla's Media Manager does not support image and video formats which have been long supported by modern browsers.

References:
* [SVG](https://caniuse.com/#search=svg)
* [WebP](https://caniuse.com/#search=webp)
* [WebM](https://caniuse.com/#search=webm)

These file types, especially SVG, are pretty common in real world sites.

### Since this will never make it into Joomla 3....

...I wrote SVG support [as a plugin](https://github.com/nikosdion/joomlasvg). It does in-memory patching of the necessary core files. It is opt-in; disable the plugin and poof! SVG support is gone. It does SVG sanitization, unlike Joomla 4 at the time of this writing. 

It took, dunno, an hour? And most of that time was spent doing the in-memory patching and magic overloading of com_media options, not the actual technical solution to sanitize SVG uploads. Hardly the complicated technical solution that some people made it out to be.

That's the whole point of me writing this plugin. I wanted to prove it can be done, it can be done safely, it can be done quickly and it's not a massive, inscrutable feature you can't accept in Joomla 3 (while at the same time 3.10 is slated to have back-ported J4 code, for crying out loud!).

For me it's now completely irrelevant if Joomla will ever add SVG support. I can EITHER use my plugin OR JCE Editor Pro to support SVGs on my sites. I put my code where my mouth is. kthxbye

### Summary of Changes

WebP and SVG are recognized as image formats. Therefore they can be previewed inline in the
Media Manager page and selected in an image selection form field.

WebM is recognized as a video format in the Media Manager.

### Testing Instructions

* Go to Content, Media
* Try to upload an SVG file (TEST 1, see below)
* Click on Options
* In "Legal Extensions (File Types)" add `svg`
* In "Legal Image Extensions (File Types)" add `svg`
* In "Legal MIME Types" add `image/svg+xml`
* Click on Save & Close
* Upload an SVG
* TEST 2 (see below)
* Create a new article in Content, Articles, Add New Article
* Go to Images and Link
* In the "Intro Image" click on Select
* TEST 3 (see below)

Important note: even though this PR adds SVG, WebP and WebM as legal extensions, legal image extensins and legal MIME types these changes will NOT take effect if you are testing this PR through the Patch Tester or if you are otherwise applying it on an existing site. Hence the extra steps about going into the Options page. These changes will only be applied on NEW sites only.

### Expected result

Test 1: I am able to upload an SVG file

Test 2: I am able to see the SVG file I uploaded as an inline preview in Media Manager

Test 3: I am able to select the SVG file I uploaded in the Media Manager

### Actual result

Test 1: I can NOT upload an SVG file

Test 2: No inline preview. A file type icon is shown.

Test 3: I can NOT select the SVG file; it's not recognised as an image.

### Documentation Changes Required

None. 