### PR TITLE
[4.0] Modal footer buttons

### DIFF
--- a/administrator/components/com_banners/tmpl/tracks/default.php
+++ b/administrator/components/com_banners/tmpl/tracks/default.php
@@ -95,12 +95,12 @@ $listDirn   = $this->escape($this->state->get('list.direction'));
 						'height'      => '370px',
 						'width'       => '300px',
 						'modalWidth'  => '40',
-						'footer'      => '<button type="button" class="btn" data-dismiss="modal"'
-								. ' onclick="Joomla.iframeButtonClick({iframeSelector: \'#downloadModal\', buttonSelector: \'#closeBtn\'})">'
-								. Text::_('COM_BANNERS_CANCEL') . '</button>'
-								. '<button type="button" class="btn btn-success"'
+						'footer'      => '<button type="button" class="btn btn-success"'
 								. ' onclick="Joomla.iframeButtonClick({iframeSelector: \'#downloadModal\', buttonSelector: \'#exportBtn\'})">'
-								. Text::_('COM_BANNERS_TRACKS_EXPORT') . '</button>',
+								. Text::_('COM_BANNERS_TRACKS_EXPORT') . '</button>'
+								. '<button type="button" class="btn" data-dismiss="modal"'
+								. ' onclick="Joomla.iframeButtonClick({iframeSelector: \'#downloadModal\', buttonSelector: \'#closeBtn\'})">'
+								. Text::_('COM_BANNERS_CANCEL') . '</button>',
 					]
 				); ?>
 				<input type="hidden" name="task" value="">

--- a/administrator/components/com_categories/src/Field/Modal/CategoryField.php
+++ b/administrator/components/com_categories/src/Field/Modal/CategoryField.php
@@ -264,15 +264,15 @@ class CategoryField extends FormField
 					'width'       => '800px',
 					'bodyHeight'  => 70,
 					'modalWidth'  => 80,
-					'footer'      => '<button type="button" class="btn btn-secondary"'
-							. ' onclick="window.processModalEdit(this, \'' . $this->id . '\', \'add\', \'category\', \'cancel\', \'item-form\'); return false;">'
-							. Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>'
-							. '<button type="button" class="btn btn-primary"'
+					'footer'      => '<button type="button" class="btn btn-success"'
+							. ' onclick="window.processModalEdit(this, \'' . $this->id . '\', \'add\', \'category\', \'apply\', \'item-form\'); return false;">'
+							. Text::_('JAPPLY') . '</button>'
+							. '<button type="button" class="btn btn-success"'
 							. ' onclick="window.processModalEdit(this, \'' . $this->id . '\', \'add\', \'category\', \'save\', \'item-form\'); return false;">'
 							. Text::_('JSAVE') . '</button>'
-							. '<button type="button" class="btn btn-success"'
-							. ' onclick="window.processModalEdit(this, \'' . $this->id . '\', \'add\', \'category\', \'apply\', \'item-form\'); return false;">'
-							. Text::_('JAPPLY') . '</button>',
+							. '<button type="button" class="btn btn-secondary"'
+							. ' onclick="window.processModalEdit(this, \'' . $this->id . '\', \'add\', \'category\', \'cancel\', \'item-form\'); return false;">'
+							. Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>',
 				)
 			);
 		}
@@ -293,16 +293,15 @@ class CategoryField extends FormField
 					'width'       => '800px',
 					'bodyHeight'  => 70,
 					'modalWidth'  => 80,
-					'footer'      => '<button type="button" class="btn btn-secondary"'
-							. ' onclick="window.processModalEdit(this, \'' . $this->id . '\', \'edit\', \'category\', \'cancel\', \'item-form\'); return false;">'
-							. Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>'
-							. '<button type="button" class="btn btn-primary"'
+					'footer'      => '<button type="button" class="btn btn-success"'
+							. ' onclick="window.processModalEdit(this, \'' . $this->id . '\', \'edit\', \'category\', \'apply\', \'item-form\'); return false;">'
+							. Text::_('JAPPLY') . '</button>'
+							. '<button type="button" class="btn btn-success"'
 							. ' onclick="window.processModalEdit(this, \'' . $this->id . '\', \'edit\', \'category\', \'save\', \'item-form\'); return false;">'
 							. Text::_('JSAVE') . '</button>'
