### PR TITLE
[4.0] Fix session token generation by overwrite the method from the framework

### DIFF
--- a/libraries/src/Session/Session.php
+++ b/libraries/src/Session/Session.php
@@ -15,6 +15,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
 use Joomla\CMS\Router\Route;
+use Joomla\CMS\User\UserHelper;
 use Joomla\Session\Session as BaseSession;
 
 /**
@@ -78,6 +79,20 @@ class Session extends BaseSession
 		$user = Factory::getUser();
 
 		return ApplicationHelper::getHash($user->get('id', 0) . Factory::getApplication()->getSession()->getToken($forceNew));
+	}
+
+	/**
+	 * Overwrite the framework Create a token-string method
+	 *
+	 * @param   integer  $length  Length of string
+	 *
+	 * @return  string  Generated token
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function createToken(int $length = 32): string
+	{
+		return UserHelper::genRandomPassword($length);
 	}
 
 	/**


### PR DESCRIPTION
Partial Pull Request for Issue #28465

### Summary of Changes

Make sure the 3.x and 4.x session tokens are generated in the same manner by overwriting the framework createToken method.

Please note this is **not** a fix for the session issue on upgrades.

### Testing Instructions

Make sure navigating in the backend with the session token is still working.

### Expected result

We get actually an `32` char string generated the same by 4.x and 3.x.

### Actual result

The framework does not use the UserHelper (as it is not aware of it) and just uses:
https://github.com/joomla-framework/session/blob/2.0-dev/src/Session.php#L620-L632
`bin2hex(random_bytes($length));`

### Documentation Changes Required

none

cc @SniperSister @wilsonge 