### PR TITLE
[4.0] Fix broken Joomla manifest and therefore broken Joomla Update check caused by recently merged PR #31504

### DIFF
--- a/administrator/manifests/files/joomla.xml
+++ b/administrator/manifests/files/joomla.xml
@@ -4,7 +4,7 @@
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
-	<copyright>(C) 2019 Open Source Matters, Inc./copyright>
+	<copyright>(C) 2019 Open Source Matters, Inc.</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<version>4.0.0-beta6-dev</version>
 	<creationDate>October 2020</creationDate>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Fixes broken closing tag for copyright in Joomla manifest caused by recently merged PR #31504 .

### Testing Instructions

Install current 4.0-dev or latest nightly, go to backend switch error reporting to "Maximum".

Then wait for the Joomla Update check to complete.

### Actual result BEFORE applying this Pull Request

![2020-11-29_j4-error-update-checks-xml](https://user-images.githubusercontent.com/7413183/100539699-82dcd500-3238-11eb-8320-61fc16cb9e40.png)

### Expected result AFTER applying this Pull Request

No such stuff, only nice green buttons.

### Documentation Changes Required

None.