### PR TITLE
[4.0] Move from Factory::getConfig to getting config from application

### DIFF
--- a/administrator/components/com_config/src/Model/ApplicationModel.php
+++ b/administrator/components/com_config/src/Model/ApplicationModel.php
@@ -714,13 +714,12 @@ class ApplicationModel extends FormModel
 		$config = new Registry($data);
 
 		// Overwrite the old FTP credentials with the new ones.
-		$temp = Factory::getConfig();
-		$temp->set('ftp_enable', $data['ftp_enable']);
-		$temp->set('ftp_host', $data['ftp_host']);
-		$temp->set('ftp_port', $data['ftp_port']);
-		$temp->set('ftp_user', $data['ftp_user']);
-		$temp->set('ftp_pass', $data['ftp_pass']);
-		$temp->set('ftp_root', $data['ftp_root']);
+		$app->set('ftp_enable', $data['ftp_enable']);
+		$app->set('ftp_host', $data['ftp_host']);
+		$app->set('ftp_port', $data['ftp_port']);
+		$app->set('ftp_user', $data['ftp_user']);
+		$app->set('ftp_pass', $data['ftp_pass']);
+		$app->set('ftp_root', $data['ftp_root']);
 
 		// Clear cache of com_config component.
 		$this->cleanCache('_system', 0);

--- a/administrator/components/com_finder/src/Table/MapTable.php
+++ b/administrator/components/com_finder/src/Table/MapTable.php
@@ -36,7 +36,7 @@ class MapTable extends Nested
 		parent::__construct('#__finder_taxonomy', 'id', $db);
 
 		$this->setColumnAlias('published', 'state');
