### PR TITLE
[4.0] com_menu - Change Featured Icon to Home Icon in

### DIFF
--- a/administrator/components/com_menus/tmpl/items/default.php
+++ b/administrator/components/com_menus/tmpl/items/default.php
@@ -209,7 +209,7 @@ $assoc   = Associations::isEnabled() && $this->state->get('filter.client_id') ==
 									<td class="text-center d-none d-md-table-cell">
 										<?php if ($item->type == 'component') : ?>
 											<?php if ($item->language == '*' || $item->home == '0') : ?>
-												<?php echo HTMLHelper::_('jgrid.isdefault', $item->home, $i, 'items.', ($item->language != '*' || !$item->home) && $canChange && !$item->protected); ?>
+												<?php echo HTMLHelper::_('jgrid.isdefault', $item->home, $i, 'items.', ($item->language != '*' || !$item->home) && $canChange && !$item->protected, "cb", null, "home", "circle"); ?>
 											<?php elseif ($canChange) : ?>
 												<a href="<?php echo Route::_('index.php?option=com_menus&task=items.unsetDefault&cid[]=' . $item->id . '&' . Session::getFormToken() . '=1'); ?>">
 													<?php if ($item->language_image) : ?>

--- a/administrator/components/com_menus/tmpl/items/default.php
+++ b/administrator/components/com_menus/tmpl/items/default.php
@@ -209,7 +209,7 @@ $assoc   = Associations::isEnabled() && $this->state->get('filter.client_id') ==
 									<td class="text-center d-none d-md-table-cell">
 										<?php if ($item->type == 'component') : ?>
 											<?php if ($item->language == '*' || $item->home == '0') : ?>
-												<?php echo HTMLHelper::_('jgrid.isdefault', $item->home, $i, 'items.', ($item->language != '*' || !$item->home) && $canChange && !$item->protected, "cb", null, "home", "circle"); ?>
+												<?php echo HTMLHelper::_('jgrid.isdefault', $item->home, $i, 'items.', ($item->language != '*' || !$item->home) && $canChange && !$item->protected, 'cb', null, 'home', 'circle'); ?>
 											<?php elseif ($canChange) : ?>
 												<a href="<?php echo Route::_('index.php?option=com_menus&task=items.unsetDefault&cid[]=' . $item->id . '&' . Session::getFormToken() . '=1'); ?>">
 													<?php if ($item->language_image) : ?>

--- a/administrator/modules/mod_menu/tmpl/default_submenu.php
+++ b/administrator/modules/mod_menu/tmpl/default_submenu.php
@@ -110,7 +110,7 @@ if ($iconImage)
 {
 	if (substr($iconImage, 0, 6) == 'class:' && substr($iconImage, 6) == 'icon-home')
 	{
-		$iconImage = '<span class="home-image fas fa-star" aria-hidden="true"></span>';
+		$iconImage = '<span class="home-image fas fa-home" aria-hidden="true"></span>';
 		$iconImage .= '<span class="sr-only">' . Text::_('JDEFAULT') . '</span>';
 	}
 	elseif (substr($iconImage, 0, 6) == 'image:')

--- a/administrator/modules/mod_submenu/src/Menu/Menu.php
+++ b/administrator/modules/mod_submenu/src/Menu/Menu.php
@@ -175,7 +175,7 @@ abstract class Menu
 				{
 					if (substr($iconImage, 0, 6) === 'class:' && substr($iconImage, 6) === 'icon-home')
 					{
-						$iconImage = '<span class="home-image fas fa-star" aria-hidden="true"></span>';
+						$iconImage = '<span class="home-image fas fa-home" aria-hidden="true"></span>';
 						$iconImage .= '<span class="sr-only">' . Text::_('JDEFAULT') . '</span>';
 					}
 					elseif (substr($iconImage, 0, 6) === 'image:')

--- a/administrator/templates/atum/scss/blocks/_icons.scss
+++ b/administrator/templates/atum/scss/blocks/_icons.scss
@@ -68,6 +68,11 @@
     color: var(--atum-text-dark);
     border: 0;
   }
+
+  &.disabled .icon-home {
+    color: $state-warning-bg;
+    border-color: $state-warning-bg;
+  }
 }
 
 .icon-joomla::before {

--- a/administrator/templates/atum/scss/blocks/_icons.scss
+++ b/administrator/templates/atum/scss/blocks/_icons.scss
@@ -69,6 +69,11 @@
     border: 0;
   }
 
