### PR TITLE
Add missing space between attributes

### DIFF
--- a/administrator/components/com_media/resources/scripts/components/toolbar/toolbar.vue
+++ b/administrator/components/com_media/resources/scripts/components/toolbar/toolbar.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="media-toolbar"role="toolbar" :aria-label="translate('COM_MEDIA_TOOLBAR_LABEL')">
+    <div class="media-toolbar" role="toolbar" :aria-label="translate('COM_MEDIA_TOOLBAR_LABEL')">
         <div class="media-loader" v-if="isLoading"></div>
         <div class="media-view-icons">
             <a href="#" class="media-toolbar-icon media-toolbar-select-all"


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This PR adds a missing space between two attributes in vue component
There should be a space character between attributes

### Testing Instructions

apply PR and see that a space is added. 
can't make it better

### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Documentation Changes Required

