### PR TITLE
[4.0] Fix install from web

### DIFF
--- a/build/media_source/com_installer/js/installer.es6.js
+++ b/build/media_source/com_installer/js/installer.es6.js
@@ -80,7 +80,7 @@ Joomla = window.Joomla || {};
       } else {
         document.querySelector('#appsloading').classList.remove('hidden');
         form.installtype.value = 'web';
-        form.submit()
+        form.submit();
       }
     };
 

--- a/build/media_source/com_installer/js/installer.es6.js
+++ b/build/media_source/com_installer/js/installer.es6.js
@@ -16,9 +16,9 @@ Joomla = window.Joomla || {};
 
       // do field validation
       if (form.install_package.value === '') {
-        alert(Joomla.JText._('PLG_INSTALLER_PACKAGEINSTALLER_NO_PACKAGE'), true);
+        Joomla.renderMessages({ warning: [Joomla.JText._('PLG_INSTALLER_PACKAGEINSTALLER_NO_PACKAGE')] });
       } else if (form.install_package.files[0].size > form.max_upload_size.value) {
-        alert(Joomla.JText._('COM_INSTALLER_MSG_WARNINGS_UPLOADFILETOOBIG'), true);
+        Joomla.renderMessages({ warning: [Joomla.JText._('COM_INSTALLER_MSG_WARNINGS_UPLOADFILETOOBIG')] });
       } else {
         Joomla.displayLoader();
 
@@ -32,7 +32,7 @@ Joomla = window.Joomla || {};
 
       // do field validation
       if (form.install_directory.value === '') {
-        alert(Joomla.JText._('PLG_INSTALLER_FOLDERINSTALLER_NO_INSTALL_PATH'), true);
+        Joomla.renderMessages({ warning: [Joomla.JText._('PLG_INSTALLER_FOLDERINSTALLER_NO_INSTALL_PATH')] });
       } else {
         Joomla.displayLoader();
 
@@ -46,7 +46,7 @@ Joomla = window.Joomla || {};
 
       // do field validation
       if (form.install_url.value === '' || form.install_url.value === 'http://' || form.install_url.value === 'https://') {
-        alert(Joomla.JText._('PLG_INSTALLER_URLINSTALLER_NO_URL'), true);
+        Joomla.renderMessages({ warning: [Joomla.JText._('PLG_INSTALLER_URLINSTALLER_NO_URL')] });
       } else {
         Joomla.displayLoader();
 
@@ -60,7 +60,7 @@ Joomla = window.Joomla || {};
 
       // do field validation
       if (form.install_url.value === '' || form.install_url.value === 'http://' || form.install_url.value === 'https://') {
-        alert(Joomla.JText._('COM_INSTALLER_MSG_INSTALL_ENTER_A_URL'), true);
+        Joomla.renderMessages({ warning: [Joomla.JText._('COM_INSTALLER_MSG_INSTALL_ENTER_A_URL')] });
       } else {
         Joomla.displayLoader();
 
@@ -76,7 +76,7 @@ Joomla = window.Joomla || {};
       if (form.install_url.value !== '' || form.install_url.value !== 'http://' || form.install_url.value !== 'https://') {
         Joomla.submitbutton4();
       } else if (form.install_url.value === '') {
-        alert(Joomla.apps.options.btntxt);
+        Joomla.renderMessages({ warning: [Joomla.apps.options.btntxt] });
       } else {
         document.querySelector('#appsloading').classList.remove('hidden');
         form.installtype.value = 'web';
@@ -89,9 +89,9 @@ Joomla = window.Joomla || {};
 
       // do field validation
       if (form.install_package.value === '') {
-        alert(Joomla.JText._('COM_INSTALLER_MSG_INSTALL_PLEASE_SELECT_A_PACKAGE'), true);
+        Joomla.renderMessages({ warning: [Joomla.JText._('COM_INSTALLER_MSG_INSTALL_PLEASE_SELECT_A_PACKAGE')] });
       } else if (form.install_package.files[0].size > form.max_upload_size.value) {
-        alert(Joomla.JText._('COM_INSTALLER_MSG_WARNINGS_UPLOADFILETOOBIG'), true);
+        Joomla.renderMessages({ warning: [Joomla.JText._('COM_INSTALLER_MSG_WARNINGS_UPLOADFILETOOBIG')] });
       } else {
         Joomla.displayLoader();
 
@@ -219,7 +219,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const data = new FormData();
 
     if (file.size > fileSizeMax) {
-      alert(Joomla.JText._('COM_INSTALLER_MSG_WARNINGS_UPLOADFILETOOBIG'), true);
+      Joomla.renderMessages({ warning: [Joomla.JText._('COM_INSTALLER_MSG_WARNINGS_UPLOADFILETOOBIG')] });
       return;
     }
 

--- a/build/media_source/com_installer/js/installer.es6.js
+++ b/build/media_source/com_installer/js/installer.es6.js
@@ -69,6 +69,21 @@ Joomla = window.Joomla || {};
       }
     };
 
+    Joomla.submitbutton5 = () => {
+      const form = document.getElementById('adminForm');
+
+      // do field validation
+      if (form.install_url.value !== '' || form.install_url.value !== 'http://' || form.install_url.value !== 'https://') {
+        Joomla.submitbutton4();
+      } else if (form.install_url.value === '') {
+        alert(Joomla.apps.options.btntxt);
+      } else {
+        document.querySelector('#appsloading').classList.remove('hidden');
+        form.installtype.value = 'web';
+        form.submit()
+      }
+    };
+
     Joomla.submitbuttonUpload = () => {
       const form = document.getElementById('uploadForm');
 

--- a/build/media_source/plg_installer_webinstaller/js/client.es6.js
+++ b/build/media_source/plg_installer_webinstaller/js/client.es6.js
@@ -173,7 +173,6 @@ if (!Joomla) {
           }
 
           if (installExtensionFromExternalButton) {
-            // @todo Migrate this handler's confirm to a CE dialog
             installExtensionFromExternalButton.addEventListener('click', () => {
               const redirectUrl = installExtensionFromExternalButton.getAttribute('data-downloadurl');
               const redirectConfirm = window.confirm(Joomla.JText._('PLG_INSTALLER_WEBINSTALLER_REDIRECT_TO_EXTERNAL_SITE_TO_INSTALL').replace('[SITEURL]', redirectUrl));
@@ -299,11 +298,10 @@ if (!Joomla) {
      * @param {string} installUrl
      * @param {string} name
      * @returns {boolean}
-     * @todo Migrate this function's alert to a CE dialog
      */
     static installfromweb(installUrl, name = null) {
       if (!installUrl) {
-        alert(Joomla.JText._('PLG_INSTALLER_WEBINSTALLER_CANNOT_INSTALL_EXTENSION_IN_PLUGIN'));
+        Joomla.renderMessages({ warning: [Joomla.JText._('PLG_INSTALLER_WEBINSTALLER_CANNOT_INSTALL_EXTENSION_IN_PLUGIN')] });
 
         return false;
       }

--- a/build/media_source/plg_installer_webinstaller/js/client.es6.js
+++ b/build/media_source/plg_installer_webinstaller/js/client.es6.js
@@ -35,7 +35,7 @@ if (!Joomla) {
 
       const installButton = document.getElementById('uploadform-web-install');
       installButton.addEventListener('click', () => {
-        if (webInstallerOptions.options === 4) {
+        if (webInstallerOptions.options.installFrom === 4) {
           Joomla.submitbutton4();
         } else {
           Joomla.submitbutton5();

--- a/build/media_source/plg_installer_webinstaller/js/client.es6.js
+++ b/build/media_source/plg_installer_webinstaller/js/client.es6.js
@@ -25,12 +25,20 @@ if (!Joomla) {
       webInstallerOptions.loaded = 1;
 
       const cancelButton = document.getElementById('uploadform-web-cancel');
-
       cancelButton.addEventListener('click', () => {
         document.getElementById('uploadform-web').classList.add('hidden');
 
         if (webInstallerOptions.list && document.querySelector('.list-view')) {
           document.querySelector('.list-view').click();
+        }
+      });
+
+      const installButton = document.getElementById('uploadform-web-install');
+      installButton.addEventListener('click', () => {
+        if (webInstallerOptions.options === 4) {
+          Joomla.submitbutton4();
+        } else {
+          Joomla.submitbutton5();
         }
       });
 
@@ -160,6 +168,7 @@ if (!Joomla) {
           if (installExtensionButton) {
             installExtensionButton.addEventListener('click', () => {
               WebInstaller.installfromweb(installExtensionButton.getAttribute('data-downloadurl'), installExtensionButton.getAttribute('data-name'));
+              document.getElementById('uploadform-web-install').scrollIntoView({ behavior: 'smooth', block: 'start' });
             });
           }
 

--- a/plugins/installer/webinstaller/tmpl/default.php
+++ b/plugins/installer/webinstaller/tmpl/default.php
@@ -39,8 +39,8 @@ $dir = $this->isRTL() ? ' dir="ltr"' : '';
 	<div class="card card-light">
 		<div class="card-body">
 			<div class="card-text">
-				<input type="button" class="btn btn-primary" value="<?php echo Text::_('COM_INSTALLER_INSTALL_BUTTON'); ?>" onclick="Joomla.submitbutton<?php echo $this->getInstallFrom() != '' ? 4 : 5; ?>()" />
-				<input type="button" class="btn btn-secondary" id="uploadform-web-cancel" value="<?php echo Text::_('JCANCEL'); ?>" />
+				<button type="button" class="btn btn-primary" id="uploadform-web-install"><?php echo Text::_('COM_INSTALLER_INSTALL_BUTTON'); ?></button>
+				<button type="button" class="btn btn-secondary" id="uploadform-web-cancel"><?php echo Text::_('JCANCEL'); ?></button>
 			</div>
 		</div>
 	</div>

--- a/plugins/installer/webinstaller/webinstaller.php
+++ b/plugins/installer/webinstaller/webinstaller.php
@@ -114,6 +114,7 @@ class PlgInstallerWebinstaller extends CMSPlugin
 				'dev_level'       => base64_encode($devLevel),
 				'installfromon'   => $installfrom ? 1 : 0,
 				'language'        => base64_encode($lang->getTag()),
+				'installFrom'     => $installfrom != '' ? 4 : 5,
 			]
 		);
 


### PR DESCRIPTION
Fixes:
- https://github.com/joomla/joomla-cms/issues/28988
- https://github.com/joomla/joomla-cms/issues/26448

### Summary of Changes

This fixes the ability to install an extension in the Web Installer.

### Testing Instructions

1. Run `node build.js --compile-js` from your terminal
2. Go to `/administrator/index.php?option=com_installer`
3. Click the "Install From Web" tab
4. Select any free extension
5. Click the green "Install" button
6. This should scroll you smoothly down to the blue "Install" button (poor UX IMO but out of scope)
7. Click the blue "Install" button and the extension should now install