### PR TITLE
[4.0] Fix extension SQL check for generic components, modules and plugins

### DIFF
--- a/administrator/components/com_installer/src/Model/DatabaseModel.php
+++ b/administrator/components/com_installer/src/Model/DatabaseModel.php
@@ -147,7 +147,7 @@ class DatabaseModel extends InstallerModel
 
 			$db        = $this->getDbo();
 
-			if ($result->type === 'component' || $result->type === 'file')
+			if ($result->type === 'component')
 			{
 				$basePath = JPATH_ADMINISTRATOR . '/components/' . $result->element;
 			}

--- a/administrator/components/com_installer/src/Model/DatabaseModel.php
+++ b/administrator/components/com_installer/src/Model/DatabaseModel.php
@@ -217,6 +217,12 @@ class DatabaseModel extends InstallerModel
 			// than the update files, add to problems message
 			$schema = $changeSet->getSchema();
 
+			// If the schema is empty we couldn't find any update files. Just ignore the extension.
+			if (empty($schema))
+			{
+				continue;
+			}
+
 			if ($result->version_id !== $schema)
 			{
 				$errorMessages[] = Text::sprintf('COM_INSTALLER_MSG_DATABASE_SCHEMA_ERROR', $result->version_id, $schema);

--- a/administrator/components/com_installer/src/Model/DatabaseModel.php
+++ b/administrator/components/com_installer/src/Model/DatabaseModel.php
@@ -189,14 +189,12 @@ class DatabaseModel extends InstallerModel
 
 			if (!file_exists($folderTmp))
 			{
-				if ($result->type === 'plugin')
-				{
-					$installationXML = InstallerHelper::getInstallationXML($result->element, $result->type, $result->client_id, $result->folder);
-				}
-				else
-				{
-					$installationXML = InstallerHelper::getInstallationXML($result->element, $result->type, $result->client_id);
-				}
+				$installationXML = InstallerHelper::getInstallationXML(
+					$result->element,
+					$result->type,
+					$result->client_id,
+					$result->type === 'plugin' ? $result->folder : null
+				);
 
 				if ($installationXML !== null)
 				{
@@ -556,14 +554,12 @@ class DatabaseModel extends InstallerModel
 		}
 		else
 		{
-			if ($extension->type === 'plugin')
-			{
-				$installationXML = InstallerHelper::getInstallationXML($extension->element, $extension->type, $extension->client_id, $extension->folder);
-			}
-			else
-			{
-				$installationXML = InstallerHelper::getInstallationXML($extension->element, $extension->type, $extension->client_id);
-			}
+			$installationXML = InstallerHelper::getInstallationXML(
+				$extension->element,
+				$extension->type,
+				$extension->client_id,
+				$extension->type === 'plugin' ? $extension->folder : null
+			);
 
 			$extensionVersion = (string) $installationXML->version;
 		}

--- a/administrator/components/com_installer/src/Model/DatabaseModel.php
+++ b/administrator/components/com_installer/src/Model/DatabaseModel.php
@@ -157,11 +157,12 @@ class DatabaseModel extends InstallerModel
 			}
 			elseif ($result->type === 'module')
 			{
-				if ($result->client_id === 1)
+				// Typehint to integer to normalise some DBs returning strings and others integers
+				if ((int) $result->client_id === 1)
 				{
 					$basePath = JPATH_ADMINISTRATOR . '/modules/' . $result->element;
 				}
-				elseif ($result->client_id === 0)
+				elseif ((int) $result->client_id === 0)
 				{
 					$basePath = JPATH_SITE . '/modules/' . $result->element;
 				}

--- a/administrator/components/com_installer/src/Model/DatabaseModel.php
+++ b/administrator/components/com_installer/src/Model/DatabaseModel.php
@@ -173,7 +173,7 @@ class DatabaseModel extends InstallerModel
 				}
 			}
 			// Specific bodge for the Joomla CMS special database check which points to com_admin
-			elseif ($result->type === 'file' && $result->name === 'files_joomla')
+			elseif ($result->type === 'file' && $result->element === 'com_admin')
 			{
 				$basePath = JPATH_ADMINISTRATOR . '/components/' . $result->element;
 			}

--- a/administrator/components/com_installer/src/Model/InstallerModel.php
+++ b/administrator/components/com_installer/src/Model/InstallerModel.php
@@ -15,6 +15,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
 use Joomla\CMS\MVC\Model\ListModel;
