### PR TITLE
[4.0] Fix custom fields in com_users

### DIFF
--- a/administrator/components/com_users/src/Extension/UsersComponent.php
+++ b/administrator/components/com_users/src/Extension/UsersComponent.php
@@ -15,6 +15,8 @@ use Joomla\CMS\Component\Router\RouterServiceInterface;
 use Joomla\CMS\Component\Router\RouterServiceTrait;
 use Joomla\CMS\Extension\BootableExtensionInterface;
 use Joomla\CMS\Extension\MVCComponent;
+use Joomla\CMS\Factory;
+use Joomla\CMS\Fields\FieldsServiceInterface;
 use Joomla\CMS\HTML\HTMLRegistryAwareTrait;
 use Joomla\Component\Users\Administrator\Service\HTML\Users;
 use Psr\Container\ContainerInterface;
@@ -24,7 +26,7 @@ use Psr\Container\ContainerInterface;
  *
  * @since  4.0.0
  */
-class UsersComponent extends MVCComponent implements BootableExtensionInterface, RouterServiceInterface
+class UsersComponent extends MVCComponent implements BootableExtensionInterface, RouterServiceInterface, FieldsServiceInterface
 {
 	use RouterServiceTrait;
 	use HTMLRegistryAwareTrait;
@@ -45,5 +47,53 @@ class UsersComponent extends MVCComponent implements BootableExtensionInterface,
 	public function boot(ContainerInterface $container)
 	{
 		$this->getRegistry()->register('users', new Users);
+	}
+
+	/**
+	 * Returns a valid section for the given section. If it is not valid then null is returned.
+	 *
+	 * @param   string  $section  The section to get the mapping for
+	 * @param   object  $item     The item
+	 *
+	 * @return  string|null  The new section or null
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function validateSection($section, $item = null)
+	{
+		if (Factory::getApplication()->isClient('site'))
+		{
+			switch ($section)
+			{
+				case 'registration':
+				case 'profile':
+					return 'user';
+			}
+		}
+
+		if ($section === 'user')
+		{
+			return $section;
+		}
+
+		// We don't know other sections.
+		return null;
+	}
+
+	/**
+	 * Returns valid contexts.
+	 *
+	 * @return  array  Associative array with contexts as keys and translated strings as values
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getContexts(): array
+	{
+		$language = Factory::getApplication()->getLanguage();
+		$language->load('com_users', JPATH_ADMINISTRATOR);
+
+		return [
+			'com_users.user' => $language->_('COM_USERS'),
+		];
 	}
 }

--- a/administrator/components/com_users/src/Extension/UsersComponent.php
+++ b/administrator/components/com_users/src/Extension/UsersComponent.php
@@ -52,8 +52,8 @@ class UsersComponent extends MVCComponent implements BootableExtensionInterface,
 	/**
 	 * Returns a valid section for the given section. If it is not valid then null is returned.
 	 *
-	 * @param   string  $section  The section to get the mapping for
-	 * @param   object  $item     The item
+	 * @param   string       $section  The section to get the mapping for
+	 * @param   object|null  $item     The content item or null
 	 *
 	 * @return  string|null  The new section or null
 	 *

--- a/administrator/components/com_users/src/Helper/UsersHelper.php
+++ b/administrator/components/com_users/src/Helper/UsersHelper.php
@@ -182,28 +182,13 @@ class UsersHelper extends ContentHelper
 	 *
 	 * @return  string|null  The new section
 	 *
-	 * @since   3.7.0
-	 * @throws  \Exception
+	 * @since       3.7.0
+	 * @throws      \Exception
+	 * @deprecated  5.0  Use \Joomla\Component\Users\Administrator\Extension\UsersComponent::validateSection() instead.
 	 */
 	public static function validateSection($section)
 	{
-		if (Factory::getApplication()->isClient('site'))
-		{
-			switch ($section)
-			{
-				case 'registration':
-				case 'profile':
-					$section = 'user';
-			}
-		}
-
-		if ($section != 'user')
-		{
-			// We don't know other sections
-			return null;
-		}
-
-		return $section;
+		return Factory::getApplication()->bootComponent('com_users')->validateSection($section, null);
 	}
 
 	/**
@@ -211,16 +196,11 @@ class UsersHelper extends ContentHelper
 	 *
 	 * @return  array
 	 *
-	 * @since   3.7.0
+	 * @since       3.7.0
+	 * @deprecated  5.0  Use \Joomla\Component\Users\Administrator\Extension\UsersComponent::getContexts() instead.
 	 */
 	public static function getContexts()
 	{
-		Factory::getLanguage()->load('com_users', JPATH_ADMINISTRATOR);
-
-		$contexts = array(
-			'com_users.user' => Text::_('COM_USERS'),
-		);
-
-		return $contexts;
+		return Factory::getApplication()->bootComponent('com_users')->getContexts();
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/joomla/joomla-cms/issues/31334.

### Summary of Changes

Fixes custom fields functionality in com_users.

### Testing Instructions

Enable user registration.
Go to Users -> Fields. Notice that context select box is missing.
Create a field. Configure permissions or enable `Display When Read-Only` setting.
Go to register in frontend.

### Actual result BEFORE applying this Pull Request

Custom fields not shown in registration form.

### Expected result AFTER applying this Pull Request

Custom fields shown in registration form.

### Documentation Changes Required

No.