### PR TITLE
[4.0] Fix Atum Safari not displaying svg background when using choices

### DIFF
--- a/administrator/templates/atum/scss/vendor/choicesjs/choices.scss
+++ b/administrator/templates/atum/scss/vendor/choicesjs/choices.scss
@@ -121,10 +121,12 @@
 .choices[data-type*="select-multiple"] {
   .choices__inner {
     padding-inline-end: $custom-select-indicator-padding;
-    background: $custom-select-bg url("../../../images/select-bg.svg") no-repeat 100%/116rem;
+    background: url("../../../images/select-bg.svg") no-repeat 100%/116rem;
+    background-color: $custom-select-bg;
 
     [dir="rtl"] & {
-      background: $custom-select-bg url("../../../images/select-bg-rtl.svg") no-repeat 0/116rem;
+      background: url("../../../images/select-bg-rtl.svg") no-repeat 0/116rem;
+      background-color: $custom-select-bg;
     }
   }
 }


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/29658

### Summary of Changes
Safari and possibly some other browsers do not like combining background color and url of image. In our case the `select-bg.svg` as well as `select-bg-rtl.svg`
This PR separates both.

### Testing Instructions
See https://github.com/joomla/joomla-cms/issues/29658
Make sure that all caches are deleted after patching.
This needs npm to test

### After patch
<img width="385" alt="Screen Shot 2020-06-17 at 12 00 27" src="https://user-images.githubusercontent.com/869724/84884933-a1884e80-b092-11ea-9f9a-5efda22e4891.png">
