### PR TITLE
[4.0] Mass mail subject prefix styling

### DIFF
--- a/administrator/components/com_users/tmpl/mail/default.php
+++ b/administrator/components/com_users/tmpl/mail/default.php
@@ -33,12 +33,14 @@ $comUserParams = ComponentHelper::getParams('com_users');
 					<fieldset class="adminform">
 						<div class="form-group">
 							<?php echo $this->form->getLabel('subject'); ?>
-							<?php if (!empty($comUserParams->get('mailSubjectPrefix'))) : ?>
-								<span class="input-group-prepend">
-									<span class="input-group-text"><?php echo $comUserParams->get('mailSubjectPrefix'); ?></span>
-								</span>
-							<?php endif; ?>
-							<?php echo $this->form->getInput('subject'); ?>
+							<span class="input-group">
+								<?php if (!empty($comUserParams->get('mailSubjectPrefix'))) : ?>
+									<span class="input-group-prepend">
+										<span class="input-group-text"><?php echo $comUserParams->get('mailSubjectPrefix'); ?></span>
+									</span>
+								<?php endif; ?>
+								<?php echo $this->form->getInput('subject'); ?>
+							</span>
 						</div>
 						<div class="form-group">
 							<?php echo $this->form->getLabel('message'); ?>


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/29561.

### Summary of Changes

Fixes subject field styling when prefix is enabled.

### Testing Instructions

Go to `com_users` options. In `Mass Mail Users` tab fill `Subject Prefix` field.
Go to Users -> Mass Mail Users.

### Expected result

Subject field looks OK.

### Actual result

Subject field looks bad.

### Documentation Changes Required

No.