### PR TITLE
[4.0] htmlhelper svg

### DIFF
--- a/libraries/src/HTML/Helpers/Icons.php
+++ b/libraries/src/HTML/Helpers/Icons.php
@@ -114,14 +114,14 @@ abstract class Icons
 		// Get path to icon
 		$file = HTMLHelper::_('image', $file, '', '', $relative, true);
 
-		// Make sure path is local to Joomla
-		$file = Path::check(JPATH_ROOT . '/' . substr($file, \strlen(Uri::root(true))));
-
 		// If you can't find the icon or if it's unsafe then skip it
 		if (!$file)
 		{
 			return null;
 		}
+
+		// Make sure path is local to Joomla
+		$file = Path::check(JPATH_ROOT . '/' . substr($file, \strlen(Uri::root(true))));
 
 		// Get contents to display inline
 		$file = file_get_contents($file);

--- a/libraries/src/HTML/Helpers/Icons.php
+++ b/libraries/src/HTML/Helpers/Icons.php
@@ -12,6 +12,7 @@ namespace Joomla\CMS\HTML\Helpers;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Filesystem\File;
 use Joomla\CMS\Layout\FileLayout;
 use Joomla\CMS\Uri\Uri;
 use Joomla\Filesystem\Path;

--- a/libraries/src/HTML/Helpers/Icons.php
+++ b/libraries/src/HTML/Helpers/Icons.php
@@ -124,7 +124,7 @@ abstract class Icons
 		// Make sure path is local to Joomla
 		$file = Path::check(JPATH_ROOT . '/' . substr($file, \strlen(Uri::root(true))));
 
-		// If it's doesn't exist then skip it.
+		// If it doesn't exist then skip it.
 		if (!File::exists($file))
 		{
 			return null;

--- a/libraries/src/HTML/Helpers/Icons.php
+++ b/libraries/src/HTML/Helpers/Icons.php
@@ -114,7 +114,7 @@ abstract class Icons
 		// Get path to icon
 		$file = HTMLHelper::_('image', $file, '', '', $relative, true);
 
-		// If you can't find the icon or if it's unsafe then skip it
+		// If you can't find the icon then skip it.
 		if (!$file)
 		{
 			return null;
@@ -122,6 +122,12 @@ abstract class Icons
 
 		// Make sure path is local to Joomla
 		$file = Path::check(JPATH_ROOT . '/' . substr($file, \strlen(Uri::root(true))));
+
+		// If it's doesn't exist then skip it.
+		if (!File::exists($file))
+		{
+			return null;
+		}
 
 		// Get contents to display inline
 		$file = file_get_contents($file);


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
changes when an error is checked for.

### Testing Instructions
go to /administrator/index.php via https://
check for webauthn icon.
apply pr.
check that webauthn icon shows.

change /plugins/system/webauthn/src/PluginTraits/AdditionalLoginButtons.php
line 156 to 'svg'                => HTMLHelper::_('icons.svg', 'http://hallhome.us/plg_system_webauthn/webauthn.svg', true),

check that icon is missing and no error shown.

change /plugins/system/webauthn/src/PluginTraits/AdditionalLoginButtons.php
line 156 to 'svg'                => HTMLHelper::_('icons.svg', 'plg_system_webauthn/webauthn2.svg', true),

check that icon is missing and no error shown.

### Actual result BEFORE applying this Pull Request
![image](https://user-images.githubusercontent.com/1850089/99194490-4b086480-2745-11eb-8527-e999dceb39ac.png)


### Expected result AFTER applying this Pull Request
![image](https://user-images.githubusercontent.com/1850089/99194492-4d6abe80-2745-11eb-9e08-d7547e20cca5.png)


### Documentation Changes Required

This helper allows for svg's to be used as inline-svg's.  This can be done by calling the helper class with the path to the image.
the webauthn plugin is a good example of how it can be used in place of the standard icon or image simply by replacing icon/image with 'svg', as shown here....
```  'svg'                => HTMLHelper::_('icons.svg', 'plg_system_webauthn/webauthn.svg', true),```
this would get the image from the /media/plg_system_webauthn/images folder.
if it was to false then it would get it from the exact path given.
Like all helpers it can be called directly in the code ( like a template for example ) if desired.