### PR TITLE
Fix image selection in media field

### DIFF
--- a/build/media_source/system/js/fields/joomla-image-select.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-image-select.w-c.es6.js
@@ -100,13 +100,8 @@
 
           // eslint-disable-next-line prefer-destructuring
           Joomla.selectedMediaFile.url = resp.data[0].url.split(rootFull)[1];
-          if (resp.data[0].thumb_path) {
-            Joomla.selectedMediaFile.thumb = resp.data[0].thumb_path;
-          } else {
-            Joomla.selectedMediaFile.thumb = false;
-          }
         } else if (resp.data[0].thumb_path) {
-          Joomla.selectedMediaFile.thumb = resp.data[0].thumb_path;
+          Joomla.selectedMediaFile.url = resp.data[0].thumb_path;
         }
       } else {
         Joomla.selectedMediaFile.url = false;


### PR DESCRIPTION
# Summary of Changes

When creating a 3rd party filesystem plugin and selecting an image in a media file selection (e.g. in the article form view), the image will not be displayed, because the variable is wrong.

### Testing Instructions
- Apply patch
- Run npm
- Install a 3rd party media filesystem plugin (like: https://github.com/bembelimen/joomla-cms/tree/4.1/media-manager ) and select an image in a media field.


### Actual result BEFORE applying this Pull Request

- Image not selected/displayed

### Expected result AFTER applying this Pull Request

- Image selected/displayed

@dgrammatiko perhaps you can check?
