### PR TITLE
[4.0] cancel button on edit article

### DIFF
--- a/administrator/components/com_content/src/View/Article/HtmlView.php
+++ b/administrator/components/com_content/src/View/Article/HtmlView.php
@@ -202,8 +202,6 @@ class HtmlView extends BaseHtmlView
 				}
 			);
 
-			$toolbar->cancel('article.cancel', 'JTOOLBAR_CLOSE');
-
 			if (ComponentHelper::isEnabled('com_contenthistory') && $this->state->params->get('save_history', 0) && $itemEditable)
 			{
 				$toolbar->versions('com_content.article', $this->item->id);
@@ -228,6 +226,8 @@ class HtmlView extends BaseHtmlView
 						->task('article.editAssociations');
 				}
 			}
+
+			$toolbar->cancel('article.cancel', 'JTOOLBAR_CLOSE');
 		}
 
 		$toolbar->divider();


### PR DESCRIPTION
Ensure that the cancel button is always the last one on the toolbar in both new and edit article views

 pr for #28843
