### PR TITLE
Fix color field attributes onchange and required.

### DIFF
--- a/layouts/joomla/form/field/color/advanced.php
+++ b/layouts/joomla/form/field/color/advanced.php
@@ -7,9 +7,9 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-use Joomla\CMS\Language\Language;
-
 defined('_JEXEC') or die;
+
+use Joomla\CMS\Language\Language;
 
 extract($displayData);
 

--- a/layouts/joomla/form/field/color/advanced.php
+++ b/layouts/joomla/form/field/color/advanced.php
@@ -39,8 +39,8 @@ extract($displayData);
  * @var   boolean   $spellcheck      Spellcheck state for the form field.
  * @var   string    $validate        Validation rules to apply.
  * @var   string    $value           Value attribute of the field.
- * @var   string    $position        Is this field checked? TODO
- * @var   string    $control         Is this field checked? TODO
+ * @var   string    $position        Position of the color picker dropdown. One of 'bottom left', 'bottom right', 'top left', or 'top right'.
+ * @var   string    $control         Type of control element. One of 'hue', 'brightness', 'saturation', or 'wheel'.
  * @var   string    $color           Color representation of the value in the adequate format.
  * @var   string    $format          Format of the color representation.
  * @var   string    $keywords        Keywords for the color selector control element.

--- a/layouts/joomla/form/field/color/advanced.php
+++ b/layouts/joomla/form/field/color/advanced.php
@@ -7,6 +7,8 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
+use Joomla\CMS\Language\Language;
+
 defined('_JEXEC') or die;
 
 extract($displayData);
@@ -14,35 +16,35 @@ extract($displayData);
 /**
  * Layout variables
  * -----------------
- * @var   string   $autocomplete    Autocomplete attribute for the field.
- * @var   boolean  $autofocus       Is autofocus enabled?
- * @var   string   $class           Classes for the input.
- * @var   string   $description     Description of the field.
- * @var   boolean  $disabled        Is this field disabled?
- * @var   string   $group           Group the field belongs to. <fields> section in form XML.
- * @var   boolean  $hidden          Is this field hidden in the form?
- * @var   string   $hint            Placeholder for the field.
- * @var   string   $id              DOM id of the field.
- * @var   string   $label           Label of the field.
- * @var   string   $labelclass      Classes to apply to the label.
- * @var   boolean  $multiple        Does this field support multiple values?
- * @var   string   $name            Name of the input field.
- * @var   string   $onchange        Onchange attribute for the field.
- * @var   string   $onclick         Onclick attribute for the field.
- * @var   string   $pattern         Pattern (Reg Ex) of value of the form field.
- * @var   boolean  $readonly        Is this field read only?
- * @var   boolean  $repeat          Allows extensions to duplicate elements.
- * @var   boolean  $required        Is this field required?
- * @var   integer  $size            Size attribute of the input.
- * @var   boolean  $spellchec       Spellcheck state for the form field.
- * @var   string   $validate        Validation rules to apply.
- * @var   string   $value           Value attribute of the field.
- * @var   array    $checkedOptions  Options that will be set as checked.
- * @var   boolean  $hasValue        Has this field a value assigned?
- * @var   array    $options         Options available for this field.
- * @var   array    $checked         Is this field checked?
- * @var   array    $position        Is this field checked?
- * @var   array    $control         Is this field checked?
+ * @var   string    $autocomplete    Autocomplete attribute for the field.
+ * @var   boolean   $autofocus       Is autofocus enabled?
+ * @var   string    $class           Classes for the input.
+ * @var   string    $description     Description of the field.
+ * @var   boolean   $disabled        Is this field disabled?
+ * @var   string    $group           Group the field belongs to. <fields> section in form XML.
+ * @var   boolean   $hidden          Is this field hidden in the form?
+ * @var   string    $hint            Placeholder for the field.
+ * @var   string    $id              DOM id of the field.
+ * @var   string    $label           Label of the field.
+ * @var   string    $labelclass      Classes to apply to the label.
+ * @var   boolean   $multiple        Does this field support multiple values?
+ * @var   string    $name            Name of the input field.
+ * @var   string    $onchange        Onchange attribute for the field.
+ * @var   string    $onclick         Onclick attribute for the field.
+ * @var   string    $pattern         Pattern (Reg Ex) of value of the form field.
+ * @var   boolean   $readonly        Is this field read only?
+ * @var   boolean   $repeat          Allows extensions to duplicate elements.
+ * @var   boolean   $required        Is this field required?
+ * @var   integer   $size            Size attribute of the input.
+ * @var   boolean   $spellcheck      Spellcheck state for the form field.
+ * @var   string    $validate        Validation rules to apply.
+ * @var   string    $value           Value attribute of the field.
+ * @var   string    $position        Is this field checked? TODO
+ * @var   string    $control         Is this field checked? TODO
+ * @var   string    $color           Color representation of the value in the adequate format.
+ * @var   string    $format          Format of the color representation.
+ * @var   string    $keywords        Keywords for the color selector control element.
+ * @var   Language  $lang            Language that is active on the site.
  */
 
 if ($validate !== 'color' && in_array($format, array('rgb', 'rgba'), true))
