### PR TITLE
Update SiteApplication.php to initialize properly the template object caused by #30192

### DIFF
--- a/libraries/src/Application/SiteApplication.php
+++ b/libraries/src/Application/SiteApplication.php
@@ -875,7 +875,9 @@ final class SiteApplication extends CMSApplication
 		{
 			$this->template = new \stdClass;
 			$this->template->template = $template;
-
+			$this->template->parent = 0;
+			$this->template->inheritable = null;
+			
 			if ($styleParams instanceof Registry)
 			{
 				$this->template->params = $styleParams;

--- a/libraries/src/Application/SiteApplication.php
+++ b/libraries/src/Application/SiteApplication.php
@@ -877,7 +877,7 @@ final class SiteApplication extends CMSApplication
 		{
 			$this->template = new \stdClass;
 			$this->template->template = $template;
-			$this->template->inheritable = inheritable;
+			$this->template->inheritable = $inheritable;
 			$this->template->parent = $parent;
 			
 			if ($styleParams instanceof Registry)

--- a/libraries/src/Application/SiteApplication.php
+++ b/libraries/src/Application/SiteApplication.php
@@ -864,8 +864,8 @@ final class SiteApplication extends CMSApplication
 	 *
 	 * @param   string  $template     The template name
 	 * @param   mixed   $styleParams  The template style parameters
-	 * @param   int   inheritable  Support for inheritance
-	 * @param   string   $parent  The name of the parent template
+	 * @param   int     $inheritable  Support for inheritance
+	 * @param   string  $parent       The name of the parent template
 	 *
 	 * @return  void
 	 *

--- a/libraries/src/Application/SiteApplication.php
+++ b/libraries/src/Application/SiteApplication.php
@@ -881,7 +881,6 @@ final class SiteApplication extends CMSApplication
 			if ($styleParams instanceof Registry)
 			{
 				$this->template->params = $styleParams;
-				
 				if (isset($styleParams->inheritable))
 				{
 					$this->template->inheritable = $styleParams->inheritable;

--- a/libraries/src/Application/SiteApplication.php
+++ b/libraries/src/Application/SiteApplication.php
@@ -881,6 +881,7 @@ final class SiteApplication extends CMSApplication
 			if ($styleParams instanceof Registry)
 			{
 				$this->template->params = $styleParams;
+
 				if (isset($styleParams->inheritable))
 				{
 					$this->template->inheritable = $styleParams->inheritable;

--- a/libraries/src/Application/SiteApplication.php
+++ b/libraries/src/Application/SiteApplication.php
@@ -871,7 +871,7 @@ final class SiteApplication extends CMSApplication
 	 *
 	 * @since   3.2
 	 */
-	public function setTemplate($template, $styleParams = null, inheritable = 0, $parent= null)
+	public function setTemplate($template, $styleParams = null, $inheritable = 0, $parent= null)
 	{
 		if (is_dir(JPATH_THEMES . '/' . $template))
 		{

--- a/libraries/src/Application/SiteApplication.php
+++ b/libraries/src/Application/SiteApplication.php
@@ -864,19 +864,21 @@ final class SiteApplication extends CMSApplication
 	 *
 	 * @param   string  $template     The template name
 	 * @param   mixed   $styleParams  The template style parameters
+	 * @param   int   inheritable  Support for inheritance
+	 * @param   string   $parent  The name of the parent template
 	 *
 	 * @return  void
 	 *
 	 * @since   3.2
 	 */
-	public function setTemplate($template, $styleParams = null)
+	public function setTemplate($template, $styleParams = null, inheritable = 0, $parent= null)
 	{
 		if (is_dir(JPATH_THEMES . '/' . $template))
 		{
 			$this->template = new \stdClass;
 			$this->template->template = $template;
-			$this->template->parent = 0;
-			$this->template->inheritable = null;
+			$this->template->inheritable = inheritable;
+			$this->template->parent = $parent;
 			
 			if ($styleParams instanceof Registry)
 			{

--- a/libraries/src/Application/SiteApplication.php
+++ b/libraries/src/Application/SiteApplication.php
@@ -864,25 +864,33 @@ final class SiteApplication extends CMSApplication
 	 *
 	 * @param   string  $template     The template name
 	 * @param   mixed   $styleParams  The template style parameters
-	 * @param   int     $inheritable  Support for inheritance
-	 * @param   string  $parent       The name of the parent template
 	 *
 	 * @return  void
 	 *
 	 * @since   3.2
 	 */
-	public function setTemplate($template, $styleParams = null, inheritable = 0, $parent= null)
+	public function setTemplate($template, $styleParams = null)
 	{
 		if (is_dir(JPATH_THEMES . '/' . $template))
 		{
 			$this->template = new \stdClass;
 			$this->template->template = $template;
-			$this->template->inheritable = inheritable;
-			$this->template->parent = $parent;
+			$this->template->inheritable = 0;
+			$this->template->parent = '';
 			
 			if ($styleParams instanceof Registry)
 			{
 				$this->template->params = $styleParams;
+				
+				if (isset($styleParams->inheritable))
+				{
+					$this->template->inheritable = $styleParams->inheritable;
+				}
+
+				if (isset($styleParams->parent))
+				{
+					$this->template->parent = $styleParams->parent;
+				}
 			}
 			else
 			{

--- a/libraries/src/Application/SiteApplication.php
+++ b/libraries/src/Application/SiteApplication.php
@@ -879,7 +879,7 @@ final class SiteApplication extends CMSApplication
 			$this->template->template = $template;
 			$this->template->inheritable = $inheritable;
 			$this->template->parent = $parent;
-			
+
 			if ($styleParams instanceof Registry)
 			{
 				$this->template->params = $styleParams;

--- a/libraries/src/Application/SiteApplication.php
+++ b/libraries/src/Application/SiteApplication.php
@@ -875,6 +875,7 @@ final class SiteApplication extends CMSApplication
 		{
 			$this->template = new \stdClass;
 			$this->template->template = $template;
+			
 			$this->template->inheritable = 0;
 			$this->template->parent = '';
 


### PR DESCRIPTION
Related to #30192 

### Summary of Changes
Add the new properties 'parent' and 'inheritable' to the object initialized in the 'setTemplate' method so that there are no 'Notice' if a plugin calls the 'setTemplate' method to override the template used


### Testing Instructions
Call the 'setTemplate' method from a system plugin


### Actual result BEFORE applying this Pull Request
Notice for undefined property 'parent'
![image](https://user-images.githubusercontent.com/17835460/90122019-0099d500-dd5d-11ea-9393-0cbcf8e8689e.png)



### Expected result AFTER applying this Pull Request
No PHP notice


### Documentation Changes Required
No
