### PR TITLE
[4.0] Fix language strings for robots options

### DIFF
--- a/administrator/language/en-GB/joomla.ini
+++ b/administrator/language/en-GB/joomla.ini
@@ -443,9 +443,9 @@ JGLOBAL_HISTORY_LIMIT_OPTIONS_LABEL="Maximum Versions"
 JGLOBAL_HITS="Hits"
 JGLOBAL_HITS_ASC="Hits ascending"
 JGLOBAL_HITS_DESC="Hits descending"
-; The string below shall not be translated
+; Please do not translate the following language string
 JGLOBAL_INDEX_FOLLOW="index, follow"
-; The string below shall not be translated
+; Please do not translate the following language string
 JGLOBAL_INDEX_NOFOLLOW="index, nofollow"
 JGLOBAL_INHERIT="Inherit"
 JGLOBAL_INTEGRATION_LABEL="Integration"
@@ -499,9 +499,9 @@ JGLOBAL_NEWITEMSFIRST_DESC="New items default to the first position. The orderin
 JGLOBAL_NEWITEMSLAST_DESC="New items default to the last position. The ordering can be changed after this item is saved."
 JGLOBAL_NO_ITEM_SELECTED="No items selected"
 JGLOBAL_NO_ORDER="No Order"
-; The string below shall not be translated
+; Please do not translate the following language string
 JGLOBAL_NOINDEX_FOLLOW="noindex, follow"
-; The string below shall not be translated
+; Please do not translate the following language string
 JGLOBAL_NOINDEX_NOFOLLOW="noindex, nofollow"
 JGLOBAL_NONAPPLICABLE="N/A"
 JGLOBAL_NUM_INTRO_ARTICLES_DESC="Number of articles to show after the leading article. Articles will be shown in columns."

--- a/administrator/language/en-GB/joomla.ini
+++ b/administrator/language/en-GB/joomla.ini
@@ -443,8 +443,10 @@ JGLOBAL_HISTORY_LIMIT_OPTIONS_LABEL="Maximum Versions"
 JGLOBAL_HITS="Hits"
 JGLOBAL_HITS_ASC="Hits ascending"
 JGLOBAL_HITS_DESC="Hits descending"
-JGLOBAL_INDEX_FOLLOW="Index, Follow"
-JGLOBAL_INDEX_NOFOLLOW="Index, No follow"
+; The string below shall not be translated
+JGLOBAL_INDEX_FOLLOW="index, follow"
+; The string below shall not be translated
+JGLOBAL_INDEX_NOFOLLOW="index, nofollow"
 JGLOBAL_INHERIT="Inherit"
 JGLOBAL_INTEGRATION_LABEL="Integration"
 JGLOBAL_INTRO_TEXT="Intro Text"
@@ -497,8 +499,10 @@ JGLOBAL_NEWITEMSFIRST_DESC="New items default to the first position. The orderin
 JGLOBAL_NEWITEMSLAST_DESC="New items default to the last position. The ordering can be changed after this item is saved."
 JGLOBAL_NO_ITEM_SELECTED="No items selected"
 JGLOBAL_NO_ORDER="No Order"
-JGLOBAL_NOINDEX_FOLLOW="No index, follow"
-JGLOBAL_NOINDEX_NOFOLLOW="No index, no follow"
+; The string below shall not be translated
+JGLOBAL_NOINDEX_FOLLOW="noindex, follow"
+; The string below shall not be translated
+JGLOBAL_NOINDEX_NOFOLLOW="noindex, nofollow"
 JGLOBAL_NONAPPLICABLE="N/A"
 JGLOBAL_NUM_INTRO_ARTICLES_DESC="Number of articles to show after the leading article. Articles will be shown in columns."
 JGLOBAL_NUM_INTRO_ARTICLES_LABEL="# Intro Articles"

--- a/api/language/en-GB/joomla.ini
+++ b/api/language/en-GB/joomla.ini
@@ -436,9 +436,9 @@ JGLOBAL_HISTORY_LIMIT_OPTIONS_LABEL="Maximum Versions"
 JGLOBAL_HITS="Hits"
 JGLOBAL_HITS_ASC="Hits ascending"
 JGLOBAL_HITS_DESC="Hits descending"
