### PR TITLE
[4.0] use layout for Toolbar title

### DIFF
--- a/build/media_source/system/scss/_icomoon.scss
+++ b/build/media_source/system/scss/_icomoon.scss
@@ -825,7 +825,8 @@
   @extend .#{$fa-css-prefix}-cube:before;
 }
 
-.icon-puzzle::before {
+.icon-puzzle::before,
+.icon-puzzle-piece::before {
   @extend .#{$fa-css-prefix}-puzzle-piece:before;
 }
 

--- a/layouts/joomla/icon/iconclass.php
+++ b/layouts/joomla/icon/iconclass.php
@@ -26,7 +26,7 @@ switch ($icon)
 	case (strpos($icon, 'icon-') !== false):
 		break;
 
-	// If its missing the fa prefix add it since its incomplete
+	// If it's missing the fa prefix add it since it's incomplete
 	case (strpos($icon, 'fa-') !== false):
 		$icon = 'fas ' . str_ireplace('fas ', '', $icon);
 		break;

--- a/layouts/joomla/icon/iconclass.php
+++ b/layouts/joomla/icon/iconclass.php
@@ -16,8 +16,8 @@ $html = $displayData['html'] ?? true;
 switch ($icon)
 {
 	// Check for Brand family
-	case (stristr($icon, "joomla") !== false):
-		str_ireplace("joomla", "fab fa-joomla", $icon);
+	case (stristr($icon, 'joomla') !== false):
+		str_ireplace('joomla', 'fab fa-joomla', $icon);
 		break;
 
 	case (strpos($icon, 'fa ') !== false):

--- a/layouts/joomla/icon/iconclass.php
+++ b/layouts/joomla/icon/iconclass.php
@@ -15,11 +15,20 @@ $html = $displayData['html'] ?? true;
 
 switch ($icon)
 {
-	case (strpos($icon, 'fa-') !== false):
-		$icon = 'fas ' . str_ireplace('fas ', '', $icon);
+	// Check for Brand family
+	case (stristr($icon, "joomla") !== false):
+		str_ireplace("joomla", "fab fa-joomla", $icon);
 		break;
 
+	case (strpos($icon, 'fa ') !== false):
+	case (strpos($icon, 'fas ') !== false):
+	case (strpos($icon, 'fab ') !== false):
 	case (strpos($icon, 'icon-') !== false):
+		break;
+
+	// If its missing the fa prefix add it since its incomplete
+	case (strpos($icon, 'fa-') !== false):
+		$icon = 'fas ' . str_ireplace('fas ', '', $icon);
 		break;
 
 	case 'archive':

--- a/layouts/joomla/toolbar/title.php
+++ b/layouts/joomla/toolbar/title.php
@@ -8,6 +8,7 @@
  */
 
 defined('_JEXEC') or die;
+use Joomla\CMS\Layout\LayoutHelper;
 
 $icon = empty($displayData['icon']) ? 'dot-circle' : preg_replace('#\.[^ .]*$#', '', $displayData['icon']);
 

--- a/layouts/joomla/toolbar/title.php
+++ b/layouts/joomla/toolbar/title.php
@@ -11,12 +11,8 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Layout\LayoutHelper;
 
+// Strip extension if given
 $icon = empty($displayData['icon']) ? 'dot-circle' : preg_replace('#\.[^ .]*$#', '', $displayData['icon']);
-
-if ($icon === 'generic')
-{
-	$icon = 'dot-circle';
-}
 
 ?>
 <h1 class="page-title">

--- a/layouts/joomla/toolbar/title.php
+++ b/layouts/joomla/toolbar/title.php
@@ -8,6 +8,7 @@
  */
 
 defined('_JEXEC') or die;
+
 use Joomla\CMS\Layout\LayoutHelper;
 
 $icon = empty($displayData['icon']) ? 'dot-circle' : preg_replace('#\.[^ .]*$#', '', $displayData['icon']);

--- a/layouts/joomla/toolbar/title.php
+++ b/layouts/joomla/toolbar/title.php
@@ -16,9 +16,8 @@ if ($icon === 'generic')
 	$icon = 'dot-circle';
 }
 
-$icon = stristr($icon, "joomla") ? str_ireplace("joomla", "fab fa-joomla", $icon) : "fas fa-" . $icon;
 ?>
 <h1 class="page-title">
-	<span class="<?php echo $icon; ?>" aria-hidden="true"></span>
+	<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => $icon]); ?>
 	<?php echo $displayData['title']; ?>
 </h1>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Changes toolbar::title to use layout.  This solves the issue of some 3rd party icons not rendering properly in title area.
bit of code cleanup.

### Testing Instructions
install akeeba &/or JCE 
check that icons display properly.
apply pr ( download prebuilt or run npm build:css )
verify icons still display properly.

### Actual result BEFORE applying this Pull Request

### Expected result AFTER applying this Pull Request
![image](https://user-images.githubusercontent.com/1850089/93583091-00e34c80-f969-11ea-8bf8-53ed85e07c83.png)
![image](https://user-images.githubusercontent.com/1850089/93583231-2d976400-f969-11ea-9cd8-4fd2665aa8d4.png)


### Documentation Changes Required

