### PR TITLE
[4.0] ArticleModel Client('site') set catid filter to int, because it could be only int

### DIFF
--- a/administrator/components/com_content/src/Model/ArticleModel.php
+++ b/administrator/components/com_content/src/Model/ArticleModel.php
@@ -509,7 +509,7 @@ class ArticleModel extends AdminModel implements WorkflowModelInterface
 					|| ($id == 0 && !$user->authorise('core.edit.state', 'com_content')))
 				{
 					$form->setFieldAttribute('catid', 'readonly', 'true');
-					$form->setFieldAttribute('catid', 'filter', 'unset');
+					$form->setFieldAttribute('catid', 'filter', 'int');
 				}
 			}
 		}


### PR DESCRIPTION
This solves for following problem #29233. But it finally not solves the real problem!
Currently we have a problem with the "unset" filter in 
libraries\src\Form\FormField.php filter() Method, 

https://github.com/joomla/joomla-cms/blob/2ef395274cc0b1037e0262d6e7969c5a3c696275/libraries/src/Form/FormField.php#L1105

because it checks any filter input, but "unset" is not really a filter and than it getts into set value null on
https://github.com/joomla/joomla-cms/blob/2ef395274cc0b1037e0262d6e7969c5a3c696275/libraries/src/Form/FormField.php#L1126

Maybe we have some more problems similary to #29233 with filter="unset", So the filter() method in general needs to be improved to work with filter="unset"

Pull Request for Issue #29233

### Summary of Changes
Change filter type of catid

### Testing Instructions
See Issue #29233 and try to repoduce

### Actual result BEFORE applying this Pull Request
Field required: Category.
These is because of filter() Method fails and the catid is set to NULL

### Expected result AFTER applying this Pull Request
catid is filtered with "int" and is correct set.
So it works.

### Documentation Changes Required
Nope
