### PR TITLE
[4.1] language of parts [a11y]

### DIFF
--- a/build/build-modules-js/compilejs.es6.js
+++ b/build/build-modules-js/compilejs.es6.js
@@ -55,6 +55,8 @@ module.exports.compileJS = (options, path) => {
           },
         );
       });
+      // hack, needs a bundler
+      HandleFile.run('media/plg_editors_tinymce/js/plugins/tinymce-language-selector/plugin.es6.js');
     })
 
     // Handle errors

--- a/build/build-modules-js/init.es6.js
+++ b/build/build-modules-js/init.es6.js
@@ -2,6 +2,7 @@ const Copydir = require('copy-dir');
 const Fs = require('fs');
 const FsExtra = require('fs-extra');
 const Path = require('path');
+const { plugin } = require('postcss');
 
 const RootPath = process.cwd();
 const xmlVersionStr = /(<version>)(.+)(<\/version>)/;
@@ -232,6 +233,23 @@ const copyFiles = (options) => {
       let tinyWrongMap = Fs.readFileSync(`${RootPath}/media/vendor/tinymce/skins/ui/oxide/skin.min.css`, { encoding: 'UTF-8' });
       tinyWrongMap = tinyWrongMap.replace('/*# sourceMappingURL=skin.min.css.map */', '');
       Fs.writeFileSync(`${RootPath}/media/vendor/tinymce/skins/ui/oxide/skin.min.css`, tinyWrongMap, { encoding: 'UTF-8' });
+    } else if (packageName === 'tinymce-language-selector') {
+      // const itemvendorPath = Path.join(RootPath, `media/vendor/${packageName}`);
+
+      // if (!FsExtra.existsSync(itemvendorPath)) {
+      //   FsExtra.mkdirSync(itemvendorPath);
+      //   FsExtra.mkdirSync(Path.join(itemvendorPath, 'tinymce-language-selector'));
+      // }
+      // eslint-disable-next-line no-console
+      console.log('################################################################');
+      concatFiles(
+        [
+          'media/vendor/tinymce-language-selector/js/constants.js',
+          'media/vendor/tinymce-language-selector/js/plugin.js',
+
+        ],
+        'media/vendor/tinymce-language-selector/plugin.js',
+      );
     } else {
       ['js', 'css', 'filesExtra'].forEach((type) => {
         if (!vendor[type]) return;

--- a/build/build-modules-js/init.es6.js
+++ b/build/build-modules-js/init.es6.js
@@ -2,7 +2,6 @@ const Copydir = require('copy-dir');
 const Fs = require('fs');
 const FsExtra = require('fs-extra');
 const Path = require('path');
-const { plugin } = require('postcss');
 
 const RootPath = process.cwd();
 const xmlVersionStr = /(<version>)(.+)(<\/version>)/;

--- a/build/build-modules-js/init.es6.js
+++ b/build/build-modules-js/init.es6.js
@@ -239,7 +239,7 @@ const copyFiles = (options) => {
         let constants = '';
         if (Fs.existsSync(Path.join(modulePathRoot, 'tinymce-language-selector/plugin.js'))) {
           constants = Fs.readFileSync(Path.join(modulePathRoot, 'tinymce-language-selector/constants.js'), { encoding: 'utf8' });
-          constants = constants.replace('export { BROWSER_DEFAULT, languages }', '');
+          constants = constants.replace('export {\n  BROWSER_DEFAULT,\n  languages\n}', '');
         }
         if (constants) {
           finalPluginCode = Fs.readFileSync(Path.join(modulePathRoot, 'tinymce-language-selector/plugin.js'), { encoding: 'utf8' });

--- a/build/build-modules-js/init.es6.js
+++ b/build/build-modules-js/init.es6.js
@@ -239,6 +239,7 @@ const copyFiles = (options) => {
         let constants = '';
         if (Fs.existsSync(Path.join(modulePathRoot, 'tinymce-language-selector/plugin.js'))) {
           constants = Fs.readFileSync(Path.join(modulePathRoot, 'tinymce-language-selector/constants.js'), { encoding: 'utf8' });
+          constants = constants.replace('export { BROWSER_DEFAULT, languages }', '');
         }
         if (constants) {
           finalPluginCode = Fs.readFileSync(Path.join(modulePathRoot, 'tinymce-language-selector/plugin.js'), { encoding: 'utf8' });

--- a/build/build-modules-js/init.es6.js
+++ b/build/build-modules-js/init.es6.js
@@ -232,23 +232,25 @@ const copyFiles = (options) => {
       let tinyWrongMap = Fs.readFileSync(`${RootPath}/media/vendor/tinymce/skins/ui/oxide/skin.min.css`, { encoding: 'UTF-8' });
       tinyWrongMap = tinyWrongMap.replace('/*# sourceMappingURL=skin.min.css.map */', '');
       Fs.writeFileSync(`${RootPath}/media/vendor/tinymce/skins/ui/oxide/skin.min.css`, tinyWrongMap, { encoding: 'UTF-8' });
-    } else if (packageName === 'tinymce-language-selector') {
-      // const itemvendorPath = Path.join(RootPath, `media/vendor/${packageName}`);
+    } else if (packageName === '@edx/tinymce-language-selector') {
+      // This whole section actually needs a bundler like rollup
+      let finalPluginCode = '';
+      if (Fs.existsSync(Path.join(modulePathRoot, 'tinymce-language-selector/plugin.js'))) {
+        let constants = '';
+        if (Fs.existsSync(Path.join(modulePathRoot, 'tinymce-language-selector/plugin.js'))) {
+          constants = Fs.readFileSync(Path.join(modulePathRoot, 'tinymce-language-selector/constants.js'), { encoding: 'utf8' });
+        }
+        if (constants) {
+          finalPluginCode = Fs.readFileSync(Path.join(modulePathRoot, 'tinymce-language-selector/plugin.js'), { encoding: 'utf8' });
+          finalPluginCode = finalPluginCode.replace('import { BROWSER_DEFAULT, languages } from \'./constants\';', constants);
 
-      // if (!FsExtra.existsSync(itemvendorPath)) {
-      //   FsExtra.mkdirSync(itemvendorPath);
-      //   FsExtra.mkdirSync(Path.join(itemvendorPath, 'tinymce-language-selector'));
-      // }
-      // eslint-disable-next-line no-console
-      console.log('################################################################');
-      concatFiles(
-        [
-          'media/vendor/tinymce-language-selector/js/constants.js',
-          'media/vendor/tinymce-language-selector/js/plugin.js',
+          FsExtra.mkdirpSync('media/plg_editors_tinymce/js/plugins/tinymce-language-selector');
 
-        ],
-        'media/vendor/tinymce-language-selector/plugin.js',
-      );
+          Fs.writeFileSync('media/plg_editors_tinymce/js/plugins/tinymce-language-selector/plugin.es6.js', finalPluginCode, { encoding: 'utf8' });
+
+          FsExtra.mkdirpSync('media/vendor/tinymce-language-selector/js');
+        }
+      }
     } else {
       ['js', 'css', 'filesExtra'].forEach((type) => {
         if (!vendor[type]) return;

--- a/build/build-modules-js/javascript/minify-vendor.es6.js
+++ b/build/build-modules-js/javascript/minify-vendor.es6.js
@@ -14,6 +14,7 @@ module.exports.compile = () => {
       const folders = [
         Path.join(RootPath, 'media/vendor/codemirror'),
         Path.join(RootPath, 'media/vendor/punycode/js'),
+        Path.join(RootPath, 'media/vendor/tinymce-language-selector/js'),
         Path.join(RootPath, 'media/vendor/webcomponentsjs'),
       ];
 

--- a/build/build-modules-js/settings.json
+++ b/build/build-modules-js/settings.json
@@ -97,6 +97,27 @@
         "dependencies": [],
         "licenseFilename": "LICENSE"
       },
+      "@edx/tinymce-language-selector": {
+        "name": "tinymce-language-selector",
+        "js": {
+          "tinymce-language-selector/constants.js": "js/constants.js",
+          "tinymce-language-selector/plugin.js": "js/plugin.js"
+        },
+        "provideAssets": [
+          {
+            "name": "constants",
+            "type": "script",
+            "uri": "constants.js"
+          },
+          {
+            "name": "plugin",
+            "type": "script",
+            "uri": "plugin.js"
+          }
+        ],
+        "dependencies": [],
+        "licenseFilename": "LICENSE"
+      },
       "cropperjs": {
         "name": "cropperjs",
         "js": {

--- a/build/build-modules-js/settings.json
+++ b/build/build-modules-js/settings.json
@@ -99,22 +99,6 @@
       },
       "@edx/tinymce-language-selector": {
         "name": "tinymce-language-selector",
-        "js": {
-          "tinymce-language-selector/constants.js": "js/constants.js",
-          "tinymce-language-selector/plugin.js": "js/plugin.js"
-        },
-        "provideAssets": [
-          {
-            "name": "constants",
-            "type": "script",
-            "uri": "constants.js"
-          },
-          {
-            "name": "plugin",
-            "type": "script",
-            "uri": "plugin.js"
-          }
-        ],
         "dependencies": [],
         "licenseFilename": "LICENSE"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -2584,6 +2584,11 @@
       "resolved": "https://registry.npmjs.org/@claviska/jquery-minicolors/-/jquery-minicolors-2.3.5.tgz",
       "integrity": "sha512-LpiN8hyqRPYB2tEzFD4lI54GxKHQXhzrJMnKnsumElYxjkjbdAPmiIm+1k/Mkfn92HepL7t9uaK5iQSFP/19aw=="
     },
+    "@edx/tinymce-language-selector": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@edx/tinymce-language-selector/-/tinymce-language-selector-1.1.0.tgz",
+      "integrity": "sha512-yw+JVsq8vRMsTeSY8xjDIlV8xHh9HweZzz1AXPgMtrcS7gEAIYE0G0899ULICV/slBCWdYnTp1oDnDH9DanQ9w=="
+    },
     "@fortawesome/fontawesome-free": {
       "version": "5.14.0",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-5.14.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1216,6 +1216,11 @@
       "resolved": "https://registry.npmjs.org/@claviska/jquery-minicolors/-/jquery-minicolors-2.3.5.tgz",
       "integrity": "sha512-LpiN8hyqRPYB2tEzFD4lI54GxKHQXhzrJMnKnsumElYxjkjbdAPmiIm+1k/Mkfn92HepL7t9uaK5iQSFP/19aw=="
     },
+    "@edx/tinymce-language-selector": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@edx/tinymce-language-selector/-/tinymce-language-selector-1.1.0.tgz",
+      "integrity": "sha512-yw+JVsq8vRMsTeSY8xjDIlV8xHh9HweZzz1AXPgMtrcS7gEAIYE0G0899ULICV/slBCWdYnTp1oDnDH9DanQ9w=="
+    },
     "@eslint/eslintrc": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.2.1.tgz",
@@ -2619,6 +2624,16 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
       "dev": true
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
     },
     "bl": {
       "version": "4.0.3",
@@ -5530,6 +5545,13 @@
       "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.2.tgz",
       "integrity": "sha512-Wz3c3XQ5xroCxd1G8b7yL0Ehkf0TC9oYC6buPFkNnU9EnaPlifeAFCyCh+iewXTyFRcg0a6j3J7FmJsIhlhBdw=="
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -6600,7 +6622,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
@@ -8206,6 +8228,13 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
       "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+    },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "dev": true,
+      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -12787,7 +12816,11 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   ],
   "dependencies": {
     "@claviska/jquery-minicolors": "^2.3.5",
+    "@edx/tinymce-language-selector": "^1.1.0",
     "@webcomponents/webcomponentsjs": "^2.4.4",
     "accessibility": "^3.0.10",
     "awesomplete": "1.1.5",

--- a/package.json
+++ b/package.json
@@ -32,9 +32,8 @@
   ],
   "dependencies": {
     "@claviska/jquery-minicolors": "^2.3.5",
-    "@webcomponents/webcomponentsjs": "^2.5.0",
-    "@edx/tinymce-language-selector": "^1.1.0",
     "@webcomponents/webcomponentsjs": "^2.4.4",
+    "@edx/tinymce-language-selector": "^1.1.0",
     "accessibility": "^3.0.10",
     "awesomplete": "1.1.5",
     "bootstrap": "^4.5.3",

--- a/plugins/editors/tinymce/forms/setoptions.xml
+++ b/plugins/editors/tinymce/forms/setoptions.xml
@@ -36,6 +36,17 @@
 	/>
 
 	<field
+		name="language"
+		type="radio"
+		label="PLG_TINY_FIELD_LANGUAGE_LABEL"
+		layout="joomla.form.field.radio.switcher"
+		default="1"
+		>
+		<option value="0">JOFF</option>
+		<option value="1">JON</option>
+	</field>
+
+	<field
 		name="drag_drop"
 		type="radio"
 		label="PLG_TINY_FIELD_DRAG_DROP_LABEL"

--- a/plugins/editors/tinymce/forms/setoptions.xml
+++ b/plugins/editors/tinymce/forms/setoptions.xml
@@ -36,17 +36,6 @@
 	/>
 
 	<field
-		name="language"
-		type="radio"
-		label="PLG_TINY_FIELD_LANGUAGE_LABEL"
-		layout="joomla.form.field.radio.switcher"
-		default="1"
-		>
-		<option value="0">JOFF</option>
-		<option value="1">JON</option>
-	</field>
-
-	<field
 		name="drag_drop"
 		type="radio"
 		label="PLG_TINY_FIELD_DRAG_DROP_LABEL"

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -532,6 +532,14 @@ class PlgEditorTinymce extends CMSPlugin
 			$scriptOptions['comMediaAdapter']    = 'local-0:';
 		}
 
+		// Language of parts plugin
+		$jlangparts    = $levelParams->get('language', 1);
+
+		if ($jlangparts)
+		{
+			$externalPlugins['language'] = HTMLHelper::_('script', 'plg_editors_tinymce/plugins/language/plugin.min.js', ['relative' => true, 'version' => 'auto', 'pathOnly' => true]);
+		}
+
 		// Convert pt to px in dropdown
 		$scriptOptions['fontsize_formats'] = '8px 10px 12px 14px 18px 24px 36px';
 
@@ -980,6 +988,7 @@ class PlgEditorTinymce extends CMSPlugin
 			'searchreplace'  => array('label' => 'Find and replace', 'plugin' => 'searchreplace'),
 			'insertdatetime' => array('label' => 'Insert date/time', 'plugin' => 'insertdatetime'),
 			// 'spellchecker'   => array('label' => 'Spellcheck', 'plugin' => 'spellchecker'),
+			'language'       => array('label' => 'Language', 'plugin' => 'language'),
 		];
 
 		return $buttons;
@@ -1041,7 +1050,7 @@ class PlgEditorTinymce extends CMSPlugin
 				'fullscreen', '|',
 				'table', '|',
 				'subscript', 'superscript', '|',
-				'charmap', 'emoticons', 'media', 'hr', 'ltr', 'rtl', '|',
+				'charmap', 'emoticons', 'media', 'hr', 'ltr', 'rtl', 'language', '|',
 				'cut', 'copy', 'paste', 'pastetext', '|',
 				'visualchars', 'visualblocks', 'nonbreaking', 'blockquote', 'template', '|',
 				'print', 'preview', 'codesample', 'insertdatetime', 'removeformat', 'jxtdbuttons'

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -533,12 +533,7 @@ class PlgEditorTinymce extends CMSPlugin
 		}
 
 		// Language of parts plugin
-		$jlangparts    = $levelParams->get('language', 1);
-
-		if ($jlangparts)
-		{
-			$externalPlugins['language'] = HTMLHelper::_('script', 'plg_editors_tinymce/plugins/language/plugin.min.js', ['relative' => true, 'version' => 'auto', 'pathOnly' => true]);
-		}
+		$externalPlugins['language'] = HTMLHelper::_('script', 'plg_editors_tinymce/plugins/tinymce-language-selector/plugin.min.js', ['relative' => true, 'version' => 'auto', 'pathOnly' => true]);
 
 		// Convert pt to px in dropdown
 		$scriptOptions['fontsize_formats'] = '8px 10px 12px 14px 18px 24px 36px';
@@ -988,7 +983,7 @@ class PlgEditorTinymce extends CMSPlugin
 			'searchreplace'  => array('label' => 'Find and replace', 'plugin' => 'searchreplace'),
 			'insertdatetime' => array('label' => 'Insert date/time', 'plugin' => 'insertdatetime'),
 			// 'spellchecker'   => array('label' => 'Spellcheck', 'plugin' => 'spellchecker'),
-			'language'       => array('label' => 'Language', 'plugin' => 'language'),
+			'language'      => array('label' => 'Language', 'plugin' => 'tinymce-language-selector'),
 		];
 
 		return $buttons;

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -983,7 +983,7 @@ class PlgEditorTinymce extends CMSPlugin
 			'searchreplace'  => array('label' => 'Find and replace', 'plugin' => 'searchreplace'),
 			'insertdatetime' => array('label' => 'Insert date/time', 'plugin' => 'insertdatetime'),
 			// 'spellchecker'   => array('label' => 'Spellcheck', 'plugin' => 'spellchecker'),
-			'language'      => array('label' => 'Language', 'plugin' => 'tinymce-language-selector'),
+			'language'       => array('label' => 'Language'),
 		];
 
 		return $buttons;

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -983,7 +983,7 @@ class PlgEditorTinymce extends CMSPlugin
 			'searchreplace'  => array('label' => 'Find and replace', 'plugin' => 'searchreplace'),
 			'insertdatetime' => array('label' => 'Insert date/time', 'plugin' => 'insertdatetime'),
 			// 'spellchecker'   => array('label' => 'Spellcheck', 'plugin' => 'spellchecker'),
-			'language'       => array('label' => 'Language'),
+			'language'       => array('label' => 'Language', 'plugin' => 'language'),
 		];
 
 		return $buttons;

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -983,7 +983,6 @@ class PlgEditorTinymce extends CMSPlugin
 			'searchreplace'  => array('label' => 'Find and replace', 'plugin' => 'searchreplace'),
 			'insertdatetime' => array('label' => 'Insert date/time', 'plugin' => 'insertdatetime'),
 			// 'spellchecker'   => array('label' => 'Spellcheck', 'plugin' => 'spellchecker'),
-			'language'       => array('label' => 'Language', 'plugin' => 'tinymce-language-selector'),
 		];
 
 		return $buttons;

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -982,6 +982,7 @@ class PlgEditorTinymce extends CMSPlugin
 			'template'       => array('label' => 'Insert template', 'plugin' => 'template'),
 			'searchreplace'  => array('label' => 'Find and replace', 'plugin' => 'searchreplace'),
 			'insertdatetime' => array('label' => 'Insert date/time', 'plugin' => 'insertdatetime'),
+			'Language'       => array('label' => 'Language', 'plugin' => 'language'),
 			// 'spellchecker'   => array('label' => 'Spellcheck', 'plugin' => 'spellchecker'),
 		];
 
@@ -1044,7 +1045,7 @@ class PlgEditorTinymce extends CMSPlugin
 				'fullscreen', '|',
 				'table', '|',
 				'subscript', 'superscript', '|',
-				'charmap', 'emoticons', 'media', 'hr', 'ltr', 'rtl', 'language', '|',
+				'charmap', 'emoticons', 'media', 'hr', 'ltr', 'rtl', 'Language', '|',
 				'cut', 'copy', 'paste', 'pastetext', '|',
 				'visualchars', 'visualblocks', 'nonbreaking', 'blockquote', 'template', '|',
 				'print', 'preview', 'codesample', 'insertdatetime', 'removeformat', 'jxtdbuttons'

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -983,7 +983,7 @@ class PlgEditorTinymce extends CMSPlugin
 			'searchreplace'  => array('label' => 'Find and replace', 'plugin' => 'searchreplace'),
 			'insertdatetime' => array('label' => 'Insert date/time', 'plugin' => 'insertdatetime'),
 			// 'spellchecker'   => array('label' => 'Spellcheck', 'plugin' => 'spellchecker'),
-			'language'       => array('label' => 'Language', 'plugin' => 'language'),
+			'language'       => array('label' => 'Language', 'plugin' => 'tinymce-language-selector'),
 		];
 
 		return $buttons;

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -532,6 +532,14 @@ class PlgEditorTinymce extends CMSPlugin
 			$scriptOptions['comMediaAdapter']    = 'local-0:';
 		}
 
