### PR TITLE
Make authorization header case insensitive in API

### DIFF
--- a/plugins/api-authentication/token/token.php
+++ b/plugins/api-authentication/token/token.php
@@ -91,12 +91,12 @@ class PlgApiAuthenticationToken extends CMSPlugin
 		if (empty($authHeader) && \PHP_SAPI === 'apache2handler'
 			&& function_exists('apache_request_headers') && apache_request_headers() !== false)
 		{
-			$apacheHeaders = \apache_request_headers();
+			$apacheHeaders = array_change_key_case(\apache_request_headers(), CASE_LOWER);
 
-			if (array_key_exists('Authorization', $apacheHeaders))
+			if (array_key_exists('authorization', $apacheHeaders))
 			{
 				$filter = \Joomla\CMS\Filter\InputFilter::getInstance();
-				$authHeader = $filter->clean($apacheHeaders['Authorization'], 'STRING');
+				$authHeader = $filter->clean($apacheHeaders['authorization'], 'STRING');
 			}
 		}
 


### PR DESCRIPTION
This change makes the authorization header case insensitive.

In the IETF standsrds docs at https://tools.ietf.org/html/rfc2616#section-4.2 it states that "Field names are case-insensitive."

See issue...
Auth headers in Joomla 4 API should maybe be case insensitive #30871

This means, both...
`curl --location --request GET 'http://MYDOMAIN//api/index.php/v1/content/article' --header 'Authorization: Bearer MY_API_TOKEN_HERE'`
...and...
`curl --location --request GET 'http://MYDOMAIN/api/index.php/v1/content/article' --header 'authorization: Bearer MY_API_TOKEN_HERE' `
...both work.

Pull Request for Issue # .

### Summary of Changes
This change makes the authorization header case insensitive in the API when using Bearer token. 


### Testing Instructions

1) Set up a test site at http://localhost/joomla/joomla_4_beta_4

2) Get a Joomla API Token, from, for example https://localhost/joomla/joomla_4_beta_4/administrator/index.php?option=com_users&view=users

3) Do an uppercase test...
`curl --location --request GET 'http://MYDOMAIN//api/index.php/v1/content/article' --header 'Authorization: Bearer MY_API_TOKEN_HERE'`

4) Do a lowercases test...
`curl --location --request GET 'http://MYDOMAIN/api/index.php/v1/content/article' --header 'authorization: Bearer MY_API_TOKEN_HERE' `


### Actual result BEFORE applying this Pull Request
Uppercase test gets a good json response of article content
Lowercase gets an gets a 406 response


### Expected result AFTER applying this Pull Request
Uppercase test gets a good json response of article content
Lowercase test gets a good json response of article content


### Documentation Changes Required
None
