### PR TITLE
[4.0] Remove role=document from the modal dialog

### DIFF
--- a/layouts/joomla/modal/main.php
+++ b/layouts/joomla/modal/main.php
@@ -72,7 +72,7 @@ if (isset($params['url']))
 }
 ?>
 <div id="<?php echo $selector; ?>" role="dialog" <?php echo ArrayHelper::toString($modalAttributes); ?> <?php echo $url ?? ''; ?> <?php echo isset($url) ? 'data-iframe="'.trim($iframeHtml).'"' : ''; ?>>
-	<div class="modal-dialog modal-lg<?php echo $modalDialogClass; ?>" role="document">
+	<div class="modal-dialog modal-lg<?php echo $modalDialogClass; ?>">
 		<div class="modal-content">
 			<?php
 				// Header


### PR DESCRIPTION
### Summary of Changes

`role="document"` is only needed when there is a parent `role="application"`. Seeing as Joomla doesn't do this, it can be removed.

As of Bootstrap 4.2, it automatically adds `aria-modal` when the modal is opened, 

### Testing Instructions

Code review

### Evidence

https://w3c.github.io/aria-practices/examples/dialog-modal/dialog.html
https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Document_Role