### PR TITLE
[4.0] Add dashboard module

### DIFF
--- a/administrator/components/com_cpanel/tmpl/cpanel/default.php
+++ b/administrator/components/com_cpanel/tmpl/cpanel/default.php
@@ -62,19 +62,14 @@ echo HTMLHelper::_(
 			echo ModuleHelper::renderModule($module, array('style' => 'well'));
 		}
 		?>
+		<?php if ($user->authorise('core.manage', 'com_modules')) : ?>
+			<button type="button" data-toggle="modal" data-target="#moduleDashboardAddModal" class="cpanel-add-module text-center py-5 w-100 d-block">
+				<div class="cpanel-add-module-icon text-center">
+					<span class="fas fa-plus-square text-light mt-2"></span>
+				</div>
+				<span><?php echo Text::_('COM_CPANEL_ADD_DASHBOARD_MODULE'); ?></span>
+			</button>
+		<?php endif; ?>
 		</div>
 	</div>
 </div>
-
-<?php if ($user->authorise('core.manage', 'com_modules')) : ?>
-<div class="row">
-	<div class="col-md-6">
-		<button type="button" data-toggle="modal" data-target="#moduleDashboardAddModal" class="cpanel-add-module text-center py-5 w-100 d-block">
-			<div class="cpanel-add-module-icon text-center">
-				<span class="fas fa-plus-square text-light mt-2"></span>
-			</div>
-			<span><?php echo Text::_('COM_CPANEL_ADD_DASHBOARD_MODULE'); ?></span>
-		</button>
-	</div>
-</div>
-<?php endif; ?>


### PR DESCRIPTION
This PR moves the add new module block from a new row to being part of the dashboard grid with the other modules

PR for #31085

### After
![image](https://user-images.githubusercontent.com/1296369/96412882-b14fa500-11e2-11eb-9807-59886bbb1a56.png)
