### PR TITLE
Fix feed image

### DIFF
--- a/administrator/modules/mod_feed/tmpl/default.php
+++ b/administrator/modules/mod_feed/tmpl/default.php
@@ -49,9 +49,6 @@ else
 	}
 
 	if ($feed != false) :
-		// Image handling
-		$iUrl   = isset($feed->image) ? $feed->image : null;
-		$iTitle = isset($feed->imagetitle) ? $feed->imagetitle : null;
 		?>
 		<div style="direction: <?php echo $rssrtl ? 'rtl' :'ltr'; ?>; text-align: <?php echo $rssrtl ? 'right' :'left'; ?> !important"  class="feed<?php echo $moduleclass_sfx; ?>">
 		<?php
@@ -76,8 +73,8 @@ else
 		<?php endif; ?>
 
 		<!--  Feed image  -->
-		<?php if ($params->get('rssimage', 1) && $iUrl) : ?>
-			<img src="<?php echo $iUrl; ?>" alt="<?php echo @$iTitle; ?>"/>
+		<?php if ($params->get('rssimage', 1) && $feed->image) : ?>
+			<img src="<?php echo $feed->image->uri; ?>" alt="<?php echo $feed->image->title; ?>"/>
 		<?php endif; ?>
 
 

--- a/components/com_newsfeeds/views/newsfeed/tmpl/default.php
+++ b/components/com_newsfeeds/views/newsfeed/tmpl/default.php
@@ -79,9 +79,9 @@ defined('_JEXEC') or die;
 			</div>
 		<?php endif; ?>
 		<!-- Show Image -->
-		<?php if (isset($this->rssDoc->image, $this->rssDoc->imagetitle) && $this->params->get('show_feed_image')) : ?>
+		<?php if ($this->rssDoc->image && $this->params->get('show_feed_image')) : ?>
 			<div>
-				<img src="<?php echo $this->rssDoc->image; ?>" alt="<?php echo $this->rssDoc->image->decription; ?>" />
+				<img src="<?php echo $this->rssDoc->image->uri; ?>" alt="<?php echo $this->rssDoc->image->title; ?>" />
 			</div>
 		<?php endif; ?>
 		<!-- Show items -->

--- a/libraries/src/Feed/Feed.php
+++ b/libraries/src/Feed/Feed.php
@@ -15,17 +15,17 @@ use Joomla\CMS\Date\Date;
 /**
  * Class to encapsulate a feed for the Joomla Platform.
  *
- * @property  FeedPerson  $author         Person responsible for feed content.
- * @property  array       $categories     Categories to which the feed belongs.
- * @property  array       $contributors   People who contributed to the feed content.
- * @property  string      $copyright      Information about rights, e.g. copyrights, held in and over the feed.
- * @property  string      $description    A phrase or sentence describing the feed.
- * @property  string      $generator      A string indicating the program used to generate the feed.
- * @property  string      $image          Specifies a GIF, JPEG or PNG image that should be displayed with the feed.
- * @property  Date        $publishedDate  The publication date for the feed content.
- * @property  string      $title          A human readable title for the feed.
- * @property  Date        $updatedDate    The last time the content of the feed changed.
- * @property  string      $uri            Universal, permanent identifier for the feed.
+ * @property  FeedPerson     $author         Person responsible for feed content.
+ * @property  array          $categories     Categories to which the feed belongs.
+ * @property  array          $contributors   People who contributed to the feed content.
+ * @property  string         $copyright      Information about rights, e.g. copyrights, held in and over the feed.
+ * @property  string         $description    A phrase or sentence describing the feed.
+ * @property  string         $generator      A string indicating the program used to generate the feed.
+ * @property  FeedLink|null  $image          FeedLink object containing feed image properties.
+ * @property  Date           $publishedDate  The publication date for the feed content.
+ * @property  string         $title          A human readable title for the feed.
+ * @property  Date           $updatedDate    The last time the content of the feed changed.
+ * @property  string         $uri            Universal, permanent identifier for the feed.
  *
  * @since  3.1.4
  */

--- a/modules/mod_feed/tmpl/default.php
+++ b/modules/mod_feed/tmpl/default.php
@@ -54,9 +54,6 @@ else
 
 	if ($feed !== false)
 	{
-		// Image handling
-		$iUrl   = isset($feed->image) ? $feed->image : null;
-		$iTitle = isset($feed->imagetitle) ? $feed->imagetitle : null;
 		?>
 		<div style="direction: <?php echo $rssrtl ? 'rtl' :'ltr'; ?>; text-align: <?php echo $rssrtl ? 'right' :'left'; ?> !important" class="feed<?php echo $moduleclass_sfx; ?>">
 		<?php
@@ -84,9 +81,9 @@ else
 			<?php
 		}
 		// Feed image
-		if ($iUrl && $params->get('rssimage', 1)) :
+		if ($feed->image && $params->get('rssimage', 1)) :
 		?>
-			<img src="<?php echo $iUrl; ?>" alt="<?php echo @$iTitle; ?>"/>
+			<img src="<?php echo $feed->image->uri; ?>" alt="<?php echo $feed->image->title; ?>"/>
 		<?php endif; ?>
 
 


### PR DESCRIPTION
Once it reaches 4.0, this PR will solve https://github.com/joomla/joomla-cms/issues/29236.

### Summary of Changes

Fixes feed image display.

### Testing Instructions

Create a feed module. Use a feed link containing an image, e.g. http://feeds.bbci.co.uk/news/world/europe/rss.xml.
View the module.

### Expected result

Image is shown.

### Actual result

Image not shown.

### Documentation Changes Required

No.