### PR TITLE
[4.0] Add Cross-Origin-Embedder-Policy header to the core htaccess and web.config.txt

### DIFF
--- a/htaccess.txt
+++ b/htaccess.txt
@@ -32,8 +32,10 @@ Header always set X-Content-Type-Options "nosniff"
 
 ## Protect against certain cross-origin requests. More information can be found here:
 ## https://developer.mozilla.org/en-US/docs/Web/HTTP/Cross-Origin_Resource_Policy_(CORP)
+## https://web.dev/why-coop-coep/
 #<IfModule mod_headers.c>
 #Header always set Cross-Origin-Resource-Policy "same-origin"
+#Header always set Cross-Origin-Embedder-Policy "require-corp"
 #</IfModule>
 
 ## These directives are only enabled if the Apache mod_rewrite module is enabled

--- a/web.config.txt
+++ b/web.config.txt
@@ -31,9 +31,9 @@
                <add name="X-Content-Type-Options" value="nosniff" />
                <!-- Protect against certain cross-origin requests. More information can be found here: -->
                <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/Cross-Origin_Resource_Policy_(CORP) -->
-					<!-- https://web.dev/why-coop-coep/ -->
+               <!-- https://web.dev/why-coop-coep/ -->
                <!-- <add name="Cross-Origin-Resource-Policy" value="same-origin" /> -->
-					<!-- <add name="Cross-Origin-Embedder-Policy" value="require-corp" /> -->
+               <!-- <add name="Cross-Origin-Embedder-Policy" value="require-corp" /> -->
            </customHeaders>
        </httpProtocol>
    </system.webServer>

--- a/web.config.txt
+++ b/web.config.txt
@@ -31,7 +31,9 @@
                <add name="X-Content-Type-Options" value="nosniff" />
                <!-- Protect against certain cross-origin requests. More information can be found here: -->
                <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/Cross-Origin_Resource_Policy_(CORP) -->
+					<!-- https://web.dev/why-coop-coep/ -->
                <!-- <add name="Cross-Origin-Resource-Policy" value="same-origin" /> -->
+					<!-- <add name="Cross-Origin-Embedder-Policy" value="require-corp" /> -->
            </customHeaders>
        </httpProtocol>
    </system.webServer>


### PR DESCRIPTION
### Summary of Changes

Add Cross-Origin-Embedder-Policy header to the core htaccess and web.config.txt. As this is connected to Cross-Origin Resource Policy (CORP) I think we should do it the same like CORP and add it is to the suggested header so it can be enabled by the people knowing what they do ;)

More details on that can be found here: https://web.dev/why-coop-coep/

### Testing Instructions

Code review ;) As no active file has been touched here.

### Expected result

We add the Cross-Origin-Embedder-Policy header

### Actual result

The Cross-Origin-Embedder-Policy header is missing

### Documentation Changes Required

This should be documented here: https://docs.joomla.org/J4.x:Http_Header_Management and i'm happy to do is so assigned it to me and adding the docs label.