### PR TITLE
[4.0] Accessibility Warning Alert Message login backend

### DIFF
--- a/administrator/templates/atum/login.php
+++ b/administrator/templates/atum/login.php
@@ -103,7 +103,9 @@ Text::script('JGLOBAL_WARNCOOKIES');
 
 	<div class="container-fluid container-main order-1">
 		<section id="content" class="content h-100">
-			<jdoc:include type="message" />
+			<div class="login_message">
+				<jdoc:include type="message" />
+			</div>
 			<main class="d-flex justify-content-center align-items-center h-100">
 				<div class="login">
 					<div class="main-brand logo text-center">

--- a/administrator/templates/atum/scss/blocks/_login.scss
+++ b/administrator/templates/atum/scss/blocks/_login.scss
@@ -242,4 +242,3 @@ label {
 .login_message {
   margin: 1rem 1rem 0 1rem;
 }
-

--- a/administrator/templates/atum/scss/blocks/_login.scss
+++ b/administrator/templates/atum/scss/blocks/_login.scss
@@ -240,5 +240,5 @@ label {
 }
 
 .login_message {
-  margin: 1rem 1rem 0 1rem;
+  margin: 1rem 1rem 0;
 }

--- a/administrator/templates/atum/scss/blocks/_login.scss
+++ b/administrator/templates/atum/scss/blocks/_login.scss
@@ -24,10 +24,10 @@
     align-self: flex-start;
     width: 25rem;
     padding: 15px;
-    margin-top: 10rem;
+    margin-top: 9rem;
     color: var(--atum-text-dark);
     background: var(--white);
-    border-radius: 3px;
+    border-radius: 2px;
     box-shadow: 0 0 10px 0 #ccc;
 
     @include media-breakpoint-down(md) {
@@ -238,3 +238,8 @@ label {
     display: block;
   }
 }
+
+.login_message {
+  margin: 1rem 1rem 0 1rem;
+}
+

--- a/administrator/templates/atum/scss/blocks/_login.scss
+++ b/administrator/templates/atum/scss/blocks/_login.scss
@@ -27,11 +27,11 @@
     margin-top: 9rem;
     color: var(--atum-text-dark);
     background: var(--white);
-    border-radius: 2px;
+    border-radius: 3px;
     box-shadow: 0 0 10px 0 #ccc;
 
     @include media-breakpoint-down(md) {
-      margin-top: 3rem;
+      margin-top: 2rem;
     }
 
     img {


### PR DESCRIPTION
Pull Request for Issue # . See issue #30382

### Summary of Changes. 

As title says: accessibility Warning Alert backend.

### Testing Instructions
Run npm run build:css or download the installer package at the bottom of the page.

Try to login with a wrong password in the backend, for:
- the desktop version
- the mobile version (responsive mode)

You will get a warning.

### Actual result BEFORE applying this Pull Request
There is no border top of the warming message in the backend.

![pr_inlog_message-1a](https://user-images.githubusercontent.com/9271775/90403289-09faa880-e0a1-11ea-9506-0239104dfe43.png)

### Expected result AFTER applying this Pull Request
Improvement of look and feel.

![pr_inlog_message-2](https://user-images.githubusercontent.com/9271775/90401007-a58a1a00-e09d-11ea-9846-a78c52653fa8.png)


### Documentation Changes Required

No