### PR TITLE
[4.0] Fix broken installation with SQL error on PostgreSQL databases

### DIFF
--- a/installation/sql/postgresql/base.sql
+++ b/installation/sql/postgresql/base.sql
@@ -798,8 +798,8 @@ CREATE TABLE IF NOT EXISTS "#__template_styles" (
   "client_id" smallint DEFAULT 0 NOT NULL,
   "home" varchar(7) DEFAULT '0' NOT NULL,
   "title" varchar(255) DEFAULT '' NOT NULL,
-  `inheritable` smallint DEFAULT 0 NOT NULL,
-  `parent` varchar(50) DEFAULT '',
+  "inheritable" smallint DEFAULT 0 NOT NULL,
+  "parent" varchar(50) DEFAULT '',
   "params" text NOT NULL,
   PRIMARY KEY ("id")
 );


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Since the merge of PR #30192 , the installation on PostgreSQL databases is broken.

You can see that by the `system-tests-postgres` constantly failing on the 4.0-dev branch.

### Testing Instructions

Code review and check that `system-tests-postgres` succeeds in Drone, or make a new installation using a PostgreSQL database.

### Actual result BEFORE applying this Pull Request

Installation fails with SQL error when using a PostgreSQL database.

### Expected result AFTER applying this Pull Request

Installation succeeds when using a PostgreSQL database.

### Documentation Changes Required

None.