### PR TITLE
[4.0][DRAFT] replace hard coded icon by jlayout

### DIFF
--- a/administrator/components/com_actionlogs/src/Field/PlugininfoField.php
+++ b/administrator/components/com_actionlogs/src/Field/PlugininfoField.php
@@ -15,6 +15,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Form\FormField;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
 /**
@@ -59,9 +60,8 @@ class PlugininfoField extends FormField
 		);
 
 		return '<div class="alert alert-info">'
-			. '<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only">'
-			. Text::_('INFO')
-			. '</span>'
+			. LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info'])
+			. '<span class="sr-only">' . Text::_('INFO') . '</span>'
 			. Text::sprintf('PLG_SYSTEM_ACTIONLOGS_JOOMLA_ACTIONLOG_DISABLED_REDIRECT', $link)
 			. '</div>';
 	}

--- a/administrator/components/com_actionlogs/tmpl/actionlogs/default.php
+++ b/administrator/components/com_actionlogs/tmpl/actionlogs/default.php
@@ -34,7 +34,8 @@ $wa->useScript('keepalive')
 		<?php echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
 		<?php if (empty($this->items)) : ?>
 			<div class="alert alert-info">
-				<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+				<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+				<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 				<?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
 			</div>
 		<?php else : ?>

--- a/administrator/components/com_admin/tmpl/profile/edit.php
+++ b/administrator/components/com_admin/tmpl/profile/edit.php
@@ -75,7 +75,8 @@ $fieldsets = $this->form->getFieldsets();
 		</div>
 		<?php if (empty($this->otpConfig->otep)) : ?>
 			<div class="alert alert-warning">
-				<span class="fas fa-exclamation-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('WARNING'); ?></span>
+				<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'warning']); ?>
+				<span class="sr-only"><?php echo Text::_('WARNING'); ?></span>
 				<?php echo Text::_('COM_ADMIN_PROFILE_OTEPS_WAIT_DESC'); ?>
 			</div>
 		<?php else : ?>

--- a/administrator/components/com_admin/tmpl/profile/edit.php
+++ b/administrator/components/com_admin/tmpl/profile/edit.php
@@ -12,6 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\Component\Users\Administrator\Helper\UsersHelper;
 
@@ -68,7 +69,8 @@ $fieldsets = $this->form->getFieldsets();
 			<?php echo Text::_('COM_ADMIN_PROFILE_OTEPS'); ?>
 		</legend>
 		<div class="alert alert-info">
-			<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+			<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+			<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 			<?php echo Text::_('COM_ADMIN_PROFILE_OTEPS_DESC'); ?>
 		</div>
 		<?php if (empty($this->otpConfig->otep)) : ?>

--- a/administrator/components/com_associations/src/Field/Modal/AssociationField.php
+++ b/administrator/components/com_associations/src/Field/Modal/AssociationField.php
@@ -71,7 +71,8 @@ class AssociationField extends FormField
 			. ' data-select="' . Text::_('COM_ASSOCIATIONS_SELECT_TARGET') . '"'
 			. ' data-change="' . Text::_('COM_ASSOCIATIONS_CHANGE_TARGET') . '"'
 			. ' data-target="#associationSelect' . $this->id . 'Modal">'
-			. '<span class="fas fa-file" aria-hidden="true"></span> '
+			. LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'file'])
+			. ' '
 			. '<span id="select-change-text"></span>'
 			. '</button>';
 

--- a/administrator/components/com_associations/src/Field/Modal/AssociationField.php
+++ b/administrator/components/com_associations/src/Field/Modal/AssociationField.php
@@ -15,6 +15,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Form\FormField;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Session\Session;
 
 /**
@@ -80,7 +81,8 @@ class AssociationField extends FormField
 			. ' class="btn btn-secondary' . ($value ? '' : ' hidden') . '"'
 			. ' onclick="return Joomla.submitbutton(\'undo-association\');"'
 			. ' id="remove-assoc">'
-			. '<span class="fas fa-times" aria-hidden="true"></span> ' . Text::_('JCLEAR')
+			. LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'times'])
+			. ' ' . Text::_('JCLEAR')
 			. '</button>';
 
 		$html[] = '<input type="hidden" id="' . $this->id . '_id" name="' . $this->name . '" value="' . $value . '">';

--- a/administrator/components/com_associations/src/View/Association/HtmlView.php
+++ b/administrator/components/com_associations/src/View/Association/HtmlView.php
@@ -15,6 +15,7 @@ use Joomla\CMS\Application\AdministratorApplication;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Object\CMSObject;
@@ -370,13 +371,15 @@ class HtmlView extends BaseHtmlView
 
 		$bar->appendButton(
 			'Custom', '<joomla-toolbar-button><button onclick="Joomla.submitbutton(\'reference\')" '
-			. 'class="btn btn-success"><span class="fas fa-save" aria-hidden="true"></span>'
+			. 'class="btn btn-success">'
+			. LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'save'])
 			. Text::_('COM_ASSOCIATIONS_SAVE_REFERENCE') . '</button></joomla-toolbar-button>', 'reference'
 		);
 
 		$bar->appendButton(
 			'Custom', '<joomla-toolbar-button><button onclick="Joomla.submitbutton(\'target\')" '
-			. 'class="btn btn-success"><span class="fas fa-save" aria-hidden="true"></span>'
+			. 'class="btn btn-success">'
+			. LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'save'])
 			. Text::_('COM_ASSOCIATIONS_SAVE_TARGET') . '</button></joomla-toolbar-button>', 'target'
 		);
 

--- a/administrator/components/com_associations/tmpl/associations/default.php
+++ b/administrator/components/com_associations/tmpl/associations/default.php
@@ -27,10 +27,10 @@ $listDirn         = $this->escape($this->state->get('list.direction'));
 $canManageCheckin = Factory::getUser()->authorise('core.manage', 'com_checkin');
 
 $iconStates = array(
-	-2 => 'fas fa-trash',
-	0  => 'fas fa-times',
-	1  => 'fas fa-check',
-	2  => 'fas fa-folder',
+	-2 => 'trash',
+	0  => 'times',
+	1  => 'check',
+	2  => 'folder',
 );
 
 Text::script('COM_ASSOCIATIONS_PURGE_CONFIRM_PROMPT', true);
@@ -102,7 +102,7 @@ Text::script('COM_ASSOCIATIONS_PURGE_CONFIRM_PROMPT', true);
 							<tr class="row<?php echo $i % 2; ?>">
 								<?php if (!empty($this->typeSupports['state'])) : ?>
 									<td class="text-center">
-										<span class="<?php echo $iconStates[$this->escape($item->state)]; ?>"></span>
+										<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => $iconStates[$this->escape($item->state)]]); ?>
 									</td>
 								<?php endif; ?>
 								<th scope="row" class="has-context">

--- a/administrator/components/com_associations/tmpl/associations/default.php
+++ b/administrator/components/com_associations/tmpl/associations/default.php
@@ -43,12 +43,14 @@ Text::script('COM_ASSOCIATIONS_PURGE_CONFIRM_PROMPT', true);
 				<?php echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
 				<?php if ($this->state->get('itemtype') == '' || $this->state->get('language') == '') : ?>
 					<div class="alert alert-info">
-						<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+						<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+						<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 						<?php echo Text::_('COM_ASSOCIATIONS_NOTICE_NO_SELECTORS'); ?>
 					</div>
 				<?php elseif (empty($this->items)) : ?>
 					<div class="alert alert-info">
-						<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+						<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+						<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 						<?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
 					</div>
 				<?php else : ?>

--- a/administrator/components/com_associations/tmpl/associations/modal.php
+++ b/administrator/components/com_associations/tmpl/associations/modal.php
@@ -36,10 +36,10 @@ $listDirn         = $this->escape($this->state->get('list.direction'));
 $canManageCheckin = Factory::getUser()->authorise('core.manage', 'com_checkin');
 
 $iconStates = array(
-	-2 => 'fas fa-trash',
-	0  => 'fas fa-times',
-	1  => 'fas fa-check',
-	2  => 'fas fa-folder',
+	-2 => 'trash',
+	0  => 'times',
+	1  => 'check',
+	2  => 'folder',
 );
 
 $this->document->addScriptOptions('associations-modal', ['func' => $function]);
@@ -101,7 +101,7 @@ $this->document->addScriptOptions('associations-modal', ['func' => $function]);
 				<tr class="row<?php echo $i % 2; ?>">
 					<?php if (!empty($this->typeSupports['state'])) : ?>
 						<td class="text-center tbody-icon">
-							<span class="<?php echo $iconStates[$this->escape($item->state)]; ?>" aria-hidden="true"></span>
+							<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => $iconStates[$this->escape($item->state)]]); ?>
 						</td>
 					<?php endif; ?>
 					<th scope="row" class="has-context">

--- a/administrator/components/com_associations/tmpl/associations/modal.php
+++ b/administrator/components/com_associations/tmpl/associations/modal.php
@@ -51,7 +51,8 @@ $this->document->addScriptOptions('associations-modal', ['func' => $function]);
 		<?php echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
 		<?php if (empty($this->items)) : ?>
 			<div class="alert alert-info">
-				<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+				<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+				<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 				<?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
 			</div>
 		<?php else : ?>

--- a/administrator/components/com_banners/src/Field/ClicksField.php
+++ b/administrator/components/com_banners/src/Field/ClicksField.php
@@ -13,6 +13,7 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Form\FormField;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 
 /**
  * Clicks field.
@@ -43,6 +44,7 @@ class ClicksField extends FormField
 		return '<div class="input-group"><input class="form-control" type="text" name="' . $this->name . '" id="' . $this->id . '" value="'
 			. htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '" readonly="readonly">'
 			. '<span class="input-group-append"><button type="button" class="btn btn-secondary" ' . $onclick . '>'
-			. '<span class="fas fa-sync" aria-hidden="true"></span> ' . Text::_('COM_BANNERS_RESET_CLICKS') . '</button></span></div>';
+			. LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'refresh'])
+			. ' ' . Text::_('COM_BANNERS_RESET_CLICKS') . '</button></span></div>';
 	}
 }

--- a/administrator/components/com_banners/src/Field/ImpmadeField.php
+++ b/administrator/components/com_banners/src/Field/ImpmadeField.php
@@ -13,6 +13,7 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Form\FormField;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 
 /**
  * Impressions field.
@@ -43,6 +44,7 @@ class ImpmadeField extends FormField
 		return '<div class="input-group"><input class="form-control" type="text" name="' . $this->name . '" id="' . $this->id . '" value="'
 			. htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '" readonly="readonly">'
 			. '<span class="input-group-append"><button type="button" class="btn btn-secondary" ' . $onclick . '>'
-			. '<span class="fas fa-sync" aria-hidden="true"></span> ' . Text::_('COM_BANNERS_RESET_IMPMADE') . '</button></span></div>';
+			. LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'refresh'])
+			. ' ' . Text::_('COM_BANNERS_RESET_IMPMADE') . '</button></span></div>';
 	}
 }

--- a/administrator/components/com_banners/tmpl/banners/default.php
+++ b/administrator/components/com_banners/tmpl/banners/default.php
@@ -43,7 +43,8 @@ if ($saveOrder && !empty($this->items))
 				?>
 				<?php if (empty($this->items)) : ?>
 					<div class="alert alert-info">
-						<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+						<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+						<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 						<?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
 					</div>
 				<?php else : ?>

--- a/administrator/components/com_banners/tmpl/banners/default.php
+++ b/administrator/components/com_banners/tmpl/banners/default.php
@@ -117,7 +117,7 @@ if ($saveOrder && !empty($this->items))
 										}
 										?>
 										<span class="sortable-handler <?php echo $iconClass ?>">
-											<span class="fas fa-ellipsis-v" aria-hidden="true"></span>
+											 <?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'ellipsis-v']); ?>
 										</span>
 										<?php if ($canChange && $saveOrder) : ?>
 											<input type="text" name="order[]" size="5"

--- a/administrator/components/com_banners/tmpl/clients/default.php
+++ b/administrator/components/com_banners/tmpl/clients/default.php
@@ -74,7 +74,7 @@ $params     = $this->state->params ?? new CMSObject;
 									<span class="sr-only"><?php echo Text::_('COM_BANNERS_COUNT_PUBLISHED_ITEMS'); ?></span>
 								</th>
 								<th scope="col" class="w-3 text-center d-none d-md-table-cell">
-									<span class="fas fa-times" aria-hidden="true" title="<?php echo Text::_('COM_BANNERS_COUNT_UNPUBLISHED_ITEMS'); ?>"></span>
+									<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'times', 'title' => Text::_('COM_BANNERS_COUNT_UNPUBLISHED_ITEMS')]); ?>
 									<span class="sr-only"><?php echo Text::_('COM_BANNERS_COUNT_UNPUBLISHED_ITEMS'); ?></span>
 								</th>
 								<th scope="col" class="w-3 text-center d-none d-md-table-cell">

--- a/administrator/components/com_banners/tmpl/clients/default.php
+++ b/administrator/components/com_banners/tmpl/clients/default.php
@@ -82,7 +82,7 @@ $params     = $this->state->params ?? new CMSObject;
 									<span class="sr-only"><?php echo Text::_('COM_BANNERS_COUNT_ARCHIVED_ITEMS'); ?></span>
 								</th>
 								<th scope="col" class="w-3 text-center d-none d-md-table-cell">
-									<span class="fas fa-trash" aria-hidden="true" title="<?php echo Text::_('COM_BANNERS_COUNT_TRASHED_ITEMS'); ?>"></span>
+									<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'trash', 'title' => Text::_('COM_BANNERS_COUNT_TRASHED_ITEMS')]); ?>
 									<span class="sr-only"><?php echo Text::_('COM_BANNERS_COUNT_TRASHED_ITEMS'); ?></span>
 								</th>
 								<th scope="col" class="w-10 d-none d-md-table-cell">

--- a/administrator/components/com_banners/tmpl/clients/default.php
+++ b/administrator/components/com_banners/tmpl/clients/default.php
@@ -44,7 +44,8 @@ $params     = $this->state->params ?? new CMSObject;
 				?>
 				<?php if (empty($this->items)) : ?>
 					<div class="alert alert-info">
-						<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+						<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+						<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 						<?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
 					</div>
 				<?php else : ?>

--- a/administrator/components/com_banners/tmpl/clients/default.php
+++ b/administrator/components/com_banners/tmpl/clients/default.php
@@ -78,7 +78,7 @@ $params     = $this->state->params ?? new CMSObject;
 									<span class="sr-only"><?php echo Text::_('COM_BANNERS_COUNT_UNPUBLISHED_ITEMS'); ?></span>
 								</th>
 								<th scope="col" class="w-3 text-center d-none d-md-table-cell">
-									<span class="fas fa-folder" aria-hidden="true" title="<?php echo Text::_('COM_BANNERS_COUNT_ARCHIVED_ITEMS'); ?>"></span>
+									<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'folder', 'title' => Text::_('COM_BANNERS_COUNT_ARCHIVED_ITEMS')]); ?>
 									<span class="sr-only"><?php echo Text::_('COM_BANNERS_COUNT_ARCHIVED_ITEMS'); ?></span>
 								</th>
 								<th scope="col" class="w-3 text-center d-none d-md-table-cell">

--- a/administrator/components/com_banners/tmpl/tracks/default.php
+++ b/administrator/components/com_banners/tmpl/tracks/default.php
@@ -26,7 +26,8 @@ $listDirn   = $this->escape($this->state->get('list.direction'));
 				<?php echo LayoutHelper::render('joomla.searchtools.default', ['view' => $this]); ?>
 				<?php if (empty($this->items)) : ?>
 					<div class="alert alert-info">
-						<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+						<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+						<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 						<?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
 					</div>
 				<?php else : ?>

--- a/administrator/components/com_cache/tmpl/cache/default.php
+++ b/administrator/components/com_cache/tmpl/cache/default.php
@@ -30,14 +30,15 @@ $wa->useScript('keepalive')
 		<div class="col-md-12">
 			<div id="j-main-container" class="j-main-container">
 				<div class="alert alert-info">
-					<span class="fas fa-info-circle" aria-hidden="true"></span>
+					<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
 					<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 					<?php echo Text::_('COM_CACHE_PURGE_INSTRUCTIONS'); ?>
 				</div>
 				<?php echo LayoutHelper::render('joomla.searchtools.default', ['view' => $this]); ?>
 				<?php if (!$this->data) : ?>
 					<div class="alert alert-info">
-						<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+						<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+						<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 						<?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
 					</div>
 				<?php else : ?>

--- a/administrator/components/com_categories/src/Field/Modal/CategoryField.php
+++ b/administrator/components/com_categories/src/Field/Modal/CategoryField.php
@@ -16,6 +16,7 @@ use Joomla\CMS\Form\FormField;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\LanguageHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Session\Session;
 use Joomla\Database\ParameterType;
 
@@ -178,7 +179,8 @@ class CategoryField extends FormField
 				. ' data-toggle="modal"'
 				. ' type="button"'
 				. ' data-target="#ModalNew' . $modalId . '">'
-				. '<span class="fas fa-plus" aria-hidden="true"></span> ' . Text::_('JACTION_CREATE')
+				. LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'new'])
+				. ' ' . Text::_('JACTION_CREATE')
 				. '</button>';
 		}
 

--- a/administrator/components/com_categories/src/Field/Modal/CategoryField.php
+++ b/administrator/components/com_categories/src/Field/Modal/CategoryField.php
@@ -205,7 +205,8 @@ class CategoryField extends FormField
 				. ' id="' . $this->id . '_clear"'
 				. ' type="button"'
 				. ' onclick="window.processModalParent(\'' . $this->id . '\'); return false;">'
-				. '<span class="fas fa-times" aria-hidden="true"></span> ' . Text::_('JCLEAR')
+				. LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'times'])
+				. Text::_('JCLEAR')
 				. '</button>';
 		}
 

--- a/administrator/components/com_categories/tmpl/categories/default.php
+++ b/administrator/components/com_categories/tmpl/categories/default.php
@@ -97,7 +97,7 @@ if ($saveOrder && !empty($this->items))
 								<?php endif; ?>
 								<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_archived')) : ?>
 									<th scope="col" class="w-3 text-center d-none d-md-table-cell">
-										<span class="fas fa-folder" aria-hidden="true" title="<?php echo Text::_('COM_CATEGORY_COUNT_ARCHIVED_ITEMS'); ?>"></span>
+										<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'folder', 'title' => Text::_('COM_CATEGORY_COUNT_ARCHIVED_ITEMS')]); ?>
 										<span class="sr-only"><?php echo Text::_('COM_CATEGORY_COUNT_ARCHIVED_ITEMS'); ?></span>
 									</th>
 								<?php endif; ?>

--- a/administrator/components/com_categories/tmpl/categories/default.php
+++ b/administrator/components/com_categories/tmpl/categories/default.php
@@ -85,7 +85,7 @@ if ($saveOrder && !empty($this->items))
 								</th>
 								<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_published')) : ?>
 									<th scope="col" class="w-3 text-center d-none d-md-table-cell">
-										<span class="fas fa-check" aria-hidden="true" title="<?php echo Text::_('COM_CATEGORY_COUNT_PUBLISHED_ITEMS'); ?>"></span>
+										<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'check', 'title' => Text::_('COM_CATEGORY_COUNT_PUBLISHED_ITEMS')]); ?>
 										<span class="sr-only"><?php echo Text::_('COM_CATEGORY_COUNT_PUBLISHED_ITEMS'); ?></span>
 									</th>
 								<?php endif; ?>

--- a/administrator/components/com_categories/tmpl/categories/default.php
+++ b/administrator/components/com_categories/tmpl/categories/default.php
@@ -91,7 +91,7 @@ if ($saveOrder && !empty($this->items))
 								<?php endif; ?>
 								<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_unpublished')) : ?>
 									<th scope="col" class="w-3 text-center d-none d-md-table-cell">
-										<span class="fas fa-times" aria-hidden="true" title="<?php echo Text::_('COM_CATEGORY_COUNT_UNPUBLISHED_ITEMS'); ?>"></span>
+										<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'times', 'title' => Text::_('COM_CATEGORY_COUNT_UNPUBLISHED_ITEMS')]); ?>
 										<span class="sr-only"><?php echo Text::_('COM_CATEGORY_COUNT_UNPUBLISHED_ITEMS'); ?></span>
 									</th>
 								<?php endif; ?>

--- a/administrator/components/com_categories/tmpl/categories/default.php
+++ b/administrator/components/com_categories/tmpl/categories/default.php
@@ -176,7 +176,7 @@ if ($saveOrder && !empty($this->items))
 										}
 										?>
 										<span class="sortable-handler<?php echo $iconClass ?>">
-											<span class="fas fa-ellipsis-v"></span>
+											<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'ellipsis-v']); ?>
 										</span>
 										<?php if ($canChange && $saveOrder) : ?>
 											<input type="text" class="hidden" name="order[]" size="5" value="<?php echo $item->lft; ?>">

--- a/administrator/components/com_categories/tmpl/categories/default.php
+++ b/administrator/components/com_categories/tmpl/categories/default.php
@@ -103,7 +103,7 @@ if ($saveOrder && !empty($this->items))
 								<?php endif; ?>
 								<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_trashed')) : ?>
 									<th scope="col" class="w-3 text-center d-none d-md-table-cell">
-										<span class="fas fa-trash" aria-hidden="true" title="<?php echo Text::_('COM_CATEGORY_COUNT_TRASHED_ITEMS'); ?>"></span>
+										<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'trash', 'title' => Text::_('COM_CATEGORY_COUNT_TRASHED_ITEMS')]); ?>
 										<span class="sr-only"><?php echo Text::_('COM_CATEGORY_COUNT_TRASHED_ITEMS'); ?></span>
 									</th>
 								<?php endif; ?>

--- a/administrator/components/com_categories/tmpl/categories/default.php
+++ b/administrator/components/com_categories/tmpl/categories/default.php
@@ -58,7 +58,8 @@ if ($saveOrder && !empty($this->items))
 				?>
 				<?php if (empty($this->items)) : ?>
 					<div class="alert alert-info">
-						<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+						<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+						<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 						<?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
 					</div>
 				<?php else : ?>

--- a/administrator/components/com_categories/tmpl/categories/modal.php
+++ b/administrator/components/com_categories/tmpl/categories/modal.php
@@ -40,7 +40,8 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 
 		<?php if (empty($this->items)) : ?>
 			<div class="alert alert-info">
-				<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+				<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+				<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 				<?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
 			</div>
 		<?php else : ?>

--- a/administrator/components/com_categories/tmpl/categories/modal.php
+++ b/administrator/components/com_categories/tmpl/categories/modal.php
@@ -72,10 +72,10 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 				<tbody>
 					<?php
 					$iconStates = array(
-						-2 => 'fas fa-trash',
-						0  => 'fas fa-times',
-						1  => 'fas fa-check',
-						2  => 'fas fa-folder',
+						-2 => 'trash',
+						0  => 'times',
+						1  => 'check',
+						2  => 'folder',
 					);
 					?>
 					<?php foreach ($this->items as $i => $item) : ?>
@@ -102,7 +102,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 						?>
 						<tr class="row<?php echo $i % 2; ?>">
 							<td class="text-center tbody-icon">
-								<span class="<?php echo $iconStates[$this->escape($item->published)]; ?>" aria-hidden="true"></span>
+								<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => $iconStates[$this->escape($item->published)]]); ?>
 							</td>
 							<th scope="row">
 								<?php echo LayoutHelper::render('joomla.html.treeprefix', array('level' => $item->level)); ?>

--- a/administrator/components/com_config/tmpl/component/default.php
+++ b/administrator/components/com_config/tmpl/component/default.php
@@ -13,6 +13,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Form\FormHelper;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
 $app = Factory::getApplication();
@@ -105,7 +106,8 @@ $xml = $this->form->getXml();
 
 					<?php if (!empty($fieldSet->description)) : ?>
 						<div class="tab-description alert alert-info">
-							<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+							<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+							<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 							<?php echo Text::_($fieldSet->description); ?>
 						</div>
 					<?php endif; ?>
@@ -133,7 +135,8 @@ $xml = $this->form->getXml();
 
 			<?php else : ?>
 				<div class="alert alert-info">
-					<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+					<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+					<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 					<?php echo Text::_('COM_CONFIG_COMPONENT_NO_CONFIG_FIELDS_MESSAGE'); ?>
 				</div>
 			<?php endif; ?>

--- a/administrator/components/com_contact/src/Field/Modal/ContactField.php
+++ b/administrator/components/com_contact/src/Field/Modal/ContactField.php
@@ -16,6 +16,7 @@ use Joomla\CMS\Form\FormField;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\LanguageHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Session\Session;
 use Joomla\Database\ParameterType;
 
@@ -167,7 +168,8 @@ class ContactField extends FormField
 				. ' data-toggle="modal"'
 				. ' type="button"'
 				. ' data-target="#ModalNew' . $modalId . '">'
-				. '<span class="fas fa-plus" aria-hidden="true"></span> ' . Text::_('JACTION_CREATE')
+				. LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'add'])
+				. ' ' . Text::_('JACTION_CREATE')
 				. '</button>';
 		}
 

--- a/administrator/components/com_contact/src/Field/Modal/ContactField.php
+++ b/administrator/components/com_contact/src/Field/Modal/ContactField.php
@@ -194,7 +194,8 @@ class ContactField extends FormField
 				. ' id="' . $this->id . '_clear"'
 				. ' type="button"'
 				. ' onclick="window.processModalParent(\'' . $this->id . '\'); return false;">'
-				. '<span class="fas fa-times" aria-hidden="true"></span> ' . Text::_('JCLEAR')
+				. LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'times'])
+				. Text::_('JCLEAR')
 				. '</button>';
 		}
 

--- a/administrator/components/com_contact/tmpl/contacts/default.php
+++ b/administrator/components/com_contact/tmpl/contacts/default.php
@@ -40,7 +40,8 @@ if ($saveOrder && !empty($this->items))
 				<?php echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
 				<?php if (empty($this->items)) : ?>
 					<div class="alert alert-info">
-						<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+						<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+						<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 						<?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
 					</div>
 				<?php else : ?>

--- a/administrator/components/com_contact/tmpl/contacts/default.php
+++ b/administrator/components/com_contact/tmpl/contacts/default.php
@@ -118,7 +118,7 @@ if ($saveOrder && !empty($this->items))
 									}
 									?>
 									<span class="sortable-handler<?php echo $iconClass; ?>">
-										<span class="fas fa-ellipsis-v" aria-hidden="true"></span>
+										<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'ellipsis-v']); ?>
 									</span>
 									<?php if ($canChange && $saveOrder) : ?>
 										<input type="text" name="order[]" size="5"

--- a/administrator/components/com_contact/tmpl/contacts/modal.php
+++ b/administrator/components/com_contact/tmpl/contacts/modal.php
@@ -51,7 +51,8 @@ if (!empty($editor))
 
 		<?php if (empty($this->items)) : ?>
 			<div class="alert alert-info">
-				<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+				<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+				<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 				<?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
 			</div>
 		<?php else : ?>

--- a/administrator/components/com_contact/tmpl/contacts/modal.php
+++ b/administrator/components/com_contact/tmpl/contacts/modal.php
@@ -88,10 +88,10 @@ if (!empty($editor))
 				<tbody>
 				<?php
 				$iconStates = array(
-					-2 => 'fas fa-trash',
-					0  => 'fas fa-times',
-					1  => 'fas fa-check',
-					2  => 'fas fa-folder',
+					-2 => 'trash',
+					0  => 'times',
+					1  => 'check',
+					2  => 'folder',
 				);
 				?>
 				<?php foreach ($this->items as $i => $item) : ?>
@@ -117,7 +117,7 @@ if (!empty($editor))
 					?>
 					<tr class="row<?php echo $i % 2; ?>">
 						<td class="text-center tbody-icon">
-							<span class="<?php echo $iconStates[$this->escape($item->published)]; ?>" aria-hidden="true"></span>
+							<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => $iconStates[$this->escape($item->published)]]); ?>
 						</td>
 						<th scope="row">
 							<a class="select-link" href="javascript:void(0)" data-function="<?php echo $this->escape($onclick); ?>" data-id="<?php echo $item->id; ?>" data-title="<?php echo $this->escape($item->name); ?>" data-uri="<?php echo $this->escape(RouteHelper::getContactRoute($item->id, $item->catid, $item->language)); ?>" data-language="<?php echo $this->escape($lang); ?>">

--- a/administrator/components/com_content/src/Field/Modal/ArticleField.php
+++ b/administrator/components/com_content/src/Field/Modal/ArticleField.php
@@ -16,6 +16,7 @@ use Joomla\CMS\Form\FormField;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\LanguageHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Session\Session;
 use Joomla\Database\ParameterType;
 
@@ -170,7 +171,8 @@ class ArticleField extends FormField
 				. ' data-toggle="modal"'
 				. ' type="button"'
 				. ' data-target="#ModalNew' . $modalId . '">'
-				. '<span class="fas fa-plus" aria-hidden="true"></span> ' . Text::_('JACTION_CREATE')
+				. LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'add'])
+				. ' ' . Text::_('JACTION_CREATE')
 				. '</button>';
 		}
 

--- a/administrator/components/com_content/src/Field/Modal/ArticleField.php
+++ b/administrator/components/com_content/src/Field/Modal/ArticleField.php
@@ -197,7 +197,8 @@ class ArticleField extends FormField
 				. ' id="' . $this->id . '_clear"'
 				. ' type="button"'
 				. ' onclick="window.processModalParent(\'' . $this->id . '\'); return false;">'
-				. '<span class="fas fa-times" aria-hidden="true"></span> ' . Text::_('JCLEAR')
+				. LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'times'])
+				. Text::_('JCLEAR')
 				. '</button>';
 		}
 

--- a/administrator/components/com_content/tmpl/articles/default.php
+++ b/administrator/components/com_content/tmpl/articles/default.php
@@ -208,7 +208,7 @@ $assoc = Associations::isEnabled();
 									}
 									?>
 									<span class="sortable-handler<?php echo $iconClass ?>">
-										<span class="fas fa-ellipsis-v" aria-hidden="true"></span>
+										<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'ellipsis-v']); ?>
 									</span>
 									<?php if ($canChange && $saveOrder) : ?>
 										<input type="text" name="order[]" size="5" value="<?php echo $item->ordering; ?>" class="width-20 text-area-order hidden">

--- a/administrator/components/com_content/tmpl/articles/default.php
+++ b/administrator/components/com_content/tmpl/articles/default.php
@@ -102,7 +102,8 @@ $assoc = Associations::isEnabled();
 				?>
 				<?php if (empty($this->items)) : ?>
 					<div class="alert alert-info">
-						<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+						<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+						<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 						<?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
 					</div>
 				<?php else : ?>

--- a/administrator/components/com_content/tmpl/articles/modal.php
+++ b/administrator/components/com_content/tmpl/articles/modal.php
@@ -91,9 +91,9 @@ if (!empty($editor))
 				<tbody>
 				<?php
 				$iconStates = array(
-					-2 => 'fas fa-trash',
-					0  => 'fas fa-times',
-					1  => 'fas fa-check',
+					-2 => 'trash',
+					0  => 'times',
+					1  => 'check',
 				);
 				?>
 				<?php foreach ($this->items as $i => $item) : ?>
@@ -119,7 +119,7 @@ if (!empty($editor))
 					?>
 					<tr class="row<?php echo $i % 2; ?>">
 						<td class="text-center tbody-icon">
-							<span class="<?php echo $iconStates[$this->escape($item->state)]; ?>" aria-hidden="true"></span>
+							<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => $iconStates[$this->escape($item->state)]]); ?>
 						</td>
 						<th scope="row">
 							<?php $attribs = 'data-function="' . $this->escape($onclick) . '"'

--- a/administrator/components/com_content/tmpl/articles/modal.php
+++ b/administrator/components/com_content/tmpl/articles/modal.php
@@ -54,7 +54,8 @@ if (!empty($editor))
 
 		<?php if (empty($this->items)) : ?>
 			<div class="alert alert-info">
-				<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+				<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+				<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 				<?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
 			</div>
 		<?php else : ?>

--- a/administrator/components/com_content/tmpl/featured/default.php
+++ b/administrator/components/com_content/tmpl/featured/default.php
@@ -208,7 +208,7 @@ $assoc = Associations::isEnabled();
 									}
 									?>
 									<span class="sortable-handler<?php echo $iconClass ?>">
-										<span class="fas fa-ellipsis-v" aria-hidden="true"></span>
+										<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'ellipsis-v']); ?>
 									</span>
 									<?php if ($canChange && $saveOrder) : ?>
 										<input type="text" name="order[]" size="5" value="<?php echo $item->ordering; ?>" class="width-20 text-area-order hidden">

--- a/administrator/components/com_content/tmpl/featured/default.php
+++ b/administrator/components/com_content/tmpl/featured/default.php
@@ -99,7 +99,8 @@ $assoc = Associations::isEnabled();
 				?>
 				<?php if (empty($this->items)) : ?>
 					<div class="alert alert-info">
-						<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+						<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+						<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 						<?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
 					</div>
 				<?php else : ?>

--- a/administrator/components/com_contenthistory/tmpl/history/modal.php
+++ b/administrator/components/com_contenthistory/tmpl/history/modal.php
@@ -12,6 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
 
@@ -63,7 +64,7 @@ $wa->useScript('com_contenthistory.admin-history-modal');
 				<span class="d-none d-md-inline"><?php echo Text::_('COM_CONTENTHISTORY_BUTTON_KEEP'); ?></span>
 			</button>
 			<button onclick="if (document.adminForm.boxchecked.value==0){<?php echo $deleteMessage; ?>}else{ Joomla.submitbutton('history.delete')}" class="btn btn-secondary pointer" aria-label="<?php echo Text::_('COM_CONTENTHISTORY_BUTTON_DELETE_DESC'); ?>" title="<?php echo Text::_('COM_CONTENTHISTORY_BUTTON_DELETE_DESC'); ?>">
-				<span class="fas fa-times" aria-hidden="true"></span>
+				<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'times']); ?>
 				<span class="d-none d-md-inline"><?php echo Text::_('COM_CONTENTHISTORY_BUTTON_DELETE'); ?></span>
 			</button>
 		</div>

--- a/administrator/components/com_contenthistory/tmpl/history/modal.php
+++ b/administrator/components/com_contenthistory/tmpl/history/modal.php
@@ -56,7 +56,7 @@ $wa->useScript('com_contenthistory.admin-history-modal');
 				<span class="d-none d-md-inline"><?php echo Text::_('COM_CONTENTHISTORY_BUTTON_PREVIEW'); ?></span>
 			</button>
 			<button id="toolbar-compare" type="button" class="btn btn-secondary" aria-label="<?php echo Text::_('COM_CONTENTHISTORY_BUTTON_COMPARE_DESC'); ?>" title="<?php echo Text::_('COM_CONTENTHISTORY_BUTTON_COMPARE_DESC'); ?>" data-url="<?php echo Route::_('index.php?option=com_contenthistory&view=compare&layout=compare&tmpl=component&' . Session::getFormToken() . '=1'); ?>">
-				<span class="fas fa-search-plus" aria-hidden="true"></span>
+				<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'search-plus']); ?>
 				<span class="d-none d-md-inline"><?php echo Text::_('COM_CONTENTHISTORY_BUTTON_COMPARE'); ?></span>
 			</button>
 			<button onclick="if (document.adminForm.boxchecked.value==0){<?php echo $deleteMessage; ?>}else{ Joomla.submitbutton('history.keep')}" class="btn btn-secondary pointer" aria-label="<?php echo Text::_('COM_CONTENTHISTORY_BUTTON_KEEP_DESC'); ?>" title="<?php echo Text::_('COM_CONTENTHISTORY_BUTTON_KEEP_DESC'); ?>">

--- a/administrator/components/com_contenthistory/tmpl/history/modal.php
+++ b/administrator/components/com_contenthistory/tmpl/history/modal.php
@@ -52,7 +52,7 @@ $wa->useScript('com_contenthistory.admin-history-modal');
 				<span class="d-none d-md-inline"><?php echo Text::_('COM_CONTENTHISTORY_BUTTON_LOAD'); ?></span>
 			</button>
 			<button id="toolbar-preview" type="button" class="btn btn-secondary" aria-label="<?php echo Text::_('COM_CONTENTHISTORY_BUTTON_PREVIEW_DESC'); ?>" title="<?php echo Text::_('COM_CONTENTHISTORY_BUTTON_PREVIEW_DESC'); ?>" data-url="<?php echo Route::_('index.php?option=com_contenthistory&view=preview&layout=preview&tmpl=component&' . Session::getFormToken() . '=1'); ?>">
-				<span class="fas fa-search" aria-hidden="true"></span>
+				<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'search']); ?>
 				<span class="d-none d-md-inline"><?php echo Text::_('COM_CONTENTHISTORY_BUTTON_PREVIEW'); ?></span>
 			</button>
 			<button id="toolbar-compare" type="button" class="btn btn-secondary" aria-label="<?php echo Text::_('COM_CONTENTHISTORY_BUTTON_COMPARE_DESC'); ?>" title="<?php echo Text::_('COM_CONTENTHISTORY_BUTTON_COMPARE_DESC'); ?>" data-url="<?php echo Route::_('index.php?option=com_contenthistory&view=compare&layout=compare&tmpl=component&' . Session::getFormToken() . '=1'); ?>">

--- a/administrator/components/com_cpanel/src/View/Cpanel/HtmlView.php
+++ b/administrator/components/com_cpanel/src/View/Cpanel/HtmlView.php
@@ -124,7 +124,7 @@ class HtmlView extends BaseHtmlView
 				}
 				elseif ($parts[0] === 'help')
 				{
-					$icon = 'fas fa-info-circle';
+					$icon = 'info';
 				}
 				elseif ($lang->hasKey($keyIcon))
 				{

--- a/administrator/components/com_cpanel/tmpl/cpanel/default.php
+++ b/administrator/components/com_cpanel/tmpl/cpanel/default.php
@@ -13,6 +13,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Helper\ModuleHelper;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
 // Load JavaScript message titles
@@ -41,7 +42,8 @@ echo HTMLHelper::_(
 		'url'         => Route::_('index.php?option=com_cpanel&task=addModule&function=jSelectModuleType&position=' . $this->escape($this->position)),
 		'bodyHeight'  => '70',
 		'modalWidth'  => '80',
-		'footer'      => '<button type="button" class="button-cancel btn btn-sm btn-danger" data-dismiss="modal" data-target="#closeBtn"><span class="fas fa-times" aria-hidden="true"></span>'
+		'footer'      => '<button type="button" class="button-cancel btn btn-sm btn-danger" data-dismiss="modal" data-target="#closeBtn">'
+		  . LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'times'])
 			. Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>'
 			. '<button type="button" class="button-save btn btn-sm btn-success hidden" data-target="#saveBtn"><span class="fas fa-copy" aria-hidden="true"></span>'
 			. Text::_('JSAVE') . '</button>',

--- a/administrator/components/com_csp/tmpl/reports/default.php
+++ b/administrator/components/com_csp/tmpl/reports/default.php
@@ -65,7 +65,8 @@ $saveOrder = $listOrder == 'a.id';
 				<?php endif; ?>
 				<?php if (empty($this->items)) : ?>
 					<div class="alert alert-info">
-						<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+						<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+						<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 						<?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
 					</div>
 				<?php else : ?>

--- a/administrator/components/com_fields/tmpl/fields/default.php
+++ b/administrator/components/com_fields/tmpl/fields/default.php
@@ -54,7 +54,8 @@ if ($saveOrder && !empty($this->items))
 				<?php echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this, 'options' => array('selectorFieldName' => 'context'))); ?>
 				<?php if (empty($this->items)) : ?>
 					<div class="alert alert-info">
-						<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+						<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+						<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 						<?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
 					</div>
 				<?php else : ?>

--- a/administrator/components/com_fields/tmpl/fields/default.php
+++ b/administrator/components/com_fields/tmpl/fields/default.php
@@ -117,7 +117,7 @@ if ($saveOrder && !empty($this->items))
 											<?php $iconClass = ' inactive" title="' . Text::_('JORDERINGDISABLED'); ?>
 										<?php endif; ?>
 										<span class="sortable-handler<?php echo $iconClass; ?>">
-											<span class="fas fa-ellipsis-v" aria-hidden="true"></span>
+											<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'ellipsis-v']); ?>
 										</span>
 										<?php if ($canChange && $saveOrder) : ?>
 											<input type="text" class="hidden" name="order[]" size="5" value="<?php echo $item->ordering; ?>">

--- a/administrator/components/com_fields/tmpl/fields/modal.php
+++ b/administrator/components/com_fields/tmpl/fields/modal.php
@@ -73,16 +73,16 @@ $editor    = Factory::getApplication()->input->get('editor', '', 'cmd');
 				<tbody>
 					<?php
 					$iconStates = array(
-						-2 => 'fas fa-trash',
-						0  => 'fas fa-times',
-						1  => 'fas fa-check',
-						2  => 'fas fa-folder',
+						-2 => 'trash',
+						0  => 'times',
+						1  => 'check',
+						2  => 'folder',
 					);
 					foreach ($this->items as $i => $item) :
 					?>
 					<tr class="row<?php echo $i % 2; ?>">
 						<td class="text-center tbody-icon">
-							<span class="<?php echo $iconStates[$this->escape($item->state)]; ?>" aria-hidden="true"></span>
+							<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => $iconStates[$this->escape($item->state)]]); ?>
 						</td>
 						<th scope="row" class="has-context">
 							<a class="btn btn-sm btn-block btn-success" href="#" onclick="Joomla.fieldIns('<?php echo $this->escape($item->id); ?>', '<?php echo $this->escape($editor); ?>');"><?php echo $this->escape($item->title); ?></a>

--- a/administrator/components/com_fields/tmpl/fields/modal.php
+++ b/administrator/components/com_fields/tmpl/fields/modal.php
@@ -35,7 +35,8 @@ $editor    = Factory::getApplication()->input->get('editor', '', 'cmd');
 		<?php echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
 		<?php if (empty($this->items)) : ?>
 			<div class="alert alert-info">
-				<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+				<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+				<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 				<?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
 			</div>
 		<?php else : ?>

--- a/administrator/components/com_fields/tmpl/groups/default.php
+++ b/administrator/components/com_fields/tmpl/groups/default.php
@@ -109,7 +109,7 @@ $context = $this->escape($this->state->get('filter.context'));
 											<?php $iconClass = ' inactive" title="' . Text::_('JORDERINGDISABLED'); ?>
 										<?php endif; ?>
 										<span class="sortable-handler<?php echo $iconClass; ?>">
-											<span class="fas fa-ellipsis-v" aria-hidden="true"></span>
+											<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'ellipsis-v']); ?>
 										</span>
 										<?php if ($canChange && $saveOrder) : ?>
 											<input type="text" class="hidden" name="order[]" size="5" value="<?php echo $item->ordering; ?>">

--- a/administrator/components/com_fields/tmpl/groups/default.php
+++ b/administrator/components/com_fields/tmpl/groups/default.php
@@ -52,7 +52,8 @@ $context = $this->escape($this->state->get('filter.context'));
 				<?php echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this, 'options' => array('selectorFieldName' => 'context'))); ?>
 				<?php if (empty($this->items)) : ?>
 					<div class="alert alert-info">
-						<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+						<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+						<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 						<?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
 					</div>
 				<?php else : ?>

--- a/administrator/components/com_finder/tmpl/filters/default.php
+++ b/administrator/components/com_finder/tmpl/filters/default.php
@@ -34,7 +34,8 @@ $wa->useScript('com_finder.filters');
 				<?php echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
 				<?php if (empty($this->items)) : ?>
 					<div class="alert alert-info">
-						<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+						<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+						<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 						<?php echo Text::_('COM_FINDER_NO_RESULTS_OR_FILTERS'); ?>
 					</div>
 				<?php else : ?>

--- a/administrator/components/com_finder/tmpl/index/default.php
+++ b/administrator/components/com_finder/tmpl/index/default.php
@@ -36,7 +36,8 @@ $wa->useScript('com_finder.index');
 				<?php echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
 				<?php if (empty($this->items)) : ?>
 					<div class="alert alert-info">
-						<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+						<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+						<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 						<?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
 					</div>
 				<?php else : ?>

--- a/administrator/components/com_finder/tmpl/maps/default.php
+++ b/administrator/components/com_finder/tmpl/maps/default.php
@@ -64,7 +64,7 @@ $wa->useScript('com_finder.maps');
 								</th>
 							<?php endif; ?>
 							<th scope="col" class="w-1 text-center">
-								<span class="fas fa-check" aria-hidden="true"></span>
+								<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'check']); ?>
 								<span class="d-none d-md-inline"><?php echo Text::_('COM_FINDER_MAPS_COUNT_PUBLISHED_ITEMS'); ?></span>
 							</th>
 							<th scope="col" class="w-1 text-center">

--- a/administrator/components/com_finder/tmpl/maps/default.php
+++ b/administrator/components/com_finder/tmpl/maps/default.php
@@ -68,7 +68,7 @@ $wa->useScript('com_finder.maps');
 								<span class="d-none d-md-inline"><?php echo Text::_('COM_FINDER_MAPS_COUNT_PUBLISHED_ITEMS'); ?></span>
 							</th>
 							<th scope="col" class="w-1 text-center">
-								<span class="fas fa-times" aria-hidden="true"></span>
+								<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'times']); ?>
 								<span class="d-none d-md-inline"><?php echo Text::_('COM_FINDER_MAPS_COUNT_UNPUBLISHED_ITEMS'); ?></span>
 							</th>
 							<?php if (Multilanguage::isEnabled()) : ?>

--- a/administrator/components/com_finder/tmpl/maps/default.php
+++ b/administrator/components/com_finder/tmpl/maps/default.php
@@ -36,7 +36,8 @@ $wa->useScript('com_finder.maps');
 				<?php echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
 				<?php if (empty($this->items)) : ?>
 					<div class="alert alert-info">
-						<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+						<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+						<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 						<?php echo Text::_('COM_FINDER_MAPS_NO_CONTENT'); ?>
 					</div>
 				<?php else : ?>

--- a/administrator/components/com_finder/tmpl/searches/default.php
+++ b/administrator/components/com_finder/tmpl/searches/default.php
@@ -27,7 +27,8 @@ $listDirn = $this->escape($this->state->get('list.direction'));
 				<?php echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this, 'options' => array('filterButton' => false))); ?>
 				<?php if (empty($this->items)) : ?>
 					<div class="alert alert-info">
-						<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+						<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+						<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 						<?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
 					</div>
 				<?php else : ?>

--- a/administrator/components/com_installer/tmpl/database/default.php
+++ b/administrator/components/com_installer/tmpl/database/default.php
@@ -29,7 +29,8 @@ $listDirection = $this->escape($this->state->get('list.direction'));
 						<?php echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
 						<?php if (empty($this->changeSet)) : ?>
 							<div class="alert alert-info">
-								<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+								<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+								<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 								<?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
 							</div>
 						<?php else : ?>

--- a/administrator/components/com_installer/tmpl/discover/default.php
+++ b/administrator/components/com_installer/tmpl/discover/default.php
@@ -33,11 +33,13 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 					<?php echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
 					<?php if (empty($this->items)) : ?>
 						<div class="alert alert-info">
-							<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+							<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+							<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 							<?php echo Text::_('COM_INSTALLER_MSG_DISCOVER_DESCRIPTION'); ?>
 						</div>
 						<div class="alert alert-info">
-							<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+							<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+							<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 							<?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
 						</div>
 					<?php else : ?>

--- a/administrator/components/com_installer/tmpl/install/default.php
+++ b/administrator/components/com_installer/tmpl/install/default.php
@@ -12,6 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
 // Load JavaScript message titles
@@ -45,7 +46,8 @@ $tabs = $app->triggerEvent('onInstallerAddInstallationTab', []);
 
 					<?php if (!$tabs) : ?>
 						<div class="alert alert-warning">
-							<span class="fas fa-exclamation-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('WARNING'); ?></span>
+							<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'warning']); ?>
+							<span class="sr-only"><?php echo Text::_('WARNING'); ?></span>
 							<?php echo Text::_('COM_INSTALLER_NO_INSTALLATION_PLUGINS_FOUND'); ?>
 						</div>
 					<?php endif; ?>

--- a/administrator/components/com_installer/tmpl/installer/default_ftp.php
+++ b/administrator/components/com_installer/tmpl/installer/default_ftp.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 
 ?>
 <fieldset class="option-fieldset options-form">
@@ -17,7 +18,7 @@ use Joomla\CMS\Language\Text;
 	<legend><?php echo Text::_('COM_INSTALLER_MSG_DESCFTPTITLE'); ?></legend>
 
 	<div class="alert alert-info">
-		<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+		<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 		<?php echo Text::_('COM_INSTALLER_MSG_DESCFTP'); ?>
 	</div>
 

--- a/administrator/components/com_installer/tmpl/languages/default.php
+++ b/administrator/components/com_installer/tmpl/languages/default.php
@@ -81,7 +81,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 										<?php // Display a Note if language pack version is not equal to Joomla version ?>
 										<?php if (strpos($language->version, $minorVersion) !== 0 || strpos($language->version, $currentShortVersion) !== 0) : ?>
 											<span class="badge badge-warning"><?php echo $language->version; ?></span>
-											<span class="fas fa-info-circle" aria-hidden="true" tabindex="0"></span>
+											<?php echo LayoutHelper::render('jooml.icon.iconclass', ['icon' => 'info', 'tabindex' => 0]); ?>
 											<div role="tooltip" class="text-left" id="tip<?php echo $language->code; ?>">
 											<?php echo Text::_('JGLOBAL_LANGUAGE_VERSION_NOT_PLATFORM'); ?>
 											</div>

--- a/administrator/components/com_installer/tmpl/languages/default.php
+++ b/administrator/components/com_installer/tmpl/languages/default.php
@@ -28,7 +28,8 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 					<?php echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this, 'options' => array('filterButton' => false))); ?>
 					<?php if (empty($this->items)) : ?>
 						<div class="alert alert-info">
-							<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+							<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+							<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 							<?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
 						</div>
 					<?php else : ?>

--- a/administrator/components/com_installer/tmpl/manage/default.php
+++ b/administrator/components/com_installer/tmpl/manage/default.php
@@ -37,7 +37,8 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 					<?php echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
 					<?php if (empty($this->items)) : ?>
 						<div class="alert alert-info">
-							<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+							<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+							<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 							<?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
 						</div>
 					<?php else : ?>

--- a/administrator/components/com_installer/tmpl/update/default.php
+++ b/administrator/components/com_installer/tmpl/update/default.php
@@ -37,7 +37,8 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 					<?php echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
 					<?php if (empty($this->items)) : ?>
 						<div class="alert alert-info">
-							<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+							<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+							<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 							<?php echo Text::_('COM_INSTALLER_MSG_UPDATE_NOUPDATES'); ?>
 						</div>
 					<?php else : ?>

--- a/administrator/components/com_installer/tmpl/updatesites/default.php
+++ b/administrator/components/com_installer/tmpl/updatesites/default.php
@@ -32,7 +32,8 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 					<?php echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
 					<?php if (empty($this->items)) : ?>
 						<div class="alert alert-info">
-							<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+							<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+							<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 							<?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
 						</div>
 					<?php else : ?>

--- a/administrator/components/com_installer/tmpl/warnings/default.php
+++ b/administrator/components/com_installer/tmpl/warnings/default.php
@@ -24,7 +24,7 @@ use Joomla\CMS\Router\Route;
 						<?php foreach ($this->messages as $message) : ?>
 							<div class="alert alert-warning">
 								<h4 class="alert-heading">
-									<span class="fas fa-exclamation-triangle" aria-hidden="true"></span>
+									<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'warning-2']); ?>
 									<span class="sr-only"><?php echo Text::_('WARNING'); ?></span>
 									<?php echo $message['message']; ?>
 								</h4>

--- a/administrator/components/com_installer/tmpl/warnings/default.php
+++ b/administrator/components/com_installer/tmpl/warnings/default.php
@@ -11,6 +11,7 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
 ?>
@@ -32,7 +33,7 @@ use Joomla\CMS\Router\Route;
 						<?php endforeach; ?>
 						<div class="alert alert-info">
 							<h4 class="alert-heading">
-								<span class="fas fa-info-circle" aria-hidden="true"></span>
+								<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
 								<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 								<?php echo Text::_('COM_INSTALLER_MSG_WARNINGFURTHERINFO'); ?>
 							</h4>
@@ -40,7 +41,7 @@ use Joomla\CMS\Router\Route;
 						</div>
 					<?php else: ?>
 						<div class="alert alert-info">
-							<span class="fas fa-info-circle" aria-hidden="true"></span>
+							<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
 							<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 							<?php echo Text::_('COM_INSTALLER_MSG_WARNINGS_NONE'); ?>
 						</div>

--- a/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_preupdatecheck.php
+++ b/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_preupdatecheck.php
@@ -50,7 +50,7 @@ use Joomla\Component\Joomlaupdate\Administrator\View\Joomlaupdate\HtmlView;
 								<span class="badge badge-<?php echo $option->state ? 'success' : 'danger'; ?>">
 									<?php echo Text::_($option->state ? 'JYES' : 'JNO'); ?>
 									<?php if ($option->notice) : ?>
-										<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info', 'class' => 'icon-white', 'title' => $option->notice]); ?>
+										<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info', 'suffix' => 'icon-white', 'title' => $option->notice]); ?>
 									<?php endif; ?>
 								</span>
 							</td>

--- a/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_preupdatecheck.php
+++ b/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_preupdatecheck.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\Component\Joomlaupdate\Administrator\View\Joomlaupdate\HtmlView;
 
 /** @var HtmlView $this */
