### PR TITLE
[4.0] com_redirect bulk import [a11y]

### DIFF
--- a/administrator/components/com_redirect/tmpl/links/default_batch_body.php
+++ b/administrator/components/com_redirect/tmpl/links/default_batch_body.php
@@ -18,7 +18,7 @@ $separator = $params->get('separator', '|');
 <div class="container">
 	<div class="row">
 		<div class="control-group col-md-12">
-			<label for="batch_urls"><?php echo Text::sprintf('COM_REDIRECT_BATCH_TIP', $separator); ?></labels>
+			<label for="batch_urls"><?php echo Text::sprintf('COM_REDIRECT_BATCH_TIP', $separator); ?></label>
 			<div class="controls">
 				<textarea class="col-md-12" rows="10" value="" id="batch_urls" name="batch_urls"></textarea>
 			</div>

--- a/administrator/components/com_redirect/tmpl/links/default_batch_body.php
+++ b/administrator/components/com_redirect/tmpl/links/default_batch_body.php
@@ -18,7 +18,7 @@ $separator = $params->get('separator', '|');
 <div class="container">
 	<div class="row">
 		<div class="control-group col-md-12">
-			<p><?php echo Text::sprintf('COM_REDIRECT_BATCH_TIP', $separator); ?></p>
+			<label for="batch_urls"><?php echo Text::sprintf('COM_REDIRECT_BATCH_TIP', $separator); ?></labels>
 			<div class="controls">
 				<textarea class="col-md-12" rows="10" value="" id="batch_urls" name="batch_urls"></textarea>
 			</div>


### PR DESCRIPTION
Every input must have a label.

This PR changes the text in the bulk import modal from a `<p>` to a `<label>`

There is no visual change