-							. '<button type="button" class="btn btn-success"'
-							. ' onclick="window.processModalEdit(this, \'' . $this->id . '\', \'edit\', \'category\', \'apply\', \'item-form\'); return false;">'
-							. Text::_('JAPPLY') . '</button>',
-				)
+							. '<button type="button" class="btn btn-secondary"'
+							. ' onclick="window.processModalEdit(this, \'' . $this->id . '\', \'edit\', \'category\', \'cancel\', \'item-form\'); return false;">'
+							. Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>',				)
 			);
 		}
 

--- a/administrator/components/com_contact/src/Field/Modal/ContactField.php
+++ b/administrator/components/com_contact/src/Field/Modal/ContactField.php
@@ -253,18 +253,18 @@ class ContactField extends FormField
 					'width'       => '800px',
 					'bodyHeight'  => 70,
 					'modalWidth'  => 80,
-					'footer'      => '<button type="button" class="btn btn-secondary"'
+					'footer'      => '<button type="button" class="btn btn-success"'
 							. ' onclick="window.processModalEdit(this, \''
-							. $this->id . '\', \'add\', \'contact\', \'cancel\', \'contact-form\', \'jform_id\', \'jform_name\'); return false;">'
-							. Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>'
-							. '<button type="button" class="btn btn-primary"'
+							. $this->id . '\', \'add\', \'contact\', \'apply\', \'contact-form\', \'jform_id\', \'jform_name\'); return false;">'
+							. Text::_('JAPPLY') . '</button>'
+							. '<button type="button" class="btn btn-success"'
 							. ' onclick="window.processModalEdit(this, \''
 							. $this->id . '\', \'add\', \'contact\', \'save\', \'contact-form\', \'jform_id\', \'jform_name\'); return false;">'
 							. Text::_('JSAVE') . '</button>'
-							. '<button type="button" class="btn btn-success"'
+							. '<button type="button" class="btn btn-secondary"'
 							. ' onclick="window.processModalEdit(this, \''
-							. $this->id . '\', \'add\', \'contact\', \'apply\', \'contact-form\', \'jform_id\', \'jform_name\'); return false;">'
-							. Text::_('JAPPLY') . '</button>',
+							. $this->id . '\', \'add\', \'contact\', \'cancel\', \'contact-form\', \'jform_id\', \'jform_name\'); return false;">'
+							. Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>',
 				)
 			);
 		}
@@ -285,18 +285,18 @@ class ContactField extends FormField
 					'width'       => '800px',
 					'bodyHeight'  => 70,
 					'modalWidth'  => 80,
-					'footer'      => '<button type="button" class="btn btn-secondary"'
-							. ' onclick="window.processModalEdit(this, \'' . $this->id
-							. '\', \'edit\', \'contact\', \'cancel\', \'contact-form\', \'jform_id\', \'jform_name\'); return false;">'
-							. Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>'
-							. '<button type="button" class="btn btn-primary"'
+					'footer'      => '<button type="button" class="btn btn-success"'
+							. ' onclick="window.processModalEdit(this, \''
+							. $this->id . '\', \'edit\', \'contact\', \'apply\', \'contact-form\', \'jform_id\', \'jform_name\'); return false;">'
+							. Text::_('JAPPLY') . '</button>'
+							. '<button type="button" class="btn btn-success"'
 							. ' onclick="window.processModalEdit(this, \''
 							. $this->id . '\', \'edit\', \'contact\', \'save\', \'contact-form\', \'jform_id\', \'jform_name\'); return false;">'
 							. Text::_('JSAVE') . '</button>'
