### PR TITLE
[4.0] Correct link preload header

### DIFF
--- a/templates/cassiopeia/index.php
+++ b/templates/cassiopeia/index.php
@@ -39,7 +39,7 @@ $wa->usePreset('template.cassiopeia.' . ($this->direction === 'rtl' ? 'rtl' : 'l
 $wa->registerStyle('template.active', '', [], [], ['template.cassiopeia.' . ($this->direction === 'rtl' ? 'rtl' : 'ltr')]);
 
 // Preload the stylesheet for the font, actually we need to preload the font
-$this->getPreloadManager()->preload('https://fonts.googleapis.com/css?family=Fira+Sans:400', array('as' => 'stylesheet'));
+$this->getPreloadManager()->preload('https://fonts.googleapis.com/css?family=Fira+Sans:400', array('as' => 'style'));
 
 // Logo file or site title param
 if ($this->params->get('logoFile'))


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/29288.

### Summary of Changes

Corrects link preload header.

### Testing Instructions

Code review.

Or view any frontend page. Inspect headers, specifically `Link` header.

### Expected result

    Link: <https://fonts.googleapis.com/css?family=Fira+Sans:400>; rel="preload"; as="style"

### Actual result

    Link: <https://fonts.googleapis.com/css?family=Fira+Sans:400>; rel="preload"; as="stylesheet"

Which generates an error:

    <link rel=preload> must have a valid `as` value

### Documentation Changes Required

No.