### PR TITLE
Use selenium version provided by os

### DIFF
--- a/tests/Codeception/drone-system-run.sh
+++ b/tests/Codeception/drone-system-run.sh
@@ -50,8 +50,7 @@ apache2ctl -D FOREGROUND &
 google-chrome --version
 
 echo "[RUNNER] Start Selenium"
-./node_modules/.bin/selenium-standalone install --drivers.chrome.version=77.0.3865.40 --drivers.chrome.baseURL=https://chromedriver.storage.googleapis.com
-./node_modules/.bin/selenium-standalone start --drivers.chrome.version=77.0.3865.40 --drivers.chrome.baseURL=https://chromedriver.storage.googleapis.com >> selenium.log 2>&1 &
+selenium-standalone start >> selenium.log 2>&1 &
 sleep 5
 
 echo "[RUNNER] Run Codeception"


### PR DESCRIPTION
We now use the installed version provided by the container. 

Based on PR https://github.com/joomla-projects/docker-images/pull/18