### PR TITLE
[4.0] Propose s/cachable/cacheable 

### DIFF
--- a/administrator/components/com_banners/src/Controller/DisplayController.php
+++ b/administrator/components/com_banners/src/Controller/DisplayController.php
@@ -34,14 +34,14 @@ class DisplayController extends BaseController
 	/**
 	 * Method to display a view.
 	 *
-	 * @param   boolean  $cachable   If true, the view output will be cached
+	 * @param   boolean  $cacheable   If true, the view output will be cached
 	 * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
 	 *
 	 * @return  BaseController|bool  This object to support chaining.
 	 *
 	 * @since   1.5
 	 */
-	public function display($cachable = false, $urlparams = array())
+	public function display($cacheable = false, $urlparams = array())
 	{
 		BannersHelper::updateReset();
 

--- a/administrator/components/com_banners/src/Controller/DisplayController.php
+++ b/administrator/components/com_banners/src/Controller/DisplayController.php
@@ -34,7 +34,7 @@ class DisplayController extends BaseController
 	/**
 	 * Method to display a view.
 	 *
-	 * @param   boolean  $cacheable   If true, the view output will be cached
+	 * @param   boolean  $cacheable  If true, the view output will be cached
 	 * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
 	 *
 	 * @return  BaseController|bool  This object to support chaining.

--- a/administrator/components/com_banners/src/Controller/TracksController.php
+++ b/administrator/components/com_banners/src/Controller/TracksController.php
@@ -93,7 +93,7 @@ class TracksController extends BaseController
 	/**
 	 * Display method for the raw track data.
 	 *
-	 * @param   boolean  $cachable   If true, the view output will be cached
+	 * @param   boolean  $cacheable   If true, the view output will be cached
 	 * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
 	 *
 	 * @return  static  This object to support chaining.
@@ -101,7 +101,7 @@ class TracksController extends BaseController
 	 * @since   1.5
 	 * @todo    This should be done as a view, not here!
 	 */
-	public function display($cachable = false, $urlparams = array())
+	public function display($cacheable = false, $urlparams = array())
 	{
 		// Get the document object.
 		$vName = 'tracks';

--- a/administrator/components/com_banners/src/Controller/TracksController.php
+++ b/administrator/components/com_banners/src/Controller/TracksController.php
@@ -93,7 +93,7 @@ class TracksController extends BaseController
 	/**
 	 * Display method for the raw track data.
 	 *
-	 * @param   boolean  $cacheable   If true, the view output will be cached
+	 * @param   boolean  $cacheable  If true, the view output will be cached
 	 * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
 	 *
 	 * @return  static  This object to support chaining.

--- a/administrator/components/com_categories/src/Controller/DisplayController.php
+++ b/administrator/components/com_categories/src/Controller/DisplayController.php
@@ -65,14 +65,14 @@ class DisplayController extends BaseController
 	/**
 	 * Method to display a view.
 	 *
-	 * @param   boolean  $cachable   If true, the view output will be cached
+	 * @param   boolean  $cacheable   If true, the view output will be cached
 	 * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
 	 *
 	 * @return  static|boolean  This object to support chaining.
 	 *
 	 * @since   1.5
 	 */
-	public function display($cachable = false, $urlparams = array())
+	public function display($cacheable = false, $urlparams = array())
 	{
 		// Get the document object.
 		$document = $this->app->getDocument();

--- a/administrator/components/com_categories/src/Controller/DisplayController.php
+++ b/administrator/components/com_categories/src/Controller/DisplayController.php
@@ -65,7 +65,7 @@ class DisplayController extends BaseController
 	/**
 	 * Method to display a view.
 	 *
-	 * @param   boolean  $cacheable   If true, the view output will be cached
+	 * @param   boolean  $cacheable  If true, the view output will be cached
 	 * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
 	 *
 	 * @return  static|boolean  This object to support chaining.

--- a/administrator/components/com_checkin/src/Controller/DisplayController.php
+++ b/administrator/components/com_checkin/src/Controller/DisplayController.php
@@ -33,12 +33,12 @@ class DisplayController extends BaseController
 	/**
 	 * Method to display a view.
 	 *
-	 * @param   boolean  $cachable   If true, the view output will be cached
+	 * @param   boolean  $cacheable   If true, the view output will be cached
 	 * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
 	 *
 	 * @return  static  A \JControllerLegacy object to support chaining.
 	 */
-	public function display($cachable = false, $urlparams = array())
+	public function display($cacheable = false, $urlparams = array())
 	{
 		return parent::display();
 	}

--- a/administrator/components/com_checkin/src/Controller/DisplayController.php
+++ b/administrator/components/com_checkin/src/Controller/DisplayController.php
@@ -33,7 +33,7 @@ class DisplayController extends BaseController
 	/**
 	 * Method to display a view.
 	 *
-	 * @param   boolean  $cacheable   If true, the view output will be cached
+	 * @param   boolean  $cacheable  If true, the view output will be cached
 	 * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
 	 *
 	 * @return  static  A \JControllerLegacy object to support chaining.

--- a/administrator/components/com_config/src/Controller/DisplayController.php
+++ b/administrator/components/com_config/src/Controller/DisplayController.php
@@ -37,7 +37,7 @@ class DisplayController extends BaseController
 	 * This function is provide as a default implementation, in most cases
 	 * you will need to override it in your own controllers.
 	 *
-	 * @param   boolean  $cachable   If true, the view output will be cached
+	 * @param   boolean  $cacheable   If true, the view output will be cached
 	 * @param   array    $urlparams  An array of safe url parameters and their variable types, for valid values see {@link InputFilter::clean()}.
 	 *
 	 * @return  static  A \JControllerLegacy object to support chaining.
@@ -45,7 +45,7 @@ class DisplayController extends BaseController
 	 * @since   3.0
 	 * @throws  \Exception
 	 */
-	public function display($cachable = false, $urlparams = array())
+	public function display($cacheable = false, $urlparams = array())
 	{
 		$component = $this->input->get('component');
 
@@ -56,6 +56,6 @@ class DisplayController extends BaseController
 			$this->setRedirect(Route::_('index.php'), Text::_('JERROR_ALERTNOAUTHOR'), 'error');
 		}
 
-		return parent::display($cachable, $urlparams);
+		return parent::display($cacheable, $urlparams);
 	}
 }

--- a/administrator/components/com_config/src/Controller/DisplayController.php
+++ b/administrator/components/com_config/src/Controller/DisplayController.php
@@ -37,7 +37,7 @@ class DisplayController extends BaseController
 	 * This function is provide as a default implementation, in most cases
 	 * you will need to override it in your own controllers.
 	 *
-	 * @param   boolean  $cacheable   If true, the view output will be cached
+	 * @param   boolean  $cacheable  If true, the view output will be cached
 	 * @param   array    $urlparams  An array of safe url parameters and their variable types, for valid values see {@link InputFilter::clean()}.
 	 *
 	 * @return  static  A \JControllerLegacy object to support chaining.

--- a/administrator/components/com_contact/src/Controller/DisplayController.php
+++ b/administrator/components/com_contact/src/Controller/DisplayController.php
@@ -33,14 +33,14 @@ class DisplayController extends BaseController
 	/**
 	 * Method to display a view.
 	 *
-	 * @param   boolean  $cachable   If true, the view output will be cached
+	 * @param   boolean  $cacheable   If true, the view output will be cached
 	 * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
 	 *
 	 * @return  static |boolean  This object to support chaining. False on failure.
 	 *
 	 * @since   1.5
 	 */
-	public function display($cachable = false, $urlparams = array())
+	public function display($cacheable = false, $urlparams = array())
 	{
 		$view   = $this->input->get('view', $this->default_view);
 		$layout = $this->input->get('layout', 'default');

--- a/administrator/components/com_contact/src/Controller/DisplayController.php
+++ b/administrator/components/com_contact/src/Controller/DisplayController.php
@@ -33,7 +33,7 @@ class DisplayController extends BaseController
 	/**
 	 * Method to display a view.
 	 *
-	 * @param   boolean  $cacheable   If true, the view output will be cached
+	 * @param   boolean  $cacheable  If true, the view output will be cached
 	 * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
 	 *
 	 * @return  static |boolean  This object to support chaining. False on failure.

--- a/administrator/components/com_content/src/Controller/DisplayController.php
+++ b/administrator/components/com_content/src/Controller/DisplayController.php
@@ -33,14 +33,14 @@ class DisplayController extends BaseController
 	/**
 	 * Method to display a view.
 	 *
-	 * @param   boolean  $cachable   If true, the view output will be cached
+	 * @param   boolean  $cacheable   If true, the view output will be cached
 	 * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link JFilterInput::clean()}.
 	 *
 	 * @return  BaseController|boolean  This object to support chaining.
 	 *
 	 * @since   1.5
 	 */
-	public function display($cachable = false, $urlparams = array())
+	public function display($cacheable = false, $urlparams = array())
 	{
 		$view   = $this->input->get('view', 'articles');
 		$layout = $this->input->get('layout', 'articles');

--- a/administrator/components/com_content/src/Controller/DisplayController.php
+++ b/administrator/components/com_content/src/Controller/DisplayController.php
@@ -33,7 +33,7 @@ class DisplayController extends BaseController
 	/**
 	 * Method to display a view.
 	 *
-	 * @param   boolean  $cacheable   If true, the view output will be cached
+	 * @param   boolean  $cacheable  If true, the view output will be cached
 	 * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link JFilterInput::clean()}.
 	 *
 	 * @return  BaseController|boolean  This object to support chaining.

--- a/administrator/components/com_cpanel/src/Controller/DisplayController.php
+++ b/administrator/components/com_cpanel/src/Controller/DisplayController.php
@@ -36,14 +36,14 @@ class DisplayController extends BaseController
 	 * This function is provide as a default implementation, in most cases
 	 * you will need to override it in your own controllers.
 	 *
-	 * @param   boolean  $cachable   If true, the view output will be cached
+	 * @param   boolean  $cacheable   If true, the view output will be cached
 	 * @param   array    $urlparams  An array of safe url parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
 	 *
 	 * @return  static  An instance of the current object to support chaining.
 	 *
 	 * @since   3.0
 	 */
-	public function display($cachable = false, $urlparams = array())
+	public function display($cacheable = false, $urlparams = array())
 	{
 		/*
 		 * Set the template - this will display cpanel.php
@@ -51,7 +51,7 @@ class DisplayController extends BaseController
 		 */
 		$this->input->set('tmpl', 'cpanel');
 
-		return parent::display($cachable, $urlparams);
+		return parent::display($cacheable, $urlparams);
 	}
 
 	/**

--- a/administrator/components/com_cpanel/src/Controller/DisplayController.php
+++ b/administrator/components/com_cpanel/src/Controller/DisplayController.php
@@ -36,7 +36,7 @@ class DisplayController extends BaseController
 	 * This function is provide as a default implementation, in most cases
 	 * you will need to override it in your own controllers.
 	 *
-	 * @param   boolean  $cacheable   If true, the view output will be cached
+	 * @param   boolean  $cacheable  If true, the view output will be cached
 	 * @param   array    $urlparams  An array of safe url parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
 	 *
 	 * @return  static  An instance of the current object to support chaining.

--- a/administrator/components/com_csp/src/Controller/DisplayController.php
+++ b/administrator/components/com_csp/src/Controller/DisplayController.php
@@ -35,14 +35,14 @@ class DisplayController extends BaseController
 	/**
 	 * Method to display a view.
 	 *
-	 * @param   boolean  $cachable   If true, the view output will be cached.
+	 * @param   boolean  $cacheable   If true, the view output will be cached.
 	 * @param   mixed    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
 	 *
 	 * @return  static   This object to support chaining.
 	 *
 	 * @since   4.0.0
 	 */
-	public function display($cachable = false, $urlparams = false)
+	public function display($cacheable = false, $urlparams = false)
 	{
 		// Show messages about the plugin when it is disabled
 		if (!PluginHelper::isEnabled('system', 'httpheaders'))

--- a/administrator/components/com_csp/src/Controller/DisplayController.php
+++ b/administrator/components/com_csp/src/Controller/DisplayController.php
@@ -35,7 +35,7 @@ class DisplayController extends BaseController
 	/**
 	 * Method to display a view.
 	 *
-	 * @param   boolean  $cacheable   If true, the view output will be cached.
+	 * @param   boolean  $cacheable  If true, the view output will be cached.
 	 * @param   mixed    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
 	 *
 	 * @return  static   This object to support chaining.

--- a/administrator/components/com_fields/src/Controller/DisplayController.php
+++ b/administrator/components/com_fields/src/Controller/DisplayController.php
@@ -37,14 +37,14 @@ class DisplayController extends BaseController
 	 * This function is provide as a default implementation, in most cases
 	 * you will need to override it in your own controllers.
 	 *
-	 * @param   boolean     $cachable   If true, the view output will be cached
+	 * @param   boolean     $cacheable   If true, the view output will be cached
 	 * @param   array|bool  $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}
 	 *
 	 * @return  BaseController|boolean  A Controller object to support chaining.
 	 *
 	 * @since   3.7.0
 	 */
-	public function display($cachable = false, $urlparams = false)
+	public function display($cacheable = false, $urlparams = false)
 	{
 		// Set the default view name and format from the Request.
 		$vName   = $this->input->get('view', 'fields');
@@ -60,6 +60,6 @@ class DisplayController extends BaseController
 			return false;
 		}
 
-		return parent::display($cachable, $urlparams);
+		return parent::display($cacheable, $urlparams);
 	}
 }

--- a/administrator/components/com_fields/src/Controller/DisplayController.php
+++ b/administrator/components/com_fields/src/Controller/DisplayController.php
@@ -37,7 +37,7 @@ class DisplayController extends BaseController
 	 * This function is provide as a default implementation, in most cases
 	 * you will need to override it in your own controllers.
 	 *
-	 * @param   boolean     $cacheable   If true, the view output will be cached
+	 * @param   boolean     $cacheable  If true, the view output will be cached
 	 * @param   array|bool  $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}
 	 *
 	 * @return  BaseController|boolean  A Controller object to support chaining.

--- a/administrator/components/com_finder/src/Controller/DisplayController.php
+++ b/administrator/components/com_finder/src/Controller/DisplayController.php
@@ -33,7 +33,7 @@ class DisplayController extends BaseController
 	/**
 	 * Method to display a view.
 	 *
-	 * @param   boolean  $cacheable   If true, the view output will be cached
+	 * @param   boolean  $cacheable  If true, the view output will be cached
 	 * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
 	 *
 	 * @return  static|boolean   A Controller object to support chaining or false on failure.

--- a/administrator/components/com_finder/src/Controller/DisplayController.php
+++ b/administrator/components/com_finder/src/Controller/DisplayController.php
@@ -33,14 +33,14 @@ class DisplayController extends BaseController
 	/**
 	 * Method to display a view.
 	 *
-	 * @param   boolean  $cachable   If true, the view output will be cached
+	 * @param   boolean  $cacheable   If true, the view output will be cached
 	 * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
 	 *
 	 * @return  static|boolean   A Controller object to support chaining or false on failure.
 	 *
 	 * @since	2.5
 	 */
-	public function display($cachable = false, $urlparams = array())
+	public function display($cacheable = false, $urlparams = array())
 	{
 		$view   = $this->input->get('view', 'index', 'word');
 		$layout = $this->input->get('layout', 'index', 'word');

--- a/administrator/components/com_installer/src/Controller/DisplayController.php
+++ b/administrator/components/com_installer/src/Controller/DisplayController.php
@@ -27,7 +27,7 @@ class DisplayController extends BaseController
 	/**
 	 * Method to display a view.
 	 *
-	 * @param   boolean  $cacheable   If true, the view output will be cached
+	 * @param   boolean  $cacheable  If true, the view output will be cached
 	 * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
 	 *
 	 * @return  static   This object to support chaining.

--- a/administrator/components/com_installer/src/Controller/DisplayController.php
+++ b/administrator/components/com_installer/src/Controller/DisplayController.php
@@ -27,14 +27,14 @@ class DisplayController extends BaseController
 	/**
 	 * Method to display a view.
 	 *
-	 * @param   boolean  $cachable   If true, the view output will be cached
+	 * @param   boolean  $cacheable   If true, the view output will be cached
 	 * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
 	 *
 	 * @return  static   This object to support chaining.
 	 *
 	 * @since   1.5
 	 */
-	public function display($cachable = false, $urlparams = false)
+	public function display($cacheable = false, $urlparams = false)
 	{
 		// Get the document object.
 		$document = $this->app->getDocument();

--- a/administrator/components/com_joomlaupdate/src/Controller/DisplayController.php
+++ b/administrator/components/com_joomlaupdate/src/Controller/DisplayController.php
@@ -26,14 +26,14 @@ class DisplayController extends BaseController
 	/**
 	 * Method to display a view.
 	 *
-	 * @param   boolean  $cachable   If true, the view output will be cached.
+	 * @param   boolean  $cacheable   If true, the view output will be cached.
 	 * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
 	 *
 	 * @return  static   This object to support chaining.
 	 *
 	 * @since   2.5.4
 	 */
-	public function display($cachable = false, $urlparams = false)
+	public function display($cacheable = false, $urlparams = false)
 	{
 		// Get the document object.
 		$document = $this->app->getDocument();

--- a/administrator/components/com_joomlaupdate/src/Controller/DisplayController.php
+++ b/administrator/components/com_joomlaupdate/src/Controller/DisplayController.php
@@ -26,7 +26,7 @@ class DisplayController extends BaseController
 	/**
 	 * Method to display a view.
 	 *
-	 * @param   boolean  $cacheable   If true, the view output will be cached.
+	 * @param   boolean  $cacheable  If true, the view output will be cached.
 	 * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
 	 *
 	 * @return  static   This object to support chaining.

--- a/administrator/components/com_joomlaupdate/src/Controller/UpdateController.php
+++ b/administrator/components/com_joomlaupdate/src/Controller/UpdateController.php
@@ -390,14 +390,14 @@ class UpdateController extends BaseController
 	/**
 	 * Method to display a view.
 	 *
-	 * @param   boolean  $cachable   If true, the view output will be cached
+	 * @param   boolean  $cacheable   If true, the view output will be cached
 	 * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
 	 *
 	 * @return  static  This object to support chaining.
 	 *
 	 * @since   2.5.4
 	 */
-	public function display($cachable = false, $urlparams = array())
+	public function display($cacheable = false, $urlparams = array())
 	{
 		// Get the document object.
 		$document = $this->app->getDocument();

--- a/administrator/components/com_joomlaupdate/src/Controller/UpdateController.php
+++ b/administrator/components/com_joomlaupdate/src/Controller/UpdateController.php
@@ -390,7 +390,7 @@ class UpdateController extends BaseController
 	/**
 	 * Method to display a view.
 	 *
-	 * @param   boolean  $cacheable   If true, the view output will be cached
+	 * @param   boolean  $cacheable  If true, the view output will be cached
 	 * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
 	 *
 	 * @return  static  This object to support chaining.

--- a/administrator/components/com_languages/src/Controller/DisplayController.php
+++ b/administrator/components/com_languages/src/Controller/DisplayController.php
@@ -31,7 +31,7 @@ class DisplayController extends BaseController
 	/**
 	 * Method to display a view.
 	 *
-	 * @param   boolean  $cacheable   If true, the view output will be cached.
+	 * @param   boolean  $cacheable  If true, the view output will be cached.
 	 * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
 	 *
 	 * @return  static|boolean   This object to support chaining or false on failure.

--- a/administrator/components/com_languages/src/Controller/DisplayController.php
+++ b/administrator/components/com_languages/src/Controller/DisplayController.php
@@ -31,14 +31,14 @@ class DisplayController extends BaseController
 	/**
 	 * Method to display a view.
 	 *
-	 * @param   boolean  $cachable   If true, the view output will be cached.
+	 * @param   boolean  $cacheable   If true, the view output will be cached.
 	 * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
 	 *
 	 * @return  static|boolean   This object to support chaining or false on failure.
 	 *
 	 * @since   1.5
 	 */
-	public function display($cachable = false, $urlparams = false)
+	public function display($cacheable = false, $urlparams = false)
 	{
 		$view   = $this->input->get('view', $this->default_view);
 		$layout = $this->input->get('layout', 'default');

--- a/administrator/components/com_login/src/Controller/DisplayController.php
+++ b/administrator/components/com_login/src/Controller/DisplayController.php
@@ -26,7 +26,7 @@ class DisplayController extends BaseController
 	/**
 	 * Method to display a view.
 	 *
-	 * @param   boolean  $cacheable   If true, the view output will be cached
+	 * @param   boolean  $cacheable  If true, the view output will be cached
 	 * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
 	 *
 	 * @return  static	 This object to support chaining.

--- a/administrator/components/com_login/src/Controller/DisplayController.php
+++ b/administrator/components/com_login/src/Controller/DisplayController.php
@@ -26,7 +26,7 @@ class DisplayController extends BaseController
 	/**
 	 * Method to display a view.
 	 *
-	 * @param   boolean  $cachable   If true, the view output will be cached
+	 * @param   boolean  $cacheable   If true, the view output will be cached
 	 * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
 	 *
 	 * @return  static	 This object to support chaining.
@@ -34,7 +34,7 @@ class DisplayController extends BaseController
 	 * @since   1.5
 	 * @throws  \Exception
 	 */
-	public function display($cachable = false, $urlparams = false)
+	public function display($cacheable = false, $urlparams = false)
 	{
 		/*
 		 * Special treatment is required for this component, as this view may be called

--- a/administrator/components/com_menus/src/Controller/DisplayController.php
+++ b/administrator/components/com_menus/src/Controller/DisplayController.php
@@ -37,7 +37,7 @@ class DisplayController extends BaseController
 	/**
 	 * Method to display a view.
 	 *
-	 * @param   boolean        $cacheable   If true, the view output will be cached
+	 * @param   boolean        $cacheable  If true, the view output will be cached
 	 * @param   array|boolean  $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link JFilterInput::clean()}.
 	 *
 	 * @return  static    This object to support chaining.

--- a/administrator/components/com_menus/src/Controller/DisplayController.php
+++ b/administrator/components/com_menus/src/Controller/DisplayController.php
@@ -37,14 +37,14 @@ class DisplayController extends BaseController
 	/**
 	 * Method to display a view.
 	 *
-	 * @param   boolean        $cachable   If true, the view output will be cached
+	 * @param   boolean        $cacheable   If true, the view output will be cached
 	 * @param   array|boolean  $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link JFilterInput::clean()}.
 	 *
 	 * @return  static    This object to support chaining.
 	 *
 	 * @since   1.5
 	 */
-	public function display($cachable = false, $urlparams = false)
+	public function display($cacheable = false, $urlparams = false)
 	{
 		// Verify menu
 		$menuType = $this->input->post->getCmd('menutype', '');

--- a/administrator/components/com_menus/src/Controller/MenuController.php
+++ b/administrator/components/com_menus/src/Controller/MenuController.php
@@ -28,14 +28,14 @@ class MenuController extends FormController
 	/**
 	 * Dummy method to redirect back to standard controller
 	 *
-	 * @param   boolean  $cachable   If true, the view output will be cached.
+	 * @param   boolean  $cacheable   If true, the view output will be cached.
 	 * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
 	 *
 	 * @return  void
 	 *
 	 * @since   1.5
 	 */
-	public function display($cachable = false, $urlparams = false)
+	public function display($cacheable = false, $urlparams = false)
 	{
 		$this->setRedirect(Route::_('index.php?option=com_menus&view=menus', false));
 	}

--- a/administrator/components/com_menus/src/Controller/MenuController.php
+++ b/administrator/components/com_menus/src/Controller/MenuController.php
@@ -28,7 +28,7 @@ class MenuController extends FormController
 	/**
 	 * Dummy method to redirect back to standard controller
 	 *
-	 * @param   boolean  $cacheable   If true, the view output will be cached.
+	 * @param   boolean  $cacheable  If true, the view output will be cached.
 	 * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
 	 *
 	 * @return  void

--- a/administrator/components/com_menus/src/Controller/MenusController.php
+++ b/administrator/components/com_menus/src/Controller/MenusController.php
@@ -27,7 +27,7 @@ class MenusController extends BaseController
 	/**
 	 * Display the view
 	 *
-	 * @param   boolean  $cacheable   If true, the view output will be cached.
+	 * @param   boolean  $cacheable  If true, the view output will be cached.
 	 * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
 	 *
 	 * @return  void

--- a/administrator/components/com_menus/src/Controller/MenusController.php
+++ b/administrator/components/com_menus/src/Controller/MenusController.php
@@ -27,14 +27,14 @@ class MenusController extends BaseController
 	/**
 	 * Display the view
 	 *
-	 * @param   boolean  $cachable   If true, the view output will be cached.
+	 * @param   boolean  $cacheable   If true, the view output will be cached.
 	 * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
 	 *
 	 * @return  void
 	 *
 	 * @since   1.6
 	 */
-	public function display($cachable = false, $urlparams = false)
+	public function display($cacheable = false, $urlparams = false)
 	{
 	}
 

--- a/administrator/components/com_messages/src/Controller/DisplayController.php
+++ b/administrator/components/com_messages/src/Controller/DisplayController.php
@@ -33,7 +33,7 @@ class DisplayController extends BaseController
 	/**
 	 * Method to display a view.
 	 *
-	 * @param   boolean  $cacheable   If true, the view output will be cached.
+	 * @param   boolean  $cacheable  If true, the view output will be cached.
 	 * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
 	 *
 	 * @return  static|boolean	 This object to support chaining or false on failure.

--- a/administrator/components/com_messages/src/Controller/DisplayController.php
+++ b/administrator/components/com_messages/src/Controller/DisplayController.php
@@ -33,14 +33,14 @@ class DisplayController extends BaseController
 	/**
 	 * Method to display a view.
 	 *
-	 * @param   boolean  $cachable   If true, the view output will be cached.
+	 * @param   boolean  $cacheable   If true, the view output will be cached.
 	 * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
 	 *
 	 * @return  static|boolean	 This object to support chaining or false on failure.
 	 *
 	 * @since   1.5
 	 */
-	public function display($cachable = false, $urlparams = false)
+	public function display($cacheable = false, $urlparams = false)
 	{
 		$view   = $this->input->get('view', 'messages');
 		$layout = $this->input->get('layout', 'default');

--- a/administrator/components/com_modules/src/Controller/DisplayController.php
+++ b/administrator/components/com_modules/src/Controller/DisplayController.php
@@ -37,7 +37,7 @@ class DisplayController extends BaseController
 	/**
 	 * Method to display a view.
 	 *
-	 * @param   boolean        $cacheable   If true, the view output will be cached
+	 * @param   boolean        $cacheable  If true, the view output will be cached
 	 * @param   array|boolean  $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}
 	 *
 	 * @return  static|boolean   This object to support chaining or false on failure.

--- a/administrator/components/com_modules/src/Controller/DisplayController.php
+++ b/administrator/components/com_modules/src/Controller/DisplayController.php
@@ -37,14 +37,14 @@ class DisplayController extends BaseController
 	/**
 	 * Method to display a view.
 	 *
-	 * @param   boolean        $cachable   If true, the view output will be cached
+	 * @param   boolean        $cacheable   If true, the view output will be cached
 	 * @param   array|boolean  $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}
 	 *
 	 * @return  static|boolean   This object to support chaining or false on failure.
 	 *
 	 * @since   1.5
 	 */
-	public function display($cachable = false, $urlparams = false)
+	public function display($cacheable = false, $urlparams = false)
 	{
 		$layout = $this->input->get('layout', 'edit');
 		$id     = $this->input->getInt('id');

--- a/administrator/components/com_newsfeeds/src/Controller/DisplayController.php
+++ b/administrator/components/com_newsfeeds/src/Controller/DisplayController.php
@@ -33,14 +33,14 @@ class DisplayController extends BaseController
 	/**
 	 * Method to display a view.
 	 *
-	 * @param   boolean  $cachable   If true, the view output will be cached
+	 * @param   boolean  $cacheable   If true, the view output will be cached
 	 * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
 	 *
 	 * @return  static|boolean   This object to support chaining.
 	 *
 	 * @since   1.5
 	 */
-	public function display($cachable = false, $urlparams = array())
+	public function display($cacheable = false, $urlparams = array())
 	{
 		$view   = $this->input->get('view', 'newsfeeds');
 		$layout = $this->input->get('layout', 'default');

--- a/administrator/components/com_newsfeeds/src/Controller/DisplayController.php
+++ b/administrator/components/com_newsfeeds/src/Controller/DisplayController.php
@@ -33,7 +33,7 @@ class DisplayController extends BaseController
 	/**
 	 * Method to display a view.
 	 *
-	 * @param   boolean  $cacheable   If true, the view output will be cached
+	 * @param   boolean  $cacheable  If true, the view output will be cached
 	 * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
 	 *
 	 * @return  static|boolean   This object to support chaining.

--- a/administrator/components/com_plugins/src/Controller/DisplayController.php
+++ b/administrator/components/com_plugins/src/Controller/DisplayController.php
@@ -33,14 +33,14 @@ class DisplayController extends BaseController
 	/**
 	 * Method to display a view.
 	 *
-	 * @param   boolean  $cachable   If true, the view output will be cached
+	 * @param   boolean  $cacheable   If true, the view output will be cached
 	 * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
 	 *
 	 * @return  static|boolean   This object to support chaining or false on failure.
 	 *
 	 * @since   1.5
 	 */
-	public function display($cachable = false, $urlparams = false)
+	public function display($cacheable = false, $urlparams = false)
 	{
 		$view   = $this->input->get('view', 'plugins');
 		$layout = $this->input->get('layout', 'default');

--- a/administrator/components/com_plugins/src/Controller/DisplayController.php
+++ b/administrator/components/com_plugins/src/Controller/DisplayController.php
@@ -33,7 +33,7 @@ class DisplayController extends BaseController
 	/**
 	 * Method to display a view.
 	 *
-	 * @param   boolean  $cacheable   If true, the view output will be cached
+	 * @param   boolean  $cacheable  If true, the view output will be cached
 	 * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
 	 *
 	 * @return  static|boolean   This object to support chaining or false on failure.

--- a/administrator/components/com_privacy/src/Controller/DisplayController.php
+++ b/administrator/components/com_privacy/src/Controller/DisplayController.php
@@ -36,7 +36,7 @@ class DisplayController extends BaseController
 	/**
 	 * Method to display a view.
 	 *
-	 * @param   boolean  $cacheable   If true, the view output will be cached
+	 * @param   boolean  $cacheable  If true, the view output will be cached
 	 * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link JFilterInput::clean()}.
 	 *
 	 * @return  $this

--- a/administrator/components/com_privacy/src/Controller/DisplayController.php
+++ b/administrator/components/com_privacy/src/Controller/DisplayController.php
@@ -36,14 +36,14 @@ class DisplayController extends BaseController
 	/**
 	 * Method to display a view.
 	 *
-	 * @param   boolean  $cachable   If true, the view output will be cached
+	 * @param   boolean  $cacheable   If true, the view output will be cached
 	 * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link JFilterInput::clean()}.
 	 *
 	 * @return  $this
 	 *
 	 * @since   3.9.0
 	 */
-	public function display($cachable = false, $urlparams = [])
+	public function display($cacheable = false, $urlparams = [])
 	{
 		// Get the document object.
 		$document = $this->app->getDocument();

--- a/administrator/components/com_redirect/src/Controller/DisplayController.php
+++ b/administrator/components/com_redirect/src/Controller/DisplayController.php
@@ -34,14 +34,14 @@ class DisplayController extends BaseController
 	/**
 	 * Method to display a view.
 	 *
-	 * @param   boolean  $cachable   If true, the view output will be cached.
+	 * @param   boolean  $cacheable   If true, the view output will be cached.
 	 * @param   mixed    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
 	 *
 	 * @return  static|boolean	 This object to support chaining or false on failure.
 	 *
 	 * @since   1.5
 	 */
-	public function display($cachable = false, $urlparams = false)
+	public function display($cacheable = false, $urlparams = false)
 	{
 		$view   = $this->input->get('view', 'links');
 		$layout = $this->input->get('layout', 'default');

--- a/administrator/components/com_redirect/src/Controller/DisplayController.php
+++ b/administrator/components/com_redirect/src/Controller/DisplayController.php
@@ -34,7 +34,7 @@ class DisplayController extends BaseController
 	/**
 	 * Method to display a view.
 	 *
-	 * @param   boolean  $cacheable   If true, the view output will be cached.
+	 * @param   boolean  $cacheable  If true, the view output will be cached.
 	 * @param   mixed    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
 	 *
 	 * @return  static|boolean	 This object to support chaining or false on failure.

--- a/administrator/components/com_tags/src/Controller/DisplayController.php
+++ b/administrator/components/com_tags/src/Controller/DisplayController.php
@@ -33,14 +33,14 @@ class DisplayController extends BaseController
 	/**
 	 * Method to display a view.
 	 *
-	 * @param   boolean  $cachable   If true, the view output will be cached
+	 * @param   boolean  $cacheable   If true, the view output will be cached
 	 * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
 	 *
 	 * @return  static|boolean   This object to support chaining or false on failure.
 	 *
 	 * @since   3.1
 	 */
-	public function display($cachable = false, $urlparams = false)
+	public function display($cacheable = false, $urlparams = false)
 	{
 		$view   = $this->input->get('view', 'tags');
 		$layout = $this->input->get('layout', 'default');

--- a/administrator/components/com_tags/src/Controller/DisplayController.php
+++ b/administrator/components/com_tags/src/Controller/DisplayController.php
@@ -33,7 +33,7 @@ class DisplayController extends BaseController
 	/**
 	 * Method to display a view.
 	 *
-	 * @param   boolean  $cacheable   If true, the view output will be cached
+	 * @param   boolean  $cacheable  If true, the view output will be cached
 	 * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
 	 *
 	 * @return  static|boolean   This object to support chaining or false on failure.

--- a/administrator/components/com_templates/src/Controller/DisplayController.php
+++ b/administrator/components/com_templates/src/Controller/DisplayController.php
@@ -31,7 +31,7 @@ class DisplayController extends BaseController
 	/**
 	 * Method to display a view.
 	 *
-	 * @param   boolean  $cacheable   If true, the view output will be cached
+	 * @param   boolean  $cacheable  If true, the view output will be cached
 	 * @param   boolean  $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
 	 *
 	 * @return  static|boolean   This object to support chaining or false on failure.

--- a/administrator/components/com_templates/src/Controller/DisplayController.php
+++ b/administrator/components/com_templates/src/Controller/DisplayController.php
@@ -31,14 +31,14 @@ class DisplayController extends BaseController
 	/**
 	 * Method to display a view.
 	 *
-	 * @param   boolean  $cachable   If true, the view output will be cached
+	 * @param   boolean  $cacheable   If true, the view output will be cached
 	 * @param   boolean  $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
 	 *
 	 * @return  static|boolean   This object to support chaining or false on failure.
 	 *
 	 * @since   1.5
 	 */
-	public function display($cachable = false, $urlparams = false)
+	public function display($cacheable = false, $urlparams = false)
 	{
 		$view   = $this->input->get('view', 'styles');
 		$layout = $this->input->get('layout', 'default');

--- a/administrator/components/com_users/src/Controller/DisplayController.php
+++ b/administrator/components/com_users/src/Controller/DisplayController.php
@@ -64,7 +64,7 @@ class DisplayController extends BaseController
 	/**
 	 * Method to display a view.
 	 *
-	 * @param   boolean  $cacheable   If true, the view output will be cached
+	 * @param   boolean  $cacheable  If true, the view output will be cached
 	 * @param   array    $urlparams  An array of safe URL parameters and their variable types,
 	 *                               for valid values see {@link \Joomla\CMS\Filter\InputFilter::clean()}.
 	 *

--- a/administrator/components/com_users/src/Controller/DisplayController.php
+++ b/administrator/components/com_users/src/Controller/DisplayController.php
@@ -64,7 +64,7 @@ class DisplayController extends BaseController
 	/**
 	 * Method to display a view.
 	 *
-	 * @param   boolean  $cachable   If true, the view output will be cached
+	 * @param   boolean  $cacheable   If true, the view output will be cached
 	 * @param   array    $urlparams  An array of safe URL parameters and their variable types,
 	 *                               for valid values see {@link \Joomla\CMS\Filter\InputFilter::clean()}.
 	 *
@@ -72,7 +72,7 @@ class DisplayController extends BaseController
 	 *
 	 * @since   1.5
 	 */
-	public function display($cachable = false, $urlparams = array())
+	public function display($cacheable = false, $urlparams = array())
 	{
 		$view   = $this->input->get('view', 'users');
 		$layout = $this->input->get('layout', 'default');
@@ -117,6 +117,6 @@ class DisplayController extends BaseController
 			return false;
 		}
 
-		return parent::display($cachable, $urlparams);
+		return parent::display($cacheable, $urlparams);
 	}
 }

--- a/administrator/components/com_workflow/src/Controller/DisplayController.php
+++ b/administrator/components/com_workflow/src/Controller/DisplayController.php
@@ -89,7 +89,7 @@ class DisplayController extends BaseController
 	/**
 	 * Method to display a view.
 	 *
-	 * @param   boolean  $cacheable   If true, the view output will be cached
+	 * @param   boolean  $cacheable  If true, the view output will be cached
 	 * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link JFilterInput::clean()}.
 	 *
 	 * @return  BaseController|boolean  This object to support chaining.

--- a/administrator/components/com_workflow/src/Controller/DisplayController.php
+++ b/administrator/components/com_workflow/src/Controller/DisplayController.php
@@ -89,14 +89,14 @@ class DisplayController extends BaseController
 	/**
 	 * Method to display a view.
 	 *
-	 * @param   boolean  $cachable   If true, the view output will be cached
+	 * @param   boolean  $cacheable   If true, the view output will be cached
 	 * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link JFilterInput::clean()}.
 	 *
 	 * @return  BaseController|boolean  This object to support chaining.
 	 *
 	 * @since   1.5
 	 */
-	public function display($cachable = false, $urlparams = array())
+	public function display($cacheable = false, $urlparams = array())
 	{
 		$view   = $this->input->get('view');
 		$layout = $this->input->get('layout');

--- a/components/com_contact/src/Controller/DisplayController.php
+++ b/components/com_contact/src/Controller/DisplayController.php
@@ -50,7 +50,7 @@ class DisplayController extends BaseController
 	/**
 	 * Method to display a view.
 	 *
-	 * @param   boolean  $cacheable   If true, the view output will be cached
+	 * @param   boolean  $cacheable  If true, the view output will be cached
 	 * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
 	 *
 	 * @return  static  This object to support chaining.

--- a/components/com_contact/src/Controller/DisplayController.php
+++ b/components/com_contact/src/Controller/DisplayController.php
@@ -50,18 +50,18 @@ class DisplayController extends BaseController
 	/**
 	 * Method to display a view.
 	 *
-	 * @param   boolean  $cachable   If true, the view output will be cached
+	 * @param   boolean  $cacheable   If true, the view output will be cached
 	 * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
 	 *
 	 * @return  static  This object to support chaining.
 	 *
 	 * @since   1.5
 	 */
-	public function display($cachable = false, $urlparams = array())
+	public function display($cacheable = false, $urlparams = array())
 	{
 		if (Factory::getApplication()->getUserState('com_contact.contact.data') === null)
 		{
-			$cachable = true;
+			$cacheable = true;
 		}
 
 		// Set the default view name and format from the Request.
@@ -70,7 +70,7 @@ class DisplayController extends BaseController
 
 		if (Factory::getUser()->get('id'))
 		{
-			$cachable = false;
+			$cacheable = false;
 		}
 
 		$safeurlparams = array('catid' => 'INT', 'id' => 'INT', 'cid' => 'ARRAY', 'year' => 'INT', 'month' => 'INT',
@@ -78,7 +78,7 @@ class DisplayController extends BaseController
 			'filter_order' => 'CMD', 'filter_order_Dir' => 'CMD', 'filter-search' => 'STRING', 'print' => 'BOOLEAN',
 			'lang' => 'CMD');
 
-		parent::display($cachable, $safeurlparams);
+		parent::display($cacheable, $safeurlparams);
 
 		return $this;
 	}

--- a/components/com_content/src/Controller/DisplayController.php
+++ b/components/com_content/src/Controller/DisplayController.php
@@ -56,16 +56,16 @@ class DisplayController extends \Joomla\CMS\MVC\Controller\BaseController
 	/**
 	 * Method to display a view.
 	 *
-	 * @param   boolean  $cachable   If true, the view output will be cached.
+	 * @param   boolean  $cacheable   If true, the view output will be cached.
 	 * @param   boolean  $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link JFilterInput::clean()}.
 	 *
 	 * @return  \Joomla\CMS\MVC\Controller\BaseController  This object to support chaining.
 	 *
 	 * @since   1.5
 	 */
-	public function display($cachable = false, $urlparams = false)
+	public function display($cacheable = false, $urlparams = false)
 	{
-		$cachable = true;
+		$cacheable = true;
 
 		/**
 		 * Set the default view name and format from the Request.
@@ -82,7 +82,7 @@ class DisplayController extends \Joomla\CMS\MVC\Controller\BaseController
 			|| ($this->input->getMethod() === 'POST'
 			&& (($vName === 'category' && $this->input->get('layout') !== 'blog') || $vName === 'archive' )))
 		{
-			$cachable = false;
+			$cacheable = false;
 		}
 
 		$safeurlparams = array(
@@ -122,7 +122,7 @@ class DisplayController extends \Joomla\CMS\MVC\Controller\BaseController
 			}
 		}
 
-		parent::display($cachable, $safeurlparams);
+		parent::display($cacheable, $safeurlparams);
 
 		return $this;
 	}

--- a/components/com_content/src/Controller/DisplayController.php
+++ b/components/com_content/src/Controller/DisplayController.php
@@ -56,7 +56,7 @@ class DisplayController extends \Joomla\CMS\MVC\Controller\BaseController
 	/**
 	 * Method to display a view.
 	 *
-	 * @param   boolean  $cacheable   If true, the view output will be cached.
+	 * @param   boolean  $cacheable  If true, the view output will be cached.
 	 * @param   boolean  $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link JFilterInput::clean()}.
 	 *
 	 * @return  \Joomla\CMS\MVC\Controller\BaseController  This object to support chaining.

--- a/components/com_finder/src/Controller/DisplayController.php
+++ b/components/com_finder/src/Controller/DisplayController.php
@@ -25,7 +25,7 @@ class DisplayController extends BaseController
 	/**
 	 * Method to display a view.
 	 *
-	 * @param   boolean  $cachable   If true, the view output will be cached. [optional]
+	 * @param   boolean  $cacheable   If true, the view output will be cached. [optional]
 	 * @param   array    $urlparams  An array of safe URL parameters and their variable types,
 	 *                               for valid values see {@link \JFilterInput::clean()}. [optional]
 	 *
@@ -33,10 +33,10 @@ class DisplayController extends BaseController
 	 *
 	 * @since   2.5
 	 */
-	public function display($cachable = false, $urlparams = array())
+	public function display($cacheable = false, $urlparams = array())
 	{
 		$input = Factory::getApplication()->input;
-		$cachable = true;
+		$cacheable = true;
 
 		// Load plugin language files.
 		LanguageHelper::loadPluginLanguage();
@@ -48,7 +48,7 @@ class DisplayController extends BaseController
 		// Don't cache view for search queries
 		if ($input->get('q', null, 'string') || $input->get('f', null, 'int') || $input->get('t', null, 'array'))
 		{
-			$cachable = false;
+			$cacheable = false;
 		}
 
 		$safeurlparams = array(
@@ -56,6 +56,6 @@ class DisplayController extends BaseController
 			'lang' => 'CMD'
 		);
 
-		return parent::display($cachable, $safeurlparams);
+		return parent::display($cacheable, $safeurlparams);
 	}
 }

--- a/components/com_finder/src/Controller/DisplayController.php
+++ b/components/com_finder/src/Controller/DisplayController.php
@@ -25,7 +25,7 @@ class DisplayController extends BaseController
 	/**
 	 * Method to display a view.
 	 *
-	 * @param   boolean  $cacheable   If true, the view output will be cached. [optional]
+	 * @param   boolean  $cacheable  If true, the view output will be cached. [optional]
 	 * @param   array    $urlparams  An array of safe URL parameters and their variable types,
 	 *                               for valid values see {@link \JFilterInput::clean()}. [optional]
 	 *

--- a/components/com_newsfeeds/src/Controller/DisplayController.php
+++ b/components/com_newsfeeds/src/Controller/DisplayController.php
@@ -24,7 +24,7 @@ class DisplayController extends BaseController
 	/**
 	 * Method to show a newsfeeds view
 	 *
-	 * @param   boolean  $cacheable   If true, the view output will be cached
+	 * @param   boolean  $cacheable  If true, the view output will be cached
 	 * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
 	 *
 	 * @return  static  This object to support chaining.

--- a/components/com_newsfeeds/src/Controller/DisplayController.php
+++ b/components/com_newsfeeds/src/Controller/DisplayController.php
@@ -24,16 +24,16 @@ class DisplayController extends BaseController
 	/**
 	 * Method to show a newsfeeds view
 	 *
-	 * @param   boolean  $cachable   If true, the view output will be cached
+	 * @param   boolean  $cacheable   If true, the view output will be cached
 	 * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
 	 *
 	 * @return  static  This object to support chaining.
 	 *
 	 * @since   1.5
 	 */
-	public function display($cachable = false, $urlparams = false)
+	public function display($cacheable = false, $urlparams = false)
 	{
-		$cachable = true;
+		$cacheable = true;
 
 		// Set the default view name and format from the Request.
 		$vName = $this->input->get('view', 'categories');
@@ -41,12 +41,12 @@ class DisplayController extends BaseController
 
 		if (Factory::getUser()->get('id') || ($this->input->getMethod() === 'POST' && $vName === 'category' ))
 		{
-			$cachable = false;
+			$cacheable = false;
 		}
 
 		$safeurlparams = array('id' => 'INT', 'limit' => 'UINT', 'limitstart' => 'UINT',
 								'filter_order' => 'CMD', 'filter_order_Dir' => 'CMD', 'lang' => 'CMD');
 
-		return parent::display($cachable, $safeurlparams);
+		return parent::display($cacheable, $safeurlparams);
 	}
 }

--- a/components/com_privacy/src/Controller/DisplayController.php
+++ b/components/com_privacy/src/Controller/DisplayController.php
@@ -26,7 +26,7 @@ class DisplayController extends BaseController
 	 * Method to display a view.
 	 *
 	 * @param   boolean  $cacheable   If true, the view output will be cached
-	 * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link JFilterInput::clean()}.
+	 * @param   array    $urlparams   An array of safe URL parameters and their variable types, for valid values see {@link JFilterInput::clean()}.
 	 *
 	 * @return  $this
 	 *

--- a/components/com_privacy/src/Controller/DisplayController.php
+++ b/components/com_privacy/src/Controller/DisplayController.php
@@ -25,14 +25,14 @@ class DisplayController extends BaseController
 	/**
 	 * Method to display a view.
 	 *
-	 * @param   boolean  $cachable   If true, the view output will be cached
+	 * @param   boolean  $cacheable   If true, the view output will be cached
 	 * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link JFilterInput::clean()}.
 	 *
 	 * @return  $this
 	 *
 	 * @since   3.9.0
 	 */
-	public function display($cachable = false, $urlparams = [])
+	public function display($cacheable = false, $urlparams = [])
 	{
 		$view = $this->input->get('view', $this->default_view);
 
@@ -52,6 +52,6 @@ class DisplayController extends BaseController
 			Factory::getApplication()->setHeader('Referrer-Policy', 'no-referrer', true);
 		}
 
-		return parent::display($cachable, $urlparams);
+		return parent::display($cacheable, $urlparams);
 	}
 }

--- a/components/com_tags/src/Controller/DisplayController.php
+++ b/components/com_tags/src/Controller/DisplayController.php
@@ -24,7 +24,7 @@ class DisplayController extends BaseController
 	/**
 	 * Method to display a view.
 	 *
-	 * @param   boolean        $cachable   If true, the view output will be cached
+	 * @param   boolean        $cacheable   If true, the view output will be cached
 	 * @param   mixed|boolean  $urlparams  An array of safe URL parameters and their
 	 *                                     variable types, for valid values see {@link \JFilterInput::clean()}.
 	 *
@@ -32,7 +32,7 @@ class DisplayController extends BaseController
 	 *
 	 * @since   3.1
 	 */
-	public function display($cachable = false, $urlparams = false)
+	public function display($cacheable = false, $urlparams = false)
 	{
 		$user = Factory::getUser();
 
@@ -42,7 +42,7 @@ class DisplayController extends BaseController
 
 		if ($user->get('id') || ($this->input->getMethod() === 'POST' && $vName === 'tags'))
 		{
-			$cachable = false;
+			$cacheable = false;
 		}
 
 		$safeurlparams = array(
@@ -55,6 +55,6 @@ class DisplayController extends BaseController
 			'lang'             => 'CMD'
 		);
 
-		return parent::display($cachable, $safeurlparams);
+		return parent::display($cacheable, $safeurlparams);
 	}
 }

--- a/components/com_tags/src/Controller/DisplayController.php
+++ b/components/com_tags/src/Controller/DisplayController.php
@@ -24,7 +24,7 @@ class DisplayController extends BaseController
 	/**
 	 * Method to display a view.
 	 *
-	 * @param   boolean        $cacheable   If true, the view output will be cached
+	 * @param   boolean        $cacheable  If true, the view output will be cached
 	 * @param   mixed|boolean  $urlparams  An array of safe URL parameters and their
 	 *                                     variable types, for valid values see {@link \JFilterInput::clean()}.
 	 *

--- a/components/com_users/src/Controller/DisplayController.php
+++ b/components/com_users/src/Controller/DisplayController.php
@@ -26,7 +26,7 @@ class DisplayController extends BaseController
 	/**
 	 * Method to display a view.
 	 *
-	 * @param   boolean        $cachable   If true, the view output will be cached
+	 * @param   boolean        $cacheable   If true, the view output will be cached
 	 * @param   array|boolean  $urlparams  An array of safe URL parameters and their variable types,
 	 *                                     for valid values see {@link Joomla\CMS\Filter\InputFilter::clean()}.
 	 *
@@ -35,7 +35,7 @@ class DisplayController extends BaseController
 	 * @since   1.5
 	 * @throws  \Exception
 	 */
-	public function display($cachable = false, $urlparams = false)
+	public function display($cacheable = false, $urlparams = false)
 	{
 		// Get the document object.
 		$document = $this->app->getDocument();

--- a/components/com_users/src/Controller/DisplayController.php
+++ b/components/com_users/src/Controller/DisplayController.php
@@ -26,7 +26,7 @@ class DisplayController extends BaseController
 	/**
 	 * Method to display a view.
 	 *
-	 * @param   boolean        $cacheable   If true, the view output will be cached
+	 * @param   boolean        $cacheable  If true, the view output will be cached
 	 * @param   array|boolean  $urlparams  An array of safe URL parameters and their variable types,
 	 *                                     for valid values see {@link Joomla\CMS\Filter\InputFilter::clean()}.
 	 *

--- a/components/com_wrapper/src/Controller/DisplayController.php
+++ b/components/com_wrapper/src/Controller/DisplayController.php
@@ -23,21 +23,21 @@ class DisplayController extends BaseController
 	/**
 	 * Method to display a view.
 	 *
-	 * @param   boolean  $cachable   If true, the view output will be cached
+	 * @param   boolean  $cacheable   If true, the view output will be cached
 	 * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link JFilterInput::clean()}.
 	 *
 	 * @return  Controller  This object to support chaining.
 	 *
 	 * @since   1.5
 	 */
-	public function display($cachable = false, $urlparams = array())
+	public function display($cacheable = false, $urlparams = array())
 	{
-		$cachable = true;
+		$cacheable = true;
 
 		// Set the default view name and format from the Request.
 		$vName = $this->input->get('view', 'wrapper');
 		$this->input->set('view', $vName);
 
-		return parent::display($cachable, array('Itemid' => 'INT'));
+		return parent::display($cacheable, array('Itemid' => 'INT'));
 	}
 }

--- a/components/com_wrapper/src/Controller/DisplayController.php
+++ b/components/com_wrapper/src/Controller/DisplayController.php
@@ -24,7 +24,7 @@ class DisplayController extends BaseController
 	 * Method to display a view.
 	 *
 	 * @param   boolean  $cacheable   If true, the view output will be cached
-	 * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link JFilterInput::clean()}.
+	 * @param   array    $urlparams   An array of safe URL parameters and their variable types, for valid values see {@link JFilterInput::clean()}.
 	 *
 	 * @return  Controller  This object to support chaining.
 	 *

--- a/installation/src/Controller/DisplayController.php
+++ b/installation/src/Controller/DisplayController.php
@@ -24,14 +24,14 @@ class DisplayController extends BaseController
 	/**
 	 * Method to display a view.
 	 *
-	 * @param   boolean  $cachable   If true, the view output will be cached.
+	 * @param   boolean  $cacheable   If true, the view output will be cached.
 	 * @param   boolean  $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link JFilterInput::clean()}.
 	 *
 	 * @return  \Joomla\CMS\MVC\Controller\BaseController  This object to support chaining.
 	 *
 	 * @since   1.5
 	 */
-	public function display($cachable = false, $urlparams = false)
+	public function display($cacheable = false, $urlparams = false)
 	{
 		$app = $this->app;
 
@@ -79,7 +79,7 @@ class DisplayController extends BaseController
 
 		$this->input->set('view', $vName);
 
-		return parent::display($cachable, $urlparams);
+		return parent::display($cacheable, $urlparams);
 	}
 
 	/**

--- a/installation/src/Controller/DisplayController.php
+++ b/installation/src/Controller/DisplayController.php
@@ -25,7 +25,7 @@ class DisplayController extends BaseController
 	 * Method to display a view.
 	 *
 	 * @param   boolean  $cacheable   If true, the view output will be cached.
-	 * @param   boolean  $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link JFilterInput::clean()}.
+	 * @param   boolean  $urlparams   An array of safe URL parameters and their variable types, for valid values see {@link JFilterInput::clean()}.
 	 *
 	 * @return  \Joomla\CMS\MVC\Controller\BaseController  This object to support chaining.
 	 *

--- a/libraries/src/MVC/Controller/BaseController.php
+++ b/libraries/src/MVC/Controller/BaseController.php
@@ -622,7 +622,7 @@ class BaseController implements ControllerInterface
 	 * This function is provide as a default implementation, in most cases
 	 * you will need to override it in your own controllers.
 	 *
-	 * @param   boolean  $cacheable   If true, the view output will be cached
+	 * @param   boolean  $cacheable  If true, the view output will be cached
 	 * @param   array    $urlparams  An array of safe url parameters and their variable types, for valid values see {@link InputFilter::clean()}.
 	 *
 	 * @return  static  A \JControllerLegacy object to support chaining.

--- a/libraries/src/MVC/Controller/BaseController.php
+++ b/libraries/src/MVC/Controller/BaseController.php
@@ -622,7 +622,7 @@ class BaseController implements ControllerInterface
 	 * This function is provide as a default implementation, in most cases
 	 * you will need to override it in your own controllers.
 	 *
-	 * @param   boolean  $cachable   If true, the view output will be cached
+	 * @param   boolean  $cacheable   If true, the view output will be cached
 	 * @param   array    $urlparams  An array of safe url parameters and their variable types, for valid values see {@link InputFilter::clean()}.
 	 *
 	 * @return  static  A \JControllerLegacy object to support chaining.
@@ -630,7 +630,7 @@ class BaseController implements ControllerInterface
 	 * @since   3.0
 	 * @throws  \Exception
 	 */
-	public function display($cachable = false, $urlparams = array())
+	public function display($cacheable = false, $urlparams = array())
 	{
 		$document = $this->app->getDocument();
 		$viewType = $document->getType();
@@ -649,7 +649,7 @@ class BaseController implements ControllerInterface
 		$view->document = $document;
 
 		// Display the view
-		if ($cachable && $viewType !== 'feed' && Factory::getApplication()->get('caching') >= 1)
+		if ($cacheable && $viewType !== 'feed' && Factory::getApplication()->get('caching') >= 1)
 		{
 			$option = $this->input->get('option');
 

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -478,7 +478,7 @@ class PlgSystemLanguageFilter extends CMSPlugin
 			{
 				$redirectHttpCode = 301;
 
-				// We cannot cache this redirect in browser. 301 is cachable by default so we need to force to not cache it in browsers.
+				// We cannot cache this redirect in browser. 301 is cacheable by default so we need to force to not cache it in browsers.
 				$this->app->setHeader('Expires', 'Wed, 17 Aug 2005 00:00:00 GMT', true);
 				$this->app->setHeader('Last-Modified', gmdate('D, d M Y H:i:s') . ' GMT', true);
 				$this->app->setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, post-check=0, pre-check=0', false);

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -478,7 +478,7 @@ class PlgSystemLanguageFilter extends CMSPlugin
 			{
 				$redirectHttpCode = 301;
 
-				// We cannot cache this redirect in browser. 301 is cacheable by default so we need to force to not cache it in browsers.
+				// We cannot cache this redirect in browser. 301 is cachable by default so we need to force to not cache it in browsers.
 				$this->app->setHeader('Expires', 'Wed, 17 Aug 2005 00:00:00 GMT', true);
 				$this->app->setHeader('Last-Modified', gmdate('D, d M Y H:i:s') . ' GMT', true);
 				$this->app->setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, post-check=0, pre-check=0', false);


### PR DESCRIPTION

### Summary of Changes

Proposing the fixing of the long term typo of `cachable` to be fixed in the new major series of Joomla 4 

It shouldn't be a b/c break as its just a variable name but @HLeithner [says](https://github.com/joomla/joomla-cms/pull/29808#pullrequestreview-438802017)

> Only thing to consider is that this method is abstracted by 3rd party developer and we should check this before we make a b/c break. I don't know if we have property/option arrays with cachable in the code base.


### Testing Instructions

TEST EVERYTHING ;-) 

### Actual result BEFORE applying this Pull Request

EVERYTHING Works

### Expected result AFTER applying this Pull Request

EVERYTHING Works

### Documentation Changes Required

Maybe a note in the https://docs.joomla.org/Potential_backward_compatibility_issues_in_Joomla_4 ?