### PR TITLE
[3.x] Fix language strings for robots options

### DIFF
--- a/administrator/language/en-GB/en-GB.ini
+++ b/administrator/language/en-GB/en-GB.ini
@@ -429,9 +429,9 @@ JGLOBAL_HISTORY_LIMIT_OPTIONS_LABEL="Maximum Versions"
 JGLOBAL_HITS="Hits"
 JGLOBAL_HITS_ASC="Hits ascending"
 JGLOBAL_HITS_DESC="Hits descending"
-; The string below shall not be translated
+; Please do not translate the following language string
 JGLOBAL_INDEX_FOLLOW="index, follow"
-; The string below shall not be translated
+; Please do not translate the following language string
 JGLOBAL_INDEX_NOFOLLOW="index, nofollow"
 JGLOBAL_INHERIT="Inherit"
 JGLOBAL_INTEGRATION_LABEL="Integration"
@@ -485,9 +485,9 @@ JGLOBAL_NEWITEMSFIRST_DESC="New items default to the first position. The orderin
 JGLOBAL_NEWITEMSLAST_DESC="New items default to the last position. The ordering can be changed after this item is saved."
 JGLOBAL_NO_ITEM_SELECTED="No items selected"
 JGLOBAL_NO_ORDER="No Order"
-; The string below shall not be translated
+; Please do not translate the following language string
 JGLOBAL_NOINDEX_FOLLOW="noindex, follow"
-; The string below shall not be translated
+; Please do not translate the following language string
 JGLOBAL_NOINDEX_NOFOLLOW="noindex, nofollow"
 JGLOBAL_NONAPPLICABLE="N/A"
 JGLOBAL_NUM_COLUMNS_DESC="The number of columns in which to show Intro Articles. Normally 1, 2, or 3."

--- a/administrator/language/en-GB/en-GB.ini
+++ b/administrator/language/en-GB/en-GB.ini
@@ -429,8 +429,10 @@ JGLOBAL_HISTORY_LIMIT_OPTIONS_LABEL="Maximum Versions"
 JGLOBAL_HITS="Hits"
 JGLOBAL_HITS_ASC="Hits ascending"
 JGLOBAL_HITS_DESC="Hits descending"
-JGLOBAL_INDEX_FOLLOW="Index, Follow"
-JGLOBAL_INDEX_NOFOLLOW="Index, No follow"
+; In the string below the terms 'index' and 'follow' should not be translated
+JGLOBAL_INDEX_FOLLOW="index, follow"
+; In the string below the terms 'index' and 'nofollow' should not be translated
+JGLOBAL_INDEX_NOFOLLOW="index, nofollow"
 JGLOBAL_INHERIT="Inherit"
 JGLOBAL_INTEGRATION_LABEL="Integration"
 JGLOBAL_INTRO_TEXT="Intro Text"
@@ -483,8 +485,10 @@ JGLOBAL_NEWITEMSFIRST_DESC="New items default to the first position. The orderin
 JGLOBAL_NEWITEMSLAST_DESC="New items default to the last position. The ordering can be changed after this item is saved."
 JGLOBAL_NO_ITEM_SELECTED="No items selected"
 JGLOBAL_NO_ORDER="No Order"
-JGLOBAL_NOINDEX_FOLLOW="No index, follow"
-JGLOBAL_NOINDEX_NOFOLLOW="No index, no follow"
+; In the string below the terms 'noindex' and 'follow' should not be translated
+JGLOBAL_NOINDEX_FOLLOW="noindex, follow"
+; In the string below the terms 'noindex' and 'nofollow' should not be translated
+JGLOBAL_NOINDEX_NOFOLLOW="noindex, nofollow"
 JGLOBAL_NONAPPLICABLE="N/A"
 JGLOBAL_NUM_COLUMNS_DESC="The number of columns in which to show Intro Articles. Normally 1, 2, or 3."
 JGLOBAL_NUM_COLUMNS_LABEL="# Columns"

--- a/administrator/language/en-GB/en-GB.ini
+++ b/administrator/language/en-GB/en-GB.ini
@@ -429,9 +429,9 @@ JGLOBAL_HISTORY_LIMIT_OPTIONS_LABEL="Maximum Versions"
 JGLOBAL_HITS="Hits"
 JGLOBAL_HITS_ASC="Hits ascending"
 JGLOBAL_HITS_DESC="Hits descending"
-; In the string below the terms 'index' and 'follow' should not be translated
+; The string below shall not be translated
 JGLOBAL_INDEX_FOLLOW="index, follow"
-; In the string below the terms 'index' and 'nofollow' should not be translated
+; The string below shall not be translated
 JGLOBAL_INDEX_NOFOLLOW="index, nofollow"
 JGLOBAL_INHERIT="Inherit"
 JGLOBAL_INTEGRATION_LABEL="Integration"
@@ -485,9 +485,9 @@ JGLOBAL_NEWITEMSFIRST_DESC="New items default to the first position. The orderin
 JGLOBAL_NEWITEMSLAST_DESC="New items default to the last position. The ordering can be changed after this item is saved."
 JGLOBAL_NO_ITEM_SELECTED="No items selected"
 JGLOBAL_NO_ORDER="No Order"
-; In the string below the terms 'noindex' and 'follow' should not be translated
+; The string below shall not be translated
 JGLOBAL_NOINDEX_FOLLOW="noindex, follow"
-; In the string below the terms 'noindex' and 'nofollow' should not be translated
+; The string below shall not be translated
 JGLOBAL_NOINDEX_NOFOLLOW="noindex, nofollow"
 JGLOBAL_NONAPPLICABLE="N/A"
 JGLOBAL_NUM_COLUMNS_DESC="The number of columns in which to show Intro Articles. Normally 1, 2, or 3."


### PR DESCRIPTION
Pull Request for Issue #29595 .

### Summary of Changes

See [https://github.com/joomla/joomla-cms/issues/29595#issuecomment-643786681](https://github.com/joomla/joomla-cms/issues/29595#issuecomment-643786681).

### Testing Instructions

Code review plus check diverse places where robots options appear (e.g. Global Configuration, tab "Site", section "Robots").

### Expected result

The options are shown like they are specified to be used in the robots meta tag, see e.g. [https://developers.google.com/search/reference/robots_meta_tag?hl=en](https://developers.google.com/search/reference/robots_meta_tag?hl=en).

They are marked in the language file by a comment as not to be translated.

### Actual result

The robots option values are an inconsistent mix of upper and lowercase spelling.

They are not marked in the language file by a comment as not to be translated, so they might be translated by translation teams to anything.

### Documentation Changes Required

None.