### PR TITLE
[4.0] Fixes issue with no bold (strong) font in cassiopeia

### DIFF
--- a/templates/cassiopeia/joomla.asset.json
+++ b/templates/cassiopeia/joomla.asset.json
@@ -49,7 +49,7 @@
     {
       "name": "template.cassiopeia.googlefont",
       "type": "style",
-      "uri": "https://fonts.googleapis.com/css?family=Fira+Sans:400"
+      "uri": "https://fonts.googleapis.com/css2?family=Fira+Sans:wght@400;500&display=swap"
     },
     {
       "name": "template.cassiopeia",


### PR DESCRIPTION
Making any text bold in cassiopeia has no effect, because only 1 weight of the Fira Sans font is being loaded in.
This fixes that.