### PR TITLE
[3.9] Log the event on actionlogs when Joomla update

### DIFF
--- a/administrator/components/com_joomlaupdate/controllers/update.php
+++ b/administrator/components/com_joomlaupdate/controllers/update.php
@@ -222,8 +222,6 @@ class JoomlaupdateControllerUpdate extends JControllerLegacy
 		{
 			// Informational log only
 		}
-	
-		JFactory::getApplication()->triggerEvent('onAfterUpdate', array(JVERSION));
 	}
 
 	/**

--- a/administrator/components/com_joomlaupdate/controllers/update.php
+++ b/administrator/components/com_joomlaupdate/controllers/update.php
@@ -222,6 +222,8 @@ class JoomlaupdateControllerUpdate extends JControllerLegacy
 		{
 			// Informational log only
 		}
+	
+		JFactory::getApplication()->triggerEvent('onAfterUpdate', array(JVERSION));
 	}
 
 	/**

--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -922,6 +922,9 @@ ENDDATA;
 
 		// Unset the update filename from the session.
 		JFactory::getApplication()->setUserState('com_joomlaupdate.file', null);
+
+		// Trigger event after joomla update.
+		JFactory::getApplication()->triggerEvent('onJoomlaAfterUpdate');
 	}
 
 	/**

--- a/administrator/language/en-GB/en-GB.plg_actionlog_joomla.ini
+++ b/administrator/language/en-GB/en-GB.plg_actionlog_joomla.ini
@@ -46,7 +46,7 @@ PLG_ACTIONLOG_JOOMLA_USER_REGISTERED="User <a href='{accountlink}'>{username}</a
 PLG_ACTIONLOG_JOOMLA_USER_REMIND="User <a href='{accountlink}'>{username}</a> requested a username reminder for their account"
 PLG_ACTIONLOG_JOOMLA_USER_RESET_COMPLETE="User <a href='{accountlink}'>{username}</a> completed the password reset for their account"
 PLG_ACTIONLOG_JOOMLA_USER_RESET_REQUEST="User <a href='{accountlink}'>{username}</a> requested a password reset for their account"
-PLG_ACTIONLOG_JOOMLA_USER_UPDATE="User <a href='{accountlink}'>{username}</a> updated the CMS to {version}"
+PLG_ACTIONLOG_JOOMLA_USER_UPDATE="User <a href='{accountlink}'>{username}</a> updated Joomla to {version}"
 ; Component
 PLG_ACTIONLOG_JOOMLA_APPLICATION_CONFIG_UPDATED="User <a href='{accountlink}'>{username}</a> changed settings of the application configuration"
 PLG_ACTIONLOG_JOOMLA_COMPONENT_CONFIG_UPDATED="User <a href='{accountlink}'>{username}</a> changed settings of the component {extension_name}"

--- a/administrator/language/en-GB/en-GB.plg_actionlog_joomla.ini
+++ b/administrator/language/en-GB/en-GB.plg_actionlog_joomla.ini
@@ -46,6 +46,7 @@ PLG_ACTIONLOG_JOOMLA_USER_REGISTERED="User <a href='{accountlink}'>{username}</a
 PLG_ACTIONLOG_JOOMLA_USER_REMIND="User <a href='{accountlink}'>{username}</a> requested a username reminder for their account"
 PLG_ACTIONLOG_JOOMLA_USER_RESET_COMPLETE="User <a href='{accountlink}'>{username}</a> completed the password reset for their account"
 PLG_ACTIONLOG_JOOMLA_USER_RESET_REQUEST="User <a href='{accountlink}'>{username}</a> requested a password reset for their account"
+PLG_ACTIONLOG_JOOMLA_USER_UPDATE="User <a href='{accountlink}'>{username}</a> updated the CMS to {version}"
 ; Component
 PLG_ACTIONLOG_JOOMLA_APPLICATION_CONFIG_UPDATED="User <a href='{accountlink}'>{username}</a> changed settings of the application configuration"
 PLG_ACTIONLOG_JOOMLA_COMPONENT_CONFIG_UPDATED="User <a href='{accountlink}'>{username}</a> changed settings of the component {extension_name}"

--- a/plugins/actionlog/joomla/joomla.php
+++ b/plugins/actionlog/joomla/joomla.php
@@ -12,6 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\User\User;
+use Joomla\CMS\Version;
 use Joomla\Utilities\ArrayHelper;
 
 JLoader::register('ActionLogPlugin', JPATH_ADMINISTRATOR . '/components/com_actionlogs/libraries/actionlogplugin.php');
@@ -1048,13 +1049,11 @@ class PlgActionlogJoomla extends ActionLogPlugin
 	 *
 	 * Method is called after user update the CMS.
 	 *
-	 * @param   string  $version  Holds the new version.
-	 *
 	 * @return  void
 	 *
 	 * @since   3.9.21
 	 */
