### PR TITLE
Adjust en-GB.localise.php with string based suffixes

### DIFF
--- a/administrator/language/en-GB/en-GB.localise.php
+++ b/administrator/language/en-GB/en-GB.localise.php
@@ -32,11 +32,11 @@ abstract class En_GBLocalise
 		}
 		elseif ($count == 1)
 		{
-			return array('1');
+			return array('ONE', '1');
 		}
 		else
 		{
-			return array('MORE');
+			return array('OTHER', 'MORE');
 		}
 	}
 

--- a/language/en-GB/en-GB.localise.php
+++ b/language/en-GB/en-GB.localise.php
@@ -32,11 +32,11 @@ abstract class En_GBLocalise
 		}
 		elseif ($count == 1)
 		{
-			return array('1');
+			return array('ONE', '1');
 		}
 		else
 		{
-			return array('MORE');
+			return array('OTHER', 'MORE');
 		}
 	}
 

--- a/tests/unit/suites/libraries/joomla/language/JLanguageTest.php
+++ b/tests/unit/suites/libraries/joomla/language/JLanguageTest.php
@@ -281,7 +281,7 @@ class JLanguageTest extends \PHPUnit\Framework\TestCase
 		);
 
 		$this->assertEquals(
-			array('1'),
+			array('ONE', '1'),
 			$this->object->getPluralSuffixes(1),
 			'Line: ' . __LINE__
 		);


### PR DESCRIPTION
Currently, most language packs as well as Crowdin use numbered suffixes for their various plural forms. Meaning they just start with _1 and go up for each form (eg _2, _3, _4 if they have four forms).
While in english this works fine since the suffix actually matches the amount (eg _1 is for "one item"), this fails for languages like Welsh which has more complex plural forms.

The reason for the failing is that Joomla actually first tries to match with the amount before it actually looks up the plural string as defined in the localise.php of the active language pack.

I had a chat with Crowdin how this could be solved and they wrote a solution especially for us which allows to use string based suffixes instead of numbers. Those suffixes will follow the suggestions from http://cldr.unicode.org/index/cldr-spec/plural-rules and http://www.unicode.org/cldr/charts/latest/supplemental/language_plural_rules.html. It's also how they already name the forms in their UI:
![image](https://user-images.githubusercontent.com/1018684/80021882-80184580-84db-11ea-97eb-5fed19313fc7.png)

### Summary of Changes
This PR changes the en-GB.localise.php "getPluralSuffixes" method so Joomla will be able to cope with this string based suffixes. The method already supported returning more than one suffix, so this PR just adds the new strings to the existing ones, being completely backward compatible.

Important: This PR doesn't change the actual language strings as this is neither needed for Crowdin nor for english.

### Testing Instructions
Simplest test is to publish/unpublish articles in the english backend.
It has to work exactly like before, eg "1 article published" and "3 articles published".

An advanced test would be to add custom language overrides like this
![image](https://user-images.githubusercontent.com/1018684/80022375-43008300-84dc-11ea-887f-8342fa769aad.png)


### Expected result
* The suffix `_7` is used if exactly 7 articles are published
* The suffix `_ONE` is not used since there exists an exact matching string (`_1`). If you'd delete the string `COM_CONTENT_N_ITEMS_PUBLISHED_1`, that suffix _ONE would be used.
* The suffix `_OTHER` is used when 2 - 6 or 8+ articles are published.


### Actual result
* The suffix `_7` is used if exactly 7 articles are published
* The suffix `_ONE` and `_OTHER` are not used



### Documentation Changes Required
Once this is merged I will tell Crowdin to activate this new feature.
TTs using Crowdin will have to adjust their localise.php files with the same type of change.
I will be able to support them in Crowdin doing that.
