### PR TITLE
[4.0] Fix column alignment

### DIFF
--- a/administrator/components/com_installer/tmpl/update/default.php
+++ b/administrator/components/com_installer/tmpl/update/default.php
@@ -109,10 +109,10 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 										</span>
 										<?php endif; ?>
 									</th>
-									<td class="text-center d-none d-md-table-cell">
+									<td class="d-none d-md-table-cell">
 										<?php echo $item->client_translated; ?>
 									</td>
-									<td class="text-center d-none d-md-table-cell">
+									<td class="d-none d-md-table-cell">
 										<?php echo $item->type_translated; ?>
 									</td>
 									<td>


### PR DESCRIPTION
### Summary of Changes
Fix column alignment.


### Testing Instructions
Code review.
or
Install an extension that requires updating (https://github.com/C-Lodder/joomla4-backend-template/releases Version 0.0.16).
Go to System > Update > Update Sites
See `Location` and `Type` columns left-aligned.
Go to System > Update > Extensions
See `Location` and `Type` columns not left-aligned.


### Expected result AFTER applying this Pull Request
Columns left-aligned.