### PR TITLE
[POC] Implement layout fallback for core fields

### DIFF
--- a/libraries/joomla/form/fields/radio.php
+++ b/libraries/joomla/form/fields/radio.php
@@ -7,6 +7,8 @@
  * @license     GNU General Public License version 2 or later; see LICENSE
  */
 
+use Joomla\CMS\Layout\FileLayout;
+
 defined('JPATH_PLATFORM') or die;
 
 JFormHelper::loadFieldClass('list');
@@ -29,12 +31,12 @@ class JFormFieldRadio extends JFormFieldList
 	protected $type = 'Radio';
 
 	/**
-	 * Name of the layout being used to render the field
+	 * Name of the core layout being used as fallback
 	 *
 	 * @var    string
-	 * @since  3.5
+	 * @since  __DEPLOY_VERSION__
 	 */
-	protected $layout = 'joomla.form.field.radio';
+	protected $defaultLayout = 'joomla.form.field.radio';
 
 	/**
 	 * Method to get the radio button field input markup.
@@ -45,12 +47,19 @@ class JFormFieldRadio extends JFormFieldList
 	 */
 	protected function getInput()
 	{
-		if (empty($this->layout))
+		$layoutExists = null;
+
+		if (!empty($this->layout))
 		{
-			throw new UnexpectedValueException(sprintf('%s has no layout assigned.', $this->name));
+			$layoutExists = $this->checkLayoutExists($this->layout);
 		}
 
-		return $this->getRenderer($this->layout)->render($this->getLayoutData());
+		if ($layoutExists instanceof FileLayout)
+		{
+			return $layoutExists->render($this->getLayoutData());
+		}
+
+		return $this->getRenderer($this->defaultLayout)->render($this->getLayoutData());
 	}
 
 	/**

--- a/libraries/src/Form/FormField.php
+++ b/libraries/src/Form/FormField.php
@@ -324,6 +324,14 @@ abstract class FormField
 	protected static $generated_fieldname = '__field';
 
 	/**
+	 * Name of the core layout being used as fallback
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $defaultLayout;
+
+	/**
 	 * Name of the layout being used to render the field
 	 *
 	 * @var    string
@@ -717,12 +725,24 @@ abstract class FormField
 	 */
 	protected function getInput()
 	{
-		if (empty($this->layout))
+		$layoutExists = false;
+
+		if (!empty($this->layout))
+		{
+			$layoutExists = $this->checkLayoutExists($this->layout);
+		}
+
+		if ($layoutExists instanceof FileLayout)
+		{
+			return $layoutExists->render($this->getLayoutData());
+		}
+
+		if (empty($this->defaultLayout))
 		{
 			throw new \UnexpectedValueException(sprintf('%s has no layout assigned.', $this->name));
 		}
 
-		return $this->getRenderer($this->layout)->render($this->getLayoutData());
+		return $this->getRenderer($this->defaultLayout)->render($this->getLayoutData());
 	}
 
 	/**
@@ -1065,6 +1085,29 @@ abstract class FormField
 		}
 
 		return $renderer;
+	}
+
+	/**
+	 * Check if the layout exists
+	 *
+	 * @param   string  $layoutId  Id to load
+	 *
+	 * @return  mixed  FileLayout or null
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function checkLayoutExists($layoutId = 'default')
+	{
+		$renderer = $this->getRenderer($layoutId);
+
+		$layoutFileExists = $renderer->checkLayoutExists();
+
+		if ($layoutFileExists)
+		{
+			return $renderer;
+		}
+
+		return;
 	}
 
 	/**

--- a/libraries/src/Layout/FileLayout.php
+++ b/libraries/src/Layout/FileLayout.php
@@ -80,7 +80,7 @@ class FileLayout extends BaseLayout
 		$this->setLayout($layoutId);
 		$this->basePath = $basePath;
 
-		// Init Enviroment
+		// Init Environment
 		$this->setComponent($this->options->get('component', 'auto'));
 		$this->setClient($this->options->get('client', 'auto'));
 	}
@@ -600,7 +600,7 @@ class FileLayout extends BaseLayout
 			}
 		}
 
-		// (4) Standard Joomla! layouts overriden
+		// (4) Standard Joomla! layouts overridden
 		$paths[] = JPATH_THEMES . '/' . \JFactory::getApplication()->getTemplate() . '/html/layouts';
 
 		// (5 - lower priority) Frontend base layouts
@@ -664,4 +664,19 @@ class FileLayout extends BaseLayout
 
 		return $sublayout->render($displayData);
 	}
+
+	/**
+	 * Check if the layout file  exists
+	 *
+	 * @return  bool
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function checkLayoutExists()
+	{
+		$layoutPath = $this->getPath();
+
+		return (!empty($layoutPath));
+	}
+
 }


### PR DESCRIPTION
### Summary of Changes

With this PR we implement an fallback to the default layout in order to better support 3.9 and 4.x at the same time.

The idea behind this is:
Developers should be able to use the same manifest file for their extensions and at the same time have the possibility to use the new layouts from Joomla 4 without having problems in Joomla 3.

### Testing Instructions

- install the attached dummy [plugin](https://github.com/joomla/joomla-cms/files/4866412/plg_content_testmanifest.zip) on joomla 3 
- check the plugin configuration page on `Extensions->Plugins->Content - Testmanifest`
- apply this patch
- check again
- install the same [plugin](https://github.com/joomla/joomla-cms/files/4866412/plg_content_testmanifest.zip) on joomla 4
- check the plugin configuration page


### Actual result BEFORE applying this Pull Request

On Joomla 3 the radio field is not rendered as we try to use the switch layout of Joomla 4.

![before_pr](https://user-images.githubusercontent.com/10517822/86404675-52583580-bcb0-11ea-93c2-3b4396d2e3e4.png)


### Expected result AFTER applying this Pull Request

With the changes applied in Joomla 3 the field fallbacks to the default layout when the supplied layout is not found. So we dont end up with a empty field view.

![after_pr](https://user-images.githubusercontent.com/10517822/86404708-600dbb00-bcb0-11ea-9926-a5e9efc0182f.png)


### Documentation Changes Required

None.



### POC

This is a POC with the radio field and for the base FormField. When this here is ok similiar changes will be done in a sperate PR for the other fields too.


