### PR TITLE
[staging] Displaying error when updating an extension/package

### DIFF
--- a/administrator/components/com_installer/models/update.php
+++ b/administrator/components/com_installer/models/update.php
@@ -446,6 +446,13 @@ class InstallerModelUpdate extends JModelList
 		// Unpack the downloaded package file
 		$package = InstallerHelper::unpack($tmp_dest . '/' . $p_file);
 
+		if (empty($package))
+		{
+			$app->enqueueMessage(JText::sprintf('COM_INSTALLER_UNPACK_ERROR', $p_file), 'error');
+
+			return false;
+		}
+
 		// Get an installer instance
 		$installer = JInstaller::getInstance();
 		$update->set('type', $package['type']);

--- a/administrator/language/en-GB/en-GB.com_installer.ini
+++ b/administrator/language/en-GB/en-GB.com_installer.ini
@@ -251,6 +251,7 @@ COM_INSTALLER_UNINSTALL_ERROR="Error uninstalling %s."
 ; This string is deprecated and will be removed with 4.0.
 COM_INSTALLER_UNINSTALL_LANGUAGE="A language should always have been installed as a package. <br />To uninstall a language, filter type by package and uninstall the package."
 COM_INSTALLER_UNINSTALL_SUCCESS="Uninstalling the %s was successful."
+COM_INSTALLER_UNPACK_ERROR="Failed to extract file: %s"
 COM_INSTALLER_UPDATE_FILTER_SEARCH_DESC="Search in extension name. Prefix with ID:, UID: or EID: to search for an update ID, update site ID or extension ID."
 COM_INSTALLER_UPDATE_FILTER_SEARCH_LABEL="Search Extensions with Updates"
 COM_INSTALLER_UPDATESITE_DISABLE="Disable update site"


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/31598

### Summary of Changes
As title says. Tested in php 3.7.9 and php 7.4.2


### Testing Instructions
Install 
[pkg_maximenuckparams_4.1.1.zip](https://github.com/joomla/joomla-cms/files/5665353/pkg_maximenuckparams_4.1.1.zip)

Then go to Update Manager, select the file and click Update

### Actual result BEFORE applying this Pull Request
many php warnings in php logs (see https://github.com/joomla/joomla-cms/issues/31598) in php 7.4+

message displays `Error updating COM_INSTALLER_TYPE_TYPE_.`


### Expected result AFTER applying this Pull Request
No more php warnings.
New message (specific to this extension update temp file):

<img width="913" alt="Screen Shot 2020-12-09 at 11 49 40" src="https://user-images.githubusercontent.com/869724/101621292-dc51ba80-3a15-11eb-8030-7f3e85da0b1c.png">



### Documentation Changes Required
None


@jsubri @HLeithner 