### PR TITLE
[4.0] Blog view links

### DIFF
--- a/components/com_content/tmpl/category/blog.php
+++ b/components/com_content/tmpl/category/blog.php
@@ -106,7 +106,7 @@ $afterDisplayContent = trim(implode("\n", $results));
 	<?php endif; ?>
 
 	<?php if (!empty($this->link_items)) : ?>
-		<div class="com-content-category-blog__items-more items-more">
+		<div class="items-more">
 			<?php echo $this->loadTemplate('links'); ?>
 		</div>
 	<?php endif; ?>

--- a/components/com_content/tmpl/category/blog_links.php
+++ b/components/com_content/tmpl/category/blog_links.php
@@ -14,9 +14,9 @@ use Joomla\Component\Content\Site\Helper\RouteHelper;
 
 ?>
 
-<ol class="com-content-category-blog__links nav nav-tabs nav-stacked">
+<ol class="com-content-blog__links">
 	<?php foreach ($this->link_items as &$item) : ?>
-		<li class="com-content-category-blog__link">
+		<li class="com-content-blog__link">
 			<a href="<?php echo Route::_(RouteHelper::getArticleRoute($item->slug, $item->catid, $item->language)); ?>">
 				<?php echo $item->title; ?></a>
 		</li>

--- a/components/com_content/tmpl/category/blog_links.php
+++ b/components/com_content/tmpl/category/blog_links.php
@@ -15,7 +15,7 @@ use Joomla\Component\Content\Site\Helper\RouteHelper;
 ?>
 
 <ol class="com-content-blog__links">
-	<?php foreach ($this->link_items as &$item) : ?>
+	<?php foreach ($this->link_items as $item) : ?>
 		<li class="com-content-blog__link">
 			<a href="<?php echo Route::_(RouteHelper::getArticleRoute($item->slug, $item->catid, $item->language)); ?>">
 				<?php echo $item->title; ?></a>

--- a/components/com_content/tmpl/featured/default.php
+++ b/components/com_content/tmpl/featured/default.php
@@ -58,7 +58,7 @@ defined('_JEXEC') or die;
 
 	<?php if (!empty($this->link_items)) : ?>
 		<div class="items-more">
-		<?php echo $this->loadTemplate('links'); ?>
+			<?php echo $this->loadTemplate('links'); ?>
 		</div>
 	<?php endif; ?>
 

--- a/components/com_content/tmpl/featured/default_links.php
+++ b/components/com_content/tmpl/featured/default_links.php
@@ -13,11 +13,11 @@ use Joomla\CMS\Router\Route;
 use Joomla\Component\Content\Site\Helper\RouteHelper;
 
 ?>
-<ol class="nav nav-tabs nav-stacked">
-<?php foreach ($this->link_items as &$item) : ?>
-	<li>
-		<a href="<?php echo Route::_(RouteHelper::getArticleRoute($item->slug, $item->catid, $item->language)); ?>">
-			<?php echo $item->title; ?></a>
-	</li>
-<?php endforeach; ?>
+<ol class="com-content-blog__links">
+	<?php foreach ($this->link_items as $item) : ?>
+		<li class="com-content-blog__link">
+			<a href="<?php echo Route::_(RouteHelper::getArticleRoute($item->slug, $item->catid, $item->language)); ?>">
+				<?php echo $item->title; ?></a>
+		</li>
+	<?php endforeach; ?>
 </ol>


### PR DESCRIPTION
Pull Request for Issue #30700 (first part, list of links) .

### Summary of Changes
Links on blog and featured view are made equal and as ordered list.


### Testing Instructions
You need a blog (featured blog ) with links.


### Actual result BEFORE applying this Pull Request
see #30700


### Expected result AFTER applying this Pull Request
The links are displayed as ordered list.
The class "item-more" remains as maybe 3rd party extensions have a styling for this class. 

### Note
A comment from JAT will be appreciated. Maybe we can add additional aria labels with a description
