### PR TITLE
Add Forms parent for subforms

### DIFF
--- a/libraries/joomla/form/fields/text.php
+++ b/libraries/joomla/form/fields/text.php
@@ -177,24 +177,27 @@ class JFormFieldText extends JFormField
 			// Get correct component for menu items
 			if ($component == 'com_menus')
 			{
-				$link      = $this->form->getData()->get('link');
+				if ($this->subformPrefix === '')
+					$link = $this->form->getData()->get('link');
+				else
+					$link = $this->subformParent->getData()->get('link');
 				$uri       = new JUri($link);
 				$component = $uri->getVar('option', 'com_menus');
 			}
 
 			$params = JComponentHelper::getParams($component);
-			$value  = $params->get($this->fieldname);
+			$value  = $params->get($this->subformPrefix . $this->fieldname);
 
 			// Try with global configuration
 			if (is_null($value))
 			{
-				$value = JFactory::getConfig()->get($this->fieldname);
+				$value = JFactory::getConfig()->get($this->subformPrefix . $this->fieldname);
 			}
 
 			// Try with menu configuration
 			if (is_null($value) && JFactory::getApplication()->input->getCmd('option') == 'com_menus')
 			{
-				$value = JComponentHelper::getParams('com_menus')->get($this->fieldname);
+				$value = JComponentHelper::getParams('com_menus')->get($this->subformPrefix . $this->fieldname);
 			}
 
 			if (!is_null($value))


### PR DESCRIPTION
On subforms, parent form is inacessible, because $form property is protected. Adding a parent property it can be access, on fields for navigation, of subforms retrive variables and use on global parameter of components.

Pull Request for Issue # .

### Summary of Changes



### Testing Instructions



### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Documentation Changes Required

