### PR TITLE
[4.0] WebAssets and Cache enabled

### DIFF
--- a/libraries/src/Document/HtmlDocument.php
+++ b/libraries/src/Document/HtmlDocument.php
@@ -18,6 +18,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
 use Joomla\CMS\Uri\Uri;
 use Joomla\CMS\Utility\Utility;
+use Joomla\CMS\WebAsset\WebAssetManager;
 use Joomla\Database\ParameterType;
 use Joomla\Registry\Registry;
 
@@ -160,6 +161,30 @@ class HtmlDocument extends Document
 
 		$data['scriptOptions'] = $this->scriptOptions;
 
+		// Get Asset manager state
+		$wa      = $this->getWebAssetManager();
+		$waState = $wa->getManagerState();
+
+		// Get asset objects and filter only manually added/enabled assets,
+		// Dependencies will be picked up from registry files
+		$waState['assets'] = [];
+
+		foreach ($waState['activeAssets'] as $assetType => $assetNames)
+		{
+			foreach ($assetNames as $assetName => $assetState)
+			{
+				if ($assetState === WebAssetManager::ASSET_STATE_ACTIVE)
+				{
+					$waState['assets'][$assetType][] = $wa->getAsset($assetType, $assetName);
+				}
+			}
+		}
+
+		// We have loaded asset objects, now can remove unused stuff
+		unset($waState['activeAssets']);
+
+		$data['assetManager'] = $waState;
+
 		return $data;
 	}
 
@@ -269,6 +294,30 @@ class HtmlDocument extends Document
 		$this->_custom       = $data['custom'] ?? $this->_custom;
 		$this->scriptOptions = (isset($data['scriptOptions']) && !empty($data['scriptOptions'])) ? $data['scriptOptions'] : $this->scriptOptions;
 
+		// Restore asset manager state
+		$wa = $this->getWebAssetManager();
+
+		if (!empty($data['assetManager']['registryFiles']))
+		{
+			$waRegistry = $wa->getRegistry();
+
+			foreach ($data['assetManager']['registryFiles'] as $registryFile)
+			{
+				$waRegistry->addRegistryFile($registryFile);
+			}
+		}
+
+		if (!empty($data['assetManager']['assets']))
+		{
+			foreach ($data['assetManager']['assets'] as $assetType => $assets)
+			{
+				foreach ($assets as $asset)
+				{
+					$wa->registerAsset($assetType, $asset)->useAsset($assetType, $asset->getName());
+				}
+			}
+		}
+
 		return $this;
 	}
 
@@ -357,6 +406,30 @@ class HtmlDocument extends Document
 			foreach ($data['scriptOptions'] as $key => $scriptOptions)
 			{
 				$this->addScriptOptions($key, $scriptOptions, true);
+			}
+		}
+
+		// Restore asset manager state
+		$wa = $this->getWebAssetManager();
+
+		if (!empty($data['assetManager']['registryFiles']))
+		{
+			$waRegistry = $wa->getRegistry();
+
+			foreach ($data['assetManager']['registryFiles'] as $registryFile)
+			{
+				$waRegistry->addRegistryFile($registryFile);
+			}
+		}
+
+		if (!empty($data['assetManager']['assets']))
+		{
+			foreach ($data['assetManager']['assets'] as $assetType => $assets)
+			{
+				foreach ($assets as $asset)
+				{
+					$wa->registerAsset($assetType, $asset)->useAsset($assetType, $asset->getName());
+				}
 			}
 		}
 

--- a/libraries/src/WebAsset/WebAssetManager.php
+++ b/libraries/src/WebAsset/WebAssetManager.php
@@ -721,6 +721,21 @@ class WebAssetManager implements WebAssetManagerInterface
 	}
 
 	/**
+	 * Get the manager state. A collection of registry files and active asset names (per type).
+	 *
+	 * @return array
+	 *
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public function getManagerState(): array
+	{
+		return [
+			'registryFiles' => $this->getRegistry()->getRegistryFiles(),
+			'activeAssets'  => $this->activeAssets,
+		];
+	}
+
+	/**
 	 * Update Dependencies state for all active Assets or only for given
 	 *
 	 * @param   string        $type   The asset type, script or style

--- a/libraries/src/WebAsset/WebAssetRegistry.php
+++ b/libraries/src/WebAsset/WebAssetRegistry.php
@@ -271,6 +271,18 @@ class WebAssetRegistry implements WebAssetRegistryInterface, DispatcherAwareInte
 	}
 
 	/**
+	 * Get a list of the registry files
+	 *
+	 * @return  array
+	 *
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public function getRegistryFiles(): array
+	{
+		return array_values($this->dataFilesParsed + $this->dataFilesNew);
+	}
+
+	/**
 	 * Helper method to register new file with Template Asset(s) info
 	 *
 	 * @param   string   $template  The template name


### PR DESCRIPTION
Pull Request for Issue #28727 .

### Summary of Changes

Store/Restore Asset Manager state for caching, with `HtmlDocument::get[set]HeadData()`


### Testing Instructions
Apply patch.
Enable caching in global configuration.
Create a CustomHTML module with next content:
`<p class="much-red">test cache</p>`

Edit `modules/mod_custom/tmpl/default.php`, add:
```php
$wa = $app->getDocument()->getWebAssetManager();
$wa->addInlineStyle('.much-red{color:red; font-weight:bold;}');
```

Open the page with module.

### Expected result

The text color in the module should be red after each page refresh.


### Actual result

The text is red only after first load (or after clearing the cache), and stays black on future page refresh


### Documentation Changes Required

none

@wilsonge please review
