### PR TITLE
[4.0][CLI] list:user needs cast to char

### DIFF
--- a/libraries/src/Console/ListUserCommand.php
+++ b/libraries/src/Console/ListUserCommand.php
@@ -63,7 +63,7 @@ class ListUserCommand extends AbstractCommand
 
 		$query = $db->getQuery(true);
 		$query->select($db->quoteName(['u.id', 'u.username', 'u.name', 'u.email', 'u.block']))
-			->select($query->groupConcat($db->quoteName('g.group_id')) . ' AS ' . $db->quoteName('groups'))
+			->select($query->groupConcat($query->castAs('CHAR', $db->quoteName('g.group_id'))) . ' AS ' . $db->quoteName('groups'))
 			->innerJoin($db->quoteName('#__user_usergroup_map', 'g'), $db->quoteName('g.user_id') . ' = ' . $db->quoteName('u.id'))
 			->from($db->quoteName('#__users', 'u'))
 			->group($db->quoteName('u.id'));


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
`groupConcat()` argument need to be casted to CHAR on postgresql


### Testing Instructions
run `php cli/joomla.php user:list`


### Actual result BEFORE applying this Pull Request
on postgresql
![Screenshot from 2020-07-20 19-03-33](https://user-images.githubusercontent.com/181681/87965275-c588e680-cabb-11ea-820c-f5e2b2a4a00e.png)


### Expected result AFTER applying this Pull Request
run as expcted


### Documentation Changes Required

