### PR TITLE
[4.0] Fix loader not showing on web installer

### DIFF
--- a/administrator/components/com_installer/tmpl/install/default.php
+++ b/administrator/components/com_installer/tmpl/install/default.php
@@ -23,6 +23,9 @@ Text::script('COM_INSTALLER_MSG_INSTALL_ENTER_A_URL');
 HTMLHelper::_('stylesheet', 'com_installer/installer.css', ['version' => 'auto', 'relative' => true]);
 HTMLHelper::_('script', 'com_installer/installer.js', ['version' => 'auto', 'relative' => true]);
 
+$this->document->getWebAssetManager()
+	->useScript('webcomponent.core-loader');
+
 $app = Factory::getApplication();
 ?>
 


### PR DESCRIPTION
### Summary of Changes

The `<joomla-core-load>` is being appended to the DOM when loading the "Install from Web" contents, however the loader was not visible because the assets weren't being included.

### Testing Instructions

1. Go to `administrator/index.php?option=com_installer`
2. Click on the "Install from Web" tab

### Expected result

![screeny](https://user-images.githubusercontent.com/2019801/81266804-4bf56680-903d-11ea-9fdb-d7087363169d.png)
