### PR TITLE
SiteRouter::buildSefRoute fix

### DIFF
--- a/libraries/src/Router/SiteRouter.php
+++ b/libraries/src/Router/SiteRouter.php
@@ -526,7 +526,14 @@ class SiteRouter extends Router
 		$itemID    = !empty($query['Itemid']) ? $query['Itemid'] : null;
 		$crouter   = $this->getComponentRouter($component);
 		$parts     = $crouter->build($query);
-		$result    = implode('/', $parts);
+		if (empty($parts))
+		{
+			$result = '';
+		}
+		else
+		{
+			$result = implode('/', $parts);
+		}
 		$tmp       = ($result !== '') ? $result : '';
 
 		// Build the application route

--- a/libraries/src/Router/SiteRouter.php
+++ b/libraries/src/Router/SiteRouter.php
@@ -526,7 +526,7 @@ class SiteRouter extends Router
 		$itemID    = !empty($query['Itemid']) ? $query['Itemid'] : null;
 		$crouter   = $this->getComponentRouter($component);
 		$parts     = $crouter->build($query);
-		if (empty($parts))
+		if (empty($parts) || is_array($parts) === false)
 		{
 			$result = '';
 		}


### PR DESCRIPTION
Fix Warning massage (implode(): Invalid arguments passed in /libraries/src/Router/SiteRouter.php on line 529) if component router build method return null or any other type of non-array.