### PR TITLE
[4.0][webservices] Allow customizing CORS headers and add support for OPTIONS method

### DIFF
--- a/administrator/components/com_config/forms/application.xml
+++ b/administrator/components/com_config/forms/application.xml
@@ -326,6 +326,32 @@
 			<option value="0">JNO</option>
 			<option value="1">JYES</option>
 		</field>
+
+		<field
+				name="cors_allow_origin"
+				type="text"
+				label="COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_ORIGIN_LABEL"
+				description="COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_ORIGIN_DESC"
+				default="*"
+				showon="cors:1"
+		/>
+
+		<field
+				name="cors_allow_headers"
+				type="text"
+				label="COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_HEADERS_LABEL"
+				description="COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_HEADERS_DESC"
+				default="Content-Type,X-Joomla-Token"
+				showon="cors:1"
+		/>
+
+		<field
+				name="cors_allow_methods"
+				type="text"
+				label="COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_METHODS_LABEL"
+				description="COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_METHODS_DESC"
+				showon="cors:1"
+		/>
 	</fieldset>
 
 	<fieldset name="ftp" label="CONFIG_FTP_SETTINGS_LABEL">

--- a/administrator/components/com_config/forms/application.xml
+++ b/administrator/components/com_config/forms/application.xml
@@ -328,29 +328,29 @@
 		</field>
 
 		<field
-				name="cors_allow_origin"
-				type="text"
-				label="COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_ORIGIN_LABEL"
-				description="COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_ORIGIN_DESC"
-				default="*"
-				showon="cors:1"
+			name="cors_allow_origin"
+			type="text"
+			label="COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_ORIGIN_LABEL"
+			description="COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_ORIGIN_DESC"
+			default="*"
+			showon="cors:1"
 		/>
 
 		<field
-				name="cors_allow_headers"
-				type="text"
-				label="COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_HEADERS_LABEL"
-				description="COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_HEADERS_DESC"
-				default="Content-Type,X-Joomla-Token"
-				showon="cors:1"
+			name="cors_allow_headers"
+			type="text"
+			label="COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_HEADERS_LABEL"
+			description="COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_HEADERS_DESC"
+			default="Content-Type,X-Joomla-Token"
+			showon="cors:1"
 		/>
 
 		<field
-				name="cors_allow_methods"
-				type="text"
-				label="COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_METHODS_LABEL"
-				description="COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_METHODS_DESC"
-				showon="cors:1"
+			name="cors_allow_methods"
+			type="text"
+			label="COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_METHODS_LABEL"
+			description="COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_METHODS_DESC"
+			showon="cors:1"
 		/>
 	</fieldset>
 

--- a/administrator/components/com_config/forms/application.xml
+++ b/administrator/components/com_config/forms/application.xml
@@ -326,32 +326,6 @@
 			<option value="0">JNO</option>
 			<option value="1">JYES</option>
 		</field>
-
-		<field
-				name="cors_allow_origin"
-				type="text"
-				label="COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_ORIGIN_LABEL"
-				description="COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_ORIGIN_DESC"
-				default="*"
-				showon="cors:1"
-		/>
-
-		<field
-				name="cors_allow_headers"
-				type="text"
-				label="COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_HEADERS_LABEL"
-				description="COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_HEADERS_DESC"
-				default="Content-Type,X-Joomla-Token"
-				showon="cors:1"
-		/>
-
-		<field
-				name="cors_allow_methods"
-				type="text"
-				label="COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_METHODS_LABEL"
-				description="COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_METHODS_DESC"
-				showon="cors:1"
-		/>
 	</fieldset>
 
 	<fieldset name="ftp" label="CONFIG_FTP_SETTINGS_LABEL">

--- a/administrator/components/com_config/forms/application.xml
+++ b/administrator/components/com_config/forms/application.xml
@@ -314,6 +314,20 @@
 
 	</fieldset>
 
+	<fieldset name="webservices" label="CONFIG_WEBSERVICES_SETTINGS_LABEL">
+		<field
+			name="cors"
+			type="radio"
+			label="COM_CONFIG_FIELD_WEBSERVICES_CORSOFFF_LABEL"
+			layout="joomla.form.field.radio.switcher"
+			default="0"
+			filter="boolean"
+			>
+			<option value="0">JNO</option>
+			<option value="1">JYES</option>
+		</field>
+	</fieldset>
+
 	<fieldset name="ftp" label="CONFIG_FTP_SETTINGS_LABEL">
 
 		<field

--- a/administrator/components/com_config/src/Model/ApplicationModel.php
+++ b/administrator/components/com_config/src/Model/ApplicationModel.php
@@ -713,11 +713,8 @@ class ApplicationModel extends FormModel
 		// Create the new configuration object.
 		$config = new Registry($data);
 
-		// Overwrite webservices cors settings
+		// Overwrite webservices cors setting
 		$app->set('cors', $data['cors']);
