### PR TITLE
[4.0]Make sure we do not add one header twice but we support to set a different header per client.

### DIFF
--- a/plugins/system/httpheaders/httpheaders.php
+++ b/plugins/system/httpheaders/httpheaders.php
@@ -512,12 +512,21 @@ class PlgSystemHttpHeaders extends CMSPlugin implements SubscriberInterface
 
 		foreach ($additionalHttpHeaders as $additionalHttpHeader)
 		{
+			// Make sure we have a key and a value
 			if (empty($additionalHttpHeader->key) || empty($additionalHttpHeader->value))
 			{
 				continue;
 			}
 
+			// Make sure the header is a valid and supported header
 			if (!in_array(strtolower($additionalHttpHeader->key), $this->supportedHttpHeaders))
+			{
+				continue;
+			}
+
+			// Make sure we do not add one header twice but we support to set a different header per client.
+			if (isset($staticHeaderConfiguration[$additionalHttpHeader->key . '#' . $additionalHttpHeader->client])
+				|| isset($staticHeaderConfiguration[$additionalHttpHeader->key . '#both']) )
 			{
 				continue;
 			}

--- a/plugins/system/httpheaders/httpheaders.php
+++ b/plugins/system/httpheaders/httpheaders.php
@@ -526,7 +526,7 @@ class PlgSystemHttpHeaders extends CMSPlugin implements SubscriberInterface
 
 			// Make sure we do not add one header twice but we support to set a different header per client.
 			if (isset($staticHeaderConfiguration[$additionalHttpHeader->key . '#' . $additionalHttpHeader->client])
-				|| isset($staticHeaderConfiguration[$additionalHttpHeader->key . '#both']) )
+				|| isset($staticHeaderConfiguration[$additionalHttpHeader->key . '#both']))
 			{
 				continue;
 			}


### PR DESCRIPTION
Pull Request for Issue #30962 cc @PhilETaylor 

### Summary of Changes

Make sure we do not add one header twice but we support to set a different header per client.

### Testing Instructions

Setup Plugins -> System - HTTP Headers as this screenshot:

<img width="1228" alt="Screenshot 2020-10-07 at 01 04 35" src="https://user-images.githubusercontent.com/400092/95272746-15648780-0839-11eb-95cc-9195b766a919.png">

### Actual result BEFORE applying this Pull Request

Content-Security-Policy:  TWO

### Expected result AFTER applying this Pull Request

Content-Security-Policy: ONE

### Documentation Changes Required

None

@PhilETaylor I'm not sure whether we should block the save as it could be valid to configure two headers with the same value. e.g. one for the backend and one for the frontend. With this change here we make sure only the first configured per site (or for both) is choosen. I'm not sure how to cleanly validate the subform at that point other than hooking into the onExtensionBeforeSave Event but than this pugin would be triggered on all extension saves does not sound that optimal to me?