### PR TITLE
[4.0] Use null coalescing operator where applicable

### DIFF
--- a/components/com_content/src/Helper/QueryHelper.php
+++ b/components/com_content/src/Helper/QueryHelper.php
@@ -69,7 +69,7 @@ class QueryHelper
 	 */
 	public static function orderbySecondary($orderby, $orderDate = 'created', DatabaseInterface $db = null)
 	{
-		$db = $db ?: Factory::getDbo();
+		$db = $db ?? Factory::getDbo();
 
 		$queryDate = self::getQueryDate($orderDate, $db);
 
@@ -179,7 +179,7 @@ class QueryHelper
 	 */
 	public static function getQueryDate($orderDate, DatabaseInterface $db = null)
 	{
-		$db = $db ?: Factory::getDbo();
+		$db = $db ?? Factory::getDbo();
 
 		switch ($orderDate)
 		{

--- a/libraries/src/Application/BaseApplication.php
+++ b/libraries/src/Application/BaseApplication.php
@@ -42,8 +42,8 @@ abstract class BaseApplication extends AbstractApplication implements Dispatcher
 	 */
 	public function __construct(Input $input = null, Registry $config = null)
 	{
-		$this->input = $input instanceof Input ? $input : new Input;
-		$this->config = $config instanceof Registry ? $config : new Registry;
+		$this->input  = $input ?? new Input;
+		$this->config = $config ?? new Registry;
 
 		$this->initialise();
 	}

--- a/libraries/src/Application/CLI/CliOutput.php
+++ b/libraries/src/Application/CLI/CliOutput.php
@@ -37,7 +37,7 @@ abstract class CliOutput
 	 */
 	public function __construct(ProcessorInterface $processor = null)
 	{
-		$this->setProcessor($processor ?: new Output\Processor\ColorProcessor);
+		$this->setProcessor($processor ?? new Output\Processor\ColorProcessor);
 	}
 
 	/**

--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -144,7 +144,7 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
 	 */
 	public function __construct(Input $input = null, Registry $config = null, WebClient $client = null, Container $container = null)
 	{
-		$container = $container ?: new Container;
+		$container = $container ?? new Container;
 		$this->setContainer($container);
 
 		parent::__construct($input, $config, $client);

--- a/libraries/src/Application/CliApplication.php
+++ b/libraries/src/Application/CliApplication.php
@@ -114,13 +114,13 @@ abstract class CliApplication extends AbstractApplication implements DispatcherA
 			$this->close();
 		}
 
-		$container = $container ?: Factory::getContainer();
+		$container = $container ?? Factory::getContainer();
 		$this->setContainer($container);
 
 		$this->input    = new \Joomla\CMS\Input\Cli;
 		$this->language = Factory::getLanguage();
-		$this->output   = $output ?: new Stdout;
-		$this->cliInput = $cliInput ?: new CliInput;
+		$this->output   = $output ?? new Stdout;
+		$this->cliInput = $cliInput ?? new CliInput;
 
 		if ($dispatcher)
 		{

--- a/libraries/src/Application/IdentityAware.php
+++ b/libraries/src/Application/IdentityAware.php
@@ -59,7 +59,7 @@ trait IdentityAware
 	 */
 	public function loadIdentity(User $identity = null)
 	{
-		$this->identity = $identity ?: $this->userFactory->loadUserById(0);
+		$this->identity = $identity ?? $this->userFactory->loadUserById(0);
 
 		return $this;
 	}

--- a/libraries/src/Application/WebApplication.php
+++ b/libraries/src/Application/WebApplication.php
@@ -79,7 +79,7 @@ abstract class WebApplication extends AbstractWebApplication
 	public function __construct(Input $input = null, Registry $config = null, WebClient $client = null, ResponseInterface $response = null)
 	{
 		// Ensure we have a CMS Input object otherwise the DI for \Joomla\CMS\Session\Storage\JoomlaStorage fails
-		$input = $input ?: new Input;
+		$input = $input ?? new Input;
 
 		parent::__construct($input, $config, $client, $response);
 

--- a/libraries/src/Dispatcher/ComponentDispatcherFactory.php
+++ b/libraries/src/Dispatcher/ComponentDispatcherFactory.php
@@ -81,6 +81,6 @@ class ComponentDispatcherFactory implements ComponentDispatcherFactoryInterface
 			}
 		}
 
-		return new $className($application, $input ?: $application->input, $this->mvcFactory);
+		return new $className($application, $input ?? $application->input, $this->mvcFactory);
 	}
 }

--- a/libraries/src/Dispatcher/ModuleDispatcherFactory.php
+++ b/libraries/src/Dispatcher/ModuleDispatcherFactory.php
@@ -68,6 +68,6 @@ class ModuleDispatcherFactory implements ModuleDispatcherFactoryInterface
 			$className = ModuleDispatcher::class;
 		}
 
