### PR TITLE
Fix Table\User:store($updateNulls = true to false) fixes #30107

### DIFF
--- a/libraries/src/Table/User.php
+++ b/libraries/src/Table/User.php
@@ -336,7 +336,7 @@ class User extends Table
 	 *
 	 * @since   1.7.0
 	 */
-	public function store($updateNulls = true)
+	public function store($updateNulls = false)
 	{
 		// Get the table key and key value.
 		$k = $this->_tbl_key;


### PR DESCRIPTION
Pull Request for Issue #30107 .

### Summary of Changes

Makes Table\User:store($updateNulls = false) instead of true by default.
This makes it OO-definitions compatible with its parent-classes Table and TableInterface definitions.

### Testing Instructions

Edit, update and save user in front-end and admin area, keeping password unchanged, and changing password, it should work fine as before.

### Actual result BEFORE applying this Pull Request

Works fine in Joomla. (But breaks CB for Joomla 4.0 dev version)

### Expected result AFTER applying this Pull Request

Works fine in Joomla.

### Documentation Changes Required

None.