-		$app->set('cors_allow_origin', $data['cors_allow_origin']);
-		$app->set('cors_allow_headers', $data['cors_allow_headers']);
-		$app->set('cors_allow_methods', $data['cors_allow_methods']);
 
 		// Overwrite the old FTP credentials with the new ones.
 		$app->set('ftp_enable', $data['ftp_enable']);

--- a/administrator/components/com_config/src/Model/ApplicationModel.php
+++ b/administrator/components/com_config/src/Model/ApplicationModel.php
@@ -713,6 +713,9 @@ class ApplicationModel extends FormModel
 		// Create the new configuration object.
 		$config = new Registry($data);
 
+		// Overwrite webservices cors setting
+		$app->set('cors', $data['cors']);
+
 		// Overwrite the old FTP credentials with the new ones.
 		$app->set('ftp_enable', $data['ftp_enable']);
 		$app->set('ftp_host', $data['ftp_host']);

--- a/administrator/components/com_config/src/Model/ApplicationModel.php
+++ b/administrator/components/com_config/src/Model/ApplicationModel.php
@@ -713,8 +713,11 @@ class ApplicationModel extends FormModel
 		// Create the new configuration object.
 		$config = new Registry($data);
 
-		// Overwrite webservices cors setting
+		// Overwrite webservices cors settings
 		$app->set('cors', $data['cors']);
+		$app->set('cors_allow_origin', $data['cors_allow_origin']);
+		$app->set('cors_allow_headers', $data['cors_allow_headers']);
+		$app->set('cors_allow_methods', $data['cors_allow_methods']);
 
 		// Overwrite the old FTP credentials with the new ones.
 		$app->set('ftp_enable', $data['ftp_enable']);

--- a/administrator/components/com_config/tmpl/application/default.php
+++ b/administrator/components/com_config/tmpl/application/default.php
@@ -56,6 +56,7 @@ Text::script('MESSAGE');
 				<?php echo HTMLHelper::_('uitab.addTab', 'configTabs', 'page-server', Text::_('COM_CONFIG_SERVER')); ?>
 					<?php echo $this->loadTemplate('server'); ?>
 					<?php echo $this->loadTemplate('locale'); ?>
+					<?php echo $this->loadTemplate('webservices'); ?>
 					<?php echo $this->loadTemplate('ftp'); ?>
 					<?php echo $this->loadTemplate('proxy'); ?>
 					<?php echo $this->loadTemplate('database'); ?>

--- a/administrator/components/com_config/tmpl/application/default_webservices.php
+++ b/administrator/components/com_config/tmpl/application/default_webservices.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_config
+ *
+ * @copyright   Copyright (C) 2005 - 2020 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
+
+defined('_JEXEC') or die;
+
+$this->name = Text::_('COM_CONFIG_WEBSERVICES_SETTINGS');
+$this->fieldsname = 'webservices';
+$this->formclass = 'options-form';
+
+echo LayoutHelper::render('joomla.content.options_default', $this);

--- a/administrator/language/en-GB/com_config.ini
+++ b/administrator/language/en-GB/com_config.ini
@@ -225,3 +225,6 @@ COM_CONFIG_XML_DESCRIPTION="Configuration Manager"
 
 ; Alternate language strings for the rules form field
 JLIB_RULES_SETTING_NOTES_COM_CONFIG="If you change the setting, it will apply to this and all child groups, components and content. Note that:<br><em><strong>Inherited</strong></em> means that the permissions from the parent group will be used.<br><em><strong>Denied</strong></em> means that no matter what the parent group's setting is, the group being edited can't take this action.<br><em><strong>Allowed</strong></em> means that the group being edited will be able to take this action (but if this is in conflict with the parent group it will have no impact; a conflict will be indicated by <em><strong>Not Allowed (Locked)</strong></em> under Calculated Settings).<br><em><strong>Not Set</strong></em> is used only for the Public group in global configuration. The Public group is the parent of all other groups. If a permission is not set, it is treated as deny but can be changed for child groups, components, categories and items."
+
+COM_CONFIG_WEBSERVICES_SETTINGS="Webservices"
+COM_CONFIG_FIELD_WEBSERVICES_CORSOFFF_LABEL="Enable CORS"

--- a/administrator/language/en-GB/com_config.ini
+++ b/administrator/language/en-GB/com_config.ini
@@ -228,3 +228,9 @@ JLIB_RULES_SETTING_NOTES_COM_CONFIG="If you change the setting, it will apply to
 
 COM_CONFIG_WEBSERVICES_SETTINGS="Webservices"
 COM_CONFIG_FIELD_WEBSERVICES_CORSOFFF_LABEL="Enable CORS"
+COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_ORIGIN_LABEL="Access-Control-Allow-Origin"
+COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_ORIGIN_DESC="Specifies the origin allowed to access webservices on this site,sent back in response to a preflight request. Default: * (=all)."
+COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_HEADERS_LABEL="Access-Control-Allow-Headers"
+COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_HEADERS_DESC="Specifies the header(s) sent back in response to a preflight request. Default: Content-Type,X-Joomla-Token"
+COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_METHODS_LABEL="Access-Control-Allow-Methods"
+COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_METHODS_DESC="Specifies the webservice method(s) allowed to access on this site, sent back in response to a preflight request. Default: all methods available for the requested route."

--- a/administrator/language/en-GB/com_config.ini
+++ b/administrator/language/en-GB/com_config.ini
@@ -228,9 +228,3 @@ JLIB_RULES_SETTING_NOTES_COM_CONFIG="If you change the setting, it will apply to
 
 COM_CONFIG_WEBSERVICES_SETTINGS="Webservices"
 COM_CONFIG_FIELD_WEBSERVICES_CORSOFFF_LABEL="Enable CORS"
-COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_ORIGIN_LABEL="Access-Control-Allow-Origin"
-COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_ORIGIN_DESC="Specifies the origin allowed to access webservices on this site,sent back in response to a preflight request. Default: * (=all)."
-COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_HEADERS_LABEL="Access-Control-Allow-Headers"
-COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_HEADERS_DESC="Specifies the header(s) sent back in response to a preflight request. Default: Content-Type,X-Joomla-Token"
-COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_METHODS_LABEL="Access-Control-Allow-Methods"
-COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_METHODS_DESC="Specifies the webservice method(s) allowed to access on this site, sent back in response to a preflight request. Default: all methods available for the requested route."

--- a/libraries/src/Application/ApiApplication.php
+++ b/libraries/src/Application/ApiApplication.php
@@ -166,9 +166,11 @@ final class ApiApplication extends CMSApplication
 
 		if ($forceCORS)
 		{
-			// Enable CORS (Cross-origin resource sharing)
-			// Obtain allowed CORS origin from Global Settings.
-			// Set to * (=all) if not set.
+			/**
+			* Enable CORS (Cross-origin resource sharing)
+			* Obtain allowed CORS origin from Global Settings.
+			* Set to * (=all) if not set.
+			*/
 			$allowedOrigin = $this->get('cors_allow_origin', '*');
 			$this->setHeader('Access-Control-Allow-Origin', $allowedOrigin, true);
 			$this->setHeader('Access-Control-Allow-Headers', 'Authorization');
@@ -329,8 +331,10 @@ final class ApiApplication extends CMSApplication
 	 */
 	protected function handlePreflight($method, $router)
 	{
-		// If not an OPTIONS request or CORS is not enabled,
-		// there's nothing useful to do here.
+		/**
+		* If not an OPTIONS request or CORS is not enabled,
+		* there's nothing useful to do here.
+		*/
 		if ($method !== 'OPTIONS' || !(int) $this->get('cors'))
 		{
 			return;
@@ -346,16 +350,22 @@ final class ApiApplication extends CMSApplication
 			}, [])
 		);
 
-		// Obtain allowed CORS origin from Global Settings.
-		// Set to * (=all) if not set.
+		/**
+		* Obtain allowed CORS origin from Global Settings.
+		* Set to * (=all) if not set.
+		*/
 		$allowedOrigin = $this->get('cors_allow_origin', '*');
 
-		// Obtain allowed CORS headers from Global Settings.
-		// Set to sensible default if not set.
+		/**
+		* Obtain allowed CORS headers from Global Settings.
+		* Set to sensible default if not set.
+		*/
 		$allowedHeaders = $this->get('cors_allowed_headers', 'Content-Type,X-Joomla-Token');
 
-		// Obtain allowed CORS methods from Global Settings.
-		// Set to methods exposed by current route if not set.
+		/**
+		* Obtain allowed CORS methods from Global Settings.
+		* Set to methods exposed by current route if not set.
+		*/
 		$allowedMethods = $this->get('cors_allowed_headers', implode(',', $matchingRoutesMethods));
 
 		// No use to go through the regular route handling hassle,

