### PR TITLE
[3.9] Missing lines JLIB_ when installing language packs

### DIFF
--- a/installation/language/en-GB/en-GB.ini
+++ b/installation/language/en-GB/en-GB.ini
@@ -49,7 +49,6 @@ INSTL_DATABASE_TYPE_LABEL="Database Type"
 INSTL_DATABASE_USER_DESC="Either a username you created or a username provided by your host."
 INSTL_DATABASE_USER_LABEL="Username"
 
-
 ;FTP view
 INSTL_AUTOFIND_FTP_PATH="Autofind FTP Path"
 INSTL_FTP="FTP Configuration"
@@ -301,10 +300,12 @@ JLIB_FORM_FIELD_INVALID="Invalid field:&#160;"
 JLIB_FORM_VALIDATE_FIELD_INVALID="Invalid field: %s"
 JLIB_FORM_VALIDATE_FIELD_REQUIRED="Field required: %s"
 JLIB_INSTALLER_ABORT="Aborting language installation: %s"
+JLIB_INSTALLER_ABORT_NOINSTALLPATH="Install path does not exist."
 JLIB_INSTALLER_ABORT_PACK_INSTALL_CREATE_DIRECTORY="Package Install: Failed to create folder: %s."
 JLIB_INSTALLER_ABORT_PACK_INSTALL_ERROR_EXTENSION="Package %1$s: There was an error installing an extension: %2$s"
 JLIB_INSTALLER_ABORT_PACK_INSTALL_NO_FILES="Package %s: There were no files to install!"
 JLIB_INSTALLER_ERROR_FAIL_COPY_FILE="JInstaller: :Install: Failed to copy file %1$s to %2$s."
+JLIB_INSTALLER_INSTALL="Install"
 JLIB_INSTALLER_NOT_ERROR="If the error is related to the installation of TinyMCE language files it has no effect on the installation of the language(s). Some language packs created prior to Joomla! 3.2.0 may try to install separate TinyMCE language files. As these are now included in the core they no longer need to be installed."
 JLIB_UTIL_ERROR_CONNECT_DATABASE="JDatabase: :getInstance: Could not connect to database <br />joomla.library: %1$s - %2$s"
 


### PR DESCRIPTION
### Summary of Changes
Missing lines `_JLIB` when installing language packs

### Testing Instructions
Download the current Joomla distribution kit, go through the standard installation process and BEFORE deleting the "installation" directory, try installing several languages.

For example, Catalan.

At the moment, there is a problem with loading this particular language. Joomla will give an error with 2 lines from `ru-RU.lib_joomla.ini`, which are not in the language installation file.

> Warning
> Joomla was unable to install Catalan language. You will be able to install it later using the Joomla! Administrator
> Package JLIB_INSTALLER_INSTALL: There was an error installing an extension: ca-ES
> JLIB_INSTALLER_ABORT_NOINSTALLPATH

### BEFORE / AFTER patch

![Screenshot_1](https://user-images.githubusercontent.com/8440661/99574815-85416280-29e0-11eb-949e-0946f35e992d.png)
