### PR TITLE
[4.0] Installation password length/meter

### DIFF
--- a/build/media_source/system/js/fields/passwordstrength.es6.js
+++ b/build/media_source/system/js/fields/passwordstrength.es6.js
@@ -103,19 +103,9 @@ class PasswordStrength {
     const i = meter.getAttribute('id').replace(/^\D+/g, '');
     const label = element.parentNode.parentNode.querySelector(`#password-${i}`);
 
-    if (score > 79) {
+    if (score === 100) {
       label.innerText = Joomla.JText._('JFIELD_PASSWORD_INDICATE_COMPLETE');
-    }
-    if (score > 64 && score < 80) {
-      label.innerText = Joomla.JText._('JFIELD_PASSWORD_INDICATE_INCOMPLETE');
-    }
-    if (score > 50 && score < 65) {
-      label.innerText = Joomla.JText._('JFIELD_PASSWORD_INDICATE_INCOMPLETE');
-    }
-    if (score > 40 && score < 51) {
-      label.innerText = Joomla.JText._('JFIELD_PASSWORD_INDICATE_INCOMPLETE');
-    }
-    if (score < 41) {
+    } else {
       label.innerText = Joomla.JText._('JFIELD_PASSWORD_INDICATE_INCOMPLETE');
     }
     meter.value = score;

--- a/build/media_source/system/js/fields/passwordstrength.es6.js
+++ b/build/media_source/system/js/fields/passwordstrength.es6.js
@@ -133,8 +133,8 @@ class PasswordStrength {
       meter.setAttribute('min', 0);
       meter.setAttribute('max', 100);
       meter.setAttribute('low', 40);
-      meter.setAttribute('high', 60);
-      meter.setAttribute('optimum', 80);
+      meter.setAttribute('high', 99);
+      meter.setAttribute('optimum', 100);
       meter.value = initialVal;
 
       const label = document.createElement('div');

--- a/installation/forms/setup.xml
+++ b/installation/forms/setup.xml
@@ -55,6 +55,9 @@
 			required="true"
 			autocomplete="new-password"
 			validate="password"
+			strengthmeter="true"
+			force="on"
+			filter="raw"
 		/>
 		<field
 			name="db_type"

--- a/libraries/src/Form/Field/PasswordField.php
+++ b/libraries/src/Form/Field/PasswordField.php
@@ -154,7 +154,7 @@ class PasswordField extends FormField
 			$this->force        = (($force === 'true' || $force === 'on' || $force === '1') && $this->meter === true);
 
 			// Set some initial values
-			$this->minLength    = 4;
+			$this->minLength    = 12;
 			$this->minIntegers  = 0;
 			$this->minSymbols   = 0;
 			$this->minUppercase = 0;
@@ -162,7 +162,7 @@ class PasswordField extends FormField
 
 			if (Factory::getApplication()->get('db') != '')
 			{
-				$this->minLength    = (int) ComponentHelper::getParams('com_users')->get('minimum_length', 4);
+				$this->minLength    = (int) ComponentHelper::getParams('com_users')->get('minimum_length', 12);
 				$this->minIntegers  = (int) ComponentHelper::getParams('com_users')->get('minimum_integers', 0);
 				$this->minSymbols   = (int) ComponentHelper::getParams('com_users')->get('minimum_symbols', 0);
 				$this->minUppercase = (int) ComponentHelper::getParams('com_users')->get('minimum_uppercase', 0);


### PR DESCRIPTION
Pull Request for Issue #30406 .

### Summary of Changes
Add meter to the installation admin password.
Update minimum length value that was missed in PR #29859.
Fix meter's complete message displaying prematurely.

Database password `data-min-length` attribute is also updated to 12 but no validation is done as before.

It is still possible to go to the next page if password doesn't meet the minimum length criteria of 12 characters to be fixed in a separate PR unless someone can propose a solution.


### Testing Instructions
Download the package installer at the bottom of the page and install.
or
Apply PR.
Run `npm run build:js`
Reinstall.

Use browser's inspector to check password fields for `data-min-length="12"` and not `data-min-length="4"`.
See password meter under admin password field and ensure the meter's complete message displays on the 12th character and not before.
