### PR TITLE
[4.0] Webauthn gmp warning

### DIFF
--- a/administrator/language/en-GB/plg_system_webauthn.ini
+++ b/administrator/language/en-GB/plg_system_webauthn.ini
@@ -41,3 +41,5 @@ PLG_SYSTEM_WEBAUTHN_MANAGE_HEADER_ACTIONS_LABEL="Actions"
 PLG_SYSTEM_WEBAUTHN_MANAGE_HEADER_NOMETHODS_LABEL="No authenticators have been set up yet."
 PLG_SYSTEM_WEBAUTHN_MSG_DELETED="The authenticator has been removed."
 PLG_SYSTEM_WEBAUTHN_MSG_SAVED_LABEL="The label has been saved."
+PLG_SYSTEM_WEBAUTHN_REQUIRES_GMP="The PHP Extension GMP is required to be loaded in order to add authenticators."
+

--- a/layouts/plugins/system/webauthn/manage.php
+++ b/layouts/plugins/system/webauthn/manage.php
@@ -57,7 +57,7 @@ $defaultDisplayData = [
 ];
 extract(array_merge($defaultDisplayData, $displayData));
 
-// Ensure GMP Extensions is loaded in PHP
+// Ensure the GMP Extension is loaded in PHP - as this is required by third party library
 if (!in_array('gmp', get_loaded_extensions()))
 {
 	$error = Text::_('PLG_SYSTEM_WEBAUTHN_REQUIRES_GMP');

--- a/layouts/plugins/system/webauthn/manage.php
+++ b/layouts/plugins/system/webauthn/manage.php
@@ -57,6 +57,13 @@ $defaultDisplayData = [
 ];
 extract(array_merge($defaultDisplayData, $displayData));
 
+// Ensure GMP Extensions is loaded in PHP
+if (!in_array('gmp', get_loaded_extensions()))
+{
+	$error = Text::_('PLG_SYSTEM_WEBAUTHN_REQUIRES_GMP');
+	$allow_add = false;
+}
+
 /**
  * Why not push these configuration variables directly to JavaScript?
  *

--- a/layouts/plugins/system/webauthn/manage.php
+++ b/layouts/plugins/system/webauthn/manage.php
@@ -58,7 +58,7 @@ $defaultDisplayData = [
 extract(array_merge($defaultDisplayData, $displayData));
 
 // Ensure the GMP Extension is loaded in PHP - as this is required by third party library
-if (!in_array('gmp', get_loaded_extensions()))
+if (false === function_exists('gmp_intval'))
 {
 	$error = Text::_('PLG_SYSTEM_WEBAUTHN_REQUIRES_GMP');
 	$allow_add = false;


### PR DESCRIPTION
Pull Request for Issue #29696 .

### Summary of Changes

A very light touch change to reuse existing code to display a warning and remove the ability to add authenticators if the PHP extension GMP is not loaded.

### Testing Instructions

Install Joomla 4 on a server (or docker container in my case) **without GMP PHP Extension enabled** (On a cPanel server you can toggle this, and its off by default in Easy Apache 4) 

Ensure you access Joomla over a secure & valid SSL connection (learn ngrok if you need this, quick and easy) 

### Before PR 

When adding an authenticator you get an internal server error


![](https://user-images.githubusercontent.com/400092/85065372-f4522b00-b1a4-11ea-9cb3-0fd2a5e9acdc.png)


### After PR

You get a error and no button allowing you to add a new authenticator (but you can still see the list of existing authenticators - if any - rename them, and delete them.) 

<img width="1227" alt="Screenshot 2020-06-21 at 12 24 50" src="https://user-images.githubusercontent.com/400092/85223320-3bfdd000-b3ba-11ea-897c-25a7dee67726.png">


### Who else to ping for visibility ;-) 
// @nikosdion 