+		// Language of parts plugin
+		$jlangparts    = $levelParams->get('language', 1);
+
+		if ($jlangparts)
+		{
+			$externalPlugins['language'] = HTMLHelper::_('script', 'plg_editors_tinymce/plugins/language/plugin.min.js', ['relative' => true, 'version' => 'auto', 'pathOnly' => true]);
+		}
+
 		// Convert pt to px in dropdown
 		$scriptOptions['fontsize_formats'] = '8px 10px 12px 14px 18px 24px 36px';
 
@@ -984,6 +992,7 @@ class PlgEditorTinymce extends CMSPlugin
 			'searchreplace'  => array('label' => 'Find and replace', 'plugin' => 'searchreplace'),
 			'insertdatetime' => array('label' => 'Insert date/time', 'plugin' => 'insertdatetime'),
 			// 'spellchecker'   => array('label' => 'Spellcheck', 'plugin' => 'spellchecker'),
+			'language'       => array('label' => 'Language', 'plugin' => 'language'),
 		];
 
 		return $buttons;
@@ -1046,7 +1055,7 @@ class PlgEditorTinymce extends CMSPlugin
 				'fullscreen', '|',
 				'table', '|',
 				'subscript', 'superscript', '|',
-				'charmap', 'emoticons', 'media', 'hr', 'ltr', 'rtl', '|',
+				'charmap', 'emoticons', 'media', 'hr', 'ltr', 'rtl', 'language', '|',
 				'cut', 'copy', 'paste', 'pastetext', '|',
 				'visualchars', 'visualblocks', 'nonbreaking', 'blockquote', 'template', '|',
 				'print', 'preview', 'codesample', 'insertdatetime', 'removeformat', 'jxtdbuttons'

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -987,7 +987,7 @@ class PlgEditorTinymce extends CMSPlugin
 			'searchreplace'  => array('label' => 'Find and replace', 'plugin' => 'searchreplace'),
 			'insertdatetime' => array('label' => 'Insert date/time', 'plugin' => 'insertdatetime'),
 			// 'spellchecker'   => array('label' => 'Spellcheck', 'plugin' => 'spellchecker'),
