### PR TITLE
TinyMCE size units not working

### DIFF
--- a/plugins/editors/tinymce/tinymce.xml
+++ b/plugins/editors/tinymce/tinymce.xml
@@ -24,10 +24,10 @@
 	<config>
 		<fields name="params">
 			<fieldset name="basic">
-				<field 
-				       name="configuration" 
-				       type="tinymcebuilder" 
-				       hiddenLabel="true" 
+				<field
+				       name="configuration"
+				       type="tinymcebuilder"
+				       hiddenLabel="true"
 				 />
 			</fieldset>
 
@@ -45,15 +45,15 @@
 
 				<field
 					name="html_height"
-					type="number"
+					type="text"
 					label="PLG_TINY_FIELD_HTMLHEIGHT_LABEL"
 					description="PLG_TINY_FIELD_HTMLHEIGHT_DESC"
-					default="550"
+					default="550px"
 				/>
 
 				<field
 					name="html_width"
-					type="number"
+					type="text"
 					label="PLG_TINY_FIELD_HTMLWIDTH_LABEL"
 					description="PLG_TINY_FIELD_HTMLWIDTH_DESC"
 					default=""


### PR DESCRIPTION
Fixes https://github.com/joomla/joomla-cms/issues/29181.

### Summary of Changes

Fixes size units not working in TinyMCE.

### Testing Instructions

Edit TinyMCE plugin.
Set `HTML Width` to 50%.
View a page containing TinyMCE editor.

### Expected result

Editor is 50% wide.

### Actual result

Editor is 100% wide.

### Documentation Changes Required

No.