### PR TITLE
[4.0][Workflow] Use new Event System for featured event and some gui fixes

### DIFF
--- a/administrator/components/com_content/src/Controller/ArticlesController.php
+++ b/administrator/components/com_content/src/Controller/ArticlesController.php
@@ -65,7 +65,7 @@ class ArticlesController extends AdminController
 		// Check for request forgeries
 		$this->checkToken();
 
-    $user        = $this->app->getIdentity();
+		$user        = $this->app->getIdentity();
 		$ids         = $this->input->get('cid', array(), 'array');
 		$values      = array('featured' => 1, 'unfeatured' => 0);
 		$task        = $this->getTask();

--- a/administrator/components/com_content/src/Controller/ArticlesController.php
+++ b/administrator/components/com_content/src/Controller/ArticlesController.php
@@ -113,6 +113,7 @@ class ArticlesController extends AdminController
 				$message = Text::plural('COM_CONTENT_N_ITEMS_UNFEATURED', count($ids));
 			}
 		}
+
 		$this->setRedirect(Route::_($redirectUrl, false), $message);
 	}
 

--- a/administrator/components/com_content/src/Controller/ArticlesController.php
+++ b/administrator/components/com_content/src/Controller/ArticlesController.php
@@ -72,7 +72,8 @@ class ArticlesController extends AdminController
 		$value  = ArrayHelper::getValue($values, $task, 0, 'int');
 		$view   = $this->input->get('view', '');
 
-		$redirectUrl = 'index.php?option=com_content&view=' . ($view === 'featured' ? 'featured' : 'articles');
+		$redirectUrl = 'index.php?option=com_content&view=' . ($view === 'featured' ? 'featured' : 'articles')
+			. $this->getRedirectToListAppend();
 
 		// Access checks.
 		foreach ($ids as $i => $id)
@@ -113,7 +114,6 @@ class ArticlesController extends AdminController
 			}
 		}
 		$this->setRedirect(Route::_($redirectUrl, false), $message);
-
 	}
 
 	/**

--- a/administrator/components/com_content/src/Controller/ArticlesController.php
+++ b/administrator/components/com_content/src/Controller/ArticlesController.php
@@ -70,6 +70,9 @@ class ArticlesController extends AdminController
 		$values = array('featured' => 1, 'unfeatured' => 0);
 		$task   = $this->getTask();
 		$value  = ArrayHelper::getValue($values, $task, 0, 'int');
+		$view   = $this->input->get('view', '');
+
+		$redirectUrl = 'index.php?option=com_content&view=' . ($view === 'featured' ? 'featured' : 'articles');
 
 		// Access checks.
 		foreach ($ids as $i => $id)
@@ -95,7 +98,9 @@ class ArticlesController extends AdminController
 			// Publish the items.
 			if (!$model->featured($ids, $value))
 			{
-				$this->app->enqueueMessage($model->getError(), 'error');
+				$this->setRedirect(Route::_($redirectUrl, false), $model->getError(), 'error');
+
+				return;
 			}
 
 			if ($value == 1)
@@ -107,17 +112,8 @@ class ArticlesController extends AdminController
 				$message = Text::plural('COM_CONTENT_N_ITEMS_UNFEATURED', count($ids));
 			}
 		}
+		$this->setRedirect(Route::_($redirectUrl, false), $message);
 
-		$view = $this->input->get('view', '');
-
-		if ($view == 'featured')
-		{
-			$this->setRedirect(Route::_('index.php?option=com_content&view=featured', false), $message);
-		}
-		else
-		{
-			$this->setRedirect(Route::_('index.php?option=com_content&view=articles', false), $message);
-		}
 	}
 
 	/**

--- a/administrator/components/com_content/src/Controller/ArticlesController.php
+++ b/administrator/components/com_content/src/Controller/ArticlesController.php
@@ -65,15 +65,12 @@ class ArticlesController extends AdminController
 		// Check for request forgeries
 		$this->checkToken();
 
-		$user   = $this->app->getIdentity();
-		$ids    = $this->input->get('cid', array(), 'array');
-		$values = array('featured' => 1, 'unfeatured' => 0);
-		$task   = $this->getTask();
-		$value  = ArrayHelper::getValue($values, $task, 0, 'int');
-		$view   = $this->input->get('view', '');
-
-		$redirectUrl = 'index.php?option=com_content&view=' . ($view === 'featured' ? 'featured' : 'articles')
-			. $this->getRedirectToListAppend();
+    $user        = $this->app->getIdentity();
+		$ids         = $this->input->get('cid', array(), 'array');
+		$values      = array('featured' => 1, 'unfeatured' => 0);
+		$task        = $this->getTask();
+		$value       = ArrayHelper::getValue($values, $task, 0, 'int');
+		$redirectUrl = 'index.php?option=com_content&view=' . $this->view_list . $this->getRedirectToListAppend();
 
 		// Access checks.
 		foreach ($ids as $i => $id)

--- a/administrator/components/com_content/src/Event/Model/FeatureEvent.php
+++ b/administrator/components/com_content/src/Event/Model/FeatureEvent.php
@@ -74,4 +74,19 @@ class FeatureEvent extends AbstractImmutableEvent
 
 		parent::__construct($name, $arguments);
 	}
+
+	/**
+	 * Set used parameter to true
+	 *
+	 * @param   bool  $value  The value to set
+	 *
+	 * @return void
+	 *
+	 * @since   4.0.0
+	 */
+	public function setAbort(string $reason)
+	{
+		$this->arguments['abort'] = true;
+		$this->arguments['abortReason'] = $reason;
+	}
 }

