### PR TITLE
[4.0] Add update SQL to delete plg_authentication_gmail from extensions table

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/4.0.0-2020-09-27.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.0.0-2020-09-27.sql
@@ -1,1 +1,2 @@
 DELETE FROM `#__extensions` WHERE `name` = 'plg_content_imagelazyload' AND `type` = 'plugin' AND `element` = 'imagelazyload' AND `folder` = 'content' AND `client_id` = 0;
+DELETE FROM `#__extensions` WHERE `name` = 'plg_authentication_gmail' AND `type` = 'plugin' AND `element` = 'gmail' AND `folder` = 'authentication' AND `client_id` = 0;

--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2020-09-27.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2020-09-27.sql
@@ -1,1 +1,2 @@
 DELETE FROM "#__extensions" WHERE "name" = 'plg_content_imagelazyload' AND "type" = 'plugin' AND "element" = 'imagelazyload' AND "folder" = 'content' AND "client_id" = 0;
+DELETE FROM "#__extensions" WHERE "name" = 'plg_authentication_gmail' AND "type" = 'plugin' AND "element" = 'gmail' AND "folder" = 'authentication' AND "client_id" = 0;


### PR DESCRIPTION
Pull Request for Issue #30928 .

### Summary of Changes

This pull request (PR) adds the necessary SQL statements to delete the obsolete record for plg_authentication_gmail in the extension table to the update SQL scripts.

I order to not add again a new update SQL script, I've decided to modify the existing script 4.0.0-2020-09-27.sql, which hasn't been released yet and so can be modified, as we don't support updates between nightlies.

If a new Beta or whatever else release of J4 will be made before this PR will be merged, I'll have to move the new statement to a new update SQL script then.

If my other PR #30945 which updates the same SQL scripts is merged before this one, I have to solve conflicts here before this one can be merged.

### Testing Instructions

#### Test 1: Reproduce the issue

1. Update a clean installation (i.e. no 3rd party extensions) of current 3.10-dev or latest 3.10 nightly or 3.10-alpha2 to the latest 4.0 nightly, using the following custom URL for Live Update or the following update package for Upload & Update:
- Custom update URL = [https://update.joomla.org/core/nightlies/next_major_list.xml](https://update.joomla.org/core/nightlies/next_major_list.xml)
- Update package = [https://developer.joomla.org/nightlies/Joomla_4.0.0-beta5-dev-Development-Update_Package.zip](https://developer.joomla.org/nightlies/Joomla_4.0.0-beta5-dev-Development-Update_Package.zip)
2. After successful update, go to the "System - Manage - Plugins" and check if there is an authentication plugin with name "plg_authentication_gmail".
Result: The plugin exists.
3. Go to "System - Manage - Extensions" and search for "plg_authentication_gmail".
Result: The plugin exists.
4. Try to uninstall the plugin.
Result: Error "Call to a member function attributes() on null", see also section "Actual result BEFORE applying this Pull Request" below.

#### Test 2: Verify that this PR fixes the issue when updating from 3.10-dev

Repeat the previous test "Test 1", but this time use the update package of latest 4.0 nightly plus the fix of this PR included.
- Custom update URL = [https://ci.joomla.org/artifacts/joomla/joomla-cms/4.0-dev/30941/downloads/36178/pr_list.xml]( https://ci.joomla.org/artifacts/joomla/joomla-cms/4.0-dev/30941/downloads/36178/pr_list.xml)
- Update package = [https://ci.joomla.org/artifacts/joomla/joomla-cms/4.0-dev/30941/downloads/36178/Joomla_4.0.0-beta5-dev+pr.30941-Development-Update_Package.zip](https://ci.joomla.org/artifacts/joomla/joomla-cms/4.0-dev/30941/downloads/36178/Joomla_4.0.0-beta5-dev+pr.30941-Development-Update_Package.zip)

Result: The plugin doesn't exists, see also section "Expected result AFTER applying this Pull Request" below.

#### Test 3: Verify that this PR fixes the issue when updating a 4.0 Beta 4

Repeat the previous test "Test 2", but this time don't start from a 3.10 installation.

Start from an installation of 4.0 Beta 4 instead.

It has to be 4.0 Beta 4 and not current 4.0-dev or latest 4.0 nighty.

Result: The plugin doesn't exists, see also section "Expected result AFTER applying this Pull Request" below.

### Actual result BEFORE applying this Pull Request

After an update from 3.10 to 4, there is still an authentication plugin with name "plg_authentication_gmail" in the extensions table in database and so in the list of plugins in backend.

Trying to uninstall that results in an error "Call to a member function attributes() on null".

### Expected result AFTER applying this Pull Request

After an update from 3.10 to 4, there is no authentication plugin with name "plg_authentication_gmail" in the extensions table in database and in the list of plugins in backend.

After update from a 4 Beta version which had the issue to a future 4 version which contains the fix from this PR, the obsolete authentication plugin "plg_authentication_gmail" will be deleted.

### Documentation Changes Required

None.