### PR TITLE
Helper/TagsHelper: fix strpos args order

### DIFF
--- a/libraries/src/Helper/TagsHelper.php
+++ b/libraries/src/Helper/TagsHelper.php
@@ -66,7 +66,7 @@ class TagsHelper extends CMSHelper
 		$typeId = $this->getTypeId($this->typeAlias);
 
 		// Insert the new tag maps
-		if (strpos('#', implode(',', $tags)) === false)
+		if (strpos(implode(',', $tags), '#') === false)
 		{
 			$tags = self::createTagsFromField($tags);
 		}


### PR DESCRIPTION
### Summary of Changes

Fixes the strpos call.
`strpos()` first argument is a haystack, not a needle.
`strpos('x', $s)` is identical to `$s === 'x'` which is probably not what we want here.

### Testing Instructions

?

### Actual result BEFORE applying this Pull Request

?

### Expected result AFTER applying this Pull Request

?

### Documentation Changes Required

None.