### PR TITLE
[4.0] Implementing display of fieldset descriptions for fieldset children

### DIFF
--- a/administrator/templates/atum/scss/blocks/_alerts.scss
+++ b/administrator/templates/atum/scss/blocks/_alerts.scss
@@ -33,7 +33,7 @@
 
 .alert-parent {
   margin-top: 0;
- }
+}
 
 fieldset .alert {
   &.alert-info {

--- a/administrator/templates/atum/scss/blocks/_alerts.scss
+++ b/administrator/templates/atum/scss/blocks/_alerts.scss
@@ -56,4 +56,3 @@ fieldset .alert {
     transform: translateY(0);
   }
 }
-

--- a/administrator/templates/atum/scss/blocks/_alerts.scss
+++ b/administrator/templates/atum/scss/blocks/_alerts.scss
@@ -31,6 +31,10 @@
   }
 }
 
+.alert-parent {
+  margin-top: 0;
+ }
+
 fieldset .alert {
   &.alert-info {
     margin: -1rem 0 1rem;

--- a/layouts/joomla/edit/params.php
+++ b/layouts/joomla/edit/params.php
@@ -118,6 +118,16 @@ foreach ($fieldSets as $name => $fieldSet)
 	{
 		echo '<fieldset id="fieldset-' . $name . '" class="options-form ' . (!empty($fieldSet->class) ? $fieldSet->class : '') . '">';
 		echo '<legend>' . $label . '</legend>';
+
+		// Include the description when available
+		if (isset($fieldSet->description) && trim($fieldSet->description))
+		{
+			echo '<div class="alert alert-info">';
+			echo '<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only">' . Text::_('INFO') . '</span> ';
+			echo Text::_($fieldSet->description);
+			echo '</div>';
+		}
+
 		echo '<div class="column-count-md-2 column-count-lg-3">';
 	}
 	// Tabs
@@ -158,6 +168,17 @@ foreach ($fieldSets as $name => $fieldSet)
 			echo '<div class="column-count-md-2 column-count-lg-3">';
 
 			$opentab = 2;
+		}
+		else
+		{
+			// Include the description when available
+			if (isset($fieldSet->description) && trim($fieldSet->description))
+			{
+				echo '<div class="alert alert-info alert-parent">';
+				echo '<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only">' . Text::_('INFO') . '</span> ';
+				echo Text::_($fieldSet->description);
+				echo '</div>';
+			}
 		}
 	}
 

--- a/layouts/joomla/edit/params.php
+++ b/layouts/joomla/edit/params.php
@@ -120,7 +120,7 @@ foreach ($fieldSets as $name => $fieldSet)
 		echo '<legend>' . $label . '</legend>';
 
 		// Include the description when available
-		if (isset($fieldSet->description) && trim($fieldSet->description))
+		if (!empty($fieldSet->description))
 		{
 			echo '<div class="alert alert-info">';
 			echo '<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only">' . Text::_('INFO') . '</span> ';
@@ -157,7 +157,7 @@ foreach ($fieldSets as $name => $fieldSet)
 			echo '<legend>' . $label . '</legend>';
 
 			// Include the description when available
-			if (isset($fieldSet->description) && trim($fieldSet->description))
+			if (!empty($fieldSet->description))
 			{
 				echo '<div class="alert alert-info">';
 				echo '<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only">' . Text::_('INFO') . '</span> ';
@@ -169,16 +169,13 @@ foreach ($fieldSets as $name => $fieldSet)
 
 			$opentab = 2;
 		}
-		else
+		// Include the description when available
+		elseif (!empty($fieldSet->description))
 		{
-			// Include the description when available
-			if (isset($fieldSet->description) && trim($fieldSet->description))
-			{
-				echo '<div class="alert alert-info alert-parent">';
-				echo '<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only">' . Text::_('INFO') . '</span> ';
-				echo Text::_($fieldSet->description);
-				echo '</div>';
-			}
+			echo '<div class="alert alert-info alert-parent">';
+			echo '<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only">' . Text::_('INFO') . '</span> ';
+			echo Text::_($fieldSet->description);
+			echo '</div>';
 		}
 	}
 


### PR DESCRIPTION
Pull Request for Issues https://github.com/joomla/joomla-cms/issues/30433 & https://github.com/joomla/joomla-cms/issues/30431

### Summary of Changes
Added the possibility to display fieldsets description for children (and parent when there are children)

### Testing Instructions
Structure of a xml with children fieldsets

```
<fieldset name="filtering" label="MOD_ARTICLES_CATEGORY_FIELD_GROUP_FILTERING_LABEL" description="Top most description">

<fieldset name="filtering_child1" label="Child 1" description="Child description 1">
[some fields]
</fieldset>
<fieldset name="filtering_child2" label="Child 2" description="Child description 2">
[the remaining fields]
</fieldset>

</fieldset>
```

For example, replace the file `modules/mod_articles_category/mod_articles_category.xml` where I have made such a structure.
with this one (unzip first)
[mod_articles_category.xml.zip](https://github.com/joomla/joomla-cms/files/5112062/mod_articles_category.xml.zip)

Test, then patch and run NPM as we have a small scss change.


### Actual result BEFORE applying this Pull Request
<img width="1530" alt="Screen Shot 2020-08-22 at 09 38 41" src="https://user-images.githubusercontent.com/869724/90951445-56f0cd00-e45b-11ea-8046-967237530926.png">

### Expected result AFTER applying this Pull Request

<img width="1560" alt="Screen Shot 2020-08-22 at 09 36 52" src="https://user-images.githubusercontent.com/869724/90951415-12fdc800-e45b-11ea-89a0-0337111fccde.png">

@obuisard
Please test and add your test result on https://issues.joomla.org/tracker/joomla-cms/30450