### PR TITLE
Remove unneeded strings from robots parameter

### DIFF
--- a/administrator/components/com_categories/models/forms/category.xml
+++ b/administrator/components/com_categories/models/forms/category.xml
@@ -295,10 +295,10 @@
 				description="JFIELD_METADATA_ROBOTS_DESC"
 				>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
-				<option value="index, follow">JGLOBAL_INDEX_FOLLOW</option>
-				<option value="noindex, follow">JGLOBAL_NOINDEX_FOLLOW</option>
-				<option value="index, nofollow">JGLOBAL_INDEX_NOFOLLOW</option>
-				<option value="noindex, nofollow">JGLOBAL_NOINDEX_NOFOLLOW</option>
+				<option value="index, follow"></option>
+				<option value="noindex, follow"></option>
+				<option value="index, nofollow"></option>
+				<option value="noindex, nofollow"></option>
 			</field>
 		</fieldset>
 	</fields>

--- a/administrator/components/com_config/model/form/application.xml
+++ b/administrator/components/com_config/model/form/application.xml
@@ -697,10 +697,10 @@
 			description="JFIELD_METADATA_ROBOTS_DESC"
 			default=""
 			>
-			<option value="">JGLOBAL_INDEX_FOLLOW</option>
-			<option value="noindex, follow">JGLOBAL_NOINDEX_FOLLOW</option>
-			<option value="index, nofollow">JGLOBAL_INDEX_NOFOLLOW</option>
-			<option value="noindex, nofollow">JGLOBAL_NOINDEX_NOFOLLOW</option>
+			<option value="">index, follow</option>
+			<option value="noindex, follow"></option>
+			<option value="index, nofollow"></option>
+			<option value="noindex, nofollow"></option>
 		</field>
 
 		<field

--- a/administrator/components/com_contact/models/forms/contact.xml
+++ b/administrator/components/com_contact/models/forms/contact.xml
@@ -944,10 +944,10 @@
 				description="JFIELD_METADATA_ROBOTS_DESC"
 				>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
-				<option value="index, follow">JGLOBAL_INDEX_FOLLOW</option>
-				<option value="noindex, follow">JGLOBAL_NOINDEX_FOLLOW</option>
-				<option value="index, nofollow">JGLOBAL_INDEX_NOFOLLOW</option>
-				<option value="noindex, nofollow">JGLOBAL_NOINDEX_NOFOLLOW</option>
+				<option value="index, follow"></option>
+				<option value="noindex, follow"></option>
+				<option value="index, nofollow"></option>
+				<option value="noindex, nofollow"></option>
 			</field>
 
 			<field

--- a/administrator/components/com_content/models/forms/article.xml
+++ b/administrator/components/com_content/models/forms/article.xml
@@ -1,40 +1,40 @@
 <?xml version="1.0" encoding="utf-8"?>
 <form>
 	<fieldset addfieldpath="/administrator/components/com_categories/models/fields" >
-		<field 
-			name="id" 
-			type="number" 
+		<field
+			name="id"
+			type="number"
 			label="JGLOBAL_FIELD_ID_LABEL"
-			description="JGLOBAL_FIELD_ID_DESC" 
-			class="readonly" 
-			size="10" 
+			description="JGLOBAL_FIELD_ID_DESC"
+			class="readonly"
+			size="10"
 			default="0"
-			readonly="true" 
+			readonly="true"
 		/>
 
-		<field 
-			name="asset_id" 
-			type="hidden" 
-			filter="unset" 
+		<field
+			name="asset_id"
+			type="hidden"
+			filter="unset"
 		/>
 
-		<field 
-			name="title" 
-			type="text" 
+		<field
+			name="title"
+			type="text"
 			label="JGLOBAL_TITLE"
 			description="JFIELD_TITLE_DESC"
 			class="input-xxlarge input-large-text"
 			size="40"
-			required="true" 
+			required="true"
 		/>
 
