### PR TITLE
FoF and PHP 8

### DIFF
--- a/libraries/fof/controller/controller.php
+++ b/libraries/fof/controller/controller.php
@@ -4,6 +4,7 @@
  * @subpackage controller
  * @copyright   Copyright (C) 2010-2016 Nicholas K. Dionysopoulos / Akeeba Ltd. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @note        This file has been modified by the Joomla! Project and no longer reflects the original work of its author.
  */
 
 // Protect from unauthorized access
@@ -2153,7 +2154,7 @@ class FOFController extends FOFUtilsObject
 	 *
 	 * @return  boolean  Returns true on success
 	 */
-	final private function applySave()
+	private function applySave()
 	{
 		// Load the model
 		$model = $this->getThisModel();

--- a/libraries/fof/controller/controller.php
+++ b/libraries/fof/controller/controller.php
@@ -4,7 +4,7 @@
  * @subpackage  controller
  * @copyright   Copyright (C) 2010-2016 Nicholas K. Dionysopoulos / Akeeba Ltd. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
- * @note        This file has been modified by the Joomla! Project and no longer reflects the original work of its author.
+ * @note       This file has been modified by the Joomla! Project and no longer reflects the original work of its author.
  */
 
 // Protect from unauthorized access

--- a/libraries/fof/controller/controller.php
+++ b/libraries/fof/controller/controller.php
@@ -4,7 +4,7 @@
  * @subpackage  controller
  * @copyright   Copyright (C) 2010-2016 Nicholas K. Dionysopoulos / Akeeba Ltd. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
- * @note       This file has been modified by the Joomla! Project and no longer reflects the original work of its author.
+ * @note        This file has been modified by the Joomla! Project and no longer reflects the original work of its author.
  */
 
 // Protect from unauthorized access

--- a/libraries/fof/controller/controller.php
+++ b/libraries/fof/controller/controller.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * @package    FrameworkOnFramework
- * @subpackage controller
+ * @package     FrameworkOnFramework
+ * @subpackage  controller
  * @copyright   Copyright (C) 2010-2016 Nicholas K. Dionysopoulos / Akeeba Ltd. All rights reserved.
- * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
  * @note        This file has been modified by the Joomla! Project and no longer reflects the original work of its author.
  */
 

--- a/libraries/fof/database/iterator.php
+++ b/libraries/fof/database/iterator.php
@@ -4,6 +4,7 @@
  * @subpackage  database
  * @copyright   Copyright (C) 2010-2016 Nicholas K. Dionysopoulos / Akeeba Ltd. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ * @note        This file has been modified by the Joomla! Project and no longer reflects the original work of its author.
  *
  * This file is adapted from the Joomla! Platform. It is used to iterate a database cursor returning FOFTable objects
  * instead of plain stdClass objects
@@ -86,7 +87,7 @@ abstract class FOFDatabaseIterator implements Iterator
 	 *
 	 * @throws  InvalidArgumentException
 	 */
-	public static function &getIterator($dbName, $cursor, $column = null, $class, $config = array())
+	public static function &getIterator($dbName, $cursor, $column, $class, $config = array())
 	{
 		$className = 'FOFDatabaseIterator' . ucfirst($dbName);
 
@@ -105,7 +106,7 @@ abstract class FOFDatabaseIterator implements Iterator
 	 *
 	 * @throws  InvalidArgumentException
 	 */
-	public function __construct($cursor, $column = null, $class, $config = array())
+	public function __construct($cursor, $column, $class, $config = array())
 	{
 		// Figure out the type and prefix of the class by the class name
 		$parts = FOFInflector::explode($class);

--- a/libraries/fof/layout/helper.php
+++ b/libraries/fof/layout/helper.php
@@ -23,6 +23,7 @@ class FOFLayoutHelper extends JLayoutHelper
 	 * @param   string  $layoutFile   Dot separated path to the layout file, relative to base path
 	 * @param   object  $displayData  Object which properties are used inside the layout file to build displayed output
 	 * @param   string  $basePath     Base path to use when loading layout files
+	 * @param   mixed   $options      Optional custom options to load. Registry or array format
 	 *
 	 * @return  string
 	 */

--- a/libraries/fof/layout/helper.php
+++ b/libraries/fof/layout/helper.php
@@ -33,7 +33,7 @@ class FOFLayoutHelper extends JLayoutHelper
 
 		// Make sure we send null to FOFLayoutFile if no path set
 		$basePath = empty($basePath) ? null : $basePath;
-		$layout = new FOFLayoutFile($layoutFile, $basePath);
+		$layout = new FOFLayoutFile($layoutFile, $basePath, $options);
 		$renderedLayout = $layout->render($displayData);
 
 		return $renderedLayout;

--- a/libraries/fof/layout/helper.php
+++ b/libraries/fof/layout/helper.php
@@ -4,6 +4,7 @@
  * @subpackage  layout
  * @copyright   Copyright (C) 2010-2016 Nicholas K. Dionysopoulos / Akeeba Ltd. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ * @note        This file has been modified by the Joomla! Project and no longer reflects the original work of its author.
  */
 // Protect from unauthorized access
 defined('FOF_INCLUDED') or die;
@@ -25,7 +26,7 @@ class FOFLayoutHelper extends JLayoutHelper
 	 *
 	 * @return  string
 	 */
-	public static function render($layoutFile, $displayData = null, $basePath = '')
+	public static function render($layoutFile, $displayData = null, $basePath = '', $options = null)
 	{
 		$basePath = empty($basePath) ? self::$defaultBasePath : $basePath;
 

--- a/libraries/fof/table/relations.php
+++ b/libraries/fof/table/relations.php
@@ -4,6 +4,7 @@
  * @subpackage  table
  * @copyright   Copyright (C) 2010-2016 Nicholas K. Dionysopoulos / Akeeba Ltd. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ * @note        This file has been modified by the Joomla! Project and no longer reflects the original work of its author.
  */
 
 // Protect from unauthorized access
@@ -898,7 +899,7 @@ class FOFTableRelations
 	 *
 	 * @return  void
 	 */
-	protected function normaliseParameters($pivot = false, &$itemName, &$tableClass, &$localKey, &$remoteKey, &$ourPivotKey, &$theirPivotKey, &$pivotTable)
+	protected function normaliseParameters($pivot, &$itemName, &$tableClass, &$localKey, &$remoteKey, &$ourPivotKey, &$theirPivotKey, &$pivotTable)
 	{
 		// Get a default table class if none is provided
 		if (empty($tableClass))


### PR DESCRIPTION
### Summary of Changes

Fixes a fatal error, a warning and deprecation notices on PHP 8.

```
Warning: Private methods cannot be final as they are never overridden by other classes in libraries\fof\controller\controller.php on line 2156
Deprecated: Required parameter $class follows optional parameter $column in libraries\fof\database\iterator.php on line 89
Deprecated: Required parameter $class follows optional parameter $column in libraries\fof\database\iterator.php on line 108
Fatal error: Declaration of FOFLayoutHelper::render($layoutFile, $displayData = null, $basePath = '') must be compatible with Joomla\CMS\Layout\LayoutHelper::render($layoutFile, $displayData = null, $basePath = '', $options = null) in libraries\fof\layout\helper.php on line 28
Deprecated: Required parameter $itemName follows optional parameter $pivot in libraries\fof\table\relations.php on line 901
Deprecated: Required parameter $tableClass follows optional parameter $pivot in libraries\fof\table\relations.php on line 901
Deprecated: Required parameter $localKey follows optional parameter $pivot in libraries\fof\table\relations.php on line 901
Deprecated: Required parameter $remoteKey follows optional parameter $pivot in libraries\fof\table\relations.php on line 901
Deprecated: Required parameter $ourPivotKey follows optional parameter $pivot in libraries\fof\table\relations.php on line 901
Deprecated: Required parameter $theirPivotKey follows optional parameter $pivot in libraries\fof\table\relations.php on line 901
Deprecated: Required parameter $pivotTable follows optional parameter $pivot in libraries\fof\table\relations.php on line 901
```

### Testing Instructions


### Documentation Changes Required

Developers who extended `FOFLayoutHelper` should note they need to add an additional argument to its `render()` method to support PHP 8.