### PR TITLE
[4.0] fix obsolete underlined whitespace in link

### DIFF
--- a/administrator/components/com_menus/tmpl/items/modal.php
+++ b/administrator/components/com_menus/tmpl/items/modal.php
@@ -114,8 +114,7 @@ if (!empty($editor))
 							<?php echo $prefix; ?>
 							<?php if (!$uselessMenuItem) : ?>
 								<a class="select-link" href="javascript:void(0)" data-function="<?php echo $this->escape($function); ?>" data-id="<?php echo $item->id; ?>" data-title="<?php echo $this->escape($item->title); ?>" data-uri="<?php echo 'index.php?Itemid=' . $item->id; ?>" data-language="<?php echo $this->escape($language); ?>">
-									<?php echo $this->escape($item->title); ?>
-								</a>
+									<?php echo $this->escape($item->title); ?></a>
 							<?php else : ?>
 								<?php echo $this->escape($item->title); ?>
 							<?php endif; ?>


### PR DESCRIPTION
Pull Request for Issue #31466 .

### Summary of Changes

This PR will fix the obsolete underlined space in the menu item link when selecting one on creation of a menu item alias. 
The same solution is applied as used on the com_menus/items

https://github.com/joomla/joomla-cms/blob/bfe4fc6aea2afb77d64c7e99e8306bb49c1004a0/administrator/components/com_menus/views/items/tmpl/default.php#L188-L189

### Testing Instructions

- Joomla 4.0-dev with at least one configured menu item.
- Create a new menu item of type `System Links > Menu Item Alias`
- Press button `Select` on field = _Menu Item_
- A modal popup appears where you can select a menu item
- See the result and compare it with _BEFORE_
- apply this pr and repeat the steps above
- See the result and compare it with _ATER_

### Actual result BEFORE applying this Pull Request

![Schermafbeelding 2020-11-24 om 13 37 53](https://user-images.githubusercontent.com/639822/100095119-50a72e00-2e5a-11eb-8d29-8ca1f6777ec3.png)


### Expected result AFTER applying this Pull Request

![Schermafbeelding 2020-11-24 om 13 55 44](https://user-images.githubusercontent.com/639822/100097383-ca401b80-2e5c-11eb-8d43-57412fbef8de.png)


### Documentation Changes Required

