### PR TITLE
[4.0] Fix creating tags in com_tags

### DIFF
--- a/administrator/components/com_tags/src/Model/TagModel.php
+++ b/administrator/components/com_tags/src/Model/TagModel.php
@@ -226,7 +226,7 @@ class TagModel extends AdminModel
 	 *
 	 * @since   3.1
 	 */
-	public function save2($data)
+	public function save($data)
 	{
 		/** @var \Joomla\Component\Tags\Administrator\Table\TagTable $table */
 		$table      = $this->getTable();


### PR DESCRIPTION
Fixes #29341.

### Summary of Changes

Fixes tag path not being generated when creating tags in com_tags.

### Testing Instructions

Create a tag using com_tags.
Create an article.
Search for the tag in Tags field.

### Expected result

Tag title shown.

### Actual result

Tag ID shown.

### Documentation Changes Required

No.