-		<field 
-			name="alias" 
-			type="text" 
+		<field
+			name="alias"
+			type="text"
 			label="JFIELD_ALIAS_LABEL"
 			description="JFIELD_ALIAS_DESC"
 			hint="JFIELD_ALIAS_PLACEHOLDER"
-			size="40" 
+			size="40"
 		/>
 
 		<field
@@ -47,9 +47,9 @@
 			maxlength="255"
 		/>
 
-		<field 
-			name="version_note" 
-			type="text" 
+		<field
+			name="version_note"
+			type="text"
 			label="JGLOBAL_FIELD_VERSION_NOTE_LABEL"
 			description="JGLOBAL_FIELD_VERSION_NOTE_DESC"
 			class="span12"
@@ -57,23 +57,23 @@
 			size="45"
 		/>
 
-		<field 
-			name="articletext" 
+		<field
+			name="articletext"
 			type="editor"
-			label="COM_CONTENT_FIELD_ARTICLETEXT_LABEL" 
+			label="COM_CONTENT_FIELD_ARTICLETEXT_LABEL"
 			description="COM_CONTENT_FIELD_ARTICLETEXT_DESC"
 			filter="JComponentHelper::filterText"
-			buttons="true" 
+			buttons="true"
 		/>
 
-		<field 
-			name="state" 
-			type="list" 
+		<field
+			name="state"
+			type="list"
 			label="JSTATUS"
-			description="JFIELD_PUBLISHED_DESC" 
+			description="JFIELD_PUBLISHED_DESC"
 			class="chzn-color-state"
-			filter="intval" 
-			size="1" 
+			filter="intval"
+			size="1"
 			default="1"
 			>
 			<option value="1">JPUBLISHED</option>
@@ -82,7 +82,7 @@
 			<option value="-2">JTRASHED</option>
 		</field>
 
-		<field 
+		<field
 			name="catid"
 			type="categoryedit"
 			label="JCATEGORY"
@@ -91,7 +91,7 @@
 			default=""
 		/>
 
-		<field 
+		<field
 			name="tags"
 			type="tag"
 			label="JTAG"
@@ -102,51 +102,51 @@
 
 		<field
 			name="buttonspacer"
-			type="spacer" 
+			type="spacer"
 			description="JGLOBAL_ACTION_PERMISSIONS_DESCRIPTION"
 		/>
 
-		<field 
-			name="created" 
-			type="calendar" 
+		<field
+			name="created"
+			type="calendar"
 			label="COM_CONTENT_FIELD_CREATED_LABEL"
 			description="COM_CONTENT_FIELD_CREATED_DESC"
 			translateformat="true"
 			showtime="true"
 			size="22"
-			filter="user_utc" 
+			filter="user_utc"
 		/>
 
-		<field 
-			name="created_by" 
+		<field
+			name="created_by"
 			type="user"
-			label="COM_CONTENT_FIELD_CREATED_BY_LABEL" 
-			description="COM_CONTENT_FIELD_CREATED_BY_DESC" 
+			label="COM_CONTENT_FIELD_CREATED_BY_LABEL"
+			description="COM_CONTENT_FIELD_CREATED_BY_DESC"
 		/>
 
-		<field 
-			name="created_by_alias" 
+		<field
+			name="created_by_alias"
 			type="text"
-			label="COM_CONTENT_FIELD_CREATED_BY_ALIAS_LABEL" 
+			label="COM_CONTENT_FIELD_CREATED_BY_ALIAS_LABEL"
 			description="COM_CONTENT_FIELD_CREATED_BY_ALIAS_DESC"
-			size="20" 
+			size="20"
 		/>
 
-		<field 
-			name="modified" 
-			type="calendar" 
-			label="JGLOBAL_FIELD_MODIFIED_LABEL" 
+		<field
+			name="modified"
+			type="calendar"
+			label="JGLOBAL_FIELD_MODIFIED_LABEL"
 			description="COM_CONTENT_FIELD_MODIFIED_DESC"
 			class="readonly"
 			translateformat="true"
 			showtime="true"
 			size="22"
 			readonly="true"
