### PR TITLE
[4.0] Filter the module types in the new module page

### DIFF
--- a/administrator/components/com_modules/tmpl/select/default.php
+++ b/administrator/components/com_modules/tmpl/select/default.php
@@ -18,16 +18,42 @@ $app = Factory::getApplication();
 
 $function  = $app->input->getCmd('function');
 
+HTMLHelper::_('script', 'com_modules/admin-module-search.js', ['version' => 'auto', 'relative' => true, 'async' => 'async']);
+
 if ($function) :
 	HTMLHelper::_('script', 'com_modules/admin-select-modal.js', ['version' => 'auto', 'relative' => true]);
 endif;
 ?>
 <h2 class="mb-3"><?php echo Text::_('COM_MODULES_TYPE_CHOOSE'); ?></h2>
+
+<div class="container d-none" id="comModulesSelectSearchContainer">
+	<div class="row">
+		<div class="col-sm-4 offset-sm-4">
+			<div class="form-inline">
+				<label class="sr-only" for="comModulesSelectSearch">
+					<?= Text::_('JSEARCH_FILTER'); ?>
+				</label>
+				<div class="input-group mb-5 mr-sm-2">
+					<input type="text" value=""
+						   class="form-control-lg" id="comModulesSelectSearch"
+						   placeholder="<?= Text::_('JSEARCH_FILTER'); ?>"
+					>
+					<div class="input-group-append" aria-hidden="true">
+						<div class="input-group-text">
+							<span class="fa fa-search"></span>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+
 <div id="new-modules-list">
 	<div class="new-modules">
 		<div class="card-columns">
 			<?php foreach ($this->items as &$item) : ?>
-				<div class="card mb-4">
+				<div class="card mb-4 comModulesSelectCard">
 					<?php // Prepare variables for the link. ?>
 					<?php $link = 'index.php?option=com_modules&task=module.add&client_id=' . $this->state->get('client_id', 0) . $this->modalLink . '&eid=' . $item->extension_id; ?>
 					<?php $name = $this->escape($item->name); ?>

--- a/administrator/components/com_modules/tmpl/select/default.php
+++ b/administrator/components/com_modules/tmpl/select/default.php
@@ -31,7 +31,7 @@ endif;
 		<div class="col-sm-4 offset-sm-4">
 			<div class="form-inline">
 				<label class="sr-only" for="comModulesSelectSearch">
-					<?= Text::_('JSEARCH_FILTER'); ?>
+					<?= Text::_('COM_MODULES_TYPE_CHOOSE'); ?>
 				</label>
 				<div class="input-group mb-5 mr-sm-2">
 					<input type="text" value=""

--- a/administrator/components/com_modules/tmpl/select/default.php
+++ b/administrator/components/com_modules/tmpl/select/default.php
@@ -35,7 +35,7 @@ endif;
 				</label>
 				<div class="input-group mb-5 mr-sm-2">
 					<input type="text" value=""
-						   class="form-control-lg" id="comModulesSelectSearch"
+						   class="form-control" id="comModulesSelectSearch"
 						   placeholder="<?= Text::_('JSEARCH_FILTER'); ?>"
 					>
 					<div class="input-group-append" aria-hidden="true">

--- a/administrator/components/com_modules/tmpl/select/default.php
+++ b/administrator/components/com_modules/tmpl/select/default.php
@@ -18,7 +18,7 @@ $app = Factory::getApplication();
 
 $function  = $app->input->getCmd('function');
 
-HTMLHelper::_('script', 'com_modules/admin-module-search.js', ['version' => 'auto', 'relative' => true, 'defer' => 'async']);
+HTMLHelper::_('script', 'com_modules/admin-module-search.js', ['version' => 'auto', 'relative' => true, 'defer' => true]);
 
 if ($function) :
 	HTMLHelper::_('script', 'com_modules/admin-select-modal.js', ['version' => 'auto', 'relative' => true]);