--- a/libraries/src/Application/ApiApplication.php
+++ b/libraries/src/Application/ApiApplication.php
@@ -322,8 +322,9 @@ final class ApiApplication extends CMSApplication
 	/**
 	 * Handles preflight requests.
 	 *
-	 * @param $method
-	 * @param $router
+	 * @param   String     $method  The REST verb
+	 *
+	 * @param   ApiRouter  $router  The API Routing object
 	 *
 	 * @return  void
 	 *

--- a/libraries/src/Application/ApiApplication.php
+++ b/libraries/src/Application/ApiApplication.php
@@ -348,8 +348,8 @@ final class ApiApplication extends CMSApplication
 		$matchingRoutesMethods = array_unique(
 			array_reduce($matchingRoutes, function ($carry, $route) {
 					return array_merge($carry, $route->getMethods());
-				},
-				[]
+			},
+			[]
 			)
 		);
 

--- a/libraries/src/Application/ApiApplication.php
+++ b/libraries/src/Application/ApiApplication.php
@@ -161,12 +161,40 @@ final class ApiApplication extends CMSApplication
 	{
 		// Set the Joomla! API signature
 		$this->setHeader('X-Powered-By', 'JoomlaAPI/1.0', true);
+		
+		$forceCORS = (int) $this->get('cors');
 
-		if (\array_key_exists('cors', $options))
+		if ($forceCORS)
 		{
 			// Enable CORS (Cross-origin resource sharing)
-			$this->setHeader('Access-Control-Allow-Origin', '*', true);
+			$this->setHeader('Access-Control-Allow-Origin', $_SERVER['HTTP_ORIGIN'], true);
 			$this->setHeader('Access-Control-Allow-Headers', 'Authorization');
+
+			if (isset($_SERVER['HTTP_ORIGIN']))
+			{
+				// TO-DO filter allowed $_SERVER['HTTP_ORIGIN']
+				header("Access-Control-Allow-Origin: {$_SERVER['HTTP_ORIGIN']}");
+				header('Access-Control-Allow-Credentials: true');
+	
+			}
+	
+			// Access-Control headers are received during OPTIONS requests (pre-flight)
+			if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS')
+			{			
+	
+				if (isset($_SERVER['HTTP_ACCESS_CONTROL_REQUEST_METHOD']))
+				{
+	
+					header("Access-Control-Allow-Methods: GET, POST, PUT, DELETE, HEAD, OPTIONS, TRACE, PATCH");         
+				}
+	
+				if (isset($_SERVER['HTTP_ACCESS_CONTROL_REQUEST_HEADERS']))
+				{
+					header("Access-Control-Allow-Headers: {$_SERVER['HTTP_ACCESS_CONTROL_REQUEST_HEADERS']}");
+				}
+	
+				exit(0);
+			}
 		}
 
 		// Parent function can be overridden later on for debugging.

--- a/libraries/src/Application/ApiApplication.php
+++ b/libraries/src/Application/ApiApplication.php
@@ -169,7 +169,7 @@ final class ApiApplication extends CMSApplication
 			// Enable CORS (Cross-origin resource sharing)
 			// Obtain allowed CORS origin from Global Settings.
 			// Set to * (=all) if not set.
-			$allowedOrigin = $this->get('cors_allowed_origin', '*');
+			$allowedOrigin = $this->get('cors_allow_origin', '*');
 			$this->setHeader('Access-Control-Allow-Origin', $allowedOrigin, true);
 			$this->setHeader('Access-Control-Allow-Headers', 'Authorization');
 
@@ -348,7 +348,7 @@ final class ApiApplication extends CMSApplication
 
 		// Obtain allowed CORS origin from Global Settings.
 		// Set to * (=all) if not set.
-		$allowedOrigin = $this->get('cors_allowed_origin', '*');
+		$allowedOrigin = $this->get('cors_allow_origin', '*');
 
 		// Obtain allowed CORS headers from Global Settings.
 		// Set to sensible default if not set.

--- a/libraries/src/Application/ApiApplication.php
+++ b/libraries/src/Application/ApiApplication.php
@@ -178,11 +178,10 @@ final class ApiApplication extends CMSApplication
 
 			// Access-Control headers are received during OPTIONS requests (pre-flight)
 			if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS')
-			{			
+			{
 
 				if (isset($_SERVER['HTTP_ACCESS_CONTROL_REQUEST_METHOD']))
 				{
-
 					header("Access-Control-Allow-Methods: GET, POST, PUT, DELETE, HEAD, OPTIONS, TRACE, PATCH");         
 				}
 

--- a/libraries/src/Application/ApiApplication.php
+++ b/libraries/src/Application/ApiApplication.php
@@ -177,7 +177,6 @@ final class ApiApplication extends CMSApplication
 
 			if ($this->input->server->getString('HTTP_ORIGIN', null) !== null)
 			{
-				// TO-DO filter on $_SERVER['HTTP_ORIGIN']
 				$this->setHeader('Access-Control-Allow-Origin', $this->input->server->getString('HTTP_ORIGIN'), true);
 				$this->setHeader('Access-Control-Allow-Credentials', 'true', true);
 			}

--- a/libraries/src/Application/ApiApplication.php
+++ b/libraries/src/Application/ApiApplication.php
@@ -347,8 +347,10 @@ final class ApiApplication extends CMSApplication
 		// Extract exposed methods from matching routes.
 		$matchingRoutesMethods = array_unique(
 			array_reduce($matchingRoutes, function ($carry, $route) {
-				return array_merge($carry, $route->getMethods());
-			}, [])
+					return array_merge($carry, $route->getMethods());
+				},
+				[]
+			)
 		);
 
 		/**

--- a/libraries/src/Application/ApiApplication.php
+++ b/libraries/src/Application/ApiApplication.php
@@ -346,10 +346,11 @@ final class ApiApplication extends CMSApplication
 
 		// Extract exposed methods from matching routes.
 		$matchingRoutesMethods = array_unique(
-			array_reduce($matchingRoutes, function ($carry, $route) {
+			array_reduce($matchingRoutes,
+				function ($carry, $route) {
 					return array_merge($carry, $route->getMethods());
-			},
-			[]
+				},
+				[]
 			)
 		);
 

--- a/libraries/src/Application/ApiApplication.php
+++ b/libraries/src/Application/ApiApplication.php
@@ -175,11 +175,11 @@ final class ApiApplication extends CMSApplication
 			$this->setHeader('Access-Control-Allow-Origin', $allowedOrigin, true);
 			$this->setHeader('Access-Control-Allow-Headers', 'Authorization');
 
-			if (isset($_SERVER['HTTP_ORIGIN']))
+			if ($this->input->server->getString('HTTP_ORIGIN', null) !== null)
 			{
-				// TO-DO filter allowed $_SERVER['HTTP_ORIGIN']
-				header("Access-Control-Allow-Origin: {$_SERVER['HTTP_ORIGIN']}");
-				header('Access-Control-Allow-Credentials: true');
+				// TO-DO filter on $_SERVER['HTTP_ORIGIN']
+				$this->setHeader('Access-Control-Allow-Origin', $this->input->server->getString('HTTP_ORIGIN'), true);
+				$this->setHeader('Access-Control-Allow-Credentials', 'true', true);
 			}
 		}
 

--- a/libraries/src/Application/ApiApplication.php
+++ b/libraries/src/Application/ApiApplication.php
@@ -179,10 +179,9 @@ final class ApiApplication extends CMSApplication
 			// Access-Control headers are received during OPTIONS requests (pre-flight)
 			if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS')
 			{
-
 				if (isset($_SERVER['HTTP_ACCESS_CONTROL_REQUEST_METHOD']))
 				{
-					header("Access-Control-Allow-Methods: GET, POST, PUT, DELETE, HEAD, OPTIONS, TRACE, PATCH");         
+					header("Access-Control-Allow-Methods: GET, POST, PUT, DELETE, HEAD, OPTIONS, TRACE, PATCH");
 				}
 
 				if (isset($_SERVER['HTTP_ACCESS_CONTROL_REQUEST_HEADERS']))

--- a/libraries/src/Application/ApiApplication.php
+++ b/libraries/src/Application/ApiApplication.php
@@ -161,7 +161,6 @@ final class ApiApplication extends CMSApplication
 	{
 		// Set the Joomla! API signature
 		$this->setHeader('X-Powered-By', 'JoomlaAPI/1.0', true);
-		
 		$forceCORS = (int) $this->get('cors');
 
 		if ($forceCORS)
@@ -175,24 +174,23 @@ final class ApiApplication extends CMSApplication
 				// TO-DO filter allowed $_SERVER['HTTP_ORIGIN']
 				header("Access-Control-Allow-Origin: {$_SERVER['HTTP_ORIGIN']}");
 				header('Access-Control-Allow-Credentials: true');
-	
 			}
-	
+
 			// Access-Control headers are received during OPTIONS requests (pre-flight)
 			if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS')
 			{			
-	
+
 				if (isset($_SERVER['HTTP_ACCESS_CONTROL_REQUEST_METHOD']))
 				{
-	
+
 					header("Access-Control-Allow-Methods: GET, POST, PUT, DELETE, HEAD, OPTIONS, TRACE, PATCH");         
 				}
-	
+
 				if (isset($_SERVER['HTTP_ACCESS_CONTROL_REQUEST_HEADERS']))
 				{
 					header("Access-Control-Allow-Headers: {$_SERVER['HTTP_ACCESS_CONTROL_REQUEST_HEADERS']}");
 				}
-	
+
 				exit(0);
 			}
 		}

--- a/libraries/src/Application/ApiApplication.php
+++ b/libraries/src/Application/ApiApplication.php
@@ -161,12 +161,16 @@ final class ApiApplication extends CMSApplication
 	{
 		// Set the Joomla! API signature
 		$this->setHeader('X-Powered-By', 'JoomlaAPI/1.0', true);
+
 		$forceCORS = (int) $this->get('cors');
 
 		if ($forceCORS)
 		{
 			// Enable CORS (Cross-origin resource sharing)
-			$this->setHeader('Access-Control-Allow-Origin', $_SERVER['HTTP_ORIGIN'], true);
+			// Obtain allowed CORS origin from Global Settings.
+			// Set to * (=all) if not set.
+			$allowedOrigin = $this->get('cors_allowed_origin', '*');
+			$this->setHeader('Access-Control-Allow-Origin', $allowedOrigin, true);
 			$this->setHeader('Access-Control-Allow-Headers', 'Authorization');
 
 			if (isset($_SERVER['HTTP_ORIGIN']))
@@ -175,27 +179,10 @@ final class ApiApplication extends CMSApplication
 				header("Access-Control-Allow-Origin: {$_SERVER['HTTP_ORIGIN']}");
 				header('Access-Control-Allow-Credentials: true');
 			}
-
-			// Access-Control headers are received during OPTIONS requests (pre-flight)
-			if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS')
-			{
-				if (isset($_SERVER['HTTP_ACCESS_CONTROL_REQUEST_METHOD']))
-				{
-					header("Access-Control-Allow-Methods: GET, POST, PUT, DELETE, HEAD, OPTIONS, TRACE, PATCH");
-				}
-
-				if (isset($_SERVER['HTTP_ACCESS_CONTROL_REQUEST_HEADERS']))
-				{
-					header("Access-Control-Allow-Headers: {$_SERVER['HTTP_ACCESS_CONTROL_REQUEST_HEADERS']}");
-				}
-
-				exit(0);
-			}
 		}
 
 		// Parent function can be overridden later on for debugging.
 		parent::respond();
-
 	}
 
 	/**
@@ -212,11 +199,11 @@ final class ApiApplication extends CMSApplication
 		// The API application should not need to use a template
 		if ($params)
 		{
-			$template = new \stdClass;
-			$template->template = 'system';
-			$template->params = new Registry;
+			$template              = new \stdClass;
+			$template->template    = 'system';
+			$template->params      = new Registry;
 			$template->inheritable = 0;
-			$template->parent = '';
+			$template->parent      = '';
 
 			return $template;
 		}
@@ -244,10 +231,13 @@ final class ApiApplication extends CMSApplication
 		PluginHelper::importPlugin('webservices');
 		$this->triggerEvent('onBeforeApiRoute', array(&$router, $this));
 		$caught404 = false;
+		$method    = $this->input->getMethod();
 
 		try
 		{
-			$route = $router->parseApiRoute($this->input->getMethod());
+			$this->handlePreflight($method, $router);
+
+			$route = $router->parseApiRoute($method);
 		}
 		catch (RouteNotFoundException $e)
 		{
@@ -325,6 +315,58 @@ final class ApiApplication extends CMSApplication
 				throw new AuthenticationFailed;
 			}
 		}
+	}
+
+	/**
+	 * Handles preflight requests.
+	 *
+	 * @param $method
+	 * @param $router
+	 *
+	 * @return  void
+	 *
+	 * @since   4.0.0
+	 */
+	protected function handlePreflight($method, $router)
+	{
+		// If not an OPTIONS request or CORS is not enabled,
+		// there's nothing useful to do here.
+		if ($method !== 'OPTIONS' || !(int) $this->get('cors'))
+		{
+			return;
+		}
+
+		// Extract routes matching current route from all known routes.
+		$matchingRoutes = $router->getMatchingRoutes();
+
+		// Extract exposed methods from matching routes.
+		$matchingRoutesMethods = array_unique(
+			array_reduce($matchingRoutes, function ($carry, $route) {
+				return array_merge($carry, $route->getMethods());
+			}, [])
+		);
+
+		// Obtain allowed CORS origin from Global Settings.
+		// Set to * (=all) if not set.
+		$allowedOrigin = $this->get('cors_allowed_origin', '*');
+
+		// Obtain allowed CORS headers from Global Settings.
+		// Set to sensible default if not set.
+		$allowedHeaders = $this->get('cors_allowed_headers', 'Content-Type,X-Joomla-Token');
+
+		// Obtain allowed CORS methods from Global Settings.
+		// Set to methods exposed by current route if not set.
+		$allowedMethods = $this->get('cors_allowed_headers', implode(',', $matchingRoutesMethods));
+
+		// No use to go through the regular route handling hassle,
+		// so let's simply output the headers and exit.
+		$this->setHeader('status', '204');
+		$this->setHeader('Access-Control-Allow-Origin', $allowedOrigin);
+		$this->setHeader('Access-Control-Allow-Headers', $allowedHeaders);
+		$this->setHeader('Access-Control-Allow-Methods', $allowedMethods);
+		$this->sendHeaders();
+
+		$this->close();
 	}
 
 	/**

--- a/libraries/src/Router/ApiRouter.php
+++ b/libraries/src/Router/ApiRouter.php
@@ -87,7 +87,7 @@ class ApiRouter extends Router
 	{
 		$method = strtoupper($method);
 
-		$validMethods = ["GET", "POST", "PUT", "DELETE", "HEAD", "TRACE", "PATCH"];
+		$validMethods = ["GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS", "TRACE", "PATCH"];
 
 		if (!\in_array($method, $validMethods))
 		{
@@ -95,51 +95,7 @@ class ApiRouter extends Router
 		}
 
 		// Get the path from the route and remove and leading or trailing slash.
-		$routePath = $this->getRoutePath();
-
-		$query = Uri::getInstance()->getQuery(true);
-
-		// Iterate through all of the known routes looking for a match.
-		foreach ($this->routes as $route)
-		{
-			if (\in_array($method, $route->getMethods()))
-			{
-				if (preg_match($route->getRegex(), ltrim($routePath, '/'), $matches))
-				{
-					// If we have gotten this far then we have a positive match.
-					$vars = $route->getDefaults();
-
-					foreach ($route->getRouteVariables() as $i => $var)
-					{
-						$vars[$var] = $matches[$i + 1];
-					}
-
-					$controller = preg_split("/[.]+/", $route->getController());
-					$vars       = array_merge($vars, $query);
-
-					return [
-						'controller' => $controller[0],
-						'task'       => $controller[1],
-						'vars'       => $vars
-					];
-				}
-			}
-		}
-
-		throw new RouteNotFoundException(sprintf('Unable to handle request for route `%s`.', $path));
-	}
-
-	/**
-	 * Get the path from the route and remove and leading or trailing slash.
-	 *
-	 * @return string
-	 *
-	 * @since 4.0.0
-	 */
-	public function getRoutePath()
-	{
-		// Get the path from the route and remove and leading or trailing slash.
-		$uri  = Uri::getInstance();
+		$uri = Uri::getInstance();
 		$path = urldecode($uri->getPath());
 
 		/**
@@ -162,7 +118,36 @@ class ApiRouter extends Router
 		// Transform the route
 		$path = $this->removeIndexPhpFromPath($path);
 
-		return $path;
+		$query = Uri::getInstance()->getQuery(true);
+
+		// Iterate through all of the known routes looking for a match.
+		foreach ($this->routes as $route)
+		{
+			if (\in_array($method, $route->getMethods()))
+			{
+				if (preg_match($route->getRegex(), ltrim($path, '/'), $matches))
+				{
+					// If we have gotten this far then we have a positive match.
+					$vars = $route->getDefaults();
+
+					foreach ($route->getRouteVariables() as $i => $var)
+					{
+						$vars[$var] = $matches[$i + 1];
+					}
+
+					$controller = preg_split("/[.]+/", $route->getController());
+					$vars       = array_merge($vars, $query);
+
+					return [
+						'controller' => $controller[0],
+						'task'       => $controller[1],
+						'vars'       => $vars
+					];
+				}
+			}
+		}
+
+		throw new RouteNotFoundException(sprintf('Unable to handle request for route `%s`.', $path));
 	}
 
 	/**
@@ -193,22 +178,5 @@ class ApiRouter extends Router
 
 		// Remove the "index.php/" part of the route and return the result.
 		return substr($path, 10);
-	}
-
-	/**
-	 * Extract routes matching current route from all known routes.
-	 *
-	 * @return \Joomla\Router\Route[]
-	 *
-	 * @since 4.0.0
-	 */
-	public function getMatchingRoutes()
-	{
-		$routePath = $this->getRoutePath();
-
-		// Extract routes matching $routePath from all known routes.
-		return array_filter($this->routes, function ($route) use ($routePath) {
-			return preg_match($route->getRegex(), ltrim($routePath, '/'), $matches) === 1;
-		});
 	}
 }

