### PR TITLE
[4.0] Optimizing Smart Search for larger content

### DIFF
--- a/administrator/components/com_finder/src/Indexer/Helper.php
+++ b/administrator/components/com_finder/src/Indexer/Helper.php
@@ -103,6 +103,11 @@ class Helper
 			$language = Language::getInstance($lang);
 		}
 
+		if (!isset($cache[$lang]))
+		{
+			$cache[$lang] = [];
+		}
+
 		$tokens = array();
 		$terms = $language->tokenise($input);
 
@@ -125,17 +130,15 @@ class Helper
 			// Create tokens from the terms.
 			for ($i = 0, $n = count($terms); $i < $n; $i++)
 			{
-				$key = $lang . '::' . $terms[$i];
-
-				if (isset($cache[$key]))
+				if (isset($cache[$lang][$terms[$i]]))
 				{
-					$tokens[] = $cache[$key];
+					$tokens[] = $cache[$lang][$terms[$i]];
 				}
 				else
 				{
 					$token = new Token($terms[$i], $language->language);
 					$tokens[] = $token;
-					$cache[$key] = $token;
+					$cache[$lang][$terms[$i]] = $token;
 				}
 			}
 
@@ -155,18 +158,18 @@ class Helper
 						}
 
 						$temp[] = $tokens[$i + $j]->term;
-						$key = $lang . '::' . implode('::', $temp);
+						$key = implode('::', $temp);
 
-						if (isset($cache[$key]))
+						if (isset($cache[$lang][$key]))
 						{
-							$tokens[] = $cache[$key];
+							$tokens[] = $cache[$lang][$key];
 						}
 						else
 						{
 							$token = new Token($temp, $language->language, $language->spacer);
 							$token->derived = true;
 							$tokens[] = $token;
-							$cache[$key] = $token;
+							$cache[$lang][$key] = $token;
 						}
 					}
 				}
@@ -174,7 +177,7 @@ class Helper
 		}
 
 		// Prevent the cache to fill up the memory
-		while (count($cache) > 2048)
+		while (count($cache[$lang]) > 1024)
 		{
 			/**
 			 * We want to cache the most common words/tokens. At the same time
@@ -182,7 +185,7 @@ class Helper
 			 * be early in the text, so we are dropping all terms/tokens which
 			 * have been cached later.
 			 */
-			array_pop($cache);
+			array_pop($cache[$lang]);
 		}
 
 		return $tokens;


### PR DESCRIPTION
### Summary of Changes
Smart Search has issues with larger content and to be honest, this already triggers rather early. It fails for content larger than 200kb.

The first issue is, that the description column in the #__finder_links table is not large enough. The solution here is to truncate the description to a reasonable size. That reasonable size is 32000 characters and I pulled that number out of thin air. I hope that it is low enough to allow for a string with multi-byte chars still to be saved.

The second issue is, that we are trying to store all tokens at once in the DB. That means if we have a text with 50k words, we are creating a query that tries to insert 50k rows at once. That fails spectacularly. So now we do this in chunks of 128 rows at a time.

Third issue is the tokens table is running full rather easily. The number of tokens storable in the tokens table is depending on the max_heap_table_size, which on my system is set to 16MB and which in that case fails at just 22k entries. To get around this issue, we have the toggleTables() method, but that has only been run so far between the different properties to index. If you text has 2MB in size, it tries to insert all those 2MB into the DB and it fails right away. Thus we are checking the limit also when storing in the additional code of issue 2. I also reduced the number of entries to 10k instead of 30k.

This fixes #27807. 

### Testing Instructions
Find a large text, for example the bible and create an article with that as content. Save and previously see that it takes a very long time and fails at some point. Apply this patch and try again. See now that it doesn't take as long and actually works successfully now.
