### PR TITLE
[4.0] Fix typo

### DIFF
--- a/libraries/src/HTML/Helpers/SortableList.php
+++ b/libraries/src/HTML/Helpers/SortableList.php
@@ -37,6 +37,6 @@ abstract class SortableList
 	 */
 	public static function sortable($tableId, $formId, $sortDir = 'asc', $saveOrderingUrl = null, $proceedSaveOrderButton = true, $nestedList = false)
 	{
-		HtmlHelper::_('dragablelist.dragable', $tableId, $formId, $sortDir, $saveOrderingUrl, $proceedSaveOrderButton, $nestedList);
+		HtmlHelper::_('draggablelist.draggable', $tableId, $formId, $sortDir, $saveOrderingUrl, $proceedSaveOrderButton, $nestedList);
 	}
 }


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This PR fixes a typo in sortable method of SortableList helper class. The helper class is DraggableList, not DragableList and the method is draggable, not dragable (see https://github.com/joomla/joomla-cms/blob/4.0-dev/libraries/src/HTML/Helpers/DraggableList.php#L45)

### Testing Instructions
Code review should be enough. I found this while testing my extension on Joomla 4 nightly build.


