### PR TITLE
[4.0] Search tip com_menus

### DIFF
--- a/administrator/components/com_menus/forms/filter_items.xml
+++ b/administrator/components/com_menus/forms/filter_items.xml
@@ -28,6 +28,8 @@
 			name="search"
 			type="text"
 			inputmode="search"
+			label="COM_MENUS_ITEMS_SEARCH_FILTER_LABEL"
+			description="COM_MENUS_ITEMS_SEARCH_FILTER"
 			hint="JSEARCH_FILTER"
 			noresults="JGLOBAL_NO_MATCHING_RESULTS"
 		/>


### PR DESCRIPTION
Pull Request for Issue #31335 .

### Steps to reproduce the issue
Login to joomla admin panel
Click on menu
Go to all menu
Hover on the search icon

### Expected result
Just like other menu search help text eg , user, banner, articles - All menu search bar should have help text

### Actual result
Help text is missing

### After
![image](https://user-images.githubusercontent.com/1296369/98437634-9c787a00-20db-11eb-89d6-10a490c965e4.png)
