### PR TITLE
[4.x] - com_finder doesn't stop indexing on CSRF token mismatch

### DIFF
--- a/administrator/components/com_finder/src/Controller/IndexerController.php
+++ b/administrator/components/com_finder/src/Controller/IndexerController.php
@@ -62,7 +62,12 @@ class IndexerController extends BaseController
 		$this->app->allowCache(false);
 
 		// Check for a valid token. If invalid, send a 403 with the error message.
-		Session::checkToken('request') or static::sendResponse(new \Exception(Text::_('JINVALID_TOKEN_NOTICE'), 403));
+		if (!Session::checkToken('request'))
+		{
+			static::sendResponse(new \Exception(Text::_('JINVALID_TOKEN_NOTICE'), 403));
+
+			return;
+		}
 
 		// Put in a buffer to silence noise.
 		ob_start();
@@ -130,7 +135,12 @@ class IndexerController extends BaseController
 		$this->app->allowCache(false);
 
 		// Check for a valid token. If invalid, send a 403 with the error message.
-		Session::checkToken('request') or static::sendResponse(new \Exception(Text::_('JINVALID_TOKEN_NOTICE'), 403));
+		if (!Session::checkToken('request'))
+		{
+			static::sendResponse(new \Exception(Text::_('JINVALID_TOKEN_NOTICE'), 403));
+
+			return;
+		}
 
 		// Put in a buffer to silence noise.
 		ob_start();
@@ -246,7 +256,12 @@ class IndexerController extends BaseController
 		$this->app->allowCache(false);
 
 		// Check for a valid token. If invalid, send a 403 with the error message.
-		Session::checkToken('request') or static::sendResponse(new \Exception(Text::_('JINVALID_TOKEN_NOTICE'), 403));
+		if (!Session::checkToken('request'))
+		{
+			static::sendResponse(new \Exception(Text::_('JINVALID_TOKEN_NOTICE'), 403));
+
+			return;
+		}
 
 		// Put in a buffer to silence noise.
 		ob_start();

--- a/administrator/components/com_finder/src/Controller/IndexerController.php
+++ b/administrator/components/com_finder/src/Controller/IndexerController.php
@@ -39,6 +39,14 @@ class IndexerController extends BaseController
 	 */
 	public function start()
 	{
+		// Check for a valid token. If invalid, send a 403 with the error message.
+		if (!Session::checkToken('request'))
+		{
+			static::sendResponse(new \Exception(Text::_('JINVALID_TOKEN_NOTICE'), 403));
+
+			return;
+		}
+
 		$params = ComponentHelper::getParams('com_finder');
 
 		if ($params->get('enable_logging', '0'))
@@ -60,14 +68,6 @@ class IndexerController extends BaseController
 
 		// We don't want this form to be cached.
 		$this->app->allowCache(false);
-
-		// Check for a valid token. If invalid, send a 403 with the error message.
-		if (!Session::checkToken('request'))
-		{
-			static::sendResponse(new \Exception(Text::_('JINVALID_TOKEN_NOTICE'), 403));
-
-			return;
-		}
 
 		// Put in a buffer to silence noise.
 		ob_start();
@@ -112,6 +112,14 @@ class IndexerController extends BaseController
 	 */
 	public function batch()
 	{
+		// Check for a valid token. If invalid, send a 403 with the error message.
+		if (!Session::checkToken('request'))
+		{
+			static::sendResponse(new \Exception(Text::_('JINVALID_TOKEN_NOTICE'), 403));
+
+			return;
+		}
+
 		$params = ComponentHelper::getParams('com_finder');
 
 		if ($params->get('enable_logging', '0'))
@@ -133,14 +141,6 @@ class IndexerController extends BaseController
 
 		// We don't want this form to be cached.
 		$this->app->allowCache(false);
-
-		// Check for a valid token. If invalid, send a 403 with the error message.
-		if (!Session::checkToken('request'))
-		{
-			static::sendResponse(new \Exception(Text::_('JINVALID_TOKEN_NOTICE'), 403));
-
-			return;
-		}
 
 		// Put in a buffer to silence noise.
 		ob_start();
@@ -252,9 +252,6 @@ class IndexerController extends BaseController
 	 */
 	public function optimize()
 	{
-		// We don't want this form to be cached.
-		$this->app->allowCache(false);
-
 		// Check for a valid token. If invalid, send a 403 with the error message.
 		if (!Session::checkToken('request'))
 		{
@@ -262,6 +259,9 @@ class IndexerController extends BaseController
 
 			return;
 		}
+
+		// We don't want this form to be cached.
+		$this->app->allowCache(false);
 
 		// Put in a buffer to silence noise.
 		ob_start();

--- a/administrator/components/com_finder/src/Response/Response.php
+++ b/administrator/components/com_finder/src/Response/Response.php
@@ -41,9 +41,6 @@ class Response
 			Log::addLogger($options);
 		}
 
-		// The old token is invalid so send a new one.
-		$this->token = Factory::getSession()->getFormToken();
-
 		// Check if we are dealing with an error.
 		if ($state instanceof \Exception)
 		{

--- a/build/media_source/com_finder/js/indexer.es6.js
+++ b/build/media_source/com_finder/js/indexer.es6.js
@@ -139,9 +139,6 @@
 
       removeElement('progress');
 
-      if (data) {
-        data = data.responseText !== null ? data.evaluate(data.responseText, true) : data;
-      }
       const header = data ? data.header : Joomla.JText._('COM_FINDER_AN_ERROR_HAS_OCCURRED');
       const message = data ? data.message : `${Joomla.JText._('COM_FINDER_MESSAGE_RETURNED')}<br>${data}`;
 


### PR DESCRIPTION
### Summary of Changes
Added the required "return" statements after sending the error message to prevent the process from continuing.


### Testing Instructions
1. run the com_finder indexer from the backend and make sure it works
2. edit the line
`<input id="finder-indexer-token" type="hidden" name="<?php echo Factory::getSession()->getFormToken(); ?>" value="1">` to
`<input id="finder-indexer-token" type="hidden" name="123" value="1">`
in administrator/components/com_finder/tmpl/indexer/default.php and hit the "reindex" button again - an error message is shown.


### Actual result BEFORE applying this Pull Request
The error message is test case two isn't shown because the returned response is invalid


### Expected result AFTER applying this Pull Request
Error is shown

