### PR TITLE
Appveyor: Downloading explicit composer.phar

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -126,8 +126,8 @@ install:
     - IF %PHP%==1 echo zend_extension=php_opcache.dll >> php.ini
     - IF %PHP%==1 echo opcache.enable_cli=1 >> php.ini
     - IF %PHP%==1 echo extension=php_ldap.dll >> php.ini
-    - IF %PHP%==1 echo @php %%~dp0composer.phar %%* > composer.bat
-    - IF %PHP%==1 php -r "readfile('http://getcomposer.org/installer');" | php
+    - IF %PHP%==1 echo @php %%~dp0composer-1.phar %%* > composer.bat
+    - IF %PHP%==1 appveyor-retry appveyor DownloadFile https://getcomposer.org/composer-1.phar
     - cd C:\projects\joomla-cms
     - appveyor-retry composer install --no-progress --profile
 


### PR DESCRIPTION
Appveyor currently fails regularly either while downloading the installer for composer or while executing composer itself. I'm not 100% sure where the issue is, but the solution seems to be to go back to downloading a specific composer file instead. So I'm downloading the latest composer 1.x phar file... @wilsonge Any comment regarding this? You changed this a few months ago to use the installer...