### PR TITLE
[3.9] Fix missing typecasting SQL query plugin privacy actionlogs

### DIFF
--- a/plugins/privacy/actionlogs/actionlogs.php
+++ b/plugins/privacy/actionlogs/actionlogs.php
@@ -42,7 +42,7 @@ class PlgPrivacyActionlogs extends PrivacyPlugin
 			->select('a.*, u.name')
 			->from('#__action_logs AS a')
 			->innerJoin('#__users AS u ON a.user_id = u.id')
-			->where($this->db->quoteName('a.user_id') . ' = ' . $user->id);
+			->where($this->db->quoteName('a.user_id') . ' = ' . (int) $user->id);
 
 		$this->db->setQuery($query);
 


### PR DESCRIPTION
Pull Request for Issue #30164 .

### Summary of Changes

This PR filters the input variable of the SQL query.


### Testing Instructions

???

### Actual result BEFORE applying this Pull Request

See line 45:
->where($this->db->quoteName('a.user_id') . ' = ' . $user->id);

### Expected result AFTER applying this Pull Request

->where($this->db->quoteName('a.user_id') . ' = ' . (int) $user->id);

### Documentation Changes Required

No