### PR TITLE
[4.0] Missing icon on Crop button

### DIFF
--- a/administrator/components/com_templates/src/View/Template/HtmlView.php
+++ b/administrator/components/com_templates/src/View/Template/HtmlView.php
@@ -266,7 +266,7 @@ class HtmlView extends BaseHtmlView
 		if ($this->preview->client_id === 0 && $this->type === 'home')
 		{
 			$bar->linkButton('preview')
-				->icon('icon-picture')
+				->icon('picture')
 				->text('COM_TEMPLATES_BUTTON_PREVIEW')
 				->url(Uri::root() . 'index.php?tp=1&templateStyle=' . $this->preview->id)
 				->attributes(['target' => '_new']);

--- a/administrator/components/com_templates/src/View/Template/HtmlView.php
+++ b/administrator/components/com_templates/src/View/Template/HtmlView.php
@@ -253,7 +253,7 @@ class HtmlView extends BaseHtmlView
 			// Add an extract button
 			elseif ($this->type === 'archive')
 			{
-				ToolbarHelper::custom('template.extractArchive', 'fas fa-chevron-down', 'fas fa-chevron-down', 'COM_TEMPLATES_BUTTON_EXTRACT_ARCHIVE', false);
+				ToolbarHelper::custom('template.extractArchive', 'chevron-down', 'chevron-down', 'COM_TEMPLATES_BUTTON_EXTRACT_ARCHIVE', false);
 			}
 			// Add a copy template button
 			elseif ($this->type === 'home')
@@ -295,7 +295,7 @@ class HtmlView extends BaseHtmlView
 
 		if (count($this->updatedList) !== 0 && $this->pluginState)
 		{
-			ToolbarHelper::custom('template.deleteOverrideHistory', 'fas fa-times', 'move', 'COM_TEMPLATES_BUTTON_DELETE_LIST_ENTRY', true, 'updateForm');
+			ToolbarHelper::custom('template.deleteOverrideHistory', 'times', 'move', 'COM_TEMPLATES_BUTTON_DELETE_LIST_ENTRY', true, 'updateForm');
 		}
 
 		if ($this->type === 'home')

--- a/administrator/components/com_templates/src/View/Template/HtmlView.php
+++ b/administrator/components/com_templates/src/View/Template/HtmlView.php
@@ -253,7 +253,7 @@ class HtmlView extends BaseHtmlView
 			// Add an extract button
 			elseif ($this->type === 'archive')
 			{
-				ToolbarHelper::custom('template.extractArchive', 'fas fa-chevron-down', 'fas fa--chevron-down', 'COM_TEMPLATES_BUTTON_EXTRACT_ARCHIVE', false);
+				ToolbarHelper::custom('template.extractArchive', 'fas fa-chevron-down', 'fas fa-chevron-down', 'COM_TEMPLATES_BUTTON_EXTRACT_ARCHIVE', false);
 			}
 			// Add a copy template button
 			elseif ($this->type === 'home')

--- a/layouts/joomla/button/iconclass.php
+++ b/layouts/joomla/button/iconclass.php
@@ -99,6 +99,22 @@ elseif ($icon === 'default')
 {
 	$icon = 'fas fa-home';
 }
+elseif ($icon === 'crop')
+{
+	$icon = 'fas fa-crop';
+}
+elseif ($icon === 'chevron-down')
+{
+	$icon = 'fas fa-chevron-down';
+}
+elseif ($icon === 'times')
+{
+	$icon = 'fas fa-times';
+}
+elseif ($icon === 'move')
+{
+	$icon = 'fas fa-arrows-alt';
+}
 else{
 	$icon = 'icon-' . $icon;
 }

--- a/layouts/joomla/toolbar/iconclass.php
+++ b/layouts/joomla/toolbar/iconclass.php
@@ -99,6 +99,22 @@ elseif ($icon === 'default')
 {
 	$icon = 'fas fa-home';
 }
+elseif ($icon === 'crop')
+{
+	$icon = 'fas fa-crop';
+}
+elseif ($icon === 'chevron-down')
+{
+	$icon = 'fas fa-chevron-down';
+}
+elseif ($icon === 'times')
+{
+	$icon = 'fas fa-times';
+}
+elseif ($icon === 'move')
+{
+	$icon = 'fas fa-arrows-alt';
+}
 else
 {
 	$icon = 'icon-' . $icon;

--- a/libraries/src/Toolbar/Button/StandardButton.php
+++ b/libraries/src/Toolbar/Button/StandardButton.php
@@ -97,30 +97,30 @@ class StandardButton extends BasicButton
 		{
 			case 'apply':
 			case 'new':
-				return ' btn btn-success';
+				return 'btn btn-success';
 
 			case 'save':
 			case 'save-new':
 			case 'save-copy':
 			case 'save-close':
 			case 'publish':
-				return ' btn btn-success';
+				return 'btn btn-success';
 
 			case 'unpublish':
-				return ' btn btn-danger';
+				return 'btn btn-danger';
 
 			case 'featured':
-				return ' btn btn-warning';
+				return 'btn btn-warning';
 
 			case 'cancel':
-				return ' btn btn-danger';
+				return 'btn btn-danger';
 
 			case 'trash':
 			case 'delete':
-				return ' btn btn-danger';
+				return 'btn btn-danger';
 
 			default:
-				return ' btn btn-primary';
+				return 'btn btn-primary';
 		}
 	}
 

--- a/libraries/src/Toolbar/ToolbarButton.php
+++ b/libraries/src/Toolbar/ToolbarButton.php
@@ -196,9 +196,9 @@ abstract class ToolbarButton
 		$options['htmlAttributes'] = ArrayHelper::toString($options['attributes']);
 
 		// Isolate button class from icon class
-		$btnclass = str_replace('fas fa-', '', $this->getName());
+		$buttonClass = str_replace('fas fa-', '', $this->getName());
 		$iconclass = $options['btnClass'] ?? '';
-		$options['btnClass'] = 'button-' . $btnclass . ' ' . $iconclass;
+		$options['btnClass'] = 'button-' . $buttonClass . ' ' . $iconclass;
 
 		// Instantiate a new LayoutFile instance and render the layout
 		$layout = new FileLayout($this->layout);

--- a/libraries/src/Toolbar/ToolbarButton.php
+++ b/libraries/src/Toolbar/ToolbarButton.php
@@ -194,7 +194,11 @@ abstract class ToolbarButton
 		);
 
 		$options['htmlAttributes'] = ArrayHelper::toString($options['attributes']);
