### PR TITLE
[4.0] Remove margin between accordion slides

### DIFF
--- a/components/com_config/tmpl/modules/default.php
+++ b/components/com_config/tmpl/modules/default.php
@@ -174,7 +174,7 @@ if (Multilanguage::isEnabled())
 					</div>
 
 					<?php if ($editorText) : ?>
-						<div class="tab-pane" id="custom">
+						<div class="mt-2" id="custom">
 							<?php echo $this->form->getInput('content'); ?>
 						</div>
 					<?php endif; ?>

--- a/libraries/src/HTML/Helpers/Bootstrap.php
+++ b/libraries/src/HTML/Helpers/Bootstrap.php
@@ -449,7 +449,7 @@ abstract class Bootstrap
 			' data-parent="' . static::$loaded[__CLASS__ . '::startAccordion'][$selector]['parent'] . '"' : '';
 		$class     = (!empty($class)) ? ' ' . $class : '';
 
-		$html = '<div class="card mb-2' . $class . '">'
+		$html = '<div class="card' . $class . '">'
 			. '<a href="#' . $id . '" data-toggle="collapse"' . $parent . ' class="card-header' . $collapsed . '" role="tab">'
 			. $text
 			. '</a>'


### PR DESCRIPTION
Fixes https://github.com/joomla/joomla-cms/issues/29311.

### Summary of Changes

Removes margin between Bootstrap accordion slides.

### Testing Instructions

Edit a module in frontend.

### Expected result

Looks OK.

### Actual result

Gap between slides and first slide is missing the bottom border:

![](https://user-images.githubusercontent.com/400092/83351046-a6ca6700-a338-11ea-90ed-660880d4d008.png)

### Documentation Changes Required

No.