@@ -49,7 +50,7 @@ use Joomla\Component\Joomlaupdate\Administrator\View\Joomlaupdate\HtmlView;
 								<span class="badge badge-<?php echo $option->state ? 'success' : 'danger'; ?>">
 									<?php echo Text::_($option->state ? 'JYES' : 'JNO'); ?>
 									<?php if ($option->notice) : ?>
-										<span class="fas fa-info icon-white" title="<?php echo $option->notice; ?>"></span>
+										<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info', 'class' => 'icon-white', 'title' => $option->notice]); ?>
 									<?php endif; ?>
 								</span>
 							</td>

--- a/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_reinstall.php
+++ b/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_reinstall.php
@@ -11,6 +11,7 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Updater\Update;
 use Joomla\Component\Joomlaupdate\Administrator\View\Joomlaupdate\HtmlView;
 
@@ -21,7 +22,7 @@ use Joomla\Component\Joomlaupdate\Administrator\View\Joomlaupdate\HtmlView;
 		<?php echo Text::_('COM_JOOMLAUPDATE_UPDATE_CHECK'); ?>
 	</legend>
 	<p class="alert alert-info">
-		<span class="fas fa-info-circle" aria-hidden="true"></span>
+		<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
 		<span class="sr-only"><?php echo Text::_('NOTICE'); ?></span>
 		<?php echo Text::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_NOUPDATES'); ?>
 	</p>

--- a/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_reinstall.php
+++ b/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_reinstall.php
@@ -28,7 +28,7 @@ use Joomla\Component\Joomlaupdate\Administrator\View\Joomlaupdate\HtmlView;
 	</p>
 	<p><?php echo Text::sprintf($this->langKey, $this->updateSourceKey); ?></p>
 	<p class="alert alert-success">
-		<span class="fas fa-check-circle" aria-hidden="true"></span>
+		<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'check-circle']); ?>
 		<span class="sr-only"><?php echo Text::_('NOTICE'); ?></span>
 		<?php echo Text::sprintf('COM_JOOMLAUPDATE_VIEW_DEFAULT_NOUPDATESNOTICE', '&#x200E;' . JVERSION); ?>
 	</p>

--- a/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_upload.php
+++ b/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_upload.php
@@ -34,7 +34,7 @@ Text::script('JGLOBAL_SELECTED_UPLOAD_FILE_SIZE', true);
 	<?php foreach ($this->warnings as $warning) : ?>
 		<div class="alert alert-warning">
 			<h4 class="alert-heading">
-				<span class="fas fa-exclamation-triangle" aria-hidden="true"></span>
+				<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'warning-2']); ?>
 				<span class="sr-only"><?php echo Text::_('WARNING'); ?></span>
 				<?php echo $warning['message']; ?>
 			</h4>

--- a/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_upload.php
+++ b/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_upload.php
@@ -11,6 +11,7 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Utility\Utility;
 use Joomla\Component\Joomlaupdate\Administrator\View\Joomlaupdate\HtmlView;
 
@@ -23,7 +24,8 @@ Text::script('JGLOBAL_SELECTED_UPLOAD_FILE_SIZE', true);
 ?>
 
 <div class="alert alert-info">
-	<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+	<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+	<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 	<?php echo Text::sprintf('COM_JOOMLAUPDATE_VIEW_DEFAULT_UPLOAD_INTRO', 'https://downloads.joomla.org/latest'); ?>
 </div>
 
@@ -41,7 +43,7 @@ Text::script('JGLOBAL_SELECTED_UPLOAD_FILE_SIZE', true);
 	<?php endforeach; ?>
 	<div class="alert alert-info">
 		<h4 class="alert-heading">
-			<span class="fas fa-info-circle" aria-hidden="true"></span>
+			<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
 			<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 			<?php echo Text::_('COM_INSTALLER_MSG_WARNINGFURTHERINFO'); ?>
 		</h4>

--- a/administrator/components/com_joomlaupdate/tmpl/update/finaliseconfirm.php
+++ b/administrator/components/com_joomlaupdate/tmpl/update/finaliseconfirm.php
@@ -13,6 +13,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Helper\AuthenticationHelper;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
 HTMLHelper::_('behavior.keepalive');
@@ -86,7 +87,7 @@ $twofactormethods = AuthenticationHelper::getTwoFactorMethods();
 			<div class="controls">
 				<div class="btn-group">
 					<a class="btn btn-danger" href="index.php?option=com_joomlaupdate">
-						<span class="fas fa-times" aria-hidden="true"></span> <?php echo Text::_('JCANCEL'); ?>
+						<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'times']); ?> <?php echo Text::_('JCANCEL'); ?>
 					</a>
 					<button type="submit" class="btn btn-primary">
 						<span class="fas fa-play" aria-hidden="true"></span> <?php echo Text::_('COM_JOOMLAUPDATE_VIEW_UPDATE_FINALISE_CONFIRM_AND_CONTINUE'); ?>

--- a/administrator/components/com_joomlaupdate/tmpl/upload/captive.php
+++ b/administrator/components/com_joomlaupdate/tmpl/upload/captive.php
@@ -13,6 +13,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Helper\AuthenticationHelper;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
 HTMLHelper::_('behavior.keepalive');
@@ -86,7 +87,7 @@ $twofactormethods = AuthenticationHelper::getTwoFactorMethods();
 			<div class="controls">
 				<div class="btn-group">
 					<a class="btn btn-danger" href="index.php?option=com_joomlaupdate">
