### PR TITLE
[4.0] Take off the Trash dropdown Action when filtering by trashed items

### DIFF
--- a/administrator/components/com_content/src/View/Articles/HtmlView.php
+++ b/administrator/components/com_content/src/View/Articles/HtmlView.php
@@ -210,7 +210,10 @@ class HtmlView extends BaseHtmlView
 
 				$childBar->checkin('articles.checkin')->listCheck(true);
 
-				$childBar->trash('articles.trash')->listCheck(true);
+				if (!$this->state->get('filter.published') == ContentComponent::CONDITION_TRASHED)
+				{
+					$childBar->trash('articles.trash')->listCheck(true);
+				}
 			}
 
 			// Add a batch button

--- a/administrator/components/com_content/src/View/Featured/HtmlView.php
+++ b/administrator/components/com_content/src/View/Featured/HtmlView.php
@@ -184,7 +184,10 @@ class HtmlView extends BaseHtmlView
 
 				$childBar->checkin('articles.checkin')->listCheck(true);
 
-				$childBar->trash('articles.trash')->listCheck(true);
+				if (!$this->state->get('filter.published') == ContentComponent::CONDITION_TRASHED)
+				{
+					$childBar->trash('articles.trash')->listCheck(true);
+				}
 			}
 		}
 

--- a/administrator/components/com_fields/src/View/Fields/HtmlView.php
+++ b/administrator/components/com_fields/src/View/Fields/HtmlView.php
@@ -176,7 +176,7 @@ class HtmlView extends BaseHtmlView
 				$childBar->checkin('fields.checkin')->listCheck(true);
 			}
 
-			if ($canDo->get('core.edit.state'))
+			if ($canDo->get('core.edit.state') && !$this->state->get('filter.state') == -2)
 			{
 				$childBar->trash('fields.trash')->listCheck(true);
 			}

--- a/administrator/components/com_fields/src/View/Groups/HtmlView.php
+++ b/administrator/components/com_fields/src/View/Groups/HtmlView.php
@@ -178,7 +178,7 @@ class HtmlView extends BaseHtmlView
 				$childBar->checkin('groups.checkin')->listCheck(true);
 			}
 
-			if ($canDo->get('core.edit.state'))
+			if ($canDo->get('core.edit.state') && !$this->state->get('filter.state') == -2)
 			{
 				$childBar->trash('groups.trash')->listCheck(true);
 			}

--- a/administrator/components/com_newsfeeds/src/View/Newsfeeds/HtmlView.php
+++ b/administrator/components/com_newsfeeds/src/View/Newsfeeds/HtmlView.php
@@ -150,7 +150,7 @@ class HtmlView extends BaseHtmlView
 				$childBar->checkin('newsfeeds.checkin')->listCheck(true);
 			}
 
-			if (!$this->state->get('filter.published') == -2 && $canDo->get('core.edit.state'))
+			if (!$this->state->get('filter.published') == -2)
 			{
 				$childBar->trash('newsfeeds.trash')->listCheck(true);
 			}

--- a/administrator/components/com_newsfeeds/src/View/Newsfeeds/HtmlView.php
+++ b/administrator/components/com_newsfeeds/src/View/Newsfeeds/HtmlView.php
@@ -150,7 +150,7 @@ class HtmlView extends BaseHtmlView
 				$childBar->checkin('newsfeeds.checkin')->listCheck(true);
 			}
 
-			if (!$this->state->get('filter.published') == -2)
+			if (!$this->state->get('filter.published') == -2 && $canDo->get('core.edit.state'))
 			{
 				$childBar->trash('newsfeeds.trash')->listCheck(true);
 			}

--- a/administrator/components/com_tags/src/View/Tags/HtmlView.php
+++ b/administrator/components/com_tags/src/View/Tags/HtmlView.php
@@ -152,7 +152,7 @@ class HtmlView extends BaseHtmlView
 				$childBar->checkin('tags.checkin')->listCheck(true);
 			}
 
-			if ($canDo->get('core.edit.state'))
+			if ($canDo->get('core.edit.state') && !$this->state->get('filter.published') == -2)
 			{
 				$childBar->trash('tags.trash')->listCheck(true);
 			}


### PR DESCRIPTION
Pull Request for part of Issue https://github.com/joomla/joomla-cms/issues/31004

### Summary of Changes
As title says.
Concerns:

1. Articles view
2. Featured articles view
3. Fields view
4. Fields => Groups view
5. Tags view

Other views already take care of this aspect.

### Testing Instructions
For each of these views, trash some items and then filter by Trashed status.
Select a trashed item and click on the Actions dropdown.


### Actual result BEFORE applying this Pull Request
The Trash choice displays

<img width="538" alt="Screen Shot 2020-10-12 at 10 06 31" src="https://user-images.githubusercontent.com/869724/95721320-b5277880-0c72-11eb-890e-c650468b17d2.png">



### Expected result AFTER applying this Pull Request
The trash choice does not display

<img width="515" alt="Screen Shot 2020-10-12 at 09 59 54" src="https://user-images.githubusercontent.com/869724/95721149-75f92780-0c72-11eb-9cd9-12bed98d5773.png">


### Documentation Changes Required

