### PR TITLE
[4] Use modal.js instead of batch.js in editor when inserting article link

### DIFF
--- a/administrator/components/com_content/tmpl/articles/modal.php
+++ b/administrator/components/com_content/tmpl/articles/modal.php
@@ -30,7 +30,7 @@ HTMLHelper::_('behavior.multiselect');
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('core')
-	->useScript('com_content.admin-articles-batch');
+	->useScript('com_content.admin-articles-modal');
 
 $function  = $app->input->getCmd('function', 'jSelectArticle');
 $editor    = $app->input->getCmd('editor', '');


### PR DESCRIPTION
Fixes https://github.com/joomla/joomla-cms/issues/29858

### Summary of Changes
- Replaced wrong asset `com_content.admin-articles-batch` with `com_content.admin-articles-modal`


### Testing Instructions
- See issue https://github.com/joomla/joomla-cms/issues/29858


### Actual result BEFORE applying this Pull Request
- No insertion of article anchor in editor text.

### Expected result AFTER applying this Pull Request
- Known behavior is back.
