### PR TITLE
Limit offset to max len in com_search

### DIFF
--- a/administrator/components/com_search/helpers/search.php
+++ b/administrator/components/com_search/helpers/search.php
@@ -287,8 +287,9 @@ class SearchHelper
 		$lsearchword = StringHelper::strtolower(self::remove_accents($searchword));
 		$wordfound   = false;
 		$pos         = 0;
+		$length      = $length > $textlen ? $textlen : $length;
 
-		while ($wordfound === false && $pos < $textlen)
+		while ($wordfound === false && $pos + $length < $textlen)
 		{
 			if (($wordpos = @StringHelper::strpos($ltext, ' ', $pos + $length)) !== false)
 			{
@@ -316,29 +317,29 @@ class SearchHelper
 			{
 				$iOriLen = StringHelper::strlen(StringHelper::substr($text, 0, $pos + $chunk_size));
 				$iModLen = StringHelper::strlen(self::remove_accents(StringHelper::substr($text, 0, $pos + $chunk_size)));
-				
+
 				$chunk_size += $iOriLen - $iModLen;
 			}
 			else
 			{
 				$iOriSkippedLen = StringHelper::strlen(StringHelper::substr($text, 0, $pos));
 				$iModSkippedLen = StringHelper::strlen(self::remove_accents(StringHelper::substr($text, 0, $pos)));
-				
+
 				// Adjust starting position $pos
 				if ($iOriSkippedLen !== $iModSkippedLen)
 				{
 					$pos += $iOriSkippedLen - $iModSkippedLen;
 				}
-				
+
 				$iOriReturnLen = StringHelper::strlen(StringHelper::substr($text, $pos, $chunk_size));
 				$iModReturnLen = StringHelper::strlen(self::remove_accents(StringHelper::substr($text, $pos, $chunk_size)));
-				
+
 				if ($iOriReturnLen !== $iModReturnLen)
 				{
 					$chunk_size += $iOriReturnLen - $iModReturnLen;
 				}
 			}
-			
+
 			$sPre = $pos > 0 ? '...&#160;' : '';
 			$sPost = ($pos + $chunk_size) >= StringHelper::strlen($text) ? '' : '&#160;...';
 


### PR DESCRIPTION
Pull Request for Issue #30501 .

### Summary of Changes
Limit the offset length to textlength


### Testing Instructions
Create a test side with short and long articles and search for a word using php 8


### Actual result BEFORE applying this Pull Request
`search error 0 mb_strpos(): Argument #3 ($offset) must be contained in argument #1 ($haystack)`

### Expected result AFTER applying this Pull Request
Get a search result


