### PR TITLE
[4.0] Add missing workflow plugins to list of core extensions in ExtensionsHelper

### DIFF
--- a/libraries/src/Extension/ExtensionHelper.php
+++ b/libraries/src/Extension/ExtensionHelper.php
@@ -320,6 +320,10 @@ class ExtensionHelper
 		array('plugin', 'templates', 'webservices', 0),
 		array('plugin', 'users', 'webservices', 0),
 
+		// Core plugin extensions - workflow
+		array('plugin', 'featuring', 'workflow', 0),
+		array('plugin', 'notification', 'workflow', 0),
+		array('plugin', 'publishing', 'workflow', 0),
 
 		// Core template extensions - administrator
 		array('template', 'atum', '', 1),


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

The workflow plugins have been forgotten to be added to the list of core extensions in ExtensionsHelper class.

This Pull Request (PR) corrects that.

### Testing Instructions

1. On an installation of a clean, current 4.0-dev branch or latest nightly or a 4.0 Beta 1, login to backend and go to the Joomla Update component.

2. In the component's options, change the update channel to "Custom URL", enter the 4.0 nightlies update URL https://update.joomla.org/core/nightlies/next_major_list.xml and save.

3. Check the extensions section of the pre-update check.

Result:
- Beside 3rd party extenions, also the 3 workflow plugins are listed, see the extensions marked with a red frame in the screenshot in section "Actual result" below.
- On a git clone, the testing sample data extenion is listed, too, see extension marked with an orange frame in the screenshot in section "Actual result" below.

4. Apply the patch of this PR.

5. Check again the extensions section of the pre-update check.

Result:
- On a git clone, the testing sample data extenion is listed, too, see extension marked with an orange frame in the screenshot in section "Expected result" below.
- No other core extensions are listed, only 3rd party extensions.

### Expected result

![j4-missing-core-extensions_corrected](https://user-images.githubusercontent.com/7413183/83979868-cb62a800-a911-11ea-8822-45a5f4deb77a.png)

### Actual result

![j4-missing-core-extensions](https://user-images.githubusercontent.com/7413183/83979863-c271d680-a911-11ea-9b33-051b5157cde2.png)

### Documentation Changes Required

None.

### Additional information

From my point of view, the testing sample data plugin also has to be added to the list of core extensions in the ExtensionsHelper class.

But I don't remember now who of you two, @SharkyKZ or @Quy , one of you was against it in a past discussion because this extension is not available and installed if not on a git clone. Now you can see what the consequence is. But when it is added, there are no negative side effects because we nowhere just fetch and output the list of core extensions, we only use it to check installed extenions. @wilsonge Please check, too, and comment.