### PR TITLE
[4.0] Move event listener from joomla-toolbar-button to button element

### DIFF
--- a/build/media_source/system/js/joomla-toolbar-button.w-c.es6.js
+++ b/build/media_source/system/js/joomla-toolbar-button.w-c.es6.js
@@ -37,7 +37,7 @@ window.customElements.define('joomla-toolbar-button', class extends HTMLElement 
     // because we cannot currently extend HTMLButtonElement
     this.buttonElement = this.querySelector('button, a');
 
-    this.addEventListener('click', this.executeTask);
+    this.buttonElement.addEventListener('click', this.executeTask);
 
     // Check whether we have a form
     const formSelector = this.form || 'adminForm';
@@ -67,7 +67,7 @@ window.customElements.define('joomla-toolbar-button', class extends HTMLElement 
       this.formElement.boxchecked.removeEventListener('change', this.onChange);
     }
 
-    this.removeEventListener('click', this.executeTask);
+    this.buttonElement.removeEventListener('click', this.executeTask);
   }
 
   onChange({ target }) {


### PR DESCRIPTION
Fixes https://github.com/joomla/joomla-cms/issues/29820.

### Summary of Changes

Moves event listener from `joomla-toolbar-button` element to actual clickable button.

### Testing Instructions

`node build.js --compile-js` required.
Go to any backend view containing toolbar buttons.
Click a couple of pixels below or above a button.

### Actual result BEFORE applying this Pull Request

Button clicked.

### Expected result AFTER applying this Pull Request

Button not clicked.
Also check that buttons continue to work properly.

### Documentation Changes Required

No.