### PR TITLE
[4.0] Fix association edit toolbar style

### DIFF
--- a/administrator/components/com_associations/src/View/Association/HtmlView.php
+++ b/administrator/components/com_associations/src/View/Association/HtmlView.php
@@ -369,15 +369,15 @@ class HtmlView extends BaseHtmlView
 		$bar = Toolbar::getInstance();
 
 		$bar->appendButton(
-			'Custom', '<button onclick="Joomla.submitbutton(\'reference\')" '
+			'Custom', '<joomla-toolbar-button><button onclick="Joomla.submitbutton(\'reference\')" '
 			. 'class="btn btn-sm btn-success"><span class="fas fa-save" aria-hidden="true"></span>'
-			. Text::_('COM_ASSOCIATIONS_SAVE_REFERENCE') . '</button>', 'reference'
+			. Text::_('COM_ASSOCIATIONS_SAVE_REFERENCE') . '</button></joomla-toolbar-button>', 'reference'
 		);
 
 		$bar->appendButton(
-			'Custom', '<button onclick="Joomla.submitbutton(\'target\')" '
+			'Custom', '<joomla-toolbar-button><button onclick="Joomla.submitbutton(\'target\')" '
 			. 'class="btn btn-sm btn-success"><span class="fas fa-save" aria-hidden="true"></span>'
-			. Text::_('COM_ASSOCIATIONS_SAVE_TARGET') . '</button>', 'target'
+			. Text::_('COM_ASSOCIATIONS_SAVE_TARGET') . '</button></joomla-toolbar-button>', 'target'
 		);
 
 		if ($this->typeName === 'category' || $this->extensionName === 'com_menus' || $this->save2copy === true)


### PR DESCRIPTION
### Summary of Changes
Fixes styling to toolbar buttons when editing an assosiation 


### Testing Instructions
Apply PR and edit an assosiation 


### Before PR
![image](https://user-images.githubusercontent.com/2803503/79070123-7c124980-7ccb-11ea-9a6f-85b44e5c1fbc.png)



### After PR
![image](https://user-images.githubusercontent.com/2803503/79070117-6e5cc400-7ccb-11ea-9cf5-2a39770e3ce6.png)


### Documentation Changes Required