--- a/administrator/components/com_content/src/Event/Model/FeatureEvent.php
+++ b/administrator/components/com_content/src/Event/Model/FeatureEvent.php
@@ -60,7 +60,7 @@ class FeatureEvent extends AbstractImmutableEvent
 			throw new BadMethodCallException("Argument 'pks' of event {$this->name} is not of type 'array'");
 		}
 
-		if (!isset($arguments['value']) || !is_numeric($arguments['value']) )
+		if (!isset($arguments['value']) || !is_numeric($arguments['value']))
 		{
 			throw new BadMethodCallException("Argument 'value' of event {$this->name} is not of type 'numeric'");
 		}

--- a/administrator/components/com_content/src/Event/Model/FeatureEvent.php
+++ b/administrator/components/com_content/src/Event/Model/FeatureEvent.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  Copyright (C) 2005 - 2019 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Component\Content\Administrator\Event\Model;
+
+\defined('JPATH_PLATFORM') or die;
+
+use BadMethodCallException;
+use Joomla\CMS\Event\AbstractImmutableEvent;
+
+/**
+ * Event class for WebAsset events
+ *
+ * @since  4.0.0
+ */
+class FeatureEvent extends AbstractImmutableEvent
+{
+	/**
+	 * Constructor.
+	 *
+	 * @param   string  $name       The event name.
+	 * @param   array   $arguments  The event arguments.
+	 *
+	 * @throws  BadMethodCallException
+	 *
+	 * @since   4.0.0
+	 */
+	public function __construct($name, array $arguments = array())
+	{
+		if (!isset($arguments['extension']))
+		{
+			throw new BadMethodCallException("Argument 'extension' of event {$this->name} is required but has not been provided");
+		}
+
+		if (!isset($arguments['extension']) || !is_string($arguments['extension']))
+		{
+			throw new BadMethodCallException("Argument 'extension' of event {$this->name} is not of type 'string'");
+		}
+
+		if (strpos($arguments['extension'], '.') === false)
+		{
+			throw new BadMethodCallException("Argument 'extension' of event {$this->name} has wrong format. Valid format: 'component.section'");
+		}
+
+		if (!\array_key_exists('extensionName', $arguments) || !\array_key_exists('section', $arguments))
+		{
+			$parts = explode('.', $arguments['extension']);
+
+			$arguments['extensionName'] = $arguments['extensionName'] ?? $parts[0];
+			$arguments['section']       = $arguments['section'] ?? $parts[1];
+		}
+
+		if (!isset($arguments['pks']) || !is_array($arguments['pks']))
+		{
+			throw new BadMethodCallException("Argument 'pks' of event {$this->name} is not of type 'array'");
+		}
+
+		if (!isset($arguments['value']) || !is_numeric($arguments['value']) )
+		{
+			throw new BadMethodCallException("Argument 'value' of event {$this->name} is not of type 'numeric'");
+		}
+
+		$arguments['value'] = (int) $arguments['value'];
+
+		if ($arguments['value'] !== 0 && $arguments['value'] !== 1)
+		{
+			throw new BadMethodCallException("Argument 'value' of event {$this->name} is not 0 or 1");
+		}
+
+		parent::__construct($name, $arguments);
+	}
+}

