### PR TITLE
Minor cleanups in Language Filter plugin

### DIFF
--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -775,7 +775,7 @@ class PlgSystemLanguageFilter extends JPlugin
 
 			// Load component associations.
 			$option = $this->app->input->get('option');
-			$cName = StringHelper::ucfirst(StringHelper::str_ireplace('com_', '', $option)) . 'HelperAssociation';
+			$cName = ucfirst(str_ireplace('com_', '', $option)) . 'HelperAssociation';
 			JLoader::register($cName, JPath::clean(JPATH_COMPONENT_SITE . '/helpers/association.php'));
 
 			if (class_exists($cName) && is_callable(array($cName, 'getAssociations')))

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -776,7 +776,7 @@ class PlgSystemLanguageFilter extends JPlugin
 			// Load component associations.
 			$option = $this->app->input->get('option');
 			$cName = ucfirst(substr($option, 4)) . 'HelperAssociation';
-			JLoader::register($cName, JPath::clean(JPATH_COMPONENT_SITE . '/helpers/association.php'));
+			JLoader::register($cName, JPath::clean(JPATH_SITE . '/components/' . $option . '/helpers/association.php'));
 
 			if (class_exists($cName) && is_callable(array($cName, 'getAssociations')))
 			{

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -784,7 +784,7 @@ class PlgSystemLanguageFilter extends JPlugin
 			}
 
 			// For each language...
-			foreach ($languages as $i => &$language)
+			foreach ($languages as $i => $language)
 			{
 				switch (true)
 				{
@@ -833,7 +833,7 @@ class PlgSystemLanguageFilter extends JPlugin
 									= preg_replace('|/' . $languages[$this->default_lang]->sef . '/|', '/', $languages[$this->default_lang]->link, 1);
 				}
 
-				foreach ($languages as $i => &$language)
+				foreach ($languages as $i => $language)
 				{
 					$doc->addHeadLink($server . $language->link, 'alternate', 'rel', array('hreflang' => $i));
 				}

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -775,7 +775,7 @@ class PlgSystemLanguageFilter extends JPlugin
 
 			// Load component associations.
 			$option = $this->app->input->get('option');
-			$cName = ucfirst(str_ireplace('com_', '', $option)) . 'HelperAssociation';
+			$cName = ucfirst(substr($option, 4)) . 'HelperAssociation';
 			JLoader::register($cName, JPath::clean(JPATH_COMPONENT_SITE . '/helpers/association.php'));
 
 			if (class_exists($cName) && is_callable(array($cName, 'getAssociations')))


### PR DESCRIPTION
### Summary of Changes

Removed unnecessary use of `Joomla\String\StringHelper`.
Simplified string manipulation.
Removed use of `JPATH_COMPONENT` constant.
Removed unnecessary reference symbols.

### Testing Instructions

Set up a multilingual site.
Test that site works.
Inspect `hreflang` links in page source code.

### Expected result AFTER applying this Pull Request

Works like before.

### Documentation Changes Required

No.