### PR TITLE
[4.0] Fix admin menu collapse when joomla is in a folder with uppercase name

### DIFF
--- a/build/media_source/mod_menu/js/admin-menu.es6.js
+++ b/build/media_source/mod_menu/js/admin-menu.es6.js
@@ -110,7 +110,7 @@
      * Sidebar Nav
      */
     const allLinks = wrapper.querySelectorAll('a.no-dropdown, a.collapse-arrow, .menu-dashboard > a');
-    const currentUrl = window.location.href.toLowerCase();
+    const currentUrl = window.location.href;
     const mainNav = document.querySelector('ul.main-nav');
     const menuParents = [].slice.call(mainNav.querySelectorAll('li.parent > a'));
     const subMenusClose = [].slice.call(mainNav.querySelectorAll('li.parent .close'));


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/30155

### Summary of Changes
mod_menu js is comparing a lowercase url to one that may not be


### Testing Instructions
Install Joomla in a subfolder and use UpperCase letters for that subfolder name.
For example:
`domain.org/newFolder/`

Click the "Content" item in the admin menu, it reveals its sub-items.
Click the "Articles" item. 

Patch. Run npm ci and test again.

### Actual result BEFORE applying this Pull Request
see https://github.com/joomla/joomla-cms/issues/30155

The admin menu returns to its default closed state


### Expected result AFTER applying this Pull Request

The admin menu remains open with the submenu highlighted, as should.

Here Joomla is in a sub-sub-folder, one of them with a Uppercase letter in its name.

<img width="815" alt="Screen Shot 2020-07-23 at 08 26 05" src="https://user-images.githubusercontent.com/869724/88257535-3ac40980-ccbe-11ea-9ec8-501973fa67dd.png">


@JackJoeJack
@PhocaCz
@Fedik 