### PR TITLE
[4.0] Display sidebar nav/toolbar when resizing from mobile to desktop

### DIFF
--- a/build/media_source/templates/atum/js/template.es6.js
+++ b/build/media_source/templates/atum/js/template.es6.js
@@ -225,12 +225,17 @@
    * @since   4.0.0
    */
   function setDesktop() {
+    const sidebarNav = doc.querySelector('.sidebar-nav');
+    const subhead = doc.querySelector('.subhead');
     const sidebarWrapper = doc.querySelector('.sidebar-wrapper');
     if (!sidebarWrapper) {
       changeLogo('closed');
     } else {
       changeLogo();
     }
+
+    if (sidebarNav) sidebarNav.classList.remove('collapse');
+    if (subhead) subhead.classList.remove('collapse');
 
     toggleArrowIcon('top');
   }


### PR DESCRIPTION
Pull Request for Issue #28374 .

### Summary of Changes
Remove collapse class when resizing from mobile to desktop to display sidebar nav.


### Steps to reproduce the issue

Go to `/administrator/index.php?option=com_config&view=component&component=com_content`
Reduce viewport width down so everything gets stacked
Click the `Toggle Menu` button so the menu is hidden
Increase viewport width back to desktop size
Apply PR.
Run npm i or install the package installer:

### Expected result

Menu is becomes visible

### Actual result

Menu is stilll hidden

![screeny1](https://user-images.githubusercontent.com/2019801/76769705-b227e080-6794-11ea-8838-1827a1aca1b4.gif)

