### PR TITLE
[4.0][com_media] Add title attribute to action buttons

### DIFF
--- a/administrator/components/com_media/resources/scripts/components/browser/items/directory.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/directory.vue
@@ -13,12 +13,12 @@
         </div>
         <a href="#" class="media-browser-select"
           @click.stop="toggleSelect()"
-          :aria-label="translate('COM_MEDIA_TOGGLE_SELECT_ITEM')"
+          :aria-label="translate('COM_MEDIA_TOGGLE_SELECT_ITEM')" :title="translate('COM_MEDIA_TOGGLE_SELECT_ITEM')"
           @focus="focused(true)" @blur="focused(false)">
         </a>
         <div class="media-browser-actions" :class="{'active': showActions}">
             <button class="action-toggle" type="button" ref="actionToggle"
-              :aria-label="translate('COM_MEDIA_OPEN_ITEM_ACTIONS')" @keyup.enter="openActions()"
+              :aria-label="translate('COM_MEDIA_OPEN_ITEM_ACTIONS')" :title="translate('COM_MEDIA_OPEN_ITEM_ACTIONS')" @keyup.enter="openActions()"
                @focus="focused(true)" @blur="focused(false)" @keyup.space="openActions()"
                @keyup.down="openActions()" @keyup.up="openLastActions()">
                 <span class="image-browser-action fas fa-ellipsis-h" aria-hidden="true"
@@ -28,7 +28,7 @@
                 <ul>
                     <li>
                         <button type="button" class="action-rename" ref="actionRename" @keyup.enter="openRenameModal()"
-                          :aria-label="translate('COM_MEDIA_ACTION_RENAME')" @keyup.space="openRenameModal()"
+                          :aria-label="translate('COM_MEDIA_ACTION_RENAME')" :title="translate('COM_MEDIA_ACTION_RENAME')" @keyup.space="openRenameModal()"
                           @focus="focused(true)" @blur="focused(false)" @keyup.esc="hideActions()"
                           @keyup.up="$refs.actionDelete.focus()" @keyup.down="$refs.actionDelete.focus()">
                             <span class="image-browser-action fas fa-text-width" aria-hidden="true"
@@ -37,7 +37,7 @@
                     </li>
                     <li>
                         <button type="button" class="action-delete" ref="actionDelete" @keyup.enter="openConfirmDeleteModal()"
-                          :aria-label="translate('COM_MEDIA_ACTION_DELETE')" @keyup.space="openConfirmDeleteModal()"
+                          :aria-label="translate('COM_MEDIA_ACTION_DELETE')" :title="translate('COM_MEDIA_ACTION_DELETE')" @keyup.space="openConfirmDeleteModal()"
                            @focus="focused(true)" @blur="focused(false)" @keyup.esc="hideActions()"
                            @keyup.up="$refs.actionRename.focus()" @keyup.down="$refs.actionRename.focus()">
                             <span class="image-browser-action fas fa-trash" aria-hidden="true" @click.stop="openConfirmDeleteModal()"></span>

--- a/administrator/components/com_media/resources/scripts/components/browser/items/file.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/file.vue
@@ -12,12 +12,12 @@
         </div>
         <a href="#" class="media-browser-select"
           @click.stop="toggleSelect()"
-          :aria-label="translate('COM_MEDIA_TOGGLE_SELECT_ITEM')"
+          :aria-label="translate('COM_MEDIA_TOGGLE_SELECT_ITEM')" :title="translate('COM_MEDIA_TOGGLE_SELECT_ITEM')"
           @focus="focused(true)" @blur="focused(false)">
         </a>
         <div class="media-browser-actions" :class="{'active': showActions}">
             <button href="#" class="action-toggle" type="button" ref="actionToggle"
-              :aria-label="translate('COM_MEDIA_OPEN_ITEM_ACTIONS')" @keyup.enter="openActions()"
+              :aria-label="translate('COM_MEDIA_OPEN_ITEM_ACTIONS')" :title="translate('COM_MEDIA_OPEN_ITEM_ACTIONS')" @keyup.enter="openActions()"
                @focus="focused(true)" @blur="focused(false)" @keyup.space="openActions()"
                @keyup.down="openActions()" @keyup.up="openLastActions()">
                 <span class="image-browser-action fas fa-ellipsis-h" aria-hidden="true"
@@ -27,7 +27,7 @@
                 <ul>
                     <li>
                         <button type="button" class="action-download" ref="actionDownload" @keyup.enter="download()"
-                           :aria-label="translate('COM_MEDIA_ACTION_DOWNLOAD')" @keyup.space="download()"
+                           :aria-label="translate('COM_MEDIA_ACTION_DOWNLOAD')" :title="translate('COM_MEDIA_ACTION_DOWNLOAD')" @keyup.space="download()"
                             @keyup.up="$refs.actionDelete.focus()" @keyup.down="$refs.actionRename.focus()">
                             <span class="image-browser-action fas fa-download" aria-hidden="true"
                                   @click.stop="download()"></span>
