### PR TITLE
[4.0] Cassiopeia component.php

### DIFF
--- a/templates/cassiopeia/component.php
+++ b/templates/cassiopeia/component.php
@@ -9,9 +9,33 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 
 /** @var JDocumentHtml $this */
+
+$app = Factory::getApplication();
+$wa  = $this->getWebAssetManager();
+
+// Template path
+$templatePath = 'templates/' . $this->template;
+
+// Color Theme
+$paramsColorName = $this->params->get('colorName', 'colors_standard');
+$assetColorName  = 'theme.' . $paramsColorName;
+$wa->registerAndUseStyle($assetColorName, $templatePath . '/css/global/' . $paramsColorName . '.css');
+$this->getPreloadManager()->prefetch($wa->getAsset('style', $assetColorName)->getUri(), ['as' => 'style']);
+
+// Use a font scheme if set in the template style options
+$paramsFontScheme = $this->params->get('useFontScheme', false);
+
+if ($paramsFontScheme)
+{
+	// Prefetch the stylesheet for the font scheme, actually we need to prefetch the font(s)
+	$assetFontScheme  = 'fontscheme.' . $paramsFontScheme;
+	$wa->registerAndUseStyle($assetFontScheme, $templatePath . '/css/global/' . $paramsFontScheme . '.css');
+	$this->getPreloadManager()->prefetch($wa->getAsset('style', $assetFontScheme)->getUri(), ['as' => 'style']);
+}
 
 // Enable assets
 $wa = $this->getWebAssetManager();


### PR DESCRIPTION
The component.php view of the cassiopeia template does not have the code to use the font or colour schemes.

This can be seen by logging in to the site and opening an article to edit. Then select any of the xtd-editor plugins and you will see the missing buttons as in the screenshots below. Then apply the PR and you can see the bbuttons


### Before
![image](https://user-images.githubusercontent.com/1296369/101998832-a559fe00-3cce-11eb-8dbb-f936afde254b.png)

### After
![image](https://user-images.githubusercontent.com/1296369/101998824-8c514d00-3cce-11eb-9491-3693eee85d1e.png)
