### PR TITLE
[4.0] Fix modal layout if no items are found

### DIFF
--- a/administrator/components/com_fields/tmpl/fields/modal.php
+++ b/administrator/components/com_fields/tmpl/fields/modal.php
@@ -30,7 +30,7 @@ $editor    = Factory::getApplication()->input->get('editor', '', 'cmd');
 ?>
 <div class="container-popup">
 
-	<form action="<?php echo Route::_('index.php?option=com_fields&view=fields&layout=modal&tmpl=component&editor=' . $editor . '&' . Session::getFormToken() . '=1'); ?>" method="post" name="adminForm" id="adminForm" class="form-inline">
+	<form action="<?php echo Route::_('index.php?option=com_fields&view=fields&layout=modal&tmpl=component&editor=' . $editor . '&' . Session::getFormToken() . '=1'); ?>" method="post" name="adminForm" id="adminForm">
 
 		<?php echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
 		<?php if (empty($this->items)) : ?>

--- a/administrator/components/com_newsfeeds/tmpl/newsfeeds/modal.php
+++ b/administrator/components/com_newsfeeds/tmpl/newsfeeds/modal.php
@@ -27,7 +27,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 ?>
 <div class="container-popup">
 
-	<form action="<?php echo Route::_('index.php?option=com_newsfeeds&view=newsfeeds&layout=modal&tmpl=component&function=' . $function); ?>" method="post" name="adminForm" id="adminForm" class="form-inline">
+	<form action="<?php echo Route::_('index.php?option=com_newsfeeds&view=newsfeeds&layout=modal&tmpl=component&function=' . $function); ?>" method="post" name="adminForm" id="adminForm">
 
 		<?php echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
 


### PR DESCRIPTION
### Summary of Changes
Compare #29962 or #29594 - fix the layout of modals if no item is found.

### Testing Instructions
code review is sufficient. but if you want: 

1) newsfeed
I suppose that you have no newsfeeds defined. 
If you want to add new menu item "single news feed" to your Menu, you must select a feed. A modal is opened. 

2) fields
In general you never will see this modal if it is empty - so code review only


### Actual result BEFORE applying this Pull Request
Searchtools and message are in a row


### Expected result AFTER applying this Pull Request
As usual: Searchtools in a row and message in a row for its own.


### Documentation Changes Required
no
