### PR TITLE
[4.0] Add router to interface

### DIFF
--- a/libraries/src/Application/CMSWebApplicationInterface.php
+++ b/libraries/src/Application/CMSWebApplicationInterface.php
@@ -13,6 +13,7 @@ namespace Joomla\CMS\Application;
 use Joomla\Application\SessionAwareWebApplicationInterface;
 use Joomla\CMS\Document\Document;
 use Joomla\CMS\Menu\AbstractMenu;
+use Joomla\CMS\Router\Router;
 
 /**
  * Interface defining a Joomla! CMS Application class for web applications.
@@ -41,6 +42,18 @@ interface CMSWebApplicationInterface extends SessionAwareWebApplicationInterface
 	 * @since   __DEPLOY_VERSION__
 	 */
 	public function getMenu($name = null, $options = array());
+
+	/**
+	 * Returns the application Router object.
+	 *
+	 * @param   string  $name     The name of the application.
+	 * @param   array   $options  An optional associative array of configuration settings.
+	 *
+	 * @return  Router
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public static function getRouter($name = null, array $options = array());
 
 	/**
 	 * Gets a user state.


### PR DESCRIPTION
Partial  Pull Request for Issue #24587

### Summary of Changes
Adds getRouter to the PR - required for things like `Joomla\CMS\Router\Route::client()` to function correctly

### Testing Instructions
Site, Admin, CLI and webservice applications continue to function

### Documentation Changes Required
Yes with rest of the interfaces