### PR TITLE
[4.0] Remove unneeded version attribute from XML files

### DIFF
--- a/administrator/components/com_mails/mails.xml
+++ b/administrator/components/com_mails/mails.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<extension type="component" version="4.0" method="upgrade">
+<extension type="component" method="upgrade">
 	<name>com_mails</name>
 	<author>Joomla! Project</author>
 	<creationDate>January 2019</creationDate>

--- a/administrator/language/en-GB/langmetadata.xml
+++ b/administrator/language/en-GB/langmetadata.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<metafile version="3.9" client="administrator">
+<metafile client="administrator">
 	<name>English (en-GB)</name>
 	<version>4.0.0</version>
 	<creationDate>June 2020</creationDate>

--- a/administrator/modules/mod_frontend/mod_frontend.xml
+++ b/administrator/modules/mod_frontend/mod_frontend.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<extension type="module" version="3.1" client="administrator" method="upgrade">
+<extension type="module" client="administrator" method="upgrade">
 	<name>mod_frontend</name>
 	<author>Joomla! Project</author>
 	<creationDate>July 2019</creationDate>

--- a/administrator/modules/mod_loginsupport/mod_loginsupport.xml
+++ b/administrator/modules/mod_loginsupport/mod_loginsupport.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<extension type="module" version="3.1" client="administrator" method="upgrade">
+<extension type="module" client="administrator" method="upgrade">
 	<name>mod_loginsupport</name>
 	<author>Joomla! Project</author>
 	<creationDate>June 2019</creationDate>

--- a/administrator/modules/mod_messages/mod_messages.xml
+++ b/administrator/modules/mod_messages/mod_messages.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<extension type="module" version="3.1" client="administrator" method="upgrade">
+<extension type="module" client="administrator" method="upgrade">
 	<name>mod_messages</name>
 	<author>Joomla! Project</author>
 	<creationDate>July 2019</creationDate>

--- a/administrator/modules/mod_post_installation_messages/mod_post_installation_messages.xml
+++ b/administrator/modules/mod_post_installation_messages/mod_post_installation_messages.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<extension type="module" version="3.1" client="administrator" method="upgrade">
+<extension type="module" client="administrator" method="upgrade">
 	<name>mod_post_installation_messages</name>
 	<author>Joomla! Project</author>
 	<creationDate>July2019</creationDate>

--- a/administrator/modules/mod_privacy_status/mod_privacy_status.xml
+++ b/administrator/modules/mod_privacy_status/mod_privacy_status.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<extension type="module" version="3.9" client="administrator" method="upgrade">
+<extension type="module" client="administrator" method="upgrade">
 	<name>mod_privacy_status</name>
 	<author>Joomla! Project</author>
 	<creationDate>July 2019</creationDate>

--- a/administrator/modules/mod_submenu/mod_submenu.xml
+++ b/administrator/modules/mod_submenu/mod_submenu.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<extension type="module" version="3.1" client="administrator" method="upgrade">
+<extension type="module" client="administrator" method="upgrade">
 	<name>mod_submenu</name>
 	<author>Joomla! Project</author>
 	<creationDate>February 2019</creationDate>

--- a/administrator/modules/mod_user/mod_user.xml
+++ b/administrator/modules/mod_user/mod_user.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<extension type="module" version="3.1" client="administrator" method="upgrade">
+<extension type="module" client="administrator" method="upgrade">
 	<name>mod_user</name>
 	<author>Joomla! Project</author>
 	<creationDate>July 2019</creationDate>

--- a/api/language/en-GB/install.xml
+++ b/api/language/en-GB/install.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<extension version="4.0" client="api" type="language" method="upgrade">
+<extension client="api" type="language" method="upgrade">
 	<name>English (en-GB)</name>
 	<tag>en-GB</tag>
 	<version>4.0.0</version>

--- a/api/language/en-GB/langmetadata.xml
+++ b/api/language/en-GB/langmetadata.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<metafile version="4.0" client="api">
+<metafile client="api">
 	<name>English (en-GB)</name>
 	<version>4.0.0</version>
 	<creationDate>June 2020</creationDate>

