### PR TITLE
[4.0] Consistent colour scheme for more info section

### DIFF
--- a/administrator/templates/atum/scss/blocks/_header.scss
+++ b/administrator/templates/atum/scss/blocks/_header.scss
@@ -273,7 +273,7 @@
       justify-content: flex-end;
       width: calc(13.2rem + 2px);
       margin-top: .1rem;
-      background-color: var(--primary);
+      background-color: var(--atum-bg-dark-70);
       border: 1px solid $gray-500;
       border-top: 0;
       box-shadow: $atum-box-shadow;

--- a/administrator/templates/atum/scss/blocks/_header.scss
+++ b/administrator/templates/atum/scss/blocks/_header.scss
@@ -273,7 +273,7 @@
       justify-content: flex-end;
       width: calc(13.2rem + 2px);
       margin-top: .1rem;
-      background-color: var(--white-offset);
+      background-color: var(--primary);
       border: 1px solid $gray-500;
       border-top: 0;
       box-shadow: $atum-box-shadow;
@@ -297,7 +297,7 @@
       height: 3.7rem;
 
       .header-item-content > :first-child {
-        color: var(--atum-special-color);
+        color: var(--white);
 
         &[aria-expanded=true] {
           color: var(--atum-text-light);


### PR DESCRIPTION
Pull Request for Issue #29295 .

### Summary of Changes
Fixes the colour schemes of the more info section

### Testing Instructions
See the issue. Before patch you can reproduce it. After patch the colour scheme is consistent with other areas of the menu

### Documentation Changes Required
None
