### PR TITLE
[4.0] mod_privacy_status layout field class missing

### DIFF
--- a/administrator/modules/mod_privacy_status/mod_privacy_status.xml
+++ b/administrator/modules/mod_privacy_status/mod_privacy_status.xml
@@ -27,6 +27,7 @@
 					name="layout"
 					type="modulelayout"
 					label="JFIELD_ALT_LAYOUT_LABEL"
+					class="custom-select"
 				/>
 
 				<field


### PR DESCRIPTION
### Summary of Changes
Adding missing custom-select class to the layout field 


### Testing Instructions
Edit the mod_privacy_status module Advanced tab


### Actual result BEFORE applying this Pull Request

<img width="548" alt="Screen Shot 2020-11-15 at 09 46 36" src="https://user-images.githubusercontent.com/869724/99180643-3e294800-2728-11eb-91bc-b7000b590f49.png">


### Expected result AFTER applying this Pull Request

<img width="557" alt="Screen Shot 2020-11-15 at 09 48 28" src="https://user-images.githubusercontent.com/869724/99180645-43869280-2728-11eb-9145-148f73046ccc.png">
