### PR TITLE
[4.0]UserHelper addUserToGroup not working

### DIFF
--- a/libraries/src/User/UserHelper.php
+++ b/libraries/src/User/UserHelper.php
@@ -126,7 +126,10 @@ abstract class UserHelper
 
 			// Add the group data to the user object.
 			$user->groups[$groupId] = $groupId;
-
+			
+			// Reindex the array for prepared statements binding
+			$user->groups = array_values($user->groups);
+			
 			// Store the user object.
 			$user->save();
 		}

--- a/libraries/src/User/UserHelper.php
+++ b/libraries/src/User/UserHelper.php
@@ -126,10 +126,10 @@ abstract class UserHelper
 
 			// Add the group data to the user object.
 			$user->groups[$groupId] = $groupId;
-			
+
 			// Reindex the array for prepared statements binding
 			$user->groups = array_values($user->groups);
-			
+
 			// Store the user object.
 			$user->save();
 		}


### PR DESCRIPTION
The addUserToGroup doesn't work because the 'whereIn' method in Joomla\CMS\Table\User->bind() uses prepared statements based on zero-indexed array

### Testing Instructions
Use the function UserHelper addUserToGroup with a user ID and a user group ID

### Expected result
The user is assigned to the group


### Actual result
The user is not assigned to the group


### Documentation Changes Required
Nope
