### PR TITLE
[com_messages] Fix inbox lock not working

### DIFF
--- a/administrator/components/com_messages/models/message.php
+++ b/administrator/components/com_messages/models/message.php
@@ -334,7 +334,7 @@ class MessagesModelMessage extends JModelAdmin
 			return false;
 		}
 
-		if ($config->get('locked', false))
+		if ($config->get('lock', false))
 		{
 			$this->setError(JText::_('COM_MESSAGES_ERR_SEND_FAILED'));
 


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/28892.

### Summary of Changes

Corrects parameter name.

### Testing Instructions

>Your site must have 2 users with access to the control panel and work e-mail addresses,
>Log in to the control panel under one of the users, go to Components -> Private Messages -> My settings, enable the Lock Inbox option, save and log out,
>Log in to the control panel as a second user and try to send him a message in Private Messages,
>Log back into the control panel under the first user and check the incoming messages.

### Expected result

> Error
> Save failed with the following error: The user has locked their mailbox. Message failed.

### Actual result

>The message was delivered to the first user without any problems.

### Documentation Changes Required

No.