### PR TITLE
[4.0] Move from Factory::getConfig to getting config from application 

### DIFF
--- a/administrator/components/com_config/src/Model/ApplicationModel.php
+++ b/administrator/components/com_config/src/Model/ApplicationModel.php
@@ -714,7 +714,7 @@ class ApplicationModel extends FormModel
 		$config = new Registry($data);
 
 		// Overwrite the old FTP credentials with the new ones.
-		$temp = Factory::getConfig();
+		$temp = Factory::getApplication()->getConfig();
 		$temp->set('ftp_enable', $data['ftp_enable']);
 		$temp->set('ftp_host', $data['ftp_host']);
 		$temp->set('ftp_port', $data['ftp_port']);

--- a/administrator/components/com_finder/src/Table/MapTable.php
+++ b/administrator/components/com_finder/src/Table/MapTable.php
@@ -36,7 +36,7 @@ class MapTable extends Nested
 		parent::__construct('#__finder_taxonomy', 'id', $db);
 
 		$this->setColumnAlias('published', 'state');
-		$this->access = (int) Factory::getConfig()->get('access');
+		$this->access = (int) Factory::getApplication()->getConfig()->get('access');
 	}
 
 	/**

--- a/administrator/components/com_menus/src/Helper/MenusHelper.php
+++ b/administrator/components/com_menus/src/Helper/MenusHelper.php
@@ -498,9 +498,9 @@ class MenusHelper extends ContentHelper
 			$item->alias = $menutype . '-' . $item->title;
 
 			// Temporarily set unicodeslugs if a menu item has an unicode alias
-			$unicode     = Factory::getConfig()->set('unicodeslugs', 1);
+			$unicode     = Factory::getApplication()->getConfig()->set('unicodeslugs', 1);
 			$item->alias = ApplicationHelper::stringURLSafe($item->alias);
-			Factory::getConfig()->set('unicodeslugs', $unicode);
+			Factory::getApplication()->getConfig()->set('unicodeslugs', $unicode);
 
 			if ($item->type == 'separator')
 			{

--- a/administrator/components/com_privacy/src/Model/RequestModel.php
+++ b/administrator/components/com_privacy/src/Model/RequestModel.php
@@ -391,7 +391,7 @@ class RequestModel extends AdminModel
 		$key   = $table->getKeyName();
 		$pk    = !empty($data[$key]) ? $data[$key] : (int) $this->getState($this->getName() . '.id');
 
-		if (!$pk && !Factory::getConfig()->get('mailonline', 1))
+		if (!$pk && !Factory::getApplication()->getConfig()->get('mailonline', 1))
 		{
 			$this->setError(Text::_('COM_PRIVACY_ERROR_CANNOT_CREATE_REQUEST_WHEN_SENDMAIL_DISABLED'));
 

--- a/administrator/components/com_privacy/src/View/Request/HtmlView.php
+++ b/administrator/components/com_privacy/src/View/Request/HtmlView.php
@@ -157,7 +157,7 @@ class HtmlView extends BaseHtmlView
 							'download'
 						);
 
-						if (Factory::getConfig()->get('mailonline', 1))
+						if (Factory::getApplication()->getConfig()->get('mailonline', 1))
 						{
 							ToolbarHelper::link(
 								Route::_('index.php?option=com_privacy&task=request.emailexport&id=' . (int) $this->item->id . $return),

--- a/administrator/components/com_privacy/src/View/Requests/HtmlView.php
+++ b/administrator/components/com_privacy/src/View/Requests/HtmlView.php
@@ -108,7 +108,7 @@ class HtmlView extends BaseHtmlView
 		$this->filterForm       = $model->getFilterForm();
 		$this->activeFilters    = $model->getActiveFilters();
 		$this->urgentRequestAge = (int) ComponentHelper::getParams('com_privacy')->get('notify', 14);
-		$this->sendMailEnabled  = (bool) Factory::getConfig()->get('mailonline', 1);
+		$this->sendMailEnabled  = (bool) Factory::getApplication()->getConfig()->get('mailonline', 1);
 
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
@@ -133,7 +133,7 @@ class HtmlView extends BaseHtmlView
 		ToolbarHelper::title(Text::_('COM_PRIVACY_VIEW_REQUESTS'), 'lock');
 
 		// Requests can only be created if mail sending is enabled
-		if (Factory::getConfig()->get('mailonline', 1))
+		if (Factory::getApplication()->getConfig()->get('mailonline', 1))
 		{
 			ToolbarHelper::addNew('request.add');
 		}

--- a/cli/finder_indexer.php
+++ b/cli/finder_indexer.php
@@ -214,7 +214,7 @@ class FinderCli extends \Joomla\CMS\Application\CliApplication
 		JLoader::register('FinderIndexer', JPATH_ADMINISTRATOR . '/components/com_finder/helpers/indexer/indexer.php');
 
 		// Disable caching.
-		$config = Factory::getConfig();
+		$config = Factory::getApplication()->getConfig();
 		$config->set('caching', 0);
 		$config->set('cache_handler', 'file');
 

--- a/components/com_privacy/src/Model/RequestModel.php
+++ b/components/com_privacy/src/Model/RequestModel.php
@@ -47,7 +47,7 @@ class RequestModel extends AdminModel
 	public function createRequest($data)
 	{
 		// Creating requests requires the site's email sending be enabled
-		if (!Factory::getConfig()->get('mailonline', 1))
+		if (!Factory::getApplication()->getConfig()->get('mailonline', 1))
 		{
 			$this->setError(Text::_('COM_PRIVACY_ERROR_CANNOT_CREATE_REQUEST_WHEN_SENDMAIL_DISABLED'));
 

--- a/components/com_privacy/src/View/Request/HtmlView.php
+++ b/components/com_privacy/src/View/Request/HtmlView.php
@@ -82,7 +82,7 @@ class HtmlView extends BaseHtmlView
 		$this->form            = $this->get('Form');
 		$this->state           = $this->get('State');
 		$this->params          = $this->state->params;
-		$this->sendMailEnabled = (bool) Factory::getConfig()->get('mailonline', 1);
+		$this->sendMailEnabled = (bool) Factory::getApplication()->getConfig()->get('mailonline', 1);
 
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))

--- a/installation/src/Model/LanguagesModel.php
+++ b/installation/src/Model/LanguagesModel.php
@@ -204,7 +204,7 @@ class LanguagesModel extends BaseInstallationModel
 			// Cleanup the install files in tmp folder.
 			if (!is_file($package['packagefile']))
 			{
-				$config                 = Factory::getConfig();
+				$config                 = Factory::getApplication()->getConfig();
 				$package['packagefile'] = $config->get('tmp_path') . '/' . $package['packagefile'];
 			}
 
@@ -282,7 +282,7 @@ class LanguagesModel extends BaseInstallationModel
 			return false;
 		}
 
-		$config   = Factory::getConfig();
+		$config   = Factory::getApplication()->getConfig();
 		$tmp_dest = $config->get('tmp_path');
 
 		// Unpack the downloaded package file.

--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -545,7 +545,7 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
 			$name = $app->getName();
 		}
 
-		$options['mode'] = Factory::getConfig()->get('sef');
+		$options['mode'] = Factory::getApplication()->getConfig()->get('sef');
 
 		return Router::getInstance($name, $options);
 	}

--- a/libraries/src/Form/Field/CalendarField.php
+++ b/libraries/src/Form/Field/CalendarField.php
@@ -356,7 +356,7 @@ class CalendarField extends FormField
 				if ((int) $value > 0)
 				{
 					// Get the server timezone setting.
-					$offset = Factory::getConfig()->get('offset');
+					$offset = Factory::getApplication()->getConfig()->get('offset');
 
 					// Return an SQL formatted datetime string in UTC.
 					$return = Factory::getDate($value, $offset)->toSql();
@@ -372,7 +372,7 @@ class CalendarField extends FormField
 				if ((int) $value > 0)
 				{
 					// Get the user timezone setting defaulting to the server timezone setting.
-					$offset = Factory::getUser()->getParam('timezone', Factory::getConfig()->get('offset'));
+					$offset = Factory::getUser()->getParam('timezone', Factory::getApplication()->getConfig()->get('offset'));
 
 					// Return an SQL formatted datetime string in UTC.
 					$return = Factory::getDate($value, $offset)->toSql();

--- a/libraries/src/Log/Logger/FormattedtextLogger.php
+++ b/libraries/src/Log/Logger/FormattedtextLogger.php
@@ -92,7 +92,7 @@ class FormattedtextLogger extends Logger
 		// The name of the text file path defaults to that which is set in configuration if not explicitly given.
 		if (empty($this->options['text_file_path']))
 		{
-			$this->options['text_file_path'] = Factory::getConfig()->get('log_path', JPATH_ADMINISTRATOR . '/logs');
+			$this->options['text_file_path'] = Factory::getApplication()->getConfig()->get('log_path', JPATH_ADMINISTRATOR . '/logs');
 		}
 
 		// False to treat the log file as a php file.

--- a/libraries/src/Mail/MailTemplate.php
+++ b/libraries/src/Mail/MailTemplate.php
@@ -189,7 +189,7 @@ class MailTemplate
 
 		/** @var Registry $params */
 		$params = $mail->params;
