### PR TITLE
Fix removing values from list-based custom fields

### DIFF
--- a/administrator/components/com_fields/models/field.php
+++ b/administrator/components/com_fields/models/field.php
@@ -191,8 +191,14 @@ class FieldsModelField extends JModelAdmin
 				}
 
 				$query = $db->getQuery(true);
-				$query->delete('#__fields_values')->where('field_id = ' . (int) $field->id)
-					->where('value NOT IN (' . implode(',', $names) . ')');
+				$query->delete('#__fields_values')->where('field_id = ' . (int) $field->id);
+
+				// If new values are set, delete only old values. Otherwise delete all values.
+				if ($names)
+				{
+					$query->where('value NOT IN (' . implode(',', $names) . ')');
+				}
+
 				$db->setQuery($query);
 				$db->execute();
 			}

--- a/administrator/components/com_fields/models/field.php
+++ b/administrator/components/com_fields/models/field.php
@@ -183,20 +183,20 @@ class FieldsModelField extends JModelAdmin
 
 			if (is_object($oldParams) && is_object($newParams) && $oldParams != $newParams)
 			{
-				$newValues = array();
+				$names = array();
 
 				foreach ($newParams as $param)
 				{
-					$newValues[] = $db->q($param['value']);
+					$names[] = $db->q($param['value']);
 				}
 
 				$query = $db->getQuery(true);
 				$query->delete('#__fields_values')->where('field_id = ' . (int) $field->id);
 
 				// If new values are set, delete only old values. Otherwise delete all values.
-				if ($newValues)
+				if ($names)
 				{
-					$query->where('value NOT IN (' . implode(',', $newValues) . ')');
+					$query->where('value NOT IN (' . implode(',', $names) . ')');
 				}
 
 				$db->setQuery($query);

--- a/administrator/components/com_fields/models/field.php
+++ b/administrator/components/com_fields/models/field.php
@@ -183,20 +183,20 @@ class FieldsModelField extends JModelAdmin
 
 			if (is_object($oldParams) && is_object($newParams) && $oldParams != $newParams)
 			{
-				$names = array();
+				$newValues = array();
 
 				foreach ($newParams as $param)
 				{
-					$names[] = $db->q($param['value']);
+					$newValues[] = $db->q($param['value']);
 				}
 
 				$query = $db->getQuery(true);
 				$query->delete('#__fields_values')->where('field_id = ' . (int) $field->id);
 
 				// If new values are set, delete only old values. Otherwise delete all values.
-				if ($names)
+				if ($newValues)
 				{
-					$query->where('value NOT IN (' . implode(',', $names) . ')');
+					$query->where('value NOT IN (' . implode(',', $newValues) . ')');
 				}
 
 				$db->setQuery($query);


### PR DESCRIPTION
### Summary of Changes

Fixes a query error which occurs when removing values from list-based custom fields.

### Testing Instructions

Create a Checkboxes custom field.
Add values 1, 2, 3.
Create an article, select those values.
Edit the custom field. Remove all values and save.

### Expected result

Values removed from `#__fields_values` table.

### Actual result

>You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near ')' at line 3 

### Documentation Changes Required

No.