### PR TITLE
[4.0] Fix template copy

### DIFF
--- a/administrator/components/com_templates/src/Model/TemplateModel.php
+++ b/administrator/components/com_templates/src/Model/TemplateModel.php
@@ -769,10 +769,10 @@ class TemplateModel extends FormModel
 			// Copy media files
 			if ($media = $manifest->media)
 			{
-				$folder      = (string) $languages->attributes()->folder;
-				$destination = (string) $languages->attributes()->destination;
+				$folder      = (string) $media->attributes()->folder;
+				$destination = (string) $media->attributes()->destination;
 
-				Folder::copy('media/' . $destination, $toPath . '/' . $folder);
+				Folder::copy(JPATH_SITE . '/media/' . $destination, $toPath . '/' . $folder);
 			}
 
 			// Adjust to ne template name
@@ -843,6 +843,8 @@ class TemplateModel extends FormModel
 			$replace[] = '<name>' . $newName . '</name>';
 			$pattern[] = '#<language(.*)' . $oldName . '(.*)</language>#';
 			$replace[] = '<language${1}' . $newName . '${2}</language>';
+			$pattern[] = '#<media(.*)' . $oldName . '(.*)>#';
+			$replace[] = '<media${1}' . $newName . '${2}>';
 			$contents = preg_replace($pattern, $replace, $contents);
 			$result = File::write($xmlFile, $contents) && $result;
 		}

--- a/administrator/components/com_templates/src/Model/TemplateModel.php
+++ b/administrator/components/com_templates/src/Model/TemplateModel.php
@@ -775,7 +775,7 @@ class TemplateModel extends FormModel
 				Folder::copy(JPATH_SITE . '/media/' . $destination, $toPath . '/' . $folder);
 			}
 
-			// Adjust to ne template name
+			// Adjust to new template name
 			if (!$this->fixTemplateName())
 			{
 				return false;

--- a/administrator/components/com_templates/src/Model/TemplateModel.php
+++ b/administrator/components/com_templates/src/Model/TemplateModel.php
@@ -787,7 +787,7 @@ class TemplateModel extends FormModel
 		// Rename Language files
 		// Get list of language files
 		$result   = true;
-		$files    = Folder::files($this->getState('to_path'), '.ini', true, true);
+		$files    = Folder::files($this->getState('to_path'), '\.ini$', true, true);
 		$newName  = strtolower($this->getState('new_name'));
 		$template = $this->getTemplate();
 		$oldName  = $template->element;

--- a/administrator/templates/atum/templateDetails.xml
+++ b/administrator/templates/atum/templateDetails.xml
@@ -43,8 +43,8 @@
 		<position>customtop</position>
 	</positions>
 	<languages folder="language">
-		<language tag="en-GB">en-GB/en-GB.tpl_atum.ini</language>
-		<language tag="en-GB">en-GB/en-GB.tpl_atum.sys.ini</language>
+		<language tag="en-GB">en-GB/tpl_atum.ini</language>
+		<language tag="en-GB">en-GB/tpl_atum.sys.ini</language>
 	</languages>
 	<config>
 		<fields name="params">

--- a/administrator/templates/atum/templateDetails.xml
+++ b/administrator/templates/atum/templateDetails.xml
@@ -26,6 +26,9 @@
 		<folder>Service</folder>
 		<folder>scss</folder>
 	</files>
+	<media destination="templates/atum" folder="media">
+		<folder>js</folder>
+	</media>
 	<positions>
 		<!-- used directly in the template -->
 		<position>bottom</position>

--- a/templates/cassiopeia/templateDetails.xml
+++ b/templates/cassiopeia/templateDetails.xml
@@ -40,8 +40,8 @@
 		<position>debug</position>
 	</positions>
 	<languages folder="language">
-		<language tag="en-GB">en-GB/en-GB.tpl_cassiopeia.ini</language>
-		<language tag="en-GB">en-GB/en-GB.tpl_cassiopeia.sys.ini</language>
+		<language tag="en-GB">en-GB/tpl_cassiopeia.ini</language>
+		<language tag="en-GB">en-GB/tpl_cassiopeia.sys.ini</language>
 	</languages>
 	<config>
 		<fields name="params">

--- a/templates/cassiopeia/templateDetails.xml
+++ b/templates/cassiopeia/templateDetails.xml
@@ -22,7 +22,6 @@
 		<folder>images</folder>
 		<folder>js</folder>
 		<folder>scss</folder>
-		<folder>language</folder>
 	</files>
 	<positions>
 		<position>menu</position>


### PR DESCRIPTION
Pull Request for Issue #28796 and #26259.

### Summary of Changes
* Adding logic to the template copy method to take care of language files in global language folder and media assets in /media
* Adjusted the templates manifest files: removing the language prefix, removing language folder from Cassiopeia, adding media folder to Atum
* Fixing the file filter to match all .ini files (it has to be regex)

### Testing Instructions
Test by copying a template in frontend and backend.

### Expected result
Works and all related files are copied and properly renamed where applicable.


### Actual result
* Cassiopeia fails with an error
* Atum is copied but not its assets in /media/templates/atum/js


### Documentation Changes Required
None
