### PR TITLE
[4.0] Improve user token plugin display in the profile page

### DIFF
--- a/plugins/user/token/token.php
+++ b/plugins/user/token/token.php
@@ -324,11 +324,12 @@ class PlgUserToken extends CMSPlugin
 		if (!isset($data[$this->profileKeyPrefix]))
 		{
 			/**
-			 * Is the user being saved programmatically, without passing the user profile information? In this case I
-			 * do not want to accidentally try to generate a new token!
+			 * Is the user being saved programmatically, without passing the user profile
+			 * information? In this case I do not want to accidentally try to generate a new token!
 			 *
-			 * We determine that by examining whether the FOF token field exists. If it does but it wasn't passed when
-			 * saving the user I know it's a programmatic user save and I have to ignore it.
+			 * We determine that by examining whether the Joomla token field exists. If it does but
+			 * it wasn't passed when saving the user I know it's a programmatic user save and I have
+			 * to ignore it.
 			 */
 			if ($this->hasTokenProfileFields($userId))
 			{

--- a/plugins/user/token/token.php
+++ b/plugins/user/token/token.php
@@ -151,8 +151,8 @@ class PlgUserToken extends CMSPlugin
 
 			foreach ($results as $v)
 			{
-				$k                                   =
-					str_replace($this->profileKeyPrefix . '.', '', $v[0]);
+				$k = str_replace($this->profileKeyPrefix . '.', '', $v[0]);
+
 				$data->{$this->profileKeyPrefix}[$k] = $v[1];
 			}
 		} catch (Exception $e)
@@ -168,7 +168,7 @@ class PlgUserToken extends CMSPlugin
 		 * generic and we run the risk of creating naming clashes. Instead, we manipulate the data
 		 * directly.
 		 */
-		if ($context === 'com_users.profile')
+		if (($context === 'com_users.profile') && (Factory::getApplication()->input->get('layout') !== 'edit'))
 		{
 			$pluginData = $data->{$this->profileKeyPrefix};
 			$enabled    = $pluginData['enabled'];

--- a/plugins/user/token/token.php
+++ b/plugins/user/token/token.php
@@ -280,7 +280,7 @@ class PlgUserToken extends CMSPlugin
 		}
 
 		// Remove the Reset field when displaying the user profile form
-		if ($form->getName() == 'com_users.profile')
+		if (($form->getName() === 'com_users.profile') && ($this->app->input->get('layout') !== 'edit'))
 		{
 			$form->removeField('reset', 'joomlatoken');
 		}

--- a/plugins/user/token/token.php
+++ b/plugins/user/token/token.php
@@ -579,7 +579,7 @@ class PlgUserToken extends CMSPlugin
 
 		try
 		{
-			$siteSecret = Factory::getApplication()->get('secret');
+			$siteSecret = $this->app->get('secret');
 		} catch (\Exception $e)
 		{
 			$siteSecret = '';

--- a/plugins/user/token/token.php
+++ b/plugins/user/token/token.php
@@ -168,7 +168,7 @@ class PlgUserToken extends CMSPlugin
 		 * generic and we run the risk of creating naming clashes. Instead, we manipulate the data
 		 * directly.
 		 */
-		if (($context === 'com_users.profile') && (Factory::getApplication()->input->get('layout') !== 'edit'))
+		if (($context === 'com_users.profile') && ($this->app->input->get('layout') !== 'edit'))
 		{
 			$pluginData = $data->{$this->profileKeyPrefix};
 			$enabled    = $pluginData['enabled'];

--- a/plugins/user/token/token.php
+++ b/plugins/user/token/token.php
@@ -168,7 +168,7 @@ class PlgUserToken extends CMSPlugin
 		 * generic and we run the risk of creating naming clashes. Instead, we manipulate the data
 		 * directly.
 		 */
-		if ($context = 'com_users.profile')
+		if ($context === 'com_users.profile')
 		{
 			$pluginData = $data->{$this->profileKeyPrefix};
 			$enabled    = $pluginData['enabled'];

--- a/plugins/user/token/token.php
+++ b/plugins/user/token/token.php
@@ -595,7 +595,7 @@ class PlgUserToken extends CMSPlugin
 		$tokenHash = hash_hmac($algorithm, $rawToken, $siteSecret);
 		$message   = base64_encode("$algorithm:$userId:$tokenHash");
 
-		if ($userId !== Factory::getUser()->id)
+		if ($userId !== $this->app->getIdentity()->id)
 		{
 			$message = '';
 		}


### PR DESCRIPTION
Pull Request for Issue #29338 and #29337

cc @PhilETaylor @Quy 

### Summary of Changes

Changed the way the Joomla Token user profile field renders its information in the User Profile view page.

### Testing Instructions

Set up a token and view – NOT edit! – your user profile in the public frontend of the site.

### Expected result

Under Joomla API Token you get reasonable information e.g. what's your token and whether it's enabled.

### Actual result

You get all sorts of misleading information. The token field displays the seed, not the token you need to use. The Active field displays 1 / 0 which great if you are a 🤖. And of course there's the Reset field which makes no sense in the context.

This PR fixes this by displaying only the _real_ token you need to use and whether it's enabled. Example:
![image](https://user-images.githubusercontent.com/256041/83966351-62a00f00-a8c2-11ea-8353-66dfee113d31.png)

### Documentation Changes Required

None.