### PR TITLE
[4.0] contact misc info [a11y]

### DIFF
--- a/administrator/components/com_contact/tmpl/contact/edit.php
+++ b/administrator/components/com_contact/tmpl/contact/edit.php
@@ -91,7 +91,8 @@ $tmpl    = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=c
 				<fieldset id="fieldset-misc" class="options-form">
 					<legend><?php echo $this->form->getField('misc')->title; ?></legend>
 					<div>
-					<?php echo $this->form->getInput('misc'); ?>
+						<?php echo $this->form->getLabel('misc'); ?>
+						<?php echo $this->form->getInput('misc'); ?>
 					</div>
 				</fieldset>
 			</div>


### PR DESCRIPTION
Every input must have a label. The misc info editor did not and this PR resolves that in exactly the same way as with other editor inputs.

code review should be fine
