### PR TITLE
[4.0] Fix file and folder deletion on updates from previous Joomla 4 Beta versions

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -6239,8 +6239,6 @@ class JoomlaInstallerScript
 			'/administrator/components/com_finder/src/Indexer/Driver',
 			'/api/components/com_installer/src/View/Languages',
 			'/libraries/vendor/joomla/controller',
-			// Joomla 4.0 Beta 3
-			// Joomla 4.0 Beta 4
 			// Joomla 4.0 Beta 5
 			'/components/com_users/layouts/joomla/form',
 			'/components/com_users/layouts/joomla',

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -476,7 +476,7 @@ class JoomlaInstallerScript
 	public function deleteUnexistingFiles()
 	{
 		$files = array(
-			// Joomla 4.0
+			// Joomla 4.0 Beta 1
 			'/administrator/components/com_actionlogs/actionlogs.php',
 			'/administrator/components/com_actionlogs/controller.php',
 			'/administrator/components/com_actionlogs/controllers/actionlogs.php',
@@ -2685,7 +2685,6 @@ class JoomlaInstallerScript
 			'/bin/index.html',
 			'/bin/keychain.php',
 			'/cli/deletefiles.php',
-			'/cli/finder_indexer.php',
 			'/cli/garbagecron.php',
 			'/cli/sessionGc.php',
 			'/cli/sessionMetadataGc.php',
@@ -2931,7 +2930,6 @@ class JoomlaInstallerScript
 			'/components/com_users/helpers/html/users.php',
 			'/components/com_users/helpers/legacyrouter.php',
 			'/components/com_users/helpers/route.php',
-			'/components/com_users/layouts/joomla/form/renderfield.php',
 			'/components/com_users/models/forms/frontend.xml',
 			'/components/com_users/models/forms/frontend_admin.xml',
 			'/components/com_users/models/forms/login.xml',
@@ -3836,12 +3834,6 @@ class JoomlaInstallerScript
 			'/media/com_finder/js/autocompleter.js',
 			'/media/com_joomlaupdate/js/json2.js',
 			'/media/com_joomlaupdate/js/json2.min.js',
-			'/media/contacts/images/con_address.png',
-			'/media/contacts/images/con_fax.png',
-			'/media/contacts/images/con_info.png',
-			'/media/contacts/images/con_mobile.png',
-			'/media/contacts/images/con_tel.png',
-			'/media/contacts/images/emailButton.png',
 			'/media/editors/codemirror/LICENSE',
 			'/media/editors/codemirror/addon/comment/comment.js',
 			'/media/editors/codemirror/addon/comment/comment.min.js',
@@ -5002,11 +4994,70 @@ class JoomlaInstallerScript
 			'/templates/system/images/j_button2_readmore.png',
 			'/templates/system/images/j_button2_right.png',
 			'/templates/system/images/selector-arrow.png',
+			// Joomla 4.0 Beta 2
+			'/administrator/components/com_finder/src/Indexer/Driver/Mysql.php',
+			'/administrator/components/com_finder/src/Indexer/Driver/Postgresql.php',
+			'/administrator/components/com_finder/src/Indexer/Driver/Mysql.php',
+			'/administrator/components/com_finder/src/Indexer/Driver/Postgresql.php',
+			'/administrator/components/com_workflow/access.xml',
+			'/api/components/com_installer/src/Controller/LanguagesController.php',
+			'/api/components/com_installer/src/View/Languages/JsonapiView.php',
+			'/libraries/vendor/joomla/controller/src/AbstractController.php',
+			'/libraries/vendor/joomla/controller/src/ControllerInterface.php',
+			'/libraries/vendor/joomla/controller/LICENSE',
+			'/media/com_users/js/admin-users-user.es6.js',
+			'/media/com_users/js/admin-users-user.es6.min.js',
+			'/media/com_users/js/admin-users-user.es6.min.js.gz',
+			'/media/com_users/js/admin-users-user.js',
+			'/media/com_users/js/admin-users-user.min.js',
+			'/media/com_users/js/admin-users-user.min.js.gz',
+			// Joomla 4.0 Beta 3
+			'/administrator/templates/atum/images/logo.svg',
+			'/administrator/templates/atum/images/logo-blue.svg',
+			'/administrator/templates/atum/images/logo-joomla-blue.svg',
+			'/administrator/templates/atum/images/logo-joomla-white.svg',
+			// Joomla 4.0 Beta 4
+			'/components/com_config/src/Model/CmsModel.php',
+			// Joomla 4.0 Beta 5
+			'/administrator/components/com_admin/sql/updates/mysql/4.0.0-2018-06-11.sql',
+			'/administrator/components/com_admin/sql/updates/mysql/4.0.0-2020-04-18.sql',
+			'/administrator/components/com_admin/sql/updates/postgresql/3.9.15-2020-01-08.sql',
+			'/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2018-06-11.sql',
+			'/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2020-04-18.sql',
+			'/administrator/components/com_config/tmpl/application/default_system.php',
+			'/administrator/language/en-GB/plg_content_imagelazyload.sys.ini',
+			'/administrator/language/en-GB/plg_fields_image.ini',
+			'/administrator/language/en-GB/plg_fields_image.sys.ini',
+			'/administrator/templates/atum/scss/vendor/bootstrap/_nav.scss',
+			'/cli/finder_indexer.php',
+			'/components/com_users/layouts/joomla/form/renderfield.php',
+			'/libraries/vendor/spomky-labs/base64url/phpstan.neon',
+			'/media/contacts/images/con_address.png',
+			'/media/contacts/images/con_fax.png',
+			'/media/contacts/images/con_info.png',
+			'/media/contacts/images/con_mobile.png',
+			'/media/contacts/images/con_tel.png',
+			'/media/contacts/images/emailButton.png',
+			'/media/plg_system_webauthn/images/webauthn-black.png',
+			'/media/plg_system_webauthn/images/webauthn-color.png',
+			'/media/plg_system_webauthn/images/webauthn-white.png',
+			'/media/system/css/system.css',
+			'/media/system/css/system.min.css',
+			'/media/system/css/system.min.css.gz',
+			'/media/system/images/notice-alert.png',
+			'/media/system/images/notice-download.png',
+			'/media/system/images/notice-info.png',
+			'/media/system/images/notice-note.png',
+			'/plugins/content/imagelazyload/imagelazyload.php',
+			'/plugins/content/imagelazyload/imagelazyload.xml',
+			'/templates/cassiopeia/html/layouts/chromes/cardGrey.php',
+			'/templates/cassiopeia/html/layouts/chromes/default.php',
+			'/templates/cassiopeia/scss/vendor/bootstrap/_card.scss',
 		);
 
 		// TODO There is an issue while deleting folders using the ftp mode
 		$folders = array(
-			// Joomla! 4.0
+			// Joomla 4.0 Beta 1
 			'/templates/system/images',
 			'/templates/system/html',
 			'/templates/protostar/less',
@@ -5303,8 +5354,6 @@ class JoomlaInstallerScript
 			'/media/editors/codemirror/addon',
 			'/media/editors/codemirror',
 			'/media/editors',
-			'/media/contacts/images',
-			'/media/contacts',
 			'/media/com_contenthistory/css',
 			'/media/cms/css',
 			'/media/cms',
@@ -6186,6 +6235,19 @@ class JoomlaInstallerScript
 			'/administrator/components/com_actionlogs/libraries',
 			'/administrator/components/com_actionlogs/helpers',
 			'/administrator/components/com_actionlogs/controllers',
+			// Joomla 4.0 Beta 2
+			'/administrator/components/com_finder/src/Indexer/Driver',
+			'/api/components/com_installer/src/View/Languages',
+			'/libraries/vendor/joomla/controller',
+			// Joomla 4.0 Beta 3
+			// Joomla 4.0 Beta 4
+			// Joomla 4.0 Beta 5
+			'/components/com_users/layouts/joomla/form',
+			'/components/com_users/layouts/joomla',
+			'/components/com_users/layouts',
+			'/media/contacts/images',
+			'/media/contacts',
+			'/plugins/content/imagelazyload',
 		);
 
 		foreach ($files as $file)


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) adds file and folder deletion to script.php for those files and folder which were deleted between Joomla 4 Beta versions (including the upcoming one).

