### PR TITLE
[4.0] Fix Alert multiple error display

### DIFF
--- a/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-alert.scss
+++ b/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-alert.scss
@@ -26,6 +26,10 @@
     background: var(--alert-accent-color, transparent);
   }
 
+  .alert-wrapper {
+    width: 100%;
+  }
+
   .alert-link {
     color: var(--success, inherit);
   }
@@ -89,6 +93,10 @@
       [dir=rtl] & {
         padding: .3rem .3rem .3rem 2rem;
       }
+    }
+
+    .alert-message:not(:first-of-type) {
+      border-top: 1px solid var(--alert-accent-color);
     }
   }
 }

--- a/build/media_source/system/js/core.es6/message.es6
+++ b/build/media_source/system/js/core.es6/message.es6
@@ -82,11 +82,12 @@
       }
 
       // Add messages to the message box
+      messageWrapper = document.createElement('div');
+      messageWrapper.className = 'alert-wrapper';
       typeMessages.forEach((typeMessage) => {
-        messageWrapper = document.createElement('div');
-        messageWrapper.innerHTML = `<div class="alert-message">${typeMessage}</div>`;
-        messagesBox.appendChild(messageWrapper);
+        messageWrapper.innerHTML += `<div class="alert-message">${typeMessage}</div>`;
       });
+      messagesBox.appendChild(messageWrapper);
 
       messageContainer.appendChild(messagesBox);
     });

--- a/layouts/joomla/system/message.php
+++ b/layouts/joomla/system/message.php
@@ -46,7 +46,7 @@ Factory::getDocument()->getWebAssetManager()
 				<joomla-alert type="<?php echo $alert[$type] ?? $type; ?>" dismiss="true">
 					<?php if (!empty($msgs)) : ?>
 						<div class="alert-heading"><?php echo Text::_($type); ?></div>
-						<div>
+						<div class="alert-wrapper">
 							<?php foreach ($msgs as $msg) : ?>
 								<div class="alert-message"><?php echo $msg; ?></div>
 							<?php endforeach; ?>

--- a/templates/cassiopeia/scss/vendor/joomla-custom-elements/joomla-alert.scss
+++ b/templates/cassiopeia/scss/vendor/joomla-custom-elements/joomla-alert.scss
@@ -26,6 +26,10 @@
     background: var(--alert-accent-color, transparent);
   }
 
+  .alert-wrapper {
+    width: 100%;
+  }
+
   .alert-link {
     color: var(--success, inherit);
   }
@@ -89,6 +93,10 @@
       [dir=rtl] & {
         padding: .3rem .3rem .3rem 2rem;
       }
+    }
+
+    .alert-message:not(:first-of-type) {
+      border-top: 1px solid var(--alert-accent-color);
     }
   }
 }


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/30391

### Summary of Changes
Installation Alerts are using the js. The `<div>` was misplaced. 
I added a class but it is not necessary when using default core Installation.

### Testing Instructions
Install a clean Joomla using a superuser password shorter than 12 characters

Patch, use NPM CI and install again

EDIT: To test multiple alerts in backend, add in Atum index.php
```
Factory::getApplication()->enqueueMessage('error message','error');
Factory::getApplication()->enqueueMessage('another long error message','error');
Factory::getApplication()->enqueueMessage('another very long error message','error');
Factory::getApplication()->enqueueMessage('warning message','warning');
Factory::getApplication()->enqueueMessage('warning message','warning');
Factory::getApplication()->enqueueMessage('notice message','notice');
```

### Actual result BEFORE applying this Pull Request

![image](https://user-images.githubusercontent.com/1296369/90344245-c9068380-e00f-11ea-9178-46a2c1944f1a.png)

### Expected result AFTER applying this Pull Request

<img width="804" alt="Screen Shot 2020-08-17 at 15 39 28" src="https://user-images.githubusercontent.com/869724/90402872-60b3b280-e0a0-11ea-9803-814c1744cf12.png">

@brianteeman @chmst 
