### PR TITLE
[4.0] Move route calls to layout in Breadcrumbs module

### DIFF
--- a/modules/mod_breadcrumbs/src/Helper/BreadcrumbsHelper.php
+++ b/modules/mod_breadcrumbs/src/Helper/BreadcrumbsHelper.php
@@ -16,7 +16,6 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\Language\Text;
-use Joomla\CMS\Router\Route;
 use Joomla\Registry\Registry;
 
 /**
@@ -57,18 +56,18 @@ class BreadcrumbsHelper
 		// Don't use $items here as it references JPathway properties directly
 		$crumbs = array();
 
-		for ($i = 0; $i < $count; $i ++)
+		for ($i = 0; $i < $count; $i++)
 		{
 			$crumbs[$i]       = new \stdClass;
 			$crumbs[$i]->name = stripslashes(htmlspecialchars($items[$i]->name, ENT_COMPAT, 'UTF-8'));
-			$crumbs[$i]->link = Route::_($items[$i]->link);
+			$crumbs[$i]->link = $items[$i]->link;
 		}
 
 		if ($params->get('showHome', 1))
 		{
 			$item       = new \stdClass;
 			$item->name = htmlspecialchars($params->get('homeText', Text::_('MOD_BREADCRUMBS_HOME')), ENT_COMPAT, 'UTF-8');
-			$item->link = Route::_('index.php?Itemid=' . $home->id);
+			$item->link = 'index.php?Itemid=' . $home->id;
 			array_unshift($crumbs, $item);
 		}
 

--- a/modules/mod_breadcrumbs/tmpl/default.php
+++ b/modules/mod_breadcrumbs/tmpl/default.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Router\Route;
 
 ?>
 <nav role="navigation" aria-label="<?php echo $module->title; ?>">
@@ -47,7 +48,7 @@ use Joomla\CMS\Language\Text;
 		foreach ($list as $key => $item) :
 			if ($key !== $last_item_key) :
 				if (!empty($item->link)) :
-					$breadcrumbItem = '<a itemprop="item" href="' . $item->link . '" class="pathway"><span itemprop="name">' . $item->name . '</span></a>';
+					$breadcrumbItem = '<a itemprop="item" href="' . Route::_($item->link) . '" class="pathway"><span itemprop="name">' . $item->name . '</span></a>';
 				else :
 					$breadcrumbItem = '<span itemprop="name">' . $item->name . '</span>';
 				endif;


### PR DESCRIPTION
### Summary of Changes

This just moves route calls to the layout to allow manipulating the link in overrides.

### Testing Instructions

Inspect links generated by Breadcrumbs module.

### Expected result AFTER applying this Pull Request

Works like before.

### Documentation Changes Required

No.