### PR TITLE
[4.0] Fix Installation language strings

### DIFF
--- a/installation/language/en-GB/joomla.ini
+++ b/installation/language/en-GB/joomla.ini
@@ -3,30 +3,28 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt
 ; Note : All ini files need to be saved as UTF-8
 
-;Build incomplete error page
-;These will be processed by the JavaScript Build
-BUILD_INCOMPLETE_LANGUAGE="English GB"
+; Build incomplete error page
+; These will be processed by the JavaScript Build
 BUILD_INCOMPLETE_HEADER="Environment Setup Incomplete"
+BUILD_INCOMPLETE_LANGUAGE="English GB"
 BUILD_INCOMPLETE_TEXT="It looks like you are trying to run Joomla! from our git repository. To do so requires you complete a couple of extra steps first."
 BUILD_INCOMPLETE_URL_TEXT="More Details"
-;End of build incomplete error page
 
-;Minimum PHP error page
-;These will be processed by the JavaScript Build
+; Minimum PHP error page
+; These will be processed by the JavaScript Build
+MIN_PHP_ERROR_HEADER="Sorry, your PHP version is not supported."
 MIN_PHP_ERROR_LANGUAGE="English GB"
-MIN_PHP_ERROR_HEADER="Sorry, your PHP version is not supported"
-MIN_PHP_ERROR_TEXT="Your host needs to use PHP version {{phpversion}} or newer to run this version of Joomla"
+MIN_PHP_ERROR_TEXT="Your host needs to use PHP version {{phpversion}} or newer to run this version of Joomla."
 MIN_PHP_ERROR_URL_TEXT="Help me resolve this"
-;End of minimum PHP error page
 
-;Main Config
+; Main Config
 INSTL_SELECT_INSTALL_LANG="Select Installation Language"
 INSTL_SELECT_LANGUAGE_TITLE="Select Language"
-INSTL_WARNJAVASCRIPT="Warning! JavaScript must be enabled for proper installation of Joomla"
-INSTL_WARNJSON="Your PHP installation needs to have JSON enabled for Joomla to be installed!"
 INSTL_SETUP_LOGIN_DATA="Setup Login Data"
+INSTL_WARNJAVASCRIPT="Warning! JavaScript must be enabled for proper installation of Joomla."
+INSTL_WARNJSON="Your PHP installation needs to have JSON enabled for Joomla to be installed!"
 
-;Precheck view
+; Precheck view
 INSTL_DATABASE_SUPPORT="Database Support:"
 INSTL_JSON_SUPPORT_AVAILABLE="JSON Support"
 INSTL_MB_LANGUAGE_IS_DEFAULT="MB Language is Default"
@@ -67,14 +65,14 @@ INSTL_DATABASE_ENCRYPTION_MSG_SRV_NOT_SUPPORTS="The database server doesn't supp
 INSTL_DATABASE_ENCRYPTION_VERIFY_SERVER_CERT_LABEL="Verify Server Certificate"
 INSTL_DATABASE_ERROR_POSTGRESQL_QUERY="PostgreSQL database query failed."
 INSTL_DATABASE_HOST_DESC="Enter the host name, usually \"localhost\" or a name provided by your host."
-INSTL_DATABASE_HOST_LABEL="Host Name"
 INSTL_DATABASE_HOST_IS_NOT_LOCALHOST_CREATE_FILE="We were not able to create the file. Please manually create a file named \"%1$s\" and upload it to the \"%2$s\" folder of your Joomla site. Then select \"%3$s\" to continue."
 INSTL_DATABASE_HOST_IS_NOT_LOCALHOST_DELETE_FILE="To confirm that you are the owner of this website please delete the file named \"%1$s\" we have created in the \"%2$s\" folder of your Joomla site. Then select \"%3$s\" to continue."
 INSTL_DATABASE_HOST_IS_NOT_LOCALHOST_GENERAL_MESSAGE="You are trying to use a database host which is not on your local server. For security reasons, you need to verify the ownership of your web hosting account. <a href=\"%s\">Please read the documentation</a> for more information."
+INSTL_DATABASE_HOST_LABEL="Host Name"
 INSTL_DATABASE_NAME_DESC="Enter the database name."
 INSTL_DATABASE_NAME_LABEL="Database Name"
-INSTL_DATABASE_NAME_MSG_POSTGRES="The database name is invalid. It must start with a letter, followed by alphanumeric characters."
 INSTL_DATABASE_NAME_MSG_MYSQL="The database name is invalid. It must not contain the following characters: \ / ."
+INSTL_DATABASE_NAME_MSG_POSTGRES="The database name is invalid. It must start with a letter, followed by alphanumeric characters."
 INSTL_DATABASE_NO_SCHEMA="No database schema exists for this database type."
 INSTL_DATABASE_PASSWORD_DESC="Either a password you created or a password provided by your host."
 INSTL_DATABASE_PREFIX_DESC="Enter a table prefix or use the randomly generated one."
@@ -84,38 +82,25 @@ INSTL_DATABASE_TYPE_DESC="Select the database type."
 INSTL_DATABASE_USER_DESC="Either a username you created or a username provided by your host."
 INSTL_DATABASE_VALIDATION_ERROR="Check your database credentials, database type, database name or hostname. If you have MySQL 8 installed then please read this <a href=\"https://docs.joomla.org/Joomla_and_MySQL_8#Workaround_to_get_Joomla_working_with_MySQL_8\" target=\"_blank\">wiki</a> for more information."
 
-INSTL_INSTALL_JOOMLA="Install Joomla"
 INSTL_CONNECT_DB="Setup Database Connection"
+INSTL_INSTALL_JOOMLA="Install Joomla"
 
-;Site View
-INSTL_LOGIN_DATA="Login Data"
-INSTL_SITE="Main Configuration"
+; Site View
 INSTL_ADMIN_EMAIL_DESC="Enter the email address of the website Super User."
 INSTL_ADMIN_PASSWORD_DESC="Set the password for your Super User account."
-INSTL_ADMIN_USERNAME_DESC="Set the username for your Super User account."
 INSTL_ADMIN_USER_DESC="Enter the real name of your Super User."
