### PR TITLE
Missing FA for icon-save

### DIFF
--- a/layouts/joomla/button/iconclass.php
+++ b/layouts/joomla/button/iconclass.php
@@ -31,7 +31,7 @@ elseif ($icon === 'new' || $icon === 'save-new')
 {
 	$icon = 'fas fa-plus';
 }
-elseif ($icon === 'apply')
+elseif ($icon === 'apply' || $icon === 'save')
 {
 	$icon = 'fas fa-save';
 }

--- a/layouts/joomla/toolbar/iconclass.php
+++ b/layouts/joomla/toolbar/iconclass.php
@@ -31,7 +31,7 @@ elseif ($icon === 'new' || $icon === 'save-new')
 {
 	$icon = 'fas fa-plus';
 }
-elseif ($icon === 'apply')
+elseif ($icon === 'apply' || $icon === 'save')
 {
 	$icon = 'fas fa-save';
 }


### PR DESCRIPTION
Pull Request for Issue #30191 

### Summary of Changes
change icon class for "icon-save" to "fas fa-save"


### Testing Instructions
go to administrator/index.php?option=com_users&view=group&layout=edit&id=9
via inspector verify both save button icons are using "fas fa-save" instead of "icon-save"


### Actual result BEFORE applying this Pull Request

![image](https://user-images.githubusercontent.com/1850089/88581755-43487700-d013-11ea-89db-23ca20d3e57b.png)


### Expected result AFTER applying this Pull Request
![image](https://user-images.githubusercontent.com/1850089/88581645-17c58c80-d013-11ea-8535-c9dd3a5bde3b.png)



### Documentation Changes Required

none