--- a/administrator/components/com_content/src/Model/ArticleModel.php
+++ b/administrator/components/com_content/src/Model/ArticleModel.php
@@ -908,13 +908,11 @@ class ArticleModel extends AdminModel implements WorkflowModelInterface
 					'extension'  => $context,
 					'pks'        => $pks,
 					'value'      => $value,
-					'abort'      => false,
-					'abortReason' => '',
 				]
 			)
 		);
 
-		if ($eventResult->getArgument('abort'))
+		if ($eventResult->getArgument('abort', false))
 		{
 			$this->setError(Text::_($eventResult->getArgument('abortReason')));
 

--- a/administrator/components/com_content/tmpl/articles/default.php
+++ b/administrator/components/com_content/tmpl/articles/default.php
@@ -82,8 +82,8 @@ $this->document->addScriptDeclaration($js);
 
 HTMLHelper::_('script', 'com_workflow/admin-items-workflow-buttons.js', ['relative' => true, 'version' => 'auto']);
 
-	$workflow_state    = Factory::getApplication()->bootComponent('com_content')->isFunctionalityUsed('core.state', 'com_content.article');
-	$workflow_featured = Factory::getApplication()->bootComponent('com_content')->isFunctionalityUsed('core.featured', 'com_content.article');
+$workflow_state    = Factory::getApplication()->bootComponent('com_content')->isFunctionalityUsed('core.state', 'com_content.article');
+$workflow_featured = Factory::getApplication()->bootComponent('com_content')->isFunctionalityUsed('core.featured', 'com_content.article');
 
 endif;
 
@@ -228,15 +228,10 @@ $assoc = Associations::isEnabled();
 								</td>
 								<?php endif; ?>
 								<td class="text-center d-none d-md-table-cell">
-									<?php
-
-										$options = [
-											'disabled' => !$canChange
-										];
-
-										if ($workflow_featured) :
-											$options['disabled'] = true;
-										endif;
+								<?php
+									$options = [
+										'disabled' => $workflow_featured || !$canChange
+									];
 
 									echo (new FeaturedButton)
 										->render((int) $item->featured, $i, $options, $item->featured_up, $item->featured_down);
@@ -246,12 +241,8 @@ $assoc = Associations::isEnabled();
 								<?php
 									$options = [
 										'task_prefix' => 'articles.',
-										'disabled' => $workflow_enabled || !$canChange
+										'disabled' => $workflow_state || !$canChange
 									];
-
-									if ($workflow_state) :
-										$options['disabled'] = true;
-									endif;
 
 									echo (new PublishedButton)->render((int) $item->state, $i, $options, $item->publish_up, $item->publish_down);
 								?>

--- a/administrator/components/com_content/tmpl/featured/default.php
+++ b/administrator/components/com_content/tmpl/featured/default.php
@@ -54,6 +54,8 @@ if ($saveOrder && !empty($this->items))
 }
 
 $workflow_enabled = ComponentHelper::getParams('com_content')->get('workflow_enabled');
+$workflow_state    = false;
+$workflow_featured = false;
 
 if ($workflow_enabled) :
 
