### PR TITLE
[4.0] Regression and b/c fix for session handling

### DIFF
--- a/libraries/src/Session/Session.php
+++ b/libraries/src/Session/Session.php
@@ -194,24 +194,36 @@ class Session extends BaseSession
 					'deprecated'
 				);
 
-				$name = '__' . $args[2] . '.' . $name;
+				$name       = $args[2] . '.' . $name;
+				$legacyName = '__' . $name;
 			}
+		}
+
+		if (parent::has($name))
+		{
+			// Parent is used because of b/c, can be changed in Joomla 5
+			return parent::get($name, $default);
+		}
+
+		/*
+		 * B/C for retrieving sessions that originated in Joomla 3.
+		 * A namespace before Joomla 4 has a prefix of 2 underscores (__).
+		 * This is no longer the case in Joomla 4 and will be converted
+		 * when saving new values in `self::set()`
+		 */
+		if (isset($legacyName) && parent::has($legacyName))
+		{
+			return parent::get($legacyName, $default);
 		}
 
 		// More b/c for retrieving sessions that originated in Joomla 3. This will be removed in Joomla 5
 		// as no sessions should have this format anymore!
-		if (parent::has($name))
-		{
-			return parent::get($name, $default);
-		}
-		elseif (parent::has('__default.' . $name))
+		if (parent::has('__default.' . $name))
 		{
 			return parent::get('__default.' . $name, $default);
 		}
-		else
-		{
-			return $default;
-		}
+
+		return $default;
 	}
 
 	/**
@@ -272,11 +284,23 @@ class Session extends BaseSession
 					'deprecated'
 				);
 
-				$name = $args[1] . '.' . $name;
+				$name       = $args[1] . '.' . $name;
+				$legacyName = '__' . $name;
 			}
 		}
 
 		if (parent::has($name))
+		{
+			return true;
+		}
+
+		/*
+		 * B/C for retrieving sessions that originated in Joomla 3.
+		 * A namespace before Joomla 4 has a prefix of 2 underscores (__).
+		 * This is no longer the case in Joomla 4 and will be converted
+		 * when saving new values in `self::set()`
+		 */
+		if (isset($legacyName) && parent::has($legacyName))
 		{
 			return true;
 		}
@@ -320,10 +344,23 @@ class Session extends BaseSession
 						'deprecated'
 					);
 
-					$name = $args[1] . '.' . $name;
+					$name       = $args[1] . '.' . $name;
+					$legacyName = '__' . $name;
 				}
 
-				return $this->remove($name);
+				$this->remove($name);
+
+				/*
+				 * B/C for cleaning sessions that originated in Joomla 3.
+				 * A namespace before Joomla 4 has a prefix of 2 underscores (__).
+				 * This is no longer the case in Joomla 4 so we clean both variants.
+				 */
+				if (isset($legacyName) && parent::has($legacyName))
+				{
+					$this->remove($legacyName);
+				}
+
+				return;
 			}
 		}
 

--- a/libraries/src/Session/Session.php
+++ b/libraries/src/Session/Session.php
@@ -195,7 +195,6 @@ class Session extends BaseSession
 				);
 
 				$name       = $args[2] . '.' . $name;
-				$legacyName = '__' . $name;
 			}
 		}
 
@@ -211,9 +210,9 @@ class Session extends BaseSession
 		 * This is no longer the case in Joomla 4 and will be converted
 		 * when saving new values in `self::set()`
 		 */
-		if (isset($legacyName) && parent::has($legacyName))
+		if (strpos($name, '.') !== false && parent::has('__' . $name))
 		{
-			return parent::get($legacyName, $default);
+			return parent::get('__' . $name, $default);
 		}
 
 		// More b/c for retrieving sessions that originated in Joomla 3. This will be removed in Joomla 5
@@ -285,7 +284,6 @@ class Session extends BaseSession
 				);
 
 				$name       = $args[1] . '.' . $name;
-				$legacyName = '__' . $name;
 			}
 		}
 
@@ -300,7 +298,7 @@ class Session extends BaseSession
 		 * This is no longer the case in Joomla 4 and will be converted
 		 * when saving new values in `self::set()`
 		 */
-		if (isset($legacyName) && parent::has($legacyName))
+		if (strpos($name, '.') !== false && parent::has('__' . $name))
 		{
 			return true;
 		}
