### PR TITLE
[4.0] Use base64 filter for return URL

### DIFF
--- a/administrator/components/com_mails/tmpl/template/edit.php
+++ b/administrator/components/com_mails/tmpl/template/edit.php
@@ -109,6 +109,6 @@ $doc->addScriptOptions('com_mails', ['templateData' => $this->templateData]);
 	<?php echo $this->form->renderField('template_id'); ?>
 	<?php echo $this->form->renderField('language'); ?>
 	<input type="hidden" name="task" value="">
-	<input type="hidden" name="return" value="<?php echo $input->getCmd('return'); ?>">
+	<input type="hidden" name="return" value="<?php echo $input->get('return', null, 'BASE64'); ?>">
 	<?php echo HTMLHelper::_('form.token'); ?>
 </form>

--- a/administrator/components/com_modules/tmpl/module/edit.php
+++ b/administrator/components/com_modules/tmpl/module/edit.php
@@ -202,7 +202,7 @@ $tmpl    = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=c
 		<?php echo HTMLHelper::_('uitab.endTabSet'); ?>
 
 		<input type="hidden" name="task" value="">
-		<input type="hidden" name="return" value="<?php echo $input->getCmd('return'); ?>">
+		<input type="hidden" name="return" value="<?php echo $input->get('return', null, 'BASE64'); ?>">
 		<?php echo HTMLHelper::_('form.token'); ?>
 		<?php echo $this->form->getInput('module'); ?>
 		<?php echo $this->form->getInput('client_id'); ?>


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/29712.

### Summary of Changes

Use base64 filter since we later run the value through `base64_decode()` and default `cmd` filter strips out certain valid base64 characters.

### Testing Instructions

Code review should be fine or try to reproduce https://github.com/joomla/joomla-cms/issues/29712.

### Documentation Changes Required

No.