### PR TITLE
Back-end Module Parameters - added validate=options

### DIFF
--- a/administrator/modules/mod_custom/mod_custom.xml
+++ b/administrator/modules/mod_custom/mod_custom.xml
@@ -59,6 +59,7 @@
 					label="COM_MODULES_FIELD_CACHING_LABEL"
 					default="1"
 					filter="integer"
+					validate="options"
 					>
 					<option value="1">JGLOBAL_USE_GLOBAL</option>
 					<option value="0">COM_MODULES_FIELD_VALUE_NOCACHING</option>

--- a/administrator/modules/mod_feed/mod_feed.xml
+++ b/administrator/modules/mod_feed/mod_feed.xml
@@ -134,6 +134,7 @@
 					label="COM_MODULES_FIELD_CACHING_LABEL"
 					default="1"
 					filter="integer"
+					validate="options"
 					>
 					<option value="1">JGLOBAL_USE_GLOBAL</option>
 					<option value="0">COM_MODULES_FIELD_VALUE_NOCACHING</option>

--- a/administrator/modules/mod_latest/mod_latest.xml
+++ b/administrator/modules/mod_latest/mod_latest.xml
@@ -36,6 +36,7 @@
 					type="list"
 					label="MOD_LATEST_FIELD_ORDERING_LABEL"
 					default="c_dsc"
+					validate="options"
 					>
 					<option value="c_dsc">MOD_LATEST_FIELD_VALUE_ORDERING_ADDED</option>
 					<option value="m_dsc">MOD_LATEST_FIELD_VALUE_ORDERING_MODIFIED</option>
@@ -58,6 +59,7 @@
 					type="list"
 					label="MOD_LATEST_FIELD_AUTHORS_LABEL"
 					default="0"
+					validate="options"
 					>
 					<option value="0">MOD_LATEST_FIELD_VALUE_AUTHORS_ANYONE</option>
 					<option value="by_me">MOD_LATEST_FIELD_VALUE_AUTHORS_BY_ME</option>

--- a/administrator/modules/mod_latestactions/mod_latestactions.xml
+++ b/administrator/modules/mod_latestactions/mod_latestactions.xml
@@ -64,6 +64,7 @@
 					label="COM_MODULES_FIELD_CACHING_LABEL"
 					default="1"
 					filter="integer"
+					validate="options"
 					>
 					<option value="1">JGLOBAL_USE_GLOBAL</option>
 					<option value="0">COM_MODULES_FIELD_VALUE_NOCACHING</option>

--- a/administrator/modules/mod_logged/mod_logged.xml
+++ b/administrator/modules/mod_logged/mod_logged.xml
@@ -37,6 +37,7 @@
 					label="MOD_LOGGED_NAME"
 					default="1"
 					filter="integer"
+					validate="options"
 					>
 					<option value="1">MOD_LOGGED_NAME</option>
 					<option value="0">JGLOBAL_USERNAME</option>

--- a/administrator/modules/mod_loginsupport/mod_loginsupport.xml
+++ b/administrator/modules/mod_loginsupport/mod_loginsupport.xml
@@ -83,6 +83,7 @@
 					label="COM_MODULES_FIELD_CACHING_LABEL"
 					default="0"
 					filter="integer"
+					validate="options"
 					>
 					<option value="1">JGLOBAL_USE_GLOBAL</option>
 					<option value="0">COM_MODULES_FIELD_VALUE_NOCACHING</option>

--- a/administrator/modules/mod_popular/mod_popular.xml
+++ b/administrator/modules/mod_popular/mod_popular.xml
@@ -48,6 +48,7 @@
 					type="list"
 					label="MOD_POPULAR_FIELD_AUTHORS_LABEL"
 					default="0"
+					validate="options"
 					>
 					<option value="0">MOD_POPULAR_FIELD_VALUE_ANYONE</option>
 					<option value="by_me">MOD_POPULAR_FIELD_VALUE_ADDED_OR_MODIFIED_BY_ME</option>

--- a/administrator/modules/mod_privacy_dashboard/mod_privacy_dashboard.xml
+++ b/administrator/modules/mod_privacy_dashboard/mod_privacy_dashboard.xml
@@ -45,6 +45,7 @@
 					description="COM_MODULES_FIELD_CACHING_DESC"
 					default="1"
 					filter="integer"
