### PR TITLE
[4.0b1] mod_menu => set attribute aria-current=page on anchor indicates the current page.

### DIFF
--- a/modules/mod_menu/tmpl/default_component.php
+++ b/modules/mod_menu/tmpl/default_component.php
@@ -29,6 +29,11 @@ if ($item->anchor_rel)
 	$attributes['rel'] = $item->anchor_rel;
 }
 
+if ($item->id == $active_id)
+{
+	$attributes['aria-current'] = 'page';
+}
+
 $linktype = $item->title;
 
 if ($item->menu_image)


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

add attribute `aria-current="page"` to frontend module mod_menu to the menu item that is the current page.

Screen readers should announce "Current page" to indicate the link with `aria-current="page"` is link is the current page in the navigation.

### Testing Instructions

- Make sure you are using mod_menu to display menu items
- Make sure mod_menu is visible on the frontend
- Visit a page on your test website
- Open your browser develop tools and find the output of mod_menu
- Find the anchor of the current page and see wha

### Expected result
```
<li class="nav-item item-101 default current active"><a href="/index.php" aria-current="page" tabindex="0">Home</a></li>
```

### Actual result
```
<li class="nav-item item-101 default current active"><a href="/index.php" tabindex="0">Home</a></li>
```


### Documentation Changes Required
Apply the PR and the attribute `aria-current` with value `page` will be applied to the frontend menu items pointing to a component. 

