### PR TITLE
[4.0] [plg_content_pagebreak] Fix first page appearing in tab/slider

### DIFF
--- a/plugins/content/pagebreak/pagebreak.php
+++ b/plugins/content/pagebreak/pagebreak.php
@@ -249,26 +249,26 @@ class PlgContentPagebreak extends CMSPlugin
 						{
 							$title = Text::sprintf('PLG_CONTENT_PAGEBREAK_PAGE_NUM', $key + 1);
 						}
-					}
 
-					if ($style === 'tabs')
-					{
-						$t[] = (string) HTMLHelper::_('uitab.addTab', 'myTab', $index, $title);
-					}
-					else
-					{
-						$t[] = (string) HTMLHelper::_('bootstrap.addSlide', 'myAccordion', $title, $index);
-					}
+						if ($style === 'tabs')
+						{
+							$t[] = (string) HTMLHelper::_('uitab.addTab', 'myTab', $index, $title);
+						}
+						else
+						{
+							$t[] = (string) HTMLHelper::_('bootstrap.addSlide', 'myAccordion', $title, $index);
+						}
 
-					$t[] = (string) $subtext;
+						$t[] = (string) $subtext;
 
-					if ($style === 'tabs')
-					{
-						$t[] = (string) HTMLHelper::_('uitab.endTab');
-					}
-					else
-					{
-						$t[] = (string) HTMLHelper::_('bootstrap.endSlide');
+						if ($style === 'tabs')
+						{
+							$t[] = (string) HTMLHelper::_('uitab.endTab');
+						}
+						else
+						{
+							$t[] = (string) HTMLHelper::_('bootstrap.endSlide');
+						}
 					}
 				}
 


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/28898.

### Summary of Changes

Corrects article display with page breaks.

### Testing Instructions

In `Content - Page Break` plugin set `Presentation Style` to `Tabs` or `Sliders`.
Create an article with 3 pages.
View the article in frontend.

### Expected result

Contents of first page appear normally above tabs/sliders.

![Screenshot_2020-05-01 Pagebreak](https://user-images.githubusercontent.com/7325021/80833582-87d09c00-8bf7-11ea-83af-c230fff03dde.png)

### Actual result

First pages appears normally and in a tab.

![Screenshot_2020-05-01 Pagebreak(1)](https://user-images.githubusercontent.com/7325021/80833592-8d2de680-8bf7-11ea-8fc9-426b9da1e38a.png)


### Documentation Changes Required

No.