### PR TITLE
[4.0] batch user field label [a11y]

### DIFF
--- a/layouts/joomla/html/batch/user.php
+++ b/layouts/joomla/html/batch/user.php
@@ -28,7 +28,7 @@ if ($noUser)
 	$optionNo = '<option value="0">' . Text::_('JLIB_HTML_BATCH_USER_NOUSER') . '</option>';
 }
 ?>
-<label id="batch-user-lbl" for="batch-user">
+<label id="batch-user-lbl" for="batch-user-id">
 	<?php echo Text::_('JLIB_HTML_BATCH_USER_LABEL'); ?>
 </label>
 <select name="batch[user_id]" class="custom-select" id="batch-user-id">


### PR DESCRIPTION
the label had the wrong `for=`

This pr corrects that so that the label is correctly marked to be for the select with the id batch-user-id

code review should be ok
