### PR TITLE
[4] Second condition is always 'true' because 'is_object($data)'

### DIFF
--- a/plugins/system/webauthn/src/PluginTraits/UserProfileFields.php
+++ b/plugins/system/webauthn/src/PluginTraits/UserProfileFields.php
@@ -155,7 +155,7 @@ trait UserProfileFields
 		{
 			$id = isset($data['id']) ? $data['id'] : null;
 		}
-		elseif (is_object($data) && is_null($data) && ($data instanceof Registry))
+		elseif (is_object($data) && ($data instanceof Registry))
 		{
 			$id = $data->get('id');
 		}

--- a/plugins/system/webauthn/src/PluginTraits/UserProfileFields.php
+++ b/plugins/system/webauthn/src/PluginTraits/UserProfileFields.php
@@ -159,7 +159,7 @@ trait UserProfileFields
 		{
 			$id = $data->get('id');
 		}
-		elseif (is_object($data) && !is_null($data))
+		elseif (is_object($data))
 		{
 			$id = isset($data->id) ? $data->id : null;
 		}


### PR DESCRIPTION
### Summary of Changes

Removal of redundant code. 

Second condition is always `true` because `is_object($data)` is already `true` at this point. 

### Testing Instructions

Code review