@@ -344,8 +342,7 @@ class Session extends BaseSession
 						'deprecated'
 					);
 
-					$name       = $args[1] . '.' . $name;
-					$legacyName = '__' . $name;
+					$name = $args[1] . '.' . $name;
 				}
 
 				$this->remove($name);
@@ -355,10 +352,7 @@ class Session extends BaseSession
 				 * A namespace before Joomla 4 has a prefix of 2 underscores (__).
 				 * This is no longer the case in Joomla 4 so we clean both variants.
 				 */
-				if (isset($legacyName) && parent::has($legacyName))
-				{
-					$this->remove($legacyName);
-				}
+				$this->remove('__' . $name);
 
 				return;
 			}

--- a/libraries/src/Session/Session.php
+++ b/libraries/src/Session/Session.php
@@ -194,7 +194,7 @@ class Session extends BaseSession
 					'deprecated'
 				);
 
-				$name       = $args[2] . '.' . $name;
+				$name = $args[2] . '.' . $name;
 			}
 		}
 
@@ -283,7 +283,7 @@ class Session extends BaseSession
 					'deprecated'
 				);
 
-				$name       = $args[1] . '.' . $name;
+				$name = $args[1] . '.' . $name;
 			}
 		}
 


### PR DESCRIPTION
Pull Request for Issue noticed by @nikosdion in https://github.com/akeeba/fof/commit/d69b179bbefcc03b4dabd5e82a04d9c0d092b2ca

The Joomla 4 session manager doesn't handle namespaces anymore. For j3 b/c joomla includes a b/c layer which was doesn't handle existing sessions correctly. In PR #31561 we tried to fix the upgrade double login issue. This PR got merged too early and a bugfix PR #31575 fixed a part of the problem. The session PRs introduced a new bug handling none "default" namespace which is addressed in this PR.

### Summary of Changes
Try the prefixed namespace used in session migrated from j3 after the none prefixed parameter in the following functions:

* `Joomla\CMS\Session\Session::get()`
* `Joomla\CMS\Session\Session::has()`
* `Joomla\CMS\Session\Session::clean()`

We don't change the `Joomla\CMS\Session\Session::set()` function because new parameters will always be stored in a none prefixed namespace.

### Testing Instructions
* Upgrade from J3.10 to j4, this should still work
* Save values to the session with and without namespace

```php
$session = JFactory::getApplication()->getSession();
# Clear session
$session->clear('__ns');
$session->clear('ns');

echo "Set wow without namespace ns\n";
$session->set('wow', 'xxx');
echo "Check wow without namespace\n";
if ($session->has('wow')) {
  echo "Good\n";
} else {
  echo "FAIL\n";
}
var_dump($session->get('wow', 'xxx'));
$session->clear('wow');

echo "Set wow with namespace ns and j3 syntax \n";
$session->set('wow', 'xxx', 'ns');
echo "check wow with j3 syntax \n";
if ($session->has('wow','ns')) {
  echo "Good\n";
} else {
  echo "FAIL\n";
}
var_dump($session->get('wow', 'not found', 'ns'));
if ($session->has('ns.wow')) {
  echo "Good\n";
} else {
  echo "FAIL\n";
}
var_dump($session->get('ns.wow', 'not found'));
$session->clear('wow', 'ns');
$session->clear('ns');

echo "Set __ns.wow for j3 session simulation \n";
$session->set('__ns.wow', 'xxx');
echo "check wow with j3 syntax \n";
if ($session->has('wow','ns')) {
  echo "Good\n";
} else {
  echo "FAIL\n";
}
var_dump($session->get('wow', 'not found', 'ns'));
echo "check wow with j4 syntax and underscore prefixed (normally not used) \n";
if ($session->has('__ns.wow')) {
  echo "Good\n";
} else {
  echo "FAIL\n";
}
var_dump($session->get('__ns.wow', 'not found'));
echo "check wow with j4 syntax\n";
if ($session->has('ns.wow')) {
  echo "Good\n";
} else {
  echo "FAIL\n";
}
var_dump($session->get('ns.wow', 'not found'));
```

### Actual result BEFORE applying this Pull Request
Working with the session using the old syntax and names doesn't work


### Expected result AFTER applying this Pull Request
Still all works including a better b/c layer for old syntax and namespaces

### Documentation Changes Required
N/A
