### PR TITLE
[POC] Fix the error handling of form fields on missing layoutfile

### DIFF
--- a/libraries/joomla/form/fields/radio.php
+++ b/libraries/joomla/form/fields/radio.php
@@ -7,6 +7,8 @@
  * @license     GNU General Public License version 2 or later; see LICENSE
  */
 
+use Joomla\CMS\Layout\FileLayout;
+
 defined('JPATH_PLATFORM') or die;
 
 JFormHelper::loadFieldClass('list');
@@ -45,12 +47,14 @@ class JFormFieldRadio extends JFormFieldList
 	 */
 	protected function getInput()
 	{
-		if (empty($this->layout))
+		$layoutExists = $this->checkLayoutExists($this->layout);
+
+		if ($layoutExists instanceof FileLayout)
 		{
-			throw new UnexpectedValueException(sprintf('%s has no layout assigned.', $this->name));
+			return $layoutExists->render($this->getLayoutData());
 		}
 
-		return $this->getRenderer($this->layout)->render($this->getLayoutData());
+		throw new \UnexpectedValueException(sprintf('%s has no layout assigned.', $this->fieldname));
 	}
 
 	/**

--- a/libraries/joomla/form/fields/radio.php
+++ b/libraries/joomla/form/fields/radio.php
@@ -7,9 +7,9 @@
  * @license     GNU General Public License version 2 or later; see LICENSE
  */
 
-use Joomla\CMS\Layout\FileLayout;
-
 defined('JPATH_PLATFORM') or die;
+
+use Joomla\CMS\Layout\FileLayout;
 
 JFormHelper::loadFieldClass('list');
 

--- a/libraries/src/Form/FormField.php
+++ b/libraries/src/Form/FormField.php
@@ -717,12 +717,14 @@ abstract class FormField
 	 */
 	protected function getInput()
 	{
-		if (empty($this->layout))
+		$layoutExists = $this->checkLayoutExists($this->layout);
+
+		if ($layoutExists instanceof FileLayout)
 		{
-			throw new \UnexpectedValueException(sprintf('%s has no layout assigned.', $this->name));
+			return $layoutExists->render($this->getLayoutData());
 		}
 
-		return $this->getRenderer($this->layout)->render($this->getLayoutData());
+		throw new \UnexpectedValueException(sprintf('%s has no layout assigned.', $this->fieldname));
 	}
 
 	/**
@@ -1077,5 +1079,28 @@ abstract class FormField
 	protected function isDebugEnabled()
 	{
 		return $this->getAttribute('debug', 'false') === 'true';
+	}
+
+	/**
+	 * Check if the layout exists
+	 *
+	 * @param   string  $layoutId  Id to load
+	 *
+	 * @return  FileLayout|void  Return null if layout don't exists
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function checkLayoutExists($layoutId = 'default')
+	{
+		$renderer = $this->getRenderer($layoutId);
+
+		$layoutFileExists = $renderer->checkLayoutExists();
+
+		if ($layoutFileExists)
+		{
+			return $renderer;
+		}
+
+		return;
 	}
 }

--- a/libraries/src/Layout/FileLayout.php
+++ b/libraries/src/Layout/FileLayout.php
@@ -666,7 +666,7 @@ class FileLayout extends BaseLayout
 	}
 
 	/**
-	 * Check if the layout file  exists
+	 * Check if the layout file exists
 	 *
 	 * @return  boolean
 	 *
@@ -678,5 +678,4 @@ class FileLayout extends BaseLayout
 
 		return (!empty($layoutPath));
 	}
-
 }

--- a/libraries/src/Layout/FileLayout.php
+++ b/libraries/src/Layout/FileLayout.php
@@ -664,4 +664,19 @@ class FileLayout extends BaseLayout
 
 		return $sublayout->render($displayData);
 	}
+
+	/**
+	 * Check if the layout file  exists
+	 *
+	 * @return  boolean
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function checkLayoutExists()
+	{
+		$layoutPath = $this->getPath();
+
+		return (!empty($layoutPath));
+	}
+
 }


### PR DESCRIPTION
### Summary of Changes
This PR is supposed to throw an error message when trying to load a field layout which does not exist.  
It is the basis for the PR #29885, without the fallback to a standard layout.  
Fields that overwrite the `getInput()` method must be adjusted as shown in the radio field.

I will gladly make the adjustments of fields in a separate PR if this change is accepted. A B/C break is not given because the render method ignores it.

### Testing Instructions
- install the attached dummy [plugin](https://github.com/joomla/joomla-cms/files/4866412/plg_content_testmanifest.zip)
- check the plugin configuration page on `Extensions->Plugins->Content - Testmanifest`
- apply this patch
- check again


### Actual result BEFORE applying this Pull Request
The field in the middle, is trying to load a non existent layout and gets back a label whithout a field. No error or exception will be returned.


### Expected result AFTER applying this Pull Request
An exception is thrown, with information about which field a non-existent layout will load.


### Documentation Changes Required
None.
