### PR TITLE
[4.0] Admin stats module

### DIFF
--- a/administrator/modules/mod_stats_admin/src/Helper/StatsAdminHelper.php
+++ b/administrator/modules/mod_stats_admin/src/Helper/StatsAdminHelper.php
@@ -119,7 +119,7 @@ class StatsAdminHelper
 				$rows[$i]->title = Text::_('MOD_STATS_ARTICLES');
 				$rows[$i]->icon  = 'file';
 				$rows[$i]->data  = $items;
-				$rows[$i]->link  = Route::_('index.php?option=com_content&view=articles&filter[condition]=1');
+				$rows[$i]->link  = Route::_('index.php?option=com_content&view=articles&filter[published]=1');
 				$i++;
 			}
 		}


### PR DESCRIPTION
This PR reverts the changes made in #27763

To test
1. Create some articles both published and unpublished
2. publish the admin stats module on the home dashboard
3. click on the count of articles

### Expected result
Article manager opens showing only the published articles

### Actual result
Article manager showing all articles

### Note
This is a result of switching to workflowsv3
