### PR TITLE
[4.0] Fixed filtering by multiple tags in a blog layout

### DIFF
--- a/components/com_content/src/Model/ArticlesModel.php
+++ b/components/com_content/src/Model/ArticlesModel.php
@@ -654,8 +654,12 @@ class ArticlesModel extends ListModel
 				$subQuery = $db->getQuery(true)
 					->select('DISTINCT ' . $db->quoteName('content_item_id'))
 					->from($db->quoteName('#__contentitem_tag_map'))
-					->whereIn($db->quoteName('tag_id'), $tagId)
-					->where($db->quoteName('type_alias') . ' = ' . $db->quote('com_content.article'));
+					->where(
+						[
+							$db->quoteName('tag_id') . ' IN (' . implode(',', $query->bindArray($tagId)) . ')',
+							$db->quoteName('type_alias') . ' = ' . $db->quote('com_content.article'),
+						]
+					);
 
 				$query->join(
 					'INNER',


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Filtering by multiple tags in a category blog layout works again.

### Testing Instructions

- Create a couple of tags. Let's call them 'foo' and 'bar'.
- Create a couple of articles. Assign one the 'foo' tag, and the other the 'bar' tag.
- Create a new menu item of type Category Blog. Leave it uncategorised, and add both 'foo' and 'bar' tags to filter it by. Save.
- Browse to the newly created menu item in the frontend.

### Actual result BEFORE applying this Pull Request

Error 500 and no articles appear.

### Expected result AFTER applying this Pull Request

Tags are correctly filtered and both articles appear.

### Documentation Changes Required

None.