### PR TITLE
[3.x] Set the threshold for rips to 0 and write out the rips cli options

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -58,8 +58,8 @@ steps:
         - staging
     commands:
       - export RIPS_BASE_URI='https://api.rips.joomla.org'
-      - rips-cli rips:list --table=scans -n -p filter='{"__and":[{"__lessThan":{"percent":100}}]}'
-      - rips-cli rips:scan:start -G -a 1 -t 1 -p $(pwd) -t 1 -R -k -T $DRONE_REPO_NAMESPACE-$DRONE_BRANCH ||  { echo "Please contact the security team at security@joomla.org"; exit 1; }
+      - rips-cli rips:list --table=scans --parameter filter='{"__and":[{"__lessThan":{"percent":100}}]}'
+      - rips-cli rips:scan:start --progress --application=1 --threshold=0 --path=$(pwd) --remove-code --remove-upload --tag=$DRONE_REPO_NAMESPACE-$DRONE_BRANCH || { echo "Please contact the security team at security@joomla.org"; exit 1; }
     environment:
       RIPS_EMAIL:
         from_secret: RIPS_EMAIL
@@ -103,6 +103,6 @@ steps:
 
 ---
 kind: signature
-hmac: 291c4194cc5fb9c0b83642e96ea938eed67df4eea3e58b51ac54f011a522efe7
+hmac: a825707d539b95fb82da2affd7ba513094430f48cd0d829d38c5f59a6b412d78
 
 ...


### PR DESCRIPTION
### Summary of Changes

Set the threshold for rips to 0 and write out the rips cli options (https://kb.ripstech.com/doc/3.1/tooling/rips-cli)

### Testing Instructions

Make sure rips via drone still works.

### Actual result BEFORE applying this Pull Request

The threshold was set to 1 but should have been 0

### Expected result AFTER applying this Pull Request

The rips threshold is set to 0 so any issue gets an failiure on drone.
This also writes out the parameters so it is easier to review

### Documentation Changes Required

None.