### PR TITLE
[4.0] Defer loading of menu items until required

### DIFF
--- a/libraries/src/Menu/AbstractMenu.php
+++ b/libraries/src/Menu/AbstractMenu.php
@@ -63,6 +63,14 @@ abstract class AbstractMenu
 	protected $user;
 
 	/**
+	 * Flag for checking if the menu items have been loaded
+	 *
+	 * @var    boolean
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $itemsLoaded = false;
+
+	/**
 	 * Class constructor
 	 *
 	 * @param   array  $options  An array of configuration options.
@@ -71,17 +79,6 @@ abstract class AbstractMenu
 	 */
 	public function __construct($options = array())
 	{
-		// Load the menu items
-		$this->load();
-
-		foreach ($this->getMenu() as $item)
-		{
-			if ($item->home)
-			{
-				$this->default[trim($item->language)] = $item->id;
-			}
-		}
-
 		$this->user = isset($options['user']) && $options['user'] instanceof User ? $options['user'] : Factory::getUser();
 	}
 
@@ -166,14 +163,17 @@ abstract class AbstractMenu
 	 */
 	public function getDefault($language = '*')
 	{
+		// Get menu items first to ensure defaults have been populated
+		$items = $this->getMenu();
+
 		if (\array_key_exists($language, $this->default))
 		{
-			return $this->getMenu()[$this->default[$language]];
+			return $items[$this->default[$language]];
 		}
 
 		if (\array_key_exists('*', $this->default))
 		{
-			return $this->getMenu()[$this->default['*']];
+			return $items[$this->default['*']];
 		}
 	}
 
@@ -301,6 +301,21 @@ abstract class AbstractMenu
 	 */
 	public function getMenu()
 	{
+		if (!$this->itemsLoaded)
+		{
+			$this->load();
+
+			foreach ($this->items as $item)
+			{
+				if ($item->home)
+				{
+					$this->default[trim($item->language)] = $item->id;
+				}
+			}
+
+			$this->itemsLoaded = true;
+		}
+
 		return $this->items;
 	}
 

--- a/libraries/src/Menu/SiteMenu.php
+++ b/libraries/src/Menu/SiteMenu.php
@@ -190,12 +190,12 @@ class SiteMenu extends AbstractMenu
 			return false;
 		}
 
-		foreach ($this->getMenu() as &$item)
+		foreach ($this->items as &$item)
 		{
 			// Get parent information.
 			$parent_tree = array();
 
-			if (isset($this->getMenu()[$item->parent_id]))
+			if (isset($this->items[$item->parent_id]))
 			{
 				$item->setParent($this->getMenu()[$item->parent_id]);
 				$parent_tree  = $this->getMenu()[$item->parent_id]->tree;
@@ -277,14 +277,17 @@ class SiteMenu extends AbstractMenu
 	 */
 	public function getDefault($language = '*')
 	{
+		// Get menu items first to ensure defaults have been populated
+		$items = $this->getMenu();
+
 		if (\array_key_exists($language, $this->default) && $this->app->isClient('site') && $this->app->getLanguageFilter())
 		{
-			return $this->getMenu()[$this->default[$language]];
+			return $items[$this->default[$language]];
 		}
 
 		if (\array_key_exists('*', $this->default))
 		{
-			return $this->getMenu()[$this->default['*']];
+			return $items[$this->default['*']];
 		}
 	}
 }


### PR DESCRIPTION
Pull Request for Issue #28614 .

### Summary of Changes
Defers loading of the menu items until we actually need the information on the menu items. In certain cases this will mean that 

### Testing Instructions

1. Ensure menus load in the frontend on a normal single language site
1. Ensure menus load in the frontend on a multilanguage site
1. Ensure menus load in the backend
1. Update Joomla from 3.10 (multilanguage site) using the PR custom update site to this branch. It should now work after this patch.

### Documentation Changes Required
Yes. Document menu items are being loaded later. This will only be relevant however for custom menus extending `Joomla\CMS\Menu\AbstractMenu` so should be an edge case.
