### PR TITLE
[4.0] Simplify post install messages module

### DIFF
--- a/administrator/modules/mod_post_installation_messages/tmpl/default.php
+++ b/administrator/modules/mod_post_installation_messages/tmpl/default.php
@@ -9,7 +9,6 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 
@@ -18,7 +17,7 @@ $hideLinks = $app->input->getBool('hidemainmenu');
 <?php if ($app->getIdentity()->authorise('core.manage', 'com_postinstall')) : ?>
 	<div class="header-item-content">
 		<a class="d-flex flex-column <?php echo ($hideLinks ? 'disabled' : ''); ?>" 
-			href="<?php echo Route::_('index.php?option=com_postinstall&eid=' . $joomlaFilesExtensionId); ?>">
+			href="<?php echo Route::_('index.php?option=com_postinstall&eid=' . $joomlaFilesExtensionId); ?>" title="<?php echo Text::_('MOD_POST_INSTALLATION_MESSAGES'); ?>">
 			<div class="d-flex align-items-end mx-auto">
 				<span class="fas fa-bell" aria-hidden="true"></span>
 				<?php if (count($messages) > 0) : ?>

--- a/administrator/modules/mod_post_installation_messages/tmpl/default.php
+++ b/administrator/modules/mod_post_installation_messages/tmpl/default.php
@@ -13,43 +13,21 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 
-// Load Bootstrap JS for dropdowns.
-HTMLHelper::_('bootstrap.framework');
-
 $hideLinks = $app->input->getBool('hidemainmenu');
 ?>
 <?php if ($app->getIdentity()->authorise('core.manage', 'com_postinstall')) : ?>
-	<div class="header-item-content dropdown d-flex">
-		<button class="dropdown-toggle d-flex flex-column align-items-stretch <?php echo ($hideLinks ? 'disabled' : ''); ?>" data-toggle="dropdown" type="button" <?php echo ($hideLinks ? 'disabled' : ''); ?>
-			title="<?php echo Text::_('MOD_POST_INSTALLATION_MESSAGES'); ?>">
+	<div class="header-item-content">
+		<a class="d-flex flex-column <?php echo ($hideLinks ? 'disabled' : ''); ?>" 
+			href="<?php echo Route::_('index.php?option=com_postinstall&eid=' . $joomlaFilesExtensionId); ?>">
 			<div class="d-flex align-items-end mx-auto">
 				<span class="fas fa-bell" aria-hidden="true"></span>
+				<?php if (count($messages) > 0) : ?>
+					<span class="badge badge-danger"><?php echo count($messages); ?></span>
+				<?php endif; ?>
 			</div>
 			<div class="tiny">
 				<?php echo Text::_('MOD_POST_INSTALLATION_MESSAGES'); ?>
 			</div>
-			<span class="fas fa-angle-down" aria-hidden="true"></span>
-			<?php if (count($messages) > 0) : ?>
-				<span class="badge badge-danger"><?php echo count($messages); ?></span>
-			<?php endif; ?>
-		</button>
-		<?php if (!$hideLinks) : ?>
-		<div class="dropdown-menu dropdown-menu-right dropdown-notifications border-0">
-			<div class="dropdown-header">
-				<?php echo Text::_('MOD_POST_INSTALLATION_MESSAGES'); ?>
-			</div>
-			<?php if (empty($messages)) : ?>
-				<a class="dropdown-item" href="<?php echo Route::_('index.php?option=com_postinstall&eid=' . $joomlaFilesExtensionId); ?>">
-					<?php echo Text::_('COM_POSTINSTALL_LBL_NOMESSAGES_TITLE'); ?>
-				</a>
-			<?php endif; ?>
-			<?php foreach ($messages as $message) : ?>
-				<?php $route = 'index.php?option=com_postinstall&amp;eid=' . $joomlaFilesExtensionId; ?>
-				<a class="dropdown-item" href="<?php echo Route::_($route); ?>">
-					<?php echo Text::_($message->title_key); ?>
-				</a>
-			<?php endforeach; ?>
-		</div>
-		<?php endif; ?>
+		</a>
 	</div>
 <?php endif; ?>


### PR DESCRIPTION
### Summary of Changes
In the header of the backend, a Postinstall-message module shows how many postinstall-messages are unread. 
It provides a dropdown

![grafik](https://user-images.githubusercontent.com/1035262/82251664-e6af4880-994d-11ea-9358-9bc2997689d5.png)

This dropdown has a haedline. But it is not obvious, that the first line is not a link but a headline. so users click there and wonder why nothing happens. 
Then the following dropdown has several links and every link leads to the postinstall messages.

This PR removes the dropdown completely. The module shows how many unread messages are there and with a cklick the user is lead to the postinstall messages, that's all.  

### Testing Instructions
See what the module shows now, apply the patch and see how it is simpler. 


### Documentation Changes Required
maybe - screenshot

### Related PR: #29132, #26109