### PR TITLE
[4.0] Fix category select in field editing form

### DIFF
--- a/administrator/components/com_categories/layouts/joomla/form/field/categoryedit.php
+++ b/administrator/components/com_categories/layouts/joomla/form/field/categoryedit.php
@@ -67,7 +67,11 @@ if ($readonly || $disabled)
 }
 
 $attr2 .= !empty($class) ? ' class="' . $class . '"' : '';
-$attr2 .= ' search-placeholder="' . $this->escape(Text::_('JGLOBAL_TYPE_OR_SELECT_CATEGORY')) . '" ';
+
+$placeholder = $this->escape(Text::_('JGLOBAL_TYPE_OR_SELECT_CATEGORY'));
+
+$attr2 .= ' placeholder="' . $placeholder . '" ';
+$attr2 .= ' search-placeholder="' . $placeholder . '" ';
 
 if ($allowCustom)
 {

--- a/administrator/components/com_fields/forms/field.xml
+++ b/administrator/components/com_fields/forms/field.xml
@@ -37,7 +37,7 @@
 			multiple="true"
 			addfieldprefix="Joomla\Component\Categories\Administrator\Field"
 			>
-			<option value="">JALL</option>
+			<option value="0">JALL</option>
 			<option value="-1">JNONE</option>
 		</field>
 


### PR DESCRIPTION
Pull Request for Issue #31352 .

### Summary of Changes
This changes `<option value="">JALL</option> ` to `<option value="0">JALL</option>`.


https://github.com/joomla/joomla-cms/blob/0e316b3ed2341c17e50ef0bca78fb1d1ef4c2c2e/administrator/components/com_fields/forms/field.xml#L39-L41

As it casts to 0 anyway, that should work fine.

https://github.com/joomla/joomla-cms/blob/d7451e644001e6fbdb85abf0c87c9c34bae2602c/administrator/components/com_fields/src/Model/FieldModel.php#L166-L184

Also I have fixed placeholder text for a "multiple category" input.

### Testing Instructions
Please look for detail #31352


### Actual result BEFORE applying this Pull Request

you cannot select All

### Expected result AFTER applying this Pull Request

you can select All

### Documentation Changes Required
none
