### PR TITLE
[4.0] Make onUserLoginButtons event work again

### DIFF
--- a/administrator/components/com_fields/src/Plugin/FieldsPlugin.php
+++ b/administrator/components/com_fields/src/Plugin/FieldsPlugin.php
@@ -150,7 +150,7 @@ abstract class FieldsPlugin extends CMSPlugin
 
 		if (!file_exists($path))
 		{
-			$path = JPluginHelper::getLayoutPath('fields', $this->_name, $field->type);
+			$path = PluginHelper::getLayoutPath('fields', $this->_name, $field->type);
 		}
 
 		// Render the layout

--- a/administrator/components/com_menus/tmpl/item/edit_modules.php
+++ b/administrator/components/com_menus/tmpl/item/edit_modules.php
@@ -90,7 +90,7 @@ echo LayoutHelper::render('joomla.menu.edit_modules', $this); ?>
 		<?php else : ?>
 			<?php $status = 'unpublished '; ?>
 		<?php endif; ?>
-		<tr class="<?php echo $no; ?><?php echo $status; ?>row<?php echo $i % 2; ?>">
+		<tr id="tr-<?php echo $module->id; ?>" class="<?php echo $no; ?><?php echo $status; ?>row<?php echo $i % 2; ?>">
 			<th scope="row">
 				<button type="button"
 					data-target="#moduleEditModal"
@@ -100,13 +100,13 @@ echo LayoutHelper::render('joomla.menu.edit_modules', $this); ?>
 					data-module-id="<?php echo $module->id; ?>">
 					<?php echo $this->escape($module->title); ?></button>
 			</th>
-			<td>
+			<td id="access-<?php echo $module->id; ?>">
 				<?php echo $this->escape($module->access_title); ?>
 			</td>
-			<td>
+			<td id="position-<?php echo $module->id; ?>">
 				<?php echo $this->escape($module->position); ?>
 			</td>
-			<td>
+			<td id="menus-<?php echo $module->id; ?>">
 				<?php if (is_null($module->menuid)) : ?>
 					<?php if ($module->except) : ?>
 						<span class="badge badge-success">
@@ -131,7 +131,7 @@ echo LayoutHelper::render('joomla.menu.edit_modules', $this); ?>
 					</span>
 				<?php endif; ?>
 			</td>
-			<td>
+			<td id="status-<?php echo $module->id; ?>">
 				<?php if ($module->published) : ?>
 					<span class="badge badge-success">
 						<?php echo Text::_('JYES'); ?>

--- a/administrator/language/en-GB/plg_system_webauthn.ini
+++ b/administrator/language/en-GB/plg_system_webauthn.ini
@@ -13,6 +13,10 @@ PLG_SYSTEM_WEBAUTHN_HEADER="W3C Web Authentication (WebAuthn) Login"
 PLG_SYSTEM_WEBAUTHN_FIELD_LABEL="W3C Web Authentication (WebAuthn) Login"
 PLG_SYSTEM_WEBAUTHN_FIELD_DESC="Lets you manage passwordless login methods using the W3C Web Authentication standard. You need a supported browser and authenticator (e.g. Google Chrome or Firefox with a FIDO2 certified security key)."
 
+PLG_SYSTEM_WEBAUTHN_FIELD_N_AUTHENTICATORS_REGISTERED_0="No WebAuthn authenticator has been set up yet"
+PLG_SYSTEM_WEBAUTHN_FIELD_N_AUTHENTICATORS_REGISTERED="%d WebAuthn authenticators already set up: %s"
+PLG_SYSTEM_WEBAUTHN_FIELD_N_AUTHENTICATORS_REGISTERED_1="One WebAuthn authenticator already set up: %2$s"
+
 PLG_SYSTEM_WEBAUTHN_MANAGE_FIELD_KEYLABEL_LABEL="Authenticator Name"
 PLG_SYSTEM_WEBAUTHN_MANAGE_FIELD_KEYLABEL_DESC="A short name for the authenticator used with this passwordless login method."
 PLG_SYSTEM_WEBAUTHN_MANAGE_HEADER_NOMETHODS_LABEL="No authenticators have been set up yet."

