### PR TITLE
[4.0] Removing obsolete code from com_finder table classes

### DIFF
--- a/administrator/components/com_finder/src/Table/FilterTable.php
+++ b/administrator/components/com_finder/src/Table/FilterTable.php
@@ -17,7 +17,6 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Table\Table;
 use Joomla\Database\DatabaseDriver;
 use Joomla\Registry\Registry;
-use Joomla\Utilities\ArrayHelper;
 
 /**
  * Filter table class for the Finder package.

--- a/administrator/components/com_finder/src/Table/FilterTable.php
+++ b/administrator/components/com_finder/src/Table/FilterTable.php
@@ -35,6 +35,14 @@ class FilterTable extends Table
 	protected $_supportNullValue = true;
 
 	/**
+	 * Ensure the params are json encoded in the bind method
+	 *
+	 * @var    array
+	 * @since  4.0.0
+	 */
+	protected $_jsonEncode = array('params');
+
+	/**
 	 * Constructor
 	 *
 	 * @param   DatabaseDriver  $db  Database Driver connector object.
@@ -46,30 +54,6 @@ class FilterTable extends Table
 		parent::__construct('#__finder_filters', 'filter_id', $db);
 
 		$this->setColumnAlias('published', 'state');
-	}
-
-	/**
-	 * Method to bind an associative array or object to the \JTable instance.  This
-	 * method only binds properties that are publicly accessible and optionally
-	 * takes an array of properties to ignore when binding.
-	 *
-	 * @param   array  $array   Named array
-	 * @param   mixed  $ignore  An optional array or space separated list of properties
-	 *                          to ignore while binding. [optional]
-	 *
-	 * @return  mixed  Null if operation was satisfactory, otherwise returns an error string
-	 *
-	 * @since   2.5
-	 */
-	public function bind($array, $ignore = '')
-	{
-		if (isset($array['params']) && is_array($array['params']))
-		{
-			$registry = new Registry($array['params']);
-			$array['params'] = (string) $registry;
-		}
-
-		return parent::bind($array, $ignore);
 	}
 
 	/**
@@ -120,97 +104,6 @@ class FilterTable extends Table
 			$params->set('d2', $d1);
 			$this->params = (string) $params;
 		}
-
-		return true;
-	}
-
-	/**
-	 * Method to set the publishing state for a row or list of rows in the database
-	 * table. The method respects checked out rows by other users and will attempt
-	 * to checkin rows that it can after adjustments are made.
-	 *
-	 * @param   mixed    $pks     An array of primary key values to update.  If not
-	 *                            set the instance property value is used. [optional]
-	 * @param   integer  $state   The publishing state. eg. [0 = unpublished, 1 = published] [optional]
-	 * @param   integer  $userId  The user id of the user performing the operation. [optional]
-	 *
-	 * @return  boolean  True on success.
-	 *
-	 * @since   2.5
-	 */
-	public function publish($pks = null, $state = 1, $userId = 0)
-	{
-		$k = $this->_tbl_key;
-
-		// Sanitize input.
-		$pks = ArrayHelper::toInteger($pks);
-		$userId = (int) $userId;
-		$state = (int) $state;
-
-		// If there are no primary keys set check to see if the instance key is set.
-		if (empty($pks))
-		{
-			if ($this->$k)
-			{
-				$pks = array($this->$k);
-			}
-			// Nothing to set publishing state on, return false.
-			else
-			{
-				$this->setError(Text::_('JLIB_DATABASE_ERROR_NO_ROWS_SELECTED'));
-
-				return false;
-			}
-		}
-
-		// Build the WHERE clause for the primary keys.
-		$where = $k . '=' . implode(' OR ' . $k . '=', $pks);
-
-		// Determine if there is checkin support for the table.
-		if (!$this->hasField('checked_out') || !$this->hasField('checked_out_time'))
-		{
-			$checkin = '';
-		}
-		else
-		{
-			$checkin = ' AND (checked_out IS NULL OR checked_out = ' . (int) $userId . ')';
-		}
-
-		// Update the publishing state for rows with the given primary keys.
-		$query = $this->_db->getQuery(true)
-			->update($this->_db->quoteName($this->_tbl))
-			->set($this->_db->quoteName('state') . ' = ' . (int) $state)
-			->where($where);
-		$this->_db->setQuery($query . $checkin);
-
-		try
-		{
-			$this->_db->execute();
-		}
-		catch (\RuntimeException $e)
-		{
-			$this->setError($e->getMessage());
-
-			return false;
-		}
-
-		// If checkin is supported and all rows were adjusted, check them in.
-		if ($checkin && count($pks) === $this->_db->getAffectedRows())
-		{
-			// Checkin the rows.
-			foreach ($pks as $pk)
-			{
-				$this->checkIn($pk);
-			}
-		}
-
-		// If the \JTable instance value is in the list of primary keys that were set, set the instance.
-		if (in_array($this->$k, $pks))
-		{
-			$this->state = $state;
-		}
-
-		$this->setError('');
 
 		return true;
 	}

