### PR TITLE
[4.0] Removing obsolete code from com_banners table classes

### DIFF
--- a/administrator/components/com_banners/src/Table/BannerTable.php
+++ b/administrator/components/com_banners/src/Table/BannerTable.php
@@ -223,11 +223,6 @@ class BannerTable extends Table implements VersionableTableInterface
 	{
 		$db = $this->getDbo();
 
-		if (is_null($this->checked_out))
-		{
-			$this->checked_out = 0;
-		}
-
 		if (empty($this->id))
 		{
 			$purchaseType = $this->purchase_type;

--- a/administrator/components/com_banners/src/Table/ClientTable.php
+++ b/administrator/components/com_banners/src/Table/ClientTable.php
@@ -43,104 +43,10 @@ class ClientTable extends Table implements VersionableTableInterface
 	public function __construct(DatabaseDriver $db)
 	{
 		$this->typeAlias        = 'com_banners.client';
-		$this->checked_out_time = null;
 
 		$this->setColumnAlias('published', 'state');
 
 		parent::__construct('#__banner_clients', 'id', $db);
-	}
-
-	/**
-	 * Method to set the publishing state for a row or list of rows in the database
-	 * table.  The method respects checked out rows by other users and will attempt
-	 * to checkin rows that it can after adjustments are made.
-	 *
-	 * @param   mixed    $pks     An optional array of primary key values to update.  If not set the instance property value is used.
-	 * @param   integer  $state   The publishing state. eg. [0 = unpublished, 1 = published, 2=archived, -2=trashed]
-	 * @param   integer  $userId  The user id of the user performing the operation.
-	 *
-	 * @return  boolean  True on success.
-	 *
-	 * @since   1.0.4
-	 */
-	public function publish($pks = null, $state = 1, $userId = 0)
-	{
-		$k = $this->_tbl_key;
-
-		// Sanitize input.
-		$pks    = ArrayHelper::toInteger($pks);
-		$userId = (int) $userId;
-		$state  = (int) $state;
-
-		// If there are no primary keys set check to see if the instance key is set.
-		if (empty($pks))
-		{
-			if ($this->$k)
-			{
-				$pks = array($this->$k);
-			}
-			// Nothing to set publishing state on, return false.
-			else
-			{
-				$this->setError(Text::_('JLIB_DATABASE_ERROR_NO_ROWS_SELECTED'));
-
-				return false;
-			}
-		}
-
-		// Update the publishing state for rows with the given primary keys.
-		$query = $this->_db->getQuery(true)
-			->update($this->_db->quoteName($this->_tbl))
-			->set($this->_db->quoteName('state') . ' = :state')
-			->whereIn($this->_db->quoteName($k), $pks)
-			->bind(':state', $state, ParameterType::INTEGER);
-
-		// Determine if there is checkin support for the table.
-		if ($this->hasField('checked_out') && $this->hasField('checked_out_time'))
-		{
-			$query->extendWhere(
-				'AND',
-				[
-					$this->_db->quoteName('checked_out') . ' IS NULL',
-					$this->_db->quoteName('checked_out') . ' = :userId',
-				],
-				'OR'
-			)
-				->bind(':userId', $userId, ParameterType::INTEGER);
-		}
-
-		$this->_db->setQuery($query);
-
-		try
-		{
-			$this->_db->execute();
-		}
-		catch (\RuntimeException $e)
-		{
-			$this->setError($e->getMessage());
-
-			return false;
-		}
-
-		// If checkin is supported and all rows were adjusted, check them in.
-		if ($checkin && (count($pks) == $this->_db->getAffectedRows()))
-		{
-			// Checkin the rows.
-			foreach ($pks as $pk)
-			{
-				$this->checkin($pk);
-			}
-		}
-
-		// If the \JTable instance value is in the list of primary keys that were set, set the instance.
-		if (in_array($this->$k, $pks))
-		{
-			$this->state = $state;
-		}
-
-		$this->setError('');
-
-		return true;
 	}
 
 	/**

--- a/administrator/components/com_banners/src/Table/ClientTable.php
+++ b/administrator/components/com_banners/src/Table/ClientTable.php
@@ -11,12 +11,9 @@ namespace Joomla\Component\Banners\Administrator\Table;
 
 \defined('_JEXEC') or die;
 
-use Joomla\CMS\Language\Text;
 use Joomla\CMS\Table\Table;
 use Joomla\CMS\Versioning\VersionableTableInterface;
 use Joomla\Database\DatabaseDriver;
-use Joomla\Database\ParameterType;
-use Joomla\Utilities\ArrayHelper;
 
 /**
  * Client table


### PR DESCRIPTION
This removes obsolete code.

BannerTable contained something that was made obsolete by the recent change of the checked_out column.

ClientTable: checked_out_time: again made unnecessary because of the recent changes. publish: made unnecessary due to the column alias feature.
