### PR TITLE
[4.0] convert string of a number to a application name

### DIFF
--- a/libraries/src/Updater/Adapter/ExtensionAdapter.php
+++ b/libraries/src/Updater/Adapter/ExtensionAdapter.php
@@ -330,7 +330,7 @@ class ExtensionAdapter extends UpdateAdapter
 		{
 			if (isset($this->latest->client) && \strlen($this->latest->client))
 			{
-				$this->latest->client_id = ApplicationHelper::getClientInfo($this->latest->client, true)->id;
+				$this->latest->client_id = ApplicationHelper::getClientInfo($this->latest->client, strlen($this->latest->client) > 1)->id;
 
 				unset($this->latest->client);
 			}


### PR DESCRIPTION
Closes #29778.

### Summary of Changes

`$this->latest->client` sometimes contains a numeric string (A PHP String containing a number, as opposed to an PHP type `integer`)  instead of a app name (like 'site', 'administrator' etc) 

This pr correctly sends the bool to `ApplicationHelper::getClientInfo` depending on what the value of `$this->latest->client`  is.

if `$this->latest->client`  = "1" then `strlen($this->latest->client) > 1` would be `false`, meaning `byName` is false. 
if `$this->latest->client`  = "site" then `strlen($this->latest->client) > 1` would be `true`, meaning `byName` is true 

### Testing Instructions

see #29778
Hard to test, will only cause error on FIRST LOAD. 

Install Akeeba Backup using Install From Url method with url 

https://www.akeebabackup.com/download/akeeba-backup/7-2-1/pkg_akeeba-7-2-1-core-zip.zip

After its installed click "Home Dashboard" 

Note that in the update checks the `Checking extensions` has failed 

<img width="653" alt="Screenshot 2020-06-25 at 16 30 52" src="https://user-images.githubusercontent.com/400092/85750106-5230c680-b701-11ea-9242-f8b56f9e946d.png">

### After installing Akeeba, to replicate the issue

Joomla 4 admin 
Click System 
Click Update -> Extensions 
Click Clear Cache
Click Home Dashboard
Inspect the Ajax call 
Note JS Console error `SyntaxError: JSON Parse error: Unrecognized token '<'`


### Actual result BEFORE applying this Pull Request

Note JS Console error `SyntaxError: JSON Parse error: Unrecognized token '<'`

Ajax request with Notices

<img width="792" alt="Screenshot 2020-06-25 at 16 31 42" src="https://user-images.githubusercontent.com/400092/85750172-5fe64c00-b701-11ea-8005-cc29afb07179.png">


php_1        | 192.168.32.5 -  25/Jun/2020:15:27:10 +0000 "GET /administrator/index.php" 200
php_1        | 192.168.32.5 -  25/Jun/2020:15:27:10 +0000 "GET /administrator/index.php" 200
php_1        | NOTICE: PHP message: PHP Notice:  Trying to get property 'id' of non-object in /application/libraries/src/Updater/Adapter/ExtensionAdapter.php on line 333
php_1        | 192.168.32.5 -  25/Jun/2020:15:27:10 +0000 "GET /index.php" 404
php_1        | 192.168.32.5 -  25/Jun/2020:15:27:10 +0000 "GET /index.php" 404
php_1        | NOTICE: PHP message: PHP Notice:  Trying to get property 'id' of non-object in /application/libraries/src/Updater/Adapter/ExtensionAdapter.php on line 333
php_1        | 192.168.32.5 -  25/Jun/2020:15:27:10 +0000 "GET /administrator/index.php" 200
webserver_1  | 2020/06/25 15:27:10 [error] 9#9: *155 FastCGI sent in stderr: "PHP message: PHP Notice:  Trying to get property 'id' of non-object in /application/libraries/src/Updater/Adapter/ExtensionAdapter.php on line 333PHP message: PHP Notice:  Trying to get property 'id' of non-object in /application/libraries/src/Updater/Adapter/ExtensionAdapter.php on line 333" while reading response header from upstream, client: 192.168.32.1, server: , request: "GET /administrator/index.php?option=com_installer&view=update&task=update.ajax&198756102de4392ec83bef34a7d00709=1&cache_timeout=3600&eid=0&skip=212 HTTP/1.1", upstream: "fastcgi://192.168.32.2:9000", host: "127.0.0.1", referrer: "http://127.0.0.1/administrator/index.php"
php_1        | 192.168.32.5 -  25/Jun/2020:15:27:12 +0000 "GET /administrator/index.php" 200


### Expected result AFTER applying this Pull Request

No errors. 

### Documentation Changes Required

None