### PR TITLE
[4.0] [webauthn] Set a default site name when the option is empty

### DIFF
--- a/plugins/system/webauthn/src/Helper/CredentialsCreation.php
+++ b/plugins/system/webauthn/src/Helper/CredentialsCreation.php
@@ -75,7 +75,7 @@ abstract class CredentialsCreation
 		try
 		{
 			$app      = Factory::getApplication();
-			$siteName = $app->getConfig()->get('sitename');
+			$siteName = $app->getConfig()->get('sitename', 'Joomla! Site');
 		}
 		catch (Exception $e)
 		{


### PR DESCRIPTION
Pull Request for Issue #30517 cc @Formatio-hippocampi

### Summary of Changes

Make sure an empty sitename does not break webauthn and fallbacks to a default site name.

### Testing Instructions

- Install J4 at launch.joomla.org
- open User-Account
- Tabs are below each other; "W3C Web Authentication (WebAuthn) Login" show Error:
![Screenshot_2020-08-30 Error 0](https://user-images.githubusercontent.com/70466955/91654932-440a7800-eaad-11ea-90ee-a6e8aa938a10.png)

### Actual result BEFORE applying this Pull Request

![Screenshot_2020-08-30 Error 0](https://user-images.githubusercontent.com/70466955/91654932-440a7800-eaad-11ea-90ee-a6e8aa938a10.png)

### Expected result AFTER applying this Pull Request

Default Sitename is choosen when there is no configured

### Documentation Changes Required

none.