### PR TITLE
[4.0] Fix password hash comparison

### DIFF
--- a/libraries/src/User/UserHelper.php
+++ b/libraries/src/User/UserHelper.php
@@ -90,7 +90,7 @@ abstract class UserHelper
 
 	/**
 	 * B/C constant `PASSWORD_BCRYPT` for PHP < 7.4 (using integer)
-	 *	 *
+	 *
 	 * @var    integer
 	 * @since  4.0.0
 	 * @deprecated  4.0.0  Use self::HASH_BCRYPT instead

--- a/libraries/src/User/UserHelper.php
+++ b/libraries/src/User/UserHelper.php
@@ -52,7 +52,7 @@ abstract class UserHelper
 	 * B/C constant `PASSWORD_ARGON2I` for PHP < 7.4 (using integer)
 	 *
 	 * Note: PHP's native `PASSWORD_ARGON2I` constant is not used as PHP may be compiled without this constant
-	 *	 *
+	 *
 	 * @var    integer
 	 * @since  4.0.0
 	 * @deprecated 4.0.0  Use self::HASH_ARGON2I instead
@@ -73,7 +73,7 @@ abstract class UserHelper
 	 * B/C constant `PASSWORD_ARGON2ID` for PHP < 7.4 (using integer)
 	 *
 	 * Note: PHP's native `PASSWORD_ARGON2ID` constant is not used as PHP may be compiled without this constant
-	 *	 *
+	 *
 	 * @var    integer
 	 * @since  4.0.0
 	 * @deprecated  4.0.0  Use self::HASH_ARGON2ID instead

--- a/libraries/src/User/UserHelper.php
+++ b/libraries/src/User/UserHelper.php
@@ -43,46 +43,97 @@ abstract class UserHelper
 	 *
 	 * Note: PHP's native `PASSWORD_ARGON2I` constant is not used as PHP may be compiled without this constant
 	 *
-	 * @var    string|integer
+	 * @var    string
 	 * @since  4.0.0
 	 */
-	const HASH_ARGON2I = 2;
+	const HASH_ARGON2I = 'argon2i';
+
+	/**
+	 * B/C constant `PASSWORD_ARGON2I` for PHP < 7.4 (using integer)
+	 *
+	 * Note: PHP's native `PASSWORD_ARGON2I` constant is not used as PHP may be compiled without this constant
+	 *
+	 * @deprecated 4.0.0  Use self::HASH_ARGON2I instead
+	 *
+	 * @var    integer
+	 * @since  4.0.0
+	 */
+	const HASH_ARGON2I_BC = 2;
 
 	/**
 	 * Constant defining the Argon2id password algorithm for use with password hashes
 	 *
 	 * Note: PHP's native `PASSWORD_ARGON2ID` constant is not used as PHP may be compiled without this constant
 	 *
-	 * @var    string|integer
+	 * @var    string
 	 * @since  4.0.0
 	 */
-	const HASH_ARGON2ID = 3;
+	const HASH_ARGON2ID = 'argon2id';
+
+	/**
+	 * B/C constant `PASSWORD_ARGON2ID` for PHP < 7.4 (using integer)
+	 *
+	 * Note: PHP's native `PASSWORD_ARGON2ID` constant is not used as PHP may be compiled without this constant
+	 *
+	 * @deprecated 4.0.0  Use self::HASH_ARGON2ID instead
+	 *
+	 * @var    integer
+	 * @since  4.0.0
+	 */
+	const HASH_ARGON2ID_BC = 3;
 
 	/**
 	 * Constant defining the BCrypt password algorithm for use with password hashes
 	 *
-	 * @var    string|integer
+	 * @var    string
 	 * @since  4.0.0
 	 */
-	const HASH_BCRYPT = PASSWORD_BCRYPT;
+	const HASH_BCRYPT = '2y';
+
+	/**
+	 * B/C constant `PASSWORD_BCRYPT` for PHP < 7.4 (using integer)
+	 *
+	 * @deprecated 4.0.0  Use self::HASH_BCRYPT instead
+	 *
+	 * @var    integer
+	 * @since  4.0.0
+	 */
+	const HASH_BCRYPT_BC = 1;
 
 	/**
 	 * Constant defining the MD5 password algorithm for use with password hashes
 	 *
-	 * @var    integer
+	 * @var    string
 	 * @since  4.0.0
 	 * @deprecated  5.0  Support for MD5 hashed passwords will be removed
 	 */
-	const HASH_MD5 = 100;
+	const HASH_MD5 = 'md5';
 
 	/**
 	 * Constant defining the PHPass password algorithm for use with password hashes
 	 *
-	 * @var    integer
+	 * @var    string
 	 * @since  4.0.0
 	 * @deprecated  5.0  Support for PHPass hashed passwords will be removed
 	 */
