### PR TITLE
[4.0] Categories need to have a route to be indexed

### DIFF
--- a/plugins/finder/categories/categories.php
+++ b/plugins/finder/categories/categories.php
@@ -11,7 +11,6 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Table\Table;
-use Joomla\Component\Content\Site\Helper\RouteHelper;
 use Joomla\Component\Finder\Administrator\Indexer\Adapter;
 use Joomla\Component\Finder\Administrator\Indexer\Helper;
 use Joomla\Component\Finder\Administrator\Indexer\Indexer;
@@ -326,7 +325,17 @@ class PlgFinderCategories extends Adapter
 		}
 		else
 		{
-			$item->route = RouteHelper::getCategoryRoute($item->id, $item->language);
+			$class = 'Joomla\\Component\\' . $extension . '\\Site\\Helper\\RouteHelper';
+
+			if (class_exists($class) && method_exists($class, 'getCategoryRoute'))
+			{
+				$item->route = $class::getCategoryRoute($item->id, $item->language);
+			}
+			else
+			{
+				// This category has no frontend route.
+				return;
+			}
 		}
 
 		// Get the menu title if it exists.


### PR DESCRIPTION
Pull Request for Issue #30968.

### Summary of Changes
When indexing categories, we need to have a route to those categories. If there is no (valid) route, we can't generate a URL to the search results source. Simply falling back to the RouteHelper of com_content is definitely wrong.


### Testing Instructions
1. After installation insert the Blog Sampledata.
2. Go to Smart Search and click "indexing".
3. Search in the frontend for "Uncategorised" by visiting `index.php?option=com_finder&view=search`.


### Actual result BEFORE applying this Pull Request
You will see an entry with ID 7. Clicking on the link will give a 404. If you look in the database, the category with ID 7 belongs to the component com_users.


### Expected result AFTER applying this Pull Request
After clearing the index and indexing again, there is no result with ID 7 anymore.


### Documentation Changes Required
None.