-			filter="user_utc" 
+			filter="user_utc"
 		/>
 
-		<field 
-			name="modified_by" 
+		<field
+			name="modified_by"
 			type="user"
 			label="JGLOBAL_FIELD_MODIFIED_BY_LABEL"
 			class="readonly"
@@ -154,19 +154,19 @@
 			filter="unset"
 		/>
 
-		<field 
-			name="checked_out" 
-			type="hidden" 
-			filter="unset" 
+		<field
+			name="checked_out"
+			type="hidden"
+			filter="unset"
 		/>
 
-		<field 
-			name="checked_out_time" 
-			type="hidden" 
-			filter="unset" 
+		<field
+			name="checked_out_time"
+			type="hidden"
+			filter="unset"
 		/>
 
-		<field 
+		<field
 			name="publish_up"
 			type="calendar"
 			label="COM_CONTENT_FIELD_PUBLISH_UP_LABEL"
@@ -174,10 +174,10 @@
 			translateformat="true"
 			showtime="true"
 			size="22"
-			filter="user_utc" 
+			filter="user_utc"
 		/>
 
-		<field 
+		<field
 			name="publish_down"
 			type="calendar"
 			label="COM_CONTENT_FIELD_PUBLISH_DOWN_LABEL"
@@ -185,77 +185,77 @@
 			translateformat="true"
 			showtime="true"
 			size="22"
-			filter="user_utc" 
+			filter="user_utc"
 		/>
 
 		<field
-			name="version" 
-			type="text" 
-			label="COM_CONTENT_FIELD_VERSION_LABEL" 
+			name="version"
+			type="text"
+			label="COM_CONTENT_FIELD_VERSION_LABEL"
 			description="COM_CONTENT_FIELD_VERSION_DESC"
-			size="6" 
-			class="readonly"
-			readonly="true" 
-			filter="unset" 
-		/>
-
-		<field 
-			name="ordering" 
-			type="text" 
-			label="JFIELD_ORDERING_LABEL"
-			description="JFIELD_ORDERING_DESC" 
 			size="6"
-			default="0" 
+			class="readonly"
+			readonly="true"
+			filter="unset"
 		/>
 
-		<field 
-			name="metakey" 
+		<field
+			name="ordering"
+			type="text"
+			label="JFIELD_ORDERING_LABEL"
+			description="JFIELD_ORDERING_DESC"
+			size="6"
+			default="0"
+		/>
+
+		<field
+			name="metakey"
 			type="textarea"
-			label="JFIELD_META_KEYWORDS_LABEL" 
+			label="JFIELD_META_KEYWORDS_LABEL"
 			description="JFIELD_META_KEYWORDS_DESC"
-			rows="3" 
+			rows="3"
 			cols="30"
 		/>
 
-		<field 
-			name="metadesc" 
+		<field
+			name="metadesc"
 			type="textarea"
-			label="JFIELD_META_DESCRIPTION_LABEL" 
+			label="JFIELD_META_DESCRIPTION_LABEL"
 			description="JFIELD_META_DESCRIPTION_DESC"
-			rows="3" 
-			cols="30" 
+			rows="3"
+			cols="30"
 		/>
 
-		<field 
-			name="access" 
-			type="accesslevel" 
+		<field
+			name="access"
+			type="accesslevel"
 			label="JFIELD_ACCESS_LABEL"
-			description="JFIELD_ACCESS_DESC" 
-			size="1" 
+			description="JFIELD_ACCESS_DESC"
+			size="1"
 		/>
 
-		<field 
-			name="hits" 
-			type="number" 
+		<field
+			name="hits"
+			type="number"
 			label="JGLOBAL_HITS"
