### PR TITLE
[4.0] Module assignment page not updating

### DIFF
--- a/administrator/components/com_menus/tmpl/item/edit_modules.php
+++ b/administrator/components/com_menus/tmpl/item/edit_modules.php
@@ -90,7 +90,7 @@ echo LayoutHelper::render('joomla.menu.edit_modules', $this); ?>
 		<?php else : ?>
 			<?php $status = 'unpublished '; ?>
 		<?php endif; ?>
-		<tr class="<?php echo $no; ?><?php echo $status; ?>row<?php echo $i % 2; ?>">
+		<tr id="tr-<?php echo $module->id; ?>" class="<?php echo $no; ?><?php echo $status; ?>row<?php echo $i % 2; ?>">
 			<th scope="row">
 				<button type="button"
 					data-target="#moduleEditModal"
@@ -100,13 +100,13 @@ echo LayoutHelper::render('joomla.menu.edit_modules', $this); ?>
 					data-module-id="<?php echo $module->id; ?>">
 					<?php echo $this->escape($module->title); ?></button>
 			</th>
-			<td>
+			<td id="access-<?php echo $module->id; ?>">
 				<?php echo $this->escape($module->access_title); ?>
 			</td>
-			<td>
+			<td id="position-<?php echo $module->id; ?>">
 				<?php echo $this->escape($module->position); ?>
 			</td>
-			<td>
+			<td id="menus-<?php echo $module->id; ?>">
 				<?php if (is_null($module->menuid)) : ?>
 					<?php if ($module->except) : ?>
 						<span class="badge badge-success">
@@ -131,7 +131,7 @@ echo LayoutHelper::render('joomla.menu.edit_modules', $this); ?>
 					</span>
 				<?php endif; ?>
 			</td>
-			<td>
+			<td id="status-<?php echo $module->id; ?>">
 				<?php if ($module->published) : ?>
 					<span class="badge badge-success">
 						<?php echo Text::_('JYES'); ?>


### PR DESCRIPTION
Fixes https://github.com/joomla/joomla-cms/issues/29437.

### Summary of Changes

Restores some IDs used in JS.

### Testing Instructions

Edit a menu item.
In `Module Assignment` tab click on a module to edit it.
Change menu assignment, status, access level or position.
Click `Save` or `Save & Close`.

### Expected result

`Module Assignment` page updated with new values.

### Actual result

Page not updated and JS error is generated:

>TypeError: tmpMenu is null admin-module-edit.js:55:69

### Documentation Changes Required

No.