### PR TITLE
[4.0] fix Templates : Edit style - unsaved menu assignments

### DIFF
--- a/administrator/components/com_templates/src/Model/StyleModel.php
+++ b/administrator/components/com_templates/src/Model/StyleModel.php
@@ -558,7 +558,7 @@ class StyleModel extends AdminModel
 					->whereIn($db->quoteName('id'), $data['assigned'])
 					->where($db->quoteName('template_style_id') . ' != :tsid')
 					->where($db->quoteName('checked_out') .' IS NULL OR ' . $db->quoteName('checked_out') . ' = :userid')
-					->bind(':userid', $userid, ParameterType::INTEGER)
+					->bind(':userid', $userId, ParameterType::INTEGER)
 					->bind(':newtsid', $tableId, ParameterType::INTEGER)
 					->bind(':tsid', $tableId, ParameterType::INTEGER);
 				$db->setQuery($query);
@@ -579,7 +579,7 @@ class StyleModel extends AdminModel
 
 			$query->where($db->quoteName('template_style_id') . ' = :templatestyleid')
 				->where($db->quoteName('checked_out') .' IS NULL OR ' . $db->quoteName('checked_out') . ' = :userid')
-				->bind(':userid', $userid, ParameterType::INTEGER)
+				->bind(':userid', $userId, ParameterType::INTEGER)
 				->bind(':templatestyleid', $tableId, ParameterType::INTEGER);
 			$db->setQuery($query);
 			$db->execute();

--- a/administrator/components/com_templates/src/Model/StyleModel.php
+++ b/administrator/components/com_templates/src/Model/StyleModel.php
@@ -557,7 +557,8 @@ class StyleModel extends AdminModel
 					->set($db->quoteName('template_style_id') . ' = :newtsid')
 					->whereIn($db->quoteName('id'), $data['assigned'])
 					->where($db->quoteName('template_style_id') . ' != :tsid')
-					->whereIn($db->quoteName('checked_out'), [null, $userId])
+					->where($db->quoteName('checked_out') .' IS NULL OR ' . $db->quoteName('checked_out') . ' = :userid')
+					->bind(':userid', $userid, ParameterType::INTEGER)
 					->bind(':newtsid', $tableId, ParameterType::INTEGER)
 					->bind(':tsid', $tableId, ParameterType::INTEGER);
 				$db->setQuery($query);
@@ -577,7 +578,8 @@ class StyleModel extends AdminModel
 			}
 
 			$query->where($db->quoteName('template_style_id') . ' = :templatestyleid')
-				->whereIn($db->quoteName('checked_out'), [null, $userId])
+				->where($db->quoteName('checked_out') .' IS NULL OR ' . $db->quoteName('checked_out') . ' = :userid')
+				->bind(':userid', $userid, ParameterType::INTEGER)
 				->bind(':templatestyleid', $tableId, ParameterType::INTEGER);
 			$db->setQuery($query);
 			$db->execute();

--- a/administrator/components/com_templates/src/Model/StyleModel.php
+++ b/administrator/components/com_templates/src/Model/StyleModel.php
@@ -557,7 +557,7 @@ class StyleModel extends AdminModel
 					->set($db->quoteName('template_style_id') . ' = :newtsid')
 					->whereIn($db->quoteName('id'), $data['assigned'])
 					->where($db->quoteName('template_style_id') . ' != :tsid')
-					->where('(' . $db->quoteName('checked_out') .' IS NULL OR ' . $db->quoteName('checked_out') . ' = :userid)')
+					->where('(' . $db->quoteName('checked_out') . ' IS NULL OR ' . $db->quoteName('checked_out') . ' = :userid)')
 					->bind(':userid', $userId, ParameterType::INTEGER)
 					->bind(':newtsid', $tableId, ParameterType::INTEGER)
 					->bind(':tsid', $tableId, ParameterType::INTEGER);

--- a/administrator/components/com_templates/src/Model/StyleModel.php
+++ b/administrator/components/com_templates/src/Model/StyleModel.php
@@ -578,7 +578,7 @@ class StyleModel extends AdminModel
 			}
 
 			$query->where($db->quoteName('template_style_id') . ' = :templatestyleid')
-				->where('(' . $db->quoteName('checked_out') .' IS NULL OR ' . $db->quoteName('checked_out') . ' = :userid)')
+				->where('(' . $db->quoteName('checked_out') . ' IS NULL OR ' . $db->quoteName('checked_out') . ' = :userid)')
 				->bind(':userid', $userId, ParameterType::INTEGER)
 				->bind(':templatestyleid', $tableId, ParameterType::INTEGER);
 			$db->setQuery($query);

--- a/administrator/components/com_templates/src/Model/StyleModel.php
+++ b/administrator/components/com_templates/src/Model/StyleModel.php
@@ -578,7 +578,7 @@ class StyleModel extends AdminModel
 			}
 
 			$query->where($db->quoteName('template_style_id') . ' = :templatestyleid')
-				->where($db->quoteName('checked_out') .' IS NULL OR ' . $db->quoteName('checked_out') . ' = :userid')
+				->where('(' . $db->quoteName('checked_out') .' IS NULL OR ' . $db->quoteName('checked_out') . ' = :userid)')
 				->bind(':userid', $userId, ParameterType::INTEGER)
 				->bind(':templatestyleid', $tableId, ParameterType::INTEGER);
 			$db->setQuery($query);

--- a/administrator/components/com_templates/src/Model/StyleModel.php
+++ b/administrator/components/com_templates/src/Model/StyleModel.php
@@ -557,7 +557,7 @@ class StyleModel extends AdminModel
 					->set($db->quoteName('template_style_id') . ' = :newtsid')
 					->whereIn($db->quoteName('id'), $data['assigned'])
 					->where($db->quoteName('template_style_id') . ' != :tsid')
-					->where($db->quoteName('checked_out') .' IS NULL OR ' . $db->quoteName('checked_out') . ' = :userid')
+					->where('(' . $db->quoteName('checked_out') .' IS NULL OR ' . $db->quoteName('checked_out') . ' = :userid)')
 					->bind(':userid', $userId, ParameterType::INTEGER)
 					->bind(':newtsid', $tableId, ParameterType::INTEGER)
 					->bind(':tsid', $tableId, ParameterType::INTEGER);


### PR DESCRIPTION
### Steps to reproduce the issue
Save a template style with menu assignments (4.0-beta-3-dev)

### Expected result
Template style saved with menu assignments

### Actual result
None of the menu assignments are saved

### System information (as much as possible)
Joomla 4.0-beta-3-dev - Linux - PHP 7.4.8 - MySql 5.7.28


### Additional comments

In the Administrator StyleModel.php function Save, replace in the 2 queries :

```
->whereIn($db->quoteName('checked_out'), [null, $userId])
```

by something like :

```
->where($db->quoteName('checked_out') .' IS NULL OR ' . $db->quoteName('checked_out') . ' = :userid')

->bind(':userid', $userid, ParameterType::INTEGER)
```

I think maybe there is something wrong in the query with `whereIn` php `null` and the mysql check `IS NULL`

`= NULL` or `IN (NULL)` may not work sometimes

`->where($db->quoteName('checked_out') . '= NULL')` => not work

`->whereIn($db->quoteName('checked_out'), [null])` => not work