+INSTL_ADMIN_USERNAME_DESC="Set the username for your Super User account."
+INSTL_LOGIN_DATA="Login Data"
 INSTL_SETUP_SITE_NAME="Setup Site Name"
+INSTL_SITE="Main Configuration"
 INSTL_SITE_DEVMODE_LABEL="We detected development mode"
 INSTL_SITE_NAME_DESC="Enter the name of your Joomla site."
 
-;Complete view
-INSTL_COMPLETE_ADMINISTRATION_LOGIN_DETAILS="Administration Login Details"
-; The word 'installation' should not be translated as it is a physical folder.
-INSTL_COMPLETE_ERROR_FOLDER_ALREADY_REMOVED="The installation folder has already been deleted."
+; Complete view
 INSTL_COMPLETE_ERROR_FOLDER_DELETE="The \"%s\" folder could not be deleted. Please manually delete the folder."
-; The word 'installation' should not be translated as it is a physical folder.
-INSTL_COMPLETE_FOLDER_REMOVED="Installation folder removed."
-INSTL_COMPLETE_LANGUAGE_1="Joomla in your own language and/or automatic basic native multilingual site creation"
-; The word 'installation' should not be translated as it is a physical folder.
-INSTL_COMPLETE_LANGUAGE_DESC="Before removing the installation folder you can install extra languages. If you want to add extra languages to your Joomla application select the following button."
-INSTL_COMPLETE_LANGUAGE_DESC2="Note: you will need internet access for Joomla to download and install the new languages. <br>Some server configurations won't allow Joomla to install the languages. If this is your case, don't worry, you will be able to install them later using the Joomla Administrator."
 INSTL_COMPLETE_REMOVE_FOLDER="Remove \"%s\" folder"
-; The word 'installation' should not be translated as it is a physical folder.
-INSTL_COMPLETE_REMOVE_INSTALLATION="PLEASE REMEMBER TO COMPLETELY REMOVE THE INSTALLATION FOLDER.<br>You will not be able to proceed beyond this point until the installation folder has been removed. This is a security feature of Joomla"
 INSTL_COMPLETE_CONGRAT="Congratulations!"
 INSTL_COMPLETE_TITLE="Congratulations! Your Joomla site is ready."
-INSTL_COMPLETE_FINISH="Finish Installation Process"
-INSTL_COMPLETE_INSTALL_LANGUAGES="Extra steps: Install languages"
 INSTL_COMPLETE_SITE_BTN="Complete & Open Site"
 INSTL_COMPLETE_ADMIN_BTN="Complete & Open Admin"
 INSTL_COMPLETE_FINAL="Installation is Complete"
@@ -123,7 +108,7 @@ INSTL_COMPLETE_FINAL_DESC="Your Joomla installation is now complete and ready to
 INSTL_COMPLETE_ADD_EXTRA_LANGUAGE="Install Additional Languages"
 INSTL_REMOVE_INST_FOLDER="Are you sure you want to delete? Confirming will permanently delete the \"%s\" folder."
 
-;Languages view
+; Languages view
 INSTL_LANGUAGES="Install Additional Languages"
 INSTL_LANGUAGES_COLUMN_HEADER_LANGUAGE="Language"
 INSTL_LANGUAGES_COLUMN_HEADER_LANGUAGE_TAG="Language Tag"
@@ -132,10 +117,10 @@ INSTL_LANGUAGES_DESC="The Joomla interface is available in several languages. Ch
 INSTL_LANGUAGES_MESSAGE_PLEASE_WAIT="This operation will take up to 10 seconds per language to complete<br>Please wait while we download and install the languages ..."
 INSTL_LANGUAGES_NO_LANGUAGE_SELECTED="No languages have been selected to be installed."
 INSTL_LANGUAGES_WARNING_NO_INTERNET="Joomla was unable to connect to the languages server. Please finish the installation process."
-INSTL_LANGUAGES_WARNING_NO_INTERNET2="Note: You will be able to install languages later using the Joomla Administrator"
+INSTL_LANGUAGES_WARNING_NO_INTERNET2="Note: You will be able to install languages later using the Joomla Administrator."
 INSTL_LANGUAGES_WARNING_BACK_BUTTON="Return to last installation step"
 
-;Default language view
+; Default language view
 INSTL_DEFAULTLANGUAGE_ADMINISTRATOR="Default Administrator language"
 INSTL_DEFAULTLANGUAGE_ADMIN_COULDNT_SET_DEFAULT="Joomla was unable to set the language as default. English will be used as default language for the Backend Administrator."
 INSTL_DEFAULTLANGUAGE_ADMIN_SET_DEFAULT="Joomla has set %s as your default ADMINISTRATOR language."
@@ -149,12 +134,12 @@ INSTL_DEFAULTLANGUAGE_FRONTEND="Default Site language"
 INSTL_DEFAULTLANGUAGE_FRONTEND_COULDNT_SET_DEFAULT="Joomla was unable to set the language as default. English will be used as default language for the Frontend SITE."
 INSTL_DEFAULTLANGUAGE_FRONTEND_SET_DEFAULT="Joomla has set %s as your default SITE language."
 INSTL_DEFAULTLANGUAGE_SET_DEFAULT_LANGUAGE="Set default language"
-INSTL_DEFAULTLANGUAGE_TRY_LATER="You will be able to install it later using the Joomla Administrator"
+INSTL_DEFAULTLANGUAGE_TRY_LATER="You will be able to install it later using the Joomla Administrator."
 
 ; IMPORTANT NOTE FOR TRANSLATORS: Do not literally translate this line, instead add the localised name of the language. For example Spanish will be Español
 INSTL_DEFAULTLANGUAGE_NATIVE_LANGUAGE_NAME="English (UK)"
 
-;Database Model
+; Database Model
 INSTL_DATABASE_COULD_NOT_CONNECT="Could not connect to the database. Connector returned error message: %s"
 INSTL_DATABASE_COULD_NOT_CREATE_DATABASE="The installer could not connect to the specified database and was unable to create the database. Please verify your settings and if necessary manually create your database."
 INSTL_DATABASE_COULD_NOT_REFRESH_MANIFEST_CACHE="Could not refresh manifest cache for extension: %s"
