### PR TITLE
[4] Unnecessary local variable

### DIFF
--- a/plugins/content/emailcloak/emailcloak.php
+++ b/plugins/content/emailcloak/emailcloak.php
@@ -71,9 +71,7 @@ class PlgContentEmailcloak extends CMSPlugin
 	 */
 	protected function _getPattern($link, $text)
 	{
-		$pattern = '~(?:<a ([^>]*)href\s*=\s*"mailto:' . $link . '"([^>]*))>' . $text . '</a>~i';
-
-		return $pattern;
+		return '~(?:<a ([^>]*)href\s*=\s*"mailto:' . $link . '"([^>]*))>' . $text . '</a>~i';
 	}
 
 	/**

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -913,8 +913,7 @@ class PlgEditorTinymce extends CMSPlugin
 	{
 		// See https://www.tinymce.com/docs/demo/full-featured/
 		// And https://www.tinymce.com/docs/plugins/
-		$buttons = [
-
+		return [
 			// General buttons
 			'|'              => array('label' => Text::_('PLG_TINY_TOOLBAR_BUTTON_SEPARATOR'), 'text' => '|'),
 
@@ -981,8 +980,6 @@ class PlgEditorTinymce extends CMSPlugin
 			'insertdatetime' => array('label' => 'Insert date/time', 'plugin' => 'insertdatetime'),
 			// 'spellchecker'   => array('label' => 'Spellcheck', 'plugin' => 'spellchecker'),
 		];
-
-		return $buttons;
 	}
 
 	/**

--- a/plugins/extension/finder/finder.php
+++ b/plugins/extension/finder/finder.php
@@ -117,9 +117,8 @@ class PlgExtensionFinder extends CMSPlugin
 			->bind(':eid', $eid, ParameterType::INTEGER);
 
 		$db->setQuery($query);
-		$extension = $db->loadObject();
 
-		return $extension;
+		return $db->loadObject();
 	}
 
 	/**

--- a/plugins/finder/tags/tags.php
+++ b/plugins/finder/tags/tags.php
@@ -354,9 +354,7 @@ class PlgFinderTags extends Adapter
 	protected function getUpdateQueryByTime($time)
 	{
 		// Build an SQL query based on the modified time.
-		$query = $this->db->getQuery(true)
+		return $this->db->getQuery(true)
 			->where('a.date >= ' . $this->db->quote($time));
-
-		return $query;
 	}
 }

--- a/plugins/twofactorauth/totp/totp.php
+++ b/plugins/twofactorauth/totp/totp.php
@@ -219,15 +219,13 @@ class PlgTwofactorauthTotp extends CMSPlugin
 		}
 
 		// Check succeeded; return an OTP configuration object
-		$otpConfig = (object) array(
+		return (object) array(
 			'method'   => 'totp',
 			'config'   => array(
 				'code' => $data['key']
 			),
 			'otep'     => array()
 		);
-
-		return $otpConfig;
 	}
 
 	/**

--- a/plugins/twofactorauth/yubikey/yubikey.php
+++ b/plugins/twofactorauth/yubikey/yubikey.php
@@ -187,15 +187,13 @@ class PlgTwofactorauthYubikey extends CMSPlugin
 		$yubikey      = substr($data['securitycode'], 0, -32);
 
 		// Check succeeded; return an OTP configuration object
-		$otpConfig    = (object) array(
+		return (object) array(
 			'method'  => $this->methodName,
 			'config'  => array(
 				'yubikey' => $yubikey
 			),
 			'otep'    => array()
 		);
-
-		return $otpConfig;
 	}
 
 	/**


### PR DESCRIPTION
### Summary of Changes

Remove unnecessary local variable

Assigning a value to a variable that is otherwise unused apart from returning is bad practice and increases the memory used by PHP and should be avoided.

### Testing Instructions

Code review