### PR TITLE
Fix "Uncaught ValueError: Path cannot be empty ..." in com_joomlaupdate restore.php

### DIFF
--- a/administrator/components/com_joomlaupdate/restore.php
+++ b/administrator/components/com_joomlaupdate/restore.php
@@ -874,7 +874,7 @@ abstract class AKAbstractUnarchiver extends AKAbstractPart
 	 */
 	public function __wakeup()
 	{
-		if ($this->currentPartNumber >= 0)
+		if ($this->currentPartNumber >= 0 && !empty($this->archiveList[$this->currentPartNumber]))
 		{
 			$this->fp = @fopen($this->archiveList[$this->currentPartNumber], 'rb');
 			if ((is_resource($this->fp)) && ($this->currentPartOffset > 0))


### PR DESCRIPTION
Pull Request for Issue #31308 .

### Summary of Changes

Adds a check if the path is empty.

### Testing Instructions

See issue #31308 .

To reproduce, update e.g. a 3.9.22 to 3.9.23 RC.

To test the fix of this PR, update e.g. a 3.9.22 to the update package built by Drone for this PR.

Verify that the update has run completely by checking the Joomla Update log file `administrator/logs/joomla_update.php`. The following logs should be there:
```
2020-11-20T18:39:21+00:00       INFO 192.168.98.1       update  Update started by user Super User (342). Old version is 3.9.22.
2020-11-20T18:39:21+00:00       INFO 192.168.98.1       update  Downloading update file from https://ci.joomla.org/artifacts/joomla/joomla-cms/staging/31442/downloads/37665/Joomla_3.9.23-rc+pr.31442-Release_Candidate-Update_Package.zip.
2020-11-20T18:39:22+00:00       INFO 192.168.98.1       update  File Joomla_3.9.23-rc+pr.31442-Release_Candidate-Update_Package.zip downloaded.
2020-11-20T18:39:22+00:00       INFO 192.168.98.1       update  Starting installation of new version.
2020-11-20T18:39:25+00:00       INFO 192.168.98.1       update  Finalising installation.
2020-11-20T18:39:25+00:00       INFO 192.168.98.1       update  Deleting removed files and folders.
2020-11-20T18:39:26+00:00       INFO 192.168.98.1       update  Cleaning up after installation.
2020-11-20T18:39:26+00:00       INFO 192.168.98.1       update  Update to version 3.9.23-rc+pr.31442 is complete.
```

### Actual result BEFORE applying this Pull Request

See issue #31308 .

### Expected result AFTER applying this Pull Request

No PHP error like described in issue #31308 .

### Documentation Changes Required

None.