### PR TITLE
[4.0] Fix the extra padding under the modal buttons

### DIFF
--- a/administrator/templates/atum/scss/blocks/_modals.scss
+++ b/administrator/templates/atum/scss/blocks/_modals.scss
@@ -6,7 +6,6 @@
     padding: 0 22px;
     margin-right: .5rem;
     font-size: 1rem;
-    line-height: 2.375rem;
     color: var(--atum-text-dark);
     background: var(--white);
     border-color: var(--whiteoffset);


### PR DESCRIPTION
Pull Request for Issue #29318 .

### Summary of Changes
Attempts to fix the spacing around the buttons on the dashboard modal

### Testing Instructions
Before patch: 
![image](https://user-images.githubusercontent.com/1986000/83462728-dde96700-a463-11ea-83f1-7447e5ffe1d6.png)

After patch: No spacing under the red box to the bottom border

### Documentation Changes Required
None
