### PR TITLE
[3.x] Manager in action logs

### DIFF
--- a/administrator/language/en-GB/en-GB.com_config.ini
+++ b/administrator/language/en-GB/en-GB.com_config.ini
@@ -3,7 +3,7 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt
 ; Note : All ini files need to be saved as UTF-8
 
-COM_CONFIG="Configuration Manager"
+COM_CONFIG="Configuration"
 COM_CONFIG_ACTION_ADMIN_DESC="Allows users in the group to perform any action over the whole site regardless of any other permission settings."
 COM_CONFIG_ACTION_CREATE_DESC="Allows users in the group to create any content in any extension."
 COM_CONFIG_ACTION_DELETE_DESC="Allows users in the group to delete any content in any extension."

--- a/administrator/language/en-GB/en-GB.com_config.sys.ini
+++ b/administrator/language/en-GB/en-GB.com_config.sys.ini
@@ -3,7 +3,7 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt
 ; Note : All ini files need to be saved as UTF-8
 
-COM_CONFIG="Configuration Manager"
+COM_CONFIG="Configuration"
 COM_CONFIG_XML_DESCRIPTION="Configuration Manager"
 
 COM_CONFIG_COMPONENT_VIEW_DEFAULT_DESC="Display the configuration options for the selected component."

--- a/administrator/language/en-GB/en-GB.com_modules.ini
+++ b/administrator/language/en-GB/en-GB.com_modules.ini
@@ -3,7 +3,7 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt
 ; Note : All ini files need to be saved as UTF-8
 
-COM_MODULES="Modules Manager"
+COM_MODULES="Modules"
 COM_MODULES_ACTION_EDITFRONTEND="Frontend Editing"
 COM_MODULES_ACTION_EDITFRONTEND_COMPONENT_DESC="Allows users in the group to edit in Frontend."
 COM_MODULES_ADMIN_LANG_FILTER_FIELDSET_LABEL="Administrator Modules"


### PR DESCRIPTION
The use of the word manager was removed some time ago. It looks like there were a few instances that were missed that have been exposed by the Action Logs

### Before
![image](https://user-images.githubusercontent.com/1296369/90343971-788e2680-e00d-11ea-81eb-55eb1b568031.png)


### After
![image](https://user-images.githubusercontent.com/1296369/90343965-67ddb080-e00d-11ea-9a78-905877479941.png)
