### PR TITLE
[4.0] Safari/Chrome Fix modal double scroll bar (Macintosh)

### DIFF
--- a/administrator/templates/atum/scss/blocks/_modals.scss
+++ b/administrator/templates/atum/scss/blocks/_modals.scss
@@ -100,7 +100,7 @@
 }
 
 .modal-body {
-  overflow-y: auto;
+  overflow-y: initial;
 }
 
 .modal-title {


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/29317

### Summary of Changes
fixing overflow


### Testing Instructions
See https://github.com/joomla/joomla-cms/issues/29317

Test on Macintosh with Safari, Chrome and for example Firefox to confirm nothing breaks.

Also test on Windows various browsers.

npm necessary to test
### Actual result BEFORE applying this Pull Request
![Screen Recording 2020-05-31 at 01 20 PM](https://user-images.githubusercontent.com/400092/83352149-881c9e00-a341-11ea-9e31-7c7c08045491.gif)


### Expected result AFTER applying this Pull Request
![scroolbar](https://user-images.githubusercontent.com/869724/89404968-1a169d80-d71b-11ea-8b08-31809bd63f87.gif)

