### PR TITLE
[4.0] html5 chrome fix [a11y] and markup

### DIFF
--- a/layouts/chromes/html5.php
+++ b/layouts/chromes/html5.php
@@ -29,14 +29,21 @@ $moduleAttribs['class'] .= $bootstrapSize !== 0 ? ' col-md-' . $bootstrapSize : 
 $headerTag              = htmlspecialchars($params->get('header_tag', 'h3'), ENT_QUOTES, 'UTF-8');
 $headerClass            = htmlspecialchars($params->get('header_class', ''), ENT_QUOTES, 'UTF-8');
 $headerAttribs          = [];
-$headerAttribs['class'] = $headerClass;
 
-if ($module->showtitle) :
-	$moduleAttribs['aria-labelledby'] = 'mod-' . $module->id;
-	$headerAttribs['id']             = 'mod-' . $module->id;
-else:
-	$moduleAttribs['aria-label'] = $module->title;
-endif;
+// Only output a header class if one is set
+if ($headerClass != '') {
+	$headerAttribs['class'] = $headerClass;
+}
+
+// Only add aria if the moduleTag is not a div
+if ($moduleTag != 'div') {
+	if ($module->showtitle) :
+		$moduleAttribs['aria-labelledby'] = 'mod-' . $module->id;
+		$headerAttribs['id']             = 'mod-' . $module->id;
+	else:
+		$moduleAttribs['aria-label'] = $module->title;
+	endif;
+}
 
 $header = '<' . $headerTag . ' ' . ArrayHelper::toString($headerAttribs) . '>' . $module->title . '</' . $headerTag . '>';
 ?>

--- a/layouts/chromes/html5.php
+++ b/layouts/chromes/html5.php
@@ -31,13 +31,13 @@ $headerClass            = htmlspecialchars($params->get('header_class', ''), ENT
 $headerAttribs          = [];
 
 // Only output a header class if one is set
-if ($headerClass != '')
+if ($headerClass !== '')
 {
 	$headerAttribs['class'] = $headerClass;
 }
 
 // Only add aria if the moduleTag is not a div
-if ($moduleTag != 'div')
+if ($moduleTag !== 'div')
 {
 	if ($module->showtitle) :
 		$moduleAttribs['aria-labelledby'] = 'mod-' . $module->id;

--- a/layouts/chromes/html5.php
+++ b/layouts/chromes/html5.php
@@ -41,7 +41,7 @@ if ($moduleTag != 'div')
 {
 	if ($module->showtitle) :
 		$moduleAttribs['aria-labelledby'] = 'mod-' . $module->id;
-		$headerAttribs['id']             = 'mod-' . $module->id;
+		$headerAttribs['id']              = 'mod-' . $module->id;
 	else:
 		$moduleAttribs['aria-label'] = $module->title;
 	endif;

--- a/layouts/chromes/html5.php
+++ b/layouts/chromes/html5.php
@@ -31,12 +31,14 @@ $headerClass            = htmlspecialchars($params->get('header_class', ''), ENT
 $headerAttribs          = [];
 
 // Only output a header class if one is set
-if ($headerClass != '') {
+if ($headerClass != '')
+{
 	$headerAttribs['class'] = $headerClass;
 }
 
 // Only add aria if the moduleTag is not a div
-if ($moduleTag != 'div') {
+if ($moduleTag != 'div')
+{
 	if ($module->showtitle) :
 		$moduleAttribs['aria-labelledby'] = 'mod-' . $module->id;
 		$headerAttribs['id']             = 'mod-' . $module->id;


### PR DESCRIPTION
### Summary of Changes
> @hans2103 introduced code with #29886 which correctly adds aria values to the module if it is using a landmark. However it also adds the value if it is a div and it has no effect here at all as assistive tech can not _see_ it
> 
> Reference https://developer.paciellogroup.com/blog/2017/07/short-note-on-aria-label-aria-labelledby-and-aria-describedby/
> 
> Summary
> If you use aria-label, aria-labelledby, or aria-describedby with any other elements (like div, span, p, blockquote, or strong etc.), they generally won’t work across all browser/assistive technology combinations.
> 
> Confirmed that this is still valid advice with the author https://twitter.com/LeonieWatson/status/1335905663113900033

With this PR the aria values are only added if the module is NOT a div ie its a section etc

Additionally there was no check for the presence of a header class as a result by default there would be an empty class


### Testing Instructions
Create a module and make sure it has the html5 chrome



### Actual result BEFORE applying this Pull Request
```
<div class="moduletable " aria-labelledby="mod-1">
	<h3 class="" id="mod-1">Title</h3>
```


### Expected result AFTER applying this Pull Request
```
<div class="moduletable ">
	<h3>Module Title</h3>
```

#### With header class
```
<div class="moduletable ">
	<h3 class="example">Module Title</h3>
```

#### Not a div
```
<section class="moduletable " aria-labelledby="mod-1">
	<h3 id="mod-1">Title</h3>
```



### Note
This is Partial Pull Request for Issue #31609 

If approved I will make similar PR for the same mistakes in the cassiopeia chromes