### PR TITLE
[4.0] Active menu does not exist, fatal error

### DIFF
--- a/templates/cassiopeia/index.php
+++ b/templates/cassiopeia/index.php
@@ -26,8 +26,7 @@ $task     = $app->input->getCmd('task', '');
 $itemid   = $app->input->getCmd('Itemid', '');
 $sitename = htmlspecialchars($app->get('sitename'), ENT_QUOTES, 'UTF-8');
 $menu     = $app->getMenu()->getActive();
-$pageclass = $menu->getParams()->get('pageclass_sfx');
-
+$pageclass = $menu !== null ? $menu->getParams()->get('pageclass_sfx', '') : '';
 // Enable assets
 $wa->usePreset('template.cassiopeia.' . ($this->direction === 'rtl' ? 'rtl' : 'ltr'))
 	->useStyle('template.active.language')


### PR DESCRIPTION
Pull Request for Issue # .https://github.com/joomla/joomla-cms/issues/30812
Follow up of PR: https://github.com/joomla/joomla-cms/pull/31100

### Summary of Changes
`$app->getMenu()->getActive();`
can return a _MenuItem_ or null

by calling a function when null is returned, it generates a fatal error.


### Testing Instructions
Add a dummy/non existent ItemId in your non sef urls.
E.g. _/index.php?option=com_content&view=article&id=2:another-article&catid=9&itemId=5000_
In that case there is no menu item with id 5000 

### Actual result BEFORE applying this Pull Request
![Screenshot_joomla_missing_menu_ietm](https://user-images.githubusercontent.com/1838041/96142871-3a2cbf00-0f0b-11eb-92bc-5507135f67a7.png)


### Expected result AFTER applying this Pull Request
No fatal error


### Documentation Changes Required
No
