### PR TITLE
Preparing 3.10 for 4.0 content versioning

### DIFF
--- a/libraries/src/Versioning/VersionableControllerTrait.php
+++ b/libraries/src/Versioning/VersionableControllerTrait.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  Copyright (C) 2005 - 2019 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Versioning;
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * Defines the trait for a Versionable Controller Class.
+ * Note: This is a placeholder to ease transition to the new system in 4.0
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+trait VersionableControllerTrait
+{
+}

--- a/libraries/src/Versioning/VersionableModelTrait.php
+++ b/libraries/src/Versioning/VersionableModelTrait.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  Copyright (C) 2005 - 2019 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Versioning;
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * Defines the trait for a Versionable Model Class.
+ * Note: This is a placeholder to ease transition to the new system in 4.0
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+trait VersionableModelTrait
+{
+}

--- a/libraries/src/Versioning/VersionableTableInterface.php
+++ b/libraries/src/Versioning/VersionableTableInterface.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  Copyright (C) 2005 - 2019 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Versioning;
+
+defined('JPATH_PLATFORM') or die;
+
+use Joomla\CMS\Table\TableInterface;
+
+/**
+ * Interface for a versionable Table class
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+interface VersionableTableInterface extends TableInterface
+{
+	/**
+	 * Get the type alias for the history table
+	 *
+	 * The type alias generally is the internal component name with the
+	 * content type. Ex.: com_content.article
+	 *
+	 * @return  string  The alias as described above
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getTypeAlias();
+}


### PR DESCRIPTION
This PR backports a few classes that would be necessary to implement versioning of content items in the same code for extensions in 3.x and 4.0. To support both 3.x-style and 4.0-style versioning, you'd have to implement the 3.x-style first. Good luck with that. To get 4.0-style working, simply let your table class implement the interface VersionableTableInterface (and the method that that defines) and let your item controller and model use the respective Versionable trait. In 3.x, these traits are empty, in 4.0 they contain all the logic necessary for versioning.

This is a redo of #23479. The original PR was merged without the feature in 4.0 being accepted. It was then reverted, but shortly before the 4.0 beta it WAS accepted and now we have to redo this again. The PR with the refactoring of the versioning was #29217.

@zero-24 