### PR TITLE
Namespace User - Joomla API Token plugin

### DIFF
--- a/plugins/user/token/forms/token.xml
+++ b/plugins/user/token/forms/token.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <form>
-	<fields name="joomlatoken" addfieldpath="/plugins/user/token/field">
+	<fields name="joomlatoken" addfieldprefix="Joomla\Plugin\User\Token\Field">
 		<fieldset
 			name="joomlatoken"
 			label="PLG_USER_TOKEN_GROUP_LABEL"

--- a/plugins/user/token/src/Field/JoomlatokenField.php
+++ b/plugins/user/token/src/Field/JoomlatokenField.php
@@ -7,36 +7,38 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
+namespace Joomla\Plugin\User\Token\Field;
+
+\defined('_JEXEC') or die;
+
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Field\TextField;
 
-defined('_JEXEC') or die;
-
 /**
- * Class JFormFieldJoomlatoken
+ * Joomlatoken field class
  *
  * @since  4.0
  */
-class JFormFieldJoomlatoken extends TextField
+class JoomlatokenField extends TextField
 {
 	/**
 	 * Method to attach a Form object to the field.
 	 *
-	 * @param   SimpleXMLElement  $element   The SimpleXMLElement object representing the `<field>`
-	 *                                       tag for the form field object.
-	 * @param   mixed             $value     The form field value to validate.
-	 * @param   string            $group     The field name group control value. This acts as an
-	 *                                       array container for the field. For example if the
-	 *                                       field has name="foo" and the group value is set to
-	 *                                       "bar" then the full field name would end up being
-	 *                                       "bar[foo]".
+	 * @param   \SimpleXMLElement  $element   The SimpleXMLElement object representing the `<field>`
+	 *                                        tag for the form field object.
+	 * @param   mixed             $value      The form field value to validate.
+	 * @param   string            $group      The field name group control value. This acts as an
+	 *                                        array container for the field. For example if the
+	 *                                        field has name="foo" and the group value is set to
+	 *                                        "bar" then the full field name would end up being
+	 *                                        "bar[foo]".
 	 *
 	 * @return  boolean  True on success.
 	 *
 	 * @see     FormField::setup()
 	 * @since   4.0.0
 	 */
-	public function setup(SimpleXMLElement $element, $value, $group = null)
+	public function setup(\SimpleXMLElement $element, $value, $group = null)
 	{
 		$ret = parent::setup($element, $value, $group);
 
@@ -99,7 +101,7 @@ class JFormFieldJoomlatoken extends TextField
 		{
 			$siteSecret = Factory::getApplication()->get('secret');
 		}
-		catch (Exception $e)
+		catch (\Exception $e)
 		{
 			$siteSecret = '';
 		}

--- a/plugins/user/token/token.php
+++ b/plugins/user/token/token.php
@@ -214,7 +214,7 @@ class PlgUserToken extends CMSPlugin
 		}
 
 		// Add the registration fields to the form.
-		Form::addFormPath(dirname(__FILE__) . '/token');
+		Form::addFormPath(__DIR__ . '/forms');
 		$form->loadFile('token', false);
 
 		// No token: no reset

--- a/plugins/user/token/token.xml
+++ b/plugins/user/token/token.xml
@@ -9,10 +9,11 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.9.0</version>
 	<description>PLG_USER_TOKEN_XML_DESCRIPTION</description>
+	<namespace path="src">Joomla\Plugin\User\Token</namespace>
 	<files>
 		<filename plugin="token">token.php</filename>
-		<folder>field</folder>
-		<folder>token</folder>
+		<folder>forms</folder>
+		<folder>src</folder>
 	</files>
 	<languages>
 		<language tag="en-GB">plg_user_token.ini</language>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Namespaces User - Joomla API Token plugin.

### Testing Instructions

Before applying patch:

Make sure User - `Joomla API Token plugin` is enabled.
Edit your profile in backend to generate token.

Apply patch. Delete `administrator/cache/autoload_psr4.php` file.
View your profile.
Check that the same token is displayed as before.

### Expected result

Works like before.

### Documentation Changes Required

No.