### PR TITLE
[4.0] Multilingual: modifying lang badges to fit languages with different country codes

### DIFF
--- a/administrator/components/com_associations/src/Helper/AssociationsHelper.php
+++ b/administrator/components/com_associations/src/Helper/AssociationsHelper.php
@@ -331,7 +331,7 @@ class AssociationsHelper extends ContentHelper
 
 			$url     = Route::_('index.php?' . http_build_query($options));
 			$url     = $allow && $addLink ? $url : '';
-			$text    = strtoupper($language->sef);
+			$text    = $language->lang_code;
 
 			$tooltip = '<strong>' . htmlspecialchars($language->title, ENT_QUOTES, 'UTF-8') . '</strong><br>'
 				. htmlspecialchars($title, ENT_QUOTES, 'UTF-8') . '<br><br>' . $additional;

--- a/administrator/components/com_categories/src/Service/HTML/AdministratorService.php
+++ b/administrator/components/com_categories/src/Service/HTML/AdministratorService.php
@@ -90,7 +90,7 @@ class AdministratorService
 				{
 					if (in_array($item->lang_code, $content_languages))
 					{
-						$text     = $item->lang_sef ? strtoupper($item->lang_sef) : 'XX';
+						$text     = $item->lang_code;
 						$url      = Route::_('index.php?option=com_categories&task=category.edit&id=' . (int) $item->id . '&extension=' . $extension);
 						$tooltip  = '<strong>' . htmlspecialchars($item->language_title, ENT_QUOTES, 'UTF-8') . '</strong><br>'
 							. htmlspecialchars($item->title, ENT_QUOTES, 'UTF-8');

--- a/administrator/components/com_contact/src/Service/HTML/AdministratorService.php
+++ b/administrator/components/com_contact/src/Service/HTML/AdministratorService.php
@@ -89,7 +89,7 @@ class AdministratorService
 				{
 					if (in_array($item->lang_code, $content_languages))
 					{
-						$text = strtoupper($item->lang_sef);
+						$text = $item->lang_code;
 						$url = Route::_('index.php?option=com_contact&task=contact.edit&id=' . (int) $item->id);
 						$tooltip = '<strong>' . htmlspecialchars($item->language_title, ENT_QUOTES, 'UTF-8') . '</strong><br>'
 							. htmlspecialchars($item->title, ENT_QUOTES, 'UTF-8') . '<br>' . Text::sprintf('JCATEGORY_SPRINTF', $item->category_title);

--- a/administrator/components/com_content/src/Service/HTML/AdministratorService.php
+++ b/administrator/components/com_content/src/Service/HTML/AdministratorService.php
@@ -89,7 +89,7 @@ class AdministratorService
 				{
 					if (in_array($item->lang_code, $content_languages))
 					{
-						$text    = $item->lang_sef ? strtoupper($item->lang_sef) : 'XX';
+						$text    = $item->lang_code;
 						$url     = Route::_('index.php?option=com_content&task=article.edit&id=' . (int) $item->id);
 						$tooltip = '<strong>' . htmlspecialchars($item->language_title, ENT_QUOTES, 'UTF-8') . '</strong><br>'
 							. htmlspecialchars($item->title, ENT_QUOTES, 'UTF-8') . '<br>' . Text::sprintf('JCATEGORY_SPRINTF', $item->category_title);

--- a/administrator/components/com_mails/tmpl/templates/default.php
+++ b/administrator/components/com_mails/tmpl/templates/default.php
@@ -86,7 +86,7 @@ $listDirn = $this->escape($this->state->get('list.direction'));
 											<?php if ($language->image) : ?>
 												<?php echo HTMLHelper::_('image', 'mod_languages/' . $language->image . '.gif', $language->title_native, array('title' => $language->title_native), true); ?>
 											<?php else : ?>
-												<span class="badge badge-secondary" title="<?php echo $language->title_native; ?>"><?php echo strtoupper($language->sef); ?></span>
+												<span class="badge badge-secondary" title="<?php echo $language->title_native; ?>"><?php echo $language->lang_code; ?></span>
 											<?php endif; ?>
 										<?php endif; ?>
 									<?php endforeach; ?>
@@ -97,7 +97,7 @@ $listDirn = $this->escape($this->state->get('list.direction'));
 											<?php if ($language->image) : ?>
 												<?php echo HTMLHelper::_('image', 'mod_languages/' . $language->image . '.gif', $language->title_native, array('title' => $language->title_native), true); ?>
 											<?php else : ?>
-												<span class="badge badge-secondary"><?php echo strtoupper($language->sef); ?></span>
+												<span class="badge badge-secondary"><?php echo $language->lang_code; ?></span>
 											<?php endif; ?>
 										<?php endif; ?>
 									<?php endforeach; ?>

--- a/administrator/components/com_menus/src/Service/HTML/Menus.php
+++ b/administrator/components/com_menus/src/Service/HTML/Menus.php
@@ -89,7 +89,7 @@ class Menus
 				{
 					if (in_array($item->lang_code, $content_languages))
 					{
-						$text    = strtoupper($item->lang_sef);
+						$text    = $item->lang_code;
 						$url     = Route::_('index.php?option=com_menus&task=item.edit&id=' . (int) $item->id);
 						$tooltip = '<strong>' . htmlspecialchars($item->language_title, ENT_QUOTES, 'UTF-8') . '</strong><br>'
 							. htmlspecialchars($item->title, ENT_QUOTES, 'UTF-8') . '<br>' . Text::sprintf('COM_MENUS_MENU_SPRINTF', $item->menu_title);

--- a/administrator/components/com_menus/tmpl/items/default.php
+++ b/administrator/components/com_menus/tmpl/items/default.php
@@ -216,7 +216,7 @@ $assoc   = Associations::isEnabled() && $this->state->get('filter.client_id') ==
 														<?php echo HTMLHelper::_('image', 'mod_languages/' . $item->language_image . '.gif', $item->language_title, array('title' => Text::sprintf('COM_MENUS_GRID_UNSET_LANGUAGE', $item->language_title)), true); ?>
 													<?php else : ?>
 														<span class="badge badge-secondary"
-															  title="<?php echo Text::sprintf('COM_MENUS_GRID_UNSET_LANGUAGE', $item->language_title); ?>"><?php echo $item->language_sef; ?></span>
+															  title="<?php echo Text::sprintf('COM_MENUS_GRID_UNSET_LANGUAGE', $item->language_title); ?>"><?php echo $item->language; ?></span>
 													<?php endif; ?>
 												</a>
 											<?php else : ?>
@@ -224,7 +224,7 @@ $assoc   = Associations::isEnabled() && $this->state->get('filter.client_id') ==
 													<?php echo HTMLHelper::_('image', 'mod_languages/' . $item->language_image . '.gif', $item->language_title, array('title' => $item->language_title), true); ?>
 												<?php else : ?>
 													<span class="badge badge-secondary"
-														  title="<?php echo $item->language_title; ?>"><?php echo $item->language_sef; ?></span>
+														  title="<?php echo $item->language_title; ?>"><?php echo $item->language; ?></span>
 												<?php endif; ?>
 											<?php endif; ?>
 										<?php endif; ?>

--- a/administrator/components/com_menus/tmpl/items/modal.php
+++ b/administrator/components/com_menus/tmpl/items/modal.php
@@ -145,7 +145,7 @@ if (!empty($editor))
 									<?php if ($item->language_image) : ?>
 										<?php echo HTMLHelper::_('image', 'mod_languages/' . $item->language_image . '.gif', $item->language_title, array('title' => $item->language_title), true); ?>
 									<?php else : ?>
-										<span class="badge badge-secondary" title="<?php echo $item->language_title; ?>"><?php echo $item->language_sef; ?></span>
+										<span class="badge badge-secondary" title="<?php echo $item->language_title; ?>"><?php echo $item->language; ?></span>
 									<?php endif; ?>
 								<?php endif; ?>
 							<?php endif; ?>

--- a/administrator/components/com_newsfeeds/src/Service/HTML/AdministratorService.php
+++ b/administrator/components/com_newsfeeds/src/Service/HTML/AdministratorService.php
@@ -93,7 +93,7 @@ class AdministratorService
 				{
 					if (in_array($item->lang_code, $content_languages))
 					{
-						$text    = strtoupper($item->lang_sef);
+						$text    = $item->lang_code;
 						$url     = Route::_('index.php?option=com_newsfeeds&task=newsfeed.edit&id=' . (int) $item->id);
 						$tooltip = '<strong>' . htmlspecialchars($item->language_title, ENT_QUOTES, 'UTF-8') . '</strong><br>'
 							. htmlspecialchars($item->title, ENT_QUOTES, 'UTF-8') . '<br>' . Text::sprintf('JCATEGORY_SPRINTF', $item->category_title);

--- a/administrator/components/com_templates/tmpl/styles/default.php
+++ b/administrator/components/com_templates/tmpl/styles/default.php
@@ -102,14 +102,14 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 											<?php if ($item->image) : ?>
 												<?php echo HTMLHelper::_('image', 'mod_languages/' . $item->image . '.gif', $item->language_title, array('title' => Text::sprintf('COM_TEMPLATES_GRID_UNSET_LANGUAGE', $item->language_title)), true); ?>
 											<?php else : ?>
-												<span class="badge badge-secondary" title="<?php echo Text::sprintf('COM_TEMPLATES_GRID_UNSET_LANGUAGE', $item->language_title); ?>"><?php echo $item->language_sef; ?></span>
+												<span class="badge badge-secondary" title="<?php echo Text::sprintf('COM_TEMPLATES_GRID_UNSET_LANGUAGE', $item->language_title); ?>"><?php echo $item->home; ?></span>
 											<?php endif; ?>
 										</a>
 									<?php else : ?>
 										<?php if ($item->image) : ?>
 											<?php echo HTMLHelper::_('image', 'mod_languages/' . $item->image . '.gif', $item->language_title, array('title' => $item->language_title), true); ?>
 										<?php else : ?>
-											<span class="badge badge-secondary" title="<?php echo $item->language_title; ?>"><?php echo $item->language_sef; ?></span>
+											<span class="badge badge-secondary" title="<?php echo $item->language_title; ?>"><?php echo $item->home; ?></span>
 										<?php endif; ?>
 									<?php endif; ?>
 								</td>


### PR DESCRIPTION
### Summary of Changes
When one is using various languages with different country codes (and also when a specific language is not using the language icon), differentiating them in admin may be hard.

For example: 
de-DE, de-AT, de-CH
en-GB, en-US, en-AU
fr-FR, fr-CA

etc.

The badge produced are using the language sef (URL language code) as defined in the content language but it is confusing if that sef is not simple.
I propose here to use the full language code instead as it is clearer. 
It also normalises the language all over admin (See below the Administrator menu MENUS for menus containing homes)

<img width="296" alt="Screen Shot 2020-05-07 at 12 17 02" src="https://user-images.githubusercontent.com/869724/81283334-be297380-905c-11ea-8743-9ad457149c6f.png">

These show in various managers (associations column, home menu item, com_associations, ...)

_I am conscious that this will use more space when many languages but I think it is worth it._

### Testing Instructions
Create a multilingual site and display the various managers 


### Before patch

<img width="1172" alt="Screen Shot 2020-05-07 at 11 35 45" src="https://user-images.githubusercontent.com/869724/81282726-db117700-905b-11ea-9041-94b56761886c.png">


### After patch
Here the German de-DE content language has no image/flag

<img width="1252" alt="Screen Shot 2020-05-07 at 11 36 49" src="https://user-images.githubusercontent.com/869724/81282869-0e540600-905c-11ea-953c-89ffa0a7423b.png">
