### PR TITLE
Correct checkin permissions

### DIFF
--- a/libraries/src/MVC/Model/FormModel.php
+++ b/libraries/src/MVC/Model/FormModel.php
@@ -96,7 +96,7 @@ abstract class FormModel extends BaseDatabaseModel
 			}
 
 			// Check if this is the user having previously checked out the row.
-			if ($table->{$checkedOutField} > 0 && $table->{$checkedOutField} != $user->get('id') && !$user->authorise('core.admin', 'com_checkin'))
+			if ($table->{$checkedOutField} > 0 && $table->{$checkedOutField} != $user->get('id') && !$user->authorise('core.manage', 'com_checkin'))
 			{
 				$this->setError(\JText::_('JLIB_APPLICATION_ERROR_CHECKIN_USER_MISMATCH'));
 


### PR DESCRIPTION
Pull Request for Issue Reported on JSE https://joomla.stackexchange.com/questions/28479/what-permission-do-you-need-to-check-in-others-article-at-any-time.

### Summary of Changes

In view layouts and in `com_checkin` we use `core.manage` permission check to determine whether users can perform a check in. But in the model we use `core.admin` check. This way the check in button appears enabled but check in fails. However, user with `core.manage` permissions in `com_checkin` can still check in items through `com_checkin`.

### Testing Instructions

Create a user in `Manager` group.
Give `Access Administrator Interface` permissions in `com_checkin` to managers.
While still logged in as super user checkout an article.
Login to backend as manager.
Try to check in the article from article list and from `com_checkin`.

### Actual result BEFORE applying this Pull Request

Checking in in article list fails but works in `com_checkin`.

### Expected result AFTER applying this Pull Request

Checking in works in both places.

### Documentation Changes Required

IDK.