### PR TITLE
[4.0] Improve view installer manage

### DIFF
--- a/administrator/components/com_installer/tmpl/manage/default.php
+++ b/administrator/components/com_installer/tmpl/manage/default.php
@@ -63,9 +63,6 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 									<?php echo Text::_('JVERSION'); ?>
 								</th>
 								<th scope="col" style="width:10%" class="d-none d-md-table-cell">
-									<?php echo Text::_('JDATE'); ?>
-								</th>
-								<th scope="col" style="width:10%" class="d-none d-md-table-cell">
 									<?php echo Text::_('JAUTHOR'); ?>
 								</th>
 								<th scope="col" style="width:5%" class="d-none d-md-table-cell">
@@ -83,7 +80,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 							</tr>
 						</thead>
 						<tbody>
-						<?php foreach ($this->items as $i => $item) : ?>
+						<?php foreach ($this->items as $i => $item) :?>
 							<tr class="row<?php echo $i % 2; if ($item->status == 2) echo ' protected'; ?>">
 								<td class="text-center">
 									<?php echo HTMLHelper::_('grid.id', $i, $item->extension_id); ?>
@@ -128,9 +125,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 										<?php endif; ?>
 									<?php else :
 										echo '&#160;';
-									endif; ?>
-								</td>
-								<td class="d-none d-md-table-cell">
+									endif; ?><br>
 									<?php echo !empty($item->creationDate) ? $item->creationDate : '&#160;'; ?>
 								</td>
 								<td class="d-none d-md-table-cell">
@@ -140,7 +135,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 									<?php echo $item->folder_translated; ?>
 								</td>
 								<td class="d-none d-md-table-cell">
-									<?php echo $item->locked ? Text::_('JYES') : Text::_('JNO'); ?>
+									<?php echo $item->protected ? Text::_('JYES') : Text::_('JNO'); ?>
 								</td>
 								<td class="d-none d-md-table-cell">
 									<?php echo $item->package_id ?: '&#160;'; ?>

--- a/administrator/components/com_installer/tmpl/manage/default.php
+++ b/administrator/components/com_installer/tmpl/manage/default.php
@@ -80,7 +80,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 							</tr>
 						</thead>
 						<tbody>
-						<?php foreach ($this->items as $i => $item) :?>
+						<?php foreach ($this->items as $i => $item) : ?>
 							<tr class="row<?php echo $i % 2; if ($item->status == 2) echo ' protected'; ?>">
 								<td class="text-center">
 									<?php echo HTMLHelper::_('grid.id', $i, $item->extension_id); ?>
@@ -135,7 +135,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 									<?php echo $item->folder_translated; ?>
 								</td>
 								<td class="d-none d-md-table-cell">
-									<?php echo $item->protected ? Text::_('JYES') : Text::_('JNO'); ?>
+									<?php echo $item->locked ? Text::_('JYES') : Text::_('JNO'); ?>
 								</td>
 								<td class="d-none d-md-table-cell">
 									<?php echo $item->package_id ?: '&#160;'; ?>


### PR DESCRIPTION
### Summary of Changes
Table extension got a new column proctected.
This PR fixes a bug in the view - the field name is protected, not locked
And concatenates two columns to reduce the number of columns. 


### Testing Instructions
Set error-reporting to "developent" and go to extensions manage. 

### Actual result
You will see a warning in column locked and two columns for version and date.

### Expected result
No warning 
and a screen like this: 
![install-manage](https://user-images.githubusercontent.com/1035262/78835737-fd7a8b00-79f0-11ea-9617-ce7083e53c23.JPG)

### Documentation Changes Required
screen
