### PR TITLE
[4.0] Fix Module Frontend Editing permissions

### DIFF
--- a/components/com_config/src/Dispatcher/Dispatcher.php
+++ b/components/com_config/src/Dispatcher/Dispatcher.php
@@ -36,9 +36,19 @@ class Dispatcher extends ComponentDispatcher
 
 		$user = $this->app->getIdentity();
 
-		if (!$user->authorise('module.edit.frontend', 'com_modules') && !$user->authorise('module.edit.frontend', 'com_modules.module.' . $mod->id))
+		if ($this->input->get('view') === 'modules')
 		{
-			throw new NotAllowed($this->app->getLanguage()->_('JERROR_ALERTNOAUTHOR'), 403);
+			if (!$user->authorise('module.edit.frontend', 'com_modules') && !$user->authorise('module.edit.frontend', 'com_modules.module.' . $this->input->get('id')))
+			{
+				throw new NotAllowed($this->app->getLanguage()->_('JERROR_ALERTNOAUTHOR'), 403);
+			}
+		}
+		else
+		{
+			if (!$this->app->getIdentity()->authorise('core.admin'))
+			{
+				throw new NotAllowed($this->app->getLanguage()->_('JERROR_ALERTNOAUTHOR'), 403);
+			}
 		}
 	}
 }

--- a/components/com_config/src/Dispatcher/Dispatcher.php
+++ b/components/com_config/src/Dispatcher/Dispatcher.php
@@ -34,7 +34,9 @@ class Dispatcher extends ComponentDispatcher
 	{
 		parent::checkAccess();
 
-		if (!$this->app->getIdentity()->authorise('core.admin'))
+		$user = $this->app->getIdentity();
+
+		if (!$user->authorise('module.edit.frontend', 'com_modules') && !$user->authorise('module.edit.frontend', 'com_modules.module.' . $mod->id))
 		{
 			throw new NotAllowed($this->app->getLanguage()->_('JERROR_ALERTNOAUTHOR'), 403);
 		}


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/30628

### Summary of Changes
Dispatcher was allowing only superuser to use module frontendediting


### Testing Instructions
Set Global Configuration to allow Frontend editing for modules
In Modules Options, set administrator permissions for frontend editing to Allowed.
<img width="871" alt="Screen Shot 2020-09-13 at 18 08 07" src="https://user-images.githubusercontent.com/869724/93022995-62638e00-f5ec-11ea-94c9-d04f31839153.png">

In frontend, log with a user set as administrator.
Click on the edit icon for a module

<img width="317" alt="Screen Shot 2020-09-13 at 18 09 32" src="https://user-images.githubusercontent.com/869724/93023021-6f807d00-f5ec-11ea-92e9-76bac2616178.png">

Patch and test again


### Actual result BEFORE applying this Pull Request

` 403 You don't have permission to access this. Please contact a website administrator if this is incorrect. `

### Expected result AFTER applying this Pull Request

Module is displayed for editing
