### PR TITLE
[4.0][api][com_content] render the image field

### DIFF
--- a/administrator/components/com_content/src/Model/ArticlesModel.php
+++ b/administrator/components/com_content/src/Model/ArticlesModel.php
@@ -260,6 +260,7 @@ class ArticlesModel extends ListModel
 					$db->quoteName('a.introtext'),
 					$db->quoteName('a.fulltext'),
 					$db->quoteName('a.note'),
+					$db->quoteName('a.images'),
 				]
 			)
 		)

--- a/api/components/com_content/src/Helper/ContentHelper.php
+++ b/api/components/com_content/src/Helper/ContentHelper.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * @package     Joomla.Api
+ * @subpackage  com_content
+ *
+ * @copyright   Copyright (C) 2005 - 2020 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\Component\Content\Api\Helper;
+
+\defined('_JEXEC') or die;
+
+use Joomla\CMS\Uri\Uri;
+
+/**
+ * Content api helper.
+ *
+ * @since  4.0
+ */
+class ContentHelper
+{
+	/**
+	 * Fully Qualified Domain name for the image url
+	 *
+	 * @param   string  $uri      The uri to resolve
+	 *
+	 * @return  string
+	 */
+	public static function resolve(string $uri): string
+	{
+		// Check if external URL.
+		if (stripos($uri, 'http') !== 0)
+		{
+			return Uri::root() . $uri;
+		}
+
+		return $uri;
+	}
+}

--- a/api/components/com_content/src/View/Articles/JsonapiView.php
+++ b/api/components/com_content/src/View/Articles/JsonapiView.php
@@ -15,8 +15,10 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\MVC\View\JsonApiView as BaseApiView;
 use Joomla\CMS\Plugin\PluginHelper;
+use Joomla\Component\Content\Api\Helper\ContentHelper;
 use Joomla\Component\Content\Api\Serializer\ContentSerializer;
 use Joomla\Component\Fields\Administrator\Helper\FieldsHelper;
+use Joomla\Registry\Registry;
 
 /**
  * The article view
@@ -43,6 +45,7 @@ class JsonapiView extends BaseApiView
 		'category',
 		'created',
 		'author',
+		'images',
 	];
 
 	/**
@@ -63,6 +66,7 @@ class JsonapiView extends BaseApiView
 		'category',
 		'created',
 		'author',
+		'images',
 	];
 
 	/**
@@ -187,6 +191,22 @@ class JsonapiView extends BaseApiView
 		else
 		{
 			$item->tags = [];
+		}
+
+		if (isset($item->images))
+		{
+			$registry = new Registry($item->images);
+			$item->images = $registry->toArray();
+
+			if (!empty($item->images['image_intro']))
+			{
+				$item->images['image_intro'] = ContentHelper::resolve($item->images['image_intro']);
+			}
+
+			if (!empty($item->images['image_fulltext']))
+			{
+				$item->images['image_fulltext'] = ContentHelper::resolve($item->images['image_fulltext']);
+			}
 		}
 
 		return parent::prepareItem($item);


### PR DESCRIPTION
redo of #29020


### Summary of Changes
 render the image field

### Testing Instructions
edit an article
add an Intro Image and/or Full Article Image
save
 call the api 
`{{base_url}}api/index.php/v1/content/article`


### Expected result
the image field are rendered
![Screenshot from 2020-05-10 12-12-47](https://user-images.githubusercontent.com/181681/81496384-ad286e80-92b7-11ea-9a4a-86329b9872aa.png)


### Actual result

N/A

### Documentation Changes Required

