### PR TITLE
Removing unused contact field

### DIFF
--- a/administrator/components/com_contact/models/forms/contact.xml
+++ b/administrator/components/com_contact/models/forms/contact.xml
@@ -299,13 +299,6 @@
 	<fieldset name="details" label="COM_CONTACT_CONTACT_DETAILS">
 
 		<field
-			name="@text_details"
-			type="note"
-			label=""
-			description="COM_CONTACT_EDIT_DETAILS"
-		/>
-
-		<field
 			name="image"
 			type="media"
 			label="COM_CONTACT_FIELD_PARAMS_IMAGE_LABEL"


### PR DESCRIPTION
Pull Request for Issue #31437 .

### Summary of Changes
Removes the contact field `text_details` which isn't used.

Looks like it is a leftover from very old days.

### Testing Instructions
Edit a contact


### Actual result BEFORE applying this Pull Request
No such field


### Expected result AFTER applying this Pull Request
No such field, contact still works the same.


### Documentation Changes Required
None
