### PR TITLE
[4.0] When there is no filter form the admin list view should not crash

### DIFF
--- a/libraries/src/MVC/Model/ListModel.php
+++ b/libraries/src/MVC/Model/ListModel.php
@@ -349,8 +349,6 @@ class ListModel extends BaseDatabaseModel implements ListModelInterface
 	 */
 	public function getFilterForm($data = array(), $loadData = true)
 	{
-		$form = null;
-
 		// Try to locate the filter form automatically. Example: ContentModelArticles => "filter_articles"
 		if (empty($this->filterFormName))
 		{
@@ -362,13 +360,21 @@ class ListModel extends BaseDatabaseModel implements ListModelInterface
 			}
 		}
 
-		if (!empty($this->filterFormName))
+		if (empty($this->filterFormName))
 		{
-			// Get the form.
-			$form = $this->loadForm($this->context . '.filter', $this->filterFormName, array('control' => '', 'load_data' => $loadData));
+			return null;
 		}
 
-		return $form;
+		try
+		{
+			// Get the form.
+			return $this->loadForm($this->context . '.filter', $this->filterFormName, array('control' => '', 'load_data' => $loadData));
+		}
+		catch (\RuntimeException $e)
+		{
+		}
+
+		return null;
 	}
 
 	/**


### PR DESCRIPTION
## Summary of Changes
When an extension has no filter form file then the list view throws an Exception, which should not be the case as the form name is guessed only. This pr catches that exception and executes normally. Additionally I made the code a bit easier to read :-)

This issue can't be reproduced with core as I have it on one of my extensions. So merge by review @wilsonge.

### Testing Instructions
None with core possible without hacking to man files.

### Actual result BEFORE applying this Pull Request
No error is thrown when no filter form file is available.

### Expected result AFTER applying this Pull Request
Page loads.