### PR TITLE
[4.0] com_finder ul instead of dl for easier styling

### DIFF
--- a/components/com_finder/tmpl/search/default_result.php
+++ b/components/com_finder/tmpl/search/default_result.php
@@ -100,8 +100,8 @@ if ($show_description)
 		</time>
 	<?php endif; ?>
 	<?php if ($this->params->get('show_url', 1)) : ?>
-		<dd class="result-url small">
+		<p class="result-url small">
 			<?php echo $this->baseUrl, Route::_($this->result->cleanURL); ?>
-		</dd>
+		</p>
 	<?php endif; ?>
 </li>

--- a/components/com_finder/tmpl/search/default_result.php
+++ b/components/com_finder/tmpl/search/default_result.php
@@ -54,52 +54,54 @@ if ($show_description)
 	$description = HTMLHelper::_('string.truncate', StringHelper::substr($full_description, $start), $desc_length, true);
 }
 ?>
-<dt class="result-title">
-	<h4 class="result-title <?php echo $mime; ?>">
-		<?php if ($this->result->route) : ?>
-			<a href="<?php echo Route::_($this->result->route); ?>">
+<li class="result-title">
+	<header class="result-title">
+		<h4 class="result-title <?php echo $mime; ?>">
+			<?php if ($this->result->route) : ?>
+				<a href="<?php echo Route::_($this->result->route); ?>">
+					<?php echo $this->result->title; ?>
+				</a>
+			<?php else : ?>
 				<?php echo $this->result->title; ?>
-			</a>
-		<?php else : ?>
-			<?php echo $this->result->title; ?>
-		<?php endif; ?>
-	</h4>
-</dt>
-
-<?php $taxonomies = $this->result->getTaxonomy(); ?>
-<?php if (count($taxonomies) && $this->params->get('show_taxonomy', 1)) : ?>
-	<dd class="result-taxonomy">
-	<?php foreach ($taxonomies as $type => $taxonomy) : ?>
-		<?php $branch = Taxonomy::getBranch($type); ?>
-		<?php if ($branch->state == 1 && in_array($branch->access, $user->getAuthorisedViewLevels())) : ?>
-			<?php
-			$taxonomy_text = array();
-
-			foreach ($taxonomy as $node) :
-				if ($node->state == 1 && in_array($node->access, $user->getAuthorisedViewLevels())) :
-					$taxonomy_text[] = $node->title;
-				endif;
-			endforeach;
-
-			if (count($taxonomy_text)) : ?>
-				<span class="badge badge-secondary"><?php echo $type . ': ' . implode(',', $taxonomy_text); ?></span>
 			<?php endif; ?>
-		<?php endif; ?>
-	<?php endforeach; ?>
-	</dd>
-<?php endif; ?>
-<?php if ($show_description && $description !== '') : ?>
-	<dd class="result-text">
-		<?php echo $description; ?>
-	</dd>
-<?php endif; ?>
-<?php if ($this->result->start_date && $this->params->get('show_date', 1)) : ?>
-	<dd class="result-date small">
-		<?php echo HTMLHelper::_('date', $this->result->start_date, Text::_('DATE_FORMAT_LC3')); ?>
-	</dd>
-<?php endif; ?>
-<?php if ($this->params->get('show_url', 1)) : ?>
-	<dd class="result-url small">
-		<?php echo $this->baseUrl, Route::_($this->result->cleanURL); ?>
-	</dd>
-<?php endif; ?>
+		</h4>
+	</header>
+
+	<?php $taxonomies = $this->result->getTaxonomy(); ?>
+	<?php if (count($taxonomies) && $this->params->get('show_taxonomy', 1)) : ?>
+		<p class="result-taxonomy">
+		<?php foreach ($taxonomies as $type => $taxonomy) : ?>
+			<?php $branch = Taxonomy::getBranch($type); ?>
+			<?php if ($branch->state == 1 && in_array($branch->access, $user->getAuthorisedViewLevels())) : ?>
+				<?php
+				$taxonomy_text = array();
+
+				foreach ($taxonomy as $node) :
+					if ($node->state == 1 && in_array($node->access, $user->getAuthorisedViewLevels())) :
+						$taxonomy_text[] = $node->title;
+					endif;
+				endforeach;
+
+				if (count($taxonomy_text)) : ?>
+					<span class="badge badge-secondary"><?php echo $type . ': ' . implode(',', $taxonomy_text); ?></span>
+				<?php endif; ?>
+			<?php endif; ?>
+		<?php endforeach; ?>
+		</p>
+	<?php endif; ?>
+	<?php if ($show_description && $description !== '') : ?>
+		<p class="result-text">
+			<?php echo $description; ?>
+		</p>
+	<?php endif; ?>
+	<?php if ($this->result->start_date && $this->params->get('show_date', 1)) : ?>
+		<time class="result-date small">
+			<?php echo HTMLHelper::_('date', $this->result->start_date, Text::_('DATE_FORMAT_LC3')); ?>
+		</time>
+	<?php endif; ?>
+	<?php if ($this->params->get('show_url', 1)) : ?>
+		<dd class="result-url small">
+			<?php echo $this->baseUrl, Route::_($this->result->cleanURL); ?>
+		</dd>
+	<?php endif; ?>
+</li>

