### PR TITLE
[4.0] Wrong language string selected when creating overrides

### DIFF
--- a/build/media_source/com_languages/js/overrider.es6.js
+++ b/build/media_source/com_languages/js/overrider.es6.js
@@ -170,7 +170,7 @@
       // Create some elements for each result and insert it into the container
       results.forEach((item, index) => {
         const a = document.createElement('a');
-        a.setAttribute('onclick', `Joomla.overrider.selectString(${this.states.counter + index});`);
+        a.setAttribute('onclick', `Joomla.overrider.selectString(${this.states.counter}${index});`);
         a.setAttribute('href', '#');
         a.classList.add('list-group-item');
         a.classList.add('list-group-item-action');
@@ -178,13 +178,13 @@
         a.classList.add('align-items-start');
 
         const key = document.createElement('div');
-        key.setAttribute('id', `override_key${this.states.counter + index}`);
+        key.setAttribute('id', `override_key${this.states.counter}${index}`);
         key.setAttribute('title', item.file);
         key.classList.add('result-key');
         key.innerHTML = item.constant;
 
         const string = document.createElement('div');
-        string.setAttribute('id', `override_string${this.states.counter + index}`);
+        string.setAttribute('id', `override_string${this.states.counter}${index}`);
         string.classList.add('result-string');
         string.innerHTML = item.string;
 


### PR DESCRIPTION
Fixes https://github.com/joomla/joomla-cms/issues/29891.

### Summary of Changes

Corrects IDs.

### Testing Instructions

`node build.js --compile-js` required.

Go to create a Language Override.
Search for a word or phrase that has more than one page of results (e.g. Joomla).
Click on `More Results` button.
Click on one of the newly loaded results (e.g. `LIB_JOOMLA_XML_DESCRIPTION`).

### Actual result BEFORE applying this Pull Request

Form fields filled with `LIB_JOOMLA_XML_DESCRIPTION` constants and its corresponding string.

### Expected result AFTER applying this Pull Request

Form fields filled with result from first page (e.g. `COM_MEDIA_DESCFTP`).

### Documentation Changes Required

No.