### PR TITLE
[4.0] Issue warnings when unsafe-inline or unsafe-eval are used in auto mode

### DIFF
--- a/administrator/components/com_csp/src/Helper/ReporterHelper.php
+++ b/administrator/components/com_csp/src/Helper/ReporterHelper.php
@@ -44,6 +44,8 @@ class ReporterHelper
 		catch (\RuntimeException $e)
 		{
 			Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');
+
+			return false;
 		}
 
 		return $result;
@@ -72,6 +74,8 @@ class ReporterHelper
 		catch (\RuntimeException $e)
 		{
 			Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');
+
+			return false;
 		}
 
 		return boolval($result);
@@ -101,6 +105,8 @@ class ReporterHelper
 		catch (\RuntimeException $e)
 		{
 			Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');
+
+			return false;
 		}
 
 		return boolval($result);
@@ -130,6 +136,8 @@ class ReporterHelper
 		catch (\RuntimeException $e)
 		{
 			Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');
+
+			return false;
 		}
 
 		return boolval($result);

--- a/administrator/components/com_csp/src/Helper/ReporterHelper.php
+++ b/administrator/components/com_csp/src/Helper/ReporterHelper.php
@@ -95,7 +95,7 @@ class ReporterHelper
 			->select('COUNT(*)')
 			->from($db->quoteName('#__csp'))
 			->where($db->quoteName('blocked_uri') . ' = ' . $db->quote("'unsafe-inline'"))
-			->where($db->quoteName('published') . ' = ' . $db->quote('1'));
+			->where($db->quoteName('published') . ' = 1'));
 		$db->setQuery($query);
 
 		try

--- a/administrator/components/com_csp/src/Helper/ReporterHelper.php
+++ b/administrator/components/com_csp/src/Helper/ReporterHelper.php
@@ -119,7 +119,7 @@ class ReporterHelper
 		$query = $db->getQuery(true)
 			->select('COUNT(*)')
 			->from($db->quoteName('#__csp'))
-			->where($db->quoteName('blocked_uri'). ' = ' . $db->quote("'unsafe-eval'"))
+			->where($db->quoteName('blocked_uri') . ' = ' . $db->quote("'unsafe-eval'"))
 			->where($db->quoteName('published') . ' = ' . $db->quote('1'));
 		$db->setQuery($query);
 

--- a/administrator/components/com_csp/src/Helper/ReporterHelper.php
+++ b/administrator/components/com_csp/src/Helper/ReporterHelper.php
@@ -76,4 +76,62 @@ class ReporterHelper
 
 		return boolval($result);
 	}
+
+	/**
+	 * Check whether there are unsafe-inline rules published
+	 *
+	 * @return  boolean  Whether there are unsafe-inline rules published
+	 *
+	 * @since   4.0.0
+	 */
+	public static function getCspUnsafeInlineStatus()
+	{
+		$db = Factory::getDbo();
+		$query = $db->getQuery(true)
+			->select('COUNT(*)')
+			->from($db->quoteName('#__csp'))
+			->where($db->quoteName('blocked_uri'). ' = ' . $db->quote("'unsafe-inline'"))
+			->where($db->quoteName('published') . ' = ' . $db->quote('1'));
+		$db->setQuery($query);
+
+		try
+		{
+			$result = (int) $db->loadResult();
+		}
+		catch (\RuntimeException $e)
+		{
+			Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');
+		}
+
+		return boolval($result);
+	}
+
+	/**
+	 * Check whether there are unsafe-eval rules published
+	 *
+	 * @return  boolean  Whether there are unsafe-eval rules published
+	 *
+	 * @since   4.0.0
+	 */
+	public static function getCspUnsafeEvalStatus()
+	{
+		$db = Factory::getDbo();
+		$query = $db->getQuery(true)
+			->select('COUNT(*)')
+			->from($db->quoteName('#__csp'))
+			->where($db->quoteName('blocked_uri'). ' = ' . $db->quote("'unsafe-eval'"))
+			->where($db->quoteName('published') . ' = ' . $db->quote('1'));
+		$db->setQuery($query);
+
+		try
+		{
+			$result = (int) $db->loadResult();
+		}
+		catch (\RuntimeException $e)
+		{
+			Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');
+		}
+
+		return boolval($result);
+	}
 }

