### PR TITLE
[4.0] Fix "explain" feature in the debug plugin

### DIFF
--- a/build/media_source/plg_system_debug/widgets/sqlqueries/widget.es5.js
+++ b/build/media_source/plg_system_debug/widgets/sqlqueries/widget.es5.js
@@ -217,13 +217,18 @@
                     if (tableExplain) {
                         tableExplain.appendTo(li)
                         for (i in stmt.explain) {
-                            var entry = stmt.explain[i]
-                            tableExplain.append('<tr>'
-                                + '<td>' + entry.id + '</td><td>' + entry.select_type + '</td><td>' + entry.table + '</td>'
-                                + '<td>' + entry.type + '</td><td>' + entry.possible_keys + '</td><td>' + entry.key + '</td>'
-                                + '<td>' + entry.key_len + '</td><td>' + entry.ref + '</td><td>' + entry.rows + '</td>'
-                                + '<td>' + entry.Extra + '</td>'
-                                + '</tr>')
+                            var entry = stmt.explain[i];
+
+                            if (entry.error) {
+                                tableExplain.append('<tr><td colspan="10">' + entry.error + '</td></tr>');
+                            } else {
+                                tableExplain.append('<tr>'
+                                  + '<td>' + entry.id + '</td><td>' + entry.select_type + '</td><td>' + entry.table + '</td>'
+                                  + '<td>' + entry.type + '</td><td>' + entry.possible_keys + '</td><td>' + entry.key + '</td>'
+                                  + '<td>' + entry.key_len + '</td><td>' + entry.ref + '</td><td>' + entry.rows + '</td>'
+                                  + '<td>' + entry.Extra + '</td>'
+                                  + '</tr>');
+                            }
                         }
                     }
 

--- a/build/media_source/plg_system_debug/widgets/sqlqueries/widget.es5.js
+++ b/build/media_source/plg_system_debug/widgets/sqlqueries/widget.es5.js
@@ -223,7 +223,7 @@
                                 tableExplain.find('.heading-row').hide();
                                 tableExplain.append('<tr><td colspan="10">' + entry.error + '</td></tr>');
                             }
-                            else if(entry['QUERY PLAN']) {
+                            else if (entry['QUERY PLAN']) {
                                 // PostgreSQL
                                 tableExplain.find('.heading-row').hide();
                                 tableExplain.append('<tr><td>QUERY PLAN </td><td colspan="9">' + entry['QUERY PLAN'] + '</td></tr>');

--- a/build/media_source/plg_system_debug/widgets/sqlqueries/widget.es5.js
+++ b/build/media_source/plg_system_debug/widgets/sqlqueries/widget.es5.js
@@ -124,30 +124,50 @@
                         })
                     }
 
-                    var tableExplain
+                    var tableExplain;
+
+                    function showTableExplain() {
+                        if (tableExplain) {
+                            tableExplain.show();
+                            return;
+                        }
+
+                        // Render table
+                        tableExplain = $('<table>').addClass(csscls('callstack')).appendTo(li);
+                        tableExplain.append('<tr><th>' + stmt.explain_col.join('</th><th>') + '</th></tr>');
+
+                        var i, entry, cols;
+                        for (i in stmt.explain) {
+                            cols  = []
+                            entry = stmt.explain[i];
+
+                            stmt.explain_col.forEach(function (key){
+                                cols.push(entry[key]);
+                            });
+
+                            tableExplain.append('<tr><td>' + cols.join('</td><td>') + '</td></tr>');
+                        }
+
+                        tableExplain.show();
+                    }
 
                     if (stmt.explain && !$.isEmptyObject(stmt.explain)) {
                         var btnExplain = $('<span title="Explain" />')
-                            .text('Explain')
-                            .addClass(csscls('eye'))
-                            .css('cursor', 'pointer')
-                            .on('click', function () {
-                                if (tableExplain.is(':visible')) {
-                                    tableExplain.hide()
-                                    btnExplain.addClass(csscls('eye'))
-                                    btnExplain.removeClass(csscls('eye-dash'))
-                                } else {
-                                    tableExplain.show()
-                                    btnExplain.addClass(csscls('eye-dash'))
-                                    btnExplain.removeClass(csscls('eye'))
-                                }
-                            })
-                            .appendTo(li)
-
-                        tableExplain = $('<table><thead>'
-                            + '<tr><th colspan="10">Explain</th></tr>'
-                            + '<tr class="heading-row"><th>Id</th><th>Select Type</th><th>Table</th><th>Type</th><th>Possible Keys</th><th>Key</th><th>Key Len</th><th>Ref</th><th>Rows</th><th>Extra</th></tr>'
-                            + '</thead></table>').addClass(csscls('callstack'))
+                          .text('Explain')
+                          .addClass(csscls('eye'))
+                          .css('cursor', 'pointer')
+                          .on('click', function () {
+                              if (tableExplain && tableExplain.is(':visible')) {
+                                  tableExplain.hide()
+                                  btnExplain.addClass(csscls('eye'))
+                                  btnExplain.removeClass(csscls('eye-dash'))
+                              } else {
+                                  showTableExplain();
+                                  btnExplain.addClass(csscls('eye-dash'))
+                                  btnExplain.removeClass(csscls('eye'))
+                              }
+                          })
+                          .appendTo(li)
                     }
 
                     var tableStack
