### PR TITLE
[4.0] Fix Notice in edit account

### DIFF
--- a/administrator/components/com_admin/tmpl/profile/edit.php
+++ b/administrator/components/com_admin/tmpl/profile/edit.php
@@ -12,7 +12,6 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
-use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\Component\Users\Administrator\Helper\UsersHelper;
 
@@ -88,7 +87,7 @@ $fieldsets = $this->form->getFieldsets();
 
 	<?php echo HTMLHelper::_('uitab.endTab'); ?>
 	<?php endif; ?>
-	<?php echo LayoutHelper::render('joomla.edit.params', $this); ?>
+
 	<?php echo HTMLHelper::_('uitab.endTabSet'); ?>
 	<input type="hidden" name="task" value="">
 	<input type="hidden" name="return" value="<?php echo $input->get('return', '', 'BASE64'); ?>">


### PR DESCRIPTION
Pull Request for Issue #31734 .

### Summary of Changes
Remove  Line 91 	<?php echo LayoutHelper::render('joomla.edit.params', $this); ?>

This probably is the result of a merge conflict @wilsonge, after merging the PR #29251


### Testing Instructions
Set error reporting "maximum", open user - edit account 


### Actual result BEFORE applying this Pull Request
Lotes of Notices 


### Expected result AFTER applying this Pull Request
No Notices 



### Documentation Changes Required
no
