### PR TITLE
[4.0] Correct CSP report link

### DIFF
--- a/plugins/system/httpheaders/httpheaders.php
+++ b/plugins/system/httpheaders/httpheaders.php
@@ -251,11 +251,9 @@ class PlgSystemHttpHeaders extends CMSPlugin implements SubscriberInterface
 		// In detecting mode we set this default rule so any report gets collected by com_csp
 		if ($cspMode === 'detect')
 		{
-			$frontendUrl = str_replace('/administrator', '', Uri::base());
-
 			$this->app->setHeader(
 				'content-security-policy-report-only',
-				"default-src 'self'; report-uri " . $frontendUrl . "index.php?option=com_csp&task=report.log&client=" . $this->app->getName()
+				"default-src 'self'; report-uri " . Uri::root() . "index.php?option=com_csp&task=report.log&client=" . $this->app->getName()
 			);
 
 			return;


### PR DESCRIPTION
### Summary of Changes

Corrects reporting URL when Joomla is installed in a path containing `/administrator`.

### Testing Instructions

Install Joomla in  path containing `/administrator`. E.g. `localhost/administrator-site`.
Enable CSP reporting. 
Check the `report-uri` value of `content-security-policy-report-only` header.

### Actual result BEFORE applying this Pull Request

    report-uri http://localhost-site/index.php?option=com_csp&task=report.log&client=administrator

### Expected result AFTER applying this Pull Request

    report-uri http://localhost/administrator-site/index.php?option=com_csp&task=report.log&client=administrator

### Documentation Changes Required

No.