### PR TITLE
[4] Variable key is used in both the inner and outer foreach loops

### DIFF
--- a/libraries/src/Console/GetConfigurationCommand.php
+++ b/libraries/src/Console/GetConfigurationCommand.php
@@ -172,7 +172,7 @@ class GetConfigurationCommand extends AbstractCommand
 				$foundGroup = true;
 				$options = [];
 
-				foreach ($value['options'] as $key => $option)
+				foreach ($value['options'] as $option)
 				{
 					$options[] = [$option, $configs[$option]];
 				}


### PR DESCRIPTION
### Summary of Changes

Variable key is used in both the inner and outer foreach loops which could cause issues (it doesn't but it could, and is code smell reported by phpStorm) 

### Testing Instructions

Code review