--- a/installation/language/en-GB/langmetadata.xml
+++ b/installation/language/en-GB/langmetadata.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<metafile
-	version="3.9"
-	client="installation">
+<metafile client="installation">
 	<name>English (United Kingdom)</name>
 	<version>4.0.0</version>
 	<creationDate>October 2019</creationDate>

--- a/installation/language/en-US/langmetadata.xml
+++ b/installation/language/en-US/langmetadata.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<metafile version="3.9" client="installation">
+<metafile client="installation">
 	<name>English (United States)</name>
 	<version>4.0.0</version>
 	<creationDate>October 2019</creationDate>

--- a/language/en-GB/langmetadata.xml
+++ b/language/en-GB/langmetadata.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<metafile version="3.9" client="site">
+<metafile client="site">
 	<name>English (en-GB)</name>
 	<version>4.0.0</version>
 	<creationDate>June 2020</creationDate>

--- a/plugins/api-authentication/token/token.xml
+++ b/plugins/api-authentication/token/token.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<extension version="4.0" type="plugin" group="api-authentication" method="upgrade">
+<extension type="plugin" group="api-authentication" method="upgrade">
 	<name>plg_api-authentication_token</name>
 	<author>Joomla! Project</author>
 	<creationDate>November 2019</creationDate>

--- a/plugins/fields/subfields/subfields.xml
+++ b/plugins/fields/subfields/subfields.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<extension type="plugin" version="4.0.0" group="fields" method="upgrade">
+<extension type="plugin" group="fields" method="upgrade">
 	<name>plg_fields_subfields</name>
 	<author>Joomla! Project</author>
 	<creationDate>June 2017</creationDate>

--- a/plugins/quickicon/downloadkey/downloadkey.xml
+++ b/plugins/quickicon/downloadkey/downloadkey.xml
@@ -1,12 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-  ~ @package    joomla4
-  ~
-  ~ @copyright  Copyright (C) 2005 - 2020 Open Source Matters, Inc. All rights reserved.
-  ~ @license    GNU General Public License version 2 or later; see LICENSE.txt
-  -->
-
-<extension version="4.0" type="plugin" group="quickicon" method="upgrade">
+<extension type="plugin" group="quickicon" method="upgrade">
 	<name>plg_quickicon_downloadkey</name>
 	<author>Joomla! Project</author>
 	<creationDate>October 2019</creationDate>

--- a/plugins/user/token/token.xml
+++ b/plugins/user/token/token.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<extension version="4.0" type="plugin" group="user" method="upgrade">
+<extension type="plugin" group="user" method="upgrade">
 	<name>plg_user_token</name>
 	<author>Joomla! Project</author>
 	<creationDate>November 2019</creationDate>

--- a/plugins/webservices/banners/banners.xml
+++ b/plugins/webservices/banners/banners.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<extension version="3.1" type="plugin" group="webservices" method="upgrade">
+<extension type="plugin" group="webservices" method="upgrade">
 	<name>plg_webservices_banners</name>
 	<author>Joomla! Project</author>
 	<creationDate>August 2017</creationDate>

--- a/plugins/webservices/config/config.xml
+++ b/plugins/webservices/config/config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<extension version="3.1" type="plugin" group="webservices" method="upgrade">
+<extension type="plugin" group="webservices" method="upgrade">
 	<name>plg_webservices_config</name>
 	<author>Joomla! Project</author>
 	<creationDate>August 2017</creationDate>

--- a/plugins/webservices/contact/contact.xml
+++ b/plugins/webservices/contact/contact.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<extension version="3.1" type="plugin" group="webservices" method="upgrade">
+<extension type="plugin" group="webservices" method="upgrade">
 	<name>plg_webservices_contact</name>
 	<author>Joomla! Project</author>
 	<creationDate>August 2017</creationDate>

--- a/plugins/webservices/installer/installer.xml
+++ b/plugins/webservices/installer/installer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<extension version="4.0" type="plugin" group="webservices" method="upgrade">
+<extension type="plugin" group="webservices" method="upgrade">
     <name>plg_webservices_installer</name>
     <author>Joomla! Project</author>
     <creationDate>October 2019</creationDate>

