### PR TITLE
[4.0] Installation: preventing translation of the "installation" folder

### DIFF
--- a/installation/language/en-GB/joomla.ini
+++ b/installation/language/en-GB/joomla.ini
@@ -102,16 +102,14 @@ INSTL_SITE_NAME_DESC="Enter the name of your Joomla site."
 INSTL_COMPLETE_ADMINISTRATION_LOGIN_DETAILS="Administration Login Details"
 ; The word 'installation' should not be translated as it is a physical folder.
 INSTL_COMPLETE_ERROR_FOLDER_ALREADY_REMOVED="The installation folder has already been deleted."
-; The word 'installation' should not be translated as it is a physical folder.
-INSTL_COMPLETE_ERROR_FOLDER_DELETE="Installation folder could not be deleted. Please manually delete the folder."
+INSTL_COMPLETE_ERROR_FOLDER_DELETE="The \"%s\" folder could not be deleted. Please manually delete the folder."
 ; The word 'installation' should not be translated as it is a physical folder.
 INSTL_COMPLETE_FOLDER_REMOVED="Installation folder removed."
 INSTL_COMPLETE_LANGUAGE_1="Joomla in your own language and/or automatic basic native multilingual site creation"
 ; The word 'installation' should not be translated as it is a physical folder.
 INSTL_COMPLETE_LANGUAGE_DESC="Before removing the installation folder you can install extra languages. If you want to add extra languages to your Joomla application select the following button."
 INSTL_COMPLETE_LANGUAGE_DESC2="Note: you will need internet access for Joomla to download and install the new languages. <br>Some server configurations won't allow Joomla to install the languages. If this is your case, don't worry, you will be able to install them later using the Joomla Administrator."
-; The word 'installation' should not be translated as it is a physical folder.
-INSTL_COMPLETE_REMOVE_FOLDER="Remove installation folder"
+INSTL_COMPLETE_REMOVE_FOLDER="Remove \"%s\" folder"
 ; The word 'installation' should not be translated as it is a physical folder.
 INSTL_COMPLETE_REMOVE_INSTALLATION="PLEASE REMEMBER TO COMPLETELY REMOVE THE INSTALLATION FOLDER.<br>You will not be able to proceed beyond this point until the installation folder has been removed. This is a security feature of Joomla"
 INSTL_COMPLETE_CONGRAT="Congratulations!"
@@ -123,7 +121,7 @@ INSTL_COMPLETE_ADMIN_BTN="Complete & Open Admin"
 INSTL_COMPLETE_FINAL="Installation is Complete"
 INSTL_COMPLETE_FINAL_DESC="Your Joomla installation is now complete and ready to use."
 INSTL_COMPLETE_ADD_EXTRA_LANGUAGE="Install Additional Languages"
-INSTL_REMOVE_INST_FOLDER="Are you sure you want to delete? Confirming will permanently delete the installation folder."
+INSTL_REMOVE_INST_FOLDER="Are you sure you want to delete? Confirming will permanently delete the \"%s\" folder."
 
 ;Languages view
 INSTL_LANGUAGES="Install Additional Languages"

--- a/installation/language/en-US/joomla.ini
+++ b/installation/language/en-US/joomla.ini
@@ -102,16 +102,14 @@ INSTL_SITE_NAME_DESC="Enter the name of your Joomla site."
 INSTL_COMPLETE_ADMINISTRATION_LOGIN_DETAILS="Administration Login Details"
 ; The word 'installation' should not be translated as it is a physical folder.
 INSTL_COMPLETE_ERROR_FOLDER_ALREADY_REMOVED="The installation folder has already been deleted."
-; The word 'installation' should not be translated as it is a physical folder.
-INSTL_COMPLETE_ERROR_FOLDER_DELETE="Installation folder could not be deleted. Please manually delete the folder."
+INSTL_COMPLETE_ERROR_FOLDER_DELETE="The \"%s\" folder could not be deleted. Please manually delete the folder."
 ; The word 'installation' should not be translated as it is a physical folder.
 INSTL_COMPLETE_FOLDER_REMOVED="Installation folder removed."
 INSTL_COMPLETE_LANGUAGE_1="Joomla in your own language and/or automatic basic native multilingual site creation"
 ; The word 'installation' should not be translated as it is a physical folder.
 INSTL_COMPLETE_LANGUAGE_DESC="Before removing the installation folder you can install extra languages. If you want to add extra languages to your Joomla application select the following button."
 INSTL_COMPLETE_LANGUAGE_DESC2="Note: you will need internet access for Joomla to download and install the new languages. <br>Some server configurations won't allow Joomla to install the languages. If this is your case, don't worry, you will be able to install them later using the Joomla Administrator."
