### PR TITLE
[4.0] Duplicate queries when user has no contacts

### DIFF
--- a/plugins/content/contact/contact.php
+++ b/plugins/content/contact/contact.php
@@ -110,7 +110,8 @@ class PlgContentContact extends CMSPlugin
 	{
 		static $contacts = array();
 
-		if (isset($contacts[$created_by]))
+		// Note: don't use isset() because value could be null.
+		if (array_key_exists($created_by, $contacts))
 		{
 			return $contacts[$created_by];
 		}


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Fixes duplicate queries in Content - Contact plugin when author has no contacts assigned.

### Testing Instructions

Create some articles
Go to `com_content` configuration.
Enable `Link to Author's Contact Page` option.
View article list/blog in frontend.

### Expected result

No (or some, based on how many authors) duplicate queries in `plugins\content\contact\contact.php`.

### Actual result

Many duplicates of this:

```
SELECT `contact`.`id` AS `contactid`,`contact`.`alias`,`contact`.`catid`,`contact`.`webpage`,`contact`.`email_to`
FROM `a400_contact_details` AS `contact`
WHERE `contact`.`published` = 1 AND `contact`.`user_id` = :createdby
ORDER BY `contact`.`id` DESC LIMIT 1
```

### Documentation Changes Required

No.