### PR TITLE
[4.0] Template Atum closed sidebar hover fix

### DIFF
--- a/administrator/templates/atum/scss/blocks/_sidebar.scss
+++ b/administrator/templates/atum/scss/blocks/_sidebar.scss
@@ -182,7 +182,8 @@
     display: none;
   }
 
-  .main-nav, .main-nav li {
+  .main-nav,
+  .main-nav li {
     max-width: 3rem;
   }
 

--- a/administrator/templates/atum/scss/blocks/_sidebar.scss
+++ b/administrator/templates/atum/scss/blocks/_sidebar.scss
@@ -182,35 +182,31 @@
     display: none;
   }
 
-  .main-nav {
-
-    max-width: 3rem;
-
-    a:hover {
-
-        max-width: 3rem;
-
-      .sidebar-item-title {
-        background-color: var(--atum-sidebar-link-color);
-        position: relative;
-        right: -1rem;
-        font-size: 0.6rem;
-        border-radius: 0.3rem;
-        top: 0;
-        display: inline-block;
-        pointer-events: none;
-        padding: 0.2rem;
-        white-space: pre;
-        opacity: 0.8;
-      }
-
-      > li > ul {
-        height: 0;
-        padding: 0;
-        visibility: hidden;
-      }
-    }
+  .main-nav a:hover {
+    max-width:3rem;
+    position: relative;
   }
+
+  .main-nav a:hover .sidebar-item-title {
+    background-color: var(--atum-sidebar-link-color);
+    position: absolute;
+    left: 3.5rem;
+    font-size: 0.6rem;
+    border-radius: 0.3rem;
+    top: 0;
+    display: inline-block;
+    pointer-events: none;
+    padding: 0.2rem;
+    white-space: pre;
+    opacity: 0.8;
+  }
+
+  .main-nav > li > ul {
+    height: 0;
+    padding: 0;
+    visibility: hidden;
+   }
+
 }
 
 @include media-breakpoint-up(sm) {

--- a/administrator/templates/atum/scss/blocks/_sidebar.scss
+++ b/administrator/templates/atum/scss/blocks/_sidebar.scss
@@ -183,11 +183,11 @@
   }
 
   .main-nav, .main-nav li {
-    max-width:3rem;
+    max-width: 3rem;
   }
 
   .main-nav a:hover {
-    max-width:3rem;
+    max-width: 3rem;
     position: relative;
   }
 

--- a/administrator/templates/atum/scss/blocks/_sidebar.scss
+++ b/administrator/templates/atum/scss/blocks/_sidebar.scss
@@ -182,6 +182,10 @@
     display: none;
   }
 
+  .main-nav, .main-nav li {
+    max-width:3rem;
+  }
+
   .main-nav a:hover {
     max-width:3rem;
     position: relative;

--- a/administrator/templates/atum/scss/blocks/_sidebar.scss
+++ b/administrator/templates/atum/scss/blocks/_sidebar.scss
@@ -203,7 +203,6 @@
     pointer-events: none;
     padding: 0.2rem;
     white-space: pre;
-    opacity: 0.8;
   }
 
   .main-nav > li > ul {

--- a/administrator/templates/atum/scss/blocks/_sidebar.scss
+++ b/administrator/templates/atum/scss/blocks/_sidebar.scss
@@ -195,9 +195,9 @@
     background-color: var(--atum-sidebar-link-color);
     position: absolute;
     left: 3.5rem;
-    font-size: 0.6rem;
+    font-size: 0.875rem;
     border-radius: 0.3rem;
-    top: 0;
+    top: 0.5rem;
     display: inline-block;
     pointer-events: none;
     padding: 0.2rem;

--- a/administrator/templates/atum/scss/blocks/_sidebar.scss
+++ b/administrator/templates/atum/scss/blocks/_sidebar.scss
@@ -182,16 +182,34 @@
     display: none;
   }
 
-  .main-nav a:hover .sidebar-item-title {
-    display: inline-block;
-    min-width: $sidebar-width;
-    background-color: var(--atum-sidebar-link-color);
-  }
+  .main-nav {
 
-  .main-nav > li > ul {
-    height: 0;
-    padding: 0;
-    visibility: hidden;
+    max-width: 3rem;
+
+    a:hover {
+
+        max-width: 3rem;
+
+      .sidebar-item-title {
+        background-color: var(--atum-sidebar-link-color);
+        position: relative;
+        right: -1rem;
+        font-size: 0.6rem;
+        border-radius: 0.3rem;
+        top: 0;
+        display: inline-block;
+        pointer-events: none;
+        padding: 0.2rem;
+        white-space: pre;
+        opacity: 0.8;
+      }
+
+      > li > ul {
+        height: 0;
+        padding: 0;
+        visibility: hidden;
+      }
+    }
   }
 }
 

--- a/administrator/templates/atum/scss/blocks/_sidebar.scss
+++ b/administrator/templates/atum/scss/blocks/_sidebar.scss
@@ -210,8 +210,7 @@
     height: 0;
     padding: 0;
     visibility: hidden;
-   }
-
+  }
 }
 
 @include media-breakpoint-up(sm) {


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/28840

### Summary of Changes
Added the max-width to the closed items and created a style where the menu titles appear like small badges, not intefering with navigation on the right side.


### Testing Instructions
Apply patch
npm run build:css
Check if you can navigate on the dashboards even if coming close to the **closed** menu

### Expected result
Navigation works and you still can see what the icons mean.


### Actual result
If you come too close the the closed menu you can't navigate on the items behind, see the linked issue


<img width="360" alt="grafik" src="https://user-images.githubusercontent.com/828371/81499094-47dd7900-92c9-11ea-8254-578238f4cf6a.png">


