### PR TITLE
[4.0] Fix deleting user groups

### DIFF
--- a/libraries/src/Table/Usergroup.php
+++ b/libraries/src/Table/Usergroup.php
@@ -248,10 +248,10 @@ class Usergroup extends Table
 
 		foreach ($ids as $id)
 		{
-			$replace[] = ',' . $db->quote("[$id,") . ',' . $db->quote('[') . ')';
-			$replace[] = ',' . $db->quote(",$id,") . ',' . $db->quote(',') . ')';
-			$replace[] = ',' . $db->quote(",$id]") . ',' . $db->quote(']') . ')';
-			$replace[] = ',' . $db->quote("[$id]") . ',' . $db->quote('[]') . ')';
+			$replace[] = ',' . $db->quote("[$id,") . ',' . $db->quote('[');
+			$replace[] = ',' . $db->quote(",$id,") . ',' . $db->quote(',');
+			$replace[] = ',' . $db->quote(",$id]") . ',' . $db->quote(']');
+			$replace[] = ',' . $db->quote("[$id]") . ',' . $db->quote('[]');
 		}
 
 		$query->clear()
@@ -280,12 +280,10 @@ class Usergroup extends Table
 
 		if (!empty($matchIds))
 		{
-			$rules = str_repeat('replace(', 4 * \count($ids)) . 'rules' . implode('', $replace);
 			$query->clear()
 				->update($db->quoteName('#__viewlevels'))
-				->set($db->quoteName('rules') . ' = :rules')
-				->whereIn($db->quoteName('id'), $matchIds)
-				->bind(':rules', $rules);
+				->set($db->quoteName('rules') . ' = ' . str_repeat('REPLACE(', 4 * \count($ids)) . $db->quoteName('rules') . implode(')', $replace) . ')')
+				->whereIn($db->quoteName('id'), $matchIds);
 			$db->setQuery($query);
 			$db->execute();
 		}


### PR DESCRIPTION
Fixes https://github.com/joomla/joomla-cms/issues/28522.

### Summary of Changes

Fixes query when deleting user groups.

### Testing Instructions

Delete `Manager` user group.

### Expected result

Group deleted and site continues to work.

### Actual result

Group deleted but site is broken, modules are missing;

> ![screen shot 2020-03-31 at 08 49 09](https://camo.githubusercontent.com/271f05701c37bb7bf7f6b539ab307ad136be0082/68747470733a2f2f6973737565732e6a6f6f6d6c612e6f72672f75706c6f6164732f312f38656333383736363265346337643764643765363061323562376637363437382e6a7067)
### Documentation Changes Required

No.