### PR TITLE
[4.0] Fix unlimited checkbox markup

### DIFF
--- a/administrator/components/com_banners/src/Field/ImptotalField.php
+++ b/administrator/components/com_banners/src/Field/ImptotalField.php
@@ -48,7 +48,7 @@ class ImptotalField extends FormField
 
 		return '<input type="text" name="' . $this->name . '" id="' . $this->id . '" size="9" value="' . htmlspecialchars($value, ENT_COMPAT, 'UTF-8')
 			. '" ' . $class . $onchange . '>'
-			. '<fieldset class="checkbox impunlimited"><input id="' . $this->id . '_unlimited" type="checkbox"' . $checked . $onclick . '>'
-			. '<label for="' . $this->id . '_unlimited" id="jform-imp" type="text">' . Text::_('COM_BANNERS_UNLIMITED') . '</label></fieldset>';
+			. '<fieldset class="form-check impunlimited"><input class="form-check-input" id="' . $this->id . '_unlimited" type="checkbox"' . $checked . $onclick . '>'
+			. '<label for="' . $this->id . '_unlimited" id="jform-imp" class="form-check-label">' . Text::_('COM_BANNERS_UNLIMITED') . '</label></fieldset>';
 	}
 }


### PR DESCRIPTION
### Summary of Changes
Apply Bootstrap markup to unlimited checkbox.

From Bootstrap migrating to v4:
> Consolidated .checkbox and .radio into .form-check and the various .form-check-* classes.

### Testing Instructions
Edit a banner.
Click Banner Details tab.


### Expected result
![unlimited-after](https://user-images.githubusercontent.com/368084/84545579-5ba74100-acb4-11ea-8203-f566f3f28f01.png)



### Actual result
![unlimited-before](https://user-images.githubusercontent.com/368084/84545588-5e099b00-acb4-11ea-8e9b-9459a87603f9.png)