### PR TITLE
Fix tags single instance view

### DIFF
--- a/components/com_tags/models/tag.php
+++ b/components/com_tags/models/tag.php
@@ -342,6 +342,9 @@ class TagsModelTag extends JModelList
 			$table = JTable::getInstance('Tag', 'TagsTable');
 			$table->hit($pk);
 
+			// Load the table data for later
+			$table->load($pk);
+
 			if (!$table->hasPrimaryKey())
 			{
 				JError::raiseError(404, JText::_('COM_TAGS_TAG_NOT_FOUND'));


### PR DESCRIPTION
### Summary of Changes
Single tags view creates a 404 when viewing a tag. Introduced in #28610 

Whilst `hit` doesn't need to load the article `hasPrimaryKey` a few lines later does.

### Testing Instructions
View a single tag in the frontend. Before the patch tag view 404's. afterwards doesn't. 

### Documentation Changes Required
None
