### PR TITLE
[4.0] Fix media manager slide animation in RTL

### DIFF
--- a/administrator/components/com_media/resources/styles/components/_animations.scss
+++ b/administrator/components/com_media/resources/styles/components/_animations.scss
@@ -23,6 +23,14 @@
   animation: slideOutRight .2s;
 }
 
+html[dir=rtl] .infobar-enter-active {
+  animation: slideOutLeft .2s reverse;
+}
+
+html[dir=rtl] .infobar-leave-active {
+  animation: slideOutLeft .2s;
+}
+
 // Slide out right animation
 @keyframes slideOutRight {
   from {
@@ -32,6 +40,17 @@
   to {
     visibility: hidden;
     transform: translate3d(100%, 0, 0);
+  }
+}
+
+@keyframes slideOutLeft {
+  from {
+    transform: translateX(0);
+  }
+
+  to {
+    visibility: hidden;
+    transform: translate3d(-100%, 0, 0);
   }
 }
 


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/29433 .

### Summary of Changes
Fixes the slideout of the media manager info tab in RTL

### Testing Instructions
Install the persian language and use it as your default or change the <rtl> flag in `administrator/language/en-GB/langmetadata.xml`. Before the patch notice the slide in of the info bar is over the top of the content. After patch it comes out from the left in a smooth motion.

### Documentation Changes Required
None
