### PR TITLE
[4.0] Set proper limits for joomla-fancy-select layout

### DIFF
--- a/build/media_source/system/js/fields/joomla-field-fancy-select.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-fancy-select.w-c.es6.js
@@ -23,6 +23,9 @@
  * min-term-length="1"   The minimum length a search value should be before choices are searched.
  * placeholder=""        The value of the inputs placeholder.
  * search-placeholder="" The value of the search inputs placeholder.
+ * 
+ * results-limit="20"    The maximum amount of search results to be displayed.
+ * render-limit="30"     The maximum amount of items to be rendered, useful for large lists.
  */
 window.customElements.define('joomla-field-fancy-select', class extends HTMLElement {
   // Attributes to monitor
@@ -33,6 +36,10 @@ window.customElements.define('joomla-field-fancy-select', class extends HTMLElem
   get url() { return this.getAttribute('url'); }
 
   get termKey() { return this.getAttribute('term-key') || 'term'; }
+  
+  get resultsLimit() { return parseInt(this.getAttribute('results-limit')) || 20; }
+
+  get renderLimit() { return parseInt(this.getAttribute('render-limit')) || 30; }  
 
   get minTermLength() { return parseInt(this.getAttribute('min-term-length')) || 1; }
 
@@ -122,7 +129,8 @@ window.customElements.define('joomla-field-fancy-select', class extends HTMLElem
       searchPlaceholderValue: this.searchPlaceholder,
       removeItemButton: true,
       searchFloor: this.minTermLength,
-      searchResultLimit: 10,
+      searchResultLimit: this.resultsLimit,
+      renderChoiceLimit: this.renderLimit,
       shouldSort: false,
       fuseOptions: {
         threshold: 0.3, // Strict search

--- a/layouts/joomla/form/field/list-fancy-select.php
+++ b/layouts/joomla/form/field/list-fancy-select.php
@@ -47,6 +47,8 @@ extract($displayData);
  * @var   array    $inputType       Options available for this field.
  * @var   string   $dataAttribute   Miscellaneous data attributes preprocessed for HTML output
  * @var   array    $dataAttributes  Miscellaneous data attribute for eg, data-*
+ * @var   integer  $renderLimit     Maximum amount of items to display, makes faster JavaScript initialization for large lists
+ * @var   integer  $resultsLimit    Maximum amount of search results to display, makes faster JavaScript execution
  */
 
 $html = array();
@@ -67,6 +69,8 @@ if ($readonly || $disabled)
 
 $attr2  = '';
 $attr2 .= !empty($class) ? ' class="' . $class . '"' : '';
+$attr2 .= !empty($renderLimit) ? ' render-limit="' . (int) $renderLimit . '"' : '';
+$attr2 .= !empty($resultsLimit) ? ' results-limit="' . (int) $resultsLimit . '"' : '';
 $attr2 .= ' placeholder="' . $this->escape($hint ?: Text::_('JGLOBAL_TYPE_OR_SELECT_SOME_OPTIONS')) . '" ';
 
 if ($required)

--- a/libraries/src/Form/Field/ListField.php
+++ b/libraries/src/Form/Field/ListField.php
@@ -257,8 +257,8 @@ class ListField extends FormField
 
 		if ($this->layout === 'joomla.form.field.list-fancy-select')
 		{
-			$data['renderLimit']    = !empty($this->element['renderLimit']) ? (int) $this->element['renderLimit'] : '';
-			$data['resultsLimit']   = !empty($this->element['resultsLimit']) ? (int) $this->element['resultsLimit'] : '';
+			$data['renderLimit']  = !empty($this->element['renderLimit']) ? (int) $this->element['renderLimit'] : '';
+			$data['resultsLimit'] = !empty($this->element['resultsLimit']) ? (int) $this->element['resultsLimit'] : '';
 		}
 
 		return $data;

--- a/libraries/src/Form/Field/ListField.php
+++ b/libraries/src/Form/Field/ListField.php
@@ -254,10 +254,11 @@ class ListField extends FormField
 	protected function getLayoutData()
 	{
 		$data = parent::getLayoutData();
+
 		if ($this->layout === 'joomla.form.field.list-fancy-select')
 		{
-			$data['renderLimit']    = !empty($this->element['renderLimit'])   ? (int) $this->element['renderLimit']  : '';
-			$data['resultsLimit']   = !empty($this->element['resultsLimit'])  ? (int) $this->element['resultsLimit'] : '';
+			$data['renderLimit']    = !empty($this->element['renderLimit']) ? (int) $this->element['renderLimit'] : '';
+			$data['resultsLimit']   = !empty($this->element['resultsLimit']) ? (int) $this->element['resultsLimit'] : '';
 		}
 
 		return $data;

--- a/libraries/src/Form/Field/ListField.php
+++ b/libraries/src/Form/Field/ListField.php
@@ -257,7 +257,7 @@ class ListField extends FormField
 
 		if ($this->layout === 'joomla.form.field.list-fancy-select')
 		{
-			$data['renderLimit']  = !empty($this->element['renderLimit']) ? (int) $this->element['renderLimit'] : '';
+			$data['renderLimit'] = !empty($this->element['renderLimit']) ? (int) $this->element['renderLimit'] : '';
 			$data['resultsLimit'] = !empty($this->element['resultsLimit']) ? (int) $this->element['resultsLimit'] : '';
 		}
 

--- a/libraries/src/Form/Field/ListField.php
+++ b/libraries/src/Form/Field/ListField.php
@@ -244,6 +244,7 @@ class ListField extends FormField
 
 	/**
 	 * Allow additional parameters for the "joomla.form.field.list-fancy-select" layout.
+	 *
 	 * @var integer $renderLimit the maximum amount of items to be rendered in the choices.js dropdown
 	 * @var integer $resultsLimit the maximum amount of search results to be displayed in the choices.js dropdown
 	 *

--- a/libraries/src/Form/Field/ListField.php
+++ b/libraries/src/Form/Field/ListField.php
@@ -254,10 +254,12 @@ class ListField extends FormField
 	protected function getLayoutData()
 	{
 		$data = parent::getLayoutData();
-		if ($this->layout === 'joomla.form.field.list-fancy-select') {	
+		if ($this->layout === 'joomla.form.field.list-fancy-select')
+		{
 			$data['renderLimit']    = !empty($this->element['renderLimit'])   ? (int) $this->element['renderLimit']  : '';
 			$data['resultsLimit']   = !empty($this->element['resultsLimit'])  ? (int) $this->element['resultsLimit'] : '';
 		}
-		return $data;		
-	}	
+
+		return $data;
+	}
 }

--- a/libraries/src/Form/Field/ListField.php
+++ b/libraries/src/Form/Field/ListField.php
@@ -241,4 +241,23 @@ class ListField extends FormField
 
 		return parent::__get($name);
 	}
+
+	/**
+	 * Allow additional parameters for the "joomla.form.field.list-fancy-select" layout.
+	 * @var integer $renderLimit the maximum amount of items to be rendered in the choices.js dropdown
+	 * @var integer $resultsLimit the maximum amount of search results to be displayed in the choices.js dropdown
+	 *
+	 * @return  array
+	 *
+	 * @since 4.0.0
+	 */
+	protected function getLayoutData()
+	{
+		$data = parent::getLayoutData();
+		if ($this->layout === 'joomla.form.field.list-fancy-select') {	
+			$data['renderLimit']    = !empty($this->element['renderLimit'])   ? (int) $this->element['renderLimit']  : '';
+			$data['resultsLimit']   = !empty($this->element['resultsLimit'])  ? (int) $this->element['resultsLimit'] : '';
+		}
+		return $data;		
+	}	
 }


### PR DESCRIPTION
PR for Issue #30288

### Summary of Changes
As explained with the issue at hand, the choices.js provides support for a render limit of the options and a search results limit, the first is much more important.

* `build/media_source/system/js/fields/joomla-field-fancy-select.w-c.es6.js` now can use `render-limit` and `results-limit` attributes to set `searchResultLimit` and `renderChoiceLimit` options for choices.js;
* `libraries/src/Form/Field/ListField.php` now can properly add the `renderLimit` and `resultsLimit` attributes from layout;
* `layouts/joomla/form/field/list-fancy-select.php` can now add the `render-limit` and `results-limit` HTML attributes to the element from the layout set `renderLimit` and `resultsLimit` field properties.

***Alternative solution***
Since the issue we're trying to solve is the slow initialization for large lists, we can simply replace `searchResultLimit` with `renderChoiceLimit` with the same value of 10 in `build/media_source/system/js/fields/joomla-field-fancy-select.w-c.es6.js`. The user would expect a search to take some time, but an initialization cannot take 2-3 seconds per field. This however won't give developers much flexibility.


### Testing Instructions
* Open any `extensionName.xml` and add this field in any `<fieldset>`
```markup
    <field
      name="fancy-select"
      type="List"
      label="List Demo"
      default="5"
      renderLimit="5"
      resultsLimit="15"
      layout="joomla.form.field.list-fancy-select">
      <option value="0">zr</option>
      <option value="1">zr 1</option>
      <option value="2">zr 2</option>
      <option value="3">zr 3</option>
      <option value="4">zr 4</option>
      <option value="5">zr 5</option>
      <option value="6">zr 6</option>
      <option value="7">zr 7</option>
      <option value="8">zr 8</option>
      <option value="9">zr 9</option>
      <option value="10">ze 10</option>
      <option value="11">ze 11</option>
      <option value="12">ze 12</option>
      <option value="13">ze 13</option>
      <option value="14">ze 14</option>
      <option value="15">ze 15</option>
      <option value="16">ze 16</option>
      <option value="17">ze 18</option>
      <option value="18">ze 18</option>
      <option value="19">ze 19</option>
      <option value="20">zt 20</option>
      <option value="21">zt 21</option>
      <option value="22">zt 22</option>
      <option value="23">zt 23</option>
      <option value="24">zt 24</option>
      <option value="25">zt 25</option>
      <option value="26">zt 26</option>
      <option value="27">zt 27</option>
      <option value="28">zt 28</option>
      <option value="29">zt 29</option>
      <option value="30">zt 30</option>
    </field>
```
* save and go to that extension config
* open the field dropdown, there should be 5 options as configured;
* type in 'Z' in the search box of the field, you should get 15 results as configured.

### Actual result BEFORE applying this Pull Request
Large lists are initialized extremely slow, also the initial `resultsLimit` of 10 was not enough. Imagine more than 10 Roboto font family styles, or much more articles that contain a certain keyword / combination of keywords.


### Expected result AFTER applying this Pull Request
Much faster initialization, also more flexible PHP extend possibilities.


### Documentation Changes Required
Yes.
