### PR TITLE
Added height control and v-scroll to com_admin sidebars

### DIFF
--- a/administrator/components/com_admin/tmpl/help/default.php
+++ b/administrator/components/com_admin/tmpl/help/default.php
@@ -20,6 +20,10 @@ use Joomla\CMS\Router\Route;
 <form action="<?php echo Route::_('index.php?option=com_admin&amp;view=help'); ?>" method="post" name="adminForm" id="adminForm">
 	<div class="row">
 		<div id="sidebar" class="col-md-3">
+			<button class="btn btn-sm btn-secondary my-2 options-menu d-md-none" type="button" data-toggle="collapse" data-target=".sidebar-nav" aria-controls="sidebar-nav" aria-expanded="false" aria-label="<?php echo Text::_('JTOGGLE_SIDEBAR_MENU'); ?>">
+				 <span class="fas fa-align-justify" aria-hidden="true"></span>
+				 <?php echo Text::_('JTOGGLE_SIDEBAR_MENU'); ?>
+			</button>
 			<div class="sidebar-nav">
 				<ul class="nav flex-column">
 					<li><?php echo HTMLHelper::_('link', Help::createUrl('JHELP_START_HERE'), Text::_('COM_ADMIN_START_HERE'), ['target' => 'helpFrame']); ?></li>

--- a/administrator/components/com_admin/tmpl/help/default.php
+++ b/administrator/components/com_admin/tmpl/help/default.php
@@ -20,7 +20,7 @@ use Joomla\CMS\Router\Route;
 <form action="<?php echo Route::_('index.php?option=com_admin&amp;view=help'); ?>" method="post" name="adminForm" id="adminForm">
 	<div class="row">
 		<div id="sidebar" class="col-md-3">
-			<button class="btn btn-sm btn-secondary my-2 options-menu d-md-none" type="button" data-toggle="collapse" data-target=".sidebar-nav" aria-controls="sidebar-nav" aria-expanded="false" aria-label="<?php echo Text::_('JTOGGLE_SIDEBAR_MENU'); ?>">
+			<button class="btn btn-sm btn-secondary my-2 options-menu d-md-none" type="button" data-toggle="collapse" data-target=".sidebar-nav" aria-controls="sidebar-nav" aria-expanded="false">
 				 <span class="fas fa-align-justify" aria-hidden="true"></span>
 				 <?php echo Text::_('JTOGGLE_SIDEBAR_MENU'); ?>
 			</button>

--- a/administrator/components/com_admin/tmpl/help/default.php
+++ b/administrator/components/com_admin/tmpl/help/default.php
@@ -24,7 +24,7 @@ use Joomla\CMS\Router\Route;
 				 <span class="fas fa-align-justify" aria-hidden="true"></span>
 				 <?php echo Text::_('JTOGGLE_SIDEBAR_MENU'); ?>
 			</button>
-			<div class="sidebar-nav">
+			<div class="sidebar-nav" id="help-index">
 				<ul class="nav flex-column">
 					<li><?php echo HTMLHelper::_('link', Help::createUrl('JHELP_START_HERE'), Text::_('COM_ADMIN_START_HERE'), ['target' => 'helpFrame']); ?></li>
 					<li><?php echo HTMLHelper::_('link', $this->latestVersionCheck, Text::_('COM_ADMIN_LATEST_VERSION_CHECK'), ['target' => 'helpFrame']); ?></li>
@@ -42,7 +42,7 @@ use Joomla\CMS\Router\Route;
 			</div>
 		</div>
 		<div class="col-md-9">
-			<iframe name="helpFrame" title="helpFrame" height="2100px" src="<?php echo $this->page; ?>" class="helpFrame table table-bordered"></iframe>
+			<iframe onLoad="var x = getElementById('help-index'); x.classList.remove('show');" name="helpFrame" title="helpFrame" height="2100px" src="<?php echo $this->page; ?>" class="helpFrame table table-bordered"></iframe>
 		</div>
 	</div>
 	<input class="textarea" type="hidden" name="option" value="com_admin">

--- a/administrator/components/com_config/tmpl/component/default.php
+++ b/administrator/components/com_config/tmpl/component/default.php
@@ -43,7 +43,7 @@ $xml = $this->form->getXml();
 
 		<?php // Begin Sidebar ?>
 		<div class="col-md-3" id="sidebar">
-			<button class="btn btn-sm btn-secondary my-2 options-menu d-md-none" type="button" data-toggle="collapse" data-target=".sidebar-nav" aria-controls="sidebar-nav" aria-expanded="false" aria-label="<?php echo Text::_('JTOGGLE_SIDEBAR_MENU'); ?>">
+			<button class="btn btn-sm btn-secondary my-2 options-menu d-md-none" type="button" data-toggle="collapse" data-target=".sidebar-nav" aria-controls="sidebar-nav" aria-expanded="false">
 				 <span class="fas fa-align-justify" aria-hidden="true"></span>
 				 <?php echo Text::_('JTOGGLE_SIDEBAR_MENU'); ?>
 			</button>

