### PR TITLE
[4.0] Intro image link [a11y]

### DIFF
--- a/layouts/joomla/content/intro_image.php
+++ b/layouts/joomla/content/intro_image.php
@@ -35,8 +35,9 @@ if ((isset($img->attributes['width']) && (int) $img->attributes['width'] > 0)
 }
 ?>
 <figure class="<?php echo htmlspecialchars($imgclass, ENT_COMPAT, 'UTF-8'); ?> item-image">
-	<?php if ($params->get('link_intro_image') && $params->get('access-view')) : ?>
-		<a href="<?php echo Route::_(RouteHelper::getArticleRoute($displayData->slug, $displayData->catid, $displayData->language)); ?>">
+	<?php if ($params->get('link_intro_image') && ($params->get('access-view') || $params->get('show_noauth', '0') == '1')) : ?>
+		<a href="<?php echo Route::_(RouteHelper::getArticleRoute($displayData->slug, $displayData->catid, $displayData->language)); ?>"
+			itemprop="url" title="<?php echo $this->escape($displayData->title); ?>">
 			<img src="<?php echo htmlspecialchars($img->url, ENT_COMPAT, 'UTF-8'); ?>"
 					 <?php echo $alt; ?>
 					 itemprop="thumbnailUrl"

--- a/layouts/joomla/content/intro_image.php
+++ b/layouts/joomla/content/intro_image.php
@@ -35,7 +35,7 @@ if ((isset($img->attributes['width']) && (int) $img->attributes['width'] > 0)
 }
 ?>
 <figure class="<?php echo htmlspecialchars($imgclass, ENT_COMPAT, 'UTF-8'); ?> item-image">
-	<?php if ($params->get('link_titles') && $params->get('access-view')) : ?>
+	<?php if ($params->get('link_intro_image') && $params->get('access-view')) : ?>
 		<a href="<?php echo Route::_(RouteHelper::getArticleRoute($displayData->slug, $displayData->catid, $displayData->language)); ?>">
 			<img src="<?php echo htmlspecialchars($img->url, ENT_COMPAT, 'UTF-8'); ?>"
 					 <?php echo $alt; ?>


### PR DESCRIPTION
This PR reverts an accidental change made in #30784 to make the intro image a link only when the option is set and to ensure that a link has a title. This is an important accessibility issue.

For full testing instructions etc see the original PR where this was introduced #30823

cc @carcam 