### PR TITLE
[4.0] Fix history version preview

### DIFF
--- a/administrator/components/com_contenthistory/src/Helper/ContenthistoryHelper.php
+++ b/administrator/components/com_contenthistory/src/Helper/ContenthistoryHelper.php
@@ -348,7 +348,7 @@ class ContenthistoryHelper
 	public static function prepareData(ContentHistory $table)
 	{
 		$object = static::decodeFields($table->version_data);
-		$typesTable = Table::getInstance('Contenttype', 'Joomla\\CMS\\Table\\');
+		$typesTable = Table::getInstance('ContentType', 'Joomla\\CMS\\Table\\');
 		$typeAlias = explode('.', $table->item_id);
 		array_pop($typeAlias);
 		$typesTable->load(array('type_alias' => implode('.', $typeAlias)));


### PR DESCRIPTION
Fixes https://github.com/joomla/joomla-cms/issues/29654.

### Summary of Changes

Corrects class casing, fixing version preview on case sensitive filesystems.

### Testing Instructions

Create and edit an article.
Click `Versions` button.
Select a version and click `Preview`.

### Expected result

Preview displayed.

### Actual result

>Call to a member function load() on bool

### Documentation Changes Required

No.