### PR TITLE
[4.0] Fix infinite loop in menu class

### DIFF
--- a/libraries/src/Menu/SiteMenu.php
+++ b/libraries/src/Menu/SiteMenu.php
@@ -197,8 +197,8 @@ class SiteMenu extends AbstractMenu
 
 			if (isset($this->items[$item->parent_id]))
 			{
-				$item->setParent($this->getMenu()[$item->parent_id]);
-				$parent_tree  = $this->getMenu()[$item->parent_id]->tree;
+				$item->setParent($this->items[$item->parent_id]);
+				$parent_tree  = $this->items[$item->parent_id]->tree;
 			}
 
 			// Create tree.


### PR DESCRIPTION
### Summary of Changes

Fixes infinite loop in `Joomla\CMS\Menu\SiteMenu`.

### Testing Instructions

Edit an article in backend or visit frontend.

### Expected result

Works.

### Actual result

Timeout.

### Documentation Changes Required

No.