### PR TITLE
[4.0] Cleanup of Appveyor test builds

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,15 +9,15 @@ branches:
 
 ## Build matrix for lowest and highest possible targets
 environment:
-  DLLVersion: "5.6.1"
+  SQLSRVDLLVersion: "5.6.1"
   PHPBuild: "x64"
   VC: "vc15"
+  WINCACHE: "2.0.0.8"
   matrix:
   - php_ver_target: 7.2
-    DLLVersion: "5.3.0"
-    WINCACHE: "2.0.0.8"
+    SQLSRVDLLVersion: "5.3.0"
   - php_ver_target: 7.3
-    WINCACHE: "2.0.0.8"
+  - php_ver_target: 7.4
 
 init:
   - SET PATH=C:\Program Files\OpenSSL;C:\tools\php;%PATH%
@@ -46,16 +46,16 @@ install:
     # - ps: >-
     #    If ($env:PHP -eq "1") {
     #        cd c:\tools\php\ext
-    #        $source = "https://windows.php.net/downloads/pecl/releases/sqlsrv/$($env:DLLVersion)/php_sqlsrv-$($env:DLLVersion)-$($env:php_ver_target)-nts-$($env:VC)-$($env:PHPBuild).zip"
-    #        $destination = "c:\tools\php\ext\php_sqlsrv-$($env:DLLVersion)-$($env:php_ver_target)-nts-$($env:VC)-$($env:PHPBuild).zip"
+    #        $source = "https://windows.php.net/downloads/pecl/releases/sqlsrv/$($env:SQLSRVDLLVersion)/php_sqlsrv-$($env:SQLSRVDLLVersion)-$($env:php_ver_target)-nts-$($env:VC)-$($env:PHPBuild).zip"
+    #        $destination = "c:\tools\php\ext\php_sqlsrv-$($env:SQLSRVDLLVersion)-$($env:php_ver_target)-nts-$($env:VC)-$($env:PHPBuild).zip"
     #        Invoke-WebRequest $source -OutFile $destination
-    #        #appveyor-retry appveyor DownloadFile https://windows.php.net/downloads/pecl/releases/sqlsrv/$($env:DLLVersion)/php_sqlsrv-$($env:DLLVersion)-$($env:php_ver_target)-nts-$($env:VC)-$($env:PHPBuild).zip
-    #        7z x -y php_sqlsrv-$($env:DLLVersion)-$($env:php_ver_target)-nts-$($env:VC)-$($env:PHPBuild).zip > $null
-    #        $source = "https://windows.php.net/downloads/pecl/releases/pdo_sqlsrv/$($env:DLLVersion)/php_pdo_sqlsrv-$($env:DLLVersion)-$($env:php_ver_target)-nts-$($env:VC)-$($env:PHPBuild).zip"
-    #        $destination = "c:\tools\php\ext\php_pdo_sqlsrv-$($env:DLLVersion)-$($env:php_ver_target)-nts-$($env:VC)-$($env:PHPBuild).zip"
+    #        #appveyor-retry appveyor DownloadFile https://windows.php.net/downloads/pecl/releases/sqlsrv/$($env:SQLSRVDLLVersion)/php_sqlsrv-$($env:SQLSRVDLLVersion)-$($env:php_ver_target)-nts-$($env:VC)-$($env:PHPBuild).zip
+    #        7z x -y php_sqlsrv-$($env:SQLSRVDLLVersion)-$($env:php_ver_target)-nts-$($env:VC)-$($env:PHPBuild).zip > $null
+    #        $source = "https://windows.php.net/downloads/pecl/releases/pdo_sqlsrv/$($env:SQLSRVDLLVersion)/php_pdo_sqlsrv-$($env:SQLSRVDLLVersion)-$($env:php_ver_target)-nts-$($env:VC)-$($env:PHPBuild).zip"
+    #        $destination = "c:\tools\php\ext\php_pdo_sqlsrv-$($env:SQLSRVDLLVersion)-$($env:php_ver_target)-nts-$($env:VC)-$($env:PHPBuild).zip"
     #        Invoke-WebRequest $source -OutFile $destination
