### PR TITLE
[4.0] Fix database error shown after new installation with PostgreSQL database

### DIFF
--- a/installation/sql/postgresql/supports.sql
+++ b/installation/sql/postgresql/supports.sql
@@ -138,6 +138,24 @@ COMMENT ON COLUMN "#__contentitem_tag_map"."tag_id" IS 'PK from the tag table';
 COMMENT ON COLUMN "#__contentitem_tag_map"."tag_date" IS 'Date of most recent save for this tag-item';
 COMMENT ON COLUMN "#__contentitem_tag_map"."type_id" IS 'PK from the content_type table';
 
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `#__csp`
+--
+
+CREATE TABLE IF NOT EXISTS "#__csp" (
+  "id" serial NOT NULL,
+  "document_uri" varchar(500) NOT NULL DEFAULT '',
+  "blocked_uri" varchar(500) NOT NULL DEFAULT '',
+  "directive" varchar(500) NOT NULL DEFAULT '',
+  "client" varchar(500) NOT NULL DEFAULT '',
+  "created" timestamp without time zone NOT NULL,
+  "modified"  timestamp without time zone NOT NULL,
+  "published" smallint DEFAULT 0 NOT NULL,
+  PRIMARY KEY ("id")
+);
+
 --
 -- Table structure for table `#__fields`
 --


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

With PR #28350 the installation sql has been restructured, i.e. joomla.sql has been split up into 3 files.

In file `supports.sql` for PostgreSQL, the `#__csp` table got lost somehow.

This PR adds it back.

### Testing Instructions

Can be tested only with PostgreSQL. MySQL or MariaDB don't have this issue.

1. Install a current 4.0-dev or nightly build of last night using a PostgreSQL database.

2. After successful installation, login to backend and go to "System - Information - Database".

Result: See section "Actual result" below.

3. Apply the patch of this PR.

4. Remove configuration.php and make again a new installation using a PostgreSQL database.

5. After successful installation, login to backend and go to "System - Information - Database".

Result: See section "Expected result" below.

### Expected result

![j4-db-ok-postgresql_2020-04-08](https://user-images.githubusercontent.com/7413183/78755186-0cbdf200-7979-11ea-8d8b-a0c81ab2f506.png)

### Actual result

![j4-db-error-postgresql_2020-04-08](https://user-images.githubusercontent.com/7413183/78755220-16475a00-7979-11ea-8f66-5fcbcd80c6ae.png)

### Documentation Changes Required

None.