### PR TITLE
[4.0] CSP: fix label translation

### DIFF
--- a/administrator/components/com_csp/config.xml
+++ b/administrator/components/com_csp/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <config>
-	<fieldset name="csp" label="Content-Security-Policy (CSP)">
+	<fieldset name="csp" label="COM_CSP_CONTENTSECURITYPOLICY_LABEL">
 		<field
 			name="contentsecuritypolicy"
 			type="radio"

--- a/administrator/language/en-GB/com_csp.ini
+++ b/administrator/language/en-GB/com_csp.ini
@@ -8,12 +8,14 @@ COM_CSP_AUTO_UNSAFE_EVAL_WARNING="You have configured a rule that still allows '
 COM_CSP_AUTO_UNSAFE_INLINE_WARNING="You have configured a rule that still allows 'unsafe-inline' that bypasses the Content Security Policy and allows the execution of unsafe in-page scripts and event handlers."
 COM_CSP_COLLECTING_TRASH_WARNING="The Content Security Policy is in detect mode. Items that have been trashed will not be detected again until they are removed from the trash."
 COM_CSP_CONFIGURATION="Content Security Policy: Options"
-; Please do not translate the following language string
+; Please do not translate '(CSP)' in the following language string
 COM_CSP_CONTENTSECURITYPOLICY="<a href='https://scotthelme.co.uk/content-security-policy-an-introduction' target='_blank' rel='noopener noreferrer'>Content Security Policy (CSP)</a>"
 COM_CSP_CONTENTSECURITYPOLICY_CLIENT="Client"
 ; Please do not translate the following language string
 COM_CSP_CONTENTSECURITYPOLICY_FRAME_ANCESTORS_SELF_ENABLED="frame-ancestors 'self'"
 COM_CSP_CONTENTSECURITYPOLICY_FRAME_ANCESTORS_SELF_ENABLED_DESC="Enable the CSP clickjacking protection frame-ancestors and only allow the origin 'self'. Please use the form below to allow origins other than 'self'."
+; Please do not translate '(CSP)' in the following language string
+COM_CSP_CONTENTSECURITYPOLICY_LABEL="Content Security Policy (CSP)"
 COM_CSP_CONTENTSECURITYPOLICY_MODE="Mode"
 COM_CSP_CONTENTSECURITYPOLICY_MODE_AUTO="Automatic"
 COM_CSP_CONTENTSECURITYPOLICY_MODE_CUSTOM="Custom"

--- a/plugins/system/httpheaders/httpheaders.xml
+++ b/plugins/system/httpheaders/httpheaders.xml
@@ -102,7 +102,7 @@
 					</form>
 				</field>
 			</fieldset>
-			<fieldset name="hsts" label="Strict-Transport-Security (HSTS)">
+			<fieldset name="hsts" label="Strict Transport Security (HSTS)">
 				<field
 					name="hsts"
 					type="radio"


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/29748

### Summary of Changes
Allow translation of `Content Security Policy` in the fieldset label as this is not the code part but the concept itself. 
Comment added is
`; Please do not translate (CSP) in the following language string` as this shorthand is common to all languages.


### Testing Instructions
Enable debug lang
Load csp `administrator/index.php?option=com_config&view=component&component=com_csp`


### Actual result BEFORE applying this Pull Request
<img width="517" alt="Screenshot 2020-06-21 at 21 05 03" src="https://user-images.githubusercontent.com/400092/85234109-07623680-b403-11ea-8275-b247409f1b2f.png">


### Expected result AFTER applying this Pull Request

<img width="620" alt="Screen Shot 2020-06-23 at 09 19 33" src="https://user-images.githubusercontent.com/869724/85373177-2eb82100-b533-11ea-8e9f-3a87825bfca5.png">
