### PR TITLE
[4.0] Do not create the Uri object again

### DIFF
--- a/libraries/src/Router/Router.php
+++ b/libraries/src/Router/Router.php
@@ -166,7 +166,7 @@ class Router
 	/**
 	 * Function to convert an internal URI to a route
 	 *
-	 * @param   string  $url  The internal URL or an associative array
+	 * @param   string|array|Uri  $url  The internal URL or an associative array
 	 *
 	 * @return  Uri  The absolute search engine friendly URL object
 	 *
@@ -181,8 +181,14 @@ class Router
 			return clone $this->cache[$key];
 		}
 
-		// Create the URI object
-		$uri = $this->createUri($url);
+		if ($url instanceof Uri)
+		{
+			$uri = $url;
+		}
+		else
+		{
+			$uri = $this->createUri($url);
+		}
 
 		// Do the preprocess stage of the URL build process
 		$this->processBuildRules($uri, self::PROCESS_BEFORE);


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This intents to be a procedural improvement rather than a fix or a feature. 

The `Joomla\CMS\Router\Route::_`  can get  a `Joomla\CMS\Uri\Uri` parameter, which is later instantiated again as Uri object. 
It creates a new object of the same type from the passed one, for no reason. The created object is a clone of the passed.


### Testing Instructions
To be able to check the change, you need to debug the code at the point where the change is applied.

Try adding a code like the following in a layout file.
```
<?php
$uri = Joomla\CMS\Uri\Uri::getInstance('index.php?option=com_content&view=category');
?>
<a href="<?php echo Joomla\CMS\Router\Route::_($uri)?>">A content link</a>
```


### Actual result BEFORE applying this Pull Request
Although we pass a Uri object, it creates a new one of the same type from our passed object.


### Expected result AFTER applying this Pull Request
Uses the passed Uri object



### Documentation Changes Required
DKN

