### PR TITLE
[4.0] Fix local adapter, keep fixed ordering, fix default value

### DIFF
--- a/plugins/filesystem/local/local.php
+++ b/plugins/filesystem/local/local.php
@@ -79,14 +79,13 @@ class PlgFileSystemLocal extends CMSPlugin implements ProviderInterface
 	public function getAdapters()
 	{
 		$adapters = [];
-		$directories = $this->params->get('directories', '[{"directory":{"directory": "images"}}]');
+		$directories = $this->params->get('directories', '[{"directory": "images"}]');
 
 		// Do a check if default settings are not saved by user
 		// If not initialize them manually
 		if (is_string($directories))
 		{
 			$directories = json_decode($directories);
-			list($directories) = $directories;
 		}
 
 		foreach ($directories as $directoryEntity)

--- a/plugins/filesystem/local/local.xml
+++ b/plugins/filesystem/local/local.xml
@@ -29,8 +29,8 @@
 					label="PLG_FILESYSTEM_LOCAL_DIRECTORIES_LABEL"
 					multiple="true"
 					layout="joomla.form.field.subform.repeatable-table"
-					buttons="add,remove,move"
-					default='{"directories0":{"directory":"images"}}'
+					buttons="add,remove"
+					default='[{"directory":"images"}]'
 				>
 					<form>
 						<field


### PR DESCRIPTION
Pull Request for Issue from comment https://github.com/joomla/joomla-cms/issues/26750#issuecomment-739246507 .

### Summary of Changes

Do not allow User to change ordering in the plugin parameters.
local-0:/, local-1:/ ... local-x:/ always should stay in original order.

I more like idea with named prefix `<provider>-<account>`, as @dgrammatiko  suggested in https://github.com/joomla/joomla-cms/issues/26750#issuecomment-739248621.
However this will not work, I not checked in deep but it seems that whole thing hardcoded to use `<account>` as integer.

Also I have fixed default value.

### Testing Instructions

Apply path.
Go to Plugins: FileSystem - Local.
Add couple Directories, and try change their order.



### Actual result BEFORE applying this Pull Request
You can change ordering


### Expected result AFTER applying this Pull Request
You cannot change ordering


### Documentation Changes Required
none
