### PR TITLE
[4.0] Menu items modal: adding missing filters

### DIFF
--- a/administrator/components/com_menus/tmpl/items/modal.php
+++ b/administrator/components/com_menus/tmpl/items/modal.php
@@ -44,8 +44,7 @@ if (!empty($editor))
 ?>
 <div class="container-popup">
 	<form action="<?php echo Route::_($link); ?>" method="post" name="adminForm" id="adminForm">
-
-		<?php echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
+		<?php echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this, 'options' => array('selectorFieldName' => 'menutype'))); ?>
 
 		<?php if (empty($this->items)) : ?>
 			<div class="alert alert-info">

--- a/components/com_menus/forms/filter_items.xml
+++ b/components/com_menus/forms/filter_items.xml
@@ -1,5 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
-<form>
+<form addfieldprefix="Joomla\Component\Menus\Administrator\Field">
+	<field
+		name="menutype"
+		type="menu"
+		label="COM_MENUS_SELECT_MENU_FILTER"
+		accesstype="manage"
+		clientid=""
+		showAll="false"
+		filtermode="selector"
+		onchange="this.form.submit();"
+		>
+		<option value="">COM_MENUS_SELECT_MENU</option>
+	</field>
 	<fields name="filter">
 		<field
 			name="search"
@@ -50,6 +62,14 @@
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_MAX_LEVELS</option>
+		</field>
+		<field
+			name="parent_id"
+			type="MenuItemByType"
+			label="COM_MENUS_FILTER_PARENT_MENU_ITEM_LABEL"
+			onchange="this.form.submit();"
+			>
+			<option value="">COM_MENUS_FILTER_SELECT_PARENT_MENU_ITEM</option>
 		</field>
 	</fields>
 	<fields name="list">


### PR DESCRIPTION
### Summary of Changes
Menus modals do not display filtering by Menu Type in backend and also in frontend.
Also, in frontend, no filtering by Parent Menu item

This PR corrects this so that filtering in modals is similar to filtering in menu tems Manager

### Testing Instructions
Edit an article in backend and also in frontend.
Through CMS Content display a  Menu Modal


### Actual result BEFORE applying this Pull Request
Backend

<img width="1333" alt="Screen Shot 2020-07-13 at 10 31 44" src="https://user-images.githubusercontent.com/869724/87281997-1749d380-c4f4-11ea-87b8-200ef1b31eb3.png">

Frontend

<img width="1326" alt="Screen Shot 2020-07-13 at 10 32 41" src="https://user-images.githubusercontent.com/869724/87282098-35173880-c4f4-11ea-9783-8e8f983061e4.png">


### Expected result AFTER applying this Pull Request
Backend

<img width="1337" alt="Screen Shot 2020-07-13 at 10 21 15" src="https://user-images.githubusercontent.com/869724/87281839-ef5a7000-c4f3-11ea-90a0-61c3bd739516.png">

Frontend

<img width="1305" alt="Screen Shot 2020-07-13 at 10 19 37" src="https://user-images.githubusercontent.com/869724/87281877-f8e3d800-c4f3-11ea-81db-1f75c23d0798.png">

