### PR TITLE
[4.0] Ooops: frontend contacts layouts `filter-field` correction

### DIFF
--- a/components/com_contact/tmpl/category/default_items.php
+++ b/components/com_contact/tmpl/category/default_items.php
@@ -31,7 +31,7 @@ $listDirn   = $this->escape($this->state->get('list.direction'));
 ?>
 <div class="com-contact-category__items">
 	<form action="<?php echo htmlspecialchars(Uri::getInstance()->toString()); ?>" method="post" name="adminForm" id="adminForm">
-		<?php if ($this->params->get('filter_field') !== 'hide') : ?>
+		<?php if ($this->params->get('filter_field')) : ?>
 			<div class="com-contact-category__filter btn-group">
 				<label class="filter-search-lbl sr-only" for="filter-search">
 					<?php echo Text::_('COM_CONTACT_FILTER_SEARCH_DESC'); ?>

--- a/components/com_contact/tmpl/featured/default_items.php
+++ b/components/com_contact/tmpl/featured/default_items.php
@@ -26,7 +26,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 ?>
 <div class="com-contact-featured__items">
 	<form action="<?php echo htmlspecialchars(Uri::getInstance()->toString()); ?>" method="post" name="adminForm" id="adminForm">
-		<?php if ($this->params->get('filter_field') !== 'hide') : ?>
+		<?php if ($this->params->get('filter_field')) : ?>
 			<div class="com-contact-featured__filter btn-group">
 				<label class="filter-search-lbl sr-only" for="filter-search">
 					<?php echo Text::_('COM_CONTACT_FILTER_SEARCH_DESC'); ?>


### PR DESCRIPTION
### Summary of Changes
For both `List Contacts in a Category` and `Featured contacts` menu items, the `filter-field` parameter is wrong when used in the layout (my fault).
Was a bad copy-paste from Articles Category List where the field may have a `hide` value.

### Testing Instructions

Check both menu items results after switching filter field to Show or Hide.