### PR TITLE
Log that PDF Fonts in language packs are deprecated and will be removed in 4.0

### DIFF
--- a/libraries/src/Installer/Adapter/LanguageAdapter.php
+++ b/libraries/src/Installer/Adapter/LanguageAdapter.php
@@ -261,6 +261,26 @@ class LanguageAdapter extends InstallerAdapter
 		// Parse optional tags
 		$this->parent->parseMedia($this->getManifest()->media);
 
+		/*
+		 * Log that PDF Fonts in language packs are deprecated and will be removed in 4.0
+		 * Ref: https://github.com/joomla/joomla-cms/issues/31286
+		 */
+		if (is_dir($basePath . '/language/pdf_fonts'))
+		{
+			try
+			{
+				\JLog::add(
+					sprintf('Using the "pdf_fonts" folder to load language specific fonts in languages is deprecated and will be removed in 4.0.', 'pdf_fonts'),
+					\JLog::WARNING,
+					'deprecated'
+				);
+			}
+			catch (RuntimeException $exception)
+			{
+				// Informational log only
+			}
+		}
+
 		// Copy all the necessary font files to the common pdf_fonts directory
 		$this->parent->setPath('extension_site', $basePath . '/language/pdf_fonts');
 		$overwrite = $this->parent->setOverwrite(true);

--- a/libraries/src/Installer/Adapter/LanguageAdapter.php
+++ b/libraries/src/Installer/Adapter/LanguageAdapter.php
@@ -270,7 +270,7 @@ class LanguageAdapter extends InstallerAdapter
 			try
 			{
 				\JLog::add(
-					sprintf('Using the "pdf_fonts" folder to load language specific fonts in languages is deprecated and will be removed in 4.0.', 'pdf_fonts'),
+					'Using the "pdf_fonts" folder to load language specific fonts in languages is deprecated and will be removed in 4.0.',
 					\JLog::WARNING,
 					'deprecated'
 				);
@@ -542,7 +542,7 @@ class LanguageAdapter extends InstallerAdapter
 			try
 			{
 				\JLog::add(
-					sprintf('Using the "pdf_fonts" folder to load language specific fonts in languages is deprecated and will be removed in 4.0.', 'pdf_fonts'),
+					'Using the "pdf_fonts" folder to load language specific fonts in languages is deprecated and will be removed in 4.0.',
 					\JLog::WARNING,
 					'deprecated'
 				);

--- a/libraries/src/Installer/Adapter/LanguageAdapter.php
+++ b/libraries/src/Installer/Adapter/LanguageAdapter.php
@@ -533,6 +533,26 @@ class LanguageAdapter extends InstallerAdapter
 		// Parse optional tags
 		$this->parent->parseMedia($xml->media);
 
+		/*
+		 * Log that PDF Fonts in language packs are deprecated and will be removed in 4.0
+		 * Ref: https://github.com/joomla/joomla-cms/issues/31286
+		 */
+		if (is_dir($basePath . '/language/pdf_fonts'))
+		{
+			try
+			{
+				\JLog::add(
+					sprintf('Using the "pdf_fonts" folder to load language specific fonts in languages is deprecated and will be removed in 4.0.', 'pdf_fonts'),
+					\JLog::WARNING,
+					'deprecated'
+				);
+			}
+			catch (RuntimeException $exception)
+			{
+				// Informational log only
+			}
+		}
+
 		// Copy all the necessary font files to the common pdf_fonts directory
 		$this->parent->setPath('extension_site', $basePath . '/language/pdf_fonts');
 		$overwrite = $this->parent->setOverwrite(true);


### PR DESCRIPTION
Pull Request for Issue #31286

### Summary of Changes

Log that PDF Fonts in language packs are deprecated and will be removed in 4.0

### Testing Instructions

Install an language via the backend

### Actual result BEFORE applying this Pull Request

Install works

### Expected result AFTER applying this Pull Request

Install works and logs when we found an pdf_fonts folder

### Documentation Changes Required

Has to be documented here: https://docs.joomla.org/Potential_backward_compatibility_issues_in_Joomla_4