### PR TITLE
[4.0] Template Atum - Toolbar Button colors

### DIFF
--- a/administrator/templates/atum/scss/_variables.scss
+++ b/administrator/templates/atum/scss/_variables.scss
@@ -169,8 +169,8 @@ $state-success-bg:                 lighten($green-dark, 70%);
 $state-success-border:             lighten($green-dark, 30%);
 
 $state-info-text:                  var(--white);
-$state-info-bg:                    var(--info);
-$state-info-border:                var(--info-border);
+$state-info-bg:                    var(--atum-bg-dark);
+$state-info-border:                var(--atum-bg-dark);
 
 $state-warning-text:               var(--atum-text-dark);
 $state-warning-bg:                 var(--warning);

--- a/administrator/templates/atum/scss/blocks/_toolbar.scss
+++ b/administrator/templates/atum/scss/blocks/_toolbar.scss
@@ -35,7 +35,6 @@
 
   .btn {
     --subhead-btn-accent: var(--atum-text-dark);
-
     padding: 0 1rem;
     margin: 5px 0;
     font-size: 1rem;
@@ -46,18 +45,18 @@
 
     > span {
       display: inline-block;
-      color: var(--atum-link-color);
+      color: var(--subhead-btn-accent);
     }
 
     &:not([disabled]):hover,
     &:not([disabled]):active,
     &:not([disabled]):focus {
       color: rgba(255, 255, 255, .90);
-      background-color: var(--atum-link-color);
-      border-color: var(--atum-link-hover-color);
+      background-color: var(--subhead-btn-accent);
+      border-color: var(--subhead-btn-accent);
 
       > span {
-        color: var(--atum-text-light);
+        color: rgba(255, 255, 255, .90);
       }
     }
 
@@ -70,15 +69,15 @@
     }
 
     &.btn-primary {
-      --subhead-btn-accent: var(--info);
-    }
-
-    &.btn-secondary {
       --subhead-btn-accent: var(--atum-link-color);
     }
 
+    &.btn-secondary {
+      --subhead-btn-accent: var(--atum-special-color);
+    }
+
     &.btn-info {
-      --subhead-btn-accent: var(--info);
+      --subhead-btn-accent: var(--atum-bg-dark);
     }
 
     &.btn-action {


### PR DESCRIPTION
Change Info buttons to use template variables

Pull Request for Issue https://github.com/joomla/joomla-cms/issues/28906

### Summary of Changes
- Reverted changes from #28788 and use special color for secodary and bg-atum-dark for the info buttons

### Testing Instructions
- apply patch
- npm run build:css
- check if save button icons and hover is green again, close red,... and so on
- check with own colors in your custom template style, Info Buttons have now the dark color from the header, secondary buttons have now the link color.