@@ -35,7 +35,7 @@
                     </li>
                     <li>
                         <button type="button" class="action-rename" ref="actionRename" @keyup.space="openRenameModal()"
-                          :aria-label="translate('COM_MEDIA_ACTION_RENAME')" @keyup.enter="openRenameModal()"
+                          :aria-label="translate('COM_MEDIA_ACTION_RENAME')" :title="translate('COM_MEDIA_ACTION_RENAME')" @keyup.enter="openRenameModal()"
                           @focus="focused(true)" @blur="focused(false)" @keyup.esc="hideActions()"
                           @keyup.up="$refs.actionDownload.focus()" @keyup.down="$refs.actionUrl.focus()">
                             <span class="image-browser-action fas fa-text-width" aria-hidden="true"
@@ -44,7 +44,7 @@
                     </li>
                     <li>
                         <button type="button" class="action-url" ref="actionUrl" @keyup.space="openShareUrlModal()"
-                          :aria-label="translate('COM_MEDIA_ACTION_SHARE')" @keyup.enter="openShareUrlModal()"
+                          :aria-label="translate('COM_MEDIA_ACTION_SHARE')" :title="translate('COM_MEDIA_ACTION_SHARE')" @keyup.enter="openShareUrlModal()"
                           @focus="focused(true)" @blur="focused(false)" @keyup.esc="hideActions()"
                           @keyup.up="$refs.actionRename.focus()" @keyup.down="$refs.actionDelete.focus()">
                             <span class="image-browser-action fas fa-link" aria-hidden="true" @click.stop="openShareUrlModal()"></span>
@@ -52,7 +52,7 @@
                     </li>
                     <li>
                         <button type="button" class="action-delete" ref="actionDelete" @keyup.space="openConfirmDeleteModal()"
-                          :aria-label="translate('COM_MEDIA_ACTION_DELETE')" @keyup.enter="openConfirmDeleteModal()"
+                          :aria-label="translate('COM_MEDIA_ACTION_DELETE')" :title="translate('COM_MEDIA_ACTION_DELETE')" @keyup.enter="openConfirmDeleteModal()"
                           @focus="focused(true)" @blur="focused(false)" @keyup.esc="hideActions()"
                           @keyup.up="$refs.actionUrl.focus()" @keyup.down="$refs.actionDownload.focus()">
                             <span class="image-browser-action fas fa-trash" aria-hidden="true" @click.stop="openConfirmDeleteModal()"></span>

--- a/administrator/components/com_media/resources/scripts/components/browser/items/image.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/image.vue
@@ -10,12 +10,12 @@
         </div>
         <a href="#" class="media-browser-select"
           @click.stop="toggleSelect()"
-          :aria-label="translate('COM_MEDIA_TOGGLE_SELECT_ITEM')"
+          :aria-label="translate('COM_MEDIA_TOGGLE_SELECT_ITEM')" :title="translate('COM_MEDIA_TOGGLE_SELECT_ITEM')"
           @focus="focused(true)" @blur="focused(false)">
         </a>
         <div class="media-browser-actions" :class="{'active': showActions}">
             <button type="button" class="action-toggle" ref="actionToggle"
-               :aria-label="translate('COM_MEDIA_OPEN_ITEM_ACTIONS')" @keyup.enter="openActions()"
+               :aria-label="translate('COM_MEDIA_OPEN_ITEM_ACTIONS')" :title="translate('COM_MEDIA_OPEN_ITEM_ACTIONS')" @keyup.enter="openActions()"
                @focus="focused(true)" @blur="focused(false)" @keyup.space="openActions()"
                @keyup.down="openActions()" @keyup.up="openLastActions()">
                 <span class="image-browser-action fas fa-ellipsis-h" aria-hidden="true"
@@ -25,7 +25,7 @@
                 <ul>
                     <li>
                         <button type="button" class="action-preview" ref="actionPreview" @keyup.enter="openPreview()"
-                            :aria-label="translate('COM_MEDIA_ACTION_PREVIEW')" @keyup.space="openPreview()"
+                            :aria-label="translate('COM_MEDIA_ACTION_PREVIEW')" :title="translate('COM_MEDIA_ACTION_PREVIEW')" @keyup.space="openPreview()"
                             @focus="focused(true)" @blur="focused(false)" @keyup.esc="hideActions()"
                             @keyup.up="$refs.actionDelete.focus()" @keyup.down="$refs.actionDownload.focus()">
                             <span class="image-browser-action fas fa-search-plus" aria-hidden="true"
@@ -34,7 +34,7 @@
                     </li>
                     <li>
                         <button type="button" class="action-download" ref="actionDownload" @keyup.enter="download()"
