### PR TITLE
[4.0] Fix media manager file rename

### DIFF
--- a/administrator/components/com_media/src/Controller/ApiController.php
+++ b/administrator/components/com_media/src/Controller/ApiController.php
@@ -275,10 +275,10 @@ class ApiController extends BaseController
 			$this->getModel()->updateFile($adapter, $name, str_replace($name, '', $path), $mediaContent);
 		}
 
-		list($destinationAdapter, $destinationPath) = explode(':', $newPath, 2);
-		
-		if ($newPath != null && ($adapter !== $destinationAdapter && str_replace($destinationAdapter . ':', '', $newPath) !== $path))
+		if ($newPath != null && $newPath !== $adapter . ':' . $path)
 		{
+			list($destinationAdapter, $destinationPath) = explode(':', $newPath, 2);
+
 			if ($move)
 			{
 				$destinationPath = $this->getModel()->move($adapter, $path, $destinationPath, false);


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/pull/28896 .

### Summary of Changes
Fixes the ability to rename a file in media manager. This was broken in https://github.com/joomla/joomla-cms/pull/28896 and was shows by the drone tests failing - unfortunately I still merged it anyway :) 

### Testing Instructions
Before patch check renaming a file with a new name gives a success message but it isn't actually renamed

Check that renaming a file to a different name works (also test that renaming a file and hitting save without saving it also works (i.e. gives a successfully renamed message).

Also check drone now passes

### Documentation Changes Required
None
