### PR TITLE
[4.0] Fix translation of tip in installer update manager

### DIFF
--- a/administrator/components/com_installer/tmpl/update/default.php
+++ b/administrator/components/com_installer/tmpl/update/default.php
@@ -92,7 +92,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 									<th scope="row">
 										<span tabindex="0"><?php echo $this->escape($item->name); ?></span>
 										<div role="tooltip" id="tip<?php echo $i; ?>">
-											<?php echo $item->description; ?>
+											<?php echo Text::_('$item->description'); ?>
 										</div>
 										<?php if($item->isMissingDownloadKey): ?>
 										<br/>


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/29039

### Summary of Changes
Using Text method to translate the description


### Testing Instructions
See https://github.com/joomla/joomla-cms/issues/29039

Can be tested/merged on review.