### PR TITLE
[4.0] Correct class casing

### DIFF
--- a/administrator/components/com_users/src/Model/LevelsModel.php
+++ b/administrator/components/com_users/src/Model/LevelsModel.php
@@ -156,7 +156,7 @@ class LevelsModel extends ListModel
 		$user = Factory::getUser();
 
 		// Get an instance of the record's table.
-		$table = Table::getInstance('viewlevel', 'Joomla\\CMS\Table\\');
+		$table = Table::getInstance('ViewLevel', 'Joomla\\CMS\Table\\');
 
 		// Load the row.
 		if (!$table->load($pk))


### PR DESCRIPTION
### Summary of Changes

Corrects class name, fixing potential issue on case sensitive filesystems.

### Testing Instructions

No idea how to trigger this code, but you can test that current code doesn't work by running this code on case sensitive system (e.g. Linux):

`var_dump(JTable::getInstance('viewlevel', 'Joomla\\CMS\Table\\'));`

### Expected result

Table object.

### Actual result

`false`.

### Documentation Changes Required

No.