### PR TITLE
[4.0] Atum and Cassiopea Change alerts styling - space saving +

### DIFF
--- a/administrator/templates/atum/scss/_variables.scss
+++ b/administrator/templates/atum/scss/_variables.scss
@@ -165,8 +165,8 @@ $card-border-color:                transparent;
 
 // Alerts
 $state-success-text:               var(--alert-success);
-$state-success-bg:                 lighten($green-dark, 70%);
-$state-success-border:             lighten($green-dark, 30%);
+$state-success-bg:                 lighten($green-dark, 80%);
+$state-success-border:             $green-dark;
 
 $state-info-text:                  var(--white);
 $state-info-bg:                    var(--atum-bg-dark);

--- a/administrator/templates/atum/scss/blocks/_alerts.scss
+++ b/administrator/templates/atum/scss/blocks/_alerts.scss
@@ -38,7 +38,7 @@ fieldset .alert {
 }
 
 .alert-heading {
-  font-size: $font-size-lg;
+  font-size: $h4-font-size;
 }
 
 @keyframes fadeIn {
@@ -52,3 +52,4 @@ fieldset .alert {
     transform: translateY(0);
   }
 }
+

--- a/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-alert.scss
+++ b/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-alert.scss
@@ -18,9 +18,9 @@
 
   .alert-heading {
     display: flex;
+    flex-direction: column;
     padding: .8rem;
     color: rgba(255, 255, 255, .95);
-    flex-direction: column;
     justify-content: center;
     align-content: center;
     background: var(--alert-accent-color, transparent);

--- a/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-alert.scss
+++ b/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-alert.scss
@@ -5,8 +5,8 @@
 
 #system-message-container joomla-alert {
   position: relative;
-  width:100%;
   display: flex;
+  width:100%;
   min-width: 16rem;
   padding: 0;
   margin-bottom: 1rem;
@@ -19,11 +19,11 @@
   .alert-heading {
     display: flex;
     padding: .8rem;
-    color: rgba(255, 255, 255, 0.95);
-    background: var(--alert-accent-color, transparent);
+    color: rgba(255, 255, 255, .95);
+    flex-direction: column;
     justify-content: center;
     align-content: center;
-    flex-direction: column;
+    background: var(--alert-accent-color, transparent);
   }
 
   .alert-link {

--- a/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-alert.scss
+++ b/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-alert.scss
@@ -49,9 +49,9 @@
   .joomla-alert--close,
   .joomla-alert-button--close {
     position: absolute;
-    padding: .2rem .8rem;
     top: 0;
     right: 0;
+    padding: .2rem .8rem;
     font-size: 2rem;
     color: var(--alert-accent-color);
     background: none;

--- a/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-alert.scss
+++ b/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-alert.scss
@@ -66,9 +66,9 @@
     }
 
     [dir=rtl] & {
-      padding: .2rem .6rem;
       right: auto;
       left: 0;
+      padding: .2rem .6rem;
     }
   }
 

--- a/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-alert.scss
+++ b/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-alert.scss
@@ -5,8 +5,8 @@
 
 #system-message-container joomla-alert {
   position: relative;
-  width: 100%;
   display: flex;
+  width: 100%;
   min-width: 16rem;
   padding: 0;
   margin-bottom: 1rem;
@@ -18,12 +18,12 @@
 
   .alert-heading {
     display: flex;
-    padding: .8rem;
-    color: rgba(255, 255, 255, 0.95);
-    background: var(--alert-accent-color, transparent);
+    flex-direction: column;
     justify-content: center;
     align-content: center;
-    flex-direction: column;
+    padding: .8rem;
+    color: rgba(255, 255, 255, .95);
+    background: var(--alert-accent-color, transparent);
   }
 
   .alert-link {

--- a/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-alert.scss
+++ b/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-alert.scss
@@ -19,10 +19,10 @@
   .alert-heading {
     display: flex;
     flex-direction: column;
-    padding: .8rem;
-    color: rgba(255, 255, 255, .95);
     justify-content: center;
     align-content: center;
+    padding: .8rem;
+    color: rgba(255, 255, 255, .95);
     background: var(--alert-accent-color, transparent);
   }
 

--- a/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-alert.scss
+++ b/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-alert.scss
@@ -1,0 +1,84 @@
+@import "../../variables";
+@import "../../../../../../node_modules/joomla-ui-custom-elements/dist/css/joomla-alert";
+
+// The following is a restyle for the system alerts
+
+#system-message-container joomla-alert {
+  position: relative;
+  width:100%;
+  display: flex;
+  min-width: 16rem;
+  padding: 0;
+  margin-bottom: 1rem;
+  color: var(--atum-text-dark);
+  background-color: var(--white);
+  border: 1px solid var(--alert-accent-color, transparent);
+  border-radius: .25rem;
+  transition: opacity .15s linear;
+
+  .alert-heading {
+    display: flex;
+    padding: .8rem;
+    color: rgba(255, 255, 255, 0.95);
+    background: var(--alert-accent-color, transparent);
+    justify-content: center;
+    align-content: center;
+    flex-direction: column;
+  }
+
+  .alert-link {
+    color: var(--success, inherit);
+  }
+
+  &[type="success"] {
+    --alert-accent-color: var(--success);
+  }
+
+  &[type="info"] {
+    --alert-accent-color: var(--info);
+  }
+
+  &[type="warning"] {
+    --alert-accent-color: var(--warning);
+  }
+
+  &[type="danger"] {
+    --alert-accent-color: var(--danger);
+  }
+
+  .joomla-alert--close,
+  .joomla-alert-button--close {
+    position: absolute;
+    top: 0;
+    right: .3rem;
+    font-size: 2rem;
+    color: var(--alert-accent-color);
+    background: none;
+    border: 0;
+    opacity: 1;
+
+    &:hover,
+    &:focus {
+      text-decoration: none;
+      cursor: pointer;
+      opacity: .75;
+    }
+
+    [dir=rtl] & {
+      right: auto;
+      left: 0;
+    }
+  }
+
+  div {
+    font-size: 1rem;
+    .alert-message {
+      padding: .3rem 2rem .3rem .3rem;
+      margin: .5rem;
+
+      [dir=rtl] & {
+        padding: .3rem .3rem .3rem 2rem;
+      }
+    }
+  }
+}

--- a/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-alert.scss
+++ b/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-alert.scss
@@ -5,8 +5,8 @@
 
 #system-message-container joomla-alert {
   position: relative;
-  display: flex;
   width: 100%;
+  display: flex;
   min-width: 16rem;
   padding: 0;
   margin-bottom: 1rem;
@@ -18,12 +18,12 @@
 
   .alert-heading {
     display: flex;
-    flex-direction: column;
+    padding: .8rem;
+    color: rgba(255, 255, 255, 0.95);
+    background: var(--alert-accent-color, transparent);
     justify-content: center;
     align-content: center;
-    padding: .8rem;
-    color: rgba(255, 255, 255, .95);
-    background: var(--alert-accent-color, transparent);
+    flex-direction: column;
   }
 
   .alert-link {
@@ -49,8 +49,9 @@
   .joomla-alert--close,
   .joomla-alert-button--close {
     position: absolute;
+    padding: .2rem .8rem;
     top: 0;
-    right: .3rem;
+    right: 0;
     font-size: 2rem;
     color: var(--alert-accent-color);
     background: none;
@@ -65,6 +66,7 @@
     }
 
     [dir=rtl] & {
+      padding: .2rem .6rem;
       right: auto;
       left: 0;
     }

--- a/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-alert.scss
+++ b/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-alert.scss
@@ -6,7 +6,7 @@
 #system-message-container joomla-alert {
   position: relative;
   display: flex;
-  width:100%;
+  width: 100%;
   min-width: 16rem;
   padding: 0;
   margin-bottom: 1rem;

--- a/build/build-modules-js/compilecss.es6.js
+++ b/build/build-modules-js/compilecss.es6.js
@@ -46,6 +46,7 @@ module.exports.compile = (options, path) => {
           `${RootPath}/templates/cassiopeia/scss/template-rtl.scss`,
           `${RootPath}/templates/cassiopeia/scss/system/searchtools/searchtools.scss`,
           `${RootPath}/templates/cassiopeia/scss/vendor/choicesjs/choices.scss`,
+          `${RootPath}/templates/cassiopeia/scss/vendor/joomla-custom-elements/joomla-alert.scss`,
           `${RootPath}/administrator/templates/atum/scss/template.scss`,
           `${RootPath}/administrator/templates/atum/scss/template-rtl.scss`,
           `${RootPath}/administrator/templates/atum/scss/system/searchtools/searchtools.scss`,

--- a/build/build-modules-js/compilecss.es6.js
+++ b/build/build-modules-js/compilecss.es6.js
@@ -52,6 +52,7 @@ module.exports.compile = (options, path) => {
           `${RootPath}/administrator/templates/atum/scss/vendor/awesomplete/awesomplete.scss`,
           `${RootPath}/administrator/templates/atum/scss/vendor/choicesjs/choices.scss`,
           `${RootPath}/administrator/templates/atum/scss/vendor/minicolors/minicolors.scss`,
+          `${RootPath}/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-alert.scss`,
           `${RootPath}/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-tab.scss`,
           `${RootPath}/administrator/templates/atum/scss/vendor/fontawesome-free/fontawesome.scss`,
           `${RootPath}/installation/template/scss/template.scss`,

--- a/build/media_source/system/js/core.es6/message.es6
+++ b/build/media_source/system/js/core.es6/message.es6
@@ -75,7 +75,7 @@
 
       // Skip titles with untranslated strings
       if (typeof title !== 'undefined') {
-        titleWrapper = document.createElement('span');
+        titleWrapper = document.createElement('div');
         titleWrapper.className = 'alert-heading';
         titleWrapper.innerHTML = Joomla.Text._(type) ? Joomla.Text._(type) : type;
         messagesBox.appendChild(titleWrapper);
@@ -84,7 +84,7 @@
       // Add messages to the message box
       typeMessages.forEach((typeMessage) => {
         messageWrapper = document.createElement('div');
-        messageWrapper.innerHTML = typeMessage;
+        messageWrapper.innerHTML = `<div class="alert-message">${typeMessage}</div>`;
         messagesBox.appendChild(messageWrapper);
       });
 

--- a/installation/template/scss/template.scss
+++ b/installation/template/scss/template.scss
@@ -15,6 +15,7 @@ $fa-font-path: "../../../media/vendor/fontawesome-free/webfonts";
 @import "../../../administrator/templates/atum/scss/blocks/global";
 @import "../../../administrator/templates/atum/scss/blocks/header";
 @import "../../../administrator/templates/atum/scss/vendor/bootstrap/custom-forms";
+@import "../../../administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-alert";
 
 // Safari fix
 @import "../../../administrator/templates/atum/scss/vendor/bootstrap/reboot";
@@ -38,7 +39,6 @@ body {
     width: auto;
   }
 }
-
 
 .j-container {
   width: 100%;
@@ -95,7 +95,6 @@ body {
   }
 }
 
-
 .languageForm {
   padding: 0 0 30px;
 
@@ -104,41 +103,13 @@ body {
   }
 }
 
-.system-message .alert {
-  margin: 25px 50px;
+// Alerts
+#system-message-container joomla-alert {
+  margin-top: 25px;
 }
 
-.alert {
-  position: relative;
-  display: flex;
-  margin: 0 0 20px;
-  background: #fafafa;
-  border: 1px solid rgba(0, 0, 0, .1);
-  box-shadow: 0 0 10px rgba(0, 0, 0, .05);
-
-  p {
-    margin-bottom: 0;
-  }
-}
-
-.alert-icon {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 25%;
-  margin-bottom: 0;
-  font-size: 3rem;
-  opacity: .6;
-
-  .fas {
-    width: 100%;
-    text-align: center;
-  }
-}
-
-.alert-text {
-  width: 75%;
-  padding: 10px 20px;
+.alert-heading {
+  font-size: $h4-font-size;
 }
 
 .hidden,

--- a/layouts/joomla/system/message.php
+++ b/layouts/joomla/system/message.php
@@ -48,7 +48,7 @@ Factory::getDocument()->getWebAssetManager()
 						<div class="alert-heading"><?php echo Text::_($type); ?></div>
 						<div>
 							<?php foreach ($msgs as $msg) : ?>
-								<p><?php echo $msg; ?></p>
+								<div class="alert-message"><?php echo $msg; ?></div>
 							<?php endforeach; ?>
 						</div>
 					<?php endif; ?>

--- a/plugins/system/stats/layouts/message.php
+++ b/plugins/system/stats/layouts/message.php
@@ -26,18 +26,20 @@ extract($displayData);
 <joomla-alert type="info" dismiss="true" class="js-pstats-alert hidden" role="alertdialog">
 	<div class="alert-heading"><?php echo Text::_('PLG_SYSTEM_STATS_LABEL_MESSAGE_TITLE'); ?></div>
 	<div>
-		<p>
-			<?php echo Text::_('PLG_SYSTEM_STATS_MSG_JOOMLA_WANTS_TO_SEND_DATA'); ?>
-			<a href="#" class="js-pstats-btn-details alert-link"><?php echo Text::_('PLG_SYSTEM_STATS_MSG_WHAT_DATA_WILL_BE_SENT'); ?></a>
-		</p>
-		<?php
-			echo $plugin->render('stats', compact('statsData'));
-		?>
-		<p><?php echo Text::_('PLG_SYSTEM_STATS_MSG_ALLOW_SENDING_DATA'); ?></p>
-		<p class="actions">
-			<button type="button" class="btn btn-primary js-pstats-btn-allow-always"><?php echo Text::_('PLG_SYSTEM_STATS_BTN_SEND_ALWAYS'); ?></button>
-			<button type="button" class="btn btn-primary js-pstats-btn-allow-once"><?php echo Text::_('PLG_SYSTEM_STATS_BTN_SEND_NOW'); ?></button>
-			<button type="button" class="btn btn-primary js-pstats-btn-allow-never"><?php echo Text::_('PLG_SYSTEM_STATS_BTN_NEVER_SEND'); ?></button>
-		</p>
+		<div class="alert-message">
+			<p>
+				<?php echo Text::_('PLG_SYSTEM_STATS_MSG_JOOMLA_WANTS_TO_SEND_DATA'); ?>
+				<a href="#" class="js-pstats-btn-details alert-link"><?php echo Text::_('PLG_SYSTEM_STATS_MSG_WHAT_DATA_WILL_BE_SENT'); ?></a>
+			</p>
+			<?php
+				echo $plugin->render('stats', compact('statsData'));
+			?>
+			<p><?php echo Text::_('PLG_SYSTEM_STATS_MSG_ALLOW_SENDING_DATA'); ?></p>
+			<p class="actions">
+				<button type="button" class="btn btn-primary js-pstats-btn-allow-always"><?php echo Text::_('PLG_SYSTEM_STATS_BTN_SEND_ALWAYS'); ?></button>
+				<button type="button" class="btn btn-primary js-pstats-btn-allow-once"><?php echo Text::_('PLG_SYSTEM_STATS_BTN_SEND_NOW'); ?></button>
+				<button type="button" class="btn btn-primary js-pstats-btn-allow-never"><?php echo Text::_('PLG_SYSTEM_STATS_BTN_NEVER_SEND'); ?></button>
+			</p>
+		</div>
 	</div>
 </joomla-alert>

--- a/templates/cassiopeia/scss/blocks/_alerts.scss
+++ b/templates/cassiopeia/scss/blocks/_alerts.scss
@@ -8,6 +8,10 @@
 
 }
 
+.alert-heading {
+  font-size: $h4-font-size;
+ }
+
 @keyframes fadeIn {
 
   from {

--- a/templates/cassiopeia/scss/blocks/_alerts.scss
+++ b/templates/cassiopeia/scss/blocks/_alerts.scss
@@ -10,7 +10,7 @@
 
 .alert-heading {
   font-size: $h4-font-size;
- }
+}
 
 @keyframes fadeIn {
 

--- a/templates/cassiopeia/scss/template.scss
+++ b/templates/cassiopeia/scss/template.scss
@@ -20,9 +20,6 @@
 // B/C for Icomoon
 @import "../../../build/media_source/system/scss/icomoon";
 
-// Alert
-@import "../../../build/media_source/system/scss/jalert";
-
 // jQuery Minicolors
 @import "../../../build/media_source/system/scss/jquery-minicolors";
 

--- a/templates/cassiopeia/scss/vendor/joomla-custom-elements/joomla-alert.scss
+++ b/templates/cassiopeia/scss/vendor/joomla-custom-elements/joomla-alert.scss
@@ -18,9 +18,9 @@
 
   .alert-heading {
     display: flex;
+    flex-direction: column;
     padding: .8rem;
     color: rgba(255, 255, 255, .95);
-    flex-direction: column;
     justify-content: center;
     align-content: center;
     background: var(--alert-accent-color, transparent);

--- a/templates/cassiopeia/scss/vendor/joomla-custom-elements/joomla-alert.scss
+++ b/templates/cassiopeia/scss/vendor/joomla-custom-elements/joomla-alert.scss
@@ -5,8 +5,8 @@
 
 #system-message-container joomla-alert {
   position: relative;
-  width:100%;
   display: flex;
+  width:100%;
   min-width: 16rem;
   padding: 0;
   margin-bottom: 1rem;
@@ -19,11 +19,11 @@
   .alert-heading {
     display: flex;
     padding: .8rem;
-    color: rgba(255, 255, 255, 0.95);
-    background: var(--alert-accent-color, transparent);
+    color: rgba(255, 255, 255, .95);
+    flex-direction: column;
     justify-content: center;
     align-content: center;
-    flex-direction: column;
+    background: var(--alert-accent-color, transparent);
   }
 
   .alert-link {

--- a/templates/cassiopeia/scss/vendor/joomla-custom-elements/joomla-alert.scss
+++ b/templates/cassiopeia/scss/vendor/joomla-custom-elements/joomla-alert.scss
@@ -1,12 +1,12 @@
 @import "../../variables";
-@import "../../../../../node_modules/joomla-ui-custom-elements/dist/css/joomla-alert";
+@import "../../../../../../node_modules/joomla-ui-custom-elements/dist/css/joomla-alert";
 
 // The following is a restyle for the system alerts
 
 #system-message-container joomla-alert {
   position: relative;
-  display: flex;
   width: 100%;
+  display: flex;
   min-width: 16rem;
   padding: 0;
   margin-bottom: 1rem;
@@ -18,12 +18,12 @@
 
   .alert-heading {
     display: flex;
-    flex-direction: column;
+    padding: .8rem;
+    color: rgba(255, 255, 255, 0.95);
+    background: var(--alert-accent-color, transparent);
     justify-content: center;
     align-content: center;
-    padding: .8rem;
-    color: rgba(255, 255, 255, .95);
-    background: var(--alert-accent-color, transparent);
+    flex-direction: column;
   }
 
   .alert-link {
@@ -49,8 +49,9 @@
   .joomla-alert--close,
   .joomla-alert-button--close {
     position: absolute;
+    padding: .2rem .8rem;
     top: 0;
-    right: .3rem;
+    right: 0;
     font-size: 2rem;
     color: var(--alert-accent-color);
     background: none;
@@ -65,6 +66,7 @@
     }
 
     [dir=rtl] & {
+      padding: .2rem .6rem;
       right: auto;
       left: 0;
     }

--- a/templates/cassiopeia/scss/vendor/joomla-custom-elements/joomla-alert.scss
+++ b/templates/cassiopeia/scss/vendor/joomla-custom-elements/joomla-alert.scss
@@ -1,12 +1,12 @@
 @import "../../variables";
-@import "../../../../../../node_modules/joomla-ui-custom-elements/dist/css/joomla-alert";
+@import "../../../../../node_modules/joomla-ui-custom-elements/dist/css/joomla-alert";
 
 // The following is a restyle for the system alerts
 
 #system-message-container joomla-alert {
   position: relative;
-  width: 100%;
   display: flex;
+  width: 100%;
   min-width: 16rem;
   padding: 0;
   margin-bottom: 1rem;
@@ -18,12 +18,12 @@
 
   .alert-heading {
     display: flex;
-    padding: .8rem;
-    color: rgba(255, 255, 255, 0.95);
-    background: var(--alert-accent-color, transparent);
+    flex-direction: column;
     justify-content: center;
     align-content: center;
-    flex-direction: column;
+    padding: .8rem;
+    color: rgba(255, 255, 255, .95);
+    background: var(--alert-accent-color, transparent);
   }
 
   .alert-link {

--- a/templates/cassiopeia/scss/vendor/joomla-custom-elements/joomla-alert.scss
+++ b/templates/cassiopeia/scss/vendor/joomla-custom-elements/joomla-alert.scss
@@ -49,9 +49,9 @@
   .joomla-alert--close,
   .joomla-alert-button--close {
     position: absolute;
-    padding: .2rem .8rem;
     top: 0;
     right: 0;
+    padding: .2rem .8rem;
     font-size: 2rem;
     color: var(--alert-accent-color);
     background: none;

--- a/templates/cassiopeia/scss/vendor/joomla-custom-elements/joomla-alert.scss
+++ b/templates/cassiopeia/scss/vendor/joomla-custom-elements/joomla-alert.scss
@@ -66,9 +66,9 @@
     }
 
     [dir=rtl] & {
-      padding: .2rem .6rem;
       right: auto;
       left: 0;
+      padding: .2rem .6rem;
     }
   }
 

--- a/templates/cassiopeia/scss/vendor/joomla-custom-elements/joomla-alert.scss
+++ b/templates/cassiopeia/scss/vendor/joomla-custom-elements/joomla-alert.scss
@@ -19,10 +19,10 @@
   .alert-heading {
     display: flex;
     flex-direction: column;
-    padding: .8rem;
-    color: rgba(255, 255, 255, .95);
     justify-content: center;
     align-content: center;
+    padding: .8rem;
+    color: rgba(255, 255, 255, .95);
     background: var(--alert-accent-color, transparent);
   }
 

--- a/templates/cassiopeia/scss/vendor/joomla-custom-elements/joomla-alert.scss
+++ b/templates/cassiopeia/scss/vendor/joomla-custom-elements/joomla-alert.scss
@@ -6,7 +6,7 @@
 #system-message-container joomla-alert {
   position: relative;
   display: flex;
-  width:100%;
+  width: 100%;
   min-width: 16rem;
   padding: 0;
   margin-bottom: 1rem;

--- a/templates/cassiopeia/scss/vendor/joomla-custom-elements/joomla-alert.scss
+++ b/templates/cassiopeia/scss/vendor/joomla-custom-elements/joomla-alert.scss
@@ -1,0 +1,84 @@
+@import "../../variables";
+@import "../../../../../node_modules/joomla-ui-custom-elements/dist/css/joomla-alert";
+
+// The following is a restyle for the system alerts
+
+#system-message-container joomla-alert {
+  position: relative;
+  width:100%;
+  display: flex;
+  min-width: 16rem;
+  padding: 0;
+  margin-bottom: 1rem;
+  color: var(--atum-text-dark);
+  background-color: var(--white);
+  border: 1px solid var(--alert-accent-color, transparent);
+  border-radius: .25rem;
+  transition: opacity .15s linear;
+
+  .alert-heading {
+    display: flex;
+    padding: .8rem;
+    color: rgba(255, 255, 255, 0.95);
+    background: var(--alert-accent-color, transparent);
+    justify-content: center;
+    align-content: center;
+    flex-direction: column;
+  }
+
+  .alert-link {
+    color: var(--success, inherit);
+  }
+
+  &[type="success"] {
+    --alert-accent-color: var(--success);
+  }
+
+  &[type="info"] {
+    --alert-accent-color: var(--info);
+  }
+
+  &[type="warning"] {
+    --alert-accent-color: var(--warning);
+  }
+
+  &[type="danger"] {
+    --alert-accent-color: var(--danger);
+  }
+
+  .joomla-alert--close,
+  .joomla-alert-button--close {
+    position: absolute;
+    top: 0;
+    right: .3rem;
+    font-size: 2rem;
+    color: var(--alert-accent-color);
+    background: none;
+    border: 0;
+    opacity: 1;
+
+    &:hover,
+    &:focus {
+      text-decoration: none;
+      cursor: pointer;
+      opacity: .75;
+    }
+
+    [dir=rtl] & {
+      right: auto;
+      left: 0;
+    }
+  }
+
+  div {
+    font-size: 1rem;
+    .alert-message {
+      padding: .3rem 2rem .3rem .3rem;
+      margin: .5rem;
+
+      [dir=rtl] & {
+        padding: .3rem .3rem .3rem 2rem;
+      }
+    }
+  }
+}


### PR DESCRIPTION
Replaces https://github.com/joomla/joomla-cms/pull/28974
Thanks @coolcat-creations for the original PR, here improved
Thanks @Fedik for the suggestions

### Summary of Changes

Changed the Header of the message to be next to the message to save space
Decreased paddings
Changed colors

Normalise system.message layout and message.es6 by using div instead of span and p tags


### Testing Instructions
Edit or create an article. Let title empty and save.

Install a clean Joomla after patching to test installation errors, see https://github.com/joomla/joomla-cms/pull/30294#issuecomment-670843570

Patch. Run npm.

Test various messages including in the login page.
### Actual result BEFORE applying this Pull Request

<img width="1575" alt="Screen Shot 2020-08-05 at 18 33 38" src="https://user-images.githubusercontent.com/869724/89440151-8610fa00-d74b-11ea-8b4b-c1ca4085ac04.png">


### Expected result AFTER applying this Pull Request
<img width="1563" alt="Screen Shot 2020-08-05 at 18 35 57" src="https://user-images.githubusercontent.com/869724/89440201-988b3380-d74b-11ea-9a44-e7aa956f563d.png">

