### PR TITLE
[4.0] Fix Tags Compact list bug

### DIFF
--- a/components/com_tags/tmpl/tag/list_items.php
+++ b/components/com_tags/tmpl/tag/list_items.php
@@ -86,9 +86,13 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 							<tr class="cat-list-row<?php echo $i % 2; ?>" >
 						<?php endif; ?>
 							<th scope="row" class="list-title">
-								<a href="<?php echo Route::_($item->link); ?>">
+								<?php if (($item->type_alias === 'com_users.category') || ($item->type_alias === 'com_banners.category')) : ?>
 									<?php echo $this->escape($item->core_title); ?>
-								</a>
+								<?php else : ?>
+									<a href="<?php echo Route::_($item->link); ?>">
+										<?php echo $this->escape($item->core_title); ?>
+									</a>
+								<?php endif; ?>
 								<?php if ($item->core_state == 0) : ?>
 									<span class="list-published badge badge-warning">
 										<?php echo Text::_('JUNPUBLISHED'); ?>


### PR DESCRIPTION
### Summary of Changes
Users Notes Categories and Banners Categories can be tagged.
I guess because of the common code for category params.

As they do not have a frontend display layout (normal) they should not have a link to display them in the Tag lists (Compact and normal list).
The code is OK in the normal list https://github.com/joomla/joomla-cms/blob/704452016b44bedb1a970ce8bce3268c4d04ed02/components/com_tags/tmpl/tag/default_items.php#L81-L90

But was forgotten in the Compact list menu item layout, therefore getting a link for these Titles and evidently a 404 if clicked.
This PR corrects list_items to solve the bug.


### Testing Instructions
Create a tag.
Tag a few items with that tag, including a banners category and a User Notes Category.
Create a Compact List of tagged items menu item.
Display in frontend.


### Actual result BEFORE applying this Pull Request
Clickable titles

<img width="844" alt="Screen Shot 2020-10-14 at 18 42 18" src="https://user-images.githubusercontent.com/869724/96019624-0db26d80-0e4d-11eb-8705-cba30e20ba68.png">



### Expected result AFTER applying this Pull Request
No more clickable link

<img width="865" alt="Screen Shot 2020-10-14 at 18 40 48" src="https://user-images.githubusercontent.com/869724/96019436-d2b03a00-0e4c-11eb-8cdb-33901ac2d434.png">


### Note:
There are other issues with the queries in `/libraries/src/Helper/TagsHelper.php`. Will create an issue for this.

