### PR TITLE
Remove create/edit menu item buttons in frontend

### DIFF
--- a/administrator/components/com_menus/models/fields/modal/menu.php
+++ b/administrator/components/com_menus/models/fields/modal/menu.php
@@ -142,9 +142,12 @@ class JFormFieldModal_Menu extends JFormField
 		{
 			$this->allowSelect = ((string) $this->element['select']) !== 'false';
 			$this->allowClear = ((string) $this->element['clear']) !== 'false';
-			$this->allowNew = ((string) $this->element['new']) === 'true';
-			$this->allowEdit = ((string) $this->element['edit']) === 'true';
 			$this->allowPropagate = ((string) $this->element['propagate']) === 'true';
+
+			// Creating/editing menu items is not supported in frontend.
+			$isAdministrator = JFactory::getApplication()->isClient('administrator');
+			$this->allowNew = $isAdministrator ? ((string) $this->element['new']) === 'true' : false;
+			$this->allowEdit = $isAdministrator ? ((string) $this->element['edit']) === 'true' : false;
 		}
 
 		return $return;


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/29190.

### Summary of Changes

Removes edit/create menu item buttons from menu modal field when in frontend.

### Testing Instructions

Login to frontend.
Edit `mod_menu` or `mod_login` module.
Inspect ` Base Item` field in `mod_menu` form and `Login Redirection Page` in `mod_login` form.

### Expected result

Create/Edit buttons not present.

### Actual result

Create/Edit buttons present and clicking them leads to a 404 page.

### Documentation Changes Required

IDK.