@@ -75,6 +77,9 @@ JS;
 $this->document->addScriptDeclaration($js);
 
 HTMLHelper::_('script', 'com_workflow/admin-items-workflow-buttons.js', ['relative' => true, 'version' => 'auto']);
+
+$workflow_state    = Factory::getApplication()->bootComponent('com_content')->isFunctionalityUsed('core.state', 'com_content.article');
+$workflow_featured = Factory::getApplication()->bootComponent('com_content')->isFunctionalityUsed('core.featured', 'com_content.article');
 
 endif;
 
@@ -223,25 +228,20 @@ $assoc = Associations::isEnabled();
 								</td>
 								<?php endif; ?>
 								<td class="text-center">
-									<?php
+								<?php
+									$options = [
+										'disabled' => $workflow_featured || !$canChange
+									];
 
-										$options = [
-											'disabled' => !$canChange
-										];
-
-									if ($workflow_enabled) :
-										$options['disabled'] = true;
-									endif;
-
-										echo (new FeaturedButton)
-											->render((int) $item->featured, $i, $options, $item->featured_up, $item->featured_down);
-									?>
+									echo (new FeaturedButton)
+										->render((int) $item->featured, $i, $options, $item->featured_up, $item->featured_down);
+								?>
 								</td>
 								<td class="article-status">
 								<?php
 									$options = [
 										'task_prefix' => 'articles.',
-										'disabled' => $workflow_enabled || !$canChange
+										'disabled' => $workflow_state || !$canChange
 									];
 
 									echo (new PublishedButton)->render((int) $item->state, $i, $options, $item->publish_up, $item->publish_down);

--- a/plugins/workflow/featuring/featuring.php
+++ b/plugins/workflow/featuring/featuring.php
@@ -22,6 +22,7 @@ use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\CMS\Table\TableInterface;
 use Joomla\CMS\Workflow\WorkflowPluginTrait;
 use Joomla\CMS\Workflow\WorkflowServiceInterface;
+use Joomla\Component\Content\Administrator\Event\Model\FeatureEvent;
 use Joomla\Event\EventInterface;
 use Joomla\Event\SubscriberInterface;
 use Joomla\String\Inflector;
@@ -349,14 +350,14 @@ class PlgWorkflowFeaturing extends CMSPlugin implements SubscriberInterface
 	/**
 	 * Change Feature State of an item. Used to disable Feature state change
 	 *
-	 * @param EventInterface $event
+	 * @param FeatureEvent $event
 	 *
 	 * @return boolean
 	 *
 	 * @throws Exception
 	 * @since   4.0.0
 	 */
-	public function onContentBeforeChangeFeatured(EventInterface $event)
+	public function onContentBeforeChangeFeatured(FeatureEvent $event)
 	{
 		$extension = $event->getArgument('extension');
 		$pks       = $event->getArgument('pks');
@@ -373,8 +374,7 @@ class PlgWorkflowFeaturing extends CMSPlugin implements SubscriberInterface
 			return true;
 		}
 
-		$event->setArgument('abort', true);
-		$event->setArgument('abortReason', 'PLG_WORKFLOW_FEATURING_CHANGE_STATE_NOT_ALLOWED');
+		$event->setAbort('PLG_WORKFLOW_FEATURING_CHANGE_STATE_NOT_ALLOWED');
 	}
 
 	/**


### PR DESCRIPTION
### Summary of Changes
Refactor the Feature up/down event to the new Event system and fix some gui issues for publising and feature button on articles overview and featured view.


### Testing Instructions
* Publish/Unpublish Articles with and without workflow active and with and without publishing plugin active on articles, featured and article edit view.
* Feature/Unfeature Articles with and without workflow active and with and without publishing plugin active on articles, featured and article edit view.

* Bonus track (with workflow enabled), disable the feature/publishing plugin
* go to the articles overview page
* Activate the feature/publishing plugin
* Press the feature/publishing button
* Should fail with an proper error message

### Expected result
Works

### Actual result
* Publish up/down button is not click able if workflow publishing button is not active
* Feature up/down button is not click on featured view able if workflow featuring button is not active
