### PR TITLE
[4.0] Move calls out of the loop

### DIFF
--- a/libraries/src/Image/Image.php
+++ b/libraries/src/Image/Image.php
@@ -355,8 +355,9 @@ class Image
 			$imgProperties = static::getImageFileProperties($this->getPath());
 
 			// Get image filename and extension.
-			$filename       = pathinfo($this->getPath(), PATHINFO_FILENAME);
-			$fileExtension  = pathinfo($this->getPath(), PATHINFO_EXTENSION);
+			$pathInfo      = pathinfo($this->getPath());
+			$filename      = $pathInfo['filename'];
+			$fileExtension = $pathInfo['extension'] ?? '';
 
 			foreach ($thumbs as $thumb)
 			{

--- a/libraries/src/Image/Image.php
+++ b/libraries/src/Image/Image.php
@@ -354,16 +354,18 @@ class Image
 			// Parent image properties
 			$imgProperties = static::getImageFileProperties($this->getPath());
 
+			// Get image filename and extension.
+			$filename       = pathinfo($this->getPath(), PATHINFO_FILENAME);
+			$fileExtension  = pathinfo($this->getPath(), PATHINFO_EXTENSION);
+
 			foreach ($thumbs as $thumb)
 			{
 				// Get thumb properties
-				$thumbWidth     = $thumb->getWidth();
-				$thumbHeight    = $thumb->getHeight();
+				$thumbWidth  = $thumb->getWidth();
+				$thumbHeight = $thumb->getHeight();
 
 				// Generate thumb name
-				$filename       = pathinfo($this->getPath(), PATHINFO_FILENAME);
-				$fileExtension  = pathinfo($this->getPath(), PATHINFO_EXTENSION);
-				$thumbFileName  = $filename . '_' . $thumbWidth . 'x' . $thumbHeight . '.' . $fileExtension;
+				$thumbFileName = $filename . '_' . $thumbWidth . 'x' . $thumbHeight . '.' . $fileExtension;
 
 				// Save thumb file to disk
 				$thumbFileName = $thumbsFolder . '/' . $thumbFileName;


### PR DESCRIPTION
### Summary of Changes

Minor optimization, combines and moves `pathinfo()` calls out of the loop.

### Testing Instructions

Test that multiple thumbnail files are created correctly. E.g. use this code:

```
$image = new Joomla\CMS\Image\Image(JPATH_ROOT . '/images/powered_by.png');
$image->createThumbs(['294x44', '147x22', '74x11']);
```

And check that 3 thumbnails are created in `images/thumbs` directory.

### Expected result AFTER applying this Pull Request

Works like before

### Documentation Changes Required

No.