### PR TITLE
[4.0] Remove FontAwesome from main template file

### DIFF
--- a/build/build-modules-js/compilecss.es6.js
+++ b/build/build-modules-js/compilecss.es6.js
@@ -47,6 +47,7 @@ module.exports.compile = (options, path) => {
           `${RootPath}/templates/cassiopeia/scss/system/searchtools/searchtools.scss`,
           `${RootPath}/templates/cassiopeia/scss/vendor/choicesjs/choices.scss`,
           `${RootPath}/templates/cassiopeia/scss/vendor/joomla-custom-elements/joomla-alert.scss`,
+          `${RootPath}/templates/cassiopeia/scss/vendor/fontawesome-free/fontawesome.scss`,
           `${RootPath}/administrator/templates/atum/scss/template.scss`,
           `${RootPath}/administrator/templates/atum/scss/template-rtl.scss`,
           `${RootPath}/administrator/templates/atum/scss/system/searchtools/searchtools.scss`,

--- a/templates/cassiopeia/scss/template.scss
+++ b/templates/cassiopeia/scss/template.scss
@@ -1,7 +1,6 @@
 // Bootstrap functions
 @import "../../../media/vendor/bootstrap/scss/functions";
 
-
 // Variables
 @import "variables";
 
@@ -11,15 +10,6 @@
 // Bootstrap
 @import "../../../media/vendor/bootstrap/scss/variables";
 @import "../../../media/vendor/bootstrap/scss/bootstrap";
-
-// "Font Awesome 5 Free"
-@import "../../../media/vendor/fontawesome-free/scss/fontawesome";
-@import "../../../media/vendor/fontawesome-free/scss/brands";
-@import "../../../media/vendor/fontawesome-free/scss/regular";
-@import "../../../media/vendor/fontawesome-free/scss/solid";
-
-// B/C for Icomoon
-@import "../../../build/media_source/system/scss/icomoon";
 
 // jQuery Minicolors
 @import "../../../build/media_source/system/scss/jquery-minicolors";

--- a/templates/cassiopeia/scss/vendor/fontawesome-free/fontawesome.scss
+++ b/templates/cassiopeia/scss/vendor/fontawesome-free/fontawesome.scss
@@ -1,0 +1,11 @@
+// Override the font path
+$fa-font-path: "../../../../../media/vendor/fontawesome-free/webfonts" !default;
+
+// "Font Awesome 5 Free"
+@import "../../../../../media/vendor/fontawesome-free/scss/fontawesome";
+@import "../../../../../media/vendor/fontawesome-free/scss/brands";
+@import "../../../../../media/vendor/fontawesome-free/scss/regular";
+@import "../../../../../media/vendor/fontawesome-free/scss/solid";
+
+// B/C for Icomoon
+@import "../../../../../build/media_source/system/scss/icomoon";


### PR DESCRIPTION
Closes https://github.com/joomla/joomla-cms/issues/31257.

### Summary of Changes

Removes FA from main Cassiopeia template file.

### Testing Instructions

Apply patch.
Run `node build/build.js --compile-css`.
Browse some frontend pages and check that icons appear correctly.

### Expected result AFTER applying this Pull Request

Works like before.

### Documentation Changes Required

No.