### PR TITLE
[4.0] Fix for wrong site title when using ToobarHelper in frontend

### DIFF
--- a/libraries/src/Toolbar/ToolbarHelper.php
+++ b/libraries/src/Toolbar/ToolbarHelper.php
@@ -44,12 +44,12 @@ abstract class ToolbarHelper
 		$app = Factory::getApplication();
 		$app->JComponentTitle = $html;
 		
-                $title = strip_tags($title) . ' - ' . $app->get('sitename');
+		$title = strip_tags($title) . ' - ' . $app->get('sitename');
             
-       		if ($app->isClient('administrator'))
-        	{
+		if ($app->isClient('administrator'))
+		{
             		$title .= ' - ' . Text::_('JADMINISTRATION');
-        	}
+		}
 		
 		Factory::getDocument()->setTitle($title);
 	}

--- a/libraries/src/Toolbar/ToolbarHelper.php
+++ b/libraries/src/Toolbar/ToolbarHelper.php
@@ -44,6 +44,7 @@ abstract class ToolbarHelper
 		$app = Factory::getApplication();
 		$app->JComponentTitle = $html;
 		$title = strip_tags($title) . ' - ' . $app->get('sitename');
+
 		if ($app->isClient('administrator'))
 		{
 			$title .= ' - ' . Text::_('JADMINISTRATION');

--- a/libraries/src/Toolbar/ToolbarHelper.php
+++ b/libraries/src/Toolbar/ToolbarHelper.php
@@ -44,7 +44,6 @@ abstract class ToolbarHelper
 		$app = Factory::getApplication();
 		$app->JComponentTitle = $html;
 		$title = strip_tags($title) . ' - ' . $app->get('sitename');
-            
 		if ($app->isClient('administrator'))
 		{
 			$title .= ' - ' . Text::_('JADMINISTRATION');

--- a/libraries/src/Toolbar/ToolbarHelper.php
+++ b/libraries/src/Toolbar/ToolbarHelper.php
@@ -49,6 +49,7 @@ abstract class ToolbarHelper
 		{
 			$title .= ' - ' . Text::_('JADMINISTRATION');
 		}
+
 		Factory::getDocument()->setTitle($title);
 	}
 

--- a/libraries/src/Toolbar/ToolbarHelper.php
+++ b/libraries/src/Toolbar/ToolbarHelper.php
@@ -43,7 +43,6 @@ abstract class ToolbarHelper
 
 		$app = Factory::getApplication();
 		$app->JComponentTitle = $html;
-		
 		$title = strip_tags($title) . ' - ' . $app->get('sitename');
             
 		if ($app->isClient('administrator'))

--- a/libraries/src/Toolbar/ToolbarHelper.php
+++ b/libraries/src/Toolbar/ToolbarHelper.php
@@ -48,7 +48,7 @@ abstract class ToolbarHelper
             
 		if ($app->isClient('administrator'))
 		{
-            		$title .= ' - ' . Text::_('JADMINISTRATION');
+			$title .= ' - ' . Text::_('JADMINISTRATION');
 		}
 		
 		Factory::getDocument()->setTitle($title);

--- a/libraries/src/Toolbar/ToolbarHelper.php
+++ b/libraries/src/Toolbar/ToolbarHelper.php
@@ -50,7 +50,6 @@ abstract class ToolbarHelper
 		{
 			$title .= ' - ' . Text::_('JADMINISTRATION');
 		}
-		
 		Factory::getDocument()->setTitle($title);
 	}
 

--- a/libraries/src/Toolbar/ToolbarHelper.php
+++ b/libraries/src/Toolbar/ToolbarHelper.php
@@ -44,7 +44,7 @@ abstract class ToolbarHelper
 		$app = Factory::getApplication();
 		$app->JComponentTitle = $html;
 		
-		$title = strip_tags($title) . ' - ' . $app->get('sitename');
+                $title = strip_tags($title) . ' - ' . $app->get('sitename');
             
        		if ($app->isClient('administrator'))
         	{

--- a/libraries/src/Toolbar/ToolbarHelper.php
+++ b/libraries/src/Toolbar/ToolbarHelper.php
@@ -43,7 +43,15 @@ abstract class ToolbarHelper
 
 		$app = Factory::getApplication();
 		$app->JComponentTitle = $html;
-		Factory::getDocument()->setTitle(strip_tags($title) . ' - ' . $app->get('sitename') . ' - ' . Text::_('JADMINISTRATION'));
+		
+		$title = strip_tags($title) . ' - ' . $app->get('sitename');
+            
+       		if ($app->isClient('administrator'))
+        	{
+            		$title .= ' - ' . Text::_('JADMINISTRATION');
+        	}
+		
+		Factory::getDocument()->setTitle($title);
 	}
 
 	/**


### PR DESCRIPTION
### Summary of Changes

Site title  "- Administration" should only be added at administrator.
This happens when component developers use the toolbar helper in the frontend

### Testing Instructions
Using Toolbar Helper in a Frontend Compoennt and check the site title.

You can test it by changeing article view like these

https://github.com/joomla/joomla-cms/compare/4.0-dev...Didldu-Florian:patch-6

Open then an article in frontend, you will see then the problem in the <title>

### Actual result BEFORE applying this Pull Request

The site title ist looking like these at frontend:

`<title>Home - JADMINISTRATION</title>`

### Expected result AFTER applying this Pull Request

`<title>Home</title>`

The Problem is also that the language key JADMINISTRATION is not translated either.
So finaly we should not add "- JADMINISTRATION" at frontend.

This fix does this

