### PR TITLE
[4.0] Fix HTML body editing for mail templates

### DIFF
--- a/build/media_source/com_mails/js/admin-email-template-edit.es6.js
+++ b/build/media_source/com_mails/js/admin-email-template-edit.es6.js
@@ -121,10 +121,13 @@
 
         if (target.value === '0') {
           this.setHtmlBodyValue(this.templateData.htmlbody ? this.templateData.htmlbody.master : '');
+          this.inputHtmlBody.disabled = true;
           Joomla.editors.instances[this.inputHtmlBody.id].disable(true);
           tagsContainer.classList.add('hidden');
         } else if (target.value === '1') {
           Joomla.editors.instances[this.inputHtmlBody.id].disable(false);
+          this.inputHtmlBody.disabled = false;
+          this.inputHtmlBody.readOnly = false;
           this.setHtmlBodyValue(this.templateData.htmlbody ? this.templateData.htmlbody.translated : '');
           tagsContainer.classList.remove('hidden');
         } else {


### PR DESCRIPTION
Pull Request for Issue #28524 .

### Summary of Changes

Add missing enable/disable of the input for the HTML body to the javascript for Mail Templates admin edit, like it is already there for the input for the (text) body.

### Testing Instructions

#### Preparation

For reproducing the issue you have to use a clean 4.0-dev staging branch or latest J4 nightly build.

For testing the patch of this Pull Request (PR) here, you have to do following 2 steps:
1. Apply the patch e.g. with patchtester on a clean 4.0-dev staging branch or latest J4 nightly build.
2. Run `npm ci` or `npm run build:js`.

If you don't have npm, make a new installation with the installation package build for this PR, and then test. No need to apply the patch in this case, the patch is already included. You can find the installation package here: [https://ci.joomla.org/artifacts/joomla/joomla-cms/4.0-dev/29229/downloads/32398/](https://ci.joomla.org/artifacts/joomla/joomla-cms/4.0-dev/29229/downloads/32398/)

#### Execution

1. See issue #28524 : Check if you can add an HTML body to a mail template. Check that the HTML body is not lost after saving.
2. Try to toggle the editor.
3. Try to insert into the HTML body some of the replacement tags shown right beside the editor.

### Expected result with patch applied

You can add an HTML body for an email template, and it's not lost after saving.

You can add replacement tags to the HTML body of an email template.

You can toggle the editor.

### Actual result without patch applied

You can't save an HTML body for an email template, see issue #28524 .

You can't add replacement tags to the HTML body of an email template.

You can't really toggle the editor.

### Documentation Changes Required

None, except if we have some documentation telling that the above shall not work ;-)