### PR TITLE
[4.0] [com_languages] Remove deprecated method

### DIFF
--- a/administrator/components/com_languages/src/Helper/LanguagesHelper.php
+++ b/administrator/components/com_languages/src/Helper/LanguagesHelper.php
@@ -21,21 +21,6 @@ use Joomla\CMS\Language\LanguageHelper;
 class LanguagesHelper
 {
 	/**
-	 * Method for parsing ini files.
-	 *
-	 * @param   string  $fileName  Path and name of the ini file to parse.
-	 *
-	 * @return  array   Array of strings found in the file, the array indices will be the keys. On failure an empty array will be returned.
-	 *
-	 * @since   2.5
-	 * @deprecated   3.9.0 Use \Joomla\CMS\Language\LanguageHelper::parseIniFile() instead.
-	 */
-	public static function parseFile($fileName)
-	{
-		return LanguageHelper::parseIniFile($fileName);
-	}
-
-	/**
 	 * Filter method for language keys.
 	 * This method will be called by \JForm while filtering the form data.
 	 *

--- a/administrator/components/com_languages/src/Model/StringsModel.php
+++ b/administrator/components/com_languages/src/Model/StringsModel.php
@@ -15,8 +15,8 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Filesystem\Folder;
 use Joomla\CMS\Filesystem\Path;
 use Joomla\CMS\Filter\InputFilter;
+use Joomla\CMS\Language\LanguageHelper;
 use Joomla\CMS\MVC\Model\BaseDatabaseModel;
-use Joomla\Component\Languages\Administrator\Helper\LanguagesHelper;
 use Joomla\Database\ParameterType;
 
 /**
@@ -91,7 +91,7 @@ class StringsModel extends BaseDatabaseModel
 		// Parse all found ini files and add the strings to the database cache.
 		foreach ($files as $file)
 		{
-			$strings = LanguagesHelper::parseFile($file);
+			$strings = LanguageHelper::parseIniFile($file);
 
 			if ($strings)
 			{


### PR DESCRIPTION
### Summary of Changes

Removes deprecated method.

### Testing Instructions

Go to Language Overrides.
Click `Clear Cache`.
Open new override form.
Test that searching for constants/values to override still works.

### Expected result

Works like before.

### Documentation Changes Required

IDK.