### PR TITLE
[4.0] check for libxml

### DIFF
--- a/installation/src/Application/InstallationApplication.php
+++ b/installation/src/Application/InstallationApplication.php
@@ -334,7 +334,7 @@ final class InstallationApplication extends CMSApplication
 		if (!function_exists('xml_parser_create'))
 		{
 			$output   = 'Joomla requires the libxml PHP extension. This should be enabled by default.';
-			$template = JPATH_ROOT . '/media/system/noxml.html';
+			$template = JPATH_ROOT . '/media/system/html/noxml.html';
 
 			if (file_exists($template))
 			{

--- a/installation/src/Application/InstallationApplication.php
+++ b/installation/src/Application/InstallationApplication.php
@@ -333,7 +333,15 @@ final class InstallationApplication extends CMSApplication
 	{
 		if (!function_exists('xml_parser_create'))
 		{
-			die('Joomla requires the libxml PHP extension. This should be enabled by default.');
+			$output   = 'Joomla requires the libxml PHP extension. This should be enabled by default.';
+			$template = JPATH_ROOT . '/media/system/noxml.html';
+
+			if (file_exists($template ))
+			{
+				$output = file_get_contents($template);
+			}
+
+			die($output);
 		}
 
 		$xml = simplexml_load_file(JPATH_INSTALLATION . '/localise.xml');

--- a/installation/src/Application/InstallationApplication.php
+++ b/installation/src/Application/InstallationApplication.php
@@ -336,7 +336,7 @@ final class InstallationApplication extends CMSApplication
 			$output   = 'Joomla requires the libxml PHP extension. This should be enabled by default.';
 			$template = JPATH_ROOT . '/media/system/noxml.html';
 
-			if (file_exists($template ))
+			if (file_exists($template))
 			{
 				$output = file_get_contents($template);
 			}

--- a/installation/src/Application/InstallationApplication.php
+++ b/installation/src/Application/InstallationApplication.php
@@ -331,6 +331,11 @@ final class InstallationApplication extends CMSApplication
 	 */
 	public function getLocalise()
 	{
+		if(!function_exists('xml_parser_create'))
+		{
+			die ('Joomla requires the libxml PHP extension. This should be enabled by default.');
+		}
+
 		$xml = simplexml_load_file(JPATH_INSTALLATION . '/localise.xml');
 
 		if (!$xml)

--- a/installation/src/Application/InstallationApplication.php
+++ b/installation/src/Application/InstallationApplication.php
@@ -331,9 +331,9 @@ final class InstallationApplication extends CMSApplication
 	 */
 	public function getLocalise()
 	{
-		if(!function_exists('xml_parser_create'))
+		if (!function_exists('xml_parser_create'))
 		{
-			die ('Joomla requires the libxml PHP extension. This should be enabled by default.');
+			die('Joomla requires the libxml PHP extension. This should be enabled by default.');
 		}
 
 		$xml = simplexml_load_file(JPATH_INSTALLATION . '/localise.xml');


### PR DESCRIPTION
PR for #29425

This is a real edge case discovered by @fedik https://github.com/joomla/joomla-cms/issues/29425#issuecomment-640010134

libxml is enabled by default when compiling php and it cannot be disabled etc in a php.ini

The check I have put in place is the same one that myBB uses for the same issue.

The only questions are
1. Did I put the check early enough
2. Do we really need it for such an edge case
