### PR TITLE
[4.0] Remove obsolete html code

### DIFF
--- a/components/com_config/tmpl/config/default.php
+++ b/components/com_config/tmpl/config/default.php
@@ -34,19 +34,9 @@ $wa->useScript('keepalive')
 
 	<hr>
 
-	<div id="page-site" class="tab-pane active">
-		<div class="row">
-			<div class="col-md-12">
-				<?php echo $this->loadTemplate('site'); ?>
-			</div>
-			<div class="col-md-12">
-				<?php echo $this->loadTemplate('seo'); ?>
-			</div>
-			<div class="col-md-12">
-				<?php echo $this->loadTemplate('metadata'); ?>
-			</div>
-		</div>
-	</div>
+	<?php echo $this->loadTemplate('site'); ?>
+	<?php echo $this->loadTemplate('seo'); ?>
+	<?php echo $this->loadTemplate('metadata'); ?>
 
 	<input type="hidden" name="task" value="">
 	<?php echo HTMLHelper::_('form.token'); ?>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This PR removes obsolete HTML code. I can see no need for the extra HTML provided. 
And... it will benefit the work on the styling of improved Cassiopeia

### Testing Instructions

- Joomla 4 install
- Login in and go to /index.php/component/config?view=config
- Apply the path (no `npm` required)
- Refresh the page and even without the wrapping divs, the result is the same. 

And the result needs some improvement. Spacing between fieldsets. Cassiopeia Team is working on it. 

### Actual result BEFORE applying this Pull Request

![joomla4 test_index php_component_config_view=config](https://user-images.githubusercontent.com/639822/93980194-9b36fc00-fd7e-11ea-9db1-ba33def81a75.png)

### Expected result AFTER applying this Pull Request

![joomla4 test_index php_component_config_view=config (1)](https://user-images.githubusercontent.com/639822/93980271-b30e8000-fd7e-11ea-8207-a3f6192a0e94.png)


### Documentation Changes Required

