### PR TITLE
[4.0] Action Logs Icon

### DIFF
--- a/administrator/components/com_actionlogs/src/View/Actionlogs/HtmlView.php
+++ b/administrator/components/com_actionlogs/src/View/Actionlogs/HtmlView.php
@@ -123,7 +123,7 @@ class HtmlView extends BaseHtmlView
 	 */
 	protected function addToolbar()
 	{
-		ToolbarHelper::title(Text::_('COM_ACTIONLOGS_MANAGER_USERLOGS'), 'icon-list-ul');
+		ToolbarHelper::title(Text::_('COM_ACTIONLOGS_MANAGER_USERLOGS'), 'icon-list-2');
 
 		ToolbarHelper::custom('actionlogs.exportSelectedLogs', 'download', '', 'COM_ACTIONLOGS_EXPORT_CSV', true);
 		ToolbarHelper::custom('actionlogs.exportLogs', 'download', '', 'COM_ACTIONLOGS_EXPORT_ALL_CSV', false);


### PR DESCRIPTION
The icon for the action logs component is not displayed as the icon name is was incorrectly named in PR #30370

## Before
![image](https://user-images.githubusercontent.com/1296369/101533533-dca67300-398d-11eb-96ba-2512ad5390bb.png)

## After
![image](https://user-images.githubusercontent.com/1296369/101533492-cef0ed80-398d-11eb-9bf4-2203c03c77c6.png)
