### PR TITLE
[4] Add missing validate="CssIdentifier" to blog_class_leading field

### DIFF
--- a/components/com_content/tmpl/category/blog.xml
+++ b/components/com_content/tmpl/category/blog.xml
@@ -184,6 +184,7 @@
 					label="JGLOBAL_BLOG_CLASS_LEADING"
 					useglobal="true"
 					size="3"
+					validate="CssIdentifier"
 				/>
 
 				<field

--- a/components/com_content/tmpl/featured/default.xml
+++ b/components/com_content/tmpl/featured/default.xml
@@ -43,6 +43,7 @@
 				label="JGLOBAL_BLOG_CLASS_LEADING"
 				useglobal="true"
 				size="3"
+				validate="CssIdentifier"
 			/>
 
 			<field


### PR DESCRIPTION
References https://github.com/joomla/joomla-cms/pull/29108

# Summary of Changes
- See code change tabulator above ("Changed files").

### Testing Instructions
- Apply patch.
- Enter an invalid CSS selector class for "Blog Class (Leading Articles)" in a featured menu item.
- Addition: ...or in a blog menu item.
- See that saving of menu item is blocked.
- Enter a valid selector.
- See that saving is not blocked.
