### PR TITLE
[4.0] Fix multilingual status icons colors

### DIFF
--- a/administrator/components/com_languages/tmpl/multilangstatus/default.php
+++ b/administrator/components/com_languages/tmpl/multilangstatus/default.php
@@ -221,7 +221,7 @@ $home_pages        = array_column($this->homepages, 'language');
 					<?php // Published Site languages ?>
 					<?php if ($status->element) : ?>
 							<td class="text-center">
-								<span class="fas fa-check" aria-hidden="true"></span>
+								<span class="text-success fas fa-check" aria-hidden="true"></span>
 								<span class="sr-only"><?php echo Text::_('JYES'); ?></span>
 							</td>
 					<?php else : ?>
@@ -232,10 +232,10 @@ $home_pages        = array_column($this->homepages, 'language');
 					<?php // Published Content languages ?>
 						<td class="text-center">
 							<?php if ($status->lang_code && $status->published == 1) : ?>
-								<span class="fas fa-check" aria-hidden="true"></span>
+								<span class="text-success fas fa-check" aria-hidden="true"></span>
 								<span class="sr-only"><?php echo Text::_('JYES'); ?></span>
 							<?php elseif ($status->lang_code && $status->published == 0) : ?>
-								<span class="fas fa-times" aria-hidden="true"></span>
+								<span class="text-danger fas fa-times" aria-hidden="true"></span>
 								<span class="sr-only"><?php echo Text::_('WARNING'); ?></span>
 							<?php elseif ($status->lang_code && $status->published == -2) : ?>
 								<span class="fas fa-trash" aria-hidden="true"></span>
@@ -248,10 +248,10 @@ $home_pages        = array_column($this->homepages, 'language');
 					<?php // Published Home pages ?>
 						<td class="text-center">
 							<?php if ($status->home_published == 1) : ?>
-								<span class="fas fa-check" aria-hidden="true"></span>
+								<span class="text-success fas fa-check" aria-hidden="true"></span>
 								<span class="sr-only"><?php echo Text::_('JYES'); ?></span>
 							<?php elseif ($status->home_published == 0) : ?>
-								<span class="fas fa-times" aria-hidden="true"></span>
+								<span class="text-danger fas fa-times" aria-hidden="true"></span>
 								<span class="sr-only"><?php echo Text::_('JNO'); ?></span>
 							<?php elseif ($status->home_published == -2) : ?>
 								<span class="fas fa-trash" aria-hidden="true"></span>
@@ -275,10 +275,10 @@ $home_pages        = array_column($this->homepages, 'language');
 							</td>
 							<td class="text-center">
 								<?php if ($contentlang->published == 1) : ?>
-									<span class="fas fa-check" aria-hidden="true"></span>
+									<span class="text-success fas fa-check" aria-hidden="true"></span>
 									<span class="sr-only"><?php echo Text::_('JYES'); ?></span>
 								<?php elseif ($contentlang->published == 0 && array_key_exists($contentlang->lang_code, $this->homepages)) : ?>
-									<span class="fas fa-times" aria-hidden="true"></span>
+									<span class="text-danger fas fa-times" aria-hidden="true"></span>
 									<span class="sr-only"><?php echo Text::_('JNO'); ?></span>
 								<?php elseif ($contentlang->published == -2 && array_key_exists($contentlang->lang_code, $this->homepages)) : ?>
 									<span class="fas fa-trash" aria-hidden="true"></span>
@@ -290,7 +290,7 @@ $home_pages        = array_column($this->homepages, 'language');
 									<span class="fas fa-exclamation-triangle" aria-hidden="true"></span>
 									<span class="sr-only"><?php echo Text::_('WARNING'); ?></span>
 								<?php else : ?>
-									<span class="fas fa-check" aria-hidden="true"></span>
+									<span class="text-success fas fa-check" aria-hidden="true"></span>
 									<span class="sr-only"><?php echo Text::_('JYES'); ?></span>
 								<?php endif; ?>
 							</td>
@@ -305,7 +305,7 @@ $home_pages        = array_column($this->homepages, 'language');
 								<?php echo $sitelang; ?>
 							</th>
 							<td class="text-center">
-								<span class="fas fa-check" aria-hidden="true"></span>
+								<span class="text-success fas fa-check" aria-hidden="true"></span>
 								<span class="sr-only"><?php echo Text::_('JYES'); ?></span>
 							</td>
 							<td class="text-center">
@@ -313,7 +313,7 @@ $home_pages        = array_column($this->homepages, 'language');
 								<span class="sr-only"><?php echo Text::_('WARNING'); ?></span>
 							</td>
 							<td class="text-center">
-								<span class="fas fa-check" aria-hidden="true"></span>
+								<span class="text-success fas fa-check" aria-hidden="true"></span>
 								<span class="sr-only"><?php echo Text::_('JYES'); ?></span>
 							</td>
 						</tr>


### PR DESCRIPTION
### Summary of Changes
Icons now need coloring via bootstrap text-success and text-danger.


### Testing Instructions
Install a few languages (fr-FR, de-DE).
Install a multilingual site via sample data plugin
Trash one of the content languages
Delete a home page for one of the languages

### Actual result BEFORE applying this Pull Request
Icons are white on white

<img width="1030" alt="Screen Shot 2020-08-18 at 18 06 24" src="https://user-images.githubusercontent.com/869724/90537900-1ef93980-e17e-11ea-83bf-5783917c3e66.png">

### Expected result AFTER applying this Pull Request
<img width="1081" alt="Screen Shot 2020-08-18 at 18 00 03" src="https://user-images.githubusercontent.com/869724/90537938-291b3800-e17e-11ea-89a6-86a7ceac07c9.png">


### Note
Similar issue in Users Permissions manager where the text-danger is missing
Will be for another PR
