### PR TITLE
[4.0] Remove btn-sm

### DIFF
--- a/layouts/joomla/toolbar/versions.php
+++ b/layouts/joomla/toolbar/versions.php
@@ -53,7 +53,7 @@ echo HTMLHelper::_(
 ?>
 <joomla-toolbar-button id="toolbar-versions">
 	<button
-		class="btn btn-sm btn-primary"
+		class="btn btn-primary"
 		type="button"
 		onclick="document.getElementById('versionsModal').open()"
 		data-toggle="modal">


### PR DESCRIPTION
### Summary of Changes
Buttons in the toolbar do not have `btn-sm` class except the `Versions` button. Remove the class for consistency.


### Testing Instructions
Code review.
or
Log in to administration.
Edit an article.
Use browser's inspector on the `Versions` button before/after PR.
Button should look the same before/after PR.




