### PR TITLE
[4.0] Header badge

### DIFF
--- a/administrator/templates/atum/scss/blocks/_header.scss
+++ b/administrator/templates/atum/scss/blocks/_header.scss
@@ -180,16 +180,16 @@
 
   .badge {
     position: absolute;
-    top: .4rem;
+    top: 0;
 
     [dir=ltr] & {
       left: 50%;
-      margin-left: .8rem;
+      margin-left: .4rem;
     }
 
     [dir=rtl] & {
       right: 50%;
-      margin-right: .8rem;
+      margin-right: .4rem;
     }
   }
 


### PR DESCRIPTION
Usually badges with counts are displayed with the count over the corner not by the side.

As this is a scss change you need to `node build.js --compile-css` to test

### before
![image](https://user-images.githubusercontent.com/1296369/86061734-3742b700-ba5f-11ea-9e20-fb37bf360e56.png)

### after
![image](https://user-images.githubusercontent.com/1296369/86061738-39a51100-ba5f-11ea-893c-f3f17d9cc362.png)
