### PR TITLE
[4.0] Ignore missing template description

### DIFF
--- a/administrator/components/com_templates/tmpl/template/default_description.php
+++ b/administrator/components/com_templates/tmpl/template/default_description.php
@@ -24,5 +24,5 @@ use Joomla\Component\Templates\Administrator\Helper\TemplatesHelper;
 	<h2><?php echo ucfirst($this->template->element); ?></h2>
 	<?php $client = ApplicationHelper::getClientInfo($this->template->client_id); ?>
 	<p><?php $this->template->xmldata = TemplatesHelper::parseXMLTemplateFile($client->path, $this->template->element); ?></p>
-	<p><?php echo Text::_($this->template->xmldata->description); ?></p>
+	<p><?php echo Text::_($this->template->xmldata->get('description')); ?></p>
 </div>


### PR DESCRIPTION
Pull Request for Issue #30974 .

### Summary of Changes

Use getter method to get description

### Testing Instructions

* Open a template in backend and look at the description tab
* Everything fine
* Rename the templateDetails.xml to anything else
* Look at the description tab again
* Everything fine

### Actual result BEFORE applying this Pull Request

Looking at the description tab displays a NOTICE

### Expected result AFTER applying this Pull Request

Everything fine

### Documentation Changes Required

No