### PR TITLE
[4.0] com Finder table caption

### DIFF
--- a/administrator/components/com_finder/tmpl/statistics/default.php
+++ b/administrator/components/com_finder/tmpl/statistics/default.php
@@ -13,8 +13,8 @@ use Joomla\CMS\Language\Text;
 
 ?>
 <div class="container-popup">
-	<p class="tab-description"><?php echo Text::sprintf('COM_FINDER_STATISTICS_STATS_DESCRIPTION', number_format($this->data->term_count, 0, Text::_('DECIMALS_SEPARATOR'), Text::_('THOUSANDS_SEPARATOR')), number_format($this->data->link_count, 0, Text::_('DECIMALS_SEPARATOR'), Text::_('THOUSANDS_SEPARATOR')), number_format($this->data->taxonomy_node_count, 0, Text::_('DECIMALS_SEPARATOR'), Text::_('THOUSANDS_SEPARATOR')), number_format($this->data->taxonomy_branch_count, 0, Text::_('DECIMALS_SEPARATOR'), Text::_('THOUSANDS_SEPARATOR'))); ?></p>
 	<table class="table table-sm">
+	<caption class="caption-top"><?php echo Text::sprintf('COM_FINDER_STATISTICS_STATS_DESCRIPTION', number_format($this->data->term_count, 0, Text::_('DECIMALS_SEPARATOR'), Text::_('THOUSANDS_SEPARATOR')), number_format($this->data->link_count, 0, Text::_('DECIMALS_SEPARATOR'), Text::_('THOUSANDS_SEPARATOR')), number_format($this->data->taxonomy_node_count, 0, Text::_('DECIMALS_SEPARATOR'), Text::_('THOUSANDS_SEPARATOR')), number_format($this->data->taxonomy_branch_count, 0, Text::_('DECIMALS_SEPARATOR'), Text::_('THOUSANDS_SEPARATOR'))); ?></caption>
 		<thead>
 			<tr>
 				<th scope="col">

--- a/administrator/templates/atum/scss/pages/_com_finder.scss
+++ b/administrator/templates/atum/scss/pages/_com_finder.scss
@@ -1,0 +1,5 @@
+// com_finder statistics
+
+.caption-top {
+  caption-side: top;
+}

--- a/administrator/templates/atum/scss/template.scss
+++ b/administrator/templates/atum/scss/template.scss
@@ -63,6 +63,7 @@
 @import "pages/com_config";
 @import "pages/com_content";
 @import "pages/com_cpanel";
+@import "pages/com_finder";
 @import "pages/com_joomlaupdate";
 @import "pages/com_modules";
 @import "pages/com_tags";


### PR DESCRIPTION
All tables should have a caption. The popup statistics looks like it has one but its actually a paragraph. This PR corrects that.

As new scss is required you will need to rebuild to be able to test.

There is no visible change with this PR