### PR TITLE
[4.0] Missing icon

### DIFF
--- a/administrator/components/com_joomlaupdate/src/View/Joomlaupdate/HtmlView.php
+++ b/administrator/components/com_joomlaupdate/src/View/Joomlaupdate/HtmlView.php
@@ -123,7 +123,7 @@ class HtmlView extends BaseHtmlView
 
 		// Set the toolbar information.
 		ToolbarHelper::title(Text::_('COM_JOOMLAUPDATE_OVERVIEW'), 'joomla install');
-		ToolbarHelper::custom('update.purge', 'sync', 'sync', 'COM_JOOMLAUPDATE_TOOLBAR_CHECK', false);
+		ToolbarHelper::custom('update.purge', 'loop', 'loop', 'COM_JOOMLAUPDATE_TOOLBAR_CHECK', false);
 
 		// Add toolbar buttons.
 		if (Factory::getUser()->authorise('core.admin'))


### PR DESCRIPTION
Since the merge of #28075 the icon is missing in the toolbar for joomla update
@N6REJ please check that I made the correct change

### Before
![image](https://user-images.githubusercontent.com/1296369/86350004-ea770000-bc59-11ea-9636-ab92dc3bf622.png)

![image](https://user-images.githubusercontent.com/1296369/86350026-f4006800-bc59-11ea-9a07-c3e9e22f4119.png)

### After
![image](https://user-images.githubusercontent.com/1296369/86350381-7e48cc00-bc5a-11ea-8584-bc07cbe87d9b.png)

![image](https://user-images.githubusercontent.com/1296369/86350400-86a10700-bc5a-11ea-85f8-6fc3bf30024e.png)
