### PR TITLE
[4.0] xtd-editor button for module

### DIFF
--- a/plugins/editors-xtd/module/module.php
+++ b/plugins/editors-xtd/module/module.php
@@ -57,7 +57,7 @@ class PlgButtonModule extends CMSPlugin
 			$button->modal   = true;
 			$button->link    = $link;
 			$button->text    = Text::_('PLG_MODULE_BUTTON_MODULE');
-			$button->name    = 'file-add22';
+			$button->name    = 'cube';
 			$button->iconSVG  = '<svg viewBox="0 0 512 512" width="24" height="24"><path d="M239.1 6.3l-208 78c-18.7 7-31.1 '
 				. '25-31.1 45v225.1c0 18.2 10.3 34.8 26.5 42.9l208 104c13.5 6.8 29.4 6.8 42.9 0l208-104c16.3-8.1 26.5-24.8 '
 				. '26.5-42.9V129.3c0-20-12.4-37.9-31.1-44.9l-208-78C262 2.2 250 2.2 239.1 6.3zM256 68.4l192 72v1.1l-192 '

--- a/plugins/editors-xtd/module/module.php
+++ b/plugins/editors-xtd/module/module.php
@@ -57,9 +57,11 @@ class PlgButtonModule extends CMSPlugin
 			$button->modal   = true;
 			$button->link    = $link;
 			$button->text    = Text::_('PLG_MODULE_BUTTON_MODULE');
-			$button->name    = 'file-add';
-			$button->iconSVG  = '<svg viewBox="0 0 32 32" width="24" height="24"><path d="M28 24v-4h-4v4h-4v4h4v4h4v-4h4v-4zM2 2h18v6h6v10h2v-10'
-								. 'l-8-8h-20v32h18v-2h-16z"></path></svg>';
+			$button->name    = 'file-add22';
+			$button->iconSVG  = '<svg viewBox="0 0 512 512" width="24" height="24"><path d="M239.1 6.3l-208 78c-18.7 7-31.1 '
+				. '25-31.1 45v225.1c0 18.2 10.3 34.8 26.5 42.9l208 104c13.5 6.8 29.4 6.8 42.9 0l208-104c16.3-8.1 26.5-24.8 '
+				. '26.5-42.9V129.3c0-20-12.4-37.9-31.1-44.9l-208-78C262 2.2 250 2.2 239.1 6.3zM256 68.4l192 72v1.1l-192 '
+				. '78-192-78v-1.1l192-72zm32 356V275.5l160-65v133.9l-160 80z"></path></svg>';
 			$button->options = [
 				'height'     => '300px',
 				'width'      => '800px',


### PR DESCRIPTION
The icon used was the same as the one for articles. This PR changes it to be the cube that is used in the module manager.

Pull Request for Issue #30863 .

### before
![image](https://user-images.githubusercontent.com/1296369/94973731-56d8f800-0504-11eb-8f18-d1bc7e6c6412.png)


### after
![image](https://user-images.githubusercontent.com/1296369/94973708-49237280-0504-11eb-9164-e57b1b617aa8.png)
