### PR TITLE
[4.0] Add possibility to add a custom path in media field

### DIFF
--- a/layouts/joomla/form/field/media.php
+++ b/layouts/joomla/form/field/media.php
@@ -158,7 +158,7 @@ Text::script('JLIB_APPLICATION_ERROR_SERVER');
 		</div>
 	<?php endif; ?>
 	<div class="input-group">
-		<input type="text" name="<?php echo $name; ?>" id="<?php echo $id; ?>" value="<?php echo htmlspecialchars($value, ENT_COMPAT, 'UTF-8'); ?>" readonly="readonly"<?php echo $attr; ?>>
+		<input type="text" name="<?php echo $name; ?>" id="<?php echo $id; ?>" value="<?php echo htmlspecialchars($value, ENT_COMPAT, 'UTF-8'); ?>" <?php echo $attr; ?>>
 		<?php if ($disabled != true) : ?>
 			<div class="input-group-append">
 				<button type="button" class="btn btn-secondary button-select"><?php echo Text::_("JLIB_FORM_BUTTON_SELECT"); ?></button>


### PR DESCRIPTION
Pull Request for Issue #28852 .

### Summary of Changes
Enable the media field for input custom url 


### Testing Instructions
Enable the patch, try to create an article and set a custom URL in the Intro Image, for example `https://via.placeholder.com/350x150`


### Actual result BEFORE applying this Pull Request

You can not insert custom URL:
![immagine](https://user-images.githubusercontent.com/906604/99145370-82f0a880-266e-11eb-88e0-404e0cd818e4.png)


### Expected result AFTER applying this Pull Request
You can insert custom URL and after save the preview is displayed:
![immagine](https://user-images.githubusercontent.com/906604/99145347-4fae1980-266e-11eb-8632-ce8d2f442694.png)


### Documentation Changes Required
NO
