### PR TITLE
fix improper ksort type definition

### DIFF
--- a/administrator/components/com_templates/views/template/tmpl/default_tree.php
+++ b/administrator/components/com_templates/views/template/tmpl/default_tree.php
@@ -8,7 +8,7 @@
  */
 
 defined('_JEXEC') or die;
-ksort($this->files, SORT_NATURAL);
+ksort($this->files, 4);
 ?>
 
 <ul class='nav nav-list directory-tree'>


### PR DESCRIPTION
Pull Request for Issue # 30979

### Summary of Changes
changed to integer per https://www.w3schools.com/php/func_array_ksort.asp

### Testing Instructions
go to global configuration
set debug to yes
set log to development
go to administrator/index.php?option=com_templates&view=template&id=506
observe php warning exists
apply pr
refresh page verify that error is gone.

### Actual result BEFORE applying this Pull Request
![image](https://user-images.githubusercontent.com/1850089/95531162-78732d00-09a5-11eb-897c-8e9541d1fa52.png)

### Expected result AFTER applying this Pull Request
![image](https://user-images.githubusercontent.com/1850089/95531131-66918a00-09a5-11eb-87b4-5e3dc7f330e8.png)

### Documentation Changes Required
none
