### PR TITLE
[3.x] clean cache after enabling 2fa in postinstall

### DIFF
--- a/plugins/twofactorauth/totp/postinstall/actions.php
+++ b/plugins/twofactorauth/totp/postinstall/actions.php
@@ -59,6 +59,7 @@ function twofactorauth_postinstall_action()
 
 	// Clean cache.
 	JFactory::getCache()->clean('com_plugins');
+
 	// Redirect the user to their profile editor page
 	$url = 'index.php?option=com_users&task=user.edit&id=' . JFactory::getUser()->id;
 	JFactory::getApplication()->redirect($url);

--- a/plugins/twofactorauth/totp/postinstall/actions.php
+++ b/plugins/twofactorauth/totp/postinstall/actions.php
@@ -27,7 +27,7 @@ function twofactorauth_postinstall_condition()
 		->select('*')
 		->from($db->qn('#__extensions'))
 		->where($db->qn('type') . ' = ' . $db->q('plugin'))
-		->where($db->qn('enabled') . ' = ' . $db->q('1'))
+		->where($db->qn('enabled') . ' = 1')
 		->where($db->qn('folder') . ' = ' . $db->q('twofactorauth'));
 	$db->setQuery($query);
 	$enabled_plugins = $db->loadObjectList();
@@ -51,12 +51,14 @@ function twofactorauth_postinstall_action()
 
 	$query = $db->getQuery(true)
 		->update($db->qn('#__extensions'))
-		->set($db->qn('enabled') . ' = ' . $db->q(1))
+		->set($db->qn('enabled') . ' = 1')
 		->where($db->qn('type') . ' = ' . $db->q('plugin'))
 		->where($db->qn('folder') . ' = ' . $db->q('twofactorauth'));
 	$db->setQuery($query);
 	$db->execute();
 
+	// Clean cache.
+	JFactory::getCache()->clean('com_plugins');
 	// Redirect the user to their profile editor page
 	$url = 'index.php?option=com_users&task=user.edit&id=' . JFactory::getUser()->id;
 	JFactory::getApplication()->redirect($url);


### PR DESCRIPTION
Pull Request for Issue #30398  .

### Summary of Changes
redo of #30416 on staging
clean cache after enabling 2fa in postinstall
see https://github.com/joomla/joomla-cms/pull/30416#issuecomment-675958570

### Testing Instructions
see #30398 but on 3.x


### Actual result BEFORE applying this Pull Request
2fa not enabled


### Expected result AFTER applying this Pull Request
2fa enabled


