### PR TITLE
[4.0] Fix Language Override filtering

### DIFF
--- a/administrator/components/com_languages/src/Helper/LanguagesHelper.php
+++ b/administrator/components/com_languages/src/Helper/LanguagesHelper.php
@@ -47,7 +47,7 @@ class LanguagesHelper
 	 */
 	public static function filterKey($value)
 	{
-		$filter = \JFilterInput::getInstance(null, null, 1, 1);
+		$filter = \JFilterInput::getInstance([], [], 1, 1);
 
 		return strtoupper($filter->clean($value, 'cmd'));
 	}
@@ -64,7 +64,7 @@ class LanguagesHelper
 	 */
 	public static function filterText($value)
 	{
-		$filter = \JFilterInput::getInstance(null, null, 1, 1);
+		$filter = \JFilterInput::getInstance([], [], 1, 1);
 
 		return $filter->clean($value);
 	}

--- a/administrator/components/com_languages/src/Helper/LanguagesHelper.php
+++ b/administrator/components/com_languages/src/Helper/LanguagesHelper.php
@@ -11,8 +11,8 @@ namespace Joomla\Component\Languages\Administrator\Helper;
 
 \defined('_JEXEC') or die;
 
-use Joomla\CMS\Language\LanguageHelper;
 use Joomla\CMS\Filter\InputFilter;
+use Joomla\CMS\Language\LanguageHelper;
 
 /**
  * Languages component helper.

--- a/administrator/components/com_languages/src/Helper/LanguagesHelper.php
+++ b/administrator/components/com_languages/src/Helper/LanguagesHelper.php
@@ -12,6 +12,7 @@ namespace Joomla\Component\Languages\Administrator\Helper;
 \defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\LanguageHelper;
+use Joomla\CMS\Filter\InputFilter;
 
 /**
  * Languages component helper.
@@ -47,7 +48,7 @@ class LanguagesHelper
 	 */
 	public static function filterKey($value)
 	{
-		$filter = \JFilterInput::getInstance([], [], 1, 1);
+		$filter = InputFilter::getInstance([], [], InputFilter::TAGS_BLACKLIST, InputFilter::ATTR_BLACKLIST);
 
 		return strtoupper($filter->clean($value, 'cmd'));
 	}
@@ -64,7 +65,7 @@ class LanguagesHelper
 	 */
 	public static function filterText($value)
 	{
-		$filter = \JFilterInput::getInstance([], [], 1, 1);
+		$filter = InputFilter::getInstance([], [], InputFilter::TAGS_BLACKLIST, InputFilter::ATTR_BLACKLIST);
 
 		return $filter->clean($value);
 	}


### PR DESCRIPTION
Fixes https://github.com/joomla/joomla-cms/issues/28945.

### Summary of Changes

Corrects arguments.

### Testing Instructions

Create a language override containing `<script>` tags.

### Expected result

No errors and `<script>` tag stripped out.

### Actual result

>Argument 1 passed to Joomla\Filter\InputFilter::__construct() must be of the type array, null given, called in libraries\src\Filter\InputFilter.php on line 55 

### Documentation Changes Required

No.