### PR TITLE
remove dead code $items is not used

### DIFF
--- a/components/com_newsfeeds/src/View/Newsfeed/HtmlView.php
+++ b/components/com_newsfeeds/src/View/Newsfeed/HtmlView.php
@@ -104,9 +104,6 @@ class HtmlView extends BaseHtmlView
 			$categoryModel->setState('category.id', $item->catid);
 			$categoryModel->setState('list.ordering', 'a.name');
 			$categoryModel->setState('list.direction', 'asc');
-
-			// @TODO: $items is not used. Remove this line?
-			$items = $categoryModel->getItems();
 		}
 
 		// Check for errors.


### PR DESCRIPTION
### Summary of Changes

removing dead code, the resultant `$items` is not used and the method call adds nothing but overhead to the run

### Testing Instructions

Code review only needed

All that I removed was the following which someone has already annotated for removal

```
// @TODO: $items is not used. Remove this line?		
$items = $categoryModel->getItems();
```


### Actual result BEFORE applying this Pull Request

Newsfeeds work 

### Expected result AFTER applying this Pull Request

Newsfeeds still work 

### Documentation Changes Required

None