--- a/libraries/src/Router/ApiRouter.php
+++ b/libraries/src/Router/ApiRouter.php
@@ -168,7 +168,7 @@ class ApiRouter extends Router
 	/**
 	 * Removes the index.php from the route's path.
 	 *
-	 * @param   string  $path
+	 * @param   string  $path  The path
 	 *
 	 * @return  string
 	 *
@@ -207,8 +207,10 @@ class ApiRouter extends Router
 		$routePath = $this->getRoutePath();
 
 		// Extract routes matching $routePath from all known routes.
-		return array_filter($this->routes, function ($route) use ($routePath) {
-			return preg_match($route->getRegex(), ltrim($routePath, '/'), $matches) === 1;
-		});
+		return array_filter($this->routes,
+			function ($route) use ($routePath) {
+				return preg_match($route->getRegex(), ltrim($routePath, '/'), $matches) === 1;
+			}
+		);
 	}
 }

--- a/libraries/src/Router/ApiRouter.php
+++ b/libraries/src/Router/ApiRouter.php
@@ -87,7 +87,7 @@ class ApiRouter extends Router
 	{
 		$method = strtoupper($method);
 
-		$validMethods = ["GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS", "TRACE", "PATCH"];
+		$validMethods = ["GET", "POST", "PUT", "DELETE", "HEAD", "TRACE", "PATCH"];
 
 		if (!\in_array($method, $validMethods))
 		{
@@ -95,28 +95,7 @@ class ApiRouter extends Router
 		}
 
 		// Get the path from the route and remove and leading or trailing slash.
-		$uri = Uri::getInstance();
-		$path = urldecode($uri->getPath());
-
-		/**
-		 * In some environments (e.g. CLI we can't form a valid base URL). In this case we catch the exception thrown
-		 * by URI and set an empty base URI for further work.
-		 * TODO: This should probably be handled better
-		 */
-		try
-		{
-			$baseUri = Uri::base(true);
-		}
-		catch (\RuntimeException $e)
-		{
-			$baseUri = '';
-		}
-
-		// Remove the base URI path.
-		$path = substr_replace($path, '', 0, \strlen($baseUri));
-
-		// Transform the route
-		$path = $this->removeIndexPhpFromPath($path);
+		$routePath = $this->getRoutePath();
 
 		$query = Uri::getInstance()->getQuery(true);
 
