### PR TITLE
[4.0] Remove coloring from icons

### DIFF
--- a/administrator/templates/atum/scss/blocks/_icons.scss
+++ b/administrator/templates/atum/scss/blocks/_icons.scss
@@ -12,24 +12,6 @@
   color: $white;
 }
 
-.icon-publish,
-.fa-check {
-  color: $whiteoffset;
-
-  .dropdown-status-group & {
-    color: inherit;
-  }
-}
-
-.icon-unpublish,
-.fa-times {
-  color: $whiteoffset;
-
-  .dropdown-status-group & {
-    color: inherit;
-  }
-}
-
 .tbody-icon {
   padding: 0 3px;
   text-align: center;

--- a/templates/cassiopeia/scss/blocks/_icons.scss
+++ b/templates/cassiopeia/scss/blocks/_icons.scss
@@ -12,24 +12,6 @@
   color: $white-offset;
 }
 
-.icon-publish,
-.fa-check {
-  color: $white-offset;
-
-  .dropdown-status-group & {
-    color: inherit;
-  }
-}
-
-.icon-unpublish,
-.fas.fa-times {
-  color: $white-offset;
-
-  .dropdown-status-group & {
-    color: inherit;
-  }
-}
-
 .input-group-text {
   &::before {
     min-width: 16px;


### PR DESCRIPTION
### Summary of Changes

Removes explicit colors from these two icons.

### Testing Instructions

`node build.js --compile-css` required.

Add some icons somewhere. E.g.:

```
<span class="icon-featured"></span>
<span class="icon-search"></span>
<span class="icon-publish"></span>
<span class="icon-unpublish"></span>
```

### Actual result BEFORE applying this Pull Request

`icon-publish` and `icon-unpublish` are invisible against white background.

### Expected result AFTER applying this Pull Request

Icons are same color.

### Documentation Changes Required

No.