### PR TITLE
[4.0] Store memory and time as float in Profiler

### DIFF
--- a/libraries/src/Profiler/Profiler.php
+++ b/libraries/src/Profiler/Profiler.php
@@ -111,9 +111,9 @@ class Profiler
 
 		$m = (object) array(
 			'prefix' => $this->prefix,
-			'time' => ($current > $this->previousTime ? '+' : '-') . (($current - $this->previousTime) * 1000),
+			'time' => ($current - $this->previousTime) * 1000,
 			'totalTime' => ($current * 1000),
-			'memory' => ($currentMem > $this->previousMem ? '+' : '-') . ($currentMem - $this->previousMem),
+			'memory' => $currentMem - $this->previousMem,
 			'totalMemory' => $currentMem,
 			'label' => $label,
 		);


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Changes mark memory and time format from improperly formatted string to float.

### Testing Instructions

Enable debug on PHP 8. 

### Actual result BEFORE applying this Pull Request

>abs(): Argument #1 ($number) must be of type int|float, string given

### Expected result AFTER applying this Pull Request

No errors.

### Documentation Changes Required

Maybe?

### Additional Comments

We also need something like this for staging (can be done without changing data type), waiting for response in https://github.com/joomla/joomla-cms/pull/29353.