### PR TITLE
[4.0] Add User ID validation to fields

### DIFF
--- a/administrator/components/com_banners/forms/banner.xml
+++ b/administrator/components/com_banners/forms/banner.xml
@@ -131,6 +131,7 @@
 			name="created_by"
 			type="user"
 			label="COM_BANNERS_FIELD_CREATED_BY_LABEL"
+			validate="UserId"
 		/>
 
 		<field
@@ -159,6 +160,7 @@
 			class="readonly"
 			readonly="true"
 			filter="unset"
+			validate="UserId"
 		/>
 
 		<field

--- a/administrator/components/com_categories/forms/category.xml
+++ b/administrator/components/com_categories/forms/category.xml
@@ -164,6 +164,7 @@
 		name="created_user_id"
 		type="user"
 		label="JGLOBAL_FIELD_CREATED_BY_LABEL"
+		validate="UserId"
 	/>
 
 	<field
@@ -183,6 +184,7 @@
 		class="readonly"
 		readonly="true"
 		filter="unset"
+		validate="UserId"
 	/>
 
 	<field

--- a/administrator/components/com_contact/forms/contact.xml
+++ b/administrator/components/com_contact/forms/contact.xml
@@ -39,6 +39,7 @@
 			name="user_id"
 			type="user"
 			label="COM_CONTACT_FIELD_LINKED_USER_LABEL"
+			validate="UserId"
 		/>
 
 		<field
@@ -88,6 +89,7 @@
 			name="created_by"
 			type="user"
 			label="JGLOBAL_FIELD_CREATED_BY_LABEL"
+			validate="UserId"
 		/>
 
 		<field
@@ -126,6 +128,7 @@
 			class="readonly"
 			readonly="true"
 			filter="unset"
+			validate="UserId"
 		/>
 
 		<field

--- a/administrator/components/com_content/forms/article.xml
+++ b/administrator/components/com_content/forms/article.xml
@@ -102,6 +102,7 @@
 			name="created_by"
 			type="user"
 			label="COM_CONTENT_FIELD_CREATED_BY_LABEL"
+			validate="UserId"
 		/>
 
 		<field
@@ -130,6 +131,7 @@
 			class="readonly"
 			readonly="true"
 			filter="unset"
+			validate="UserId"
 		/>
 
 		<field

--- a/administrator/components/com_fields/forms/field.xml
+++ b/administrator/components/com_fields/forms/field.xml
@@ -114,6 +114,7 @@
 			name="created_user_id"
 			type="user"
 			label="JGLOBAL_FIELD_CREATED_BY_LABEL"
+			validate="UserId"
 		/>
 
 		<field
@@ -133,6 +134,7 @@
 			class="readonly"
 			readonly="true"
 			filter="unset"
+			validate="UserId"
 		/>
 
 		<field

--- a/administrator/components/com_fields/forms/group.xml
+++ b/administrator/components/com_fields/forms/group.xml
@@ -71,6 +71,7 @@
 			name="created_by"
 			type="user"
 			label="JGLOBAL_FIELD_CREATED_BY_LABEL"
+			validate="UserId"
 		/>
 
 		<field
@@ -89,6 +90,7 @@
 			class="readonly"
 			readonly="true"
 			filter="unset"
+			validate="UserId"
 		/>
 
 		<field

--- a/administrator/components/com_finder/forms/filter.xml
+++ b/administrator/components/com_finder/forms/filter.xml
@@ -54,6 +54,7 @@
 			name="created_by"
 			type="user"
 			label="COM_FINDER_FIELD_CREATED_BY_LABEL"
+			validate="UserId"
 		/>
 
 		<field
@@ -70,6 +71,7 @@
 			class="readonly"
 			readonly="true"
 			filter="unset"
+			validate="UserId"
 		 />
 
 		<field

--- a/administrator/components/com_newsfeeds/forms/newsfeed.xml
+++ b/administrator/components/com_newsfeeds/forms/newsfeed.xml
@@ -131,6 +131,7 @@
 			name="created_by"
 			type="user"
 			label="JGLOBAL_FIELD_CREATED_BY_LABEL"
+			validate="UserId"
 		/>
 
 		<field
@@ -159,6 +160,7 @@
 			class="readonly"
 			readonly="true"
 			filter="unset"
+			validate="UserId"
 		/>
 
 		<field

--- a/administrator/components/com_tags/forms/tag.xml
+++ b/administrator/components/com_tags/forms/tag.xml
@@ -160,6 +160,7 @@
 		name="created_user_id"
 		type="user"
 		label="JGLOBAL_FIELD_CREATED_BY_LABEL"
