### PR TITLE
[4.0] Can't Save article on frontend

### DIFF
--- a/administrator/components/com_content/src/Model/ArticleModel.php
+++ b/administrator/components/com_content/src/Model/ArticleModel.php
@@ -509,6 +509,7 @@ class ArticleModel extends AdminModel implements WorkflowModelInterface
 					|| ($id == 0 && !$user->authorise('core.edit.state', 'com_content')))
 				{
 					$form->setFieldAttribute('catid', 'readonly', 'true');
+					$form->setFieldAttribute('catid', 'required', 'false');
 					$form->setFieldAttribute('catid', 'filter', 'unset');
 				}
 			}
@@ -710,6 +711,12 @@ class ArticleModel extends AdminModel implements WorkflowModelInterface
 
 		// Create new category, if needed.
 		$createCategory = true;
+
+		if (is_null($data['catid']))
+		{
+			// When there is no catid passed don't try to crate one
+			$createCategory = false;
+		}
 
 		// If category ID is provided, check if it's valid.
 		if (is_numeric($data['catid']) && $data['catid'])
@@ -1129,6 +1136,7 @@ class ArticleModel extends AdminModel implements WorkflowModelInterface
 	 */
 	public function hit()
 	{
+		return;
 	}
 
 	/**

--- a/administrator/components/com_content/src/Model/ArticleModel.php
+++ b/administrator/components/com_content/src/Model/ArticleModel.php
@@ -714,7 +714,7 @@ class ArticleModel extends AdminModel implements WorkflowModelInterface
 
 		if (is_null($data['catid']))
 		{
-			// When there is no catid passed don't try to crate one
+			// When there is no catid passed don't try to create one
 			$createCategory = false;
 		}
 

--- a/administrator/components/com_content/src/Model/ArticleModel.php
+++ b/administrator/components/com_content/src/Model/ArticleModel.php
@@ -1136,7 +1136,6 @@ class ArticleModel extends AdminModel implements WorkflowModelInterface
 	 */
 	public function hit()
 	{
-		return;
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue #29233

### Summary of Changes

mark the catid as optional when we are not allowed to change it

### Testing Instructions

Create a user at the author level
Change the "created by" of an existing article to that author.
On the front end login as the author and navigate to the article
Click on the edit article
Click on save

### Actual result BEFORE applying this Pull Request

`Warning Field required: Category`

### Expected result AFTER applying this Pull Request

`Article saved.`

### Documentation Changes Required

none

### mentions

@bembelimen can you please take a look here whether that could affect workflow. I don't see a reason given at that step the article is already setup and an category is assigned just not changed. Thanks!

