### PR TITLE
[4.0] Refactor to return early, remove if depths and throw NotAllowed

### DIFF
--- a/administrator/components/com_contenthistory/src/Model/CompareModel.php
+++ b/administrator/components/com_contenthistory/src/Model/CompareModel.php
@@ -34,6 +34,8 @@ class CompareModel extends ListModel
 	 * @return  array|boolean    On success, array of populated tables. False on failure.
 	 *
 	 * @since   3.2
+	 *
+	 * @throws  NotAllowed   Thrown if not authorised to edit an item
 	 */
 	public function getItems()
 	{

--- a/administrator/components/com_contenthistory/src/Model/CompareModel.php
+++ b/administrator/components/com_contenthistory/src/Model/CompareModel.php
@@ -11,6 +11,7 @@ namespace Joomla\Component\Contenthistory\Administrator\Model;
 
 \defined('_JEXEC') or die;
 
+use Joomla\CMS\Access\Exception\NotAllowed;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
@@ -66,60 +67,50 @@ class CompareModel extends ListModel
 			$user = Factory::getUser();
 
 			// Access check
-			if ($user->authorise('core.edit', $table1->item_id) || $this->canEdit($table1))
+			if (!$user->authorise('core.edit', $table1->item_id) || !$this->canEdit($table1))
 			{
-				$return = true;
-			}
-			else
-			{
-				$this->setError(Text::_('JERROR_ALERTNOAUTHOR'));
-
-				return false;
+                throw new NotAllowed(Text::_('JERROR_ALERTNOAUTHOR'), 403);
 			}
 
-			// All's well, process the records
-			if ($return == true)
-			{
-				$nullDate = $this->getDbo()->getNullDate();
+            $nullDate = $this->getDbo()->getNullDate();
 
-				foreach (array($table1, $table2) as $table)
-				{
-					$object = new \stdClass;
-					$object->data = ContenthistoryHelper::prepareData($table);
-					$object->version_note = $table->version_note;
+            foreach (array($table1, $table2) as $table)
+            {
+                $object = new \stdClass;
+                $object->data = ContenthistoryHelper::prepareData($table);
+                $object->version_note = $table->version_note;
 
-					// Let's use custom calendars when present
-					$object->save_date = HTMLHelper::_('date', $table->save_date, Text::_('DATE_FORMAT_LC6'));
+                // Let's use custom calendars when present
+                $object->save_date = HTMLHelper::_('date', $table->save_date, Text::_('DATE_FORMAT_LC6'));
 
-					$dateProperties = array (
-						'modified_time',
-						'created_time',
-						'modified',
-						'created',
-						'checked_out_time',
-						'publish_up',
-						'publish_down',
-					);
+                $dateProperties = array (
+                    'modified_time',
+                    'created_time',
+                    'modified',
+                    'created',
+                    'checked_out_time',
+                    'publish_up',
+                    'publish_down',
+                );
 
-					foreach ($dateProperties as $dateProperty)
-					{
-						if (property_exists($object->data, $dateProperty)
-							&& $object->data->$dateProperty->value !== null
-							&& $object->data->$dateProperty->value !== $nullDate)
-						{
-							$object->data->$dateProperty->value = HTMLHelper::_(
-								'date',
-								$object->data->$dateProperty->value,
-								Text::_('DATE_FORMAT_LC6')
-							);
-						}
-					}
+                foreach ($dateProperties as $dateProperty)
+                {
+                    if (property_exists($object->data, $dateProperty)
+                        && $object->data->$dateProperty->value !== null
+                        && $object->data->$dateProperty->value !== $nullDate)
+                    {
+                        $object->data->$dateProperty->value = HTMLHelper::_(
+                            'date',
+                            $object->data->$dateProperty->value,
+                            Text::_('DATE_FORMAT_LC6')
+                        );
+                    }
+                }
 
-					$result[] = $object;
-				}
+                $result[] = $object;
+            }
 
-				return $result;
-			}
+            return $result;
 		}
 
 		return false;