-						<span class="fas fa-times icon-white" aria-hidden="true"></span> <?php echo Text::_('JCANCEL'); ?>
+						<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'times', 'class' => 'icon-white']); ?> <?php echo Text::_('JCANCEL'); ?>
 					</a>
 					<button type="submit" class="btn btn-primary">
 						<span class="fas fa-play icon-white" aria-hidden="true"></span> <?php echo Text::_('COM_INSTALLER_INSTALL_BUTTON'); ?>

--- a/administrator/components/com_joomlaupdate/tmpl/upload/captive.php
+++ b/administrator/components/com_joomlaupdate/tmpl/upload/captive.php
@@ -87,7 +87,7 @@ $twofactormethods = AuthenticationHelper::getTwoFactorMethods();
 			<div class="controls">
 				<div class="btn-group">
 					<a class="btn btn-danger" href="index.php?option=com_joomlaupdate">
-						<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'times', 'class' => 'icon-white']); ?> <?php echo Text::_('JCANCEL'); ?>
+						<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'times', 'suffix' => 'icon-white']); ?> <?php echo Text::_('JCANCEL'); ?>
 					</a>
 					<button type="submit" class="btn btn-primary">
 						<span class="fas fa-play icon-white" aria-hidden="true"></span> <?php echo Text::_('COM_INSTALLER_INSTALL_BUTTON'); ?>

--- a/administrator/components/com_languages/tmpl/installed/default.php
+++ b/administrator/components/com_languages/tmpl/installed/default.php
@@ -28,7 +28,8 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 				<?php echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
 				<?php if (empty($this->rows)) : ?>
 					<div class="alert alert-info">
-						<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+						<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+						<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 						<?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
 					</div>
 				<?php else : ?>

--- a/administrator/components/com_languages/tmpl/languages/default.php
+++ b/administrator/components/com_languages/tmpl/languages/default.php
@@ -106,7 +106,7 @@ if ($saveOrder && !empty($this->items))
 											$disableClassName = 'inactive';
 										endif; ?>
 										<span class="sortable-handler <?php echo $disableClassName; ?>" title="<?php echo $disabledLabel; ?>">
-											<span class="fas fa-ellipsis-v" aria-hidden="true"></span>
+											<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'ellipsis-v']); ?>
 										</span>
 										<input type="text" name="order[]" size="5" value="<?php echo $item->ordering; ?>" class="width-20 text-area-order hidden">
 									<?php else : ?>

--- a/administrator/components/com_languages/tmpl/languages/default.php
+++ b/administrator/components/com_languages/tmpl/languages/default.php
@@ -37,7 +37,8 @@ if ($saveOrder && !empty($this->items))
 				<?php echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
 				<?php if (empty($this->items)) : ?>
 					<div class="alert alert-info">
-						<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+						<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+						<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 						<?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
 					</div>
 				<?php else : ?>

--- a/administrator/components/com_languages/tmpl/multilangstatus/default.php
+++ b/administrator/components/com_languages/tmpl/multilangstatus/default.php
@@ -229,7 +229,7 @@ $home_pages        = array_column($this->homepages, 'language');
 					<?php // Published Site languages ?>
 					<?php if ($status->element) : ?>
 							<td class="text-center">
-								<span class="text-success fas fa-check" aria-hidden="true"></span>
+								<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'check', 'suffix' => 'text-success']); ?>
 								<span class="sr-only"><?php echo Text::_('JYES'); ?></span>
 							</td>
 					<?php else : ?>
@@ -240,7 +240,7 @@ $home_pages        = array_column($this->homepages, 'language');
 					<?php // Published Content languages ?>
 						<td class="text-center">
 							<?php if ($status->lang_code && $status->published == 1) : ?>
-								<span class="text-success fas fa-check" aria-hidden="true"></span>
+								<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'check', 'suffix' => 'text-success']); ?>
 								<span class="sr-only"><?php echo Text::_('JYES'); ?></span>
 							<?php elseif ($status->lang_code && $status->published == 0) : ?>
 								<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'times', 'suffix' => 'text-danger']); ?>
@@ -256,7 +256,7 @@ $home_pages        = array_column($this->homepages, 'language');
 					<?php // Published Home pages ?>
 						<td class="text-center">
 							<?php if ($status->home_published == 1) : ?>
-								<span class="text-success fas fa-check" aria-hidden="true"></span>
+								<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'check', 'suffix' => 'text-success']); ?>
 								<span class="sr-only"><?php echo Text::_('JYES'); ?></span>
 							<?php elseif ($status->home_published == 0) : ?>
 								<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'times', 'suffix' => 'text-danger']); ?>
@@ -283,7 +283,7 @@ $home_pages        = array_column($this->homepages, 'language');
 							</td>
 							<td class="text-center">
 								<?php if ($contentlang->published == 1) : ?>
-									<span class="text-success fas fa-check" aria-hidden="true"></span>
+									<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'check', 'suffix' => 'text-success']); ?>
 									<span class="sr-only"><?php echo Text::_('JYES'); ?></span>
 								<?php elseif ($contentlang->published == 0 && array_key_exists($contentlang->lang_code, $this->homepages)) : ?>
 									<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'times', 'suffix' => 'text-danger']); ?>
@@ -298,7 +298,7 @@ $home_pages        = array_column($this->homepages, 'language');
 									<span class="fas fa-exclamation-triangle" aria-hidden="true"></span>
 									<span class="sr-only"><?php echo Text::_('WARNING'); ?></span>
 								<?php else : ?>
-									<span class="text-success fas fa-check" aria-hidden="true"></span>
+									<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'check', 'suffix' => 'text-success']); ?>
 									<span class="sr-only"><?php echo Text::_('JYES'); ?></span>
 								<?php endif; ?>
 							</td>
@@ -313,7 +313,7 @@ $home_pages        = array_column($this->homepages, 'language');
 								<?php echo $sitelang; ?>
 							</th>
 							<td class="text-center">
-								<span class="text-success fas fa-check" aria-hidden="true"></span>
+								<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'check', 'suffix' => 'text-success']); ?>
 								<span class="sr-only"><?php echo Text::_('JYES'); ?></span>
 							</td>
 							<td class="text-center">
@@ -321,7 +321,7 @@ $home_pages        = array_column($this->homepages, 'language');
 								<span class="sr-only"><?php echo Text::_('WARNING'); ?></span>
 							</td>
 							<td class="text-center">
-								<span class="text-success fas fa-check" aria-hidden="true"></span>
+								<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'check', 'suffix' => 'text-success']); ?>
 								<span class="sr-only"><?php echo Text::_('JYES'); ?></span>
 							</td>
 						</tr>

--- a/administrator/components/com_languages/tmpl/multilangstatus/default.php
+++ b/administrator/components/com_languages/tmpl/multilangstatus/default.php
@@ -243,7 +243,7 @@ $home_pages        = array_column($this->homepages, 'language');
 								<span class="text-success fas fa-check" aria-hidden="true"></span>
 								<span class="sr-only"><?php echo Text::_('JYES'); ?></span>
 							<?php elseif ($status->lang_code && $status->published == 0) : ?>
-								<span class="text-danger fas fa-times" aria-hidden="true"></span>
+								<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'times', 'class' => 'text-danger']); ?>
 								<span class="sr-only"><?php echo Text::_('WARNING'); ?></span>
 							<?php elseif ($status->lang_code && $status->published == -2) : ?>
 								<span class="fas fa-trash" aria-hidden="true"></span>
@@ -259,7 +259,7 @@ $home_pages        = array_column($this->homepages, 'language');
 								<span class="text-success fas fa-check" aria-hidden="true"></span>
 								<span class="sr-only"><?php echo Text::_('JYES'); ?></span>
 							<?php elseif ($status->home_published == 0) : ?>
-								<span class="text-danger fas fa-times" aria-hidden="true"></span>
+								<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'times', 'class' => 'text-danger']); ?>
 								<span class="sr-only"><?php echo Text::_('JNO'); ?></span>
 							<?php elseif ($status->home_published == -2) : ?>
 								<span class="fas fa-trash" aria-hidden="true"></span>
@@ -286,7 +286,7 @@ $home_pages        = array_column($this->homepages, 'language');
 									<span class="text-success fas fa-check" aria-hidden="true"></span>
 									<span class="sr-only"><?php echo Text::_('JYES'); ?></span>
 								<?php elseif ($contentlang->published == 0 && array_key_exists($contentlang->lang_code, $this->homepages)) : ?>
-									<span class="text-danger fas fa-times" aria-hidden="true"></span>
+									<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'times', 'class' => 'text-danger']); ?>
 									<span class="sr-only"><?php echo Text::_('JNO'); ?></span>
 								<?php elseif ($contentlang->published == -2 && array_key_exists($contentlang->lang_code, $this->homepages)) : ?>
 									<span class="fas fa-trash" aria-hidden="true"></span>

--- a/administrator/components/com_languages/tmpl/multilangstatus/default.php
+++ b/administrator/components/com_languages/tmpl/multilangstatus/default.php
@@ -38,7 +38,7 @@ $home_pages        = array_column($this->homepages, 'language');
 	<?php else : ?>
 		<?php if (!in_array($this->default_lang, $content_languages)) : ?>
 			<div class="alert alert-error">
-				<span class="fas fa-exclamation" aria-hidden="true"></span>
+				<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'error']); ?>
 				<span class="sr-only"><?php echo Text::_('ERROR'); ?></span>
 				<?php echo Text::sprintf('COM_LANGUAGES_MULTILANGSTATUS_ERROR_DEFAULT_CONTENT_LANGUAGE', $this->default_lang); ?>
 			</div>
@@ -46,7 +46,7 @@ $home_pages        = array_column($this->homepages, 'language');
 			<?php foreach ($this->contentlangs as $contentlang) : ?>
 				<?php if ($contentlang->lang_code == $this->default_lang && $contentlang->published != 1) : ?>
 					<div class="alert alert-error">
-						<span class="fas fa-exclamation" aria-hidden="true"></span>
+						<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'error']); ?>
 						<span class="sr-only"><?php echo Text::_('ERROR'); ?></span>
 						<?php echo Text::sprintf('COM_LANGUAGES_MULTILANGSTATUS_ERROR_DEFAULT_CONTENT_LANGUAGE', $this->default_lang); ?>
 					</div>
@@ -55,7 +55,7 @@ $home_pages        = array_column($this->homepages, 'language');
 		<?php endif; ?>
 		<?php if ($this->defaultHome == true) : ?>
 			<div class="alert alert-warning">
-				<span class="fas fa-exclamation-triangle" aria-hidden="true"></span>
+				<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'warning-2']); ?>
 				<span class="sr-only"><?php echo Text::_('WARNING'); ?></span>
 				<?php echo Text::_('COM_LANGUAGES_MULTILANGSTATUS_DEFAULT_HOME_MODULE_PUBLISHED'); ?>
 			</div>
@@ -64,7 +64,7 @@ $home_pages        = array_column($this->homepages, 'language');
 			<?php // Displays error when Site language and Content language are published but Home page is unpublished, trashed or missing. ?>
 			<?php if ($status->lang_code && $status->published == 1 && $status->home_published != 1) : ?>
 				<div class="alert alert-warning">
-					<span class="fas fa-exclamation-triangle" aria-hidden="true"></span>
+					<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'warning-2']); ?>
 					<span class="sr-only"><?php echo Text::_('WARNING'); ?></span>
 					<?php echo Text::sprintf('COM_LANGUAGES_MULTILANGSTATUS_HOME_UNPUBLISHED', $status->lang_code, $status->lang_code); ?>
 				</div>
@@ -72,7 +72,7 @@ $home_pages        = array_column($this->homepages, 'language');
 			<?php // Displays error when both Content Language and Home page are unpublished. ?>
 			<?php if ($status->lang_code && $status->published == 0 && $status->home_published != 1) : ?>
 				<div class="alert alert-warning">
-					<span class="fas fa-exclamation-triangle" aria-hidden="true"></span>
+					<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'warning-2']); ?>
 					<span class="sr-only"><?php echo Text::_('WARNING'); ?></span>
 					<?php echo Text::sprintf('COM_LANGUAGES_MULTILANGSTATUS_CONTENT_LANGUAGE_HOME_UNPUBLISHED', $status->lang_code, $status->lang_code); ?>
 				</div>
@@ -80,14 +80,14 @@ $home_pages        = array_column($this->homepages, 'language');
 		<?php endforeach; ?>
 		<?php if ($notice_disabled) : ?>
 			<div class="alert alert-warning">
-				<span class="fas fa-exclamation-triangle" aria-hidden="true"></span>
+				<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'warning-2']); ?>
 				<span class="sr-only"><?php echo Text::_('WARNING'); ?></span>
 				<?php echo Text::_('COM_LANGUAGES_MULTILANGSTATUS_LANGUAGEFILTER_DISABLED'); ?>
 			</div>
 		<?php endif; ?>
 		<?php if ($notice_switchers) : ?>
 			<div class="alert alert-warning">
-				<span class="fas fa-exclamation-triangle" aria-hidden="true"></span>
+				<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'warning-2']); ?>
 				<span class="sr-only"><?php echo Text::_('WARNING'); ?></span>
 				<?php echo Text::_('COM_LANGUAGES_MULTILANGSTATUS_LANGSWITCHER_UNPUBLISHED'); ?>
 			</div>
@@ -95,28 +95,28 @@ $home_pages        = array_column($this->homepages, 'language');
 		<?php foreach ($this->contentlangs as $contentlang) : ?>
 			<?php if (array_key_exists($contentlang->lang_code, $this->homepages) && (!array_key_exists($contentlang->lang_code, $this->site_langs) || $contentlang->published != 1)) : ?>
 				<div class="alert alert-warning">
-					<span class="fas fa-exclamation-triangle" aria-hidden="true"></span>
+					<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'warning-2']); ?>
 					<span class="sr-only"><?php echo Text::_('WARNING'); ?></span>
 					<?php echo Text::sprintf('COM_LANGUAGES_MULTILANGSTATUS_ERROR_CONTENT_LANGUAGE', $contentlang->lang_code); ?>
 				</div>
 			<?php endif; ?>
 			<?php if (!array_key_exists($contentlang->lang_code, $this->site_langs)) : ?>
 				<div class="alert alert-warning">
-					<span class="fas fa-exclamation-triangle" aria-hidden="true"></span>
+					<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'warning-2']); ?>
 					<span class="sr-only"><?php echo Text::_('WARNING'); ?></span>
 					<?php echo Text::sprintf('COM_LANGUAGES_MULTILANGSTATUS_ERROR_LANGUAGE_TAG', $contentlang->lang_code); ?>
 				</div>
 			<?php endif; ?>
 			<?php if ($contentlang->published == -2) : ?>
 				<div class="alert alert-warning">
-					<span class="fas fa-exclamation-triangle" aria-hidden="true"></span>
+					<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'warning-2']); ?>
 					<span class="sr-only"><?php echo Text::_('WARNING'); ?></span>
 					<?php echo Text::sprintf('COM_LANGUAGES_MULTILANGSTATUS_CONTENT_LANGUAGE_TRASHED', $contentlang->lang_code); ?>
 				</div>
 			<?php endif; ?>
 			<?php if (empty($contentlang->sef)) : ?>
 				<div class="alert alert-error">
-					<span class="fas fa-exclamation" aria-hidden="true"></span>
+					<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'error']); ?>
 					<span class="sr-only"><?php echo Text::_('ERROR'); ?></span>
 					<?php echo Text::sprintf('COM_LANGUAGES_MULTILANGSTATUS_CONTENT_LANGUAGE_SEF_MISSING', $contentlang->lang_code); ?>
 				</div>
@@ -124,7 +124,7 @@ $home_pages        = array_column($this->homepages, 'language');
 		<?php endforeach; ?>
 		<?php if ($this->listUsersError) : ?>
 			<div class="alert alert-warning">
-				<span class="fas fa-exclamation-triangle" aria-hidden="true"></span>
+				<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'warning-2']); ?>
 				<span class="sr-only"><?php echo Text::_('WARNING'); ?></span>
 				<?php echo Text::_('COM_LANGUAGES_MULTILANGSTATUS_CONTACTS_ERROR_TIP'); ?>
 				<ul>
@@ -140,7 +140,7 @@ $home_pages        = array_column($this->homepages, 'language');
 		<?php foreach ($sitelangs as $sitelang) : ?>
 			<?php if (!in_array($sitelang, $content_languages) && in_array($sitelang, $home_pages)) : ?>
 				<div class="alert alert-warning">
-					<span class="fas fa-exclamation-triangle" aria-hidden="true"></span>
+					<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'warning-2']); ?>
 					<span class="sr-only"><?php echo Text::_('WARNING'); ?></span>
 					<?php echo Text::sprintf('COM_LANGUAGES_MULTILANGSTATUS_CONTENT_LANGUAGE_MISSING', $sitelang); ?>
 				</div>
@@ -249,7 +249,7 @@ $home_pages        = array_column($this->homepages, 'language');
 								<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'trash']); ?>
 								<span class="sr-only"><?php echo Text::_('WARNING'); ?></span>
 							<?php else : ?>
-								<span class="fas fa-exclamation-triangle" aria-hidden="true"></span>
+								<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'warning-2']); ?>
 								<span class="sr-only"><?php echo Text::_('WARNING'); ?></span>
 							<?php endif; ?>
 						</td>
@@ -265,7 +265,7 @@ $home_pages        = array_column($this->homepages, 'language');
 								<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'trash']); ?>
 								<span class="sr-only"><?php echo Text::_('WARNING'); ?></span>
 							<?php else : ?>
-								<span class="fas fa-exclamation-triangle" aria-hidden="true"></span>
+								<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'warning-2']); ?>
 								<span class="sr-only"><?php echo Text::_('WARNING'); ?></span>
 							<?php endif; ?>
 						</td>
@@ -278,7 +278,7 @@ $home_pages        = array_column($this->homepages, 'language');
 								<?php echo $contentlang->lang_code; ?>
 							</th>
 							<td class="text-center">
-								<span class="fas fa-exclamation-triangle" aria-hidden="true"></span>
+								<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'warning-2']); ?>
 								<span class="sr-only"><?php echo Text::_('WARNING'); ?></span>
 							</td>
 							<td class="text-center">
@@ -295,7 +295,7 @@ $home_pages        = array_column($this->homepages, 'language');
 							</td>
 							<td class="text-center">
 								<?php if (!array_key_exists($contentlang->lang_code, $this->homepages)) : ?>
-									<span class="fas fa-exclamation-triangle" aria-hidden="true"></span>
+									<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'warning-2']); ?>
 									<span class="sr-only"><?php echo Text::_('WARNING'); ?></span>
 								<?php else : ?>
 									<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'check', 'suffix' => 'text-success']); ?>
@@ -317,7 +317,7 @@ $home_pages        = array_column($this->homepages, 'language');
 								<span class="sr-only"><?php echo Text::_('JYES'); ?></span>
 							</td>
 							<td class="text-center">
-								<span class="fas fa-exclamation-triangle" aria-hidden="true"></span>
+								<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'warning-2']); ?>
 								<span class="sr-only"><?php echo Text::_('WARNING'); ?></span>
 							</td>
 							<td class="text-center">

--- a/administrator/components/com_languages/tmpl/multilangstatus/default.php
+++ b/administrator/components/com_languages/tmpl/multilangstatus/default.php
@@ -243,7 +243,7 @@ $home_pages        = array_column($this->homepages, 'language');
 								<span class="text-success fas fa-check" aria-hidden="true"></span>
 								<span class="sr-only"><?php echo Text::_('JYES'); ?></span>
 							<?php elseif ($status->lang_code && $status->published == 0) : ?>
-								<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'times', 'class' => 'text-danger']); ?>
+								<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'times', 'suffix' => 'text-danger']); ?>
 								<span class="sr-only"><?php echo Text::_('WARNING'); ?></span>
 							<?php elseif ($status->lang_code && $status->published == -2) : ?>
 								<span class="fas fa-trash" aria-hidden="true"></span>
@@ -259,7 +259,7 @@ $home_pages        = array_column($this->homepages, 'language');
 								<span class="text-success fas fa-check" aria-hidden="true"></span>
 								<span class="sr-only"><?php echo Text::_('JYES'); ?></span>
 							<?php elseif ($status->home_published == 0) : ?>
-								<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'times', 'class' => 'text-danger']); ?>
+								<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'times', 'suffix' => 'text-danger']); ?>
 								<span class="sr-only"><?php echo Text::_('JNO'); ?></span>
 							<?php elseif ($status->home_published == -2) : ?>
 								<span class="fas fa-trash" aria-hidden="true"></span>
@@ -286,7 +286,7 @@ $home_pages        = array_column($this->homepages, 'language');
 									<span class="text-success fas fa-check" aria-hidden="true"></span>
 									<span class="sr-only"><?php echo Text::_('JYES'); ?></span>
 								<?php elseif ($contentlang->published == 0 && array_key_exists($contentlang->lang_code, $this->homepages)) : ?>
-									<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'times', 'class' => 'text-danger']); ?>
+									<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'times', 'suffix' => 'text-danger']); ?>
 									<span class="sr-only"><?php echo Text::_('JNO'); ?></span>
 								<?php elseif ($contentlang->published == -2 && array_key_exists($contentlang->lang_code, $this->homepages)) : ?>
 									<span class="fas fa-trash" aria-hidden="true"></span>

--- a/administrator/components/com_languages/tmpl/multilangstatus/default.php
+++ b/administrator/components/com_languages/tmpl/multilangstatus/default.php
@@ -246,7 +246,7 @@ $home_pages        = array_column($this->homepages, 'language');
 								<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'times', 'suffix' => 'text-danger']); ?>
 								<span class="sr-only"><?php echo Text::_('WARNING'); ?></span>
 							<?php elseif ($status->lang_code && $status->published == -2) : ?>
-								<span class="fas fa-trash" aria-hidden="true"></span>
+								<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'trash']); ?>
 								<span class="sr-only"><?php echo Text::_('WARNING'); ?></span>
 							<?php else : ?>
 								<span class="fas fa-exclamation-triangle" aria-hidden="true"></span>
@@ -262,7 +262,7 @@ $home_pages        = array_column($this->homepages, 'language');
 								<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'times', 'suffix' => 'text-danger']); ?>
 								<span class="sr-only"><?php echo Text::_('JNO'); ?></span>
 							<?php elseif ($status->home_published == -2) : ?>
-								<span class="fas fa-trash" aria-hidden="true"></span>
+								<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'trash']); ?>
 								<span class="sr-only"><?php echo Text::_('WARNING'); ?></span>
 							<?php else : ?>
 								<span class="fas fa-exclamation-triangle" aria-hidden="true"></span>
@@ -289,7 +289,7 @@ $home_pages        = array_column($this->homepages, 'language');
 									<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'times', 'suffix' => 'text-danger']); ?>
 									<span class="sr-only"><?php echo Text::_('JNO'); ?></span>
 								<?php elseif ($contentlang->published == -2 && array_key_exists($contentlang->lang_code, $this->homepages)) : ?>
-									<span class="fas fa-trash" aria-hidden="true"></span>
+									<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'trash']); ?>
 									<span class="sr-only"><?php echo Text::_('WARNING'); ?></span>
 								<?php endif; ?>
 							</td>

--- a/administrator/components/com_languages/tmpl/multilangstatus/default.php
+++ b/administrator/components/com_languages/tmpl/multilangstatus/default.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 
 $notice_disabled  = !$this->language_filter && ($this->homes > 1 || $this->switchers != 0);
 $notice_switchers = !$this->switchers && ($this->homes > 1 || $this->language_filter);
@@ -23,13 +24,13 @@ $home_pages        = array_column($this->homepages, 'language');
 	<?php if (!$this->language_filter && $this->switchers == 0) : ?>
 		<?php if ($this->homes == 1) : ?>
 			<div class="alert alert-info">
-				<span class="fas fa-info-circle" aria-hidden="true"></span>
+				<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
 				<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 				<?php echo Text::_('COM_LANGUAGES_MULTILANGSTATUS_NONE'); ?>
 			</div>
 		<?php else : ?>
 			<div class="alert alert-info">
-				<span class="fas fa-info-circle" aria-hidden="true"></span>
+				<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
 				<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 				<?php echo Text::_('COM_LANGUAGES_MULTILANGSTATUS_USELESS_HOMES'); ?>
 			</div>

--- a/administrator/components/com_languages/tmpl/override/edit.php
+++ b/administrator/components/com_languages/tmpl/override/edit.php
@@ -11,6 +11,7 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
 $expired = ($this->state->get('cache_expired') == 1 ) ? '1' : '';
@@ -50,7 +51,8 @@ $wa->useScript('keepalive')
 				<legend><?php echo Text::_('COM_LANGUAGES_VIEW_OVERRIDE_SEARCH_LEGEND'); ?></legend>
 				<div>
 				<div class="alert alert-info">
-					<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+					<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+					<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 					<?php echo Text::_('COM_LANGUAGES_VIEW_OVERRIDE_SEARCH_TIP'); ?>
 				</div>
 				<?php echo $this->form->renderField('searchtype'); ?>

--- a/administrator/components/com_languages/tmpl/overrides/default.php
+++ b/administrator/components/com_languages/tmpl/overrides/default.php
@@ -35,7 +35,8 @@ $oppositeStrings  = LanguageHelper::parseIniFile($oppositeFilename);
 				<div class="clearfix"></div>
 				<?php if (empty($this->items)) : ?>
 					<div class="alert alert-info">
-						<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+						<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+						<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 						<?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
 					</div>
 				<?php else : ?>

--- a/administrator/components/com_media/layouts/toolbar/create-folder.php
+++ b/administrator/components/com_media/layouts/toolbar/create-folder.php
@@ -11,6 +11,7 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 
 Factory::getDocument()->getWebAssetManager()
 	->useScript('webcomponent.toolbar-button');
@@ -19,7 +20,7 @@ $title = Text::_('COM_MEDIA_CREATE_NEW_FOLDER');
 ?>
 <joomla-toolbar-button>
 	<button class="btn btn-info" onclick="MediaManager.Event.fire('onClickCreateFolder');">
-		<span class="fas fa-folder" aria-hidden="true"></span>
+		<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'folder'); ?>
 		<?php echo $title; ?>
 	</button>
 </joomla-toolbar-button>

--- a/administrator/components/com_media/layouts/toolbar/create-folder.php
+++ b/administrator/components/com_media/layouts/toolbar/create-folder.php
@@ -20,7 +20,7 @@ $title = Text::_('COM_MEDIA_CREATE_NEW_FOLDER');
 ?>
 <joomla-toolbar-button>
 	<button class="btn btn-info" onclick="MediaManager.Event.fire('onClickCreateFolder');">
-		<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'folder'); ?>
+		<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'folder']); ?>
 		<?php echo $title; ?>
 	</button>
 </joomla-toolbar-button>

--- a/administrator/components/com_media/layouts/toolbar/delete.php
+++ b/administrator/components/com_media/layouts/toolbar/delete.php
@@ -11,6 +11,7 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 
 Factory::getDocument()->getWebAssetManager()
 	->useScript('webcomponent.toolbar-button');
@@ -19,7 +20,7 @@ $title = Text::_('JTOOLBAR_DELETE');
 ?>
 <joomla-toolbar-button>
 	<button id="mediaDelete" class="btn btn-danger" onclick="MediaManager.Event.fire('onClickDelete');">
-		<span class="fas fa-times" aria-hidden="true"></span>
+		<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'times']); ?>
 		<?php echo $title; ?>
 	</button>
 </joomla-toolbar-button>

--- a/administrator/components/com_menus/src/Field/Modal/MenuField.php
+++ b/administrator/components/com_menus/src/Field/Modal/MenuField.php
@@ -16,6 +16,7 @@ use Joomla\CMS\Form\FormField;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\LanguageHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Session\Session;
 use Joomla\Database\ParameterType;
 
@@ -302,7 +303,8 @@ class MenuField extends FormField
 				. ' data-toggle="modal"'
 				. ' type="button"'
 				. ' data-target="#ModalNew' . $modalId . '">'
-				. '<span class="fas fa-plus" aria-hidden="true"></span> ' . Text::_('JACTION_CREATE')
+				. LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'add'])
+				. ' ' . Text::_('JACTION_CREATE')
 				. '</button>';
 		}
 

--- a/administrator/components/com_menus/src/Field/Modal/MenuField.php
+++ b/administrator/components/com_menus/src/Field/Modal/MenuField.php
@@ -329,7 +329,8 @@ class MenuField extends FormField
 				. ' id="' . $this->id . '_clear"'
 				. ' type="button"'
 				. ' onclick="window.processModalParent(\'' . $this->id . '\'); return false;">'
-				. '<span class="fas fa-times" aria-hidden="true"></span> ' . Text::_('JCLEAR')
+				. LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'times'])
+				. Text::_('JCLEAR')
 				. '</button>';
 		}
 

--- a/administrator/components/com_menus/tmpl/item/edit_container.php
+++ b/administrator/components/com_menus/tmpl/item/edit_container.php
@@ -9,6 +9,7 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\Component\Menus\Administrator\Helper\MenusHelper;
 use Joomla\Registry\Registry;
 
@@ -44,7 +45,8 @@ $wa->useScript('joomla.treeselectmenu')
 
 		<hr>
 		<div class="alert alert-info">
-			<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+			<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+			<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 			<?php echo Text::_('COM_MENUS_ITEM_FIELD_COMPONENTS_CONTAINER_HIDE_ITEMS_DESC'); ?>
 		</div>
 			<?php if (count($menuLinks)) : ?>

--- a/administrator/components/com_menus/tmpl/items/default.php
+++ b/administrator/components/com_menus/tmpl/items/default.php
@@ -154,7 +154,7 @@ $assoc   = Associations::isEnabled() && $this->state->get('filter.client_id') ==
 										}
 										?>
 										<span class="sortable-handler<?php echo $iconClass ?>">
