### PR TITLE
align icons in mod_login

### DIFF
--- a/modules/mod_login/tmpl/default.php
+++ b/modules/mod_login/tmpl/default.php
@@ -39,7 +39,7 @@ Text::script('JHIDEPASSWORD');
 					<span class="input-group-append">
 						<label for="modlgn-username-<?php echo $module->id; ?>" class="sr-only"><?php echo Text::_('MOD_LOGIN_VALUE_USERNAME'); ?></label>
 						<span class="input-group-text" title="<?php echo Text::_('MOD_LOGIN_VALUE_USERNAME'); ?>">
-							<span class="fas fa-user" aria-hidden="true"></span>
+							<span class="fas fa-user fa-fw" aria-hidden="true"></span>
 						</span>
 					</span>
 				</div>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Aligns icons in mod_login


### Testing Instructions
visually inspect icon alignment.
apply patch
verify icons are now aligned.

### Actual result BEFORE applying this Pull Request
![image](https://user-images.githubusercontent.com/1850089/93026138-67fbac80-f5c9-11ea-95b9-20006c093c0a.png)

### Expected result AFTER applying this Pull Request
![image](https://user-images.githubusercontent.com/1850089/93026127-53b7af80-f5c9-11ea-9ff5-d4e81e64951c.png)

### Documentation Changes Required
none