### PR TITLE
[4.0] Fix card display in modules selection

### DIFF
--- a/administrator/templates/atum/scss/pages/_com_modules.scss
+++ b/administrator/templates/atum/scss/pages/_com_modules.scss
@@ -1,6 +1,6 @@
 .new-modules {
   .card-columns {
-    grid-template-columns: 1fr 1fr 1fr 1fr;
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
   }
 
   .card {


### PR DESCRIPTION
Pull Request for Issue #29064 and #29525.

### Summary of Changes
Display as many columns that allow the cards to be at least 240px wide.

Thanks @ciar4n for the code.


### Testing Instructions
Run npm i
Click "Add module to the dashboard" or Content > Site Modules +
Reduce viewport


