### PR TITLE
[4.0] Remove obsolete string

### DIFF
--- a/administrator/language/en-GB/plg_fields_sql.ini
+++ b/administrator/language/en-GB/plg_fields_sql.ini
@@ -10,5 +10,4 @@ PLG_FIELDS_SQL_PARAMS_MULTIPLE_LABEL="Multiple"
 ; In the string below the terms 'value' and 'text' should not be translated
 PLG_FIELDS_SQL_PARAMS_QUERY_DESC="The SQL query which will provide the data for the dropdown list. The query must return two columns; one called 'value' which will hold the values of the list items; the other called 'text' with the text in the dropdown list."
 PLG_FIELDS_SQL_PARAMS_QUERY_LABEL="Query"
-PLG_FIELDS_SQL_RULES_ADAPTED="For increased security the edit permission for this SQL field was set to denied for all non Super Users."
 PLG_FIELDS_SQL_XML_DESCRIPTION="This plugin lets you create new fields of type 'sql' in any extensions where custom fields are supported."


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/28745

### Summary of Changes
- Remove lang string PLG_FIELDS_SQL_RULES_ADAPTED because no longer used since J3.9.16

### Testing Instructions
- Search in core files for string PLG_FIELDS_SQL_RULES_ADAPTED.
- Only used once and only in ini file.
