### PR TITLE
[4] Correct @deprecated DocBlock texts

### DIFF
--- a/components/com_content/helpers/icon.php
+++ b/components/com_content/helpers/icon.php
@@ -15,7 +15,7 @@ use Joomla\Registry\Registry;
  * Content Component HTML Helper
  *
  * @since       1.5
- * @deprecated  5.0 Use the class \Joomla\Component\Content\Site\Service\HTML\Icon instead
+ * @deprecated  5.0 Use the class \Joomla\Component\Content\Administrator\Service\HTML\Icon instead
  */
 abstract class JHtmlIcon
 {
@@ -29,7 +29,7 @@ abstract class JHtmlIcon
 	 *
 	 * @return  string  The HTML markup for the create item link
 	 *
-	 * @deprecated 5.0 Use the class \Joomla\Component\Content\Site\Service\HTML\Icon instead
+	 * @deprecated 5.0 Use the class \Joomla\Component\Content\Administrator\Service\HTML\Icon instead
 	 */
 	public static function create($category, $params, $attribs = array(), $legacy = false)
 	{
@@ -51,7 +51,7 @@ abstract class JHtmlIcon
 	 *
 	 * @since   1.6
 	 *
-	 * @deprecated 5.0 Use the class \Joomla\Component\Content\Site\Service\HTML\Icon instead
+	 * @deprecated 5.0 Use the class \Joomla\Component\Content\Administrator\Service\HTML\Icon instead
 	 */
 	public static function edit($article, $params, $attribs = array(), $legacy = false)
 	{
@@ -68,7 +68,7 @@ abstract class JHtmlIcon
 	 *
 	 * @return  string  The HTML markup for the popup link
 	 *
-	 * @deprecated 5.0 Use the class \Joomla\Component\Content\Site\Service\HTML\Icon instead
+	 * @deprecated 5.0 Use the class \Joomla\Component\Content\Administrator\Service\HTML\Icon instead
 	 */
 	public static function print_popup($article, $params, $attribs = array(), $legacy = false)
 	{
@@ -85,7 +85,7 @@ abstract class JHtmlIcon
 	 *
 	 * @return  string  The HTML markup for the popup link
 	 *
-	 * @deprecated 5.0 Use the class \Joomla\Component\Content\Site\Service\HTML\Icon instead
+	 * @deprecated 5.0 Use the class \Joomla\Component\Content\Administrator\Service\HTML\Icon instead
 	 */
 	public static function print_screen($article, $params, $attribs = array(), $legacy = false)
 	{


### PR DESCRIPTION
Fixes  https://github.com/joomla/joomla-cms/issues/30386 .

### Summary of Changes
- Change Service namespace from Site to Administrator

### Testing Instructions
- Code review after check that Icon.php is located here (Administrator)
https://github.com/joomla/joomla-cms/tree/4.0-dev/administrator/components/com_content/src/Service/HTML

not here (Site)
https://github.com/joomla/joomla-cms/tree/4.0-dev/components/com_content/src/Service
