### PR TITLE
[4.0[] Fix Features Icon color missing - s/color-featured/icon-color-featured

### DIFF
--- a/libraries/src/Button/FeaturedButton.php
+++ b/libraries/src/Button/FeaturedButton.php
@@ -29,10 +29,10 @@ class FeaturedButton extends ActionButton
 	 */
 	protected function preprocess()
 	{
-		$this->addState(0, 'articles.featured', 'color-unfeatured far fa-star',
+		$this->addState(0, 'articles.featured', 'icon-color-unfeatured far fa-star',
 			Text::_('JGLOBAL_TOGGLE_FEATURED'), ['tip_title' => Text::_('COM_CONTENT_UNFEATURED')]
 		);
-		$this->addState(1, 'articles.unfeatured', 'color-featured fas fa-star',
+		$this->addState(1, 'articles.unfeatured', 'icon-color-featured fas fa-star',
 			Text::_('JGLOBAL_TOGGLE_FEATURED'), ['tip_title' => Text::_('COM_CONTENT_FEATURED')]
 		);
 	}


### PR DESCRIPTION
### Summary of Changes

Fix classname so that featured icon has right color 

### Testing Instructions

Add some articles - make one featured

### Actual result BEFORE applying this Pull Request

<img width="259" alt="Screenshot 2020-07-04 at 13 18 13" src="https://user-images.githubusercontent.com/400092/86512331-1aa8d500-bdf9-11ea-8894-edd0a37efd01.png">

### Expected result AFTER applying this Pull Request


<img width="264" alt="Screenshot 2020-07-04 at 13 20 20" src="https://user-images.githubusercontent.com/400092/86512333-1e3c5c00-bdf9-11ea-9819-7719ca93404f.png">


### Documentation Changes Required

none