### PR TITLE
[3.x] clean cache after enabling 2fa in postinstall

### DIFF
--- a/plugins/twofactorauth/totp/postinstall/actions.php
+++ b/plugins/twofactorauth/totp/postinstall/actions.php
@@ -29,7 +29,7 @@ function twofactorauth_postinstall_condition()
 		->select('*')
 		->from($db->quoteName('#__extensions'))
 		->where($db->quoteName('type') . ' = ' . $db->quote('plugin'))
-		->where($db->quoteName('enabled') . ' = ' . $db->quote('1'))
+		->where($db->quoteName('enabled') . ' = 1')
 		->where($db->quoteName('folder') . ' = ' . $db->quote('twofactorauth'));
 	$db->setQuery($query);
 	$enabled_plugins = $db->loadObjectList();
@@ -53,11 +53,14 @@ function twofactorauth_postinstall_action()
 
 	$query = $db->getQuery(true)
 		->update($db->quoteName('#__extensions'))
-		->set($db->quoteName('enabled') . ' = ' . $db->quote(1))
+		->set($db->quoteName('enabled') . ' = 1')
 		->where($db->quoteName('type') . ' = ' . $db->quote('plugin'))
 		->where($db->quoteName('folder') . ' = ' . $db->quote('twofactorauth'));
 	$db->setQuery($query);
 	$db->execute();
+
+	// Clean cache.
+	Factory::getCache()->clean('com_plugins');
 
 	// Redirect the user to their profile editor page
 	$url = 'index.php?option=com_users&task=user.edit&id=' . Factory::getUser()->id;


### PR DESCRIPTION
Pull Request for Issue #30398  .

### Summary of Changes
redo of #30416 on staging
clean cache after enabling 2fa in postinstall
see https://github.com/joomla/joomla-cms/pull/30416#issuecomment-675958570

### Testing Instructions
see #30398 but on 3.x


### Actual result BEFORE applying this Pull Request
2fa not enabled


### Expected result AFTER applying this Pull Request
2fa enabled


