### PR TITLE
Add loading=lazy for the drag&dropped images in tinyMCE

### DIFF
--- a/build/media_source/plg_editors_tinymce/js/plugins/dragdrop/plugin.es6.js
+++ b/build/media_source/plg_editors_tinymce/js/plugins/dragdrop/plugin.es6.js
@@ -47,6 +47,7 @@ tinymce.PluginManager.add('jdragdrop', (editor) => {
           // Create the image tag
           const newNode = tinyMCE.activeEditor.getDoc().createElement('img');
           newNode.src = tinyMCE.activeEditor.settings.setCustomDir + resp.location;
+          newNode.setAttribute('loading', 'lazy');
           tinyMCE.activeEditor.execCommand('mceInsertContent', false, newNode.outerHTML);
         }
       } else {


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Add loading=lazy for the drag&dropped images in tinyMCE


### Testing Instructions
Apply the patch
Run `npm ci`

Create a new article, and add an image with drag and drop to editor (editor needs to be set to tinyMCE, it's the default)

Add a title and some dummy content

Save and publish the article

Observe the article in the frontend with the browser's tools and check that the image has an attribute `loading="lazy"`

### Expected result



### Actual result



### Documentation Changes Required

This is a system wide change, meaning that the documentation will reflect all these changes (eg nothing special for this instance)

@wilsonge