### PR TITLE
[4.0] Set checked_out value to null if supported

### DIFF
--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -1311,8 +1311,8 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 		$this->_db->execute();
 
 		// Set table values in the object.
-		$this->$checkedOutField      = 0;
-		$this->$checkedOutTimeField = $nullDate === 'NULL' ? null : '';
+		$this->$checkedOutField     = $this->_supportNullValue ? null : 0;
+		$this->$checkedOutTimeField = $this->_supportNullValue ? null : '';
 
 		// Post-processing by observers
 		$event = AbstractEvent::create(


### PR DESCRIPTION
### Summary of Changes

Sets `checked_out` value to `null` after checkin if table supports null values.

### Testing Instructions

Checkin still works.

### Documentation Changes Required

No.