### PR TITLE
[4.0] media manager fix inconsistent select

### DIFF
--- a/administrator/components/com_media/resources/scripts/components/browser/items/directory.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/directory.vue
@@ -16,15 +16,11 @@
     <div class="media-browser-item-info">
       {{ item.name }}
     </div>
-    <a
-      href="#"
+    <span
       class="media-browser-select"
       :aria-label="translate('COM_MEDIA_TOGGLE_SELECT_ITEM')"
       :title="translate('COM_MEDIA_TOGGLE_SELECT_ITEM')"
-      @click.stop="toggleSelect()"
-      @focus="focused(true)"
-      @blur="focused(false)"
-    />
+    ></span>
     <div
       class="media-browser-actions"
       :class="{'active': showActions}"

--- a/administrator/components/com_media/resources/scripts/components/browser/items/directory.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/directory.vue
@@ -20,7 +20,7 @@
       class="media-browser-select"
       :aria-label="translate('COM_MEDIA_TOGGLE_SELECT_ITEM')"
       :title="translate('COM_MEDIA_TOGGLE_SELECT_ITEM')"
-    ></span>
+    />
     <div
       class="media-browser-actions"
       :class="{'active': showActions}"

--- a/administrator/components/com_media/resources/scripts/components/browser/items/directory.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/directory.vue
@@ -128,10 +128,6 @@ export default {
       this.$store.commit(types.SELECT_BROWSER_ITEM, this.item);
       this.$store.commit(types.SHOW_RENAME_MODAL);
     },