@@ -125,7 +104,7 @@ class ApiRouter extends Router
 		{
 			if (\in_array($method, $route->getMethods()))
 			{
-				if (preg_match($route->getRegex(), ltrim($path, '/'), $matches))
+				if (preg_match($route->getRegex(), ltrim($routePath, '/'), $matches))
 				{
 					// If we have gotten this far then we have a positive match.
 					$vars = $route->getDefaults();
@@ -148,6 +127,42 @@ class ApiRouter extends Router
 		}
 
 		throw new RouteNotFoundException(sprintf('Unable to handle request for route `%s`.', $path));
+	}
+
+	/**
+	 * Get the path from the route and remove and leading or trailing slash.
+	 *
+	 * @return string
+	 *
+	 * @since 4.0.0
+	 */
+	public function getRoutePath()
+	{
+		// Get the path from the route and remove and leading or trailing slash.
+		$uri  = Uri::getInstance();
+		$path = urldecode($uri->getPath());
+
+		/**
+		 * In some environments (e.g. CLI we can't form a valid base URL). In this case we catch the exception thrown
+		 * by URI and set an empty base URI for further work.
+		 * TODO: This should probably be handled better
+		 */
+		try
+		{
+			$baseUri = Uri::base(true);
+		}
+		catch (\RuntimeException $e)
+		{
+			$baseUri = '';
+		}
+
+		// Remove the base URI path.
+		$path = substr_replace($path, '', 0, \strlen($baseUri));
+
+		// Transform the route
+		$path = $this->removeIndexPhpFromPath($path);
+
+		return $path;
 	}
 
 	/**
@@ -178,5 +193,22 @@ class ApiRouter extends Router
 
 		// Remove the "index.php/" part of the route and return the result.
 		return substr($path, 10);
+	}
+
+	/**
+	 * Extract routes matching current route from all known routes.
+	 *
+	 * @return \Joomla\Router\Route[]
+	 *
+	 * @since 4.0.0
+	 */
+	public function getMatchingRoutes()
+	{
+		$routePath = $this->getRoutePath();
+
+		// Extract routes matching $routePath from all known routes.
+		return array_filter($this->routes, function ($route) use ($routePath) {
+			return preg_match($route->getRegex(), ltrim($routePath, '/'), $matches) === 1;
+		});
 	}
 }


