### PR TITLE
[4.0] Add missing update SQL for adding plg_quickicon_downloadkey to the extensions

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/4.0.0-2020-04-11.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.0.0-2020-04-11.sql
@@ -1,0 +1,2 @@
+INSERT INTO `#__extensions` (`package_id`, `name`, `type`, `element`, `folder`, `client_id`, `enabled`, `access`, `protected`, `locked`, `manifest_cache`, `params`, `checked_out`, `checked_out_time`, `ordering`, `state`) VALUES
+(0, 'plg_quickicon_downloadkey', 'plugin', 'downloadkey', 'quickicon', 0, 1, 1, 1, 1, '', '', 0, NULL, 0, 0);

--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2020-04-11.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2020-04-11.sql
@@ -1,0 +1,2 @@
+INSERT INTO "#__extensions" ("package_id", "name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "locked", "manifest_cache", "params", "checked_out", "checked_out_time", "ordering", "state") VALUES
+(0, 'plg_quickicon_downloadkey', 'plugin', 'downloadkey', 'quickicon', 0, 1, 1, 1, 1, '', '', 0, NULL, 0, 0);


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This Pull Request (PR) adds the missing update SQL script to add the "Missing Download Key Notification" quick icon plugin to the `#__extensions` table when updating to Joomla 4.

The quick icon plugin has been added with PR #26744 , but that PR did not provide any update sql script or other method (script.php) to add the record for that plugin to the `#__extensions` table.

### Testing Instructions

#### Test 1: Reproduce the issue

1. Update a clean 3.10-dev to a 4.0-beta1-dev nightly build or any upther J4 update package which does **not** contain the changes from this PR here, or use the corresponding custom URL for Live Update.

2. Login to backend.

3. Go to "System - Install - Discover".

4. Use the "Discover" button if there are no extensions discovered yet.

Result: See section "Actual result" below.

#### Test 2: Check that this PR here solves the issue

1. Repeat the previous Test 1, but this time use the [update package built for this PR](https://ci.joomla.org/artifacts/joomla/joomla-cms/4.0-dev/28655/downloads/31175/Joomla_4.0.0-beta1-dev+pr.28655-Development-Update_Package.zip) when using "Upload & Update", or use the [corresponding custom URL](https://ci.joomla.org/artifacts/joomla/joomla-cms/4.0-dev/28655/downloads/31175/pr_list.xml) when using "Live Update".

Result: No extension is discovered.

2. Check in "System - Manage - Plugins" if the "Quick Icon - Missing Download Key Notification" plugin is installed.

Result: The "Quick Icon - Missing Download Key Notification" plugin is installed.

### Expected result

No extension is discovered. The "Quick Icon - Missing Download Key Notification" plugin is installed.

### Actual result

One extension is discovered: "Quick Icon - Missing Download Key Notification".

### Documentation Changes Required

None.