### PR TITLE
[4.0] TinyMCE, Fix drag and drop

### DIFF
--- a/build/media_source/plg_editors_tinymce/js/plugins/dragdrop/plugin.es6.js
+++ b/build/media_source/plg_editors_tinymce/js/plugins/dragdrop/plugin.es6.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-undef */
-tinymce.PluginManager.add('jdragndrop', (editor) => {
+tinymce.PluginManager.add('jdragndrop', function (editor) {
   // Reset the drop area border
   tinyMCE.DOM.bind(document, 'dragleave', (e) => {
     e.stopPropagation();
@@ -55,7 +55,7 @@ tinymce.PluginManager.add('jdragndrop', (editor) => {
           if (/local-/.test(response.data.adapter)) {
             const { rootFull } = Joomla.getOptions('system.paths');
 
-            urlPath = `${response.data.url.split(rootFull)[1]}`;
+            urlPath = `${response.data.thumb_path.split(rootFull)[1]}`;
           } else if (response.data.thumb_path) {
             // Absolute path for different domain
             urlPath = response.data.thumb_path;

--- a/build/media_source/plg_editors_tinymce/js/plugins/dragdrop/plugin.es6.js
+++ b/build/media_source/plg_editors_tinymce/js/plugins/dragdrop/plugin.es6.js
@@ -26,41 +26,24 @@ tinymce.PluginManager.add('jdragndrop', (editor) => {
     return false;
   });
 
-  function readFile(file) {
-    // Create a new file reader instance
-    let reader = new FileReader();
-
-    // Add the on load callback
-    reader.onload = (progressEvent) => {
-      const result = progressEvent.target.result,
-        splitIndex = result.indexOf('base64') + 7,
-        content = result.slice(splitIndex, result.length);
-
-      // Upload the file
-      uploadFile(file.name, content)
-    };
-
-    reader.readAsDataURL(file);
-  }
-
   function uploadFile(name, content) {
     const url = `${tinyMCE.activeEditor.settings.uploadUri}&path=${tinyMCE.activeEditor.settings.comMediaAdapter}`;
     const data = {
       [tinyMCE.activeEditor.settings.csrfToken]: '1',
-      name: name,
-      content: content,
+      name,
+      content,
       parent: tinyMCE.activeEditor.settings.parentUploadFolder,
     };
 
     Joomla.request({
-      url: url,
+      url,
       method: 'POST',
       data: JSON.stringify(data),
-      headers: {'Content-Type': 'application/json'},
+      headers: { 'Content-Type': 'application/json' },
       onSuccess: (resp) => {
         let response;
 
-        try{
+        try {
           response = JSON.parse(resp);
         } catch (e) {
           editor.windowManager.alert(`${Joomla.Text._('JERROR')}: {e}`);
@@ -70,7 +53,7 @@ tinymce.PluginManager.add('jdragndrop', (editor) => {
           let urlPath;
           // For local adapters use relative paths
           if (/local-/.test(response.data.adapter)) {
-            const {rootFull} = Joomla.getOptions('system.paths');
+            const { rootFull } = Joomla.getOptions('system.paths');
 
             urlPath = `/${response.data.thumb_path.split(rootFull)[1]}`;
           } else if (response.data.thumb_path) {
@@ -83,8 +66,25 @@ tinymce.PluginManager.add('jdragndrop', (editor) => {
       },
       onError: (xhr) => {
         editor.windowManager.alert(`Error: ${xhr.statusText}`);
-      }
+      },
     });
+  }
+
+  function readFile(file) {
+    // Create a new file reader instance
+    const reader = new FileReader();
+
+    // Add the on load callback
+    reader.onload = (progressEvent) => {
+      const { result } = progressEvent.target;
+      const splitIndex = result.indexOf('base64') + 7;
+      const content = result.slice(splitIndex, result.length);
+
+      // Upload the file
+      uploadFile(file.name, content);
+    };
+
+    reader.readAsDataURL(file);
   }
 
   // Listers for drag and drop

--- a/build/media_source/plg_editors_tinymce/js/plugins/dragdrop/plugin.es6.js
+++ b/build/media_source/plg_editors_tinymce/js/plugins/dragdrop/plugin.es6.js
@@ -61,7 +61,7 @@ tinymce.PluginManager.add('jdragndrop', (editor) => {
             urlPath = response.data.thumb_path;
           }
 
-          tinyMCE.activeEditor.execCommand('mceInsertContent', false, `<img loading="lazy" src="${urlPath}" />`);
+          tinyMCE.activeEditor.execCommand('mceInsertContent', false, `<img loading="lazy" src="${urlPath}" alt=""/>`);
         }
       },
       onError: (xhr) => {

--- a/build/media_source/plg_editors_tinymce/js/plugins/dragdrop/plugin.es6.js
+++ b/build/media_source/plg_editors_tinymce/js/plugins/dragdrop/plugin.es6.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-undef */
-tinymce.PluginManager.add('jdragdrop', (editor) => {
+tinymce.PluginManager.add('jdragndrop', (editor) => {
   // Reset the drop area border
   tinyMCE.DOM.bind(document, 'dragleave', (e) => {
     e.stopPropagation();
@@ -9,108 +9,98 @@ tinymce.PluginManager.add('jdragdrop', (editor) => {
     return false;
   });
 
-  // The upload logic
-  const UploadFile = (file) => {
-    const fd = new FormData();
-    fd.append('Filedata', file);
-    fd.append('folder', tinyMCE.activeEditor.settings.mediaUploadPath);
+  // Fix for Chrome
+  editor.on('dragenter', (e) => {
+    e.stopPropagation();
 
-    const xhr = new XMLHttpRequest();
+    return false;
+  });
 
-    xhr.upload.onprogress = (e) => {
-      const percentComplete = (e.loaded / e.total) * 100;
-      document.querySelector('.bar').style.width = `${percentComplete}%`;
+
+  // Notify user when file is over the drop area
+  editor.on('dragover', (e) => {
+    e.preventDefault();
+    editor.contentAreaContainer.style.borderStyle = 'dashed';
+    editor.contentAreaContainer.style.borderWidth = '5px';
+
+    return false;
+  });
+
+  function readFile(file) {
+    // Create a new file reader instance
+    let reader = new FileReader();
+
+    // Add the on load callback
+    reader.onload = (progressEvent) => {
+      const result = progressEvent.target.result,
+        splitIndex = result.indexOf('base64') + 7,
+        content = result.slice(splitIndex, result.length);
+
+      // Upload the file
+      uploadFile(file.name, content)
     };
 
-    const removeProgessBar = () => {
-      // @todo Promisify
-      setTimeout(() => {
-        const loader = document.querySelector('#jloader');
-        loader.parentNode.removeChild(loader);
-        editor.contentAreaContainer.style.borderWidth = '1px 0 0 0';
-      }, 200);
+    reader.readAsDataURL(file);
+  }
+
+  function uploadFile(name, content) {
+    const url = `${tinyMCE.activeEditor.settings.uploadUri}&path=${tinyMCE.activeEditor.settings.comMediaAdapter}`;
+    const data = {
+      [tinyMCE.activeEditor.settings.csrfToken]: '1',
+      name: name,
+      content: content,
+      parent: tinyMCE.activeEditor.settings.parentUploadFolder,
     };
 
-    xhr.onload = () => {
-      const resp = JSON.parse(xhr.responseText);
+    Joomla.request({
+      url: url,
+      method: 'POST',
+      data: JSON.stringify(data),
+      headers: {'Content-Type': 'application/json'},
+      onSuccess: (resp) => {
+        let response;
 
-      if (xhr.status === 200) {
-        if (resp.status === '0') {
-          removeProgessBar();
-
-          editor.windowManager.alert(`${resp.message}: ${tinyMCE.activeEditor.settings.setCustomDir}${resp.location}`);
+        try{
+          response = JSON.parse(resp);
+        } catch (e) {
+          editor.windowManager.alert(`${Joomla.Text._('JERROR')}: {e}`);
         }
 
-        if (resp.status === '1') {
-          removeProgessBar();
+        if (response.data && response.data.path) {
+          let urlPath;
+          // For local adapters use relative paths
+          if (/local-/.test(response.data.adapter)) {
+            const {rootFull} = Joomla.getOptions('system.paths');
 
-          // Create the image tag
-          const newNode = tinyMCE.activeEditor.getDoc().createElement('img');
-          newNode.src = tinyMCE.activeEditor.settings.setCustomDir + resp.location;
-          tinyMCE.activeEditor.execCommand('mceInsertContent', false, newNode.outerHTML);
+            urlPath = `/${response.data.thumb_path.split(rootFull)[1]}`;
+          } else if (response.data.thumb_path) {
+            // Absolute path for different domain
+            urlPath = response.data.thumb_path;
+          }
+
+          tinyMCE.activeEditor.execCommand('mceInsertContent', false, `<img loading="lazy" src="${urlPath}" />`);
         }
-      } else {
-        removeProgessBar();
+      },
+      onError: (xhr) => {
+        editor.windowManager.alert(`Error: ${xhr.statusText}`);
       }
-    };
-
-    xhr.onerror = () => {
-      removeProgessBar();
-    };
-
-    xhr.open('POST', tinyMCE.activeEditor.settings.uploadUri, true);
-    xhr.send(fd);
-  };
+    });
+  }
 
   // Listers for drag and drop
   if (typeof FormData !== 'undefined') {
-    // Fix for Chrome
-    editor.on('dragenter', (e) => {
-      e.stopPropagation();
-
-      return false;
-    });
-
-
-    // Notify user when file is over the drop area
-    editor.on('dragover', (e) => {
-      e.preventDefault();
-      editor.contentAreaContainer.style.borderStyle = 'dashed';
-      editor.contentAreaContainer.style.borderWidth = '5px';
-
-      return false;
-    });
-
     // Logic for the dropped file
     editor.on('drop', (e) => {
+      e.preventDefault();
       // We override only for files
       if (e.dataTransfer && e.dataTransfer.files && e.dataTransfer.files.length > 0) {
         const files = [].slice.call(e.dataTransfer.files);
         files.forEach((file) => {
           // Only images allowed
           if (file.name.toLowerCase().match(/\.(jpg|jpeg|png|gif)$/)) {
-            // Create and display the progress bar
-            const container = document.createElement('div');
-            container.id = 'jloader';
-            const innerDiv = document.createElement('div');
-            innerDiv.classList.add('progress');
-            innerDiv.classList.add('progress-success');
-            innerDiv.classList.add('progress-striped');
-            innerDiv.classList.add('active');
-            innerDiv.style.width = '100%';
-            innerDiv.style.height = '30px';
-            const progressBar = document.createElement('div');
-            progressBar.classList.add('bar');
-            progressBar.style.width = '0';
-            innerDiv.appendChild(progressBar);
-            container.appendChild(innerDiv);
-            document.querySelector('.mce-toolbar-grp').appendChild(container);
-
             // Upload the file(s)
-            UploadFile(file);
+            readFile(file);
           }
-
-          e.preventDefault();
         });
       }
       editor.contentAreaContainer.style.borderWidth = '1px 0 0';

--- a/build/media_source/plg_editors_tinymce/js/plugins/dragdrop/plugin.es6.js
+++ b/build/media_source/plg_editors_tinymce/js/plugins/dragdrop/plugin.es6.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-undef */
-tinymce.PluginManager.add('jdragndrop', function (editor) {
+tinymce.PluginManager.add('jdragndrop', (editor) => {
   // Reset the drop area border
   tinyMCE.DOM.bind(document, 'dragleave', (e) => {
     e.stopPropagation();

--- a/build/media_source/plg_editors_tinymce/js/plugins/dragdrop/plugin.es6.js
+++ b/build/media_source/plg_editors_tinymce/js/plugins/dragdrop/plugin.es6.js
@@ -55,7 +55,7 @@ tinymce.PluginManager.add('jdragndrop', (editor) => {
           if (/local-/.test(response.data.adapter)) {
             const { rootFull } = Joomla.getOptions('system.paths');
 
-            urlPath = `/${response.data.thumb_path.split(rootFull)[1]}`;
+            urlPath = `${response.data.url.split(rootFull)[1]}`;
           } else if (response.data.thumb_path) {
             // Absolute path for different domain
             urlPath = response.data.thumb_path;

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -507,7 +507,7 @@ class PlgEditorTinymce extends CMSPlugin
 
 		if ($dragdrop && $user->authorise('core.create', 'com_media'))
 		{
-			$externalPlugins['jdragndrop'] = substr(HTMLHelper::_('script', 'plg_editors_tinymce/plugins/dragdrop/plugin.min.js', ['relative' => true, 'version' => 'auto', 'pathOnly' => true]);
+			$externalPlugins['jdragndrop'] = HTMLHelper::_('script', 'plg_editors_tinymce/plugins/dragdrop/plugin.min.js', ['relative' => true, 'version' => 'auto', 'pathOnly' => true]);
 			$uploadUrl                     = Uri::base(false) . 'index.php?option=com_media&format=json&task=api.files';
 
 			if ($this->app->isClient('site'))

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -507,7 +507,7 @@ class PlgEditorTinymce extends CMSPlugin
 
 		if ($dragdrop && $user->authorise('core.create', 'com_media'))
 		{
-			$externalPlugins['jdragndrop'] = Uri::root(false) . 'media/plg_editors_tinymce/js/plugins/dragdrop/plugin.js';
+			$externalPlugins['jdragndrop'] = Uri::root(false) . 'media/plg_editors_tinymce/js/plugins/dragdrop/plugin.min.js';
 			$uploadUrl                     = Uri::base(false) . 'index.php?option=com_media&format=json&task=api.files';
 
 			if ($this->app->isClient('site'))

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -507,7 +507,7 @@ class PlgEditorTinymce extends CMSPlugin
 
 		if ($dragdrop && $user->authorise('core.create', 'com_media'))
 		{
-			$externalPlugins['jdragndrop'] = Uri::root(false) . 'media/plg_editors_tinymce/js/plugins/dragdrop/plugin.min.js';
+			$externalPlugins['jdragndrop'] = substr(JUri::root(false), 0, -1) . HTMLHelper::_('script', 'plg_editors_tinymce/plugins/dragdrop/plugin.min.js', ['relative' => true, , 'version' => 'auto']);
 			$uploadUrl                     = Uri::base(false) . 'index.php?option=com_media&format=json&task=api.files';
 
 			if ($this->app->isClient('site'))

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -501,38 +501,29 @@ class PlgEditorTinymce extends CMSPlugin
 			}
 		}
 
-		// Drag and drop Images
+		// Drag and drop Images always FALSE, reverting this allows for inlining the images
 		$allowImgPaste = false;
 		$dragdrop      = $levelParams->get('drag_drop', 1);
 
 		if ($dragdrop && $user->authorise('core.create', 'com_media'))
 		{
-			$externalPlugins['jdragndrop'] = Uri::root() . 'media/plg_editors_tinymce/js/plugins/dragdrop/plugin.min.js';
-
-			$allowImgPaste = true;
-			$isSubDir      = '';
-			$session       = $this->app->getSession();
-			$uploadUrl     = Uri::base() . 'index.php?option=com_media&task=file.upload&tmpl=component&'
-				. $session->getName() . '=' . $session->getId()
-				. '&' . Session::getFormToken() . '=1'
-				. '&asset=image&format=json';
+			$externalPlugins['jdragndrop'] = Uri::root(false) . 'media/plg_editors_tinymce/js/plugins/dragdrop/plugin.js';
+			$uploadUrl                     = Uri::base(false) . 'index.php?option=com_media&format=json&task=api.files';
 
 			if ($this->app->isClient('site'))
 			{
 				$uploadUrl = htmlentities($uploadUrl, null, 'UTF-8', null);
 			}
 
-			// Is Joomla installed in subdirectory
-			if (Uri::root(true) !== '/')
-			{
-				$isSubDir = Uri::root(true);
-			}
-
 			Text::script('PLG_TINY_ERR_UNSUPPORTEDBROWSER');
+			Text::script('JERROR');
 
-			$scriptOptions['setCustomDir']    = $isSubDir;
-			$scriptOptions['mediaUploadPath'] = $levelParams->get('path', '');
-			$scriptOptions['uploadUri']       = $uploadUrl;
+			$scriptOptions['parentUploadFolder'] = '';
+			$scriptOptions['csrfToken']          = Session::getFormToken();
+			$scriptOptions['uploadUri']          = $uploadUrl;
+
+			// @TODO have a way to select the adapter, used to be $levelParams->get('path', '');
+			$scriptOptions['comMediaAdapter']    = 'local:0';
 		}
 
 		// Convert pt to px in dropdown

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -507,7 +507,7 @@ class PlgEditorTinymce extends CMSPlugin
 
 		if ($dragdrop && $user->authorise('core.create', 'com_media'))
 		{
-			$externalPlugins['jdragndrop'] = substr(JUri::root(false), 0, -1) . HTMLHelper::_('script', 'plg_editors_tinymce/plugins/dragdrop/plugin.min.js', ['relative' => true, , 'version' => 'auto']);
+			$externalPlugins['jdragndrop'] = substr(JUri::root(false), 0, -1) . HTMLHelper::_('script', 'plg_editors_tinymce/plugins/dragdrop/plugin.min.js', ['relative' => true, 'version' => 'auto', 'pathOnly' => true]);
 			$uploadUrl                     = Uri::base(false) . 'index.php?option=com_media&format=json&task=api.files';
 
 			if ($this->app->isClient('site'))

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -14,6 +14,7 @@ use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Filesystem\Folder;
 use Joomla\CMS\Filter\InputFilter;
+use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Log\Log;

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -518,11 +518,11 @@ class PlgEditorTinymce extends CMSPlugin
 			Text::script('PLG_TINY_ERR_UNSUPPORTEDBROWSER');
 			Text::script('JERROR');
 
-			$scriptOptions['parentUploadFolder'] = '/';
+			$scriptOptions['parentUploadFolder'] = $levelParams->get('path', '');
 			$scriptOptions['csrfToken']          = Session::getFormToken();
 			$scriptOptions['uploadUri']          = $uploadUrl;
 
-			// @TODO have a way to select the adapter, used to be $levelParams->get('path', '');
+			// @TODO have a way to select the adapter, similar to $levelParams->get('path', '');
 			$scriptOptions['comMediaAdapter']    = 'local-0:';
 		}
 

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -518,12 +518,12 @@ class PlgEditorTinymce extends CMSPlugin
 			Text::script('PLG_TINY_ERR_UNSUPPORTEDBROWSER');
 			Text::script('JERROR');
 
-			$scriptOptions['parentUploadFolder'] = '';
+			$scriptOptions['parentUploadFolder'] = '/';
 			$scriptOptions['csrfToken']          = Session::getFormToken();
 			$scriptOptions['uploadUri']          = $uploadUrl;
 
 			// @TODO have a way to select the adapter, used to be $levelParams->get('path', '');
-			$scriptOptions['comMediaAdapter']    = 'local:0';
+			$scriptOptions['comMediaAdapter']    = 'local-0:';
 		}
 
 		// Convert pt to px in dropdown

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -507,7 +507,7 @@ class PlgEditorTinymce extends CMSPlugin
 
 		if ($dragdrop && $user->authorise('core.create', 'com_media'))
 		{
-			$externalPlugins['jdragndrop'] = substr(JUri::root(false), 0, -1) . HTMLHelper::_('script', 'plg_editors_tinymce/plugins/dragdrop/plugin.min.js', ['relative' => true, 'version' => 'auto', 'pathOnly' => true]);
+			$externalPlugins['jdragndrop'] = substr(HTMLHelper::_('script', 'plg_editors_tinymce/plugins/dragdrop/plugin.min.js', ['relative' => true, 'version' => 'auto', 'pathOnly' => true]);
 			$uploadUrl                     = Uri::base(false) . 'index.php?option=com_media&format=json&task=api.files';
 
 			if ($this->app->isClient('site'))


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/27477 .

### Summary of Changes

Restores Drag and Drop images functionality for tinyMCE

#### Some remarks:
- This solves the Release Blocker issue
- There is a hardcoded part (there is a todo in the code) which is the same issue as https://github.com/joomla/joomla-cms/issues/26750, which is also a Release Blocker
- There is no more a progress indicator, this is due to the lack of information to implement such functionality
- This PR is also adding the `lading=lazy` attribute

### Testing Instructions
Apply the patch run `npm ci` and try to drag an image into tinyMCE's edit area

### Expected result



### Actual result



### Documentation Changes Required
No, it's a bug fix.
