### PR TITLE
[4.0] Missing import

### DIFF
--- a/plugins/system/updatenotification/postinstall/updatecachetime.php
+++ b/plugins/system/updatenotification/postinstall/updatecachetime.php
@@ -10,6 +10,7 @@
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Plugin\PluginHelper;
+use Joomla\CMS\Table\Table;
 
 /**
  * Checks if the com_installer config for the cache Hours are eq 0 and the updatenotification Plugin is enabled


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Adds missing import.

### Testing Instructions

Code review.

Or go to `com_installer` configuration.
Set `Updates Caching (in hours)` to 0.
Go to Postinstall Messages.
In `The Joomla! Update Notification will not run in this configuration` message click `Set it back to the default setting (6 Hours)` button.

### Expected result

No errors.

### Actual result

> Class 'Table' not found 

### Documentation Changes Required

No.