### PR TITLE
[4.0] Fix template preview on PDO

### DIFF
--- a/administrator/components/com_templates/tmpl/styles/default.php
+++ b/administrator/components/com_templates/tmpl/styles/default.php
@@ -15,7 +15,6 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
-use Joomla\CMS\Uri\Uri;
 
 HTMLHelper::_('behavior.multiselect');
 

--- a/administrator/components/com_templates/tmpl/styles/default.php
+++ b/administrator/components/com_templates/tmpl/styles/default.php
@@ -81,17 +81,14 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 								</th>
 								<td class="text-center">
 									<?php if ($this->preview) : ?>
-										<?php if ($clientId === 0 && $item->client_id == '0') : ?>
-											<a target="_blank" href="<?php echo Uri::root() . 'index.php?tp=1&templateStyle=' . (int) $item->id ?>" class="jgrid">
-										<?php elseif ($clientId === 1 && $item->client_id == '1') : ?>
-											<a target="_blank" href="<?php echo Uri::root() . 'administrator/index.php?tp=1&templateStyle=' . (int) $item->id ?>" class="jgrid">
-										<?php endif; ?>
+										<?php $client = (int) $item->client_id === 1 ? 'administrator' : 'site'; ?>
+										<a href="<?php echo Route::link($client, 'index.php?tp=1&templateStyle=' . (int) $item->id); ?>" target="_blank" class="jgrid">
 											<span class="fas fa-eye" aria-hidden="true" title="<?php echo Text::_('COM_TEMPLATES_TEMPLATE_PREVIEW'); ?>"></span>
 											<span class="sr-only"><?php echo Text::_('COM_TEMPLATES_TEMPLATE_PREVIEW'); ?></span>
-											</a>
+										</a>
 									<?php else : ?>
-											<span class="fas fa-eye-slash" aria-hidden="true" title="<?php echo Text::_('COM_TEMPLATES_TEMPLATE_NO_PREVIEW'); ?>"></span>
-											<span class="sr-only"><?php echo Text::_('COM_TEMPLATES_TEMPLATE_NO_PREVIEW'); ?></span>
+										<span class="fas fa-eye-slash" aria-hidden="true" title="<?php echo Text::_('COM_TEMPLATES_TEMPLATE_NO_PREVIEW'); ?>"></span>
+										<span class="sr-only"><?php echo Text::_('COM_TEMPLATES_TEMPLATE_NO_PREVIEW'); ?></span>
 									<?php endif; ?>
 								</td>
 								<td class="text-center">

--- a/administrator/components/com_templates/tmpl/templates/default.php
+++ b/administrator/components/com_templates/tmpl/templates/default.php
@@ -69,13 +69,10 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 										<?php echo Text::sprintf('COM_TEMPLATES_TEMPLATE_DETAILS', ucfirst($item->name)); ?></a>
 									<div>
 										<?php if ($this->preview) : ?>
-											<?php if ((int) $item->client_id === 0) : ?>
-												<a href="<?php echo Route::_(Uri::root() . 'index.php?tp=1&template=' . $item->element); ?>" target="_blank"
+											<?php $client = (int) $item->client_id === 1 ? 'administrator' : 'site'; ?>
+											<a href="<?php echo Route::link($client, 'index.php?tp=1&template=' . $item->element); ?>"
+												target="_blank"
 												title="<?php echo Text::sprintf('JBROWSERTARGET_NEW_TITLE', Text::_($item->name)); ?>">
-											<?php elseif ((int) $item->client_id === 1) : ?>
-												<a href="<?php echo Route::_(Uri::root() . 'administrator/index.php?tp=1&template=' . $item->element); ?>" target="_blank"
-												title="<?php echo Text::sprintf('JBROWSERTARGET_NEW_TITLE', Text::_($item->name)); ?>">
-											<?php endif; ?>
 											<?php echo Text::_('COM_TEMPLATES_TEMPLATE_PREVIEW'); ?>
 											</a>
 										<?php else : ?>

--- a/administrator/components/com_templates/tmpl/templates/default.php
+++ b/administrator/components/com_templates/tmpl/templates/default.php
@@ -69,10 +69,10 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 										<?php echo Text::sprintf('COM_TEMPLATES_TEMPLATE_DETAILS', ucfirst($item->name)); ?></a>
 									<div>
 										<?php if ($this->preview) : ?>
-											<?php if ($item->client_id === 0) : ?>
+											<?php if ((int) $item->client_id === 0) : ?>
 												<a href="<?php echo Route::_(Uri::root() . 'index.php?tp=1&template=' . $item->element); ?>" target="_blank"
 												title="<?php echo Text::sprintf('JBROWSERTARGET_NEW_TITLE', Text::_($item->name)); ?>">
-											<?php elseif ($item->client_id === 1) : ?>
+											<?php elseif ((int) $item->client_id === 1) : ?>
 												<a href="<?php echo Route::_(Uri::root() . 'administrator/index.php?tp=1&template=' . $item->element); ?>" target="_blank"
 												title="<?php echo Text::sprintf('JBROWSERTARGET_NEW_TITLE', Text::_($item->name)); ?>">
 											<?php endif; ?>

--- a/administrator/components/com_templates/tmpl/templates/default.php
+++ b/administrator/components/com_templates/tmpl/templates/default.php
@@ -14,7 +14,6 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
-use Joomla\CMS\Uri\Uri;
 
 HTMLHelper::_('behavior.multiselect');
 


### PR DESCRIPTION
### Summary of Changes

Fixes template preview on PDO and cleans up related code.

### Testing Instructions

Use PDO database driver.
Enable template preview.
Go to template list.
Look under `Details and Files` text.
Inspect page using browser tools.

### Expected result

Clickable preview link.

### Actual result

Unclickable `Preview` text and a loose `</a>` tag.
![Screenshot_2020-05-07 Templates Templates (Site) - Joomla - Administration](https://user-images.githubusercontent.com/7325021/81296146-2470bf00-907a-11ea-99d4-7759d18cc229.png)

### Documentation Changes Required

No.