--- a/plugins/webservices/languages/languages.xml
+++ b/plugins/webservices/languages/languages.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<extension version="3.1" type="plugin" group="webservices" method="upgrade">
+<extensiontype="plugin" group="webservices" method="upgrade">
 	<name>plg_webservices_languages</name>
 	<author>Joomla! Project</author>
 	<creationDate>August 2017</creationDate>

--- a/plugins/webservices/languages/languages.xml
+++ b/plugins/webservices/languages/languages.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<extensiontype="plugin" group="webservices" method="upgrade">
+<extension type="plugin" group="webservices" method="upgrade">
 	<name>plg_webservices_languages</name>
 	<author>Joomla! Project</author>
 	<creationDate>August 2017</creationDate>

--- a/plugins/webservices/menus/menus.xml
+++ b/plugins/webservices/menus/menus.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<extension version="3.1" type="plugin" group="webservices" method="upgrade">
+<extensiontype="plugin" group="webservices" method="upgrade">
 		<name>plg_webservices_menus</name>
 	<author>Joomla! Project</author>
 	<creationDate>August 2017</creationDate>

--- a/plugins/webservices/menus/menus.xml
+++ b/plugins/webservices/menus/menus.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<extensiontype="plugin" group="webservices" method="upgrade">
+<extension type="plugin" group="webservices" method="upgrade">
 		<name>plg_webservices_menus</name>
 	<author>Joomla! Project</author>
 	<creationDate>August 2017</creationDate>

--- a/plugins/webservices/messages/messages.xml
+++ b/plugins/webservices/messages/messages.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<extensiontype="plugin" group="webservices" method="upgrade">
+<extension type="plugin" group="webservices" method="upgrade">
 	<name>plg_webservices_messages</name>
 	<author>Joomla! Project</author>
 	<creationDate>August 2017</creationDate>

--- a/plugins/webservices/messages/messages.xml
+++ b/plugins/webservices/messages/messages.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<extension version="3.1" type="plugin" group="webservices" method="upgrade">
+<extensiontype="plugin" group="webservices" method="upgrade">
 	<name>plg_webservices_messages</name>
 	<author>Joomla! Project</author>
 	<creationDate>August 2017</creationDate>

--- a/plugins/webservices/modules/modules.xml
+++ b/plugins/webservices/modules/modules.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<extension version="3.1" type="plugin" group="webservices" method="upgrade">
+<extensiontype="plugin" group="webservices" method="upgrade">
 		<name>plg_webservices_modules</name>
 	<author>Joomla! Project</author>
 	<creationDate>August 2017</creationDate>

--- a/plugins/webservices/modules/modules.xml
+++ b/plugins/webservices/modules/modules.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<extensiontype="plugin" group="webservices" method="upgrade">
+<extension type="plugin" group="webservices" method="upgrade">
 		<name>plg_webservices_modules</name>
 	<author>Joomla! Project</author>
 	<creationDate>August 2017</creationDate>

--- a/plugins/webservices/newsfeeds/newsfeeds.xml
+++ b/plugins/webservices/newsfeeds/newsfeeds.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<extension version="3.1" type="plugin" group="webservices" method="upgrade">
+<extensiontype="plugin" group="webservices" method="upgrade">
 	<name>plg_webservices_newsfeeds</name>
 	<author>Joomla! Project</author>
 	<creationDate>August 2017</creationDate>

--- a/plugins/webservices/newsfeeds/newsfeeds.xml
+++ b/plugins/webservices/newsfeeds/newsfeeds.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<extensiontype="plugin" group="webservices" method="upgrade">
+<extension type="plugin" group="webservices" method="upgrade">
 	<name>plg_webservices_newsfeeds</name>
 	<author>Joomla! Project</author>
 	<creationDate>August 2017</creationDate>

--- a/plugins/webservices/plugins/plugins.xml
+++ b/plugins/webservices/plugins/plugins.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<extension version="3.1" type="plugin" group="webservices" method="upgrade">
+<extensiontype="plugin" group="webservices" method="upgrade">
 		<name>plg_webservices_plugins</name>
 	<author>Joomla! Project</author>
 	<creationDate>August 2017</creationDate>