@@ -162,8 +147,9 @@ INSTL_DATABASE_ERROR_BACKINGUP="Some errors occurred in backing up the database.
 INSTL_DATABASE_ERROR_CREATE="An error occurred while trying to create the database %s.<br>The user may not have enough privileges to create a database. The required database may need to be created separately before you can install Joomla"
 INSTL_DATABASE_ERROR_DELETE="Some errors occurred deleting the database."
 INSTL_DATABASE_ERROR_READING_SQL_FILE="Could not read SQL file."
-INSTL_DATABASE_FIELD_VALUE_REMOVE="Remove"
 INSTL_DATABASE_FIELD_VALUE_BACKUP="Backup"
+INSTL_DATABASE_FIELD_VALUE_REMOVE="Remove"
+INSTL_DATABASE_FILE_DOES_NOT_EXIST="File %s does not exist."
 INSTL_DATABASE_FIX_LOWERCASE="The table prefix must be lowercase for PostgreSQL."
 INSTL_DATABASE_FIX_TOO_LONG="The MySQL table prefix must be a maximum of 15 characters."
 INSTL_DATABASE_INVALID_DB_DETAILS="The database details provided are incorrect and/or empty."
@@ -172,46 +158,45 @@ INSTL_DATABASE_INVALID_MYSQL_VERSION="You need MySQL %1$s or higher to continue 
 INSTL_DATABASE_INVALID_MYSQLI_VERSION="You need MySQL %1$s or higher to continue the installation. Your version is: %2$s"
 INSTL_DATABASE_INVALID_PGSQL_VERSION="You need PostgreSQL %1$s or higher to continue the installation. Your version is: %2$s"
 INSTL_DATABASE_INVALID_POSTGRESQL_VERSION="You need PostgreSQL %1$s or higher to continue the installation. Your version is: %2$s"
-INSTL_DATABASE_INVALID_TYPE="Please select the database type"
-INSTL_DATABASE_NAME_TOO_LONG="The MySQL database name must be a maximum of 64 characters."
-INSTL_DATABASE_NAME_INVALID_SPACES="MySQL database names and table names may not begin or end with spaces."
+INSTL_DATABASE_INVALID_TYPE="Please select the database type."
 INSTL_DATABASE_NAME_INVALID_CHAR="No MySQL identifier can have a NULL ASCII(0x00)."
-INSTL_DATABASE_FILE_DOES_NOT_EXIST="File %s does not exist"
+INSTL_DATABASE_NAME_INVALID_SPACES="MySQL database names and table names may not begin or end with spaces."
+INSTL_DATABASE_NAME_TOO_LONG="The MySQL database name must be a maximum of 64 characters."
 
-;controllers
+; Controllers
 INSTL_COOKIES_NOT_ENABLED="Cookies do not appear to be enabled on your browser client. You will not be able to install the application with this feature disabled. Alternatively, there could also be a problem with the server's <strong>session.save_path</strong>. If this is the case, please consult your hosting provider if you don't know how to check or fix this yourself."
 INSTL_HEADER_ERROR="Error"
 
-;Helpers
+; Helpers
 INSTL_PAGE_TITLE="Joomla Installer"
 
-;Configuration model
-INSTL_ERROR_CONNECT_DB="Could not connect to the database. Connector returned number: %s"
+; Configuration model
+INSTL_ERROR_CONNECT_DB="Could not connect to the database. Connector returned number: %s."
 INSTL_STD_OFFLINE_MSG="This site is down for maintenance.<br>Please check back again soon."
 
-;others
+; Others
 INSTL_CONFPROBLEM="Your configuration file or folder is not writable or there was a problem creating the configuration file. You will have to upload the following code by hand. Select in the text area to highlight all of the code and then paste into a new text file. Name this file 'configuration.php' and upload it to your site root folder."
 INSTL_DISPLAY_ERRORS="Display Errors"
-INSTL_ERROR_DB="Some errors occurred while populating the database: %s"
-INSTL_ERROR_INITIALISE_SCHEMA="Can't initialise database schema"
+INSTL_ERROR="Error"
+INSTL_ERROR_DB="Some errors occurred while populating the database: %s."
+INSTL_ERROR_INITIALISE_SCHEMA="Can't initialise database schema."
 INSTL_FILE_UPLOADS="File Uploads"
 INSTL_GNU_GPL_LICENSE="GNU General Public License"
-INSTL_NOTICEYOUCANSTILLINSTALL="You can still continue the installation only if you repair the permissions or you provide an FTP connection"
+INSTL_HELP_LINK="Help installing Joomla"
+INSTL_NOTICEYOUCANSTILLINSTALL="You can still continue the installation only if you repair the permissions or you provide an FTP connection."
 INSTL_OUTPUT_BUFFERING="Output Buffering"
 INSTL_PHP_VERSION="PHP Version"
 INSTL_PHP_VERSION_NEWER="PHP Version >= %s"
-INSTL_SESSION_AUTO_START="Session Auto Start"
-INSTL_WRITABLE="Insufficient permission to create %s"
-INSTL_ZIP_SUPPORT_AVAILABLE="Native ZIP support"
 INSTL_PROCESS_BUSY="Process is in progress. Please wait ..."
-INSTL_ERROR="Error"
-INSTL_HELP_LINK="Help installing Joomla"
+INSTL_SESSION_AUTO_START="Session Auto Start"
+INSTL_WRITABLE="Insufficient permission to create %s."
+INSTL_ZIP_SUPPORT_AVAILABLE="Native ZIP support"
 
-;Global strings
+; Global strings
 JADMINISTRATOR="Administrator"
+JEMAIL="Email"
 JERROR="Error"
 JERROR_LAYOUT_ERROR_HAS_OCCURRED_WHILE_PROCESSING_YOUR_REQUEST="An error has occurred while processing your request."
