### PR TITLE
[4.0] Don't display hidden menu items at all.

### DIFF
--- a/administrator/modules/mod_submenu/tmpl/default.php
+++ b/administrator/modules/mod_submenu/tmpl/default.php
@@ -47,10 +47,10 @@ use Joomla\CMS\Router\Route;
 				</h2>
 				<ul class="list-group list-group-flush">
 					<?php foreach ($child->getChildren() as $item) : ?>
-						<li class="list-group-item d-flex align-items-center">
-							<?php $params = $item->getParams(); ?>
-							<?php // Only if Menu-show = true
-								if ($params->get('menu_show', 1)) : ?>
+						<?php $params = $item->getParams(); ?>
+						<?php // Only if Menu-show = true
+						if ($params->get('menu_show', 1)) : ?>
+							<li class="list-group-item d-flex align-items-center">
 								<a class="flex-grow-1" href="<?php echo $item->link; ?>"
 									<?php echo $item->target === '_blank' ? ' title="' . Text::sprintf('JBROWSERTARGET_NEW_TITLE', Text::_($item->title)) . '"' : ''; ?>
 									<?php echo $item->target ? ' target="' . $item->target . '"' : ''; ?>>
@@ -101,8 +101,8 @@ use Joomla\CMS\Router\Route;
 										</a>
 									</span>
 								<?php endif; ?>
-							<?php endif; ?>
-						</li>
+							</li>
+						<?php endif; ?>
 					<?php endforeach; ?>
 				</ul>
 			</div>

--- a/administrator/modules/mod_submenu/tmpl/default.php
+++ b/administrator/modules/mod_submenu/tmpl/default.php
@@ -48,8 +48,8 @@ use Joomla\CMS\Router\Route;
 				<ul class="list-group list-group-flush">
 					<?php foreach ($child->getChildren() as $item) : ?>
 						<?php $params = $item->getParams(); ?>
-						<?php // Only if Menu-show = true
-						if ($params->get('menu_show', 1)) : ?>
+						<?php // Only if Menu-show = true ?>
+						<?php if ($params->get('menu_show', 1)) : ?>
 							<li class="list-group-item d-flex align-items-center">
 								<a class="flex-grow-1" href="<?php echo $item->link; ?>"
 									<?php echo $item->target === '_blank' ? ' title="' . Text::sprintf('JBROWSERTARGET_NEW_TITLE', Text::_($item->title)) . '"' : ''; ?>


### PR DESCRIPTION
### Summary of Changes
If an item is set to hidden / not show, it doesn't make any sense to display an empty `<li>` item.


### Testing Instructions
Because it is a backend module, this is a bit tricky.

**Important:** Don't activate the "Recovery mode" for the menu, because it seems to be bugged!
1. At Menus - Manage, select "Administrator" and create a new menu.
2. In this new administrator menu, create one basis menu item on the top level, and at least three menu items that are children to this basis menu item.
3. For one of these child items, under "Link Type", set "Display in Menu: No".
4. Go to the Home Dashboard.
5. Click on "Add Module to the Dashboard".
  - Type: "Administrator Dashboard Menu"
  - Menu: select your previously created menu
  - Enter a module title and save the module.
6. Look at the newly created module.

### Actual result BEFORE applying this Pull Request
At the place, where the hidden item would be, there is an empty `<li></li>` tag, which is displayed as empty space between two lines.
![Screenshot_2020-11-20 Home Dashboard - Joomla 4 Test Site - Administration 2](https://user-images.githubusercontent.com/1410135/99835534-088bc100-2b65-11eb-8991-e200b783cd5a.png)


### Expected result AFTER applying this Pull Request
Only the items that are not hidden are displayed.
![Screenshot_2020-11-20 Home Dashboard - Joomla 4 Test Site - Administration](https://user-images.githubusercontent.com/1410135/99835528-075a9400-2b65-11eb-9766-78a66aa4379e.png)


### Documentation Changes Required
None
