### PR TITLE
Allow tinyMCE's dnd plugin to be overridden

### DIFF
--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -585,7 +585,9 @@ class PlgEditorTinymce extends JPlugin
 
 		if ($dragdrop && $user->authorise('core.create', 'com_media'))
 		{
-			$externalPlugins['jdragdrop'] = substr(JUri::root(), 0, -1) . HTMLHelper::_('script', 'editors/tinymce/plugins/dragdrop/plugin.min.js', array('relative' => true));			$allowImgPaste = true;
+			$externalPlugins['jdragdrop'] = substr(JUri::root(false), 0, -1)
+				. HTMLHelper::_('script', 'editors/tinymce/plugins/dragdrop/plugin.min.js', array('relative' => true, , 'version' => 'auto'));			
+			$allowImgPaste = true;
 			$isSubDir      = '';
 			$session       = JFactory::getSession();
 			$uploadUrl     = JUri::base() . 'index.php?option=com_media&task=file.upload&tmpl=component&'
@@ -1894,7 +1896,9 @@ class PlgEditorTinymce extends JPlugin
 			$scriptOptions['uploadUri']       = $uploadUrl;
 
 			$externalPlugins = array(
-				array('jdragdrop' => substr(JUri::root(), 0, -1) . HTMLHelper::_('script', 'editors/tinymce/plugins/dragdrop/plugin.min.js', array('relative' => true))),
+				array(
+					'jdragdrop' => substr(JUri::root(false), 0, -1)
+					. HTMLHelper::_('script', 'editors/tinymce/plugins/dragdrop/plugin.min.js', array('relative' => true))),
 			);
 		}
 

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\HTML\HTMLHelper;
+
 /**
  * TinyMCE Editor Plugin
  *
@@ -583,8 +585,7 @@ class PlgEditorTinymce extends JPlugin
 
 		if ($dragdrop && $user->authorise('core.create', 'com_media'))
 		{
-			$externalPlugins['jdragdrop'] = JUri::root() . 'media/editors/tinymce/js/plugins/dragdrop/plugin.min.js';
-			$allowImgPaste = true;
+			$externalPlugins['jdragdrop'] = substr(JUri::root(), 0, -1) . HTMLHelper::_('script', 'editors/tinymce/plugins/dragdrop/plugin.min.js', array('relative' => true));			$allowImgPaste = true;
 			$isSubDir      = '';
 			$session       = JFactory::getSession();
 			$uploadUrl     = JUri::base() . 'index.php?option=com_media&task=file.upload&tmpl=component&'
@@ -1893,7 +1894,7 @@ class PlgEditorTinymce extends JPlugin
 			$scriptOptions['uploadUri']       = $uploadUrl;
 
 			$externalPlugins = array(
-				array('jdragdrop' => JUri::root() . 'media/editors/tinymce/js/plugins/dragdrop/plugin.min.js'),
+				array('jdragdrop' => substr(JUri::root(), 0, -1) . HTMLHelper::_('script', 'editors/tinymce/plugins/dragdrop/plugin.min.js', array('relative' => true))),
 			);
 		}
 

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -585,8 +585,7 @@ class PlgEditorTinymce extends JPlugin
 
 		if ($dragdrop && $user->authorise('core.create', 'com_media'))
 		{
-			$externalPlugins['jdragdrop'] = substr(JUri::root(false), 0, -1)
-				. HTMLHelper::_(
+			$externalPlugins['jdragdrop'] = HTMLHelper::_(
 					'script',
 					'editors/tinymce/plugins/dragdrop/plugin.min.js',
 					array('relative' => true, 'version' => 'auto', 'pathOnly' => true)
@@ -1901,8 +1900,7 @@ class PlgEditorTinymce extends JPlugin
 
 			$externalPlugins = array(
 				array(
-					'jdragdrop' => substr(JUri::root(false), 0, -1)
-					. HTMLHelper::_('script', 'editors/tinymce/plugins/dragdrop/plugin.min.js', array('relative' => true, 'version' => 'auto', 'pathOnly' => true))),
+					'jdragdrop' => substr(HTMLHelper::_('script', 'editors/tinymce/plugins/dragdrop/plugin.min.js', array('relative' => true, 'version' => 'auto', 'pathOnly' => true))),
 			);
 		}
 

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -586,7 +586,7 @@ class PlgEditorTinymce extends JPlugin
 		if ($dragdrop && $user->authorise('core.create', 'com_media'))
 		{
 			$externalPlugins['jdragdrop'] = substr(JUri::root(false), 0, -1)
-				. HTMLHelper::_('script', 'editors/tinymce/plugins/dragdrop/plugin.min.js', array('relative' => true, , 'version' => 'auto'));			
+				. HTMLHelper::_('script', 'editors/tinymce/plugins/dragdrop/plugin.min.js', array('relative' => true, 'version' => 'auto', 'pathOnly' => true));			
 			$allowImgPaste = true;
 			$isSubDir      = '';
 			$session       = JFactory::getSession();
@@ -1898,7 +1898,7 @@ class PlgEditorTinymce extends JPlugin
 			$externalPlugins = array(
 				array(
 					'jdragdrop' => substr(JUri::root(false), 0, -1)
-					. HTMLHelper::_('script', 'editors/tinymce/plugins/dragdrop/plugin.min.js', array('relative' => true))),
+					. HTMLHelper::_('script', 'editors/tinymce/plugins/dragdrop/plugin.min.js', array('relative' => true, 'version' => 'auto', 'pathOnly' => true))),
 			);
 		}
 

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -1900,7 +1900,12 @@ class PlgEditorTinymce extends JPlugin
 
 			$externalPlugins = array(
 				array(
-					'jdragdrop' => substr(HTMLHelper::_('script', 'editors/tinymce/plugins/dragdrop/plugin.min.js', array('relative' => true, 'version' => 'auto', 'pathOnly' => true))),
+					'jdragdrop' => HTMLHelper::_(
+						'script',
+						'editors/tinymce/plugins/dragdrop/plugin.min.js',
+						array('relative' => true, 'version' => 'auto', 'pathOnly' => true)
+					),
+				),
 			);
 		}
 

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -589,7 +589,7 @@ class PlgEditorTinymce extends JPlugin
 					'script',
 					'editors/tinymce/plugins/dragdrop/plugin.min.js',
 					array('relative' => true, 'version' => 'auto', 'pathOnly' => true)
-				);			
+				);
 			$allowImgPaste = true;
 			$isSubDir      = '';
 			$session       = JFactory::getSession();

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -586,7 +586,11 @@ class PlgEditorTinymce extends JPlugin
 		if ($dragdrop && $user->authorise('core.create', 'com_media'))
 		{
 			$externalPlugins['jdragdrop'] = substr(JUri::root(false), 0, -1)
-				. HTMLHelper::_('script', 'editors/tinymce/plugins/dragdrop/plugin.min.js', array('relative' => true, 'version' => 'auto', 'pathOnly' => true));			
+				. HTMLHelper::_(
+					'script',
+					'editors/tinymce/plugins/dragdrop/plugin.min.js',
+					array('relative' => true, 'version' => 'auto', 'pathOnly' => true)
+				);			
 			$allowImgPaste = true;
 			$isSubDir      = '';
 			$session       = JFactory::getSession();


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
The drag and drop plugin has a hardcoded path. This PR is forcing it to use the CMS' own override policy by utilising HTMLHelper. Plain English: you can override it by placing an override file in your template's js folder (following the established convention) 


### Testing Instructions
Apply the patch and creat/edit an article. Drag and drop an image to verify that the functionality is still there


### Expected result
Allow to override the plugin using the CMS' established convention


### Actual result
Plugin cannot be overridden


### Documentation Changes Required

This is not a new feature, we just properly call the plugin.