### PR TITLE
[4.0] Hide gear icon since no toolbar to display

### DIFF
--- a/administrator/components/com_admin/tmpl/help/default.php
+++ b/administrator/components/com_admin/tmpl/help/default.php
@@ -18,7 +18,7 @@ use Joomla\CMS\Router\Route;
 
 ?>
 <form action="<?php echo Route::_('index.php?option=com_admin&amp;view=help'); ?>" method="post" name="adminForm" id="adminForm">
-	<div class="row">
+	<div class="row mt-sm-3">
 		<div id="sidebar" class="col-md-3">
 			<div class="sidebar-nav">
 				<ul class="nav flex-column">

--- a/administrator/templates/atum/index.php
+++ b/administrator/templates/atum/index.php
@@ -26,7 +26,7 @@ $option     = $input->get('option', '');
 $view       = $input->get('view', '');
 $layout     = $input->get('layout', 'default');
 $task       = $input->get('task', 'display');
-$cpanel     = $option === 'com_cpanel';
+$cpanel     = $option === 'com_cpanel' || ($option === 'com_admin' && $view === 'help');
 $hiddenMenu = $app->input->get('hidemainmenu');
 
 // Getting user accessibility settings


### PR DESCRIPTION
### Testing Instructions
Go to Help > Joomla! Help
Resize browser to phone size.
Click gear icon to open toolbar with no buttons.

