### PR TITLE
[4.0] A load of general cleanup

### DIFF
--- a/components/com_contact/layouts/joomla/form/renderfield.php
+++ b/components/com_contact/layouts/joomla/form/renderfield.php
@@ -16,9 +16,9 @@ extract($displayData);
 /**
  * Layout variables
  * -----------------
- * 	@var   array   $options  Optional parameters
- * 	@var   string  $label    The html code for the label (not required if $options['hiddenLabel'] is true)
- * 	@var   string  $input    The input field html code
+ * @var   array   $options  Optional parameters
+ * @var   string  $label    The html code for the label (not required if $options['hiddenLabel'] is true)
+ * @var   string  $input    The input field html code
  */
 
 if (!empty($options['showonEnabled']))

--- a/components/com_contact/layouts/joomla/form/renderfield.php
+++ b/components/com_contact/layouts/joomla/form/renderfield.php
@@ -15,10 +15,10 @@ extract($displayData);
 
 /**
  * Layout variables
- * ---------------------
- * 	$options         : (array)  Optional parameters
- * 	$label           : (string) The html code for the label (not required if $options['hiddenLabel'] is true)
- * 	$input           : (string) The input field html code
+ * -----------------
+ * 	@var   array   $options  Optional parameters
+ * 	@var   string  $label    The html code for the label (not required if $options['hiddenLabel'] is true)
+ * 	@var   string  $input    The input field html code
  */
 
 if (!empty($options['showonEnabled']))

--- a/components/com_users/layouts/joomla/form/renderfield.php
+++ b/components/com_users/layouts/joomla/form/renderfield.php
@@ -15,7 +15,7 @@ extract($displayData);
 
 /**
  * Layout variables
- * ---------------------
+ * -----------------
  * @var   array   $options  Optional parameters
  * @var   string  $label    The html code for the label (not required if $options['hiddenLabel'] is true)
  * @var   string  $input    The input field html code

--- a/components/com_users/layouts/joomla/form/renderfield.php
+++ b/components/com_users/layouts/joomla/form/renderfield.php
@@ -16,9 +16,9 @@ extract($displayData);
 /**
  * Layout variables
  * ---------------------
- *    $options         : (array)  Optional parameters
- *    $label           : (string) The html code for the label (not required if $options['hiddenLabel'] is true)
- *    $input           : (string) The input field html code
+ * @var   array   $options  Optional parameters
+ * @var   string  $label    The html code for the label (not required if $options['hiddenLabel'] is true)
+ * @var   string  $input    The input field html code
  */
 
 if (!empty($options['showonEnabled']))

--- a/layouts/chromes/outline.php
+++ b/layouts/chromes/outline.php
@@ -12,7 +12,9 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 
-Factory::getApplication()->getDocument()->getWebAssetManager()->registerAndUseStyle('layouts.chromes.outline', 'layouts/chromes/outline.css');
+Factory::getApplication()->getDocument()
+	->getWebAssetManager()
+	->registerAndUseStyle('layouts.chromes.outline', 'layouts/chromes/outline.css');
 
 $module = $displayData['module'];
 

--- a/layouts/chromes/outline.php
+++ b/layouts/chromes/outline.php
@@ -12,10 +12,9 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 
-Factory::getApplication()->getDocument()->getWebAssetManager()
-		->registerAndUseStyle('layouts.chromes.outline', 'layouts/chromes/outline.css');
+Factory::getApplication()->getDocument()->getWebAssetManager()->registerAndUseStyle('layouts.chromes.outline', 'layouts/chromes/outline.css');
 
-$module  = $displayData['module'];
+$module = $displayData['module'];
 
 ?>
 <div class="mod-preview">

--- a/layouts/chromes/outline.php
+++ b/layouts/chromes/outline.php
@@ -12,7 +12,8 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 
-Factory::getApplication()->getDocument()->getWebAssetManager()->registerAndUseStyle('layouts.chromes.outline', 'layouts/chromes/outline.css');
+Factory::getApplication()->getDocument()->getWebAssetManager()
+		->registerAndUseStyle('layouts.chromes.outline', 'layouts/chromes/outline.css');
 
 $module  = $displayData['module'];
 

--- a/layouts/joomla/button/action-button.php
+++ b/layouts/joomla/button/action-button.php
@@ -11,14 +11,17 @@ use Joomla\CMS\HTML\HTMLHelper;
 
 HTMLHelper::_('bootstrap.popover');
 
-/**
- * @var $icon    string
- * @var $title   string
- * @var $value   string
- * @var $task    string
- * @var $options array
- */
 extract($displayData, EXTR_OVERWRITE);
+
+/**
+ * Layout variables
+ * -----------------
+ * @var   string  $icon
+ * @var   string  $title
+ * @var   string  $value
+ * @var   string  $task
+ * @var   array   $options
+ */
 
 $disabled = !empty($options['disabled']);
 $taskPrefix = $options['task_prefix'];

--- a/layouts/joomla/button/transition-button.php
+++ b/layouts/joomla/button/transition-button.php
@@ -12,14 +12,17 @@ use Joomla\CMS\Language\Text;
 
 HTMLHelper::_('bootstrap.popover');
 
-/**
- * @var $icon    string
- * @var $title   string
- * @var $value   string
- * @var $task    string
- * @var $options array
- */
 extract($displayData, EXTR_OVERWRITE);
+
+/**
+ * Layout variables
+ * -----------------
+ * @var   string  $icon
+ * @var   string  $title
+ * @var   string  $value
+ * @var   string  $task
+ * @var   array   $options
+ */
 
 $only_icon = empty($options['transitions']);
 $disabled = !empty($options['disabled']);

