### PR TITLE
Add missing return statement in com_joomlaupdate controller for Upload & Update

### DIFF
--- a/administrator/components/com_joomlaupdate/controllers/update.php
+++ b/administrator/components/com_joomlaupdate/controllers/update.php
@@ -273,6 +273,8 @@ class JoomlaupdateControllerUpdate extends JControllerLegacy
 		{
 			$url = 'index.php?option=com_joomlaupdate';
 			$this->setRedirect($url, $e->getMessage(), 'error');
+
+			return;
 		}
 
 		$token = JSession::getFormToken();


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This Pull Request (PR) adds a missing return statement to the `upload` function in file `administrator/components/com_joomlaupdate/controllers/update.php`.

### Testing Instructions

Code review should be enough, but if you want to make a real test ...

1. Because it is not easy to cause one of the exceptions in function `upload` of the Joomla Update model, add a line as follows to throw an exception just at the beginning of the function, e.g. here https://github.com/joomla/joomla-cms/blob/staging/administrator/components/com_joomlaupdate/models/default.php#L941
`throw new RuntimeException('THIS IS A TEST', 500);`

2. On a clean current staging or recent 3.9 nightly build or a 3.9.19, login to backend and go to "Components -> Joomla Update".

3. Select any file for upload.
Result: See section "Actual result BEFORE applying this Pull Request" below.

4. Apply the patch of this PR.

5. Repeat steps 2 and 3.
Result: See section "Expected result AFTER applying this Pull Request" below.

### Actual result BEFORE applying this Pull Request

First a 403 "Access forbidden" error is shown.
![snap_1](https://user-images.githubusercontent.com/7413183/86270421-80b01500-bbcb-11ea-93ec-694a535baebc.png)

After that when navigating or using the "Back to Control Panel" button, the alert with the exception message is shown.
![snap_2](https://user-images.githubusercontent.com/7413183/86270495-9b828980-bbcb-11ea-957c-d57790be074d.png)

### Expected result AFTER applying this Pull Request

The alert with the exception message is shown on the Joomla Update Component page. There is no 403 "Access forbidden" error.
![snap_3](https://user-images.githubusercontent.com/7413183/86270914-53179b80-bbcc-11ea-9d16-022a36c12953.png)

### Documentation Changes Required

None.

### Additional information

When doing the test with one of the language strings `COM_INSTALLER_MSG_...` used in one of the exceptions thrown in that function, you will see that these language strings are not trantlated. This is a separate issue not within the scope of this PR. I will later check if there is already an issue or not.

What remains to be clarified is: Shall we make com_joomlaupdate load the strings from com_installer, or shouldn't we better duplicate the necessary strings into the com_joomlaupdate language file and change their name so we have `COM_JOOMLAUPDATE_MSG_...`? @infograf768 What do you think?