### PR TITLE
[4.0] Upgrade column blog layouts to according CSS classes

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -7047,19 +7047,14 @@ class JoomlaInstallerScript
 		$query = $db->getQuery(true)
 			->select(
 				[
-					$db->quoteName('id'),
-					$db->quoteName('link'),
-					$db->quoteName('params'),
+					$db->quoteName('m.id'),
+					$db->quoteName('m.link'),
+					$db->quoteName('m.params'),
 				]
 			)
-			->from($db->quoteName('#__menu'));
-
-		// Restrict selection to com_content items.
-		$query2 = $db->getQuery(true)
-			->select($db->quoteName('extension_id'))
-			->from($db->quoteName('#__extensions'))
-			->where($db->quoteName('element') . ' = ' . $db->quote('com_content'));
-		$query->where($db->quoteName('component_id') . ' = (' . $query2 . ')');
+			->from($db->quoteName('#__menu', 'm'))
+			->leftJoin($db->quoteName('#__extensions', 'e'), $db->quoteName('e.extension_id') . ' = ' . $db->quoteName('m.component_id'))
+			->where($db->quoteName('e.element') . ' = ' . $db->quote('com_content'));
 
 		$menuItems = $db->setQuery($query)->loadAssocList('id');
 

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -9,6 +9,7 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Extension\ExtensionHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Filesystem\File;
@@ -7078,13 +7079,15 @@ class JoomlaInstallerScript
 				continue;
 			}
 
-			$nColumns = (int) $params['num_columns'];
+			$nColumns = $params['num_columns'] !== '' ? (int) $params['num_columns']
+				: (int) ComponentHelper::getParams('com_content')->get('num_columns', '1');
 			unset($params['num_columns']);
 			$order = 0;
 
 			if (isset($params['multi_column_order']))
 			{
-				$order = (int) $params['multi_column_order'];
+				$order = $params['multi_column_order'] !== '' ? (int) $params['multi_column_order']
+					: (int) ComponentHelper::getParams('com_content')->get('multi_column_order', '0');
 				unset($params['multi_column_order']);
 			}
 

--- a/administrator/components/com_content/config.xml
+++ b/administrator/components/com_content/config.xml
@@ -715,6 +715,22 @@
 		description="COM_CONTENT_CONFIG_BLOG_SETTINGS_DESC"
 		>
 		<field
+			name="blog_class_leading"
+			type="text"
+			label="JGLOBAL_BLOG_CLASS_LEADING"
+			size="3"
+			validate="CssIdentifier"
+		/>
+
+		<field
+			name="blog_class"
+			type="text"
+			label="JGLOBAL_BLOG_CLASS"
+			size="3"
+			validate="CssIdentifier"
+		/>
+
+		<field
 			name="num_leading_articles"
 			type="number"
 			label="JGLOBAL_NUM_LEADING_ARTICLES_LABEL"

--- a/components/com_content/tmpl/categories/default.xml
+++ b/components/com_content/tmpl/categories/default.xml
@@ -205,6 +205,24 @@
 	<fieldset name="blog" label="JGLOBAL_BLOG_LAYOUT_OPTIONS" description="JGLOBAL_SUBSLIDER_DRILL_CATEGORIES_LABEL">
 
 			<field
+				name="blog_class_leading"
+				type="text"
+				label="JGLOBAL_BLOG_CLASS_LEADING"
+				useglobal="true"
+				size="3"
+				validate="CssIdentifier"
+			/>
+
+			<field
+				name="blog_class"
+				type="text"
+				label="JGLOBAL_BLOG_CLASS"
+				useglobal="true"
+				size="3"
+				validate="CssIdentifier"
+			/>
+
+			<field
 				name="num_leading_articles"
 				type="number"
 				label="JGLOBAL_NUM_LEADING_ARTICLES_LABEL"


### PR DESCRIPTION
Pull Request for Issue #27478. This is an alternative approach to #30910. 

### Summary of Changes
Instead of re-adding the parameters that were removed with #18319, this approach searches for the "column" and "ordering" parameters from J3 and converts the values into the according CSS classes, i.e. `columns-X` in the case of horizontal ordering, or `masonry-X` in the case of vertical ordering.


### Testing Instructions