-		$this->access = (int) Factory::getConfig()->get('access');
+		$this->access = (int) Factory::getApplication()->get('access');
 	}
 
 	/**

--- a/administrator/components/com_menus/src/Helper/MenusHelper.php
+++ b/administrator/components/com_menus/src/Helper/MenusHelper.php
@@ -498,9 +498,9 @@ class MenusHelper extends ContentHelper
 			$item->alias = $menutype . '-' . $item->title;
 
 			// Temporarily set unicodeslugs if a menu item has an unicode alias
-			$unicode     = Factory::getConfig()->set('unicodeslugs', 1);
+			$unicode     = Factory::getApplication()->set('unicodeslugs', 1);
 			$item->alias = ApplicationHelper::stringURLSafe($item->alias);
-			Factory::getConfig()->set('unicodeslugs', $unicode);
+			Factory::getApplication()->set('unicodeslugs', $unicode);
 
 			if ($item->type == 'separator')
 			{

--- a/administrator/components/com_privacy/src/Model/RequestModel.php
+++ b/administrator/components/com_privacy/src/Model/RequestModel.php
@@ -391,7 +391,7 @@ class RequestModel extends AdminModel
 		$key   = $table->getKeyName();
 		$pk    = !empty($data[$key]) ? $data[$key] : (int) $this->getState($this->getName() . '.id');
 
-		if (!$pk && !Factory::getConfig()->get('mailonline', 1))
+		if (!$pk && !Factory::getApplication()->get('mailonline', 1))
 		{
 			$this->setError(Text::_('COM_PRIVACY_ERROR_CANNOT_CREATE_REQUEST_WHEN_SENDMAIL_DISABLED'));
 

--- a/administrator/components/com_privacy/src/View/Request/HtmlView.php
+++ b/administrator/components/com_privacy/src/View/Request/HtmlView.php
@@ -157,7 +157,7 @@ class HtmlView extends BaseHtmlView
 							'download'
 						);
 
-						if (Factory::getConfig()->get('mailonline', 1))
+						if (Factory::getApplication()->get('mailonline', 1))
 						{
 							ToolbarHelper::link(
 								Route::_('index.php?option=com_privacy&task=request.emailexport&id=' . (int) $this->item->id . $return),

--- a/administrator/components/com_privacy/src/View/Requests/HtmlView.php
+++ b/administrator/components/com_privacy/src/View/Requests/HtmlView.php
@@ -108,7 +108,7 @@ class HtmlView extends BaseHtmlView
 		$this->filterForm       = $model->getFilterForm();
 		$this->activeFilters    = $model->getActiveFilters();
 		$this->urgentRequestAge = (int) ComponentHelper::getParams('com_privacy')->get('notify', 14);
-		$this->sendMailEnabled  = (bool) Factory::getConfig()->get('mailonline', 1);
+		$this->sendMailEnabled  = (bool) Factory::getApplication()->get('mailonline', 1);
 
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
@@ -133,7 +133,7 @@ class HtmlView extends BaseHtmlView
 		ToolbarHelper::title(Text::_('COM_PRIVACY_VIEW_REQUESTS'), 'lock');
 
 		// Requests can only be created if mail sending is enabled
-		if (Factory::getConfig()->get('mailonline', 1))
+		if (Factory::getApplication()->get('mailonline', 1))
 		{
 			ToolbarHelper::addNew('request.add');
 		}

--- a/cli/finder_indexer.php
+++ b/cli/finder_indexer.php
@@ -214,9 +214,9 @@ class FinderCli extends \Joomla\CMS\Application\CliApplication
 		JLoader::register('FinderIndexer', JPATH_ADMINISTRATOR . '/components/com_finder/helpers/indexer/indexer.php');
 
 		// Disable caching.
-		$config = Factory::getConfig();
-		$config->set('caching', 0);
-		$config->set('cache_handler', 'file');
+		$app = Factory::getApplication();
+		$app->set('caching', 0);
+		$app->set('cache_handler', 'file');
 
 		// Reset the indexer state.
 		FinderIndexer::resetState();

--- a/components/com_privacy/src/Model/RequestModel.php
+++ b/components/com_privacy/src/Model/RequestModel.php
@@ -46,8 +46,10 @@ class RequestModel extends AdminModel
 	 */
 	public function createRequest($data)
 	{
+		$app = Factory::getApplication();
+
 		// Creating requests requires the site's email sending be enabled
-		if (!Factory::getConfig()->get('mailonline', 1))
+		if (!$app->get('mailonline', 1))
 		{
 			$this->setError(Text::_('COM_PRIVACY_ERROR_CANNOT_CREATE_REQUEST_WHEN_SENDMAIL_DISABLED'));
 
@@ -131,7 +133,7 @@ class RequestModel extends AdminModel
 
 		// Push a notification to the site's super users, deliberately ignoring if this process fails so the below message goes out
 		/** @var MessageModel $messageModel */
-		$messageModel = Factory::getApplication()->bootComponent('com_messages')->getMVCFactory()->createModel('Message', 'Administrator');
+		$messageModel = $app->bootComponent('com_messages')->getMVCFactory()->createModel('Message', 'Administrator');
 
 		$messageModel->notifySuperUsers(
 			Text::_('COM_PRIVACY_ADMIN_NOTIFICATION_USER_CREATED_REQUEST_SUBJECT'),
@@ -141,8 +143,6 @@ class RequestModel extends AdminModel
 		// The mailer can be set to either throw Exceptions or return boolean false, account for both
 		try
 		{
-			$app = Factory::getApplication();
-
 			$linkMode = $app->get('force_ssl', 0) == 2 ? Route::TLS_FORCE : Route::TLS_IGNORE;
 
 			$substitutions = [

--- a/components/com_privacy/src/View/Request/HtmlView.php
+++ b/components/com_privacy/src/View/Request/HtmlView.php
@@ -82,7 +82,7 @@ class HtmlView extends BaseHtmlView
 		$this->form            = $this->get('Form');
 		$this->state           = $this->get('State');
 		$this->params          = $this->state->params;
-		$this->sendMailEnabled = (bool) Factory::getConfig()->get('mailonline', 1);
+		$this->sendMailEnabled = (bool) Factory::getApplication()->get('mailonline', 1);
 
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))

--- a/installation/src/Model/LanguagesModel.php
+++ b/installation/src/Model/LanguagesModel.php
@@ -71,7 +71,7 @@ class LanguagesModel extends BaseInstallationModel
 		// Overrides application config and set the configuration.php file so tokens and database works.
 		if (file_exists(JPATH_BASE . '/configuration.php'))
 		{
-			Factory::getApplication()->setConfiguration(new Registry(new \JConfig()));
+			Factory::getApplication()->setConfiguration(new Registry(new \JConfig));
 		}
 
 		/*

--- a/installation/src/Model/LanguagesModel.php
+++ b/installation/src/Model/LanguagesModel.php
@@ -69,7 +69,10 @@ class LanguagesModel extends BaseInstallationModel
 	public function __construct()
 	{
 		// Overrides application config and set the configuration.php file so tokens and database works.
-		Factory::getApplication()->setConfiguration(new Registry(new \JConfig));
+		if (file_exists(JPATH_BASE . '/configuration.php'))
+		{
+			Factory::getApplication()->setConfiguration(new Registry(new \JConfig()));
+		}
 
 		/*
 		 * Factory::getDbo() gets called during app bootup, and because of the "uniqueness" of the install app, the config doesn't get read

--- a/installation/src/Model/LanguagesModel.php
+++ b/installation/src/Model/LanguagesModel.php
@@ -22,6 +22,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Table\Table;
 use Joomla\CMS\Updater\Update;
 use Joomla\CMS\Updater\Updater;
+use Joomla\Registry\Registry;
 
 /**
  * Language Installer model for the Joomla Core Installer.
@@ -68,8 +69,7 @@ class LanguagesModel extends BaseInstallationModel
 	public function __construct()
 	{
 		// Overrides application config and set the configuration.php file so tokens and database works.
-		Factory::$config = null;
-		Factory::getConfig(JPATH_SITE . '/configuration.php');
+		Factory::getApplication()->setConfiguration(new Registry(new \JConfig));
 
 		/*
 		 * Factory::getDbo() gets called during app bootup, and because of the "uniqueness" of the install app, the config doesn't get read
@@ -147,6 +147,7 @@ class LanguagesModel extends BaseInstallationModel
 	 */
 	public function install($lids)
 	{
+		$app = Factory::getApplication();
 		$installerBase = new Installer;
 
 		// Loop through every selected language.
@@ -167,7 +168,7 @@ class LanguagesModel extends BaseInstallationModel
 				$message = Text::sprintf('INSTL_DEFAULTLANGUAGE_COULD_NOT_INSTALL_LANGUAGE', $language->name);
 				$message .= ' ' . Text::_('INSTL_DEFAULTLANGUAGE_TRY_LATER');
 
-				Factory::getApplication()->enqueueMessage($message, 'warning');
+				$app->enqueueMessage($message, 'warning');
 
 				continue;
 			}
@@ -181,7 +182,7 @@ class LanguagesModel extends BaseInstallationModel
 				$message = Text::sprintf('INSTL_DEFAULTLANGUAGE_COULD_NOT_INSTALL_LANGUAGE', $language->name);
 				$message .= ' ' . Text::_('INSTL_DEFAULTLANGUAGE_TRY_LATER');
 
-				Factory::getApplication()->enqueueMessage($message, 'warning');
+				$app->enqueueMessage($message, 'warning');
 
 				continue;
 			}
@@ -196,7 +197,7 @@ class LanguagesModel extends BaseInstallationModel
 				$message = Text::sprintf('INSTL_DEFAULTLANGUAGE_COULD_NOT_INSTALL_LANGUAGE', $language->name);
 				$message .= ' ' . Text::_('INSTL_DEFAULTLANGUAGE_TRY_LATER');
 
-				Factory::getApplication()->enqueueMessage($message, 'warning');
+				$app->enqueueMessage($message, 'warning');
 
 				continue;
 			}
@@ -204,8 +205,7 @@ class LanguagesModel extends BaseInstallationModel
 			// Cleanup the install files in tmp folder.
 			if (!is_file($package['packagefile']))
 			{
-				$config                 = Factory::getConfig();
-				$package['packagefile'] = $config->get('tmp_path') . '/' . $package['packagefile'];
+				$package['packagefile'] = $app->get('tmp_path') . '/' . $package['packagefile'];
 			}
 
 			InstallerHelper::cleanupInstall($package['packagefile'], $package['extractdir']);
@@ -271,22 +271,21 @@ class LanguagesModel extends BaseInstallationModel
 	 */
 	protected function downloadPackage($url)
 	{
+		$app = Factory::getApplication();
+
 		// Download the package from the given URL.
 		$p_file = InstallerHelper::downloadPackage($url);
 
 		// Was the package downloaded?
 		if (!$p_file)
 		{
-			Factory::getApplication()->enqueueMessage(Text::_('COM_INSTALLER_MSG_INSTALL_INVALID_URL'), 'warning');
+			$app->enqueueMessage(Text::_('COM_INSTALLER_MSG_INSTALL_INVALID_URL'), 'warning');
 
 			return false;
 		}
 
-		$config   = Factory::getConfig();
-		$tmp_dest = $config->get('tmp_path');
-
 		// Unpack the downloaded package file.
-		return InstallerHelper::unpack($tmp_dest . '/' . $p_file);
+		return InstallerHelper::unpack($app->get('tmp_path') . '/' . $p_file);
 	}
 
 	/**

--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -539,13 +539,14 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
 	 */
 	public static function getRouter($name = null, array $options = array())
 	{
+		$app = Factory::getApplication();
+
 		if (!isset($name))
 		{
-			$app = Factory::getApplication();
 			$name = $app->getName();
 		}
 
-		$options['mode'] = Factory::getConfig()->get('sef');
+		$options['mode'] = $app->get('sef');
 
 		return Router::getInstance($name, $options);
 	}

--- a/libraries/src/Factory.php
+++ b/libraries/src/Factory.php
@@ -167,8 +167,12 @@ abstract class Factory
 			E_USER_DEPRECATED
 		);
 
