### PR TITLE
Clear old session data before save in global configuration

### DIFF
--- a/administrator/components/com_config/controller/application/save.php
+++ b/administrator/components/com_config/controller/application/save.php
@@ -46,6 +46,9 @@ class ConfigControllerApplicationSave extends JControllerBase
 			$this->app->redirect('index.php');
 		}
 
+		// Clear the data from the session.
+		$this->app->setUserState('com_config.config.global.data', null);
+
 		// Set FTP credentials, if given.
 		JClientHelper::setCredentialsFromRequest('ftp');
 
@@ -54,6 +57,7 @@ class ConfigControllerApplicationSave extends JControllerBase
 
 		// Complete data array if needed
 		$oldData = $model->getData();
+
 		$data = array_replace($oldData, $data);
 
 		// Get request type
@@ -115,9 +119,6 @@ class ConfigControllerApplicationSave extends JControllerBase
 
 		// Set the success message.
 		$this->app->enqueueMessage(JText::_('COM_CONFIG_SAVE_SUCCESS'), 'message');
-
-		// Clear the data from the session.
-		$this->app->setUserState('com_config.config.global.data', null);
 
 		// Set the redirect based on the task.
 		switch ($this->options[3])


### PR DESCRIPTION
Pull Request for Issue #31716 .

### Summary of Changes
Clear session data on save to prevent usage of old data in global configuration


### Testing Instructions
* change database password to a invalid value in global configuration
* get an error message
* save again


### Actual result BEFORE applying this Pull Request
On second save you get an error message because the old value from the session is used


### Expected result AFTER applying this Pull Request
Data get saved without errors

