### PR TITLE
[4.0] tag field cursor

### DIFF
--- a/administrator/templates/atum/scss/vendor/choicesjs/choices.scss
+++ b/administrator/templates/atum/scss/vendor/choicesjs/choices.scss
@@ -123,6 +123,7 @@
     padding-inline-end: $custom-select-indicator-padding;
     background: url("../../../images/select-bg.svg") no-repeat 100%/116rem;
     background-color: $custom-select-bg;
+    cursor: pointer;
 
     [dir="rtl"] & {
       background: url("../../../images/select-bg-rtl.svg") no-repeat 0/116rem;


### PR DESCRIPTION
PR for #29677

This pr changes scss so you will need to node build.js --compile-css

The changes here ensure that the cursor maintains the i-beam on the text and then uses the pointer on the arrow

### after
![pointer](https://user-images.githubusercontent.com/1296369/84958899-3a03ea80-b0f6-11ea-8b70-3011523f55c9.gif)
