### PR TITLE
[4.0][RFC] Fix CSP and apply deferred attribute to all scripts (with exceptions)

### DIFF
--- a/administrator/templates/atum/component.php
+++ b/administrator/templates/atum/component.php
@@ -33,7 +33,9 @@ $this->addHeadLink(HTMLHelper::_('image', 'joomla-favicon-pinned.svg', '', [], t
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
-	<jdoc:include type="head" />
+	<jdoc:include type="metas" />
+	<jdoc:include type="styles" />
+	<jdoc:include type="scripts" />
 </head>
 <body class="contentpane component">
 	<jdoc:include type="message" />

--- a/administrator/templates/atum/error_full.php
+++ b/administrator/templates/atum/error_full.php
@@ -82,6 +82,7 @@ HTMLHelper::_('atum.rootcolors', $this->params);
 <head>
 	<jdoc:include type="metas" />
 	<jdoc:include type="styles" />
+	<jdoc:include type="scripts" />
 </head>
 
 <body class="admin <?php echo $option . ' view-' . $view . ' layout-' . $layout . ($task ? ' task-' . $task : '') . ($monochrome ? ' monochrome' : ''); ?>">
@@ -196,6 +197,5 @@ HTMLHelper::_('atum.rootcolors', $this->params);
 	</div>
 </div>
 <jdoc:include type="modules" name="debug" style="none" />
-<jdoc:include type="scripts" />
 </body>
 </html>

--- a/administrator/templates/atum/error_login.php
+++ b/administrator/templates/atum/error_login.php
@@ -85,6 +85,7 @@ HTMLHelper::_('atum.rootcolors', $this->params);
 <head>
 	<jdoc:include type="metas" />
 	<jdoc:include type="styles" />
+	<jdoc:include type="scripts" />
 </head>
 
 <body class="admin <?php echo $option . ' view-' . $view . ' layout-' . $layout . ($task ? ' task-' . $task : '') . ($monochrome ? ' monochrome' : ''); ?>">
@@ -168,6 +169,5 @@ HTMLHelper::_('atum.rootcolors', $this->params);
 	</div>
 </div>
 <jdoc:include type="modules" name="debug" style="none" />
-<jdoc:include type="scripts" />
 </body>
 </html>

--- a/administrator/templates/atum/index.php
+++ b/administrator/templates/atum/index.php
@@ -84,6 +84,7 @@ Text::script('TPL_ATUM_MORE_ELEMENTS');
 <head>
 	<jdoc:include type="metas" />
 	<jdoc:include type="styles" />
+	<jdoc:include type="scripts" />
 </head>
 
 <body class="admin <?php echo $option . ' view-' . $view . ' layout-' . $layout . ($task ? ' task-' . $task : '') . ($monochrome || $a11y_mono ? ' monochrome' : '') . ($a11y_contrast ? ' a11y_contrast' : '') . ($a11y_highlight ? ' a11y_highlight' : ''); ?>">
@@ -178,6 +179,5 @@ Text::script('TPL_ATUM_MORE_ELEMENTS');
 	</div>
 </div>
 <jdoc:include type="modules" name="debug" style="none" />
-<jdoc:include type="scripts" />
 </body>
 </html>

--- a/administrator/templates/atum/login.php
+++ b/administrator/templates/atum/login.php
@@ -80,6 +80,7 @@ Text::script('JGLOBAL_WARNCOOKIES');
 <head>
 	<jdoc:include type="metas" />
 	<jdoc:include type="styles" />
+	<jdoc:include type="scripts" />
 </head>
 
 <body class="admin <?php echo $option . ' view-' . $view . ' layout-' . $layout . ($task ? ' task-' . $task : '') . ($monochrome ? ' monochrome' : ''); ?>">
@@ -140,6 +141,5 @@ Text::script('JGLOBAL_WARNCOOKIES');
 	</div>
 </div>
 <jdoc:include type="modules" name="debug" style="none" />
-<jdoc:include type="scripts" />
 </body>
 </html>

--- a/build/build-modules-js/settings.json
+++ b/build/build-modules-js/settings.json
@@ -82,7 +82,8 @@
             "type": "script",
             "uri": "bootstrap.min.js",
             "dependencies": [
-              "jquery"
+              "jquery",
+              "jquery-noconflict"
             ]
           },
           {
@@ -90,7 +91,8 @@
             "type": "script",
             "uri": "bootstrap.bundle.min.js",
             "dependencies": [
-              "jquery"
+              "jquery",
+              "jquery-noconflict"
             ]
           }
         ],