--- a/administrator/components/com_csp/src/Helper/ReporterHelper.php
+++ b/administrator/components/com_csp/src/Helper/ReporterHelper.php
@@ -23,7 +23,7 @@ class ReporterHelper
 	/**
 	 * Gets the httpheaders system plugin extension id.
 	 *
-	 * @return  integer  The httpheaders system plugin extension id.
+	 * @return  mixed  The httpheaders system plugin extension id or false in case of an error.
 	 *
 	 * @since   4.0.0
 	 */

--- a/administrator/components/com_csp/src/Helper/ReporterHelper.php
+++ b/administrator/components/com_csp/src/Helper/ReporterHelper.php
@@ -126,7 +126,7 @@ class ReporterHelper
 			->select('COUNT(*)')
 			->from($db->quoteName('#__csp'))
 			->where($db->quoteName('blocked_uri') . ' = ' . $db->quote("'unsafe-eval'"))
-			->where($db->quoteName('published') . ' = 1'));
+			->where($db->quoteName('published') . ' = 1');
 		$db->setQuery($query);
 
 		try

--- a/administrator/components/com_csp/src/Helper/ReporterHelper.php
+++ b/administrator/components/com_csp/src/Helper/ReporterHelper.php
@@ -90,7 +90,7 @@ class ReporterHelper
 		$query = $db->getQuery(true)
 			->select('COUNT(*)')
 			->from($db->quoteName('#__csp'))
-			->where($db->quoteName('blocked_uri'). ' = ' . $db->quote("'unsafe-inline'"))
+			->where($db->quoteName('blocked_uri') . ' = ' . $db->quote("'unsafe-inline'"))
 			->where($db->quoteName('published') . ' = ' . $db->quote('1'));
 		$db->setQuery($query);
 

--- a/administrator/components/com_csp/src/Helper/ReporterHelper.php
+++ b/administrator/components/com_csp/src/Helper/ReporterHelper.php
@@ -126,7 +126,7 @@ class ReporterHelper
 			->select('COUNT(*)')
 			->from($db->quoteName('#__csp'))
 			->where($db->quoteName('blocked_uri') . ' = ' . $db->quote("'unsafe-eval'"))
-			->where($db->quoteName('published') . ' = ' . $db->quote('1'));
+			->where($db->quoteName('published') . ' = 1'));
 		$db->setQuery($query);
 
 		try

--- a/administrator/components/com_csp/src/Helper/ReporterHelper.php
+++ b/administrator/components/com_csp/src/Helper/ReporterHelper.php
@@ -95,7 +95,7 @@ class ReporterHelper
 			->select('COUNT(*)')
 			->from($db->quoteName('#__csp'))
 			->where($db->quoteName('blocked_uri') . ' = ' . $db->quote("'unsafe-inline'"))
-			->where($db->quoteName('published') . ' = 1'));
+			->where($db->quoteName('published') . ' = 1');
 		$db->setQuery($query);
 
 		try

--- a/administrator/components/com_csp/src/View/Reports/HtmlView.php
+++ b/administrator/components/com_csp/src/View/Reports/HtmlView.php
@@ -103,11 +103,25 @@ class HtmlView extends BaseHtmlView
 			$this->httpHeadersId = ReporterHelper::getHttpHeadersPluginId();
 		}
 
