### PR TITLE
[4.0] Fix "Undefined property: stdClass::$version" notices on updated J4 in Extensions Manager

### DIFF
--- a/libraries/src/Extension/ExtensionHelper.php
+++ b/libraries/src/Extension/ExtensionHelper.php
@@ -92,6 +92,9 @@ class ExtensionHelper
 		// Core language extensions - site
 		array('language', 'en-GB', '', 0),
 
+		// Core language extensions - API
+		array('language', 'en-GB', '', 3),
+
 		// Core library extensions
 		array('library', 'joomla', '', 0),
 		array('library', 'phpass', '', 0),
@@ -212,7 +215,6 @@ class ExtensionHelper
 		array('plugin', 'list', 'fields', 0),
 		array('plugin', 'media', 'fields', 0),
 		array('plugin', 'radio', 'fields', 0),
-		array('plugin', 'repeatable', 'fields', 0),
 		array('plugin', 'sql', 'fields', 0),
 		array('plugin', 'subfields', 'fields', 0),
 		array('plugin', 'text', 'fields', 0),
@@ -295,6 +297,7 @@ class ExtensionHelper
 		array('plugin', 'joomla', 'user', 0),
 		array('plugin', 'profile', 'user', 0),
 		array('plugin', 'terms', 'user', 0),
+		array('plugin', 'token', 'user', 0),
 
 		// Core plugin extensions - webservices
 		array('plugin', 'banners', 'webservices', 0),


### PR DESCRIPTION
Pull Request for Issue #28624 .

### Summary of Changes

Removes the obsolete repetabale field from the list of core extensions in the extensions helper and adds the (hopefully) last ones which have been forgotten before.

### Testing Instructions

#### Test 1: Reproduce the issue

1. Update 3.10 nightly to Joomla 4.0 using the regular 4.0 nightly update package or custom URL.
Hint: If you have the language filter plugin enabled on your 3.10 and are using a MySQL or MariaDB database, you should use the MySQL (PDO) database driver and not MySQLi (you can change that in Global Confiruation if necessary), otherwise you will run into issue #28614 .
- When using Live Update with custom URL (most comfortable way): Use custom URL [https://update.joomla.org/core/nightlies/next_major_list.xml](https://update.joomla.org/core/nightlies/next_major_list.xml)
- When using Upload & Update: Download the package from here: [https://developer.joomla.org/nightlies/Joomla_4.0.0-beta1-dev-Development-Update_Package.zip](https://developer.joomla.org/nightlies/Joomla_4.0.0-beta1-dev-Development-Update_Package.zip).

2. Login to backend.

3. Set error reporting to "Maximum" in Global Configuration.

4. Go to extensions manager.

Result: See actual result below.

#### Test 2: Test that this Pull Request (PR) solves it

Do the same as in Test 1 but this time use the update package or custom update URL created for this PR .
- When using Live Update with custom URL (most comfortable way): Use custom URL [https://ci.joomla.org/artifacts/joomla/joomla-cms/4.0-dev/28625/downloads/31106/pr_list.xml](https://ci.joomla.org/artifacts/joomla/joomla-cms/4.0-dev/28625/downloads/31106/pr_list.xml)
- When using Upload & Update: Download the package from here: [https://ci.joomla.org/artifacts/joomla/joomla-cms/4.0-dev/28625/downloads/31106/Joomla_4.0.0-beta1-dev+pr.28625-Development-Update_Package.zip](https://ci.joomla.org/artifacts/joomla/joomla-cms/4.0-dev/28625/downloads/31106/Joomla_4.0.0-beta1-dev+pr.28625-Development-Update_Package.zip).

Result: See expected result below.

### Expected result

No PHP notices of type "Undefined property: stdClass::$version".

### Actual result

```
Notice: Undefined property: stdClass::$version in /administrator/components/com_installer/tmpl/manage/default.php on line 111

Notice: Undefined property: stdClass::$version in /administrator/components/com_installer/tmpl/manage/default.php on line 127
```

### Documentation Changes Required

