### PR TITLE
[4.0] Fix Batch categories Add to root missing in dropdown

### DIFF
--- a/administrator/components/com_categories/tmpl/categories/default_batch_body.php
+++ b/administrator/components/com_categories/tmpl/categories/default_batch_body.php
@@ -34,7 +34,7 @@ $extension = $this->escape($this->state->get('filter.extension'));
 		<?php if ($published >= 0) : ?>
 			<div class="form-group col-md-6">
 				<div class="controls">
-					<?php echo LayoutHelper::render('joomla.html.batch.item', ['extension' => $extension]); ?>
+					<?php echo LayoutHelper::render('joomla.html.batch.item', ['extension' => $extension, 'addRoot' => true]); ?>
 				</div>
 			</div>
 		<?php endif; ?>

--- a/layouts/joomla/html/batch/item.php
+++ b/layouts/joomla/html/batch/item.php
@@ -41,9 +41,9 @@ $wa->useScript('joomla.batch-language');
 		<option value=""><?php echo Text::_('JLIB_HTML_BATCH_NO_CATEGORY'); ?></option>
 		<?php if (isset($addRoot) && $addRoot) : ?>
 			<?php echo HTMLHelper::_('select.options', HTMLHelper::_('category.categories', $extension)); ?>
-		<?php else: ?>
+		<?php else : ?>
 			<?php echo HTMLHelper::_('select.options', HTMLHelper::_('category.options', $extension)); ?>
-		<?php endif ?>
+		<?php endif; ?>
 	</select>
 </div>
 <div id="batch-copy-move" class="control-group radio">

--- a/layouts/joomla/html/batch/item.php
+++ b/layouts/joomla/html/batch/item.php
@@ -39,7 +39,11 @@ $wa->useScript('joomla.batch-language');
 <div id="batch-choose-action" class="control-group">
 	<select name="batch[category_id]" class="custom-select" id="batch-category-id">
 		<option value=""><?php echo Text::_('JLIB_HTML_BATCH_NO_CATEGORY'); ?></option>
-		<?php echo HTMLHelper::_('select.options', HTMLHelper::_('category.options', $extension)); ?>
+		<?php if (isset($addRoot) && $addRoot) : ?>
+			<?php echo HTMLHelper::_('select.options', HTMLHelper::_('category.categories', $extension)); ?>
+		<?php else: ?>
+			<?php echo HTMLHelper::_('select.options', HTMLHelper::_('category.options', $extension)); ?>
+		<?php endif ?>
 	</select>
 </div>
 <div id="batch-copy-move" class="control-group radio">


### PR DESCRIPTION
PR thanks to code by @artur-stepien 

### Summary of Changes
In J4, batch categories is using the category.options method instead of category.categories one, therefore misses the possibility to move/copy to ROOT in the dropdown ( `Add to root` )
This is due to the use of the `joomla.html.batch.item` layout which does not differenciate between both cases.


### Testing Instructions
Select a category and click on the Actions=>batch in toolbar.
Display the dropdown for the field `To Move or Copy your selection please select a Category.`


### Before patch
<img width="457" alt="Screen Shot 2020-05-13 at 11 24 40" src="https://user-images.githubusercontent.com/869724/81795769-c70ebf00-950c-11ea-8ae9-5f5e1c7cb15f.png">


### After patch
<img width="422" alt="Screen Shot 2020-05-13 at 11 20 01" src="https://user-images.githubusercontent.com/869724/81795072-fa9d1980-950b-11ea-94c7-789925dd5f68.png">


### Note
The lang tag will be added when https://github.com/joomla/joomla-cms/pull/29003 makes its way into 3.9.x., 3.10 and then J4