### PR TITLE
[4.0] Fix debuguser/debuggroup icon color

### DIFF
--- a/administrator/components/com_users/tmpl/debuggroup/default.php
+++ b/administrator/components/com_users/tmpl/debuggroup/default.php
@@ -66,7 +66,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 									$button = 'btn-success';
 									$text   = Text::_('COM_USERS_DEBUG_EXPLICIT_ALLOW');
 								elseif ($check === false) :
-									$class  = 'fas fa-times';
+									$class  = 'text-danger fas fa-times';
 									$button = 'btn-danger';
 									$text   = Text::_('COM_USERS_DEBUG_EXPLICIT_DENY');
 								elseif ($check === null) :
@@ -98,7 +98,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 			<div class="legend">
 				<span class="text-danger fas fa-minus-circle" aria-hidden="true"></span>&nbsp;<?php echo Text::_('COM_USERS_DEBUG_IMPLICIT_DENY'); ?>&nbsp;
 				<span class="text-success fas fa-check" aria-hidden="true"></span>&nbsp;<?php echo Text::_('COM_USERS_DEBUG_EXPLICIT_ALLOW'); ?>&nbsp;
-				<span class="fas fa-times" aria-hidden="true"></span>&nbsp;<?php echo Text::_('COM_USERS_DEBUG_EXPLICIT_DENY'); ?>
+				<span class="text-danger fas fa-times" aria-hidden="true"></span>&nbsp;<?php echo Text::_('COM_USERS_DEBUG_EXPLICIT_DENY'); ?>
 			</div>
 
 			<?php // load the pagination. ?>

--- a/administrator/components/com_users/tmpl/debuguser/default.php
+++ b/administrator/components/com_users/tmpl/debuguser/default.php
@@ -66,7 +66,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 									$button = 'btn-success';
 									$text   = Text::_('COM_USERS_DEBUG_EXPLICIT_ALLOW');
 								elseif ($check === false) :
-									$class  = 'fas fa-times';
+									$class  = 'text-danger fas fa-times';
 									$button = 'btn-danger';
 									$text   = Text::_('COM_USERS_DEBUG_EXPLICIT_DENY');
 								elseif ($check === null) :
@@ -98,7 +98,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 			<div class="legend">
 				<span class="text-danger fas fa-minus-circle" aria-hidden="true"></span>&nbsp;<?php echo Text::_('COM_USERS_DEBUG_IMPLICIT_DENY'); ?>&nbsp;
 				<span class="text-success fas fa-check" aria-hidden="true"></span>&nbsp;<?php echo Text::_('COM_USERS_DEBUG_EXPLICIT_ALLOW'); ?>&nbsp;
-				<span class="fas fa-times" aria-hidden="true">&nbsp;</span><?php echo Text::_('COM_USERS_DEBUG_EXPLICIT_DENY'); ?>
+				<span class="text-danger fas fa-times" aria-hidden="true">&nbsp;</span><?php echo Text::_('COM_USERS_DEBUG_EXPLICIT_DENY'); ?>
 			</div>
 
 			<?php // load the pagination. ?>


### PR DESCRIPTION
Same issue as https://github.com/joomla/joomla-cms/pull/30411

### Summary of Changes
Icon class `fas fa-times` needs `text-danger` color. Otherwise it displays as white on white/lightgrey


### Testing Instructions
Click on Permissions column icon to get the debug manager for a specififc user.
Same for a specific group.

### Actual result BEFORE applying this Pull Request

User

<img width="1383" alt="Screen Shot 2020-08-19 at 09 01 38" src="https://user-images.githubusercontent.com/869724/90604018-7a6a0c80-e1fc-11ea-8428-10d6beaab546.png">

Group

<img width="510" alt="group_times" src="https://user-images.githubusercontent.com/869724/90604029-805fed80-e1fc-11ea-813e-e908ed02ca93.png">

### Expected result AFTER applying this Pull Request

User

<img width="811" alt="Screen Shot 2020-08-19 at 09 03 20" src="https://user-images.githubusercontent.com/869724/90604118-a8e7e780-e1fc-11ea-83be-1c772a4e80d5.png">

Group

<img width="614" alt="Screen Shot 2020-08-19 at 09 04 05" src="https://user-images.githubusercontent.com/869724/90604109-a5ecf700-e1fc-11ea-8ef7-033ae72a3f90.png">

