### PR TITLE
[4.0] Remove useless code for alerts

### DIFF
--- a/build/media_source/system/js/core.es6/message.es6
+++ b/build/media_source/system/js/core.es6/message.es6
@@ -52,23 +52,23 @@
     [].slice.call(Object.keys(messages)).forEach((type) => {
       // Array of messages of this type
       typeMessages = messages[type];
-			messagesBox = document.createElement('joomla-alert');
+      messagesBox = document.createElement('joomla-alert');
 
-			if (['notice', 'message', 'error', 'warning'].indexOf(type) > -1) {
-				alertClass = (type === 'notice') ? 'info' : type;
-				alertClass = (type === 'message') ? 'success' : alertClass;
-				alertClass = (type === 'error') ? 'danger' : alertClass;
-				alertClass = (type === 'warning') ? 'warning' : alertClass;
-			} else {
-				alertClass = 'info';
-			}
+      if (['notice', 'message', 'error', 'warning'].indexOf(type) > -1) {
+        alertClass = (type === 'notice') ? 'info' : type;
+        alertClass = (type === 'message') ? 'success' : alertClass;
+        alertClass = (type === 'error') ? 'danger' : alertClass;
+        alertClass = (type === 'warning') ? 'warning' : alertClass;
+      } else {
+        alertClass = 'info';
+      }
 
-			messagesBox.setAttribute('type', alertClass);
-			messagesBox.setAttribute('dismiss', 'true');
+      messagesBox.setAttribute('type', alertClass);
+      messagesBox.setAttribute('dismiss', 'true');
 
-			if (timeout && parseInt(timeout, 10) > 0) {
-				messagesBox.setAttribute('autodismiss', timeout);
-			}
+      if (timeout && parseInt(timeout, 10) > 0) {
+        messagesBox.setAttribute('autodismiss', timeout);
+      }
 
       // Title
       title = Joomla.Text._(type);
@@ -89,11 +89,11 @@
       });
 
       messageContainer.appendChild(messagesBox);
-			if (timeout && parseInt(timeout, 10) > 0) {
-				setTimeout(() => {
-					Joomla.removeMessages(messageContainer);
-				}, timeout);
-			}
+      if (timeout && parseInt(timeout, 10) > 0) {
+        setTimeout(() => {
+          Joomla.removeMessages(messageContainer);
+        }, timeout);
+      }
     });
   };
 
@@ -114,12 +114,12 @@
       messageContainer = document.getElementById('system-message-container');
     }
 
