### PR TITLE
[4.0] fix improper icon family name.

### DIFF
--- a/libraries/src/Button/FeaturedButton.php
+++ b/libraries/src/Button/FeaturedButton.php
@@ -29,7 +29,7 @@ class FeaturedButton extends ActionButton
 	 */
 	protected function preprocess()
 	{
-		$this->addState(0, 'articles.featured', 'icon-color-unfeatured far fa-star',
+		$this->addState(0, 'articles.featured', 'icon-color-unfeatured fas fa-star',
 			Text::_('JGLOBAL_TOGGLE_FEATURED'), ['tip_title' => Text::_('COM_CONTENT_UNFEATURED')]
 		);
 		$this->addState(1, 'articles.unfeatured', 'icon-color-featured fas fa-star',


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
change far to fas.

### Testing Instructions
inspect administrator/index.php?option=com_content&view=articles featured icon
![image](https://user-images.githubusercontent.com/1850089/91245846-11125e00-e714-11ea-9255-2f287c19c360.png)
apply pr
should now show correct family and same icon.

### Actual result BEFORE applying this Pull Request
![image](https://user-images.githubusercontent.com/1850089/91245846-11125e00-e714-11ea-9255-2f287c19c360.png)

### Expected result AFTER applying this Pull Request
![image](https://user-images.githubusercontent.com/1850089/91245925-47e87400-e714-11ea-8107-382493afd619.png)

### Documentation Changes Required
Joomla! 4.0 only supports "fab" and "fas" font families in the admin, since they are free families.