### PR TITLE
[4.0][Atum] Choices CSS rewrite

### DIFF
--- a/administrator/templates/atum/scss/system/searchtools/searchtools.scss
+++ b/administrator/templates/atum/scss/system/searchtools/searchtools.scss
@@ -31,7 +31,7 @@
   &-visible {
     display: grid;
     grid-gap: 8px;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
     padding: 10px;
     background-color: $white;
   }

--- a/administrator/templates/atum/scss/vendor/choicesjs/choices.scss
+++ b/administrator/templates/atum/scss/vendor/choicesjs/choices.scss
@@ -18,7 +18,6 @@
 
 .choices__inner {
   border: $input-border;
-  border-color: $gray-400;
   box-shadow: $input-box-shadow;
 }
 
@@ -53,27 +52,30 @@
   }
 }
 
-.choices[data-type*="select-one"] {
-
-  .choices__button_joomla {
-    position: absolute;
-    top: 50%;
-    width: 20px;
-    height: 20px;
-    padding: 0;
-    margin-top: -10px;
-    border-radius: 0 20px 20px 0;
-    opacity: .5;
-
-    [dir=ltr] & {
-      right: 0;
-      margin-right: 3rem;
-    }
+.choices[data-type*="select-one"],
+.choices[data-type*="select-multiple"] {
+  .choices__inner {
+    padding: $custom-select-padding-y;
+    padding-block-start: $custom-select-padding-x;
+    padding-inline-end: $custom-select-indicator-padding;
+    background: url("../../../images/select-bg.svg") no-repeat right center / $custom-select-bg-size;
+    background-color: $custom-select-bg;
 
     [dir=rtl] & {
-      left: 0;
-      margin-left: 3rem;
+      background: url("../../../images/select-bg-rtl.svg") no-repeat left center / $custom-select-bg-size;
     }
+  }
+}
+
+.choices[data-type*="select-one"] {
+  .choices__item {
+    display: flex;
+    justify-content: space-between;
+  }
+
+  .choices__button_joomla {
+    opacity: .5;
+    padding: 0 10px;
 
     &:hover,
     &:focus {
@@ -85,30 +87,8 @@
     }
   }
 
-  &[dir="rtl"] {
-
-    .choices__button_joomla {
-      right: auto;
-      left: 0;
-      margin-right: 0;
-      margin-left: 25px;
-    }
-  }
-
   &::after {
     display: none;
-  }
-
-  .choices__inner {
-    padding: $custom-select-padding-y ($custom-select-padding-x + $custom-select-indicator-padding) $custom-select-padding-y $custom-select-padding-x;
-    background: url("../../../images/select-bg.svg") no-repeat right center / $custom-select-bg-size;
-    background-color: $custom-select-bg;
-
-    [dir=rtl] & {
-      padding: $custom-select-padding-y $custom-select-padding-x $custom-select-padding-y ($custom-select-padding-x + $custom-select-indicator-padding);
-      background: url("../../../images/select-bg-rtl.svg") no-repeat left center / $custom-select-bg-size;
-      background-color: $custom-select-bg;
-    }
   }
 }
 
@@ -116,34 +96,34 @@
 .choices[data-type*="text"] {
 
   .choices__button_joomla {
-    position: absolute;
-    top: 0;
-    display: block;
-    width: .5rem;
-    height: 1.625rem;
-    padding: .8125rem;
-    line-height: 2;
-    background-color: rgba(0, 0, 0, .2);
-    border: 0;
-    border-radius: 0 20px 20px 0;
-    opacity: 1;
+    // position: absolute;
+    // top: 0;
+    // display: block;
+    // width: .5rem;
+    // height: 1.625rem;
+    // padding: .8125rem;
+    // line-height: 2;
+    // background-color: rgba(0, 0, 0, .2);
+    // border: 0;
+    // border-radius: 0 20px 20px 0;
+    // opacity: 1;
 
-    [dir=ltr] & {
-      right: 0;
-    }
+    // [dir=ltr] & {
+    //   right: 0;
+    // }
 
-    [dir=rtl] & {
-      left: 0;
-    }
+    // [dir=rtl] & {
+    //   left: 0;
+    // }
 
-    &:hover,
-    &:focus {
-      opacity: 1;
-    }
+    // &:hover,
+    // &:focus {
+    //   opacity: 1;
+    // }
 
-    &::before {
-      color: $white;
-    }
+    // &::before {
+    //   color: $white;
+    // }
   }
 
   .choices__inner {
@@ -167,16 +147,6 @@
     border: 1px solid var(--atum-bg-dark);
     opacity: .9;
   }
-
-  &[data-deletable] {
-    [dir=ltr] & {
-      padding-right: 1.8125rem;
-    }
-
-    [dir=rtl] & {
-      padding-left: 1.8125rem;
-    }
-  }
 }
 
 .choices__input {
@@ -187,7 +157,7 @@
 
 .choices__inner,
 .choices__input {
-  background-color: var(--white);
+  background-color: transparent;
 }
 
 .choices__list--single {
@@ -204,4 +174,12 @@
   [dir=rtl] & {
     padding-left: 1.8125rem !important;
   }
+}
+
+.choices__list--dropdown .choices__item--selectable::after {
+  display: none;
+}
+
+.choices__list--dropdown .choices__item {
+  padding-right: 10px;
 }

--- a/administrator/templates/atum/scss/vendor/choicesjs/choices.scss
+++ b/administrator/templates/atum/scss/vendor/choicesjs/choices.scss
@@ -16,11 +16,6 @@
   border: 0;
   border-radius: $border-radius;
 
-  ::-moz-placeholder,
-  ::-webkit-input-placeholder {
-    opacity: 1
-  }
-
   &:hover {
     cursor: pointer;
   }
@@ -34,7 +29,7 @@
   border: $input-border;
   border-radius: $border-radius;
   box-shadow: $input-box-shadow;
-  padding: .4rem 1rem;
+  padding: 0.4rem 1rem;
   margin-bottom: 0;
   font-size: 1rem;
 
@@ -48,6 +43,16 @@
   margin-bottom: 0;
   font-size: 1rem;
   background-color: transparent;
+
+  &::-moz-placeholder {
+    color: $gray-700;
+    opacity: 1;
+  }
+
+  &::-webkit-input-placeholder {
+    color: $gray-700;
+    opacity: 1;
+  }
 }
 
 .choices__list--dropdown {
@@ -64,7 +69,7 @@
 
   &.is-highlighted {
     background-color: var(--atum-bg-dark);
-    opacity: .9;
+    opacity: 0.9;
   }
 }
 
@@ -78,9 +83,8 @@
   }
 }
 
