### PR TITLE
Remove publish-diff from drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -37,35 +37,6 @@ steps:
     commands:
       - npm ci --unsafe-perm
 
-  - name: publish-diff
-    image: joomlaprojects/docker-images:patchtester
-    failure: ignore
-    depends_on: [ npm ]
-    environment:
-      CMP_ARCHIVE_NAME: "build"
-      CMP_MASTER_FOLDER: "/reference"
-      CMP_SLAVE_FOLDER: "." # The directory the current repo is in
-      FTP_USERNAME:
-        from_secret: ftpusername
-      FTP_PASSWORD:
-        from_secret: ftppassword
-      FTP_HOSTNAME: ci.joomla.org
-      FTP_PORT: "21"
-      FTP_DEST_DIR: /artifacts
-      FTP_VERIFY: "false"
-      FTP_SECURE: "true"
-      BRANCH_NAME: "4.0-dev" # Current branch to check against (from repo joomla/joomla-cms)
-      DRONE_PULL_REQUEST: DRONE_PULL_REQUEST
-    commands:
-      - export PULL_ID=$DRONE_PULL_REQUEST
-      - /bin/compare.sh
-    volumes:
-      - name: reference
-        path: /reference
-    when:
-      branch:
-      - 4.0-dev
-
   - name: rebuild-cache
     image: drillster/drone-volume-cache
     depends_on: [ npm ]
@@ -339,6 +310,6 @@ steps:
 
 ---
 kind: signature
-hmac: 96e2fc482e327ef648d7632eb06048ece16cf3a04e27c30dd4ff4a1dc2236a8d
+hmac: 9bb74c784835b3ef017189b6f407cf7750d3f38464d42006da76999b62b41277
 
 ...


### PR DESCRIPTION
Temporary remove patchtester builds from drone because of the container fill the disk space our drone nodes.