### PR TITLE
[4.0] Handle if this method is incorrectly called 

### DIFF
--- a/libraries/src/Application/ApplicationHelper.php
+++ b/libraries/src/Application/ApplicationHelper.php
@@ -186,7 +186,7 @@ class ApplicationHelper
 		/**
 		 * Handle if this method is incorrectly called with $id = 1/2/3/4 and $byName = true
 		 * @deprecated	Short Term Compatibility with Joomla 3 extension XML's using int's as ids - Remove in 5.0
-		 * @see 		https://github.com/joomla/joomla-cms/pull/29879
+		 * @see			https://github.com/joomla/joomla-cms/pull/29879
 		 */
 		if (strlen((int) $id) === 1 && in_array((int) $id, [1,2,3,4]))
 		{

--- a/libraries/src/Application/ApplicationHelper.php
+++ b/libraries/src/Application/ApplicationHelper.php
@@ -186,7 +186,7 @@ class ApplicationHelper
 		/**
 		 * Handle if this method is incorrectly called with $id = 1/2/3/4 and $byName = true
 		 * @deprecated	Short Term Compatibility with Joomla 3 extension XML's using int's as ids - Remove in 5.0
-		 * @see			https://github.com/joomla/joomla-cms/pull/29879
+		 * @see		https://github.com/joomla/joomla-cms/pull/29879
 		 */
 		if (strlen((int) $id) === 1 && in_array((int) $id, [1,2,3,4]))
 		{

--- a/libraries/src/Application/ApplicationHelper.php
+++ b/libraries/src/Application/ApplicationHelper.php
@@ -183,6 +183,16 @@ class ApplicationHelper
 			}
 		}
 
+		/**
+		 * Handle if this method is incorrectly called with $id = 1/2/3/4 and $byName = true
+		 * @deprecated	Short Term Compatibility with Joomla 3 extension XML's using int's as ids - Remove in 5.0
+		 * @see 		https://github.com/joomla/joomla-cms/pull/29879
+		 */
+		if (strlen((int) $id) === 1 && in_array((int) $id, [1,2,3,4]))
+		{
+			return self::$_clients[$id];
+		}
+
 		return;
 	}
 


### PR DESCRIPTION
Closes #29778
Alternative to Closes #29879

### Summary of Changes

read history in comments of #29879 

Joomla 4 expects developers to use names and not integers for client id

>The code was changed in J4 to remove the deprecated behaviour of using numbers see https://docs.joomla.org/Potential_backward_compatibility_issues_in_Joomla_4#Updater

> The use of numbers was marked as deprecated and documented here in 2012 https://docs.joomla.org/Design_of_JUpdate#Client_versus_Client_ID

If you install an extension that still uses ids then PHP notices can be rendered 

This is an alternative to #29879 

### Testing Instructions

see  #29879 

Install Akeeba Backup using Install From Url method with url 

https://www.akeebabackup.com/download/akeeba-backup/7-2-1/pkg_akeeba-7-2-1-core-zip.zip

After its installed click "Home Dashboard" 

Note that in the update checks the `Checking extensions` has failed 

<img width="653" alt="Screenshot 2020-06-25 at 16 30 52" src="https://user-images.githubusercontent.com/400092/85750106-5230c680-b701-11ea-9242-f8b56f9e946d.png">

### After installing Akeeba, to replicate the issue

Joomla 4 admin 
Click System 
Click Update -> Extensions 
Click Clear Cache
Click Home Dashboard
Inspect the Ajax call 
Note JS Console error `SyntaxError: JSON Parse error: Unrecognized token '<'`

### Actual result BEFORE applying this Pull Request

Note JS Console error `SyntaxError: JSON Parse error: Unrecognized token '<'`

Ajax request with Notices

<img width="792" alt="Screenshot 2020-06-25 at 16 31 42" src="https://user-images.githubusercontent.com/400092/85750172-5fe64c00-b701-11ea-8005-cc29afb07179.png">


php_1        | 192.168.32.5 -  25/Jun/2020:15:27:10 +0000 "GET /administrator/index.php" 200
php_1        | 192.168.32.5 -  25/Jun/2020:15:27:10 +0000 "GET /administrator/index.php" 200
php_1        | NOTICE: PHP message: PHP Notice:  Trying to get property 'id' of non-object in /application/libraries/src/Updater/Adapter/ExtensionAdapter.php on line 333
php_1        | 192.168.32.5 -  25/Jun/2020:15:27:10 +0000 "GET /index.php" 404
php_1        | 192.168.32.5 -  25/Jun/2020:15:27:10 +0000 "GET /index.php" 404
php_1        | NOTICE: PHP message: PHP Notice:  Trying to get property 'id' of non-object in /application/libraries/src/Updater/Adapter/ExtensionAdapter.php on line 333
php_1        | 192.168.32.5 -  25/Jun/2020:15:27:10 +0000 "GET /administrator/index.php" 200
webserver_1  | 2020/06/25 15:27:10 [error] 9#9: *155 FastCGI sent in stderr: "PHP message: PHP Notice:  Trying to get property 'id' of non-object in /application/libraries/src/Updater/Adapter/ExtensionAdapter.php on line 333PHP message: PHP Notice:  Trying to get property 'id' of non-object in /application/libraries/src/Updater/Adapter/ExtensionAdapter.php on line 333" while reading response header from upstream, client: 192.168.32.1, server: , request: "GET /administrator/index.php?option=com_installer&view=update&task=update.ajax&198756102de4392ec83bef34a7d00709=1&cache_timeout=3600&eid=0&skip=212 HTTP/1.1", upstream: "fastcgi://192.168.32.2:9000", host: "127.0.0.1", referrer: "http://127.0.0.1/administrator/index.php"
php_1        | 192.168.32.5 -  25/Jun/2020:15:27:12 +0000 "GET /administrator/index.php" 200


### Expected result AFTER applying this Pull Request

No errors. 

### Documentation Changes Required

Maybe