### PR TITLE
[4.0] Load jQuery for Treeselectmenu

### DIFF
--- a/administrator/components/com_menus/tmpl/item/edit_container.php
+++ b/administrator/components/com_menus/tmpl/item/edit_container.php
@@ -18,9 +18,8 @@ $menuLinks = MenusHelper::getMenuLinks('main');
 
 HTMLHelper::_('stylesheet', 'com_menus/admin-item-edit_container.css', array('version' => 'auto', 'relative' => true));
 HTMLHelper::_('script', 'com_menus/admin-item-edit_container.min.js', ['version' => 'auto', 'relative' => true], ['defer' => 'defer']);
-HTMLHelper::_('script', 'legacy/treeselectmenu.min.js', ['version' => 'auto', 'relative' => true], ['defer' => 'defer']);
+$this->document->getWebAssetManager()->useScript('joomla.treeselectmenu');
 ?>
-
 <div id="menuselect-group" class="control-group">
 	<div class="control-label"><?php echo $this->form->getLabel('hideitems', 'params'); ?></div>
 

--- a/administrator/components/com_modules/tmpl/module/edit_assignment.php
+++ b/administrator/components/com_modules/tmpl/module/edit_assignment.php
@@ -18,7 +18,7 @@ use Joomla\Component\Modules\Administrator\Helper\ModulesHelper;
 // Initialise related data.
 $menuTypes = MenusHelper::getMenuLinks();
 
-HTMLHelper::_('script', 'legacy/treeselectmenu.min.js', array('version' => 'auto', 'relative' => true));
+$this->document->getWebAssetManager()->useScript('joomla.treeselectmenu');
 HTMLHelper::_('script', 'com_modules/admin-module-edit_assignment.min.js', array('version' => 'auto', 'relative' => true));
 ?>
 <div class="control-group">

--- a/build/media_source/legacy/joomla.asset.json
+++ b/build/media_source/legacy/joomla.asset.json
@@ -36,6 +36,17 @@
         "joomla.frontediting#style",
         "joomla.frontediting#script"
       ]
+    },
+    {
+      "name": "joomla.treeselectmenu",
+      "type": "script",
+      "dependencies": [
+        "jquery"
+      ],
+      "uri": "legacy/treeselectmenu.min.js",
+      "attributes": {
+        "defer": true
+      }
     }
   ]
 }


### PR DESCRIPTION
Fixes #29436.

### Summary of Changes

Loads jQuery for treeselectmenu.js.

### Testing Instructions

Depending on whether jQuery is loaded elsewhere you may not be able to reproduce the issue. Should be reproducible on a clean installation with debug disabled.

Edit a menu item.
In `Module Assignments` tab click on  a module.
In the modal go to `Menu Assignment` tab.
In `Module Assignment` field select `Only on the pages selected` or `On all pages except those selected`.
Click on `All` and `None` buttons to change selected items.

### Expected result

Items selected/unselected.

### Actual result

Nothing happens, JS error is generated:

>ReferenceError: jQuery is not defined treeselectmenu.min.js:1:1

### Documentation Changes Required

No.