### PR TITLE
[4.0] Custom read more text accessibility

### DIFF
--- a/layouts/joomla/content/readmore.php
+++ b/layouts/joomla/content/readmore.php
@@ -26,7 +26,7 @@ $direction = Factory::getLanguage()->isRtl() ? 'left' : 'right';
 			<?php echo Text::_('COM_CONTENT_REGISTER_TO_READ_MORE'); ?>
 		</a>
 	<?php elseif ($readmore = $item->alternative_readmore) : ?>
-		<a class="btn btn-secondary" href="<?php echo $displayData['link']; ?>" itemprop="url" aria-label="<?php echo htmlspecialchars($item->title, ENT_QUOTES, 'UTF-8'); ?>">
+		<a class="btn btn-secondary" href="<?php echo $displayData['link']; ?>" itemprop="url" aria-label="<?php echo $readmore; ?> <?php echo htmlspecialchars($item->title, ENT_QUOTES, 'UTF-8'); ?>">
 			<?php echo '<span class="fas fa-chevron-' . $direction . '" aria-hidden="true"></span>'; ?>
 			<?php echo $readmore; ?>
 			<?php if ($params->get('show_readmore_title', 0) != 0) : ?>


### PR DESCRIPTION
If you look at the readmore link of an article in a blog view you will see it has an aria label of "read more: articletitle"

But when you add a custom readmore text you only get an aria label of "articletitle" instead of the expected "customreadmore: articletitle"

### setup
![image](https://user-images.githubusercontent.com/1296369/79634058-21ac3980-8160-11ea-8f69-a0969aab5f90.png)

![image](https://user-images.githubusercontent.com/1296369/79634067-3092ec00-8160-11ea-8390-01e7edf16465.png)

### Before
![image](https://user-images.githubusercontent.com/1296369/79634104-646e1180-8160-11ea-93ba-1ebe97cd8d6a.png)


### After
![image](https://user-images.githubusercontent.com/1296369/79634091-51f3d800-8160-11ea-8bc4-1e3f7388c883.png)
