### PR TITLE
[4.0] Private message display

### DIFF
--- a/administrator/components/com_messages/tmpl/message/default.php
+++ b/administrator/components/com_messages/tmpl/message/default.php
@@ -16,49 +16,45 @@ use Joomla\CMS\Router\Route;
 HTMLHelper::_('behavior.core');
 ?>
 <form action="<?php echo Route::_('index.php?option=com_messages'); ?>" method="post" name="adminForm" id="adminForm">
-	<div class="row mt-2">
-		<div class="col-md-9">
-			<div class="card">
-				<div class="card-body">
-					<fieldset>
-						<div class="form-group">
-							<div class="control-label">
-								<?php echo Text::_('COM_MESSAGES_FIELD_USER_ID_FROM_LABEL'); ?>
-							</div>
-							<div class="form-control" readonly>
-								<?php echo $this->item->get('from_user_name'); ?>
-							</div>
-						</div>
-						<div class="form-group">
-							<div class="control-label">
-								<?php echo Text::_('COM_MESSAGES_FIELD_DATE_TIME_LABEL'); ?>
-							</div>
-							<div class="form-control" readonly>
-								<?php echo HTMLHelper::_('date', $this->item->date_time, Text::_('DATE_FORMAT_LC2')); ?>
-							</div>
-						</div>
-						<div class="form-group">
-							<div class="control-label">
-								<?php echo Text::_('COM_MESSAGES_FIELD_SUBJECT_LABEL'); ?>
-							</div>
-							<div class="form-control" readonly>
-								<?php echo $this->item->subject; ?>
-							</div>
-						</div>
-						<div class="form-group">
-							<div class="control-label">
-								<?php echo Text::_('COM_MESSAGES_FIELD_MESSAGE_LABEL'); ?>
-							</div>
-							<div class="form-control" readonly>
-								<?php echo $this->item->message; ?>
-							</div>
-						</div>
-						<input type="hidden" name="task" value="">
-						<input type="hidden" name="reply_id" value="<?php echo $this->item->message_id; ?>">
-						<?php echo HTMLHelper::_('form.token'); ?>
-					</fieldset>
+	<div class="card">
+		<div class="card-body">
+			<fieldset>
+				<div class="form-group">
+					<div class="control-label">
+						<?php echo Text::_('COM_MESSAGES_FIELD_USER_ID_FROM_LABEL'); ?>
+					</div>
+					<div class="p-3 bg-light">
+						<?php echo $this->item->get('from_user_name'); ?>
+					</div>
 				</div>
-			</div>
+				<div class="form-group">
+					<div class="control-label">
+						<?php echo Text::_('COM_MESSAGES_FIELD_DATE_TIME_LABEL'); ?>
+					</div>
+					<div class="p-3 bg-light">
+						<?php echo HTMLHelper::_('date', $this->item->date_time, Text::_('DATE_FORMAT_LC2')); ?>
+					</div>
+				</div>
+				<div class="form-group">
+					<div class="control-label">
+						<?php echo Text::_('COM_MESSAGES_FIELD_SUBJECT_LABEL'); ?>
+					</div>
+					<div class="p-3 bg-light">
+						<?php echo $this->item->subject; ?>
+					</div>
+				</div>
+				<div class="form-group">
+					<div class="control-label">
+						<?php echo Text::_('COM_MESSAGES_FIELD_MESSAGE_LABEL'); ?>
+					</div>
+					<div class="p-3 bg-light">
+						<?php echo $this->item->message; ?>
+					</div>
+				</div>
+				<input type="hidden" name="task" value="">
+				<input type="hidden" name="reply_id" value="<?php echo $this->item->message_id; ?>">
+				<?php echo HTMLHelper::_('form.token'); ?>
+			</fieldset>
 		</div>
 	</div>
 </form>


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/29543.

### Summary of Changes

Fixes private message display.

### Testing Instructions

Send a formatted, multi-line private message.
View the message.

### Expected result

Looks OK.

### Actual result

Text is overflowing.


![](https://user-images.githubusercontent.com/400092/84192123-7352af80-aa91-11ea-9c28-5d9345de9c69.png)

### Documentation Changes Required

No.