### PR TITLE
[4.0] Add padding to external link icon

### DIFF
--- a/administrator/templates/atum/scss/blocks/_global.scss
+++ b/administrator/templates/atum/scss/blocks/_global.scss
@@ -167,11 +167,12 @@ body .container-main {
 }
 
 // extern links with icons
-a[target="_blank"]::before {
+a[target="_blank"]::after {
   font-family: "Font Awesome 5 Free";
   font-size: 14px;
   font-weight: 900;
   content: "\f35d";
+  padding-left: 5px;
 }
 
 #wrapper {

--- a/administrator/templates/atum/scss/blocks/_global.scss
+++ b/administrator/templates/atum/scss/blocks/_global.scss
@@ -167,12 +167,12 @@ body .container-main {
 }
 
 // extern links with icons
-a[target="_blank"]::after {
+a[target="_blank"]::before {
   font-family: "Font Awesome 5 Free";
   font-size: 14px;
   font-weight: 900;
   content: "\f35d";
-  padding-left: 5px;
+  padding-right: 5px;
 }
 
 #wrapper {

--- a/administrator/templates/atum/scss/blocks/_global.scss
+++ b/administrator/templates/atum/scss/blocks/_global.scss
@@ -172,7 +172,7 @@ a[target="_blank"]::before {
   font-size: 14px;
   font-weight: 900;
   content: "\f35d";
-  padding-right: 5px;
+  padding-right: 3px;
 }
 
 #wrapper {

--- a/administrator/templates/atum/scss/blocks/_global.scss
+++ b/administrator/templates/atum/scss/blocks/_global.scss
@@ -168,11 +168,11 @@ body .container-main {
 
 // extern links with icons
 a[target="_blank"]::before {
+  padding-right: 3px;
   font-family: "Font Awesome 5 Free";
   font-size: 14px;
   font-weight: 900;
   content: "\f35d";
-  padding-right: 3px;
 }
 
 #wrapper {


### PR DESCRIPTION
Pull Request for Issue #29335 .

### Summary of Changes
Add padding to external link icon.

In Help Dashboard, padding is slightly wider due to markup, but at least it is better with this PR than before.

### Testing Instructions
Run `npm run build:css` or download the installer package at the bottom of the page.

Navigate backend to see external links in:
- Post Installation Messages
- reCAPTCHA plugin
- Two Factor Authentication - Google Authenticator plugin
- Content Security Policy configuration and select Custom (see screenshots)
- Extensions > Install from Web
- Help Dashboard


### Actual result BEFORE applying this Pull Request
![29335-before](https://user-images.githubusercontent.com/368084/89076037-62f1df00-d334-11ea-9770-59399af59c66.png)






### Expected result AFTER applying this Pull Request
![29335-before](https://user-images.githubusercontent.com/368084/89075909-173f3580-d334-11ea-8cf1-18c44ea7efe7.png)
