### PR TITLE
[4.0] [a11y] Add fieldset with id to users batch modal

### DIFF
--- a/administrator/components/com_users/tmpl/users/default_batch_body.php
+++ b/administrator/components/com_users/tmpl/users/default_batch_body.php
@@ -41,8 +41,12 @@ $resetOptions = array(
 			</div>
 		</div>
 		<div class="form-group">
-			<label><?php echo Text::_('COM_USERS_REQUIRE_PASSWORD_RESET'); ?></label>
-			<?php echo HTMLHelper::_('select.radiolist', $resetOptions, 'batch[reset_id]', '', 'value', 'text', ''); ?>
+			<label class="control-label" for="batch-password-reset_id">
+				<?php echo Text::_('COM_USERS_REQUIRE_PASSWORD_RESET'); ?>
+			</label>
+			<fieldset id="batch-password-reset_id">
+				<?php echo HTMLHelper::_('select.radiolist', $resetOptions, 'batch[reset_id]', '', 'value', 'text', ''); ?>
+			</fieldset>
 		</div>
 	</form>
 </div>


### PR DESCRIPTION
### Summary of Changes
In users batch modal: 
There is a label for the button group "password reset" but it is not related to the following buttpn group. 
This PR adds a label-for and a fieldset to the radio button group.


### Testing Instructions
Code review, there are noch cahnges visible on the screen.
The label must be related to a fieldset as it shown here: 

![batch-fieldset users](https://user-images.githubusercontent.com/1035262/79052968-45d8b980-7c3a-11ea-80a6-711fbb04c6b1.JPG)


