### PR TITLE
[4] Add generic AJAX error message translation

### DIFF
--- a/administrator/templates/atum/login.php
+++ b/administrator/templates/atum/login.php
@@ -62,6 +62,8 @@ HTMLHelper::_('atum.rootcolors', $this->params);
 
 // Add cookie alert message
 Text::script('JGLOBAL_WARNCOOKIES');
+// Add generic AJAX error message
+Text::script('JLIB_JS_AJAX_ERROR_OTHER');
 ?>
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">


### PR DESCRIPTION
Pull Request for Issue #30896

### Summary of Changes

Add dependancy so that generic Ajax error messages are translated.

### Testing Instructions

see #30896

### Actual result BEFORE applying this Pull Request

error is untranslated `JLIB_JS_AJAX_ERROR_OTHER`

### Expected result AFTER applying this Pull Request

<img width="1156" alt="94988693-70fbf000-056f-11eb-878a-f5aeb8af77f7" src="https://user-images.githubusercontent.com/400092/94995481-715bb180-0596-11eb-8c7a-e3aa0ad2c704.png">


### Documentation Changes Required

None

@infograf768 