### PR TITLE
[4.0] Adding back all categories menu item tip

### DIFF
--- a/components/com_contact/tmpl/categories/default.xml
+++ b/components/com_contact/tmpl/categories/default.xml
@@ -17,6 +17,7 @@
 				name="id"
 				type="category"
 				label="JGLOBAL_FIELD_CATEGORIES_CHOOSE_CATEGORY_LABEL"
+				description="JGLOBAL_FIELD_CATEGORIES_CHOOSE_CATEGORY_DESC"
 				extension="com_contact"
 				show_root="true"
 				required="true"

--- a/components/com_content/tmpl/categories/default.xml
+++ b/components/com_content/tmpl/categories/default.xml
@@ -17,6 +17,7 @@
 				name="id"
 				type="category"
 				label="JGLOBAL_FIELD_CATEGORIES_CHOOSE_CATEGORY_LABEL"
+				description="JGLOBAL_FIELD_CATEGORIES_CHOOSE_CATEGORY_DESC"
 				extension="com_content"
 				show_root="true"
 				required="true"

--- a/components/com_newsfeeds/tmpl/categories/default.xml
+++ b/components/com_newsfeeds/tmpl/categories/default.xml
@@ -17,6 +17,7 @@
 				name="id"
 				type="category"
 				label="JGLOBAL_FIELD_CATEGORIES_CHOOSE_CATEGORY_LABEL"
+				description="JGLOBAL_FIELD_CATEGORIES_CHOOSE_CATEGORY_DESC"
 				extension="com_newsfeeds"
 				show_root="true"
 				required="true"


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/31110

### Summary of Changes
Reinstating tips as it is very easy to not understand that the Top Level category does not include that category.
As the lang strings were not deleted it is a simple patch.

### Testing Instructions
Create all categories menu items for articles, contact, newsfeeds.


### Expected result AFTER applying this Pull Request
<img width="1017" alt="Screen Shot 2020-10-16 at 18 39 18" src="https://user-images.githubusercontent.com/869724/96287436-37e96400-0fe2-11eb-8111-81440291f888.png">