--- a/administrator/components/com_modules/tmpl/select/default.php
+++ b/administrator/components/com_modules/tmpl/select/default.php
@@ -28,7 +28,7 @@ endif;
 
 <div class="container d-none" id="comModulesSelectSearchContainer">
 	<div class="row">
-		<div class="col-sm-4 offset-sm-4">
+		<div class="col-sm-6 offset-sm-2 col-md-4 offset-sm-4 offset-md-5 offset-lg-4">
 			<div class="form-inline">
 				<label class="sr-only" for="comModulesSelectSearch">
 					<?= Text::_('COM_MODULES_TYPE_CHOOSE'); ?>

--- a/administrator/components/com_modules/tmpl/select/default.php
+++ b/administrator/components/com_modules/tmpl/select/default.php
@@ -18,7 +18,7 @@ $app = Factory::getApplication();
 
 $function  = $app->input->getCmd('function');
 
-HTMLHelper::_('script', 'com_modules/admin-module-search.js', ['version' => 'auto', 'relative' => true, 'async' => 'async']);
+HTMLHelper::_('script', 'com_modules/admin-module-search.js', ['version' => 'auto', 'relative' => true, 'defer' => 'async']);
 
 if ($function) :
 	HTMLHelper::_('script', 'com_modules/admin-select-modal.js', ['version' => 'auto', 'relative' => true]);

--- a/administrator/components/com_modules/tmpl/select/default.php
+++ b/administrator/components/com_modules/tmpl/select/default.php
@@ -18,7 +18,12 @@ $app = Factory::getApplication();
 
 $function  = $app->input->getCmd('function');
 
-HTMLHelper::_('script', 'com_modules/admin-module-search.js', ['version' => 'auto', 'relative' => true, 'defer' => true]);
+HTMLHelper::_('script', 'com_modules/admin-module-search.js',
+		[
+				'version' => 'auto', 'relative' => true
+		], [
+				'defer' => true
+		]);
 
 if ($function) :
 	HTMLHelper::_('script', 'com_modules/admin-select-modal.js', ['version' => 'auto', 'relative' => true]);

--- a/build/media_source/com_modules/js/admin-module-search.es6.js
+++ b/build/media_source/com_modules/js/admin-module-search.es6.js
@@ -3,39 +3,39 @@
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
 
