### PR TITLE
[3.9] use StringHelper::substr method from instead of \substr

### DIFF
--- a/administrator/components/com_finder/helpers/indexer/indexer.php
+++ b/administrator/components/com_finder/helpers/indexer/indexer.php
@@ -426,10 +426,10 @@ abstract class FinderIndexer
 					if ($ls)
 					{
 						// Truncate the string to the last space character.
-						$string = substr($buffer, 0, $ls);
+						$string = StringHelper::substr($buffer, 0, $ls);
 
 						// Adjust the buffer based on the last space for the next iteration and trim.
-						$buffer = StringHelper::trim(substr($buffer, $ls));
+						$buffer = StringHelper::trim(StringHelper::substr($buffer, $ls));
 					}
 					// No space character was found.
 					else


### PR DESCRIPTION
### Summary of Changes

Reviewed in testing 3.9.24RC PRs...  Change made on sight of code review.

Hat tip to @Avalon18 who highlighted in https://github.com/joomla/joomla-cms/pull/31533 that com_finder did not always manipulate strings (specifically Cyrillic) correctly.

This PR is just expounding the fix

### Testing Instructions

Code review, maybe someone intimate with com_finder might be able to give a test case that triggers these lines of code? I only edited on Github quickly. 

### Actual result BEFORE applying this Pull Request

Im guessing the handling of Cyrillic and other alphabets might be odd when using \substr as opposed to StringHelper::substr

### Expected result AFTER applying this Pull Request

Everything works

### Documentation Changes Required

None.