### PR TITLE
Add "accept" attribute to the upload file input element of com_joomlaupdate's Upload & Update tab

### DIFF
--- a/administrator/components/com_joomlaupdate/views/default/tmpl/default_upload.php
+++ b/administrator/components/com_joomlaupdate/views/default/tmpl/default_upload.php
@@ -96,7 +96,7 @@ JFactory::getDocument()->addStyleDeclaration($css);
 					<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_UPLOAD_PACKAGE_FILE'); ?>
 				</td>
 				<td>
-					<input class="input_box" id="install_package" name="install_package" type="file" size="57" /><br>
+					<input class="input_box" id="install_package" name="install_package" type="file" size="57" accept=".zip,application/zip" /><br>
 					<?php $maxSize = JHtml::_('number.bytes', JUtility::getMaxUploadSize()); ?>
 					<?php echo JText::sprintf('JGLOBAL_MAXIMUM_UPLOAD_SIZE_LIMIT', '&#x200E;' . $maxSize); ?>
 				</td>


### PR DESCRIPTION
Pull Request for Issue #29763 (partly).

### Summary of Changes

This Pull Request (PR) adds the "accept" attribute to the file field of the Joomla Update Component's Upload & Update tab so that only zip files with mime type "application/zip" are selectable.

Only zip because currently the Joomla Update Component only supports that packing format for Upload & Update, see also the discussion in comments below. No idea what the other update packages (tar.gz, tar.bz2) are good for. There is no update from folder option or update channel for which they could be used.

**Important:** This is **NOT** a security fix, it only shall make it harder to accidently select the wrong file for upload.

See the following description on [https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/accept](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/accept):

> The accept attribute doesn't validate the types of the selected files; it simply provides hints for browsers to guide users towards selecting the correct file types. It is still possible (in most cases) for users to toggle an option in the file chooser that makes it possible to override this and select any file they wish, and then choose incorrect file types.
> 
> Because of this, you should make sure that expected requirement is validated server-side.

I will work on these server-side validations and provide a separate PR.

Browser support see [https://caniuse.com/#feat=input-file-accept](https://caniuse.com/#feat=input-file-accept).

### Testing Instructions

1. On a clean current staging or recent 3.9 nightly build or a 3.9.19, login to backend and go to "Components -> Joomla Update".

2. Go to the "Upload & Update" tab and use the button right beside "Joomla package file" to select a file for upload.
Result: See section "Actual result BEFORE applying this Pull Request" below.

3. Apply the patch of this PR.

4. Repeat step 2.
Result: See section "Expected result AFTER applying this Pull Request" below.

### Actual result BEFORE applying this Pull Request

A browser dialogue opens which allows you to select a file. It shows all kinds of files in the currently active folder. There is no filter for zip files only.

E.g. on Firefox 77.0.1 (64-Bit) for Windows:
![j3-pr29877_actual](https://user-images.githubusercontent.com/7413183/86256401-95cf7880-bbb8-11ea-9b89-22588484c7d5.png)

### Expected result AFTER applying this Pull Request

A browser dialogue opens which allows you to select a file. Depending on your browser it limits the files being shown to zip files.

E.g. on Firefox 77.0.1 (64-Bit) for Windows:
![j3-pr29877_expected](https://user-images.githubusercontent.com/7413183/86256845-168e7480-bbb9-11ea-83e5-519157855362.png)

### Documentation Changes Required

None, I think.