### PR TITLE
[4.0] Articles List Layout vote/ratings fields xml should not be switchers

### DIFF
--- a/administrator/components/com_content/config.xml
+++ b/administrator/components/com_content/config.xml
@@ -222,7 +222,7 @@
 
 		<field
 			name="show_vote"
-			type="radio"
+			type="voteradio"
 			label="JGLOBAL_SHOW_VOTE_LABEL"
 			layout="joomla.form.field.radio.switcher"
 			default="0"

--- a/administrator/components/com_content/src/Field/VotelistField.php
+++ b/administrator/components/com_content/src/Field/VotelistField.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_content
+ *
+ * @copyright   Copyright (C) 2005 - 2020 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\Component\Content\Administrator\Field;
+
+\defined('_JEXEC') or die;
+
+use Joomla\CMS\Form\Field\ListField;
+use Joomla\CMS\Plugin\PluginHelper;
+
+/**
+ * Voteradio Field class.
+ *
+ * @since  3.8.0
+ */
+class VotelistField extends ListField
+{
+	/**
+	 * The form field type.
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $type = 'Votelist';
+
+	/**
+	 * Method to attach a form object to the field.
+	 *
+	 * @param   \SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
+	 * @param   mixed              $value    The form field value to validate.
+	 * @param   string             $group    The field name group control value. This acts as as an array container for the field.
+	 *                                       For example if the field has name="foo" and the group value is set to "bar" then the
+	 *                                       full field name would end up being "bar[foo]".
+	 *
+	 * @return  boolean  True on success.
+	 *
+	 * @since  4.0.0
+	 */
+	public function setup(\SimpleXMLElement $element, $value, $group = null)
+	{
+		// Requires vote plugin enabled
+		if (!PluginHelper::isEnabled('content', 'vote'))
+		{
+			return false;
+		}
+
+		return parent::setup($element, $value, $group);
+	}
+}

--- a/administrator/components/com_content/src/Field/VotelistField.php
+++ b/administrator/components/com_content/src/Field/VotelistField.php
@@ -15,7 +15,7 @@ use Joomla\CMS\Form\Field\ListField;
 use Joomla\CMS\Plugin\PluginHelper;
 
 /**
- * Voteradio Field class.
+ * Votelist Field class.
  *
  * @since  __DEPLOY_VERSION__
  */

--- a/administrator/components/com_content/src/Field/VotelistField.php
+++ b/administrator/components/com_content/src/Field/VotelistField.php
@@ -17,7 +17,7 @@ use Joomla\CMS\Plugin\PluginHelper;
 /**
  * Voteradio Field class.
  *
- * @since  3.8.0
+ * @since  __DEPLOY_VERSION__
  */
 class VotelistField extends ListField
 {
@@ -40,7 +40,7 @@ class VotelistField extends ListField
 	 *
 	 * @return  boolean  True on success.
 	 *
-	 * @since  4.0.0
+	 * @since  __DEPLOY_VERSION__
 	 */
 	public function setup(\SimpleXMLElement $element, $value, $group = null)
 	{

--- a/components/com_content/tmpl/category/default.xml
+++ b/components/com_content/tmpl/category/default.xml
@@ -263,8 +263,8 @@
 				name="list_show_votes"
 				type="list"
 				label="JGLOBAL_LIST_VOTES_LABEL"
-				layout="joomla.form.field.radio.switcher"
 				useglobal="true"
+				class="custom-select-color-state"
 				validate="options"
 				>
 				<option value="0" requires="vote">JHIDE</option>
@@ -275,8 +275,8 @@
 				name="list_show_ratings"
 				type="list"
 				label="JGLOBAL_LIST_RATINGS_LABEL"
-				layout="joomla.form.field.radio.switcher"
 				useglobal="true"
+				class="custom-select-color-state"
 				validate="options"
 				>
 				<option value="0" requires="vote">JHIDE</option>

--- a/components/com_content/tmpl/category/default.xml
+++ b/components/com_content/tmpl/category/default.xml
@@ -173,7 +173,9 @@
 
 		</fieldset>
 
-		<fieldset name="advanced" label="JGLOBAL_LIST_LAYOUT_OPTIONS">
+		<fieldset name="advanced" label="JGLOBAL_LIST_LAYOUT_OPTIONS"
+			addfieldprefix="Joomla\Component\Content\Administrator\Field"
+		>
 			<field
 				name="show_pagination_limit"
 				type="list"
@@ -261,7 +263,7 @@
 
 			<field
 				name="list_show_votes"
-				type="list"
+				type="votelist"
 				label="JGLOBAL_LIST_VOTES_LABEL"
 				useglobal="true"
 				class="custom-select-color-state"
@@ -273,7 +275,7 @@
 
 			<field
 				name="list_show_ratings"
-				type="list"
+				type="votelist"
 				label="JGLOBAL_LIST_RATINGS_LABEL"
 				useglobal="true"
 				class="custom-select-color-state"


### PR DESCRIPTION
### Summary of Changes
Vote and ratings fields are list and not switchers. Switchers there are not only displayed wrong but they do not allow to select Use Global settings.

EDIT: This PR also prevents the fields from being displayed when the vote plugin is disabled.


### Testing Instructions
Create an articles category list menu item.
Display `List Layouts` tab.

Look at the Vote and Ratings fields

EDIT: Switch the vote plugin ON and OFF


### Actual result BEFORE applying this Pull Request

<img width="1018" alt="Screen Shot 2020-11-11 at 07 21 25" src="https://user-images.githubusercontent.com/869724/98776423-2df32f00-23ef-11eb-9d23-1361c667cff4.png">


### Expected result AFTER applying this Pull Request
<img width="1014" alt="Screen Shot 2020-11-11 at 07 17 26" src="https://user-images.githubusercontent.com/869724/98776445-38152d80-23ef-11eb-8260-b6f924bc98eb.png">

EDIT: See also https://github.com/joomla/joomla-cms/pull/31381#issuecomment-725905232



### Documentation Changes Required

