### PR TITLE
[4.0] Fixes for worklow notification

### DIFF
--- a/administrator/language/en-GB/plg_workflow_notification.ini
+++ b/administrator/language/en-GB/plg_workflow_notification.ini
@@ -4,17 +4,17 @@
 ; Note : All ini files need to be saved as UTF-8
 
 COM_WORKFLOW_NOTIFICATION_FIELDSET_LABEL="Notification"
+COM_WORKFLOW_BASIC_STAGE="Basic Stage"
 PLG_WORKFLOW_NOTIFICATION="Workflow - Notification"
 PLG_WORKFLOW_NOTIFICATION_ADDTEXT="The stage has changed"
-PLG_WORKFLOW_NOTIFICATION_ADDTEXT_DESC="This text will be sent: Title [title], Changed by [user], New State: [state]. You can add own Text to this information. You can localise the Text by using a Language key and make language overrides."
-PLG_WORKFLOW_NOTIFICATION_ADDTEXT_LABEL="Additional Message Text."
-PLG_WORKFLOW_NOTIFICATION_ON_TRANSITION_MSG="Title: '%1$s', Changed by '%2$s',  New State: '%3$s'."
-PLG_WORKFLOW_NOTIFICATION_ON_TRANSITION_SUBJECT="The status of an '%1$s' has been changed";
+PLG_WORKFLOW_NOTIFICATION_ADDTEXT_DESC="This text will be sent: Title [title], changed by [user], new state: [state]. You can add own text to this information. You can localise the text by using a language key and make language overrides."
+PLG_WORKFLOW_NOTIFICATION_ADDTEXT_LABEL="Additional message text."
+PLG_WORKFLOW_NOTIFICATION_ON_TRANSITION_MSG="Title: %1$s, changed by %2$s,  new state: %3$s."
+PLG_WORKFLOW_NOTIFICATION_ON_TRANSITION_SUBJECT="The status of an %1$s has been changed";
 PLG_WORKFLOW_NOTIFICATION_RECEIVERS_LABEL="Users"
-PLG_WORKFLOW_NOTIFICATION_RECEIVERS_SELECT="Select single  Users who obtain a Notification"
 PLG_WORKFLOW_NOTIFICATION_SENDMAIL_LABEL="Send Notification"
-PLG_WORKFLOW_NOTIFICATION_SENT="Notifications have been sent"
+PLG_WORKFLOW_NOTIFICATION_SENT="Notifications sent"
 PLG_WORKFLOW_NOTIFICATION_USERGROUP_DESC="The users in this usergroup get a notification if this transition has been performed"
 PLG_WORKFLOW_NOTIFICATION_USERGROUP_LABEL="Usergroups"
 PLG_WORKFLOW_NOTIFICATION_USERGROUP_SELECT="Select usergroups"
-PLG_WORKFLOW_NOTIFICATION_XML_DESCRIPTION="Send Notification if a Transition has been performed in a Workflow"
+PLG_WORKFLOW_NOTIFICATION_XML_DESCRIPTION="Send notification if a transition has been performed in a workflow"


### PR DESCRIPTION
### Summary of Changes
Resolves also  #29371.

Fix language strings.
Make sure that only users with access to com_messages get a notification.
Remove superfluous filters for users.


### Testing Instructions
You must have workflow enabled and at least one article.
Go to workflows, select transitions. 
For one transition i.e. published, set the sendMessage to on and add manager and administrator to receiver groups. Save and close.

Then go to articles.
Perform the transition for an article.
The transition must be performed and you must get a message that notofication is sent.

Check that only users of the group administrator have got the message, but not users of the group manager (you can see this in table #__message).

Check the messages and texts.


### Expected result
as decribed


### Documentation Changes Required
no
