### PR TITLE
[4.0] Reduced duplicated code in ProfileModel.

### DIFF
--- a/administrator/components/com_admin/src/Model/ProfileModel.php
+++ b/administrator/components/com_admin/src/Model/ProfileModel.php
@@ -147,87 +147,15 @@ class ProfileModel extends UserModel
 	{
 		$user = Factory::getUser();
 		$pk   = $user->id;
+		$data['id'] = $pk;
+		$data['block'] = $user->block;
+		$iAmSuperAdmin = $user->authorise('core.admin');
 
-		unset($data['id'], $data['groups'], $data['sendEmail'], $data['block']);
-
-		$isUsernameCompliant = $this->getState('user.username.compliant');
-
-		if (!ComponentHelper::getParams('com_users')->get('change_login_name') && $isUsernameCompliant)
+		if ($iAmSuperAdmin)
 		{
-			unset($data['username']);
+			$data['groups'] = $user->groups;
 		}
 
-		// Handle the two factor authentication setup
-		if (\array_key_exists('twofactor', $data))
-		{
-			$twoFactorMethod = $data['twofactor']['method'];
-
-			// Get the current One Time Password (two factor auth) configuration
-			$otpConfig = $this->getOtpConfig($pk);
-
-			if ($twoFactorMethod !== 'none')
-			{
-				// Run the plugins
-				PluginHelper::importPlugin('twofactorauth');
-				$otpConfigReplies = Factory::getApplication()->triggerEvent('onUserTwofactorApplyConfiguration', [$twoFactorMethod]);
-
-				// Look for a valid reply
-				foreach ($otpConfigReplies as $reply)
-				{
-					if (!\is_object($reply) || empty($reply->method) || ($reply->method !== $twoFactorMethod))
-					{
-						continue;
-					}
-
-					$otpConfig->method = $reply->method;
-					$otpConfig->config = $reply->config;
-
-					break;
-				}
-
-				// Save OTP configuration.
-				$this->setOtpConfig($pk, $otpConfig);
-
-				// Generate one time emergency passwords if required (depleted or not set)
-				if (empty($otpConfig->otep))
-				{
-					$oteps = $this->generateOteps($pk);
-				}
-			}
-			else
-			{
-				$otpConfig->method = 'none';
-				$otpConfig->config = [];
-				$this->setOtpConfig($pk, $otpConfig);
-			}
-
-			// Unset the raw data
-			unset($data['twofactor']);
-
-			// Reload the user record with the updated OTP configuration
-			$user->load($pk);
-		}
-
-		// Bind the data.
-		if (!$user->bind($data))
-		{
-			$this->setError($user->getError());
-
-			return false;
-		}
-
-		$user->groups = null;
-
-		// Store the data.
-		if (!$user->save())
-		{
-			$this->setError($user->getError());
-
-			return false;
-		}
-
-		$this->setState('user.id', $user->id);
-
-		return true;
+		return parent::save($data);
 	}
 }


### PR DESCRIPTION
As mentioned in https://github.com/joomla/joomla-cms/pull/30152#issuecomment-663627717, the method `ProfileModel::save` is mostly a copy of its parent `UserModel::save`. This is going to lead to problems (just like the issue fixed in #30152), because every time someone changes the method `UserModel::save`, they need to remember about `ProfileModel` and might need to include the same change there. 

### Summary of Changes
By calling the parent method, code duplication is reduced. As the form in the profile view is a reduced form of the user edit form, some values need to be changed, because the validation inside `UserModel::save` would fail otherwise.


### Testing Instructions
1. Log in to backend with an account with "Manager" permissions.
2. Edit your profile by clicking on "User Menu" (top right) - "Edit Account", change something and save.
3. Make sure everything regarding changing the profile works.
4. Log in to backend with an account with "Administrator" permissions (not Super User!).
5. Edit your profile by clicking on "User Menu" (top right) - "Edit Account", change something and save.
6. Make sure everything regarding changing the profile works.
7. Navigate to "Users - Manage". 
8. Edit your own account there, change something, save.
9. Edit another account there, change something, save.
10. Make sure everything regarding editing user accounts works.
11. Log in to backend with an account with "Super User" permissions. Repeat steps 5-10.

### Expected result AFTER applying this Pull Request
Everything should still work like before.


### Documentation Changes Required
None

/cc @SharkyKZ 