### PR TITLE
[4.0] Improving Color harmony of the dark colour background in atum

### DIFF
--- a/administrator/templates/atum/Service/HTML/Atum.php
+++ b/administrator/templates/atum/Service/HTML/Atum.php
@@ -192,17 +192,17 @@ class JHtmlAtum
 		$root = [];
 
 		// No need to calculate if we have the default value
-		if ($hue === 207)
+		if ($hue === 214)
 		{
 			return $root;
 		}
 
 		try
 		{
-			$bgcolor = new Hsl('hsl(' . $hue . ', ' . 61 . ', 26)');
+			$bgcolor = new Hsl('hsl(' . $hue . ', ' . 63 . ', 20)');
 
-			$root[] = '--atum-bg-dark: ' . (new Hsl('hsl(' . $hue . ', 61, 26)'))->toHex() . ';';
-			$root[] = '--atum-contrast: ' . (new Hsl('hsl(' . $hue . ', 61, 26)'))->spin(-40)->lighten(18)->toHex() . ';';
+			$root[] = '--atum-bg-dark: ' . (new Hsl('hsl(' . $hue . ', 63, 20)'))->toHex() . ';';
+			$root[] = '--atum-contrast: ' . (new Hsl('hsl(' . $hue . ', 63, 20)'))->spin(-40)->lighten(18)->toHex() . ';';
 			$root[] = '--atum-bg-dark-0: ' . (clone $bgcolor)->desaturate(86)->lighten(71.4)->spin(-6)->toHex() . ';';
 			$root[] = '--atum-bg-dark-5: ' . (clone $bgcolor)->desaturate(85)->lighten(65.1)->spin(-6)->toHex() . ';';
 			$root[] = '--atum-bg-dark-10: ' . (clone $bgcolor)->desaturate(80)->lighten(59.4)->spin(-6)->toHex() . ';';

--- a/administrator/templates/atum/Service/HTML/Atum.php
+++ b/administrator/templates/atum/Service/HTML/Atum.php
@@ -8,7 +8,7 @@
  */
 
 defined('_JEXEC') or die;
-
+ 
 use Joomla\CMS\Factory;
 use Joomla\Registry\Registry;
 use OzdemirBurak\Iris\Color\Hex;

--- a/administrator/templates/atum/Service/HTML/Atum.php
+++ b/administrator/templates/atum/Service/HTML/Atum.php
@@ -8,7 +8,7 @@
  */
 
 defined('_JEXEC') or die;
- 
+
 use Joomla\CMS\Factory;
 use Joomla\Registry\Registry;
 use OzdemirBurak\Iris\Color\Hex;

--- a/administrator/templates/atum/scss/_variables.scss
+++ b/administrator/templates/atum/scss/_variables.scss
@@ -31,7 +31,7 @@ $green:                            #2f7d32; //used in bootstrap
 $green-dark:                       #0f2f21; //used for alert success
 $teal:                             #20c997; //used in bootstrap
 $cyan:                             #107d8e; //used in bootstrap
-$darkblue:                         #3b4a5c;
+$darkblue:                         #1c2f52;
 $base-color:                       $darkblue;
 
 $theme-colors: ();

--- a/administrator/templates/atum/scss/_variables.scss
+++ b/administrator/templates/atum/scss/_variables.scss
@@ -31,7 +31,7 @@ $green:                            #2f7d32; //used in bootstrap
 $green-dark:                       #0f2f21; //used for alert success
 $teal:                             #20c997; //used in bootstrap
 $cyan:                             #107d8e; //used in bootstrap
-$darkblue:                         #1c2f52;
+$darkblue:                         #132f53;
 $base-color:                       $darkblue;
 
 $theme-colors: ();

--- a/administrator/templates/atum/templateDetails.xml
+++ b/administrator/templates/atum/templateDetails.xml
@@ -57,7 +57,7 @@
 					control="slider"
 					preview="true"
 					saveFormat="hsl"
-					default="hsl(207,61%,26%)"
+					default="hsl(219,49%,22%)"
 				/>
 				<field
 					name="bg-light"

--- a/administrator/templates/atum/templateDetails.xml
+++ b/administrator/templates/atum/templateDetails.xml
@@ -57,7 +57,7 @@
 					control="slider"
 					preview="true"
 					saveFormat="hsl"
-					default="hsl(219,49%,22%)"
+					default="hsl(214,63%,20%)"
 				/>
 				<field
 					name="bg-light"


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/28663

### Summary of Changes
Changed the main color preset to match the new light blue color better.
I see that the previoused chosed color was probably chosen by monochromatic approch with a lighter shade of the monochromatic matching color, but it did not match the  color harmony of the light blue color that good. So I used a color mix between black and the light blue to get some more exe candy.

![grafik](https://user-images.githubusercontent.com/828371/80275404-3ac56500-86e1-11ea-86ee-8a37be5fc2cf.png)

### Testing Instructions
Apply the patch and reset the hue setting in the Backend Template Atum Style for the dark colour

### Expected result
The backend top bar should change to hex #132f53
it should look nicer now

### Documentation Changes Required
no

### Additional Information
Next step could be to remove the hue settings and calculations at all because they were actually only made for the dark themed sidebar that is gone now. I can open a RFC for this.
