### PR TITLE
[4.0] com_messages icon

### DIFF
--- a/administrator/components/com_messages/src/View/Message/HtmlView.php
+++ b/administrator/components/com_messages/src/View/Message/HtmlView.php
@@ -84,7 +84,7 @@ class HtmlView extends BaseHtmlView
 		{
 			Factory::getApplication()->input->set('hidemainmenu', true);
 			ToolbarHelper::title(Text::_('COM_MESSAGES_WRITE_PRIVATE_MESSAGE'), 'envelope-open-text new-privatemessage');
-			ToolbarHelper::save('message.save', 'COM_MESSAGES_TOOLBAR_SEND');
+			ToolbarHelper::custom('message.save', 'envelope.png', 'send_f2.png', 'COM_MESSAGES_TOOLBAR_SEND', false);
 			ToolbarHelper::cancel('message.cancel', 'JTOOLBAR_CLOSE');
 			ToolbarHelper::help('JHELP_COMPONENTS_MESSAGING_WRITE');
 		}


### PR DESCRIPTION
This PR fixes #29540

Changes the Send button icon to an email from a save

Can be tested with patchtester

After
![image](https://user-images.githubusercontent.com/1296369/85183213-da871580-b282-11ea-89f7-0d931b5a82a7.png)
