### PR TITLE
[4.0] installer override plugin: Fix wrong plural string format

### DIFF
--- a/administrator/language/en-GB/plg_installer_override.ini
+++ b/administrator/language/en-GB/plg_installer_override.ini
@@ -3,7 +3,7 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt
 ; Note : All ini files need to be saved as UTF-8
 
-PLG_INSTALLER_N_OVERRIDE_FILE_UPDATED="%s Overridden files have changed."
-PLG_INSTALLER_N_OVERRIDE_FILE_UPDATED_1="Overridden file has changed."
 PLG_INSTALLER_OVERRIDE="Installer - Override"
+PLG_INSTALLER_OVERRIDE_N_FILE_UPDATED="%s Overridden files have changed."
+PLG_INSTALLER_OVERRIDE_N_FILE_UPDATED_1="Overridden file has changed."
 PLG_INSTALLER_OVERRIDE_PLUGIN_XML_DESCRIPTION="This plugin enables notifications and handling of overrides after an update in case of changes."

--- a/plugins/installer/override/override.php
+++ b/plugins/installer/override/override.php
@@ -192,7 +192,7 @@ class PlgInstallerOverride extends CMSPlugin
 
 		if ($num != 0)
 		{
-			$this->app->enqueueMessage(Text::plural('PLG_INSTALLER_N_OVERRIDE_FILE_UPDATED', $num), 'notice');
+			$this->app->enqueueMessage(Text::plural('PLG_INSTALLER_OVERRIDE_N_FILE_UPDATED', $num), 'notice');
 			$this->saveOverrides($result);
 		}
 


### PR DESCRIPTION
### Summary of Changes

While alpha ordering lang strings, I found out the plural strings for this new plugin were not following the usual plural form. This PR corrects this.

### Note
We do have other plugins with similar prefix issues. TODO.