--- a/layouts/joomla/edit/publishingdata.php
+++ b/layouts/joomla/edit/publishingdata.php
@@ -9,9 +9,6 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\Factory;
-
-$app  = Factory::getApplication();
 $form = $displayData->getForm();
 
 $fields = $displayData->get('fields') ?: array(

--- a/layouts/joomla/form/field/color/simple.php
+++ b/layouts/joomla/form/field/color/simple.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 
-extract($displayData, null);
+extract($displayData);
 
 /**
  * Layout variables

--- a/layouts/joomla/form/field/contenthistory.php
+++ b/layouts/joomla/form/field/contenthistory.php
@@ -12,6 +12,8 @@ defined('_JEXEC') or die;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
+extract($displayData);
+
 /**
  * Layout variables
  * -----------------
@@ -46,7 +48,6 @@ use Joomla\CMS\Language\Text;
  * @var   string   $dataAttribute   Miscellaneous data attributes preprocessed for HTML output
  * @var   array    $dataAttributes  Miscellaneous data attributes for eg, data-*.
  */
-extract($displayData);
 
 echo HTMLHelper::_(
 	'bootstrap.renderModal',

--- a/layouts/joomla/form/field/media.php
+++ b/layouts/joomla/form/field/media.php
@@ -15,10 +15,11 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Uri\Uri;
 
+extract($displayData);
+
 /**
  * Layout variables
- * ---------------------
- *
+ * -----------------
  * @var  string   $asset           The asset text
  * @var  string   $authorField     The label text
  * @var  integer  $authorId        The author id
@@ -39,7 +40,6 @@ use Joomla\CMS\Uri\Uri;
  * @var  string   $dataAttribute   Miscellaneous data attributes preprocessed for HTML output
  * @var  array    $dataAttributes  Miscellaneous data attribute for eg, data-*
  */
-extract($displayData);
 
 $attr = '';
 

--- a/layouts/joomla/form/field/radio/buttons.php
+++ b/layouts/joomla/form/field/radio/buttons.php
@@ -9,7 +9,7 @@
 
 defined('_JEXEC') or die;
 
-extract($displayData, null);
+extract($displayData);
 
 /**
  * Layout variables

--- a/layouts/joomla/form/field/radio/switcher.php
+++ b/layouts/joomla/form/field/radio/switcher.php
@@ -11,7 +11,7 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 
-extract($displayData, null);
+extract($displayData);
 
 /**
  * Layout variables

--- a/layouts/joomla/form/field/rules.php
+++ b/layouts/joomla/form/field/rules.php
@@ -17,7 +17,6 @@ use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
 
-
 extract($displayData);
 
 // Get some system objects.

--- a/layouts/joomla/form/field/subform/default.php
+++ b/layouts/joomla/form/field/subform/default.php
@@ -9,23 +9,24 @@
 
 defined('_JEXEC') or die;
 
-/**
- * Make thing clear
- *
- * @var JForm   $tmpl             The Empty form for template
- * @var array   $forms            Array of JForm instances for render the rows
- * @var bool    $multiple         The multiple state for the form field
- * @var int     $min              Count of minimum repeating in multiple mode
- * @var int     $max              Count of maximum repeating in multiple mode
- * @var string  $name             Name of the input field.
- * @var string  $fieldname        The field name
- * @var string  $control          The forms control
- * @var string  $label            The field label
- * @var string  $description      The field description
- * @var array   $buttons          Array of the buttons that will be rendered
- * @var bool    $groupByFieldset  Whether group the subform fields by it`s fieldset
- */
 extract($displayData);
+
+/**
+ * Layout variables
+ * -----------------
+ * @var   JForm   $tmpl             The Empty form for template
+ * @var   array   $forms            Array of JForm instances for render the rows
+ * @var   bool    $multiple         The multiple state for the form field
+ * @var   int     $min              Count of minimum repeating in multiple mode
+ * @var   int     $max              Count of maximum repeating in multiple mode
+ * @var   string  $name             Name of the input field.
+ * @var   string  $fieldname        The field name
+ * @var   string  $control          The forms control
+ * @var   string  $label            The field label
+ * @var   string  $description      The field description
+ * @var   array   $buttons          Array of the buttons that will be rendered
+ * @var   bool    $groupByFieldset  Whether group the subform fields by it`s fieldset
+ */
 
 $form = $forms[0];
 ?>

--- a/layouts/joomla/form/field/subform/repeatable-table.php
+++ b/layouts/joomla/form/field/subform/repeatable-table.php
@@ -12,23 +12,24 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 
-/**
- * Make thing clear
- *
- * @var JForm   $tmpl             The Empty form for template
- * @var array   $forms            Array of JForm instances for render the rows
- * @var bool    $multiple         The multiple state for the form field
- * @var int     $min              Count of minimum repeating in multiple mode
- * @var int     $max              Count of maximum repeating in multiple mode
- * @var string  $name             Name of the input field.
- * @var string  $fieldname        The field name
- * @var string  $control          The forms control
- * @var string  $label            The field label
- * @var string  $description      The field description
- * @var array   $buttons          Array of the buttons that will be rendered
- * @var bool    $groupByFieldset  Whether group the subform fields by it`s fieldset
- */
 extract($displayData);
+
+/**
+ * Layout variables
+ * -----------------
+ * @var   JForm   $tmpl             The Empty form for template
+ * @var   array   $forms            Array of JForm instances for render the rows
+ * @var   bool    $multiple         The multiple state for the form field
+ * @var   int     $min              Count of minimum repeating in multiple mode
+ * @var   int     $max              Count of maximum repeating in multiple mode
+ * @var   string  $name             Name of the input field.
+ * @var   string  $fieldname        The field name
+ * @var   string  $control          The forms control
+ * @var   string  $label            The field label
+ * @var   string  $description      The field description
+ * @var   array   $buttons          Array of the buttons that will be rendered
+ * @var   bool    $groupByFieldset  Whether group the subform fields by it`s fieldset
+ */
 
 // Add script
 if ($multiple)

--- a/layouts/joomla/form/field/subform/repeatable-table/section-byfieldsets.php
+++ b/layouts/joomla/form/field/subform/repeatable-table/section-byfieldsets.php
@@ -11,16 +11,16 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 
-/**
- * Make thing clear
- *
- * @var JForm   $form       The form instance for render the section
- * @var string  $basegroup  The base group name
- * @var string  $group      Current group name
- * @var array   $buttons    Array of the buttons that will be rendered
- */
 extract($displayData);
 
+/**
+ * Layout variables
+ * -----------------
+ * @var   JForm   $form       The form instance for render the section
+ * @var   string  $basegroup  The base group name
+ * @var   string  $group      Current group name
+ * @var   array   $buttons    Array of the buttons that will be rendered
+ */
 ?>
 
 <tr class="subform-repeatable-group" data-base-name="<?php echo $basegroup; ?>" data-group="<?php echo $group; ?>">

--- a/layouts/joomla/form/field/subform/repeatable-table/section.php
+++ b/layouts/joomla/form/field/subform/repeatable-table/section.php
@@ -11,16 +11,16 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 
-/**
- * Make thing clear
- *
- * @var JForm   $form       The form instance for render the section
- * @var string  $basegroup  The base group name
- * @var string  $group      Current group name
- * @var array   $buttons    Array of the buttons that will be rendered
- */
 extract($displayData);
 
+/**
+ * Layout variables
+ * -----------------
+ * @var   JForm   $form       The form instance for render the section
+ * @var   string  $basegroup  The base group name
+ * @var   string  $group      Current group name
+ * @var   array   $buttons    Array of the buttons that will be rendered
+ */
 ?>
 
 <tr class="subform-repeatable-group" data-base-name="<?php echo $basegroup; ?>" data-group="<?php echo $group; ?>">

--- a/layouts/joomla/form/field/subform/repeatable.php
+++ b/layouts/joomla/form/field/subform/repeatable.php
@@ -12,23 +12,24 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 
-/**
- * Make thing clear
- *
- * @var JForm   $tmpl             The Empty form for template
- * @var array   $forms            Array of JForm instances for render the rows
- * @var bool    $multiple         The multiple state for the form field
- * @var int     $min              Count of minimum repeating in multiple mode
- * @var int     $max              Count of maximum repeating in multiple mode
- * @var string  $name             Name of the input field.
- * @var string  $fieldname        The field name
- * @var string  $control          The forms control
- * @var string  $label            The field label
- * @var string  $description      The field description
- * @var array   $buttons          Array of the buttons that will be rendered
- * @var bool    $groupByFieldset  Whether group the subform fields by it`s fieldset
- */
 extract($displayData);
+
+/**
+ * Layout variables
+ * -----------------
+ * @var   JForm   $tmpl             The Empty form for template
+ * @var   array   $forms            Array of JForm instances for render the rows
+ * @var   bool    $multiple         The multiple state for the form field
+ * @var   int     $min              Count of minimum repeating in multiple mode
+ * @var   int     $max              Count of maximum repeating in multiple mode
+ * @var   string  $name             Name of the input field.
+ * @var   string  $fieldname        The field name
+ * @var   string  $control          The forms control
+ * @var   string  $label            The field label
+ * @var   string  $description      The field description
+ * @var   array   $buttons          Array of the buttons that will be rendered
+ * @var   bool    $groupByFieldset  Whether group the subform fields by it`s fieldset
+ */
 
 // Add script
 if ($multiple)

--- a/layouts/joomla/form/field/subform/repeatable/section-byfieldsets.php
+++ b/layouts/joomla/form/field/subform/repeatable/section-byfieldsets.php
@@ -11,15 +11,16 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 
-/**
- * Make thing clear
- *
- * @var JForm   $form       The form instance for render the section
- * @var string  $basegroup  The base group name
- * @var string  $group      Current group name
- * @var array   $buttons    Array of the buttons that will be rendered
- */
 extract($displayData);
+
+/**
+ * Layout variables
+ * -----------------
+ * @var   JForm   $form       The form instance for render the section
+ * @var   string  $basegroup  The base group name
+ * @var   string  $group      Current group name
+ * @var   array   $buttons    Array of the buttons that will be rendered
+ */
 ?>
 
 <div class="subform-repeatable-group" data-base-name="<?php echo $basegroup; ?>" data-group="<?php echo $group; ?>">

--- a/layouts/joomla/form/field/subform/repeatable/section.php
+++ b/layouts/joomla/form/field/subform/repeatable/section.php
@@ -11,16 +11,16 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 
-/**
- * Make thing clear
- *
- * @var JForm   $form       The form instance for render the section
- * @var string  $basegroup  The base group name
- * @var string  $group      Current group name
- * @var array   $buttons    Array of the buttons that will be rendered
- */
 extract($displayData);
 
+/**
+ * Layout variables
+ * -----------------
+ * @var   JForm   $form       The form instance for render the section
+ * @var   string  $basegroup  The base group name
+ * @var   string  $group      Current group name
+ * @var   array   $buttons    Array of the buttons that will be rendered
+ */
 ?>
 
 <div class="subform-repeatable-group" data-base-name="<?php echo $basegroup; ?>" data-group="<?php echo $group; ?>">

--- a/layouts/joomla/form/field/textarea.php
+++ b/layouts/joomla/form/field/textarea.php
@@ -17,7 +17,6 @@ extract($displayData);
 /**
  * Layout variables
  * -----------------
- *
  * @var   string   $autocomplete    Autocomplete attribute for the field.
  * @var   boolean  $autofocus       Is autofocus enabled?
  * @var   string   $class           Classes for the input.

--- a/layouts/joomla/form/field/time.php
+++ b/layouts/joomla/form/field/time.php
@@ -17,7 +17,6 @@ extract($displayData);
 /**
  * Layout variables
  * -----------------
- *
  * @var   boolean $autofocus      Is autofocus enabled?
  * @var   string  $class          Classes for the input.
  * @var   string  $description    Description of the field.

--- a/layouts/joomla/form/field/user.php
+++ b/layouts/joomla/form/field/user.php
@@ -43,7 +43,6 @@ extract($displayData);
  * @var   boolean  $spellcheck      Spellcheck state for the form field.
  * @var   string   $validate        Validation rules to apply.
  * @var   string   $value           Value attribute of the field.
- *
  * @var   string   $userName        The user name
  * @var   mixed    $groups          The filtering groups (null means no filtering)
  * @var   mixed    $excluded        The users to exclude from the list of users

--- a/layouts/joomla/form/renderfield.php
+++ b/layouts/joomla/form/renderfield.php
@@ -15,12 +15,12 @@ extract($displayData);
 
 /**
  * Layout variables
- * ---------------------
- * 	$options      : (array)  Optional parameters
- * 	$name         : (string) The id of the input this label is for
- * 	$label        : (string) The html code for the label
- * 	$input        : (string) The input field html code
- * 	$description  : (string) An optional description to use in a tooltip
+ * -----------------
+ * @var   array   $options      Optional parameters
+ * @var   string  $name         The id of the input this label is for
+ * @var   string  $label        The html code for the label
+ * @var   string  $input        The input field html code
+ * @var   string  $description  An optional description to use in a tooltip
  */
 
 if (!empty($options['showonEnabled']))

--- a/layouts/joomla/form/renderlabel.php
+++ b/layouts/joomla/form/renderlabel.php
@@ -13,11 +13,11 @@ extract($displayData);
 
 /**
  * Layout variables
- * ---------------------
- * 	$text         : (string)  The label text
- * 	$for          : (string)  The id of the input this label is for
- * 	$required     : (boolean) True if a required field
- * 	$classes      : (array)   A list of classes
+ * -----------------
+ * @var   string   $text      The label text
+ * @var   string   $for       The id of the input this label is for
+ * @var   boolean  $required  True if a required field
+ * @var   array    $classes   A list of classes
  */
 
 $classes = array_filter((array) $classes);

--- a/layouts/joomla/html/batch/access.php
+++ b/layouts/joomla/html/batch/access.php
@@ -12,13 +12,6 @@ defined('_JEXEC') or die;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
-/**
- * Layout variables
- * ---------------------
- *
- * none
- */
-
 ?>
 <label id="batch-access-lbl" for="batch-access">
 	<?php echo Text::_('JLIB_HTML_BATCH_ACCESS_LABEL'); ?>
@@ -31,4 +24,4 @@ use Joomla\CMS\Language\Text;
 			'title' => Text::_('JLIB_HTML_BATCH_NOCHANGE'),
 			'id'    => 'batch-access'
 		)
-	); ?>
+	);