-							. '<button type="button" class="btn btn-success"'
-							. ' onclick="window.processModalEdit(this, \''
-							. $this->id . '\', \'edit\', \'contact\', \'apply\', \'contact-form\', \'jform_id\', \'jform_name\'); return false;">'
-							. Text::_('JAPPLY') . '</button>',
+							. '<button type="button" class="btn btn-secondary"'
+							. ' onclick="window.processModalEdit(this, \'' . $this->id
+							. '\', \'edit\', \'contact\', \'cancel\', \'contact-form\', \'jform_id\', \'jform_name\'); return false;">'
+							. Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>',
 				)
 			);
 		}

--- a/administrator/components/com_content/src/Field/Modal/ArticleField.php
+++ b/administrator/components/com_content/src/Field/Modal/ArticleField.php
@@ -256,15 +256,15 @@ class ArticleField extends FormField
 					'width'       => '800px',
 					'bodyHeight'  => 70,
 					'modalWidth'  => 80,
-					'footer'      => '<button type="button" class="btn btn-secondary"'
-							. ' onclick="window.processModalEdit(this, \'' . $this->id . '\', \'add\', \'article\', \'cancel\', \'item-form\'); return false;">'
-							. Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>'
-							. '<button type="button" class="btn btn-primary"'
+					'footer'      => '<button type="button" class="btn btn-success"'
+							. ' onclick="window.processModalEdit(this, \'' . $this->id . '\', \'add\', \'article\', \'apply\', \'item-form\'); return false;">'
+							. Text::_('JAPPLY') . '</button>'
+							. '<button type="button" class="btn btn-success"'
 							. ' onclick="window.processModalEdit(this, \'' . $this->id . '\', \'add\', \'article\', \'save\', \'item-form\'); return false;">'
 							. Text::_('JSAVE') . '</button>'
-							. '<button type="button" class="btn btn-success"'
-							. ' onclick="window.processModalEdit(this, \'' . $this->id . '\', \'add\', \'article\', \'apply\', \'item-form\'); return false;">'
-							. Text::_('JAPPLY') . '</button>',
+							. '<button type="button" class="btn btn-secondary"'
+							. ' onclick="window.processModalEdit(this, \'' . $this->id . '\', \'add\', \'article\', \'cancel\', \'item-form\'); return false;">'
+							. Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>',
 				)
 			);
 		}
@@ -285,15 +285,15 @@ class ArticleField extends FormField
 					'width'       => '800px',
 					'bodyHeight'  => 70,
 					'modalWidth'  => 80,
-					'footer'      => '<button type="button" class="btn btn-secondary"'
-							. ' onclick="window.processModalEdit(this, \'' . $this->id . '\', \'edit\', \'article\', \'cancel\', \'item-form\'); return false;">'
-							. Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>'
-							. '<button type="button" class="btn btn-primary"'
+					'footer'      => '<button type="button" class="btn btn-success"'
+							. ' onclick="window.processModalEdit(this, \'' . $this->id . '\', \'edit\', \'article\', \'apply\', \'item-form\'); return false;">'
+							. Text::_('JAPPLY') . '</button>'
+							. '<button type="button" class="btn btn-success"'
 							. ' onclick="window.processModalEdit(this, \'' . $this->id . '\', \'edit\', \'article\', \'save\', \'item-form\'); return false;">'
 							. Text::_('JSAVE') . '</button>'
-							. '<button type="button" class="btn btn-success"'
-							. ' onclick="window.processModalEdit(this, \'' . $this->id . '\', \'edit\', \'article\', \'apply\', \'item-form\'); return false;">'
-							. Text::_('JAPPLY') . '</button>',
+							. '<button type="button" class="btn btn-secondary"'
+							. ' onclick="window.processModalEdit(this, \'' . $this->id . '\', \'edit\', \'article\', \'cancel\', \'item-form\'); return false;">'
+							. Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>',
 				)
 			);
 		}

