### PR TITLE
Fixed version history modals.

### DIFF
--- a/administrator/templates/isis/html/layouts/joomla/toolbar/versions.php
+++ b/administrator/templates/isis/html/layouts/joomla/toolbar/versions.php
@@ -19,6 +19,7 @@ defined('_JEXEC') or die;
  * @var  string   $typeAlias The component type
  */
 extract($displayData);
+JHtml::_('script', 'com_contenthistory/admin-history-versions.js', array('version' => 'auto', 'relative' => true));
 
 $link = 'index.php?option=com_contenthistory&amp;view=history&amp;layout=modal&amp;tmpl=component&amp;item_id='
 	. (int) $itemId . '&amp;type_id=' . $typeId . '&amp;type_alias='
@@ -40,4 +41,3 @@ echo JHtml::_(
 <button type="button" onclick="jQuery('#versionsModal').modal('show')" class="btn btn-small" data-toggle="modal">
 	<span class="icon-archive" aria-hidden="true"></span><?php echo $title; ?>
 </button>
-

--- a/media/com_contenthistory/js/admin-history-versions.js
+++ b/media/com_contenthistory/js/admin-history-versions.js
@@ -1,0 +1,7 @@
+/**
+ * @copyright  Copyright (C) 2005 - 2020 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+window.addEventListener('DOMContentLoaded', function() {
+	document.body.appendChild(document.getElementById('versionsModal'));
+});


### PR DESCRIPTION
### Summary of Changes
This PR is an adaptation of the nice JS modal fix #25147 for version 3.x. By calling the script from the button layout instead of every single view using versions, I hope it to be even more elegant (but let me know if this has some flaws I forgot about).

### Testing Instructions
1. In backend, edit an article.
2. Scroll the page down until the toolbar switches to the sticky mode (so it follows the scrolling).
3. Click on the "Versions" button.

To test this to full extent, you might want to test this editing the following items:
- Banner
- Banner Client
- Category
- Contact
- Article
- Newsfeed
- Tag
- User Note

Please test in Hathor as well to make sure the PR doesn't break anything there, and modals still work.

### Actual result BEFORE applying this Pull Request

The article versions are displayed behind the modal backdrop.
![joomla-content-versions-modal-backdrop](https://user-images.githubusercontent.com/1410135/94589301-67c80600-0285-11eb-906a-7a2060b43269.png)

### Expected result AFTER applying this Pull Request
The article versions should be displayed on top of the dark background.


### Documentation Changes Required
None
