### PR TITLE
[4.0] Prevent global timezone changing after use of JDate class

### DIFF
--- a/libraries/src/Date/Date.php
+++ b/libraries/src/Date/Date.php
@@ -58,6 +58,8 @@ class Date extends \DateTime
 	 *
 	 * @var    object
 	 * @since  1.7.0
+	 *
+	 * @deprecated  5.0 Without replacement
 	 */
 	protected static $gmt;
 
@@ -67,6 +69,8 @@ class Date extends \DateTime
 	 *
 	 * @var    object
 	 * @since  1.7.0
+	 *
+	 * @deprecated  5.0 Without replacement
 	 */
 	protected static $stz;
 
@@ -91,6 +95,7 @@ class Date extends \DateTime
 		// Create the base GMT and server time zone objects.
 		if (empty(self::$gmt) || empty(self::$stz))
 		{
+			// @TODO: This code block stays here only for B/C, can be removed in 5.0
 			self::$gmt = new \DateTimeZone('GMT');
 			self::$stz = new \DateTimeZone(@date_default_timezone_get());
 		}
@@ -98,25 +103,30 @@ class Date extends \DateTime
 		// If the time zone object is not set, attempt to build it.
 		if (!($tz instanceof \DateTimeZone))
 		{
-			if ($tz === null)
-			{
-				$tz = self::$gmt;
-			}
-			elseif (\is_string($tz))
+			if (\is_string($tz))
 			{
 				$tz = new \DateTimeZone($tz);
 			}
+			else
+			{
+				$tz = new \DateTimeZone('UTC');
+			}
 		}
 
-		// If the date is numeric assume a unix timestamp and convert it.
+		// Backup active time zone
+		$activeTZ = date_default_timezone_get();
+
+		// Force UTC timezone for correct time handling
 		date_default_timezone_set('UTC');
+
+		// If the date is numeric assume a unix timestamp and convert it.
 		$date = is_numeric($date) ? date('c', $date) : $date;
 
 		// Call the DateTime constructor.
 		parent::__construct($date, $tz);
 
-		// Reset the timezone for 3rd party libraries/extension that does not use Date
-		date_default_timezone_set(self::$stz->getName());
+		// Restore previously active timezone
+		date_default_timezone_set($activeTZ);
 
 		// Set the timezone object for access later.
 		$this->tz = $tz;
@@ -293,10 +303,10 @@ class Date extends \DateTime
 			$format = preg_replace('/(^|[^\\\])F/', "\\1" . self::MONTH_NAME, $format);
 		}
 
-		// If the returned time should not be local use GMT.
-		if ($local == false && !empty(self::$gmt))
+		// If the returned time should not be local use UTC.
+		if ($local == false)
 		{
-			parent::setTimezone(self::$gmt);
+			parent::setTimezone(new \DateTimeZone('UTC'));
 		}
 
 		// Format the date.
@@ -326,7 +336,7 @@ class Date extends \DateTime
 			}
 		}
 
-		if ($local == false && !empty($this->tz))
+		if ($local == false)
 		{
 			parent::setTimezone($this->tz);
 		}


### PR DESCRIPTION
Pull Request for Issue #14587

### Summary of Changes

As described in #14587 `JDate` incorrectly resets the TZ if the server default time zone not UTC.
In some reason `JDate` resets TZ to the server default instead of "previous state".
This patch fixing this strange behavior.


### Testing Instructions
In the root index.php add 
```php
date_default_timezone_set('Europe/Berlin'); // emulate server time zone Europe/Berlin
```

in template index.php add:
```php
date_default_timezone_set('UTC');
var_dump(date_default_timezone_get());
$someDate = JDate::getInstance('now -3 day');
var_dump(date_default_timezone_get());
```


### Expected result
var dump should show:
`'UTC'`
`'UTC'` // correct


### Actual result
`'UTC'`
`'Europe/Berlin'` // incorect



