### PR TITLE
[4.0] Remove module from sidebar in com_config

### DIFF
--- a/administrator/components/com_config/tmpl/application/default.php
+++ b/administrator/components/com_config/tmpl/application/default.php
@@ -9,11 +9,9 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\Helper\ModuleHelper;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
-use Joomla\Registry\Registry;
 
 // Load tooltips behavior
 HTMLHelper::_('behavior.formvalidator');

--- a/administrator/components/com_config/tmpl/application/default.php
+++ b/administrator/components/com_config/tmpl/application/default.php
@@ -36,16 +36,6 @@ Text::script('MESSAGE');
 			</button>
 			<div class="sidebar-nav bg-light p-2 my-2">
 				<?php echo $this->loadTemplate('navigation'); ?>
-				<?php
-				// Display the submenu position modules
-				$this->submenumodules = ModuleHelper::getModules('submenu');
-				foreach ($this->submenumodules as $submenumodule)
-				{
-					$output = ModuleHelper::renderModule($submenumodule);
-					$params = new Registry($submenumodule->params);
-					echo $output;
-				}
-				?>
 			</div>
 		</div>
 		<!-- End Sidebar -->


### PR DESCRIPTION
Pull Request for Issue #28674 .

### Summary of Changes
Remove position sidebar frmom com_config. 


### Testing Instructions
See issue #28674. Make a update from 3.10 to 4.0 
In J4 this PR may not change anything in the backend. 


### Expected result
The updated site looks like a fresh installation of a J4 in com_config.
In J4.0 every view of com_config looks as before


### Actual result
See issue #28674. 


### Documentation Changes Required
no
