### PR TITLE
[4.0] Template Atum - Improve appereance of backend icons

### DIFF
--- a/administrator/templates/atum/scss/blocks/_global.scss
+++ b/administrator/templates/atum/scss/blocks/_global.scss
@@ -169,8 +169,10 @@ body .container-main {
 
 // extern links with icons
 a[target="_blank"]::before {
-  font: normal normal normal 14px/1 'Font Awesome 5 Free';
-  content: "\f35d  ";
+  font-family: "Font Awesome 5 Free";
+  font-size: 14px;
+  font-weight: 900;
+  content: "\f35d";
 }
 
 #wrapper {

--- a/administrator/templates/atum/scss/blocks/_icons.scss
+++ b/administrator/templates/atum/scss/blocks/_icons.scss
@@ -50,7 +50,8 @@
     border-color: var(--success);
   }
 
-  .icon-featured {
+  .icon-featured,
+  .icon-color-featured {
     color: $state-warning-bg;
     border-color: $state-warning-bg;
   }
@@ -70,7 +71,9 @@
   }
 
   &.home-disabled,
-  &.featured-disabled {
+  &.featured-disabled,
+  &.color-featured-disabled,
+  &.fa-star-disabled {
     opacity: 1;
     cursor: not-allowed;
   }

--- a/administrator/templates/atum/scss/blocks/_icons.scss
+++ b/administrator/templates/atum/scss/blocks/_icons.scss
@@ -69,7 +69,8 @@
     border: 0;
   }
 
-  &.home-disabled {
+  &.home-disabled,
+  &.featured-disabled {
     opacity: 1;
     cursor: not-allowed;
   }

--- a/administrator/templates/atum/scss/blocks/_sidebar.scss
+++ b/administrator/templates/atum/scss/blocks/_sidebar.scss
@@ -132,6 +132,7 @@
       justify-content: center;
       width: 2rem;
       font-family: "Font Awesome 5 Free";
+      font-weight: 900;
 
       [dir="ltr"] & {
         content: "\f054";

--- a/administrator/templates/atum/scss/blocks/_toolbar.scss
+++ b/administrator/templates/atum/scss/blocks/_toolbar.scss
@@ -90,6 +90,7 @@
         font-family: "Font Awesome 5 Free";
         content: "\f078";
         border: 0;
+        font-weight: 900;
       }
     }
 

--- a/administrator/templates/atum/scss/vendor/fontawesome-free/fontawesome.scss
+++ b/administrator/templates/atum/scss/vendor/fontawesome-free/fontawesome.scss
@@ -3,6 +3,7 @@ $fa-font-path: "../../../../../../media/vendor/fontawesome-free/webfonts" !defau
 
 
 // Font Awesome 5 Free
+@import "../../../../../../media/vendor/fontawesome-free/scss/regular";
 @import "../../../../../../media/vendor/fontawesome-free/scss/solid";
 @import "../../../../../../media/vendor/fontawesome-free/scss/brands";
 @import "../../../../../../media/vendor/fontawesome-free/scss/fontawesome";

--- a/build/media_source/system/scss/_icomoon.scss
+++ b/build/media_source/system/scss/_icomoon.scss
@@ -12,10 +12,13 @@
   font-family: "Font Awesome 5 Free";
   font-style: normal;
   speak: none;
+  font-weight: 900;
 }
 [class^="icon-"].disabled,
