### PR TITLE
Fixing admin user activation url

### DIFF
--- a/administrator/components/com_admin/views/profile/tmpl/edit.php
+++ b/administrator/components/com_admin/views/profile/tmpl/edit.php
@@ -101,8 +101,8 @@ $this->ignore_fieldsets = array('user_details');
 				<div class="clearfix"></div>
 			<?php endif; ?>
 		</fieldset>
+		<?php echo JHtml::_('bootstrap.endTab'); ?>
 	<?php endif; ?>
-	<?php echo JHtml::_('bootstrap.endTab'); ?>
 	<?php echo JLayoutHelper::render('joomla.edit.params', $this); ?>
 	<?php echo JHtml::_('bootstrap.endTabSet'); ?>
 	<input type="hidden" name="task" value="" />

--- a/administrator/components/com_redirect/models/forms/link.xml
+++ b/administrator/components/com_redirect/models/forms/link.xml
@@ -19,7 +19,7 @@
 			description="COM_REDIRECT_FIELD_OLD_URL_DESC"
 			class="input-xxlarge"
 			size="50"
-			required="true" 
+			required="true"
 		/>
 
 		<field
@@ -29,7 +29,7 @@
 			description="COM_REDIRECT_FIELD_NEW_URL_DESC"
 			class="input-xxlarge"
 			size="50"
-			required="true" 
+			required="true"
 		/>
 
 		<field
@@ -37,7 +37,7 @@
 			type="text"
 			label="COM_REDIRECT_FIELD_COMMENT_LABEL"
 			description="COM_REDIRECT_FIELD_COMMENT_DESC"
-			size="40" 
+			size="40"
 		/>
 
 		<field
@@ -61,7 +61,7 @@
 			label="COM_REDIRECT_FIELD_REFERRER_LABEL"
 			id="referer"
 			size="50"
-			readonly="true" 
+			readonly="true"
 		/>
 
 		<field
@@ -71,7 +71,7 @@
 			id="created_date"
 			class="readonly"
 			size="20"
-			readonly="true" 
+			readonly="true"
 		/>
 
 		<field
@@ -81,7 +81,7 @@
 			id="modified_date"
 			class="readonly"
 			size="20"
-			readonly="true" 
+			readonly="true"
 		/>
 
 		<field
@@ -92,7 +92,7 @@
 			class="readonly"
 			size="20"
 			readonly="true"
-			filter="unset" 
+			filter="unset"
 		/>
 	</fieldset>
 	<fieldset name="advanced">
@@ -102,6 +102,7 @@
 			label="COM_REDIRECT_FIELD_REDIRECT_STATUS_CODE_LABEL"
 			description="COM_REDIRECT_FIELD_REDIRECT_STATUS_CODE_DESC"
 			default="301"
+			validate="options"
 			class="input-xlarge"
 		/>
 	</fieldset>

--- a/administrator/components/com_templates/models/template.php
+++ b/administrator/components/com_templates/models/template.php
@@ -1159,12 +1159,26 @@ class TemplatesModelTemplate extends JModelForm
 			$client   = JApplicationHelper::getClientInfo($template->client_id);
 			$relPath  = base64_decode($file);
 			$path     = JPath::clean($client->path . '/templates/' . $template->element . '/' . $relPath);
-			$JImage   = new JImage($path);
 
 			try
 			{
-				$image = $JImage->crop($w, $h, $x, $y, true);
-				$image->toFile($path);
+				$image      = new \JImage($path);
+				$properties = $image->getImageFileProperties($path);
+
+				switch ($properties->mime)
+				{
+					case 'image/png':
+						$imageType = \IMAGETYPE_PNG;
+						break;
+					case 'image/gif':
+						$imageType = \IMAGETYPE_GIF;
+						break;
+					default:
+						$imageType = \IMAGETYPE_JPEG;
+				}
+
+				$image->crop($w, $h, $x, $y, false);
+				$image->toFile($path, $imageType);
 
 				return true;
 			}
@@ -1195,12 +1209,25 @@ class TemplatesModelTemplate extends JModelForm
 			$relPath = base64_decode($file);
 			$path    = JPath::clean($client->path . '/templates/' . $template->element . '/' . $relPath);
 
