### PR TITLE
Remove reference to Media manager in Imagelist Custom Field

### DIFF
--- a/administrator/language/en-GB/en-GB.plg_fields_imagelist.ini
+++ b/administrator/language/en-GB/en-GB.plg_fields_imagelist.ini
@@ -5,7 +5,8 @@
 
 PLG_FIELDS_IMAGELIST="Fields - Imagelist"
 PLG_FIELDS_IMAGELIST_LABEL="List of Images (%s)"
-PLG_FIELDS_IMAGELIST_PARAMS_DIRECTORY_DESC="The directory with the image files to be listed relative to the default image folder (set in Media > Options)."
+; Don't translate "images" in the string below.
+PLG_FIELDS_IMAGELIST_PARAMS_DIRECTORY_DESC="The directory with the image files to be listed, relative to \"images\" directory in Joomla! root."
 PLG_FIELDS_IMAGELIST_PARAMS_DIRECTORY_LABEL="Directory"
 PLG_FIELDS_IMAGELIST_PARAMS_IMAGE_CLASS_DESC="The class which is added to the image (src tag)."
 PLG_FIELDS_IMAGELIST_PARAMS_IMAGE_CLASS_LABEL="Image Class"


### PR DESCRIPTION
Closes https://github.com/joomla/joomla-cms/issues/31162.

### Summary of Changes

Removes reference to Media manager. The field does not read Media configuration, nor it should.

### Testing Instructions

Language review.

### Documentation Changes Required

No.