### PR TITLE
[4.0] Fix translation of message titles in Cassiopea

### DIFF
--- a/layouts/joomla/system/message.php
+++ b/layouts/joomla/system/message.php
@@ -27,6 +27,12 @@ $alert = [
 	'message'                     => 'success'
 ];
 
+// Load JavaScript message titles
+Text::script('ERROR');
+Text::script('WARNING');
+Text::script('NOTICE');
+Text::script('MESSAGE');
+
 // Alerts progressive enhancement
 Factory::getDocument()->getWebAssetManager()
 	->useStyle('webcomponent.joomla-alert')

--- a/templates/cassiopeia/index.php
+++ b/templates/cassiopeia/index.php
@@ -73,12 +73,6 @@ $this->setMetaData('viewport', 'width=device-width, initial-scale=1');
 
 $stickyHeader = $this->params->get('stickyHeader') ? 'position-sticky sticky-top' : '';
 
-// Load JavaScript message titles
-Text::script('ERROR');
-Text::script('WARNING');
-Text::script('NOTICE');
-Text::script('MESSAGE');
-
 ?>
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">

--- a/templates/cassiopeia/index.php
+++ b/templates/cassiopeia/index.php
@@ -73,6 +73,12 @@ $this->setMetaData('viewport', 'width=device-width, initial-scale=1');
 
 $stickyHeader = $this->params->get('stickyHeader') ? 'position-sticky sticky-top' : '';
 
+// Load JavaScript message titles
+Text::script('ERROR');
+Text::script('WARNING');
+Text::script('NOTICE');
+Text::script('MESSAGE');
+
 ?>
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/30009

### Summary of Changes
Adding the javascript strings in index.php. Thanks @brianteeman 
Chose index.php instead of specific views to not bother anymore.
We use the same trick for installation/index.php


### Testing Instructions
See https://github.com/joomla/joomla-cms/issues/30009


### Actual result BEFORE applying this Pull Request
<img width="595" alt="Screenshot 2020-07-05 at 22 20 42" src="https://user-images.githubusercontent.com/400092/86542454-d1967500-bf0d-11ea-99c2-1ca506e75b5f.png">



### Expected result AFTER applying this Pull Request
<img width="891" alt="Screen Shot 2020-07-06 at 10 42 56" src="https://user-images.githubusercontent.com/869724/86574036-7dbf7680-bf75-11ea-86ec-aa9041edbcda.png">
