### PR TITLE
[4.0] Fix exclude folders in FolderlistField

### DIFF
--- a/libraries/src/Form/Field/FolderlistField.php
+++ b/libraries/src/Form/Field/FolderlistField.php
@@ -220,6 +220,9 @@ class FolderlistField extends ListField
 		{
 			foreach ($folders as $folder)
 			{
+				// Remove the root part and the leading /
+				$folder = trim(str_replace($path, '', $folder), DIRECTORY_SEPARATOR);
+
 				// Check to see if the file is in the exclude mask.
 				if ($this->exclude)
 				{
@@ -228,9 +231,6 @@ class FolderlistField extends ListField
 						continue;
 					}
 				}
-
-				// Remove the root part and the leading /
-				$folder = trim(str_replace($path, '', $folder), DIRECTORY_SEPARATOR);
 
 				$options[] = HTMLHelper::_('select.option', $folder, $folder);
 			}


### PR DESCRIPTION
### Summary of Changes
As title says
`$folder` is a full path and can't be compared to folder names in the pregmatch.

### Testing Instructions
Create a field anywhere in a core config.xml
Example

```
		<field
			name="installation"
			type="folderlist"
			label="COM_LOCALISE_LABEL_INSTALLATION_FOLDER"
			description="COM_LOCALISE_LABEL_INSTALLATION_FOLDER_DESC"
			hide_default="true"
			default="installation"
			exclude="administrator|api|build|components|cache|images|includes|language|libraries|logs|media|modules|node_modules|plugins|templates|test|tmp|bin|cli|layouts" />
```
That field should display in a dropdown all folders which are not excluded.
For example, when testing on 4.0-dev and if one keeps the installation folder, it will let select the installation folder.

### Before patch
No folder displays in dropdown.


### After patch
Folders not in the list in `exclude` are displayed.

### NOTE
The existing code works fine in staging/3.10-dev
Therefore something has broken it. As I could not find what, I corrected the file.

@SharkyKZ 
As you worked on that file, you may know if there is another solution.
