### PR TITLE
[4.0] Fix undefined variable notice

### DIFF
--- a/administrator/components/com_config/src/Controller/ComponentController.php
+++ b/administrator/components/com_config/src/Controller/ComponentController.php
@@ -196,12 +196,11 @@ class ComponentController extends FormController
 	 */
 	public function cancel($key = null)
 	{
-		$option = $this->input->get('component');
+		$component = $this->input->get('component');
 
 		// Clear session data.
-		$this->app->setUserState("$this->option.edit.$this->context.$option.data", null);
+		$this->app->setUserState("$this->option.edit.$this->context.$component.data", null);
 
-		$component = $this->input->get('component');
 		$this->setRedirect(Route::_('index.php?option=' . $component, false));
 
 		return true;

--- a/administrator/components/com_config/src/Controller/ComponentController.php
+++ b/administrator/components/com_config/src/Controller/ComponentController.php
@@ -196,6 +196,8 @@ class ComponentController extends FormController
 	 */
 	public function cancel($key = null)
 	{
+		$option = $this->input->get('component');
+
 		// Clear session data.
 		$this->app->setUserState("$this->option.edit.$this->context.$option.data", null);
 


### PR DESCRIPTION
### Summary of Changes

Fixes undefined variable notice.

### Testing Instructions

Go to some component's configuration.
Click `Cancel` button.
Check PHP error log.

### Actual result BEFORE applying this Pull Request

>Notice:  Undefined variable: option in administrator\components\com_config\src\Controller\ComponentController.php on line 200

### Expected result AFTER applying this Pull Request

No notices.

### Documentation Changes Required

No.