### PR TITLE
[4.0] Remove reference to non-existing class

### DIFF
--- a/plugins/system/webauthn/webauthn.php
+++ b/plugins/system/webauthn/webauthn.php
@@ -20,7 +20,6 @@ use Joomla\Plugin\System\Webauthn\PluginTraits\AjaxHandlerCreate;
 use Joomla\Plugin\System\Webauthn\PluginTraits\AjaxHandlerDelete;
 use Joomla\Plugin\System\Webauthn\PluginTraits\AjaxHandlerLogin;
 use Joomla\Plugin\System\Webauthn\PluginTraits\AjaxHandlerSaveLabel;
-use Joomla\Plugin\System\Webauthn\PluginTraits\ButtonsInUserPage;
 use Joomla\Plugin\System\Webauthn\PluginTraits\UserDeletion;
 use Joomla\Plugin\System\Webauthn\PluginTraits\UserProfileFields;
 


### PR DESCRIPTION
### Summary of Changes

Removes import of `Joomla\Plugin\System\Webauthn\PluginTraits\ButtonsInUserPage` which doesn't exist.

### Testing Instructions

Code review.

### Documentation Changes Required

No.