### PR TITLE
[4.0] Correct tooltip on contact edit icon on PDO

### DIFF
--- a/administrator/components/com_contact/src/Service/HTML/Icon.php
+++ b/administrator/components/com_contact/src/Service/HTML/Icon.php
@@ -141,7 +141,7 @@ class Icon
 		$contactUrl = RouteHelper::getContactRoute($contact->slug, $contact->catid, $contact->language);
 		$url        = $contactUrl . '&task=contact.edit&id=' . $contact->id . '&return=' . base64_encode($uri);
 
-		if ($contact->published === 0)
+		if ((int) $contact->published === 0)
 		{
 			$overlib = Text::_('JUNPUBLISHED');
 		}


### PR DESCRIPTION
### Summary of Changes

Adds explicit cast for value returned from database.

### Testing Instructions

Code review is fine.

Or create and unpublish a contact.
Login as admin to frontend.
View the contact, hover over the icon next to Edit button.

### Expected result

    <strong>Edit Contact</strong><br>Unpublished<br />Saturday, 06 June 2020<br />Written by You

### Actual result

    <strong>Edit Contact</strong><br>Published<br />Saturday, 06 June 2020<br />Written by You

### Documentation Changes Required

No.