### PR TITLE
[4.0][Atum] Rounded 'input-group-append'

### DIFF
--- a/administrator/templates/atum/scss/blocks/_form.scss
+++ b/administrator/templates/atum/scss/blocks/_form.scss
@@ -156,3 +156,17 @@ legend {
   font-size: $label-font-size;
   color: var(--atum-special-color);
 }
+
+.input-group-append {
+  overflow: hidden;
+
+  [dir=ltr] & {
+    border-top-right-radius: $border-radius;
+    border-bottom-right-radius: $border-radius;
+  }
+
+  [dir=rtl] & {
+    border-top-left-radius: $border-radius;
+    border-bottom-left-radius: $border-radius;
+  }
+}


### PR DESCRIPTION
Pull Request for Issue #28363 (alternative to #28404).

### Summary of changes

The hidden buttons don't play nice with Bootstrap button groups giving the last item square corners. 

### Testing Instructions
Apply this patch and run `node build.js --compile-css` for updating the changed SCSS. Check new menu item -> single article.

This should also work if group has 3+ button which was an issue with the previous pr.

### Before
![image](https://user-images.githubusercontent.com/2803503/79042102-c7a1f600-7bec-11ea-8fbb-30268d610d8c.png)


### After
![image](https://user-images.githubusercontent.com/2803503/79042091-b6f18000-7bec-11ea-9724-9f6ced1599f4.png)
![image](https://user-images.githubusercontent.com/2803503/79042175-5f074900-7bed-11ea-9da4-9b425fb9cbbf.png)


### Documentation Changes Required

