### PR TITLE
Fix undefined index for user token plugin

### DIFF
--- a/plugins/user/token/token.php
+++ b/plugins/user/token/token.php
@@ -171,9 +171,9 @@ class PlgUserToken extends CMSPlugin
 		 */
 		if (($context === 'com_users.profile') && ($this->app->input->get('layout') !== 'edit'))
 		{
-			$pluginData = $data->{$this->profileKeyPrefix};
-			$enabled    = $pluginData['enabled'];
-			$token      = $pluginData['token'];
+			$pluginData = $data->{$this->profileKeyPrefix} ?? [];
+			$enabled    = $pluginData['enabled'] ?? false;
+			$token      = $pluginData['token'] ?? '';
 
 			$pluginData['enabled'] = Text::_('JDISABLED');
 			$pluginData['token']   = '';


### PR DESCRIPTION
Pull Request for Issue #29591.

### Summary of Changes

Fixed PHP notice about undefined index when viewing the user profile before creating a Joomla API token.

### Testing Instructions

Clean install 4.0-dev. Set error reporting to maximum. Go to the frontend profile page.

### Expected result

No PHP errors displayed.

### Actual result

PHP Notice, Undefined index: enabled in .../plugins/user/token/token.php on line 174

### Documentation Changes Required

None