+/**
+ * Add a keyboard event listener to the Select a Module Type search element.
+ *
+ * IMPORTANT! This script is meant to be loaded deferred. This means that a. it's non-blocking
+ * (the browser can load it whenever) and b. it doesn't need an on DOMContentLoaded event handler
+ * because the browser is guaranteed to execute it only after the DOM content has loaded, the
+ * whole point of it being deferred.
+ *
+ * The search box has a keybaord handler that fires every time you press a keyboard button or send
+ * a keypress with a touch / virtual keyboard. We then iterate all module type cards and check if
+ * the plain text (HTML stripped out) representation of the module title or description partially
+ * matches the text you entered in the search box. If it doesn't we add a Bootstrap class to hide
+ * the module.
+ *
+ * This way we limit the displayed modules only to those searched.
+ *
+ * This feature follows progressive enhancement. The search box is hidden by default and only
+ * displayed when this JavaScript here executes. Furthermore, session storage is only used if it
+ * is available in the browser. That's a bit of a pain but makes sure things won't break in older
+ * browsers.
+ *
+ * Furthermore and to facilitate the user experience we auto-focus the search element which has a
+ * suitable title so that non-sighted users are not startled. This way we address both UX concerns
+ * and accessibility.
+ *
+ * Finally, the search string is saved into session storage on the assumption that the user is
+ * probably going to be creating multiple instances of the same module, one after another, as is
+ * typical when building a new Joomla! site.
+ */
 ((document) => {
   'use strict';
 
-  /**
-   * Add a keyboard event listener to the Select a Module Type search element.
-   *
-   * IMPORTANT! This script is meant to be loaded deferred. This means that a. it's non-blocking
-   * (the browser can load it whenever) and b. it doesn't need an on DOMContentLoaded event handler
-   * because the browser is guaranteed to execute it only after the DOM content has loaded, the
-   * whole point of it being deferred.
-   *
-   * The search box has a keybaord handler that fires every time you press a keyboard button or send
-   * a keypress with a touch / virtual keyboard. We then iterate all module type cards and check if
-   * the plain text (HTML stripped out) representation of the module title or description partially
-   * matches the text you entered in the search box. If it doesn't we add a Bootstrap class to hide
-   * the module.
-   *
-   * This way we limit the displayed modules only to those searched.
-   *
-   * This feature follows progressive enhancement. The search box is hidden by default and only
-   * displayed when this JavaScript here executes. Furthermore, session storage is only used if it
-   * is available in the browser. That's a bit of a pain but makes sure things won't break in older
-   * browsers.
-   *
-   * Furthermore and to facilitate the user experience we auto-focus the search element which has a
-   * suitable title so that non-sighted users are not startled. This way we address both UX concerns
-   * and accessibility.
-   *
-   * Finally, the search string is saved into session storage on the assumption that the user is
-   * probably going to be creating multiple instances of the same module, one after another, as is
-   * typical when building a new Joomla! site.
-   */
-    // Make sure the element exists i.e. a template override has not removed it.
+  // Make sure the element exists i.e. a template override has not removed it.
   const elSearch = document.getElementById('comModulesSelectSearch');
   const elSearchContainer = document.getElementById('comModulesSelectSearchContainer');
 

--- a/build/media_source/com_modules/js/admin-module-search.es6.js
+++ b/build/media_source/com_modules/js/admin-module-search.es6.js
@@ -83,7 +83,7 @@
     {
       if (typeof (sessionStorage) !== 'undefined') {
         // Load the search string from session storage
-        elSearch.value = sessionStorage.getItem('Joomla.com_modules.new.search') ?? '';
+        elSearch.value = sessionStorage.getItem('Joomla.com_modules.new.search') || '';
 
         // Trigger the keyboard handler event manually to initiate the search
         elSearch.dispatchEvent(new KeyboardEvent('keyup'));

--- a/build/media_source/com_modules/js/admin-module-search.es6.js
+++ b/build/media_source/com_modules/js/admin-module-search.es6.js
@@ -1,0 +1,95 @@
+/**
+ * @copyright  Copyright (C) 2005 - 2020 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+((document) => {
+  'use strict';
+
+  /**
+   * Add a keyboard event listener to the Select a Module Type search element.
+   *
+   * The search box has a keybaord handler that fires every time you press a keyboard button or send
+   * a keypress with a touch / virtual keyboard. We then iterate all module type cards and check if
+   * the plain text (HTML stripped out) representation of the module title or description partially
+   * matches the text you entered in the search box. If it doesn't we add a Bootstrap class to hide
+   * the module.
+   *
+   * This way we limit the displayed modules only to those searched.
+   *
+   * This feature follows progressive enhancement. The search box is hidden by default and only
+   * displayed when this JavaScript here executes. Furthermore, session storage is only used if it
+   * is available in the browser. That's a bit of a pain but makes sure things won't break in older
+   * browsers.
+   *
+   * Furthermore and to facilitate the user experience we auto-focus the search element which has a
+   * suitable title so that non-sighted users are not startled. This way we address both UX concerns
+   * and accessibility.
+   *
+   * Finally, the search string is saved into session storage on the assumption that the user is
+   * probably going to be creating multiple instances of the same module, one after another, as is
+   * typical when building a new Joomla! site.
+   */
+  document.addEventListener('DOMContentLoaded', () => {
+    // Make sure the element exists i.e. a template override has not removed it.
+    const elSearch = document.getElementById('comModulesSelectSearch');
+    const elSearchContainer = document.getElementById('comModulesSelectSearchContainer');
+
+    if (!elSearch || !elSearchContainer) {
+      return;
+    }
+
+    // Add the keyboard event listener which performs the live search in the cards
+    elSearch.addEventListener('keyup', (event) => {
+      /** @type {KeyboardEvent} event */
+      const elSearch = event.target;
+      const partialSearch = elSearch.value;
+      const elCards = document.querySelectorAll('.comModulesSelectCard');
+
+      // Save the search string into session storage
+      if (typeof (sessionStorage) !== 'undefined') {
+        sessionStorage.setItem('Joomla.com_modules.new.search', partialSearch);
+      }
+
+      // Iterate all the module cards
+      elCards.forEach((card) => {
+        const cardHeaderList = card.querySelectorAll('.card-header');
+        const cardBodyList = card.querySelectorAll('.card-body');
+        const title = cardHeaderList.length ? cardHeaderList[0].textContent : '';
+        const description = cardBodyList.length ? cardBodyList[0].textContent : '';
+
+        // First remove the classes which hide the module cards
+        card.classList.remove('d-none');
+
+        // An empty search string means that we should show everything
+        if (partialSearch === '') {
+          return;
+        }
+
+        // If the module title or description doesn't match add a class to hide it.
+        if (!title.toLowerCase().includes(partialSearch.toLowerCase()) && !description.toLowerCase().includes(partialSearch.toLowerCase())) {
+          card.classList.add('d-none');
+        }
+      });
+    });
+
+    // For reasons of progressive enhancement the search box is hidden by default.
+    elSearchContainer.classList.remove('d-none');
+
+    // Focus the just show element
+    elSearch.focus();
+
+    try
+    {
+      if (typeof (sessionStorage) !== 'undefined') {
+        // Load the search string from session storage
+        elSearch.value = sessionStorage.getItem('Joomla.com_modules.new.search') ?? '';
+
+        // Trigger the keyboard handler event manually to initiate the search
+        elSearch.dispatchEvent(new KeyboardEvent('keyup'));
+      }
+    } catch (e) {
+      // This is probably Internet Explorer which doesn't support the KeyboardEvent constructor :(
+    }
+  });
+})(document);

--- a/build/media_source/com_modules/js/admin-module-search.es6.js
+++ b/build/media_source/com_modules/js/admin-module-search.es6.js
@@ -9,6 +9,11 @@
   /**
    * Add a keyboard event listener to the Select a Module Type search element.
    *
+   * IMPORTANT! This script is meant to be loaded deferred. This means that a. it's non-blocking
+   * (the browser can load it whenever) and b. it doesn't need an on DOMContentLoaded event handler
+   * because the browser is guaranteed to execute it only after the DOM content has loaded, the
+   * whole point of it being deferred.
+   *
    * The search box has a keybaord handler that fires every time you press a keyboard button or send
    * a keypress with a touch / virtual keyboard. We then iterate all module type cards and check if
    * the plain text (HTML stripped out) representation of the module title or description partially
@@ -30,65 +35,63 @@
    * probably going to be creating multiple instances of the same module, one after another, as is
    * typical when building a new Joomla! site.
    */
-  document.addEventListener('DOMContentLoaded', () => {
     // Make sure the element exists i.e. a template override has not removed it.
-    const elSearch = document.getElementById('comModulesSelectSearch');
-    const elSearchContainer = document.getElementById('comModulesSelectSearchContainer');
+  const elSearch = document.getElementById('comModulesSelectSearch');
+  const elSearchContainer = document.getElementById('comModulesSelectSearchContainer');
 
-    if (!elSearch || !elSearchContainer) {
-      return;
+  if (!elSearch || !elSearchContainer) {
+    return;
+  }
+
+  // Add the keyboard event listener which performs the live search in the cards
+  elSearch.addEventListener('keyup', (event) => {
+    /** @type {KeyboardEvent} event */
+    const partialSearch = event.target.value;
+    const elCards = document.querySelectorAll('.comModulesSelectCard');
+
+    // Save the search string into session storage
+    if (typeof (sessionStorage) !== 'undefined') {
+      sessionStorage.setItem('Joomla.com_modules.new.search', partialSearch);
     }
 
-    // Add the keyboard event listener which performs the live search in the cards
-    elSearch.addEventListener('keyup', (event) => {
-      /** @type {KeyboardEvent} event */
-      const partialSearch = event.target.value;
-      const elCards = document.querySelectorAll('.comModulesSelectCard');
+    // Iterate all the module cards
+    elCards.forEach((card) => {
+      const cardHeaderList = card.querySelectorAll('.card-header');
+      const cardBodyList = card.querySelectorAll('.card-body');
+      const title = cardHeaderList.length ? cardHeaderList[0].textContent : '';
+      const description = cardBodyList.length ? cardBodyList[0].textContent : '';
 
-      // Save the search string into session storage
-      if (typeof (sessionStorage) !== 'undefined') {
-        sessionStorage.setItem('Joomla.com_modules.new.search', partialSearch);
+      // First remove the classes which hide the module cards
+      card.classList.remove('d-none');
+
+      // An empty search string means that we should show everything
+      if (partialSearch === '') {
+        return;
       }
 
-      // Iterate all the module cards
-      elCards.forEach((card) => {
-        const cardHeaderList = card.querySelectorAll('.card-header');
-        const cardBodyList = card.querySelectorAll('.card-body');
-        const title = cardHeaderList.length ? cardHeaderList[0].textContent : '';
-        const description = cardBodyList.length ? cardBodyList[0].textContent : '';
-
-        // First remove the classes which hide the module cards
-        card.classList.remove('d-none');
-
-        // An empty search string means that we should show everything
-        if (partialSearch === '') {
-          return;
-        }
-
-        // If the module title or description doesn't match add a class to hide it.
-        if (!title.toLowerCase().includes(partialSearch.toLowerCase())
-          && !description.toLowerCase().includes(partialSearch.toLowerCase())) {
-          card.classList.add('d-none');
-        }
-      });
+      // If the module title or description doesn't match add a class to hide it.
+      if (!title.toLowerCase().includes(partialSearch.toLowerCase())
+        && !description.toLowerCase().includes(partialSearch.toLowerCase())) {
+        card.classList.add('d-none');
+      }
     });
-
-    // For reasons of progressive enhancement the search box is hidden by default.
-    elSearchContainer.classList.remove('d-none');
-
-    // Focus the just show element
-    elSearch.focus();
-
-    try {
-      if (typeof (sessionStorage) !== 'undefined') {
-        // Load the search string from session storage
-        elSearch.value = sessionStorage.getItem('Joomla.com_modules.new.search') || '';
-
-        // Trigger the keyboard handler event manually to initiate the search
-        elSearch.dispatchEvent(new KeyboardEvent('keyup'));
-      }
-    } catch (e) {
-      // This is probably Internet Explorer which doesn't support the KeyboardEvent constructor :(
-    }
   });
+
+  // For reasons of progressive enhancement the search box is hidden by default.
+  elSearchContainer.classList.remove('d-none');
+
+  // Focus the just show element
+  elSearch.focus();
+
+  try {
+    if (typeof (sessionStorage) !== 'undefined') {
+      // Load the search string from session storage
+      elSearch.value = sessionStorage.getItem('Joomla.com_modules.new.search') || '';
+
+      // Trigger the keyboard handler event manually to initiate the search
+      elSearch.dispatchEvent(new KeyboardEvent('keyup'));
+    }
+  } catch (e) {
+    // This is probably Internet Explorer which doesn't support the KeyboardEvent constructor :(
+  }
 })(document);

--- a/build/media_source/com_modules/js/admin-module-search.es6.js
+++ b/build/media_source/com_modules/js/admin-module-search.es6.js
@@ -42,8 +42,7 @@
     // Add the keyboard event listener which performs the live search in the cards
     elSearch.addEventListener('keyup', (event) => {
       /** @type {KeyboardEvent} event */
-      const elSearch = event.target;
-      const partialSearch = elSearch.value;
+      const partialSearch = event.target.value;
       const elCards = document.querySelectorAll('.comModulesSelectCard');
 
       // Save the search string into session storage
@@ -67,7 +66,8 @@
         }
 
         // If the module title or description doesn't match add a class to hide it.
-        if (!title.toLowerCase().includes(partialSearch.toLowerCase()) && !description.toLowerCase().includes(partialSearch.toLowerCase())) {
+        if (!title.toLowerCase().includes(partialSearch.toLowerCase()) &&
+          !description.toLowerCase().includes(partialSearch.toLowerCase())) {
           card.classList.add('d-none');
         }
       });
@@ -79,8 +79,7 @@
     // Focus the just show element
     elSearch.focus();
 
-    try
-    {
+    try {
       if (typeof (sessionStorage) !== 'undefined') {
         // Load the search string from session storage
         elSearch.value = sessionStorage.getItem('Joomla.com_modules.new.search') || '';

--- a/build/media_source/com_modules/js/admin-module-search.es6.js
+++ b/build/media_source/com_modules/js/admin-module-search.es6.js
@@ -69,7 +69,7 @@
         return;
       }
 
-      // If the module title or description doesn't match add a class to hide it.
+      // If the module title and description don’t match add a class to hide it.
       if (!title.toLowerCase().includes(partialSearch.toLowerCase())
         && !description.toLowerCase().includes(partialSearch.toLowerCase())) {
         card.classList.add('d-none');

--- a/build/media_source/com_modules/js/admin-module-search.es6.js
+++ b/build/media_source/com_modules/js/admin-module-search.es6.js
@@ -11,7 +11,7 @@
  * because the browser is guaranteed to execute it only after the DOM content has loaded, the
  * whole point of it being deferred.
  *
- * The search box has a keybaord handler that fires every time you press a keyboard button or send
+ * The search box has a keyboard handler that fires every time you press a keyboard button or send
  * a keypress with a touch / virtual keyboard. We then iterate all module type cards and check if
  * the plain text (HTML stripped out) representation of the module title or description partially
  * matches the text you entered in the search box. If it doesn't we add a Bootstrap class to hide

--- a/build/media_source/com_modules/js/admin-module-search.es6.js
+++ b/build/media_source/com_modules/js/admin-module-search.es6.js
@@ -66,8 +66,8 @@
         }
 
         // If the module title or description doesn't match add a class to hide it.
-        if (!title.toLowerCase().includes(partialSearch.toLowerCase()) &&
-          !description.toLowerCase().includes(partialSearch.toLowerCase())) {
+        if (!title.toLowerCase().includes(partialSearch.toLowerCase())
+          && !description.toLowerCase().includes(partialSearch.toLowerCase())) {
           card.classList.add('d-none');
         }
       });


### PR DESCRIPTION
Pull Request for Issue #29415. Closes gh-29415

### Summary of Changes

Adds a search box in the new module (“Select a Module Type“) page.

The search box is implemented entirely in JavaScript and operates directly on the page. It does not reload content from the server.

The search box is autofocused and has a screen reader title so non-sighted users are not startled. I have checked that keyboard navigation between the search box and the module cards is possible to prevent the introduction of any unintentional accessibility issues.

The search string is stored in the browser's session storage. This means that subsequent opens of the same URL _in the same tab and window_ will remember your search. If you close the tab the saved search string goes away.

### Testing Instructions

From the backend of the site click on Content, Modules, Add.

### Expected result

You can select the module you want without blowing a lid by a massive amount of content.

### Actual result

Before this PR you have to select between dozens of cards. That's cruel and unusual punishment for the poor user of the CMS.

![“Boy, that must be tiresome for everybody“ animation](https://media.giphy.com/media/xT1R9V6HMZ4uVQGKVG/giphy.gif)

After the PR your keyboard cursor is autofocused in a prominent search box. Start typing e.g. `custom` since I want to add a custom module. You now see only the card you were looking for. Press TAB and ENTER.

![“Magic!“ animation](https://media.giphy.com/media/12NUbkX6p4xOO4/giphy.gif)

### Documentation Changes Required

None seem to be necessary.