--- a/administrator/components/com_cpanel/tmpl/cpanel/default.php
+++ b/administrator/components/com_cpanel/tmpl/cpanel/default.php
@@ -41,10 +41,10 @@ echo HTMLHelper::_(
 		'url'         => Route::_('index.php?option=com_cpanel&task=addModule&function=jSelectModuleType&position=' . $this->escape($this->position)),
 		'bodyHeight'  => '70',
 		'modalWidth'  => '80',
-		'footer'      => '<button type="button" class="button-cancel btn btn-sm btn-danger" data-dismiss="modal" data-target="#closeBtn"><span class="fas fa-times" aria-hidden="true"></span>'
-			. Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>'
-			. '<button type="button" class="button-save btn btn-sm btn-success hidden" data-target="#saveBtn"><span class="fas fa-copy" aria-hidden="true"></span>'
-			. Text::_('JSAVE') . '</button>',
+		'footer'      => '<button type="button" class="button-save btn btn-sm btn-success hidden" data-target="#saveBtn"><span class="fas fa-copy" aria-hidden="true"></span>'
+			. Text::_('JSAVE') . '</button>'
+			. '<button type="button" class="button-cancel btn btn-sm btn-danger" data-dismiss="modal" data-target="#closeBtn"><span class="fas fa-times" aria-hidden="true"></span>'
+			. Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>',
 	)
 );
 ?>

--- a/administrator/components/com_menus/src/Field/Modal/MenuField.php
+++ b/administrator/components/com_menus/src/Field/Modal/MenuField.php
@@ -388,15 +388,15 @@ class MenuField extends FormField
 					'width'       => '800px',
 					'bodyHeight'  => 70,
 					'modalWidth'  => 80,
-					'footer'      => '<button type="button" class="btn btn-secondary"'
-							. ' onclick="window.processModalEdit(this, \'' . $this->id . '\', \'add\', \'item\', \'cancel\', \'item-form\'); return false;">'
-							. Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>'
-							. '<button type="button" class="btn btn-primary"'
+					'footer'      => '<button type="button" class="btn btn-success"'
+							. ' onclick="window.processModalEdit(this, \'' . $this->id . '\', \'add\', \'item\', \'apply\', \'item-form\'); return false;">'
+							. Text::_('JAPPLY') . '</button>'
+							. '<button type="button" class="btn btn-success"'
 							. ' onclick="window.processModalEdit(this, \'' . $this->id . '\', \'add\', \'item\', \'save\', \'item-form\'); return false;">'
 							. Text::_('JSAVE') . '</button>'
-							. '<button type="button" class="btn btn-success"'
-							. ' onclick="window.processModalEdit(this, \'' . $this->id . '\', \'add\', \'item\', \'apply\', \'item-form\'); return false;">'
-							. Text::_('JAPPLY') . '</button>',
+							.'<button type="button" class="btn btn-secondary"'
+							. ' onclick="window.processModalEdit(this, \'' . $this->id . '\', \'add\', \'item\', \'cancel\', \'item-form\'); return false;">'
+							. Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>',
 				)
 			);
 		}
@@ -417,15 +417,15 @@ class MenuField extends FormField
 					'width'       => '800px',
 					'bodyHeight'  => 70,
 					'modalWidth'  => 80,
-					'footer'      => '<button type="button" class="btn btn-secondary"'
-							. ' onclick="window.processModalEdit(this, \'' . $this->id . '\', \'edit\', \'item\', \'cancel\', \'item-form\'); return false;">'
-							. Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>'
-							. '<button type="button" class="btn btn-primary"'
+					'footer'      => '<button type="button" class="btn btn-success"'
+							. ' onclick="window.processModalEdit(this, \'' . $this->id . '\', \'edit\', \'item\', \'apply\', \'item-form\'); return false;">'
+							. Text::_('JAPPLY') . '</button>'
+							. '<button type="button" class="btn btn-success"'
 							. ' onclick="window.processModalEdit(this, \'' . $this->id . '\', \'edit\', \'item\', \'save\', \'item-form\'); return false;">'
 							. Text::_('JSAVE') . '</button>'
