### PR TITLE
[3.10] Undeprecate Joomla\CMS\Image classes

### DIFF
--- a/libraries/src/Image/Image.php
+++ b/libraries/src/Image/Image.php
@@ -15,8 +15,7 @@ use Joomla\CMS\Log\Log;
 /**
  * Class to manipulate an image.
  *
- * @since       1.7.3
- * @deprecated  5.0 Use the class \Joomla\Image\Image instead
+ * @since  1.7.3
  */
 class Image extends \Joomla\Image\Image
 {
@@ -30,8 +29,6 @@ class Image extends \Joomla\Image\Image
 	 */
 	public function __construct($source = null)
 	{
-		Log::add('Joomla\CMS\Image\Image is deprecated, use Joomla\Image\Image instead.', Log::WARNING, 'deprecated');
-
 		// Inject the PSR-3 compatible logger in for forward compatibility
 		$this->setLogger(Log::createDelegatedLogger());
 

--- a/libraries/src/Image/ImageFilter.php
+++ b/libraries/src/Image/ImageFilter.php
@@ -15,8 +15,7 @@ use Joomla\CMS\Log\Log;
 /**
  * Class to manipulate an image.
  *
- * @since       1.7.3
- * @deprecated  5.0  Use Joomla\Image\ImageFilter instead.
+ * @since  1.7.3
  */
 abstract class ImageFilter extends \Joomla\Image\ImageFilter
 {
@@ -25,13 +24,10 @@ abstract class ImageFilter extends \Joomla\Image\ImageFilter
 	 *
 	 * @param   resource  $handle  The image resource on which to apply the filter.
 	 *
-	 * @since   1.7.3
-	 * @deprecated  5.0  Use Joomla\Image\ImageFilter instead.
+	 * @since  1.7.3
 	 */
 	public function __construct($handle)
 	{
-		Log::add('Joomla\CMS\Image\ImageFilter is deprecated, use Joomla\Image\ImageFilter instead.', Log::WARNING, 'deprecated');
-
 		// Inject the PSR-3 compatible logger in for forward compatibility
 		$this->setLogger(Log::createDelegatedLogger());
 


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/29853.

### Summary of Changes

Removes deprecation notices for `Joomla\CMS\Image\Image` and `Joomla\CMS\Image\ImageFilter` since they're no longer being replaced by framework package.

### Testing Instructions

Code review.

### Documentation Changes Required

Docs for J4 should be changed to mention that `joomla/image` package has been removed and `Joomla\CMS\Image` classes no longer extend it https://docs.joomla.org/Potential_backward_compatibility_issues_in_Joomla_4#Image.