### PR TITLE
Use ZipArchive in JArchiveZip

### DIFF
--- a/libraries/joomla/archive/zip.php
+++ b/libraries/joomla/archive/zip.php
@@ -189,7 +189,7 @@ class JArchiveZip implements JArchiveExtractable
 	 */
 	public static function hasNativeSupport()
 	{
-		return function_exists('zip_open') && function_exists('zip_read');
+		return extension_loaded('zip');
 	}
 
 	/**

--- a/libraries/joomla/archive/zip.php
+++ b/libraries/joomla/archive/zip.php
@@ -282,41 +282,46 @@ class JArchiveZip implements JArchiveExtractable
 	 */
 	protected function extractNative($archive, $destination)
 	{
-		$zip = zip_open($archive);
+		$zip = new \ZipArchive;
 
-		if (!is_resource($zip))
+		if ($zip->open($archive) !== true)
 		{
 			return $this->raiseWarning(100, 'Unable to open archive');
 		}
 
 		// Make sure the destination folder exists
-		if (!JFolder::create($destination))
+		if (!Folder::create($destination))
 		{
 			return $this->raiseWarning(100, 'Unable to create destination');
 		}
 
 		// Read files in the archive
-		while ($file = @zip_read($zip))
+		for ($index = 0; $index < $zip->numFiles; $index++)
 		{
-			if (!zip_entry_open($zip, $file, 'r'))
+			$file = $zip->getNameIndex($index);
+
+			if (substr($file, -1) === '/')
+			{
+				continue;
+			}
+
+			$stream = $zip->getStream($file);
+
+			if ($stream === false)
 			{
 				return $this->raiseWarning(100, 'Unable to read entry');
 			}
 
-			if (substr(zip_entry_name($file), strlen(zip_entry_name($file)) - 1) != '/')
+			$buffer = stream_get_contents($stream);
+			fclose($stream);
+
+			if (File::write($destination . '/' . $file, $buffer) === false)
 			{
-				$buffer = zip_entry_read($file, zip_entry_filesize($file));
-
-				if (JFile::write($destination . '/' . zip_entry_name($file), $buffer) === false)
-				{
-					return $this->raiseWarning(100, 'Unable to write entry');
-				}
-
-				zip_entry_close($file);
+				return $this->raiseWarning(100, 'Unable to write entry');
 			}
 		}
 
-		@zip_close($zip);
+		$zip->close();
 
 		return true;
 	}

--- a/libraries/joomla/archive/zip.php
+++ b/libraries/joomla/archive/zip.php
@@ -290,7 +290,7 @@ class JArchiveZip implements JArchiveExtractable
 		}
 
 		// Make sure the destination folder exists
-		if (!Folder::create($destination))
+		if (!JFolder::create($destination))
 		{
 			return $this->raiseWarning(100, 'Unable to create destination');
 		}
@@ -315,7 +315,7 @@ class JArchiveZip implements JArchiveExtractable
 			$buffer = stream_get_contents($stream);
 			fclose($stream);
 
-			if (File::write($destination . '/' . $file, $buffer) === false)
+			if (JFile::write($destination . '/' . $file, $buffer) === false)
 			{
 				return $this->raiseWarning(100, 'Unable to write entry');
 			}


### PR DESCRIPTION
### Summary of Changes

`zip_*` functions are deprecated on PHP 8. Use `ZipArchive` instead.

### Testing Instructions

Test that extracting zip archive using `JArchiveZip` still works. E.g. use this code:

```
$zip = new JArchiveZip;
$zip->extract($file, $destination);
```
Where `$file` is path to zip archive and `$destination` is destination directory.

### Expected result AFTER applying this Pull Request

Works like before.

### Documentation Changes Required

No.