### PR TITLE
Show message when saving config with "Save & Close" button

### DIFF
--- a/administrator/components/com_config/controller/component/save.php
+++ b/administrator/components/com_config/controller/component/save.php
@@ -129,6 +129,7 @@ class ConfigControllerComponentSave extends JControllerBase
 				break;
 
 			case 'save':
+				$this->app->enqueueMessage(JText::_('COM_CONFIG_SAVE_SUCCESS'), 'message');
 			default:
 				$redirect = 'index.php?option=' . $option;
 


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/28915.

### Summary of Changes

Adds message when saving component configuration using `Save & Close` button.

### Testing Instructions

Edit some component.
Save settings using `Save & Close` button.

### Expected result

`Configuration saved` message shown.

### Actual result

No message.

### Documentation Changes Required

No.