### PR TITLE
Add CSRF prevention to com_postinstall

### DIFF
--- a/administrator/components/com_postinstall/controllers/message.php
+++ b/administrator/components/com_postinstall/controllers/message.php
@@ -25,6 +25,9 @@ class PostinstallControllerMessage extends FOFController
 	 */
 	public function reset()
 	{
+		// CSRF prevention.
+		$this->_csrfProtection();
+
 		/** @var PostinstallModelMessages $model */
 		$model = $this->getThisModel();
 
@@ -49,6 +52,9 @@ class PostinstallControllerMessage extends FOFController
 	 */
 	public function hideAll()
 	{
+		// CSRF prevention.
+		$this->_csrfProtection();
+
 		/** @var PostinstallModelMessages $model */
 		$model = $this->getThisModel();
 
@@ -74,10 +80,7 @@ class PostinstallControllerMessage extends FOFController
 	public function action()
 	{
 		// CSRF prevention.
-		if ($this->csrfProtection)
-		{
-			$this->_csrfProtection();
-		}
+		$this->_csrfProtection();
 
 		$model = $this->getThisModel();
 

--- a/administrator/components/com_postinstall/views/messages/tmpl/default.php
+++ b/administrator/components/com_postinstall/views/messages/tmpl/default.php
@@ -35,6 +35,7 @@ JHtml::_('formbehavior.chosen', 'select');
 <form action="index.php" method="post" name="adminForm" class="form-inline" id="adminForm">
 	<input type="hidden" name="option" value="com_postinstall">
 	<input type="hidden" name="task" value="">
+	<?php echo JHtml::_('form.token'); ?>
 	<label for="eid"><?php echo JText::_('COM_POSTINSTALL_MESSAGES_FOR'); ?></label>
 	<?php echo JHtml::_('select.genericlist', $this->extension_options, 'eid', array('onchange' => 'this.form.submit()', 'class' => 'input-xlarge'), 'value', 'text', $this->eid, 'eid'); ?>
 </form>


### PR DESCRIPTION
### Summary of Changes

Add CSRF prevention to com_postinstall

### Testing Instructions

- login to the backend
- go to com_postinstall
- make sure the "reset all messages" button works
- make sure the "hide all messages" button works
- use the "activate 2fa action" button and make sure it still works too

### Expected result

All buttons have csrf protection

### Actual result

Two buttons did not had an csrf protection.

### Documentation Changes Required

none

Original report to the JSST by Khoa Bùi Đức Anh