### PR TITLE
[4.0] Button text double translation

### DIFF
--- a/administrator/components/com_content/src/View/Article/HtmlView.php
+++ b/administrator/components/com_content/src/View/Article/HtmlView.php
@@ -152,7 +152,7 @@ class HtmlView extends BaseHtmlView
 
 					if ($user->authorise('core.create', 'com_menus.menu'))
 					{
-						$childBar->save('article.save2menu', Text::_('JTOOLBAR_SAVE_TO_MENU'));
+						$childBar->save('article.save2menu', 'JTOOLBAR_SAVE_TO_MENU');
 					}
 
 					$childBar->save2new('article.save2new');
@@ -191,7 +191,7 @@ class HtmlView extends BaseHtmlView
 					// If checked out, we can still save2menu
 					if ($user->authorise('core.create', 'com_menus.menu'))
 					{
-						$childBar->save('article.save2menu', Text::_('JTOOLBAR_SAVE_TO_MENU'));
+						$childBar->save('article.save2menu', 'JTOOLBAR_SAVE_TO_MENU');
 					}
 
 					// If checked out, we can still save


### PR DESCRIPTION
Enable language debug
Open an article
On the save button dropdown you will see `??**Save to Menu**??`

Apply the PR
Now the button is correctly displayed as `**Save to Menu**`

![image](https://user-images.githubusercontent.com/1296369/95177445-1902fa80-07b6-11eb-89a1-bf7d2209b5ea.png)
