### PR TITLE
[4.0] Make sure hsts is only added on https sites

### DIFF
--- a/plugins/system/httpheaders/httpheaders.php
+++ b/plugins/system/httpheaders/httpheaders.php
@@ -488,8 +488,8 @@ class PlgSystemHttpHeaders extends CMSPlugin implements SubscriberInterface
 			$staticHeaderConfiguration['cross-origin-opener-policy#both'] = $coop;
 		}
 
-		// Generate the strict-transport-security header
-		if ($this->params->get('hsts', 0) === 1)
+		// Generate the strict-transport-security header and make sure the site is SSL
+		if ($this->params->get('hsts', 0) === 1 && Uri::getInstance()->isSsl() === true)
 		{
 			$hstsOptions   = [];
 			$hstsOptions[] = 'max-age=' . (int) $this->params->get('hsts_maxage', 31536000);


### PR DESCRIPTION
Pull Request for Issue #30886

### Summary of Changes

Make sure hsts is only added on https sites

### Testing Instructions

- install 4.x on a http site (localhost for example)
- enable hsts from the plugin
- notice it is added to the header
- apply this patch
- see its gone
- install this patch on a https site
- make sure the hsts header is still added

### Actual result BEFORE applying this Pull Request

HSTS is added on http sites

### Expected result AFTER applying this Pull Request

HSTS is only added on https site.

### Documentation Changes Required

None