### PR TITLE
[4.0] Fix broken check for com_admin in database schema fixer

### DIFF
--- a/administrator/components/com_installer/src/Model/DatabaseModel.php
+++ b/administrator/components/com_installer/src/Model/DatabaseModel.php
@@ -259,7 +259,7 @@ class DatabaseModel extends InstallerModel
 			$this->fixSchemaVersion($changeSet['changeset'], $changeSet['extension']->extension_id);
 			$this->fixUpdateVersion($changeSet['extension']->extension_id);
 
-			if ($i === 'com_admin')
+			if ($changeSet['extension']->element === 'com_admin')
 			{
 				$installer = new \JoomlaInstallerScript;
 				$installer->deleteUnexistingFiles();


### PR DESCRIPTION
Pull Request for Issue #30223 .

### Summary of Changes

This pull request (PR) fixes an error from PR #17537 which has introduced database schema checker and fixer for extensions in Joomla 4.

The double error is that an arry index and not the value of an array which holds extension IDs is compared with the extension element value 'com_admin'.

This PR fixes it by using the `element` property of the `extensions` element of the previously obtained `changeset` for the given extension ID.

### Testing Instructions

#### Preparation

Have a clean, current 4.0-dev branch or a 4.0 nightly or a Beta 3 with at least one extension installed, e.g. the patchtester.

Have error reporting set to "Maximum" in Global Configuration in server settings.

In your PHP settings, have display errors on or log errors on and log into a file.

#### Procedure

1. Open file `administrator/components/com_installer/src/Model/DatabaseModel.php` in an editor and go to following line:
[https://github.com/joomla/joomla-cms/blob/4.0-dev/administrator/components/com_installer/src/Model/DatabaseModel.php#L264](https://github.com/joomla/joomla-cms/blob/4.0-dev/administrator/components/com_installer/src/Model/DatabaseModel.php#L264).

2. Before that line, add a line with debug output into the PHP log as follows:
`error_log('Hello, I am com_admin');`
or whatever else comes into your mind, so it finally looks like:
```
if ($i === 'com_admin')
{
	error_log('Hello, I am com_admin');
	$installer = new \JoomlaInstallerScript;

	...
}
```

3. Go to "System -> Information -> Database".

4. Use the "Update Structure" button with each of the following combinations of selected check boxes and then check your PHP error log if there is the debug log you have added before with the preparation for the test.
a) Only some extension's check box selected, but not the one for "Joomla CMS" = the core.
b Only "Joomla CMS" = the core's check box selected, but not any other check box for any extension.
c) The check box for "Joomla CMS" and also one of some extension selected.
Result: See section "Actual result BEFORE applying this Pull Request" below.

5. Apply the patch of this PR.
Note: When using patchtester you might have to remove the debug log which you have added before in step 2, then apply the patch and after that add back the debug log, so it looks like:
```
if ($changeSet['extension']->element === 'com_admin')
{
	error_log('Hello, I am com_admin');
	$installer = new \JoomlaInstallerScript;

	...
}
```

6. Repeat steps 3 and 4.
Result: See section "Expected result AFTER applying this Pull Request" below.

### Actual result BEFORE applying this Pull Request

In all 3 cases a) to c) no debug log.

### Expected result AFTER applying this Pull Request

a) Only some extension's check box selected, but not the one for "Joomla CMS" = the core  => No debug log.
b Only "Joomla CMS" = the core's check box selected, but not any other check box for any extension => Debug log.
c) The check box for "Joomla CMS" and also one of some extension selected => Debug log.

### Documentation Changes Required

None.