### PR TITLE
[4.0] [Atum] Fix admin menu remaining hidden when enlarging screen width from small mobile to larger

### DIFF
--- a/build/media_source/templates/atum/js/template.es6.js
+++ b/build/media_source/templates/atum/js/template.es6.js
@@ -192,6 +192,7 @@
     const sidebarNav = doc.querySelector('.sidebar-nav');
     const subhead = doc.querySelector('.subhead');
     const wrapper = doc.querySelector('.wrapper');
+    const sidebarWrapper = doc.querySelector('.sidebar-wrapper');
 
     changeLogo('closed');
 
@@ -212,9 +213,11 @@
     if (small.matches) {
       if (sidebarNav) sidebarNav.classList.add('collapse');
       if (subhead) subhead.classList.add('collapse');
+      if (sidebarWrapper) sidebarWrapper.classList.add('collapse');
     } else {
       if (sidebarNav) sidebarNav.classList.remove('collapse');
       if (subhead) subhead.classList.remove('collapse');
+      if (sidebarWrapper) sidebarWrapper.classList.remove('collapse');
     }
   }
 
@@ -231,6 +234,7 @@
       changeLogo('closed');
     } else {
       changeLogo();
+      sidebarWrapper.classList.remove('collapse');
     }
 
     if (sidebarNav) sidebarNav.classList.remove('collapse');


### PR DESCRIPTION
Pull Request for Issue #30683 .

### Summary of Changes

Add and remove CSS class "collapse" also for the sidebar wrapper when resizing the screen, in the same way as it is already done for the sidebar nav.

### Testing Instructions

It needs current 4.0-dev for testing because last nightly build or Beta 4 don't include PR #30131 yet.

1. In backend on a desktop screen, reduce browser window width until the admin menu on the left hand side disappears and the burger button is shown at the bottom right corner.
2. Click on the burger button.
Result: The admin menu which is now at the bottom of the screen is expanded => ok.
3. Click again on the burger button.
Result: The admin menu at the bottom of the screen is collapsed => ok.
4. Enlarge browser window width until the burger button disappears.
Result: See section "Actual result BEFORE applying this Pull Request" below.
5. Apply the patch of this PR.
6. Run `npm run build:js` or `npm ci`.
7. Clear browser cache or at least forced reload the backend page to get rid of cached old js.
8. Reppeat steps 1 to 4.
Result: See section "Expected result AFTER applying this Pull Request" below.

The issue happened to me also sometimes when skipping steps 2 and 3, but only when the particular page was shown for the very first time in that session, and even then not in all cases, so it was hard to reproduce. With steps 2 and 3 I could reproduce it reliably.

### Actual result BEFORE applying this Pull Request

The admin menu remains invisible.

After a page reload the admin menu appears with collapsed status on the left hand side.

### Expected result AFTER applying this Pull Request

The admin menu appears again at the left hand side.

### Documentation Changes Required

None.

### Additional information

I have no idea if this fix is the right fix. But it works. Hoping for feedback of experts.