### PR TITLE
[4.0] com_finder: Pull access levels from state

### DIFF
--- a/components/com_finder/src/Model/SearchModel.php
+++ b/components/com_finder/src/Model/SearchModel.php
@@ -138,7 +138,9 @@ class SearchModel extends ListModel
 
 		$query->from('#__finder_links AS l');
 
-		$query->where('l.access IN (' . implode(',', $this->getState('user.groups')) . ')')
+		$user = Factory::getUser();
+		$groups = $this->getState('user.groups', $user->getAuthorisedViewLevels());
+		$query->whereIn($db->quoteName('l.access'), $groups)
 			->where('l.state = 1')
 			->where('l.published = 1');
 

--- a/components/com_finder/src/Model/SearchModel.php
+++ b/components/com_finder/src/Model/SearchModel.php
@@ -124,10 +124,6 @@ class SearchModel extends ListModel
 	 */
 	protected function getListQuery()
 	{
-		// Get the current user for authorisation checks
-		$user = Factory::getUser();
-		$groups = implode(',', $user->getAuthorisedViewLevels());
-
 		// Create a new query object.
 		$db    = $this->getDbo();
 		$query = $db->getQuery(true);
@@ -142,7 +138,7 @@ class SearchModel extends ListModel
 
 		$query->from('#__finder_links AS l');
 
-		$query->where('l.access IN (' . $groups . ')')
+		$query->where('l.access IN (' . implode(',', $this->getState('user.groups')) . ')')
 			->where('l.state = 1')
 			->where('l.published = 1');
 


### PR DESCRIPTION
### Summary of Changes
The Smart Search component (com_finder) in the frontend was hardcoded to always use the view access levels from the current user and thus did not allow to override that when using the model in a different context. Since we are already populating the current state of the model with the view access levels of the current user, we might as well use them here directly.

### Testing Instructions
1. Have Smart Search setup correctly and add 2 articles, one for public users, one for registered users with similar content, so that you can have a matching search term in both articles.
2. Search for the matching term and see that you only get the public article.
3. Edit components/com_finder/src/Model/SearchModel.php line 489 and replace ```$user->getAuthorisedViewLevels()``` with ```[1,2]```. Search again and still only see the public article. Revert the code change.
4. Apply the patch and search for the term again, again only getting the public article.
5. Do the changes from step 3 again (the line has moved up a bit) and search again. Now you should get both articles.