### PR TITLE
[4.0] CLI help text

### DIFF
--- a/libraries/src/Console/AddUserCommand.php
+++ b/libraries/src/Console/AddUserCommand.php
@@ -293,18 +293,15 @@ class AddUserCommand extends AbstractCommand
 	 */
 	protected function configure(): void
 	{
+		$help = "<info>%command.name%</info> will add a user
+		\nUsage: <info>php %command.full_name%</info>";
+
 		$this->addOption('username', null, InputOption::VALUE_OPTIONAL, 'username');
 		$this->addOption('name', null, InputOption::VALUE_OPTIONAL, 'full name of user');
 		$this->addOption('password', null, InputOption::VALUE_OPTIONAL, 'password');
 		$this->addOption('email', null, InputOption::VALUE_OPTIONAL, 'email address');
 		$this->addOption('usergroup', null, InputOption::VALUE_OPTIONAL, 'usergroup (separate multiple groups with comma ",")');
 		$this->setDescription('Add a user');
-		$this->setHelp(
-			<<<EOF
-The <info>%command.name%</info> command adds a user
-
-<info>php %command.full_name%</info>
-EOF
-		);
+		$this->setHelp($help);
 	}
 }

--- a/libraries/src/Console/AddUserToGroupCommand.php
+++ b/libraries/src/Console/AddUserToGroupCommand.php
@@ -289,15 +289,12 @@ class AddUserToGroupCommand extends AbstractCommand
 	 */
 	protected function configure(): void
 	{
+		$help = "<info>%command.name%</info> adds a user to a group
+		\nUsage: <info>php %command.full_name%</info>";
+
 		$this->setDescription('Add a user to a group');
 		$this->addOption('username', null, InputOption::VALUE_OPTIONAL, 'username');
 		$this->addOption('group', null, InputOption::VALUE_OPTIONAL, 'group');
-		$this->setHelp(
-			<<<EOF
-The <info>%command.name%</info> command adds a user to a group
-
-<info>php %command.full_name%</info>
-EOF
-		);
+		$this->setHelp($help);
 	}
 }

--- a/libraries/src/Console/ChangeUserPasswordCommand.php
+++ b/libraries/src/Console/ChangeUserPasswordCommand.php
@@ -162,15 +162,12 @@ class ChangeUserPasswordCommand extends AbstractCommand
 	 */
 	protected function configure(): void
 	{
+		$help = "<info>%command.name%</info> will change a user's password
+		\nUsage: <info>php %command.full_name%</info>";
+
 		$this->addOption('username', null, InputOption::VALUE_OPTIONAL, 'username');
 		$this->addOption('password', null, InputOption::VALUE_OPTIONAL, 'password');
 		$this->setDescription("Change a user's password");
-		$this->setHelp(
-			<<<EOF
-The <info>%command.name%</info> command changes the user's password
-
-<info>php %command.full_name%</info>
-EOF
-		);
+		$this->setHelp($help);
 	}
 }

--- a/libraries/src/Console/CheckJoomlaUpdatesCommand.php
+++ b/libraries/src/Console/CheckJoomlaUpdatesCommand.php
@@ -47,11 +47,9 @@ class CheckJoomlaUpdatesCommand extends AbstractCommand
 	 */
 	protected function configure(): void
 	{
-		$help = <<<'EOF'
-The <info>%command.name%</info> Checks for Joomla updates.
+		$help = "<info>%command.name%</info> will check for Joomla updates
+\nUsage: <info>php %command.full_name%</info>";
 
-  <info>php %command.full_name%</info>
-EOF;
 		$this->setDescription('Check for Joomla updates');
 		$this->setHelp($help);
 	}

