### PR TITLE
Fix broken Associations toolbar button when editing category

### DIFF
--- a/administrator/components/com_categories/models/category.php
+++ b/administrator/components/com_categories/models/category.php
@@ -9,6 +9,7 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Factory;
 use Joomla\Registry\Registry;
 use Joomla\String\StringHelper;
 use Joomla\Utilities\ArrayHelper;
@@ -686,6 +687,11 @@ class CategoriesModelCategory extends JModelAdmin
 		}
 
 		$this->setState($this->getName() . '.id', $table->id);
+
+		if (Factory::getApplication()->input->get('task') == 'editAssociations')
+		{
+			return $this->redirectToAssociations($data);
+		}
 
 		// Clear the cache
 		$this->cleanCache();


### PR DESCRIPTION
Pull Request for Issue # .

Redo of PR #28675 .

Thanks @infograf768 for the fix.

### Summary of Changes

Same code exists for menu items. Was missing in category model.

### Testing Instructions

Create multilingual site using sample data.
Edit a category tagged to a language.
Click on the Associations toolbar button
Instead of displaying the side by side of com_associations, it just saves the category and redirects to the manager.

Patch and test again.

### Expected result

Associations side-by-side view opened.

### Actual result

Redirected to the categories manager.

### Documentation Changes Required

None.