### PR TITLE
[4.0] RTL: fix treeselect chevron direction

### DIFF
--- a/build/media_source/legacy/js/treeselectmenu.es5.js
+++ b/build/media_source/legacy/js/treeselectmenu.es5.js
@@ -5,6 +5,7 @@
 jQuery(function($)
 {
 	var treeselectmenu = $('div#treeselectmenu').html();
+	var direction = (document.dir !== undefined) ? document.dir : document.getElementsByTagName("html")[0].getAttribute("dir");
 
 	$('.treeselect li').each(function()
 	{
@@ -32,15 +33,21 @@ jQuery(function($)
 	{
 		$i = $(this);
 
+		if (direction === 'rtl') {
+			var chevron = 'fa-chevron-left';
+		} else {
+			var chevron = 'fa-chevron-right';
+		}
+
 		// Take care of parent UL
 		if ($i.parent().find('ul.treeselect-sub').is(':visible')) {
-			$i.removeClass('fa-chevron-down').addClass('fa-chevron-right');
+			$i.removeClass('fa-chevron-down').addClass(chevron);
 			$i.parent().find('ul.treeselect-sub').hide();
-			$i.parent().find('ul.treeselect-sub i.treeselect-toggle').removeClass('fa-chevron-down').addClass('fa-chevron-right');
+			$i.parent().find('ul.treeselect-sub i.treeselect-toggle').removeClass('fa-chevron-down').addClass(chevron);
 		} else {
-			$i.removeClass('fa-chevron-right').addClass('fa-chevron-down');
+			$i.removeClass(chevron).addClass('fa-chevron-down');
 			$i.parent().find('ul.treeselect-sub').show();
-			$i.parent().find('ul.treeselect-sub i.treeselect-toggle').removeClass('fa-chevron-right').addClass('fa-chevron-down');
+			$i.parent().find('ul.treeselect-sub i.treeselect-toggle').removeClass(chevron).addClass('fa-chevron-down');
 		}
 	});
 


### PR DESCRIPTION
Folow-up on https://github.com/joomla/joomla-cms/pull/29453

### Summary of Changes
Correcting chevron direction in menu assignments treeselect


### Testing Instructions
Will look better after https://github.com/joomla/joomla-cms/pull/29453 is merged, but can be tested independently.

Install Persian language and switch to Persian in backend
Edit a site module =>Menu Assignments
Display 3rd choice in dropdown
<img width="1149" alt="Screen Shot 2020-06-06 at 11 57 22" src="https://user-images.githubusercontent.com/869724/83941594-ebe51200-a7ec-11ea-8681-b815cf017ab4.png">

### Before patch

LTR: tree closed displays chevron towards title of menu item i.e. to the right

![chevron_LTR](https://user-images.githubusercontent.com/869724/84013273-fdf3bb80-a978-11ea-9f44-0058969cb093.gif)

RTL: chevron is still directed towards the right

![chevron_RTL_before](https://user-images.githubusercontent.com/869724/84013451-385d5880-a979-11ea-96f9-490253152b00.gif)

### After patch

in RTL chevron is directed towards menu item title

![chevron_RTL_after](https://user-images.githubusercontent.com/869724/84013516-4e6b1900-a979-11ea-91ea-ec684b379fae.gif)




### Documentation Changes Required

