### PR TITLE
Default to showing language strings when language debug is enabled

### DIFF
--- a/libraries/src/Language/Language.php
+++ b/libraries/src/Language/Language.php
@@ -320,7 +320,7 @@ class Language
 			// Store debug information
 			if ($this->debug)
 			{
-				$value = \JFactory::getApplication()->get('debug_lang_const') == 0 ? $key : $string;
+				$value = \JFactory::getApplication()->get('debug_lang_const', 1) == 0 ? $key : $string;
 				$string = '**' . $value . '**';
 
 				$caller = $this->getCallerInfo();


### PR DESCRIPTION
Partial Pull Request for Issue https://github.com/joomla/joomla-cms/issues/28913.

### Summary of Changes

Since the option to show language constants was added, it is assumed to be enabled unless it's explicitly disabled. It should have been the other way around.

### Testing Instructions

Modify `installation/localise.xml` to use debug:

    <debug>1</debug>

Start installation.

### Expected result

Language strings are shown.

### Actual result

Language constants are shown.

### Documentation Changes Required

IDK.