### PR TITLE
[4.0] Fix required checkbox client-side validation

### DIFF
--- a/build/media_source/system/js/fields/validate.es6.js
+++ b/build/media_source/system/js/fields/validate.es6.js
@@ -194,7 +194,7 @@
             this.handleResponse(false, element, 'checkbox');
             return false;
           }
-        } else if ((element.getAttribute('type') === 'checkbox' && !element.checked.length !== 0) || (tagName === 'select' && !element.value.length)) {
+        } else if ((element.getAttribute('type') === 'checkbox' && element.checked !== true) || (tagName === 'select' && !element.value.length)) {
           this.handleResponse(false, element, 'checkbox');
           return false;
         } else if (!element.value || element.classList.contains('placeholder')) {


### PR DESCRIPTION
### Summary of Changes

Fixes JS validation for required checkboxes.

### Testing Instructions

Create a form containing required checkbox.

E.g. add `required="true"` to `both` field in `administrator/components/com_languages/forms/override.xml`:

    <field
    	name="both"
    	type="checkbox"
    	label="COM_LANGUAGES_OVERRIDE_FIELD_BOTH_LABEL"
    	value="true"
    	filter="boolean"
    	required="true"
    />
Go to Language Override form. Check the checkbox and click somewhere on the page.

### Expected result

No validation warning shown.

### Actual result

Warning shown:
>One of the options must be selected

### Documentation Changes Required

No.