### PR TITLE
[4.0] Media field fix

### DIFF
--- a/build/media_source/legacy/js/bootstrap-init.es5.js
+++ b/build/media_source/legacy/js/bootstrap-init.es5.js
@@ -28,6 +28,7 @@ Joomla = window.Joomla || {};
 	};
 
 	jQuery(document).ready(function($) {
+	  Joomla.Bootstrap = {};
 
 		// Initialize some variables
 		var accordion = Joomla.getOptions('bootstrap.accordion'),
@@ -35,11 +36,87 @@ Joomla = window.Joomla || {};
 		    button = Joomla.getOptions('bootstrap.button'),
 		    carousel = Joomla.getOptions('bootstrap.carousel'),
 		    dropdown = Joomla.getOptions('bootstrap.dropdown'),
-		    modal = $('.joomla-modal'),
+		    modals = [].slice.call(document.querySelectorAll('.joomla-modal')),
 		    popover = Joomla.getOptions('bootstrap.popover'),
 		    scrollspy = Joomla.getOptions('bootstrap.scrollspy'),
 		    tabs = Joomla.getOptions('bootstrap.tabs'),
 		    tooltip = Joomla.getOptions('bootstrap.tooltip');
+
+    Joomla.Bootstrap.initModal = function(element) {
+      var $self = $(element);
+
+      // Comply with the Joomla API
+      // Bound element.open()
+      if (element) {
+        element.open = function () {
+          return $self.modal('show');
+        };
+
+        // Bound element.close()
+        element.close = function () {
+          return $self.modal('hide');
+        };
+      }
+
+      $self.on('show.bs.modal', function() {
+        // Comply with the Joomla API
+        // Set the current Modal ID
+        Joomla.Modal.setCurrent(element);
+
+        // @TODO throw the standard Joomla event
+        if ($self.data('url')) {
+          var modalBody = $self.find('.modal-body');
+          var el;
+          modalBody.find('iframe').remove();
+
+          // Hacks because com_associations and field modals use pure javascript in the url!
+          if ($self.data('iframe').indexOf("document.getElementById") > 0){
+            var iframeTextArr = $self.data('iframe').split('+');
+            var idFieldArr = iframeTextArr[1].split('"');
+
+            idFieldArr[0] = idFieldArr[0].replace(/&quot;/g,'"');
+
+            if (!document.getElementById(idFieldArr[1])) {
+              el = eval(idFieldArr[0]);
+            } else {
+              el = document.getElementById(idFieldArr[1]).value;
+            }
+
+            var data_iframe = iframeTextArr[0] + el + iframeTextArr[2];
+            modalBody.prepend(data_iframe);
+          } else {
+            modalBody.prepend($self.data('iframe'));
+          }
+        }
+      }).on('shown.bs.modal', function() {
+        var modalHeight = $('div.modal:visible').outerHeight(true),
+          modalHeaderHeight = $('div.modal-header:visible').outerHeight(true),
+          modalBodyHeightOuter = $('div.modal-body:visible').outerHeight(true),
+          modalBodyHeight = $('div.modal-body:visible').height(),
+          modalFooterHeight = $('div.modal-footer:visible').outerHeight(true),
+          padding = $self.offsetTop,
+          maxModalHeight = ($(window).height()-(padding*2)),
+          modalBodyPadding = (modalBodyHeightOuter-modalBodyHeight),
+          maxModalBodyHeight = maxModalHeight-(modalHeaderHeight+modalFooterHeight+modalBodyPadding);
+        if ($self.data('url')) {
+          var iframeHeight = $('.iframe').height();
+          if (iframeHeight > maxModalBodyHeight){
+            $('.modal-body').css({'max-height': maxModalBodyHeight, 'overflow-y': 'auto'});
+            $('.iframe').css('max-height', maxModalBodyHeight-modalBodyPadding);
+          }
+        }
+        // @TODO throw the standard Joomla event
+      }).on('hide.bs.modal', function() {
+        $('.modal-body').css({'max-height': 'initial'});
+        $('.modalTooltip').tooltip('dispose');
+        // @TODO throw the standard Joomla event
+      }).on('hidden.bs.modal', function() {
+        // Comply with the Joomla API
+        // Remove the current Modal ID
+        Joomla.Modal.setCurrent('');
+        // @TODO throw the standard Joomla event
+      });
+    };
 
 		/** Accordion **/
 		if (accordion) {
@@ -90,85 +167,8 @@ Joomla = window.Joomla || {};
 		}
 
 		/** Modals **/
-		if (modal.length) {
-			$.each($('.joomla-modal'), function() {
-				var $self = $(this);
-
-				// element.id is mandatory for modals!!!
-				var element = $self.get(0);
-
-				// Comply with the Joomla API
-				// Bound element.open()
-				if (element) {
-					element.open = function () {
-						return $self.modal('show');
-					};
-
-					// Bound element.close()
-					element.close = function () {
-						return $self.modal('hide');
-					};
-				}
-
-				$self.on('show.bs.modal', function() {
-					// Comply with the Joomla API
-					// Set the current Modal ID
-					Joomla.Modal.setCurrent(element);
-
-					// @TODO throw the standard Joomla event
-					if ($self.data('url')) {
-						var modalBody = $self.find('.modal-body');
-						var el;
-						modalBody.find('iframe').remove();
-
-						// Hacks because com_associations and field modals use pure javascript in the url!
-						if ($self.data('iframe').indexOf("document.getElementById") > 0){
-							var iframeTextArr = $self.data('iframe').split('+');
-							var idFieldArr = iframeTextArr[1].split('"');
-
-							idFieldArr[0] = idFieldArr[0].replace(/&quot;/g,'"');
-
-							if (!document.getElementById(idFieldArr[1])) {
-								el = eval(idFieldArr[0]);
-							} else {
-								el = document.getElementById(idFieldArr[1]).value;
-							}
-
-							var data_iframe = iframeTextArr[0] + el + iframeTextArr[2];
-							modalBody.prepend(data_iframe);
-						} else {
-							modalBody.prepend($self.data('iframe'));
-						}
-					}
-				}).on('shown.bs.modal', function() {
-					var modalHeight = $('div.modal:visible').outerHeight(true),
-					    modalHeaderHeight = $('div.modal-header:visible').outerHeight(true),
-					    modalBodyHeightOuter = $('div.modal-body:visible').outerHeight(true),
-					    modalBodyHeight = $('div.modal-body:visible').height(),
-					    modalFooterHeight = $('div.modal-footer:visible').outerHeight(true),
-					    padding = $self.offsetTop,
-					    maxModalHeight = ($(window).height()-(padding*2)),
-					    modalBodyPadding = (modalBodyHeightOuter-modalBodyHeight),
-					    maxModalBodyHeight = maxModalHeight-(modalHeaderHeight+modalFooterHeight+modalBodyPadding);
-					if ($self.data('url')) {
-						var iframeHeight = $('.iframe').height();
-						if (iframeHeight > maxModalBodyHeight){
-							$('.modal-body').css({'max-height': maxModalBodyHeight, 'overflow-y': 'auto'});
-							$('.iframe').css('max-height', maxModalBodyHeight-modalBodyPadding);
-						}
-					}
-					// @TODO throw the standard Joomla event
-				}).on('hide.bs.modal', function() {
-					$('.modal-body').css({'max-height': 'initial'});
-					$('.modalTooltip').tooltip('dispose');
-					// @TODO throw the standard Joomla event
-				}).on('hidden.bs.modal', function() {
-					// Comply with the Joomla API
-					// Remove the current Modal ID
-					Joomla.Modal.setCurrent('');
-					// @TODO throw the standard Joomla event
-				});
-			});
+		if (modals.length) {
+      modals.forEach((modal) => { Joomla.Bootstrap.initModal(modal); });
 		}
 
 		/** Popover **/

--- a/build/media_source/legacy/js/bootstrap-init.es5.js
+++ b/build/media_source/legacy/js/bootstrap-init.es5.js
@@ -168,7 +168,7 @@ Joomla = window.Joomla || {};
 
 		/** Modals **/
 		if (modals.length) {
-      modals.forEach((modal) => { Joomla.Bootstrap.initModal(modal); });
+      modals.forEach(function(modal){ Joomla.Bootstrap.initModal(modal); });
 		}
 
 		/** Popover **/

--- a/build/media_source/system/js/fields/joomla-field-media.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-media.w-c.es6.js
@@ -160,7 +160,20 @@
 
     connectedCallback() {
       this.button = this.querySelector(this.buttonSelect);
+      this.inputElement = this.querySelector(this.input);
       this.buttonClearEl = this.querySelector(this.buttonClear);
+      this.modalElement = this.querySelector(`.joomla-modal`);
+      this.buttonSaveSelectedElement = this.querySelector(this.buttonSaveSelected);
+      this.previewElement = this.querySelector('.field-media-preview');
+
+      if (!this.button || !this.inputElement || !this.buttonClearEl || !this.modalElement
+        || !this.buttonSaveSelectedElement) {
+        throw new Error('Misconfiguaration...');
+      }
+
+      if (typeof Joomla.Bootstrap.initModal === 'function') {
+        Joomla.Bootstrap.initModal(this.modalElement);
+      }
 
       this.button.addEventListener('click', this.show);
 
@@ -181,7 +194,6 @@
     }
 
     onSelected(event) {
-      // event.target.removeEventListener('click', this.onSelected);
       event.preventDefault();
       event.stopPropagation();
 
@@ -190,24 +202,15 @@
     }
 
     show() {
-      const button = this.querySelector(this.buttonSaveSelected);
-      const modalElement = this.querySelector(`#imageModal_${this.querySelector(this.input).id}`);
-
-      if (!button || !modalElement) {
-        throw new Error('Misconfiguaration...');
-      }
-
-      modalElement.open();
+      this.modalElement.open();
 
       Joomla.selectedFile = {};
 
-      button.addEventListener('click', this.onSelected);
+      this.buttonSaveSelectedElement.addEventListener('click', this.onSelected);
     }
 
     modalClose() {
-      const input = this.querySelector(this.input);
-
-      Joomla.getImage(Joomla.selectedFile, input, this)
+      Joomla.getImage(Joomla.selectedFile, this.inputElement, this)
         .then(() => {
           Joomla.Modal.getCurrent().close();
           Joomla.selectedFile = {};
@@ -222,7 +225,7 @@
     }
 
     setValue(value) {
-      this.querySelector(this.input).value = value;
+      this.inputElement.value = value;
       this.updatePreview();
     }
 
@@ -231,20 +234,18 @@
     }
 
     updatePreview() {
-      if (['true', 'static'].indexOf(this.preview) === -1 || this.preview === 'false') {
+      if (['true', 'static'].indexOf(this.preview) === -1 || this.preview === 'false' || !this.previewElement) {
         return;
       }
 
       // Reset preview
       if (this.preview) {
-        const input = this.querySelector(this.input);
-        const { value } = input;
-        const div = this.querySelector('.field-media-preview');
+        const { value } = this.inputElement;
 
         if (!value) {
-          div.innerHTML = '<span class="field-media-preview-icon"></span>';
+          this.previewElement.innerHTML = '<span class="field-media-preview-icon"></span>';
         } else {
-          div.innerHTML = '';
+          this.previewElement.innerHTML = '';
           const imgPreview = new Image();
 
           switch (this.type) {
@@ -257,8 +258,8 @@
               break;
           }
 
-          div.style.width = this.previewWidth;
-          div.appendChild(imgPreview);
+          this.previewElement.style.width = this.previewWidth;
+          this.previewElement.appendChild(imgPreview);
         }
       }
     }

--- a/build/media_source/system/js/fields/joomla-field-media.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-media.w-c.es6.js
@@ -171,7 +171,7 @@
         throw new Error('Misconfiguaration...');
       }
 
-      if (Joomla.Bootstrap || Joomla.Bootstrap.initModal || typeof Joomla.Bootstrap.initModal === 'function') {
+      if (Joomla.Bootstrap && Joomla.Bootstrap.initModal && typeof Joomla.Bootstrap.initModal === 'function') {
         Joomla.Bootstrap.initModal(this.modalElement);
       }
 

--- a/build/media_source/system/js/fields/joomla-field-media.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-media.w-c.es6.js
@@ -171,7 +171,7 @@
         throw new Error('Misconfiguaration...');
       }
 
-      if (typeof Joomla.Bootstrap.initModal === 'function') {
+      if (!Joomla.Bootstrap || !Joomla.Bootstrap.initModal || typeof Joomla.Bootstrap.initModal === 'function') {
         Joomla.Bootstrap.initModal(this.modalElement);
       }
 

--- a/build/media_source/system/js/fields/joomla-field-media.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-media.w-c.es6.js
@@ -171,7 +171,7 @@
         throw new Error('Misconfiguaration...');
       }
 
-      if (!Joomla.Bootstrap || !Joomla.Bootstrap.initModal || typeof Joomla.Bootstrap.initModal === 'function') {
+      if (Joomla.Bootstrap || Joomla.Bootstrap.initModal || typeof Joomla.Bootstrap.initModal === 'function') {
         Joomla.Bootstrap.initModal(this.modalElement);
       }
 

--- a/build/media_source/system/js/fields/joomla-field-media.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-media.w-c.es6.js
@@ -194,7 +194,7 @@
       const modalElement = this.querySelector(`#imageModal_${this.querySelector(this.input).id}`);
 
       if (!button || !modalElement) {
-        throw new Error('Misconfiguaration...');
+        throw new Error('Misconfiguration...');
       }
 
       modalElement.open();

--- a/build/media_source/system/js/fields/joomla-field-media.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-media.w-c.es6.js
@@ -89,6 +89,9 @@
       this.onSelected = this.onSelected.bind(this);
       this.show = this.show.bind(this);
       this.clearValue = this.clearValue.bind(this);
+      this.modalClose = this.modalClose.bind(this);
+      this.setValue = this.setValue.bind(this);
+      this.updatePreview = this.updatePreview.bind(this);
     }
 
     static get observedAttributes() {
@@ -158,11 +161,6 @@
     connectedCallback() {
       this.button = this.querySelector(this.buttonSelect);
       this.buttonClearEl = this.querySelector(this.buttonClear);
-      this.show = this.show.bind(this);
-      this.modalClose = this.modalClose.bind(this);
-      this.clearValue = this.clearValue.bind(this);
-      this.setValue = this.setValue.bind(this);
-      this.updatePreview = this.updatePreview.bind(this);
 
       this.button.addEventListener('click', this.show);
 
@@ -192,11 +190,18 @@
     }
 
     show() {
-      this.querySelector('[role="dialog"]').open();
+      const button = this.querySelector(this.buttonSaveSelected);
+      const modalElement = this.querySelector(`#imageModal_${this.querySelector(this.input).id}`);
+
+      if (!button || !modalElement) {
+        throw new Error('Misconfiguaration...');
+      }
+
+      modalElement.open();
 
       Joomla.selectedFile = {};
 
-      this.querySelector(this.buttonSaveSelected).addEventListener('click', this.onSelected);
+      button.addEventListener('click', this.onSelected);
     }
 
     modalClose() {

--- a/build/media_source/system/js/fields/joomla-field-media.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-media.w-c.es6.js
@@ -162,7 +162,7 @@
       this.button = this.querySelector(this.buttonSelect);
       this.inputElement = this.querySelector(this.input);
       this.buttonClearEl = this.querySelector(this.buttonClear);
-      this.modalElement = this.querySelector(`.joomla-modal`);
+      this.modalElement = this.querySelector('.joomla-modal');
       this.buttonSaveSelectedElement = this.querySelector(this.buttonSaveSelected);
       this.previewElement = this.querySelector('.field-media-preview');
 


### PR DESCRIPTION
Pull Request for Issue #30453 .

### Summary of Changes

- Bug fix
- Remove duplicate bindings

### Testing Instructions
- Download  and install the module from @Razzo1987
- Create a Swiper Slider module
- Go to "Options" tab
- Select a Background Image
- Try to select a different image
- Remove the image with the X button
- Try to select an image 
- add more fields and repeat the previous steps


### Actual result BEFORE applying this Pull Request

Modal doesn't open as expected

### Expected result AFTER applying this Pull Request

Modal  opens as expected

### Documentation Changes Required

Nope


PS a note here: 
- All Bootstrap init functions need a similar approach, so whenever a Bootstrap component is added programmatically it can be initialised.
- This is largely unneeded if all the components were custom elements. Custom elements have lifecycle events and therefore the initialisation can happen on the `connectedCallback`, no extra fuzz, they just work...