### PR TITLE
[4.0] Improve asset registry files handling

### DIFF
--- a/libraries/src/Application/AdministratorApplication.php
+++ b/libraries/src/Application/AdministratorApplication.php
@@ -115,8 +115,8 @@ class AdministratorApplication extends CMSApplication
 
 				// Add Asset registry files
 				$document->getWebAssetManager()->getRegistry()
-					->addRegistryFile('media/' . $component . '/joomla.asset.json')
-					->addRegistryFile('administrator/templates/' . $template->template . '/joomla.asset.json');
+					->addExtensionRegistryFile($component)
+					->addTemplateRegistryFile($template->template, $this->getClientId());
 
 				break;
 

--- a/libraries/src/Application/SiteApplication.php
+++ b/libraries/src/Application/SiteApplication.php
@@ -170,8 +170,8 @@ final class SiteApplication extends CMSApplication
 
 				// Add Asset registry files
 				$document->getWebAssetManager()->getRegistry()
-					->addRegistryFile('media/' . $component . '/joomla.asset.json')
-					->addRegistryFile('templates/' . $template->template . '/joomla.asset.json');
+					->addExtensionRegistryFile($component)
+					->addTemplateRegistryFile($template->template, $this->getClientId());
 
 				break;
 

--- a/libraries/src/Error/Renderer/HtmlRenderer.php
+++ b/libraries/src/Error/Renderer/HtmlRenderer.php
@@ -51,7 +51,7 @@ class HtmlRenderer extends AbstractRenderer
 
 		// Add registry file for the template asset
 		$this->getDocument()->getWebAssetManager()->getRegistry()
-			->addRegistryFile('templates/' . $template . '/joomla.asset.json');
+			->addTemplateRegistryFile($template, $app->getClientId());
 
 		if (ob_get_contents())
 		{

--- a/libraries/src/WebAsset/WebAssetRegistry.php
+++ b/libraries/src/WebAsset/WebAssetRegistry.php
@@ -271,6 +271,49 @@ class WebAssetRegistry implements WebAssetRegistryInterface, DispatcherAwareInte
 	}
 
 	/**
+	 * Helper method to register new file with Template Asset(s) info
+	 *
+	 * @param   string   $template  The template name
+	 * @param   integer  $client    The application client id
+	 *
+	 * @return  self
+	 *
+	 * @since  4.0.0
+	 */
+	public function addTemplateRegistryFile(string $template, int $client): self
+	{
+		switch ($client)
+		{
+			case 0:
+				$this->addRegistryFile('templates/' . $template . '/joomla.asset.json');
+				break;
+			case 1:
+				$this->addRegistryFile('administrator/templates/' . $template . '/joomla.asset.json');
+				break;
+			default:
+				break;
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Helper method to register new file with Extension Asset(s) info
+	 *
+	 * @param   string  $name  A full extension name, actually a name in the /media folder, eg: com_example, plg_system_example etc.
+	 *
+	 * @return  self
+	 *
+	 * @since  4.0.0
+	 */
+	public function addExtensionRegistryFile(string $name): self
+	{
+		$this->addRegistryFile('media/' . $name . '/joomla.asset.json');
+
+		return $this;
+	}
+
+	/**
 	 * Parse registered files
 	 *
 	 * @return  void
@@ -286,11 +329,17 @@ class WebAssetRegistry implements WebAssetRegistryInterface, DispatcherAwareInte
 
 		foreach ($this->dataFilesNew as $path)
 		{
-			$this->parseRegistryFile($path);
+			// Parse only if the file was not parsed already
+			if (empty($this->dataFilesParsed[$path]))
+			{
+				$this->parseRegistryFile($path);
 
-			// Mark as parsed (not new)
+				// Mark the file as parsed
+				$this->dataFilesParsed[$path] = $path;
+			}
+
+			// Remove the file from queue
 			unset($this->dataFilesNew[$path]);
-			$this->dataFilesParsed[$path] = $path;
 		}
 	}
 


### PR DESCRIPTION
Pull Request for Issue #28623 .

### Summary of Changes
Improve asset registry files handling, and fix asset loading on administrator error page


### Testing Instructions

add an exception onAfterInitialise event, eg place it in system/sef plugin:

```
public function onAfterInitialise()
{
  throw new Exception('that an error!!');
}
```

And go to administrator side.


### Expected result

You should get error page from the template


### Actual result

An error that some asset not exits

ping @wilsonge 
