### PR TITLE
[4.0] Use update description from update XML

### DIFF
--- a/administrator/components/com_installer/src/Model/UpdateModel.php
+++ b/administrator/components/com_installer/src/Model/UpdateModel.php
@@ -202,7 +202,7 @@ class UpdateModel extends ListModel
 			$item->client_translated  = Text::_([0 => 'JSITE', 1 => 'JADMINISTRATOR', 3 => 'JAPI'][$item->client_id] ?? 'JSITE');
 			$manifest                 = json_decode($item->manifest_cache);
 			$item->current_version    = $manifest->version ?? Text::_('JLIB_UNKNOWN');
-			$item->description        = $manifest->description ?? Text::_('COM_INSTALLER_MSG_UPDATE_NODESC');
+			$item->description        = $item->description ?? Text::_('COM_INSTALLER_MSG_UPDATE_NODESC');
 			$item->type_translated    = Text::_('COM_INSTALLER_TYPE_' . strtoupper($item->type));
 			$item->folder_translated  = $item->folder ?: Text::_('COM_INSTALLER_TYPE_NONAPPLICABLE');
 			$item->install_type       = $item->extension_id ? Text::_('COM_INSTALLER_MSG_UPDATE_UPDATE') : Text::_('COM_INSTALLER_NEW_INSTALL');

--- a/administrator/components/com_installer/src/Model/UpdateModel.php
+++ b/administrator/components/com_installer/src/Model/UpdateModel.php
@@ -202,7 +202,7 @@ class UpdateModel extends ListModel
 			$item->client_translated  = Text::_([0 => 'JSITE', 1 => 'JADMINISTRATOR', 3 => 'JAPI'][$item->client_id] ?? 'JSITE');
 			$manifest                 = json_decode($item->manifest_cache);
 			$item->current_version    = $manifest->version ?? Text::_('JLIB_UNKNOWN');
-			$item->description        = $item->description ?? Text::_('COM_INSTALLER_MSG_UPDATE_NODESC');
+			$item->description        = $item->description !== '' ? $item->description : Text::_('COM_INSTALLER_MSG_UPDATE_NODESC');
 			$item->type_translated    = Text::_('COM_INSTALLER_TYPE_' . strtoupper($item->type));
 			$item->folder_translated  = $item->folder ?: Text::_('COM_INSTALLER_TYPE_NONAPPLICABLE');
 			$item->install_type       = $item->extension_id ? Text::_('COM_INSTALLER_MSG_UPDATE_UPDATE') : Text::_('COM_INSTALLER_NEW_INSTALL');


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/29039. Alternative PR to https://github.com/joomla/joomla-cms/pull/29067.

### Summary of Changes

Changes update description to use description from remote XML file instead of extension manifest.

### Testing Instructions

Install some extension that uses updater, e.g. this https://github.com/C-Lodder/joomla4-backend-template/releases/download/v0.0.14/tpl_bettum-v0.0.14.zip.
Check for updates.
Hover over the update to see a tooltip.

### Expected result

>A dark themed administrator template for Joomla 4

### Actual result

>TPL_BETTUM_XML_DESCRIPTION


### Documentation Changes Required

No.