### PR TITLE
[3.x] Versions button

### DIFF
--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -7736,6 +7736,20 @@ ul.manager .height-50 .icon-folder-2 {
 .header-search .mod-languages ul {
 	margin: 0 0 5px 0;
 }
+.btn-group > .versions {
+	-webkit-border-top-right-radius: 4px;
+	-moz-border-radius-topright: 4px;
+	border-top-right-radius: 4px;
+	-webkit-border-bottom-right-radius: 4px;
+	-moz-border-radius-bottomright: 4px;
+	border-bottom-right-radius: 4px;
+	-webkit-border-top-left-radius: 4px;
+	-moz-border-radius-topleft: 4px;
+	border-top-left-radius: 4px;
+	-webkit-border-bottom-left-radius: 4px;
+	-moz-border-radius-bottomleft: 4px;
+	border-bottom-left-radius: 4px;
+}
 .rtl .navigation .nav-child {
 	left: auto;
 	right: 0;

--- a/templates/protostar/html/layouts/joomla/form/field/contenthistory.php
+++ b/templates/protostar/html/layouts/joomla/form/field/contenthistory.php
@@ -58,6 +58,6 @@ echo JHtml::_(
 );
 
 ?>
-<button type="button" onclick="jQuery('#versionsModal').modal('show')" class="btn" data-toggle="modal" title="<?php echo $label; ?>">
+<button type="button" onclick="jQuery('#versionsModal').modal('show')" class="btn versions" data-toggle="modal" title="<?php echo $label; ?>">
 	<span class="icon-archive" aria-hidden="true"></span><?php echo $label; ?>
 </button>

--- a/templates/protostar/less/template.less
+++ b/templates/protostar/less/template.less
@@ -733,6 +733,15 @@ ul.manager .height-50 .icon-folder-2 {
 
 /* mod_search in position-0 */
 .header-search .mod-languages ul {
-	margin: 0 0 5px 0;
-	}
+    margin: 0 0 5px 0;
+}
+
+/* versions button radius */
+.btn-group > .versions{
+    .border-top-right-radius(@baseBorderRadius);
+    .border-bottom-right-radius(@baseBorderRadius);
+    .border-top-left-radius(@baseBorderRadius);
+    .border-bottom-left-radius(@baseBorderRadius);
+}
+
 @import "template_rtl.less"; // Specific for rtl. Always load last.


### PR DESCRIPTION
New class and Template css override for the versions button so that it has 4 rounded corners.

Pull request for #28659

To test log in to the frontend and open an article for editing

### Before
![image](https://user-images.githubusercontent.com/1296369/103078072-059f4880-45c9-11eb-9a81-ce1618693d36.png)

### After
![image](https://user-images.githubusercontent.com/1296369/103078057-f8825980-45c8-11eb-818c-35cf277564bb.png)
