### PR TITLE
[4.0] Fix permission display in mobile view

### DIFF
--- a/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-tab.scss
+++ b/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-tab.scss
@@ -196,6 +196,7 @@ joomla-tab {
 
     a[role=tab] {
       color: var(--atum-text-light);
+      background-color: var(--atum-link-color);
       border: 1px solid var(--atum-text-light);
       border-top: 0;
 
@@ -204,6 +205,10 @@ joomla-tab {
       &:focus {
         color: var(--atum-text-light);
         background-color: var(--atum-bg-dark);
+      }
+
+      .text-muted {
+        color: var(--atum-text-light) !important;
       }
     }
 


### PR DESCRIPTION
Pull Request for Issue #28347.

### Summary of Changes
When we get to the accordion display, the unfocused tabs don't get a background-color and are therefore invisible until hover.

@angieradtke Thanks for the code.

### Testing Instructions
Apply PR.
Run `npm run build:css`
Edit an article.
Click on the Permissions tab.
Reduce window size.



### Actual result BEFORE applying this Pull Request
![permissions](https://user-images.githubusercontent.com/869724/76700514-9949fd00-66b8-11ea-857e-d35d9ab279f7.gif)

