### PR TITLE
[4.0] Fix wrong table name "#__ucm_history" in utf8mb4 conversion SQL script

### DIFF
--- a/administrator/components/com_admin/sql/others/mysql/utf8mb4-conversion.sql
+++ b/administrator/components/com_admin/sql/others/mysql/utf8mb4-conversion.sql
@@ -24,6 +24,7 @@ ALTER TABLE `#__fields` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode
 ALTER TABLE `#__fields_categories` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 ALTER TABLE `#__fields_groups` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 ALTER TABLE `#__fields_values` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE `#__history` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 ALTER TABLE `#__languages` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 ALTER TABLE `#__menu` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 ALTER TABLE `#__menu_types` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
@@ -44,7 +45,6 @@ ALTER TABLE `#__template_overrides` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf
 ALTER TABLE `#__template_styles` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 ALTER TABLE `#__ucm_base` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 ALTER TABLE `#__ucm_content` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-ALTER TABLE `#__ucm_history` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 ALTER TABLE `#__updates` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 ALTER TABLE `#__update_sites` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 ALTER TABLE `#__update_sites_extensions` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
@@ -97,6 +97,7 @@ ALTER TABLE `#__fields` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci
 ALTER TABLE `#__fields_categories` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 ALTER TABLE `#__fields_groups` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 ALTER TABLE `#__fields_values` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE `#__history` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 ALTER TABLE `#__languages` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 ALTER TABLE `#__menu` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 ALTER TABLE `#__menu_types` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
@@ -117,7 +118,6 @@ ALTER TABLE `#__template_overrides` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb
 ALTER TABLE `#__template_styles` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 ALTER TABLE `#__ucm_base` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 ALTER TABLE `#__ucm_content` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-ALTER TABLE `#__ucm_history` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 ALTER TABLE `#__updates` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 ALTER TABLE `#__update_sites` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 ALTER TABLE `#__update_sites_extensions` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;


### PR DESCRIPTION
Pull Request for Issue #30224 .

This pull request is not relevant for installations with a PostgreSQL database. It only applies to MySQL (or MariaDB).

### Summary of Changes

With Pull Request (PR) #29217 , the `#__ucm_history` database table has been renamed to `#__history`.

But it was forgotten to do this change in the utf8mb4 conversion SQL script.

This causes an update from 3.10 to 4 with utf8mb4 conversion to fail with an SQL error.

This PR here corrects this.

Due to the minimum database server version requirement we can be sure that J4 runs on a database which supports utf8mb4.

But the utf8mb4 conversion is still needed in J4 for following scenario:
1. Just after the update to version 3.10, the dabase is migrated to the new server which supports utf8mb4, or updated to a newer version, so the conversion could not be triggered by the update to 3.10.
2. The database checker would show that the utf8mb4 conversion needs to be done, and with using the "Fix" button it should be run, but the admin simply doesn't check for database error and immediately updates to J4.
3. So the database changes for J4 are done during the update, but the database tables still are utf8 without mb4.
4. That's why we have to run the utf8mb4 conversion once at the end when updating to J4.

### Testing Instructions

#### Preparation

On a clean installation of Joomla 3.10 (latest nightly or Alpha 1 or current 3.10-dev branch) using a MySQL or MariaDB database, login to database using a tool like e.g. phpMyAdmin, and issue following SQL statement, replacing `#__` by your database table prefix:
```
UPDATE `#__utf8_conversion` SET `converted`=3;
```
This will simulate the situation that a database server of a J 3.10 has been updated from an old version which did not support utf8mb4 to a newer version which does that and fulfills the version requirements of J4, or migrates the database from an old server to a new server with the same result.

Go to Global Configuration and set error reporting to "Maximum" in the server settings.

Go to "Extensions -> Manage -> Database" and check if there are database problems, but DO **_NOT_** USE THE FIX BUTTON!!!

Result: 1 database problem "The Joomla! Core database tables have not been converted yet to UTF-8 Multibyte (utf8mb4).".
![j4-pr-30227_preparation](https://user-images.githubusercontent.com/7413183/88898910-b0dfe780-d24d-11ea-849a-8cd6fce7b4b8.png)

Make a complete backup, i.e. files and database, so you can later restore the starting point for test 2 after having done test 1. 

#### Test 1: Reproduce the issue

Update a Joomla 3.10 which has been prepared as described above in section "Preparation" to the latest Joomla 4 nightly build.

If you can use the Live Update, change the update Channel to "Custom URL" and enter the following URL in the Joomla Update component's options: [https://update.joomla.org/core/nightlies/next_major_list.xml](https://update.joomla.org/core/nightlies/next_major_list.xml).

I you can't use the Live Update for some reason, download the update package from the following link and use "Upload & Update": [https://developer.joomla.org/nightlies/Joomla_4.0.0-beta4-dev-Development-Update_Package.zip](https://developer.joomla.org/nightlies/Joomla_4.0.0-beta4-dev-Development-Update_Package.zip).

Hint: The error alert "The template for this display is not available." shown during the update when having to log in is a know issue and can be ignored.

Result: See section "Actual result BEFORE applying this Pull Request" below.

#### Test 2: Test the fix of this PR

Same as before, but this time you update the prepared 3.10 to latest 4.0-dev plus the patch of this PR applied.

For this you either use the Live Update with custom URL [https://ci.joomla.org/artifacts/joomla/joomla-cms/4.0-dev/30227/downloads/34309/pr_list.xml](https://ci.joomla.org/artifacts/joomla/joomla-cms/4.0-dev/30227/downloads/34309/pr_list.xml), or use the "Upload & Update" and download the update package for this PR from [https://ci.joomla.org/artifacts/joomla/joomla-cms/4.0-dev/30227/downloads/34309/Joomla_4.0.0-beta4-dev+pr.30227-Development-Update_Package.zip](https://ci.joomla.org/artifacts/joomla/joomla-cms/4.0-dev/30227/downloads/34309/Joomla_4.0.0-beta4-dev+pr.30227-Development-Update_Package.zip).

Use a tool like e.g. phpMyAdmin to check collation of core database tables.

Result: See section "Expected result AFTER applying this Pull Request" below.

### Actual result BEFORE applying this Pull Request

The update fails with an SQL error about not existing table `#__ucm_history` (replace `#__`by your database prefix). See issue #30224 .
![j4-pr-30227_error](https://user-images.githubusercontent.com/7413183/88901758-809a4800-d251-11ea-9648-1ac283e3d957.png)

In "System -> Information -> Database" (which was "Extensions -> Manage -> Database" in J3):
![j4-pr-30227_error-2](https://user-images.githubusercontent.com/7413183/88901859-a7f11500-d251-11ea-8765-ab833769f327.png)

Using the "Update Structure" button (formerly called "Fix" in J3) does not change anything.

### Expected result AFTER applying this Pull Request

The update ends with success.
![j4-pr-30227_ok](https://user-images.githubusercontent.com/7413183/88902877-108cc180-d253-11ea-8abe-444922d3ecf9.png)

The error alert "The template for this display is not available." is a know issue and can be ignored. It will disappear and never appear again after first navigating in the backend.

In "System -> Information -> Database" (which was "Extensions -> Manage -> Database" in J3):
![j4-pr-30227_ok-2](https://user-images.githubusercontent.com/7413183/88903004-429e2380-d253-11ea-8f70-89669b704a56.png)

The error about not matching version numbers is normal when using an update package which has been automatically build for a PR. It can be ignored, but it also can be fixed with the "Update Structure" button because that looks nicer at the end.

In database all core tables have collation `utf8mb4_unicode_ci`.

### Documentation Changes Required

None.