### PR TITLE
[4.0] Reduce table padding

### DIFF
--- a/administrator/templates/atum/scss/vendor/bootstrap/_table.scss
+++ b/administrator/templates/atum/scss/vendor/bootstrap/_table.scss
@@ -2,7 +2,6 @@
 
 .table {
 
-
   thead {
 
     th {
@@ -11,7 +10,6 @@
 
     th,
     td {
-      padding: 1rem;
       font-weight: $font-weight-normal;
       color: var(--atum-link-color);
       white-space: nowrap;
@@ -66,8 +64,6 @@
 
   th,
   td {
-    padding: 1rem;
-
     label {
       margin-bottom: 0;
     }


### PR DESCRIPTION
### Summary of Changes

Removes a couple of lines bad SCSS override (there's a variable for that) and reduces table cell padding.

### Testing Instructions

Run `node build.js --compile-css`.
View some pages containing tables (e.g. article list).

### Expected result

Still looks OK.

### Documentation Changes Required

No.