### PR TITLE
[4.0] Choices RTL dropdown fix

### DIFF
--- a/administrator/templates/atum/scss/vendor/choicesjs/choices.scss
+++ b/administrator/templates/atum/scss/vendor/choicesjs/choices.scss
@@ -73,9 +73,9 @@
   }
 }
 
-.choices__list--dropdown {
+.choices .choices__list--dropdown {
   .choices__item {
-    padding-right: 10px;
+    padding-inline-end: 10px;
   }
 
   .choices__item--selectable::after {


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
#28658 removed 'press to select' from the choices dropdown. This pr translates a related padding correction to rtl.


### Testing Instructions
Apply this patch and run `node build.js --compile-css` for updating the changed SCSS. With RTL, check choices select fields (searchtools / new article -> category). Ensure dropdown displays correctly.


### Before
![image](https://user-images.githubusercontent.com/2803503/79117938-63199f00-7d84-11ea-9a4f-aa428ab271f8.png)



### After
![image](https://user-images.githubusercontent.com/2803503/79117944-66148f80-7d84-11ea-9a95-436262f1684f.png)



### Documentation Changes Required