--- a/administrator/modules/mod_login/tmpl/default.php
+++ b/administrator/modules/mod_login/tmpl/default.php
@@ -101,19 +101,27 @@ Text::script('MESSAGE');
 				<?php echo $langs; ?>
 			</div>
 		<?php endif; ?>
-		<?php foreach ($extraButtons as $button) : ?>
+		<?php foreach($extraButtons as $button):
+			$dataAttributeKeys = array_filter(array_keys($button), function ($key) {
+				return substr($key, 0, 5) == 'data-';
+			});
+			?>
 		<div class="form-group">
 			<button type="button"
 			        class="btn btn-secondary btn-block mt-4 <?= $button['class'] ?? '' ?>"
-			        data-webauthn-form="<?= $button['data-webauthn-form'] ?>"
-			        data-webauthn-url="<?= $button['data-webauthn-url'] ?>"
+					<?php foreach ($dataAttributeKeys as $key): ?>
+					<?php echo $key ?>="<?php echo $button[$key] ?>"
+					<?php endforeach; ?>
+					<?php if ($button['onclick']): ?>
+					onclick="<?= $button['onclick'] ?>"
+					<?php endif; ?>
 			        title="<?= Text::_($button['label']) ?>"
 			        id="<?= $button['id'] ?>"
 			>
 				<?php if (!empty($button['icon'])): ?>
 					<span class="<?= $button['icon'] ?>"></span>
 				<?php elseif (!empty($button['image'])): ?>
