### PR TITLE
Unclosed tab set in contact view using Beez3 template

### DIFF
--- a/templates/beez3/html/com_contact/contact/default.php
+++ b/templates/beez3/html/com_contact/contact/default.php
@@ -174,9 +174,11 @@ $cparams = JComponentHelper::getParams('com_media');
 		</div>
 	<?php endif; ?>
 
-	<?php if ($this->params->get('presentation_style') === 'sliders') :
-		echo JHtml::_('sliders.end');
-	endif; ?>
+	<?php if ($this->params->get('presentation_style') === 'sliders') : ?>
+		<?php echo JHtml::_('sliders.end'); ?>
+	<?php elseif ($this->params->get('presentation_style') === 'tabs') : ?>
+		<?php echo JHtml::_('tabs.end'); ?>
+	<?php endif; ?>
 
 	<?php echo $this->item->event->afterDisplayContent; ?>
 </div>


### PR DESCRIPTION
### Summary of Changes

Fixes markup.

### Testing Instructions

Create a contact.
Set `Presentation Style` to `Tabs`.
View the contact in frontend using Beez3 template.

### Expected result

No unclosed elements.

### Actual result

>End tag div seen, but there were open elements.
>Unclosed element dl.

### Documentation Changes Required

No.