### PR TITLE
[4.0] Fix bulk importing redirects

### DIFF
--- a/administrator/components/com_redirect/src/Model/LinksModel.php
+++ b/administrator/components/com_redirect/src/Model/LinksModel.php
@@ -230,7 +230,30 @@ class LinksModel extends ListModel
 			'modified_date',
 		];
 
-		foreach ($batch_urls as $i => $batch_url)
+		$values = [
+			':oldurl',
+			':newurl',
+			$db->quote(''),
+			$db->quote(''),
+			0,
+			':state',
+			':created',
+			':modified',
+		];
+
+		$query
+			->insert($db->quoteName('#__redirect_links'), false)
+			->columns($db->quoteName($columns))
+			->values(implode(', ', $values))
+			->bind(':oldurl', $old_url)
+			->bind(':newurl', $new_url)
+			->bind(':state', $state, ParameterType::INTEGER)
+			->bind(':created', $created)
+			->bind(':modified', $created);
+
+		$db->setQuery($query);
+
+		foreach ($batch_urls as $batch_url)
 		{
 			$old_url = $batch_url[0];
 
@@ -244,28 +267,6 @@ class LinksModel extends ListModel
 				$new_url = '';
 			}
 
-			$values = [
-				':oldurl' . $i,
-				':newurl' . $i,
-				$db->quote(''),
-				$db->quote(''),
-				0,
-				':state' . $i,
-				':created' . $i,
-				':modified' . $i,
-			];
-
-			$query->clear()
-				->insert($db->quoteName('#__redirect_links'), false)
-				->columns($db->quoteName($columns))
-				->values(implode(', ', $values))
-				->bind(':oldurl' . $i, $old_url)
-				->bind(':newurl' . $i, $new_url)
-				->bind(':state' . $i, $state, ParameterType::INTEGER)
-				->bind(':created' . $i, $created)
-				->bind(':modified' . $i, $created);
-
-			$db->setQuery($query);
 			$db->execute();
 		}
 

--- a/administrator/components/com_redirect/src/Model/LinksModel.php
+++ b/administrator/components/com_redirect/src/Model/LinksModel.php
@@ -227,6 +227,7 @@ class LinksModel extends ListModel
 			'hits',
 			'published',
 			'created_date',
+			'modified_date',
 		];
 
 		foreach ($batch_urls as $i => $batch_url)
@@ -251,6 +252,7 @@ class LinksModel extends ListModel
 				0,
 				':state' . $i,
 				':created' . $i,
+				':modified' . $i,
 			];
 
 			$query->clear()
@@ -260,7 +262,8 @@ class LinksModel extends ListModel
 				->bind(':oldurl' . $i, $old_url)
 				->bind(':newurl' . $i, $new_url)
 				->bind(':state' . $i, $state, ParameterType::INTEGER)
-				->bind(':created' . $i, $created);
+				->bind(':created' . $i, $created)
+				->bind(':modified' . $i, $created);
 
 			$db->setQuery($query);
 			$db->execute();


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Adds missing `modified_date` column.
Cleans up the query.

### Testing Instructions

Go to System -> Redirects.
Click `Bulk Import` button.
Enter a few lines of new/old URLs
Click `Process`.

### Expected result

All URLs imported.

### Actual result

>HY000, 1364, Field 'modified_date' doesn't have a default value 

### Documentation Changes Required

No.