### PR TITLE
[3.x] alphanumeric validation rule

### DIFF
--- a/administrator/components/com_languages/models/forms/language.xml
+++ b/administrator/components/com_languages/models/forms/language.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <form>
 	<fieldset>
-		<field 
-			name="lang_id" 
+		<field
+			name="lang_id"
 			type="text"
 			label="JGLOBAL_FIELD_ID_LABEL"
 			description="JGLOBAL_FIELD_ID_DESC"
@@ -11,8 +11,8 @@
 			readonly="true"
 		/>
 
-		<field 
-			name="lang_code" 
+		<field
+			name="lang_code"
 			type="text"
 			label="COM_LANGUAGES_FIELD_LANG_TAG_LABEL"
 			description="COM_LANGUAGES_FIELD_LANG_TAG_DESC"
@@ -21,7 +21,7 @@
 			size="10"
 		/>
 
-		<field 
+		<field
 			name="title"
 			type="text"
 			label="JGLOBAL_TITLE"
@@ -31,7 +31,7 @@
 			size="40"
 		/>
 
-		<field 
+		<field
 			name="title_native"
 			type="text"
 			label="COM_LANGUAGES_FIELD_TITLE_NATIVE_LABEL"
@@ -41,11 +41,12 @@
 			size="40"
 		/>
 
-		<field 
-			name="sef" 
+		<field
+			name="sef"
 			type="text"
 			label="COM_LANGUAGES_FIELD_LANG_CODE_LABEL"
 			description="COM_LANGUAGES_FIELD_LANG_CODE_DESC"
+			validate="alphanumeric"
 			maxlength="50"
 			required="true"
 			size="10"
@@ -66,8 +67,8 @@
 			<option value="">JNONE</option>
 		</field>
 
-		<field 
-			name="description" 
+		<field
+			name="description"
 			type="textarea"
 			label="JGLOBAL_DESCRIPTION"
 			description="COM_LANGUAGES_FIELD_DESCRIPTION_DESC"
@@ -75,8 +76,8 @@
 			rows="5"
 		/>
 
-		<field 
-			name="published" 
+		<field
+			name="published"
 			type="list"
 			label="JSTATUS"
 			description="COM_LANGUAGES_FIELD_PUBLISHED_DESC"
@@ -87,9 +88,9 @@
 			<option value="0">JUNPUBLISHED</option>
 			<option value="-2">JTRASHED</option>
 		</field>
-		
-		<field 
-			name="access" 
+
+		<field
+			name="access"
 			type="accesslevel"
 			label="JFIELD_ACCESS_LABEL"
 			description="JFIELD_ACCESS_DESC"
@@ -97,8 +98,8 @@
 		/>
 	</fieldset>
 	<fieldset name="metadata" label="JGLOBAL_FIELDSET_METADATA_OPTIONS">
-		<field 
-			name="metakey" 
+		<field
+			name="metakey"
 			type="textarea"
 			label="JFIELD_META_KEYWORDS_LABEL"
 			description="JFIELD_META_KEYWORDS_DESC"
@@ -106,8 +107,8 @@
 			cols="30"
 		/>
 
-		<field 
-			name="metadesc" 
+		<field
+			name="metadesc"
 			type="textarea"
 			label="JFIELD_META_DESCRIPTION_LABEL"
 			description="JFIELD_META_DESCRIPTION_DESC"
@@ -116,8 +117,8 @@
 		/>
 	</fieldset>
 	<fieldset name="site_name" label="COM_LANGUAGES_FIELDSET_SITE_NAME_LABEL">
-		<field 
-			name="sitename" 
+		<field
+			name="sitename"
 			type="text"
 			label="COM_LANGUAGES_FIELD_SITE_NAME_LABEL"
 			description="COM_LANGUAGES_FIELD_SITE_NAME_DESC"

--- a/libraries/src/Form/Rule/AlphanumericRule.php
+++ b/libraries/src/Form/Rule/AlphanumericRule.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  Copyright (C) 2005 - 2020 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Form\Rule;
+
+defined('JPATH_PLATFORM') or die;
+
+use Joomla\CMS\Form\Form;
+use Joomla\CMS\Form\FormRule;
+use Joomla\Registry\Registry;
+
+/**
+ * Form Rule class for the Joomla Platform.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class AlphanumericRule extends FormRule
+{
+	/**
+	 * Method to test for alphanumeric characters only.
+	 *
+	 * @param   \SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
+	 * @param   mixed              $value    The form field value to validate.
+	 * @param   string             $group    The field name group control value. This acts as an array container for the field.
+	 *                                       For example if the field has name="foo" and the group value is set to "bar" then the
+	 *                                       full field name would end up being "bar[foo]".
+	 * @param   Registry           $input    An optional Registry object with the entire data set to validate against the entire form.
+	 * @param   Form               $form     The form object for which the field is being tested.
+	 *
+	 * @return  boolean  True if the value is valid, false otherwise.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function test(\SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
+	{
+		$value = trim($value);
+
+		// If the field is empty and not required, the field is valid.
+		$required = ((string) $element['required'] == 'true' || (string) $element['required'] == 'required');
+
+		if (!$required && empty($value))
+		{
+			return true;
+		}
+
+        // The value must be alphanumeric characters only
+		if (!ctype_alnum($value))
+		{
+			return false;
+		}
+
+		return true;
+	}
+}

--- a/libraries/src/Form/Rule/AlphanumericRule.php
+++ b/libraries/src/Form/Rule/AlphanumericRule.php
@@ -48,7 +48,7 @@ class AlphanumericRule extends FormRule
 			return true;
 		}
 
-        // The value must be alphanumeric characters only
+		// The value must be alphanumeric characters only
 		if (!ctype_alnum($value))
 		{
 			return false;


### PR DESCRIPTION
### Summary of Changes
This PR prevents saving a Content Language when its Url Language Code is empty.
Alternative to #30496

### Testing Instructions
Try to save the URL Language Code field using non alphanumeric characters eg #~@


### Actual result BEFORE applying this Pull Request
Language Saved


### Expected result AFTER applying this Pull Request
Invalid field: URL Language Code



### Documentation Changes Required
Add rule to the list https://docs.joomla.org/J3.x:Server-side_form_validation ?
