### PR TITLE
[4.0] pull-right is not a bs4 class (frontend)

### DIFF
--- a/components/com_newsfeeds/tmpl/newsfeed/default.php
+++ b/components/com_newsfeeds/tmpl/newsfeed/default.php
@@ -72,7 +72,7 @@ use Joomla\CMS\Layout\FileLayout;
 
 		<?php if (isset($images->image_second) and !empty($images->image_second)) : ?>
 			<?php $imgfloat = empty($images->float_second) ? $this->params->get('float_second') : $images->float_second; ?>
-			<div class="com-newsfeeds-newsfeed__second-image pull-<?php echo htmlspecialchars($imgfloat, ENT_COMPAT, 'UTF-8'); ?> item-image">
+			<div class="com-newsfeeds-newsfeed__second-image float-<?php echo htmlspecialchars($imgfloat, ENT_COMPAT, 'UTF-8'); ?> item-image">
 				<img
 				<?php if ($images->image_second_caption) : ?>
 					<?php echo 'class="caption" title="' . htmlspecialchars($images->image_second_caption) . '"'; ?>

--- a/layouts/joomla/content/full_image.php
+++ b/layouts/joomla/content/full_image.php
@@ -14,7 +14,7 @@ $images  = json_decode($displayData->images);
 ?>
 <?php if (!empty($images->image_fulltext)) : ?>
 	<?php $imgfloat = empty($images->float_fulltext) ? $params->get('float_fulltext') : $images->float_fulltext; ?>
-	<figure class="pull-<?php echo htmlspecialchars($imgfloat, ENT_COMPAT, 'UTF-8'); ?> item-image">
+	<figure class="float-<?php echo htmlspecialchars($imgfloat, ENT_COMPAT, 'UTF-8'); ?> item-image">
 		<img src="<?php echo htmlspecialchars($images->image_fulltext, ENT_COMPAT, 'UTF-8'); ?>"
 			 alt="<?php echo htmlspecialchars($images->image_fulltext_alt, ENT_COMPAT, 'UTF-8'); ?>"
 			 itemprop="image"/>

--- a/layouts/joomla/content/intro_image.php
+++ b/layouts/joomla/content/intro_image.php
@@ -17,7 +17,7 @@ $images  = json_decode($displayData->images);
 ?>
 <?php if (!empty($images->image_intro)) : ?>
 	<?php $imgfloat = empty($images->float_intro) ? $params->get('float_intro') : $images->float_intro; ?>
-	<figure class="pull-<?php echo htmlspecialchars($imgfloat, ENT_COMPAT, 'UTF-8'); ?> item-image">
+	<figure class="float-<?php echo htmlspecialchars($imgfloat, ENT_COMPAT, 'UTF-8'); ?> item-image">
 		<?php if ($params->get('link_titles') && $params->get('access-view')) : ?>
 			<a href="<?php echo Route::_(RouteHelper::getArticleRoute($displayData->slug, $displayData->catid, $displayData->language)); ?>">
 				<img src="<?php echo htmlspecialchars($images->image_intro, ENT_COMPAT, 'UTF-8'); ?>"


### PR DESCRIPTION
When you include an image you have the option to float the image left or right. this adds the class pull-left to the image. In BS4 we dont use pull- instead it is float-

Add an image to an article and select image float right

![image](https://user-images.githubusercontent.com/1296369/80024512-1b5aec00-84d7-11ea-84ce-501abada9481.png)


View on the front end

### before
![image](https://user-images.githubusercontent.com/1296369/80024588-36c5f700-84d7-11ea-96b0-a8ad3103751f.png)


### after
![image](https://user-images.githubusercontent.com/1296369/80024545-23b32700-84d7-11ea-9b83-b948fd0d98cc.png)
