### PR TITLE
[4] Return value type is not compatible with declared

### DIFF
--- a/installation/src/Model/ConfigurationModel.php
+++ b/installation/src/Model/ConfigurationModel.php
@@ -375,8 +375,6 @@ class ConfigurationModel extends BaseInstallationModel
 				'error'
 			);
 		}
-
-		return true;
 	}
 
 	/**


### PR DESCRIPTION

### Summary of Changes

Return value type is not compatible with declared type in PHPDoc block

I chose to remove the `return true` instead of update the docs (like I have for these https://github.com/joomla/joomla-cms/pull/31060) because this method is ONLY called by 

https://github.com/joomla/joomla-cms/blob/3f96c70fe712bde3fa3e65d7687ec5c788c8ab36/installation/src/Model/ConfigurationModel.php#L224

where it doesn't need a `true` to be returned and expects just a void return.

### Testing Instructions

Code review