### PR TITLE
[4.0] Add "accept" attribute to the upload file input element of com_joomlaupdate's Upload & Update tab

### DIFF
--- a/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_upload.php
+++ b/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_upload.php
@@ -58,7 +58,7 @@ Text::script('JGLOBAL_SELECTED_UPLOAD_FILE_SIZE', true);
 					<?php echo Text::_('COM_JOOMLAUPDATE_VIEW_UPLOAD_PACKAGE_FILE'); ?>
 				</td>
 				<td>
-					<input class="form-control-file" id="install_package" name="install_package" type="file" size="57" onchange="Joomla.installpackageChange()">
+					<input class="form-control-file" id="install_package" name="install_package" type="file" size="57" accept=".zip,application/zip" onchange="Joomla.installpackageChange()">
 					<?php $maxSizeBytes = Utility::getMaxUploadSize(); ?>
 					<?php $maxSize = HTMLHelper::_('number.bytes', $maxSizeBytes); ?>
 					<input id="max_upload_size" name="max_upload_size" type="hidden" value="<?php echo $maxSizeBytes; ?>" />


### PR DESCRIPTION
Pull Request for Issue #29763 (partly).

### Summary of Changes

This Pull Request adds the "accept" attribute to the file field of the Joomla Update Component's Upload & Update tab so that only zip files with mime type "application/zip" are selectable.

**Important:** This is **NOT** a security fix, it only shall prevent from accidently selecting the wrong file for upload and then getting an error message which is not really user friendly.

See the following description on [https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/accept](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/accept):

> The accept attribute doesn't validate the types of the selected files; it simply provides hints for browsers to guide users towards selecting the correct file types. It is still possible (in most cases) for users to toggle an option in the file chooser that makes it possible to override this and select any file they wish, and then choose incorrect file types.
> 
> Because of this, you should make sure that expected requirement is validated server-side.

I will work on these server-side validations and provide a separate PR.

### Testing Instructions

Will be added soon. Until this has been done I will leave this PR in draft status. As soon as draft status will be removed, the PR can be tested.

### Actual result BEFORE applying this Pull Request

Will be added soon.

### Expected result AFTER applying this Pull Request

Will be added soon.

### Documentation Changes Required

None, I think.