### PR TITLE
[4.0] Remove closest and matches polyfills

### DIFF
--- a/build/media_source/com_cpanel/js/admin-cpanel-default.es6.js
+++ b/build/media_source/com_cpanel/js/admin-cpanel-default.es6.js
@@ -4,24 +4,6 @@
  */
 
 ((window, document, Joomla) => {
-  let matchesFn = 'matches';
-
-  const closest = (element, selector) => {
-    let parent;
-    let el = element;
-
-    // Traverse parents
-    while (el) {
-      parent = el.parentElement;
-      if (parent && parent[matchesFn](selector)) {
-        return parent;
-      }
-      el = parent;
-    }
-
-    return null;
-  };
-
   Joomla.unpublishModule = (element) => {
     // Get variables
     const baseUrl = 'index.php?option=com_modules&task=modules.unpublish&format=json';
@@ -34,7 +16,7 @@
         'Content-Type': 'application/json',
       },
       onSuccess: () => {
-        const wrapper = closest(element, '.module-wrapper');
+        const wrapper = element.closest('.module-wrapper');
         wrapper.parentNode.removeChild(wrapper);
 
         Joomla.renderMessages({
@@ -50,15 +32,6 @@
   };
 
   const onBoot = () => {
-    // Find matchesFn with vendor prefix
-    ['matches', 'msMatchesSelector'].some((fn) => {
-      if (typeof document.body[fn] === 'function') {
-        matchesFn = fn;
-        return true;
-      }
-      return false;
-    });
-
     const cpanelModules = document.getElementById('content');
     if (cpanelModules) {
       const links = [].slice.call(cpanelModules.querySelectorAll('.unpublish-module'));

--- a/build/media_source/mod_menu/js/admin-menu.es6.js
+++ b/build/media_source/mod_menu/js/admin-menu.es6.js
@@ -27,32 +27,6 @@
     new MetisMenu(menu);
   });
 
-  const closest = (element, selector) => {
-    let matchesFn;
-    let parent;
-
-    // find vendor prefix
-    ['matches', 'msMatchesSelector'].some((fn) => {
-      if (typeof document.body[fn] === 'function') {
-        matchesFn = fn;
-        return true;
-      }
-      return false;
-    });
-
-    // Traverse parents
-    while (element) {
-      parent = element.parentElement;
-      if (parent && parent[matchesFn](selector)) {
-        return parent;
-      }
-      // eslint-disable-next-line no-param-reassign
-      element = parent;
-    }
-
-    return null;
-  };
-
   const wrapper = document.getElementById('wrapper');
   const sidebar = document.getElementById('sidebar-wrapper');
   const menuToggleIcon = document.getElementById('menu-collapse-icon');
@@ -149,8 +123,8 @@
 
         // Auto Expand Levels
         if (!link.parentNode.classList.contains('parent')) {
-          const firstLevel = closest(link, '.collapse-level-1');
-          const secondLevel = closest(link, '.collapse-level-2');
+          const firstLevel = link.closest('.collapse-level-1');
+          const secondLevel = link.closest('.collapse-level-2');
           if (firstLevel) firstLevel.parentNode.classList.add('mm-active');
           if (firstLevel) firstLevel.classList.add('mm-show');
           if (secondLevel) secondLevel.parentNode.classList.add('mm-active');

--- a/build/media_source/system/js/fields/joomla-field-subform.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-subform.w-c.es6.js
@@ -264,7 +264,7 @@
       const ids = {}; // Collect id for fix checkboxes and radio
 
       // Filter out nested
-      haveName = [].slice.call(haveName).filter(el => el.closest('joomla-field-subform') === this);
+      haveName = [].slice.call(haveName).filter((el) => el.closest('joomla-field-subform') === this);
 
       for (let i = 0, l = haveName.length; i < l; i++) {
         const $el = haveName[i];

--- a/build/media_source/system/js/fields/joomla-field-subform.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-subform.w-c.es6.js
@@ -90,7 +90,9 @@
           }
 
           if (that.buttonRemove) {
-            btnRem = event.target.matches(that.buttonRemove) ? event.target : event.target.closest(that.buttonRemove);
+            btnRem = event.target.matches(that.buttonRemove)
+              ? event.target
+              : event.target.closest(that.buttonRemove);
           }
 
           // Check actine, with extra check for nested joomla-field-subform
@@ -152,7 +154,7 @@
      * Prepare a row template
      */
     prepareTemplate() {
-      const tmplElement = [].slice.call(this.children).filter(el => el.classList.contains('subform-repeatable-template-section'));
+      const tmplElement = [].slice.call(this.children).filter((el) => el.classList.contains('subform-repeatable-template-section'));
 
       if (tmplElement[0]) {
         this.template = tmplElement[0].innerHTML;
@@ -547,12 +549,15 @@
       // Handle drag action, move element to hovered position
       this.addEventListener('dragenter', (event) => {
         // Make sure the target in the correct container
-        if (!item || that.rowsContainer && event.target.closest(that.rowsContainer) !== that.containerWithRows) {
+        if (!item || (that.rowsContainer
+          && event.target.closest(that.rowsContainer) !== that.containerWithRows)) {
           return;
         }
 
         // Find a hovered row, and replace it
-        const row = event.target.matches(that.repeatableElement) ? event.target : event.target.closest(that.repeatableElement);
+        const row = event.target.matches(that.repeatableElement)
+          ? event.target
+          : event.target.closest(that.repeatableElement);
         if (!row) return;
 
         switchRowPositions(item, row);

--- a/build/media_source/system/js/fields/joomla-field-subform.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-subform.w-c.es6.js
@@ -12,41 +12,6 @@
     ENTER: 13,
   };
 
-  // Find matchesFn with vendor prefix
-  let matchesFn = 'matches';
-  ['matches', 'msMatchesSelector'].some((fn) => {
-    if (typeof document.body[fn] === 'function') {
-      matchesFn = fn;
-      return true;
-    }
-    return false;
-  });
-
-  /**
-   * Helper to find a closest parent element
-   *
-   * @param {HTMLElement} element
-   * @param {String}      selector
-   *
-   * @returns {HTMLElement|null}
-   */
-  function closest(element, selector) {
-    let parent;
-
-    // Traverse parents
-    while (element) {
-      parent = element.parentElement;
-      if (parent && parent[matchesFn](selector)) {
-        return parent;
-      }
-
-      // eslint-disable-next-line no-param-reassign
-      element = parent;
-    }
-
-    return null;
-  }
-
   /**
    * Helper for testing whether a selection modifier is pressed
    * @param {Event} event
@@ -95,7 +60,7 @@
 
         // Find closest, and exclude nested
         for (let i = 0, l = allContainers.length; i < l; i++) {
-          if (closest(allContainers[i], 'joomla-field-subform') === this) {
+          if (allContainers[i].closest('joomla-field-subform') === this) {
             this.containerWithRows = allContainers[i];
             break;
           }
@@ -119,21 +84,21 @@
             btnRem = null;
 
           if (that.buttonAdd) {
-            btnAdd = event.target[matchesFn](that.buttonAdd) ? event.target : closest(event.target, that.buttonAdd);
+            btnAdd = event.target.matches(that.buttonAdd) ? event.target : event.target.closest(that.buttonAdd);
           }
 
           if (that.buttonRemove) {
-            btnRem = event.target[matchesFn](that.buttonRemove) ? event.target : closest(event.target, that.buttonRemove);
+            btnRem = event.target.matches(that.buttonRemove) ? event.target : event.target.closest(that.buttonRemove);
           }
 
           // Check actine, with extra check for nested joomla-field-subform
-          if (btnAdd && closest(btnAdd, 'joomla-field-subform') === that) {
-            let row = closest(btnAdd, that.repeatableElement);
-            row = closest(row, 'joomla-field-subform') === that ? row : null;
+          if (btnAdd && btnAdd.closest('joomla-field-subform') === that) {
+            let row = btnAdd.closest(that.repeatableElement);
+            row = row.closest('joomla-field-subform') === that ? row : null;
             that.addRow(row);
             event.preventDefault();
-          } else if (btnRem && closest(btnRem, 'joomla-field-subform') === that) {
-            const row = closest(btnRem, that.repeatableElement);
+          } else if (btnRem && btnRem.closest('joomla-field-subform') === that) {
+            const row = btnRem.closest(that.repeatableElement);
             that.removeRow(row);
             event.preventDefault();
           }
@@ -141,12 +106,12 @@
 
         this.addEventListener('keydown', (event) => {
           if (event.keyCode !== KEYCODE.SPACE) return;
-          const isAdd = that.buttonAdd && event.target[matchesFn](that.buttonAdd);
-          const isRem = that.buttonRemove && event.target[matchesFn](that.buttonRemove);
+          const isAdd = that.buttonAdd && event.target.matches(that.buttonAdd);
+          const isRem = that.buttonRemove && event.target.matches(that.buttonRemove);
 
-          if ((isAdd || isRem) && closest(event.target, 'joomla-field-subform') === that) {
-            let row = closest(event.target, that.repeatableElement);
-            row = closest(row, 'joomla-field-subform') === that ? row : null;
+          if ((isAdd || isRem) && event.target.closest('joomla-field-subform') === that) {
+            let row = event.target.closest(that.repeatableElement);
+            row = row.closest('joomla-field-subform') === that ? row : null;
             if (isRem && row) {
               that.removeRow(row);
             } else if (isAdd) {
@@ -169,12 +134,11 @@
      */
     getRows() {
       const rows = this.containerWithRows.children;
-      const matchesFn = document.body.msMatchesSelector ? 'msMatchesSelector' : 'matches';
       const result = [];
 
       // Filter out the rows
       for (let i = 0, l = rows.length; i < l; i++) {
-        if (rows[i][matchesFn](this.repeatableElement)) {
+        if (rows[i].matches(this.repeatableElement)) {
           result.push(rows[i]);
         }
       }
@@ -296,7 +260,7 @@
       const ids = {}; // Collect id for fix checkboxes and radio
 
       // Filter out nested
-      haveName = [].slice.call(haveName).filter(el => closest(el, 'joomla-field-subform') === this);
+      haveName = [].slice.call(haveName).filter(el => el.closest('joomla-field-subform') === this);
 
       for (let i = 0, l = haveName.length; i < l; i++) {
         const $el = haveName[i];
@@ -316,7 +280,7 @@
           countMulti = ids[id] ? ids[id].length : 0;
           if (!countMulti) {
             // Set the id for fieldset and group label
-            const fieldset = closest($el, 'fieldset.checkboxes');
+            const fieldset = $el.closest('fieldset.checkboxes');
 
 
             const elLbl = row.querySelector(`label[for="${id}"]`);
@@ -337,7 +301,7 @@
           countMulti = ids[id] ? ids[id].length : 0;
           if (!countMulti) {
             // Set the id for fieldset and group label
-            const fieldset = closest($el, 'fieldset.radio');
+            const fieldset = $el.closest('fieldset.radio');
 
 
             const elLbl = row.querySelector(`label[for="${id}"]`);
@@ -400,7 +364,7 @@
       // Helper method to test whether Handler was clicked
       function getMoveHandler(element) {
         return !element.form // This need to test whether the element is :input
-        && element[matchesFn](that.buttonMove) ? element : closest(element, that.buttonMove);
+        && element.matches(that.buttonMove) ? element : element.closest(that.buttonMove);
       }
 
       // Helper method to mover row to selected position
@@ -432,9 +396,9 @@
         const handler = getMoveHandler(event.target);
 
 
-        const row = handler ? closest(handler, that.repeatableElement) : null;
+        const row = handler ? handler.closest(that.repeatableElement) : null;
 
-        if (!row || closest(row, 'joomla-field-subform') !== that) {
+        if (!row || row.closest('joomla-field-subform') !== that) {
           return;
         }
 
@@ -469,9 +433,9 @@
         const handler = getMoveHandler(event.target);
 
 
-        const row = handler ? closest(handler, that.repeatableElement) : null;
+        const row = handler ? handler.closest(that.repeatableElement) : null;
 
-        if (!row || closest(row, 'joomla-field-subform') !== that) {
+        if (!row || row.closest('joomla-field-subform') !== that) {
           return;
         }
 
@@ -496,14 +460,14 @@
       // - "esc" to cancel selection
       this.addEventListener('keydown', (event) => {
         if ((event.keyCode !== KEYCODE.ESC && event.keyCode !== KEYCODE.SPACE && event.keyCode !== KEYCODE.ENTER)
-          || event.target.form || !event.target[matchesFn](that.repeatableElement)) {
+          || event.target.form || !event.target.matches(that.repeatableElement)) {
           return;
         }
 
         const row = event.target;
 
         // Make sure we handle correct children
-        if (!row || closest(row, 'joomla-field-subform') !== that) {
+        if (!row || row.closest('joomla-field-subform') !== that) {
           return;
         }
 
@@ -581,12 +545,12 @@
       // Handle drag action, move element to hovered position
       this.addEventListener('dragenter', (event) => {
         // Make sure the target in the correct container
-        if (!item || that.rowsContainer && closest(event.target, that.rowsContainer) !== that.containerWithRows) {
+        if (!item || that.rowsContainer && event.target.closest(that.rowsContainer) !== that.containerWithRows) {
           return;
         }
 
         // Find a hovered row, and replace it
-        const row = event.target[matchesFn](that.repeatableElement) ? event.target : closest(event.target, that.repeatableElement);
+        const row = event.target.matches(that.repeatableElement) ? event.target : event.target.closest(that.repeatableElement);
         if (!row) return;
 
         switchRowPositions(item, row);

--- a/build/media_source/system/js/fields/joomla-field-subform.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-subform.w-c.es6.js
@@ -80,11 +80,13 @@
       // Bind buttons
       if (this.buttonAdd || this.buttonRemove) {
         this.addEventListener('click', (event) => {
-          let btnAdd = null; let
-            btnRem = null;
+          let btnAdd = null;
+          let btnRem = null;
 
           if (that.buttonAdd) {
-            btnAdd = event.target.matches(that.buttonAdd) ? event.target : event.target.closest(that.buttonAdd);
+            btnAdd = event.target.matches(that.buttonAdd)
+              ? event.target
+              : event.target.closest(that.buttonAdd);
           }
 
           if (that.buttonRemove) {

--- a/build/media_source/system/js/multiselect.es6.js
+++ b/build/media_source/system/js/multiselect.es6.js
@@ -3,23 +3,6 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-// Helper function for IE11
-function getClosest(el, tag) {
-  // this is necessary since nodeName is always in upper case
-  const elementTag = tag.toUpperCase();
-  let element = el;
-  do {
-    if (element.nodeName === elementTag) {
-      // tag name is found! return
-      return element;
-    }
-    element = element.parentNode;
-  } while (element != null);
-
-  // Not found
-  return null;
-}
-
 /**
  * JavaScript behavior to allow shift select in administrator grids
  */
@@ -83,7 +66,7 @@ function getClosest(el, tag) {
         return;
       }
 
-      const currentRowNum = this.rows.indexOf((navigator.userAgent.indexOf('MSIE ') > -1 || navigator.userAgent.indexOf('Trident/') > -1) ? getClosest(event.target, 'tr') : event.target.closest('tr'));
+      const currentRowNum = this.rows.indexOf(event.target.closest('tr'));
       const currentCheckBox = this.checkallToggle ? currentRowNum + 1 : currentRowNum;
       let isChecked = this.boxes[currentCheckBox].checked;
 


### PR DESCRIPTION
Pull Request for Issue #25186

### Summary of Changes

This removes the custom polyfills for the `closest()` and `matches()` methods and replaces with the the native JS methods

### Testing Instructions

1. Ensure you can unpublish a module in the admin dashboard and it's removed
2. Ensure subform fields work as expected
3. Ensure the sidebar menu works the same as before

Or:

Code review