### PR TITLE
[4.0] Transitions still shown when workflows disabled

### DIFF
--- a/administrator/components/com_content/src/View/Featured/HtmlView.php
+++ b/administrator/components/com_content/src/View/Featured/HtmlView.php
@@ -86,7 +86,6 @@ class HtmlView extends BaseHtmlView
 		$this->state         = $this->get('State');
 		$this->filterForm    = $this->get('FilterForm');
 		$this->activeFilters = $this->get('ActiveFilters');
-		$this->transitions   = $this->get('Transitions');
 		$this->vote          = PluginHelper::isEnabled('content', 'vote');
 
 		if (ComponentHelper::getParams('com_content')->get('workflow_enabled'))


### PR DESCRIPTION
Fixes https://github.com/joomla/joomla-cms/issues/30041.

### Summary of Changes

Removes transitions from actions list in featured article view when workflows are disabled.

### Testing Instructions

Make sure workflows are disabled.
Create a featured article.
Go to featured articles in backend.
Select the article and click `Actions` button.
Inspect the contents of the dropdown.

### Actual result BEFORE applying this Pull Request

Transitions and standard actions are shown.

### Expected result AFTER applying this Pull Request

Only standard actions are shown.

### Documentation Changes Required

No.