### PR TITLE
[4.0] remove redundant code & general cleanup

### DIFF
--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -54,7 +54,7 @@ class PlgSystemDebug extends CMSPlugin
 	 * @var    LogEntry[]
 	 * @since  3.1
 	 */
-	private $logEntries = array();
+	private $logEntries = [];
 
 	/**
 	 * Holds SHOW PROFILES of queries.
@@ -62,7 +62,7 @@ class PlgSystemDebug extends CMSPlugin
 	 * @var    array
 	 * @since  3.1.2
 	 */
-	private $sqlShowProfiles = array();
+	private $sqlShowProfiles = [];
 
 	/**
 	 * Holds all SHOW PROFILE FOR QUERY n, indexed by n-1.
@@ -70,7 +70,7 @@ class PlgSystemDebug extends CMSPlugin
 	 * @var    array
 	 * @since  3.1.2
 	 */
-	private $sqlShowProfileEach = array();
+	private $sqlShowProfileEach = [];
 
 	/**
 	 * Holds all EXPLAIN EXTENDED for all queries.
@@ -78,7 +78,7 @@ class PlgSystemDebug extends CMSPlugin
 	 * @var    array
 	 * @since  3.1.2
 	 */
-	private $explains = array();
+	private $explains = [];
 
 	/**
 	 * Holds total amount of executed queries.
@@ -363,20 +363,20 @@ class PlgSystemDebug extends CMSPlugin
 		// Log the deprecated API.
 		if ($this->params->get('log-deprecated'))
 		{
-			Log::addLogger(array('text_file' => 'deprecated.php'), Log::ALL, array('deprecated'));
+			Log::addLogger(['text_file' => 'deprecated.php'], Log::ALL, ['deprecated']);
 		}
 
 		// Log everything (except deprecated APIs, these are logged separately with the option above).
 		if ($this->params->get('log-everything', 0))
 		{
-			Log::addLogger(array('text_file' => 'everything.php'), Log::ALL, array('deprecated', 'databasequery'), true);
+			Log::addLogger(['text_file' => 'everything.php'], Log::ALL, ['deprecated', 'databasequery'], true);
 		}
 
 		if ($this->params->get('logs', 1))
 		{
 			$priority = 0;
 
-			foreach ($this->params->get('log_priorities', array()) as $p)
+			foreach ($this->params->get('log_priorities', []) as $p)
 			{
 				$const = '\\Joomla\\CMS\\Log\\Log::' . strtoupper($p);
 
@@ -390,7 +390,7 @@ class PlgSystemDebug extends CMSPlugin
 			$categories = preg_split('/[^\w.-]+/', $this->params->get('log_categories', ''), -1, PREG_SPLIT_NO_EMPTY);
 			$mode = $this->params->get('log_category_mode', 0);
 
-			Log::addLogger(array('logger' => 'callback', 'callback' => array($this, 'logger')), $priority, $categories, $mode);
+			Log::addLogger(['logger' => 'callback', 'callback' => [$this, 'logger']], $priority, $categories, $mode);
 		}
 
 		// Log deprecated class aliases
@@ -428,7 +428,7 @@ class PlgSystemDebug extends CMSPlugin
 		}
 
 		// If the user is not allowed to view the output then end here.
-		$filterGroups = (array) $this->params->get('filter_groups', array());
+		$filterGroups = (array) $this->params->get('filter_groups', []);
 
 		if (!empty($filterGroups))
 		{
@@ -496,12 +496,12 @@ class PlgSystemDebug extends CMSPlugin
 				}
 				else
 				{
-					$this->sqlShowProfileEach[0] = array(array('Error' => 'MySql have_profiling = off'));
+					$this->sqlShowProfileEach[0] = [['Error' => 'MySql have_profiling = off']];
 				}
 			}
 			catch (Exception $e)
 			{
-				$this->sqlShowProfileEach[0] = array(array('Error' => $e->getMessage()));
+				$this->sqlShowProfileEach[0] = [['Error' => $e->getMessage()]];
 			}
 		}
 
@@ -528,7 +528,7 @@ class PlgSystemDebug extends CMSPlugin
 					}
 					catch (Exception $e)
 					{
-						$this->explains[$k] = array(array('Error' => $e->getMessage()));
+						$this->explains[$k] = [['Error' => $e->getMessage()]];
 					}
 				}
 			}

--- a/plugins/system/debug/src/DataCollector/InfoCollector.php
+++ b/plugins/system/debug/src/DataCollector/InfoCollector.php
@@ -100,10 +100,10 @@ class InfoCollector extends AbstractDataCollector implements AssetProvider
 	 */
 	public function getAssets(): array
 	{
-		return array(
+		return [
 			'js' => Uri::root(true) . '/media/plg_system_debug/widgets/info/widget.min.js',
 			'css' => Uri::root(true) . '/media/plg_system_debug/widgets/info/widget.min.css',
-		);
+		];
 	}
 
 	/**

--- a/plugins/system/debug/src/DataCollector/LanguageErrorsCollector.php
+++ b/plugins/system/debug/src/DataCollector/LanguageErrorsCollector.php
@@ -104,10 +104,10 @@ class LanguageErrorsCollector extends AbstractDataCollector implements AssetProv
 	 */
 	public function getAssets()
 	{
-		return array(
+		return [
 			'js' => Uri::root(true) . '/media/plg_system_debug/widgets/languageErrors/widget.min.js',
 			'css' => Uri::root(true) . '/media/plg_system_debug/widgets/languageErrors/widget.min.css',
-		);
+		];
 	}
 
 	/**

--- a/plugins/system/debug/src/DataCollector/LanguageFilesCollector.php
+++ b/plugins/system/debug/src/DataCollector/LanguageFilesCollector.php
@@ -121,9 +121,9 @@ class LanguageFilesCollector extends AbstractDataCollector implements AssetProvi
 	 */
 	public function getAssets(): array
 	{
-		return array(
+		return [
 			'js' => Uri::root(true) . '/media/plg_system_debug/widgets/languageFiles/widget.min.js',
 			'css' => Uri::root(true) . '/media/plg_system_debug/widgets/languageFiles/widget.min.css',
-		);
+		];
 	}
 }

