### PR TITLE
[4.0] Nested fieldsets

### DIFF
--- a/layouts/joomla/edit/params.php
+++ b/layouts/joomla/edit/params.php
@@ -118,7 +118,7 @@ foreach ($fieldSets as $name => $fieldSet)
 	{
 		echo '<fieldset id="fieldset-' . $name . '" class="options-form ' . (!empty($fieldSet->class) ? $fieldSet->class : '') . '">';
 		echo '<legend>' . $label . '</legend>';
-		echo '<div class="column-count-md-2 column-count-lg-3">';
+		echo '<div>';
 	}
 	// Tabs
 	elseif (!$hasParent)


### PR DESCRIPTION
This PR stops splitting nested fieldsets using the params layout from being split again into columns

Possible solution to #29388 and #29254 

## before
![image](https://user-images.githubusercontent.com/1296369/83577901-5a944800-a52d-11ea-9761-0434feeec2b3.png)

## after
![image](https://user-images.githubusercontent.com/1296369/83577872-46504b00-a52d-11ea-9b41-9cf277352be2.png)

I have **not** checked to see if there are other places where this happens other than the example in the screenshot with com_tags