### PR TITLE
[4.0] size of the template name font in module position selector

### DIFF
--- a/administrator/templates/atum/scss/vendor/choicesjs/choices.scss
+++ b/administrator/templates/atum/scss/vendor/choicesjs/choices.scss
@@ -177,3 +177,7 @@
     padding: .2rem 0;
   }
 }
+
+.choices__heading {
+  font-size: 1.2rem;
+}

--- a/templates/cassiopeia/scss/vendor/choicesjs/choices.scss
+++ b/templates/cassiopeia/scss/vendor/choicesjs/choices.scss
@@ -116,3 +116,7 @@
     }
   }
 }
+
+.choices__heading {
+  font-size: 1.2rem;
+}


### PR DESCRIPTION


PR for #30844

The heading should be visibly disabled larger than the items

### before
![image](https://user-images.githubusercontent.com/1296369/94972328-f1cfd300-0500-11eb-8d81-2b91f0521eb5.png)

### after
![image](https://user-images.githubusercontent.com/1296369/94972301-e2e92080-0500-11eb-9af5-acd971eaaaba.png)

### testing
dont forget npm ci or node build.js --compile-css
