### PR TITLE
Fix comment to be factually correct.

### DIFF
--- a/administrator/components/com_admin/postinstall/eaccelerator.php
+++ b/administrator/components/com_admin/postinstall/eaccelerator.php
@@ -73,7 +73,7 @@ function admin_postinstall_eaccelerator_action()
 		return;
 	}
 
-	// Attempt to make the file unwriteable if using FTP.
+	// Attempt to make the file unwriteable if NOT using FTP.
 	if (!$ftp['enabled'] && JPath::isOwner($file) && !JPath::setPermissions($file, '0444'))
 	{
 		JError::raiseNotice(500, JText::_('COM_CONFIG_ERROR_CONFIGURATION_PHP_NOTUNWRITABLE'));

--- a/administrator/components/com_config/model/application.php
+++ b/administrator/components/com_config/model/application.php
@@ -497,7 +497,7 @@ class ConfigModelApplication extends ConfigModelForm
 			opcache_invalidate($file);
 		}
 
-		// Attempt to make the file unwriteable if using FTP.
+		// Attempt to make the file unwriteable if NOT using FTP.
 		if (!$ftp['enabled'] && JPath::isOwner($file) && !JPath::setPermissions($file, '0444'))
 		{
 			$app->enqueueMessage(JText::_('COM_CONFIG_ERROR_CONFIGURATION_PHP_NOTUNWRITABLE'), 'notice');


### PR DESCRIPTION
### Summary of Changes

Comment change only. 

Clearly `Attempt to make the file unwriteable if using FTP.` is wrong as it goes on to use `if (!$ftp['enabled'] `

+NOT