-		return new $className($module, $application, $input ?: $application->input);
+		return new $className($module, $application, $input ?? $application->input);
 	}
 }

--- a/libraries/src/Document/PreloadManager.php
+++ b/libraries/src/Document/PreloadManager.php
@@ -38,7 +38,7 @@ class PreloadManager implements PreloadManagerInterface
 	 */
 	public function __construct(EvolvableLinkProviderInterface $linkProvider = null)
 	{
-		$this->linkProvider = $linkProvider ?: new GenericLinkProvider;
+		$this->linkProvider = $linkProvider ?? new GenericLinkProvider;
 	}
 
 	/**

--- a/libraries/src/Language/Multilanguage.php
+++ b/libraries/src/Language/Multilanguage.php
@@ -52,7 +52,7 @@ class Multilanguage
 		}
 
 		// Get application object.
-		$app = $app ?: Factory::getApplication();
+		$app = $app ?? Factory::getApplication();
 
 		// If being called from the frontend, we can avoid the database query.
 		if ($app->isClient('site'))
@@ -66,7 +66,7 @@ class Multilanguage
 		if (!$tested)
 		{
 			// Determine status of language filter plugin.
-			$db    = $db ?: Factory::getDbo();
+			$db    = $db ?? Factory::getDbo();
 			$query = $db->getQuery(true)
 				->select($db->quoteName('enabled'))
 				->from($db->quoteName('#__extensions'))
@@ -103,7 +103,7 @@ class Multilanguage
 		if (!isset($multilangSiteHomePages))
 		{
 			// Check for Home pages languages.
-			$db    = $db ?: Factory::getDbo();
+			$db    = $db ?? Factory::getDbo();
 			$query = $db->getQuery(true)
 				->select(
 					[

--- a/libraries/src/MVC/Controller/BaseController.php
+++ b/libraries/src/MVC/Controller/BaseController.php
@@ -374,8 +374,8 @@ class BaseController implements ControllerInterface
 		$this->redirect = null;
 		$this->taskMap = array();
 
-		$this->app   = $app ? $app : Factory::getApplication();
-		$this->input = $input ? $input : $this->app->input;
+		$this->app   = $app ?? Factory::getApplication();
+		$this->input = $input ?? $this->app->input;
 
 		if (\defined('JDEBUG') && JDEBUG)
 		{
@@ -482,7 +482,7 @@ class BaseController implements ControllerInterface
 			$this->default_view = $this->getName();
 		}
 
-		$this->factory = $factory ? : new LegacyFactory;
+		$this->factory = $factory ?? new LegacyFactory;
 	}
 
 	/**

--- a/libraries/src/Pagination/Pagination.php
+++ b/libraries/src/Pagination/Pagination.php
@@ -126,7 +126,7 @@ class Pagination
 		$this->limitstart = (int) max($limitstart, 0);
 		$this->limit = (int) max($limit, 0);
 		$this->prefix = $prefix;
-		$this->app = $app ?: Factory::getApplication();
+		$this->app = $app ?? Factory::getApplication();
 
 		if ($this->limit > $this->total)
 		{

--- a/libraries/src/Pathway/SitePathway.php
+++ b/libraries/src/Pathway/SitePathway.php
@@ -32,7 +32,7 @@ class SitePathway extends Pathway
 	{
 		$this->pathway = array();
 
-		$app  = $app ?: Factory::getContainer()->get(SiteApplication::class);
+		$app  = $app ?? Factory::getContainer()->get(SiteApplication::class);
 		$menu = $app->getMenu();
 		$lang = Factory::getLanguage();
 

--- a/libraries/src/Plugin/PluginHelper.php
+++ b/libraries/src/Plugin/PluginHelper.php
@@ -162,7 +162,7 @@ abstract class PluginHelper
 		}
 
 		// Ensure we have a dispatcher now so we can correctly track the loaded plugins
-		$dispatcher = $dispatcher ?: Factory::getApplication()->getDispatcher();
+		$dispatcher = $dispatcher ?? Factory::getApplication()->getDispatcher();
 
 		// Get the dispatcher's hash to allow plugins to be registered to unique dispatchers
 		$dispatcherHash = spl_object_hash($dispatcher);

--- a/libraries/src/Router/SiteRouter.php
+++ b/libraries/src/Router/SiteRouter.php
@@ -60,8 +60,8 @@ class SiteRouter extends Router
 	 */
 	public function __construct(CMSApplication $app = null, AbstractMenu $menu = null)
 	{
-		$this->app  = $app ?: Factory::getContainer()->get(SiteApplication::class);
-		$this->menu = $menu ?: $this->app->getMenu();
+		$this->app  = $app ?? Factory::getContainer()->get(SiteApplication::class);
+		$this->menu = $menu ?? $this->app->getMenu();
 
 		// Add core rules
 		if ($this->app->get('force_ssl') === 2)

--- a/libraries/src/UCM/UCMBase.php
+++ b/libraries/src/UCM/UCMBase.php
@@ -52,7 +52,7 @@ class UCMBase implements UCM
 		$input = Factory::getApplication()->input;
 		$this->alias = $alias ?: $input->get('option') . '.' . $input->get('view');
 
-		$this->type = $type ?: $this->getType();
+		$this->type = $type ?? $this->getType();
 	}
 
 	/**
@@ -132,7 +132,7 @@ class UCMBase implements UCM
 	 */
 	public function mapBase($original, UCMType $type = null)
 	{
-		$type = $type ?: $this->type;
+		$type = $type ?? $this->type;
 
 		$data = array(
 			'ucm_type_id' => $type->id,

--- a/libraries/src/UCM/UCMContent.php
+++ b/libraries/src/UCM/UCMContent.php
@@ -75,7 +75,7 @@ class UCMContent extends UCMBase
 	 */
 	public function save($original = null, UCMType $type = null)
 	{
-		$type    = $type ?: $this->type;
+		$type    = $type ?? $this->type;
 		$ucmData = $original ? $this->mapData($original, $type) : $this->ucmData;
 
 		// Store the Common fields
@@ -104,7 +104,7 @@ class UCMContent extends UCMBase
 	public function delete($pk, UCMType $type = null)
 	{
 		$db   = Factory::getDbo();
-		$type = $type ?: $this->type;
+		$type = $type ?? $this->type;
 
 		if (!\is_array($pk))
 		{
@@ -135,7 +135,7 @@ class UCMContent extends UCMBase
 	 */
 	public function mapData($original, UCMType $type = null)
 	{
-		$contentType = $type ?: $this->type;
+		$contentType = $type ?? $this->type;
 
 		$fields = json_decode($contentType->type->field_mappings);
 
@@ -190,7 +190,7 @@ class UCMContent extends UCMBase
 	 */
 	protected function store($data, TableInterface $table = null, $primaryKey = null)
 	{
-		$table = $table ?: Table::getInstance('Corecontent');
+		$table = $table ?? Table::getInstance('Corecontent');
 
 		$typeId     = $this->getType()->type->type_id;
 		$primaryKey = $primaryKey ?: $this->getPrimaryKey($typeId, $data['core_content_item_id']);

--- a/libraries/src/UCM/UCMType.php
+++ b/libraries/src/UCM/UCMType.php
@@ -90,8 +90,8 @@ class UCMType implements UCM
 	 */
 	public function __construct($alias = null, DatabaseDriver $database = null, AbstractApplication $application = null)
 	{
-		$this->db = $database ?: Factory::getDbo();
-		$app      = $application ?: Factory::getApplication();
+		$this->db = $database ?? Factory::getDbo();
+		$app      = $application ?? Factory::getApplication();
 
 		// Make the best guess we can in the absence of information.
 		$this->alias = $alias ?: $app->input->get('option') . '.' . $app->input->get('view');


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Use null coalescing operator over ternary operator and `instanceof` checks in methods with nullable class typehints.

### Testing Instructions

1. Code review.
2. Browse around in frontend and backend.

### Expected result AFTER applying this Pull Request

2. Joomla still works.

### Documentation Changes Required

No.