### PR TITLE
Only add count as suffix if it's a real plural

### DIFF
--- a/libraries/src/Language/Text.php
+++ b/libraries/src/Language/Text.php
@@ -217,7 +217,13 @@ class Text
 		// Try the key from the language plural potential suffixes
 		$found = false;
 		$suffixes = $lang->getPluralSuffixes((int) $n);
-		array_unshift($suffixes, (int) $n);
+
+		// Add the count as possible suffix to allow for eg "a dozen" with suffix _12.
+		// Only do that if it is a real plural (more than one) to avoid issues with languages. See https://github.com/joomla/joomla-cms/pull/29029
+		if ($count != 1)
+		{
+			array_unshift($suffixes, (int) $n);
+		}
 
 		foreach ($suffixes as $suffix)
 		{

--- a/libraries/src/Language/Text.php
+++ b/libraries/src/Language/Text.php
@@ -220,7 +220,7 @@ class Text
 
 		// Add the count as possible suffix to allow for eg "a dozen" with suffix _12.
 		// Only do that if it is a real plural (more than one) to avoid issues with languages. See https://github.com/joomla/joomla-cms/pull/29029
-		if ($count != 1)
+		if ($n != 1)
 		{
 			array_unshift($suffixes, (int) $n);
 		}


### PR DESCRIPTION
In Crowdin, we changed how the plural suffixes are processed to avoid clashing with the special feature in our Text::plural() method that is first checking with the actual count as suffix.
Eg with 12 items it first looks for a string with the suffix _12 and only if not found it looks for suffixes as specified in the active language pack.

See some explanation also here: https://github.com/joomla/joomla-cms/pull/28763

Now this had created an unexpected issue: Since we always load the en-GB files as fallback, that means we always have the en-GB plural forms loaded as well and they don't get overwritten with the active language strings since those use different suffixes (string based, eg _ONE, _OTHER) now.

Since english happily only has two plural forms, we only get an issue with the singular suffix ("_1").

### Summary of Changes
This PR changes the behavior so a single count (1) doesn't get added to the potential suffixes ("_1").

This is a small B/C in theory. But in practice I don't see a use case where someone would add a special string for "one item" that is different from the regular singular plural form.
There are languages like french which share the same form for zero and one item, but those are differentiated already since we often use a specific "_0" suffix ("No items ..." instead of "0 items"). So that absolutely still works.

### Testing Instructions
Use a language pack from Crowdin (eg the Welsh one) and check if the singular form works as expected. A simple test can be done by looking at the status module


### Expected result
![image](https://user-images.githubusercontent.com/1018684/81508981-be00d080-9307-11ea-9471-2d4f4b912c32.png)



### Actual result
![image](https://user-images.githubusercontent.com/1018684/81509018-01f3d580-9308-11ea-8c9d-46fc594ad122.png)


### Documentation Changes Required
None