### PR TITLE
[4] com_menus. Items modal. Right align toolbar fields like in all other modals.

### DIFF
--- a/administrator/components/com_menus/tmpl/items/modal.php
+++ b/administrator/components/com_menus/tmpl/items/modal.php
@@ -43,7 +43,7 @@ if (!empty($editor))
 }
 ?>
 <div class="container-popup">
-	<form action="<?php echo Route::_($link); ?>" method="post" name="adminForm" id="adminForm" class="form-inline">
+	<form action="<?php echo Route::_($link); ?>" method="post" name="adminForm" id="adminForm">
 
 		<?php echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
 


### PR DESCRIPTION
### Summary of Changes
- Remove `class="form-inline"` that hinders `justify-content: flex-end;` of `.btn-toolbar` (=> alignment right).

### Testing Instructions
- Desktop screen.
- Open new article.
- Click editor button "CMS Content" > "Menu".
- See: Toolbar fields in modal are left aligned. 

![menu](https://user-images.githubusercontent.com/20780646/87231335-a5b83b00-c3b6-11ea-93b0-295dc0c66498.jpg)

- Close modal.

- Click one of the other modal buttons below "CMS Content" (Module, Contact, Article, ...).
- See: Toolbar fields are right aligned. 

![article](https://user-images.githubusercontent.com/20780646/87231338-ad77df80-c3b6-11ea-91ae-15d6c44c94be.jpg)

### Actual result BEFORE applying this Pull Request

### Expected result AFTER applying this Pull Request
- fields are also right aligned in "Menu" modal.