-    #        #appveyor-retry appveyor DownloadFile https://windows.php.net/downloads/pecl/releases/pdo_sqlsrv/$($env:DLLVersion)/php_pdo_sqlsrv-$($env:DLLVersion)-$($env:php_ver_target)-nts-$($env:VC)-$($env:PHPBuild).zip
-    #        7z x -y php_pdo_sqlsrv-$($env:DLLVersion)-$($env:php_ver_target)-nts-$($env:VC)-$($env:PHPBuild).zip > $null
+    #        #appveyor-retry appveyor DownloadFile https://windows.php.net/downloads/pecl/releases/pdo_sqlsrv/$($env:SQLSRVDLLVersion)/php_pdo_sqlsrv-$($env:SQLSRVDLLVersion)-$($env:php_ver_target)-nts-$($env:VC)-$($env:PHPBuild).zip
+    #        7z x -y php_pdo_sqlsrv-$($env:SQLSRVDLLVersion)-$($env:php_ver_target)-nts-$($env:VC)-$($env:PHPBuild).zip > $null
     #        Remove-Item c:\tools\php\ext* -include .zip
     #        cd c:\tools\php
     #    }

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -25,7 +25,7 @@ init:
   - SET PHP=1 # This var relates to caching the php install
   - SET ANSICON=121x90 (121x90)
 services:
-  - mssql2014
+  # - mssql2014
   - mysql
   - postgresql94
   - iis
@@ -40,25 +40,25 @@ install:
         If ($env:PHP -eq "1") {
           appveyor-retry cinst --no-progress --params '""/InstallDir:C:\tools\php""' --ignore-checksums -y php --version ((choco search php --exact --all-versions -r | select-string -pattern $env:php_ver_target | sort { [version]($_ -split '\|' | select -last 1) } -Descending | Select-Object -first 1) -replace '[php|]','')
         }
-    - appveyor-retry cinst -y sqlite
+    # - appveyor-retry cinst -y sqlite
     - cd C:\tools\php
     # Get the MSSQL DLLs
