### PR TITLE
Use Factory::, not JFactory

### DIFF
--- a/administrator/components/com_joomlaupdate/src/Controller/UpdateController.php
+++ b/administrator/components/com_joomlaupdate/src/Controller/UpdateController.php
@@ -119,7 +119,7 @@ class UpdateController extends BaseController
 	public function install()
 	{
 		$this->checkToken('get');
-		JFactory::getApplication()->setUserState('com_joomlaupdate.oldversion', JVERSION);
+		Factory::getApplication()->setUserState('com_joomlaupdate.oldversion', JVERSION);
 
 		$options['format'] = '{DATE}\t{TIME}\t{LEVEL}\t{CODE}\t{MESSAGE}';
 		$options['text_file'] = 'joomla_update.php';


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
- Whilst fiddling with com_joomlaupdate > Upload & Update in a J4 nightly of today I saw several times error like 

`Class 'Joomla\Component\Joomlaupdate\Administrator\Controller\JFactory' not found`

thrown by 

JROOT/administrator/components/com_joomlaupdate/src/Controller/UpdateController.php:122

Reason is commit https://github.com/joomla/joomla-cms/commit/af5b1001dac15595c97e35fed3d953d927b7171b#diff-b4783c09040c64562973e4fa903f3c5e844a7a4fc6aa9c0a18fcb4765eae673f

### Testing
- Code review. It's obvious.
