### PR TITLE
Fix array offset notice on PHP 7.4 when installing extensions

### DIFF
--- a/administrator/components/com_installer/models/install.php
+++ b/administrator/components/com_installer/models/install.php
@@ -135,6 +135,14 @@ class InstallerModelInstall extends JModelLegacy
 			return false;
 		}
 
+		// Check if package was uploaded successfully.
+		if (!\is_array($package))
+		{
+			$app->enqueueMessage(JText::_('COM_INSTALLER_UNABLE_TO_FIND_INSTALL_PACKAGE'), 'error');
+
+			return false;
+		}
+
 		// Get an installer instance.
 		$installer = JInstaller::getInstance();
 
@@ -145,7 +153,7 @@ class InstallerModelInstall extends JModelLegacy
 		 * This must be done before the unpacked check because JInstallerHelper::detectType() returns a boolean false since the manifest
 		 * can't be found in the expected location.
 		 */
-		if (is_array($package) && isset($package['dir']) && is_dir($package['dir']))
+		if (isset($package['dir']) && is_dir($package['dir']))
 		{
 			$installer->setPath('source', $package['dir']);
 
@@ -171,7 +179,7 @@ class InstallerModelInstall extends JModelLegacy
 		}
 
 		// Was the package unpacked?
-		if (!$package || !$package['type'])
+		if (empty($package['type']))
 		{
 			if (in_array($installType, array('upload', 'url')))
 			{

--- a/administrator/components/com_installer/models/install.php
+++ b/administrator/components/com_installer/models/install.php
@@ -186,7 +186,7 @@ class InstallerModelInstall extends JModelLegacy
 				JInstallerHelper::cleanupInstall($package['packagefile'], $package['extractdir']);
 			}
 
-			$app->enqueueMessage(JText::_('COM_INSTALLER_UNABLE_TO_FIND_INSTALL_PACKAGE'), 'error');
+			$app->enqueueMessage(JText::_('JLIB_INSTALLER_ABORT_DETECTMANIFEST'), 'error');
 
 			return false;
 		}


### PR DESCRIPTION
Partial Pull Request for Issue https://github.com/joomla/joomla-cms/issues/29414.

### Summary of Changes

Fixes a notice on PHP 7.4 when uploading extension package fails.

### Testing Instructions

1) Install an extension package with size over `upload_max_filesize` limit. Check PHP error log.
2) Try to install a random file, e.g. an image. Check Joomla's tmp directory.
3) Install an extension with size under `upload_max_filesize` limit.

### Expected result

1) Installation aborted. No PHP notices.
2) Installation aborted and uploaded file is removed from tmp directory.
3) Extension installed successfully.

### Actual result

1) Installation aborted. PHP notice: `Trying to access array offset on value of type bool in administrator\components\com_installer\models\install.php on line 178`

### Documentation Changes Required

No.