### PR TITLE
[4.0] Remove use of ReflectionParameter::getClass()

### DIFF
--- a/libraries/src/Plugin/CMSPlugin.php
+++ b/libraries/src/Plugin/CMSPlugin.php
@@ -324,7 +324,7 @@ abstract class CMSPlugin implements DispatcherAwareInterface, PluginInterface
 	 */
 	protected function checkTypeHint(\ReflectionType $reflectionType): bool
 	{
-		if ($reflectionType->isBuiltin() || $reflectionType->allowsNull())
+		if ($reflectionType->allowsNull())
 		{
 			return false;
 		}
@@ -338,9 +338,9 @@ abstract class CMSPlugin implements DispatcherAwareInterface, PluginInterface
 		// Handle PHP 8 union types.
 		if ($reflectionType instanceof \ReflectionUnionType)
 		{
-			foreach (explode('|', $reflectionType->getNames()) as $type)
+			foreach ($reflectionType->getTypes() as $type)
 			{
-				if (!\is_a($type, EventInterface::class, true))
+				if (!\is_a($type->getName(), EventInterface::class, true))
 				{
 					return false;
 				}

--- a/libraries/src/Plugin/CMSPlugin.php
+++ b/libraries/src/Plugin/CMSPlugin.php
@@ -222,7 +222,7 @@ abstract class CMSPlugin implements DispatcherAwareInterface, PluginInterface
 			$parameters = $method->getParameters();
 
 			// If the parameter count is not 1 it is by definition a legacy listener
-			if (\count($parameters) != 1)
+			if (\count($parameters) !== 1)
 			{
 				$this->registerLegacyListener($method->name);
 
@@ -292,7 +292,7 @@ abstract class CMSPlugin implements DispatcherAwareInterface, PluginInterface
 				}
 
 				// Restore the old results and add the new result from our method call
-				array_push($allResults, $result);
+				$allResults[]    = $result;
 				$event['result'] = $allResults;
 			}
 		);


### PR DESCRIPTION
### Summary of Changes

Remove use of `ReflectionParameter::getClass()` method which is deprecated in PHP 8.0.

### Testing Instructions

Run Joomla on PHP 8.

### Actual result BEFORE applying this Pull Request

Deprecation messages:

>Deprecated: Method ReflectionParameter::getClass() is deprecated in C:\wamp\www\joomla-cms\libraries\src\Plugin\CMSPlugin.php on line 233

### Expected result AFTER applying this Pull Request

No deprecation messages and plugins continue to work.

### Documentation Changes Required

No.