### PR TITLE
Add Forms parent for subforms #30122

### DIFF
--- a/libraries/src/Form/Form.php
+++ b/libraries/src/Form/Form.php
@@ -102,6 +102,7 @@ class Form
 
 		// Set the options if specified.
 		$this->options['control'] = isset($options['control']) ? $options['control'] : false;
+		$this->options['parent'] = isset($options['parent']) ? $options['parent'] : false;
 	}
 
 	/**
@@ -487,6 +488,19 @@ class Form
 	public function getFormControl()
 	{
 		return (string) $this->options['control'];
+	}
+	
+	/**
+	 * Method to get the form parent. This form object is used by subforms for travel on form structure,
+	 * to get values and settings.
+	 *
+	 * @return  mixed false or jform object
+	 *
+	 * @since   3.9.?? - patch proposed
+	 */
+	public function getFormParent()
+	{
+		return $this->options['parent'];
 	}
 
 	/**


### PR DESCRIPTION
On subforms, parent form is inacessible, because $form property is protected. Adding a parent property it can be access, on fields for navigation, of subforms retrive variables and use on global parameter of components.

Pull Request for Issue # .

### Summary of Changes
add parent option to subforms, and function to retrive parent form or return false



### Testing Instructions



### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Documentation Changes Required