-											<span class="fas fa-ellipsis-v" aria-hidden="true"></span>
+											<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'ellipsis-v']); ?>
 										</span>
 										<?php if ($canChange && $saveOrder) : ?>
 											<input type="text" class="hidden" name="order[]" size="5"

--- a/administrator/components/com_menus/tmpl/items/modal.php
+++ b/administrator/components/com_menus/tmpl/items/modal.php
@@ -49,7 +49,8 @@ if (!empty($editor))
 
 		<?php if (empty($this->items)) : ?>
 			<div class="alert alert-info">
-				<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+				<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+				<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 				<?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
 			</div>
 		<?php else : ?>

--- a/administrator/components/com_menus/tmpl/menus/default.php
+++ b/administrator/components/com_menus/tmpl/menus/default.php
@@ -74,7 +74,7 @@ $wa->useScript('com_menus.admin-menus');
 									<span class="d-none d-md-inline"><?php echo Text::_('COM_MENUS_HEADING_PUBLISHED_ITEMS'); ?></span>
 								</th>
 								<th scope="col" class="w-10 text-center d-none d-md-table-cell">
-									<span class="fas fa-times" aria-hidden="true"></span>
+									<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'times']); ?>
 									<span class="d-none d-md-inline"><?php echo Text::_('COM_MENUS_HEADING_UNPUBLISHED_ITEMS'); ?></span>
 								</th>
 								<th scope="col" class="w-10 text-center d-none d-md-table-cell">

--- a/administrator/components/com_menus/tmpl/menus/default.php
+++ b/administrator/components/com_menus/tmpl/menus/default.php
@@ -70,7 +70,7 @@ $wa->useScript('com_menus.admin-menus');
 									<?php echo Text::_('COM_MENUS_MENUS'); ?>
 								</th>
 								<th scope="col" class="w-10 text-center  d-none d-md-table-cell">
-									<span class="fas fa-check" aria-hidden="true"></span>
+									<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'check']); ?>
 									<span class="d-none d-md-inline"><?php echo Text::_('COM_MENUS_HEADING_PUBLISHED_ITEMS'); ?></span>
 								</th>
 								<th scope="col" class="w-10 text-center d-none d-md-table-cell">

--- a/administrator/components/com_menus/tmpl/menus/default.php
+++ b/administrator/components/com_menus/tmpl/menus/default.php
@@ -78,7 +78,7 @@ $wa->useScript('com_menus.admin-menus');
 									<span class="d-none d-md-inline"><?php echo Text::_('COM_MENUS_HEADING_UNPUBLISHED_ITEMS'); ?></span>
 								</th>
 								<th scope="col" class="w-10 text-center d-none d-md-table-cell">
-									<span class="fas fa-trash" aria-hidden="true"></span>
+									<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'trash']); ?>
 									<span class="d-none d-md-inline"><?php echo Text::_('COM_MENUS_HEADING_TRASHED_ITEMS'); ?></span>
 								</th>
 								<th scope="col" class="w-10 text-center d-none d-lg-table-cell">

--- a/administrator/components/com_menus/tmpl/menus/default.php
+++ b/administrator/components/com_menus/tmpl/menus/default.php
@@ -47,7 +47,8 @@ $wa->useScript('com_menus.admin-menus');
 				<?php echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this, 'options' => array('filterButton' => false))); ?>
 				<?php if (empty($this->items)) : ?>
 					<div class="alert alert-info">
-						<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+						<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+						<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 						<?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
 					</div>
 				<?php else : ?>

--- a/administrator/components/com_messages/tmpl/messages/default.php
+++ b/administrator/components/com_messages/tmpl/messages/default.php
@@ -26,7 +26,8 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 		<?php echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
 		<?php if (empty($this->items)) : ?>
 			<div class="alert alert-info">
-				<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+				<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+				<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 				<?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
 			</div>
 		<?php else : ?>

--- a/administrator/components/com_modules/layouts/toolbar/cancelselect.php
+++ b/administrator/components/com_modules/layouts/toolbar/cancelselect.php
@@ -10,11 +10,12 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 
 $text = Text::_('JTOOLBAR_CANCEL');
 ?>
 <joomla-toolbar-button>
 	<button onclick="location.href='index.php?option=com_modules&view=modules&client_id=<?php echo $displayData['client_id']; ?>'" class="btn btn-danger">
-		<span class="fas fa-times" aria-hidden="true"></span> <?php echo $text; ?>
+		<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'times']); ?> <?php echo $text; ?>
 	</button>
 </joomla-toolbar-button>

--- a/administrator/components/com_modules/tmpl/module/edit.php
+++ b/administrator/components/com_modules/tmpl/module/edit.php
@@ -119,7 +119,8 @@ $tmpl    = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=c
 							<?php endif; ?>
 						<?php else : ?>
 							<div class="alert alert-danger">
-								<span class="fas fa-exclamation-triangle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('ERROR'); ?></span>
+								<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'warning-2']); ?>
+								<span class="sr-only"><?php echo Text::_('ERROR'); ?></span>
 								<?php echo Text::_('COM_MODULES_ERR_XML'); ?>
 							</div>
 						<?php endif; ?>

--- a/administrator/components/com_modules/tmpl/module/edit_assignment.php
+++ b/administrator/components/com_modules/tmpl/module/edit_assignment.php
@@ -12,6 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\Component\Menus\Administrator\Helper\MenusHelper;
 use Joomla\Component\Modules\Administrator\Helper\ModulesHelper;
 
@@ -144,7 +145,7 @@ $this->document->getWebAssetManager()
 								<a class="dropdown-item uncheckall" href="javascript://"><span class="fas fa-square" aria-hidden="true"></span> <?php echo Text::_('COM_MODULES_DESELECT'); ?></a>
 								<div class="treeselect-menu-expand">
 									<div class="dropdown-divider"></div>
-									<a class="dropdown-item expandall" href="javascript://"><span class="fas fa-plus" aria-hidden="true"></span> <?php echo Text::_('COM_MODULES_EXPAND'); ?></a>
+									<a class="dropdown-item expandall" href="javascript://"><?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'collapse']); ?> <?php echo Text::_('COM_MODULES_EXPAND'); ?></a>
 									<a class="dropdown-item collapseall" href="javascript://"><span class="fas fa-minus" aria-hidden="true"></span> <?php echo Text::_('COM_MODULES_COLLAPSE'); ?></a>
 								</div>
 							</div>

--- a/administrator/components/com_modules/tmpl/module/edit_assignment.php
+++ b/administrator/components/com_modules/tmpl/module/edit_assignment.php
@@ -141,7 +141,7 @@ $this->document->getWebAssetManager()
 							<div class="dropdown-menu">
 								<h1 class="dropdown-header"><?php echo Text::_('COM_MODULES_SUBITEMS'); ?></h1>
 								<div class="dropdown-divider"></div>
-								<a class="dropdown-item checkall" href="javascript://"><span class="fas fa-check-square" aria-hidden="true"></span> <?php echo Text::_('JSELECT'); ?></a>
+								<a class="dropdown-item checkall" href="javascript://"><?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'check']); ?> <?php echo Text::_('JSELECT'); ?></a>
 								<a class="dropdown-item uncheckall" href="javascript://"><span class="fas fa-square" aria-hidden="true"></span> <?php echo Text::_('COM_MODULES_DESELECT'); ?></a>
 								<div class="treeselect-menu-expand">
 									<div class="dropdown-divider"></div>

--- a/administrator/components/com_modules/tmpl/modules/default.php
+++ b/administrator/components/com_modules/tmpl/modules/default.php
@@ -111,7 +111,7 @@ if ($saveOrder && !empty($this->items))
 							}
 							?>
 							<span class="sortable-handler<?php echo $iconClass; ?>">
-								<span class="fas fa-ellipsis-v"></span>
+								<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'ellipsis-v']); ?>
 							</span>
 							<?php if ($canChange && $saveOrder) : ?>
 								<input type="text" name="order[]" size="5" value="<?php echo $item->ordering; ?>" class="width-20 text-area-order hidden">

--- a/administrator/components/com_modules/tmpl/modules/modal.php
+++ b/administrator/components/com_modules/tmpl/modules/modal.php
@@ -79,16 +79,16 @@ if (!empty($editor))
 			<tbody>
 				<?php
 				$iconStates = array(
-					-2 => 'fas fa-trash',
-					0  => 'fas fa-times',
-					1  => 'fas fa-check',
-					2  => 'fas fa-folder',
+					-2 => 'trash',
+					0  => 'times',
+					1  => 'check',
+					2  => 'folder',
 				);
 				foreach ($this->items as $i => $item) :
 				?>
 				<tr class="row<?php echo $i % 2; ?>">
 					<td class="text-center tbody-icon">
-						<span class="<?php echo $iconStates[$this->escape($item->published)]; ?>" aria-hidden="true"></span>
+						<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => $iconStates[$this->escape($item->published)]]); ?>
 					</td>
 					<td scope="row" class="has-context">
 						<a class="js-module-insert btn btn-sm btn-block btn-success" href="#" data-module="<?php echo $item->id; ?>" data-editor="<?php echo $this->escape($editor); ?>">

--- a/administrator/components/com_modules/tmpl/select/default.php
+++ b/administrator/components/com_modules/tmpl/select/default.php
@@ -12,6 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
 $app = Factory::getApplication();
@@ -43,7 +44,7 @@ endif;
 					>
 					<div class="input-group-append" aria-hidden="true">
 						<div class="input-group-text">
-							<span class="fa fa-search"></span>
+							<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'search']); ?>
 						</div>
 					</div>
 				</div>

--- a/administrator/components/com_newsfeeds/src/Field/Modal/NewsfeedField.php
+++ b/administrator/components/com_newsfeeds/src/Field/Modal/NewsfeedField.php
@@ -195,7 +195,8 @@ class NewsfeedField extends FormField
 				. ' id="' . $this->id . '_clear"'
 				. ' type="button"'
 				. ' onclick="window.processModalParent(\'' . $this->id . '\'); return false;">'
-				. '<span class="fas fa-times" aria-hidden="true"></span> ' . Text::_('JCLEAR')
+				. LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'times'])
+				. Text::_('JCLEAR')
 				. '</button>';
 		}
 

--- a/administrator/components/com_newsfeeds/src/Field/Modal/NewsfeedField.php
+++ b/administrator/components/com_newsfeeds/src/Field/Modal/NewsfeedField.php
@@ -16,6 +16,7 @@ use Joomla\CMS\Form\FormField;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\LanguageHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Session\Session;
 use Joomla\Database\ParameterType;
 
@@ -168,7 +169,8 @@ class NewsfeedField extends FormField
 				. ' data-toggle="modal"'
 				. ' type="button"'
 				. ' data-target="#ModalNew' . $modalId . '">'
-				. '<span class="fas fa-plus" aria-hidden="true"></span> ' . Text::_('JACTION_CREATE')
+				. LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'add'])
+				. ' ' . Text::_('JACTION_CREATE')
 				. '</button>';
 		}
 

--- a/administrator/components/com_newsfeeds/tmpl/newsfeeds/default.php
+++ b/administrator/components/com_newsfeeds/tmpl/newsfeeds/default.php
@@ -114,7 +114,7 @@ if ($saveOrder && !empty($this->items))
 									}
 									?>
 									<span class="sortable-handler<?php echo $iconClass ?>">
-										<span class="fas fa-ellipsis-v" aria-hidden="true"></span>
+										<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'ellipsis-v']); ?>
 									</span>
 									<?php if ($canChange && $saveOrder) : ?>
 										<input type="text" name="order[]" size="5" value="<?php echo $item->ordering; ?>" class="width-20 text-area-order hidden">

--- a/administrator/components/com_newsfeeds/tmpl/newsfeeds/default.php
+++ b/administrator/components/com_newsfeeds/tmpl/newsfeeds/default.php
@@ -39,7 +39,8 @@ if ($saveOrder && !empty($this->items))
 				<?php echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
 				<?php if (empty($this->items)) : ?>
 					<div class="alert alert-info">
-						<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+						<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+						<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 						<?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
 					</div>
 				<?php else : ?>

--- a/administrator/components/com_newsfeeds/tmpl/newsfeeds/modal.php
+++ b/administrator/components/com_newsfeeds/tmpl/newsfeeds/modal.php
@@ -68,10 +68,10 @@ $multilang = Multilanguage::isEnabled();
 				<tbody>
 				<?php
 				$iconStates = array(
-					-2 => 'fas fa-trash',
-					0  => 'fas fa-times',
-					1  => 'fas fa-check',
-					2  => 'fas fa-folder',
+					-2 => 'trash',
+					0  => 'times',
+					1  => 'check',
+					2  => 'folder',
 				);
 				?>
 				<?php foreach ($this->items as $i => $item) : ?>
@@ -97,7 +97,7 @@ $multilang = Multilanguage::isEnabled();
 					?>
 					<tr class="row<?php echo $i % 2; ?>">
 						<td class="text-center tbody-icon">
-							<span class="<?php echo $iconStates[$this->escape($item->published)]; ?>" aria-hidden="true"></span>
+							<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => $iconStates[$this->escape($item->published)]]); ?>
 						</td>
 						<th scope="row">
 							<a href="javascript:void(0)" onclick="if (window.parent) window.parent.<?php echo $this->escape($function); ?>('<?php echo $item->id; ?>', '<?php echo $this->escape(addslashes($item->name)); ?>', '<?php echo $this->escape($item->catid); ?>', null, '<?php echo $this->escape(RouteHelper::getNewsfeedRoute($item->id, $item->catid, $item->language)); ?>', '<?php echo $this->escape($lang); ?>', null);">

--- a/administrator/components/com_newsfeeds/tmpl/newsfeeds/modal.php
+++ b/administrator/components/com_newsfeeds/tmpl/newsfeeds/modal.php
@@ -34,7 +34,8 @@ $multilang = Multilanguage::isEnabled();
 
 		<?php if (empty($this->items)) : ?>
 			<div class="alert alert-info">
-				<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+				<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+				<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 				<?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
 			</div>
 		<?php else : ?>

--- a/administrator/components/com_plugins/tmpl/plugin/edit.php
+++ b/administrator/components/com_plugins/tmpl/plugin/edit.php
@@ -97,7 +97,8 @@ $tmpl     = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=
 							<?php endif; ?>
 							<?php else : ?>
 								<div class="alert alert-danger">
-								<span class="fas fa-exclamation-triangle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('ERROR'); ?></span>
+									<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'warning-2']); ?>
+									<span class="sr-only"><?php echo Text::_('ERROR'); ?></span>
 									<?php echo Text::_('COM_PLUGINS_XML_ERR'); ?>
 								</div>
 							<?php endif; ?>

--- a/administrator/components/com_plugins/tmpl/plugins/default.php
+++ b/administrator/components/com_plugins/tmpl/plugins/default.php
@@ -34,7 +34,8 @@ if ($saveOrder)
 		<?php echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
 		<?php if (empty($this->items)) : ?>
 			<div class="alert alert-info">
-				<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+				<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+				<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 				<?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
 			</div>
 		<?php else : ?>

--- a/administrator/components/com_plugins/tmpl/plugins/default.php
+++ b/administrator/components/com_plugins/tmpl/plugins/default.php
@@ -97,7 +97,7 @@ if ($saveOrder)
 							}
 							?>
 							<span class="sortable-handler<?php echo $iconClass; ?>">
-								<span class="fas fa-ellipsis-v" aria-hidden="true"></span>
+								<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'ellipsis-v']); ?>
 							</span>
 							<?php if ($canChange && $saveOrder) : ?>
 								<input type="text" name="order[]" size="5" value="<?php echo $item->ordering; ?>" class="width-20 text-area-order hidden">

--- a/administrator/components/com_postinstall/tmpl/messages/default.php
+++ b/administrator/components/com_postinstall/tmpl/messages/default.php
@@ -13,6 +13,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Helper\ModuleHelper;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
 $lang     = Factory::getLanguage();
@@ -52,7 +53,7 @@ $params = array('params' => json_encode($param));
 		<h2><?php echo Text::_('COM_POSTINSTALL_LBL_NOMESSAGES_TITLE'); ?></h2>
 		<p><?php echo Text::_('COM_POSTINSTALL_LBL_NOMESSAGES_DESC'); ?></p>
 		<a href="<?php echo Route::_('index.php?option=com_postinstall&view=messages&task=message.reset&eid=' . $this->eid . '&' . $this->token . '=1'); ?>" class="btn btn-warning btn-lg">
-			<span class="fas fa-eye" aria-hidden="true"></span>
+			<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'eye-open']); ?>
 			<?php echo Text::_('COM_POSTINSTALL_BTN_RESET'); ?>
 		</a>
 	</div>

--- a/administrator/components/com_privacy/tmpl/capabilities/default.php
+++ b/administrator/components/com_privacy/tmpl/capabilities/default.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 
 /** @var PrivacyViewCapabilities $this */
 
@@ -21,7 +22,8 @@ use Joomla\CMS\Language\Text;
 	</div>
 	<?php if (empty($this->capabilities)) : ?>
 		<div class="alert alert-info">
-			<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+			<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+			<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 			<?php echo Text::_('COM_PRIVACY_MSG_CAPABILITIES_NO_CAPABILITIES'); ?>
 		</div>
 	<?php else : ?>
@@ -30,7 +32,8 @@ use Joomla\CMS\Language\Text;
 			<summary><?php echo $extension; ?></summary>
 				<?php if (empty($capabilities)) : ?>
 					<div class="alert alert-info">
-						<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+						<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+						<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 						<?php echo Text::_('COM_PRIVACY_MSG_EXTENSION_NO_CAPABILITIES'); ?>
 					</div>
 				<?php else : ?>

--- a/administrator/components/com_privacy/tmpl/consents/default.php
+++ b/administrator/components/com_privacy/tmpl/consents/default.php
@@ -37,7 +37,8 @@ $stateMsgs  = array(
 		<?php echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
 		<?php if (empty($this->items)) : ?>
 			<div class="alert alert-info">
-				<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+				<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+				<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 				<?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
 			</div>
 		<?php else : ?>

--- a/administrator/components/com_privacy/tmpl/request/default.php
+++ b/administrator/components/com_privacy/tmpl/request/default.php
@@ -11,6 +11,7 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\Component\Actionlogs\Administrator\Helper\ActionlogsHelper;
 
@@ -48,7 +49,8 @@ HTMLHelper::_('behavior.keepalive');
 				<div class="card-body">
 					<?php if (empty($this->actionlogs)) : ?>
 						<div class="alert alert-info">
-							<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+							<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+							<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 							<?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
 						</div>
 					<?php else : ?>

--- a/administrator/components/com_privacy/tmpl/requests/default.php
+++ b/administrator/components/com_privacy/tmpl/requests/default.php
@@ -35,7 +35,8 @@ $urgentRequestDate->sub(new DateInterval('P' . $this->urgentRequestAge . 'D'));
 		<?php echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
 		<?php if (empty($this->items)) : ?>
 			<div class="alert alert-info">
-				<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+				<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+				<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 				<?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
 			</div>
 		<?php else : ?>

--- a/administrator/components/com_privacy/tmpl/requests/default.php
+++ b/administrator/components/com_privacy/tmpl/requests/default.php
@@ -83,7 +83,7 @@ $urgentRequestDate->sub(new DateInterval('P' . $this->urgentRequestAge . 'D'));
 										<?php endif; ?>
 									<?php endif; ?>
 									<?php if ($item->status == 1 && $item->request_type === 'remove') : ?>
-										<a class="btn tbody-icon" href="<?php echo Route::_('index.php?option=com_privacy&task=request.remove&id=' . (int) $item->id); ?>" title="<?php echo Text::_('COM_PRIVACY_ACTION_DELETE_DATA'); ?>"><span class="fas fa-times" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('COM_PRIVACY_ACTION_DELETE_DATA'); ?></span></a>
+										<a class="btn tbody-icon" href="<?php echo Route::_('index.php?option=com_privacy&task=request.remove&id=' . (int) $item->id); ?>" title="<?php echo Text::_('COM_PRIVACY_ACTION_DELETE_DATA'); ?>"><?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'times']); ?><span class="sr-only"><?php echo Text::_('COM_PRIVACY_ACTION_DELETE_DATA'); ?></span></a>
 									<?php endif; ?>
 								</div>
 							</td>

--- a/administrator/components/com_redirect/tmpl/links/default.php
+++ b/administrator/components/com_redirect/tmpl/links/default.php
@@ -53,7 +53,8 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 
 		<?php if (empty($this->items)) : ?>
 			<div class="alert alert-info">
-				<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+				<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+				<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 				<?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
 			</div>
 		<?php else : ?>

--- a/administrator/components/com_tags/tmpl/tags/default.php
+++ b/administrator/components/com_tags/tmpl/tags/default.php
@@ -64,7 +64,8 @@ if ($saveOrder && !empty($this->items))
 		?>
 		<?php if (empty($this->items)) : ?>
 			<div class="alert alert-info">
-				<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+				<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+				<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 				<?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
 			</div>
 		<?php else : ?>

--- a/administrator/components/com_tags/tmpl/tags/default.php
+++ b/administrator/components/com_tags/tmpl/tags/default.php
@@ -104,7 +104,8 @@ if ($saveOrder && !empty($this->items))
 						<?php endif; ?>
 						<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_archived')) : ?>
 							<th scope="col" class="w-1 text-center d-none d-md-table-cell">
-								<span class="fas fa-folder" aria-hidden="true" title="<?php echo Text::_('COM_TAGS_COUNT_ARCHIVED_ITEMS'); ?>"><span class="sr-only"><?php echo Text::_('COM_TAGS_COUNT_ARCHIVED_ITEMS'); ?></span></span>
+								<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'folder', 'title' => Text::_('COM_TAGS_COUNT_ARCHIVED_ITEMS')]); ?>
+								<span class="sr-only"><?php echo Text::_('COM_TAGS_COUNT_ARCHIVED_ITEMS'); ?></span>
 							</th>
 						<?php endif; ?>
 						<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_trashed')) : ?>

--- a/administrator/components/com_tags/tmpl/tags/default.php
+++ b/administrator/components/com_tags/tmpl/tags/default.php
@@ -183,7 +183,7 @@ if ($saveOrder && !empty($this->items))
 								}
 								?>
 								<span class="sortable-handler<?php echo $iconClass ?>">
-									<span class="fas fa-ellipsis-v"></span>
+									<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'ellipsis-v']); ?>
 								</span>
 								<?php if ($canChange && $saveOrder) : ?>
 									<input type="text" class="hidden" name="order[]" size="5" value="<?php echo $orderkey + 1; ?>">

--- a/administrator/components/com_tags/tmpl/tags/default.php
+++ b/administrator/components/com_tags/tmpl/tags/default.php
@@ -97,7 +97,8 @@ if ($saveOrder && !empty($this->items))
 						<?php endif; ?>
 						<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_unpublished')) : ?>
 							<th scope="col" class="w-1 text-center d-none d-md-table-cell">
-								<span class="fas fa-times" aria-hidden="true" title="<?php echo Text::_('COM_TAGS_COUNT_UNPUBLISHED_ITEMS'); ?>"><span class="sr-only"><?php echo Text::_('COM_TAGS_COUNT_UNPUBLISHED_ITEMS'); ?></span></span>
+								<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'times', 'title' => Text::_('COM_TAGS_COUNT_UNPUBLISHED_ITEMS')]); ?>
+								<span class="sr-only"><?php echo Text::_('COM_TAGS_COUNT_UNPUBLISHED_ITEMS'); ?></span>
 							</th>
 						<?php endif; ?>
 						<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_archived')) : ?>

--- a/administrator/components/com_tags/tmpl/tags/default.php
+++ b/administrator/components/com_tags/tmpl/tags/default.php
@@ -92,7 +92,8 @@ if ($saveOrder && !empty($this->items))
 
 						<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_published')) : ?>
 							<th scope="col" class="w-1 text-center d-none d-md-table-cell">
-								<span class="fas fa-check" aria-hidden="true" title="<?php echo Text::_('COM_TAGS_COUNT_PUBLISHED_ITEMS'); ?>"><span class="sr-only"><?php echo Text::_('COM_TAGS_COUNT_PUBLISHED_ITEMS'); ?></span></span>
+								<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'check', 'title' => Text::_('COM_TAGS_COUNT_PUBLISHED_ITEMS')]); ?>
+								<span class="sr-only"><?php echo Text::_('COM_TAGS_COUNT_PUBLISHED_ITEMS'); ?></span>
 							</th>
 						<?php endif; ?>
 						<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_unpublished')) : ?>

--- a/administrator/components/com_tags/tmpl/tags/default.php
+++ b/administrator/components/com_tags/tmpl/tags/default.php
@@ -110,7 +110,8 @@ if ($saveOrder && !empty($this->items))
 						<?php endif; ?>
 						<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_trashed')) : ?>
 							<th scope="col" class="w-1 text-center d-none d-md-table-cell">
-								<span class="fas fa-trash" aria-hidden="true" title="<?php echo Text::_('COM_TAGS_COUNT_TRASHED_ITEMS'); ?>"><span class="sr-only"><?php echo Text::_('COM_TAGS_COUNT_TRASHED_ITEMS'); ?></span></span>
+								<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'trash', 'title' => Text::_('COM_TAGS_COUNT_TRASHED_ITEMS')]); ?>
+								<span class="sr-only"><?php echo Text::_('COM_TAGS_COUNT_TRASHED_ITEMS'); ?></span>
 							</th>
 						<?php endif; ?>
 

--- a/administrator/components/com_templates/src/View/Template/HtmlView.php
+++ b/administrator/components/com_templates/src/View/Template/HtmlView.php
@@ -290,7 +290,7 @@ class HtmlView extends BaseHtmlView
 				ToolbarHelper::modal('renameModal', 'fas fa-sync', 'COM_TEMPLATES_BUTTON_RENAME_FILE');
 
 				// Add a Delete file Button
-				ToolbarHelper::modal('deleteModal', 'fas fa-times', 'COM_TEMPLATES_BUTTON_DELETE_FILE', 'btn-danger');
+				ToolbarHelper::modal('deleteModal', 'times', 'COM_TEMPLATES_BUTTON_DELETE_FILE', 'btn-danger');
 			}
 		}
 

--- a/administrator/components/com_templates/tmpl/styles/default.php
+++ b/administrator/components/com_templates/tmpl/styles/default.php
@@ -89,7 +89,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 											<span class="sr-only"><?php echo Text::_('COM_TEMPLATES_TEMPLATE_PREVIEW'); ?></span>
 										</a>
 									<?php else : ?>
-										<span class="fas fa-eye-slash" aria-hidden="true" title="<?php echo Text::_('COM_TEMPLATES_TEMPLATE_NO_PREVIEW'); ?>"></span>
+										<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'eye-close', 'title' => Text::_('COM_TEMPLATES_TEMPLATE_NO_PREVIEW')]); ?>
 										<span class="sr-only"><?php echo Text::_('COM_TEMPLATES_TEMPLATE_NO_PREVIEW'); ?></span>
 									<?php endif; ?>
 								</td>

--- a/administrator/components/com_templates/tmpl/template/default.php
+++ b/administrator/components/com_templates/tmpl/template/default.php
@@ -147,7 +147,7 @@ if ($this->type == 'font')
 					<?php foreach ($this->archive as $file) : ?>
 						<li>
 							<?php if (substr($file, -1) === DIRECTORY_SEPARATOR) : ?>
-								<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'folder', 'class' => 'fa-fw']); ?>&nbsp;<?php echo $file; ?>
+								<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'folder', 'fixed' => true]); ?>&nbsp;<?php echo $file; ?>
 							<?php endif; ?>
 							<?php if (substr($file, -1) != DIRECTORY_SEPARATOR) : ?>
 								<span class="fas fa-file fa-fw" aria-hidden="true"></span>&nbsp;<?php echo $file; ?>

--- a/administrator/components/com_templates/tmpl/template/default.php
+++ b/administrator/components/com_templates/tmpl/template/default.php
@@ -147,7 +147,7 @@ if ($this->type == 'font')
 					<?php foreach ($this->archive as $file) : ?>
 						<li>
 							<?php if (substr($file, -1) === DIRECTORY_SEPARATOR) : ?>
-								<span class="fas fa-folder fa-fw" aria-hidden="true"></span>&nbsp;<?php echo $file; ?>
+								<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'folder', 'class' => 'fa-fw']); ?>&nbsp;<?php echo $file; ?>
 							<?php endif; ?>
 							<?php if (substr($file, -1) != DIRECTORY_SEPARATOR) : ?>
 								<span class="fas fa-file fa-fw" aria-hidden="true"></span>&nbsp;<?php echo $file; ?>
@@ -263,7 +263,7 @@ if ($this->type == 'font')
 						<?php foreach ($this->overridesList['components'] as $key => $value) : ?>
 							<li class="component-folder">
 								<a href="#" class="component-folder-url">
-									<span class="fas fa-folder" aria-hidden="true"></span>&nbsp;<?php echo $key; ?>
+									<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'folder']); ?>&nbsp;<?php echo $key; ?>
 								</a>
 								<ul class="list-unstyled">
 									<?php foreach ($value as $view) : ?>
@@ -291,7 +291,7 @@ if ($this->type == 'font')
 						<?php foreach ($this->overridesList['plugins'] as $key => $group) : ?>
 							<li class="plugin-folder">
 								<a href="#" class="plugin-folder-url">
-									<span class="fas fa-folder" aria-hidden="true"></span>&nbsp;<?php echo $key; ?>
+									<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'folder']); ?>&nbsp;<?php echo $key; ?>
 								</a>
 								<ul class="list-unstyled">
 									<?php foreach ($group as $plugin) : ?>