--- a/administrator/components/com_contenthistory/src/Model/CompareModel.php
+++ b/administrator/components/com_contenthistory/src/Model/CompareModel.php
@@ -69,48 +69,48 @@ class CompareModel extends ListModel
 			// Access check
 			if (!$user->authorise('core.edit', $table1->item_id) || !$this->canEdit($table1))
 			{
-                throw new NotAllowed(Text::_('JERROR_ALERTNOAUTHOR'), 403);
+				throw new NotAllowed(Text::_('JERROR_ALERTNOAUTHOR'), 403);
 			}
 
-            $nullDate = $this->getDbo()->getNullDate();
+			$nullDate = $this->getDbo()->getNullDate();
 
-            foreach (array($table1, $table2) as $table)
-            {
-                $object = new \stdClass;
-                $object->data = ContenthistoryHelper::prepareData($table);
-                $object->version_note = $table->version_note;
+			foreach (array($table1, $table2) as $table)
+			{
+				$object = new \stdClass;
+				$object->data = ContenthistoryHelper::prepareData($table);
+				$object->version_note = $table->version_note;
 
-                // Let's use custom calendars when present
-                $object->save_date = HTMLHelper::_('date', $table->save_date, Text::_('DATE_FORMAT_LC6'));
+				// Let's use custom calendars when present
+				$object->save_date = HTMLHelper::_('date', $table->save_date, Text::_('DATE_FORMAT_LC6'));
 
-                $dateProperties = array (
-                    'modified_time',
-                    'created_time',
-                    'modified',
-                    'created',
-                    'checked_out_time',
-                    'publish_up',
-                    'publish_down',
-                );
+				$dateProperties = array (
+					'modified_time',
+					'created_time',
+					'modified',
+					'created',
+					'checked_out_time',
+					'publish_up',
+					'publish_down',
+				);
 
-                foreach ($dateProperties as $dateProperty)
-                {
-                    if (property_exists($object->data, $dateProperty)
-                        && $object->data->$dateProperty->value !== null
-                        && $object->data->$dateProperty->value !== $nullDate)
-                    {
-                        $object->data->$dateProperty->value = HTMLHelper::_(
-                            'date',
-                            $object->data->$dateProperty->value,
-                            Text::_('DATE_FORMAT_LC6')
-                        );
-                    }
-                }
+				foreach ($dateProperties as $dateProperty)
+				{
+					if (property_exists($object->data, $dateProperty)
+						&& $object->data->$dateProperty->value !== null
+						&& $object->data->$dateProperty->value !== $nullDate)
+					{
+						$object->data->$dateProperty->value = HTMLHelper::_(
+							'date',
+							$object->data->$dateProperty->value,
+							Text::_('DATE_FORMAT_LC6')
+						);
+					}
+				}
 
-                $result[] = $object;
-            }
+				$result[] = $object;
+			}
 
-            return $result;
+			return $result;
 		}
 
 		return false;

--- a/administrator/components/com_contenthistory/src/Model/HistoryModel.php
+++ b/administrator/components/com_contenthistory/src/Model/HistoryModel.php
@@ -224,6 +224,7 @@ class HistoryModel extends ListModel
 		{
 			throw new NotAllowed(Text::_('JERROR_ALERTNOAUTHOR'), 403);
 		}
+
 		return $items;
 	}
 

--- a/administrator/components/com_contenthistory/src/Model/HistoryModel.php
+++ b/administrator/components/com_contenthistory/src/Model/HistoryModel.php
@@ -203,6 +203,8 @@ class HistoryModel extends ListModel
 	 * @return  mixed  An array of data items on success, false on failure.
 	 *
 	 * @since   3.4.5
+	 *
+	 * @throws  NotAllowed   Thrown if not authorised to edit an item
 	 */
 	public function getItems()
 	{

--- a/administrator/components/com_contenthistory/src/Model/HistoryModel.php
+++ b/administrator/components/com_contenthistory/src/Model/HistoryModel.php
@@ -224,7 +224,6 @@ class HistoryModel extends ListModel
 		{
 			throw new NotAllowed(Text::_('JERROR_ALERTNOAUTHOR'), 403);
 		}
-		
 		return $items;
 	}
 

--- a/administrator/components/com_contenthistory/src/Model/HistoryModel.php
+++ b/administrator/components/com_contenthistory/src/Model/HistoryModel.php
@@ -81,9 +81,9 @@ class HistoryModel extends ListModel
 		 */
 		$user   = Factory::getUser();
 