-		// If there is an application object, fetch the configuration from there
-		if (self::$application)
+		/**
+		 * If there is an application object, fetch the configuration from there
+		 * Check its not null because LanguagesModel can make it null and if its null
+		 * we would want to re-init it from configuration.php
+		 */
+		if (self::$application && self::$application->getConfig() !== null)
 		{
 			return self::$application->getConfig();
 		}

--- a/libraries/src/Factory.php
+++ b/libraries/src/Factory.php
@@ -168,9 +168,9 @@ abstract class Factory
 		);
 
 		/**
-		 * If there is an application object, fetch the configuration from there
-		 * Check its not null because LanguagesModel can make it null and if its null
-		 * we would want to re-init it from configuration.php
+		 * If there is an application object, fetch the configuration from there.
+		 * Check it's not null because LanguagesModel can make it null and if it's null
+		 * we would want to re-init it from configuration.php.
 		 */
 		if (self::$application && self::$application->getConfig() !== null)
 		{

--- a/libraries/src/Form/Field/CalendarField.php
+++ b/libraries/src/Form/Field/CalendarField.php
@@ -338,6 +338,8 @@ class CalendarField extends FormField
 	 */
 	public function filter($value, $group = null, Registry $input = null)
 	{
+		$app = Factory::getApplication();
+
 		// Make sure there is a valid SimpleXMLElement.
 		if (!($this->element instanceof \SimpleXMLElement))
 		{
@@ -356,7 +358,7 @@ class CalendarField extends FormField
 				if ((int) $value > 0)
 				{
 					// Get the server timezone setting.
-					$offset = Factory::getConfig()->get('offset');
+					$offset = $app->get('offset');
 
 					// Return an SQL formatted datetime string in UTC.
 					$return = Factory::getDate($value, $offset)->toSql();
@@ -372,7 +374,7 @@ class CalendarField extends FormField
 				if ((int) $value > 0)
 				{
 					// Get the user timezone setting defaulting to the server timezone setting.
-					$offset = Factory::getUser()->getParam('timezone', Factory::getConfig()->get('offset'));
+					$offset = Factory::getUser()->getParam('timezone', $app->get('offset'));
 
 					// Return an SQL formatted datetime string in UTC.
 					$return = Factory::getDate($value, $offset)->toSql();

--- a/libraries/src/Log/Logger/FormattedtextLogger.php
+++ b/libraries/src/Log/Logger/FormattedtextLogger.php
@@ -92,7 +92,7 @@ class FormattedtextLogger extends Logger
 		// The name of the text file path defaults to that which is set in configuration if not explicitly given.
 		if (empty($this->options['text_file_path']))
 		{
-			$this->options['text_file_path'] = Factory::getConfig()->get('log_path', JPATH_ADMINISTRATOR . '/logs');
+			$this->options['text_file_path'] = Factory::getApplication()->get('log_path', JPATH_ADMINISTRATOR . '/logs');
 		}
 
 		// False to treat the log file as a php file.

--- a/libraries/src/Mail/MailTemplate.php
+++ b/libraries/src/Mail/MailTemplate.php
@@ -189,18 +189,18 @@ class MailTemplate
 
 		/** @var Registry $params */
 		$params = $mail->params;
-		$gconfig = Factory::getConfig();
+		$app = Factory::getApplication();
 
 		if ($config->get('alternative_mailconfig'))
 		{
 			if ($this->mailer->Mailer === 'smtp' || $params->get('mailer') === 'smtp')
 			{
-				$smtpauth = ($params->get('smtpauth', $gconfig->get('smtpauth')) == 0) ? null : 1;
-				$smtpuser = $params->get('smtpuser', $gconfig->get('smtpuser'));
-				$smtppass = $params->get('smtppass', $gconfig->get('smtppass'));
-				$smtphost = $params->get('smtphost', $gconfig->get('smtphost'));
-				$smtpsecure = $params->get('smtpsecure', $gconfig->get('smtpsecure'));
-				$smtpport = $params->get('smtpport', $gconfig->get('smtpport'));
+				$smtpauth = ($params->get('smtpauth', $app->get('smtpauth')) == 0) ? null : 1;
+				$smtpuser = $params->get('smtpuser', $app->get('smtpuser'));
+				$smtppass = $params->get('smtppass', $app->get('smtppass'));
+				$smtphost = $params->get('smtphost', $app->get('smtphost'));
+				$smtpsecure = $params->get('smtpsecure', $app->get('smtpsecure'));
+				$smtpport = $params->get('smtpport', $app->get('smtpport'));
 				$this->mailer->useSmtp($smtpauth, $smtphost, $smtpuser, $smtppass, $smtpsecure, $smtpport);
 			}
 
@@ -209,8 +209,8 @@ class MailTemplate
 				$this->mailer->isSendmail();
 			}
 
-			$mailfrom = $params->get('mailfrom', $gconfig->get('mailfrom'));
-			$fromname = $params->get('fromname', $gconfig->get('fromname'));
+			$mailfrom = $params->get('mailfrom', $app->get('mailfrom'));
+			$fromname = $params->get('fromname', $app->get('fromname'));
 
 			if (MailHelper::isEmailAddress($mailfrom))
 			{
@@ -218,7 +218,7 @@ class MailTemplate
 			}
 		}
 
-		Factory::getApplication()->triggerEvent('onMailBeforeRendering', array($this->template_id, &$this));
+		$app->triggerEvent('onMailBeforeRendering', array($this->template_id, &$this));
 
 		$mail->subject = $this->replaceTags(Text::_($mail->subject), $this->data);
 		$this->mailer->setSubject($mail->subject);

--- a/libraries/src/Session/Storage/JoomlaStorage.php
+++ b/libraries/src/Session/Storage/JoomlaStorage.php
@@ -109,9 +109,9 @@ class JoomlaStorage extends NativeStorage
 		 */
 		if (isset($_COOKIE[$session_name]))
 		{
-			$config        = Factory::getConfig();
-			$cookie_domain = $config->get('cookie_domain', '');
-			$cookie_path   = $config->get('cookie_path', '/');
+			$app           = Factory::getApplication();
+			$cookie_domain = $app->get('cookie_domain', '');
+			$cookie_path   = $app->get('cookie_path', '/');
 			$cookie = session_get_cookie_params();
 			setcookie($session_name, '', time() - 42000, $cookie_path, $cookie_domain, $cookie['secure'], true);
 		}
@@ -242,16 +242,16 @@ class JoomlaStorage extends NativeStorage
 			$cookie['secure'] = true;
 		}
 
-		$config = Factory::getConfig();
+		$app = Factory::getApplication();
 
-		if ($config->get('cookie_domain', '') != '')
+		if ($app->get('cookie_domain', '') != '')
 		{
-			$cookie['domain'] = $config->get('cookie_domain');
+			$cookie['domain'] = $app->get('cookie_domain');
 		}
 
-		if ($config->get('cookie_path', '') != '')
+		if ($app->get('cookie_path', '') != '')
 		{
-			$cookie['path'] = $config->get('cookie_path');
+			$cookie['path'] = $app->get('cookie_path');
 		}
 
 		session_set_cookie_params($cookie['lifetime'], $cookie['path'], $cookie['domain'], $cookie['secure'], true);

--- a/plugins/privacy/user/user.php
+++ b/plugins/privacy/user/user.php
@@ -143,7 +143,7 @@ class PlgPrivacyUser extends PrivacyPlugin
 			return;
 		}
 
-		$storeName = Factory::getConfig()->get('session_handler', 'none');
+		$storeName = Factory::getApplication()->get('session_handler', 'none');
 		$store     = JSessionStorage::getInstance($storeName);
 
 		// Destroy the sessions and quote the IDs to purge the session table

--- a/plugins/sampledata/blog/blog.php
+++ b/plugins/sampledata/blog/blog.php
@@ -127,9 +127,9 @@ class PlgSampledataBlog extends CMSPlugin
 		// Set unicodeslugs if alias is empty
 		if (trim(str_replace('-', '', $alias) == ''))
 		{
-			$unicode = Factory::getConfig()->set('unicodeslugs', 1);
+			$unicode = $this->app->set('unicodeslugs', 1);
 			$alias = ApplicationHelper::stringURLSafe($categoryTitle);
-			Factory::getConfig()->set('unicodeslugs', $unicode);
+			$this->app->set('unicodeslugs', $unicode);
 		}
 
 		$category      = array(
@@ -174,9 +174,9 @@ class PlgSampledataBlog extends CMSPlugin
 		// Set unicodeslugs if alias is empty
 		if (trim(str_replace('-', '', $alias) == ''))
 		{
-			$unicode = Factory::getConfig()->set('unicodeslugs', 1);
+			$unicode = $this->app->set('unicodeslugs', 1);
 			$alias = ApplicationHelper::stringURLSafe($categoryTitle);
-			Factory::getConfig()->set('unicodeslugs', $unicode);
+			$this->app->set('unicodeslugs', $unicode);
 		}
 
 		$category      = array(
@@ -266,9 +266,9 @@ class PlgSampledataBlog extends CMSPlugin
 			// Set unicodeslugs if alias is empty
 			if (trim(str_replace('-', '', $alias) == ''))
 			{
-				$unicode = Factory::getConfig()->set('unicodeslugs', 1);
+				$unicode = $this->app->set('unicodeslugs', 1);
 				$article['alias'] = ApplicationHelper::stringURLSafe($article['title']);
-				Factory::getConfig()->set('unicodeslugs', $unicode);
+				$this->app->set('unicodeslugs', $unicode);
 			}
 
 			$article['language']        = $language;
@@ -1003,6 +1003,7 @@ class PlgSampledataBlog extends CMSPlugin
 		$itemIds = array();
 		$access  = (int) $this->app->get('access', 1);
 		$user    = Factory::getUser();
+		$app     = Factory::getApplication();
 
 		// Detect language to be used.
 		$language   = Multilanguage::isEnabled() ? Factory::getLanguage()->getTag() : '*';
@@ -1021,9 +1022,9 @@ class PlgSampledataBlog extends CMSPlugin
 			// Set unicodeslugs if alias is empty
 			if (trim(str_replace('-', '', $menuItem['alias']) == ''))
 			{
-				$unicode = Factory::getConfig()->set('unicodeslugs', 1);
+				$unicode = $app->set('unicodeslugs', 1);
 				$menuItem['alias'] = ApplicationHelper::stringURLSafe($menuItem['title']);
-				Factory::getConfig()->set('unicodeslugs', $unicode);
+				$app->set('unicodeslugs', $unicode);
 			}
 
 			// Append language suffix to title.

--- a/plugins/sampledata/multilang/multilang.php
+++ b/plugins/sampledata/multilang/multilang.php
@@ -1005,7 +1005,7 @@ class PlgSampledataMultilang extends CMSPlugin
 		$title = $newlanguage->_('JCATEGORY');
 		$alias = ApplicationHelper::stringURLSafe($title);
 
-		$app = JFactory::getApplication();
+		$app = Factory::getApplication();
 
 		// Set unicodeslugs if alias is empty
 		if (trim(str_replace('-', '', $alias) == ''))

--- a/plugins/sampledata/multilang/multilang.php
+++ b/plugins/sampledata/multilang/multilang.php
@@ -1005,12 +1005,14 @@ class PlgSampledataMultilang extends CMSPlugin
 		$title = $newlanguage->_('JCATEGORY');
 		$alias = ApplicationHelper::stringURLSafe($title);
 
+		$app = JFactory::getApplication();
+
 		// Set unicodeslugs if alias is empty
 		if (trim(str_replace('-', '', $alias) == ''))
 		{
-			$unicode = Factory::getConfig()->set('unicodeslugs', 1);
+			$unicode = $app->set('unicodeslugs', 1);
 			$alias   = ApplicationHelper::stringURLSafe($title);
-			Factory::getConfig()->set('unicodeslugs', $unicode);
+			$app->set('unicodeslugs', $unicode);
 		}
 
 		// Initialize a new category.
@@ -1084,9 +1086,9 @@ class PlgSampledataMultilang extends CMSPlugin
 		// Set unicodeslugs if alias is empty
 		if (trim(str_replace('-', '', $alias) == ''))
 		{
-			$unicode = Factory::getConfig()->set('unicodeslugs', 1);
+			$unicode = $this->app->set('unicodeslugs', 1);
 			$alias   = ApplicationHelper::stringURLSafe($title);
-			Factory::getConfig()->set('unicodeslugs', $unicode);
+			$this->app->set('unicodeslugs', $unicode);
 		}
 
 		// Initialize a new article.

--- a/plugins/system/actionlogs/actionlogs.php
+++ b/plugins/system/actionlogs/actionlogs.php
@@ -334,8 +334,6 @@ class PlgSystemActionLogs extends CMSPlugin
 	 */
 	private function clearCacheGroups(array $clearGroups, array $cacheClients = [0, 1])
 	{
-		$conf = Factory::getConfig();
-
 		foreach ($clearGroups as $group)
 		{
 			foreach ($cacheClients as $clientId)
@@ -345,7 +343,7 @@ class PlgSystemActionLogs extends CMSPlugin
 					$options = [
 						'defaultgroup' => $group,
 						'cachebase'    => $clientId ? JPATH_ADMINISTRATOR . '/cache' :
-							$conf->get('cache_path', JPATH_SITE . '/cache')
+							Factory::getApplication()->get('cache_path', JPATH_SITE . '/cache')
 					];
 
 					$cache = Cache::getInstance('callback', $options);

--- a/plugins/system/logrotation/logrotation.php
+++ b/plugins/system/logrotation/logrotation.php
@@ -252,8 +252,6 @@ class PlgSystemLogrotation extends CMSPlugin
 	 */
 	private function clearCacheGroups(array $clearGroups, array $cacheClients = array(0, 1))
 	{
-		$conf = Factory::getConfig();
-
 		foreach ($clearGroups as $group)
 		{
 			foreach ($cacheClients as $client_id)
@@ -263,7 +261,7 @@ class PlgSystemLogrotation extends CMSPlugin
 					$options = array(
 						'defaultgroup' => $group,
 						'cachebase'    => $client_id ? JPATH_ADMINISTRATOR . '/cache' :
-							$conf->get('cache_path', JPATH_SITE . '/cache')
+							Factory::getApplication()->get('cache_path', JPATH_SITE . '/cache')
 					);
 
 					$cache = Cache::getInstance('callback', $options);

--- a/plugins/system/privacyconsent/privacyconsent.php
+++ b/plugins/system/privacyconsent/privacyconsent.php
@@ -712,8 +712,6 @@ class PlgSystemPrivacyconsent extends CMSPlugin
 	 */
 	private function clearCacheGroups(array $clearGroups, array $cacheClients = [0, 1])
 	{
-		$conf = Factory::getConfig();
-
 		foreach ($clearGroups as $group)
 		{
 			foreach ($cacheClients as $client_id)
@@ -723,7 +721,7 @@ class PlgSystemPrivacyconsent extends CMSPlugin
 					$options = [
 						'defaultgroup' => $group,
 						'cachebase'    => $client_id ? JPATH_ADMINISTRATOR . '/cache' :
-							$conf->get('cache_path', JPATH_SITE . '/cache')
+							Factory::getApplication()->get('cache_path', JPATH_SITE . '/cache')
 					];
 
 					$cache = Cache::getInstance('callback', $options);


### PR DESCRIPTION
### Summary of Changes

A straight replacement of `Factory::getConfig()` with `Factory::getApplication()->get()` and `$app->get()` etc..

44 instances across 22 files

Implements the change instructed in the `@deprecated` notes throughout Joomla 4

### Testing Instructions

Apply PR - browse around - nothing should be broken. 

### Actual result BEFORE applying this Pull Request

Enabling System debug plugin with all options enabled to log all things and deprecated
Note that Factory::getConfig in libraries/src/Log/Logger/FormattedtextLogger.php is logged in the `deprecated-core`  tab

### Expected result AFTER applying this Pull Request

Everything still works, no deprecated notices in the debug log `deprecated-core` tabs 

Nothing should break as the changes are swapping apples for apples from another store. 

### Documentation Changes Required

none

### Additional notes...

@wilsonge I have gone through each line, selecting an appropriate method of getting the config I believe. I reuse `$app` or `$this->app` where `Factory::getApplication` has already been called.

@infograf768 There is a complexity in the Language Installer, Please can I ask you to look over that change that includes reloading the configuration and injecting it back into the application in https://github.com/joomla/joomla-cms/pull/29854/files#diff-14ba76332f3c8fb4af43ae3d16937a2bR72 I have no idea if this even works so it needs real life testing, and I dont know how to test that with Joomla 4 languages?!