### PR TITLE
[Fix] Properly use sublayout

### DIFF
--- a/layouts/joomla/searchtools/default.php
+++ b/layouts/joomla/searchtools/default.php
@@ -83,7 +83,7 @@ JHtml::_('searchtools.form', $data['options']['formSelector'], $data['options'])
 	<div class="clearfix">
 		<?php if ($data['options']['showSelector']) : ?>
 		<div class="js-stools-container-selector">
-			<?php echo JLayoutHelper::render('joomla.searchtools.default.selector', $data); ?>
+			<?php echo $this->sublayout('selector', $data); ?>
 		</div>
 		<?php endif; ?>
 		<div class="js-stools-container-bar">


### PR DESCRIPTION
### Summary of Changes
In case of `searchtools.default` the sublayout `selector` not calling by `$this->sublayout`. The main benefit of this is that it makes it easier to override parts of a layout and debug.

### Testing Instructions
Check that the layouts are still rendering as expected.
The `searchtools.default.selector` layout renders the search tool selector at the top of list pages in the administrator (e.g. com_modules/modules)

### Documentation Changes Required
No
