### PR TITLE
[4.0] Rewrite searchtools CSS

### DIFF
--- a/administrator/templates/atum/scss/blocks/_toolbar.scss
+++ b/administrator/templates/atum/scss/blocks/_toolbar.scss
@@ -133,67 +133,6 @@
   }
 }
 
-.js-stools {
-  @include media-breakpoint-down(lg) {
-    justify-content: flex-start;
-
-    .js-stools-container-bar {
-      .btn-toolbar {
-        justify-content: flex-start;
-
-        > * {
-          margin-bottom: .75rem;
-        }
-      }
-    }
-  }
-
-  @include media-breakpoint-down(xs) {
-    display: block;
-
-    .joomla-toolbar-button,
-    .btn-group,
-    .input-group,
-    .ordering-select,
-    .js-stools-field-list,
-    .js-stools-container-selector {
-      @include media-breakpoint-down(sm) {
-        width: 100%;
-      }
-    }
-
-    .ordering-select {
-      margin-right: 0;
-
-      @include media-breakpoint-down(sm) {
-        [dir=rtl] & {
-          margin-right: 0 !important;
-        }
-      }
-    }
-
-    .btn-group {
-      @include media-breakpoint-down(sm) {
-        margin-right: 0;
-      }
-    }
-
-    .js-stools-container-bar {
-      .js-stools-field-list {
-        @include media-breakpoint-down(sm) {
-          margin-bottom: .75rem;
-        }
-      }
-    }
-
-    .js-stools-btn-filter {
-      @include media-breakpoint-down(sm) {
-        width: 75%;
-      }
-    }
-  }
-}
-
 @include media-breakpoint-down(xs) {
   .toggler-toolbar {
     top: 20px;

--- a/administrator/templates/atum/scss/system/searchtools/searchtools.scss
+++ b/administrator/templates/atum/scss/system/searchtools/searchtools.scss
@@ -1,7 +1,4 @@
 // Search tools
-@import "../../variables";
-@import "../../../../../../media/vendor/bootstrap/scss/variables";
-@import "../../../../../../media/vendor/bootstrap/scss/mixins";
 
 .js-stools-container-bar,
 .js-stools-container-filters {

--- a/administrator/templates/atum/scss/system/searchtools/searchtools.scss
+++ b/administrator/templates/atum/scss/system/searchtools/searchtools.scss
@@ -3,278 +3,43 @@
 @import "../../../../../../media/vendor/bootstrap/scss/variables";
 @import "../../../../../../media/vendor/bootstrap/scss/mixins";
 
-
-// Media queries
-@media (max-width: 480px) {
-  .js-stools .js-stools-container-filters {
-    display: block;
-  }
-
-  .js-stools .js-stools-container-filters .btn-group {
-    display: block;
-  }
-
-  .js-stools .js-stools-container-filters .btn-wrapper {
-    width: 100%;
-  }
-
-  .js-stools .js-stools-container-bar {
-    margin-top: 20px;
-  }
+.js-stools-container-bar,
+.js-stools-container-filters {
+  margin-bottom: 10px;
 }
 
-@media (min-width: 768px) and (max-width: 979px) {
+.js-stools-container-bar {
+  .btn-toolbar {
+    justify-content: flex-end;
 
-  .js-stools .js-stools-container-selector,
-  .js-stools .js-stools-container-bar,
-  .js-stools .js-stools-container-list {
-    display: block;
-  }
-}
+    > * {
+      margin: 5px 0;
 
-.js-stools {
-  position: relative;
-  width: 100%;
-  padding: .25rem 0 0;
-  margin-bottom: .5rem;
-
-  > div {
-    margin-bottom: 1rem;
-  }
-
-  .js-stools-container-filters {
-    display: none;
-    flex-direction: row;
-    flex-wrap: wrap;
-    width: 100%;
-    padding: 1rem .5rem .5rem;
-    margin-top: .5rem;
-    margin-bottom: 1rem;
-    background-color: $white;
-
-    joomla-field-fancy-select .choices,
-    .custom-select {
-      min-width: 15rem;
-
-      &.is-focused {
-        border-color: $focuscolor;
-        box-shadow: $focusshadow;
-      }
-    }
-
-    .chzn-container-single {
-      display: block;
-
-      .chzn-single {
-        display: block;
-        font-size: 1rem;
+      + * {
+        margin-inline-start: 8px;
       }
     }
   }
 
-  .js-stools-field-filter {
-
-    margin: 0 .5rem .5rem;
-
-    @include media-breakpoint-down(sm) {
-      width: 100%;
-    }
-
-    .custom-select {
-      box-shadow: $input-box-shadow;
-
-      &.active {
-        background: $custom-select-indicator-active no-repeat right center;
-        background-color: $custom-select-bg;
-        background-size: $custom-select-bg-size;
-
-        [dir=rtl] & {
-          background: $custom-select-indicator-active-rtl no-repeat left center;
-          background-color: $custom-select-bg;
-        }
-      }
-
-      &:focus {
-        border-color: $focuscolor;
-        box-shadow: $focusshadow;
-      }
-
-      option {
-        font-size: .875rem;
-        color: var(--atum-text-dark);
-        background-color: var(--white);
-      }
-    }
-  }
-
-  .js-stools-container-selector {
-    margin-inline-end: .5rem;
-
-    [dir=ltr] & {
-      float: left;
-    }
-
-    [dir=rtl] & {
-      float: right;
-    }
-
-    @include media-breakpoint-down(sm) {
-      float: none !important;
-      width: 100%;
-      margin-right: 0;
-    }
-
-    @include media-breakpoint-down(xs) {
-      margin-inline-end: 0;
-    }
-
-    .js-stools-field-selector {
-      @include media-breakpoint-down(sm) {
-        margin-inline-end: 0;
-      }
-
-      @include media-breakpoint-down(xs) {
-        margin-inline-end: 0;
-      }
-    }
-  }
-
-  .js-stools-container-selector-first {
-    margin-inline-end: .5rem;
-
-    @include media-breakpoint-down(sm) {
-      float: none !important;
-      width: 100%;
-      margin-right: 0;
-    }
-
-    @include media-breakpoint-down(xs) {
-      margin-inline-end: 0;
-    }
-
-    .js-stools-field-selector {
-      @include media-breakpoint-down(sm) {
-        max-width: 100%;
-        margin-right: 0;
-
-        [dir=rtl] & {
-          margin-right: 0;
-        }
-      }
-    }
-  }
-
-  .js-stools-container-list {
-    [dir=ltr] & {
-      float: right;
-      text-align: right;
-    }
-
-    [dir=rtl] & {
-      float: left;
-      text-align: left;
-    }
-  }
-
-  .chosen-container {
-    text-align: end;
-  }
-
-  .js-stools-container-filters-visible {
+  .ordering-select {
     display: flex;
   }
+}
 
-  .chzn-container-single .chzn-single span {
-    overflow: visible;
-  }
+.js-stools-container-filters {
+  display: none;
 
-  .js-stools-field-list,
-  .js-stools-field-filter {
-    display: inline-block;
-  }
-
-  .js-stools-container-list .js-stools-field-list:last-child {
-    margin-right: 0;
-  }
-
-  .js-stools-container-bar {
-
-    .btn-toolbar {
-      justify-content: flex-end;
-
-      .js-stools-btn-clear {
-        color: var(--atum-text-light);
-        background-color: var(--atum-bg-dark);
-        border: 1px solid var(--border);
-        border-left: 1px solid var(--atum-text-light);
-
-        [dir=rtl] & {
-          margin-left: 5px;
-        }
-
-        @include media-breakpoint-down(sm) {
-          margin-inline-end: 0 !important;
-        }
-
-        &.disabled,
-        &:disabled {
-          color: var(--atum-text-dark);
-          cursor: not-allowed;
-          background-color: rgba($gray-300, .8);
-          border-color: rgba($gray-500, .8);
-          opacity: 1;
-        }
-      }
-
-      .js-stools-btn-filter {
-        border-right: 1px solid var(--border);
-
-        .fas {
-          margin-left: .25rem;
-        }
-      }
-
-      .form-control {
-        height: auto;
-      }
-    }
-
-    .js-stools-field-list {
-      margin-bottom: 0;
-
-      [dir=ltr] & {
-        margin-right: .25rem;
-
-        &:last-child {
-          margin-right: 0;
-        }
-      }
-
-      [dir=rtl] & {
-        margin-left: .25rem;
-
-        &:last-child {
-          margin-left: 0;
-        }
-      }
-    }
-
-    .input-append {
-      margin-bottom: 0;
-    }
-
-    .btn-primary .caret {
-      margin-top: 7px;
-      margin-bottom: 8px;
-      border-top: 0;
-      border-bottom: 4px solid #fff;
-
-    }
+  &-visible {
+    display: grid;
+    grid-gap: 8px;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    padding: 10px;
+    background-color: $white;
   }
 }
 
-.js-stools-button-sort {
-  cursor: pointer;
-  background: none;
-  border: 0;
+.js-stools-field-list {
+  + .js-stools-field-list {
+    margin-inline-start: 8px;
+  }
 }

--- a/administrator/templates/atum/scss/template-rtl.scss
+++ b/administrator/templates/atum/scss/template-rtl.scss
@@ -123,11 +123,6 @@ ul {
   }
 }
 
-.js-stools .js-stools-container-filters {
-  right: auto;
-  left: 0;
-}
-
 .ml-auto {
   margin-right: auto !important;
   margin-left: 0 !important;

--- a/components/com_config/tmpl/config/default.php
+++ b/components/com_config/tmpl/config/default.php
@@ -21,7 +21,7 @@ HTMLHelper::_('script', 'com_config/config-default.js', ['version' => 'auto', 'r
 <form action="<?php echo Route::_('index.php?option=com_config'); ?>" id="application-form" method="post" name="adminForm" class="form-validate">
 
 	<div class="btn-toolbar" role="toolbar" aria-label="<?php echo Text::_('JTOOLBAR'); ?>">
-		<div class="btn-group mr-2">
+		<div class="btn-group">
 			<button type="button" class="btn btn-primary" data-submit-task="config.apply">
 				<span class="fas fa-check" aria-hidden="true"></span>
 				<?php echo Text::_('JSAVE') ?>

--- a/components/com_config/tmpl/modules/default.php
+++ b/components/com_config/tmpl/modules/default.php
@@ -47,13 +47,13 @@ if (Multilanguage::isEnabled())
 		<div class="col-md-12">
 
 			<div class="btn-toolbar" role="toolbar" aria-label="<?php echo Text::_('JTOOLBAR'); ?>">
-				<div class="btn-group mr-2">
+				<div class="btn-group">
 					<button type="button" class="btn btn-primary" data-submit-task="modules.apply">
 						<span class="fas fa-check" aria-hidden="true"></span>
 						<?php echo Text::_('JAPPLY') ?>
 					</button>
 				</div>
-				<div class="btn-group mr-2">
+				<div class="btn-group">
 					<button type="button" class="btn btn-secondary" data-submit-task="modules.save">
 						<span class="fas fa-check" aria-hidden="true"></span>
 						<?php echo Text::_('JSAVE') ?>

--- a/components/com_config/tmpl/templates/default.php
+++ b/components/com_config/tmpl/templates/default.php
@@ -24,7 +24,7 @@ HTMLHelper::_('script', 'com_config/templates-default.js', ['version' => 'auto',
 <form action="<?php echo Route::_('index.php?option=com_config'); ?>" method="post" name="adminForm" id="templates-form" class="form-validate">
 
 	<div class="btn-toolbar" role="toolbar" aria-label="<?php echo Text::_('JTOOLBAR'); ?>">
-		<div class="btn-group mr-2">
+		<div class="btn-group">
 			<button type="button" class="btn btn-primary" data-submit-task="templates.apply">
 				<span class="fas fa-check" aria-hidden="true"></span>
 				<?php echo Text::_('JSAVE') ?>

--- a/layouts/joomla/searchtools/default/bar.php
+++ b/layouts/joomla/searchtools/default/bar.php
@@ -31,7 +31,7 @@ $filters = $data['view']->filterForm->getGroup('filter');
 
 <?php if (!empty($filters['filter_search'])) : ?>
 	<?php if ($searchButton) : ?>
-		<div class="btn-group mr-2">
+		<div class="btn-group">
 			<div class="input-group">
 				<?php echo $filters['filter_search']->input; ?>
 				<?php if ($filters['filter_search']->description) : ?>
@@ -60,7 +60,7 @@ $filters = $data['view']->filterForm->getGroup('filter');
 					<span class="fas fa-angle-down" aria-hidden="true"></span>
 				</button>
 			<?php endif; ?>
-			<button type="button" class="btn btn-primary js-stools-btn-clear mr-2">
+			<button type="button" class="btn btn-primary js-stools-btn-clear">
 				<?php echo Text::_('JSEARCH_FILTER_CLEAR'); ?>
 			</button>
 		</div>


### PR DESCRIPTION
This PR rewrites the CSS for searchtools. The current CSS is a bit of a mess and hugely excessive. Here we remove 300+ lines of SCSS. Style changes are minimal but in general, should look the same.

Apply this patch and run `node build.js --compile-css` for updating the changed SCSS. Check searchtools are displaying correctly.

![image](https://user-images.githubusercontent.com/2803503/78880230-fbdeb080-7a4c-11ea-9a29-ba1d9516835f.png)
