### PR TITLE
[4] Don't interrupt getCoreList() if single template has no /html/

### DIFF
--- a/administrator/components/com_templates/src/Model/TemplateModel.php
+++ b/administrator/components/com_templates/src/Model/TemplateModel.php
@@ -245,12 +245,6 @@ class TemplateModel extends FormModel
 			{
 				$this->prepareCoreFiles($path, $element, $template);
 			}
-			else
-			{
-				$app->enqueueMessage(Text::_('COM_TEMPLATES_ERROR_TEMPLATE_FOLDER_NOT_FOUND'), 'error');
-
-				return false;
-			}
 		}
 
 		// Sort list of stdClass array.


### PR DESCRIPTION
Fixes https://github.com/joomla/joomla-cms/issues/30035

### Summary of Changes
- Don't interrupt `getCoreList()` at all if single template has no `/html/` folder. Simply go on.

### Testing Instructions
- **Activate plugin `Installer - Override`**
- Install this remplate: [Link removed 2020-07-11 after request of shor-ty] (provided by @shor-ty).
This template has no /html/-folder in package.

- Hint: Uninstall template before each new test (it has no `method="update"`).

### Actual result BEFORE applying this Pull Request
- Plugin `Installer - Override` provokes an error message `COM_TEMPLATES_ERROR_TEMPLATE_FOLDER_NOT_FOUND`  by calling method getCoreList() that can't find folder /html/ in new template.
- `COM_TEMPLATES_ERROR_TEMPLATE_FOLDER_NOT_FOUND` is wrong here because it says that the template folder wasn't found. That's not true.

### Expected result AFTER applying this Pull Request
- There is no need to stop searching for overrides in other templates just because a single template has no html folder.
- No error message during installation. 

### Documentation Changes Required
- No.
