### PR TITLE
[4.0] [template.cassiopeia] replacing div selector by * for module styling

### DIFF
--- a/templates/cassiopeia/scss/blocks/_css-grid.scss
+++ b/templates/cassiopeia/scss/blocks/_css-grid.scss
@@ -30,7 +30,7 @@
       display: flex;
       flex-direction: column;
 
-      > div + div {
+      > * + * {
         margin-top: $cassiopeia-grid-gutter;
       }
     }

--- a/templates/cassiopeia/scss/blocks/_css-grid.scss
+++ b/templates/cassiopeia/scss/blocks/_css-grid.scss
@@ -138,7 +138,7 @@
   grid-gap: $cassiopeia-grid-gutter;
   grid-template-columns: 1fr;
 
-  > div {
+  > * {
     margin: 0;
   }
 

--- a/templates/cassiopeia/scss/blocks/_layout.scss
+++ b/templates/cassiopeia/scss/blocks/_layout.scss
@@ -34,7 +34,7 @@ header {
 .container-top-b,
 .container-bottom-a,
 .container-bottom-b {
-  > div {
+  > * {
     flex: 1;
     margin: ($cassiopeia-grid-gutter / 2);
   }
@@ -42,21 +42,21 @@ header {
   @include media-breakpoint-down(sm) {
     flex-direction: column;
 
-    > div {
+    > * {
       flex: 0 1 auto;
     }
   }
 }
 
 .container-main {
-  > div {
+  > * {
     margin: ($cassiopeia-grid-gutter / 2);
   }
 
   @include media-breakpoint-down(sm) {
     flex-direction: column;
 
-    > div {
+    > * {
       flex: 0 1 auto;
     }
   }
@@ -65,7 +65,7 @@ header {
 .container-component {
   flex: 1;
 
-  > div:not(#system-message-container) {
+  > *:not(#system-message-container) {
     margin-bottom: $cassiopeia-grid-gutter;
 
     &:last-of-type {

--- a/templates/cassiopeia/scss/blocks/_layout.scss
+++ b/templates/cassiopeia/scss/blocks/_layout.scss
@@ -80,14 +80,6 @@ header {
   width: calc(100% - #{$cassiopeia-grid-gutter});
   order: 1;
 
-  > div {
-    margin-bottom: $cassiopeia-grid-gutter;
-
-    &:last-of-type {
-      margin-bottom: 0;
-    }
-  }
-
   @include media-breakpoint-up(sm) {
     width: calc(25% - #{$cassiopeia-grid-gutter});
     order: 0;


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This PR fixes module spacing when selecting a module tag other than `div`.
After applying this PR the spacing between modules is reduced since margin-bottom is removed. 
All spacing should be accomplished by the lobotomized owl selector `* + *`. Not by using both `margin-top` and `margin-bottom` on modules. 

### Testing Instructions

- Make sure some kind of Sample Data is applied and Cassiopeia is default frontend template.
- Joomla administrator > Content > Site Modules
- Open module "Popular Tags" assigned to position `sidebar-right` (this is the second module shown in sidebar-right)
- Go to tab _Advanced_
- Change _Module Tag_ from `div` to `aside`
- Save & Close 
- Refresh frontend

- Apply PR
- Open terminal to run `npm build:css` on Joomla root
- Refresh frontend to see effect AFTER PR

### Actual result BEFORE applying this Pull Request

#### Chosen Module Tag === `div`
<img width="355" alt="Schermafdruk 2020-07-21 21 17 36" src="https://user-images.githubusercontent.com/639822/88098433-1242ef00-cb9a-11ea-8b17-e9bb525c85bd.png">

#### Chosen Module Tag !== `div`
<img width="325" alt="Schermafdruk 2020-07-21 21 19 01" src="https://user-images.githubusercontent.com/639822/88098506-2d156380-cb9a-11ea-8b89-a41b3bf1002f.png">

### Expected result AFTER applying this Pull Request

#### Chosen Module Tag .... all
<img width="330" alt="Schermafdruk 2020-07-21 21 36 35" src="https://user-images.githubusercontent.com/639822/88098585-4ae2c880-cb9a-11ea-9562-576382da6636.png">

### Documentation Changes Required

I don't know if changes on documentation is required. 