### PR TITLE
[4.0] Cassiopea: Fixing modals custom-select fields display

### DIFF
--- a/templates/cassiopeia/scss/_variables.scss
+++ b/templates/cassiopeia/scss/_variables.scss
@@ -135,7 +135,7 @@ $treeselect-line-height:             2.2rem;
 $list-group-bg:                      $white-offset;
 
 // Custom form
-$custom-select-bg:                   $white-offset;
+$custom-select-bg:                   $gray-200;
 
 // Custom form
 $custom-select-indicator-padding:    3rem;

--- a/templates/cassiopeia/scss/blocks/_modals.scss
+++ b/templates/cassiopeia/scss/blocks/_modals.scss
@@ -51,3 +51,7 @@
 .container-popup .mb-3 {
   margin: 1rem;
 }
+
+.container-popup .custom-select {
+  width: auto;
+}

--- a/templates/cassiopeia/scss/vendor/bootstrap/_custom-forms.scss
+++ b/templates/cassiopeia/scss/vendor/bootstrap/_custom-forms.scss
@@ -52,4 +52,10 @@
       }
     }
   }
+
+  optgroup,
+  option {
+    color: var(--dark);
+    background-color: $white;
+  }
 }


### PR DESCRIPTION
Follow-up on https://github.com/joomla/joomla-cms/pull/30087

### Summary of Changes
Correct css for the menutype custom select field
Use correctly the background SVG for all custom fields


### Testing Instructions
Make sure you have patched with https://github.com/joomla/joomla-cms/pull/30087 to also test menutype field width.
Edit an article in frontend.
Select CMS Content => Menu (this will also show the correction for the menutype)
Any other xtd will also have the background corrected.


### Actual result BEFORE applying this Pull Request
<img width="1305" alt="Screen Shot 2020-07-13 at 10 19 37" src="https://user-images.githubusercontent.com/869724/87281877-f8e3d800-c4f3-11ea-81db-1f75c23d0798.png">


### Expected result AFTER applying this Pull Request
<img width="1378" alt="Screen Shot 2020-07-14 at 11 56 02" src="https://user-images.githubusercontent.com/869724/87413680-e5f00700-c5ca-11ea-8c5d-d42662c6e61e.png">
