### PR TITLE
[4.0] Revert ajax login message

### DIFF
--- a/administrator/templates/atum/login.php
+++ b/administrator/templates/atum/login.php
@@ -69,8 +69,6 @@ HTMLHelper::_('atum.rootcolors', $this->params);
 
 // Add cookie alert message
 Text::script('JGLOBAL_WARNCOOKIES');
-// Add generic AJAX error message
-Text::script('JLIB_JS_AJAX_ERROR_OTHER');
 ?>
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">


### PR DESCRIPTION
This PR removes the loading of a text string for ajax in the admin login page that was added in #30909 as it is no longer needed as the ajax login functionality was removed #29571 