### PR TITLE
[4.0] Template Atum - Remove content padding

### DIFF
--- a/administrator/templates/atum/scss/blocks/_global.scss
+++ b/administrator/templates/atum/scss/blocks/_global.scss
@@ -125,7 +125,6 @@ body .container-main {
 
 
 .content {
-  padding: 2vw;
   border-radius: $border-radius;
 
   > .row {

--- a/administrator/templates/atum/scss/pages/_com_cpanel.scss
+++ b/administrator/templates/atum/scss/pages/_com_cpanel.scss
@@ -72,7 +72,7 @@
 .com_cpanel {
 
   .content {
-    margin-top: 0;
+    margin-top: 1rem;
   }
 
   .card {


### PR DESCRIPTION
### Summary of Changes
this PR removes additional padding in content which lets some elements appear misaligned...

### Testing Instructions
Apply the patch
npm run build:css
See if I broke something else :-)


### Expected result
![grafik](https://user-images.githubusercontent.com/828371/81221340-fdb37980-8fe2-11ea-8a80-dd5ccf6a9232.png)




### Actual result
![grafik](https://user-images.githubusercontent.com/828371/81221461-276ca080-8fe3-11ea-8ca9-f31e42d7cfcf.png)


cc @HLeithner who reported the issue to me

