### PR TITLE
Remove reference to non-existing class

### DIFF
--- a/libraries/src/Form/Form.php
+++ b/libraries/src/Form/Form.php
@@ -10,7 +10,6 @@ namespace Joomla\CMS\Form;
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\CMS\Form\Factory\LegacyFormFactory;
 use Joomla\Registry\Registry;
 use Joomla\Utilities\ArrayHelper;
 


### PR DESCRIPTION
Closes https://github.com/joomla/joomla-cms/issues/29680.

### Summary of Changes

Removes import of `Joomla\CMS\Form\Factory\LegacyFormFactory` which doesn't exist in staging.

### Testing Instructions

Code review.

### Documentation Changes Required

No.