-			'language'       => array('label' => 'Language'),
+			'language'       => array('label' => 'Language', 'plugin' => 'language'),
 		];
 
 		return $buttons;

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -987,7 +987,7 @@ class PlgEditorTinymce extends CMSPlugin
 			'searchreplace'  => array('label' => 'Find and replace', 'plugin' => 'searchreplace'),
 			'insertdatetime' => array('label' => 'Insert date/time', 'plugin' => 'insertdatetime'),
 			// 'spellchecker'   => array('label' => 'Spellcheck', 'plugin' => 'spellchecker'),
-			'language'      => array('label' => 'Language', 'plugin' => 'tinymce-language-selector'),
+			'language'       => array('label' => 'Language'),
 		];
 
 		return $buttons;

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -533,12 +533,7 @@ class PlgEditorTinymce extends CMSPlugin
 		}
 
 		// Language of parts plugin
-		$jlangparts    = $levelParams->get('language', 1);
-
-		if ($jlangparts)
-		{
-			$externalPlugins['language'] = HTMLHelper::_('script', 'plg_editors_tinymce/plugins/language/plugin.min.js', ['relative' => true, 'version' => 'auto', 'pathOnly' => true]);
-		}
+		$externalPlugins['language'] = HTMLHelper::_('script', 'plg_editors_tinymce/plugins/tinymce-language-selector/plugin.min.js', ['relative' => true, 'version' => 'auto', 'pathOnly' => true]);
 
 		// Convert pt to px in dropdown
 		$scriptOptions['fontsize_formats'] = '8px 10px 12px 14px 18px 24px 36px';
