### PR TITLE
[4.0] [com_postinstall] Parameterized queries

### DIFF
--- a/administrator/components/com_postinstall/src/Model/MessagesModel.php
+++ b/administrator/components/com_postinstall/src/Model/MessagesModel.php
@@ -18,6 +18,7 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Model\BaseDatabaseModel;
 use Joomla\Component\Postinstall\Administrator\Helper\PostinstallHelper;
+use Joomla\Database\ParameterType;
 
 /**
  * Model class to manage postinstall messages
@@ -38,27 +39,30 @@ class MessagesModel extends BaseDatabaseModel
 	public function getItem($id)
 	{
 		$db = $this->getDbo();
+		$id = (int) $id;
 
 		$query = $db->getQuery(true);
 		$query->select(
-			$db->quoteName(
-				array
-				('postinstall_message_id',
-					'extension_id',
-					'title_key',
-					'description_key',
-					'action_key',
-					'language_extension',
-					'language_client_id',
-					'type',
-					'action_file',
-					'action',
-					'condition_file',
-					'condition_method',
-					'version_introduced',
-					'enabled')
-			)
-		)->from($db->quoteName('#__postinstall_messages'))->where($db->quoteName('postinstall_message_id') . ' = ' . $db->quote($id));
+			[
+				$db->quoteName('postinstall_message_id'),
+				$db->quoteName('extension_id'),
+				$db->quoteName('title_key'),
+				$db->quoteName('description_key'),
+				$db->quoteName('action_key'),
+				$db->quoteName('language_extension'),
+				$db->quoteName('language_client_id'),
+				$db->quoteName('type'),
+				$db->quoteName('action_file'),
+				$db->quoteName('action'),
+				$db->quoteName('condition_file'),
+				$db->quoteName('condition_method'),
+				$db->quoteName('version_introduced'),
+				$db->quoteName('enabled'),
+			]
+		)
+			->from($db->quoteName('#__postinstall_messages'))
+			->where($db->quoteName('postinstall_message_id') . ' = :id')
+			->bind(':id', $id, ParameterType::INTEGER);
 
 		$db->setQuery($query);
 
@@ -77,10 +81,14 @@ class MessagesModel extends BaseDatabaseModel
 	public function unpublishMessage($id)
 	{
 		$db = $this->getDbo();
+		$id = (int) $id;
 
 		$query = $db->getQuery(true);
-		$query->update($db->quoteName('#__postinstall_messages'))
-			->set($db->quoteName('enabled') . ' = ' . $db->quote(0))->where($db->quoteName('postinstall_message_id') . ' = ' . $db->quote($id));
+		$query
+			->update($db->quoteName('#__postinstall_messages'))
+			->set($db->quoteName('enabled') . ' = 0')
+			->where($db->quoteName('postinstall_message_id') . ' = :id')
+			->bind(':id', $id, ParameterType::INTEGER);
 		$db->setQuery($query);
 		$db->execute();
 	}
@@ -99,34 +107,34 @@ class MessagesModel extends BaseDatabaseModel
 		$query = $db->getQuery(true);
 
 		$query->select(
-			$db->quoteName(
-				array
-				('postinstall_message_id',
-											'extension_id',
-											'title_key',
-											'description_key',
-											'action_key',
-											'language_extension',
-											'language_client_id',
-											'type',
-											'action_file',
-											'action',
-											'condition_file',
-											'condition_method',
-											'version_introduced',
-											'enabled')
-			)
-		);
+			[
+				$db->quoteName('postinstall_message_id'),
+				$db->quoteName('extension_id'),
+				$db->quoteName('title_key'),
+				$db->quoteName('description_key'),
+				$db->quoteName('action_key'),
+				$db->quoteName('language_extension'),
+				$db->quoteName('language_client_id'),
+				$db->quoteName('type'),
+				$db->quoteName('action_file'),
+				$db->quoteName('action'),
+				$db->quoteName('condition_file'),
+				$db->quoteName('condition_method'),
+				$db->quoteName('version_introduced'),
+				$db->quoteName('enabled'),
+			]
+		)
+			->from($db->quoteName('#__postinstall_messages'));
 
 		// Add a forced extension filtering to the list
-		$eid = $this->getState('eid', $this->getJoomlaFilesExtensionId());
-		$query->where($db->quoteName('extension_id') . ' = ' . $db->quote($eid));
+		$eid = (int) $this->getState('eid', $this->getJoomlaFilesExtensionId());
+		$query->where($db->quoteName('extension_id') . ' = :eid')
+			->bind(':eid', $eid, ParameterType::INTEGER);
 
 		// Force filter only enabled messages
-		$published = $this->getState('published', 1);
-		$query->where($db->quoteName('enabled') . ' = ' . (int) $published);
-
-		$query->from($db->quoteName('#__postinstall_messages'));
+		$published = (int) $this->getState('published', 1);
+		$query->where($db->quoteName('enabled') . ' = :published')
+			->bind(':published', $published, ParameterType::INTEGER);
 
 		$db->setQuery($query);
 
@@ -149,14 +157,22 @@ class MessagesModel extends BaseDatabaseModel
 	public function getExtensionName($eid)
 	{
 		// Load the extension's information from the database
-		$db = $this->getDbo();
+		$db  = $this->getDbo();
+		$eid = (int) $eid;
 
 		$query = $db->getQuery(true)
-			->select(array('name', 'element', 'client_id'))
+			->select(
+				[
+					$db->quoteName('name'),
+					$db->quoteName('element'),
+					$db->quoteName('client_id'),
+				]
+			)
 			->from($db->quoteName('#__extensions'))
-			->where($db->quoteName('extension_id') . ' = ' . (int) $eid);
+			->where($db->quoteName('extension_id') . ' = :eid')
+			->bind(':eid', $eid, ParameterType::INTEGER)
+			->setLimit(1);
 
-		$query->setLimit(1);
 		$db->setQuery($query);
 
 		$extension = $db->loadObject();
@@ -192,12 +208,14 @@ class MessagesModel extends BaseDatabaseModel
 	 */
 	public function resetMessages($eid)
 	{
-		$db = $this->getDbo();
+		$db  = $this->getDbo();
+		$eid = (int) $eid;
 
 		$query = $db->getQuery(true)
 			->update($db->quoteName('#__postinstall_messages'))
 			->set($db->quoteName('enabled') . ' = 1')
-			->where($db->quoteName('extension_id') . ' = ' . (int) $eid);
+			->where($db->quoteName('extension_id') . ' = :eid')
+			->bind(':eid', $eid, ParameterType::INTEGER);
 		$db->setQuery($query);
 
 		return $db->execute();
@@ -214,12 +232,14 @@ class MessagesModel extends BaseDatabaseModel
 	 */
 	public function hideMessages($eid)
 	{
-		$db = $this->getDbo();
+		$db  = $this->getDbo();
+		$eid = (int) $eid;
 
 		$query = $db->getQuery(true)
 			->update($db->quoteName('#__postinstall_messages'))
 			->set($db->quoteName('enabled') . ' = 0')
-			->where($db->quoteName('extension_id') . ' = ' . (int) $eid);
+			->where($db->quoteName('extension_id') . ' = :eid')
+			->bind(':eid', $eid, ParameterType::INTEGER);
 		$db->setQuery($query);
 
 		return $db->execute();
@@ -302,9 +322,9 @@ class MessagesModel extends BaseDatabaseModel
 		$db = $this->getDbo();
 
 		$query = $db->getQuery(true)
-			->select('extension_id')
+			->select($db->quoteName('extension_id'))
 			->from($db->quoteName('#__postinstall_messages'))
-			->group(array($db->quoteName('extension_id')));
+			->group($db->quoteName('extension_id'));
 		$db->setQuery($query);
 		$extension_ids = $db->loadColumn();
 
@@ -532,16 +552,24 @@ class MessagesModel extends BaseDatabaseModel
 		}
 
 		// Check if the definition exists
-		$table     = $this->getTable();
-		$tableName = $table->getTableName();
+		$table       = $this->getTable();
+		$tableName   = $table->getTableName();
+		$extensionId = (int) $options['extension_id'];
 
 		$db    = $this->getDbo();
 		$query = $db->getQuery(true)
 			->select('*')
 			->from($db->quoteName($tableName))
-			->where($db->quoteName('extension_id') . ' = ' . (int) $options['extension_id'])
-			->where($db->quoteName('type') . ' = ' . $db->quote($options['type']))
-			->where($db->quoteName('title_key') . ' = ' . $db->quote($options['title_key']));
+			->where(
+				[
+					$db->quoteName('extension_id') . ' = :extensionId',
+					$db->quoteName('type') . ' = :type',
+					$db->quoteName('title_key') . ' = :titleKey',
+				]
+			)
+			->bind(':extensionId', $extensionId, ParameterType::INTEGER)
+			->bind(':type', $options['type'])
+			->bind(':titleKey', $options['title_key']);
 
 		$existingRow = $db->setQuery($query)->loadAssoc();
 
@@ -568,9 +596,16 @@ class MessagesModel extends BaseDatabaseModel
 			// Otherwise it's not the same row. Remove the old row before insert a new one.
 			$query = $db->getQuery(true)
 				->delete($db->quoteName($tableName))
-				->where($db->quote('extension_id') . ' = ' . (int) $options['extension_id'])
-				->where($db->quote('type') . ' = ' . $db->quote($options['type']))
-				->where($db->quote('title_key') . ' = ' . $db->quote($options['title_key']));
+				->where(
+				[
+					$db->quoteName('extension_id') . ' = :extensionId',
+					$db->quoteName('type') . ' = :type',
+					$db->quoteName('title_key') . ' = :titleKey',
+				]
+			)
+			->bind(':extensionId', $extensionId, ParameterType::INTEGER)
+			->bind(':type', $options['type'])
+			->bind(':titleKey', $options['title_key']);
 
 			$db->setQuery($query)->execute();
 		}


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Adds parameterized queries to `com_postinstall`.

### Testing Instructions

Check that `com_postinstall` continues to work.
Try to hide a message, hide all messages, reset messages.
If you have some extensions installed, filter by extension.

### Expected result

Works like before.

### Documentation Changes Required

No.