### PR TITLE
[4.0] Child templates 

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/4.0.0-2020-06-25.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.0.0-2020-06-25.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `#__template_styles` ADD COLUMN `parent` tinyint(1) NOT NULL DEFAULT '0';
+ALTER TABLE `#__template_styles` ADD COLUMN `inherits` varchar(50) DEFAULT '';

--- a/administrator/components/com_admin/sql/updates/mysql/4.0.0-2020-06-25.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.0.0-2020-06-25.sql
@@ -1,2 +1,2 @@
-ALTER TABLE `#__template_styles` ADD COLUMN `inheritable` tinyint(1) NOT NULL DEFAULT '0';
+ALTER TABLE `#__template_styles` ADD COLUMN `inheritable` tinyint(1) NOT NULL DEFAULT 0;
 ALTER TABLE `#__template_styles` ADD COLUMN `parent` varchar(50) DEFAULT '';

--- a/administrator/components/com_admin/sql/updates/mysql/4.0.0-2020-06-25.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.0.0-2020-06-25.sql
@@ -1,2 +1,2 @@
-ALTER TABLE `#__template_styles` ADD COLUMN `parent` tinyint(1) NOT NULL DEFAULT '0';
-ALTER TABLE `#__template_styles` ADD COLUMN `inherits` varchar(50) DEFAULT '';
+ALTER TABLE `#__template_styles` ADD COLUMN `inheritable` tinyint(1) NOT NULL DEFAULT '0';
+ALTER TABLE `#__template_styles` ADD COLUMN `parent` varchar(50) DEFAULT '';

--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2020-06-25.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2020-06-25.sql
@@ -1,2 +1,2 @@
-ALTER TABLE "#__template_styles" ADD COLUMN "parent" smallint NOT NULL DEFAULT 0;
-ALTER TABLE "#__template_styles" ADD COLUMN "inherits" varchar(50) DEFAULT "";
+ALTER TABLE "#__template_styles" ADD COLUMN "inheritable" smallint NOT NULL DEFAULT 0;
+ALTER TABLE "#__template_styles" ADD COLUMN "parent" varchar(50) DEFAULT "";

--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2020-06-25.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2020-06-25.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "#__template_styles" ADD COLUMN "parent" smallint NOT NULL DEFAULT 0;
+ALTER TABLE "#__template_styles" ADD COLUMN "inherits" varchar(50) DEFAULT "";

