### PR TITLE
[4.0] com contact select field groups

### DIFF
--- a/administrator/components/com_contact/config.xml
+++ b/administrator/components/com_contact/config.xml
@@ -331,6 +331,7 @@
 			multiple="true"
 			context="com_users.user"
 			addfieldprefix="Joomla\Component\Fields\Administrator\Field"
+			layout="joomla.form.field.list-fancy-select"
 			>
 			<option value="-1">JALL</option>
 		</field>

--- a/administrator/components/com_contact/forms/contact.xml
+++ b/administrator/components/com_contact/forms/contact.xml
@@ -655,6 +655,7 @@
 					multiple="true"
 					context="com_users.user"
 					addfieldprefix="Joomla\Component\Fields\Administrator\Field"
+					layout="joomla.form.field.list-fancy-select"
 					>
 					<option value="-1">JALL</option>
 				</field>


### PR DESCRIPTION
Simple pr to use the correct layout for this field as it is a multi select. without this it may not be possible to see all the selected field groups

This can be seen in the contact component options

### before
![image](https://user-images.githubusercontent.com/1296369/79832447-5eb33e80-83a1-11ea-99d6-a66d35a5c644.png)


### after
![image](https://user-images.githubusercontent.com/1296369/79832435-5a872100-83a1-11ea-9207-7b4d946664a1.png)
