### PR TITLE
[4.0] spacer hr display

### DIFF
--- a/administrator/templates/atum/scss/vendor/bootstrap/_form.scss
+++ b/administrator/templates/atum/scss/vendor/bootstrap/_form.scss
@@ -4,17 +4,6 @@ label {
   margin-bottom: 0;
 }
 
-.spacer {
-  hr {
-    width: 380px;
-    border: 0;
-  }
-
-  label {
-    width: 440px;
-  }
-}
-
 td .form-control {
   display: inline-block;
   width: auto;


### PR DESCRIPTION
Removes the duplicated classes and the erroneous border 0 which prevents the spacer hr being displayed.  Not much point in having a line that can not be displayed

### before
![image](https://user-images.githubusercontent.com/1296369/79724896-33b4e600-82e0-11ea-8b3f-facfdaa4cafe.png)


### after
![image](https://user-images.githubusercontent.com/1296369/79724884-30215f00-82e0-11ea-9dd3-ef1d06f500cc.png)
