### PR TITLE
[4.0]  Modal for articles fix form

### DIFF
--- a/administrator/components/com_content/tmpl/articles/modal.php
+++ b/administrator/components/com_content/tmpl/articles/modal.php
@@ -44,7 +44,7 @@ if (!empty($editor))
 ?>
 <div class="container-popup">
 
-	<form action="<?php echo Route::_('index.php?option=com_content&view=articles&layout=modal&tmpl=component&function=' . $function . '&' . Session::getFormToken() . '=1&editor=' . $editor); ?>" method="post" name="adminForm" id="adminForm" class="form-inline">
+	<form action="<?php echo Route::_('index.php?option=com_content&view=articles&layout=modal&tmpl=component&function=' . $function . '&' . Session::getFormToken() . '=1&editor=' . $editor); ?>" method="post" name="adminForm" id="adminForm">
 
 		<?php echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
 


### PR DESCRIPTION
Pull Request for Issue #29588 .

### Summary of Changes


### Testing Instructions
see #29588
or any other situation where the mocal for articles is used (new menu item for a single article for example)


### Expected result
The modal looks a expected, the search tools are displayed as always. 
<img width="671" alt="modal-after" src="https://user-images.githubusercontent.com/1035262/84565887-d338a700-ad6c-11ea-95da-0803dfc857b3.PNG">



### Actual result



### Documentation Changes Required

