### PR TITLE
[4.0] Double translations

### DIFF
--- a/administrator/components/com_installer/tmpl/updatesites/default.php
+++ b/administrator/components/com_installer/tmpl/updatesites/default.php
@@ -97,7 +97,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 											<a class="hasPopover"
 											   href="<?php echo Route::_('index.php?option=com_installer&task=updatesite.edit&update_site_id=' . (int) $item->update_site_id); ?>"
 											   title="<?= Text::_('COM_INSTALLER_UPDATESITE_EDIT_TITLE') ?>"
-											   data-content="<?= Text::sprintf('COM_INSTALLER_UPDATESITE_EDIT_TIP', Text::_($item->update_site_name), Text::_($item->name)) ?>"
+											   data-content="<?= Text::sprintf('COM_INSTALLER_UPDATESITE_EDIT_TIP', $item->update_site_name, $item->name) ?>"
 											>
 												<?php echo Text::_($item->update_site_name); ?>
 											</a>


### PR DESCRIPTION
As can be seen after enabling language debug in the screenshot the strings were being translated twice.

### Before
![image](https://user-images.githubusercontent.com/1296369/86520687-130c1f00-be3f-11ea-90d5-be313436ffae.png)

### After
![image](https://user-images.githubusercontent.com/1296369/86520685-11425b80-be3f-11ea-8121-681dc307918e.png)
