### PR TITLE
back-end Component Parameters - added validate=options

### DIFF
--- a/administrator/components/com_actionlogs/config.xml
+++ b/administrator/components/com_actionlogs/config.xml
@@ -17,6 +17,7 @@
 			type="list"
 			label="COM_ACTIONLOGS_CSV_DELIMITER_LABEL"
 			default=","
+			validate="options"
 			>
 			<option value=",">COM_ACTIONLOGS_COMMA</option>
 			<option value=";">COM_ACTIONLOGS_SEMICOLON</option>

--- a/administrator/components/com_banners/config.xml
+++ b/administrator/components/com_banners/config.xml
@@ -12,6 +12,7 @@
 			label="COM_BANNERS_FIELD_PURCHASETYPE_LABEL"
 			id="purchase_type"
 			default="1"
+			validate="options"
 			>
 			<option value="1">COM_BANNERS_FIELD_VALUE_UNLIMITED</option>
 			<option value="2">COM_BANNERS_FIELD_VALUE_YEARLY</option>

--- a/administrator/components/com_banners/forms/banner.xml
+++ b/administrator/components/com_banners/forms/banner.xml
@@ -46,6 +46,7 @@
 			class="custom-select-color-state"
 			size="1"
 			default="1"
+			validate="options"
 			>
 			<option value="1">JPUBLISHED</option>
 			<option value="0">JUNPUBLISHED</option>
@@ -90,6 +91,7 @@
 			type="list"
 			label="COM_BANNERS_FIELD_TYPE_LABEL"
 			default="0"
+			validate="options"
 			>
 			<option value="0">COM_BANNERS_FIELD_VALUE_IMAGE</option>
 			<option value="1">COM_BANNERS_FIELD_VALUE_CUSTOM</option>
@@ -238,6 +240,7 @@
 			type="list"
 			label="COM_BANNERS_FIELD_PURCHASETYPE_LABEL"
 			default="0"
+			validate="options"
 			>
 			<option value="-1">COM_BANNERS_FIELD_VALUE_USECLIENTDEFAULT</option>
 			<option value="1">COM_BANNERS_FIELD_VALUE_UNLIMITED</option>
@@ -252,6 +255,7 @@
 			type="list"
 			label="COM_BANNERS_FIELD_TRACKIMPRESSION_LABEL"
 			default="0"
+			validate="options"
 			>
 			<option value="-1">COM_BANNERS_FIELD_VALUE_USECLIENTDEFAULT</option>
 			<option value="0">JNO</option>
@@ -263,6 +267,7 @@
 			type="list"
 			label="COM_BANNERS_FIELD_TRACKCLICK_LABEL"
 			default="0"
+			validate="options"
 			>
 			<option value="-1">COM_BANNERS_FIELD_VALUE_USECLIENTDEFAULT</option>
 			<option value="0">JNO</option>

--- a/administrator/components/com_banners/forms/client.xml
+++ b/administrator/components/com_banners/forms/client.xml
@@ -41,6 +41,7 @@
 			class="custom-select-color-state"
 			size="1"
 			default="1"
+			validate="options"
 			>
 			<option value="1">JPUBLISHED</option>
 			<option value="0">JUNPUBLISHED</option>
@@ -61,6 +62,7 @@
 			type="list"
 			label="COM_BANNERS_FIELD_PURCHASETYPE_LABEL"
 			default="0"
+			validate="options"
 			>
 			<option value="-1">JGLOBAL_USE_GLOBAL</option>
 			<option value="1">COM_BANNERS_FIELD_VALUE_UNLIMITED</option>
@@ -75,6 +77,7 @@
 			type="list"
 			label="COM_BANNERS_FIELD_TRACKIMPRESSION_LABEL"
 			default="0"
+			validate="options"
 			>
 			<option value="-1">JGLOBAL_USE_GLOBAL</option>
 			<option value="0">JNO</option>
@@ -86,6 +89,7 @@
 			type="list"
 			label="COM_BANNERS_FIELD_TRACKCLICK_LABEL"
 			default="0"
+			validate="options"
 			>
 			<option value="-1">JGLOBAL_USE_GLOBAL</option>
 			<option value="0">JNO</option>

--- a/administrator/components/com_banners/forms/filter_clients.xml
+++ b/administrator/components/com_banners/forms/filter_clients.xml
@@ -25,6 +25,7 @@
 			label="COM_BANNERS_SELECT_TYPE"
 			default="0"
 			onchange="this.form.submit();"
+			validate="options"
 			>
 			<option value="">COM_BANNERS_SELECT_TYPE</option>
 			<option value="1">COM_BANNERS_FIELD_VALUE_UNLIMITED</option>

--- a/administrator/components/com_banners/forms/filter_tracks.xml
+++ b/administrator/components/com_banners/forms/filter_tracks.xml
@@ -36,6 +36,7 @@
 			type="list"
 			label="COM_BANNERS_SELECT_TYPE"
 			onchange="this.form.submit();"
+			validate="options"
 			>
 			<option value="">COM_BANNERS_SELECT_TYPE</option>
 			<option value="1">COM_BANNERS_TYPE1</option>

--- a/administrator/components/com_categories/forms/category.xml
+++ b/administrator/components/com_categories/forms/category.xml
@@ -114,6 +114,7 @@
 		default="1"
 		class="custom-select-color-state"
 		size="1"
+		validate="options"
 		>
 		<option value="1">JPUBLISHED</option>
 		<option value="0">JUNPUBLISHED</option>
@@ -267,6 +268,7 @@
 				name="robots"
 				type="list"
 				label="JFIELD_METADATA_ROBOTS_LABEL"
+				validate="options"
 				>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="index, follow">JGLOBAL_INDEX_FOLLOW</option>

--- a/administrator/components/com_config/forms/application.xml
+++ b/administrator/components/com_config/forms/application.xml
@@ -10,6 +10,7 @@
 			label="COM_CONFIG_FIELD_CACHE_LABEL"
 			default="2"
 			filter="integer"
+			validate="options"
 			>
 			<option value="0">COM_CONFIG_FIELD_VALUE_CACHE_OFF</option>
 			<option value="1">COM_CONFIG_FIELD_VALUE_CACHE_CONSERVATIVE</option>
@@ -215,6 +216,7 @@
 			label="COM_CONFIG_FIELD_DATABASE_ENCRYPTION_MODE_LABEL"
 			default="0"
 			filter="integer"
+			validate="options"
 			>
 			<option value="0">COM_CONFIG_FIELD_DATABASE_ENCRYPTION_MODE_VALUE_NONE</option>
 			<option value="1">COM_CONFIG_FIELD_DATABASE_ENCRYPTION_MODE_VALUE_ONE_WAY</option>
@@ -526,6 +528,7 @@
 			default="mail"
 			filter="word"
 			showon="mailonline:1"
+			validate="options"
 			>
 			<option value="mail">COM_CONFIG_FIELD_VALUE_PHP_MAIL</option>
 			<option value="sendmail">COM_CONFIG_FIELD_VALUE_SENDMAIL</option>
@@ -572,6 +575,7 @@
 			default="none"
 			showon="mailonline:1[AND]mailer:smtp"
 			filter="word"
+			validate="options"
 			>
 			<option value="none">COM_CONFIG_FIELD_VALUE_NONE</option>
 			<option value="ssl">COM_CONFIG_FIELD_VALUE_SSL</option>
@@ -633,6 +637,7 @@
 			type="list"
 			label="JFIELD_METADATA_ROBOTS_LABEL"
 			default=""
+			validate="options"
 			>
 			<option value="">JGLOBAL_INDEX_FOLLOW</option>
 			<option value="noindex, follow">JGLOBAL_NOINDEX_FOLLOW</option>
@@ -745,6 +750,7 @@
 			label="COM_CONFIG_FIELD_SITENAME_PAGETITLES_LABEL"
 			default="0"
 			filter="integer"
+			validate="options"
 			>
 			<option value="2">COM_CONFIG_FIELD_VALUE_AFTER</option>
 			<option value="1">COM_CONFIG_FIELD_VALUE_BEFORE</option>
@@ -783,6 +789,7 @@
 			label="COM_CONFIG_FIELD_ERROR_REPORTING_LABEL"
 			default="default"
 			filter="cmd"
+			validate="options"
 			>
 			<option value="default">COM_CONFIG_FIELD_VALUE_SYSTEM_DEFAULT</option>
 			<option value="none">COM_CONFIG_FIELD_VALUE_NONE</option>
