### PR TITLE
[4.0] Fix PHP error with pagebreak

### DIFF
--- a/plugins/content/pagebreak/tmpl/navigation.php
+++ b/plugins/content/pagebreak/tmpl/navigation.php
@@ -9,6 +9,7 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 
@@ -17,6 +18,7 @@ use Joomla\CMS\Router\Route;
  * @var $page    integer  The page number
  */
 
+$lang = Factory::getLanguage();
 ?>
 <ul>
 	<li>


### PR DESCRIPTION
Pull Request for Issue #28795 

### Summary of Changes

Fix a PHP error being throw with the pagebreak plugin

### Testing Instructions

1. Add a page break to any article
2. View the article in the frontend

### Expected result

The article is displayed

### Actual result

PHP error