### PR TITLE
[4.0] Menu home not default

### DIFF
--- a/administrator/language/en-GB/com_menus.ini
+++ b/administrator/language/en-GB/com_menus.ini
@@ -199,3 +199,7 @@ COM_MENUS_XML_DESCRIPTION="Component for creating menus."
 
 ; Alternate language strings for the rules form field
 JLIB_RULES_SETTING_NOTES_COM_MENUS="Changes apply to this component only.<br><em><strong>Inherited</strong></em> - a Global Configuration setting or higher level setting is applied.<br><em><strong>Denied</strong></em> always wins - whatever is set at the Global or higher level and applies to all child elements.<br><em><strong>Allowed</strong></em> will enable the action for this component unless overruled by a Global Configuration setting."
+
+; Alternate language strings for the default menu item
+JDEFAULT="Home"
+JLIB_HTML_SETDEFAULT_ITEM="Set as Home"


### PR DESCRIPTION
The column title is home but the contents are default. Same with the messages See gifs
### Before
![befoire](https://user-images.githubusercontent.com/1296369/102544091-3274cc80-40ac-11eb-8a0c-66d8619e1379.gif)




### After
![after](https://user-images.githubusercontent.com/1296369/102543996-09543c00-40ac-11eb-83ba-2e42ff8ebb35.gif)
