### PR TITLE
Remove $items that is not used

### DIFF
--- a/components/com_newsfeeds/views/newsfeed/view.html.php
+++ b/components/com_newsfeeds/views/newsfeed/view.html.php
@@ -57,15 +57,6 @@ class NewsfeedsViewNewsfeed extends JViewLegacy
 		$state = $this->get('State');
 		$item  = $this->get('Item');
 
-		if ($item)
-		{
-			// Get Category Model data
-			$categoryModel = JModelLegacy::getInstance('Category', 'NewsfeedsModel', array('ignore_request' => true));
-			$categoryModel->setState('category.id', $item->catid);
-			$categoryModel->setState('list.ordering', 'a.name');
-			$categoryModel->setState('list.direction', 'asc');
-		}
-
 		// Check for errors.
 		// @TODO: Maybe this could go into JComponentHelper::raiseErrors($this->get('Errors'))
 		if (count($errors = $this->get('Errors')))

--- a/components/com_newsfeeds/views/newsfeed/view.html.php
+++ b/components/com_newsfeeds/views/newsfeed/view.html.php
@@ -64,9 +64,6 @@ class NewsfeedsViewNewsfeed extends JViewLegacy
 			$categoryModel->setState('category.id', $item->catid);
 			$categoryModel->setState('list.ordering', 'a.name');
 			$categoryModel->setState('list.direction', 'asc');
-
-			// @TODO: $items is not used. Remove this line?
-			$items = $categoryModel->getItems();
 		}
 
 		// Check for errors.


### PR DESCRIPTION
### Summary of Changes

removing dead code, the resultant `$items` is not used and the method call adds nothing but overhead to the run

### Testing Instructions

Code review only needed

All that I removed was the following which someone has already annotated for removal

```
// @TODO: $items is not used. Remove this line?		
$items = $categoryModel->getItems();
```


### Actual result BEFORE applying this Pull Request

Newsfeeds work 

### Expected result AFTER applying this Pull Request

Newsfeeds still work 

### Documentation Changes Required

None

Closes #29806 which was based on `4.0-dev`, this is a rework on `staging` although the files are different Im hoping @wilsonge merges these things up? 