### PR TITLE
[4.0] Client-side validation not triggered when submitting some forms

### DIFF
--- a/libraries/src/Toolbar/ToolbarHelper.php
+++ b/libraries/src/Toolbar/ToolbarHelper.php
@@ -479,47 +479,45 @@ abstract class ToolbarHelper
 		$bar = Toolbar::getInstance('toolbar');
 
 		// Add an apply button
-		$bar->appendButton('Standard', 'apply', $alt, $task, false);
+		$bar->apply($task, $alt);
 	}
 
 	/**
 	 * Writes a save button for a given option.
 	 * Save operation leads to a save and then close action.
 	 *
-	 * @param   string   $task   An override for the task.
-	 * @param   string   $alt    An override for the alt text.
-	 * @param   boolean  $group  True or false
+	 * @param   string   $task  An override for the task.
+	 * @param   string   $alt   An override for the alt text.
 	 *
 	 * @return  void
 	 *
 	 * @since   1.5
 	 */
-	public static function save($task = 'save', $alt = 'JTOOLBAR_SAVE', $group = false)
+	public static function save($task = 'save', $alt = 'JTOOLBAR_SAVE')
 	{
 		$bar = Toolbar::getInstance('toolbar');
 
 		// Add a save button.
-		$bar->appendButton('Standard', 'save', $alt, $task, false, $group);
+		$bar->save($task, $alt);
 	}
 
 	/**
 	 * Writes a save and create new button for a given option.
 	 * Save and create operation leads to a save and then add action.
 	 *
-	 * @param   string   $task   An override for the task.
-	 * @param   string   $alt    An override for the alt text.
-	 * @param   boolean  $group  True or false
+	 * @param   string   $task  An override for the task.
+	 * @param   string   $alt   An override for the alt text.
 	 *
 	 * @return  void
 	 *
 	 * @since   1.6
 	 */
-	public static function save2new($task = 'save2new', $alt = 'JTOOLBAR_SAVE_AND_NEW', $group = false)
+	public static function save2new($task = 'save2new', $alt = 'JTOOLBAR_SAVE_AND_NEW')
 	{
 		$bar = Toolbar::getInstance('toolbar');
 
 		// Add a save and create new button.
-		$bar->appendButton('Standard', 'save-new', $alt, $task, false, $group);
+		$bar->save2new($task, $alt);
 	}
 
 	/**
@@ -527,20 +525,19 @@ abstract class ToolbarHelper
 	 * Save as copy operation leads to a save after clearing the key,
 	 * then returns user to edit mode with new key.
 	 *
-	 * @param   string   $task   An override for the task.
-	 * @param   string   $alt    An override for the alt text.
-	 * @param   boolean  $group  True or false
+	 * @param   string   $task  An override for the task.
+	 * @param   string   $alt   An override for the alt text.
 	 *
 	 * @return  void
 	 *
 	 * @since   1.6
 	 */
-	public static function save2copy($task = 'save2copy', $alt = 'JTOOLBAR_SAVE_AS_COPY', $group = false)
+	public static function save2copy($task = 'save2copy', $alt = 'JTOOLBAR_SAVE_AS_COPY')
 	{
 		$bar = Toolbar::getInstance('toolbar');
 
 		// Add a save and create new button.
-		$bar->appendButton('Standard', 'save-copy', $alt, $task, false, $group);
+		$bar->save2copy($task, $alt);
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue #26639.

### Summary of Changes

Adds client-side validation to toolbar buttons added using `Joomla\CMS\Toolbar\ToolbarHelper`.
Also removes broken `$group` argument.

### Testing Instructions

Go to Users.
Click `New`.
Without entering anything in the form click `Save`.

### Expected result

Form is not submitted, required fields are highlighted and message is shown:

> The form cannot be submitted as it's missing required data.
> Please correct the marked fields and try again.

### Actual result

Form is submitted but saving fails with warning:

> Field required: Name
> Field required: Login Name (Username)
> Field required: Email

### Documentation Changes Required

No.