### PR TITLE
[4.0] Fix TinyMCE - simple preset

### DIFF
--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -998,7 +998,7 @@ class PlgEditorTinymce extends CMSPlugin
 
 		$preset['simple'] = [
 			'menu' => [],
-			'toolbar' => [
+			'toolbar1' => [
 				'bold', 'underline', 'strikethrough', '|',
 				'undo', 'redo', '|',
 				'bullist', 'numlist', '|',


### PR DESCRIPTION
Pull Request for Issue #30014 .

### Summary of Changes
Fix incorrect key.


### Steps to reproduce the issue

1. Go to Plugin Manager and open TinyMCE
2. Click the `medium` and `advanced` preset buttons

You'll notice below the TinyMCE toolbar changes based on the preset chosen.

3. Click the `simple preset` button

### Expected result

Toolbar with buttons.

### Actual result

Toolbar is empty.

