### PR TITLE
[4.0] Fix for Lazyloading bad url

### DIFF
--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -742,19 +742,24 @@ abstract class HTMLHelper
 	{
 		$returnPath = (int) $returnPath;
 
+		if (strpos($file, '?') !== false)
+		{
+			$file = (static::cleanImageURL($file))->url;
+		}
+
 		if ($returnPath !== -1)
 		{
-			$includes = static::includeRelativeFiles('images', (self::cleanImageURL($file))->url, $relative, false, false);
+			$includes = static::includeRelativeFiles('images', $file, $relative, false, false);
 			$file = \count($includes) ? $includes[0] : null;
 		}
 
 		// If only path is required
 		if ($returnPath === 1)
 		{
-			return (self::cleanImageURL($file))->url;
+			return $file;
 		}
 
-		return '<img src="' . (self::cleanImageURL($file))->url . '" alt="' . $alt . '" ' . trim((\is_array($attribs) ? ArrayHelper::toString($attribs) : $attribs)) . '>';
+		return '<img src="' . $file . '" alt="' . $alt . '" ' . trim((\is_array($attribs) ? ArrayHelper::toString($attribs) : $attribs)) . '>';
 	}
 
 	/**

--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -684,6 +684,7 @@ abstract class HTMLHelper
 			return $obj;
 		}
 
+		$url    = preg_replace('#&amp;#', '&', $url);
 		$pieces = explode('?', $url);
 
 		parse_str($pieces[1], $urlParams);
@@ -743,17 +744,17 @@ abstract class HTMLHelper
 
 		if ($returnPath !== -1)
 		{
-			$includes = static::includeRelativeFiles('images', $file, $relative, false, false);
+			$includes = static::includeRelativeFiles('images', (self::cleanImageURL($file))->url, $relative, false, false);
 			$file = \count($includes) ? $includes[0] : null;
 		}
 
 		// If only path is required
 		if ($returnPath === 1)
 		{
-			return $file;
+			return (self::cleanImageURL($file))->url;
 		}
 
-		return '<img src="' . $file . '" alt="' . $alt . '" ' . trim((\is_array($attribs) ? ArrayHelper::toString($attribs) : $attribs)) . '>';
+		return '<img src="' . (self::cleanImageURL($file))->url . '" alt="' . $alt . '" ' . trim((\is_array($attribs) ? ArrayHelper::toString($attribs) : $attribs)) . '>';
 	}
 
 	/**

--- a/templates/cassiopeia/offline.php
+++ b/templates/cassiopeia/offline.php
@@ -70,8 +70,8 @@ else
 			<?php else : ?>
 				<h1><?php echo $sitename; ?></h1>
 			<?php endif; ?>
-			<?php if ($app->get('offline_image') && file_exists($app->get('offline_image'))) : ?>
-				<img src="<?php echo $app->get('offline_image'); ?>" alt="<?php echo $sitename; ?>">
+			<?php if ($app->get('offline_image')) : ?>
+				<?php echo HTMLHelper::_('image', $app->get('offline_image'), $sitename, [], false, 0); ?>
 			<?php endif; ?>
 			<?php if ($app->get('display_offline_message', 1) == 1 && str_replace(' ', '', $app->get('offline_message')) != '') : ?>
 				<p><?php echo $app->get('offline_message'); ?></p>


### PR DESCRIPTION
Pull Request for Issue #31509 .

### Summary of Changes
Fixing bad URL (front end links replace `&` with `&amp;`, my bad never tested that case 

### Testing Instructions
Try to add an image to a menuItem or to the offline page.


### Expected == Actual result 

The image is selected and the image name is stored in the parameter images.


### Documentation Changes Required


@wilsonge just FWIW the new URL with the extra 2 params will always fail for code like: `<?php if ($app->get('offline_image') && file_exists($app->get('offline_image'))) : ?>` (interpreting the URL as a file path). I think this is something that needs to be communicated. (it's not that bad, removing the `file_exists`, will get you back to 100% compatibility, eg a URL with the extra params that works fine but a better and safer way out is to use the `HTMLHelper::image` as the tag will be inserted only if the file exists).
