### PR TITLE
[4.0] Fix for Synchronization of module filter when changing admin and site

### DIFF
--- a/administrator/components/com_modules/src/Model/ModulesModel.php
+++ b/administrator/components/com_modules/src/Model/ModulesModel.php
@@ -87,12 +87,17 @@ class ModulesModel extends ListModel
 			$this->context .= '.' . $layout;
 		}
 
-		// Load the filter state.
-		$this->setState('filter.search', $this->getUserStateFromRequest($this->context . '.filter.search', 'filter_search', '', 'string'));
-		$this->setState('filter.position', $this->getUserStateFromRequest($this->context . '.filter.position', 'filter_position', '', 'string'));
-		$this->setState('filter.module', $this->getUserStateFromRequest($this->context . '.filter.module', 'filter_module', '', 'string'));
-		$this->setState('filter.menuitem', $this->getUserStateFromRequest($this->context . '.filter.menuitem', 'filter_menuitem', '', 'cmd'));
-		$this->setState('filter.access', $this->getUserStateFromRequest($this->context . '.filter.access', 'filter_access', '', 'cmd'));
+		$clientNotChanged = $app->input->get('client_not_changed', "0", 'cmd');
+
+		if ($clientNotChanged === "1")
+		{
+			// Load the filter state.
+			$this->setState('filter.search', $this->getUserStateFromRequest($this->context . '.filter.search', 'filter_search', '', 'string'));
+			$this->setState('filter.position', $this->getUserStateFromRequest($this->context . '.filter.position', 'filter_position', '', 'string'));
+			$this->setState('filter.module', $this->getUserStateFromRequest($this->context . '.filter.module', 'filter_module', '', 'string'));
+			$this->setState('filter.menuitem', $this->getUserStateFromRequest($this->context . '.filter.menuitem', 'filter_menuitem', '', 'cmd'));
+			$this->setState('filter.access', $this->getUserStateFromRequest($this->context . '.filter.access', 'filter_access', '', 'cmd'));
+		}
 
 		// If in modal layout on the frontend, state and language are always forced.
 		if ($app->isClient('site') && $layout === 'modal')
@@ -131,7 +136,10 @@ class ModulesModel extends ListModel
 		$this->setState('params', $params);
 
 		// List state information.
-		parent::populateState($ordering, $direction);
+		if ($clientNotChanged === "1")
+		{
+			parent::populateState($ordering, $direction);
+		}
 	}
 
 	/**

--- a/administrator/components/com_modules/src/Model/ModulesModel.php
+++ b/administrator/components/com_modules/src/Model/ModulesModel.php
@@ -89,7 +89,7 @@ class ModulesModel extends ListModel
 
 		$clientNotChanged = $app->input->get('client_not_changed', '0', 'cmd');
 
-		if ($clientNotChanged === "1")
+		if ($clientNotChanged === '1')
 		{
 			// Load the filter state.
 			$this->setState('filter.search', $this->getUserStateFromRequest($this->context . '.filter.search', 'filter_search', '', 'string'));

--- a/administrator/components/com_modules/src/Model/ModulesModel.php
+++ b/administrator/components/com_modules/src/Model/ModulesModel.php
@@ -87,9 +87,9 @@ class ModulesModel extends ListModel
 			$this->context .= '.' . $layout;
 		}
 
-		$clientNotChanged = $app->input->get('client_not_changed', '0', 'cmd');
+		$clientNotChanged = (int) $app->input->get('client_not_changed', 0, 'int');
 
-		if ($clientNotChanged === '1')
+		if ($clientNotChanged === 1)
 		{
 			// Load the filter state.
 			$this->setState('filter.search', $this->getUserStateFromRequest($this->context . '.filter.search', 'filter_search', '', 'string'));
@@ -136,7 +136,7 @@ class ModulesModel extends ListModel
 		$this->setState('params', $params);
 
 		// List state information.
-		if ($clientNotChanged === '1')
+		if ($clientNotChanged === 1)
 		{
 			parent::populateState($ordering, $direction);
 		}

--- a/administrator/components/com_modules/src/Model/ModulesModel.php
+++ b/administrator/components/com_modules/src/Model/ModulesModel.php
@@ -87,7 +87,7 @@ class ModulesModel extends ListModel
 			$this->context .= '.' . $layout;
 		}
 
-		$clientNotChanged = $app->input->get('client_not_changed', "0", 'cmd');
+		$clientNotChanged = $app->input->get('client_not_changed', '0', 'cmd');
 
 		if ($clientNotChanged === "1")
 		{

--- a/administrator/components/com_modules/src/Model/ModulesModel.php
+++ b/administrator/components/com_modules/src/Model/ModulesModel.php
@@ -136,7 +136,7 @@ class ModulesModel extends ListModel
 		$this->setState('params', $params);
 
 		// List state information.
-		if ($clientNotChanged === "1")
+		if ($clientNotChanged === '1')
 		{
 			parent::populateState($ordering, $direction);
 		}

--- a/administrator/components/com_modules/tmpl/modules/default.php
+++ b/administrator/components/com_modules/tmpl/modules/default.php
@@ -32,7 +32,7 @@ if ($saveOrder && !empty($this->items))
 	HTMLHelper::_('draggablelist.draggable');
 }
 ?>
-<form action="<?php echo Route::_('index.php?option=com_modules&view=modules&client_id=' . $clientId); ?>" method="post" name="adminForm" id="adminForm">
+<form action="<?php echo Route::_('index.php?option=com_modules&view=modules&client_id=' . $clientId . '&client_not_changed=1'); ?>" method="post" name="adminForm" id="adminForm">
 	<div id="j-main-container" class="j-main-container">
 		<?php echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
 		<?php if ($this->total > 0) : ?>


### PR DESCRIPTION
Pull Request for Issue # https://github.com/joomla/joomla-cms/issues/30302.

### Summary of Changes
Add a GET-Variable for determining if client has changed. 
If the filters are used, the form is submitted and the GET-variable is set. If the client changes via the menu or the Select, it is only a redirected.

### Testing Instructions
See https://github.com/joomla/joomla-cms/issues/30302.

### Actual result BEFORE applying this Pull Request
See https://github.com/joomla/joomla-cms/issues/30302.

### Expected result AFTER applying this Pull Request
Filters are completely in default state (not only in view) if client changed.

### Documentation Changes Required

No