### PR TITLE
[4.0] Atum: Change Column Settings for Parameters and Article Edit where column class was set

### DIFF
--- a/administrator/components/com_content/tmpl/article/edit.php
+++ b/administrator/components/com_content/tmpl/article/edit.php
@@ -153,7 +153,7 @@ $tmpl    = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=c
 			<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'editor', Text::_('COM_CONTENT_SLIDER_EDITOR_CONFIG')); ?>
 			<fieldset id="fieldset-editor" class="options-form">
 				<legend><?php echo Text::_('COM_CONTENT_SLIDER_EDITOR_CONFIG'); ?></legend>
-				<div class="col-12 col-md-8 col-lg-6 col-xl-4">
+				<div class="column-count-md-2">
 				<?php echo $this->form->renderFieldset('editorConfig'); ?>
 				</div>
 			</fieldset>

--- a/administrator/components/com_content/tmpl/article/edit.php
+++ b/administrator/components/com_content/tmpl/article/edit.php
@@ -153,7 +153,7 @@ $tmpl    = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=c
 			<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'editor', Text::_('COM_CONTENT_SLIDER_EDITOR_CONFIG')); ?>
 			<fieldset id="fieldset-editor" class="options-form">
 				<legend><?php echo Text::_('COM_CONTENT_SLIDER_EDITOR_CONFIG'); ?></legend>
-				<div class="column-count-md-2 column-count-lg-3">
+				<div class="col-12 col-md-8 col-lg-6 col-xl-4">
 				<?php echo $this->form->renderFieldset('editorConfig'); ?>
 				</div>
 			</fieldset>

--- a/layouts/joomla/edit/params.php
+++ b/layouts/joomla/edit/params.php
@@ -118,7 +118,7 @@ foreach ($fieldSets as $name => $fieldSet)
 	{
 		echo '<fieldset id="fieldset-' . $name . '" class="options-form ' . (!empty($fieldSet->class) ? $fieldSet->class : '') . '">';
 		echo '<legend>' . $label . '</legend>';
-		echo '<div class="col-12 col-md-8 col-lg-6 col-xl-4">';
+		echo '<div class="column-count-md-2">';
 	}
 	// Tabs
 	elseif (!$hasParent)

--- a/layouts/joomla/edit/params.php
+++ b/layouts/joomla/edit/params.php
@@ -152,7 +152,7 @@ foreach ($fieldSets as $name => $fieldSet)
 				echo '<div class="alert alert-info">' . $this->escape(Text::_($fieldSet->description)) . '</div>';
 			}
 
-			echo '<div class="col-12 col-md-8 col-lg-6 col-xl-4">';
+			echo '<div class="column-count-md-2">';
 
 			$opentab = 2;
 		}

--- a/layouts/joomla/edit/params.php
+++ b/layouts/joomla/edit/params.php
@@ -118,7 +118,7 @@ foreach ($fieldSets as $name => $fieldSet)
 	{
 		echo '<fieldset id="fieldset-' . $name . '" class="options-form ' . (!empty($fieldSet->class) ? $fieldSet->class : '') . '">';
 		echo '<legend>' . $label . '</legend>';
-		echo '<div class="column-count-md-2 column-count-lg-3">';
+		echo '<div class="col-12 col-md-8 col-lg-6 col-xl-4">';
 	}
 	// Tabs
 	elseif (!$hasParent)
@@ -152,7 +152,7 @@ foreach ($fieldSets as $name => $fieldSet)
 				echo '<div class="alert alert-info">' . $this->escape(Text::_($fieldSet->description)) . '</div>';
 			}
 
-			echo '<div class="column-count-md-2 column-count-lg-3">';
+			echo '<div class="col-12 col-md-8 col-lg-6 col-xl-4">';
 
 			$opentab = 2;
 		}


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/25891

### Summary of Changes
changed the multi column appearance to a one column appearance with different width settings for the screensizes.

### Testing Instructions
Apply patch and see how the parameters appear now in 
- Article Edit view
- Menu Item Paramenters
- Module Parameters

### Expected result
- You have now only one column, on xxl devices like a 34" Screen the fields are not full width

### Actual result
- You have 2 or 3 Columns (on large screens) - The input fields are very hard to scan

### Documentation Changes Required
no
