### PR TITLE
[4.0] Fix notice in extension manager

### DIFF
--- a/administrator/components/com_installer/tmpl/manage/default.php
+++ b/administrator/components/com_installer/tmpl/manage/default.php
@@ -113,7 +113,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 									<?php echo $item->type_translated; ?>
 								</td>
 								<td class="d-none d-md-table-cell">
-									<?php if ($item->version !== '') : ?>
+									<?php if (!empty($item->version)) : ?>
 										<?php if (!empty($item->changelogurl)) : ?>
 											<a href="#changelogModal<?php echo $item->extension_id; ?>" class="changelogModal" data-js-extensionid="<?php echo $item->extension_id; ?>" data-js-view="manage" data-toggle="modal">
 												<?php echo $item->version?>


### PR DESCRIPTION
Pull Request for Issue #29888 .

### Summary of Changes
Fix notice in com_installer manage


### Testing Instructions
See #29888


### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request
No notice is shown if an extension has not manifest file or the version is empty






### Documentation Changes Required
no
