### PR TITLE
[4.0] Auto removing $root_user gives Invalid controller class: config

### DIFF
--- a/libraries/src/Application/AdministratorApplication.php
+++ b/libraries/src/Application/AdministratorApplication.php
@@ -478,7 +478,7 @@ class AdministratorApplication extends CMSApplication
 				$this->enqueueMessage(
 					Text::sprintf(
 						'JWARNING_REMOVE_ROOT_USER',
-						'index.php?option=com_config&task=config.removeroot&' . Session::getFormToken() . '=1'
+						'index.php?option=com_config&task=application.removeroot&' . Session::getFormToken() . '=1'
 					),
 					'error'
 				);
@@ -490,7 +490,7 @@ class AdministratorApplication extends CMSApplication
 					Text::sprintf(
 						'JWARNING_REMOVE_ROOT_USER_ADMIN',
 						$rootUser,
-						'index.php?option=com_config&task=config.removeroot&' . Session::getFormToken() . '=1'
+						'index.php?option=com_config&task=application.removeroot&' . Session::getFormToken() . '=1'
 					),
 					'error'
 				);

--- a/libraries/src/Application/AdministratorApplication.php
+++ b/libraries/src/Application/AdministratorApplication.php
@@ -480,7 +480,7 @@ class AdministratorApplication extends CMSApplication
 						'JWARNING_REMOVE_ROOT_USER',
 						'index.php?option=com_config&task=application.removeroot&' . Session::getFormToken() . '=1'
 					),
-					'error'
+					'warning'
 				);
 			}
 			// Show this message to superusers too

--- a/libraries/src/Application/AdministratorApplication.php
+++ b/libraries/src/Application/AdministratorApplication.php
@@ -492,7 +492,7 @@ class AdministratorApplication extends CMSApplication
 						$rootUser,
 						'index.php?option=com_config&task=application.removeroot&' . Session::getFormToken() . '=1'
 					),
-					'error'
+					'warning'
 				);
 			}
 		}


### PR DESCRIPTION
Fixes https://github.com/joomla/joomla-cms/issues/30029

### Summary of Changes
- Exchange controller class "config" (controller AdministratorConfig.php does mot exist) => "application" (= controller AdministratorApplication.php)
- Change error alert to warning alert.

### Testing Instructions
- In congiguration.php add line:

`public $root_user = 'admin';`

- Backend: 1) Login as a Super User 2) Login with `$root_user `.

- In both cases you'll see a alert message with a link "Select here to try to do it automatically.".

### Actual result BEFORE applying this Pull Request
- ALert message says "Error" but it's not an error.
- Clicking link throws an fatal error "Invalid controller class: config".

### Expected result AFTER applying this Pull Request
- Alert color changed from red error to whatever-color-this-is warning.
- Clicking link deletes line `public $root_user = 'admin';` from configuration.php.
- Success message "Configuration saved".

### Documentation Changes Required
- No
