### PR TITLE
[4.0] Cassiopeia: Add height auto to images to maintain aspect ratio

### DIFF
--- a/templates/cassiopeia/scss/blocks/_global.scss
+++ b/templates/cassiopeia/scss/blocks/_global.scss
@@ -19,6 +19,7 @@ body {
 
 img {
   max-width: 100%;
+  height: auto;
 }
 
 h1,


### PR DESCRIPTION
Pull Request for Issue #31647 .

### Summary of Changes
Added height: auto to img to maintain aspect ratio when width 100%


### Testing Instructions
Create an article with a full image in format 16:9 (e.g. 1280 x 720px), set Image Class to float-none. 
Install this PR and run "npm run build:css"


### Actual result BEFORE applying this Pull Request
The image will have a width of 100%, but the height stay at 720px, so the aspect ratio is distorted.


### Expected result AFTER applying this Pull Request
The image is 100% wide and the height scale proportionally.

