### PR TITLE
Fix API application routing

### DIFF
--- a/htaccess.txt
+++ b/htaccess.txt
@@ -75,20 +75,34 @@ Header always set X-Content-Type-Options "nosniff"
 	# RewriteBase /
 
 	## Begin - Joomla! core SEF Section.
-	#
-	RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
-	#
-	# If the requested path and file is not /index.php and the request
-	# has not already been internally rewritten to the index.php script
-	RewriteCond %{REQUEST_URI} !^/index\.php
-	# and the requested path and file doesn't directly match a physical file
-	RewriteCond %{REQUEST_FILENAME} !-f
-	# and the requested path and file doesn't directly match a physical folder
-	RewriteCond %{REQUEST_FILENAME} !-d
-	# internally rewrite the request to the index.php script
-	RewriteRule .* index.php [L]
-	#
-	## End - Joomla! core SEF Section.
+    #
+    # PHP FastCGI fix for HTTP Authorization, required for the API application
+    RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+    # -- SEF URLs for the API application
+    # If the requested path starts with /api, the file is not /api/index.php
+    # and the request has not already been internally rewritten to the
+    # api/index.php script
+    RewriteCond %{REQUEST_URI} ^/api/
+    RewriteCond %{REQUEST_URI} !^/api/index\.php
+    # and the requested path and file doesn't directly match a physical file
+    RewriteCond %{REQUEST_FILENAME} !-f
+    # and the requested path and file doesn't directly match a physical folder
+    RewriteCond %{REQUEST_FILENAME} !-d
+    # internally rewrite the request the the /api/index.php script
+    RewriteRule .* api/index.php [L]
+    # -- SEF URLs for the public frontend application
+    # If the requested path and file is not /index.php and the request
+    # has not already been internally rewritten to the index.php script
+    RewriteCond %{REQUEST_URI} !^/index\.php
+    # and the requested path and file doesn't directly match a physical file
+    RewriteCond %{REQUEST_FILENAME} !-f
+    # and the requested path and file doesn't directly match a physical folder
+    RewriteCond %{REQUEST_FILENAME} !-d
+    # internally rewrite the request to the index.php script
+    RewriteRule .* index.php [L]
+    #
+    ## End - Joomla! core SEF Section.
+
 </IfModule>
 
 ## These directives are only enabled if the Apache mod_rewrite module is disabled

--- a/htaccess.txt
+++ b/htaccess.txt
@@ -88,7 +88,7 @@ Header always set X-Content-Type-Options "nosniff"
     RewriteCond %{REQUEST_FILENAME} !-f
     # and the requested path and file doesn't directly match a physical folder
     RewriteCond %{REQUEST_FILENAME} !-d
-    # internally rewrite the request the the /api/index.php script
+    # internally rewrite the request to the /api/index.php script
     RewriteRule .* api/index.php [L]
     # -- SEF URLs for the public frontend application
     # If the requested path and file is not /index.php and the request

--- a/libraries/src/Router/ApiRouter.php
+++ b/libraries/src/Router/ApiRouter.php
@@ -115,18 +115,8 @@ class ApiRouter extends Router
 		// Remove the base URI path.
 		$path = substr_replace($path, '', 0, \strlen($baseUri));
 
-		if (!$this->app->get('sef_rewrite'))
-		{
-			// Transform the route
-			if ($path === 'index.php')
-			{
-				$path = '';
-			}
-			else
-			{
-				$path = str_replace('index.php/', '', $path);
-			}
-		}
+		// Transform the route
+		$path = $this->removeIndexPhpFromPath($path);
 
 		$query = Uri::getInstance()->getQuery(true);
 
@@ -158,5 +148,35 @@ class ApiRouter extends Router
 		}
 
 		throw new RouteNotFoundException(sprintf('Unable to handle request for route `%s`.', $path));
+	}
+
+	/**
+	 * Removes the index.php from the route's path.
+	 *
+	 * @param   string  $path
+	 *
+	 * @return  string
+	 *
+	 * @since   4.0.0
+	 */
+	private function removeIndexPhpFromPath(string $path): string
+	{
+		// Normalize the path
+		$path = ltrim($path, '/');
+
+		// We can only remove index.php if it's present in the beginning of the route
+		if (strpos($path, 'index.php') !== 0)
+		{
+			return $path;
+		}
+
+		// Edge case: the route is index.php without a trailing slash. Bad idea but we can still map it to a null route.
+		if ($path === 'index.php')
+		{
+			return '';
+		}
+
+		// Remove the "index.php/" part of the route and return the result.
+		return substr($path, 10);
 	}
 }

--- a/web.config.txt
+++ b/web.config.txt
@@ -5,7 +5,7 @@
        <directoryBrowse enabled="false" />
        <rewrite>
            <rules>
