### PR TITLE
Set  alt="" for  images in the random image module

### DIFF
--- a/modules/mod_random_image/tmpl/default.php
+++ b/modules/mod_random_image/tmpl/default.php
@@ -24,7 +24,7 @@ if (!count($images))
 <?php if ($link) : ?>
 <a href="<?php echo $link; ?>">
 <?php endif; ?>
-	<?php echo HTMLHelper::_('image', $image->folder . '/' . htmlspecialchars($image->name, ENT_COMPAT, 'UTF-8'), htmlspecialchars($image->name, ENT_COMPAT, 'UTF-8'), array('width' => $image->width, 'height' => $image->height)); ?>
+	<?php echo HTMLHelper::_('image', $image->folder . '/' . htmlspecialchars($image->name, ENT_COMPAT, 'UTF-8'), '', array('width' => $image->width, 'height' => $image->height)); ?>
 <?php if ($link) : ?>
 </a>
 <?php endif; ?>


### PR DESCRIPTION
### Summary of Changes
Random images have their filenames as alt-text. 
This is wrong for accessibility.

### Testing Instructions
Make a module with random images.
In the output, inspect the source code. 


### Actual result BEFORE applying this Pull Request
The image has an alt-text which contains the filename of the image


### Expected result AFTER applying this Pull Request
The image has alt=""


### Documentation Changes Required
no
