### PR TITLE
[3.9] Log the from version on actionlogs when Joomla update

### DIFF
--- a/administrator/components/com_joomlaupdate/controllers/update.php
+++ b/administrator/components/com_joomlaupdate/controllers/update.php
@@ -102,6 +102,7 @@ class JoomlaupdateControllerUpdate extends JControllerLegacy
 	public function install()
 	{
 		$this->checkToken('get');
+		JFactory::getApplication()->setUserState('com_joomlaupdate.oldversion', JVERSION);
 
 		$options['format'] = '{DATE}\t{TIME}\t{LEVEL}\t{CODE}\t{MESSAGE}';
 		$options['text_file'] = 'joomla_update.php';

--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -922,6 +922,7 @@ ENDDATA;
 
 		// Unset the update filename from the session.
 		JFactory::getApplication()->setUserState('com_joomlaupdate.file', null);
+		$oldVersion = JFactory::getApplication()->getUserState('com_joomlaupdate.oldversion');
 
 		// Trigger event after joomla update.
 		JFactory::getApplication()->triggerEvent('onJoomlaAfterUpdate', array($oldVersion));
@@ -1010,7 +1011,6 @@ ENDDATA;
 		}
 
 		JFactory::getApplication()->setUserState('com_joomlaupdate.temp_file', $tmp_dest);
-		JFactory::getApplication()->setUserState('com_joomlaupdate.oldversion', JVERSION);
 	}
 
 	/**

--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -924,6 +924,7 @@ ENDDATA;
 		JFactory::getApplication()->setUserState('com_joomlaupdate.file', null);
 
 		$oldVersion = JFactory::getApplication()->getUserState('com_joomlaupdate.oldversion');
+
 		// Trigger event after joomla update.
 		JFactory::getApplication()->triggerEvent('onJoomlaAfterUpdate', array($oldVersion));
 		JFactory::getApplication()->setUserState('com_joomlaupdate.oldversion', null);

--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -923,8 +923,6 @@ ENDDATA;
 		// Unset the update filename from the session.
 		JFactory::getApplication()->setUserState('com_joomlaupdate.file', null);
 
-		$oldVersion = JFactory::getApplication()->getUserState('com_joomlaupdate.oldversion');
-
 		// Trigger event after joomla update.
 		JFactory::getApplication()->triggerEvent('onJoomlaAfterUpdate', array($oldVersion));
 		JFactory::getApplication()->setUserState('com_joomlaupdate.oldversion', null);

--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -18,10 +18,7 @@ jimport('joomla.filesystem.file');
  * @since  2.5.4
  */
 class JoomlaupdateModelDefault extends JModelLegacy
