### PR TITLE
[4.0] Correct @param docblock parameter types

### DIFF
--- a/libraries/src/Application/ApplicationHelper.php
+++ b/libraries/src/Application/ApplicationHelper.php
@@ -114,7 +114,7 @@ class ApplicationHelper
 	 * with no arguments which can be used to add custom application information.
 	 *
 	 * @param   integer|string|null		$id      A client identifier
-	 * @param   boolean					$byName  If true, find the client by its name
+	 * @param   boolean			$byName  If true, find the client by its name
 	 *
 	 * @return  \stdClass|array|void  	Object describing the client, array containing all the clients or void if $id not known
 	 *

--- a/libraries/src/Application/ApplicationHelper.php
+++ b/libraries/src/Application/ApplicationHelper.php
@@ -113,10 +113,10 @@ class ApplicationHelper
 	 * This method will return a client information array if called
 	 * with no arguments which can be used to add custom application information.
 	 *
-	 * @param   integer|string|null		$id      A client identifier
-	 * @param   boolean			$byName  If true, find the client by its name
+	 * @param   integer|string|null   $id      A client identifier
+	 * @param   boolean               $byName  If true, find the client by its name
 	 *
-	 * @return  \stdClass|array|void  	Object describing the client, array containing all the clients or void if $id not known
+	 * @return  \stdClass|array|void  Object describing the client, array containing all the clients or void if $id not known
 	 *
 	 * @since   1.5
 	 */

--- a/libraries/src/Application/ApplicationHelper.php
+++ b/libraries/src/Application/ApplicationHelper.php
@@ -113,7 +113,7 @@ class ApplicationHelper
 	 * This method will return a client information array if called
 	 * with no arguments which can be used to add custom application information.
 	 *
-	 * @param   integer|string  $id      A client identifier
+	 * @param   integer|string	$id      A client identifier
 	 * @param   boolean  		$byName  If True, find the client by its name
 	 *
 	 * @return  mixed  Object describing the client or false if not known

--- a/libraries/src/Application/ApplicationHelper.php
+++ b/libraries/src/Application/ApplicationHelper.php
@@ -113,10 +113,10 @@ class ApplicationHelper
 	 * This method will return a client information array if called
 	 * with no arguments which can be used to add custom application information.
 	 *
-	 * @param   integer|string	$id      A client identifier
-	 * @param   boolean  		$byName  If True, find the client by its name
+	 * @param   integer|string|null		$id      A client identifier
+	 * @param   boolean  				$byName  If true, find the client by its name
 	 *
-	 * @return  mixed  Object describing the client or false if not known
+	 * @return  \stdClass|array|void  	Object describing the client, array containing all the clients or void if $id not known
 	 *
 	 * @since   1.5
 	 */

--- a/libraries/src/Application/ApplicationHelper.php
+++ b/libraries/src/Application/ApplicationHelper.php
@@ -113,8 +113,8 @@ class ApplicationHelper
 	 * This method will return a client information array if called
 	 * with no arguments which can be used to add custom application information.
 	 *
-	 * @param   integer  $id      A client identifier
-	 * @param   boolean  $byName  If True, find the client by its name
+	 * @param   integer|string  $id      A client identifier
+	 * @param   boolean  		$byName  If True, find the client by its name
 	 *
 	 * @return  mixed  Object describing the client or false if not known
 	 *

--- a/libraries/src/Application/ApplicationHelper.php
+++ b/libraries/src/Application/ApplicationHelper.php
@@ -114,7 +114,7 @@ class ApplicationHelper
 	 * with no arguments which can be used to add custom application information.
 	 *
 	 * @param   integer|string|null		$id      A client identifier
-	 * @param   boolean  				$byName  If true, find the client by its name
+	 * @param   boolean					$byName  If true, find the client by its name
 	 *
 	 * @return  \stdClass|array|void  	Object describing the client, array containing all the clients or void if $id not known
 	 *


### PR DESCRIPTION
### Summary of Changes

Method signature changes in docblock only, no code changes

### Actual result BEFORE applying this Pull Request

The docblock documented that `$id` could only be an integer

This is factually incorrect as evidenced by the second param `$byName` which is a bool that says if the `$id` is the name (i.e. a string "site/administrator/api/cli etc") then to handle it differently than an integer client id. 

There are many places in code where $id is provided as a string of the name and `$byName` is set to true, further proving the documentation to be incorrect. 

### Documentation Changes Required

None. 