### PR TITLE
[4.0] Fix select missing icon for removing the selected value

### DIFF
--- a/administrator/templates/atum/scss/vendor/choicesjs/choices.scss
+++ b/administrator/templates/atum/scss/vendor/choicesjs/choices.scss
@@ -86,7 +86,6 @@
 .choices__button_joomla {
   opacity: 0.5;
   padding: 0 10px;
-  color: white;
 
   position: relative;
   text-indent: -9999px;

--- a/administrator/templates/atum/scss/vendor/choicesjs/choices.scss
+++ b/administrator/templates/atum/scss/vendor/choicesjs/choices.scss
@@ -86,6 +86,7 @@
 .choices__button_joomla {
   opacity: 0.5;
   padding: 0 10px;
+  color: inherit;
 
   position: relative;
   text-indent: -9999px;


### PR DESCRIPTION
Pull Request for Issue #29750.

### Summary of Changes
The x icon is the same color as the background color. Remove the color assignment.


### Testing Instructions
Edit an article in backend.
See Category dropdown missing the x icon.

Apply PR.
Run npm i.

