### PR TITLE
[4.0] Fix undefined error when invalid redis cache host

### DIFF
--- a/libraries/src/Cache/Storage/RedisStorage.php
+++ b/libraries/src/Cache/Storage/RedisStorage.php
@@ -102,6 +102,7 @@ class RedisStorage extends CacheStorage
 		}
 		catch (\RedisException $e)
 		{
+			$connection = false;
 			Log::add($e->getMessage(), Log::DEBUG);
 		}
 


### PR DESCRIPTION
Pull Request for Issue #30378 (partial) .

### Summary of Changes
Fixes the `$connection` variable being undefined if an exception is thrown connecting to the redis server for caching

### Testing Instructions
Setup redis as a cache provider but don't point to a valid host

### Actual result BEFORE applying this Pull Request
A whole host of errors (see the linked issue)

### Expected result AFTER applying this Pull Request
Many pconnect warnings still - but no undefined variable warnings

### Documentation Changes Required
None
