### PR TITLE
[4.0] Standardise indents of instructions in .htaccess

### DIFF
--- a/htaccess.txt
+++ b/htaccess.txt
@@ -22,20 +22,20 @@ Options -Indexes
 
 ## No directory listings
 <IfModule autoindex>
-  IndexIgnore *
+	IndexIgnore *
 </IfModule>
 
 ## Suppress mime type detection in browsers for unknown types
 <IfModule mod_headers.c>
-Header always set X-Content-Type-Options "nosniff"
+	Header always set X-Content-Type-Options "nosniff"
 </IfModule>
 
 ## Protect against certain cross-origin requests. More information can be found here:
 ## https://developer.mozilla.org/en-US/docs/Web/HTTP/Cross-Origin_Resource_Policy_(CORP)
 ## https://web.dev/why-coop-coep/
 #<IfModule mod_headers.c>
-#Header always set Cross-Origin-Resource-Policy "same-origin"
-#Header always set Cross-Origin-Embedder-Policy "require-corp"
+#   Header always set Cross-Origin-Resource-Policy "same-origin"
+#   Header always set Cross-Origin-Embedder-Policy "require-corp"
 #</IfModule>
 
 ## These directives are only enabled if the Apache mod_rewrite module is enabled
@@ -77,75 +77,72 @@ Header always set X-Content-Type-Options "nosniff"
 	# RewriteBase /
 
 	## Begin - Joomla! core SEF Section.
-    #
-    # PHP FastCGI fix for HTTP Authorization, required for the API application
-    RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
-    # -- SEF URLs for the API application
-    # If the requested path starts with /api, the file is not /api/index.php
-    # and the request has not already been internally rewritten to the
-    # api/index.php script
-    RewriteCond %{REQUEST_URI} ^/api/
-    RewriteCond %{REQUEST_URI} !^/api/index\.php
-    # and the requested path and file doesn't directly match a physical file
-    RewriteCond %{REQUEST_FILENAME} !-f
-    # and the requested path and file doesn't directly match a physical folder
-    RewriteCond %{REQUEST_FILENAME} !-d
-    # internally rewrite the request to the /api/index.php script
-    RewriteRule .* api/index.php [L]
-    # -- SEF URLs for the public frontend application
-    # If the requested path and file is not /index.php and the request
-    # has not already been internally rewritten to the index.php script
-    RewriteCond %{REQUEST_URI} !^/index\.php
-    # and the requested path and file doesn't directly match a physical file
-    RewriteCond %{REQUEST_FILENAME} !-f
-    # and the requested path and file doesn't directly match a physical folder
-    RewriteCond %{REQUEST_FILENAME} !-d
-    # internally rewrite the request to the index.php script
-    RewriteRule .* index.php [L]
-    #
-    ## End - Joomla! core SEF Section.
-
+	#
+	# PHP FastCGI fix for HTTP Authorization, required for the API application
+	RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+	# -- SEF URLs for the API application
+	# If the requested path starts with /api, the file is not /api/index.php
+	# and the request has not already been internally rewritten to the
+	# api/index.php script
+	RewriteCond %{REQUEST_URI} ^/api/
+	RewriteCond %{REQUEST_URI} !^/api/index\.php
+	# and the requested path and file doesn't directly match a physical file
+	RewriteCond %{REQUEST_FILENAME} !-f
+	# and the requested path and file doesn't directly match a physical folder
+	RewriteCond %{REQUEST_FILENAME} !-d
+	# internally rewrite the request to the /api/index.php script
+	RewriteRule .* api/index.php [L]
+	# -- SEF URLs for the public frontend application
+	# If the requested path and file is not /index.php and the request
+	# has not already been internally rewritten to the index.php script
+	RewriteCond %{REQUEST_URI} !^/index\.php
+	# and the requested path and file doesn't directly match a physical file
+	RewriteCond %{REQUEST_FILENAME} !-f
+	# and the requested path and file doesn't directly match a physical folder
+	RewriteCond %{REQUEST_FILENAME} !-d
+	# internally rewrite the request to the index.php script
+	RewriteRule .* index.php [L]
+	#
+	## End - Joomla! core SEF Section.
 </IfModule>
 
 ## These directives are only enabled if the Apache mod_rewrite module is disabled
 <IfModule !mod_rewrite.c>