-							. '<button type="button" class="btn btn-success"'
-							. ' onclick="window.processModalEdit(this, \'' . $this->id . '\', \'edit\', \'item\', \'apply\', \'item-form\'); return false;">'
-							. Text::_('JAPPLY') . '</button>',
+							. '<button type="button" class="btn btn-secondary"'
+							. ' onclick="window.processModalEdit(this, \'' . $this->id . '\', \'edit\', \'item\', \'cancel\', \'item-form\'); return false;">'
+							. Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>',
 				)
 			);
 		}

--- a/administrator/components/com_menus/src/Field/Modal/MenuField.php
+++ b/administrator/components/com_menus/src/Field/Modal/MenuField.php
@@ -394,7 +394,7 @@ class MenuField extends FormField
 							. '<button type="button" class="btn btn-success"'
 							. ' onclick="window.processModalEdit(this, \'' . $this->id . '\', \'add\', \'item\', \'save\', \'item-form\'); return false;">'
 							. Text::_('JSAVE') . '</button>'
-							.'<button type="button" class="btn btn-secondary"'
+							. '<button type="button" class="btn btn-secondary"'
 							. ' onclick="window.processModalEdit(this, \'' . $this->id . '\', \'add\', \'item\', \'cancel\', \'item-form\'); return false;">'
 							. Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>',
 				)

--- a/administrator/components/com_menus/tmpl/item/edit_modules.php
+++ b/administrator/components/com_menus/tmpl/item/edit_modules.php
@@ -36,12 +36,12 @@ echo HTMLHelper::_(
 		'closeButton' => false,
 		'bodyHeight'  => '70',
 		'modalWidth'  => '80',
-		'footer'      => '<button type="button" class="btn" data-dismiss="modal" data-target="#closeBtn">'
-				. Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>'
-				. '<button type="button" class="btn btn-primary" data-dismiss="modal" data-target="#saveBtn">'
+		'footer'      => '<button type="button" class="btn btn-success" data-target="#applyBtn">'
+				. Text::_('JAPPLY') . '</button>'
+				. '<button type="button" class="btn btn-success" data-dismiss="modal" data-target="#saveBtn">'
 				. Text::_('JSAVE') . '</button>'
-				. '<button type="button" class="btn btn-success" data-target="#applyBtn">'
-				. Text::_('JAPPLY') . '</button>',
+				. '<button type="button" class="btn" data-dismiss="modal" data-target="#closeBtn">'
+				. Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>',
 	)
 );
 

--- a/administrator/components/com_menus/tmpl/menus/default.php
+++ b/administrator/components/com_menus/tmpl/menus/default.php
@@ -183,15 +183,15 @@ $wa->useScript('com_menus.admin-menus');
 															'width'       => '800px',
 															'bodyHeight'  => 70,
 															'modalWidth'  => 80,
-															'footer'      => '<button type="button" class="btn btn-danger" data-dismiss="modal"'
-																	. ' onclick="Joomla.iframeButtonClick({iframeSelector: \'#moduleEdit' . $module->id . 'Modal\', buttonSelector: \'#closeBtn\'})">'
-																	. Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>'
+															'footer'      => '<button type="button" class="btn btn-success"'
+																	. ' onclick="Joomla.iframeButtonClick({iframeSelector: \'#moduleEdit' . $module->id . 'Modal\', buttonSelector: \'#applyBtn\'})">'
+																	. Text::_('JAPPLY') . '</button>'
 																	. '<button type="button" class="btn btn-success"'
 																	. ' onclick="Joomla.iframeButtonClick({iframeSelector: \'#moduleEdit' . $module->id . 'Modal\', buttonSelector: \'#saveBtn\'})">'
 																	. Text::_('JSAVE') . '</button>'
-																	. '<button type="button" class="btn btn-success"'
-																	. ' onclick="Joomla.iframeButtonClick({iframeSelector: \'#moduleEdit' . $module->id . 'Modal\', buttonSelector: \'#applyBtn\'})">'
-																	. Text::_('JAPPLY') . '</button>',
+																	. '<button type="button" class="btn btn-danger" data-dismiss="modal"'
+																	. ' onclick="Joomla.iframeButtonClick({iframeSelector: \'#moduleEdit' . $module->id . 'Modal\', buttonSelector: \'#closeBtn\'})">'
+																	. Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>',
 														)
 													); ?>
 											<?php endif; ?>
