### PR TITLE
[4.0] Fix history versions display

### DIFF
--- a/administrator/components/com_contenthistory/src/Model/HistoryModel.php
+++ b/administrator/components/com_contenthistory/src/Model/HistoryModel.php
@@ -411,15 +411,15 @@ class HistoryModel extends ListModel
 	 */
 	protected function getSha1Hash()
 	{
-		$result = false;
-		$item_id = Factory::getApplication()->input->getCmd('item_id', '');
-		$typeAlias        = explode('.', $item_id);
+		$result    = false;
+		$item_id   = Factory::getApplication()->input->getCmd('item_id', '');
+		$typeAlias = explode('.', $item_id);
 		Table::addIncludePath(JPATH_ADMINISTRATOR . '/components/' . $typeAlias[0] . '/tables');
 		$typeTable = $this->getTable('ContentType');
-		$typeTable->load($typeAlias[0] . '.' . $typeAlias[1]);
+		$typeTable->load(['type_alias' => $typeAlias[0] . '.' . $typeAlias[1]]);
 		$contentTable = $typeTable->getContentTable();
 
-		if ($contentTable && $contentTable->load($typeAlias[3]))
+		if ($contentTable && $contentTable->load($typeAlias[2]))
 		{
 			$helper = new CMSHelper;
 

--- a/libraries/src/Form/Field/ContenthistoryField.php
+++ b/libraries/src/Form/Field/ContenthistoryField.php
@@ -13,7 +13,6 @@ namespace Joomla\CMS\Form\Field;
 use Joomla\CMS\Form\FormField;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Session\Session;
-use Joomla\CMS\Table\Table;
 
 /**
  * Field to select Content History from a modal list.

--- a/libraries/src/Form/Field/ContenthistoryField.php
+++ b/libraries/src/Form/Field/ContenthistoryField.php
@@ -47,19 +47,16 @@ class ContenthistoryField extends FormField
 		// Get the basic field data
 		$data = parent::getLayoutData();
 
-		$typeId = Table::getInstance('Contenttype')->getTypeId($this->element['data-typeAlias']);
-		$itemId = $this->form->getValue('id');
+		$itemId = $this->element['data-typeAlias'] . '.' . $this->form->getValue('id');
 		$label  = Text::_('JTOOLBAR_VERSIONS');
 
-		$link   = 'index.php?option=com_contenthistory&amp;view=history&amp;layout=modal&amp;tmpl=component&amp;field='
-			. $this->id . '&amp;item_id=' . $itemId . '&amp;type_id=' . $typeId . '&amp;type_alias='
-			. $this->element['data-typeAlias'] . '&amp;' . Session::getFormToken() . '=1';
+		$link = 'index.php?option=com_contenthistory&amp;view=history&amp;layout=modal&amp;tmpl=component&amp;field='
+			. $this->id . '&amp;item_id=' . $itemId . '&amp;' . Session::getFormToken() . '=1';
 
 		$extraData = array(
-				'type' => $typeId,
-				'item' => $itemId,
-				'label' => $label,
-				'link' => $link,
+			'item' => $itemId,
+			'label' => $label,
+			'link' => $link,
 		);
 
 		return array_merge($data, $extraData);


### PR DESCRIPTION
Pull Request for Issue #29287.

### Summary of Changes

Fixes query error on PostgreSQL, current version not being marked and versions not being displayed in frontend.

### Testing Instructions

1) On PostgreSQL, create some articles and view their versions.
2) On any DB, edit an article and check its versions.
3) On any DB, view article versions from frontend.

### Expected result

1) Works.
2) Current version marked with a star.
3) Versions displayed.

### Actual result

1) >22P02, 7, ERROR: invalid input syntax for integer: "6." LINE 3: WHERE "type_id" = '6.' ^ 
2) Current version not marked with a star.
3) No versions are displayed.

### Documentation Changes Required

No.