### PR TITLE
Fix hiddenLabel and add hiddenLegend form attribute

### DIFF
--- a/layouts/joomla/form/renderfield.php
+++ b/layouts/joomla/form/renderfield.php
@@ -30,17 +30,17 @@ if (!empty($options['showonEnabled']))
 	$wa->useScript('showon');
 }
 
-$class      = empty($options['class']) ? '' : ' ' . $options['class'];
-$rel        = empty($options['rel']) ? '' : ' ' . $options['rel'];
-$id         = $name . '-desc';
-$hide       = empty($options['hiddenLabel']) ? '' : ' sr-only';
-$hideLegend = empty($options['hiddenLegend']) ? false : $options['hiddenLegend'];
+$class           = empty($options['class']) ? '' : ' ' . $options['class'];
+$rel             = empty($options['rel']) ? '' : ' ' . $options['rel'];
+$id              = $name . '-desc';
+$hide            = empty($options['hiddenLabel']) ? '' : ' sr-only';
+$hideDescription = empty($options['hiddenDescription']) ? false : $options['hiddenDescription'];
 ?>
 <div class="control-group<?php echo $class; ?>"<?php echo $rel; ?>>
 	<div class="control-label<?php echo $hide; ?>"><?php echo $label; ?></div>
 	<div class="controls">
 		<?php echo $input; ?>
-		<?php if (!$hideLegend) : ?>
+		<?php if (!$hideDescription) : ?>
 			<?php if (!empty($description)) : ?>
 				<div id="<?php echo $id; ?>">
 					<small class="form-text text-muted">

--- a/layouts/joomla/form/renderfield.php
+++ b/layouts/joomla/form/renderfield.php
@@ -29,22 +29,25 @@ if (!empty($options['showonEnabled']))
 	$wa = Factory::getApplication()->getDocument()->getWebAssetManager();
 	$wa->useScript('showon');
 }
-$class = empty($options['class']) ? '' : ' ' . $options['class'];
-$rel   = empty($options['rel']) ? '' : ' ' . $options['rel'];
-$id    = $name . '-desc';
-$hide  = empty($options['hiddenLabel']) ? '' : ' sr-only';
 
+$class      = empty($options['class']) ? '' : ' ' . $options['class'];
+$rel        = empty($options['rel']) ? '' : ' ' . $options['rel'];
+$id         = $name . '-desc';
+$hide       = empty($options['hiddenLabel']) ? '' : ' sr-only';
+$hideLegend = empty($options['hiddenLegend']) ? false : $options['hiddenLegend'];
 ?>
 <div class="control-group<?php echo $class; ?>"<?php echo $rel; ?>>
 	<div class="control-label<?php echo $hide; ?>"><?php echo $label; ?></div>
 	<div class="controls">
 		<?php echo $input; ?>
-		<?php if (!empty($description)) : ?>
-			<div id="<?php echo $id; ?>">
-				<small class="form-text text-muted">
-					<?php echo $description; ?>
-				</small>
-			</div>
+		<?php if (!$hideLegend) : ?>
+			<?php if (!empty($description)) : ?>
+				<div id="<?php echo $id; ?>">
+					<small class="form-text text-muted">
+						<?php echo $description; ?>
+					</small>
+				</div>
+			<?php endif; ?>
 		<?php endif; ?>
 	</div>
 </div>

