### PR TITLE
[4.0] JS: Users Field: init Bootstrap Modal

### DIFF
--- a/build/media_source/system/js/fields/joomla-field-user.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-user.w-c.es6.js
@@ -52,6 +52,12 @@
       // Bind events
       this.modalClose = this.modalClose.bind(this);
       this.setValue = this.setValue.bind(this);
+      
+      // Bootstrap modal init
+      if (Joomla.Bootstrap && Joomla.Bootstrap.initModal && typeof Joomla.Bootstrap.initModal === 'function') {
+          Joomla.Bootstrap.initModal(this.modal);
+      }
+      
       if (this.buttonSelect) {
         this.buttonSelect.addEventListener('click', this.modalOpen.bind(this));
         this.modal.addEventListener('hide', this.removeIframe.bind(this));

--- a/build/media_source/system/js/fields/joomla-field-user.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-user.w-c.es6.js
@@ -52,12 +52,12 @@
       // Bind events
       this.modalClose = this.modalClose.bind(this);
       this.setValue = this.setValue.bind(this);
-      
+
       // Bootstrap modal init
       if (Joomla.Bootstrap && Joomla.Bootstrap.initModal && typeof Joomla.Bootstrap.initModal === 'function') {
-          Joomla.Bootstrap.initModal(this.modal);
+        Joomla.Bootstrap.initModal(this.modal);
       }
-      
+
       if (this.buttonSelect) {
         this.buttonSelect.addEventListener('click', this.modalOpen.bind(this));
         this.modal.addEventListener('hide', this.removeIframe.bind(this));


### PR DESCRIPTION
Fix for #28953  this.modal.open is not a function

Pull Request for Issue #28953

### Summary of Changes
initBootsraps Modal

### Testing Instructions
Reproduce #28953, test with patch and it did work

### Actual result BEFORE applying this Pull Request
Modal did not open, js error:
` this.modal.open is not a function`

### Expected result AFTER applying this Pull Request
Modal should be open and user should be selectable

### Documentation Changes Required
nope