### PR TITLE
[4.0] Fix extension text when renaming in Media Manager

### DIFF
--- a/administrator/components/com_media/resources/scripts/components/modals/rename-modal.vue
+++ b/administrator/components/com_media/resources/scripts/components/modals/rename-modal.vue
@@ -8,7 +8,9 @@
                     <div :class="{'input-group': extension.length}">
                         <input id="name" class="form-control" type="text" :placeholder="translate('COM_MEDIA_NAME')"
                                :value="name" required autocomplete="off" ref="nameField">
-                        <span class="input-group-addon" v-if="extension.length">{{extension }}</span>
+                        <span class="input-group-append" v-if="extension.length">
+                            <span class="input-group-text">{{extension }}</span>
+                        </span>
                     </div>
                 </div>
             </form>


### PR DESCRIPTION
Pull Request for Issue #29154.

### Summary of Changes
Replace obsolete class `input-group-addon` with `input-group-append` to fix text display.


### Testing Instructions
Apply PR.
Run `npm i`
Go to Media Manager
Click on a file.
Click Rename icon.
Click on a folder.
Click Rename icon.


### Expected result
![29154](https://user-images.githubusercontent.com/368084/82765067-6ca51680-9dc8-11ea-8311-b7ac0261b784.png)



### Actual result
![82327320-1efa6980-99d6-11ea-87ae-e0dc98621156](https://user-images.githubusercontent.com/368084/82765082-847c9a80-9dc8-11ea-88b2-20f779950ea8.png)



### Documentation Changes Required

