### PR TITLE
[4.0] Atum - Change hardcoded class of delete button and add as parameter

### DIFF
--- a/administrator/components/com_templates/src/View/Template/HtmlView.php
+++ b/administrator/components/com_templates/src/View/Template/HtmlView.php
@@ -288,7 +288,7 @@ class HtmlView extends BaseHtmlView
 			// Add a Delete file Button
 			if ($this->type != 'home')
 			{
-				ToolbarHelper::modal('deleteModal', 'icon-remove', 'COM_TEMPLATES_BUTTON_DELETE_FILE');
+				ToolbarHelper::modal('deleteModal', 'icon-remove', 'COM_TEMPLATES_BUTTON_DELETE_FILE', 'btn-danger');
 			}
 		}
 

--- a/libraries/src/Toolbar/ToolbarHelper.php
+++ b/libraries/src/Toolbar/ToolbarHelper.php
@@ -696,6 +696,7 @@ abstract class ToolbarHelper
 	 * @param   string  $targetModalId  ID of the target modal box
 	 * @param   string  $icon           Icon class to show on modal button
 	 * @param   string  $alt            Title for the modal button
+	 * @param   string  $class 	    The button class
 	 *
 	 * @return  void
 	 *

--- a/libraries/src/Toolbar/ToolbarHelper.php
+++ b/libraries/src/Toolbar/ToolbarHelper.php
@@ -696,7 +696,7 @@ abstract class ToolbarHelper
 	 * @param   string  $targetModalId  ID of the target modal box
 	 * @param   string  $icon           Icon class to show on modal button
 	 * @param   string  $alt            Title for the modal button
-	 * @param   string  $class 	    The button class
+	 * @param   string  $class          The button class
 	 *
 	 * @return  void
 	 *

--- a/libraries/src/Toolbar/ToolbarHelper.php
+++ b/libraries/src/Toolbar/ToolbarHelper.php
@@ -701,11 +701,11 @@ abstract class ToolbarHelper
 	 *
 	 * @since   3.2
 	 */
-	public static function modal($targetModalId, $icon, $alt)
+	public static function modal($targetModalId, $icon, $alt, $class = 'btn-primary')
 	{
 		$title = Text::_($alt);
 
-		$dhtml = '<joomla-toolbar-button><button data-toggle="modal" data-target="#' . $targetModalId . '" class="btn btn-primary">
+		$dhtml = '<joomla-toolbar-button><button data-toggle="modal" data-target="#' . $targetModalId . '" class="btn ' . $class . '">
 			<span class="' . $icon . '" title="' . $title . '"></span> ' . $title . '</button></joomla-toolbar-button>';
 
 		$bar = Toolbar::getInstance('toolbar');


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/28263

### Summary of Changes
Added a parameter $class to the modal buttons with default to btn-primary
Added the class btn-danger to the delete button

### Testing Instructions
Apply the patch 
Go to the template Manager into the files edit section, select a file and see if the delete file button is red (icon and hover)

### Expected result
Button has class btn-danger and hovers red


### Actual result
Button has class btn-primary and hovers blue


### Documentation Changes Required
no
