### PR TITLE
Change header_class type from text to textarea

### DIFF
--- a/components/com_config/forms/modules_advanced.xml
+++ b/components/com_config/forms/modules_advanced.xml
@@ -31,6 +31,7 @@
 				name="header_class"
 				type="textarea"
 				label="COM_MODULES_FIELD_HEADER_CLASS_LABEL"
+				rows="3"
 			/>
 
 			<field

--- a/components/com_config/forms/modules_advanced.xml
+++ b/components/com_config/forms/modules_advanced.xml
@@ -29,7 +29,7 @@
 
 			<field
 				name="header_class"
-				type="text"
+				type="textarea"
 				label="COM_MODULES_FIELD_HEADER_CLASS_LABEL"
 			/>
 


### PR DESCRIPTION
Update front end layout: Change header_class type from text to textarea

File has the parameters displayed on the front end module editing form.

Pull Request for Issue #29183 .

### Summary of Changes
Changed type from text to textarea

### Testing Instructions
For consistency with the backend change, the field type on the front end advanced settings should also be changed to textarea.

- Login on front end 
- Edit a module
- Open the Advanced accordion

### Expected result
Header Class field will change from text field to textarea

![image](https://user-images.githubusercontent.com/5515866/82733636-78f18b00-9d58-11ea-99eb-51cdac9e84d7.png)

### Actual result



### Documentation Changes Required

