### PR TITLE
Clear backend cache when purging the updates

### DIFF
--- a/administrator/components/com_installer/models/update.php
+++ b/administrator/components/com_installer/models/update.php
@@ -292,6 +292,10 @@ class InstallerModelUpdate extends JModelList
 			->set($db->quoteName('last_check_timestamp') . ' = ' . $db->quote(0));
 		$db->setQuery($query);
 		$db->execute();
+
+		// Clear the administrator cache
+		$this->cleanCache('_system', 1);
+
 		$this->_message = JText::_('JLIB_INSTALLER_PURGED_UPDATES');
 
 		return true;


### PR DESCRIPTION
### Summary of Changes

Clear backend cache when purging the updates

### Testing Instructions

- enable caching
- apply this patch
- got to com_installer -> updates
- hit `clear cache`
- check the administrator/cache/_system folder creation dates of the files it should be a fresh version.

### Expected result

now also the backend caches are cleared

### Actual result

right now the backend caches are not cleared.

### Documentation Changes Required

none

### Mentions

@nikosdion sorry that it took that long to get back to you on this. Please confirm that this is what you had in mind regarding that method. The other two things truncate #__updates and set the last check to zero is already done in the existing code.