### PR TITLE
Add missing return statement in joomlaupdate controller

### DIFF
--- a/administrator/components/com_joomlaupdate/controllers/update.php
+++ b/administrator/components/com_joomlaupdate/controllers/update.php
@@ -273,6 +273,8 @@ class JoomlaupdateControllerUpdate extends JControllerLegacy
 		{
 			$url = 'index.php?option=com_joomlaupdate';
 			$this->setRedirect($url, $e->getMessage(), 'error');
+
+			return;
 		}
 
 		$token = JSession::getFormToken();


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This Pull Request (PR) adds a missing return statement to the `upload` function in file `administrator/components/com_joomlaupdate/controllers/update.php`.

This fixes the issue that a 403 "Not allowed" error happens when an exception is raised by the Joomla Update Component's Upload & Update function when uploading a file fails for some reason.

The issue is valid for J4, too, and will be fixed in J4 when this PR has been merged into staging and later that has been merged up into 4.0-dev.

### Testing Instructions

Code review should be enough, but if you want to make a real test ...

1. On a clean current staging or recent 3.9 nightly build or a 3.9.19, login to backend and go to "Components -> Joomla Update".

2. Go to tab "Upload & Update" and select  zip file with zero byte size for upload.

Hint: You can create a zero size zip file as follows:
- On Linux `touch test.zip`
- In Windows Command Shell (CMD) `copy nul test.zip`

Result: See section "Actual result BEFORE applying this Pull Request" below.

3. Apply the patch of this PR.

4. Repeat steps 1 and 2.

Result: See section "Expected result AFTER applying this Pull Request" below.

### Actual result BEFORE applying this Pull Request

First a 403 "Access forbidden" error is shown.
![snap_1](https://user-images.githubusercontent.com/7413183/86270421-80b01500-bbcb-11ea-93ec-694a535baebc.png)

After that when navigating or using the "Back to Control Panel" button, the alert with the exception message is shown.
![pr-29881_1](https://user-images.githubusercontent.com/7413183/86514768-72086e80-be14-11ea-8a95-b63b4440e084.png)

Hint: The not translated language string will be solved with PR #29899 .

### Expected result AFTER applying this Pull Request

The alert with the exception message is shown on the Joomla Update Component page. There is no 403 "Access forbidden" error.
![pr-29881_2](https://user-images.githubusercontent.com/7413183/86514802-cd3a6100-be14-11ea-948e-33a028d76294.png)

### Documentation Changes Required

None.

### Additional information

When doing the test with one of the language strings `COM_INSTALLER_MSG_...` used in one of the exceptions thrown in that function, you will see that these language strings are not trantlated. This is a separate issue not within the scope of this PR. I will later check if there is already an issue or not.

What remains to be clarified is: Shall we make com_joomlaupdate load the strings from com_installer, or shouldn't we better duplicate the necessary strings into the com_joomlaupdate language file and change their name so we have `COM_JOOMLAUPDATE_MSG_...`? @infograf768 What do you think?