-    - ps: >-
-        If ($env:PHP -eq "1") {
-            cd c:\tools\php\ext
-            $source = "https://windows.php.net/downloads/pecl/releases/sqlsrv/$($env:DLLVersion)/php_sqlsrv-$($env:DLLVersion)-$($env:php_ver_target)-nts-$($env:VC)-$($env:PHPBuild).zip"
-            $destination = "c:\tools\php\ext\php_sqlsrv-$($env:DLLVersion)-$($env:php_ver_target)-nts-$($env:VC)-$($env:PHPBuild).zip"
-            Invoke-WebRequest $source -OutFile $destination
-            #appveyor-retry appveyor DownloadFile https://windows.php.net/downloads/pecl/releases/sqlsrv/$($env:DLLVersion)/php_sqlsrv-$($env:DLLVersion)-$($env:php_ver_target)-nts-$($env:VC)-$($env:PHPBuild).zip
-            7z x -y php_sqlsrv-$($env:DLLVersion)-$($env:php_ver_target)-nts-$($env:VC)-$($env:PHPBuild).zip > $null
-            $source = "https://windows.php.net/downloads/pecl/releases/pdo_sqlsrv/$($env:DLLVersion)/php_pdo_sqlsrv-$($env:DLLVersion)-$($env:php_ver_target)-nts-$($env:VC)-$($env:PHPBuild).zip"
-            $destination = "c:\tools\php\ext\php_pdo_sqlsrv-$($env:DLLVersion)-$($env:php_ver_target)-nts-$($env:VC)-$($env:PHPBuild).zip"
-            Invoke-WebRequest $source -OutFile $destination
-            #appveyor-retry appveyor DownloadFile https://windows.php.net/downloads/pecl/releases/pdo_sqlsrv/$($env:DLLVersion)/php_pdo_sqlsrv-$($env:DLLVersion)-$($env:php_ver_target)-nts-$($env:VC)-$($env:PHPBuild).zip
-            7z x -y php_pdo_sqlsrv-$($env:DLLVersion)-$($env:php_ver_target)-nts-$($env:VC)-$($env:PHPBuild).zip > $null
-            Remove-Item c:\tools\php\ext* -include .zip
-            cd c:\tools\php
-        }
+    # - ps: >-
+    #    If ($env:PHP -eq "1") {
+    #        cd c:\tools\php\ext
+    #        $source = "https://windows.php.net/downloads/pecl/releases/sqlsrv/$($env:DLLVersion)/php_sqlsrv-$($env:DLLVersion)-$($env:php_ver_target)-nts-$($env:VC)-$($env:PHPBuild).zip"
+    #        $destination = "c:\tools\php\ext\php_sqlsrv-$($env:DLLVersion)-$($env:php_ver_target)-nts-$($env:VC)-$($env:PHPBuild).zip"
+    #        Invoke-WebRequest $source -OutFile $destination
+    #        #appveyor-retry appveyor DownloadFile https://windows.php.net/downloads/pecl/releases/sqlsrv/$($env:DLLVersion)/php_sqlsrv-$($env:DLLVersion)-$($env:php_ver_target)-nts-$($env:VC)-$($env:PHPBuild).zip
+    #        7z x -y php_sqlsrv-$($env:DLLVersion)-$($env:php_ver_target)-nts-$($env:VC)-$($env:PHPBuild).zip > $null
+    #        $source = "https://windows.php.net/downloads/pecl/releases/pdo_sqlsrv/$($env:DLLVersion)/php_pdo_sqlsrv-$($env:DLLVersion)-$($env:php_ver_target)-nts-$($env:VC)-$($env:PHPBuild).zip"
+    #        $destination = "c:\tools\php\ext\php_pdo_sqlsrv-$($env:DLLVersion)-$($env:php_ver_target)-nts-$($env:VC)-$($env:PHPBuild).zip"
+    #        Invoke-WebRequest $source -OutFile $destination
+    #        #appveyor-retry appveyor DownloadFile https://windows.php.net/downloads/pecl/releases/pdo_sqlsrv/$($env:DLLVersion)/php_pdo_sqlsrv-$($env:DLLVersion)-$($env:php_ver_target)-nts-$($env:VC)-$($env:PHPBuild).zip
+    #        7z x -y php_pdo_sqlsrv-$($env:DLLVersion)-$($env:php_ver_target)-nts-$($env:VC)-$($env:PHPBuild).zip > $null
+    #        Remove-Item c:\tools\php\ext* -include .zip
+    #        cd c:\tools\php
+    #    }
     - IF %PHP%==1 copy php.ini-production php.ini /Y
     - IF %PHP%==1 echo date.timezone="UTC" >> php.ini
     - IF %PHP%==1 echo extension_dir=ext >> php.ini
@@ -68,16 +68,16 @@ install:
     - IF %PHP%==1 echo extension=php_gd2.dll >> php.ini
     - IF %PHP%==1 echo extension=php_gmp.dll >> php.ini
 
-    - ps: >-
-        If ($env:PHP -eq "1") {
-          Add-Content php.ini "`nextension=php_sqlsrv.dll"
-          Add-Content php.ini "`nextension=php_pdo_sqlsrv.dll"
-          Add-Content php.ini "`n"}
+    # - ps: >-
+    #    If ($env:PHP -eq "1") {
+    #      Add-Content php.ini "`nextension=php_sqlsrv.dll"
+    #      Add-Content php.ini "`nextension=php_pdo_sqlsrv.dll"
+    #      Add-Content php.ini "`n"}
 
     - IF %PHP%==1 echo extension=php_pgsql.dll >> php.ini
     - IF %PHP%==1 echo extension=php_pdo_pgsql.dll >> php.ini
