### PR TITLE
[4.0] Prioritise /tmpl component folder for menu items .xml definitions and componentlayout field

### DIFF
--- a/administrator/components/com_menus/src/Model/ItemModel.php
+++ b/administrator/components/com_menus/src/Model/ItemModel.php
@@ -1177,9 +1177,9 @@ class ItemModel extends AdminModel
 
 				// Check for the layout XML file. Use standard xml file if it exists.
 				$tplFolders = array(
+					$base . '/tmpl/' . $view,
 					$base . '/views/' . $view . '/tmpl',
 					$base . '/view/' . $view . '/tmpl',
-					$base . '/tmpl/' . $view
 				);
 				$path = Path::find($tplFolders, $layout . '.xml');
 

--- a/libraries/src/Form/Field/ComponentlayoutField.php
+++ b/libraries/src/Form/Field/ComponentlayoutField.php
@@ -128,12 +128,12 @@ class ComponentlayoutField extends FormField
 			$templates = $db->loadObjectList('element');
 
 			// Build the search paths for component layouts.
-			$component_path = Path::clean($client->path . '/components/' . $extension . '/views/' . $view . '/tmpl');
+			$component_path = Path::clean($client->path . '/components/' . $extension . '/tmpl/' . $view);
 
-			// Check if the old layouts folder exists, else use the new one
+			// Check if the new layouts folder exists, else use the old one
 			if (!is_dir($component_path))
 			{
-				$component_path = Path::clean($client->path . '/components/' . $extension . '/tmpl/' . $view);
+				$component_path = Path::clean($client->path . '/components/' . $extension . '/views/' . $view . '/tmpl');
 			}
 
 			// Prepare array of component layouts


### PR DESCRIPTION
# Summary of Changes

Joomla 4 code is mostly prioritised to load layouts and their xml files from `/components/com_component/tmpl` folder but not from `/components/com_component/views/xxxx/tmpl`.

But when editing the menu item, the Joomla3-style `/components/com_component/views/xxxx/tmpl/layout.xml` is still loaded instead of Joomla4-style `/components/com_component/tmpl/xxxx/layout.xml`.

Same for "componentlayout" field.

### Testing Instructions

Try to edit menu items of a component which as Joomla3-style `/views` folder and Joomla4-style `/tmpl` folder.

### Actual result BEFORE applying this Pull Request

See that Joomla3-style layouts are loaded.

### Expected result AFTER applying this Pull Request

Joomla4-style layouts are loaded.

### Documentation Changes Required

No.