### PR TITLE
[4.0] All values are deleted when changing list-based custom field options

### DIFF
--- a/administrator/components/com_fields/src/Model/FieldModel.php
+++ b/administrator/components/com_fields/src/Model/FieldModel.php
@@ -218,12 +218,8 @@ class FieldModel extends AdminModel
 
 			if (is_object($oldParams) && is_object($newParams) && $oldParams != $newParams)
 			{
-				$names = array();
-
-				foreach ($newParams as $param)
-				{
-					$names[] = $db->quote($param['value']);
-				}
+				// Get new values.
+				$names = array_column((array) $newParams, 'value');
 
 				$fieldId = (int) $field->id;
 				$query = $db->getQuery(true);


### PR DESCRIPTION
### Summary of Changes

Fixes query deleting all field values when changing list-based custom field options.

### Testing Instructions

Create a list-based field (e.g. Checkboxes).
Add some options (e.g. 1, 2, 3).
Create an article. Select all options.
Edit the custom field. Remove option with value 3.
View the article in frontend. Check the custom field values.

### Expected result

Values 1 and 2 are shown.

### Actual result

All values gone.

### Documentation Changes Required

No.