-			$JImage = new JImage($path);
-
 			try
 			{
-				$image = $JImage->resize($width, $height, true, 1);
-				$image->toFile($path);
+				$image      = new \JImage($path);
+				$properties = $image->getImageFileProperties($path);
+
+				switch ($properties->mime)
+				{
+					case 'image/png':
+						$imageType = \IMAGETYPE_PNG;
+						break;
+					case 'image/gif':
+						$imageType = \IMAGETYPE_GIF;
+						break;
+					default:
+						$imageType = \IMAGETYPE_JPEG;
+				}
+
+				$image->resize($width, $height, false, \JImage::SCALE_FILL);
+				$image->toFile($path, $imageType);
 
 				return true;
 			}

--- a/build/build.php
+++ b/build/build.php
@@ -155,6 +155,7 @@ $filesArray = array(
  */
 $doNotPackage = array(
 	'.appveyor.yml',
+	'.drone.jsonnet',
 	'.drone.yml',
 	'.editorconfig',
 	'.github',

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -684,7 +684,7 @@ class PlgSystemLanguageFilter extends JPlugin
 						if (isset($associations[$lang_code]) && $menu->getItem($associations[$lang_code]))
 						{
 							$associationItemid = $associations[$lang_code];
-							$this->app->setUserState('users.login.form.return', 'index.php?Itemid=' . $associationItemid);
+							$this->app->setUserState('users.login.form.return', $this->processLoginReturnUrl($associationItemid));
 							$foundAssociation = true;
 						}
 					}
@@ -696,7 +696,7 @@ class PlgSystemLanguageFilter extends JPlugin
 						 * We redirect to the user preferred site language associated page.
 						 */
 						$associationItemid = $associations[$lang_code];
-						$this->app->setUserState('users.login.form.return', 'index.php?Itemid=' . $associationItemid);
+						$this->app->setUserState('users.login.form.return', $this->processLoginReturnUrl($associationItemid));
 						$foundAssociation = true;
 					}
 					elseif ($active->home)
@@ -706,7 +706,7 @@ class PlgSystemLanguageFilter extends JPlugin
 
 						if ($item && $item->language !== $active->language && $item->language !== '*')
 						{
-							$this->app->setUserState('users.login.form.return', 'index.php?Itemid=' . $item->id);
+							$this->app->setUserState('users.login.form.return', $this->processLoginReturnUrl($item->id));
 							$foundAssociation = true;
 						}
 					}
@@ -732,6 +732,26 @@ class PlgSystemLanguageFilter extends JPlugin
 				}
 			}
 		}
+	}
+
+	/**
+	 * Process login return URL and make sure it contains Itemid.
+	 *
+	 * @param   int  $fallbackItemid  Default menu item id if there is no Itemid in the url.
+	 *
+	 * @return string
+	 *
+	 * @since 3.9.23
+	 */
+	protected function processLoginReturnUrl($fallbackItemid)
+	{
+		$redirect = $this->app->getUserState('users.login.form.return');
+		$uri = new JUri($redirect);
+		if( JUri::isInternal($redirect) ) {
+			$uri->setVar('Itemid', $fallbackItemid);
+		}
+
+		return $uri->toString();
 	}
 
 	/**

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -741,13 +741,15 @@ class PlgSystemLanguageFilter extends JPlugin
 	 *
 	 * @return string
 	 *
-	 * @since 3.9.23
+	 * @since __DEPLOY_VERSION__
 	 */
 	protected function processLoginReturnUrl($fallbackItemid)
 	{
 		$redirect = $this->app->getUserState('users.login.form.return');
 		$uri = new JUri($redirect);
-		if( JUri::isInternal($redirect) ) {
+
+		if (JUri::isInternal($redirect))
+		{
 			$uri->setVar('Itemid', $fallbackItemid);
 		}
 


### PR DESCRIPTION
If you have users activation approved by administrator and administrator is not logged in when he clicks the activation anchor in notification e-mail he will be redirected to the login page. Then after successful authorization he is redirected. The problem is that language filter changes the return url (the activation url) when it doesn't detect Itemid set in the url. With activation URL there is no Itemid set anywhere so it changes the return by wiping ANY redirection data like the most important part - the token. This patch just sets Itemid if it is an internal url and it was not set. That way any redirection data should be safe right now.

Pull Request for Issue # .

### Summary of Changes



### Testing Instructions



### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Documentation Changes Required

