### PR TITLE
Check if the versions object has the property

### DIFF
--- a/administrator/components/com_contenthistory/models/compare.php
+++ b/administrator/components/com_contenthistory/models/compare.php
@@ -90,7 +90,7 @@ class ContenthistoryModelCompare extends JModelItem
 
 					foreach ($dateProperties as $dateProperty)
 					{
-						if (isset($object->data->$dateProperty) && $object->data->$dateProperty->value != '0000-00-00 00:00:00')
+						if (property_exists($object->data, $dateProperty) && $object->data->$dateProperty->value != '0000-00-00 00:00:00')
 						{
 							$object->data->$dateProperty->value = JHtml::_('date', $object->data->$dateProperty->value, JText::_('DATE_FORMAT_LC6'));
 						}

--- a/administrator/components/com_contenthistory/models/compare.php
+++ b/administrator/components/com_contenthistory/models/compare.php
@@ -90,7 +90,7 @@ class ContenthistoryModelCompare extends JModelItem
 
 					foreach ($dateProperties as $dateProperty)
 					{
-						if (array_key_exists($dateProperty, $object->data) && $object->data->$dateProperty->value != '0000-00-00 00:00:00')
+						if (isset($object->data->$dateProperty) && $object->data->$dateProperty->value != '0000-00-00 00:00:00')
 						{
 							$object->data->$dateProperty->value = JHtml::_('date', $object->data->$dateProperty->value, JText::_('DATE_FORMAT_LC6'));
 						}

--- a/administrator/components/com_contenthistory/models/preview.php
+++ b/administrator/components/com_contenthistory/models/preview.php
@@ -82,7 +82,7 @@ class ContenthistoryModelPreview extends JModelItem
 
 			foreach ($dateProperties as $dateProperty)
 			{
-				if (array_key_exists($dateProperty, $result->data) && $result->data->$dateProperty->value != '0000-00-00 00:00:00')
+				if (property_exists($result->data, $dateProperty) && $result->data->$dateProperty->value != '0000-00-00 00:00:00')
 				{
 					$result->data->$dateProperty->value = JHtml::_('date', $result->data->$dateProperty->value, JText::_('DATE_FORMAT_LC6'));
 				}


### PR DESCRIPTION
Staging pull request for issue #27214, basically a backport of #27493.

### Summary of Changes
When comparing two versions of an article a warning is thrown:

_Deprecated: array_key_exists(): Using array_key_exists() on objects is deprecated. Use isset() or property_exists() instead_

This pr fixes it.

### Testing Instructions
- Ensure versions is enabled in the articles options in the editing layout tab
- Create an article
- Edit the title and save the article again
- Edit the title again and save it
- Click on the versions button
- Select the two versions
- Click on compare

### Expected result
No warning is thrown.

### Actual result
A warning is thrown.