### PR TITLE
[4.0] Get menu directly in com_tags menu route helper

### DIFF
--- a/components/com_tags/src/Helper/RouteHelper.php
+++ b/components/com_tags/src/Helper/RouteHelper.php
@@ -11,6 +11,7 @@ namespace Joomla\Component\Tags\Site\Helper;
 
 \defined('_JEXEC') or die;
 
+use Joomla\CMS\Application\SiteApplication;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Helper\RouteHelper as CMSRouteHelper;
@@ -153,7 +154,7 @@ class RouteHelper extends CMSRouteHelper
 	 */
 	protected static function _findItem($needles = null)
 	{
-		$app      = Factory::getApplication();
+		$app      = Factory::getContainer()->get(SiteApplication::class);
 		$menus    = $app->getMenu('site');
 		$language = $needles['language'] ?? '*';
 

--- a/components/com_tags/src/Helper/RouteHelper.php
+++ b/components/com_tags/src/Helper/RouteHelper.php
@@ -11,7 +11,6 @@ namespace Joomla\Component\Tags\Site\Helper;
 
 \defined('_JEXEC') or die;
 
-use Joomla\CMS\Application\SiteApplication;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Helper\RouteHelper as CMSRouteHelper;
 use Joomla\CMS\Menu\AbstractMenu;

--- a/components/com_tags/src/Helper/RouteHelper.php
+++ b/components/com_tags/src/Helper/RouteHelper.php
@@ -13,8 +13,8 @@ namespace Joomla\Component\Tags\Site\Helper;
 
 use Joomla\CMS\Application\SiteApplication;
 use Joomla\CMS\Component\ComponentHelper;
-use Joomla\CMS\Factory;
 use Joomla\CMS\Helper\RouteHelper as CMSRouteHelper;
+use Joomla\CMS\Menu\AbstractMenu;
 
 /**
  * Tags Component Route Helper.
@@ -154,8 +154,7 @@ class RouteHelper extends CMSRouteHelper
 	 */
 	protected static function _findItem($needles = null)
 	{
-		$app      = Factory::getContainer()->get(SiteApplication::class);
-		$menus    = $app->getMenu('site');
+		$menus    = AbstractMenu::getInstance('site');
 		$language = $needles['language'] ?? '*';
 
 		// Prepare the reverse lookup array.


### PR DESCRIPTION
### Summary of Changes

Fixes error when running Finder CLI.

### Testing Instructions

Install Testing Sample Data or create some articles with tags.
Run `php cli/finder_indexer.php`

### Actual result BEFORE applying this Pull Request

```
Symfony\Component\ErrorHandler\Error\UndefinedMethodError^ {#688
  #message: "Attempted to call an undefined method named "getMenu" of class "FinderCli"."
  #code: 0
  #file: "C:\wamp\www\joomla-cms\components\com_tags\src\Helper\RouteHelper.php"
  #line: 157
  trace: {
    C:\wamp\www\joomla-cms\components\com_tags\src\Helper\RouteHelper.php:157 {
      Joomla\Component\Tags\Site\Helper\RouteHelper::_findItem($needles = null)^
      › $app      = Factory::getApplication();
      › $menus    = $app->getMenu('site');
      › $language = $needles['language'] ?? '*';
    }
    C:\wamp\www\joomla-cms\components\com_tags\src\Helper\RouteHelper.php:104 { …}
    C:\wamp\www\joomla-cms\plugins\finder\tags\tags.php:232 { …}
    C:\wamp\www\joomla-cms\administrator\components\com_finder\src\Indexer\Adapter.php:247 { …}
    C:\wamp\www\joomla-cms\libraries\src\Plugin\CMSPlugin.php:285 { …}
    C:\wamp\www\joomla-cms\libraries\vendor\joomla\event\src\Dispatcher.php:495 { …}
    C:\wamp\www\joomla-cms\libraries\src\Application\EventAware.php:111 { …}
    C:\wamp\www\joomla-cms\cli\finder_indexer.php:266 { …}
    C:\wamp\www\joomla-cms\cli\finder_indexer.php:194 { …}
    C:\wamp\www\joomla-cms\libraries\src\Application\CliApplication.php:241 { …}
    C:\wamp\www\joomla-cms\cli\finder_indexer.php:514 { …}
  }
}
```

### Expected result AFTER applying this Pull Request

No errors.

### Documentation Changes Required

