### PR TITLE
Trigger an event when a repeatable-subform is sorted

### DIFF
--- a/media/system/js/subform-repeatable-uncompressed.js
+++ b/media/system/js/subform-repeatable-uncompressed.js
@@ -56,7 +56,11 @@
 			this.$containerRows.sortable({
 				items: this.options.repeatableElement,
 				handle: this.options.btMove,
-				tolerance: 'pointer'
+				tolerance: 'pointer',
+				update: function (event, ui) {
+            				var $row = ui.item[0];
+            				self.$container.trigger('subform-row-sort', $row);
+        			}
 			});
 		}
 

--- a/media/system/js/subform-repeatable-uncompressed.js
+++ b/media/system/js/subform-repeatable-uncompressed.js
@@ -57,7 +57,7 @@
 				items: this.options.repeatableElement,
 				handle: this.options.btMove,
 				tolerance: 'pointer',
-				update: function (event, ui) {
+				stop: function (event, ui) {
             				var $row = ui.item[0];
             				self.$container.trigger('subform-row-sort', $row);
         			}


### PR DESCRIPTION
Pull Request for Issue #24343 (Part 1 of 2)

### Summary of Changes
This PR adds a configuration option to the sortable function to trigger a "subform-row-sort" event when a repeatable subform is sorted.

### Testing Instructions
After applying the PR, make a copy of the file. Delete the media/system/js/subform-repeatable.js, and rename the copy to media/system/js/subform-repeatable.js

On the bottom of the file, under
```javascript
$(document).on('subform-row-add', initSubform);
```
add

```javascript
$(document).on('subform-row-sort', function (event, row) {
    console.log(row);
});
```

In Content -> Fields, create a new Field with the **Type** _Repeatable_. Give the Field a name, eg: _Repeat Text_. Create a **Form Field** of type _Text_ and give it a name.

Assign the field to **Category** _All_ and **Field Group** _None_.

Click **Save & Close**.

Create a new article to edit, click on the Fields tab. Click on the plus icon twice in Text Repeat to create 2 new Text fields.

Open your browsers javascript console.

Drag the bottom field using the blue handle to re-order it above the top field. When this is done you should see a message in the browser's Console.

After conducting the test, remove the logging script, ie: 

```javascript
$(document).on('subform-row-sort', function (event, row) {
    console.log(row);
});
```

### Actual result BEFORE applying this Pull Request
No message is disaplyed in the browser console as not sort event is triggered.


### Expected result AFTER applying this Pull Request
A sort event is triggered and a message is displayed in the browser console.


### Documentation Changes Required
None.