### PR TITLE
[4.0] menu item create article: swap default category switch colours

### DIFF
--- a/components/com_content/tmpl/form/edit.xml
+++ b/components/com_content/tmpl/form/edit.xml
@@ -19,8 +19,8 @@
 				layout="joomla.form.field.radio.switcher"
 				default="0"
 				>
-				<option value="1">JYES</option>
 				<option value="0">JNO</option>
+				<option value="1">JYES</option>
 			</field>
 
 			<field


### PR DESCRIPTION
### Summary of Changes
Swap colours of the switch "default category"



### Testing Instructions
Make a new Menu item for "create article" and g to tab "Options".



### Expected result
switch "Specific Category" is "no" with colour grey, as in other switches.


### Actual result
switch "Specific Category" is "no" with colour green.

