### PR TITLE
[4] Return is unnecessary as the last statement in a void method

### DIFF
--- a/administrator/components/com_associations/src/Controller/AssociationsController.php
+++ b/administrator/components/com_associations/src/Controller/AssociationsController.php
@@ -133,7 +133,5 @@ class AssociationsController extends AdminController
 			Route::_('index.php?option=' . $this->option . '&view=' . $this->view_list),
 			Text::_('COM_ASSOCIATIONS_YOU_ARE_NOT_ALLOWED_TO_CHECKIN_THIS_ITEM')
 		);
-
-		return;
 	}
 }

--- a/administrator/components/com_content/src/Model/ArticleModel.php
+++ b/administrator/components/com_content/src/Model/ArticleModel.php
@@ -1129,7 +1129,6 @@ class ArticleModel extends AdminModel implements WorkflowModelInterface
 	 */
 	public function hit()
 	{
-		return;
 	}
 
 	/**

--- a/administrator/components/com_fields/src/Controller/FieldController.php
+++ b/administrator/components/com_fields/src/Controller/FieldController.php
@@ -194,7 +194,5 @@ class FieldController extends FormController
 			$registry->loadArray($item->params);
 			$item->params = (string) $registry;
 		}
-
-		return;
 	}
 }

--- a/administrator/components/com_fields/src/Controller/GroupController.php
+++ b/administrator/components/com_fields/src/Controller/GroupController.php
@@ -168,8 +168,6 @@ class GroupController extends FormController
 			$registry->loadArray($item->params);
 			$item->params = (string) $registry;
 		}
-
-		return;
 	}
 
 	/**

--- a/administrator/components/com_login/src/Controller/DisplayController.php
+++ b/administrator/components/com_login/src/Controller/DisplayController.php
@@ -111,8 +111,6 @@ class DisplayController extends BaseController
 			}
 
 			echo $response;
-
-			return;
 		}
 		else
 		{

--- a/administrator/components/com_templates/src/Model/TemplateModel.php
+++ b/administrator/components/com_templates/src/Model/TemplateModel.php
@@ -303,8 +303,6 @@ class TemplateModel extends FormModel
 				}
 			}
 		}
-
-		return;
 	}
 
 	/**

--- a/administrator/components/com_users/src/Controller/UserController.php
+++ b/administrator/components/com_users/src/Controller/UserController.php
@@ -110,6 +110,5 @@ class UserController extends FormController
 	 */
 	protected function postSaveHook(BaseDatabaseModel $model, $validData = array())
 	{
-		return;
 	}
 }

--- a/libraries/src/Access/Rules.php
+++ b/libraries/src/Access/Rules.php
@@ -170,8 +170,6 @@ class Rules
 		{
 			return $this->data[$action]->allow($identity);
 		}
-
-		return;
 	}
 
 	/**

--- a/libraries/src/Feed/Parser/Rss/ItunesRssParser.php
+++ b/libraries/src/Feed/Parser/Rss/ItunesRssParser.php
@@ -34,7 +34,6 @@ class ItunesRssParser implements NamespaceParserInterface
 	 */
 	public function processElementForFeed(Feed $feed, \SimpleXMLElement $el)
 	{
-		return;
 	}
 
 	/**
@@ -49,6 +48,5 @@ class ItunesRssParser implements NamespaceParserInterface
 	 */
 	public function processElementForFeedEntry(FeedEntry $entry, \SimpleXMLElement $el)
 	{
-		return;
 	}
 }

--- a/libraries/src/Feed/Parser/Rss/MediaRssParser.php
+++ b/libraries/src/Feed/Parser/Rss/MediaRssParser.php
@@ -34,7 +34,6 @@ class MediaRssParser implements NamespaceParserInterface
 	 */
 	public function processElementForFeed(Feed $feed, \SimpleXMLElement $el)
 	{
-		return;
 	}
 
 	/**
@@ -49,6 +48,5 @@ class MediaRssParser implements NamespaceParserInterface
 	 */
 	public function processElementForFeedEntry(FeedEntry $entry, \SimpleXMLElement $el)
 	{
-		return;
 	}
 }

