### PR TITLE
Joomla\CMS\Installation\Helper\ArrayHelper not found

### DIFF
--- a/installation/src/Helper/DatabaseHelper.php
+++ b/installation/src/Helper/DatabaseHelper.php
@@ -17,6 +17,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\User\UserHelper;
 use Joomla\Database\DatabaseDriver;
 use Joomla\Database\DatabaseInterface;
+use Joomla\Utilities\ArrayHelper;
 
 /**
  * Joomla Installation Database Helper Class.


### PR DESCRIPTION
[4.0b4] Class 'Joomla\CMS\Installation\Helper\ArrayHelper' not found


Pull Request for Issue #30900.

### Summary of Changes
missing `use` statement causes opaque error during installation


### Testing Instructions
added missing line
ran new installation successfully


### Actual result BEFORE applying this Pull Request
Error message `Class 'Joomla\CMS\Installation\Helper\ArrayHelper' not found` on installation screen after clicking "install joomla" button".


### Expected result AFTER applying this Pull Request
Successful install


### Documentation Changes Required
None
