### PR TITLE
[4.0] Extra space cpanel tables

### DIFF
--- a/administrator/templates/atum/scss/pages/_com_cpanel.scss
+++ b/administrator/templates/atum/scss/pages/_com_cpanel.scss
@@ -99,6 +99,7 @@
         padding-left: .9rem;
         border-left: 5px solid var(--danger);
       }
+      margin-bottom: unset;
     }
 
   }


### PR DESCRIPTION
Removes the margin bottom from tables included in cpanel cards

PR for #31012 

### To test
npm ci or node build.js --compile-css

### before
![image](https://user-images.githubusercontent.com/1296369/95638393-57d1d280-0a8c-11eb-8736-db358da4bbdc.png)

### after
![image](https://user-images.githubusercontent.com/1296369/95638373-4b4d7a00-0a8c-11eb-95e6-ff58ad88137c.png)
