### PR TITLE
[4.0] Show debug bar on error page

### DIFF
--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -15,6 +15,7 @@ use DebugBar\DataCollector\RequestDataCollector;
 use DebugBar\DebugBar;
 use DebugBar\OpenHandler;
 use Joomla\CMS\Application\CMSApplicationInterface;
+use Joomla\CMS\Document\HtmlDocument;
 use Joomla\CMS\Log\Log;
 use Joomla\CMS\Log\LogEntry;
 use Joomla\CMS\Plugin\CMSPlugin;
@@ -181,7 +182,7 @@ class PlgSystemDebug extends CMSPlugin
 	public function onAfterDispatch()
 	{
 		// Only if debugging or language debug is enabled.
-		if ((JDEBUG || $this->debugLang) && $this->isAuthorisedDisplayDebug() && strtolower($this->app->getDocument()->getType()) === 'html')
+		if ((JDEBUG || $this->debugLang) && $this->isAuthorisedDisplayDebug() && $this->app->getDocument() instanceof HtmlDocument)
 		{
 			// Use our own jQuery and fontawesome instead of the debug bar shipped version
 			$assetManager = $this->app->getDocument()->getWebAssetManager();
@@ -218,7 +219,7 @@ class PlgSystemDebug extends CMSPlugin
 	public function onAfterRespond()
 	{
 		// Do not render if debugging or language debug is not enabled.
-		if (!JDEBUG && !$this->debugLang || $this->isAjax || strtolower($this->app->getDocument()->getType()) !== 'html')
+		if (!JDEBUG && !$this->debugLang || $this->isAjax || !($this->app->getDocument() instanceof HtmlDocument))
 		{
 			return;
 		}
@@ -277,7 +278,7 @@ class PlgSystemDebug extends CMSPlugin
 		}
 
 		// Only render for HTML output.
-		if ($this->app->getDocument()->getType() !== 'html')
+		if (!($this->app->getDocument() instanceof HtmlDocument))
 		{
 			$this->debugBar->stackData();
 


### PR DESCRIPTION
Closes https://github.com/joomla/joomla-cms/issues/29844.

### Summary of Changes

Shows debug bar on error pages.

### Testing Instructions

Enable debug.
Cause an error, e.g. a syntax error in `templates/cassiopeia/index.php`.

### Actual result BEFORE applying this Pull Request

Debug bar not shown on error page.

### Expected result AFTER applying this Pull Request

Debug bar shown on error page.

### Documentation Changes Required

No.