### PR TITLE
[com_users] Clear user state on cancel

### DIFF
--- a/administrator/components/com_users/controllers/mail.php
+++ b/administrator/components/com_users/controllers/mail.php
@@ -46,7 +46,7 @@ class UsersControllerMail extends JControllerLegacy
 		}
 
 		$msg = $model->getError();
-		$this->setredirect('index.php?option=com_users&view=mail', $msg, $type);
+		$this->setRedirect('index.php?option=com_users&view=mail', $msg, $type);
 	}
 
 	/**
@@ -60,6 +60,10 @@ class UsersControllerMail extends JControllerLegacy
 	{
 		// Check for request forgeries.
 		$this->checkToken('request');
+
+		// Clear data from session.
+		\JFactory::getApplication()->setUserState('com_users.display.mail.data', null);
+
 		$this->setRedirect('index.php');
 	}
 }


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/29535.

### Summary of Changes

Clears data from session on cancel.

### Testing Instructions

> Go to Admin -> Users -> Mass Mail Users
> 
> Compose an email
> 
> Select a group that has no users in it
> 
> Click Send email - note correct error message saying group has no users
> 
> Give up and click Cancel, can't be arsed to email anyone anyway...
> 
> Do something else for a while, Grab a coffee, edit some content, look out the window...
> 
> Go to Admin -> Users -> Mass Mail Users
> 

### Expected result

>Blank form ready for some new mail I want to compose.

### Actual result

>The contents of the last form submission (The composed email) which failed to send some time ago.

### Documentation Changes Required

No.