+  &.home-disabled {
+    opacity: 1;
+    cursor: not-allowed;
+  }
+
   &.disabled .icon-home {
     color: $state-warning-bg;
     border-color: $state-warning-bg;

--- a/libraries/src/HTML/Helpers/JGrid.php
+++ b/libraries/src/HTML/Helpers/JGrid.php
@@ -89,7 +89,7 @@ abstract class JGrid
 		}
 		else
 		{
-			$html[] = '<a class="tbody-icon disabled jgrid"';
+			$html[] = '<a class="tbody-icon ' . $active_class . '-disabled disabled jgrid"';
 			$html[] = $tip ? ' aria-labelledby="' . $ariaid . '"' : '';
 			$html[] = '>';
 

--- a/libraries/src/HTML/Helpers/JGrid.php
+++ b/libraries/src/HTML/Helpers/JGrid.php
@@ -258,19 +258,21 @@ abstract class JGrid
 	/**
 	 * Returns an isDefault state on a grid
 	 *
-	 * @param   integer       $value     The state value.
-	 * @param   integer       $i         The row index
-	 * @param   string|array  $prefix    An optional task prefix or an array of options
-	 * @param   boolean       $enabled   An optional setting for access control on the action.
-	 * @param   string        $checkbox  An optional prefix for checkboxes.
-	 * @param   string        $formId    An optional form selector.
+	 * @param   integer       $value             The state value.
+	 * @param   integer       $i                 The row index
+	 * @param   string|array  $prefix            An optional task prefix or an array of options
+	 * @param   boolean       $enabled           An optional setting for access control on the action.
+	 * @param   string        $checkbox          An optional prefix for checkboxes.
+	 * @param   string        $formId            An optional form selector.
+	 * @param   string        $active_class      The class for active items.
+	 * @param   string        $inactive_class    The class for inactive items.
 	 *
 	 * @return  string  The HTML markup
 	 *
 	 * @see     JHtmlJGrid::state()
 	 * @since   1.6
 	 */
-	public static function isdefault($value, $i, $prefix = '', $enabled = true, $checkbox = 'cb', $formId = null)
+	public static function isdefault($value, $i, $prefix = '', $enabled = true, $checkbox = 'cb', $formId = null, $active_class = 'featured', $inactive_class = 'unfeatured')
 	{
 		if (is_array($prefix))
 		{
@@ -281,8 +283,8 @@ abstract class JGrid
 		}
 
 		$states = array(
-			0 => array('setDefault', '', 'JLIB_HTML_SETDEFAULT_ITEM', '', 1, 'unfeatured', 'unfeatured'),
-			1 => array('unsetDefault', 'JDEFAULT', 'JLIB_HTML_UNSETDEFAULT_ITEM', 'JDEFAULT', 1, 'featured', 'featured'),
+			0 => array('setDefault', '', 'JLIB_HTML_SETDEFAULT_ITEM', '', 1, $inactive_class, $inactive_class),
+			1 => array('unsetDefault', 'JDEFAULT', 'JLIB_HTML_UNSETDEFAULT_ITEM', 'JDEFAULT', 1, $active_class, $active_class),
 		);
 
 		return static::state($states, $value, $i, $prefix, $enabled, true, $checkbox, $formId);


### PR DESCRIPTION
Pull Request for Issue  #28976 

### Summary of Changes
Changed the Default Icon in Menus to a home icon. If it has to be called home or default could be discussed in another issue. This PR makes a difference between the _featured - action_ and the _set menu item as default_ action. It also adds the possibility to pass the active and inactive iconclass suffix to the isDefault method.


### Testing Instructions
apply patch 
see if the home Icon on monolingual sites is now a home icon
the non-default items are for now a simple circle
on a multilingual website the home icon should be still a flag like before.

### Expected result

<img width="557" alt="grafik" src="https://user-images.githubusercontent.com/828371/81486584-f516a980-9255-11ea-988f-4c6fce1888be.png">

Sidebar:
<img width="317" alt="grafik" src="https://user-images.githubusercontent.com/828371/81486624-53dc2300-9256-11ea-96d8-7f0c975cfe56.png">




### Actual result
<img width="549" alt="grafik" src="https://user-images.githubusercontent.com/828371/81486298-16769600-9254-11ea-9ae7-db674da5feee.png">