@@ -418,7 +420,8 @@
             "type": "script",
             "uri": "jquery.minicolors.min.js",
             "dependencies": [
-              "jquery"
+              "jquery",
+              "jquery-noconflict"
             ],
             "attributes": {
               "defer": true
@@ -434,7 +437,8 @@
           }
         ],
         "dependencies": [
-          "jquery"
+          "jquery",
+          "jquery-noconflict"
         ],
         "licenseFilename": "LICENSE.md"
       },
@@ -478,7 +482,8 @@
             "type": "script",
             "uri": "chosen.jquery.js",
             "dependencies": [
-              "jquery"
+              "jquery",
+              "jquery-noconflict"
             ]
           },
           {

--- a/build/media_source/com_associations/joomla.asset.json
+++ b/build/media_source/com_associations/joomla.asset.json
@@ -49,7 +49,8 @@
       "uri": "com_associations/sidebyside.min.js",
       "dependencies": [
         "core",
-        "jquery"
+        "jquery",
+        "jquery-noconflict"
       ],
       "attributes": {
         "defer": true

--- a/build/media_source/com_finder/joomla.asset.json
+++ b/build/media_source/com_finder/joomla.asset.json
@@ -43,7 +43,8 @@
       "uri": "com_finder/finder-edit.min.js",
       "dependencies": [
         "core",
-        "jquery"
+        "jquery",
+        "jquery-noconflict"
       ],
       "attributes": {
         "defer": true
@@ -55,7 +56,8 @@
       "uri": "com_finder/index.min.js",
       "dependencies": [
         "core",
-        "jquery"
+        "jquery",
+        "jquery-noconflict"
       ],
       "attributes": {
         "defer": true

--- a/build/media_source/com_joomlaupdate/joomla.asset.json
+++ b/build/media_source/com_joomlaupdate/joomla.asset.json
@@ -45,6 +45,7 @@
       "dependencies": [
         "core",
         "jquery",
+        "jquery-noconflict",
         "com_joomlaupdate.encryption"
       ],
       "attributes": {

--- a/build/media_source/com_menus/joomla.asset.json
+++ b/build/media_source/com_menus/joomla.asset.json
@@ -76,7 +76,8 @@
       "uri": "com_menus/admin-menus-default.min.js",
       "dependencies": [
         "core",
-        "jquery"
+        "jquery",
+        "jquery-noconflict"
       ],
       "attributes": {
         "defer": true

--- a/build/media_source/legacy/joomla.asset.json
+++ b/build/media_source/legacy/joomla.asset.json
@@ -22,7 +22,8 @@
       "name": "joomla.frontediting",
       "type": "script",
       "dependencies": [
-        "jquery"
+        "jquery",
+        "jquery-noconflict"
       ],
       "uri": "legacy/frontediting.min.js",
       "attributes": {
@@ -41,7 +42,8 @@
       "name": "joomla.treeselectmenu",
       "type": "script",
       "dependencies": [
-        "jquery"
+        "jquery",
+        "jquery-noconflict"
       ],
       "uri": "legacy/treeselectmenu.min.js",
       "attributes": {

--- a/libraries/src/Document/Document.php
+++ b/libraries/src/Document/Document.php
@@ -534,6 +534,14 @@ class Document
 			$attribs['type'] = 'text/javascript';
 		}
 
+		// Default to defer.
+		if ((!isset($attribs['type']) || $attribs['type'] !== 'module')
+			&& (!isset($attribs['defer']) || $attribs['defer'] !== false)
+			&& !isset($attribs['async']))
+		{
+			$attribs['defer'] = '';
+		}
+
 		$this->_scripts[$url]            = isset($this->_scripts[$url]) ? array_replace($this->_scripts[$url], $attribs) : $attribs;
 		$this->_scripts[$url]['options'] = isset($this->_scripts[$url]['options']) ? array_replace($this->_scripts[$url]['options'], $options) : $options;
 

--- a/libraries/src/Document/HtmlDocument.php
+++ b/libraries/src/Document/HtmlDocument.php
@@ -34,7 +34,7 @@ class HtmlDocument extends Document
 	 * @var    array
 	 * @since  1.7.0
 	 */
-	public $_links = array();
+	public $_links = [];
 
 	/**
 	 * Array of custom tags
@@ -42,7 +42,7 @@ class HtmlDocument extends Document
 	 * @var    array
 	 * @since  1.7.0
 	 */
-	public $_custom = array();
+	public $_custom = [];
 
 	/**
 	 * Name of the template
@@ -98,7 +98,7 @@ class HtmlDocument extends Document
 	 * @var    array
 	 * @since  1.7.0
 	 */
-	protected $_template_tags = array();
+	protected $_template_tags = [];
 
 	/**
 	 * Integer with caching setting
@@ -123,7 +123,7 @@ class HtmlDocument extends Document
 	 *
 	 * @since   1.7.0
 	 */
-	public function __construct($options = array())
+	public function __construct($options = [])
 	{
 		parent::__construct($options);
 
@@ -143,7 +143,7 @@ class HtmlDocument extends Document
 	 */
 	public function getHeadData()
 	{
-		$data = array();
+		$data = [];
 		$data['title']         = $this->title;
 		$data['description']   = $this->description;
 		$data['link']          = $this->link;
@@ -203,14 +203,14 @@ class HtmlDocument extends Document
 			$this->title         = '';
 			$this->description   = '';
 			$this->link          = '';
-			$this->_metaTags     = array();
-			$this->_links        = array();
-			$this->_styleSheets  = array();
-			$this->_style        = array();
-			$this->_scripts      = array();
-			$this->_script       = array();
-			$this->_custom       = array();
-			$this->scriptOptions = array();
+			$this->_metaTags     = [];
+			$this->_links        = [];
+			$this->_styleSheets  = [];
+			$this->_style        = [];
+			$this->_scripts      = [];
+			$this->_script       = [];
+			$this->_custom       = [];
+			$this->scriptOptions = [];
 		}
 
 		if (\is_array($types))
@@ -256,11 +256,11 @@ class HtmlDocument extends Document
 			case 'script':
 			case 'custom':
 				$realType = '_' . $type;
-				$this->{$realType} = array();
+				$this->{$realType} = [];
 				break;
 
 			case 'scriptOptions':
-				$this->{$type} = array();
+				$this->{$type} = [];
 				break;
 		}
 	}
@@ -325,7 +325,7 @@ class HtmlDocument extends Document
 	 *
 	 * @param   array  $data  The document head data in array form
 	 *
-	 * @return  HtmlDocument|null instance of $this to allow chaining or null for empty input data
+	 * @return  HtmlDocument|void instance of $this to allow chaining or null for empty input data
 	 *
 	 * @since   1.7.0
 	 */
@@ -451,7 +451,7 @@ class HtmlDocument extends Document
 	 *
 	 * @since   1.7.0
 	 */
-	public function addHeadLink($href, $relation, $relType = 'rel', $attribs = array())
+	public function addHeadLink($href, $relation, $relType = 'rel', $attribs = [])
 	{
 		$this->_links[$href]['relation'] = $relation;
 		$this->_links[$href]['relType'] = $relType;
@@ -539,7 +539,7 @@ class HtmlDocument extends Document
 	 *
 	 * @since   1.7.0
 	 */
-	public function getBuffer($type = null, $name = null, $attribs = array())
+	public function getBuffer($type = null, $name = null, $attribs = [])
 	{
 		// If no type is specified, return the whole buffer
 		if ($type === null)
@@ -569,7 +569,7 @@ class HtmlDocument extends Document
 			}
 			else
 			{
-				$options = array();
+				$options = [];
 				$options['nopathway'] = 1;
 				$options['nomodules'] = 1;
 				$options['modulemode'] = 1;
@@ -602,13 +602,13 @@ class HtmlDocument extends Document
 	 *
 	 * @since   1.7.0
 	 */
-	public function setBuffer($content, $options = array())
+	public function setBuffer($content, $options = [])
 	{
 		// The following code is just for backward compatibility.
 		if (\func_num_args() > 1 && !\is_array($options))
 		{
 			$args = \func_get_args();
-			$options = array();
+			$options = [];
 			$options['type'] = $args[1];
 			$options['name'] = $args[2] ?? null;
 			$options['title'] = $args[3] ?? null;
@@ -628,7 +628,7 @@ class HtmlDocument extends Document
 	 *
 	 * @since   1.7.0
 	 */
-	public function parse($params = array())
+	public function parse($params = [])
 	{
 		return $this->_fetchTemplate($params)->_parseTemplate();
 	}
@@ -643,7 +643,7 @@ class HtmlDocument extends Document
 	 *
 	 * @since   1.7.0
 	 */
-	public function render($caching = false, $params = array())
+	public function render($caching = false, $params = [])
 	{
 		$this->_caching = $caching;
 
@@ -785,7 +785,7 @@ class HtmlDocument extends Document
 	 *
 	 * @since   1.7.0
 	 */
-	protected function _fetchTemplate($params = array())
+	protected function _fetchTemplate($params = [])
 	{
 		// Check
 		$directory = $params['directory'] ?? 'templates';
@@ -841,7 +841,7 @@ class HtmlDocument extends Document
 	 */
 	protected function _parseTemplate()
 	{
-		$matches = array();
+		$matches = [];
 
 		if (preg_match_all('#<jdoc:include\ type="([^"]+)"(.*)\/>#iU', $this->_template, $matches))
 		{
@@ -853,7 +853,7 @@ class HtmlDocument extends Document
 			for ($i = \count($matches[0]) - 1; $i >= 0; $i--)
 			{
 				$type = $matches[1][$i];
-				$attribs = empty($matches[2][$i]) ? array() : Utility::parseAttributes($matches[2][$i]);
+				$attribs = empty($matches[2][$i]) ? [] : Utility::parseAttributes($matches[2][$i]);
 				$name = $attribs['name'] ?? null;
 
 				// Separate buffers to be executed first and last

--- a/libraries/src/Document/Renderer/Html/ComponentRenderer.php
+++ b/libraries/src/Document/Renderer/Html/ComponentRenderer.php
@@ -11,6 +11,7 @@ namespace Joomla\CMS\Document\Renderer\Html;
 \defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Document\DocumentRenderer;
+use Joomla\CMS\Factory;
 
 /**
  * HTML document renderer for the component output
@@ -19,6 +20,8 @@ use Joomla\CMS\Document\DocumentRenderer;
  */
 class ComponentRenderer extends DocumentRenderer
 {
+	use FixAssets;
+
 	/**
 	 * Renders a component script and returns the results as a string
 	 *
@@ -30,8 +33,16 @@ class ComponentRenderer extends DocumentRenderer
 	 *
 	 * @since   3.5
 	 */
-	public function render($component = null, $params = array(), $content = null)
+	public function render($component = '', $params = array(), $content = '')
 	{
+		$app      = Factory::getApplication();
+		$template = $app->getTemplate(true);
+
+		if ($template->params->getBool('joomla_skip_assets_processing_components', true))
+		{
+			return $this->fixAssets($content);
+		}
+
 		return $content;
 	}
 }

--- a/libraries/src/Document/Renderer/Html/FixAssets.php
+++ b/libraries/src/Document/Renderer/Html/FixAssets.php
@@ -1,0 +1,227 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  Copyright (C) 2005 - 2020 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Document\Renderer\Html;
+
+use Joomla\CMS\Factory;
+
+\defined('JPATH_PLATFORM') or die;
+
+/**
+ * Trait that fixes assets
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+trait FixAssets
+{
+	/**
+	 * Function that will enforce nonce and defer to scripts to use the API.
+	 *
+	 * @param   string   $asset    The array of the html tags
+	 * @param   boolean  $inPlace  Flag to fix in place or not
+	 *
+	 * @return  string
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function fixAsset($asset, $inPlace = false)
+	{
+		$dom = new \DOMDocument;
+		$wa  = Factory::getDocument()->getWebAssetManager();
+
+		\libxml_use_internal_errors(true);
+		$dom->loadHtml($asset);
+		\libxml_clear_errors();
+
+		$script = $dom->getElementsByTagName('script')->item(0);
+		$style  = $dom->getElementsByTagName('style')->item(0);
+
+		// Case script
+		if ($script)
+		{
+			$src = $script->getAttribute('src');
+
+			if ($src)
+			{
+				$attrs = [];
+
+				for ($i = 0; $i < $script->attributes->length; ++$i)
+				{
+					$node = $script->attributes->item($i);
+
+					if ($node->nodeName !== 'src')
+					{
+						$attrs[$node->nodeName] = $node->nodeValue;
+					}
+				}
+
+				// Defer by default
+				if (!isset($attrs['defer']) && (!isset($attrs['type']) || $attrs['type'] !== 'module') && !isset($attrs['data-joomla-no-defer']))
+				{
+					$attrs['defer'] = '';
+				}
+
+				// Add missing nonce
+				if (!isset($attrs['nonce']))
+				{
+					$attrs['nonce'] = $this->_doc->nonce;
+				}
+
+				if (!$inPlace)
+				{
+					$wa->registerAndUseScript(
+						md5($src),
+						$src,
+						[],
+						$attrs
+					);
+
+					return '';
+				}
+
+				return $dom->saveXML();
+			}
+			else
+			{
+				$type = $script->getAttribute('type');
+				$noDefer = $script->hasAttribute('data-joomla-no-defer');
+
+				if ($noDefer || $type === 'module')
+				{
+					// Add missing nonce
+					if (!isset($attrs['nonce']))
+					{
+						$attrs['nonce'] = $this->_doc->nonce;
+					}
+
+					return $dom->saveXML();
+				}
+
+				// Add missing nonce
+				if (!isset($attrs['nonce']))
+				{
+					$attrs['nonce'] = $this->_doc->cspNonce;
+				}
+
+				if (in_array($type, ["application/javascript", "text/javascript", '']))
+				{
+					if (!$inPlace)
+					{
+						$wa->addInlineScript(
+							$script->nodeValue,
+							['name' => md5($script->nodeValue)],
+							[],
+							[]
+						);
+
+						return '';
+					}
+
+					return $dom->saveXML();
+				}
+			}
+
+			return '';
+		}
+
+		// Case inline style
+		if ($style)
+		{
+			// Add missing nonce
+			if (!isset($attrs['nonce']))
+			{
+				$attrs['nonce'] = $this->_doc->nonce;
+			}
+
+			if ($style->hasAttribute('data-joomla-no-defer'))
+			{
+				return $dom->saveXML();
+			}
+
+			if (!$inPlace)
+			{
+				$wa->addInlineStyle(
+					$style->nodeValue,
+					['name' => md5($style->nodeValue)],
+					[],
+					[]
+				);
+
+				return '';
+			}
+
+			return $dom->saveXML();
+		}
+	}
+
+	/**
+	 * Method that fixes the head assets inserted with addCustomTag
+	 *
+	 * @return void
+	 */
+	public function fixCustom()
+	{
+		foreach ($this->_doc->_custom as $id => $custom)
+		{
+			$result = $this->fixAsset($custom, false);
+
+			if (!$result)
+			{
+				// Remove from the array
+				unset($this->_doc->_custom[$id]);
+			}
+		}
+	}
+
+	/**
+	 * Method that fixes the static assets in an html fragment
+	 *
+	 * @param   string  $content  The html fragment
+	 *
+	 * @return string
+	 */
+	public function fixAssets($content)
+	{
+		preg_match_all('/<script(.|\s)*?<\/script>/i', $content, $scripts);
+		preg_match_all('/<style(.|\s)*?<\/style>/i', $content, $styles);
+
+		// Bail quickly
+		if (count($scripts[0]) === 0 && count($styles[0]) === 0)
+		{
+			return $content;
+		}
+
+		if (count($scripts[0]))
+		{
+			foreach ($scripts[0] as $script)
+			{
+				$newSrcipt = $this->fixAsset($script, true);
+
+				if ($newSrcipt !== '')
+				{
+					preg_replace($script, $newSrcipt, $content);
+				}
+			}
+		}
+
+		if (count($styles[0]))
+		{
+			foreach ($styles[0] as $style)
+			{
+				$newStyle = $this->fixAsset($style, true);
+
+				if ($newStyle !== '')
+				{
+					preg_replace($style, $newStyle, $content);
+				}
+			}
+		}
+
+		return $content;
+	}
+}

--- a/libraries/src/Document/Renderer/Html/HeadRenderer.php
+++ b/libraries/src/Document/Renderer/Html/HeadRenderer.php
@@ -30,13 +30,10 @@ class HeadRenderer extends DocumentRenderer
 	 *
 	 * @since   3.5
 	 */
-	public function render($head, $params = array(), $content = null)
+	public function render($head, $params = array(), $content = '')
 	{
-		$buffer  = '';
-		$buffer .= $this->_doc->loadRenderer('metas')->render($head, $params, $content);
-		$buffer .= $this->_doc->loadRenderer('styles')->render($head, $params, $content);
-		$buffer .= $this->_doc->loadRenderer('scripts')->render($head, $params, $content);
-
-		return $buffer;
+		return $this->_doc->loadRenderer('metas')->render($head, $params, $content) .
+			$this->_doc->loadRenderer('styles')->render($head, $params, $content) .
+			$this->_doc->loadRenderer('scripts')->render($head, $params, $content);
 	}
 }

--- a/libraries/src/Document/Renderer/Html/MessageRenderer.php
+++ b/libraries/src/Document/Renderer/Html/MessageRenderer.php
@@ -33,7 +33,7 @@ class MessageRenderer extends DocumentRenderer
 	 *
 	 * @since   3.5
 	 */
-	public function render($name, $params = array(), $content = null)
+	public function render($name, $params = [], $content = '')
 	{
 		$msgList     = $this->getData();
 		$displayData = array(
@@ -71,7 +71,7 @@ class MessageRenderer extends DocumentRenderer
 	private function getData()
 	{
 		// Initialise variables.
-		$lists = array();
+		$lists = [];
 
 		// Get the message queue
 		$messages = Factory::getApplication()->getMessageQueue();

--- a/libraries/src/Document/Renderer/Html/StylesRenderer.php
+++ b/libraries/src/Document/Renderer/Html/StylesRenderer.php
@@ -152,7 +152,6 @@ class StylesRenderer extends DocumentRenderer
 		{
 			$attribs     = $asset->getAttributes();
 			$version     = $asset->getVersion();
-			$conditional = $asset->getOption('conditional');
 
 			// Add an asset info for debugging
 			if (JDEBUG)
@@ -169,7 +168,6 @@ class StylesRenderer extends DocumentRenderer
 		{
 			$attribs     = $item;
 			$version     = isset($attribs['options']['version']) ? $attribs['options']['version'] : '';
-			$conditional = !empty($attribs['options']['conditional']) ? $attribs['options']['conditional'] : null;
 		}
 
 		// To prevent double rendering
@@ -183,12 +181,6 @@ class StylesRenderer extends DocumentRenderer
 
 		$buffer .= $tab;
 
-		// This is for IE conditional statements support.
-		if (!\is_null($conditional))
-		{
-			$buffer .= '<!--[if ' . $conditional . ']>';
-		}
-
 		// Avoid double rel="", StyleSheet can have only rel="stylesheet"
 		unset($attribs['rel']);
 
@@ -196,12 +188,6 @@ class StylesRenderer extends DocumentRenderer
 		$buffer .= '<link href="' . htmlspecialchars($src) . '" rel="stylesheet"';
 		$buffer .= $this->renderAttributes($attribs);
 		$buffer .= ' />';
-
-		// This is for IE conditional statements support.
-		if (!\is_null($conditional))
-		{
-			$buffer .= '<![endif]-->';
-		}
 
 		$buffer .= $lnEnd;
 

--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -782,7 +782,7 @@ abstract class HTMLHelper
 		{
 			if (\count($includes) === 0)
 			{
-				return;
+				return null;
 			}
 
 			if (\count($includes) === 1)

--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -206,7 +206,7 @@ class PlgSystemDebug extends CMSPlugin
 				'plg_system_debug/debug.min.js',
 				[],
 				['defer' => true],
-				['jquery']
+				['jquery', 'jquery-noconflict']
 			);
 		}
 
@@ -343,7 +343,7 @@ class PlgSystemDebug extends CMSPlugin
 			return;
 		}
 
-		echo str_replace('</body>', $debugBarRenderer->renderHead() . $debugBarRenderer->render() . '</body>', $contents);
+		echo str_replace('</head>', $debugBarRenderer->renderHead() . $debugBarRenderer->render() . '</head>', $contents);
 	}
 
 	/**

--- a/plugins/system/skipto/skipto.php
+++ b/plugins/system/skipto/skipto.php
@@ -85,7 +85,7 @@ class PlgSystemSkipto extends CMSPlugin
 				. 'window.SkipToConfig = Joomla.getOptions(\'skipto-settings\');'
 				. 'window.skipToMenuInit();});',
 				[],
-				['type' => 'module'],
+				[],
 				['skipto']
 			);
 	}


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
- Apply nonce to **all** inline scripts and styles
- Introduce the `type="module"` `nomodule` for scripts (eg load ES2015+ for new browsers or legacy js for old browsers)
- Defer all scripts (unless an attribute `data-joomla-no-defer` exists or the script has an attribute `async`, or an attribute `type=module` which is deferred by default)
- To defer the inline scripts the contents are base64 encoded and assigned to the `src` attribute, keep reading...
- This is fully backwards compatible!!!


### The CSP problem
First and mostly lets thank @zero-24 for implementing the endpoint and the headers part for CSP and @wilsonge adding the `nonce` attribute for the inline scripts/styles. That said the CSP, as is right now` is totally broken even when someone will use the Joomla API and here's the proof:
- add these lines into atum/cassiopeia index.php:

```php
$this->addCustomTag('<script>
if (window.jQuery) {
	console.log(\'hello\')
}
</script>');
$this->addCustomTag('<style>
:root {
    --atum-sidebar-bg: red;
}
</style>');
```
- The expectation is that since I'm using the API the style/script would have a `nonce` attribute but they don't and thus the CSP is BROKEN! To take this one step forward try to insert the following code into **any** layout (component/module/JLayout)
```html
<style>
:root {
    --atum-sidebar-bg: red;
}
</style>
<script>
if (window.jQuery) {
	console.log(\'hello\')
}
</script>
```
Once again the CSP is broken as there's no `nonce` attribute

- The proposed fix: regex sales/scripts in the component/modules renderers and apply the missing attribute `nonce`.


### The script defer
Some background (very brief) information on the scripts loading (read more on https://flaviocopes.com/javascript-async-defer/ )
- Joomla 3.x has all the scripts (appended using the API) in the head of the document resulting into blocking the parser:
![without-defer-async-head](https://user-images.githubusercontent.com/3889375/100247091-3fcde980-2f3a-11eb-94d4-c660d10cc5a1.png)

- Joomla 4.0 moved the code to the body end (breaking B/C and possibly any inline script that exists into any component/module content). Although it doesn't pause the parser it introduces another problem, scripts starts downloading late and maybe behind fetches for images and other not critical assets
![without-defer-async-body](https://user-images.githubusercontent.com/3889375/100247376-8facb080-2f3a-11eb-9f0c-b6f945895ac0.png)

- The proposed solution: defer all scripts but keep them in the head (or wherever the dev injected them)
![with-defer](https://user-images.githubusercontent.com/3889375/100247738-f16d1a80-2f3a-11eb-98ff-bcf26771453e.png)

The last one is not the first time tried for Joomla 4.0 (eg: https://github.com/joomla/joomla-cms/pull/22460 ) but that PR had side effects, notably the inline scripts inside any content area. So the solution is a two fold here, since fixing the CSP requires adding the nonce attribute we can add also a defer attribute. Unfortunately this **will not** work for inline scripts since the browsers behaviour (unless type=module) is to parse and execute immediately. We will bend things a bit here by appending the content of the inline script to the src attribute and to do that we will use the very well known/supported way of encoding the data: `$attribs['src'] = 'data:text/javascript;base64,' . base64_encode($content);`. That's it. Scripts get to load the new ES2015+ code for newer browsers, have a fallback for IE11 or other legacy, and the inline scripts are properly deferred.

### Things that need a decision
- The name of the attribute that will bail out from this behaviour (atm `data-joomla-no-defer`
- Shall the templates have the ability to skip the parsing of the components/modules for CSP/deferred scripts? atm I left a snippet there of what that could look like: 
```php
if ($template->params->getBool('joomla_skip_assets_processing_modules', true))
{
   $module->content = $this->fixAssets($content);
}
```

### Testing Instructions
Follow the description above

### Actual result BEFORE applying this Pull Request
Lighthouse really bad results


### Expected result AFTER applying this Pull Request
A bit better Lighthouse results, but there's a lot more work to get to the green fields...


@zero-24 since I know that you're in charge of the Lighthouse insights integration could you please ask Paul Irish to comment on this proposal?

### Documentation Changes Required

Probably
