### PR TITLE
[4.0] Ignore null results in events

### DIFF
--- a/libraries/src/Plugin/CMSPlugin.php
+++ b/libraries/src/Plugin/CMSPlugin.php
@@ -284,6 +284,12 @@ abstract class CMSPlugin implements DispatcherAwareInterface, PluginInterface
 
 				$result = $this->{$methodName}(...$arguments);
 
+				// When result is null, then ignore to be compatible with Joomla 3
+				if ($result === null)
+				{
+					return;
+				}
+
 				// Restore the old results and add the new result from our method call
 				array_push($allResults, $result);
 				$event['result'] = $allResults;

--- a/libraries/src/Plugin/CMSPlugin.php
+++ b/libraries/src/Plugin/CMSPlugin.php
@@ -284,7 +284,7 @@ abstract class CMSPlugin implements DispatcherAwareInterface, PluginInterface
 
 				$result = $this->{$methodName}(...$arguments);
 
-				// When result is null, then ignore to be compatible with Joomla 3
+				// Ignroe null results
 				if ($result === null)
 				{
 					return;

--- a/libraries/src/Plugin/CMSPlugin.php
+++ b/libraries/src/Plugin/CMSPlugin.php
@@ -284,7 +284,7 @@ abstract class CMSPlugin implements DispatcherAwareInterface, PluginInterface
 
 				$result = $this->{$methodName}(...$arguments);
 
-				// Ignroe null results
+				// Ignore null results
 				if ($result === null)
 				{
 					return;


### PR DESCRIPTION
### Summary of Changes
In Joomla 3 when an event is triggered, null results are ignored in the result. This pr restores the same behavior for legacy listeners on Joomla 4 and improves backwards compatibility.

@wilsonge this is merge by code review.

### Testing Instructions
None as this is more a 3rd party issue.

### Actual result BEFORE applying this Pull Request
Events do return null.

### Expected result AFTER applying this Pull Request
Events do return null.

### Documentation Changes Required
None as it restores an old behavior.