### PR TITLE
[4.0] Optimizing routing in languagefilter plugin

### DIFF
--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -159,10 +159,10 @@ class PlgSystemLanguageFilter extends CMSPlugin
 
 		// Attach build rules for language SEF.
 		$router->attachBuildRule(array($this, 'preprocessBuildRule'), Router::PROCESS_BEFORE);
-		$router->attachBuildRule(array($this, 'buildRule'), Router::PROCESS_BEFORE);
 
 		if ($this->mode_sef)
 		{
+			$router->attachBuildRule(array($this, 'buildRule'), Router::PROCESS_BEFORE);
 			$router->attachBuildRule(array($this, 'postprocessSEFBuildRule'), Router::PROCESS_AFTER);
 		}
 		else
@@ -203,13 +203,13 @@ class PlgSystemLanguageFilter extends CMSPlugin
 	public function preprocessBuildRule(&$router, &$uri)
 	{
 		$lang = $uri->getVar('lang', $this->current_lang);
-		$uri->setVar('lang', $lang);
 
 		if (isset($this->sefs[$lang]))
 		{
 			$lang = $this->sefs[$lang]->lang_code;
-			$uri->setVar('lang', $lang);
 		}
+
+		$uri->setVar('lang', $lang);
 	}
 
 	/**
@@ -235,10 +235,9 @@ class PlgSystemLanguageFilter extends CMSPlugin
 			$sef = $this->lang_codes[$this->current_lang]->sef;
 		}
 
-		if ($this->mode_sef
-			&& (!$this->params->get('remove_default_prefix', 0)
+		if (!$this->params->get('remove_default_prefix', 0)
 			|| $lang !== $this->default_lang
-			|| $lang !== $this->current_lang))
+			|| $lang !== $this->current_lang)
 		{
 			$uri->setPath($uri->getPath() . '/' . $sef . '/');
 		}


### PR DESCRIPTION
This optimizes the routing slightly in the languagefilter plugin. The buildRule() method only does anything when SEF is enabled and thus we can drop those checks and instead make the call to the method conditional based on SEF being enabled. This also further optimizes the onAfterRoute() call, since that second setVar() call is unnecessary.

Unfortunately this is nearly untestable and should be merged on a code review.

This has come up while trying to look at a change to remove the trailing slash in our URLs.