### PR TITLE
[4.0] Fix save2copy for workflows

### DIFF
--- a/administrator/components/com_workflow/forms/workflow.xml
+++ b/administrator/components/com_workflow/forms/workflow.xml
@@ -50,7 +50,6 @@
 			label="COM_WORKFLOW_FIELD_IS_DEFAULT_LABEL"
 			layout="joomla.form.field.radio.switcher"
 			default="0"
-			required="true"
 			>
 			<option value="0">JNO</option>
 			<option value="1">JYES</option>


### PR DESCRIPTION
Pull Request for Issue #29597 .

### Summary of Changes
Remove rquired from field default


### Testing Instructions
see #29597


### Actual result BEFORE applying this Pull Request
Error: Field required: default


### Expected result AFTER applying this Pull Request
No Warning, the workflow is saved as copy


### Documentation Changes Required
no