@@ -796,6 +803,7 @@
 			label="COM_CONFIG_FIELD_FORCE_SSL_LABEL"
 			default="-1"
 			filter="integer"
+			validate="options"
 			>
 			<option value="0">COM_CONFIG_FIELD_VALUE_NONE</option>
 			<option value="1">COM_CONFIG_FIELD_VALUE_ADMINISTRATOR_ONLY</option>
@@ -970,6 +978,7 @@
 			default="1"
 			filter="integer"
 			showon="offline:1"
+			validate="options"
 			>
 			<option value="0">JHIDE</option>
 			<option value="1">COM_CONFIG_FIELD_VALUE_DISPLAY_OFFLINE_MESSAGE_CUSTOM</option>
@@ -999,6 +1008,7 @@
 			label="COM_CONFIG_FRONTEDITING_LABEL"
 			default="1"
 			filter="integer"
+			validate="options"
 			>
 			<option value="2">COM_CONFIG_FRONTEDITING_MENUSANDMODULES</option>
 			<option value="1">COM_CONFIG_FRONTEDITING_MODULES</option>
@@ -1039,6 +1049,7 @@
 			label="COM_CONFIG_FIELD_DEFAULT_LIST_LIMIT_LABEL"
 			default="20"
 			filter="integer"
+			validate="options"
 			>
 			<option value="5">J5</option>
 			<option value="10">J10</option>
@@ -1058,6 +1069,7 @@
 			label="COM_CONFIG_FIELD_DEFAULT_FEED_LIMIT_LABEL"
 			default="10"
 			filter="integer"
+			validate="options"
 			>
 			<option value="5">J5</option>
 			<option value="10">J10</option>
@@ -1075,6 +1087,7 @@
 			label="COM_CONFIG_FIELD_FEED_EMAIL_LABEL"
 			default="none"
 			filter="word"
+			validate="options"
 			>
 			<option value="author">COM_CONFIG_FIELD_VALUE_AUTHOR_EMAIL</option>
 			<option value="site">COM_CONFIG_FIELD_VALUE_SITE_EMAIL</option>

--- a/administrator/components/com_contact/config.xml
+++ b/administrator/components/com_contact/config.xml
@@ -816,7 +816,7 @@
  			type="list"
  			label="COM_CONTACT_NUMBER_CONTACTS_LIST_LABEL"
  			default="10"
-		    validate="options"
+			validate="options"
  			>
  			<option value="5">J5</option>
  			<option value="10">J10</option>

--- a/administrator/components/com_contact/config.xml
+++ b/administrator/components/com_contact/config.xml
@@ -20,6 +20,7 @@
 			type="list"
 			label="COM_CONTACT_FIELD_CONTACT_SHOW_CATEGORY_LABEL"
 			default="hide"
+			validate="options"
 			>
 			<option value="hide">JHIDE</option>
 			<option value="show_no_link">COM_CONTACT_FIELD_VALUE_NO_LINK</option>
@@ -295,6 +296,7 @@
 			label="COM_CONTACT_FIELD_ARTICLES_DISPLAY_NUM_LABEL"
 			default="10"
 			showon="show_articles:1"
+			validate="options"
 			>
 			<option value="use_contact">COM_CONTACT_FIELD_VALUE_USE_CONTACT_SETTINGS</option>
 			<option value="5">J5</option>
@@ -402,6 +404,7 @@
 			type="list"
 			label="COM_CONTACT_FIELD_ICONS_SETTINGS_LABEL"
 			default="0"
+			validate="options"
 			>
 			<option value="0">COM_CONTACT_FIELD_VALUE_ICONS</option>
 			<option value="1">COM_CONTACT_FIELD_VALUE_TEXT</option>
@@ -515,6 +518,7 @@
 			type="list"
 			label="JGLOBAL_MAXIMUM_CATEGORY_LEVELS_LABEL"
 			default="-1"
+			validate="options"
 			>
 			<option value="-1">JALL</option>
 			<option value="0">JNONE</option>
@@ -592,6 +596,7 @@
 			type="list"
 			label="JGLOBAL_MAXIMUM_CATEGORY_LEVELS_LABEL"
 			default="-1"
+			validate="options"
 			>
 			<option value="-1">JALL</option>
 			<option value="0">JNONE</option>
@@ -787,6 +792,7 @@
 			type="list"
 			label="JGLOBAL_PAGINATION_LABEL"
 			default="2"
+			validate="options"
 			>
 			<option value="0">JHIDE</option>
 			<option value="1">JSHOW</option>
@@ -810,6 +816,7 @@
  			type="list"
  			label="COM_CONTACT_NUMBER_CONTACTS_LIST_LABEL"
  			default="10"
+		    validate="options"
  			>
  			<option value="5">J5</option>
  			<option value="10">J10</option>

--- a/administrator/components/com_contact/forms/contact.xml
+++ b/administrator/components/com_contact/forms/contact.xml
@@ -49,6 +49,7 @@
 			id="published"
 			class="custom-select-color-state"
 			size="1"
+			validate="options"
 			>
 			<option value="1">JPUBLISHED</option>
 			<option value="0">JUNPUBLISHED</option>
@@ -216,6 +217,7 @@
 			type="list"
 			label="COM_CONTACT_FIELD_ICONS_SETTINGS"
 			default="0"
+			validate="options"
 			>
 			<option value="0">COM_CONTACT_FIELD_VALUE_NONE</option>
 			<option value="1">COM_CONTACT_FIELD_VALUE_TEXT</option>
@@ -391,6 +393,7 @@
 					type="list"
 					label="JGLOBAL_SHOW_CATEGORY_LABEL"
 					useglobal="true"
+					validate="options"
 					>
 					<option value="hide">JHIDE</option>
 					<option value="show_no_link">COM_CONTACT_FIELD_VALUE_NO_LINK</option>
@@ -402,6 +405,7 @@
 					type="list"
 					label="COM_CONTACT_FIELD_CONTACT_SHOW_LIST_LABEL"
 					useglobal="true"
+					validate="options"
 					>
 					<option value="0">JHIDE</option>
 					<option value="1">JSHOW</option>
@@ -412,6 +416,7 @@
 					type="list"
 					label="COM_CONTACT_FIELD_SHOW_TAGS_LABEL"
 					useglobal="true"
+					validate="options"
 					>
 					<option value="0">JHIDE</option>
 					<option value="1">JSHOW</option>
@@ -423,6 +428,7 @@
 					label="COM_CONTACT_FIELD_SHOW_INFO_LABEL"
 					class="custom-select-color"
 					useglobal="true"
+					validate="options"
 					>
 					<option value="0">JHIDE</option>
 					<option value="1">JSHOW</option>
@@ -434,6 +440,7 @@
 					label="COM_CONTACT_FIELD_PARAMS_NAME_LABEL"
 					useglobal="true"
 					showon="show_info:1"
+					validate="options"
 					>
 					<option value="0">JHIDE</option>
 					<option value="1">JSHOW</option>
@@ -445,6 +452,7 @@
 					label="COM_CONTACT_FIELD_PARAMS_CONTACT_POSITION_LABEL"
 					useglobal="true"
 					showon="show_info:1"
+					validate="options"
 					>
 					<option value="0">JHIDE</option>
 					<option value="1">JSHOW</option>
@@ -456,6 +464,7 @@
 					label="JGLOBAL_EMAIL"
 					useglobal="true"
 					showon="show_info:1"
+					validate="options"
 					>
 					<option value="0">JHIDE</option>
 					<option value="1">JSHOW</option>
@@ -468,6 +477,7 @@
 					class="custom-select-color"
 					useglobal="true"
 					showon="show_info:1"
+					validate="options"
 					>
 					<option value="1">JYES</option>
 					<option value="0">JNO</option>
@@ -479,6 +489,7 @@
 					label="COM_CONTACT_FIELD_PARAMS_STREET_ADDRESS_LABEL"
 					useglobal="true"
 					showon="show_info:1"
+					validate="options"
 					>
 					<option value="0">JHIDE</option>
 					<option value="1">JSHOW</option>
@@ -490,6 +501,7 @@
 					label="COM_CONTACT_FIELD_PARAMS_TOWN-SUBURB_LABEL"
 					useglobal="true"
 					showon="show_info:1"
+					validate="options"
 					>
 					<option value="0">JHIDE</option>
 					<option value="1">JSHOW</option>
