### PR TITLE
[4.0] Install from url messages

### DIFF
--- a/administrator/components/com_installer/tmpl/install/default.php
+++ b/administrator/components/com_installer/tmpl/install/default.php
@@ -14,6 +14,12 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 
+// Load JavaScript message titles
+Text::script('ERROR');
+Text::script('WARNING');
+Text::script('NOTICE');
+Text::script('MESSAGE');
+
 Text::script('PLG_INSTALLER_PACKAGEINSTALLER_NO_PACKAGE');
 Text::script('PLG_INSTALLER_FOLDERINSTALLER_NO_INSTALL_PATH');
 Text::script('PLG_INSTALLER_URLINSTALLER_NO_URL');


### PR DESCRIPTION
Ensure that the language strings for the message titles are available to javascript and can be translated

fixes #29887

go to Install from URL tab
leave the URL field blank
Click Check and Install
Note the alert at the top of the page: warning LowerCase W

apply the patch and its now correct
