### PR TITLE
[4.0] Force file type in Crowdin

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -4,6 +4,7 @@ files:
   - source: /administrator/language/en-GB/*.ini
     translation: /administrator/language/%locale%/%original_file_name%
     update_option: update_as_unapproved
+    type: ini
   - source: /administrator/language/en-GB/*.xml
     translation: /administrator/language/%locale%/%original_file_name%
     update_option: update_as_unapproved
@@ -15,6 +16,7 @@ files:
   - source: /api/language/en-GB/*.ini
     translation: /api/language/%locale%/%original_file_name%
     update_option: update_as_unapproved
+    type: ini
   - source: /api/language/en-GB/*.xml
     translation: /api/language/%locale%/%original_file_name%
     update_option: update_as_unapproved
@@ -22,6 +24,7 @@ files:
   - source: /language/en-GB/*.ini
     translation: /language/%locale%/%original_file_name%
     update_option: update_as_unapproved
+    type: ini
   - source: /language/en-GB/*.xml
     translation: /language/%locale%/%original_file_name%
     update_option: update_as_unapproved
@@ -33,6 +36,7 @@ files:
   - source: /installation/language/en-GB/joomla.ini
     translation: /installation/language/%locale%/joomla.ini
     update_option: update_as_unapproved
+    type: ini
   - source: /installation/language/en-GB/langmetadata.xml
     translation: /installation/language/%locale%/langmetadata.xml
     content_segmentation: 0


### PR DESCRIPTION
Redo of https://github.com/joomla/joomla-cms/pull/23025 for J4.0

Unfortunately this PR had to be reverted in J3, which happend with https://github.com/joomla/joomla-cms/commit/505366a20d22e581fc38ee91c5625b680081e9c3

Unfortunately, the type parameter was also reverted, but we need it in J4 as those Joomla INI files (using _QQ_) are no longer support in J4.