### PR TITLE
[4.0] Filtering by core extensions returns non-core extensions

### DIFF
--- a/administrator/components/com_installer/src/Model/ManageModel.php
+++ b/administrator/components/com_installer/src/Model/ManageModel.php
@@ -373,34 +373,12 @@ class ManageModel extends InstallerModel
 				->bind(':folder', $folder);
 		}
 
+		// Filter by core extensions.
 		if ($core === '1' || $core === '0')
 		{
-			$coreExtensions = ExtensionHelper::getCoreExtensions();
-			$where          = [];
-
-			$subQuery = $db->getQuery(true)
-				->select($db->quoteName('extension_id'))
-				->from($db->quoteName('#__extensions'));
-
-			foreach ($coreExtensions as $extension)
-			{
-				// Bind values and get parameter names.
-				$bounded = $query->bindArray(
-					$extension,
-					[ParameterType::STRING, ParameterType::STRING, ParameterType::STRING, ParameterType::INTEGER]
-				);
-
-				// Select core extension IDs.
-				$subQuery->where(
-					'(' . $db->quoteName('type') . ' = ' . $bounded[0] . ' AND ' . $db->quoteName('element') . ' = ' . $bounded[1]
-					. ' AND ' . $db->quoteName('folder') . ' = ' . $bounded[2] . ' AND ' . $db->quoteName('client_id') . ' = ' . $bounded[3] . ')',
-					'OR'
-				);
-			}
-
-			// Filter by core extension IDs.
-			$operator = $core === '1' ? ' IN ' : ' NOT IN ';
-			$query->where($db->quoteName('extension_id') . $operator . '(' . $subQuery . ')');
+			$coreExtensionIds = ExtensionHelper::getCoreExtensionIds();
+			$method = $core === '1' ? 'whereIn' : 'whereNotIn';
+			$query->$method($db->quoteName('extension_id'), $coreExtensionIds);
 		}
 
 		// Process search filter (extension id).

--- a/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
+++ b/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
@@ -1375,11 +1375,11 @@ ENDDATA;
 			]
 		)
 			->from($db->quoteName('#__extensions', 'ex'))
-			->where($db->quoteName('ex.package_id') . ' = 0');
+			->where($db->quoteName('ex.package_id') . ' = 0')
+			->whereNotIn($db->quoteName('ex.extension_id'), ExtensionHelper::getCoreExtensionIds());
 
 		$db->setQuery($query);
 		$rows = $db->loadObjectList();
-		$rows = array_filter($rows, self::class . '::isNonCoreExtension');
 
 		foreach ($rows as $extension)
 		{
@@ -1391,31 +1391,6 @@ ENDDATA;
 		}
 
 		return $rows;
-	}
-
-	/**
-	 * Checks if extension is non core extension.
-	 *
-	 * @param   object  $extension  The extension to be checked
-	 *
-	 * @return  bool  true if extension is not a core extension
-	 *
-	 * @since   4.0.0
-	 */
-	private static function isNonCoreExtension($extension)
-	{
-		$coreExtensions = ExtensionHelper::getCoreExtensions();
-
-		foreach ($coreExtensions as $coreExtension)
-		{
-			if ($coreExtension[1] == $extension->element)
-			{
-				return false;
-			}
-		}
-
-		return true;
-
 	}
 
 	/**

--- a/libraries/src/Extension/ExtensionHelper.php
+++ b/libraries/src/Extension/ExtensionHelper.php
@@ -360,6 +360,7 @@ class ExtensionHelper
 	 * @return  array
 	 *
 	 * @since   4.0.0
+	 * @throws  \RuntimeException
 	 */
 	public static function getCoreExtensionIds()
 	{

--- a/libraries/src/Extension/ExtensionHelper.php
+++ b/libraries/src/Extension/ExtensionHelper.php
@@ -333,6 +333,14 @@ class ExtensionHelper
 	);
 
 	/**
+	 * Array of core extension IDs.
+	 *
+	 * @var    array
+	 * @since  4.0.0
+	 */
+	protected static $coreExtensionIds;
+
+	/**
 	 * Gets the core extensions.
 	 *
 	 * @return  array  Array with core extensions.
@@ -344,6 +352,42 @@ class ExtensionHelper
 	public static function getCoreExtensions()
 	{
 		return self::$coreExtensions;
+	}
+
+	/**
+	 * Returns an array of core extension IDs.
+	 *
+	 * @return  array
+	 *
+	 * @since   4.0.0
+	 */
+	public static function getCoreExtensionIds()
+	{
+		if (self::$coreExtensionIds !== null)
+		{
+			return self::$coreExtensionIds;
+		}
+
+		$db    = Factory::getDbo();
+		$query = $db->getQuery(true)
+			->select($db->quoteName('extension_id'))
+			->from($db->quoteName('#__extensions'));
+
+		foreach (self::$coreExtensions as $extension)
+		{
+			$values = $query->bindArray($extension, [ParameterType::STRING, ParameterType::STRING, ParameterType::STRING, ParameterType::INTEGER]);
+			$query->where(
+				'(' . $db->quoteName('type') . ' = ' . $values[0] . ' AND ' . $db->quoteName('element') . ' = ' . $values[1]
+				. ' AND ' . $db->quoteName('folder') . ' = ' . $values[2] . ' AND ' . $db->quoteName('client_id') . ' = ' . $values[3] . ')',
+				'OR'
+			);
+		}
+
+		$db->setQuery($query);
+		self::$coreExtensionIds = $db->loadColumn();
+
+		return self::$coreExtensionIds;
+
 	}
 
 	/**

--- a/libraries/src/Extension/ExtensionHelper.php
+++ b/libraries/src/Extension/ExtensionHelper.php
@@ -388,7 +388,6 @@ class ExtensionHelper
 		self::$coreExtensionIds = $db->loadColumn();
 
 		return self::$coreExtensionIds;
-
 	}
 
 	/**


### PR DESCRIPTION
### Summary of Changes

Filtering by core extensions uses only element, which is not unique. This fixes that.
A method for getting core extension IDs was added to `Joomla\CMS\Extension\ExtensionHelper`.

### Testing Instructions

Copy a template.
Give it a name of some element used by a core extension, e.g. `sef`, `joomla`, `highlight`, etc.
View installed extensions.
Filter by core and non-core extensions.

### Expected result

The copied template appears when filtering by non-core extensions.

### Actual result

The copied template appears when filtering by core extensions.

### Documentation Changes Required

No.