### PR TITLE
[4.0] Select article etc button styling

### DIFF
--- a/administrator/components/com_categories/src/Field/Modal/CategoryField.php
+++ b/administrator/components/com_categories/src/Field/Modal/CategoryField.php
@@ -215,7 +215,7 @@ class CategoryField extends FormField
 			$callbackFunctionStem = substr("jSelectCategory_" . $this->id, 0, -$tagLength);
 
 			$html .= '<button'
-			. ' class="btn btn-secondary' . ($value ? '' : ' hidden') . '"'
+			. ' class="btn btn-primary' . ($value ? '' : ' hidden') . '"'
 			. ' type="button"'
 			. ' id="' . $this->id . '_propagate"'
 			. ' title="' . Text::_('JGLOBAL_ASSOCIATIONS_PROPAGATE_TIP') . '"'

--- a/administrator/components/com_categories/src/Field/Modal/CategoryField.php
+++ b/administrator/components/com_categories/src/Field/Modal/CategoryField.php
@@ -186,7 +186,7 @@ class CategoryField extends FormField
 		if ($allowEdit)
 		{
 			$html .= '<button'
-				. ' class="btn btn-secondary' . ($value ? '' : ' hidden') . '"'
+				. ' class="btn btn-primary' . ($value ? '' : ' hidden') . '"'
 				. ' id="' . $this->id . '_edit"'
 				. ' data-toggle="modal"'
 				. ' type="button"'

--- a/administrator/components/com_contact/src/Field/Modal/ContactField.php
+++ b/administrator/components/com_contact/src/Field/Modal/ContactField.php
@@ -204,7 +204,7 @@ class ContactField extends FormField
 			$callbackFunctionStem = substr("jSelectContact_" . $this->id, 0, -$tagLength);
 
 			$html .= '<button'
-			. ' class="btn btn-secondary' . ($value ? '' : ' hidden') . '"'
+			. ' class="btn btn-primary' . ($value ? '' : ' hidden') . '"'
 			. ' type="button"'
 			. ' id="' . $this->id . '_propagate"'
 			. ' title="' . Text::_('JGLOBAL_ASSOCIATIONS_PROPAGATE_TIP') . '"'

--- a/administrator/components/com_contact/src/Field/Modal/ContactField.php
+++ b/administrator/components/com_contact/src/Field/Modal/ContactField.php
@@ -175,7 +175,7 @@ class ContactField extends FormField
 		if ($allowEdit)
 		{
 			$html .= '<button'
-				. ' class="btn btn-secondary' . ($value ? '' : ' hidden') . '"'
+				. ' class="btn btn-primary' . ($value ? '' : ' hidden') . '"'
 				. ' id="' . $this->id . '_edit"'
 				. ' data-toggle="modal"'
 				. ' type="button"'

--- a/administrator/components/com_content/src/Field/Modal/ArticleField.php
+++ b/administrator/components/com_content/src/Field/Modal/ArticleField.php
@@ -178,7 +178,7 @@ class ArticleField extends FormField
 		if ($allowEdit)
 		{
 			$html .= '<button'
-				. ' class="btn btn-secondary' . ($value ? '' : ' hidden') . '"'
+				. ' class="btn btn-primary' . ($value ? '' : ' hidden') . '"'
 				. ' id="' . $this->id . '_edit"'
 				. ' data-toggle="modal"'
 				. ' type="button"'
@@ -207,7 +207,7 @@ class ArticleField extends FormField
 			$callbackFunctionStem = substr("jSelectArticle_" . $this->id, 0, -$tagLength);
 
 			$html .= '<button'
-			. ' class="btn btn-secondary' . ($value ? '' : ' hidden') . '"'
+			. ' class="btn btn-primary' . ($value ? '' : ' hidden') . '"'
 			. ' type="button"'
 			. ' id="' . $this->id . '_propagate"'
 			. ' title="' . Text::_('JGLOBAL_ASSOCIATIONS_PROPAGATE_TIP') . '"'

--- a/administrator/components/com_menus/src/Field/Modal/MenuField.php
+++ b/administrator/components/com_menus/src/Field/Modal/MenuField.php
@@ -310,7 +310,7 @@ class MenuField extends FormField
 		if ($this->allowEdit)
 		{
 			$html .= '<button'
-				. ' class="btn btn-secondary' . ($value ? '' : ' hidden') . '"'
+				. ' class="btn btn-primary' . ($value ? '' : ' hidden') . '"'
 				. ' id="' . $this->id . '_edit"'
 				. ' data-toggle="modal"'
 				. ' type="button"'

--- a/administrator/components/com_menus/src/Field/Modal/MenuField.php
+++ b/administrator/components/com_menus/src/Field/Modal/MenuField.php
@@ -339,7 +339,7 @@ class MenuField extends FormField
 			$callbackFunctionStem = substr("jSelectMenu_" . $this->id, 0, -$tagLength);
 
 			$html .= '<button'
-			. ' class="btn btn-secondary' . ($value ? '' : ' hidden') . '"'
+			. ' class="btn btn-primary' . ($value ? '' : ' hidden') . '"'
 			. ' type="button"'
 			. ' id="' . $this->id . '_propagate"'
 			. ' title="' . Text::_('JGLOBAL_ASSOCIATIONS_PROPAGATE_TIP') . '"'

--- a/administrator/components/com_newsfeeds/src/Field/Modal/NewsfeedField.php
+++ b/administrator/components/com_newsfeeds/src/Field/Modal/NewsfeedField.php
@@ -205,7 +205,7 @@ class NewsfeedField extends FormField
 			$callbackFunctionStem = substr("jSelectNewsfeed_" . $this->id, 0, -$tagLength);
 
 			$html .= '<button'
-			. ' class="btn btn-secondary' . ($value ? '' : ' hidden') . '"'
+			. ' class="btn btn-primary' . ($value ? '' : ' hidden') . '"'
 			. ' type="button"'
 			. ' id="' . $this->id . '_propagate"'
 			. ' title="' . Text::_('JGLOBAL_ASSOCIATIONS_PROPAGATE_TIP') . '"'

--- a/administrator/components/com_newsfeeds/src/Field/Modal/NewsfeedField.php
+++ b/administrator/components/com_newsfeeds/src/Field/Modal/NewsfeedField.php
@@ -176,7 +176,7 @@ class NewsfeedField extends FormField
 		if ($allowEdit)
 		{
 			$html .= '<button'
-				. ' class="btn btn-secondary' . ($value ? '' : ' hidden') . '"'
+				. ' class="btn btn-primary' . ($value ? '' : ' hidden') . '"'
 				. ' id="' . $this->id . '_edit"'
 				. ' data-toggle="modal"'
 				. ' type="button"'


### PR DESCRIPTION
When we have two buttons _joined_ together visually it is important that a user can determine that there are two buttons and not just one big button with two pieces of text. This is important for those with cognitive issues etc

### Before
![image](https://user-images.githubusercontent.com/1296369/98461732-94394100-21a6-11eb-8550-f65a0c9735c4.png)

![image](https://user-images.githubusercontent.com/1296369/98461758-c8146680-21a6-11eb-800c-e345c4e7ef56.png)

### After
![image](https://user-images.githubusercontent.com/1296369/98461744-ad41f200-21a6-11eb-8872-1e7c415be8b2.png)

![image](https://user-images.githubusercontent.com/1296369/98461751-b6cb5a00-21a6-11eb-94ff-62018a64d4e8.png)

### Testing
You can find this field when you create a menu item for a single article

Also included in this PR are the identical change for the category, contact, menu and newsfeed fields

cc @carcam as requested