### PR TITLE
[3.x] Contact Address

### DIFF
--- a/components/com_contact/views/contact/tmpl/default_address.php
+++ b/components/com_contact/views/contact/tmpl/default_address.php
@@ -14,9 +14,9 @@ defined('_JEXEC') or die;
  * jicon-text, jicon-none, jicon-icon
  */
 ?>
-<dl class="contact-address dl-horizontal" itemprop="address" itemscope itemtype="https://schema.org/PostalAddress">
-	<?php if (($this->params->get('address_check') > 0) &&
-		($this->contact->address || $this->contact->suburb  || $this->contact->state || $this->contact->country || $this->contact->postcode)) : ?>
+<?php if (($this->params->get('address_check') > 0) &&
+	($this->contact->address || $this->contact->suburb  || $this->contact->state || $this->contact->country || $this->contact->postcode)) : ?>
+	<dl class="contact-address dl-horizontal" itemprop="address" itemscope itemtype="https://schema.org/PostalAddress">
 		<dt>
 			<span class="<?php echo $this->params->get('marker_class'); ?>">
 				<?php echo $this->params->get('marker_address'); ?>
@@ -126,5 +126,5 @@ defined('_JEXEC') or die;
 			<?php echo JStringPunycode::urlToUTF8($this->contact->webpage); ?></a>
 		</span>
 	</dd>
-<?php endif; ?>
 </dl>
+<?php endif; ?>


### PR DESCRIPTION
The check to see if the address should be displayed for a contact takes place inside the definition list. This means that you get an empty dl if you have chosen not to display the address.

This PR corrects that and moves the dl inside the if statement

### Testing Instructions
Code review and checking the generated markup of the contact component when the address is displayed and when it is not.


### Expected result
The empty dl will be removed if there is no address being displayed

### Backwards Compatibility
I can't imagine any bc issues other than potentially removing some white space

