### PR TITLE
[3.x]remove redundant table read during Article hit counter increment

### DIFF
--- a/components/com_contact/models/category.php
+++ b/components/com_contact/models/category.php
@@ -436,7 +436,6 @@ class ContactModelCategory extends JModelList
 			$pk = (!empty($pk)) ? $pk : (int) $this->getState('category.id');
 
 			$table = JTable::getInstance('Category', 'JTable');
-			$table->load($pk);
 			$table->hit($pk);
 		}
 

--- a/components/com_contact/models/contact.php
+++ b/components/com_contact/models/contact.php
@@ -626,7 +626,6 @@ class ContactModelContact extends JModelForm
 			$pk = (!empty($pk)) ? $pk : (int) $this->getState('contact.id');
 
 			$table = JTable::getInstance('Contact', 'ContactTable');
-			$table->load($pk);
 			$table->hit($pk);
 		}
 

--- a/components/com_content/models/article.php
+++ b/components/com_content/models/article.php
@@ -251,7 +251,6 @@ class ContentModelArticle extends JModelItem
 			$pk = (!empty($pk)) ? $pk : (int) $this->getState('article.id');
 
 			$table = JTable::getInstance('Content', 'JTable');
-			$table->load($pk);
 			$table->hit($pk);
 		}
 

--- a/components/com_content/models/category.php
+++ b/components/com_content/models/category.php
@@ -486,7 +486,6 @@ class ContentModelCategory extends JModelList
 			$pk = (!empty($pk)) ? $pk : (int) $this->getState('category.id');
 
 			$table = JTable::getInstance('Category', 'JTable');
-			$table->load($pk);
 			$table->hit($pk);
 		}
 

--- a/components/com_newsfeeds/models/category.php
+++ b/components/com_newsfeeds/models/category.php
@@ -369,7 +369,6 @@ class NewsfeedsModelCategory extends JModelList
 		{
 			$pk    = (!empty($pk)) ? $pk : (int) $this->getState('category.id');
 			$table = JTable::getInstance('Category', 'JTable');
-			$table->load($pk);
 			$table->hit($pk);
 		}
 

--- a/components/com_newsfeeds/models/newsfeed.php
+++ b/components/com_newsfeeds/models/newsfeed.php
@@ -185,7 +185,6 @@ class NewsfeedsModelNewsfeed extends JModelItem
 			$pk = (!empty($pk)) ? $pk : (int) $this->getState('newsfeed.id');
 
 			$table = JTable::getInstance('Newsfeed', 'NewsfeedsTable');
-			$table->load($pk);
 			$table->hit($pk);
 		}
 

--- a/components/com_tags/models/tag.php
+++ b/components/com_tags/models/tag.php
@@ -340,7 +340,6 @@ class TagsModelTag extends JModelList
 		{
 			$pk    = (!empty($pk)) ? $pk : (int) $this->getState('tag.id');
 			$table = JTable::getInstance('Tag', 'TagsTable');
-			$table->load($pk);
 			$table->hit($pk);
 
 			if (!$table->hasPrimaryKey())


### PR DESCRIPTION
Pull Request for Issue #28610 .

### Summary of Changes
During article hit counter increment there is an additional #content table read which produces unwanted Db load and network trafic. 
components/com_content/models/**article.php**

Changes in the method that Increments the hit counter for the article.

public function hit($pk = 0)

Before the actual update 
`$table->hit($pk);`
It reads required row from the content table `$table->load($pk);.` 
That selects all columns including "fulltext" which can be quite big.

That redundant select produces additional network and DB load.

### Testing Instructions
Check the hit counter for an article.
Visit the article on the frontend.
Check the hit counter again.
In DB queries log should NOT be present request:
`"SELECT * FROM #_content WHERE `id` = 'XXX'"`
Where XXX **is the visited article Id.**


### Expected result
After visit the article page hit counter should be incremented by 1.
No request performed `"SELECT * FROM #_content WHERE `id` = 'XXX'"`

### Actual result
Request is performed:
`"SELECT * FROM #_content WHERE `id` = 'XXX'"`


### Documentation Changes Required
No
