### PR TITLE
Notice in installer script #29116

### DIFF
--- a/libraries/src/Installer/InstallerScript.php
+++ b/libraries/src/Installer/InstallerScript.php
@@ -142,7 +142,7 @@ class InstallerScript
 		{
 			$manifest = $this->getItemArray('manifest_cache', '#__extensions', 'element', \JFactory::getDbo()->quote($this->extension));
 
-			// Check whether we have an old release installed and skip this check when this here is the instial install.
+			// Check whether we have an old release installed and skip this check when this here is the initial install.
 			if (!isset($manifest['version']))
 			{
 				return true;

--- a/libraries/src/Installer/InstallerScript.php
+++ b/libraries/src/Installer/InstallerScript.php
@@ -141,6 +141,13 @@ class InstallerScript
 		if (!$this->allowDowngrades && strtolower($type) === 'update')
 		{
 			$manifest = $this->getItemArray('manifest_cache', '#__extensions', 'element', \JFactory::getDbo()->quote($this->extension));
+
+			// Check whether we have an old release installed and skip this check when this here is the instial install.
+			if (!isset($manifest['version']))
+			{
+				return true;
+			}
+
 			$oldRelease = $manifest['version'];
 
 			if (version_compare($this->release, $oldRelease, '<'))


### PR DESCRIPTION
Pull Request for Issue #29116 cc @chmst @SharkyKZ 

### Summary of Changes

Check whether we have an old release installed and skip this check when this here is the initial install.

### Testing Instructions

- install a clean joomla
- install an extension for the first time
- notice the notice in the backend or the error log

### Expected result

No notices

### Actual result

Trying to access array offset on value of type null in line 148 of libraries\src\Installer\InstallerScript.php

### Documentation Changes Required

none