### PR TITLE
[4.0] save group button hover fix

### DIFF
--- a/administrator/templates/atum/scss/vendor/bootstrap/_dropdown.scss
+++ b/administrator/templates/atum/scss/vendor/bootstrap/_dropdown.scss
@@ -42,7 +42,7 @@
 
     .btn-group.show .dropdown-menu &:not(.disabled) {
       color: var(--atum-text-light);
-      background-color: var(--atum-bg-dark);
+      background-color: theme-color("success");;
     }
   }
 

--- a/administrator/templates/atum/scss/vendor/bootstrap/_dropdown.scss
+++ b/administrator/templates/atum/scss/vendor/bootstrap/_dropdown.scss
@@ -40,7 +40,12 @@
       background-color: theme-color("info");
     }
 
-    .btn-group.show .dropdown-menu &:not(.disabled) {
+    .dropdown-status-group .dropdown-menu &:not(.disabled) {
+      color: var(--atum-text-light);
+      background-color: var(--atum-bg-dark);
+    }
+
+    .dropdown-save-group .dropdown-menu &:not(.disabled) {
       color: var(--atum-text-light);
       background-color: theme-color("success");
     }

--- a/administrator/templates/atum/scss/vendor/bootstrap/_dropdown.scss
+++ b/administrator/templates/atum/scss/vendor/bootstrap/_dropdown.scss
@@ -42,7 +42,7 @@
 
     .btn-group.show .dropdown-menu &:not(.disabled) {
       color: var(--atum-text-light);
-      background-color: theme-color("success");;
+      background-color: theme-color("success");
     }
   }
 


### PR DESCRIPTION
Pull Request for Issue # .#30116

### Summary of Changes
Modified the theme color for save group buttons


### Testing Instructions
Joomla 4 -> create article -> click on save & close dropdown -> hover the dropdown save options it must show green background color.

### Actual result BEFORE applying this Pull Request
![current-save-button](https://user-images.githubusercontent.com/14950384/92964017-09331780-f491-11ea-8049-f6f9a0272c83.png)


### Expected result AFTER applying this Pull Request
![save-button-group](https://user-images.githubusercontent.com/14950384/92964018-0afcdb00-f491-11ea-9e5c-b1e14caf5864.png)



### Documentation Changes Required
No
