### PR TITLE
[3.10] Switcher field transition, from j3.10 to j4

### DIFF
--- a/layouts/joomla/form/field/radio/switcher.php
+++ b/layouts/joomla/form/field/radio/switcher.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   Copyright (C) 2005 - 2020 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+use Joomla\CMS\Layout\FileLayout;
+
+// The layout need for transition from "btn-group" in Joomla! 3.10 to "switcher" field in Joomla! 4
+
+if (!$displayData['class'] || strpos($displayData['class'], 'btn-group') === false)
+{
+	$displayData['class'] .= ' btn-group';
+}
+
+$renderer = new FileLayout('joomla.form.field.radio', null, $this->options);
+$renderer->setIncludePaths($this->includePaths);
+
+echo $renderer->render($displayData);

--- a/layouts/joomla/form/field/radio/switcher.php
+++ b/layouts/joomla/form/field/radio/switcher.php
@@ -11,7 +11,7 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Layout\FileLayout;
 
-// The layout need for transition from "btn-group" in Joomla! 3.10 to "switcher" field in Joomla! 4
+// The layout is needed for transition from "btn-group" in Joomla! 3.10 to the "switcher" field in Joomla! 4
 
 if (!$displayData['class'] || strpos($displayData['class'], 'btn-group') === false)
 {


### PR DESCRIPTION
Pull Request for Issue #29885 
Redo of #30070

### Summary of Changes

The patch allows to transition from "btn-group" to "switcher" field more transparent.
The developer only need to add the layout attribute `layout="joomla.form.field.radio.switcher"` to the field xml.


### Testing Instructions

 * Apply the patch.
 * Create a "btn-group" field, somewhere, example in Custom HTML module:
```xml
<field
	name="switchertest"
	type="radio"
	label="switcher test"
	class="btn-group btn-group-yesno"
	layout="joomla.form.field.radio.switcher"
	default="1"
>
	<option value="1">JYES</option>
	<option value="0">JNO</option>
</field>
```



### Actual result BEFORE applying this Pull Request
The field are empty


### Expected result AFTER applying this Pull Request
The field rendered as "btn-group"

Also try testing Instructions from #29885 pull.

### Documentation Changes Required
I guess, maybe some explanation about transition to Joomla! 4
