### PR TITLE
[4.0] frontend articles category list improvements

### DIFF
--- a/components/com_content/tmpl/category/default_articles.php
+++ b/components/com_content/tmpl/category/default_articles.php
@@ -171,11 +171,11 @@ if (!empty($this->items))
 			<tbody>
 			<?php foreach ($this->items as $i => $article) : ?>
 				<?php if ($this->items[$i]->state == ContentComponent::CONDITION_UNPUBLISHED) : ?>
-					<tr class="system-unpublished cat-list-row<?php echo $i % 2; ?>">
+					<tr scope="row" class="system-unpublished cat-list-row<?php echo $i % 2; ?>">
 				<?php else : ?>
-					<tr class="cat-list-row<?php echo $i % 2; ?>" >
+					<tr scope="row" class="cat-list-row<?php echo $i % 2; ?>" >
 				<?php endif; ?>
-				<td headers="categorylist_header_title" class="list-title">
+				<td class="list-title">
 					<?php if (in_array($article->access, $this->user->getAuthorisedViewLevels())) : ?>
 						<a href="<?php echo Route::_(RouteHelper::getArticleRoute($article->slug, $article->catid, $article->language)); ?>">
 							<?php echo $this->escape($article->title); ?>
@@ -251,41 +251,53 @@ if (!empty($this->items))
 					</td>
 				<?php endif; ?>
 				<?php if ($this->params->get('list_show_author', 1)) : ?>
-					<td headers="categorylist_header_author" class="list-author">
+					<td class="list-author">
 						<?php if (!empty($article->author) || !empty($article->created_by_alias)) : ?>
 							<?php $author = $article->author ?>
 							<?php $author = $article->created_by_alias ?: $author; ?>
 							<?php if (!empty($article->contact_link) && $this->params->get('link_author') == true) : ?>
-								<?php echo Text::sprintf('COM_CONTENT_WRITTEN_BY', HTMLHelper::_('link', $article->contact_link, $author)); ?>
+								<?php if ($this->params->get('show_headings')) : ?>
+									<?php echo HTMLHelper::_('link', $article->contact_link, $author); ?>
+								<?php else : ?>
+									<?php echo Text::sprintf('COM_CONTENT_WRITTEN_BY', HTMLHelper::_('link', $article->contact_link, $author)); ?>
+								<?php endif; ?>
 							<?php else : ?>
-								<?php echo Text::sprintf('COM_CONTENT_WRITTEN_BY', $author); ?>
+								<?php if ($this->params->get('show_headings')) : ?>
+									<?php echo $author; ?>
+								<?php else : ?>
+									<?php echo Text::sprintf('COM_CONTENT_WRITTEN_BY', $author); ?>
+								<?php endif; ?>
 							<?php endif; ?>
 						<?php endif; ?>
 					</td>
 				<?php endif; ?>
 				<?php if ($this->params->get('list_show_hits', 1)) : ?>
-					<td headers="categorylist_header_hits" class="list-hits">
+					<td class="list-hits">
 						<span class="badge badge-info">
-							<?php echo Text::sprintf('JGLOBAL_HITS_COUNT', $article->hits); ?>
+							<?php if ($this->params->get('show_headings')) : ?>
+								<?php echo $article->hits; ?>
+							<?php else : ?>
+								<?php echo Text::sprintf('JGLOBAL_HITS_COUNT', $article->hits); ?>
+							<?php endif; ?>
 						</span>
 					</td>
 				<?php endif; ?>
 				<?php if ($this->params->get('list_show_votes', 0) && $this->vote) : ?>
-					<td headers="categorylist_header_votes" class="list-votes">
+					<td class="list-votes">
 						<span class="badge badge-success">
 							<?php echo Text::sprintf('COM_CONTENT_VOTES_COUNT', $article->rating_count); ?>
 						</span>
 					</td>
 				<?php endif; ?>
 				<?php if ($this->params->get('list_show_ratings', 0) && $this->vote) : ?>
-					<td headers="categorylist_header_ratings" class="list-ratings">
+					<td class="list-ratings">
 						<span class="badge badge-warning">
 							<?php echo Text::sprintf('COM_CONTENT_RATINGS_COUNT', $article->rating); ?>
 						</span>
 					</td>
 				<?php endif; ?>
 				<?php if ($isEditable) : ?>
-					<td headers="categorylist_header_edit" class="list-edit">
+					<td class="list-edit">
 						<?php if ($article->params->get('access-edit')) : ?>
 							<?php echo HTMLHelper::_('contenticon.edit', $article, $article->params); ?>
 						<?php endif; ?>

--- a/components/com_content/tmpl/category/default_articles.php
+++ b/components/com_content/tmpl/category/default_articles.php
@@ -175,7 +175,7 @@ if (!empty($this->items))
 				<?php else : ?>
 					<tr class="cat-list-row<?php echo $i % 2; ?>" >
 				<?php endif; ?>