--- a/libraries/src/Console/CheckJoomlaUpdatesCommand.php
+++ b/libraries/src/Console/CheckJoomlaUpdatesCommand.php
@@ -48,7 +48,7 @@ class CheckJoomlaUpdatesCommand extends AbstractCommand
 	protected function configure(): void
 	{
 		$help = "<info>%command.name%</info> will check for Joomla updates
-\nUsage: <info>php %command.full_name%</info>";
+		\nUsage: <info>php %command.full_name%</info>";
 
 		$this->setDescription('Check for Joomla updates');
 		$this->setHelp($help);

--- a/libraries/src/Console/CheckUpdatesCommand.php
+++ b/libraries/src/Console/CheckUpdatesCommand.php
@@ -70,13 +70,10 @@ class CheckUpdatesCommand extends AbstractCommand
 	 */
 	protected function configure(): void
 	{
-		$this->setDescription('Check for pending extension updates');
-		$this->setHelp(
-			<<<EOF
-The <info>%command.name%</info> command checks for pending extension updates
+		$help = "<info>%command.name%</info> command checks for pending extension updates
+		\nUsage: <info>php %command.full_name%</info>";
 
-<info>php %command.full_name%</info>
-EOF
-		);
+		$this->setDescription('Check for pending extension updates');
+		$this->setHelp($help);
 	}
 }

--- a/libraries/src/Console/CleanCacheCommand.php
+++ b/libraries/src/Console/CleanCacheCommand.php
@@ -63,13 +63,10 @@ class CleanCacheCommand extends AbstractCommand
 	 */
 	protected function configure(): void
 	{
-		$this->setDescription('Clean expired cache entries');
-		$this->setHelp(
-			<<<EOF
-The <info>%command.name%</info> command cleans the system cache of expired entries
+		$help = "<info>%command.name%</info> will clear expired entries from the system cache
+		\nUsage: <info>php %command.full_name%</info>";
 
-<info>php %command.full_name%</info>
-EOF
-		);
+		$this->setDescription('Clean expired cache entries');
+		$this->setHelp($help);
 	}
 }

--- a/libraries/src/Console/DeleteUserCommand.php
+++ b/libraries/src/Console/DeleteUserCommand.php
@@ -182,14 +182,11 @@ class DeleteUserCommand extends AbstractCommand
 	 */
 	protected function configure(): void
 	{
+		$help = "<info>%command.name%</info> deletes a user
+		\nUsage: <info>php %command.full_name%</info>";
+
 		$this->setDescription('Delete a user');
 		$this->addOption('username', null, InputOption::VALUE_OPTIONAL, 'username');
-		$this->setHelp(
-			<<<EOF
-The <info>%command.name%</info> command deletes a user
-
-<info>php %command.full_name%</info>
-EOF
-		);
+		$this->setHelp($help);
 	}
 }

--- a/libraries/src/Console/ExtensionInstallCommand.php
+++ b/libraries/src/Console/ExtensionInstallCommand.php
@@ -88,7 +88,6 @@ class ExtensionInstallCommand extends AbstractCommand
 		$this->addOption('path', null, InputOption::VALUE_REQUIRED, 'The path to the extension');
 		$this->addOption('url', null, InputOption::VALUE_REQUIRED, 'The url to the extension');
 
-
 		$help = "<info>%command.name%</info> is used to install extensions
 		\nYou must provide one of the following options to the command:
 		\n  --path: The path on your local filesystem to the install package

--- a/libraries/src/Console/ExtensionInstallCommand.php
+++ b/libraries/src/Console/ExtensionInstallCommand.php
@@ -88,21 +88,16 @@ class ExtensionInstallCommand extends AbstractCommand
 		$this->addOption('path', null, InputOption::VALUE_REQUIRED, 'The path to the extension');
 		$this->addOption('url', null, InputOption::VALUE_REQUIRED, 'The url to the extension');
 
+
+		$help = "<info>%command.name%</info> is used to install extensions
+		\nYou must provide one of the following options to the command:
+		\n  --path: The path on your local filesystem to the install package
+		\n  --url: The URL from where the install package should be downloaded
+		\nUsage:
+		\n  <info>php %command.full_name% --path=<path_to_file></info>
+		\n  <info>php %command.full_name% --url=<url_to_file></info>";
+
 		$this->setDescription('Install an extension from a URL or from a path');
-
-		$help = <<<'EOF'
-The <info>%command.name%</info> is used to install extensions
-
-  <info>php %command.full_name%</info>
-
-You must provide one of the following options to the command:
-
-  --path: The path on your local filesystem to the install package
-  --url: The URL from where the install package should be downloaded
-
-  <info>php %command.full_name% --path=<path_to_file></info>
-  <info>php %command.full_name% --url=<url_to_file></info>
-EOF;
 		$this->setHelp($help);
 	}
 

