### PR TITLE
Missing client check when uninstalling template

### DIFF
--- a/libraries/src/Installer/Adapter/TemplateAdapter.php
+++ b/libraries/src/Installer/Adapter/TemplateAdapter.php
@@ -461,7 +461,8 @@ class TemplateAdapter extends InstallerAdapter
 			->select('COUNT(*)')
 			->from($db->qn('#__template_styles'))
 			->where($db->qn('home') . ' = ' . $db->q('1'))
-			->where($db->qn('template') . ' = ' . $db->q($name));
+			->where($db->qn('template') . ' = ' . $db->q($name))
+			->where($db->quoteName('client_id') . ' = ' . $clientId);
 		$db->setQuery($query);
 
 		if ($db->loadResult() != 0)


### PR DESCRIPTION
### Summary of Changes

Adds client check for default template check when uninstalling a template.

### Testing Instructions

Install a template with the same name as another template installed for another client. E.g. use this Isis frontend template: [isis.zip](https://github.com/joomla/joomla-cms/files/4587042/isis.zip).
Try to uninstall it

### Expected result

Template uninstalled.

### Actual result

Uninstalling fails with message:
>Template Uninstall: Can't remove default template.

### Documentation Changes Required

No.