### PR TITLE
[4.0] Article Info fields

### DIFF
--- a/templates/cassiopeia/scss/blocks/_modifiers.scss
+++ b/templates/cassiopeia/scss/blocks/_modifiers.scss
@@ -160,6 +160,10 @@
     .image-right & {
       padding-right: 25px;
     }
+
+    dd {
+      padding: 0;
+    }
   }
 
   .image-left &,

--- a/templates/cassiopeia/scss/blocks/_modifiers.scss
+++ b/templates/cassiopeia/scss/blocks/_modifiers.scss
@@ -160,10 +160,6 @@
     .image-right & {
       padding-right: 25px;
     }
-
-    dd {
-      padding: 0;
-    }
   }
 
   .image-left &,
@@ -173,6 +169,12 @@
     @include media-breakpoint-up(md) {
       flex-direction: row;
     }
+  }
+}
+
+.article-info {
+  dd {
+    padding: 0;
   }
 }
 


### PR DESCRIPTION
In Joomla 4 we correctly changed the article info from a regular list to a definition. This has resulted in the items being indented and this is confusing some users as previously these items were not indented.

This PR removes the padding so that there is no visual change with J3 and yet maintains the correct semantic markup.

To test dont forget to rebuild the css

## Before
![image](https://user-images.githubusercontent.com/1296369/101267417-5cdf9500-3750-11eb-9a42-4128b2968527.png)

## After
![image](https://user-images.githubusercontent.com/1296369/101267410-476a6b00-3750-11eb-84a3-9a1743436a67.png)
