### PR TITLE
[4.0] Media Manager modal toolbar

### DIFF
--- a/administrator/components/com_media/tmpl/media/default.php
+++ b/administrator/components/com_media/tmpl/media/default.php
@@ -35,9 +35,9 @@ $tmpl = Factory::getApplication()->input->getCmd('tmpl');
 // Load the toolbar when we are in an iframe
 if ($tmpl === 'component')
 {
-	echo "<div class='subhead noshadow'>";
+	echo '<div class="subhead noshadow">';
 	echo Toolbar::getInstance('toolbar')->render();
-	echo "</div>";
+	echo '</div>';
 }
 
 // Populate the media config

--- a/administrator/components/com_media/tmpl/media/default.php
+++ b/administrator/components/com_media/tmpl/media/default.php
@@ -35,7 +35,9 @@ $tmpl = Factory::getApplication()->input->getCmd('tmpl');
 // Load the toolbar when we are in an iframe
 if ($tmpl === 'component')
 {
+	echo "<div class='subhead noshadow'>";
 	echo Toolbar::getInstance('toolbar')->render();
+	echo "</div>";
 }
 
 // Populate the media config

--- a/administrator/templates/atum/scss/blocks/_toolbar.scss
+++ b/administrator/templates/atum/scss/blocks/_toolbar.scss
@@ -16,6 +16,10 @@
     margin-left: 0;
   }
 
+  &.noshadow {
+    box-shadow: none;
+  }
+
   joomla-toolbar-button,
   .btn-group {
     margin-inline-start: .75rem;


### PR DESCRIPTION
scss has been changed in this pr so you will need to node build.js --compile-css

### The problem
The toolbar buttons in the media manager modal eg when adding an intro image is displayed with the full colours and no spacing

### The solution
This could be technically wrong. It works but maybe there is a better way. It wraps the toolbar with the subhead div and adds a noshadow class

### before
![image](https://user-images.githubusercontent.com/1296369/84957840-ff994e00-b0f3-11ea-9240-73bf06adf1d6.png)

### after
![image](https://user-images.githubusercontent.com/1296369/84957809-ed1f1480-b0f3-11ea-91dd-87d5c06d51f3.png)
