### PR TITLE
Fix TagsHelper::createTagsFromField() method to set parent_id for newTags. Add Rebuild Button to tags manager

### DIFF
--- a/administrator/components/com_postinstall/controllers/message.php
+++ b/administrator/components/com_postinstall/controllers/message.php
@@ -25,6 +25,9 @@ class PostinstallControllerMessage extends FOFController
 	 */
 	public function reset()
 	{
+		// CSRF prevention.
+		$this->_csrfProtection();
+
 		/** @var PostinstallModelMessages $model */
 		$model = $this->getThisModel();
 
@@ -49,6 +52,9 @@ class PostinstallControllerMessage extends FOFController
 	 */
 	public function hideAll()
 	{
+		// CSRF prevention.
+		$this->_csrfProtection();
+
 		/** @var PostinstallModelMessages $model */
 		$model = $this->getThisModel();
 
@@ -74,10 +80,7 @@ class PostinstallControllerMessage extends FOFController
 	public function action()
 	{
 		// CSRF prevention.
-		if ($this->csrfProtection)
-		{
-			$this->_csrfProtection();
-		}
+		$this->_csrfProtection();
 
 		$model = $this->getThisModel();
 

--- a/administrator/components/com_postinstall/views/messages/tmpl/default.php
+++ b/administrator/components/com_postinstall/views/messages/tmpl/default.php
@@ -35,6 +35,7 @@ JHtml::_('formbehavior.chosen', 'select');
 <form action="index.php" method="post" name="adminForm" class="form-inline" id="adminForm">
 	<input type="hidden" name="option" value="com_postinstall">
 	<input type="hidden" name="task" value="">
+	<?php echo JHtml::_('form.token'); ?>
 	<label for="eid"><?php echo JText::_('COM_POSTINSTALL_MESSAGES_FOR'); ?></label>
 	<?php echo JHtml::_('select.genericlist', $this->extension_options, 'eid', array('onchange' => 'this.form.submit()', 'class' => 'input-xlarge'), 'value', 'text', $this->eid, 'eid'); ?>
 </form>

--- a/administrator/components/com_tags/views/tags/view.html.php
+++ b/administrator/components/com_tags/views/tags/view.html.php
@@ -127,6 +127,11 @@ class TagsViewTags extends JViewLegacy
 			$bar->appendButton('Custom', $dhtml, 'batch');
 		}
 
+		if ($canDo->get('core.admin'))
+		{
+			JToolbarHelper::custom('tags.rebuild', 'refresh.png', 'refresh_f2.png', 'JTOOLBAR_REBUILD', false);
+		}
+
 		if ($state->get('filter.published') == -2 && $canDo->get('core.delete'))
 		{
 			JToolbarHelper::deleteList('JGLOBAL_CONFIRM_DELETE', 'tags.delete', 'JTOOLBAR_EMPTY_TRASH');

--- a/components/com_users/controllers/registration.php
+++ b/components/com_users/controllers/registration.php
@@ -75,7 +75,7 @@ class UsersControllerRegistration extends UsersController
 		if (($uParams->get('useractivation') == 2) && $userToActivate->getParam('activate', 0))
 		{
 			// If a user admin is not logged in, redirect them to the login page with an error message
-			if (!$user->authorise('core.create', 'com_users'))
+			if (!$user->authorise('core.create', 'com_users') || !$user->authorise('core.manage', 'com_users'))
 			{
 				$activationUrl = 'index.php?option=com_users&task=registration.activate&token=' . $token;
 				$loginUrl      = 'index.php?option=com_users&view=login&return=' . base64_encode($activationUrl);

--- a/components/com_users/models/registration.php
+++ b/components/com_users/models/registration.php
@@ -170,7 +170,7 @@ class UsersModelRegistration extends JModelForm
 			{
 				$usercreator = JFactory::getUser($row->id);
 
-				if ($usercreator->authorise('core.create', 'com_users'))
+				if ($usercreator->authorise('core.create', 'com_users') && $usercreator->authorise('core.manage', 'com_users'))
 				{
 					$return = JFactory::getMailer()->sendMail($data['mailfrom'], $data['fromname'], $row->email, $emailSubject, $emailBody);
 

--- a/libraries/src/Helper/TagsHelper.php
+++ b/libraries/src/Helper/TagsHelper.php
@@ -249,6 +249,7 @@ class TagsHelper extends CMSHelper
 						$tagTable->access = 1;
 
 						// Make this item a child of the root tag
+						$tagTable->parent_id = $tagTable->getRootId();
 						$tagTable->setLocation($tagTable->getRootId(), 'last-child');
 
 						// Try to store tag


### PR DESCRIPTION
Pull Request for Issue #29015 , #29033   ?? (i have not tested) (i have only tested by own extension)

### Summary of Changes
TagsHelper::createTagsFromField() is not setting
parent_id

But when not setting parent_id, 
- the DB 's default for the column parent_id is used, which is '0'

thus the tag is created with parent_id is 0 instead of the expected parent_id which is 1 (the id of the root record)

As said above in my case the tags were created with parent_id zero
NOTE: This PR does not fix the any tags already created with parent_id 0

### Testing Instructions



### Expected result



### Actual result



### Documentation Changes Required

