### PR TITLE
Fixing admin user activation

### DIFF
--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -684,7 +684,7 @@ class PlgSystemLanguageFilter extends JPlugin
 						if (isset($associations[$lang_code]) && $menu->getItem($associations[$lang_code]))
 						{
 							$associationItemid = $associations[$lang_code];
-							$this->app->setUserState('users.login.form.return', 'index.php?Itemid=' . $associationItemid);
+							$this->app->setUserState('users.login.form.return', $this->processLoginReturnUrl($associationItemid));
 							$foundAssociation = true;
 						}
 					}
@@ -696,7 +696,7 @@ class PlgSystemLanguageFilter extends JPlugin
 						 * We redirect to the user preferred site language associated page.
 						 */
 						$associationItemid = $associations[$lang_code];
-						$this->app->setUserState('users.login.form.return', 'index.php?Itemid=' . $associationItemid);
+						$this->app->setUserState('users.login.form.return', $this->processLoginReturnUrl($associationItemid));
 						$foundAssociation = true;
 					}
 					elseif ($active->home)
@@ -706,7 +706,7 @@ class PlgSystemLanguageFilter extends JPlugin
 
 						if ($item && $item->language !== $active->language && $item->language !== '*')
 						{
-							$this->app->setUserState('users.login.form.return', 'index.php?Itemid=' . $item->id);
+							$this->app->setUserState('users.login.form.return', $this->processLoginReturnUrl($item->id)));
 							$foundAssociation = true;
 						}
 					}
@@ -732,6 +732,28 @@ class PlgSystemLanguageFilter extends JPlugin
 				}
 			}
 		}
+	}
+	
+	/**
+	 * Process login return URL and make sure it contains Itemid.
+	 *
+	 * @param   int  $fallbackItemid  Default menu item id if there is no Itemid in the url.
+	 *
+	 * @return string
+	 *
+	 * @since __DEPLOY_VERSION__
+	 */
+	protected function processLoginReturnUrl($fallbackItemid)
+	{
+		$redirect = $this->app->getUserState('users.login.form.return');
+		$uri = new JUri($redirect);
+
+		if (JUri::isInternal($redirect))
+		{
+			$uri->setVar('Itemid', $fallbackItemid);
+		}
+
+		return $uri->toString();
 	}
 
 	/**


### PR DESCRIPTION
If you have users activation approved by administrator and administrator is not logged in when he clicks the activation anchor in notification e-mail he will be redirected to the login page. Then after successful authorization he is redirected. The problem is that language filter changes the return url (the activation url) when it doesn't detect Itemid set in the url. With activation URL there is no Itemid set anywhere so it changes the return by wiping ANY redirection data like the most important part - the token. This patch just sets Itemid if it is an internal url and it was not set. That way any redirection data should be safe right now.

(moved from #31024)

Pull Request for Issue # .

### Summary of Changes



### Testing Instructions



### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Documentation Changes Required