-	const HASH_PHPASS = 101;
+	const HASH_PHPASS = 'phpass';
+
+	/**
+	 * Mapping array for the algorithm handler
+	 *
+	 * @var array
+	 * @since  4.0.0
+	 */
+	const HASH_ALGORITHMS = [
+		self::HASH_ARGON2I => Argon2iHandler::class,
+		self::HASH_ARGON2I_BC => Argon2iHandler::class,
+		self::HASH_ARGON2ID => Argon2idHandler::class,
+		self::HASH_ARGON2ID_BC => Argon2idHandler::class,
+		self::HASH_BCRYPT => BCryptHandler::class,
+		self::HASH_BCRYPT_BC => BCryptHandler::class,
+		self::HASH_MD5 => MD5Handler::class,
+		self::HASH_PHPASS => PHPassHandler::class
+	];
 
 	/**
 	 * Method to add a user to a group.
@@ -389,23 +440,10 @@ abstract class UserHelper
 			return $container->get($algorithm)->hashPassword($password, $options);
 		}
 
-		// Try a known handler next
-		switch ($algorithm)
+		// Try to load handler
+		if (isset(self::HASH_ALGORITHMS[$algorithm]))
 		{
-			case self::HASH_ARGON2I :
-				return $container->get(Argon2iHandler::class)->hashPassword($password, $options);
-
-			case self::HASH_ARGON2ID :
-				return $container->get(Argon2idHandler::class)->hashPassword($password, $options);
-
-			case self::HASH_BCRYPT :
-				return $container->get(BCryptHandler::class)->hashPassword($password, $options);
-
-			case self::HASH_MD5 :
-				return $container->get(MD5Handler::class)->hashPassword($password, $options);
-
-			case self::HASH_PHPASS :
-				return $container->get(PHPassHandler::class)->hashPassword($password, $options);
+			return $container->get(self::HASH_ALGORITHMS[$algorithm])->hashPassword($password, $options);
 		}
 
 		// Unsupported algorithm, sorry!

--- a/libraries/src/User/UserHelper.php
+++ b/libraries/src/User/UserHelper.php
@@ -52,11 +52,10 @@ abstract class UserHelper
 	 * B/C constant `PASSWORD_ARGON2I` for PHP < 7.4 (using integer)
 	 *
 	 * Note: PHP's native `PASSWORD_ARGON2I` constant is not used as PHP may be compiled without this constant
-	 *
-	 * @deprecated 4.0.0  Use self::HASH_ARGON2I instead
-	 *
+	 *	 *
 	 * @var    integer
 	 * @since  4.0.0
+	 * @deprecated 4.0.0  Use self::HASH_ARGON2I instead
 	 */
 	const HASH_ARGON2I_BC = 2;
 
@@ -74,11 +73,10 @@ abstract class UserHelper
 	 * B/C constant `PASSWORD_ARGON2ID` for PHP < 7.4 (using integer)
 	 *
 	 * Note: PHP's native `PASSWORD_ARGON2ID` constant is not used as PHP may be compiled without this constant
-	 *
-	 * @deprecated 4.0.0  Use self::HASH_ARGON2ID instead
-	 *
+	 *	 *
 	 * @var    integer
 	 * @since  4.0.0
+	 * @deprecated  4.0.0  Use self::HASH_ARGON2ID instead
 	 */
 	const HASH_ARGON2ID_BC = 3;
 
@@ -92,11 +90,10 @@ abstract class UserHelper
 
 	/**
 	 * B/C constant `PASSWORD_BCRYPT` for PHP < 7.4 (using integer)
-	 *
-	 * @deprecated 4.0.0  Use self::HASH_BCRYPT instead
-	 *
+	 *	 *
 	 * @var    integer
 	 * @since  4.0.0
+	 * @deprecated  4.0.0  Use self::HASH_BCRYPT instead
 	 */
 	const HASH_BCRYPT_BC = 1;
 


### PR DESCRIPTION
Pull Request for Issue #31176 .

### Summary of Changes
This PR fixes the weak comparison for the password hashing handler.

@HLeithner and me tried to fix the wrong usage of the switch statement mentioned here: https://github.com/joomla/joomla-cms/issues/31176#issuecomment-713536433


### Testing Instructions
Register a user without libsodium installed.


### Actual result BEFORE applying this Pull Request
See: https://github.com/joomla/joomla-cms/issues/31176#issuecomment-713103641


### Expected result AFTER applying this Pull Request
User is registered and BCryprt is used.


### Documentation Changes Required