@@ -212,15 +212,15 @@ $wa->useScript('com_menus.admin-menus');
 													'width'       => '800px',
 													'bodyHeight'  => 70,
 													'modalWidth'  => 80,
-													'footer'      => '<button type="button" class="btn btn-secondary" data-dismiss="modal"'
-															. ' onclick="Joomla.iframeButtonClick({iframeSelector: \'#moduleAddModal\', buttonSelector: \'#closeBtn\'})">'
-															. Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>'
-															. '<button type="button" class="btn btn-primary"'
+													'footer'      => '<button type="button" class="btn btn-success"'
+															. ' onclick="Joomla.iframeButtonClick({iframeSelector: \'#moduleAddModal\', buttonSelector: \'#applyBtn\'})">'
+															. Text::_('JAPPLY') . '</button>'
+															. '<button type="button" class="btn btn-success"'
 															. ' onclick="Joomla.iframeButtonClick({iframeSelector: \'#moduleAddModal\', buttonSelector: \'#saveBtn\'})">'
 															. Text::_('JSAVE') . '</button>'
-															. '<button type="button" class="btn btn-success"'
-															. ' onclick="Joomla.iframeButtonClick({iframeSelector: \'#moduleAddModal\', buttonSelector: \'#applyBtn\'})">'
-															. Text::_('JAPPLY') . '</button>',
+															. '<button type="button" class="btn btn-secondary" data-dismiss="modal"'
+															. ' onclick="Joomla.iframeButtonClick({iframeSelector: \'#moduleAddModal\', buttonSelector: \'#closeBtn\'})">'
+															. Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>',
 												)
 											); ?>
 									<?php endif; ?>

--- a/administrator/components/com_newsfeeds/src/Field/Modal/NewsfeedField.php
+++ b/administrator/components/com_newsfeeds/src/Field/Modal/NewsfeedField.php
@@ -254,18 +254,18 @@ class NewsfeedField extends FormField
 					'width'       => '800px',
 					'bodyHeight'  => 70,
 					'modalWidth'  => 80,
-					'footer'      => '<button type="button" class="btn btn-secondary"'
+					'footer'      => '<button type="button" class="btn btn-success"'
 							. ' onclick="window.processModalEdit(this, \''
-							. $this->id . '\', \'add\', \'newsfeed\', \'cancel\', \'newsfeed-form\', \'jform_id\', \'jform_name\'); return false;">'
-							. Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>'
-							. '<button type="button" class="btn btn-primary"'
+							. $this->id . '\', \'add\', \'newsfeed\', \'apply\', \'newsfeed-form\', \'jform_id\', \'jform_name\'); return false;">'
+							. Text::_('JAPPLY') . '</button>'
+							. '<button type="button" class="btn btn-success"'
 							. ' onclick="window.processModalEdit(this, \''
 							. $this->id . '\', \'add\', \'newsfeed\', \'save\', \'newsfeed-form\', \'jform_id\', \'jform_name\'); return false;">'
 							. Text::_('JSAVE') . '</button>'
-							. '<button type="button" class="btn btn-success"'
+							. '<button type="button" class="btn btn-secondary"'
 							. ' onclick="window.processModalEdit(this, \''
-							. $this->id . '\', \'add\', \'newsfeed\', \'apply\', \'newsfeed-form\', \'jform_id\', \'jform_name\'); return false;">'
-							. Text::_('JAPPLY') . '</button>',
+							. $this->id . '\', \'add\', \'newsfeed\', \'cancel\', \'newsfeed-form\', \'jform_id\', \'jform_name\'); return false;">'
+							. Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>',
 				)
 			);
 		}
@@ -286,18 +286,18 @@ class NewsfeedField extends FormField
 					'width'       => '800px',
 					'bodyHeight'  => 70,
 					'modalWidth'  => 80,
