### PR TITLE
[4.0] fix removeroot automatically

### DIFF
--- a/libraries/src/Application/AdministratorApplication.php
+++ b/libraries/src/Application/AdministratorApplication.php
@@ -478,7 +478,7 @@ class AdministratorApplication extends CMSApplication
 				$this->enqueueMessage(
 					Text::sprintf(
 						'JWARNING_REMOVE_ROOT_USER',
-						'index.php?option=com_config&task=config.removeroot&' . Session::getFormToken() . '=1'
+						'index.php?option=com_config&task=application.removeroot&' . Session::getFormToken() . '=1'
 					),
 					'error'
 				);
@@ -490,7 +490,7 @@ class AdministratorApplication extends CMSApplication
 					Text::sprintf(
 						'JWARNING_REMOVE_ROOT_USER_ADMIN',
 						$rootUser,
-						'index.php?option=com_config&task=config.removeroot&' . Session::getFormToken() . '=1'
+						'index.php?option=com_config&task=application.removeroot&' . Session::getFormToken() . '=1'
 					),
 					'error'
 				);


### PR DESCRIPTION
Closes https://github.com/joomla/joomla-cms/issues/30029

### Summary of Changes

change controller in url

### Testing Instructions


install Joomla 4
manually edit `configuration.php` add:

```php
public $root_user = 'admin';
```

Login to the admin console 


<img width="1074" alt="Screenshot 2020-07-06 at 12 59 15" src="https://user-images.githubusercontent.com/400092/86591127-d77d6c00-bf88-11ea-9e41-e32bf8e9d993.png">

Click the link `Select here to try to do it automatically.`

### Actual result BEFORE applying this Pull Request

<img width="1260" alt="Screenshot 2020-07-06 at 13 02 24" src="https://user-images.githubusercontent.com/400092/86591181-f4b23a80-bf88-11ea-9128-927c1a7422b5.png">

### Expected result AFTER applying this Pull Request

Clicking the link removes the $root_user param in `JConfig` / `configuration.php`

### Documentation Changes Required

