### PR TITLE
[4.0] Articles: Allow to populate viewlevels from state

### DIFF
--- a/components/com_content/src/Model/ArticlesModel.php
+++ b/components/com_content/src/Model/ArticlesModel.php
@@ -327,7 +327,7 @@ class ArticlesModel extends ListModel
 		// Filter by access level.
 		if ($this->getState('filter.access', true))
 		{
-			$groups = $user->getAuthorisedViewLevels();
+			$groups = $this->getState('filter.viewlevels', $user->getAuthorisedViewLevels());
 			$query->whereIn($db->quoteName('a.access'), $groups)
 				->whereIn($db->quoteName('c.access'), $groups);
 		}


### PR DESCRIPTION
I noticed this in Smart Search, that you can't define your own viewlevels for the list models. There might be situations where you want to set viewlevels different to those of the current user and this small change would allow that. This could only be tested by writing your own code that uses this feature and thus I would ask for a codereview instead.