### PR TITLE
[3.x] When there are no exception the filePath Rule should pass.

### DIFF
--- a/libraries/src/Form/Rule/FilePathRule.php
+++ b/libraries/src/Form/Rule/FilePathRule.php
@@ -62,6 +62,8 @@ class FilePathRule extends FormRule
 			return false;
 		}
 
-		return $value === $path;
+		// When there are no exception this rule should pass.
+		// https://github.com/joomla/joomla-cms/issues/30500#issuecomment-683290162
+		return true;
 	}
 }

--- a/libraries/src/Form/Rule/FilePathRule.php
+++ b/libraries/src/Form/Rule/FilePathRule.php
@@ -54,7 +54,7 @@ class FilePathRule extends FormRule
 
 		try
 		{
-			$path = Path::check($value);
+			Path::check($value);
 		}
 		catch (\Exception $e)
 		{

--- a/libraries/src/Form/Rule/FilePathRule.php
+++ b/libraries/src/Form/Rule/FilePathRule.php
@@ -63,7 +63,7 @@ class FilePathRule extends FormRule
 		}
 
 		// When there are no exception this rule should pass.
-		// https://github.com/joomla/joomla-cms/issues/30500#issuecomment-683290162
+		// See: https://github.com/joomla/joomla-cms/issues/30500#issuecomment-683290162
 		return true;
 	}
 }


### PR DESCRIPTION
Pull Request for Issue #30500 cc @Webdongle @SharkyKZ 

### Summary of Changes

Make sure the filepath rule passes when there are no exception from Path::check

### Testing Instructions

try to save the com_media options on a windows system

### Actual result BEFORE applying this Pull Request

Error
Invalid field: Path to Files Folder
Invalid field: Path to Images Folder

### Expected result AFTER applying this Pull Request

Works fine

### Documentation Changes Required

none-