### PR TITLE
[4.0] Error message if you don't select an image

### DIFF
--- a/build/media_source/system/joomla.asset.json
+++ b/build/media_source/system/joomla.asset.json
@@ -201,6 +201,7 @@
     },
     {
       "name": "webcomponent.field-media",
+      "class": "MediaFieldAssetItem",
       "type": "script",
       "uri": "system/fields/joomla-field-media.min.js",
       "webcomponent": true

--- a/build/media_source/system/js/fields/joomla-field-media.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-media.w-c.es6.js
@@ -192,6 +192,16 @@
 
     modalClose() {
       const input = this.querySelector(this.input);
+
+      if (Object.keys(Joomla.selectedFile).length === 0) {
+        // The user didn't select an item but hit the select button!?
+        const messages = {
+          error: [Joomla.Text._('JLIB_FORM_MEDIA_PREVIEW_EMPTY')],
+        };
+
+        Joomla.renderMessages(messages);
+      }
+
       Joomla.getImage(Joomla.selectedFile, input, this);
 
       Joomla.Modal.getCurrent().close();

--- a/build/media_source/system/js/fields/joomla-field-media.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-media.w-c.es6.js
@@ -199,7 +199,13 @@
           error: [Joomla.Text._('JLIB_FORM_MEDIA_PREVIEW_EMPTY')],
         };
 
+        Joomla.Modal.getCurrent().close();
         Joomla.renderMessages(messages);
+
+        // Scroll to top of page to ensure user sees the message on smaller screens
+        window.scrollTo(0, 0);
+
+        return;
       }
 
       Joomla.getImage(Joomla.selectedFile, input, this);

--- a/libraries/src/WebAsset/AssetItem/MediaFieldAssetItem.php
+++ b/libraries/src/WebAsset/AssetItem/MediaFieldAssetItem.php
@@ -2,7 +2,7 @@
 /**
  * Joomla! Content Management System
  *
- * @copyright  Copyright (C) 2005 - 2019 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2020 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/libraries/src/WebAsset/AssetItem/MediaFieldAssetItem.php
+++ b/libraries/src/WebAsset/AssetItem/MediaFieldAssetItem.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  Copyright (C) 2005 - 2019 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\WebAsset\AssetItem;
+
+\defined('JPATH_PLATFORM') or die;
+
+use Joomla\CMS\Document\Document;
+use Joomla\CMS\Language\Text;
+use Joomla\CMS\WebAsset\WebAssetAttachBehaviorInterface;
+use Joomla\CMS\WebAsset\WebAssetItem;
+
+/**
+ * Web Asset Item class for form.validate asset
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class MediaFieldAssetItem extends WebAssetItem implements WebAssetAttachBehaviorInterface
+{
+	/**
+	 * Method called when asset attached to the Document.
+	 * Useful for Asset to add a Script options.
+	 *
+	 * @param   Document  $doc  Active document
+	 *
+	 * @return void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function onAttachCallback(Document $doc)
+	{
+		Text::script('JLIB_FORM_MEDIA_PREVIEW_EMPTY');
+	}
+}


### PR DESCRIPTION
### Summary of Changes
Fixes an edge case in the media field


### Testing Instructions
Create an article, go to the media field (intro-text, full-text images), open the modal and hit the "select" button without actually selecting an image. Before patch you get a javascript error, after patch a nice happy warning.

### Documentation Changes Required
None.
