### PR TITLE
[4.0]Remove  extra css attribute

### DIFF
--- a/administrator/templates/atum/scss/blocks/_utilities.scss
+++ b/administrator/templates/atum/scss/blocks/_utilities.scss
@@ -18,7 +18,6 @@
 
 .hidden {
   display: none;
-  visibility: hidden;
 }
 
 .table-row {


### PR DESCRIPTION
The hidden classes in Atum has 2 properties.

display:none; and visibility:hidden;

There is no need to use both of these as they are different. display:none will supersede the visibility property and hide the spacing.

This PR keeps just the display:none

PR for #27104

