### PR TITLE
[4.0] Add new permissions-policy to the HTTPHeaders Plugin

### DIFF
--- a/plugins/system/httpheaders/httpheaders.php
+++ b/plugins/system/httpheaders/httpheaders.php
@@ -79,6 +79,7 @@ class PlgSystemHttpHeaders extends CMSPlugin implements SubscriberInterface
 		'expect-ct',
 		'feature-policy',
 		'cross-origin-opener-policy',
+		'permissions-policy',
 	];
 
 	/**

--- a/plugins/system/httpheaders/httpheaders.xml
+++ b/plugins/system/httpheaders/httpheaders.xml
@@ -80,6 +80,7 @@
 							<option value="expect-ct">Expect-CT</option>
 							<option value="feature-policy">Feature-Policy</option>
 							<option value="cross-origin-opener-policy">Cross-Origin-Opener-Policy</option>
+							<option value="permissions-policy">Permissions-Policy</option>
 						</field>
 						<field
 							name="value"

--- a/plugins/system/httpheaders/httpheaders.xml
+++ b/plugins/system/httpheaders/httpheaders.xml
@@ -72,15 +72,15 @@
 							validate="options"
 							class="col-md-4"
 							>
-							<option value="strict-transport-security">Strict-Transport-Security</option>
 							<option value="content-security-policy">Content-Security-Policy</option>
 							<option value="content-security-policy-report-only">Content-Security-Policy-Report-Only</option>
-							<option value="x-frame-options">X-Frame-Options</option>
-							<option value="referrer-policy">Referrer-Policy</option>
+							<option value="cross-origin-opener-policy">Cross-Origin-Opener-Policy</option>
 							<option value="expect-ct">Expect-CT</option>
 							<option value="feature-policy">Feature-Policy</option>
-							<option value="cross-origin-opener-policy">Cross-Origin-Opener-Policy</option>
 							<option value="permissions-policy">Permissions-Policy</option>
+							<option value="referrer-policy">Referrer-Policy</option>
+							<option value="strict-transport-security">Strict-Transport-Security</option>
+							<option value="x-frame-options">X-Frame-Options</option>
 						</field>
 						<field
 							name="value"


### PR DESCRIPTION
Pull Request for Issue https://github.com/w3c/webappsec-permissions-policy/pull/379

### Summary of Changes

The Feature-policy has been renamed to permissions-policy: https://github.com/w3c/webappsec-permissions-policy/pull/379

More details:
https://www.chromestatus.com/feature/5745992911552512
https://groups.google.com/a/chromium.org/forum/#!msg/blink-dev/As1ABvc2QdA/yZSpPXY4CAAJ

### Testing Instructions

Make sure you can now set feature-policy and permissions-policy.

### Actual result BEFORE applying this Pull Request

We could only set feature-policy

### Expected result AFTER applying this Pull Request

we can set feature + permissions-policy

### Documentation Changes Required

Docpage has been updated: https://docs.joomla.org/J4.x:Http_Header_Management