### PR TITLE
[4.0][CLI] add confirmation step before delete user

### DIFF
--- a/libraries/src/Console/DeleteUserCommand.php
+++ b/libraries/src/Console/DeleteUserCommand.php
@@ -86,7 +86,7 @@ class DeleteUserCommand extends AbstractCommand
 			return 1;
 		}
 
-		if ((!$this->ioStyle->confirm('Are you sure you want to delete this user?', false)) && $input->isInteractive())
+		if ($input->isInteractive() && (!$this->ioStyle->confirm('Are you sure you want to delete this user?', false)))
 		{
 			$this->ioStyle->note('User not deleted');
 

--- a/libraries/src/Console/DeleteUserCommand.php
+++ b/libraries/src/Console/DeleteUserCommand.php
@@ -86,7 +86,7 @@ class DeleteUserCommand extends AbstractCommand
 			return 1;
 		}
 
-		if ($input->isInteractive() && (!$this->ioStyle->confirm('Are you sure you want to delete this user?', false)))
+		if ($input->isInteractive() && !$this->ioStyle->confirm('Are you sure you want to delete this user?', false))
 		{
 			$this->ioStyle->note('User not deleted');
 

--- a/libraries/src/Console/DeleteUserCommand.php
+++ b/libraries/src/Console/DeleteUserCommand.php
@@ -86,9 +86,7 @@ class DeleteUserCommand extends AbstractCommand
 			return 1;
 		}
 
-		$response = $this->ioStyle->ask('Are you sure you want to delete this user?', 'yes/no');
-
-		if (strtolower($response) === 'no')
+		if (!$this->ioStyle->confirm('Are you sure you want to delete this user?', false))
 		{
 			$this->ioStyle->note('User not deleted');
 

--- a/libraries/src/Console/DeleteUserCommand.php
+++ b/libraries/src/Console/DeleteUserCommand.php
@@ -86,7 +86,7 @@ class DeleteUserCommand extends AbstractCommand
 			return 1;
 		}
 
-		if (!$this->ioStyle->confirm('Are you sure you want to delete this user?', false))
+		if ((!$this->ioStyle->confirm('Are you sure you want to delete this user?', false)) && $input->isInteractive())
 		{
 			$this->ioStyle->note('User not deleted');
 

--- a/libraries/src/Console/DeleteUserCommand.php
+++ b/libraries/src/Console/DeleteUserCommand.php
@@ -86,6 +86,15 @@ class DeleteUserCommand extends AbstractCommand
 			return 1;
 		}
 
+		$response = $this->ioStyle->ask('Are you sure you want to delete this user?', 'yes/no');
+
+		if (strtolower($response) === 'no')
+		{
+			$this->ioStyle->note('User not deleted');
+
+			return 0;
+		}
+
 		$groups = UserHelper::getUserGroups($userId);
 		$user = User::getInstance($userId);
 


### PR DESCRIPTION
Pull Request for Issue #29819 .

### Summary of Changes
added confirmation step before delete a user


### Testing Instructions
`php cli/joomla.php user:delete`


### Actual result BEFORE applying this Pull Request

User deleted without confirmation

### Expected result AFTER applying this Pull Request
a confirmation is required


### Documentation Changes Required
? probably yes
