### PR TITLE
[4.0] Fix again postgresql update

### DIFF
--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2020-05-21.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2020-05-21.sql
@@ -7,10 +7,7 @@ ALTER TABLE "#__history" ALTER COLUMN "item_id" SET NOT NULL;
 ALTER TABLE "#__history" ALTER COLUMN "item_id" DROP DEFAULT;
 
 -- Extend the original field content with the alias of the content type
-UPDATE "#__history" AS h
-   SET "item_id" = CONCAT(c."type_alias", '.', "item_id")
-  FROM "#__content_types" AS c
- WHERE h."ucm_type_id" = c."type_id";
+UPDATE "#__history" AS h SET "item_id" = CONCAT(c."type_alias", '.', "item_id") FROM "#__content_types" AS c WHERE h."ucm_type_id" = c."type_id";
 
 -- Now we don't need the ucm_type_id anymore and drop it.
 ALTER TABLE "#__history" DROP COLUMN "ucm_type_id";

--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2020-05-21.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2020-05-21.sql
@@ -7,7 +7,11 @@ ALTER TABLE "#__history" ALTER COLUMN "item_id" SET NOT NULL;
 ALTER TABLE "#__history" ALTER COLUMN "item_id" DROP DEFAULT;
 
 -- Extend the original field content with the alias of the content type
-UPDATE "#__history" AS h INNER JOIN "#__content_types" AS c ON h.ucm_type_id = c.type_id SET h.item_id = CONCAT(c.type_alias, ".", h.item_id);
+UPDATE "#__history" AS h
+   SET "item_id" = CONCAT(c."type_alias", '.', "item_id")
+  FROM "#__content_types" AS c
+ WHERE h."ucm_type_id" = c."type_id";
+
 -- Now we don't need the ucm_type_id anymore and drop it.
 ALTER TABLE "#__history" DROP COLUMN "ucm_type_id";
 ALTER TABLE "#__history" ALTER COLUMN "save_date" DROP DEFAULT;


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Fix syntax error for PostgreSQL databases in update SQL script.

See also [https://stackoverflow.com/questions/7869592/how-to-do-an-update-join-in-postgresql](https://stackoverflow.com/questions/7869592/how-to-do-an-update-join-in-postgresql).

### Testing Instructions

Update a clean and current 3.10-dev to latest 4.0-dev using a PostgreSQL database and a self made update package for reproducing the issue, or the one built for this PR for testing the fix.

### Expected result

Update succeeds,

### Actual result

`ERROR:  syntax error at or near "INNER" at character 29`
`STATEMENT:  UPDATE "j3ux0_history" AS h INNER JOIN "j3ux0_content_types" AS c ON h.ucm_type_id = c.type_id SET h.item_id = CONCAT(c.type_alias, ".", h.item_id);`

### Documentation Changes Required

None.