### PR TITLE
Fix line height parameter in CodeMirror

### DIFF
--- a/plugins/editors/codemirror/codemirror.xml
+++ b/plugins/editors/codemirror/codemirror.xml
@@ -276,7 +276,7 @@
 					default="1.2"
 					filter="float"
 					>
-					<option value="1.0">1.0</option>
+					<option value="1">1</option>
 					<option value="1.1">1.1</option>
 					<option value="1.2">1.2</option>
 					<option value="1.3">1.3</option>
@@ -286,7 +286,7 @@
 					<option value="1.7">1.7</option>
 					<option value="1.8">1.8</option>
 					<option value="1.9">1.9</option>
-					<option value="2.0">2.0</option>
+					<option value="2">2</option>
 				</field>
 
 				<field


### PR DESCRIPTION
Pull Request for Issue #29177.

### Summary of Changes
Change 1.0 and 2.0 to 1 and 2.


### Testing Instructions
1. Go to your Plugin Manager and open Codemirror
2. Click on the `Appearance Options` tab
3. Set the `Line Height` to `2.0`
4. Click `Save`


### Expected result

The parameter shows as `2.0`

### Actual result

The parameter shows as `1.0`

