### PR TITLE
Update Category.php

### DIFF
--- a/libraries/src/Table/Category.php
+++ b/libraries/src/Table/Category.php
@@ -238,7 +238,7 @@ class Category extends Nested
 		// Verify that the alias is unique
 		$table = Table::getInstance('Category', 'JTable', array('dbo' => $this->getDbo()));
 
-		if ($table->load(array('alias' => $this->alias, 'parent_id' => (int) $this->parent_id, 'extension' => $this->extension))
+		if ($table->load(array('alias' => $this->alias, 'parent_id' => (int) $this->parent_id, 'extension' => $this->extension, 'language' => $this->language))
 			&& ($table->id != $this->id || $this->id == 0))
 		{
 			$this->setError(\JText::_('JLIB_DATABASE_ERROR_CATEGORY_UNIQUE_ALIAS'));


### PR DESCRIPTION
### Summary of Changes
Allow same category alias in the same parent category and extension when there is a different language selected.


### Testing Instructions
- Install additional language (eg pl-PL)
- Got to `Content -> Categories`
- Create a category with the name `Test`, select the language to `en-GB`
- Try to create another category with the name `Test` and alias set to `test` but with a different language (eg `pl-PL`) and set the parent to same parent as the category above.


### Expected result
- Ability to have the same alias for categories in a different language but same root category


### Actual result
- Save fails



### Documentation Changes Required
None