@@ -501,6 +513,7 @@
 					label="COM_CONTACT_FIELD_PARAMS_STATE-COUNTY_LABEL"
 					useglobal="true"
 					showon="show_info:1"
+					validate="options"
 					>
 					<option value="0">JHIDE</option>
 					<option value="1">JSHOW</option>
@@ -512,6 +525,7 @@
 					label="COM_CONTACT_FIELD_PARAMS_POST-ZIP_CODE_LABEL"
 					useglobal="true"
 					showon="show_info:1"
+					validate="options"
 					>
 					<option value="0">JHIDE</option>
 					<option value="1">JSHOW</option>
@@ -523,6 +537,7 @@
 					label="COM_CONTACT_FIELD_PARAMS_COUNTRY_LABEL"
 					useglobal="true"
 					showon="show_info:1"
+					validate="options"
 					>
 					<option value="0">JHIDE</option>
 					<option value="1">JSHOW</option>
@@ -534,6 +549,7 @@
 					label="COM_CONTACT_FIELD_PARAMS_TELEPHONE_LABEL"
 					useglobal="true"
 					showon="show_info:1"
+					validate="options"
 					>
 					<option value="0">JHIDE</option>
 					<option value="1">JSHOW</option>
@@ -545,6 +561,7 @@
 					label="COM_CONTACT_FIELD_PARAMS_MOBILE_LABEL"
 					useglobal="true"
 					showon="show_info:1"
+					validate="options"
 					>
 					<option value="0">JHIDE</option>
 					<option value="1">JSHOW</option>
@@ -556,6 +573,7 @@
 					label="COM_CONTACT_FIELD_PARAMS_FAX_LABEL"
 					useglobal="true"
 					showon="show_info:1"
+					validate="options"
 					>
 					<option value="0">JHIDE</option>
 					<option value="1">JSHOW</option>
@@ -567,6 +585,7 @@
 					label="COM_CONTACT_FIELD_PARAMS_WEBPAGE_LABEL"
 					useglobal="true"
 					showon="show_info:1"
+					validate="options"
 					>
 					<option value="0">JHIDE</option>
 					<option value="1">JSHOW</option>
@@ -579,6 +598,7 @@
 					class="custom-select-color"
 					useglobal="true"
 					showon="show_info:1"
+					validate="options"
 					>
 					<option value="0">JHIDE</option>
 					<option value="1">JSHOW</option>
@@ -588,8 +608,9 @@
 					name="show_misc"
 					type="list"
 					label="COM_CONTACT_FIELD_PARAMS_MISC_INFO_LABEL"
-				class="custom-select-color"
+					class="custom-select-color"
 					useglobal="true"
+					validate="options"
 					>
 					<option value="0">JHIDE</option>
 					<option value="1">JSHOW</option>
@@ -600,6 +621,7 @@
 					type="list"
 					label="COM_CONTACT_FIELD_PARAMS_VCARD_LABEL"
 					useglobal="true"
+					validate="options"
 					>
 					<option value="0">JHIDE</option>
 					<option value="1">JSHOW</option>
@@ -610,6 +632,7 @@
 					type="list"
 					label="COM_CONTACT_FIELD_ARTICLES_SHOW_LABEL"
 					useglobal="true"
+					validate="options"
 					>
 					<option value="0">JHIDE</option>
 					<option value="1">JSHOW</option>
@@ -621,6 +644,7 @@
 					label="COM_CONTACT_FIELD_ARTICLES_DISPLAY_NUM_LABEL"
 					default=""
 					useglobal="true"
+					validate="options"
 					>
 					<option value="5">J5</option>
 					<option value="10">J10</option>
@@ -643,6 +667,7 @@
 					type="list"
 					label="COM_CONTACT_FIELD_PROFILE_SHOW_LABEL"
 					useglobal="true"
+					validate="options"
 					>
 					<option value="0">JHIDE</option>
 					<option value="1">JSHOW</option>
@@ -677,6 +702,7 @@
 					type="list"
 					label="COM_CONTACT_FIELD_SHOW_LINKS_LABEL"
 					useglobal="true"
+					validate="options"
 					>
 					<option value="0">JHIDE</option>
 					<option value="1">JSHOW</option>
@@ -771,6 +797,7 @@
 					type="list"
 					label="COM_CONTACT_FIELD_EMAIL_SHOW_FORM_LABEL"
 					useglobal="true"
+					validate="options"
 					>
 					<option value="0">JHIDE</option>
 					<option value="1">JSHOW</option>
@@ -781,6 +808,7 @@
 					type="list"
 					label="COM_CONTACT_FIELD_EMAIL_EMAIL_COPY_LABEL"
 					useglobal="true"
+					validate="options"
 					>
 					<option value="0">JHIDE</option>
 					<option value="1">JSHOW</option>
@@ -791,6 +819,7 @@
 					type="list"
 					label="COM_CONTACT_FIELD_CONFIG_SESSION_CHECK_LABEL"
 					useglobal="true"
+					validate="options"
 					>
 					<option value="0">JNO</option>
 					<option value="1">JYES</option>
@@ -801,6 +830,7 @@
 					type="list"
 					label="COM_CONTACT_FIELD_CONFIG_CUSTOM_REPLY_LABEL"
 					useglobal="true"
+					validate="options"
 					>
 					<option value="0">JNO</option>
 					<option value="1">JYES</option>
@@ -822,6 +852,7 @@
 				name="robots"
 				type="list"
 				label="JFIELD_METADATA_ROBOTS_LABEL"
+				validate="options"
 				>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="index, follow">JGLOBAL_INDEX_FOLLOW</option>

--- a/administrator/components/com_contact/forms/filter_contacts.xml
+++ b/administrator/components/com_contact/forms/filter_contacts.xml
@@ -18,6 +18,7 @@
 			label="JOPTION_SELECT_FEATURED"
 			onchange="this.form.submit();"
 			default=""
+			validate="options"
 			>
 			<option value="">JOPTION_SELECT_FEATURED</option>
 			<option value="0">JUNFEATURED</option>

--- a/administrator/components/com_content/config.xml
+++ b/administrator/components/com_content/config.xml
@@ -54,6 +54,7 @@
 			type="list"
 			label="COM_CONTENT_FIELD_INFOBLOCK_POSITION_LABEL"
 			default="0"
+			validate="options"
 			>
 			<option value="0">COM_CONTENT_FIELD_OPTION_ABOVE</option>
 			<option value="1">COM_CONTENT_FIELD_OPTION_BELOW</option>
@@ -451,6 +452,7 @@
 			default="Parent"
 			filter="int"
 			showon="show_urls_images_backend:1[OR]show_urls_images_frontend:1"
+			validate="options"
 			>
 			<option value="0">JBROWSERTARGET_PARENT</option>
 			<option value="1">JBROWSERTARGET_NEW</option>
@@ -465,6 +467,7 @@
 			default="Parent"
 			filter="int"
 			showon="show_urls_images_backend:1[OR]show_urls_images_frontend:1"
+			validate="options"
 			>
 			<option value="0">JBROWSERTARGET_PARENT</option>
 			<option value="1">JBROWSERTARGET_NEW</option>
@@ -479,6 +482,7 @@
 			default="Parent"
 			filter="int"
 			showon="show_urls_images_backend:1[OR]show_urls_images_frontend:1"
+			validate="options"
 			>
 			<option value="0">JBROWSERTARGET_PARENT</option>
 			<option value="1">JBROWSERTARGET_NEW</option>
@@ -498,6 +502,7 @@
 			type="list"
 			label="COM_CONTENT_FLOAT_INTRO_LABEL"
 			showon="show_urls_images_backend:1[OR]show_urls_images_frontend:1"
+			validate="options"
 			>
 			<option value="right">COM_CONTENT_RIGHT</option>
 			<option value="left">COM_CONTENT_LEFT</option>
@@ -509,6 +514,7 @@
 			type="list"
 			label="COM_CONTENT_FLOAT_FULLTEXT_LABEL"
 			showon="show_urls_images_backend:1[OR]show_urls_images_frontend:1"
+			validate="options"
 			>
 			<option value="right">COM_CONTENT_RIGHT</option>
 			<option value="left">COM_CONTENT_LEFT</option>
@@ -579,6 +585,7 @@
 			type="list"
 			label="JGLOBAL_MAXIMUM_CATEGORY_LEVELS_LABEL"
 			default="-1"
+			validate="options"
 			>
 			<option value="0">JNONE</option>
 			<option value="-1">JALL</option>
