### PR TITLE
[4.0] Removing unnecessary workaround in finder indexer

### DIFF
--- a/administrator/components/com_finder/src/Controller/IndexerController.php
+++ b/administrator/components/com_finder/src/Controller/IndexerController.php
@@ -11,9 +11,7 @@ namespace Joomla\Component\Finder\Administrator\Controller;
 
 \defined('_JEXEC') or die;
 
-use Joomla\CMS\Application\SiteApplication;
 use Joomla\CMS\Component\ComponentHelper;
-use Joomla\CMS\Document\FactoryInterface;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;

--- a/administrator/components/com_finder/src/Controller/IndexerController.php
+++ b/administrator/components/com_finder/src/Controller/IndexerController.php
@@ -155,7 +155,6 @@ class IndexerController extends BaseController
 		 * in order to work around some plugins that don't do proper environment
 		 * checks before trying to use HTML document functions.
 		 */
-		$raw = clone Factory::getDocument();
 		$lang = Factory::getLanguage();
 
 		// Get the document properties.
@@ -166,27 +165,6 @@ class IndexerController extends BaseController
 			'language'  => $lang->getTag(),
 			'direction' => $lang->isRtl() ? 'rtl' : 'ltr'
 		);
-
-		// Get the HTML document.
-		$html = Factory::getContainer()->get(FactoryInterface::class)->createDocument('html', $attributes);
-
-		// TODO: Why is this document fetched and immediately overwritten?
-		$doc  = Factory::getDocument();
-
-		// Swap the documents.
-		$doc = $html;
-
-		// Get the admin application.
-		$admin = clone Factory::getApplication();
-
-		// Get the site app.
-		$site = Factory::getContainer()->get(SiteApplication::class);
-
-		// Swap the app.
-		$app = Factory::getApplication();
-
-		// TODO: Why is the app fetched and immediately overwritten?
-		$app = $site;
 
 		// Start the indexer.
 		try
@@ -201,12 +179,6 @@ class IndexerController extends BaseController
 			$state = Indexer::getState();
 			$state->start = 0;
 			$state->complete = 0;
-
-			// Swap the documents back.
-			$doc = $raw;
-
-			// Swap the applications back.
-			$app = $admin;
 
 			// Log batch completion and memory high-water mark.
 			try
@@ -225,9 +197,6 @@ class IndexerController extends BaseController
 		// Catch an exception and return the response.
 		catch (\Exception $e)
 		{
-			// Swap the documents back.
-			$doc = $raw;
-
 			// Send the response.
 			static::sendResponse($e);
 		}
@@ -318,8 +287,12 @@ class IndexerController extends BaseController
 		// Create the response object.
 		$response = new Response($data);
 
-		// Add the buffer.
-		$response->buffer = \JDEBUG ? ob_get_contents() : ob_end_clean();
+		if (\JDEBUG)
+		{
+			// Add the buffer and memory usage
+			$response->buffer = ob_get_contents();
+			$response->memory = memory_get_usage(true);
+		}
 
 		// Send the JSON response.
 		echo json_encode($response);


### PR DESCRIPTION
There is a bunch of code swapping around application and document objects in the hopes to get around badly written plugins. However first of all we shouldn't be promoting to write bad code and instead enforce proper code and second: We don't have any of this in the CLI indexer. So if we don't need it there, we don't need it anywhere. So this can simply go.

I'm also adding the used memory to the debug output. That is rather helpfull to debug memory optimisations in the finder.