### PR TITLE
Fieldsfix

### DIFF
--- a/administrator/components/com_fields/src/Model/FieldsModel.php
+++ b/administrator/components/com_fields/src/Model/FieldsModel.php
@@ -240,7 +240,7 @@ class FieldsModel extends ListModel
 				$query->where(
 					'(' .
 						$db->quoteName('fc.category_id') . ' IS NULL OR ' .
-						$db->quoteName('fc.category_id') . ' IN (' . implode(',', $query->bindArray($categories, ParameterType::INTEGER)) . ')' .
+						$db->quoteName('fc.category_id') . ' IN (' . implode(',', $query->bindArray(array_values($categories), ParameterType::INTEGER)) . ')' .
 					')'
 				);
 			}


### PR DESCRIPTION
Pull Request for Issue # .
Fields are not being inherited by sub-categories

### Summary of Changes
corrected getting of category values


### Testing Instructions
Create category Cat1
Create category Cat2 and set its Parent to Cat1
Create Article TestArticle and set its Category to Cat2
Create Field TestField and set its Category to Cat1 only
Open Article TestArticle

Expected result
TestField should be available under the Fields tab in the Article
TestArticle is in Cat2 and TestField should have been inherited from Cat1 

### Actual result BEFORE applying this Pull Request
TestField is not available in TestArticle


### Expected result AFTER applying this Pull Request
TestField is available in TestArticle.
Also all other combinations of Categories / Fields work as expected


### Documentation Changes Required
none?
