### PR TITLE
[4.0] adding additional check to avoid js script error

### DIFF
--- a/build/media_source/plg_media-action_rotate/js/rotate.es6.js
+++ b/build/media_source/plg_media-action_rotate/js/rotate.es6.js
@@ -75,7 +75,9 @@ Joomla.MediaManager.Edit = Joomla.MediaManager.Edit || {};
       elements.forEach((element) => {
         element.addEventListener('click', ({ target }) => {
           const inputElement = target.querySelector('input');
-          inputElement && rotate(parseInt(inputElement.value, 10));
+          if (inputElement) {
+            rotate(parseInt(inputElement.value, 10));
+          }
         });
       });
     };

--- a/build/media_source/plg_media-action_rotate/js/rotate.es6.js
+++ b/build/media_source/plg_media-action_rotate/js/rotate.es6.js
@@ -74,7 +74,8 @@ Joomla.MediaManager.Edit = Joomla.MediaManager.Edit || {};
       const elements = [].slice.call(document.querySelectorAll('#jform_rotate_distinct label'));
       elements.forEach((element) => {
         element.addEventListener('click', ({ target }) => {
-          rotate(parseInt(target.querySelector('input').value, 10));
+          const inputElement = target.querySelector('input');
+          inputElement && rotate(parseInt(inputElement.value, 10));
         });
       });
     };


### PR DESCRIPTION
Pull Request for Issue # . https://github.com/joomla/joomla-cms/issues/29157

### Summary of Changes
added additional check in js file to avoid script error


### Testing Instructions

1. Go to edit an image in the Media Manager
2. Click the Rotate tab
3. Click the buttons 0, 90, 180, 270 to rotate the image


### Actual result BEFORE applying this Pull Request

`TypeError: c.querySelector(...) is null -- rotate.min.js:1:1416`

### Expected result AFTER applying this Pull Request

No script error should come and functionality should work as is.


### Documentation Changes Required
NO
