### PR TITLE
[4] Remove Unnecessary Local Variable

### DIFF
--- a/api/components/com_languages/src/Controller/OverridesController.php
+++ b/api/components/com_languages/src/Controller/OverridesController.php
@@ -142,9 +142,7 @@ class OverridesController extends ApiController
 			throw new Exception\Save(Text::sprintf('JLIB_APPLICATION_ERROR_SAVE_FAILED', $model->getError()));
 		}
 
-		$id = $validData['key'];
-
-		return $id;
+		return $validData['key'];
 	}
 
 	/**


### PR DESCRIPTION


### Summary of Changes

Remove Unnecessary Local Variable

Its not good practice to create a variable just before using it once and returning. 

Highlighted by #phpStorm code smell.

### Testing Instructions

Code review.


### Documentation Changes Required

None.