### PR TITLE
Sync isSSLConnection function to framework

### DIFF
--- a/libraries/legacy/application/application.php
+++ b/libraries/legacy/application/application.php
@@ -1182,7 +1182,16 @@ class JApplication extends BaseApplication
 	 */
 	public function isSSLConnection()
 	{
-		return (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on') || getenv('SSL_PROTOCOL_VERSION');
+		$serverSSLVar = $this->input->server->getString('HTTPS', '');
+
+		if (!empty($serverSSLVar) && strtolower($serverSSLVar) !== 'off')
+		{
+			return true;
+		}
+
+		$serverForwarderProtoVar = $this->input->server->getString('HTTP_X_FORWARDED_PROTO', '');
+
+		return !empty($serverForwarderProtoVar) && strtolower($serverForwarderProtoVar) === 'https';
 	}
 
 	/**

--- a/libraries/src/Application/WebApplication.php
+++ b/libraries/src/Application/WebApplication.php
@@ -979,7 +979,7 @@ class WebApplication extends BaseApplication
 	protected function detectRequestUri()
 	{
 		// First we need to detect the URI scheme.
-		if (isset($_SERVER['HTTPS']) && !empty($_SERVER['HTTPS']) && (strtolower($_SERVER['HTTPS']) != 'off'))
+		if ($this->isSslConnection())
 		{
 			$scheme = 'https://';
 		}
@@ -1109,7 +1109,16 @@ class WebApplication extends BaseApplication
 	 */
 	public function isSSLConnection()
 	{
-		return (isset($_SERVER['HTTPS']) && ($_SERVER['HTTPS'] == 'on')) || getenv('SSL_PROTOCOL_VERSION');
+		$serverSSLVar = $this->input->server->getString('HTTPS', '');
+
+		if (!empty($serverSSLVar) && strtolower($serverSSLVar) !== 'off')
+		{
+			return true;
+		}
+
+		$serverForwarderProtoVar = $this->input->server->getString('HTTP_X_FORWARDED_PROTO', '');
+
+		return !empty($serverForwarderProtoVar) && strtolower($serverForwarderProtoVar) === 'https';
 	}
 
 	/**

--- a/libraries/src/Environment/Browser.php
+++ b/libraries/src/Environment/Browser.php
@@ -1025,14 +1025,14 @@ class Browser
 			'deprecated'
 		);
 
-		$serverSSLVar = $this->input->server->getString('HTTPS', '');
+		$serverSSLVar = isset($_SERVER['HTTPS']) ? $_SERVER['HTTPS'] : '';
 
 		if (!empty($serverSSLVar) && strtolower($serverSSLVar) !== 'off')
 		{
 			return true;
 		}
 
-		$serverForwarderProtoVar = $this->input->server->getString('HTTP_X_FORWARDED_PROTO', '');
+		$serverForwarderProtoVar = isset($_SERVER['HTTP_X_FORWARDED_PROTO']) ? $_SERVER['HTTP_X_FORWARDED_PROTO'] : '';
 
 		return !empty($serverForwarderProtoVar) && strtolower($serverForwarderProtoVar) === 'https';
 	}

--- a/libraries/src/Environment/Browser.php
+++ b/libraries/src/Environment/Browser.php
@@ -1025,6 +1025,15 @@ class Browser
 			'deprecated'
 		);
 
-		return (isset($_SERVER['HTTPS']) && ($_SERVER['HTTPS'] == 'on')) || getenv('SSL_PROTOCOL_VERSION');
+		$serverSSLVar = $this->input->server->getString('HTTPS', '');
+
+		if (!empty($serverSSLVar) && strtolower($serverSSLVar) !== 'off')
+		{
+			return true;
+		}
+
+		$serverForwarderProtoVar = $this->input->server->getString('HTTP_X_FORWARDED_PROTO', '');
+
+		return !empty($serverForwarderProtoVar) && strtolower($serverForwarderProtoVar) === 'https';
 	}
 }

--- a/tests/unit/suites/libraries/joomla/application/JApplicationWebTest.php
+++ b/tests/unit/suites/libraries/joomla/application/JApplicationWebTest.php
@@ -558,7 +558,7 @@ class JApplicationWebTest extends TestCase
 	{
 		if ($https !== null)
 		{
-			$_SERVER['HTTPS'] = $https;
+			$this->class->input->server->set('HTTPS', $https);
 		}
 
 		$_SERVER['PHP_SELF'] = $phpSelf;
@@ -1548,26 +1548,26 @@ class JApplicationWebTest extends TestCase
 	 */
 	public function testIsSSLConnection()
 	{
-		unset($_SERVER['HTTPS']);
-		unset($_SERVER['HTTP_X_FORWARDED_PROTO']);
+		$this->class->input->server->set('HTTPS', '');
+		$this->class->input->server->set('HTTP_X_FORWARDED_PROTO', '');
 
 		$this->assertFalse($this->class->isSSLConnection());
 
-		$_SERVER['HTTPS'] = 'off';
+		$this->class->input->server->set('HTTPS', 'off');
 
 		$this->assertFalse($this->class->isSSLConnection());
 
-		$_SERVER['HTTPS'] = 'on';
+		$this->class->input->server->set('HTTPS', 'on');
 
 		$this->assertTrue($this->class->isSSLConnection());
 
-		unset($_SERVER['HTTPS']);
+		$this->class->input->server->set('HTTPS', '');
 
-		$_SERVER['HTTP_X_FORWARDED_PROTO'] = 'http';
+		$this->class->input->server->set('HTTP_X_FORWARDED_PROTO', 'http');
 
 		$this->assertFalse($this->class->isSSLConnection());
 
-		$_SERVER['HTTP_X_FORWARDED_PROTO'] = 'https';
+		$this->class->input->server->set('HTTP_X_FORWARDED_PROTO', 'https');
 
 		$this->assertTrue($this->class->isSSLConnection());
 	}

--- a/tests/unit/suites/libraries/joomla/application/JApplicationWebTest.php
+++ b/tests/unit/suites/libraries/joomla/application/JApplicationWebTest.php
@@ -1192,7 +1192,7 @@ class JApplicationWebTest extends TestCase
 	 * @since   1.7.3
 	 */
 	public function testRedirectWithExistingStatusCode2()
-	{	
+	{
 		// Case Sensitive: Status
 		$this->class->setHeader('Status', 201);
 
@@ -1549,10 +1549,25 @@ class JApplicationWebTest extends TestCase
 	public function testIsSSLConnection()
 	{
 		unset($_SERVER['HTTPS']);
+		unset($_SERVER['HTTP_X_FORWARDED_PROTO']);
+
+		$this->assertFalse($this->class->isSSLConnection());
+
+		$_SERVER['HTTPS'] = 'off';
 
 		$this->assertFalse($this->class->isSSLConnection());
 
 		$_SERVER['HTTPS'] = 'on';
+
+		$this->assertTrue($this->class->isSSLConnection());
+
+		unset($_SERVER['HTTPS']);
+
+		$_SERVER['HTTP_X_FORWARDED_PROTO'] = 'http';
+
+		$this->assertFalse($this->class->isSSLConnection());
+
+		$_SERVER['HTTP_X_FORWARDED_PROTO'] = 'https';
 
 		$this->assertTrue($this->class->isSSLConnection());
 	}

--- a/tests/unit/suites/libraries/joomla/environment/JBrowserTest.php
+++ b/tests/unit/suites/libraries/joomla/environment/JBrowserTest.php
@@ -189,10 +189,25 @@ class JBrowserTest extends \PHPUnit\Framework\TestCase
 	public function testIsSSLConnection()
 	{
 		unset($_SERVER['HTTPS']);
+		unset($_SERVER['HTTP_X_FORWARDED_PROTO']);
+
+		$this->assertFalse($this->object->isSSLConnection());
+
+		$_SERVER['HTTPS'] = 'off';
 
 		$this->assertFalse($this->object->isSSLConnection());
 
 		$_SERVER['HTTPS'] = 'on';
+
+		$this->assertTrue($this->object->isSSLConnection());
+
+		unset($_SERVER['HTTPS']);
+
+		$_SERVER['HTTP_X_FORWARDED_PROTO'] = 'http';
+
+		$this->assertFalse($this->object->isSSLConnection());
+
+		$_SERVER['HTTP_X_FORWARDED_PROTO'] = 'https';
 
 		$this->assertTrue($this->object->isSSLConnection());
 	}

--- a/tests/unit/suites/libraries/legacy/application/JApplicationTest.php
+++ b/tests/unit/suites/libraries/legacy/application/JApplicationTest.php
@@ -114,26 +114,26 @@ class JApplicationTest extends TestCase
 	 */
 	public function testIsSSLConnection()
 	{
-		unset($_SERVER['HTTPS']);
-		unset($_SERVER['HTTP_X_FORWARDED_PROTO']);
+		$this->object->input->server->set('HTTPS', '');
+		$this->object->input->server->set('HTTP_X_FORWARDED_PROTO', '');
 
 		$this->assertFalse($this->object->isSSLConnection());
 
-		$_SERVER['HTTPS'] = 'off';
+		$this->object->input->server->set('HTTPS', 'off');
 
 		$this->assertFalse($this->object->isSSLConnection());
 
-		$_SERVER['HTTPS'] = 'on';
+		$this->object->input->server->set('HTTPS', 'on');
 
 		$this->assertTrue($this->object->isSSLConnection());
 
-		unset($_SERVER['HTTPS']);
+		$this->object->input->server->set('HTTPS', '');
 
-		$_SERVER['HTTP_X_FORWARDED_PROTO'] = 'http';
+		$this->object->input->server->set('HTTP_X_FORWARDED_PROTO', 'http');
 
 		$this->assertFalse($this->object->isSSLConnection());
 
-		$_SERVER['HTTP_X_FORWARDED_PROTO'] = 'https';
+		$this->object->input->server->set('HTTP_X_FORWARDED_PROTO', 'https');
 
 		$this->assertTrue($this->object->isSSLConnection());
 	}

--- a/tests/unit/suites/libraries/legacy/application/JApplicationTest.php
+++ b/tests/unit/suites/libraries/legacy/application/JApplicationTest.php
@@ -115,17 +115,26 @@ class JApplicationTest extends TestCase
 	public function testIsSSLConnection()
 	{
 		unset($_SERVER['HTTPS']);
+		unset($_SERVER['HTTP_X_FORWARDED_PROTO']);
 
-		$this->assertThat(
-			$this->object->isSSLConnection(),
-			$this->equalTo(false)
-		);
+		$this->assertFalse($this->object->isSSLConnection());
+
+		$_SERVER['HTTPS'] = 'off';
+
+		$this->assertFalse($this->object->isSSLConnection());
 
 		$_SERVER['HTTPS'] = 'on';
 
-		$this->assertThat(
-			$this->object->isSSLConnection(),
-			$this->equalTo(true)
-		);
+		$this->assertTrue($this->object->isSSLConnection());
+
+		unset($_SERVER['HTTPS']);
+
+		$_SERVER['HTTP_X_FORWARDED_PROTO'] = 'http';
+
+		$this->assertFalse($this->object->isSSLConnection());
+
+		$_SERVER['HTTP_X_FORWARDED_PROTO'] = 'https';
+
+		$this->assertTrue($this->object->isSSLConnection());
 	}
 }


### PR DESCRIPTION
Pull Request for Issue #15436 .

### Summary of Changes
Complete the TLS detection already done in parts of the CMS if a reverse proxy only provide the HTTP_X_FORWARDED_PROTO environment variable.

This PR copies the framework function into the CMS classes.


### Testing Instructions
Install Joomla behind a proxy that only support HTTP_X_FORWARDED_PROTO === 'https' to test.
Also test all other variation for URL generation, simplest location should be the RSS feed.
All Links should have the same http/s protocol like the initial request.

You also can simulate this by setting 
`$_SERVER['HTTP_X_FORWARDED_PROTO'] = 'https'`
in the index.php.

Do the same in a separated test for `HTTPS = 'on';` and `HTTPS = 'off';`
