### PR TITLE
Fix token check when removing data via privacy removal request

### DIFF
--- a/administrator/components/com_privacy/controllers/request.php
+++ b/administrator/components/com_privacy/controllers/request.php
@@ -287,7 +287,7 @@ class PrivacyControllerRequest extends JControllerForm
 	public function remove()
 	{
 		// Check for request forgeries.
-		JSession::checkToken('get') or jexit(JText::_('JINVALID_TOKEN'));
+		JSession::checkToken('request') or jexit(JText::_('JINVALID_TOKEN'));
 
 		/** @var PrivacyModelRemove $model */
 		$model = $this->getModel('Remove');

--- a/administrator/components/com_privacy/controllers/request.php
+++ b/administrator/components/com_privacy/controllers/request.php
@@ -287,7 +287,7 @@ class PrivacyControllerRequest extends JControllerForm
 	public function remove()
 	{
 		// Check for request forgeries.
-		JSession::checkToken('request') or jexit(JText::_('JINVALID_TOKEN'));
+		$this->checkToken('request');
 
 		/** @var PrivacyModelRemove $model */
 		$model = $this->getModel('Remove');


### PR DESCRIPTION
Fixes https://github.com/joomla/joomla-cms/issues/30478.

### Summary of Changes

Fixes removing user data from request view.

### Testing Instructions

Create a data removal request and confirm it.
Open the request in backend.
Click `Delete Data` button in toolbar.

### Actual result BEFORE applying this Pull Request

White page with text:

>The most recent request was denied because it had an invalid security token. Please refresh the page and try again.

### Expected result AFTER applying this Pull Request

Data removed.

### Documentation Changes Required

No.