### PR TITLE
Repalce `dirname(__FILE__)` with `__DIR__`

### DIFF
--- a/plugins/system/actionlogs/actionlogs.php
+++ b/plugins/system/actionlogs/actionlogs.php
@@ -126,7 +126,7 @@ class PlgSystemActionLogs extends JPlugin
 			return true;
 		}
 
-		Form::addFormPath(dirname(__FILE__) . '/forms');
+		Form::addFormPath(__DIR__ . '/forms');
 
 		if ((!PluginHelper::isEnabled('actionlog', 'joomla')) && (Factory::getApplication()->isAdmin()))
 		{


### PR DESCRIPTION

Pull Request for Issue # .

### Summary of Changes

PHP 5.3 adds support for the `__DIR__` magic constant, and its result is identical to `dirname(__FILE__)`. The former is more clearer and does not has a function call, giving a tiny performance advantage as well.

### Testing Instructions



### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Documentation Changes Required

