### PR TITLE
[4.0] Improve text padding in quickicons

### DIFF
--- a/administrator/templates/atum/scss/blocks/_quickicons.scss
+++ b/administrator/templates/atum/scss/blocks/_quickicons.scss
@@ -166,16 +166,9 @@
       }
     }
 
-    .quickicon-text {
-      min-height: 1.2rem;
-      padding: .2rem;
-      font-size: .875rem;
-      text-align: center;
-    }
-
     .j-links-link {
       display: block;
-      padding: 0 1rem;
+      padding: 0 .2rem;
       line-height: 1.1;
     }
 

--- a/layouts/joomla/quickicons/icon.php
+++ b/layouts/joomla/quickicons/icon.php
@@ -80,7 +80,7 @@ $class = !empty($tmp) ? ' class="' . implode(' ', array_unique($tmp)) . '"' : ''
 			<?php endif; ?>
 			<?php // Information or action from plugins
 			if (isset($displayData['text'])): ?>
-				<div class="quickicon-text d-flex align-items-center">
+				<div class="quickicon-name d-flex align-items-center">
 					<?php echo $text; ?>
 				</div>
 			<?php endif; ?>


### PR DESCRIPTION
Pull Request for Issue #28665 .

### Summary of Changes
Improve padding around text in quickicons


### Testing Instructions
Apply the patch don't forget to build the css with npm.
Have a look on the quickicons on differents screens. 


### Expected result
All texts should have some padding. 



### Actual result
see the issue


### Documentation Changes Required
no
