### PR TITLE
Use base64 filter for return URL

### DIFF
--- a/administrator/components/com_content/views/article/tmpl/edit.php
+++ b/administrator/components/com_content/views/article/tmpl/edit.php
@@ -137,7 +137,7 @@ $tmpl    = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=c
 		<?php echo JHtml::_('bootstrap.endTabSet'); ?>
 
 		<input type="hidden" name="task" value="" />
-		<input type="hidden" name="return" value="<?php echo $input->getCmd('return'); ?>" />
+		<input type="hidden" name="return" value="<?php echo $input->get('return', null, 'BASE64'); ?>" />
 		<input type="hidden" name="forcedLanguage" value="<?php echo $input->get('forcedLanguage', '', 'cmd'); ?>" />
 		<?php echo JHtml::_('form.token'); ?>
 	</div>

--- a/administrator/components/com_finder/views/filter/tmpl/edit.php
+++ b/administrator/components/com_finder/views/filter/tmpl/edit.php
@@ -98,6 +98,6 @@ JFactory::getDocument()->addStyleDeclaration('
 	</div>
 
 	<input type="hidden" name="task" value="" />
-	<input type="hidden" name="return" value="<?php echo JFactory::getApplication()->input->get('return', '', 'cmd'); ?>" />
+	<input type="hidden" name="return" value="<?php echo JFactory::getApplication()->input->get('return', '', 'BASE64'); ?>" />
 	<?php echo JHtml::_('form.token'); ?>
 </form>

--- a/administrator/components/com_installer/controllers/install.php
+++ b/administrator/components/com_installer/controllers/install.php
@@ -39,7 +39,7 @@ class InstallerControllerInstall extends JControllerLegacy
 
 		if (!$redirect_url)
 		{
-			$redirect_url = base64_decode($app->input->get('return'));
+			$redirect_url = base64_decode($app->input->get('return', null, 'BASE64'));
 		}
 
 		// Don't redirect to an external URL.

--- a/administrator/templates/hathor/html/com_content/article/edit.php
+++ b/administrator/templates/hathor/html/com_content/article/edit.php
@@ -269,7 +269,7 @@ JFactory::getDocument()->addScriptDeclaration("
 	<?php endif; ?>
 	<div>
 		<input type="hidden" name="task" value="" />
-		<input type="hidden" name="return" value="<?php echo $input->getCmd('return');?>" />
+		<input type="hidden" name="return" value="<?php echo $input->get('return', null, 'BASE64');?>" />
 		<?php echo JHtml::_('form.token'); ?>
 	</div>
 </form>


### PR DESCRIPTION
### Summary of Changes

Use base64 filter since we later run the value through `base64_decode()` and default `cmd` filter strips out certain valid base64 characters.

### Testing Instructions

Code review is fine.

### Documentation Changes Required

No.