--- a/plugins/webservices/plugins/plugins.xml
+++ b/plugins/webservices/plugins/plugins.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<extensiontype="plugin" group="webservices" method="upgrade">
+<extension type="plugin" group="webservices" method="upgrade">
 		<name>plg_webservices_plugins</name>
 	<author>Joomla! Project</author>
 	<creationDate>August 2017</creationDate>

--- a/plugins/webservices/privacy/privacy.xml
+++ b/plugins/webservices/privacy/privacy.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<extensiontype="plugin" group="webservices" method="upgrade">
+<extension type="plugin" group="webservices" method="upgrade">
 		<name>plg_webservices_privacy</name>
 	<author>Joomla! Project</author>
 	<creationDate>August 2017</creationDate>

--- a/plugins/webservices/privacy/privacy.xml
+++ b/plugins/webservices/privacy/privacy.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<extension version="3.1" type="plugin" group="webservices" method="upgrade">
+<extensiontype="plugin" group="webservices" method="upgrade">
 		<name>plg_webservices_privacy</name>
 	<author>Joomla! Project</author>
 	<creationDate>August 2017</creationDate>

--- a/plugins/webservices/redirect/redirect.xml
+++ b/plugins/webservices/redirect/redirect.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<extensiontype="plugin" group="webservices" method="upgrade">
+<extension type="plugin" group="webservices" method="upgrade">
 		<name>plg_webservices_redirect</name>
 	<author>Joomla! Project</author>
 	<creationDate>August 2017</creationDate>

--- a/plugins/webservices/redirect/redirect.xml
+++ b/plugins/webservices/redirect/redirect.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<extension version="3.1" type="plugin" group="webservices" method="upgrade">
+<extensiontype="plugin" group="webservices" method="upgrade">
 		<name>plg_webservices_redirect</name>
 	<author>Joomla! Project</author>
 	<creationDate>August 2017</creationDate>

--- a/plugins/webservices/tags/tags.xml
+++ b/plugins/webservices/tags/tags.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<extension version="3.1" type="plugin" group="webservices" method="upgrade">
+<extensiontype="plugin" group="webservices" method="upgrade">
 		<name>plg_webservices_tags</name>
 	<author>Joomla! Project</author>
 	<creationDate>August 2017</creationDate>

--- a/plugins/webservices/tags/tags.xml
+++ b/plugins/webservices/tags/tags.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<extensiontype="plugin" group="webservices" method="upgrade">
+<extension type="plugin" group="webservices" method="upgrade">
 		<name>plg_webservices_tags</name>
 	<author>Joomla! Project</author>
 	<creationDate>August 2017</creationDate>

--- a/plugins/webservices/templates/templates.xml
+++ b/plugins/webservices/templates/templates.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<extension version="3.1" type="plugin" group="webservices" method="upgrade">
+<extensiontype="plugin" group="webservices" method="upgrade">
 		<name>plg_webservices_templates</name>
 	<author>Joomla! Project</author>
 	<creationDate>August 2017</creationDate>

--- a/plugins/webservices/templates/templates.xml
+++ b/plugins/webservices/templates/templates.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<extensiontype="plugin" group="webservices" method="upgrade">
+<extension type="plugin" group="webservices" method="upgrade">
 		<name>plg_webservices_templates</name>
 	<author>Joomla! Project</author>
 	<creationDate>August 2017</creationDate>

--- a/plugins/webservices/users/users.xml
+++ b/plugins/webservices/users/users.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<extensiontype="plugin" group="webservices" method="upgrade">
+<extension type="plugin" group="webservices" method="upgrade">
 		<name>plg_webservices_users</name>
 	<author>Joomla! Project</author>
 	<creationDate>August 2017</creationDate>

--- a/plugins/webservices/users/users.xml
+++ b/plugins/webservices/users/users.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<extension version="3.1" type="plugin" group="webservices" method="upgrade">
+<extensiontype="plugin" group="webservices" method="upgrade">
 		<name>plg_webservices_users</name>
 	<author>Joomla! Project</author>
 	<creationDate>August 2017</creationDate>


### PR DESCRIPTION
This PR removes the version attributes (not the version tag!) from XML files as they were never be used in core anyway.
Afaik that was already done for some extensions. This now removes it from the remaining ones.

This can be merged by review.