### PR TITLE
[4.0] Indicate current menu item in sidebar

### DIFF
--- a/administrator/templates/atum/scss/blocks/_sidebar.scss
+++ b/administrator/templates/atum/scss/blocks/_sidebar.scss
@@ -144,6 +144,10 @@
     }
   }
 
+  a.mm-active {
+    background-color: $gray-300;
+  } 
+
   .mm-active > .has-arrow::after {
     content: "\f078";
   }


### PR DESCRIPTION
Pull Request for Issue # .

@chmst 

### Summary of Changes
Adds shading to the background of the current menu item (sidebar)


### Testing Instructions
Apply this patch and run `node build.js --compile-css` to update the changed SCSS. Check current menu item is indicated in sidebar (grey background).


### Expected result



### Actual result



### Documentation Changes Required

