### PR TITLE
Remove unnecessary check of loaded language file

### DIFF
--- a/libraries/src/Plugin/CMSPlugin.php
+++ b/libraries/src/Plugin/CMSPlugin.php
@@ -137,12 +137,6 @@ abstract class CMSPlugin extends \JEvent
 		$extension = strtolower($extension);
 		$lang      = \JFactory::getLanguage();
 
-		// If language already loaded, don't load it again.
-		if ($lang->getPaths($extension))
-		{
-			return true;
-		}
-
 		return $lang->load($extension, $basePath, null, false, true)
 			|| $lang->load($extension, JPATH_PLUGINS . '/' . $this->_type . '/' . $this->_name, null, false, true);
 	}


### PR DESCRIPTION
Language::load() also checks, and that works better.

Pull Request for Issue #31311 .

### Testing/reproduction
I found the issue in the following situation:
I have a component which have settings for users (at user profile, via plugin) and one of these can be changed temporary for a specific item. The UI for changing default value and for the temporary change shares the same code, and same language file.
Because the plugin works with user profile I can edit it's value both frontend and backend. For some reason (probably custom field types in admin folder) on the admin side it loads the components admin language file, which prevents the loading of frontend language file if CMSPlugin checks if there is **_any_** file loaded for the extension.