### PR TITLE
Email Fails HTML Validation as uses text/javascript

### DIFF
--- a/libraries/cms/html/email.php
+++ b/libraries/cms/html/email.php
@@ -99,7 +99,7 @@ abstract class JHtmlEmail
 		";
 
 		// TODO: Use inline script for now
-		$inlineScript = "<script type='text/javascript'>" . $script . "</script>";
+		$inlineScript = "<script>" . $script . "</script>";
 
 		return '<span id="cloak' . $rand . '">' . JText::_('JLIB_HTML_CLOAKING') . '</span>' . $inlineScript;
 	}

--- a/libraries/cms/html/email.php
+++ b/libraries/cms/html/email.php
@@ -99,7 +99,7 @@ abstract class JHtmlEmail
 		";
 
 		// TODO: Use inline script for now
-		$inlineScript = "<script>" . $script . "</script>";
+		$inlineScript = '<script>' . $script . '</script>';
 
 		return '<span id="cloak' . $rand . '">' . JText::_('JLIB_HTML_CLOAKING') . '</span>' . $inlineScript;
 	}


### PR DESCRIPTION
If scripts have  type='text/javascript' in it - it triggers a warning in html5 validation:

`Warning: The type attribute is unnecessary for JavaScript resources.`

In our templates we can set $doc->setHtml5(true) to remove type='text/javascript' from script.
But in the email.php its hard coded - so it doesn't seem to work.

Is there away to do this?

Pull Request for Issue # .

### Summary of Changes
Remove type='text/javascript' to pass html5 validation


### Testing Instructions



### Actual result BEFORE applying this Pull Request

<script type='text/javascript'>

### Expected result AFTER applying this Pull Request

<script>


### Documentation Changes Required

