### PR TITLE
[4.0] Finder: pseudo-empty search query should not throw error

### DIFF
--- a/administrator/components/com_finder/src/Indexer/Query.php
+++ b/administrator/components/com_finder/src/Indexer/Query.php
@@ -1225,6 +1225,12 @@ class Query
 		{
 			// Tokenize the phrase.
 			$token = Helper::tokenize($phrases[$i], $lang, true);
+
+			if (!count($token))
+			{
+				continue;
+			}
+
 			$token = $this->getTokenData(array_shift($token));
 
 			if ($params->get('filter_commonwords', 0) && $token->common)


### PR DESCRIPTION
In short, this fixes #29511. Before applying this patch, search for ```":"``` in Smart Search including the quotes. See that it returns notices. Apply patch, see that notices are gone.