### PR TITLE
[4.0] favicon changes to support child templates

### DIFF
--- a/libraries/src/Document/HtmlDocument.php
+++ b/libraries/src/Document/HtmlDocument.php
@@ -773,16 +773,34 @@ class HtmlDocument extends Document
 			ob_end_clean();
 		}
 
+		$app      = CmsFactory::getApplication();
+		$client   = $app->isClient('administrator') === true ? 'administrator/' : 'site/';
+		$template = $app->getTemplate(true);
+
 		// Try to find a favicon by checking the template and root folder
 		$icon = '/favicon.ico';
+		$foldersToCheck = [
+			JPATH_BASE => JPATH_BASE,
+			JPATH_ROOT => JPATH_ROOT . '/media/templates/' . $client . $template->template,
+			JPATH_BASE => $directory,
+		];
 
-		foreach (array(JPATH_BASE, $directory) as $dir)
+		foreach ($foldersToCheck as $base => $dir)
 		{
+			if ($template->parent !== ''
+				&& !file_exists(JPATH_ROOT . '/media/templates/' . $client . $template->template . $icon)
+			)
+			{
+				$base = JPATH_ROOT;
+				$dir  = JPATH_ROOT . '/media/templates/' . $client . $template->parent;
+			}
+
 			if (file_exists($dir . $icon))
 			{
-				$path = str_replace(JPATH_BASE, '', $dir);
+				$path = str_replace($base, '', $dir);
 				$path = str_replace('\\', '/', $path);
-				$this->addFavicon(Uri::base(true) . $path . $icon);
+				$urlBase = $base === JPATH_ROOT ? Uri::root(true) : Uri::base(true);
+				$this->addFavicon($urlBase . $path . $icon);
 				break;
 			}
 		}

--- a/libraries/src/Document/HtmlDocument.php
+++ b/libraries/src/Document/HtmlDocument.php
@@ -797,7 +797,7 @@ class HtmlDocument extends Document
 
 			if (file_exists($dir . $icon))
 			{
-				$urlBase = in_array($base, [0, 2]) ? Uri::root(true) : Uri::base(true);
+				$urlBase = in_array($base, [0, 2]) ? Uri::bse(true) : Uri::root(true);
 				$base    = in_array($base, [0, 2]) ? JPATH_BASE : JPATH_ROOT;
 				$path    = str_replace($base, '', $dir);
 				$path    = str_replace('\\', '/', $path);

--- a/libraries/src/Document/HtmlDocument.php
+++ b/libraries/src/Document/HtmlDocument.php
@@ -797,7 +797,7 @@ class HtmlDocument extends Document
 
 			if (file_exists($dir . $icon))
 			{
-				$urlBase = in_array($base, [0, 2]) ? Uri::bse(true) : Uri::root(true);
+				$urlBase = in_array($base, [0, 2]) ? Uri::base(true) : Uri::root(true);
 				$base    = in_array($base, [0, 2]) ? JPATH_BASE : JPATH_ROOT;
 				$path    = str_replace($base, '', $dir);
 				$path    = str_replace('\\', '/', $path);

--- a/libraries/src/Document/HtmlDocument.php
+++ b/libraries/src/Document/HtmlDocument.php
@@ -789,10 +789,9 @@ class HtmlDocument extends Document
 		{
 			if ($template->parent !== ''
 				&& $base === 1
-				&& !file_exists(JPATH_ROOT . '/media/templates/' . $client . $template->template . $icon)
-			)
+				&& !file_exists(JPATH_ROOT . '/media/templates/' . $client . $template->template . $icon))
 			{
-				$dir  = JPATH_ROOT . '/media/templates/' . $client . $template->parent;
+				$dir = JPATH_ROOT . '/media/templates/' . $client . $template->parent;
 			}
 
 			if (file_exists($dir . $icon))

--- a/libraries/src/Document/HtmlDocument.php
+++ b/libraries/src/Document/HtmlDocument.php
@@ -780,26 +780,27 @@ class HtmlDocument extends Document
 		// Try to find a favicon by checking the template and root folder
 		$icon = '/favicon.ico';
 		$foldersToCheck = [
-			JPATH_BASE => JPATH_BASE,
-			JPATH_ROOT => JPATH_ROOT . '/media/templates/' . $client . $template->template,
-			JPATH_BASE => $directory,
+			JPATH_BASE,
+			JPATH_ROOT . '/media/templates/' . $client . $template->template,
+			$directory,
 		];
 
 		foreach ($foldersToCheck as $base => $dir)
 		{
 			if ($template->parent !== ''
+				&& $base === 1
 				&& !file_exists(JPATH_ROOT . '/media/templates/' . $client . $template->template . $icon)
 			)
 			{
-				$base = JPATH_ROOT;
 				$dir  = JPATH_ROOT . '/media/templates/' . $client . $template->parent;
 			}
 
 			if (file_exists($dir . $icon))
 			{
-				$path = str_replace($base, '', $dir);
-				$path = str_replace('\\', '/', $path);
-				$urlBase = $base === JPATH_ROOT ? Uri::root(true) : Uri::base(true);
+				$urlBase = in_array($base, [0, 2]) ? Uri::root(true) : Uri::base(true);
+				$base    = in_array($base, [0, 2]) ? JPATH_BASE : JPATH_ROOT;
+				$path    = str_replace($base, '', $dir);
+				$path    = str_replace('\\', '/', $path);
 				$this->addFavicon($urlBase . $path . $icon);
 				break;
 			}


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Cascade correctly for any parent/children template


### Testing Instructions
Checkout this PR or download the installable at the end of the GitHub page

Check that both Cassiopeia and Atum have correct favicons
Install the templates from the PR https://github.com/joomla/joomla-cms/pull/30192 (links in the description) and check that both parent and child templates have correct favicon (check the url)

### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Documentation Changes Required