--- a/layouts/joomla/form/renderfield.php
+++ b/layouts/joomla/form/renderfield.php
@@ -40,14 +40,12 @@ $hideDescription = empty($options['hiddenDescription']) ? false : $options['hidd
 	<div class="control-label<?php echo $hide; ?>"><?php echo $label; ?></div>
 	<div class="controls">
 		<?php echo $input; ?>
-		<?php if (!$hideDescription) : ?>
-			<?php if (!empty($description)) : ?>
-				<div id="<?php echo $id; ?>">
-					<small class="form-text text-muted">
-						<?php echo $description; ?>
-					</small>
-				</div>
-			<?php endif; ?>
+		<?php if (!$hideDescription && !empty($description)) : ?>
+			<div id="<?php echo $id; ?>">
+				<small class="form-text text-muted">
+					<?php echo $description; ?>
+				</small>
+			</div>
 		<?php endif; ?>
 	</div>
 </div>

--- a/libraries/src/Form/Field/NoteField.php
+++ b/libraries/src/Form/Field/NoteField.php
@@ -31,6 +31,14 @@ class NoteField extends FormField
 	protected $type = 'Note';
 
 	/**
+	 * Hide the legend when rendering the form field.
+	 *
+	 * @var    boolean
+	 * @since  4.0.0
+	 */
+	protected $hiddenLegend = true;
+
+	/**
 	 * Method to get the field label markup.
 	 *
 	 * @return  string  The field label markup.

--- a/libraries/src/Form/Field/NoteField.php
+++ b/libraries/src/Form/Field/NoteField.php
@@ -31,12 +31,20 @@ class NoteField extends FormField
 	protected $type = 'Note';
 
 	/**
-	 * Hide the legend when rendering the form field.
+	 * Hide the label when rendering the form field.
 	 *
 	 * @var    boolean
 	 * @since  4.0.0
 	 */
-	protected $hiddenLegend = true;
+	protected $hiddenLabel = true;
+
+	/**
+	 * Hide the description when rendering the form field.
+	 *
+	 * @var    boolean
+	 * @since  4.0.0
+	 */
+	protected $hiddenDescription = true;
 
 	/**
 	 * Method to get the field label markup.

--- a/libraries/src/Form/FormField.php
+++ b/libraries/src/Form/FormField.php
@@ -111,13 +111,13 @@ abstract class FormField
 	protected $hiddenLabel = false;
 
 	/**
-	 * Should the legend be hidden when rendering the form field? This may be useful if you have the
+	 * Should the description be hidden when rendering the form field? This may be useful if you have the
 	 * description rendering in your form field itself for e.g. note fields.
 	 *
 	 * @var    boolean
 	 * @since  4.0.0
 	 */
-	protected $hiddenLegend = false;
+	protected $hiddenDescription = false;
 
 	/**
 	 * True to translate the field label string.
@@ -1048,15 +1048,15 @@ abstract class FormField
 			}
 		}
 
-		if (empty($options['hiddenLegend']))
+		if (empty($options['hiddenDescription']))
 		{
-			if ($this->getAttribute('hiddenLegend'))
+			if ($this->getAttribute('hiddenDescription'))
 			{
-				$options['hiddenLegend'] = $this->getAttribute('hiddenLegend') == 'true' ? true : false;
+				$options['hiddenDescription'] = $this->getAttribute('hiddenDescription') == 'true' ? true : false;
 			}
 			else
 			{
-				$options['hiddenLegend'] = $this->hiddenLegend;
+				$options['hiddenDescription'] = $this->hiddenDescription;
 			}
 		}
 

--- a/libraries/src/Form/FormField.php
+++ b/libraries/src/Form/FormField.php
@@ -111,6 +111,15 @@ abstract class FormField
 	protected $hiddenLabel = false;
 
 	/**
+	 * Should the legend be hidden when rendering the form field? This may be useful if you have the
+	 * description rendering in your form field itself for e.g. note fields.
+	 *
+	 * @var    boolean
+	 * @since  4.0.0
+	 */
+	protected $hiddenLegend = false;
+
+	/**
 	 * True to translate the field label string.
 	 *
 	 * @var    boolean
@@ -1027,9 +1036,28 @@ abstract class FormField
 
 		$options['rel'] = '';
 
-		if (empty($options['hiddenLabel']) && $this->getAttribute('hiddenLabel') || $this->hiddenLabel)
+		if (empty($options['hiddenLabel']))
 		{
-			$options['hiddenLabel'] = true;
+			if ($this->getAttribute('hiddenLabel'))
+			{
+				$options['hiddenLabel'] = $this->getAttribute('hiddenLabel') == 'true' ? true : false;
+			}
+			else
+			{
+				$options['hiddenLabel'] = $this->hiddenLabel;
+			}
+		}
+
+		if (empty($options['hiddenLegend']))
+		{
+			if ($this->getAttribute('hiddenLegend'))
+			{
+				$options['hiddenLegend'] = $this->getAttribute('hiddenLegend') == 'true' ? true : false;
+			}
+			else
+			{
+				$options['hiddenLegend'] = $this->hiddenLegend;
+			}
 		}
 
 		if ($this->showon)


### PR DESCRIPTION
Pull Request for Issue #29611 and #29709  .

### Summary of Changes
1. This PR fixes #29709
2. This PR adds form attribute 'hiddenLegend' and fixes #29611 

the PR introduces a new hiddenLegend form attribute that can be set in the xml file as attribute for toggling the legend on any field) or in the layout file to give the attribute an initial value (defaults to true when not set)

### Testing Instructions
1.1 add form attribute hiddenLabel="false" to a form field
2.1 add a form field type Note to a config file
2.2 add form attribute hiddenLegend="false" to the 2.1 added field
2.3 add form attribute hiddenLegend="true" to a form field

### Expected result
1.1 the label for the form field should NOT ( = false)  be hidden
2.1 the legend for the Note field (which is the description that is part of the Note field) should not be displayed
2.2 the legend for the Note field should be DISPLAYED
2.3 the legend for the form field that you added the attribute to should be HIDDEN

### Actual result
whithout this PR:
1.1 the label for the form field IS hidden
2.1 the legend IS shown with the same information as the note itself
2.2 the legend IS shown with the same information as the note itself
2.3 the legend IS shown for the form field that you added the attribute to

### Documentation Changes Required
yes, same changes as made for the 'hiddenLabel' attribute
