### PR TITLE
[4.0] ATUM prefers-reduced-motion [a11y]

### DIFF
--- a/administrator/templates/atum/scss/template.scss
+++ b/administrator/templates/atum/scss/template.scss
@@ -74,12 +74,12 @@
 // Forcing reduced motion when set in the user OS
 @media (prefers-reduced-motion: reduce) {
   *, ::before, ::after {
-    animation-delay: -1ms !important;
-    animation-duration: 1ms !important;
-    animation-iteration-count: 1 !important;
     background-attachment: initial !important;
+    animation-duration: 1ms !important;
+    animation-delay: -1ms !important;
+    animation-iteration-count: 1 !important;
     scroll-behavior: auto !important;
-    transition-duration: 0s !important;
     transition-delay: 0s !important;
+    transition-duration: 0s !important;
   }
 }

--- a/administrator/templates/atum/scss/template.scss
+++ b/administrator/templates/atum/scss/template.scss
@@ -75,11 +75,11 @@
 @media (prefers-reduced-motion: reduce) {
   *, ::before, ::after {
     background-attachment: initial !important;
+    transition-delay: 0s !important;
+    transition-duration: 0s !important;
     animation-duration: 1ms !important;
     animation-delay: -1ms !important;
     animation-iteration-count: 1 !important;
     scroll-behavior: auto !important;
-    transition-delay: 0s !important;
-    transition-duration: 0s !important;
   }
 }

--- a/administrator/templates/atum/scss/template.scss
+++ b/administrator/templates/atum/scss/template.scss
@@ -70,3 +70,16 @@
 @import "pages/com_privacy";
 @import "pages/com_templates";
 @import "pages/com_users";
+
+// Forcing reduced motion when set in the user OS
+@media (prefers-reduced-motion: reduce) {
+  *, ::before, ::after {
+    animation-delay: -1ms !important;
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    background-attachment: initial !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0s !important;
+    transition-delay: 0s !important;
+  }
+}


### PR DESCRIPTION
Applies a global css rule to support users who have set prefers-reduced-motion in their operating system.

### Testing
1. Apply PR and npm ci or node build.js --compile-css

2. Set prefers reduced motion in your operating system
- In Windows 10: Settings > Ease of Access > Display > Show animations in Windows.
- In macOS: System Preferences > Accessibility > Display > Reduce motion.

**Toggle the menu sidebar**
If working correctly it will be a smooth transition if animations are on and it will be an immediate close if animations are off

**Origin of the chosen css**
https://web.dev/prefers-reduced-motion/#(bonus)-forcing-reduced-motion-on-all-websites

Also solves Issue #28206
