### PR TITLE
[4.0] [com_templates] Move form manipulation to model

### DIFF
--- a/administrator/components/com_templates/forms/style_administrator.xml
+++ b/administrator/components/com_templates/forms/style_administrator.xml
@@ -7,6 +7,7 @@
 			label="COM_TEMPLATES_FIELD_HOME_LABEL"
 			layout="joomla.form.field.radio.switcher"
 			default="0"
+			validate="options"
 			>
 			<option value="0">JNO</option>
 			<option value="1">JYES</option>

--- a/administrator/components/com_templates/forms/style_site.xml
+++ b/administrator/components/com_templates/forms/style_site.xml
@@ -6,6 +6,7 @@
 			type="contentlanguage"
 			label="COM_TEMPLATES_FIELD_HOME_LABEL"
 			default="0"
+			validate="options"
 			>
 			<option value="0">JNO</option>
 			<option value="1">JALL</option>

--- a/administrator/components/com_templates/src/Model/StyleModel.php
+++ b/administrator/components/com_templates/src/Model/StyleModel.php
@@ -16,6 +16,7 @@ use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Filesystem\Path;
 use Joomla\CMS\Form\Form;
+use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
 use Joomla\CMS\MVC\Model\AdminModel;
@@ -435,6 +436,12 @@ class StyleModel extends AdminModel
 			|| (is_object($data) && isset($data->home) && $data->home == '1'))
 		{
 			$form->setFieldAttribute('home', 'readonly', 'true');
+		}
+
+		if ($client->name === 'site' && !Multilanguage::isEnabled())
+		{
+			$form->setFieldAttribute('home', 'type', 'radio');
+			$form->setFieldAttribute('home', 'layout', 'joomla.form.field.radio.switcher');
 		}
 
 		// Attempt to load the xml file.

--- a/administrator/components/com_templates/src/View/Style/HtmlView.php
+++ b/administrator/components/com_templates/src/View/Style/HtmlView.php
@@ -13,7 +13,6 @@ namespace Joomla\Component\Templates\Administrator\View\Style;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Helper\ContentHelper;
-use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
@@ -75,12 +74,6 @@ class HtmlView extends BaseHtmlView
 		if (count($errors = $this->get('Errors')))
 		{
 			throw new GenericDataException(implode("\n", $errors), 500);
-		}
-
-		if ((!Multilanguage::isEnabled()) && ($this->item->client_id == 0))
-		{
-			$this->form->setFieldAttribute('home', 'type', 'radio');
-			$this->form->setFieldAttribute('home', 'layout', 'joomla.form.field.radio.switcher');
 		}
 
 		$this->addToolbar();


### PR DESCRIPTION
### Summary of Changes

Moves some form code from the view to the model. Forms should never be manipulated in the view - the changes are never reflected when validating the form.

### Testing Instructions

Edit a site template style.
Check that `Default` field appears as a switcher on monolingual sites and as a dropdown on multilingual sites.
Check that you can still save the style.

### Expected result

Works like before.

### Documentation Changes Required

No.