### PR TITLE
[4.0] Fix redirect after deleting content history versions

### DIFF
--- a/administrator/components/com_contenthistory/src/Controller/HistoryController.php
+++ b/administrator/components/com_contenthistory/src/Controller/HistoryController.php
@@ -94,8 +94,6 @@ class HistoryController extends AdminController
 	 */
 	protected function getRedirectToListAppend()
 	{
-		return '&layout=modal&tmpl=component&item_id='
-			. $this->input->getInt('item_id') . '&type_id=' . $this->input->getInt('type_id')
-			. '&type_alias=' . $this->input->getCmd('type_alias') . '&' . Session::getFormToken() . '=1';
+		return '&layout=modal&tmpl=component&item_id=' . $this->input->get('item_id') . '&' . Session::getFormToken() . '=1';
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/joomla/joomla-cms/issues/29653.

### Summary of Changes

Corrects redirect after deleting content history version.

### Testing Instructions

Create an article.
Edit and save it so a version history is saved.
Click `Versions` button in the toolbar.
Select the older version. Click `Delete`.

### Expected result

Redirected back to a list containing remaining versions.

### Actual result

Redirected to an empty page. PHP notices are shown:

>  Notice: Undefined offset: 1 in administrator\components\com_contenthistory\src\Model\HistoryModel.php on line 419
> Notice: Undefined offset: 1 in administrator\components\com_contenthistory\tmpl\history\modal.php on line 29
> Notice: Undefined offset: 1 in administrator\components\com_contenthistory\tmpl\history\modal.php on line 31

### Documentation Changes Required

No.