### PR TITLE
Fix page break title when title attribute is after class

### DIFF
--- a/plugins/content/pagebreak/pagebreak.php
+++ b/plugins/content/pagebreak/pagebreak.php
@@ -154,9 +154,9 @@ class PlgContentPagebreak extends JPlugin
 			$hasToc = $this->params->get('multipage_toc', 1);
 
 			// Adds heading or title to <site> Title.
-			if ($title && $page && isset($matches[$page - 1], $matches[$page - 1][2]))
+			if ($title && $page && isset($matches[$page - 1][0]))
 			{
-				$attrs = JUtility::parseAttributes($matches[$page - 1][1]);
+				$attrs = JUtility::parseAttributes($matches[$page - 1][0]);
 
 				if (isset($attrs['title']))
 				{


### PR DESCRIPTION
Fixes https://github.com/joomla/joomla-cms/issues/30518.

### Summary of Changes

Fixes page break title when title attribute is placed after class attribute containing `system-pagebreak` class.

### Testing Instructions

Use CodeMirror as editor.
Create a multipage article.
Change attribute order in page break's `<hr>` tag so `title` is after `class`, e.g.:

```
<p>Page 1.</p>
<hr alt="Page 2 Alt" class="system-pagebreak" title="Page 2 Title" />
<p>Page 2.</p>
<hr title="Page 3 Title" alt="Page 3 Alt" class="system-pagebreak" />
<p>Page 3.</p>
```
View Page 2 and Page 3 of the article.

### Actual result BEFORE applying this Pull Request

Title from `title` attribute shown only on Page 3.

### Expected result AFTER applying this Pull Request

Titles from  `title` attribute are shown on both pages.

### Documentation Changes Required

No.