### PR TITLE
[4.0] Media manager icons

### DIFF
--- a/administrator/components/com_media/resources/styles/components/_media-browser.scss
+++ b/administrator/components/com_media/resources/styles/components/_media-browser.scss
@@ -372,48 +372,48 @@
     }
   }
   // Images
-  &[data-type="jpg"],
-  &[data-type="png"],
-  &[data-type="gif"],
-  &[data-type="jpeg"],
-  &[data-type="tiff"],
-  &[data-type="bmp"],
-  &[data-type="svg"] {
+  &[data-type="jpg" i],
+  &[data-type="png" i],
+  &[data-type="gif" i],
+  &[data-type="jpeg" i],
+  &[data-type="tiff" i],
+  &[data-type="bmp" i],
+  &[data-type="svg" i] {
     &::before {
       content: $icon-type-images;
     }
   }
   // Video
-  &[data-type="mov"],
-  &[data-type="mkv"],
-  &[data-type="mp4"],
-  &[data-type="mpg"],
-  &[data-type="mpeg"] {
+  &[data-type="mov" i],
+  &[data-type="mkv" i],
+  &[data-type="mp4" i],
+  &[data-type="mpg" i],
+  &[data-type="mpeg" i] {
     &::before {
       content: $icon-type-video;
     }
   }
   // Audio
-  &[data-type="mp3"],
-  &[data-type="wav"],
-  &[data-type="raw"],
-  &[data-type="wma"] {
+  &[data-type="mp3" i],
+  &[data-type="wav" i],
+  &[data-type="raw" i],
+  &[data-type="wma" i] {
     &::before {
       content: $icon-type-audio;
     }
   }
   // Docs
-  &[data-type="doc"],
-  &[data-type="xls"],
-  &[data-type="pdf"],
-  &[data-type="txt"] {
+  &[data-type="doc" i],
+  &[data-type="xls" i],
+  &[data-type="pdf" i],
+  &[data-type="txt" i] {
     &::before {
       content: $icon-type-docs;
     }
   }
   // Code
-  &[data-type="html"],
-  &[data-type="htm"] {
+  &[data-type="html" i],
+  &[data-type="htm" i] {
     &::before {
       content: $icon-type-code;
     }


### PR DESCRIPTION
When the media manager is in list view it uses css data-type to generate an appropriate icon.

However the current code only matches lowercase file extensions. This PR make it case insensitive.

To test  upload an image with an uppercase filetype eg _DSC1234.JPG and go to the lust view and you will see there is no icon.

Apply this pr and run npm ci and refresh and now you have an icon

## Before
![image](https://user-images.githubusercontent.com/1296369/101295009-d2139e80-3812-11eb-80cb-6e14fe5b377d.png)

## After
![image](https://user-images.githubusercontent.com/1296369/101294995-b8725700-3812-11eb-9cf6-0aa73b546838.png)