-			description="COM_CONTENT_FIELD_HITS_DESC" 
-			class="readonly" 
+			description="COM_CONTENT_FIELD_HITS_DESC"
+			class="readonly"
 			size="6"
-			readonly="true" 
-			filter="unset" 
+			readonly="true"
+			filter="unset"
 		/>
 
-		<field 
-			name="language" 
-			type="contentlanguage" 
+		<field
+			name="language"
+			type="contentlanguage"
 			label="JFIELD_LANGUAGE_LABEL"
 			description="COM_CONTENT_FIELD_LANGUAGE_DESC"
 			>
 			<option value="*">JALL</option>
 		</field>
 
-		<field 
-			name="featured" 
+		<field
+			name="featured"
 			type="radio"
 			label="JFEATURED"
 			description="COM_CONTENT_FIELD_FEATURED_DESC"
@@ -266,14 +266,14 @@
 			<option value="0">JNO</option>
 		</field>
 
-		<field 
-			name="rules" 
-			type="rules" 
+		<field
+			name="rules"
+			type="rules"
 			label="JFIELD_RULES_LABEL"
-			translate_label="false" 
+			translate_label="false"
 			filter="rules"
-			component="com_content" 
-			section="article" 
+			component="com_content"
+			section="article"
 			validate="rules"
 		/>
 
@@ -282,13 +282,13 @@
 	<fields name="attribs" label="COM_CONTENT_ATTRIBS_FIELDSET_LABEL">
 		<fieldset name="basic" label="COM_CONTENT_ATTRIBS_FIELDSET_LABEL">
 
-			<field 
-				name="article_layout" 
+			<field
+				name="article_layout"
 				type="componentlayout"
 				label="JFIELD_ALT_LAYOUT_LABEL"
 				description="JFIELD_ALT_COMPONENT_LAYOUT_DESC"
 				useglobal="true"
-				extension="com_content" 
+				extension="com_content"
 				view="article"
 			/>
 
@@ -316,7 +316,7 @@
 				<option value="1">JYES</option>
 			</field>
 
-			<field 
+			<field
 				name="show_tags"
 				type="list"
 				label="COM_CONTENT_FIELD_SHOW_TAGS_LABEL"
@@ -328,7 +328,7 @@
 				<option value="0">JHIDE</option>
 			</field>
 
-			<field 
+			<field
 				name="show_intro"
 				type="list"
 				label="JGLOBAL_SHOW_INTRO_LABEL"
@@ -586,20 +586,20 @@
 				hr="true"
 			/>
 
-			<field 
-				name="alternative_readmore" 
+			<field
+				name="alternative_readmore"
 				type="text"
 				label="JFIELD_READMORE_LABEL"
 				description="JFIELD_READMORE_DESC"
-				size="25" 
+				size="25"
 			/>
 
-			<field 
-				name="article_page_title" 
+			<field
+				name="article_page_title"
 				type="text"
 				label="COM_CONTENT_FIELD_BROWSER_PAGE_TITLE_LABEL"
 				description="COM_CONTENT_FIELD_BROWSER_PAGE_TITLE_DESC"
-				size="25" 
+				size="25"
 			/>
 		</fieldset>
 
@@ -672,7 +672,7 @@
 				description="JGLOBAL_LINKED_TITLES_DESC"
 			/>
 
-			<field 
+			<field
 				name="show_intro"
 				type="hidden"
 				label="JGLOBAL_SHOW_INTRO_LABEL"
@@ -791,16 +791,16 @@
 				description="JGLOBAL_SHOW_UNAUTH_LINKS_DESC"
 			/>
 
-			<field 
-				name="alternative_readmore" 
+			<field
+				name="alternative_readmore"
 				type="hidden"
 				label="JFIELD_READMORE_LABEL"
 				description="JFIELD_READMORE_DESC"
-				size="25" 
+				size="25"
 			/>
 