--- a/layouts/joomla/html/batch/adminlanguage.php
+++ b/layouts/joomla/html/batch/adminlanguage.php
@@ -13,12 +13,6 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
-/**
- * Layout variables
- * ---------------------
- * None
- */
-
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = Factory::getApplication()->getDocument()->getWebAssetManager();
 $wa->useScript('joomla.batch-language');

--- a/layouts/joomla/html/batch/item.php
+++ b/layouts/joomla/html/batch/item.php
@@ -13,14 +13,13 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
+extract($displayData);
+
 /**
  * Layout variables
- * ---------------------
- *
- * @var  string   $extension The extension name
+ * -----------------
+ * @var   string  $extension  The extension name
  */
-
-extract($displayData);
 
 // Create the copy/move options.
 $options = array(

--- a/layouts/joomla/html/batch/language.php
+++ b/layouts/joomla/html/batch/language.php
@@ -13,12 +13,6 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
-/**
- * Layout variables
- * ---------------------
- * None
- */
-
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = Factory::getApplication()->getDocument()->getWebAssetManager();
 $wa->useScript('joomla.batch-language');

--- a/layouts/joomla/html/batch/tag.php
+++ b/layouts/joomla/html/batch/tag.php
@@ -12,12 +12,6 @@ defined('_JEXEC') or die;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
-/**
- * Layout variables
- * ---------------------
- * None
- */
-
 ?>
 <label id="batch-tag-lbl" for="batch-tag-id">
 	<?php echo Text::_('JLIB_HTML_BATCH_TAG_LABEL'); ?>

--- a/layouts/joomla/html/batch/user.php
+++ b/layouts/joomla/html/batch/user.php
@@ -12,14 +12,13 @@ defined('_JEXEC') or die;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
+extract($displayData);
+
 /**
  * Layout variables
- * ---------------------
- *
- * @var  boolean   $noUser Inject an option for no user?
+ * -----------------
+ * @var   boolean  $noUser  Inject an option for no user?
  */
-
-extract($displayData);
 
 $optionNo = '';
 

--- a/layouts/joomla/html/batch/workflowstage.php
+++ b/layouts/joomla/html/batch/workflowstage.php
@@ -12,12 +12,6 @@ defined('_JEXEC') or die;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
-/**
- * Layout variables
- * ---------------------
- * None
- */
-
 ?>
 <label id="batch-workflowstage-lbl" for="batch-workflowstage-id">
 	<?php echo Text::_('JLIB_HTML_BATCH_WORKFLOW_STAGE_LABEL'); ?>

--- a/layouts/joomla/html/treeprefix.php
+++ b/layouts/joomla/html/treeprefix.php
@@ -9,16 +9,15 @@
 
 defined('_JEXEC') or die;
 
+extract($displayData);
+
 /**
  * Layout variables
- * ---------------------
- *
- * @var  integer  $level  The level of the item in the tree like structure.
+ * -----------------
+ * @var   integer  $level  The level of the item in the tree like structure.
  *
  * @since  3.6.0
  */
-
-extract($displayData);
 
 if ($level > 1)
 {

--- a/layouts/joomla/modal/body.php
+++ b/layouts/joomla/modal/body.php
@@ -13,9 +13,9 @@ extract($displayData);
 
 /**
  * Layout variables
- * ------------------
- * @param   string  $selector  Unique DOM identifier for the modal. CSS id without #
- * @param   array   $params    Modal parameters. Default supported parameters:
+ * -----------------
+ * @var   string  $selector  Unique DOM identifier for the modal. CSS id without #
+ * @var   array   $params    Modal parameters. Default supported parameters:
  *                             - title        string   The modal title
  *                             - backdrop     mixed    A boolean select if a modal-backdrop element should be included (default = true)
  *                                                     The string 'static' includes a backdrop which doesn't close the modal on click.
@@ -28,8 +28,7 @@ extract($displayData);
  *                             - width        string   width of the <iframe> containing the remote resource
  *                             - bodyHeight   int      Optional height of the modal body in viewport units (vh)
  *                             - modalWidth   int      Optional width of the modal in viewport units (vh)
- * @param   string  $body      Markup for the modal body. Appended after the <iframe> if the URL option is set
- *
+ * @var   string  $body      Markup for the modal body. Appended after the <iframe> if the URL option is set
  */
 
 $bodyClass = 'modal-body';

--- a/layouts/joomla/modal/footer.php
+++ b/layouts/joomla/modal/footer.php
@@ -13,9 +13,9 @@ extract($displayData);
 
 /**
  * Layout variables
- * ------------------
- * @param   string  $selector  Unique DOM identifier for the modal. CSS id without #
- * @param   array   $params    Modal parameters. Default supported parameters:
+ * -----------------
+ * @var   string  $selector  Unique DOM identifier for the modal. CSS id without #
+ * @var   array   $params    Modal parameters. Default supported parameters:
  *                             - title        string   The modal title
  *                             - backdrop     mixed    A boolean select if a modal-backdrop element should be included (default = true)
  *                                                     The string 'static' includes a backdrop which doesn't close the modal on click.
@@ -28,8 +28,7 @@ extract($displayData);
  *                             - width        string   width of the <iframe> containing the remote resource
  *                             - bodyHeight   int      Optional height of the modal body in viewport units (vh)
  *                             - modalWidth   int      Optional width of the modal in viewport units (vh)
- * @param   string  $body      Markup for the modal body. Appended after the <iframe> if the URL option is set
- *
+ * @var   string  $body      Markup for the modal body. Appended after the <iframe> if the URL option is set
  */
 ?>
 <div class="modal-footer">

--- a/layouts/joomla/modal/header.php
+++ b/layouts/joomla/modal/header.php
@@ -15,9 +15,9 @@ extract($displayData);
 
 /**
  * Layout variables
- * ------------------
- * @param   string  $selector  Unique DOM identifier for the modal. CSS id without #
- * @param   array   $params    Modal parameters. Default supported parameters:
+ * -----------------
+ * @var   string  $selector  Unique DOM identifier for the modal. CSS id without #
+ * @var   array   $params    Modal parameters. Default supported parameters:
  *                             - title        string   The modal title
  *                             - backdrop     mixed    A boolean select if a modal-backdrop element should be included (default = true)
  *                                                     The string 'static' includes a backdrop which doesn't close the modal on click.
@@ -30,8 +30,7 @@ extract($displayData);
  *                             - width        string   width of the <iframe> containing the remote resource
  *                             - bodyHeight   int      Optional height of the modal body in viewport units (vh)
  *                             - modalWidth   int      Optional width of the modal in viewport units (vh)
- * @param   string  $body      Markup for the modal body. Appended after the <iframe> if the URL option is set
- *
+ * @var   string  $body      Markup for the modal body. Appended after the <iframe> if the URL option is set
  */
 ?>
 <div class="modal-header">

--- a/layouts/joomla/modal/iframe.php
+++ b/layouts/joomla/modal/iframe.php
@@ -15,9 +15,9 @@ extract($displayData);
 
 /**
  * Layout variables
- * ------------------
- * @param   string  $selector  Unique DOM identifier for the modal. CSS id without #
- * @param   array   $params    Modal parameters. Default supported parameters:
+ * -----------------
+ * @var   string  $selector  Unique DOM identifier for the modal. CSS id without #
+ * @var   array   $params    Modal parameters. Default supported parameters:
  *                             - title        string   The modal title
  *                             - backdrop     mixed    A boolean select if a modal-backdrop element should be included (default = true)
  *                                                     The string 'static' includes a backdrop which doesn't close the modal on click.
@@ -28,8 +28,7 @@ extract($displayData);
  *                             - url          string   URL of a resource to be inserted as an <iframe> inside the modal body
  *                             - height       string   height of the <iframe> containing the remote resource
  *                             - width        string   width of the <iframe> containing the remote resource
- * @param   string  $body      Markup for the modal body. Appended after the <iframe> if the URL option is set
- *
+ * @var   string  $body      Markup for the modal body. Appended after the <iframe> if the URL option is set
  */
 
 $iframeAttributes = array(

--- a/layouts/joomla/modal/main.php
+++ b/layouts/joomla/modal/main.php
@@ -16,9 +16,9 @@ extract($displayData);
 
 /**
  * Layout variables
- * ------------------
- * @param   string  $selector  Unique DOM identifier for the modal. CSS id without #
- * @param   array   $params    Modal parameters. Default supported parameters:
+ * -----------------
+ * @var   string  $selector  Unique DOM identifier for the modal. CSS id without #
+ * @var   array   $params    Modal parameters. Default supported parameters:
  *                             - title        string   The modal title
  *                             - backdrop     mixed    A boolean select if a modal-backdrop element should be included (default = true)
  *                                                     The string 'static' includes a backdrop which doesn't close the modal on click.
@@ -31,8 +31,7 @@ extract($displayData);
  *                             - bodyHeight   int      Optional height of the modal body in viewport units (vh)
  *                             - modalWidth   int      Optional width of the modal in viewport units (vh)
  *                             - footer       string   Optional markup for the modal footer
- * @param   string  $body      Markup for the modal body. Appended after the <iframe> if the URL option is set
- *
+ * @var   string  $body      Markup for the modal body. Appended after the <iframe> if the URL option is set
  */
 
 $modalClasses = array('modal');

--- a/layouts/joomla/toolbar/base.php
+++ b/layouts/joomla/toolbar/base.php
@@ -9,11 +9,13 @@
 
 defined('_JEXEC') or die;
 
+extract($displayData, EXTR_OVERWRITE);
+
 /**
+ * Layout variables
+ * -----------------
  * @var  string  $action
  * @var  array   $options
  */
-extract($displayData, EXTR_OVERWRITE);
-?>
 
-<?php echo $action; ?>
+echo $action;

--- a/layouts/joomla/toolbar/basic.php
+++ b/layouts/joomla/toolbar/basic.php
@@ -16,20 +16,23 @@ Factory::getDocument()->getWebAssetManager()
 	->useScript('core')
 	->useScript('webcomponent.toolbar-button');
 
-/**
- * @var  int     $id
- * @var  string  $onclick
- * @var  string  $class
- * @var  string  $text
- * @var  string  $btnClass
- * @var  string  $tagName
- * @var  string  $htmlAttributes
- * @var  string  $task             The task which should be executed
- * @var  bool    $listCheck        Boolean, whether selection from a list is needed
- * @var  string  $form             CSS selector for a target form
- * @var  bool    $formValidation   Whether the form need to be validated before run the task
- */
 extract($displayData, EXTR_OVERWRITE);
+
+/**
+ * Layout variables
+ * -----------------
+ * @var   int     $id
+ * @var   string  $onclick
+ * @var   string  $class
+ * @var   string  $text
+ * @var   string  $btnClass
+ * @var   string  $tagName
+ * @var   string  $htmlAttributes
+ * @var   string  $task             The task which should be executed
+ * @var   bool    $listCheck        Boolean, whether selection from a list is needed
+ * @var   string  $form             CSS selector for a target form
+ * @var   bool    $formValidation   Whether the form need to be validated before run the task
+ */
 
 $tagName = $tagName ?? 'button';
 

--- a/layouts/joomla/toolbar/dropdown.php
+++ b/layouts/joomla/toolbar/dropdown.php
@@ -13,23 +13,27 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
-$direction = Factory::getLanguage()->isRtl() ? 'dropdown-menu-right' : '';
+extract($displayData, EXTR_OVERWRITE);
 
 /**
- * @var  string  $id
- * @var  string  $onclick
- * @var  string  $class
- * @var  string  $text
- * @var  string  $btnClass
- * @var  string  $tagName
- * @var  string  $htmlAttributes
- * @var  string  $hasButtons
- * @var  string  $button
- * @var  string  $dropdownItems
- * @var  string  $caretClass
- * @var  string  $toggleSplit
+ * Layout variables
+ * -----------------
+ * @var   string  $id
+ * @var   string  $onclick
+ * @var   string  $class
+ * @var   string  $text
+ * @var   string  $btnClass
+ * @var   string  $tagName
+ * @var   string  $htmlAttributes
+ * @var   string  $hasButtons
+ * @var   string  $button
+ * @var   string  $dropdownItems
+ * @var   string  $caretClass
+ * @var   string  $toggleSplit
  */
-extract($displayData, EXTR_OVERWRITE);
+
+$direction = Factory::getLanguage()->isRtl() ? 'dropdown-menu-right' : '';
+
 ?>
 <?php if ($hasButtons && trim($button) !== ''): ?>
 	<?php HTMLHelper::_('bootstrap.framework'); ?>

--- a/layouts/joomla/toolbar/link.php
+++ b/layouts/joomla/toolbar/link.php
@@ -10,13 +10,15 @@
 defined('_JEXEC') or die;
 
 /**
- * @var  int     $id
- * @var  string  $name
- * @var  string  $class
- * @var  string  $text
- * @var  string  $btnClass
- * @var  string  $tagName
- * @var  string  $htmlAttributes
+ * Layout variables
+ * -----------------
+ * @var   int     $id
+ * @var   string  $name
+ * @var   string  $class
+ * @var   string  $text
+ * @var   string  $btnClass
+ * @var   string  $tagName
+ * @var   string  $htmlAttributes
  */
 extract($displayData, EXTR_OVERWRITE);
 

--- a/layouts/joomla/toolbar/link.php
+++ b/layouts/joomla/toolbar/link.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+extract($displayData, EXTR_OVERWRITE);
+
 /**
  * Layout variables
  * -----------------
@@ -20,7 +22,6 @@ defined('_JEXEC') or die;
  * @var   string  $tagName
  * @var   string  $htmlAttributes
  */
-extract($displayData, EXTR_OVERWRITE);
 
 $margin = (strpos($url ?? '', 'index.php?option=com_config') === false) ? '' : 'ml-auto';
 $target = empty($target) ? '' : 'target="' . $target . '"';

--- a/layouts/joomla/toolbar/popup.php
+++ b/layouts/joomla/toolbar/popup.php
@@ -12,22 +12,25 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\Utilities\ArrayHelper;
 
-Factory::getDocument()->getWebAssetManager()
-	->useScript('core')
-	->useScript('webcomponent.toolbar-button');
+extract($displayData, EXTR_OVERWRITE);
 
 /**
- * @var  int     $id
- * @var  string  $name
- * @var  string  $doTask
- * @var  string  $class
- * @var  string  $text
- * @var  string  $btnClass
- * @var  string  $tagName
- * @var  bool    $listCheck
- * @var  string  $htmlAttributes
+ * Layout variables
+ * -----------------
+ * @var   int     $id
+ * @var   string  $name
+ * @var   string  $doTask
+ * @var   string  $class
+ * @var   string  $text
+ * @var   string  $btnClass
+ * @var   string  $tagName
+ * @var   bool    $listCheck
+ * @var   string  $htmlAttributes
  */
-extract($displayData, EXTR_OVERWRITE);
+
+Factory::getDocument()->getWebAssetManager()
+		->useScript('core')
+		->useScript('webcomponent.toolbar-button');
 
 $tagName = $tagName ?? 'button';
 

--- a/layouts/joomla/toolbar/popup.php
+++ b/layouts/joomla/toolbar/popup.php
@@ -29,8 +29,8 @@ extract($displayData, EXTR_OVERWRITE);
  */
 
 Factory::getDocument()->getWebAssetManager()
-		->useScript('core')
-		->useScript('webcomponent.toolbar-button');
+	->useScript('core')
+	->useScript('webcomponent.toolbar-button');
 
 $tagName = $tagName ?? 'button';
 

--- a/layouts/joomla/toolbar/separator.php
+++ b/layouts/joomla/toolbar/separator.php
@@ -9,17 +9,20 @@
 
 defined('_JEXEC') or die;
 
-/**
- * @var  bool    $is_child
- * @var  string  $id
- * @var  string  $doTask
- * @var  string  $class
- * @var  string  $text
- * @var  string  $btnClass
- * @var  string  $tagName
- * @var  string  $htmlAttributes
- */
 extract($displayData, EXTR_OVERWRITE);
+
+/**
+ * Layout variables
+ * -----------------
+ * @var   bool    $is_child
+ * @var   string  $id
+ * @var   string  $doTask
+ * @var   string  $class
+ * @var   string  $text
+ * @var   string  $btnClass
+ * @var   string  $tagName
+ * @var   string  $htmlAttributes
+ */
 ?>
 
 <?php if ($is_child): ?>

--- a/layouts/joomla/toolbar/standard.php
+++ b/layouts/joomla/toolbar/standard.php
@@ -31,8 +31,8 @@ extract($displayData, EXTR_OVERWRITE);
  */
 
 Factory::getDocument()->getWebAssetManager()
-		->useScript('core')
-		->useScript('webcomponent.toolbar-button');
+	->useScript('core')
+	->useScript('webcomponent.toolbar-button');
 
 $tagName  = $tagName ?? 'button';
 

--- a/layouts/joomla/toolbar/standard.php
+++ b/layouts/joomla/toolbar/standard.php
@@ -11,26 +11,28 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 
-Factory::getDocument()->getWebAssetManager()
-	->useScript('core')
-	->useScript('webcomponent.toolbar-button');
+extract($displayData, EXTR_OVERWRITE);
 
 /**
- * @var  string  $id
- * @var  string  $onclick
- * @var  string  $class
- * @var  string  $text
- * @var  string  $btnClass
- * @var  string  $tagName
- * @var  string  $htmlAttributes
- * @var  string  $task             The task which should be executed
- * @var  bool    $listCheck        Boolean, whether selection from a list is needed
- * @var  string  $form             CSS selector for a target form
- * @var  bool    $formValidation   Whether the form need to be validated before run the task
- * @var  string  $message          Confirmation message before run the task
- *
+ * Layout variables
+ * -----------------
+ * @var   string  $id
+ * @var   string  $onclick
+ * @var   string  $class
+ * @var   string  $text
+ * @var   string  $btnClass
+ * @var   string  $tagName
+ * @var   string  $htmlAttributes
+ * @var   string  $task             The task which should be executed
+ * @var   bool    $listCheck        Boolean, whether selection from a list is needed
+ * @var   string  $form             CSS selector for a target form
+ * @var   bool    $formValidation   Whether the form need to be validated before run the task
+ * @var   string  $message          Confirmation message before run the task
  */
-extract($displayData, EXTR_OVERWRITE);
+
+Factory::getDocument()->getWebAssetManager()
+		->useScript('core')
+		->useScript('webcomponent.toolbar-button');
 
 $tagName  = $tagName ?? 'button';
 

--- a/layouts/joomla/toolbar/versions.php
+++ b/layouts/joomla/toolbar/versions.php
@@ -27,8 +27,8 @@ extract($displayData, EXTR_OVERWRITE);
  */
 
 Factory::getDocument()->getWebAssetManager()
-		->useScript('core')
-		->useScript('webcomponent.toolbar-button');
+	->useScript('core')
+	->useScript('webcomponent.toolbar-button');
 
 echo HTMLHelper::_(
 	'bootstrap.renderModal',

--- a/layouts/joomla/toolbar/versions.php
+++ b/layouts/joomla/toolbar/versions.php
@@ -14,18 +14,21 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Session\Session;
 
-Factory::getDocument()->getWebAssetManager()
-	->useScript('core')
-	->useScript('webcomponent.toolbar-button');
+extract($displayData, EXTR_OVERWRITE);
 
 /**
- * @var  string  $id
- * @var  string  $itemId
- * @var  string  $typeId
- * @var  string  $typeAlias
- * @var  string  $title
+ * Layout variables
+ * -----------------
+ * @var   string  $id
+ * @var   string  $itemId
+ * @var   string  $typeId
+ * @var   string  $typeAlias
+ * @var   string  $title
  */
-extract($displayData, EXTR_OVERWRITE);
+
+Factory::getDocument()->getWebAssetManager()
+		->useScript('core')
+		->useScript('webcomponent.toolbar-button');
 
 echo HTMLHelper::_(
 	'bootstrap.renderModal',

--- a/layouts/plugins/editors/tinymce/field/tinymcebuilder.php
+++ b/layouts/plugins/editors/tinymce/field/tinymcebuilder.php
@@ -9,6 +9,7 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Document\HtmlDocument;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 
@@ -17,44 +18,42 @@ extract($displayData);
 /**
  * Layout variables
  * -----------------
- * @var   string  $autocomplete   Autocomplete attribute for the field.
- * @var   boolean $autofocus      Is autofocus enabled?
- * @var   string  $class          Classes for the input.
- * @var   string  $description    Description of the field.
- * @var   boolean $disabled       Is this field disabled?
- * @var   string  $group          Group the field belongs to. <fields> section in form XML.
- * @var   boolean $hidden         Is this field hidden in the form?
- * @var   string  $hint           Placeholder for the field.
- * @var   string  $id             DOM id of the field.
- * @var   string  $label          Label of the field.
- * @var   string  $labelclass     Classes to apply to the label.
- * @var   boolean $multiple       Does this field support multiple values?
- * @var   string  $name           Name of the input field.
- * @var   string  $onchange       Onchange attribute for the field.
- * @var   string  $onclick        Onclick attribute for the field.
- * @var   string  $pattern        Pattern (Reg Ex) of value of the form field.
- * @var   boolean $readonly       Is this field read only?
- * @var   boolean $repeat         Allows extensions to duplicate elements.
- * @var   boolean $required       Is this field required?
- * @var   integer $size           Size attribute of the input.
- * @var   boolean $spellcheck     Spellcheck state for the form field.
- * @var   string  $validate       Validation rules to apply.
- * @var   array   $value          Value of the field.
-  *
- * @var   array   $menus           List of the menu items
- * @var   array   $menubarSource   Menu items for builder
- * @var   array   $buttons         List of the buttons
- * @var   array   $buttonsSource   Buttons by group, for the builder
- * @var   array   $toolbarPreset   Toolbar preset (default values)
- * @var   int     $setsAmount      Amount of sets
- * @var   array   $setsNames       List of Sets names
- * @var   JForm[] $setsForms       Form with extra options for an each set
- * @var   string   $languageFile   TinyMCE language file to translate the buttons
- *
- * @var   JLayoutFile  $this       Context
+ * @var   string       $autocomplete   Autocomplete attribute for the field.
+ * @var   boolean      $autofocus      Is autofocus enabled?
+ * @var   string       $class          Classes for the input.
+ * @var   string       $description    Description of the field.
+ * @var   boolean      $disabled       Is this field disabled?
+ * @var   string       $group          Group the field belongs to. <fields> section in form XML.
+ * @var   boolean      $hidden         Is this field hidden in the form?
+ * @var   string       $hint           Placeholder for the field.
+ * @var   string       $id             DOM id of the field.
+ * @var   string       $label          Label of the field.
+ * @var   string       $labelclass     Classes to apply to the label.
+ * @var   boolean      $multiple       Does this field support multiple values?
+ * @var   string       $name           Name of the input field.
+ * @var   string       $onchange       Onchange attribute for the field.
+ * @var   string       $onclick        Onclick attribute for the field.
+ * @var   string       $pattern        Pattern (Reg Ex) of value of the form field.
+ * @var   boolean      $readonly       Is this field read only?
+ * @var   boolean      $repeat         Allows extensions to duplicate elements.
+ * @var   boolean      $required       Is this field required?
+ * @var   integer      $size           Size attribute of the input.
+ * @var   boolean      $spellcheck     Spellcheck state for the form field.
+ * @var   string       $validate       Validation rules to apply.
+ * @var   array        $value          Value of the field.
+ * @var   array        $menus          List of the menu items
+ * @var   array        $menubarSource  Menu items for builder
+ * @var   array        $buttons        List of the buttons
+ * @var   array        $buttonsSource  Buttons by group, for the builder
+ * @var   array        $toolbarPreset  Toolbar preset (default values)
+ * @var   int          $setsAmount     Amount of sets
+ * @var   array        $setsNames      List of Sets names
+ * @var   JForm[]      $setsForms      Form with extra options for an each set
+ * @var   string       $languageFile   TinyMCE language file to translate the buttons
+ * @var   JLayoutFile  $this           Context
  */
 
-/** @var Joomla\CMS\Document\HtmlDocument $doc */
+/** @var HtmlDocument $doc */
 $doc = Factory::getApplication()->getDocument();
 $wa  = $doc->getWebAssetManager();
 

--- a/layouts/plugins/editors/tinymce/field/tinymcebuilder/setoptions.php
+++ b/layouts/plugins/editors/tinymce/field/tinymcebuilder/setoptions.php
@@ -14,8 +14,8 @@ extract($displayData);
 /**
  * Layout variables
  * -----------------
- * @var   JForm        $form    Form with extra options for the set
- * @var   JLayoutFile  $this    Context
+ * @var   JForm        $form  Form with extra options for the set
+ * @var   JLayoutFile  $this  Context
  */
 
 ?>

--- a/layouts/plugins/system/privacyconsent/label.php
+++ b/layouts/plugins/system/privacyconsent/label.php
@@ -48,7 +48,7 @@ extract($displayData);
  * @var   array    $translateDescription   Should the description be translated?
  * @var   array    $translateHint          Should the hint be translated?
  * @var   array    $privacyArticle         The Article ID holding the Privacy Article
- * $var   object   $article                The Article object
+ * @var   object   $article                The Article object
  */
 
 // Get the label text from the XML element, defaulting to the element name.

--- a/layouts/plugins/user/profile/fields/dob.php
+++ b/layouts/plugins/user/profile/fields/dob.php
@@ -9,10 +9,13 @@
 
 defined('_JEXEC') or die;
 
-/**
- * $text  string  infotext to be displayed
- */
 extract($displayData);
+
+/**
+ * Layout variables
+ * -----------------
+ * @var   string  $text  infotext to be displayed
+ */
 
 // Closing the opening .control-group and .control-label div so we can add our info text on own line ?>
 </div></div>

--- a/layouts/plugins/user/terms/label.php
+++ b/layouts/plugins/user/terms/label.php
@@ -48,7 +48,7 @@ extract($displayData);
  * @var   array    $translateDescription   Should the description be translated?
  * @var   array    $translateHint          Should the hint be translated?
  * @var   array    $termsArticle           The Article ID holding the Terms Article
- * $var   object   $article                The Article object
+ * @var   object   $article                The Article object
  */
 
 // Get the label text from the XML element, defaulting to the element name.

--- a/plugins/system/stats/layouts/message.php
+++ b/plugins/system/stats/layouts/message.php
@@ -10,15 +10,16 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
+use Joomla\Registry\Registry;
 
 extract($displayData);
 
 /**
  * Layout variables
  * -----------------
- * @var  PlgSystemStats             $plugin        Plugin rendering this layout
- * @var  \Joomla\Registry\Registry  $pluginParams  Plugin parameters
- * @var  array                      $statsData     Array containing the data that will be sent to the stats server
+ * @var  PlgSystemStats  $plugin        Plugin rendering this layout
+ * @var  Registry        $pluginParams  Plugin parameters
+ * @var  array           $statsData     Array containing the data that will be sent to the stats server
  */
 ?>
 

--- a/plugins/system/stats/layouts/stats.php
+++ b/plugins/system/stats/layouts/stats.php
@@ -16,7 +16,7 @@ extract($displayData);
 /**
  * Layout variables
  * -----------------
- * @var  array  $statsData  Array containing the data that will be sent to the stats server
+ * @var   array  $statsData  Array containing the data that will be sent to the stats server
  */
 
 $versionFields = array('php_version', 'db_version', 'cms_version');


### PR DESCRIPTION
### Summary of Changes

A load of general cleanups including, but not limited to 

 - Mostly work around "Layout variables" commenting
 - standardising extract of view data to be above the typehints (as most were)
 - remove unused `$app` and its `Factory` import (in layouts/joomla/edit/publishingdata.php)
 - a/Make thing clear/Layout variables/
 - Standardise the length of the `-----------------` under `Layout variables` heading to be one `-` more than the chars in `Layout variables` as most were already, but some were random length
 - s/`@param`/`@var` where the docs were not params to a method, but inline typehints for IDEs

### Testing Instructions

gulp... most are comments only, a few PHP changes but just moving code above/below comments and no real "code" changes so everything should work

### Actual result BEFORE applying this Pull Request

everything should work


### Expected result AFTER applying this Pull Request

everything should work

### Documentation Changes Required

none