### PR TITLE
[4.0][api][com_users]  add groups and levels entrypoint

### DIFF
--- a/api/components/com_users/src/Controller/GroupsController.php
+++ b/api/components/com_users/src/Controller/GroupsController.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * @package     Joomla.API
+ * @subpackage  com_users
+ *
+ * @copyright   Copyright (C) 2005 - 2020 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\Component\Users\Api\Controller;
+
+\defined('_JEXEC') or die;
+
+use Joomla\CMS\MVC\Controller\ApiController;
+
+/**
+ * The groups controller
+ *
+ * @since  4.0.0
+ */
+class GroupsController extends ApiController
+{
+	/**
+	 * The content type of the item.
+	 *
+	 * @var    string
+	 * @since  4.0.0
+	 */
+	protected $contentType = 'groups';
+
+	/**
+	 * The default view for the display method.
+	 *
+	 * @var    string
+	 * @since  3.0
+	 */
+	protected $default_view = 'groups';
+}

--- a/api/components/com_users/src/Controller/LevelsController.php
+++ b/api/components/com_users/src/Controller/LevelsController.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * @package     Joomla.API
+ * @subpackage  com_users
+ *
+ * @copyright   Copyright (C) 2005 - 2020 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\Component\Users\Api\Controller;
+
+\defined('_JEXEC') or die;
+
+use Joomla\CMS\MVC\Controller\ApiController;
+
+/**
+ * The levels controller
+ *
+ * @since  4.0.0
+ */
+class LevelsController extends ApiController
+{
+	/**
+	 * The content type of the item.
+	 *
+	 * @var    string
+	 * @since  4.0.0
+	 */
+	protected $contentType = 'levels';
+
+	/**
+	 * The default view for the display method.
+	 *
+	 * @var    string
+	 * @since  4.0.0
+	 */
+	protected $default_view = 'levels';
+}

--- a/api/components/com_users/src/View/Groups/JsonapiView.php
+++ b/api/components/com_users/src/View/Groups/JsonapiView.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * @package     Joomla.API
+ * @subpackage  com_users
+ *
+ * @copyright   Copyright (C) 2005 - 2020 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\Component\Users\Api\View\Groups;
+
+\defined('_JEXEC') or die;
+
+use Joomla\CMS\MVC\View\JsonApiView as BaseApiView;
+
+/**
+ * The groups view
+ *
+ * @since  4.0.0
+ */
+class JsonapiView extends BaseApiView
+{
+	/**
+	 * The fields to render item in the documents
+	 *
+	 * @var  array
+	 * @since  4.0.0
+	 */
+	protected $fieldsToRenderItem = [
+		'id',
+		'parent_id',
+		'lft',
+		'rgt',
+		'title',
+	];
+
+	/**
+	 * The fields to render items in the documents
+	 *
+	 * @var  array
+	 * @since  4.0.0
+	 */
+	protected $fieldsToRenderList = [
+		'id',
+		'parent_id',
+		'lft',
+		'rgt',
+		'title',
+	];
+}

--- a/api/components/com_users/src/View/Levels/JsonapiView.php
+++ b/api/components/com_users/src/View/Levels/JsonapiView.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * @package     Joomla.API
+ * @subpackage  com_users
+ *
+ * @copyright   Copyright (C) 2005 - 2020 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\Component\Users\Api\View\Levels;
+
+\defined('_JEXEC') or die;
+
+use Joomla\CMS\MVC\View\JsonApiView as BaseApiView;
+
+/**
+ * The levels view
+ *
+ * @since  4.0.0
+ */
+class JsonapiView extends BaseApiView
+{
+	/**
+	 * The fields to render item in the documents
+	 *
+	 * @var  array
+	 * @since  4.0.0
+	 */
+	protected $fieldsToRenderItem = [
+		'id',
+		'title',
+		'rules'
+	];
+
+	/**
+	 * The fields to render items in the documents
+	 *
+	 * @var  array
+	 * @since  4.0.0
+	 */
+	protected $fieldsToRenderList = [
+		'id',
+		'title',
+		'rules',
+	];
+}

--- a/plugins/webservices/users/users.php
+++ b/plugins/webservices/users/users.php
@@ -45,6 +45,18 @@ class PlgWebservicesUsers extends CMSPlugin
 		);
 
 		$this->createFieldsRoutes($router);
+
+		$router->createCRUDRoutes(
+			'v1/users/groups',
+			'groups',
+			['component' => 'com_users']
+		);
+
+		$router->createCRUDRoutes(
+			'v1/users/levels',
+			'levels',
+			['component' => 'com_users']
+		);
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue #30203 .

### Summary of Changes
added 2 new entrypoint for com_users

- levels
- groups


### Testing Instructions
for list 
`{{base_url}}api/index.php/v1/users/groups`
`{{base_url}}api/index.php/v1/users/levels`

 for item
`{{base_url}}api/index.php/v1/users/groups/{id}`
`{{base_url}}api/index.php/v1/users/levels/{id}`


### Actual result BEFORE applying this Pull Request
N/A


### Expected result AFTER applying this Pull Request
levels

![Screenshot from 2020-07-28 18-47-05](https://user-images.githubusercontent.com/181681/88695897-d1e7f180-d102-11ea-91d1-ca9563a7dd03.png)

level
![Screenshot from 2020-07-28 18-48-08](https://user-images.githubusercontent.com/181681/88695955-e7f5b200-d102-11ea-9c98-b31ab18ddce6.png)

groups
![Screenshot from 2020-07-28 18-48-41](https://user-images.githubusercontent.com/181681/88696027-ffcd3600-d102-11ea-8a5b-0571c56b313c.png)

group

![Screenshot from 2020-07-28 18-49-19](https://user-images.githubusercontent.com/181681/88696081-12476f80-d103-11ea-82ea-2564d24ac5e8.png)




### Documentation Changes Required

yes