-		if ($result = $user->authorise('core.edit', $record->item_id))
+		if ($user->authorise('core.edit', $record->item_id))
 		{
-			return $result;
+			return true;
 		}
 
 		// Finally try session (this catches edit.own case too)

--- a/administrator/components/com_contenthistory/src/Model/HistoryModel.php
+++ b/administrator/components/com_contenthistory/src/Model/HistoryModel.php
@@ -80,6 +80,7 @@ class HistoryModel extends ListModel
 		 * for the content item, not delete permissions for the content history row.
 		 */
 		$user   = Factory::getUser();
+
 		if ($result = $user->authorise('core.edit', $record->item_id))
 		{
 			return $result;

--- a/administrator/components/com_contenthistory/src/Model/HistoryModel.php
+++ b/administrator/components/com_contenthistory/src/Model/HistoryModel.php
@@ -11,6 +11,7 @@ namespace Joomla\Component\Contenthistory\Administrator\Model;
 
 \defined('_JEXEC') or die;
 
+use Joomla\CMS\Access\Exception\NotAllowed;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Helper\CMSHelper;
@@ -219,16 +220,12 @@ class HistoryModel extends ListModel
 		}
 
 		// Access check
-		if ($user->authorise('core.edit', $items[0]->item_id) || $this->canEdit($items[0]))
+		if (!$user->authorise('core.edit', $items[0]->item_id) || !$this->canEdit($items[0]))
 		{
-			return $items;
-		}
-		else
-		{
-			$this->setError(Text::_('JERROR_ALERTNOAUTHOR'));
+            throw new NotAllowed(Text::_('JERROR_ALERTNOAUTHOR'), 403);
 
-			return false;
 		}
