### PR TITLE
[4.0] Remove placeholder translation not used

### DIFF
--- a/components/com_finder/tmpl/search/default.php
+++ b/components/com_finder/tmpl/search/default.php
@@ -9,10 +9,6 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\Language\Text;
-
-Text::script('MOD_FINDER_SEARCH_VALUE', true);
-
 $this->document->getWebAssetManager()
 	->registerAndUseStyle('com_finder', 'com_finder/finder.css')
 	->registerAndUseScript('com_finder', 'com_finder/finder.js', [], ['defer' => true], ['core']);


### PR DESCRIPTION
Pull Request for Issue #29745 .

### Summary of Changes

Remove unused JS Translation of a placeholder

### Testing Instructions

create a menu item to the search page - visit it with language debug on

### Actual result BEFORE applying this Pull Request

debug bar warns of untranslated text 

### Expected result AFTER applying this Pull Request

debug bar doesnt warn of untranslated text
search still works.

### Documentation Changes Required

none