### PR TITLE
[4.0] Display Alias inline on desktop

### DIFF
--- a/administrator/components/com_categories/tmpl/categories/default.php
+++ b/administrator/components/com_categories/tmpl/categories/default.php
@@ -195,7 +195,7 @@ if ($saveOrder && !empty($this->items))
 										<?php else : ?>
 											<?php echo $this->escape($item->title); ?>
 										<?php endif; ?>
-										<div class="small" title="<?php echo $this->escape($item->path); ?>">
+										<div class="small d-xl-inline" title="<?php echo $this->escape($item->path); ?>">
 											<?php if (empty($item->note)) : ?>
 												<?php echo Text::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->alias)); ?>
 											<?php else : ?>

--- a/administrator/components/com_categories/tmpl/categories/modal.php
+++ b/administrator/components/com_categories/tmpl/categories/modal.php
@@ -108,7 +108,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 								<?php echo LayoutHelper::render('joomla.html.treeprefix', array('level' => $item->level)); ?>
 								<a href="javascript:void(0)" onclick="if (window.parent) window.parent.<?php echo $this->escape($function); ?>('<?php echo $item->id; ?>', '<?php echo $this->escape(addslashes($item->title)); ?>', null, '<?php echo $this->escape(RouteHelper::getCategoryRoute($item->id, $item->language)); ?>', '<?php echo $this->escape($lang); ?>', null);">
 									<?php echo $this->escape($item->title); ?></a>
-								<div class="small" title="<?php echo $this->escape($item->path); ?>">
+								<div class="small d-xl-inline" title="<?php echo $this->escape($item->path); ?>">
 									<?php if (empty($item->note)) : ?>
 										<?php echo Text::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->alias)); ?>
 									<?php else : ?>

--- a/administrator/components/com_content/tmpl/articles/default.php
+++ b/administrator/components/com_content/tmpl/articles/default.php
@@ -260,7 +260,7 @@ $assoc = Associations::isEnabled();
 										<?php else : ?>
 											<span title="<?php echo Text::sprintf('JFIELD_ALIAS_LABEL', $this->escape($item->alias)); ?>"><?php echo $this->escape($item->title); ?></span>
 										<?php endif; ?>
-											<div class="small break-word">
+											<div class="small break-word d-xl-inline">
 												<?php if (empty($item->note)) : ?>
 													<?php echo Text::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->alias)); ?>
 												<?php else : ?>

--- a/administrator/components/com_content/tmpl/featured/default.php
+++ b/administrator/components/com_content/tmpl/featured/default.php
@@ -260,7 +260,7 @@ $assoc = Associations::isEnabled();
 										<?php else : ?>
 											<span title="<?php echo Text::sprintf('JFIELD_ALIAS_LABEL', $this->escape($item->alias)); ?>"><?php echo $this->escape($item->title); ?></span>
 										<?php endif; ?>
-										<div class="small break-word">
+										<div class="small break-word d-xl-inline">
 											<?php if (empty($item->note)) : ?>
 												<?php echo Text::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->alias)); ?>
 											<?php else : ?>


### PR DESCRIPTION
Improves Issue #29200.

### Summary of Changes
To be consistent with other components, display `Alias` on the same line as `Title` on desktop and on its own line on smaller viewports.

Reduces vertical spacing taking up 2 lines vs. 3 lines on desktop.


### Testing Instructions
Go to Content > Articles
See Alias on the same line as Title.
Go to Content > Featured Articles
See Alias on the same line as Title.
Apply PR.
Reduce browser's viewport.
Repeat above steps.
See Alias on its own line.