### PR TITLE
Fix broken versioning in workflow items

### DIFF
--- a/administrator/components/com_contenthistory/tmpl/compare/compare.php
+++ b/administrator/components/com_contenthistory/tmpl/compare/compare.php
@@ -41,7 +41,7 @@ $wa->useScript('com_contenthistory.admin-compare-compare');
 		</thead>
 		<tbody>
 		<?php foreach ($object1 as $name => $value) : ?>
-			<?php if ($value->value != $object2->$name->value) : ?>
+			<?php if (isset($value->value) && isset($object2->$name->value) && $value->value != $object2->$name->value) : ?>
 				<?php if (is_object($value->value)) : ?>
 					<tr>
 						<td colspan="4">

--- a/libraries/src/Versioning/Versioning.php
+++ b/libraries/src/Versioning/Versioning.php
@@ -11,8 +11,11 @@ namespace Joomla\CMS\Versioning;
 \defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Component\ComponentHelper;
+use Joomla\CMS\Event\AbstractEvent;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Table\Table;
+use Joomla\CMS\Workflow\WorkflowServiceInterface;
 use Joomla\Database\ParameterType;
 
 /**
@@ -92,10 +95,31 @@ class Versioning
 		$historyTable = Table::getInstance('Contenthistory', 'JTable');
 		$historyTable->item_id = $typeAlias . '.' . $id;
 
+		$aliasParts = explode('.', $typeAlias);
+
 		// Don't store unless we have a non-zero item id
 		if (!$historyTable->item_id)
 		{
 			return true;
+		}
+
+		// We should allow workflow items interact with the versioning
+		$component = Factory::getApplication()->bootComponent($aliasParts[0]);
+
+		if ($component instanceof WorkflowServiceInterface && $component->isWorkflowActive($typeAlias))
+		{
+			PluginHelper::importPlugin('workflow');
+
+			// Pre-processing by observers
+			$event = AbstractEvent::create(
+				'onContentVersioningPrepareTable',
+				[
+					'subject'	=> $historyTable,
+					'extension'	=> $typeAlias
+				]
+			);
+
+			Factory::getApplication()->getDispatcher()->dispatch('onContentVersioningPrepareTable', $event);
 		}
 
 		$historyTable->version_data = json_encode($data);
@@ -120,8 +144,6 @@ class Versioning
 		$result = $historyTable->store();
 
 		// Load history_limit config from extension.
-		$aliasParts = explode('.', $typeAlias);
-
 		$context = $aliasParts[1] ?? '';
 
 		$maxVersionsContext = ComponentHelper::getParams($aliasParts[0])->get('history_limit_' . $context, 0);

--- a/plugins/workflow/featuring/featuring.php
+++ b/plugins/workflow/featuring/featuring.php
@@ -427,7 +427,7 @@ class PlgWorkflowFeaturing extends CMSPlugin implements SubscriberInterface
 	}
 
 	/**
-	 * We remove the publishing field from the versioning
+	 * We remove the featured field from the versioning
 	 *
 	 * @param   EventInterface  $event
 	 *

--- a/plugins/workflow/featuring/featuring.php
+++ b/plugins/workflow/featuring/featuring.php
@@ -11,6 +11,7 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Application\CMSApplicationInterface;
 use Joomla\CMS\Event\AbstractEvent;
+use Joomla\CMS\Event\Table\BeforeStoreEvent;
 use Joomla\CMS\Event\View\DisplayEvent;
 use Joomla\CMS\Event\Workflow\WorkflowFunctionalityUsedEvent;
 use Joomla\CMS\Event\Workflow\WorkflowTransitionEvent;
@@ -19,12 +20,14 @@ use Joomla\CMS\Form\Form;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Model\DatabaseModelInterface;
 use Joomla\CMS\Plugin\CMSPlugin;
+use Joomla\CMS\Table\ContentHistory;
 use Joomla\CMS\Table\TableInterface;
 use Joomla\CMS\Workflow\WorkflowPluginTrait;
 use Joomla\CMS\Workflow\WorkflowServiceInterface;
 use Joomla\Component\Content\Administrator\Event\Model\FeatureEvent;
 use Joomla\Event\EventInterface;
 use Joomla\Event\SubscriberInterface;
+use Joomla\Registry\Registry;
 use Joomla\String\Inflector;
 
 /**
@@ -70,13 +73,15 @@ class PlgWorkflowFeaturing extends CMSPlugin implements SubscriberInterface
 	public static function getSubscribedEvents(): array
 	{
 		return [
-			'onContentPrepareForm'          => 'onContentPrepareForm',
-			'onAfterDisplay'                => 'onAfterDisplay',
-			'onWorkflowBeforeTransition'    => 'onWorkflowBeforeTransition',
-			'onWorkflowAfterTransition'     => 'onWorkflowAfterTransition',
-			'onContentBeforeChangeFeatured' => 'onContentBeforeChangeFeatured',
-			'onContentBeforeSave'           => 'onContentBeforeSave',
-			'onWorkflowFunctionalityUsed'   => 'onWorkflowFunctionalityUsed',
+			'onAfterDisplay'                  => 'onAfterDisplay',
+			'onContentBeforeChangeFeatured'   => 'onContentBeforeChangeFeatured',
+			'onContentBeforeSave'             => 'onContentBeforeSave',
+			'onContentPrepareForm'            => 'onContentPrepareForm',
+			'onContentVersioningPrepareTable' => 'onContentVersioningPrepareTable',
+			'onTableBeforeStore'              => 'onTableBeforeStore',
+			'onWorkflowAfterTransition'       => 'onWorkflowAfterTransition',
+			'onWorkflowBeforeTransition'      => 'onWorkflowBeforeTransition',
+			'onWorkflowFunctionalityUsed'     => 'onWorkflowFunctionalityUsed'
 		];
 	}
 
@@ -419,6 +424,82 @@ class PlgWorkflowFeaturing extends CMSPlugin implements SubscriberInterface
 		}
 
 		return true;
+	}
+
+	/**
+	 * We remove the publishing field from the versioning
+	 *
+	 * @param   EventInterface  $event
+	 *
+	 * @return  boolean
+	 *
+	 * @since   4.0.0
+	 */
+	public function onContentVersioningPrepareTable(EventInterface $event)
+	{
+		$subject = $event->getArgument('subject');
+		$context = $event->getArgument('extension');
+
+		if (!$this->isSupported($context))
+		{
+			return true;
+		}
+
+		$parts = explode('.', $context);
+
+		$component = $this->app->bootComponent($parts[0]);
+
+		$modelName = $component->getModelName($context);
+
+		$model = $component->getMVCFactory()->createModel($modelName, $this->app->getName(), ['ignore_request' => true]);
+
+		$table = $model->getTable();
+
+		$subject->ignoreChanges[] = $table->getColumnAlias('featured');
+	}
+
+	/**
+	 * Pre-processor for $table->store($updateNulls)
+	 *
+	 * @param   BeforeStoreEvent  $event  The event to handle
+	 *
+	 * @return  void
+	 *
+	 * @since   4.0.0
+	 */
+	public function onTableBeforeStore(BeforeStoreEvent $event)
+	{
+		$subject = $event->getArgument('subject');
+
+		if (!($subject instanceof ContentHistory))
+		{
+			return;
+		}
+
+		$parts = explode('.', $subject->item_id);
+
+		$typeAlias = $parts[0] . (isset($parts[1]) ? '.' . $parts[1] : '');
+
+		if (!$this->isSupported($typeAlias))
+		{
+			return;
+		}
+
+		$component = $this->app->bootComponent($parts[0]);
+
+		$modelName = $component->getModelName($typeAlias);
+
+		$model = $component->getMVCFactory()->createModel($modelName, $this->app->getName(), ['ignore_request' => true]);
+
+		$table = $model->getTable();
+
+		$field = $table->getColumnAlias('featured');
+
+		$versionData = new Registry($subject->version_data);
+
+		$versionData->remove($field);
+
+		$subject->version_data = $versionData->toString();
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue #26595 .

### Summary of Changes
After discussing with @HLeithner we decide to go for the following approach:
when workflow is active, the values from the items which are covered by the workflow plugins (in this case "state" + "featured") should not be put into the versioning table.

This happens by removing this values from the hash + the values itself via the workflow plugins.

### Testing Instructions
- Create an article
- Change it


### Actual result BEFORE applying this Pull Request
- Values handled by the workflow are only versioned after a second save


### Expected result AFTER applying this Pull Request
- Values handled by the workflow are never versioned.


