### PR TITLE
[3]fix batch/copy on php 8

### DIFF
--- a/administrator/components/com_categories/views/categories/tmpl/default_batch_body.php
+++ b/administrator/components/com_categories/views/categories/tmpl/default_batch_body.php
@@ -12,7 +12,7 @@ $options = array(
 	JHtml::_('select.option', 'c', JText::_('JLIB_HTML_BATCH_COPY')),
 	JHtml::_('select.option', 'm', JText::_('JLIB_HTML_BATCH_MOVE'))
 );
-$published = $this->state->get('filter.published');
+$published = (int) $this->state->get('filter.published');
 $extension = $this->escape($this->state->get('filter.extension'));
 ?>
 

--- a/administrator/components/com_content/views/articles/tmpl/default_batch_body.php
+++ b/administrator/components/com_content/views/articles/tmpl/default_batch_body.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 defined('_JEXEC') or die;
-$published = $this->state->get('filter.published');
+$published = (int) $this->state->get('filter.published');
 ?>
 
 <div class="container-fluid">

--- a/administrator/components/com_menus/views/items/tmpl/default_batch_body.php
+++ b/administrator/components/com_menus/views/items/tmpl/default_batch_body.php
@@ -12,8 +12,8 @@ $options = array(
 	JHtml::_('select.option', 'c', JText::_('JLIB_HTML_BATCH_COPY')),
 	JHtml::_('select.option', 'm', JText::_('JLIB_HTML_BATCH_MOVE'))
 );
-$published = $this->state->get('filter.published');
-$clientId  = $this->state->get('filter.client_id');
+$published = (int) $this->state->get('filter.published');
+$clientId  = (int) $this->state->get('filter.client_id');
 $menuType  = JFactory::getApplication()->getUserState('com_menus.items.menutype');
 if ($clientId == 1) :
 	JFactory::getDocument()->addScriptDeclaration(

--- a/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/default_batch_body.php
+++ b/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/default_batch_body.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 defined('_JEXEC') or die;
-$published = $this->state->get('filter.published');
+$published = (int) $this->state->get('filter.published');
 ?>
 
 <div class="container-fluid">


### PR DESCRIPTION
Pull Request for Issue #31467 .

### Summary of Changes
cast to int


### Testing Instructions
with php 8
Add some Categories, Articles, and Menu Items.
Use Batch in any of these to copy or move them.


### Actual result BEFORE applying this Pull Request

missing options

### Expected result AFTER applying this Pull Request

options are there as before

