### PR TITLE
Update checksum not validated when in different character case

### DIFF
--- a/libraries/src/Installer/InstallerHelper.php
+++ b/libraries/src/Installer/InstallerHelper.php
@@ -395,7 +395,7 @@ abstract class InstallerHelper
 				$hashRemote  = $updateObject->$hash->_data;
 				$hashOnFile  = true;
 
-				if ($hashPackage !== $hashRemote)
+				if (strtolower($hashPackage) !== strtolower($hashRemote))	
 				{
 					return self::HASH_NOT_VALIDATED;
 				}

--- a/libraries/src/Installer/InstallerHelper.php
+++ b/libraries/src/Installer/InstallerHelper.php
@@ -395,7 +395,7 @@ abstract class InstallerHelper
 				$hashRemote  = $updateObject->$hash->_data;
 				$hashOnFile  = true;
 
-				if (strtolower($hashPackage) !== strtolower($hashRemote))	
+				if ($hashPackage !== strtolower($hashRemote))	
 				{
 					return self::HASH_NOT_VALIDATED;
 				}


### PR DESCRIPTION
If update server's XML has checksum in capitals, it will be marked invalid because the Joomla!-generated $hashPackage will be lower case.
With the proposed change (line 398), the process will be more foregiving. I used the MD5 & SHA Checksum Utility from Raymond Lin (https://raylin.wordpress.com) to generate the checksum in the update server's XML file. This utility generates an upper case checksum and is therefore incompatible with the Joomla! process.

Pull Request for Issue https://github.com/joomla/joomla-cms/issues/31178 .

### Summary of Changes



### Testing Instructions



### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Documentation Changes Required

