### PR TITLE
[4.0] move comment above block

### DIFF
--- a/administrator/modules/mod_login/tmpl/default.php
+++ b/administrator/modules/mod_login/tmpl/default.php
@@ -21,9 +21,9 @@ $wa->useScript('core')
 	->useScript('field.passwordview')
 	->registerAndUseScript('mod_login.admin', 'mod_login/admin-login.min.js', [], ['defer' => true], ['core', 'form.validate']);
 
+// Load JS message titles
 Text::script('JSHOWPASSWORD');
 Text::script('JHIDEPASSWORD');
-// Load JS message titles
 Text::script('ERROR');
 Text::script('WARNING');
 Text::script('NOTICE');

--- a/installation/template/index.php
+++ b/installation/template/index.php
@@ -32,25 +32,19 @@ $this->getWebAssetManager()
 // Add script options
 $this->addScriptOptions('system.installation', ['url' => Route::_('index.php')]);
 
-// Load JavaScript message titles
+// Load JavaScript translations
 Text::script('ERROR');
 Text::script('WARNING');
 Text::script('NOTICE');
 Text::script('MESSAGE');
-
-// Add strings for JavaScript error translations.
 Text::script('JLIB_JS_AJAX_ERROR_CONNECTION_ABORT');
 Text::script('JLIB_JS_AJAX_ERROR_NO_CONTENT');
 Text::script('JLIB_JS_AJAX_ERROR_OTHER');
 Text::script('JLIB_JS_AJAX_ERROR_PARSE');
 Text::script('JLIB_JS_AJAX_ERROR_TIMEOUT');
 Text::script('INSTL_DATABASE_RESPONSE_ERROR');
-
-// Load the JavaScript translated messages
 Text::script('INSTL_PROCESS_BUSY');
 Text::script('INSTL_FTP_SETTINGS_CORRECT');
-
-// Load strings for translated messages (directory removal)
 Text::script('INSTL_REMOVE_INST_FOLDER');
 Text::script('INSTL_COMPLETE_REMOVE_FOLDER');
 ?>

--- a/installation/template/index.php
+++ b/installation/template/index.php
@@ -28,7 +28,6 @@ $this->getWebAssetManager()
 	->useScript('webcomponent.joomla-alert')
 	->useScript('webcomponent.core-loader');
 
-
 // Add script options
 $this->addScriptOptions('system.installation', ['url' => Route::_('index.php')]);
 


### PR DESCRIPTION
### Summary of Changes

move comment above block


### Testing Instructions

no testing needed - just merge - only change is moving a comment. 

### Actual result BEFORE applying this Pull Request

```
Text::script('JSHOWPASSWORD');
Text::script('JHIDEPASSWORD');
// Load JS message titles
Text::script('ERROR');
Text::script('WARNING');
Text::script('NOTICE');
Text::script('MESSAGE');
```

### Expected result AFTER applying this Pull Request

```
// Load JS message titles
Text::script('JSHOWPASSWORD');
Text::script('JHIDEPASSWORD');
Text::script('ERROR');
Text::script('WARNING');
Text::script('NOTICE');
Text::script('MESSAGE');
```

### Documentation Changes Required

none