### PR TITLE
[4.0] pull-right is not a bs4 class

### DIFF
--- a/administrator/components/com_privacy/tmpl/requests/default.php
+++ b/administrator/components/com_privacy/tmpl/requests/default.php
@@ -89,7 +89,7 @@ $urgentRequestDate->sub(new DateInterval('P' . $this->urgentRequestAge . 'D'));
 							</td>
 							<td scope="row">
 								<?php if ($item->status == 1 && $urgentRequestDate >= $itemRequestedAt) : ?>
-									<span class="pull-right badge badge-danger"><?php echo Text::_('COM_PRIVACY_BADGE_URGENT_REQUEST'); ?></span>
+									<span class="float-right badge badge-danger"><?php echo Text::_('COM_PRIVACY_BADGE_URGENT_REQUEST'); ?></span>
 								<?php endif; ?>
 								<a href="<?php echo Route::_('index.php?option=com_privacy&view=request&id=' . (int) $item->id); ?>" title="<?php echo Text::_('COM_PRIVACY_ACTION_VIEW'); ?>">
 									<?php echo PunycodeHelper::emailToUTF8($this->escape($item->email)); ?>

--- a/administrator/templates/atum/scss/vendor/fontawesome-free/fontawesome.scss
+++ b/administrator/templates/atum/scss/vendor/fontawesome-free/fontawesome.scss
@@ -11,6 +11,6 @@ $fa-font-path: "../../../../../../media/vendor/fontawesome-free/webfonts" !defau
 @import "../../../../../../build/media_source/system/scss/icomoon";
 
 // RTL override
-html[dir=rtl] .pull-right {
+html[dir=rtl] .float-right {
   float: left;
 }

--- a/build/media_source/com_cpanel/js/admin-system-loader.es6.js
+++ b/build/media_source/com_cpanel/js/admin-system-loader.es6.js
@@ -36,7 +36,7 @@
               } else if (response.data) {
                 const elem = document.createElement('span');
 
-                elem.classList.add('pull-right');
+                elem.classList.add('float-right');
                 elem.classList.add('badge');
                 elem.classList.add('badge-warning');
                 elem.innerHTML = response.data;


### PR DESCRIPTION
The count of items in the system dashboard is supposed to be on the right hand side and not bunched up against the text based on the presence of class pull-right.

In BS4 we dont use pull- instead it is float-

### before
![image](https://user-images.githubusercontent.com/1296369/80376666-12309d00-8892-11ea-8094-ad06bae9d1fd.png)

### after
![image](https://user-images.githubusercontent.com/1296369/80376804-4310d200-8892-11ea-94cf-76ad9d72be3e.png)