+		validate="UserId"
 	/>
 
 	<field
@@ -187,6 +188,7 @@
 		class="readonly"
 		readonly="true"
 		filter="unset"
+		validate="UserId"
 	/>
 
 	<field

--- a/administrator/components/com_users/forms/note.xml
+++ b/administrator/components/com_users/forms/note.xml
@@ -17,6 +17,7 @@
 			label="COM_USERS_FIELD_USER_ID_LABEL"
 			size="50"
 			required="true"
+			validate="UserId"
 		/>
 
 		<field

--- a/components/com_contact/forms/form.xml
+++ b/components/com_contact/forms/form.xml
@@ -41,6 +41,7 @@
 			name="created_by"
 			type="user"
 			label="JGLOBAL_FIELD_CREATED_BY_LABEL"
+			validate="UserId"
 		/>
 
 		<field
@@ -72,6 +73,7 @@
 			class="readonly"
 			readonly="true"
 			filter="unset"
+			validate="UserId"
 		/>
 
 		<field

--- a/libraries/src/Form/Rule/UserIdRule.php
+++ b/libraries/src/Form/Rule/UserIdRule.php
@@ -43,7 +43,7 @@ class UserIdRule extends FormRule
 		// Check if the field is required.
 		$required = ((string) $element['required'] === 'true' || (string) $element['required'] === 'required');
 
