### PR TITLE
Fix asymetrical NoMenuRules parsing #28858

### DIFF
--- a/libraries/src/Component/Router/Rules/NomenuRules.php
+++ b/libraries/src/Component/Router/Rules/NomenuRules.php
@@ -77,7 +77,17 @@ class NomenuRules implements RulesInterface
 
 				if (isset($views[$vars['view']]->key) && isset($segments[0]))
 				{
-					$vars[$views[$vars['view']]->key] = preg_replace('/-/', ':', array_shift($segments), 1);
+					if (is_callable(array($this->router, 'get' . ucfirst($views[$vars['view']]->name) . 'Id')))
+					{
+						$vars[$views[$vars['view']]->key] = call_user_func_array(
+							array($this->router, 'get' . ucfirst($views[$vars['view']]->name) . 'Id'),
+							array($segments[0], $vars)
+						);
+					}
+					else
+					{
+						$vars[$views[$vars['view']]->key] = preg_replace('/-/', ':', array_shift($segments), 1);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Pull Request for Issue #28858 .
duplicate of https://github.com/joomla/joomla-cms/pull/28859

### Summary of Changes
use get<View>Id when parsing urls


### Testing Instructions
you need a component with a router stripping ids, and way to get to a specific frontend view without a matching menu item


### Expected result

urls are built and parsed properly

### Actual result
urls were built using get<View>Segment, but not parsed using get<View>Id


### Documentation Changes Required

