### PR TITLE
Pull request for #27530 - Make dropdown close at clicking anywhere else

### DIFF
--- a/build/media_source/templates/atum/js/template.es6.js
+++ b/build/media_source/templates/atum/js/template.es6.js
@@ -146,10 +146,14 @@
         headerMoreItem.appendChild(headerItemContent);
         headerMoreItem.appendChild(headerMoreMenu);
         headerWrapper.appendChild(headerMoreItem);
+	    headerMoreBtn.addEventListener('click', function () {
+		      event.stopPropagation();
+		      headerMoreItem.classList.toggle('active');
+	    });
+	    window.onclick = function(event) {
+		      headerMoreItem.classList.remove("active");
+	    }
 
-        headerMoreBtn.addEventListener('click', () => {
-          headerMoreItem.classList.toggle('active');
-        });
         headerItemsWidth += headerMoreItem.offsetWidth;
       }
 

--- a/build/media_source/templates/atum/js/template.es6.js
+++ b/build/media_source/templates/atum/js/template.es6.js
@@ -146,12 +146,12 @@
         headerMoreItem.appendChild(headerItemContent);
         headerMoreItem.appendChild(headerMoreMenu);
         headerWrapper.appendChild(headerMoreItem);
-        headerMoreBtn.addEventListener('click', function () {
+        headerMoreBtn.addEventListener('click', (event) => {
           event.stopPropagation();
           headerMoreItem.classList.toggle('active');
         });
-        window.onclick = function(event) {
-          headerMoreItem.classList.remove("active");
+        window.onclick = () => {
+          headerMoreItem.classList.remove('active');
         }
         
         headerItemsWidth += headerMoreItem.offsetWidth;

--- a/build/media_source/templates/atum/js/template.es6.js
+++ b/build/media_source/templates/atum/js/template.es6.js
@@ -152,8 +152,8 @@
         });
         window.onclick = () => {
           headerMoreItem.classList.remove('active');
-        }
-        
+        };
+
         headerItemsWidth += headerMoreItem.offsetWidth;
       }
 

--- a/build/media_source/templates/atum/js/template.es6.js
+++ b/build/media_source/templates/atum/js/template.es6.js
@@ -151,7 +151,7 @@
              headerMoreItem.classList.toggle('active');
         });
         window.onclick = function(event) {
-             headerMoreItem.classList.remove("active");
+          headerMoreItem.classList.remove("active");
         }
         
         headerItemsWidth += headerMoreItem.offsetWidth;

--- a/build/media_source/templates/atum/js/template.es6.js
+++ b/build/media_source/templates/atum/js/template.es6.js
@@ -146,14 +146,14 @@
         headerMoreItem.appendChild(headerItemContent);
         headerMoreItem.appendChild(headerMoreMenu);
         headerWrapper.appendChild(headerMoreItem);
-	    headerMoreBtn.addEventListener('click', function () {
-		      event.stopPropagation();
-		      headerMoreItem.classList.toggle('active');
-	    });
-	    window.onclick = function(event) {
-		      headerMoreItem.classList.remove("active");
-	    }
-
+        headerMoreBtn.addEventListener('click', function () {
+              event.stopPropagation();
+             headerMoreItem.classList.toggle('active');
+        });
+        window.onclick = function(event) {
+             headerMoreItem.classList.remove("active");
+        }
+        
         headerItemsWidth += headerMoreItem.offsetWidth;
       }
 

--- a/build/media_source/templates/atum/js/template.es6.js
+++ b/build/media_source/templates/atum/js/template.es6.js
@@ -147,8 +147,8 @@
         headerMoreItem.appendChild(headerMoreMenu);
         headerWrapper.appendChild(headerMoreItem);
         headerMoreBtn.addEventListener('click', function () {
-              event.stopPropagation();
-             headerMoreItem.classList.toggle('active');
+          event.stopPropagation();
+          headerMoreItem.classList.toggle('active');
         });
         window.onclick = function(event) {
           headerMoreItem.classList.remove("active");


### PR DESCRIPTION
Pull Request for Issue #27530 .

### Summary of Changes
I added following lines into the template js file:
` headerMoreBtn.addEventListener('click', function () {
		      event.stopPropagation();
		      headerMoreItem.classList.toggle('active');
	    });
	    window.onclick = function(event) {
		      headerMoreItem.classList.remove("active");
	    }`

### Testing Instructions
Test if the dropdown is closed when clicking anywhere else
See if the code makes sense - I am not too familiar with Javascript 

### Actual result BEFORE applying this Pull Request
The dropdown stays open when clicking outside the menu

### Expected result AFTER applying this Pull Request
The dropdown closes when clicking outside the menu

### Documentation Changes Required
no
