### PR TITLE
[4.0] loading=lazy HTMLHelper

### DIFF
--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -688,7 +688,7 @@ abstract class HTMLHelper
 		}
 
 		// Default to loading=lazy you can disable it by passing $attribs['loading'] = 'eager';
-		if ((is_null($attribs) 
+		if (is_null($attribs))
 		{
 			$attribs = ' loading="lazy"';
 		}

--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -695,7 +695,7 @@ abstract class HTMLHelper
 
 		if (is_string($attribs) && !strpos($attribs, 'loading='))
 		{
-			$attribs .= ' loading="lazy"'
+			$attribs .= ' loading="lazy"';
 		}
 
 		return '<img src="' . $file . '" alt="' . $alt . '" ' . trim((\is_array($attribs) ? ArrayHelper::toString($attribs) : $attribs)) . '>';

--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -687,20 +687,6 @@ abstract class HTMLHelper
 			return $file;
 		}
 
-		// Default to loading=lazy you can disable it by passing $attribs['loading'] = 'eager';
-		if (is_null($attribs))
-		{
-			$attribs = ' loading="lazy"';
-		}
-		elseif (is_array($attribs) && !isset($attribs['loading']))
-		{
-			$attribs['loading'] = 'lazy';
-		}
-		elseif (is_string($attribs) && !strpos($attribs, ' loading='))
-		{
-			$attribs .= ' loading="lazy"';
-		}
-
 		return '<img src="' . $file . '" alt="' . $alt . '" ' . trim((\is_array($attribs) ? ArrayHelper::toString($attribs) : $attribs)) . '>';
 	}
 

--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -693,7 +693,7 @@ abstract class HTMLHelper
 			$attribs['loading'] = 'lazy';
 		}
 
-		if (is_string($attribs) && !strpos($attribs, 'loading='))
+		if ((is_string($attribs) || $attribs === NULL) && !strpos($attribs, 'loading='))
 		{
 			$attribs .= ' loading="lazy"';
 		}

--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -687,10 +687,15 @@ abstract class HTMLHelper
 			return $file;
 		}
 
-		// Default to lazy you can disable lazyloading by passing $attribs['loading'] = 'eager';
-		if (!isset($attribs['loading']))
+		// Default to loading=lazy you can disable it by passing $attribs['loading'] = 'eager';
+		if (is_array($attribs) && !isset($attribs['loading']))
 		{
 			$attribs['loading'] = 'lazy';
+		}
+
+		if (is_string($attribs) && !strpos($attribs, 'loading='))
+		{
+			$attribs .= ' loading="lazy"'
 		}
 
 		return '<img src="' . $file . '" alt="' . $alt . '" ' . trim((\is_array($attribs) ? ArrayHelper::toString($attribs) : $attribs)) . '>';

--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -688,12 +688,15 @@ abstract class HTMLHelper
 		}
 
 		// Default to loading=lazy you can disable it by passing $attribs['loading'] = 'eager';
-		if (is_array($attribs) && !isset($attribs['loading']))
+		if ((is_null($attribs) 
+		{
+			$attribs = ' loading="lazy"';
+		}
+		elseif (is_array($attribs) && !isset($attribs['loading']))
 		{
 			$attribs['loading'] = 'lazy';
 		}
-
-		if ((is_string($attribs) || $attribs === null) && !strpos($attribs, 'loading='))
+		elseif (is_string($attribs) && !strpos($attribs, ' loading='))
 		{
 			$attribs .= ' loading="lazy"';
 		}

--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -693,7 +693,7 @@ abstract class HTMLHelper
 			$attribs['loading'] = 'lazy';
 		}
 
-		if ((is_string($attribs) || $attribs === NULL) && !strpos($attribs, 'loading='))
+		if ((is_string($attribs) || $attribs === null) && !strpos($attribs, 'loading='))
 		{
 			$attribs .= ' loading="lazy"';
 		}
@@ -1278,4 +1278,3 @@ abstract class HTMLHelper
 		return '';
 	}
 }
-


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/30615

### Summary of Changes

Make sure we support both strings and arrays passed as attributes. cc @SharkyKZ 

### Testing Instructions

- install 4.0-dev
- setup an contact with an contact image
- add it to a menu
- open it on the frontend
- check that the loading=lazy attribute is there.
- Add `<?php echo Joomla\CMS\HTML\HTMLHelper::_('image', 'mod_languages/de.gif', '', null, true); ?>` to this line https://github.com/joomla/joomla-cms/blob/4.0-dev/templates/cassiopeia/index.php#L106
- Notice the german flag when checking the frontend.
- notice it does not has the loading attribute set.
- apply the patch
- notice that loading=lazy is gone for the contact menu image too.
- notice there is no waring when using the code mention above anymore.

### Actual result BEFORE applying this Pull Request

warning when using NULL or an string as attributes

### Expected result AFTER applying this Pull Request

no warning anymore and no default to loading=lazy

### Documentation Changes Required

None