### PR TITLE
[4.0] Fix saving items without creation date

### DIFF
--- a/administrator/components/com_banners/src/Table/BannerTable.php
+++ b/administrator/components/com_banners/src/Table/BannerTable.php
@@ -117,6 +117,12 @@ class BannerTable extends Table implements VersionableTableInterface
 			return false;
 		}
 
+		// Set created date if not set.
+		if (!(int) $this->created)
+		{
+			$this->created = Factory::getDate()->toSql();
+		}
+
 		// Set publish_up, publish_down to null if not set
 		if (!$this->publish_up)
 		{

--- a/administrator/components/com_contact/src/Table/ContactTable.php
+++ b/administrator/components/com_contact/src/Table/ContactTable.php
@@ -73,6 +73,12 @@ class ContactTable extends Table implements VersionableTableInterface
 		$date   = Factory::getDate()->toSql();
 		$userId = Factory::getUser()->id;
 
+		// Set created date if not set.
+		if (!(int) $this->created)
+		{
+			$this->created = $date;
+		}
+
 		if ($this->id)
 		{
 			// Existing item
@@ -81,13 +87,7 @@ class ContactTable extends Table implements VersionableTableInterface
 		}
 		else
 		{
-			// New contact. A contact created and created_by field can be set by the user,
-			// so we don't touch either of these if they are set.
-			if (!(int) $this->created)
-			{
-				$this->created = $date;
-			}
-
+			// Field created_by field can be set by the user, so we don't touch it if it's set.
 			if (empty($this->created_by))
 			{
 				$this->created_by = $userId;

--- a/administrator/components/com_fields/src/Table/FieldTable.php
+++ b/administrator/components/com_fields/src/Table/FieldTable.php
@@ -173,22 +173,23 @@ class FieldTable extends Table
 			$this->fieldparams = '{}';
 		}
 
-		$date = Factory::getDate();
+		$date = Factory::getDate()->toSql();
 		$user = Factory::getUser();
+
+		// Set created date if not set.
+		if (!(int) $this->created_time)
+		{
+			$this->created_time = $date;
+		}
 
 		if ($this->id)
 		{
 			// Existing item
-			$this->modified_time = $date->toSql();
+			$this->modified_time = $date;
 			$this->modified_by = $user->get('id');
 		}
 		else
 		{
-			if (!(int) $this->created_time)
-			{
-				$this->created_time = $date->toSql();
-			}
-
 			if (!(int) $this->modified_time)
 			{
 				$this->modified_time = $this->created_time;

--- a/administrator/components/com_fields/src/Table/GroupTable.php
+++ b/administrator/components/com_fields/src/Table/GroupTable.php
@@ -100,21 +100,22 @@ class GroupTable extends Table
 			return false;
 		}
 
-		$date = Factory::getDate();
+		$date = Factory::getDate()->toSql();
 		$user = Factory::getUser();
+
+		// Set created date if not set.
+		if (!(int) $this->created)
+		{
+			$this->created = $date;
+		}
 
 		if ($this->id)
 		{
-			$this->modified = $date->toSql();
+			$this->modified = $date;
 			$this->modified_by = $user->get('id');
 		}
 		else
 		{
-			if (!(int) $this->created)
-			{
-				$this->created = $date->toSql();
-			}
-
 			if (!(int) $this->modified)
 			{
 				$this->modified = $this->created;

--- a/administrator/components/com_finder/src/Table/FilterTable.php
+++ b/administrator/components/com_finder/src/Table/FilterTable.php
@@ -125,6 +125,12 @@ class FilterTable extends Table
 		$date = Factory::getDate()->toSql();
 		$userId = Factory::getUser()->id;
 
+		// Set created date if not set.
+		if (!(int) $this->created)
+		{
+			$this->created = $date;
+		}
+
 		if ($this->filter_id)
 		{
 			// Existing item
@@ -133,13 +139,6 @@ class FilterTable extends Table
 		}
 		else
 		{
-			// New item. A filter's created field can be set by the user,
-			// so we don't touch it if it is set.
-			if (!(int) $this->created)
-			{
-				$this->created = $date;
-			}
-
 			if (empty($this->created_by))
 			{
 				$this->created_by = $userId;

--- a/administrator/components/com_newsfeeds/src/Table/NewsfeedTable.php
+++ b/administrator/components/com_newsfeeds/src/Table/NewsfeedTable.php
@@ -139,6 +139,12 @@ class NewsfeedTable extends Table implements VersionableTableInterface
 		$date = Factory::getDate();
 		$user = Factory::getUser();
 
+		// Set created date if not set.
+		if (!(int) $this->created)
+		{
+			$this->created = $date->toSql();
+		}
+
 		if ($this->id)
 		{
 			// Existing item
@@ -147,13 +153,7 @@ class NewsfeedTable extends Table implements VersionableTableInterface
 		}
 		else
 		{
-			// New newsfeed. A feed created and created_by field can be set by the user,
-			// so we don't touch either of these if they are set.
-			if (!(int) $this->created)
-			{
-				$this->created = $date->toSql();
-			}
-
+			// Field created_by can be set by the user, so we don't touch it if it's set.
 			if (empty($this->created_by))
 			{
 				$this->created_by = $user->get('id');

--- a/libraries/src/Table/Category.php
+++ b/libraries/src/Table/Category.php
@@ -231,29 +231,29 @@ class Category extends Nested implements VersionableTableInterface
 	 */
 	public function store($updateNulls = true)
 	{
-		$date = Factory::getDate();
+		$date = Factory::getDate()->toSql();
 		$user = Factory::getUser();
+
+		// Set created date if not set.
+		if (!(int) $this->created_time)
+		{
+			$this->created_time = $date;
+		}
 
 		if ($this->id)
 		{
 			// Existing category
 			$this->modified_user_id = $user->get('id');
-			$this->modified_time    = $date->toSql();
+			$this->modified_time    = $date;
 		}
 		else
 		{
-			// New category. A category created_time and created_user_id field can be set by the user,
-			// so we don't touch either of these if they are set.
-			if (!(int) $this->created_time)
-			{
-				$this->created_time = $date->toSql();
-			}
-
 			if (!(int) ($this->modified_time))
 			{
 				$this->modified_time = $this->created_time;
 			}
 
+			// Field created_user_id can be set by the user, so we don't touch it if it's set.
 			if (empty($this->created_user_id))
 			{
 				$this->created_user_id = $user->get('id');

--- a/libraries/src/Table/Content.php
+++ b/libraries/src/Table/Content.php
@@ -339,24 +339,24 @@ class Content extends Table implements VersionableTableInterface
 	 */
 	public function store($updateNulls = true)
 	{
-		$date = Factory::getDate();
+		$date = Factory::getDate()->toSql();
 		$user = Factory::getUser();
+
+		// Set created date if not set.
+		if (!(int) $this->created)
+		{
+			$this->created = $date;
+		}
 
 		if ($this->id)
 		{
 			// Existing item
 			$this->modified_by = $user->get('id');
-			$this->modified    = $date->toSql();
+			$this->modified    = $date;
 		}
 		else
 		{
-			// New article. An article created and created_by field can be set by the user,
-			// so we don't touch either of these if they are set.
-			if (!(int) $this->created)
-			{
-				$this->created = $date->toSql();
-			}
-
+			// Field created_by can be set by the user, so we don't touch it if it's set.
 			if (empty($this->created_by))
 			{
 				$this->created_by = $user->get('id');


### PR DESCRIPTION
Fixes https://github.com/joomla/joomla-cms/issues/31046.

### Summary of Changes

Fixes saving content without creation date.

### Testing Instructions

Edit an article/contact/banner/category/newsfeed/custom field/custom field group/smart search filter.
Remove value from `Created Date` field.
Save.

### Actual result BEFORE applying this Pull Request

An error like this:

>Save failed with the following error: Incorrect datetime value: '' for column 'created_time' at row 1

### Expected result AFTER applying this Pull Request

Item saved and `Created Date` field populated with current date.

### Documentation Changes Required

No.