### PR TITLE
[4.0] Fix icons display in debug bar

### DIFF
--- a/build/media_source/plg_system_debug/widgets/sqlqueries/widget.css
+++ b/build/media_source/plg_system_debug/widgets/sqlqueries/widget.css
@@ -49,9 +49,10 @@ div.phpdebugbar-widgets-sqlqueries span.phpdebugbar-widgets-eye:before,
 div.phpdebugbar-widgets-sqlqueries span.phpdebugbar-widgets-eye-dash:before,
 div.phpdebugbar-widgets-sqlqueries span.phpdebugbar-widgets-stmt-id:before,
 div.phpdebugbar-widgets-sqlqueries a.phpdebugbar-widgets-editor-link:before {
-    font-family:"Font Awesome 5 Free";
+    font-family: "Font Awesome 5 Free";
     margin-right: 4px;
     font-size: 12px;
+    font-weight: 900;
 }
 
 div.phpdebugbar-widgets-sqlqueries span.phpdebugbar-widgets-database:before {


### PR DESCRIPTION
Pull Request for Issue #30719  .

### Summary of Changes
Add font weight where the missing icons exist.


### Testing Instructions
Install PR
Run npm i
or 
Download the installer package at the bottom of the page.
Enable Debug System under Global Configuration > System
Click Queries in footer.


### Actual result BEFORE applying this Pull Request
![93778172-7013a780-fbda-11ea-8c8c-b55c349d2075](https://user-images.githubusercontent.com/368084/94053715-8c0c7a00-fd8f-11ea-9acb-54331e8c2da8.png)



