### PR TITLE
[4.0] com_messages: fix user settings and move these params to a view

### DIFF
--- a/administrator/components/com_messages/src/Controller/ConfigController.php
+++ b/administrator/components/com_messages/src/Controller/ConfigController.php
@@ -34,7 +34,7 @@ class ConfigController extends BaseController
 		// Check for request forgeries.
 		$this->checkToken();
 
-		$model = $this->getModel('Config', 'MessagesModel');
+		$model = $this->getModel('Config');
 		$data  = $this->input->post->get('jform', array(), 'array');
 
 		// Validate the posted data.
@@ -87,5 +87,17 @@ class ConfigController extends BaseController
 		$this->setRedirect(Route::_('index.php?option=com_messages&view=messages', false));
 
 		return true;
+	}
+
+	/**
+	 * Cancel operation.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function cancel()
+	{
+		$this->setRedirect(Route::_('index.php?option=com_messages&view=messages', false));
 	}
 }

--- a/administrator/components/com_messages/src/View/Config/HtmlView.php
+++ b/administrator/components/com_messages/src/View/Config/HtmlView.php
@@ -11,8 +11,11 @@ namespace Joomla\Component\Messages\Administrator\View\Config;
 
 \defined('_JEXEC') or die;
 
+use Joomla\CMS\Factory;
+use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
+use Joomla\CMS\Toolbar\ToolbarHelper;
 
 /**
  * View to edit messages user configuration.
@@ -66,6 +69,26 @@ class HtmlView extends BaseHtmlView
 		// Bind the record to the form.
 		$this->form->bind($this->item);
 
+		$this->addToolbar();
+
 		parent::display($tpl);
+	}
+
+	/**
+	 * Add the page title and toolbar.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function addToolbar()
+	{
+		Factory::getApplication()->input->set('hidemainmenu', true);
+
+		ToolbarHelper::title(Text::_('COM_MESSAGES_TOOLBAR_MY_SETTINGS'), 'envelope');
+
+		ToolbarHelper::apply('config.save', 'JSAVE');
+
+		ToolbarHelper::cancel('config.cancel', 'JCANCEL');
 	}
 }

--- a/administrator/components/com_messages/src/View/Messages/HtmlView.php
+++ b/administrator/components/com_messages/src/View/Messages/HtmlView.php
@@ -137,25 +137,8 @@ class HtmlView extends BaseHtmlView
 			}
 		}
 
-		$toolbar->appendButton(
-			'Popup',
-			'cog',
-			'COM_MESSAGES_TOOLBAR_MY_SETTINGS',
-			'index.php?option=com_messages&amp;view=config&amp;tmpl=component',
-			500,
-			250,
-			0,
-			0,
-			'',
-			Text::_('COM_MESSAGES_TOOLBAR_MY_SETTINGS'),
-			'<button type="button" class="btn btn-secondary" data-dismiss="modal">'
-			. Text::_('JCANCEL')
-			. '</button>'
-			. '<button type="button" class="btn btn-success" data-dismiss="modal"'
-			. ' onclick="Joomla.iframeButtonClick({iframeSelector: \'#modal-cog\', buttonSelector: \'#saveBtn\'})">'
-			. Text::_('JSAVE')
-			. '</button>'
-		);
+		$toolbar->appendButton('Link', 'cog', 'COM_MESSAGES_TOOLBAR_MY_SETTINGS', 'index.php?option=com_messages&amp;view=config');
+		ToolbarHelper::divider();
 
 		if ($this->state->get('filter.state') == -2 && $canDo->get('core.delete'))
 		{

--- a/administrator/components/com_messages/tmpl/config/default.php
+++ b/administrator/components/com_messages/tmpl/config/default.php
@@ -15,16 +15,18 @@ use Joomla\CMS\Router\Route;
 HTMLHelper::_('behavior.formvalidator');
 HTMLHelper::_('behavior.keepalive');
 ?>
-<div class="container-popup">
-	<form action="<?php echo Route::_('index.php?option=com_messages&view=config'); ?>" method="post" name="adminForm" id="message-form" class="form-validate">
-		<fieldset>
-			<?php echo $this->form->renderField('lock'); ?>
-			<?php echo $this->form->renderField('mail_on_new'); ?>
-			<?php echo $this->form->renderField('auto_purge'); ?>
-		</fieldset>
-		<button id="saveBtn" type="button" class="hidden" onclick="Joomla.submitform('config.save', this.form);"></button>
 
-		<input type="hidden" name="task" value="">
-		<?php echo HTMLHelper::_('form.token'); ?>
-	</form>
-</div>
+<form action="<?php echo Route::_('index.php?option=com_messages&view=config'); ?>" method="post" name="adminForm" id="message-form" class="form-validate">
+	<div class="col-lg-8 col-xl-6">
+		<div class="card">
+			<div class="card-body">
+				<?php echo $this->form->renderField('lock'); ?>
+				<?php echo $this->form->renderField('mail_on_new'); ?>
+				<?php echo $this->form->renderField('auto_purge'); ?>
+			</div>
+		</div>
+	</div>
+
+	<input type="hidden" name="task" value="">
+	<?php echo HTMLHelper::_('form.token'); ?>
+</form>


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/28958
### Summary of Changes
As title says.
The pop up is here changed to a view and the controller is corrected.

### Testing Instructions
Load Private Messages Manager.
Click on `My Settings` button.
For example switch `Lock Inbox` to Yes.
Save.
Click again on the button.


### Before patch

![lockbrokenj4](https://user-images.githubusercontent.com/869724/81145886-85639e80-8f77-11ea-96e0-b0a2312a7619.gif)

### After patch

![mysettings](https://user-images.githubusercontent.com/869724/81470425-fced3400-91ea-11ea-8ecd-2414fe7f959a.gif)

