### PR TITLE
Remove duplicate minus sign in Profiler

### DIFF
--- a/libraries/src/Profiler/Profiler.php
+++ b/libraries/src/Profiler/Profiler.php
@@ -111,9 +111,9 @@ class Profiler
 
 		$m = (object) array(
 			'prefix' => $this->prefix,
-			'time' => ($current > $this->previousTime ? '+' : '-') . (($current - $this->previousTime) * 1000),
+			'time' => ($current > $this->previousTime ? '+' : '') . (($current - $this->previousTime) * 1000),
 			'totalTime' => ($current * 1000),
-			'memory' => ($currentMem > $this->previousMem ? '+' : '-') . ($currentMem - $this->previousMem),
+			'memory' => ($currentMem > $this->previousMem ? '+' : '') . ($currentMem - $this->previousMem),
 			'totalMemory' => $currentMem,
 			'label' => $label,
 		);


### PR DESCRIPTION
Alternative to https://github.com/joomla/joomla-cms/pull/29353 and also fixes errors on PHP 8.

### Summary of Changes

Removes double minus sign when storing time and memory in Profiler. This fixes type error on PHP 8 and notices on PHP 7.

### Testing Instructions

Enable debug on PHP 8.

### Actual result BEFORE applying this Pull Request

>round(): Argument #1 ($number) must be of type int|float, string given 
>C:\wamp\www\joomla-cms-3\plugins\system\debug\debug.php:716 

### Expected result AFTER applying this Pull Request

No errors.

### Documentation Changes Required

Don't think so.