### PR TITLE
[4.0] tinymce plugin missing string [a11y]

### DIFF
--- a/administrator/language/en-GB/plg_editors_tinymce.ini
+++ b/administrator/language/en-GB/plg_editors_tinymce.ini
@@ -4,6 +4,7 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_EDITORS_TINYMCE="Editor - TinyMCE"
+PLG_TINY_BUILDER="TinyMCE Configuration Builder"
 PLG_TINY_BUTTON_TOGGLE_EDITOR="Toggle Editor"
 PLG_TINY_CONFIG_TEXTFILTER_ACL_LABEL="Use Joomla Text Filter"
 PLG_TINY_CORE_BUTTONS="CMS Content"

--- a/plugins/editors/tinymce/tinymce.xml
+++ b/plugins/editors/tinymce/tinymce.xml
@@ -28,6 +28,7 @@
 				<field
 					name="configuration"
 					type="tinymcebuilder"
+					label="PLG_TINY_BUILDER"
 					hiddenLabel="true"
 				 />
 			</fieldset>


### PR DESCRIPTION
Fixes an untranslated string

### Testing Instructions
code review
or
open the plugin with language debug enabled
