### PR TITLE
[4.0] Cassiopeia missing string

### DIFF
--- a/language/en-GB/tpl_cassiopeia.ini
+++ b/language/en-GB/tpl_cassiopeia.ini
@@ -3,6 +3,7 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt
 ; Note : All ini files need to be saved as UTF-8
 
+CASSIOPEIA="Cassiopeia Site template"
 TPL_CASSIOPEIA_BACKTOTOP="Back to Top"
 TPL_CASSIOPEIA_BACKTOTOP_LABEL="Back-to-top Link"
 TPL_CASSIOPEIA_FLUID="Fluid"


### PR DESCRIPTION
The string is used in the template style page of the template

### Before
![image](https://user-images.githubusercontent.com/1296369/94258700-25b96000-ff25-11ea-8005-4095105c68c0.png)

### After
![image](https://user-images.githubusercontent.com/1296369/94258592-fa367580-ff24-11ea-82c9-1a3e814b8d93.png)