--- a/libraries/src/HTML/Helpers/Behavior.php
+++ b/libraries/src/HTML/Helpers/Behavior.php
@@ -123,8 +123,6 @@ abstract class Behavior
 	public static function keepalive()
 	{
 		Factory::getApplication()->getDocument()->getWebAssetManager()->useScript('keepalive');
-
-		return;
 	}
 
 	/**
@@ -194,8 +192,6 @@ abstract class Behavior
 		);
 
 		static::$loaded[__METHOD__][$sig] = true;
-
-		return;
 	}
 
 	/**

--- a/libraries/src/HTML/Helpers/Dropdown.php
+++ b/libraries/src/HTML/Helpers/Dropdown.php
@@ -77,8 +77,6 @@ abstract class Dropdown
 
 		// Set static array
 		static::$loaded[__METHOD__] = true;
-
-		return;
 	}
 
 	/**
@@ -103,8 +101,6 @@ abstract class Dropdown
 							<ul class="dropdown-menu">';
 		static::$dropDownList = $dropDownList;
 		static::$loaded[__METHOD__] = true;
-
-		return;
 	}
 
 	/**
@@ -154,8 +150,6 @@ abstract class Dropdown
 		$link = Route::_($link);
 
 		static::addCustomItem(Text::_('JACTION_EDIT'), $link);
-
-		return;
 	}
 
 	/**
@@ -172,8 +166,6 @@ abstract class Dropdown
 	{
 		$task = $prefix . 'publish';
 		static::addCustomItem(Text::_('JTOOLBAR_PUBLISH'), 'javascript:void(0)', 'onclick="contextAction(\'' . $checkboxId . '\', \'' . $task . '\')"');
-
-		return;
 	}
 
 	/**
@@ -190,8 +182,6 @@ abstract class Dropdown
 	{
 		$task = $prefix . 'unpublish';
 		static::addCustomItem(Text::_('JTOOLBAR_UNPUBLISH'), 'javascript:void(0)', 'onclick="contextAction(\'' . $checkboxId . '\', \'' . $task . '\')"');
-
-		return;
 	}
 
 	/**
@@ -208,8 +198,6 @@ abstract class Dropdown
 	{
 		$task = $prefix . 'featured';
 		static::addCustomItem(Text::_('JFEATURED'), 'javascript:void(0)', 'onclick="contextAction(\'' . $checkboxId . '\', \'' . $task . '\')"');
-
-		return;
 	}
 
 	/**
@@ -226,8 +214,6 @@ abstract class Dropdown
 	{
 		$task = $prefix . 'unfeatured';
 		static::addCustomItem(Text::_('JUNFEATURED'), 'javascript:void(0)', 'onclick="contextAction(\'' . $checkboxId . '\', \'' . $task . '\')"');
-
-		return;
 	}
 
 	/**
@@ -244,8 +230,6 @@ abstract class Dropdown
 	{
 		$task = $prefix . 'archive';
 		static::addCustomItem(Text::_('JTOOLBAR_ARCHIVE'), 'javascript:void(0)', 'onclick="contextAction(\'' . $checkboxId . '\', \'' . $task . '\')"');
-
-		return;
 	}
 
 	/**
@@ -262,8 +246,6 @@ abstract class Dropdown
 	{
 		$task = $prefix . 'unpublish';
 		static::addCustomItem(Text::_('JTOOLBAR_UNARCHIVE'), 'javascript:void(0)', 'onclick="contextAction(\'' . $checkboxId . '\', \'' . $task . '\')"');
-
-		return;
 	}
 
 	/**
@@ -280,8 +262,6 @@ abstract class Dropdown
 	{
 		$task = $prefix . 'trash';
 		static::addCustomItem(Text::_('JTOOLBAR_TRASH'), 'javascript:void(0)', 'onclick="contextAction(\'' . $checkboxId . '\', \'' . $task . '\')"');
-
-		return;
 	}
 
 	/**
@@ -298,8 +278,6 @@ abstract class Dropdown
 	{
 		$task = $prefix . 'publish';
 		static::addCustomItem(Text::_('JTOOLBAR_UNTRASH'), 'javascript:void(0)', 'onclick="contextAction(\'' . $checkboxId . '\', \'' . $task . '\')"');
-
-		return;
 	}
 
 	/**
@@ -316,8 +294,6 @@ abstract class Dropdown
 	{
 		$task = $prefix . 'checkin';
 		static::addCustomItem(Text::_('JTOOLBAR_CHECKIN'), 'javascript:void(0)', 'onclick="contextAction(\'' . $checkboxId . '\', \'' . $task . '\')"');
-
-		return;
 	}
 
 	/**
@@ -330,8 +306,6 @@ abstract class Dropdown
 	public static function divider()
 	{
 		static::$dropDownList .= '<li class="divider"></li>';
-
-		return;
 	}
 
 	/**
@@ -368,7 +342,5 @@ abstract class Dropdown
 		$dropDownList .= $label;
 		$dropDownList .= '</a></li>';
 		static::$dropDownList = $dropDownList;
-
-		return;
 	}
 }

--- a/libraries/src/HTML/Helpers/Jquery.php
+++ b/libraries/src/HTML/Helpers/Jquery.php
@@ -59,8 +59,6 @@ abstract class Jquery
 		{
 			$wa->useScript('jquery-migrate');
 		}
-
-		return;
 	}
 
 	/**

--- a/libraries/src/Image/Filter/Backgroundfill.php
+++ b/libraries/src/Image/Filter/Backgroundfill.php
@@ -76,8 +76,6 @@ class Backgroundfill extends ImageFilter
 
 		// Free up memory
 		imagedestroy($bg);
-
-		return;
 	}
 
 	/**

--- a/libraries/src/Language/LanguageHelper.php
+++ b/libraries/src/Language/LanguageHelper.php
@@ -102,8 +102,6 @@ class LanguageHelper
 				}
 			}
 		}
-
-		return;
 	}
 
 	/**

--- a/libraries/src/Utility/BufferStreamHandler.php
+++ b/libraries/src/Utility/BufferStreamHandler.php
@@ -70,8 +70,6 @@ class BufferStreamHandler
 
 			self::$registered = true;
 		}
-
-		return;
 	}
 
 	/**


### PR DESCRIPTION
Core Review 

Return is unnecessary as the last statement in a void method (or as the last segment ion an `if` in a method ending with an if/else block.