### PR TITLE
Debug plugin freezes page with lots of DB queries

### DIFF
--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -1330,8 +1330,7 @@ class PlgSystemDebug extends JPlugin
 
 			if (isset($bar->tip) && $bar->tip)
 			{
-				$barClass .= ' hasTooltip';
-				$tip      = JHtml::_('tooltipText', $bar->tip, '', 0);
+				$tip = JHtml::_('tooltipText', $bar->tip, '', 0);
 			}
 
 			$html[] = '<a class="bar dbg-bar ' . $barClass . '" title="' . $tip . '" style="width: '
@@ -1537,7 +1536,7 @@ class PlgSystemDebug extends JPlugin
 
 				if ($dbVersion80)
 				{
-					$dbVersion56 = false; 
+					$dbVersion56 = false;
 				}
 
 				if ((stripos($query, 'select') === 0) || ($dbVersion56 && ((stripos($query, 'delete') === 0) || (stripos($query, 'update') === 0))))

--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -1834,9 +1834,9 @@ class PlgSystemDebug extends JPlugin
 		$logEntriesDeprecated = count(
 			array_filter(
 				$this->logEntries, function ($logEntry)
-			{
-				return $logEntry->category === 'deprecated';
-			}
+				{
+					return $logEntry->category === 'deprecated';
+				}
 			)
 		);
 		$showDeprecated       = $this->params->get('log-deprecated', 0);

--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -1326,7 +1326,7 @@ class PlgSystemDebug extends JPlugin
 				$barClass .= ' dbg-bar-active';
 			}
 
-			$tip = empty($bar->tip) ? '' : ' title="' . htmlspecialchars($bar->tip, ENT_COMPAT, 'UTF-8'). '"';
+			$tip = empty($bar->tip) ? '' : ' title="' . htmlspecialchars($bar->tip, ENT_COMPAT, 'UTF-8') . '"';
 
 			$html[] = '<a class="bar dbg-bar ' . $barClass . '"' . $tip . ' style="width: '
 				. $bar->width . '%;" href="#dbg-' . $class . '-' . ($i + 1) . '"></a>';

--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -1175,7 +1175,7 @@ class PlgSystemDebug extends JPlugin
 					}
 
 					$htmlQuery = '<div class="alert alert-error">' . JText::_('PLG_DEBUG_QUERY_DUPLICATES') . ': ' . implode('&nbsp; ', $dups) . '</div>'
-						. '<pre class="alert hasTooltip" title="' . JHtml::_('tooltipText', 'PLG_DEBUG_QUERY_DUPLICATES_FOUND') . '">' . $text . '</pre>';
+						. '<pre class="alert" title="' . htmlspecialchars(JText::_('PLG_DEBUG_QUERY_DUPLICATES_FOUND'), ENT_COMPAT, 'UTF-8') . '">' . $text . '</pre>';
 				}
 				else
 				{
@@ -1418,8 +1418,8 @@ class PlgSystemDebug extends JPlugin
 					if ($td === 'NULL')
 					{
 						// Displays query parts which don't use a key with warning:
-						$html[]      = '<td><strong>' . '<span class="dbg-warning hasTooltip" title="'
-							. JHtml::_('tooltipText', 'PLG_DEBUG_WARNING_NO_INDEX_DESC') . '">'
+						$html[]      = '<td><strong>' . '<span class="dbg-warning" title="'
+							. htmlspecialchars(JText::_('PLG_DEBUG_WARNING_NO_INDEX_DESC'), ENT_COMPAT, 'UTF-8') . '">'
 							. JText::_('PLG_DEBUG_WARNING_NO_INDEX') . '</span>' . '</strong>';
 						$hasWarnings = true;
 					}
@@ -1438,8 +1438,8 @@ class PlgSystemDebug extends JPlugin
 					// Displays warnings for "Using filesort":
 					$htmlTdWithWarnings = str_replace(
 						'Using&nbsp;filesort',
-						'<span class="dbg-warning hasTooltip" title="'
-						. JHtml::_('tooltipText', 'PLG_DEBUG_WARNING_USING_FILESORT_DESC') . '">'
+						'<span class="dbg-warning" title="'
+						. htmlspecialchars(JText::_('PLG_DEBUG_WARNING_USING_FILESORT_DESC'), ENT_COMPAT, 'UTF-8') . '">' . '">'
 						. JText::_('PLG_DEBUG_WARNING_USING_FILESORT') . '</span>',
 						$htmlTd
 					);

--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -949,7 +949,7 @@ class PlgSystemDebug extends JPlugin
 					'class' => $barClass,
 					'width' => $barWidth,
 					'pre'   => $barPre,
-					'tip'   => sprintf('%.2f&nbsp;ms', $queryTime),
+					'tip'   => sprintf('%.2f ms', $queryTime),
 				);
 				$info[$id] = (object) array(
 					'class'       => $labelClass,
@@ -1326,14 +1326,9 @@ class PlgSystemDebug extends JPlugin
 				$barClass .= ' dbg-bar-active';
 			}
 
