### PR TITLE
[4.0] fix typehint syntax & other comment issues

### DIFF
--- a/plugins/workflow/featuring/featuring.php
+++ b/plugins/workflow/featuring/featuring.php
@@ -83,7 +83,7 @@ class PlgWorkflowFeaturing extends CMSPlugin implements SubscriberInterface
 	/**
 	 * The form event.
 	 *
-	 * @param EventInterface $event The event
+	 * @param   EventInterface  $event  The event
 	 *
 	 * @since   4.0.0
 	 */
@@ -111,8 +111,8 @@ class PlgWorkflowFeaturing extends CMSPlugin implements SubscriberInterface
 	 * Disable certain fields in the item form view, when we want to take over this function in the transition
 	 * Check also for the workflow implementation and if the field exists
 	 *
-	 * @param Form     $form The form
-	 * @param stdClass $data The data
+	 * @param   Form      $form  The form
+	 * @param   stdClass  $data  The data
 	 *
 	 * @return  boolean
 	 *
@@ -185,7 +185,7 @@ class PlgWorkflowFeaturing extends CMSPlugin implements SubscriberInterface
 	/**
 	 * Manipulate the generic list view
 	 *
-	 * @param DisplayEvent $event
+	 * @param   DisplayEvent  $event
 	 *
 	 * @since   4.0.0
 	 */
@@ -245,9 +245,9 @@ class PlgWorkflowFeaturing extends CMSPlugin implements SubscriberInterface
 	/**
 	 * Check if we can execute the transition
 	 *
-	 * @param WorkflowTransitionEvent $event
+	 * @param   WorkflowTransitionEvent  $event
 	 *
-	 * @return boolean
+	 * @return   boolean
 	 *
 	 * @since   4.0.0
 	 */
@@ -307,9 +307,9 @@ class PlgWorkflowFeaturing extends CMSPlugin implements SubscriberInterface
 	/**
 	 * Change Feature State of an item. Used to disable feature state change
 	 *
-	 * @param WorkflowTransitionEvent $event
+	 * @param   WorkflowTransitionEvent  $event
 	 *
-	 * @return boolean
+	 * @return   boolean
 	 *
 	 * @since   4.0.0
 	 */
@@ -350,11 +350,11 @@ class PlgWorkflowFeaturing extends CMSPlugin implements SubscriberInterface
 	/**
 	 * Change Feature State of an item. Used to disable Feature state change
 	 *
-	 * @param FeatureEvent $event
+	 * @param   FeatureEvent  $event
 	 *
-	 * @return boolean
+	 * @return   boolean
 	 *
-	 * @throws Exception
+	 * @throws   Exception
 	 * @since   4.0.0
 	 */
 	public function onContentBeforeChangeFeatured(FeatureEvent $event)
@@ -380,7 +380,7 @@ class PlgWorkflowFeaturing extends CMSPlugin implements SubscriberInterface
 	/**
 	 * The save event.
 	 *
-	 * @param EventInterface $event
+	 * @param   EventInterface  $event
 	 *
 	 * @return  boolean
 	 *
@@ -424,9 +424,9 @@ class PlgWorkflowFeaturing extends CMSPlugin implements SubscriberInterface
 	/**
 	 * Check if the current plugin should execute workflow related activities
 	 *
-	 * @param string $context
+	 * @param   string  $context
 	 *
-	 * @return boolean
+	 * @return   boolean
 	 *
 	 * @since   4.0.0
 	 */
@@ -476,7 +476,7 @@ class PlgWorkflowFeaturing extends CMSPlugin implements SubscriberInterface
 	/**
 	 * If plugin supports the functionality we set the used variable
 	 *
-	 * @param WorkflowFunctionalityUsedEvent $event
+	 * @param   WorkflowFunctionalityUsedEvent  $event
 	 *
 	 * @since 4.0.0
 	 */

--- a/plugins/workflow/featuring/featuring.php
+++ b/plugins/workflow/featuring/featuring.php
@@ -407,8 +407,10 @@ class PlgWorkflowFeaturing extends CMSPlugin implements SubscriberInterface
 
 		$article->load($table->id);
 
