### PR TITLE
[4.0] Check whether CSP is enabled and enabled by the current client

### DIFF
--- a/administrator/components/com_csp/config.xml
+++ b/administrator/components/com_csp/config.xml
@@ -13,9 +13,8 @@
 		</field>
 		<field
 			name="contentsecuritypolicy_client"
-			type="radio"
+			type="list"
 			label="COM_CSP_CONTENTSECURITYPOLICY_CLIENT"
-			class="col-md-12"
 			default="site"
 			validate="options"
 			showon="contentsecuritypolicy:1"

--- a/administrator/components/com_csp/config.xml
+++ b/administrator/components/com_csp/config.xml
@@ -12,6 +12,19 @@
 			<option value="1">JENABLED</option>
 		</field>
 		<field
+			name="contentsecuritypolicy_client"
+			type="radio"
+			label="COM_CSP_CONTENTSECURITYPOLICY_CLIENT"
+			class="col-md-12"
+			default="site"
+			validate="options"
+			showon="contentsecuritypolicy:1"
+			>
+			<option value="site">JSITE</option>
+			<option value="administrator">JADMINISTRATOR</option>
+			<option value="both">COM_CSP_HEADER_CLIENT_BOTH</option>
+		</field>
+		<field
 			name="contentsecuritypolicy_mode"
 			type="list"
 			label="COM_CSP_CONTENTSECURITYPOLICY_MODE"

--- a/administrator/language/en-GB/com_csp.ini
+++ b/administrator/language/en-GB/com_csp.ini
@@ -8,6 +8,7 @@ COM_CSP_COLLECTING_TRASH_WARNING="The Content Security Policy is in detect mode.
 COM_CSP_CONFIGURATION="Content Security Policy: Options"
 ; Please do not translate the following language string
 COM_CSP_CONTENTSECURITYPOLICY="<a href='https://scotthelme.co.uk/content-security-policy-an-introduction' target='_blank' rel='noopener noreferrer'>Content Security Policy (CSP)</a>"
+COM_CSP_CONTENTSECURITYPOLICY_CLIENT="Client"
 ; Please do not translate the following language string
 COM_CSP_CONTENTSECURITYPOLICY_FRAME_ANCESTORS_SELF_ENABLED="frame-ancestors 'self'"
 COM_CSP_CONTENTSECURITYPOLICY_FRAME_ANCESTORS_SELF_ENABLED_DESC="Enable the CSP clickjacking protection frame-ancestors and only allow the origin 'self'. Please use the form below to allow origins other than 'self'."

--- a/plugins/system/httpheaders/httpheaders.php
+++ b/plugins/system/httpheaders/httpheaders.php
@@ -229,7 +229,7 @@ class PlgSystemHttpHeaders extends CMSPlugin implements SubscriberInterface
 		$cspEnabled = (int) $this->comCspParams->get('contentsecuritypolicy', 0);
 		$cspClient  = (string) $this->comCspParams->get('contentsecuritypolicy_client', 'site');
 
-		// Check whether CSP is enabled and anabled by the current client
+		// Check whether CSP is enabled and enabled by the current client
 		if ($cspEnabled && ($this->app->isClient($cspClient) || $cspClient === 'both'))
 		{
 			$this->setCspHeader();

--- a/plugins/system/httpheaders/httpheaders.php
+++ b/plugins/system/httpheaders/httpheaders.php
@@ -229,7 +229,8 @@ class PlgSystemHttpHeaders extends CMSPlugin implements SubscriberInterface
 		$cspEnabled = (int) $this->comCspParams->get('contentsecuritypolicy', 0);
 		$cspClient  = (string) $this->comCspParams->get('contentsecuritypolicy_client', 'site');
 
-		if ($cspEnabled && $this->app->isClient($cspClient))
+		// Check whether CSP is enabled and anabled by the current client
+		if ($cspEnabled && ($this->app->isClient($cspClient) || $cspClient === 'both'))
 		{
 			$this->setCspHeader();
 		}

--- a/plugins/system/httpheaders/httpheaders.php
+++ b/plugins/system/httpheaders/httpheaders.php
@@ -226,9 +226,10 @@ class PlgSystemHttpHeaders extends CMSPlugin implements SubscriberInterface
 		$this->setStaticHeaders();
 
 		// Handle CSP Header configuration
-		$cspOptions = (int) $this->comCspParams->get('contentsecuritypolicy', 0);
+		$cspEnabled = (int) $this->comCspParams->get('contentsecuritypolicy', 0);
+		$cspClient  = (string) $this->comCspParams->get('contentsecuritypolicy_client', 'site');
 
-		if ($cspOptions)
+		if ($cspEnabled && $this->app->isClient($cspClient))
 		{
 			$this->setCspHeader();
 		}


### PR DESCRIPTION
### Summary of Changes

Check whether CSP is enabled and enabled by the current client

### Testing Instructions

- Apply this PR
- configure the CSP via the options in com_csp
- check that the client filter (Site, Admin, both) works

![image](https://user-images.githubusercontent.com/2596554/84582010-cf496b00-ade6-11ea-8786-1afefc4fbbd9.png)

### Expected result

You can configure the CSP client

### Actual result

You can not configure the CSP client

### Documentation Changes Required

Yes: https://help.joomla.org/proxy?keyref=Help40:Components_CSP_Reports_Options && https://help.joomla.org/proxy?keyref=J4.x:Http_Header_Management