### PR TITLE
[4.0] Fix wrong db_select in installation

### DIFF
--- a/installation/src/Model/DatabaseModel.php
+++ b/installation/src/Model/DatabaseModel.php
@@ -333,7 +333,7 @@ class DatabaseModel extends BaseInstallationModel
 						'user'     => $options->db_user,
 						'password' => $options->db_pass_plain,
 						'prefix'   => $options->db_prefix,
-						'select'   => $options->db_select,
+						'select'   => false,
 						DatabaseHelper::getEncryptionSettings($options),
 					);
 				}
@@ -347,7 +347,7 @@ class DatabaseModel extends BaseInstallationModel
 						'password' => $options->db_pass_plain,
 						'database' => 'postgres',
 						'prefix'   => $options->db_prefix,
-						'select'   => $options->db_select,
+						'select'   => false,
 						DatabaseHelper::getEncryptionSettings($options),
 					);
 				}


### PR DESCRIPTION
Pull Request for Issue #29354 .

### Summary of Changes

Since PR #28350 , the db_select option of the session variables for the database connection is not used anymore. But with thas PR it has been forgottento remove it from the parameters of the alternative database connection which is used for the attempt to create a new database when using the MySQL (PDO) or the PostgreSQL (PDO) database driver and the database doesn't exist and the user has privilege to create a database.

This causes a PHP notice "Undefined property: stdClass::$db_select in installation\src\Model\DatabaseModel.php on line 336" on PHP 7.4.

This Pull Request (PR) here solves that.

It is not an issue in J3.

### Testing Instructions

Could be merged by review even.

But for real tests: Make a new installation with current 4.0-dev plus the patch of this PR applied. Try different scenarios:
- Different database types "MySQL (PDO)" or "PostgreSQL (PDO)", whatever you have available, only "MySQLi" doesn't make sense because with this database type the issue doesn't happen.
- Existing database with database user who has full privileges to only this database => installation succeeds.
- Not existing database and user who has the privilege to create a new database, so that the installation can create it => installation succeeds.
- Not existing database and user who doesn't have  the privilege to create a new database => installation not started, error message shown.

### Expected result

In no case there is any PHP notice "Undefined property: stdClass::$db_select in installation\src\Model\DatabaseModel.php on line 336".

### Actual result

Under certain conditions (PHP version?) PHP notice "Undefined property: stdClass::$db_select in installation\src\Model\DatabaseModel.php on line 336".

### Documentation Changes Required

None.