### PR TITLE
move opening and closing php of message

### DIFF
--- a/layouts/joomla/system/message.php
+++ b/layouts/joomla/system/message.php
@@ -45,8 +45,8 @@ Factory::getDocument()->getWebAssetManager()
 
 ?>
 <div id="system-message-container" aria-live="polite">
-	<div id="system-message">
-		<?php if (is_array($msgList) && !empty($msgList)) : ?>
+	<div id="system-message"><?php
+		if (is_array($msgList) && !empty($msgList)) : ?>
 			<?php foreach ($msgList as $type => $msgs) : ?>
 				<joomla-alert type="<?php echo $alert[$type] ?? $type; ?>" dismiss="true">
 					<?php if (!empty($msgs)) : ?>
@@ -62,6 +62,6 @@ Factory::getDocument()->getWebAssetManager()
 					<?php endif; ?>
 				</joomla-alert>
 			<?php endforeach; ?>
-		<?php endif; ?>
-	</div>
+		<?php endif;
+	?></div>
 </div>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

When styling the messages and spacing around it I would like to be able to hide the message box when empty. 
```
#system-message:empty {
    display: none;
}
```

Because the opening of PHP starts on a new line there is some obsolete spacing rendered. 
When PR is merged the empty message box will appear together with its spacing

### Testing Instructions

- Joomla 4 install
- Inspect element

### Actual result BEFORE applying this Pull Request

```
<div id="system-message">
			</div>
```

### Expected result AFTER applying this Pull Request

```
<div id="system-message"></div>
```

### Documentation Changes Required

