### PR TITLE
[31506] Solved performance issue with zip archives containing zip files

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -187,16 +187,16 @@
         },
         {
             "name": "joomla/archive",
-            "version": "1.1.7",
+            "version": "1.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-framework/archive.git",
-                "reference": "185be301bae7cb6479a1e755944a68d52870e9fe"
+                "reference": "3753805379a764fa96fd3db7e3b6218760d169ac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/archive/zipball/185be301bae7cb6479a1e755944a68d52870e9fe",
-                "reference": "185be301bae7cb6479a1e755944a68d52870e9fe",
+                "url": "https://api.github.com/repos/joomla-framework/archive/zipball/3753805379a764fa96fd3db7e3b6218760d169ac",
+                "reference": "3753805379a764fa96fd3db7e3b6218760d169ac",
                 "shasum": ""
             },
             "require": {
@@ -235,7 +235,17 @@
                 "framework",
                 "joomla"
             ],
-            "time": "2020-11-14T17:40:00+00:00"
+            "funding": [
+                {
+                    "url": "https://community.joomla.org/sponsorship-campaigns.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/joomla",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-27T23:24:42+00:00"
         },
         {
             "name": "joomla/compat",

--- a/libraries/joomla/archive/zip.php
+++ b/libraries/joomla/archive/zip.php
@@ -305,15 +305,12 @@ class JArchiveZip implements JArchiveExtractable
 				continue;
 			}
 
-			$stream = $zip->getStream($file);
+			$buffer = $zip->getFromIndex($index);
 
-			if ($stream === false)
+			if ($buffer === false)
 			{
 				return $this->raiseWarning(100, 'Unable to read entry');
 			}
-
-			$buffer = stream_get_contents($stream);
-			fclose($stream);
 
 			if (JFile::write($destination . '/' . $file, $buffer) === false)
 			{

--- a/libraries/vendor/joomla/archive/src/Zip.php
+++ b/libraries/vendor/joomla/archive/src/Zip.php
@@ -270,8 +270,8 @@ class Zip implements ExtractableInterface
 	 *
 	 * @return  boolean  True on success
 	 *
-	 * @since   1.0
 	 * @throws  \RuntimeException
+	 * @since   1.0
 	 */
 	protected function extractNative($archive, $destination)
 	{
@@ -285,7 +285,7 @@ class Zip implements ExtractableInterface
 		// Make sure the destination folder exists
 		if (!Folder::create($destination))
 		{
-			throw new \RuntimeException('Unable to create destination folder ' . \dirname($path));
+			throw new \RuntimeException('Unable to create destination folder ' . \dirname($destination));
 		}
 
 		// Read files in the archive
@@ -298,15 +298,12 @@ class Zip implements ExtractableInterface
 				continue;
 			}
 
-			$stream = $zip->getStream($file);
+			$buffer = $zip->getFromIndex($index);
 
-			if ($stream === false)
+			if ($buffer === false)
 			{
 				throw new \RuntimeException('Unable to read ZIP entry');
 			}
-
-			$buffer = stream_get_contents($stream);
-			fclose($stream);
 
 			if (File::write($destination . '/' . $file, $buffer) === false)
 			{


### PR DESCRIPTION
Pull Request for Issue #31506.

### Summary of Changes

For zip files, load the buffer directly instead of utilising the stream.

### Testing Instructions

Install an extension that contains zip files in the zip archive without increasing the max execution time..

### Actual result BEFORE applying this Pull Request

You'll get an error like
*Gateway Timeout - The gateway did not receive a timely response from the upstream server or application.*
because of the timeout.

### Expected result AFTER applying this Pull Request

Installation works as it should.

### Documentation Changes Required

No.