### PR TITLE
[4.0] Information link -contrast [a11y]

### DIFF
--- a/administrator/language/en-GB/com_installer.ini
+++ b/administrator/language/en-GB/com_installer.ini
@@ -167,7 +167,7 @@ COM_INSTALLER_MSG_UPDATESITES_REBUILD_SUCCESS="Update sites have been rebuilt fr
 COM_INSTALLER_MSG_UPDATESITES_REBUILD_WARNING="Update sites have been rebuilt. No extension with updates sites discovered."
 COM_INSTALLER_MSG_WARNING_NO_LANGUAGES_UPDATESERVER="The update table is not up to date. Please <a href=\"index.php?option=com_installer&view=updatesites\">rebuild your update server table</a>"
 COM_INSTALLER_MSG_WARNINGFURTHERINFO="Further information on warnings"
-COM_INSTALLER_MSG_WARNINGFURTHERINFODESC="For more information see the <a href=\"https://docs.joomla.org\" target=\"_blank\">Joomla! Documentation Site</a>."
+COM_INSTALLER_MSG_WARNINGFURTHERINFODESC="For more information see the <a href=\"https://docs.joomla.org\" target=\"_blank\" class=\"alert-link\">Joomla! Documentation Site</a>."
 COM_INSTALLER_MSG_WARNINGS_FILEUPLOADISDISABLEDDESC="File uploads are required to upload extensions with the installer."
 COM_INSTALLER_MSG_WARNINGS_FILEUPLOADSDISABLED="File uploads disabled."
 COM_INSTALLER_MSG_WARNINGS_JOOMLATMPNOTSET="The Joomla temporary folder is not set."


### PR DESCRIPTION
This fixes a colour contrast accessibility failure by applying the already existing class that was created for this purpose.
![image](https://user-images.githubusercontent.com/1296369/100394807-62ddc380-3036-11eb-926c-05506ef61318.png)

cc @carcam 