-	public function onAfterUpdate($version)
+	public function onJoomlaAfterUpdate()
 	{
 		$context = $this->app->input->get('option');
 		$user    = JFactory::getUser();
@@ -1067,7 +1066,7 @@ class PlgActionlogJoomla extends ActionLogPlugin
 			'userid'      => $user->id,
 			'username'    => $user->username,
 			'accountlink' => 'index.php?option=com_users&task=user.edit&id=' . $user->id,
-			'version'     => $version,
+			'version'     => JVERSION,
 		);
 		$this->addLog(array($message), 'PLG_ACTIONLOG_JOOMLA_USER_UPDATE', $context, $user->id);
 	}

--- a/plugins/actionlog/joomla/joomla.php
+++ b/plugins/actionlog/joomla/joomla.php
@@ -1058,9 +1058,6 @@ class PlgActionlogJoomla extends ActionLogPlugin
 	{
 		$context = $this->app->input->get('option');
 		$user    = JFactory::getUser();
-
-
-
 		$message = array(
 			'action'      => 'cache',
 			'type'        => 'PLG_ACTIONLOG_JOOMLA_TYPE_USER',

--- a/plugins/actionlog/joomla/joomla.php
+++ b/plugins/actionlog/joomla/joomla.php
@@ -1042,4 +1042,36 @@ class PlgActionlogJoomla extends ActionLogPlugin
 		);
 		$this->addLog(array($message), 'PLG_ACTIONLOG_JOOMLA_USER_CACHE', $context, $user->id);
 	}
+
+	/**
+	 * On after CMS Update
+	 *
+	 * Method is called after user update the CMS.
+	 *
+	 * @param   string  $version  Holds the new version.
+	 *
+	 * @return  void
+	 *
+	 * @since   3.9.21
+	 */
+	public function onAfterUpdate($version)
+	{
+		$context = $this->app->input->get('option');
+		$user    = JFactory::getUser();
+
+
+
+		$message = array(
+			'action'      => 'cache',
+			'type'        => 'PLG_ACTIONLOG_JOOMLA_TYPE_USER',
+			'id'          => $user->id,
+			'title'       => $user->username,
+			'itemlink'    => 'index.php?option=com_users&task=user.edit&id=' . $user->id,
+			'userid'      => $user->id,
+			'username'    => $user->username,
+			'accountlink' => 'index.php?option=com_users&task=user.edit&id=' . $user->id,
+			'version'     => $version,
+		);
+		$this->addLog(array($message), 'PLG_ACTIONLOG_JOOMLA_USER_UPDATE', $context, $user->id);
+	}
 }


### PR DESCRIPTION
Pull Request for Issue #30074 .

### Summary of Changes
Log the Joomla update event on the Actionlogs


### Testing Instructions
joomlaupdate -> options
change  to Custom URL
and put this manifest https://ci.joomla.org/artifacts/joomla/joomla-cms/staging/30157/downloads/34205/pr_list.xml
you'll find it here on the download pkg link  Prebuilt packages are available for download. 

### Actual result BEFORE applying this Pull Request
no event is logged when joomla update


### Expected result AFTER applying this Pull Request
the event is logged
![Screenshot from 2020-07-21 19-39-11](https://user-images.githubusercontent.com/181681/88087921-f3d4f780-cb89-11ea-9bf1-02e30838fcce.png)


### Documentation Changes Required

