### PR TITLE
Fix subform default value filtering, and warning while string foreach()

### DIFF
--- a/libraries/src/Form/Form.php
+++ b/libraries/src/Form/Form.php
@@ -1563,6 +1563,18 @@ class Form
 					$field   = $this->loadField($element);
 					$subForm = $field->loadSubForm();
 
+					// Subform field may have a default value, that is a JSON string
+					if ($value && is_string($value))
+					{
+						$value = json_decode($value, true);
+
+						// The string is invalid json
+						if (!$value)
+						{
+							return null;
+						}
+					}
+
 					if ($field->multiple)
 					{
 						$return = array();


### PR DESCRIPTION
Pull Request for Issue #31331 .

### Summary of Changes

This fixes subform value filtering when it have a default value.
Because a default value is a JSON string `Form::filterField()` produce:
```
Warning: Invalid argument supplied for foreach() in <root>/libraries/src/Form/Form.php on line 1572
```


### Testing Instructions

Add subform field in to any xml in params section, example `mod_custom.xml`

```xml
<field name="subform_test2" type="subform" label="Subform field"
  multiple="true"
  default='[{"child_field": "Default text field value"}]'
>
    <form>
        <field
            name="child_field"
            type="text"
            label="Text field"
        />
    </form>
</field>
```
Open the form, remove all subform rows, and save.


### Actual result BEFORE applying this Pull Request
Subform field is empty, with zero rows


### Expected result AFTER applying this Pull Request
Subform field should show 1 row of default value


### Documentation Changes Required
none
