### PR TITLE
[4.0] Add missing vars from extract into the docblock

### DIFF
--- a/layouts/joomla/form/field/text.php
+++ b/layouts/joomla/form/field/text.php
@@ -46,6 +46,9 @@ extract($displayData);
  * @var   string   $accept          File types that are accepted.
  * @var   string   $dataAttribute   Miscellaneous data attributes preprocessed for HTML output
  * @var   array    $dataAttributes  Miscellaneous data attribute for eg, data-*.
+ * @var   string   $dirname         The directory name
+ * @var   string   $addonBefore     The text to use in a bootstrap input group prepend
+ * @var   string   $addonAfter      The text to use in a bootstrap input group append
  */
 
 $list = '';


### PR DESCRIPTION
docblock changes only, can be merged on review 

added missing `@var` for the extracted $vars from $displaydata 

```
 * @var   string   $dirname         The directory name
 * @var   string   $addonBefore     The text to use in a bootstrap input group prepend
 * @var   string   $addonAfter      The text to use in a bootstrap input group append
```

Before this an IDE would show these in red (by default in phpStorm) 

<img width="940" alt="Screenshot 2020-06-21 at 22 04 16" src="https://user-images.githubusercontent.com/400092/85235207-2a90e400-b40b-11ea-82a7-afc334de839e.png">
