### PR TITLE
[4.0] Remove missing argument handling

### DIFF
--- a/libraries/src/Language/Text.php
+++ b/libraries/src/Language/Text.php
@@ -272,11 +272,6 @@ class Text
 		$args = \func_get_args();
 		$count = \count($args);
 
-		if ($count < 1)
-		{
-			return '';
-		}
-
 		if (\is_array($args[$count - 1]))
 		{
 			$args[0] = $lang->_(
@@ -318,11 +313,6 @@ class Text
 		$lang = Factory::getLanguage();
 		$args = \func_get_args();
 		$count = \count($args);
-
-		if ($count < 1)
-		{
-			return '';
-		}
 
 		if (\is_array($args[$count - 1]))
 		{

--- a/libraries/src/Language/Text.php
+++ b/libraries/src/Language/Text.php
@@ -201,19 +201,6 @@ class Text
 		$args = \func_get_args();
 		$count = \count($args);
 
-		if ($count < 1)
-		{
-			return '';
-		}
-
-		if ($count == 1)
-		{
-			// Default to the normal sprintf handling.
-			$args[0] = $lang->_($string);
-
-			return \call_user_func_array('sprintf', $args);
-		}
-
 		// Try the key from the language plural potential suffixes
 		$found = false;
 		$suffixes = $lang->getPluralSuffixes((int) $n);


### PR DESCRIPTION
### Summary of Changes

Removes missing argument handling in `Joomla\CMS\Language\Text` methods. Since PHP 7.1 calling functions with missing arguments throws `ArgumentCountError`. So this code is never executed anymore.

### Testing Instructions

Code review or test that the methods still work.

### Documentation Changes Required

No.