### PR TITLE
[4.0] Featured button: Swap popover title and body

### DIFF
--- a/libraries/src/Button/FeaturedButton.php
+++ b/libraries/src/Button/FeaturedButton.php
@@ -30,10 +30,10 @@ class FeaturedButton extends ActionButton
 	protected function preprocess()
 	{
 		$this->addState(0, 'articles.featured', 'color-unfeatured far fa-star',
-			Text::_('COM_CONTENT_UNFEATURED'), ['tip_title' => Text::_('JGLOBAL_TOGGLE_FEATURED')]
+			Text::_('JGLOBAL_TOGGLE_FEATURED'), ['tip_title' => Text::_('COM_CONTENT_UNFEATURED')]
 		);
 		$this->addState(1, 'articles.unfeatured', 'color-featured fas fa-star',
-			Text::_('COM_CONTENT_FEATURED'), ['tip_title' => Text::_('JGLOBAL_TOGGLE_FEATURED')]
+			Text::_('JGLOBAL_TOGGLE_FEATURED'), ['tip_title' => Text::_('COM_CONTENT_FEATURED')]
 		);
 	}
 


### PR DESCRIPTION
### Summary of Changes
Show the title and body in the right place

### Testing Instructions
Compare the popvers of featured and status button before and after Patch. 

The popover of the featured button after patch is like the status button
<img width="709" alt="featrured-popover" src="https://user-images.githubusercontent.com/1035262/84050249-c3f0dc80-a9ad-11ea-99b6-c1fc493ab644.PNG"> 
