### PR TITLE
[4.0] Updates without description not working

### DIFF
--- a/libraries/src/Table/Update.php
+++ b/libraries/src/Table/Update.php
@@ -68,6 +68,12 @@ class Update extends Table
 			$this->data = '';
 		}
 
+		// While column is not nullable, make sure we have a value.
+		if ($this->description === null)
+		{
+			$this->description = '';
+		}
+
 		return true;
 	}
 


### PR DESCRIPTION
### Summary of Changes

Fixes error when storing update information with missing description. According to [documentation](https://docs.joomla.org/Deploying_an_Update_Server), description is optional.

### Testing Instructions

Install this dummy plugin [plg_system_dummy.zip](https://github.com/joomla/joomla-cms/files/4778871/plg_system_dummy.zip)
Place this file so it can be accessed through `http://localhost/testing/dummy.xml`:

```
<updates>
	<update>
		<name>Dummy Plugin</name>
		<element>dummy</element>
		<folder>system</folder>
		<type>plugin</type>
		<version>0.0.2</version>
		<downloads>
			<downloadurl type="full" format="zip">http://localhost/downloads/dummy_0.0.2.zip</downloadurl>
		</downloads>
		<maintainer>Localhost</maintainer>
		<maintainerurl>http://localhost</maintainerurl>
		<targetplatform name="joomla" version="."/>
		<client>site</client>
	</update>
</updates>

```
Check for updates.

### Expected result

Plugin update found.

### Actual result

Plugin update not found.

### Documentation Changes Required

No.