### PR TITLE
[4.0] Associations warning translateable

### DIFF
--- a/layouts/joomla/edit/associations.php
+++ b/layouts/joomla/edit/associations.php
@@ -20,8 +20,15 @@ $options  = array(
 );
 
 HTMLHelper::_('behavior.core');
+
+// Load JavaScript message titles
+Text::script('ERROR');
+Text::script('WARNING');
+Text::script('NOTICE');
+Text::script('MESSAGE');
 Text::script('JGLOBAL_ASSOC_NOT_POSSIBLE');
 Text::script('JGLOBAL_ASSOCIATIONS_RESET_WARNING');
+
 Factory::getDocument()->addScriptOptions('system.associations.edit', $options);
 HTMLHelper::_('script', 'com_associations/associations-edit.min.js', array('version' => 'auto', 'relative' => true));
 


### PR DESCRIPTION
Create a multilingual site
Change a menu item from language all to any other language
You will see an alert as below with a non translated warning

Apply the pr and try again

### Before
![image](https://user-images.githubusercontent.com/1296369/79043967-73057780-7bfa-11ea-8746-1e429c623723.png)

### After
![image](https://user-images.githubusercontent.com/1296369/79043968-7698fe80-7bfa-11ea-9026-71e415c52e4e.png)
