### PR TITLE
[4.0] Fix subform default value filtering, and warning while string foreach()

### DIFF
--- a/libraries/src/Form/Field/SubformField.php
+++ b/libraries/src/Form/Field/SubformField.php
@@ -442,6 +442,18 @@ class SubformField extends FormField
 		// Dirty way of ensuring required fields in subforms are submitted and filtered the way other fields are
 		$subForm = $this->loadSubForm();
 
+		// Subform field may have a default value, that is a JSON string
+		if ($value && is_string($value))
+		{
+			$value = json_decode($value, true);
+
+			// The string is invalid json
+			if (!$value)
+			{
+				return null;
+			}
+		}
+
 		if ($this->multiple)
 		{
 			$return = [];


### PR DESCRIPTION
### Summary of Changes

The same as #31399 but for J4

### Testing Instructions

Add subform field in to any xml in params section, example `mod_custom.xml`

```xml
<field name="subform_test2" type="subform" label="Subform field"
  multiple="true"
  default='[{"child_field": "Default text field value"}]'
>
    <form>
        <field
            name="child_field"
            type="text"
            label="Text field"
        />
    </form>
</field>
```
Open the form, remove all subform rows, and save.


### Actual result BEFORE applying this Pull Request
Subform field is empty, with zero rows


### Expected result AFTER applying this Pull Request
Subform field should show 1 row of default value


### Documentation Changes Required
none

