### PR TITLE
[4.0] Correcting articles blog badge date

### DIFF
--- a/layouts/joomla/content/blog_style_default_item_title.php
+++ b/layouts/joomla/content/blog_style_default_item_title.php
@@ -40,11 +40,11 @@ $currentDate = Factory::getDate()->format('Y-m-d H:i:s');
 			<span class="badge badge-warning"><?php echo Text::_('JUNPUBLISHED'); ?></span>
 		<?php endif; ?>
 
-		<?php if (strtotime($displayData->publish_up) > $currentDate) : ?>
+		<?php if ($displayData->publish_up > $currentDate) : ?>
 			<span class="badge badge-warning"><?php echo Text::_('JNOTPUBLISHEDYET'); ?></span>
 		<?php endif; ?>
 
-		<?php if ($displayData->publish_down !== null && strtotime($displayData->publish_down) < strtotime(Factory::getDate())) : ?>
+		<?php if ($displayData->publish_down !== null && $displayData->publish_down < $currentDate) : ?>
 			<span class="badge badge-warning"><?php echo Text::_('JEXPIRED'); ?></span>
 		<?php endif; ?>
 	</div>


### PR DESCRIPTION
### Summary of Changes
As title says. Issue comes from conflict last last 3.x merge

### Testing Instructions
Create some articles to Publish later and some which date is expired.
Create an articles blog menu item.

Display in frontend and log as superadmin.

### Actual result BEFORE applying this Pull Request

<img width="365" alt="Screen Shot 2020-12-17 at 16 38 47" src="https://user-images.githubusercontent.com/869724/102510622-1cedab80-4088-11eb-9b45-33080eeb862e.png">



### Expected result AFTER applying this Pull Request

<img width="562" alt="Screen Shot 2020-12-17 at 16 33 33" src="https://user-images.githubusercontent.com/869724/102510652-25de7d00-4088-11eb-875b-6d5f12601c0a.png">
