### PR TITLE
[4.0] CLI list

### DIFF
--- a/libraries/src/Console/AddUserToGroupCommand.php
+++ b/libraries/src/Console/AddUserToGroupCommand.php
@@ -289,7 +289,7 @@ class AddUserToGroupCommand extends AbstractCommand
 	 */
 	protected function configure(): void
 	{
-		$this->setDescription('Add a user to group');
+		$this->setDescription('Add a user to a group');
 		$this->addOption('username', null, InputOption::VALUE_OPTIONAL, 'username');
 		$this->addOption('group', null, InputOption::VALUE_OPTIONAL, 'group');
 		$this->setHelp(

--- a/libraries/src/Console/ChangeUserPasswordCommand.php
+++ b/libraries/src/Console/ChangeUserPasswordCommand.php
@@ -164,7 +164,7 @@ class ChangeUserPasswordCommand extends AbstractCommand
 	{
 		$this->addOption('username', null, InputOption::VALUE_OPTIONAL, 'username');
 		$this->addOption('password', null, InputOption::VALUE_OPTIONAL, 'password');
-		$this->setDescription("Changes a user's password");
+		$this->setDescription("Change a user's password");
 		$this->setHelp(
 			<<<EOF
 The <info>%command.name%</info> command changes the user's password

--- a/libraries/src/Console/CheckJoomlaUpdatesCommand.php
+++ b/libraries/src/Console/CheckJoomlaUpdatesCommand.php
@@ -52,7 +52,7 @@ The <info>%command.name%</info> Checks for Joomla updates.
 
   <info>php %command.full_name%</info>
 EOF;
-		$this->setDescription('Checks for Joomla updates');
+		$this->setDescription('Check for Joomla updates');
 		$this->setHelp($help);
 	}
 

--- a/libraries/src/Console/ExtensionInstallCommand.php
+++ b/libraries/src/Console/ExtensionInstallCommand.php
@@ -88,7 +88,7 @@ class ExtensionInstallCommand extends AbstractCommand
 		$this->addOption('path', null, InputOption::VALUE_REQUIRED, 'The path to the extension');
 		$this->addOption('url', null, InputOption::VALUE_REQUIRED, 'The url to the extension');
 
-		$this->setDescription('Installs an extension from a URL or from a Path.');
+		$this->setDescription('Install an extension from a URL or from a path');
 
 		$help = <<<'EOF'
 The <info>%command.name%</info> is used to install extensions

--- a/libraries/src/Console/ExtensionRemoveCommand.php
+++ b/libraries/src/Console/ExtensionRemoveCommand.php
@@ -125,7 +125,7 @@ class ExtensionRemoveCommand extends AbstractCommand
 			InputArgument::REQUIRED,
 			'ID of extension to be removed (run extension:list command to check)'
 		);
-		$this->setDescription('Removes an extension');
+		$this->setDescription('Remove an extension');
 
 		$help = <<<'EOF'
 The <info>%command.name%</info> is used to uninstall extensions.

--- a/libraries/src/Console/GetConfigurationCommand.php
+++ b/libraries/src/Console/GetConfigurationCommand.php
@@ -308,7 +308,7 @@ class GetConfigurationCommand extends AbstractCommand
 
 		$groupNames = implode(', ', $groupNames);
 
-		$this->setDescription('Displays the current value of a configuration option');
+		$this->setDescription('Display the current value of a configuration option');
 
 		$this->addArgument('option', null, 'Name of the option');
 		$this->addOption('group', 'g', InputOption::VALUE_REQUIRED, 'Name of the option');

--- a/libraries/src/Console/SetConfigurationCommand.php
+++ b/libraries/src/Console/SetConfigurationCommand.php
@@ -243,7 +243,7 @@ class SetConfigurationCommand extends AbstractCommand
 	 */
 	protected function configure(): void
 	{
-		$this->setDescription('Sets a value for a configuration option');
+		$this->setDescription('Set a value for a configuration option');
 
 		$this->addArgument(
 			'options',

--- a/libraries/src/Console/SiteDownCommand.php
+++ b/libraries/src/Console/SiteDownCommand.php
@@ -75,7 +75,7 @@ class SiteDownCommand extends AbstractCommand
 	 */
 	protected function configure(): void
 	{
-		$this->setDescription('Puts the site into offline mode');
+		$this->setDescription('Put the site into offline mode');
 
 		$help = <<<'EOF'
 The <info>%command.name%</info> is used to place the site offline.

--- a/libraries/src/Console/SiteUpCommand.php
+++ b/libraries/src/Console/SiteUpCommand.php
@@ -75,7 +75,7 @@ class SiteUpCommand extends AbstractCommand
 	 */
 	protected function configure(): void
 	{
-		$this->setDescription('Puts the site into online mode');
+		$this->setDescription('Put the site into online mode');
 
 		$help = "The <info>%command.name%</info> Puts the site into online mode
 				\nUsage: <info>php %command.full_name%</info>";

--- a/libraries/src/Console/UpdateCoreCommand.php
+++ b/libraries/src/Console/UpdateCoreCommand.php
@@ -189,7 +189,7 @@ class UpdateCoreCommand extends AbstractCommand
 	 */
 	protected function configure(): void
 	{
-		$this->setDescription('Updates joomla core');
+		$this->setDescription('Update Joomla');
 
 		$help = <<<'EOF'
 The <info>%command.name%</info> is used to update Joomla.


### PR DESCRIPTION
Updates the strings displayed when running `php cli/joomla.php list` to ensure consistent grammar and tense etc

(a subsequent pr will be created for `php cli/joomla.php help`)