-		$options['btnClass'] = $options['btnClass'] ?? '';
+
+		// Isolate button class from icon class
+		$btnclass = str_replace('fas fa-', '', $this->getName());
+		$iconclass = $options['btnClass'] ?? '';
+		$options['btnClass'] = 'button-' . $btnclass . ' ' . $iconclass;
 
 		// Instantiate a new LayoutFile instance and render the layout
 		$layout = new FileLayout($this->layout);

--- a/libraries/src/Toolbar/ToolbarButton.php
+++ b/libraries/src/Toolbar/ToolbarButton.php
@@ -215,7 +215,6 @@ abstract class ToolbarButton
 	 */
 	protected function fetchId()
 	{
-
 		return $this->parent->getName() . '-' . str_ireplace(' ', '-', $this->getName());
 	}
 

--- a/libraries/src/Toolbar/ToolbarButton.php
+++ b/libraries/src/Toolbar/ToolbarButton.php
@@ -215,7 +215,8 @@ abstract class ToolbarButton
 	 */
 	protected function fetchId()
 	{
-		return $this->parent->getName() . '-' . $this->getName();
+
+		return $this->parent->getName() . '-' . str_ireplace(' ', '-', $this->getName());
 	}
 
 	/**

--- a/libraries/src/Toolbar/ToolbarButton.php
+++ b/libraries/src/Toolbar/ToolbarButton.php
@@ -194,7 +194,7 @@ abstract class ToolbarButton
 		);
 
 		$options['htmlAttributes'] = ArrayHelper::toString($options['attributes']);
-		$options['btnClass'] = ($options['btnClass'] ?? '');
+		$options['btnClass'] = $options['btnClass'] ?? '';
 
 		// Instantiate a new LayoutFile instance and render the layout
 		$layout = new FileLayout($this->layout);

--- a/libraries/src/Toolbar/ToolbarButton.php
+++ b/libraries/src/Toolbar/ToolbarButton.php
@@ -194,7 +194,7 @@ abstract class ToolbarButton
 		);
 
 		$options['htmlAttributes'] = ArrayHelper::toString($options['attributes']);
-		$options['btnClass'] = 'button-' . $this->getName() . ' ' . ($options['btnClass'] ?? '');
+		$options['btnClass'] = ($options['btnClass'] ?? '');
 
 		// Instantiate a new LayoutFile instance and render the layout
 		$layout = new FileLayout($this->layout);


### PR DESCRIPTION
Pull Request for Issue #30024

### Summary of Changes
removed button- from button render as the class shouldn't be there

### Testing Instructions
Go to /administrator/index.php?option=com_templates&view=templates
Cassiopeia Details and Files
Click template_thumbnail.png

### Actual result BEFORE applying this Pull Request
Missing icon on Crop button
![image](https://user-images.githubusercontent.com/2019801/86574663-13ef9e80-bf6e-11ea-875a-05045666c182.png)

### Expected result AFTER applying this Pull Request
![image](https://user-images.githubusercontent.com/1850089/88587327-670fbb00-d01b-11ea-8805-88013d4bc832.png)
![image](https://user-images.githubusercontent.com/1850089/88587572-bf46bd00-d01b-11ea-94e3-2bd1cee83e2d.png)

### Documentation Changes Required

none