### PR TITLE
[4.0] Shuffle the execution order of tests

### DIFF
--- a/codeception.yml
+++ b/codeception.yml
@@ -8,6 +8,7 @@ paths:
 settings:
     colors: true
     memory_limit: 1024M
+    shuffle: true
 extensions:
     enabled:
         - Codeception\Extension\RunFailed


### PR DESCRIPTION
Tests should not depend on each other, except specified with the @depend annotation. To ensure this situation, codeception has a shuffle flag which changes the execution order randomly.

More information about the flag can be found [here](https://codeception.com/docs/07-AdvancedUsage#Shuffle).