### PR TITLE
[3.9] Fix types of `registerDate` and `lastvisitDate` in Documentation

### DIFF
--- a/libraries/src/User/User.php
+++ b/libraries/src/User/User.php
@@ -98,7 +98,7 @@ class User extends \JObject
 	/**
 	 * Date the user was registered
 	 *
-	 * @var    \DateTime
+	 * @var    string
 	 * @since  1.7.0
 	 */
 	public $registerDate = null;
@@ -106,7 +106,7 @@ class User extends \JObject
 	/**
 	 * Date of last visit
 	 *
-	 * @var    \DateTime
+	 * @var    string
 	 * @since  1.7.0
 	 */
 	public $lastvisitDate = null;


### PR DESCRIPTION
Pull Request for Issue #28765.

### Summary of Changes

Change the type of `registerDate` and `lastvisitDate` from `\DateTime` to `string` inside the DocBlocks of `\Joomla\CMS\User\User`.

### Testing Instructions

We should verify that `registerDate` and `lastvisitDate` really are strings regardless of e.g. the database driver.

[jtest.zip](https://github.com/joomla/joomla-cms/files/4524616/jtest.zip) is a simple user plugin that can be used for testing. Just install and enable it, then the types of the current user object are shown on each login.

### Expected result

The message should contain:

    lastvisitDate: string
    registerDate: string

### Actual result

I tested this on J3.9.18 using MySQLi as well as J3.9.18 using MySQL PDO and in both cases the actual result was as expected.

### Documentation Changes Required

Well, these are the (API) documentation changes.