### PR TITLE
[4.0] One more 3.9 file to be deleted: mysql/3.9.19-2020-06-01.sql

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/3.9.19-2020-06-01.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.9.19-2020-06-01.sql
@@ -1,3 +1,0 @@
-INSERT INTO `#__postinstall_messages` (`extension_id`, `title_key`, `description_key`, `action_key`, `language_extension`, `language_client_id`, `type`, `action_file`, `action`, `condition_file`, `condition_method`, `version_introduced`, `enabled`)
-VALUES
-(700, 'COM_CPANEL_MSG_TEXTFILTER3919_TITLE', 'COM_CPANEL_MSG_TEXTFILTER3919_BODY', '', 'com_cpanel', 1, 'message', '', '', 'admin://components/com_admin/postinstall/textfilter3919.php', 'admin_postinstall_textfilter3919_condition', '3.9.19', 1);


### PR DESCRIPTION
Pull Request for [https://github.com/joomla/joomla-cms/pull/31222#issuecomment-715962090](https://github.com/joomla/joomla-cms/pull/31222#issuecomment-715962090).

### Summary of Changes

This pull request (PR) deletes one more 3.9 update SQL script for MySQL which was merged up to 4.0-dev by accident and has not been removed with PR #31222 .

### Testing Instructions

Code review: Check that there will be no more 3.9 update SQL script for any kind of database in 4.0-dev.

### Actual result BEFORE applying this Pull Request

[https://github.com/joomla/joomla-cms/blob/4.0-dev/administrator/components/com_admin/sql/updates/mysql/3.9.19-2020-06-01.sql](https://github.com/joomla/joomla-cms/blob/4.0-dev/administrator/components/com_admin/sql/updates/mysql/3.9.19-2020-06-01.sql)

### Expected result AFTER applying this Pull Request

No file [https://github.com/joomla/joomla-cms/blob/4.0-dev/administrator/components/com_admin/sql/updates/mysql/3.9.19-2020-06-01.sql](https://github.com/joomla/joomla-cms/blob/4.0-dev/administrator/components/com_admin/sql/updates/mysql/3.9.19-2020-06-01.sql).

### Documentation Changes Required

None.
