### PR TITLE
[4.0] com_users front end forms

### DIFF
--- a/components/com_users/layouts/joomla/form/renderfield.php
+++ b/components/com_users/layouts/joomla/form/renderfield.php
@@ -10,7 +10,6 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
-use Joomla\CMS\Language\Text;
 
 extract($displayData);
 

--- a/components/com_users/layouts/joomla/form/renderfield.php
+++ b/components/com_users/layouts/joomla/form/renderfield.php
@@ -53,9 +53,6 @@ $typeOfSpacer = (strpos($label, 'spacer-lbl') !== false);
 	<?php if (empty($options['hiddenLabel'])): ?>
 		<div class="control-label">
 			<?php echo $label; ?>
-			<?php if (!$required && !$typeOfSpacer) : ?>
-				<span class="optional"><?php echo Text::_('COM_USERS_OPTIONAL'); ?></span>
-			<?php endif; ?>
 		</div>
 	<?php endif; ?>
 	<div class="controls">

--- a/components/com_users/tmpl/profile/edit.php
+++ b/components/com_users/tmpl/profile/edit.php
@@ -59,11 +59,6 @@ HTMLHelper::_('script', 'com_users/two-factor-switcher.min.js', array('version' 
 							<div class="control-group">
 								<div class="control-label">
 									<?php echo $field->label; ?>
-									<?php if (!$field->required && $field->type !== 'Spacer') : ?>
-										<span class="optional">
-											<?php echo Text::_('COM_USERS_OPTIONAL'); ?>
-										</span>
-									<?php endif; ?>
 								</div>
 								<div class="controls">
 									<?php echo $field->input; ?>

--- a/language/en-GB/com_users.ini
+++ b/language/en-GB/com_users.ini
@@ -58,7 +58,6 @@ COM_USERS_MSG_NOT_ENOUGH_UPPERCASE_LETTERS_N_1="Password does not have enough up
 COM_USERS_MSG_PASSWORD_TOO_LONG="Password is too long. Passwords must be less than 100 characters."
 COM_USERS_MSG_PASSWORD_TOO_SHORT_N="Password is too short. Passwords must have at least %s characters."
 COM_USERS_MSG_SPACES_IN_PASSWORD="Password must not have spaces."
-COM_USERS_OPTIONAL="(optional)"
 COM_USERS_OR="or"
 COM_USERS_PROFILE="User Profile"
 COM_USERS_PROFILE_BIND_FAILED="Could not bind profile data: %s"


### PR DESCRIPTION
The fields in the edit profile are hardcoded to display `(optional)`

This is unlike any other form where only required fields are marked with *

This PR removes the hard coded `optional` without replacement. Both for consistency and removal of clutter AND by hardcoding it this way it is applied to readonly fields etc that are neither required or optional

To test apply the PR and on the front end check the edit user profile form
