### PR TITLE
[4.0] [NO CACHE] Fix js console error

### DIFF
--- a/build/media_source/system/js/fields/joomla-field-subform.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-subform.w-c.es6.js
@@ -136,7 +136,7 @@
      * @returns {HTMLElement[]}
      */
     getRows() {
-      const rows = this.containerWithRows.children;
+      const rows = Array.from(this.containerWithRows.children);
       const result = [];
 
       // Filter out the rows
@@ -352,7 +352,7 @@
       let touched = false; // We have a touch events
 
       // Find all existing rows and add draggable attributes
-      const rows = this.getRows();
+      const rows = Array.from(this.getRows());
 
       rows.forEach((row) => {
         row.setAttribute('draggable', 'false');


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/pull/31158#issuecomment-714796805 .


### Summary of Changes
Nodelist is not an array, always convert it to array. Fix the subform custom Element.


### Testing Instructions
Go to plugin tinyMCE's edit page.
- No console error
- the `External Plugin URLs` is working as expected (add new, remove, drag and drop)

### Actual result BEFORE applying this Pull Request
console error, subform broken


### Expected result AFTER applying this Pull Request
subform is working as expected


### Documentation Changes Required

Nope, bug fix