-		// If the value is empty, null or has the value 0 and the field is not required return True else return false
+		// If the value is empty, null or has the value 0 and the field is not required return true else return false
 		if (($value === '' || $value === null || (string) $value === '0'))
 		{
 			return !$required;

--- a/libraries/src/Form/Rule/UserIdRule.php
+++ b/libraries/src/Form/Rule/UserIdRule.php
@@ -19,7 +19,7 @@ use Joomla\Registry\Registry;
 /**
  * Form Rule class for the Joomla Platform.
  *
- * @since  1.7.0
+ * @since  __DEPLOY_VERSION__
  */
 class UserIdRule extends FormRule
 {

--- a/libraries/src/Form/Rule/UserIdRule.php
+++ b/libraries/src/Form/Rule/UserIdRule.php
@@ -43,8 +43,8 @@ class UserIdRule extends FormRule
 		// Check if the field is required.
 		$required = ((string) $element['required'] === 'true' || (string) $element['required'] === 'required');
 
-		// If the value is empty and the field is not required return True.
-		if (($value === '' || $value === null) && !$required)
+		// If the value is empty, null or has the value 0 and the field is not required return True.
+		if (($value === '' || $value === null || (string) $value === '0') && !$required)
 		{
 			return true;
 		}

--- a/libraries/src/Form/Rule/UserIdRule.php
+++ b/libraries/src/Form/Rule/UserIdRule.php
@@ -24,7 +24,7 @@ use Joomla\Registry\Registry;
 class UserIdRule extends FormRule
 {
 	/**
-	 * Method to test the username for uniqueness.
+	 * Method to test the validity of a Joomla User.
 	 *
 	 * @param   \SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
 	 * @param   mixed              $value    The form field value to validate.

--- a/libraries/src/Form/Rule/UserIdRule.php
+++ b/libraries/src/Form/Rule/UserIdRule.php
@@ -60,8 +60,6 @@ class UserIdRule extends FormRule
 			->bind(':userId', $value, ParameterType::INTEGER);
 
 		// Set and query the database.
-		$db->setQuery($query);
-
-		return (bool) $db->loadResult();
+		return (bool) $db->setQuery($query)->loadResult();
 	}
 }

--- a/libraries/src/Form/Rule/UserIdRule.php
+++ b/libraries/src/Form/Rule/UserIdRule.php
@@ -2,7 +2,7 @@
 /**
  * Joomla! Content Management System
  *
- * @copyright  (C) 2017 Open Source Matters, Inc. <https://www.joomla.org>
+ * @copyright  (C) 2020 Open Source Matters, Inc. <https://www.joomla.org>
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/libraries/src/Form/Rule/UserIdRule.php
+++ b/libraries/src/Form/Rule/UserIdRule.php
@@ -43,10 +43,10 @@ class UserIdRule extends FormRule
 		// Check if the field is required.
 		$required = ((string) $element['required'] === 'true' || (string) $element['required'] === 'required');
 
-		// If the value is empty, null or has the value 0 and the field is not required return True.
-		if (($value === '' || $value === null || (string) $value === '0') && !$required)
+		// If the value is empty, null or has the value 0 and the field is not required return True else return false
+		if (($value === '' || $value === null || (string) $value === '0'))
 		{
-			return true;
+			return !$required;
 		}
 
 		// Get the database object and a new query object.

--- a/libraries/src/Form/Rule/UserIdRule.php
+++ b/libraries/src/Form/Rule/UserIdRule.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  (C) 2017 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Form\Rule;
+
+\defined('JPATH_PLATFORM') or die;
+
+use Joomla\CMS\Factory;
+use Joomla\CMS\Form\Form;
+use Joomla\CMS\Form\FormRule;
+use Joomla\Database\ParameterType;
+use Joomla\Registry\Registry;
+
+/**
+ * Form Rule class for the Joomla Platform.
+ *
+ * @since  1.7.0
+ */
+class UserIdRule extends FormRule
+{
+	/**
+	 * Method to test the username for uniqueness.
+	 *
+	 * @param   \SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
+	 * @param   mixed              $value    The form field value to validate.
+	 * @param   ?string            $group    The field name group control value. This acts as an array container for the field.
+	 *                                       For example if the field has name="foo" and the group value is set to "bar" then the
+	 *                                       full field name would end up being "bar[foo]".
+	 * @param   ?Registry          $input    An optional Registry object with the entire data set to validate against the entire form.
+	 * @param   ?Form              $form     The form object for which the field is being tested.
+	 *
+	 * @return  boolean  True if the value is valid, false otherwise.
+	 *
+	 * @since   1.7.0
+	 */
+	public function test(\SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
+	{
+		// Check if the field is required.
+		$required = ((string) $element['required'] === 'true' || (string) $element['required'] === 'required');
+
+		// If the value is empty and the field is not required return True.
+		if (($value === '' || $value === null) && !$required)
+		{
+			return true;
+		}
+
+		// Get the database object and a new query object.
+		$db = Factory::getDbo();
+		$query = $db->getQuery(true);
+
+		// Build the query.
+		$query->select('COUNT(*)')
+			->from($db->quoteName('#__users'))
+			->where($db->quoteName('id') . ' = :userId')
+			->bind(':userId', $value, ParameterType::INTEGER);
+
+		// Set and query the database.
+		$db->setQuery($query);
+
+		return (bool) $db->loadResult();
+	}
+}

--- a/libraries/src/Form/Rule/UserIdRule.php
+++ b/libraries/src/Form/Rule/UserIdRule.php
@@ -36,7 +36,7 @@ class UserIdRule extends FormRule
 	 *
 	 * @return  boolean  True if the value is valid, false otherwise.
 	 *
-	 * @since   1.7.0
+	 * @since   __DEPLOY_VERSION__
 	 */
 	public function test(\SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
 	{

--- a/plugins/fields/user/params/user.xml
+++ b/plugins/fields/user/params/user.xml
@@ -4,6 +4,7 @@
 		name="default_value"
 		type="user"
 		label="PLG_FIELDS_USER_DEFAULT_VALUE_LABEL"
+		validate="UserId"
 	/>
 	<fields name="params" label="COM_FIELDS_FIELD_BASIC_LABEL">
 		<fieldset name="basic">


### PR DESCRIPTION
Pull Request for Issue #30969 .

### Summary of Changes
Adds a new validation rule for having a valid user ID and applies it to all form fields in the CMS of type user.


### Testing Instructions
Joomla 4 -> Edit any article (sample data or manually create one and hit save)

Edit HTML of the edit page with inspector tools

change the value of jform_created_by_id field

<input type="hidden" id="jform_created_by_id" name="jform[created_by]" value="Mr Hacker" class="field-user-input " data-onchange="">

Before patch: If you hit save you'll get a database validation error `Save failed with the following error: Incorrect integer value: 'Mr Hacker' for column 'created_by' at row 1` (see original issue for screenshot). After patch:

<img width="1263" alt="Screenshot 2020-12-18 at 04 57 12" src="https://user-images.githubusercontent.com/1986000/102576460-7f2cc780-40ed-11eb-9799-2dbbf6908b2a.png">

You can also try and do the same thing with an invalid user id (e.g. 999999) - note before patch an integer id even if not valid was saved to the DB. After the patch it will not be.

### Backwards Compatibility

There is one issue here which is that articles which were created by deleted users now will NOT save to the database until they are changed to point to a user that does exist. I'm unsure how serious to rank this as an issue (you will get an error like the following :-

<img width="1244" alt="Screenshot 2020-12-18 at 04 59 00" src="https://user-images.githubusercontent.com/1986000/102576568-c024dc00-40ed-11eb-992f-74ef41e2d485.png">

but it will still save)

### Documentation Changes Required
Possibly relating to the deleted users comment.

/cc @joomla/security 
