### PR TITLE
[4.0] Fix wrong ID loading when "0" is given as saving parameter

### DIFF
--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -1270,7 +1270,7 @@ abstract class AdminModel extends FormModel
 		}
 
 		$key = $table->getKeyName();
-		$pk = (isset($data[$key])) ? (int) $data[$key] : (int) $this->getState($this->getName() . '.id');
+		$pk = (isset($data[$key])) ? $data[$key] : (int) $this->getState($this->getName() . '.id');
 		$isNew = true;
 
 		// Include the plugins for the save events.

--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -1270,7 +1270,7 @@ abstract class AdminModel extends FormModel
 		}
 
 		$key = $table->getKeyName();
-		$pk = (!empty($data[$key])) ? $data[$key] : (int) $this->getState($this->getName() . '.id');
+		$pk = (isset($data[$key])) ? (int) $data[$key] : (int) $this->getState($this->getName() . '.id');
 		$isNew = true;
 
 		// Include the plugins for the save events.

--- a/plugins/sampledata/blog/blog.php
+++ b/plugins/sampledata/blog/blog.php
@@ -217,7 +217,6 @@ class PlgSampledataBlog extends CMSPlugin
 		$catIds[] = $categoryModel->getItem()->id;
 
 		// Create Articles.
-		$articleModel = new \Joomla\Component\Content\Administrator\Model\ArticleModel;
 		$articles     = array(
 			array(
 				'catid'    => $catIds[1],
@@ -245,9 +244,13 @@ class PlgSampledataBlog extends CMSPlugin
 				'ordering' => 0,
 			),
 		);
+		
+		$mvcFactory = $this->app->bootComponent('com_content')->getMVCFactory();
 
 		foreach ($articles as $i => $article)
 		{
+			$articleModel = $mvcFactory->createModel('Article', 'Administrator', ['ignore_request' => true]);
+
 			// Set values from language strings.
 			$title                = Text::_('PLG_SAMPLEDATA_BLOG_SAMPLEDATA_CONTENT_ARTICLE_' . $i . '_TITLE');
 			$alias                = ApplicationHelper::stringURLSafe($title);

--- a/plugins/sampledata/blog/blog.php
+++ b/plugins/sampledata/blog/blog.php
@@ -244,6 +244,7 @@ class PlgSampledataBlog extends CMSPlugin
 				'ordering' => 0,
 			),
 		);
+
 		$mvcFactory = $this->app->bootComponent('com_content')->getMVCFactory();
 
 		foreach ($articles as $i => $article)

--- a/plugins/sampledata/blog/blog.php
+++ b/plugins/sampledata/blog/blog.php
@@ -244,7 +244,6 @@ class PlgSampledataBlog extends CMSPlugin
 				'ordering' => 0,
 			),
 		);
-		
 		$mvcFactory = $this->app->bootComponent('com_content')->getMVCFactory();
 
 		foreach ($articles as $i => $article)


### PR DESCRIPTION
### Summary of Changes
When you do something like:
```
$articleModel = new \Joomla\Component\Content\Administrator\Model\ArticleModel;

$articles = [
  [
    'id' => 0,
    'title' => 'bla',
    'alias' => 'bla'
    'catid' => 1,
    'ordering' => 1
  ],
  [
    'id' => 0,
    'title' => 'foobar',
    'alias' => 'foobar',
    'catid' => 1,
    'ordering' => 2
  ]
];

foreach ($articles as $article)
{
  $articleModel->save($article);

  var_dump($articleModel->getState($articleModel->getName() . '.new'));
}
```
You will get:

```
true
false
```
Because giving the save method directly the ID does create a new article but does not reset the internal ID state in the model. So e.g. plugins which rely on this ```$isNew``` get the wrong information.

This happens e.g. heavily in the sample data plugin: https://github.com/joomla/joomla-cms/blob/4.0-dev/plugins/sampledata/blog/blog.php#L220-L298 So plugins which hear on "onContentAfterSave" could act the wrong way.

### Testing Instructions
1. Install a clean Joomla
2. Go to https://github.com/joomla/joomla-cms/blob/4.0-dev/plugins/sampledata/blog/blog.php#L295
3. Add ```var_dump($articleModel->getState($articleModel->getName() . '.new'));```
4. Open browser developer console
5. Execute sample data installation

(Adding this test/debug code will break the installation of the sample datas, but that's ok, as we're testing a specific part and not the whole sample data)

### Expected result
```
bool(true)
bool(true)
bool(true)
bool(true)
bool(true)
bool(true)
```


### Actual result
```
bool(true)
bool(false)
bool(false)
bool(false)
bool(false)
bool(false)
```

