### PR TITLE
[4.0] Set fixed width for password toggle icon

### DIFF
--- a/administrator/modules/mod_login/tmpl/default.php
+++ b/administrator/modules/mod_login/tmpl/default.php
@@ -65,7 +65,7 @@ Text::script('MESSAGE');
 				>
 				<span class="input-group-append">
 					<button type="button" class="btn btn-secondary input-password-toggle">
-						<span class="fas fa-fw fa-eye" aria-hidden="true"></span>
+						<span class="fas fa-eye fa-fw" aria-hidden="true"></span>
 						<span class="sr-only"><?php echo Text::_('JSHOWPASSWORD'); ?></span>
 					</button>
 				</span>

--- a/administrator/modules/mod_login/tmpl/default.php
+++ b/administrator/modules/mod_login/tmpl/default.php
@@ -65,7 +65,7 @@ Text::script('MESSAGE');
 				>
 				<span class="input-group-append">
 					<button type="button" class="btn btn-secondary input-password-toggle">
-						<span class="fas fa-eye" aria-hidden="true"></span>
+						<span class="fas fa-fw fa-eye" aria-hidden="true"></span>
 						<span class="sr-only"><?php echo Text::_('JSHOWPASSWORD'); ?></span>
 					</button>
 				</span>

--- a/layouts/joomla/form/field/password.php
+++ b/layouts/joomla/form/field/password.php
@@ -101,7 +101,7 @@ $attributes = array(
 			<?php echo implode(' ', $attributes); ?>>
 		<span class="input-group-append">
 			<button type="button" class="btn btn-secondary input-password-toggle">
-				<span class="fas fa-fw fa-eye" aria-hidden="true"></span>
+				<span class="fas fa-eye fa-fw" aria-hidden="true"></span>
 				<span class="sr-only"><?php echo Text::_('JSHOWPASSWORD'); ?></span>
 			</button>
 		</span>

--- a/layouts/joomla/form/field/password.php
+++ b/layouts/joomla/form/field/password.php
@@ -101,7 +101,7 @@ $attributes = array(
 			<?php echo implode(' ', $attributes); ?>>
 		<span class="input-group-append">
 			<button type="button" class="btn btn-secondary input-password-toggle">
-				<span class="fas fa-eye" aria-hidden="true"></span>
+				<span class="fas fa-fw fa-eye" aria-hidden="true"></span>
 				<span class="sr-only"><?php echo Text::_('JSHOWPASSWORD'); ?></span>
 			</button>
 		</span>

--- a/modules/mod_login/tmpl/default.php
+++ b/modules/mod_login/tmpl/default.php
@@ -56,7 +56,7 @@ Text::script('JHIDEPASSWORD');
 					<span class="input-group-append">
 						<label for="modlgn-passwd-<?php echo $module->id; ?>" class="sr-only"><?php echo Text::_('JGLOBAL_PASSWORD'); ?></label>
 						<button type="button" class="btn btn-secondary input-password-toggle">
-							<span class="fas fa-fw fa-eye" aria-hidden="true"></span>
+							<span class="fas fa-eye fa-fw" aria-hidden="true"></span>
 							<span class="sr-only"><?php echo Text::_('JSHOWPASSWORD'); ?></span>
 						</button>
 					</span>

--- a/modules/mod_login/tmpl/default.php
+++ b/modules/mod_login/tmpl/default.php
@@ -56,7 +56,7 @@ Text::script('JHIDEPASSWORD');
 					<span class="input-group-append">
 						<label for="modlgn-passwd-<?php echo $module->id; ?>" class="sr-only"><?php echo Text::_('JGLOBAL_PASSWORD'); ?></label>
 						<button type="button" class="btn btn-secondary input-password-toggle">
-							<span class="fas fa-eye" aria-hidden="true"></span>
+							<span class="fas fa-fw fa-eye" aria-hidden="true"></span>
 							<span class="sr-only"><?php echo Text::_('JSHOWPASSWORD'); ?></span>
 						</button>
 					</span>


### PR DESCRIPTION
Fixes https://github.com/joomla/joomla-cms/issues/28256.

### Summary of Changes

Sets fixed width for password toggler icon.

### Testing Instructions

View login, registration or user profile form.
Click on the eye icon in password field.

### Actual result BEFORE applying this Pull Request

Icon changes width:
![](https://user-images.githubusercontent.com/1296369/88370585-3107d800-cd8a-11ea-871c-9ec3f9351ee0.gif)


### Expected result AFTER applying this Pull Request

Icon width stays the same.

### Documentation Changes Required

No.