### PR TITLE
[4.0] Fix line height parameter in CodeMirror

### DIFF
--- a/plugins/editors/codemirror/codemirror.xml
+++ b/plugins/editors/codemirror/codemirror.xml
@@ -250,7 +250,6 @@
 					type="list"
 					label="PLG_CODEMIRROR_FIELD_LINE_HEIGHT_LABEL"
 					default="1.2"
-					filter="float"
 					validate="options"
 					>
 					<option value="1.0">1.0</option>


### PR DESCRIPTION
Pull Request for Issue #29177.

### Summary of Changes
Remove float filter since there is already options validation.


### Testing Instructions
1. Go to your Plugin Manager and open Codemirror
2. Click on the `Appearance Options` tab
3. Set the `Line Height` to `2.0`
4. Click `Save`


### Expected result

The parameter shows as `2.0`

### Actual result

The parameter shows as `1.0`



### Documentation Changes Required

