### PR TITLE
[4.0] Admin module checkout id [a11y]

### DIFF
--- a/administrator/modules/mod_latest/tmpl/default.php
+++ b/administrator/modules/mod_latest/tmpl/default.php
@@ -13,8 +13,11 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
 HTMLHelper::_('bootstrap.framework');
+
+$moduleId = str_replace(' ', '', $module->title) . $module->id;
+
 ?>
-<table class="table" id="<?php echo str_replace(' ', '', $module->title) . $module->id; ?>">
+<table class="table" id="<?php echo $moduleId; ?>">
 	<caption class="sr-only"><?php echo $module->title; ?></caption>
 	<thead>
 		<tr>
@@ -29,7 +32,7 @@ HTMLHelper::_('bootstrap.framework');
 		<tr>
 			<th scope="row">
 				<?php if ($item->checked_out) : ?>
-					<?php echo HTMLHelper::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time); ?>
+					<?php echo HTMLHelper::_('jgrid.checkedout', $moduleId . $i, $item->editor, $item->checked_out_time, $module->id); ?>
 				<?php endif; ?>
 				<?php if ($item->link) : ?>
 					<a href="<?php echo $item->link; ?>" title="<?php echo Text::_('JACTION_EDIT'); ?> <?php echo htmlspecialchars($item->title, ENT_QUOTES, 'UTF-8'); ?>">

--- a/administrator/modules/mod_popular/tmpl/default.php
+++ b/administrator/modules/mod_popular/tmpl/default.php
@@ -35,7 +35,7 @@ $moduleId = str_replace(' ', '', $module->title) . $module->id;
 			<tr>
 				<th scope="row">
 					<?php if ($item->checked_out) : ?>
-						<?php echo HTMLHelper::_('jgrid.checkedout', $moduleId, $item->editor, $item->checked_out_time); ?>
+						<?php echo HTMLHelper::_('jgrid.checkedout', $moduleId . $i, $item->editor, $item->checked_out_time); ?>
 					<?php endif; ?>
 					<?php if ($item->link) : ?>
 						<a href="<?php echo $item->link; ?>" title="<?php echo Text::_('JACTION_EDIT'); ?> <?php echo htmlspecialchars($item->title, ENT_QUOTES, 'UTF-8'); ?>">

--- a/administrator/modules/mod_popular/tmpl/default.php
+++ b/administrator/modules/mod_popular/tmpl/default.php
@@ -13,6 +13,9 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
 HTMLHelper::_('bootstrap.framework');
+
+$moduleId = str_replace(' ', '', $module->title) . $module->id;
+
 ?>
 <table class="table" id="<?php echo str_replace(' ', '', $module->title) . $module->id; ?>">
 	<caption class="sr-only"><?php echo $module->title; ?></caption>
@@ -32,7 +35,7 @@ HTMLHelper::_('bootstrap.framework');
 			<tr>
 				<th scope="row">
 					<?php if ($item->checked_out) : ?>
-						<?php echo HTMLHelper::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time); ?>
+						<?php echo HTMLHelper::_('jgrid.checkedout', $moduleId, $item->editor, $item->checked_out_time); ?>
 					<?php endif; ?>
 					<?php if ($item->link) : ?>
 						<a href="<?php echo $item->link; ?>" title="<?php echo Text::_('JACTION_EDIT'); ?> <?php echo htmlspecialchars($item->title, ENT_QUOTES, 'UTF-8'); ?>">


### PR DESCRIPTION
Every id on a page must be unique. Before this PR the id of the checked out icon in the admin modules Article Latest and Article Popular could be identical as it only used the number of the item in the list as the id. This PR additionally adds the name of the module and module id to ensure that the checked out id is unique.

To test you will need to have some checked out articles and then you can view the source and see the arialabelledby id

Before the pr it will look like
`aria-labelledby="cbcheckin3-desc`

After the pr it will look like
`aria-labelledby="cbcheckinPopularArticles3-desc`

cc @carcam
