### PR TITLE
[4.0] sidebar height

### DIFF
--- a/administrator/templates/atum/scss/blocks/_sidebar.scss
+++ b/administrator/templates/atum/scss/blocks/_sidebar.scss
@@ -1,7 +1,7 @@
 // Sidebar
 
 .sidebar-wrapper {
-  min-height: calc(100vh -69px);
+  min-height: calc(100vh - 69px);
   z-index: $zindex-sidebar;
   background-color: var(--atum-sidebar-bg);
   box-shadow: $atum-box-shadow;


### PR DESCRIPTION
On a page that is pretty empty the sidebar does not extend the full height of the screen. This is because there is a missing space in the height calculation

`min-height: calc(100vh -69px);`

That is invalid because the browser thinks its an invalid property value

![image](https://user-images.githubusercontent.com/1296369/80869742-1c8bd600-8c9a-11ea-9a48-34ac5b18d881.png)

This pr puts the space back and then the browser can do the calculation

(Maybe this is browser dependent but it definitely is reproducible on chrome for windows)


### before
![image](https://user-images.githubusercontent.com/1296369/80869769-40e7b280-8c9a-11ea-8813-33d6beb0d032.png)

### after
![image](https://user-images.githubusercontent.com/1296369/80869778-4c3ade00-8c9a-11ea-9c87-4f679370fe20.png)
