### PR TITLE
Fixed frontend module editing permissions.

### DIFF
--- a/components/com_config/controller/modules/display.php
+++ b/components/com_config/controller/modules/display.php
@@ -89,8 +89,7 @@ class ConfigControllerModulesDisplay extends ConfigControllerDisplay
 			// Access check.
 			$user = JFactory::getUser();
 
-			if (!$user->authorise('module.edit.frontend', 'com_modules.module.' . $serviceData['id'])
-				&& !$user->authorise('module.edit.frontend', 'com_modules'))
+			if (!$user->authorise('module.edit.frontend', 'com_modules.module.' . $serviceData['id']))
 			{
 				$app->enqueueMessage(JText::_('JERROR_ALERTNOAUTHOR'), 'error');
 				$app->redirect($redirect);

--- a/components/com_config/controller/modules/save.php
+++ b/components/com_config/controller/modules/save.php
@@ -37,10 +37,9 @@ class ConfigControllerModulesSave extends JControllerBase
 		// Check if the user is authorized to do this.
 		$user = JFactory::getUser();
 
-		if (!$user->authorise('module.edit.frontend', 'com_modules.module.' . $this->input->get('id'))
-			&& !$user->authorise('module.edit.frontend', 'com_modules'))
+		if (!$user->authorise('module.edit.frontend', 'com_modules.module.' . $this->input->get('id')))
 		{
-			$this->app->enqueueMessage(JText::_('JERROR_ALERTNOAUTHOR'));
+			$this->app->enqueueMessage(JText::_('JERROR_ALERTNOAUTHOR'), 'error');
 			$this->app->redirect('index.php');
 		}
 


### PR DESCRIPTION
Version: Joomla! 3.x

In #6113, the permission check for editing a module in frontend was checked from "return error if user is not allowed to edit this module OR if user is not allowed to edit any module" to "return error if user is not allowed to edit this module AND if user is not allowed to edit any module". The intention was to allow users to edit a single module even if they are lacking the general permission to edit modules in frontend. 
However, this introduces a problem for the inverse case: A user that generally may edit frontend modules, but should not be allowed to edit one particular module. For this case, the "OR" construction worked and the "AND" doesn't.

### Summary of Changes
I suggest to get rid of the check of the general permission. If there are no permission rules for the particular module, Joomla's ACL has an automatic fallback to the general permissions for frontend module editing. So I don't see any need to check both rules. Please correct me if I'm mistaken!


### Testing Instructions
For the frontend steps, you need a user who is no "Super Administrator", but in another user group, for example "Administrator". For the backend steps, use your "Super Administrator" account or at least an account who has the permissions to edit permissions.

1. Backend: Navigate to "Extensions - Modules - Options". Under "Permissions", set the "Frontend Editing" permission for the "Administrator" user group to "inherited". This should result to a calculated permission of "Not Allowed (Inherited)".
2. Backend: Edit a module. In the "Permissions" tab, set the "Frontend Editing" permission for "Administrator" to "Allowed". Hit "Save and Close".
3. Frontend: Make sure you can edit this particular module and no other module. While editing the module, save the URL of the edit form for later usage. Change something and hit "Save and Close".
4. Backend: Navigate to "Extensions - Modules - Options". Under "Permissions", set the "Frontend Editing" permission for the "Administrator" user group to "Allowed".
5. Frontend: Make sure you can edit and save all modules on the site.
6. Backend: Edit a module. In the "Permissions" tab, set the "Frontend Editing" permission for "Administrator" to "Denied". Hit "Save and Close".
7. Frontend: Make sure that there is no button to edit this particular module. For all others however, the button is there. Make sure you still can edit all other modules by changing values and saving them.
8. Frontend: Nevertheless, try to access the module edit form using the URL you saved in step 3. Change some values and hit "Save and Close".

### Actual result BEFORE applying this Pull Request
Although you shouldn't be allowed to do this, you can edit the module in step 8.


### Expected result AFTER applying this Pull Request
Step 8 should result in a "You are not allowed to view this resource" error. All other steps should still work like before (e.g. follow the ACL permissions).


### Documentation Changes Required
None
