### PR TITLE
[4.0][com_finder] Fix columns sort

### DIFF
--- a/administrator/components/com_finder/forms/filter_index.xml
+++ b/administrator/components/com_finder/forms/filter_index.xml
@@ -67,8 +67,8 @@
 			<option value="t.title DESC">COM_FINDER_INDEX_HEADING_INDEX_TYPE_DESC</option>
 			<option value="l.indexdate ASC">COM_FINDER_INDEX_HEADING_INDEX_DATE_ASC</option>
 			<option value="l.indexdate DESC">COM_FINDER_INDEX_HEADING_INDEX_DATE_DESC</option>
-			<option value="language ASC" requires="multilanguage">JGRID_HEADING_LANGUAGE_ASC</option>
-			<option value="language DESC" requires="multilanguage">JGRID_HEADING_LANGUAGE_DESC</option>
+			<option value="l.language ASC" requires="multilanguage">JGRID_HEADING_LANGUAGE_ASC</option>
+			<option value="l.language DESC" requires="multilanguage">JGRID_HEADING_LANGUAGE_DESC</option>
 			<option value="l.url ASC">COM_FINDER_INDEX_HEADING_LINK_URL_ASC</option>
 			<option value="l.url DESC">COM_FINDER_INDEX_HEADING_LINK_URL_DESC</option>
 		</field>

--- a/administrator/components/com_finder/forms/filter_maps.xml
+++ b/administrator/components/com_finder/forms/filter_maps.xml
@@ -56,6 +56,8 @@
 			<option value="a.state DESC">JSTATUS_DESC</option>
 			<option value="branch_title ASC">JGLOBAL_TITLE_ASC</option>
 			<option value="branch_title DESC">JGLOBAL_TITLE_DESC</option>
+			<option value="a.language ASC" requires="multilanguage">JGRID_HEADING_LANGUAGE_ASC</option>
+			<option value="a.language DESC" requires="multilanguage">JGRID_HEADING_LANGUAGE_DESC</option>
 		</field>
 
 		<field

--- a/administrator/components/com_finder/src/Model/MapsModel.php
+++ b/administrator/components/com_finder/src/Model/MapsModel.php
@@ -44,6 +44,7 @@ class MapsModel extends ListModel
 				'branch',
 				'branch_title', 'd.branch_title',
 				'level', 'd.level',
+				'language', 'a.language',
 			);
 		}
 

--- a/administrator/components/com_finder/src/Model/SearchesModel.php
+++ b/administrator/components/com_finder/src/Model/SearchesModel.php
@@ -36,7 +36,7 @@ class SearchesModel extends ListModel
 		if (empty($config['filter_fields']))
 		{
 			$config['filter_fields'] = array(
-				'search_term', 'a.search_term',
+				'searchterm', 'a.searchterm',
 				'hits', 'a.hits',
 			);
 		}

--- a/administrator/components/com_finder/tmpl/maps/default.php
+++ b/administrator/components/com_finder/tmpl/maps/default.php
@@ -67,7 +67,7 @@ HTMLHelper::_('script', 'com_finder/maps.js', ['version' => 'auto', 'relative' =
 							</th>
 							<?php if (Multilanguage::isEnabled()) : ?>
 								<th scope="col" class="w-10 nowrap d-none d-md-table-cell">
-									<?php echo HTMLHelper::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'language', $listDirn, $listOrder); ?>
+									<?php echo HTMLHelper::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'a.language', $listDirn, $listOrder); ?>
 								</th>
 							<?php endif; ?>
 						</tr>


### PR DESCRIPTION
### Summary of Changes
Fix columns sort.


### Testing Instructions
Install Multilingual Sample Data
Go to Components > Smart Search
Under Index, click `Language` column header
See Languages not selected under Sort Table By dropdown
Under Content Maps, click `Language` column header
See Languages not listed/selected under Sort Table By dropdown
Under Options, enable `Gather Search Statistics`
Enable `Smart Search` module, and do searches on frontend
Under Statistics, click `Search Phrase` column header
Sort is by Hits and not Search Phrase


