### PR TITLE
Plugin parameters - added validate=options to all type=list

### DIFF
--- a/plugins/authentication/cookie/cookie.xml
+++ b/plugins/authentication/cookie/cookie.xml
@@ -35,6 +35,7 @@
 					default="16"
 					filter="integer"
 					required="true"
+					validate="options"
 					>
 					<option value="8">8</option>
 					<option value="16">16</option>

--- a/plugins/authentication/ldap/ldap.xml
+++ b/plugins/authentication/ldap/ldap.xml
@@ -93,6 +93,7 @@
 					type="list"
 					label="PLG_LDAP_FIELD_AUTHMETHOD_LABEL"
 					default="bind"
+					validate="options"
 					>
 					<option value="search">PLG_LDAP_FIELD_VALUE_BINDSEARCH</option>
 					<option value="bind">PLG_LDAP_FIELD_VALUE_BINDUSER</option>

--- a/plugins/captcha/recaptcha/recaptcha.xml
+++ b/plugins/captcha/recaptcha/recaptcha.xml
@@ -25,6 +25,7 @@
 					label="PLG_RECAPTCHA_VERSION_LABEL"
 					default="2.0"
 					size="1"
+					validate="options"
 					>
 					<option value="2.0">PLG_RECAPTCHA_VERSION_V2</option>
 				</field>
@@ -58,6 +59,7 @@
 					default="light"
 					showon="version:2.0"
 					filter=""
+					validate="options"
 					>
 					<option value="light">PLG_RECAPTCHA_THEME_LIGHT</option>
 					<option value="dark">PLG_RECAPTCHA_THEME_DARK</option>
@@ -70,6 +72,7 @@
 					default="normal"
 					showon="version:2.0"
 					filter=""
+					validate="options"
 					>
 					<option value="normal">PLG_RECAPTCHA_THEME_NORMAL</option>
 					<option value="compact">PLG_RECAPTCHA_THEME_COMPACT</option>

--- a/plugins/captcha/recaptcha_invisible/recaptcha_invisible.xml
+++ b/plugins/captcha/recaptcha_invisible/recaptcha_invisible.xml
@@ -50,6 +50,7 @@
 					label="PLG_RECAPTCHA_INVISIBLE_BADGE_LABEL"
 					description="PLG_RECAPTCHA_INVISIBLE_BADGE_DESC"
 					default="bottomright"
+					validate="options"
 					>
 					<option value="bottomright">PLG_RECAPTCHA_INVISIBLE_BADGE_BOTTOMRIGHT</option>
 					<option value="bottomleft">PLG_RECAPTCHA_INVISIBLE_BADGE_BOTTOMLEFT</option>

--- a/plugins/content/contact/contact.xml
+++ b/plugins/content/contact/contact.xml
@@ -25,6 +25,7 @@
 					label="PLG_CONTENT_CONTACT_PARAM_URL_LABEL"
 					description="PLG_CONTENT_CONTACT_PARAM_URL_DESCRIPTION"
 					default="url"
+					validate="options"
 					>
 					<option value="url">PLG_CONTENT_CONTACT_PARAM_URL_URL</option>
 					<option value="webpage">PLG_CONTENT_CONTACT_PARAM_URL_WEBPAGE</option>

--- a/plugins/content/emailcloak/emailcloak.xml
+++ b/plugins/content/emailcloak/emailcloak.xml
@@ -25,6 +25,7 @@
 					label="PLG_CONTENT_EMAILCLOAK_MODE_LABEL"
 					default="1"
 					filter="integer"
+					validate="options"
 					>
 					<option value="0">PLG_CONTENT_EMAILCLOAK_NONLINKABLE</option>
 					<option value="1">PLG_CONTENT_EMAILCLOAK_LINKABLE</option>

--- a/plugins/content/loadmodule/loadmodule.xml
+++ b/plugins/content/loadmodule/loadmodule.xml
@@ -24,6 +24,7 @@
 					type="list"
 					label="PLG_LOADMODULE_FIELD_STYLE_LABEL"
 					default="table"
+					validate="options"
 					>
 					<option value="table">PLG_LOADMODULE_FIELD_VALUE_TABLE</option>
 					<option value="horz">PLG_LOADMODULE_FIELD_VALUE_HORIZONTAL</option>

