### PR TITLE
[4.0.b1] Fix notice thrown by Calendar

### DIFF
--- a/layouts/joomla/form/field/calendar.php
+++ b/layouts/joomla/form/field/calendar.php
@@ -114,7 +114,7 @@ $document->getWebAssetManager()
 			value="<?php echo htmlspecialchars(($value !== '0000-00-00 00:00:00') ? $value : '', ENT_COMPAT, 'UTF-8'); ?>"
 			<?php echo !empty($description) ? ' aria-describedby="' . $name . '-desc"' : ''; ?>
 			<?php echo $attributes; ?>
-			<?php echo $dataAttribute; ?>
+			<?php echo $dataAttribute ?? ''; ?>
 			<?php echo !empty($hint) ? 'placeholder="' . htmlspecialchars($hint, ENT_COMPAT, 'UTF-8') . '"' : ''; ?>
 			data-alt-value="<?php echo htmlspecialchars($value, ENT_COMPAT, 'UTF-8'); ?>" autocomplete="off">
 		<span class="input-group-append">


### PR DESCRIPTION
Closes gh-29340

Pull Request for Issue #29340 .

### Summary of Changes

Fixes https://github.com/joomla/joomla-cms/blob/4.0-dev/layouts/joomla/form/field/calendar.php#L117 to stop emitting a PHP Notice when you display a Calendar field with HtmlHelper.

### Testing Instructions

Set error reporting to Maximum.

Use any extension which uses something similar to
```php
echo \Joomla\CMS\HTML\HTMLHelper::('calendar', $myDate, 'fieldName', 'fieldID');
```
such as Akeeba Backup Core, Manage Backups tab.

### Expected result

Calendar (date picker) fields displayed without an issue.

### Actual result

You see "Notice: Undefined variable: dataAttribute in ...../layouts/joomla/form/field/calendar.php on line 117" in the middle of the calendar field. The effect is more pronounced and disruptive if you have XDebug enabled.

### Documentation Changes Required

None.