### PR TITLE
[4.0][com_plugins] Move buttons out of dropdown

### DIFF
--- a/administrator/components/com_plugins/src/View/Plugins/HtmlView.php
+++ b/administrator/components/com_plugins/src/View/Plugins/HtmlView.php
@@ -104,20 +104,11 @@ class HtmlView extends BaseHtmlView
 		// Get the toolbar object instance
 		$toolbar = Toolbar::getInstance('toolbar');
 
-		$dropdown = $toolbar->dropdownButton('status-group')
-			->text('JTOOLBAR_CHANGE_STATUS')
-			->toggleSplit(false)
-			->icon('fas fa-ellipsis-h')
-			->buttonClass('btn btn-action')
-			->listCheck(true);
-
-		$childBar = $dropdown->getChildToolbar();
-
 		if ($canDo->get('core.edit.state'))
 		{
-			$childBar->publish('plugins.publish', 'JTOOLBAR_ENABLE')->listCheck(true);
-			$childBar->unpublish('plugins.unpublish', 'JTOOLBAR_DISABLE')->listCheck(true);
-			$childBar->checkin('plugins.checkin');
+			$toolbar->publish('plugins.publish', 'JTOOLBAR_ENABLE')->listCheck(true);
+			$toolbar->unpublish('plugins.unpublish', 'JTOOLBAR_DISABLE')->listCheck(true);
+			$toolbar->checkin('plugins.checkin')->listCheck(true);
 		}
 
 		if ($canDo->get('core.admin'))
@@ -126,6 +117,5 @@ class HtmlView extends BaseHtmlView
 		}
 
 		$toolbar->help('JHELP_EXTENSIONS_PLUGIN_MANAGER');
-
 	}
 }


### PR DESCRIPTION
### Summary of Changes
Make Plugins buttons same as Extensions buttons by removing out of dropdown menu.


### Testing Instructions
Go to System > Extensions
See buttons not in dropdown menu
Go to System > Plugins
Actions in dropdown menu
Apply PR
Go to System > Plugins
See buttons not in dropdown menu


