### PR TITLE
[4.0] Fix broken update with SQL error on PostgreSQL databases

### DIFF
--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2020-06-25.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2020-06-25.sql
@@ -1,2 +1,2 @@
 ALTER TABLE "#__template_styles" ADD COLUMN "inheritable" smallint NOT NULL DEFAULT 0;
-ALTER TABLE "#__template_styles" ADD COLUMN "parent" varchar(50) DEFAULT "";
+ALTER TABLE "#__template_styles" ADD COLUMN "parent" varchar(50) DEFAULT '';


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Since the merge of PR #30192 , updating the CMS from 3.10 to 4 on PostgreSQL databases is broken.

### Testing Instructions

Code review, or check that updating a 3.10 to the J4 update package which has been built for this PR here works without SQL error.

The issue can't be really reproduced at the moment because nightly builds have stopped on August 5, but the erroneout PR has been merged later. 

### Actual result BEFORE applying this Pull Request

Update fails with SQL error with a PotsgreSQL database.

### Expected result AFTER applying this Pull Request

Update succeeds with a PotsgreSQL database.

### Documentation Changes Required

None.