-               <rule name="Joomla! Rule 1" stopProcessing="true">
+               <rule name="Joomla! Common Exploits Prevention" stopProcessing="true">
                    <match url="^(.*)$" ignoreCase="false" />
                    <conditions logicalGrouping="MatchAny">
                        <add input="{QUERY_STRING}" pattern="base64_encode[^(]*\([^)]*\)" ignoreCase="false" />
@@ -15,7 +15,16 @@
                    </conditions>
                    <action type="CustomResponse" url="index.php" statusCode="403" statusReason="Forbidden" statusDescription="Forbidden" />
                </rule>
-               <rule name="Joomla! Rule 2">
+               <rule name="Joomla! API Application SEF URLs">
+                   <match url="^api/(.*)" ignoreCase="false" />
+                   <conditions logicalGrouping="MatchAll">
+                     <add input="{URL}" pattern="^/api/index.php" ignoreCase="true" negate="true" />
+                     <add input="{REQUEST_FILENAME}" matchType="IsFile" ignoreCase="false" negate="true" />
+                     <add input="{REQUEST_FILENAME}" matchType="IsDirectory" ignoreCase="false" negate="true" />
+                   </conditions>
+                   <action type="Rewrite" url="api/index.php" />
+               </rule>
+               <rule name="Joomla! Public Frontend SEF URLs">
                    <match url="(.*)" ignoreCase="false" />
                    <conditions logicalGrouping="MatchAll">
                      <add input="{URL}" pattern="^/index.php" ignoreCase="true" negate="true" />


### PR DESCRIPTION
I was asked by @wilsonge to address the routing issues of the API application using SEF URLs. This PR addresses those issues.

### Summary of Changes

* Modified `htaccess.txt` to rewrite the API application SEF URLs (e.g. `/api/v1/content/articles`) onto the `api/index.php` instead of `index.php`
* Modified `web.config.txt` to rewrite the API application SEF URLs (e.g. `/api/v1/content/articles`) onto the `api/index.php` instead of `index.php`
* Addressed a bug in `ApiRouter` which prevented semi-SEF URLs (e.g. `/api/index.php/v1/content/articles`) from working

### Testing Instructions

#### Common Preparation

Create an API token by editing your user profile and saving it. Go back into it, click the Joomla API Token tab and copy your token. Further below it's noted as YOUR_TOKEN. Please remember that you _must_ use a Super User token for the API to work!

Moreover, wherever you see https://www.example.com you should put your site's URL.

#### Apache

**Semi-SEF URL**

Run `curl -H "Authorization: Bearer YOUR_TOKEN" -H "Accept: application/vnd.api+json" "https://www.example.com/api/index.php/v1/content/article"`

**Full-SEF URL**

Copy `htaccess.txt` into `.htaccess` first.

Run `curl -H "Authorization: Bearer YOUR_TOKEN" -H "Accept: application/vnd.api+json" "https://www.example.com/api/v1/content/article"`

#### IIS

**Semi-SEF URL**

Run `curl -H "Authorization: Bearer YOUR_TOKEN" -H "Accept: application/vnd.api+json" "https://www.example.com/api/index.php/v1/content/article"`

**Full-SEF URL**

Copy `web.config.txt` into `web.config` first.

Run `curl -H "Authorization: Bearer YOUR_TOKEN" -H "Accept: application/vnd.api+json" "https://www.example.com/api/v1/content/article"`

### Expected result

You get an HTTP 200 OK response with a JSON document listing your articles.

### Actual result

Before the patch the semi-SEF URL would throw errors if URL Rewriting was disabled in Global Configuration.

Moreover, before the path, the full-SEF URL wouldn't work. Instead, the URL was routed to the front-end application which responded with a 404.

### Documentation Changes Required

None. It actually helps Joomla work the intended and documented way :)

### Post scriptum

I had promised @wilsonge I'd also come up with a solution with NginX and type it as a comment in the PR but I forgot about it 🤦‍♂️ Here's the super simple solution for NginX:

```nginx
## Enable SEF URLs
# Joomla API application
location /api/ {
	try_files $uri $uri/ /api/index.php?$args;
}
# Joomla public frontend application
location / {
	try_files $uri $uri/ /index.php?$args;
}
## -- End
```

Of course if you are in a subdirectory you need to adjust your NginX configuration. For example, if your site is under `/joomla`:

```nginx
## Enable SEF URLs
# Joomla API application
location /joomla/api/ {
	try_files $uri $uri/ /joomla/api/index.php?$args;
}
# Joomla public frontend application
location /joomla/ {
	try_files $uri $uri/ /joomla/index.php?$args;
}
## -- End
```
