### PR TITLE
[4.0] Child templates consistency

### DIFF
--- a/installation/src/Application/InstallationApplication.php
+++ b/installation/src/Application/InstallationApplication.php
@@ -406,7 +406,7 @@ final class InstallationApplication extends CMSApplication
 			$template->template = 'template';
 			$template->params = new Registry;
 			$template->inheritable = 0;
-			$template->parent = null;
+			$template->parent = '';
 
 			return $template;
 		}

--- a/libraries/src/Application/ApiApplication.php
+++ b/libraries/src/Application/ApiApplication.php
@@ -192,7 +192,7 @@ final class ApiApplication extends CMSApplication
 			$template->template = 'system';
 			$template->params = new Registry;
 			$template->inheritable = 0;
-			$template->parent = null;
+			$template->parent = '';
 
 			return $template;
 		}

--- a/libraries/src/Application/ApiApplication.php
+++ b/libraries/src/Application/ApiApplication.php
@@ -186,6 +186,17 @@ final class ApiApplication extends CMSApplication
 	public function getTemplate($params = false)
 	{
 		// The API application should not need to use a template
+		if ($params)
+		{
+			$template = new \stdClass;
+			$template->template = 'system';
+			$template->params = new Registry;
+			$template->inheritable = 0;
+			$template->parent = null;
+
+			return $template;
+		}
+
 		return 'system';
 	}
 

--- a/libraries/src/Application/WebApplication.php
+++ b/libraries/src/Application/WebApplication.php
@@ -180,9 +180,10 @@ abstract class WebApplication extends AbstractWebApplication
 	{
 		// Setup the document options.
 		$options = array(
-			'template' => $this->get('theme'),
-			'file' => $this->get('themeFile', 'index.php'),
-			'params' => $this->get('themeParams'),
+			'template'         => $this->get('theme'),
+			'file'             => $this->get('themeFile', 'index.php'),
+			'params'           => $this->get('themeParams'),
+			'templateInherits' => $this->get('themeInherits'),
 		);
 
 		if ($this->get('themes.base'))

--- a/libraries/src/Error/Renderer/HtmlRenderer.php
+++ b/libraries/src/Error/Renderer/HtmlRenderer.php
@@ -44,14 +44,20 @@ class HtmlRenderer extends AbstractRenderer
 		$app = Factory::getApplication();
 
 		// Get the current template from the application
-		$template = $app->getTemplate();
+		$template = $app->getTemplate(true);
 
 		// Push the error object into the document
 		$this->getDocument()->setError($error);
 
 		// Add registry file for the template asset
-		$this->getDocument()->getWebAssetManager()->getRegistry()
-			->addTemplateRegistryFile($template, $app->getClientId());
+		$wa = $this->getDocument()->getWebAssetManager()->getRegistry();
+
+		$wa->addTemplateRegistryFile($template->template, $app->getClientId());
+
+		if (!empty($template->parent))
+		{
+			$wa->addTemplateRegistryFile($template->parent, $app->getClientId());
+		}
 
 		if (ob_get_contents())
 		{
@@ -63,10 +69,11 @@ class HtmlRenderer extends AbstractRenderer
 		return $this->getDocument()->render(
 			false,
 			[
-				'template'  => $template,
-				'directory' => JPATH_THEMES,
-				'debug'     => JDEBUG,
-				'csp_nonce' => $app->get('csp_nonce'),
+				'template'         => $template->template,
+				'directory'        => JPATH_THEMES,
+				'debug'            => JDEBUG,
+				'csp_nonce'        => $app->get('csp_nonce'),
+				'templateInherits' => $template->parent
 			]
 		);
 	}


### PR DESCRIPTION
Pull Request supplementary for Issue #30384 .

### Summary of Changes

This PR ensures that all the `render()` have the appropriate params (in particular `templateInherits` that acts as a switch for child templates)

### Testing Instructions

Error pages render correctly (even for child templates, the previous PR was covering only the legacy mode)

### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Documentation Changes Required


@wilsonge 
