### PR TITLE
[4.0] [a11y] Remove uppercase text transformation from menus in the header area of the Cassiopeia template

### DIFF
--- a/templates/cassiopeia/scss/blocks/_header.scss
+++ b/templates/cassiopeia/scss/blocks/_header.scss
@@ -76,7 +76,6 @@
     position: relative;
     display: inline-block;
     margin-right: 20px;
-    text-transform: uppercase;
     letter-spacing: 1.75px;
 
     &:last-child {


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This Pull Request (PR) removes `text-transform: uppercase;` from (S)CSS for com_menu items (`.mod-menu li`) in the header section of the Cassiopeia template (`.container-header`), i.e. from menus shown at the top on module positions "Menu" or "Search".

Having all menu items in uppercase letters makes the menu hard to read, e.g. for dyslexic people. As I've just learned it's an accessibility issue.

### Testing Instructions

1. Create a menu with more than 1 item on the first level and at least one item having sub-items on the 2nd level.

2. Create a frontend module for that menu on one of the module positions on module positions "Menu" or "Search" and set `Sub-menu Items` to `Show` in the module settings. 

3. Go to the front page and check the menu link texts.

Result: They are all in uppercase on all levels of the menu.

4. Apply the patch of this PR.

5. Run `npm run build:css` if you have npm, or update to the update package built for this PR if you know how to do that.

6. Go again to the front page or if still there, do a forced reload so no cached css is used, and check again the menu link texts.

Result: They are on all menu levels as defined for that menu item, i.e. not capitalized anymore.

### Actual result BEFORE applying this Pull Request

On all levels of menus shown in the header section, i.e. module positions "Menu" or "Search", the link texts are transformed into uppercase letters:

![j4-menu-capitalization_1](https://user-images.githubusercontent.com/7413183/89711789-bf847800-d98c-11ea-8a7c-8d7cc123fed4.png)

### Expected result AFTER applying this Pull Request

On all levels of menus shown in the header section, i.e. module positions "Menu" or "Search", the link texts are **not** transformed into uppercase letters:

![j4-menu-capitalization_2](https://user-images.githubusercontent.com/7413183/89712053-a41a6c80-d98e-11ea-9fab-6b5ad49c130d.png)

Note: The ugly display of menus with more than one level is not subject of this PR. We should have some nice accessible menu with dropdowns.

### Documentation Changes Required

None.