### PR TITLE
[4.0] Check if service is registered before registering

### DIFF
--- a/administrator/templates/atum/error_full.php
+++ b/administrator/templates/atum/error_full.php
@@ -15,7 +15,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
 
-/** @var JDocumentError $this */
+/** @var \Joomla\CMS\Document\ErrorDocument $this */
 
 $app   = Factory::getApplication();
 $input = $app->input;
@@ -57,8 +57,16 @@ $this->setMetaData('theme-color', '#1c3d5c');
 
 $monochrome = (bool) $this->params->get('monochrome');
 
-HTMLHelper::getServiceRegistry()->register('atum', 'JHtmlAtum');
+$htmlRegistry = HTMLHelper::getServiceRegistry();
+
+// This may already be registered in main template file.
+if (!$htmlRegistry->hasService('atum'))
+{
+	$htmlRegistry->register('atum', 'JHtmlAtum');
+}
+
 HTMLHelper::_('atum.rootcolors', $this->params);
+
 ?>
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">

--- a/administrator/templates/atum/error_login.php
+++ b/administrator/templates/atum/error_login.php
@@ -14,7 +14,7 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Uri\Uri;
 
-/** @var \Joomla\CMS\Document\HtmlDocument $this */
+/** @var \Joomla\CMS\Document\ErrorDocument $this */
 
 $app   = Factory::getApplication();
 $input = $app->input;
@@ -63,6 +63,7 @@ if (!$htmlHelperRegistry->hasService('atum'))
 }
 
 HTMLHelper::_('atum.rootcolors', $this->params);
+
 ?>
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Fixes an error on error page if an error occurs after after the template has been parsed (e.g. in a module).

### Testing Instructions

Enable debug.
Edit some backend module file to cause an error. E.g. add `foo()` to `administrator/modules/mod_menu/mod_menu.php`.
Login to backend.

### Actual result BEFORE applying this Pull Request

Error:
>The 'atum' service key is already registered.

### Expected result AFTER applying this Pull Request

Error:
>Attempted to call function "foo" from the global namespace.

### Documentation Changes Required

