### PR TITLE
[3.10] Backport database changes from PR #30192 to fix broken updates from 3.10 to 4

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/3.10.0-2020-08-10.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.10.0-2020-08-10.sql
@@ -1,2 +1,6 @@
+--
+-- These database columns are not used in Joomla 3.10 but will be used in Joomla 4.
+-- They are added to 3.10 because otherwise the update to 4 will fail.
+--
 ALTER TABLE `#__template_styles` ADD COLUMN `inheritable` tinyint(1) NOT NULL DEFAULT 0;
 ALTER TABLE `#__template_styles` ADD COLUMN `parent` varchar(50) DEFAULT '';

--- a/administrator/components/com_admin/sql/updates/mysql/3.10.0-2020-08-10.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.10.0-2020-08-10.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `#__template_styles` ADD COLUMN `inheritable` tinyint(1) NOT NULL DEFAULT 0;
+ALTER TABLE `#__template_styles` ADD COLUMN `parent` varchar(50) DEFAULT '';

--- a/administrator/components/com_admin/sql/updates/postgresql/3.10.0-2020-08-10.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.10.0-2020-08-10.sql
@@ -1,2 +1,6 @@
+--
+-- These database columns are not used in Joomla 3.10 but will be used in Joomla 4.
+-- They are added to 3.10 because otherwise the update to 4 will fail.
+--
 ALTER TABLE "#__template_styles" ADD COLUMN "inheritable" smallint NOT NULL DEFAULT 0;
 ALTER TABLE "#__template_styles" ADD COLUMN "parent" character varying(50) DEFAULT '';

--- a/administrator/components/com_admin/sql/updates/postgresql/3.10.0-2020-08-10.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.10.0-2020-08-10.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "#__template_styles" ADD COLUMN "inheritable" smallint NOT NULL DEFAULT 0;
+ALTER TABLE "#__template_styles" ADD COLUMN "parent" character varying(50) DEFAULT '';

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -1833,6 +1833,8 @@ CREATE TABLE IF NOT EXISTS `#__template_styles` (
   `client_id` tinyint(1) unsigned NOT NULL DEFAULT 0,
   `home` char(7) NOT NULL DEFAULT '0',
   `title` varchar(255) NOT NULL DEFAULT '',
+  `inheritable` tinyint(1) NOT NULL DEFAULT 0,
+  `parent` varchar(50) DEFAULT '',
   `params` text NOT NULL,
   PRIMARY KEY (`id`),
   KEY `idx_template` (`template`),

--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -1803,6 +1803,8 @@ CREATE TABLE "#__template_styles" (
   "client_id" smallint DEFAULT 0 NOT NULL,
   "home" varchar(7) DEFAULT '0' NOT NULL,
   "title" varchar(255) DEFAULT '' NOT NULL,
+  "inheritable" smallint DEFAULT 0 NOT NULL,
+  "parent" varchar(50) DEFAULT '',
   "params" text NOT NULL,
   PRIMARY KEY ("id")
 );


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This fixes update from 3.10 to 4 failing with SQL error due to not existing database columns by creating these columns already in 3.10.

It seems there is not really a way to fix it in J4, because first the PHP is updated and then the database, and the getTemplate call in the AdminApplication uses the new columns added by PR #30192 .

### Testing Instructions

This PR should be tested with both kinds of databases, MySQL (or MariaDB) and PostgreSQL. If you have only one of these types, report back with your test result what kind of database you have used.

1. Update a clean 3.10-dev or latest 3.10 nightly to Joomla 4, using a Joomla 4 update package which already contains the changes from PRs #30192 , #30327 and #30330 .
Because there is no nightly update package yet which contains these changes, you can use following custom update URL or zip package, depending on which method you prefer, Live Update or Upload & Update:
- Custom URL [https://test5.richard-fath.de/pr_list_pr-30330.xml](https://test5.richard-fath.de/pr_list_pr-30330.xml)
- Update package https://test5.richard-fath.de/Joomla_4.0.0-beta4-dev+pr.30330-Development-Update_Package.zip 

Result: The update fails with an SQL error, see section "Actual result BEFORE applying this Pull Request" below.

2. Start again with a clean 3.10-dev or latest 3.10 nightly.

3. Run the SQL statements in the update SQL script added by this PR and suitable for your database type, replacing the `#__` by your database prefix.

4. Do again an update with the custom update URL or zip package mentioned in step 1.

Result: The update suceeds when starting from a new installation of J 3.10 which has been updated before so that it contains the patch of this PR.

5. Start again with a clean 3.10-dev or latest 3.10 nightly.

6. Apply the patch of this PR.

7. If you have already made an installation, delete configuration.php.

8. Make a new installation.

9. Do again an update with the custom update URL or zip package mentioned in step 1.

Result: The update suceeds when starting from a new installation of J 3.10 which already included the patch of this PR.

### Actual result BEFORE applying this Pull Request

Update to J4 fails:

![j4-update-sql-error](https://user-images.githubusercontent.com/7413183/89774433-24afa900-db06-11ea-9477-4a00ef8db8f1.png)

The screnshot has been taken when testing with PostgreSQL. With MySQL or MariaDB it might look different but have the same result.

### Expected result AFTER applying this Pull Request

Update to J4 succeeds.

### Documentation Changes Required

None.

