### PR TITLE
[staging] Backporting xtd menu items modal frontend filters

### DIFF
--- a/administrator/components/com_menus/views/items/tmpl/modal.php
+++ b/administrator/components/com_menus/views/items/tmpl/modal.php
@@ -47,7 +47,7 @@ if (!empty($editor))
 
 	<form action="<?php echo JRoute::_($link); ?>" method="post" name="adminForm" id="adminForm" class="form-inline">
 
-		<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
+		<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this, 'options' => array('selectorFieldName' => 'menutype'))); ?>
 
 		<?php if (empty($this->items)) : ?>
 			<div class="alert alert-no-items">
@@ -119,7 +119,7 @@ if (!empty($editor))
 								</a>
 							<?php else : ?>
 								<?php echo $this->escape($item->title); ?>
-							<?php endif; ?>	
+							<?php endif; ?>
 							<span class="small">
 								<?php if (empty($item->note)) : ?>
 									<?php echo JText::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->alias)); ?>

--- a/components/com_menus/models/forms/filter_items.xml
+++ b/components/com_menus/models/forms/filter_items.xml
@@ -1,6 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <form>
 	<fieldset addfieldpath="/administrator/components/com_menus/models/fields" />
+		<field
+			name="menutype"
+			type="menu"
+			label="COM_MENUS_SELECT_MENU_FILTER"
+			accesstype="manage"
+			clientid=""
+			showAll="false"
+			filtermode="selector"
+			onchange="this.form.submit();"
+			>
+			<option value="">COM_MENUS_SELECT_MENU</option>
+		</field>
 		<fields name="filter">
 			<field
 				name="search"
@@ -51,6 +63,14 @@
 				onchange="this.form.submit();"
 				>
 				<option value="">JOPTION_SELECT_MAX_LEVELS</option>
+			</field>
+			<field
+				name="parent_id"
+				type="MenuItemByType"
+				label="COM_MENUS_FILTER_PARENT_MENU_ITEM_LABEL"
+				onchange="this.form.submit();"
+				>
+				<option value="">COM_MENUS_FILTER_SELECT_PARENT_MENU_ITEM</option>
 			</field>
 		</fields>
 		<fields name="list">


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/30753

### Summary of Changes
As title says. Backporting https://github.com/joomla/joomla-cms/pull/30087
The modal can now be filtered by Menu and Parent Menu Item


### Testing Instructions
Edit an article in frontend. Insert a menu by clicking on the Menu icon in the editor toolbar.


### Actual result BEFORE applying this Pull Request

<img width="881" alt="Screen Shot 2020-09-24 at 11 00 32" src="https://user-images.githubusercontent.com/869724/94124402-3dc1ae80-fe55-11ea-87d7-6986e987a6d0.png">


### Expected result AFTER applying this Pull Request

<img width="973" alt="Screen Shot 2020-09-24 at 10 42 04" src="https://user-images.githubusercontent.com/869724/94124213-0521d500-fe55-11ea-8931-72658baba973.png">

