### PR TITLE
[4.0] Remove deprecated client handling from the updater extension adapter class

### DIFF
--- a/libraries/src/Updater/Adapter/ExtensionAdapter.php
+++ b/libraries/src/Updater/Adapter/ExtensionAdapter.php
@@ -331,21 +331,7 @@ class ExtensionAdapter extends UpdateAdapter
 		{
 			if (isset($this->latest->client) && \strlen($this->latest->client))
 			{
-				if (is_numeric($this->latest->client))
-				{
-					$byName = false;
-
-					// <client> has to be 'administrator' or 'site', numeric values are deprecated. See https://docs.joomla.org/Special:MyLanguage/Design_of_JUpdate
-					Log::add(
-						'Using numeric values for <client> in the updater xml is deprecated. Use \'administrator\' or \'site\' instead.',
-						Log::WARNING, 'deprecated'
-					);
-				}
-				else
-				{
-					$byName = true;
-				}
-
+				$byName = true;
 				$this->latest->client_id = ApplicationHelper::getClientInfo($this->latest->client, $byName)->id;
 				unset($this->latest->client);
 			}

--- a/libraries/src/Updater/Adapter/ExtensionAdapter.php
+++ b/libraries/src/Updater/Adapter/ExtensionAdapter.php
@@ -331,8 +331,8 @@ class ExtensionAdapter extends UpdateAdapter
 		{
 			if (isset($this->latest->client) && \strlen($this->latest->client))
 			{
-				$byName = true;
-				$this->latest->client_id = ApplicationHelper::getClientInfo($this->latest->client, $byName)->id;
+				$this->latest->client_id = ApplicationHelper::getClientInfo($this->latest->client, true)->id;
+
 				unset($this->latest->client);
 			}
 


### PR DESCRIPTION
### Summary of Changes

Remove deprecated client handling from the updater extension adapter class

### Testing Instructions

- install an outdated version of any extension
- make sure you can update it.
- apply this patch
- install another outdated version on an extension
- make sure you can stull update
- install an outdated extension that still uses the numeric client stuff
- confirm that now breaks as expected.

### Expected result

the client value only accepts site and administrator and no numeric id any more

### Actual result

there is still lagacy behavior in the extensionadapter class.

### Documentation Changes Required

This has to be documented as B/C break.

cc @wilsonge IIRC this has to go in before beta when accepted right?