### PR TITLE
[4.0] Fixed error message when closing add module modal.

### DIFF
--- a/build/media_source/com_cpanel/js/admin-add_module.es6.js
+++ b/build/media_source/com_cpanel/js/admin-add_module.es6.js
@@ -50,8 +50,11 @@ Joomla = window.Joomla || {};
 
             const iframe = document.querySelector('#moduleDashboardAddModal iframe');
             const content = iframe.contentDocument || iframe.contentWindow.document;
+            const targetBtn = content.querySelector(clickTarget);
 
-            content.querySelector(clickTarget).click();
+            if (targetBtn) {
+              targetBtn.click();
+            }
           }
         });
       });


### PR DESCRIPTION
Pull Request for Issue #29759.

### Summary of Changes
When closing the "Add module" modal, the "Cancel" button inside the modal should be clicked. In the second step, i.e. after we have selected the type of the module to be added and see the module form, this works. But in the first step, there is no "Cancel" button inside the modal, which leads to a JavaScript error being logged in the browser console.


### Testing Instructions
After applying the patch, you need to run `npm ci` to compile the JavaScript change.

1. Login to the Joomla backend
2. Open your browser's JavaScript console (usually F12 or Ctrl+Shift+K).
3. At the bottom of the dashboard, click the Add module to the dashboard link
4. Close the modal using the Close button in the footer. Look at the JavaScript console.
5. Again, click "Add module". Select a module type.
6. Close the modal using the Close button in the footer. Make sure that cancelling still works after applying this PR.
7. Again, click "Add module". Select a module type.
8. Enter the module information and click "Save and Close" to make sure that saving still works after applying this PR.

### Actual result BEFORE applying this Pull Request
An error message is shown in the console: 
> content.querySelector(clickTarget) is null --- admin-add_module.min.js

**Note:** The modal still closes correctly, so no functionality is broken. But the error appears and we don't want that.

### Expected result AFTER applying this Pull Request
No JS error should appear.


### Documentation Changes Required
None

Ping @bembelimen as you implemented the original functionality and might see any caveats how this PR could break things.
