### PR TITLE
[4.0] Fix Vertical Tabs - The orientation parameter is ignored

### DIFF
--- a/libraries/src/HTML/Helpers/UiTab.php
+++ b/libraries/src/HTML/Helpers/UiTab.php
@@ -57,7 +57,9 @@ abstract class UiTab
 		// @TODO echo the recall attribute correctly, now it's hardcoded!!!
 		$recall = !isset($params['recall']) ? '' : 'recall';
 
-		return '<joomla-tab id="' . $selector . '" recall>';
+		$orientation = isset($params['orientation']) ? $params['orientation'] : 'horizontal';
+
+		return '<joomla-tab id="' . $selector . '" orientation="' . $orientation . '" recall>';
 	}
 
 	/**


### PR DESCRIPTION
### Summary of Changes
Although the Tabs CSS file includes styles for displaying tabs in a vertical orientation the UiTab class doesn't take into account the _orientation_ parameter. The PR makes `startTabSet()` method read that property too.

### Testing Instructions
Try to create vertical tabs using the code below:

```
use Joomla\CMS\HTML\HTMLHelper;

echo HTMLHelper::_('uitab.startTabSet', 'sections', ['orientation' => 'vertical']);

echo HTMLHelper::_('uitab.addTab', 'sections', 'tab1', 'Tab 1');
echo 'content of tab1';
echo HTMLHelper::_('uitab.endTab');

echo HTMLHelper::_('uitab.addTab', 'sections', 'tab2', 'Tab 2');
echo 'content of tab2';
echo HTMLHelper::_('uitab.endTab');

echo HTMLHelper::_('uitab.addTab', 'sections', 'tab3', 'Tab 3');
echo 'content of tab3';
echo HTMLHelper::_('uitab.endTab');

echo HTMLHelper::_('uitab.endTabSet');

```
### Actual result BEFORE applying this Pull Request
The orientation param is ignored and the tabs are displayed horizontally

![Peek 2020-07-03 11-28](https://user-images.githubusercontent.com/6807469/86449295-a995ee80-bd20-11ea-92dc-ff6b049a7348.gif)

### Expected result AFTER applying this Pull Request
With this PR tabs are correctly displayed vertically

![fixed](https://user-images.githubusercontent.com/6807469/86449350-bca8be80-bd20-11ea-95bb-0b0f8dced906.gif)

Keep in mind that the styling doesn't look really nice to me but I am willing to check it with another PR.
