### PR TITLE
[4.0] Fix filtering banners by keywords

### DIFF
--- a/components/com_banners/src/Model/BannersModel.php
+++ b/components/com_banners/src/Model/BannersModel.php
@@ -205,33 +205,42 @@ class BannersModel extends ListModel
 
 				foreach ($keywords as $key => $keyword)
 				{
-					$condition1 = $db->quoteName('a.own_prefix') . ' = 1'
-						. ' AND ' . $db->quoteName('a.metakey_prefix')
-						. ' = SUBSTRING(:aprefix' . $key . ',1,LENGTH(' . $db->quoteName('a.metakey_prefix') . '))'
-						. ' OR ' . $db->quoteName('a.own_prefix') . ' = 0'
-						. ' AND ' . $db->quoteName('cl.own_prefix') . ' = 1'
-						. ' AND ' . $db->quoteName('cl.metakey_prefix')
-						. ' = SUBSTRING(:clprefix' . $key . ',1,LENGTH(' . $db->quoteName('cl.metakey_prefix') . '))'
-						. ' OR ' . $db->quoteName('a.own_prefix') . ' = 0'
-						. ' AND ' . $db->quoteName('cl.own_prefix') . ' = 0'
-						. ' AND ' . ($prefix == substr($keyword, 0, strlen($prefix)) ? '0 = 0' : '0 != 0');
-
-					$query->bind([':aprefix' . $key, ':clprefix' . $key], $keyword);
-
-					$regexp     = '[[:<:]]' . $keyword . '[[:>:]]';
-					$condition2 = $db->quoteName('a.metakey') . ' ' . $query->regexp(':aregexp' . $key) . ' ';
-					$query->bind(':aregexp' . $key, $regexp);
+					$regexp       = '[[:<:]]' . $keyword . '[[:>:]]';
+					$valuesToBind = [$keyword, $keyword, $regexp];
 
 					if ($cid)
 					{
-						$condition2 .= ' OR ' . $db->quoteName('cl.metakey') . ' ' . $query->regexp(':clregexp' . $key) . ' ';
-						$query->bind(':clregexp' . $key, $regexp);
+						$valuesToBind[] = $regexp;
 					}
 
 					if ($categoryId)
 					{
-						$condition2 .= ' OR ' . $db->quoteName('cat.metakey') . ' ' . $query->regexp(':catregexp' . $key) . ' ';
-						$query->bind(':catregexp' . $key, $regexp);
+						$valuesToBind[] = $regexp;
+					}
+
+					$bounded = $query->bindArray($valuesToBind, ParameterType::STRING);
+
+					$condition1 = $db->quoteName('a.own_prefix') . ' = 1'
+						. ' AND ' . $db->quoteName('a.metakey_prefix')
+						. ' = SUBSTRING(' . $bounded[0] . ',1,LENGTH(' . $db->quoteName('a.metakey_prefix') . '))'
+						. ' OR ' . $db->quoteName('a.own_prefix') . ' = 0'
+						. ' AND ' . $db->quoteName('cl.own_prefix') . ' = 1'
+						. ' AND ' . $db->quoteName('cl.metakey_prefix')
+						. ' = SUBSTRING(' . $bounded[1] . ',1,LENGTH(' . $db->quoteName('cl.metakey_prefix') . '))'
+						. ' OR ' . $db->quoteName('a.own_prefix') . ' = 0'
+						. ' AND ' . $db->quoteName('cl.own_prefix') . ' = 0'
+						. ' AND ' . ($prefix == substr($keyword, 0, strlen($prefix)) ? '0 = 0' : '0 != 0');
+
+					$condition2 = $db->quoteName('a.metakey') . ' ' . $query->regexp($bounded[2]);
+
+					if ($cid)
+					{
+						$condition2 .= ' OR ' . $db->quoteName('cl.metakey') . ' ' . $query->regexp($bounded[3]) . ' ';
+					}
+
+					if ($categoryId)
+					{
+						$condition2 .= ' OR ' . $db->quoteName('cat.metakey') . ' ' . $query->regexp($bounded[4]) . ' ';
 					}
 
 					$temp[] = "($condition1) AND ($condition2)";

--- a/components/com_banners/src/Model/BannersModel.php
+++ b/components/com_banners/src/Model/BannersModel.php
@@ -218,6 +218,7 @@ class BannersModel extends ListModel
 						$valuesToBind[] = $regexp;
 					}
 
+					// Because values to $query->bind() are passed by reference, using $query->bindArray() here instead to prevent overwriting.
 					$bounded = $query->bindArray($valuesToBind, ParameterType::STRING);
 
 					$condition1 = $db->quoteName('a.own_prefix') . ' = 1'


### PR DESCRIPTION
### Summary of Changes

Fixes filtering banners by keywords. Similar to https://github.com/joomla/joomla-cms/pull/29466.

### Testing Instructions

Create a banner client.
Create a banner. Assign to a client. Add a keyword, e.g. `Joomla`.
Set some keywords for the document. Make sure the last keyword is not the same as the one set in the banner. E.g. add this to `templates/cassiopeia/index.php`:

    $this->setMetadata('keywords', 'Joomla, CMS');

Publish a banner module. Enable `Select by Keyword` option.
View the module in frontend.

### Expected result

Banner shown.

### Actual result

Banner not shown.

### Documentation Changes Required

