### PR TITLE
fixes issue with type transformations

### DIFF
--- a/libraries/src/Profiler/Profiler.php
+++ b/libraries/src/Profiler/Profiler.php
@@ -123,9 +123,9 @@ class Profiler
 			'%s %.3f seconds (%.3f); %0.2f MB (%0.3f) - %s',
 			$m->prefix,
 			$m->totalTime / 1000,
-			$m->time / 1000,
+			$current - $this->previousTime,
 			$m->totalMemory,
-			$m->memory,
+			$currentMem - $this->previousMem,
 			$m->label
 		);
 		$this->buffer[] = $mark;


### PR DESCRIPTION
### Summary of Changes
Since PHP 7.{1-4} server's logs are polluted with notice messages `PHP Notice:  A non well formed numeric value encountered in %ROOT%/libraries/src/Profiler/Profiler.php on line 126`.

The problem is wrong type casting (from `string` to `float`).

This patch is resolving this.  


### Testing Instructions
Looking for mentioned notices into server's logs after any pages have being requested via http proto.

**Attention**: notice level of messages has to been allowed!


### Expected result
Mentioned notices is not found.


### Actual result
Mentioned notices is found.


### Documentation Changes Required
None
