### PR TITLE
[4.0] Fix fancy select, not possible to add custom term when similar term exists

### DIFF
--- a/build/media_source/system/js/fields/joomla-field-fancy-select.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-fancy-select.w-c.es6.js
@@ -146,7 +146,7 @@ window.customElements.define('joomla-field-fancy-select', class extends HTMLElem
       // This workaround can be removed when choices.js
       // will have an option that allow to disable it.
 
-      // eslint-disable-next-line no-underscore-dangle prefer-destructuring
+      // eslint-disable-next-line no-underscore-dangle, prefer-destructuring
       const _highlightChoice = this.choicesInstance._highlightChoice;
       // eslint-disable-next-line no-underscore-dangle
       this.choicesInstance._highlightChoice = (el) => {

--- a/build/media_source/system/js/fields/joomla-field-fancy-select.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-fancy-select.w-c.es6.js
@@ -140,30 +140,37 @@ window.customElements.define('joomla-field-fancy-select', class extends HTMLElem
     // Handle typing of custom Term
     if (this.allowCustom) {
       // START Work around for issue https://github.com/joomla/joomla-cms/issues/29459
-      // The choices.js always auto-hightlight first element in the dropdown that not allow to add a custom Term.
+      // The choices.js always auto-hightlight first element
+      // in the dropdown that not allow to add a custom Term.
       //
-      // This workaround can be removed when choices.js will have an option that allow to disable it.
+      // This workaround can be removed when choices.js
+      // will have an option that allow to disable it.
       const _highlightChoice = this.choicesInstance._highlightChoice;
+      // eslint-disable-next-line no-underscore-dangle
       this.choicesInstance._highlightChoice = (el) => {
         // Prevent auto-highlight of first element, if nothing actually highlighted
         if (!el) return;
 
         // Call original highlighter
         _highlightChoice.call(this.choicesInstance, el);
-      }
+      };
 
       // Unhighlight any highlighted items, when mouse leave the dropdown
-      this.addEventListener('mouseleave', (event) => {
+      this.addEventListener('mouseleave', () => {
+
         if (!this.choicesInstance.dropdown.isActive){
           return;
         }
 
-        const highlighted = Array.from(this.choicesInstance.dropdown.element.querySelectorAll(`.${this.choicesInstance.config.classNames.highlightedState}`));
+        const highlighted = Array.from(this.choicesInstance.dropdown.element
+          .querySelectorAll(`.${this.choicesInstance.config.classNames.highlightedState}`));
+
         highlighted.forEach((choice) => {
           choice.classList.remove(this.choicesInstance.config.classNames.highlightedState);
           choice.setAttribute('aria-selected', 'false');
         });
 
+        // eslint-disable-next-line no-underscore-dangle
         this.choicesInstance._highlightPosition = 0;
       });
       // END workaround for issue #29459
@@ -176,12 +183,15 @@ window.customElements.define('joomla-field-fancy-select', class extends HTMLElem
         }
         event.preventDefault();
 
+        // eslint-disable-next-line no-underscore-dangle
         if (this.choicesInstance._highlightPosition || !event.target.value) {
           return;
         }
 
         // Make sure nothing is highlighted
-        const highlighted = this.choicesInstance.dropdown.element.querySelector(`.${this.choicesInstance.config.classNames.highlightedState}`);
+        const highlighted = this.choicesInstance.dropdown.element
+          .querySelector(`.${this.choicesInstance.config.classNames.highlightedState}`);
+
         if (highlighted) {
           return;
         }
@@ -191,25 +201,24 @@ window.customElements.define('joomla-field-fancy-select', class extends HTMLElem
         let valueInCache = false;
 
         // Check if value in existing choices
-        this.choicesInstance.config.choices.forEach((choiceItem) => {
-          if (choiceItem.value.toLowerCase() === lowerValue || choiceItem.label.toLowerCase() === lowerValue) {
+        this.choicesInstance.config.choices.some((choiceItem) => {
+          if (choiceItem.value.toLowerCase() === lowerValue
+            || choiceItem.label.toLowerCase() === lowerValue) {
             valueInCache = choiceItem.value;
-            return false;
+            return true;
           }
+          return false;
         });
 
         if (valueInCache === false) {
           // Check if value in cache
-          for (const k in this.choicesCache) {
-            if (!this.choicesCache.hasOwnProperty(k)) {
-              continue;
+          Object.keys(this.choicesCache).some((key) => {
+            if (key.toLowerCase() === lowerValue || this.choicesCache[key].toLowerCase() === lowerValue) {
+              valueInCache = key;
+              return true;
             }
-
-            if (k.toLowerCase() === lowerValue || this.choicesCache[k].toLowerCase() === lowerValue) {
-              valueInCache = k;
-              break;
-            }
-          }
+            return false;
+          });
         }
 
         // Make choice based on existing value

--- a/build/media_source/system/js/fields/joomla-field-fancy-select.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-fancy-select.w-c.es6.js
@@ -137,7 +137,7 @@ window.customElements.define('joomla-field-fancy-select', class extends HTMLElem
       }
     });
 
-    // Handle typing of custom term
+    // Handle typing of custom Term
     if (this.allowCustom) {
       // START Work around for issue https://github.com/joomla/joomla-cms/issues/29459
       // The choices.js always auto-hightlight first element in the dropdown that not allow to add a custom Term.
@@ -176,7 +176,7 @@ window.customElements.define('joomla-field-fancy-select', class extends HTMLElem
         }
         event.preventDefault();
 
-        if (this.choicesInstance._highlightPosition || !event.target.value || this.choicesCache[event.target.value]) {
+        if (this.choicesInstance._highlightPosition || !event.target.value) {
           return;
         }
 
@@ -186,6 +186,41 @@ window.customElements.define('joomla-field-fancy-select', class extends HTMLElem
           return;
         }
 
+        // Check if value already exist
+        const lowerValue = event.target.value.toLowerCase();
+        let valueInCache = false;
+
+        // Check if value in existing choices
+        this.choicesInstance.config.choices.forEach((choiceItem) => {
+          if (choiceItem.value.toLowerCase() === lowerValue || choiceItem.label.toLowerCase() === lowerValue) {
+            valueInCache = choiceItem.value;
+            return false;
+          }
+        });
+
+        if (valueInCache === false) {
+          // Check if value in cache
+          for (const k in this.choicesCache) {
+            if (!this.choicesCache.hasOwnProperty(k)) {
+              continue;
+            }
+
+            if (k.toLowerCase() === lowerValue || this.choicesCache[k].toLowerCase() === lowerValue) {
+              valueInCache = k;
+              break;
+            }
+          }
+        }
+
+        // Make choice based on existing value
+        if (valueInCache !== false) {
+          this.choicesInstance.setChoiceByValue(valueInCache);
+          event.target.value = null;
+          this.choicesInstance.hideDropdown();
+          return;
+        }
+
+        // Create and add new
         this.choicesInstance.setChoices([{
           value: this.newItemPrefix + event.target.value,
           label: event.target.value,

--- a/build/media_source/system/js/fields/joomla-field-fancy-select.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-fancy-select.w-c.es6.js
@@ -145,6 +145,8 @@ window.customElements.define('joomla-field-fancy-select', class extends HTMLElem
       //
       // This workaround can be removed when choices.js
       // will have an option that allow to disable it.
+
+      // eslint-disable-next-line no-underscore-dangle
       const _highlightChoice = this.choicesInstance._highlightChoice;
       // eslint-disable-next-line no-underscore-dangle
       this.choicesInstance._highlightChoice = (el) => {
@@ -157,8 +159,7 @@ window.customElements.define('joomla-field-fancy-select', class extends HTMLElem
 
       // Unhighlight any highlighted items, when mouse leave the dropdown
       this.addEventListener('mouseleave', () => {
-
-        if (!this.choicesInstance.dropdown.isActive){
+        if (!this.choicesInstance.dropdown.isActive) {
           return;
         }
 
@@ -213,7 +214,8 @@ window.customElements.define('joomla-field-fancy-select', class extends HTMLElem
         if (valueInCache === false) {
           // Check if value in cache
           Object.keys(this.choicesCache).some((key) => {
-            if (key.toLowerCase() === lowerValue || this.choicesCache[key].toLowerCase() === lowerValue) {
+            if (key.toLowerCase() === lowerValue
+              || this.choicesCache[key].toLowerCase() === lowerValue) {
               valueInCache = key;
               return true;
             }

--- a/build/media_source/system/js/fields/joomla-field-fancy-select.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-fancy-select.w-c.es6.js
@@ -146,7 +146,7 @@ window.customElements.define('joomla-field-fancy-select', class extends HTMLElem
       // This workaround can be removed when choices.js
       // will have an option that allow to disable it.
 
-      // eslint-disable-next-line no-underscore-dangle
+      // eslint-disable-next-line no-underscore-dangle prefer-destructuring
       const _highlightChoice = this.choicesInstance._highlightChoice;
       // eslint-disable-next-line no-underscore-dangle
       this.choicesInstance._highlightChoice = (el) => {


### PR DESCRIPTION
Pull Request for Issue #29459 .

### Summary of Changes

This is a bit as workaround, because Choices.js always auto-highlight first item in drop-down list.


### Testing Instructions

Apply patch and run `npm install`,
And follow the steps from #29459 issue:

Create two custom modules with positions bubletopright and bubletopleft.
Create a third custom module with position bublebottomright


### Actual result BEFORE applying this Pull Request
Not posible to create a module in new position - one of the other positions is selected all the time



### Expected result AFTER applying this Pull Request
Posible to create the new third module in new position