@@ -319,7 +319,7 @@ if ($this->type == 'font')
 						<?php foreach ($this->overridesList['layouts'] as $key => $value) : ?>
 						<li class="layout-folder">
 							<a href="#" class="layout-folder-url">
-								<span class="fas fa-folder" aria-hidden="true"></span>&nbsp;<?php echo $key; ?>
+								<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'folder']); ?>&nbsp;<?php echo $key; ?>
 							</a>
 							<ul class="list-unstyled">
 								<?php foreach ($value as $layout) : ?>

--- a/administrator/components/com_templates/tmpl/template/default_folders.php
+++ b/administrator/components/com_templates/tmpl/template/default_folders.php
@@ -7,6 +7,8 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
+use Joomla\CMS\Layout\LayoutHelper;
+
 defined('_JEXEC') or die;
 ksort($this->files, SORT_STRING);
 ?>
@@ -16,7 +18,7 @@ ksort($this->files, SORT_STRING);
 		<?php if (is_array($value)) : ?>
 			<li class="folder-select">
 				<a class="folder-url" data-id="<?php echo base64_encode($key); ?>" href="">
-					<span class="fas fa-folder fa-fw" aria-hidden="true"></span>
+					<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'folder', 'class' => 'fa-fw']); ?>
 					<?php $explodeArray = explode('/', $key); echo $this->escape(end($explodeArray)); ?>
 				</a>
 				<?php echo $this->folderTree($value); ?>

--- a/administrator/components/com_templates/tmpl/template/default_folders.php
+++ b/administrator/components/com_templates/tmpl/template/default_folders.php
@@ -18,7 +18,7 @@ ksort($this->files, SORT_STRING);
 		<?php if (is_array($value)) : ?>
 			<li class="folder-select">
 				<a class="folder-url" data-id="<?php echo base64_encode($key); ?>" href="">
-					<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'folder', 'class' => 'fa-fw']); ?>
+					<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'folder', 'fixed' => true]); ?>
 					<?php $explodeArray = explode('/', $key); echo $this->escape(end($explodeArray)); ?>
 				</a>
 				<?php echo $this->folderTree($value); ?>

--- a/administrator/components/com_templates/tmpl/template/default_tree.php
+++ b/administrator/components/com_templates/tmpl/template/default_tree.php
@@ -52,7 +52,7 @@ ksort($this->files, SORT_NATURAL);
 			?>
 			<li class="<?php echo $class; ?>">
 				<a class="folder-url" href="">
-					<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'folder', 'class' => 'fa-fw']); ?>&nbsp;<?php $explodeArray = explode('/', $key); echo $this->escape(end($explodeArray)); ?>
+					<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'folder', 'fixed' => true]); ?>&nbsp;<?php $explodeArray = explode('/', $key); echo $this->escape(end($explodeArray)); ?>
 				</a>
 				<?php echo $this->directoryTree($value); ?>
 			</li>

--- a/administrator/components/com_templates/tmpl/template/default_tree.php
+++ b/administrator/components/com_templates/tmpl/template/default_tree.php
@@ -9,6 +9,7 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
 ksort($this->files, SORT_NATURAL);
@@ -51,7 +52,7 @@ ksort($this->files, SORT_NATURAL);
 			?>
 			<li class="<?php echo $class; ?>">
 				<a class="folder-url" href="">
-					<span class="fas fa-folder fa-fw" aria-hidden="true"></span>&nbsp;<?php $explodeArray = explode('/', $key); echo $this->escape(end($explodeArray)); ?>
+					<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'folder', 'class' => 'fa-fw']); ?>&nbsp;<?php $explodeArray = explode('/', $key); echo $this->escape(end($explodeArray)); ?>
 				</a>
 				<?php echo $this->directoryTree($value); ?>
 			</li>

--- a/administrator/components/com_templates/tmpl/template/default_updated_files.php
+++ b/administrator/components/com_templates/tmpl/template/default_updated_files.php
@@ -12,6 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
 $input = Factory::getApplication()->input;
@@ -81,7 +82,8 @@ $input = Factory::getApplication()->input;
 					<?php echo HTMLHelper::_('form.token'); ?>
 				<?php else : ?>
 					<div class="alert alert-success">
-						<span class="fas fa-check-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('NOTICE'); ?></span>
+						<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'check']); ?>
+						<span class="sr-only"><?php echo Text::_('NOTICE'); ?></span>
 						<?php echo Text::_('COM_TEMPLATES_OVERRIDE_UPTODATE'); ?>
 					</div>
 				<?php endif; ?>

--- a/administrator/components/com_users/src/Service/HTML/Users.php
+++ b/administrator/components/com_users/src/Service/HTML/Users.php
@@ -115,7 +115,9 @@ class Users
 		$title = Text::plural('COM_USERS_N_USER_NOTES', $count);
 
 		return '<button  type="button" data-target="#userModal_' . (int) $userId . '" id="modal-' . (int) $userId
-			. '" data-toggle="modal" class="dropdown-item"><span class="fas fa-eye" aria-hidden="true"></span> ' . $title . '</button>';
+			. '" data-toggle="modal" class="dropdown-item">'
+			.  LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'eye-open'])
+			. ' ' . $title . '</button>';
 	}
 
 	/**

--- a/administrator/components/com_users/src/Service/HTML/Users.php
+++ b/administrator/components/com_users/src/Service/HTML/Users.php
@@ -16,6 +16,7 @@ use Joomla\CMS\Filesystem\Path;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\LanguageHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
 use Joomla\Database\ParameterType;
@@ -66,8 +67,9 @@ class Users
 		$title = Text::_('COM_USERS_ADD_NOTE');
 
 		return '<a href="' . Route::_('index.php?option=com_users&task=note.add&u_id=' . (int) $userId)
-			. '" class="btn btn-secondary btn-sm"><span class="fas fa-plus" aria-hidden="true">'
-			. '</span> ' . $title . '</a>';
+			. '" class="btn btn-secondary btn-sm">'
+			. LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'add'])
+			. ' ' . $title . '</a>';
 	}
 
 	/**

--- a/administrator/components/com_users/tmpl/debuggroup/default.php
+++ b/administrator/components/com_users/tmpl/debuggroup/default.php
@@ -103,7 +103,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 			<div class="legend">
 				<span class="text-danger fas fa-minus-circle" aria-hidden="true"></span>&nbsp;<?php echo Text::_('COM_USERS_DEBUG_IMPLICIT_DENY'); ?>&nbsp;
 				<span class="text-success fas fa-check" aria-hidden="true"></span>&nbsp;<?php echo Text::_('COM_USERS_DEBUG_EXPLICIT_ALLOW'); ?>&nbsp;
-				<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'times', 'class' => 'text-danger']); ?>&nbsp;<?php echo Text::_('COM_USERS_DEBUG_EXPLICIT_DENY'); ?>
+				<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'times', 'suffix' => 'text-danger']); ?>&nbsp;<?php echo Text::_('COM_USERS_DEBUG_EXPLICIT_DENY'); ?>
 			</div>
 
 			<?php // load the pagination. ?>

--- a/administrator/components/com_users/tmpl/debuggroup/default.php
+++ b/administrator/components/com_users/tmpl/debuggroup/default.php
@@ -62,7 +62,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 								$name  = $action[0];
 								$check = $item->checks[$name];
 								if ($check === true) :
-									$icon   = 'fas fa-check';
+									$icon   = 'check';
 									$class  = 'text-success';
 									$button = 'btn-success';
 									$text   = Text::_('COM_USERS_DEBUG_EXPLICIT_ALLOW');
@@ -102,7 +102,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 			</table>
 			<div class="legend">
 				<span class="text-danger fas fa-minus-circle" aria-hidden="true"></span>&nbsp;<?php echo Text::_('COM_USERS_DEBUG_IMPLICIT_DENY'); ?>&nbsp;
-				<span class="text-success fas fa-check" aria-hidden="true"></span>&nbsp;<?php echo Text::_('COM_USERS_DEBUG_EXPLICIT_ALLOW'); ?>&nbsp;
+				<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'check', 'suffix' => 'text-success']); ?>&nbsp;<?php echo Text::_('COM_USERS_DEBUG_EXPLICIT_ALLOW'); ?>&nbsp;
 				<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'times', 'suffix' => 'text-danger']); ?>&nbsp;<?php echo Text::_('COM_USERS_DEBUG_EXPLICIT_DENY'); ?>
 			</div>
 

--- a/administrator/components/com_users/tmpl/debuggroup/default.php
+++ b/administrator/components/com_users/tmpl/debuggroup/default.php
@@ -62,24 +62,29 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 								$name  = $action[0];
 								$check = $item->checks[$name];
 								if ($check === true) :
-									$class  = 'text-success fas fa-check';
+									$icon   = 'fas fa-check';
+									$class  = 'text-success';
 									$button = 'btn-success';
 									$text   = Text::_('COM_USERS_DEBUG_EXPLICIT_ALLOW');
 								elseif ($check === false) :
-									$class  = 'text-danger fas fa-times';
+									$icon   = 'times';
+									$class  = 'text-danger';
 									$button = 'btn-danger';
 									$text   = Text::_('COM_USERS_DEBUG_EXPLICIT_DENY');
 								elseif ($check === null) :
-									$class  = 'text-danger fas fa-minus-circle';
+									$icon   = 'fas fa-minus-circle';
+									$class  = 'text-danger';
 									$button = 'btn-warning';
 									$text   = Text::_('COM_USERS_DEBUG_IMPLICIT_DENY');
 								else :
+									$icon   = '';
 									$class  = '';
 									$button = '';
 									$text   = '';
 								endif;
 								?>
 							<td class="text-center">
+								<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => $icon, 'class' => $class]); ?>
 								<span class="<?php echo $class; ?>" aria-hidden="true"></span>
 								<span class="sr-only"> <?php echo $text; ?></span>
 							</td>
@@ -98,7 +103,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 			<div class="legend">
 				<span class="text-danger fas fa-minus-circle" aria-hidden="true"></span>&nbsp;<?php echo Text::_('COM_USERS_DEBUG_IMPLICIT_DENY'); ?>&nbsp;
 				<span class="text-success fas fa-check" aria-hidden="true"></span>&nbsp;<?php echo Text::_('COM_USERS_DEBUG_EXPLICIT_ALLOW'); ?>&nbsp;
-				<span class="text-danger fas fa-times" aria-hidden="true"></span>&nbsp;<?php echo Text::_('COM_USERS_DEBUG_EXPLICIT_DENY'); ?>
+				<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'times', 'class' => 'text-danger']); ?>&nbsp;<?php echo Text::_('COM_USERS_DEBUG_EXPLICIT_DENY'); ?>
 			</div>
 
 			<?php // load the pagination. ?>

--- a/administrator/components/com_users/tmpl/debuguser/default.php
+++ b/administrator/components/com_users/tmpl/debuguser/default.php
@@ -102,7 +102,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 			<div class="legend">
 				<span class="text-danger fas fa-minus-circle" aria-hidden="true"></span>&nbsp;<?php echo Text::_('COM_USERS_DEBUG_IMPLICIT_DENY'); ?>&nbsp;
 				<span class="text-success fas fa-check" aria-hidden="true"></span>&nbsp;<?php echo Text::_('COM_USERS_DEBUG_EXPLICIT_ALLOW'); ?>&nbsp;
-				<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'times', 'class' => 'text-danger']); ?>&nbsp;<?php echo Text::_('COM_USERS_DEBUG_EXPLICIT_DENY'); ?>
+				<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'times', 'suffix' => 'text-danger']); ?>&nbsp;<?php echo Text::_('COM_USERS_DEBUG_EXPLICIT_DENY'); ?>
 			</div>
 
 			<?php // load the pagination. ?>

--- a/administrator/components/com_users/tmpl/debuguser/default.php
+++ b/administrator/components/com_users/tmpl/debuguser/default.php
@@ -62,25 +62,29 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 								$name  = $action[0];
 								$check = $item->checks[$name];
 								if ($check === true) :
-									$class  = 'text-success fas fa-check';
+									$icon   = 'fas fa-check';
+									$class  = 'text-success';
 									$button = 'btn-success';
 									$text   = Text::_('COM_USERS_DEBUG_EXPLICIT_ALLOW');
 								elseif ($check === false) :
-									$class  = 'text-danger fas fa-times';
+									$icon   = 'times';
+									$class  = 'text-danger';
 									$button = 'btn-danger';
 									$text   = Text::_('COM_USERS_DEBUG_EXPLICIT_DENY');
 								elseif ($check === null) :
-									$class  = 'text-danger fas fa-minus-circle';
+									$icon   = 'fas fa-minus-circle';
+									$class  = 'text-danger';
 									$button = 'btn-warning';
 									$text   = Text::_('COM_USERS_DEBUG_IMPLICIT_DENY');
 								else :
+									$icon   = '';
 									$class  = '';
 									$button = '';
 									$text   = '';
 								endif;
 								?>
 							<td class="text-center">
-								<span class="<?php echo $class; ?>" aria-hidden="true"></span>
+								<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => $icon, 'class' => $class]); ?>
 								<span class="sr-only"> <?php echo $text; ?></span>
 							</td>
 							<?php endforeach; ?>
@@ -98,7 +102,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 			<div class="legend">
 				<span class="text-danger fas fa-minus-circle" aria-hidden="true"></span>&nbsp;<?php echo Text::_('COM_USERS_DEBUG_IMPLICIT_DENY'); ?>&nbsp;
 				<span class="text-success fas fa-check" aria-hidden="true"></span>&nbsp;<?php echo Text::_('COM_USERS_DEBUG_EXPLICIT_ALLOW'); ?>&nbsp;
-				<span class="text-danger fas fa-times" aria-hidden="true">&nbsp;</span><?php echo Text::_('COM_USERS_DEBUG_EXPLICIT_DENY'); ?>
+				<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'times', 'class' => 'text-danger']); ?>&nbsp;<?php echo Text::_('COM_USERS_DEBUG_EXPLICIT_DENY'); ?>
 			</div>
 
 			<?php // load the pagination. ?>

--- a/administrator/components/com_users/tmpl/debuguser/default.php
+++ b/administrator/components/com_users/tmpl/debuguser/default.php
@@ -62,7 +62,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 								$name  = $action[0];
 								$check = $item->checks[$name];
 								if ($check === true) :
-									$icon   = 'fas fa-check';
+									$icon   = 'check';
 									$class  = 'text-success';
 									$button = 'btn-success';
 									$text   = Text::_('COM_USERS_DEBUG_EXPLICIT_ALLOW');
@@ -101,7 +101,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 			</table>
 			<div class="legend">
 				<span class="text-danger fas fa-minus-circle" aria-hidden="true"></span>&nbsp;<?php echo Text::_('COM_USERS_DEBUG_IMPLICIT_DENY'); ?>&nbsp;
-				<span class="text-success fas fa-check" aria-hidden="true"></span>&nbsp;<?php echo Text::_('COM_USERS_DEBUG_EXPLICIT_ALLOW'); ?>&nbsp;
+				<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'check', 'suffix' => 'text-success']); ?>&nbsp;<?php echo Text::_('COM_USERS_DEBUG_EXPLICIT_ALLOW'); ?>&nbsp;
 				<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'times', 'suffix' => 'text-danger']); ?>&nbsp;<?php echo Text::_('COM_USERS_DEBUG_EXPLICIT_DENY'); ?>
 			</div>
 

--- a/administrator/components/com_users/tmpl/groups/default.php
+++ b/administrator/components/com_users/tmpl/groups/default.php
@@ -63,7 +63,7 @@ $wa->useScript('com_users.admin-users-groups');
 									<span class="sr-only"><?php echo Text::_('COM_USERS_COUNT_ENABLED_USERS'); ?></span>
 								</th>
 								<th scope="col" class="w-10 text-center">
-									<span class="fas fa-times" aria-hidden="true" title="<?php echo Text::_('COM_USERS_COUNT_DISABLED_USERS'); ?>"></span>
+									<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'times', 'title' => Text::_('COM_USERS_COUNT_DISABLED_USERS')]); ?>
 									<span class="sr-only"><?php echo Text::_('COM_USERS_COUNT_DISABLED_USERS'); ?></span>
 								</th>
 								<th scope="col" class="w-10 d-none d-md-table-cell">

--- a/administrator/components/com_users/tmpl/groups/default.php
+++ b/administrator/components/com_users/tmpl/groups/default.php
@@ -59,7 +59,7 @@ $wa->useScript('com_users.admin-users-groups');
 									<?php echo Text::_('COM_USERS_DEBUG_PERMISSIONS'); ?>
 								</th>
 								<th scope="col" class="w-10 text-center">
-									<span class="fas fa-check" aria-hidden="true" title="<?php echo Text::_('COM_USERS_COUNT_ENABLED_USERS'); ?>"></span>
+									<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'check', 'title' => Text::_('COM_USERS_COUNT_ENABLED_USERS')]); ?>
 									<span class="sr-only"><?php echo Text::_('COM_USERS_COUNT_ENABLED_USERS'); ?></span>
 								</th>
 								<th scope="col" class="w-10 text-center">

--- a/administrator/components/com_users/tmpl/groups/default.php
+++ b/administrator/components/com_users/tmpl/groups/default.php
@@ -36,7 +36,8 @@ $wa->useScript('com_users.admin-users-groups');
 				<?php echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this, 'options' => array('filterButton' => false))); ?>
 				<?php if (empty($this->items)) : ?>
 					<div class="alert alert-info">
-						<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+						<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+						<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 						<?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
 					</div>
 				<?php else : ?>

--- a/administrator/components/com_users/tmpl/levels/default.php
+++ b/administrator/components/com_users/tmpl/levels/default.php
@@ -39,7 +39,8 @@ if ($saveOrder && !empty($this->items))
 
 				<?php if (empty($this->items)) : ?>
 					<div class="alert alert-info">
-						<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+						<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+						<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 						<?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
 					</div>
 				<?php else : ?>

--- a/administrator/components/com_users/tmpl/levels/default.php
+++ b/administrator/components/com_users/tmpl/levels/default.php
@@ -106,7 +106,7 @@ if ($saveOrder && !empty($this->items))
 									}
 									?>
 									<span class="sortable-handler<?php echo $iconClass ?>">
-										<span class="fas fa-ellipsis-v" aria-hidden="true"></span>
+										<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'ellipsis-v']); ?>
 									</span>
 									<?php if ($canChange && $saveOrder) : ?>
 										<input type="text" name="order[]" size="5" value="<?php echo $item->ordering; ?>" class="width-20 text-area-order hidden">

--- a/administrator/components/com_users/tmpl/notes/default.php
+++ b/administrator/components/com_users/tmpl/notes/default.php
@@ -30,7 +30,8 @@ $listDirn   = $this->escape($this->state->get('list.direction'));
 
 				<?php if (empty($this->items)) : ?>
 					<div class="alert alert-info">
-						<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+						<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+						<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 						<?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
 					</div>
 				<?php else : ?>

--- a/administrator/components/com_users/tmpl/user/edit.php
+++ b/administrator/components/com_users/tmpl/user/edit.php
@@ -95,7 +95,8 @@ $this->useCoreUI = true;
 		</div>
 		<?php if (empty($this->otpConfig->otep)) : ?>
 			<div class="alert alert-warning">
-				<span class="fas fa-exclamation-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('WARNING'); ?></span>
+				<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'warning']); ?>
+				<span class="sr-only"><?php echo Text::_('WARNING'); ?></span>
 				<?php echo Text::_('COM_USERS_USER_OTEPS_WAIT_DESC'); ?>
 			</div>
 		<?php else : ?>

--- a/administrator/components/com_users/tmpl/user/edit.php
+++ b/administrator/components/com_users/tmpl/user/edit.php
@@ -89,7 +89,8 @@ $this->useCoreUI = true;
 			<?php echo Text::_('COM_USERS_USER_OTEPS'); ?>
 		</legend>
 		<div class="alert alert-info">
-			<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+			<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+			<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 			<?php echo Text::_('COM_USERS_USER_OTEPS_DESC'); ?>
 		</div>
 		<?php if (empty($this->otpConfig->otep)) : ?>

--- a/administrator/components/com_users/tmpl/users/default.php
+++ b/administrator/components/com_users/tmpl/users/default.php
@@ -160,7 +160,7 @@ $tfa        = PluginHelper::isEnabled('twofactorauth');
 								<td class="text-center d-none d-md-table-cell">
 									<span class="tbody-icon">
 									<?php if (!empty($item->otpKey)) : ?>
-										<span class="fas fa-check" aria-hidden="true"></span>
+										<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'check']); ?>
 										<span class="sr-only"><?php echo Text::_('COM_USERS_TFA_ACTIVE'); ?></span>
 									<?php else : ?>
 										<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'times']); ?>

--- a/administrator/components/com_users/tmpl/users/default.php
+++ b/administrator/components/com_users/tmpl/users/default.php
@@ -163,7 +163,7 @@ $tfa        = PluginHelper::isEnabled('twofactorauth');
 										<span class="fas fa-check" aria-hidden="true"></span>
 										<span class="sr-only"><?php echo Text::_('COM_USERS_TFA_ACTIVE'); ?></span>
 									<?php else : ?>
-										<span class="fas fa-times" aria-hidden="true"></span>
+										<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'times']); ?>
 										<span class="sr-only"><?php echo Text::_('COM_USERS_TFA_NOTACTIVE'); ?></span>
 									<?php endif; ?>
 									</span>

--- a/administrator/components/com_users/tmpl/users/default.php
+++ b/administrator/components/com_users/tmpl/users/default.php
@@ -36,7 +36,8 @@ $tfa        = PluginHelper::isEnabled('twofactorauth');
 				?>
 				<?php if (empty($this->items)) : ?>
 					<div class="alert alert-info">
-						<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+						<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+						<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 						<?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
 					</div>
 				<?php else : ?>

--- a/administrator/components/com_users/tmpl/users/modal.php
+++ b/administrator/components/com_users/tmpl/users/modal.php
@@ -21,8 +21,8 @@ $input           = Factory::getApplication()->input;
 $field           = $input->getCmd('field');
 $listOrder       = $this->escape($this->state->get('list.ordering'));
 $listDirn        = $this->escape($this->state->get('list.direction'));
-$enabledStates   = array(0 => 'fas fa-check', 1 => 'fas fa-times');
-$activatedStates = array(0 => 'fas fa-check', 1 => 'fas fa-times');
+$enabledStates   = array(0 => 'check', 1 => 'times');
+$activatedStates = array(0 => 'check', 1 => 'times');
 $userRequired    = (int) $input->get('required', 0, 'int');
 $onClick         = "window.parent.jSelectUser(this);window.parent.Joomla.Modal.getCurrent().close()";
 

--- a/administrator/components/com_users/tmpl/users/modal.php
+++ b/administrator/components/com_users/tmpl/users/modal.php
@@ -38,7 +38,8 @@ $onClick         = "window.parent.jSelectUser(this);window.parent.Joomla.Modal.g
 		<?php echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
 		<?php if (empty($this->items)) : ?>
 			<div class="alert alert-info">
-				<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+				<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+				<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 				<?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
 			</div>
 		<?php else : ?>

--- a/administrator/components/com_workflow/tmpl/stages/default.php
+++ b/administrator/components/com_workflow/tmpl/stages/default.php
@@ -107,7 +107,7 @@ if ($saveOrder)
 										}
 										?>
 										<span class="sortable-handler<?php echo $iconClass ?>">
-											<span class="fas fa-ellipsis-v" aria-hidden="true"></span>
+											<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'ellipsis-v']); ?>
 										</span>
 										<?php if ($canChange && $saveOrder) : ?>
 											<input type="text" name="order[]" size="5" value="<?php echo $item->ordering; ?>" class="width-20 text-area-order hidden">

--- a/administrator/components/com_workflow/tmpl/stages/default.php
+++ b/administrator/components/com_workflow/tmpl/stages/default.php
@@ -48,7 +48,8 @@ if ($saveOrder)
 				?>
 				<?php if (empty($this->stages)) : ?>
 					<div class="alert alert-info">
-						<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+						<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+						<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 						<?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
 					</div>
 				<?php else: ?>

--- a/administrator/components/com_workflow/tmpl/transitions/default.php
+++ b/administrator/components/com_workflow/tmpl/transitions/default.php
@@ -108,7 +108,7 @@ if ($saveOrder)
 										}
 										?>
 										<span class="sortable-handler<?php echo $iconClass ?>">
-											<span class="fas fa-ellipsis-v" aria-hidden="true"></span>
+											<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'ellipsis-v']); ?>
 										</span>
 										<?php if ($canChange && $saveOrder) : ?>
 											<input type="text" name="order[]" size="5" value="<?php echo $item->ordering; ?>" class="width-20 text-area-order hidden">

--- a/administrator/components/com_workflow/tmpl/transitions/default.php
+++ b/administrator/components/com_workflow/tmpl/transitions/default.php
@@ -47,7 +47,8 @@ if ($saveOrder)
 				?>
 				<?php if (empty($this->transitions)) : ?>
 					<div class="alert alert-info">
-						<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+						<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+						<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 						<?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
 					</div>
 				<?php else: ?>

--- a/administrator/components/com_workflow/tmpl/workflows/default.php
+++ b/administrator/components/com_workflow/tmpl/workflows/default.php
@@ -124,7 +124,7 @@ $userId = $user->id;
 									}
 									?>
 									<span class="sortable-handler<?php echo $iconClass ?>">
-										<span class="fas fa-ellipsis-v" aria-hidden="true"></span>
+										<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'ellipsis-v']); ?>
 									</span>
 									<?php if ($canChange && $saveOrder) : ?>
 										<input type="text" name="order[]" size="5" value="<?php echo $item->ordering; ?>" class="width-20 text-area-order hidden">

--- a/administrator/components/com_workflow/tmpl/workflows/default.php
+++ b/administrator/components/com_workflow/tmpl/workflows/default.php
@@ -57,7 +57,8 @@ $userId = $user->id;
 				?>
 				<?php if (empty($this->workflows)) : ?>
 					<div class="alert alert-info">
-						<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+						<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+						<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 						<?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
 					</div>
 				<?php else: ?>

--- a/administrator/modules/mod_login/tmpl/default.php
+++ b/administrator/modules/mod_login/tmpl/default.php
@@ -11,6 +11,7 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
@@ -65,7 +66,7 @@ Text::script('MESSAGE');
 				>
 				<span class="input-group-append">
 					<button type="button" class="btn btn-secondary input-password-toggle">
-						<span class="fas fa-eye fa-fw" aria-hidden="true"></span>
+						<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'eye-open', 'fixed' => true]); ?>
 						<span class="sr-only"><?php echo Text::_('JSHOWPASSWORD'); ?></span>
 					</button>
 				</span>

--- a/administrator/modules/mod_privacy_status/tmpl/default.php
+++ b/administrator/modules/mod_privacy_status/tmpl/default.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
 ?>
@@ -25,7 +26,7 @@ use Joomla\CMS\Router\Route;
 			<td>
 				<?php if ($privacyPolicyInfo['published'] && $privacyPolicyInfo['articlePublished']) : ?>
 					<span class="badge badge-success">
-						<span class="fas fa-check-square" aria-hidden="true"></span>
+						<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'success']); ?>
 						<?php echo Text::_('JPUBLISHED'); ?>
 					</span>
 				<?php elseif ($privacyPolicyInfo['published'] && !$privacyPolicyInfo['articlePublished']) : ?>
@@ -54,7 +55,7 @@ use Joomla\CMS\Router\Route;
 			<td>
 				<?php if ($requestFormPublished['published'] && $requestFormPublished['exists']) : ?>
 					<span class="badge badge-success">
-						<span class="fas fa-check-square" aria-hidden="true"></span>
+						<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'success']); ?>
 						<?php echo Text::_('JPUBLISHED'); ?>
 					</span>
 				<?php elseif (!$requestFormPublished['published'] && $requestFormPublished['exists']) : ?>
@@ -80,7 +81,7 @@ use Joomla\CMS\Router\Route;
 			<td>
 				<?php if ($numberOfUrgentRequests === 0) : ?>
 					<span class="badge badge-success">
-						<span class="fas fa-check-square" aria-hidden="true"></span>
+						<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'success']); ?>
 						<?php echo Text::_('JNONE'); ?>
 					</span>
 				<?php else : ?>
@@ -102,7 +103,7 @@ use Joomla\CMS\Router\Route;
 			<td>
 				<?php if ($sendMailEnabled) : ?>
 					<span class="badge badge-success">
-						<span class="fas fa-check-square" aria-hidden="true"></span>
+						<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'success']); ?>
 						<?php echo Text::_('JENABLED'); ?>
 					</span>
 				<?php else : ?>
@@ -125,7 +126,7 @@ use Joomla\CMS\Router\Route;
 			<td>
 				<?php if ($databaseConnectionEncryption !== '') : ?>
 					<span class="badge badge-success">
-						<span class="fas fa-check-square" aria-hidden="true"></span>
+						<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'success']); ?>
 						<?php echo Text::_('JENABLED'); ?>
 					</span>
 				<?php else : ?>

--- a/administrator/modules/mod_privacy_status/tmpl/default.php
+++ b/administrator/modules/mod_privacy_status/tmpl/default.php
@@ -31,12 +31,12 @@ use Joomla\CMS\Router\Route;
 					</span>
 				<?php elseif ($privacyPolicyInfo['published'] && !$privacyPolicyInfo['articlePublished']) : ?>
 					<span class="badge badge-warning">
-						<span class="fas fa-exclamation-triangle" aria-hidden="true"></span>
+						<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'warning-2']); ?>
 						<?php echo Text::_('JUNPUBLISHED'); ?>
 					</span>
 				<?php else : ?>
 					<span class="badge badge-warning">
-						<span class="fas fa-exclamation-triangle" aria-hidden="true"></span>
+						<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'warning-2']); ?>
 						<?php echo Text::_('COM_PRIVACY_STATUS_CHECK_NOT_AVAILABLE'); ?>
 					</span>
 				<?php endif; ?>
@@ -60,12 +60,12 @@ use Joomla\CMS\Router\Route;
 					</span>
 				<?php elseif (!$requestFormPublished['published'] && $requestFormPublished['exists']) : ?>
 					<span class="badge badge-warning">
-						<span class="fas fa-exclamation-triangle" aria-hidden="true"></span>
+						<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'warning-2']); ?>
 						<?php echo Text::_('JUNPUBLISHED'); ?>
 					</span>
 				<?php else : ?>
 					<span class="badge badge-warning">
-						<span class="fas fa-exclamation-triangle" aria-hidden="true"></span>
+						<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'warning-2']); ?>
 						<?php echo Text::_('COM_PRIVACY_STATUS_CHECK_NOT_AVAILABLE'); ?>
 					</span>
 				<?php endif; ?>
@@ -86,7 +86,7 @@ use Joomla\CMS\Router\Route;
 					</span>
 				<?php else : ?>
 					<span class="badge badge-danger">
-						<span class="fas fa-exclamation-triangle" aria-hidden="true"></span>
+						<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'warning-2']); ?>
 						<?php echo Text::_('WARNING'); ?>
 					</span>
 				<?php endif; ?>
@@ -108,7 +108,7 @@ use Joomla\CMS\Router\Route;
 					</span>
 				<?php else : ?>
 					<span class="badge badge-danger">
-						<span class="fas fa-exclamation-triangle" aria-hidden="true"></span>
+						<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'warning-2']); ?>
 						<?php echo Text::_('JDISABLED'); ?>
 					</span>
 				<?php endif; ?>
@@ -131,7 +131,7 @@ use Joomla\CMS\Router\Route;
 					</span>
 				<?php else : ?>
 					<span class="badge badge-warning">
-						<span class="fas fa-exclamation-triangle" aria-hidden="true"></span>
+						<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'warning-2']); ?>
 						<?php echo Text::_('COM_PRIVACY_STATUS_CHECK_NOT_AVAILABLE'); ?>
 					</span>
 				<?php endif; ?>

--- a/administrator/modules/mod_quickicon/src/Helper/QuickIconHelper.php
+++ b/administrator/modules/mod_quickicon/src/Helper/QuickIconHelper.php
@@ -123,7 +123,7 @@ abstract class QuickIconHelper
 			if ($params->get('show_categories'))
 			{
 				$tmp = [
-					'image'   => 'fas fa-folder-open',
+					'image'   => 'folder-open',
 					'link'    => Route::_('index.php?option=com_categories&view=categories&extension=com_content'),
 					'linkadd' => Route::_('index.php?option=com_categories&task=category.add'),
 					'name'    => 'MOD_QUICKICON_CATEGORY_MANAGER',

--- a/administrator/modules/mod_sampledata/tmpl/default.php
+++ b/administrator/modules/mod_sampledata/tmpl/default.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Uri\Uri;
 
 $app->getDocument()->getWebAssetManager()
@@ -56,7 +57,8 @@ $app->getDocument()->addScriptOptions(
 	</ul>
 <?php else : ?>
 	<div class="alert alert-warning">
-		<span class="fas fa-exclamation-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('WARNING'); ?></span>
+		<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'warning']); ?>
+		<span class="sr-only"><?php echo Text::_('WARNING'); ?></span>
 		<?php echo Text::_('MOD_SAMPLEDATA_NOTAVAILABLE'); ?>
 	</div>
 <?php endif; ?>

--- a/components/com_config/tmpl/config/default.php
+++ b/components/com_config/tmpl/config/default.php
@@ -11,6 +11,7 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
@@ -28,7 +29,7 @@ $wa->useScript('keepalive')
 		<?php echo Text::_('JSAVE') ?>
 	</button>
 	<button type="button" class="btn btn-danger" data-submit-task="config.cancel">
-		<span class="fas fa-times" aria-hidden="true"></span>
+		<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'times']); ?>
 		<?php echo Text::_('JCANCEL') ?>
 	</button>
 

--- a/components/com_config/tmpl/config/default.php
+++ b/components/com_config/tmpl/config/default.php
@@ -25,7 +25,7 @@ $wa->useScript('keepalive')
 <form action="<?php echo Route::_('index.php?option=com_config'); ?>" id="application-form" method="post" name="adminForm" class="form-validate">
 
 	<button type="button" class="btn btn-primary" data-submit-task="config.apply">
-		<span class="fas fa-check" aria-hidden="true"></span>
+		<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'check']); ?>
 		<?php echo Text::_('JSAVE') ?>
 	</button>
 	<button type="button" class="btn btn-danger" data-submit-task="config.cancel">

--- a/components/com_config/tmpl/modules/default.php
+++ b/components/com_config/tmpl/modules/default.php
@@ -14,6 +14,7 @@ use Joomla\CMS\Filesystem\File;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
 HTMLHelper::_('behavior.combobox');
@@ -57,7 +58,7 @@ if (Multilanguage::isEnabled())
 				<?php echo Text::_('JSAVE'); ?>
 			</button>
 			<button type="button" class="btn btn-danger" data-submit-task="modules.cancel">
-				<span class="fas fa-times" aria-hidden="true"></span>
+				<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'times']); ?>
 				<?php echo Text::_('JCANCEL'); ?>
 			</button>
 

--- a/components/com_config/tmpl/modules/default.php
+++ b/components/com_config/tmpl/modules/default.php
@@ -50,11 +50,11 @@ if (Multilanguage::isEnabled())
 		<div class="col-md-12">
 
 			<button type="button" class="btn btn-primary" data-submit-task="modules.apply">
-				<span class="fas fa-check" aria-hidden="true"></span>
+				<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'check']); ?>
 				<?php echo Text::_('JAPPLY'); ?>
 			</button>
 			<button type="button" class="btn btn-primary" data-submit-task="modules.save">
-				<span class="fas fa-check" aria-hidden="true"></span>
+				<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'check']); ?>
 				<?php echo Text::_('JSAVE'); ?>
 			</button>
 			<button type="button" class="btn btn-danger" data-submit-task="modules.cancel">

--- a/components/com_config/tmpl/templates/default.php
+++ b/components/com_config/tmpl/templates/default.php
@@ -32,7 +32,7 @@ $wa->useScript('keepalive')
 		<?php echo Text::_('JSAVE') ?>
 	</button>
 	<button type="button" class="btn btn-danger" data-submit-task="templates.cancel">
-		<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'times', 'class' => 'text-white']); ?>
+		<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'times', 'suffix' => 'text-white']); ?>
 		<?php echo Text::_('JCANCEL') ?>
 	</button>
 

--- a/components/com_config/tmpl/templates/default.php
+++ b/components/com_config/tmpl/templates/default.php
@@ -28,7 +28,7 @@ $wa->useScript('keepalive')
 <form action="<?php echo Route::_('index.php?option=com_config'); ?>" method="post" name="adminForm" id="templates-form" class="form-validate">
 
 	<button type="button" class="btn btn-primary" data-submit-task="templates.apply">
-		<span class="fas fa-check text-white" aria-hidden="true"></span>
+		<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'check', 'suffix' => 'text-white']); ?>
 		<?php echo Text::_('JSAVE') ?>
 	</button>
 	<button type="button" class="btn btn-danger" data-submit-task="templates.cancel">

--- a/components/com_config/tmpl/templates/default.php
+++ b/components/com_config/tmpl/templates/default.php
@@ -12,6 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
 $user = Factory::getUser();
@@ -31,7 +32,7 @@ $wa->useScript('keepalive')
 		<?php echo Text::_('JSAVE') ?>
 	</button>
 	<button type="button" class="btn btn-danger" data-submit-task="templates.cancel">
-		<span class="fas fa-times text-white" aria-hidden="true"></span>
+		<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'times', 'class' => 'text-white']); ?>
 		<?php echo Text::_('JCANCEL') ?>
 	</button>
 

--- a/components/com_contact/tmpl/categories/default_items.php
+++ b/components/com_contact/tmpl/categories/default_items.php
@@ -11,6 +11,7 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\Component\Contact\Site\Helper\RouteHelper;
 
@@ -37,7 +38,7 @@ if ($this->maxLevelcat != 0 && count($this->items[$this->parent->id]) > 0) :
 							class="btn btn-secondary btn-sm float-right"
 							aria-label="<?php echo Text::_('JGLOBAL_EXPAND_CATEGORIES'); ?>"
 						>
-							<span class="fas fa-plus" aria-hidden="true"></span>
+							<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'collapse']); ?>
 						</button>
 					<?php endif; ?>
 				</h3>

--- a/components/com_contact/tmpl/form/edit.php
+++ b/components/com_contact/tmpl/form/edit.php
@@ -66,7 +66,7 @@ $this->useCoreUI        = true;
 		</fieldset>
 		<div class="mb-2">
 			<button type="button" class="btn btn-primary" onclick="Joomla.submitbutton('contact.save')">
-				<span class="fas fa-check" aria-hidden="true"></span>
+				<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'check']); ?>
 				<?php echo Text::_('JSAVE'); ?>
 			</button>
 			<button type="button" class="btn btn-danger" onclick="Joomla.submitbutton('contact.cancel')">

--- a/components/com_contact/tmpl/form/edit.php
+++ b/components/com_contact/tmpl/form/edit.php
@@ -70,7 +70,7 @@ $this->useCoreUI        = true;
 				<?php echo Text::_('JSAVE'); ?>
 			</button>
 			<button type="button" class="btn btn-danger" onclick="Joomla.submitbutton('contact.cancel')">
-				<span class="fas fa-times-cancel" aria-hidden="true"></span>
+				<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'times-cancel']); ?>
 				<?php echo Text::_('JCANCEL'); ?>
 			</button>
 			<?php if ($this->params->get('save_history', 0) && $this->item->id) : ?>

--- a/components/com_content/tmpl/archive/default_items.php
+++ b/components/com_content/tmpl/archive/default_items.php
@@ -11,6 +11,7 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\Component\Content\Site\Helper\RouteHelper;
 
@@ -214,7 +215,7 @@ $params = $this->params;
 				<?php if ($params->get('show_hits')) : ?>
 					<dd>
 						<div class="hits">
-							<span class="fas fa-eye"></span>
+							<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'hits']); ?>
 							<meta content="UserPageVisits:<?php echo $item->hits; ?>" itemprop="interactionCount">
 							<?php echo Text::sprintf('COM_CONTENT_ARTICLE_HITS', $item->hits); ?>
 						</div>

--- a/components/com_content/tmpl/categories/default_items.php
+++ b/components/com_content/tmpl/categories/default_items.php
@@ -11,6 +11,7 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\Component\Content\Site\Helper\RouteHelper;
 
@@ -38,7 +39,7 @@ if ($this->maxLevelcat != 0 && count($this->items[$this->parent->id]) > 0) :
 							class="btn btn-secondary btn-sm float-right"
 							aria-label="<?php echo Text::_('JGLOBAL_EXPAND_CATEGORIES'); ?>"
 						>
-							<span class="fas fa-plus" aria-hidden="true"></span>
+							<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'collapse']); ?>
 						</button>
 					<?php endif; ?>
 				</h3>

--- a/components/com_content/tmpl/category/blog_children.php
+++ b/components/com_content/tmpl/category/blog_children.php
@@ -12,6 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\Component\Content\Site\Helper\RouteHelper;
 
@@ -37,7 +38,7 @@ if ($this->maxLevel != 0 && count($this->children[$this->category->id]) > 0) : ?
 					<?php echo $this->escape($child->title); ?></a>
 
 					<?php if ($this->maxLevel > 1 && count($child->getChildren()) > 0) : ?>
-						<a href="#category-<?php echo $child->id; ?>" data-toggle="collapse" data-toggle="button" class="btn btn-sm float-right" aria-label="<?php echo Text::_('JGLOBAL_EXPAND_CATEGORIES'); ?>"><span class="fas fa-plus" aria-hidden="true"></span></a>
+						<a href="#category-<?php echo $child->id; ?>" data-toggle="collapse" data-toggle="button" class="btn btn-sm float-right" aria-label="<?php echo Text::_('JGLOBAL_EXPAND_CATEGORIES'); ?>"><?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'collapse']); ?></a>
 					<?php endif; ?>
 				</h3>
 				<?php else : ?>
@@ -51,7 +52,7 @@ if ($this->maxLevel != 0 && count($this->children[$this->category->id]) > 0) : ?
 					<?php endif; ?>
 
 					<?php if ($this->maxLevel > 1 && count($child->getChildren()) > 0) : ?>
-						<a href="#category-<?php echo $child->id; ?>" data-toggle="collapse" data-toggle="button" class="btn btn-sm float-right" aria-label="<?php echo Text::_('JGLOBAL_EXPAND_CATEGORIES'); ?>"><span class="fas fa-plus" aria-hidden="true"></span></a>
+						<a href="#category-<?php echo $child->id; ?>" data-toggle="collapse" data-toggle="button" class="btn btn-sm float-right" aria-label="<?php echo Text::_('JGLOBAL_EXPAND_CATEGORIES'); ?>"><?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'collapse']); ?></a>
 					<?php endif; ?>
 				</h3>
 				<?php endif; ?>

--- a/components/com_content/tmpl/category/default_children.php
+++ b/components/com_content/tmpl/category/default_children.php
@@ -12,6 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\Component\Content\Site\Helper\RouteHelper;
 
@@ -37,7 +38,7 @@ $groups = $user->getAuthorisedViewLevels();
 					<?php echo $this->escape($child->title); ?></a>
 
 					<?php if (count($child->getChildren()) > 0 && $this->maxLevel > 1) : ?>
-						<a href="#category-<?php echo $child->id; ?>" data-toggle="collapse" data-toggle="button" class="btn btn-sm float-right" aria-label="<?php echo Text::_('JGLOBAL_EXPAND_CATEGORIES'); ?>"><span class="fas fa-plus" aria-hidden="true"></span></a>
+						<a href="#category-<?php echo $child->id; ?>" data-toggle="collapse" data-toggle="button" class="btn btn-sm float-right" aria-label="<?php echo Text::_('JGLOBAL_EXPAND_CATEGORIES'); ?>"><?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'collapse']); ?></a>
 					<?php endif; ?>
 				</h3>
 				<?php else : ?>
@@ -50,7 +51,7 @@ $groups = $user->getAuthorisedViewLevels();
 					<?php endif; ?>
 
 					<?php if (count($child->getChildren()) > 0 && $this->maxLevel > 1) : ?>
-						<a href="#category-<?php echo $child->id; ?>" data-toggle="collapse" data-toggle="button" class="btn btn-sm float-right" aria-label="<?php echo Text::_('JGLOBAL_EXPAND_CATEGORIES'); ?>"><span class="fas fa-plus" aria-hidden="true"></span></a>
+						<a href="#category-<?php echo $child->id; ?>" data-toggle="collapse" data-toggle="button" class="btn btn-sm float-right" aria-label="<?php echo Text::_('JGLOBAL_EXPAND_CATEGORIES'); ?>"><?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'collapse']); ?></a>
 					<?php endif; ?>
 				</h3>
 				<?php endif; ?>

--- a/components/com_content/tmpl/form/edit.php
+++ b/components/com_content/tmpl/form/edit.php
@@ -160,7 +160,7 @@ if (!$editoroptions)
 				<?php echo Text::_('JSAVE'); ?>
 			</button>
 			<button type="button" class="btn btn-danger" data-submit-task="article.cancel">
-				<span class="fas fa-times" aria-hidden="true"></span>
+				<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'times']); ?>
 				<?php echo Text::_('JCANCEL'); ?>
 			</button>
 			<?php if ($params->get('save_history', 0) && $this->item->id) : ?>

--- a/components/com_content/tmpl/form/edit.php
+++ b/components/com_content/tmpl/form/edit.php
@@ -156,7 +156,7 @@ if (!$editoroptions)
 		</fieldset>
 		<div class="mb-2">
 			<button type="button" class="btn btn-primary" data-submit-task="article.save">
-				<span class="fas fa-check" aria-hidden="true"></span>
+				<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'check']); ?>
 				<?php echo Text::_('JSAVE'); ?>
 			</button>
 			<button type="button" class="btn btn-danger" data-submit-task="article.cancel">

--- a/components/com_finder/tmpl/search/default_form.php
+++ b/components/com_finder/tmpl/search/default_form.php
@@ -43,7 +43,7 @@ if ($this->params->get('show_autosuggest', 1))
 				</button>
 				<?php if ($this->params->get('show_advanced', 1)) : ?>
 					<a href="#advancedSearch" data-toggle="collapse" class="btn btn-secondary">
-						<span class="fas fa-search-plus" aria-hidden="true"></span>
+						<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'search-plus']); ?>
 						<?php echo Text::_('COM_FINDER_ADVANCED_SEARCH_TOGGLE'); ?></a>
 				<?php endif; ?>
 				</span>

--- a/components/com_finder/tmpl/search/default_form.php
+++ b/components/com_finder/tmpl/search/default_form.php
@@ -11,6 +11,7 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
 /*
@@ -38,7 +39,7 @@ if ($this->params->get('show_autosuggest', 1))
 				<input type="text" name="q" id="q" class="js-finder-search-query form-control" value="<?php echo $this->escape($this->query->input); ?>">
 				<span class="input-group-append">
 				<button type="submit" class="btn btn-primary">
-					<span class="fas fa-search icon-white" aria-hidden="true"></span>
+					<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'search', 'class' => 'icon-white']); ?>
 					<?php echo Text::_('JSEARCH_FILTER_SUBMIT'); ?>
 				</button>
 				<?php if ($this->params->get('show_advanced', 1)) : ?>

--- a/components/com_finder/tmpl/search/default_form.php
+++ b/components/com_finder/tmpl/search/default_form.php
@@ -39,7 +39,7 @@ if ($this->params->get('show_autosuggest', 1))
 				<input type="text" name="q" id="q" class="js-finder-search-query form-control" value="<?php echo $this->escape($this->query->input); ?>">
 				<span class="input-group-append">
 				<button type="submit" class="btn btn-primary">
-					<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'search', 'class' => 'icon-white']); ?>
+					<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'search', 'suffix' => 'icon-white']); ?>
 					<?php echo Text::_('JSEARCH_FILTER_SUBMIT'); ?>
 				</button>
 				<?php if ($this->params->get('show_advanced', 1)) : ?>

--- a/components/com_newsfeeds/tmpl/categories/default_items.php
+++ b/components/com_newsfeeds/tmpl/categories/default_items.php
@@ -11,6 +11,7 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\Component\Newsfeeds\Site\Helper\RouteHelper;
 
@@ -38,7 +39,7 @@ use Joomla\Component\Newsfeeds\Site\Helper\RouteHelper;
 							class="btn btn-secondary btn-sm float-right"
 							aria-label="<?php echo Text::_('JGLOBAL_EXPAND_CATEGORIES'); ?>"
 						>
-							<span class="fas fa-plus" aria-hidden="true"></span>
+							<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'collapse']); ?>
 						</button>
 					<?php endif; ?>
 				</h3>

--- a/components/com_privacy/tmpl/request/default.php
+++ b/components/com_privacy/tmpl/request/default.php
@@ -11,6 +11,7 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
 /** @var \Joomla\Component\Privacy\Site\View\Request\HtmlView $this */