@@ -665,6 +672,7 @@
 			type="list"
 			label="JGLOBAL_MAXIMUM_CATEGORY_LEVELS_LABEL"
 			default="-1"
+			validate="options"
 			>
 			<option value="0">JNONE</option>
 			<option value="-1">JALL</option>
@@ -747,6 +755,7 @@
 			type="list"
 			label="JGLOBAL_SHOW_SUBCATEGORY_CONTENT_LABEL"
 			default="0"
+			validate="options"
 			>
 			<option value="0">JNONE</option>
 			<option value="-1">JALL</option>
@@ -779,6 +788,7 @@
 			type="list"
 			label="JGLOBAL_FILTER_FIELD_LABEL"
 			default="hide"
+			validate="options"
 			>
 			<option value="hide">JHIDE</option>
 			<option value="title">JGLOBAL_TITLE</option>
@@ -804,6 +814,7 @@
 			type="list"
 			label="JGLOBAL_SHOW_DATE_LABEL"
 			default="0"
+			validate="options"
 			>
 			<option value="0">JHIDE</option>
 			<option value="created">JGLOBAL_CREATED</option>
@@ -873,6 +884,7 @@
 			type="list"
 			label="JGLOBAL_CATEGORY_ORDER_LABEL"
 			default="none"
+			validate="options"
 			>
 			<option value="none">JGLOBAL_NO_ORDER</option>
 			<option value="alpha">JGLOBAL_TITLE_ALPHABETICAL</option>
@@ -885,6 +897,7 @@
 			type="list"
 			label="JGLOBAL_ARTICLE_ORDER_LABEL"
 			default="rdate"
+			validate="options"
 			>
 			<option value="rdate">JGLOBAL_MOST_RECENT_FIRST</option>
 			<option value="date">JGLOBAL_OLDEST_FIRST</option>
@@ -908,6 +921,7 @@
 			label="JGLOBAL_ORDERING_DATE_LABEL"
 			showon="orderby_sec:rdate,date"
 			default="published"
+			validate="options"
 			>
 			<option value="created">JGLOBAL_CREATED</option>
 			<option value="modified">JGLOBAL_MODIFIED</option>
@@ -919,6 +933,7 @@
 			type="list"
 			label="JGLOBAL_PAGINATION_LABEL"
 			default="2"
+			validate="options"
 			>
 			<option value="0">JHIDE</option>
 			<option value="1">JSHOW</option>
@@ -942,6 +957,7 @@
 			type="list"
 			label="JGLOBAL_SHOW_FEATURED_ARTICLES_LABEL"
 			default="show"
+			validate="options"
 			>
 			<option value="show">JSHOW</option>
 			<option value="hide">JHIDE</option>
@@ -974,6 +990,7 @@
 				label="JGLOBAL_FEED_SUMMARY_LABEL"
 				default="0"
 				showon="show_feed_link:1"
+				validate="options"
 				>
 				<option value="0">JGLOBAL_INTRO_TEXT</option>
 				<option value="1">JGLOBAL_FULL_TEXT</option>

--- a/administrator/components/com_content/forms/article.xml
+++ b/administrator/components/com_content/forms/article.xml
@@ -282,6 +282,7 @@
 					type="list"
 					label="JGLOBAL_SHOW_TITLE_LABEL"
 					useglobal="true"
+					validate="options"
 					>
 					<option value="1">JSHOW</option>
 					<option value="0">JHIDE</option>
@@ -292,6 +293,7 @@
 					type="list"
 					label="JGLOBAL_LINKED_TITLES_LABEL"
 					useglobal="true"
+					validate="options"
 					>
 					<option value="0">JNO</option>
 					<option value="1">JYES</option>
@@ -303,6 +305,7 @@
 					label="COM_CONTENT_FIELD_SHOW_TAGS_LABEL"
 					class="custom-select-color"
 					useglobal="true"
+					validate="options"
 					>
 					<option value="1">JSHOW</option>
 					<option value="0">JHIDE</option>
@@ -314,6 +317,7 @@
 					label="JGLOBAL_SHOW_INTRO_LABEL"
 					class="custom-select-color"
 					useglobal="true"
+					validate="options"
 					>
 					<option value="1">JSHOW</option>
 					<option value="0">JHIDE</option>
@@ -324,6 +328,7 @@
 					type="list"
 					label="COM_CONTENT_FIELD_INFOBLOCK_POSITION_LABEL"
 					useglobal="true"
+					validate="options"
 					>
 					<option value="0">COM_CONTENT_FIELD_OPTION_ABOVE</option>
 					<option value="1">COM_CONTENT_FIELD_OPTION_BELOW</option>
@@ -335,6 +340,7 @@
 					type="list"
 					label="COM_CONTENT_FIELD_INFOBLOCK_TITLE_LABEL"
 					useglobal="true"
+					validate="options"
 					>
 					<option value="0">JHIDE</option>
 					<option value="1">JSHOW</option>
@@ -347,6 +353,7 @@
 					type="list"
 					label="JGLOBAL_SHOW_CATEGORY_LABEL"
 					useglobal="true"
+					validate="options"
 					>
 					<option value="0">JHIDE</option>
 					<option value="1">JSHOW</option>
@@ -357,6 +364,7 @@
 					type="list"
 					label="JGLOBAL_LINK_CATEGORY_LABEL"
 					useglobal="true"
+					validate="options"
 					>
 					<option value="0">JNO</option>
 					<option value="1">JYES</option>
@@ -367,6 +375,7 @@
 					type="list"
 					label="JGLOBAL_SHOW_PARENT_CATEGORY_LABEL"
 					useglobal="true"
+					validate="options"
 					>
 					<option value="0">JHIDE</option>
 					<option value="1">JSHOW</option>
@@ -377,6 +386,7 @@
 					type="list"
 					label="JGLOBAL_LINK_PARENT_CATEGORY_LABEL"
 					useglobal="true"
+					validate="options"
 					>
 					<option value="0">JNO</option>
 					<option value="1">JYES</option>
@@ -401,6 +411,7 @@
 					label="JGLOBAL_SHOW_FLAG_LABEL"
 					useglobal="true"
 					showon="show_associations:1"
+					validate="options"
 					>
 					<option value="0">JNO</option>
 					<option value="1">JYES</option>
@@ -413,6 +424,7 @@
 					type="list"
 					label="JGLOBAL_SHOW_AUTHOR_LABEL"
 					useglobal="true"
+					validate="options"
 					>
 					<option value="0">JHIDE</option>
 					<option value="1">JSHOW</option>
@@ -423,6 +435,7 @@
 					type="list"
 					label="JGLOBAL_LINK_AUTHOR_LABEL"
 					useglobal="true"
+					validate="options"
 					>
 					<option value="0">JNO</option>
 					<option value="1">JYES</option>
@@ -435,6 +448,7 @@
 					type="list"
 					label="JGLOBAL_SHOW_CREATE_DATE_LABEL"
 					useglobal="true"
+					validate="options"
 					>
 					<option value="0">JHIDE</option>
 					<option value="1">JSHOW</option>
@@ -445,6 +459,7 @@
 					type="list"
 					label="JGLOBAL_SHOW_MODIFY_DATE_LABEL"
 					useglobal="true"
+					validate="options"
 					>
 					<option value="0">JHIDE</option>
 					<option value="1">JSHOW</option>
@@ -455,6 +470,7 @@
 					type="list"
 					label="JGLOBAL_SHOW_PUBLISH_DATE_LABEL"
 					useglobal="true"
+					validate="options"
 					>
 					<option value="0">JHIDE</option>
 					<option value="1">JSHOW</option>
@@ -467,6 +483,7 @@
 					type="list"
 					label="JGLOBAL_SHOW_NAVIGATION_LABEL"
 					useglobal="true"
+					validate="options"
 					>
 					<option value="0">JHIDE</option>
 					<option value="1">JSHOW</option>
@@ -477,6 +494,7 @@
 					type="list"
 					label="JGLOBAL_SHOW_VOTE_LABEL"
 					useglobal="true"
+					validate="options"
 					>
 					<option value="0">JHIDE</option>
 					<option value="1">JSHOW</option>
@@ -487,6 +505,7 @@
 					type="list"
 					label="JGLOBAL_SHOW_HITS_LABEL"
 					useglobal="true"
+					validate="options"
 					>
 					<option value="0">JHIDE</option>
 					<option value="1">JSHOW</option>
