### PR TITLE
Remove pdf_fonts handling for language installer

### DIFF
--- a/libraries/src/Installer/Adapter/LanguageAdapter.php
+++ b/libraries/src/Installer/Adapter/LanguageAdapter.php
@@ -425,20 +425,6 @@ class LanguageAdapter extends InstallerAdapter
 		// Parse optional tags
 		$this->parent->parseMedia($this->getManifest()->media);
 
-		// Copy all the necessary font files to the common pdf_fonts directory
-		$this->parent->setPath('extension_site', $basePath . '/language/pdf_fonts');
-		$overwrite = $this->parent->setOverwrite(true);
-
-		if ($this->parent->parseFiles($this->getManifest()->fonts) === false)
-		{
-			// Install failed, rollback changes
-			$this->parent->abort();
-
-			return false;
-		}
-
-		$this->parent->setOverwrite($overwrite);
-
 		// Get the language description
 		$description = (string) $this->getManifest()->description;
 
@@ -610,20 +596,6 @@ class LanguageAdapter extends InstallerAdapter
 
 		// Parse optional tags
 		$this->parent->parseMedia($xml->media);
-
-		// Copy all the necessary font files to the common pdf_fonts directory
-		$this->parent->setPath('extension_site', $basePath . '/language/pdf_fonts');
-		$overwrite = $this->parent->setOverwrite(true);
-
-		if ($this->parent->parseFiles($xml->fonts) === false)
-		{
-			// Install failed, rollback changes
-			$this->parent->abort();
-
-			return false;
-		}
-
-		$this->parent->setOverwrite($overwrite);
 
 		// Get the language description and set it as message
 		$this->parent->set('message', (string) $xml->description);


### PR DESCRIPTION
Pull Request for Issue #31286

### Summary of Changes

Remove pdf_fonts handling for language installer as deprecated here: https://github.com/joomla/joomla-cms/pull/31287

### Testing Instructions

Make sure the installation of languages still work

### Actual result BEFORE applying this Pull Request

We have pdf_fonts folder handling not used since 1.6 as reported by JM at #31286 

### Expected result AFTER applying this Pull Request

We no longer have that code

### Documentation Changes Required

Has to be documented here: https://docs.joomla.org/Potential_backward_compatibility_issues_in_Joomla_4