-			<field 
-				name="article_layout" 
+			<field
+				name="article_layout"
 				type="hidden"
 				label="JFIELD_ALT_LAYOUT_LABEL"
 				description="JFIELD_ALT_COMPONENT_LAYOUT_DESC"
@@ -810,12 +810,12 @@
 		</fieldset>
 	</fields>
 
-	<field 
-		name="xreference" 
+	<field
+		name="xreference"
 		type="text"
 		label="JFIELD_KEY_REFERENCE_LABEL"
 		description="JFIELD_KEY_REFERENCE_DESC"
-		size="20" 
+		size="20"
 	/>
 
 	<fields name="images" label="COM_CONTENT_FIELD_IMAGE_OPTIONS">
@@ -823,9 +823,9 @@
 			name="image_intro"
 			type="media"
 			label="COM_CONTENT_FIELD_INTRO_LABEL"
-			description="COM_CONTENT_FIELD_INTRO_DESC" 
+			description="COM_CONTENT_FIELD_INTRO_DESC"
 		/>
-		
+
 		<field
 			name="float_intro"
 			type="list"
@@ -837,8 +837,8 @@
 			<option value="left">COM_CONTENT_LEFT</option>
 			<option value="none">COM_CONTENT_NONE</option>
 		</field>
-		
-		<field 
+
+		<field
 			name="image_intro_alt"
 			type="text"
 			label="COM_CONTENT_FIELD_IMAGE_ALT_LABEL"
@@ -846,7 +846,7 @@
 			size="20"
 		/>
 
-		<field 
+		<field
 			name="image_intro_caption"
 			type="text"
 			label="COM_CONTENT_FIELD_IMAGE_CAPTION_LABEL"
@@ -879,15 +879,15 @@
 			<option value="none">COM_CONTENT_NONE</option>
 		</field>
 
-		<field 
+		<field
 			name="image_fulltext_alt"
 			type="text"
 			label="COM_CONTENT_FIELD_IMAGE_ALT_LABEL"
 			description="COM_CONTENT_FIELD_IMAGE_ALT_DESC"
 			size="20"
 		/>
-			
-		<field 
+
+		<field
 			name="image_fulltext_caption"
 			type="text"
 			label="COM_CONTENT_FIELD_IMAGE_CAPTION_LABEL"
@@ -906,7 +906,7 @@
 			relative="true"
 		/>
 
-		<field 
+		<field
 			name="urlatext"
 			type="text"
 			label="COM_CONTENT_FIELD_URLA_LINK_TEXT_LABEL"
@@ -945,7 +945,7 @@
 			relative="true"
 		/>
 
-		<field 
+		<field
 			name="urlbtext"
 			type="text"
 			label="COM_CONTENT_FIELD_URLB_LINK_TEXT_LABEL"
@@ -1013,57 +1013,57 @@
 		<fieldset name="jmetadata"
 			label="JGLOBAL_FIELDSET_METADATA_OPTIONS">
 
-			<field 
+			<field
 				name="robots"
 				type="list"
 				label="JFIELD_METADATA_ROBOTS_LABEL"
 				description="JFIELD_METADATA_ROBOTS_DESC"
 				>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
-				<option value="index, follow">JGLOBAL_INDEX_FOLLOW</option>
-				<option value="noindex, follow">JGLOBAL_NOINDEX_FOLLOW</option>
-				<option value="index, nofollow">JGLOBAL_INDEX_NOFOLLOW</option>
-				<option value="noindex, nofollow">JGLOBAL_NOINDEX_NOFOLLOW</option>
+				<option value="index, follow"></option>
+				<option value="noindex, follow"></option>
+				<option value="index, nofollow"></option>
+				<option value="noindex, nofollow"></option>
 			</field>
 
-			<field 
-				name="author" 
+			<field
+				name="author"
 				type="text"
 				label="JAUTHOR"
 				description="JFIELD_METADATA_AUTHOR_DESC"
-				size="20" 
+				size="20"
 			/>
 
