### PR TITLE
[4.0] Ensure images are cleaned up after tests are run

### DIFF
--- a/tests/Unit/Libraries/Cms/Image/ImageTest.php
+++ b/tests/Unit/Libraries/Cms/Image/ImageTest.php
@@ -66,6 +66,24 @@ class ImageTest extends UnitTestCase
 	}
 
 	/**
+	 * This method is called after a test is executed.
+	 *
+	 * @return  void
+	 *
+	 * @since   4.0.0
+	 */
+	protected function tearDown():void
+	{
+		unlink($this->testFile);
+		unlink($this->testFileGif);
+		unlink($this->testFilePng);
+		unlink($this->testFileBmp);
+		unlink($this->testFileWebp);
+
+		parent::tearDown();
+	}
+
+	/**
 	 * Data for Joomla\CMS\Image\Image::prepareDimensions method.
 	 *
 	 * Don't put percentages in here.  We test elsewhere that percentages get sanitized into


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Currently images are not being correctly cleaned up after tests are being run. You can simulate this by running the J4 test suite locally and you'll see there are a tonne of image files left with the format `tests/unit/Libraries/Cms/Image/tmp/koala-BLAH`

This cleans them up

### Testing Instructions
Check travis still passes. Test locally too if you feel confident

### Documentation Changes Required
N/A
