### PR TITLE
[4.0] Backend: Plugin changelog fails #29043

### DIFF
--- a/libraries/src/Installer/Adapter/PluginAdapter.php
+++ b/libraries/src/Installer/Adapter/PluginAdapter.php
@@ -472,8 +472,19 @@ class PluginAdapter extends InstallerAdapter
 				);
 			}
 
+			// Load the entry and update the manifest_cache
 			$this->extension->load($this->currentExtensionId);
+
+			// Update name
 			$this->extension->name = $this->name;
+
+			// Update namespace
+			$this->extension->namespace = (string) $this->manifest->namespace;
+
+			// Update changelogurl
+			$this->extension->changelogurl = (string) $this->manifest->changelogurl;
+
+			// Update manifest
 			$this->extension->manifest_cache = $this->parent->generateManifestCache();
 
 			// Update the manifest cache and name


### PR DESCRIPTION
Pull Request for Issue #29043 .

### Summary of Changes

Update plugin extension information

### Testing Instructions

Install plugin, check that changelogurl is empty, then try to install new plugin with a changelogurl on the xml.

### Expected result

That the extension table is updated.

### Actual result

The changelogurl is empty.

### Documentation Changes Required

