### PR TITLE
[4.0] Add loading=lazy for the custom field media images

### DIFF
--- a/plugins/fields/media/tmpl/media.php
+++ b/plugins/fields/media/tmpl/media.php
@@ -30,7 +30,7 @@ foreach ($value as $path)
 		continue;
 	}
 
-	$buffer .= sprintf('<img src="%s"%s>',
+	$buffer .= sprintf('<img loading="lazy" src="%s"%s>',
 		htmlentities($path, ENT_COMPAT, 'UTF-8', true),
 		$class
 	);


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Add loading=lazy for the custom field media

### Testing Instructions

Enable Custom fields
Create a custom field of type media

Create an article in a category with this custom field available

Add an image (in the custom field)

Observe in the front end

### Expected result



### Actual result



### Documentation Changes Required

This is a system wide change, meaning that the documentation will reflect all these changes (eg nothing special for this instance)

@wilsonge @laoneo 