### PR TITLE
[4.0] Cassiopea: fix category x layout

### DIFF
--- a/templates/cassiopeia/scss/vendor/choicesjs/choices.scss
+++ b/templates/cassiopeia/scss/vendor/choicesjs/choices.scss
@@ -53,9 +53,16 @@
     height: 20px;
     padding: 0;
     margin-top: -10px;
-    margin-right: 25px;
+    margin-right: 45px;
     border-radius: 10em;
     opacity: .5;
+
+    [dir=rtl] & {
+      right: auto;
+      left: 0;
+      margin-right: 0;
+      margin-left: 45px;
+    }
 
     &:hover,
     &:focus {
@@ -64,15 +71,6 @@
 
     &:focus {
       box-shadow: 0 0 0 2px #00bcd4;
-    }
-  }
-
-  &[dir="rtl"] {
-    .choices__button_joomla {
-      right: auto;
-      left: 0;
-      margin-right: 0;
-      margin-left: 25px;
     }
   }
 


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/30703

### Summary of Changes
As title says + also correcting rtl where the X was not displayed at all.


### Testing Instructions
Edit an article in frontend in LTR and RTL

Patch needs npm.

### Actual result BEFORE applying this Pull Request
<img width="848" alt="Screenshot 2020-09-20 at 15 41 18" src="https://user-images.githubusercontent.com/400092/93714038-becc2d80-fb57-11ea-91fe-929657eca794.png">


### Expected result AFTER applying this Pull Request

<img width="842" alt="Screen Shot 2020-09-21 at 09 33 28" src="https://user-images.githubusercontent.com/869724/93742537-917e8e80-fbee-11ea-8d5d-5937028ba1e6.png">
<img width="834" alt="Screen Shot 2020-09-21 at 09 27 56" src="https://user-images.githubusercontent.com/869724/93742539-92afbb80-fbee-11ea-81bf-07326b8783ff.png">



