### PR TITLE
Make ToolbarHelper::back rtl compliant

### DIFF
--- a/libraries/src/Toolbar/ToolbarHelper.php
+++ b/libraries/src/Toolbar/ToolbarHelper.php
@@ -159,7 +159,7 @@ abstract class ToolbarHelper
 	{
 		$bar = Toolbar::getInstance('toolbar');
 
-		// Add a (rtl) back button.
+		// Add a back button.
 		$arrow  = Factory::getLanguage()->isRtl() ? 'arrow-right' : 'arrow-left';
 		$bar->appendButton('Link', $arrow, $alt, $href);
 	}

--- a/libraries/src/Toolbar/ToolbarHelper.php
+++ b/libraries/src/Toolbar/ToolbarHelper.php
@@ -159,8 +159,9 @@ abstract class ToolbarHelper
 	{
 		$bar = Toolbar::getInstance('toolbar');
 
-		// Add a back button.
-		$bar->appendButton('Link', 'arrow-left', $alt, $href);
+		// Add a (rtl) back button.
+		$arrow  = Factory::getLanguage()->isRtl() ? 'arrow-right' : 'arrow-left';
+		$bar->appendButton('Link', $arrow, $alt, $href);
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/pull/29638#issuecomment-644890614

### Summary of Changes
make ToolbarHelper::back() rtl compliant


### Testing Instructions
Add ToolbarHelp::back() to your view
test if position and direction of arrow icon is correct in both rtl and ltr languages


### Expected result
arrow icon should be > on rtl and < on ltr languages


### Actual result
arrow icon is always <


### Documentation Changes Required
no
