### PR TITLE
[4.0] Reset the state on the media field

### DIFF
--- a/build/media_source/system/js/fields/joomla-field-media.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-media.w-c.es6.js
@@ -194,6 +194,8 @@
     show() {
       this.querySelector('[role="dialog"]').open();
 
+      Joomla.selectedFile = {};
+
       this.querySelector(this.buttonSaveSelected).addEventListener('click', this.onSelected);
     }
 
@@ -201,9 +203,13 @@
       const input = this.querySelector(this.input);
 
       Joomla.getImage(Joomla.selectedFile, input, this)
-        .then(() => { Joomla.Modal.getCurrent().close(); })
+        .then(() => {
+          Joomla.Modal.getCurrent().close();
+          Joomla.selectedFile = {};
+        })
         .catch(() => {
           Joomla.Modal.getCurrent().close();
+          Joomla.selectedFile = {};
           Joomla.renderMessages({
             error: [Joomla.Text._('JLIB_APPLICATION_ERROR_SERVER')],
           });


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

- Always reset the state


### Testing Instructions
- Create a new article
- go to the images tab
- on the intro image select a random image
- go to the fulltext image open the media field selector, DO NOT select anything and close the modal by clicking on the select button

### Actual result BEFORE applying this Pull Request
The state of the field was not properly reseted


### Expected result AFTER applying this Pull Request
The state of the field is now properly reseted


### Documentation Changes Required

No 