-			<field 
-				name="rights" 
-				type="textarea" 
+			<field
+				name="rights"
+				type="textarea"
 				label="JFIELD_META_RIGHTS_LABEL"
-				description="JFIELD_META_RIGHTS_DESC" 
+				description="JFIELD_META_RIGHTS_DESC"
 				filter="string"
-				cols="30" 
-				rows="2" 
+				cols="30"
+				rows="2"
 			/>
 
-			<field 
-				name="xreference" 
+			<field
+				name="xreference"
 				type="text"
 				label="COM_CONTENT_FIELD_XREFERENCE_LABEL"
 				description="COM_CONTENT_FIELD_XREFERENCE_DESC"
-				size="20" 
+				size="20"
 			/>
 
 		</fieldset>
 	</fields>
 	<!-- These fields are used to get labels for the Content History Preview and Compare Views -->
 	<fields>
-		<field 
-			name="introtext" 
-			label="COM_CONTENT_FIELD_INTROTEXT" 
+		<field
+			name="introtext"
+			label="COM_CONTENT_FIELD_INTROTEXT"
 		/>
 
-		<field 
-			name="fulltext" 
-			label="COM_CONTENT_FIELD_FULLTEXT" 
+		<field
+			name="fulltext"
+			label="COM_CONTENT_FIELD_FULLTEXT"
 		/>
 	</fields>
 

--- a/administrator/components/com_menus/models/forms/item_component.xml
+++ b/administrator/components/com_menus/models/forms/item_component.xml
@@ -4,36 +4,36 @@
 	>
 		<fieldset name="menu-options" label="COM_MENUS_LINKTYPE_OPTIONS_LABEL">
 
-			<field 
-				name="menu-anchor_title" 
+			<field
+				name="menu-anchor_title"
 				type="text"
 				label="COM_MENUS_ITEM_FIELD_ANCHOR_TITLE_LABEL"
-				description="COM_MENUS_ITEM_FIELD_ANCHOR_TITLE_DESC" 
-			/>
-
-			<field 
-				name="menu-anchor_css" 
-				type="text"
-				label="COM_MENUS_ITEM_FIELD_ANCHOR_CSS_LABEL"
-				description="COM_MENUS_ITEM_FIELD_ANCHOR_CSS_DESC" 
+				description="COM_MENUS_ITEM_FIELD_ANCHOR_TITLE_DESC"
 			/>
 
 			<field
-				name="menu_image" 
+				name="menu-anchor_css"
+				type="text"
+				label="COM_MENUS_ITEM_FIELD_ANCHOR_CSS_LABEL"
+				description="COM_MENUS_ITEM_FIELD_ANCHOR_CSS_DESC"
+			/>
+
+			<field
+				name="menu_image"
 				type="media"
 				label="COM_MENUS_ITEM_FIELD_MENU_IMAGE_LABEL"
-				description="COM_MENUS_ITEM_FIELD_MENU_IMAGE_DESC" 
+				description="COM_MENUS_ITEM_FIELD_MENU_IMAGE_DESC"
 			/>
 
-			<field 
+			<field
 				name="menu_image_css"
-				type="text" 
+				type="text"
 				label="COM_MENUS_ITEM_FIELD_MENU_IMAGE_CSS_LABEL"
-				description="COM_MENUS_ITEM_FIELD_MENU_IMAGE_CSS_DESC" 
+				description="COM_MENUS_ITEM_FIELD_MENU_IMAGE_CSS_DESC"
 			/>
 
-			<field 
-				name="menu_text" 
+			<field
+				name="menu_text"
 				type="radio"
 				label="COM_MENUS_ITEM_FIELD_MENU_TEXT_LABEL"
 				description="COM_MENUS_ITEM_FIELD_MENU_TEXT_DESC"
@@ -98,43 +98,43 @@
 		</fieldset>
 
 		<fieldset name="metadata" label="JGLOBAL_FIELDSET_METADATA_OPTIONS">
