### PR TITLE
[staging] Multilingual: add lang tag to categories names in batch dropdown

### DIFF
--- a/libraries/cms/html/category.php
+++ b/libraries/cms/html/category.php
@@ -154,7 +154,7 @@ abstract class JHtmlCategory
 			$user = JFactory::getUser();
 			$db = JFactory::getDbo();
 			$query = $db->getQuery(true)
-				->select('a.id, a.title, a.level, a.parent_id')
+				->select('a.id, a.title, a.level, a.parent_id, a.language')
 				->from('#__categories AS a')
 				->where('a.parent_id > 0');
 
@@ -191,6 +191,12 @@ abstract class JHtmlCategory
 			{
 				$repeat = ($item->level - 1 >= 0) ? $item->level - 1 : 0;
 				$item->title = str_repeat('- ', $repeat) . $item->title;
+
+				if ($item->language !== '*')
+				{
+					$item->title .= ' (' . $item->language . ')';
+				}
+
 				static::$items[$hash][] = JHtml::_('select.option', $item->id, $item->title);
 			}
 			// Special "Add to root" option:


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/28963
Redo of https://github.com/joomla/joomla-cms/pull/28964

### Summary of Changes
As title says. Normalizes vs other category edit fields (see Note)


### Testing Instructions
Create a multilingual site
Make sure you have tagged some categories to a Content Language.
In categories manager, select a category and click on the batch Toolbar button
Look into the category field (select field under To Move or Copy your selection please select a Category.)

### Before patch

<img width="466" alt="Screen Shot 2020-05-09 at 09 34 49" src="https://user-images.githubusercontent.com/869724/81467349-6283f500-91d8-11ea-871f-839a85131f29.png">

### After patch
<img width="516" alt="Screen Shot 2020-05-09 at 09 35 59" src="https://user-images.githubusercontent.com/869724/81467376-8ba48580-91d8-11ea-92ed-49afdaf7ee43.png">


### Note
This has already been done for other categories dropdowns fileds.

<img width="397" alt="Screen Shot 2020-05-09 at 09 39 47" src="https://user-images.githubusercontent.com/869724/81467469-0ec5db80-91d9-11ea-8ee2-0bbd66ec5232.png">
.
