### PR TITLE
[4.0] Add anchor to full message in postinstall dropdown

### DIFF
--- a/administrator/components/com_postinstall/tmpl/messages/default.php
+++ b/administrator/components/com_postinstall/tmpl/messages/default.php
@@ -56,10 +56,10 @@ $params = array('params' => json_encode($param));
 		</a>
 	</div>
 <?php else : ?>
-	<?php foreach ($this->items as $item) : ?>
+	<?php foreach ($this->items as $i => $item) : ?>
 	<div class="card card-outline-secondary mb-3">
 		<div class="card-body">
-			<h3><?php echo Text::_($item->title_key); ?></h3>
+			<h3 id="postinstall<?php echo $i; ?>"><?php echo Text::_($item->title_key); ?></h3>
 			<p class="small">
 				<?php echo Text::sprintf('COM_POSTINSTALL_LBL_SINCEVERSION', $item->version_introduced); ?>
 			</p>

--- a/administrator/modules/mod_post_installation_messages/tmpl/default.php
+++ b/administrator/modules/mod_post_installation_messages/tmpl/default.php
@@ -43,8 +43,10 @@ $hideLinks = $app->input->getBool('hidemainmenu');
 					<?php echo Text::_('COM_POSTINSTALL_LBL_NOMESSAGES_TITLE'); ?>
 				</a>
 			<?php endif; ?>
-			<?php foreach ($messages as $message) : ?>
-				<?php $route = 'index.php?option=com_postinstall&amp;eid=' . $joomlaFilesExtensionId; ?>
+			<?php $showAnchor = false; ?>
+			<?php foreach ($messages as $i => $message) : ?>
+				<?php $route = 'index.php?option=com_postinstall&amp;eid=' . $joomlaFilesExtensionId . ($showAnchor ? '#postinstall' . $i : ''); ?>
+				<?php $showAnchor = true; ?>
 				<a class="dropdown-item" href="<?php echo Route::_($route); ?>">
 					<?php echo Text::_($message->title_key); ?>
 				</a>


### PR DESCRIPTION
Pull Request for Issue #25886 .

### Summary of Changes
Add anchor to full message in postinstall dropdown.

Note: The first message does not have an anchor to prevent the overlapping of the title with the `Hide all messages` toolbar.


### Testing Instructions
Install PR.
Click `Post Installation Messages` icon to display dropdown menu.
Click on a message item to scroll directly to it.