### PR TITLE
[4.0] Installer enable the bootup error trace when debug enabled

### DIFF
--- a/installation/includes/framework.php
+++ b/installation/includes/framework.php
@@ -33,3 +33,14 @@ if (file_exists(JPATH_CONFIGURATION . '/configuration.php')
 
 // Import the Joomla Platform.
 require_once JPATH_LIBRARIES . '/bootstrap.php';
+
+if (JDEBUG)
+{
+	// Set new Exception handler with debug enabled
+	$errorHandler->setExceptionHandler(
+		[
+			new \Symfony\Component\ErrorHandler\ErrorHandler(null, true),
+			'renderException'
+		]
+	);
+}


### PR DESCRIPTION
### Summary of Changes

Enable the bootup error trace when debug enabled, for Installer.


### Testing Instructions
Edit `installation/includes/app.php` somwhere at middle add `throw new \Exception('error');`
Edit `installation/includes/framework.php` change `JDEBUG` to be `true`.
Start installation.


### Expected result
You should get full trace with error message


### Actual result
You get `Oops! An Error Occurred`