--- a/administrator/templates/atum/scss/blocks/_sidebar-nav.scss
+++ b/administrator/templates/atum/scss/blocks/_sidebar-nav.scss
@@ -6,7 +6,7 @@
   max-height: 75vh;
   background: var(--atum-sidebar-bg) !important;
   overflow-y:scroll;
-  box-shadow: $atum-box-shadow;
+  box-shadow: $atum-box-shadow; 
 
   ul {
     padding-left: .5rem;

--- a/administrator/templates/atum/scss/blocks/_sidebar-nav.scss
+++ b/administrator/templates/atum/scss/blocks/_sidebar-nav.scss
@@ -3,10 +3,10 @@
 .sidebar-nav {
 
   // override bootstrap important
-  background: var(--atum-sidebar-bg) !important;
   max-height: 100vh;
+  background: var(--atum-sidebar-bg) !important;
+  overflow-y: scroll;
   box-shadow: $atum-box-shadow;
-  overflow-y:scroll;
 
   ul {
     padding-left: .5rem;

--- a/administrator/templates/atum/scss/blocks/_sidebar-nav.scss
+++ b/administrator/templates/atum/scss/blocks/_sidebar-nav.scss
@@ -6,7 +6,7 @@
   max-height: 75vh;
   background: var(--atum-sidebar-bg) !important;
   overflow-y:scroll;
-  box-shadow: $atum-box-shadow; 
+  box-shadow: $atum-box-shadow;
 
   ul {
     padding-left: .5rem;

--- a/administrator/templates/atum/scss/blocks/_sidebar-nav.scss
+++ b/administrator/templates/atum/scss/blocks/_sidebar-nav.scss
@@ -3,7 +3,7 @@
 .sidebar-nav {
 
   // override bootstrap important
-  max-height: 100vh;
+  max-height: 75vh;
   overflow-y: scroll;
   background: var(--atum-sidebar-bg) !important;
   box-shadow: $atum-box-shadow;

--- a/administrator/templates/atum/scss/blocks/_sidebar-nav.scss
+++ b/administrator/templates/atum/scss/blocks/_sidebar-nav.scss
@@ -5,6 +5,8 @@
   // override bootstrap important
   background: var(--atum-sidebar-bg) !important;
   box-shadow: $atum-box-shadow;
+  max-height: 75vh;
+  overflow-y:scroll;
 
   ul {
     padding-left: .5rem;

--- a/administrator/templates/atum/scss/blocks/_sidebar-nav.scss
+++ b/administrator/templates/atum/scss/blocks/_sidebar-nav.scss
@@ -3,10 +3,10 @@
 .sidebar-nav {
 
   // override bootstrap important
-  background: var(--atum-sidebar-bg) !important;
-  box-shadow: $atum-box-shadow;
   max-height: 75vh;
+  background: var(--atum-sidebar-bg) !important;
   overflow-y:scroll;
+  box-shadow: $atum-box-shadow;
 
   ul {
     padding-left: .5rem;

--- a/administrator/templates/atum/scss/blocks/_sidebar-nav.scss
+++ b/administrator/templates/atum/scss/blocks/_sidebar-nav.scss
@@ -3,10 +3,10 @@
 .sidebar-nav {
 
   // override bootstrap important
-  max-height: 75vh;
   background: var(--atum-sidebar-bg) !important;
-  overflow-y:scroll;
+  max-height: 100vh;
   box-shadow: $atum-box-shadow;
+  overflow-y:scroll;
 
   ul {
     padding-left: .5rem;

--- a/administrator/templates/atum/scss/blocks/_sidebar-nav.scss
+++ b/administrator/templates/atum/scss/blocks/_sidebar-nav.scss
@@ -4,8 +4,8 @@
 
   // override bootstrap important
   max-height: 100vh;
-  background: var(--atum-sidebar-bg) !important;
   overflow-y: scroll;
+  background: var(--atum-sidebar-bg) !important;
   box-shadow: $atum-box-shadow;
 
   ul {


### PR DESCRIPTION
Pull Request for Issue #30507.

### Summary of Changes

Added css to make com_admin index divs limited height vertical scroll
Added code to toggle index display on small screens

### Testing Instructions

Go to Admin Home Dashboard / Help / Joomla Help
Scroll to the bottom of the list - a long way - and select the last item
View in responsive mode
Repeat for the Global Configuration page

Apply the patch and then run an npm build

### Actual result BEFORE applying this Pull Request

Nothing appears to happen because the iframe to the right is out of sight.
In the small screen view the menu cannot be collapsed.

### Expected result AFTER applying this Pull Request

The index div is scrollable and the iframe is always visible - so a selection change is obvious
On small screens the index can be collapsed.


### Documentation Changes Required

None