### PR TITLE
[4.0] Change link to more appropriate link

### DIFF
--- a/administrator/language/en-GB/plg_captcha_recaptcha.ini
+++ b/administrator/language/en-GB/plg_captcha_recaptcha.ini
@@ -4,7 +4,7 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_CAPTCHA_RECAPTCHA="CAPTCHA - reCAPTCHA"
-PLG_CAPTCHA_RECAPTCHA_XML_DESCRIPTION="This CAPTCHA plugin uses the reCAPTCHA service to prevent spammers while it helps to digitize books, newspapers and old radio shows. To get a site and secret key for your domain, go to <a href=\"https://www.google.com/recaptcha\" target=\"_blank\">https://www.google.com/recaptcha</a>. To use this for new account registration, go to Options in the User Manager and select CAPTCHA - reCAPTCHA as the CAPTCHA."
+PLG_CAPTCHA_RECAPTCHA_XML_DESCRIPTION="This CAPTCHA plugin uses the reCAPTCHA service to prevent spammers while it helps to digitize books, newspapers and old radio shows. To get a site and secret key for your domain, go to <a href=\"https://www.google.com/recaptcha/admin\" target=\"_blank\">https://www.google.com/recaptcha</a>. To use this for new account registration, go to Options in the User Manager and select CAPTCHA - reCAPTCHA as the CAPTCHA."
 PLG_RECAPTCHA_CALLBACK_DESC="(Optional) JavaScript callback, executed after successful reCAPTCHA response."
 PLG_RECAPTCHA_CALLBACK_LABEL="Callback"
 PLG_RECAPTCHA_ERROR_CALLBACK_DESC="(Optional) JavaScript callback, executed when the reCAPTCHA encounters an error."

--- a/administrator/language/en-GB/plg_captcha_recaptcha.ini
+++ b/administrator/language/en-GB/plg_captcha_recaptcha.ini
@@ -4,7 +4,7 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_CAPTCHA_RECAPTCHA="CAPTCHA - reCAPTCHA"
-PLG_CAPTCHA_RECAPTCHA_XML_DESCRIPTION="This CAPTCHA plugin uses the reCAPTCHA service to prevent spammers while it helps to digitize books, newspapers and old radio shows. To get a site and secret key for your domain, go to <a href=\"https://www.google.com/recaptcha/admin\" target=\"_blank\">https://www.google.com/recaptcha</a>. To use this for new account registration, go to Options in the User Manager and select CAPTCHA - reCAPTCHA as the CAPTCHA."
+PLG_CAPTCHA_RECAPTCHA_XML_DESCRIPTION="This CAPTCHA plugin uses the reCAPTCHA service to prevent spammers while it helps to digitize books, newspapers and old radio shows. To get a site and secret key for your domain, go to <a href=\"https://www.google.com/recaptcha/admin\" target=\"_blank\">https://www.google.com/recaptcha/admin</a>. To use this for new account registration, go to Options in the User Manager and select CAPTCHA - reCAPTCHA as the CAPTCHA."
 PLG_RECAPTCHA_CALLBACK_DESC="(Optional) JavaScript callback, executed after successful reCAPTCHA response."
 PLG_RECAPTCHA_CALLBACK_LABEL="Callback"
 PLG_RECAPTCHA_ERROR_CALLBACK_DESC="(Optional) JavaScript callback, executed when the reCAPTCHA encounters an error."

