### PR TITLE
WIP [4.0] Custom admin menu items alias

### DIFF
--- a/administrator/components/com_menus/tmpl/item/edit.php
+++ b/administrator/components/com_menus/tmpl/item/edit.php
@@ -47,12 +47,13 @@ if ($clientId === 1)
 ?>
 <form action="<?php echo Route::_('index.php?option=com_menus&view=item&client_id=' . $clientId . '&layout=' . $layout . $tmpl . '&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="item-form" class="form-validate">
 
-	<?php echo LayoutHelper::render('joomla.edit.title_alias', $this); ?>
-
 	<?php // Add the translation of the menu item title when client is administrator ?>
 	<?php if ($clientId === 1 && $this->item->id != 0) : ?>
 		<div class="row title-alias form-vertical mb-3">
-			<div class="col-12">
+			<div class="col-12 col-md-6">
+				<?php echo $this->form->renderField('title'); ?>
+			</div>
+			<div class="col-12 col-md-6">
 				<div class="control-group">
 					<div class="control-label">
 						<label for="menus_title_translation"><?php echo Text::sprintf('COM_MENUS_TITLE_TRANSLATION', $lang); ?></label>
@@ -63,8 +64,10 @@ if ($clientId === 1)
 				</div>
 			</div>
 		</div>
+	<?php // Add the alias of the menu item title when client is site ?>
+	<?php else : ?>
+		<?php echo LayoutHelper::render('joomla.edit.title_alias', $this); ?>
 	<?php endif; ?>
-
 	<div>
 
 		<?php echo HTMLHelper::_('uitab.startTabSet', 'myTab', array('active' => 'details')); ?>

--- a/administrator/components/com_menus/tmpl/items/default.php
+++ b/administrator/components/com_menus/tmpl/items/default.php
@@ -179,13 +179,13 @@ $assoc   = Associations::isEnabled() && $this->state->get('filter.client_id') ==
 										<?php echo $this->escape($item->title); ?>
 									<?php endif; ?>
 									<span class="small">
-									<?php if ($item->type != 'url') : ?>
+									<?php if ($item->type != 'url' && $item->client_id != 1) : ?>
 										<?php if (empty($item->note)) : ?>
 											<?php echo Text::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->alias)); ?>
 										<?php else : ?>
 											<?php echo Text::sprintf('JGLOBAL_LIST_ALIAS_NOTE', $this->escape($item->alias), $this->escape($item->note)); ?>
 										<?php endif; ?>
-									<?php elseif ($item->type == 'url' && $item->note) : ?>
+									<?php elseif ($item->type == 'url' || $item->client_id == 1 && $item->note) : ?>
 										<?php echo Text::sprintf('JGLOBAL_LIST_NOTE', $this->escape($item->note)); ?>
 									<?php endif; ?>
 									</span>


### PR DESCRIPTION
In the admin there are no SEF urls so there is no need to have a menu item alias for admin menu items. It just clutters the interface and confuses the user.

This PR _only_ removes the display of the alias it does not stop it being created.

### Testing Instructions
create an admin menu.
Create a menu item in that menu


### Actual result BEFORE applying this Pull Request
![image](https://user-images.githubusercontent.com/1296369/86530259-20f98880-beaf-11ea-8863-9265c0c53b29.png)


![image](https://user-images.githubusercontent.com/1296369/86530253-13440300-beaf-11ea-82c6-a428b5b02c3c.png)

### Expected result AFTER applying this Pull Request
![image](https://user-images.githubusercontent.com/1296369/86530240-f14a8080-beae-11ea-9163-8e0a308fb6f6.png)

![image](https://user-images.githubusercontent.com/1296369/86530247-02938d00-beaf-11ea-8d81-7b27d76b0aea.png)




