### PR TITLE
[4.0][CLI] s/remove/removed

### DIFF
--- a/libraries/src/Console/RemoveUserFromGroupCommand.php
+++ b/libraries/src/Console/RemoveUserFromGroupCommand.php
@@ -152,7 +152,7 @@ class RemoveUserFromGroupCommand extends AbstractCommand
 				return 1;
 			}
 
-			$this->ioStyle->success("Remove '" . $user->username . "' from group '" . $result . "'!");
+			$this->ioStyle->success("Removed '" . $user->username . "' from group '" . $result . "'!");
 		}
 
 		return 0;


### PR DESCRIPTION
### Summary of Changes

When removing a user from a group using CLI you get the text below

All this PR does is correct the the English to say the user has been removed from the group

<img width="399" alt="Screenshot 2020-06-28 at 20 23 42" src="https://user-images.githubusercontent.com/400092/85956361-45b8a200-b97d-11ea-823d-e036372c37c8.png">


### Testing Instructions

`php cli/joomla.php  user:removefromgroup -vvv`

### Actual result BEFORE applying this Pull Request

[OK] Remove 'mike' from group 'Manager'!

### Expected result AFTER applying this Pull Request

[OK] Removed 'mike' from group 'Manager'!


<img width="340" alt="Screenshot 2020-06-28 at 20 25 00" src="https://user-images.githubusercontent.com/400092/85956383-7698d700-b97d-11ea-9fb4-6f2a316cd0d2.png">


