### PR TITLE
[4.0] Another [274 file] General Cleanup

### DIFF
--- a/administrator/components/com_actionlogs/tmpl/actionlogs/default.php
+++ b/administrator/components/com_actionlogs/tmpl/actionlogs/default.php
@@ -21,7 +21,7 @@ use Joomla\Component\Actionlogs\Administrator\View\Actionlogs\HtmlView;
 $listOrder  = $this->escape($this->state->get('list.ordering'));
 $listDirn   = $this->escape($this->state->get('list.direction'));
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('keepalive')
 	->useScript('com_actionlogs.admin-actionlogs');

--- a/administrator/components/com_admin/src/View/Profile/HtmlView.php
+++ b/administrator/components/com_admin/src/View/Profile/HtmlView.php
@@ -75,7 +75,7 @@ class HtmlView extends BaseHtmlView
 	 */
 	public function display($tpl = null)
 	{
-		/** @var \Joomla\Component\Admin\Administrator\Model\ProfileModel $model */
+		/* @var \Joomla\Component\Admin\Administrator\Model\ProfileModel $model */
 		$model = $this->getModel();
 
 		$this->form      = $model->getForm();

--- a/administrator/components/com_admin/tmpl/help/default.php
+++ b/administrator/components/com_admin/tmpl/help/default.php
@@ -14,7 +14,7 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 
-/** @var \Joomla\Component\Admin\Administrator\View\Help\HtmlView $this */
+/* @var \Joomla\Component\Admin\Administrator\View\Help\HtmlView $this */
 
 ?>
 <form action="<?php echo Route::_('index.php?option=com_admin&amp;view=help'); ?>" method="post" name="adminForm" id="adminForm">

--- a/administrator/components/com_admin/tmpl/sysinfo/default.php
+++ b/administrator/components/com_admin/tmpl/sysinfo/default.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
-/** @var \Joomla\Component\Admin\Administrator\View\Sysinfo\HtmlView $this */
+/* @var \Joomla\Component\Admin\Administrator\View\Sysinfo\HtmlView $this */
 
 ?>
 <div class="row">

--- a/administrator/components/com_admin/tmpl/sysinfo/default_config.php
+++ b/administrator/components/com_admin/tmpl/sysinfo/default_config.php
@@ -11,7 +11,7 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 
-/** @var \Joomla\Component\Admin\Administrator\View\Sysinfo\HtmlView $this */
+/* @var \Joomla\Component\Admin\Administrator\View\Sysinfo\HtmlView $this */
 ?>
 <div class="sysinfo">
 	<table class="table">

--- a/administrator/components/com_admin/tmpl/sysinfo/default_directory.php
+++ b/administrator/components/com_admin/tmpl/sysinfo/default_directory.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
-/** @var \Joomla\Component\Admin\Administrator\View\Sysinfo\HtmlView $this */
+/* @var \Joomla\Component\Admin\Administrator\View\Sysinfo\HtmlView $this */
 
 ?>
 <div class="sysinfo">

--- a/administrator/components/com_admin/tmpl/sysinfo/default_phpinfo.php
+++ b/administrator/components/com_admin/tmpl/sysinfo/default_phpinfo.php
@@ -9,7 +9,7 @@
 
 defined('_JEXEC') or die;
 
-/** @var \Joomla\Component\Admin\Administrator\View\Sysinfo\HtmlView $this */
+/* @var \Joomla\Component\Admin\Administrator\View\Sysinfo\HtmlView $this */
 
 ?>
 <div class="sysinfo">

--- a/administrator/components/com_admin/tmpl/sysinfo/default_phpsettings.php
+++ b/administrator/components/com_admin/tmpl/sysinfo/default_phpsettings.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
-/** @var \Joomla\Component\Admin\Administrator\View\Sysinfo\HtmlView $this */
+/* @var \Joomla\Component\Admin\Administrator\View\Sysinfo\HtmlView $this */
 
 ?>
 <div class="sysinfo">

--- a/administrator/components/com_admin/tmpl/sysinfo/default_system.php
+++ b/administrator/components/com_admin/tmpl/sysinfo/default_system.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
-/** @var \Joomla\Component\Admin\Administrator\View\Sysinfo\HtmlView $this */
+/* @var \Joomla\Component\Admin\Administrator\View\Sysinfo\HtmlView $this */
 
 ?>
 <div class="sysinfo">

--- a/administrator/components/com_associations/tmpl/association/edit.php
+++ b/administrator/components/com_associations/tmpl/association/edit.php
@@ -16,7 +16,7 @@ use Joomla\Component\Associations\Administrator\View\Association\HtmlView;
 
 /** @var HtmlView $this */
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('keepalive')
 	->useScript('form.validate')

--- a/administrator/components/com_associations/tmpl/associations/default.php
+++ b/administrator/components/com_associations/tmpl/associations/default.php
@@ -18,7 +18,7 @@ use Joomla\Component\Associations\Administrator\Helper\AssociationsHelper;
 
 HTMLHelper::_('behavior.multiselect');
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('com_associations.admin-associations-default');
 

--- a/administrator/components/com_associations/tmpl/associations/modal.php
+++ b/administrator/components/com_associations/tmpl/associations/modal.php
@@ -26,7 +26,7 @@ if ($app->isClient('site'))
 
 HTMLHelper::_('behavior.multiselect');
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('com_associations.admin-associations-modal');
 

--- a/administrator/components/com_banners/src/Controller/BannersController.php
+++ b/administrator/components/com_banners/src/Controller/BannersController.php
@@ -90,7 +90,7 @@ class BannersController extends AdminController
 		else
 		{
 			// Get the model.
-			/** @var \Joomla\Component\Banners\Administrator\Model\BannerModel $model */
+			/* @var \Joomla\Component\Banners\Administrator\Model\BannerModel $model */
 			$model = $this->getModel();
 
 			// Change the state of the records.

--- a/administrator/components/com_banners/src/Controller/TracksController.php
+++ b/administrator/components/com_banners/src/Controller/TracksController.php
@@ -59,7 +59,7 @@ class TracksController extends BaseController
 		$this->checkToken();
 
 		// Get the model.
-		/** @var \Joomla\Component\Banners\Administrator\Model\TracksModel $model */
+		/* @var \Joomla\Component\Banners\Administrator\Model\TracksModel $model */
 		$model = $this->getModel();
 
 		// Load the filter state.
@@ -110,7 +110,7 @@ class TracksController extends BaseController
 		if ($view = $this->getView($vName, 'raw'))
 		{
 			// Get the model for the view.
-			/** @var \Joomla\Component\Banners\Administrator\Model\TracksModel $model */
+			/* @var \Joomla\Component\Banners\Administrator\Model\TracksModel $model */
 			$model = $this->getModel($vName);
 
 			// Load the filter state.

--- a/administrator/components/com_banners/src/Helper/BannersHelper.php
+++ b/administrator/components/com_banners/src/Helper/BannersHelper.php
@@ -79,7 +79,7 @@ class BannersHelper extends ContentHelper
 
 			if ($purchaseType < 0 && $row->cid)
 			{
-				/** @var \Joomla\Component\Banners\Administrator\Table\ClientTable $client */
+				/* @var \Joomla\Component\Banners\Administrator\Table\ClientTable $client */
 				$client = Table::getInstance('ClientTable', '\\Joomla\\Component\\Banners\\Administrator\\Table\\');
 				$client->load($row->cid);
 				$purchaseType = $client->purchase_type;

--- a/administrator/components/com_banners/src/Model/BannerModel.php
+++ b/administrator/components/com_banners/src/Model/BannerModel.php
@@ -77,7 +77,7 @@ class BannerModel extends AdminModel
 		// Set the variables
 		$user = Factory::getUser();
 
-		/** @var \Joomla\Component\Banners\Administrator\Table\Banner $table */
+		/* @var \Joomla\Component\Banners\Administrator\Table\Banner $table */
 		$table = $this->getTable();
 
 		foreach ($pks as $pk)
@@ -257,7 +257,7 @@ class BannerModel extends AdminModel
 	 */
 	public function stick(&$pks, $value = 1)
 	{
-		/** @var \Joomla\Component\Banners\Administrator\Table\Banner $table */
+		/* @var \Joomla\Component\Banners\Administrator\Table\Banner $table */
 		$table = $this->getTable();
 		$pks   = (array) $pks;
 
@@ -406,7 +406,7 @@ class BannerModel extends AdminModel
 				'published' => 1,
 			];
 
-			/** @var \Joomla\Component\Categories\Administrator\Model\CategoryModel $categoryModel */
+			/* @var \Joomla\Component\Categories\Administrator\Model\CategoryModel $categoryModel */
 			$categoryModel = Factory::getApplication()->bootComponent('com_categories')
 				->getMVCFactory()->createModel('Category', 'Administrator', ['ignore_request' => true]);
 
@@ -425,7 +425,7 @@ class BannerModel extends AdminModel
 		// Alter the name for save as copy
 		if ($input->get('task') == 'save2copy')
 		{
-			/** @var \Joomla\Component\Banners\Administrator\Table\BannerTable $origTable */
+			/* @var \Joomla\Component\Banners\Administrator\Table\BannerTable $origTable */
 			$origTable = clone $this->getTable();
 			$origTable->load($input->getInt('id'));
 

--- a/administrator/components/com_banners/tmpl/banner/edit.php
+++ b/administrator/components/com_banners/tmpl/banner/edit.php
@@ -14,9 +14,9 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
-/** @var \Joomla\Component\Banners\Administrator\View\Banner\HtmlView $this */
+/* @var \Joomla\Component\Banners\Administrator\View\Banner\HtmlView $this */
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->getRegistry()->addExtensionRegistryFile('com_contenthistory');
 $wa->useScript('keepalive')

--- a/administrator/components/com_banners/tmpl/banners/default.php
+++ b/administrator/components/com_banners/tmpl/banners/default.php
@@ -17,7 +17,7 @@ use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
 
-/** @var \Joomla\Component\Banners\Administrator\View\Banners\HtmlView $this */
+/* @var \Joomla\Component\Banners\Administrator\View\Banners\HtmlView $this */
 
 HTMLHelper::_('behavior.multiselect');
 

--- a/administrator/components/com_banners/tmpl/banners/default_batch_body.php
+++ b/administrator/components/com_banners/tmpl/banners/default_batch_body.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Layout\LayoutHelper;
 
-/** @var \Joomla\Component\Banners\Administrator\View\Banners\HtmlView $this */
+/* @var \Joomla\Component\Banners\Administrator\View\Banners\HtmlView $this */
 
 $published = $this->state->get('filter.published');
 ?>

--- a/administrator/components/com_banners/tmpl/banners/default_batch_footer.php
+++ b/administrator/components/com_banners/tmpl/banners/default_batch_footer.php
@@ -11,7 +11,7 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 
-/** @var \Joomla\Component\Banners\Administrator\View\Banners\HtmlView $this */
+/* @var \Joomla\Component\Banners\Administrator\View\Banners\HtmlView $this */
 
 ?>
 <button type="button" class="btn btn-secondary" onclick="document.getElementById('batch-category-id').value='';document.getElementById('batch-client-id').value='';document.getElementById('batch-language-id').value=''" data-dismiss="modal">

--- a/administrator/components/com_banners/tmpl/client/edit.php
+++ b/administrator/components/com_banners/tmpl/client/edit.php
@@ -14,9 +14,9 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
-/** @var \Joomla\Component\Banners\Administrator\View\Client\HtmlView $this */
+/* @var \Joomla\Component\Banners\Administrator\View\Client\HtmlView $this */
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->getRegistry()->addExtensionRegistryFile('com_contenthistory');
 $wa->useScript('keepalive')

--- a/administrator/components/com_banners/tmpl/clients/default.php
+++ b/administrator/components/com_banners/tmpl/clients/default.php
@@ -16,7 +16,7 @@ use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Router\Route;
 
-/** @var \Joomla\Component\Banners\Administrator\View\Clients\HtmlView $this */
+/* @var \Joomla\Component\Banners\Administrator\View\Clients\HtmlView $this */
 
 HTMLHelper::_('behavior.multiselect');
 

--- a/administrator/components/com_banners/tmpl/download/default.php
+++ b/administrator/components/com_banners/tmpl/download/default.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Router\Route;
 
-/** @var \Joomla\Component\Banners\Administrator\View\Download\HtmlView $this */
+/* @var \Joomla\Component\Banners\Administrator\View\Download\HtmlView $this */
 
 HTMLHelper::_('behavior.formvalidator');
 

--- a/administrator/components/com_banners/tmpl/tracks/default.php
+++ b/administrator/components/com_banners/tmpl/tracks/default.php
@@ -14,7 +14,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
-/** @var \Joomla\Component\Banners\Administrator\View\Tracks\HtmlView $this */
+/* @var \Joomla\Component\Banners\Administrator\View\Tracks\HtmlView $this */
 
 $listOrder  = $this->escape($this->state->get('list.ordering'));
 $listDirn   = $this->escape($this->state->get('list.direction'));

--- a/administrator/components/com_cache/src/Controller/DisplayController.php
+++ b/administrator/components/com_cache/src/Controller/DisplayController.php
@@ -114,7 +114,7 @@ class DisplayController extends BaseController
 		// Check for request forgeries
 		$this->checkToken();
 
-		/** @var \Joomla\Component\Cache\Administrator\Model\CacheModel $model */
+		/* @var \Joomla\Component\Cache\Administrator\Model\CacheModel $model */
 		$model      = $this->getModel('cache');
 		$allCleared = true;
 

--- a/administrator/components/com_cache/tmpl/cache/default.php
+++ b/administrator/components/com_cache/tmpl/cache/default.php
@@ -14,12 +14,12 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
-/** @var \Joomla\Component\Cache\Administrator\View\Cache\HtmlView $this */
+/* @var \Joomla\Component\Cache\Administrator\View\Cache\HtmlView $this */
 
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('keepalive')
 	->useScript('com_cache.admin-cache');

--- a/administrator/components/com_categories/src/Controller/CategoriesController.php
+++ b/administrator/components/com_categories/src/Controller/CategoriesController.php
@@ -77,7 +77,7 @@ class CategoriesController extends AdminController
 		$extension = $this->input->get('extension');
 		$this->setRedirect(Route::_('index.php?option=com_categories&view=categories&extension=' . $extension, false));
 
-		/** @var \Joomla\Component\Categories\Administrator\Model\CategoryModel $model */
+		/* @var \Joomla\Component\Categories\Administrator\Model\CategoryModel $model */
 		$model = $this->getModel();
 
 		if ($model->rebuild())

--- a/administrator/components/com_categories/src/Controller/CategoryController.php
+++ b/administrator/components/com_categories/src/Controller/CategoryController.php
@@ -130,7 +130,7 @@ class CategoryController extends FormController
 	{
 		$this->checkToken();
 
-		/** @var \Joomla\Component\Categories\Administrator\Model\CategoryModel $model */
+		/* @var \Joomla\Component\Categories\Administrator\Model\CategoryModel $model */
 		$model = $this->getModel('Category');
 
 		// Preset the redirect

--- a/administrator/components/com_categories/src/Field/Modal/CategoryField.php
+++ b/administrator/components/com_categories/src/Field/Modal/CategoryField.php
@@ -69,7 +69,7 @@ class CategoryField extends FormField
 		// Create the modal id.
 		$modalId = 'Category_' . $this->id;
 
-		/** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
+		/* @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
 		$wa = Factory::getApplication()->getDocument()->getWebAssetManager();
 
 		// Add the modal field script to the document head.

--- a/administrator/components/com_categories/src/View/Categories/HtmlView.php
+++ b/administrator/components/com_categories/src/View/Categories/HtmlView.php
@@ -174,7 +174,7 @@ class HtmlView extends BaseHtmlView
 		}
 
 		// Load specific css component
-		/** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
+		/* @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
 		$wa = $this->document->getWebAssetManager();
 		$wa->getRegistry()->addExtensionRegistryFile($component);
 

--- a/administrator/components/com_categories/src/View/Category/HtmlView.php
+++ b/administrator/components/com_categories/src/View/Category/HtmlView.php
@@ -175,7 +175,7 @@ class HtmlView extends BaseHtmlView
 		}
 
 		// Load specific css component
-		/** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
+		/* @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
 		$wa = $this->document->getWebAssetManager();
 		$wa->getRegistry()->addExtensionRegistryFile($component);
 

--- a/administrator/components/com_categories/tmpl/category/edit.php
+++ b/administrator/components/com_categories/tmpl/category/edit.php
@@ -16,7 +16,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->getRegistry()->addExtensionRegistryFile('com_contenthistory');
 $wa->useScript('keepalive')

--- a/administrator/components/com_checkin/src/Controller/DisplayController.php
+++ b/administrator/components/com_checkin/src/Controller/DisplayController.php
@@ -62,7 +62,7 @@ class DisplayController extends BaseController
 		else
 		{
 			// Get the model.
-			/** @var \Joomla\Component\Checkin\Administrator\Model\CheckinModel $model */
+			/* @var \Joomla\Component\Checkin\Administrator\Model\CheckinModel $model */
 			$model = $this->getModel('Checkin');
 
 			// Checked in the items.

--- a/administrator/components/com_config/src/Controller/ApplicationController.php
+++ b/administrator/components/com_config/src/Controller/ApplicationController.php
@@ -83,7 +83,7 @@ class ApplicationController extends BaseController
 		// Set FTP credentials, if given.
 		ClientHelper::setCredentialsFromRequest('ftp');
 
-		/** @var \Joomla\Component\Config\Administrator\Model\ApplicationModel $model */
+		/* @var \Joomla\Component\Config\Administrator\Model\ApplicationModel $model */
 		$model = $this->getModel('Application', 'Administrator');
 
 		$data  = $this->input->post->get('jform', array(), 'array');
@@ -229,7 +229,7 @@ class ApplicationController extends BaseController
 
 		// Initialise model.
 
-		/** @var \Joomla\Component\Config\Administrator\Model\ApplicationModel $model */
+		/* @var \Joomla\Component\Config\Administrator\Model\ApplicationModel $model */
 		$model = $this->getModel('Application', 'Administrator');
 
 		// Attempt to save the configuration and remove root.
@@ -281,7 +281,7 @@ class ApplicationController extends BaseController
 			$this->app->close();
 		}
 
-		/** @var \Joomla\Component\Config\Administrator\Model\ApplicationModel $model */
+		/* @var \Joomla\Component\Config\Administrator\Model\ApplicationModel $model */
 		$model = $this->getModel('Application', 'Administrator');
 
 		echo new JsonResponse($model->sendTestMail());
@@ -311,7 +311,7 @@ class ApplicationController extends BaseController
 			$this->app->close();
 		}
 
-		/** @var \Joomla\Component\Config\Administrator\Model\Application $model */
+		/* @var \Joomla\Component\Config\Administrator\Model\Application $model */
 		$model = $this->getModel('Application', 'Administrator');
 		echo new JsonResponse($model->storePermissions());
 		$this->app->close();

--- a/administrator/components/com_config/src/Controller/ComponentController.php
+++ b/administrator/components/com_config/src/Controller/ComponentController.php
@@ -66,7 +66,7 @@ class ComponentController extends BaseController
 		// Set FTP credentials, if given.
 		ClientHelper::setCredentialsFromRequest('ftp');
 
-		/** @var \Joomla\Component\Config\Administrator\Model\ComponentModel $model */
+		/* @var \Joomla\Component\Config\Administrator\Model\ComponentModel $model */
 		$model = $this->getModel('Component', 'Administrator');
 		$form   = $model->getForm();
 		$data   = $this->input->get('jform', array(), 'array');

--- a/administrator/components/com_config/tmpl/component/default.php
+++ b/administrator/components/com_config/tmpl/component/default.php
@@ -23,7 +23,7 @@ Text::script('WARNING');
 Text::script('NOTICE');
 Text::script('MESSAGE');
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 
 // Load the tooltip behavior.

--- a/administrator/components/com_contact/src/Controller/ContactController.php
+++ b/administrator/components/com_contact/src/Controller/ContactController.php
@@ -100,7 +100,7 @@ class ContactController extends FormController
 		$this->checkToken();
 
 		// Set the model
-		/** @var \Joomla\Component\Contact\Administrator\Model\ContactModel $model */
+		/* @var \Joomla\Component\Contact\Administrator\Model\ContactModel $model */
 		$model = $this->getModel('Contact', 'Administrator', array());
 
 		// Preset the redirect

--- a/administrator/components/com_contact/src/Controller/ContactsController.php
+++ b/administrator/components/com_contact/src/Controller/ContactsController.php
@@ -62,7 +62,7 @@ class ContactsController extends AdminController
 		$value  = ArrayHelper::getValue($values, $task, 0, 'int');
 
 		// Get the model.
-		/** @var \Joomla\Component\Contact\Administrator\Model\ContactModel $model */
+		/* @var \Joomla\Component\Contact\Administrator\Model\ContactModel $model */
 		$model  = $this->getModel();
 
 		// Access checks.

--- a/administrator/components/com_contact/src/Field/Modal/ContactField.php
+++ b/administrator/components/com_contact/src/Field/Modal/ContactField.php
@@ -60,7 +60,7 @@ class ContactField extends FormField
 		// Create the modal id.
 		$modalId = 'Contact_' . $this->id;
 
-		/** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
+		/* @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
 		$wa = Factory::getApplication()->getDocument()->getWebAssetManager();
 
 		// Add the modal field script to the document head.

--- a/administrator/components/com_contact/src/Model/ContactModel.php
+++ b/administrator/components/com_contact/src/Model/ContactModel.php
@@ -309,7 +309,7 @@ class ContactModel extends AdminModel
 				'published' => 1,
 			];
 
-			/** @var \Joomla\Component\Categories\Administrator\Model\CategoryModel $categoryModel */
+			/* @var \Joomla\Component\Categories\Administrator\Model\CategoryModel $categoryModel */
 			$categoryModel = Factory::getApplication()->bootComponent('com_categories')
 				->getMVCFactory()->createModel('Category', 'Administrator', ['ignore_request' => true]);
 

--- a/administrator/components/com_contact/tmpl/contact/edit.php
+++ b/administrator/components/com_contact/tmpl/contact/edit.php
@@ -16,7 +16,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->getRegistry()->addExtensionRegistryFile('com_contenthistory');
 $wa->useScript('keepalive')

--- a/administrator/components/com_contact/tmpl/contacts/modal.php
+++ b/administrator/components/com_contact/tmpl/contacts/modal.php
@@ -25,7 +25,7 @@ if ($app->isClient('site'))
 	Session::checkToken('get') or die(Text::_('JINVALID_TOKEN'));
 }
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('com_contact.admin-contacts-modal');
 

--- a/administrator/components/com_content/src/Controller/ArticleController.php
+++ b/administrator/components/com_content/src/Controller/ArticleController.php
@@ -174,7 +174,7 @@ class ArticleController extends FormController
 		$this->checkToken();
 
 		// Set the model
-		/** @var \Joomla\Component\Content\Administrator\Model\ArticleModel $model */
+		/* @var \Joomla\Component\Content\Administrator\Model\ArticleModel $model */
 		$model = $this->getModel('Article', 'Administrator', array());
 
 		// Preset the redirect

--- a/administrator/components/com_content/src/Controller/ArticlesController.php
+++ b/administrator/components/com_content/src/Controller/ArticlesController.php
@@ -90,7 +90,7 @@ class ArticlesController extends AdminController
 		else
 		{
 			// Get the model.
-			/** @var \Joomla\Component\Content\Administrator\Model\ArticleModel $model */
+			/* @var \Joomla\Component\Content\Administrator\Model\ArticleModel $model */
 			$model = $this->getModel();
 
 			// Publish the items.

--- a/administrator/components/com_content/src/Controller/FeaturedController.php
+++ b/administrator/components/com_content/src/Controller/FeaturedController.php
@@ -52,7 +52,7 @@ class FeaturedController extends ArticlesController
 		}
 		else
 		{
-			/** @var \Joomla\Component\Content\Administrator\Model\FeatureModel $model */
+			/* @var \Joomla\Component\Content\Administrator\Model\FeatureModel $model */
 			$model = $this->getModel();
 
 			// Remove the items.

--- a/administrator/components/com_content/src/Field/Modal/ArticleField.php
+++ b/administrator/components/com_content/src/Field/Modal/ArticleField.php
@@ -60,7 +60,7 @@ class ArticleField extends FormField
 		// Create the modal id.
 		$modalId = 'Article_' . $this->id;
 
-		/** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
+		/* @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
 		$wa = Factory::getApplication()->getDocument()->getWebAssetManager();
 
 		// Add the modal field script to the document head.

--- a/administrator/components/com_content/src/Model/ArticleModel.php
+++ b/administrator/components/com_content/src/Model/ArticleModel.php
@@ -731,7 +731,7 @@ class ArticleModel extends AdminModel implements WorkflowModelInterface
 				'published' => 1,
 			];
 
-			/** @var \Joomla\Component\Categories\Administrator\Model\CategoryModel $categoryModel */
+			/* @var \Joomla\Component\Categories\Administrator\Model\CategoryModel $categoryModel */
 			$categoryModel = Factory::getApplication()->bootComponent('com_categories')
 				->getMVCFactory()->createModel('Category', 'Administrator', ['ignore_request' => true]);
 

--- a/administrator/components/com_content/tmpl/article/edit.php
+++ b/administrator/components/com_content/tmpl/article/edit.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-/** @var \Joomla\Component\Content\Administrator\View\Article\HtmlView $this */
+/* @var \Joomla\Component\Content\Administrator\View\Article\HtmlView $this */
 
 defined('_JEXEC') or die;
 
@@ -19,7 +19,7 @@ use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\Registry\Registry;
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->getRegistry()->addExtensionRegistryFile('com_contenthistory');
 $wa->useScript('keepalive')

--- a/administrator/components/com_content/tmpl/article/pagebreak.php
+++ b/administrator/components/com_content/tmpl/article/pagebreak.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('com_content.admin-article-pagebreak');
 

--- a/administrator/components/com_content/tmpl/articles/default.php
+++ b/administrator/components/com_content/tmpl/articles/default.php
@@ -77,7 +77,7 @@ $js = <<<JS
 })();
 JS;
 
-/** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 
 $wa->getRegistry()->addExtensionRegistryFile('com_workflow');

--- a/administrator/components/com_content/tmpl/articles/default_batch_footer.php
+++ b/administrator/components/com_content/tmpl/articles/default_batch_footer.php
@@ -10,7 +10,7 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('com_content.admin-articles-batch');
 

--- a/administrator/components/com_content/tmpl/articles/modal.php
+++ b/administrator/components/com_content/tmpl/articles/modal.php
@@ -27,7 +27,7 @@ if ($app->isClient('site'))
 
 HTMLHelper::_('behavior.multiselect');
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('core')
 	->useScript('com_content.admin-articles-modal');

--- a/administrator/components/com_content/tmpl/featured/default.php
+++ b/administrator/components/com_content/tmpl/featured/default.php
@@ -73,7 +73,7 @@ $js = <<<JS
 })();
 JS;
 
-/** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 
 $wa->getRegistry()->addExtensionRegistryFile('com_workflow');

--- a/administrator/components/com_content/tmpl/featured/default_stage_footer.php
+++ b/administrator/components/com_content/tmpl/featured/default_stage_footer.php
@@ -10,7 +10,7 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('com_content.admin-articles-stage');
 

--- a/administrator/components/com_contenthistory/src/Model/PreviewModel.php
+++ b/administrator/components/com_contenthistory/src/Model/PreviewModel.php
@@ -36,7 +36,7 @@ class PreviewModel extends ItemModel
 	 */
 	public function getItem($pk = null)
 	{
-		/** @var \Joomla\CMS\Table\ContentHistory $table */
+		/* @var \Joomla\CMS\Table\ContentHistory $table */
 		$table = $this->getTable('ContentHistory');
 		$versionId = Factory::getApplication()->input->getInt('version_id');
 

--- a/administrator/components/com_contenthistory/tmpl/compare/compare.php
+++ b/administrator/components/com_contenthistory/tmpl/compare/compare.php
@@ -19,7 +19,7 @@ $version1 = $this->items[1];
 $object1  = $version1->data;
 $object2  = $version2->data;
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('com_contenthistory.admin-compare-compare');
 

--- a/administrator/components/com_contenthistory/tmpl/history/modal.php
+++ b/administrator/components/com_contenthistory/tmpl/history/modal.php
@@ -38,7 +38,7 @@ Text::script('COM_CONTENTHISTORY_BUTTON_SELECT_ONE', true);
 Text::script('COM_CONTENTHISTORY_BUTTON_SELECT_TWO', true);
 Text::script('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST');
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('com_contenthistory.admin-history-modal');
 

--- a/administrator/components/com_cpanel/tmpl/cpanel/default.php
+++ b/administrator/components/com_cpanel/tmpl/cpanel/default.php
@@ -24,7 +24,7 @@ Text::script('MESSAGE');
 Text::script('COM_CPANEL_UNPUBLISH_MODULE_SUCCESS');
 Text::script('COM_CPANEL_UNPUBLISH_MODULE_ERROR');
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('com_cpanel.admin-cpanel')
 	->useScript('com_cpanel.admin-addmodule');

--- a/administrator/components/com_fields/tmpl/field/edit.php
+++ b/administrator/components/com_fields/tmpl/field/edit.php
@@ -19,7 +19,7 @@ $input = $app->input;
 
 $this->useCoreUI = true;
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('keepalive')
 	->useScript('form.validate')

--- a/administrator/components/com_fields/tmpl/field/modal.php
+++ b/administrator/components/com_fields/tmpl/field/modal.php
@@ -14,7 +14,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('keepalive')
 	->useScript('form.validate')

--- a/administrator/components/com_fields/tmpl/fields/default_batch_body.php
+++ b/administrator/components/com_fields/tmpl/fields/default_batch_body.php
@@ -12,7 +12,7 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('com_fields.admin-fields-batch');
 

--- a/administrator/components/com_fields/tmpl/fields/modal.php
+++ b/administrator/components/com_fields/tmpl/fields/modal.php
@@ -20,7 +20,7 @@ if (Factory::getApplication()->isClient('site'))
 	Session::checkToken('get') or die(Text::_('JINVALID_TOKEN'));
 }
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('com_fields.admin-fields-modal');
 

--- a/administrator/components/com_finder/src/Controller/FilterController.php
+++ b/administrator/components/com_finder/src/Controller/FilterController.php
@@ -38,7 +38,7 @@ class FilterController extends FormController
 		// Check for request forgeries.
 		$this->checkToken();
 
-		/** @var \Joomla\Component\Finder\Administrator\Model\FilterModel $model */
+		/* @var \Joomla\Component\Finder\Administrator\Model\FilterModel $model */
 		$model = $this->getModel();
 		$table = $model->getTable();
 		$data = $this->input->post->get('jform', array(), 'array');

--- a/administrator/components/com_finder/src/Controller/IndexController.php
+++ b/administrator/components/com_finder/src/Controller/IndexController.php
@@ -51,7 +51,7 @@ class IndexController extends AdminController
 		// Remove the script time limit.
 		@set_time_limit(0);
 
-		/** @var \Joomla\Component\Finder\Administrator\Model\IndexModel $model */
+		/* @var \Joomla\Component\Finder\Administrator\Model\IndexModel $model */
 		$model = $this->getModel('Index', 'Administrator');
 
 		// Attempt to purge the index.

--- a/administrator/components/com_finder/src/Service/HTML/Filter.php
+++ b/administrator/components/com_finder/src/Service/HTML/Filter.php
@@ -467,7 +467,7 @@ class Filter
 			// Load the CSS/JS resources.
 			if ($loadMedia)
 			{
-				/** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
+				/* @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
 				$wa = Factory::getApplication()->getDocument()->getWebAssetManager();
 				$wa->useStyle('com_finder.dates');
 			}

--- a/administrator/components/com_finder/tmpl/filter/edit.php
+++ b/administrator/components/com_finder/tmpl/filter/edit.php
@@ -22,7 +22,7 @@ $this->ignore_fieldsets = ['jbasic'];
 
 $this->useCoreUI = true;
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('keepalive')
 	->useScript('form.validate')

--- a/administrator/components/com_finder/tmpl/filters/default.php
+++ b/administrator/components/com_finder/tmpl/filters/default.php
@@ -22,7 +22,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 
 Text::script('COM_FINDER_INDEX_CONFIRM_DELETE_PROMPT');
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('com_finder.filters');
 

--- a/administrator/components/com_finder/tmpl/index/default.php
+++ b/administrator/components/com_finder/tmpl/index/default.php
@@ -24,7 +24,7 @@ $lang      = Factory::getLanguage();
 Text::script('COM_FINDER_INDEX_CONFIRM_PURGE_PROMPT');
 Text::script('COM_FINDER_INDEX_CONFIRM_DELETE_PROMPT');
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('com_finder.index');
 

--- a/administrator/components/com_finder/tmpl/indexer/default.php
+++ b/administrator/components/com_finder/tmpl/indexer/default.php
@@ -14,7 +14,7 @@ use Joomla\CMS\Language\Text;
 
 Text::script('COM_FINDER_INDEXER_MESSAGE_COMPLETE', true);
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('keepalive')
 	->useStyle('com_finder.indexer')

--- a/administrator/components/com_finder/tmpl/maps/default.php
+++ b/administrator/components/com_finder/tmpl/maps/default.php
@@ -24,7 +24,7 @@ $branchFilter  = $this->escape($this->state->get('filter.branch'));
 
 Text::script('COM_FINDER_MAPS_CONFIRM_DELETE_PROMPT');
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('com_finder.maps');
 

--- a/administrator/components/com_installer/src/Controller/DatabaseController.php
+++ b/administrator/components/com_installer/src/Controller/DatabaseController.php
@@ -56,7 +56,7 @@ class DatabaseController extends BaseController
 			$model = $this->getModel('Database');
 			$model->fix($cid);
 
-			/** @var \Joomla\Component\Joomlaupdate\Administrator\Model\UpdateModel $updateModel */
+			/* @var \Joomla\Component\Joomlaupdate\Administrator\Model\UpdateModel $updateModel */
 			$updateModel = $this->app->bootComponent('com_joomlaupdate')
 				->getMVCFactory()->createModel('Update', 'Administrator', ['ignore_request' => true]);
 			$updateModel->purge();

--- a/administrator/components/com_installer/src/Controller/DiscoverController.php
+++ b/administrator/components/com_installer/src/Controller/DiscoverController.php
@@ -33,7 +33,7 @@ class DiscoverController extends BaseController
 	{
 		$this->checkToken();
 
-		/** @var \Joomla\Component\Installer\Administrator\Model\DiscoverModel $model */
+		/* @var \Joomla\Component\Installer\Administrator\Model\DiscoverModel $model */
 		$model = $this->getModel('discover');
 		$model->discover();
 		$this->setRedirect(Route::_('index.php?option=com_installer&view=discover', false));
@@ -50,7 +50,7 @@ class DiscoverController extends BaseController
 	{
 		$this->checkToken();
 
-		/** @var \Joomla\Component\Installer\Administrator\Model\DiscoverModel $model */
+		/* @var \Joomla\Component\Installer\Administrator\Model\DiscoverModel $model */
 		$model = $this->getModel('discover');
 		$model->discover_install();
 		$this->setRedirect(Route::_('index.php?option=com_installer&view=discover', false));
@@ -67,7 +67,7 @@ class DiscoverController extends BaseController
 	{
 		$this->checkToken();
 
-		/** @var \Joomla\Component\Installer\Administrator\Model\DiscoverModel $model */
+		/* @var \Joomla\Component\Installer\Administrator\Model\DiscoverModel $model */
 		$model = $this->getModel('discover');
 		$model->purge();
 		$this->setRedirect(Route::_('index.php?option=com_installer&view=discover', false), $model->_message);

--- a/administrator/components/com_installer/src/Controller/InstallController.php
+++ b/administrator/components/com_installer/src/Controller/InstallController.php
@@ -35,7 +35,7 @@ class InstallController extends BaseController
 		// Check for request forgeries.
 		$this->checkToken();
 
-		/** @var \Joomla\Component\Installer\Administrator\Model\InstallModel $model */
+		/* @var \Joomla\Component\Installer\Administrator\Model\InstallModel $model */
 		$model = $this->getModel('install');
 
 		// TODO: Reset the users acl here as well to kill off any missing bits.

--- a/administrator/components/com_installer/src/Controller/UpdateController.php
+++ b/administrator/components/com_installer/src/Controller/UpdateController.php
@@ -40,7 +40,7 @@ class UpdateController extends BaseController
 		// Check for request forgeries.
 		$this->checkToken();
 
-		/** @var \Joomla\Component\Installer\Administrator\Model\UpdateModel $model */
+		/* @var \Joomla\Component\Installer\Administrator\Model\UpdateModel $model */
 		$model = $this->getModel('update');
 
 		$uid = $this->input->get('cid', array(), 'array');
@@ -96,7 +96,7 @@ class UpdateController extends BaseController
 		$minimum_stability = (int) $params->get('minimum_stability', Updater::STABILITY_STABLE);
 
 		// Find updates.
-		/** @var \Joomla\Component\Installer\Administrator\Model\UpdateModel $model */
+		/* @var \Joomla\Component\Installer\Administrator\Model\UpdateModel $model */
 		$model = $this->getModel('update');
 
 		$disabledUpdateSites = $model->getDisabledUpdateSites();
@@ -123,7 +123,7 @@ class UpdateController extends BaseController
 		// Check for request forgeries.
 		$this->checkToken();
 
-		/** @var \Joomla\Component\Installer\Administrator\Model\UpdateModel $model */
+		/* @var \Joomla\Component\Installer\Administrator\Model\UpdateModel $model */
 		$model = $this->getModel('update');
 		$model->purge();
 
@@ -170,7 +170,7 @@ class UpdateController extends BaseController
 			$minimum_stability = (int) $params->get('minimum_stability', Updater::STABILITY_STABLE);
 		}
 
-		/** @var \Joomla\Component\Installer\Administrator\Model\UpdateModel $model */
+		/* @var \Joomla\Component\Installer\Administrator\Model\UpdateModel $model */
 		$model = $this->getModel('update');
 		$model->findUpdates($eid, $cache_timeout, $minimum_stability);
 

--- a/administrator/components/com_installer/src/Controller/UpdatesitesController.php
+++ b/administrator/components/com_installer/src/Controller/UpdatesitesController.php
@@ -98,7 +98,7 @@ class UpdatesitesController extends AdminController
 		}
 
 		// Get the model.
-		/** @var \Joomla\Component\Installer\Administrator\Model\UpdatesitesModel $model */
+		/* @var \Joomla\Component\Installer\Administrator\Model\UpdatesitesModel $model */
 		$model = $this->getModel('Updatesites');
 
 		// Change the state of the records.

--- a/administrator/components/com_installer/tmpl/install/default.php
+++ b/administrator/components/com_installer/tmpl/install/default.php
@@ -25,7 +25,7 @@ Text::script('PLG_INSTALLER_FOLDERINSTALLER_NO_INSTALL_PATH');
 Text::script('PLG_INSTALLER_URLINSTALLER_NO_URL');
 Text::script('COM_INSTALLER_MSG_INSTALL_ENTER_A_URL');
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('core')
 	->usePreset('com_installer.installer')

--- a/administrator/components/com_installer/tmpl/manage/default.php
+++ b/administrator/components/com_installer/tmpl/manage/default.php
@@ -16,7 +16,7 @@ use Joomla\CMS\Router\Route;
 
 HTMLHelper::_('behavior.multiselect');
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('com_installer.changelog');
 

--- a/administrator/components/com_installer/tmpl/update/default.php
+++ b/administrator/components/com_installer/tmpl/update/default.php
@@ -16,7 +16,7 @@ use Joomla\CMS\Router\Route;
 
 HTMLHelper::_('behavior.multiselect');
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('com_installer.changelog');
 

--- a/administrator/components/com_joomlaupdate/src/Controller/DisplayController.php
+++ b/administrator/components/com_joomlaupdate/src/Controller/DisplayController.php
@@ -50,7 +50,7 @@ class DisplayController extends BaseController
 			$view->ftp = &$ftp;
 
 			// Get the model for the view.
-			/** @var \Joomla\Component\Joomlaupdate\Administrator\Model\UpdateModel $model */
+			/* @var \Joomla\Component\Joomlaupdate\Administrator\Model\UpdateModel $model */
 			$model = $this->getModel('Update');
 
 			$warningsModel = $this->app->bootComponent('com_installer')

--- a/administrator/components/com_joomlaupdate/src/Controller/UpdateController.php
+++ b/administrator/components/com_joomlaupdate/src/Controller/UpdateController.php
@@ -54,7 +54,7 @@ class UpdateController extends BaseController
 
 		$this->_applyCredentials();
 
-		/** @var \Joomla\Component\Joomlaupdate\Administrator\Model\UpdateModel $model */
+		/* @var \Joomla\Component\Joomlaupdate\Administrator\Model\UpdateModel $model */
 		$model  = $this->getModel('Update');
 		$result = $model->download();
 		$file   = $result['basename'];
@@ -130,7 +130,7 @@ class UpdateController extends BaseController
 
 		$this->_applyCredentials();
 
-		/** @var \Joomla\Component\Joomlaupdate\Administrator\Model\UpdateModel $model */
+		/* @var \Joomla\Component\Joomlaupdate\Administrator\Model\UpdateModel $model */
 		$model = $this->getModel('Update');
 
 		$file = Factory::getApplication()->getUserState('com_joomlaupdate.file', null);
@@ -174,7 +174,7 @@ class UpdateController extends BaseController
 
 		$this->_applyCredentials();
 
-		/** @var \Joomla\Component\Joomlaupdate\Administrator\Model\UpdateModel $model */
+		/* @var \Joomla\Component\Joomlaupdate\Administrator\Model\UpdateModel $model */
 		$model = $this->getModel('Update');
 
 		$model->finaliseUpgrade();
@@ -218,7 +218,7 @@ class UpdateController extends BaseController
 
 		$this->_applyCredentials();
 
-		/** @var \Joomla\Component\Joomlaupdate\Administrator\Model\UpdateModel $model */
+		/* @var \Joomla\Component\Joomlaupdate\Administrator\Model\UpdateModel $model */
 		$model = $this->getModel('Update');
 
 		$model->cleanUp();
@@ -249,7 +249,7 @@ class UpdateController extends BaseController
 		$this->checkToken();
 
 		// Purge updates
-		/** @var \Joomla\Component\Joomlaupdate\Administrator\Model\UpdateModel $model */
+		/* @var \Joomla\Component\Joomlaupdate\Administrator\Model\UpdateModel $model */
 		$model = $this->getModel('Update');
 		$model->purge();
 
@@ -274,7 +274,7 @@ class UpdateController extends BaseController
 
 		$this->_applyCredentials();
 
-		/** @var \Joomla\Component\Joomlaupdate\Administrator\Model\UpdateModel $model */
+		/* @var \Joomla\Component\Joomlaupdate\Administrator\Model\UpdateModel $model */
 		$model = $this->getModel('Update');
 
 		try
@@ -342,7 +342,7 @@ class UpdateController extends BaseController
 			throw new \RuntimeException(Text::_('JLIB_APPLICATION_ERROR_ACCESS_FORBIDDEN'), 403);
 		}
 
-		/** @var \Joomla\Component\Joomlaupdate\Administrator\Model\UpdateModel $model */
+		/* @var \Joomla\Component\Joomlaupdate\Administrator\Model\UpdateModel $model */
 		$model = $this->getModel('Update');
 
 		// Get the captive file before the session resets
@@ -411,7 +411,7 @@ class UpdateController extends BaseController
 		if ($view = $this->getView($vName, $vFormat))
 		{
 			// Get the model for the view.
-			/** @var \Joomla\Component\Joomlaupdate\Administrator\Model\UpdateModel $model */
+			/* @var \Joomla\Component\Joomlaupdate\Administrator\Model\UpdateModel $model */
 			$model = $this->getModel('Update');
 
 			// Push the model into the view (as default).
@@ -472,7 +472,7 @@ class UpdateController extends BaseController
 		}
 
 		// Get the model
-		/** @var \Joomla\Component\Joomlaupdate\Administrator\Model\UpdateModel $model */
+		/* @var \Joomla\Component\Joomlaupdate\Administrator\Model\UpdateModel $model */
 		$model = $this->getModel('Update');
 
 		// Try to log in
@@ -511,7 +511,7 @@ class UpdateController extends BaseController
 		$extensionID = $this->input->get('extension-id', '', 'DEFAULT');
 		$joomlaTargetVersion = $this->input->get('joomla-target-version', '', 'DEFAULT');
 
-		/** @var \Joomla\Component\Joomlaupdate\Administrator\Model\UpdateModel $model */
+		/* @var \Joomla\Component\Joomlaupdate\Administrator\Model\UpdateModel $model */
 		$model = $this->getModel('Update');
 		$compatibilityStatus = $model->fetchCompatibility($extensionID, $joomlaTargetVersion);
 

--- a/administrator/components/com_joomlaupdate/src/View/Joomlaupdate/HtmlView.php
+++ b/administrator/components/com_joomlaupdate/src/View/Joomlaupdate/HtmlView.php
@@ -104,7 +104,7 @@ class HtmlView extends BaseHtmlView
 		$this->state = $this->get('State');
 
 		// Load useful classes.
-		/** @var \Joomla\Component\Joomlaupdate\Administrator\Model\UpdateModel $model */
+		/* @var \Joomla\Component\Joomlaupdate\Administrator\Model\UpdateModel $model */
 		$model = $this->getModel();
 		$this->loadHelper('select');
 
@@ -177,7 +177,7 @@ class HtmlView extends BaseHtmlView
 		}
 
 		$this->warnings = array();
-		/** @var \Joomla\Component\Installer\Administrator\Model\WarningsModel $warningsModel */
+		/* @var \Joomla\Component\Installer\Administrator\Model\WarningsModel $warningsModel */
 		$warningsModel = $this->getModel('warnings');
 
 		if (is_object($warningsModel) && $warningsModel instanceof \Joomla\CMS\MVC\Model\BaseDatabaseModel)

--- a/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default.php
+++ b/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default.php
@@ -13,9 +13,9 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
-/** @var \Joomla\Component\Joomlaupdate\Administrator\View\Joomlaupdate\HtmlView $this */
+/* @var \Joomla\Component\Joomlaupdate\Administrator\View\Joomlaupdate\HtmlView $this */
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('core')
 	->useScript('com_joomlaupdate.default');

--- a/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_nodownload.php
+++ b/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_nodownload.php
@@ -11,7 +11,7 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 
-/** @var \Joomla\Component\Joomlaupdate\Administrator\View\Joomlaupdate\Html $this */
+/* @var \Joomla\Component\Joomlaupdate\Administrator\View\Joomlaupdate\Html $this */
 ?>
 
 <fieldset class="options-form">

--- a/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_noupdate.php
+++ b/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_noupdate.php
@@ -11,7 +11,7 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 
-/** @var JoomlaupdateViewDefault $this */
+/* @var JoomlaupdateViewDefault $this */
 ?>
 <fieldset>
 	<legend>

--- a/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_preupdatecheck.php
+++ b/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_preupdatecheck.php
@@ -11,7 +11,7 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 
-/** @var \Joomla\Component\Joomlaupdate\Administrator\View\Joomlaupdate\Html $this */
+/* @var \Joomla\Component\Joomlaupdate\Administrator\View\Joomlaupdate\Html $this */
 ?>
 
 <h2 class="mt-3 mb-3">

--- a/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_reinstall.php
+++ b/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_reinstall.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Updater\Update;
 
-/** @var \Joomla\Component\Joomlaupdate\Administrator\View\Joomlaupdate\HtmlView $this */
+/* @var \Joomla\Component\Joomlaupdate\Administrator\View\Joomlaupdate\HtmlView $this */
 ?>
 <fieldset class="options-form">
 	<legend>

--- a/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_update.php
+++ b/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_update.php
@@ -11,7 +11,7 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 
-/** @var \Joomla\Component\Joomlaupdate\Administrator\View\Joomlaupdate\Html $this */
+/* @var \Joomla\Component\Joomlaupdate\Administrator\View\Joomlaupdate\Html $this */
 ?>
 
 <fieldset class="options-form">

--- a/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_updatemefirst.php
+++ b/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_updatemefirst.php
@@ -10,7 +10,7 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 
-/** @var JoomlaupdateViewDefault $this */
+/* @var JoomlaupdateViewDefault $this */
 ?>
 
 <fieldset class="options-form">

--- a/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_upload.php
+++ b/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_upload.php
@@ -13,7 +13,7 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Utility\Utility;
 
-/** @var JoomlaupdateViewDefault $this */
+/* @var JoomlaupdateViewDefault $this */
 
 HTMLHelper::_('behavior.core');
 Text::script('COM_INSTALLER_MSG_INSTALL_PLEASE_SELECT_A_PACKAGE', true);

--- a/administrator/components/com_joomlaupdate/tmpl/update/default.php
+++ b/administrator/components/com_joomlaupdate/tmpl/update/default.php
@@ -13,7 +13,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Uri\Uri;
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('core')
 	->useScript('com_joomlaupdate.encryption')

--- a/administrator/components/com_languages/src/Controller/OverridesController.php
+++ b/administrator/components/com_languages/src/Controller/OverridesController.php
@@ -80,7 +80,7 @@ class OverridesController extends AdminController
 		// Check for request forgeries.
 		$this->checkToken();
 
-		/** @var \Joomla\Component\Languages\Administrator\Model\OverridesModel $model */
+		/* @var \Joomla\Component\Languages\Administrator\Model\OverridesModel $model */
 		$model = $this->getModel('overrides');
 		$model->purge();
 		$this->setRedirect(Route::_('index.php?option=com_languages&view=overrides', false));

--- a/administrator/components/com_languages/tmpl/language/edit.php
+++ b/administrator/components/com_languages/tmpl/language/edit.php
@@ -13,7 +13,7 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('keepalive')
 	->useScript('form.validate')

--- a/administrator/components/com_languages/tmpl/override/edit.php
+++ b/administrator/components/com_languages/tmpl/override/edit.php
@@ -15,7 +15,7 @@ use Joomla\CMS\Router\Route;
 
 $expired = ($this->state->get('cache_expired') == 1 ) ? '1' : '';
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('keepalive')
 	->useScript('form.validate')

--- a/administrator/components/com_mails/src/Controller/TemplateController.php
+++ b/administrator/components/com_mails/src/Controller/TemplateController.php
@@ -148,7 +148,7 @@ class TemplateController extends FormController
 		// Check for request forgeries.
 		$this->checkToken();
 
-		/** @var \Joomla\CMS\MVC\Model\AdminModel $model */
+		/* @var \Joomla\CMS\MVC\Model\AdminModel $model */
 		$model = $this->getModel();
 		$data  = $this->input->post->get('jform', array(), 'array');
 		$context = "$this->option.edit.$this->context";

--- a/administrator/components/com_mails/tmpl/template/edit.php
+++ b/administrator/components/com_mails/tmpl/template/edit.php
@@ -19,7 +19,7 @@ use Joomla\Component\Mails\Administrator\Helper\MailsHelper;
 
 $app = Factory::getApplication();
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('keepalive')
 	->useScript('form.validate')

--- a/administrator/components/com_media/tmpl/file/default.php
+++ b/administrator/components/com_media/tmpl/file/default.php
@@ -17,7 +17,7 @@ use Joomla\CMS\Session\Session;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Uri\Uri;
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('keepalive')
 	->useScript('form.validate')
@@ -26,7 +26,7 @@ $wa->useScript('keepalive')
 
 $params = ComponentHelper::getParams('com_media');
 
-/** @var \Joomla\CMS\Form\Form $form */
+/* @var \Joomla\CMS\Form\Form $form */
 $form = $this->form;
 
 $tmpl = Factory::getApplication()->input->getCmd('tmpl');

--- a/administrator/components/com_media/tmpl/media/default.php
+++ b/administrator/components/com_media/tmpl/media/default.php
@@ -16,7 +16,7 @@ use Joomla\CMS\Uri\Uri;
 
 $params = ComponentHelper::getParams('com_media');
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('keepalive')
 	->useStyle('com_media.mediamanager')

--- a/administrator/components/com_menus/src/Controller/ItemController.php
+++ b/administrator/components/com_menus/src/Controller/ItemController.php
@@ -145,7 +145,7 @@ class ItemController extends FormController
 	{
 		$this->checkToken();
 
-		/** @var \Joomla\Component\Menus\Administrator\Model\ItemModel $model */
+		/* @var \Joomla\Component\Menus\Administrator\Model\ItemModel $model */
 		$model = $this->getModel('Item', 'Administrator', array());
 
 		// Preset the redirect
@@ -229,7 +229,7 @@ class ItemController extends FormController
 
 		if ($recordId)
 		{
-			/** @var \Joomla\Component\Menus\Administrator\Model\ItemModel $model */
+			/* @var \Joomla\Component\Menus\Administrator\Model\ItemModel $model */
 			$model    = $this->getModel();
 			$item     = $model->getItem($recordId);
 			$clientId = $item->client_id;
@@ -260,7 +260,7 @@ class ItemController extends FormController
 		// Check for request forgeries.
 		$this->checkToken();
 
-		/** @var \Joomla\Component\Menus\Administrator\Model\ItemModel $model */
+		/* @var \Joomla\Component\Menus\Administrator\Model\ItemModel $model */
 		$model    = $this->getModel('Item', 'Administrator', array());
 		$table    = $model->getTable();
 		$data     = $this->input->post->get('jform', array(), 'array');
@@ -594,7 +594,7 @@ class ItemController extends FormController
 
 		if ($menutype)
 		{
-			/** @var \Joomla\Component\Menus\Administrator\Model\ItemsModel $model */
+			/* @var \Joomla\Component\Menus\Administrator\Model\ItemsModel $model */
 			$model = $this->getModel('Items', 'Administrator', array());
 			$model->getState();
 			$model->setState('filter.menutype', $menutype);

--- a/administrator/components/com_menus/src/Controller/ItemsController.php
+++ b/administrator/components/com_menus/src/Controller/ItemsController.php
@@ -99,7 +99,7 @@ class ItemsController extends AdminController
 
 		$this->setRedirect('index.php?option=com_menus&view=items&menutype=' . $this->input->getCmd('menutype'));
 
-		/** @var \Joomla\Component\Menus\Administrator\Model\ItemModel $model */
+		/* @var \Joomla\Component\Menus\Administrator\Model\ItemModel $model */
 		$model = $this->getModel();
 
 		if ($model->rebuild())

--- a/administrator/components/com_menus/src/Controller/MenuController.php
+++ b/administrator/components/com_menus/src/Controller/MenuController.php
@@ -78,7 +78,7 @@ class MenuController extends FormController
 		$data['id'] = $recordId;
 
 		// Get the model and attempt to validate the posted data.
-		/** @var \Joomla\Component\Menus\Administrator\Model\MenuModel $model */
+		/* @var \Joomla\Component\Menus\Administrator\Model\MenuModel $model */
 		$model = $this->getModel('Menu', '', ['ignore_request' => false]);
 		$form  = $model->getForm();
 

--- a/administrator/components/com_menus/src/Controller/MenusController.php
+++ b/administrator/components/com_menus/src/Controller/MenusController.php
@@ -89,7 +89,7 @@ class MenusController extends BaseController
 			if (count($cids) > 0)
 			{
 				// Get the model.
-				/** @var \Joomla\Component\Menus\Administrator\Model\MenuModel $model */
+				/* @var \Joomla\Component\Menus\Administrator\Model\MenuModel $model */
 				$model = $this->getModel();
 
 				// Make sure the item ids are integers
@@ -123,7 +123,7 @@ class MenusController extends BaseController
 
 		$this->setRedirect('index.php?option=com_menus&view=menus');
 
-		/** @var \Joomla\Component\Menus\Administrator\Model\ItemModel $model */
+		/* @var \Joomla\Component\Menus\Administrator\Model\ItemModel $model */
 		$model = $this->getModel('Item');
 
 		if ($model->rebuild())

--- a/administrator/components/com_menus/src/Field/Modal/MenuField.php
+++ b/administrator/components/com_menus/src/Field/Modal/MenuField.php
@@ -180,7 +180,7 @@ class MenuField extends FormField
 		// Create the modal id.
 		$modalId = 'Item_' . $this->id;
 
-		/** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
+		/* @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
 		$wa = Factory::getApplication()->getDocument()->getWebAssetManager();
 
 		// Add the modal field script to the document head.

--- a/administrator/components/com_menus/tmpl/item/edit.php
+++ b/administrator/components/com_menus/tmpl/item/edit.php
@@ -23,7 +23,7 @@ Text::script('JGLOBAL_VALIDATION_FORM_FAILED');
 
 $this->document->addScriptOptions('menu-item', ['itemId' => (int) $this->item->id]);
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('keepalive')
 	->useScript('form.validate')

--- a/administrator/components/com_menus/tmpl/item/edit_container.php
+++ b/administrator/components/com_menus/tmpl/item/edit_container.php
@@ -15,7 +15,7 @@ use Joomla\Registry\Registry;
 // Initialise related data.
 $menuLinks = MenusHelper::getMenuLinks('main');
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('joomla.treeselectmenu')
 	->useStyle('com_menus.admin-item-edit-container')

--- a/administrator/components/com_menus/tmpl/item/edit_modules.php
+++ b/administrator/components/com_menus/tmpl/item/edit_modules.php
@@ -20,7 +20,7 @@ foreach ($this->levels as $key => $value)
 
 $this->document->addScriptOptions('menus-edit-modules', ['viewLevels' => $allLevels, 'itemId' => $this->item->id]);
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useStyle('com_menus.admin-item-edit-modules')
 	->useScript('com_menus.admin-item-edit-modules');

--- a/administrator/components/com_menus/tmpl/items/default_batch_body.php
+++ b/administrator/components/com_menus/tmpl/items/default_batch_body.php
@@ -23,7 +23,7 @@ $menuType  = Factory::getApplication()->getUserState('com_menus.items.menutype')
 
 if ($clientId == 1)
 {
-	/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+	/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 	$wa = $this->document->getWebAssetManager();
 	$wa->useScript('com_menus.batch-body');
 }

--- a/administrator/components/com_menus/tmpl/items/modal.php
+++ b/administrator/components/com_menus/tmpl/items/modal.php
@@ -24,7 +24,7 @@ if ($app->isClient('site'))
 	Session::checkToken('get') or die(Text::_('JINVALID_TOKEN'));
 }
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('com_menus.admin-items-modal');
 

--- a/administrator/components/com_menus/tmpl/menus/default.php
+++ b/administrator/components/com_menus/tmpl/menus/default.php
@@ -35,7 +35,7 @@ foreach ($this->items as $item)
 
 $this->document->addScriptOptions('menus-default', ['items' => $itemIds]);
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('com_menus.admin-menus');
 

--- a/administrator/components/com_menus/tmpl/menutypes/default.php
+++ b/administrator/components/com_menus/tmpl/menutypes/default.php
@@ -19,7 +19,7 @@ $input = Factory::getApplication()->input;
 $tmpl = ($input->getCmd('tmpl') != '') ? '1' : '';
 $tmpl = json_encode($tmpl, JSON_NUMERIC_CHECK);
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('com_menus.admin-item-modal');
 

--- a/administrator/components/com_modules/tmpl/module/edit.php
+++ b/administrator/components/com_modules/tmpl/module/edit.php
@@ -37,7 +37,7 @@ Text::script('JTRASHED');
 
 $this->document->addScriptOptions('module-edit', ['itemId' => $this->item->id, 'state' => (int) $this->item->id == 0 ? 'Add' : 'Edit']);
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('keepalive')
 	->useScript('form.validate')

--- a/administrator/components/com_modules/tmpl/modules/modal.php
+++ b/administrator/components/com_modules/tmpl/modules/modal.php
@@ -21,7 +21,7 @@ if (Factory::getApplication()->isClient('site'))
 	Session::checkToken('get') or die(Text::_('JINVALID_TOKEN'));
 }
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('com_modules.admin-modules-modal');
 

--- a/administrator/components/com_modules/tmpl/select/default.php
+++ b/administrator/components/com_modules/tmpl/select/default.php
@@ -18,7 +18,7 @@ $app = Factory::getApplication();
 
 $function  = $app->input->getCmd('function');
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('com_modules.admin-module-search');
 

--- a/administrator/components/com_newsfeeds/src/Field/Modal/NewsfeedField.php
+++ b/administrator/components/com_newsfeeds/src/Field/Modal/NewsfeedField.php
@@ -60,7 +60,7 @@ class NewsfeedField extends FormField
 		// Create the modal id.
 		$modalId = 'Newsfeed_' . $this->id;
 
-		/** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
+		/* @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
 		$wa = Factory::getApplication()->getDocument()->getWebAssetManager();
 
 		// Add the modal field script to the document head.

--- a/administrator/components/com_newsfeeds/src/Model/NewsfeedModel.php
+++ b/administrator/components/com_newsfeeds/src/Model/NewsfeedModel.php
@@ -199,7 +199,7 @@ class NewsfeedModel extends AdminModel
 				'published' => 1,
 			];
 
-			/** @var \Joomla\Component\Categories\Administrator\Model\CategoryModel $categoryModel */
+			/* @var \Joomla\Component\Categories\Administrator\Model\CategoryModel $categoryModel */
 			$categoryModel = Factory::getApplication()->bootComponent('com_categories')
 				->getMVCFactory()->createModel('Category', 'Administrator', ['ignore_request' => true]);
 

--- a/administrator/components/com_newsfeeds/tmpl/newsfeed/edit.php
+++ b/administrator/components/com_newsfeeds/tmpl/newsfeed/edit.php
@@ -16,7 +16,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->getRegistry()->addExtensionRegistryFile('com_contenthistory');
 $wa->useScript('keepalive')

--- a/administrator/components/com_privacy/tmpl/request/default.php
+++ b/administrator/components/com_privacy/tmpl/request/default.php
@@ -14,7 +14,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 use Joomla\Component\Actionlogs\Administrator\Helper\ActionlogsHelper;
 
-/** @var \Joomla\Component\Privacy\Administrator\View\Request\HtmlView $this */
+/* @var \Joomla\Component\Privacy\Administrator\View\Request\HtmlView $this */
 
 HTMLHelper::_('behavior.formvalidator');
 HTMLHelper::_('behavior.keepalive');

--- a/administrator/components/com_privacy/tmpl/request/edit.php
+++ b/administrator/components/com_privacy/tmpl/request/edit.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Router\Route;
 
-/** @var \Joomla\Component\Privacy\Administrator\View\Request\HtmlView $this */
+/* @var \Joomla\Component\Privacy\Administrator\View\Request\HtmlView $this */
 
 HTMLHelper::_('behavior.formvalidator');
 HTMLHelper::_('behavior.keepalive');

--- a/administrator/components/com_tags/src/Controller/TagsController.php
+++ b/administrator/components/com_tags/src/Controller/TagsController.php
@@ -51,7 +51,7 @@ class TagsController extends AdminController
 
 		$this->setRedirect(Route::_('index.php?option=com_tags&view=tags', false));
 
-		/** @var \Joomla\Component\Tags\Administrator\Model\TagModel $model */
+		/* @var \Joomla\Component\Tags\Administrator\Model\TagModel $model */
 		$model = $this->getModel();
 
 		if ($model->rebuild())

--- a/administrator/components/com_tags/src/Model/TagModel.php
+++ b/administrator/components/com_tags/src/Model/TagModel.php
@@ -228,7 +228,7 @@ class TagModel extends AdminModel
 	 */
 	public function save($data)
 	{
-		/** @var \Joomla\Component\Tags\Administrator\Table\TagTable $table */
+		/* @var \Joomla\Component\Tags\Administrator\Table\TagTable $table */
 		$table      = $this->getTable();
 		$input      = Factory::getApplication()->input;
 		$pk         = (!empty($data['id'])) ? $data['id'] : (int) $this->getState($this->getName() . '.id');
@@ -358,7 +358,7 @@ class TagModel extends AdminModel
 	public function rebuild()
 	{
 		// Get an instance of the table object.
-		/** @var \Joomla\Component\Tags\Administrator\Table\Tag $table */
+		/* @var \Joomla\Component\Tags\Administrator\Table\Tag $table */
 
 		$table = $this->getTable();
 
@@ -390,7 +390,7 @@ class TagModel extends AdminModel
 	public function saveorder($idArray = null, $lft_array = null)
 	{
 		// Get an instance of the table object.
-		/** @var \Joomla\Component\Tags\Administrator\Table\Tag $table */
+		/* @var \Joomla\Component\Tags\Administrator\Table\Tag $table */
 
 		$table = $this->getTable();
 
@@ -421,7 +421,7 @@ class TagModel extends AdminModel
 	protected function generateNewTitle($parent_id, $alias, $title)
 	{
 		// Alter the title & alias
-		/** @var \Joomla\Component\Tags\Administrator\Table\Tag $table */
+		/* @var \Joomla\Component\Tags\Administrator\Table\Tag $table */
 
 		$table = $this->getTable();
 

--- a/administrator/components/com_tags/tmpl/tag/edit.php
+++ b/administrator/components/com_tags/tmpl/tag/edit.php
@@ -14,7 +14,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->getRegistry()->addExtensionRegistryFile('com_contenthistory');
 $wa->useScript('keepalive')

--- a/administrator/components/com_templates/src/Controller/StylesController.php
+++ b/administrator/components/com_templates/src/Controller/StylesController.php
@@ -98,7 +98,7 @@ class StylesController extends AdminController
 			// Pop off the first element.
 			$id = array_shift($pks);
 
-			/** @var \Joomla\Component\Templates\Administrator\Model\StyleModel $model */
+			/* @var \Joomla\Component\Templates\Administrator\Model\StyleModel $model */
 			$model = $this->getModel();
 			$model->setHome($id);
 			$this->setMessage(Text::_('COM_TEMPLATES_SUCCESS_HOME_SET'));
@@ -136,7 +136,7 @@ class StylesController extends AdminController
 			// Pop off the first element.
 			$id = array_shift($pks);
 
-			/** @var \Joomla\Component\Templates\Administrator\Model\StyleModel $model */
+			/* @var \Joomla\Component\Templates\Administrator\Model\StyleModel $model */
 			$model = $this->getModel();
 			$model->unsetHome($id);
 			$this->setMessage(Text::_('COM_TEMPLATES_SUCCESS_HOME_UNSET'));

--- a/administrator/components/com_templates/src/Controller/TemplateController.php
+++ b/administrator/components/com_templates/src/Controller/TemplateController.php
@@ -222,7 +222,7 @@ class TemplateController extends BaseController
 			// Call installation model
 			$this->input->set('install_directory', $app->get('tmp_path') . '/' . $model->getState('tmp_prefix'));
 
-			/** @var \Joomla\Component\Installer\Administrator\Model\InstallModel $installModel */
+			/* @var \Joomla\Component\Installer\Administrator\Model\InstallModel $installModel */
 			$installModel = $this->app->bootComponent('com_installer')
 				->getMVCFactory()->createModel('Install', 'Administrator');
 			$this->app->getLanguage()->load('com_installer');
@@ -286,7 +286,7 @@ class TemplateController extends BaseController
 		$data         = $this->input->post->get('jform', array(), 'array');
 		$task         = $this->getTask();
 
-		/** @var \Joomla\Component\Templates\Administrator\Model\TemplateModel $model */
+		/* @var \Joomla\Component\Templates\Administrator\Model\TemplateModel $model */
 		$model        = $this->getModel();
 		$fileName     = $this->input->get('file');
 		$explodeArray = explode(':', base64_decode($fileName));
@@ -580,7 +580,7 @@ class TemplateController extends BaseController
 		// Check for request forgeries
 		$this->checkToken();
 
-		/** @var \Joomla\Component\Templates\Administrator\Model\TemplateModel $model */
+		/* @var \Joomla\Component\Templates\Administrator\Model\TemplateModel $model */
 		$model    = $this->getModel();
 		$id       = $this->input->get('id');
 		$file     = $this->input->get('file');
@@ -627,7 +627,7 @@ class TemplateController extends BaseController
 		// Check for request forgeries
 		$this->checkToken();
 
-		/** @var \Joomla\Component\Templates\Administrator\Model\TemplateModel $model */
+		/* @var \Joomla\Component\Templates\Administrator\Model\TemplateModel $model */
 		$model    = $this->getModel();
 		$id       = $this->input->get('id');
 		$file     = $this->input->get('file');
@@ -679,7 +679,7 @@ class TemplateController extends BaseController
 		// Check for request forgeries
 		$this->checkToken();
 
-		/** @var \Joomla\Component\Templates\Administrator\Model\TemplateModel $model */
+		/* @var \Joomla\Component\Templates\Administrator\Model\TemplateModel $model */
 		$model   = $this->getModel();
 		$id      = $this->input->get('id');
 		$file    = $this->input->get('file');
@@ -738,7 +738,7 @@ class TemplateController extends BaseController
 		$w     = $this->input->get('w');
 		$h     = $this->input->get('h');
 
-		/** @var \Joomla\Component\Templates\Administrator\Model\TemplateModel $model */
+		/* @var \Joomla\Component\Templates\Administrator\Model\TemplateModel $model */
 		$model = $this->getModel();
 
 		// Access check.
@@ -786,7 +786,7 @@ class TemplateController extends BaseController
 		$width  = $this->input->get('width');
 		$height = $this->input->get('height');
 
-		/** @var \Joomla\Component\Templates\Administrator\Model\TemplateModel $model */
+		/* @var \Joomla\Component\Templates\Administrator\Model\TemplateModel $model */
 		$model  = $this->getModel();
 
 		// Access check.
@@ -828,7 +828,7 @@ class TemplateController extends BaseController
 		$newName  = $this->input->get('new_name');
 		$location = base64_decode($this->input->get('address'));
 
-		/** @var \Joomla\Component\Templates\Administrator\Model\TemplateModel $model */
+		/* @var \Joomla\Component\Templates\Administrator\Model\TemplateModel $model */
 		$model    = $this->getModel();
 
 		// Access check.
@@ -873,7 +873,7 @@ class TemplateController extends BaseController
 		$id    = $this->input->get('id');
 		$file  = $this->input->get('file');
 
-		/** @var \Joomla\Component\Templates\Administrator\Model\TemplateModel $model */
+		/* @var \Joomla\Component\Templates\Administrator\Model\TemplateModel $model */
 		$model = $this->getModel();
 
 		// Access check.
@@ -927,7 +927,7 @@ class TemplateController extends BaseController
 			$app->close();
 		}
 
-		/** @var \Joomla\Component\Templates\Administrator\Model\TemplateModel $model */
+		/* @var \Joomla\Component\Templates\Administrator\Model\TemplateModel $model */
 		$model = $this->getModel();
 
 		$result = $model->getUpdatedList(true, true);

--- a/administrator/components/com_templates/tmpl/style/edit_assignment.php
+++ b/administrator/components/com_templates/tmpl/style/edit_assignment.php
@@ -18,7 +18,7 @@ use Joomla\Component\Menus\Administrator\Helper\MenusHelper;
 $menuTypes = MenusHelper::getMenuLinks();
 $user      = Factory::getUser();
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('com_templates.admin-template-toggle-assignment');
 

--- a/administrator/components/com_templates/tmpl/template/default.php
+++ b/administrator/components/com_templates/tmpl/template/default.php
@@ -18,7 +18,7 @@ use Joomla\CMS\Session\Session;
 
 HTMLHelper::_('behavior.multiselect', 'updateForm');
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa    = $this->document->getWebAssetManager();
 $input = Factory::getApplication()->input;
 

--- a/administrator/components/com_users/tmpl/groups/default.php
+++ b/administrator/components/com_users/tmpl/groups/default.php
@@ -24,7 +24,7 @@ $listDirn    = $this->escape($this->state->get('list.direction'));
 
 Text::script('COM_USERS_GROUPS_CONFIRM_DELETE', true);
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('com_users.admin-users-groups');
 

--- a/administrator/components/com_users/tmpl/mail/default.php
+++ b/administrator/components/com_users/tmpl/mail/default.php
@@ -18,7 +18,7 @@ Text::script('COM_USERS_MAIL_PLEASE_FILL_IN_THE_SUBJECT', true);
 Text::script('COM_USERS_MAIL_PLEASE_SELECT_A_GROUP', true);
 Text::script('COM_USERS_MAIL_PLEASE_FILL_IN_THE_MESSAGE', true);
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('com_users.admin-users-mail');
 

--- a/administrator/components/com_users/tmpl/note/edit.php
+++ b/administrator/components/com_users/tmpl/note/edit.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Router\Route;
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->getRegistry()->addExtensionRegistryFile('com_contenthistory');
 $wa->useScript('keepalive')

--- a/administrator/components/com_users/tmpl/user/edit.php
+++ b/administrator/components/com_users/tmpl/user/edit.php
@@ -16,7 +16,7 @@ use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\Component\Users\Administrator\Helper\UsersHelper;
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('keepalive')
 	->useScript('form.validate')

--- a/administrator/modules/mod_login/tmpl/default.php
+++ b/administrator/modules/mod_login/tmpl/default.php
@@ -13,7 +13,7 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $app->getDocument()->getWebAssetManager();
 $wa->useScript('core')
 	->useScript('form.validate')

--- a/administrator/modules/mod_menu/tmpl/default.php
+++ b/administrator/modules/mod_menu/tmpl/default.php
@@ -16,7 +16,7 @@ $doc       = $app->getDocument();
 $direction = $doc->direction === 'rtl' ? 'float-right' : '';
 $class     = $enabled ? 'nav flex-column main-nav ' . $direction : 'nav flex-column main-nav disabled ' . $direction;
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $doc->getWebAssetManager();
 $wa->getRegistry()->addExtensionRegistryFile('com_cpanel');
 $wa->useScript('metismenujs')

--- a/administrator/modules/mod_quickicon/tmpl/default.php
+++ b/administrator/modules/mod_quickicon/tmpl/default.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $app->getDocument()->getWebAssetManager();
 $wa->registerAndUseScript('mod_quickicon', 'mod_quickicon/quickicon.min.js', [], ['defer' => true]);
 

--- a/administrator/templates/atum/Service/HTML/Atum.php
+++ b/administrator/templates/atum/Service/HTML/Atum.php
@@ -140,7 +140,7 @@ class JHtmlAtum
 
 		if (count($root))
 		{
-			/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+			/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 			$wa = Factory::getApplication()->getDocument()->getWebAssetManager();
 			$wa->addInlineStyle(':root {' . implode($root) . '}');
 		}

--- a/administrator/templates/atum/error_login.php
+++ b/administrator/templates/atum/error_login.php
@@ -14,7 +14,7 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Uri\Uri;
 
-/** @var \Joomla\CMS\Document\HtmlDocument $this */
+/* @var \Joomla\CMS\Document\HtmlDocument $this */
 
 $app   = Factory::getApplication();
 $input = $app->input;

--- a/administrator/templates/system/error.php
+++ b/administrator/templates/system/error.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 
-/** @var Joomla\CMS\Document\ErrorDocument $this */
+/* @var Joomla\CMS\Document\ErrorDocument $this */
 
 // Load template CSS file
 $this->getWebAssetManager()->registerAndUseStyle('template.system.error', 'administrator/templates/system/css/error.css');

--- a/api/components/com_categories/src/View/Categories/JsonapiView.php
+++ b/api/components/com_categories/src/View/Categories/JsonapiView.php
@@ -124,7 +124,7 @@ class JsonapiView extends BaseApiView
 
 		if ($item === null)
 		{
-			/** @var \Joomla\CMS\MVC\Model\AdminModel $model */
+			/* @var \Joomla\CMS\MVC\Model\AdminModel $model */
 			$model = $this->getModel();
 			$item  = $this->prepareItem($model->getItem());
 		}

--- a/api/components/com_fields/src/View/Fields/JsonapiView.php
+++ b/api/components/com_fields/src/View/Fields/JsonapiView.php
@@ -108,7 +108,7 @@ class JsonapiView extends BaseApiView
 	{
 		if ($item === null)
 		{
-			/** @var \Joomla\CMS\MVC\Model\AdminModel $model */
+			/* @var \Joomla\CMS\MVC\Model\AdminModel $model */
 			$model = $this->getModel();
 			$item  = $this->prepareItem($model->getItem());
 		}

--- a/api/components/com_fields/src/View/Groups/JsonapiView.php
+++ b/api/components/com_fields/src/View/Groups/JsonapiView.php
@@ -101,7 +101,7 @@ class JsonapiView extends BaseApiView
 	{
 		if ($item === null)
 		{
-			/** @var \Joomla\CMS\MVC\Model\AdminModel $model */
+			/* @var \Joomla\CMS\MVC\Model\AdminModel $model */
 			$model = $this->getModel();
 			$item  = $this->prepareItem($model->getItem());
 		}

--- a/api/components/com_languages/src/Controller/OverridesController.php
+++ b/api/components/com_languages/src/Controller/OverridesController.php
@@ -84,7 +84,7 @@ class OverridesController extends ApiController
 	 */
 	protected function save($recordKey = null)
 	{
-		/** @var \Joomla\CMS\MVC\Model\AdminModel $model */
+		/* @var \Joomla\CMS\MVC\Model\AdminModel $model */
 		$model = $this->getModel(Inflector::singularize($this->contentType));
 
 		$model->setState('filter.language', $this->input->post->get('lang_code'));

--- a/api/components/com_languages/src/Controller/StringsController.php
+++ b/api/components/com_languages/src/Controller/StringsController.php
@@ -72,7 +72,7 @@ class StringsController extends ApiController
 
 		try
 		{
-			/** @var \Joomla\Component\Languages\Api\View\Strings\JsonapiView $view */
+			/* @var \Joomla\Component\Languages\Api\View\Strings\JsonapiView $view */
 			$view = $this->getView(
 				$viewName,
 				$viewType,
@@ -85,7 +85,7 @@ class StringsController extends ApiController
 			throw new \RuntimeException($e->getMessage());
 		}
 
-		/** @var \Joomla\Component\Languages\Administrator\Model\StringsModel $model */
+		/* @var \Joomla\Component\Languages\Administrator\Model\StringsModel $model */
 		$model = $this->getModel($this->contentType, '', ['ignore_request' => true]);
 
 		if (!$model)
@@ -112,7 +112,7 @@ class StringsController extends ApiController
 	 */
 	public function refresh()
 	{
-		/** @var \Joomla\Component\Languages\Administrator\Model\StringsModel $model */
+		/* @var \Joomla\Component\Languages\Administrator\Model\StringsModel $model */
 		$model = $this->getModel($this->contentType, '', ['ignore_request' => true]);
 
 		if (!$model)

--- a/api/components/com_languages/src/View/Overrides/JsonapiView.php
+++ b/api/components/com_languages/src/View/Overrides/JsonapiView.php
@@ -47,7 +47,7 @@ class JsonapiView extends BaseApiView
 	 */
 	public function displayItem($item = null)
 	{
-		/** @var \Joomla\Component\Languages\Administrator\Model\OverrideModel $model */
+		/* @var \Joomla\Component\Languages\Administrator\Model\OverrideModel $model */
 		$model = $this->getModel();
 		$id    = $model->getState($model->getName() . '.id');
 		$item  = $this->prepareItem($model->getItem($id));
@@ -65,7 +65,7 @@ class JsonapiView extends BaseApiView
 	 */
 	public function displayList(array $items = null)
 	{
-		/** @var \Joomla\Component\Languages\Administrator\Model\OverridesModel $model */
+		/* @var \Joomla\Component\Languages\Administrator\Model\OverridesModel $model */
 		$model = $this->getModel();
 		$items = [];
 

--- a/api/components/com_languages/src/View/Strings/JsonapiView.php
+++ b/api/components/com_languages/src/View/Strings/JsonapiView.php
@@ -47,7 +47,7 @@ class JsonapiView extends BaseApiView
 	 */
 	public function displayList(array $items = null)
 	{
-		/** @var \Joomla\Component\Languages\Administrator\Model\StringsModel $model */
+		/* @var \Joomla\Component\Languages\Administrator\Model\StringsModel $model */
 		$model  = $this->getModel();
 		$result = $model->search();
 

--- a/api/components/com_menus/src/View/Items/JsonapiView.php
+++ b/api/components/com_menus/src/View/Items/JsonapiView.php
@@ -119,7 +119,7 @@ class JsonapiView extends BaseApiView
 	 */
 	public function displayListTypes()
 	{
-		/** @var \Joomla\Component\Menus\Administrator\Model\MenutypesModel $model */
+		/* @var \Joomla\Component\Menus\Administrator\Model\MenutypesModel $model */
 		$model = $this->getModel();
 		$items = [];
 

--- a/api/components/com_modules/src/View/Modules/JsonapiView.php
+++ b/api/components/com_modules/src/View/Modules/JsonapiView.php
@@ -93,7 +93,7 @@ class JsonapiView extends BaseApiView
 	 */
 	public function displayItem($item = null)
 	{
-		/** @var \Joomla\CMS\MVC\Model\AdminModel $model */
+		/* @var \Joomla\CMS\MVC\Model\AdminModel $model */
 		$model = $this->getModel();
 
 		if ($item === null)

--- a/api/components/com_plugins/src/Controller/PluginsController.php
+++ b/api/components/com_plugins/src/Controller/PluginsController.php
@@ -68,7 +68,7 @@ class PluginsController extends ApiController
 			}
 		}
 
-		/** @var \Joomla\Component\Plugins\Administrator\Model\PluginModel $model */
+		/* @var \Joomla\Component\Plugins\Administrator\Model\PluginModel $model */
 		$model = $this->getModel(Inflector::singularize($this->contentType), '', ['ignore_request' => true]);
 
 		if (!$model)

--- a/api/components/com_privacy/src/View/Consents/JsonapiView.php
+++ b/api/components/com_privacy/src/View/Consents/JsonapiView.php
@@ -80,7 +80,7 @@ class JsonapiView extends BaseApiView
 			throw new \RuntimeException(Text::_('JLIB_APPLICATION_ERROR_ITEMID_MISSING'));
 		}
 
-		/** @var \Joomla\CMS\MVC\Model\ListModel $model */
+		/* @var \Joomla\CMS\MVC\Model\ListModel $model */
 		$model       = $this->getModel();
 		$displayItem = null;
 

--- a/components/com_ajax/ajax.php
+++ b/components/com_ajax/ajax.php
@@ -25,7 +25,7 @@ use Joomla\CMS\Table\Table;
  * - https://groups.google.com/d/msg/joomla-dev-cms/WsC0nA9Fixo/Ur-gPqpqh-EJ
  */
 
-/** @var \Joomla\CMS\Application\CMSApplication $app */
+/* @var \Joomla\CMS\Application\CMSApplication $app */
 $app = Factory::getApplication();
 $app->allowCache(false);
 

--- a/components/com_banners/src/Controller/DisplayController.php
+++ b/components/com_banners/src/Controller/DisplayController.php
@@ -33,7 +33,7 @@ class DisplayController extends BaseController
 
 		if ($id)
 		{
-			/** @var \Joomla\Component\Banners\Site\Model\BannerModel $model */
+			/* @var \Joomla\Component\Banners\Site\Model\BannerModel $model */
 			$model = $this->getModel('Banner', 'Site', array('ignore_request' => true));
 			$model->setState('banner.id', $id);
 			$model->click();

--- a/components/com_banners/src/Model/BannerModel.php
+++ b/components/com_banners/src/Model/BannerModel.php
@@ -175,7 +175,7 @@ class BannerModel extends BaseDatabaseModel
 	{
 		if (!isset($this->_item))
 		{
-			/** @var \Joomla\CMS\Cache\Controller\CallbackController $cache */
+			/* @var \Joomla\CMS\Cache\Controller\CallbackController $cache */
 			$cache = Factory::getCache('com_banners', 'callback');
 
 			$id = (int) $this->getState('banner.id');

--- a/components/com_config/src/Controller/ModulesController.php
+++ b/components/com_config/src/Controller/ModulesController.php
@@ -113,7 +113,7 @@ class ModulesController extends BaseController
 		$app->loadDocument($document);
 		$app->loadIdentity($user);
 
-		/** @var \Joomla\CMS\Dispatcher\ComponentDispatcher $dispatcher */
+		/* @var \Joomla\CMS\Dispatcher\ComponentDispatcher $dispatcher */
 		$dispatcher = $app->bootComponent('com_modules')->getDispatcher($app);
 
 		/** @var ModuleController $controllerClass */

--- a/components/com_config/tmpl/config/default.php
+++ b/components/com_config/tmpl/config/default.php
@@ -13,7 +13,7 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('keepalive')
 	->useScript('form.validate')

--- a/components/com_config/tmpl/modules/default.php
+++ b/components/com_config/tmpl/modules/default.php
@@ -18,7 +18,7 @@ use Joomla\CMS\Router\Route;
 
 HTMLHelper::_('behavior.combobox');
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('keepalive')
 	->useScript('form.validate')

--- a/components/com_config/tmpl/templates/default.php
+++ b/components/com_config/tmpl/templates/default.php
@@ -16,7 +16,7 @@ use Joomla\CMS\Router\Route;
 
 $user = Factory::getUser();
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('keepalive')
 	->useScript('form.validate')

--- a/components/com_contact/layouts/joomla/form/renderfield.php
+++ b/components/com_contact/layouts/joomla/form/renderfield.php
@@ -15,15 +15,15 @@ extract($displayData);
 
 /**
  * Layout variables
- * ---------------------
- * 	$options         : (array)  Optional parameters
- * 	$label           : (string) The html code for the label (not required if $options['hiddenLabel'] is true)
- * 	$input           : (string) The input field html code
+ * -----------------
+ * 	@var   array   $options  Optional parameters
+ * 	@var   string  $label    The html code for the label (not required if $options['hiddenLabel'] is true)
+ * 	@var   string  $input    The input field html code
  */
 
 if (!empty($options['showonEnabled']))
 {
-	/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+	/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 	$wa = $this->document->getWebAssetManager();
 	$wa->useScript('showon');
 }

--- a/components/com_contact/layouts/joomla/form/renderfield.php
+++ b/components/com_contact/layouts/joomla/form/renderfield.php
@@ -16,9 +16,9 @@ extract($displayData);
 /**
  * Layout variables
  * -----------------
- * 	@var   array   $options  Optional parameters
- * 	@var   string  $label    The html code for the label (not required if $options['hiddenLabel'] is true)
- * 	@var   string  $input    The input field html code
+ * @var   array   $options  Optional parameters
+ * @var   string  $label    The html code for the label (not required if $options['hiddenLabel'] is true)
+ * @var   string  $input    The input field html code
  */
 
 if (!empty($options['showonEnabled']))

--- a/components/com_contact/tmpl/categories/default.php
+++ b/components/com_contact/tmpl/categories/default.php
@@ -16,7 +16,7 @@ use Joomla\CMS\Layout\LayoutHelper;
 Text::script('JGLOBAL_EXPAND_CATEGORIES');
 Text::script('JGLOBAL_COLLAPSE_CATEGORIES');
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->getRegistry()->addExtensionRegistryFile('com_categories');
 $wa->useScript('com_categories.shared-categories-accordion');

--- a/components/com_content/src/View/Featured/HtmlView.php
+++ b/components/com_content/src/View/Featured/HtmlView.php
@@ -122,7 +122,7 @@ class HtmlView extends BaseHtmlView
 			throw new GenericDataException(implode("\n", $errors), 500);
 		}
 
-		/** @var \Joomla\Registry\Registry $params */
+		/* @var \Joomla\Registry\Registry $params */
 		$params = &$state->params;
 
 		// PREPARE THE DATA

--- a/components/com_content/tmpl/categories/default.php
+++ b/components/com_content/tmpl/categories/default.php
@@ -16,7 +16,7 @@ use Joomla\CMS\Layout\LayoutHelper;
 Text::script('JGLOBAL_EXPAND_CATEGORIES');
 Text::script('JGLOBAL_COLLAPSE_CATEGORIES');
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->getRegistry()->addExtensionRegistryFile('com_categories');
 $wa->useScript('com_categories.shared-categories-accordion');

--- a/components/com_content/tmpl/form/edit.php
+++ b/components/com_content/tmpl/form/edit.php
@@ -15,7 +15,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('keepalive')
 	->useScript('form.validate')

--- a/components/com_newsfeeds/tmpl/categories/default.php
+++ b/components/com_newsfeeds/tmpl/categories/default.php
@@ -16,7 +16,7 @@ use Joomla\CMS\Layout\LayoutHelper;
 Text::script('JGLOBAL_EXPAND_CATEGORIES');
 Text::script('JGLOBAL_COLLAPSE_CATEGORIES');
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->getRegistry()->addExtensionRegistryFile('com_categories');
 $wa->useScript('com_categories.shared-categories-accordion');

--- a/components/com_privacy/tmpl/confirm/default.php
+++ b/components/com_privacy/tmpl/confirm/default.php
@@ -13,7 +13,7 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 
-/** @var \Joomla\Component\Privacy\Site\View\Confirm\HtmlView $this */
+/* @var \Joomla\Component\Privacy\Site\View\Confirm\HtmlView $this */
 
 HTMLHelper::_('behavior.keepalive');
 HTMLHelper::_('behavior.formvalidator');

--- a/components/com_privacy/tmpl/remind/default.php
+++ b/components/com_privacy/tmpl/remind/default.php
@@ -13,7 +13,7 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 
-/** @var \Joomla\Component\Privacy\Site\View\Remind\HtmlView $this */
+/* @var \Joomla\Component\Privacy\Site\View\Remind\HtmlView $this */
 
 HTMLHelper::_('behavior.keepalive');
 HTMLHelper::_('behavior.formvalidator');

--- a/components/com_privacy/tmpl/request/default.php
+++ b/components/com_privacy/tmpl/request/default.php
@@ -13,7 +13,7 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 
-/** @var \Joomla\Component\Privacy\Site\View\Request\HtmlView $this */
+/* @var \Joomla\Component\Privacy\Site\View\Request\HtmlView $this */
 
 HTMLHelper::_('behavior.keepalive');
 HTMLHelper::_('behavior.formvalidator');

--- a/components/com_tags/src/Model/TagModel.php
+++ b/components/com_tags/src/Model/TagModel.php
@@ -286,7 +286,7 @@ class TagModel extends ListModel
 			}
 
 			// Get a level row instance.
-			/** @var \Joomla\Component\Tags\Administrator\Table\Tag $table */
+			/* @var \Joomla\Component\Tags\Administrator\Table\Tag $table */
 			$table = $this->getTable();
 
 			$idsArray = explode(',', $pk);
@@ -351,7 +351,7 @@ class TagModel extends ListModel
 		{
 			$pk    = (!empty($pk)) ? $pk : (int) $this->getState('tag.id');
 
-			/** @var \Joomla\Component\Tags\Administrator\Table\Tag $table */
+			/* @var \Joomla\Component\Tags\Administrator\Table\Tag $table */
 			$table = $this->getTable();
 			$table->hit($pk);
 

--- a/components/com_tags/tmpl/tag/default_items.php
+++ b/components/com_tags/tmpl/tag/default_items.php
@@ -16,7 +16,7 @@ use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
 use Joomla\Component\Tags\Site\Helper\RouteHelper;
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('com_tags.tag-default');
 

--- a/components/com_tags/tmpl/tag/list_items.php
+++ b/components/com_tags/tmpl/tag/list_items.php
@@ -14,7 +14,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('com_tags.tag-list');
 

--- a/components/com_tags/tmpl/tags/default_items.php
+++ b/components/com_tags/tmpl/tags/default_items.php
@@ -16,7 +16,7 @@ use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
 use Joomla\Component\Tags\Site\Helper\RouteHelper;
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('com_tags.tags-default');
 

--- a/components/com_users/layouts/joomla/form/renderfield.php
+++ b/components/com_users/layouts/joomla/form/renderfield.php
@@ -16,14 +16,14 @@ extract($displayData);
 /**
  * Layout variables
  * ---------------------
- *    $options         : (array)  Optional parameters
- *    $label           : (string) The html code for the label (not required if $options['hiddenLabel'] is true)
- *    $input           : (string) The input field html code
+ * @var   array   $options  Optional parameters
+ * @var   string  $label    The html code for the label (not required if $options['hiddenLabel'] is true)
+ * @var   string  $input    The input field html code
  */
 
 if (!empty($options['showonEnabled']))
 {
-	/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+	/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 	$wa = Factory::getApplication()->getDocument()->getWebAssetManager();
 	$wa->useScript('showon');
 }

--- a/components/com_users/src/Controller/ProfileController.php
+++ b/components/com_users/src/Controller/ProfileController.php
@@ -65,7 +65,7 @@ class ProfileController extends BaseController
 		// Set the user id for the user to edit in the session.
 		$app->setUserState('com_users.edit.profile.id', $userId);
 
-		/** @var \Joomla\Component\Users\Site\Model\ProfileModel $model */
+		/* @var \Joomla\Component\Users\Site\Model\ProfileModel $model */
 		$model = $this->getModel('Profile', 'Site');
 
 		// Check out the user.
@@ -101,7 +101,7 @@ class ProfileController extends BaseController
 
 		$app    = $this->app;
 
-		/** @var \Joomla\Component\Users\Site\Model\ProfileModel $model */
+		/* @var \Joomla\Component\Users\Site\Model\ProfileModel $model */
 		$model  = $this->getModel('Profile', 'Site');
 		$user   = Factory::getUser();
 		$userId = (int) $user->get('id');

--- a/components/com_users/src/Controller/RegistrationController.php
+++ b/components/com_users/src/Controller/RegistrationController.php
@@ -54,7 +54,7 @@ class RegistrationController extends BaseController
 			return false;
 		}
 
-		/** @var \Joomla\Component\Users\Site\Model\RegistrationModel $model */
+		/* @var \Joomla\Component\Users\Site\Model\RegistrationModel $model */
 		$model = $this->getModel('Registration', 'Site');
 		$token = $input->getAlnum('token');
 
@@ -167,7 +167,7 @@ class RegistrationController extends BaseController
 
 		$app   = $this->app;
 
-		/** @var \Joomla\Component\Users\Site\Model\RegistrationModel $model */
+		/* @var \Joomla\Component\Users\Site\Model\RegistrationModel $model */
 		$model = $this->getModel('Registration', 'Site');
 
 		// Get the user data.

--- a/components/com_users/src/Controller/RemindController.php
+++ b/components/com_users/src/Controller/RemindController.php
@@ -34,7 +34,7 @@ class RemindController extends BaseController
 		// Check the request token.
 		$this->checkToken('post');
 
-		/** @var \Joomla\Component\Users\Site\Model\RemindModel $model */
+		/* @var \Joomla\Component\Users\Site\Model\RemindModel $model */
 		$model = $this->getModel('Remind', 'Site');
 		$data  = $this->input->post->get('jform', array(), 'array');
 

--- a/components/com_users/src/Controller/ResetController.php
+++ b/components/com_users/src/Controller/ResetController.php
@@ -35,7 +35,7 @@ class ResetController extends BaseController
 
 		$app   = $this->app;
 
-		/** @var \Joomla\Component\Users\Site\Model\ResetModel $model */
+		/* @var \Joomla\Component\Users\Site\Model\ResetModel $model */
 		$model = $this->getModel('Reset', 'Site');
 		$data  = $this->input->post->get('jform', array(), 'array');
 
@@ -94,7 +94,7 @@ class ResetController extends BaseController
 
 		$app   = $this->app;
 
-		/** @var \Joomla\Component\Users\Site\Model\Reset $model */
+		/* @var \Joomla\Component\Users\Site\Model\Reset $model */
 		$model = $this->getModel('Reset', 'Site');
 		$data  = $this->input->get('jform', array(), 'array');
 
@@ -152,7 +152,7 @@ class ResetController extends BaseController
 
 		$app   = $this->app;
 
-		/** @var \Joomla\Component\Users\Site\Model\ResetModel $model */
+		/* @var \Joomla\Component\Users\Site\Model\ResetModel $model */
 		$model = $this->getModel('Reset', 'Site');
 		$data  = $this->input->post->get('jform', array(), 'array');
 

--- a/components/com_users/src/Controller/UserController.php
+++ b/components/com_users/src/Controller/UserController.php
@@ -316,7 +316,7 @@ class UserController extends BaseController
 
 		$app   = $this->app;
 
-		/** @var \Joomla\Component\Users\Site\Model\RemindModel $model */
+		/* @var \Joomla\Component\Users\Site\Model\RemindModel $model */
 		$model = $this->getModel('Remind', 'Site');
 		$data  = $this->input->post->get('jform', array(), 'array');
 

--- a/components/com_users/tmpl/profile/edit.php
+++ b/components/com_users/tmpl/profile/edit.php
@@ -20,7 +20,7 @@ HTMLHelper::_('bootstrap.tooltip');
 $lang = Factory::getLanguage();
 $lang->load('plg_user_profile', JPATH_ADMINISTRATOR);
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('keepalive')
 	->useScript('form.validate')

--- a/installation/src/Controller/DisplayController.php
+++ b/installation/src/Controller/DisplayController.php
@@ -45,7 +45,7 @@ class DisplayController extends BaseController
 			$defaultView = 'remove';
 		}
 
-		/** @var \Joomla\CMS\Installation\Model\ChecksModel $model */
+		/* @var \Joomla\CMS\Installation\Model\ChecksModel $model */
 		$model = $this->getModel('Checks');
 
 		$vName = $this->input->getWord('view', $defaultView);

--- a/installation/src/Controller/InstallationController.php
+++ b/installation/src/Controller/InstallationController.php
@@ -64,7 +64,7 @@ class InstallationController extends JSONController
 		$r->view = 'setup';
 
 		// Check the form
-		/** @var \Joomla\CMS\Installation\Model\SetupModel $model */
+		/* @var \Joomla\CMS\Installation\Model\SetupModel $model */
 		$model = $this->getModel('Setup');
 
 		if ($model->checkForm('setup') === false)
@@ -94,7 +94,7 @@ class InstallationController extends JSONController
 
 		$r = new \stdClass;
 
-		/** @var \Joomla\CMS\Installation\Model\DatabaseModel $databaseModel */
+		/* @var \Joomla\CMS\Installation\Model\DatabaseModel $databaseModel */
 		$databaseModel = $this->getModel('Database');
 
 		// Create Db
@@ -135,7 +135,7 @@ class InstallationController extends JSONController
 	{
 		$this->checkValidToken();
 		$step = $this->getTask();
-		/** @var \Joomla\CMS\Installation\Model\DatabaseModel $model */
+		/* @var \Joomla\CMS\Installation\Model\DatabaseModel $model */
 		$model = $this->getModel('Database');
 
 		$r = new \stdClass;
@@ -185,7 +185,7 @@ class InstallationController extends JSONController
 	{
 		$this->checkValidToken();
 
-		/** @var \Joomla\CMS\Installation\Model\SetupModel $setUpModel */
+		/* @var \Joomla\CMS\Installation\Model\SetupModel $setUpModel */
 		$setUpModel = $this->getModel('Setup');
 
 		// Get the options from the session
@@ -194,7 +194,7 @@ class InstallationController extends JSONController
 		$r = new \stdClass;
 		$r->view = 'remove';
 
-		/** @var \Joomla\CMS\Installation\Model\ConfigurationModel $configurationModel */
+		/* @var \Joomla\CMS\Installation\Model\ConfigurationModel $configurationModel */
 		$configurationModel = $this->getModel('Configuration');
 
 		// Attempt to setup the configuration.
@@ -229,7 +229,7 @@ class InstallationController extends JSONController
 		else
 		{
 			// Get the languages model.
-			/** @var \Joomla\CMS\Installation\Model\LanguagesModel $model */
+			/* @var \Joomla\CMS\Installation\Model\LanguagesModel $model */
 			$model = $this->getModel('Languages');
 
 			// Install selected languages
@@ -254,7 +254,7 @@ class InstallationController extends JSONController
 	{
 		$this->checkValidToken();
 
-		/** @var \Joomla\CMS\Installation\Model\CleanupModel $model */
+		/* @var \Joomla\CMS\Installation\Model\CleanupModel $model */
 		$model = $this->getModel('Cleanup');
 		$success = $model->deleteInstallationFolder();
 

--- a/installation/src/Controller/LanguageController.php
+++ b/installation/src/Controller/LanguageController.php
@@ -87,7 +87,7 @@ class LanguageController extends JSONController
 
 		$app = $this->app;
 
-		/** @var \Joomla\CMS\Installation\Model\LanguagesModel $model */
+		/* @var \Joomla\CMS\Installation\Model\LanguagesModel $model */
 		$model = $this->getModel('Languages');
 
 		// Check for request forgeries in the administrator language

--- a/installation/tmpl/error/default.php
+++ b/installation/tmpl/error/default.php
@@ -8,7 +8,7 @@
 
 defined('_JEXEC') or die;
 
-/** @var \Joomla\CMS\Installation\View\Error\HtmlView $this */
+/* @var \Joomla\CMS\Installation\View\Error\HtmlView $this */
 ?>
 
 <h3>error</h3>

--- a/installation/tmpl/preinstall/default.php
+++ b/installation/tmpl/preinstall/default.php
@@ -13,7 +13,7 @@ use Joomla\CMS\Language\Text;
 
 HTMLHelper::_('behavior.formvalidator');
 
-/** @var \Joomla\CMS\Installation\View\Preinstall\HtmlView $this */
+/* @var \Joomla\CMS\Installation\View\Preinstall\HtmlView $this */
 ?>
 <div id="installer-view" class="container" data-page-name="preinstall">
 		<div class="row">

--- a/installation/tmpl/remove/default.php
+++ b/installation/tmpl/remove/default.php
@@ -14,7 +14,7 @@ use Joomla\CMS\Uri\Uri;
 
 HTMLHelper::_('behavior.formvalidator');
 
-/** @var \Joomla\CMS\Installation\View\Remove\HtmlView $this */
+/* @var \Joomla\CMS\Installation\View\Remove\HtmlView $this */
 ?>
 <div id="installer-view" data-page-name="remove">
 

--- a/installation/tmpl/setup/default.php
+++ b/installation/tmpl/setup/default.php
@@ -14,7 +14,7 @@ use Joomla\CMS\Language\Text;
 
 HTMLHelper::_('behavior.formvalidator');
 
-/** @var \Joomla\CMS\Installation\View\Setup\HtmlView $this */
+/* @var \Joomla\CMS\Installation\View\Setup\HtmlView $this */
 ?>
 
 <div id="installer-view" data-page-name="setup">

--- a/layouts/chromes/outline.php
+++ b/layouts/chromes/outline.php
@@ -12,7 +12,8 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 
-Factory::getApplication()->getDocument()->getWebAssetManager()->registerAndUseStyle('layouts.chromes.outline', 'layouts/chromes/outline.css');
+Factory::getApplication()->getDocument()->getWebAssetManager()
+		->registerAndUseStyle('layouts.chromes.outline', 'layouts/chromes/outline.css');
 
 $module  = $displayData['module'];
 

--- a/layouts/joomla/button/action-button.php
+++ b/layouts/joomla/button/action-button.php
@@ -11,14 +11,17 @@ use Joomla\CMS\HTML\HTMLHelper;
 
 HTMLHelper::_('bootstrap.popover');
 
-/**
- * @var $icon    string
- * @var $title   string
- * @var $value   string
- * @var $task    string
- * @var $options array
- */
 extract($displayData, EXTR_OVERWRITE);
+
+/**
+ * Layout variables
+ * -----------------
+ * @var   string  $icon
+ * @var   string  $title
+ * @var   string  $value
+ * @var   string  $task
+ * @var   array   $options
+ */
 
 $disabled = !empty($options['disabled']);
 $taskPrefix = $options['task_prefix'];

--- a/layouts/joomla/button/transition-button.php
+++ b/layouts/joomla/button/transition-button.php
@@ -12,14 +12,17 @@ use Joomla\CMS\Language\Text;
 
 HTMLHelper::_('bootstrap.popover');
 
-/**
- * @var $icon    string
- * @var $title   string
- * @var $value   string
- * @var $task    string
- * @var $options array
- */
 extract($displayData, EXTR_OVERWRITE);
+
+/**
+ * Layout variables
+ * -----------------
+ * @var   string  $icon
+ * @var   string  $title
+ * @var   string  $value
+ * @var   string  $task
+ * @var   array   $options
+ */
 
 $only_icon = empty($options['transitions']);
 $disabled = !empty($options['disabled']);

--- a/layouts/joomla/content/info_block/associations.php
+++ b/layouts/joomla/content/info_block/associations.php
@@ -13,9 +13,7 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 
-?>
-
-<?php if (!empty($displayData['item']->associations)) : ?>
+if (!empty($displayData['item']->associations)) : ?>
 <?php $associations = $displayData['item']->associations; ?>
 
 <dd class="association">

--- a/layouts/joomla/content/options_default.php
+++ b/layouts/joomla/content/options_default.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\FormHelper;
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = Factory::getApplication()->getDocument()->getWebAssetManager();
 
 ?>

--- a/layouts/joomla/content/tags.php
+++ b/layouts/joomla/content/tags.php
@@ -16,8 +16,7 @@ use Joomla\Registry\Registry;
 
 $authorised = Factory::getUser()->getAuthorisedViewLevels();
 
-?>
-<?php if (!empty($displayData)) : ?>
+if (!empty($displayData)) : ?>
 	<ul class="tags list-inline">
 		<?php foreach ($displayData as $i => $tag) : ?>
 			<?php if (in_array($tag->access, $authorised)) : ?>

--- a/layouts/joomla/edit/associations.php
+++ b/layouts/joomla/edit/associations.php
@@ -9,6 +9,7 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Document\HtmlDocument;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 
@@ -26,7 +27,7 @@ Text::script('MESSAGE');
 Text::script('JGLOBAL_ASSOC_NOT_POSSIBLE');
 Text::script('JGLOBAL_ASSOCIATIONS_RESET_WARNING');
 
-/** @var \Joomla\CMS\Document\HtmlDocument $doc */
+/* @var HtmlDocument $doc */
 $doc = Factory::getApplication()->getDocument();
 $wa  = $doc->getWebAssetManager();
 $wa->getRegistry()->addExtensionRegistryFile('com_associations');

--- a/layouts/joomla/edit/frontediting_modules.php
+++ b/layouts/joomla/edit/frontediting_modules.php
@@ -70,7 +70,7 @@ if ($count)
 	// Load stylesheet and javascript to head:
 	HTMLHelper::_('bootstrap.popover');
 
-	/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+	/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 	$wa = Factory::getApplication()->getDocument()->getWebAssetManager();
 	$wa->usePreset('joomla.frontediting');
 }

--- a/layouts/joomla/edit/publishingdata.php
+++ b/layouts/joomla/edit/publishingdata.php
@@ -9,9 +9,6 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\Factory;
-
-$app  = Factory::getApplication();
 $form = $displayData->getForm();
 
 $fields = $displayData->get('fields') ?: array(

--- a/layouts/joomla/error/backtrace.php
+++ b/layouts/joomla/error/backtrace.php
@@ -11,7 +11,7 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 
-/** @var $displayData array */
+/* @var $displayData array */
 $backtraceList = $displayData['backtrace'];
 
 if (!$backtraceList)

--- a/layouts/joomla/form/field/color/advanced.php
+++ b/layouts/joomla/form/field/color/advanced.php
@@ -73,7 +73,7 @@ $autocomplete = !empty($autocomplete) ? 'autocomplete="' . $autocomplete . '"' :
 // Force LTR input value in RTL, due to display issues with rgba/hex colors
 $direction = $lang->isRtl() ? ' dir="ltr" style="text-align:right"' : '';
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = Factory::getApplication()->getDocument()->getWebAssetManager();
 $wa->usePreset('minicolors')
 	->useScript('field.color-adv');

--- a/layouts/joomla/form/field/color/simple.php
+++ b/layouts/joomla/form/field/color/simple.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 
-extract($displayData, null);
+extract($displayData);
 
 /**
  * Layout variables

--- a/layouts/joomla/form/field/color/slider.php
+++ b/layouts/joomla/form/field/color/slider.php
@@ -66,7 +66,7 @@ $validate     = $validate ? ' data-validate="' . $validate . '"' : '';
 $displayValues = explode(',', $display);
 $allSliders    = $display === 'full' || empty($display);
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = Factory::getApplication()->getDocument()->getWebAssetManager();
 $wa->useScript('field.color-slider');
 

--- a/layouts/joomla/form/field/contenthistory.php
+++ b/layouts/joomla/form/field/contenthistory.php
@@ -12,6 +12,8 @@ defined('_JEXEC') or die;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
+extract($displayData);
+
 /**
  * Layout variables
  * -----------------
@@ -46,7 +48,6 @@ use Joomla\CMS\Language\Text;
  * @var   string   $dataAttribute   Miscellaneous data attributes preprocessed for HTML output
  * @var   array    $dataAttributes  Miscellaneous data attributes for eg, data-*.
  */
-extract($displayData);
 
 echo HTMLHelper::_(
 	'bootstrap.renderModal',

--- a/layouts/joomla/form/field/media.php
+++ b/layouts/joomla/form/field/media.php
@@ -15,10 +15,11 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Uri\Uri;
 
+extract($displayData);
+
 /**
  * Layout variables
- * ---------------------
- *
+ * -----------------
  * @var  string   $asset           The asset text
  * @var  string   $authorField     The label text
  * @var  integer  $authorId        The author id
@@ -39,7 +40,6 @@ use Joomla\CMS\Uri\Uri;
  * @var  string   $dataAttribute   Miscellaneous data attributes preprocessed for HTML output
  * @var  array    $dataAttributes  Miscellaneous data attribute for eg, data-*
  */
-extract($displayData);
 
 $attr = '';
 

--- a/layouts/joomla/form/field/password.php
+++ b/layouts/joomla/form/field/password.php
@@ -49,7 +49,7 @@ extract($displayData);
  * @var   array    $dataAttributes  Miscellaneous data attribute for eg, data-*.
  */
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = Factory::getApplication()->getDocument()->getWebAssetManager();
 
 if ($meter)

--- a/layouts/joomla/form/field/radio/switcher.php
+++ b/layouts/joomla/form/field/radio/switcher.php
@@ -11,7 +11,7 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 
-extract($displayData, null);
+extract($displayData);
 
 /**
  * Layout variables

--- a/layouts/joomla/form/field/rules.php
+++ b/layouts/joomla/form/field/rules.php
@@ -17,7 +17,6 @@ use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
 
-
 extract($displayData);
 
 // Get some system objects.

--- a/layouts/joomla/form/field/subform/default.php
+++ b/layouts/joomla/form/field/subform/default.php
@@ -9,23 +9,24 @@
 
 defined('_JEXEC') or die;
 
-/**
- * Make thing clear
- *
- * @var JForm   $tmpl             The Empty form for template
- * @var array   $forms            Array of JForm instances for render the rows
- * @var bool    $multiple         The multiple state for the form field
- * @var int     $min              Count of minimum repeating in multiple mode
- * @var int     $max              Count of maximum repeating in multiple mode
- * @var string  $name             Name of the input field.
- * @var string  $fieldname        The field name
- * @var string  $control          The forms control
- * @var string  $label            The field label
- * @var string  $description      The field description
- * @var array   $buttons          Array of the buttons that will be rendered
- * @var bool    $groupByFieldset  Whether group the subform fields by it`s fieldset
- */
 extract($displayData);
+
+/**
+ * Layout variables
+ * -----------------
+ * @var   JForm   $tmpl             The Empty form for template
+ * @var   array   $forms            Array of JForm instances for render the rows
+ * @var   bool    $multiple         The multiple state for the form field
+ * @var   int     $min              Count of minimum repeating in multiple mode
+ * @var   int     $max              Count of maximum repeating in multiple mode
+ * @var   string  $name             Name of the input field.
+ * @var   string  $fieldname        The field name
+ * @var   string  $control          The forms control
+ * @var   string  $label            The field label
+ * @var   string  $description      The field description
+ * @var   array   $buttons          Array of the buttons that will be rendered
+ * @var   bool    $groupByFieldset  Whether group the subform fields by it`s fieldset
+ */
 
 $form = $forms[0];
 ?>

--- a/layouts/joomla/form/field/subform/repeatable-table.php
+++ b/layouts/joomla/form/field/subform/repeatable-table.php
@@ -12,23 +12,24 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 
-/**
- * Make thing clear
- *
- * @var JForm   $tmpl             The Empty form for template
- * @var array   $forms            Array of JForm instances for render the rows
- * @var bool    $multiple         The multiple state for the form field
- * @var int     $min              Count of minimum repeating in multiple mode
- * @var int     $max              Count of maximum repeating in multiple mode
- * @var string  $name             Name of the input field.
- * @var string  $fieldname        The field name
- * @var string  $control          The forms control
- * @var string  $label            The field label
- * @var string  $description      The field description
- * @var array   $buttons          Array of the buttons that will be rendered
- * @var bool    $groupByFieldset  Whether group the subform fields by it`s fieldset
- */
 extract($displayData);
+
+/**
+ * Layout variables
+ * -----------------
+ * @var   JForm   $tmpl             The Empty form for template
+ * @var   array   $forms            Array of JForm instances for render the rows
+ * @var   bool    $multiple         The multiple state for the form field
+ * @var   int     $min              Count of minimum repeating in multiple mode
+ * @var   int     $max              Count of maximum repeating in multiple mode
+ * @var   string  $name             Name of the input field.
+ * @var   string  $fieldname        The field name
+ * @var   string  $control          The forms control
+ * @var   string  $label            The field label
+ * @var   string  $description      The field description
+ * @var   array   $buttons          Array of the buttons that will be rendered
+ * @var   bool    $groupByFieldset  Whether group the subform fields by it`s fieldset
+ */
 
 // Add script
 if ($multiple)

--- a/layouts/joomla/form/field/subform/repeatable-table/section-byfieldsets.php
+++ b/layouts/joomla/form/field/subform/repeatable-table/section-byfieldsets.php
@@ -11,16 +11,16 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 
-/**
- * Make thing clear
- *
- * @var JForm   $form       The form instance for render the section
- * @var string  $basegroup  The base group name
- * @var string  $group      Current group name
- * @var array   $buttons    Array of the buttons that will be rendered
- */
 extract($displayData);
 
+/**
+ * Layout variables
+ * -----------------
+ * @var   JForm   $form       The form instance for render the section
+ * @var   string  $basegroup  The base group name
+ * @var   string  $group      Current group name
+ * @var   array   $buttons    Array of the buttons that will be rendered
+ */
 ?>
 
 <tr class="subform-repeatable-group" data-base-name="<?php echo $basegroup; ?>" data-group="<?php echo $group; ?>">

--- a/layouts/joomla/form/field/subform/repeatable-table/section.php
+++ b/layouts/joomla/form/field/subform/repeatable-table/section.php
@@ -11,16 +11,16 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 
-/**
- * Make thing clear
- *
- * @var JForm   $form       The form instance for render the section
- * @var string  $basegroup  The base group name
- * @var string  $group      Current group name
- * @var array   $buttons    Array of the buttons that will be rendered
- */
 extract($displayData);
 
+/**
+ * Layout variables
+ * -----------------
+ * @var   JForm   $form       The form instance for render the section
+ * @var   string  $basegroup  The base group name
+ * @var   string  $group      Current group name
+ * @var   array   $buttons    Array of the buttons that will be rendered
+ */
 ?>
 
 <tr class="subform-repeatable-group" data-base-name="<?php echo $basegroup; ?>" data-group="<?php echo $group; ?>">

--- a/layouts/joomla/form/field/subform/repeatable.php
+++ b/layouts/joomla/form/field/subform/repeatable.php
@@ -12,23 +12,24 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 
-/**
- * Make thing clear
- *
- * @var JForm   $tmpl             The Empty form for template
- * @var array   $forms            Array of JForm instances for render the rows
- * @var bool    $multiple         The multiple state for the form field
- * @var int     $min              Count of minimum repeating in multiple mode
- * @var int     $max              Count of maximum repeating in multiple mode
- * @var string  $name             Name of the input field.
- * @var string  $fieldname        The field name
- * @var string  $control          The forms control
- * @var string  $label            The field label
- * @var string  $description      The field description
- * @var array   $buttons          Array of the buttons that will be rendered
- * @var bool    $groupByFieldset  Whether group the subform fields by it`s fieldset
- */
 extract($displayData);
+
+/**
+ * Layout variables
+ * -----------------
+ * @var   JForm   $tmpl             The Empty form for template
+ * @var   array   $forms            Array of JForm instances for render the rows
+ * @var   bool    $multiple         The multiple state for the form field
+ * @var   int     $min              Count of minimum repeating in multiple mode
+ * @var   int     $max              Count of maximum repeating in multiple mode
+ * @var   string  $name             Name of the input field.
+ * @var   string  $fieldname        The field name
+ * @var   string  $control          The forms control
+ * @var   string  $label            The field label
+ * @var   string  $description      The field description
+ * @var   array   $buttons          Array of the buttons that will be rendered
+ * @var   bool    $groupByFieldset  Whether group the subform fields by it`s fieldset
+ */
 
 // Add script
 if ($multiple)

--- a/layouts/joomla/form/field/subform/repeatable/section-byfieldsets.php
+++ b/layouts/joomla/form/field/subform/repeatable/section-byfieldsets.php
@@ -11,15 +11,16 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 
-/**
- * Make thing clear
- *
- * @var JForm   $form       The form instance for render the section
- * @var string  $basegroup  The base group name
- * @var string  $group      Current group name
- * @var array   $buttons    Array of the buttons that will be rendered
- */
 extract($displayData);
+
+/**
+ * Layout variables
+ * -----------------
+ * @var   JForm   $form       The form instance for render the section
+ * @var   string  $basegroup  The base group name
+ * @var   string  $group      Current group name
+ * @var   array   $buttons    Array of the buttons that will be rendered
+ */
 ?>
 
 <div class="subform-repeatable-group" data-base-name="<?php echo $basegroup; ?>" data-group="<?php echo $group; ?>">

--- a/layouts/joomla/form/field/subform/repeatable/section.php
+++ b/layouts/joomla/form/field/subform/repeatable/section.php
@@ -11,16 +11,16 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 
-/**
- * Make thing clear
- *
- * @var JForm   $form       The form instance for render the section
- * @var string  $basegroup  The base group name
- * @var string  $group      Current group name
- * @var array   $buttons    Array of the buttons that will be rendered
- */
 extract($displayData);
 
+/**
+ * Layout variables
+ * -----------------
+ * @var   JForm   $form       The form instance for render the section
+ * @var   string  $basegroup  The base group name
+ * @var   string  $group      Current group name
+ * @var   array   $buttons    Array of the buttons that will be rendered
+ */
 ?>
 
 <div class="subform-repeatable-group" data-base-name="<?php echo $basegroup; ?>" data-group="<?php echo $group; ?>">

--- a/layouts/joomla/form/field/textarea.php
+++ b/layouts/joomla/form/field/textarea.php
@@ -17,7 +17,6 @@ extract($displayData);
 /**
  * Layout variables
  * -----------------
- *
  * @var   string   $autocomplete    Autocomplete attribute for the field.
  * @var   boolean  $autofocus       Is autofocus enabled?
  * @var   string   $class           Classes for the input.
@@ -55,7 +54,7 @@ extract($displayData);
 if ($charcounter)
 {
 	// Load the js file
-	/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+	/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 	$wa = Factory::getApplication()->getDocument()->getWebAssetManager();
 	$wa->useScript('short-and-sweet');
 

--- a/layouts/joomla/form/field/time.php
+++ b/layouts/joomla/form/field/time.php
@@ -17,7 +17,6 @@ extract($displayData);
 /**
  * Layout variables
  * -----------------
- *
  * @var   boolean $autofocus      Is autofocus enabled?
  * @var   string  $class          Classes for the input.
  * @var   string  $description    Description of the field.

--- a/layouts/joomla/form/field/user.php
+++ b/layouts/joomla/form/field/user.php
@@ -43,7 +43,6 @@ extract($displayData);
  * @var   boolean  $spellcheck      Spellcheck state for the form field.
  * @var   string   $validate        Validation rules to apply.
  * @var   string   $value           Value attribute of the field.
- *
  * @var   string   $userName        The user name
  * @var   mixed    $groups          The filtering groups (null means no filtering)
  * @var   mixed    $excluded        The users to exclude from the list of users

--- a/layouts/joomla/form/renderfield.php
+++ b/layouts/joomla/form/renderfield.php
@@ -15,17 +15,17 @@ extract($displayData);
 
 /**
  * Layout variables
- * ---------------------
- * 	$options      : (array)  Optional parameters
- * 	$name         : (string) The id of the input this label is for
- * 	$label        : (string) The html code for the label
- * 	$input        : (string) The input field html code
- * 	$description  : (string) An optional description to use in a tooltip
+ * -----------------
+ * @var   array   $options      Optional parameters
+ * @var   string  $name         The id of the input this label is for
+ * @var   string  $label        The html code for the label
+ * @var   string  $input        The input field html code
+ * @var   string  $description  An optional description to use in a tooltip
  */
 
 if (!empty($options['showonEnabled']))
 {
-	/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+	/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 	$wa = Factory::getApplication()->getDocument()->getWebAssetManager();
 	$wa->useScript('showon');
 }

--- a/layouts/joomla/form/renderlabel.php
+++ b/layouts/joomla/form/renderlabel.php
@@ -13,11 +13,11 @@ extract($displayData);
 
 /**
  * Layout variables
- * ---------------------
- * 	$text         : (string)  The label text
- * 	$for          : (string)  The id of the input this label is for
- * 	$required     : (boolean) True if a required field
- * 	$classes      : (array)   A list of classes
+ * -----------------
+ * @var   string   $text      The label text
+ * @var   string   $for       The id of the input this label is for
+ * @var   boolean  $required  True if a required field
+ * @var   array    $classes   A list of classes
  */
 
 $classes = array_filter((array) $classes);

--- a/layouts/joomla/html/batch/access.php
+++ b/layouts/joomla/html/batch/access.php
@@ -12,13 +12,6 @@ defined('_JEXEC') or die;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
-/**
- * Layout variables
- * ---------------------
- *
- * none
- */
-
 ?>
 <label id="batch-access-lbl" for="batch-access">
 	<?php echo Text::_('JLIB_HTML_BATCH_ACCESS_LABEL'); ?>
@@ -31,4 +24,4 @@ use Joomla\CMS\Language\Text;
 			'title' => Text::_('JLIB_HTML_BATCH_NOCHANGE'),
 			'id'    => 'batch-access'
 		)
-	); ?>
+	);

--- a/layouts/joomla/html/batch/adminlanguage.php
+++ b/layouts/joomla/html/batch/adminlanguage.php
@@ -13,13 +13,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
-/**
- * Layout variables
- * ---------------------
- * None
- */
-
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = Factory::getApplication()->getDocument()->getWebAssetManager();
 $wa->useScript('joomla.batch-language');
 

--- a/layouts/joomla/html/batch/item.php
+++ b/layouts/joomla/html/batch/item.php
@@ -13,14 +13,13 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
+extract($displayData);
+
 /**
  * Layout variables
- * ---------------------
- *
- * @var  string   $extension The extension name
+ * -----------------
+ * @var   string  $extension  The extension name
  */
-
-extract($displayData);
 
 // Create the copy/move options.
 $options = array(
@@ -28,7 +27,7 @@ $options = array(
 	HTMLHelper::_('select.option', 'm', Text::_('JLIB_HTML_BATCH_MOVE'))
 );
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = Factory::getApplication()->getDocument()->getWebAssetManager();
 $wa->useScript('joomla.batch-language');
 

--- a/layouts/joomla/html/batch/language.php
+++ b/layouts/joomla/html/batch/language.php
@@ -13,13 +13,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
-/**
- * Layout variables
- * ---------------------
- * None
- */
-
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = Factory::getApplication()->getDocument()->getWebAssetManager();
 $wa->useScript('joomla.batch-language');
 

--- a/layouts/joomla/html/batch/tag.php
+++ b/layouts/joomla/html/batch/tag.php
@@ -12,12 +12,6 @@ defined('_JEXEC') or die;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
-/**
- * Layout variables
- * ---------------------
- * None
- */
-
 ?>
 <label id="batch-tag-lbl" for="batch-tag-id">
 	<?php echo Text::_('JLIB_HTML_BATCH_TAG_LABEL'); ?>

--- a/layouts/joomla/html/batch/user.php
+++ b/layouts/joomla/html/batch/user.php
@@ -12,14 +12,13 @@ defined('_JEXEC') or die;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
+extract($displayData);
+
 /**
  * Layout variables
- * ---------------------
- *
- * @var  boolean   $noUser Inject an option for no user?
+ * -----------------
+ * @var   boolean  $noUser  Inject an option for no user?
  */
-
-extract($displayData);
 
 $optionNo = '';
 

--- a/layouts/joomla/html/batch/workflowstage.php
+++ b/layouts/joomla/html/batch/workflowstage.php
@@ -12,12 +12,6 @@ defined('_JEXEC') or die;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
-/**
- * Layout variables
- * ---------------------
- * None
- */
-
 ?>
 <label id="batch-workflowstage-lbl" for="batch-workflowstage-id">
 	<?php echo Text::_('JLIB_HTML_BATCH_WORKFLOW_STAGE_LABEL'); ?>

--- a/layouts/joomla/html/treeprefix.php
+++ b/layouts/joomla/html/treeprefix.php
@@ -9,16 +9,15 @@
 
 defined('_JEXEC') or die;
 
+extract($displayData);
+
 /**
  * Layout variables
- * ---------------------
- *
- * @var  integer  $level  The level of the item in the tree like structure.
+ * -----------------
+ * @var   integer  $level  The level of the item in the tree like structure.
  *
  * @since  3.6.0
  */
-
-extract($displayData);
 
 if ($level > 1)
 {

--- a/layouts/joomla/modal/body.php
+++ b/layouts/joomla/modal/body.php
@@ -13,9 +13,9 @@ extract($displayData);
 
 /**
  * Layout variables
- * ------------------
- * @param   string  $selector  Unique DOM identifier for the modal. CSS id without #
- * @param   array   $params    Modal parameters. Default supported parameters:
+ * -----------------
+ * @var   string  $selector  Unique DOM identifier for the modal. CSS id without #
+ * @var   array   $params    Modal parameters. Default supported parameters:
  *                             - title        string   The modal title
  *                             - backdrop     mixed    A boolean select if a modal-backdrop element should be included (default = true)
  *                                                     The string 'static' includes a backdrop which doesn't close the modal on click.
@@ -28,8 +28,7 @@ extract($displayData);
  *                             - width        string   width of the <iframe> containing the remote resource
  *                             - bodyHeight   int      Optional height of the modal body in viewport units (vh)
  *                             - modalWidth   int      Optional width of the modal in viewport units (vh)
- * @param   string  $body      Markup for the modal body. Appended after the <iframe> if the URL option is set
- *
+ * @var   string  $body      Markup for the modal body. Appended after the <iframe> if the URL option is set
  */
 
 $bodyClass = 'modal-body';

--- a/layouts/joomla/modal/footer.php
+++ b/layouts/joomla/modal/footer.php
@@ -13,9 +13,9 @@ extract($displayData);
 
 /**
  * Layout variables
- * ------------------
- * @param   string  $selector  Unique DOM identifier for the modal. CSS id without #
- * @param   array   $params    Modal parameters. Default supported parameters:
+ * -----------------
+ * @var   string  $selector  Unique DOM identifier for the modal. CSS id without #
+ * @var   array   $params    Modal parameters. Default supported parameters:
  *                             - title        string   The modal title
  *                             - backdrop     mixed    A boolean select if a modal-backdrop element should be included (default = true)
  *                                                     The string 'static' includes a backdrop which doesn't close the modal on click.
@@ -28,8 +28,7 @@ extract($displayData);
  *                             - width        string   width of the <iframe> containing the remote resource
  *                             - bodyHeight   int      Optional height of the modal body in viewport units (vh)
  *                             - modalWidth   int      Optional width of the modal in viewport units (vh)
- * @param   string  $body      Markup for the modal body. Appended after the <iframe> if the URL option is set
- *
+ * @var   string  $body      Markup for the modal body. Appended after the <iframe> if the URL option is set
  */
 ?>
 <div class="modal-footer">

--- a/layouts/joomla/modal/header.php
+++ b/layouts/joomla/modal/header.php
@@ -15,9 +15,9 @@ extract($displayData);
 
 /**
  * Layout variables
- * ------------------
- * @param   string  $selector  Unique DOM identifier for the modal. CSS id without #
- * @param   array   $params    Modal parameters. Default supported parameters:
+ * -----------------
+ * @var   string  $selector  Unique DOM identifier for the modal. CSS id without #
+ * @var   array   $params    Modal parameters. Default supported parameters:
  *                             - title        string   The modal title
  *                             - backdrop     mixed    A boolean select if a modal-backdrop element should be included (default = true)
  *                                                     The string 'static' includes a backdrop which doesn't close the modal on click.
@@ -30,8 +30,7 @@ extract($displayData);
  *                             - width        string   width of the <iframe> containing the remote resource
  *                             - bodyHeight   int      Optional height of the modal body in viewport units (vh)
  *                             - modalWidth   int      Optional width of the modal in viewport units (vh)
- * @param   string  $body      Markup for the modal body. Appended after the <iframe> if the URL option is set
- *
+ * @var   string  $body      Markup for the modal body. Appended after the <iframe> if the URL option is set
  */
 ?>
 <div class="modal-header">

--- a/layouts/joomla/modal/iframe.php
+++ b/layouts/joomla/modal/iframe.php
@@ -15,9 +15,9 @@ extract($displayData);
 
 /**
  * Layout variables
- * ------------------
- * @param   string  $selector  Unique DOM identifier for the modal. CSS id without #
- * @param   array   $params    Modal parameters. Default supported parameters:
+ * -----------------
+ * @var   string  $selector  Unique DOM identifier for the modal. CSS id without #
+ * @var   array   $params    Modal parameters. Default supported parameters:
  *                             - title        string   The modal title
  *                             - backdrop     mixed    A boolean select if a modal-backdrop element should be included (default = true)
  *                                                     The string 'static' includes a backdrop which doesn't close the modal on click.
@@ -28,8 +28,7 @@ extract($displayData);
  *                             - url          string   URL of a resource to be inserted as an <iframe> inside the modal body
  *                             - height       string   height of the <iframe> containing the remote resource
  *                             - width        string   width of the <iframe> containing the remote resource
- * @param   string  $body      Markup for the modal body. Appended after the <iframe> if the URL option is set
- *
+ * @var   string  $body      Markup for the modal body. Appended after the <iframe> if the URL option is set
  */
 
 $iframeAttributes = array(

--- a/layouts/joomla/modal/main.php
+++ b/layouts/joomla/modal/main.php
@@ -16,9 +16,9 @@ extract($displayData);
 
 /**
  * Layout variables
- * ------------------
- * @param   string  $selector  Unique DOM identifier for the modal. CSS id without #
- * @param   array   $params    Modal parameters. Default supported parameters:
+ * -----------------
+ * @var   string  $selector  Unique DOM identifier for the modal. CSS id without #
+ * @var   array   $params    Modal parameters. Default supported parameters:
  *                             - title        string   The modal title
  *                             - backdrop     mixed    A boolean select if a modal-backdrop element should be included (default = true)
  *                                                     The string 'static' includes a backdrop which doesn't close the modal on click.
@@ -31,8 +31,7 @@ extract($displayData);
  *                             - bodyHeight   int      Optional height of the modal body in viewport units (vh)
  *                             - modalWidth   int      Optional width of the modal in viewport units (vh)
  *                             - footer       string   Optional markup for the modal footer
- * @param   string  $body      Markup for the modal body. Appended after the <iframe> if the URL option is set
- *
+ * @var   string  $body      Markup for the modal body. Appended after the <iframe> if the URL option is set
  */
 
 $modalClasses = array('modal');

--- a/layouts/joomla/searchtools/default/filters.php
+++ b/layouts/joomla/searchtools/default/filters.php
@@ -17,7 +17,7 @@ $data = $displayData;
 // Load the form filters
 $filters = $data['view']->filterForm->getGroup('filter');
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = Factory::getApplication()->getDocument()->getWebAssetManager();
 
 ?>

--- a/layouts/joomla/toolbar/base.php
+++ b/layouts/joomla/toolbar/base.php
@@ -9,11 +9,13 @@
 
 defined('_JEXEC') or die;
 
+extract($displayData, EXTR_OVERWRITE);
+
 /**
+ * Layout variables
+ * -----------------
  * @var  string  $action
  * @var  array   $options
  */
-extract($displayData, EXTR_OVERWRITE);
-?>
 
-<?php echo $action; ?>
+echo $action;

--- a/layouts/joomla/toolbar/basic.php
+++ b/layouts/joomla/toolbar/basic.php
@@ -16,20 +16,23 @@ Factory::getDocument()->getWebAssetManager()
 	->useScript('core')
 	->useScript('webcomponent.toolbar-button');
 
-/**
- * @var  int     $id
- * @var  string  $onclick
- * @var  string  $class
- * @var  string  $text
- * @var  string  $btnClass
- * @var  string  $tagName
- * @var  string  $htmlAttributes
- * @var  string  $task             The task which should be executed
- * @var  bool    $listCheck        Boolean, whether selection from a list is needed
- * @var  string  $form             CSS selector for a target form
- * @var  bool    $formValidation   Whether the form need to be validated before run the task
- */
 extract($displayData, EXTR_OVERWRITE);
+
+/**
+ * Layout variables
+ * -----------------
+ * @var   int     $id
+ * @var   string  $onclick
+ * @var   string  $class
+ * @var   string  $text
+ * @var   string  $btnClass
+ * @var   string  $tagName
+ * @var   string  $htmlAttributes
+ * @var   string  $task             The task which should be executed
+ * @var   bool    $listCheck        Boolean, whether selection from a list is needed
+ * @var   string  $form             CSS selector for a target form
+ * @var   bool    $formValidation   Whether the form need to be validated before run the task
+ */
 
 $tagName = $tagName ?? 'button';
 

--- a/layouts/joomla/toolbar/containeropen.php
+++ b/layouts/joomla/toolbar/containeropen.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = Factory::getApplication()->getDocument()->getWebAssetManager();
 $wa->registerAndUseScript('joomla.toolbar', 'legacy/toolbar.min.js', [], ['defer' => true], ['core']);
 

--- a/layouts/joomla/toolbar/dropdown.php
+++ b/layouts/joomla/toolbar/dropdown.php
@@ -13,23 +13,27 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
-$direction = Factory::getLanguage()->isRtl() ? 'dropdown-menu-right' : '';
+extract($displayData, EXTR_OVERWRITE);
 
 /**
- * @var  string  $id
- * @var  string  $onclick
- * @var  string  $class
- * @var  string  $text
- * @var  string  $btnClass
- * @var  string  $tagName
- * @var  string  $htmlAttributes
- * @var  string  $hasButtons
- * @var  string  $button
- * @var  string  $dropdownItems
- * @var  string  $caretClass
- * @var  string  $toggleSplit
+ * Layout variables
+ * -----------------
+ * @var   string  $id
+ * @var   string  $onclick
+ * @var   string  $class
+ * @var   string  $text
+ * @var   string  $btnClass
+ * @var   string  $tagName
+ * @var   string  $htmlAttributes
+ * @var   string  $hasButtons
+ * @var   string  $button
+ * @var   string  $dropdownItems
+ * @var   string  $caretClass
+ * @var   string  $toggleSplit
  */
-extract($displayData, EXTR_OVERWRITE);
+
+$direction = Factory::getLanguage()->isRtl() ? 'dropdown-menu-right' : '';
+
 ?>
 <?php if ($hasButtons && trim($button) !== ''): ?>
 	<?php HTMLHelper::_('bootstrap.framework'); ?>

--- a/layouts/joomla/toolbar/link.php
+++ b/layouts/joomla/toolbar/link.php
@@ -10,13 +10,15 @@
 defined('_JEXEC') or die;
 
 /**
- * @var  int     $id
- * @var  string  $name
- * @var  string  $class
- * @var  string  $text
- * @var  string  $btnClass
- * @var  string  $tagName
- * @var  string  $htmlAttributes
+ * Layout variables
+ * -----------------
+ * @var   int     $id
+ * @var   string  $name
+ * @var   string  $class
+ * @var   string  $text
+ * @var   string  $btnClass
+ * @var   string  $tagName
+ * @var   string  $htmlAttributes
  */
 extract($displayData, EXTR_OVERWRITE);
 

--- a/layouts/joomla/toolbar/popup.php
+++ b/layouts/joomla/toolbar/popup.php
@@ -12,22 +12,25 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\Utilities\ArrayHelper;
 
-Factory::getDocument()->getWebAssetManager()
-	->useScript('core')
-	->useScript('webcomponent.toolbar-button');
+extract($displayData, EXTR_OVERWRITE);
 
 /**
- * @var  int     $id
- * @var  string  $name
- * @var  string  $doTask
- * @var  string  $class
- * @var  string  $text
- * @var  string  $btnClass
- * @var  string  $tagName
- * @var  bool    $listCheck
- * @var  string  $htmlAttributes
+ * Layout variables
+ * -----------------
+ * @var   int     $id
+ * @var   string  $name
+ * @var   string  $doTask
+ * @var   string  $class
+ * @var   string  $text
+ * @var   string  $btnClass
+ * @var   string  $tagName
+ * @var   bool    $listCheck
+ * @var   string  $htmlAttributes
  */
-extract($displayData, EXTR_OVERWRITE);
+
+Factory::getDocument()->getWebAssetManager()
+		->useScript('core')
+		->useScript('webcomponent.toolbar-button');
 
 $tagName = $tagName ?? 'button';
 

--- a/layouts/joomla/toolbar/separator.php
+++ b/layouts/joomla/toolbar/separator.php
@@ -9,17 +9,20 @@
 
 defined('_JEXEC') or die;
 
-/**
- * @var  bool    $is_child
- * @var  string  $id
- * @var  string  $doTask
- * @var  string  $class
- * @var  string  $text
- * @var  string  $btnClass
- * @var  string  $tagName
- * @var  string  $htmlAttributes
- */
 extract($displayData, EXTR_OVERWRITE);
+
+/**
+ * Layout variables
+ * -----------------
+ * @var   bool    $is_child
+ * @var   string  $id
+ * @var   string  $doTask
+ * @var   string  $class
+ * @var   string  $text
+ * @var   string  $btnClass
+ * @var   string  $tagName
+ * @var   string  $htmlAttributes
+ */
 ?>
 
 <?php if ($is_child): ?>

--- a/layouts/joomla/toolbar/standard.php
+++ b/layouts/joomla/toolbar/standard.php
@@ -11,26 +11,28 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 
-Factory::getDocument()->getWebAssetManager()
-	->useScript('core')
-	->useScript('webcomponent.toolbar-button');
+extract($displayData, EXTR_OVERWRITE);
 
 /**
- * @var  string  $id
- * @var  string  $onclick
- * @var  string  $class
- * @var  string  $text
- * @var  string  $btnClass
- * @var  string  $tagName
- * @var  string  $htmlAttributes
- * @var  string  $task             The task which should be executed
- * @var  bool    $listCheck        Boolean, whether selection from a list is needed
- * @var  string  $form             CSS selector for a target form
- * @var  bool    $formValidation   Whether the form need to be validated before run the task
- * @var  string  $message          Confirmation message before run the task
- *
+ * Layout variables
+ * -----------------
+ * @var   string  $id
+ * @var   string  $onclick
+ * @var   string  $class
+ * @var   string  $text
+ * @var   string  $btnClass
+ * @var   string  $tagName
+ * @var   string  $htmlAttributes
+ * @var   string  $task             The task which should be executed
+ * @var   bool    $listCheck        Boolean, whether selection from a list is needed
+ * @var   string  $form             CSS selector for a target form
+ * @var   bool    $formValidation   Whether the form need to be validated before run the task
+ * @var   string  $message          Confirmation message before run the task
  */
-extract($displayData, EXTR_OVERWRITE);
+
+Factory::getDocument()->getWebAssetManager()
+		->useScript('core')
+		->useScript('webcomponent.toolbar-button');
 
 $tagName  = $tagName ?? 'button';
 

--- a/layouts/joomla/toolbar/versions.php
+++ b/layouts/joomla/toolbar/versions.php
@@ -14,18 +14,21 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Session\Session;
 
-Factory::getDocument()->getWebAssetManager()
-	->useScript('core')
-	->useScript('webcomponent.toolbar-button');
+extract($displayData, EXTR_OVERWRITE);
 
 /**
- * @var  string  $id
- * @var  string  $itemId
- * @var  string  $typeId
- * @var  string  $typeAlias
- * @var  string  $title
+ * Layout variables
+ * -----------------
+ * @var   string  $id
+ * @var   string  $itemId
+ * @var   string  $typeId
+ * @var   string  $typeAlias
+ * @var   string  $title
  */
-extract($displayData, EXTR_OVERWRITE);
+
+Factory::getDocument()->getWebAssetManager()
+		->useScript('core')
+		->useScript('webcomponent.toolbar-button');
 
 echo HTMLHelper::_(
 	'bootstrap.renderModal',

--- a/layouts/plugins/editors/tinymce/field/tinymcebuilder.php
+++ b/layouts/plugins/editors/tinymce/field/tinymcebuilder.php
@@ -9,6 +9,7 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Document\HtmlDocument;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 
@@ -17,44 +18,42 @@ extract($displayData);
 /**
  * Layout variables
  * -----------------
- * @var   string  $autocomplete   Autocomplete attribute for the field.
- * @var   boolean $autofocus      Is autofocus enabled?
- * @var   string  $class          Classes for the input.
- * @var   string  $description    Description of the field.
- * @var   boolean $disabled       Is this field disabled?
- * @var   string  $group          Group the field belongs to. <fields> section in form XML.
- * @var   boolean $hidden         Is this field hidden in the form?
- * @var   string  $hint           Placeholder for the field.
- * @var   string  $id             DOM id of the field.
- * @var   string  $label          Label of the field.
- * @var   string  $labelclass     Classes to apply to the label.
- * @var   boolean $multiple       Does this field support multiple values?
- * @var   string  $name           Name of the input field.
- * @var   string  $onchange       Onchange attribute for the field.
- * @var   string  $onclick        Onclick attribute for the field.
- * @var   string  $pattern        Pattern (Reg Ex) of value of the form field.
- * @var   boolean $readonly       Is this field read only?
- * @var   boolean $repeat         Allows extensions to duplicate elements.
- * @var   boolean $required       Is this field required?
- * @var   integer $size           Size attribute of the input.
- * @var   boolean $spellcheck     Spellcheck state for the form field.
- * @var   string  $validate       Validation rules to apply.
- * @var   array   $value          Value of the field.
-  *
- * @var   array   $menus           List of the menu items
- * @var   array   $menubarSource   Menu items for builder
- * @var   array   $buttons         List of the buttons
- * @var   array   $buttonsSource   Buttons by group, for the builder
- * @var   array   $toolbarPreset   Toolbar preset (default values)
- * @var   int     $setsAmount      Amount of sets
- * @var   array   $setsNames       List of Sets names
- * @var   JForm[] $setsForms       Form with extra options for an each set
- * @var   string   $languageFile   TinyMCE language file to translate the buttons
- *
- * @var   JLayoutFile  $this       Context
+ * @var   string       $autocomplete   Autocomplete attribute for the field.
+ * @var   boolean      $autofocus      Is autofocus enabled?
+ * @var   string       $class          Classes for the input.
+ * @var   string       $description    Description of the field.
+ * @var   boolean      $disabled       Is this field disabled?
+ * @var   string       $group          Group the field belongs to. <fields> section in form XML.
+ * @var   boolean      $hidden         Is this field hidden in the form?
+ * @var   string       $hint           Placeholder for the field.
+ * @var   string       $id             DOM id of the field.
+ * @var   string       $label          Label of the field.
+ * @var   string       $labelclass     Classes to apply to the label.
+ * @var   boolean      $multiple       Does this field support multiple values?
+ * @var   string       $name           Name of the input field.
+ * @var   string       $onchange       Onchange attribute for the field.
+ * @var   string       $onclick        Onclick attribute for the field.
+ * @var   string       $pattern        Pattern (Reg Ex) of value of the form field.
+ * @var   boolean      $readonly       Is this field read only?
+ * @var   boolean      $repeat         Allows extensions to duplicate elements.
+ * @var   boolean      $required       Is this field required?
+ * @var   integer      $size           Size attribute of the input.
+ * @var   boolean      $spellcheck     Spellcheck state for the form field.
+ * @var   string       $validate       Validation rules to apply.
+ * @var   array        $value          Value of the field.
+ * @var   array        $menus          List of the menu items
+ * @var   array        $menubarSource  Menu items for builder
+ * @var   array        $buttons        List of the buttons
+ * @var   array        $buttonsSource  Buttons by group, for the builder
+ * @var   array        $toolbarPreset  Toolbar preset (default values)
+ * @var   int          $setsAmount     Amount of sets
+ * @var   array        $setsNames      List of Sets names
+ * @var   JForm[]      $setsForms      Form with extra options for an each set
+ * @var   string       $languageFile   TinyMCE language file to translate the buttons
+ * @var   JLayoutFile  $this           Context
  */
 
-/** @var Joomla\CMS\Document\HtmlDocument $doc */
+/* @var HtmlDocument $doc */
 $doc = Factory::getApplication()->getDocument();
 $wa  = $doc->getWebAssetManager();
 

--- a/layouts/plugins/editors/tinymce/field/tinymcebuilder/setoptions.php
+++ b/layouts/plugins/editors/tinymce/field/tinymcebuilder/setoptions.php
@@ -14,8 +14,8 @@ extract($displayData);
 /**
  * Layout variables
  * -----------------
- * @var   JForm        $form    Form with extra options for the set
- * @var   JLayoutFile  $this    Context
+ * @var   JForm        $form  Form with extra options for the set
+ * @var   JLayoutFile  $this  Context
  */
 
 ?>

--- a/layouts/plugins/system/privacyconsent/label.php
+++ b/layouts/plugins/system/privacyconsent/label.php
@@ -48,7 +48,7 @@ extract($displayData);
  * @var   array    $translateDescription   Should the description be translated?
  * @var   array    $translateHint          Should the hint be translated?
  * @var   array    $privacyArticle         The Article ID holding the Privacy Article
- * $var   object   $article                The Article object
+ * @var   object   $article                The Article object
  */
 
 // Get the label text from the XML element, defaulting to the element name.

--- a/layouts/plugins/user/terms/label.php
+++ b/layouts/plugins/user/terms/label.php
@@ -48,7 +48,7 @@ extract($displayData);
  * @var   array    $translateDescription   Should the description be translated?
  * @var   array    $translateHint          Should the hint be translated?
  * @var   array    $termsArticle           The Article ID holding the Terms Article
- * $var   object   $article                The Article object
+ * @var   object   $article                The Article object
  */
 
 // Get the label text from the XML element, defaulting to the element name.

--- a/libraries/src/Application/ApiApplication.php
+++ b/libraries/src/Application/ApiApplication.php
@@ -247,7 +247,7 @@ final class ApiApplication extends CMSApplication
 			throw new Exception\NotAcceptable('Could not match accept header', 406);
 		}
 
-		/** @var $mediaType Accept */
+		/* @var $mediaType Accept */
 		$format = $mediaType->getValue();
 
 		if (\array_key_exists($mediaType->getValue(), $this->formatMapper))

--- a/libraries/src/Categories/Categories.php
+++ b/libraries/src/Categories/Categories.php
@@ -219,7 +219,7 @@ class Categories implements CategoryInterface
 	 */
 	protected function _load($id)
 	{
-		/** @var \Joomla\Database\DatabaseDriver */
+		/* @var \Joomla\Database\DatabaseDriver */
 		$db   = Factory::getDbo();
 		$app  = Factory::getApplication();
 		$user = Factory::getUser();

--- a/libraries/src/Document/JsonDocument.php
+++ b/libraries/src/Document/JsonDocument.php
@@ -68,7 +68,7 @@ class JsonDocument extends Document
 	 */
 	public function render($cache = false, $params = array())
 	{
-		/** @var \Joomla\CMS\Application\CMSApplication $app */
+		/* @var \Joomla\CMS\Application\CMSApplication $app */
 		$app = CmsFactory::getApplication();
 
 		$app->allowCache($cache);

--- a/libraries/src/Document/Renderer/Html/MetasRenderer.php
+++ b/libraries/src/Document/Renderer/Html/MetasRenderer.php
@@ -44,7 +44,7 @@ class MetasRenderer extends DocumentRenderer
 			$this->_doc->_metaTags['name']['tags'] = implode(', ', $tagsHelper->getTagNames($this->_doc->_metaTags['name']['tags']));
 		}
 
-		/** @var \Joomla\CMS\Application\CMSApplication $app */
+		/* @var \Joomla\CMS\Application\CMSApplication $app */
 		$app = Factory::getApplication();
 		$wa  = $this->_doc->getWebAssetManager();
 		$wc  = $this->_doc->getScriptOptions('webcomponents');

--- a/libraries/src/HTML/Helpers/Behavior.php
+++ b/libraries/src/HTML/Helpers/Behavior.php
@@ -161,7 +161,7 @@ abstract class Behavior
 			return;
 		}
 
-		/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+		/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 		$wa = Factory::getApplication()->getDocument()->getWebAssetManager();
 
 		$wa
@@ -229,7 +229,7 @@ abstract class Behavior
 			$scriptOptions = array('version' => 'auto', 'relative' => true);
 			$scriptOptions = $conditionalBrowser !== null ? array_replace($scriptOptions, array('conditional' => $conditionalBrowser)) : $scriptOptions;
 
-			/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+			/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 			$wa = Factory::getApplication()->getDocument()->getWebAssetManager();
 			$wa->registerAndUseScript('polyfill.' . $polyfillType, 'vendor/polyfills/polyfill-' . $polyfillType . '.js', $scriptOptions);
 

--- a/libraries/src/HTML/Helpers/Bootstrap.php
+++ b/libraries/src/HTML/Helpers/Bootstrap.php
@@ -151,7 +151,7 @@ abstract class Bootstrap
 	 */
 	public static function framework($debug = null)
 	{
-		/** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
+		/* @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
 		$wa = Factory::getApplication()->getDocument()->getWebAssetManager();
 
 		if ($wa->assetExists('script', 'bootstrap.init.legacy') && $wa->isAssetActive('script', 'bootstrap.init.legacy'))

--- a/libraries/src/HTML/Helpers/Content.php
+++ b/libraries/src/HTML/Helpers/Content.php
@@ -61,10 +61,10 @@ abstract class Content
 	 */
 	public static function months($state)
 	{
-		/** @var \Joomla\Component\Content\Administrator\Extension\ContentComponent $contentComponent */
+		/* @var \Joomla\Component\Content\Administrator\Extension\ContentComponent $contentComponent */
 		$contentComponent = Factory::getApplication()->bootComponent('com_content');
 
-		/** @var \Joomla\Component\Content\Site\Model\ArticlesModel $model */
+		/* @var \Joomla\Component\Content\Site\Model\ArticlesModel $model */
 		$model = $contentComponent->getMVCFactory()
 			->createModel('Articles', 'Site', ['ignore_request' => true]);
 

--- a/libraries/src/HTML/Helpers/FormBehavior.php
+++ b/libraries/src/HTML/Helpers/FormBehavior.php
@@ -93,7 +93,7 @@ abstract class FormBehavior
 
 		// Add chosen.js assets
 
-		/** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
+		/* @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
 		$wa = Factory::getApplication()->getDocument()->getWebAssetManager();
 		$wa->usePreset('chosen')
 			->registerAndUseScript('joomla-chosen', 'legacy/joomla-chosen.min.js', [], [], ['chosen'])

--- a/libraries/src/MVC/Controller/ApiController.php
+++ b/libraries/src/MVC/Controller/ApiController.php
@@ -300,7 +300,7 @@ class ApiController extends BaseController
 
 		$modelName = $this->input->get('model', Inflector::singularize($this->contentType));
 
-		/** @var \Joomla\CMS\MVC\Model\AdminModel $model */
+		/* @var \Joomla\CMS\MVC\Model\AdminModel $model */
 		$model = $this->getModel($modelName, '', ['ignore_request' => true]);
 
 		if (!$model)
@@ -353,7 +353,7 @@ class ApiController extends BaseController
 	 */
 	public function edit()
 	{
-		/** @var \Joomla\CMS\MVC\Model\AdminModel $model */
+		/* @var \Joomla\CMS\MVC\Model\AdminModel $model */
 		$model = $this->getModel(Inflector::singularize($this->contentType));
 
 		if (!$model)
@@ -409,7 +409,7 @@ class ApiController extends BaseController
 	 */
 	protected function save($recordKey = null)
 	{
-		/** @var \Joomla\CMS\MVC\Model\AdminModel $model */
+		/* @var \Joomla\CMS\MVC\Model\AdminModel $model */
 		$model = $this->getModel(Inflector::singularize($this->contentType));
 
 		if (!$model)

--- a/libraries/src/MVC/Controller/FormController.php
+++ b/libraries/src/MVC/Controller/FormController.php
@@ -859,7 +859,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
 			false
 		);
 
-		/** @var \Joomla\CMS\Form\Form $form */
+		/* @var \Joomla\CMS\Form\Form $form */
 		$form = $model->getForm($data, false);
 
 		/**

--- a/libraries/src/MVC/View/JsonApiView.php
+++ b/libraries/src/MVC/View/JsonApiView.php
@@ -111,7 +111,7 @@ abstract class JsonApiView extends JsonView
 	 */
 	public function displayList(array $items = null)
 	{
-		/** @var \Joomla\CMS\MVC\Model\ListModel $model */
+		/* @var \Joomla\CMS\MVC\Model\ListModel $model */
 		$model = $this->getModel();
 
 		// Get page query
@@ -217,7 +217,7 @@ abstract class JsonApiView extends JsonView
 	{
 		if ($item === null)
 		{
-			/** @var \Joomla\CMS\MVC\Model\AdminModel $model */
+			/* @var \Joomla\CMS\MVC\Model\AdminModel $model */
 			$model = $this->getModel();
 			$item  = $this->prepareItem($model->getItem());
 		}

--- a/libraries/src/Toolbar/ToolbarHelper.php
+++ b/libraries/src/Toolbar/ToolbarHelper.php
@@ -627,7 +627,7 @@ abstract class ToolbarHelper
 		$lang = Factory::getLanguage();
 		$lang->load('com_contenthistory', JPATH_ADMINISTRATOR, $lang->getTag(), true);
 
-		/** @var \Joomla\CMS\Table\ContentType $contentTypeTable */
+		/* @var \Joomla\CMS\Table\ContentType $contentTypeTable */
 		$contentTypeTable = Table::getInstance('Contenttype');
 		$typeId           = $contentTypeTable->getTypeId($typeAlias);
 

--- a/libraries/src/Updater/Updater.php
+++ b/libraries/src/Updater/Updater.php
@@ -169,7 +169,7 @@ class Updater extends \JAdapter
 			{
 				$retval = true;
 
-				/** @var \Joomla\CMS\Table\Update $update */
+				/* @var \Joomla\CMS\Table\Update $update */
 				foreach ($updateObjects as $update)
 				{
 					$update->check();
@@ -305,15 +305,15 @@ class Updater extends \JAdapter
 
 			if (\array_key_exists('updates', $update_result) && \count($update_result['updates']))
 			{
-				/** @var \Joomla\CMS\Table\Update $current_update */
+				/* @var \Joomla\CMS\Table\Update $current_update */
 				foreach ($update_result['updates'] as $current_update)
 				{
 					$current_update->extra_query = $updateSite['extra_query'];
 
-					/** @var \Joomla\CMS\Table\Update $update */
+					/* @var \Joomla\CMS\Table\Update $update */
 					$update = Table::getInstance('update');
 
-					/** @var \Joomla\CMS\Table\Extension $extension */
+					/* @var \Joomla\CMS\Table\Extension $extension */
 					$extension = Table::getInstance('extension');
 
 					$uid = $update

--- a/libraries/src/User/User.php
+++ b/libraries/src/User/User.php
@@ -501,7 +501,7 @@ class User extends CMSObject
 	public function setLastVisit($timestamp = null)
 	{
 		// Create the user table object
-		/** @var \Joomla\CMS\Table\User $table */
+		/* @var \Joomla\CMS\Table\User $table */
 		$table = $this->getTable();
 		$table->load($this->id);
 

--- a/modules/mod_articles_news/src/Helper/ArticlesNewsHelper.php
+++ b/modules/mod_articles_news/src/Helper/ArticlesNewsHelper.php
@@ -41,7 +41,7 @@ abstract class ArticlesNewsHelper
 	{
 		$app = Factory::getApplication();
 
-		/** @var \Joomla\Component\Content\Site\Model\ArticlesModel $model */
+		/* @var \Joomla\Component\Content\Site\Model\ArticlesModel $model */
 		$model = $app->bootComponent('com_content')
 			->getMVCFactory()->createModel('Articles', 'Site', ['ignore_request' => true]);
 

--- a/modules/mod_finder/tmpl/default.php
+++ b/modules/mod_finder/tmpl/default.php
@@ -43,7 +43,7 @@ else
 	$output .= $input;
 }
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $app->getDocument()->getWebAssetManager();
 $wa->getRegistry()->addExtensionRegistryFile('com_finder');
 $wa->useScript('com_finder.finder');

--- a/modules/mod_languages/tmpl/default.php
+++ b/modules/mod_languages/tmpl/default.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Uri\Uri;
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $app->getDocument()->getWebAssetManager();
 $wa->registerAndUseStyle('mod_languages', 'mod_languages/template.css');
 

--- a/modules/mod_menu/tmpl/default.php
+++ b/modules/mod_menu/tmpl/default.php
@@ -11,7 +11,7 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Helper\ModuleHelper;
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $app->getDocument()->getWebAssetManager();
 $wa->registerAndUseScript('mod_menu', 'mod_menu/menu.min.js', [], ['defer' => true]);
 

--- a/modules/mod_related_items/src/Helper/RelatedItemsHelper.php
+++ b/modules/mod_related_items/src/Helper/RelatedItemsHelper.php
@@ -43,7 +43,7 @@ abstract class RelatedItemsHelper
 		$factory   = $app->bootComponent('com_content')->getMVCFactory();
 
 		// Get an instance of the generic articles model
-		/** @var \Joomla\Component\Content\Site\Model\ArticlesModel $articles */
+		/* @var \Joomla\Component\Content\Site\Model\ArticlesModel $articles */
 		$articles = $factory->createModel('Articles', 'Site', ['ignore_request' => true]);
 
 		// Set application parameters in model

--- a/modules/mod_wrapper/tmpl/default.php
+++ b/modules/mod_wrapper/tmpl/default.php
@@ -11,7 +11,7 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $app->getDocument()->getWebAssetManager();
 $wa->registerAndUseScript('com_wrapper.iframe', 'com_wrapper/iframe-height.min.js', [], ['defer' => true]);
 

--- a/plugins/content/loadmodule/loadmodule.php
+++ b/plugins/content/loadmodule/loadmodule.php
@@ -87,6 +87,7 @@ class PlgContentLoadmodule extends CMSPlugin
 				// We should replace only first occurrence in order to allow positions with the same name to regenerate their content:
 				if (($start = strpos($article->text, $match[0])) !== false)
 				{
+
 					$article->text = substr_replace($article->text, $output, $start, strlen($match[0]));
 				}
 
@@ -126,6 +127,7 @@ class PlgContentLoadmodule extends CMSPlugin
 				// We should replace only first occurrence in order to allow positions with the same name to regenerate their content:
 				if (($start = strpos($article->text, $matchmod[0])) !== false)
 				{
+
 					$article->text = substr_replace($article->text, $output, $start, strlen($matchmod[0]));
 				}
 

--- a/plugins/editors/codemirror/layouts/editors/codemirror/styles.php
+++ b/plugins/editors/codemirror/layouts/editors/codemirror/styles.php
@@ -31,7 +31,7 @@ $g                   = hexdec($color[3] . $color[4]);
 $b                   = hexdec($color[5] . $color[6]);
 $highlightMatchColor = 'rgba(' . $r . ', ' . $g . ', ' . $b . ', .5)';
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = Factory::getApplication()->getDocument()->getWebAssetManager();
 $wa->registerAndUseStyle('plg_editors_codemirror', 'plg_editors_codemirror/codemirror.css');
 $wa->addInlineStyle(

--- a/plugins/installer/override/override.php
+++ b/plugins/installer/override/override.php
@@ -60,10 +60,10 @@ class PlgInstallerOverride extends CMSPlugin
 	 */
 	public function getModel($name = 'Template', $prefix = 'Administrator')
 	{
-		/** @var \Joomla\Component\Templates\Administrator\Extension\TemplatesComponent $templateProvider */
+		/* @var \Joomla\Component\Templates\Administrator\Extension\TemplatesComponent $templateProvider */
 		$templateProvider = $this->app->bootComponent('com_templates');
 
-		/** @var \Joomla\Component\Templates\Administrator\Model\TemplateModel $model */
+		/* @var \Joomla\Component\Templates\Administrator\Model\TemplateModel $model */
 		$model = $templateProvider->getMVCFactory()->createModel($name, $prefix);
 
 		return $model;
@@ -166,7 +166,7 @@ class PlgInstallerOverride extends CMSPlugin
 	{
 		try
 		{
-			/** @var \Joomla\Component\Templates\Administrator\Model\TemplateModel $templateModel */
+			/* @var \Joomla\Component\Templates\Administrator\Model\TemplateModel $templateModel */
 			$templateModel = $this->getModel();
 		}
 		catch (\Exception $e)

--- a/plugins/sampledata/testing/testing.php
+++ b/plugins/sampledata/testing/testing.php
@@ -112,7 +112,7 @@ class PlgSampledataTesting extends CMSPlugin
 			return $response;
 		}
 
-		/** @var \Joomla\Component\Tags\Administrator\Model\TagModel $model */
+		/* @var \Joomla\Component\Tags\Administrator\Model\TagModel $model */
 		$model = $this->app->bootComponent('com_tags')->getMVCFactory()->createModel('Tag', 'Administrator', ['ignore_request' => true]);
 		$access = (int) $this->app->get('access', 1);
 		$user   = Factory::getUser();
@@ -222,10 +222,10 @@ class PlgSampledataTesting extends CMSPlugin
 
 		$factory = $this->app->bootComponent('com_banners')->getMVCFactory();
 
-		/** @var Joomla\Component\Banners\Administrator\Model\ClientModel $clientModel */
+		/* @var Joomla\Component\Banners\Administrator\Model\ClientModel $clientModel */
 		$clientModel = $factory->createModel('Client', 'Administrator', ['ignore_request' => true]);
 
-		/** @var Joomla\Component\Banners\Administrator\Model\BannerModel $bannerModel */
+		/* @var Joomla\Component\Banners\Administrator\Model\BannerModel $bannerModel */
 		$bannerModel = $factory->createModel('Banner', 'Administrator', ['ignore_request' => true]);
 
 		$user = Factory::getUser();
@@ -1402,7 +1402,7 @@ class PlgSampledataTesting extends CMSPlugin
 			return $response;
 		}
 
-		/** @var \Joomla\Component\Newsfeeds\Administrator\Model\NewsfeedModel $model */
+		/* @var \Joomla\Component\Newsfeeds\Administrator\Model\NewsfeedModel $model */
 		$model  = $this->app->bootComponent('com_newsfeeds')->getMVCFactory()->createModel('Newsfeed', 'Administrator', ['ignore_request' => true]);
 		$access = (int) $this->app->get('access', 1);
 		$user   = Factory::getUser();
@@ -1530,7 +1530,7 @@ class PlgSampledataTesting extends CMSPlugin
 			return $response;
 		}
 
-		/** @var \Joomla\Component\Menus\Administrator\Model\MenuModel $model */
+		/* @var \Joomla\Component\Menus\Administrator\Model\MenuModel $model */
 		$factory = $this->app->bootComponent('com_menus')->getMVCFactory();
 		$model = $factory->createModel('Menu', 'Administrator', ['ignore_request' => true]);
 		$modelItem = $factory->createModel('Item', 'Administrator', ['ignore_request' => true]);
@@ -4628,7 +4628,7 @@ class PlgSampledataTesting extends CMSPlugin
 
 		foreach ($articles as $i => $article)
 		{
-			/** @var \Joomla\Component\Content\Administrator\Model\ArticleModel $model */
+			/* @var \Joomla\Component\Content\Administrator\Model\ArticleModel $model */
 			$model = $mvcFactory->createModel('Article', 'Administrator', ['ignore_request' => true]);
 
 			// Set values from language strings.

--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -150,7 +150,7 @@ class PlgSystemDebug extends CMSPlugin
 		ob_start();
 		ob_implicit_flush(false);
 
-		/** @var \Joomla\Database\Monitor\DebugMonitor */
+		/* @var \Joomla\Database\Monitor\DebugMonitor */
 		$this->queryMonitor = $this->db->getMonitor();
 
 		if (!$this->params->get('queries', 1))

--- a/plugins/system/logrotation/logrotation.php
+++ b/plugins/system/logrotation/logrotation.php
@@ -60,7 +60,7 @@ class PlgSystemLogrotation extends CMSPlugin
 	{
 		// Get the timeout as configured in plugin parameters
 
-		/** @var \Joomla\Registry\Registry $params */
+		/* @var \Joomla\Registry\Registry $params */
 		$cache_timeout = (int) $this->params->get('cachetimeout', 30);
 		$cache_timeout = 24 * 3600 * $cache_timeout;
 		$logsToKeep    = (int) $this->params->get('logstokeep', 1);

--- a/plugins/system/redirect/redirect.php
+++ b/plugins/system/redirect/redirect.php
@@ -69,7 +69,7 @@ class PlgSystemRedirect extends CMSPlugin implements SubscriberInterface
 	 */
 	public function handleError(ErrorEvent $event)
 	{
-		/** @var \Joomla\CMS\Application\CMSApplication $app */
+		/* @var \Joomla\CMS\Application\CMSApplication $app */
 		$app = $event->getApplication();
 
 		if ($app->isClient('administrator') || ((int) $event->getError()->getCode() !== 404))

--- a/plugins/system/skipto/skipto.php
+++ b/plugins/system/skipto/skipto.php
@@ -75,7 +75,7 @@ class PlgSystemSkipto extends CMSPlugin
 			]
 		);
 
-		/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+		/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 		$wa = $document->getWebAssetManager();
 		$wa->useStyle('skipto')
 			->useScript('skipto.dropmenu')

--- a/plugins/system/stats/layouts/field/data.php
+++ b/plugins/system/stats/layouts/field/data.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+/* @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = Factory::getApplication()->getDocument()->getWebAssetManager();
 $wa->registerAndUseScript('plg_system_stats.stats', 'plg_system_stats/stats.js', [], ['defer' => true], ['core']);
 

--- a/plugins/system/stats/layouts/message.php
+++ b/plugins/system/stats/layouts/message.php
@@ -10,15 +10,16 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
+use Joomla\Registry\Registry;
 
 extract($displayData);
 
 /**
  * Layout variables
  * -----------------
- * @var  PlgSystemStats             $plugin        Plugin rendering this layout
- * @var  \Joomla\Registry\Registry  $pluginParams  Plugin parameters
- * @var  array                      $statsData     Array containing the data that will be sent to the stats server
+ * @var  PlgSystemStats  $plugin        Plugin rendering this layout
+ * @var  Registry        $pluginParams  Plugin parameters
+ * @var  array           $statsData     Array containing the data that will be sent to the stats server
  */
 ?>
 

--- a/plugins/system/stats/layouts/stats.php
+++ b/plugins/system/stats/layouts/stats.php
@@ -16,7 +16,7 @@ extract($displayData);
 /**
  * Layout variables
  * -----------------
- * @var  array  $statsData  Array containing the data that will be sent to the stats server
+ * @var   array  $statsData  Array containing the data that will be sent to the stats server
  */
 
 $versionFields = array('php_version', 'db_version', 'cms_version');

--- a/plugins/system/updatenotification/updatenotification.php
+++ b/plugins/system/updatenotification/updatenotification.php
@@ -77,7 +77,7 @@ class PlgSystemUpdatenotification extends CMSPlugin
 		// Get the timeout for Joomla! updates, as configured in com_installer's component parameters
 		$component = ComponentHelper::getComponent('com_installer');
 
-		/** @var \Joomla\Registry\Registry $params */
+		/* @var \Joomla\Registry\Registry $params */
 		$params        = $component->getParams();
 		$cache_timeout = (int) $params->get('cachetimeout', 6);
 		$cache_timeout = 3600 * $cache_timeout;

--- a/plugins/system/webauthn/src/PluginTraits/AdditionalLoginButtons.php
+++ b/plugins/system/webauthn/src/PluginTraits/AdditionalLoginButtons.php
@@ -175,7 +175,7 @@ trait AdditionalLoginButtons
 		// Set the "don't load again" flag
 		$this->injectedCSSandJS = true;
 
-		/** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
+		/* @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
 		$wa = Factory::getApplication()->getDocument()->getWebAssetManager();
 
 		if (!$wa->assetExists('style', 'plg_system_webauthn.button'))

--- a/plugins/webservices/languages/languages.php
+++ b/plugins/webservices/languages/languages.php
@@ -70,7 +70,7 @@ class PlgWebservicesLanguages extends CMSPlugin
 
 		$router->addRoutes($routes);
 
-		/** @var \Joomla\Component\Languages\Administrator\Model\LanguagesModel $model */
+		/* @var \Joomla\Component\Languages\Administrator\Model\LanguagesModel $model */
 		$model = Factory::getApplication()->bootComponent('com_languages')
 			->getMVCFactory()->createModel('Languages', 'Administrator', ['ignore_request' => true]);
 

--- a/templates/cassiopeia/index.php
+++ b/templates/cassiopeia/index.php
@@ -13,7 +13,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Uri\Uri;
 
-/** @var Joomla\CMS\Document\HtmlDocument $this */
+/* @var Joomla\CMS\Document\HtmlDocument $this */
 
 $app = Factory::getApplication();
 $wa  = $this->getWebAssetManager();

--- a/templates/system/component.php
+++ b/templates/system/component.php
@@ -9,7 +9,7 @@
 
 defined('_JEXEC') or die;
 
-/** @var Joomla\CMS\Document\HtmlDocument $this */
+/* @var Joomla\CMS\Document\HtmlDocument $this */
 
 // Styles
 $this->getWebAssetManager()->registerAndUseStyle('template.system.general', 'templates/system/css/general.css');

--- a/templates/system/error.php
+++ b/templates/system/error.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Uri\Uri;
 
-/** @var Joomla\CMS\Document\ErrorDocument  $this */
+/* @var Joomla\CMS\Document\ErrorDocument  $this */
 
 if (!isset($this->error))
 {

--- a/templates/system/offline.php
+++ b/templates/system/offline.php
@@ -16,7 +16,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
 
-/** @var Joomla\CMS\Document\HtmlDocument $this */
+/* @var Joomla\CMS\Document\HtmlDocument $this */
 
 $app = Factory::getApplication();
 $wa  = $this->getWebAssetManager();


### PR DESCRIPTION
### Summary of Changes

A load of general cleanups including, but not limited to 

 - removing double asterisk from single line inline type hints
 - work around "Layout variables" commenting
 - standardising extract of view data to be above the typehints (as most were)
 - remove a few `?><?php` 
 - remove unused `$app` and its `Factory` import (in layouts/joomla/edit/publishingdata.php)
 - a/Make thing clear/Layout variables/
 - Standardise the length of the `-----------------` under `Layout variables` heading to be one `-` more than the chars in `Layout variables` as most were already, but some were random length
 - s/`@param`/`@var` where the docs were not params to a method, but inline typehints for IDEs


### Testing Instructions

gulp... most are comments only, a few PHP changes but just moving code above/below comments and no real "code" changes so everything should work

### Actual result BEFORE applying this Pull Request

everything should work


### Expected result AFTER applying this Pull Request

everything should work

### Documentation Changes Required

none