### PR TITLE
[com_messages] Validate message and user ID

### DIFF
--- a/administrator/components/com_messages/models/message.php
+++ b/administrator/components/com_messages/models/message.php
@@ -140,7 +140,7 @@ class MessagesModelMessage extends JModelAdmin
 						// If replying to a message, preload some data.
 						$db    = $this->getDbo();
 						$query = $db->getQuery(true)
-							->select($db->quoteName(array('subject', 'user_id_from')))
+							->select($db->quoteName(array('subject', 'user_id_from', 'user_id_to')))
 							->from($db->quoteName('#__messages'))
 							->where($db->quoteName('message_id') . ' = ' . (int) $replyId);
 
@@ -155,12 +155,19 @@ class MessagesModelMessage extends JModelAdmin
 							return false;
 						}
 
+						if (!$message || $message->user_id_to != JFactory::getUser()->id)
+						{
+							$this->setError(JText::_('JERROR_ALERTNOAUTHOR'));
+
+							return false;
+						}
+
 						$this->item->set('user_id_to', $message->user_id_from);
 						$re = JText::_('COM_MESSAGES_RE');
 
 						if (stripos($message->subject, $re) !== 0)
 						{
-							$this->item->set('subject', $re . $message->subject);
+							$this->item->set('subject', $re . ' ' . $message->subject);
 						}
 					}
 				}


### PR DESCRIPTION
Pull Request for Issue #29562.

### Summary of Changes
Check message exists and compare user_id to ensure there is a message sent to the user to reply to.
Add space before subject in reply.

### Testing Instructions
Fake a reply_id:
`/administrator/index.php?option=com_messages&view=message&layout=edit&reply_id=666999666`


### Actual result BEFORE applying this Pull Request
Enable `Maximum` in Error Reporting.
Check PHP error log.

> PHP Notice:  Trying to get property 'user_id_from' of non-object in \administrator\components\com_messages\models\message.php on line 158
PHP Notice:  Trying to get property 'subject' of non-object in \administrator\components\com_messages\models\message.php on line 161
PHP Notice:  Trying to get property 'subject' of non-object in \administrator\components\com_messages\models\message.php on line 163



### Expected result AFTER applying this Pull Request
```
An error message
500 You are not authorised to view this resource. 
```
