### PR TITLE
[4.0] Fix Cassiopea searchtools alignment in modals

### DIFF
--- a/templates/cassiopeia/scss/system/searchtools/searchtools.scss
+++ b/templates/cassiopeia/scss/system/searchtools/searchtools.scss
@@ -6,6 +6,7 @@
   padding: 10px 20px;
 
   .btn-toolbar {
+    justify-content: flex-end;
 
     > * {
       margin: 4px 0;


### PR DESCRIPTION
### Summary of Changes
Correct searchtools alignment to same position as backend.
I.e. bar should be aligned right in LTR, left in RTL


### Testing Instructions
Edit Article in frontend. Select CMS Content article xtd.
Patch and run npm

### Actual result BEFORE applying this Pull Request

<img width="1194" alt="Screen Shot 2020-07-12 at 08 57 22" src="https://user-images.githubusercontent.com/869724/87241021-1d21b500-c41f-11ea-8d7b-8bd83f0125fd.png">

### Expected result AFTER applying this Pull Request

<img width="1181" alt="Screen Shot 2020-07-12 at 08 57 34" src="https://user-images.githubusercontent.com/869724/87241029-2b6fd100-c41f-11ea-9985-a4e742114882.png">