-[class*=" icon-"].disabled {
-  font-weight: 900;
+[class*=" icon-"].disabled,
+[class^="far"]::before,
+[class*=" far"]::before {
+  font-weight: 400;
 }
 
 .icon-generic::before {

--- a/libraries/src/Button/FeaturedButton.php
+++ b/libraries/src/Button/FeaturedButton.php
@@ -29,8 +29,8 @@ class FeaturedButton extends ActionButton
 	 */
 	protected function preprocess()
 	{
-		$this->addState(0, 'articles.featured', 'unfeatured', Text::_('COM_CONTENT_UNFEATURED'), ['tip_title' => Text::_('JGLOBAL_TOGGLE_FEATURED')]);
-		$this->addState(1, 'articles.unfeatured', 'featured', Text::_('COM_CONTENT_FEATURED'), ['tip_title' => Text::_('JGLOBAL_TOGGLE_FEATURED')]);
+		$this->addState(0, 'articles.featured', 'color-unfeatured far fa-star', Text::_('COM_CONTENT_UNFEATURED'), ['tip_title' => Text::_('JGLOBAL_TOGGLE_FEATURED')]);
+		$this->addState(1, 'articles.unfeatured', 'color-featured fas fa-star', Text::_('COM_CONTENT_FEATURED'), ['tip_title' => Text::_('JGLOBAL_TOGGLE_FEATURED')]);
 	}
 
 	/**

--- a/libraries/src/Button/FeaturedButton.php
+++ b/libraries/src/Button/FeaturedButton.php
@@ -30,11 +30,11 @@ class FeaturedButton extends ActionButton
 	protected function preprocess()
 	{
 		$this->addState(0, 'articles.featured', 'color-unfeatured far fa-star', 
-				Text::_('COM_CONTENT_UNFEATURED'), ['tip_title' => Text::_('JGLOBAL_TOGGLE_FEATURED')]
-			       );
+			Text::_('COM_CONTENT_UNFEATURED'), ['tip_title' => Text::_('JGLOBAL_TOGGLE_FEATURED')]
+		);
 		$this->addState(1, 'articles.unfeatured', 'color-featured fas fa-star', 
-				Text::_('COM_CONTENT_FEATURED'), ['tip_title' => Text::_('JGLOBAL_TOGGLE_FEATURED')]
-			       );
+			Text::_('COM_CONTENT_FEATURED'), ['tip_title' => Text::_('JGLOBAL_TOGGLE_FEATURED')]
+		);
 	}
 
 	/**

--- a/libraries/src/Button/FeaturedButton.php
+++ b/libraries/src/Button/FeaturedButton.php
@@ -29,8 +29,10 @@ class FeaturedButton extends ActionButton
 	 */
 	protected function preprocess()
 	{
-		$this->addState(0, 'articles.featured', 'color-unfeatured far fa-star', Text::_('COM_CONTENT_UNFEATURED'), ['tip_title' => Text::_('JGLOBAL_TOGGLE_FEATURED')]);
-		$this->addState(1, 'articles.unfeatured', 'color-featured fas fa-star', Text::_('COM_CONTENT_FEATURED'), ['tip_title' => Text::_('JGLOBAL_TOGGLE_FEATURED')]);
+		$this->addState(0, 'articles.featured', 'color-unfeatured far fa-star', 
+				Text::_('COM_CONTENT_UNFEATURED'), ['tip_title' => Text::_('JGLOBAL_TOGGLE_FEATURED')]);
+		$this->addState(1, 'articles.unfeatured', 'color-featured fas fa-star', 
+				Text::_('COM_CONTENT_FEATURED'), ['tip_title' => Text::_('JGLOBAL_TOGGLE_FEATURED')]);
 	}
 
 	/**

--- a/libraries/src/Button/FeaturedButton.php
+++ b/libraries/src/Button/FeaturedButton.php
@@ -29,10 +29,10 @@ class FeaturedButton extends ActionButton
 	 */
 	protected function preprocess()
 	{
-		$this->addState(0, 'articles.featured', 'color-unfeatured far fa-star', 
+		$this->addState(0, 'articles.featured', 'color-unfeatured far fa-star',
 			Text::_('COM_CONTENT_UNFEATURED'), ['tip_title' => Text::_('JGLOBAL_TOGGLE_FEATURED')]
 		);
-		$this->addState(1, 'articles.unfeatured', 'color-featured fas fa-star', 
+		$this->addState(1, 'articles.unfeatured', 'color-featured fas fa-star',
 			Text::_('COM_CONTENT_FEATURED'), ['tip_title' => Text::_('JGLOBAL_TOGGLE_FEATURED')]
 		);
 	}

--- a/libraries/src/Button/FeaturedButton.php
+++ b/libraries/src/Button/FeaturedButton.php
@@ -30,9 +30,11 @@ class FeaturedButton extends ActionButton
 	protected function preprocess()
 	{
 		$this->addState(0, 'articles.featured', 'color-unfeatured far fa-star', 
-				Text::_('COM_CONTENT_UNFEATURED'), ['tip_title' => Text::_('JGLOBAL_TOGGLE_FEATURED')]);
+				Text::_('COM_CONTENT_UNFEATURED'), ['tip_title' => Text::_('JGLOBAL_TOGGLE_FEATURED')]
+			       );
 		$this->addState(1, 'articles.unfeatured', 'color-featured fas fa-star', 
-				Text::_('COM_CONTENT_FEATURED'), ['tip_title' => Text::_('JGLOBAL_TOGGLE_FEATURED')]);
+				Text::_('COM_CONTENT_FEATURED'), ['tip_title' => Text::_('JGLOBAL_TOGGLE_FEATURED')]
+			       );
 	}
 
 	/**

--- a/libraries/src/HTML/Helpers/JGrid.php
+++ b/libraries/src/HTML/Helpers/JGrid.php
@@ -272,7 +272,7 @@ abstract class JGrid
 	 * @see     JHtmlJGrid::state()
 	 * @since   1.6
 	 */
-	public static function isdefault($value, $i, $prefix = '', $enabled = true, $checkbox = 'cb', $formId = null, $active_class = 'featured', $inactive_class = 'unfeatured')
+	public static function isdefault($value, $i, $prefix = '', $enabled = true, $checkbox = 'cb', $formId = null, $active_class = 'color-featured fas fa-star', $inactive_class = 'color-unfeatured far fa-star')
 	{
 		if (is_array($prefix))
 		{


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/pull/29016#issuecomment-626482419

cc @infograf768 

### Summary of Changes
Changed Opacity of featured icons when they are in disabled state, 
changed cursor to not-allow to still demonstrate that there is no change possible
Added Font Awesome regular to backend to make a difference between the icon states

### Testing Instructions
apply patch
npm run build:css
check in template styles and in content languages that the featured Icon is now with full opacity
Featured Icons have now a solid background star
Unfeatured Icons have now an outline star

### Expected result
![grafik](https://user-images.githubusercontent.com/828371/81928386-74550600-95e5-11ea-8ff1-221938a36c48.png)

