### PR TITLE
[4.0] Removing obsolete code from com_contact table class

### DIFF
--- a/administrator/components/com_contact/src/Table/ContactTable.php
+++ b/administrator/components/com_contact/src/Table/ContactTable.php
@@ -71,13 +71,6 @@ class ContactTable extends Table implements VersionableTableInterface
 	 */
 	public function store($updateNulls = true)
 	{
-		// Transform the params field
-		if (is_array($this->params))
-		{
-			$registry = new Registry($this->params);
-			$this->params = (string) $registry;
-		}
-
 		$date   = Factory::getDate()->toSql();
 		$userId = Factory::getUser()->id;
 

--- a/administrator/components/com_contact/src/Table/ContactTable.php
+++ b/administrator/components/com_contact/src/Table/ContactTable.php
@@ -18,7 +18,6 @@ use Joomla\CMS\String\PunycodeHelper;
 use Joomla\CMS\Table\Table;
 use Joomla\CMS\Versioning\VersionableTableInterface;
 use Joomla\Database\DatabaseDriver;
-use Joomla\Registry\Registry;
 use Joomla\String\StringHelper;
 
 /**


### PR DESCRIPTION
The removed code is not necessary anymore, since we have the automatically json encoded field feature in the Table class already.