### PR TITLE
[4.0-dev] Cassiopeia set font-size-root to 1em

### DIFF
--- a/templates/cassiopeia/scss/tools/variables/_variables.scss
+++ b/templates/cassiopeia/scss/tools/variables/_variables.scss
@@ -135,7 +135,7 @@ $cassiopeia-toolbar-line-height:      1.8rem;
 $font-family-sans-serif:             -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji" !default;
 $font-family-base:                    var(--cassiopeia-font-family-body, $font-family-sans-serif);
 
-$font-size-root:                      calc(1em + .16vw);
+$font-size-root:                      1em;
 $font-size-lg:                        1.25rem;
 $font-size-sm:                        .875rem;
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This PR will change the `$font-size-root` to 1em. 

Increasing font-size with increasing viewport width is too early for us. :-)

### Testing Instructions

- Joomla 4
- `npm run build:css`
- see frontend ... increase view port and see that font-size grows
- apply path
- `npm run build:css`
- see frontend. ... increase viewport and see that font-size does not grow anymore

### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Documentation Changes Required

