### PR TITLE
[4.0] Get rid of the not used gravatar form the webauthn plugin.

### DIFF
--- a/plugins/system/webauthn/src/Helper/CredentialsCreation.php
+++ b/plugins/system/webauthn/src/Helper/CredentialsCreation.php
@@ -96,8 +96,7 @@ abstract class CredentialsCreation
 		$userEntity = new PublicKeyCredentialUserEntity(
 			$user->username,
 			$repository->getHandleFromUserId($user->id),
-			$user->name,
-			self::getAvatar($user, 64)
+			$user->name
 		);
 
 		// Challenge
@@ -355,23 +354,5 @@ abstract class CredentialsCreation
 		}
 
 		return rtrim(Uri::base(), '/') . '/' . ltrim($relFile, '/');
-	}
-
-	/**
-	 * Get the user's avatar (through Gravatar)
-	 *
-	 * @param   User  $user  The Joomla user object
-	 * @param   int   $size  The dimensions of the image to fetch (default: 64 pixels)
-	 *
-	 * @return  string  The URL to the user's avatar
-	 *
-	 * @since   4.0.0
-	 */
-	public static function getAvatar(User $user, int $size = 64)
-	{
-		$scheme = Uri::getInstance()->getScheme();
-		$subdomain = ($scheme == 'https') ? 'secure' : 'www';
-
-		return sprintf('%s://%s.gravatar.com/avatar/%s.jpg?s=%u&d=mm', $scheme, $subdomain, md5($user->email), $size);
 	}
 }


### PR DESCRIPTION
### Summary of Changes

Get rid of the not used gravatar from the webauthn plugin.

### Testing Instructions

- apply this patch
- setup webauthn
- confirm login works as expected.

### Expected result

We don't use the image from gravatar so let's not try to get one.

### Actual result

We try to get an image from gravatar that we don't use anyway.

### Documentation Changes Required

None

cc @wilsonge 