### PR TITLE
Fix markup in com_admin profile view

### DIFF
--- a/administrator/components/com_admin/views/profile/tmpl/edit.php
+++ b/administrator/components/com_admin/views/profile/tmpl/edit.php
@@ -101,8 +101,8 @@ $this->ignore_fieldsets = array('user_details');
 				<div class="clearfix"></div>
 			<?php endif; ?>
 		</fieldset>
+		<?php echo JHtml::_('bootstrap.endTab'); ?>
 	<?php endif; ?>
-	<?php echo JHtml::_('bootstrap.endTab'); ?>
 	<?php echo JLayoutHelper::render('joomla.edit.params', $this); ?>
 	<?php echo JHtml::_('bootstrap.endTabSet'); ?>
 	<input type="hidden" name="task" value="" />


### PR DESCRIPTION
Fixes https://github.com/joomla/joomla-cms/issues/31001.

### Summary of Changes

Corrects markup, fixing tabs not switching.

### Testing Instructions

Login to backend.
Edit your profile through `com_admin`.
Try switching tabs.

### Actual result BEFORE applying this Pull Request

Switching tabs doesn't work.

### Expected result AFTER applying this Pull Request

Switching tabs works.

### Documentation Changes Required

No.