### PR TITLE
[4.0] Show error message when restoring version fails

### DIFF
--- a/libraries/src/Versioning/VersionableControllerTrait.php
+++ b/libraries/src/Versioning/VersionableControllerTrait.php
@@ -74,14 +74,19 @@ trait VersionableControllerTrait
 			return false;
 		}
 
-		$table->check();
-		$table->store();
 		$this->setRedirect(
 			Route::_(
 				'index.php?option=' . $this->option . '&view=' . $this->view_item
 				. $this->getRedirectToItemAppend($recordId, $urlVar), false
 			)
 		);
+
+		if (!$table->check() || !$table->store())
+		{
+			$this->setMessage($table->getError(), 'error');
+
+			return false;
+		}
 
 		$this->setMessage(
 			Text::sprintf(


### PR DESCRIPTION
### Summary of Changes

Show a message when restoring history version fails.

### Testing Instructions

Create an article.
Make some edits to create multiple versions.
Click `Versions` button.
In the modal select a version and click `Restore`.

### Actual result BEFORE applying this Pull Request

Version is not restore but success message is shown.

### Expected result AFTER applying this Pull Request

Error message is shown:

>Error
>Column 'ordering' cannot be null

### Documentation Changes Required

No.