### PR TITLE
[4.0] Fix broken B/C layer for event triggering in workflow plugins

### DIFF
--- a/plugins/workflow/featuring/featuring.php
+++ b/plugins/workflow/featuring/featuring.php
@@ -296,6 +296,8 @@ class PlgWorkflowFeaturing extends CMSPlugin implements SubscriberInterface
 
 		if ($eventResult->getArgument('abort'))
 		{
+			$event->setStopTransition();
+
 			return false;
 		}
 

--- a/plugins/workflow/publishing/publishing.php
+++ b/plugins/workflow/publishing/publishing.php
@@ -307,6 +307,8 @@ class PlgWorkflowPublishing extends CMSPlugin implements SubscriberInterface
 
 		if (\in_array(false, $result, true))
 		{
+			$event->setStopTransition();
+
 			return false;
 		}
 


### PR DESCRIPTION
### Summary of Changes
The workflow ```onWorkflowBeforeTransition``` uses the "new" event handling method (setting some internal parameters), but the two plugins still only ```return false;```. So this PR takes care of it.


### Testing Instructions
It's rather hard to test, because there is no plugin which uses this function in the core. What you need is a plugin listening to ```onContentBeforeChangeState``` and returning false.


### Actual result BEFORE applying this Pull Request
Transition is still executed.


### Expected result AFTER applying this Pull Request
Transition is stopped-

