### PR TITLE
[4.0] Hide and disable "More Results" button in Language Overrides when no more results

### DIFF
--- a/administrator/components/com_languages/tmpl/override/edit.php
+++ b/administrator/components/com_languages/tmpl/override/edit.php
@@ -80,7 +80,7 @@ $wa->useScript('keepalive')
 				<legend><?php echo Text::_('COM_LANGUAGES_VIEW_OVERRIDE_RESULTS_LEGEND'); ?></legend>
 				<div id="overrider-spinner" class="overrider-spinner text-center" data-search-string-expired="<?php echo $expired; ?>"><span class="fas fa-spinner fa-spin" aria-hidden="true"></span></div>
 				<span id="more-results" class="mt-2">
-					<button type="button" id="more-results-button" class="btn btn-secondary">
+					<button type="button" id="more-results-button" class="btn btn-secondary" disabled>
 						<span id="overrider-spinner-btn" class="overrider-spinner-btn fas fa-spinner fa-spin" aria-hidden="true"></span>
 						<?php echo Text::_('COM_LANGUAGES_VIEW_OVERRIDE_MORE_RESULTS'); ?>
 					</button>

--- a/build/media_source/com_languages/js/overrider.es6.js
+++ b/build/media_source/com_languages/js/overrider.es6.js
@@ -134,8 +134,7 @@
               this.states.more = response.data.more;
               this.moreResultsButton.disabled = false;
               this.moreResults.classList.add('show');
-            }
-            else {
+            } else {
               this.moreResultsButton.disabled = true;
               this.moreResults.classList.remove('show');
             }

--- a/build/media_source/com_languages/js/overrider.es6.js
+++ b/build/media_source/com_languages/js/overrider.es6.js
@@ -135,8 +135,7 @@
               this.moreResultsButton.disabled = false;
               this.moreResults.classList.add('show');
             }
-            else
-            {
+            else {
               this.moreResultsButton.disabled = true;
               this.moreResults.classList.remove('show');
             }

--- a/build/media_source/com_languages/js/overrider.es6.js
+++ b/build/media_source/com_languages/js/overrider.es6.js
@@ -133,6 +133,10 @@
               this.states.more = response.data.more;
               this.moreResults.classList.add('show');
             }
+            else
+            {
+              this.moreResults.classList.remove('show');
+            }
           }
 
           this.spinnerBtn.classList.remove('show');

--- a/build/media_source/com_languages/js/overrider.es6.js
+++ b/build/media_source/com_languages/js/overrider.es6.js
@@ -15,6 +15,7 @@
       this.spinner = document.getElementById('overrider-spinner');
       this.spinnerBtn = document.getElementById('overrider-spinner-btn');
       this.moreResults = document.getElementById('more-results');
+      this.moreResultsButton = document.getElementById('more-results-button');
       this.resultsContainer = document.getElementById('results-container');
       this.refreshStatus = document.getElementById('refresh-status');
     }
@@ -131,10 +132,12 @@
               // If there are more results than the sent ones
               // display the more link
               this.states.more = response.data.more;
+              this.moreResultsButton.disabled = false;
               this.moreResults.classList.add('show');
             }
             else
             {
+              this.moreResultsButton.disabled = true;
               this.moreResults.classList.remove('show');
             }
           }
@@ -144,6 +147,7 @@
         },
         onError: () => {
           alert(Joomla.JText._('COM_LANGUAGES_VIEW_OVERRIDE_REQUEST_ERROR'));
+          this.moreResultsButton.disabled = true;
           this.moreResults.classList.remove('show');
           this.resultsContainer.classList.remove('show');
         },


### PR DESCRIPTION
### Summary of Changes

Hides and disables "More Results" button when there are no more results.

### Testing Instructions

Requires `node build.js --compile-js`.

Go to create a Language Override.
Select `English (United Kingdom) - Site` language and client.
Search for a term that returns multiple pages, e.g. `Version`.
Keep clicking on "More Results" button.

### Actual result BEFORE applying this Pull Request

Button is always clickable. When on last page, the same results keep getting returned.

### Expected result AFTER applying this Pull Request

Button is clickable while there are unique pages and then disappears.

### Documentation Changes Required

No.