### PR TITLE
[4.0][RFC] hide db credentials from API

### DIFF
--- a/api/components/com_config/src/View/Application/JsonapiView.php
+++ b/api/components/com_config/src/View/Application/JsonapiView.php
@@ -45,6 +45,7 @@ class JsonapiView extends BaseApiView
 		'dbsslcert',
 		'dbsslca',
 		'dbsslcipher',
+		'dbsslkey',
 	];
 
 	/**

--- a/api/components/com_config/src/View/Application/JsonapiView.php
+++ b/api/components/com_config/src/View/Application/JsonapiView.php
@@ -26,6 +26,28 @@ USE Joomla\Component\Config\Administrator\Model\ApplicationModel;
 class JsonapiView extends BaseApiView
 {
 	/**
+	 * The fields to not render for secuty reason
+	 *
+	 * @var  array
+	 * @since  4.0.0
+	 */
+	protected $fieldsToNotRender = [
+		'editor',
+		'captcha',
+		'dbprefix',
+		'db',
+		'password',
+		'user',
+		'host',
+		'dbtype',
+		'dbencryption',
+		'dbsslverifyservercert',
+		'dbsslcert',
+		'dbsslca',
+		'dbsslcipher',
+	];
+
+	/**
 	 * Execute and display a template script.
 	 *
 	 * @param   array|null  $items  Array of items
@@ -42,6 +64,11 @@ class JsonapiView extends BaseApiView
 
 		foreach ($model->getData() as $key => $value)
 		{
+			if (\in_array($key, $this->fieldsToNotRender))
+			{
+				continue;
+			}
+	
 			$item    = (object) [$key => $value];
 			$items[] = $this->prepareItem($item);
 		}

--- a/api/components/com_config/src/View/Application/JsonapiView.php
+++ b/api/components/com_config/src/View/Application/JsonapiView.php
@@ -69,7 +69,7 @@ class JsonapiView extends BaseApiView
 			{
 				continue;
 			}
-	
+
 			$item    = (object) [$key => $value];
 			$items[] = $this->prepareItem($item);
 		}

--- a/api/components/com_config/src/View/Application/JsonapiView.php
+++ b/api/components/com_config/src/View/Application/JsonapiView.php
@@ -26,7 +26,7 @@ USE Joomla\Component\Config\Administrator\Model\ApplicationModel;
 class JsonapiView extends BaseApiView
 {
 	/**
-	 * The fields to not render for secuty reason
+	 * The fields to not render for security reason
 	 *
 	 * @var  array
 	 * @since  4.0.0

--- a/api/components/com_config/src/View/Application/JsonapiView.php
+++ b/api/components/com_config/src/View/Application/JsonapiView.php
@@ -12,6 +12,7 @@ namespace Joomla\Component\Config\Api\View\Application;
 \defined('_JEXEC') or die;
 
 use Joomla\CMS\Extension\ExtensionHelper;
+use Joomla\CMS\Factory;
 use Joomla\CMS\MVC\View\JsonApiView as BaseApiView;
 use Joomla\CMS\Serializer\JoomlaSerializer;
 use Joomla\CMS\Uri\Uri;
@@ -25,28 +26,6 @@ USE Joomla\Component\Config\Administrator\Model\ApplicationModel;
  */
 class JsonapiView extends BaseApiView
 {
-	/**
-	 * The fields to not render for security reason
-	 *
-	 * @var  array
-	 * @since  4.0.0
-	 */
-	protected $fieldsToNotRender = [
-		'editor',
-		'captcha',
-		'dbprefix',
-		'db',
-		'password',
-		'user',
-		'host',
-		'dbtype',
-		'dbencryption',
-		'dbsslverifyservercert',
-		'dbsslcert',
-		'dbsslca',
-		'dbsslcipher',
-		'dbsslkey',
-	];
 
 	/**
 	 * Execute and display a template script.
@@ -59,19 +38,21 @@ class JsonapiView extends BaseApiView
 	 */
 	public function displayList(array $items = null)
 	{
-		/** @var ApplicationModel $model */
-		$model = $this->getModel();
+		/** @var AdminModel $model */
+		$app   = Factory::getApplication();
+		$model = $app->bootComponent('com_admin')->getMVCFactory()->createModel('Sysinfo', 'Administrator');
 		$items = [];
+		$infos = ['info', 'phpSettings', 'config', 'directory', 'phpInfoArray', 'extensions'];
 
-		foreach ($model->getData() as $key => $value)
+		foreach ($infos as $keys)
 		{
-			if (\in_array($key, $this->fieldsToNotRender))
-			{
-				continue;
-			}
+			$config = $model->getSafeData($keys);
 
-			$item    = (object) [$key => $value];
-			$items[] = $this->prepareItem($item);
+			foreach ($config as $key => $value)
+			{
+				$item    = (object) [$key => $value];
+				$items[] = $this->prepareItem($item);
+			}
 		}
 
 		// Set up links for pagination

--- a/api/components/com_config/src/View/Application/JsonapiView.php
+++ b/api/components/com_config/src/View/Application/JsonapiView.php
@@ -26,7 +26,6 @@ USE Joomla\Component\Config\Administrator\Model\ApplicationModel;
  */
 class JsonapiView extends BaseApiView
 {
-
 	/**
 	 * Execute and display a template script.
 	 *


### PR DESCRIPTION
Pull Request for Issue #29196 .

### Summary of Changes
hide db credential fields


### Testing Instructions
`curl -H "Authorization: Bearer YOUR_TOKEN" {{URL}}/api/index.php/v1/config/application
`


### Expected result
db credentials not exposed


### Actual result
exposed


### Documentation Changes Required
?
