### PR TITLE
[4] use integer in sql

### DIFF
--- a/administrator/components/com_content/src/Model/ArticlesModel.php
+++ b/administrator/components/com_content/src/Model/ArticlesModel.php
@@ -17,7 +17,6 @@ use Joomla\CMS\Language\Associations;
 use Joomla\CMS\MVC\Model\ListModel;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Table\Table;
-use Joomla\CMS\Workflow\Workflow;
 use Joomla\Component\Content\Administrator\Extension\ContentComponent;
 use Joomla\Database\ParameterType;
 use Joomla\Registry\Registry;

--- a/administrator/components/com_content/src/Model/ArticlesModel.php
+++ b/administrator/components/com_content/src/Model/ArticlesModel.php
@@ -159,6 +159,12 @@ class ArticlesModel extends ListModel
 
 		$formSubmited = $app->input->post->get('form_submited');
 
+		// Gets the value of a user state variable and sets it in the session
+		$this->getUserStateFromRequest($this->context . '.filter.access', 'filter_access');
+		$this->getUserStateFromRequest($this->context . '.filter.author_id', 'filter_author_id');
+		$this->getUserStateFromRequest($this->context . '.filter.category_id', 'filter_category_id');
+		$this->getUserStateFromRequest($this->context . '.filter.tag', 'filter_tag', '');
+
 		if ($formSubmited)
 		{
 			$access = $app->input->post->get('access');

--- a/administrator/components/com_content/src/Model/ArticlesModel.php
+++ b/administrator/components/com_content/src/Model/ArticlesModel.php
@@ -160,11 +160,6 @@ class ArticlesModel extends ListModel
 
 		$formSubmited = $app->input->post->get('form_submited');
 
-		$access     = $this->getUserStateFromRequest($this->context . '.filter.access', 'filter_access');
-		$authorId   = $this->getUserStateFromRequest($this->context . '.filter.author_id', 'filter_author_id');
-		$categoryId = $this->getUserStateFromRequest($this->context . '.filter.category_id', 'filter_category_id');
-		$tag        = $this->getUserStateFromRequest($this->context . '.filter.tag', 'filter_tag', '');
-
 		if ($formSubmited)
 		{
 			$access = $app->input->post->get('access');
@@ -385,7 +380,7 @@ class ArticlesModel extends ListModel
 			{
 				$state = (int) $published;
 				$query->where($db->quoteName('a.state') . ' = :state')
-					->bind(':state', $published, ParameterType::INTEGER);
+					->bind(':state', $state, ParameterType::INTEGER);
 			}
 			elseif (!is_numeric($workflowStage))
 			{
@@ -418,7 +413,6 @@ class ArticlesModel extends ListModel
 			foreach ($categoryId as $key => $filter_catid)
 			{
 				$categoryTable->load($filter_catid);
-				$categoryWhere = '';
 
 				// Because values to $query->bind() are passed by reference, using $query->bindArray() here instead to prevent overwriting.
 				$valuesToBind = [$categoryTable->lft, $categoryTable->rgt];
@@ -659,8 +653,6 @@ class ArticlesModel extends ListModel
 				$query->where('((' . implode(') OR (', $where) . '))');
 
 				$transitions = $db->setQuery($query)->loadAssocList();
-
-				$workflow = new Workflow(['extension' => 'com_content.article']);
 
 				foreach ($transitions as $key => $transition)
 				{


### PR DESCRIPTION
### Summary of Changes

Code review

`$state` is defined as an integer, and is then not used for the rest of the method as $published is passed to the query, 

phpStorm complains that `$state` is unused

I guess it should be used in the query that follows its casting to int 

This PR makes that change

-- 

This PR also removes some other "unused" variables. 