### PR TITLE
[3.10] Fix broken closing tag for copyright in joomla.xml causing update from 3.10 to 4 fail completely

### DIFF
--- a/administrator/manifests/files/joomla.xml
+++ b/administrator/manifests/files/joomla.xml
@@ -4,7 +4,7 @@
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
-	<copyright>(C) 2019 Open Source Matters, Inc./copyright>
+	<copyright>(C) 2019 Open Source Matters, Inc.</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<version>3.10.0-alpha2-dev</version>
 	<creationDate>July 2020</creationDate>


### PR DESCRIPTION
Pull Request for Issue [https://github.com/joomla/joomla-cms/pull/29689#issuecomment-673961923](https://github.com/joomla/joomla-cms/pull/29689#issuecomment-673961923).

### Summary of Changes

Fix broken XML syntax caused by #29689 .

The update component uses the XML file to get the version from. `simplexml_load_file` breaks when loading that XML file at the beginning of an update to J4 (why ever that is done).

This causes the update to fail.

### Testing Instructions

Can be merged on review.

I've checked that we don't have the same error anywhere else.

But if someone wants to see what such small mistake can cause:

1. Update a current 3.10-dev or the last 3.10 nightly from tonight to J4 using the custom URL for the J4 nightlies.

Result: See section "Actual result BEFORE applying this Pull Request" below.

2. Update a current 3.10-dev or the last 3.10 nightly from tonight to which the change of this PR has been applied to J4 using the custom URL for the J4 nightlies.

Result: See section "Expected result AFTER applying this Pull Request" below.

### Actual result BEFORE applying this Pull Request

![j-3 10-to-4-update-error_1](https://user-images.githubusercontent.com/7413183/90232270-b710bf00-de1c-11ea-8f58-0d4cfc30e252.png)

The database hasn't been updated at all.

Backend is completely broken.

### Expected result AFTER applying this Pull Request

![j-3 10-to-4-update-error_2-ok](https://user-images.githubusercontent.com/7413183/90232280-baa44600-de1c-11ea-8ff3-741d079db17b.png)

Except of the usual template error alert which can be ignored, all is fine.

### Documentation Changes Required

None.