### PR TITLE
[4.0] Fix Cassiopea Modals body and Close button display

### DIFF
--- a/templates/cassiopeia/scss/blocks/_modals.scss
+++ b/templates/cassiopeia/scss/blocks/_modals.scss
@@ -20,7 +20,9 @@
 
   .close {
     width: $modal-header-height;
+    padding: 0;
     margin-top: 0;
+    margin-bottom: 0;
     font-size: 2rem;
     line-height: $modal-header-height;
 
@@ -34,10 +36,6 @@
       border-right: 1px solid $cassiopeia-border-color;
     }
   }
-}
-
-.modal-body {
-  padding: 0;
 }
 
 .modal-title {


### PR DESCRIPTION
### Summary of Changes
Correcting wrong body padding.
Therefore correcting wrong Close button padding and margin to display as square
Both body and close button will now display as in back-end


### Testing Instructions
Display any modal in frontend, for example through CMS Content when editing an article OR editing Template settings and Select Image


### Actual result BEFORE applying this Pull Request
Example below is for Image Select in Template settings
<img width="1432" alt="Screen Shot 2020-07-07 at 08 17 22" src="https://user-images.githubusercontent.com/869724/86730525-e9b1e580-c02e-11ea-8d8c-93ea9f45ecaf.png">

Close button detail
<img width="157" alt="Screen Shot 2020-07-07 at 08 59 25" src="https://user-images.githubusercontent.com/869724/86731897-3d70fe80-c030-11ea-86d3-384013e2ab2b.png">


### Expected result AFTER applying this Pull Request
Image below is for CMS Content =>Image
<img width="1451" alt="Screen Shot 2020-07-07 at 08 56 56" src="https://user-images.githubusercontent.com/869724/86731501-e4a16600-c02f-11ea-8fe2-149230f05d28.png">


Close button detail
<img width="276" alt="Screen Shot 2020-07-07 at 08 41 13" src="https://user-images.githubusercontent.com/869724/86731005-6218a680-c02f-11ea-89b4-1ce9a0a5adb1.png">
