### PR TITLE
[4.0] media manager remove xs

### DIFF
--- a/administrator/components/com_media/resources/scripts/components/toolbar/toolbar.vue
+++ b/administrator/components/com_media/resources/scripts/components/toolbar/toolbar.vue
@@ -42,7 +42,7 @@
         v-if="isGridView"
         type="button"
         class="media-toolbar-icon media-toolbar-decrease-grid-size"
-        :class="{disabled: isGridSize('xs')}"
+        :class="{disabled: isGridSize('sm')}"
         :aria-label="translate('COM_MEDIA_DECREASE_GRID')"
         @click.stop.prevent="decreaseGridSize()"
       >
@@ -127,7 +127,7 @@ export default {
       }
     },
     decreaseGridSize() {
-      if (!this.isGridSize('xs')) {
+      if (!this.isGridSize('sm')) {
         this.$store.commit(types.DECREASE_GRID_SIZE);
       }
     },

--- a/administrator/components/com_media/resources/scripts/store/mutations.es6.js
+++ b/administrator/components/com_media/resources/scripts/store/mutations.es6.js
@@ -8,7 +8,7 @@ const nodePath = require('path');
 // and it will receive the state as the first argument.
 
 // The grid item sizes
-const gridItemSizes = ['xs', 'sm', 'md', 'lg', 'xl'];
+const gridItemSizes = ['sm', 'md', 'lg', 'xl'];
 
 export default {
 

--- a/administrator/components/com_media/resources/styles/components/_media-browser.scss
+++ b/administrator/components/com_media/resources/styles/components/_media-browser.scss
@@ -23,9 +23,6 @@
   margin-bottom: $grid-gutter-width;
   cursor: pointer;
   user-select: none;
-  .media-browser-items-xs & {
-    width: calc(#{$grid-item-width-xs} - #{$grid-gutter-width});
-  }
   .media-browser-items-sm & {
     width: calc(#{$grid-item-width-sm} - #{$grid-gutter-width});
   }

--- a/administrator/components/com_media/resources/styles/variables.scss
+++ b/administrator/components/com_media/resources/styles/variables.scss
@@ -44,7 +44,6 @@ $grid-item-icon-color-hover:        rgba(0,0,0,.8);
 $grid-item-icon-bg-color-hover:     #fff;
 $grid-item-icon-warning-icon-bg:    #d9534f;
 $grid-item-no-preview-bg:           #f5f5f5;
-$grid-item-width-xs:                8.333%;
 $grid-item-width-sm:                12.5%;
 $grid-item-width-md:                16.666%;
 $grid-item-width-lg:                25%;

--- a/tests/Codeception/acceptance/administrator/components/com_media/MediaListCest.php
+++ b/tests/Codeception/acceptance/administrator/components/com_media/MediaListCest.php
@@ -834,8 +834,6 @@ class MediaListCest
 		$I->seeElement(MediaListPage::$itemsContainerMedium);
 		$I->click(MediaListPage::$decreaseThumbnailSizeButton);
 		$I->seeElement(MediaListPage::$itemsContainerSmall);
-		$I->click(MediaListPage::$decreaseThumbnailSizeButton);
-		$I->seeElement(MediaListPage::$itemsContainerExtraSmall);
 		$I->seeElement(MediaListPage::$decreaseThumbnailSizeButtonDisabled);
 	}
 


### PR DESCRIPTION
PR for #29332

### Steps to reproduce the issue
Got to media manager of a folder
Make sure the information block is displayed by clickin on the i icon in the toolbar
use the zoom out button as far as you can zoom out
Hover over an image or folder

### Expected result
nice display 
![image](https://user-images.githubusercontent.com/1296369/94917678-e2bd3680-04a8-11eb-966f-cba6dc7d3558.png)

### Actual result
When image list zoomed out to maximum zoom there is not enough room for both squares
![image](https://user-images.githubusercontent.com/1296369/94917717-fd8fab00-04a8-11eb-9c95-06c0eccfa52e.png)

### Summary of changes
This PR removes the smallest zoom level

### Test instructions
Don't forget to run npm ci