@@ -498,6 +517,7 @@
 					label="JGLOBAL_SHOW_UNAUTH_LINKS_LABEL"
 					description="JGLOBAL_SHOW_UNAUTH_LINKS_DESC"
 					useglobal="true"
+					validate="options"
 					>
 					<option value="0">JNO</option>
 					<option value="1">JYES</option>
@@ -508,6 +528,7 @@
 					type="list"
 					label="COM_CONTENT_FIELD_URLSPOSITION_LABEL"
 					useglobal="true"
+					validate="options"
 					>
 					<option value="0">COM_CONTENT_FIELD_OPTION_ABOVE</option>
 					<option value="1">COM_CONTENT_FIELD_OPTION_BELOW</option>
@@ -538,6 +559,7 @@
 				label="COM_CONTENT_SHOW_PUBLISHING_OPTIONS_LABEL"
 				default=""
 				useglobal="true"
+				validate="options"
 				>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
@@ -549,6 +571,7 @@
 				label="COM_CONTENT_SHOW_ARTICLE_OPTIONS_LABEL"
 				default=""
 				useglobal="true"
+				validate="options"
 				>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
@@ -560,6 +583,7 @@
 				label="COM_CONTENT_SHOW_IMAGES_URLS_BACK_LABEL"
 				useglobal="true"
 				default=""
+				validate="options"
 				>
 				<option value="0">JNO</option>
 				<option value="1">JYES</option>
@@ -571,6 +595,7 @@
 				label="COM_CONTENT_SHOW_IMAGES_URLS_FRONT_LABEL"
 				useglobal="true"
 				default=""
+				validate="options"
 				>
 				<option value="0">JNO</option>
 				<option value="1">JYES</option>
@@ -706,6 +731,7 @@
 				type="list"
 				label="COM_CONTENT_FLOAT_LABEL"
 				useglobal="true"
+				validate="options"
 				>
 				<option value="right">COM_CONTENT_RIGHT</option>
 				<option value="left">COM_CONTENT_LEFT</option>
@@ -740,6 +766,7 @@
 				type="list"
 				label="COM_CONTENT_FLOAT_LABEL"
 				useglobal="true"
+				validate="options"
 				>
 				<option value="right">COM_CONTENT_RIGHT</option>
 				<option value="left">COM_CONTENT_LEFT</option>
@@ -787,6 +814,7 @@
 				default=""
 				filter="options"
 				useglobal="true"
+				validate="options"
 				>
 				<option value="0">JBROWSERTARGET_PARENT</option>
 				<option value="1">JBROWSERTARGET_NEW</option>
@@ -819,6 +847,7 @@
 				default=""
 				filter="options"
 				useglobal="true"
+				validate="options"
 				>
 				<option value="0">JBROWSERTARGET_PARENT</option>
 				<option value="1">JBROWSERTARGET_NEW</option>
@@ -851,6 +880,7 @@
 				default=""
 				filter="options"
 				useglobal="true"
+				validate="options"
 				>
 				<option value="0">JBROWSERTARGET_PARENT</option>
 				<option value="1">JBROWSERTARGET_NEW</option>
@@ -868,6 +898,7 @@
 				name="robots"
 				type="list"
 				label="JFIELD_METADATA_ROBOTS_LABEL"
+				validate="options"
 				>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="index, follow">JGLOBAL_INDEX_FOLLOW</option>

--- a/administrator/components/com_content/forms/filter_articles.xml
+++ b/administrator/components/com_content/forms/filter_articles.xml
@@ -16,6 +16,7 @@
 			label="JOPTION_SELECT_FEATURED"
 			onchange="this.form.submit();"
 			default=""
+			validate="options"
 			>
 			<option value="">COM_CONTENT_SELECT_FEATURED</option>
 			<option value="0">COM_CONTENT_FILTER_FEATURED_NO</option>

--- a/administrator/components/com_csp/forms/filter_reports.xml
+++ b/administrator/components/com_csp/forms/filter_reports.xml
@@ -40,6 +40,7 @@
 			label="JSITEADMIN"
 			filtermode="selector"
 			onchange="this.form.submit();"
+			validate="options"
 			>
 			<option value="">JGLOBAL_FILTER_CLIENT</option>
 			<option value="site">JSITE</option>
@@ -55,6 +56,7 @@
 			default="a.id ASC"
 			statuses="*,0,1,2,-2"
 			onchange="this.form.submit();"
+			validate="options"
 			>
 			<option value="">JGLOBAL_SORT_BY</option>
 			<option value="a.published ASC">JSTATUS_ASC</option>

--- a/administrator/components/com_fields/forms/field.xml
+++ b/administrator/components/com_fields/forms/field.xml
@@ -90,6 +90,7 @@
 			class="custom-select-color-state"
 			default="1"
 			size="1"
+			validate="options"
 			>
 			<option value="1">JPUBLISHED</option>
 			<option value="0">JUNPUBLISHED</option>
@@ -232,6 +233,7 @@
 					type="list"
 					label="COM_FIELDS_FIELD_EDITABLE_IN_LABEL"
 					default=""
+					validate="options"
 					>
 					<option value="1">COM_FIELDS_FIELD_EDITABLE_IN_SITE</option>
 					<option value="2">COM_FIELDS_FIELD_EDITABLE_IN_ADMIN</option>
@@ -272,6 +274,7 @@
 					type="list"
 					label="COM_FIELDS_FIELD_DISPLAY_LABEL"
 					default="2"
+					validate="options"
 					>
 					<option value="1">COM_FIELDS_FIELD_DISPLAY_AFTER_TITLE</option>
 					<option value="2">COM_FIELDS_FIELD_DISPLAY_BEFORE_DISPLAY</option>
@@ -305,6 +308,7 @@
 					type="list"
 					label="JFIELD_DISPLAY_READONLY_LABEL"
 					default="2"
+					validate="options"
 					>
 					<option value="2">JGLOBAL_INHERIT</option>
 					<option value="1">JYES</option>

--- a/administrator/components/com_fields/forms/group.xml
+++ b/administrator/components/com_fields/forms/group.xml
@@ -37,6 +37,7 @@
 			label="JSTATUS"
 			class="custom-select-color-state"
 			default="1"
+			validate="options"
 			>
 			<option value="1">JPUBLISHED</option>
 			<option value="0">JUNPUBLISHED</option>

--- a/administrator/components/com_finder/forms/filter.xml
+++ b/administrator/components/com_finder/forms/filter.xml
@@ -93,6 +93,7 @@
 			filter="intval"
 			size="1"
 			default="1"
+			validate="options"
 			>
 			<option value="1">JPUBLISHED</option>
 			<option value="0">JUNPUBLISHED</option>
@@ -117,6 +118,7 @@
 				label="COM_FINDER_FILTER_WHEN_START_DATE_LABEL"
 				default=""
 				filter="string"
+				validate="options"
 				>
 				<option value="">JNONE</option>
 				<option value="-1">COM_FINDER_FILTER_WHEN_BEFORE</option>
@@ -139,6 +141,7 @@
 				label="COM_FINDER_FILTER_WHEN_END_DATE_LABEL"
 				default=""
 				filter="string"
+				validate="options"
 				>
 				<option value="">JNONE</option>
 				<option value="-1">COM_FINDER_FILTER_WHEN_BEFORE</option>

--- a/administrator/components/com_installer/config.xml
+++ b/administrator/components/com_installer/config.xml
@@ -21,6 +21,7 @@
 			type="list"
 			label="COM_INSTALLER_MINIMUM_STABILITY_LABEL"
 			default="4"
+			validate="options"
 			>
 			<option value="0">COM_INSTALLER_MINIMUM_STABILITY_DEV</option>
 			<option value="1">COM_INSTALLER_MINIMUM_STABILITY_ALPHA</option>

--- a/administrator/components/com_installer/forms/filter_database.xml
+++ b/administrator/components/com_installer/forms/filter_database.xml
@@ -45,6 +45,7 @@
 			label="JGLOBAL_SORT_BY"
 			onchange="this.form.submit();"
 			default="name ASC"
+			validate="options"
 			>
 			<option value="">JGLOBAL_SORT_BY</option>
 			<option value="name ASC">JGLOBAL_NAME_ASC</option>

--- a/administrator/components/com_installer/forms/filter_manage.xml
+++ b/administrator/components/com_installer/forms/filter_manage.xml
@@ -51,6 +51,7 @@
 			type="list"
 			label="COM_INSTALLER_VALUE_CORE_SELECT"
 			onchange="this.form.submit();"
