### PR TITLE
remove dead code, remove use of $data as it doesnt exist in the scope

### DIFF
--- a/components/com_config/src/Controller/TemplatesController.php
+++ b/components/com_config/src/Controller/TemplatesController.php
@@ -104,10 +104,6 @@ class TemplatesController extends BaseController
 		// Check the return value.
 		if ($return === false)
 		{
-			// Save the data in the session.
-			// TODO Which data?! How did that work?
-			$app->setUserState('com_config.config.global.data', $data);
-
 			// Save failed, go back to the screen and display a notice.
 			$this->setMessage(Text::sprintf('JERROR_SAVE_FAILED'), 'error');
 			$this->setRedirect(Route::_('index.php?option=com_config&view=templates', false));


### PR DESCRIPTION
### Summary of Changes

Remove dead code. 

This code has never worked as `$data` doesnt exist in the scope

Its a copy and paste error from other controllers like https://github.com/joomla/joomla-cms/blob/a1227d8bda0b523a5e6f3099c71fe8d048ef0b35/components/com_config/src/Controller/ConfigController.php#L132

### Testing Instructions

Hard to test as you would need to simulate a save failure

### Actual result BEFORE applying this Pull Request

When editing the "Display Template Options" on the frontend - everything saves ok

If there was ever a condition (like ACL changed AFTER the form loaded) where the save failed, `$data` would not be "a thing" and so could not be saved to the session state and depending on PHP error reporting could show an undefined var notice

### Expected result AFTER applying this Pull Request

When editing the "Display Template Options" on the frontend - everything saves ok

No notices on save failure 

### Documentation Changes Required

None