### PR TITLE
When viewing the Settings of some component, ensure that hitting "Cancel" redirects back to the specific URL the user was previously on

### DIFF
--- a/administrator/components/com_config/controller/component/cancel.php
+++ b/administrator/components/com_config/controller/component/cancel.php
@@ -16,21 +16,44 @@ defined('_JEXEC') or die;
  */
 class ConfigControllerComponentCancel extends ConfigControllerCanceladmin
 {
-	/**
-	 * Method to cancel global configuration component.
-	 *
-	 * @return  void
-	 *
-	 * @since   3.2
-	 */
-	public function execute()
-	{
-		$this->context = 'com_config.config.global';
+    /**
+     * Application object - Redeclared for proper typehinting
+     *
+     * @var    JApplicationCms
+     * @since  3.2
+     */
+    protected $app;
 
-		$this->component = $this->input->get('component');
+    /**
+     * Method to cancel global configuration component.
+     *
+     * @return  void
+     *
+     * @since   3.2
+     */
+    public function execute()
+    {
+        $this->context = 'com_config.config.global';
 
-		$this->redirect = 'index.php?option=' . $this->component;
+        $this->component = $this->input->get('component');
 
-		parent::execute();
-	}
+        $returnUri = $this->input->get('return', null, 'base64');
+
+        $redirect = 'index.php?option=' . $this->component;
+
+        if (!empty($returnUri))
+        {
+            $redirect = base64_decode($returnUri);
+        }
+
+        // Don't redirect to an external URL.
+        if (!JUri::isInternal($redirect))
+        {
+            $redirect = JUri::base();
+        }
+
+        $this->app->redirect(JRoute::_($redirect, false));
+
+        parent::execute();
+    }
 }

--- a/administrator/components/com_config/controller/component/cancel.php
+++ b/administrator/components/com_config/controller/component/cancel.php
@@ -10,7 +10,7 @@
 defined('_JEXEC') or die;
 
 /**
- * Cancel Controller for global configuration components
+ * Cancel Controller for global configuration
  *
  * @since  3.2
  */
@@ -37,23 +37,21 @@ class ConfigControllerComponentCancel extends ConfigControllerCanceladmin
 
 		$this->component = $this->input->get('component');
 
-		$returnUri = $this->input->get('return', null, 'base64');
+		$this->redirect = 'index.php?option=' . $this->component;
 
-		$redirect = 'index.php?option=' . $this->component;
+		$returnUri = $this->input->get('return', null, 'base64');
 
 		if (!empty($returnUri))
 		{
-			$redirect = base64_decode($returnUri);
+			$this->redirect = base64_decode($returnUri);
+
+			// Don't redirect to an external URL.
+			if (!JUri::isInternal($this->redirect))
+			{
+				$this->redirect = JUri::base();
+			}
 		}
 
-		// Don't redirect to an external URL.
-		if (!JUri::isInternal($redirect))
-		{
-			$redirect = JUri::base();
-		}
-
-		$this->app->redirect(JRoute::_($redirect, false));
-
-		parent::execute();
+		$this->app->redirect($this->redirect);
 	}
 }

--- a/administrator/components/com_config/controller/component/cancel.php
+++ b/administrator/components/com_config/controller/component/cancel.php
@@ -1,10 +1,10 @@
 <?php
 /**
- * @package	 Joomla.Administrator
+ * @package     Joomla.Administrator
  * @subpackage  com_config
  *
  * @copyright   Copyright (C) 2005 - 2020 Open Source Matters, Inc. All rights reserved.
- * @license	 GNU General Public License version 2 or later; see LICENSE.txt
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
 defined('_JEXEC') or die;
@@ -19,7 +19,7 @@ class ConfigControllerComponentCancel extends ConfigControllerCanceladmin
 	/**
 	 * Application object - Redeclared for proper typehinting
 	 *
-	 * @var	JApplicationCms
+	 * @var    JApplicationCms
 	 * @since  3.2
 	 */
 	protected $app;

--- a/administrator/components/com_config/controller/component/cancel.php
+++ b/administrator/components/com_config/controller/component/cancel.php
@@ -1,10 +1,10 @@
 <?php
 /**
- * @package     Joomla.Administrator
+ * @package	 Joomla.Administrator
  * @subpackage  com_config
  *
  * @copyright   Copyright (C) 2005 - 2020 Open Source Matters, Inc. All rights reserved.
- * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ * @license	 GNU General Public License version 2 or later; see LICENSE.txt
  */
 
 defined('_JEXEC') or die;
@@ -16,44 +16,44 @@ defined('_JEXEC') or die;
  */
 class ConfigControllerComponentCancel extends ConfigControllerCanceladmin
 {
-    /**
-     * Application object - Redeclared for proper typehinting
-     *
-     * @var    JApplicationCms
-     * @since  3.2
-     */
-    protected $app;
+	/**
+	 * Application object - Redeclared for proper typehinting
+	 *
+	 * @var	JApplicationCms
+	 * @since  3.2
+	 */
+	protected $app;
 
-    /**
-     * Method to cancel global configuration component.
-     *
-     * @return  void
-     *
-     * @since   3.2
-     */
-    public function execute()
-    {
-        $this->context = 'com_config.config.global';
+	/**
+	 * Method to cancel global configuration component.
+	 *
+	 * @return  void
+	 *
+	 * @since   3.2
+	 */
+	public function execute()
+	{
+		$this->context = 'com_config.config.global';
 
-        $this->component = $this->input->get('component');
+		$this->component = $this->input->get('component');
 
-        $returnUri = $this->input->get('return', null, 'base64');
+		$returnUri = $this->input->get('return', null, 'base64');
 
-        $redirect = 'index.php?option=' . $this->component;
+		$redirect = 'index.php?option=' . $this->component;
 
-        if (!empty($returnUri))
-        {
-            $redirect = base64_decode($returnUri);
-        }
+		if (!empty($returnUri))
+		{
+			$redirect = base64_decode($returnUri);
+		}
 
-        // Don't redirect to an external URL.
-        if (!JUri::isInternal($redirect))
-        {
-            $redirect = JUri::base();
-        }
+		// Don't redirect to an external URL.
+		if (!JUri::isInternal($redirect))
+		{
+			$redirect = JUri::base();
+		}
 
-        $this->app->redirect(JRoute::_($redirect, false));
+		$this->app->redirect(JRoute::_($redirect, false));
 
-        parent::execute();
-    }
+		parent::execute();
+	}
 }


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/28871

### Summary of Changes
Steps to reproduce the original bug:
- Hit the "Settings" toolbar button on any component (let's call it com_X) and you get redirected to the component's settings, loaded via com_config.
- If you hit "Save & Close" you get redirected back to the *exact* URL you previously were on com_X.
- If you hit "Cancel" you are redirected back to the component's main page (index.php?com_X) and NOT to the page you were in that component.

This PR properly adapts the code to respect the "return" variable (if it exists) and redirect back to the exact URL the user was on if they hit "Cancel".


### Testing Instructions



### Expected result



### Actual result



### Documentation Changes Required
None.
