### PR TITLE
[3.x] Added some missing deprecations

### DIFF
--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -302,6 +302,19 @@ class CMSApplication extends WebApplication
 	 */
 	public function getCfg($varname, $default = null)
 	{
+		try
+		{
+			\JLog::add(
+				sprintf('%s() is deprecated. Use JFactory->getApplication()->get() instead.', __METHOD__),
+				\JLog::WARNING,
+				'deprecated'
+			);
+		}
+		catch (RuntimeException $exception)
+		{
+			// Informational log only
+		}
+
 		return $this->get($varname, $default);
 	}
 
@@ -636,6 +649,19 @@ class CMSApplication extends WebApplication
 	 */
 	public function isAdmin()
 	{
+		try
+		{
+			\JLog::add(
+				sprintf("%s() is deprecated. Use JFactory->getApplication()->isClient('administrator') instead.", __METHOD__),
+				\JLog::WARNING,
+				'deprecated'
+			);
+		}
+		catch (RuntimeException $exception)
+		{
+			// Informational log only
+		}
+
 		return $this->isClient('administrator');
 	}
 
@@ -649,6 +675,19 @@ class CMSApplication extends WebApplication
 	 */
 	public function isSite()
 	{
+		try
+		{
+			\JLog::add(
+				sprintf("%s() is deprecated. Use JFactory->getApplication()->isClient('site') instead.", __METHOD__),
+				\JLog::WARNING,
+				'deprecated'
+			);
+		}
+		catch (RuntimeException $exception)
+		{
+			// Informational log only
+		}
+
 		return $this->isClient('site');
 	}
 

--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -305,7 +305,7 @@ class CMSApplication extends WebApplication
 		try
 		{
 			\JLog::add(
-				sprintf('%s() is deprecated. Use JFactory->getApplication()->get() instead.', __METHOD__),
+				sprintf('%s() is deprecated and will be removed in 4.0. Use JFactory->getApplication()->get() instead.', __METHOD__),
 				\JLog::WARNING,
 				'deprecated'
 			);
@@ -652,7 +652,7 @@ class CMSApplication extends WebApplication
 		try
 		{
 			\JLog::add(
-				sprintf("%s() is deprecated. Use JFactory->getApplication()->isClient('administrator') instead.", __METHOD__),
+				sprintf("%s() is deprecated and will be removed in 4.0. Use JFactory->getApplication()->isClient('administrator') instead.", __METHOD__),
 				\JLog::WARNING,
 				'deprecated'
 			);
@@ -678,7 +678,7 @@ class CMSApplication extends WebApplication
 		try
 		{
 			\JLog::add(
-				sprintf("%s() is deprecated. Use JFactory->getApplication()->isClient('site') instead.", __METHOD__),
+				sprintf("%s() is deprecated and will be removed in 4.0. Use JFactory->getApplication()->isClient('site') instead.", __METHOD__),
 				\JLog::WARNING,
 				'deprecated'
 			);


### PR DESCRIPTION
### Summary of Changes
Added some missing deprecations:

- `isAdmin()`
- `isSite()`
- `getCfg()`


### Testing Instructions
enable debug plugin 
enable  Log Depreated API
install some extensions that use one  ofthose deprecated methods
or simply create a dummy sistem plugin like this one

```php
class PlgSystemOldwaytest extends JPlugin
{
	function onAfterRoute()
	{
		$app = JFactory::getApplication();
		if ( $app->isAdmin() )
		{
			return;
		}
	}
}
```

### Actual result BEFORE applying this Pull Request

no depreactions logged

### Expected result AFTER applying this Pull Request



2020-10-06T09:41:08+00:00	WARNING 172.16.238.1	deprecated	Joomla\CMS\Application\CMSApplication::isAdmin() is deprecated. Use JFactory->getApplication()->isClient('administrator') instead.