-    <IfModule mod_alias.c>
-        # When Apache mod_rewrite is not available, we instruct a temporary redirect
-        # of the start page to the front controller explicitly so that the website
-        # and the generated links can still be used.
-        RedirectMatch 302 ^/$ /index.php/
-        # RedirectTemp cannot be used instead
-    </IfModule>
+	<IfModule mod_alias.c>
+		# When Apache mod_rewrite is not available, we instruct a temporary redirect
+		# of the start page to the front controller explicitly so that the website
+		# and the generated links can still be used.
+		RedirectMatch 302 ^/$ /index.php/
+		# RedirectTemp cannot be used instead
+	</IfModule>
 </IfModule>
 
 ## These directives are only enabled if the Apache mod_headers module is enabled.
 ## This section will check if a .gz file exists and if so will stream it
 ##     directly or fallback to gzip any asset on the fly
 <IfModule mod_headers.c>
-    # Serve gzip compressed CSS files if they exist
-    # and the client accepts gzip.
-    RewriteCond "%{HTTP:Accept-encoding}" "gzip"
-    RewriteCond "%{REQUEST_FILENAME}\.gz" -s
-    RewriteRule "^(.*)\.css" "$1\.css\.gz" [QSA]
+	# Serve gzip compressed CSS files if they exist
+	# and the client accepts gzip.
+	RewriteCond "%{HTTP:Accept-encoding}" "gzip"
+	RewriteCond "%{REQUEST_FILENAME}\.gz" -s
+	RewriteRule "^(.*)\.css" "$1\.css\.gz" [QSA]
 
-    # Serve gzip compressed JS files if they exist
-    # and the client accepts gzip.
-    RewriteCond "%{HTTP:Accept-encoding}" "gzip"
-    RewriteCond "%{REQUEST_FILENAME}\.gz" -s
-    RewriteRule "^(.*)\.js" "$1\.js\.gz" [QSA]
+	# Serve gzip compressed JS files if they exist
+	# and the client accepts gzip.
+	RewriteCond "%{HTTP:Accept-encoding}" "gzip"
+	RewriteCond "%{REQUEST_FILENAME}\.gz" -s
+	RewriteRule "^(.*)\.js" "$1\.js\.gz" [QSA]
 
+	# Serve correct content types, and prevent mod_deflate double gzip.
+	RewriteRule "\.css\.gz$" "-" [T=text/css,E=no-gzip:1]
+	RewriteRule "\.js\.gz$" "-" [T=text/javascript,E=no-gzip:1]
 
-    # Serve correct content types, and prevent mod_deflate double gzip.
-    RewriteRule "\.css\.gz$" "-" [T=text/css,E=no-gzip:1]
-    RewriteRule "\.js\.gz$" "-" [T=text/javascript,E=no-gzip:1]
+	<FilesMatch "(\.js\.gz|\.css\.gz)$">
+		# Serve correct encoding type.
+		Header append Content-Encoding gzip
 
-
-    <FilesMatch "(\.js\.gz|\.css\.gz)$">
-      # Serve correct encoding type.
-      Header append Content-Encoding gzip
-
-      # Force proxies to cache gzipped &
-      # non-gzipped css/js files separately.
-      Header append Vary Accept-Encoding
-    </FilesMatch>
+		# Force proxies to cache gzipped &
+		# non-gzipped css/js files separately.
+		Header append Vary Accept-Encoding
+	</FilesMatch>
 </IfModule>

--- a/htaccess.txt
+++ b/htaccess.txt
@@ -34,8 +34,8 @@ Options -Indexes
 ## https://developer.mozilla.org/en-US/docs/Web/HTTP/Cross-Origin_Resource_Policy_(CORP)
 ## https://web.dev/why-coop-coep/
 #<IfModule mod_headers.c>
-#   Header always set Cross-Origin-Resource-Policy "same-origin"
-#   Header always set Cross-Origin-Embedder-Policy "require-corp"
+#	Header always set Cross-Origin-Resource-Policy "same-origin"
+#	Header always set Cross-Origin-Embedder-Policy "require-corp"
 #</IfModule>
 
 ## These directives are only enabled if the Apache mod_rewrite module is enabled


### PR DESCRIPTION
### Summary of Changes

Standardise all indents correctly - no functionality changes at all.

### Testing Instructions

Nothing to test

### Actual result BEFORE applying this Pull Request

Some instructions within modules were not indented, some were, some with space, some with tab

### Expected result AFTER applying this Pull Request

nicely laid out file 

### Documentation Changes Required

None