### PR TITLE
[4.0] Fixing Warning Alert color contrast

### DIFF
--- a/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-alert.scss
+++ b/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-alert.scss
@@ -22,7 +22,7 @@
     justify-content: center;
     align-content: center;
     padding: .8rem;
-    color: rgba(255, 255, 255, .95);
+    color: var(--alert-heading-text);
     background: var(--alert-accent-color, transparent);
   }
 
@@ -32,18 +32,26 @@
 
   &[type="success"] {
     --alert-accent-color: var(--success);
+    --alert-heading-text: rgba(255, 255, 255, .95);
+    --alert-close-button: var(--success);
   }
 
   &[type="info"] {
     --alert-accent-color: var(--info);
+    --alert-heading-text: rgba(255, 255, 255, .95);
+    --alert-close-button: var(--info);
   }
 
   &[type="warning"] {
     --alert-accent-color: var(--warning);
+    --alert-heading-text: #000;
+    --alert-close-button: #000;
   }
 
   &[type="danger"] {
     --alert-accent-color: var(--danger);
+    --alert-heading-text: rgba(255, 255, 255, .95);
+    --alert-close-button: var(--danger);
   }
 
   .joomla-alert--close,
@@ -53,7 +61,7 @@
     right: 0;
     padding: .2rem .8rem;
     font-size: 2rem;
-    color: var(--alert-accent-color);
+    color: var(--alert-close-button);
     background: none;
     border: 0;
     opacity: 1;

--- a/templates/cassiopeia/scss/vendor/joomla-custom-elements/joomla-alert.scss
+++ b/templates/cassiopeia/scss/vendor/joomla-custom-elements/joomla-alert.scss
@@ -10,7 +10,7 @@
   min-width: 16rem;
   padding: 0;
   margin-bottom: 1rem;
-  color: var(--atum-text-dark);
+  color: var(--gray-dark);
   background-color: var(--white);
   border: 1px solid var(--alert-accent-color, transparent);
   border-radius: .25rem;
@@ -22,7 +22,7 @@
     justify-content: center;
     align-content: center;
     padding: .8rem;
-    color: rgba(255, 255, 255, .95);
+    color: var(--alert-heading-text);
     background: var(--alert-accent-color, transparent);
   }
 
@@ -32,18 +32,26 @@
 
   &[type="success"] {
     --alert-accent-color: var(--success);
+    --alert-heading-text: rgba(255, 255, 255, .95);
+    --alert-close-button: var(--success);
   }
 
   &[type="info"] {
     --alert-accent-color: var(--info);
+    --alert-heading-text: rgba(255, 255, 255, .95);
+    --alert-close-button: var(--info);
   }
 
   &[type="warning"] {
     --alert-accent-color: var(--warning);
+    --alert-heading-text: #000;
+    --alert-close-button: #000;
   }
 
   &[type="danger"] {
     --alert-accent-color: var(--danger);
+    --alert-heading-text: rgba(255, 255, 255, .95);
+    --alert-close-button: var(--danger);
   }
 
   .joomla-alert--close,
@@ -53,7 +61,7 @@
     right: 0;
     padding: .2rem .8rem;
     font-size: 2rem;
-    color: var(--alert-accent-color);
+    color: var(--alert-close-button);
     background: none;
     border: 0;
     opacity: 1;


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/30375

### Summary of Changes
As title says. Changing Warning heading and Close button to black to increase contrast with Yellow background


### Testing Instructions
Try to login with a wrong password. in frontend as well as backend
You will get a warning.

NPM after patch

### Actual result BEFORE applying this Pull Request
Frontend

<img width="901" alt="Screen Shot 2020-08-16 at 07 14 45" src="https://user-images.githubusercontent.com/869724/90327084-4db1bd00-df90-11ea-87f4-1090d6563954.png">

Backend

<img width="916" alt="Screen Shot 2020-08-16 at 07 15 16" src="https://user-images.githubusercontent.com/869724/90327087-54d8cb00-df90-11ea-8c96-974dc0d21790.png">

### Expected result AFTER applying this Pull Request
Frontend
<img width="884" alt="Screen Shot 2020-08-16 at 06 51 11" src="https://user-images.githubusercontent.com/869724/90327006-b5b3d380-df8f-11ea-8a4b-46e5efd59217.png">

Backend

<img width="916" alt="Screen Shot 2020-08-16 at 06 46 22" src="https://user-images.githubusercontent.com/869724/90327008-b9475a80-df8f-11ea-8420-5266ce05c7e2.png">




