### PR TITLE
[4.0] Clean up disabled property code in toolbar button

### DIFF
--- a/build/media_source/system/js/joomla-toolbar-button.w-c.es6.js
+++ b/build/media_source/system/js/joomla-toolbar-button.w-c.es6.js
@@ -79,24 +79,17 @@ window.customElements.define('joomla-toolbar-button', class extends HTMLElement 
     // Make sure we have a boolean value
     this.disabled = !!disabled;
 
-    // Switch attribute for current element
-    if (this.disabled) {
-      this.setAttribute('disabled', true);
-    } else {
-      this.removeAttribute('disabled');
-    }
-
     // Switch attribute for native element
     // An anchor does not support "disabled" attribute, so use class
     if (this.buttonElement) {
       if (this.disabled) {
         if (this.buttonElement.nodeName === 'BUTTON') {
-          this.buttonElement.setAttribute('disabled', true);
+          this.buttonElement.disabled = true;
         } else {
           this.buttonElement.classList.add('disabled');
         }
       } else if (this.buttonElement.nodeName === 'BUTTON') {
-        this.buttonElement.removeAttribute('disabled');
+        this.buttonElement.disabled = false;
       } else {
         this.buttonElement.classList.remove('disabled');
       }


### PR DESCRIPTION
### Summary of Changes

Minor cleanup related to disabled attribute.

### Testing Instructions

Run `node build.js --compile-js`.
Go to a list view with `Actions` dropdown button.
Check that the button is disabled at first.
Check that button gets enabled when selecting an item.

### Expected result

Works like before.

### Documentation Changes Required

No.