### PR TITLE
[4.0] Replace 25% & 50% width inline styles with respective classes

### DIFF
--- a/administrator/components/com_admin/tmpl/sysinfo/default_system.php
+++ b/administrator/components/com_admin/tmpl/sysinfo/default_system.php
@@ -22,7 +22,7 @@ use Joomla\CMS\Language\Text;
 		</caption>
 		<thead>
 			<tr>
-				<th scope="col" style="width:25%">
+				<th scope="col" class="w-25">
 					<?php echo Text::_('COM_ADMIN_SETTING'); ?>
 				</th>
 				<th scope="col">

--- a/administrator/components/com_contenthistory/tmpl/compare/compare.php
+++ b/administrator/components/com_contenthistory/tmpl/compare/compare.php
@@ -34,7 +34,7 @@ $wa->useScript('diff')
 		</caption>
 		<thead>
 			<tr>
-				<th scope="col" style="width:25%"><?php echo Text::_('COM_CONTENTHISTORY_PREVIEW_FIELD'); ?></th>
+				<th scope="col" class="w-25"><?php echo Text::_('COM_CONTENTHISTORY_PREVIEW_FIELD'); ?></th>
 				<th scope="col"><?php echo Text::_('COM_CONTENTHISTORY_COMPARE_OLD'); ?></th>
 				<th scope="col"><?php echo Text::_('COM_CONTENTHISTORY_COMPARE_NEW'); ?></th>
 				<th scope="col"><?php echo Text::_('COM_CONTENTHISTORY_COMPARE_DIFF'); ?></th>

--- a/administrator/components/com_contenthistory/tmpl/preview/preview.php
+++ b/administrator/components/com_contenthistory/tmpl/preview/preview.php
@@ -31,7 +31,7 @@ Session::checkToken('get') or die(Text::_('JINVALID_TOKEN'));
 		</caption>
 		<thead>
 			<tr>
-				<th style="width:25%"><?php echo Text::_('COM_CONTENTHISTORY_PREVIEW_FIELD'); ?></th>
+				<th class="w-25"><?php echo Text::_('COM_CONTENTHISTORY_PREVIEW_FIELD'); ?></th>
 				<th><?php echo Text::_('COM_CONTENTHISTORY_PREVIEW_VALUE'); ?></th>
 			</tr>
 		</thead>

--- a/administrator/components/com_templates/tmpl/templates/default.php
+++ b/administrator/components/com_templates/tmpl/templates/default.php
@@ -47,7 +47,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 								<th scope="col" style="width:10%" class="d-none d-md-table-cell text-center">
 									<?php echo Text::_('JDATE'); ?>
 								</th>
-								<th scope="col" style="width:25%" class="d-none d-md-table-cell text-center">
+								<th scope="col" class="w-25 d-none d-md-table-cell text-center">
 									<?php echo Text::_('JAUTHOR'); ?>
 								</th>
 								<?php if ($this->pluginState) : ?>

--- a/administrator/components/com_users/tmpl/users/modal.php
+++ b/administrator/components/com_users/tmpl/users/modal.php
@@ -51,7 +51,7 @@ $onClick         = "window.parent.jSelectUser(this);window.parent.Joomla.Modal.g
 					<th scope="col">
 						<?php echo HTMLHelper::_('searchtools.sort', 'COM_USERS_HEADING_NAME', 'a.name', $listDirn, $listOrder); ?>
 					</th>
-					<th scope="col" style="width:25%">
+					<th scope="col" class="w-25">
 						<?php echo HTMLHelper::_('searchtools.sort', 'JGLOBAL_USERNAME', 'a.username', $listDirn, $listOrder); ?>
 					</th>
 					<th scope="col" style="width:1%" class="text-center">
@@ -60,7 +60,7 @@ $onClick         = "window.parent.jSelectUser(this);window.parent.Joomla.Modal.g
 					<th scope="col" style="width:1%" class="text-center">
 						<?php echo HTMLHelper::_('searchtools.sort', 'COM_USERS_HEADING_ACTIVATED', 'a.activation', $listDirn, $listOrder); ?>
 					</th>
-					<th scope="col" style="width:25%">
+					<th scope="col" class="w-25">
 						<?php echo Text::_('COM_USERS_HEADING_GROUPS'); ?>
 					</th>
 					<th scope="col" style="width:1%">

--- a/administrator/modules/mod_logged/tmpl/default.php
+++ b/administrator/modules/mod_logged/tmpl/default.php
@@ -18,7 +18,7 @@ HTMLHelper::_('bootstrap.framework');
 	<caption class="sr-only"><?php echo $module->title; ?></caption>
 	<thead>
 		<tr>
-			<th scope="col" style="width:50%">
+			<th scope="col" class="w-50">
 				<?php if ($params->get('name', 1) == 0) : ?>
 					<?php echo Text::_('JGLOBAL_USERNAME'); ?>
 				<?php else : ?>


### PR DESCRIPTION
Redo of #27344 to fix conflicts and do incremental PRs for easy testing.

Thanks @chang-zhao for the initial PR.

### Summary of Changes
Replace width inline styles with classes.

`w-25` and `w-50` are Bootstrap sizing classes so no need to create these classes.

### Testing Instructions
Code review.
or
Log in to administration.
No visual changes in the following:
See `Logged-in Users` module.
See System > System Information > System Information tab