### PR TITLE
Fix shownon to also work on radio with btn-group btn-group-yesno class

### DIFF
--- a/build/media_source/system/js/showon.es6.js
+++ b/build/media_source/system/js/showon.es6.js
@@ -98,6 +98,7 @@
               // Setup listeners
               elem.addEventListener('change', () => { self.linkedOptions(key); });
               elem.addEventListener('keyup', () => { self.linkedOptions(key); });
+              elem.addEventListener('click', () => { self.linkedOptions(key); });
             });
           }
         });


### PR DESCRIPTION
Pull Request for Issue #27555 

### Summary of Changes
As suggested by @C-Lodder add additional click eventlistener in showon.js


### Testing Instructions
Apply path, and run npm i to rebuild JavaScript files with this PR

Add config form field type radio with class "switcher btn-group btn-group-yesno"
Add an additional field that has a shownon dependency on the radio fiels


### Expected result
clicking yes should show the additional field, no should hide the additional fields


### Actual result
without this change, the showon functionality would not work on this radio field. Omitting the "btn-group btn-groupyesno" would fix that but then the same config file would break Joomla 3.x showon behavior.


### Documentation Changes Required
None

### Special Thanks to
@C-Lodder  for coming up with the solution and everybody in advance for testing this PR
