### PR TITLE
[3+] handle blank $root_user correctly

### DIFF
--- a/libraries/src/Application/AdministratorApplication.php
+++ b/libraries/src/Application/AdministratorApplication.php
@@ -421,7 +421,7 @@ class AdministratorApplication extends CMSApplication
 		// Safety check for when configuration.php root_user is in use.
 		$rootUser = $this->get('root_user');
 
-		if (property_exists('\JConfig', 'root_user'))
+		if ($rootUser && property_exists('\JConfig', 'root_user'))
 		{
 			if (\JFactory::getUser()->get('username') === $rootUser || \JFactory::getUser()->id === (string) $rootUser)
 			{

--- a/libraries/src/Application/AdministratorApplication.php
+++ b/libraries/src/Application/AdministratorApplication.php
@@ -421,7 +421,7 @@ class AdministratorApplication extends CMSApplication
 		// Safety check for when configuration.php root_user is in use.
 		$rootUser = $this->get('root_user');
 
-		if ($rootUser && property_exists('\JConfig', 'root_user'))
+		if ($rootUser)
 		{
 			if (\JFactory::getUser()->get('username') === $rootUser || \JFactory::getUser()->id === (string) $rootUser)
 			{


### PR DESCRIPTION
Closes #30051

### Summary of Changes

only shows message when `$root_user` has an actual value and not when `$root_user = '';` in `configuration.php`

Same fix needs to bubble up to Joomla 4 as Joomla 4 has the same bug. 

### Testing Instructions

Install Joomla 3
manually edit /configuration.php and create class property of 

```
	public $root_user = '';
```

visit /administrator/ when logged out

### Actual result BEFORE applying this Pull Request

<img width="440" alt="86895731-d1100100-c0fc-11ea-9367-d22d1ca5cf66" src="https://user-images.githubusercontent.com/400092/86940984-4dc1d000-c13b-11ea-8314-3eefef71a1ab.png">


### Expected result AFTER applying this Pull Request

<img width="554" alt="Screenshot 2020-07-08 at 16 52 06" src="https://user-images.githubusercontent.com/400092/86941040-5dd9af80-c13b-11ea-92a6-6bb934cf7db3.png">


### Documentation Changes Required

none