### PR TITLE
Tag cloud improvement

### DIFF
--- a/build/media_source/mod_tags_popular/template.css
+++ b/build/media_source/mod_tags_popular/template.css
@@ -1,0 +1,3 @@
+.nowrap {
+  white-space: nowrap;
+}

--- a/modules/mod_tags_popular/tmpl/cloud.php
+++ b/modules/mod_tags_popular/tmpl/cloud.php
@@ -49,11 +49,12 @@ if (!count($list)) : ?>
 		endif;
 ?>
 		<span class="tag">
-			<a class="tag-name" style="font-size: <?php echo $fontsize . 'em'; ?>" href="<?php echo Route::_(RouteHelper::getTagRoute($item->tag_id . ':' . $item->alias)); ?>">
-				<?php echo htmlspecialchars($item->title, ENT_COMPAT, 'UTF-8'); ?></a>
-			<?php if ($display_count) : ?>
-				<span class="tag-count badge badge-info"><?php echo $item->count; ?></span>
-			<?php endif; ?>
+			<a class="tag-name" href="<?php echo Route::_(RouteHelper::getTagRoute($item->tag_id . ':' . $item->alias)); ?>">
+				<?php echo htmlspecialchars($item->title, ENT_COMPAT, 'UTF-8'); ?>
+				<?php if ($display_count) : ?>
+					<span class="tag-count badge badge-info"><?php echo $item->count; ?></span>
+				<?php endif; ?>
+			</a>
 		</span>
 	<?php endforeach; ?>
 <?php endif; ?>

--- a/modules/mod_tags_popular/tmpl/cloud.php
+++ b/modules/mod_tags_popular/tmpl/cloud.php
@@ -16,6 +16,10 @@ use Joomla\Component\Tags\Site\Helper\RouteHelper;
 $minsize = $params->get('minsize', 1);
 $maxsize = $params->get('maxsize', 2);
 
+/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+$wa = $app->getDocument()->getWebAssetManager();
+$wa->registerAndUseStyle('mod_modules', 'mod_tagas_popular/template.css');
+
 ?>
 <div class="mod-tagspopular-cloud tagspopular tagscloud">
 <?php
@@ -50,9 +54,16 @@ if (!count($list)) : ?>
 ?>
 		<span class="tag">
 			<a class="tag-name" href="<?php echo Route::_(RouteHelper::getTagRoute($item->tag_id . ':' . $item->alias)); ?>">
-				<?php echo htmlspecialchars($item->title, ENT_COMPAT, 'UTF-8'); ?>
-				<?php if ($display_count) : ?>
-					<span class="tag-count badge badge-info"><?php echo $item->count; ?></span>
+				<?php if (!$display_count) : ?>
+					<?php echo htmlspecialchars($item->title, ENT_COMPAT, 'UTF-8'); ?>
+				<?php else : ?>
+					<?php $tmp = explode(' ', htmlspecialchars($item->title, ENT_COMPAT, 'UTF-8'));?>
+					<?php $lastWord = array_pop($tmp);?>
+					<?php echo htmlspecialchars(implode(' ', $tmp), ENT_COMPAT, 'UTF-8'); ?>
+					<span class="nowrap">
+						<?php echo htmlspecialchars($lastWord, ENT_COMPAT, 'UTF-8'); ?>
+						<span class="tag-count badge badge-info"><?php echo $item->count; ?></span>
+					</span>
 				<?php endif; ?>
 			</a>
 		</span>


### PR DESCRIPTION
Pull Request for Issue #30795 .

### Summary of Changes
This PR keeps the last word of a tag and it's badge together. 


### Testing Instructions
Make some tags and install a module tags_popular. Choose the cloud lyout. 


### Actual result BEFORE applying this Pull Request
see #30795


### Expected result AFTER applying this Pull Request
Tags and their badges are kept together. If a tag consits of several words, the last word and the badge are kept together when lines break on narrow screens.


### Documentation Changes Required
no
