### PR TITLE
Banner impressions exceeded by 1

### DIFF
--- a/components/com_banners/models/banners.php
+++ b/components/com_banners/models/banners.php
@@ -83,7 +83,7 @@ class BannersModelBanners extends JModelList
 			->where('a.state=1')
 			->where('(a.publish_up = ' . $nullDate . ' OR a.publish_up <= ' . $nowDate . ')')
 			->where('(a.publish_down = ' . $nullDate . ' OR a.publish_down >= ' . $nowDate . ')')
-			->where('(a.imptotal = 0 OR a.impmade <= a.imptotal)');
+			->where('(a.imptotal = 0 OR a.impmade < a.imptotal)');
 
 		if ($cid)
 		{


### PR DESCRIPTION
Fixes https://github.com/joomla/joomla-cms/issues/29651.

### Summary of Changes

Fixes max banner impressions being exceeded by 1 impression.

### Testing Instructions

Create a banner. Set `Max. Impressions` to 1.
Create a banner module.
Open a page containing the module.
Refresh the page a couple of times.

### Expected result

Banner is shown once (on first load only).

### Actual result

Banner is shown twice (on first load and after first refresh).

### Documentation Changes Required

No.