### PR TITLE
[4.0] Long labels wrapping

### DIFF
--- a/administrator/templates/atum/scss/blocks/_utilities.scss
+++ b/administrator/templates/atum/scss/blocks/_utilities.scss
@@ -41,6 +41,10 @@
     &.hidden {
       display: none;
     }
+
+    .control-label {
+      width: 100%;
+    }
   }
 
   .form-no-columns & {


### PR DESCRIPTION
When we have fields displayed in columns with the label displayed above the input there is a width limit of 240px on the label.

This results in long labels wrapping when it is not needed as the column is wider than 240px.

In English we do'nt see this is many places but the easiest is in the __configure edit screen_  fields of an article

This simple PR changes the label width to 100% when the fields are displayed in columns like this.

As this is an scss change you will need to `node build.js --compile-css` in order to test

### Before
![image](https://user-images.githubusercontent.com/1296369/91159906-a6840280-e6c0-11ea-941f-ca5f7a4c15f5.png)


### After
![image](https://user-images.githubusercontent.com/1296369/91159875-9704b980-e6c0-11ea-8125-fa940119b189.png)

