### PR TITLE
Fix tabs not wrapping and trigger horizontal scrolling

### DIFF
--- a/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-tab.scss
+++ b/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-tab.scss
@@ -31,6 +31,7 @@ joomla-tab {
 
   > ul {
     display: flex;
+    flex-flow: wrap;
     padding: 0;
     margin: 0;
     white-space: nowrap;


### PR DESCRIPTION
Pull Request for Issue #30667 

### Summary of Changes

Add flex wrap to enable wrap on tabs

### Testing Instructions

- apply pr, 
- npm run build:css


### Actual result BEFORE applying this Pull Request
see issue #30667


### Expected result AFTER applying this Pull Request
see issue #30667


### Documentation Changes Required
nope
