### PR TITLE
Undefined constant on PHP 5.3

### DIFF
--- a/administrator/components/com_templates/views/template/tmpl/default_tree.php
+++ b/administrator/components/com_templates/views/template/tmpl/default_tree.php
@@ -8,9 +8,11 @@
  */
 
 defined('_JEXEC') or die;
-ksort($this->files, SORT_NATURAL);
-?>
 
+// use ksort() with SORT_NATURAL flag when minimum PHP is 5.4.
+uksort($this->files, 'strnatcmp');
+
+?>
 <ul class='nav nav-list directory-tree'>
 	<?php foreach ($this->files as $key => $value) : ?>
 		<?php if (is_array($value)) : ?>


### PR DESCRIPTION
### Summary of Changes

`SORT_NATURAL` is not available on PHP 5.3.

### Testing Instructions

Use PHP 5.3.
Go to template file list in backend.

### Actual result BEFORE applying this Pull Request

Many PHP notices and warnings:

>Notice: Use of undefined constant SORT_NATURAL - assumed 'SORT_NATURAL' in administrator\components\com_templates\views\template\tmpl\default_tree.php on line 11
>Warning: ksort() expects parameter 2 to be long, string given in administrator\components\com_templates\views\template\tmpl\default_tree.php on line 11

### Expected result AFTER applying this Pull Request

No PHP notices/warnings.

### Documentation Changes Required

No.