### PR TITLE
[4.0] Fix markup

### DIFF
--- a/libraries/src/HTML/Helpers/JGrid.php
+++ b/libraries/src/HTML/Helpers/JGrid.php
@@ -129,7 +129,7 @@ abstract class JGrid
 		}
 		else
 		{
-			$html[] = '<span class="tbody-icon jgrid';
+			$html[] = '<span class="tbody-icon jgrid"';
 			$html[] = $tip ? ' aria-labelledby="' . $ariaid . '"' : '';
 			$html[] = '>';
 


### PR DESCRIPTION

### Summary of Changes
Add closing quote.


### Testing Instructions
Code review
or
Go to Menus > All Menu Items
View page source
Find `jgrid` without the closing quote


### Actual result BEFORE applying this Pull Request
`<span class="tbody-icon jgrid aria-labelledby="cbunsetDefault0-desc">`


### Expected result AFTER applying this Pull Request
`<span class="tbody-icon jgrid" aria-labelledby="cbunsetDefault0-desc">`