### PR TITLE
[4.0] Fix js error when previewing admin template

### DIFF
--- a/build/media_source/com_cpanel/js/admin-cpanel-default.es6.js
+++ b/build/media_source/com_cpanel/js/admin-cpanel-default.es6.js
@@ -54,10 +54,12 @@
     // Calculate "grid-row-end" property
     resizeGridItem($cell, rowHeight, rowGap) {
       const $content = $cell.querySelector('.card');
-      const contentHeight = $content.getBoundingClientRect().height + rowGap;
-      const rowSpan = Math.ceil(contentHeight / (rowHeight + rowGap));
+      if ($content) {
+        const contentHeight = $content.getBoundingClientRect().height + rowGap;
+        const rowSpan = Math.ceil(contentHeight / (rowHeight + rowGap));
 
-      $cell.style.gridRowEnd = `span ${rowSpan}`;
+        $cell.style.gridRowEnd = `span ${rowSpan}`;
+      }
     },
 
     // Check a size of every cell in the grid


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/29120

### Summary of Changes
Use conditional for the `$content` variable

### Testing Instructions
Make sure that the Preview Module Positions is set to enabled
Click on the eye to open the preview if in  template style or Preview Toolbar in templates manager

### Before patch
js error. See https://github.com/joomla/joomla-cms/issues/29120
### After patch

No more error