### PR TITLE
[4.0] scss stylint

### DIFF
--- a/build/.stylelintrc.json
+++ b/build/.stylelintrc.json
@@ -213,7 +213,7 @@
     "selector-pseudo-class-parentheses-space-inside": "never",
     "shorthand-property-no-redundant-values": true,
     "string-quotes": "double",
-    "unit-whitelist": [
+    "unit-allowed-list": [
       "ch",
       "em",
       "ex",


### PR DESCRIPTION
Resolves:
Deprecation Warning: 'unit-whitelist' has been deprecated. Instead use 'unit-allowed-list'. See: https://github.com/stylelint/stylelint/blob/13.7.0/lib/rules/unit-whitelist/README.md


code review