--- a/plugins/content/pagebreak/pagebreak.xml
+++ b/plugins/content/pagebreak/pagebreak.xml
@@ -80,6 +80,7 @@
 					type="list"
 					label="PLG_CONTENT_PAGEBREAK_STYLE_LABEL"
 					default="pages"
+					validate="options"
 					>
 					<option value="pages">PLG_CONTENT_PAGEBREAK_PAGES</option>
 					<option value="sliders">PLG_CONTENT_PAGEBREAK_SLIDERS</option>

--- a/plugins/content/pagenavigation/pagenavigation.xml
+++ b/plugins/content/pagenavigation/pagenavigation.xml
@@ -27,6 +27,7 @@
 					label="PLG_PAGENAVIGATION_FIELD_POSITION_LABEL"
 					default="1"
 					filter="integer"
+					validate="options"
 					>
 					<option value="1">PLG_PAGENAVIGATION_FIELD_VALUE_BELOW</option>
 					<option value="0">PLG_PAGENAVIGATION_FIELD_VALUE_ABOVE</option>
@@ -38,6 +39,7 @@
 					label="PLG_PAGENAVIGATION_FIELD_RELATIVE_LABEL"
 					default="1"
 					filter="integer"
+					validate="options"
 					>
 					<option value="1">PLG_PAGENAVIGATION_FIELD_VALUE_ARTICLE</option>
 					<option value="0">PLG_PAGENAVIGATION_FIELD_VALUE_TEXT</option>
@@ -49,6 +51,7 @@
 					label="PLG_PAGENAVIGATION_FIELD_DISPLAY_LABEL"
 					default="0"
 					filter="integer"
+					validate="options"
 					>
 					<option value="0">PLG_PAGENAVIGATION_FIELD_VALUE_NEXTPREV</option>
 					<option value="1">PLG_PAGENAVIGATION_FIELD_VALUE_TITLE</option>

--- a/plugins/content/vote/vote.xml
+++ b/plugins/content/vote/vote.xml
@@ -25,6 +25,7 @@
 					type="list"
 					label="PLG_VOTE_POSITION_LABEL"
 					default="top"
+					validate="options"
 					>
 					<option value="top">PLG_VOTE_TOP</option>
 					<option value="bottom">PLG_VOTE_BOTTOM</option>

--- a/plugins/editors/codemirror/codemirror.xml
+++ b/plugins/editors/codemirror/codemirror.xml
@@ -151,6 +151,7 @@
 					label="PLG_CODEMIRROR_FIELD_KEYMAP_LABEL"
 					description="PLG_CODEMIRROR_FIELD_KEYMAP_DESC"
 					default=""
+					validate="options"
 					>
 					<option value="">JDEFAULT</option>
 					<option value="emacs">PLG_CODEMIRROR_FIELD_KEYMAP_EMACS</option>
@@ -163,6 +164,7 @@
 					type="list"
 					label="PLG_CODEMIRROR_FIELD_FULLSCREEN_LABEL"
 					default="F10"
+					validate="options"
 					>
 					<option value="F1">F1</option>
 					<option value="F2">F2</option>
@@ -249,6 +251,7 @@
 					label="PLG_CODEMIRROR_FIELD_LINE_HEIGHT_LABEL"
 					default="1.2"
 					filter="float"
+					validate="options"
 					>
 					<option value="1.0">1.0</option>
 					<option value="1.1">1.1</option>
@@ -268,6 +271,7 @@
 					type="list"
 					label="PLG_CODEMIRROR_FIELD_VALUE_SCROLLBARSTYLE_LABEL"
 					default="native"
+					validate="options"
 					>
 					<option value="native">PLG_CODEMIRROR_FIELD_VALUE_SCROLLBARSTYLE_DEFAULT</option>
 					<option value="simple">PLG_CODEMIRROR_FIELD_VALUE_SCROLLBARSTYLE_SIMPLE</option>

--- a/plugins/editors/tinymce/forms/setoptions.xml
+++ b/plugins/editors/tinymce/forms/setoptions.xml
@@ -58,6 +58,7 @@
 		type="list"
 		label="PLG_TINY_FIELD_ENCODING_LABEL"
 		default="raw"
