### PR TITLE
[4.0][com_users] - fix param type onUserAfterSave

### DIFF
--- a/administrator/components/com_users/src/Model/UserModel.php
+++ b/administrator/components/com_users/src/Model/UserModel.php
@@ -496,7 +496,7 @@ class UserModel extends AdminModel
 						}
 
 						// Trigger the after save event
-						Factory::getApplication()->triggerEvent($this->event_after_save, array($table->getProperties(), false, true, null));
+						Factory::getApplication()->triggerEvent($this->event_after_save, [$table->getProperties(), false, true, '']);
 					}
 					catch (\Exception $e)
 					{
@@ -593,7 +593,7 @@ class UserModel extends AdminModel
 						}
 
 						// Fire the after save event
-						Factory::getApplication()->triggerEvent($this->event_after_save, array($table->getProperties(), false, true, null));
+						Factory::getApplication()->triggerEvent($this->event_after_save, [$table->getProperties(), false, true, '']);
 					}
 					catch (\Exception $e)
 					{

--- a/administrator/components/com_users/src/Model/UserModel.php
+++ b/administrator/components/com_users/src/Model/UserModel.php
@@ -496,7 +496,7 @@ class UserModel extends AdminModel
 						}
 
 						// Trigger the after save event
-						Factory::getApplication()->triggerEvent($this->event_after_save, [$table->getProperties(), false, true, '']);
+						Factory::getApplication()->triggerEvent($this->event_after_save, [$table->getProperties(), false, true, null]);
 					}
 					catch (\Exception $e)
 					{
@@ -593,7 +593,7 @@ class UserModel extends AdminModel
 						}
 
 						// Fire the after save event
-						Factory::getApplication()->triggerEvent($this->event_after_save, [$table->getProperties(), false, true, '']);
+						Factory::getApplication()->triggerEvent($this->event_after_save, [$table->getProperties(), false, true, null]);
 					}
 					catch (\Exception $e)
 					{

--- a/plugins/user/token/token.php
+++ b/plugins/user/token/token.php
@@ -265,7 +265,7 @@ class PlgUserToken extends CMSPlugin
 	 * @return  boolean
 	 * @since   4.0.0
 	 */
-	public function onUserAfterSave($data, bool $isNew, bool $result, string $error): bool
+	public function onUserAfterSave($data, bool $isNew, bool $result, ?string $error): bool
 	{
 		if (!is_array($data))
 		{


### PR DESCRIPTION
Pull Request for Issue #28984 .

### Summary of Changes
pass the 4th param type as a string


### Testing Instructions

- Enable users registration (Back-end > Users > Options > Allow User Registration: yes)
- Go to frontend and create a new user but do not open the mail to confirm the new account
- Return to back-end and go to Users panel.
- Try to Activate the new user

or try block / unblock an already registered user



### Expected result
able to activate , block / unblock a user from backend without errors


### Actual result
Error
Argument 4 passed to PlgUserToken::onUserAfterSave() must be of the type string, null given,




