### PR TITLE
[4.0][com_content] - create article performance

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/4.0.0-2020-08-02.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.0.0-2020-08-02.sql
@@ -1,0 +1,25 @@
+ALTER TABLE `#__content` ADD INDEX `idx_catid_ordering` (`catid`, `ordering`);
+
+--
+-- Add index for ordering on #__content_frontpage table
+--
+ALTER TABLE `#__content_frontpage` ADD INDEX `idx_ordering` (`ordering`);
+
+-- Reverse ordering in #__content table
+UPDATE `#__content` AS n
+INNER JOIN (
+	SELECT (
+		SELECT @rownum := IF(@group = catid OR ((@group := catid) AND 0), @rownum + 1, 1)
+		FROM (SELECT @rownum := 0, @group := '') AS r) AS new_ordering, id, catid, ordering
+	FROM `#__content`
+	ORDER BY catid DESC, ordering DESC) n2 ON n2.id = n.id
+SET n.ordering = n2.new_ordering;
+
+-- Reverse ordering in #__content_frontpage table
+UPDATE `#__content_frontpage` AS n
+INNER JOIN (
+	SELECT (SELECT @rownum := @rownum + 1 FROM (SELECT @rownum := 0) AS r) AS new_ordering, content_id, ordering
+	FROM `#__content_frontpage`
+	ORDER BY ordering DESC
+) n2 ON n2.content_id = n.content_id
+SET n.ordering = n2.new_ordering;

--- a/administrator/components/com_admin/sql/updates/mysql/4.0.0-2020-08-02.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.0.0-2020-08-02.sql
@@ -27,7 +27,8 @@ SET n.ordering = n2.new_ordering
 WHERE n.id = n2.id;
 
 -- Reverse ordering in #__content_frontpage table
-SET @new_ordering := 0; 
+SET @new_ordering := 0;
+SET @row_number := 0;
 UPDATE `#__content_frontpage` AS n
 INNER JOIN (
   SELECT 

--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2020-08-02.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2020-08-02.sql
@@ -1,0 +1,27 @@
+--
+-- Add index for ordering in category on #__content table
+--
+CREATE INDEX "#__content_idx_catid_ordering" ON "#__content" ("catid", "ordering");
+
+--
+-- Add index for ordering on #__content_frontpage table
+--
+CREATE INDEX "#__content_frontpage_idx_ordering" ON "#__content_frontpage" ("ordering");
+
+-- Reverse ordering in #__content table
+UPDATE "#__content" n
+SET ordering = n2.new_ordering
+FROM (
+	SELECT id, ROW_NUMBER() OVER (PARTITION BY catid ORDER BY ordering DESC) AS new_ordering
+	FROM "#__content"
+) n2
+WHERE n.id = n2.id;
+
+-- Reverse ordering in #__content_frontpage table
+UPDATE "#__content_frontpage" n
+SET ordering = n2.new_ordering
+FROM (
+	SELECT content_id, ROW_NUMBER() OVER (ORDER BY ordering DESC) AS new_ordering
+	FROM "#__content_frontpage"
+) n2
+WHERE n.content_id = n2.content_id;

--- a/administrator/components/com_content/src/Model/ArticleModel.php
+++ b/administrator/components/com_content/src/Model/ArticleModel.php
@@ -363,7 +363,7 @@ class ArticleModel extends AdminModel implements WorkflowModelInterface
 		// Reorder the articles within the category so the new article is first
 		if (empty($table->id))
 		{
-			$table->reorder('catid = ' . (int) $table->catid . ' AND state >= 0');
+			$table->ordering = $table->getNextOrder('catid = ' . (int) $table->catid);
 		}
 	}
 