+		validate="options"
 		>
 		<option value="named">PLG_TINY_FIELD_VALUE_NAMED</option>
 		<option value="numeric">PLG_TINY_FIELD_VALUE_NUMERIC</option>
@@ -93,6 +94,7 @@
 		type="list"
 		label="PLG_TINY_FIELD_DIRECTION_LABEL"
 		default="ltr"
+		validate="options"
 		>
 		<option value="ltr">PLG_TINY_FIELD_VALUE_LTR</option>
 		<option value="rtl">PLG_TINY_FIELD_VALUE_RTL</option>
@@ -122,6 +124,7 @@
 		type="list"
 		label="PLG_TINY_FIELD_URLS_LABEL"
 		default="1"
+		validate="options"
 		>
 		<option value="0">PLG_TINY_FIELD_VALUE_ABSOLUTE</option>
 		<option value="1">PLG_TINY_FIELD_VALUE_RELATIVE</option>
@@ -132,6 +135,7 @@
 		type="list"
 		label="PLG_TINY_FIELD_NEWLINES_LABEL"
 		default="0"
+		validate="options"
 		>
 		<option value="1">PLG_TINY_FIELD_VALUE_BR</option>
 		<option value="0">PLG_TINY_FIELD_VALUE_P</option>

--- a/plugins/fields/editor/params/editor.xml
+++ b/plugins/fields/editor/params/editor.xml
@@ -7,6 +7,7 @@
 				type="list"
 				label="PLG_FIELDS_EDITOR_PARAMS_SHOW_BUTTONS_LABEL"
 				filter="integer"
+				validate="options"
 				>
 				<option value="">COM_FIELDS_FIELD_USE_GLOBAL</option>
 				<option value="1">JYES</option>

--- a/plugins/fields/imagelist/params/imagelist.xml
+++ b/plugins/fields/imagelist/params/imagelist.xml
@@ -20,6 +20,7 @@
 				type="list"
 				label="PLG_FIELDS_IMAGELIST_PARAMS_MULTIPLE_LABEL"
 				filter="integer"
+				validate="options"
 				>
 				<option value="">COM_FIELDS_FIELD_USE_GLOBAL</option>
 				<option value="1">JYES</option>

--- a/plugins/fields/integer/params/integer.xml
+++ b/plugins/fields/integer/params/integer.xml
@@ -7,6 +7,7 @@
 				type="list"
 				label="PLG_FIELDS_INTEGER_PARAMS_MULTIPLE_LABEL"
 				filter="integer"
+				validate="options"
 				>
 				<option value="">COM_FIELDS_FIELD_USE_GLOBAL</option>
 				<option value="1">JYES</option>

--- a/plugins/fields/list/params/list.xml
+++ b/plugins/fields/list/params/list.xml
@@ -7,6 +7,7 @@
 				type="list"
 				label="PLG_FIELDS_LIST_PARAMS_MULTIPLE_LABEL"
 				filter="integer"
+				validate="options"
 				>
 				<option value="">COM_FIELDS_FIELD_USE_GLOBAL</option>
 				<option value="1">JYES</option>

--- a/plugins/fields/media/media.xml
+++ b/plugins/fields/media/media.xml
@@ -36,6 +36,7 @@
 					label="PLG_FIELDS_MEDIA_PARAMS_PREVIEW_LABEL"
 					class="list"
 					default="tooltip"
+					validate="options"
 					>
 					<option value="tooltip">PLG_FIELDS_MEDIA_PARAMS_PREVIEW_TOOLTIP</option>
 					<option value="true">PLG_FIELDS_MEDIA_PARAMS_PREVIEW_INLINE</option>

--- a/plugins/fields/media/params/media.xml
+++ b/plugins/fields/media/params/media.xml
@@ -15,6 +15,7 @@
 				name="preview"
 				type="list"
 				label="PLG_FIELDS_MEDIA_PARAMS_PREVIEW_LABEL"
+				validate="options"
 				>
 				<option value="">COM_FIELDS_FIELD_USE_GLOBAL</option>
 				<option value="tooltip">PLG_FIELDS_MEDIA_PARAMS_PREVIEW_TOOLTIP</option>

--- a/plugins/fields/sql/params/sql.xml
+++ b/plugins/fields/sql/params/sql.xml
@@ -17,6 +17,7 @@
 				type="list"
 				label="PLG_FIELDS_SQL_PARAMS_MULTIPLE_LABEL"
 				filter="integer"
