### PR TITLE
[4.x] Only allow POST requests for admin login

### DIFF
--- a/administrator/components/com_login/src/Controller/DisplayController.php
+++ b/administrator/components/com_login/src/Controller/DisplayController.php
@@ -69,7 +69,7 @@ class DisplayController extends BaseController
 	public function login()
 	{
 		// Check for request forgeries.
-		$this->checkToken('request');
+		$this->checkToken('post');
 
 		$app = $this->app;
 

--- a/administrator/components/com_login/src/Controller/DisplayController.php
+++ b/administrator/components/com_login/src/Controller/DisplayController.php
@@ -69,7 +69,7 @@ class DisplayController extends BaseController
 	public function login()
 	{
 		// Check for request forgeries.
-		$this->checkToken('post');
+		$this->checkToken();
 
 		$app = $this->app;
 


### PR DESCRIPTION
### Summary of Changes
Enforce the usage of POST requests for administrator login requests – doesn't affect core CMS as it's doing POST logins by default anyway.


### Testing Instructions
Apply patch, login.


### Actual result BEFORE applying this Pull Request
Login works


### Expected result AFTER applying this Pull Request
Login works

