### PR TITLE
[4] Only show error code if greater than zero

### DIFF
--- a/administrator/templates/atum/error_full.php
+++ b/administrator/templates/atum/error_full.php
@@ -151,7 +151,9 @@ HTMLHelper::_('atum.rootcolors', $this->params);
 				<div class="col-md-12">
 					<h1><?php echo Text::_('JERROR_AN_ERROR_HAS_OCCURRED'); ?></h1>
 					<blockquote class="blockquote">
-						<span class="badge badge-secondary"><?php echo $this->error->getCode(); ?></span>
+						<?php if ($this->error->getCode() > 0) : ?>
+							<span class="badge badge-secondary"><?php echo $this->error->getCode(); ?></span>
+						<?php endif; ?>
 						<?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?>
 					</blockquote>
 					<?php if ($this->debug) : ?>

--- a/administrator/templates/atum/error_login.php
+++ b/administrator/templates/atum/error_login.php
@@ -126,7 +126,9 @@ HTMLHelper::_('atum.rootcolors', $this->params);
 						<h1><?php echo Text::_('JERROR_AN_ERROR_HAS_OCCURRED'); ?></h1>
 						<jdoc:include type="message" />
 						<blockquote class="blockquote">
-							<span class="badge badge-secondary"><?php echo $this->error->getCode(); ?></span>
+							<?php if ($this->error->getCode() > 0) : ?>
+								<span class="badge badge-secondary"><?php echo $this->error->getCode(); ?></span>
+							<?php endif; ?>
 							<?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?>
 						</blockquote>
 						<?php if ($this->debug) : ?>

--- a/administrator/templates/system/error.php
+++ b/administrator/templates/system/error.php
@@ -31,7 +31,12 @@ $this->setTitle($this->error->getCode() . ' - ' . htmlspecialchars($this->error-
 	<table class="outline">
 		<tr>
 			<td style="text-align: center;">
-				<h1><?php echo $this->error->getCode() ?> - <?php echo Text::_('JERROR_AN_ERROR_HAS_OCCURRED'); ?></h1>
+				<h1>
+					<?php if ($this->error->getCode() > 0) : ?>
+						<?php echo $this->error->getCode() . ' - ' ?>
+					<?php endif; ?>
+					<?php echo Text::_('JERROR_AN_ERROR_HAS_OCCURRED'); ?>
+				</h1>
 			</td>
 		</tr>
 		<tr>

--- a/administrator/templates/system/error.php
+++ b/administrator/templates/system/error.php
@@ -18,7 +18,7 @@ use Joomla\CMS\Router\Route;
 $this->getWebAssetManager()->registerAndUseStyle('template.system.error', 'administrator/templates/system/css/error.css');
 
 // Set page title
-$this->setTitle($this->error->getCode() . ' - ' . htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'));
+$this->setTitle(($this->error->getCode() > 0 ? $this->error->getCode() .' - ': '') . htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'));
 ?>
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">

--- a/installation/template/error.php
+++ b/installation/template/error.php
@@ -72,7 +72,13 @@ $this->setMetaData('viewport', 'width=device-width, initial-scale=1');
 								</div>
 								<div class="alert-text">
 									<h2><?php echo Text::_('JERROR_LAYOUT_ERROR_HAS_OCCURRED_WHILE_PROCESSING_YOUR_REQUEST'); ?></h2>
-									<p class="form-text text-muted small"><span class="badge badge-default"><?php echo $this->error->getCode(); ?></span> <?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></p>
+									<p class="form-text text-muted small">
+										<?php if ($this->error->getCode() > 0) : ?>
+											<span class="badge badge-default">
+												<?php echo $this->error->getCode(); ?>
+											</span>
+										<?php endif; ?>
+										<?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></p>
 								</div>
 							</div>
 							<?php if ($this->debug) : ?>

--- a/installation/template/error.php
+++ b/installation/template/error.php
@@ -27,7 +27,7 @@ $this->getWebAssetManager()
 $this->addScriptOptions('system.installation', ['url' => Route::_('index.php')]);
 
 // Set page title
-$this->setTitle($this->error->getCode() . ' - ' . htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'));
+$this->setTitle(($this->error->getCode() > 0 ? $this->error->getCode() .' - ': '') . htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'));
 
 $this->setMetaData('viewport', 'width=device-width, initial-scale=1');
 

--- a/templates/cassiopeia/error.php
+++ b/templates/cassiopeia/error.php
@@ -146,7 +146,10 @@ $this->setMetaData('viewport', 'width=device-width, initial-scale=1');
 					<hr>
 					<p><?php echo Text::_('JERROR_LAYOUT_PLEASE_CONTACT_THE_SYSTEM_ADMINISTRATOR'); ?></p>
 					<blockquote>
-						<span class="badge badge-secondary"><?php echo $this->error->getCode(); ?></span> <?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?>
+						<?php if ($this->error->getCode() > 0) : ?>
+							<span class="badge badge-secondary"><?php echo $this->error->getCode(); ?></span>
+						<?php endif; ?>
+						<?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?>
 					</blockquote>
 					<?php if ($this->debug) : ?>
 						<div>

--- a/templates/system/error.php
+++ b/templates/system/error.php
@@ -29,7 +29,7 @@ if ($this->direction === 'rtl')
 }
 
 // Set page title
-$this->setTitle($this->error->getCode() . ' - ' . htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'));
+$this->setTitle(($this->error->getCode() > 0 ? $this->error->getCode() .' - ': '') . htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'));
 
 ?>
 <!DOCTYPE html>

--- a/templates/system/error.php
+++ b/templates/system/error.php
@@ -43,7 +43,11 @@ $this->setTitle($this->error->getCode() . ' - ' . htmlspecialchars($this->error-
 	<div class="error">
 		<div id="outline">
 		<div id="errorboxoutline">
-			<div id="errorboxheader"><?php echo $this->error->getCode(); ?> - <?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></div>
+			<div id="errorboxheader">
+				<?php if ($this->error->getCode() > 0) : ?>
+					<?php echo $this->error->getCode() . ' - '; ?>
+				<?php endif; ?>
+				<?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></div>
 			<div id="errorboxbody">
 			<p><strong><?php echo Text::_('JERROR_LAYOUT_NOT_ABLE_TO_VISIT'); ?></strong></p>
 			<ol>


### PR DESCRIPTION
### Summary of Changes

When an error occurs we get an error page, it has a useless error code 0 most of the time.

This PR only shows the error code if its greater than 0 


### Testing Instructions

[Generate an error](https://github.com/joomla/joomla-cms/issues/30951)
URL http://example.com/administrator/index.php?option=com_media&task=file.edit&id=0 will currently do that for you ;-) 

### Actual result BEFORE applying this Pull Request

<img width="704" alt="Screenshot 2020-10-06 at 23 13 09" src="https://user-images.githubusercontent.com/400092/95266467-1c849900-082b-11eb-9614-9397ee0836f4.png">


### Expected result AFTER applying this Pull Request

<img width="648" alt="Screenshot 2020-10-06 at 23 18 52" src="https://user-images.githubusercontent.com/400092/95266470-1e4e5c80-082b-11eb-93de-acba24334292.png">


### Documentation Changes Required

