### PR TITLE
[4.0] Fix "Exit Recovery Mode" link

### DIFF
--- a/administrator/modules/mod_menu/src/Menu/CssMenu.php
+++ b/administrator/modules/mod_menu/src/Menu/CssMenu.php
@@ -142,7 +142,7 @@ class CssMenu
 				$uri = clone Uri::getInstance();
 				$uri->setVar('recover_menu', 0);
 
-				$this->root->addChild(new AdministratorMenuItem(['title' => 'MOD_MENU_RECOVERY_EXIT', 'type' => 'url', 'url' => $uri->toString()]));
+				$this->root->addChild(new AdministratorMenuItem(['title' => 'MOD_MENU_RECOVERY_EXIT', 'type' => 'url', 'link' => $uri->toString()]));
 
 				return $this->root;
 			}


### PR DESCRIPTION
Fixes https://github.com/joomla/joomla-cms/issues/29829.

### Summary of Changes

Makes "Exit Recovery Mode" link clickable.

### Testing Instructions

> Menus -> Manager -> Select Administrator -> Click New =>
> Title = MyBrokenMenu
> Unique Name = MyBrokenMenu
> Import a preset = none
> Click Save and close
> Click "Add a module for this menu"
> Select MyBrokenMenu under Administrator in the left menu
> Title = MyBrokenMenuModule
> Menu to show = MyBrokenMenu
> CheckMenu = yes
> Position = Menu [menu]
> Click save & close
> 
> Enable Menu Recovery Mode

### Actual result BEFORE applying this Pull Request

>No href on the a tag for Exit Recovery mode and is unclickable.

### Expected result AFTER applying this Pull Request

> Exit Recovery mode is a hyperlink that is clickable in the menu

### Documentation Changes Required

No.