### PR TITLE
[4.0] calendar field [a11y]

### DIFF
--- a/layouts/joomla/form/field/calendar.php
+++ b/layouts/joomla/form/field/calendar.php
@@ -134,7 +134,9 @@ $document->getWebAssetManager()
 				<?php echo isset($minYear) && strlen($minYear) ? 'data-min-year="' . $minYear . '"' : ''; ?>
 				<?php echo isset($maxYear) && strlen($maxYear) ? 'data-max-year="' . $maxYear . '"' : ''; ?>
 				title="<?php echo Text::_('JLIB_HTML_BEHAVIOR_OPEN_CALENDAR'); ?>"
-			><span class="fas fa-calendar" aria-hidden="true"></span></button>
+			><span class="fas fa-calendar" aria-hidden="true"></span>
+			<span class="sr-only"><?php echo Text::_('JLIB_HTML_BEHAVIOR_OPEN_CALENDAR'); ?></span>
+			</button>
 		</span>
 		<?php if (!$readonly && !$disabled) : ?>
 	</div>


### PR DESCRIPTION
After reports from webaim and checking with Bruce Lawson it is not safe to rely on a "title" attribute to provide the required text for assistive technology.

In this PR the text from the title is now also present as sr-only text. The title is kept so that sighted users have a textual description of the button on hover

Code Review