-			<field 
-				name="menu-meta_description" 
+			<field
+				name="menu-meta_description"
 				type="textarea"
-				label="JFIELD_META_DESCRIPTION_LABEL" 
+				label="JFIELD_META_DESCRIPTION_LABEL"
 				description="JFIELD_META_DESCRIPTION_DESC"
-				rows="3" 
-				cols="40" 
+				rows="3"
+				cols="40"
 			/>
 
-			<field 
-				name="menu-meta_keywords" 
+			<field
+				name="menu-meta_keywords"
 				type="textarea"
-				label="JFIELD_META_KEYWORDS_LABEL" 
+				label="JFIELD_META_KEYWORDS_LABEL"
 				description="JFIELD_META_KEYWORDS_DESC"
-				rows="3" 
-				cols="40" 
+				rows="3"
+				cols="40"
 			/>
 
-			<field 
+			<field
 				name="robots"
 				type="list"
 				label="JFIELD_METADATA_ROBOTS_LABEL"
 				description="JFIELD_METADATA_ROBOTS_DESC"
 				>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
-				<option value="index, follow">JGLOBAL_INDEX_FOLLOW</option>
-				<option value="noindex, follow">JGLOBAL_NOINDEX_FOLLOW</option>
-				<option value="index, nofollow">JGLOBAL_INDEX_NOFOLLOW</option>
-				<option value="noindex, nofollow">JGLOBAL_NOINDEX_NOFOLLOW</option>
+				<option value="index, follow"></option>
+				<option value="noindex, follow"></option>
+				<option value="index, nofollow"></option>
+				<option value="noindex, nofollow"></option>
 			</field>
 
-			<field 
-				name="secure" 
+			<field
+				name="secure"
 				type="list"
-				label="COM_MENUS_ITEM_FIELD_SECURE_LABEL" 
+				label="COM_MENUS_ITEM_FIELD_SECURE_LABEL"
 				description="COM_MENUS_ITEM_FIELD_SECURE_DESC"
-				default="0" 
+				default="0"
 				filter="integer"
 				>
 				<option value="-1">JOFF</option>

--- a/administrator/components/com_newsfeeds/models/forms/newsfeed.xml
+++ b/administrator/components/com_newsfeeds/models/forms/newsfeed.xml
@@ -463,10 +463,10 @@
 				description="JFIELD_METADATA_ROBOTS_DESC"
 				>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
-				<option value="index, follow">JGLOBAL_INDEX_FOLLOW</option>
-				<option value="noindex, follow">JGLOBAL_NOINDEX_FOLLOW</option>
-				<option value="index, nofollow">JGLOBAL_INDEX_NOFOLLOW</option>
-				<option value="noindex, nofollow">JGLOBAL_NOINDEX_NOFOLLOW</option>
+				<option value="index, follow"></option>
+				<option value="noindex, follow"></option>
+				<option value="index, nofollow"></option>
+				<option value="noindex, nofollow"></option>
 			</field>
 
 			<field

--- a/administrator/components/com_tags/models/forms/tag.xml
+++ b/administrator/components/com_tags/models/forms/tag.xml
@@ -357,10 +357,10 @@
 				description="JFIELD_METADATA_ROBOTS_DESC"
 				>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
-				<option value="index, follow">JGLOBAL_INDEX_FOLLOW</option>
-				<option value="noindex, follow">JGLOBAL_NOINDEX_FOLLOW</option>
-				<option value="index, nofollow">JGLOBAL_INDEX_NOFOLLOW</option>
-				<option value="noindex, nofollow">JGLOBAL_NOINDEX_NOFOLLOW</option>
+				<option value="index, follow"></option>
+				<option value="noindex, follow"></option>
+				<option value="index, nofollow"></option>
+				<option value="noindex, nofollow"></option>
 			</field>
 		</fieldset>
 	</fields>

