### PR TITLE
[4.0] Cassiopeia copyright dates

### DIFF
--- a/templates/cassiopeia/component.php
+++ b/templates/cassiopeia/component.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Site
  * @subpackage  Templates.cassiopeia
  *
- * @copyright   (C) 2012 Open Source Matters, Inc. <https://www.joomla.org>
+ * @copyright   (C) 2017 Open Source Matters, Inc. <https://www.joomla.org>
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/templates/cassiopeia/error.php
+++ b/templates/cassiopeia/error.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Site
  * @subpackage  Templates.cassiopeia
  *
- * @copyright   (C) 2012 Open Source Matters, Inc. <https://www.joomla.org>
+ * @copyright   (C) 2017 Open Source Matters, Inc. <https://www.joomla.org>
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/templates/cassiopeia/js/template.js
+++ b/templates/cassiopeia/js/template.js
@@ -1,7 +1,7 @@
 /**
  * @package     Joomla.Site
  * @subpackage  Templates.Cassiopeia
- * @copyright   (C) 2013 Open Source Matters, Inc. <https://www.joomla.org>
+ * @copyright   (C) 2017 Open Source Matters, Inc. <https://www.joomla.org>
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  * @since       4.0
  */

--- a/templates/cassiopeia/offline.php
+++ b/templates/cassiopeia/offline.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Site
  * @subpackage  Templates.cassiopeia
  *
- * @copyright   (C) 2016 Open Source Matters, Inc. <https://www.joomla.org>
+ * @copyright   (C) 2017 Open Source Matters, Inc. <https://www.joomla.org>
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 


### PR DESCRIPTION
The changes to the copyright date by @nibra in #31504 can not possibly be correct as they predate the actual template creation. (yes I understand why those dates were found)

This pr changes them to the start date of the actual template

code review
