### PR TITLE
[4.0] Accessibility plugin position

### DIFF
--- a/plugins/system/accessibility/accessibility.php
+++ b/plugins/system/accessibility/accessibility.php
@@ -56,7 +56,7 @@ class PlgSystemAccessibility extends CMSPlugin
 		$this->loadLanguage();
 
 		// Determine if it is an LTR or RTL language
-		$direction = Factory::getLanguage()->isRTL() ? 'left' : 'right';
+		$direction = Factory::getLanguage()->isRTL() ? 'right' : 'left';
 
 		/**
 		* Add strings for translations in Javascript.


### PR DESCRIPTION
Pull Request for Issue #30551 
This simple PR flips the display of the plugin from the right hand side to the left hand side in LTR languages and the opposite in RTL languages

This is to avoid clashing with the menu icon on mobile displays.

On desktops it probably makes more sense this way as its with the menus.

### Steps to reproduce the issue
Enable Plugin: System - Additional Accessibility Features
mobile view
scroll to bottom

### BEFORE LTR
![image](https://user-images.githubusercontent.com/1296369/92020300-d336ba80-ed4f-11ea-9ed8-24c94d2af7b0.png)


### AFTER LTR
![image](https://user-images.githubusercontent.com/1296369/92020041-73d8aa80-ed4f-11ea-9244-80b608d61f17.png)

### AFTER RTL
![image](https://user-images.githubusercontent.com/1296369/92020180-aaaec080-ed4f-11ea-9654-a5f86cd63e91.png)

