### PR TITLE
[com_content] Undefined property with read more when params are missing

### DIFF
--- a/components/com_content/views/article/tmpl/default.php
+++ b/components/com_content/views/article/tmpl/default.php
@@ -145,16 +145,11 @@ JHtml::_('behavior.caption');
 		<?php
 		if ($params->get('alternative_readmore', '') === '') :
 			echo JText::_('COM_CONTENT_REGISTER_TO_READ_MORE');
-		elseif ($params->get('alternative_readmore')) :
+		else :
 			echo $params->get('alternative_readmore');
 			if ($params->get('show_readmore_title', 0) != 0) :
 				echo JHtml::_('string.truncate', $this->item->title, $params->get('readmore_limit'));
 			endif;
-		elseif ($params->get('show_readmore_title', 0) == 0) :
-			echo JText::sprintf('COM_CONTENT_READ_MORE_TITLE');
-		else :
-			echo JText::_('COM_CONTENT_READ_MORE');
-			echo JHtml::_('string.truncate', $this->item->title, $params->get('readmore_limit'));
 		endif; ?>
 		</a>
 	</p>

--- a/components/com_content/views/article/tmpl/default.php
+++ b/components/com_content/views/article/tmpl/default.php
@@ -142,12 +142,11 @@ JHtml::_('behavior.caption');
 	<?php $link->setVar('return', base64_encode(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid, $this->item->language))); ?>
 	<p class="readmore">
 		<a href="<?php echo $link; ?>" class="register">
-		<?php $attribs = json_decode($this->item->attribs); ?>
 		<?php
-		if ($attribs->alternative_readmore == null) :
+		if ($params->get('alternative_readmore', '') === '') :
 			echo JText::_('COM_CONTENT_REGISTER_TO_READ_MORE');
-		elseif ($readmore = $attribs->alternative_readmore) :
-			echo $readmore;
+		elseif ($params->get('alternative_readmore')) :
+			echo $params->get('alternative_readmore');
 			if ($params->get('show_readmore_title', 0) != 0) :
 				echo JHtml::_('string.truncate', $this->item->title, $params->get('readmore_limit'));
 			endif;

--- a/components/com_content/views/article/tmpl/default.php
+++ b/components/com_content/views/article/tmpl/default.php
@@ -142,15 +142,14 @@ JHtml::_('behavior.caption');
 	<?php $link->setVar('return', base64_encode(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid, $this->item->language))); ?>
 	<p class="readmore">
 		<a href="<?php echo $link; ?>" class="register">
-		<?php
-		if ($params->get('alternative_readmore', '') === '') :
-			echo JText::_('COM_CONTENT_REGISTER_TO_READ_MORE');
-		else :
-			echo $params->get('alternative_readmore');
-			if ($params->get('show_readmore_title', 0) != 0) :
-				echo JHtml::_('string.truncate', $this->item->title, $params->get('readmore_limit'));
-			endif;
-		endif; ?>
+			<?php if ($params->get('alternative_readmore', '') === '') : ?>
+				<?php echo JText::_('COM_CONTENT_REGISTER_TO_READ_MORE'); ?>
+			<?php else : ?>
+				<?php echo $params->get('alternative_readmore'); ?>
+				<?php if ($params->get('show_readmore_title', 0) != 0) : ?>
+					<?php echo JHtml::_('string.truncate', $this->item->title, $params->get('readmore_limit')); ?>
+				<?php endif; ?>
+			<?php endif; ?>
 		</a>
 	</p>
 	<?php endif; ?>


### PR DESCRIPTION
### Summary of Changes

Fixes a rare case of undefined property.
Removes unreachable elseif/else conditions.

### Testing Instructions

Create an article with intro/full text and registered access level. In `#__content` table set article `attribs` to empty JSON object: `{}`.
View the article in frontend.

### Expected result

No notices

### Actual result

Notice:

>Undefined property: stdClass::$alternative_readmore in components\com_content\views\article\tmpl\default.php on line 147

### Documentation Changes Required

No.