### PR TITLE
[4.0] Language extension fixes

### DIFF
--- a/administrator/components/com_installer/src/Helper/InstallerHelper.php
+++ b/administrator/components/com_installer/src/Helper/InstallerHelper.php
@@ -159,6 +159,9 @@ class InstallerHelper
 				break;
 			case 'package':
 				$path = JPATH_ADMINISTRATOR . '/manifests/packages/' . $element . '.xml';
+				break;
+			case 'language':
+				$path .= '/language/' . $element . '/install.xml';
 		}
 
 		if (file_exists($path) === false)

--- a/administrator/components/com_installer/src/Helper/InstallerHelper.php
+++ b/administrator/components/com_installer/src/Helper/InstallerHelper.php
@@ -135,7 +135,7 @@ class InstallerHelper
 		?string $folder = null
 	): ?SimpleXMLElement
 	{
-		$path = $clientId ? JPATH_ADMINISTRATOR : JPATH_ROOT;
+		$path = [0 => JPATH_SITE, 1 => JPATH_ADMINISTRATOR, 3 => JPATH_API][$clientId] ?? JPATH_SITE;
 
 		switch ($type)
 		{

--- a/administrator/components/com_installer/src/Model/InstallerModel.php
+++ b/administrator/components/com_installer/src/Model/InstallerModel.php
@@ -169,7 +169,7 @@ class InstallerModel extends ListModel
 			}
 
 			$item->author_info       = @$item->authorEmail . '<br>' . @$item->authorUrl;
-			$item->client            = Text::_([0 => 'JSITE', 1 => 'JADMINISTRATOR', 3 => 'JAPI'][$item->client_id]);
+			$item->client            = Text::_([0 => 'JSITE', 1 => 'JADMINISTRATOR', 3 => 'JAPI'][$item->client_id] ?? 'JSITE');
 			$item->client_translated = $item->client;
 			$item->type_translated   = Text::_('COM_INSTALLER_TYPE_' . strtoupper($item->type));
 			$item->folder_translated = @$item->folder ? $item->folder : Text::_('COM_INSTALLER_TYPE_NONAPPLICABLE');

--- a/administrator/components/com_installer/src/Model/UpdateModel.php
+++ b/administrator/components/com_installer/src/Model/UpdateModel.php
@@ -199,7 +199,7 @@ class UpdateModel extends ListModel
 	{
 		foreach ($items as &$item)
 		{
-			$item->client_translated  = $item->client_id ? Text::_('JADMINISTRATOR') : Text::_('JSITE');
+			$item->client_translated  = Text::_([0 => 'JSITE', 1 => 'JADMINISTRATOR', 3 => 'JAPI'][$item->client_id] ?? 'JSITE');
 			$manifest                 = json_decode($item->manifest_cache);
 			$item->current_version    = $manifest->version ?? Text::_('JLIB_UNKNOWN');
 			$item->description        = $manifest->description ?? Text::_('COM_INSTALLER_MSG_UPDATE_NODESC');


### PR DESCRIPTION
### Summary of Changes

Adds language extension paths.
Adds API path.
Corrects client display for API extension.

### Testing Instructions

Install this language: [api_fr-FR.zip](https://github.com/joomla/joomla-cms/files/4627648/api_fr-FR.zip)

Create a file so it's accessible through `localhost/testing/api-fr-FR.xml`:

```
<?xml version="1.0" encoding="utf-8"?>
<updates>
  <update>
    <name>French</name>
    <description>French Translation of Joomla!</description>
    <element>fr-FR</element>
	<client>api</client>
    <type>language</type>
    <version>3.9.18.1</version>
    <downloads>
      <downloadurl type="full" format="zip">http://localhost/testing/api-fr-FR-3.9.18.1.zip</downloadurl>
    </downloads>
    <targetplatform name="joomla" version="[34].([0123456789]|10)"/>
  </update>
</updates>
```
Check for updates.

### Expected result

No warnings and `Location` is shown as `API`.

### Actual result

>Warning: simplexml_load_file(): failed to open stream: Permission denied in administrator\components\com_installer\src\Helper\InstallerHelper.php on line 169

`Location` is shown as `Administrator`.

### Documentation Changes Required

No.