### PR TITLE
[4.0] com_banner batch client [a11y]

### DIFF
--- a/administrator/components/com_banners/src/Service/Html/Banner.php
+++ b/administrator/components/com_banners/src/Service/Html/Banner.php
@@ -35,7 +35,7 @@ class Banner
 		return implode(
 			"\n",
 			array(
-				'<label id="batch-client-lbl" for="batch-client">',
+				'<label id="batch-client-lbl" for="batch-client-id">',
 				Text::_('COM_BANNERS_BATCH_CLIENT_LABEL'),
 				'</label>',
 				'<select class="custom-select" name="batch[client_id]" id="batch-client-id">',


### PR DESCRIPTION
the label had the wrong for=

This pr corrects that so that the label is correctly marked to be for the select with the id batch-client-id

code review should be ok
