### PR TITLE
[4.0] FieldsHelper: Choose a first available category  correctly

### DIFF
--- a/administrator/components/com_content/src/Model/ArticleModel.php
+++ b/administrator/components/com_content/src/Model/ArticleModel.php
@@ -524,22 +524,20 @@ class ArticleModel extends AdminModel implements WorkflowModelInterface
 					? (int) reset($assignedCatids)
 					: (int) $assignedCatids;
 
-				// Try to get the category from the html code of the field
+				// Try to get the category from the category field
 				if (empty($assignedCatids))
 				{
 					$assignedCatids = $formField->getAttribute('default', null);
 
-					// Choose the first category available
-					$xml = new \DOMDocument;
-					libxml_use_internal_errors(true);
-					$xml->loadHTML($formField->__get('input'));
-					libxml_clear_errors();
-					libxml_use_internal_errors(false);
-					$options = $xml->getElementsByTagName('option');
-
-					if (!$assignedCatids && $firstChoice = $options->item(0))
+					if (!$assignedCatids)
 					{
-						$assignedCatids = $firstChoice->getAttribute('value');
+						// Choose the first category available
+						$catOptions = $formField->options;
+
+						if ($catOptions && !empty($catOptions[0]->value))
+						{
+							$assignedCatids = (int) $catOptions[0]->value;
+						}
 					}
 				}
 

--- a/administrator/components/com_fields/src/Helper/FieldsHelper.php
+++ b/administrator/components/com_fields/src/Helper/FieldsHelper.php
@@ -318,9 +318,10 @@ class FieldsHelper
 
 			if (!$assignedCatids)
 			{
+				// Choose the first category available
 				$catOptions = $formField->options;
 
-				if (!empty($catOptions[0]->value))
+				if ($catOptions && !empty($catOptions[0]->value))
 				{
 					$assignedCatids = (int) $catOptions[0]->value;
 				}

--- a/administrator/components/com_fields/src/Helper/FieldsHelper.php
+++ b/administrator/components/com_fields/src/Helper/FieldsHelper.php
@@ -316,17 +316,14 @@ class FieldsHelper
 		{
 			$assignedCatids = $formField->getAttribute('default', null);
 
-			// Choose the first category available
-			$xml = new \DOMDocument;
-			libxml_use_internal_errors(true);
-			$xml->loadHTML($formField->__get('input'));
-			libxml_clear_errors();
-			libxml_use_internal_errors(false);
-			$options = $xml->getElementsByTagName('option');
-
-			if (!$assignedCatids && $firstChoice = $options->item(0))
+			if (!$assignedCatids)
 			{
-				$assignedCatids = $firstChoice->getAttribute('value');
+				$catOptions = $formField->options;
+
+				if (!empty($catOptions[0]->value))
+				{
+					$assignedCatids = (int) $catOptions[0]->value;
+				}
 			}
 
 			$data->fieldscatid = $assignedCatids;

--- a/libraries/src/MVC/Model/WorkflowBehaviorTrait.php
+++ b/libraries/src/MVC/Model/WorkflowBehaviorTrait.php
@@ -411,17 +411,15 @@ trait WorkflowBehaviorTrait
 		{
 			$catId = $field->getAttribute('default', null);
 
-			// Choose the first category available
-			$xml = new \DOMDocument;
-			libxml_use_internal_errors(true);
-			$xml->loadHTML($field->__get('input'));
-			libxml_clear_errors();
-			libxml_use_internal_errors(false);
-			$options = $xml->getElementsByTagName('option');
-
-			if (!$catId && $firstChoice = $options->item(0))
+			if (!$catId)
 			{
-				$catId = $firstChoice->getAttribute('value');
+				// Choose the first category available
+				$catOptions = $field->options;
+
+				if ($catOptions && !empty($catOptions[0]->value))
+				{
+					$catId = (int) $catOptions[0]->value;
+				}
 			}
 		}
 


### PR DESCRIPTION
Try to fix release blocker #23036 .

### Summary of Changes

This is correcting a way to retrieve a first category in list


### Testing Instructions

Apply patch, and create a field assigned to specific category.
Then create a new Article to this category and make sure the field is there.


### Actual result BEFORE applying this Pull Request

Works

### Expected result AFTER applying this Pull Request

Works

### Documentation Changes Required

nope

ping @wilsonge 