### PR TITLE
[4.0] [a11y] Update _icomoon.scss px => rem

### DIFF
--- a/build/media_source/system/scss/_icomoon.scss
+++ b/build/media_source/system/scss/_icomoon.scss
@@ -3,9 +3,9 @@
 [class^="icon-"]:not(.input-group-text),
 [class*=" icon-"]:not(.input-group-text) {
   display: inline-block;
-  width: 14px;
-  height: 14px;
-  line-height: 14px;
+  width: 1rem;
+  height: 1rem;
+  line-height: 1rem;
 }
 [class^="icon-"]::before,
 [class*=" icon-"]::before {


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/29411 .

### Summary of Changes

This small PR will replace the `px` set in _icomoon by `rem`.
Using relative sizes instead of absolute sizes will make this part of the Joomla a wee more a11y. 
This PR is just a small piece of all replaces that have to be done. 

### Testing Instructions

- Open Jooml4 test and inspect element of an icon (in Chrome => use the shortcut `Cmd + Shift + C` (`Ctrl + Shift + C` on Windows)) Your pointer is in Inspect Element mode, go ahead and click an element on the webpage
- icon is present in the search form
- lookup the width, height and line-height
- apply PR and run `npm run build:css`

### Actual result BEFORE applying this Pull Request

Before PR the values of the items `width`, `height` and `line-height` are set to `14px`


### Expected result AFTER applying this Pull Request

After applying PR the values of the items `width`, `height` and `line-height` are set to `1rem`

### Documentation Changes Required

