### PR TITLE
[4.0] Fix float-right for other quickicons than counters in the Atum system dashboard for LTR

### DIFF
--- a/administrator/modules/mod_submenu/tmpl/default.php
+++ b/administrator/modules/mod_submenu/tmpl/default.php
@@ -65,7 +65,7 @@ use Joomla\CMS\Router\Route;
 									<?php echo ($params->get('menu_text', 1)) ? htmlspecialchars(Text::_($item->title), ENT_QUOTES, 'UTF-8') . $item->iconImage : ''; ?>
 									<?php if ($item->ajaxbadge) : ?>
 										<span class="menu-badge">
-											<span class="fas fa-spin fa-spinner mt-1 system-counter" data-url="<?php echo $item->ajaxbadge; ?>"></span>
+											<span class="fas fa-spin fa-spinner mt-1 system-counter float-right" data-url="<?php echo $item->ajaxbadge; ?>"></span>
 										</span>
 									<?php endif; ?>
 								</a>

--- a/build/media_source/com_cpanel/js/admin-system-loader.es6.js
+++ b/build/media_source/com_cpanel/js/admin-system-loader.es6.js
@@ -31,6 +31,7 @@
               if (response.error || !response.success) {
                 element.classList.remove('fa-spin');
                 element.classList.remove('fa-spinner');
+                element.classList.add('float-right');
                 element.classList.add('text-danger');
                 element.classList.add('fa-remove');
               } else if (response.data) {
@@ -45,6 +46,7 @@
               } else {
                 element.classList.remove('fa-spin');
                 element.classList.remove('fa-spinner');
+                element.classList.add('float-right');
                 element.classList.add('fa-check');
                 element.classList.add('text-success');
               }
@@ -52,6 +54,7 @@
             onError: () => {
               element.classList.remove('fa-spin');
               element.classList.remove('fa-spinner');
+              element.classList.add('float-right');
               element.classList.add('text-danger');
               element.classList.add('fa-remove');
             },

--- a/build/media_source/com_cpanel/js/admin-system-loader.es6.js
+++ b/build/media_source/com_cpanel/js/admin-system-loader.es6.js
@@ -31,7 +31,6 @@
               if (response.error || !response.success) {
                 element.classList.remove('fa-spin');
                 element.classList.remove('fa-spinner');
-                element.classList.add('float-right');
                 element.classList.add('text-danger');
                 element.classList.add('fa-remove');
               } else if (response.data) {
@@ -46,7 +45,6 @@
               } else {
                 element.classList.remove('fa-spin');
                 element.classList.remove('fa-spinner');
-                element.classList.add('float-right');
                 element.classList.add('fa-check');
                 element.classList.add('text-success');
               }
@@ -54,7 +52,6 @@
             onError: () => {
               element.classList.remove('fa-spin');
               element.classList.remove('fa-spinner');
-              element.classList.add('float-right');
               element.classList.add('text-danger');
               element.classList.add('fa-remove');
             },


### PR DESCRIPTION
Pull Request for Issue #28879 .

### Summary of Changes

With Pull Request (PR) #28834 , setting the Bootstrap class for the counters in file `build/media_source/com_cpanel/js/admin-system-loader.es6.js` has been adapted to Bootstrap 4 class "float-right", so these counters are pulled to the right side when LTR and to the left side when RTL.

But the check marks shown wenn all is ok and no counter is shown, or the danger icons shown when something went wrong with the check, those have never been handled in that way in that js.

This mix of alignment looks ugly when direction is LTR, see screenshot in section "Actual result" below. For RTL the other icons beside the counters are already floating to the left.

This PR here fixes this by adding the "float-right" class to the span initially in PHP.

### Testing Instructions

1. Check the system dashboard in Atum.
Result: See section "Actual result" below.

2. Apply the patch of this PR.

3. Check again the system dashboard in Atum (refresh page before).
Result: See section "Expected result" below.

### Expected result

LTR:
![j4-system-dashboard-checks-right](https://user-images.githubusercontent.com/7413183/80700076-62e80600-8add-11ea-9c89-292991d69809.png)

RTL:
![j4-system-dashboard-checks-right_RTL](https://user-images.githubusercontent.com/7413183/80700097-6a0f1400-8add-11ea-96d9-376547dedd2c.png)

### Actual result

LTR:
![j4-system-dashboard-current](https://user-images.githubusercontent.com/7413183/80699988-421fb080-8add-11ea-902b-a95ede96d714.png)

RTL: See expected result.

### Documentation Changes Required

None, except if we have some documentation telling our backend has to look ugly ;-) (joking).

### Additional information

What is interesting: For RTL the other icons beside the counters are already floating to the left. I think the reason is this section in Atum's template-rtl.scss, but I am not sure:
[https://github.com/joomla/joomla-cms/blob/4.0-dev/administrator/templates/atum/scss/template-rtl.scss#L167-L171](https://github.com/joomla/joomla-cms/blob/4.0-dev/administrator/templates/atum/scss/template-rtl.scss#L167-L171). So we might have duplicate css in case of RTL, which can be simplified. But this is not scope of this PR here.