### PR TITLE
[4.0] AfterDelete events to return void

### DIFF
--- a/plugins/actionlog/joomla/joomla.php
+++ b/plugins/actionlog/joomla/joomla.php
@@ -155,7 +155,7 @@ class PlgActionlogJoomla extends ActionLogPlugin
 	 *
 	 * @since   3.9.0
 	 */
-	public function onContentAfterDelete($context, $article)
+	public function onContentAfterDelete($context, $article): void
 	{
 		$option = $this->app->input->get('option');
 
@@ -563,7 +563,7 @@ class PlgActionlogJoomla extends ActionLogPlugin
 	 *
 	 * @since   3.9.0
 	 */
-	public function onExtensionAfterDelete($context, $table)
+	public function onExtensionAfterDelete($context, $table): void
 	{
 		if (!$this->checkLoggable($this->app->input->get('option')))
 		{
@@ -676,7 +676,7 @@ class PlgActionlogJoomla extends ActionLogPlugin
 	 *
 	 * @since   3.9.0
 	 */
-	public function onUserAfterDelete($user, $success, $msg)
+	public function onUserAfterDelete($user, $success, $msg): void
 	{
 		$context = $this->app->input->get('option');
 
@@ -754,7 +754,7 @@ class PlgActionlogJoomla extends ActionLogPlugin
 	 *
 	 * @since   3.9.0
 	 */
-	public function onUserAfterDeleteGroup($group, $success, $msg)
+	public function onUserAfterDeleteGroup($group, $success, $msg): void
 	{
 		$context = $this->app->input->get('option');
 

--- a/plugins/content/finder/finder.php
+++ b/plugins/content/finder/finder.php
@@ -72,7 +72,7 @@ class PlgContentFinder extends CMSPlugin
 	 *
 	 * @since   2.5
 	 */
-	public function onContentAfterDelete($context, $article)
+	public function onContentAfterDelete($context, $article): void
 	{
 		PluginHelper::importPlugin('finder');
 

--- a/plugins/finder/contacts/contacts.php
+++ b/plugins/finder/contacts/contacts.php
@@ -113,12 +113,12 @@ class PlgFinderContacts extends Adapter
 	 * @param   string  $context  The context of the action being performed.
 	 * @param   Table   $table    A Table object containing the record to be deleted
 	 *
-	 * @return  boolean  True on success.
+	 * @return  void
 	 *
 	 * @since   2.5
 	 * @throws  Exception on database error.
 	 */
-	public function onFinderAfterDelete($context, $table)
+	public function onFinderAfterDelete($context, $table): void
 	{
 		if ($context === 'com_contact.contact')
 		{
@@ -130,11 +130,11 @@ class PlgFinderContacts extends Adapter
 		}
 		else
 		{
-			return true;
+			return;
 		}
 
 		// Remove the items.
-		return $this->remove($id);
+		$this->remove($id);
 	}
 
 	/**

--- a/plugins/finder/content/content.php
+++ b/plugins/finder/content/content.php
@@ -115,12 +115,12 @@ class PlgFinderContent extends Adapter
 	 * @param   string  $context  The context of the action being performed.
 	 * @param   Table   $table    A Table object containing the record to be deleted
 	 *
-	 * @return  boolean  True on success.
+	 * @return  void
 	 *
 	 * @since   2.5
 	 * @throws  Exception on database error.
 	 */
-	public function onFinderAfterDelete($context, $table)
+	public function onFinderAfterDelete($context, $table): void
 	{
 		if ($context === 'com_content.article')
 		{
@@ -132,11 +132,11 @@ class PlgFinderContent extends Adapter
 		}
 		else
 		{
-			return true;
+			return;
 		}
 
 		// Remove item from the index.
-		return $this->remove($id);
+		$this->remove($id);
 	}
 
 	/**

--- a/plugins/finder/newsfeeds/newsfeeds.php
+++ b/plugins/finder/newsfeeds/newsfeeds.php
@@ -111,7 +111,7 @@ class PlgFinderNewsfeeds extends Adapter
 	 * @param   string  $context  The context of the action being performed.
 	 * @param   Table   $table    A Table object containing the record to be deleted.
 	 *
-	 * @return  boolean  True on success.
+	 * @return  void
 	 *
 	 * @since   2.5
 	 * @throws  Exception on database error.

--- a/plugins/finder/newsfeeds/newsfeeds.php
+++ b/plugins/finder/newsfeeds/newsfeeds.php
@@ -116,7 +116,7 @@ class PlgFinderNewsfeeds extends Adapter
 	 * @since   2.5
 	 * @throws  Exception on database error.
 	 */
-	public function onFinderAfterDelete($context, $table)
+	public function onFinderAfterDelete($context, $table): void
 	{
 		if ($context === 'com_newsfeeds.newsfeed')
 		{
@@ -128,11 +128,11 @@ class PlgFinderNewsfeeds extends Adapter
 		}
 		else
 		{
-			return true;
+			return;
 		}
 
 		// Remove the item from the index.
-		return $this->remove($id);
+		$this->remove($id);
 	}
 
 	/**

--- a/plugins/finder/tags/tags.php
+++ b/plugins/finder/tags/tags.php
@@ -88,7 +88,7 @@ class PlgFinderTags extends Adapter
 	 * @param   string  $context  The context of the action being performed.
 	 * @param   Table   $table    A Table object containing the record to be deleted
 	 *
-	 * @return  boolean  True on success.
+	 * @return  void
 	 *
 	 * @since   3.1
 	 * @throws  Exception on database error.

--- a/plugins/finder/tags/tags.php
+++ b/plugins/finder/tags/tags.php
@@ -93,7 +93,7 @@ class PlgFinderTags extends Adapter
 	 * @since   3.1
 	 * @throws  Exception on database error.
 	 */
-	public function onFinderAfterDelete($context, $table)
+	public function onFinderAfterDelete($context, $table): void
 	{
 		if ($context === 'com_tags.tag')
 		{
@@ -109,7 +109,7 @@ class PlgFinderTags extends Adapter
 		}
 
 		// Remove the items.
-		return $this->remove($id);
+		$this->remove($id);
 	}
 
 	/**

--- a/plugins/finder/tags/tags.php
+++ b/plugins/finder/tags/tags.php
@@ -105,7 +105,7 @@ class PlgFinderTags extends Adapter
 		}
 		else
 		{
-			return true;
+			return;
 		}
 
 		// Remove the items.

--- a/plugins/system/actionlogs/actionlogs.php
+++ b/plugins/system/actionlogs/actionlogs.php
@@ -478,15 +478,15 @@ class PlgSystemActionLogs extends CMSPlugin
 	 * @param   boolean  $success  True if user was successfully stored in the database
 	 * @param   string   $msg      Message
 	 *
-	 * @return  boolean
+	 * @return  void
 	 *
 	 * @since   3.9.0
 	 */
-	public function onUserAfterDelete($user, $success, $msg)
+	public function onUserAfterDelete($user, $success, $msg): void
 	{
 		if (!$success)
 		{
-			return false;
+			return;
 		}
 
 		$db     = $this->db;
@@ -503,10 +503,8 @@ class PlgSystemActionLogs extends CMSPlugin
 		}
 		catch (ExecutionFailureException $e)
 		{
-			return false;
+			// Do nothing.
 		}
-
-		return true;
 	}
 
 	/**

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -208,25 +208,23 @@ class PlgSystemFields extends CMSPlugin
 	 * @param   string    $context  The context
 	 * @param   stdClass  $item     The item
 	 *
-	 * @return  boolean
+	 * @return  void
 	 *
 	 * @since   3.7.0
 	 */
-	public function onContentAfterDelete($context, $item)
+	public function onContentAfterDelete($context, $item): void
 	{
 		$parts = FieldsHelper::extract($context, $item);
 
 		if (!$parts || empty($item->id))
 		{
-			return true;
+			return;
 		}
 
 		$context = $parts[0] . '.' . $parts[1];
 
 		$model = new \Joomla\Component\Fields\Administrator\Model\FieldModel(array('ignore_request' => true));
 		$model->cleanupValues($context, $item->id);
-
-		return true;
 	}
 
 	/**
@@ -236,16 +234,16 @@ class PlgSystemFields extends CMSPlugin
 	 * @param   boolean   $succes  Is success
 	 * @param   string    $msg     The message
 	 *
-	 * @return  boolean
+	 * @return  void
 	 *
 	 * @since   3.7.0
 	 */
-	public function onUserAfterDelete($user, $succes, $msg)
+	public function onUserAfterDelete($user, $succes, $msg): void
 	{
 		$item     = new stdClass;
 		$item->id = $user['id'];
 
-		return $this->onContentAfterDelete('com_users.user', $item);
+		$this->onContentAfterDelete('com_users.user', $item);
 	}
 
 	/**

--- a/plugins/system/privacyconsent/privacyconsent.php
+++ b/plugins/system/privacyconsent/privacyconsent.php
@@ -235,15 +235,15 @@ class PlgSystemPrivacyconsent extends CMSPlugin
 	 * @param   boolean  $success  True if user was succesfully stored in the database
 	 * @param   string   $msg      Message
 	 *
-	 * @return  boolean
+	 * @return  void
 	 *
 	 * @since   3.9.0
 	 */
-	public function onUserAfterDelete($user, $success, $msg)
+	public function onUserAfterDelete($user, $success, $msg): void
 	{
 		if (!$success)
 		{
-			return false;
+			return;
 		}
 
 		$userId = ArrayHelper::getValue($user, 'id', 0, 'int');
@@ -263,12 +263,8 @@ class PlgSystemPrivacyconsent extends CMSPlugin
 			catch (Exception $e)
 			{
 				$this->_subject->setError($e->getMessage());
-
-				return false;
 			}
 		}
-
-		return true;
 	}
 
 	/**

--- a/plugins/system/webauthn/src/PluginTraits/UserDeletion.php
+++ b/plugins/system/webauthn/src/PluginTraits/UserDeletion.php
@@ -34,17 +34,17 @@ trait UserDeletion
 	 * @param   bool    $success  True if user was successfully stored in the database
 	 * @param   string  $msg      Message
 	 *
-	 * @return  boolean
+	 * @return  void
 	 *
 	 * @throws  Exception
 	 *
 	 * @since   4.0.0
 	 */
-	public function onUserAfterDelete(array $user, bool $success, ?string $msg): bool
+	public function onUserAfterDelete(array $user, bool $success, ?string $msg): void
 	{
 		if (!$success)
 		{
-			return false;
+			return;
 		}
 
 		$userId = ArrayHelper::getValue($user, 'id', 0, 'int');
@@ -63,7 +63,5 @@ trait UserDeletion
 
 			$db->setQuery($query)->execute();
 		}
-
-		return true;
 	}
 }

--- a/plugins/user/joomla/joomla.php
+++ b/plugins/user/joomla/joomla.php
@@ -94,15 +94,15 @@ class PlgUserJoomla extends CMSPlugin
 	 * @param   boolean  $success  True if user was successfully stored in the database
 	 * @param   string   $msg      Message
 	 *
-	 * @return  boolean
+	 * @return  void
 	 *
 	 * @since   1.6
 	 */
-	public function onUserAfterDelete($user, $success, $msg)
+	public function onUserAfterDelete($user, $success, $msg): void
 	{
 		if (!$success)
 		{
-			return false;
+			return;
 		}
 
 		$db     = $this->db;
@@ -122,7 +122,7 @@ class PlgUserJoomla extends CMSPlugin
 			}
 			catch (ExecutionFailureException $e)
 			{
-				return false;
+				// Continue.
 			}
 		}
 
@@ -137,10 +137,8 @@ class PlgUserJoomla extends CMSPlugin
 		}
 		catch (ExecutionFailureException $e)
 		{
-			return false;
+			// Do nothing.
 		}
