### PR TITLE
[4.0] [a11y] :recycle: replace non-a11y form in table by a11y form

### DIFF
--- a/administrator/components/com_installer/tmpl/installer/default_ftp.php
+++ b/administrator/components/com_installer/tmpl/installer/default_ftp.php
@@ -13,33 +13,35 @@ use Joomla\CMS\Language\Text;
 
 ?>
 <fieldset class="option-fieldset options-form">
+
 	<legend><?php echo Text::_('COM_INSTALLER_MSG_DESCFTPTITLE'); ?></legend>
 
-	<?php echo Text::_('COM_INSTALLER_MSG_DESCFTP'); ?>
+	<div class="alert alert-info">
+		<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only">Info</span>
+		<?php echo Text::_('COM_INSTALLER_MSG_DESCFTP'); ?>
+	</div>
 
 	<?php if ($this->ftp instanceof Exception) : ?>
 		<p><?php echo Text::_($this->ftp->getMessage()); ?></p>
 	<?php endif; ?>
 
-	<table class="adminform">
-		<tbody>
-			<tr>
-				<td style="width:120">
-					<label for="username"><?php echo Text::_('JGLOBAL_USERNAME'); ?></label>
-				</td>
-				<td>
-					<input type="text" id="username" name="username" class="form-control" size="70" value="">
-				</td>
-			</tr>
-			<tr>
-				<td style="width:120">
-					<label for="password"><?php echo Text::_('JGLOBAL_PASSWORD'); ?></label>
-				</td>
-				<td>
-					<input type="password" id="password" name="password" class="form-control" size="70" value="">
-				</td>
-			</tr>
-		</tbody>
-	</table>
+	<div>
+		<div class="control-group">
+			<div class="control-label">
+				<label id="username" for="username"><?php echo Text::_('JGLOBAL_USERNAME'); ?></label>
+			</div>
+			<div class="controls">
+				<input type="text" name="username" id="username" class="form-control">
+			</div>
+		</div>
 
+		<div class="control-group">
+			<div class="control-label">
+				<label id="password-lbl" for="password"><?php echo Text::_('JGLOBAL_PASSWORD'); ?></label>
+			</div>
+			<div class="controls">
+				<input type="password" name="password" id="password" class="form-control">
+			</div>
+		</div>
+	</div>
 </fieldset>

--- a/administrator/components/com_installer/tmpl/installer/default_ftp.php
+++ b/administrator/components/com_installer/tmpl/installer/default_ftp.php
@@ -17,7 +17,7 @@ use Joomla\CMS\Language\Text;
 	<legend><?php echo Text::_('COM_INSTALLER_MSG_DESCFTPTITLE'); ?></legend>
 
 	<div class="alert alert-info">
-		<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only">Info</span>
+		<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 		<?php echo Text::_('COM_INSTALLER_MSG_DESCFTP'); ?>
 	</div>
 


### PR DESCRIPTION
Pull Request for Issue #30081 .

### Summary of Changes

This PR replaces the ugly non-a11y form by an a11y form. 
Small steps.


### Testing Instructions

Follow the test instructions from #30081

### Actual result BEFORE applying this Pull Request

See the screenshot in #30081

### Expected result AFTER applying this Pull Request

<img width="972" alt="Schermafdruk 2020-07-21 13 36 58" src="https://user-images.githubusercontent.com/639822/88050509-4648f080-cb57-11ea-86f8-07b3a30ceaa6.png">

