### PR TITLE
[4.0] Add loading=lazy for the custom field imagelist

### DIFF
--- a/plugins/fields/imagelist/tmpl/imagelist.php
+++ b/plugins/fields/imagelist/tmpl/imagelist.php
@@ -33,7 +33,7 @@ foreach ($value as $path)
 
 	if ($fieldParams->get('directory', '/') !== '/')
 	{
-		$buffer .= sprintf('<img src="images/%s/%s"%s>',
+		$buffer .= sprintf('<img loading="lazy" src="images/%s/%s"%s>',
 			$fieldParams->get('directory'),
 			htmlentities($path, ENT_COMPAT, 'UTF-8', true),
 			$class
@@ -41,7 +41,7 @@ foreach ($value as $path)
 	}
 	else
 	{
-		$buffer .= sprintf('<img src="images/%s"%s>',
+		$buffer .= sprintf('<img loading="lazy" src="images/%s"%s>',
 			htmlentities($path, ENT_COMPAT, 'UTF-8', true),
 			$class
 		);


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Add loading=lazy for the custom field imagelist


### Testing Instructions
Enable Custom fields
Create a custom field of type imagelist

Create an article in a category with this custom field available

Add some images


Observe in the front end


### Expected result



### Actual result



### Documentation Changes Required
This is a system wide change, meaning that the documentation will reflect all these changes (eg nothing special for this instance)

@wilsonge @laoneo 