### PR TITLE
[4.0][a11y]Make module assignment accessible - step 2

### DIFF
--- a/administrator/components/com_modules/tmpl/module/edit_assignment.php
+++ b/administrator/components/com_modules/tmpl/module/edit_assignment.php
@@ -98,7 +98,7 @@ HTMLHelper::_('script', 'com_modules/admin-module-edit_assignment.min.js', array
 										?>
 										<input type="checkbox" class="novalidate" name="jform[assigned][]" id="<?php echo $id . $link->value; ?>" value="<?php echo (int) $link->value; ?>"<?php echo $selected ? ' checked="checked"' : ''; echo $uselessMenuItem ? ' disabled="disabled"' : ''; ?>>
 										<label for="<?php echo $id . $link->value; ?>" class="">
-											<?php echo $link->text; ?> <span class="small"><?php echo Text::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($link->alias)); ?></span>
+											<?php echo $link->text; ?>
 											<?php if (Multilanguage::isEnabled() && $link->language != '' && $link->language != '*') : ?>
 												<?php if ($link->language_image) : ?>
 													<?php echo HTMLHelper::_('image', 'mod_languages/' . $link->language_image . '.gif', $link->language_title, array('title' => $link->language_title), true); ?>


### PR DESCRIPTION
Pull Request for Issue #23911, step 2. 

There are described several a11y issues in the tab menu association of modules. There were already some PRs, as #25128, #28250, which have been closed.

This PR continues this work.

### Summary of Changes
Remove the alias from the Menu tree, such reducing elements on the screen, as mentioned in **no. 4 ** of issue #23911. 


### Testing Instructions

After Patch, the selection looks cleaner, a blind user must not hear the whole information about aliases. 

![no-alias](https://user-images.githubusercontent.com/1035262/81071328-d9717300-8ee4-11ea-8554-553945706a0b.JPG)


### Documentation Changes Required
screen
