### PR TITLE
Use proper string comparison function for tag aliases

### DIFF
--- a/libraries/joomla/form/fields/aliastag.php
+++ b/libraries/joomla/form/fields/aliastag.php
@@ -63,7 +63,7 @@ class JFormFieldAliastag extends JFormFieldList
 			$options,
 			function($a, $b)
 			{
-				return $a->text > $b->text;
+				return strcmp ($a->text, $b->text);
 			}
 		);
 

--- a/libraries/joomla/form/fields/aliastag.php
+++ b/libraries/joomla/form/fields/aliastag.php
@@ -63,7 +63,7 @@ class JFormFieldAliastag extends JFormFieldList
 			$options,
 			function($a, $b)
 			{
-				return strcmp ($a->text, $b->text);
+				return strcmp($a->text, $b->text);
 			}
 		);
 


### PR DESCRIPTION
Pull Request for Tags Issue in PHP8

### Summary of Changes
Changed arrow comparison function to use strcmp function


### Testing Instructions
1. Open Tags list view
1. Open Search Tools

### Actual result BEFORE applying this Pull Request

Deprecated: usort(): Returning bool from comparison function is deprecated, return an integer less than, equal to, or greater than zero in libraries/joomla/form/fields/aliastag.php on line 67

### Expected result AFTER applying this Pull Request
No error


