### PR TITLE
[4.0] com_config buttons front end

### DIFF
--- a/components/com_config/tmpl/config/default.php
+++ b/components/com_config/tmpl/config/default.php
@@ -20,20 +20,14 @@ HTMLHelper::_('script', 'com_config/config-default.js', ['version' => 'auto', 'r
 
 <form action="<?php echo Route::_('index.php?option=com_config'); ?>" id="application-form" method="post" name="adminForm" class="form-validate">
 
-	<div class="btn-toolbar" role="toolbar" aria-label="<?php echo Text::_('JTOOLBAR'); ?>">
-		<div class="btn-group">
-			<button type="button" class="btn btn-primary" data-submit-task="config.apply">
-				<span class="fas fa-check" aria-hidden="true"></span>
-				<?php echo Text::_('JSAVE') ?>
-			</button>
-		</div>
-		<div class="btn-group">
-			<button type="button" class="btn btn-danger" data-submit-task="config.cancel">
-				<span class="fas fa-times" aria-hidden="true"></span>
-				<?php echo Text::_('JCANCEL') ?>
-			</button>
-		</div>
-	</div>
+	<button type="button" class="btn btn-primary" data-submit-task="config.apply">
+		<span class="fas fa-check" aria-hidden="true"></span>
+		<?php echo Text::_('JSAVE') ?>
+	</button>
+	<button type="button" class="btn btn-danger" data-submit-task="config.cancel">
+		<span class="fas fa-times" aria-hidden="true"></span>
+		<?php echo Text::_('JCANCEL') ?>
+	</button>
 
 	<hr>
 

--- a/components/com_config/tmpl/modules/default.php
+++ b/components/com_config/tmpl/modules/default.php
@@ -46,20 +46,18 @@ if (Multilanguage::isEnabled())
 	<div class="row">
 		<div class="col-md-12">
 
-			<div role="toolbar" aria-label="<?php echo Text::_('JTOOLBAR'); ?>">
-				<button type="button" class="btn btn-primary" data-submit-task="modules.apply">
-					<span class="fas fa-check" aria-hidden="true"></span>
-					<?php echo Text::_('JAPPLY'); ?>
-				</button>
-				<button type="button" class="btn btn-secondary" data-submit-task="modules.save">
-					<span class="fas fa-check" aria-hidden="true"></span>
-					<?php echo Text::_('JSAVE'); ?>
-				</button>
-				<button type="button" class="btn btn-danger" data-submit-task="modules.cancel">
-					<span class="fas fa-times" aria-hidden="true"></span>
-					<?php echo Text::_('JCANCEL'); ?>
-				</button>
-			</div>
+			<button type="button" class="btn btn-primary" data-submit-task="modules.apply">
+				<span class="fas fa-check" aria-hidden="true"></span>
+				<?php echo Text::_('JAPPLY'); ?>
+			</button>
+			<button type="button" class="btn btn-secondary" data-submit-task="modules.save">
+				<span class="fas fa-check" aria-hidden="true"></span>
+				<?php echo Text::_('JSAVE'); ?>
+			</button>
+			<button type="button" class="btn btn-danger" data-submit-task="modules.cancel">
+				<span class="fas fa-times" aria-hidden="true"></span>
+				<?php echo Text::_('JCANCEL'); ?>
+			</button>
 
 			<hr>
 

--- a/components/com_config/tmpl/templates/default.php
+++ b/components/com_config/tmpl/templates/default.php
@@ -23,20 +23,14 @@ HTMLHelper::_('script', 'com_config/templates-default.js', ['version' => 'auto',
 
 <form action="<?php echo Route::_('index.php?option=com_config'); ?>" method="post" name="adminForm" id="templates-form" class="form-validate">
 
-	<div class="btn-toolbar" role="toolbar" aria-label="<?php echo Text::_('JTOOLBAR'); ?>">
-		<div class="btn-group">
-			<button type="button" class="btn btn-primary" data-submit-task="templates.apply">
-				<span class="fas fa-check" aria-hidden="true"></span>
-				<?php echo Text::_('JSAVE') ?>
-			</button>
-		</div>
-		<div class="btn-group">
-			<button type="button" class="btn btn-danger" data-submit-task="templates.cancel">
-				<span class="fas fa-times" aria-hidden="true"></span>
-				<?php echo Text::_('JCANCEL') ?>
-			</button>
-		</div>
-	</div>
+	<button type="button" class="btn btn-primary" data-submit-task="templates.apply">
+		<span class="fas fa-check" aria-hidden="true"></span>
+		<?php echo Text::_('JSAVE') ?>
+	</button>
+	<button type="button" class="btn btn-danger" data-submit-task="templates.cancel">
+		<span class="fas fa-times" aria-hidden="true"></span>
+		<?php echo Text::_('JCANCEL') ?>
+	</button>
 
 	<hr>
 


### PR DESCRIPTION
Removes the toolbar markup as it is not needed - they are just buttons.
Bonus this also ensures the buttons are spaced correctly

To test. Install sample data and log in to the front end
Test the menu items for Site Settings and Template Settings and also test editing a module

Before this PR the buttons are next to each other without any spacing

After this PR the toolbar markup is removed and the buttons are spaced correctly
