### PR TITLE
[4.0] WebAuthn: Cannot take an administrative action after adding an authenticator

### DIFF
--- a/build/media_source/plg_system_webauthn/js/management.es6.js
+++ b/build/media_source/plg_system_webauthn/js/management.es6.js
@@ -54,7 +54,7 @@ window.Joomla = window.Joomla || {};
    * @param   {String}  message
    */
   const handleCreationError = (message) => {
-    Joomla.renderMessages({error: [message]});
+    Joomla.renderMessages({ error: [message] });
   };
 
   /**
@@ -71,7 +71,7 @@ window.Joomla = window.Joomla || {};
   Joomla.plgSystemWebauthnCreateCredentials = (storeID, interfaceSelector) => {
     // Make sure the browser supports Webauthn
     if (!('credentials' in navigator)) {
-      Joomla.renderMessages({error: [Joomla.JText._('PLG_SYSTEM_WEBAUTHN_ERR_NO_BROWSER_SUPPORT')]});
+      Joomla.renderMessages({ error: [Joomla.JText._('PLG_SYSTEM_WEBAUTHN_ERR_NO_BROWSER_SUPPORT')] });
 
       return;
     }
@@ -104,7 +104,7 @@ window.Joomla = window.Joomla || {};
 
     // Convert the public key information to a format usable by the browser's credentials manager
     publicKey.challenge = Uint8Array.from(
-      window.atob(base64url2base64(publicKey.challenge)), (c) => c.charCodeAt(0)
+      window.atob(base64url2base64(publicKey.challenge)), (c) => c.charCodeAt(0),
     );
 
     publicKey.user.id = Uint8Array.from(window.atob(publicKey.user.id), (c) => c.charCodeAt(0));
@@ -117,7 +117,7 @@ window.Joomla = window.Joomla || {};
     }
 
     // Ask the browser to prompt the user for their authenticator
-    navigator.credentials.create({publicKey})
+    navigator.credentials.create({ publicKey })
       .then((data) => {
         const publicKeyCredential = {
           id: data.id,
@@ -125,8 +125,8 @@ window.Joomla = window.Joomla || {};
           rawId: arrayToBase64String(new Uint8Array(data.rawId)),
           response: {
             clientDataJSON: arrayToBase64String(new Uint8Array(data.response.clientDataJSON)),
-            attestationObject: arrayToBase64String(new Uint8Array(data.response.attestationObject))
-          }
+            attestationObject: arrayToBase64String(new Uint8Array(data.response.attestationObject)),
+          },
         };
 
         // Send the response to your server
@@ -137,7 +137,7 @@ window.Joomla = window.Joomla || {};
           format: 'raw',
           akaction: 'create',
           encoding: 'raw',
-          data: btoa(JSON.stringify(publicKeyCredential))
+          data: btoa(JSON.stringify(publicKeyCredential)),
         };
 
         Joomla.request({
@@ -159,7 +159,7 @@ window.Joomla = window.Joomla || {};
           },
           onError: (xhr) => {
             handleCreationError(`${xhr.status} ${xhr.statusText}`);
-          }
+          },
         });
       })
       .catch((error) => {
@@ -220,7 +220,7 @@ window.Joomla = window.Joomla || {};
           encoding: 'json',
           akaction: 'savelabel',
           credential_id: credentialId,
-          new_label: elNewLabel
+          new_label: elNewLabel,
         };
 
         Joomla.request({
@@ -238,16 +238,16 @@ window.Joomla = window.Joomla || {};
 
             if (result !== true) {
               handleCreationError(
-                Joomla.JText._('PLG_SYSTEM_WEBAUTHN_ERR_LABEL_NOT_SAVED')
+                Joomla.JText._('PLG_SYSTEM_WEBAUTHN_ERR_LABEL_NOT_SAVED'),
               );
             }
           },
           onError: (xhr) => {
             handleCreationError(
               `${Joomla.JText._('PLG_SYSTEM_WEBAUTHN_ERR_LABEL_NOT_SAVED')
-              } -- ${xhr.status} ${xhr.statusText}`
+              } -- ${xhr.status} ${xhr.statusText}`,
             );
-          }
+          },
         });
       }
 
@@ -317,7 +317,7 @@ window.Joomla = window.Joomla || {};
       format: 'json',
       encoding: 'json',
       akaction: 'delete',
-      credential_id: credentialId
+      credential_id: credentialId,
     };
 
     Joomla.request({
@@ -348,9 +348,9 @@ window.Joomla = window.Joomla || {};
         elDelete.disabled = false;
         handleCreationError(
           `${Joomla.JText._('PLG_SYSTEM_WEBAUTHN_ERR_NOT_DELETED')
-          } -- ${xhr.status} ${xhr.statusText}`
+          } -- ${xhr.status} ${xhr.statusText}`,
         );
-      }
+      },
     });
 
     return false;

--- a/build/media_source/plg_system_webauthn/js/management.es6.js
+++ b/build/media_source/plg_system_webauthn/js/management.es6.js
@@ -34,7 +34,7 @@ window.Joomla = window.Joomla || {};
         } else {
           encodedString
             += `${encodeURIComponent(prefix)}[${encodeURIComponent(prop)}]=${encodeURIComponent(
-              object[prop]
+              object[prop],
             )}`;
         }
 
@@ -335,7 +335,7 @@ window.Joomla = window.Joomla || {};
 
         if (result !== true) {
           handleCreationError(
-            Joomla.JText._('PLG_SYSTEM_WEBAUTHN_ERR_NOT_DELETED')
+            Joomla.JText._('PLG_SYSTEM_WEBAUTHN_ERR_NOT_DELETED'),
           );
 
           return;

--- a/build/media_source/plg_system_webauthn/js/management.es6.js
+++ b/build/media_source/plg_system_webauthn/js/management.es6.js
@@ -423,7 +423,7 @@ window.Joomla = window.Joomla || {};
         button.addEventListener('click', Joomla.plgSystemWebauthnDeleteOnClick);
       });
     }
-  }
+  };
 
   // Initialization. Runs on DOM content loaded since this script is always loaded deferred.
   Joomla.plgSystemWebauthnInitialize();

--- a/build/media_source/plg_system_webauthn/js/management.es6.js
+++ b/build/media_source/plg_system_webauthn/js/management.es6.js
@@ -34,8 +34,8 @@ window.Joomla = window.Joomla || {};
         } else {
           encodedString
             += `${encodeURIComponent(prefix)}[${encodeURIComponent(prop)}]=${encodeURIComponent(
-              object[prop],
-            )}`;
+            object[prop]
+          )}`;
         }
 
         return;
@@ -54,7 +54,7 @@ window.Joomla = window.Joomla || {};
    * @param   {String}  message
    */
   const handleCreationError = (message) => {
-    Joomla.renderMessages({ error: [message] });
+    Joomla.renderMessages({error: [message]});
   };
 
   /**
@@ -71,7 +71,7 @@ window.Joomla = window.Joomla || {};
   Joomla.plgSystemWebauthnCreateCredentials = (storeID, interfaceSelector) => {
     // Make sure the browser supports Webauthn
     if (!('credentials' in navigator)) {
-      Joomla.renderMessages({ error: [Joomla.JText._('PLG_SYSTEM_WEBAUTHN_ERR_NO_BROWSER_SUPPORT')] });
+      Joomla.renderMessages({error: [Joomla.JText._('PLG_SYSTEM_WEBAUTHN_ERR_NO_BROWSER_SUPPORT')]});
 
       return;
     }
@@ -104,7 +104,7 @@ window.Joomla = window.Joomla || {};
 
     // Convert the public key information to a format usable by the browser's credentials manager
     publicKey.challenge = Uint8Array.from(
-      window.atob(base64url2base64(publicKey.challenge)), (c) => c.charCodeAt(0),
+      window.atob(base64url2base64(publicKey.challenge)), (c) => c.charCodeAt(0)
     );
 
     publicKey.user.id = Uint8Array.from(window.atob(publicKey.user.id), (c) => c.charCodeAt(0));
@@ -117,7 +117,7 @@ window.Joomla = window.Joomla || {};
     }
 
     // Ask the browser to prompt the user for their authenticator
-    navigator.credentials.create({ publicKey })
+    navigator.credentials.create({publicKey})
       .then((data) => {
         const publicKeyCredential = {
           id: data.id,
@@ -125,8 +125,8 @@ window.Joomla = window.Joomla || {};
           rawId: arrayToBase64String(new Uint8Array(data.rawId)),
           response: {
             clientDataJSON: arrayToBase64String(new Uint8Array(data.response.clientDataJSON)),
-            attestationObject: arrayToBase64String(new Uint8Array(data.response.attestationObject)),
-          },
+            attestationObject: arrayToBase64String(new Uint8Array(data.response.attestationObject))
+          }
         };
 
         // Send the response to your server
@@ -137,7 +137,7 @@ window.Joomla = window.Joomla || {};
           format: 'raw',
           akaction: 'create',
           encoding: 'raw',
-          data: btoa(JSON.stringify(publicKeyCredential)),
+          data: btoa(JSON.stringify(publicKeyCredential))
         };
 
         Joomla.request({
@@ -154,10 +154,12 @@ window.Joomla = window.Joomla || {};
             const elContainer = elements[0];
 
             elContainer.outerHTML = responseHTML;
+
+            Joomla.plgSystemWebauthnInitialize();
           },
           onError: (xhr) => {
             handleCreationError(`${xhr.status} ${xhr.statusText}`);
-          },
+          }
         });
       })
       .catch((error) => {
@@ -218,7 +220,7 @@ window.Joomla = window.Joomla || {};
           encoding: 'json',
           akaction: 'savelabel',
           credential_id: credentialId,
-          new_label: elNewLabel,
+          new_label: elNewLabel
         };
 
         Joomla.request({
@@ -236,16 +238,16 @@ window.Joomla = window.Joomla || {};
 
             if (result !== true) {
               handleCreationError(
-                Joomla.JText._('PLG_SYSTEM_WEBAUTHN_ERR_LABEL_NOT_SAVED'),
+                Joomla.JText._('PLG_SYSTEM_WEBAUTHN_ERR_LABEL_NOT_SAVED')
               );
             }
           },
           onError: (xhr) => {
             handleCreationError(
               `${Joomla.JText._('PLG_SYSTEM_WEBAUTHN_ERR_LABEL_NOT_SAVED')
-              } -- ${xhr.status} ${xhr.statusText}`,
+              } -- ${xhr.status} ${xhr.statusText}`
             );
-          },
+          }
         });
       }
 
@@ -315,7 +317,7 @@ window.Joomla = window.Joomla || {};
       format: 'json',
       encoding: 'json',
       akaction: 'delete',
-      credential_id: credentialId,
+      credential_id: credentialId
     };
 
     Joomla.request({
@@ -333,7 +335,7 @@ window.Joomla = window.Joomla || {};
 
         if (result !== true) {
           handleCreationError(
-            Joomla.JText._('PLG_SYSTEM_WEBAUTHN_ERR_NOT_DELETED'),
+            Joomla.JText._('PLG_SYSTEM_WEBAUTHN_ERR_NOT_DELETED')
           );
 
           return;
@@ -346,49 +348,83 @@ window.Joomla = window.Joomla || {};
         elDelete.disabled = false;
         handleCreationError(
           `${Joomla.JText._('PLG_SYSTEM_WEBAUTHN_ERR_NOT_DELETED')
-          } -- ${xhr.status} ${xhr.statusText}`,
+          } -- ${xhr.status} ${xhr.statusText}`
         );
-      },
+      }
     });
 
     return false;
   };
 
+  /**
+   * Add New Authenticator button click handler
+   *
+   * @param   {MouseEvent} event  The mouse click event
+   *
+   * @returns {boolean} Returns false to prevent the default browser button behavior
+   */
+  Joomla.plgSystemWebauthnAddOnClick = (event) => {
+    event.preventDefault();
+
+    Joomla.plgSystemWebauthnCreateCredentials(event.currentTarget.getAttribute('data-random-id'), '#plg_system_webauthn-management-interface');
+
+    return false;
+  };
+
+  /**
+   * Edit Name button click handler
+   *
+   * @param   {MouseEvent} event  The mouse click event
+   *
+   * @returns {boolean} Returns false to prevent the default browser button behavior
+   */
+  Joomla.plgSystemWebauthnEditOnClick = (event) => {
+    event.preventDefault();
+
+    Joomla.plgSystemWebauthnEditLabel(event.currentTarget, event.currentTarget.getAttribute('data-random-id'));
+
+    return false;
+  };
+
+  /**
+   * Remove button click handler
+   *
+   * @param   {MouseEvent} event  The mouse click event
+   *
+   * @returns {boolean} Returns false to prevent the default browser button behavior
+   */
+  Joomla.plgSystemWebauthnDeleteOnClick = (event) => {
+    event.preventDefault();
+
+    Joomla.plgSystemWebauthnDelete(event.currentTarget, event.currentTarget.getAttribute('data-random-id'));
+
+    return false;
+  };
+
+  /**
+   * Initialization on page load.
+   */
+  Joomla.plgSystemWebauthnInitialize = () => {
+    const addButton = document.getElementById('plg_system_webauthn-manage-add');
+    if (addButton) {
+      addButton.addEventListener('click', Joomla.plgSystemWebauthnAddOnClick);
+    }
+
+    const editLabelButtons = [].slice.call(document.querySelectorAll('.plg_system_webauthn-manage-edit'));
+    if (editLabelButtons.length) {
+      editLabelButtons.forEach((button) => {
+        button.addEventListener('click', Joomla.plgSystemWebauthnEditOnClick);
+      });
+    }
+
+    const deleteButtons = [].slice.call(document.querySelectorAll('.plg_system_webauthn-manage-delete'));
+    if (deleteButtons.length) {
+      deleteButtons.forEach((button) => {
+        button.addEventListener('click', Joomla.plgSystemWebauthnDeleteOnClick);
+      });
+    }
+  }
+
   // Initialization. Runs on DOM content loaded since this script is always loaded deferred.
