### PR TITLE
[4.0] Fix null value support check for checked_out user id in table class

### DIFF
--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -1297,11 +1297,12 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 		$checkedOutTimeField = $this->getColumnAlias('checked_out_time');
 
 		$nullDate = $this->_supportNullValue ? 'NULL' : $this->_db->quote($this->_db->getNullDate());
+		$nullID   = $this->_supportNullValue ? 'NULL' : '0';
 
 		// Check the row in by primary key.
 		$query = $this->_db->getQuery(true)
 			->update($this->_tbl)
-			->set($this->_db->quoteName($checkedOutField) . ' = NULL')
+			->set($this->_db->quoteName($checkedOutField) . ' = ' . $nullID)
 			->set($this->_db->quoteName($checkedOutTimeField) . ' = ' . $nullDate);
 		$this->appendPrimaryKeys($query, $pk);
 		$this->_db->setQuery($query);


### PR DESCRIPTION
Pull Request for [https://github.com/joomla/joomla-cms/pull/29260#issuecomment-636343831](https://github.com/joomla/joomla-cms/pull/29260#issuecomment-636343831).

### Summary of Changes

Check null value support in the table (base) class before updating the checked_out column of a table, and write either real `NULL` or zero value depending on the result.

### Testing Instructions

Can be merged by review.

### Expected result

3rd party extensions continue to work.

### Actual result

3rd party extensions break if the use (J)Table to write into their component-specific table and that table doesn't support `NULL`s for the checked_out column.


### Documentation Changes Required

None.