-			$tip = '';
+			$tip = empty($bar->tip) ? '' : ' title="' . htmlspecialchars($bar->tip, ENT_COMPAT, 'UTF-8'). '"';
 
-			if (isset($bar->tip) && $bar->tip)
-			{
-				$tip = JHtml::_('tooltipText', $bar->tip, '', 0);
-			}
-
-			$html[] = '<a class="bar dbg-bar ' . $barClass . '" title="' . $tip . '" style="width: '
+			$html[] = '<a class="bar dbg-bar ' . $barClass . '"' . $tip . ' style="width: '
 				. $bar->width . '%;" href="#dbg-' . $class . '-' . ($i + 1) . '"></a>';
 		}
 
@@ -1827,9 +1822,9 @@ class PlgSystemDebug extends JPlugin
 			$logEntriesDatabasequery = count(
 				array_filter(
 					$this->logEntries, function ($logEntry)
-					{
-						return $logEntry->category === 'databasequery';
-					}
+				{
+					return $logEntry->category === 'databasequery';
+				}
 				)
 			);
 			$logEntriesTotal         -= $logEntriesDatabasequery;
@@ -1839,9 +1834,9 @@ class PlgSystemDebug extends JPlugin
 		$logEntriesDeprecated = count(
 			array_filter(
 				$this->logEntries, function ($logEntry)
-				{
-					return $logEntry->category === 'deprecated';
-				}
+			{
+				return $logEntry->category === 'deprecated';
+			}
 			)
 		);
 		$showDeprecated       = $this->params->get('log-deprecated', 0);

--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -1439,7 +1439,7 @@ class PlgSystemDebug extends JPlugin
 					$htmlTdWithWarnings = str_replace(
 						'Using&nbsp;filesort',
 						'<span class="dbg-warning" title="'
-						. htmlspecialchars(JText::_('PLG_DEBUG_WARNING_USING_FILESORT_DESC'), ENT_COMPAT, 'UTF-8') . '">' . '">'
+						. htmlspecialchars(JText::_('PLG_DEBUG_WARNING_USING_FILESORT_DESC'), ENT_COMPAT, 'UTF-8') . '">'
 						. JText::_('PLG_DEBUG_WARNING_USING_FILESORT') . '</span>',
 						$htmlTd
 					);

--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -1822,9 +1822,9 @@ class PlgSystemDebug extends JPlugin
 			$logEntriesDatabasequery = count(
 				array_filter(
 					$this->logEntries, function ($logEntry)
-				{
-					return $logEntry->category === 'databasequery';
-				}
+					{
+						return $logEntry->category === 'databasequery';
+					}
 				)
 			);
 			$logEntriesTotal         -= $logEntriesDatabasequery;


### PR DESCRIPTION
# Summary of Changes

Debug plugin freezes page with lots of DB queries due to the enormous number of tooltips is being initialized in query bars.

We can afford to have the usual title attribute.

### Testing Instructions

Enable debug, load page with lots of queries, i.e. >100 (there are tons of purely-coded Joomla extensions which produce such amount of queries, i.e. SobiPro etc.)

### Actual result BEFORE applying this Pull Request

The page is frozen in the browser for a long time. The tooltips are being initialized and JS execution takes ages.

### Expected result AFTER applying this Pull Request

The JS execution is much faster.

### Documentation Changes Required

No.