--- a/libraries/src/Console/ExtensionRemoveCommand.php
+++ b/libraries/src/Console/ExtensionRemoveCommand.php
@@ -125,15 +125,13 @@ class ExtensionRemoveCommand extends AbstractCommand
 			InputArgument::REQUIRED,
 			'ID of extension to be removed (run extension:list command to check)'
 		);
+
+		$help = "<info>%command.name%</info> is used to uninstall extensions.
+		\nThe command requires one argument, the ID of the extension to uninstall.
+		\nYou may find this ID by running the <info>extension:list</info> command.
+		\nUsage: <info>php %command.full_name% <extension_id></info>";
+
 		$this->setDescription('Remove an extension');
-
-		$help = <<<'EOF'
-The <info>%command.name%</info> is used to uninstall extensions.
-The command requires one argument, the ID of the extension to uninstall.
-You may find this ID by running the <info>extension:list</info> command.
-
-<info>php %command.full_name% <extension_id></info>
-EOF;
 		$this->setHelp($help);
 	}
 

--- a/libraries/src/Console/ExtensionsListCommand.php
+++ b/libraries/src/Console/ExtensionsListCommand.php
@@ -100,19 +100,15 @@ class ExtensionsListCommand extends AbstractCommand
 	 */
 	protected function configure(): void
 	{
-		$this->setDescription('List installed extensions');
 
 		$this->addOption('type', null, InputOption::VALUE_REQUIRED, 'Type of the extension');
 
-		$help = <<<'EOF'
-The <info>%command.name%</info> is used to list all extensions installed on your site.
+		$help = "<info>%command.name%</info> lists all installed extensions
+		\nUsage: <info>php %command.full_name% <extension_id></info>
+		\nYou may filter on the type of extension (component, module, plugin, etc.) using the <info>--type</info> option:
+		\n  <info>php %command.full_name% --type=<type></info>";
 
-  <info>php %command.full_name% <extension_id></info>
-
-You may filter on the type of extension (component, module, plugin, etc.) using the <info>--type</info> option:
-
-  <info>php %command.full_name% --type=<type></info>
-EOF;
+		$this->setDescription('List installed extensions');
 		$this->setHelp($help);
 	}
 

--- a/libraries/src/Console/GetConfigurationCommand.php
+++ b/libraries/src/Console/GetConfigurationCommand.php
@@ -308,17 +308,16 @@ class GetConfigurationCommand extends AbstractCommand
 
 		$groupNames = implode(', ', $groupNames);
 
-		$this->setDescription('Display the current value of a configuration option');
-
 		$this->addArgument('option', null, 'Name of the option');
 		$this->addOption('group', 'g', InputOption::VALUE_REQUIRED, 'Name of the option');
 
-		$help = "The <info>%command.name%</info> Displays the current value of a configuration option
+		$help = "<info>%command.name%</info> displays the current value of a configuration option
 				\nUsage: <info>php %command.full_name%</info> <option>
 				\nGroup usage: <info>php %command.full_name%</info> --group <groupname>
 				\nAvailable group names: $groupNames";
 
-		$this->setHelp($help);
+			$this->setDescription('Display the current value of a configuration option');
+			$this->setHelp($help);
 	}
 
 	/**

--- a/libraries/src/Console/GetConfigurationCommand.php
+++ b/libraries/src/Console/GetConfigurationCommand.php
@@ -316,8 +316,8 @@ class GetConfigurationCommand extends AbstractCommand
 				\nGroup usage: <info>php %command.full_name%</info> --group <groupname>
 				\nAvailable group names: $groupNames";
 
-			$this->setDescription('Display the current value of a configuration option');
-			$this->setHelp($help);
+		$this->setDescription('Display the current value of a configuration option');
+		$this->setHelp($help);
 	}
 
 	/**

--- a/libraries/src/Console/ListUserCommand.php
+++ b/libraries/src/Console/ListUserCommand.php
@@ -113,13 +113,11 @@ class ListUserCommand extends AbstractCommand
 	 */
 	protected function configure(): void
 	{
-		$this->setDescription('List all users');
-		$this->setHelp(
-			<<<EOF
-The <info>%command.name%</info> command lists all users
+		$help = "<info>%command.name%</info> will list all users
+		\nUsage: <info>php %command.full_name%</info>";
 
-<info>php %command.full_name%</info>
-EOF
-		);
+		$this->setDescription('List all users');
+		$this->setHelp($help);
+
 	}
 }

