### PR TITLE
Use renderField frontend com_config modules view

### DIFF
--- a/components/com_config/view/modules/tmpl/default_options.php
+++ b/components/com_config/view/modules/tmpl/default_options.php
@@ -30,21 +30,15 @@ endif;
 <?php foreach ($this->form->getFieldset($name) as $field) : ?>
 
 	<li>
-		<div class="control-group">
-			<div class="control-label">
-				<?php echo $field->label; ?>
-			</div>
-			<div class="controls">
-				<?php
-				// If multi-language site, make menu-type selection read-only
-				if (JLanguageMultilang::isEnabled() && $this->item['module'] === 'mod_menu' && $field->getAttribute('name') === 'menutype')
-				{
-					$field->__set('readonly', true);
-				}
-				echo $field->input;
-				?>
-			</div>
-		</div>
+		<?php
+		// If multi-language site, make menu-type selection read-only
+		if (JLanguageMultilang::isEnabled() && $this->item['module'] === 'mod_menu' && $field->getAttribute('name') === 'menutype')
+		{
+			$field->readonly = true;
+		}
+
+		echo $field->renderField();
+		?>
 	</li>
 
 <?php endforeach; ?>

--- a/components/com_config/view/modules/tmpl/default_options.php
+++ b/components/com_config/view/modules/tmpl/default_options.php
@@ -30,15 +30,11 @@ endif;
 <?php foreach ($this->form->getFieldset($name) as $field) : ?>
 
 	<li>
-		<?php
-		// If multi-language site, make menu-type selection read-only
-		if (JLanguageMultilang::isEnabled() && $this->item['module'] === 'mod_menu' && $field->getAttribute('name') === 'menutype')
-		{
-			$field->readonly = true;
-		}
-
-		echo $field->renderField();
-		?>
+		<?php // If multi-language site, make menu-type selection read-only ?>
+		<?php if (JLanguageMultilang::isEnabled() && $this->item['module'] === 'mod_menu' && $field->getAttribute('name') === 'menutype') : ?>
+			<?php $field->readonly = true; ?>
+		<?php endif; ?>
+		<?php echo $field->renderField(); ?>
 	</li>
 
 <?php endforeach; ?>


### PR DESCRIPTION
### Summary of Changes
Use renderField frontend com_contig modules view


### Testing Instructions
- go to the com_config modules frontend view (edit module)
- confirm all is working
- apply this patch
- confirm it is still working


#### Extra test
- repeat the steps from above on a multilangual site


### Expected result
We use renderField and not hardcode the field generation



### Actual result
We use a hardcoded field generation


### Documentation Changes Required
none

