### PR TITLE
Improve build script and remove .github/SECURITY.md in next release

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -2033,6 +2033,9 @@ class JoomlaInstallerScript
 
 			// Joomla! 3.9.17
 			'/administrator/components/com_templates/controllers/template.php.orig',
+
+			// Joomla! 3.9.21
+			'/.github/SECURITY.md',
 		);
 
 		// TODO There is an issue while deleting folders using the ftp mode

--- a/build/build.php
+++ b/build/build.php
@@ -247,12 +247,6 @@ for ($num = $release - 1; $num >= 0; $num--)
 		{
 			continue;
 		}
-		if (strpos($file, '.github') !== false) {
-			print_r('diffdocs/' . $version . '.' . $num);
-			print_r($command);
-			print_r([$fileName, $baseFolderName, $doNotPackageFile, $doNotPatch, $doNotPackageBaseFolder, $doNotPatchBaseFolder]);
-			die();
-		}
 
 		// Act on the file based on the action
 		switch (substr($file, 0, 1))

--- a/build/build.php
+++ b/build/build.php
@@ -107,7 +107,8 @@ $fullVersion = (new Version)->getShortVersion();
 
 $previousRelease = Version::PATCH_VERSION - 1;
 
-if ($previousRelease < 0) {
+if ($previousRelease < 0)
+{
 	$previousRelease = false;
 }
 

--- a/build/build.php
+++ b/build/build.php
@@ -105,6 +105,12 @@ $version     = Version::MAJOR_VERSION . '.' . Version::MINOR_VERSION;
 $release     = Version::PATCH_VERSION;
 $fullVersion = (new Version)->getShortVersion();
 
+$previousRelease = Version::PATCH_VERSION - 1;
+
+if ($previousRelease < 0) {
+	$previousRelease = false;
+}
+
 chdir($tmp);
 system('mkdir diffdocs');
 system('mkdir diffconvert');
@@ -223,7 +229,11 @@ for ($num = $release - 1; $num >= 0; $num--)
 	// Loop through and add all files except: tests, installation, build, .git, .travis, travis, phpunit, .md, or images
 	foreach ($files as $file)
 	{
-		$fileName   = substr($file, 2);
+		if (substr($file, 0, 1) === 'R') {
+			$fileName   = substr($file, strrpos($file, "\t") + 1);
+		} else {
+			$fileName   = substr($file, 2);
+		}
 		$folderPath = explode('/', $fileName);
 		$baseFolderName = $folderPath[0];
 
@@ -235,6 +245,12 @@ for ($num = $release - 1; $num >= 0; $num--)
 		if ($doNotPackageFile || $doNotPatchFile || $doNotPackageBaseFolder || $doNotPatchBaseFolder)
 		{
 			continue;
+		}
+		if (strpos($file, '.github') !== false) {
+			print_r('diffdocs/' . $version . '.' . $num);
+			print_r($command);
+			print_r([$fileName, $baseFolderName, $doNotPackageFile, $doNotPatch, $doNotPackageBaseFolder, $doNotPatchBaseFolder]);
+			die();
 		}
 
 		// Act on the file based on the action
@@ -414,5 +430,50 @@ foreach ($checksums as $packageName => $packageHashes)
 }
 
 file_put_contents('checksums.txt', $checksumsContent);
+
+echo "Generating github_release.txt file\n";
+
+$githubContent = array();
+$githubText = '';
+$releaseText = array(
+	'FULL' => 'New Joomla! Installations ',
+	'POINT' => 'Update from Joomla! ' . $version . '.' . $previousRelease . ' ',
+	'MINOR' => 'Update from Joomla! ' . $version . '.x ',
+	'UPGRADE' => 'Update from Joomla! 2.5 or previous 3.x releases ',
+);
+$githubLink = 'https://github.com/joomla/joomla-cms/releases/download/' . $tagVersion . '/';
+
+foreach ($checksums as $packageName => $packageHashes)
+{
+	$type = '';
+	if (strpos($packageName, 'Full_Package') !== false)
+	{
+		$type = 'FULL';
+	} elseif (strpos($packageName, 'Patch_Package') !== false) {
+		if (strpos($packageName, '.x_to') !== false) {
+			$type = 'MINOR';
+		} else {
+			$type = 'POINT';
+		}
+	} elseif (strpos($packageName, 'Update_Package') !== false) {
+		$type = 'UPGRADE';
+	}
+
+	$githubContent[$type][] = '[' . substr($packageName, strpos($packageName, 'Package') + 7) . '](' . $githubLink . $packageName . ')';
+}
+
+foreach($releaseText as $type => $text)
+{
+	if (empty($githubContent[$type])) {
+		continue;
+	}
+
+	$githubText .= $text;
+	$githubText .= implode(" | ", $githubContent[$type]);
+
+	$githubText .= "\n";
+}
+
+file_put_contents('github_release.txt', $githubText);
 
 echo "Build of version $fullVersion complete!\n";


### PR DESCRIPTION
### Summary of Changes
While packaging patch releases renamed files didn't get filtered. That's the reason why .github/SECURITY.md is shipped with the last Joomla! release.

This is fixed in this PR, also we remove `.github/SECURITY.md` but not the directory because I'm unsure if we do more harm then good if we simple delete the directory.

Additionally the build script generates a github release template.

### Testing Instructions
Build joomla with `build/build.php` this will generate the release files in `build/tmp/packages` 
The generated template is "only" interesting for Release Leads but can be found in `build/tmp/github_release.txt`

### Actual result BEFORE applying this Pull Request
Package includes a `.github/SECURITY.md` in update packages.


### Expected result AFTER applying this Pull Request
Package does not include a `.github` directory in update packages but all other files are the same as before.

