### PR TITLE
[4.0] Support null values in Extensions table

### DIFF
--- a/libraries/src/Table/Extension.php
+++ b/libraries/src/Table/Extension.php
@@ -29,6 +29,7 @@ class Extension extends Table
 	 * @since  __DEPLOY_VERSION__
 	 */
 	protected $_supportNullValue = true;
+
 	/**
 	 * Constructor
 	 *

--- a/libraries/src/Table/Extension.php
+++ b/libraries/src/Table/Extension.php
@@ -23,6 +23,13 @@ use Joomla\Utilities\ArrayHelper;
 class Extension extends Table
 {
 	/**
+	 * Indicates that columns fully support the NULL value in the database
+	 *
+	 * @var    boolean
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $_supportNullValue = true;
+	/**
 	 * Constructor
 	 *
 	 * @param   DatabaseDriver  $db  Database driver object.


### PR DESCRIPTION
### Summary of Changes

Adds null value support flag to Extensions table. Fixes enabling/disabling plugins.

### Testing Instructions

Go to plugins list.
Click the icon to disable a plugin.
Click the icon again to enable the plugin.

### Expected result

Plugin enabled.

### Actual result

Plugin remains disabled.

### Documentation Changes Required

IDK.