### PR TITLE
Javascript Improvement for some minifiers

### DIFF
--- a/media/system/js/validate-uncompressed.js
+++ b/media/system/js/validate-uncompressed.js
@@ -212,7 +212,7 @@ var JFormValidator = function() {
  	 	});
  	 	setHandler('email', function(value, element) {
 		    value = punycode.toASCII(value);
- 	 	 	var regex = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
+ 	 	 	var regex = new RegExp("/^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/");
  	 	 	return regex.test(value);
  	 	});
  	 	// Attach to forms with class 'form-validate'


### PR DESCRIPTION
I simply put  
new RegExp(" ... ")
around the email validation RegEx.
Reason : At least one very famous JS minifier which is in widespread use does stumble over this complex pattern, especially because they have problem recognizing them as such in the first place.
The simple 'wrap' makes it clearly and surely possible to identify the RegEx as such. 
The Minifier I tested the most with and draw my conclusion from is JShrink from tedious ( https://github.com/tedious/JShrink ).

Pull Request for Issue # .

### Summary of Changes



### Testing Instructions



### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Documentation Changes Required

