### PR TITLE
[4.0] treeselect alerts

### DIFF
--- a/administrator/components/com_menus/tmpl/item/edit_container.php
+++ b/administrator/components/com_menus/tmpl/item/edit_container.php
@@ -103,7 +103,7 @@ $wa->useScript('joomla.treeselectmenu')
 					</li>
 				</ul>
 			<?php endif; ?>
-		<joomla-alert id="noresultsfound" type="warning" class="hidden"><?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?></joomla-alert>
+		<joomla-alert id="noresultsfound" type="warning" style="display:none"><?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?></joomla-alert>
 		<?php endif; ?>
 	</div>
 </div>

--- a/administrator/components/com_modules/tmpl/module/edit_assignment.php
+++ b/administrator/components/com_modules/tmpl/module/edit_assignment.php
@@ -129,7 +129,7 @@ $this->document->getWebAssetManager()
 						<?php endif; ?>
 					<?php endforeach; ?>
 				</ul>
-				<joomla-alert id="noresultsfound" type="warning" class="hidden"><?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?></joomla-alert>
+				<joomla-alert id="noresultsfound" type="warning" style="display:none"><?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?></joomla-alert>
 				<div class="hidden" id="treeselectmenu">
 					<div class="nav-hover treeselect-menu">
 						<div class="dropdown">


### PR DESCRIPTION
PR for #29489

### Steps to reproduce the issue
create new module
Go to Menu Assignment tab
Select "only on the pages selected"
Note the warning "No Matching Results" at the bottom of the page

### After PR Test 1
As above No warning message

### After PR Test 2
In the search box enter something that will not match a menu
Warning message correctly displayed

### Note
a js rewrite of treeselect **might** be another solution