As this PR modifies the update mechanism, you need to test it by upgrading a J3 site to J4. Note that you might not be able to update afterwards to higher J4-beta versions on the same site (don't know how this behaves with PR update packages). So I'd recommend to set up a clean, new installation (or a copy from an existing one) only for this PR.
1. Set up a local 3.10-alpha installation.
2. Create a set of articles, at least 4, in the same category. They should have different text lengths and at least 4 of them should also be featured.
3. For each of the three menu item types "Category Blog", "Featured" and "List All Categories", create several menu items that differ in the parameters "Number of Columns" and "Multi-Column Order". Some should be using only one column, some two or three. Some should use the global order, some horizontal and some vertical.
4. To be able to repeatedly test the upgrade process, you might want to create a backup of files and database at this point.
5. Upgrade your site to J4 using the update package of this PR.
  - At "Components - Joomla! Update", click on "Options". 
  - Update Channel: Custom URL
  - Minimum Stability: Development
  - Custom URL: At the GitHub page of this PR, scroll down to the bottom. Click on "Show all checks". Next to "Download — Prebuilt packages are available for download.", click on "Details". Search for the part "You can test this package as an update by using this custom update server:" and copy the URL from there.

#### How to test the "List All Categories" menu item type

- Create a menu item of type "List All Categories"
  - Select a Top Level Category: Root
  - In the tab "Blog Layout", you can configure the parameters "Number of Columns" and "Multi-Column Order".
- Either create a new category, again with at least 4 articles, that has no own menu item, or unpublish all menu items for the category that you created above in step 2.
- To test, navigate to frontend, click on your "List All Categories" menu item and then click on the title of your category. The category should now be displayed in blog layout according to the parameters you specified above.

### Actual result BEFORE applying this Pull Request
("before applying this PR" = using an unpatched update package, such as the normal beta6 or nightly build)

All blog views are rendered in only one column, all with the same order. The above-mentioned parameters are gone without a trace.


### Expected result AFTER applying this Pull Request
The number of columns should stay the same compared to before the upgrade. Depending on whether the according menu item used horizontal or vertical ordering, the articles should now be arranged in a similar manner.

More precisely (with "local" = set in the menu item, "global" = in the configuration of com_content):

<table>
<thead>
<tr><th colspan="4">Before Upgrade (J3)</th><th colspan="2">After Upgrade (J4)</th></tr>
<tr><th>columns (local)</th><th>order (local)</th><th>columns (global)</th><th>order (global)</th><th>CSS class (local)</th><th>CSS class (global)</th></tr>
</thead>
<tbody>
<tr><td>3</td><td>horizontal</td><td>2</td><td>vertical</td><td>columns-3</td><td>masonry-2</td></tr>
<tr><td>3</td><td>vertical</td><td>2</td><td>vertical</td><td>masonry-3</td><td>masonry-2</td></tr>
<tr><td>3</td><td><em>(global)</em></td><td>2</td><td>vertical</td><td>masonry-3</td><td>masonry-2</td></tr>
<tr><td><em>(global)</em></td><td>horizontal</td><td>2</td><td>vertical</td><td>columns-2</td><td>masonry-2</td></tr>
<tr><td><em>(global)</em></td><td><em>(global)</em></td><td>2</td><td>vertical</td><td><em>(global)</em></td><td>masonry-2</td></tr>
<tr><td>3</td><td>horizontal</td><td>1</td><td>vertical</td><td>columns-3</td><td></td></tr>
<tr><td><em>(global)</em></td><td><em>(global)</em></td><td>2</td><td>vertical</td><td>(global)</td><td>masonry-2</td></tr>
<tr><td><em>1</em></td><td><em>(global)</em></td><td>2</td><td>vertical</td><td><strong>(global)</strong></td><td><strong>masonry-2</strong> <sup><a href="#issuecomment-754564227">[1]</a></sup></td></tr>
</tbody>
</table>

Obviously, this table is not exhaustive because listing all possible combinations would take some time and space. So please feel free to come up with your own combinations!

### Documentation Changes Required
Not sure where to document this. We definitely need to document what classes are available for layouts in the Cassiopeia template.

### Open Points
1. I'm not sure how to handle the "categories" view. In J3, it has parameters to control the blog layouts which are displayed when users click on one of the categories. In J4, this tab exists as well, but I don't see a "blog class" field there. Should we add such a field there? (This is the reason, why this PR is created as a draft. After fixing this, the PR should be ready to test)
2. The masonry layout breaks articles in two if it fits the column layout. This is a different display from J3. And looking at this part, which seems to have no effect at all, I doubt if this behaviour is intended or if it is preferable to avoid breaking articles there. https://github.com/joomla/joomla-cms/blob/8053386a7c9c1c1f1766748aae3c5161662aaf2d/templates/cassiopeia/scss/blocks/_modifiers.scss#L214-L224
  I could add another modifier CSS class that could be used to avoid breaking. In that case, the next question would be whether this class should be included in the conversion from J3 to J4 that is done with this PR. Or we could change this for the masonry layout in general, if breaking inside articles is not intended at all. Comments?

### Screenshots

order | J3 | J4
------------ | ------------- | -------------
horizontal | ![blog-horizontal-j3](https://user-images.githubusercontent.com/1410135/101067830-4c84ba00-3598-11eb-8768-0e98a0f465ea.png) | ![blog-horizontal-j4](https://user-images.githubusercontent.com/1410135/101067837-4db5e700-3598-11eb-8b02-30d05e5ab10a.png)
vertical | ![blog-vertical-j3](https://user-images.githubusercontent.com/1410135/101067840-4e4e7d80-3598-11eb-8815-16232dab7d1f.png) | ![blog-vertical-j4](https://user-images.githubusercontent.com/1410135/101067842-4e4e7d80-3598-11eb-8b2d-2f0575095627.png)