### PR TITLE
Improve error message for broken JSON

### DIFF
--- a/libraries/src/WebAsset/WebAssetRegistry.php
+++ b/libraries/src/WebAsset/WebAssetRegistry.php
@@ -371,12 +371,12 @@ class WebAssetRegistry implements WebAssetRegistryInterface, DispatcherAwareInte
 		$data = file_get_contents(JPATH_ROOT . '/' . $path);
 		$data = $data ? json_decode($data, true) : null;
 
-		if (!$data)
+		if ($data === null)
 		{
-			throw new \RuntimeException(sprintf('Asset registry file "%s" are broken', $path));
+			throw new \RuntimeException(sprintf('Asset registry file "%s" contains invalid JSON', $path));
 		}
 
-		// Asset exists but empty, skip it silently
+		// Check if asset field exists and contains data. If it doesn't - we can just bail here.
 		if (empty($data['assets']))
 		{
 			return;


### PR DESCRIPTION
### Summary of Changes
The current string for broken JSON in a web asset registry doesn't make much human sense. This fixes it to specifically check for broken JSON and reports on that. As a result we pass things like an empty json file to the next step where we check for the assets to exist. So I've amended the code comment to reflect that

### Test Instructions
Part code review. You can also try editing one of the web asset files (e.g. templates/cassiopeia/joomla.asset.json) to contain invalid json and turn on debug mode in the symfony handler (change line 56 in libraries/bootstrap.php to `$errorHandler = \Symfony\Component\ErrorHandler\ErrorHandler::register(new Symfony\Component\ErrorHandler\ErrorHandler(null, true));`) and view the exception message generated


### Documentation Changes Required
None
