### PR TITLE
Define fields for the joomla.edit.global layout in the view.html.php files

### DIFF
--- a/administrator/components/com_banners/views/banner/view.html.php
+++ b/administrator/components/com_banners/views/banner/view.html.php
@@ -53,6 +53,25 @@ class BannersViewBanner extends JViewLegacy
 		$this->item  = $this->get('Item');
 		$this->state = $this->get('State');
 
+		// Global fields
+		$this->fields = array(
+			array('parent', 'parent_id'),
+			array('published', 'state', 'enabled'),
+			array('category', 'catid'),
+			'featured',
+			'sticky',
+			'access',
+			'id',
+			'language',
+			'tags',
+			'note',
+			'version_note',
+		);
+
+		$context      = $this->form->getName();
+		$fields       = JFactory::getApplication()->getUserState($context . '.edit.global.fields', array());
+		$this->fields = array_merge($this->fields, $fields);
+
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{

--- a/administrator/components/com_banners/views/banner/view.html.php
+++ b/administrator/components/com_banners/views/banner/view.html.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Utilities\ArrayHelper;
+
 JLoader::register('BannersHelper', JPATH_ADMINISTRATOR . '/components/com_banners/helpers/banners.php');
 
 /**
@@ -54,7 +56,7 @@ class BannersViewBanner extends JViewLegacy
 		$this->state = $this->get('State');
 
 		// Global fields
-		$this->fields = array(
+		$globalFields = array(
 			array('parent', 'parent_id'),
 			array('published', 'state', 'enabled'),
 			array('category', 'catid'),
@@ -68,9 +70,17 @@ class BannersViewBanner extends JViewLegacy
 			'version_note',
 		);
 
-		$context      = $this->form->getName();
-		$fields       = JFactory::getApplication()->getUserState($context . '.edit.global.fields', array());
-		$this->fields = array_merge($this->fields, $fields);
+		$context = $this->form->getName();
+
+		// Get new fields
+		$newFields = JFactory::getApplication()->getUserState($context . '.edit.global.fields', array());
+
+		// Reset session value
+		JFactory::getApplication()->setUserState($context . '.edit.global.fields', array());
+
+		// Merge global fields with new fields
+		$fields       = array_merge($globalFields, $newFields);
+		$this->fields = ArrayHelper::arrayUnique($fields);
 
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))

--- a/administrator/components/com_banners/views/client/view.html.php
+++ b/administrator/components/com_banners/views/client/view.html.php
@@ -58,6 +58,26 @@ class BannersViewClient extends JViewLegacy
 		$this->form  = $this->get('Form');
 		$this->item  = $this->get('Item');
 		$this->state = $this->get('State');
+
+		// Global fields
+		$this->fields = array(
+			array('parent', 'parent_id'),
+			array('published', 'state', 'enabled'),
+			array('category', 'catid'),
+			'featured',
+			'sticky',
+			'access',
+			'id',
+			'language',
+			'tags',
+			'note',
+			'version_note',
+		);
+
+		$context      = $this->form->getName();
+		$fields       = JFactory::getApplication()->getUserState($context . '.edit.global.fields', array());
+		$this->fields = array_merge($this->fields, $fields);
+
 		$this->canDo = JHelperContent::getActions('com_banners');
 
 		// Check for errors.

--- a/administrator/components/com_banners/views/client/view.html.php
+++ b/administrator/components/com_banners/views/client/view.html.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Utilities\ArrayHelper;
+
 JLoader::register('BannersHelper', JPATH_ADMINISTRATOR . '/components/com_banners/helpers/banners.php');
 
 /**
@@ -60,7 +62,7 @@ class BannersViewClient extends JViewLegacy
 		$this->state = $this->get('State');
 
 		// Global fields
-		$this->fields = array(
+		$globalFields = array(
 			array('parent', 'parent_id'),
 			array('published', 'state', 'enabled'),
 			array('category', 'catid'),
@@ -74,9 +76,17 @@ class BannersViewClient extends JViewLegacy
 			'version_note',
 		);
 
-		$context      = $this->form->getName();
-		$fields       = JFactory::getApplication()->getUserState($context . '.edit.global.fields', array());
-		$this->fields = array_merge($this->fields, $fields);
+		$context = $this->form->getName();
+
+		// Get new fields
+		$newFields = JFactory::getApplication()->getUserState($context . '.edit.global.fields', array());
+
+		// Reset session value
+		JFactory::getApplication()->setUserState($context . '.edit.global.fields', array());
+
+		// Merge global fields with new fields
+		$fields       = array_merge($globalFields, $newFields);
+		$this->fields = ArrayHelper::arrayUnique($fields);
 
 		$this->canDo = JHelperContent::getActions('com_banners');
 

--- a/administrator/components/com_categories/views/category/view.html.php
+++ b/administrator/components/com_categories/views/category/view.html.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Utilities\ArrayHelper;
+
 /**
  * HTML View class for the Categories component
  *
@@ -65,7 +67,7 @@ class CategoriesViewCategory extends JViewLegacy
 		$this->state = $this->get('State');
 
 		// Global fields
-		$this->fields = array(
+		$globalFields = array(
 			array('parent', 'parent_id'),
 			array('published', 'state', 'enabled'),
 			array('category', 'catid'),
@@ -79,9 +81,17 @@ class CategoriesViewCategory extends JViewLegacy
 			'version_note',
 		);
 
-		$context      = $this->form->getName();
-		$fields       = JFactory::getApplication()->getUserState($context . '.edit.global.fields', array());
-		$this->fields = array_merge($this->fields, $fields);
+		$context = $this->form->getName();
+
+		// Get new fields
+		$newFields = JFactory::getApplication()->getUserState($context . '.edit.global.fields', array());
+
+		// Reset session value
+		JFactory::getApplication()->setUserState($context . '.edit.global.fields', array());
+
+		// Merge global fields with new fields
+		$fields       = array_merge($globalFields, $newFields);
+		$this->fields = ArrayHelper::arrayUnique($fields);
 
 		$section = $this->state->get('category.section') ? $this->state->get('category.section') . '.' : '';
 		$this->canDo = JHelperContent::getActions($this->state->get('category.component'), $section . 'category', $this->item->id);

--- a/administrator/components/com_categories/views/category/view.html.php
+++ b/administrator/components/com_categories/views/category/view.html.php
@@ -63,6 +63,26 @@ class CategoriesViewCategory extends JViewLegacy
 		$this->form = $this->get('Form');
 		$this->item = $this->get('Item');
 		$this->state = $this->get('State');
+
+		// Global fields
+		$this->fields = array(
+			array('parent', 'parent_id'),
+			array('published', 'state', 'enabled'),
+			array('category', 'catid'),
+			'featured',
+			'sticky',
+			'access',
+			'id',
+			'language',
+			'tags',
+			'note',
+			'version_note',
+		);
+
+		$context      = $this->form->getName();
+		$fields       = JFactory::getApplication()->getUserState($context . '.edit.global.fields', array());
+		$this->fields = array_merge($this->fields, $fields);
+
 		$section = $this->state->get('category.section') ? $this->state->get('category.section') . '.' : '';
 		$this->canDo = JHelperContent::getActions($this->state->get('category.component'), $section . 'category', $this->item->id);
 		$this->assoc = $this->get('Assoc');

--- a/administrator/components/com_contact/views/contact/view.html.php
+++ b/administrator/components/com_contact/views/contact/view.html.php
@@ -51,6 +51,25 @@ class ContactViewContact extends JViewLegacy
 		$this->item  = $this->get('Item');
 		$this->state = $this->get('State');
 
+		// Global fields
+		$this->fields = array(
+			array('parent', 'parent_id'),
+			array('published', 'state', 'enabled'),
+			array('category', 'catid'),
+			'featured',
+			'sticky',
+			'access',
+			'id',
+			'language',
+			'tags',
+			'note',
+			'version_note',
+		);
+
+		$context      = $this->form->getName();
+		$fields       = JFactory::getApplication()->getUserState($context . '.edit.global.fields', array());
+		$this->fields = array_merge($this->fields, $fields);
+
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{

--- a/administrator/components/com_contact/views/contact/view.html.php
+++ b/administrator/components/com_contact/views/contact/view.html.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Utilities\ArrayHelper;
+
 /**
  * View to edit a contact.
  *
@@ -52,7 +54,7 @@ class ContactViewContact extends JViewLegacy
 		$this->state = $this->get('State');
 
 		// Global fields
-		$this->fields = array(
+		$globalFields = array(
 			array('parent', 'parent_id'),
 			array('published', 'state', 'enabled'),
 			array('category', 'catid'),
@@ -66,9 +68,17 @@ class ContactViewContact extends JViewLegacy
 			'version_note',
 		);
 
-		$context      = $this->form->getName();
-		$fields       = JFactory::getApplication()->getUserState($context . '.edit.global.fields', array());
-		$this->fields = array_merge($this->fields, $fields);
+		$context = $this->form->getName();
+
+		// Get new fields
+		$newFields = JFactory::getApplication()->getUserState($context . '.edit.global.fields', array());
+
+		// Reset session value
+		JFactory::getApplication()->setUserState($context . '.edit.global.fields', array());
+
+		// Merge global fields with new fields
+		$fields       = array_merge($globalFields, $newFields);
+		$this->fields = ArrayHelper::arrayUnique($fields);
 
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))

--- a/administrator/components/com_content/views/article/view.html.php
+++ b/administrator/components/com_content/views/article/view.html.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Utilities\ArrayHelper;
+
 /**
  * View to edit an article.
  *
@@ -65,7 +67,7 @@ class ContentViewArticle extends JViewLegacy
 		$this->state = $this->get('State');
 
 		// Global fields
-		$this->fields = array(
+		$globalFields = array(
 			array('parent', 'parent_id'),
 			array('published', 'state', 'enabled'),
 			array('category', 'catid'),
@@ -79,9 +81,17 @@ class ContentViewArticle extends JViewLegacy
 			'version_note',
 		);
 
-		$context      = $this->form->getName();
-		$fields       = JFactory::getApplication()->getUserState($context . '.edit.global.fields', array());
-		$this->fields = array_merge($this->fields, $fields);
+		$context = $this->form->getName();
+
+		// Get new fields
+		$newFields = JFactory::getApplication()->getUserState($context . '.edit.global.fields', array());
+
+		// Reset session value
+		JFactory::getApplication()->setUserState($context . '.edit.global.fields', array());
+
+		// Merge global fields with new fields
+		$fields       = array_merge($globalFields, $newFields);
+		$this->fields = ArrayHelper::arrayUnique($fields);
 
 		$this->canDo = JHelperContent::getActions('com_content', 'article', $this->item->id);
 

--- a/administrator/components/com_content/views/article/view.html.php
+++ b/administrator/components/com_content/views/article/view.html.php
@@ -63,6 +63,26 @@ class ContentViewArticle extends JViewLegacy
 		$this->form  = $this->get('Form');
 		$this->item  = $this->get('Item');
 		$this->state = $this->get('State');
+
+		// Global fields
+		$this->fields = array(
+			array('parent', 'parent_id'),
+			array('published', 'state', 'enabled'),
+			array('category', 'catid'),
+			'featured',
+			'sticky',
+			'access',
+			'id',
+			'language',
+			'tags',
+			'note',
+			'version_note',
+		);
+
+		$context      = $this->form->getName();
+		$fields       = JFactory::getApplication()->getUserState($context . '.edit.global.fields', array());
+		$this->fields = array_merge($this->fields, $fields);
+
 		$this->canDo = JHelperContent::getActions('com_content', 'article', $this->item->id);
 
 		// Check for errors.

--- a/administrator/components/com_fields/views/field/tmpl/edit.php
+++ b/administrator/components/com_fields/views/field/tmpl/edit.php
@@ -64,20 +64,6 @@ JFactory::getDocument()->addScriptDeclaration('
 
 			</div>
 			<div class="span3">
-				<?php $this->set('fields',
-						array(
-							array(
-								'published',
-								'state',
-								'enabled',
-							),
-							'group_id',
-							'assigned_cat_ids',
-							'access',
-							'language',
-							'note',
-						)
-				); ?>
 				<?php echo JLayoutHelper::render('joomla.edit.global', $this); ?>
 				<?php $this->set('fields', null); ?>
 			</div>

--- a/administrator/components/com_fields/views/field/view.html.php
+++ b/administrator/components/com_fields/views/field/view.html.php
@@ -52,6 +52,24 @@ class FieldsViewField extends JViewLegacy
 		$this->item  = $this->get('Item');
 		$this->state = $this->get('State');
 
+		// Global fields
+		$this->fields = array(
+			array(
+				'published',
+				'state',
+				'enabled',
+			),
+			'group_id',
+			'assigned_cat_ids',
+			'access',
+			'language',
+			'note',
+		);
+
+		$context      = $this->form->getName();
+		$fields       = JFactory::getApplication()->getUserState($context . '.edit.global.fields', array());
+		$this->fields = array_merge($this->fields, $fields);
+
 		$this->canDo = JHelperContent::getActions($this->state->get('field.component'), 'field', $this->item->id);
 
 		// Check for errors.

--- a/administrator/components/com_fields/views/field/view.html.php
+++ b/administrator/components/com_fields/views/field/view.html.php
@@ -8,6 +8,8 @@
  */
 defined('_JEXEC') or die;
 
+use Joomla\Utilities\ArrayHelper;
+
 /**
  * Field View
  *
@@ -53,7 +55,7 @@ class FieldsViewField extends JViewLegacy
 		$this->state = $this->get('State');
 
 		// Global fields
-		$this->fields = array(
+		$globalFields = array(
 			array(
 				'published',
 				'state',
@@ -66,9 +68,17 @@ class FieldsViewField extends JViewLegacy
 			'note',
 		);
 
-		$context      = $this->form->getName();
-		$fields       = JFactory::getApplication()->getUserState($context . '.edit.global.fields', array());
-		$this->fields = array_merge($this->fields, $fields);
+		$context = $this->form->getName();
+
+		// Get new fields
+		$newFields = JFactory::getApplication()->getUserState($context . '.edit.global.fields', array());
+
+		// Reset session value
+		JFactory::getApplication()->setUserState($context . '.edit.global.fields', array());
+
+		// Merge global fields with new fields
+		$fields       = array_merge($globalFields, $newFields);
+		$this->fields = ArrayHelper::arrayUnique($fields);
 
 		$this->canDo = JHelperContent::getActions($this->state->get('field.component'), 'field', $this->item->id);
 

--- a/administrator/components/com_fields/views/group/tmpl/edit.php
+++ b/administrator/components/com_fields/views/group/tmpl/edit.php
@@ -41,18 +41,6 @@ JFactory::getDocument()->addScriptDeclaration('
 				<?php echo $this->form->renderField('description'); ?>
 			</div>
 			<div class="span3">
-				<?php $this->set('fields',
-						array(
-							array(
-								'published',
-								'state',
-								'enabled',
-							),
-							'access',
-							'language',
-							'note',
-						)
-				); ?>
 				<?php echo JLayoutHelper::render('joomla.edit.global', $this); ?>
 				<?php $this->set('fields', null); ?>
 			</div>

--- a/administrator/components/com_fields/views/group/view.html.php
+++ b/administrator/components/com_fields/views/group/view.html.php
@@ -8,6 +8,8 @@
  */
 defined('_JEXEC') or die;
 
+use Joomla\Utilities\ArrayHelper;
+
 /**
  * Group View
  *
@@ -63,7 +65,7 @@ class FieldsViewGroup extends JViewLegacy
 		$this->state = $this->get('State');
 
 		// Global fields
-		$this->fields = array(
+		$globalFields = array(
 			array(
 				'published',
 				'state',
@@ -74,9 +76,17 @@ class FieldsViewGroup extends JViewLegacy
 			'note',
 		);
 
-		$context      = $this->form->getName();
-		$fields       = JFactory::getApplication()->getUserState($context . '.edit.global.fields', array());
-		$this->fields = array_merge($this->fields, $fields);
+		$context = $this->form->getName();
+
+		// Get new fields
+		$newFields = JFactory::getApplication()->getUserState($context . '.edit.global.fields', array());
+
+		// Reset session value
+		JFactory::getApplication()->setUserState($context . '.edit.global.fields', array());
+
+		// Merge global fields with new fields
+		$fields       = array_merge($globalFields, $newFields);
+		$this->fields = ArrayHelper::arrayUnique($fields);
 
 		$component = '';
 		$parts     = FieldsHelper::extract($this->state->get('filter.context'));

--- a/administrator/components/com_fields/views/group/view.html.php
+++ b/administrator/components/com_fields/views/group/view.html.php
@@ -62,6 +62,22 @@ class FieldsViewGroup extends JViewLegacy
 		$this->item  = $this->get('Item');
 		$this->state = $this->get('State');
 
+		// Global fields
+		$this->fields = array(
+			array(
+				'published',
+				'state',
+				'enabled',
+			),
+			'access',
+			'language',
+			'note',
+		);
+
+		$context      = $this->form->getName();
+		$fields       = JFactory::getApplication()->getUserState($context . '.edit.global.fields', array());
+		$this->fields = array_merge($this->fields, $fields);
+
 		$component = '';
 		$parts     = FieldsHelper::extract($this->state->get('filter.context'));
 

--- a/administrator/components/com_finder/views/filter/view.html.php
+++ b/administrator/components/com_finder/views/filter/view.html.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Utilities\ArrayHelper;
+
 /**
  * Filter view class for Finder.
  *
@@ -80,7 +82,7 @@ class FinderViewFilter extends JViewLegacy
 		$this->total = $this->get('Total');
 
 		// Global fields
-		$this->fields = array(
+		$globalFields = array(
 			array('parent', 'parent_id'),
 			array('published', 'state', 'enabled'),
 			array('category', 'catid'),
@@ -94,9 +96,17 @@ class FinderViewFilter extends JViewLegacy
 			'version_note',
 		);
 
-		$context      = $this->form->getName();
-		$fields       = JFactory::getApplication()->getUserState($context . '.edit.global.fields', array());
-		$this->fields = array_merge($this->fields, $fields);
+		$context = $this->form->getName();
+
+		// Get new fields
+		$newFields = JFactory::getApplication()->getUserState($context . '.edit.global.fields', array());
+
+		// Reset session value
+		JFactory::getApplication()->setUserState($context . '.edit.global.fields', array());
+
+		// Merge global fields with new fields
+		$fields       = array_merge($globalFields, $newFields);
+		$this->fields = ArrayHelper::arrayUnique($fields);
 
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))

--- a/administrator/components/com_finder/views/filter/view.html.php
+++ b/administrator/components/com_finder/views/filter/view.html.php
@@ -79,6 +79,25 @@ class FinderViewFilter extends JViewLegacy
 		$this->state = $this->get('State');
 		$this->total = $this->get('Total');
 
+		// Global fields
+		$this->fields = array(
+			array('parent', 'parent_id'),
+			array('published', 'state', 'enabled'),
+			array('category', 'catid'),
+			'featured',
+			'sticky',
+			'access',
+			'id',
+			'language',
+			'tags',
+			'note',
+			'version_note',
+		);
+
+		$context      = $this->form->getName();
+		$fields       = JFactory::getApplication()->getUserState($context . '.edit.global.fields', array());
+		$this->fields = array_merge($this->fields, $fields);
+
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{

--- a/administrator/components/com_menus/views/item/tmpl/edit.php
+++ b/administrator/components/com_menus/views/item/tmpl/edit.php
@@ -186,20 +186,6 @@ if ($clientId === 1)
 			</div>
 			<div class="span3">
 				<?php
-				// Set main fields.
-				$this->fields = array(
-					'id',
-					'client_id',
-					'menutype',
-					'parent_id',
-					'menuordering',
-					'published',
-					'home',
-					'access',
-					'language',
-					'note',
-				);
-
 				if ($this->item->type != 'component')
 				{
 					$this->fields = array_diff($this->fields, array('home'));

--- a/administrator/components/com_menus/views/item/view.html.php
+++ b/administrator/components/com_menus/views/item/view.html.php
@@ -59,6 +59,25 @@ class MenusViewItem extends JViewLegacy
 		$this->item    = $this->get('Item');
 		$this->modules = $this->get('Modules');
 		$this->levels  = $this->get('ViewLevels');
+
+		// Global fields
+		$this->fields = array(
+			'id',
+			'client_id',
+			'menutype',
+			'parent_id',
+			'menuordering',
+			'published',
+			'home',
+			'access',
+			'language',
+			'note',
+		);
+
+		$context      = $this->form->getName();
+		$fields       = JFactory::getApplication()->getUserState($context . '.edit.global.fields', array());
+		$this->fields = array_merge($this->fields, $fields);
+
 		$this->canDo   = JHelperContent::getActions('com_menus', 'menu', (int) $this->state->get('item.menutypeid'));
 
 		// Check if we're allowed to edit this item

--- a/administrator/components/com_menus/views/item/view.html.php
+++ b/administrator/components/com_menus/views/item/view.html.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Utilities\ArrayHelper;
+
 /**
  * The HTML Menus Menu Item View.
  *
@@ -61,7 +63,7 @@ class MenusViewItem extends JViewLegacy
 		$this->levels  = $this->get('ViewLevels');
 
 		// Global fields
-		$this->fields = array(
+		$globalFields = array(
 			'id',
 			'client_id',
 			'menutype',
@@ -74,9 +76,17 @@ class MenusViewItem extends JViewLegacy
 			'note',
 		);
 
-		$context      = $this->form->getName();
-		$fields       = JFactory::getApplication()->getUserState($context . '.edit.global.fields', array());
-		$this->fields = array_merge($this->fields, $fields);
+		$context = $this->form->getName();
+
+		// Get new fields
+		$newFields = JFactory::getApplication()->getUserState($context . '.edit.global.fields', array());
+
+		// Reset session value
+		JFactory::getApplication()->setUserState($context . '.edit.global.fields', array());
+
+		// Merge global fields with new fields
+		$fields       = array_merge($globalFields, $newFields);
+		$this->fields = ArrayHelper::arrayUnique($fields);
 
 		$this->canDo   = JHelperContent::getActions('com_menus', 'menu', (int) $this->state->get('item.menutypeid'));
 

--- a/administrator/components/com_modules/views/module/tmpl/edit.php
+++ b/administrator/components/com_modules/views/module/tmpl/edit.php
@@ -244,19 +244,6 @@ $tmpl    = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=c
 						</div>
 					</div>
 				</fieldset>
-				<?php
-				// Set main fields.
-				$this->fields = array(
-					'published',
-					'publish_up',
-					'publish_down',
-					'access',
-					'ordering',
-					'language',
-					'note'
-				);
-
-				?>
 				<?php echo JLayoutHelper::render('joomla.edit.global', $this); ?>
 			</div>
 		</div>

--- a/administrator/components/com_modules/views/module/view.html.php
+++ b/administrator/components/com_modules/views/module/view.html.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Utilities\ArrayHelper;
+
 /**
  * View to edit a module.
  *
@@ -36,7 +38,7 @@ class ModulesViewModule extends JViewLegacy
 		$this->state = $this->get('State');
 
 		// Global fields
-		$this->fields = array(
+		$globalFields = array(
 			'published',
 			'publish_up',
 			'publish_down',
@@ -46,9 +48,17 @@ class ModulesViewModule extends JViewLegacy
 			'note',
 		);
 
-		$context      = $this->form->getName();
-		$fields       = JFactory::getApplication()->getUserState($context . '.edit.global.fields', array());
-		$this->fields = array_merge($this->fields, $fields);
+		$context = $this->form->getName();
+
+		// Get new fields
+		$newFields = JFactory::getApplication()->getUserState($context . '.edit.global.fields', array());
+
+		// Reset session value
+		JFactory::getApplication()->setUserState($context . '.edit.global.fields', array());
+
+		// Merge global fields with new fields
+		$fields       = array_merge($globalFields, $newFields);
+		$this->fields = ArrayHelper::arrayUnique($fields);
 
 		$this->canDo  = JHelperContent::getActions('com_modules', 'module', $this->item->id);
 

--- a/administrator/components/com_modules/views/module/view.html.php
+++ b/administrator/components/com_modules/views/module/view.html.php
@@ -34,7 +34,23 @@ class ModulesViewModule extends JViewLegacy
 		$this->form  = $this->get('Form');
 		$this->item  = $this->get('Item');
 		$this->state = $this->get('State');
-		$this->canDo = JHelperContent::getActions('com_modules', 'module', $this->item->id);
+
+		// Global fields
+		$this->fields = array(
+			'published',
+			'publish_up',
+			'publish_down',
+			'access',
+			'ordering',
+			'language',
+			'note',
+		);
+
+		$context      = $this->form->getName();
+		$fields       = JFactory::getApplication()->getUserState($context . '.edit.global.fields', array());
+		$this->fields = array_merge($this->fields, $fields);
+
+		$this->canDo  = JHelperContent::getActions('com_modules', 'module', $this->item->id);
 
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))

--- a/administrator/components/com_newsfeeds/views/newsfeed/view.html.php
+++ b/administrator/components/com_newsfeeds/views/newsfeed/view.html.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Utilities\ArrayHelper;
+
 /**
  * View to edit a newsfeed.
  *
@@ -56,7 +58,7 @@ class NewsfeedsViewNewsfeed extends JViewLegacy
 		$this->form  = $this->get('Form');
 
 		// Global fields
-		$this->fields = array(
+		$globalFields = array(
 			array('parent', 'parent_id'),
 			array('published', 'state', 'enabled'),
 			array('category', 'catid'),
@@ -70,9 +72,17 @@ class NewsfeedsViewNewsfeed extends JViewLegacy
 			'version_note',
 		);
 
-		$context      = $this->form->getName();
-		$fields       = JFactory::getApplication()->getUserState($context . '.edit.global.fields', array());
-		$this->fields = array_merge($this->fields, $fields);
+		$context = $this->form->getName();
+
+		// Get new fields
+		$newFields = JFactory::getApplication()->getUserState($context . '.edit.global.fields', array());
+
+		// Reset session value
+		JFactory::getApplication()->setUserState($context . '.edit.global.fields', array());
+
+		// Merge global fields with new fields
+		$fields       = array_merge($globalFields, $newFields);
+		$this->fields = ArrayHelper::arrayUnique($fields);
 
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))

--- a/administrator/components/com_newsfeeds/views/newsfeed/view.html.php
+++ b/administrator/components/com_newsfeeds/views/newsfeed/view.html.php
@@ -55,6 +55,25 @@ class NewsfeedsViewNewsfeed extends JViewLegacy
 		$this->item  = $this->get('Item');
 		$this->form  = $this->get('Form');
 
+		// Global fields
+		$this->fields = array(
+			array('parent', 'parent_id'),
+			array('published', 'state', 'enabled'),
+			array('category', 'catid'),
+			'featured',
+			'sticky',
+			'access',
+			'id',
+			'language',
+			'tags',
+			'note',
+			'version_note',
+		);
+
+		$context      = $this->form->getName();
+		$fields       = JFactory::getApplication()->getUserState($context . '.edit.global.fields', array());
+		$this->fields = array_merge($this->fields, $fields);
+
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{

--- a/administrator/components/com_plugins/views/plugin/view.html.php
+++ b/administrator/components/com_plugins/views/plugin/view.html.php
@@ -35,6 +35,25 @@ class PluginsViewPlugin extends JViewLegacy
 		$this->item  = $this->get('Item');
 		$this->form  = $this->get('Form');
 
+		// Global fields
+		$this->fields = array(
+			array('parent', 'parent_id'),
+			array('published', 'state', 'enabled'),
+			array('category', 'catid'),
+			'featured',
+			'sticky',
+			'access',
+			'id',
+			'language',
+			'tags',
+			'note',
+			'version_note',
+		);
+
+		$context      = $this->form->getName();
+		$fields       = JFactory::getApplication()->getUserState($context . '.edit.global.fields', array());
+		$this->fields = array_merge($this->fields, $fields);
+
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{

--- a/administrator/components/com_plugins/views/plugin/view.html.php
+++ b/administrator/components/com_plugins/views/plugin/view.html.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Utilities\ArrayHelper;
+
 /**
  * View to edit a plugin.
  *
@@ -36,7 +38,7 @@ class PluginsViewPlugin extends JViewLegacy
 		$this->form  = $this->get('Form');
 
 		// Global fields
-		$this->fields = array(
+		$globalFields = array(
 			array('parent', 'parent_id'),
 			array('published', 'state', 'enabled'),
 			array('category', 'catid'),
@@ -50,9 +52,17 @@ class PluginsViewPlugin extends JViewLegacy
 			'version_note',
 		);
 
-		$context      = $this->form->getName();
-		$fields       = JFactory::getApplication()->getUserState($context . '.edit.global.fields', array());
-		$this->fields = array_merge($this->fields, $fields);
+		$context = $this->form->getName();
+
+		// Get new fields
+		$newFields = JFactory::getApplication()->getUserState($context . '.edit.global.fields', array());
+
+		// Reset session value
+		JFactory::getApplication()->setUserState($context . '.edit.global.fields', array());
+
+		// Merge global fields with new fields
+		$fields       = array_merge($globalFields, $newFields);
+		$this->fields = ArrayHelper::arrayUnique($fields);
 
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))

--- a/administrator/components/com_tags/views/tag/view.html.php
+++ b/administrator/components/com_tags/views/tag/view.html.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Utilities\ArrayHelper;
+
 /**
  * HTML View class for the Tags component
  *
@@ -38,7 +40,7 @@ class TagsViewTag extends JViewLegacy
 		$this->state = $this->get('State');
 
 		// Global fields
-		$this->fields = array(
+		$globalFields = array(
 			array('parent', 'parent_id'),
 			array('published', 'state', 'enabled'),
 			array('category', 'catid'),
@@ -52,9 +54,17 @@ class TagsViewTag extends JViewLegacy
 			'version_note',
 		);
 
-		$context      = $this->form->getName();
-		$fields       = JFactory::getApplication()->getUserState($context . '.edit.global.fields', array());
-		$this->fields = array_merge($this->fields, $fields);
+		$context = $this->form->getName();
+
+		// Get new fields
+		$newFields = JFactory::getApplication()->getUserState($context . '.edit.global.fields', array());
+
+		// Reset session value
+		JFactory::getApplication()->setUserState($context . '.edit.global.fields', array());
+
+		// Merge global fields with new fields
+		$fields       = array_merge($globalFields, $newFields);
+		$this->fields = ArrayHelper::arrayUnique($fields);
 
 		$this->canDo = JHelperContent::getActions('com_tags');
 		$this->assoc = $this->get('Assoc');

--- a/administrator/components/com_tags/views/tag/view.html.php
+++ b/administrator/components/com_tags/views/tag/view.html.php
@@ -36,6 +36,26 @@ class TagsViewTag extends JViewLegacy
 		$this->form  = $this->get('Form');
 		$this->item  = $this->get('Item');
 		$this->state = $this->get('State');
+
+		// Global fields
+		$this->fields = array(
+			array('parent', 'parent_id'),
+			array('published', 'state', 'enabled'),
+			array('category', 'catid'),
+			'featured',
+			'sticky',
+			'access',
+			'id',
+			'language',
+			'tags',
+			'note',
+			'version_note',
+		);
+
+		$context      = $this->form->getName();
+		$fields       = JFactory::getApplication()->getUserState($context . '.edit.global.fields', array());
+		$this->fields = array_merge($this->fields, $fields);
+
 		$this->canDo = JHelperContent::getActions('com_tags');
 		$this->assoc = $this->get('Assoc');
 

--- a/administrator/components/com_templates/views/style/tmpl/edit.php
+++ b/administrator/components/com_templates/views/style/tmpl/edit.php
@@ -66,14 +66,6 @@ JFactory::getDocument()->addScriptDeclaration("
 				?>
 			</div>
 			<div class="span3">
-				<?php
-				// Set main fields.
-				$this->fields = array(
-					'home',
-					'client_id',
-					'template'
-				);
-				?>
 				<?php echo JLayoutHelper::render('joomla.edit.global', $this); ?>
 			</div>
 		</div>

--- a/administrator/components/com_templates/views/style/view.html.php
+++ b/administrator/components/com_templates/views/style/view.html.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Utilities\ArrayHelper;
+
 /**
  * View to edit a template style.
  *
@@ -53,15 +55,23 @@ class TemplatesViewStyle extends JViewLegacy
 		$this->form  = $this->get('Form');
 
 		// Global fields
-		$this->fields = array(
+		$globalFields = array(
 			'home',
 			'client_id',
 			'template'
 		);
 
-		$context      = $this->form->getName();
-		$fields       = JFactory::getApplication()->getUserState($context . '.edit.global.fields', array());
-		$this->fields = array_merge($this->fields, $fields);
+		$context = $this->form->getName();
+
+		// Get new fields
+		$newFields = JFactory::getApplication()->getUserState($context . '.edit.global.fields', array());
+
+		// Reset session value
+		JFactory::getApplication()->setUserState($context . '.edit.global.fields', array());
+
+		// Merge global fields with new fields
+		$fields       = array_merge($globalFields, $newFields);
+		$this->fields = ArrayHelper::arrayUnique($fields);
 
 		$this->canDo = JHelperContent::getActions('com_templates');
 

--- a/administrator/components/com_templates/views/style/view.html.php
+++ b/administrator/components/com_templates/views/style/view.html.php
@@ -51,6 +51,18 @@ class TemplatesViewStyle extends JViewLegacy
 		$this->item  = $this->get('Item');
 		$this->state = $this->get('State');
 		$this->form  = $this->get('Form');
+
+		// Global fields
+		$this->fields = array(
+			'home',
+			'client_id',
+			'template'
+		);
+
+		$context      = $this->form->getName();
+		$fields       = JFactory::getApplication()->getUserState($context . '.edit.global.fields', array());
+		$this->fields = array_merge($this->fields, $fields);
+
 		$this->canDo = JHelperContent::getActions('com_templates');
 
 		// Check for errors.

--- a/administrator/templates/hathor/html/com_fields/field/edit.php
+++ b/administrator/templates/hathor/html/com_fields/field/edit.php
@@ -71,20 +71,6 @@ JFactory::getDocument()->addScriptDeclaration('
 	<div class="col options-section">
 		<?php echo JHtml::_('sliders.start', 'groups-sliders-' . $this->item->id, array('useCookie' => 1)); ?>
 		<?php echo JHtml::_('sliders.panel', JText::_('COM_FIELDS_VIEW_FIELD_FIELDSET_GENERAL'), 'general'); ?>
-				<?php $this->set('fields',
-						array(
-							array(
-								'published',
-								'state',
-								'enabled',
-							),
-							'group_id',
-							'assigned_cat_ids',
-							'access',
-							'language',
-							'note',
-						)
-				); ?>
 				<?php echo JLayoutHelper::render('joomla.edit.global', $this); ?>
 				<?php $this->set('fields', null); ?>
 


### PR DESCRIPTION
### Summary of Changes
Define fields for the joomla.edit.global layout in the view.html.php files and not hardcoded it to the edit view of the extension.

cc: @zero-24


### Testing Instructions
- Install staging
- Go to one listed edit view in the backend
- Check the global fields layout on the right hand side
- Apply patch
- Check again, still be the same
![grafik](https://user-images.githubusercontent.com/10517822/80305085-e55d8680-87ba-11ea-91dd-d10cc96def08.png)


#### List of backendviews
- [ ] com_banners/views/banner/
- [ ] com_banners/views/client/
- [ ] com_categories/views/category/
- [ ] com_contact/views/contact/
- [ ] com_content/views/article/
- [ ] com_fields/views/field/
- [ ] com_fields/views/group/
- [ ] com_finder/views/filter/
- [ ] com_menus/views/item/
- [ ] com_modules/views/module/
- [ ] com_newsfeeds/views/newsfeed/
- [ ] com_plugins/views/plugin/
- [ ] com_tags/views/tag/
- [ ] com_templates/views/style/


### B/C statement
This PR is fully B/C as you can still choose to override the fields list from the edit view and the global layout.


### Expected result
Nothing hardcoded in the edit view anymore but still the same fields in the output


### Actual result
Right now we hardcode the fields for the global layout in the edit fields and they can not be extended by extensions.


### Documentation Changes Required
That should be documented but do you have any pointers where to look? Maybe we write a new docs page about it.