--- a/plugins/system/debug/src/DataCollector/LanguageStringsCollector.php
+++ b/plugins/system/debug/src/DataCollector/LanguageStringsCollector.php
@@ -93,10 +93,10 @@ class LanguageStringsCollector extends AbstractDataCollector implements AssetPro
 	 */
 	public function getAssets(): array
 	{
-		return array(
+		return [
 			'js'  => Uri::root(true) . '/media/plg_system_debug/widgets/languageStrings/widget.min.js',
 			'css' => Uri::root(true) . '/media/plg_system_debug/widgets/languageStrings/widget.min.css',
-		);
+		];
 	}
 
 	/**

--- a/plugins/system/debug/src/DataCollector/ProfileCollector.php
+++ b/plugins/system/debug/src/DataCollector/ProfileCollector.php
@@ -44,7 +44,7 @@ class ProfileCollector extends AbstractDataCollector
 	 * @var array
 	 * @since  4.0.0
 	 */
-	protected $startedMeasures = array();
+	protected $startedMeasures = [];
 
 	/**
 	 * Measures.
@@ -52,7 +52,7 @@ class ProfileCollector extends AbstractDataCollector
 	 * @var array
 	 * @since  4.0.0
 	 */
-	protected $measures = array();
+	protected $measures = [];
 
 	/**
 	 * Constructor.
@@ -89,11 +89,11 @@ class ProfileCollector extends AbstractDataCollector
 	{
 		$start = microtime(true);
 
-		$this->startedMeasures[$name] = array(
+		$this->startedMeasures[$name] = [
 			'label'     => $label ?: $name,
 			'start'     => $start,
 			'collector' => $collector,
-		);
+		];
 	}
 
 	/**
@@ -119,7 +119,7 @@ class ProfileCollector extends AbstractDataCollector
 	 * @throws DebugBarException
 	 * @return void
 	 */
-	public function stopMeasure($name, array $params = array())
+	public function stopMeasure($name, array $params = [])
 	{
 		$end = microtime(true);
 
@@ -151,9 +151,9 @@ class ProfileCollector extends AbstractDataCollector
 	 * @since  4.0.0
 	 * @return void
 	 */
-	public function addMeasure($label, $start, $end, array $params = array(), $collector = null)
+	public function addMeasure($label, $start, $end, array $params = [], $collector = null)
 	{
-		$this->measures[] = array(
+		$this->measures[] = [
 			'label'          => $label,
 			'start'          => $start,
 			'relative_start' => $start - $this->requestStartTime,
@@ -163,7 +163,7 @@ class ProfileCollector extends AbstractDataCollector
 			'duration_str'   => $this->getDataFormatter()->formatDuration($end - $start),
 			'params'         => $params,
 			'collector'      => $collector,
-		);
+		];
 	}
 
 	/**
@@ -181,7 +181,7 @@ class ProfileCollector extends AbstractDataCollector
 		$name = spl_object_hash($closure);
 		$this->startMeasure($name, $label, $collector);
 		$result = $closure();
-		$params = \is_array($result) ? $result : array();
+		$params = \is_array($result) ? $result : [];
 		$this->stopMeasure($name, $params);
 	}
 
@@ -275,14 +275,14 @@ class ProfileCollector extends AbstractDataCollector
 			}
 		);
 
-		return array(
+		return [
 			'start'        => $this->requestStartTime,
 			'end'          => $this->requestEndTime,
 			'duration'     => $this->getRequestDuration(),
 			'duration_str' => $this->getDataFormatter()->formatDuration($this->getRequestDuration()),
 			'measures'     => array_values($this->measures),
 			'rawMarks'     => $marks,
-		);
+		];
 	}
 
 	/**
@@ -305,19 +305,19 @@ class ProfileCollector extends AbstractDataCollector
 	 */
 	public function getWidgets(): array
 	{
-		return array(
-			'profileTime' => array(
+		return [
+			'profileTime' => [
 				'icon'    => 'clock-o',
 				'tooltip' => 'Request Duration',
 				'map'     => 'profile.duration_str',
 				'default' => "'0ms'",
-			),
-			'profile'     => array(
+			],
+			'profile'     => [
 				'icon'    => 'clock-o',
 				'widget'  => 'PhpDebugBar.Widgets.TimelineWidget',
 				'map'     => 'profile',
 				'default' => '{}',
-			),
-		);
+			],
+		];
 	}
 }

