### PR TITLE
[4.0] Throw exception when field class not found

### DIFF
--- a/libraries/src/Form/Form.php
+++ b/libraries/src/Form/Form.php
@@ -1590,6 +1590,8 @@ class Form
 	 * @return  FormField|boolean  The FormField object for the field or boolean false on error.
 	 *
 	 * @since   1.7.0
+	 * @throws  \UnexpectedValueException
+	 * @throws	\RuntimeException
 	 */
 	protected function loadField($element, $group = null, $value = null)
 	{
@@ -1608,7 +1610,7 @@ class Form
 		// If the object could not be loaded, get a text field object.
 		if ($field === false)
 		{
-			$field = FormHelper::loadFieldType('text');
+			throw new \RuntimeException(sprintf('Class for field type "%s" not found.', $type));
 		}
 
 		/*

--- a/libraries/src/Form/Form.php
+++ b/libraries/src/Form/Form.php
@@ -1591,7 +1591,7 @@ class Form
 	 *
 	 * @since   1.7.0
 	 * @throws  \UnexpectedValueException
-	 * @throws	\RuntimeException
+	 * @throws  \RuntimeException
 	 */
 	protected function loadField($element, $group = null, $value = null)
 	{


### PR DESCRIPTION
### Summary of Changes

Currently, when a form field class is not found, we fall back to a text field. This is highly unexpected and hard to spot for developers. If missing field class is not fixed, this ends up with poorly usable form and has potential security implications.

This changes the behavior so an exception is thrown instead.

### Testing Instructions

Go to Redirects.
In configuration enable Advanced Mode.
Try to create a new redirect.

### Actual result BEFORE applying this Pull Request

Redirect form opens but `Redirect Status Code` field is a text field (it should be a select list).

### Expected result AFTER applying this Pull Request

Error page is shown with message:

>Class for field type "redirect" not found. 

### Documentation Changes Required

Yes.