### PR TITLE
[4.0] Correcting addInline() to support WebAssetItemInterface and String, as planned

### DIFF
--- a/libraries/src/WebAsset/WebAssetManager.php
+++ b/libraries/src/WebAsset/WebAssetManager.php
@@ -673,7 +673,7 @@ class WebAssetManager implements WebAssetManagerInterface
 	 *
 	 * @since  4.0.0
 	 */
-	public function addInline(string $type, string $content, array $options = [], array $attributes = [], array $dependencies = []): self
+	public function addInline(string $type, $content, array $options = [], array $attributes = [], array $dependencies = []): self
 	{
 		if ($content instanceof WebAssetItemInterface)
 		{
@@ -683,6 +683,7 @@ class WebAssetManager implements WebAssetManagerInterface
 		{
 			$name          = $options['name'] ?? ('inline.' . md5($content));
 			$assetInstance = $this->registry->createAsset($name, '', $options, $attributes, $dependencies);
+			$assetInstance->setOption('content', $content);
 		}
 		else
 		{
@@ -695,7 +696,6 @@ class WebAssetManager implements WebAssetManagerInterface
 		// Set required options
 		$assetInstance->setOption('type', $type);
 		$assetInstance->setOption('inline', true);
-		$assetInstance->setOption('content', $content);
 
 		// Add to registry
 		$this->registry->add($type, $assetInstance);


### PR DESCRIPTION
Pull Request for Issue #30933 .

### Summary of Changes

Remove typehint for addInline() method, as it in registerAsset().
To support both types WebAssetItemInterface and String


### Testing Instructions
add to index.php of the template:
```
$wa->addInlineScript(new \Joomla\CMS\WebAsset\WebAssetItem('inline.blabla', null, ['content' => 'alert(1);']));
$wa->addInlineScript('alert(2);');
```


### Actual result BEFORE applying this Pull Request
an error


### Expected result AFTER applying this Pull Request
you get 2 alerts


### Documentation Changes Required
none