-                            :aria-label="translate('COM_MEDIA_ACTION_DOWNLOAD')" @keyup.space="download()"
+                            :aria-label="translate('COM_MEDIA_ACTION_DOWNLOAD')" :title="translate('COM_MEDIA_ACTION_DOWNLOAD')" @keyup.space="download()"
                             @focus="focused(true)" @blur="focused(false)" @keyup.esc="hideActions()"
                             @keyup.up="$refs.actionPreview.focus()" @keyup.down="$refs.actionRename.focus()">
                             <span class="image-browser-action fas fa-download" aria-hidden="true"
@@ -43,7 +43,7 @@
                     </li>
                     <li>
                         <button type="button" class="action-rename" ref="actionRename" @keyup.enter="openRenameModal()"
-                            :aria-label="translate('COM_MEDIA_ACTION_RENAME')" @keyup.space="openRenameModal()"
+                            :aria-label="translate('COM_MEDIA_ACTION_RENAME')" :title="translate('COM_MEDIA_ACTION_RENAME')" @keyup.space="openRenameModal()"
                             @focus="focused(true)" @blur="focused(false)" @keyup.esc="hideActions()"
                             @keyup.up="$refs.actionDownload.focus()" @keyup.down="canEdit ? $refs.actionEdit.focus() : $refs.actionShare.focus()">
                             <span class="image-browser-action fas fa-text-width" aria-hidden="true"
@@ -52,7 +52,7 @@
                     </li>
                     <li v-if="canEdit">
                         <button type="button" class="action-edit" ref="actionEdit"
-                            :aria-label="translate('COM_MEDIA_ACTION_EDIT')" @keyup.enter="editItem()" @keyup.space="editItem()"
+                            :aria-label="translate('COM_MEDIA_ACTION_EDIT')" :title="translate('COM_MEDIA_ACTION_EDIT')" @keyup.enter="editItem()" @keyup.space="editItem()"
                             @focus="focused(true)" @blur="focused(false)" @keyup.esc="hideActions()"
                             @keyup.up="$refs.actionRename.focus()" @keyup.down="$refs.actionShare.focus()">
                             <span class="image-browser-action fas fa-pencil-alt" aria-hidden="true" @click.stop="editItem()"></span>
@@ -60,7 +60,7 @@
                     </li>
                     <li>
                         <button type="button" class="action-url" ref="actionShare" @keyup.enter="openShareUrlModal()"
-                          :aria-label="translate('COM_MEDIA_ACTION_SHARE')" @keyup.space="openShareUrlModal()"
+                          :aria-label="translate('COM_MEDIA_ACTION_SHARE')" :title="translate('COM_MEDIA_ACTION_SHARE')" @keyup.space="openShareUrlModal()"
                           @focus="focused(true)" @blur="focused(false)" @keyup.esc="hideActions()"
                           @keyup.up="canEdit ? $refs.actionEdit.focus() : $refs.actionRename.focus()" @keyup.down="$refs.actionDelete.focus()">
                             <span class="image-browser-action fas fa-link" aria-hidden="true" @click.stop="openShareUrlModal()"></span>
@@ -68,7 +68,7 @@
                     </li>
                     <li>
                         <button type="button" class="action-delete" ref="actionDelete" @keyup.enter="openConfirmDeleteModal()"
-                          :aria-label="translate('COM_MEDIA_ACTION_DELETE')" @keyup.space="openConfirmDeleteModal()"
+                          :aria-label="translate('COM_MEDIA_ACTION_DELETE')" :title="translate('COM_MEDIA_ACTION_DELETE')" @keyup.space="openConfirmDeleteModal()"
                            @focus="focused(true)" @blur="focused(false)" @keyup.esc="hideActions()"
                            @keyup.up="$refs.actionShare.focus()" @keyup.down="$refs.actionPreview.focus()">
                             <span class="image-browser-action fas fa-trash" aria-hidden="true" @click.stop="openConfirmDeleteModal()"></span>

--- a/administrator/components/com_media/resources/scripts/components/browser/items/video.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/video.vue
@@ -12,11 +12,11 @@
         </div>
         <a href="#" class="media-browser-select"
           @click.stop="toggleSelect()"
-          :aria-label="translate('COM_MEDIA_TOGGLE_SELECT_ITEM')">
+          :aria-label="translate('COM_MEDIA_TOGGLE_SELECT_ITEM')"> :title="translate('COM_MEDIA_TOGGLE_SELECT_ITEM')">
         </a>
         <div class="media-browser-actions" :class="{'active': showActions}">
             <button type="button" class="action-toggle" ref="actionToggle" @keyup.enter="openActions()"
