### PR TITLE
[4.0] Check if orderedby element is available in searchtools

### DIFF
--- a/build/media_source/system/js/searchtools.es6.js
+++ b/build/media_source/system/js/searchtools.es6.js
@@ -530,7 +530,7 @@ Joomla = window.Joomla || {};
 
     const sort = document.getElementById('sorted');
 
-    if (sort && sort.hasAttribute('data-caption')) {
+    if (sort && sort.hasAttribute('data-caption') && document.getElementById('orderedBy')) {
       const orderedBy = sort.getAttribute('data-caption');
       document.getElementById('orderedBy').textContent += orderedBy;
     }

--- a/build/media_source/system/js/searchtools.es6.js
+++ b/build/media_source/system/js/searchtools.es6.js
@@ -529,10 +529,11 @@ Joomla = window.Joomla || {};
     }
 
     const sort = document.getElementById('sorted');
+    const order = document.getElementById('orderedBy');
 
-    if (sort && sort.hasAttribute('data-caption') && document.getElementById('orderedBy')) {
+    if (sort && sort.hasAttribute('data-caption') && order) {
       const orderedBy = sort.getAttribute('data-caption');
-      document.getElementById('orderedBy').textContent += orderedBy;
+      order.textContent += orderedBy;
     }
 
     if (sort && sort.hasAttribute('data-sort')) {


### PR DESCRIPTION
### Summary of Changes
Joomla 3 components do not have the new `orderedBy` element in the back end lists. If this element is not available then a Javascript error happens:

```
Uncaught TypeError: document.getElementById(...) is null
onBoot /media/system/js/searchtools.js:540
EventListener.handleEvent* /media/system/js/searchtools.js:553
<anonymous> /media/system/js/searchtools.js:554
```

This pr stabilizes by adding a check if the element exists.

### Testing Instructions
- Remove the lines 110 - 114 in the file /administrator/components/com_content/tmpl/articles/default.php
- Go to /administrator/index.php?option=com_content&view=articles

### Actual result BEFORE applying this Pull Request
Error happens as described above.

### Expected result AFTER applying this Pull Request
No JS error.

### Documentation Changes Required
Nothing as the new orderedby element is not required anymore. When the pr is not accepted, then the docs need an update of the new required element.