@@ -992,7 +987,7 @@ class PlgEditorTinymce extends CMSPlugin
 			'searchreplace'  => array('label' => 'Find and replace', 'plugin' => 'searchreplace'),
 			'insertdatetime' => array('label' => 'Insert date/time', 'plugin' => 'insertdatetime'),
 			// 'spellchecker'   => array('label' => 'Spellcheck', 'plugin' => 'spellchecker'),
-			'language'       => array('label' => 'Language', 'plugin' => 'language'),
+			'language'      => array('label' => 'Language', 'plugin' => 'tinymce-language-selector'),
 		];
 
 		return $buttons;

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -986,6 +986,7 @@ class PlgEditorTinymce extends CMSPlugin
 			'template'       => array('label' => 'Insert template', 'plugin' => 'template'),
 			'searchreplace'  => array('label' => 'Find and replace', 'plugin' => 'searchreplace'),
 			'insertdatetime' => array('label' => 'Insert date/time', 'plugin' => 'insertdatetime'),
+			'Language'       => array('label' => 'Language', 'plugin' => 'language'),
 			// 'spellchecker'   => array('label' => 'Spellcheck', 'plugin' => 'spellchecker'),
 		];
 
@@ -1049,7 +1050,7 @@ class PlgEditorTinymce extends CMSPlugin
 				'fullscreen', '|',
 				'table', '|',
 				'subscript', 'superscript', '|',
