### PR TITLE
[4.0] Fix inline scripts/style with caching enabled

### DIFF
--- a/libraries/src/Document/HtmlDocument.php
+++ b/libraries/src/Document/HtmlDocument.php
@@ -318,11 +318,14 @@ class HtmlDocument extends Document
 
 		if (isset($data['style']))
 		{
-			foreach ($data['style'] as $type => $stdata)
+			foreach ($data['style'] as $type => $styles)
 			{
-				if (!isset($this->_style[strtolower($type)]) || !stristr($stdata, $this->_style[strtolower($type)]))
+				foreach ($styles as $hash => $style)
 				{
-					$this->addStyleDeclaration($stdata, $type);
+					if (!isset($this->_style[strtolower($type)][$hash]))
+					{
+						$this->addStyleDeclaration($style, $type);
+					}
 				}
 			}
 		}
@@ -333,11 +336,14 @@ class HtmlDocument extends Document
 
 		if (isset($data['script']))
 		{
-			foreach ($data['script'] as $type => $sdata)
+			foreach ($data['script'] as $type => $scripts)
 			{
-				if (!isset($this->_script[strtolower($type)]) || !stristr($sdata, $this->_script[strtolower($type)]))
+				foreach ($scripts as $hash => $script)
 				{
-					$this->addScriptDeclaration($sdata, $type);
+					if (!isset($this->_script[strtolower($type)][$hash]))
+					{
+						$this->addScriptDeclaration($script, $type);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/27163.

### Summary of Changes

Fixes inline assets in module with Progressive Caching enabled.

### Testing Instructions

Add some inline scripts and styles to a module:

```
$app->getDocument()->addStyleDeclaration('* {background:white !important;');
$app->getDocument()->addStyleDeclaration('* {background:black !important;');
$app->getDocument()->addStyleDeclaration('* {color:white !important;}');
$app->getDocument()->addStyleDeclaration('* {color:white !important;}');
$app->getDocument()->addScriptDeclaration('alert(1);');
$app->getDocument()->addScriptDeclaration('alert(2);');
$app->getDocument()->addScriptDeclaration('alert(1);');
$app->getDocument()->addScriptDeclaration('alert(2);');
```
Enable Progressive Caching.
View some page twice to generate cache and to load cached data.

### Expected result

No warnings.
The added styles/scripts are working correctly.
Duplicated scripts/styles do not appear in source code (e.g. script with `alert(1);` only appears once).

### Actual result

Scripts/styles don't work and warnings are generated:

>Warning:  md5() expects parameter 1 to be string, array given in  libraries\src\Document\Document.php on line 676
> Warning: stristr() expects parameter 1 to be string, array given in libraries\src\Document\HtmlDocument.php on line 338

### Documentation Changes Required

No.