@@ -970,6 +970,8 @@ class ArticleModel extends AdminModel implements WorkflowModelInterface
 				// Featuring.
 				if ($newFeatured)
 				{
+					$ordering = $table->getNextOrder();
+	
 					$query = $db->getQuery(true)
 						->insert($db->quoteName('#__content_frontpage'))
 						->columns(
@@ -990,7 +992,8 @@ class ArticleModel extends AdminModel implements WorkflowModelInterface
 
 					foreach ($newFeatured as $pk)
 					{
-						$query->values(implode(',', $query->bindArray([$pk, 0, $featuredUp, $featuredDown], $dataTypes)));
+						$query->values(implode(',', $query->bindArray([$pk, $ordering, $featuredUp, $featuredDown], $dataTypes)));
+						$ordering++;
 					}
 
 					$db->setQuery($query);
@@ -1004,8 +1007,6 @@ class ArticleModel extends AdminModel implements WorkflowModelInterface
 
 			return false;
 		}
-
-		$table->reorder();
 
 		// Trigger the change state event.
 		Factory::getApplication()->getDispatcher()->dispatch(

--- a/administrator/components/com_content/src/Model/ArticleModel.php
+++ b/administrator/components/com_content/src/Model/ArticleModel.php
@@ -971,7 +971,6 @@ class ArticleModel extends AdminModel implements WorkflowModelInterface
 				if ($newFeatured)
 				{
 					$ordering = $table->getNextOrder();
-	
 					$query = $db->getQuery(true)
 						->insert($db->quoteName('#__content_frontpage'))
 						->columns(

--- a/installation/sql/mysql/extensions.sql
+++ b/installation/sql/mysql/extensions.sql
@@ -195,7 +195,8 @@ CREATE TABLE IF NOT EXISTS `#__content` (
   KEY `idx_createdby` (`created_by`),
   KEY `idx_featured_catid` (`featured`,`catid`),
   KEY `idx_language` (`language`),
-  KEY `idx_alias` (`alias`(191))
+  KEY `idx_alias` (`alias`(191)),
+  KEY `idx_catid_ordering` (`catid`, `ordering`),													 
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
 
 -- --------------------------------------------------------
@@ -209,7 +210,8 @@ CREATE TABLE IF NOT EXISTS `#__content_frontpage` (
   `ordering` int(11) NOT NULL DEFAULT 0,
   `featured_up` datetime,
   `featured_down` datetime,
-  PRIMARY KEY (`content_id`)
+  PRIMARY KEY (`content_id`),
+  KEY `idx_ordering` (`ordering`),
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
 
 -- --------------------------------------------------------

--- a/installation/sql/mysql/extensions.sql
+++ b/installation/sql/mysql/extensions.sql
@@ -211,7 +211,7 @@ CREATE TABLE IF NOT EXISTS `#__content_frontpage` (
   `featured_up` datetime,
   `featured_down` datetime,
   PRIMARY KEY (`content_id`),
-  KEY `idx_ordering` (`ordering`),
+  KEY `idx_ordering` (`ordering`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
 
 -- --------------------------------------------------------

--- a/installation/sql/mysql/extensions.sql
+++ b/installation/sql/mysql/extensions.sql
@@ -196,7 +196,7 @@ CREATE TABLE IF NOT EXISTS `#__content` (
   KEY `idx_featured_catid` (`featured`,`catid`),
   KEY `idx_language` (`language`),
   KEY `idx_alias` (`alias`(191)),
-  KEY `idx_catid_ordering` (`catid`, `ordering`),													 
+  KEY `idx_catid_ordering` (`catid`, `ordering`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
 
 -- --------------------------------------------------------

--- a/installation/sql/postgresql/extensions.sql
+++ b/installation/sql/postgresql/extensions.sql
@@ -188,6 +188,7 @@ CREATE INDEX "#__content_idx_createdby" ON "#__content" ("created_by");
 CREATE INDEX "#__content_idx_featured_catid" ON "#__content" ("featured", "catid");
 CREATE INDEX "#__content_idx_language" ON "#__content" ("language");
 CREATE INDEX "#__content_idx_alias" ON "#__content" ("alias");
+CREATE INDEX "#__content_idx_catid_ordering" ON "#__content" ("catid", "ordering");
 
 COMMENT ON COLUMN "#__content"."asset_id" IS 'FK to the #__assets table.';
 COMMENT ON COLUMN "#__content"."featured" IS 'Set if article is featured.';
@@ -205,6 +206,7 @@ CREATE TABLE IF NOT EXISTS "#__content_frontpage" (
   "featured_down" timestamp without time zone,
   PRIMARY KEY ("content_id")
 );
+CREATE INDEX "#__content_frontpage_idx_ordering" ON "#__content_frontpage" ("ordering");
 
 --
 -- Table structure for table `#__content_rating`


### PR DESCRIPTION
Redo of #21871 .

### Summary of Changes
performance
the` $table->reorder()` was insanely invoked in the artcle model

Support for updates existed articles in joomla 3.x to 4.0:

-  reversing the order in the featured/frontpage table
-  reversing the order in the article table per category.

Two indexes have been added to speed up the order change.


### Testing Instructions
- add this lines of code after  https://github.com/joomla/joomla-cms/blob/4.0-dev/administrator/components/com_content/src/Model/ArticleModel.php#L348
```php
JDEBUG ? $time = microtime(true) : null;
JDEBUG ? Log::addLogger(array('text_file' => 'testPR8576.php', ), Log::INFO) : null;
```
- add this lines of code before https://github.com/joomla/joomla-cms/blob/4.0-dev/administrator/components/com_content/src/Model/ArticleModel.php#L367
```php
JDEBUG ? Log::add('prepareTable():' . round(microtime(true) - $time, 3), Log::INFO) : null;
```
- enabled the debug plugin
- create 1000 articles in 1 category with this component https://github.com/wilsonge/com_overload 
- look at the log file `/administrators/log/testPR8576.php`

then
- apply the pr
- run the query in the update path
- delete configuration.php
- reinstall
- discover com_overload
- create 1000 article in 1 category
- look at the log file `/administrators/log/testPR8576.php`


### Actual result BEFORE applying this Pull Request

the time needed for create an article is more huge than the time with this pr

### Expected result AFTER applying this Pull Request

the time for create an article is less with this pr

### Documentation Changes Required
No
