### PR TITLE
[4.0] Fix error on System Information page

### DIFF
--- a/administrator/components/com_admin/src/Extension/AdminComponent.php
+++ b/administrator/components/com_admin/src/Extension/AdminComponent.php
@@ -14,6 +14,7 @@ defined('JPATH_PLATFORM') or die;
 use Joomla\CMS\Extension\BootableExtensionInterface;
 use Joomla\CMS\Extension\MVCComponent;
 use Joomla\CMS\HTML\HTMLRegistryAwareTrait;
+use Joomla\Component\Admin\Administrator\Service\HTML\Configuration;
 use Joomla\Component\Admin\Administrator\Service\HTML\Directory;
 use Joomla\Component\Admin\Administrator\Service\HTML\PhpSetting;
 use Joomla\Component\Admin\Administrator\Service\HTML\System;
@@ -46,5 +47,6 @@ class AdminComponent extends MVCComponent implements BootableExtensionInterface
 		$this->getRegistry()->register('system', new System);
 		$this->getRegistry()->register('phpsetting', new PhpSetting);
 		$this->getRegistry()->register('directory', new Directory);
+		$this->getRegistry()->register('configuration', new Configuration);
 	}
 }

--- a/administrator/components/com_admin/src/Service/HTML/Configuration.php
+++ b/administrator/components/com_admin/src/Service/HTML/Configuration.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_admin
+ *
+ * @copyright   Copyright (C) 2005 - 2020 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\Component\Admin\Administrator\Service\HTML;
+
+\defined('_JEXEC') or die;
+
+/**
+ * Class for rendering configuration values
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class Configuration
+{
+	/**
+	 * Method to generate a string for a value
+	 *
+	 * @param   mixed  $value  The configuration value
+	 *
+	 * @return  string  Formatted and escaped string
+	 *
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public function value($value): string
+	{
+		if (\is_bool($value))
+		{
+			return $value ? 'true' : 'false';
+		}
+
+		if (\is_array($value))
+		{
+			$value = implode(', ', $value);
+		}
+
+		return htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+	}
+}

--- a/administrator/components/com_admin/tmpl/sysinfo/default_config.php
+++ b/administrator/components/com_admin/tmpl/sysinfo/default_config.php
@@ -9,6 +9,7 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
 /** @var \Joomla\Component\Admin\Administrator\View\Sysinfo\HtmlView $this */
@@ -35,10 +36,7 @@ use Joomla\CMS\Language\Text;
 						<?php echo $key; ?>
 					</th>
 					<td>
-						<?php if (is_bool($value)) : ?>
-							<?php $value = $value === true ? 'true' : 'false'; ?>
-						<?php endif; ?>
-						<?php echo htmlspecialchars($value, ENT_QUOTES); ?>
+						<?php echo HTMLHelper::_('configuration.value', $value); ?>
 					</td>
 				</tr>
 			<?php endforeach; ?>


### PR DESCRIPTION
### Summary of Changes

Fixes error on System Information page.

### Testing Instructions

Save Global Configuration at least once.
Go to System -> System Information.

### Actual result BEFORE applying this Pull Request

>htmlspecialchars(): Argument #1 ($string) must be of type string, array given 

### Expected result AFTER applying this Pull Request

No errors.

### Documentation Changes Required

No.