### PR TITLE
[4.0][a11y] Add a fieldset with id in batch modal of categories

### DIFF
--- a/administrator/components/com_categories/tmpl/categories/default_batch_body.php
+++ b/administrator/components/com_categories/tmpl/categories/default_batch_body.php
@@ -50,7 +50,9 @@ $extension = $this->escape($this->state->get('filter.extension'));
 				<label id="flip-ordering-id-lbl" for="flip-ordering-id" class="control-label">
 					<?php echo Text::_('JLIB_HTML_BATCH_FLIPORDERING_LABEL'); ?>
 				</label>
-				<?php echo HTMLHelper::_('select.booleanlist', 'batch[flip_ordering]', array(), 0, 'JYES', 'JNO', 'flip-ordering-id'); ?>
+				<fieldset id="flip-ordering-id">
+					<?php echo HTMLHelper::_('select.booleanlist', 'batch[flip_ordering]', array(), 0, 'JYES', 'JNO', 'flip-ordering-id'); ?>
+				</fieldset>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
### Summary of Changes
The radio button group in batch categories now has a fieldset with id. 
See also #28577

### Testing Instructions
Got to categores overview, mark at least one and open the batch modal.

Code inspect

![batch-fieldset](https://user-images.githubusercontent.com/1035262/79043491-c8905300-7bff-11ea-942f-f98ce1cef51f.JPG)


### Documentation Changes Required
no