@@ -211,31 +231,6 @@
                                 location = '<a href="' + self.xdebug_link.replace('%f', entry[3]).replace('%l', entry[4]) + '">' + location + '</a>'
                             }
                             tableStack.append('<tr class="' + cssClass + '"><th>' + entry[0] + '</th><td>' + caller + '</td><td>' + location + '</td></tr>')
-                        }
-                    }
-
-                    if (tableExplain) {
-                        tableExplain.appendTo(li)
-                        for (i in stmt.explain) {
-                            var entry = stmt.explain[i];
-
-                            if (entry.error) {
-                                tableExplain.find('.heading-row').hide();
-                                tableExplain.append('<tr><td colspan="10">' + entry.error + '</td></tr>');
-                            }
-                            else if (entry['QUERY PLAN']) {
-                                // PostgreSQL
-                                tableExplain.find('.heading-row').hide();
-                                tableExplain.append('<tr><td>QUERY PLAN </td><td colspan="9">' + entry['QUERY PLAN'] + '</td></tr>');
-                            } else {
-                                // MySQL
-                                tableExplain.append('<tr>'
-                                  + '<td>' + entry.id + '</td><td>' + entry.select_type + '</td><td>' + entry.table + '</td>'
-                                  + '<td>' + entry.type + '</td><td>' + entry.possible_keys + '</td><td>' + entry.key + '</td>'
-                                  + '<td>' + entry.key_len + '</td><td>' + entry.ref + '</td><td>' + entry.rows + '</td>'
-                                  + '<td>' + entry.Extra + '</td>'
-                                  + '</tr>');
-                            }
                         }
                     }
 

--- a/build/media_source/plg_system_debug/widgets/sqlqueries/widget.es5.js
+++ b/build/media_source/plg_system_debug/widgets/sqlqueries/widget.es5.js
@@ -146,7 +146,7 @@
 
                         tableExplain = $('<table><thead>'
                             + '<tr><th colspan="10">Explain</th></tr>'
-                            + '<tr><th>Id</th><th>Select Type</th><th>Table</th><th>Type</th><th>Possible Keys</th><th>Key</th><th>Key Len</th><th>Ref</th><th>Rows</th><th>Extra</th></tr>'
+                            + '<tr class="heading-row"><th>Id</th><th>Select Type</th><th>Table</th><th>Type</th><th>Possible Keys</th><th>Key</th><th>Key Len</th><th>Ref</th><th>Rows</th><th>Extra</th></tr>'
                             + '</thead></table>').addClass(csscls('callstack'))
                     }
 
