### PR TITLE
[4.0] header dropdown menu on tablet

### DIFF
--- a/administrator/templates/atum/scss/blocks/_header.scss
+++ b/administrator/templates/atum/scss/blocks/_header.scss
@@ -290,6 +290,14 @@
     .header-item {
       width: 6.6rem;
       height: 3.7rem;
+
+      .header-item-content > :first-child {
+        color: var(--atum-special-color);
+
+        &[aria-expanded=true] {
+          color: var(--atum-text-light);
+        }
+      }
     }
 
     .header-item-content {
@@ -367,14 +375,6 @@
         [dir=rtl] & {
           right: 0;
           left: auto;
-        }
-      }
-
-      & .header-item .header-item-content > :first-child {
-        color: var(--atum-special-color);
-
-        &[aria-expanded=true] {
-          color: var(--atum-text-light);
         }
       }
     }


### PR DESCRIPTION
As the screen size is reduced the icons in the header and moved into a dropdown. But their styling didnt change so they were white icons on white. This PR resolves that.

Pull Request for Issue #28639 .

### before
![image](https://user-images.githubusercontent.com/1296369/79046960-bcaa8e00-7c0b-11ea-9b1c-49a5e6b70035.png)

### after
![image](https://user-images.githubusercontent.com/1296369/79046942-a43a7380-7c0b-11ea-8c84-e90e767b5c26.png)
