### PR TITLE
[4.0] Create empty modules when template preview is enabled

### DIFF
--- a/libraries/src/Helper/ModuleHelper.php
+++ b/libraries/src/Helper/ModuleHelper.php
@@ -725,7 +725,7 @@ abstract class ModuleHelper
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	protected static function createDummyModule(string $name = ''): \StdClass
+	protected static function createDummyModule(string $name = ''): \stdClass
 	{
 		$module            = new \stdClass;
 		$module->id        = 0;

--- a/libraries/src/Helper/ModuleHelper.php
+++ b/libraries/src/Helper/ModuleHelper.php
@@ -64,7 +64,8 @@ abstract class ModuleHelper
 		// If we didn't find it, and the name is mod_something, create a dummy object
 		if ($result === null && strpos($name, 'mod_') === 0)
 		{
-			$result = static::createDummyModule($name);
+			$result = static::createDummyModule();
+			$result->module = $name;
 		}
 
 		return $result;
@@ -719,18 +720,16 @@ abstract class ModuleHelper
 	/**
 	 * Method to create a dummy module.
 	 *
-	 * @param   string  $name  Optional module type with mod_ prefix
-	 *
 	 * @return  \stdClass  The Module object
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	protected static function createDummyModule(string $name = ''): \stdClass
+	protected static function createDummyModule(): \stdClass
 	{
 		$module            = new \stdClass;
 		$module->id        = 0;
 		$module->title     = '';
-		$module->module    = $name;
+		$module->module    = '';
 		$module->position  = '';
 		$module->content   = '';
 		$module->showtitle = 0;

--- a/libraries/src/Helper/ModuleHelper.php
+++ b/libraries/src/Helper/ModuleHelper.php
@@ -64,15 +64,7 @@ abstract class ModuleHelper
 		// If we didn't find it, and the name is mod_something, create a dummy object
 		if ($result === null && strpos($name, 'mod_') === 0)
 		{
-			$result            = new \stdClass;
-			$result->id        = 0;
-			$result->title     = '';
-			$result->module    = $name;
-			$result->position  = '';
-			$result->content   = '';
-			$result->showtitle = 0;
-			$result->control   = '';
-			$result->params    = '';
+			$result = static::createDummyModule($name);
 		}
 
 		return $result;
@@ -109,7 +101,7 @@ abstract class ModuleHelper
 		{
 			if ($input->getBool('tp') && ComponentHelper::getParams('com_templates')->get('template_positions_display'))
 			{
-				$result[0] = static::getModule('mod_' . $position);
+				$result[0] = static::createDummyModule();
 				$result[0]->title = $position;
 				$result[0]->position = $position;
 			}
@@ -719,16 +711,32 @@ abstract class ModuleHelper
 		}
 
 		// If we didn't find it, create a dummy object
-		$result            = new \stdClass;
-		$result->id        = 0;
-		$result->title     = '';
-		$result->module    = '';
-		$result->position  = '';
-		$result->content   = '';
-		$result->showtitle = 0;
-		$result->control   = '';
-		$result->params    = '';
+		$result = static::createDummyModule();
 
 		return $result;
+	}
+
+	/**
+	 * Method to create a dummy module.
+	 *
+	 * @param   string  $name  Optional module type with mod_ prefix
+	 *
+	 * @return  \stdClass  The Module object
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected static function createDummyModule(string $name = ''): \StdClass
+	{
+		$module            = new \stdClass;
+		$module->id        = 0;
+		$module->title     = '';
+		$module->module    = $name;
+		$module->position  = '';
+		$module->content   = '';
+		$module->showtitle = 0;
+		$module->control   = '';
+		$module->params    = '';
+
+		return $module;
 	}
 }


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/29494.

### Summary of Changes

When template preview is enabled and no module is published in a module position, a module based on position name is created in the position. This changes the module to an empty dummy module.

### Testing Instructions

1. Make sure no module is published in frontend `footer` position. Enable template preview. Inspect module positions.
2. Create an article. Use `{loadmoduleid}` shortcode to insert module. One with existing ID and one with non-existing.
3. Go to Postinstall Messages in backend. Check that `Release news from the Joomla! Project` newsfeed still appears.

### Expected result

1. Empty `footer` position is shown.
2. Works like before (existing module shows up, non-existing does not).
3. Works like before. No notices.

### Actual result

1. `mod_footer` is shown in `footer` position (contents: `Copyright © 2020 Joomla!. All Rights Reserved.`).

### Documentation Changes Required

No.