### PR TITLE
[4.x] Tinmyce image decorative [a11y]

### DIFF
--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -592,17 +592,20 @@ class PlgEditorTinymce extends CMSPlugin
 				'document_base_url'  => Uri::root(true) . '/',
 				'paste_data_images'  => $allowImgPaste,
 				'importcss_append'   => true,
-				'image_title'        => true,
 				'height'             => $html_height,
 				'width'              => $html_width,
 				'elementpath'        => (bool) $levelParams->get('element_path', true),
 				'resize'             => $resizing,
 				'templates'          => $templates,
-				'image_advtab'       => (bool) $levelParams->get('image_advtab', false),
 				'external_plugins'   => empty($externalPlugins) ? null  : $externalPlugins,
 				'contextmenu'        => (bool) $levelParams->get('contextmenu', true) ? null : false,
 				'toolbar_sticky'     => true,
 				'toolbar_mode'       => 'sliding',
+
+				// Image plugin options
+				'a11y_advanced_options' => true,
+				'image_advtab'       => (bool) $levelParams->get('image_advtab', false),
+				'image_title'        => true,
 
 				// Drag and drop specific
 				'dndEnabled' => $dragdrop,

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -604,8 +604,8 @@ class PlgEditorTinymce extends CMSPlugin
 
 				// Image plugin options
 				'a11y_advanced_options' => true,
-				'image_advtab'       => (bool) $levelParams->get('image_advtab', false),
-				'image_title'        => true,
+				'image_advtab'          => (bool) $levelParams->get('image_advtab', false),
+				'image_title'           => true,
 
 				// Drag and drop specific
 				'dndEnabled' => $dragdrop,


### PR DESCRIPTION
This PR enables the native tinymce feature to mark an image as decorative. This continues the work started in #31318 and #31323


### Background
To read why this change is very important see #31318 

### Testing Part 1
Testing is really easy. No npm, js or css involved.
Merge the pull request and then use the tinmyce image button to add an image
![image](https://user-images.githubusercontent.com/1296369/98956105-8dd4fd00-24f7-11eb-87ce-797a788e3039.png)

The **new** options is highlighted here
![image](https://user-images.githubusercontent.com/1296369/98956232-b0671600-24f7-11eb-9a90-c7aae70bb323.png)


### Testing Part 2
Please test three scenarios 

1. Image Description (Alt Text) = Empty
Images is decorative = unchecked

2. Image Description (Alt Text) = "some description"
Images is decorative = unchecked

3. Image Description (Alt Text) = Empty
Images is decorative = checked

The expected behaviour for each of these tests is

1.`<img  src="filename.jpg" width="xx" height="xx" />`
2. `<img  src="filename.jpg" alt="some description" width="xx" height="xx" />`
3. `<img  role="presentation" src="filename.jpg" alt  width="xx" height="xx" />`
3. `<img  role="presentation" src="filename.jpg" alt=""  width="xx" height="xx" />`


PLEASE do not comment on what you think the code does but apply the PR and test it. Getting very tired of people blocking PR with their comments without actually testing the code.

### Bonus 
I have grouped the three image options together in the code.

cc @carcam 