+use Joomla\Database\DatabaseQuery;
 use Joomla\Utilities\ArrayHelper;
 
 /**
@@ -54,9 +55,9 @@ class InstallerModel extends ListModel
 	/**
 	 * Returns an object list
 	 *
-	 * @param   \JDatabaseQuery  $query       The query
-	 * @param   int              $limitstart  Offset
-	 * @param   int              $limit       The number of records
+	 * @param   DatabaseQuery  $query       The query
+	 * @param   int            $limitstart  Offset
+	 * @param   int            $limit       The number of records
 	 *
 	 * @return  array
 	 */

--- a/libraries/src/Schema/ChangeSet.php
+++ b/libraries/src/Schema/ChangeSet.php
@@ -256,7 +256,7 @@ class ChangeSet
 	/**
 	 * Get list of SQL update files for this database
 	 *
-	 * @return  array|bool  list of sql update full-path names. False if directory doesn't exist
+	 * @return  array|boolean  list of sql update full-path names. False if directory doesn't exist
 	 *
 	 * @since   2.5
 	 */

--- a/libraries/src/Schema/ChangeSet.php
+++ b/libraries/src/Schema/ChangeSet.php
@@ -241,6 +241,13 @@ class ChangeSet
 	public function getSchema()
 	{
 		$updateFiles = $this->getUpdateFiles();
+
+		// No schema files found - abort and return empty string
+		if (empty($updateFiles))
+		{
+			return '';
+		}
+
 		$result = new \SplFileInfo(array_pop($updateFiles));
 
 		return $result->getBasename('.sql');
@@ -249,7 +256,7 @@ class ChangeSet
 	/**
 	 * Get list of SQL update files for this database
 	 *
-	 * @return  array  list of sql update full-path names
+	 * @return  array|bool  list of sql update full-path names. False if directory doesn't exist
 	 *
 	 * @since   2.5
 	 */
@@ -268,6 +275,13 @@ class ChangeSet
 		if (!$this->folder)
 		{
 			$this->folder = JPATH_ADMINISTRATOR . '/components/com_admin/sql/updates/';
+		}
+
+		// We don't want to enqueue an error if the directory doesn't exist - this can be handled elsewhere/
+		// So bail here.
+		if (!is_dir($this->folder . '/' . $sqlFolder))
+		{
+			return [];
 		}
 
 		return Folder::files(

--- a/libraries/src/Schema/ChangeSet.php
+++ b/libraries/src/Schema/ChangeSet.php
@@ -69,6 +69,13 @@ class ChangeSet
 		$this->db = $db;
 		$this->folder = $folder;
 		$updateFiles = $this->getUpdateFiles();
+
+		// If no files were found nothing more we can do - continue
+		if ($updateFiles === false)
+		{
+			return;
+		}
+
 		$updateQueries = $this->getUpdateQueries($updateFiles);
 
 		foreach ($updateQueries as $obj)


### PR DESCRIPTION
This code should work as it is but it's in draft as I need to create some dummy plugins and modules for people to test with.

### Summary of Changes
Fixes Joomla database checker for 3rd party modules and plugins

### Testing Instructions
Install the following 4 sample extensions: 

[test_module_admin_update_files.zip](https://github.com/joomla/joomla-cms/files/5220889/test_module_admin_update_files.zip)
[test_module_site_update_files.zip](https://github.com/joomla/joomla-cms/files/5220891/test_module_site_update_files.zip)
[test_plugin_update_files.zip](https://github.com/joomla/joomla-cms/files/5220892/test_plugin_update_files.zip)
[test_plugin_wrong_files.zip](https://github.com/joomla/joomla-cms/files/5220893/test_plugin_wrong_files.zip)

there's two plugins, a backend module and a frontend module. Before patch the database checker page will give an exception:

<img width="1278" alt="Screenshot 2020-09-14 at 21 52 18" src="https://user-images.githubusercontent.com/1986000/93136878-90240200-f6d4-11ea-8328-617f46d451c0.png">

After the patch the checker will show 3 of the extensions (one plugin and two modules) and won't list a plugin that is in an 'unexpected location' (see note on doc required change below if you're interested as to why)

<img width="1280" alt="Screenshot 2020-09-14 at 21 52 45" src="https://user-images.githubusercontent.com/1986000/93136933-a0d47800-f6d4-11ea-86fd-687fd8966600.png">

### Documentation Changes Required
We need to document that for database fixer to work updates must exist in the format updates/mysql or updates/postgresql (at any level) - if you have mysql/updates as a folder structure the extension will be ignored by the schema checker.
