### PR TITLE
Change grid minmax definition for newsflash module

### DIFF
--- a/build/media_source/mod_articles_news/css/template.css
+++ b/build/media_source/mod_articles_news/css/template.css
@@ -23,7 +23,7 @@
   .mod-articlesnews-horizontal {
     display: grid;
     grid-gap: 2rem;
-    grid-template-columns: repeat(auto-fit, minmax(330px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   }
   .mod-articlesnews-horizontal li:not(:last-child) {
     margin-right: 0;


### PR DESCRIPTION
Change grid minmax definition for newsflash module (horizontal layout) to better fit in small displays
See issue https://github.com/joomla/cassiopeia/issues/119

### Summary of Changes
Changed 330px to 200px


### Testing Instructions
Run npm ci


### Actual result BEFORE applying this Pull Request
The news don't fit on small displays, horizontal scrolling


### Expected result AFTER applying this Pull Request
The news fit on small displays, no horizontal scrolling


