### PR TITLE
Revert "[3.x] Adding New article button in category blog layout"

### DIFF
--- a/components/com_content/views/category/tmpl/blog.php
+++ b/components/com_content/views/category/tmpl/blog.php
@@ -134,9 +134,4 @@ $afterDisplayContent = trim(implode("\n", $results));
 			<?php endif; ?>
 			<?php echo $this->pagination->getPagesLinks(); ?> </div>
 	<?php endif; ?>
-
-	<?php // Code to add a link to submit an article. ?>
-	<?php if ($this->category->getParams()->get('access-create')) : ?>
-		<?php echo JHtml::_('icon.create', $this->category, $this->category->params); ?>
-	<?php endif; ?>
 </div>


### PR DESCRIPTION
Since this PR breaks one joomla.org property because $this->category is a stdClass and not a categoryNode object I revert it.

After release I will try to find the reason for this.