### PR TITLE
Fix missing lft rgt nested tree rebuild in usergroups table when deleting usergroup(s)

### DIFF
--- a/libraries/src/Table/Usergroup.php
+++ b/libraries/src/Table/Usergroup.php
@@ -196,6 +196,9 @@ class Usergroup extends Table
 		$db->setQuery($query);
 		$db->execute();
 
+		// Rebuild the nested set tree.
+		$this->rebuild();
+
 		// Delete the usergroup in view levels
 		$replace = array();
 


### PR DESCRIPTION
Pull Request for Issue [https://github.com/joomla/joomla-cms/issues/28522#issuecomment-613123176](https://github.com/joomla/joomla-cms/issues/28522#issuecomment-613123176).

### Summary of Changes

When deleting one or more usergroups, the `lft`and `rgt` values in the `#__usergroups` table are not recalculated, i.e. the nested set tree is not rebuilt.

This PR adds the missing function call for that purpose to the delete routine of the `Usergroup` table class.

### Testing Instructions

1. On a clean, new installation, check with an SQL client (e.g. phpMyAdmin when using MySQL or MariaDB) the content of the `#__usergroups` as follows:
![j3_usergroup-delete-manager_table-before](https://user-images.githubusercontent.com/7413183/79252492-013f5f00-7e82-11ea-84cd-bd4090985690.png)

2. In backend as a super user and not being member of one of these groups, delete the usergroup "Manager", which will also delete its child group "Administrator". (You can also delete others but then it's on you to calculate the right `lft`and `rgt` values to check if this PR is right.)

3. Check again with an SQL client the content of the `#__usergroups` with the same SQL query as before.

Result: `lft`and `rgt` values in the `#__usergroups` table haven't changed for the remaining records:
![j3_usergroup-delete-manager_table-after-wrong](https://user-images.githubusercontent.com/7413183/79252888-a0fced00-7e82-11ea-9ef8-a89acff56356.png)

4. If you want to delete in the next test the same user group as in the test before: Make a new installation.

5. Apply the patch.

6. Repeat steps 2 and 3.

Result: `lft`and `rgt` values in the `#__usergroups` table have been recalculated. If you have deleted the group as described above, it should look as follows:
![j3_usergroup-delete-manager_table-after-right](https://user-images.githubusercontent.com/7413183/79252479-fa185100-7e81-11ea-86f6-a34dc31efc2b.png)

The calculation scheme is as follows for that example:
![usergroup-tree-calculation](https://user-images.githubusercontent.com/7413183/79256362-2931c100-7e88-11ea-9c53-f1b13dcb9280.jpg)

### Expected result

The `lft`and `rgt` values in the `#__usergroups` table are **correctly** recalculated.

### Actual result

The `lft`and `rgt` values in the `#__usergroups` table are **not** recalculated.

### Documentation Changes Required

None.

### Additional information

When inserting new user groups or moving some around between parent groups, the `lft`and `rgt` values in the `#__usergroups` table are recalculated without this patch using the same function, so I assume the `lft`and `rgt` values are still relevant.