### PR TITLE
Category title and subheading change order, add h1 tag support for category title

### DIFF
--- a/components/com_content/views/category/tmpl/blog.php
+++ b/components/com_content/views/category/tmpl/blog.php
@@ -37,13 +37,22 @@ $afterDisplayContent = trim(implode("\n", $results));
 	<?php endif; ?>
 
 	<?php if ($this->params->get('show_category_title')) : ?>
-		<h2><?php echo $this->category->title; ?>
+		<?php
+			if(!$this->params->get('show_page_heading')){
+				$head_tag_start = "<h1>";
+				$head_tag_end = "</h1>";
+			} else {
+				$head_tag_start = "<h2>";
+				$head_tag_end = "</h2>";
+			};?>
+		<?php echo $head_tag_start;?>
+			<?php echo $this->category->title; ?>
 			<?php if ($this->params->get('page_subheading')) : ?>
 				<span class="subheading-category">
 					<?php echo $this->escape($this->params->get('page_subheading')); ?>
 				</span>
-			<?php endif; ?>
-		</h2>
+			<?php endif;?>
+		<?php echo $head_tag_end;?>
 	<?php endif; ?>
 	<?php echo $afterDisplayTitle; ?>
 

--- a/components/com_content/views/category/tmpl/blog.php
+++ b/components/com_content/views/category/tmpl/blog.php
@@ -36,12 +36,14 @@ $afterDisplayContent = trim(implode("\n", $results));
 		</div>
 	<?php endif; ?>
 
-	<?php if ($this->params->get('show_category_title', 1) or $this->params->get('page_subheading')) : ?>
-		<h2> <?php echo $this->escape($this->params->get('page_subheading')); ?>
-			<?php if ($this->params->get('show_category_title')) : ?>
-				<span class="subheading-category"><?php echo $this->category->title; ?></span>
+	<?php if ($this->params->get('show_category_title')) : ?>
+		<h2> <?php echo $this->category->title; ?>
+            		<?php if ($this->params->get('show_category_title', 1) and $this->params->get('page_subheading')) : ?>
+                		<span class="subheading-category">
+					<?php echo $this->escape($this->params->get('page_subheading')); ?>
+				</span>
 			<?php endif; ?>
-		</h2>
+        	</h2>
 	<?php endif; ?>
 	<?php echo $afterDisplayTitle; ?>
 

--- a/components/com_content/views/category/tmpl/blog.php
+++ b/components/com_content/views/category/tmpl/blog.php
@@ -37,13 +37,13 @@ $afterDisplayContent = trim(implode("\n", $results));
 	<?php endif; ?>
 
 	<?php if ($this->params->get('show_category_title')) : ?>
-		<h2> <?php echo $this->category->title; ?>
-            		<?php if ($this->params->get('show_category_title', 1) and $this->params->get('page_subheading')) : ?>
-                		<span class="subheading-category">
+		<h2><?php echo $this->category->title; ?>
+			<?php if ($this->params->get('page_subheading')) : ?>
+				<span class="subheading-category">
 					<?php echo $this->escape($this->params->get('page_subheading')); ?>
 				</span>
 			<?php endif; ?>
-        	</h2>
+		</h2>
 	<?php endif; ?>
 	<?php echo $afterDisplayTitle; ?>
 


### PR DESCRIPTION
### Actual result BEFORE applying this Pull Request
1. It was so that the category title was wrapped always in span tags. It doesn't matter if the subtitle was specified or not. 
2.  If there is no page heading from menu item category title is still output in h2 tag. So page can be without h1 tag

### Expected result AFTER applying this Pull Request
1. Now, if the subtitle is not specified, only the text of the title in the tag is output.
2.  If there is no page heading from menu item category title outputs in h1 tag


### Documentation Changes Required
- replaced spaces to tabs
- remove excessive condition in subheading if
