### PR TITLE
[4.0] Fix markup in color field

### DIFF
--- a/layouts/joomla/form/field/color/advanced.php
+++ b/layouts/joomla/form/field/color/advanced.php
@@ -59,7 +59,7 @@ else
 }
 
 $inputclass   = ($keywords && ! in_array($format, array('rgb', 'rgba'), true)) ? ' keywords' : ' ' . $format;
-$class        = ' class="form-control ' . trim('minicolors ' . $class) . ($validate === 'color' ? 'form-control ' : $inputclass) . '"';
+$class        = ' class="form-control ' . trim('minicolors ' . $class) . ($validate === 'color' ? '' : $inputclass) . '"';
 $control      = $control ? ' data-control="' . $control . '"' : '';
 $format       = $format ? ' data-format="' . $format . '"' : '';
 $keywords     = $keywords ? ' data-keywords="' . $keywords . '"' : '';


### PR DESCRIPTION
Fixes https://github.com/joomla/joomla-cms/issues/31339.

### Summary of Changes

Fixes markup in color field layout.

### Testing Instructions

Create a Color custom field for articles.
Edit an article.
Go to Fields tabs and inspect the color field.

### Actual result BEFORE applying this Pull Request

Color field appears as text field.

### Expected result AFTER applying this Pull Request

Color field appears as color picker.

### Documentation Changes Required

No.