### PR TITLE
[4.0] Replace file_exists() where applicable

### DIFF
--- a/libraries/loader.php
+++ b/libraries/loader.php
@@ -351,7 +351,7 @@ abstract class JLoader
 	public static function registerPrefix($prefix, $path, $reset = false, $prepend = false)
 	{
 		// Verify the library path exists.
-		if (!file_exists($path))
+		if (!is_dir($path))
 		{
 			$path = (str_replace(JPATH_ROOT, '', $path) == $path) ? basename($path) : str_replace(JPATH_ROOT, '', $path);
 
@@ -444,7 +444,7 @@ abstract class JLoader
 		}
 
 		// Verify the library path exists.
-		if (!file_exists($path))
+		if (!is_dir($path))
 		{
 			$path = (str_replace(JPATH_ROOT, '', $path) == $path) ? basename($path) : str_replace(JPATH_ROOT, '', $path);
 
@@ -561,7 +561,7 @@ abstract class JLoader
 					}
 
 					// We check for class_exists to handle case-sensitive file systems
-					if (file_exists($classFilePath) && !class_exists($class, false))
+					if (is_file($classFilePath) && !class_exists($class, false))
 					{
 						$found = (bool) include_once $classFilePath;
 
@@ -674,7 +674,7 @@ abstract class JLoader
 			$path = realpath($base . '/' . implode('/', array_map('strtolower', $parts)) . '.php');
 
 			// Load the file if it exists and is in the lookup path.
-			if (strpos($path, realpath($base)) === 0 && file_exists($path))
+			if (strpos($path, realpath($base)) === 0 && is_file($path))
 			{
 				$found = (bool) include_once $path;
 
@@ -695,7 +695,7 @@ abstract class JLoader
 				$path = realpath($base . '/' . implode('/', array_map('strtolower', array($parts[0], $parts[0]))) . '.php');
 
 				// Load the file if it exists and is in the lookup path.
-				if (strpos($path, realpath($base)) === 0 && file_exists($path))
+				if (strpos($path, realpath($base)) === 0 && is_file($path))
 				{
 					$found = (bool) include_once $path;
 

--- a/libraries/namespacemap.php
+++ b/libraries/namespacemap.php
@@ -35,7 +35,7 @@ class JNamespacePsr4Map
 	 */
 	public function exists()
 	{
-		return file_exists($this->file);
+		return is_file($this->file);
 	}
 
 	/**
@@ -176,7 +176,7 @@ class JNamespacePsr4Map
 				$file = $extensionPath . $name . '.xml';
 
 				// If there is no manifest file, ignore. If it was a component check if the xml was named with the com_ prefix.
-				if (!file_exists($file))
+				if (!is_file($file))
 				{
 					if (!$count)
 					{
@@ -185,7 +185,7 @@ class JNamespacePsr4Map
 
 					$file = $extensionPath . $extension . '.xml';
 
-					if (!file_exists($file))
+					if (!is_file($file))
 					{
 						continue;
 					}

--- a/libraries/src/Adapter/Adapter.php
+++ b/libraries/src/Adapter/Adapter.php
@@ -157,7 +157,7 @@ class Adapter extends CMSObject
 
 		$fullpath = $this->_basepath . '/' . $this->_adapterfolder . '/' . strtolower($name) . '.php';
 
-		if (!file_exists($fullpath))
+		if (!is_file($fullpath))
 		{
 			return false;
 		}

--- a/libraries/src/Application/AdministratorApplication.php
+++ b/libraries/src/Application/AdministratorApplication.php
@@ -268,15 +268,15 @@ class AdministratorApplication extends CMSApplication
 		$template->params = new Registry($template->params);
 
 		// Fallback template
-		if (!file_exists(JPATH_THEMES . '/' . $template->template . '/index.php')
-			&& !file_exists(JPATH_THEMES . '/' . $template->parent . '/index.php'))
+		if (!is_file(JPATH_THEMES . '/' . $template->template . '/index.php')
+			&& !is_file(JPATH_THEMES . '/' . $template->parent . '/index.php'))
 		{
 			$this->enqueueMessage(Text::_('JERROR_ALERTNOTEMPLATE'), 'error');
 			$template->params = new Registry;
 			$template->template = 'atum';
 
 			// Check, the data were found and if template really exists
-			if (!file_exists(JPATH_THEMES . '/' . $template->template . '/index.php'))
+			if (!is_file(JPATH_THEMES . '/' . $template->template . '/index.php'))
 			{
 				throw new \InvalidArgumentException(Text::sprintf('JERROR_COULD_NOT_FIND_TEMPLATE', $template->template));
 			}

--- a/libraries/src/Application/SiteApplication.php
+++ b/libraries/src/Application/SiteApplication.php
@@ -401,15 +401,15 @@ final class SiteApplication extends CMSApplication
 		{
 			if ($this->template->parent)
 			{
-				if (!file_exists(JPATH_THEMES . '/' . $this->template->template . '/index.php'))
+				if (!is_file(JPATH_THEMES . '/' . $this->template->template . '/index.php'))
 				{
-					if (!file_exists(JPATH_THEMES . '/' . $this->template->parent . '/index.php'))
+					if (!is_file(JPATH_THEMES . '/' . $this->template->parent . '/index.php'))
 					{
 						throw new \InvalidArgumentException(Text::sprintf('JERROR_COULD_NOT_FIND_TEMPLATE', $this->template->template));
 					}
 				}
 			}
-			elseif (!file_exists(JPATH_THEMES . '/' . $this->template->template . '/index.php'))
+			elseif (!is_file(JPATH_THEMES . '/' . $this->template->template . '/index.php'))
 			{
 				throw new \InvalidArgumentException(Text::sprintf('JERROR_COULD_NOT_FIND_TEMPLATE', $this->template->template));
 			}
@@ -528,7 +528,7 @@ final class SiteApplication extends CMSApplication
 		// Only set template override if it is a valid template (= it exists and is enabled)
 		if (!empty($template_override))
 		{
-			if (file_exists(JPATH_THEMES . '/' . $template_override . '/index.php'))
+			if (is_file(JPATH_THEMES . '/' . $template_override . '/index.php'))
 			{
 				foreach ($templates as $tmpl)
 				{
@@ -547,9 +547,9 @@ final class SiteApplication extends CMSApplication
 		// Fallback template
 		if (!empty($template->parent))
 		{
-			if (!file_exists(JPATH_THEMES . '/' . $template->template . '/index.php'))
+			if (!is_file(JPATH_THEMES . '/' . $template->template . '/index.php'))
 			{
-				if (!file_exists(JPATH_THEMES . '/' . $template->parent . '/index.php'))
+				if (!is_file(JPATH_THEMES . '/' . $template->parent . '/index.php'))
 				{
 					$this->enqueueMessage(Text::_('JERROR_ALERTNOTEMPLATE'), 'error');
 
@@ -566,14 +566,14 @@ final class SiteApplication extends CMSApplication
 					}
 
 					// Check, the data were found and if template really exists
-					if (!file_exists(JPATH_THEMES . '/' . $template->template . '/index.php'))
+					if (!is_file(JPATH_THEMES . '/' . $template->template . '/index.php'))
 					{
 						throw new \InvalidArgumentException(Text::sprintf('JERROR_COULD_NOT_FIND_TEMPLATE', $original_tmpl));
 					}
 				}
 			}
 		}
-		elseif (!file_exists(JPATH_THEMES . '/' . $template->template . '/index.php'))
+		elseif (!is_file(JPATH_THEMES . '/' . $template->template . '/index.php'))
 		{
 			$this->enqueueMessage(Text::_('JERROR_ALERTNOTEMPLATE'), 'error');
 
@@ -590,7 +590,7 @@ final class SiteApplication extends CMSApplication
 			}
 
 			// Check, the data were found and if template really exists
-			if (!file_exists(JPATH_THEMES . '/' . $template->template . '/index.php'))
+			if (!is_file(JPATH_THEMES . '/' . $template->template . '/index.php'))
 			{
 				throw new \InvalidArgumentException(Text::sprintf('JERROR_COULD_NOT_FIND_TEMPLATE', $original_tmpl));
 			}

--- a/libraries/src/Dispatcher/LegacyComponentDispatcher.php
+++ b/libraries/src/Dispatcher/LegacyComponentDispatcher.php
@@ -54,7 +54,7 @@ class LegacyComponentDispatcher implements DispatcherInterface
 		$path = JPATH_COMPONENT . '/' . substr($this->app->scope, 4) . '.php';
 
 		// If component file doesn't exist throw error
-		if (!file_exists($path))
+		if (!is_file($path))
 		{
 			throw new \Exception(Text::_('JLIB_APPLICATION_ERROR_COMPONENT_NOT_FOUND'), 404);
 		}

--- a/libraries/src/Dispatcher/ModuleDispatcher.php
+++ b/libraries/src/Dispatcher/ModuleDispatcher.php
@@ -30,7 +30,7 @@ class ModuleDispatcher extends AbstractModuleDispatcher
 	{
 		$path = JPATH_BASE . '/modules/' . $this->module->module . '/' . $this->module->module . '.php';
 
-		if (!file_exists($path))
+		if (!is_file($path))
 		{
 			return;
 		}

--- a/libraries/src/Document/HtmlDocument.php
+++ b/libraries/src/Document/HtmlDocument.php
@@ -761,7 +761,7 @@ class HtmlDocument extends Document
 		$contents = '';
 
 		// Check to see if we have a valid template file
-		if (file_exists($directory . '/' . $filename))
+		if (is_file($directory . '/' . $filename))
 		{
 			// Store the file path
 			$this->_file = $directory . '/' . $filename;
@@ -789,12 +789,12 @@ class HtmlDocument extends Document
 		{
 			if ($template->parent !== ''
 				&& $base === 1
-				&& !file_exists(JPATH_ROOT . '/media/templates/' . $client . $template->template . $icon))
+				&& !is_file(JPATH_ROOT . '/media/templates/' . $client . $template->template . $icon))
 			{
 				$dir = JPATH_ROOT . '/media/templates/' . $client . $template->parent;
 			}
 
-			if (file_exists($dir . $icon))
+			if (is_file($dir . $icon))
 			{
 				$urlBase = in_array($base, [0, 2]) ? Uri::base(true) : Uri::root(true);
 				$base    = in_array($base, [0, 2]) ? JPATH_BASE : JPATH_ROOT;
@@ -828,19 +828,19 @@ class HtmlDocument extends Document
 		$baseDir = $directory . '/' . $template;
 
 		if (!empty($inherits)
-			&& !file_exists($directory . '/' . $template . '/' . $file)
-			&& file_exists($directory . '/' . $inherits . '/' . $file)
+			&& !is_file($directory . '/' . $template . '/' . $file)
+			&& is_file($directory . '/' . $inherits . '/' . $file)
 		)
 		{
 			$baseDir = $directory . '/' . $inherits;
 		}
 
-		if (!file_exists($baseDir . '/' . $file))
+		if (!is_file($baseDir . '/' . $file))
 		{
 			$template = 'system';
 		}
 
-		if (!file_exists($baseDir . '/' . $file))
+		if (!is_file($baseDir . '/' . $file))
 		{
 			$file = 'index.php';
 		}

--- a/libraries/src/Document/OpensearchDocument.php
+++ b/libraries/src/Document/OpensearchDocument.php
@@ -83,7 +83,7 @@ class OpensearchDocument extends Document
 
 		foreach ($dirs as $dir)
 		{
-			if (file_exists($dir . '/favicon.ico'))
+			if (is_file($dir . '/favicon.ico'))
 			{
 				$path = str_replace(JPATH_BASE, '', $dir);
 				$path = str_replace('\\', '/', $path);

--- a/libraries/src/Document/Renderer/Html/MessageRenderer.php
+++ b/libraries/src/Document/Renderer/Html/MessageRenderer.php
@@ -46,7 +46,7 @@ class MessageRenderer extends DocumentRenderer
 		$app        = Factory::getApplication();
 		$chromePath = JPATH_THEMES . '/' . $app->getTemplate() . '/html/message.php';
 
-		if (file_exists($chromePath))
+		if (is_file($chromePath))
 		{
 			include_once $chromePath;
 		}

--- a/libraries/src/Extension/ExtensionManagerTrait.php
+++ b/libraries/src/Extension/ExtensionManagerTrait.php
@@ -131,7 +131,7 @@ trait ExtensionManagerTrait
 		// The path of the loader file
 		$path = $extensionPath . '/services/provider.php';
 
-		if (file_exists($path))
+		if (is_file($path))
 		{
 			// Load the file
 			$provider = require_once $path;
@@ -209,7 +209,7 @@ trait ExtensionManagerTrait
 		$path = JPATH_PLUGINS . '/' . $type . '/' . $plugin . '/' . $plugin . '.php';
 
 		// Return an empty class when the file doesn't exist
-		if (!file_exists($path))
+		if (!is_file($path))
 		{
 			return new DummyPlugin($dispatcher);
 		}

--- a/libraries/src/Extension/LegacyComponent.php
+++ b/libraries/src/Extension/LegacyComponent.php
@@ -233,7 +233,7 @@ class LegacyComponent
 			$path = JPATH_SITE . '/components/com_' . $this->component . '/router.php';
 
 			// Use the custom routing handler if it exists
-			if (file_exists($path))
+			if (is_file($path))
 			{
 				require_once $path;
 			}
@@ -270,7 +270,7 @@ class LegacyComponent
 
 		$file = Path::clean(JPATH_ADMINISTRATOR . '/components/com_' . $this->component . '/helpers/' . $this->component . '.php');
 
-		if (!file_exists($file))
+		if (!is_file($file))
 		{
 			return false;
 		}

--- a/libraries/src/Form/Field/AccessiblemediaField.php
+++ b/libraries/src/Form/Field/AccessiblemediaField.php
@@ -148,7 +148,7 @@ class AccessiblemediaField extends SubformField
 				 * it is most likely a custom field created in Joomla 3 and
 				 * the value is a string that contains the file name.
 				*/
-				if (file_exists(JPATH_ROOT . '/' . $value))
+				if (is_file(JPATH_ROOT . '/' . $value))
 				{
 					$value = '{"imagefile":"' . $value . '","alt_text":""}';
 				}

--- a/libraries/src/Form/Field/ComponentlayoutField.php
+++ b/libraries/src/Form/Field/ComponentlayoutField.php
@@ -131,7 +131,7 @@ class ComponentlayoutField extends FormField
 			$component_path = Path::clean($client->path . '/components/' . $extension . '/views/' . $view . '/tmpl');
 
 			// Check if the old layouts folder exists, else use the new one
-			if (!file_exists($component_path))
+			if (!is_dir($component_path))
 			{
 				$component_path = Path::clean($client->path . '/components/' . $extension . '/tmpl/' . $view);
 			}

--- a/libraries/src/Form/Field/MediaField.php
+++ b/libraries/src/Form/Field/MediaField.php
@@ -242,14 +242,14 @@ class MediaField extends FormField
 			$asset = Factory::getApplication()->input->get('option');
 		}
 
-		if ($this->value && file_exists(JPATH_ROOT . '/' . $this->value))
+		if ($this->value && is_file(JPATH_ROOT . '/' . $this->value))
 		{
 			$this->folder = explode('/', $this->value);
 			$this->folder = array_diff_assoc($this->folder, explode('/', ComponentHelper::getParams('com_media')->get('image_path', 'images')));
 			array_pop($this->folder);
 			$this->folder = implode('/', $this->folder);
 		}
-		elseif (file_exists(JPATH_ROOT . '/' . ComponentHelper::getParams('com_media')->get('image_path', 'images') . '/' . $this->directory))
+		elseif (is_dir(JPATH_ROOT . '/' . ComponentHelper::getParams('com_media')->get('image_path', 'images') . '/' . $this->directory))
 		{
 			$this->folder = $this->directory;
 		}

--- a/libraries/src/Helper/ModuleHelper.php
+++ b/libraries/src/Helper/ModuleHelper.php
@@ -340,17 +340,17 @@ abstract class ModuleHelper
 		$dPath = JPATH_BASE . '/modules/' . $module . '/tmpl/default.php';
 
 		// If the template has a layout override use it
-		if (file_exists($tPath))
+		if (is_file($tPath))
 		{
 			return $tPath;
 		}
 
-		if (!empty($templateObj->parent) && file_exists($iPath))
+		if (!empty($templateObj->parent) && is_file($iPath))
 		{
 			return $iPath;
 		}
 
-		if (file_exists($bPath))
+		if (is_file($bPath))
 		{
 			return $bPath;
 		}

--- a/libraries/src/Image/Image.php
+++ b/libraries/src/Image/Image.php
@@ -175,7 +175,7 @@ class Image
 	public static function getImageFileProperties($path)
 	{
 		// Make sure the file exists.
-		if (!file_exists($path))
+		if (!is_file($path))
 		{
 			throw new \InvalidArgumentException('The image file does not exist.');
 		}
@@ -580,7 +580,7 @@ class Image
 		$this->destroy();
 
 		// Make sure the file exists.
-		if (!file_exists($path))
+		if (!is_file($path))
 		{
 			throw new \InvalidArgumentException('The image file does not exist.');
 		}

--- a/libraries/src/Language/Language.php
+++ b/libraries/src/Language/Language.php
@@ -220,7 +220,7 @@ class Language
 
 		while (!class_exists($class) && $path)
 		{
-			if (file_exists($path))
+			if (is_file($path))
 			{
 				require_once $path;
 			}
@@ -792,7 +792,7 @@ class Language
 		$strings = LanguageHelper::parseIniFile($fileName, $this->debug);
 
 		// Debug the ini file if needed.
-		if ($this->debug === true && file_exists($fileName))
+		if ($this->debug === true && is_file($fileName))
 		{
 			$this->debugFile($fileName);
 		}
@@ -813,7 +813,7 @@ class Language
 	public function debugFile($filename)
 	{
 		// Make sure our file actually exists
-		if (!file_exists($filename))
+		if (!is_file($filename))
 		{
 			throw new \InvalidArgumentException(
 				sprintf('Unable to locate file "%s" for debugging', $filename)

--- a/libraries/src/Language/LanguageHelper.php
+++ b/libraries/src/Language/LanguageHelper.php
@@ -450,7 +450,7 @@ class LanguageHelper
 	public static function parseIniFile($fileName, $debug = false)
 	{
 		// Check if file exists.
-		if (!file_exists($fileName))
+		if (!is_file($fileName))
 		{
 			return array();
 		}

--- a/libraries/src/MVC/Controller/BaseController.php
+++ b/libraries/src/MVC/Controller/BaseController.php
@@ -320,11 +320,11 @@ class BaseController implements ControllerInterface
 		if (!class_exists($class))
 		{
 			// If the controller file path exists, include it.
-			if (file_exists($path))
+			if (is_file($path))
 			{
 				require_once $path;
 			}
-			elseif (isset($backuppath) && file_exists($backuppath))
+			elseif (isset($backuppath) && is_file($backuppath))
 			{
 				require_once $backuppath;
 			}

--- a/libraries/src/Pagination/Pagination.php
+++ b/libraries/src/Pagination/Pagination.php
@@ -336,7 +336,7 @@ class Pagination
 
 		$chromePath = JPATH_THEMES . '/' . $this->app->getTemplate() . '/html/pagination.php';
 
-		if (file_exists($chromePath))
+		if (is_file($chromePath))
 		{
 			include_once $chromePath;
 		}
@@ -512,7 +512,7 @@ class Pagination
 		// Keep B/C for overrides done with chromes
 		$chromePath = JPATH_THEMES . '/' . $this->app->getTemplate() . '/html/pagination.php';
 
-		if (file_exists($chromePath))
+		if (is_file($chromePath))
 		{
 			include_once $chromePath;
 

--- a/libraries/src/Plugin/PluginHelper.php
+++ b/libraries/src/Plugin/PluginHelper.php
@@ -63,15 +63,15 @@ abstract class PluginHelper
 		$dPath = JPATH_PLUGINS . '/' . $type . '/' . $name . '/tmpl/default.php';
 
 		// If the template has a layout override use it
-		if (file_exists($tPath))
+		if (is_file($tPath))
 		{
 			return $tPath;
 		}
-		elseif (!empty($templateObj->parent) && file_exists($iPath))
+		elseif (!empty($templateObj->parent) && is_file($iPath))
 		{
 			return $iPath;
 		}
-		elseif (file_exists($bPath))
+		elseif (is_file($bPath))
 		{
 			return $bPath;
 		}

--- a/libraries/src/Router/SiteRouter.php
+++ b/libraries/src/Router/SiteRouter.php
@@ -158,7 +158,7 @@ class SiteRouter extends Router
 
 			// If a php file has been found in the request path, check to see if it is a valid file.
 			// Also verify that it represents the same file from the server variable for entry script.
-			if (file_exists(JPATH_SITE . $matches[0]) && ($matches[0] === $relativeScriptPath))
+			if (is_file(JPATH_SITE . $matches[0]) && ($matches[0] === $relativeScriptPath))
 			{
 				// Remove the entry point segments from the request path for proper routing.
 				$path = str_replace($matches[0], '', $path);

--- a/libraries/src/Service/Provider/Config.php
+++ b/libraries/src/Service/Provider/Config.php
@@ -37,7 +37,7 @@ class Config implements ServiceProviderInterface
 				'JConfig',
 				function (Container $container)
 				{
-					if (!file_exists(JPATH_CONFIGURATION . '/configuration.php'))
+					if (!is_file(JPATH_CONFIGURATION . '/configuration.php'))
 					{
 						return new Registry;
 					}

--- a/libraries/src/Workflow/WorkflowPluginTrait.php
+++ b/libraries/src/Workflow/WorkflowPluginTrait.php
@@ -45,7 +45,7 @@ trait WorkflowPluginTrait
 		// Load XML file from "parent" plugin
 		$path = dirname((new ReflectionClass(static::class))->getFileName());
 
-		if (file_exists($path . '/forms/action.xml'))
+		if (is_file($path . '/forms/action.xml'))
 		{
 			$form->loadFile($path . '/forms/action.xml');
 		}


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Replaces `file_exists()` checks with more suitable `is_file()` and `is_dir()`, e.g. to avoid including directories as PHP files.

### Testing Instructions

Browse around, do some Joomla things.

### Expected result AFTER applying this Pull Request

Still works.

### Documentation Changes Required

No.