### PR TITLE
[4.0] Simplify Module postinstall messages 2

### DIFF
--- a/administrator/components/com_postinstall/src/Model/MessagesModel.php
+++ b/administrator/components/com_postinstall/src/Model/MessagesModel.php
@@ -128,7 +128,6 @@ class MessagesModel extends BaseDatabaseModel
 
 		// Add a forced extension filtering to the list
 		$eid = (int) $this->getState('eid', $this->getJoomlaFilesExtensionId());
-
 		$query->where($db->quoteName('extension_id') . ' = :eid')
 			->bind(':eid', $eid, ParameterType::INTEGER);
 
@@ -166,7 +165,7 @@ class MessagesModel extends BaseDatabaseModel
 		$query->where($db->quoteName('enabled') . ' = :published')
 			->bind(':published', $published, ParameterType::INTEGER);
 
-		return $db->setQuery($query)->loadResult(); exit;
+		return $db->setQuery($query)->loadResult();
 	}
 
 	/**

--- a/administrator/components/com_postinstall/src/Model/MessagesModel.php
+++ b/administrator/components/com_postinstall/src/Model/MessagesModel.php
@@ -128,6 +128,7 @@ class MessagesModel extends BaseDatabaseModel
 
 		// Add a forced extension filtering to the list
 		$eid = (int) $this->getState('eid', $this->getJoomlaFilesExtensionId());
+
 		$query->where($db->quoteName('extension_id') . ' = :eid')
 			->bind(':eid', $eid, ParameterType::INTEGER);
 
@@ -143,6 +144,29 @@ class MessagesModel extends BaseDatabaseModel
 		$this->onProcessList($result);
 
 		return $result;
+	}
+
+	/**
+	 * Get total of messages
+	 *
+	 * @return  integer  Total
+	 *
+	 * @since   4.0
+	 */
+	public function getTotal()
+	{
+		$db = $this->getDbo();
+
+		$query = $db->getQuery(true)
+			->select('COUNT(*)')
+			->from($db->quoteName('#__postinstall_messages'));
+
+		// Force filter only enabled messages
+		$published = (int) $this->getState('published', 1);
+		$query->where($db->quoteName('enabled') . ' = :published')
+			->bind(':published', $published, ParameterType::INTEGER);
+
+		return $db->setQuery($query)->loadResult(); exit;
 	}
 
 	/**

--- a/administrator/components/com_postinstall/src/Model/MessagesModel.php
+++ b/administrator/components/com_postinstall/src/Model/MessagesModel.php
@@ -161,7 +161,7 @@ class MessagesModel extends BaseDatabaseModel
 			->from($db->quoteName('#__postinstall_messages'));
 
 		// Force filter only enabled messages
-		$published = (int) $this->getState('published', 1);
+		$published = 1;
 		$query->where($db->quoteName('enabled') . ' = :published')
 			->bind(':published', $published, ParameterType::INTEGER);
 

--- a/administrator/components/com_postinstall/src/Model/MessagesModel.php
+++ b/administrator/components/com_postinstall/src/Model/MessagesModel.php
@@ -161,9 +161,7 @@ class MessagesModel extends BaseDatabaseModel
 			->from($db->quoteName('#__postinstall_messages'));
 
 		// Force filter only enabled messages
-		$published = 1;
-		$query->where($db->quoteName('enabled') . ' = :published')
-			->bind(':published', $published, ParameterType::INTEGER);
+		$query->where($db->quoteName('enabled') . ' = 1');
 
 		return $db->setQuery($query)->loadResult();
 	}

--- a/administrator/modules/mod_post_installation_messages/mod_post_installation_messages.php
+++ b/administrator/modules/mod_post_installation_messages/mod_post_installation_messages.php
@@ -16,12 +16,10 @@ use Joomla\CMS\Helper\ModuleHelper;
 try
 {
 	$messagesModel = new \Joomla\Component\Postinstall\Administrator\Model\MessagesModel(['ignore_request' => true]);
-	$messages      = $messagesModel->getItems();
+	$countUnread  = $messagesModel->getTotal();
 }
 catch (RuntimeException $e)
 {
-	$messages = [];
-
 	// Still render the error message from the Exception object
 	$app->enqueueMessage($e->getMessage(), 'error');
 }

--- a/administrator/modules/mod_post_installation_messages/tmpl/default.php
+++ b/administrator/modules/mod_post_installation_messages/tmpl/default.php
@@ -16,12 +16,12 @@ $hideLinks = $app->input->getBool('hidemainmenu');
 ?>
 <?php if ($app->getIdentity()->authorise('core.manage', 'com_postinstall')) : ?>
 	<div class="header-item-content">
-		<a class="d-flex flex-column <?php echo ($hideLinks ? 'disabled' : ''); ?>" 
+		<a class="d-flex flex-column <?php echo ($hideLinks ? 'disabled' : ''); ?>"
 			href="<?php echo Route::_('index.php?option=com_postinstall&eid=' . $joomlaFilesExtensionId); ?>" title="<?php echo Text::_('MOD_POST_INSTALLATION_MESSAGES'); ?>">
 			<div class="d-flex align-items-end mx-auto">
 				<span class="fas fa-bell" aria-hidden="true"></span>
-				<?php if (count($messages) > 0) : ?>
-					<span class="badge badge-danger"><?php echo count($messages); ?></span>
+				<?php if ($countUnread > 0) : ?>
+					<span class="badge badge-danger"><?php echo $countUnread; ?></span>
 				<?php endif; ?>
 			</div>
 			<div class="tiny">


### PR DESCRIPTION
Pull Request for Issue #26109 .

### Summary of Changes
New method getTota() n the model postinstall messages, as we no longer need the messages themselves but only the number. 

### Testing Instructions
Install the patch and see that the number is indicated correctly. Compare with the number of enabled entries in the Table for postinstall messages.

### Expected result
The number indicates the enabled messages .

### Actual result
The number is not correct. After a fresh installation it is 3. 


### Documentation Changes Required
no