-					<?= HTMLHelper::_('image', $button['image'], Text::_('PLG_SYSTEM_WEBAUTHN_LOGIN_DESC'), [
+					<?= HTMLHelper::_('image', $button['image'], Text::_($button['tooltip'] ?? ''), [
 						'class' => 'icon',
 					], true) ?>
 				<?php endif; ?>

--- a/build/media_source/plg_system_webauthn/js/login.es6.js
+++ b/build/media_source/plg_system_webauthn/js/login.es6.js
@@ -77,8 +77,14 @@ window.Joomla = window.Joomla || {};
    * @returns {null|Element}  NULL when no element is found
    */
   const lookForField = (outerElement, fieldSelector) => {
-    const elElement = outerElement.parentElement;
     let elInput = null;
+
+    if (!outerElement)
+    {
+      return elInput;
+    }
+
+    const elElement = outerElement.parentElement;
 
     if (elElement.nodeName === 'FORM') {
       elInput = findField(elElement, fieldSelector);
@@ -250,14 +256,13 @@ window.Joomla = window.Joomla || {};
     return false;
   };
 
-  document.addEventListener('DOMContentLoaded', () => {
-    const loginButtons = [].slice.call(document.querySelectorAll('.plg_system_webauthn_login_button'));
-    if (loginButtons.length) {
-      loginButtons.forEach((button) => {
-        button.addEventListener('click', ({ currentTarget }) => {
-          Joomla.plgSystemWebauthnLogin(currentTarget.getAttribute('data-random-form'), currentTarget.getAttribute('data-random-url'));
-        });
+  // Initialization. Runs on DOM content loaded since this script is always loaded deferred.
+  const loginButtons = [].slice.call(document.querySelectorAll('.plg_system_webauthn_login_button'));
+  if (loginButtons.length) {
+    loginButtons.forEach((button) => {
+      button.addEventListener('click', ({ currentTarget }) => {
+        Joomla.plgSystemWebauthnLogin(currentTarget.getAttribute('data-webauthn-form'), currentTarget.getAttribute('data-webauthn-url'));
       });
-    }
-  });
-})(window, Joomla);
+    });
+  }
+})(Joomla, document);

--- a/build/media_source/plg_system_webauthn/js/login.es6.js
+++ b/build/media_source/plg_system_webauthn/js/login.es6.js
@@ -79,8 +79,7 @@ window.Joomla = window.Joomla || {};
   const lookForField = (outerElement, fieldSelector) => {
     let elInput = null;
 
-    if (!outerElement)
-    {
+    if (!outerElement) {
       return elInput;
     }
 

--- a/build/media_source/plg_system_webauthn/js/management.es6.js
+++ b/build/media_source/plg_system_webauthn/js/management.es6.js
@@ -354,30 +354,41 @@ window.Joomla = window.Joomla || {};
     return false;
   };
 
-  document.addEventListener('DOMContentLoaded', () => {
-    const addButton = document.getElementById('plg_system_webauthn-manage-add');
-    if (addButton) {
-      addButton.addEventListener('click', ({ currentTarget }) => {
-        Joomla.plgSystemWebauthnCreateCredentials(currentTarget.getAttribute('data-random-id'), '#plg_system_webauthn-management-interface');
-      });
-    }
+  // Initialization. Runs on DOM content loaded since this script is always loaded deferred.
+  const addButton = document.getElementById('plg_system_webauthn-manage-add');
+  if (addButton) {
+    addButton.addEventListener('click', (event) => {
+      event.preventDefault();
 
-    const editLabelButtons = [].slice.call(document.querySelectorAll('.plg_system_webauthn-manage-edit'));
-    if (editLabelButtons.length) {
-      editLabelButtons.forEach((button) => {
-        button.addEventListener('click', ({ currentTarget }) => {
-          Joomla.plgSystemWebauthnEditLabel(currentTarget, currentTarget.getAttribute('data-random-id'));
-        });
-      });
-    }
+      Joomla.plgSystemWebauthnCreateCredentials(event.currentTarget.getAttribute('data-random-id'), '#plg_system_webauthn-management-interface');
 
-    const deleteButtons = [].slice.call(document.querySelectorAll('.plg_system_webauthn-manage-delete'));
-    if (deleteButtons.length) {
-      deleteButtons.forEach((button) => {
-        button.addEventListener('click', ({ currentTarget }) => {
-          Joomla.plgSystemWebauthnDelete(currentTarget, currentTarget.getAttribute('data-random-id'));
-        });
+      return false;
+    });
+  }
+
+  const editLabelButtons = [].slice.call(document.querySelectorAll('.plg_system_webauthn-manage-edit'));
+  if (editLabelButtons.length) {
+    editLabelButtons.forEach((button) => {
+      button.addEventListener('click', (event) => {
+        event.preventDefault();
+
+        Joomla.plgSystemWebauthnEditLabel(event.currentTarget, event.currentTarget.getAttribute('data-random-id'));
+
+        return false;
       });
-    }
-  });
-})(window, Joomla);
+    });
+  }
+
+  const deleteButtons = [].slice.call(document.querySelectorAll('.plg_system_webauthn-manage-delete'));
+  if (deleteButtons.length) {
+    deleteButtons.forEach((button) => {
+      button.addEventListener('click', (event) => {
+        event.preventDefault();
+
+        Joomla.plgSystemWebauthnDelete(event.currentTarget, event.currentTarget.getAttribute('data-random-id'));
+
+        return false;
+      });
+    });
+  }
+})(Joomla, document);

--- a/build/media_source/system/js/showon.es6.js
+++ b/build/media_source/system/js/showon.es6.js
@@ -98,6 +98,7 @@
               // Setup listeners
               elem.addEventListener('change', () => { self.linkedOptions(key); });
               elem.addEventListener('keyup', () => { self.linkedOptions(key); });
+              elem.addEventListener('click', () => { self.linkedOptions(key); });
             });
           }
         });

--- a/components/com_content/forms/article.xml
+++ b/components/com_content/forms/article.xml
@@ -60,7 +60,7 @@
 			label="JSTATUS"
 			class="custom-select-color-state"
 			size="1"
-			default="0"
+			default="1"
 			>
 			<option value="1">JPUBLISHED</option>
 			<option value="0">JUNPUBLISHED</option>

--- a/components/com_content/forms/article.xml
+++ b/components/com_content/forms/article.xml
@@ -60,7 +60,7 @@
 			label="JSTATUS"
 			class="custom-select-color-state"
 			size="1"
-			default="1"
+			default="0"
 			>
 			<option value="1">JPUBLISHED</option>
 			<option value="0">JUNPUBLISHED</option>

