### PR TITLE
[4.0] Delete unused contact lang string

### DIFF
--- a/administrator/language/en-GB/com_contact.ini
+++ b/administrator/language/en-GB/com_contact.ini
@@ -16,7 +16,6 @@ COM_CONTACT_CONTACT_VIEW_DEFAULT_DESC="This links to the contact information for
 COM_CONTACT_CONTACTS="Contacts"
 COM_CONTACT_DETAILS="Contact Information"
 COM_CONTACT_EDIT_CONTACT="Edit Contact"
-COM_CONTACT_EDIT_DETAILS="Edit contact information displayed on an individual page."
 COM_CONTACT_ERROR_ALL_LANGUAGE_ASSOCIATED="A contact item set to All languages can't be associated. Associations have not been set."
 COM_CONTACT_ERROR_UNIQUE_ALIAS="Another Contact from this category has the same alias (remember it may be a trashed item)."
 COM_CONTACT_FIELD_ARTICLES_DISPLAY_NUM_LABEL="# Articles to List"


### PR DESCRIPTION
Follow up on https://github.com/joomla/joomla-cms/pull/31439

### Summary of Changes

Deleting `COM_CONTACT_EDIT_DETAILS="Edit contact information displayed on an individual page."`
The string is not used at all in J4


Can be merged on review