### PR TITLE
Update default_updated_files.php

### DIFF
--- a/administrator/components/com_templates/tmpl/template/default_updated_files.php
+++ b/administrator/components/com_templates/tmpl/template/default_updated_files.php
@@ -56,7 +56,7 @@ $input = Factory::getApplication()->input;
 										<?php echo HTMLHelper::_('jgrid.published', $value->state, $i, 'template.', 1, 'cb', null, null, 'updateForm'); ?>
 									</td>
 									<td>
-										<a href="<?php echo Route::_('index.php?option=com_templates&view=template&id=' . (int) $value->extension_id . '&file=' . $value->hash_id); ?>" title="<?php echo Text::_('JACTION_EDIT'); ?>"><?php echo base64_decode($value->hash_id); ?></a>
+										<a href="<?php echo Route::_('index.php?option=com_templates&view=template&id=' . (int) $value->extension_id . '&file=' . $value->hash_id); ?>" title="<?php echo Text::_('JACTION_EDIT'); ?>"><?php echo \base64_decode($value->hash_id); ?></a>
 									</td>
 									<td>
 										<?php $created_date = $value->created_date; ?>


### PR DESCRIPTION
Pull Request for Issue #30494 .

### Summary of Changes
Change
`<?php echo base64_decode($value->hash_id); ?>` with `<?php echo \base64_decode($value->hash_id); ?>` to circumvent the recognition of "echo base64_decode" as a virus in cPanel (false positive).


### Testing Instructions

1. Try to upload in cPanel file manager the compiled zip file (NO PATCH TESTER) from https://ci.joomla.org/artifacts/joomla/joomla-cms/4.0-dev/30529/downloads/35140
2. _I don't know how to test `default_updated_files.php` functionality_


### Actual result BEFORE applying this Pull Request
1. Uploading alert a Virus in the ZIP file:
![immagine](https://user-images.githubusercontent.com/906604/91418430-6c4a6a80-e852-11ea-8edf-0d23f1f40a35.png)
2. _Test of `default_updated_files.php`_

### Expected result AFTER applying this Pull Request
1. Uploading success:
![immagine](https://user-images.githubusercontent.com/906604/91752187-3f85b280-ebc6-11ea-9b69-2625e2b8a289.png)
2. _Test of `default_updated_files.php`_


### Documentation Changes Required


### cPanel version affected
86.0.22 :red_circle: 
88.0 :green_circle: 