@@ -48,7 +49,8 @@ HTMLHelper::_('behavior.formvalidator');
 		</form>
 	<?php else : ?>
 		<div class="alert alert-warning">
-			<span class="fas fa-exclamation-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('WARNING'); ?></span>
+			<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'warning']); ?>
+			<span class="sr-only"><?php echo Text::_('WARNING'); ?></span>
 			<?php echo Text::_('COM_PRIVACY_WARNING_CANNOT_CREATE_REQUEST_WHEN_SENDMAIL_DISABLED'); ?>
 		</div>
 	<?php endif; ?>

--- a/components/com_tags/tmpl/tag/default_items.php
+++ b/components/com_tags/tmpl/tag/default_items.php
@@ -41,7 +41,7 @@ $canEditState = $user->authorise('core.edit.state', 'com_tags');
 					<input type="text" name="filter-search" id="filter-search" value="<?php echo $this->escape($this->state->get('list.filter')); ?>" class="form-control" title="<?php echo Text::_('COM_TAGS_FILTER_SEARCH_DESC'); ?>" placeholder="<?php echo Text::_('COM_TAGS_TITLE_FILTER_LABEL'); ?>">
 					<span class="input-group-append">
 						<button type="submit" name="filter-search-button" title="<?php echo Text::_('JSEARCH_FILTER_SUBMIT'); ?>" class="btn btn-secondary">
-							<span class="fas fa-search" aria-hidden="true"></span>
+							<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'search']); ?>
 						</button>
 						<button type="reset" name="filter-clear-button" title="<?php echo Text::_('JSEARCH_FILTER_CLEAR'); ?>" class="btn btn-secondary">
 							<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'times']); ?>

--- a/components/com_tags/tmpl/tag/default_items.php
+++ b/components/com_tags/tmpl/tag/default_items.php
@@ -12,6 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
 use Joomla\Component\Tags\Site\Helper\RouteHelper;
@@ -43,7 +44,7 @@ $canEditState = $user->authorise('core.edit.state', 'com_tags');
 							<span class="fas fa-search" aria-hidden="true"></span>
 						</button>
 						<button type="reset" name="filter-clear-button" title="<?php echo Text::_('JSEARCH_FILTER_CLEAR'); ?>" class="btn btn-secondary">
-							<span class="fas fa-times" aria-hidden="true"></span>
+							<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'times']); ?>
 						</button>
 					</span>
 				</div>

--- a/components/com_tags/tmpl/tag/list_items.php
+++ b/components/com_tags/tmpl/tag/list_items.php
@@ -11,6 +11,7 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
 
@@ -35,7 +36,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 							<span class="fas fa-search" aria-hidden="true"></span>
 						</button>
 						<button type="reset" name="filter-clear-button" title="<?php echo Text::_('JSEARCH_FILTER_CLEAR'); ?>" class="btn btn-secondary">
-							<span class="fas fa-times" aria-hidden="true"></span>
+							<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'times']); ?>
 						</button>
 					</span>
 				</div>

--- a/components/com_tags/tmpl/tag/list_items.php
+++ b/components/com_tags/tmpl/tag/list_items.php
@@ -33,7 +33,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 					<input type="text" name="filter-search" id="filter-search" value="<?php echo $this->escape($this->state->get('list.filter')); ?>" class="form-control" title="<?php echo Text::_('COM_TAGS_FILTER_SEARCH_DESC'); ?>" placeholder="<?php echo Text::_('COM_TAGS_TITLE_FILTER_LABEL'); ?>">
 					<span class="input-group-append">
 						<button type="submit" name="filter-search-button" title="<?php echo Text::_('JSEARCH_FILTER_SUBMIT'); ?>" class="btn btn-secondary">
-							<span class="fas fa-search" aria-hidden="true"></span>
+							<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'search']); ?>
 						</button>
 						<button type="reset" name="filter-clear-button" title="<?php echo Text::_('JSEARCH_FILTER_CLEAR'); ?>" class="btn btn-secondary">
 							<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'times']); ?>

--- a/components/com_tags/tmpl/tags/default_items.php
+++ b/components/com_tags/tmpl/tags/default_items.php
@@ -12,6 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
 use Joomla\Component\Tags\Site\Helper\RouteHelper;
@@ -62,7 +63,7 @@ $n         = count($this->items);
 								<span class="fas fa-search" aria-hidden="true"></span>
 							</button>
 							<button type="reset" name="filter-clear-button" title="<?php echo Text::_('JSEARCH_FILTER_CLEAR'); ?>" class="btn btn-secondary">
-								<span class="fas fa-times" aria-hidden="true"></span>
+								<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'times']); ?>
 							</button>
 						</span>
 					</div>

--- a/components/com_tags/tmpl/tags/default_items.php
+++ b/components/com_tags/tmpl/tags/default_items.php
@@ -60,7 +60,7 @@ $n         = count($this->items);
 						<input type="text" name="filter-search" id="filter-search" value="<?php echo $this->escape($this->state->get('list.filter')); ?>" class="form-control" title="<?php echo Text::_('COM_TAGS_FILTER_SEARCH_DESC'); ?>" placeholder="<?php echo Text::_('COM_TAGS_TITLE_FILTER_LABEL'); ?>">
 						<span class="input-group-append">
 							<button type="submit" name="filter-search-button" title="<?php echo Text::_('JSEARCH_FILTER_SUBMIT'); ?>" class="btn btn-secondary">
-								<span class="fas fa-search" aria-hidden="true"></span>
+								<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'search']); ?>
 							</button>
 							<button type="reset" name="filter-clear-button" title="<?php echo Text::_('JSEARCH_FILTER_CLEAR'); ?>" class="btn btn-secondary">
 								<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'times']); ?>

--- a/components/com_users/tmpl/profile/edit.php
+++ b/components/com_users/tmpl/profile/edit.php
@@ -110,7 +110,8 @@ $wa->useScript('keepalive')
 				</div>
 				<?php if (empty($this->otpConfig->otep)) : ?>
 					<div class="alert alert-warning">
-						<span class="fas fa-exclamation-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('WARNING'); ?></span>
+						<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'warning']); ?>
+						<span class="sr-only"><?php echo Text::_('WARNING'); ?></span>
 						<?php echo Text::_('COM_USERS_PROFILE_OTEPS_WAIT_DESC'); ?>
 					</div>
 				<?php else : ?>

--- a/components/com_users/tmpl/profile/edit.php
+++ b/components/com_users/tmpl/profile/edit.php
@@ -12,6 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
 HTMLHelper::_('bootstrap.tooltip');
@@ -103,7 +104,8 @@ $wa->useScript('keepalive')
 					<?php echo Text::_('COM_USERS_PROFILE_OTEPS'); ?>
 				</legend>
 				<div class="alert alert-info">
-					<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+					<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+					<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 					<?php echo Text::_('COM_USERS_PROFILE_OTEPS_DESC'); ?>
 				</div>
 				<?php if (empty($this->otpConfig->otep)) : ?>

--- a/installation/template/error.php
+++ b/installation/template/error.php
@@ -9,6 +9,7 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
 /** @var JDocumentError $this */
@@ -63,12 +64,13 @@ $this->setMetaData('viewport', 'width=device-width, initial-scale=1');
 				<div id="container-installation" class="container-installation flex">
 					<div class="j-install-step active">
 						<div class="j-install-step-header">
-							<span class="fas fa-exclamation" aria-hidden="true"></span> <?php echo Text::_('INSTL_ERROR'); ?>
+							<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'error']); ?>
+							 <?php echo Text::_('INSTL_ERROR'); ?>
 						</div>
 						<div class="j-install-step-form">
 							<div class="alert preinstall-alert">
 								<div class="alert-icon">
-									<span class="alert-icon fas fa-exclamation-triangle" aria-hidden="true"></span>
+									<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'warning-2', 'suffix' => 'alert-icon']); ?>
 								</div>
 								<div class="alert-text">
 									<h2><?php echo Text::_('JERROR_LAYOUT_ERROR_HAS_OCCURRED_WHILE_PROCESSING_YOUR_REQUEST'); ?></h2>

--- a/installation/template/index.php
+++ b/installation/template/index.php
@@ -9,6 +9,7 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
 use Joomla\CMS\Version;
@@ -83,7 +84,7 @@ Text::script('INSTL_COMPLETE_REMOVE_FOLDER');
 					</div>
 					<div class="m-2 d-flex align-items-center">
 						<a href="https://docs.joomla.org/Special:MyLanguage/J4.x:Installing_Joomla" target="_blank">
-							<span class="fas fa-question" aria-hidden="true"></span>
+							<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'question']); ?>
 							<span class="sr-only"><?php echo Text::_('INSTL_HELP_LINK'); ?></span>
 						</a>
 					</div>

--- a/installation/tmpl/preinstall/default.php
+++ b/installation/tmpl/preinstall/default.php
@@ -21,7 +21,7 @@ HTMLHelper::_('behavior.formvalidator');
 			<div class="col-md-12 mb-4">
 				<div class="j-install-step active">
 					<div class="j-install-step-header">
-						<span class="fas fa-check" aria-hidden="true"></span> <?php echo Text::_('INSTL_PRECHECK_TITLE'); ?>
+						<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'check']); ?> <?php echo Text::_('INSTL_PRECHECK_TITLE'); ?>
 					</div>
 					<div class="j-install-step-form">
 						<?php foreach ($this->options as $option) : ?>
@@ -76,7 +76,7 @@ HTMLHelper::_('behavior.formvalidator');
 							</div>
 							<div class="form-group row">
 								<div class="col-md-8 offset-md-2 justify-content-end d-flex">
-									<button id="verifybutton" class="btn btn-success"><span class="fas fa-check icon-white"></span> <?php echo Text::_('INSTL_VERIFY_FTP_SETTINGS'); ?></button>
+									<button id="verifybutton" class="btn btn-success"><?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'check', 'suffix' => 'icon-white']); ?> <?php echo Text::_('INSTL_VERIFY_FTP_SETTINGS'); ?></button>
 								</div>
 							</div>
 							<input type="hidden" name="format" value="json">

--- a/installation/tmpl/preinstall/default.php
+++ b/installation/tmpl/preinstall/default.php
@@ -10,6 +10,7 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 
 HTMLHelper::_('behavior.formvalidator');
 