--- a/administrator/language/en-GB/en-GB.ini
+++ b/administrator/language/en-GB/en-GB.ini
@@ -429,9 +429,9 @@ JGLOBAL_HISTORY_LIMIT_OPTIONS_LABEL="Maximum Versions"
 JGLOBAL_HITS="Hits"
 JGLOBAL_HITS_ASC="Hits ascending"
 JGLOBAL_HITS_DESC="Hits descending"
-; Please do not translate the following language string
+; Deprecated, will be removed with 4.0. Please do not translate the following language string
 JGLOBAL_INDEX_FOLLOW="index, follow"
-; Please do not translate the following language string
+; Deprecated, will be removed with 4.0. Please do not translate the following language string
 JGLOBAL_INDEX_NOFOLLOW="index, nofollow"
 JGLOBAL_INHERIT="Inherit"
 JGLOBAL_INTEGRATION_LABEL="Integration"
@@ -485,9 +485,9 @@ JGLOBAL_NEWITEMSFIRST_DESC="New items default to the first position. The orderin
 JGLOBAL_NEWITEMSLAST_DESC="New items default to the last position. The ordering can be changed after this item is saved."
 JGLOBAL_NO_ITEM_SELECTED="No items selected"
 JGLOBAL_NO_ORDER="No Order"
-; Please do not translate the following language string
+; Deprecated, will be removed with 4.0. Please do not translate the following language string
 JGLOBAL_NOINDEX_FOLLOW="noindex, follow"
-; Please do not translate the following language string
+; Deprecated, will be removed with 4.0. Please do not translate the following language string
 JGLOBAL_NOINDEX_NOFOLLOW="noindex, nofollow"
 JGLOBAL_NONAPPLICABLE="N/A"
 JGLOBAL_NUM_COLUMNS_DESC="The number of columns in which to show Intro Articles. Normally 1, 2, or 3."

--- a/components/com_contact/models/forms/form.xml
+++ b/components/com_contact/models/forms/form.xml
@@ -319,10 +319,10 @@
 				description="JFIELD_METADATA_ROBOTS_DESC"
 				>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
-				<option value="index, follow">JGLOBAL_INDEX_FOLLOW</option>
-				<option value="noindex, follow">JGLOBAL_NOINDEX_FOLLOW</option>
-				<option value="index, nofollow">JGLOBAL_INDEX_NOFOLLOW</option>
-				<option value="noindex, nofollow">JGLOBAL_NOINDEX_NOFOLLOW</option>
+				<option value="index, follow"></option>
+				<option value="noindex, follow"></option>
+				<option value="index, nofollow"></option>
+				<option value="noindex, nofollow"></option>
 			</field>
 
 			<field


### PR DESCRIPTION
Based on some discussions (see https://github.com/joomla/joomla-cms/issues/29595#issuecomment-658676605) initiated by a translator I'm proposing to completely remove the usage of the following strings and deprecated them.
````
JGLOBAL_INDEX_FOLLOW="Index, follow"
JGLOBAL_INDEX_NOFOLLOW="Index, no follow"
JGLOBAL_NOINDEX_FOLLOW="No index, follow"
JGLOBAL_NOINDEX_NOFOLLOW="No index, no follow"
````

In J4 they can be removed completely.

Reason is that they are now marked as "not to translate". But if a complete string shouldn't be translated, it doesn't make sense to have them as language strings to begin with.

### Summary of Changes
Removing the strings from the XML. Instead the list will now directly show the value.
Deprecating the strings so they can still be used by 3rd parties but will get removed with J4.

The global configuration is a bit different since for some reason the first option is currently an empty value (`<option value="">JGLOBAL_INDEX_FOLLOW</option>)`. I've changed that to `<option value="">index, follow</option>` so the behavior is the same.


### Testing Instructions
Check the robots parameters in the global configuration and the various other places (eg category, article, contact, ...)

No difference before and after the PR.

### Documentation Changes Required
None