### PR TITLE
[4.0] Hiding download progress of chocolatey in Appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -35,10 +35,10 @@ install:
     - IF EXIST C:\tools\php (SET PHP=0)
     # TODO: This is a workaround for https://github.com/chocolatey/choco/issues/1843. Once this is fixed we
     #       should go back to latest version in appveyor saving ourselves test time
-    - ps: choco upgrade chocolatey -y --version 0.10.13 --allow-downgrade
+    - ps: choco upgrade chocolatey -y --version 0.10.13 --allow-downgrade --no-progress
     - ps: >-
         If ($env:PHP -eq "1") {
-          appveyor-retry cinst --params '""/InstallDir:C:\tools\php""' --ignore-checksums -y php --version ((choco search php --exact --all-versions -r | select-string -pattern $env:php_ver_target | sort { [version]($_ -split '\|' | select -last 1) } -Descending | Select-Object -first 1) -replace '[php|]','')
+          appveyor-retry cinst --no-progress --params '""/InstallDir:C:\tools\php""' --ignore-checksums -y php --version ((choco search php --exact --all-versions -r | select-string -pattern $env:php_ver_target | sort { [version]($_ -split '\|' | select -last 1) } -Descending | Select-Object -first 1) -replace '[php|]','')
         }
     - appveyor-retry cinst -y sqlite
     - cd C:\tools\php


### PR DESCRIPTION
This removes the download progress in chocolatey in order to shorten the logfiles of builds a bit. Adding these attributes reduces the number of lines in this PR for example from 26,384 lines down to 328. 