+			validate="options"
 			>
 			<option value="">COM_INSTALLER_VALUE_CORE_SELECT</option>
 			<option value="1">COM_INSTALLER_VALUE_CORE_YES</option>

--- a/administrator/components/com_installer/forms/filter_updatesites.xml
+++ b/administrator/components/com_installer/forms/filter_updatesites.xml
@@ -14,6 +14,7 @@
 			type="list"
 			label="JOPTION_SELECT_PUBLISHED"
 			onchange="this.form.submit();"
+			validate="options"
 			>
 			<option value="">JOPTION_SELECT_PUBLISHED</option>
 			<option value="0">JDISABLED</option>
@@ -47,6 +48,7 @@
 			name="supported"
 			type="list"
 			onchange="this.form.submit();"
+			validate="options"
 		>
 			<option value="">COM_INSTALLER_VALUE_SUPPORTED_SELECT</option>
 			<option value="1">COM_INSTALLER_VALUE_SUPPORTED_SUPPORTED</option>

--- a/administrator/components/com_joomlaupdate/config.xml
+++ b/administrator/components/com_joomlaupdate/config.xml
@@ -11,6 +11,7 @@
 			type="list"
 			label="COM_JOOMLAUPDATE_CONFIG_UPDATESOURCE_LABEL"
 			default="default"
+			validate="options"
 			>
 			<!-- Note: Changed the values lts to default and sts to next with 3.4.0 -->
 			<!--       Eliminated the 'nochange' option with 3.4.0 -->
@@ -28,6 +29,7 @@
 			description="COM_JOOMLAUPDATE_MINIMUM_STABILITY_DESC"
 			default="4"
 			showon="updatesource:testing[OR]updatesource:custom"
+			validate="options"
 			>
 			<option value="0">COM_JOOMLAUPDATE_MINIMUM_STABILITY_DEV</option>
 			<option value="1">COM_JOOMLAUPDATE_MINIMUM_STABILITY_ALPHA</option>

--- a/administrator/components/com_languages/forms/filter_installed.xml
+++ b/administrator/components/com_languages/forms/filter_installed.xml
@@ -6,6 +6,7 @@
 		label="JSITEADMIN"
 		onchange="Joomla.resetFilters(this)"
 		filtermode="selector"
+		validate="options"
 		>
 		<option value="0">JSITE</option>
 		<option value="1">JADMINISTRATOR</option>

--- a/administrator/components/com_languages/forms/filter_overrides.xml
+++ b/administrator/components/com_languages/forms/filter_overrides.xml
@@ -27,6 +27,7 @@
 			label="JGLOBAL_SORT_BY"
 			onchange="this.form.submit();"
 			default="key ASC"
+			validate="options"
 			>
 			<option value="">JGLOBAL_SORT_BY</option>
 			<option value="key ASC">COM_LANGUAGES_VIEW_OVERRIDES_KEY_ASC</option>

--- a/administrator/components/com_languages/forms/language.xml
+++ b/administrator/components/com_languages/forms/language.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <form>
 	<fieldset>
-		<field 
-			name="lang_id" 
+		<field
+			name="lang_id"
 			type="text"
 			label="JGLOBAL_FIELD_ID_LABEL"
 			class="readonly"
@@ -75,6 +75,7 @@
 			class="custom-select-color-state"
 			default="1"
 			size="1"
+			validate="options"
 			>
 			<option value="1">JPUBLISHED</option>
 			<option value="0">JUNPUBLISHED</option>

--- a/administrator/components/com_languages/forms/override.xml
+++ b/administrator/components/com_languages/forms/override.xml
@@ -39,6 +39,7 @@
 			type="list"
 			label="COM_LANGUAGES_OVERRIDE_FIELD_SEARCHTYPE_LABEL"
 			default="value"
+			validate="options"
 			>
 			<option value="constant">COM_LANGUAGES_OVERRIDE_FIELD_SEARCHTYPE_CONSTANT</option>
 			<option value="value">COM_LANGUAGES_OVERRIDE_FIELD_SEARCHTYPE_TEXT</option>

--- a/administrator/components/com_mails/config.xml
+++ b/administrator/components/com_mails/config.xml
@@ -9,6 +9,7 @@
 			type="list"
 			label="COM_MAILS_FIELD_MAIL_STYLE_LABEL"
 			default="plaintext"
+			validate="options"
 			>
 			<option value="plaintext">COM_MAILS_FIELD_OPTION_PLAINTEXT</option>
 			<option value="html">COM_MAILS_FIELD_OPTION_HTML</option>

--- a/administrator/components/com_mails/forms/filter_templates.xml
+++ b/administrator/components/com_mails/forms/filter_templates.xml
@@ -39,6 +39,7 @@
 			label="JGLOBAL_SORT_BY"
 			onchange="this.form.submit();"
 			default="a.id DESC"
+			validate="options"
 			>
 			<option value="">JGLOBAL_SORT_BY</option>
 			<option value="a.title ASC">JGLOBAL_TITLE_ASC</option>

--- a/administrator/components/com_mails/forms/template.xml
+++ b/administrator/components/com_mails/forms/template.xml
@@ -151,6 +151,7 @@
 				default="mail"
 				filter="word"
 				showon="alternative_mailconfig:1"
+				validate="options"
 				>
 				<option value="mail">COM_MAILS_FIELD_VALUE_PHP_MAIL</option>
 				<option value="sendmail">COM_MAILS_FIELD_VALUE_SENDMAIL</option>
@@ -197,6 +198,7 @@
 				default="none"
 				showon="alternative_mailconfig:1[AND]mailer:smtp"
 				filter="word"
+				validate="options"
 				>
 				<option value="none">COM_MAILS_FIELD_VALUE_NONE</option>
 				<option value="ssl">COM_MAILS_FIELD_VALUE_SSL</option>

--- a/administrator/components/com_menus/forms/filter_items.xml
+++ b/administrator/components/com_menus/forms/filter_items.xml
@@ -6,6 +6,7 @@
 		label="JSITEADMIN"
 		filtermode="selector"
 		onchange="Joomla.resetFilters(this)"
+		validate="options"
 		>
 		<option value="0">JSITE</option>
 		<option value="1">JADMINISTRATOR</option>

--- a/administrator/components/com_menus/forms/filter_itemsadmin.xml
+++ b/administrator/components/com_menus/forms/filter_itemsadmin.xml
@@ -6,6 +6,7 @@
 		label="JSITEADMIN"
 		filtermode="selector"
 		onchange="Joomla.resetFilters(this)"
+		validate="options"
 		>
 		<option value="0">JSITE</option>
 		<option value="1">JADMINISTRATOR</option>

--- a/administrator/components/com_menus/forms/filter_menus.xml
+++ b/administrator/components/com_menus/forms/filter_menus.xml
@@ -6,6 +6,7 @@
 		label="JSITEADMIN"
 		filtermode="selector"
 		onchange="this.form.submit();"
+		validate="options"
 		>
 		<option value="0">JSITE</option>
 		<option value="1">JADMINISTRATOR</option>

--- a/administrator/components/com_menus/forms/item.xml
+++ b/administrator/components/com_menus/forms/item.xml
@@ -72,6 +72,7 @@
 			size="1"
 			default="1"
 			filter="integer"
+			validate="options"
 			>
 			<option value="1">JPUBLISHED</option>
 			<option value="0">JUNPUBLISHED</option>
@@ -134,6 +135,7 @@
 			label="COM_MENUS_ITEM_FIELD_BROWSERNAV_LABEL"
 			default="0"
 			filter="int"
+			validate="options"
 			>
 			<option value="0">COM_MENUS_FIELD_VALUE_PARENT</option>
 			<option value="1">COM_MENUS_FIELD_VALUE_NEW_WITH_NAV</option>

--- a/administrator/components/com_menus/forms/item_component.xml
+++ b/administrator/components/com_menus/forms/item_component.xml
@@ -68,6 +68,7 @@
 				class="custom-select-color-state"
 				default=""
 				useglobal="true"
+				validate="options"
 				>
 				<option value="1">JSHOW</option>
 				<option value="0">JHIDE</option>
@@ -100,6 +101,7 @@
 				name="robots"
 				type="list"
 				label="JFIELD_METADATA_ROBOTS_LABEL"
+				validate="options"
 				>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="index, follow">JGLOBAL_INDEX_FOLLOW</option>

