### PR TITLE
[4.0] Store changelogurl during module update via "Extensions: Install"

### DIFF
--- a/libraries/src/Installer/Adapter/ModuleAdapter.php
+++ b/libraries/src/Installer/Adapter/ModuleAdapter.php
@@ -602,6 +602,9 @@ class ModuleAdapter extends InstallerAdapter
 			// Update namespace
 			$this->extension->namespace = (string) $this->manifest->namespace;
 
+			// Update changelogurl
+			$this->extension->changelogurl = (string) $this->manifest->changelogurl;
+
 			// Update manifest
 			$this->extension->manifest_cache = $this->parent->generateManifestCache();
 


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/29208

### Testing Instructions
- Current Joomla 4 nightly build.

- Go to `administrator/index.php?option=com_installer&view=install`
- Install a module that has no `changelogurl` in its extension manifest file, i.e. this Joomla 3 module
https://snapshots.ghsvs.de/updates/joomla/mod_administratorlinkghsvs/mod_administratorlinkghsvs_2015.12.28.zip
**via tabulator `Upload Package File`.**
- Install the Joomla 4 version of the module. [It has a `changelogurl` in its extension manifest](https://github.com/GHSVS-de/mod_administratorlinkghsvs/blob/2020.05.23/mod_administratorlinkghsvs.xml#L17) file:
https://github.com/GHSVS-de/mod_administratorlinkghsvs/archive/2020.05.23.zip
**Also via tabulator `Upload Package File`.**

- See entry (= newest `extension_id`) for this module in table `#__extensions` => field `changelogurl` is empty. 

- Uninstall the module!

- Apply patch and try the installations steps above again (first Joomla 3 version, then Joomla 4 version).

- See entry for this module in table `#__extensions` => `changelogurl` correctly filled with an URL. 

- Uninstall the module to get rid of it ;-)