### PR TITLE
[4.0] media manager transparent preview

### DIFF
--- a/administrator/components/com_media/resources/scripts/components/modals/preview-modal.vue
+++ b/administrator/components/com_media/resources/scripts/components/modals/preview-modal.vue
@@ -1,7 +1,7 @@
 <template>
     <media-modal v-if="$store.state.showPreviewModal && item" :size="'md'" @close="close()" class="media-preview-modal" label-element="previewTitle" :show-close="false">
         <h3 slot="header" id="previewTitle" class="modal-title">{{ item.name }}</h3>
-        <div slot="body">
+        <div slot="body" class="image-background">
             <img :src="item.url" v-if="isImage()" :type="item.mime_type"/>
             <video controls v-if="isVideo()">
                 <source :src="item.url" :type="item.mime_type">


### PR DESCRIPTION
The media manager uses a background of checked squares in the thumbnail view which is useful when you have a transparent image such as the joomla_black.png

However in the preview it uses a solid white background which hides most of this image.

This pr replaces the white background with the checked squares

Dont forget to run npm ci

### Before
![image](https://user-images.githubusercontent.com/1296369/94918771-2153f080-04ab-11eb-88c1-e901bf44e512.png)

### After
![image](https://user-images.githubusercontent.com/1296369/94918738-126d3e00-04ab-11eb-8bf6-d1327d2094ef.png)
