### PR TITLE
[4.0] Fixing "expand all" for com_finder in filter

### DIFF
--- a/build/media_source/com_finder/js/finder-edit.es6.js
+++ b/build/media_source/com_finder/js/finder-edit.es6.js
@@ -36,25 +36,18 @@ Joomla = window.Joomla || {};
         if (event.target.innerText === Joomla.JText._('COM_FINDER_FILTER_SHOW_ALL')) {
           event.target.innerText = Joomla.JText._('COM_FINDER_FILTER_HIDE_ALL');
 
-          elements = [].slice.call(document.querySelectorAll('.collapse:not(.in)'));
-
-          if (elements) {
-            elements.forEach((element) => {
-              // @todo Remove jQuery!!
-              window.jQuery(element).collapse('toggle');
-            });
-          }
+          elements = [].slice.call(document.querySelectorAll('.collapse:not(.show)'));
         } else {
           event.target.innerText = Joomla.JText._('COM_FINDER_FILTER_SHOW_ALL');
 
-          elements = [].slice.call(document.querySelectorAll('.collapse.in'));
+          elements = [].slice.call(document.querySelectorAll('.collapse.show'));
+        }
 
-          if (elements) {
-            elements.forEach((element) => {
-              // @todo Remove jQuery!!
-              window.jQuery(element).collapse('toggle');
-            });
-          }
+        if (elements) {
+          elements.forEach((element) => {
+            // @todo Remove jQuery!!
+            window.jQuery(element).collapse('toggle');
+          });
         }
       });
     }


### PR DESCRIPTION
Pull Request for Issue #30966.

### Summary of Changes
When creating a new filter in Smart Search, clicking the "Expand all" button doesn't have the desired effect. It closes the first tab, while expanding the others and the other way around. This fixes that.


### Testing Instructions
Copying the instructions from the original issue:
1. Joomla 4 -> install blog sample data
2. Index your content with Smart search
3. publish all your maps
4. Create a new Smart Search Filter
5. Click Expand all button


### Actual result BEFORE applying this Pull Request
The first accordion is closed, the rest is opened.


### Expected result AFTER applying this Pull Request
All accordions are expanded, the button is renamed to "Collapse all", clicking it again closes all and renames it again to "Expand all".


### Documentation Changes Required
None
