### PR TITLE
[4.0] Weekend codestyle

### DIFF
--- a/administrator/language/en-GB/langmetadata.xml
+++ b/administrator/language/en-GB/langmetadata.xml
@@ -16,7 +16,7 @@
 		<rtl>0</rtl>
 		<locale>en_GB.utf8, en_GB.UTF-8, en_GB, eng_GB, en, english, english-uk, uk, gbr, britain, england, great britain, uk, united kingdom, united-kingdom</locale>
 		<firstDay>0</firstDay>
-		<weekEnd>0,6</weekEnd>
+		<weekend>0,6</weekend>
 		<calendar>gregorian</calendar>
 	</metadata>
 	<params />

--- a/api/language/en-GB/langmetadata.xml
+++ b/api/language/en-GB/langmetadata.xml
@@ -16,7 +16,7 @@
 		<rtl>0</rtl>
 		<locale>en_GB.utf8, en_GB.UTF-8, en_GB, eng_GB, en, english, english-uk, uk, gbr, britain, england, great britain, uk, united kingdom, united-kingdom</locale>
 		<firstDay>0</firstDay>
-		<weekEnd>0,6</weekEnd>
+		<weekend>0,6</weekend>
 		<calendar>gregorian</calendar>
 	</metadata>
 	<params />

--- a/language/en-GB/langmetadata.xml
+++ b/language/en-GB/langmetadata.xml
@@ -16,7 +16,7 @@
 		<rtl>0</rtl>
 		<locale>en_GB.utf8, en_GB.UTF-8, en_GB, eng_GB, en, english, english-uk, uk, gbr, britain, england, great britain, uk, united kingdom, united-kingdom</locale>
 		<firstDay>0</firstDay>
-		<weekEnd>0,6</weekEnd>
+		<weekend>0,6</weekend>
 		<calendar>gregorian</calendar>
 	</metadata>
 	<params />

--- a/layouts/joomla/form/field/calendar.php
+++ b/layouts/joomla/form/field/calendar.php
@@ -124,7 +124,7 @@ $document->getWebAssetManager()
 				data-dayformat="<?php echo $format; ?>"
 				data-button="<?php echo $id; ?>_btn"
 				data-firstday="<?php echo Factory::getLanguage()->getFirstDay(); ?>"
-				data-weekend="<?php echo Factory::getLanguage()->getWeekEnd(); ?>"
+				data-weekend="<?php echo Factory::getLanguage()->getWeekend(); ?>"
 				data-today-btn="<?php echo $todaybutton; ?>"
 				data-week-numbers="<?php echo $weeknumbers; ?>"
 				data-show-time="<?php echo $showtime; ?>"

--- a/libraries/src/HTML/Helpers/Behavior.php
+++ b/libraries/src/HTML/Helpers/Behavior.php
@@ -309,7 +309,7 @@ abstract class Behavior
 			'DRAG_TO_MOVE'    => Text::_('JLIB_HTML_BEHAVIOR_DRAG_TO_MOVE'),
 			'PART_TODAY'      => $today,
 			'DAY_FIRST'       => Text::_('JLIB_HTML_BEHAVIOR_DISPLAY_S_FIRST'),
-			'WEEKEND'         => Factory::getLanguage()->getWeekEnd(),
+			'WEEKEND'         => Factory::getLanguage()->getWeekend(),
 			'CLOSE'           => Text::_('JLIB_HTML_BEHAVIOR_CLOSE'),
 			'TODAY'           => Text::_('JLIB_HTML_BEHAVIOR_TODAY'),
 			'TIME_PART'       => Text::_('JLIB_HTML_BEHAVIOR_SHIFT_CLICK_OR_DRAG_TO_CHANGE_VALUE'),

--- a/libraries/src/Language/Language.php
+++ b/libraries/src/Language/Language.php
@@ -1210,7 +1210,7 @@ class Language
 	 *
 	 * @since   3.2
 	 */
-	public function getWeekEnd()
+	public function getWeekend()
 	{
 		return $this->metadata['weekend'] ?? '0,6';
 	}

--- a/libraries/src/Language/Language.php
+++ b/libraries/src/Language/Language.php
@@ -1212,6 +1212,6 @@ class Language
 	 */
 	public function getWeekEnd()
 	{
-		return $this->metadata['weekEnd'] ?? '0,6';
+		return $this->metadata['weekend'] ?? '0,6';
 	}
 }


### PR DESCRIPTION
Weekend is just one word and not two

Therefore it is incorrect to label it <weekEnd> in the xml and it should just be `<weekend>`

Code review