@@ -65,6 +67,8 @@ $disabled     = $disabled ? ' disabled' : '';
 $readonly     = $readonly ? ' readonly' : '';
 $hint         = strlen($hint) ? ' placeholder="' . $this->escape($hint) . '"' : ' placeholder="' . $placeholder . '"';
 $autocomplete = ! $autocomplete ? ' autocomplete="off"' : '';
+$required     = $required ? ' required aria-required="true"' : '';
+$onchange     = $onchange ? ' onchange="' . $onchange . '"' : '';
 
 // Force LTR input value in RTL, due to display issues with rgba/hex colors
 $direction    = $lang->isRtl() ? ' dir="ltr" style="text-align:right"' : '';
@@ -86,7 +90,6 @@ JHtml::_('script', 'system/color-field-adv-init.min.js', array('version' => 'aut
 		$required,
 		$onchange,
 		$autocomplete,
-		$autofocus,
 		$format,
 		$keywords,
 		$direction,

--- a/layouts/joomla/form/field/color/simple.php
+++ b/layouts/joomla/form/field/color/simple.php
@@ -37,8 +37,7 @@ extract($displayData);
  * @var   boolean  $spellcheck      Spellcheck state for the form field.
  * @var   string   $validate        Validation rules to apply.
  * @var   string   $value           Value attribute of the field.
- * @var   string   $position        Is this field checked? TODO
- * @var   string   $control         Is this field checked? TODO
+ * @var   string   $position        Position of the color picker dropdown. One of 'bottom left', 'bottom right', 'top left', or 'top right'.
  * @var   string   $color           Color representation of the value in the adequate format.
  * @var   string   $format          Format of the color representation.
  * @var   string   $keywords        Keywords for the color selector control element.

--- a/layouts/joomla/form/field/color/simple.php
+++ b/layouts/joomla/form/field/color/simple.php
@@ -7,6 +7,8 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
+use Joomla\CMS\Language\Language;
+
 defined('_JEXEC') or die;
 
 extract($displayData);
@@ -34,20 +36,23 @@ extract($displayData);
  * @var   boolean  $repeat          Allows extensions to duplicate elements.
  * @var   boolean  $required        Is this field required?
  * @var   integer  $size            Size attribute of the input.
- * @var   boolean  $spellchec       Spellcheck state for the form field.
+ * @var   boolean  $spellcheck      Spellcheck state for the form field.
  * @var   string   $validate        Validation rules to apply.
  * @var   string   $value           Value attribute of the field.
- * @var   array    $checkedOptions  Options that will be set as checked.
- * @var   boolean  $hasValue        Has this field a value assigned?
- * @var   array    $options         Options available for this field.
- * @var   array    $checked         Is this field checked?
- * @var   array    $position        Is this field checked?
- * @var   array    $control         Is this field checked?
+ * @var   string   $position        Is this field checked? TODO
+ * @var   string   $control         Is this field checked? TODO
+ * @var   string   $color           Color representation of the value in the adequate format.
+ * @var   string   $format          Format of the color representation.
+ * @var   string   $keywords        Keywords for the color selector control element.
+ * @var   array    $colors          Set of colors to be displayed in the color picker.
+ * @var   integer  $split           Number of columns for arranging the options in the color picker.
  */
 
 $class    = ' class="' . trim('simplecolors chzn-done ' . $class) . '"';
 $disabled = $disabled ? ' disabled' : '';
 $readonly = $readonly ? ' readonly' : '';
+$required = $required ? ' required aria-required="true"' : '';
+$onchange = $onchange ? ' onchange="' . $onchange . '"' : '';
 
 // Include jQuery
 JHtml::_('jquery.framework');
@@ -58,7 +63,7 @@ JHtml::_('script', 'system/color-field-init.min.js', array('version' => 'auto', 
 ?>
 <select data-chosen="true" name="<?php echo $name; ?>" id="<?php echo $id; ?>"<?php
 echo $disabled; ?><?php echo $readonly; ?><?php echo $required; ?><?php echo $class; ?><?php echo $position; ?><?php
-echo $onchange; ?><?php echo $autofocus; ?> style="visibility:hidden;width:22px;height:1px">
+echo $onchange; ?> style="visibility:hidden;width:22px;height:1px">
 	<?php foreach ($colors as $i => $c) : ?>
 		<option<?php echo ($c == $color ? ' selected="selected"' : ''); ?>><?php echo $c; ?></option>
 		<?php if (($i + 1) % $split == 0) : ?>

--- a/layouts/joomla/form/field/color/simple.php
+++ b/layouts/joomla/form/field/color/simple.php
@@ -7,8 +7,6 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-use Joomla\CMS\Language\Language;
-
 defined('_JEXEC') or die;
 
 extract($displayData);


### PR DESCRIPTION

### Summary of Changes
- Fixed the attributes `onchange` and `required` for the color form field.
- Improved the documentation in the layout files.


### Testing Instructions
1. In some kind of form, create or edit a form field of `type="color"`. Add the attributes `required` and/or `onchange`. Test with both color field layouts (`control="simple"` for the simple version).
Alternatively, you can use the demo plugin at https://github.com/Harmageddon/plg_demo_colorfield
2. Open the form. 
3. Test the `required` attribute: Try saving the form without entering a value in the required color field.
4. Test the `onchange` attribute: Select a value for the field that has the `onchange` attribute and see whether the JavaScript handler is called.
5. Check the HTML source of the form for validity.

### Actual result BEFORE applying this Pull Request
The values for the two attributes are printed directly in the source code, leading to invalid HTML like:
```HTML
<input type="text" name="jform[params][color2]" id="jform_params_color2" value="none" placeholder="#rrggbb" class="minicolors hex" data-position="default" data-control="hue"alert('New value: ' + this.value); data-format="hex"/>
```
The onchange handler is not executed.

Required fields don't get the `required` attribute, neither the `aria-required="true"` attribute.

### Expected result AFTER applying this Pull Request
Onchange handlers are executed correctly. Required fields get the `required` attribute.

### Documentation Changes Required
The documentation of the color form field is very rudimentary and doesn't mention most of the available attributes. It should be improved overall.

### Open Issues
- The `required` attribute still has no effect for the simple color picker variant. The reason is that the empty value is not an empty string, but `'none'`, which counts as a value both for server-side and client-side validation. I'm not sure how to fix this.
- ~I also fixed the documentation in the PHP code of the layouts files. For `$control` and `$position`, the original description was copy-pasted, so it should be changed to something more meaningful. However, I'm not sure about a good description here. Maybe @dgrammatiko can help here, as you created these layouts?~