### PR TITLE
Check matched search text for word breaks

### DIFF
--- a/administrator/components/com_search/helpers/search.php
+++ b/administrator/components/com_search/helpers/search.php
@@ -327,8 +327,10 @@ class SearchHelper
 				{
 					$pos += $iOriSkippedLen - $iModSkippedLen;
 				}
+				
 				$iOriReturnLen = StringHelper::strlen(StringHelper::substr($text, $pos, $chunk_size));
 				$iModReturnLen = StringHelper::strlen(self::remove_accents(StringHelper::substr($text, $pos, $chunk_size)));
+				
 				if ($iOriReturnLen != $iModReturnLen)
 				{
 					$chunk_size += $iOriReturnLen - $iModReturnLen;

--- a/administrator/components/com_search/helpers/search.php
+++ b/administrator/components/com_search/helpers/search.php
@@ -311,7 +311,8 @@ class SearchHelper
 		if ($wordfound !== false)
 		{
 			// Check if original text is different length than searched text (changed by function self::remove_accents)
-			if ($pos == 0) // Displayed text only, adjust $chunk_size
+			// Displayed text only, adjust $chunk_size
+			if ($pos === 0)
 			{
 				$iOriLen = StringHelper::strlen(StringHelper::substr($text, 0, $pos + $chunk_size));
 				$iModLen = StringHelper::strlen(self::remove_accents(StringHelper::substr($text, 0, $pos + $chunk_size)));
@@ -324,7 +325,7 @@ class SearchHelper
 				$iModSkippedLen = StringHelper::strlen(self::remove_accents(StringHelper::substr($text, 0, $pos)));
 				
 				// Adjust starting position $pos
-				if ($iOriSkippedLen != $iModSkippedLen)
+				if ($iOriSkippedLen !== $iModSkippedLen)
 				{
 					$pos += $iOriSkippedLen - $iModSkippedLen;
 				}
@@ -332,7 +333,7 @@ class SearchHelper
 				$iOriReturnLen = StringHelper::strlen(StringHelper::substr($text, $pos, $chunk_size));
 				$iModReturnLen = StringHelper::strlen(self::remove_accents(StringHelper::substr($text, $pos, $chunk_size)));
 				
-				if ($iOriReturnLen != $iModReturnLen)
+				if ($iOriReturnLen !== $iModReturnLen)
 				{
 					$chunk_size += $iOriReturnLen - $iModReturnLen;
 				}

--- a/administrator/components/com_search/helpers/search.php
+++ b/administrator/components/com_search/helpers/search.php
@@ -335,7 +335,9 @@ class SearchHelper
 				}
 			}
 			
-			return (($pos > 0) ? '...&#160;' : '') . StringHelper::substr($text, $pos, $chunk_size) . ($pos + $chunk_size >= StringHelper::strlen($text) ? '' : '&#160;...');
+			$sPre = $pos > 0 ? '...&#160;' : '';
+			$sPost = ($pos + $chunk_size) >= StringHelper::strlen($text) ? '' : '&#160;...';
+			return $sPre . StringHelper::substr($text, $pos, $chunk_size) . $sPost;
 		}
 		else
 		{

--- a/administrator/components/com_search/helpers/search.php
+++ b/administrator/components/com_search/helpers/search.php
@@ -323,7 +323,8 @@ class SearchHelper
 				$iOriSkippedLen = StringHelper::strlen(StringHelper::substr($text, 0, $pos));
 				$iModSkippedLen = StringHelper::strlen(self::remove_accents(StringHelper::substr($text, 0, $pos)));
 				
-				if ($iOriSkippedLen != $iModSkippedLen) // Adjust starting position $pos
+				// Adjust starting position $pos
+				if ($iOriSkippedLen != $iModSkippedLen)
 				{
 					$pos += $iOriSkippedLen - $iModSkippedLen;
 				}

--- a/administrator/components/com_search/helpers/search.php
+++ b/administrator/components/com_search/helpers/search.php
@@ -310,7 +310,7 @@ class SearchHelper
 
 		if ($wordfound !== false)
 		{
-			// Check if original text is other length than searched text (changed by self::remove_accents)
+			// Check if original text is different length than searched text (changed by function self::remove_accents)
 			if ($pos == 0) // Displayed text only, adjust $chunk_size
 			{
 				$iOriLen = StringHelper::strlen(StringHelper::substr($text, 0, $pos + $chunk_size));

--- a/administrator/components/com_search/helpers/search.php
+++ b/administrator/components/com_search/helpers/search.php
@@ -310,7 +310,33 @@ class SearchHelper
 
 		if ($wordfound !== false)
 		{
-			return (($pos > 0) ? '...&#160;' : '') . StringHelper::substr($text, $pos, $chunk_size) . '&#160;...';
+			// Check if original text is other length than searched text (changed by self::remove_accents)
+			$iOriLen = StringHelper::strlen(StringHelper::substr($text, 0, $pos + $chunk_size));
+			$iModLen = StringHelper::strlen(self::remove_accents(StringHelper::substr($text, 0, $pos + $chunk_size)));
+			if($iOriLen != $iModLen)
+			{
+				//check if difference is in displayed text or before
+				if ($pos == 0) // displayed text only, adjust $chunk_size
+				{
+					$chunk_size += $iOriLen - $iModLen;
+				}
+				else
+				{
+					$iOriSkippedLen = StringHelper::strlen(StringHelper::substr($text, 0, $pos));
+					$iModSkippedLen = StringHelper::strlen(self::remove_accents(StringHelper::substr($text, 0, $pos)));
+					if ($iOriSkippedLen != $iModSkippedLen) // adjust starting position $pos
+					{
+						$pos += $iOriSkippedLen - $iModSkippedLen;
+					}
+					$iOriReturnLen = StringHelper::strlen(StringHelper::substr($text, $pos, $chunk_size));
+					$iModReturnLen = StringHelper::strlen(self::remove_accents(StringHelper::substr($text, $pos, $chunk_size)));
+					if ($iOriReturnLen != $iModReturnLen)
+					{
+						$chunk_size += $iOriReturnLen - $iModReturnLen;
+					}
+				}
+			}
+			return (($pos > 0) ? '...&#160;' : '') . StringHelper::substr($text, $pos, $chunk_size) . ($pos + $chunk_size >= StringHelper::strlen($text) ? '' : '&#160;...');
 		}
 		else
 		{

--- a/administrator/components/com_search/helpers/search.php
+++ b/administrator/components/com_search/helpers/search.php
@@ -311,36 +311,30 @@ class SearchHelper
 		if ($wordfound !== false)
 		{
 			// Check if original text is other length than searched text (changed by self::remove_accents)
-			$iOriLen = StringHelper::strlen(StringHelper::substr($text, 0, $pos + $chunk_size));
-			$iModLen = StringHelper::strlen(self::remove_accents(StringHelper::substr($text, 0, $pos + $chunk_size)));
-
-			if ($iOriLen != $iModLen)
+			if ($pos == 0) // Displayed text only, adjust $chunk_size
 			{
-				//check if difference is in displayed text or before
-				if ($pos == 0) // displayed text only, adjust $chunk_size
+				$iOriLen = StringHelper::strlen(StringHelper::substr($text, 0, $pos + $chunk_size));
+				$iModLen = StringHelper::strlen(self::remove_accents(StringHelper::substr($text, 0, $pos + $chunk_size)));
+				
+				$chunk_size += $iOriLen - $iModLen;
+			}
+			else
+			{
+				$iOriSkippedLen = StringHelper::strlen(StringHelper::substr($text, 0, $pos));
+				$iModSkippedLen = StringHelper::strlen(self::remove_accents(StringHelper::substr($text, 0, $pos)));
+				
+				if ($iOriSkippedLen != $iModSkippedLen) // Adjust starting position $pos
 				{
-					$chunk_size += $iOriLen - $iModLen;
+					$pos += $iOriSkippedLen - $iModSkippedLen;
 				}
-				else
+				$iOriReturnLen = StringHelper::strlen(StringHelper::substr($text, $pos, $chunk_size));
+				$iModReturnLen = StringHelper::strlen(self::remove_accents(StringHelper::substr($text, $pos, $chunk_size)));
+				if ($iOriReturnLen != $iModReturnLen)
 				{
-					$iOriSkippedLen = StringHelper::strlen(StringHelper::substr($text, 0, $pos));
-					$iModSkippedLen = StringHelper::strlen(self::remove_accents(StringHelper::substr($text, 0, $pos)));
-
-					if ($iOriSkippedLen != $iModSkippedLen) // adjust starting position $pos
-					{
-						$pos += $iOriSkippedLen - $iModSkippedLen;
-					}
-
-					$iOriReturnLen = StringHelper::strlen(StringHelper::substr($text, $pos, $chunk_size));
-					$iModReturnLen = StringHelper::strlen(self::remove_accents(StringHelper::substr($text, $pos, $chunk_size)));
-
-					if ($iOriReturnLen != $iModReturnLen)
-					{
-						$chunk_size += $iOriReturnLen - $iModReturnLen;
-					}
+					$chunk_size += $iOriReturnLen - $iModReturnLen;
 				}
 			}
-
+			
 			return (($pos > 0) ? '...&#160;' : '') . StringHelper::substr($text, $pos, $chunk_size) . ($pos + $chunk_size >= StringHelper::strlen($text) ? '' : '&#160;...');
 		}
 		else

--- a/administrator/components/com_search/helpers/search.php
+++ b/administrator/components/com_search/helpers/search.php
@@ -341,6 +341,7 @@ class SearchHelper
 			
 			$sPre = $pos > 0 ? '...&#160;' : '';
 			$sPost = ($pos + $chunk_size) >= StringHelper::strlen($text) ? '' : '&#160;...';
+
 			return $sPre . StringHelper::substr($text, $pos, $chunk_size) . $sPost;
 		}
 		else

--- a/administrator/components/com_search/helpers/search.php
+++ b/administrator/components/com_search/helpers/search.php
@@ -313,7 +313,8 @@ class SearchHelper
 			// Check if original text is other length than searched text (changed by self::remove_accents)
 			$iOriLen = StringHelper::strlen(StringHelper::substr($text, 0, $pos + $chunk_size));
 			$iModLen = StringHelper::strlen(self::remove_accents(StringHelper::substr($text, 0, $pos + $chunk_size)));
-			if($iOriLen != $iModLen)
+
+			if ($iOriLen != $iModLen)
 			{
 				//check if difference is in displayed text or before
 				if ($pos == 0) // displayed text only, adjust $chunk_size
@@ -324,18 +325,22 @@ class SearchHelper
 				{
 					$iOriSkippedLen = StringHelper::strlen(StringHelper::substr($text, 0, $pos));
 					$iModSkippedLen = StringHelper::strlen(self::remove_accents(StringHelper::substr($text, 0, $pos)));
+
 					if ($iOriSkippedLen != $iModSkippedLen) // adjust starting position $pos
 					{
 						$pos += $iOriSkippedLen - $iModSkippedLen;
 					}
+
 					$iOriReturnLen = StringHelper::strlen(StringHelper::substr($text, $pos, $chunk_size));
 					$iModReturnLen = StringHelper::strlen(self::remove_accents(StringHelper::substr($text, $pos, $chunk_size)));
+
 					if ($iOriReturnLen != $iModReturnLen)
 					{
 						$chunk_size += $iOriReturnLen - $iModReturnLen;
 					}
 				}
 			}
+
 			return (($pos > 0) ? '...&#160;' : '') . StringHelper::substr($text, $pos, $chunk_size) . ($pos + $chunk_size >= StringHelper::strlen($text) ? '' : '&#160;...');
 		}
 		else


### PR DESCRIPTION
Adjust starting position and length of the returned text when a search match is found and the length of the searched text is changed by SearchHelper::remove_accents
This also removes the trailing ... when the searched text is at it's end.
 #30348

Pull Request for Issue # .

### Summary of Changes



### Testing Instructions



### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Documentation Changes Required