-              :aria-label="translate('COM_MEDIA_OPEN_ITEM_ACTIONS')"
+              :aria-label="translate('COM_MEDIA_OPEN_ITEM_ACTIONS')" :title="translate('COM_MEDIA_OPEN_ITEM_ACTIONS')"
                @focus="focused(true)" @blur="focused(false)" @keyup.space="openActions()"
                @keyup.down="openActions()" @keyup.up="openLastActions()">
                 <span class="image-browser-action fas fa-ellipsis-h" aria-hidden="true"
@@ -26,7 +26,7 @@
                 <ul>
                     <li>
                         <button type="button" class="action-preview" ref="actionPreview" @keyup.enter="openPreview()"
-                           :aria-label="translate('COM_MEDIA_ACTION_PREVIEW')" @keyup.space="openPreview()"
+                           :aria-label="translate('COM_MEDIA_ACTION_PREVIEW')" :title="translate('COM_MEDIA_ACTION_PREVIEW')" @keyup.space="openPreview()"
                            @focus="focused(true)" @blur="focused(false)" @keyup.esc="hideActions()"
                            @keyup.up="$refs.actionDelete.focus()" @keyup.down="$refs.actionDownload.focus()">
                             <span class="image-browser-action fas fa-search-plus" aria-hidden="true"
@@ -35,7 +35,7 @@
                     </li>
                     <li>
                         <button type="button" class="action-download" ref="actionDownload" @keyup.enter="download()"
-                           :aria-label="translate('COM_MEDIA_ACTION_DOWNLOAD')" @keyup.space="download()"
+                           :aria-label="translate('COM_MEDIA_ACTION_DOWNLOAD')" :title="translate('COM_MEDIA_ACTION_DOWNLOAD')" @keyup.space="download()"
                            @focus="focused(true)" @blur="focused(false)" @keyup.esc="hideActions()"
                            @keyup.up="$refs.actionPreview.focus()" @keyup.down="$refs.actionRename.focus()">
                             <span class="image-browser-action fas fa-download" aria-hidden="true"
@@ -44,7 +44,7 @@
                     </li>
                     <li>
                         <button type="button" class="action-rename" ref="actionRename" @keyup.enter="openRenameModal()"
-                          :aria-label="translate('COM_MEDIA_ACTION_RENAME')" @keyup.space="openRenameModal()"
+                          :aria-label="translate('COM_MEDIA_ACTION_RENAME')" :title="translate('COM_MEDIA_ACTION_RENAME')" @keyup.space="openRenameModal()"
                           @focus="focused(true)" @blur="focused(false)" @keyup.esc="hideActions()"
                           @keyup.up="$refs.actionDownload.focus()" @keyup.down="$refs.actionShare.focus()">
                             <span class="image-browser-action fas fa-text-width" aria-hidden="true"
@@ -53,7 +53,7 @@
                     </li>
                     <li>
                         <button type="button" class="action-url" ref="actionShare" @keyup.enter="openShareUrlModal()"
-                          :aria-label="translate('COM_MEDIA_ACTION_SHARE')" @keyup.space="openShareUrlModal()"
+                          :aria-label="translate('COM_MEDIA_ACTION_SHARE')" :title="translate('COM_MEDIA_ACTION_SHARE')" @keyup.space="openShareUrlModal()"
                           @focus="focused(true)" @blur="focused(false)" @keyup.esc="hideActions()"
                           @keyup.up="$refs.actionRename.focus()" @keyup.down="$refs.actionDelete.focus()">
                             <span class="image-browser-action fas fa-link" aria-hidden="true" @click.stop="openShareUrlModal()"></span>
@@ -61,7 +61,7 @@
                     </li>
                     <li>
                         <button type="button" class="action-delete" ref="actionDelete" @keyup.enter="openConfirmDeleteModal()"
-                          :aria-label="translate('COM_MEDIA_ACTION_DELETE')" @keyup.space="openConfirmDeleteModal()"
+                          :aria-label="translate('COM_MEDIA_ACTION_DELETE')" :title="translate('COM_MEDIA_ACTION_DELETE')" @keyup.space="openConfirmDeleteModal()"
                            @focus="focused(true)" @blur="focused(false)" @keyup.esc="hideActions()"
                            @keyup.up="$refs.actionShare.focus()" @keyup.down="$refs.actionPreview.focus()">
                             <span class="image-browser-action fas fa-trash" aria-hidden="true" @click.stop="openConfirmDeleteModal()"></span>


### PR DESCRIPTION
Redo #23893 to fix conflicting files.

### Summary of Changes
Add title attribute to action buttons. 

It is not 100% accessible as stated in the previous PR, however, it is better than nothing. 

### Testing Instructions
Apply PR.
Run npm i.

Go to Media.
Hover an image/directory to display ... icon.
Click ... icon to display icons.
Hover an icon to show a title tip.


### Actual result BEFORE applying this Pull Request
No title tip.