### PR TITLE
Category title and subheading change order

### DIFF
--- a/components/com_content/views/category/tmpl/blog.php
+++ b/components/com_content/views/category/tmpl/blog.php
@@ -36,12 +36,14 @@ $afterDisplayContent = trim(implode("\n", $results));
 		</div>
 	<?php endif; ?>
 
-	<?php if ($this->params->get('show_category_title', 1) or $this->params->get('page_subheading')) : ?>
-		<h2> <?php echo $this->escape($this->params->get('page_subheading')); ?>
-			<?php if ($this->params->get('show_category_title')) : ?>
-				<span class="subheading-category"><?php echo $this->category->title; ?></span>
+	<?php if ($this->params->get('show_category_title')) : ?>
+		<h2> <?php echo $this->category->title; ?>
+            		<?php if ($this->params->get('show_category_title', 1) and $this->params->get('page_subheading')) : ?>
+                		<span class="subheading-category">
+					<?php echo $this->escape($this->params->get('page_subheading')); ?>
+				</span>
 			<?php endif; ?>
-		</h2>
+        	</h2>
 	<?php endif; ?>
 	<?php echo $afterDisplayTitle; ?>
 

--- a/components/com_content/views/category/tmpl/blog.php
+++ b/components/com_content/views/category/tmpl/blog.php
@@ -37,13 +37,13 @@ $afterDisplayContent = trim(implode("\n", $results));
 	<?php endif; ?>
 
 	<?php if ($this->params->get('show_category_title')) : ?>
-		<h2> <?php echo $this->category->title; ?>
-            		<?php if ($this->params->get('show_category_title', 1) and $this->params->get('page_subheading')) : ?>
-                		<span class="subheading-category">
+		<h2><?php echo $this->category->title; ?>
+			<?php if ($this->params->get('page_subheading')) : ?>
+				<span class="subheading-category">
 					<?php echo $this->escape($this->params->get('page_subheading')); ?>
 				</span>
 			<?php endif; ?>
-        	</h2>
+		</h2>
 	<?php endif; ?>
 	<?php echo $afterDisplayTitle; ?>
 


### PR DESCRIPTION
It was so that the category title was wrapped <span class="subheading-category"></span> always. It doesn't matter if the subtitle was specified or not. Now, if the subtitle is not specified, only the text of the title in the tag is output.

Pull Request for Issue # .

### Summary of Changes



### Testing Instructions



### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Documentation Changes Required

