### PR TITLE
[4.0] Templates: Styles (Administrator) menu color changes on save

### DIFF
--- a/administrator/templates/atum/templateDetails.xml
+++ b/administrator/templates/atum/templateDetails.xml
@@ -73,7 +73,7 @@
 					name="text-dark"
 					type="color"
 					label="TPL_ATUM_COLORS_SETTINGS_TEXT_DARK_LABEL"
-					default="#3b4a5c"
+					default="#495057"
 					filter="color"
 				/>
 				<field
@@ -94,7 +94,7 @@
 					name="sidebar-link-color"
 					type="color"
 					label="TPL_ATUM_COLORS_SETTINGS_LINK_SIDEBAR_COLOR_LABEL"
-					default="#3b4a5c"
+					default="#132f53"
 					filter="color"
 				/>
 				<field


### PR DESCRIPTION
PR for #29958

The values in the XML are different to those in the variables.scss when they should be the same

As no reply from @coolcat-creations or @angieradtke to confirm which is the correct version I took the choice to make the xml match the scss https://github.com/joomla/joomla-cms/issues/29958#issuecomment-653785030

