### PR TITLE
typo in ArticlesNewsHelper.php

### DIFF
--- a/modules/mod_articles_news/src/Helper/ArticlesNewsHelper.php
+++ b/modules/mod_articles_news/src/Helper/ArticlesNewsHelper.php
@@ -69,7 +69,7 @@ abstract class ArticlesNewsHelper
 		// Filter by language
 		$model->setState('filter.language', $app->getLanguageFilter());
 
-		// Filer by tag
+		// Filter by tag
 		$model->setState('filter.tag', $params->get('tag', array()));
 
 		// Featured switch


### PR DESCRIPTION
Accidentally encountered this typo while searching for the phrase 'File'


### Summary of Changes
misprint 'Filer' > 'Filter'
