### PR TITLE
[4.0] Use component when building session key

### DIFF
--- a/administrator/components/com_config/src/Controller/ComponentController.php
+++ b/administrator/components/com_config/src/Controller/ComponentController.php
@@ -69,7 +69,7 @@ class ComponentController extends FormController
 		$id      = $this->input->get('id', null, 'INT');
 		$option  = $this->input->get('component');
 		$user    = $this->app->getIdentity();
-		$context = "$this->option.edit.$this->context";
+		$context = "$this->option.edit.$this->context.$option";
 
 		/** @var \Joomla\Component\Config\Administrator\Model\ComponentModel $model */
 		$model = $this->getModel('Component', 'Administrator');
@@ -197,7 +197,7 @@ class ComponentController extends FormController
 	public function cancel($key = null)
 	{
 		// Clear session data.
-		$this->app->setUserState("$this->option.edit.$this->context.data", null);
+		$this->app->setUserState("$this->option.edit.$this->context.$option.data", null);
 
 		$component = $this->input->get('component');
 		$this->setRedirect(Route::_('index.php?option=' . $component, false));

--- a/administrator/components/com_config/src/Model/ComponentModel.php
+++ b/administrator/components/com_config/src/Model/ComponentModel.php
@@ -112,8 +112,10 @@ class ComponentModel extends FormModel
 	 */
 	protected function loadFormData()
 	{
+		$option = $this->getState()->get('component.option');
+
 		// Check the session for previously entered form data.
-		$data = Factory::getApplication()->getUserState('com_config.edit.component.data', []);
+		$data = Factory::getApplication()->getUserState('com_config.edit.component.' . $option . '.data', []);
 
 		if (empty($data))
 		{


### PR DESCRIPTION
### Summary of Changes

Missed this in https://github.com/joomla/joomla-cms/pull/31105. Adds component to the session key to ensure unique key for each component.

### Testing Instructions

Testing requires up to date version with #31105 already applied.

Enable some Captcha plugins.
Go to `Users` configuration.
In `Captcha` field select some captcha plugin.
In `Password Options` tab set `Minimum Characters` to a value lower than 8.
Click `Save`. Ignore
Navigate away but don't use `Close` button in the toolbar.
Go to `Articles` configuration.
Inspect `Captcha` field.

### Actual result BEFORE applying this Pull Request

`Captcha` field contains whatever was selected in `Users` configuration.

### Expected result AFTER applying this Pull Request

`Captcha` field has default value.

### Documentation Changes Required

No.