-JEMAIL="Email"
 JGLOBAL_ISFREESOFTWARE="%s is free software released under the %s."
 JGLOBAL_LANGUAGE_VERSION_NOT_PLATFORM="Language pack does not match this Joomla version. Some strings may be missing and will be displayed in English."
 JGLOBAL_SELECT_AN_OPTION="Select an option"
@@ -234,23 +219,23 @@ JYES="Yes"
 ; Framework strings necessary when no lang pack is available
 JLIB_DATABASE_ERROR_CONNECT_MYSQL="Could not connect to MySQL."
 JLIB_DATABASE_ERROR_DATABASE="A Database error occurred."
-JLIB_DATABASE_ERROR_LOAD_DATABASE_DRIVER="Unable to load Database Driver: %s"
+JLIB_DATABASE_ERROR_LOAD_DATABASE_DRIVER="Unable to load Database Driver: %s."
 JLIB_DATABASE_ERROR_VALID_MAIL="The email address you entered is invalid. Please enter another email address."
 JLIB_ENVIRONMENT_SESSION_EXPIRED="Your session has expired, please reload the page."
 JLIB_FILESYSTEM_ERROR_COPY_FAILED="Copy failed"
-JLIB_FILESYSTEM_ERROR_PATH_IS_NOT_A_FOLDER_FILES="JFolder: :files: Path is not a folder. Path: %s"
+JLIB_FILESYSTEM_ERROR_PATH_IS_NOT_A_FOLDER_FILES="JFolder: :files: Path is not a folder. Path: %s."
 JLIB_FORM_FIELD_INVALID="Invalid field:&#160;"
 JLIB_FORM_VALIDATE_FIELD_INVALID="Invalid field: %s"
 JLIB_FORM_VALIDATE_FIELD_REQUIRED="Field required: %s"
 JLIB_INSTALLER_ABORT="Aborting language installation: %s"
 JLIB_INSTALLER_ABORT_PACK_INSTALL_CREATE_DIRECTORY="Package Install: Failed to create folder: %s."
-JLIB_INSTALLER_ABORT_PACK_INSTALL_ERROR_EXTENSION="Package %1$s: There was an error installing an extension: %2$s"
+JLIB_INSTALLER_ABORT_PACK_INSTALL_ERROR_EXTENSION="Package %1$s: There was an error installing an extension: %2$s."
 JLIB_INSTALLER_ABORT_PACK_INSTALL_NO_FILES="Package %s: There were no files to install!"
 JLIB_INSTALLER_ERROR_FAIL_COPY_FILE="JInstaller: :Install: Failed to copy file %1$s to %2$s."
 JLIB_INSTALLER_NOT_ERROR="If the error is related to the installation of TinyMCE language files it has no effect on the installation of the language(s). Some language packs created prior to Joomla 3.2.0 may try to install separate TinyMCE language files. As these are now included in the core they no longer need to be installed."
-JLIB_INSTALLER_WARNING_UNABLE_TO_INSTALL_CONTENT_LANGUAGE="Unable to create a content language for %s language: %s"
-JLIB_UPDATER_ERROR_OPEN_UPDATE_SITE="Update: Could not open update site #%d &quot;%s&quot;, URL: %s"
-JLIB_UTIL_ERROR_CONNECT_DATABASE="JDatabase: :getInstance: Could not connect to database <br>joomla.library: %1$s - %2$s"
+JLIB_INSTALLER_WARNING_UNABLE_TO_INSTALL_CONTENT_LANGUAGE="Unable to create a content language for %s language: %s."
+JLIB_UPDATER_ERROR_OPEN_UPDATE_SITE="Update: Could not open update site #%d &quot;%s&quot;, URL: %s."
+JLIB_UTIL_ERROR_CONNECT_DATABASE="JDatabase: :getInstance: Could not connect to database <br>joomla.library: %1$s - %2$s."
 
 ; Strings for the language debugger
 JDEBUG_LANGUAGE_FILES_IN_ERROR="Parsing errors in language files"
@@ -284,13 +269,13 @@ JLIB_JS_AJAX_ERROR_PARSE="A parse error has occurred while processing the follow
 JLIB_JS_AJAX_ERROR_TIMEOUT="A timeout has occurred while fetching the JSON data."
 
 ; Field password messages
-JFIELD_PASSWORD_INDICATE_INCOMPLETE="Password doesn't meet site's requirements"
 JFIELD_PASSWORD_INDICATE_COMPLETE="Password accepted"
-JFIELD_PASSWORD_NOTE_LBL="Password must contain:"
+JFIELD_PASSWORD_INDICATE_INCOMPLETE="Password doesn't meet site's requirements."
 JFIELD_PASSWORD_NOTE_DESC="%1 symbol(s), %2 uppercase letter(s), %3 lowercase letter(s), %4 number(s)"
+JFIELD_PASSWORD_NOTE_LBL="Password must contain:"
 
 ; Javascript Form Validation Messages
-JLIB_FORM_CONTAINS_INVALID_FIELDS="The form cannot be submitted as it's missing required data. <br> Please correct the marked fields and try again"
-JLIB_FORM_FIELD_REQUIRED_VALUE="Please fill in this field"
-JLIB_FORM_FIELD_REQUIRED_CHECK="One of the options must be selected"
-JLIB_FORM_FIELD_INVALID_VALUE="This value is not valid"
+JLIB_FORM_CONTAINS_INVALID_FIELDS="The form cannot be submitted as it's missing required data. <br> Please correct the marked fields and try again."
+JLIB_FORM_FIELD_INVALID_VALUE="This value is not valid."
+JLIB_FORM_FIELD_REQUIRED_CHECK="One of the options must be selected."
+JLIB_FORM_FIELD_REQUIRED_VALUE="Please fill in this field."

--- a/installation/language/en-US/joomla.ini
+++ b/installation/language/en-US/joomla.ini
@@ -3,30 +3,28 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt
 ; Note : All ini files need to be saved as UTF-8
 
-;Build incomplete error page
-;These will be processed by the JavaScript Build
-BUILD_INCOMPLETE_LANGUAGE="English US"
+; Build incomplete error page
+; These will be processed by the JavaScript Build
 BUILD_INCOMPLETE_HEADER="Environment Setup Incomplete"
