### PR TITLE
[4.0] remove user from user group

### DIFF
--- a/libraries/src/User/UserHelper.php
+++ b/libraries/src/User/UserHelper.php
@@ -189,12 +189,15 @@ abstract class UserHelper
 
 		if ($key !== false)
 		{
-			// Remove the user from the group.
-			unset($user->groups[$key]);
+			$userGroups = Access::getGroupsByUser($userId, false);
+			unset($userGroups[array_search($groupId, $userGroups)]);
+
+			$user->groups = $userGroups;
 
 			// Store the user object.
 			$user->save();
 		}
+
 
 		// Set the group data for any preloaded user objects.
 		$temp = Factory::getUser((int) $userId);

--- a/libraries/src/User/UserHelper.php
+++ b/libraries/src/User/UserHelper.php
@@ -189,10 +189,8 @@ abstract class UserHelper
 
 		if ($key !== false)
 		{
-			$userGroups = Access::getGroupsByUser($userId, false);
-			unset($userGroups[array_search($groupId, $userGroups)]);
-
-			$user->groups = $userGroups;
+			unset($user->groups[$key]);
+			$user->groups = array_values($user->groups);
 
 			// Store the user object.
 			$user->save();

--- a/libraries/src/User/UserHelper.php
+++ b/libraries/src/User/UserHelper.php
@@ -196,7 +196,6 @@ abstract class UserHelper
 			$user->save();
 		}
 
-
 		// Set the group data for any preloaded user objects.
 		$temp = Factory::getUser((int) $userId);
 		$temp->groups = $user->groups;


### PR DESCRIPTION
Pull Request for Issue #30324.

### Summary of Changes
all credits goes to @veperr


### Testing Instructions


-  create a group, get groupId
-  create a user, get userId
-  add user to group
-  try to remove user from group using: `UserHelper::removeUserFromGroup($userId, $groupId)`

for the last point i've used the CLI command `php cli/joomla.php user:removefromgroup`



### Actual result BEFORE applying this Pull Request
despite the successfull message from CLI command the user is not removed from that group  ie it is not removed from the `#__user_usergroup_map` table


### Expected result AFTER applying this Pull Request
the user is removed correctly from that table




