### PR TITLE
[4.0] Administrator menu module should have the default preset as default

### DIFF
--- a/administrator/modules/mod_menu/mod_menu.xml
+++ b/administrator/modules/mod_menu/mod_menu.xml
@@ -35,6 +35,7 @@
 				<field
 					name="preset"
 					type="menuPreset"
+					default="default"
 					label="MOD_MENU_FIELD_PRESET_LABEL"
 					description="MOD_MENU_FIELD_PRESET_DESC"
 					showon="menutype:*"


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/28620

### Steps to reproduce the issue
Make a clean install of j4-dev

Edit Admin Menu (Administrator Menu module)
### Expected result
The Preset displayed in the `Choose Preset` field should be `Preset - Joomla Main Menu`
But it is `Preset - Content Dashboard`, although it is indeed the `Joomla Main Menu` which is used.
If one does not care and just modify something else than the Preset and save, one loses the admin menu in back-end...


### Actual result
<img width="928" alt="Screen Shot 2020-04-10 at 10 26 53" src="https://user-images.githubusercontent.com/869724/78976824-462c6400-7b17-11ea-8fae-4c46789fff5f.png">

### Solution after patch
Add the `Preset - Joomla Main Menu` preset as default in the xml

We will get (after clean install OR new Admin menu)
<img width="1023" alt="Screen Shot 2020-04-11 at 11 29 03" src="https://user-images.githubusercontent.com/869724/79040632-10a47b00-7bea-11ea-920c-12f0b0fbd7fe.png">