-    - IF %PHP%==1 echo extension=php_pdo_sqlite.dll >> php.ini
-    - IF %PHP%==1 echo extension=php_sqlite3.dll >> php.ini
+    # - IF %PHP%==1 echo extension=php_pdo_sqlite.dll >> php.ini
+    # - IF %PHP%==1 echo extension=php_sqlite3.dll >> php.ini
     - IF %PHP%==1 echo extension=php_pdo_mysql.dll >> php.ini
     - IF %PHP%==1 echo extension=php_mysqli.dll >> php.ini
     - IF %PHP_VER_TARGET%==5.6 IF %PHP%==1 echo extension=php_mysql.dll >> php.ini

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -101,7 +101,8 @@ install:
     - IF %PHP%==1 echo opcache.enable_cli=1 >> php.ini
     - IF %PHP%==1 echo extension=php_ldap.dll >> php.ini
     - IF %PHP%==1 echo @php %%~dp0composer.phar %%* > composer.bat
-    - appveyor-retry appveyor DownloadFile https://getcomposer.org/composer.phar
+    - appveyor-retry appveyor DownloadFile https://getcomposer.org/download/1.10.5/composer.phar
+    - appveyor-retry composer self-update
     - cd C:\projects\joomla-cms
     - appveyor-retry composer install --no-progress --profile
 before_test:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,13 +9,11 @@ branches:
 
 ## Build matrix for lowest and highest possible targets
 environment:
-  SQLSRVDLLVersion: "5.6.1"
   PHPBuild: "x64"
   VC: "vc15"
   WINCACHE: "2.0.0.8"
   matrix:
   - php_ver_target: 7.2
-    SQLSRVDLLVersion: "5.3.0"
   - php_ver_target: 7.3
   - php_ver_target: 7.4
 
@@ -25,7 +23,6 @@ init:
   - SET PHP=1 # This var relates to caching the php install
   - SET ANSICON=121x90 (121x90)
 services:
-  # - mssql2014
   - mysql
   - postgresql94
   - iis
@@ -40,25 +37,7 @@ install:
         If ($env:PHP -eq "1") {
           appveyor-retry cinst --no-progress --params '""/InstallDir:C:\tools\php""' --ignore-checksums -y php --version ((choco search php --exact --all-versions -r | select-string -pattern $env:php_ver_target | sort { [version]($_ -split '\|' | select -last 1) } -Descending | Select-Object -first 1) -replace '[php|]','')
         }
-    # - appveyor-retry cinst -y sqlite
     - cd C:\tools\php
-    # Get the MSSQL DLLs
-    # - ps: >-
-    #    If ($env:PHP -eq "1") {
-    #        cd c:\tools\php\ext
-    #        $source = "https://windows.php.net/downloads/pecl/releases/sqlsrv/$($env:SQLSRVDLLVersion)/php_sqlsrv-$($env:SQLSRVDLLVersion)-$($env:php_ver_target)-nts-$($env:VC)-$($env:PHPBuild).zip"
-    #        $destination = "c:\tools\php\ext\php_sqlsrv-$($env:SQLSRVDLLVersion)-$($env:php_ver_target)-nts-$($env:VC)-$($env:PHPBuild).zip"
-    #        Invoke-WebRequest $source -OutFile $destination
-    #        #appveyor-retry appveyor DownloadFile https://windows.php.net/downloads/pecl/releases/sqlsrv/$($env:SQLSRVDLLVersion)/php_sqlsrv-$($env:SQLSRVDLLVersion)-$($env:php_ver_target)-nts-$($env:VC)-$($env:PHPBuild).zip
-    #        7z x -y php_sqlsrv-$($env:SQLSRVDLLVersion)-$($env:php_ver_target)-nts-$($env:VC)-$($env:PHPBuild).zip > $null
-    #        $source = "https://windows.php.net/downloads/pecl/releases/pdo_sqlsrv/$($env:SQLSRVDLLVersion)/php_pdo_sqlsrv-$($env:SQLSRVDLLVersion)-$($env:php_ver_target)-nts-$($env:VC)-$($env:PHPBuild).zip"
-    #        $destination = "c:\tools\php\ext\php_pdo_sqlsrv-$($env:SQLSRVDLLVersion)-$($env:php_ver_target)-nts-$($env:VC)-$($env:PHPBuild).zip"
-    #        Invoke-WebRequest $source -OutFile $destination
-    #        #appveyor-retry appveyor DownloadFile https://windows.php.net/downloads/pecl/releases/pdo_sqlsrv/$($env:SQLSRVDLLVersion)/php_pdo_sqlsrv-$($env:SQLSRVDLLVersion)-$($env:php_ver_target)-nts-$($env:VC)-$($env:PHPBuild).zip
-    #        7z x -y php_pdo_sqlsrv-$($env:SQLSRVDLLVersion)-$($env:php_ver_target)-nts-$($env:VC)-$($env:PHPBuild).zip > $null
-    #        Remove-Item c:\tools\php\ext* -include .zip
-    #        cd c:\tools\php
-    #    }
     - IF %PHP%==1 copy php.ini-production php.ini /Y
     - IF %PHP%==1 echo date.timezone="UTC" >> php.ini
     - IF %PHP%==1 echo extension_dir=ext >> php.ini
