### PR TITLE
[4.0] Fix badge for removed item in changelog

### DIFF
--- a/layouts/joomla/installer/changelog.php
+++ b/layouts/joomla/installer/changelog.php
@@ -37,7 +37,7 @@ array_walk(
 			case 'change':
 				$class = 'badge-warning';
 				break;
-			case 'removed':
+			case 'remove':
 				$class = 'badge-light';
 				break;
 			default:


### PR DESCRIPTION
### Summary of Changes

According to the [Documentation](https://docs.joomla.org/Adding_changelog_to_your_manifest_file), this is the syntax for removed items in the changelog:

```
<remove>
    <item>Item A</item>
    <item>Item b</item>
</remove>
```

However when the layout if detecting the type, it's not correctly assigning the badge class to removed items, becuase it searching for `removed` as opposed to `remove`.

### Testing Instructions

Code review
