### PR TITLE
Fix possible warning in the System-Debug's DataFormatter.php file

### DIFF
--- a/plugins/system/debug/src/DataFormatter.php
+++ b/plugins/system/debug/src/DataFormatter.php
@@ -63,6 +63,12 @@ class DataFormatter extends DebugBarDataFormatter
 					$arg = \get_class($arg);
 				}
 
+				// Keep only the size of array
+				if (\is_array($arg))
+				{
+					$arg = 'Array(count=' . count($arg) . ')';
+				}
+
 				$string .= htmlspecialchars($arg) . ', ';
 			}
 


### PR DESCRIPTION
Fix a warning `htmlspecialchars() expects parameter 1 to be string, array given`  in the case of array passed as an argument in the stack trace.

### Summary of Changes
Add a check for special case of `is_array($arg)`.


### Testing Instructions
Declare a function like
```
function TestMe($array) {
  JText::_($array[0]);
}
```
and call it `TestMe(['qweasd'])` with enabled language logging.

### Actual result BEFORE applying this Pull Request
```
<b>Warning</b>:  htmlspecialchars() expects parameter 1 to be string, array given in <b>.../plugins/system/debug/src/DataFormatter.php</b> on line <b>66</b>
```

### Expected result AFTER applying this Pull Request
No warning message