+        return $items;
 	}
 
 	/**

--- a/administrator/components/com_contenthistory/src/Model/HistoryModel.php
+++ b/administrator/components/com_contenthistory/src/Model/HistoryModel.php
@@ -222,10 +222,10 @@ class HistoryModel extends ListModel
 		// Access check
 		if (!$user->authorise('core.edit', $items[0]->item_id) || !$this->canEdit($items[0]))
 		{
-            throw new NotAllowed(Text::_('JERROR_ALERTNOAUTHOR'), 403);
+			throw new NotAllowed(Text::_('JERROR_ALERTNOAUTHOR'), 403);
 
 		}
-        return $items;
+		return $items;
 	}
 
 	/**

--- a/administrator/components/com_contenthistory/src/Model/HistoryModel.php
+++ b/administrator/components/com_contenthistory/src/Model/HistoryModel.php
@@ -225,6 +225,7 @@ class HistoryModel extends ListModel
 			throw new NotAllowed(Text::_('JERROR_ALERTNOAUTHOR'), 403);
 
 		}
+		
 		return $items;
 	}
 

--- a/administrator/components/com_contenthistory/src/Model/HistoryModel.php
+++ b/administrator/components/com_contenthistory/src/Model/HistoryModel.php
@@ -223,7 +223,6 @@ class HistoryModel extends ListModel
 		if (!$user->authorise('core.edit', $items[0]->item_id) || !$this->canEdit($items[0]))
 		{
 			throw new NotAllowed(Text::_('JERROR_ALERTNOAUTHOR'), 403);
-
 		}
 		
 		return $items;

--- a/administrator/components/com_contenthistory/src/Model/PreviewModel.php
+++ b/administrator/components/com_contenthistory/src/Model/PreviewModel.php
@@ -16,6 +16,8 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Model\ItemModel;
+use Joomla\CMS\Table\ContentHistory;
+use Joomla\CMS\Table\ContentType;
 use Joomla\CMS\Table\Table;
 use Joomla\Component\Contenthistory\Administrator\Helper\ContenthistoryHelper;
 
@@ -34,10 +36,12 @@ class PreviewModel extends ItemModel
 	 * @return  \stdClass|boolean    On success, standard object with row data. False on failure.
 	 *
 	 * @since   3.2
+	 *
+	 * @throws  NotAllowed   Thrown if not authorised to edit an item
 	 */
 	public function getItem($pk = null)
 	{
-		/** @var \Joomla\CMS\Table\ContentHistory $table */
+		/** @var ContentHistory $table */
 		$table = $this->getTable('ContentHistory');
 		$versionId = Factory::getApplication()->input->getInt('version_id');
 
@@ -109,7 +113,7 @@ class PreviewModel extends ItemModel
 	/**
 	 * Method to test whether a record is editable
 	 *
-	 * @param   \Joomla\CMS\Table\ContentHistory  $record  A Table object.
+	 * @param   ContentHistory  $record  A Table object.
 	 *
 	 * @return  boolean  True if allowed to edit the record. Defaults to the permission set in the component.
 	 *

--- a/administrator/components/com_contenthistory/src/Model/PreviewModel.php
+++ b/administrator/components/com_contenthistory/src/Model/PreviewModel.php
@@ -51,43 +51,43 @@ class PreviewModel extends ItemModel
 		// Access check
 		if (!$user->authorise('core.edit', $table->item_id) || !$this->canEdit($table))
 		{
-            throw new NotAllowed(Text::_('JERROR_ALERTNOAUTHOR'), 403);
+			throw new NotAllowed(Text::_('JERROR_ALERTNOAUTHOR'), 403);
 		}
 
-        $result = new \stdClass;
-        $result->version_note = $table->version_note;
-        $result->data = ContenthistoryHelper::prepareData($table);
+		$result = new \stdClass;
+		$result->version_note = $table->version_note;
+		$result->data = ContenthistoryHelper::prepareData($table);
 
-        // Let's use custom calendars when present
-        $result->save_date = HTMLHelper::_('date', $table->save_date, Text::_('DATE_FORMAT_LC6'));
+		// Let's use custom calendars when present
+		$result->save_date = HTMLHelper::_('date', $table->save_date, Text::_('DATE_FORMAT_LC6'));
 
-        $dateProperties = array (
-            'modified_time',
-            'created_time',
-            'modified',
-            'created',
-            'checked_out_time',
-            'publish_up',
-            'publish_down',
-        );
+		$dateProperties = array (
+			'modified_time',
+			'created_time',
+			'modified',
+			'created',
+			'checked_out_time',
+			'publish_up',
+			'publish_down',
+		);
 
-        $nullDate = $this->getDbo()->getNullDate();
+		$nullDate = $this->getDbo()->getNullDate();
 
-        foreach ($dateProperties as $dateProperty)
-        {
-            if (property_exists($result->data, $dateProperty)
-                && $result->data->$dateProperty->value !== null
-                && $result->data->$dateProperty->value !== $nullDate)
-            {
-                $result->data->$dateProperty->value = HTMLHelper::_(
-                    'date',
-                    $result->data->$dateProperty->value,
-                    Text::_('DATE_FORMAT_LC6')
-                );
-            }
-        }
+		foreach ($dateProperties as $dateProperty)
+		{
+			if (property_exists($result->data, $dateProperty)
+				&& $result->data->$dateProperty->value !== null
+				&& $result->data->$dateProperty->value !== $nullDate)
+			{
+				$result->data->$dateProperty->value = HTMLHelper::_(
+					'date',
+					$result->data->$dateProperty->value,
+					Text::_('DATE_FORMAT_LC6')
+				);
+			}
+		}
 
-        return $result;
+		return $result;
 	}
 
 	/**

--- a/administrator/components/com_contenthistory/src/Model/PreviewModel.php
+++ b/administrator/components/com_contenthistory/src/Model/PreviewModel.php
@@ -49,7 +49,7 @@ class PreviewModel extends ItemModel
 		$user = Factory::getUser();
 
 		// Access check
-		if (!$user->authorise('core.edit', $table->item_id) || !$this->canEdit($table))
+		if (!$user->authorise('core.edit', $table->item_id) && !$this->canEdit($table))
 		{
 			throw new NotAllowed(Text::_('JERROR_ALERTNOAUTHOR'), 403);
 		}


### PR DESCRIPTION
While working in this area, noticed bad use of if statements so refactored it a little

**This fixes nothing - it just improves code readability and implements best practices** 

### Summary of Changes

Refactor to apply concept of "return early" by throwing `NotAllowed` exceptions if ACL fails


### Testing Instructions

use com_contenthistory - nothing should be broken, ACL should correctly error, this time with NotAllowed exceptions 

### Expected result

Nothing broken


### Documentation Changes Required

None