### PR TITLE
[4.0] Check for empty client com_banners

### DIFF
--- a/administrator/components/com_banners/src/Table/ClientTable.php
+++ b/administrator/components/com_banners/src/Table/ClientTable.php
@@ -11,6 +11,7 @@ namespace Joomla\Component\Banners\Administrator\Table;
 
 \defined('_JEXEC') or die;
 
+use Joomla\CMS\Language\Text;
 use Joomla\CMS\Table\Table;
 use Joomla\CMS\Versioning\VersionableTableInterface;
 use Joomla\Database\DatabaseDriver;
@@ -56,5 +57,26 @@ class ClientTable extends Table implements VersionableTableInterface
 	public function getTypeAlias()
 	{
 		return 'com_banners.client';
+	}
+
+	/**
+	 * Overloaded check function
+	 *
+	 * @return  boolean
+	 *
+	 * @see     Table::check
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function check()
+	{
+		// Check that client name is not blank
+		if (trim($this->contact) === '')
+		{
+			$this->setError(Text::_('JLIB_CMS_WARNING_PROVIDE_VALID_NAME'));
+
+			return false;
+		}
+
+		return true;
 	}
 }

--- a/administrator/components/com_banners/src/Table/ClientTable.php
+++ b/administrator/components/com_banners/src/Table/ClientTable.php
@@ -69,7 +69,15 @@ class ClientTable extends Table implements VersionableTableInterface
 	 */
 	public function check()
 	{
-		// Check that client name is not blank
+		// Check that client is not blank
+		if (trim($this->name) === '')
+		{
+			$this->setError(Text::_('JLIB_CMS_WARNING_PROVIDE_VALID_NAME'));
+
+			return false;
+		}
+
+		// Check that client contact name is not blank
 		if (trim($this->contact) === '')
 		{
 			$this->setError(Text::_('JLIB_CMS_WARNING_PROVIDE_VALID_NAME'));


### PR DESCRIPTION
Pull Request for Issue #31345 and #31355

### Summary of Changes
Adds a check to ensure that the client name can not be saved with just blank characters

Adds a check to ensure that the contact name can not be saved with just blank characters


### Testing Instructions

- log in to the backend
- Goto Components-> Banners -> Clients
- Click the New button and fill the form
- While filling the form add ONLY tabs/spaces in "Contact Name" which is a required field.
- Click on Save and close button
- You can see the contact column for our added client is blank.

Repeat above for Client Name


### Actual result BEFORE applying this Pull Request

Article is saved

### Expected result AFTER applying this Pull Request

Article is not saved with error message saying why

### Documentation Changes Required

none