### PR TITLE
[4.0] Offsets separated by white space(s) are deprecated, use a comma (,) instead.

### DIFF
--- a/libraries/src/HTML/Helpers/Bootstrap.php
+++ b/libraries/src/HTML/Helpers/Bootstrap.php
@@ -354,7 +354,7 @@ abstract class Bootstrap
 		$opt['title']       = isset($params['title']) ? $params['title'] : null;
 		$opt['trigger']     = isset($params['trigger']) ? $params['trigger'] : 'hover focus';
 		$opt['constraints'] = isset($params['constraints']) ? $params['constraints'] : ['to' => 'scrollParent', 'attachment' => 'together', 'pin' => true];
-		$opt['offset']      = isset($params['offset']) ? $params['offset'] : '0 0';
+		$opt['offset']      = isset($params['offset']) ? $params['offset'] : '0,0';
 		$onShow             = isset($params['onShow']) ? (string) $params['onShow'] : null;
 		$onShown            = isset($params['onShown']) ? (string) $params['onShown'] : null;
 		$onHide             = isset($params['onHide']) ? (string) $params['onHide'] : null;


### PR DESCRIPTION
Similar to #18724.

### Summary of Changes

Default offsets for Bootstrap are comma-separated.


### Testing Instructions

Add your custom Bootstrap tooltips, i.e. via `HTMLHelper::_('bootstrap.tooltip', '.myTooltip');`

### Actual result BEFORE applying this Pull Request

See JS notice: `Offsets separated by white space(s) are deprecated, use a comma (,) instead.`

### Expected result AFTER applying this Pull Request

No JS notice.

### Documentation Changes Required

No.