### PR TITLE
[4.0] Fix SQL error on update from 3.10-dev to J4 for PostgreSQL

### DIFF
--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2020-05-21.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2020-05-21.sql
@@ -2,7 +2,10 @@
 ALTER TABLE "#__ucm_history" RENAME TO "#__history";
 -- Rename ucm_item_id to item_id as the new primary identifier for the original content item
 ALTER TABLE "#__history" RENAME "ucm_item_id" TO "item_id";
-ALTER TABLE "#__history" ALTER COLUMN "item_id" VARCHAR(50) NOT NULL DEFAULT "";
+ALTER TABLE "#__history" ALTER COLUMN "item_id" TYPE character varying(50);
+ALTER TABLE "#__history" ALTER COLUMN "item_id" SET NOT NULL;
+ALTER TABLE "#__history" ALTER COLUMN "item_id" DROP DEFAULT;
+
 -- Extend the original field content with the alias of the content type
 UPDATE "#__history" AS h INNER JOIN "#__content_types" AS c ON h.ucm_type_id = c.type_id SET h.item_id = CONCAT(c.type_alias, ".", h.item_id);
 -- Now we don't need the ucm_type_id anymore and drop it.


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

- The schema checker's change item class for PostgreSQL doesn't understand "varchar", it need "character vayring".
- In PostgreSQL you change the "NOT NULL" contrsaint for a column or the default value with a separate statement, or at least our schema checker expects it like this for PostgreSQL.

### Testing Instructions

Can be merged by review.

### Expected result

Update from current 3.10-dev suceeds.

### Actual result

`ERROR:  syntax error at or near "VARCHAR" at character 52`
`STATEMENT:  ALTER TABLE "j3ux0_history" ALTER COLUMN "item_id" VARCHAR(50) NOT NULL DEFAULT "";`

### Documentation Changes Required

