### PR TITLE
Transparency lost when cropping/resizing images

### DIFF
--- a/administrator/components/com_templates/models/template.php
+++ b/administrator/components/com_templates/models/template.php
@@ -1185,8 +1185,6 @@ class TemplatesModelTemplate extends JModelForm
 			catch (Exception $e)
 			{
 				$app->enqueueMessage($e->getMessage(), 'error');
-
-				return false;
 			}
 		}
 	}
@@ -1236,8 +1234,6 @@ class TemplatesModelTemplate extends JModelForm
 			catch (Exception $e)
 			{
 				$app->enqueueMessage($e->getMessage(), 'error');
-
-				return false;
 			}
 		}
 	}

--- a/administrator/components/com_templates/models/template.php
+++ b/administrator/components/com_templates/models/template.php
@@ -1159,18 +1159,34 @@ class TemplatesModelTemplate extends JModelForm
 			$client   = JApplicationHelper::getClientInfo($template->client_id);
 			$relPath  = base64_decode($file);
 			$path     = JPath::clean($client->path . '/templates/' . $template->element . '/' . $relPath);
-			$JImage   = new JImage($path);
 
 			try
 			{
-				$image = $JImage->crop($w, $h, $x, $y, true);
-				$image->toFile($path);
+				$image      = new \JImage($path);
+				$properties = $image->getImageFileProperties($path);
+
+				switch ($properties->mime)
+				{
+					case 'image/png':
+						$imageType = \IMAGETYPE_PNG;
+						break;
+					case 'image/gif':
+						$imageType = \IMAGETYPE_GIF;
+						break;
+					default:
+						$imageType = \IMAGETYPE_JPEG;
+				}
+
+				$image->crop($w, $h, $x, $y, false);
+				$image->toFile($path, $imageType);
 
 				return true;
 			}
 			catch (Exception $e)
 			{
 				$app->enqueueMessage($e->getMessage(), 'error');
+
+				return false;
 			}
 		}
 	}
@@ -1195,18 +1211,33 @@ class TemplatesModelTemplate extends JModelForm
 			$relPath = base64_decode($file);
 			$path    = JPath::clean($client->path . '/templates/' . $template->element . '/' . $relPath);
 
-			$JImage = new JImage($path);
-
 			try
 			{
-				$image = $JImage->resize($width, $height, true, 1);
-				$image->toFile($path);
+				$image      = new \JImage($path);
+				$properties = $image->getImageFileProperties($path);
+
+				switch ($properties->mime)
+				{
+					case 'image/png':
+						$imageType = \IMAGETYPE_PNG;
+						break;
+					case 'image/gif':
+						$imageType = \IMAGETYPE_GIF;
+						break;
+					default:
+						$imageType = \IMAGETYPE_JPEG;
+				}
+
+				$image->resize($width, $height, false, \JImage::SCALE_FILL);
+				$image->toFile($path, $imageType);
 
 				return true;
 			}
 			catch (Exception $e)
 			{
 				$app->enqueueMessage($e->getMessage(), 'error');
+
+				return false;
 			}
 		}
 	}


### PR DESCRIPTION
Closes https://github.com/joomla/joomla-cms/issues/30975.

### Summary of Changes

Fixes transparency being lost when cropping/resizing PNG images.

### Testing Instructions

Go to edit template files in backend.
Select one of PNG images in `images` directory.
Use `Crop` and `Resize` buttons to crop/resize the image.

Note, because template is styled to have a black background behind transparent images, you'll have to inspect image files directly on your server or in the browser.

### Actual result BEFORE applying this Pull Request

Transparency is lost, images get a black background.

### Expected result AFTER applying this Pull Request

Images maintain transparency.

### Documentation Changes Required

No.