### PR TITLE
[4.0] Missing check icon in media manager

### DIFF
--- a/administrator/components/com_media/resources/styles/components/_media-browser.scss
+++ b/administrator/components/com_media/resources/styles/components/_media-browser.scss
@@ -95,6 +95,7 @@
     height: calc(#{$grid-item-icon-size} * 1.3);
     font-family: "Font Awesome 5 Free";
     font-size: $grid-item-icon-size;
+    font-weight: 900;
     line-height: calc(#{$grid-item-icon-size} * 1.3);
     text-align: center;
     content: "\f00c";


### PR DESCRIPTION
### Summary of Changes

Fixes https://github.com/joomla/joomla-cms/issues/29150.

### Testing Instructions

`npm i` required.

> * Open any article in the Article Manager
> 
> * Navigate to the `Images and Links` tab
> 
> * Click the `select` button under `Full Article Image` (which will open the Media Manager)
> 
> * Select an image

### Expected result

Checkmark icon not missing.

### Actual result

Checkmark icon missing.

### Documentation Changes Required

No.