### PR TITLE
[4.0] - Respect the field limits for the asset table

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/4.0.0-2018-07-29.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.0.0-2018-07-29.sql
@@ -11,6 +11,7 @@ ALTER TABLE `#__finder_filters` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4
 ALTER TABLE `#__finder_filters` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 TRUNCATE TABLE `#__finder_links`;
+ALTER TABLE `#__finder_links` CHANGE `route` `route` varchar(400);
 ALTER TABLE `#__finder_links` CHANGE `language` `language` CHAR(7) NOT NULL DEFAULT '' AFTER `access`;
 ALTER TABLE `#__finder_links` MODIFY `state` int(5) NOT NULL DEFAULT 1;
 ALTER TABLE `#__finder_links` MODIFY `access` int(5) NOT NULL DEFAULT 0;

--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2018-07-29.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2018-07-29.sql
@@ -10,6 +10,7 @@ ALTER TABLE "#__finder_filters" ALTER COLUMN "checked_out_time" DROP NOT NULL;
 ALTER TABLE "#__finder_filters" ALTER COLUMN "checked_out_time" DROP DEFAULT;
 
 TRUNCATE TABLE "#__finder_links";
+ALTER TABLE "#__finder_links" ALTER COLUMN "route" TYPE character varying(400);
 ALTER TABLE "#__finder_links" ALTER COLUMN "state" SET NOT NULL;
 ALTER TABLE "#__finder_links" ALTER COLUMN "access" SET NOT NULL;
 ALTER TABLE "#__finder_links" ALTER COLUMN "language" TYPE character varying(7);

--- a/administrator/components/com_content/forms/article.xml
+++ b/administrator/components/com_content/forms/article.xml
@@ -22,6 +22,7 @@
 			label="JGLOBAL_TITLE"
 			size="40"
 			required="true"
+			maxlength="255"
 		/>
 
 		<field

--- a/administrator/components/com_content/src/Model/ArticleModel.php
+++ b/administrator/components/com_content/src/Model/ArticleModel.php
@@ -804,6 +804,12 @@ class ArticleModel extends AdminModel
 			}
 		}
 
+		if (strlen($data['title']) > 200)
+		{
+			Factory::getApplication()->enqueueMessage('title too long', 'warning');
+			return false;
+		}
+
 		return parent::validate($form, $data, $group);
 	}
 

--- a/administrator/components/com_content/src/Model/ArticleModel.php
+++ b/administrator/components/com_content/src/Model/ArticleModel.php
@@ -804,13 +804,6 @@ class ArticleModel extends AdminModel
 			}
 		}
 
-		if (strlen($data['title']) > 200)
-		{
-			Factory::getApplication()->enqueueMessage('title too long', 'warning');
-
-			return false;
-		}
-
 		return parent::validate($form, $data, $group);
 	}
 

--- a/administrator/components/com_content/src/Model/ArticleModel.php
+++ b/administrator/components/com_content/src/Model/ArticleModel.php
@@ -807,6 +807,7 @@ class ArticleModel extends AdminModel
 		if (strlen($data['title']) > 200)
 		{
 			Factory::getApplication()->enqueueMessage('title too long', 'warning');
+
 			return false;
 		}
 

--- a/installation/sql/mysql/extensions.sql
+++ b/installation/sql/mysql/extensions.sql
@@ -259,7 +259,7 @@ CREATE TABLE IF NOT EXISTS `#__finder_filters` (
 CREATE TABLE IF NOT EXISTS `#__finder_links` (
   `link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `url` varchar(255) NOT NULL,
-  `route` varchar(255) NOT NULL,
+  `route` varchar(400) NOT NULL,
   `title` varchar(400) DEFAULT NULL,
   `description` text,
   `indexdate` datetime NOT NULL,

--- a/installation/sql/postgresql/extensions.sql
+++ b/installation/sql/postgresql/extensions.sql
@@ -247,7 +247,7 @@ CREATE TABLE IF NOT EXISTS "#__finder_filters" (
 CREATE TABLE IF NOT EXISTS "#__finder_links" (
   "link_id" serial NOT NULL,
   "url" varchar(255) NOT NULL,
-  "route" varchar(255) NOT NULL,
+  "route" varchar(400) NOT NULL,
   "title" varchar(400) DEFAULT NULL,
   "description" text,
   "indexdate" timestamp without time zone NOT NULL,

--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -954,7 +954,10 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 				// Prepare the asset to be stored.
 				$asset->parent_id = $parentId;
 				$asset->name      = $name;
-				$asset->title     = $title;
+				
+				// Respect the table field limits
+				$asset->title = substr($title, 0, 100);
+
 
 				if ($this->_rules instanceof Rules)
 				{

--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -954,10 +954,9 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 				// Prepare the asset to be stored.
 				$asset->parent_id = $parentId;
 				$asset->name      = $name;
-				
+
 				// Respect the table field limits
 				$asset->title = substr($title, 0, 100);
-
 
 				if ($this->_rules instanceof Rules)
 				{

--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -21,6 +21,7 @@ use Joomla\Database\DatabaseQuery;
 use Joomla\Event\DispatcherAwareInterface;
 use Joomla\Event\DispatcherAwareTrait;
 use Joomla\Event\DispatcherInterface;
+use Joomla\String\StringHelper;
 
 /**
  * Abstract Table class
@@ -956,7 +957,7 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 				$asset->name      = $name;
 
 				// Respect the table field limits
-				$asset->title = substr($title, 0, 100);
+				$asset->title = StringHelper::substr($title, 0, 100);
 
 				if ($this->_rules instanceof Rules)
 				{


### PR DESCRIPTION
Pull Request for Issue #27673 (about the title length issue)

### Summary of Changes

Respect the field limits for the asset table and give an error if not true

### Testing Instructions
create a very long article title that is more than 100 chars



### Expected result
warning if the article length is more higher than allowed

### Actual result

error  after saving


