### PR TITLE
[com_messages] Validate message before display

### DIFF
--- a/administrator/components/com_messages/models/message.php
+++ b/administrator/components/com_messages/models/message.php
@@ -131,7 +131,7 @@ class MessagesModelMessage extends JModelAdmin
 		{
 			if ($this->item = parent::getItem($pk))
 			{
-				// Invalid message_id or no access to message returns 0
+				// Invalid message_id returns 0
 				if ($this->item->user_id_to === '0')
 				{
 					$this->setError(JText::_('JERROR_ALERTNOAUTHOR'));

--- a/administrator/components/com_messages/models/message.php
+++ b/administrator/components/com_messages/models/message.php
@@ -131,6 +131,14 @@ class MessagesModelMessage extends JModelAdmin
 		{
 			if ($this->item = parent::getItem($pk))
 			{
+				// Invalid message_id or no access to message returns 0
+				if ($this->item->user_id_to === '0')
+				{
+					$this->setError(JText::_('JERROR_ALERTNOAUTHOR'));
+
+					return false;
+				}
+
 				// Prime required properties.
 				if (empty($this->item->message_id))
 				{


### PR DESCRIPTION
Pull Request for Issue #29532.

### Summary of Changes
Check message exists before display message.


### Testing Instructions
Fake message id that doesn't exist:
`/administrator/index.php?option=com_messages&view=message&message_id=1000000`


### Actual result BEFORE applying this Pull Request
Blank form.



### Expected result AFTER applying this Pull Request
```
An error message
500 You are not authorised to view this resource. 
```
