### PR TITLE
[4] add missing import for exception

### DIFF
--- a/api/components/com_plugins/src/Controller/PluginsController.php
+++ b/api/components/com_plugins/src/Controller/PluginsController.php
@@ -14,6 +14,7 @@ namespace Joomla\Component\Plugins\Api\Controller;
 use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Controller\ApiController;
+use Joomla\CMS\MVC\Controller\Exception;
 use Joomla\CMS\Router\Exception\RouteNotFoundException;
 use Joomla\String\Inflector;
 use Tobscure\JsonApi\Exception\InvalidParameterException;


### PR DESCRIPTION
Closes #31063

### Summary of Changes

Add missing import so that `Exception\ResourceNotFound` is correctly resolved

### Testing Instructions

Code Review