### PR TITLE
Hashing the simpleXMLElement doesn't produce an unique hash per element

### DIFF
--- a/libraries/src/Form/Field/LimitboxField.php
+++ b/libraries/src/Form/Field/LimitboxField.php
@@ -54,7 +54,7 @@ class LimitboxField extends \JFormFieldList
 	protected function getOptions()
 	{
 		// Accepted modifiers
-		$hash = md5($this->element);
+		$hash = md5($this->element['name']);
 
 		if (!isset(static::$options[$hash]))
 		{

--- a/libraries/src/Form/Field/LimitboxField.php
+++ b/libraries/src/Form/Field/LimitboxField.php
@@ -54,7 +54,7 @@ class LimitboxField extends \JFormFieldList
 	protected function getOptions()
 	{
 		// Accepted modifiers
-		$hash = md5($this->element['name']);
+		$hash = md5($this->element->asXML());
 
 		if (!isset(static::$options[$hash]))
 		{


### PR DESCRIPTION
Currently the field `LimitboxField` generates a hash so it doesn't have to calculate the options with each appearance of the same element. This is fine.
Howvere the has is created from `$this->element` which is a simpleXMLElement. We all know that stuff behaves very strange and in unexpected ways.
In this case, `$hash = md5($this->element);` doesn't create a hash based on the whole element with all its attributes. The hash is instead created on an empty simpleXMLElement (ignoring attributes) which ends up the same hash for each instance of the field.

### Summary of Changes
This PR changes the hash so it is created from the XML string instead.


### Testing Instructions
Simplest test would be to add two fields to the article form (administrator/components/com_content/models/forms/article.xml)
Within the fieldset "basic" add this lines:
````
		<field
			name="list_limit"
			type="limitbox"
			label="List"
			useglobal="true"
		/>
		<field
			name="feed_limit"
			type="limitbox"
			label="Feed"
			useglobal="true"
		/>

````
Now check the options tab in an article. And see the value in "Use Global"
If your installation has the default values, then the List field should show 20 and the Feed field should show 10 (values come from global configuration).

### Actual result BEFORE applying this Pull Request
![image](https://user-images.githubusercontent.com/1018684/102610109-eb7aeb80-412c-11eb-99e0-3a4548997dc4.png)

Both fields show the same value, because the hash is actually the same for both fields

### Expected result AFTER applying this Pull Request
![image](https://user-images.githubusercontent.com/1018684/102610138-f7ff4400-412c-11eb-9042-f50d86a64929.png)

Fields are showing correct values since hashes are different.

### Documentation Changes Required
None