-		const alerts = [].slice.call(messageContainer.querySelectorAll('joomla-alert'));
-		if (alerts.length) {
-			alerts.forEach((alert) => {
-				alert.close();
-			});
-		}
+    const alerts = [].slice.call(messageContainer.querySelectorAll('joomla-alert'));
+    if (alerts.length) {
+      alerts.forEach((alert) => {
+        alert.close();
+      });
+    }
   };
 
   /**

--- a/build/media_source/system/js/core.es6/message.es6
+++ b/build/media_source/system/js/core.es6/message.es6
@@ -52,49 +52,23 @@
     [].slice.call(Object.keys(messages)).forEach((type) => {
       // Array of messages of this type
       typeMessages = messages[type];
+			messagesBox = document.createElement('joomla-alert');
 
-      if (typeof window.customElements === 'object' && typeof window.customElements.get('joomla-alert') === 'function') {
-        messagesBox = document.createElement('joomla-alert');
+			if (['notice', 'message', 'error', 'warning'].indexOf(type) > -1) {
+				alertClass = (type === 'notice') ? 'info' : type;
+				alertClass = (type === 'message') ? 'success' : alertClass;
+				alertClass = (type === 'error') ? 'danger' : alertClass;
+				alertClass = (type === 'warning') ? 'warning' : alertClass;
+			} else {
+				alertClass = 'info';
+			}
 
-        if (['notice', 'message', 'error', 'warning'].indexOf(type) > -1) {
-          alertClass = (type === 'notice') ? 'info' : type;
-          alertClass = (type === 'message') ? 'success' : alertClass;
-          alertClass = (type === 'error') ? 'danger' : alertClass;
-          alertClass = (type === 'warning') ? 'warning' : alertClass;
-        } else {
-          alertClass = 'info';
-        }
+			messagesBox.setAttribute('type', alertClass);
+			messagesBox.setAttribute('dismiss', 'true');
 
-        messagesBox.setAttribute('type', alertClass);
-        messagesBox.setAttribute('dismiss', 'true');
-
-        if (timeout && parseInt(timeout, 10) > 0) {
-          messagesBox.setAttribute('autodismiss', timeout);
-        }
-      } else {
-        // Create the alert box
-        messagesBox = document.createElement('div');
-
-        // Message class
-        if (['notice', 'message', 'error', 'warning'].indexOf(type) > -1) {
-          alertClass = (type === 'notice') ? 'info' : type;
-          alertClass = (type === 'message') ? 'success' : alertClass;
-          alertClass = (type === 'error') ? 'danger' : alertClass;
-          alertClass = (type === 'warning') ? 'warning' : alertClass;
-        } else {
-          alertClass = 'info';
-        }
-
-        messagesBox.className = `alert alert-${alertClass}`;
-
-        // Close button
-        const buttonWrapper = document.createElement('button');
-        buttonWrapper.setAttribute('type', 'button');
-        buttonWrapper.setAttribute('data-dismiss', 'alert');
-        buttonWrapper.className = 'close';
-        buttonWrapper.innerHTML = '×';
-        messagesBox.appendChild(buttonWrapper);
-      }
+			if (timeout && parseInt(timeout, 10) > 0) {
+				messagesBox.setAttribute('autodismiss', timeout);
+			}
 
       // Title
       title = Joomla.Text._(type);
@@ -115,14 +89,11 @@
       });
 
       messageContainer.appendChild(messagesBox);
-
-      if (typeof window.customElements !== 'object' && typeof window.customElements.get('joomla-alert') !== 'function') {
-        if (timeout && parseInt(timeout, 10) > 0) {
-          setTimeout(() => {
-            Joomla.removeMessages(messageContainer);
-          }, timeout);
-        }
-      }
+			if (timeout && parseInt(timeout, 10) > 0) {
+				setTimeout(() => {
+					Joomla.removeMessages(messageContainer);
+				}, timeout);
+			}
     });
   };
 
@@ -143,24 +114,12 @@
       messageContainer = document.getElementById('system-message-container');
     }
 
-    if (typeof window.customElements === 'object' && window.customElements.get('joomla-alert')) {
-      const alerts = [].slice.call(messageContainer.querySelectorAll('joomla-alert'));
-      if (alerts.length) {
-        alerts.forEach((alert) => {
-          alert.close();
-        });
-      }
-    } else {
-      // Empty container with a while for Chrome performance issues
-      while (messageContainer.firstChild) {
-        messageContainer.removeChild(messageContainer.firstChild);
-      }
-
-      // Fix Chrome bug not updating element height
-      messageContainer.classList.add('hidden');
-      delete messageContainer.offsetHeight;
-      messageContainer.style.display = '';
-    }
+		const alerts = [].slice.call(messageContainer.querySelectorAll('joomla-alert'));
+		if (alerts.length) {
+			alerts.forEach((alert) => {
+				alert.close();
+			});
+		}
   };
 
   /**

--- a/build/media_source/system/js/core.es6/message.es6
+++ b/build/media_source/system/js/core.es6/message.es6
@@ -89,11 +89,6 @@
       });
 
       messageContainer.appendChild(messagesBox);
-      if (timeout && parseInt(timeout, 10) > 0) {
-        setTimeout(() => {
-          Joomla.removeMessages(messageContainer);
-        }, timeout);
-      }
     });
   };
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
The core.js had a conditional for the alerts checking if the alerts custom element was present and having 2 different behaviours (for custom elements or Bootstrap). The problem is that the code would never work as intended, so it's better to leave only the code for the custom element there (the conditional will never work as the custom element is always loaded there from the messages layout).

### Testing Instructions
Apply the patch and run `npm ci`, alerts should be ok

### Expected result



### Actual result



### Documentation Changes Required
Nope