--- a/libraries/src/Console/ListUserCommand.php
+++ b/libraries/src/Console/ListUserCommand.php
@@ -118,6 +118,5 @@ class ListUserCommand extends AbstractCommand
 
 		$this->setDescription('List all users');
 		$this->setHelp($help);
-
 	}
 }

--- a/libraries/src/Console/RemoveOldFilesCommand.php
+++ b/libraries/src/Console/RemoveOldFilesCommand.php
@@ -65,13 +65,10 @@ class RemoveOldFilesCommand extends AbstractCommand
 	 */
 	protected function configure(): void
 	{
-		$this->setDescription('Remove old system files');
-		$this->setHelp(
-			<<<EOF
-The <info>%command.name%</info> command removes old files which should have been deleted during a Joomla update
+		$help = "<info>%command.name%</info> removes old files which should have been deleted during a Joomla update
+		\nUsage: <info>php %command.full_name%</info>";
 
-<info>php %command.full_name%</info>
-EOF
-		);
+		$this->setDescription('Remove old system files');
+		$this->setHelp($help);
 	}
 }

--- a/libraries/src/Console/RemoveUserFromGroupCommand.php
+++ b/libraries/src/Console/RemoveUserFromGroupCommand.php
@@ -290,15 +290,12 @@ class RemoveUserFromGroupCommand extends AbstractCommand
 	 */
 	protected function configure(): void
 	{
+		$help = "<info>%command.name%</info> removes a user from a group
+		\nUsage: <info>php %command.full_name%</info>";
+
 		$this->setDescription('Remove a user from a group');
 		$this->addOption('username', null, InputOption::VALUE_OPTIONAL, 'username');
 		$this->addOption('group', null, InputOption::VALUE_OPTIONAL, 'group');
-		$this->setHelp(
-			<<<EOF
-The <info>%command.name%</info> command removes a user from a group
-
-<info>php %command.full_name%</info>
-EOF
-		);
+		$this->setHelp($help);
 	}
 }

--- a/libraries/src/Console/SessionGcCommand.php
+++ b/libraries/src/Console/SessionGcCommand.php
@@ -80,20 +80,15 @@ class SessionGcCommand extends AbstractCommand implements ContainerAwareInterfac
 	 */
 	protected function configure(): void
 	{
+		$help = "<info>%command.name%</info> runs PHP's garbage collection operation for session data
+		\nUsage: <info>php %command.full_name%</info>
+		\nThis command defaults to performing garbage collection for the frontend (site) application.
+		\nTo run garbage collection for another application, you can specify it with the <info>--application</info> option.
+		\nUsage: <info>php %command.full_name% --application=[APPLICATION]</info>";
+
 		$this->setDescription('Perform session garbage collection');
 		$this->addOption('application', 'app', InputOption::VALUE_OPTIONAL, 'The application to perform garbage collection for.', 'site');
-		$this->setHelp(
-			<<<EOF
-The <info>%command.name%</info> command runs PHP's garbage collection operation for session data
-
-<info>php %command.full_name%</info>
-
-This command defaults to performing garbage collection for the frontend (site) application. To run garbage collection
-for another application, you can specify it with the <info>--application</info> option.
-
-<info>php %command.full_name% --application=[APPLICATION]</info>
-EOF
-		);
+		$this->setHelp($help);
 	}
 
 	/**

--- a/libraries/src/Console/SessionMetadataGcCommand.php
+++ b/libraries/src/Console/SessionMetadataGcCommand.php
@@ -98,13 +98,10 @@ class SessionMetadataGcCommand extends AbstractCommand
 	 */
 	protected function configure(): void
 	{
-		$this->setDescription('Perform session metadata garbage collection');
-		$this->setHelp(
-			<<<EOF
-The <info>%command.name%</info> command runs the garbage collection operation for Joomla session metadata
+		$help = "<info>%command.name%</info> runs the garbage collection operation for Joomla session metadata
+		\nUsage: <info>php %command.full_name%</info>";
 
-<info>php %command.full_name%</info>
-EOF
-		);
+		$this->setDescription('Perform session metadata garbage collection');
+		$this->setHelp($help);
 	}
 }