+BUILD_INCOMPLETE_LANGUAGE="English GB"
 BUILD_INCOMPLETE_TEXT="It looks like you are trying to run Joomla! from our git repository. To do so requires you complete a couple of extra steps first."
 BUILD_INCOMPLETE_URL_TEXT="More Details"
-;End of build incomplete error page
 
-;Minimum PHP error page
-;These will be processed by the JavaScript Build
-MIN_PHP_ERROR_LANGUAGE="English US"
-MIN_PHP_ERROR_HEADER="Sorry, your PHP version is not supported"
-MIN_PHP_ERROR_TEXT="Your host needs to use PHP version {{phpversion}} or newer to run this version of Joomla"
+; Minimum PHP error page
+; These will be processed by the JavaScript Build
+MIN_PHP_ERROR_HEADER="Sorry, your PHP version is not supported."
+MIN_PHP_ERROR_LANGUAGE="English GB"
+MIN_PHP_ERROR_TEXT="Your host needs to use PHP version {{phpversion}} or newer to run this version of Joomla."
 MIN_PHP_ERROR_URL_TEXT="Help me resolve this"
-;End of minimum PHP error page
 
-;Main Config
+; Main Config
 INSTL_SELECT_INSTALL_LANG="Select Installation Language"
 INSTL_SELECT_LANGUAGE_TITLE="Select Language"
-INSTL_WARNJAVASCRIPT="Warning! JavaScript must be enabled for proper installation of Joomla"
-INSTL_WARNJSON="Your PHP installation needs to have JSON enabled for Joomla to be installed!"
 INSTL_SETUP_LOGIN_DATA="Setup Login Data"
+INSTL_WARNJAVASCRIPT="Warning! JavaScript must be enabled for proper installation of Joomla."
+INSTL_WARNJSON="Your PHP installation needs to have JSON enabled for Joomla to be installed!"
 
-;Precheck view
+; Precheck view
 INSTL_DATABASE_SUPPORT="Database Support:"
 INSTL_JSON_SUPPORT_AVAILABLE="JSON Support"
 INSTL_MB_LANGUAGE_IS_DEFAULT="MB Language is Default"
@@ -67,14 +65,14 @@ INSTL_DATABASE_ENCRYPTION_MSG_SRV_NOT_SUPPORTS="The database server doesn't supp
 INSTL_DATABASE_ENCRYPTION_VERIFY_SERVER_CERT_LABEL="Verify Server Certificate"
 INSTL_DATABASE_ERROR_POSTGRESQL_QUERY="PostgreSQL database query failed."
 INSTL_DATABASE_HOST_DESC="Enter the host name, usually \"localhost\" or a name provided by your host."
-INSTL_DATABASE_HOST_LABEL="Host Name"
 INSTL_DATABASE_HOST_IS_NOT_LOCALHOST_CREATE_FILE="We were not able to create the file. Please manually create a file named \"%1$s\" and upload it to the \"%2$s\" folder of your Joomla site. Then select \"%3$s\" to continue."
 INSTL_DATABASE_HOST_IS_NOT_LOCALHOST_DELETE_FILE="To confirm that you are the owner of this website please delete the file named \"%1$s\" we have created in the \"%2$s\" folder of your Joomla site. Then select \"%3$s\" to continue."
 INSTL_DATABASE_HOST_IS_NOT_LOCALHOST_GENERAL_MESSAGE="You are trying to use a database host which is not on your local server. For security reasons, you need to verify the ownership of your web hosting account. <a href=\"%s\">Please read the documentation</a> for more information."
+INSTL_DATABASE_HOST_LABEL="Host Name"
 INSTL_DATABASE_NAME_DESC="Enter the database name."
 INSTL_DATABASE_NAME_LABEL="Database Name"
-INSTL_DATABASE_NAME_MSG_POSTGRES="The database name is invalid. It must start with a letter, followed by alphanumeric characters."
 INSTL_DATABASE_NAME_MSG_MYSQL="The database name is invalid. It must not contain the following characters: \ / ."
+INSTL_DATABASE_NAME_MSG_POSTGRES="The database name is invalid. It must start with a letter, followed by alphanumeric characters."
 INSTL_DATABASE_NO_SCHEMA="No database schema exists for this database type."
 INSTL_DATABASE_PASSWORD_DESC="Either a password you created or a password provided by your host."
 INSTL_DATABASE_PREFIX_DESC="Enter a table prefix or use the randomly generated one."
@@ -84,38 +82,25 @@ INSTL_DATABASE_TYPE_DESC="Select the database type."
 INSTL_DATABASE_USER_DESC="Either a username you created or a username provided by your host."
 INSTL_DATABASE_VALIDATION_ERROR="Check your database credentials, database type, database name or hostname. If you have MySQL 8 installed then please read this <a href=\"https://docs.joomla.org/Joomla_and_MySQL_8#Workaround_to_get_Joomla_working_with_MySQL_8\" target=\"_blank\">wiki</a> for more information."
 
-INSTL_INSTALL_JOOMLA="Install Joomla"
 INSTL_CONNECT_DB="Setup Database Connection"
+INSTL_INSTALL_JOOMLA="Install Joomla"
 
-;Site View
-INSTL_LOGIN_DATA="Login Data"
-INSTL_SITE="Main Configuration"
+; Site View
 INSTL_ADMIN_EMAIL_DESC="Enter the email address of the website Super User."
 INSTL_ADMIN_PASSWORD_DESC="Set the password for your Super User account."
-INSTL_ADMIN_USERNAME_DESC="Set the username for your Super User account."
 INSTL_ADMIN_USER_DESC="Enter the real name of your Super User."
+INSTL_ADMIN_USERNAME_DESC="Set the username for your Super User account."
+INSTL_LOGIN_DATA="Login Data"
 INSTL_SETUP_SITE_NAME="Setup Site Name"
+INSTL_SITE="Main Configuration"
 INSTL_SITE_DEVMODE_LABEL="We detected development mode"
 INSTL_SITE_NAME_DESC="Enter the name of your Joomla site."
 
