### PR TITLE
[4.0] protected $_router instead of private

### DIFF
--- a/libraries/src/Router/Route.php
+++ b/libraries/src/Router/Route.php
@@ -49,7 +49,7 @@ class Route
 	 * @var    Router[]
 	 * @since  3.0.1
 	 */
-	private static $_router = array();
+	protected static $_router = array();
 
 	/**
 	 * Translates an internal Joomla URL to a humanly readable URL. This method builds links for the current active client.


### PR DESCRIPTION
### Summary of Changes
Set the `$_router` variable as protected instead of private in the class: `Joomla\CMS\Router\Route`
By doing that we can extend the Route class and define our own Router in that.

This way we can provide additional functionalities in our Router.

### Testing Instructions
It can only be tested by extending the `Joomla\CMS\Router\Route` and defining our own Router


### Actual result BEFORE applying this Pull Request
No Router can be defined in sub-classes.


### Expected result AFTER applying this Pull Request
You can define your own Router in sub-classes.


### Documentation Changes Required
DKN