--- a/libraries/src/Console/SetConfigurationCommand.php
+++ b/libraries/src/Console/SetConfigurationCommand.php
@@ -252,8 +252,8 @@ class SetConfigurationCommand extends AbstractCommand
 		$help = "<info>%command.name%</info> sets the value for a configuration option
 				\nUsage: <info>php %command.full_name%</info> <option>=<value>";
 
-			$this->setDescription('Set a value for a configuration option');
-			$this->setHelp($help);
+		$this->setDescription('Set a value for a configuration option');
+		$this->setHelp($help);
 	}
 
 	/**

--- a/libraries/src/Console/SetConfigurationCommand.php
+++ b/libraries/src/Console/SetConfigurationCommand.php
@@ -243,19 +243,17 @@ class SetConfigurationCommand extends AbstractCommand
 	 */
 	protected function configure(): void
 	{
-		$this->setDescription('Set a value for a configuration option');
-
 		$this->addArgument(
 			'options',
 			InputArgument::REQUIRED | InputArgument::IS_ARRAY,
 			'All options you want to set'
 		);
 
-		$help = "The <info>%command.name%</info>
-				Sets a value for a configuration option
+		$help = "<info>%command.name%</info> sets the value for a configuration option
 				\nUsage: <info>php %command.full_name%</info> <option>=<value>";
 
-		$this->setHelp($help);
+			$this->setDescription('Set a value for a configuration option');
+			$this->setHelp($help);
 	}
 
 	/**

--- a/libraries/src/Console/SiteDownCommand.php
+++ b/libraries/src/Console/SiteDownCommand.php
@@ -75,13 +75,10 @@ class SiteDownCommand extends AbstractCommand
 	 */
 	protected function configure(): void
 	{
+		$help = "<info>%command.name%</info> puts the site into offline mode
+		\nUsage: <info>php %command.full_name%</info>";
+
 		$this->setDescription('Put the site into offline mode');
-
-		$help = <<<'EOF'
-The <info>%command.name%</info> is used to place the site offline.
-
-  <info>php %command.full_name%</info>
-EOF;
 		$this->setHelp($help);
 	}
 

--- a/libraries/src/Console/SiteUpCommand.php
+++ b/libraries/src/Console/SiteUpCommand.php
@@ -75,11 +75,10 @@ class SiteUpCommand extends AbstractCommand
 	 */
 	protected function configure(): void
 	{
-		$this->setDescription('Put the site into online mode');
-
-		$help = "The <info>%command.name%</info> Puts the site into online mode
+		$help = "<info>%command.name%</info> puts the site into online mode
 				\nUsage: <info>php %command.full_name%</info>";
 
+		$this->setDescription('Put the site into online mode');
 		$this->setHelp($help);
 	}
 

--- a/libraries/src/Console/UpdateCoreCommand.php
+++ b/libraries/src/Console/UpdateCoreCommand.php
@@ -189,13 +189,10 @@ class UpdateCoreCommand extends AbstractCommand
 	 */
 	protected function configure(): void
 	{
+		$help = "<info>%command.name%</info> is used to update Joomla
+		\nUsage: <info>php %command.full_name%</info>";
+
 		$this->setDescription('Update Joomla');
-
-		$help = <<<'EOF'
-The <info>%command.name%</info> is used to update Joomla.
-
-  <info>php %command.full_name%</info>
-EOF;
 		$this->setHelp($help);
 	}
 


### PR DESCRIPTION
Try to make the help text consistent in code, grammar and usage

` php cli\joomla.php user:removefromgroup`
