### PR TITLE
[4.0] mod_article_news readmore

### DIFF
--- a/modules/mod_articles_news/tmpl/_item.php
+++ b/modules/mod_articles_news/tmpl/_item.php
@@ -8,6 +8,8 @@
  */
 
 defined('_JEXEC') or die;
+
+use Joomla\CMS\Layout\LayoutHelper;
 ?>
 <?php if ($params->get('item_title')) : ?>
 
@@ -23,7 +25,7 @@ defined('_JEXEC') or die;
 	</<?php echo $item_heading; ?>>
 <?php endif; ?>
 
-<?php if ($params->get('img_intro_full') !== 'none' && !empty($item->imageSrc)) : ?>	
+<?php if ($params->get('img_intro_full') !== 'none' && !empty($item->imageSrc)) : ?>
 	<figure class="newsflash-image">
 		<img src="<?php echo $item->imageSrc; ?>" alt="<?php echo $item->imageAlt; ?>">
 		<?php if (!empty($item->imageCaption)) : ?>
@@ -47,5 +49,5 @@ defined('_JEXEC') or die;
 <?php echo $item->afterDisplayContent; ?>
 
 <?php if (isset($item->link) && $item->readmore != 0 && $params->get('readmore')) : ?>
-	<?php echo '<a class="readmore" href="' . $item->link . '">' . $item->linkText . '</a>'; ?>
+	<?php echo LayoutHelper::render('joomla.content.readmore', array('item' => $item, 'params' => $item->params, 'link' => $item->link)); ?>
 <?php endif; ?>


### PR DESCRIPTION
### accessibility
If you have enabled show readmore in the module then it will only display the text "read more" with the link which is ambiguous.

As a result if you are displaying more than one item in the module you have multiple links all with the same ambiguous link name.

### additional issues
The text is always "read more" even if you have set a custom text in the article options (globally or per article)

The link title is never displayed even if you have set it to be displayed in the article options (globally or per article)

The read more link in the module has different markup to the readmore link in an article making consistent styling harder

### Fix
This PR simply changes the module to use the existing joomla.content.readmore layout

### Test
Create a module of type Article News
test the module option for readmore
test all the com_content options for readmore
test all the individual article options for readmore

It is expected that depending on the options above there will be either
- no readmore
- readmore + aria label
- readmore + article title + arial label