--- a/plugins/system/debug/src/DataCollector/QueryCollector.php
+++ b/plugins/system/debug/src/DataCollector/QueryCollector.php
@@ -129,7 +129,7 @@ class QueryCollector extends AbstractDataCollector implements AssetProvider
 
 	/**
 	 * Returns a hash where keys are control names and their values
-	 * an array of options as defined in {@see DebugBar\JavascriptRenderer::addControl()}
+	 * an array of options as defined in {@see \DebugBar\JavascriptRenderer::addControl()}
 	 *
 	 * @since  4.0.0
 	 *

--- a/plugins/system/debug/src/DataCollector/QueryCollector.php
+++ b/plugins/system/debug/src/DataCollector/QueryCollector.php
@@ -160,10 +160,10 @@ class QueryCollector extends AbstractDataCollector implements AssetProvider
 	 */
 	public function getAssets(): array
 	{
-		return array(
+		return [
 			'css' => Uri::root(true) . '/media/plg_system_debug/widgets/sqlqueries/widget.min.css',
 			'js' => Uri::root(true) . '/media/plg_system_debug/widgets/sqlqueries/widget.min.js'
-		);
+		];
 	}
 
 	/**

--- a/plugins/system/debug/src/DataCollector/QueryCollector.php
+++ b/plugins/system/debug/src/DataCollector/QueryCollector.php
@@ -10,7 +10,6 @@
 namespace Joomla\Plugin\System\Debug\DataCollector;
 
 use DebugBar\DataCollector\AssetProvider;
-use Joomla\CMS\Factory;
 use Joomla\CMS\Uri\Uri;
 use Joomla\Database\Monitor\DebugMonitor;
 use Joomla\Plugin\System\Debug\AbstractDataCollector;

--- a/plugins/system/debug/src/DataCollector/QueryCollector.php
+++ b/plugins/system/debug/src/DataCollector/QueryCollector.php
@@ -100,9 +100,6 @@ class QueryCollector extends AbstractDataCollector implements AssetProvider
 	 */
 	public function collect(): array
 	{
-		// @todo fetch the database object in a non deprecated way..
-		$database = Factory::$database;
-
 		$statements = $this->getStatements();
 
 		return [

--- a/plugins/system/debug/src/Storage/FileStorage.php
+++ b/plugins/system/debug/src/Storage/FileStorage.php
@@ -55,7 +55,7 @@ class FileStorage extends \DebugBar\Storage\FileStorage
 		$dataStr = file_get_contents($this->makeFilename($id));
 		$dataStr = str_replace('<?php die(); ?>#(^-^)#', '', $dataStr);
 
-		return json_decode($dataStr, true) ?: array();
+		return json_decode($dataStr, true) ?: [];
 	}
 
 	/**
@@ -78,10 +78,10 @@ class FileStorage extends \DebugBar\Storage\FileStorage
 		{
 			if ($file->getExtension() == 'php')
 			{
-				$files[] = array(
+				$files[] = [
 					'time' => $file->getMTime(),
 					'id' => $file->getBasename('.php')
-				);
+				];
 			}
 		}
 


### PR DESCRIPTION
### Summary of Changes

remove redundant code (and a todo) 

`$database` is not used 

added a `\` to a fqdn to allow for IDE auto completion and cmd+click

Convert `array` to `[]` syntax

### Testing Instructions

Turn on the debug mode to get the pgpDebugBar at the bottom - open it up to the queries page

### Actual result BEFORE applying this Pull Request

Everything is logged fine

### Expected result AFTER applying this Pull Request

Everything is logged fine - no change. 

IDE can hover cmd+click full class 

![Screen Recording 2020-06-21 at 09 54 PM](https://user-images.githubusercontent.com/400092/85235046-dc2f1580-b409-11ea-8387-14f97c82144b.gif)


### Documentation Changes Required

None. 