### PR TITLE
[4.0] Update default behavior for the referrer policy

### DIFF
--- a/plugins/system/httpheaders/httpheaders.php
+++ b/plugins/system/httpheaders/httpheaders.php
@@ -471,7 +471,7 @@ class PlgSystemHttpHeaders extends CMSPlugin implements SubscriberInterface
 		}
 
 		// Referrer-policy
-		$referrerPolicy = (string) $this->params->get('referrerpolicy', 'no-referrer-when-downgrade');
+		$referrerPolicy = (string) $this->params->get('referrerpolicy', 'strict-origin-when-cross-origin');
 
 		if ($referrerPolicy !== 'disabled')
 		{

--- a/plugins/system/httpheaders/httpheaders.xml
+++ b/plugins/system/httpheaders/httpheaders.xml
@@ -32,7 +32,7 @@
 					name="referrerpolicy"
 					type="list"
 					label="PLG_SYSTEM_HTTPHEADERS_REFERRERPOLICY"
-					default="no-referrer-when-downgrade"
+					default="strict-origin-when-cross-origin"
 					validate="options"
 					>
 					<option value="disabled">JDISABLED</option>


### PR DESCRIPTION
### Summary of Changes

Update default behavior for the referrer policy from `no-referrer-when-downgrade` to `strict-origin-when-cross-origin`.

The details can be checked here: https://web.dev/referrer-best-practices/ with Chrome 85 this is going to be the default in the browsers too.

### Testing Instructions

check the default option for the referrer policy
apply this patch
check the default option for the referrer policy has been updated to `strict-origin-when-cross-origin`

### Actual result BEFORE applying this Pull Request

Default is `no-referrer-when-downgrade`

### Expected result AFTER applying this Pull Request

Default is `strict-origin-when-cross-origin`

### Documentation Changes Required

https://docs.joomla.org/J4.x:Http_Header_Management