### PR TITLE
Set alt-text for the feed-image if no other text is displayed (a11y)

### DIFF
--- a/modules/mod_syndicate/tmpl/default.php
+++ b/modules/mod_syndicate/tmpl/default.php
@@ -3,15 +3,17 @@
  * @package     Joomla.Site
  * @subpackage  mod_syndicate
  *
- * @copyright   Copyright (C) 2005 - 2020 Open Source Matters, Inc. All rights reserved.
+ * @copyright   (C) 2006 Open Source Matters, Inc. <https://www.joomla.org>
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
 defined('_JEXEC') or die;
 
+// Set alt-text for the image only if no text is displayed
+$alt = (!$params->get('display_text', 1) && empty($text)) ? JText::_('MOD_SYNDICATE_DEFAULT_FEED_ENTRIES') : '';
 ?>
 <a href="<?php echo $link; ?>" class="syndicate-module<?php echo $moduleclass_sfx; ?>">
-	<?php echo JHtml::_('image', 'system/livemarks.png', 'feed-image', null, true); ?>
+	<?php echo JHtml::_('image', 'system/livemarks.png', $alt, null, true); ?>
 	<?php if ($params->get('display_text', 1)) : ?>
 		<span>
 		<?php if (str_replace(' ', '', $text) !== '') : ?>

--- a/modules/mod_syndicate/tmpl/default.php
+++ b/modules/mod_syndicate/tmpl/default.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Site
  * @subpackage  mod_syndicate
  *
- * @copyright   (C) 2006 Open Source Matters, Inc. <https://www.joomla.org>
+ * @copyright   Copyright (C) 2005 - 2020 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/modules/mod_syndicate/tmpl/default.php
+++ b/modules/mod_syndicate/tmpl/default.php
@@ -10,7 +10,7 @@
 defined('_JEXEC') or die;
 
 // Set alt-text for the image only if no text is displayed
-$alt = (!$params->get('display_text', 1) && empty($text)) ? JText::_('MOD_SYNDICATE_DEFAULT_FEED_ENTRIES') : '';
+$alt = (!$params->get('display_text', 1)) ? JText::_('MOD_SYNDICATE_DEFAULT_FEED_ENTRIES') : '';
 ?>
 <a href="<?php echo $link; ?>" class="syndicate-module<?php echo $moduleclass_sfx; ?>">
 	<?php echo JHtml::_('image', 'system/livemarks.png', $alt, null, true); ?>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
As title says


### Testing Instructions
Make a module syndication feeds. 
Try different variants: 

- Display text yes, and enter a text
- Display text yes, but let the text empty
- Display text no

Inspect the code for the image and see which alt text is displayed.

### Actual result BEFORE applying this Pull Request
The image always has a hard coded alt-text. 


### Expected result AFTER applying this Pull Request
If the feed image is displayed with a text, then it has alt="", 
otherwise it has a translated text "feed entries"


### Documentation Changes Required
no
