### PR TITLE
[4.0] Restore the functionality for Ext Button Media

### DIFF
--- a/build/media_source/system/js/fields/joomla-field-media.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-media.w-c.es6.js
@@ -3,10 +3,10 @@
     throw new Error('Joomla API is not properly initiated');
   }
 
-  let selectedFile = {};
+  Joomla.selectedFile = {};
 
   window.document.addEventListener('onMediaFileSelected', (e) => {
-    selectedFile = e.detail;
+    Joomla.selectedFile = e.detail;
   });
 
   const execTransform = (resp, editor, fieldClass) => {
@@ -16,17 +16,17 @@
           const { rootFull } = Joomla.getOptions('system.paths');
 
           // eslint-disable-next-line prefer-destructuring
-          selectedFile.url = resp.data[0].url.split(rootFull)[1];
+          Joomla.selectedFile.url = resp.data[0].url.split(rootFull)[1];
           if (resp.data[0].thumb_path) {
-            selectedFile.thumb = resp.data[0].thumb_path;
+            Joomla.selectedFile.thumb = resp.data[0].thumb_path;
           } else {
-            selectedFile.thumb = false;
+            Joomla.selectedFile.thumb = false;
           }
         } else if (resp.data[0].thumb_path) {
-          selectedFile.thumb = resp.data[0].thumb_path;
+          Joomla.selectedFile.thumb = resp.data[0].thumb_path;
         }
       } else {
-        selectedFile.url = false;
+        Joomla.selectedFile.url = false;
       }
 
       const isElement = (o) => (
@@ -34,13 +34,13 @@
           : o && typeof o === 'object' && o !== null && o.nodeType === 1 && typeof o.nodeName === 'string'
       );
 
-      if (selectedFile.url) {
+      if (Joomla.selectedFile.url) {
         if (!isElement(editor) && (typeof editor !== 'object')) {
-          Joomla.editors.instances[editor].replaceSelection(`<img loading="lazy" src="${selectedFile.url}" alt=""/>`);
+          Joomla.editors.instances[editor].replaceSelection(`<img loading="lazy" src="${Joomla.selectedFile.url}" alt=""/>`);
         } else if (!isElement(editor) && (typeof editor === 'object' && editor.id)) {
-          window.parent.Joomla.editors.instances[editor.id].replaceSelection(`<img loading="lazy" src="${selectedFile.url}" alt=""/>`);
+          window.parent.Joomla.editors.instances[editor.id].replaceSelection(`<img loading="lazy" src="${Joomla.selectedFile.url}" alt=""/>`);
         } else {
-          editor.value = selectedFile.url;
+          editor.value = Joomla.selectedFile.url;
           fieldClass.updatePreview();
         }
       }
@@ -54,9 +54,9 @@
    *
    * @returns {void}
    */
-  const fetchImageDetails = (data, editor, fieldClass) => new Promise((resolve, reject) => {
+  Joomla.getImage = (data, editor, fieldClass) => new Promise((resolve, reject) => {
     if (!data || (typeof data === 'object' && (!data.path || data.path === ''))) {
-      selectedFile = {};
+      Joomla.selectedFile = {};
       reject(new Error('Nothing selected'));
       return;
     }
@@ -196,7 +196,7 @@
     modalClose() {
       const input = this.querySelector(this.input);
 
-      fetchImageDetails(selectedFile, input, this)
+      Joomla.getImage(Joomla.selectedFile, input, this)
         .then(() => { Joomla.Modal.getCurrent().close(); })
         .catch(() => {
           Joomla.Modal.getCurrent().close();
@@ -233,13 +233,13 @@
           const imgPreview = new Image();
 
           switch (this.type) {
-            case 'image':
-              imgPreview.src = /http/.test(value) ? value : Joomla.getOptions('system.paths').rootFull + value;
-              imgPreview.setAttribute('alt', '');
-              break;
-            default:
-              // imgPreview.src = dummy image path;
-              break;
+          case 'image':
+            imgPreview.src = /http/.test(value) ? value : Joomla.getOptions('system.paths').rootFull + value;
+            imgPreview.setAttribute('alt', '');
+            break;
+          default:
+            // imgPreview.src = dummy image path;
+            break;
           }
 
           div.style.width = this.previewWidth;

--- a/build/media_source/system/js/fields/joomla-field-media.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-media.w-c.es6.js
@@ -233,13 +233,13 @@
           const imgPreview = new Image();
 
           switch (this.type) {
-          case 'image':
-            imgPreview.src = /http/.test(value) ? value : Joomla.getOptions('system.paths').rootFull + value;
-            imgPreview.setAttribute('alt', '');
-            break;
-          default:
-            // imgPreview.src = dummy image path;
-            break;
+            case 'image':
+              imgPreview.src = /http/.test(value) ? value : Joomla.getOptions('system.paths').rootFull + value;
+              imgPreview.setAttribute('alt', '');
+              break;
+            default:
+              // imgPreview.src = dummy image path;
+              break;
           }
 
           div.style.width = this.previewWidth;


### PR DESCRIPTION


Pull Request for Issue # https://github.com/joomla/joomla-cms/commit/0469adb705e479636e12966ad41465b60396b831 .

### Summary of Changes
Restores the Joomla namespace for couple variables

As a remark here the XTD button Media:
- should have it's own script
- shouldn't use hardcoded `onclick`

As is in a form that doesn't have a media field the editor image button is broken.

### Testing Instructions

Check that you can insert an image in tinyMCE

### Expected result

Working

### Actual result

Broken

### Documentation Changes Required
No, this was my bad

@wilsonge sorry mate I totally forgot that this code was also used in the xtd button. 