### PR TITLE
Fix for Note form field displaying description

### DIFF
--- a/layouts/joomla/form/renderfield.php
+++ b/layouts/joomla/form/renderfield.php
@@ -39,7 +39,7 @@ $hide  = empty($options['hiddenLabel']) ? '' : ' sr-only';
 	<div class="control-label<?php echo $hide; ?>"><?php echo $label; ?></div>
 	<div class="controls">
 		<?php echo $input; ?>
-		<?php if (!empty($description)) : ?>
+		<?php if (!empty($description) && $field->type !== 'Note') : ?>
 			<div id="<?php echo $id; ?>">
 				<small class="form-text text-muted">
 					<?php echo $description; ?>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
The Note field is used to display a note to the user in the configuration. The text in the note field comes from the description parameter.


### Testing Instructions
Add a note field to e.g. a plugin config file with a label and description
verify that the description is both set in the note field as well as below the notefield as the 'description'
install this PR
verify that the description below the notefield is not displayed, but that all other descriptions on non-note fields are displayed


### Expected result
The notefield should be displayed without the additional description below the note field (which is the same text as the note field itself)
![Selection_002](https://user-images.githubusercontent.com/2733197/84590650-ac47a700-ae38-11ea-8927-07a33d286a40.jpg)



### Actual result
The description displays below the notefield as a description text doubling the information on the screen

![Selection_001](https://user-images.githubusercontent.com/2733197/84590634-93d78c80-ae38-11ea-92d1-151802d01a27.jpg)


### Documentation Changes Required
no