@@ -67,17 +46,8 @@ install:
     - IF %PHP%==1 echo extension=php_fileinfo.dll >> php.ini
     - IF %PHP%==1 echo extension=php_gd2.dll >> php.ini
     - IF %PHP%==1 echo extension=php_gmp.dll >> php.ini
-
-    # - ps: >-
-    #    If ($env:PHP -eq "1") {
-    #      Add-Content php.ini "`nextension=php_sqlsrv.dll"
-    #      Add-Content php.ini "`nextension=php_pdo_sqlsrv.dll"
-    #      Add-Content php.ini "`n"}
-
     - IF %PHP%==1 echo extension=php_pgsql.dll >> php.ini
     - IF %PHP%==1 echo extension=php_pdo_pgsql.dll >> php.ini
-    # - IF %PHP%==1 echo extension=php_pdo_sqlite.dll >> php.ini
-    # - IF %PHP%==1 echo extension=php_sqlite3.dll >> php.ini
     - IF %PHP%==1 echo extension=php_pdo_mysql.dll >> php.ini
     - IF %PHP%==1 echo extension=php_mysqli.dll >> php.ini
     - IF %PHP_VER_TARGET%==5.6 IF %PHP%==1 echo extension=php_mysql.dll >> php.ini
@@ -114,10 +84,6 @@ before_test:
   - SET PGPASSWORD=Password12!
   - PATH=C:\Program Files\PostgreSQL\9.4\bin\;%PATH%
   - createdb joomla_ut
-
-# Database setup for SQL Server
-#  - ps: $sqlInstance = "(local)\SQL2014"
-#  - ps: sqlcmd -b -E -S "$sqlInstance" -Q "CREATE DATABASE joomla_ut"
 
 test_script:
   - cd C:\projects\joomla-cms

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -116,8 +116,8 @@ before_test:
   - createdb joomla_ut
 
 # Database setup for SQL Server
-  - ps: $sqlInstance = "(local)\SQL2014"
-  - ps: sqlcmd -b -E -S "$sqlInstance" -Q "CREATE DATABASE joomla_ut"
+#  - ps: $sqlInstance = "(local)\SQL2014"
+#  - ps: sqlcmd -b -E -S "$sqlInstance" -Q "CREATE DATABASE joomla_ut"
 
 test_script:
   - cd C:\projects\joomla-cms


### PR DESCRIPTION
This pull request cleans up our Appveyor builds.
- It fixes the composer issue where a 2.0 beta was used instead of the latest stable. We are now loading composer 1.10.5 and then do a self-update to update to the latest stable version. That way we most likely get around updating the appveyor.yml on each new release of composer.
- This also adds PHP 7.4 to the test setup.
- Since Joomla 4.0 does not support running on MSSQL and SQLite, those setups were removed. The database layer has its own tests for the RDBMS that it supports, Joomla only supports MySQL and Postgres. So we don't need that anymore.

All removals have just been commented out for now so that we can put them back in if we want, but I tend to completely removing this altogether...