### PR TITLE
[4.0] [com_finder] Class error

### DIFF
--- a/administrator/components/com_finder/src/Indexer/Parser.php
+++ b/administrator/components/com_finder/src/Indexer/Parser.php
@@ -37,7 +37,7 @@ abstract class Parser
 	 * @return  Parser  A Parser instance.
 	 *
 	 * @since   2.5
-	 * @throws  Exception on invalid parser.
+	 * @throws  \Exception on invalid parser.
 	 */
 	public static function getInstance($format)
 	{
@@ -61,7 +61,7 @@ abstract class Parser
 		}
 
 		// Throw invalid format exception.
-		throw new Exception(Text::sprintf('COM_FINDER_INDEXER_INVALID_PARSER', $format));
+		throw new \Exception(Text::sprintf('COM_FINDER_INDEXER_INVALID_PARSER', $format));
 	}
 
 	/**


### PR DESCRIPTION
### Summary of Changes

Corrects class.

### Testing Instructions

Code review or run this code:

```
try
{
	$parser = \Joomla\Component\Finder\Administrator\Indexer\Parser::getInstance('foo');
}
catch (\Exception $e)
{
}
```

### Expected result

No errors.

### Actual result

>Class 'Joomla\Component\Finder\Administrator\Indexer\Exception' not found 

### Documentation Changes Required

No.