### PR TITLE
[4.0] Toggler icons missing in backend

### DIFF
--- a/administrator/templates/atum/scss/blocks/_sidebar.scss
+++ b/administrator/templates/atum/scss/blocks/_sidebar.scss
@@ -246,7 +246,7 @@
     }
 
     .navbar-toggler-icon::before {
-      font: normal normal normal 30px/1 "Font Awesome 5 Free";
+      font: normal normal 900 30px/1 "Font Awesome 5 Free";
       color: var(--toggle-color);
       content: "\f00d";
     }

--- a/administrator/templates/atum/scss/blocks/_toolbar.scss
+++ b/administrator/templates/atum/scss/blocks/_toolbar.scss
@@ -147,7 +147,7 @@
     }
 
     .toggler-toolbar-icon::before {
-      font: normal normal normal 30px/1 'Font Awesome 5 Free';
+      font: normal normal 900 30px/1 'Font Awesome 5 Free';
       color: var(--toggle-color);
       content: "\f00d";
     }


### PR DESCRIPTION
Fixes https://github.com/joomla/joomla-cms/issues/29188.

### Summary of Changes

Fixes missing toolbar and sidebar toggler icons.

### Testing Instructions

Using small resolution (<= 575px) go to a view containing a toolbar in backend.

### Expected result

No missing icons.

### Actual result

Missing toolbar and sidebar toggler icons:


![](https://user-images.githubusercontent.com/2019801/82550918-301eb400-9b57-11ea-8441-feec919829a3.png)


### Documentation Changes Required

No.