--- a/installation/sql/mysql/base.sql
+++ b/installation/sql/mysql/base.sql
@@ -796,8 +796,8 @@ CREATE TABLE IF NOT EXISTS `#__template_styles` (
 --
 
 INSERT INTO `#__template_styles` (`id`, `template`, `client_id`, `home`, `title`, `inheritable`, `parent`, `params`) VALUES
-(10, 'atum', 1, '1', 'atum - Default', '0', '0', ''),
-(11, 'cassiopeia', 0, '1', 'cassiopeia - Default', '0', '0', '{"logoFile":"","fluidContainer":"0","sidebarLeftWidth":"3","sidebarRightWidth":"3"}');
+(10, 'atum', 1, '1', 'atum - Default', '0', '', ''),
+(11, 'cassiopeia', 0, '1', 'cassiopeia - Default', '0', '', '{"logoFile":"","fluidContainer":"0","sidebarLeftWidth":"3","sidebarRightWidth":"3"}');
 
 -- --------------------------------------------------------
 

--- a/installation/sql/mysql/base.sql
+++ b/installation/sql/mysql/base.sql
@@ -796,8 +796,8 @@ CREATE TABLE IF NOT EXISTS `#__template_styles` (
 --
 
 INSERT INTO `#__template_styles` (`id`, `template`, `client_id`, `home`, `title`, `inheritable`, `parent`, `params`) VALUES
-(10, 'atum', 1, '1', 'atum - Default', '0', '', ''),
-(11, 'cassiopeia', 0, '1', 'cassiopeia - Default', '0', '', '{"logoFile":"","fluidContainer":"0","sidebarLeftWidth":"3","sidebarRightWidth":"3"}');
+(10, 'atum', 1, '1', 'atum - Default', 0, '', ''),
+(11, 'cassiopeia', 0, '1', 'cassiopeia - Default', 0, '', '{"logoFile":"","fluidContainer":"0","sidebarLeftWidth":"3","sidebarRightWidth":"3"}');
 
 -- --------------------------------------------------------
 

--- a/installation/sql/mysql/base.sql
+++ b/installation/sql/mysql/base.sql
@@ -782,7 +782,7 @@ CREATE TABLE IF NOT EXISTS `#__template_styles` (
   `client_id` tinyint(1) unsigned NOT NULL DEFAULT 0,
   `home` char(7) NOT NULL DEFAULT '0',
   `title` varchar(255) NOT NULL DEFAULT '',
-  `inheritable` tinyint(1) NOT NULL DEFAULT '0',
+  `inheritable` tinyint(1) NOT NULL DEFAULT 0,
   `parent` varchar(50) DEFAULT '',
   `params` text NOT NULL,
   PRIMARY KEY (`id`),

--- a/installation/sql/mysql/base.sql
+++ b/installation/sql/mysql/base.sql
@@ -782,6 +782,8 @@ CREATE TABLE IF NOT EXISTS `#__template_styles` (
   `client_id` tinyint(1) unsigned NOT NULL DEFAULT 0,
   `home` char(7) NOT NULL DEFAULT '0',
   `title` varchar(255) NOT NULL DEFAULT '',
+  `parent` tinyint(1) NOT NULL DEFAULT '0',
+  `inherits` varchar(50) DEFAULT '',
   `params` text NOT NULL,
   PRIMARY KEY (`id`),
   KEY `idx_template` (`template`),
@@ -793,9 +795,9 @@ CREATE TABLE IF NOT EXISTS `#__template_styles` (
 -- Dumping data for table `#__template_styles`
 --
 
-INSERT INTO `#__template_styles` (`id`, `template`, `client_id`, `home`, `title`, `params`) VALUES
-(10, 'atum', 1, '1', 'atum - Default', ''),
-(11, 'cassiopeia', 0, '1', 'cassiopeia - Default', '{"logoFile":"","fluidContainer":"0","sidebarLeftWidth":"3","sidebarRightWidth":"3"}');
+INSERT INTO `#__template_styles` (`id`, `template`, `client_id`, `home`, `title`, `parent`, `inherits`, `params`) VALUES
+(10, 'atum', 1, '1', 'atum - Default', '0', '0', ''),
+(11, 'cassiopeia', 0, '1', 'cassiopeia - Default', '0', '0', '{"logoFile":"","fluidContainer":"0","sidebarLeftWidth":"3","sidebarRightWidth":"3"}');
 
 -- --------------------------------------------------------
 

--- a/installation/sql/mysql/base.sql
+++ b/installation/sql/mysql/base.sql
@@ -782,8 +782,8 @@ CREATE TABLE IF NOT EXISTS `#__template_styles` (
   `client_id` tinyint(1) unsigned NOT NULL DEFAULT 0,
   `home` char(7) NOT NULL DEFAULT '0',
   `title` varchar(255) NOT NULL DEFAULT '',
-  `parent` tinyint(1) NOT NULL DEFAULT '0',
-  `inherits` varchar(50) DEFAULT '',
+  `inheritable` tinyint(1) NOT NULL DEFAULT '0',
+  `parent` varchar(50) DEFAULT '',
   `params` text NOT NULL,
   PRIMARY KEY (`id`),
   KEY `idx_template` (`template`),
@@ -795,7 +795,7 @@ CREATE TABLE IF NOT EXISTS `#__template_styles` (
 -- Dumping data for table `#__template_styles`
 --
 
-INSERT INTO `#__template_styles` (`id`, `template`, `client_id`, `home`, `title`, `parent`, `inherits`, `params`) VALUES
+INSERT INTO `#__template_styles` (`id`, `template`, `client_id`, `home`, `title`, `inheritable`, `parent`, `params`) VALUES
 (10, 'atum', 1, '1', 'atum - Default', '0', '0', ''),
 (11, 'cassiopeia', 0, '1', 'cassiopeia - Default', '0', '0', '{"logoFile":"","fluidContainer":"0","sidebarLeftWidth":"3","sidebarRightWidth":"3"}');
 

--- a/installation/sql/postgresql/base.sql
+++ b/installation/sql/postgresql/base.sql
@@ -798,8 +798,8 @@ CREATE TABLE IF NOT EXISTS "#__template_styles" (
   "client_id" smallint DEFAULT 0 NOT NULL,
   "home" varchar(7) DEFAULT '0' NOT NULL,
   "title" varchar(255) DEFAULT '' NOT NULL,
-  `parent` tinyint(1) DEFAULT '0' NOT NULL,
-  `inherits` varchar(50) DEFAULT '',
+  `inheritable` tinyint(1) DEFAULT '0' NOT NULL,
+  `parent` varchar(50) DEFAULT '',
   "params" text NOT NULL,
   PRIMARY KEY ("id")
 );
@@ -810,7 +810,7 @@ CREATE INDEX "#__template_styles_idx_client_id_home" ON "#__template_styles" ("c
 --
 -- Dumping data for table `#__template_styles`
 --
-INSERT INTO "#__template_styles" ("id", "template", "client_id", "home", "title", "parent", "inherits", "params") VALUES
+INSERT INTO "#__template_styles" ("id", "template", "client_id", "home", "title", "inheritable", "parent", "params") VALUES
 (10, 'atum', 1, '1', 'atum - Default', '0', '', ''),
 (11, 'cassiopeia', 0, '1', 'cassiopeia - Default', '0', '', '{"logoFile":"","fluidContainer":"0","sidebarLeftWidth":"3","sidebarRightWidth":"3"}');
 

--- a/installation/sql/postgresql/base.sql
+++ b/installation/sql/postgresql/base.sql
@@ -810,8 +810,7 @@ CREATE INDEX "#__template_styles_idx_client_id_home" ON "#__template_styles" ("c
 --
 -- Dumping data for table `#__template_styles`
 --
-
-INSERT INTO "#__template_styles" (`id`, `template`, `client_id`, `home`, `title`, `parent`, `inherits`, `params`) VALUES
+INSERT INTO "#__template_styles" ("id", "template", "client_id", "home", "title", "parent", "inherits", "params") VALUES
 (10, 'atum', 1, '1', 'atum - Default', '0', '', ''),
 (11, 'cassiopeia', 0, '1', 'cassiopeia - Default', '0', '', '{"logoFile":"","fluidContainer":"0","sidebarLeftWidth":"3","sidebarRightWidth":"3"}');
 

--- a/installation/sql/postgresql/base.sql
+++ b/installation/sql/postgresql/base.sql
@@ -811,8 +811,8 @@ CREATE INDEX "#__template_styles_idx_client_id_home" ON "#__template_styles" ("c
 -- Dumping data for table `#__template_styles`
 --
 INSERT INTO "#__template_styles" ("id", "template", "client_id", "home", "title", "inheritable", "parent", "params") VALUES
-(10, 'atum', 1, '1', 'atum - Default', '0', '', ''),
-(11, 'cassiopeia', 0, '1', 'cassiopeia - Default', '0', '', '{"logoFile":"","fluidContainer":"0","sidebarLeftWidth":"3","sidebarRightWidth":"3"}');
+(10, 'atum', 1, '1', 'atum - Default', 0, '', ''),
+(11, 'cassiopeia', 0, '1', 'cassiopeia - Default', 0, '', '{"logoFile":"","fluidContainer":"0","sidebarLeftWidth":"3","sidebarRightWidth":"3"}');
 
 SELECT setval('#__template_styles_id_seq', 12, false);
 

--- a/installation/sql/postgresql/base.sql
+++ b/installation/sql/postgresql/base.sql
@@ -798,7 +798,7 @@ CREATE TABLE IF NOT EXISTS "#__template_styles" (
   "client_id" smallint DEFAULT 0 NOT NULL,
   "home" varchar(7) DEFAULT '0' NOT NULL,
   "title" varchar(255) DEFAULT '' NOT NULL,
-  `inheritable` tinyint(1) DEFAULT '0' NOT NULL,
+  `inheritable` smallint DEFAULT 0 NOT NULL,
   `parent` varchar(50) DEFAULT '',
   "params" text NOT NULL,
   PRIMARY KEY ("id")

--- a/installation/sql/postgresql/base.sql
+++ b/installation/sql/postgresql/base.sql
@@ -798,6 +798,8 @@ CREATE TABLE IF NOT EXISTS "#__template_styles" (
   "client_id" smallint DEFAULT 0 NOT NULL,
   "home" varchar(7) DEFAULT '0' NOT NULL,
   "title" varchar(255) DEFAULT '' NOT NULL,
+  `parent` tinyint(1) DEFAULT '0' NOT NULL,
+  `inherits` varchar(50) DEFAULT '',
   "params" text NOT NULL,
   PRIMARY KEY ("id")
 );
@@ -809,9 +811,9 @@ CREATE INDEX "#__template_styles_idx_client_id_home" ON "#__template_styles" ("c
 -- Dumping data for table `#__template_styles`
 --
 
-INSERT INTO "#__template_styles" ("id", "template", "client_id", "home", "title", "params") VALUES
-(10, 'atum', 1, '1', 'atum - Default', ''),
-(11, 'cassiopeia', 0, '1', 'cassiopeia - Default', '{"logoFile":"","fluidContainer":"0","sidebarLeftWidth":"3","sidebarRightWidth":"3"}');
+INSERT INTO "#__template_styles" (`id`, `template`, `client_id`, `home`, `title`, `parent`, `inherits`, `params`) VALUES
+(10, 'atum', 1, '1', 'atum - Default', '0', '', ''),
+(11, 'cassiopeia', 0, '1', 'cassiopeia - Default', '0', '', '{"logoFile":"","fluidContainer":"0","sidebarLeftWidth":"3","sidebarRightWidth":"3"}');
 
 SELECT setval('#__template_styles_id_seq', 12, false);
 

--- a/installation/src/Application/InstallationApplication.php
+++ b/installation/src/Application/InstallationApplication.php
@@ -405,11 +405,28 @@ final class InstallationApplication extends CMSApplication
 			$template = new \stdClass;
 			$template->template = 'template';
 			$template->params = new Registry;
+			$template->parent = 0;
+			$template->inherits = null;
 
 			return $template;
 		}
 
 		return 'template';
+	}
+
+	/**
+	 * Gets the name of the current template.
+	 *
+	 * @param   boolean  $params  True to return the template parameters
+	 * @param   string   $name    The name of the template
+	 *
+	 * @return  string  The name of the template.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getTemplateByName($params = false, $name = '')
+	{
+		return $this->getTemplate($params);
 	}
 
 	/**

--- a/installation/src/Application/InstallationApplication.php
+++ b/installation/src/Application/InstallationApplication.php
@@ -415,21 +415,6 @@ final class InstallationApplication extends CMSApplication
 	}
 
 	/**
-	 * Gets the name of the current template.
-	 *
-	 * @param   boolean  $params  True to return the template parameters
-	 * @param   string   $name    The name of the template
-	 *
-	 * @return  string  The name of the template.
-	 *
-	 * @since   __DEPLOY_VERSION__
-	 */
-	public function getTemplateByName($params = false, $name = '')
-	{
-		return $this->getTemplate($params);
-	}
-
-	/**
 	 * Initialise the application.
 	 *
 	 * @param   array  $options  An optional associative array of configuration settings.

--- a/installation/src/Application/InstallationApplication.php
+++ b/installation/src/Application/InstallationApplication.php
@@ -401,7 +401,7 @@ final class InstallationApplication extends CMSApplication
 	public function getTemplate($params = false)
 	{
 		// Pass the parent template to the state
-		$this->set('templateInherits', '');
+		$this->set('themeInherits', '');
 
 		if ($params)
 		{

--- a/installation/src/Application/InstallationApplication.php
+++ b/installation/src/Application/InstallationApplication.php
@@ -405,8 +405,8 @@ final class InstallationApplication extends CMSApplication
 			$template = new \stdClass;
 			$template->template = 'template';
 			$template->params = new Registry;
-			$template->parent = 0;
-			$template->inherits = null;
+			$template->inheritable = 0;
+			$template->parent = null;
 
 			return $template;
 		}

--- a/installation/src/Application/InstallationApplication.php
+++ b/installation/src/Application/InstallationApplication.php
@@ -400,6 +400,9 @@ final class InstallationApplication extends CMSApplication
 	 */
 	public function getTemplate($params = false)
 	{
+		// Pass the parent template to the state
+ 		$this->set('themeInherits', '');
+
 		if ($params)
 		{
 			$template = new \stdClass;

--- a/installation/src/Application/InstallationApplication.php
+++ b/installation/src/Application/InstallationApplication.php
@@ -401,7 +401,7 @@ final class InstallationApplication extends CMSApplication
 	public function getTemplate($params = false)
 	{
 		// Pass the parent template to the state
-		$this->set('themeInherits', '');
+		$this->set('templateInherits', '');
 
 		if ($params)
 		{

--- a/installation/src/Application/InstallationApplication.php
+++ b/installation/src/Application/InstallationApplication.php
@@ -400,9 +400,6 @@ final class InstallationApplication extends CMSApplication
 	 */
 	public function getTemplate($params = false)
 	{
-		// Pass the parent template to the state
-		$this->set('themeInherits', '');
-
 		if ($params)
 		{
 			$template = new \stdClass;
@@ -549,10 +546,11 @@ final class InstallationApplication extends CMSApplication
 			$file = $this->input->getCmd('tmpl', 'index');
 
 			$options = [
-				'template'  => 'template',
-				'file'      => $file . '.php',
-				'directory' => JPATH_THEMES,
-				'params'    => '{}',
+				'template'         => 'template',
+				'file'             => $file . '.php',
+				'directory'        => JPATH_THEMES,
+				'params'           => '{}',
+				"templateInherits" => ''
 			];
 		}
 

--- a/installation/src/Application/InstallationApplication.php
+++ b/installation/src/Application/InstallationApplication.php
@@ -401,7 +401,7 @@ final class InstallationApplication extends CMSApplication
 	public function getTemplate($params = false)
 	{
 		// Pass the parent template to the state
- 		$this->set('themeInherits', '');
+		$this->set('themeInherits', '');
 
 		if ($params)
 		{

--- a/libraries/src/Application/AdministratorApplication.php
+++ b/libraries/src/Application/AdministratorApplication.php
@@ -236,7 +236,8 @@ class AdministratorApplication extends CMSApplication
 			$db->quoteName('s.home') . ' = ' . $db->quote('1'),
 		];
 
-		if ('' !== $name) {
+		if ('' !== $name)
+		{
 			$conditions[] = $db->quoteName('e.element') . ' = ' . $name;
 		}
 
@@ -273,10 +274,8 @@ class AdministratorApplication extends CMSApplication
 		$template->params = new Registry($template->params);
 
 		// Fallback template
-		if (
-			!file_exists(JPATH_THEMES . '/' . $template->template . '/index.php')
-			&& !file_exists(JPATH_THEMES . '/' . $template->inherits . '/index.php')
-		)
+		if (!file_exists(JPATH_THEMES . '/' . $template->template . '/index.php')
+			&& !file_exists(JPATH_THEMES . '/' . $template->inherits . '/index.php'))
 		{
 			$this->enqueueMessage(Text::_('JERROR_ALERTNOTEMPLATE'), 'error');
 			$template->params = new Registry;

--- a/libraries/src/Application/AdministratorApplication.php
+++ b/libraries/src/Application/AdministratorApplication.php
@@ -207,14 +207,13 @@ class AdministratorApplication extends CMSApplication
 	 * Gets the name of the current template.
 	 *
 	 * @param   boolean  $params  True to return the template parameters
-	 * @param   string   $name    The name of the template
 	 *
 	 * @return  string  The name of the template.
 	 *
-	 * @since   __DEPLOY_VERSION__
+	 * @since   3.2
 	 * @throws  \InvalidArgumentException
 	 */
-	public function getTemplateByName($params = false, $name = '')
+	public function getTemplate($params = false)
 	{
 		if (\is_object($this->template))
 		{
@@ -231,16 +230,6 @@ class AdministratorApplication extends CMSApplication
 		// Load the template name from the database
 		$db = Factory::getDbo();
 
-		$conditions = [
-			$db->quoteName('s.client_id') . ' = 1',
-			$db->quoteName('s.home') . ' = ' . $db->quote('1'),
-		];
-
-		if ('' !== $name)
-		{
-			$conditions[] = $db->quoteName('e.element') . ' = ' . $name;
-		}
-
 		$query = $db->getQuery(true)
 			->select($db->quoteName(['s.template', 's.params', 's.parent', 's.inherits']))
 			->from($db->quoteName('#__template_styles', 's'))
@@ -251,7 +240,12 @@ class AdministratorApplication extends CMSApplication
 					. ' AND ' . $db->quoteName('e.element') . ' = ' . $db->quoteName('s.template')
 					. ' AND ' . $db->quoteName('e.client_id') . ' = ' . $db->quoteName('s.client_id')
 			)
-			->where($conditions);
+			->where(
+				[
+					$db->quoteName('s.client_id') . ' = 1',
+					$db->quoteName('s.home') . ' = ' . $db->quote('1'),
+				]
+			);
 
 		if ($admin_style)
 		{
@@ -297,21 +291,6 @@ class AdministratorApplication extends CMSApplication
 		}
 
 		return $template->template;
-	}
-
-	/**
-	 * Gets the name of the current template.
-	 *
-	 * @param   boolean  $params  True to return the template parameters
-	 *
-	 * @return  string  The name of the template.
-	 *
-	 * @since   3.2
-	 * @throws  \InvalidArgumentException
-	 */
-	public function getTemplate($params = false)
-	{
-		return $this->getTemplateByName($params, '');
 	}
 
 	/**

--- a/libraries/src/Application/AdministratorApplication.php
+++ b/libraries/src/Application/AdministratorApplication.php
@@ -122,9 +122,9 @@ class AdministratorApplication extends CMSApplication
 					$wr->addExtensionRegistryFile($component);
 				}
 
-				if (!empty($template->inherits))
+				if (!empty($template->parent))
 				{
-					$wr->addTemplateRegistryFile($template->inherits, $clientId);
+					$wr->addTemplateRegistryFile($template->parent, $clientId);
 				}
 
 				$wr->addTemplateRegistryFile($template->template, $clientId);
@@ -231,7 +231,7 @@ class AdministratorApplication extends CMSApplication
 		$db = Factory::getDbo();
 
 		$query = $db->getQuery(true)
-			->select($db->quoteName(['s.template', 's.params', 's.parent', 's.inherits']))
+			->select($db->quoteName(['s.template', 's.params', 's.inheritable', 's.parent']))
 			->from($db->quoteName('#__template_styles', 's'))
 			->join(
 				'LEFT',
@@ -269,7 +269,7 @@ class AdministratorApplication extends CMSApplication
 
 		// Fallback template
 		if (!file_exists(JPATH_THEMES . '/' . $template->template . '/index.php')
-			&& !file_exists(JPATH_THEMES . '/' . $template->inherits . '/index.php'))
+			&& !file_exists(JPATH_THEMES . '/' . $template->parent . '/index.php'))
 		{
 			$this->enqueueMessage(Text::_('JERROR_ALERTNOTEMPLATE'), 'error');
 			$template->params = new Registry;
@@ -284,6 +284,9 @@ class AdministratorApplication extends CMSApplication
 
 		// Cache the result
 		$this->template = $template;
+
+		// Pass the parent template to the state
+		$this->set('themeInherits', $template->parent);
 
 		if ($params)
 		{

--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -945,7 +945,7 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
 		$this->docOptions['file']             = $this->get('themeFile', 'index.php');
 		$this->docOptions['params']           = $this->get('themeParams');
 		$this->docOptions['csp_nonce']        = $this->get('csp_nonce');
-		$this->docOptions['templateInherits'] = $this->get('themeInherits') ?? '';
+		$this->docOptions['templateInherits'] = $this->get('themeInherits');
 
 		if ($this->get('themes.base'))
 		{

--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -561,17 +561,19 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
 	 */
 	public function getTemplate($params = false)
 	{
-		$template = new \stdClass;
-
-		$template->template = 'system';
-		$template->params   = new Registry;
-
 		if ($params)
 		{
+			$template = new \stdClass;
+
+			$template->template = 'system';
+			$template->params   = new Registry;
+			$template->parent   = 0;
+			$template->inherits = '';
+
 			return $template;
 		}
 
-		return $template->template;
+		return 'system';
 	}
 
 	/**

--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -941,10 +941,11 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
 	protected function render()
 	{
 		// Setup the document options.
-		$this->docOptions['template']  = $this->get('theme');
-		$this->docOptions['file']      = $this->get('themeFile', 'index.php');
-		$this->docOptions['params']    = $this->get('themeParams');
-		$this->docOptions['csp_nonce'] = $this->get('csp_nonce');
+		$this->docOptions['template']         = $this->get('theme');
+		$this->docOptions['file']             = $this->get('themeFile', 'index.php');
+		$this->docOptions['params']           = $this->get('themeParams');
+		$this->docOptions['csp_nonce']        = $this->get('csp_nonce');
+		$this->docOptions['templateInherits'] = $this->get('themeInherits');
 
 		if ($this->get('themes.base'))
 		{

--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -565,10 +565,10 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
 		{
 			$template = new \stdClass;
 
-			$template->template = 'system';
-			$template->params   = new Registry;
-			$template->parent   = 0;
-			$template->inherits = '';
+			$template->template    = 'system';
+			$template->params      = new Registry;
+			$template->inheritable = 0;
+			$template->parent      = '';
 
 			return $template;
 		}

--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -945,7 +945,7 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
 		$this->docOptions['file']             = $this->get('themeFile', 'index.php');
 		$this->docOptions['params']           = $this->get('themeParams');
 		$this->docOptions['csp_nonce']        = $this->get('csp_nonce');
-		$this->docOptions['templateInherits'] = $this->get('themeInherits');
+		$this->docOptions['templateInherits'] = $this->get('themeInherits') ?? '';
 
 		if ($this->get('themes.base'))
 		{

--- a/libraries/src/Application/SiteApplication.php
+++ b/libraries/src/Application/SiteApplication.php
@@ -176,9 +176,9 @@ final class SiteApplication extends CMSApplication
 					$wr->addExtensionRegistryFile($component);
 				}
 
-				if ($template->inherits)
+				if ($template->parent)
 				{
-					$wr->addTemplateRegistryFile($template->inherits, $this->getClientId());
+					$wr->addTemplateRegistryFile($template->parent, $this->getClientId());
 				}
 
 				$wr->addTemplateRegistryFile($template->template, $this->getClientId());
@@ -399,11 +399,11 @@ final class SiteApplication extends CMSApplication
 	{
 		if (\is_object($this->template))
 		{
-			if ($this->template->inherits)
+			if ($this->template->parent)
 			{
 				if (!file_exists(JPATH_THEMES . '/' . $this->template->template . '/index.php'))
 				{
-					if (!file_exists(JPATH_THEMES . '/' . $this->template->inherits . '/index.php'))
+					if (!file_exists(JPATH_THEMES . '/' . $this->template->parent . '/index.php'))
 					{
 						throw new \InvalidArgumentException(Text::sprintf('JERROR_COULD_NOT_FIND_TEMPLATE', $this->template->template));
 					}
@@ -470,7 +470,7 @@ final class SiteApplication extends CMSApplication
 			$db = Factory::getDbo();
 
 			$query = $db->getQuery(true)
-				->select($db->quoteName(['id', 'home', 'template', 's.params', 'parent', 'inherits']))
+				->select($db->quoteName(['id', 'home', 'template', 's.params', 'inheritable', 'parent']))
 				->from($db->quoteName('#__template_styles', 's'))
 				->where(
 					[
@@ -545,11 +545,11 @@ final class SiteApplication extends CMSApplication
 		$template->template = InputFilter::getInstance()->clean($template->template, 'cmd');
 
 		// Fallback template
-		if (!empty($template->inherits))
+		if (!empty($template->parent))
 		{
 			if (!file_exists(JPATH_THEMES . '/' . $template->template . '/index.php'))
 			{
-				if (!file_exists(JPATH_THEMES . '/' . $template->inherits . '/index.php'))
+				if (!file_exists(JPATH_THEMES . '/' . $template->parent . '/index.php'))
 				{
 					$this->enqueueMessage(Text::_('JERROR_ALERTNOTEMPLATE'), 'error');
 
@@ -796,7 +796,7 @@ final class SiteApplication extends CMSApplication
 				}
 
 				// Pass the parent template to the state
-				$this->set('themeInherits', $template->inherits);
+				$this->set('themeInherits', $template->parent);
 
 				break;
 		}

--- a/libraries/src/Application/SiteApplication.php
+++ b/libraries/src/Application/SiteApplication.php
@@ -580,7 +580,6 @@ final class SiteApplication extends CMSApplication
 						throw new \InvalidArgumentException(Text::sprintf('JERROR_COULD_NOT_FIND_TEMPLATE', $original_tmpl));
 					}
 				}
-
 			}
 		}
 		elseif (!file_exists(JPATH_THEMES . '/' . $template->template . '/index.php'))

--- a/libraries/src/Application/SiteApplication.php
+++ b/libraries/src/Application/SiteApplication.php
@@ -796,7 +796,7 @@ final class SiteApplication extends CMSApplication
 				}
 
 				// Pass the parent template to the state
-				$this->set('themeInherit', $template->inherits);
+				$this->set('themeInherits', $template->inherits);
 
 				break;
 		}

--- a/libraries/src/Application/SiteApplication.php
+++ b/libraries/src/Application/SiteApplication.php
@@ -389,14 +389,13 @@ final class SiteApplication extends CMSApplication
 	 * Gets the name of the current template.
 	 *
 	 * @param   boolean  $params  True to return the template parameters
-	 * @param   string   $name    The template name
 	 *
 	 * @return  string  The name of the template.
 	 *
 	 * @since   3.2
 	 * @throws  \InvalidArgumentException
 	 */
-	public function getTemplateByName($params = false, $name = '')
+	public function getTemplate($params = false)
 	{
 		if (\is_object($this->template))
 		{
@@ -470,20 +469,15 @@ final class SiteApplication extends CMSApplication
 			// Load styles
 			$db = Factory::getDbo();
 
-			$conditions = [
-				$db->quoteName('s.client_id') . ' = 0',
-				$db->quoteName('e.enabled') . ' = 1',
-			];
-
-			if ('' !== $name)
-			{
-				$conditions[] = $db->quoteName('e.element') . ' = ' . $name;
-			}
-
 			$query = $db->getQuery(true)
 				->select($db->quoteName(['id', 'home', 'template', 's.params', 'parent', 'inherits']))
 				->from($db->quoteName('#__template_styles', 's'))
-				->where($conditions)
+				->where(
+					[
+						$db->quoteName('s.client_id') . ' = 0',
+						$db->quoteName('e.enabled') . ' = 1',
+					]
+				)
 				->join(
 					'LEFT',
 					$db->quoteName('#__extensions', 'e'),
@@ -497,9 +491,6 @@ final class SiteApplication extends CMSApplication
 
 			foreach ($templates as &$template)
 			{
-				$template->inherits = !empty($template->inherits) ? $template->inherits : false;
-				$template->parent = $template->parent === 1;
-
 				// Create home element
 				if ($template->home == 1 && !isset($template_home) || $this->getLanguageFilter() && $template->home == $tag)
 				{
@@ -614,21 +605,6 @@ final class SiteApplication extends CMSApplication
 		}
 
 		return $template->template;
-	}
-
-	/**
-	 * Gets the name of the current template.
-	 *
-	 * @param   boolean  $params  True to return the template parameters
-	 *
-	 * @return  string  The name of the template.
-	 *
-	 * @since   3.2
-	 * @throws  \InvalidArgumentException
-	 */
-	public function getTemplate($params = false)
-	{
-		return $this->getTemplateByName($params, '');
 	}
 
 	/**
@@ -818,6 +794,9 @@ final class SiteApplication extends CMSApplication
 				{
 					$this->set('themeFile', $file . '.php');
 				}
+
+				// Pass the parent template to the state
+				$this->set('themeInherit', $template->inherits);
 
 				break;
 		}

--- a/libraries/src/Document/HtmlDocument.php
+++ b/libraries/src/Document/HtmlDocument.php
@@ -804,17 +804,17 @@ class HtmlDocument extends Document
 		// Check
 		$directory = $params['directory'] ?? 'templates';
 		$filter = InputFilter::getInstance();
-		$templateName = $filter->clean($params['template'], 'cmd');
+		$template = $filter->clean($params['template'], 'cmd');
 		$file = $filter->clean($params['file'], 'cmd');
-		$activeTemplate = CmsFactory::getApplication()->getTemplateByName(true, $templateName);
-		$baseDir = $directory . '/' . $activeTemplate->template;
+		$inherits = $params['templateInherits'];
+		$baseDir = $directory . '/' . $template;
 
-		if (!empty($activeTemplate->inherits)
-			&& !file_exists($directory . '/' . $activeTemplate->template . '/' . $file)
-			&& file_exists($directory . '/' . $activeTemplate->inherits . '/' . $file)
+		if (!empty($inherits)
+			&& !file_exists($directory . '/' . $template . '/' . $file)
+			&& file_exists($directory . '/' . $inherits . '/' . $file)
 		)
 		{
-			$baseDir = $directory . '/' . $activeTemplate->inherits;
+			$baseDir = $directory . '/' . $inherits;
 		}
 
 		if (!file_exists($baseDir . '/' . $file))
@@ -831,14 +831,14 @@ class HtmlDocument extends Document
 		$lang = CmsFactory::getLanguage();
 
 		// 1.5 or core then 1.6
-		$lang->load('tpl_' . $activeTemplate->template, JPATH_BASE)
-			|| $lang->load('tpl_' . $activeTemplate->inherits, $directory . '/' . $activeTemplate->inherits)
-			|| $lang->load('tpl_' . $activeTemplate->template, $directory . '/' . $activeTemplate->template);
+		$lang->load('tpl_' . $template, JPATH_BASE)
+			|| $lang->load('tpl_' . $inherits, $directory . '/' . $inherits)
+			|| $lang->load('tpl_' . $template, $directory . '/' . $template);
 
 		// Assign the variables
 		$this->baseurl = Uri::base(true);
 		$this->params = $params['params'] ?? new Registry;
-		$this->template = $activeTemplate->template;
+		$this->template = $template;
 
 		// Load
 		$this->_template = $this->_loadTemplate($baseDir, $file);

--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -440,7 +440,7 @@ abstract class HTMLHelper
 				$template   = $app->getTemplate(true);
 				$templaPath = JPATH_THEMES;
 
-				if ($template->parent || !empty($template->inherits))
+				if ($template->inheritable || !empty($template->parent))
 				{
 					$client     = $app->isClient('administrator') === true ? 'administrator' : 'site';
 					$templaPath = JPATH_ROOT . "/media/templates/$client";
@@ -459,13 +459,13 @@ abstract class HTMLHelper
 					 */
 					foreach ($files as $file)
 					{
-						if (!empty($template->inherits))
+						if (!empty($template->parent))
 						{
 							$found = static::addFileToBuffer("$templaPath/$template->template/$folder/$file", $ext, $debugMode);
 
 							if (empty($found))
 							{
-								$found = static::addFileToBuffer("$templaPath/$template->inherits/$folder/$file", $ext, $debugMode);
+								$found = static::addFileToBuffer("$templaPath/$template->parent/$folder/$file", $ext, $debugMode);
 							}
 						}
 						else
@@ -514,7 +514,7 @@ abstract class HTMLHelper
 									}
 
 									// Try to deal with system files in the template folder
-									if (!empty($template->inherits))
+									if (!empty($template->parent))
 									{
 										$found = static::addFileToBuffer("$templaPath/$template->template/$folder/system/$element/$file", $ext, $debugMode);
 
@@ -525,7 +525,7 @@ abstract class HTMLHelper
 											break;
 										}
 
-										$found = static::addFileToBuffer("$templaPath/$template->inherits/$folder/system/$element/$file", $ext, $debugMode);
+										$found = static::addFileToBuffer("$templaPath/$template->parent/$folder/system/$element/$file", $ext, $debugMode);
 
 										if (!empty($found))
 										{
@@ -560,7 +560,7 @@ abstract class HTMLHelper
 									}
 
 									// Try to deal with system files in the template folder
-									if (!empty($template->inherits))
+									if (!empty($template->parent))
 									{
 										$found = static::addFileToBuffer("$templaPath/$template->templete/$folder/system/$file", $ext, $debugMode);
 
@@ -571,7 +571,7 @@ abstract class HTMLHelper
 											break;
 										}
 
-										$found = static::addFileToBuffer("$templaPath/$template->inherits/$folder/system/$file", $ext, $debugMode);
+										$found = static::addFileToBuffer("$templaPath/$template->parent/$folder/system/$file", $ext, $debugMode);
 
 										if (!empty($found))
 										{

--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -436,8 +436,16 @@ abstract class HTMLHelper
 			// If relative search in template directory or media directory
 			if ($relative)
 			{
+				$app = Factory::getApplication();
 				// Get the template
-				$template = Factory::getApplication()->getTemplate();
+				$template = $app->getTemplate(true);
+				$templaPath = JPATH_THEMES;
+
+				if ($template->parent || !empty($template->inherits))
+				{
+					$client = $app->isClient('administrator') === true ? 'administrator' : 'site';
+					$templaPath = JPATH_ROOT . "/media/templates/$client";
+				}
 
 				// For each potential files
 				foreach ($potential as $strip)
@@ -452,7 +460,19 @@ abstract class HTMLHelper
 					 */
 					foreach ($files as $file)
 					{
-						$found = static::addFileToBuffer(JPATH_THEMES . "/$template/$folder/$file", $ext, $debugMode);
+						if (!empty($template->inherits))
+						{
+							$found = static::addFileToBuffer("$templaPath/$template->template/$folder/$file", $ext, $debugMode);
+
+							if (empty($found))
+							{
+								$found = static::addFileToBuffer("$templaPath/$template->inherits/$folder/$file", $ext, $debugMode);
+							}
+						}
+						else
+						{
+							$found = static::addFileToBuffer("$templaPath/$template->template/$folder/$file", $ext, $debugMode);
+						}
 
 						if (!empty($found))
 						{
@@ -495,23 +515,37 @@ abstract class HTMLHelper
 									}
 
 									// Try to deal with system files in the template folder
-									$found = static::addFileToBuffer(JPATH_THEMES . "/$template/$folder/system/$element/$file", $ext, $debugMode);
-
-									if (!empty($found))
+									if (!empty($template->inherits))
 									{
-										$includes[] = $found;
+										$found = static::addFileToBuffer("$templaPath/$template->template/$folder/system/$element/$file", $ext, $debugMode);
 
-										break;
+										if (!empty($found))
+										{
+											$includes[] = $found;
+
+											break;
+										}
+
+										$found = static::addFileToBuffer("$templaPath/$template->inherits/$folder/system/$element/$file", $ext, $debugMode);
+
+										if (!empty($found))
+										{
+											$includes[] = $found;
+
+											break;
+										}
 									}
-
-									// Try to deal with system files in the media folder
-									$found = static::addFileToBuffer(JPATH_ROOT . "/media/system/$folder/$element/$file", $ext, $debugMode);
-
-									if (!empty($found))
+									else
 									{
-										$includes[] = $found;
+										// Try to deal with system files in the media folder
+										$found = static::addFileToBuffer(JPATH_ROOT . "/media/system/$folder/$element/$file", $ext, $debugMode);
 
-										break;
+										if (!empty($found))
+										{
+											$includes[] = $found;
+
+											break;
+										}
 									}
 								}
 								else
@@ -527,13 +561,37 @@ abstract class HTMLHelper
 									}
 
 									// Try to deal with system files in the template folder
-									$found = static::addFileToBuffer(JPATH_THEMES . "/$template/$folder/system/$file", $ext, $debugMode);
-
-									if (!empty($found))
+									if (!empty($template->inherits))
 									{
-										$includes[] = $found;
+										$found = static::addFileToBuffer("$templaPath/$template->templete/$folder/system/$file", $ext, $debugMode);
 
-										break;
+										if (!empty($found))
+										{
+											$includes[] = $found;
+
+											break;
+										}
+
+										$found = static::addFileToBuffer("$templaPath/$template->inherits/$folder/system/$file", $ext, $debugMode);
+
+										if (!empty($found))
+										{
+											$includes[] = $found;
+
+											break;
+										}
+									}
+									else
+									{
+										// Try to deal with system files in the template folder
+										$found = static::addFileToBuffer("$templaPath/$template->templete/$folder/system/$file", $ext, $debugMode);
+
+										if (!empty($found))
+										{
+											$includes[] = $found;
+
+											break;
+										}
 									}
 
 									// Try to deal with system files in the media folder

--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -436,14 +436,13 @@ abstract class HTMLHelper
 			// If relative search in template directory or media directory
 			if ($relative)
 			{
-				$app = Factory::getApplication();
-				// Get the template
-				$template = $app->getTemplate(true);
+				$app        = Factory::getApplication();
+				$template   = $app->getTemplate(true);
 				$templaPath = JPATH_THEMES;
 
 				if ($template->parent || !empty($template->inherits))
 				{
-					$client = $app->isClient('administrator') === true ? 'administrator' : 'site';
+					$client     = $app->isClient('administrator') === true ? 'administrator' : 'site';
 					$templaPath = JPATH_ROOT . "/media/templates/$client";
 				}
 

--- a/libraries/src/Helper/ModuleHelper.php
+++ b/libraries/src/Helper/ModuleHelper.php
@@ -320,8 +320,9 @@ abstract class ModuleHelper
 	 */
 	public static function getLayoutPath($module, $layout = 'default')
 	{
-		$template = Factory::getApplication()->getTemplate();
+		$templateObj   = Factory::getApplication()->getTemplate(true);
 		$defaultLayout = $layout;
+		$template      = $templateObj->template;
 
 		if (strpos($layout, ':') !== false)
 		{
@@ -334,6 +335,7 @@ abstract class ModuleHelper
 
 		// Build the template and base path for the layout
 		$tPath = JPATH_THEMES . '/' . $template . '/html/' . $module . '/' . $layout . '.php';
+		$iPath = JPATH_THEMES . '/' . $templateObj->inherits . '/html/' . $module . '/' . $layout . '.php';
 		$bPath = JPATH_BASE . '/modules/' . $module . '/tmpl/' . $defaultLayout . '.php';
 		$dPath = JPATH_BASE . '/modules/' . $module . '/tmpl/default.php';
 
@@ -341,6 +343,11 @@ abstract class ModuleHelper
 		if (file_exists($tPath))
 		{
 			return $tPath;
+		}
+
+		if (!empty($templateObj->inherits) && file_exists($iPath))
+		{
+			return $iPath;
 		}
 
 		if (file_exists($bPath))

--- a/libraries/src/Helper/ModuleHelper.php
+++ b/libraries/src/Helper/ModuleHelper.php
@@ -335,7 +335,7 @@ abstract class ModuleHelper
 
 		// Build the template and base path for the layout
 		$tPath = JPATH_THEMES . '/' . $template . '/html/' . $module . '/' . $layout . '.php';
-		$iPath = JPATH_THEMES . '/' . $templateObj->inherits . '/html/' . $module . '/' . $layout . '.php';
+		$iPath = JPATH_THEMES . '/' . $templateObj->parent . '/html/' . $module . '/' . $layout . '.php';
 		$bPath = JPATH_BASE . '/modules/' . $module . '/tmpl/' . $defaultLayout . '.php';
 		$dPath = JPATH_BASE . '/modules/' . $module . '/tmpl/default.php';
 
@@ -345,7 +345,7 @@ abstract class ModuleHelper
 			return $tPath;
 		}
 
-		if (!empty($templateObj->inherits) && file_exists($iPath))
+		if (!empty($templateObj->parent) && file_exists($iPath))
 		{
 			return $iPath;
 		}

--- a/libraries/src/Installer/Adapter/TemplateAdapter.php
+++ b/libraries/src/Installer/Adapter/TemplateAdapter.php
@@ -334,7 +334,7 @@ class TemplateAdapter extends InstallerAdapter
 					'0',
 					Text::sprintf('JLIB_INSTALLER_DEFAULT_STYLE', Text::_($this->extension->name)),
 					$this->extension->params,
-					intval($this->manifest->inheritable),
+					(int) $this->manifest->inheritable,
 					$this->manifest->parent ? $this->manifest->parent : '',
 				],
 				[

--- a/libraries/src/Installer/Adapter/TemplateAdapter.php
+++ b/libraries/src/Installer/Adapter/TemplateAdapter.php
@@ -327,9 +327,6 @@ class TemplateAdapter extends InstallerAdapter
 				$db->quoteName('inherits'),
 			];
 
-			$parent = intval($this->manifest->parent);
-			$inherits = $this->manifest->inherits;
-
 			$values = $query->bindArray(
 				[
 					$this->extension->element,
@@ -337,8 +334,8 @@ class TemplateAdapter extends InstallerAdapter
 					'0',
 					Text::sprintf('JLIB_INSTALLER_DEFAULT_STYLE', Text::_($this->extension->name)),
 					$this->extension->params,
-					$parent,
-					$inherits,
+					intval($this->manifest->inheritable),
+					$this->manifest->parent ? $this->manifest->parent : '',
 				],
 				[
 					ParameterType::STRING,

--- a/libraries/src/Installer/Adapter/TemplateAdapter.php
+++ b/libraries/src/Installer/Adapter/TemplateAdapter.php
@@ -335,7 +335,7 @@ class TemplateAdapter extends InstallerAdapter
 					Text::sprintf('JLIB_INSTALLER_DEFAULT_STYLE', Text::_($this->extension->name)),
 					$this->extension->params,
 					(int) $this->manifest->inheritable,
-					$this->manifest->parent ? $this->manifest->parent : '',
+					$this->manifest->parent ?: '',
 				],
 				[
 					ParameterType::STRING,

--- a/libraries/src/Installer/Adapter/TemplateAdapter.php
+++ b/libraries/src/Installer/Adapter/TemplateAdapter.php
@@ -323,7 +323,12 @@ class TemplateAdapter extends InstallerAdapter
 				$db->quoteName('home'),
 				$db->quoteName('title'),
 				$db->quoteName('params'),
+				$db->quoteName('parent'),
+				$db->quoteName('inherits'),
 			];
+
+			$parent = intval($this->manifest->parent);
+			$inherits = $this->manifest->inherits;
 
 			$values = $query->bindArray(
 				[
@@ -332,12 +337,16 @@ class TemplateAdapter extends InstallerAdapter
 					'0',
 					Text::sprintf('JLIB_INSTALLER_DEFAULT_STYLE', Text::_($this->extension->name)),
 					$this->extension->params,
+					$parent,
+					$inherits,
 				],
 				[
 					ParameterType::STRING,
 					ParameterType::INTEGER,
 					ParameterType::STRING,
 					ParameterType::STRING,
+					ParameterType::STRING,
+					ParameterType::INTEGER,
 					ParameterType::STRING,
 				]
 			);

--- a/libraries/src/Layout/FileLayout.php
+++ b/libraries/src/Layout/FileLayout.php
@@ -535,6 +535,9 @@ class FileLayout extends BaseLayout
 	 */
 	public function getDefaultIncludePaths()
 	{
+		// Get the template
+		$template = Factory::getApplication()->getTemplate(true);
+
 		// Reset includePaths
 		$paths = array();
 
@@ -550,7 +553,13 @@ class FileLayout extends BaseLayout
 		if (!empty($component))
 		{
 			// (2) Component template overrides path
-			$paths[] = JPATH_THEMES . '/' . Factory::getApplication()->getTemplate() . '/html/layouts/' . $component;
+			$paths[] = JPATH_THEMES . '/' . $template->template . '/html/layouts/' . $component;
+
+			if (!empty($template->inherits))
+			{
+				// (2.a) Component template overrides path for an inherited template using the parent
+				$paths[] = JPATH_THEMES . '/' . $template->inherits . '/html/layouts/' . $component;
+			}
 
 			// (3) Component path
 			if ($this->options->get('client') == 0)
@@ -564,7 +573,13 @@ class FileLayout extends BaseLayout
 		}
 
 		// (4) Standard Joomla! layouts overridden
-		$paths[] = JPATH_THEMES . '/' . Factory::getApplication()->getTemplate() . '/html/layouts';
+		$paths[] = JPATH_THEMES . '/' . $template->template . '/html/layouts';
+
+		if (!empty($template->inherits))
+		{
+			// (4.a) Component template overrides path for an inherited template using the parent
+			$paths[] = JPATH_THEMES . '/' . $template->inherits . '/html/layouts';
+		}
 
 		// (5 - lower priority) Frontend base layouts
 		$paths[] = JPATH_ROOT . '/layouts';

--- a/libraries/src/Layout/FileLayout.php
+++ b/libraries/src/Layout/FileLayout.php
@@ -555,10 +555,10 @@ class FileLayout extends BaseLayout
 			// (2) Component template overrides path
 			$paths[] = JPATH_THEMES . '/' . $template->template . '/html/layouts/' . $component;
 
-			if (!empty($template->inherits))
+			if (!empty($template->parent))
 			{
 				// (2.a) Component template overrides path for an inherited template using the parent
-				$paths[] = JPATH_THEMES . '/' . $template->inherits . '/html/layouts/' . $component;
+				$paths[] = JPATH_THEMES . '/' . $template->parent . '/html/layouts/' . $component;
 			}
 
 			// (3) Component path
@@ -575,10 +575,10 @@ class FileLayout extends BaseLayout
 		// (4) Standard Joomla! layouts overridden
 		$paths[] = JPATH_THEMES . '/' . $template->template . '/html/layouts';
 
-		if (!empty($template->inherits))
+		if (!empty($template->parent))
 		{
 			// (4.a) Component template overrides path for an inherited template using the parent
-			$paths[] = JPATH_THEMES . '/' . $template->inherits . '/html/layouts';
+			$paths[] = JPATH_THEMES . '/' . $template->parent . '/html/layouts';
 		}
 
 		// (5 - lower priority) Frontend base layouts

--- a/libraries/src/MVC/View/HtmlView.php
+++ b/libraries/src/MVC/View/HtmlView.php
@@ -386,7 +386,7 @@ class HtmlView extends AbstractView
 		// Load the language file for the template
 		$lang = Factory::getLanguage();
 		$lang->load('tpl_' . $template->template, JPATH_BASE)
-			|| $lang->load('tpl_' . $template->inherits, JPATH_THEMES . '/' . $template->inherits)
+			|| $lang->load('tpl_' . $template->parent, JPATH_THEMES . '/' . $template->parent)
 			|| $lang->load('tpl_' . $template->template, JPATH_THEMES . '/' . $template->template);
 
 		// Change the template folder if alternative layout is in different template
@@ -505,10 +505,10 @@ class HtmlView extends AbstractView
 					$component = preg_replace('/[^A-Z0-9_\.-]/i', '', $component);
 					$name = $this->getName();
 
-					if (!empty($template->inherits))
+					if (!empty($template->parent))
 					{
 						// Parent template's overrides
-						$this->_addPath('template', JPATH_THEMES . "/$template->inherits/html/$component/$name");
+						$this->_addPath('template', JPATH_THEMES . "/$template->parent/html/$component/$name");
 
 						// Child template's overrides
 						$this->_addPath('template', JPATH_THEMES . "/$template->template/html/$component/$name");

--- a/libraries/src/MVC/View/HtmlView.php
+++ b/libraries/src/MVC/View/HtmlView.php
@@ -389,7 +389,6 @@ class HtmlView extends AbstractView
 			|| $lang->load('tpl_' . $template->inherits, JPATH_THEMES . '/' . $template->inherits)
 			|| $lang->load('tpl_' . $template->template, JPATH_THEMES . '/' . $template->template);
 
-
 		// Change the template folder if alternative layout is in different template
 		if (isset($layoutTemplate) && $layoutTemplate !== '_' && $layoutTemplate != $template->template)
 		{

--- a/libraries/src/MVC/View/HtmlView.php
+++ b/libraries/src/MVC/View/HtmlView.php
@@ -372,7 +372,7 @@ class HtmlView extends AbstractView
 		// Clear prior output
 		$this->_output = null;
 
-		$template = Factory::getApplication()->getTemplate();
+		$template = Factory::getApplication()->getTemplate(true);
 		$layout = $this->getLayout();
 		$layoutTemplate = $this->getLayoutTemplate();
 
@@ -385,14 +385,16 @@ class HtmlView extends AbstractView
 
 		// Load the language file for the template
 		$lang = Factory::getLanguage();
-		$lang->load('tpl_' . $template, JPATH_BASE)
-		|| $lang->load('tpl_' . $template, JPATH_THEMES . "/$template");
+		$lang->load('tpl_' . $template->template, JPATH_BASE)
+			|| $lang->load('tpl_' . $template->inherits, JPATH_THEMES . '/' . $template->inherits)
+			|| $lang->load('tpl_' . $template->template, JPATH_THEMES . '/' . $template->template);
+
 
 		// Change the template folder if alternative layout is in different template
-		if (isset($layoutTemplate) && $layoutTemplate !== '_' && $layoutTemplate != $template)
+		if (isset($layoutTemplate) && $layoutTemplate !== '_' && $layoutTemplate != $template->template)
 		{
 			$this->_path['template'] = str_replace(
-				JPATH_THEMES . DIRECTORY_SEPARATOR . $template,
+				JPATH_THEMES . DIRECTORY_SEPARATOR . $template->template,
 				JPATH_THEMES . DIRECTORY_SEPARATOR . $layoutTemplate,
 				$this->_path['template']
 			);
@@ -491,6 +493,9 @@ class HtmlView extends AbstractView
 		// Actually add the user-specified directories
 		$this->_addPath($type, $path);
 
+		// Get the active template object
+		$template = $app->getTemplate(true);
+
 		// Always add the fallback directories as last resort
 		switch (strtolower($type))
 		{
@@ -499,8 +504,20 @@ class HtmlView extends AbstractView
 				if (isset($app))
 				{
 					$component = preg_replace('/[^A-Z0-9_\.-]/i', '', $component);
-					$fallback = JPATH_THEMES . '/' . $app->getTemplate() . '/html/' . $component . '/' . $this->getName();
-					$this->_addPath('template', $fallback);
+					$name = $this->getName();
+
+					if (!empty($template->inherits))
+					{
+						// Parent template's overrides
+						$this->_addPath('template', JPATH_THEMES . "/$template->inherits/html/$component/$name");
+
+						// Child template's overrides
+						$this->_addPath('template', JPATH_THEMES . "/$template->template/html/$component/$name");
+
+						break;
+					}
+
+					$this->_addPath('template', JPATH_THEMES . "/$template->template/html/$component/$name");
 				}
 				break;
 		}

--- a/libraries/src/MVC/View/HtmlView.php
+++ b/libraries/src/MVC/View/HtmlView.php
@@ -508,15 +508,15 @@ class HtmlView extends AbstractView
 					if (!empty($template->parent))
 					{
 						// Parent template's overrides
-						$this->_addPath('template', JPATH_THEMES . "/$template->parent/html/$component/$name");
+						$this->_addPath('template', JPATH_THEMES . '/' . $template->parent . '/html/' . $component . '/' . $name);
 
 						// Child template's overrides
-						$this->_addPath('template', JPATH_THEMES . "/$template->template/html/$component/$name");
+						$this->_addPath('template', JPATH_THEMES . '/' . $template->template . '/html/' . $component . '/' . $name);
 
 						break;
 					}
 
-					$this->_addPath('template', JPATH_THEMES . "/$template->template/html/$component/$name");
+					$this->_addPath('template', JPATH_THEMES . '/' . $template->template . '/html/' . $component . '/' . $name);
 				}
 				break;
 		}

--- a/libraries/src/Plugin/PluginHelper.php
+++ b/libraries/src/Plugin/PluginHelper.php
@@ -43,20 +43,22 @@ abstract class PluginHelper
 	 */
 	public static function getLayoutPath($type, $name, $layout = 'default')
 	{
-		$template = Factory::getApplication()->getTemplate();
+		$templateObj   = Factory::getApplication()->getTemplate(true);
 		$defaultLayout = $layout;
+		$template      = $templateObj->template;
 
 		if (strpos($layout, ':') !== false)
 		{
 			// Get the template and file name from the string
 			$temp = explode(':', $layout);
-			$template = $temp[0] === '_' ? $template : $temp[0];
+			$template = $temp[0] === '_' ? $templateObj->template : $temp[0];
 			$layout = $temp[1];
 			$defaultLayout = $temp[1] ?: 'default';
 		}
 
 		// Build the template and base path for the layout
 		$tPath = JPATH_THEMES . '/' . $template . '/html/plg_' . $type . '_' . $name . '/' . $layout . '.php';
+		$iPath = JPATH_THEMES . '/' . $templateObj->inherits . '/html/plg_' . $type . '_' . $name . '/' . $layout . '.php';
 		$bPath = JPATH_PLUGINS . '/' . $type . '/' . $name . '/tmpl/' . $defaultLayout . '.php';
 		$dPath = JPATH_PLUGINS . '/' . $type . '/' . $name . '/tmpl/default.php';
 
@@ -64,6 +66,10 @@ abstract class PluginHelper
 		if (file_exists($tPath))
 		{
 			return $tPath;
+		}
+		elseif (file_exists($iPath))
+		{
+			return $iPath;
 		}
 		elseif (file_exists($bPath))
 		{

--- a/libraries/src/Plugin/PluginHelper.php
+++ b/libraries/src/Plugin/PluginHelper.php
@@ -58,7 +58,7 @@ abstract class PluginHelper
 
 		// Build the template and base path for the layout
 		$tPath = JPATH_THEMES . '/' . $template . '/html/plg_' . $type . '_' . $name . '/' . $layout . '.php';
-		$iPath = JPATH_THEMES . '/' . $templateObj->inherits . '/html/plg_' . $type . '_' . $name . '/' . $layout . '.php';
+		$iPath = JPATH_THEMES . '/' . $templateObj->parent . '/html/plg_' . $type . '_' . $name . '/' . $layout . '.php';
 		$bPath = JPATH_PLUGINS . '/' . $type . '/' . $name . '/tmpl/' . $defaultLayout . '.php';
 		$dPath = JPATH_PLUGINS . '/' . $type . '/' . $name . '/tmpl/default.php';
 
@@ -67,7 +67,7 @@ abstract class PluginHelper
 		{
 			return $tPath;
 		}
-		elseif (file_exists($iPath))
+		elseif (!empty($templateObj->parent) && file_exists($iPath))
 		{
 			return $iPath;
 		}


### PR DESCRIPTION
Pull Request is the foundation for #30149

### Summary of Changes
Introduces Inheritable templates solving numerous problem with the current state of templates. Read more on the linked issue above

This PR is complete in the sense that contains all the changes (even the upgrade path from J3) to introduce the new mode but without introducing the GUI and neither is moving any of the templates to the new mode. These can be done in following PR's


### Testing Instructions

Do not try to test this with patch tester, it won't work.
Install the PR's installable, you can d/l it here (at the bottom of this page)
If you want to use git command lines or the desktop app make sure that you'll do a fresh install or apply the updates (sql files)

Make sure you have the browser's console open so you can observe any missing assets.

If this went smooth, then it's a good sign as the installation is a seperate application with it's own template and although this PR is not touching the installation template everything works as before. B/C check 1

### Front End step 1

Go to the front end and vist the following urls:

- /index.php/blog
- /index.php/blog/3-welcome-to-your-blog
- /index.php/author-login (login here)
- /index.php?option=com_config&view=modules&id=109&Itemid=104 (or just try to edit the top left module)

Everything should be fine, no console logs or missinng icons, etc. B/C check 2

### Front End step 2

Download this [cassiopeia_overrides_v2.zip](https://github.com/joomla/joomla-cms/files/4977969/cassiopeia_overrides_v2.zip) and extract the contents and copy them in the folder `templates/cassiopeia/html`. Revisit the pages of the previous step. You should see in the pages some plain text (that will also break a bit the design) `Legacy Component view override`. You have to look for `Component`, `Module`, `Plugin` and `JLayout`. If so then the cascading of the templating is working correctly, in the previous step there was no overrides in this one the overrides were treated as top priority. Also cassiopeia has some overrides for the static assets so that was already tested (if you want you might open a normal 4.0 version in another winndow and check the number of assets per page between the 2). B/C check 3

### Front End step 3

Install the first new mode template (basically cassiopeia with another name: siteparent) from here [siteparent_v2.zip](https://github.com/joomla/joomla-cms/files/4977972/siteparent_v2.zip)


Go to the admin and make the siteparent template default and also assign all the menus to this template!!! Go to the front end and repeat the Front End step 1 and confirm that everything is as before. check 4

### Front End step 4

Go with your filemanager to `templates/siteparent` and copy the contents os the folder `xhtml` to the folder `html`. Redo the ritual of Front End step 1 and confirm that all the parts `Component`, `Module`, `Plugin` and `JLayout` are there. check 5

### Front End step 5

Although the child templates should be created inside joomla's env for testing purposes we will do it using the installer, so install this: [sitechild_v2.zip](https://github.com/joomla/joomla-cms/files/4977974/sitechild_v2.zip)



Go to the admin and make the sitechild template default and also assign all the menus to this template!!! Go to the front end and repeat the Front End step 1 and confirm that everything is as before. check 6

### Front End step 6

Go with your filemanager to `templates/sitechild` and rename the folder `xhtml` to `html`. Redo the ritual of Front End step 1 and confirm that all the parts `Component`, `Module`, `Plugin` and `JLayout` are there. check 7

### Back End step 1

Go to the addinistrator end and vist the following urls:

- /administrator/index.php
- /administrator/index.php?option=com_content&view=articles
- /administrator/index.php?option=com_installer&view=install

Everything should be fine, no console logs or missinng icons, etc. B/C check 8

### Back End step 2

Download this [atum_overrides_v2.zip](https://github.com/joomla/joomla-cms/files/4977975/atum_overrides_v2.zip) and extract the contents and copy them in the folder `administrator/templates/atum/html`. Revisit the pages of the previous step. You should see in the pages some plain text (that will also break a bit the design) `Legacy Component view override`. You have to look for `Component`, `Module`, `Plugin` and `JLayout`. If so then the cascading of the templating is working correctly, in the previous step there was no overrides in this one the overrides were treated as top priority. Also cassiopeia has some overrides for the static assets so that was already tested (if you want you might open a normal 4.0 version in another window and check the number of assets per page between the 2). B/C check 9

### Back End step 3

Install the new mode template (basically atum with another name: adminparent) from here 
[adminparent_v2.zip](https://github.com/joomla/joomla-cms/files/4977976/adminparent_v2.zip)


Go to the administrator template styles and make the adminparent template the default one. Repeat the Back End step 1 and confirm that everything is as before. check 10

### Back End step 4

Go with your filemanager to `administrator/templates/adminparent` and copy the contents os the folder `xhtml` to the folder `html`. Redo the dance of the Back End step 1 and confirm that all the parts `Component`, `Module`, `Plugin` and `JLayout` are there. check 11

### Back End step 5

Althouth the child templates should be created inside joomla's env for testing purposes we will do it using the installer, so install this: 
[adminchild_v2.zip](https://github.com/joomla/joomla-cms/files/4977978/adminchild_v2.zip)



Go to the admin and make the adminchild template the default. Repeat the Back End step 1 and confirm that everything is as before. check 12

### Back End step 6

Go with your filemanager to `administrator/templates/adminchild` and rename the folder `xhtml` to `html`. Redo the ritual of the Back End step 1 and confirm that all the parts `Component`, `Module`, `Plugin` and `JLayout` are there. check 13

### Final checks

Check your db and the table template_styles, you should have

- autum and cassiopeia with parent `0` and inherits ``
- from the new ones the parent ones with parent `1` and inherits ``
- and the child ones ones with parent `0` and inherits `siteparent` and `siteadmin` respectfully

Finally someone needs to confirm that the update sql files are all that is needed here

### And the last one

You have probably saw some missing strings when you were trying to edit any of the template styles. This is expected as I forgot to include any languages in the parent template, but this is quite easy to check. You are already in the adminchild template so all you have to do is create a folder `language/en-GB` in the **adminparent** template and then copy the tmpl_atum\*.ini to this folder and rename them to tmpl_adminparent.ini and tmpl_adminparent.sys.ini. Check again the strings are back. Then make the adminparent the default template and check for any changes (readable text should remain readable). You can repeat this for the front end templates (although the function is common for both).


### Documentation Changes Required
For the devs the new parts are 2:
- manifest **requires** a tag `<inheritable>1</inheritable >` to enable a template in the new mode
- **all** static assets **and also any static asset override** should be done in the `media/( administrator || site )/templateName`. Folders like css/js/images inside the above path will act exactly the same as they did in the old `templates/name/( css || js || images )` 
