### PR TITLE
[4.0] Filesystem plugin: limit folders choice to images and any custom folder

### DIFF
--- a/plugins/filesystem/local/local.xml
+++ b/plugins/filesystem/local/local.xml
@@ -42,6 +42,7 @@
 							exclude="administrator|api|cache|cli|components|includes|language|layouts|libraries|modules|plugins|templates|tmp"
 							recursive="true"
 							stripext=""
+							hide_none="true"
 						/>
 					</form>
 				</field>

--- a/plugins/filesystem/local/local.xml
+++ b/plugins/filesystem/local/local.xml
@@ -39,7 +39,8 @@
 							default="images"
 							label="PLG_FILESYSTEM_LOCAL_DIRECTORIES_DIRECTORY_LABEL"
 							folderFilter=""
-							exclude="administrator|api|build|cache|cli|components|includes|installation|language|layouts|libraries|media|modules|node_modules|plugins|templates|tests|tmp"
+							exclude="administrator|api|cache|cli|components|includes|language|layouts|libraries|modules|plugins|templates|tmp"
+							recursive="true"
 							stripext=""
 						/>
 					</form>

--- a/plugins/filesystem/local/local.xml
+++ b/plugins/filesystem/local/local.xml
@@ -39,7 +39,7 @@
 							default="images"
 							label="PLG_FILESYSTEM_LOCAL_DIRECTORIES_DIRECTORY_LABEL"
 							folderFilter=""
-							exclude=""
+							exclude="administrator|api|build|cache|cli|components|includes|installation|language|layouts|libraries|media|modules|node_modules|plugins|templates|tests|tmp"
 							stripext=""
 						/>
 					</form>


### PR DESCRIPTION
### Summary of Changes
Makes no sense to let choose core folders (except `images`) to contain media files.

### Testing Instructions
Display the filesystem local plugin after creating a custom root folder


### Before patch
<img width="1053" alt="Screen Shot 2020-06-20 at 11 09 46" src="https://user-images.githubusercontent.com/869724/85198158-962d6100-b2e6-11ea-8b34-04dbb6475a89.png">


### After patch

<img width="1218" alt="Screen Shot 2020-06-20 at 11 11 38" src="https://user-images.githubusercontent.com/869724/85198188-e73d5500-b2e6-11ea-8a3b-d18d2a1db742.png">

Therefore if we do this
<img width="1217" alt="Screen Shot 2020-06-20 at 11 14 26" src="https://user-images.githubusercontent.com/869724/85198243-48fdbf00-b2e7-11ea-9cd0-6b2136f22f23.png">

we will get this
<img width="693" alt="Screen Shot 2020-06-20 at 11 13 58" src="https://user-images.githubusercontent.com/869724/85198246-52872700-b2e7-11ea-8da9-0dce6c942c2c.png">

### NOTE:
We could also add recursing as proposed and closed here: https://github.com/joomla/joomla-cms/pull/29719 as this limits drastically the number of sub folders to fetch, preventing overload.

If we do, we would get:

<img width="1171" alt="Screen Shot 2020-06-20 at 08 06 48" src="https://user-images.githubusercontent.com/869724/85198335-2ae48e80-b2e8-11ea-97b2-e867c7183e48.png">
