### PR TITLE
[4.0][api][com_content] render metafields "metakey", "metadesc" and "metadata" and fields "featured" and "access"

### DIFF
--- a/administrator/components/com_content/src/Model/ArticlesModel.php
+++ b/administrator/components/com_content/src/Model/ArticlesModel.php
@@ -20,6 +20,7 @@ use Joomla\CMS\Table\Table;
 use Joomla\CMS\Workflow\Workflow;
 use Joomla\Component\Content\Administrator\Extension\ContentComponent;
 use Joomla\Database\ParameterType;
+use Joomla\Registry\Registry;
 use Joomla\Utilities\ArrayHelper;
 
 /**
@@ -261,6 +262,9 @@ class ArticlesModel extends ListModel
 					$db->quoteName('a.fulltext'),
 					$db->quoteName('a.note'),
 					$db->quoteName('a.images'),
+					$db->quoteName('a.metakey'),
+					$db->quoteName('a.metadesc'),
+					$db->quoteName('a.metadata'),
 				]
 			)
 		)
@@ -693,6 +697,8 @@ class ArticlesModel extends ListModel
 		foreach ($items as $item)
 		{
 			$item->typeAlias = 'com_content.article';
+			$registry = new Registry($item->metadata);
+			$item->metadata = $registry->toArray();
 		}
 
 		return $items;

--- a/api/components/com_content/src/View/Articles/JsonapiView.php
+++ b/api/components/com_content/src/View/Articles/JsonapiView.php
@@ -46,6 +46,9 @@ class JsonapiView extends BaseApiView
 		'created',
 		'author',
 		'images',
+		'metakey',
+		'metadesc',
+		'metadata',
 	];
 
 	/**
@@ -67,6 +70,9 @@ class JsonapiView extends BaseApiView
 		'created',
 		'author',
 		'images',
+		'metakey',
+		'metadesc',
+		'metadata',
 	];
 
 	/**

--- a/api/components/com_content/src/View/Articles/JsonapiView.php
+++ b/api/components/com_content/src/View/Articles/JsonapiView.php
@@ -49,6 +49,8 @@ class JsonapiView extends BaseApiView
 		'metakey',
 		'metadesc',
 		'metadata',
+		'access',
+		'featured',
 	];
 
 	/**
@@ -73,6 +75,8 @@ class JsonapiView extends BaseApiView
 		'metakey',
 		'metadesc',
 		'metadata',
+		'access',
+		'featured',
 	];
 
 	/**


### PR DESCRIPTION
Pull Request for Issue #30130, #30135

### Summary of Changes
render metafields: metakey, metadesc, metadata, featured, access


### Testing Instructions
edit an article
add content to  metakey, metadesc, metadata fields
save
call the api

  --for article list
`{{base_url}}api/index.php/v1/content/article `             

 --for article item
`{{base_url}}api/index.php/v1/content/article/{id} `        

### Actual result BEFORE applying this Pull Request
no render of metakey, metadesc, metadata, featured, access, fields


### Expected result AFTER applying this Pull Request
![Screenshot from 2020-07-18 07-26-26](https://user-images.githubusercontent.com/181681/87845472-0f10e000-c8c8-11ea-8f60-1aea20ccc1ec.png)


![Screenshot from 2020-07-19 10-46-20](https://user-images.githubusercontent.com/181681/87871011-43120100-c9ad-11ea-8639-92fd5ac69248.png)

### Documentation Changes Required
probably ?