### PR TITLE
[4.0] No Matching Results in wrong place in contacts model

### DIFF
--- a/administrator/components/com_contact/tmpl/contacts/modal.php
+++ b/administrator/components/com_contact/tmpl/contacts/modal.php
@@ -44,7 +44,7 @@ if (!empty($editor))
 ?>
 <div class="container-popup">
 
-	<form action="<?php echo Route::_('index.php?option=com_contact&view=contacts&layout=modal&tmpl=component&editor=' . $editor . '&function=' . $function . '&' . Session::getFormToken() . '=1'); ?>" method="post" name="adminForm" id="adminForm" class="form-inline">
+	<form action="<?php echo Route::_('index.php?option=com_contact&view=contacts&layout=modal&tmpl=component&editor=' . $editor . '&function=' . $function . '&' . Session::getFormToken() . '=1'); ?>" method="post" name="adminForm" id="adminForm">
 
 		<?php echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
 


### PR DESCRIPTION
### Steps to reproduce the issue
Closes #29961

**NOT A DUPLICATE of https://github.com/joomla/joomla-cms/issues/29588 fixed in https://github.com/joomla/joomla-cms/pull/29594 but very close. Same root issue different place** 

Joomla 4 admin
Navigate Menus -> + next to Main Menu -> SELECT menu Item type -> Select Contacts -> Single Contact 
Click SELECT to select a contact 

### Expected result

No Matching Results on line by itself like always

<img width="1299" alt="Screenshot 2020-07-04 at 13 43 36" src="https://user-images.githubusercontent.com/400092/86512724-61e49500-bdfc-11ea-87b9-537d77992075.png">

### Actual result

<img width="1293" alt="Screenshot 2020-07-04 at 13 39 13" src="https://user-images.githubusercontent.com/400092/86512642-c4896100-bdfb-11ea-95b1-e793ecfe2e05.png">


### System information (as much as possible)

Safari on Mac

### Additional comments
//@chmst