### PR TITLE
[4.0] Fix SVG code

### DIFF
--- a/plugins/editors-xtd/menu/menu.php
+++ b/plugins/editors-xtd/menu/menu.php
@@ -58,7 +58,7 @@ class PlgButtonMenu extends CMSPlugin
 		$button->text    = Text::_('PLG_EDITORS-XTD_MENU_BUTTON_MENU');
 		$button->name    = 'share-alt';
 		$button->iconSVG = '<svg viewBox="0 0 32 32" width="24" height="24"><path d="M8 20c0 0 1.838-6 12-6v6l12-8-12-8v6c-8 0-12 4.99-12 10zM22'
-							. '24h-18v-12h3.934c0.315-0.372 0.654-0.729 1.015-1.068 1.374-1.287 3.018-2.27 4.879-2.932h-13.827v20h26v-8.395l-4 2.'
+							. ' 24h-18v-12h3.934c0.315-0.372 0.654-0.729 1.015-1.068 1.374-1.287 3.018-2.27 4.879-2.932h-13.827v20h26v-8.395l-4 2.'
 							. '667v1.728z"></path></svg>';
 		$button->options = [
 			'height' => '300px',


### PR DESCRIPTION
Pull Request for Issue Closes #29660

### Summary of Changes

Fixes SVG which has been split incorrectly to a multiline string in PHP

### Testing Instructions

with SAFARI or GOOGLE CHROME (not Firefox) 
Joomla 4 admin console 
Go to edit an article
Click the `CMS Content` button in the WYSIWYG Editor


### Actual result BEFORE applying this Pull Request

note the console.log error message/s

<img width="1602" alt="Screenshot 2020-06-17 at 00 09 18" src="https://user-images.githubusercontent.com/400092/84836978-d06cd900-b02e-11ea-80db-3ca8e036fa38.png">

### Expected result AFTER applying this Pull Request

No console.log errors 

### Documentation Changes Required

none