-				'charmap', 'emoticons', 'media', 'hr', 'ltr', 'rtl', 'language', '|',
+				'charmap', 'emoticons', 'media', 'hr', 'ltr', 'rtl', 'Language', '|',
 				'cut', 'copy', 'paste', 'pastetext', '|',
 				'visualchars', 'visualblocks', 'nonbreaking', 'blockquote', 'template', '|',
 				'print', 'preview', 'codesample', 'insertdatetime', 'removeformat', 'jxtdbuttons'

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -987,7 +987,7 @@ class PlgEditorTinymce extends CMSPlugin
 			'searchreplace'  => array('label' => 'Find and replace', 'plugin' => 'searchreplace'),
 			'insertdatetime' => array('label' => 'Insert date/time', 'plugin' => 'insertdatetime'),
 			// 'spellchecker'   => array('label' => 'Spellcheck', 'plugin' => 'spellchecker'),
-			'language'       => array('label' => 'Language', 'plugin' => 'language'),
+			'language'       => array('label' => 'Language', 'plugin' => 'tinymce-language-selector'),
 		];
 
 		return $buttons;

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -987,7 +987,6 @@ class PlgEditorTinymce extends CMSPlugin
 			'searchreplace'  => array('label' => 'Find and replace', 'plugin' => 'searchreplace'),
 			'insertdatetime' => array('label' => 'Insert date/time', 'plugin' => 'insertdatetime'),
 			// 'spellchecker'   => array('label' => 'Spellcheck', 'plugin' => 'spellchecker'),