--- a/components/com_finder/tmpl/search/default_results.php
+++ b/components/com_finder/tmpl/search/default_results.php
@@ -50,7 +50,7 @@ use Joomla\CMS\Uri\Uri;
 <?php endif; ?>
 <?php // Display a list of results ?>
 <br id="highlighter-start" />
-<dl class="search-results list-striped">
+<ol id="search-results-list" class="search-results list-striped">
 	<?php $this->baseUrl = Uri::getInstance()->toString(array('scheme', 'host', 'port')); ?>
 	<?php foreach ($this->results as $i => $result) : ?>
 		<?php $this->result = &$result; ?>
@@ -58,7 +58,7 @@ use Joomla\CMS\Uri\Uri;
 		<?php $layout = $this->getLayoutFile($this->result->layout); ?>
 		<?php echo $this->loadTemplate($layout); ?>
 	<?php endforeach; ?>
-</dl>
+</ol>
 <br id="highlighter-end" />
 <?php // Display the pagination ?>
 <div class="com-finder__navigation search-pagination">

--- a/components/com_finder/tmpl/search/default_results.php
+++ b/components/com_finder/tmpl/search/default_results.php
@@ -50,7 +50,7 @@ use Joomla\CMS\Uri\Uri;
 <?php endif; ?>
 <?php // Display a list of results ?>
 <br id="highlighter-start" />
-<ul id="search-results-list" class="search-results list-striped">
+<ul id="search-results-list" class="search-results list-unstyled">
 	<?php $this->baseUrl = Uri::getInstance()->toString(array('scheme', 'host', 'port')); ?>
 	<?php foreach ($this->results as $i => $result) : ?>
 		<?php $this->result = &$result; ?>

--- a/components/com_finder/tmpl/search/default_results.php
+++ b/components/com_finder/tmpl/search/default_results.php
@@ -50,7 +50,7 @@ use Joomla\CMS\Uri\Uri;
 <?php endif; ?>
 <?php // Display a list of results ?>
 <br id="highlighter-start" />
-<ol id="search-results-list" class="search-results list-striped">
+<ul id="search-results-list" class="search-results list-striped">
 	<?php $this->baseUrl = Uri::getInstance()->toString(array('scheme', 'host', 'port')); ?>
 	<?php foreach ($this->results as $i => $result) : ?>
 		<?php $this->result = &$result; ?>
@@ -58,7 +58,7 @@ use Joomla\CMS\Uri\Uri;
 		<?php $layout = $this->getLayoutFile($this->result->layout); ?>
 		<?php echo $this->loadTemplate($layout); ?>
 	<?php endforeach; ?>
-</ol>
+</ul>
 <br id="highlighter-end" />
 <?php // Display the pagination ?>
 <div class="com-finder__navigation search-pagination">


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

- DL => UL conversion
- DL was implemented in https://github.com/joomla/joomla-cms/pull/20572 by @Hackwar 

quote from @Hackwar taken from a private message to find out reason of changing `ul` to `dl`

> I used a DL because I considered that the syntactically correct structure. There is no deeper reasoning.

Changing it from DL back to UL makes it easier for frontend developers to style each search result. 
Styling DT+DD is not as easy as styling a LI

### Testing Instructions

- Go to the search results.
  - using Joomla 4 with Blog Sample Data it will be the following url with `blog` as searched word. 
  /index.php/component/finder/search?q=blog&Itemid=101&Itemid=101
- Inspect element on the search results and see the HTML structure
- Apply this PR, refresh the page
- Inspect element on the search results and see the HTML structure

### Actual result BEFORE applying this Pull Request

It is very hard to style dt+dd+dd+dd as a card. Try adding a background image, box-shadow and spacing between the individual search results. 

<img width="922" alt="Schermafbeelding 2020-09-01 om 08 56 15" src="https://user-images.githubusercontent.com/639822/91812556-970d3800-ec31-11ea-94c7-8065247f2b1f.png">


### Expected result AFTER applying this Pull Request

After applying this PR it is much easier to style individual search results. 

<img width="921" alt="Schermafbeelding 2020-09-01 om 08 55 27" src="https://user-images.githubusercontent.com/639822/91812539-91175700-ec31-11ea-900d-e69de5bde670.png">

### Documentation Changes Required

