### PR TITLE
[4.0] Normalizing authentication cookie plugin lang strings

### DIFF
--- a/administrator/language/en-GB/plg_authentication_cookie.ini
+++ b/administrator/language/en-GB/plg_authentication_cookie.ini
@@ -3,9 +3,9 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt
 ; Note : All ini files need to be saved as UTF-8
 
-PLG_AUTH_COOKIE_ERROR_LOG_LOGIN_FAILED="Cookie login failed for user %u."
-PLG_AUTH_COOKIE_FIELD_COOKIE_LIFETIME_LABEL="Cookie Lifetime (days)"
-PLG_AUTH_COOKIE_FIELD_KEY_LENGTH_LABEL="Key Length"
-PLG_AUTH_COOKIE_PRIVACY_CAPABILITY_COOKIE="In conjunction with a plugin which supports a \"Remember Me\" feature, such as the \"System - Remember Me\" plugin, this plugin creates a cookie on the user's client if a \"Remember Me\" checkbox is selected when logging into the website. This cookie can be identified with the prefix `joomla_remember_me` and is used to automatically log users into the website when they visit and are not already logged in."
-PLG_AUTH_COOKIE_XML_DESCRIPTION="Handles Joomla's cookie User authentication.<br><strong> Warning! You must have at least one other authentication plugin enabled.</strong> <br>You will also need a plugin such as the System - Remember Me plugin to implement cookie login."
 PLG_AUTHENTICATION_COOKIE="Authentication - Cookie"
+PLG_AUTHENTICATION_COOKIE_ERROR_LOG_LOGIN_FAILED="Cookie login failed for user %u."
+PLG_AUTHENTICATION_COOKIE_FIELD_COOKIE_LIFETIME_LABEL="Cookie Lifetime (days)"
+PLG_AUTHENTICATION_COOKIE_FIELD_KEY_LENGTH_LABEL="Key Length"
+PLG_AUTHENTICATION_COOKIE_PRIVACY_CAPABILITY_COOKIE="In conjunction with a plugin which supports a \"Remember Me\" feature, such as the \"System - Remember Me\" plugin, this plugin creates a cookie on the user's client if a \"Remember Me\" checkbox is selected when logging into the website. This cookie can be identified with the prefix `joomla_remember_me` and is used to automatically log users into the website when they visit and are not already logged in."
+PLG_AUTHENTICATION_COOKIE_XML_DESCRIPTION="Handles Joomla's cookie User authentication.<br><strong> Warning! You must have at least one other authentication plugin enabled.</strong> <br>You will also need a plugin such as the System - Remember Me plugin to implement cookie login."

--- a/administrator/language/en-GB/plg_authentication_cookie.sys.ini
+++ b/administrator/language/en-GB/plg_authentication_cookie.sys.ini
@@ -3,5 +3,5 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt
 ; Note : All ini files need to be saved as UTF-8
 
-PLG_AUTH_COOKIE_XML_DESCRIPTION="Handles Joomla's cookie User authentication.<br><strong> Warning! You must have at least one other authentication plugin enabled.</strong><br>You will also need a plugin such as the System - Remember Me plugin to implement cookie login."
 PLG_AUTHENTICATION_COOKIE="Authentication - Cookie"
+PLG_AUTHENTICATION_COOKIE_XML_DESCRIPTION="Handles Joomla's cookie User authentication.<br><strong> Warning! You must have at least one other authentication plugin enabled.</strong><br>You will also need a plugin such as the System - Remember Me plugin to implement cookie login."

--- a/plugins/authentication/cookie/cookie.php
+++ b/plugins/authentication/cookie/cookie.php
@@ -55,7 +55,7 @@ class PlgAuthenticationCookie extends CMSPlugin
 
 		return array(
 			Text::_('PLG_AUTHENTICATION_COOKIE') => array(
-				Text::_('PLG_AUTH_COOKIE_PRIVACY_CAPABILITY_COOKIE'),
+				Text::_('PLG_AUTHENTICATION_COOKIE_PRIVACY_CAPABILITY_COOKIE'),
 			)
 		);
 	}
@@ -190,7 +190,7 @@ class PlgAuthenticationCookie extends CMSPlugin
 			$this->app->input->cookie->set($cookieName, '', 1, $this->app->get('cookie_path', '/'), $this->app->get('cookie_domain', ''));
 
 			// Issue warning by email to user and/or admin?
-			Log::add(Text::sprintf('PLG_AUTH_COOKIE_ERROR_LOG_LOGIN_FAILED', $results[0]->user_id), Log::WARNING, 'security');
+			Log::add(Text::sprintf('PLG_AUTHENTICATION_COOKIE_ERROR_LOG_LOGIN_FAILED', $results[0]->user_id), Log::WARNING, 'security');
 			$response->status = Authentication::STATUS_FAILURE;
 
 			return false;

--- a/plugins/authentication/cookie/cookie.xml
+++ b/plugins/authentication/cookie/cookie.xml
@@ -8,7 +8,7 @@
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
-	<description>PLG_AUTH_COOKIE_XML_DESCRIPTION</description>
+	<description>PLG_AUTHENTICATION_COOKIE_XML_DESCRIPTION</description>
 	<files>
 		<filename plugin="cookie">cookie.php</filename>
 	</files>
@@ -22,7 +22,7 @@
 				<field
 					name="cookie_lifetime"
 					type="number"
-					label="PLG_AUTH_COOKIE_FIELD_COOKIE_LIFETIME_LABEL"
+					label="PLG_AUTHENTICATION_COOKIE_FIELD_COOKIE_LIFETIME_LABEL"
 					default="60"
 					filter="integer"
 					required="true"
@@ -31,7 +31,7 @@
 				<field
 					name="key_length"
 					type="list"
-					label="PLG_AUTH_COOKIE_FIELD_KEY_LENGTH_LABEL"
+					label="PLG_AUTHENTICATION_COOKIE_FIELD_KEY_LENGTH_LABEL"
 					default="16"
 					filter="integer"
 					required="true"


### PR DESCRIPTION
### Summary of Changes
Following up on https://github.com/joomla/joomla-cms/pull/29665

This normalizes the language strings for this plugin to keep the right prefix

