### PR TITLE
[4.0] font-weight variables Atum

### DIFF
--- a/administrator/templates/atum/scss/blocks/_layout.scss
+++ b/administrator/templates/atum/scss/blocks/_layout.scss
@@ -9,7 +9,7 @@
   > legend {
     width: auto;
     padding: 0 .5rem;
-    font-weight: bold;
+    font-weight: $font-weight-bold;
     color: var(--atum-text-dark);
     background-color: $white;
   }

--- a/administrator/templates/atum/scss/blocks/_login.scss
+++ b/administrator/templates/atum/scss/blocks/_login.scss
@@ -90,7 +90,7 @@
   h1 {
     padding-bottom: 1rem;
     margin: 0;
-    font-weight: bold;
+    font-weight: $font-weight-bold;
     color: var(--atum-special-color);
     text-align: center;
   }

--- a/administrator/templates/atum/scss/blocks/_sidebar-nav.scss
+++ b/administrator/templates/atum/scss/blocks/_sidebar-nav.scss
@@ -36,7 +36,7 @@
       display: block;
       padding: .35rem .35rem .35rem 1.2rem;
       overflow: hidden;
-      font-weight: normal;
+      font-weight: $font-weight-normal;
       color: var(--atum-text-dark);
 
       &::before {

--- a/administrator/templates/atum/scss/pages/_com_admin.scss
+++ b/administrator/templates/atum/scss/pages/_com_admin.scss
@@ -6,7 +6,7 @@
     box-shadow: $atum-box-shadow;
 
     th {
-      font-weight: bold;
+      font-weight: $font-weight-bold;
     }
   }
 }

--- a/administrator/templates/atum/scss/vendor/bootstrap/_table.scss
+++ b/administrator/templates/atum/scss/vendor/bootstrap/_table.scss
@@ -28,7 +28,7 @@
       color: var(--atum-link-color);
 
       &#sorted {
-        font-weight: 500;
+        font-weight: $medium-weight;
         color: $gray-800;
       }
     }
@@ -60,7 +60,7 @@
     }
 
     th {
-      font-weight: 500;
+      font-weight: $medium-weight;
     }
   }
 


### PR DESCRIPTION
This PR makes sure that the font-weight is always using a variable and not hard coded.

Note sometimes we are using atum variables and sometimes bootstrap variables. Fixing that in Atum is beyond the scope of this PR

testing is by code review