### PR TITLE
[4.0] Fix Fieldset description display

### DIFF
--- a/layouts/joomla/edit/params.php
+++ b/layouts/joomla/edit/params.php
@@ -149,7 +149,10 @@ foreach ($fieldSets as $name => $fieldSet)
 			// Include the description when available
 			if (isset($fieldSet->description) && trim($fieldSet->description))
 			{
-				echo '<div class="alert alert-info">' . $this->escape(Text::_($fieldSet->description)) . '</div>';
+				echo '<div class="alert alert-info">';
+				echo '<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only">' . Text::_('INFO') . '</span> ';
+				echo Text::_($fieldSet->description);
+				echo '</div>';
 			}
 
 			echo '<div class="column-count-md-2 column-count-lg-3">';


### PR DESCRIPTION
### Summary of Changes
Fieldset description as created in the layout is not a11y aware, misses info icon, prevents html in language string

This PR modifies the layout to obtain the same results we already have when we have no results in a manager.
<img width="258" alt="Screen Shot 2020-08-21 at 09 44 57" src="https://user-images.githubusercontent.com/869724/90865741-26ddf700-e393-11ea-9934-cad6ba0d3603.png">



### Testing Instructions
Install French language. (it is a 3.x lang and one string still contains some `<br>` which will be taken off in J4)
Create a `List All Categories` menu item
Display the Category Tab (same for Blog Layout, List Layout)
Switch backend language between en-GB and fr-FR

### Actual result BEFORE applying this Pull Request
English

<img width="933" alt="Screen Shot 2020-08-21 at 09 18 43" src="https://user-images.githubusercontent.com/869724/90864127-6ce58b80-e390-11ea-96c9-df9dcb96747f.png">

French

<img width="929" alt="Screen Shot 2020-08-21 at 09 19 25" src="https://user-images.githubusercontent.com/869724/90864114-69ea9b00-e390-11ea-9e4f-73d943e17372.png">


### Expected result AFTER applying this Pull Request

English

<img width="925" alt="Screen Shot 2020-08-21 at 09 20 20" src="https://user-images.githubusercontent.com/869724/90864428-ee3d1e00-e390-11ea-9169-00a547c6372c.png">

French

<img width="943" alt="Screen Shot 2020-08-21 at 09 20 02" src="https://user-images.githubusercontent.com/869724/90864480-0ad95600-e391-11ea-9d31-e3fea6b09fea.png">

Code obtained:
<img width="759" alt="Screen Shot 2020-08-21 at 09 32 25" src="https://user-images.githubusercontent.com/869724/90864604-4411c600-e391-11ea-8aa5-687788c76a90.png">

