### PR TITLE
[4.0] Template Atum - Remove static text

### DIFF
--- a/administrator/templates/atum/index.php
+++ b/administrator/templates/atum/index.php
@@ -117,7 +117,7 @@ HTMLHelper::_('atum.rootcolors', $this->params);
 <div id="wrapper" class="d-flex wrapper<?php echo $hiddenMenu ? '0' : ''; ?>">
 	<?php // Sidebar ?>
 	<?php if (!$hiddenMenu) : ?>
-		<button class="navbar-toggler toggler-burger collapsed" type="button" data-toggle="collapse" data-target="#sidebar-wrapper" aria-controls="sidebar-wrapper" aria-expanded="false" aria-label="Toggle navigation">
+		<button class="navbar-toggler toggler-burger collapsed" type="button" data-toggle="collapse" data-target="#sidebar-wrapper" aria-controls="sidebar-wrapper" aria-expanded="false" aria-label="<?php echo Text::_('JTOGGLE_SIDEBAR_MENU'); ?>">
 			<span class="navbar-toggler-icon"></span>
 		</button>
 


### PR DESCRIPTION
Change for issue #28970


### Summary of Changes
Add JText instead of static text


### Testing Instructions
Apply the patch
Check if the Aria Label of Navbar Toggler is still correct 

<img width="487" alt="grafik" src="https://user-images.githubusercontent.com/828371/81209693-2763a500-8fd1-11ea-9f48-81f73125f234.png">


