### PR TITLE
[4.0.beta1]Fix non existing FA back icon

### DIFF
--- a/libraries/src/Toolbar/ToolbarHelper.php
+++ b/libraries/src/Toolbar/ToolbarHelper.php
@@ -160,7 +160,7 @@ abstract class ToolbarHelper
 		$bar = Toolbar::getInstance('toolbar');
 
 		// Add a back button.
-		$bar->appendButton('Link', 'back', $alt, $href);
+		$bar->appendButton('Link', 'arrow-left', $alt, $href);
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
icon-back non existing in Joomla! 4.0, replaced it with icon-arrow-left (which is the same)


### Testing Instructions
Add toolbar button with ToolbarHelper::back()


### Expected result
![Selection_002](https://user-images.githubusercontent.com/2733197/84755989-877f3b00-afc2-11ea-8a9a-5629d011f268.jpg)



### Actual result
![Selection_001](https://user-images.githubusercontent.com/2733197/84756001-8b12c200-afc2-11ea-96cf-03b79178ab07.jpg)



### Documentation Changes Required
no
