### PR TITLE
[4.0] Add Cross-Origin-Opener-Policy to the HTTP Headers Plugin

### DIFF
--- a/administrator/language/en-GB/plg_system_httpheaders.ini
+++ b/administrator/language/en-GB/plg_system_httpheaders.ini
@@ -9,6 +9,8 @@ PLG_SYSTEM_HTTPHEADERS_ADDITIONAL_HEADER="Force HTTP Headers"
 ; Please do not translate the word 'HTTP Header' in the following two language strings
 PLG_SYSTEM_HTTPHEADERS_ADDITIONAL_HEADER_KEY="HTTP Header"
 PLG_SYSTEM_HTTPHEADERS_ADDITIONAL_HEADER_VALUE="HTTP Header Value"
+; Please do not translate the following language string
+PLG_SYSTEM_HTTPHEADERS_COOP="Cross-Origin-Opener-Policy"
 PLG_SYSTEM_HTTPHEADERS_HEADER_CLIENT="Client"
 PLG_SYSTEM_HTTPHEADERS_HEADER_CLIENT_BOTH="Both"
 ; Please do not translate the following language string

--- a/plugins/system/httpheaders/httpheaders.php
+++ b/plugins/system/httpheaders/httpheaders.php
@@ -78,6 +78,7 @@ class PlgSystemHttpHeaders extends CMSPlugin implements SubscriberInterface
 		'referrer-policy',
 		'expect-ct',
 		'feature-policy',
+		'cross-origin-opener-policy',
 	];
 
 	/**
@@ -473,6 +474,14 @@ class PlgSystemHttpHeaders extends CMSPlugin implements SubscriberInterface
 		if ($referrerPolicy !== 'disabled')
 		{
 			$staticHeaderConfiguration['referrer-policy#both'] = $referrerPolicy;
+		}
+
+		// Cross-Origin-Opener-Policy
+		$coop = (string) $this->params->get('coop', 'same-origin');
+
+		if ($coop !== 'disabled')
+		{
+			$staticHeaderConfiguration['cross-origin-opener-policy#both'] = $coop;
 		}
 
 		// Generate the strict-transport-security header

--- a/plugins/system/httpheaders/httpheaders.xml
+++ b/plugins/system/httpheaders/httpheaders.xml
@@ -46,6 +46,19 @@
 					<option value="unsafe-url">unsafe-url</option>
 				</field>
 				<field
+					name="coop"
+					type="list"
+					label="PLG_SYSTEM_HTTPHEADERS_COOP"
+					default="same-origin"
+					validate="options"
+					>
+					<option value="disabled">JDISABLED</option>
+					<option value="same-origin">same-origin</option>
+					<option value="same-origin-allow-popups">same-origin-allow-popups</option>
+					<option value="unsafe-none">unsafe-none</option>
+				</field>
+
+				<field
 					name="additional_httpheader"
 					type="subform"
 					label="PLG_SYSTEM_HTTPHEADERS_ADDITIONAL_HEADER"
@@ -66,6 +79,7 @@
 							<option value="referrer-policy">Referrer-Policy</option>
 							<option value="expect-ct">Expect-CT</option>
 							<option value="feature-policy">Feature-Policy</option>
+							<option value="cross-origin-resource-policy">Cross-Origin-Resource-Policy</option>
 						</field>
 						<field
 							name="value"

--- a/plugins/system/httpheaders/httpheaders.xml
+++ b/plugins/system/httpheaders/httpheaders.xml
@@ -79,7 +79,7 @@
 							<option value="referrer-policy">Referrer-Policy</option>
 							<option value="expect-ct">Expect-CT</option>
 							<option value="feature-policy">Feature-Policy</option>
-							<option value="cross-origin-resource-policy">Cross-Origin-Resource-Policy</option>
+							<option value="cross-origin-opener-policy">Cross-Origin-Opener-Policy</option>
 						</field>
 						<field
 							name="value"


### PR DESCRIPTION
### Summary of Changes

Add the upcoming [Cross-Origin-Opener-Policy](https://www.chromestatus.com/feature/5432089535053824) to the HTTP Headers Plugin.

### Testing Instructions

- install 4.0-dev
- check the http headers set in the browser console
- Apply the patch
- check the http headers set in the browser console

### Expected result

We set Cross-Origin-Opener-Policy to same-origin by default

### Actual result

We don't set Cross-Origin-Opener-Policy

### Documentation Changes Required

- [x] https://docs.joomla.org/J4.x:Http_Header_Management - has to be updated