### PR TITLE
Set variable (type) in case of an empty request in json input object

### DIFF
--- a/libraries/src/Input/Json.php
+++ b/libraries/src/Input/Json.php
@@ -54,13 +54,17 @@ class Json extends Input
 		{
 			$this->_raw = file_get_contents('php://input');
 			$this->data = json_decode($this->_raw, true);
+
+			if (!is_array($this->data))
+			{
+				$this->data = array();
+			}
 		}
 		else
 		{
-			$this->data = & $source;
+			$this->data = &$source;
 		}
 
-		// Set the options for the class.
 		$this->options = $options;
 	}
 


### PR DESCRIPTION
### Summary of Changes
If you want to process raw post data send to an (open) API, you probably would use something similar to this.:
`$payload = $this->input->json->getArray();`

This is fine when (valid) data was send. In case of an empty request though, a null value is passed to `Input::getArrayRecursive()`, which results in the following warning:
> Warning: Invalid argument supplied for foreach() in [...]\libraries\src\Input\Input.php on line 165

### Testing Instructions
First, create a test controller "foobar" with the following content in e.g. `/components/com_users/controllers/foobar.php`
```
<?php

defined('_JEXEC') or die;

use Joomla\CMS\Factory;

JLoader::register('UsersController', JPATH_COMPONENT . '/controller.php');

class UsersControllerFoobar extends UsersController
{
	public function foobar()
	{
		$payload = $this->input->json->getArray();

		print_r($payload);

		Factory::getApplication()->close();
	}
}
```
Send a POST request, preferably with the content type "application/json" to that controller / method and leave out the payload / data. It shouldn't matter if you use curl, your browser console and / or an addons to do that.

### Expected result
The expected result would be an empty array.

### Actual result
The warning mentioned above appears.