### PR TITLE
[4.0] Support Model::getInstance for namespaced components

### DIFF
--- a/libraries/src/MVC/Model/LegacyModelLoaderTrait.php
+++ b/libraries/src/MVC/Model/LegacyModelLoaderTrait.php
@@ -161,6 +161,7 @@ trait LegacyModelLoaderTrait
 		// Detect the client based on the include paths
 		$adminPath = Path::clean(JPATH_ADMINISTRATOR . '/components/' . $componentName);
 		$sitePath  = Path::clean(JPATH_SITE . '/components/' . $componentName);
+
 		foreach (self::addIncludePath() as $path)
 		{
 			if (strpos($path, $adminPath) !== false)

--- a/libraries/src/MVC/Model/LegacyModelLoaderTrait.php
+++ b/libraries/src/MVC/Model/LegacyModelLoaderTrait.php
@@ -159,15 +159,17 @@ trait LegacyModelLoaderTrait
 		$client = Factory::getApplication()->getName();
 
 		// Detect the client based on the include paths
+		$adminPath = Path::clean(JPATH_ADMINISTRATOR . '/components/' . $componentName);
+		$sitePath  = Path::clean(JPATH_SITE . '/components/' . $componentName);
 		foreach (self::addIncludePath() as $path)
 		{
-			if (strpos($path, Path::clean(JPATH_ADMINISTRATOR . '/components/' . $componentName)) !== false)
+			if (strpos($path, $adminPath) !== false)
 			{
 				$client = 'Administrator';
 				break;
 			}
 
-			if (strpos($path, Path::clean(JPATH_SITE . '/components/' . $componentName))!== false)
+			if (strpos($path, $sitePath) !== false)
 			{
 				$client = 'Site';
 				break;

--- a/libraries/src/MVC/Model/LegacyModelLoaderTrait.php
+++ b/libraries/src/MVC/Model/LegacyModelLoaderTrait.php
@@ -10,9 +10,12 @@ namespace Joomla\CMS\MVC\Model;
 
 \defined('JPATH_PLATFORM') or die;
 
+use Joomla\CMS\Extension\LegacyComponent;
+use Joomla\CMS\Factory;
 use Joomla\CMS\Filesystem\Path;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
+use Joomla\CMS\MVC\Factory\MVCFactoryServiceInterface;
 use Joomla\CMS\Table\Table;
 
 /**
@@ -72,6 +75,12 @@ trait LegacyModelLoaderTrait
 		);
 
 		$type = preg_replace('/[^A-Z0-9_\.-]/i', '', $type);
+
+		if ($model = self::createModelFromComponent($type, $prefix, $config))
+		{
+			return $model;
+		}
+
 		$modelClass = $prefix . ucfirst($type);
 
 		if (!class_exists($modelClass))
@@ -114,5 +123,67 @@ trait LegacyModelLoaderTrait
 	public static function addTablePath($path)
 	{
 		Table::addIncludePath($path);
+	}
+
+	/**
+	 * Returns a Model object by loading the component from the prefix.
+	 *
+	 * @param   string  $type    The model type to instantiate
+	 * @param   string  $prefix  Prefix for the model class name. Optional.
+	 * @param   array   $config  Configuration array for model. Optional.
+	 *
+	 * @return  ModelInterface|null   A ModelInterface instance or null on failure
+	 *
+	 * @since       __DEPLOY_VERSION__
+	 * @deprecated  5.0 See getInstance
+	 */
+	private static function createModelFromComponent($type, $prefix = '', $config = []) : ?ModelInterface
+	{
+		// Do nothing when prefix is not given
+		if (!$prefix)
+		{
+			return null;
+		}
+
+		// Boot the component
+		$componentName = 'com_' . str_replace('model', '', strtolower($prefix));
+		$component     = Factory::getApplication()->bootComponent($componentName);
+
+		// When it is a legacy component or not a MVCFactoryService then ignore
+		if ($component instanceof LegacyComponent || !$component instanceof MVCFactoryServiceInterface)
+		{
+			return null;
+		}
+
+		// Setup the client
+		$client = Factory::getApplication()->getName();
+
+		// Detect the client based on the include paths
+		foreach (self::addIncludePath() as $path)
+		{
+			if (strpos($path, JPATH_ADMINISTRATOR . '/components/' . $componentName) !== false)
+			{
+				$client = 'Administrator';
+				break;
+			}
+
+			if (strpos($path, JPATH_SITE . '/components/' . $componentName) !== false)
+			{
+				$client = 'Site';
+				break;
+			}
+		}
+
+		// Create the model
+		$model = $component->getMVCFactory()->createModel($type, $client, $config);
+
+		// When the model can't be loaded, then return null
+		if (!$model)
+		{
+			return null;
+		}
+
+		// Return the model instance
+		return $model;
 	}
 }

--- a/libraries/src/MVC/Model/LegacyModelLoaderTrait.php
+++ b/libraries/src/MVC/Model/LegacyModelLoaderTrait.php
@@ -167,7 +167,7 @@ trait LegacyModelLoaderTrait
 				break;
 			}
 
-			if (strpos($path, Path::clean(JPATH_SITE . '/components/' . $componentName))!== false)
+			if (strpos($path, Path::clean(JPATH_SITE . '/components/' . $componentName)) !== false)
 			{
 				$client = 'Site';
 				break;

--- a/libraries/src/MVC/Model/LegacyModelLoaderTrait.php
+++ b/libraries/src/MVC/Model/LegacyModelLoaderTrait.php
@@ -161,13 +161,13 @@ trait LegacyModelLoaderTrait
 		// Detect the client based on the include paths
 		foreach (self::addIncludePath() as $path)
 		{
-			if (strpos($path, JPATH_ADMINISTRATOR . '/components/' . $componentName) !== false)
+			if (strpos($path, Path::clean(JPATH_ADMINISTRATOR . '/components/' . $componentName)) !== false)
 			{
 				$client = 'Administrator';
 				break;
 			}
 
-			if (strpos($path, JPATH_SITE . '/components/' . $componentName) !== false)
+			if (strpos($path, Path::clean(JPATH_SITE . '/components/' . $componentName))!== false)
 			{
 				$client = 'Site';
 				break;


### PR DESCRIPTION
### Summary of Changes
The legacy way to load a model is `JModelLegacy::getInstance` which is widely used in Joomla 3. This doesn't work anymore for components which are namespaced in Joomla 4 as models are loaded there through the component MVC factory. This pr adds a functionality to also load namespaced models the old way. The following code works both on J3 and J4 with this patch, without, the model can't be found on J4.

```
JModelLegacy::addIncludePath(JPATH_ADMINISTRATOR . '/components/com_contact/models', 'ContactModel');
$model   = JModelLegacy::getInstance('Contact', 'ContactModel', ['ignore_request' => true]);
```
Additionally it fixes the indexer purge task on the command line.

### Testing Instructions
On the command line execute the following command in the joomla root:
`php cli/finder_indexer.php --purge`

### Actual result BEFORE applying this Pull Request
The following error is printed:
```
Smart Search INDEXER
============================
Saving filters
- number of saved filters: 0
Clear index
Error {#191
  #message: "Call to a member function purge() on bool"
  #code: 0
  #file: "/var/www/html/Projects/cms4/cli/finder_indexer.php"
  #line: 360
  trace: {
    /var/www/html/Projects/cms4/cli/finder_indexer.php:360 {
      FinderCli->purge()^
      › // Attempt to purge the index.
      › $return = $model->purge();
      › 
    }
    /var/www/html/Projects/cms4/cli/finder_indexer.php:183 { …}
    /var/www/html/Projects/cms4/libraries/src/Application/CliApplication.php:241 { …}
    /var/www/html/Projects/cms4/cli/finder_indexer.php:514 { …}
  }
}
```
### Expected result AFTER applying this Pull Request
The purging process doesn't fail:
```
Smart Search INDEXER
============================
Saving filters
- number of saved filters: 0
Clear index
- index clear successful
Starting Indexer
Setting up Smart Search plugins
Setup 5 items in 0.293 seconds.
 * Processed batch 1 in 0.411 seconds.
 * Skipping pause, as previous batch had a very low processing time (0.411s < 1s)
Restoring filters
- number of filters restored: 0
Total Processing Time: 0.705 seconds.
Peak memory usage: 16,777,216 bytes
```

### Documentation Changes Required
None, as it is not documented in the potential issues doc that `JModelLegacy::getInstance`is not working for namespaced components.