### PR TITLE
[4.0] Fix missing $ for scss variable cassiopeia-grid-gutter

### DIFF
--- a/templates/cassiopeia/scss/blocks/_css-grid.scss
+++ b/templates/cassiopeia/scss/blocks/_css-grid.scss
@@ -31,7 +31,7 @@
       flex-direction: column;
 
       > div + div {
-        margin-top: cassiopeia-grid-gutter;
+        margin-top: $cassiopeia-grid-gutter;
       }
     }
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This PR just adds a missing `$` to a scss variable

### Testing Instructions

- `npm run build:css` to compile the css
- check the css output
- apply PR
- `npm run build:css` to compile the css
- check the css output and compare

### Actual result BEFORE applying this Pull Request

```
.site-grid .container-component > div + div,
.site-grid .container-sidebar-left > div + div,
.site-grid .container-sidebar-right > div + div {
   margin-top: cassiopeia-grid-gutter;
}
```

### Expected result AFTER applying this Pull Request


```
.site-grid .container-component > div + div,
.site-grid .container-sidebar-left > div + div,
.site-grid .container-sidebar-right > div + div {
   margin-top: 15px;
}
```

### Documentation Changes Required

No changes required
