### PR TITLE
[4.0] Support multiple values for addfieldprefix and others.

### DIFF
--- a/libraries/src/Form/Form.php
+++ b/libraries/src/Form/Form.php
@@ -1679,7 +1679,7 @@ class Form
 		 *
 		 * @since 4.0
 		 */
-		$splitAndMerge = function($carry, $item)
+		$splitAndMerge = function ($carry, $item)
 		{
 			return array_merge($carry, explode(',', $item));
 		};

--- a/libraries/src/Form/Form.php
+++ b/libraries/src/Form/Form.php
@@ -1669,9 +1669,25 @@ class Form
 			throw new \UnexpectedValueException(sprintf('%s::%s `xml` is not an instance of SimpleXMLElement', \get_class($this), __METHOD__));
 		}
 
+		/**
+		 * Given an array and a string, splits the string at commas, and appends all fragments to the array.
+		 *
+		 * @param   string[]  $carry  Array containing strings.
+		 * @param   string    $item   String possibly containing comma-separated values
+		 *
+		 * @return string[]
+		 *
+		 * @since 4.0
+		 */
+		$splitAndMerge = function($carry, $item)
+		{
+			return array_merge($carry, explode(',', $item));
+		};
+
 		// Get any addfieldpath attributes from the form definition.
 		$paths = $this->xml->xpath('//*[@addfieldpath]/@addfieldpath');
 		$paths = array_map('strval', $paths ? $paths : array());
+		$paths = array_reduce($paths, $splitAndMerge, array());
 
 		// Add the field paths.
 		foreach ($paths as $path)
@@ -1683,6 +1699,7 @@ class Form
 		// Get any addformpath attributes from the form definition.
 		$paths = $this->xml->xpath('//*[@addformpath]/@addformpath');
 		$paths = array_map('strval', $paths ? $paths : array());
+		$paths = array_reduce($paths, $splitAndMerge, array());
 
 		// Add the form paths.
 		foreach ($paths as $path)
@@ -1694,6 +1711,7 @@ class Form
 		// Get any addrulepath attributes from the form definition.
 		$paths = $this->xml->xpath('//*[@addrulepath]/@addrulepath');
 		$paths = array_map('strval', $paths ? $paths : array());
+		$paths = array_reduce($paths, $splitAndMerge, array());
 
 		// Add the rule paths.
 		foreach ($paths as $path)
@@ -1705,6 +1723,7 @@ class Form
 		// Get any addrulepath attributes from the form definition.
 		$paths = $this->xml->xpath('//*[@addfilterpath]/@addfilterpath');
 		$paths = array_map('strval', $paths ? $paths : array());
+		$paths = array_reduce($paths, $splitAndMerge, array());
 
 		// Add the rule paths.
 		foreach ($paths as $path)
@@ -1716,6 +1735,7 @@ class Form
 		// Get any addfieldprefix attributes from the form definition.
 		$prefixes = $this->xml->xpath('//*[@addfieldprefix]/@addfieldprefix');
 		$prefixes = array_map('strval', $prefixes ? $prefixes : array());
+		$prefixes = array_reduce($prefixes, $splitAndMerge, array());
 
 		// Add the field prefixes.
 		foreach ($prefixes as $prefix)
@@ -1726,6 +1746,7 @@ class Form
 		// Get any addformprefix attributes from the form definition.
 		$prefixes = $this->xml->xpath('//*[@addformprefix]/@addformprefix');
 		$prefixes = array_map('strval', $prefixes ? $prefixes : array());
+		$prefixes = array_reduce($prefixes, $splitAndMerge, array());
 
 		// Add the field prefixes.
 		foreach ($prefixes as $prefix)
@@ -1736,6 +1757,7 @@ class Form
 		// Get any addruleprefix attributes from the form definition.
 		$prefixes = $this->xml->xpath('//*[@addruleprefix]/@addruleprefix');
 		$prefixes = array_map('strval', $prefixes ? $prefixes : array());
+		$prefixes = array_reduce($prefixes, $splitAndMerge, array());
 
 		// Add the field prefixes.
 		foreach ($prefixes as $prefix)
@@ -1746,6 +1768,7 @@ class Form
 		// Get any addruleprefix attributes from the form definition.
 		$prefixes = $this->xml->xpath('//*[@addfilterprefix]/@addfilterprefix');
 		$prefixes = array_map('strval', $prefixes ? $prefixes : array());
+		$prefixes = array_reduce($prefixes, $splitAndMerge, array());
 
 		// Add the field prefixes.
 		foreach ($prefixes as $prefix)


### PR DESCRIPTION
Form definitions in XML allow the usage of `add(field|form|filter|rule)(path|prefix)` to add form fields, forms, filters and rules from specified paths. Right now, this only works for single values. This means, if you want to import fields from two different locations, you need to specify them for example like this:

```XML
<fields name="params" addfieldpath="path/to/first/fields">
  <fieldset name="basic" addfieldpath="path/to/second/fields">
```
This separation of the two paths is not logically motivated. Second, it introduces a limitation on the number of paths you can add. If you have a structure `form > fields > fieldset`, you can enter at most three paths. To add more, you'd have to introduce empty dummy fieldsets at the end of the file.

### Summary of Changes
This PR introduces the possibility to add multiple paths in a single argument, separated by comma. This reduces the above example to:

```XML
<fields name="params">
  <fieldset name="basic" addfieldpath="path/to/first/fields,path/to/second/fields">
```

### Testing Instructions
1. Make sure all forms using `addfieldpath`, `addfieldprefix`, `addfilterpath`, `addfilterprefix`, `addformpath`, `addformprefix`, `addrulepath`, and `addruleprefix` still work as before.
2. Either write your own forms using two values for these attributes, or use the plugins I wrote:

### Demo Plugins
I wrote https://github.com/Harmageddon/plg_demo_addfieldpath and https://github.com/Harmageddon/plg_demo_addfieldprefix for testing. As they use cross-references between each other, both need to be installed at the same time.

#### plg_demo_addfieldpath
This plugin aims to test the add*path functionalities. The form should contain the following fields:
- An article modal field to test the first value of `addfieldpath`.
- A menu item modal field to test the second value of `addfieldpath`.
- A "Filter and Rule test" field that requires an "a" to be entered by the rule. The filter converts text from lower to upper case. This tests the first value of `addfilterpath` and `addrulepath`.
- A "Filter and Rule test 2" field that requires a "b" to be entered by the rule. The filter converts text from upper to lower case. This tests the second value of `addfilterpath` and `addrulepath`.
- Two subform fields, one with color values and one with numbers to test both values for `addformpath`.

#### plg_demo_addfieldprefix
This plugin aims to test the add*prefix functionalities. The form should contain the following fields:
- An article modal field to test the first value of `addfieldprefix`.
- A menu item modal field to test the first value of `addfieldprefix`.
- A "Filter and Rule test" field that requires a number to be entered by the rule. The filter converts text from lower to upper case. This tests the first value of `addfilterprefix` and `addruleprefix`.
- A "Filter and Rule test 2" field that requires an "a" to be entered by the rule. The filter converts text from upper to lower case. This tests the second value of `addfilterprefix` and `addruleprefix`.

I couldn't find any usage of `addformprefix`, so if someone has an idea how to test this, I'm open for suggestions.

### Documentation Changes Required
Could be noted at https://docs.joomla.org/Creating_a_custom_form_field_type#Linked_with_a_form or https://docs.joomla.org/Advanced_form_guide.
