### PR TITLE
Add upload file size check to Extensions Installer Upload & Install Package

### DIFF
--- a/plugins/installer/packageinstaller/tmpl/default.php
+++ b/plugins/installer/packageinstaller/tmpl/default.php
@@ -14,6 +14,7 @@ JHtml::_('jquery.token');
 
 JText::script('PLG_INSTALLER_PACKAGEINSTALLER_UPLOAD_ERROR_UNKNOWN');
 JText::script('PLG_INSTALLER_PACKAGEINSTALLER_UPLOAD_ERROR_EMPTY');
+JText::script('COM_INSTALLER_MSG_WARNINGS_UPLOADFILETOOBIG');
 
 JFactory::getDocument()->addScriptDeclaration('
 	Joomla.submitbuttonpackage = function()
@@ -24,6 +25,10 @@ JFactory::getDocument()->addScriptDeclaration('
 		if (form.install_package.value == "")
 		{
 			alert("' . JText::_('PLG_INSTALLER_PACKAGEINSTALLER_NO_PACKAGE', true) . '");
+		}
+		else if (form.install_package.files[0].size > form.max_upload_size.value)
+		{
+			alert("' . JText::_('COM_INSTALLER_MSG_WARNINGS_UPLOADFILETOOBIG', true) . '");
 		}
 		else
 		{
@@ -48,16 +53,17 @@ JFactory::getDocument()->addScriptDeclaration(
 			return;
 		}
 
-		var uploading = false;
-		var dragZone  = $('#dragarea');
-		var fileInput = $('#install_package');
-		var button    = $('#select-file-button');
-		var url       = 'index.php?option=com_installer&task=install.ajax_upload';
-		var returnUrl = $('#installer-return').val();
-		var actions   = $('.upload-actions');
-		var progress  = $('.upload-progress');
+		var uploading   = false;
+		var dragZone    = $('#dragarea');
+		var fileInput   = $('#install_package');
+		var fileSizeMax = $('#max_upload_size').val();
+		var button      = $('#select-file-button');
+		var url         = 'index.php?option=com_installer&task=install.ajax_upload';
+		var returnUrl   = $('#installer-return').val();
+		var actions     = $('.upload-actions');
+		var progress    = $('.upload-progress');
 		var progressBar = progress.find('.bar');
-		var percentage = progress.find('.uploading-number');
+		var percentage  = progress.find('.uploading-number');
 
 		if (returnUrl) {
 			url += '&return=' + returnUrl;
@@ -121,6 +127,12 @@ JFactory::getDocument()->addScriptDeclaration(
 			var file = files[0];
 
 			var data = new FormData;
+
+			if (file.size > fileSizeMax) {
+				alert(Joomla.JText._('COM_INSTALLER_MSG_WARNINGS_UPLOADFILETOOBIG'), true);
+				return;
+			}
+
 			data.append('install_package', file);
 			data.append('installtype', 'upload');
 
@@ -278,7 +290,8 @@ JFactory::getDocument()->addStyleDeclaration(
 CSS
 );
 
-$maxSize = JFilesystemHelper::fileUploadMaxSize();
+$maxSizeBytes = JFilesystemHelper::fileUploadMaxSize(false);
+$maxSize = JHtml::_('number.bytes', $maxSizeBytes);
 ?>
 <legend><?php echo JText::_('PLG_INSTALLER_PACKAGEINSTALLER_UPLOAD_INSTALL_JOOMLA_EXTENSION'); ?></legend>
 
@@ -337,7 +350,8 @@ $maxSize = JFilesystemHelper::fileUploadMaxSize();
 	<div class="control-group">
 		<label for="install_package" class="control-label"><?php echo JText::_('PLG_INSTALLER_PACKAGEINSTALLER_EXTENSION_PACKAGE_FILE'); ?></label>
 		<div class="controls">
-			<input class="input_box" id="install_package" name="install_package" type="file" size="57" /><br>
+			<input class="input_box" id="install_package" name="install_package" type="file" size="57" />
+			<input id="max_upload_size" name="max_upload_size" type="hidden" value="<?php echo $maxSizeBytes; ?>" /><br>
 			<?php echo JText::sprintf('JGLOBAL_MAXIMUM_UPLOAD_SIZE_LIMIT', $maxSize); ?>
 		</div>
 	</div>


### PR DESCRIPTION
Pull Request for Issue [https://github.com/joomla/joomla-cms/issues/27494#issuecomment-573425846](https://github.com/joomla/joomla-cms/issues/27494#issuecomment-573425846).

Requires PR #29895 for the language strings.

### Summary of Changes

This Pull Request (PR) is a back port of PR #27665 from 4.0-dev.

It adds a check if the selected file is too big to be uploaded with respect to the PHP limits to the "Upload & Install Package" tab of the Extensions Installer.

If the user tries to upload a file which is too big, the upload is rejected with an appropriate browser alert message.

### Testing Instructions

**Requirements:**
PR #29895 for the language strings.

**Procedure:**
1. Apply the patch of this PR and also the patch of PR #29895 .
2. Go to `administrator/index.php?option=com_installer&view=install` and there to tab "Upload Package File".
3. Drag to the drag and drop area a file which **is** too big compared to the maximum upload size shown below the file selection.
**Hint:** This can be any file, it doesn't necessarily have to be a valid extension package.
**Result:** See screenshot  in section "Expected result" below. A browser alert is shown telling that the file can't be uploaded because it's too big. The upload is not started.
4. Select a file which **is** too big, using the "Or browse for file" button.
**Result:** Same as in previous step. A browser alert is shown telling that the file can't be uploaded because it's too big.
5. Drag to the drag and drop area a file which is **not** too big compared to the maximum upload size shown below the file selection.
**Result:** Uploading of not too big package file using drag and drop still works as well as without this PR.
6. Finally select another package file which is **not** too big, using the "Or browse for file" button, and verify that uploading still works.
**Result:** Uploading of not too big package file using the "Or browse for file" button still works as well as without this PR.

### Actual result BEFORE applying this Pull Request

- If `post_max_size` is big enough but `upload_max_size` is violated:
![j3-pr-30190-upload-max-filesize-violated](https://user-images.githubusercontent.com/7413183/88464276-b50cad80-ceb9-11ea-986e-f4daa62e69a5.png)

- If `upload_max_size` is big enough but `post_max_size` is violated:
There is no error shown in backend if display errors is off in PHP config.
In the PHP log file (if log_errors is switched on in PHP config):
`PHP Warning:  POST Content-Length of 24829262 bytes exceeds the limit of 16777216 bytes in Unknown on line 0, referer: https://www.joomla.vmkubu02.vmnet2.local/administrator/index.php?option=com_installer`

### Expected result AFTER applying this Pull Request

Broswer alert when trying to upload too big file:
![j3-pr-30190-alert-after-patch](https://user-images.githubusercontent.com/7413183/88464412-d02bed00-ceba-11ea-949a-cacb3c8d70a3.png)

### Documentation Changes Required

None.