### PR TITLE
Ensure Itemid is never an array

### DIFF
--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -192,6 +192,28 @@ class CMSApplication extends WebApplication
 	 */
 	public function execute()
 	{
+		$input = $this->input;
+
+		// Get invalid input variables
+		$invalidInputVariables = array_filter(
+			array('option', 'view', 'format', 'lang', 'Itemid', 'template', 'templateStyle', 'task'),
+			function($systemVariable) use ($input) {
+				return $input->exists($systemVariable) && is_array($input->getRaw($systemVariable));
+			}
+		);
+
+		// Unset invalid system variables
+		foreach ($invalidInputVariables as $systemVariable)
+		{
+			$input->set($systemVariable, null);
+		}
+
+		// Abort when there are invalid variables
+		if ($invalidInputVariables)
+		{
+			throw new \RuntimeException('Invalid input, aborting application.');
+		}
+
 		// Perform application routines.
 		$this->doExecute();
 


### PR DESCRIPTION
Pull Request for pr #28481.

### Summary of Changes
This is an alternative to pr #28481 where the Itemid is checked early in the process if it is an array and then the first item of the array is used.

I did choose the initialiseApp function to make the check, perhaps there are better places. Happy to get opinions.

### Testing Instructions
- Set SEF urls to No in the global Joomla configuration
- Create a blog menu item
- Create a module and assign it to the blog menu item only
- Open the front blog menu item
- Replace in the url Itemid=xx with Itemid[]=xx (where xx is the id of the menu item)

### Expected result
Page loads correctly and the module is shown.

### Actual result
Some PHP warnings like _Illegal offset type in isset or empty_ are thrown.

### Documentation Changes Required
It should be noted that the Itemid is always an integer.
