### PR TITLE
[4.0] Fix admin login button hover

### DIFF
--- a/administrator/templates/atum/scss/blocks/_login.scss
+++ b/administrator/templates/atum/scss/blocks/_login.scss
@@ -13,7 +13,6 @@
     }
 
     #content {
-
       @include media-breakpoint-down(sm) {
         max-width: 98%;
         padding: 0;
@@ -51,7 +50,6 @@
     }
 
     #form-login {
-
       .form-group {
         position: relative;
         margin-bottom: 1.85rem;
@@ -65,21 +63,9 @@
         }
       }
     }
-
-    #btn-login-submit {
-      color: var(--atum-text-light);
-      background-color: var(--atum-link-color);
-      border-color: var(--atum-link-color);
-
-      @include hover-focus-active {
-        background-color: var(--atum-bg-dark-70);
-        border-color: var(--atum-bg-dark-90);
-      }
-    }
   }
 
   .form-group {
-
     label {
       span {
         font-size: .9rem;

--- a/administrator/templates/atum/scss/blocks/_login.scss
+++ b/administrator/templates/atum/scss/blocks/_login.scss
@@ -48,7 +48,6 @@
       path {
         fill: var(--atum-bg-dark);
       }
-
     }
 
     #form-login {
@@ -65,13 +64,17 @@
           text-align: right;
         }
       }
-
     }
 
     #btn-login-submit {
       color: var(--atum-text-light);
       background-color: var(--atum-link-color);
       border-color: var(--atum-link-color);
+
+      @include hover-focus-active {
+        background-color: var(--atum-bg-dark-70);
+        border-color: var(--atum-bg-dark-90);
+      }
     }
   }
 


### PR DESCRIPTION
### Summary of Changes
The admin login button has no background `hover` color.
This PR adds it. Same colors as btn-primary hover


### Testing Instructions
Patch, run npm. Display admin login page.


### Actual result BEFORE applying this Pull Request
Hovering the button does not change the background color.


### Expected result AFTER applying this Pull Request


![hoverloginbutton](https://user-images.githubusercontent.com/869724/86212975-44ec5f80-bb79-11ea-8e34-e4c868f785e2.gif)