-;Complete view
-INSTL_COMPLETE_ADMINISTRATION_LOGIN_DETAILS="Administration Login Details"
-; The word 'installation' should not be translated as it is a physical folder.
-INSTL_COMPLETE_ERROR_FOLDER_ALREADY_REMOVED="The installation folder has already been deleted."
+; Complete view
 INSTL_COMPLETE_ERROR_FOLDER_DELETE="The \"%s\" folder could not be deleted. Please manually delete the folder."
-; The word 'installation' should not be translated as it is a physical folder.
-INSTL_COMPLETE_FOLDER_REMOVED="Installation folder removed."
-INSTL_COMPLETE_LANGUAGE_1="Joomla in your own language and/or automatic basic native multilingual site creation"
-; The word 'installation' should not be translated as it is a physical folder.
-INSTL_COMPLETE_LANGUAGE_DESC="Before removing the installation folder you can install extra languages. If you want to add extra languages to your Joomla application select the following button."
-INSTL_COMPLETE_LANGUAGE_DESC2="Note: you will need internet access for Joomla to download and install the new languages. <br>Some server configurations won't allow Joomla to install the languages. If this is your case, don't worry, you will be able to install them later using the Joomla Administrator."
 INSTL_COMPLETE_REMOVE_FOLDER="Remove \"%s\" folder"
-; The word 'installation' should not be translated as it is a physical folder.
-INSTL_COMPLETE_REMOVE_INSTALLATION="PLEASE REMEMBER TO COMPLETELY REMOVE THE INSTALLATION FOLDER.<br>You will not be able to proceed beyond this point until the installation folder has been removed. This is a security feature of Joomla"
 INSTL_COMPLETE_CONGRAT="Congratulations!"
 INSTL_COMPLETE_TITLE="Congratulations! Your Joomla site is ready."
-INSTL_COMPLETE_FINISH="Finish Installation Process"
-INSTL_COMPLETE_INSTALL_LANGUAGES="Extra steps: Install languages"
 INSTL_COMPLETE_SITE_BTN="Complete & Open Site"
 INSTL_COMPLETE_ADMIN_BTN="Complete & Open Admin"
 INSTL_COMPLETE_FINAL="Installation is Complete"
@@ -123,7 +108,7 @@ INSTL_COMPLETE_FINAL_DESC="Your Joomla installation is now complete and ready to
 INSTL_COMPLETE_ADD_EXTRA_LANGUAGE="Install Additional Languages"
 INSTL_REMOVE_INST_FOLDER="Are you sure you want to delete? Confirming will permanently delete the \"%s\" folder."
 
-;Languages view
+; Languages view
 INSTL_LANGUAGES="Install Additional Languages"
 INSTL_LANGUAGES_COLUMN_HEADER_LANGUAGE="Language"
 INSTL_LANGUAGES_COLUMN_HEADER_LANGUAGE_TAG="Language Tag"
@@ -132,10 +117,10 @@ INSTL_LANGUAGES_DESC="The Joomla interface is available in several languages. Ch
 INSTL_LANGUAGES_MESSAGE_PLEASE_WAIT="This operation will take up to 10 seconds per language to complete<br>Please wait while we download and install the languages ..."
 INSTL_LANGUAGES_NO_LANGUAGE_SELECTED="No languages have been selected to be installed."
 INSTL_LANGUAGES_WARNING_NO_INTERNET="Joomla was unable to connect to the languages server. Please finish the installation process."
-INSTL_LANGUAGES_WARNING_NO_INTERNET2="Note: You will be able to install languages later using the Joomla Administrator"
+INSTL_LANGUAGES_WARNING_NO_INTERNET2="Note: You will be able to install languages later using the Joomla Administrator."
 INSTL_LANGUAGES_WARNING_BACK_BUTTON="Return to last installation step"
 
-;Default language view
+; Default language view
 INSTL_DEFAULTLANGUAGE_ADMINISTRATOR="Default Administrator language"
 INSTL_DEFAULTLANGUAGE_ADMIN_COULDNT_SET_DEFAULT="Joomla was unable to set the language as default. English will be used as default language for the Backend Administrator."
 INSTL_DEFAULTLANGUAGE_ADMIN_SET_DEFAULT="Joomla has set %s as your default ADMINISTRATOR language."
@@ -149,12 +134,12 @@ INSTL_DEFAULTLANGUAGE_FRONTEND="Default Site language"
 INSTL_DEFAULTLANGUAGE_FRONTEND_COULDNT_SET_DEFAULT="Joomla was unable to set the language as default. English will be used as default language for the Frontend SITE."
 INSTL_DEFAULTLANGUAGE_FRONTEND_SET_DEFAULT="Joomla has set %s as your default SITE language."
 INSTL_DEFAULTLANGUAGE_SET_DEFAULT_LANGUAGE="Set default language"
-INSTL_DEFAULTLANGUAGE_TRY_LATER="You will be able to install it later using the Joomla Administrator"
+INSTL_DEFAULTLANGUAGE_TRY_LATER="You will be able to install it later using the Joomla Administrator."
 
 ; IMPORTANT NOTE FOR TRANSLATORS: Do not literally translate this line, instead add the localised name of the language. For example Spanish will be Español
-INSTL_DEFAULTLANGUAGE_NATIVE_LANGUAGE_NAME="English (UK)"
+INSTL_DEFAULTLANGUAGE_NATIVE_LANGUAGE_NAME="English (US)"
 
-;Database Model
+; Database Model
 INSTL_DATABASE_COULD_NOT_CONNECT="Could not connect to the database. Connector returned error message: %s"
 INSTL_DATABASE_COULD_NOT_CREATE_DATABASE="The installer could not connect to the specified database and was unable to create the database. Please verify your settings and if necessary manually create your database."
 INSTL_DATABASE_COULD_NOT_REFRESH_MANIFEST_CACHE="Could not refresh manifest cache for extension: %s"
