### PR TITLE
[3.9][plg_actionlogs] self activate account

### DIFF
--- a/administrator/language/en-GB/en-GB.plg_actionlog_joomla.ini
+++ b/administrator/language/en-GB/en-GB.plg_actionlog_joomla.ini
@@ -42,6 +42,7 @@ PLG_ACTIONLOG_JOOMLA_USER_LOGEXPORT="User <a href='{accountlink}'>{username}</a>
 PLG_ACTIONLOG_JOOMLA_USER_LOGGED_IN="User <a href='{accountlink}'>{username}</a> logged in to {app}"
 PLG_ACTIONLOG_JOOMLA_USER_LOGGED_OUT="User <a href='{accountlink}'>{username}</a> logged out from {app}"
 PLG_ACTIONLOG_JOOMLA_USER_LOGIN_FAILED="User <a href='{accountlink}'>{username}</a> tried to login to {app}"
+PLG_ACTIONLOG_JOOMLA_USER_REGISTRATION_ACTIVATE ="User <a href='{accountlink}'>{username}</a> activated the account"
 PLG_ACTIONLOG_JOOMLA_USER_REGISTERED="User <a href='{accountlink}'>{username}</a> registered for an account"
 PLG_ACTIONLOG_JOOMLA_USER_REMIND="User <a href='{accountlink}'>{username}</a> requested a username reminder for their account"
 PLG_ACTIONLOG_JOOMLA_USER_RESET_COMPLETE="User <a href='{accountlink}'>{username}</a> completed the password reset for their account"

--- a/plugins/actionlog/joomla/joomla.php
+++ b/plugins/actionlog/joomla/joomla.php
@@ -616,6 +616,13 @@ class PlgActionlogJoomla extends ActionLogPlugin
 				$messageLanguageKey = 'PLG_ACTIONLOG_JOOMLA_USER_RESET_COMPLETE';
 				$action             = 'resetcomplete';
 			}
+
+			// Registration Activation
+			if ($task === 'registration.activate')
+			{
+				$messageLanguageKey = 'PLG_ACTIONLOG_JOOMLA_USER_REGISTRATION_ACTIVATE';
+				$action             = 'activaterequest';
+			}
 		}
 		elseif ($isnew)
 		{


### PR DESCRIPTION
Pull Request for Issue #29114 .

### Summary of Changes
Different message when user self activate account


### Testing Instructions
Turn on the registration on the site and the Self value for parameter New User Account Activation.
Register on the site with a real email address. Follow all instructions to activate your account.
Go to the User Actions Log section and pay attention to the lines.


### Actual result BEFORE applying this Pull Request
2 identical messages

![image](https://user-images.githubusercontent.com/181681/93849993-80e11d80-fcad-11ea-987f-a02342fb8547.png)

### Expected result AFTER applying this Pull Request
![image](https://user-images.githubusercontent.com/181681/93850026-91919380-fcad-11ea-96bb-63050a850ee1.png)



