### PR TITLE
Remove btn-sm class

### DIFF
--- a/libraries/src/Toolbar/Button/StandardButton.php
+++ b/libraries/src/Toolbar/Button/StandardButton.php
@@ -97,30 +97,30 @@ class StandardButton extends BasicButton
 		{
 			case 'apply':
 			case 'new':
-				return ' btn btn-sm btn-success';
+				return ' btn btn-success';
 
 			case 'save':
 			case 'save-new':
 			case 'save-copy':
 			case 'save-close':
 			case 'publish':
-				return ' btn btn-sm btn-success';
+				return ' btn btn-success';
 
 			case 'unpublish':
-				return ' btn btn-sm btn-danger';
+				return ' btn btn-danger';
 
 			case 'featured':
-				return ' btn btn-sm btn-warning';
+				return ' btn btn-warning';
 
 			case 'cancel':
-				return ' btn btn-sm btn-danger';
+				return ' btn btn-danger';
 
 			case 'trash':
 			case 'delete':
-				return ' btn btn-sm btn-danger';
+				return ' btn btn-danger';
 
 			default:
-				return ' btn btn-sm btn-primary';
+				return ' btn btn-primary';
 		}
 	}
 


### PR DESCRIPTION
Pull Request for https://github.com/joomla/joomla-cms/issues/26075

### Summary of Changes

Removed the btn-sm class for the Toolbar Buttons because that are not small buttons

### Testing Instructions
Apply the patch


### Expected result
everything should look like before (Toolbar Buttons such as Save, Close,...)


### Documentation Changes Required
no