-; The word 'installation' should not be translated as it is a physical folder.
-INSTL_COMPLETE_REMOVE_FOLDER="Remove installation folder"
+INSTL_COMPLETE_REMOVE_FOLDER="Remove \"%s\" folder"
 ; The word 'installation' should not be translated as it is a physical folder.
 INSTL_COMPLETE_REMOVE_INSTALLATION="PLEASE REMEMBER TO COMPLETELY REMOVE THE INSTALLATION FOLDER.<br>You will not be able to proceed beyond this point until the installation folder has been removed. This is a security feature of Joomla"
 INSTL_COMPLETE_CONGRAT="Congratulations!"
@@ -123,7 +121,7 @@ INSTL_COMPLETE_ADMIN_BTN="Complete & Open Admin"
 INSTL_COMPLETE_FINAL="Installation is Complete"
 INSTL_COMPLETE_FINAL_DESC="Your Joomla installation is now complete and ready to use."
 INSTL_COMPLETE_ADD_EXTRA_LANGUAGE="Install Additional Languages"
-INSTL_REMOVE_INST_FOLDER="Are you sure you want to delete? Confirming will permanently delete the installation folder."
+INSTL_REMOVE_INST_FOLDER="Are you sure you want to delete? Confirming will permanently delete the \"%s\" folder."
 
 ;Languages view
 INSTL_LANGUAGES="Install Additional Languages"

--- a/installation/template/js/remove.js
+++ b/installation/template/js/remove.js
@@ -29,7 +29,7 @@ if (document.getElementById('removeInstallationFolder')) {
 	document.getElementById('removeInstallationFolder')
 		.addEventListener('click', function (e) {
 			e.preventDefault();
-			let confirm = window.confirm(Joomla.Text._('INSTL_REMOVE_INST_FOLDER'));
+			let confirm = window.confirm(Joomla.Text._('INSTL_REMOVE_INST_FOLDER').replace('%s', 'installation'));
 			if (confirm) {
 				Joomla.request({
 					method: "POST",

--- a/installation/tmpl/remove/default.php
+++ b/installation/tmpl/remove/default.php
@@ -182,7 +182,7 @@ HTMLHelper::_('behavior.formvalidator');
 				<?php if ($this->development) : ?>
 					<div class="alert flex-column mb-1" id="removeInstallationTab">
 						<span class="mb-1 font-weight-bold"><?php echo Text::_('INSTL_SITE_DEVMODE_LABEL'); ?></span>
-						<button class="btn btn-danger mb-1" id="removeInstallationFolder"><?php echo Text::_('INSTL_COMPLETE_REMOVE_FOLDER'); ?></button>
+						<button class="btn btn-danger mb-1" id="removeInstallationFolder"><?php echo Text::sprintf('INSTL_COMPLETE_REMOVE_FOLDER', 'installation'); ?></button>
 					</div>
 				<?php endif; ?>
 				<?php echo HTMLHelper::_('form.token'); ?>


### PR DESCRIPTION
### Summary of Changes
As done in 3.x, this PR hardcodes the name of the `installation` folder to prevent translating it.
See code change
### Testing Instructions
Patch and install J4

### After PR
<img width="620" alt="Screen Shot 2020-04-22 at 09 06 32" src="https://user-images.githubusercontent.com/869724/79951436-f768bd80-8478-11ea-988f-04765cce0725.png">
<img width="644" alt="Screen Shot 2020-04-22 at 09 06 17" src="https://user-images.githubusercontent.com/869724/79951438-f8015400-8478-11ea-87b0-c4b01d08239f.png">

### Note
Still remains in the installation ini files 4 strings containing the wording `installation folder`.
They are not used in J4 at this time but may be in the future. Therefore I have not deleted them.
The decision about them should be taken during beta phase.

@brianteeman 