--- a/administrator/language/en-GB/plg_captcha_recaptcha.sys.ini
+++ b/administrator/language/en-GB/plg_captcha_recaptcha.sys.ini
@@ -4,4 +4,4 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_CAPTCHA_RECAPTCHA="CAPTCHA - reCAPTCHA"
-PLG_CAPTCHA_RECAPTCHA_XML_DESCRIPTION="This CAPTCHA plugin uses the reCAPTCHA service to prevent spammers while it helps to digitize books, newspapers and old radio shows. To get a site and secret key for your domain, go to <a href=\"https://www.google.com/recaptcha/admin\" target=\"_blank\">https://www.google.com/recaptcha</a>. To use this for new account registration, go to Options in the User Manager and select CAPTCHA - reCAPTCHA as the CAPTCHA."
+PLG_CAPTCHA_RECAPTCHA_XML_DESCRIPTION="This CAPTCHA plugin uses the reCAPTCHA service to prevent spammers while it helps to digitize books, newspapers and old radio shows. To get a site and secret key for your domain, go to <a href=\"https://www.google.com/recaptcha/admin\" target=\"_blank\">https://www.google.com/recaptcha/admin</a>. To use this for new account registration, go to Options in the User Manager and select CAPTCHA - reCAPTCHA as the CAPTCHA."

--- a/administrator/language/en-GB/plg_captcha_recaptcha.sys.ini
+++ b/administrator/language/en-GB/plg_captcha_recaptcha.sys.ini
@@ -4,4 +4,4 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_CAPTCHA_RECAPTCHA="CAPTCHA - reCAPTCHA"
-PLG_CAPTCHA_RECAPTCHA_XML_DESCRIPTION="This CAPTCHA plugin uses the reCAPTCHA service to prevent spammers while it helps to digitize books, newspapers and old radio shows. To get a site and secret key for your domain, go to <a href=\"https://www.google.com/recaptcha\" target=\"_blank\">https://www.google.com/recaptcha</a>. To use this for new account registration, go to Options in the User Manager and select CAPTCHA - reCAPTCHA as the CAPTCHA."
+PLG_CAPTCHA_RECAPTCHA_XML_DESCRIPTION="This CAPTCHA plugin uses the reCAPTCHA service to prevent spammers while it helps to digitize books, newspapers and old radio shows. To get a site and secret key for your domain, go to <a href=\"https://www.google.com/recaptcha/admin\" target=\"_blank\">https://www.google.com/recaptcha</a>. To use this for new account registration, go to Options in the User Manager and select CAPTCHA - reCAPTCHA as the CAPTCHA."

--- a/administrator/language/en-GB/plg_captcha_recaptcha_invisible.ini
+++ b/administrator/language/en-GB/plg_captcha_recaptcha_invisible.ini
@@ -4,7 +4,7 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_CAPTCHA_RECAPTCHA_INVISIBLE="CAPTCHA - Invisible reCAPTCHA"
-PLG_CAPTCHA_RECAPTCHA_INVISIBLE_XML_DESCRIPTION="This CAPTCHA plugin uses the Invisible reCAPTCHA service. To get a site and secret key for your domain, go to <a href=\"https://www.google.com/recaptcha\" target=\"_blank\">https://www.google.com/recaptcha</a>."
+PLG_CAPTCHA_RECAPTCHA_INVISIBLE_XML_DESCRIPTION="This CAPTCHA plugin uses the Invisible reCAPTCHA service. To get a site and secret key for your domain, go to <a href=\"https://www.google.com/recaptcha/admin\" target=\"_blank\">https://www.google.com/recaptcha</a>."
 PLG_RECAPTCHA_INVISIBLE_BADGE_BOTTOMLEFT="Bottom left"
 PLG_RECAPTCHA_INVISIBLE_BADGE_BOTTOMRIGHT="Bottom right"
 PLG_RECAPTCHA_INVISIBLE_BADGE_DESC="Positioning of the reCAPTCHA badge."

