### PR TITLE
[3.9] Space and line break in Mass Mail Users

### DIFF
--- a/administrator/components/com_users/models/mail.php
+++ b/administrator/components/com_users/models/mail.php
@@ -162,7 +162,7 @@ class UsersModelMail extends JModelAdmin
 
 		// Build email message format.
 		$mailer->setSender(array($app->get('mailfrom'), $app->get('fromname')));
-		$mailer->setSubject($params->get('mailSubjectPrefix') . " " . stripslashes($subject));
+		$mailer->setSubject($params->get('mailSubjectPrefix') . ' ' . stripslashes($subject));
 		$mailer->setBody($message_body . "\n\n" . $params->get('mailBodySuffix'));
 		$mailer->IsHtml($mode);
 

--- a/administrator/components/com_users/models/mail.php
+++ b/administrator/components/com_users/models/mail.php
@@ -162,8 +162,8 @@ class UsersModelMail extends JModelAdmin
 
 		// Build email message format.
 		$mailer->setSender(array($app->get('mailfrom'), $app->get('fromname')));
-		$mailer->setSubject($params->get('mailSubjectPrefix') . stripslashes($subject));
-		$mailer->setBody($message_body . $params->get('mailBodySuffix'));
+		$mailer->setSubject($params->get('mailSubjectPrefix') . " " . stripslashes($subject));
+		$mailer->setBody($message_body . "\n\n" . $params->get('mailBodySuffix'));
 		$mailer->IsHtml($mode);
 
 		// Add recipients


### PR DESCRIPTION
### Summary of Changes
Added a space and line break to the message that the Mass Mail Users component sends.

### Testing Instructions
1. Create a user with an email address (e.g. Gmail) that you have access to. Also, in the settings, enable sending email messages.
2. Go to Users: Options -> Mass Mail Users, add some prefix and some signature.
3. Go to Users -> Mass Mail Users, write some subject and some message text. Send a message.
4. Go to Gmail and pay attention to the subject of the message - there is no space, to the message - there is no line break.

I propose a small patch to solve the problem.

### Before / After Patch

![___mail_01](https://user-images.githubusercontent.com/8440661/78822286-838fd500-79e3-11ea-9034-92823ffa24ce.png)

Joomla 3.9.16
PHP 7.3.2

### Documentation Changes Required
Not necessary.
