### PR TITLE
[4.0]  Workflow in Categories should not display if Worfklow is No

### DIFF
--- a/administrator/components/com_categories/tmpl/category/edit.php
+++ b/administrator/components/com_categories/tmpl/category/edit.php
@@ -9,6 +9,7 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Associations;
@@ -32,6 +33,12 @@ $extensionassoc = array_key_exists('item_associations', $this->form->getFieldset
 
 // Fieldsets to not automatically render by /layouts/joomla/edit/params.php
 $this->ignore_fieldsets = ['jmetadata', 'item_associations'];
+
+if (!ComponentHelper::getParams('com_content')->get('workflow_enabled'))
+{
+	$this->ignore_fieldsets[] = 'workflow';
+}
+
 $this->useCoreUI = true;
 
 // In case of modal


### PR DESCRIPTION
Pull Request for Issue #30342 .

### Summary of Changes
do not render workflow tab if it is not enabled

### Testing Instructions
Go to Global Configuration > Articles > Integration
Confirm Enable Workflow is No
Go to Content > Categories
Edit Uncategorised


### Actual result BEFORE applying this Pull Request
the workflow tab is displayed


### Expected result AFTER applying this Pull Request
the workflow tab is not displayed


