### PR TITLE
[4.0] Remove hover effect from com_cpanel card, make your eyes happy

### DIFF
--- a/administrator/templates/atum/scss/pages/_com_cpanel.scss
+++ b/administrator/templates/atum/scss/pages/_com_cpanel.scss
@@ -84,10 +84,6 @@
       margin-bottom: 0;
     }
 
-    &:hover {
-      box-shadow: 0 0 40px 10px rgba(0, 28, 73, .15);
-    }
-
     .list-group,
     .table {
       > .published {


### PR DESCRIPTION
### Summary of Changes 

Removes hover effect from .com_cpanel .card, to make navigation more easy for eyes.
Such effect would make sense if the card content does not have hover effect. Currently it just distracting.


### Testing Instructions
Apply path, run `node build.js --compile-css`.
Go to Home Dashboard, and move mouse around different cards


### Actual result BEFORE applying this Pull Request
Everything blinking, eyes distracted by card hover and content hover.


### Expected result AFTER applying this Pull Request
Easy for eyes :)


### Documentation Changes Required
none
