### PR TITLE
[4.0] Share image link

### DIFF
--- a/administrator/templates/atum/scss/blocks/_form.scss
+++ b/administrator/templates/atum/scss/blocks/_form.scss
@@ -171,3 +171,7 @@ legend {
     border-bottom-left-radius: $border-radius;
   }
 }
+
+.input-group > .form-control[readonly] {
+  margin-right: 1px
+}

--- a/administrator/templates/atum/scss/blocks/_form.scss
+++ b/administrator/templates/atum/scss/blocks/_form.scss
@@ -173,5 +173,5 @@ legend {
 }
 
 .input-group > .form-control[readonly] {
-  margin-right: 1px
+  margin-right: 1px;
 }


### PR DESCRIPTION
### Steps to reproduce the issue
Go to media manager in admin, select an image and select to get the shareable link.
click "Get shareable link"

### Expected result
When clicking the copy button, the left border doesn't disappear

### Actual result
left border of the copy button disappears on click, and on any click/selection of the actual url

Pull Request for Issue #29331

### Testing Instructions
npm ci or node build.js --compile-css

