### PR TITLE
Start reordering with 1 instead of 0

### DIFF
--- a/build/media_source/system/js/draggable.es6.js
+++ b/build/media_source/system/js/draggable.es6.js
@@ -63,7 +63,7 @@ document.addEventListener('DOMContentLoaded', () => {
       // Get the order array
       for (i = 0, l = rows.length; l > i; i += 1) {
         rows[i].value = i + 1;
-        result.push(`order[]=${encodeURIComponent(i)}`);
+        result.push(`order[]=${encodeURIComponent(rows[i].value)}`);
         result.push(`cid[]=${encodeURIComponent(inputRows[i].value)}`);
       }
 


### PR DESCRIPTION
Pull Request for Issue #24008 .

### Summary of Changes
Starts the ordering with 1 instead of 0, this allows to use getNextOrder in table store function for new items. This is used in com_modules.

Thx to @bembelimen for helping to find and fixing this issue.


### Testing Instructions
* npm ci
* Test ordering in com_modules
* Test ordering in any other component


### Actual result BEFORE applying this Pull Request

* com modules ordering does strange things
* other components are working fine


### Expected result AFTER applying this Pull Request

* all components including com_modules are working fine


### Documentation Changes Required
N/A
