### PR TITLE
Fix webservice plugin to show super user group

### DIFF
--- a/plugins/user/token/token.xml
+++ b/plugins/user/token/token.xml
@@ -27,7 +27,7 @@
 					type="UserGroupList"
 					label="PLG_USER_TOKEN_ALLOWEDUSERGROUPS_LABEL"
 					description="PLG_USER_TOKEN_ALLOWEDUSERGROUPS_DESC"
-					checksuperusergroup="1"
+					checksuperusergroup="0"
 					default="8"
 					multiple="true"
 				/>


### PR DESCRIPTION
### Summary of Changes
Allow Super User groups to always show in the webservices plugin so that they can view their api tokens.

### Testing Instructions
View API plugin. select some user groups. currently super user doesn't show. Save some other user groups to access the token. Before patch a super user loose their ability to view the API token. After patch they can still view the token.

### Documentation Changes Required
None
