### PR TITLE
[4.0] Fix for subfields values not outputting 0 values

### DIFF
--- a/plugins/fields/subfields/subfields.php
+++ b/plugins/fields/subfields/subfields.php
@@ -185,15 +185,8 @@ class PlgFieldsSubfields extends FieldsPlugin
 			// For each row, iterate over all the subfields
 			foreach ($this->getSubfieldsFromField($field) as $subfield)
 			{
-				// Just to be sure, unset this subfields value (and rawvalue)
-				$subfield->rawvalue = $subfield->value = '';
-
-				// If we have data for this field in the current row
-				if (isset($row[$subfield->name]) && $row[$subfield->name])
-				{
-					// Take over the data into our virtual subfield
-					$subfield->rawvalue = $subfield->value = $row[$subfield->name];
-				}
+				// Fill value (and rawvalue) if we have data for this subfield in the current row, otherwise set them to empty
+				$subfield->rawvalue = $subfield->value = isset($row[$subfield->name]) ? $row[$subfield->name] : '';
 
 				// Do we want to render the value of this field, and is the value non-empty?
 				if ($subfield->value !== '' && $subfield->render_values == '1')


### PR DESCRIPTION
### Summary of Changes

Very quick fix.

It turns out that having a 0 as the value of a subfield wasn't outputting the value. This fixes it.

### Testing Instructions

Create a subfields instance containing for example an integer field, or a text field, or a radio field, etc. that can contain a 0 value.

In the article form, give this field a 0 value inside the subfields.

### Actual result BEFORE applying this Pull Request

The 0 values are not output, they're turned into an empty string.

### Expected result AFTER applying this Pull Request

The 0 values are output correctly.

### Documentation Changes Required

None.