### PR TITLE
[4.0] Fix spacing between icon and text

### DIFF
--- a/administrator/modules/mod_login/tmpl/default.php
+++ b/administrator/modules/mod_login/tmpl/default.php
@@ -141,9 +141,14 @@ Text::script('MESSAGE');
 </form>
 <div class="text-center">
 	<div>
-		<a href="<?php echo Text::_('MOD_LOGIN_CREDENTIALS_LINK'); ?>" target="_blank" rel="noopener nofollow"
-			title="<?php echo Text::sprintf('JBROWSERTARGET_NEW_TITLE', Text::_('MOD_LOGIN_CREDENTIALS')); ?>">
-			<?php echo Text::_('MOD_LOGIN_CREDENTIALS'); ?>
-		</a>
+		<?php echo HTMLHelper::link(
+			Text::_('MOD_LOGIN_CREDENTIALS_LINK'),
+			Text::_('MOD_LOGIN_CREDENTIALS'),
+			[
+				'target' => '_blank',
+				'rel'    => 'noopener noreferrer',
+				'title'  => Text::sprintf('JBROWSERTARGET_NEW_TITLE', Text::_('MOD_LOGIN_CREDENTIALS'))
+			]
+		); ?>
 	</div>
 </div>

--- a/administrator/modules/mod_login/tmpl/default.php
+++ b/administrator/modules/mod_login/tmpl/default.php
@@ -146,7 +146,7 @@ Text::script('MESSAGE');
 			Text::_('MOD_LOGIN_CREDENTIALS'),
 			[
 				'target' => '_blank',
-				'rel'    => 'noopener noreferrer',
+				'rel'    => 'noopener nofollow',
 				'title'  => Text::sprintf('JBROWSERTARGET_NEW_TITLE', Text::_('MOD_LOGIN_CREDENTIALS'))
 			]
 		); ?>

--- a/administrator/modules/mod_loginsupport/tmpl/default.php
+++ b/administrator/modules/mod_loginsupport/tmpl/default.php
@@ -9,20 +9,45 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
 ?>
 <section class="loginsupport">
 	<p><?php echo Text::_('MOD_LOGINSUPPORT_HEADLINE'); ?></p>
 	<ul class="list-unstyled">
-		<li><a href="<?php echo $params->get('forum_url') ?>" target="_blank" rel="nofollow noopener">
-			<?php echo Text::_('MOD_LOGINSUPPORT_FORUM'); ?></a>
+		<li>
+			<?php echo HTMLHelper::link(
+				$params->get('forum_url'),
+				Text::_('MOD_LOGINSUPPORT_FORUM'),
+				[
+					'target' => '_blank',
+					'rel'    => 'nofollow noopener',
+					'title'  => Text::sprintf('JBROWSERTARGET_NEW_TITLE', Text::_('MOD_LOGINSUPPORT_FORUM'))
+				]
+			); ?>
 		</li>
-		<li><a href="<?php echo $params->get('documentation_url') ?>" target="_blank" rel="nofollow noopener">
-			<?php echo Text::_('MOD_LOGINSUPPORT_DOCUMENTATION'); ?></a>
+		<li>
+			<?php echo HTMLHelper::link(
+				$params->get('documentation_url'),
+				Text::_('MOD_LOGINSUPPORT_DOCUMENTATION'),
+				[
+					'target' => '_blank',
+					'rel'    => 'nofollow noopener',
+					'title'  => Text::sprintf('JBROWSERTARGET_NEW_TITLE', Text::_('MOD_LOGINSUPPORT_DOCUMENTATION'))
+				]
+			); ?>
 		</li>
-		<li><a href="<?php echo $params->get('news_url') ?>" target="_blank" rel="nofollow noopener">
-			<?php echo Text::_('MOD_LOGINSUPPORT_NEWS'); ?></a>
+		<li>
+			<?php echo HTMLHelper::link(
+				$params->get('news_url'),
+				Text::_('MOD_LOGINSUPPORT_NEWS'),
+				[
+					'target' => '_blank',
+					'rel'    => 'nofollow noopener',
+					'title'  => Text::sprintf('JBROWSERTARGET_NEW_TITLE', Text::_('MOD_LOGINSUPPORT_NEWS'))
+				]
+			); ?>
 		</li>
 	</ul>
 </section>


### PR DESCRIPTION
### Summary of Changes
Fix spacing with underline between icon and text.
Add tooltip under `Need Support?`

### Testing Instructions
Go to the administration backend
See `Need Support?` box and `Forgot your login details?` link

### Actual result BEFORE applying this Pull Request
![login-before](https://user-images.githubusercontent.com/368084/89434484-71574680-d6f8-11ea-9946-94a41552626f.png)




### Expected result AFTER applying this Pull Request
![login-after](https://user-images.githubusercontent.com/368084/89435120-47525400-d6f9-11ea-9c50-02629ed7cbc9.png)