-
-		return true;
 	}
 
 	/**

--- a/plugins/user/profile/profile.php
+++ b/plugins/user/profile/profile.php
@@ -497,13 +497,13 @@ class PlgUserProfile extends CMSPlugin
 	 * @param   boolean  $success  True if user was successfully stored in the database
 	 * @param   string   $msg      Message
 	 *
-	 * @return  boolean
+	 * @return  void
 	 */
-	public function onUserAfterDelete($user, $success, $msg)
+	public function onUserAfterDelete($user, $success, $msg): void
 	{
 		if (!$success)
 		{
-			return false;
+			return;
 		}
 
 		$userId = ArrayHelper::getValue($user, 'id', 0, 'int');
@@ -520,7 +520,5 @@ class PlgUserProfile extends CMSPlugin
 			$db->setQuery($query);
 			$db->execute();
 		}
-
-		return true;
 	}
 }

--- a/plugins/user/token/token.php
+++ b/plugins/user/token/token.php
@@ -384,23 +384,23 @@ class PlgUserToken extends CMSPlugin
 	 * @param   boolean  $success  True if user was succesfully stored in the database
 	 * @param   string   $msg      Message
 	 *
-	 * @return  boolean
+	 * @return  void
 	 *
 	 * @throws  Exception
 	 * @since   4.0.0
 	 */
-	public function onUserAfterDelete(array $user, bool $success, string $msg): bool
+	public function onUserAfterDelete(array $user, bool $success, string $msg): void
 	{
 		if (!$success)
 		{
-			return false;
+			return;
 		}
 
 		$userId = ArrayHelper::getValue($user, 'id', 0, 'int');
 
 		if ($userId <= 0)
 		{
-			return true;
+			return;
 		}
 
 		try
@@ -419,10 +419,8 @@ class PlgUserToken extends CMSPlugin
 		}
 		catch (Exception $e)
 		{
-			return false;
+			// Do nothing.
 		}
-
-		return true;
 	}
 
 


### PR DESCRIPTION
### Summary of Changes

The return values of after delete events are not used. Unless they should be, this changes them to be void.

### Testing Instructions

Code review or try deleting some stuff. Should work like before.

### Documentation Changes Required

No.