### PR TITLE
[4.0] Render com_admin tabs with the global JLayout

### DIFF
--- a/administrator/components/com_admin/tmpl/profile/edit.php
+++ b/administrator/components/com_admin/tmpl/profile/edit.php
@@ -12,6 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\Component\Users\Administrator\Helper\UsersHelper;
 
@@ -24,6 +25,8 @@ $input = Factory::getApplication()->input;
 // Get the form fieldsets.
 $fieldsets = $this->form->getFieldsets();
 
+// Fieldsets to not automatically render by /layouts/joomla/edit/params.php
+$this->useCoreUI = true;
 ?>
 <form
 	action="<?php echo Route::_('index.php?option=com_admin&view=profile&layout=edit&id=' . $this->item->id); ?>"
@@ -34,14 +37,7 @@ $fieldsets = $this->form->getFieldsets();
 	class="form-validate"
 >
 	<?php echo HTMLHelper::_('uitab.startTabSet', 'myTab', ['active' => 'user_details']); ?>
-	<?php foreach ($fieldsets as $fieldset) : ?>
-		<?php echo HTMLHelper::_('uitab.addTab', 'myTab', $fieldset->name, Text::_($fieldset->label)); ?>
-		<?php foreach ($this->form->getFieldset($fieldset->name) as $field) : ?>
-			<?php echo $field->renderField(); ?>
-		<?php endforeach; ?>
-		<?php echo HTMLHelper::_('uitab.endTab'); ?>
-	<?php endforeach; ?>
-
+	<?php echo LayoutHelper::render('joomla.edit.params', $this); ?>
 	<?php if (!empty($this->twofactorform) && $this->item->id) : ?>
 	<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'twofactorauth', Text::_('COM_ADMIN_PROFILE_TWO_FACTOR_AUTH')); ?>
 	<div class="control-group">


### PR DESCRIPTION
### Summary of Changes
Renders all the tabs in JLayout with the global layout render rather than something built into the component layout. This gives greater normalisation across the rest of the CMS Component views

### Testing Instructions
Same tabs and fields when editing profile in com_admin before and after patch. However after patch the first tabs fields are grouped into 3 columns like in other layouts

### Documentation Changes Required
None