-		$gconfig = Factory::getConfig();
+		$gconfig = Factory::getApplication()->getConfig();
 
 		if ($config->get('alternative_mailconfig'))
 		{

--- a/libraries/src/Session/Storage/JoomlaStorage.php
+++ b/libraries/src/Session/Storage/JoomlaStorage.php
@@ -109,7 +109,7 @@ class JoomlaStorage extends NativeStorage
 		 */
 		if (isset($_COOKIE[$session_name]))
 		{
-			$config        = Factory::getConfig();
+			$config        = Factory::getApplication()->getConfig();
 			$cookie_domain = $config->get('cookie_domain', '');
 			$cookie_path   = $config->get('cookie_path', '/');
 			$cookie = session_get_cookie_params();
@@ -242,7 +242,7 @@ class JoomlaStorage extends NativeStorage
 			$cookie['secure'] = true;
 		}
 
-		$config = Factory::getConfig();
+		$config = Factory::getApplication()->getConfig();
 
 		if ($config->get('cookie_domain', '') != '')
 		{

--- a/plugins/privacy/user/user.php
+++ b/plugins/privacy/user/user.php
@@ -143,7 +143,7 @@ class PlgPrivacyUser extends PrivacyPlugin
 			return;
 		}
 
-		$storeName = Factory::getConfig()->get('session_handler', 'none');
+		$storeName = Factory::getApplication()->getConfig()->get('session_handler', 'none');
 		$store     = JSessionStorage::getInstance($storeName);
 
 		// Destroy the sessions and quote the IDs to purge the session table

--- a/plugins/sampledata/blog/blog.php
+++ b/plugins/sampledata/blog/blog.php
@@ -127,9 +127,9 @@ class PlgSampledataBlog extends CMSPlugin
 		// Set unicodeslugs if alias is empty
 		if (trim(str_replace('-', '', $alias) == ''))
 		{
-			$unicode = Factory::getConfig()->set('unicodeslugs', 1);
+			$unicode = Factory::getApplication()->getConfig()->set('unicodeslugs', 1);
 			$alias = ApplicationHelper::stringURLSafe($categoryTitle);
-			Factory::getConfig()->set('unicodeslugs', $unicode);
+			Factory::getApplication()->getConfig()->set('unicodeslugs', $unicode);
 		}
 
 		$category      = array(
@@ -174,9 +174,9 @@ class PlgSampledataBlog extends CMSPlugin
 		// Set unicodeslugs if alias is empty
 		if (trim(str_replace('-', '', $alias) == ''))
 		{
-			$unicode = Factory::getConfig()->set('unicodeslugs', 1);
+			$unicode = Factory::getApplication()->getConfig()->set('unicodeslugs', 1);
 			$alias = ApplicationHelper::stringURLSafe($categoryTitle);
-			Factory::getConfig()->set('unicodeslugs', $unicode);
+			Factory::getApplication()->getConfig()->set('unicodeslugs', $unicode);
 		}
 
 		$category      = array(
@@ -266,9 +266,9 @@ class PlgSampledataBlog extends CMSPlugin
 			// Set unicodeslugs if alias is empty
 			if (trim(str_replace('-', '', $alias) == ''))
 			{
-				$unicode = Factory::getConfig()->set('unicodeslugs', 1);
+				$unicode = Factory::getApplication()->getConfig()->set('unicodeslugs', 1);
 				$article['alias'] = ApplicationHelper::stringURLSafe($article['title']);
-				Factory::getConfig()->set('unicodeslugs', $unicode);
+				Factory::getApplication()->getConfig()->set('unicodeslugs', $unicode);
 			}
 
 			$article['language']        = $language;
@@ -1021,9 +1021,9 @@ class PlgSampledataBlog extends CMSPlugin
 			// Set unicodeslugs if alias is empty
 			if (trim(str_replace('-', '', $menuItem['alias']) == ''))
 			{
-				$unicode = Factory::getConfig()->set('unicodeslugs', 1);
+				$unicode = Factory::getApplication()->getConfig()->set('unicodeslugs', 1);
 				$menuItem['alias'] = ApplicationHelper::stringURLSafe($menuItem['title']);
-				Factory::getConfig()->set('unicodeslugs', $unicode);
+				Factory::getApplication()->getConfig()->set('unicodeslugs', $unicode);
 			}
 
 			// Append language suffix to title.

--- a/plugins/sampledata/multilang/multilang.php
+++ b/plugins/sampledata/multilang/multilang.php
@@ -1008,9 +1008,9 @@ class PlgSampledataMultilang extends CMSPlugin
 		// Set unicodeslugs if alias is empty
 		if (trim(str_replace('-', '', $alias) == ''))
 		{
-			$unicode = Factory::getConfig()->set('unicodeslugs', 1);
+			$unicode = Factory::getApplication()->getConfig()->set('unicodeslugs', 1);
 			$alias   = ApplicationHelper::stringURLSafe($title);
-			Factory::getConfig()->set('unicodeslugs', $unicode);
+			Factory::getApplication()->getConfig()->set('unicodeslugs', $unicode);
 		}
 
 		// Initialize a new category.
@@ -1084,9 +1084,9 @@ class PlgSampledataMultilang extends CMSPlugin
 		// Set unicodeslugs if alias is empty
 		if (trim(str_replace('-', '', $alias) == ''))
 		{
-			$unicode = Factory::getConfig()->set('unicodeslugs', 1);
+			$unicode = Factory::getApplication()->getConfig()->set('unicodeslugs', 1);
 			$alias   = ApplicationHelper::stringURLSafe($title);
-			Factory::getConfig()->set('unicodeslugs', $unicode);
+			Factory::getApplication()->getConfig()->set('unicodeslugs', $unicode);
 		}
 
 		// Initialize a new article.

--- a/plugins/system/actionlogs/actionlogs.php
+++ b/plugins/system/actionlogs/actionlogs.php
@@ -334,7 +334,7 @@ class PlgSystemActionLogs extends CMSPlugin
 	 */
 	private function clearCacheGroups(array $clearGroups, array $cacheClients = [0, 1])
 	{
-		$conf = Factory::getConfig();
+		$conf = Factory::getApplication()->getConfig();
 
 		foreach ($clearGroups as $group)
 		{

--- a/plugins/system/logrotation/logrotation.php
+++ b/plugins/system/logrotation/logrotation.php
@@ -252,7 +252,7 @@ class PlgSystemLogrotation extends CMSPlugin
 	 */
 	private function clearCacheGroups(array $clearGroups, array $cacheClients = array(0, 1))
 	{
-		$conf = Factory::getConfig();
+		$conf = Factory::getApplication()->getConfig();
 
 		foreach ($clearGroups as $group)
 		{

--- a/plugins/system/privacyconsent/privacyconsent.php
+++ b/plugins/system/privacyconsent/privacyconsent.php
@@ -712,7 +712,7 @@ class PlgSystemPrivacyconsent extends CMSPlugin
 	 */
 	private function clearCacheGroups(array $clearGroups, array $cacheClients = [0, 1])
 	{
-		$conf = Factory::getConfig();
+		$conf = Factory::getApplication()->getConfig();
 
 		foreach ($clearGroups as $group)
 		{


### PR DESCRIPTION
### Summary of Changes

A straight replacement of `Factory::getConfig()` with `Factory::getApplication()->getConfig()`

44 instances across 22 files

Implements the change instructed in the `@deprecated` notes throughout Joomla 4

### Testing Instructions

Apply PR - browse around - nothing should be broken. 

### Actual result BEFORE applying this Pull Request

Enabling System debug plugin with all options enabled to log all things and deprecated
Note that Factory::getConfig in libraries/src/Log/Logger/FormattedtextLogger.php is logged in the `deprecated-core`  tab

### Expected result AFTER applying this Pull Request

Everything still works, no deprecated notices in the debug log `deprecated-core` tabs 

### Documentation Changes Required

none