+				validate="options"
 				>
 				<option value="">COM_FIELDS_FIELD_USE_GLOBAL</option>
 				<option value="1">JYES</option>

--- a/plugins/fields/url/params/url.xml
+++ b/plugins/fields/url/params/url.xml
@@ -8,6 +8,7 @@
 				label="PLG_FIELDS_URL_PARAMS_SCHEMES_LABEL"
 				multiple="true"
 				layout="joomla.form.field.list-fancy-select"
+				validate="options"
 				>
 				<option value="http">HTTP</option>
 				<option value="https">HTTPS</option>
@@ -22,6 +23,7 @@
 				type="list"
 				label="PLG_FIELDS_URL_PARAMS_RELATIVE_LABEL"
 				filter="integer"
+				validate="options"
 				>
 				<option value="">COM_FIELDS_FIELD_USE_GLOBAL</option>
 				<option value="1">JYES</option>

--- a/plugins/fields/url/url.xml
+++ b/plugins/fields/url/url.xml
@@ -27,6 +27,7 @@
 					label="PLG_FIELDS_URL_PARAMS_SCHEMES_LABEL"
 					multiple="true"
 					layout="joomla.form.field.list-fancy-select"
+					validate="options"
 					>
 					<option value="http">HTTP</option>
 					<option value="https">HTTPS</option>

--- a/plugins/fields/usergrouplist/params/usergrouplist.xml
+++ b/plugins/fields/usergrouplist/params/usergrouplist.xml
@@ -7,6 +7,7 @@
 				type="list"
 				label="PLG_FIELDS_USERGROUPLIST_PARAMS_MULTIPLE_LABEL"
 				filter="integer"
+				validate="options"
 				>
 				<option value="">COM_FIELDS_FIELD_USE_GLOBAL</option>
 				<option value="1">JYES</option>

--- a/plugins/system/debug/debug.xml
+++ b/plugins/system/debug/debug.xml
@@ -237,6 +237,7 @@
 					multiple="true"
 					layout="joomla.form.field.list-fancy-select"
 					default="all"
+					validate="options"
 					>
 					<option value="all">PLG_DEBUG_FIELD_LOG_PRIORITIES_ALL</option>
 					<option value="emergency">PLG_DEBUG_FIELD_LOG_PRIORITIES_EMERGENCY</option>

--- a/plugins/system/languagefilter/languagefilter.xml
+++ b/plugins/system/languagefilter/languagefilter.xml
@@ -25,6 +25,7 @@
 					label="PLG_SYSTEM_LANGUAGEFILTER_FIELD_DETECT_BROWSER_LABEL"
 					default="0"
 					filter="integer"
+					validate="options"
 					>
 					<option value="0">PLG_SYSTEM_LANGUAGEFILTER_SITE_LANGUAGE</option>
 					<option value="1">PLG_SYSTEM_LANGUAGEFILTER_BROWSER_SETTINGS</option>
@@ -107,6 +108,7 @@
 					label="PLG_SYSTEM_LANGUAGEFILTER_FIELD_COOKIE_LABEL"
 					default="0"
 					filter="integer"
+					validate="options"
 					>
 					<option value="1">PLG_SYSTEM_LANGUAGEFILTER_OPTION_YEAR</option>
 					<option value="0">PLG_SYSTEM_LANGUAGEFILTER_OPTION_SESSION</option>

--- a/plugins/system/stats/stats.xml
+++ b/plugins/system/stats/stats.xml
@@ -48,6 +48,7 @@
 					type="list"
 					label="PLG_SYSTEM_STATS_MODE_LABEL"
 					default="1"
+					validate="options"
 					>
 					<option value="1">PLG_SYSTEM_STATS_MODE_OPTION_ALWAYS_SEND</option>
 					<option value="2">PLG_SYSTEM_STATS_MODE_OPTION_ON_DEMAND</option>

--- a/plugins/twofactorauth/totp/totp.xml
+++ b/plugins/twofactorauth/totp/totp.xml
@@ -27,6 +27,7 @@
 					label="PLG_TWOFACTORAUTH_TOTP_SECTION_LABEL"
 					default="3"
 					filter="integer"