--- a/administrator/components/com_finder/src/Table/MapTable.php
+++ b/administrator/components/com_finder/src/Table/MapTable.php
@@ -35,6 +35,8 @@ class MapTable extends Nested
 	public function __construct(DatabaseDriver $db)
 	{
 		parent::__construct('#__finder_taxonomy', 'id', $db);
+
+		$this->setColumnAlias('published', 'state');
 		$this->access = (int) Factory::getConfig()->get('access');
 	}
 
@@ -73,76 +75,6 @@ class MapTable extends Nested
 		{
 			$this->alias = md5(serialize($this->getProperties()));
 		}
-
-		return true;
-	}
-
-	/**
-	 * Method to set the publishing state for a row or list of rows in the database
-	 * table. The method respects checked out rows by other users and will attempt
-	 * to checkin rows that it can after adjustments are made.
-	 *
-	 * @param   mixed    $pks     An array of primary key values to update.  If not
-	 *                            set the instance property value is used. [optional]
-	 * @param   integer  $state   The publishing state. eg. [0 = unpublished, 1 = published] [optional]
-	 * @param   integer  $userId  The user id of the user performing the operation. [optional]
-	 *
-	 * @return  boolean  True on success.
-	 *
-	 * @since   2.5
-	 */
-	public function publish($pks = null, $state = 1, $userId = 0)
-	{
-		$k = $this->_tbl_key;
-
-		// Sanitize input.
-		$pks = ArrayHelper::toInteger($pks);
-		$state = (int) $state;
-
-		// If there are no primary keys set check to see if the instance key is set.
-		if (empty($pks))
-		{
-			if ($this->$k)
-			{
-				$pks = array($this->$k);
-			}
-			// Nothing to set publishing state on, return false.
-			else
-			{
-				$this->setError(Text::_('JLIB_DATABASE_ERROR_NO_ROWS_SELECTED'));
-
-				return false;
-			}
-		}
-
-		// Build the WHERE clause for the primary keys.
-		$where = $k . '=' . implode(' OR ' . $k . '=', $pks);
-
-		// Update the publishing state for rows with the given primary keys.
-		$query = $this->_db->getQuery(true)
-			->update($this->_db->quoteName($this->_tbl))
-			->set($this->_db->quoteName('state') . ' = ' . (int) $state)
-			->where($where);
-		$this->_db->setQuery($query);
-
-		try
-		{
-			$this->_db->execute();
-		}
-		catch (\RuntimeException $e)
-		{
-			$this->setError($e->getMessage());
-
-			return false;
-		}
-
-		// If the \JTable instance value is in the list of primary keys that were set, set the instance.
-		if (in_array($this->$k, $pks))
-		{
-			$this->state = $state;
-		}
-
-		$this->setError('');
 
 		return true;
 	}


### PR DESCRIPTION
This removes obsolete code from the com_finder table classes. The bind method is unnecessary after the introduction of the encode-field-as-json-feature. Both publish methods can be dropped with the column-alias-feature.