### PR TITLE
[4.0] Add permission check to mod_messages

### DIFF
--- a/administrator/modules/mod_messages/mod_messages.php
+++ b/administrator/modules/mod_messages/mod_messages.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Helper\ModuleHelper;
 
 // Check permissions.
-if (!$app->getIdentity()->authorise('core.admin.login') || !$app->getIdentity()->authorise('core.manage', 'com_messages'))
+if (!$app->getIdentity()->authorise('core.login.admin') || !$app->getIdentity()->authorise('core.manage', 'com_messages'))
 {
 	return;
 }

--- a/administrator/modules/mod_messages/mod_messages.php
+++ b/administrator/modules/mod_messages/mod_messages.php
@@ -11,6 +11,12 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Helper\ModuleHelper;
 
+// Check permissions.
+if (!$app->getIdentity()->authorise('core.admin.login') || !$app->getIdentity()->authorise('core.manage', 'com_messages'))
+{
+	return;
+}
+
 // Try to get the items from the messages model
 try
 {


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/29542.

### Summary of Changes

Adds permission check to mod_messages.

### Testing Instructions

Create an account assigned to Manager user group.
Login to backend.
Click on "Private Messages" on top.

### Expected result

Either user is authorised to access the component or "Private Messages" isn't shown at all.

### Actual result

>You don't have permission to access this. Please contact a website administrator if this is incorrect. 

### Documentation Changes Required

No.