+					validate="options"
 					>
 					<option value="1">PLG_TWOFACTORAUTH_TOTP_SECTION_SITE</option>
 					<option value="2">PLG_TWOFACTORAUTH_TOTP_SECTION_ADMIN</option>

--- a/plugins/twofactorauth/yubikey/yubikey.xml
+++ b/plugins/twofactorauth/yubikey/yubikey.xml
@@ -26,6 +26,7 @@
 					label="PLG_TWOFACTORAUTH_YUBIKEY_SECTION_LABEL"
 					default="3"
 					filter="integer"
+					validate="options"
 					>
 					<option value="1">PLG_TWOFACTORAUTH_YUBIKEY_SECTION_SITE</option>
 					<option value="2">PLG_TWOFACTORAUTH_YUBIKEY_SECTION_ADMIN</option>

--- a/plugins/user/profile/profile.xml
+++ b/plugins/user/profile/profile.xml
@@ -35,6 +35,7 @@
 					label="PLG_USER_PROFILE_FIELD_ADDRESS1_LABEL"
 					default="1"
 					filter="integer"
+					validate="options"
 					>
 					<option value="2">JOPTION_REQUIRED</option>
 					<option value="1">JOPTION_OPTIONAL</option>
@@ -47,6 +48,7 @@
 					label="PLG_USER_PROFILE_FIELD_ADDRESS2_LABEL"
 					default="1"
 					filter="integer"
+					validate="options"
 					>
 					<option value="2">JOPTION_REQUIRED</option>
 					<option value="1">JOPTION_OPTIONAL</option>
@@ -59,6 +61,7 @@
 					label="PLG_USER_PROFILE_FIELD_CITY_LABEL"
 					default="1"
 					filter="integer"
+					validate="options"
 					>
 					<option value="2">JOPTION_REQUIRED</option>
 					<option value="1">JOPTION_OPTIONAL</option>
@@ -71,6 +74,7 @@
 					label="PLG_USER_PROFILE_FIELD_REGION_LABEL"
 					default="1"
 					filter="integer"
+					validate="options"
 					>
 					<option value="2">JOPTION_REQUIRED</option>
 					<option value="1">JOPTION_OPTIONAL</option>
@@ -83,6 +87,7 @@
 					label="PLG_USER_PROFILE_FIELD_COUNTRY_LABEL"
 					default="1"
 					filter="integer"
+					validate="options"
 					>
 					<option value="2">JOPTION_REQUIRED</option>
 					<option value="1">JOPTION_OPTIONAL</option>
@@ -95,6 +100,7 @@
 					label="PLG_USER_PROFILE_FIELD_POSTAL_CODE_LABEL"
 					default="1"
 					filter="integer"
+					validate="options"
 					>
 					<option value="2">JOPTION_REQUIRED</option>
 					<option value="1">JOPTION_OPTIONAL</option>
@@ -107,6 +113,7 @@
 					label="PLG_USER_PROFILE_FIELD_PHONE_LABEL"
 					default="1"
 					filter="integer"
+					validate="options"
 					>
 					<option value="2">JOPTION_REQUIRED</option>
 					<option value="1">JOPTION_OPTIONAL</option>
@@ -119,6 +126,7 @@
 					label="PLG_USER_PROFILE_FIELD_WEB_SITE_LABEL"
 					default="1"
 					filter="integer"
+					validate="options"
 					>
 					<option value="2">JOPTION_REQUIRED</option>
 					<option value="1">JOPTION_OPTIONAL</option>
@@ -131,6 +139,7 @@
 					label="PLG_USER_PROFILE_FIELD_FAVORITE_BOOK_LABEL"
 					default="1"
 					filter="integer"
+					validate="options"
 					>
 					<option value="2">JOPTION_REQUIRED</option>
 					<option value="1">JOPTION_OPTIONAL</option>
@@ -143,6 +152,7 @@
 					label="PLG_USER_PROFILE_FIELD_ABOUT_ME_LABEL"
 					default="1"
 					filter="integer"
+					validate="options"
 					>
 					<option	value="2">JOPTION_REQUIRED</option>
 					<option	value="1">JOPTION_OPTIONAL</option>
