### PR TITLE
Make read more URLs absolute in feed

### DIFF
--- a/components/com_content/views/category/view.feed.php
+++ b/components/com_content/views/category/view.feed.php
@@ -56,9 +56,14 @@ class ContentViewCategory extends JViewCategoryfeed
 			$item->slug = $item->alias ? ($item->id . ':' . $item->alias) : $item->id;
 
 			// URL link to article
-			$link = JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catid, $item->language));
+			$link = JRoute::_(
+				ContentHelperRoute::getArticleRoute($item->slug, $item->catid, $item->language),
+				true,
+				$app->get('force_ssl') == 2 ? \JRoute::TLS_FORCE : \JRoute::TLS_IGNORE,
+				true
+			);
 
-			$item->description .= '<p class="feed-readmore"><a target="_blank" href ="' . $link . '">' . JText::_('COM_CONTENT_FEED_READMORE') . '</a></p>';
+			$item->description .= '<p class="feed-readmore"><a target="_blank" href="' . $link . '">' . JText::_('COM_CONTENT_FEED_READMORE') . '</a></p>';
 		}
 
 		$item->author = $item->created_by_alias ?: $item->author;

--- a/components/com_content/views/featured/view.feed.php
+++ b/components/com_content/views/featured/view.feed.php
@@ -97,7 +97,7 @@ class ContentViewFeatured extends JViewLegacy
 			if (!$params->get('feed_summary', 0) && $params->get('feed_show_readmore', 0) && $row->fulltext)
 			{
 				$link = \JRoute::_($link, true, $app->get('force_ssl') == 2 ? \JRoute::TLS_FORCE : \JRoute::TLS_IGNORE, true);
-				$description .= '<p class="feed-readmore"><a target="_blank" href="' . $link  . '">' . JText::_('COM_CONTENT_FEED_READMORE') . '</a></p>';
+				$description .= '<p class="feed-readmore"><a target="_blank" href="' . $link . '">' . JText::_('COM_CONTENT_FEED_READMORE') . '</a></p>';
 			}
 
 			// Load item description and add div

--- a/components/com_content/views/featured/view.feed.php
+++ b/components/com_content/views/featured/view.feed.php
@@ -48,7 +48,7 @@ class ContentViewFeatured extends JViewLegacy
 			$row->slug = $row->alias ? ($row->id . ':' . $row->alias) : $row->id;
 
 			// URL link to article
-			$link = JRoute::_(ContentHelperRoute::getArticleRoute($row->slug, $row->catid, $row->language));
+			$link = ContentHelperRoute::getArticleRoute($row->slug, $row->catid, $row->language);
 
 			$description = '';
 			$obj = json_decode($row->images);
@@ -66,7 +66,7 @@ class ContentViewFeatured extends JViewLegacy
 			// Load individual item creator class
 			$item           = new JFeedItem;
 			$item->title    = $title;
-			$item->link     = $link;
+			$item->link     = \JRoute::_($link);
 			$item->date     = $row->publish_up;
 			$item->category = array();
 
@@ -96,7 +96,8 @@ class ContentViewFeatured extends JViewLegacy
 			// Add readmore link to description if introtext is shown, show_readmore is true and fulltext exists
 			if (!$params->get('feed_summary', 0) && $params->get('feed_show_readmore', 0) && $row->fulltext)
 			{
-				$description .= '<p class="feed-readmore"><a target="_blank" href ="' . $item->link . '">' . JText::_('COM_CONTENT_FEED_READMORE') . '</a></p>';
+				$link = \JRoute::_($link, true, $app->get('force_ssl') == 2 ? \JRoute::TLS_FORCE : \JRoute::TLS_IGNORE, true);
+				$description .= '<p class="feed-readmore"><a target="_blank" href="' . $link  . '">' . JText::_('COM_CONTENT_FEED_READMORE') . '</a></p>';
 			}
 
 			// Load item description and add div


### PR DESCRIPTION
Fixes https://github.com/joomla/joomla-cms/issues/23064.

### Summary of Changes

Makes read more URLs absolute in feed views.

### Testing Instructions

Go to `com_content` configuration. In `Integration` tab enable `Show Feed Link` and `Show "Read More"`.

Create an article with read more.
Make it featured.
View featured and category views containing the article in frontend.
View the feeds of these views.

### Actual result BEFORE applying this Pull Request

Read more links are relative.

### Expected result AFTER applying this Pull Request

Read more links are absolute.

### Documentation Changes Required

No.