### PR TITLE
[4.0] Remove quoting from ordering columns

### DIFF
--- a/administrator/components/com_banners/src/Model/BannersModel.php
+++ b/administrator/components/com_banners/src/Model/BannersModel.php
@@ -227,7 +227,7 @@ class BannersModel extends ListModel
 				$orderCol = 'cl.name';
 			}
 
-			$ordering = $db->quoteName($db->escape($orderCol)) . ' ' . $db->escape($orderDirn);
+			$ordering = $db->escape($orderCol) . ' ' . $db->escape($orderDirn);
 		}
 
 		$query->order($ordering);

--- a/administrator/components/com_content/src/Model/ArticlesModel.php
+++ b/administrator/components/com_content/src/Model/ArticlesModel.php
@@ -566,7 +566,7 @@ class ArticlesModel extends ListModel
 		}
 		else
 		{
-			$ordering = $db->quoteName($db->escape($orderCol)) . ' ' . $db->escape($orderDirn);
+			$ordering = $db->escape($orderCol) . ' ' . $db->escape($orderDirn);
 		}
 
 		$query->order($ordering);

--- a/administrator/components/com_newsfeeds/src/Model/NewsfeedsModel.php
+++ b/administrator/components/com_newsfeeds/src/Model/NewsfeedsModel.php
@@ -332,7 +332,7 @@ class NewsfeedsModel extends ListModel
 		}
 		else
 		{
-			$ordering = $db->quoteName($db->escape($orderCol)) . ' ' . $db->escape($orderDirn);
+			$ordering = $db->escape($orderCol) . ' ' . $db->escape($orderDirn);
 		}
 
 		$query->order($ordering);

--- a/administrator/components/com_workflow/src/Model/TransitionsModel.php
+++ b/administrator/components/com_workflow/src/Model/TransitionsModel.php
@@ -200,7 +200,7 @@ class TransitionsModel extends ListModel
 		$orderCol	= $this->state->get('list.ordering', 't.id');
 		$orderDirn 	= strtoupper($this->state->get('list.direction', 'ASC'));
 
-		$query->order($db->quoteName($db->escape($orderCol)) . ' ' . $db->escape($orderDirn === 'DESC' ? 'DESC' : 'ASC'));
+		$query->order($db->escape($orderCol) . ' ' . $db->escape($orderDirn === 'DESC' ? 'DESC' : 'ASC'));
 
 		return $query;
 	}

--- a/administrator/components/com_workflow/src/Model/TransitionsModel.php
+++ b/administrator/components/com_workflow/src/Model/TransitionsModel.php
@@ -200,7 +200,7 @@ class TransitionsModel extends ListModel
 		$orderCol	= $this->state->get('list.ordering', 't.id');
 		$orderDirn 	= strtoupper($this->state->get('list.direction', 'ASC'));
 
-		$query->order($db->escape($orderCol) . ' ' . $db->escape($orderDirn === 'DESC' ? 'DESC' : 'ASC'));
+		$query->order($db->escape($orderCol) . ' ' . ($orderDirn === 'DESC' ? 'DESC' : 'ASC'));
 
 		return $query;
 	}

--- a/administrator/components/com_workflow/src/Model/WorkflowsModel.php
+++ b/administrator/components/com_workflow/src/Model/WorkflowsModel.php
@@ -274,7 +274,7 @@ class WorkflowsModel extends ListModel
 		$orderCol  = $this->state->get('list.ordering', 'w.ordering');
 		$orderDirn = strtoupper($this->state->get('list.direction', 'ASC'));
 
-		$query->order($db->quoteName($db->escape($orderCol)) . ' ' . $db->escape($orderDirn === 'DESC' ? 'DESC' : 'ASC'));
+		$query->order($db->escape($orderCol) . ' ' . $db->escape($orderDirn === 'DESC' ? 'DESC' : 'ASC'));
 
 		return $query;
 	}

--- a/administrator/components/com_workflow/src/Model/WorkflowsModel.php
+++ b/administrator/components/com_workflow/src/Model/WorkflowsModel.php
@@ -274,7 +274,7 @@ class WorkflowsModel extends ListModel
 		$orderCol  = $this->state->get('list.ordering', 'w.ordering');
 		$orderDirn = strtoupper($this->state->get('list.direction', 'ASC'));
 
-		$query->order($db->escape($orderCol) . ' ' . $db->escape($orderDirn === 'DESC' ? 'DESC' : 'ASC'));
+		$query->order($db->escape($orderCol) . ' ' . ($orderDirn === 'DESC' ? 'DESC' : 'ASC'));
 
 		return $query;
 	}

--- a/administrator/modules/mod_latest/src/Helper/LatestHelper.php
+++ b/administrator/modules/mod_latest/src/Helper/LatestHelper.php
@@ -46,13 +46,13 @@ abstract class LatestHelper
 		switch ($params->get('ordering', 'c_dsc'))
 		{
 			case 'm_dsc':
-				$model->setState('list.ordering', 'modified DESC, created');
+				$model->setState('list.ordering', 'a.modified DESC, a.created');
 				$model->setState('list.direction', 'DESC');
 				break;
 
 			case 'c_dsc':
 			default:
-				$model->setState('list.ordering', 'created');
+				$model->setState('list.ordering', 'a.created');
 				$model->setState('list.direction', 'DESC');
 				break;
 		}


### PR DESCRIPTION
Fixes https://github.com/joomla/joomla-cms/issues/30309.

### Summary of Changes

Removes quoting from ordering columns since there could be multiple columns.
Remove unneeded escaped used on hardcoded values.
Fixes ambiguous column names.

### Testing Instructions

Create `Articles - Latest` in administrator.
Set `Order` to `Recently Modified First`.
View the module in control panel.

### Actual result BEFORE applying this Pull Request

Error:

> Unknown column 'modified DESC, created' in 'order clause' 

### Expected result AFTER applying this Pull Request

Works.

### Documentation Changes Required

No.