### PR TITLE
[4.0] No user information if the user hast not the right to manage users

### DIFF
--- a/administrator/modules/mod_stats_admin/src/Helper/StatsAdminHelper.php
+++ b/administrator/modules/mod_stats_admin/src/Helper/StatsAdminHelper.php
@@ -114,7 +114,7 @@ class StatsAdminHelper
 
 				if ($user->authorise('core.manage', 'com_users'))
 				{
-					$rows[$i]->link  = Route::_('index.php?option=com_users');
+					$rows[$i]->link = Route::_('index.php?option=com_users');
 				}
 
 				$i++;

--- a/administrator/modules/mod_stats_admin/src/Helper/StatsAdminHelper.php
+++ b/administrator/modules/mod_stats_admin/src/Helper/StatsAdminHelper.php
@@ -111,6 +111,7 @@ class StatsAdminHelper
 				$rows[$i]->title = Text::_('MOD_STATS_USERS');
 				$rows[$i]->icon  = 'users';
 				$rows[$i]->data  = $users;
+
 				if ($user->authorise('core.manage', 'com_users'))
 				{
 					$rows[$i]->link  = Route::_('index.php?option=com_users');

--- a/administrator/modules/mod_stats_admin/src/Helper/StatsAdminHelper.php
+++ b/administrator/modules/mod_stats_admin/src/Helper/StatsAdminHelper.php
@@ -105,13 +105,16 @@ class StatsAdminHelper
 				$items = false;
 			}
 
-			if ($users && $user->authorise('core.PR an', 'com_users'))
+			if ($users)
 			{
 				$rows[$i]        = new \stdClass;
 				$rows[$i]->title = Text::_('MOD_STATS_USERS');
 				$rows[$i]->icon  = 'users';
 				$rows[$i]->data  = $users;
-				$rows[$i]->link  = Route::_('index.php?option=com_users');
+				if ($user->authorise('core.manage', 'com_users'))
+				{
+					$rows[$i]->link  = Route::_('index.php?option=com_users');
+				}
 				$i++;
 			}
 

--- a/administrator/modules/mod_stats_admin/src/Helper/StatsAdminHelper.php
+++ b/administrator/modules/mod_stats_admin/src/Helper/StatsAdminHelper.php
@@ -116,6 +116,7 @@ class StatsAdminHelper
 				{
 					$rows[$i]->link  = Route::_('index.php?option=com_users');
 				}
+
 				$i++;
 			}
 

--- a/administrator/modules/mod_stats_admin/src/Helper/StatsAdminHelper.php
+++ b/administrator/modules/mod_stats_admin/src/Helper/StatsAdminHelper.php
@@ -38,6 +38,8 @@ class StatsAdminHelper
 	 */
 	public static function getStats(Registry $params, CMSApplication $app, DatabaseInterface $db)
 	{
+		$user = $app->getIdentity();
+
 		$rows  = array();
 		$query = $db->getQuery(true);
 
@@ -103,7 +105,7 @@ class StatsAdminHelper
 				$items = false;
 			}
 
-			if ($users)
+			if ($users && $user->authorise('core.PR an', 'com_users'))
 			{
 				$rows[$i]        = new \stdClass;
 				$rows[$i]->title = Text::_('MOD_STATS_USERS');


### PR DESCRIPTION
Pull Request for Issue #29589 .

### Summary of Changes
In general, the site information has view level "super users". So in geeral, module "site information" is not shown for users of other groups.
But this view level can be changed to public or special.

If a user hast not permission to manage users, he should not see the users information.


### Testing Instructions
Make sure that the admin module "site information" has view level "manage" or lower.
Login as a user in a group without the right to manage users. 
You may not see the users information. 

### Expected result

<img width="514" alt="site-information" src="https://user-images.githubusercontent.com/1035262/84568472-09cbed00-ad80-11ea-8253-9cc1cb046aeb.PNG">

### Remark
Users and articles information are shown in many places. 
I think this information could be removed from site information as well.
