### PR TITLE
Fix warning mb_strpos(): Offset not contained in string

### DIFF
--- a/libraries/vendor/joomla/string/src/StringHelper.php
+++ b/libraries/vendor/joomla/string/src/StringHelper.php
@@ -179,7 +179,8 @@ abstract class StringHelper
 		{
 			return utf8_strpos($str, $search);
 		}
-
+		$strLength=mb_strlen($str);
+		$offset=$offset<$strLength?$offset:$strLength;
 		return utf8_strpos($str, $search, $offset);
 	}
 


### PR DESCRIPTION
encountered while using search component Search component

Pull Request for Issue # .

### Summary of Changes



### Testing Instructions



### Expected result



### Actual result



### Documentation Changes Required

