### PR TITLE
Fix call_user_func_array() arguments on PHP 8

### DIFF
--- a/libraries/joomla/event/dispatcher.php
+++ b/libraries/joomla/event/dispatcher.php
@@ -162,7 +162,7 @@ class JEventDispatcher extends JObject
 			// Fire the event for a function based observer.
 			elseif (is_array($this->_observers[$key]))
 			{
-				$value = call_user_func_array($this->_observers[$key]['handler'], $args);
+				$value = call_user_func_array($this->_observers[$key]['handler'], array_values($args));
 			}
 
 			if (isset($value))

--- a/libraries/joomla/event/event.php
+++ b/libraries/joomla/event/event.php
@@ -67,7 +67,7 @@ abstract class JEvent extends JObject
 		 */
 		if (method_exists($this, $event))
 		{
-			return call_user_func_array(array($this, $event), $args);
+			return call_user_func_array(array($this, $event), array_values($args));
 		}
 	}
 }


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Changes second argument of `call_user_func_array()` from associative to indexed array. Before PHP 8 both types of arrays work the same but on PHP 8 associative arrays are interpreted as "named parameters". In our case this causes code to break.

### Testing Instructions

Use PHP 8.
Open article form.

### Actual result BEFORE applying this Pull Request

Error:
> Unknown named parameter $name 

### Expected result AFTER applying this Pull Request

No errors, editor and editor buttons appear correctly.

### Documentation Changes Required

No.