@@ -63,7 +64,7 @@ HTMLHelper::_('behavior.formvalidator');
 								<div class="col-md-8 offset-md-2">
 									<?php echo $this->form->getLabel('ftp_host'); ?>
 									<div class="input-append d-flex">
-										<?php echo $this->form->getInput('ftp_host'); ?><button id="findbutton" class="btn btn-secondary ml-2" onclick="Joomla.installation.detectFtpRoot(this);"><span class="fas fa-folder-open"></span> <?php echo Text::_('INSTL_AUTOFIND_FTP_PATH'); ?></button>
+										<?php echo $this->form->getInput('ftp_host'); ?><button id="findbutton" class="btn btn-secondary ml-2" onclick="Joomla.installation.detectFtpRoot(this);"><?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'folder-open']); ?> <?php echo Text::_('INSTL_AUTOFIND_FTP_PATH'); ?></button>
 									</div>
 								</div>
 							</div>

--- a/installation/tmpl/preinstall/default.php
+++ b/installation/tmpl/preinstall/default.php
@@ -28,7 +28,7 @@ HTMLHelper::_('behavior.formvalidator');
 							<?php if ($option->state === 'JNO' || $option->state === false) : ?>
 								<div class="alert preinstall-alert">
 									<div class="alert-icon">
-										<span class="alert-icon fas fa-exclamation-triangle" aria-hidden="true"></span>
+										<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'warning-2', 'suffix' => 'alert-icon']); ?>
 									</div>
 									<div class="alert-text">
 										<strong><?php echo $option->label; ?></strong>

--- a/installation/tmpl/remove/default.php
+++ b/installation/tmpl/remove/default.php
@@ -10,6 +10,7 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Uri\Uri;
 
 HTMLHelper::_('behavior.formvalidator');
@@ -188,7 +189,7 @@ HTMLHelper::_('behavior.formvalidator');
 				<?php echo HTMLHelper::_('form.token'); ?>
 
 				<div class="form-group j-install-last-step">
-					<a class="btn btn-primary btn-block" href="<?php echo Uri::root(); ?>" title="<?php echo Text::_('JSITE'); ?>"><span class="fas fa-eye" aria-hidden="true"></span> <?php echo Text::_('INSTL_COMPLETE_SITE_BTN'); ?></a>
+					<a class="btn btn-primary btn-block" href="<?php echo Uri::root(); ?>" title="<?php echo Text::_('JSITE'); ?>"><?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'eye-open']); ?> <?php echo Text::_('INSTL_COMPLETE_SITE_BTN'); ?></a>
 					<a class="btn btn-primary btn-block" href="<?php echo Uri::root(); ?>administrator/" title="<?php echo Text::_('JADMINISTRATOR'); ?>"><span class="fas fa-lock" aria-hidden="true"></span> <?php echo Text::_('INSTL_COMPLETE_ADMIN_BTN'); ?></a>
 				</div>
 			</div>

--- a/layouts/joomla/content/icons/create.php
+++ b/layouts/joomla/content/icons/create.php
@@ -10,12 +10,13 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 
 $params = $displayData['params'];
 
 ?>
 <?php if ($params->get('show_icons')) : ?>
-	<span class="fas fa-plus fa-fw" aria-hidden="true"></span>
+	<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'new', 'class' => 'fa-fw']); ?>
 	<?php echo Text::_('JNEW'); ?>
 <?php else : ?>
 	<?php echo Text::_('JNEW') . '&#160;'; ?>

--- a/layouts/joomla/content/icons/create.php
+++ b/layouts/joomla/content/icons/create.php
@@ -16,7 +16,7 @@ $params = $displayData['params'];
 
 ?>
 <?php if ($params->get('show_icons')) : ?>
-	<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'new', 'class' => 'fa-fw']); ?>
+	<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'new', 'fixed' => true]); ?>
 	<?php echo Text::_('JNEW'); ?>
 <?php else : ?>
 	<?php echo Text::_('JNEW') . '&#160;'; ?>

--- a/layouts/joomla/content/info_block/category.php
+++ b/layouts/joomla/content/info_block/category.php
@@ -16,7 +16,7 @@ use Joomla\Component\Content\Site\Helper\RouteHelper;
 
 ?>
 <dd class="category-name">
-	<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'folder-open', 'class' => 'fa-fw']); ?>
+	<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'folder-open', 'fixed' => true]); ?>
 	<?php $title = $this->escape($displayData['item']->category_title); ?>
 	<?php if ($displayData['params']->get('link_category') && !empty($displayData['item']->catid)) : ?>
 		<?php $url = '<a href="' . Route::_(

--- a/layouts/joomla/content/info_block/category.php
+++ b/layouts/joomla/content/info_block/category.php
@@ -16,7 +16,7 @@ use Joomla\Component\Content\Site\Helper\RouteHelper;
 
 ?>
 <dd class="category-name">
-	<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'fa-folder-open fa-fw']); ?>
+	<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'folder-open', 'class' => 'fa-fw']); ?>
 	<?php $title = $this->escape($displayData['item']->category_title); ?>
 	<?php if ($displayData['params']->get('link_category') && !empty($displayData['item']->catid)) : ?>
 		<?php $url = '<a href="' . Route::_(

--- a/layouts/joomla/content/info_block/hits.php
+++ b/layouts/joomla/content/info_block/hits.php
@@ -10,10 +10,11 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 
 ?>
 <dd class="hits">
-	<span class="fas fa-eye fa-fw" aria-hidden="true"></span>
+	<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'hits', 'fixed' => true]); ?>
 	<meta itemprop="interactionCount" content="UserPageVisits:<?php echo $displayData['item']->hits; ?>">
 	<?php echo Text::sprintf('COM_CONTENT_ARTICLE_HITS', $displayData['item']->hits); ?>
 </dd>

--- a/layouts/joomla/edit/metadata.php
+++ b/layouts/joomla/edit/metadata.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 
 $form = $displayData->getForm();
 
@@ -20,7 +21,8 @@ $fieldSets = $form->getFieldsets('metadata');
 <?php foreach ($fieldSets as $name => $fieldSet) : ?>
 	<?php if (isset($fieldSet->description) && trim($fieldSet->description)) : ?>
 		<div class="alert alert-info">
-			<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+			<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+			<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 			<?php echo $this->escape(Text::_($fieldSet->description)); ?>
 		</div>
 	<?php endif; ?>

--- a/layouts/joomla/edit/params.php
+++ b/layouts/joomla/edit/params.php
@@ -123,7 +123,8 @@ foreach ($fieldSets as $name => $fieldSet)
 		if (!empty($fieldSet->description))
 		{
 			echo '<div class="alert alert-info">';
-			echo '<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only">' . Text::_('INFO') . '</span> ';
+			echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']);
+			echo '<span class="sr-only">' . Text::_('INFO') . '</span> ';
 			echo Text::_($fieldSet->description);
 			echo '</div>';
 		}
@@ -160,7 +161,8 @@ foreach ($fieldSets as $name => $fieldSet)
 			if (!empty($fieldSet->description))
 			{
 				echo '<div class="alert alert-info">';
-				echo '<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only">' . Text::_('INFO') . '</span> ';
+				echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']);
+				echo '<span class="sr-only">' . Text::_('INFO') . '</span> ';
 				echo Text::_($fieldSet->description);
 				echo '</div>';
 			}
@@ -173,7 +175,8 @@ foreach ($fieldSets as $name => $fieldSet)
 		elseif (!empty($fieldSet->description))
 		{
 			echo '<div class="alert alert-info alert-parent">';
-			echo '<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only">' . Text::_('INFO') . '</span> ';
+			echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']);
+			echo '<span class="sr-only">' . Text::_('INFO') . '</span> ';
 			echo Text::_($fieldSet->description);
 			echo '</div>';
 		}

--- a/layouts/joomla/form/field/media.php
+++ b/layouts/joomla/form/field/media.php
@@ -13,6 +13,7 @@ use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
 
@@ -163,7 +164,7 @@ Text::script('JLIB_APPLICATION_ERROR_SERVER');
 		<?php if ($disabled != true) : ?>
 			<div class="input-group-append">
 				<button type="button" class="btn btn-secondary button-select"><?php echo Text::_("JLIB_FORM_BUTTON_SELECT"); ?></button>
-				<button type="button" class="btn btn-secondary button-clear"><span class="fas fa-times" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_("JLIB_FORM_BUTTON_CLEAR"); ?></span></button>
+				<button type="button" class="btn btn-secondary button-clear"><?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'times']); ?><span class="sr-only"><?php echo Text::_("JLIB_FORM_BUTTON_CLEAR"); ?></span></button>
 			</div>
 		<?php endif; ?>
 	</div>

--- a/layouts/joomla/form/field/password.php
+++ b/layouts/joomla/form/field/password.php
@@ -11,6 +11,7 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 
 extract($displayData);
 
@@ -142,7 +143,7 @@ if ($rules && !empty($description))
 			<?php echo implode(' ', $attributes); ?>>
 		<span class="input-group-append">
 			<button type="button" class="btn btn-secondary input-password-toggle">
-				<span class="fas fa-eye fa-fw" aria-hidden="true"></span>
+				<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'eye-open', 'fixed' => true]); ?>
 				<span class="sr-only"><?php echo Text::_('JSHOWPASSWORD'); ?></span>
 			</button>
 		</span>

--- a/layouts/joomla/form/field/subform/repeatable-table.php
+++ b/layouts/joomla/form/field/subform/repeatable-table.php
@@ -49,7 +49,7 @@ if (!empty($groupByFieldset))
 
 		if ($fieldset->description)
 		{
-			$table_head .= '<span class="fas fa-info-circle" aria-hidden="true" tabindex="0"></span><div role="tooltip" id="tip-' . $field->id . '">' . Text::_($field->description) . '</div>';
+			$table_head .= LayoutHelper::render('jooml.icon.iconclass', ['icon' => 'info', 'tabindex' => 0]) . '<div role="tooltip" id="tip-' . $field->id . '">' . Text::_($field->description) . '</div>';
 		}
 
 		$table_head .= '</th>';
@@ -64,7 +64,7 @@ else
 
 		if ($field->description)
 		{
-			$table_head .= '<span class="fas fa-info-circle" aria-hidden="true" tabindex="0"></span><div role="tooltip" id="tip-' . $field->id . '">' . Text::_($field->description) . '</div>';
+			$table_head .= LayoutHelper::render('jooml.icon.iconclass', ['icon' => 'info', 'tabindex' => 0]) . '<div role="tooltip" id="tip-' . $field->id . '">' . Text::_($field->description) . '</div>';
 		}
 
 		$table_head .= '</th>';

--- a/layouts/joomla/form/field/subform/repeatable-table.php
+++ b/layouts/joomla/form/field/subform/repeatable-table.php
@@ -11,6 +11,7 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 
 extract($displayData);
 
@@ -95,7 +96,7 @@ else
 							<?php if (!empty($buttons['add'])) : ?>
 								<div class="btn-group">
 									<button type="button" class="group-add btn btn-sm btn-success" aria-label="<?php echo Text::_('JGLOBAL_FIELD_ADD'); ?>">
-										<span class="fas fa-plus" aria-hidden="true"></span>
+										<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'add']); ?>
 									</button>
 								</div>
 							<?php endif; ?>

--- a/layouts/joomla/form/field/subform/repeatable-table/section-byfieldsets.php
+++ b/layouts/joomla/form/field/subform/repeatable-table/section-byfieldsets.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 
 extract($displayData);
 
@@ -36,7 +37,7 @@ extract($displayData);
 		<div class="btn-group">
 			<?php if (!empty($buttons['add'])) : ?>
 				<button type="button" class="group-add btn btn-sm btn-success" aria-label="<?php echo Text::_('JGLOBAL_FIELD_ADD'); ?>">
-					<span class="fas fa-plus" aria-hidden="true"></span>
+					<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'add']); ?>
 				</button>
 			<?php endif; ?>
 			<?php if (!empty($buttons['remove'])) : ?>

--- a/layouts/joomla/form/field/subform/repeatable-table/section.php
+++ b/layouts/joomla/form/field/subform/repeatable-table/section.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 
 extract($displayData);
 
@@ -34,7 +35,7 @@ extract($displayData);
 		<div class="btn-group">
 			<?php if (!empty($buttons['add'])) : ?>
 				<button type="button" class="group-add btn btn-sm btn-success" aria-label="<?php echo Text::_('JGLOBAL_FIELD_ADD'); ?>">
-					<span class="fas fa-plus" aria-hidden="true"></span>
+					<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'add']); ?>
 				</button>
 			<?php endif; ?>
 			<?php if (!empty($buttons['remove'])) : ?>

--- a/layouts/joomla/form/field/subform/repeatable.php
+++ b/layouts/joomla/form/field/subform/repeatable.php
@@ -50,7 +50,7 @@ $sublayout = empty($groupByFieldset) ? 'section' : 'section-byfieldsets';
 			<div class="btn-toolbar">
 				<div class="btn-group">
 					<a class="group-add btn btn-sm button btn-success" aria-label="<?php echo Text::_('JGLOBAL_FIELD_ADD'); ?>" tabindex="0">
-						<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'add', 'class' => 'icon-white']); ?>
+						<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'add', 'suffix' => 'icon-white']); ?>
 				</div>
 			</div>
 			<?php endif; ?>

--- a/layouts/joomla/form/field/subform/repeatable.php
+++ b/layouts/joomla/form/field/subform/repeatable.php
@@ -11,6 +11,7 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 
 extract($displayData);
 
@@ -49,7 +50,7 @@ $sublayout = empty($groupByFieldset) ? 'section' : 'section-byfieldsets';
 			<div class="btn-toolbar">
 				<div class="btn-group">
 					<a class="group-add btn btn-sm button btn-success" aria-label="<?php echo Text::_('JGLOBAL_FIELD_ADD'); ?>" tabindex="0">
-						<span class="fas fa-plus icon-white" aria-hidden="true"></span> </a>
+						<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'add', 'class' => 'icon-white']); ?>
 				</div>
 			</div>
 			<?php endif; ?>

--- a/layouts/joomla/form/field/subform/repeatable/section-byfieldsets.php
+++ b/layouts/joomla/form/field/subform/repeatable/section-byfieldsets.php
@@ -27,7 +27,7 @@ extract($displayData);
 	<?php if (!empty($buttons)) : ?>
 	<div class="btn-toolbar text-right">
 		<div class="btn-group">
-			<?php if (!empty($buttons['add'])) : ?><a class="group-add btn btn-sm button btn-success" aria-label="<?php echo Text::_('JGLOBAL_FIELD_ADD'); ?>" tabindex="0"><span class="fas fa-plus icon-white" aria-hidden="true"></span> </a><?php endif; ?>
+			<?php if (!empty($buttons['add'])) : ?><a class="group-add btn btn-sm button btn-success" aria-label="<?php echo Text::_('JGLOBAL_FIELD_ADD'); ?>" tabindex="0"><?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'add', 'class' => 'icon-white']); ?> </a><?php endif; ?>
 			<?php if (!empty($buttons['remove'])) : ?><a class="group-remove btn btn-sm button btn-danger" aria-label="<?php echo Text::_('JGLOBAL_FIELD_REMOVE'); ?>" tabindex="0"><span class="fas fa-minus icon-white" aria-hidden="true"></span> </a><?php endif; ?>
 			<?php if (!empty($buttons['move'])) : ?><a class="group-move btn btn-sm button btn-primary" aria-label="<?php echo Text::_('JGLOBAL_FIELD_MOVE'); ?>"><span class="fas fa-arrows-alt icon-white" aria-hidden="true"></span> </a><?php endif; ?>
 		</div>

--- a/layouts/joomla/form/field/subform/repeatable/section-byfieldsets.php
+++ b/layouts/joomla/form/field/subform/repeatable/section-byfieldsets.php
@@ -27,7 +27,7 @@ extract($displayData);
 	<?php if (!empty($buttons)) : ?>
 	<div class="btn-toolbar text-right">
 		<div class="btn-group">
-			<?php if (!empty($buttons['add'])) : ?><a class="group-add btn btn-sm button btn-success" aria-label="<?php echo Text::_('JGLOBAL_FIELD_ADD'); ?>" tabindex="0"><?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'add', 'class' => 'icon-white']); ?> </a><?php endif; ?>
+			<?php if (!empty($buttons['add'])) : ?><a class="group-add btn btn-sm button btn-success" aria-label="<?php echo Text::_('JGLOBAL_FIELD_ADD'); ?>" tabindex="0"><?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'add', 'suffix' => 'icon-white']); ?> </a><?php endif; ?>
 			<?php if (!empty($buttons['remove'])) : ?><a class="group-remove btn btn-sm button btn-danger" aria-label="<?php echo Text::_('JGLOBAL_FIELD_REMOVE'); ?>" tabindex="0"><span class="fas fa-minus icon-white" aria-hidden="true"></span> </a><?php endif; ?>
 			<?php if (!empty($buttons['move'])) : ?><a class="group-move btn btn-sm button btn-primary" aria-label="<?php echo Text::_('JGLOBAL_FIELD_MOVE'); ?>"><span class="fas fa-arrows-alt icon-white" aria-hidden="true"></span> </a><?php endif; ?>
 		</div>

--- a/layouts/joomla/form/field/subform/repeatable/section.php
+++ b/layouts/joomla/form/field/subform/repeatable/section.php
@@ -27,7 +27,7 @@ extract($displayData);
 	<?php if (!empty($buttons)) : ?>
 	<div class="btn-toolbar text-right">
 		<div class="btn-group">
-			<?php if (!empty($buttons['add'])) : ?><a class="group-add btn btn-sm button btn-success" aria-label="<?php echo Text::_('JGLOBAL_FIELD_ADD'); ?>" tabindex="0"><span class="fas fa-plus icon-white" aria-hidden="true"></span> </a><?php endif; ?>
+			<?php if (!empty($buttons['add'])) : ?><a class="group-add btn btn-sm button btn-success" aria-label="<?php echo Text::_('JGLOBAL_FIELD_ADD'); ?>" tabindex="0"><?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'add', 'class' => 'icon-white']); ?> </a><?php endif; ?>
 			<?php if (!empty($buttons['remove'])) : ?><a class="group-remove btn btn-sm button btn-danger" aria-label="<?php echo Text::_('JGLOBAL_FIELD_REMOVE'); ?>" tabindex="0"><span class="fas fa-minus icon-white" aria-hidden="true"></span> </a><?php endif; ?>
 			<?php if (!empty($buttons['move'])) : ?><a class="group-move btn btn-sm button btn-primary" aria-label="<?php echo Text::_('JGLOBAL_FIELD_MOVE'); ?>"><span class="fas fa-arrows-alt icon-white" aria-hidden="true"></span> </a><?php endif; ?>
 		</div>

--- a/layouts/joomla/form/field/subform/repeatable/section.php
+++ b/layouts/joomla/form/field/subform/repeatable/section.php
@@ -27,7 +27,7 @@ extract($displayData);
 	<?php if (!empty($buttons)) : ?>
 	<div class="btn-toolbar text-right">
 		<div class="btn-group">
-			<?php if (!empty($buttons['add'])) : ?><a class="group-add btn btn-sm button btn-success" aria-label="<?php echo Text::_('JGLOBAL_FIELD_ADD'); ?>" tabindex="0"><?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'add', 'class' => 'icon-white']); ?> </a><?php endif; ?>
+			<?php if (!empty($buttons['add'])) : ?><a class="group-add btn btn-sm button btn-success" aria-label="<?php echo Text::_('JGLOBAL_FIELD_ADD'); ?>" tabindex="0"><?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'add', 'suffix' => 'icon-white']); ?> </a><?php endif; ?>
 			<?php if (!empty($buttons['remove'])) : ?><a class="group-remove btn btn-sm button btn-danger" aria-label="<?php echo Text::_('JGLOBAL_FIELD_REMOVE'); ?>" tabindex="0"><span class="fas fa-minus icon-white" aria-hidden="true"></span> </a><?php endif; ?>
 			<?php if (!empty($buttons['move'])) : ?><a class="group-move btn btn-sm button btn-primary" aria-label="<?php echo Text::_('JGLOBAL_FIELD_MOVE'); ?>"><span class="fas fa-arrows-alt icon-white" aria-hidden="true"></span> </a><?php endif; ?>
 		</div>

--- a/layouts/joomla/icon/iconclass.php
+++ b/layouts/joomla/icon/iconclass.php
@@ -15,6 +15,7 @@ defined('_JEXEC') or die;
 $icon     = $displayData['icon'];
 $class    = $displayData['class'] ?? null;
 $tabindex = $displayData['tabindex'] ?? null;
+$title    = $displayData['title'] ?? null;
 $html     = $displayData['html'] ?? true;
 
 switch ($icon)
@@ -170,6 +171,11 @@ if ($html !== false)
 	if ($tabindex)
 	{
 		$iconAttribs['tabindex'] = $tabindex;
+	}
+
+	if ($title)
+	{
+		$iconAttribs['title'] = $title;
 	}
 
 	$icon = '<span ' . ArrayHelper::toString($iconAttribs) . '></span>';

--- a/layouts/joomla/icon/iconclass.php
+++ b/layouts/joomla/icon/iconclass.php
@@ -27,6 +27,7 @@ switch ($icon)
 		break;
 
 	case 'archive':
+	case 'folder':
 	case 'folder-close':
 	case 'folder-folder-2':
 	case 'folder-minus':

--- a/layouts/joomla/icon/iconclass.php
+++ b/layouts/joomla/icon/iconclass.php
@@ -11,7 +11,7 @@ defined('_JEXEC') or die;
 
 // Convert icomoon to fa
 $icon  = $displayData['icon'];
-$class = $displayData['class'] ? ' ' . $displayData['class'] : null;
+$class = isset($displayData['class']) ? ' ' . $displayData['class'] : null;
 $html  = $displayData['html'] ?? true;
 
 switch ($icon)

--- a/layouts/joomla/icon/iconclass.php
+++ b/layouts/joomla/icon/iconclass.php
@@ -48,6 +48,10 @@ switch ($icon)
 		$icon = 'fas fa-check';
 		break;
 
+	case 'check-circle':
+		$icon = 'fas fa-check-circle';
+		break;
+
 	case 'unpublish':
 	case 'cancel':
 	case 'delete':
@@ -125,6 +129,7 @@ switch ($icon)
 		$icon = 'fas fa-copy';
 		break;
 
+	case 'success':
 	case 'checkin':
 		$icon = 'fas fa-check-square';
 		break;

--- a/layouts/joomla/icon/iconclass.php
+++ b/layouts/joomla/icon/iconclass.php
@@ -138,6 +138,10 @@ switch ($icon)
 		$icon = 'fas fa-arrows-alt';
 		break;
 
+	case 'loading':
+		$icon = 'fas fa-spinner';
+		break;
+
 	default:
 		$icon = 'icon-' . $icon;
 		break;

--- a/layouts/joomla/icon/iconclass.php
+++ b/layouts/joomla/icon/iconclass.php
@@ -41,6 +41,7 @@ switch ($icon)
 		$icon = 'fas fa-folder-open';
 		break;
 
+	case 'check':
 	case 'publish':
 		$icon = 'fas fa-check';
 		break;

--- a/layouts/joomla/icon/iconclass.php
+++ b/layouts/joomla/icon/iconclass.php
@@ -10,8 +10,9 @@
 defined('_JEXEC') or die;
 
 // Convert icomoon to fa
