### PR TITLE
[4.0] Loader web component styling fixes

### DIFF
--- a/build/media_source/system/js/joomla-core-loader.w-c.es6.js
+++ b/build/media_source/system/js/joomla-core-loader.w-c.es6.js
@@ -15,7 +15,7 @@
     <span class="red"></span>
     <span class="blue"></span>
     <span class="green"></span>
-    <p>&reg;</p>
+    <p>&trade;</p>
 </div>`;
 
       // Patch the shadow DOM

--- a/build/media_source/system/scss/joomla-core-loader.scss
+++ b/build/media_source/system/scss/joomla-core-loader.scss
@@ -6,31 +6,30 @@ $theme-colours: map-merge((
   "green"  : #7ac143,
 ), $theme-colours);
 
-:host {
+joomla-core-loader {
   position: fixed;
   top: 0;
   left: 0;
   z-index: 10000;
-  display: block;
+  display: flex;
   width: 100%;
   height: 100%;
   overflow: hidden;
+  align-items: center;
   opacity: .8;
 }
 
 .box {
   position: relative;
-  width: 300px;
-  height: 300px;
+  width: 345px;
+  height: 345px;
   margin: 0 auto;
-  transform: rotate(45deg);
 
   p {
-    float: left;
-    margin: -20px 0 0 252px;
+    float: right;
+    margin: 95px 0 0 0;
     font: normal 1.25em/1em sans-serif;
     color: #999;
-    transform: rotate(-45deg);
   }
 
   > span {
@@ -82,31 +81,30 @@ $theme-colours: map-merge((
     }
 
     &::after {
-      height: 101px;
-      margin: 145px 0 0 -30px;
+      height: 105px;
+      margin: 140px 0 0 -30px;
       border-width: 0 0 0 50px;
     }
   }
 }
 
 .yellow {
-  margin: 0 0 0 182px;
-  transform: rotate(0deg);
+  margin: 0 0 0 255px;
+  transform: rotate(45deg);
 }
 
 .red {
-  margin: 182px 0 0 364px;
-  transform: rotate(90deg);
+  margin: 255px 0 0 255px;
+  transform: rotate(135deg);
 }
 
 .blue {
-  margin: 364px 0 0 182px;
-  transform: rotate(180deg);
+  margin: 255px 0 0 0;
+  transform: rotate(225deg);
 }
 
 .green {
-  margin: 182px 0 0;
-  transform: rotate(270deg);
+  transform: rotate(315deg);
 }
 
 @keyframes jspinner {

--- a/build/media_source/system/scss/joomla-core-loader.scss
+++ b/build/media_source/system/scss/joomla-core-loader.scss
@@ -6,7 +6,7 @@ $theme-colours: map-merge((
   "green"  : #7ac143,
 ), $theme-colours);
 
-joomla-core-loader {
+:host {
   position: fixed;
   top: 0;
   left: 0;


### PR DESCRIPTION
Pull Request for Issue #28885

### Summary of Changes

- Fixes the spacing issues with the Joomla loader web component in Firefox 75
- Replaces the **&reg;** with **&trade;** as per Joomla's trademark policy: https://tm.joomla.org/trademark/158-logos/227-using-the-logo.html
- Logo should now always be vertically aligned on the page

### Testing Instructions

- You can see a live demo here: https://codepen.io/charlie-lodder/pen/PoPKMXe
- Install J4 from scratch
- Or do something else that you know triggers the display of the loading logo
