### PR TITLE
Fix session's moving from Joomla 3 to Joomla 4

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -102,10 +102,6 @@ class JoomlaInstallerScript
 		$this->clearStatsCache();
 		$this->convertTablesToUtf8mb4(true);
 		$this->cleanJoomlaCache();
-
-		// VERY IMPORTANT! THIS METHOD SHOULD BE CALLED LAST, SINCE IT COULD
-		// LOGOUT ALL THE USERS
-		$this->flushSessions();
 	}
 
 	/**
@@ -6304,66 +6300,6 @@ class JoomlaInstallerScript
 
 				return false;
 			}
-		}
-
-		return true;
-	}
-
-	/**
-	 * If we migrated the session from the previous system, flush all the active sessions.
-	 * Otherwise users will be logged in, but not able to do anything since they don't have
-	 * a valid session
-	 *
-	 * @return  boolean
-	 */
-	public function flushSessions()
-	{
-		/**
-		 * The session may have not been started yet (e.g. CLI-based Joomla! update scripts). Let's make sure we do
-		 * have a valid session.
-		 */
-		$session = Factory::getSession();
-
-		/**
-		 * Restarting the Session require a new login for the current user so lets check if we have an active session
-		 * and only restart it if not.
-		 * For B/C reasons we need to use getState as isActive is not available in 2.5
-		 */
-		if ($session->getState() !== 'active')
-		{
-			$session->restart();
-		}
-
-		// If $_SESSION['__default'] is no longer set we do not have a migrated session, therefore we can quit.
-		if (!isset($_SESSION['__default']))
-		{
-			return true;
-		}
-
-		$db = Factory::getDbo();
-
-		try
-		{
-			switch ($db->getServerType())
-			{
-				// MySQL database, use TRUNCATE (faster, more resilient)
-				case 'mysql':
-					$db->truncateTable('#__session');
-					break;
-
-				// Non-MySQL databases, use a simple DELETE FROM query
-				default:
-					$query = $db->getQuery(true)
-						->delete($db->quoteName('#__session'));
-					$db->setQuery($query)->execute();
-					break;
-			}
-		}
-		catch (Exception $e)
-		{
-			echo Text::sprintf('JLIB_DATABASE_ERROR_FUNCTION_FAILED', $e->getCode(), $e->getMessage()) . '<br>';
-
-			return false;
 		}
 
 		return true;


### PR DESCRIPTION
@HLeithner did basically all of the debugging work on this so massive massive credit to him! Both me and @zero-24 had unsuccessfully tried to debug this in the past.

Pull Request for Issue #28465 .

### Summary of Changes
- Double encodes the session name for compat with session names in Joomla 3
- Ensures the code that is stored within a session namespace (concept removed in the framework) continues to function during the lifetime of J4 to allow stable upgrades from J3 (it's worth noting that in the future if users go from Joomla 3 to Joomla 4 and straight a J5 where this migration code has been removed there could be issues - but I'm taking this as another bridge for another day)
- Removes the session migration step that was left over from 3.4.7 session security issues as we require users to go via 3.10 all users will have had their session migrated so this code is useless anyhow.

### Testing Instructions
Test by upgrading from Joomla 3.x to this 4.x repo. Before you'll get logged out during the upgrade. After patch you will stay logged in

### Documentation Changes Required
None