-$icon = $displayData['icon'];
-$html = $displayData['html'] ?? true;
+$icon  = $displayData['icon'];
+$class = $displayData['class'] ? ' ' . $displayData['class'] : null;
+$html  = $displayData['html'] ?? true;
 
 switch ($icon)
 {
@@ -143,7 +144,7 @@ switch ($icon)
 
 if ($html !== false)
 {
-	$icon = '<span class="' . $icon . '" aria-hidden="true"></span>';
+	$icon = '<span class="' . $icon . $class . '" aria-hidden="true"></span>';
 }
 
-echo $icon;
+echo $icon . $class;

--- a/layouts/joomla/icon/iconclass.php
+++ b/layouts/joomla/icon/iconclass.php
@@ -28,6 +28,10 @@ switch ($icon)
 	case (strpos($icon, 'icon-') !== false):
 		break;
 
+	case 'file':
+		$icon = 'fas fa-file';
+		break;
+
 	case 'archive':
 	case 'folder':
 	case 'folder-close':
@@ -172,6 +176,18 @@ switch ($icon)
 
 	case 'info':
 		$icon = 'fas fa-info-circle';
+		break;
+
+	case 'error':
+		$icon = 'fa-exclamation';
+		break;
+
+	case 'warning':
+		$icon = 'fa-exclamation-circle';
+		break;
+
+	case 'warning-2':
+		$icon = 'fa-exclamation-triangle';
 		break;
 
 	default:

--- a/layouts/joomla/icon/iconclass.php
+++ b/layouts/joomla/icon/iconclass.php
@@ -156,6 +156,10 @@ switch ($icon)
 		$icon = 'fas fa-spinner';
 		break;
 
+	case 'search-plus':
+		$icon = 'fas fa-search-plus';
+		break;
+
 	case 'info':
 		$icon = 'fas fa-info-circle';
 		break;

--- a/layouts/joomla/icon/iconclass.php
+++ b/layouts/joomla/icon/iconclass.php
@@ -46,6 +46,7 @@ switch ($icon)
 
 	case 'new':
 	case 'save-new':
+	case 'collapse':
 		$icon = 'fas fa-plus';
 		break;
 

--- a/layouts/joomla/icon/iconclass.php
+++ b/layouts/joomla/icon/iconclass.php
@@ -7,12 +7,15 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
+use Joomla\Utilities\ArrayHelper;
+
 defined('_JEXEC') or die;
 
 // Convert icomoon to fa
-$icon  = $displayData['icon'];
-$class = isset($displayData['class']) ? ' ' . $displayData['class'] : null;
-$html  = $displayData['html'] ?? true;
+$icon     = $displayData['icon'];
+$class    = $displayData['class'] ?? null;
+$tabindex = $displayData['tabindex'] ?? null;
+$html     = $displayData['html'] ?? true;
 
 switch ($icon)
 {
@@ -142,6 +145,10 @@ switch ($icon)
 		$icon = 'fas fa-spinner';
 		break;
 
+	case 'info':
+		$icon = 'fas fa-info-circle';
+		break;
+
 	default:
 		$icon = 'icon-' . $icon;
 		break;
@@ -149,7 +156,17 @@ switch ($icon)
 
 if ($html !== false)
 {
-	$icon = '<span class="' . $icon . $class . '" aria-hidden="true"></span>';
+	$iconAttribs = [
+		'class'       => implode(' ', [$icon, $class]),
+		'aria-hidden' => "true"
+	];
+
+	if ($tabindex)
+	{
+		$iconAttribs['tabindex'] = $tabindex;
+	}
+
+	$icon = '<span ' . ArrayHelper::toString($iconAttribs) . '></span>';
 }
 
-echo $icon . $class;
+echo implode(' ', [$icon, $class]);

--- a/layouts/joomla/icon/iconclass.php
+++ b/layouts/joomla/icon/iconclass.php
@@ -156,6 +156,10 @@ switch ($icon)
 		$icon = 'fas fa-spinner';
 		break;
 
+	case 'search':
+		$icon = 'fas fa-search';
+		break;
+
 	case 'search-plus':
 		$icon = 'fas fa-search-plus';
 		break;

--- a/layouts/joomla/icon/iconclass.php
+++ b/layouts/joomla/icon/iconclass.php
@@ -47,6 +47,7 @@ switch ($icon)
 
 	case 'new':
 	case 'save-new':
+	case 'add':
 	case 'collapse':
 		$icon = 'fas fa-plus';
 		break;

--- a/layouts/joomla/icon/iconclass.php
+++ b/layouts/joomla/icon/iconclass.php
@@ -12,11 +12,12 @@ use Joomla\Utilities\ArrayHelper;
 defined('_JEXEC') or die;
 
 // Convert icomoon to fa
-$icon     = $displayData['icon'];
-$class    = $displayData['class'] ?? null;
-$tabindex = $displayData['tabindex'] ?? null;
-$title    = $displayData['title'] ?? null;
-$html     = $displayData['html'] ?? true;
+$icon       = $displayData['icon'];
+$iconFixed  = $displayData['fixed'] ?? null;
+$iconSuffix = $displayData['suffix'] ?? null;
+$tabindex   = $displayData['tabindex'] ?? null;
+$title      = $displayData['title'] ?? null;
+$html       = $displayData['html'] ?? true;
 
 switch ($icon)
 {
@@ -173,10 +174,15 @@ switch ($icon)
 		break;
 }
 
+if ($iconFixed)
+{
+	$iconFixed = 'fa-fw';
+}
+
 if ($html !== false)
 {
 	$iconAttribs = [
-		'class'       => implode(' ', [$icon, $class]),
+		'class'       => implode(' ', [$icon, $iconFixed, $iconSuffix]),
 		'aria-hidden' => "true"
 	];
 
@@ -193,4 +199,4 @@ if ($html !== false)
 	$icon = '<span ' . ArrayHelper::toString($iconAttribs) . '></span>';
 }
 
-echo implode(' ', [$icon, $class]);
+echo implode(' ', [$icon, $iconFixed, $iconSuffix]);

--- a/layouts/joomla/icon/iconclass.php
+++ b/layouts/joomla/icon/iconclass.php
@@ -14,6 +14,7 @@ defined('_JEXEC') or die;
 // Convert icomoon to fa
 $icon       = $displayData['icon'];
 $iconFixed  = $displayData['fixed'] ?? null;
+$iconPrefix = 'fas fa-';
 $iconSuffix = $displayData['suffix'] ?? null;
 $tabindex   = $displayData['tabindex'] ?? null;
 $title      = $displayData['title'] ?? null;
@@ -29,7 +30,7 @@ switch ($icon)
 		break;
 
 	case 'file':
-		$icon = 'fas fa-file';
+		$icon = $iconPrefix . 'file';
 		break;
 
 	case 'archive':
@@ -40,20 +41,20 @@ switch ($icon)
 	case 'folder-plus-2':
 	case 'folder-remove':
 	case 'drawer-2':
-		$icon = 'fas fa-folder';
+		$icon = $iconPrefix . 'folder';
 		break;
 
 	case 'folder-open':
-		$icon = 'fas fa-folder-open';
+		$icon = $iconPrefix . 'folder-open';
 		break;
 
 	case 'check':
 	case 'publish':
-		$icon = 'fas fa-check';
+		$icon = $iconPrefix . 'check';
 		break;
 
 	case 'check-circle':
-		$icon = 'fas fa-check-circle';
+		$icon = $iconPrefix . 'check-circle';
 		break;
 
 	case 'unpublish':
@@ -61,133 +62,160 @@ switch ($icon)
 	case 'delete':
 	case 'remove':
 	case 'times':
-		$icon = 'fas fa-times';
+		$icon = $iconPrefix . 'times';
 		break;
 
 	case 'times-cancel':
-		$icon = 'fas fa-times-cancel';
+		$icon = $iconPrefix . 'times-cancel';
 		break;
 
 	case 'new':
 	case 'save-new':
 	case 'add':
 	case 'collapse':
-		$icon = 'fas fa-plus';
+		$icon = $iconPrefix . 'plus';
 		break;
 
 	case 'apply':
 	case 'save':
-		$icon = 'fas fa-save';
+		$icon = $iconPrefix . 'save';
 		break;
 
 	case 'mail':
-		$icon = 'fas fa-envelope';
+		$icon = $iconPrefix . 'envelope';
 		break;
 
 	case 'unfeatured':
 	case 'asterisk':
-		$icon = 'fas fa-star';
+		$icon = $iconPrefix . 'star';
 		break;
 
 	case 'featured':
-		$icon = 'fas fa-star featured';
+		$icon = $iconPrefix . 'star featured';
 		break;
 
 	case 'checkedout':
 	case 'protected':
-		$icon = 'fas fa-lock';
+		$icon = $iconPrefix . 'lock';
 		break;
 
 	case 'eye-close':
-		$icon = 'fas fa-eye-slash';
+		$icon = $iconPrefix . 'eye-slash';
 		break;
 
 	case 'eye-open':
-		$icon = 'fas fa-eye';
+		$icon = $iconPrefix . 'eye';
 		break;
 
 	case 'loop':
 	case 'refresh':
 	case 'unblock':
-		$icon = 'fas fa-sync';
+		$icon = $iconPrefix . 'sync';
 		break;
 
 	case 'contract':
-		$icon = 'fas fa-compress';
+		$icon = $iconPrefix . 'compress';
 		break;
 
 	case 'purge':
 	case 'trash':
-		$icon = 'fas fa-trash';
+		$icon = $iconPrefix . 'trash';
 		break;
 
 	case 'options':
-		$icon = 'fas fa-cog';
+		$icon = $iconPrefix . 'cog';
 		break;
 
 	case 'expired':
-		$icon = 'fas fa-minus-circle';
+		$icon = $iconPrefix . 'minus-circle';
 		break;
 
+	case 'select-file':
 	case 'save-copy':
-		$icon = 'fas fa-copy';
+		$icon = $iconPrefix . 'copy';
 		break;
 
 	case 'success':
 	case 'checkin':
-		$icon = 'fas fa-check-square';
+		$icon = $iconPrefix . 'check-square';
 		break;
 
 	case 'generic':
-		$icon = 'fas fa-dot-circle';
+		$icon = $iconPrefix . 'dot-circle';
 		break;
 
 	case 'list-2':
-		$icon = 'fas fa-list-ul';
+		$icon = $iconPrefix . 'list-ul';
 		break;
 
 	case 'default':
-		$icon = 'fas fa-home';
+		$icon = $iconPrefix . 'home';
 		break;
 
 	case 'crop':
-		$icon = 'fas fa-crop';
+		$icon = $iconPrefix . 'crop';
 		break;
 
 	case 'chevron-down':
-		$icon = 'fas fa-chevron-down';
+		$icon = $iconPrefix . 'chevron-down';
+		break;
+
+	case 'previous':
+	case 'nextRtl':
+		$icon = $iconPrefix . 'chevron-left';
+		break;
+
+	case 'next':
+	case 'previousRtl':
+		$icon = $iconPrefix . 'chevron-right';
 		break;
 
 	case 'move':
-		$icon = 'fas fa-arrows-alt';
+		$icon = $iconPrefix . 'arrows-alt';
 		break;
 
 	case 'loading':
-		$icon = 'fas fa-spinner';
+		$icon = $iconPrefix . 'spinner';
+		break;
+
+	case 'question':
+		$icon = $iconPrefix . 'question';
+		break;
+
+	case 'register':
+		$icon = $iconPrefix . 'arrow-alt-circle-right';
 		break;
 
 	case 'search':
-		$icon = 'fas fa-search';
+		$icon = $iconPrefix . 'search';
 		break;
 
 	case 'search-plus':
-		$icon = 'fas fa-search-plus';
+		$icon = $iconPrefix . 'search-plus';
+		break;
+
+	case 'sort':
+		$icon = $iconPrefix . 'sort';
+		break;
+
+	case 'user':
+		$icon = $iconPrefix . 'user';
 		break;
 
 	case 'info':
-		$icon = 'fas fa-info-circle';
+		$icon = $iconPrefix . 'info-circle';
 		break;
 
 	case 'error':
-		$icon = 'fa-exclamation';
+		$icon = $iconPrefix . 'exclamation';
 		break;
 
 	case 'warning':
-		$icon = 'fa-exclamation-circle';
+		$icon = $iconPrefix . 'exclamation-circle';
 		break;
 
 	case 'warning-2':
-		$icon = 'fa-exclamation-triangle';
+		$icon = $iconPrefix . 'exclamation-triangle';
 		break;
 
 	default:

--- a/layouts/joomla/icon/iconclass.php
+++ b/layouts/joomla/icon/iconclass.php
@@ -103,6 +103,7 @@ switch ($icon)
 		$icon = $iconPrefix . 'eye-slash';
 		break;
 
+	case 'hits';
 	case 'eye-open':
 		$icon = $iconPrefix . 'eye';
 		break;
@@ -194,6 +195,14 @@ switch ($icon)
 		$icon = $iconPrefix . 'search-plus';
 		break;
 
+	case 'ellipsis-v':
+		$icon = $iconPrefix . 'ellipsis-v';
+		break;
+
+	case 'ellipsis-h':
+		$icon = $iconPrefix . 'ellipsis-h';
+		break;
+
 	case 'sort':
 		$icon = $iconPrefix . 'sort';
 		break;
@@ -216,6 +225,26 @@ switch ($icon)
 
 	case 'warning-2':
 		$icon = $iconPrefix . 'exclamation-triangle';
+		break;
+
+	case 'paginationStart':
+	case 'paginationEndRtl':
+		$icon = $iconPrefix . 'fa-angle-double-left';
+		break;
+
+	case 'paginationStartRtl':
+	case 'paginationEnd':
+		$icon = $iconPrefix . 'fa-angle-double-right';
+		break;
+
+	case 'paginationNext':
+	case 'paginationPrevRtl':
+		$icon = $iconPrefix . 'fa-angle-left';
+		break;
+
+	case 'paginationNextRtl':
+	case 'paginationPrev':
+		$icon = $iconPrefix . 'fa-angle-right';
 		break;
 
 	default:

--- a/layouts/joomla/icon/iconclass.php
+++ b/layouts/joomla/icon/iconclass.php
@@ -55,6 +55,10 @@ switch ($icon)
 		$icon = 'fas fa-times';
 		break;
 
+	case 'times-cancel':
+		$icon = 'fas fa-times-cancel';
+		break;
+
 	case 'new':
 	case 'save-new':
 	case 'add':

--- a/layouts/joomla/icon/iconclass.php
+++ b/layouts/joomla/icon/iconclass.php
@@ -36,6 +36,10 @@ switch ($icon)
 		$icon = 'fas fa-folder';
 		break;
 
+	case 'folder-open':
+		$icon = 'fas fa-folder-open';
+		break;
+
 	case 'publish':
 		$icon = 'fas fa-check';
 		break;

--- a/layouts/joomla/pagination/link.php
+++ b/layouts/joomla/pagination/link.php
@@ -11,35 +11,37 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 
-$item    = $displayData['data'];
-$display = $item->text;
-$app = Factory::getApplication();
+$item      = $displayData['data'];
+$display   = $item->text;
+$app       = Factory::getApplication();
+$direction = $app->getLanguage()->isRtl() ? "Rtl" : null;
 
 switch ((string) $item->text)
 {
 	// Check for "Start" item
 	case Text::_('JLIB_HTML_START') :
-		$icon = $app->getLanguage()->isRtl() ? 'fas fa-angle-double-right' : 'fas fa-angle-double-left';
+		$icon = 'paginationStart' . $direction;
 		$aria = Text::sprintf('JLIB_HTML_GOTO_POSITION', strtolower($item->text));
 		break;
 
 	// Check for "Prev" item
 	case $item->text === Text::_('JPREV') :
 		$item->text = Text::_('JPREVIOUS');
-		$icon = $app->getLanguage()->isRtl() ? 'fas fa-angle-right' : 'fas fa-angle-left';
-		$aria =Text::sprintf('JLIB_HTML_GOTO_POSITION', strtolower($item->text));
+		$icon       = 'paginationPrev' . $direction;
+		$aria       = Text::sprintf('JLIB_HTML_GOTO_POSITION', strtolower($item->text));
 		break;
 
 	// Check for "Next" item
 	case Text::_('JNEXT') :
-		$icon = $app->getLanguage()->isRtl() ? 'fas fa-angle-left' : 'fas fa-angle-right';
+		$icon = 'paginationNext' . $direction;
 		$aria = Text::sprintf('JLIB_HTML_GOTO_POSITION', strtolower($item->text));
 		break;
 
 	// Check for "End" item
 	case Text::_('JLIB_HTML_END') :
-		$icon = $app->getLanguage()->isRtl() ? 'fas fa-angle-double-left' : 'fas fa-angle-double-right';
+		$icon = 'paginationEnd' . $direction;
 		$aria = Text::sprintf('JLIB_HTML_GOTO_POSITION', strtolower($item->text));
 		break;
 
@@ -51,7 +53,7 @@ switch ((string) $item->text)
 
 if ($icon !== null)
 {
-	$display = '<span class="' . $icon . '" aria-hidden="true"></span>';
+	$display = LayoutHelper::render('joomla.icon.iconclass', ['icon' => $icon]);
 }
 
 if ($displayData['active'])

--- a/layouts/joomla/quickicons/icon.php
+++ b/layouts/joomla/quickicons/icon.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 
 $id      = empty($displayData['id']) ? '' : (' id="' . $displayData['id'] . '"');
 $target  = empty($displayData['target']) ? '' : (' target="' . $displayData['target'] . '"');
@@ -90,7 +91,7 @@ $class = !empty($tmp) ? ' class="' . implode(' ', array_unique($tmp)) . '"' : ''
 	if (isset($displayData['linkadd'])): ?>
 		<li class="btn-block quickicon-linkadd j-links-link d-flex">
 			<a class="d-flex align-items-center" href="<?php echo $displayData['linkadd']; ?>" title="<?php echo Text::_($displayData['name'] . '_ADD'); ?>">
-				<span class="fas fa-plus" aria-hidden="true"></span>
+				<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'add']); ?>
 			</a>
 		</li>
 	</ul>

--- a/layouts/joomla/quickicons/icon.php
+++ b/layouts/joomla/quickicons/icon.php
@@ -69,7 +69,7 @@ $class = !empty($tmp) ? ' class="' . implode(' ', array_unique($tmp)) . '"' : ''
 			<?php endif; ?>
 			<?php if (isset($displayData['ajaxurl'])) : ?>
 				<div class="quickicon-amount" <?php echo $dataUrl ?> aria-hidden="true">
-					<span class="fas fa-spinner" aria-hidden="true"></span>
+					<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'loading']); ?>
 				</div>
 				<div class="quickicon-sr-desc sr-only"></div>
 			<?php endif; ?>

--- a/layouts/joomla/searchtools/default/bar.php
+++ b/layouts/joomla/searchtools/default/bar.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\Registry\Registry;
 
 $data = $displayData;
@@ -48,7 +49,7 @@ $filters = $data['view']->filterForm->getGroup('filter');
 					<?php endif; ?>
 					</label>
 					<button type="submit" class="btn btn-primary" aria-label="<?php echo Text::_('JSEARCH_FILTER_SUBMIT'); ?>">
-						<span class="fas fa-search" aria-hidden="true"></span>
+						<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'search']); ?>
 					</button>
 				</span>
 			</div>

--- a/layouts/joomla/searchtools/default/noitems.php
+++ b/layouts/joomla/searchtools/default/noitems.php
@@ -10,10 +10,12 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 
 $data = $displayData;
 ?>
 <div class="alert alert-info">
-	<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+	<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+	<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 	<?php echo $data['options']['noResultsText']; ?>
 </div>

--- a/layouts/joomla/tinymce/togglebutton.php
+++ b/layouts/joomla/tinymce/togglebutton.php
@@ -10,12 +10,13 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 
 ?>
 <div class="toggle-editor btn-toolbar float-right clearfix mt-3">
 	<div class="btn-group">
 		<button type="button" disabled class="btn btn-secondary js-tiny-toggler-button">
-			<span class="fas fa-eye" aria-hidden="true"></span>
+			<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'eye-open']); ?>
 			<?php echo Text::_('PLG_TINY_BUTTON_TOGGLE_EDITOR'); ?>
 		</button>
 	</div>

--- a/layouts/joomla/toolbar/title.php
+++ b/layouts/joomla/toolbar/title.php
@@ -7,6 +7,8 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
+use Joomla\CMS\Layout\LayoutHelper;
+
 defined('_JEXEC') or die;
 
 $icon = empty($displayData['icon']) ? 'dot-circle' : preg_replace('#\.[^ .]*$#', '', $displayData['icon']);
@@ -19,6 +21,6 @@ if ($icon === 'generic')
 $icon = stristr($icon, "joomla") ? str_ireplace("joomla", "fab fa-joomla", $icon) : "fas fa-" . $icon;
 ?>
 <h1 class="page-title">
-	<span class="<?php echo $icon; ?>" aria-hidden="true"></span>
+	<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => $icon]); ?>
 	<?php echo $displayData['title']; ?>
 </h1>

--- a/layouts/plugins/system/webauthn/manage.php
+++ b/layouts/plugins/system/webauthn/manage.php
@@ -12,6 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\FileLayout;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Uri\Uri;
 use Joomla\CMS\User\User;
 use Joomla\CMS\User\UserHelper;
@@ -134,7 +135,7 @@ $postbackURL = base64_encode(rtrim(Uri::base(), '/') . '/index.php?' . Joomla::g
 				id="plg_system_webauthn-manage-add"
 				class="btn btn-success btn-block"
 				data-random-id="<?php echo $randomId; ?>">
-				<span class="fas fa-plus" aria-hidden="true"></span>
+				<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'add']); ?>
 				<?php echo Text::_('PLG_SYSTEM_WEBAUTHN_MANAGE_BTN_ADD_LABEL') ?>
 			</button>
 		</p>

--- a/layouts/plugins/system/webauthn/manage.php
+++ b/layouts/plugins/system/webauthn/manage.php
@@ -106,6 +106,7 @@ $postbackURL = base64_encode(rtrim(Uri::base(), '/') . '/index.php?' . Joomla::g
 				<td><?php echo htmlentities($method['label']) ?></td>
 				<td>
 					<button data-random-id="<?php echo $randomId; ?>" class="plg_system_webauthn-manage-edit btn btn-secondary">
+						$iconPrefix . '
 						<span class="fas fa-edit" aria-hidden="true"></span>
 						<?php echo Text::_('PLG_SYSTEM_WEBAUTHN_MANAGE_BTN_EDIT_LABEL') ?>
 					</button>

--- a/libraries/src/HTML/Helpers/Grid.php
+++ b/libraries/src/HTML/Helpers/Grid.php
@@ -13,6 +13,7 @@ defined('JPATH_PLATFORM') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Table\Table;
 
 /**
@@ -258,7 +259,9 @@ abstract class Grid
 	{
 		return '<a href="javascript:saveorder('
 			. (count($rows) - 1) . ', \'' . $task . '\')" rel="tooltip" class="saveorder btn btn-sm btn-secondary float-right" title="'
-			. Text::_('JLIB_HTML_SAVE_ORDER') . '"><span class="fas fa-sort"></span></a>';
+			. Text::_('JLIB_HTML_SAVE_ORDER') . '">'
+			. LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'sort'])
+			. '</a>';
 	}
 
 	/**

--- a/modules/mod_breadcrumbs/tmpl/default.php
+++ b/modules/mod_breadcrumbs/tmpl/default.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 
 ?>
 <nav role="navigation" aria-label="<?php echo $module->title; ?>">
@@ -20,7 +21,7 @@ use Joomla\CMS\Language\Text;
 			</li>
 		<?php else : ?>
 			<li class="mod-breadcrumbs__divider float-left">
-				<span class="divider fas fa-location" aria-hidden="true"></span>
+				<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'default']); ?>
 			</li>
 		<?php endif; ?>
 

--- a/modules/mod_finder/tmpl/default.php
+++ b/modules/mod_finder/tmpl/default.php
@@ -35,7 +35,7 @@ if ($params->get('show_button', 0))
 	$output .= $input;
 	$output .= '<span class="input-group-append">';
 	$output .= '<button class="btn btn-primary" type="submit">';
-	$output .= LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'search', 'class' => 'icon-white']);
+	$output .= LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'search', 'suffix' => 'icon-white']);
 	$output .= Text::_('JSEARCH_FILTER_SUBMIT') . '</button>';
 	$output .= '</span>';
 	$output .= '</div>';

--- a/modules/mod_finder/tmpl/default.php
+++ b/modules/mod_finder/tmpl/default.php
@@ -11,6 +11,7 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\Module\Finder\Site\Helper\FinderHelper;
 
@@ -33,7 +34,9 @@ if ($params->get('show_button', 0))
 	$output .= '<div class="mod-finder__search input-group">';
 	$output .= $input;
 	$output .= '<span class="input-group-append">';
-	$output .= '<button class="btn btn-primary" type="submit"><span class="fas fa-search icon-white" aria-hidden="true"></span> ' . Text::_('JSEARCH_FILTER_SUBMIT') . '</button>';
+	$output .= '<button class="btn btn-primary" type="submit">';
+	$output .= LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'search', 'class' => 'icon-white']);
+	$output .= Text::_('JSEARCH_FILTER_SUBMIT') . '</button>';
 	$output .= '</span>';
 	$output .= '</div>';
 }

--- a/modules/mod_login/tmpl/default.php
+++ b/modules/mod_login/tmpl/default.php
@@ -12,6 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Router\Route;
 
@@ -39,7 +40,7 @@ Text::script('JHIDEPASSWORD');
 					<span class="input-group-append">
 						<label for="modlgn-username-<?php echo $module->id; ?>" class="sr-only"><?php echo Text::_('MOD_LOGIN_VALUE_USERNAME'); ?></label>
 						<span class="input-group-text" title="<?php echo Text::_('MOD_LOGIN_VALUE_USERNAME'); ?>">
-							<span class="fas fa-user" aria-hidden="true"></span>
+							<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'user']); ?>
 						</span>
 					</span>
 				</div>
@@ -56,7 +57,7 @@ Text::script('JHIDEPASSWORD');
 					<span class="input-group-append">
 						<label for="modlgn-passwd-<?php echo $module->id; ?>" class="sr-only"><?php echo Text::_('JGLOBAL_PASSWORD'); ?></label>
 						<button type="button" class="btn btn-secondary input-password-toggle">
-							<span class="fas fa-eye fa-fw" aria-hidden="true"></span>
+							<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'eye-open', 'fixed' => true]); ?>
 							<span class="sr-only"><?php echo Text::_('JSHOWPASSWORD'); ?></span>
 						</button>
 					</span>
@@ -73,14 +74,14 @@ Text::script('JHIDEPASSWORD');
 					<div class="input-group">
 						<span class="input-group-prepend" title="<?php echo Text::_('JGLOBAL_SECRETKEY'); ?>">
 							<span class="input-group-text">
-								<span class="fas fa-star" aria-hidden="true"></span>
+								<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'asterisk']); ?>
 							</span>
 							<label for="modlgn-secretkey-<?php echo $module->id; ?>" class="sr-only"><?php echo Text::_('JGLOBAL_SECRETKEY'); ?></label>
 						</span>
 						<input id="modlgn-secretkey-<?php echo $module->id; ?>" autocomplete="one-time-code" type="text" name="secretkey" class="form-control" placeholder="<?php echo Text::_('JGLOBAL_SECRETKEY'); ?>">
 						<span class="input-group-append" title="<?php echo Text::_('JGLOBAL_SECRETKEY_HELP'); ?>">
 							<span class="input-group-text">
-								<span class="fas fa-question" aria-hidden="true"></span>
+								<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'question']); ?>
 							</span>
 						</span>
 					</div>
@@ -88,7 +89,7 @@ Text::script('JHIDEPASSWORD');
 					<label for="modlgn-secretkey-<?php echo $module->id; ?>"><?php echo Text::_('JGLOBAL_SECRETKEY'); ?></label>
 					<input id="modlgn-secretkey-<?php echo $module->id; ?>" autocomplete="one-time-code" type="text" name="secretkey" class="form-control" placeholder="<?php echo Text::_('JGLOBAL_SECRETKEY'); ?>">
 					<span class="btn width-auto" title="<?php echo Text::_('JGLOBAL_SECRETKEY_HELP'); ?>">
-						<span class="fas fa-question" aria-hidden="true"></span>
+						<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'question']); ?>
 					</span>
 				<?php endif; ?>
 			</div>
@@ -144,7 +145,8 @@ Text::script('JHIDEPASSWORD');
 			<?php if ($usersConfig->get('allowUserRegistration')) : ?>
 				<li>
 					<a href="<?php echo Route::_($registerLink); ?>">
-					<?php echo Text::_('MOD_LOGIN_REGISTER'); ?> <span class="fas fa-arrow-alt-circle-right"></span></a>
+						<?php echo Text::_('MOD_LOGIN_REGISTER'); ?> <?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'register']); ?>
+					</a>
 				</li>
 			<?php endif; ?>
 				<li>

--- a/modules/mod_tags_popular/tmpl/cloud.php
+++ b/modules/mod_tags_popular/tmpl/cloud.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\Component\Tags\Site\Helper\RouteHelper;
 
@@ -21,7 +22,8 @@ $maxsize = $params->get('maxsize', 2);
 <?php
 if (!count($list)) : ?>
 	<div class="alert alert-info">
-		<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+		<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+		<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 		<?php echo Text::_('MOD_TAGS_POPULAR_NO_ITEMS_FOUND'); ?>
 	</div>
 <?php else :

--- a/modules/mod_tags_popular/tmpl/default.php
+++ b/modules/mod_tags_popular/tmpl/default.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\Component\Tags\Site\Helper\RouteHelper;
 
@@ -17,7 +18,8 @@ use Joomla\Component\Tags\Site\Helper\RouteHelper;
 <div class="mod-tagspopular tagspopular">
 <?php if (!count($list)) : ?>
 	<div class="alert alert-info">
-		<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+		<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+		<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 		<?php echo Text::_('MOD_TAGS_POPULAR_NO_ITEMS_FOUND'); ?>
 	</div>
 <?php else : ?>

--- a/plugins/content/pagenavigation/tmpl/default.php
+++ b/plugins/content/pagenavigation/tmpl/default.php
@@ -11,31 +11,33 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
-$lang = Factory::getLanguage(); ?>
-
+$lang      = Factory::getLanguage();
+$direction = $lang->isRtl() ? 'Rtl' : null;
+?>
 <nav class="pagenavigation">
 	<ul class="pagination ml-0">
-	<?php if ($row->prev) :
-		$direction = $lang->isRtl() ? 'right' : 'left'; ?>
+	<?php if ($row->prev) : ?>
 		<li class="previous page-item">
 			<a class="page-link" href="<?php echo Route::_($row->prev); ?>" rel="prev">
 			<span class="sr-only">
 				<?php echo Text::sprintf('JPREVIOUS_TITLE', htmlspecialchars($rows[$location-1]->title)); ?>
 			</span>
-			<?php echo '<span class="fas fa-chevron-' . $direction . '" aria-hidden="true"></span> <span aria-hidden="true">' . $row->prev_label . '</span>'; ?>
+			<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'previous' . $direction ]); ?>
+      <?php echo ' <span aria-hidden="true">' . $row->prev_label . '</span>'; ?>
 			</a>
 		</li>
 	<?php endif; ?>
-	<?php if ($row->next) :
-		$direction = $lang->isRtl() ? 'left' : 'right'; ?>
+	<?php if ($row->next) : ?>
 		<li class="next page-item">
 			<a class="page-link" href="<?php echo Route::_($row->next); ?>" rel="next">
 			<span class="sr-only">
 				<?php echo Text::sprintf('JNEXT_TITLE', htmlspecialchars($rows[$location+1]->title)); ?>
 			</span>
-			<?php echo '<span aria-hidden="true">' . $row->next_label . '</span> <span class="fas fa-chevron-' . $direction . '" aria-hidden="true"></span>'; ?>
+			<?php echo '<span aria-hidden="true">' . $row->next_label . '</span> '; ?>
+			<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'next' . $direction ]); ?>
 			</a>
 		</li>
 	<?php endif; ?>

--- a/plugins/installer/packageinstaller/tmpl/default.php
+++ b/plugins/installer/packageinstaller/tmpl/default.php
@@ -12,6 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Filesystem\FilesystemHelper;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 
 /** @var PlgInstallerPackageInstaller $this */
 
@@ -78,7 +79,7 @@ $maxSize = HTMLHelper::_('number.bytes', $maxSizeBytes);
 				</p>
 				<p>
 					<button id="select-file-button" type="button" class="btn btn-success">
-						<span class="fas fa-copy" aria-hidden="true"></span>
+						<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'select-file']); ?>
 						<?php echo Text::_('PLG_INSTALLER_PACKAGEINSTALLER_SELECT_FILE'); ?>
 					</button>
 				</p>

--- a/plugins/system/stats/layouts/field/uniqueid.php
+++ b/plugins/system/stats/layouts/field/uniqueid.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 
 extract($displayData);
 
@@ -44,5 +45,6 @@ extract($displayData);
 ?>
 <input type="hidden" name="<?php echo $name; ?>" id="<?php echo $id; ?>" value="<?php echo htmlspecialchars($value, ENT_QUOTES, 'UTF-8'); ?>">
 <button class="btn btn-secondary" type="button" id="js-pstats-reset-uid">
-	<span class="fas fa-sync"></span> <?php echo Text::_('PLG_SYSTEM_STATS_RESET_UNIQUE_ID'); ?>
+	<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'reset']); ?>
+	&nbsp;<?php echo Text::_('PLG_SYSTEM_STATS_RESET_UNIQUE_ID'); ?>
 </button>

--- a/plugins/twofactorauth/totp/tmpl/form.php
+++ b/plugins/twofactorauth/totp/tmpl/form.php
@@ -59,7 +59,8 @@ Factory::getDocument()->addScriptDeclaration($js);
 		</li>
 	</ul>
 	<div class="alert alert-warning">
-		<span class="fas fa-exclamation-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('WARNING'); ?></span>
+		<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'warning']); ?>
+		<span class="sr-only"><?php echo Text::_('WARNING'); ?></span>
 		<?php echo Text::_('PLG_TWOFACTORAUTH_TOTP_STEP1_WARN'); ?>
 	</div>
 </fieldset>

--- a/plugins/twofactorauth/totp/tmpl/form.php
+++ b/plugins/twofactorauth/totp/tmpl/form.php
@@ -11,6 +11,7 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 
 Factory::getDocument()->getWebAssetManager()->usePreset('qrcode');
 
@@ -101,7 +102,8 @@ Factory::getDocument()->addScriptDeclaration($js);
 	</div>
 
 	<div class="alert alert-info">
-		<span class="fas fa-info-circle" aria-hidden="true"></span><span class="sr-only"><?php echo Text::_('INFO'); ?></span>
+		<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info']); ?>
+		<span class="sr-only"><?php echo Text::_('INFO'); ?></span>
 		<?php echo Text::_('PLG_TWOFACTORAUTH_TOTP_STEP2_RESET'); ?>
 	</div>
 </fieldset>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

With this PR merged all hard coded icons `<span class="fas fa-some-kind-of-icon" aria-hidden="true" and-more-attributes></span>` are being replaced by the JLayout implemented with #30470 
The reason behind this is to make Joomla more flexible to switch to other icon libraries, or to implement your own. 
With this PR merged the declaration of icons is only be done in https://github.com/joomla/joomla-cms/blob/4.0-dev/layouts/joomla/icon/iconclass.php

### Testing Instructions

- Open Joomla Administrator and inspect icons
- Apply PR and refresh page
- All icons should be shown as it was before this PR. 

### Actual result BEFORE applying this Pull Request

All icons are hard coded.

### Expected result AFTER applying this Pull Request

Most of all icons are set through the `LayoutHelper('joomla.icon.iconclass', ['icon' => 'some-kind-of-icon-type'])`


### Documentation Changes Required

I don't know if there is documentation about the present LayoutHelpers and how they are / should be used. 