### PR TITLE
[4.0] Non-empty, non-matching searches shouldn't return anything

### DIFF
--- a/components/com_finder/src/Model/SearchModel.php
+++ b/components/com_finder/src/Model/SearchModel.php
@@ -260,7 +260,7 @@ class SearchModel extends ListModel
 		 * If there are no optional or required search terms in the query, we
 		 * can get the results in one relatively simple database query.
 		 */
-		if (empty($this->includedTerms) && $this->searchquery->empty)
+		if (empty($this->includedTerms) && $this->searchquery->empty && $this->searchquery->input == '')
 		{
 			// Return the results.
 			return $query;
@@ -269,8 +269,11 @@ class SearchModel extends ListModel
 		/*
 		 * If there are no optional or required search terms in the query and
 		 * empty searches are not allowed, we return an empty query.
+		 * If the search term is not empty and empty searches are allowed,
+		 * but no terms were found, we return an empty query as well.
 		 */
-		if (empty($this->includedTerms) && !$this->searchquery->empty)
+		if (empty($this->includedTerms)
+			&& (!$this->searchquery->empty || ($this->searchquery->empty && $this->searchquery->input != '')))
 		{
 			// Since we need to return a query, we simplify this one.
 			$query->clear('join')


### PR DESCRIPTION
### Summary of Changes
This fixes #30967. When empty searches are allowed and the search is non-empty, but not matching, then it shouldn't return any results.


### Testing Instructions
1. After installation, insert sample data of choice.
2. Edit global options of Smart Search and set "Allow Empty Search" to "Yes".
3. Go to the frontend and open Smart Search for example by accessing index.php?option=com_finder&view=search.
4. Search for something that definitely is not on the site, like "cockadoodle".


### Actual result BEFORE applying this Pull Request
Returns all entries in your index.


### Expected result AFTER applying this Pull Request
Returns an empty result.


### Documentation Changes Required
none.
