### PR TITLE
Change message for com_privacy (#29125)

### DIFF
--- a/language/en-GB/en-GB.com_privacy.ini
+++ b/language/en-GB/en-GB.com_privacy.ini
@@ -10,7 +10,7 @@ COM_PRIVACY_ADMIN_NOTIFICATION_USER_CREATED_REQUEST_MESSAGE="A new information r
 COM_PRIVACY_ADMIN_NOTIFICATION_USER_CREATED_REQUEST_SUBJECT="Information Request Submitted"
 COM_PRIVACY_CONFIRM_REMIND_SUCCEEDED="Your consent to this web site's Privacy Policy has been extended."
 COM_PRIVACY_CONFIRM_REQUEST_FIELDSET_LABEL="An email has been sent to your email address. The email has a confirmation token, please confirm your email address again and paste the confirmation token in the field below to prove that you are the owner of the information being requested."
-COM_PRIVACY_CONFIRM_REQUEST_SUCCEEDED="Your information request has been confirmed. We will process your request as soon as possible and the export will be sent to your email."
+COM_PRIVACY_CONFIRM_REQUEST_SUCCEEDED="Your information request has been confirmed. We will process your request as soon as possible."
 COM_PRIVACY_CREATE_REQUEST_SUCCEEDED="Your information request has been created. Before it can be processed, you must verify this request. An email has been sent to your address with additional instructions to complete this verification."
 ; You can use the following merge codes for all COM_PRIVACY_EMAIL strings:
 ; [SITENAME]  Site name, as set in Global Configuration.


### PR DESCRIPTION
@brianteeman (as the author PR #29125)

### Summary of Changes
For version 3.9.19, changes were made to the localization files, see https://github.com/joomla/joomla-cms/pull/29125.

> COM_PRIVACY_CONFIRM_REQUEST_SUCCEEDED="Your information request has been confirmed. We will process your request as soon as possible and the export will be sent to your email."

I suggest shortening this line for several reasons:

1. The user can create a request to DELETE his data and in this case the message confirming the request will not correspond to reality, because pressing the DELETE button in the control panel DOES NOT send a copy of the data to the address of this user.

2. Even assuming that before deleting, you can send a copy of the data to the user by mail - this is impossible, because the send data button is not available if the user has selected a request to delete data (see screenshot).

![Screenshot_1](https://user-images.githubusercontent.com/8440661/82764965-920f4000-9e1b-11ea-8b52-d175bf645d57.png)

---

By the way, it would be good to implement the function of automatically sending a notification to the user’s address about DELETING his data from the site. For example, how this is done for the export option:

> COM_PRIVACY_EMAIL_DATA_EXPORT_COMPLETED_BODY="An administrator for [URL] has completed the data export you requested and a copy of the information can be found in the file attached to this message."

In this case, we could write something like this (universal for all options) in the request confirmation message:

> COM_PRIVACY_CONFIRM_REQUEST_SUCCEEDED="Your information request has been confirmed. We will process your request as soon as possible and a notification will be sent to your email."