### PR TITLE
Wrong menu items displayed when logged-in through remember-me feature

### DIFF
--- a/libraries/src/Menu/AbstractMenu.php
+++ b/libraries/src/Menu/AbstractMenu.php
@@ -11,6 +11,7 @@ namespace Joomla\CMS\Menu;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\Registry\Registry;
+use Joomla\CMS\Factory;
 
 /**
  * Menu class
@@ -66,7 +67,7 @@ class AbstractMenu
 	/**
 	 * Class constructor
 	 *
-	 * @param   array  $options  An array of configuration options.
+	 * @param array $options An array of configuration options.
 	 *
 	 * @since   1.5
 	 */
@@ -83,19 +84,23 @@ class AbstractMenu
 			}
 		}
 
+		// Storing user here breaks menu display if called by a plugin before the Remember Me plugin has been running.
+		// Left in for B/C but within AbstractMenu and SiteMenu, now using \JFactory::getUser() each time user is needed
+		// instead of the memoized value.
+		// See https://github.com/joomla/joomla-cms/issues/11541
 		$this->user = isset($options['user']) && $options['user'] instanceof \JUser ? $options['user'] : \JFactory::getUser();
 	}
 
 	/**
 	 * Returns a Menu object
 	 *
-	 * @param   string  $client   The name of the client
-	 * @param   array   $options  An associative array of options
+	 * @param string $client The name of the client
+	 * @param array $options An associative array of options
 	 *
 	 * @return  AbstractMenu  A menu object.
 	 *
-	 * @since   1.5
 	 * @throws  \Exception
+	 * @since   1.5
 	 */
 	public static function getInstance($client, $options = array())
 	{
@@ -137,7 +142,7 @@ class AbstractMenu
 	/**
 	 * Get menu item by id
 	 *
-	 * @param   integer  $id  The item id
+	 * @param integer $id The item id
 	 *
 	 * @return  MenuItem|null  The item object if the ID exists or null if not found
 	 *
@@ -158,8 +163,8 @@ class AbstractMenu
 	/**
 	 * Set the default item by id and language code.
 	 *
-	 * @param   integer  $id        The menu item id.
-	 * @param   string   $language  The language code (since 1.6).
+	 * @param integer $id The menu item id.
+	 * @param string $language The language code (since 1.6).
 	 *
 	 * @return  boolean  True if a menu item with the given ID exists
 	 *
@@ -180,7 +185,7 @@ class AbstractMenu
 	/**
 	 * Get the default item by language code.
 	 *
-	 * @param   string  $language  The language code, default value of * means all.
+	 * @param string $language The language code, default value of * means all.
 	 *
 	 * @return  MenuItem|null  The item object or null when not found for given language
 	 *
@@ -204,7 +209,7 @@ class AbstractMenu
 	/**
 	 * Set the default item by id
 	 *
-	 * @param   integer  $id  The item id
+	 * @param integer $id The item id
 	 *
 	 * @return  MenuItem|null  The menu item representing the given ID if present or null otherwise
 	 *
@@ -242,10 +247,10 @@ class AbstractMenu
 	/**
 	 * Gets menu items by attribute
 	 *
-	 * @param   mixed    $attributes  The field name(s).
-	 * @param   mixed    $values      The value(s) of the field. If an array, need to match field names
+	 * @param mixed $attributes The field name(s).
+	 * @param mixed $values The value(s) of the field. If an array, need to match field names
 	 *                                each attribute may have multiple values to lookup for.
-	 * @param   boolean  $firstonly   If true, only returns the first item found
+	 * @param boolean $firstonly If true, only returns the first item found
 	 *
 	 * @return  MenuItem|MenuItem[]  An array of menu item objects or a single object if the $firstonly parameter is true
 	 *
@@ -253,10 +258,10 @@ class AbstractMenu
 	 */
 	public function getItems($attributes, $values, $firstonly = false)
 	{
-		$items = array();
-		$attributes = (array) $attributes;
-		$values = (array) $values;
-		$count = count($attributes);
+		$items      = array();
+		$attributes = (array)$attributes;
+		$values     = (array)$values;
+		$count      = count($attributes);
 
 		foreach ($this->_items as $item)
 		{
@@ -304,7 +309,7 @@ class AbstractMenu
 	/**
 	 * Gets the parameter object for a certain menu item
 	 *
-	 * @param   integer  $id  The item id
+	 * @param integer $id The item id
 	 *
 	 * @return  Registry
 	 *
@@ -335,7 +340,7 @@ class AbstractMenu
 	/**
 	 * Method to check Menu object authorization against an access control object and optionally an access extension object
 	 *
-	 * @param   integer  $id  The menu id
+	 * @param integer $id The menu id
 	 *
 	 * @return  boolean
 	 *
@@ -347,7 +352,7 @@ class AbstractMenu
 
 		if ($menu)
 		{
-			return in_array((int) $menu->access, $this->user->getAuthorisedViewLevels());
+			return in_array((int)$menu->access, Factory::getUser()->getAuthorisedViewLevels());
 		}
 
 		return true;

--- a/libraries/src/Menu/AbstractMenu.php
+++ b/libraries/src/Menu/AbstractMenu.php
@@ -25,7 +25,7 @@ class AbstractMenu
 	 * Array to hold the menu items
 	 *
 	 * @var    MenuItem[]
-	 * @since  1.5
+	 * @since       1.5
 	 * @deprecated  4.0  Will convert to $items
 	 */
 	protected $_items = array();
@@ -34,7 +34,7 @@ class AbstractMenu
 	 * Identifier of the default menu item
 	 *
 	 * @var    integer
-	 * @since  1.5
+	 * @since       1.5
 	 * @deprecated  4.0  Will convert to $default
 	 */
 	protected $_default = array();
@@ -43,7 +43,7 @@ class AbstractMenu
 	 * Identifier of the active menu item
 	 *
 	 * @var    integer
-	 * @since  1.5
+	 * @since       1.5
 	 * @deprecated  4.0  Will convert to $active
 	 */
 	protected $_active = 0;
@@ -94,8 +94,8 @@ class AbstractMenu
 	/**
 	 * Returns a Menu object
 	 *
-	 * @param string $client The name of the client
-	 * @param array $options An associative array of options
+	 * @param string $client  The name of the client
+	 * @param array  $options An associative array of options
 	 *
 	 * @return  AbstractMenu  A menu object.
 	 *
@@ -163,8 +163,8 @@ class AbstractMenu
 	/**
 	 * Set the default item by id and language code.
 	 *
-	 * @param integer $id The menu item id.
-	 * @param string $language The language code (since 1.6).
+	 * @param integer $id       The menu item id.
+	 * @param string  $language The language code (since 1.6).
 	 *
 	 * @return  boolean  True if a menu item with the given ID exists
 	 *
@@ -247,10 +247,10 @@ class AbstractMenu
 	/**
 	 * Gets menu items by attribute
 	 *
-	 * @param mixed $attributes The field name(s).
-	 * @param mixed $values The value(s) of the field. If an array, need to match field names
+	 * @param mixed   $attributes     The field name(s).
+	 * @param mixed   $values         The value(s) of the field. If an array, need to match field names
 	 *                                each attribute may have multiple values to lookup for.
-	 * @param boolean $firstonly If true, only returns the first item found
+	 * @param boolean $firstonly      If true, only returns the first item found
 	 *
 	 * @return  MenuItem|MenuItem[]  An array of menu item objects or a single object if the $firstonly parameter is true
 	 *

--- a/libraries/src/Menu/SiteMenu.php
+++ b/libraries/src/Menu/SiteMenu.php
@@ -49,7 +49,7 @@ class SiteMenu extends AbstractMenu
 	/**
 	 * Class constructor
 	 *
-	 * @param   array  $options  An array of configuration options.
+	 * @param array $options An array of configuration options.
 	 *
 	 * @since   1.5
 	 */
@@ -75,18 +75,17 @@ class SiteMenu extends AbstractMenu
 		// For PHP 5.3 compat we can't use $this in the lambda function below
 		$db = $this->db;
 
-		$loader = function () use ($db)
-		{
+		$loader = function () use ($db) {
 			$query = $db->getQuery(true)
-				->select('m.id, m.menutype, m.title, m.alias, m.note, m.path AS route, m.link, m.type, m.level, m.language')
-				->select($db->quoteName('m.browserNav') . ', m.access, m.params, m.home, m.img, m.template_style_id, m.component_id, m.parent_id')
-				->select('e.element as component')
-				->from('#__menu AS m')
-				->join('LEFT', '#__extensions AS e ON m.component_id = e.extension_id')
-				->where('m.published = 1')
-				->where('m.parent_id > 0')
-				->where('m.client_id = 0')
-				->order('m.lft');
+						->select('m.id, m.menutype, m.title, m.alias, m.note, m.path AS route, m.link, m.type, m.level, m.language')
+						->select($db->quoteName('m.browserNav') . ', m.access, m.params, m.home, m.img, m.template_style_id, m.component_id, m.parent_id')
+						->select('e.element as component')
+						->from('#__menu AS m')
+						->join('LEFT', '#__extensions AS e ON m.component_id = e.extension_id')
+						->where('m.published = 1')
+						->where('m.parent_id > 0')
+						->where('m.client_id = 0')
+						->order('m.lft');
 
 			// Set the query
 			$db->setQuery($query);
@@ -128,12 +127,12 @@ class SiteMenu extends AbstractMenu
 
 			if (isset($this->_items[$item->parent_id]))
 			{
-				$parent_tree  = $this->_items[$item->parent_id]->tree;
+				$parent_tree = $this->_items[$item->parent_id]->tree;
 			}
 
 			// Create tree.
 			$parent_tree[] = $item->id;
-			$item->tree = $parent_tree;
+			$item->tree    = $parent_tree;
 
 			// Create the query array.
 			$url = str_replace('index.php?', '', $item->link);
@@ -148,9 +147,9 @@ class SiteMenu extends AbstractMenu
 	/**
 	 * Gets menu items by attribute
 	 *
-	 * @param   string   $attributes  The field name
-	 * @param   string   $values      The value of the field
-	 * @param   boolean  $firstonly   If true, only returns the first item found
+	 * @param string  $attributes The field name
+	 * @param string  $values     The value of the field
+	 * @param boolean $firstonly  If true, only returns the first item found
 	 *
 	 * @return  MenuItem|MenuItem[]  An array of menu item objects or a single object if the $firstonly parameter is true
 	 *
@@ -158,8 +157,8 @@ class SiteMenu extends AbstractMenu
 	 */
 	public function getItems($attributes, $values, $firstonly = false)
 	{
-		$attributes = (array) $attributes;
-		$values     = (array) $values;
+		$attributes = (array)$attributes;
+		$values     = (array)$values;
 
 		if ($this->app->isClient('site'))
 		{
@@ -181,7 +180,7 @@ class SiteMenu extends AbstractMenu
 			if (($key = array_search('access', $attributes)) === false)
 			{
 				$attributes[] = 'access';
-				$values[] = Factory::getUser()->getAuthorisedViewLevels();
+				$values[]     = Factory::getUser()->getAuthorisedViewLevels();
 			}
 			elseif ($values[$key] === null)
 			{
@@ -191,7 +190,7 @@ class SiteMenu extends AbstractMenu
 
 		// Reset arrays or we get a notice if some values were unset
 		$attributes = array_values($attributes);
-		$values = array_values($values);
+		$values     = array_values($values);
 
 		return parent::getItems($attributes, $values, $firstonly);
 	}
@@ -199,7 +198,7 @@ class SiteMenu extends AbstractMenu
 	/**
 	 * Get menu item by id
 	 *
-	 * @param   string  $language  The language code.
+	 * @param string $language The language code.
 	 *
 	 * @return  MenuItem|null  The item object or null when not found for given language
 	 *

--- a/libraries/src/Menu/SiteMenu.php
+++ b/libraries/src/Menu/SiteMenu.php
@@ -13,6 +13,7 @@ defined('JPATH_PLATFORM') or die;
 use Joomla\CMS\Application\CMSApplication;
 use Joomla\CMS\Language\Language;
 use Joomla\CMS\Language\Multilanguage;
+use Joomla\CMS\Factory;
 
 /**
  * Menu class
@@ -180,7 +181,7 @@ class SiteMenu extends AbstractMenu
 			if (($key = array_search('access', $attributes)) === false)
 			{
 				$attributes[] = 'access';
-				$values[] = $this->user->getAuthorisedViewLevels();
+				$values[] = Factory::getUser()->getAuthorisedViewLevels();
 			}
 			elseif ($values[$key] === null)
 			{


### PR DESCRIPTION
Pull Request for Issue #11541 .

### Summary of Changes
AbstracMenu and SiteMenu classes use a memoized copy of the current user. Under some circumstances, this causes incorrect menu items to be displayed when user is logged in through the Remember-be feature (registered-access level items not shown) as the user has not yet been updated to logged-in state.

Circumstances are that Application::getMenu() is called from a plugin early on, typically from a system plugin constructor or onAfterInitialise. 

getMenu() may not be called directly but for instance calling Application::getRouter() to add parse or build rules triggers the problem because the router itself grabs the menu in its contructor.

The language filter plugin does that, any SEF extension will also attach routing rules as well as many other extensions.

For 3rd party extensions, the problem will appear less frequently because it is also a requirement that the plugin in question is located **before** the RememberMe plugin, which is not common but will happen when user re-order plugins or when extensions want to the be the 1st plugin in the list for instance.

Note that it would make sense the Remember me plugin is located first in the list of system plugins. It would even make more sense that logging-in through the remember me feature is embedded in the CMS app and not in a plugin. Such logging-in should happen exactly as early as if the user was logged-in through the session or else there's a risk of similar side-effects happening in other areas, where some parts of the code see the user as a guest while later on it's seen as logged-in.

### Testing Instructions

From a stock Joomla install:

1. Disable Caching in Global configuration
2. Create a menu item GUEST with access level "guest"
3. Create a menu item REGISTERED with access level "registered"
4. Enable the Language Filter system plugin
5. Log out of admin
6. On front end, GUEST menu item should be displayed
7. Log in to the front end **make sure to tick the Remember me check box"
8. The REGISTERED menu item is shown, GUEST menu item is hidden
9. Close your browser:
    - the entire browser, not just the current tab
    - browser must **NOT** be set to "reload all tabs opened when it was closed".
10. Navigate to your test site URL again by pasting it in the address bar

Step 9 & 10 can be replaced by deleting some cookies, see end of this description.

### Actual result BEFORE applying this Pull Request

The GUEST menu item is displayed despite the user being logged in and the login module showing the user as Logged in. The REGISTERED menu item is not displayed.

### Expected result AFTER applying this Pull Request

The REGISTERED menu item is displayed and the GUEST one is not shown.

### Note on testing:

Rather than closing browser at each attempt, you can simulate the same behavior with the development tools:

1. Open the dev tools at Application->Cookies
2. After logging-in with Remember me checked - step 8, you'll see (at least) 3 cookies:

- joomla_remember_me_xxxx
- joomla_user_state_xxx
- session cookie that looks like "433f42e5e0d104622fd1b9c1c38b3945"

To simulate closing the browser, you can delete the joomla_user_state cookie and the session cookie. After that, just reload the page to reproduce step 10.


