### PR TITLE
Missing preview icon

### DIFF
--- a/administrator/components/com_templates/src/View/Template/HtmlView.php
+++ b/administrator/components/com_templates/src/View/Template/HtmlView.php
@@ -263,10 +263,9 @@ class HtmlView extends BaseHtmlView
 		}
 
 		// Add a Template preview button
-		$client = (int) $this->preview->client_id === 1 ? 'administrator/' : '';
-
 		if ($this->type === 'home')
 		{
+			$client = (int) $this->preview->client_id === 1 ? 'administrator/' : '';
 			$bar->linkButton('preview')
 				->icon('fas fa-image')
 				->text('COM_TEMPLATES_BUTTON_PREVIEW')

--- a/administrator/components/com_templates/src/View/Template/HtmlView.php
+++ b/administrator/components/com_templates/src/View/Template/HtmlView.php
@@ -266,7 +266,7 @@ class HtmlView extends BaseHtmlView
 		if ($this->preview->client_id === 0 && $this->type === 'home')
 		{
 			$bar->linkButton('preview')
-				->icon('picture')
+				->icon('fas fa-image')
 				->text('COM_TEMPLATES_BUTTON_PREVIEW')
 				->url(Uri::root() . 'index.php?tp=1&templateStyle=' . $this->preview->id)
 				->attributes(['target' => '_new']);

--- a/administrator/components/com_templates/src/View/Template/HtmlView.php
+++ b/administrator/components/com_templates/src/View/Template/HtmlView.php
@@ -263,12 +263,14 @@ class HtmlView extends BaseHtmlView
 		}
 
 		// Add a Template preview button
-		if ($this->preview->client_id === 0 && $this->type === 'home')
+		$client = (int) $this->preview->client_id === 1 ? 'administrator/' : '';
+
+		if ($this->type === 'home')
 		{
 			$bar->linkButton('preview')
 				->icon('fas fa-image')
 				->text('COM_TEMPLATES_BUTTON_PREVIEW')
-				->url(Uri::root() . 'index.php?tp=1&templateStyle=' . $this->preview->id)
+				->url(Uri::root() . $client . 'index.php?tp=1&templateStyle=' . $this->preview->id)
 				->attributes(['target' => '_new']);
 		}
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
repaired preview icon lost in last pr

### Testing Instructions
go to System > Site Templates > Cassiopeia Details and Files > Template Preview button and verify the image icon "fas fa-image" is there


### Actual result BEFORE applying this Pull Request

no icon present

### Expected result AFTER applying this Pull Request

![image](https://user-images.githubusercontent.com/1850089/89019015-4c229c80-d2e2-11ea-8ede-bec9ed54df82.png)


### Documentation Changes Required

none