### PR TITLE
[4.0] Article Links markup

### DIFF
--- a/components/com_content/tmpl/article/default_links.php
+++ b/components/com_content/tmpl/article/default_links.php
@@ -19,7 +19,7 @@ $params = $this->item->params;
 if ($urls && (!empty($urls->urla) || !empty($urls->urlb) || !empty($urls->urlc))) :
 ?>
 <div class="com-content-article__links content-links">
-	<ul class="nav nav-tabs nav-stacked">
+	<ul class="com-content-article__links content-list">
 		<?php
 			$urlarray = array(
 			array($urls->urla, $urls->urlatext, $urls->targeta, 'a'),


### PR DESCRIPTION
### Summary of Changes
Changes the class on the list of article links to be consistent with other classes and to enable them to be styled uniquely by the template


### Testing Instructions
Add some links on the "images and links" tab of an article


### Actual result BEFORE applying this Pull Request
links displayed in a list using the generic nav classes


### Expected result AFTER applying this Pull Request
links displayed using the (non-existant) com_content named class

this will enable the cassiopeia template and other templates to style the links more easily

### Documentation Changes Required
none
