### PR TITLE
[4.0] RTL: fix media info alignment

### DIFF
--- a/administrator/components/com_media/resources/styles/components/_media-infobar.scss
+++ b/administrator/components/com_media/resources/styles/components/_media-infobar.scss
@@ -83,6 +83,7 @@ html[dir=rtl] .media-infobar dd {
   margin-right: 0;
   margin-left: auto;
   direction: ltr;
+  text-align: right;
 }
 html[dir=rtl] .media-infobar h2 {
   padding: 20px $gutter-width 10px 0;


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/29435

### Summary of Changes

Align values to the right in RTL

### Testing Instructions
Display Media Manager, select an image and click on the `I` (info)


### Before patch
LTR

<img width="431" alt="Screen Shot 2020-06-08 at 11 40 05" src="https://user-images.githubusercontent.com/869724/84022266-44034c00-a986-11ea-933d-4d1930a42d69.png">

RTL

<img width="699" alt="Screen Shot 2020-06-08 at 12 48 15" src="https://user-images.githubusercontent.com/869724/84022351-61d0b100-a986-11ea-9571-d0db192e20d2.png">


### After patch
<img width="896" alt="Screen Shot 2020-06-08 at 12 38 12" src="https://user-images.githubusercontent.com/869724/84022231-351c9980-a986-11ea-9800-fb5689a5731a.png">

