### PR TITLE
[4.0] PluginHelper classname invalide - fixed

### DIFF
--- a/administrator/components/com_fields/src/Plugin/FieldsPlugin.php
+++ b/administrator/components/com_fields/src/Plugin/FieldsPlugin.php
@@ -150,7 +150,7 @@ abstract class FieldsPlugin extends CMSPlugin
 
 		if (!file_exists($path))
 		{
-			$path = JPluginHelper::getLayoutPath('fields', $this->_name, $field->type);
+			$path = PluginHelper::getLayoutPath('fields', $this->_name, $field->type);
 		}
 
 		// Render the layout


### PR DESCRIPTION
Fix for Class 'Joomla\Component\Fields\Administrator\Plugin\JPluginHelper' not found

### Summary of Changes
just minor fix for invalid class name, effects if running a new fields plugin