### PR TITLE
[4.0] com contact select field groups cont.

### DIFF
--- a/components/com_contact/tmpl/category/default.xml
+++ b/components/com_contact/tmpl/category/default.xml
@@ -592,6 +592,8 @@
 				label="COM_CONTACT_FIELD_USER_CUSTOM_FIELDS_SHOW_LABEL"
 				multiple="true"
 				context="com_users.user"
+				addfieldprefix="Joomla\Component\Fields\Administrator\Field"
+				layout="joomla.form.field.list-fancy-select"
 				>
 				<option value="-1">JALL</option>
 			</field>

--- a/components/com_contact/tmpl/contact/default.xml
+++ b/components/com_contact/tmpl/contact/default.xml
@@ -322,6 +322,7 @@
 				multiple="true"
 				context="com_users.user"
 				addfieldprefix="Joomla\Component\Fields\Administrator\Field"
+				layout="joomla.form.field.list-fancy-select"
 				>
 				<option value="-1">JALL</option>
 			</field>


### PR DESCRIPTION
This is a continuation of #28736

Simple pr to use the correct layout for this field as it is a multi select. without this it may not be possible to see all the selected field groups

This can be seen in the options for the contact menu items - oops I missed them in the previous PR

### before
![image](https://user-images.githubusercontent.com/1296369/80744099-09e89400-8b16-11ea-894c-5577683b18ae.png)

### after
![image](https://user-images.githubusercontent.com/1296369/80744089-06550d00-8b16-11ea-83a0-e4c7a2ccf7c1.png)