The reason why this has to be done here is that the tool for creating the lists currently only checks the difference between 4.0 and 3.10, and so (almost) everything what happened between J4 Beta 1 and now is missing.

As agreed with @wilsonge , I have separated the beta releases into different sections for the different releases.

The few things which were not missing because added with some PR have been moved to the right section.

### Testing Instructions

Update any **_Joomla 4 Beta version_** (i.e. **_not nightly build_**) to the update package which has been built for this PR.

If you use "Live Update", use following custom URL: [https://ci.joomla.org/artifacts/joomla/joomla-cms/4.0-dev/31250/downloads/37111/pr_list.xml](https://ci.joomla.org/artifacts/joomla/joomla-cms/4.0-dev/31250/downloads/37111/pr_list.xml).

If you can't use "Live Update" for some reason, download the update package from following link and use "Upload & Update": [https://ci.joomla.org/artifacts/joomla/joomla-cms/4.0-dev/31250/downloads/37111/Joomla_4.0.0-beta5-dev+pr.31250-Development-Update_Package.zip](https://ci.joomla.org/artifacts/joomla/joomla-cms/4.0-dev/31250/downloads/37111/Joomla_4.0.0-beta5-dev+pr.31250-Development-Update_Package.zip).

When updating from a version before Joomla 4 Beta 4, mind the additional SQL step described here: [https://docs.joomla.org/J4.x:Upgrade_to_4.0_Beta_4](https://docs.joomla.org/J4.x:Upgrade_to_4.0_Beta_4). Despite of what the title says, this step is also necessary when updating a Beta lower than 4 to a Beta higher than 4.

Check if the files and folder which are added by this PR to script.php are present after the update.

Finally update a current 3.10-dev or latest 3.10 nightly to the update package built for this PR. Check that it still works without errors.

### Actual result BEFORE applying this Pull Request

Files and folders added by this PR to script.php have not been deleted with the update from a previous J4 Beta version.

### Expected result AFTER applying this Pull Request

Files and folders added by this PR to script.php have been deleted with the update from a previous J4 Beta version.

Update from a 3.10-dev works as well as before.

### Documentation Changes Required

None.