-					'footer'      => '<button type="button" class="btn btn-secondary"'
-							. ' onclick="window.processModalEdit(this, \'' . $this->id
-							. '\', \'edit\', \'newsfeed\', \'cancel\', \'newsfeed-form\', \'jform_id\', \'jform_name\'); return false;">'
-							. Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>'
-							. '<button type="button" class="btn btn-primary"'
+					'footer'      => '<button type="button" class="btn btn-success"'
+							. ' onclick="window.processModalEdit(this, \''
+							. $this->id . '\', \'edit\', \'newsfeed\', \'apply\', \'newsfeed-form\', \'jform_id\', \'jform_name\'); return false;">'
+							. Text::_('JAPPLY') . '</button>'
+							. '<button type="button" class="btn btn-success"'
 							. ' onclick="window.processModalEdit(this, \''
 							. $this->id . '\', \'edit\', \'newsfeed\', \'save\', \'newsfeed-form\', \'jform_id\', \'jform_name\'); return false;">'
 							. Text::_('JSAVE') . '</button>'
-							. '<button type="button" class="btn btn-success"'
-							. ' onclick="window.processModalEdit(this, \''
-							. $this->id . '\', \'edit\', \'newsfeed\', \'apply\', \'newsfeed-form\', \'jform_id\', \'jform_name\'); return false;">'
-							. Text::_('JAPPLY') . '</button>',
+							. '<button type="button" class="btn btn-secondary"'
+							. ' onclick="window.processModalEdit(this, \'' . $this->id
+							. '\', \'edit\', \'newsfeed\', \'cancel\', \'newsfeed-form\', \'jform_id\', \'jform_name\'); return false;">'
+							. Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>',
 				)
 			);
 		}

--- a/administrator/components/com_redirect/tmpl/links/default.php
+++ b/administrator/components/com_redirect/tmpl/links/default.php
@@ -40,13 +40,13 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 					'closeButton' => false,
 					'backdrop'    => 'static',
 					'keyboard'    => false,
-					'footer'      => '<button type="button" class="btn" data-dismiss="modal"'
-						. ' onclick="Joomla.iframeButtonClick({iframeSelector: \'#plugin' . $this->redirectPluginId . 'Modal\', buttonSelector: \'#closeBtn\'})">'
-						. Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>'
-						. '<button type="button" class="btn btn-primary" data-dismiss="modal" onclick="Joomla.iframeButtonClick({iframeSelector: \'#plugin' . $this->redirectPluginId . 'Modal\', buttonSelector: \'#saveBtn\'})">'
-						. Text::_("JSAVE") . '</button>'
-						. '<button type="button" class="btn btn-success" onclick="Joomla.iframeButtonClick({iframeSelector: \'#plugin' . $this->redirectPluginId . 'Modal\', buttonSelector: \'#applyBtn\'}); return false;">'
+					'footer'      => '<button type="button" class="btn btn-success" onclick="Joomla.iframeButtonClick({iframeSelector: \'#plugin' . $this->redirectPluginId . 'Modal\', buttonSelector: \'#applyBtn\'}); return false;">'
 						. Text::_("JAPPLY") . '</button>'
+						. '<button type="button" class="btn btn-success" data-dismiss="modal" onclick="Joomla.iframeButtonClick({iframeSelector: \'#plugin' . $this->redirectPluginId . 'Modal\', buttonSelector: \'#saveBtn\'})">'
+						. Text::_("JSAVE") . '</button>'
+						. '<button type="button" class="btn" data-dismiss="modal"'
+						. ' onclick="Joomla.iframeButtonClick({iframeSelector: \'#plugin' . $this->redirectPluginId . 'Modal\', buttonSelector: \'#closeBtn\'})">'
+						. Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>',
 				)
 			); ?>
 		<?php endif; ?>


### PR DESCRIPTION
This PR changes the order of the modal footer buttons so that they are in the same order as the toolbar buttons ie Save, Save & Close, Close

This PR also changes the class from btn-primary to btn-success for the Save & Close button to match the toolbar colour

Any other changes to the code or codestyle are beyond the scope of this PR

Pull Request for Issue #29560  .