-  const addButton = document.getElementById('plg_system_webauthn-manage-add');
-  if (addButton) {
-    addButton.addEventListener('click', (event) => {
-      event.preventDefault();
-
-      Joomla.plgSystemWebauthnCreateCredentials(event.currentTarget.getAttribute('data-random-id'), '#plg_system_webauthn-management-interface');
-
-      return false;
-    });
-  }
-
-  const editLabelButtons = [].slice.call(document.querySelectorAll('.plg_system_webauthn-manage-edit'));
-  if (editLabelButtons.length) {
-    editLabelButtons.forEach((button) => {
-      button.addEventListener('click', (event) => {
-        event.preventDefault();
-
-        Joomla.plgSystemWebauthnEditLabel(event.currentTarget, event.currentTarget.getAttribute('data-random-id'));
-
-        return false;
-      });
-    });
-  }
-
-  const deleteButtons = [].slice.call(document.querySelectorAll('.plg_system_webauthn-manage-delete'));
-  if (deleteButtons.length) {
-    deleteButtons.forEach((button) => {
-      button.addEventListener('click', (event) => {
-        event.preventDefault();
-
-        Joomla.plgSystemWebauthnDelete(event.currentTarget, event.currentTarget.getAttribute('data-random-id'));
-
-        return false;
-      });
-    });
-  }
+  Joomla.plgSystemWebauthnInitialize();
 })(Joomla, document);

