### PR TITLE
[4.0] Work around SQL template bug while upgrade

### DIFF
--- a/libraries/src/Application/AdministratorApplication.php
+++ b/libraries/src/Application/AdministratorApplication.php
@@ -235,6 +235,8 @@ class AdministratorApplication extends CMSApplication
 			 * This is important to use asterisk for THIS select query.
 			 * It needed due to upgrade process.
 			 * At some point of time of the upgrade the list of columns is changes that may lead to upgrade crash.
+			 *
+			 * Can be reviewed for Joomla! 5.0
 			 */
 			->select('s.*')
 			->from($db->quoteName('#__template_styles', 's'))

--- a/libraries/src/Application/AdministratorApplication.php
+++ b/libraries/src/Application/AdministratorApplication.php
@@ -274,7 +274,7 @@ class AdministratorApplication extends CMSApplication
 		$template->template = InputFilter::getInstance()->clean($template->template, 'cmd');
 		$template->params   = new Registry($template->params);
 
-		// We have to check required properties, that may not exist while upgrade process
+		// We have to check required properties which may not exist during the upgrade process
 		if (!property_exists($template, 'parent'))
 		{
 			$template->parent = '';

--- a/libraries/src/Application/AdministratorApplication.php
+++ b/libraries/src/Application/AdministratorApplication.php
@@ -231,9 +231,11 @@ class AdministratorApplication extends CMSApplication
 		$db = Factory::getDbo();
 
 		$query = $db->getQuery(true)
-			// This is important to use asterisk for THIS select query.
-			// It needed due to upgrade process.
-			// At some point of time of the upgrade the list of columns is changes that may lead to upgrade crash.
+			/*
+			 * This is important to use asterisk for THIS select query.
+			 * It needed due to upgrade process.
+			 * At some point of time of the upgrade the list of columns is changes that may lead to upgrade crash.
+			 */
 			->select('s.*')
 			->from($db->quoteName('#__template_styles', 's'))
 			->join(

--- a/libraries/src/Application/AdministratorApplication.php
+++ b/libraries/src/Application/AdministratorApplication.php
@@ -232,9 +232,10 @@ class AdministratorApplication extends CMSApplication
 
 		$query = $db->getQuery(true)
 			/*
-			 * This is important to use asterisk for THIS select query.
-			 * It needed due to upgrade process.
-			 * At some point of time of the upgrade the list of columns is changes that may lead to upgrade crash.
+			 * It is important to use the asterisk for THIS select query here.
+			 * It is needed due to the core update process.
+			 * Depending on the version before the update new database columns are used before they exist.
+			 * This causes the update to crash with SQL error.
 			 *
 			 * Can be reviewed for Joomla! 5.0
 			 */

--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -440,7 +440,7 @@ abstract class HTMLHelper
 				$template   = $app->getTemplate(true);
 				$templaPath = JPATH_THEMES;
 
-				if ($template->inheritable || !empty($template->parent))
+				if (!empty($template->inheritable) || !empty($template->parent))
 				{
 					$client     = $app->isClient('administrator') === true ? 'administrator' : 'site';
 					$templaPath = JPATH_ROOT . "/media/templates/$client";

--- a/libraries/src/Helper/ModuleHelper.php
+++ b/libraries/src/Helper/ModuleHelper.php
@@ -335,7 +335,12 @@ abstract class ModuleHelper
 
 		// Build the template and base path for the layout
 		$tPath = JPATH_THEMES . '/' . $template . '/html/' . $module . '/' . $layout . '.php';
-		$iPath = JPATH_THEMES . '/' . $templateObj->parent . '/html/' . $module . '/' . $layout . '.php';
+
+		if (!empty($templateObj->parent))
+		{
+			$iPath = JPATH_THEMES . '/' . $templateObj->parent . '/html/' . $module . '/' . $layout . '.php';
+		}
+
 		$bPath = JPATH_BASE . '/modules/' . $module . '/tmpl/' . $defaultLayout . '.php';
 		$dPath = JPATH_BASE . '/modules/' . $module . '/tmpl/default.php';
 


### PR DESCRIPTION
Pull Request for Issue #30333 #30363 #30365 and much others

### Summary of Changes

Use asterisk to load template style, for AdministratorApplication

### Testing Instructions

1. Update a 4.0 Beta-1 or -2 or -3 to the latest 4.0 nightly build using the custom update URL or download package which can be found here: [https://developer.joomla.org/nightly-builds.html](https://developer.joomla.org/nightly-builds.html).

Result: Update crashes with SQL error about not existing database column "s.inheritable".

2. Update a 4.0 Beta-1 or -2 or -3 to the update package which has been built for this Pull Request. You can find the custom update URL and a download package when following the link "Details" for "Download" step in the automated testing results at the bottom of this PR. If necessary expand the "Show all checks".
![pr-downloads](https://user-images.githubusercontent.com/7413183/90242250-ee876780-de2c-11ea-883f-4ffcd46ab20c.png)

Result: Update succeeds.

### Actual result BEFORE applying this Pull Request

Update crashes

### Expected result AFTER applying this Pull Request

Update is okay
