### PR TITLE
[4.0] Fix pagebreak modal missing style

### DIFF
--- a/administrator/components/com_content/tmpl/article/pagebreak.php
+++ b/administrator/components/com_content/tmpl/article/pagebreak.php
@@ -28,7 +28,7 @@ $this->document->setTitle(Text::_('COM_CONTENT_PAGEBREAK_DOC_TITLE'));
 				<label for="title"><?php echo Text::_('COM_CONTENT_PAGEBREAK_TITLE'); ?></label>
 			</div>
 			<div class="controls">
-				<input type="text" id="title" name="title">
+				<input class="form-control" type="text" id="title" name="title">
 			</div>
 		</div>
 		<div class="control-group">
@@ -36,7 +36,7 @@ $this->document->setTitle(Text::_('COM_CONTENT_PAGEBREAK_DOC_TITLE'));
 				<label for="alias"><?php echo Text::_('COM_CONTENT_PAGEBREAK_TOC'); ?></label>
 			</div>
 			<div class="controls">
-				<input type="text" id="alt" name="alt">
+				<input class="form-control" type="text" id="alt" name="alt">
 			</div>
 		</div>
 


### PR DESCRIPTION
Pull Request for Issue #30877.

### Testing Instructions
Edit article in Joomla 4 admin
Click `CMS Content` in wysiwyg edit
Click `Page Break`
See fields without styling in modal
