### PR TITLE
[4.0] Loading plg_system_actionlogs lang even when disabled

### DIFF
--- a/administrator/components/com_actionlogs/src/Helper/ActionlogsHelper.php
+++ b/administrator/components/com_actionlogs/src/Helper/ActionlogsHelper.php
@@ -340,6 +340,9 @@ class ActionlogsHelper
 			|| $lang->load($extension, JPATH_PLUGINS . '/' . $type . '/' . $name);
 		}
 
+		// Load plg_system_actionlogs too
+		$lang->load('plg_system_actionlogs', JPATH_ADMINISTRATOR);
+
 		// Load com_privacy too.
 		$lang->load('com_privacy', JPATH_ADMINISTRATOR);
 	}


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/31122#issuecomment-748570793

### Summary of Changes
As title says.


### Testing Instructions
Enable the plg_system_actionlogs plugin.
Switch to Home dashboard and look at the Latest Actions Module.

Then disable the plg_system_actionlogs plugin and look again at the  Latest Actions Module.

Patch and redo.

### Actual result BEFORE applying this Pull Request
Plugin enabled:

<img width="615" alt="Screen Shot 2020-12-21 at 08 50 14" src="https://user-images.githubusercontent.com/869724/102752259-937cf880-4369-11eb-8828-d3763c48bac1.png">

Plugin disabled: the system plugin lang file is not loaded.

<img width="544" alt="Screen Shot 2020-12-21 at 08 52 14" src="https://user-images.githubusercontent.com/869724/102752429-de970b80-4369-11eb-9165-fe23341bc9ec.png">

### Expected result AFTER applying this Pull Request

Same result when enabled or disabled

<img width="567" alt="Screen Shot 2020-12-21 at 08 53 37" src="https://user-images.githubusercontent.com/869724/102752560-09815f80-436a-11eb-9812-e1706892680c.png">

