### PR TITLE
Change header_class type from text to textarea

### DIFF
--- a/administrator/components/com_modules/forms/advanced.xml
+++ b/administrator/components/com_modules/forms/advanced.xml
@@ -35,7 +35,7 @@
 
 			<field
 				name="header_class"
-				type="text"
+				type="textarea"
 				label="COM_MODULES_FIELD_HEADER_CLASS_LABEL"
 			/>
 		</fieldset>

--- a/administrator/components/com_modules/forms/advanced.xml
+++ b/administrator/components/com_modules/forms/advanced.xml
@@ -37,6 +37,7 @@
 				name="header_class"
 				type="textarea"
 				label="COM_MODULES_FIELD_HEADER_CLASS_LABEL"
+				rows="3"
 			/>
 		</fieldset>
 	</fields>


### PR DESCRIPTION
Change the type for header_class to textarea to resolve https://github.com/joomla/joomla-cms/issues/29183

Pull Request for Issue #29183.

### Summary of Changes
Change the type for header_class to textarea


### Testing Instructions
- Edit a module
- Go to the Advanced settings tab for the module
- Header Class will now be a textarea instead of a text field.

### Expected result
![image](https://user-images.githubusercontent.com/5515866/82732944-e9e27400-9d53-11ea-8db8-9c5963188347.png)




### Actual result



### Documentation Changes Required

