### PR TITLE
[4.0] Normalise session params with J3

### DIFF
--- a/libraries/src/Session/Storage/JoomlaStorage.php
+++ b/libraries/src/Session/Storage/JoomlaStorage.php
@@ -59,9 +59,14 @@ class JoomlaStorage extends NativeStorage
 	{
 		// Disable transparent sid support and default use cookies
 		$options += [
-			'use_cookies'   => 1,
 			'use_trans_sid' => 0,
 		];
+
+		// Only allow the session ID to come from cookies and nothing else.
+		if ((int) ini_get('session.use_cookies') !== 1)
+		{
+			$options['use_only_cookies'] = 1;
+		}
 
 		if (!headers_sent() && !$this->isActive())
 		{


### PR DESCRIPTION
### Summary of Changes
This is a bit of a test - It normalises the way the session params are set with that of J3. The main aim is to solve the session being 'lost' when upgrading from j3 to j4. If you still get password prompted this is no good and can be consigned to the dustbin :)

### Testing Instructions
Upgrade from j3 to j4 - hopefully you don't get kicked out the browser :)

### Documentation Changes Required
N/A
