### PR TITLE
[4.0] Convert icon used for jgrid defaults to fas fa-

### DIFF
--- a/administrator/components/com_menus/tmpl/items/default.php
+++ b/administrator/components/com_menus/tmpl/items/default.php
@@ -211,7 +211,7 @@ $assoc   = Associations::isEnabled() && $this->state->get('filter.client_id') ==
 									<td class="text-center d-none d-md-table-cell">
 										<?php if ($item->type == 'component') : ?>
 											<?php if ($item->language == '*' || $item->home == '0') : ?>
-												<?php echo HTMLHelper::_('jgrid.isdefault', $item->home, $i, 'items.', ($item->language != '*' || !$item->home) && $canChange && !$item->protected, 'cb', null, 'home', 'circle'); ?>
+												<?php echo HTMLHelper::_('jgrid.isdefault', $item->home, $i, 'items.', ($item->language != '*' || !$item->home) && $canChange && !$item->protected, 'cb', null, 'fa-home', 'fa-circle'); ?>
 											<?php elseif ($canChange) : ?>
 												<a href="<?php echo Route::_('index.php?option=com_menus&task=items.unsetDefault&cid[]=' . $item->id . '&' . Session::getFormToken() . '=1'); ?>">
 													<?php if ($item->language_image) : ?>

--- a/libraries/src/HTML/Helpers/JGrid.php
+++ b/libraries/src/HTML/Helpers/JGrid.php
@@ -96,7 +96,7 @@ abstract class JGrid
 			}
 			elseif (strpos($active_class, 'icon-') !== false)
 			{
-				$active_class = 'icon-' . $active_class;
+				$active_class = $active_class;
 			}
 			elseif ($active_class === 'publish')
 			{
@@ -149,7 +149,7 @@ abstract class JGrid
 				}
 				elseif (strpos($inactive_class, 'icon-') !== false)
 				{
-					$inactive_class = 'icon-' . $inactive_class;
+					$inactive_class = $inactive_class;
 				}
 				elseif ($inactive_class === 'publish')
 				{

--- a/libraries/src/HTML/Helpers/JGrid.php
+++ b/libraries/src/HTML/Helpers/JGrid.php
@@ -90,9 +90,13 @@ abstract class JGrid
 			$html[] = $tip ? ' aria-labelledby="' . $ariaid . '"' : '';
 			$html[] = '>';
 
-			if (strpos($active_class, 'fa-') == true || strpos($active_class, 'icon-') == true)
+			if (strpos($active_class, 'fa-') !== false)
 			{
-				$active_class = $active_class;
+				$active_class = 'fas ' . $active_class;
+			}
+			elseif (strpos($active_class, 'icon-') !== false)
+			{
+				$active_class = 'icon-' . $active_class;
 			}
 			elseif ($active_class === 'publish')
 			{
@@ -139,9 +143,13 @@ abstract class JGrid
 			}
 			else
 			{
-				if (strpos($inactive_class, 'fa-') == true || strpos($inactive_class, 'icon-') == true)
+				if (strpos($inactive_class, 'fa-') !== false)
 				{
-					$inactive_class = $inactive_class;
+					$inactive_class = 'fas ' . $inactive_class;
+				}
+				elseif (strpos($inactive_class, 'icon-') !== false)
+				{
+					$inactive_class = 'icon-' . $inactive_class;
 				}
 				elseif ($inactive_class === 'publish')
 				{


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
changes the icon used for grid defaults to fas fa-

### Testing Instructions
go to administrator/index.php?option=com_menus&view=items&menutype=0main-menu-blog inspect circle icon
go to administrator/index.php?option=com_menus&view=items&menutype=mainmenu inspect home icon
apply pr
both icons should not change but inspect should show fas fa-

### Actual result BEFORE applying this Pull Request
![image](https://user-images.githubusercontent.com/1850089/91054408-61d96800-e5e9-11ea-9d60-13b489ed31ca.png)
![image](https://user-images.githubusercontent.com/1850089/91054600-6dc52a00-e5e9-11ea-9276-0a84647ed4a5.png)



### Expected result AFTER applying this Pull Request
![image](https://user-images.githubusercontent.com/1850089/91054010-479f8a00-e5e9-11ea-93d2-bc5c6da3a8db.png)
![image](https://user-images.githubusercontent.com/1850089/91053972-3bb3c800-e5e9-11ea-9e52-7432434d3e37.png)


### Documentation Changes Required
none