@@ -162,8 +147,9 @@ INSTL_DATABASE_ERROR_BACKINGUP="Some errors occurred in backing up the database.
 INSTL_DATABASE_ERROR_CREATE="An error occurred while trying to create the database %s.<br>The user may not have enough privileges to create a database. The required database may need to be created separately before you can install Joomla"
 INSTL_DATABASE_ERROR_DELETE="Some errors occurred deleting the database."
 INSTL_DATABASE_ERROR_READING_SQL_FILE="Could not read SQL file."
-INSTL_DATABASE_FIELD_VALUE_REMOVE="Remove"
 INSTL_DATABASE_FIELD_VALUE_BACKUP="Backup"
+INSTL_DATABASE_FIELD_VALUE_REMOVE="Remove"
+INSTL_DATABASE_FILE_DOES_NOT_EXIST="File %s does not exist."
 INSTL_DATABASE_FIX_LOWERCASE="The table prefix must be lowercase for PostgreSQL."
 INSTL_DATABASE_FIX_TOO_LONG="The MySQL table prefix must be a maximum of 15 characters."
 INSTL_DATABASE_INVALID_DB_DETAILS="The database details provided are incorrect and/or empty."
@@ -172,46 +158,45 @@ INSTL_DATABASE_INVALID_MYSQL_VERSION="You need MySQL %1$s or higher to continue 
 INSTL_DATABASE_INVALID_MYSQLI_VERSION="You need MySQL %1$s or higher to continue the installation. Your version is: %2$s"
 INSTL_DATABASE_INVALID_PGSQL_VERSION="You need PostgreSQL %1$s or higher to continue the installation. Your version is: %2$s"
 INSTL_DATABASE_INVALID_POSTGRESQL_VERSION="You need PostgreSQL %1$s or higher to continue the installation. Your version is: %2$s"
-INSTL_DATABASE_INVALID_TYPE="Please select the database type"
-INSTL_DATABASE_NAME_TOO_LONG="The MySQL database name must be a maximum of 64 characters."
-INSTL_DATABASE_NAME_INVALID_SPACES="MySQL database names and table names may not begin or end with spaces."
+INSTL_DATABASE_INVALID_TYPE="Please select the database type."
 INSTL_DATABASE_NAME_INVALID_CHAR="No MySQL identifier can have a NULL ASCII(0x00)."
-INSTL_DATABASE_FILE_DOES_NOT_EXIST="File %s does not exist"
+INSTL_DATABASE_NAME_INVALID_SPACES="MySQL database names and table names may not begin or end with spaces."
+INSTL_DATABASE_NAME_TOO_LONG="The MySQL database name must be a maximum of 64 characters."
 
-;controllers
+; Controllers
 INSTL_COOKIES_NOT_ENABLED="Cookies do not appear to be enabled on your browser client. You will not be able to install the application with this feature disabled. Alternatively, there could also be a problem with the server's <strong>session.save_path</strong>. If this is the case, please consult your hosting provider if you don't know how to check or fix this yourself."
 INSTL_HEADER_ERROR="Error"
 
-;Helpers
+; Helpers
 INSTL_PAGE_TITLE="Joomla Installer"
 
-;Configuration model
-INSTL_ERROR_CONNECT_DB="Could not connect to the database. Connector returned number: %s"
+; Configuration model
+INSTL_ERROR_CONNECT_DB="Could not connect to the database. Connector returned number: %s."
 INSTL_STD_OFFLINE_MSG="This site is down for maintenance.<br>Please check back again soon."
 
-;others
+; Others
 INSTL_CONFPROBLEM="Your configuration file or folder is not writable or there was a problem creating the configuration file. You will have to upload the following code by hand. Select in the text area to highlight all of the code and then paste into a new text file. Name this file 'configuration.php' and upload it to your site root folder."
 INSTL_DISPLAY_ERRORS="Display Errors"
-INSTL_ERROR_DB="Some errors occurred while populating the database: %s"
-INSTL_ERROR_INITIALISE_SCHEMA="Can't initialise database schema"
+INSTL_ERROR="Error"
+INSTL_ERROR_DB="Some errors occurred while populating the database: %s."
+INSTL_ERROR_INITIALISE_SCHEMA="Can't initialise database schema."
 INSTL_FILE_UPLOADS="File Uploads"
 INSTL_GNU_GPL_LICENSE="GNU General Public License"
-INSTL_NOTICEYOUCANSTILLINSTALL="You can still continue the installation only if you repair the permissions or you provide an FTP connection"
+INSTL_HELP_LINK="Help installing Joomla"
+INSTL_NOTICEYOUCANSTILLINSTALL="You can still continue the installation only if you repair the permissions or you provide an FTP connection."
 INSTL_OUTPUT_BUFFERING="Output Buffering"
 INSTL_PHP_VERSION="PHP Version"
 INSTL_PHP_VERSION_NEWER="PHP Version >= %s"
-INSTL_SESSION_AUTO_START="Session Auto Start"
-INSTL_WRITABLE="Insufficient permission to create %s"
-INSTL_ZIP_SUPPORT_AVAILABLE="Native ZIP support"
 INSTL_PROCESS_BUSY="Process is in progress. Please wait ..."
-INSTL_ERROR="Error"
-INSTL_HELP_LINK="Help installing Joomla"
+INSTL_SESSION_AUTO_START="Session Auto Start"
+INSTL_WRITABLE="Insufficient permission to create %s."
+INSTL_ZIP_SUPPORT_AVAILABLE="Native ZIP support"
 
-;Global strings
+; Global strings
 JADMINISTRATOR="Administrator"
+JEMAIL="Email"
 JERROR="Error"
 JERROR_LAYOUT_ERROR_HAS_OCCURRED_WHILE_PROCESSING_YOUR_REQUEST="An error has occurred while processing your request."
-JEMAIL="Email"
 JGLOBAL_ISFREESOFTWARE="%s is free software released under the %s."
 JGLOBAL_LANGUAGE_VERSION_NOT_PLATFORM="Language pack does not match this Joomla version. Some strings may be missing and will be displayed in English."
 JGLOBAL_SELECT_AN_OPTION="Select an option"
@@ -234,23 +219,23 @@ JYES="Yes"
 ; Framework strings necessary when no lang pack is available
 JLIB_DATABASE_ERROR_CONNECT_MYSQL="Could not connect to MySQL."
 JLIB_DATABASE_ERROR_DATABASE="A Database error occurred."