-		if (ComponentHelper::getParams('com_csp')->get('contentsecuritypolicy_mode', 'custom') === 'detect'
+		if (ComponentHelper::getParams('com_csp')->get('contentsecuritypolicy_mode', 'detect') === 'detect'
 			&& ComponentHelper::getParams('com_csp')->get('contentsecuritypolicy', 0)
 			&& ReporterHelper::getCspTrashStatus())
 		{
 			$this->trashWarningMessage = Text::_('COM_CSP_COLLECTING_TRASH_WARNING');
+		}
+
+		if (ComponentHelper::getParams('com_csp')->get('contentsecuritypolicy_mode', 'detect') === 'auto'
+			&& ComponentHelper::getParams('com_csp')->get('contentsecuritypolicy', 0)
+			&& ReporterHelper::getCspUnsafeInlineStatus())
+		{
+			$this->unsafeInlineWarningMessage = Text::_('COM_CSP_AUTO_UNSAFE_INLINE_WARNING');
+		}
+
+		if (ComponentHelper::getParams('com_csp')->get('contentsecuritypolicy_mode', 'detect') === 'auto'
+			&& ComponentHelper::getParams('com_csp')->get('contentsecuritypolicy', 0)
+			&& ReporterHelper::getCspUnsafeEvalStatus())
+		{
+			$this->unsafeEvalWarningMessage = Text::_('COM_CSP_AUTO_UNSAFE_EVAL_WARNING');
 		}
 
 		$this->addToolbar();

--- a/administrator/components/com_csp/tmpl/reports/default.php
+++ b/administrator/components/com_csp/tmpl/reports/default.php
@@ -57,6 +57,12 @@ $saveOrder = $listOrder == 'a.id';
 				<?php if (isset($this->trashWarningMessage)) : ?>
 					<?php Factory::getApplication()->enqueueMessage($this->trashWarningMessage, 'warning'); ?>
 				<?php endif; ?>
+				<?php if (isset($this->unsafeInlineWarningMessage)) : ?>
+					<?php Factory::getApplication()->enqueueMessage($this->unsafeInlineWarningMessage, 'warning'); ?>
+				<?php endif; ?>
+				<?php if (isset($this->unsafeEvalWarningMessage)) : ?>
+					<?php Factory::getApplication()->enqueueMessage($this->unsafeEvalWarningMessage, 'warning'); ?>
+				<?php endif; ?>
 				<?php if (empty($this->items)) : ?>
 					<div class="alert alert-info">
 						<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>

--- a/administrator/language/en-GB/com_csp.ini
+++ b/administrator/language/en-GB/com_csp.ini
@@ -4,6 +4,8 @@
 ; Note : All ini files need to be saved as UTF-8
 
 COM_CSP="Content Security Policy"
+COM_CSP_AUTO_UNSAFE_EVAL_WARNING="You have configured a rule that still allows 'unsafe-eval' this bypasses the Content Security Policy and allows the execution of code injected into DOM APIs such as eval()."
+COM_CSP_AUTO_UNSAFE_INLINE_WARNING="You have configured a rule that still allows 'unsafe-inline' this bypasses the Content Security Policy and allows the execution of unsafe in-page scripts and event handlers."
 COM_CSP_COLLECTING_TRASH_WARNING="The Content Security Policy is in detect mode. Items that have been trashed will not be detected again until they are removed from the trash."
 COM_CSP_CONFIGURATION="Content Security Policy: Options"
 ; Please do not translate the following language string

--- a/administrator/language/en-GB/com_csp.ini
+++ b/administrator/language/en-GB/com_csp.ini
@@ -4,8 +4,8 @@
 ; Note : All ini files need to be saved as UTF-8
 
 COM_CSP="Content Security Policy"
-COM_CSP_AUTO_UNSAFE_EVAL_WARNING="You have configured a rule that still allows 'unsafe-eval' this bypasses the Content Security Policy and allows the execution of code injected into DOM APIs such as eval()."
-COM_CSP_AUTO_UNSAFE_INLINE_WARNING="You have configured a rule that still allows 'unsafe-inline' this bypasses the Content Security Policy and allows the execution of unsafe in-page scripts and event handlers."
+COM_CSP_AUTO_UNSAFE_EVAL_WARNING="You have configured a rule that still allows 'unsafe-eval' that bypasses the Content Security Policy and allows the execution of code injected into DOM APIs such as eval()."
+COM_CSP_AUTO_UNSAFE_INLINE_WARNING="You have configured a rule that still allows 'unsafe-inline' that bypasses the Content Security Policy and allows the execution of unsafe in-page scripts and event handlers."
 COM_CSP_COLLECTING_TRASH_WARNING="The Content Security Policy is in detect mode. Items that have been trashed will not be detected again until they are removed from the trash."
 COM_CSP_CONFIGURATION="Content Security Policy: Options"
 ; Please do not translate the following language string


### PR DESCRIPTION
### Summary of Changes

Issue warnings when unsafe-inline or unsafe-eval are used in auto mode

### Testing Instructions

- apply this patch
- switch com_csp in detect mode
- visit the frontend with eval and or inline css usage
- publish the collected reports about unsafe-inine / unsafe-eval
- switch com_csp to auto mode


### Expected result

You get a warning as this bypasses the CSP

![image](https://user-images.githubusercontent.com/2596554/84582459-7d0b4880-adec-11ea-94cf-2fec32634de6.png)

### Actual result

You get no info about that bypass.

### Documentation Changes Required

Yes.
https://help.joomla.org/proxy?keyref=Help40:Components_CSP_Reports_Options && https://help.joomla.org/proxy?keyref=J4.x:Http_Header_Management

### Acknowledgements

Warnings / Message text based on https://csp-evaluator.withgoogle.com/
`'unsafe-inline' allows the execution of unsafe in-page scripts and event handlers.`
`'unsafe-eval' allows the execution of code injected into DOM APIs such as eval().`