### PR TITLE
[4.0] Fix colouring of "Fluid Layout" toggle in Cassiopeia's template style options

### DIFF
--- a/templates/cassiopeia/templateDetails.xml
+++ b/templates/cassiopeia/templateDetails.xml
@@ -76,8 +76,8 @@
 					default="0"
 					label="TPL_CASSIOPEIA_FLUID_LABEL"
 					>
-					<option value="1">TPL_CASSIOPEIA_FLUID</option>
 					<option value="0">TPL_CASSIOPEIA_STATIC</option>
+					<option value="1">TPL_CASSIOPEIA_FLUID</option>
 				</field>
 
 				<field


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Change order of options of the "Fluid Layout" toggle in Cassiopeia's template style options so it is like for other toggle buttons.

### Testing Instructions

Check in the template style's advanced options of Cassiopeia how the toggle buttons are coloured when being not enabled and when being enabled.

### Actual result BEFORE applying this Pull Request

When not enabled, "Fluid Layout" is coloured green (see red mark in screenshot below), while other toggles are grey when not being enabled (see green mark below):
![j4-cassiopeia-fluid_1](https://user-images.githubusercontent.com/7413183/93019272-3806d600-f5d6-11ea-9ad1-056e914af7c9.png)

When enabled, "Fluid Layout" is coloured grey (see red mark in screenshot below), while other toggles are green when being enabled (see green mark below):
![j4-cassiopeia-fluid_2](https://user-images.githubusercontent.com/7413183/93019275-3e954d80-f5d6-11ea-9927-21adc3ca29fa.png)

### Expected result AFTER applying this Pull Request

Grey when "Fluid Layout" is not enabled, i.e. static layout is used:
![j4-cassiopeia-fluid_3](https://user-images.githubusercontent.com/7413183/93019122-4b657180-f5d5-11ea-8a57-aa36b33c8a21.png)

Green when "Fluid Layout" is enabled:
![j4-cassiopeia-fluid_4](https://user-images.githubusercontent.com/7413183/93019123-4ef8f880-f5d5-11ea-98f4-ae055e160add.png)

### Documentation Changes Required

None.