--- a/build/media_source/plg_system_webauthn/js/management.es6.js
+++ b/build/media_source/plg_system_webauthn/js/management.es6.js
@@ -34,8 +34,8 @@ window.Joomla = window.Joomla || {};
         } else {
           encodedString
             += `${encodeURIComponent(prefix)}[${encodeURIComponent(prop)}]=${encodeURIComponent(
-            object[prop]
-          )}`;
+              object[prop]
+            )}`;
         }
 
         return;


### PR DESCRIPTION
For example, after adding one authenticator you cannot edit its name or add another authenticator.

Pull Request for Issue #29697 .

### Summary of Changes

Re-attaches the click event handlers after adding an authenticator

This bug is present since the original merge of the WebAuthn feature into Joomla 4. No, I did not contribute a broken feature. The code I had contributed was using ES5 and inline click handlers; it was working just fine. Before merging, Harald converted the ES5 to ES6 and replaced the inline click handlers to event handlers. However, after saving an Authenticator we are replacing the HTML of the `#plg_system_webauthn-management-interface` element with the one loaded from the server. With inline click handlers this worked fine. The new HTML had click handlers and all interface elements worked. After the conversion, Harald forgot to attach event handlers to the new HTML, therefore the interface was inert.

### Testing Instructions

On an HTTPS site's backend edit your user account. Go to the WebAuthn tab.

Add a new authenticator.

Click on its Edit button.

### Expected result

You can edit the authenticator's name.

### Actual result

Nothing happens no matter how hard you click on that button.

### Documentation Changes Required

None.