### PR TITLE
Update of joomla-framework/archive

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require": {
         "php": ">=5.3.10",
         "joomla/application": "~1.9",
-        "joomla/archive": "^1.1.7",
+        "joomla/archive": "dev-master",
         "joomla/data": "~1.2",
         "joomla/di": "~1.5",
         "joomla/event": "~1.2",

--- a/libraries/joomla/archive/zip.php
+++ b/libraries/joomla/archive/zip.php
@@ -305,15 +305,12 @@ class JArchiveZip implements JArchiveExtractable
 				continue;
 			}
 
-			$stream = $zip->getStream($file);
+			$buffer = $zip->getFromIndex($index);
 
-			if ($stream === false)
+			if ($buffer === false)
 			{
 				return $this->raiseWarning(100, 'Unable to read entry');
 			}
-
-			$buffer = stream_get_contents($stream);
-			fclose($stream);
 
 			if (JFile::write($destination . '/' . $file, $buffer) === false)
 			{

--- a/libraries/vendor/joomla/archive/src/Zip.php
+++ b/libraries/vendor/joomla/archive/src/Zip.php
@@ -270,8 +270,8 @@ class Zip implements ExtractableInterface
 	 *
 	 * @return  boolean  True on success
 	 *
-	 * @since   1.0
 	 * @throws  \RuntimeException
+	 * @since   1.0
 	 */
 	protected function extractNative($archive, $destination)
 	{
@@ -285,7 +285,7 @@ class Zip implements ExtractableInterface
 		// Make sure the destination folder exists
 		if (!Folder::create($destination))
 		{
-			throw new \RuntimeException('Unable to create destination folder ' . \dirname($path));
+			throw new \RuntimeException('Unable to create destination folder ' . \dirname($destination));
 		}
 
 		// Read files in the archive
@@ -298,15 +298,12 @@ class Zip implements ExtractableInterface
 				continue;
 			}
 
-			$stream = $zip->getStream($file);
+			$buffer = $zip->getFromIndex($index);
 
-			if ($stream === false)
+			if ($buffer === false)
 			{
 				throw new \RuntimeException('Unable to read ZIP entry');
 			}
-
-			$buffer = stream_get_contents($stream);
-			fclose($stream);
 
 			if (File::write($destination . '/' . $file, $buffer) === false)
 			{


### PR DESCRIPTION
Pull Request for Issue #31506.

### Summary of Changes

For zip files, load the buffer directly instead of utilising the stream.

### Testing Instructions

Install an extension that contains zip files in the zip archive without increasing the max execution time..

### Actual result BEFORE applying this Pull Request

You'll get an error like
*Gateway Timeout - The gateway did not receive a timely response from the upstream server or application.*
because of the timeout.

### Expected result AFTER applying this Pull Request

Installation works as it should.

### Documentation Changes Required

No.