### PR TITLE
[4.0] sticky sidebar menu

### DIFF
--- a/administrator/templates/atum/index.php
+++ b/administrator/templates/atum/index.php
@@ -121,7 +121,7 @@ Text::script('TPL_ATUM_MORE_ELEMENTS');
 		</button>
 
 		<div id="sidebar-wrapper" class="sidebar-wrapper sidebar-menu" <?php echo $hiddenMenu ? 'data-hidden="' . $hiddenMenu . '"' : ''; ?>>
-			<div id="sidebarmenu">
+			<div id="sidebarmenu" class="sidebar-sticky">
 				<div class="sidebar-toggle item item-level-1">
 					<a id="menu-collapse" href="#" aria-label="<?php echo Text::_('JTOGGLE_SIDEBAR_MENU'); ?>">
 						<span id="menu-collapse-icon" class="fas fa-toggle-off fa-fw" aria-hidden="true"></span>

--- a/administrator/templates/atum/scss/blocks/_sidebar.scss
+++ b/administrator/templates/atum/scss/blocks/_sidebar.scss
@@ -6,6 +6,11 @@
   background-color: var(--atum-sidebar-bg);
   box-shadow: $atum-box-shadow;
 
+  .sidebar-sticky {
+    position: sticky;
+    top: 0;
+  }
+
   .item {
     position: relative;
     display: flex;


### PR DESCRIPTION
On very long pages (eg install from web) as you scroll down the page the sidebar menu disappears off screen.

This PR makes the sidebar sticky so that it never scrolls out of the screen just as the subhead toolbar is sticky.

pr for #30019

### Testing Instructions
Dont forget npm ci or node build.js --compile-css

### before
![before](https://user-images.githubusercontent.com/1296369/94868800-cc2cc600-043b-11eb-8517-6c64062e4ed0.gif)

### after
![after](https://user-images.githubusercontent.com/1296369/94868858-e5ce0d80-043b-11eb-8bcc-cfeb1b5d8778.gif)