--- a/components/com_users/tmpl/login/default_login.php
+++ b/components/com_users/tmpl/login/default_login.php
@@ -68,19 +68,28 @@ $usersConfig = ComponentHelper::getParams('com_users');
 				</div>
 			<?php endif; ?>
 
-			<?php foreach ($this->extraButtons as $button): ?>
+			<?php foreach ($this->extraButtons as $button):
+				$dataAttributeKeys = array_filter(array_keys($button), function ($key) {
+					return substr($key, 0, 5) == 'data-';
+				});
+				?>
 				<div class="com-users-login__submit control-group">
 					<div class="controls">
 						<button type="button"
 						        class="btn btn-secondary <?= $button['class'] ?? '' ?>"
+								<?php foreach ($dataAttributeKeys as $key): ?>
+								<?php echo $key ?>="<?php echo $button[$key] ?>"
+								<?php endforeach; ?>
+								<?php if ($button['onclick']): ?>
 						        onclick="<?= $button['onclick'] ?>"
+								<?php endif; ?>
 						        title="<?= Text::_($button['label']) ?>"
 						        id="<?= $button['id'] ?>"
 						>
 							<?php if (!empty($button['icon'])): ?>
 								<span class="<?= $button['icon'] ?>"></span>
 							<?php elseif (!empty($button['image'])): ?>