--- a/administrator/language/en-GB/plg_captcha_recaptcha_invisible.ini
+++ b/administrator/language/en-GB/plg_captcha_recaptcha_invisible.ini
@@ -4,7 +4,7 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_CAPTCHA_RECAPTCHA_INVISIBLE="CAPTCHA - Invisible reCAPTCHA"
-PLG_CAPTCHA_RECAPTCHA_INVISIBLE_XML_DESCRIPTION="This CAPTCHA plugin uses the Invisible reCAPTCHA service. To get a site and secret key for your domain, go to <a href=\"https://www.google.com/recaptcha/admin\" target=\"_blank\">https://www.google.com/recaptcha</a>."
+PLG_CAPTCHA_RECAPTCHA_INVISIBLE_XML_DESCRIPTION="This CAPTCHA plugin uses the Invisible reCAPTCHA service. To get a site and secret key for your domain, go to <a href=\"https://www.google.com/recaptcha/admin\" target=\"_blank\">https://www.google.com/recaptcha/admin</a>."
 PLG_RECAPTCHA_INVISIBLE_BADGE_BOTTOMLEFT="Bottom left"
 PLG_RECAPTCHA_INVISIBLE_BADGE_BOTTOMRIGHT="Bottom right"
 PLG_RECAPTCHA_INVISIBLE_BADGE_DESC="Positioning of the reCAPTCHA badge."

--- a/administrator/language/en-GB/plg_captcha_recaptcha_invisible.sys.ini
+++ b/administrator/language/en-GB/plg_captcha_recaptcha_invisible.sys.ini
@@ -4,4 +4,4 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_CAPTCHA_RECAPTCHA_INVISIBLE="CAPTCHA - Invisible reCAPTCHA"
-PLG_CAPTCHA_RECAPTCHA_INVISIBLE_XML_DESCRIPTION="This CAPTCHA plugin uses the Invisible reCAPTCHA service. To get a site and secret key for your domain, go to <a href=\"https://www.google.com/recaptcha\" target=\"_blank\">https://www.google.com/recaptcha</a>."
+PLG_CAPTCHA_RECAPTCHA_INVISIBLE_XML_DESCRIPTION="This CAPTCHA plugin uses the Invisible reCAPTCHA service. To get a site and secret key for your domain, go to <a href=\"https://www.google.com/recaptcha/admin\" target=\"_blank\">https://www.google.com/recaptcha</a>."

--- a/administrator/language/en-GB/plg_captcha_recaptcha_invisible.sys.ini
+++ b/administrator/language/en-GB/plg_captcha_recaptcha_invisible.sys.ini
@@ -4,4 +4,4 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_CAPTCHA_RECAPTCHA_INVISIBLE="CAPTCHA - Invisible reCAPTCHA"
-PLG_CAPTCHA_RECAPTCHA_INVISIBLE_XML_DESCRIPTION="This CAPTCHA plugin uses the Invisible reCAPTCHA service. To get a site and secret key for your domain, go to <a href=\"https://www.google.com/recaptcha/admin\" target=\"_blank\">https://www.google.com/recaptcha</a>."
+PLG_CAPTCHA_RECAPTCHA_INVISIBLE_XML_DESCRIPTION="This CAPTCHA plugin uses the Invisible reCAPTCHA service. To get a site and secret key for your domain, go to <a href=\"https://www.google.com/recaptcha/admin\" target=\"_blank\">https://www.google.com/recaptcha/admin</a>."


### PR DESCRIPTION
### Summary of Changes

Change link to google

### Testing Instructions

The current link is https://www.google.com/recaptcha which google has now redirected to promote their v3 captcha project which Joomla does not support. 

This is [confusing for users](https://github.com/joomla/joomla-cms/issues/29722#issuecomment-647132316). 

### Expected result

When linked clicked it goes to something helpful - like https://www.google.com/recaptcha/admin where a user can actually "get a site and secret key for your domain" like the preceding text of the help states. 

### Actual result

https://www.google.com/recaptcha redirects to unhelpful https://www.google.com/recaptcha/intro/v3.html

<img width="1162" alt="Screenshot 2020-06-21 at 15 09 19" src="https://user-images.githubusercontent.com/400092/85227013-5fcd1000-b3d2-11ea-8d59-6835b16d4b79.png">

