### PR TITLE
[4.0] Fix bootstrap tabs active background

### DIFF
--- a/administrator/templates/atum/scss/_variables.scss
+++ b/administrator/templates/atum/scss/_variables.scss
@@ -157,7 +157,7 @@ $dropdown-spacer:                  0;
 
 // Tabs
 $nav-tabs-border-width:            0;
-$nav-tabs-link-active-bg:          rgba($black, .2); //is it used?
+$nav-tabs-link-active-bg:          rgba($gray-100, .2); // Used by bootstrap tabs
 
 // Cards
 $card-border-width:                0;


### PR DESCRIPTION
### Summary of Changes
In some cases, (and specially for 3rd party components and B/C), we need to use bootstrap tabs and not uitab or joomlatab.
The advantage of bootstrap tab is that we have `accordion` and `slide` variations.

In that case, when the tab is active, the background color is not differentiated from the the non-active tab.


### Testing Instructions
Choose any edit for example com_content/tmpl/article/edit.php

Replace `uitab` in
```
uitab.startTabSet
uitab.addTab
uitab.enTab
uitab.endTabSet
```

by `bootstrap`
example `bootstrap.startTabSet`

### Before patch
Example here for a third party component.

<img width="1187" alt="Screen Shot 2020-05-31 at 10 26 54" src="https://user-images.githubusercontent.com/869724/83347992-4a138000-a329-11ea-93f8-dba1c995e05a.png">


### After patch

<img width="1381" alt="Screen Shot 2020-05-31 at 09 52 33" src="https://user-images.githubusercontent.com/869724/83347978-3700b000-a329-11ea-8dc4-c1eaf08a0101.png">

### Note
I did not find any other use of `.nav-tabs .nav-item.show .nav-link, .nav-tabs .nav-link.active` in core.
I tested with various atum main color without issue, but not tested all.

@coolcat-creations 
Could you please check there are no undesired consequences?

