### PR TITLE
[4.0] Readonly switcher, not disabled

### DIFF
--- a/layouts/joomla/form/field/radio/switcher.php
+++ b/layouts/joomla/form/field/radio/switcher.php
@@ -83,10 +83,10 @@ $attr .= $dataAttribute;
 		// Initialize some option attributes.
 		$checked    = (string) $option->value == $value ? 'checked class="active"' : '';
 		$disable    = (string) $option->value != $value && $readonly || $disabled ? 'disabled' : '';
-		$oid		= $id . $i;
-		$ovalue		= htmlspecialchars($option->value, ENT_COMPAT, 'UTF-8');
-		$attributes	= array_filter([$checked, $disable]);
-		$text		= $options[$i]->text;
+		$oid        = $id . $i;
+		$ovalue     = htmlspecialchars($option->value, ENT_COMPAT, 'UTF-8');
+		$attributes = array_filter([$checked, $disable]);
+		$text       = $options[$i]->text;
 		?>
 		<?php echo sprintf($input, $oid, $name, $ovalue, implode(' ', $attributes)); ?>
 		<?php echo '<label for="' . $oid . '">' . $text . '</label>'; ?>

--- a/layouts/joomla/form/field/radio/switcher.php
+++ b/layouts/joomla/form/field/radio/switcher.php
@@ -66,10 +66,6 @@ $attr = 'id="' . $id . '"';
 $attr .= $onchange ? ' onchange="' . $onchange . '"' : '';
 $attr .= $dataAttribute;
 
-if (!empty($disabled) || !empty($readonly))
-{
-	$disabled = 'disabled="disabled"';
-}
 ?>
 <fieldset <?php echo $attr; ?>>
 	<legend class="switcher__legend sr-only">
@@ -85,11 +81,11 @@ if (!empty($disabled) || !empty($readonly))
 		}
 
 		// Initialize some option attributes.
-		$checked	= ((string) $option->value == $value) ? 'checked="checked"' : '';
-		$active		= ((string) $option->value == $value) ? 'class="active"' : '';
+		$checked	= (string) $option->value == $value ? 'checked class="active"' : '';
+		$disable    = (string) $option->value != $value && $readonly || $disabled ? 'disabled' : '';
 		$oid		= $id . $i;
 		$ovalue		= htmlspecialchars($option->value, ENT_COMPAT, 'UTF-8');
-		$attributes	= array_filter([$checked, $active, $disabled]);
+		$attributes	= array_filter([$checked, $disable]);
 		$text		= $options[$i]->text;
 		?>
 		<?php echo sprintf($input, $oid, $name, $ovalue, implode(' ', $attributes)); ?>

--- a/layouts/joomla/form/field/radio/switcher.php
+++ b/layouts/joomla/form/field/radio/switcher.php
@@ -81,7 +81,7 @@ $attr .= $dataAttribute;
 		}
 
 		// Initialize some option attributes.
-		$checked	= (string) $option->value == $value ? 'checked class="active"' : '';
+		$checked    = (string) $option->value == $value ? 'checked class="active"' : '';
 		$disable    = (string) $option->value != $value && $readonly || $disabled ? 'disabled' : '';
 		$oid		= $id . $i;
 		$ovalue		= htmlspecialchars($option->value, ENT_COMPAT, 'UTF-8');


### PR DESCRIPTION
Fixes https://github.com/joomla/joomla-cms/issues/29355.

### Summary of Changes

Currently, switcher makes no distinction between `readonly` and `disabled` attributes. I.e. data is not submitted when `readonly` attribute is used, as if it was disabled. This fixes that.

### Testing Instructions

See https://github.com/joomla/joomla-cms/issues/29355

### Documentation Changes Required

No.