### PR TITLE
[3.x] URL Invalid

### DIFF
--- a/libraries/src/Router/Router.php
+++ b/libraries/src/Router/Router.php
@@ -235,7 +235,7 @@ class Router
 		if (strlen($uri->getPath()) > 0 && array_key_exists('option', $vars)
 			&& ComponentHelper::getParams($vars['option'])->get('sef_advanced', 0))
 		{
-			throw new RouteNotFoundException('URL invalid');
+			throw new RouteNotFoundException(\JText::_('JERROR_PAGE_NOT_FOUND'));
 		}
 
 		return array_merge($this->getVars(), $vars);


### PR DESCRIPTION
PR for #30732

## Summary
make sure the modern router uses a translatable string for 404 pages

### Step 1
Make sure that you have SEF working
Make sure that you have modern routing enabled for com_content

### Step 3
Go to a non existent page on the frontend

The error message says 404 URL Invalid

![image](https://user-images.githubusercontent.com/1296369/100251706-f4fea280-2f36-11eb-80de-2f74c6a9b8a9.png)

### Step 4
Apply this pull request
Refresh the frontend

The error message says 404 page not found

![image](https://user-images.githubusercontent.com/1296369/100251629-e0baa580-2f36-11eb-859c-30b2f9a102cc.png)
