### PR TITLE
[4.0] th on safari

### DIFF
--- a/administrator/templates/atum/scss/template.scss
+++ b/administrator/templates/atum/scss/template.scss
@@ -30,6 +30,7 @@
 @import "vendor/bootstrap/modal";
 @import "vendor/bootstrap/nav";
 @import "vendor/bootstrap/pagination";
+@import "vendor/bootstrap/reboot";
 @import "vendor/bootstrap/table";
 
 // Blocks

--- a/administrator/templates/atum/scss/vendor/bootstrap/_reboot.scss
+++ b/administrator/templates/atum/scss/vendor/bootstrap/_reboot.scss
@@ -1,6 +1,5 @@
 // Matches default `<td>` alignment by inheriting `text-align`.
 // 1. Fix alignment for Safari
-// @todo Can be removed with Bootstrap 4.4.2
 
 th {
   text-align: inherit;

--- a/administrator/templates/atum/scss/vendor/bootstrap/_reboot.scss
+++ b/administrator/templates/atum/scss/vendor/bootstrap/_reboot.scss
@@ -1,0 +1,8 @@
+// Matches default `<td>` alignment by inheriting `text-align`.
+// 1. Fix alignment for Safari
+// @todo Can be removed with Bootstrap 4.4.2
+
+th {
+  text-align: inherit;
+  text-align: -webkit-match-parent; // 1
+}


### PR DESCRIPTION
PR for #28904

This is a test PR for the TH alignment issue with safari. It is a bug in bootstrap that they have fixed and merged but not released yet. See https://github.com/twbs/bootstrap/pull/30323

This PR adds a _temporary_ reboot.css override with the code direct from bootstrap. I can't see any other way to fix this beta blocker.

I do not have access to Safari to test this.

@nikosdion please can you test this
