### PR TITLE
[staging] [fields plugins] Deleting use of Telephone filter as it is broken

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/3.9.21-2020-07-20.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.9.21-2020-07-20.sql
@@ -1,0 +1,2 @@
+UPDATE `#__fields` SET `fieldparams` = REPLACE(`fieldparams`, '"filter":"tel"', '"filter":"text"') WHERE `type` IN ('text', 'textarea');
+UPDATE `#__fields` SET `fieldparams` = REPLACE(`fieldparams`, '"fieldfilter":"tel"', '"fieldfilter":"text"') WHERE `type` = 'repeatable';

--- a/administrator/components/com_admin/sql/updates/postgresql/3.9.21-2020-07-20.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.9.21-2020-07-20.sql
@@ -1,0 +1,2 @@
+UPDATE "#__fields" SET "fieldparams" = REPLACE("fieldparams", '"filter":"tel"', '"filter":"text"') WHERE "type" IN ('text', 'textarea');
+UPDATE "#__fields" SET "fieldparams" = REPLACE("fieldparams", '"fieldfilter":"tel"', '"fieldfilter":"text"') WHERE "type" = 'repeatable';

--- a/administrator/components/com_admin/sql/updates/sqlazure/3.9.21-2020-07-20.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.9.21-2020-07-20.sql
@@ -1,0 +1,2 @@
+UPDATE [#__fields] SET [fieldparams] = REPLACE([fieldparams], '"filter":"tel"', '"filter":"text"') WHERE [type] IN ('text', 'textarea');
+UPDATE [#__fields] SET [fieldparams] = REPLACE([fieldparams], '"fieldfilter":"tel"', '"fieldfilter":"text"') WHERE [type] = 'repeatable';

--- a/plugins/fields/repeatable/params/repeatable.xml
+++ b/plugins/fields/repeatable/params/repeatable.xml
@@ -58,9 +58,6 @@
 								<option
 									showon="fieldtype:text,textarea"
 									value="float">JLIB_FILTER_PARAMS_FLOAT</option>
-								<option
-									showon="fieldtype:text,textarea"
-									value="tel">JLIB_FILTER_PARAMS_TEL</option>
 							</field>
 						</fieldset>
 					</fields>

--- a/plugins/fields/text/params/text.xml
+++ b/plugins/fields/text/params/text.xml
@@ -18,7 +18,6 @@
 				<option value="alnum">JLIB_FILTER_PARAMS_ALNUM</option>
 				<option value="integer">JLIB_FILTER_PARAMS_INTEGER</option>
 				<option value="float">JLIB_FILTER_PARAMS_FLOAT</option>
-				<option value="tel">JLIB_FILTER_PARAMS_TEL</option>
 			</field>
 
 			<field

--- a/plugins/fields/text/text.xml
+++ b/plugins/fields/text/text.xml
@@ -37,7 +37,6 @@
 					<option value="alnum">JLIB_FILTER_PARAMS_ALNUM</option>
 					<option value="integer">JLIB_FILTER_PARAMS_INTEGER</option>
 					<option value="float">JLIB_FILTER_PARAMS_FLOAT</option>
-					<option value="tel">JLIB_FILTER_PARAMS_TEL</option>
 				</field>
 
 				<field

--- a/plugins/fields/textarea/params/textarea.xml
+++ b/plugins/fields/textarea/params/textarea.xml
@@ -44,7 +44,6 @@
 				<option value="alnum">JLIB_FILTER_PARAMS_ALNUM</option>
 				<option value="integer">JLIB_FILTER_PARAMS_INTEGER</option>
 				<option value="float">JLIB_FILTER_PARAMS_FLOAT</option>
-				<option value="tel">JLIB_FILTER_PARAMS_TEL</option>
 			</field>
 		</fieldset>
 	</fields>

--- a/plugins/fields/textarea/textarea.xml
+++ b/plugins/fields/textarea/textarea.xml
@@ -65,7 +65,6 @@
 					<option value="alnum">JLIB_FILTER_PARAMS_ALNUM</option>
 					<option value="integer">JLIB_FILTER_PARAMS_INTEGER</option>
 					<option value="float">JLIB_FILTER_PARAMS_FLOAT</option>
-					<option value="tel">JLIB_FILTER_PARAMS_TEL</option>
 				</field>
 			</fieldset>
 		</fields>


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/18566

### Summary of Changes
The `TEL` Form filter being totally broken ( https://github.com/joomla/joomla-cms/blob/staging/libraries/src/Form/Form.php#L1466-L1544 ), the filter should never be used in the fields parameters.

Changing telephone filter `tel` to `text` in sql upgrade `#__fields` table for B/C.
Taking off the Telephone filter in the fields plugin parameters.


### Testing Instructions
Create 3 fields (type text, textarea, repeatable->text
Use the Telephone filter => number always get an unwanted period when saved when editing an article, various formats are not honored.

Patch and try to create new fields of the same type (no need to save them)
The filter field telephone is no more proposed.

Use the new sql update => all existing fields which have been set with the `tel` filter are modified to use the `text` filter.

@richard67 
I only created the sql update for `mysql`. Please add for `postgresql` and `sqlazure`
