### PR TITLE
[4.0] Provide empty string as default for empty protected fields when saving configuration.php

### DIFF
--- a/administrator/components/com_config/src/Model/ApplicationModel.php
+++ b/administrator/components/com_config/src/Model/ApplicationModel.php
@@ -316,7 +316,7 @@ class ApplicationModel extends FormModel
 		{
 			if (isset($data[$fieldKey]) && empty($data[$fieldKey]))
 			{
-				$data[$fieldKey] = $app->get($fieldKey);
+				$data[$fieldKey] = $app->get($fieldKey, '');
 			}
 		}
 


### PR DESCRIPTION
Pull Request for Issue #31679 .

### Summary of Changes

See title.

### Testing Instructions

See issue #31679 .

### Actual result BEFORE applying this Pull Request

Instant 500 error.

In configuration.php:

```
public $ftp_pass = ;
public $smtppass = ;
public $redis_server_auth = ;
public $session_redis_server_auth = ;
```

### Expected result AFTER applying this Pull Request

Successfully saved.

In configuration.php:

```
public $ftp_pass = '';
public $smtppass = '';
public $redis_server_auth = '';
public $session_redis_server_auth = '';
```

### Documentation Changes Required

None.