### PR TITLE
[4.0] menu items modal

### DIFF
--- a/administrator/components/com_menus/tmpl/items/modal.php
+++ b/administrator/components/com_menus/tmpl/items/modal.php
@@ -113,9 +113,13 @@ if (!empty($editor))
 							<?php $prefix = LayoutHelper::render('joomla.html.treeprefix', array('level' => $item->level)); ?>
 							<?php echo $prefix; ?>
 							<?php if (!$uselessMenuItem) : ?>
-								<a class="select-link" href="javascript:void(0)" data-function="<?php echo $this->escape($function); ?>" data-id="<?php echo $item->id; ?>" data-title="<?php echo $this->escape($item->title); ?>" data-uri="<?php echo 'index.php?Itemid=' . $item->id; ?>" data-language="<?php echo $this->escape($language); ?>">
-									<?php echo $this->escape($item->title); ?>
-								</a>
+								<a class="select-link" href="javascript:void(0)"
+									data-function="<?php echo $this->escape($function); ?>"
+									data-id="<?php echo $item->id; ?>"
+									data-title="<?php echo $this->escape($item->title); ?>"
+									data-uri="<?php echo 'index.php?Itemid=' . $item->id; ?>"
+									data-language="<?php echo $this->escape($language); ?>">
+									<?php echo $this->escape($item->title); ?></a>
 							<?php else : ?>
 								<?php echo $this->escape($item->title); ?>
 							<?php endif; ?>


### PR DESCRIPTION
Pull Request for Issue #31466 .

### Summary of Changes
removes the empty space between the title and the closing `<\a>`


### Testing Instructions
Steps to reproduce:

Create a new menu item of type = System Links > Menu Item Alias
Press the button Select on Menu Item
A modal popup appears listinig the menu items


### Actual result BEFORE applying this Pull Request
space after the text but part of the link


### Expected result AFTER applying this Pull Request
space after the link and before the alias


### Documentation Changes Required

