### PR TITLE
Rename transition field label to workflow

### DIFF
--- a/libraries/src/MVC/Model/WorkflowBehaviorTrait.php
+++ b/libraries/src/MVC/Model/WorkflowBehaviorTrait.php
@@ -339,7 +339,7 @@ trait WorkflowBehaviorTrait
 
 		$field->addAttribute('name', 'transition');
 		$field->addAttribute('type', $this->workflowEnabled ? 'transition' : 'hidden');
-		$field->addAttribute('label', 'COM_CONTENT_TRANSITION');
+		$field->addAttribute('label', 'COM_CONTENT_WORKFLOW');
 		$field->addAttribute('extension', $extension);
 
 		$form->setField($field);


### PR DESCRIPTION
### Summary of Changes
Rename the "Transition" label to "Workflow" in the article edit view, because the dropdown are transitions + stages.

![grafik](https://user-images.githubusercontent.com/1229869/83922163-26649580-a780-11ea-8df9-a21a3e1b474f.png)

@brianteeman you pointed out the wrong labeling here, is this better?