### PR TITLE
[4.0] Simple correct spelling, and rephrase sentence

### DIFF
--- a/libraries/src/Exception/ExceptionHandler.php
+++ b/libraries/src/Exception/ExceptionHandler.php
@@ -171,8 +171,7 @@ class ExceptionHandler
 			 * $errorRendererError  - the error caused by error renderer
 			 * $error               - the main error
 			 *
-			 * Both we need to show without loosing of a trace information
-			 * So use a bit of magic to merge them.
+			 * We need to show both exceptions, without loss of trace information so use a bit of magic to merge them
 			 *
 			 * Use exception nesting feature: rethrow the exceptions, an exception thrown in a finally block
 			 * will take unhandled exception as previous.

--- a/libraries/src/Exception/ExceptionHandler.php
+++ b/libraries/src/Exception/ExceptionHandler.php
@@ -171,7 +171,7 @@ class ExceptionHandler
 			 * $errorRendererError  - the error caused by error renderer
 			 * $error               - the main error
 			 *
-			 * We need to show both exceptions, without loss of trace information so use a bit of magic to merge them
+			 * We need to show both exceptions, without loss of trace information, so use a bit of magic to merge them.
 			 *
 			 * Use exception nesting feature: rethrow the exceptions, an exception thrown in a finally block
 			 * will take unhandled exception as previous.


### PR DESCRIPTION
### Summary of Changes

Comment changes only - no code changes. 

what started out as a mammoth debugging session on an error message lead me to this class, which lead to me addressing a simple spelling [s/loosing/losing/ ](https://www.grammarly.com/blog/loose-lose/) issue, which turned into a rewrite of the sentence to make it more readable. 

![Unknown](https://user-images.githubusercontent.com/400092/86263008-818b7b80-bbb8-11ea-90fa-d51f26b5acd1.jpeg)