-				<td class="list-title" scope="row">
+				<th class="list-title" scope="row">
 					<?php if (in_array($article->access, $this->user->getAuthorisedViewLevels())) : ?>
 						<a href="<?php echo Route::_(RouteHelper::getArticleRoute($article->slug, $article->catid, $article->language)); ?>">
 							<?php echo $this->escape($article->title); ?>
@@ -240,7 +240,7 @@ if (!empty($this->items))
 							</span>
 						</div>
 					<?php endif; ?>
-				</td>
+				</th>
 				<?php if ($this->params->get('list_show_date')) : ?>
 					<td headers="categorylist_header_date" class="list-date small">
 						<?php

--- a/components/com_content/tmpl/category/default_articles.php
+++ b/components/com_content/tmpl/category/default_articles.php
@@ -242,7 +242,7 @@ if (!empty($this->items))
 					<?php endif; ?>
 				</th>
 				<?php if ($this->params->get('list_show_date')) : ?>
-					<td headers="categorylist_header_date" class="list-date small">
+					<td class="list-date small">
 						<?php
 						echo HTMLHelper::_(
 							'date', $article->displayDate,

--- a/components/com_content/tmpl/category/default_articles.php
+++ b/components/com_content/tmpl/category/default_articles.php
@@ -171,11 +171,11 @@ if (!empty($this->items))
 			<tbody>
 			<?php foreach ($this->items as $i => $article) : ?>
 				<?php if ($this->items[$i]->state == ContentComponent::CONDITION_UNPUBLISHED) : ?>
-					<tr scope="row" class="system-unpublished cat-list-row<?php echo $i % 2; ?>">
+					<tr class="system-unpublished cat-list-row<?php echo $i % 2; ?>">
 				<?php else : ?>
-					<tr scope="row" class="cat-list-row<?php echo $i % 2; ?>" >
+					<tr class="cat-list-row<?php echo $i % 2; ?>" >
 				<?php endif; ?>
-				<td class="list-title">
+				<td class="list-title" scope="row">
 					<?php if (in_array($article->access, $this->user->getAuthorisedViewLevels())) : ?>
 						<a href="<?php echo Route::_(RouteHelper::getArticleRoute($article->slug, $article->catid, $article->language)); ?>">
 							<?php echo $this->escape($article->title); ?>

--- a/components/com_content/tmpl/category/default_articles.php
+++ b/components/com_content/tmpl/category/default_articles.php
@@ -285,14 +285,22 @@ if (!empty($this->items))
 				<?php if ($this->params->get('list_show_votes', 0) && $this->vote) : ?>
 					<td class="list-votes">
 						<span class="badge badge-success">
-							<?php echo Text::sprintf('COM_CONTENT_VOTES_COUNT', $article->rating_count); ?>
+							<?php if ($this->params->get('show_headings')) : ?>
+								<?php echo $article->rating_count; ?>
+							<?php else : ?>
+								<?php echo Text::sprintf('COM_CONTENT_VOTES_COUNT', $article->rating_count); ?>
+							<?php endif; ?>
 						</span>
 					</td>
 				<?php endif; ?>
 				<?php if ($this->params->get('list_show_ratings', 0) && $this->vote) : ?>
 					<td class="list-ratings">
 						<span class="badge badge-warning">
-							<?php echo Text::sprintf('COM_CONTENT_RATINGS_COUNT', $article->rating); ?>
+							<?php if ($this->params->get('show_headings')) : ?>
+								<?php echo $article->rating; ?>
+							<?php else : ?>
+								<?php echo Text::sprintf('COM_CONTENT_RATINGS_COUNT', $article->rating); ?>
+							<?php endif; ?>
 						</span>
 					</td>
 				<?php endif; ?>


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/31367

### Summary of Changes
Added scope row.
Taking off useless `headers="categorylist_header_WHATEVER"`
Display `Written by` and `Hits` in badge only when table headings are set to No in the list layout parameters.


### Testing Instructions
Create some articles in the same category.Create a category list menu item.
Switch `Table Headings` to yes and no
Load menu item in frontend.

### Actual result BEFORE applying this Pull Request
<img width="1197" alt="tableheadingsbefore" src="https://user-images.githubusercontent.com/869724/98644067-39cbec00-2330-11eb-9f45-814487e6e9a2.png">



### Expected result AFTER applying this Pull Request
<img width="1196" alt="tableheadings after" src="https://user-images.githubusercontent.com/869724/98644097-46e8db00-2330-11eb-8a3e-12529dec9693.png">


<img width="1197" alt="Screen Shot 2020-11-10 at 07 42 34" src="https://user-images.githubusercontent.com/869724/98644152-5a944180-2330-11eb-8248-49bf0aa911c6.png">