@@ -220,8 +220,15 @@
                             var entry = stmt.explain[i];
 
                             if (entry.error) {
+                                tableExplain.find('.heading-row').hide();
                                 tableExplain.append('<tr><td colspan="10">' + entry.error + '</td></tr>');
+                            }
+                            else if(entry['QUERY PLAN']) {
+                                // PostgreSQL
+                                tableExplain.find('.heading-row').hide();
+                                tableExplain.append('<tr><td>QUERY PLAN </td><td colspan="9">' + entry['QUERY PLAN'] + '</td></tr>');
                             } else {
+                                // MySQL
                                 tableExplain.append('<tr>'
                                   + '<td>' + entry.id + '</td><td>' + entry.select_type + '</td><td>' + entry.table + '</td>'
                                   + '<td>' + entry.type + '</td><td>' + entry.possible_keys + '</td><td>' + entry.key + '</td>'

--- a/composer.lock
+++ b/composer.lock
@@ -910,16 +910,16 @@
         },
         {
             "name": "joomla/database",
-            "version": "2.0.0-beta",
+            "version": "2.0.0-beta2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-framework/database.git",
-                "reference": "1332ca4c1ed8411d58898c5c68c1a818ff95bb21"
+                "reference": "1eef40d30cca0661b5cfb5c60c8600ed0d09b42d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/database/zipball/1332ca4c1ed8411d58898c5c68c1a818ff95bb21",
-                "reference": "1332ca4c1ed8411d58898c5c68c1a818ff95bb21",
+                "url": "https://api.github.com/repos/joomla-framework/database/zipball/1eef40d30cca0661b5cfb5c60c8600ed0d09b42d",
+                "reference": "1eef40d30cca0661b5cfb5c60c8600ed0d09b42d",
                 "shasum": ""
             },
             "require": {
@@ -936,6 +936,7 @@
                 "joomla/test": "^2.0",
                 "phpunit/phpunit": "^8.5|^9.0",
                 "psr/log": "^1.1",
+                "symfony/deprecation-contracts": "^2.1",
                 "symfony/phpunit-bridge": "^4.4|^5.0"
             },
             "suggest": {
@@ -971,7 +972,7 @@
                 "framework",
                 "joomla"
             ],
-            "time": "2020-06-05T11:27:58+00:00"
+            "time": "2020-09-01T07:19:19+00:00"
         },
         {
             "name": "joomla/di",
@@ -6806,6 +6807,7 @@
             "keywords": [
                 "tokenizer"
             ],
+            "abandoned": true,
             "time": "2019-09-17T06:23:10+00:00"
         },
         {

--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -508,7 +508,8 @@ class PlgSystemDebug extends CMSPlugin
 
 		if ($this->params->get('query_explains') && in_array($db->getServerType(), ['mysql', 'postgresql'], true))
 		{
-			$logs = $this->queryMonitor->getLogs();
+			$logs        = $this->queryMonitor->getLogs();
+			$boundParams = $this->queryMonitor->getBoundParams();
 
 			foreach ($logs as $k => $query)
 			{
@@ -524,12 +525,22 @@ class PlgSystemDebug extends CMSPlugin
 				{
 					try
 					{
-						$db->setQuery('EXPLAIN ' . ($dbVersion56 ? 'EXTENDED ' : '') . $query);
-						$this->explains[$k] = $db->loadAssocList();
+						$queryInstance = $db->getQuery(true);
+						$queryInstance->setQuery('EXPLAIN ' . ($dbVersion56 ? 'EXTENDED ' : '') . $query);
+
+						if ($boundParams[$k])
+						{
+							foreach ($boundParams[$k] as $key => $obj)
+							{
+								$queryInstance->bind($key, $obj->value, $obj->dataType, $obj->length, $obj->driverOptions);
+							}
+						}
+
+						$this->explains[$k] = $db->setQuery($queryInstance)->loadAssocList();
 					}
 					catch (Exception $e)
 					{
-						$this->explains[$k] = [['Error' => $e->getMessage()]];
+						$this->explains[$k] = [['error' => $e->getMessage()]];
 					}
 				}
 			}

--- a/plugins/system/debug/src/DataCollector/QueryCollector.php
+++ b/plugins/system/debug/src/DataCollector/QueryCollector.php
@@ -233,13 +233,23 @@ class QueryCollector extends AbstractDataCollector implements AssetProvider
 				}
 			}
 
+			$explain        = $this->explains[$id] ?? [];
+			$explainColumns = [];
+
+			// Extract column labels for Explain table
+			if ($explain)
+			{
+				$explainColumns = array_keys(reset($explain));
+			}
+
 			$statements[] = [
 				'sql'          => $item,
 				'duration_str' => $this->getDataFormatter()->formatDuration($queryTime),
 				'memory_str'   => $this->getDataFormatter()->formatBytes($queryMemory),
 				'caller'       => $callerLocation,
 				'callstack'    => $trace,
-				'explain'      => $this->explains[$id] ?? [],
+				'explain'      => $explain,
+				'explain_col'  => $explainColumns,
 				'profile'      => $this->profiles[$id] ?? [],
 			];
 		}


### PR DESCRIPTION
Pull Request for Issue #30318 .

### Summary of Changes
Fixing query explain feature. This also update `joomla/database` lib.


### Testing Instructions

Run `composer install` and `npm install`

Enable debug plugin and enable "Query explain" feature.
In the Debugbar, in Query tab you should be able to see Explain , near the every "select" query.
Click on it.

### Actual result BEFORE applying this Pull Request
it show empty table. 


### Expected result AFTER applying this Pull Request
it show "explain"


### Documentation Changes Required
none
