### PR TITLE
Fix "Keep Forever" option for content history versions on PostgreSQL

### DIFF
--- a/administrator/components/com_contenthistory/models/history.php
+++ b/administrator/components/com_contenthistory/models/history.php
@@ -120,7 +120,7 @@ class ContenthistoryModelHistory extends JModelList
 		{
 			if ($table->load($pk))
 			{
-				if ($table->keep_forever === "1")
+				if ((int) $table->keep_forever === 1)
 				{
 					unset($pks[$i]);
 					continue;


### PR DESCRIPTION
### Summary of Changes

Explicit cast because PostgreSQL returns integers for integer columns.

### Testing Instructions

Code review is fine. If you want real test (PostgreSQL only):

Create and then edit some content.
View content history.
Enable "Keep Forever" option for some version.
Try to deleted that version.

### Expected result

Version not deleted.

### Actual result

Version deleted.

### Documentation Changes Required

No.