### PR TITLE
[4.0] Discover extensions [a11y]

### DIFF
--- a/administrator/components/com_installer/tmpl/discover/default.php
+++ b/administrator/components/com_installer/tmpl/discover/default.php
@@ -82,13 +82,11 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 						<?php foreach ($this->items as $i => $item) : ?>
 							<tr class="row<?php echo $i % 2; ?>">
 								<td class="text-center">
-									<?php echo HTMLHelper::_('grid.id', $i, $item->extension_id); ?>
+									<?php echo HTMLHelper::_('grid.id', $i, $item->extension_id, false, 'cid', 'cb', $item->name); ?>
 								</td>
 								<th scope="row">
-									<label for="cb<?php echo $i; ?>">
-										<?php echo $item->name; ?>
-										<div class="small"><?php echo $item->description; ?></div>
-									</label>
+									<?php echo $item->name; ?>
+									<div class="small"><?php echo $item->description; ?></div>
 								</th>
 								<td class="d-none d-md-table-cell">
 									<?php echo $item->client_translated; ?>


### PR DESCRIPTION
The select checkbox had two labels and the label for all checkboxes was identical.

To test make sure you have an extension listed as discoverable (I deleted a plugin from the extensions table to test)

The checkbox only has a label "Select" and the name of the extension is also a label.

After this PR the second label tag is removed and the first label says "Select <extension name">

See screenshots
### Before
![image](https://user-images.githubusercontent.com/1296369/86363587-f9b47880-bc6e-11ea-9c1f-562ca01439f9.png)


### After
![image](https://user-images.githubusercontent.com/1296369/86363536-e73a3f00-bc6e-11ea-980e-5ba1d34e7b2b.png)