-{
-	
-	public $oldVersion = null;
-
+{	
 	/**
 	 * Detects if the Joomla! update site currently in use matches the one
 	 * configured in this component. If they don't match, it changes it.
@@ -160,7 +157,6 @@ class JoomlaupdateModelDefault extends JModelLegacy
 			'object'    => null,
 			'hasUpdate' => false,
 		);
-		$this->oldVersion = JVERSION;
 
 		// Fetch the update information from the database.
 		$db = $this->getDbo();
@@ -927,8 +923,10 @@ ENDDATA;
 		// Unset the update filename from the session.
 		JFactory::getApplication()->setUserState('com_joomlaupdate.file', null);
 
+		$oldVersion = JFactory::getApplication()->getUserState('com_joomlaupdate.oldversion', JVERSION);
 		// Trigger event after joomla update.
-		JFactory::getApplication()->triggerEvent('onJoomlaAfterUpdate', array($this->oldVersion));
+		JFactory::getApplication()->triggerEvent('onJoomlaAfterUpdate', array($oldVersion));
+		JFactory::getApplication()->setUserState('com_joomlaupdate.oldversion', null);
 	}
 
 	/**
@@ -1013,6 +1011,7 @@ ENDDATA;
 		}
 
 		JFactory::getApplication()->setUserState('com_joomlaupdate.temp_file', $tmp_dest);
+		JFactory::getApplication()->setUserState('com_joomlaupdate.oldversion', JVERSION);
 	}
 
 	/**

--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -19,6 +19,9 @@ jimport('joomla.filesystem.file');
  */
 class JoomlaupdateModelDefault extends JModelLegacy
 {
+	
+	public $oldVersion = null;
+
 	/**
 	 * Detects if the Joomla! update site currently in use matches the one
 	 * configured in this component. If they don't match, it changes it.
@@ -157,6 +160,7 @@ class JoomlaupdateModelDefault extends JModelLegacy
 			'object'    => null,
 			'hasUpdate' => false,
 		);
+		$this->oldVersion = JVERSION;
 
 		// Fetch the update information from the database.
 		$db = $this->getDbo();
@@ -924,7 +928,7 @@ ENDDATA;
 		JFactory::getApplication()->setUserState('com_joomlaupdate.file', null);
 
 		// Trigger event after joomla update.
-		JFactory::getApplication()->triggerEvent('onJoomlaAfterUpdate');
+		JFactory::getApplication()->triggerEvent('onJoomlaAfterUpdate', array($this->oldVersion));
 	}
 
 	/**

--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -18,7 +18,7 @@ jimport('joomla.filesystem.file');
  * @since  2.5.4
  */
 class JoomlaupdateModelDefault extends JModelLegacy
-{	
+{
 	/**
 	 * Detects if the Joomla! update site currently in use matches the one
 	 * configured in this component. If they don't match, it changes it.

--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -923,7 +923,7 @@ ENDDATA;
 		// Unset the update filename from the session.
 		JFactory::getApplication()->setUserState('com_joomlaupdate.file', null);
 
-		$oldVersion = JFactory::getApplication()->getUserState('com_joomlaupdate.oldversion', JVERSION);
+		$oldVersion = JFactory::getApplication()->getUserState('com_joomlaupdate.oldversion');
 		// Trigger event after joomla update.
 		JFactory::getApplication()->triggerEvent('onJoomlaAfterUpdate', array($oldVersion));
 		JFactory::getApplication()->setUserState('com_joomlaupdate.oldversion', null);

--- a/administrator/language/en-GB/en-GB.plg_actionlog_joomla.ini
+++ b/administrator/language/en-GB/en-GB.plg_actionlog_joomla.ini
@@ -46,7 +46,7 @@ PLG_ACTIONLOG_JOOMLA_USER_REGISTERED="User <a href='{accountlink}'>{username}</a
 PLG_ACTIONLOG_JOOMLA_USER_REMIND="User <a href='{accountlink}'>{username}</a> requested a username reminder for their account"
 PLG_ACTIONLOG_JOOMLA_USER_RESET_COMPLETE="User <a href='{accountlink}'>{username}</a> completed the password reset for their account"
 PLG_ACTIONLOG_JOOMLA_USER_RESET_REQUEST="User <a href='{accountlink}'>{username}</a> requested a password reset for their account"
-PLG_ACTIONLOG_JOOMLA_USER_UPDATE="User <a href='{accountlink}'>{username}</a> updated Joomla to {version}"
+PLG_ACTIONLOG_JOOMLA_USER_UPDATE="User <a href='{accountlink}'>{username}</a> updated Joomla from {oldversion} to {version}"
 ; Component
 PLG_ACTIONLOG_JOOMLA_APPLICATION_CONFIG_UPDATED="User <a href='{accountlink}'>{username}</a> changed settings of the application configuration"
 PLG_ACTIONLOG_JOOMLA_COMPONENT_CONFIG_UPDATED="User <a href='{accountlink}'>{username}</a> changed settings of the component {extension_name}"

--- a/plugins/actionlog/joomla/joomla.php
+++ b/plugins/actionlog/joomla/joomla.php
@@ -1055,10 +1055,16 @@ class PlgActionlogJoomla extends ActionLogPlugin
 	 *
 	 * @since   3.9.21
 	 */
-	public function onJoomlaAfterUpdate($oldVersion)
+	public function onJoomlaAfterUpdate($oldVersion = 'unknown')
 	{
 		$context = $this->app->input->get('option');
 		$user    = JFactory::getUser();
+		
+		if ($oldVersion === 'unknown')
+		{			
+			$oldVersion = JText::_('JLIB_UNKNOWN');	
+		}
+
 		$message = array(
 			'action'      => 'joomlaupdate',
 			'type'        => 'PLG_ACTIONLOG_JOOMLA_TYPE_USER',

--- a/plugins/actionlog/joomla/joomla.php
+++ b/plugins/actionlog/joomla/joomla.php
@@ -1053,7 +1053,7 @@ class PlgActionlogJoomla extends ActionLogPlugin
 	 *
 	 * @since   3.9.21
 	 */
-	public function onJoomlaAfterUpdate()
+	public function onJoomlaAfterUpdate($oldVersion)
 	{
 		$context = $this->app->input->get('option');
 		$user    = JFactory::getUser();
@@ -1067,6 +1067,7 @@ class PlgActionlogJoomla extends ActionLogPlugin
 			'username'    => $user->username,
 			'accountlink' => 'index.php?option=com_users&task=user.edit&id=' . $user->id,
 			'version'     => JVERSION,
+			'oldversion'  => $oldVersion,
 		);
 		$this->addLog(array($message), 'PLG_ACTIONLOG_JOOMLA_USER_UPDATE', $context, $user->id);
 	}

--- a/plugins/actionlog/joomla/joomla.php
+++ b/plugins/actionlog/joomla/joomla.php
@@ -1055,12 +1055,12 @@ class PlgActionlogJoomla extends ActionLogPlugin
 	 *
 	 * @since   3.9.21
 	 */
-	public function onJoomlaAfterUpdate($oldVersion = 'unknown')
+	public function onJoomlaAfterUpdate($oldVersion = null)
 	{
 		$context = $this->app->input->get('option');
 		$user    = JFactory::getUser();
 		
-		if ($oldVersion === 'unknown')
+		if empty($oldVersion)
 		{			
 			$oldVersion = JText::_('JLIB_UNKNOWN');	
 		}

--- a/plugins/actionlog/joomla/joomla.php
+++ b/plugins/actionlog/joomla/joomla.php
@@ -1050,6 +1050,9 @@ class PlgActionlogJoomla extends ActionLogPlugin
 	 * Method is called after user update the CMS.
 	 *
 	 * @return  void
+	 * @param   string  $oldVersion  The Joomla version before the update
+	 *
+	 * @return  void
 	 *
 	 * @since   3.9.21
 	 */

--- a/plugins/actionlog/joomla/joomla.php
+++ b/plugins/actionlog/joomla/joomla.php
@@ -1049,7 +1049,6 @@ class PlgActionlogJoomla extends ActionLogPlugin
 	 *
 	 * Method is called after user update the CMS.
 	 *
-	 * @return  void
 	 * @param   string  $oldVersion  The Joomla version before the update
 	 *
 	 * @return  void

--- a/plugins/actionlog/joomla/joomla.php
+++ b/plugins/actionlog/joomla/joomla.php
@@ -1060,7 +1060,7 @@ class PlgActionlogJoomla extends ActionLogPlugin
 		$context = $this->app->input->get('option');
 		$user    = JFactory::getUser();
 		
-		if empty($oldVersion)
+		if (empty($oldVersion))
 		{			
 			$oldVersion = JText::_('JLIB_UNKNOWN');	
 		}


### PR DESCRIPTION
Pull Request for Issue #30499 .

### Summary of Changes
Log the from version on  Joomla update event on the Actionlogs


### Testing Instructions
apply pr
joomlaupdate -> options
change to Custom URL
and put this manifest https://ci.joomla.org/artifacts/joomla/joomla-cms/staging/30714/downloads/35635/pr_list.xml
is the one available on bottom  near Download — Prebuilt packages are available for download.

### Actual result BEFORE applying this Pull Request
information about from version not available


### Expected result AFTER applying this Pull Request
information about from version  available
![image](https://user-images.githubusercontent.com/181681/93774093-27331180-fc21-11ea-8376-9ea22c1e4d78.png)




### Documentation Changes Required