@@ -155,6 +165,7 @@
 					label="PLG_USER_PROFILE_FIELD_TOS_LABEL"
 					default="0"
 					filter="integer"
+					validate="options"
 					>
 					<option	value="2">JOPTION_REQUIRED</option>
 					<option	value="0">JDISABLED</option>
@@ -177,6 +188,7 @@
 					label="PLG_USER_PROFILE_FIELD_DOB_LABEL"
 					default="1"
 					filter="integer"
+					validate="options"
 					>
 					<option	value="2">JOPTION_REQUIRED</option>
 					<option	value="1">JOPTION_OPTIONAL</option>
@@ -202,6 +214,7 @@
 					label="PLG_USER_PROFILE_FIELD_ADDRESS1_LABEL"
 					default="1"
 					filter="integer"
+					validate="options"
 					>
 					<option value="2">JOPTION_REQUIRED</option>
 					<option value="1">JOPTION_OPTIONAL</option>
@@ -214,6 +227,7 @@
 					label="PLG_USER_PROFILE_FIELD_ADDRESS2_LABEL"
 					default="1"
 					filter="integer"
+					validate="options"
 					>
 					<option value="2">JOPTION_REQUIRED</option>
 					<option value="1">JOPTION_OPTIONAL</option>
@@ -226,6 +240,7 @@
 					label="PLG_USER_PROFILE_FIELD_CITY_LABEL"
 					default="1"
 					filter="integer"
+					validate="options"
 					>
 					<option value="2">JOPTION_REQUIRED</option>
 					<option value="1">JOPTION_OPTIONAL</option>
@@ -238,6 +253,7 @@
 					label="PLG_USER_PROFILE_FIELD_REGION_LABEL"
 					default="1"
 					filter="integer"
+					validate="options"
 					>
 					<option value="2">JOPTION_REQUIRED</option>
 					<option value="1">JOPTION_OPTIONAL</option>
@@ -250,6 +266,7 @@
 					label="PLG_USER_PROFILE_FIELD_COUNTRY_LABEL"
 					default="1"
 					filter="integer"
+					validate="options"
 					>
 					<option value="2">JOPTION_REQUIRED</option>
 					<option value="1">JOPTION_OPTIONAL</option>
@@ -262,6 +279,7 @@
 					label="PLG_USER_PROFILE_FIELD_POSTAL_CODE_LABEL"
 					default="1"
 					filter="integer"
+					validate="options"
 					>
 					<option value="2">JOPTION_REQUIRED</option>
 					<option value="1">JOPTION_OPTIONAL</option>
@@ -274,6 +292,7 @@
 					label="PLG_USER_PROFILE_FIELD_PHONE_LABEL"
 					default="1"
 					filter="integer"
+					validate="options"
 					>
 					<option value="2">JOPTION_REQUIRED</option>
 					<option value="1">JOPTION_OPTIONAL</option>
@@ -286,6 +305,7 @@
 					label="PLG_USER_PROFILE_FIELD_WEB_SITE_LABEL"
 					default="1"
 					filter="integer"
+					validate="options"
 					>
 					<option value="2">JOPTION_REQUIRED</option>
 					<option value="1">JOPTION_OPTIONAL</option>
@@ -298,6 +318,7 @@
 					label="PLG_USER_PROFILE_FIELD_FAVORITE_BOOK_LABEL"
 					default="1"
 					filter="integer"
+					validate="options"
 					>
 					<option value="2">JOPTION_REQUIRED</option>
 					<option value="1">JOPTION_OPTIONAL</option>
@@ -310,6 +331,7 @@
 					label="PLG_USER_PROFILE_FIELD_ABOUT_ME_LABEL"
 					default="1"
 					filter="integer"
+					validate="options"
 					>
 					<option	value="2">JOPTION_REQUIRED</option>
 					<option	value="1">JOPTION_OPTIONAL</option>
@@ -322,6 +344,7 @@
 					label="PLG_USER_PROFILE_FIELD_DOB_LABEL"
 					default="1"
 					filter="integer"
+					validate="options"
 					>
 					<option	value="2">JOPTION_REQUIRED</option>
 					<option	value="1">JOPTION_OPTIONAL</option>


### PR DESCRIPTION
This PR adds validation to parameter fields of type=option

I've added
```xml
validate="options"
```
to all fields of type=list with defined options