### PR TITLE
[4.0] Fix validation in menu field

### DIFF
--- a/administrator/components/com_associations/src/Field/Modal/AssociationField.php
+++ b/administrator/components/com_associations/src/Field/Modal/AssociationField.php
@@ -43,7 +43,7 @@ class AssociationField extends FormField
 	{
 		// @TODO USE JLayouts here!!!
 		// The active item id field.
-		$value = (int) $this->value > 0 ? (int) $this->value : '';
+		$value = (int) $this->value ?: '';
 
 		Factory::getDocument()->addScriptOptions('admin_associations_modal', ['itemId' => $value]);
 		HTMLHelper::_('script', 'com_associations/admin_associations_modal.min.js', ['version' => 'auto', 'relative' => true]);

--- a/administrator/components/com_categories/src/Field/Modal/CategoryField.php
+++ b/administrator/components/com_categories/src/Field/Modal/CategoryField.php
@@ -64,7 +64,7 @@ class CategoryField extends FormField
 		Factory::getLanguage()->load('com_categories', JPATH_ADMINISTRATOR);
 
 		// The active category id field.
-		$value = (int) $this->value > 0 ? (int) $this->value : '';
+		$value = (int) $this->value ?: '';
 
 		// Create the modal id.
 		$modalId = 'Category_' . $this->id;

--- a/administrator/components/com_contact/src/Field/Modal/ContactField.php
+++ b/administrator/components/com_contact/src/Field/Modal/ContactField.php
@@ -55,7 +55,7 @@ class ContactField extends FormField
 		Factory::getLanguage()->load('com_contact', JPATH_ADMINISTRATOR);
 
 		// The active contact id field.
-		$value = (int) $this->value > 0 ? (int) $this->value : '';
+		$value = (int) $this->value ?: '';
 
 		// Create the modal id.
 		$modalId = 'Contact_' . $this->id;

--- a/administrator/components/com_content/src/Field/Modal/ArticleField.php
+++ b/administrator/components/com_content/src/Field/Modal/ArticleField.php
@@ -55,7 +55,7 @@ class ArticleField extends FormField
 		Factory::getLanguage()->load('com_content', JPATH_ADMINISTRATOR);
 
 		// The active article id field.
-		$value = ((int) $this->value) ?: '';
+		$value = (int) $this->value ?: '';
 
 		// Create the modal id.
 		$modalId = 'Article_' . $this->id;

--- a/administrator/components/com_menus/src/Field/Modal/MenuField.php
+++ b/administrator/components/com_menus/src/Field/Modal/MenuField.php
@@ -172,7 +172,7 @@ class MenuField extends FormField
 		Factory::getLanguage()->load('com_menus', JPATH_ADMINISTRATOR);
 
 		// The active article id field.
-		$value = (int) $this->value;
+		$value = (int) $this->value ?: '';
 
 		// Create the modal id.
 		$modalId = 'Item_' . $this->id;

--- a/administrator/components/com_newsfeeds/src/Field/Modal/NewsfeedField.php
+++ b/administrator/components/com_newsfeeds/src/Field/Modal/NewsfeedField.php
@@ -55,7 +55,7 @@ class NewsfeedField extends FormField
 		Factory::getLanguage()->load('com_newsfeeds', JPATH_ADMINISTRATOR);
 
 		// The active newsfeed id field.
-		$value = (int) $this->value > 0 ? (int) $this->value : '';
+		$value = (int) $this->value ?: '';
 
 		// Create the modal id.
 		$modalId = 'Newsfeed_' . $this->id;

--- a/layouts/joomla/form/field/user.php
+++ b/layouts/joomla/form/field/user.php
@@ -122,7 +122,7 @@ if (!$readonly)
 	</div>
 	<?php // Create the real field, hidden, that stored the user id. ?>
 	<?php if (!$readonly) : ?>
-		<input type="hidden" id="<?php echo $id; ?>_id" name="<?php echo $name; ?>" value="<?php echo $value; ?>"
+		<input type="hidden" id="<?php echo $id; ?>_id" name="<?php echo $name; ?>" value="<?php echo $this->escape($value); ?>"
 			class="field-user-input <?php echo $class ? (string) $class : ''?>"
 			data-onchange="<?php echo $this->escape($onchange); ?>">
 		<?php echo HTMLHelper::_(


### PR DESCRIPTION
Fixes https://github.com/joomla/joomla-cms/issues/28935.

### Summary of Changes

Fixes menu field validation and simplify related code in other modal fields.

### Testing Instructions


> * Create a new menu item (back-end)
> 
> * Select "Menu Item Type": "Menu Item Alias"
> 
> * DO NOT select a "Menu Item"!!
> 
> * Save.


### Expected result

> * It should not be possible to save the menu item

### Actual result

> * One can save the menu item.

### Documentation Changes Required

No.