### PR TITLE
[J!3.9] Update of joomla-framework/image  #31552

### DIFF
--- a/libraries/vendor/joomla/image/src/Image.php
+++ b/libraries/vendor/joomla/image/src/Image.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Framework Image Package
  *
- * @copyright  Copyright (C) 2005 - 2018 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2020 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
@@ -75,7 +75,7 @@ class Image implements LoggerAwareInterface
 	const ORIENTATION_SQUARE = 'square';
 
 	/**
-	 * @var    resource  The image resource handle.
+	 * @var    resource|\GdImage  The image resource handle.
 	 * @since  1.0
 	 */
 	protected $handle;
@@ -133,7 +133,7 @@ class Image implements LoggerAwareInterface
 		}
 
 		// If the source input is a resource, set it as the image handle.
-		if (is_resource($source) && (get_resource_type($source) == 'gd'))
+		if ($this->isValidImage($source))
 		{
 			$this->handle = &$source;
 		}
@@ -588,12 +588,7 @@ class Image implements LoggerAwareInterface
 	public function isLoaded()
 	{
 		// Make sure the resource handle is valid.
-		if (!is_resource($this->handle) || (get_resource_type($this->handle) != 'gd'))
-		{
-			return false;
-		}
-
-		return true;
+		return $this->isValidImage($this->handle);
 	}
 
 	/**
@@ -652,7 +647,7 @@ class Image implements LoggerAwareInterface
 				// Attempt to create the image handle.
 				$handle = imagecreatefromgif($path);
 
-				if (!is_resource($handle))
+				if (!$this->isValidImage($handle))
 				{
 					// @codeCoverageIgnoreStart
 					throw new \RuntimeException('Unable to process GIF image.');
@@ -678,7 +673,7 @@ class Image implements LoggerAwareInterface
 				// Attempt to create the image handle.
 				$handle = imagecreatefromjpeg($path);
 
-				if (!is_resource($handle))
+				if (!$this->isValidImage($handle))
 				{
 					// @codeCoverageIgnoreStart
 					throw new \RuntimeException('Unable to process JPG image.');
@@ -704,7 +699,7 @@ class Image implements LoggerAwareInterface
 				// Attempt to create the image handle.
 				$handle = imagecreatefrompng($path);
 
-				if (!is_resource($handle))
+				if (!$this->isValidImage($handle))
 				{
 					// @codeCoverageIgnoreStart
 					throw new \RuntimeException('Unable to process PNG image.');
@@ -1239,5 +1234,17 @@ class Image implements LoggerAwareInterface
 	public function setThumbnailGenerate($quality = true)
 	{
 		$this->generateBestQuality = (boolean) $quality;
+	}
+
+	/**
+	 * @param   mixed  $handle  A potential image handle
+	 *
+	 * @return  boolean
+	 */
+	private function isValidImage($handle)
+	{
+		// @todo Remove resource check, once PHP7 support is dropped.
+		return (\is_resource($handle) && \get_resource_type($handle) === 'gd')
+			|| (\is_object($handle) && $handle instanceof \GDImage);
 	}
 }

--- a/libraries/vendor/joomla/image/src/ImageFilter.php
+++ b/libraries/vendor/joomla/image/src/ImageFilter.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Framework Image Package
  *
- * @copyright  Copyright (C) 2005 - 2018 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2020 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
@@ -21,7 +21,7 @@ use Psr\Log\LoggerAwareInterface;
 abstract class ImageFilter implements LoggerAwareInterface
 {
 	/**
-	 * @var    resource  The image resource handle.
+	 * @var    resource|\GdImage  The image resource handle.
 	 * @since  1.0
 	 */
 	protected $handle;
@@ -35,7 +35,7 @@ abstract class ImageFilter implements LoggerAwareInterface
 	/**
 	 * Class constructor.
 	 *
-	 * @param   resource  $handle  The image resource on which to apply the filter.
+	 * @param   resource|\GdImage  $handle  The image resource on which to apply the filter.
 	 *
 	 * @since   1.0
 	 * @throws  \InvalidArgumentException
@@ -55,7 +55,7 @@ abstract class ImageFilter implements LoggerAwareInterface
 		}
 
 		// Make sure the file handle is valid.
-		if (!is_resource($handle) || (get_resource_type($handle) != 'gd'))
+		if (!$this->isValidImage($handle))
 		{
 			$this->getLogger()->error('The image handle is invalid for the image filter.');
 
@@ -88,7 +88,7 @@ abstract class ImageFilter implements LoggerAwareInterface
 	 *
 	 * @param   LoggerInterface  $logger  A PSR-3 compliant logger.
 	 *
-	 * @return  Image  This object for message chaining.
+	 * @return  ImageFilter  This object for message chaining.
 	 *
 	 * @since   1.0
 	 */
@@ -109,4 +109,16 @@ abstract class ImageFilter implements LoggerAwareInterface
 	 * @since   1.0
 	 */
 	abstract public function execute(array $options = array());
+
+	/**
+	 * @param   mixed  $handle  A potential image handle
+	 *
+	 * @return  boolean
+	 */
+	private function isValidImage($handle)
+	{
+		// @todo Remove resource check, once PHP7 support is dropped.
+		return (\is_resource($handle) && \get_resource_type($handle) === 'gd')
+			|| (\is_object($handle) && $handle instanceof \GDImage);
+	}
 }


### PR DESCRIPTION
Pull Request for Issue #31552.

### Summary of Changes

Changes the checks for the Php 8.0 compatibility after the calls of imagecreatefromgif, imagecreatefromjpeg and imagecreatefrompng when the image is loaded because it doesn't return a ressource in Php 8.0 but an object

### Testing Instructions

Use an extension which use the Joomla\Image class

### Actual result BEFORE applying this Pull Request

Exception : Unable to process JPG image. in C:\Users\xillibit\git\joomla-cms-39\libraries\vendor\joomla\image\src\Image.php on line 143

### Expected result AFTER applying this Pull Request

No exception

### Documentation Changes Required

No
