### PR TITLE
[4.0] Atum closed sidebar hover fix (alternate)

### DIFF
--- a/administrator/templates/atum/scss/blocks/_sidebar.scss
+++ b/administrator/templates/atum/scss/blocks/_sidebar.scss
@@ -176,6 +176,10 @@
     max-width: $sidebar-width-closed;
   }
 
+  .main-nav {
+    max-width: $sidebar-width-closed;
+  }
+
   .sidebar-item-title,
   .has-arrow::after,
   .menu-dashboard {


### PR DESCRIPTION
Quick alternate proposal that resolves the reported issue.

my scss is not very good so I may have put this in the wrong place

original pr at #28840 and original proposed fix and discussion #29023 

### sidebar open
![open](https://user-images.githubusercontent.com/1296369/81610956-32a04180-93d2-11ea-84eb-a2e71f5fa107.gif)


### sidebar closed
![closed](https://user-images.githubusercontent.com/1296369/81610943-2fa55100-93d2-11ea-8a67-b0b10a071396.gif)
