### PR TITLE
[4.0] Change in Installation form for showing Congratulations-Section after skip installation of additional language

### DIFF
--- a/installation/template/js/remove.js
+++ b/installation/template/js/remove.js
@@ -19,9 +19,13 @@ if (document.getElementById('installAddFeatures')) {
 if (document.getElementById('skipLanguages')) {
 	document.getElementById('skipLanguages').addEventListener('click', function(e) {
 		e.preventDefault();
+        document.getElementById('installCongrat').classList.add('active');
 		document.getElementById('installFinal').classList.add('active');
 		document.getElementById('installRecommended').classList.add('active');
 		document.getElementById('installLanguages').classList.remove('active');
+        if (document.getElementById('installFinal')) {
+          document.getElementById('installFinal').focus();
+        }
 	})
 }
 

--- a/installation/template/js/remove.js
+++ b/installation/template/js/remove.js
@@ -19,13 +19,14 @@ if (document.getElementById('installAddFeatures')) {
 if (document.getElementById('skipLanguages')) {
 	document.getElementById('skipLanguages').addEventListener('click', function(e) {
 		e.preventDefault();
-        document.getElementById('installCongrat').classList.add('active');
+		document.getElementById('installCongrat').classList.add('active');
 		document.getElementById('installFinal').classList.add('active');
 		document.getElementById('installRecommended').classList.add('active');
 		document.getElementById('installLanguages').classList.remove('active');
-        if (document.getElementById('installFinal')) {
-          document.getElementById('installFinal').focus();
-        }
+
+		if (document.getElementById('installFinal')) {
+			document.getElementById('installFinal').focus();
+		}
 	})
 }
 


### PR DESCRIPTION
Pull Request for Issue # https://github.com/joomla/joomla-cms/issues/29896.

### Summary of Changes
Show Congratulations-Section after skip the installation of a additional language and focus on the Final-Section.


### Testing Instructions

1. Install a clean 4.0-dev.
2. When you get to the first screen which lets you Install Additional Languages, click to install a new language.
3. Do not select a language
4. Click on the skip button at the end of the page.


Without this patch you do not see the Congratulations-Section again. So you are not possible to change your mind and install another language.
With the patch you can scroll to the Congratulations-Section if you want to. 