### PR TITLE
[4] [cassiopeia] Remove unused $lang variable

### DIFF
--- a/templates/cassiopeia/error.php
+++ b/templates/cassiopeia/error.php
@@ -16,7 +16,6 @@ use Joomla\CMS\Uri\Uri;
 /** @var JDocumentError $this */
 
 $app  = Factory::getApplication();
-$lang = Factory::getLanguage();
 $wa   = $this->getWebAssetManager();
 
 // Detecting Active Variables


### PR DESCRIPTION
Fixes https://github.com/joomla/joomla-cms/issues/29837

### Changes
- Remove unused variable $lang.

### Testing Instructions
- Create an 404 error in frontend and see that nothing changes after applying patch.
- Code review should be suffient.
