### PR TITLE
[4.0] Fix media URLs when SEF suffix is enabled

### DIFF
--- a/administrator/components/com_media/tmpl/file/default.php
+++ b/administrator/components/com_media/tmpl/file/default.php
@@ -13,7 +13,6 @@ use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Layout\LayoutHelper;
-use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Uri\Uri;
@@ -40,10 +39,10 @@ if ($tmpl == 'component')
 
 // Populate the media config
 $config = [
-	'apiBaseUrl'              => Route::_('index.php?option=com_media&format=json', false, Route::TLS_IGNORE, true),
+	'apiBaseUrl'              => Uri::base() . 'index.php?option=com_media&format=json',
 	'csrfToken'               => Session::getFormToken(),
 	'uploadPath'              => $this->file->path,
-	'editViewUrl'             => Route::_('index.php?option=com_media&view=file' . ($tmpl ? '&tmpl=' . $tmpl : ''), false, Route::TLS_IGNORE, true),
+	'editViewUrl'             => Uri::base() . 'index.php?option=com_media&view=file' . ($tmpl ? '&tmpl=' . $tmpl : ''),
 	'allowedUploadExtensions' => $params->get('upload_extensions', ''),
 	'maxUploadSizeMb'         => $params->get('upload_maxsize', 10),
 	'contents'                => $this->file->content,

--- a/administrator/components/com_media/tmpl/media/default.php
+++ b/administrator/components/com_media/tmpl/media/default.php
@@ -10,7 +10,6 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
-use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Uri\Uri;
@@ -38,12 +37,12 @@ if ($tmpl === 'component')
 
 // Populate the media config
 $config = array(
-	'apiBaseUrl'              => Route::_('index.php?option=com_media&format=json', false, Route::TLS_IGNORE, true),
+	'apiBaseUrl'              => Uri::base() . 'index.php?option=com_media&format=json',
 	'csrfToken'               => Session::getFormToken(),
 	'filePath'                => $params->get('file_path', 'images'),
 	'fileBaseUrl'             => Uri::root() . $params->get('file_path', 'images'),
 	'fileBaseRelativeUrl'     => $params->get('file_path', 'images'),
-	'editViewUrl'             => Route::_('index.php?option=com_media&view=file' . ($tmpl ? '&tmpl=' . $tmpl : ''), false, Route::TLS_IGNORE, true),
+	'editViewUrl'             => Uri::base() . 'index.php?option=com_media&view=file' . ($tmpl ? '&tmpl=' . $tmpl : ''),
 	'allowedUploadExtensions' => $params->get('upload_extensions', ''),
 	'maxUploadSizeMb'         => $params->get('upload_maxsize', 10),
 	'providers'               => (array) $this->providers,


### PR DESCRIPTION
Fixes https://github.com/joomla/joomla-cms/issues/30665.

### Summary of Changes

Use non-SEF URLs for media paths.

### Testing Instructions

Enable `Add Suffix to URL` option in Global Configuration.
Edit an article in frontend.
Click `CMS Content` -> `Image` button.

### Actual result BEFORE applying this Pull Request

Images shown in modal.

### Expected result AFTER applying this Pull Request

Images not shown in modal.

### Documentation Changes Required

No.