--- a/administrator/components/com_menus/forms/item_url.xml
+++ b/administrator/components/com_menus/forms/item_url.xml
@@ -21,6 +21,7 @@
 				type="list"
 				label="COM_MENUS_ITEM_FIELD_ANCHOR_REL_LABEL"
 				default=""
+				validate="options"
 				>
 				<option value="">JNONE</option>
 				<option value="alternate"/>

--- a/administrator/components/com_menus/forms/itemadmin.xml
+++ b/administrator/components/com_menus/forms/itemadmin.xml
@@ -73,6 +73,7 @@
 			size="1"
 			default="1"
 			filter="integer"
+			validate="options"
 			>
 			<option value="1">JPUBLISHED</option>
 			<option value="0">JUNPUBLISHED</option>
@@ -111,6 +112,7 @@
 			label="COM_MENUS_ITEM_FIELD_BROWSERNAV_LABEL"
 			default="0"
 			filter="int"
+			validate="options"
 			>
 			<option value="0">COM_MENUS_FIELD_VALUE_PARENT</option>
 			<option value="1">COM_MENUS_FIELD_VALUE_NEW_WITH_NAV</option>

--- a/administrator/components/com_menus/forms/itemadmin_url.xml
+++ b/administrator/components/com_menus/forms/itemadmin_url.xml
@@ -15,6 +15,7 @@
 				type="list"
 				label="COM_MENUS_ITEM_FIELD_ANCHOR_REL_LABEL"
 				default=""
+				validate="options"
 				>
 				<option value="">JNONE</option>
 				<option value="alternate"/>

--- a/administrator/components/com_modules/config.xml
+++ b/administrator/components/com_modules/config.xml
@@ -12,6 +12,7 @@
 			default="site"
 			label="COM_MODULES_REDIRECT_EDIT_LABEL"
 			description="COM_MODULES_REDIRECT_EDIT_DESC"
+			validate="options"
 			>
 			<option value="admin">JADMINISTRATOR</option>
 			<option value="site">JSITE</option>

--- a/administrator/components/com_modules/forms/filter_modules.xml
+++ b/administrator/components/com_modules/forms/filter_modules.xml
@@ -6,6 +6,7 @@
 		label="JSITEADMIN"
 		filtermode="selector"
 		onchange="Joomla.resetFilters(this)"
+		validate="options"
 		>
 		<option value="0">JSITE</option>
 		<option value="1">JADMINISTRATOR</option>

--- a/administrator/components/com_modules/forms/filter_modulesadmin.xml
+++ b/administrator/components/com_modules/forms/filter_modulesadmin.xml
@@ -8,6 +8,7 @@
 		label="JSITEADMIN"
 		filtermode="selector"
 		onchange="Joomla.resetFilters(this)"
+		validate="options"
 		>
 		<option value="0">JSITE</option>
 		<option value="1">JADMINISTRATOR</option>

--- a/administrator/components/com_modules/forms/module.xml
+++ b/administrator/components/com_modules/forms/module.xml
@@ -52,6 +52,7 @@
 			class="custom-select-color-state"
 			default="1"
 			size="1"
+			validate="options"
 			>
 			<option value="1">JPUBLISHED</option>
 			<option value="0">JUNPUBLISHED</option>

--- a/administrator/components/com_modules/forms/moduleadmin.xml
+++ b/administrator/components/com_modules/forms/moduleadmin.xml
@@ -53,6 +53,7 @@
 			class="custom-select-color-state"
 			default="1"
 			size="1"
+			validate="options"
 			>
 			<option value="1">JPUBLISHED</option>
 			<option value="0">JUNPUBLISHED</option>

--- a/administrator/components/com_newsfeeds/config.xml
+++ b/administrator/components/com_newsfeeds/config.xml
@@ -16,7 +16,7 @@
 			extension="com_newsfeeds"
 			view="newsfeed"
 		/>
-		
+
 		<field
 			name="save_history"
 			type="radio"
@@ -27,7 +27,7 @@
 			<option value="0">JNO</option>
 			<option value="1">JYES</option>
 		</field>
-		
+
 		<field
 			name="history_limit"
 			type="number"
@@ -82,20 +82,22 @@
 			default="0"
 		/>
 
-		<field 
-			name="feed_display_order" 
+		<field
+			name="feed_display_order"
 			type="list"
 			label="COM_NEWSFEEDS_FIELD_FEED_DISPLAY_ORDER_LABEL"
 			id="feed_display_order"
+			validate="options"
 			>
 			<option value="des">JGLOBAL_MOST_RECENT_FIRST</option>
 			<option value="asc">JGLOBAL_OLDEST_FIRST</option>
 		</field>
-		
+
 		<field
 			name="float_first"
 			type="list"
 			label="COM_NEWSFEEDS_FLOAT_FIRST_LABEL"
+			validate="options"
 			>
 			<option value="right">COM_NEWSFEEDS_RIGHT</option>
 			<option value="left">COM_NEWSFEEDS_LEFT</option>
@@ -106,6 +108,7 @@
 			name="float_second"
 			type="list"
 			label="COM_NEWSFEEDS_FLOAT_SECOND_LABEL"
+			validate="options"
 			>
 			<option value="right">COM_NEWSFEEDS_RIGHT</option>
 			<option value="left">COM_NEWSFEEDS_LEFT</option>
@@ -180,6 +183,7 @@
 			type="list"
 			label="JGLOBAL_MAXIMUM_CATEGORY_LEVELS_LABEL"
 			default="-1"
+			validate="options"
 			>
 			<option value="0">JNONE</option>
 			<option value="-1">JALL</option>
@@ -260,6 +264,7 @@
 			type="list"
 			label="JGLOBAL_MAXIMUM_CATEGORY_LEVELS_LABEL"
 			default="-1"
+			validate="options"
 			>
 			<option value="-1">JALL</option>
 			<option value="0">JNONE</option>
@@ -375,6 +380,7 @@
 			type="list"
 			label="JGLOBAL_PAGINATION_LABEL"
 			default="2"
+			validate="options"
 			>
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>

--- a/administrator/components/com_newsfeeds/forms/newsfeed.xml
+++ b/administrator/components/com_newsfeeds/forms/newsfeed.xml
@@ -36,6 +36,7 @@
 			default="1"
 			class="custom-select-color-state"
 			size="1"
+			validate="options"
 			>
 			<option value="1">JPUBLISHED</option>
 			<option value="0">JUNPUBLISHED</option>
@@ -248,6 +249,7 @@
 					type="list"
 					label="COM_NEWSFEEDS_FLOAT_LABEL"
 					useglobal="true"
+					validate="options"
 					>
 					<option value="right">COM_NEWSFEEDS_RIGHT</option>
 					<option value="left">COM_NEWSFEEDS_LEFT</option>
@@ -285,6 +287,7 @@
 					type="list"
 					label="COM_NEWSFEEDS_FLOAT_LABEL"
 					useglobal="true"
+					validate="options"
 					>
 					<option value="right">COM_NEWSFEEDS_RIGHT</option>
 					<option value="left">COM_NEWSFEEDS_LEFT</option>
@@ -329,6 +332,7 @@
 			type="list"
 			label="COM_NEWSFEEDS_FIELD_RTL_LABEL"
 			default="0"
+			validate="options"
 			>
 			<option value="0">COM_NEWSFEEDS_FIELD_VALUE_SITE</option>
 			<option value="1">COM_NEWSFEEDS_FIELD_VALUE_LTR</option>
@@ -342,6 +346,7 @@
 				type="list"
 				label="COM_NEWSFEEDS_FIELD_SHOW_FEED_IMAGE_LABEL"
 				useglobal="true"
+				validate="options"
 				>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
@@ -352,6 +357,7 @@
 				type="list"
 				label="COM_NEWSFEEDS_FIELD_SHOW_FEED_DESCRIPTION_LABEL"
 				useglobal="true"
+				validate="options"
 				>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
@@ -362,6 +368,7 @@
 				type="list"
 				label="COM_NEWSFEEDS_FIELD_SHOW_ITEM_DESCRIPTION_LABEL"
 				useglobal="true"
+				validate="options"
 				>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
@@ -390,6 +397,7 @@
 				type="list"
 				label="COM_NEWSFEEDS_FIELD_FEED_DISPLAY_ORDER_LABEL"
 				useglobal="true"
