### PR TITLE
[4.0] Do not delete associated tags while reordering

### DIFF
--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -1499,6 +1499,11 @@ abstract class AdminModel extends FormModel
 		{
 			$this->table->load((int) $pk);
 
+			// We don't want to modify tags on reorder, not removing the tagsHelper removes all tags asociated
+			if (property_exists($this->table, 'tagsHelper')) {
+				unset($this->table->tagsHelper);
+			}
+
 			// Access checks.
 			if (!$this->canEditState($this->table))
 			{


### PR DESCRIPTION
Pull Request for Issue #31751 .

### Summary of Changes
Remove loaded tags from reorder table.


### Testing Instructions
* Create several articles, or categories or any other tagable and order able items 
* set tags to the items
* reorder the items


### Actual result BEFORE applying this Pull Request
Tags get deleted


### Expected result AFTER applying this Pull Request
Tags still exists


