### PR TITLE
[4.0] Refactor toolbar styling

### DIFF
--- a/administrator/templates/atum/scss/blocks/_toolbar.scss
+++ b/administrator/templates/atum/scss/blocks/_toolbar.scss
@@ -26,7 +26,9 @@
   }
 
   joomla-toolbar-button {
-    .btn > span {
+
+    .btn > span,
+    .dropdown-item > span {
       margin-inline-end: .5rem;
     }
   }

--- a/administrator/templates/atum/scss/blocks/_toolbar.scss
+++ b/administrator/templates/atum/scss/blocks/_toolbar.scss
@@ -54,11 +54,7 @@
       background-color: var(--subhead-btn-accent);
       border-color: var(--subhead-btn-accent);
 
-      [class^='icon-'],
-      [class*=' icon-'],
-      [class^='#{$fa-css-prefix}-'],
-      [class*=' #{$fa-css-prefix}-'],
-      [class^='icon-download'] {
+      > span {
         color: rgba(255, 255, 255, .90);
       }
     }

--- a/administrator/templates/atum/scss/blocks/_toolbar.scss
+++ b/administrator/templates/atum/scss/blocks/_toolbar.scss
@@ -89,10 +89,8 @@
       align-items: center;
 
       &::after {
-        display: block;
         width: 2.375rem;
         font-family: "Font Awesome 5 Free";
-        color: rgba(255, 255, 255, .90);
         content: "\f078";
         border: 0;
       }

--- a/administrator/templates/atum/scss/blocks/_toolbar.scss
+++ b/administrator/templates/atum/scss/blocks/_toolbar.scss
@@ -1,23 +1,3 @@
-joomla-toolbar-button {
-
-  [class^='icon-'],
-  [class*=' icon-'],
-  [class^='#{$fa-css-prefix}-'],
-  [class*=' #{$fa-css-prefix}-'],
-  [class^='icon-download'] {
-    margin-right: .5rem;
-
-    [dir=rtl] & {
-      margin-right: 0;
-      margin-left: .5em;
-    }
-  }
-}
-
-.toggle-toolbar {
-  display: block;
-}
-
 .subhead {
   position: sticky;
   top: 0;
@@ -26,7 +6,7 @@ joomla-toolbar-button {
   z-index: $zindex-toolbar;
   width: auto;
   min-height: 43px;
-  padding: 15px 0;
+  padding: 10px 0;
   color: var(--atum-text-dark); //#0c192e;
   background: var(--toolbar-bg);
   box-shadow: -3px -2px 22px #ddd;
@@ -36,28 +16,18 @@ joomla-toolbar-button {
     margin-left: 0;
   }
 
-  .btn-toolbar {
-    margin-bottom: 0;
+  joomla-toolbar-button,
+  .btn-group {
+    margin-inline-start: .75rem;
 
-    > joomla-toolbar-button,
-    > .btn-group {
-      margin-left: .75rem;
-
-      [dir=rtl] & {
-        margin-left: 0;
-      }
-
-      &:first-child {
-        margin-left: 0;
-      }
+    &:first-child {
+      margin-inline-start: 0;
     }
   }
 
-  .button-save {
-    border-radius: .2rem 0 0 .2rem;
-
-    [dir=rtl] & {
-      border-radius: 0 .2rem .2rem 0;
+  joomla-toolbar-button {
+    .btn > span {
+      margin-inline-end: .5rem;
     }
   }
 
@@ -65,17 +35,14 @@ joomla-toolbar-button {
     --subhead-btn-accent: var(--atum-text-dark);
 
     padding: 0 1rem;
+    margin: 5px 0;
     font-size: 1rem;
     line-height: $atum-toolbar-line-height;
     color: var(--atum-text-dark);
     background: $white;
     border-color: $gray-500;
 
-    [class^='icon-'],
-    [class*=' icon-'],
-    [class^='#{$fa-css-prefix}-'],
-    [class*=' #{$fa-css-prefix}-'],
-    [class^='icon-download'] {
+    > span {
       display: inline-block;
       color: var(--subhead-btn-accent);
     }
@@ -120,6 +87,15 @@ joomla-toolbar-button {
       --subhead-btn-accent: var(--atum-bg-dark);
       display: flex;
       align-items: center;
+
+      &::after {
+        display: block;
+        width: 2.375rem;
+        font-family: "Font Awesome 5 Free";
+        color: rgba(255, 255, 255, .90);
+        content: "\f078";
+        border: 0;
+      }
     }
 
     &[disabled],
@@ -136,56 +112,20 @@ joomla-toolbar-button {
     }
   }
 
-  .dropdown-item {
-    &:hover:not(.disabled) {
-      color: #212529;
-      cursor: pointer;
-    }
-  }
-
   .dropdown-toggle {
     &.btn {
-      padding: 0;
-
-      &::after {
-        display: block;
-        width: 2.375rem;
-        font-family: "Font Awesome 5 Free";
-        color: rgba(255, 255, 255, .90);
-        background: var(--subhead-btn-accent);
-        content: "\f078";
-        border: 0;
-      }
+      padding-inline-end: 0;
     }
   }
-}
 
-.btn-toolbar {
+  .btn-group:not(:last-child) > .dropdown-toggle-split {
+    border-start-end-radius: $border-radius;
+    border-end-end-radius: $border-radius;
+    margin-inline-start: -$border-radius;
+  }
 
-  > joomla-toolbar-button,
-  > .btn-group {
-    @include media-breakpoint-down(lg) {
-      margin-right: .75rem;
-      margin-bottom: .75rem;
-      margin-left: 0 !important;
-
-      @include media-breakpoint-down(sm) {
-        [dir=rtl] & {
-          margin-right: 0 !important;
-          margin-left: .75rem !important;
-        }
-      }
-    }
-
-    @include media-breakpoint-down(xs) {
-      [dir=ltr] & {
-        margin-right: 0 !important;
-      }
-
-      [dir=rtl] & {
-        margin-left: 0 !important;
-      }
-    }
+  .dropdown-menu joomla-toolbar-button {
+    margin-inline-start: 0;
   }
 }
 
@@ -196,6 +136,10 @@ joomla-toolbar-button {
     .js-stools-container-bar {
       .btn-toolbar {
         justify-content: flex-start;
+
+        > * {
+          margin-bottom: .75rem;
+        }
       }
     }
   }
@@ -276,24 +220,22 @@ joomla-toolbar-button {
     .btn-group,
     .btn {
       width: 100%;
+      margin-left: 0;
+      text-align: left;
+    }
+
+    .btn-toolbar > .btn-group,
+    .btn-toolbar > joomla-toolbar-button {
+      margin-left: 0;
+    }
+
+    .btn.btn-action::after {
+      text-align: center;
+      margin-inline-start: auto;
     }
 
     .dropdown-toggle-split {
       width: auto;
-    }
-
-    .btn {
-
-      [class^='icon-'],
-      [class*=' icon-'],
-      [class^='fa-'],
-      [class*=' fa-'] {
-        float: left;
-
-        [dir=rtl] & {
-          float: right;
-        }
-      }
     }
   }
 }

--- a/administrator/templates/atum/scss/blocks/_toolbar.scss
+++ b/administrator/templates/atum/scss/blocks/_toolbar.scss
@@ -115,9 +115,17 @@
   }
 
   .btn-group:not(:last-child) > .dropdown-toggle-split {
-    border-start-end-radius: $border-radius;
-    border-end-end-radius: $border-radius;
     margin-inline-start: -$border-radius;
+
+    [dir="ltr"] & {
+      border-top-right-radius: $border-radius;
+      border-bottom-right-radius: $border-radius;
+    }
+
+    [dir="rtl"] & {
+      border-top-left-radius: $border-radius;
+      border-bottom-left-radius: $border-radius;
+    }
   }
 
   .dropdown-menu joomla-toolbar-button {

--- a/administrator/templates/atum/scss/blocks/_toolbar.scss
+++ b/administrator/templates/atum/scss/blocks/_toolbar.scss
@@ -1,8 +1,10 @@
 joomla-toolbar-button {
-  border: 0 solid var(--border);
 
   [class^='icon-'],
-  [class*=' icon-'] {
+  [class*=' icon-'],
+  [class^='#{$fa-css-prefix}-'],
+  [class*=' #{$fa-css-prefix}-'],
+  [class^='icon-download'] {
     margin-right: .5rem;
 
     [dir=rtl] & {
@@ -116,6 +118,8 @@ joomla-toolbar-button {
 
     &.btn-action {
       --subhead-btn-accent: var(--atum-bg-dark);
+      display: flex;
+      align-items: center;
     }
 
     &[disabled],
@@ -129,12 +133,10 @@ joomla-toolbar-button {
       &:focus {
         cursor: not-allowed;
       }
-
     }
   }
 
   .dropdown-item {
-
     &:hover:not(.disabled) {
       color: #212529;
       cursor: pointer;
@@ -142,69 +144,15 @@ joomla-toolbar-button {
   }
 
   .dropdown-toggle {
-
     &.btn {
-      color: var(--atum-text-dark);
-
-      span {
-        color: rgba(255, 255, 255, .90);
-        background-color: var(--atum-bg-dark);
-      }
-    }
-
-    &.btn-primary {
-      span {
-        color: rgba(255, 255, 255, .90);
-        background-color: var(--atum-bg-dark);
-      }
-    }
-
-    &.btn-success {
       padding: 0;
-      background-color: theme-color("success");
-
-      span {
-        color: rgba(255, 255, 255, .90);
-      }
 
       &::after {
+        display: block;
         width: 2.375rem;
-        margin-top: -1px;
         font-family: "Font Awesome 5 Free";
-        line-height: 2.3rem;
         color: rgba(255, 255, 255, .90);
-        vertical-align: middle;
-        content: "\f078";
-        border: 0;
-      }
-    }
-
-    &.btn-info {
-      background-color: darken(theme-color("info"), 8%);
-    }
-
-    &.btn-danger {
-      background-color: darken(theme-color("danger"), 8%);
-    }
-
-    &.btn-action {
-      background-color: $white;
-
-      [class^='icon-'],
-      [class*=' icon-'],
-      [class^='#{$fa-css-prefix}-'],
-      [class*=' #{$fa-css-prefix}-'] {
-        color: rgba(255, 255, 255, .90);
-        background-color: var(--atum-bg-dark);
-      }
-
-      &::after {
-        width: 2.375rem;
-        height: 100%;
-        margin: $input-btn-padding-y-sm-submenu -#{$input-btn-padding-x-sm-submenu} $input-btn-padding-y-sm-submenu $input-btn-submenu-icon-distance;
-        font-family: "Font Awesome 5 Free";
-        line-height: 2.375rem;
-        vertical-align: 0;
+        background: var(--subhead-btn-accent);
         content: "\f078";
         border: 0;
       }

--- a/administrator/templates/atum/scss/blocks/_toolbar.scss
+++ b/administrator/templates/atum/scss/blocks/_toolbar.scss
@@ -60,237 +60,76 @@ joomla-toolbar-button {
   }
 
   .btn {
-    padding: $input-btn-padding-y-sm-submenu $input-btn-padding-x-sm-submenu;
+    --subhead-btn-accent: var(--atum-text-dark);
+
+    padding: 0 1rem;
     font-size: 1rem;
     line-height: $atum-toolbar-line-height;
     color: var(--atum-text-dark);
     background: $white;
     border-color: $gray-500;
-    box-shadow: 0 0 0 .1rem lighten(theme-color("atum-link-color"), 45%);
-    box-shadow: none;
-
 
     [class^='icon-'],
     [class*=' icon-'],
     [class^='#{$fa-css-prefix}-'],
-    [class*=' #{$fa-css-prefix}-'] {
-      z-index: $zindex-negative;
+    [class*=' #{$fa-css-prefix}-'],
+    [class^='icon-download'] {
       display: inline-block;
-      width: 2.438rem;
-      height: 100%;
-      margin: $input-btn-padding-y-sm-submenu $input-btn-submenu-icon-distance $input-btn-padding-y-sm-submenu -#{$input-btn-padding-x-sm-submenu};
-      line-height: $atum-toolbar-line-height;
-      color: var(--atum-text-dark);
-      border-radius: .2rem 0 0 .2rem;
+      color: var(--subhead-btn-accent);
+    }
 
-      [dir=rtl] & {
-        border-radius: 0 .2rem .2rem 0;
+    &:not([disabled]):hover,
+    &:not([disabled]):active,
+    &:not([disabled]):focus {
+      color: rgba(255, 255, 255, .90);
+      background-color: var(--subhead-btn-accent);
+      border-color: var(--subhead-btn-accent);
+
+      [class^='icon-'],
+      [class*=' icon-'],
+      [class^='#{$fa-css-prefix}-'],
+      [class*=' #{$fa-css-prefix}-'],
+      [class^='icon-download'] {
+        color: rgba(255, 255, 255, .90);
       }
     }
 
     &.btn-success {
-
-      background-color: $white;
-
-      [class^='icon-'],
-      [class*=' icon-'],
-      [class^='#{$fa-css-prefix}-'],
-      [class*=' #{$fa-css-prefix}-'],
-      span {
-        color: darken(theme-color("success"), 5%);
-      }
-
-      &:hover,
-      &:active,
-      &:focus {
-
-        [class^='icon-'],
-        [class*=' icon-'],
-        [class^='#{$fa-css-prefix}-'],
-        [class*=' #{$fa-css-prefix}-'],
-        span {
-          color: rgba(255, 255, 255, .90);
-          background: darken(theme-color("success"), 10%);
-        }
-
-        color: rgba(255, 255, 255, .90);
-        background-color: theme-color("success");
-      }
+      --subhead-btn-accent: var(--success);
     }
 
     &.btn-danger {
-
-      background-color: $white;
-      [class^='icon-'],
-      [class*=' icon-'],
-      [class^='#{$fa-css-prefix}-'],
-      [class*=' #{$fa-css-prefix}-'],
-      span {
-        color: darken(theme-color("danger"), 5%);
-      }
-
-      &:hover,
-      &:active,
-      &:focus {
-
-        [class^='icon-'],
-        [class*=' icon-'],
-        [class^='#{$fa-css-prefix}-'],
-        [class*=' #{$fa-css-prefix}-'],
-        span {
-          color: rgba(255, 255, 255, .90);
-          background-color: darken(theme-color("danger"), 10%);
-        }
-
-        color: rgba(255, 255, 255, .90);
-        background-color: theme-color("danger");
-      }
+      --subhead-btn-accent: var(--danger);
     }
 
     &.btn-primary {
-
-      background-color: $white;
-
-      [class^='icon-'],
-      [class*=' icon-'],
-      [class^='#{$fa-css-prefix}-'],
-      [class*=' #{$fa-css-prefix}-'],
-      span {
-        color: darken(theme-color("info"), 5%);
-      }
-
-      &:hover,
-      &:active,
-      &:focus {
-        color: rgba(255, 255, 255, .90);
-        background-color: theme-color("info");
-
-        [class^='icon-'],
-        [class*=' icon-'],
-        [class^='#{$fa-css-prefix}-'],
-        [class*=' #{$fa-css-prefix}-'],
-        span {
-          color: rgba(255, 255, 255, .90);
-          background: darken(theme-color("info"), 10%);
-        }
-      }
+      --subhead-btn-accent: var(--info);
     }
 
     &.btn-secondary {
-
-      [class^='icon-download'] {
-        color: rgba(255, 255, 255, .90);
-        background-color: var(--atum-link-color);
-      }
-
-      &:hover,
-      &:active,
-      &:focus {
-        [class^='icon-download'] {
-          color: rgba(255, 255, 255, .90);
-          background-color: var(--atum-link-color);
-        }
-      }
+      --subhead-btn-accent: var(--atum-link-color);
     }
 
     &.btn-info {
-
-      background-color: $white;
-      border-radius: $border-radius;
-
-      [class^='icon-'],
-      [class*=' icon-'],
-      [class^='#{$fa-css-prefix}-'],
-      [class*=' #{$fa-css-prefix}-'],
-      span {
-        color: darken(theme-color("info"), 5%);
-      }
-
-      &:hover,
-      &:active,
-      &:focus {
-        color: rgba(255, 255, 255, .90);
-        background-color: lighten(theme-color("info"), 10%);
-
-        [class^='icon-'],
-        [class*=' icon-'],
-        [class^='#{$fa-css-prefix}-'],
-        [class*=' #{$fa-css-prefix}-'],
-        span {
-          color: rgba(255, 255, 255, .90);
-          background: lighten(theme-color("info"), 5%);
-        }
-      }
+      --subhead-btn-accent: var(--info);
     }
 
     &.btn-action {
-
-      background-color: $white;
-
-      [class^='icon-'],
-      [class*=' icon-'],
-      [class^='#{$fa-css-prefix}-'],
-      [class*=' #{$fa-css-prefix}-'],
-      span {
-        color: rgba(255, 255, 255, .90);
-        background-color: var(--atum-bg-dark-70);
-      }
-
-      &:hover,
-      &:active,
-      &:focus {
-
-        [class^='icon-'],
-        [class*=' icon-'],
-        [class^='#{$fa-css-prefix}-'],
-        [class*=' #{$fa-css-prefix}-'],
-        span {
-          color: rgba(255, 255, 255, .90);
-          background-color: var(--atum-bg-dark-80);
-        }
-
-        color: rgba(255, 255, 255, .90);
-        background-color: var(--atum-bg-dark);
-      }
+      --subhead-btn-accent: var(--atum-bg-dark);
     }
 
     &[disabled],
     &.dropdown-toggle[disabled] {
-      background-color: rgba($gray-300, .8);
-      border-color: rgba($gray-500, .8);
-
-      [class^='icon-'],
-      [class*=' icon-'],
-      [class^='#{$fa-css-prefix}-'],
-      [class*=' #{$fa-css-prefix}-'],
-      span {
-        color: var(--atum-text-dark);
-        background-color: rgba($gray-500, .8);
-         }
+      --subhead-btn-accent: var(--atum-bg-dark);
+      background: rgba($gray-300, .8);
+      opacity: .5;
 
       &:hover,
       &:active,
       &:focus {
-
-        [class^='icon-'],
-        [class*=' icon-'],
-        [class^='#{$fa-css-prefix}-'],
-        [class*=' #{$fa-css-prefix}-'],
-        span {
-          color: var(--atum-text-dark);
-          background-color: rgba($gray-500, .8);
-        }
-
-        color: var(--atum-text-dark);
         cursor: not-allowed;
-        background-color: rgba($gray-300, .8);
       }
 
-    }
-
-    &.disabled,
-    &:disabled {
-      opacity: 1;
     }
   }
 
@@ -490,6 +329,7 @@ joomla-toolbar-button {
     .btn {
       width: 100%;
     }
+
     .dropdown-toggle-split {
       width: auto;
     }

--- a/administrator/templates/atum/scss/template-rtl.scss
+++ b/administrator/templates/atum/scss/template-rtl.scss
@@ -33,12 +33,6 @@ body {
   left: auto;
 }
 
-.subhead {
-  .dropdown-toggle.btn-action::after {
-    margin: 0 16px 0 -22px;
-  }
-}
-
 .switcher {
   float: right;
 }
@@ -94,32 +88,6 @@ body {
 
 .sidebar-wrapper[data-hidden='1'] ~ .status {
   margin-right: 0;
-}
-
-// Toolbar
-.subhead {
-
-  .btn,
-  .btn-sm {
-
-    [class*=' fa-'],
-    [class^='fa-'],
-    [class^='icon-'],
-    [class*=' icon-'],
-    [class^='#{$fa-css-prefix}-'],
-    [class*=' #{$fa-css-prefix}-'] {
-      margin: 0 -1.625rem 0 1rem;
-    }
-  }
-
-  .btn-toolbar > * {
-    margin-right: .75rem;
-    margin-left: 0;
-
-    &:first-child {
-      margin-right: 0;
-    }
-  }
 }
 
 // com_cpanel

--- a/layouts/joomla/toolbar/dropdown.php
+++ b/layouts/joomla/toolbar/dropdown.php
@@ -37,9 +37,10 @@ extract($displayData, EXTR_OVERWRITE);
 		<?php echo $button; ?>
 
 		<?php if ($toggleSplit ?? true): ?>
-			<button type="button" class="<?php echo $caretClass ?? ''; ?> dropdown-toggle dropdown-toggle-split"
+			<button type="button" class="<?php echo $caretClass ?? ''; ?> dropdown-toggle-split"
 				data-toggle="dropdown" data-target="#<?php echo $id; ?>" data-display="static" aria-haspopup="true" aria-expanded="false">
 				<span class="sr-only"><?php echo Text::_('JGLOBAL_TOGGLE_DROPDOWN'); ?></span>
+				<span class="icon-chevron-down" aria-hidden="true"></span>
 			</button>
 		<?php endif; ?>
 


### PR DESCRIPTION
This PR refactors the styling for the toolbar buttons. The current CSS is a bit of a mess and hugely excessive. Here we remove 300+ lines of SCSS. Style changes are minimal but in general, should look neater and be more reliable. 

Styling ~~fully~~ using logical properties so no RTL CSS required. Out of the box RTL.

### Before

![image](https://user-images.githubusercontent.com/2803503/78770820-0afb2b00-7987-11ea-92ab-89604517203a.png)
![image](https://user-images.githubusercontent.com/2803503/78770883-29612680-7987-11ea-9788-316a63a96239.png)
![image](https://user-images.githubusercontent.com/2803503/78770926-3b42c980-7987-11ea-995b-5e266ca7c692.png)

### After

![image](https://user-images.githubusercontent.com/2803503/78777217-0f2c4600-7991-11ea-99d5-ddc289825817.png)
![image](https://user-images.githubusercontent.com/2803503/78771023-662d1d80-7987-11ea-8a0a-71364b753663.png)
![image](https://user-images.githubusercontent.com/2803503/78771208-b6a47b00-7987-11ea-9711-36d3b52eda8a.png)


