### PR TITLE
[3.10] Add the explanation about the compatibility tag to the pre update checker

### DIFF
--- a/administrator/language/en-GB/en-GB.com_joomlaupdate.ini
+++ b/administrator/language/en-GB/en-GB.com_joomlaupdate.ini
@@ -44,7 +44,7 @@ COM_JOOMLAUPDATE_VIEW_COMPLETE_MESSAGE="Your site has been updated. Your Joomla 
 COM_JOOMLAUPDATE_VIEW_DEFAULT_ACTUAL="Actual"
 COM_JOOMLAUPDATE_VIEW_DEFAULT_COMPATIBILITY_CHECK="Joomla! %s Compatibility Check"
 COM_JOOMLAUPDATE_VIEW_DEFAULT_DESCRIPTION_BREAK="Extensions marked with <span class='label label-important'>No</span> or <span class='label'>Missing Compatibility Tag</span> might break your website. Please consult with the developer before upgrading."
-COM_JOOMLAUPDATE_VIEW_DEFAULT_DESCRIPTION_MISSING_TAG="Extensions marked with <span class='label'>Missing Compatibility Tag</span> indicate the developer did not add a compatibility tag in the respective extension's XML."
+COM_JOOMLAUPDATE_VIEW_DEFAULT_DESCRIPTION_MISSING_TAG="Extensions marked with <span class='label'>Missing Compatibility Tag</span> indicate the developer did not add a <a href='https://docs.joomla.org/Special:MyLanguage/Deploying_an_Update_Server' target='_blank' rel='noopener noreferrer'>compatibility tag in the respective extension's XML.</a>"
 COM_JOOMLAUPDATE_VIEW_DEFAULT_DESCRIPTION_UPDATE_REQUIRED="Extensions marked with <span class='label label-warning'>Yes (X.X.X)</span> might require an update."
 COM_JOOMLAUPDATE_VIEW_DEFAULT_DIRECTIVE="Directive"
 COM_JOOMLAUPDATE_VIEW_DEFAULT_DOWNLOAD_IN_PROGRESS="Downloading update file. Please wait ..."

--- a/administrator/language/en-GB/en-GB.com_joomlaupdate.ini
+++ b/administrator/language/en-GB/en-GB.com_joomlaupdate.ini
@@ -44,7 +44,7 @@ COM_JOOMLAUPDATE_VIEW_COMPLETE_MESSAGE="Your site has been updated. Your Joomla 
 COM_JOOMLAUPDATE_VIEW_DEFAULT_ACTUAL="Actual"
 COM_JOOMLAUPDATE_VIEW_DEFAULT_COMPATIBILITY_CHECK="Joomla! %s Compatibility Check"
 COM_JOOMLAUPDATE_VIEW_DEFAULT_DESCRIPTION_BREAK="Extensions marked with <span class='label label-important'>No</span> or <span class='label'>Missing Compatibility Tag</span> might break your website. Please consult with the developer before upgrading."
-COM_JOOMLAUPDATE_VIEW_DEFAULT_DESCRIPTION_MISSING_TAG="Extensions marked with <span class='label'>Missing Compatibility Tag</span> indicate the developer did not add a <a href='https://docs.joomla.org/Special:MyLanguage/Deploying_an_Update_Server' target='_blank' rel='noopener noreferrer'>compatibility tag in the respective extension's XML.</a>"
+COM_JOOMLAUPDATE_VIEW_DEFAULT_DESCRIPTION_MISSING_TAG="Extensions marked with <span class='label'>Missing Compatibility Tag</span> indicate the developer has not included <a href='https://docs.joomla.org/Special:MyLanguage/Deploying_an_Update_Server' target='_blank' rel='noopener noreferrer'>compatibility information.</a>"
 COM_JOOMLAUPDATE_VIEW_DEFAULT_DESCRIPTION_UPDATE_REQUIRED="Extensions marked with <span class='label label-warning'>Yes (X.X.X)</span> might require an update."
 COM_JOOMLAUPDATE_VIEW_DEFAULT_DIRECTIVE="Directive"
 COM_JOOMLAUPDATE_VIEW_DEFAULT_DOWNLOAD_IN_PROGRESS="Downloading update file. Please wait ..."


### PR DESCRIPTION
### Summary of Changes

Add the explanation about the compatibility tag to the pre update checker. Thanks @bayareajenn

### Testing Instructions

- install 3.10-dev
- install one extension (example: https://github.com/zero-24/plg_content_imagelazyloading/releases/download/1.0.0/plg_content_imagelazyloading.zip)
- set the core update server url to: https://update.joomla.org/core/nightlies/next_major_list.xml
- check the legend about the missing compatibility tag.

### Expected result

![image](https://user-images.githubusercontent.com/2596554/80157501-9ea73b00-85c6-11ea-8456-d2dee6f472dc.png)


### Actual result

![image](https://user-images.githubusercontent.com/2596554/80157334-3eb09480-85c6-11ea-8d25-a8b068a2a63d.png)


### Documentation Changes Required

none