### PR TITLE
[4.0] Rename imageLazyloading plugin

### DIFF
--- a/administrator/language/en-GB/plg_content_imagelazyload.sys.ini
+++ b/administrator/language/en-GB/plg_content_imagelazyload.sys.ini
@@ -3,5 +3,5 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt
 ; Note : All ini files need to be saved as UTF-8
 
-PLG_CONTENT_IMAGELAZYLOAD="Content - ImageLazyloading"
-PLG_CONTENT_IMAGELAZYLOAD_XML_DESCRIPTION="This plugin can set the loading=lazy attribute for all images."
+PLG_CONTENT_IMAGELAZYLOAD="Content - Lazy Loading Images"
+PLG_CONTENT_IMAGELAZYLOAD_XML_DESCRIPTION="This plugin will set the 'loading=lazy' attribute for all images."


### PR DESCRIPTION
Simple PR to rename the plugin to something more en-GB and to tweak the other language string

### After
```
PLG_CONTENT_IMAGELAZYLOAD="Content - Lazy Loading Images"
PLG_CONTENT_IMAGELAZYLOAD_XML_DESCRIPTION="This plugin will set the 'loading=lazy' attribute for all images."

```