### PR TITLE
[4.0] Media Manager close preview

### DIFF
--- a/administrator/components/com_media/resources/scripts/components/modals/modal.vue
+++ b/administrator/components/com_media/resources/scripts/components/modals/modal.vue
@@ -2,11 +2,11 @@
     <div class="media-modal-backdrop" @click="close()">
         <div class="modal" @click.stop style="display: flex">
 			<tab-lock>
-				<slot name="backdrop-close"></slot>
 				<div class="modal-dialog" :class="modalClass" role="dialog" :aria-labelledby="labelElement">
 					<div class="modal-content">
 						<div class="modal-header">
 							<slot name="header"></slot>
+							<slot name="backdrop-close"></slot>
 							<button type="button" v-if="showClose" class="close" @click="close()"
 									aria-label="Close">
 								<span aria-hidden="true">&times;</span>

--- a/administrator/components/com_media/resources/styles/components/_media-modal.scss
+++ b/administrator/components/com_media/resources/styles/components/_media-modal.scss
@@ -60,8 +60,8 @@
 
 .media-preview-close {
   position: absolute;
-  top: 0;
-  right: 0;
+  bottom: 100%;
+  left: 100%;
   font-size: 2rem;
   color: inherit;
   background: none;

--- a/administrator/components/com_media/resources/styles/components/_media-modal.scss
+++ b/administrator/components/com_media/resources/styles/components/_media-modal.scss
@@ -62,8 +62,7 @@
   position: absolute;
   top: 0;
   right: 0;
-  margin: 5px 20px;
-  font-size: 3rem;
+  font-size: 2rem;
   color: inherit;
   background: none;
   border: 0;


### PR DESCRIPTION
Pull Request for Issue #29434 .

### Summary of Changes
Close button moved from top right of the screen and detached from the image to the top right of the image itself 


### Testing Instructions
npm ci
Preview any image in the media manager


### Actual result BEFORE applying this Pull Request
![image](https://user-images.githubusercontent.com/1296369/94863642-ab13a780-0432-11eb-88b7-f59ca2c66323.png)



### Expected result AFTER applying this Pull Request
![image](https://user-images.githubusercontent.com/1296369/94863543-81f31700-0432-11eb-9ae3-3c0e6733bf23.png)



### Documentation Changes Required

