### PR TITLE
[4.0] Remove strings without translations

### DIFF
--- a/administrator/modules/mod_privacy_dashboard/mod_privacy_dashboard.xml
+++ b/administrator/modules/mod_privacy_dashboard/mod_privacy_dashboard.xml
@@ -34,7 +34,6 @@
 					name="moduleclass_sfx"
 					type="textarea"
 					label="COM_MODULES_FIELD_MODULECLASS_SFX_LABEL"
-					description="COM_MODULES_FIELD_MODULECLASS_SFX_DESC"
 				 	rows="3"
 				/>
 
@@ -42,7 +41,6 @@
 					name="cache"
 					type="list"
 					label="COM_MODULES_FIELD_CACHING_LABEL"
-					description="COM_MODULES_FIELD_CACHING_DESC"
 					default="1"
 					filter="integer"
 					validate="options"
@@ -55,7 +53,6 @@
 					name="cache_time"
 					type="number"
 					label="COM_MODULES_FIELD_CACHE_TIME_LABEL"
-					description="COM_MODULES_FIELD_CACHE_TIME_DESC"
 					default="900"
 					filter="integer"
 				/>


### PR DESCRIPTION
Pull Request for Issue #29289 .

### Summary of Changes
Removes language strings that have been removed and don't exist elsewhere in the CMS

### Testing Instructions
Edit a module dashboard. Before patch missing language strings. After patch they're removed.

### Documentation Changes Required
N/A
