### PR TITLE
[4.0] menu xtd-editor icon

### DIFF
--- a/plugins/editors-xtd/menu/menu.php
+++ b/plugins/editors-xtd/menu/menu.php
@@ -56,10 +56,14 @@ class PlgButtonMenu extends CMSPlugin
 		$button->modal   = true;
 		$button->link    = $link;
 		$button->text    = Text::_('PLG_EDITORS-XTD_MENU_BUTTON_MENU');
-		$button->name    = 'share-alt';
-		$button->iconSVG = '<svg viewBox="0 0 32 32" width="24" height="24"><path d="M8 20c0 0 1.838-6 12-6v6l12-8-12-8v6c-8 0-12 4.99-12 10zM22'
-							. ' 24h-18v-12h3.934c0.315-0.372 0.654-0.729 1.015-1.068 1.374-1.287 3.018-2.27 4.879-2.932h-13.827v20h26v-8.395l-4 2.'
-							. '667v1.728z"></path></svg>';
+		$button->name    = 'list';
+		$button->iconSVG = '<svg viewBox="0 0 512 512"  width="24" height="24"><path d="M80 368H16a16 16 0 0 0-16 16v64a16 16 0 0 0 16 16h64a16 1'
+							. '6 0 0 0 16-16v-64a16 16 0 0 0-16-16zm0-320H16A16 16 0 0 0 0 64v64a16 16 0 0 0 16 16h64a16 16 0 0 0 16-16V64a16 16 '
+							. '0 0 0-16-16zm0 160H16a16 16 0 0 0-16 16v64a16 16 0 0 0 16 16h64a16 16 0 0 0 16-16v-64a16 16 0 0 0-16-16zm416 176H1'
+							. '76a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h320a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm0-320H176a16 16 0 0 0-16 16'
+							. 'v32a16 16 0 0 0 16 16h320a16 16 0 0 0 16-16V80a16 16 0 0 0-16-16zm0 160H176a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16'
+							. 'h320a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16z"></path></svg>';
+
 		$button->options = [
 			'height' => '300px',
 			'width'  => '800px',


### PR DESCRIPTION
Corrects the icon for the editor so that is the same icon used for the menu elsewhere

### Before

![image](https://user-images.githubusercontent.com/1296369/102996822-a800f280-451b-11eb-8e59-de377633ecfb.png)

![image](https://user-images.githubusercontent.com/1296369/102996865-c23ad080-451b-11eb-89ac-6a4882de8108.png)

### After

![image](https://user-images.githubusercontent.com/1296369/102996803-9f102100-451b-11eb-8f20-7ec9ca4c2b03.png)
