### PR TITLE
[4.0] run gzip

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "install": "node build/build.js --copy-assets && node build/build.js --build-pages",
     "postinstall": "node build/build.js --compile-js && node build/build.js --compile-css && npm run build:com_media",
     "update": "node build/build.js --copy-assets && node build/build.js --build-pages && node build/build.js --compile-js && node build/build.js --compile-css",
-    "gzip": "node -e 'require(\"./build/build-modules-js/gzip-assets.es6.js\").gzipFiles()'",
+    "gzip": "node -e require('./build/build-modules-js/gzip-assets.es6.js').gzipFiles()",
     "watch:com_media": "cross-env NODE_ENV=development webpack --progress --hide-modules --watch --config administrator/components/com_media/webpack.config.js",
     "dev:com_media": "cross-env NODE_ENV=development webpack --progress --hide-modules --config administrator/components/com_media/webpack.config.js",
     "build:com_media": "cross-env NODE_ENV=production webpack --progress --hide-modules --config administrator/components/com_media/webpack.config.js"


### PR DESCRIPTION
There is a node command to gzip the assets

`npm run gzip`

When testing on windows it doesn't work (no idea about linux/mac)

After applying this PR then running the same command and it will work. (note it will appear to hang at the end - just be patient its slow)

Discovered while testing #31635 