### PR TITLE
[4.0] Don't show empty tooltip

### DIFF
--- a/administrator/components/com_menus/tmpl/items/modal.php
+++ b/administrator/components/com_menus/tmpl/items/modal.php
@@ -142,7 +142,7 @@ if (!empty($editor))
 						<td class="text-center d-none d-md-table-cell">
 							<?php if ($item->type == 'component') : ?>
 								<?php if ($item->language == '*' || $item->home == '0') : ?>
-									<?php echo HTMLHelper::_('jgrid.isdefault', $item->home, $i, 'items.', ($item->language != '*' || !$item->home) && 0); ?>
+									<?php echo HTMLHelper::_('jgrid.isdefault', $item->home, $i, 'items.', ($item->language != '*' || !$item->home) && false && !$item->protected, 'cb', null, 'home', 'circle'); ?>
 								<?php else : ?>
 									<?php if ($item->language_image) : ?>
 										<?php echo HTMLHelper::_('image', 'mod_languages/' . $item->language_image . '.gif', $item->language_title, array('title' => $item->language_title), true); ?>

--- a/libraries/src/HTML/Helpers/JGrid.php
+++ b/libraries/src/HTML/Helpers/JGrid.php
@@ -95,7 +95,7 @@ abstract class JGrid
 		}
 		else
 		{
-			$html[] = '<a class="tbody-icon ' . $active_class . '-disabled disabled jgrid"';
+			$html[] = '<span class="tbody-icon ' . $active_class . '-disabled disabled jgrid"';
 			$html[] = $tip ? ' aria-labelledby="' . $ariaid . '"' : '';
 			$html[] = '>';
 
@@ -108,7 +108,7 @@ abstract class JGrid
 				$html[] = '<span class="icon-' . $inactive_class . '" aria-hidden="true"></span>';
 			}
 
-			$html[] = '</a>';
+			$html[] = '</span>';
 			$html[] = $tip ? '<div role="tooltip" id="' . $ariaid . '">' . $title . '</div>' : '';
 		}
 

--- a/libraries/src/HTML/Helpers/JGrid.php
+++ b/libraries/src/HTML/Helpers/JGrid.php
@@ -65,6 +65,12 @@ abstract class JGrid
 			$title = $enabled ? $active_title : $inactive_title;
 			$title = $translate ? Text::_($title) : $title;
 			$ariaid = $checkbox . $task . $i . '-desc';
+
+			// Don't show empty tooltip.
+			if ($title === '')
+			{
+				$tip = false;
+			}
 		}
 
 		if ($enabled)


### PR DESCRIPTION
Fixes https://github.com/joomla/joomla-cms/issues/29173.

### Summary of Changes

Omits tooltip when empty.
Also corrects menu item icons in modal layout.

### Testing Instructions

Create an article.
In the editor click CMS Content -> Menu.
Hover over icons in "Home" column.

### Expected result

Nothing or tooltip with text shown.

### Actual result

Empty tooltip:

![](https://user-images.githubusercontent.com/2019801/82457909-ecbc3b00-9aad-11ea-9a0c-8e518631ba8e.png)


### Documentation Changes Required

No.