### PR TITLE
[4.0] Fixed titles for 3rd party component dashboards

### DIFF
--- a/administrator/components/com_cpanel/src/View/Cpanel/HtmlView.php
+++ b/administrator/components/com_cpanel/src/View/Cpanel/HtmlView.php
@@ -56,7 +56,7 @@ class HtmlView extends BaseHtmlView
 	public function display($tpl = null)
 	{
 		$app = Factory::getApplication();
-		$extension = ApplicationHelper::stringURLSafe($app->input->getCmd('dashboard'));
+		$extension = $app->input->getCmd('dashboard');
 
 		$title = Text::_('COM_CPANEL_DASHBOARD_BASE_TITLE');
 		$icon  = 'icon-home';


### PR DESCRIPTION
### Summary of Changes
In version 4, extensions can create their own dashboards. While this is a really cool feature, it seems to be mostly undocumented, so I had to do a bit of research on how to use this, by reading PRs like #28027, #27773 and similar.
The code for `com_cpanel` contains parts to define the title and icon used for the dashboard. However, these don't seem to work. There is a test that checks if the `$extension` string starts with `com_`. But previous filtering converts `com_something` into `com-something`.

### Testing Instructions
1. Install a component that uses an own dashboard. For this purpose, I created https://github.com/Harmageddon/com_demoj4 which you can use.
  If you develop your own extension, this is the perfect occasion to test dashboards. ;-)
2. In backend, click on the dashboard icon next to the component's menu item.
3. Look at the title on top of the page.


### Actual result BEFORE applying this Pull Request
There is no icon and the title says "Home Dashboard".


### Expected result AFTER applying this Pull Request
An icon is shown and the title says "DemoJ4 Dashboard" (or what you have specified as `COM_<YOUR COMPONENT>_DASHBOARD_TITLE`.

### Documentation Changes Required
The whole feature lacks documentation. I'm not even sure if it is correct to name the dashboard `com_demoj4` for a component with the name `com_demoj4` or it should be just `demoj4`.

Pinging @Bakual as I saw you used the dashboard already for your extension. Of course, it would be great to have other extension developers here as well who might be already using this feature as well.
