### PR TITLE
[4.0] Fix css compile after #28615

### DIFF
--- a/administrator/templates/atum/scss/system/searchtools/searchtools.scss
+++ b/administrator/templates/atum/scss/system/searchtools/searchtools.scss
@@ -1,3 +1,5 @@
+@import "../../variables";
+
 // Search tools
 
 .js-stools-container-bar,


### PR DESCRIPTION
Fixes css compile after #28615

Apply this patch and run `node build.js --compile-css`. No errors