### PR TITLE
[4.0] Correct menu toggler icon

### DIFF
--- a/administrator/components/com_languages/tmpl/languages/default.php
+++ b/administrator/components/com_languages/tmpl/languages/default.php
@@ -110,7 +110,7 @@ if ($saveOrder && !empty($this->items))
 										<input type="text" name="order[]" size="5" value="<?php echo $item->ordering; ?>" class="width-20 text-area-order hidden">
 									<?php else : ?>
 										<span class="sortable-handler inactive">
-											<span class="icon-bars" aria-hidden="true"></span>
+											<span class="icon-ellipsis-v" aria-hidden="true"></span>
 										</span>
 									<?php endif; ?>
 								</td>

--- a/administrator/components/com_languages/tmpl/languages/default.php
+++ b/administrator/components/com_languages/tmpl/languages/default.php
@@ -110,7 +110,7 @@ if ($saveOrder && !empty($this->items))
 										<input type="text" name="order[]" size="5" value="<?php echo $item->ordering; ?>" class="width-20 text-area-order hidden">
 									<?php else : ?>
 										<span class="sortable-handler inactive">
-											<span class="icon-ellipsis-v" aria-hidden="true"></span>
+											<span class="icon-bars" aria-hidden="true"></span>
 										</span>
 									<?php endif; ?>
 								</td>

--- a/templates/cassiopeia/error.php
+++ b/templates/cassiopeia/error.php
@@ -89,7 +89,7 @@ $this->setMetaData('viewport', 'width=device-width, initial-scale=1');
 
 			<?php if ($this->countModules('menu') || $this->countModules('search')) : ?>
 				<button class="navbar-toggler navbar-toggler-right" type="button" aria-hidden="true" data-toggle="collapse" data-target="#navbar" aria-controls="navbar" aria-expanded="false" aria-label="<?php echo Text::_('TPL_CASSIOPEIA_TOGGLE'); ?>">
-					<span class="icon-bars"></span>
+					<span class="icon-menu"></span>
 				</button>
 				<div class="collapse navbar-collapse" id="navbar">
 					<jdoc:include type="modules" name="menu" style="none" />

--- a/templates/cassiopeia/index.php
+++ b/templates/cassiopeia/index.php
@@ -105,7 +105,7 @@ $stickyHeader = $this->params->get('stickyHeader') ? 'position-sticky sticky-top
 
 				<?php if ($this->countModules('menu') || $this->countModules('search')) : ?>
 					<button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#navbar" aria-controls="navbar" aria-expanded="false" aria-label="<?php echo Text::_('TPL_CASSIOPEIA_TOGGLE'); ?>">
-						<span class="icon-bars" aria-hidden="true"></span>
+						<span class="icon-menu" aria-hidden="true"></span>
 					</button>
 					<div class="collapse navbar-collapse" id="navbar">
 						<jdoc:include type="modules" name="menu" style="none" />


### PR DESCRIPTION
Fixes https://github.com/joomla/joomla-cms/issues/31261.

### Summary of Changes

Corrects icons in Cassiopeia menu and Languages list.

### Testing Instructions

Go to frontend. Reduce viewport size. Inspect menu toggler button.

### Actual result BEFORE applying this Pull Request

Button has bars icon.

### Expected result AFTER applying this Pull Request

Button has burger icon.

### Documentation Changes Required

No.