-		// We don't allow the change of the feature state when we use the workflow
-		// As we're setting the field to disabled, no value should be there at all
+		/**
+		 * We don't allow the change of the feature state when we use the workflow
+		 * As we're setting the field to disabled, no value should be there at all
+		 */
 		if (isset($data[$keyName]))
 		{
 			$this->app->enqueueMessage(Text::_('PLG_WORKFLOW_FEATURING_CHANGE_STATE_NOT_ALLOWED'), 'error');

--- a/plugins/workflow/featuring/featuring.php
+++ b/plugins/workflow/featuring/featuring.php
@@ -390,8 +390,7 @@ class PlgWorkflowFeaturing extends CMSPlugin implements SubscriberInterface
 	{
 		$context = $event->getArgument('0');
 
-		// @var TableInterface
-
+		/* @var TableInterface $table */
 		$table = $event->getArgument('1');
 		$isNew = $event->getArgument('2');
 		$data  = $event->getArgument('3');

--- a/plugins/workflow/featuring/featuring.php
+++ b/plugins/workflow/featuring/featuring.php
@@ -390,7 +390,7 @@ class PlgWorkflowFeaturing extends CMSPlugin implements SubscriberInterface
 	{
 		$context = $event->getArgument('0');
 
-		/* @var TableInterface $table */
+		/** @var TableInterface $table */
 		$table = $event->getArgument('1');
 		$isNew = $event->getArgument('2');
 		$data  = $event->getArgument('3');

--- a/plugins/workflow/notification/notification.php
+++ b/plugins/workflow/notification/notification.php
@@ -101,9 +101,9 @@ class PlgWorkflowNotification extends CMSPlugin implements SubscriberInterface
 	/**
 	 * Send a Notification to defined users a transition is performed
 	 *
-	 * @param   string   $context  The context for the content passed to the plugin.
-	 * @param   array    $pks      A list of primary key ids of the content that has changed stage.
-	 * @param   object  $data    Object containing data about the transition
+	 * @param   string  $context  The context for the content passed to the plugin.
+	 * @param   array   $pks      A list of primary key ids of the content that has changed stage.
+	 * @param   object  $data     Object containing data about the transition
 	 *
 	 * @return  boolean
 	 *

--- a/plugins/workflow/notification/notification.php
+++ b/plugins/workflow/notification/notification.php
@@ -60,7 +60,7 @@ class PlgWorkflowNotification extends CMSPlugin implements SubscriberInterface
 	/**
 	 * Returns an array of events this subscriber will listen to.
 	 *
-	 * @return  array
+	 * @return   array
 	 *
 	 * @since   4.0.0
 	 */
@@ -78,7 +78,7 @@ class PlgWorkflowNotification extends CMSPlugin implements SubscriberInterface
 	 * @param   Form      $form  The form
 	 * @param   stdClass  $data  The data
 	 *
-	 * @return  boolean
+	 * @return   boolean
 	 *
 	 * @since   4.0.0
 	 */
@@ -105,7 +105,7 @@ class PlgWorkflowNotification extends CMSPlugin implements SubscriberInterface
 	 * @param   array   $pks      A list of primary key ids of the content that has changed stage.
 	 * @param   object  $data     Object containing data about the transition
 	 *
-	 * @return  boolean
+	 * @return   boolean
 	 *
 	 * @since   4.0.0
 	 */
@@ -230,7 +230,7 @@ class PlgWorkflowNotification extends CMSPlugin implements SubscriberInterface
 	/**
 	 * Get user_ids of receivers
 	 *
-	 * @param   object  $data    Object containing data about the transition
+	 * @param   object  $data  Object containing data about the transition
 	 *
 	 * @return   array  $userIds  The receivers
 	 *
@@ -280,9 +280,9 @@ class PlgWorkflowNotification extends CMSPlugin implements SubscriberInterface
 	/**
 	 * Check if the current plugin should execute workflow related activities
 	 *
-	 * @param string $context
+	 * @param   string  $context
 	 *
-	 * @return boolean
+	 * @return   boolean
 	 *
 	 * @since   4.0.0
 	 */

--- a/plugins/workflow/publishing/publishing.php
+++ b/plugins/workflow/publishing/publishing.php
@@ -401,8 +401,7 @@ class PlgWorkflowPublishing extends CMSPlugin implements SubscriberInterface
 	{
 		$context = $event->getArgument('0');
 
-		// @var TableInterface
-
+		/* @var TableInterface $table */
 		$table = $event->getArgument('1');
 		$isNew = $event->getArgument('2');
 		$data  = $event->getArgument('3');

--- a/plugins/workflow/publishing/publishing.php
+++ b/plugins/workflow/publishing/publishing.php
@@ -401,7 +401,7 @@ class PlgWorkflowPublishing extends CMSPlugin implements SubscriberInterface
 	{
 		$context = $event->getArgument('0');
 
-		/* @var TableInterface $table */
+		/** @var TableInterface $table */
 		$table = $event->getArgument('1');
 		$isNew = $event->getArgument('2');
 		$data  = $event->getArgument('3');

--- a/plugins/workflow/publishing/publishing.php
+++ b/plugins/workflow/publishing/publishing.php
@@ -81,7 +81,7 @@ class PlgWorkflowPublishing extends CMSPlugin implements SubscriberInterface
 	/**
 	 * The form event.
 	 *
-	 * @param EventInterface $event The event
+	 * @param   EventInterface  $event  The event
 	 *
 	 * @since   4.0.0
 	 */
@@ -108,8 +108,8 @@ class PlgWorkflowPublishing extends CMSPlugin implements SubscriberInterface
 	/**
 	 * Add different parameter options to the transition view, we need when executing the transition
 	 *
-	 * @param Form     $form The form
-	 * @param stdClass $data The data
+	 * @param   Form      $form The form
+	 * @param   stdClass  $data The data
 	 *
 	 * @return  boolean
 	 *
@@ -133,8 +133,8 @@ class PlgWorkflowPublishing extends CMSPlugin implements SubscriberInterface
 	 * Disable certain fields in the item  form view, when we want to take over this function in the transition
 	 * Check also for the workflow implementation and if the field exists
 	 *
-	 * @param Form     $form The form
-	 * @param stdClass $data The data
+	 * @param   Form      $form  The form
+	 * @param   stdClass  $data  The data
 	 *
 	 * @return  boolean
 	 *
@@ -203,7 +203,7 @@ class PlgWorkflowPublishing extends CMSPlugin implements SubscriberInterface
 	/**
 	 * Manipulate the generic list view
 	 *
-	 * @param DisplayEvent $event
+	 * @param   DisplayEvent    $event
 	 *
 	 * @since   4.0.0
 	 */
@@ -266,7 +266,7 @@ class PlgWorkflowPublishing extends CMSPlugin implements SubscriberInterface
 	/**
 	 * Check if we can execute the transition
 	 *
-	 * @param WorkflowTransitionEvent $event
+	 * @param   WorkflowTransitionEvent  $event
 	 *
 	 * @return boolean
 	 *
@@ -318,7 +318,7 @@ class PlgWorkflowPublishing extends CMSPlugin implements SubscriberInterface
 	/**
 	 * Change State of an item. Used to disable state change
 	 *
-	 * @param WorkflowTransitionEvent $event
+	 * @param   WorkflowTransitionEvent  $event
 	 *
 	 * @return boolean
 	 *
@@ -361,7 +361,7 @@ class PlgWorkflowPublishing extends CMSPlugin implements SubscriberInterface
 	/**
 	 * Change State of an item. Used to disable state change
 	 *
-	 * @param EventInterface $event
+	 * @param   EventInterface  $event
 	 *
 	 * @return boolean
 	 *
@@ -391,7 +391,7 @@ class PlgWorkflowPublishing extends CMSPlugin implements SubscriberInterface
 	/**
 	 * The save event.
 	 *
-	 * @param EventInterface $event
+	 * @param   EventInterface  $event
 	 *
 	 * @return  boolean
 	 *
@@ -418,8 +418,10 @@ class PlgWorkflowPublishing extends CMSPlugin implements SubscriberInterface
 
 		$article->load($table->id);
 
-		// We don't allow the change of the state when we use the workflow
-		// As we're setting the field to disabled, no value should be there at all
+		/**
+		 * We don't allow the change of the state when we use the workflow
+		 * As we're setting the field to disabled, no value should be there at all
+		 */
 		if (isset($data[$keyName]))
 		{
 			$this->app->enqueueMessage(Text::_('PLG_WORKFLOW_PUBLISHING_CHANGE_STATE_NOT_ALLOWED'), 'error');
@@ -433,7 +435,7 @@ class PlgWorkflowPublishing extends CMSPlugin implements SubscriberInterface
 	/**
 	 * Check if the current plugin should execute workflow related activities
 	 *
-	 * @param string $context
+	 * @param   string  $context
 	 *
 	 * @return boolean
 	 *
@@ -485,7 +487,7 @@ class PlgWorkflowPublishing extends CMSPlugin implements SubscriberInterface
 	/**
 	 * If plugin supports the functionality we set the used variable
 	 *
-	 * @param WorkflowFunctionalityUsedEvent $event
+	 * @param   WorkflowFunctionalityUsedEvent  $event
 	 *
 	 * @since 4.0.0
 	 */


### PR DESCRIPTION
 - fix typehint syntax in single line comment to meet code standards 
 - fix multi line comment syntax
 - reindent docblock