### PR TITLE
[4.0] Fix saving images

### DIFF
--- a/build/media_source/com_media/js/edit-images.es6.js
+++ b/build/media_source/com_media/js/edit-images.es6.js
@@ -157,7 +157,7 @@ Joomla.MediaManager = Joomla.MediaManager || {};
         Joomla.MediaManager.Edit.Reset(true);
         break;
       case 'save':
-        Joomla.UploadFile.exec(name, JSON.stringify(forUpload), uploadPath, url, type, function() {
+        Joomla.UploadFile.exec(name, JSON.stringify(forUpload), uploadPath, url, type, function () {
           if (this.readyState === XMLHttpRequest.DONE) {
             if (window.self !== window.top) {
               window.location = `${pathName}?option=com_media&view=media&path=${fileDirectory}&tmpl=component`;
@@ -204,7 +204,7 @@ Joomla.MediaManager = Joomla.MediaManager || {};
       Joomla.MediaManager.Edit.updateProgressBar((e.loaded / e.total) * 100);
     };
 
-    if (typeof(stateChangeCallback) === 'function') {
+    if (typeof stateChangeCallback === 'function') {
       xhr.onreadystatechange = stateChangeCallback;
     }
 

--- a/build/media_source/com_media/js/edit-images.es6.js
+++ b/build/media_source/com_media/js/edit-images.es6.js
@@ -157,8 +157,15 @@ Joomla.MediaManager = Joomla.MediaManager || {};
         Joomla.MediaManager.Edit.Reset(true);
         break;
       case 'save':
-        Joomla.UploadFile.exec(name, JSON.stringify(forUpload), uploadPath, url, type);
-        window.location = `${pathName}?option=com_media&view=media&path=${fileDirectory}`;
+        Joomla.UploadFile.exec(name, JSON.stringify(forUpload), uploadPath, url, type, function() {
+          if (this.readyState !== XMLHttpRequest.DONE) {
+            if (window.self !== window.top) {
+              window.location = `${pathName}?option=com_media&view=media&path=${fileDirectory}&tmpl=component`;
+            } else {
+              window.location = `${pathName}?option=com_media&view=media&path=${fileDirectory}`;
+            }
+          }
+        });
         break;
       case 'cancel':
         if (window.self !== window.top) {
@@ -190,12 +197,16 @@ Joomla.MediaManager = Joomla.MediaManager || {};
   /**
    * @TODO Extend Joomla.request and drop this code!!!!
    */
-  Joomla.UploadFile.exec = (name, data, uploadPath, url, type) => {
+  Joomla.UploadFile.exec = (name, data, uploadPath, url, type, stateChangeCallback) => {
     const xhr = new XMLHttpRequest();
 
     xhr.upload.onprogress = (e) => {
       Joomla.MediaManager.Edit.updateProgressBar((e.loaded / e.total) * 100);
     };
+
+    if (typeof(stateChangeCallback) === 'function') {
+      xhr.onreadystatechange = stateChangeCallback;
+    }
 
     xhr.onload = () => {
       let resp;

--- a/build/media_source/com_media/js/edit-images.es6.js
+++ b/build/media_source/com_media/js/edit-images.es6.js
@@ -158,7 +158,7 @@ Joomla.MediaManager = Joomla.MediaManager || {};
         break;
       case 'save':
         Joomla.UploadFile.exec(name, JSON.stringify(forUpload), uploadPath, url, type, function() {
-          if (this.readyState !== XMLHttpRequest.DONE) {
+          if (this.readyState === XMLHttpRequest.DONE) {
             if (window.self !== window.top) {
               window.location = `${pathName}?option=com_media&view=media&path=${fileDirectory}&tmpl=component`;
             } else {


### PR DESCRIPTION
Fixes https://github.com/joomla/joomla-cms/issues/30664 and https://github.com/joomla/joomla-cms/issues/28842.

### Summary of Changes

Fixes saving images after editing in media manager.

### Testing Instructions

`node build.js --compile-js` required.

Edit an article.
In editor click `CMS Content` -> `Image`.
Edit an image in the modal.
Click `Save & Close`.

### Actual result BEFORE applying this Pull Request

Modified image is not saved and modules appear in the modal after redirect.

### Expected result AFTER applying this Pull Request

Modified images is saved and your are redireceted back to media list without modules showing.

### Documentation Changes Required

No.