### PR TITLE
[4.0] Remove None Selected option in FileSystem

### DIFF
--- a/plugins/filesystem/local/local.xml
+++ b/plugins/filesystem/local/local.xml
@@ -41,6 +41,7 @@
 							folderFilter=""
 							exclude=""
 							stripext=""
+							hide_none="true"
 						/>
 					</form>
 				</field>


### PR DESCRIPTION
Pull Request for Issue #30958.

### Summary of Changes
Prevent error in Media when None Selected is selected under FileSystem plugin.


### Testing Instructions
Go to System > Plugins
Search `FileSystem - Local`
Edit plugin.
Click dropdown and check that `None Selected` is not listed.