-
 .choices__button_joomla {
-  opacity: .5;
+  opacity: 0.5;
   padding: 0 10px;
   color: white;
 
@@ -119,7 +123,7 @@
     padding-inline-end: $custom-select-indicator-padding;
     background: $custom-select-bg url("../../../images/select-bg.svg") no-repeat 100%/116rem;
 
-    [dir=rtl] & {
+    [dir="rtl"] & {
       background: $custom-select-bg url("../../../images/select-bg-rtl.svg") no-repeat 0/116rem;
     }
   }
@@ -139,15 +143,6 @@
 .choices[data-type*="select-multiple"],
 .choices[data-type*="text"] {
   .choices__input {
-    padding: .2rem 0;
-    color: $custom-select-color;
-  }
-
-  .choices__list:not(:empty) + .choices__input {
-    display: none;
-
-    &::placeholder {
-      display: none;
-    }
+    padding: 0.2rem 0;
   }
 }

--- a/administrator/templates/atum/scss/vendor/choicesjs/choices.scss
+++ b/administrator/templates/atum/scss/vendor/choicesjs/choices.scss
@@ -14,22 +14,33 @@
 
 .choices {
   border: 0;
+  border-radius: $border-radius;
 
-  ::-moz-placeholder {
+  ::-moz-placeholder,
+  ::-webkit-input-placeholder {
     opacity: 1
   }
 
   &:hover {
     cursor: pointer;
   }
+
+  &.is-focused {
+    box-shadow: $focusshadow;
+  }
 }
 
 .choices__inner {
   border: $input-border;
+  border-radius: $border-radius;
   box-shadow: $input-box-shadow;
   padding: .4rem 1rem;
   margin-bottom: 0;
   font-size: 1rem;
+
+  .is-focused & {
+    border-color: $focuscolor;
+  }
 }
 
 .choices__input {

--- a/administrator/templates/atum/scss/vendor/choicesjs/choices.scss
+++ b/administrator/templates/atum/scss/vendor/choicesjs/choices.scss
@@ -14,20 +14,65 @@
 
 .choices {
   border: 0;
+
+  ::-moz-placeholder {
+    opacity: 1
+  }
+
+  &:hover {
+    cursor: pointer;
+  }
 }
 
 .choices__inner {
   border: $input-border;
   box-shadow: $input-box-shadow;
+  padding: .4rem 1rem;
+  margin-bottom: 0;
+  font-size: 1rem;
 }
 
-// Fix position
+.choices__input {
+  padding: 0;
+  margin-bottom: 0;
+  font-size: 1rem;
+  background-color: transparent;
+}
+
 .choices__list--dropdown {
   z-index: $zindex-popover;
 }
 
-// Fix close button
+.choices__list--multiple .choices__item {
+  position: relative;
+  background-color: var(--atum-bg-dark);
+  margin: 2px;
+  margin-inline-end: 2px;
+  border: 0;
+  border-radius: $border-radius;
+
+  &.is-highlighted {
+    background-color: var(--atum-bg-dark);
+    opacity: .9;
+  }
+}
+
+.choices__list--dropdown {
+  .choices__item {
+    padding-right: 10px;
+  }
+
+  .choices__item--selectable::after {
+    display: none;
+  }
+}
+
+
 .choices__button_joomla {
+  opacity: .5;
+  padding: 0 10px;
+  color: white;
+
   position: relative;
   text-indent: -9999px;
   cursor: pointer;
@@ -47,6 +92,11 @@
     content: "\00d7";
   }
 
+  &:hover,
+  &:focus {
+    opacity: 1;
+  }
+
   &:focus {
     outline: none;
   }
@@ -55,14 +105,11 @@
 .choices[data-type*="select-one"],
 .choices[data-type*="select-multiple"] {
   .choices__inner {
-    padding: $custom-select-padding-y;
-    padding-block-start: $custom-select-padding-x;
     padding-inline-end: $custom-select-indicator-padding;
-    background: url("../../../images/select-bg.svg") no-repeat right center / $custom-select-bg-size;
-    background-color: $custom-select-bg;
+    background: $custom-select-bg url("../../../images/select-bg.svg") no-repeat 100%/116rem;
 
     [dir=rtl] & {
-      background: url("../../../images/select-bg-rtl.svg") no-repeat left center / $custom-select-bg-size;
+      background: $custom-select-bg url("../../../images/select-bg-rtl.svg") no-repeat 0/116rem;
     }
   }
 }
@@ -73,20 +120,6 @@
     justify-content: space-between;
   }
 
-  .choices__button_joomla {
-    opacity: .5;
-    padding: 0 10px;
-
-    &:hover,
-    &:focus {
-      opacity: 1;
-    }
-
-    &:focus {
-      box-shadow: 0 0 0 2px var(--atum-bg-dark-80);
-    }
-  }
-
   &::after {
     display: none;
   }
@@ -94,92 +127,16 @@
 
 .choices[data-type*="select-multiple"],
 .choices[data-type*="text"] {
-
-  .choices__button_joomla {
-    // position: absolute;
-    // top: 0;
-    // display: block;
-    // width: .5rem;
-    // height: 1.625rem;
-    // padding: .8125rem;
-    // line-height: 2;
-    // background-color: rgba(0, 0, 0, .2);
-    // border: 0;
-    // border-radius: 0 20px 20px 0;
-    // opacity: 1;
-
-    // [dir=ltr] & {
-    //   right: 0;
-    // }
-
-    // [dir=rtl] & {
-    //   left: 0;
-    // }
-
-    // &:hover,
-    // &:focus {
-    //   opacity: 1;
-    // }
-
-    // &::before {
-    //   color: $white;
-    // }
-  }
-
-  .choices__inner {
-    padding: .4rem 1rem .256rem;
-  }
-
   .choices__input {
-    padding: .2rem 0 .356rem;
+    padding: .2rem 0;
     color: $custom-select-color;
   }
-}
 
-.choices__list--multiple .choices__item {
-  position: relative;
-  background-color: var(--atum-bg-dark);
-  border: 1px solid var(--atum-bg-dark);
-  border-radius: 0;
+  .choices__list:not(:empty) + .choices__input {
+    display: none;
 
-  &.is-highlighted {
-    background-color: var(--atum-bg-dark);
-    border: 1px solid var(--atum-bg-dark);
-    opacity: .9;
+    &::placeholder {
+      display: none;
+    }
   }
-}
-
-.choices__input {
-  padding: 0;
-  margin-bottom: 0;
-  font-size: 1rem;
-}
-
-.choices__inner,
-.choices__input {
-  background-color: transparent;
-}
-
-.choices__list--single {
-  padding: 0;
-  font-size: 1rem;
-  color: var(--atum-text-dark);
-}
-
-.choices__list--multiple .choices__item[data-deletable] {
-  [dir=ltr] & {
-    padding-right: 1.8125rem !important;
-  }
-
-  [dir=rtl] & {
-    padding-left: 1.8125rem !important;
-  }
-}
-
-.choices__list--dropdown .choices__item--selectable::after {
-  display: none;
-}
-
-.choices__list--dropdown .choices__item {
-  padding-right: 10px;
 }


### PR DESCRIPTION
Pull Request for Issue #28648, #28461, #23451.

### Summary of Changes
Rewrites choices CSS

- Reduced CSS
- Simplifies styling
- Removes 'Press to Select' text
- Matches style with non choices select fields
- ~~Removes placholder text if 1+ item selected.~~


### Testing Instructions
Apply this patch and run `node build.js --compile-css` for updating the changed SCSS. Check choices select fields (searchtools / new article -> category)

### Before
![image](https://user-images.githubusercontent.com/2803503/79053496-c0530a80-7c35-11ea-893a-76e0da7ec921.png)
![image](https://user-images.githubusercontent.com/2803503/79054233-386fff00-7c3b-11ea-993f-4e96a27fc195.png)

### After
![image](https://user-images.githubusercontent.com/2803503/79053520-fb553e00-7c35-11ea-891a-c492733a462b.png)
![image](https://user-images.githubusercontent.com/2803503/79054245-53db0a00-7c3b-11ea-9f0e-a36007e1430d.png)