-								<?= HTMLHelper::_('image', $button['image'], Text::_('PLG_SYSTEM_WEBAUTHN_LOGIN_DESC'), [
+								<?= HTMLHelper::_('image', $button['image'], Text::_($button['tooltip'] ?? ''), [
 									'class' => 'icon',
 								], true) ?>
 							<?php endif; ?>

--- a/libraries/src/Helper/AuthenticationHelper.php
+++ b/libraries/src/Helper/AuthenticationHelper.php
@@ -61,34 +61,52 @@ abstract class AuthenticationHelper
 	}
 
 	/**
-	 * Get additional login buttons to add in a login module. These buttons can be used for authentication methods
-	 * external to Joomla such as WebAuthn, login with social media providers, login with third party providers or even
-	 * login with third party Single Sign On (SSO) services.
+	 * Get additional login buttons to add in a login module. These buttons can be used for
+	 * authentication methods external to Joomla such as WebAuthn, login with social media
+	 * providers, login with third party providers or even login with third party Single Sign On
+	 * (SSO) services.
 	 *
-	 * Button definitions are returned by the onUserLoginButtons event handlers in plugins. By default, only system and
-	 * user plugins are taken into account. The former because they are always loaded. The latter are explicitly loaded
-	 * in this method.
+	 * Button definitions are returned by the onUserLoginButtons event handlers in plugins. By
+	 * default, only system and user plugins are taken into account. The former because they are
+	 * always loaded. The latter are explicitly loaded in this method.
 	 *
 	 * The onUserLoginButtons event handlers must conform to the following method definition:
 	 *
 	 * public function onUserLoginButtons(string $formId): array
 	 *
-	 * The onUserLoginButtons event handlers must return a simple array containing 0 or more button definitions.
+	 * The onUserLoginButtons event handlers must return a simple array containing 0 or more button
+	 * definitions.
 	 *
 	 * Each button definition is a hash array with the following keys:
 	 *
-	 * - label      The translation string used as the label and title of the button
-	 * - onclick    The onclick attribute, used to fire a JavaScript event
-	 * - id         The HTML ID of the button.
-	 * - icon       [optional] A CSS class for an optional icon displayed before the label; has precedence over 'image'
-	 * - image      [optional] An image path for an optional icon displayed before the label
-	 * - class      [optional] CSS class(es) to be added to the button
+	 * * `label`   The translation string used as the label and title of the button. Required
+	 * * `id`      The HTML ID of the button. Required.
+	 * * `tooltip` (optional) The translation string used as the alt tag of the button's image
+	 * * `onclick` (optional) The onclick attribute, used to fire a JavaScript event. Not
+	 *             recommended.
+	 * * `data-*`  (optional) Data attributes to pass verbatim. Use these and JavaScript to handle
+	 *             the button.
+	 * * `icon`    (optional) A CSS class for an optional icon displayed before the label; has
+	 *             precedence over 'image'
+	 * * `image`   (optional) An image path for an optional icon displayed before the label
+	 * * `class`   (optional) CSS class(es) to be added to the button
 	 *
-	 * @param   string  $formId           The HTML ID of the login form container.
+	 * You can find a real world implementation of the onUserLoginButtons plugin event in the
+	 * system/webauthn plugin.
+	 *
+	 * You can find a real world implementation of consuming the output of this method in the
+	 * modules/mod_login module.
+	 *
+	 * Third party developers implementing a login module or a login form in their component are
+	 * strongly advised to call this method and consume its results to display additional login
+	 * buttons. Not doing that means that you are not fully compatible with Joomla 4.
+	 *
+	 * @param   string  $formId  The HTML ID of the login form container. Use it to filter when and
+	 *                           where to show your additional login button(s)
 	 *
 	 * @return  array  Button definitions.
 	 *
-	 * @since 4.0.0
+	 * @since   4.0.0
 	 */
 	public static function getLoginButtons(string $formId): array
 	{
@@ -129,6 +147,7 @@ abstract class AuthenticationHelper
 				// Force mandatory fields
 				$defaultButtonDefinition = [
 					'label'   => '',
+					'tooltip' => '',
 					'icon'    => '',
 					'image'   => '',
 					'class'   => '',
@@ -141,14 +160,19 @@ abstract class AuthenticationHelper
 				// Unset anything that doesn't conform to a button definition
 				foreach (array_keys($button) as $key)
 				{
-					if (!in_array($key, ['label', 'icon', 'image', 'class', 'id', 'onclick']))
+					if (substr($key, 0, 5) == 'data-')
+					{
+						continue;
+					}
+
+					if (!in_array($key, ['label', 'tooltip', 'icon', 'image', 'class', 'id', 'onclick']))
 					{
 						unset($button[$key]);
 					}
 				}
 
-				// We need a label and an onclick handler at the bare minimum
-				if (empty($button['label']) || empty($button['onclick']) || empty($button['id']))
+				// We need a label and an ID as the bare minimum
+				if (empty($button['label']) || empty($button['id']))
 				{
 					continue;
 				}

--- a/libraries/src/MVC/Model/WorkflowBehaviorTrait.php
+++ b/libraries/src/MVC/Model/WorkflowBehaviorTrait.php
@@ -339,7 +339,7 @@ trait WorkflowBehaviorTrait
 
 		$field->addAttribute('name', 'transition');
 		$field->addAttribute('type', $this->workflowEnabled ? 'transition' : 'hidden');
-		$field->addAttribute('label', 'COM_CONTENT_TRANSITION');
+		$field->addAttribute('label', 'COM_CONTENT_WORKFLOW');
 		$field->addAttribute('extension', $extension);
 
 		$form->setField($field);

--- a/modules/mod_login/tmpl/default.php
+++ b/modules/mod_login/tmpl/default.php
@@ -105,19 +105,27 @@ Text::script('JHIDEPASSWORD');
 			</div>
 		<?php endif; ?>
 
-		<?php foreach($extraButtons as $button): ?>
+		<?php foreach($extraButtons as $button):
+			$dataAttributeKeys = array_filter(array_keys($button), function ($key) {
+				return substr($key, 0, 5) == 'data-';
+			});
+			?>
 			<div class="mod-login__submit form-group">
 				<button type="button"
 				        class="btn btn-secondary <?php echo $button['class'] ?? '' ?>"
-				        data-webauthn-form="<?= $button['data-webauthn-form'] ?>"
-					data-webauthn-url="<?= $button['data-webauthn-url'] ?>"
+						<?php foreach ($dataAttributeKeys as $key): ?>
+						<?php echo $key ?>="<?php echo $button[$key] ?>"
+						<?php endforeach; ?>
+						<?php if ($button['onclick']): ?>
+						onclick="<?= $button['onclick'] ?>"
+						<?php endif; ?>
 				        title="<?php echo Text::_($button['label']) ?>"
 				        id="<?php echo $button['id'] ?>"
 						>
 					<?php if (!empty($button['icon'])): ?>
 						<span class="<?php echo $button['icon'] ?>"></span>
 					<?php elseif (!empty($button['image'])): ?>
-						<?php echo HTMLHelper::_('image', $button['image'], Text::_('PLG_SYSTEM_WEBAUTHN_LOGIN_DESC'), [
+						<?php echo HTMLHelper::_('image', $button['image'], Text::_($button['tooltip'] ?? ''), [
 							'class' => 'icon',
 						], true) ?>
 					<?php endif; ?>

--- a/plugins/system/webauthn/src/PluginTraits/AdditionalLoginButtons.php
+++ b/plugins/system/webauthn/src/PluginTraits/AdditionalLoginButtons.php
@@ -148,6 +148,7 @@ trait AdditionalLoginButtons
 		return [
 			[
 				'label'              => 'PLG_SYSTEM_WEBAUTHN_LOGIN_LABEL',
+				'tooltip'            => 'PLG_SYSTEM_WEBAUTHN_LOGIN_DESC',
 				'id'                 => $randomId,
 				'data-webauthn-form' => $form,
 				'data-webauthn-url'  => $url,

--- a/plugins/system/webauthn/src/PluginTraits/UserProfileFields.php
+++ b/plugins/system/webauthn/src/PluginTraits/UserProfileFields.php
@@ -15,22 +15,67 @@ defined('_JEXEC') or die();
 use Exception;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;
+use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Language\Text;
 use Joomla\CMS\Uri\Uri;
+use Joomla\CMS\User\User;
 use Joomla\CMS\User\UserFactoryInterface;
+use Joomla\Plugin\System\Webauthn\CredentialRepository;
 use Joomla\Plugin\System\Webauthn\Helper\Joomla;
 use Joomla\Registry\Registry;
 
 /**
  * Add extra fields in the User Profile page.
  *
- * This class only injects the custom form fields. The actual interface is rendered through JFormFieldWebauthn.
+ * This class only injects the custom form fields. The actual interface is rendered through
+ * JFormFieldWebauthn.
  *
- * @see JFormFieldWebauthn::getInput()
+ * @see     JFormFieldWebauthn::getInput()
  *
  * @since   4.0.0
  */
 trait UserProfileFields
 {
+	/**
+	 * User object derived from the displayed user profile data.
+	 *
+	 * This is required to display the number and names of authenticators already registered when
+	 * the user displays the profile view page.
+	 *
+	 * @var   User|null
+	 * @since 4.0.0
+	 */
+	private static $userFromFormData = null;
+
+	/**
+	 * HTMLHelper method to render the WebAuthn user profile field in the profile view page.
+	 *
+	 * Instead of showing a nonsensical "Website default" label next to the field, this method
+	 * displays the number and names of authenticators already registered by the user.
+	 *
+	 * This static method is set up for use in the onContentPrepareData method of this plugin.
+	 *
+	 * @param   mixed  $value  Ignored. The WebAuthn profile field is virtual, it doesn't have a
+	 *                         stored value. We only use it as a proxy to render a sub-form.
+	 *
+	 * @return  string
+	 */
+	public static function renderWebauthnProfileField($value): string
+	{
+		if (is_null(self::$userFromFormData))
+		{
+			return '';
+		}
+
+		$credentialRepository = new CredentialRepository;
+		$credentials          = $credentialRepository->getAll(self::$userFromFormData->id);
+		$authenticators       = array_map(function (array $credential) {
+			return $credential['label'];
+		}, $credentials);
+
+		return Text::plural('PLG_SYSTEM_WEBAUTHN_FIELD_N_AUTHENTICATORS_REGISTERED', count($authenticators), implode(', ', $authenticators));
+	}
+
 	/**
 	 * Adds additional fields to the user editing form
 	 *
@@ -59,12 +104,52 @@ trait UserProfileFields
 
 		$name = $form->getName();
 
-		if (!in_array($name, ['com_admin.profile', 'com_users.user', 'com_users.profile', 'com_users.registration']))
+		$allowedForms = [
+			'com_admin.profile', 'com_users.user', 'com_users.profile', 'com_users.registration'
+		];
+
+		if (!in_array($name, $allowedForms))
 		{
 			return true;
 		}
 
-		// Get the user ID
+		// Get the user object
+		$user = $this->getUserFromData($data);
+
+		// Make sure the loaded user is the correct one
+		if (is_null($user))
+		{
+			return true;
+		}
+
+		// Make sure I am either editing myself OR I am a Super User
+		if (!Joomla::canEditUser($user))
+		{
+			return true;
+		}
+
+		// Add the fields to the form.
+		Joomla::log('system',
+			'Injecting WebAuthn Passwordless Login fields in user profile edit page');
+		Form::addFormPath(JPATH_PLUGINS . '/' . $this->_type . '/' . $this->_name . '/forms');
+		$this->loadLanguage();
+		$form->loadFile('webauthn', false);
+
+		return true;
+	}
+
+	/**
+	 * Get the user object based on the ID found in the provided user form data
+	 *
+	 * @param   array|object|null  $data  The user form data
+	 *
+	 * @return  User|null  A user object or null if no match is found
+	 *
+	 * @throws  Exception
+	 * @since   4.0.0
+	 */
+	private function getUserFromData($data): ?User
+	{
 		$id = null;
 
 		if (is_array($data))
@@ -80,27 +165,41 @@ trait UserProfileFields
 			$id = isset($data->id) ? $data->id : null;
 		}
 
-		$user = empty($id) ? Factory::getApplication()->getIdentity() : Factory::getContainer()->get(UserFactoryInterface::class)->loadUserById($id);
+		$user = empty($id) ? Factory::getApplication()->getIdentity() : Factory::getContainer()
+			->get(UserFactoryInterface::class)
+			->loadUserById($id);
 
 		// Make sure the loaded user is the correct one
 		if ($user->id != $id)
 		{
-			return true;
+			return null;
 		}
 
-		// Make sure I am either editing myself OR I am a Super User
-		if (!Joomla::canEditUser($user))
+		return $user;
+	}
+
+	/**
+	 * @param   string|null        $context  The context for the data
+	 * @param   array|object|null  $data     An object or array containing the data for the form.
+	 *
+	 * @return  bool
+	 *
+	 * @since   4.0.0
+	 */
+	public function onContentPrepareData(?string $context, $data): bool
+	{
+		if (!in_array($context, ['com_users.profile', 'com_admin.profile', 'com_users.user']))
 		{
 			return true;
 		}
 
-		// Add the fields to the form.
-		Joomla::log('system', 'Injecting WebAuthn Passwordless Login fields in user profile edit page');
-		Form::addFormPath(JPATH_PLUGINS . '/' . $this->_type . '/' . $this->_name . '/forms');
-		$this->loadLanguage();
-		$form->loadFile('webauthn', false);
+		self::$userFromFormData = $this->getUserFromData($data);
+
+		if (!HTMLHelper::isRegistered('users.webauthnWebauthn'))
+		{
+			HTMLHelper::register('users.webauthn', [__CLASS__, 'renderWebauthnProfileField']);
+		}
 
 		return true;
 	}
-
 }

--- a/plugins/system/webauthn/src/PluginTraits/UserProfileFields.php
+++ b/plugins/system/webauthn/src/PluginTraits/UserProfileFields.php
@@ -69,9 +69,12 @@ trait UserProfileFields
 
 		$credentialRepository = new CredentialRepository;
 		$credentials          = $credentialRepository->getAll(self::$userFromFormData->id);
-		$authenticators       = array_map(function (array $credential) {
-			return $credential['label'];
-		}, $credentials);
+		$authenticators       = array_map(
+			function (array $credential) {
+				return $credential['label'];
+			},
+			$credentials
+		);
 
 		return Text::plural('PLG_SYSTEM_WEBAUTHN_FIELD_N_AUTHENTICATORS_REGISTERED', count($authenticators), implode(', ', $authenticators));
 	}
@@ -129,8 +132,10 @@ trait UserProfileFields
 		}
 
 		// Add the fields to the form.
-		Joomla::log('system',
-			'Injecting WebAuthn Passwordless Login fields in user profile edit page');
+		Joomla::log(
+			'system',
+			'Injecting WebAuthn Passwordless Login fields in user profile edit page'
+		);
 		Form::addFormPath(JPATH_PLUGINS . '/' . $this->_type . '/' . $this->_name . '/forms');
 		$this->loadLanguage();
 		$form->loadFile('webauthn', false);

--- a/templates/cassiopeia/scss/vendor/bootstrap/_custom-forms.scss
+++ b/templates/cassiopeia/scss/vendor/bootstrap/_custom-forms.scss
@@ -34,7 +34,7 @@
 
     &.custom-select-success {
       background-color: theme-color("success");
-
+	  color: background-color: theme-color("success");
       option {
         color: $custom-select-color;
         background-color: $white-offset;
@@ -43,7 +43,7 @@
 
     &.custom-select-danger {
       background-color: theme-color("danger");
-
+	  color: background-color: theme-color("danger");
       option {
         color: $custom-select-color;
         background-color: $white-offset;

--- a/templates/cassiopeia/scss/vendor/bootstrap/_custom-forms.scss
+++ b/templates/cassiopeia/scss/vendor/bootstrap/_custom-forms.scss
@@ -33,7 +33,6 @@
   &.custom-select-color-state {
 
     &.custom-select-success {
-      color: $white-offset;
       background-color: theme-color("success");
 
       option {
@@ -43,7 +42,6 @@
     }
 
     &.custom-select-danger {
-      color: $white-offset;
       background-color: theme-color("danger");
 
       option {

--- a/templates/cassiopeia/scss/vendor/bootstrap/_custom-forms.scss
+++ b/templates/cassiopeia/scss/vendor/bootstrap/_custom-forms.scss
@@ -33,8 +33,9 @@
   &.custom-select-color-state {
 
     &.custom-select-success {
+      color: background-color: theme-color("success");
       background-color: theme-color("success");
-	  color: background-color: theme-color("success");
+
       option {
         color: $custom-select-color;
         background-color: $white-offset;
@@ -42,8 +43,9 @@
     }
 
     &.custom-select-danger {
+      color: background-color: theme-color("danger");
       background-color: theme-color("danger");
-	  color: background-color: theme-color("danger");
+
       option {
         color: $custom-select-color;
         background-color: $white-offset;

--- a/templates/cassiopeia/scss/vendor/bootstrap/_custom-forms.scss
+++ b/templates/cassiopeia/scss/vendor/bootstrap/_custom-forms.scss
@@ -33,7 +33,7 @@
   &.custom-select-color-state {
 
     &.custom-select-success {
-      color: background-color: theme-color("success");
+      color: theme-color("success");
       background-color: theme-color("success");
 
       option {
@@ -43,7 +43,7 @@
     }
 
     &.custom-select-danger {
-      color: background-color: theme-color("danger");
+      color: theme-color("danger");
       background-color: theme-color("danger");
 
       option {


### PR DESCRIPTION
Pull Request for Issue #29451 .

### Summary of Changes

Fixes the architecture breaks inflicted by https://github.com/joomla/joomla-cms/commit/9d3f7aac28c0aa6dc7ef480caca8fee68afac7cf

### Testing Instructions

Install this patch and make sure you can log in with WebAuthn. It should still work.

### Further information

To the casual observer there is no change between 4.0 Beta 1 and this PR. However, this PR makes it possible for 3PDs to provide additional non-password login buttons. Here's an example of my dev site implementing a GitHub login button (work in progress reimplementation of SocialLogin to use the native Joomla 4 `onUserLoginButtons` plugin event).

![image](https://user-images.githubusercontent.com/256041/83941813-0ae8a180-a7f7-11ea-9f6a-c3c60a496679.png)

Before this PR my costom button would simply not render AND break the WebAuthn login button as well because of the broken implementation.