### PR TITLE
[4.0] Fix media manage console error

### DIFF
--- a/administrator/components/com_media/resources/scripts/components/browser/items/directory.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/directory.vue
@@ -94,7 +94,7 @@
            /* Hide actions dropdown */
            hideActions() {
                this.showActions = false;
-               this.$nextTick(() => this.$refs.actionToggle.focus());
+               this.$nextTick(() => { this.$refs.actionToggle ? this.$refs.actionToggle.focus() : false });
            },
         }
     }


### PR DESCRIPTION
Pull Request for Issue #30891 .

### Summary of Changes

No ref to non existing elements (v-if)

### Testing Instructions

(from the issue):

Joomla4 admin -> Content -> Media

(Check you are on the Images tab in the breadcrumbs, the top most folder, if you have been messing before).

Reload the page manually to ensure you are all JS loaded.

Double click on "Banners" folder... hold mouse steady.... folder will load... move mouse = JS error logged.

TypeError: undefined is not an object (evaluating 'this.$refs.actionToggle.focus')

### Actual result BEFORE applying this Pull Request
Errors logged in the browser console


### Expected result AFTER applying this Pull Request
No errors logged in the browser console


### Documentation Changes Required

No