### PR DESCRIPTION
Pull Request for Issue #31325

### Summary of Changes
a 1st step to allow cors requests

- Added global config settings for `Access-Control-Allow-Origin`, `Access-Control-Allow-Headers` and `Access-Control-Allow-Methods`.
- Added preflight handler method to `Joomla\CMS\Application\ApiApplication`.
- Made some changes to  `Joomla\CMS\Application\ApiApplication` and `Joomla\CMS\Router\Router` needed for implementation of  the preflight handler.
- Removed obsolete code from the  `Joomla\CMS\Application\ApiApplication` respond method.


### Testing Instructions 
from https://github.com/joomla/joomla-cms/issues/31325

Assuming site A is a Joomla! 4 site and site B is another site, in a domain other than site A, wanting to consume webservices of site A 


-  On site A create an API token for a Joomla! user that has adequate permissions to access the webservices.
-  On site B copy the below <script> into file administrator/components/com_content/views/articles/tmpl/default.php after line 55 

if it's J3 or in file administrator/components/com_content/tmpl/articles/default.php after line 93 if it's J4.


```php
<script type="application/javascript">
    var myHeaders = new Headers();
    myHeaders.append("X-Joomla-Token", "YOUR TOKEN");

    var requestOptions = {
        method: 'GET',
        headers: myHeaders,
        redirect: 'follow'
    };

    fetch("http:/DOMAIN OF SITE A/api/index.php/v1/content/article", requestOptions)
        .then(response => response.text())
        .then(result => console.log(result))
        .catch(error => console.log('error', error));
</script>
```

- Replace DOMAIN OF SITE A in the script with the domain of site A.
- Replace YOUR TOKEN in the script with the API token created in the first step.
- Open the browser developer console, navigate to the content articles page and notice the errors.



### Actual result BEFORE applying this Pull Request
A 404 for the preflight OPTIONS request and a Cross-Origin request blocked error for the GET request.
![image](https://user-images.githubusercontent.com/181681/98782134-be357200-23f7-11eb-873b-f75d244173d1.png)


### Expected result AFTER applying this Pull Request

- apply the pr
- Enable CORS

![image](https://user-images.githubusercontent.com/181681/99378305-9185cc80-28c7-11eb-8b5d-c8c96265bc48.png)


- A valid 200 response for both the preflight OPTIONS request and the subsequent GET request
![image](https://user-images.githubusercontent.com/181681/98781940-7282c880-23f7-11eb-9be1-7cdc6981678b.png)


### Documentation Changes Required
?
