### PR TITLE
[4.0] Fix php notice when no version_id specified

### DIFF
--- a/administrator/components/com_contenthistory/src/Model/PreviewModel.php
+++ b/administrator/components/com_contenthistory/src/Model/PreviewModel.php
@@ -40,7 +40,7 @@ class PreviewModel extends ItemModel
 		$table = $this->getTable('ContentHistory');
 		$versionId = Factory::getApplication()->input->getInt('version_id');
 
-		if (!$versionId || !$table->load($versionId))
+		if (!$versionId || \is_array($versionId) || !$table->load($versionId))
 		{
 			return false;
 		}

--- a/administrator/components/com_contenthistory/src/Model/PreviewModel.php
+++ b/administrator/components/com_contenthistory/src/Model/PreviewModel.php
@@ -40,7 +40,7 @@ class PreviewModel extends ItemModel
 		$table = $this->getTable('ContentHistory');
 		$versionId = Factory::getApplication()->input->getInt('version_id');
 
-		if (!$table->load($versionId))
+		if (!$versionId || !$table->load($versionId))
 		{
 			return false;
 		}


### PR DESCRIPTION
Pull Request for part of Issue #29654 and a

### Summary of Changes

Fix php notice when no version_id specified in faked/truncated url

### Testing Instructions

Joomla 4
apply https://github.com/joomla/joomla-cms/pull/29692
 go to 

http://127.0.0.1/administrator/index.php?option=com_contenthistory&view=preview&layout=preview&tmpl=component&version_id=

### Expected result

No PHP notice, no comparison 

After PR should be 

<img width="844" alt="Screenshot 2020-06-18 at 19 12 06" src="https://user-images.githubusercontent.com/400092/85056731-a4209c00-b197-11ea-9eed-bfb026ff4bea.png">


### Actual result before PR

<img width="803" alt="Screenshot 2020-06-18 at 19 02 59" src="https://user-images.githubusercontent.com/400092/85056742-aaaf1380-b197-11ea-9fb2-e692471b2904.png">




### Documentation Changes Required

none