-; The string below shall not be translated
+; Please do not translate the following language string
 JGLOBAL_INDEX_FOLLOW="index, follow"
-; The string below shall not be translated
+; Please do not translate the following language string
 JGLOBAL_INDEX_NOFOLLOW="index, nofollow"
 JGLOBAL_INHERIT="Inherit"
 JGLOBAL_INTEGRATION_LABEL="Integration"
@@ -492,9 +492,9 @@ JGLOBAL_NEWITEMSFIRST_DESC="New items default to the first position. The orderin
 JGLOBAL_NEWITEMSLAST_DESC="New items default to the last position. The ordering can be changed after this item is saved."
 JGLOBAL_NO_ITEM_SELECTED="No items selected"
 JGLOBAL_NO_ORDER="No Order"
-; The string below shall not be translated
+; Please do not translate the following language string
 JGLOBAL_NOINDEX_FOLLOW="noindex, follow"
-; The string below shall not be translated
+; Please do not translate the following language string
 JGLOBAL_NOINDEX_NOFOLLOW="noindex, nofollow"
 JGLOBAL_NONAPPLICABLE="N/A"
 JGLOBAL_NUM_INTRO_ARTICLES_DESC="Number of articles to show after the leading article. Articles will be shown in columns."

--- a/api/language/en-GB/joomla.ini
+++ b/api/language/en-GB/joomla.ini
@@ -436,8 +436,10 @@ JGLOBAL_HISTORY_LIMIT_OPTIONS_LABEL="Maximum Versions"
 JGLOBAL_HITS="Hits"
 JGLOBAL_HITS_ASC="Hits ascending"
 JGLOBAL_HITS_DESC="Hits descending"
-JGLOBAL_INDEX_FOLLOW="Index, Follow"
-JGLOBAL_INDEX_NOFOLLOW="Index, No follow"
+; The string below shall not be translated
+JGLOBAL_INDEX_FOLLOW="index, follow"
+; The string below shall not be translated
+JGLOBAL_INDEX_NOFOLLOW="index, nofollow"
 JGLOBAL_INHERIT="Inherit"
 JGLOBAL_INTEGRATION_LABEL="Integration"
 JGLOBAL_INTRO_TEXT="Intro Text"
@@ -490,8 +492,10 @@ JGLOBAL_NEWITEMSFIRST_DESC="New items default to the first position. The orderin
 JGLOBAL_NEWITEMSLAST_DESC="New items default to the last position. The ordering can be changed after this item is saved."
 JGLOBAL_NO_ITEM_SELECTED="No items selected"
 JGLOBAL_NO_ORDER="No Order"
-JGLOBAL_NOINDEX_FOLLOW="No index, follow"
-JGLOBAL_NOINDEX_NOFOLLOW="No index, no follow"
+; The string below shall not be translated
+JGLOBAL_NOINDEX_FOLLOW="noindex, follow"
+; The string below shall not be translated
+JGLOBAL_NOINDEX_NOFOLLOW="noindex, nofollow"
 JGLOBAL_NONAPPLICABLE="N/A"
 JGLOBAL_NUM_INTRO_ARTICLES_DESC="Number of articles to show after the leading article. Articles will be shown in columns."
 JGLOBAL_NUM_INTRO_ARTICLES_LABEL="# Intro Articles"


### PR DESCRIPTION
Pull Request for Issue #29595 .

### Summary of Changes

See [https://github.com/joomla/joomla-cms/issues/29595#issuecomment-643786681](https://github.com/joomla/joomla-cms/issues/29595#issuecomment-643786681).

Same as #29612 does for J3, but this here is for J4.

### Testing Instructions

Code review plus check diverse places where robots options appear (e.g. Global Configuration, tab "Site", section "Robots").

### Expected result

The options are shown like they are specified to be used in the robots meta tag, see e.g. [https://developers.google.com/search/reference/robots_meta_tag?hl=en](https://developers.google.com/search/reference/robots_meta_tag?hl=en).

They are marked in the language file by a comment as not to be translated.

### Actual result

The robots option values are an inconsistent mix of upper and lowercase spelling.

They are not marked in the language file by a comment as not to be translated, so they might be translated by translation teams to anything.

### Documentation Changes Required

None.