### PR TITLE
[3.9] Invalid constant in Featured Contacts menu item

### DIFF
--- a/components/com_contact/views/featured/tmpl/default.xml
+++ b/components/com_contact/views/featured/tmpl/default.xml
@@ -454,7 +454,7 @@
 			<field
 				name="linkb_name"
 				type="text"
-				label="COM_CONTACT_FIELD_LINKB_LABEL"
+				label="COM_CONTACT_FIELD_LINKB_NAME_LABEL"
 				description="COM_CONTACT_FIELD_LINK_NAME_DESC"
 				size="30"
 				useglobal="true"


### PR DESCRIPTION
Log in to your control panel, go to Menus: Items -> New Item, select the type Contacts -> Featured Contacts, pay attention to the Form tab (see screenshot).

**Before Patch / After Patch**

![Screenshot_1](https://user-images.githubusercontent.com/8440661/81118877-57a83680-8f32-11ea-8b86-75c8b86af59f.png)
