### PR TITLE
[4.0] Fix WebAuthn white icons

### DIFF
--- a/layouts/plugins/system/webauthn/manage.php
+++ b/layouts/plugins/system/webauthn/manage.php
@@ -98,11 +98,11 @@ $postbackURL = base64_encode(rtrim(Uri::base(), '/') . '/index.php?' . Joomla::g
 				<td><?php echo htmlentities($method['label']) ?></td>
 				<td>
 					<button data-random-id="<?php echo $randomId; ?>" class="plg_system_webauthn-manage-edit btn btn-secondary">
-						<span class="icon-edit icon-white" aria-hidden="true"></span>
+						<span class="fas fa-edit" aria-hidden="true"></span>
 						<?php echo Text::_('PLG_SYSTEM_WEBAUTHN_MANAGE_BTN_EDIT_LABEL') ?>
 					</button>
 					<button data-random-id="<?php echo $randomId; ?>" class="plg_system_webauthn-manage-delete btn btn-danger">
-						<span class="icon-minus-sign icon-white" aria-hidden="true"></span>
+						<span class="fas fa-minus" aria-hidden="true"></span>
 						<?php echo Text::_('PLG_SYSTEM_WEBAUTHN_MANAGE_BTN_DELETE_LABEL') ?>
 					</button>
 				</td>
@@ -127,7 +127,7 @@ $postbackURL = base64_encode(rtrim(Uri::base(), '/') . '/index.php?' . Joomla::g
 				id="plg_system_webauthn-manage-add"
 				class="btn btn-success btn-block"
 				data-random-id="<?php echo $randomId; ?>">
-				<span class="icon-plus icon-white" aria-hidden="true"></span>
+				<span class="fas fa-plus" aria-hidden="true"></span>
 				<?php echo Text::_('PLG_SYSTEM_WEBAUTHN_MANAGE_BTN_ADD_LABEL') ?>
 			</button>
 		</p>


### PR DESCRIPTION
Pull Request for Issue #29700

### Summary of Changes

- Replace the `icon-` prefix with `fa-`
- Remove the `icon-white` class so that icons inherit the colour of the parent

### Testing Instructions

Code review