-JLIB_DATABASE_ERROR_LOAD_DATABASE_DRIVER="Unable to load Database Driver: %s"
+JLIB_DATABASE_ERROR_LOAD_DATABASE_DRIVER="Unable to load Database Driver: %s."
 JLIB_DATABASE_ERROR_VALID_MAIL="The email address you entered is invalid. Please enter another email address."
 JLIB_ENVIRONMENT_SESSION_EXPIRED="Your session has expired, please reload the page."
 JLIB_FILESYSTEM_ERROR_COPY_FAILED="Copy failed"
-JLIB_FILESYSTEM_ERROR_PATH_IS_NOT_A_FOLDER_FILES="JFolder: :files: Path is not a folder. Path: %s"
+JLIB_FILESYSTEM_ERROR_PATH_IS_NOT_A_FOLDER_FILES="JFolder: :files: Path is not a folder. Path: %s."
 JLIB_FORM_FIELD_INVALID="Invalid field:&#160;"
 JLIB_FORM_VALIDATE_FIELD_INVALID="Invalid field: %s"
 JLIB_FORM_VALIDATE_FIELD_REQUIRED="Field required: %s"
 JLIB_INSTALLER_ABORT="Aborting language installation: %s"
 JLIB_INSTALLER_ABORT_PACK_INSTALL_CREATE_DIRECTORY="Package Install: Failed to create folder: %s."
-JLIB_INSTALLER_ABORT_PACK_INSTALL_ERROR_EXTENSION="Package %1$s: There was an error installing an extension: %2$s"
+JLIB_INSTALLER_ABORT_PACK_INSTALL_ERROR_EXTENSION="Package %1$s: There was an error installing an extension: %2$s."
 JLIB_INSTALLER_ABORT_PACK_INSTALL_NO_FILES="Package %s: There were no files to install!"
 JLIB_INSTALLER_ERROR_FAIL_COPY_FILE="JInstaller: :Install: Failed to copy file %1$s to %2$s."
 JLIB_INSTALLER_NOT_ERROR="If the error is related to the installation of TinyMCE language files it has no effect on the installation of the language(s). Some language packs created prior to Joomla 3.2.0 may try to install separate TinyMCE language files. As these are now included in the core they no longer need to be installed."
-JLIB_INSTALLER_WARNING_UNABLE_TO_INSTALL_CONTENT_LANGUAGE="Unable to create a content language for %s language: %s"
-JLIB_UPDATER_ERROR_OPEN_UPDATE_SITE="Update: Could not open update site #%d &quot;%s&quot;, URL: %s"
-JLIB_UTIL_ERROR_CONNECT_DATABASE="JDatabase: :getInstance: Could not connect to database <br>joomla.library: %1$s - %2$s"
+JLIB_INSTALLER_WARNING_UNABLE_TO_INSTALL_CONTENT_LANGUAGE="Unable to create a content language for %s language: %s."
+JLIB_UPDATER_ERROR_OPEN_UPDATE_SITE="Update: Could not open update site #%d &quot;%s&quot;, URL: %s."
+JLIB_UTIL_ERROR_CONNECT_DATABASE="JDatabase: :getInstance: Could not connect to database <br>joomla.library: %1$s - %2$s."
 
 ; Strings for the language debugger
 JDEBUG_LANGUAGE_FILES_IN_ERROR="Parsing errors in language files"
@@ -284,13 +269,13 @@ JLIB_JS_AJAX_ERROR_PARSE="A parse error has occurred while processing the follow
 JLIB_JS_AJAX_ERROR_TIMEOUT="A timeout has occurred while fetching the JSON data."
 
 ; Field password messages
-JFIELD_PASSWORD_INDICATE_INCOMPLETE="Password doesn't meet site's requirements"
 JFIELD_PASSWORD_INDICATE_COMPLETE="Password accepted"
-JFIELD_PASSWORD_NOTE_LBL="Password must contain:"
+JFIELD_PASSWORD_INDICATE_INCOMPLETE="Password doesn't meet site's requirements."
 JFIELD_PASSWORD_NOTE_DESC="%1 symbol(s), %2 uppercase letter(s), %3 lowercase letter(s), %4 number(s)"
+JFIELD_PASSWORD_NOTE_LBL="Password must contain:"
 
 ; Javascript Form Validation Messages
-JLIB_FORM_CONTAINS_INVALID_FIELDS="The form cannot be submitted as it's missing required data. <br> Please correct the marked fields and try again"
-JLIB_FORM_FIELD_REQUIRED_VALUE="Please fill in this field"
-JLIB_FORM_FIELD_REQUIRED_CHECK="One of the options must be selected"
-JLIB_FORM_FIELD_INVALID_VALUE="This value is not valid"
+JLIB_FORM_CONTAINS_INVALID_FIELDS="The form cannot be submitted as it's missing required data. <br> Please correct the marked fields and try again."
+JLIB_FORM_FIELD_INVALID_VALUE="This value is not valid."
+JLIB_FORM_FIELD_REQUIRED_CHECK="One of the options must be selected."
+JLIB_FORM_FIELD_REQUIRED_VALUE="Please fill in this field."

--- a/installation/language/en-US/langmetadata.xml
+++ b/installation/language/en-US/langmetadata.xml
@@ -10,7 +10,7 @@
 		<filename>joomla.ini</filename>
 	</files>
 	<metadata>
-		<name>English (en_US)</name>
+		<name>English (en-US)</name>
 		<nativeName>English (United States)</nativeName>
 		<tag>en-US</tag>
 		<rtl>0</rtl>


### PR DESCRIPTION
### Summary of Changes
1. Alpha sort strings
2. Deleted now useless 3.x strings
4. Corrected missing end of phrase periods
5. Corrected cs comments
6. Corrected wrong specific en-US tag in ini as well as langmetadata

### Testing Instructions
Patch and install a clean Joomla including languages (fr-FR, de-DE, fa-IR)

### Note
This may not be exhaustive as there could be more strings to delete. 