-    /* Toggle the item selection */
-    toggleSelect() {
-      this.$store.dispatch('toggleBrowserItemSelect', this.item);
-    },
     /* Open actions dropdown */
     openActions() {
       this.showActions = true;

--- a/administrator/components/com_media/resources/scripts/components/browser/items/file.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/file.vue
@@ -166,10 +166,6 @@ export default {
       this.$store.commit(types.SELECT_BROWSER_ITEM, this.item);
       this.$store.commit(types.SHOW_RENAME_MODAL);
     },
-    /* Toggle the item selection */
-    toggleSelect() {
-      this.$store.dispatch('toggleBrowserItemSelect', this.item);
-    },
     /* Open modal for share url */
     openShareUrlModal() {
       this.$store.commit(types.SELECT_BROWSER_ITEM, this.item);

--- a/administrator/components/com_media/resources/scripts/components/browser/items/file.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/file.vue
@@ -13,15 +13,11 @@
     <div class="media-browser-item-info">
       {{ item.name }} {{ item.filetype }}
     </div>
-    <a
-      href="#"
+    <span
       class="media-browser-select"
       :aria-label="translate('COM_MEDIA_TOGGLE_SELECT_ITEM')"
       :title="translate('COM_MEDIA_TOGGLE_SELECT_ITEM')"
-      @click.stop="toggleSelect()"
-      @focus="focused(true)"
-      @blur="focused(false)"
-    />
+    ></span>
     <div
       class="media-browser-actions"
       :class="{'active': showActions}"

--- a/administrator/components/com_media/resources/scripts/components/browser/items/file.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/file.vue
@@ -17,7 +17,7 @@
       class="media-browser-select"
       :aria-label="translate('COM_MEDIA_TOGGLE_SELECT_ITEM')"
       :title="translate('COM_MEDIA_TOGGLE_SELECT_ITEM')"
-    ></span>
+    />
     <div
       class="media-browser-actions"
       :class="{'active': showActions}"

--- a/administrator/components/com_media/resources/scripts/components/browser/items/image.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/image.vue
@@ -15,15 +15,11 @@
     <div class="media-browser-item-info">
       {{ item.name }} {{ item.filetype }}
     </div>
-    <a
-      href="#"
+    <span
       class="media-browser-select"
       :aria-label="translate('COM_MEDIA_TOGGLE_SELECT_ITEM')"
       :title="translate('COM_MEDIA_TOGGLE_SELECT_ITEM')"
-      @click.stop="toggleSelect()"
-      @focus="focused(true)"
-      @blur="focused(false)"
-    />
+    ></span>
     <div
       class="media-browser-actions"
       :class="{'active': showActions}"
@@ -239,10 +235,6 @@ export default {
       const fileBaseUrl = `${Joomla.getOptions('com_media').editViewUrl}&path=`;
 
       window.location.href = fileBaseUrl + this.item.path;
-    },
-    /* Toggle the item selection */
-    toggleSelect() {
-      this.$store.dispatch('toggleBrowserItemSelect', this.item);
     },
     /* Open modal for share url */
     openShareUrlModal() {

--- a/administrator/components/com_media/resources/scripts/components/browser/items/image.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/image.vue
@@ -19,7 +19,7 @@
       class="media-browser-select"
       :aria-label="translate('COM_MEDIA_TOGGLE_SELECT_ITEM')"
       :title="translate('COM_MEDIA_TOGGLE_SELECT_ITEM')"
-    ></span>
+    />
     <div
       class="media-browser-actions"
       :class="{'active': showActions}"

--- a/administrator/components/com_media/resources/scripts/components/browser/items/item.es6.js
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/item.es6.js
@@ -102,6 +102,19 @@ export default {
         );
       }
 
+      if (this.item.type === 'dir') {
+        window.parent.document.dispatchEvent(
+          new CustomEvent(
+            'onMediaFileSelected',
+            {
+              bubbles: true,
+              cancelable: false,
+              detail: {},
+            },
+          ),
+        );
+      }
+
       // Handle clicks when the item was not selected
       if (!this.isSelected()) {
         // Unselect all other selected items,
@@ -111,6 +124,18 @@ export default {
         }
         this.$store.commit(types.SELECT_BROWSER_ITEM, this.item);
         return;
+      } else {
+        this.$store.dispatch('toggleBrowserItemSelect', this.item);
+        window.parent.document.dispatchEvent(
+          new CustomEvent(
+            'onMediaFileSelected',
+            {
+              bubbles: true,
+              cancelable: false,
+              detail: {},
+            },
+          ),
+        );
       }
 
       // If more than one item was selected and the user clicks again on the selected item,

--- a/administrator/components/com_media/resources/scripts/components/browser/items/item.es6.js
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/item.es6.js
@@ -124,19 +124,18 @@ export default {
         }
         this.$store.commit(types.SELECT_BROWSER_ITEM, this.item);
         return;
-      } else {
-        this.$store.dispatch('toggleBrowserItemSelect', this.item);
-        window.parent.document.dispatchEvent(
-          new CustomEvent(
-            'onMediaFileSelected',
-            {
-              bubbles: true,
-              cancelable: false,
-              detail: {},
-            },
-          ),
-        );
       }
+      this.$store.dispatch('toggleBrowserItemSelect', this.item);
+      window.parent.document.dispatchEvent(
+        new CustomEvent(
+          'onMediaFileSelected',
+          {
+            bubbles: true,
+            cancelable: false,
+            detail: {},
+          },
+        ),
+      );
 
       // If more than one item was selected and the user clicks again on the selected item,
       // he most probably wants to unselect all other items.

--- a/administrator/components/com_media/resources/scripts/components/browser/items/video.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/video.vue
@@ -14,13 +14,11 @@
     <div class="media-browser-item-info">
       {{ item.name }} {{ item.filetype }}
     </div>
-    <a
-      href="#"
+    <span
       class="media-browser-select"
       :aria-label="translate('COM_MEDIA_TOGGLE_SELECT_ITEM')"
-      @click.stop="toggleSelect()"
-    > :title="translate('COM_MEDIA_TOGGLE_SELECT_ITEM')">
-    </a>
+      :title="translate('COM_MEDIA_TOGGLE_SELECT_ITEM')"
+    ></span>
     <div
       class="media-browser-actions"
       :class="{'active': showActions}"

--- a/administrator/components/com_media/resources/scripts/components/browser/items/video.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/video.vue
@@ -18,7 +18,7 @@
       class="media-browser-select"
       :aria-label="translate('COM_MEDIA_TOGGLE_SELECT_ITEM')"
       :title="translate('COM_MEDIA_TOGGLE_SELECT_ITEM')"
-    ></span>
+    />
     <div
       class="media-browser-actions"
       :class="{'active': showActions}"


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/pull/30784#issuecomment-700486088

### Summary of Changes
Bug fix: The select box should respond to the same event as the thumb.


### Testing Instructions
Edit an article and either try to set a fulltext/intro image or insert an image through the editor button.

Click around, selecting folder, image, clicking on the tick box, etc. The additional data should appear/disappear depending on the selected file (only on selected images). The next comment/gif might be helpful:

> It seems you have to "click" the image and it is not enough to just "select the image" could that might be a different event?

![](https://user-images.githubusercontent.com/2596554/94522361-d24e5700-022f-11eb-9162-7da7e70ebd8e.gif)

### Actual result BEFORE applying this Pull Request

Inconsistent behaviour 

### Expected result AFTER applying this Pull Request

All good

### Documentation Changes Required

No bug fix