### PR TITLE
[4.0] Fixed frontend module editing for non-superusers.

### DIFF
--- a/components/com_config/src/Dispatcher/Dispatcher.php
+++ b/components/com_config/src/Dispatcher/Dispatcher.php
@@ -34,7 +34,18 @@ class Dispatcher extends ComponentDispatcher
 	{
 		parent::checkAccess();
 
-		if (!$this->app->getIdentity()->authorise('core.admin'))
+		$task = $this->input->getCmd('task', 'display');
+		$view = $this->input->get('view');
+		$user = $this->app->getIdentity();
+
+		if (substr($task, 0, 8) === 'modules.' || $view === 'modules')
+		{
+			if (!$user->authorise('module.edit.frontend', 'com_modules.module.' . $this->input->get('id')))
+			{
+				throw new NotAllowed($this->app->getLanguage()->_('JERROR_ALERTNOAUTHOR'), 403);
+			}
+		}
+		elseif (!$user->authorise('core.admin'))
 		{
 			throw new NotAllowed($this->app->getLanguage()->_('JERROR_ALERTNOAUTHOR'), 403);
 		}


### PR DESCRIPTION
Pull Request for Issue #30628.

### Summary of Changes
Extended #30636 using the `task` parameter in addition to the view.

The frontend module editing feature uses `com_config`. If a user doesn't have permissions to access `com_config`, J4 forbids them from editing modules in frontend, even if they have the appropriate permission.
This PR adds a check for the `modules` view and tasks, which is separate from the `com_config` permission.

### Testing Instructions
1. Create a user in the "Administrator" (not Super User!) group.
2. Enable frontend module editing and allow frontend module editing for the "Administrator" group.
3. Log in to the Administrator account in frontend.
4. Try to edit a module in frontend. This includes functionality of the buttons "Save", "Save and Close", and "Cancel".

### Actual result BEFORE applying this Pull Request
Error 403: You don't have permission to access this.


### Expected result AFTER applying this Pull Request
Frontend module editing works as expected.

Please make sure that the user who has only permissions for frontend module editing is still not allowed to access any other parts of `com_config` in frontend. You can do this with the following steps:
1. Create a menu item of type "Configuration Manager - Site Configuration Options".
2. Try to access this menu item with the non-superuser account in frontend.
3. Create a menu item of type "Configuration Manager - Display Template Options".
4. Try to access this menu item with the non-superuser account in frontend.
5. And of course make sure that nobody who doesn't have the permission for frontend module editing is able to do this.