-			'language'       => array('label' => 'Language', 'plugin' => 'tinymce-language-selector'),
 		];
 
 		return $buttons;


### PR DESCRIPTION
This is a plugin for TinyMCE 5 that allows users to specify what language their text is written in. As TinyMCE does not currently provide a plugin for language of parts this is an implementation of https://github.com/edx/tinymce-language-selector/. 

The plugin wraps the desired text in span tags with a lang attribute for the specified language. Unspecified text is assumed to be written in the page's language. This helps the resulting text comply with WCAG 2.0 3.1.2 Language of Parts: "The human language of each passage or phrase in the content can be programmatically determined..."

![parts](https://user-images.githubusercontent.com/1296369/95791046-71fff080-0cd8-11eb-9d79-5d8886956e40.gif)

The only valid comments are on the implementation of the plugin. Comments about the plugin itself should be addressed upstream at https://github.com/edx/tinymce-language-selector/

[ The need for this is based on the EU funded research project for improving the process of creating accessible content by authors https://accessibilitycluster.com/about ]

If you have customised your tinymce editor toolbar you will need to edit the toolbar again to include this one

### Testing
Dont forget to do a full `npm ci`

### Todo - Help Wanted
In the build scripts
1. Remove the empty folder media\vendor\tinymce-language-selector\
2. To be compliant with the license node_modules\@edx\tinymce-language-selector\LICENSE needs to be copied to the final folder
Thank to @dgrammatiko for the work so far on those scripts