### PR TITLE
[4.0] Fix column name ordering

### DIFF
--- a/administrator/components/com_modules/src/Model/PositionsModel.php
+++ b/administrator/components/com_modules/src/Model/PositionsModel.php
@@ -59,7 +59,7 @@ class PositionsModel extends ListModel
 	 *
 	 * @since   1.6
 	 */
-	protected function populateState($ordering = 'value', $direction = 'asc')
+	protected function populateState($ordering = 'ordering', $direction = 'asc')
 	{
 		// Load the filter state.
 		$search = $this->getUserStateFromRequest($this->context . '.filter.search', 'filter_search');


### PR DESCRIPTION
### Summary of Changes
Fix wrong column name in populateState params


### Testing Instructions
Code inspect. Compare the table #__modules, there is no column "value".