+					validate="options"
 					>
 					<option value="1">JGLOBAL_USE_GLOBAL</option>
 					<option value="0">COM_MODULES_FIELD_VALUE_NOCACHING</option>

--- a/administrator/modules/mod_privacy_status/mod_privacy_status.xml
+++ b/administrator/modules/mod_privacy_status/mod_privacy_status.xml
@@ -42,6 +42,7 @@
 					label="COM_MODULES_FIELD_CACHING_LABEL"
 					default="1"
 					filter="integer"
+					validate="options"
 					>
 					<option value="1">JGLOBAL_USE_GLOBAL</option>
 					<option value="0">COM_MODULES_FIELD_VALUE_NOCACHING</option>

--- a/administrator/modules/mod_quickicon/mod_quickicon.xml
+++ b/administrator/modules/mod_quickicon/mod_quickicon.xml
@@ -53,6 +53,7 @@
 					type="list"
 					label="MOD_QUICKICON_SHOW_CHECKIN_LABEL"
 					default="0"
+					validate="options"
 					>
 					<option value="0">JHIDE</option>
 					<option value="1">JSHOW</option>
@@ -63,6 +64,7 @@
 					type="list"
 					label="MOD_QUICKICON_SHOW_CACHE_LABEL"
 					default="0"
+					validate="options"
 					>
 					<option value="0">JHIDE</option>
 					<option value="1">JSHOW</option>
@@ -73,6 +75,7 @@
 					type="list"
 					label="MOD_QUICKICON_SHOW_USERS_LABEL"
 					default="0"
+					validate="options"
 					>
 					<option value="0">JHIDE</option>
 					<option value="1">JSHOW</option>
@@ -83,6 +86,7 @@
 					type="list"
 					label="MOD_QUICKICON_SHOW_ARTICLES_LABEL"
 					default="0"
+					validate="options"
 					>
 					<option value="0">JHIDE</option>
 					<option value="1">JSHOW</option>
@@ -93,6 +97,7 @@
 					type="list"
 					label="MOD_QUICKICON_SHOW_MODULES_LABEL"
 					default="0"
+					validate="options"
 					>
 					<option value="0">JHIDE</option>
 					<option value="1">JSHOW</option>
@@ -103,6 +108,7 @@
 					type="list"
 					label="MOD_QUICKICON_SHOW_CATEGORIES_LABEL"
 					default="0"
+					validate="options"
 					>
 					<option value="0">JHIDE</option>
 					<option value="1">JSHOW</option>
@@ -123,6 +129,7 @@
 					type="list"
 					label="MOD_QUICKICON_SHOW_MENUITEMS_LABEL"
 					default="0"
+					validate="options"
 					>
 					<option value="0">JHIDE</option>
 					<option value="1">JSHOW</option>
@@ -133,6 +140,7 @@
 					type="list"
 					label="MOD_QUICKICON_SHOW_PLUGINS_LABEL"
 					default="0"
+					validate="options"
 					>
 					<option value="0">JHIDE</option>
 					<option value="1">JSHOW</option>
@@ -170,6 +178,7 @@
 					label="COM_MODULES_FIELD_CACHING_LABEL"
 					default="0"
 					filter="integer"
+					validate="options"
 					>
 					<option value="1">JGLOBAL_USE_GLOBAL</option>
 					<option value="0">COM_MODULES_FIELD_VALUE_NOCACHING</option>

--- a/administrator/modules/mod_stats_admin/mod_stats_admin.xml
+++ b/administrator/modules/mod_stats_admin/mod_stats_admin.xml
@@ -68,6 +68,7 @@
 					label="COM_MODULES_FIELD_CACHING_LABEL"
 					default="1"
 					filter="integer"
+					validate="options"
 					>
 					<option value="1">JGLOBAL_USE_GLOBAL</option>
 					<option value="0">COM_MODULES_FIELD_VALUE_NOCACHING</option>


### PR DESCRIPTION
This PR adds validation to parameter fields of type=option to the parameters of .xml files **back-end Modules**

I've added
```xml
validate="options"
```
to all fields of type=list with defined options