### PR TITLE
[4.0] Remove Cassiopeias "_card.scss" override

### DIFF
--- a/templates/cassiopeia/scss/template.scss
+++ b/templates/cassiopeia/scss/template.scss
@@ -43,7 +43,6 @@
 // Vendor overrides
 @import "vendor/awesomplete";
 @import "vendor/bootstrap/buttons";
-@import "vendor/bootstrap/card";
 @import "vendor/bootstrap/custom-forms";
 @import "vendor/bootstrap/collapse";
 @import "vendor/bootstrap/dropdown";

--- a/templates/cassiopeia/scss/vendor/bootstrap/_card.scss
+++ b/templates/cassiopeia/scss/vendor/bootstrap/_card.scss
@@ -1,9 +1,0 @@
-// Alerts
-
-.card-grey {
-  background-color: #f7f7f9;
-}
-
-.card-inverse {
-  color: rgba(255, 255, 255, .9);
-}


### PR DESCRIPTION
Since PR https://github.com/joomla/joomla-cms/pull/30734 is already RTC this is a followup to remove the Cassiopeia Override for Bootstrap cards.
That file only contains two additional card specific classes: "card-grey" and "card-inverse".

A very similar effect like those two classes can be achieved by using the standard Bootstrap colour classes (see https://getbootstrap.com/docs/4.5/utilities/colors/):
![image](https://user-images.githubusercontent.com/1018684/94120152-161c1780-fe50-11ea-9e7b-cca748cc8c39.png)


### Summary of Changes
Deleting the whole file and the reference in the template.


### Testing Instructions
* Apply PR
*  run "npm run build.css" to regenerate the template CSS file
* Compare module output and other appearance of card layouts (are there any?)
* Add "card-grey" and "card-inverse" to a module class and assign that module to a position with actually uses the card chrome (eg top-b or sidebars).

### Actual result BEFORE applying this Pull Request
The module has a slight darker greyish background with "card-grey" and text becomes white with "card-inverse"


### Expected result AFTER applying this Pull Request
The classes have no effect anymore.


### Documentation Changes Required
None