+				validate="options"
 				>
 				<option value="des">JGLOBAL_MOST_RECENT_FIRST</option>
 				<option value="asc">JGLOBAL_OLDEST_FIRST</option>
@@ -405,6 +413,7 @@
 				name="robots"
 				type="list"
 				label="JFIELD_METADATA_ROBOTS_LABEL"
+				validate="options"
 				>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="index, follow">JGLOBAL_INDEX_FOLLOW</option>

--- a/administrator/components/com_plugins/forms/plugin.xml
+++ b/administrator/components/com_plugins/forms/plugin.xml
@@ -23,6 +23,7 @@
 			class="custom-select-color-state"
 			size="1"
 			default="1"
+			validate="options"
 			>
 			<option value="1">JENABLED</option>
 			<option value="0">JDISABLED</option>

--- a/administrator/components/com_privacy/forms/filter_consents.xml
+++ b/administrator/components/com_privacy/forms/filter_consents.xml
@@ -15,6 +15,7 @@
 			type="list"
 			label="COM_PRIVACY_CONSENTS_FILTER_STATE"
 			onchange="this.form.submit();"
+			validate="options"
 			>
 			<option value="">JOPTION_SELECT_PUBLISHED</option>
 			<option value="1">COM_PRIVACY_CONSENTS_STATE_VALID</option>

--- a/administrator/components/com_redirect/forms/link.xml
+++ b/administrator/components/com_redirect/forms/link.xml
@@ -43,6 +43,7 @@
 			class="custom-select-color-state"
 			size="1"
 			default="1"
+			validate="options"
 			>
 			<option value="1">JENABLED</option>
 			<option value="0">JDISABLED</option>

--- a/administrator/components/com_tags/config.xml
+++ b/administrator/components/com_tags/config.xml
@@ -104,7 +104,7 @@
 			type="radio"
 			label="COM_TAGS_TAG_LIST_SHOW_HEADINGS_LABEL"
 			layout="joomla.form.field.radio.switcher"
-			default="1"			
+			default="1"
 			>
 			<option value="0">JHIDE</option>
 			<option value="1">JSHOW</option>
@@ -326,6 +326,7 @@
 			type="list"
 			label="JGLOBAL_PAGINATION_LABEL"
 			default="2"
+			validate="options"
 			>
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>

--- a/administrator/components/com_tags/forms/tag.xml
+++ b/administrator/components/com_tags/forms/tag.xml
@@ -91,6 +91,7 @@
 		class="custom-select-color-state"
 		default="1"
 		size="1"
+		validate="options"
 		>
 		<option value="1">JPUBLISHED</option>
 		<option value="0">JUNPUBLISHED</option>
@@ -247,6 +248,7 @@
 					name="float_intro"
 					type="list"
 					label="COM_TAGS_FLOAT_LABEL"
+					validate="options"
 					>
 					<option value="">JGLOBAL_SELECT_AN_OPTION</option>
 					<option value="right">COM_TAGS_RIGHT</option>
@@ -280,6 +282,7 @@
 					name="float_fulltext"
 					type="list"
 					label="COM_TAGS_FLOAT_LABEL"
+					validate="options"
 					>
 					<option value="">JGLOBAL_SELECT_AN_OPTION</option>
 					<option value="right">COM_TAGS_RIGHT</option>
@@ -318,6 +321,7 @@
 				name="robots"
 				type="list"
 				label="JFIELD_METADATA_ROBOTS_LABEL"
+				validate="options"
 				>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="index, follow">JGLOBAL_INDEX_FOLLOW</option>

--- a/administrator/components/com_templates/forms/filter_styles.xml
+++ b/administrator/components/com_templates/forms/filter_styles.xml
@@ -6,6 +6,7 @@
 		label="JSITEADMIN"
 		filtermode="selector"
 		onchange="Joomla.resetFilters(this)"
+		validate="options"
 		>
 		<option value="0">JSITE</option>
 		<option value="1">JADMINISTRATOR</option>

--- a/administrator/components/com_templates/forms/filter_templates.xml
+++ b/administrator/components/com_templates/forms/filter_templates.xml
@@ -6,6 +6,7 @@
 		label="JSITEADMIN"
 		filtermode="selector"
 		onchange="Joomla.resetFilters(this)"
+		validate="options"
 		>
 		<option value="0">JSITE</option>
 		<option value="1">JADMINISTRATOR</option>

--- a/administrator/components/com_users/config.xml
+++ b/administrator/components/com_users/config.xml
@@ -46,6 +46,7 @@
 			type="list"
 			label="COM_USERS_CONFIG_FIELD_USERACTIVATION_LABEL"
 			default="2"
+			validate="options"
 			>
 			<option value="0">JNONE</option>
 			<option value="1">COM_USERS_CONFIG_FIELD_USERACTIVATION_OPTION_SELFACTIVATION</option>
@@ -114,6 +115,7 @@
 			label="COM_USERS_CONFIG_FIELD_ENFORCE_2FA_FIELD_LABEL"
 			default="0"
 			filter="integer"
+			validate="options"
 			>
 			<option value="0">JNO</option>
 			<option value="1">COM_USERS_CONFIG_FIELD_ENFORCE_2FA_FIELD_SITE</option>

--- a/administrator/components/com_users/forms/note.xml
+++ b/administrator/components/com_users/forms/note.xml
@@ -53,6 +53,7 @@
 			label="JSTATUS"
 			size="1"
 			default="1"
+			validate="options"
 			>
 			<option value="1">JPUBLISHED</option>
 			<option value="0">JUNPUBLISHED</option>

--- a/administrator/components/com_workflow/forms/filter_stages.xml
+++ b/administrator/components/com_workflow/forms/filter_stages.xml
@@ -35,6 +35,7 @@
 			statuses="*,0,1,2,-2"
 			onchange="this.form.submit();"
 			default="s.ordering ASC"
+			validate="options"
 			>
 			<option value="">JGLOBAL_SORT_BY</option>
 			<option vaule="s.ordering ASC">JGRID_HEADING_ORDERING_ASC</option>

--- a/administrator/components/com_workflow/forms/filter_transitions.xml
+++ b/administrator/components/com_workflow/forms/filter_transitions.xml
@@ -47,6 +47,7 @@
 			default="t.ordering ASC"
 			statuses="*,0,1,2,-2"
 			onchange="this.form.submit();"
+			validate="options"
 			>
 			<option value="">JGLOBAL_SORT_BY</option>
 			<option vaule="t.ordering ASC">JGRID_HEADING_ORDERING_ASC</option>

--- a/administrator/components/com_workflow/forms/filter_workflows.xml
+++ b/administrator/components/com_workflow/forms/filter_workflows.xml
@@ -27,6 +27,7 @@
 			label="JGLOBAL_SORT_BY"
 			default="w.ordering ASC"
 			onchange="this.form.submit();"
+			validate="options"
 			>
 			<option value="">JGLOBAL_SORT_BY</option>
 			<option value="w.ordering ASC">JGRID_HEADING_ORDERING_ASC</option>

--- a/administrator/components/com_workflow/forms/stage.xml
+++ b/administrator/components/com_workflow/forms/stage.xml
@@ -41,6 +41,7 @@
 			required="true"
 			class="custom-select-color-state"
 			default="1"
+			validate="options"
 			>
 			<option value="1">JENABLED</option>
 			<option value="0">JDISABLED</option>

--- a/administrator/components/com_workflow/forms/transition.xml
+++ b/administrator/components/com_workflow/forms/transition.xml
@@ -56,6 +56,7 @@
 			required="true"
 			class="custom-select-color-state"
 			default="1"
+			validate="options"
 			>
 			<option value="1">JENABLED</option>
 			<option value="0">JDISABLED</option>

--- a/administrator/components/com_workflow/forms/workflow.xml
+++ b/administrator/components/com_workflow/forms/workflow.xml
@@ -38,6 +38,7 @@
 			required="true"
 			class="custom-select-color-state"
 			default="1"
+			validate="options"
 			>
 			<option value="1">JENABLED</option>
 			<option value="0">JDISABLED</option>
@@ -69,7 +70,7 @@
 	</fieldset>
 
 	<fieldset name="permissions" label="JCONFIG_PERMISSIONS_LABEL">
-		<field 
+		<field
 			name="asset_id"
 			type="hidden"
 			filter="unset"


### PR DESCRIPTION
This PR adds validation to parameter fields of type=option to the parameters of .xml files **back-end components**

I've added
```xml
validate="options"
```
to all fields of type=list with defined options