### PR TITLE
[4.0] Fix Safari issue with overflow hidden

### DIFF
--- a/administrator/templates/atum/scss/blocks/_form.scss
+++ b/administrator/templates/atum/scss/blocks/_form.scss
@@ -159,7 +159,7 @@ legend {
 
 .input-group-append {
   overflow: hidden;
-  mask-image: radial-gradient(#fff, #000);
+  transform: translate3d(0, 0, 0);
 
   [dir=ltr] & {
     border-top-right-radius: $border-radius;

--- a/administrator/templates/atum/scss/blocks/_form.scss
+++ b/administrator/templates/atum/scss/blocks/_form.scss
@@ -159,7 +159,7 @@ legend {
 
 .input-group-append {
   overflow: hidden;
-  -webkit-mask-image: -webkit-radial-gradient(white, black);
+  mask-image: radial-gradient(#fff, #000);
 
   [dir=ltr] & {
     border-top-right-radius: $border-radius;

--- a/administrator/templates/atum/scss/blocks/_form.scss
+++ b/administrator/templates/atum/scss/blocks/_form.scss
@@ -159,6 +159,7 @@ legend {
 
 .input-group-append {
   overflow: hidden;
+  -webkit-mask-image: -webkit-radial-gradient(white, black);
 
   [dir=ltr] & {
     border-top-right-radius: $border-radius;

--- a/build/media_source/system/scss/fields/switcher.scss
+++ b/build/media_source/system/scss/fields/switcher.scss
@@ -73,7 +73,7 @@ $switcher-height: 28px;
   width: 58px;
   height: 100%;
   overflow: hidden;
-  -webkit-mask-image: -webkit-radial-gradient(white, black);
+  mask-image: radial-gradient(#fff, #000);
   background: $off-background-colour;
   border: 1px solid rgba(0, 0, 0, .18);
   transition: .2s ease all;

--- a/build/media_source/system/scss/fields/switcher.scss
+++ b/build/media_source/system/scss/fields/switcher.scss
@@ -74,8 +74,8 @@ $switcher-height: 28px;
   height: 100%;
   overflow: hidden;
   background: $off-background-colour;
-  transform: translate3d(0, 0, 0);
   border: 1px solid rgba(0, 0, 0, .18);
+  transform: translate3d(0, 0, 0);
   transition: .2s ease all;
 
   [dir=rtl] & {

--- a/build/media_source/system/scss/fields/switcher.scss
+++ b/build/media_source/system/scss/fields/switcher.scss
@@ -73,7 +73,7 @@ $switcher-height: 28px;
   width: 58px;
   height: 100%;
   overflow: hidden;
-  mask-image: radial-gradient(#fff, #000);
+  transform: translate3d(0, 0, 0);
   background: $off-background-colour;
   border: 1px solid rgba(0, 0, 0, .18);
   transition: .2s ease all;

--- a/build/media_source/system/scss/fields/switcher.scss
+++ b/build/media_source/system/scss/fields/switcher.scss
@@ -75,8 +75,8 @@ $switcher-height: 28px;
   overflow: hidden;
   background: $off-background-colour;
   border: 1px solid rgba(0, 0, 0, .18);
-  transform: translate3d(0, 0, 0);
   transition: .2s ease all;
+  transform: translate3d(0, 0, 0);
 
   [dir=rtl] & {
     right: 0;

--- a/build/media_source/system/scss/fields/switcher.scss
+++ b/build/media_source/system/scss/fields/switcher.scss
@@ -73,6 +73,7 @@ $switcher-height: 28px;
   width: 58px;
   height: 100%;
   overflow: hidden;
+  -webkit-mask-image: -webkit-radial-gradient(white, black);
   background: $off-background-colour;
   border: 1px solid rgba(0, 0, 0, .18);
   transition: .2s ease all;

--- a/build/media_source/system/scss/fields/switcher.scss
+++ b/build/media_source/system/scss/fields/switcher.scss
@@ -73,8 +73,8 @@ $switcher-height: 28px;
   width: 58px;
   height: 100%;
   overflow: hidden;
-  transform: translate3d(0, 0, 0);
   background: $off-background-colour;
+  transform: translate3d(0, 0, 0);
   border: 1px solid rgba(0, 0, 0, .18);
   transition: .2s ease all;
 


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/30298
and https://github.com/joomla/joomla-cms/issues/29285
and https://github.com/joomla/joomla-cms/issues/29314

### Summary of Changes
There is a known bug in Safari with the class `overflow: hidden;`
This Pr corrects the behavior for 2 aspects in core:
The switcher (edit cassiopea template style for example)
The Select Image button  (edit category for example)
The switchers when editing user.


### Testing Instructions
Test various places where these are used in Safari.
Confirm it does not break anything with other browsers.

After patch run npm ci


### Actual result BEFORE applying this Pull Request
<img width="1230" alt="Screen Shot 2020-08-19 at 11 27 01" src="https://user-images.githubusercontent.com/869724/90617930-91662a00-e20f-11ea-8630-10efcadbd397.png">
<img width="1323" alt="Screen Shot 2020-08-19 at 11 25 29" src="https://user-images.githubusercontent.com/869724/90618982-f79f7c80-e210-11ea-9720-41757a035f32.png">



### Expected result AFTER applying this Pull Request
<img width="1053" alt="Screen Shot 2020-08-19 at 11 10 19" src="https://user-images.githubusercontent.com/869724/90616709-0df80900-e20e-11ea-90e6-ae59728a7e6c.png">
<img width="1100" alt="Screen Shot 2020-08-19 at 11 30 48" src="https://user-images.githubusercontent.com/869724/90617838-772c4c00-e20f-11ea-93db-8e19d4301ac4.png">
<img width="1304" alt="Screen Shot 2020-08-19 at 11 09 38" src="https://user-images.githubusercontent.com/869724/90616730-14868080-e20e-11ea-8873-341cc4868419.png">

<img width="789" alt="Screen Shot 2020-08-19 at 11 34 29" src="https://user-images.githubusercontent.com/869724/90618250-0174b000-e210-11ea-84ba-c8d49b7d5149.png">

@PhilETaylor 
