### PR TITLE
Fix module rendering on error page

### DIFF
--- a/templates/protostar/error.php
+++ b/templates/protostar/error.php
@@ -118,20 +118,26 @@ else
 					<a class="brand pull-left" href="<?php echo $this->baseurl; ?>/">
 						<?php echo $logo; ?>
 					</a>
-					<div class="header-search pull-right">
-						<?php // Display position-0 modules ?>
-						<?php echo $this->getBuffer('modules', 'position-0', array('style' => 'none')); ?>
-					</div>
+					<?php if ($format === 'html') : ?>
+						<div class="header-search pull-right">
+							<?php // Display position-0 modules ?>
+							<?php echo $this->loadRenderer('modules')->render('position-0', array('style' => 'none')); ?>
+						</div>
+					<?php endif; ?>
 				</div>
 			</header>
-			<nav class="navigation" role="navigation">
-				<?php // Display position-1 modules ?>
-				<?php echo $this->getBuffer('modules', 'position-1', array('style' => 'none')); ?>
-			</nav>
+			<?php if ($format === 'html') : ?>
+				<nav class="navigation" role="navigation">
+					<?php // Display position-1 modules ?>
+					<?php echo $this->loadRenderer('modules')->render('position-1', array('style' => 'none')); ?>
+				</nav>
+			<?php endif; ?>
 			<!-- Banner -->
-			<div class="banner">
-				<?php echo $this->getBuffer('modules', 'banner', array('style' => 'xhtml')); ?>
-			</div>
+			<?php if ($format === 'html') : ?>
+				<div class="banner">
+					<?php echo $this->loadRenderer('modules')->render('banner', array('style' => 'xhtml')); ?>
+				</div>
+			<?php endif; ?>
 			<div class="row-fluid">
 				<main id="content" role="main" class="span12">
 					<!-- Begin Content -->
@@ -200,7 +206,9 @@ else
 	<footer class="footer" role="contentinfo">
 		<div class="container<?php echo ($params->get('fluidContainer') ? '-fluid' : ''); ?>">
 			<hr />
-			<?php echo $this->getBuffer('modules', 'footer', array('style' => 'none')); ?>
+			<?php if ($format === 'html') : ?>
+				<?php echo $this->loadRenderer('modules')->render('footer', array('style' => 'none')); ?>
+			<?php endif; ?>
 			<p class="pull-right">
 				<a href="#top" id="back-top">
 					<?php echo JText::_('TPL_PROTOSTAR_BACKTOTOP'); ?>
@@ -211,6 +219,8 @@ else
 			</p>
 		</div>
 	</footer>
-	<?php echo $this->getBuffer('modules', 'debug', array('style' => 'none')); ?>
+	<?php if ($format === 'html') : ?>
+		<?php echo $this->loadRenderer('modules')->render('debug', array('style' => 'none')); ?>
+	<?php endif; ?>
 </body>
 </html>


### PR DESCRIPTION
Fixes regression from https://github.com/joomla/joomla-cms/pull/10847.

### Summary of Changes

Fixes notices and rendering of modules on error page.

### Testing Instructions

Publish a module in `position-0` position.
Cause an error page to be rendered.

### Actual result BEFORE applying this Pull Request

Module not rendererd and notices are shown:

> Notice: Array to string conversion in C:\wamp\www\joomla-cms-3\templates\protostar\error.php on line 123

### Expected result AFTER applying this Pull Request

Module rendered and no notices.

### Documentation Changes Required

No.