### PR TITLE
[4.0] language module titles

### DIFF
--- a/modules/mod_languages/tmpl/default.php
+++ b/modules/mod_languages/tmpl/default.php
@@ -77,7 +77,7 @@ $wa->registerAndUseStyle('mod_languages', 'mod_languages/template.css');
 				<a href="<?php echo htmlspecialchars_decode(htmlspecialchars($language->link, ENT_QUOTES, 'UTF-8'), ENT_NOQUOTES); ?>">
 					<?php if ($params->get('image', 1)) : ?>
 						<?php if ($language->image) : ?>
-							<?php echo HTMLHelper::_('image', 'mod_languages/' . $language->image . '.gif', $language->title_native, array('title' => $language->title_native), true); ?>
+							<?php echo HTMLHelper::_('image', 'mod_languages/' . $language->image . '.gif', $language->title_native, null, true); ?>
 						<?php else : ?>
 							<span class="label" title="<?php echo $language->title_native; ?>"><?php echo strtoupper($language->sef); ?></span>
 						<?php endif; ?>
@@ -93,7 +93,7 @@ $wa->registerAndUseStyle('mod_languages', 'mod_languages/template.css');
 
 			<?php if ($params->get('image', 1)) : ?>
 				<?php if ($language->image) : ?>
-					<?php echo HTMLHelper::_('image', 'mod_languages/' . $language->image . '.gif', $language->title_native, array('title' => $language->title_native), true); ?>
+					<?php echo HTMLHelper::_('image', 'mod_languages/' . $language->image . '.gif', $language->title_native, null, true); ?>
 				<?php else : ?>
 					<span class="badge badge-secondary"><?php echo strtoupper($language->sef); ?></span>
 				<?php endif; ?>


### PR DESCRIPTION
This only applies to the language switcher module on the front end when you have selected the options to use image flags and not to use a dropdown
![image](https://user-images.githubusercontent.com/1296369/96936138-691fd380-14bd-11eb-973a-4de527878b7e.png)

Here the visual output will be similar to this (depending on the installed languages)
![image](https://user-images.githubusercontent.com/1296369/96936208-8eacdd00-14bd-11eb-8e35-926e71a9685d.png)

Each of these flags (_no discussion please here about country flags vs languages_) is a link to the site in the selected language.

Currently the image has an alt text that is identical to the title text. This is bad practice. In addition the title text is of no benefit for accessibility. It is sufficient in this case to just have the alt text and this will be used by default for the link name for accessibility purposes.

### Before
![image](https://user-images.githubusercontent.com/1296369/96936647-5d80dc80-14be-11eb-81fd-1a3072dc52c1.png)


### After
![image](https://user-images.githubusercontent.com/1296369/96936573-3cb88700-14be-11eb-9333-b71d15d60779.png)
