### PR TITLE
[4.0] Finder js Uncaught TypeError when Advanced Search is set to hide or link to component

### DIFF
--- a/build/media_source/com_finder/js/finder.es6.js
+++ b/build/media_source/com_finder/js/finder.es6.js
@@ -41,7 +41,7 @@
     const advanced = event.target.querySelector('.js-finder-advanced');
 
     // Disable select boxes with no value selected.
-    if (advanced !== null && advanced.length) {
+    if (advanced) {
       const fields = [].slice.call(advanced.querySelectorAll('select'));
 
       fields.forEach((field) => {

--- a/build/media_source/com_finder/js/finder.es6.js
+++ b/build/media_source/com_finder/js/finder.es6.js
@@ -41,7 +41,7 @@
     const advanced = event.target.querySelector('.js-finder-advanced');
 
     // Disable select boxes with no value selected.
-    if (advanced.length) {
+    if (advanced !== null && advanced.length) {
       const fields = [].slice.call(advanced.querySelectorAll('select'));
 
       fields.forEach((field) => {


### PR DESCRIPTION
### Summary of Changes
As title says


### Testing Instructions
Create a smart search module or/and create a smartsearch menu item.
Set Advanced Search parameter to Hide (or, in the module, to Link to Component)

In frontend search for any term. 
Look at Console.

Patch, run npm and test again.

### Actual result BEFORE applying this Pull Request
Set to Hide
```
Uncaught TypeError: advanced is null
    onSubmit http://localhost:8888/newfolder/joomla40/media/com_finder/js/finder.js?d95aaed2474d55e8cd9c2b345143f252:54
finder.js:54:9
    onSubmit http://localhost:8888/newfolder/joomla40/media/com_finder/js/finder.js?d95aaed2474d55e8cd9c2b345143f252:54
```

Set to Link to Component

```    
    Uncaught TypeError: advanced is null
    onSubmit http://localhost:8888/newfolder/joomla40/media/com_finder/js/finder.js?b0b050708b2289022423e09adb1ec45a:54
    onBoot http://localhost:8888/newfolder/joomla40/media/com_finder/js/finder.js?b0b050708b2289022423e09adb1ec45a:77
    onBoot http://localhost:8888/newfolder/joomla40/media/com_finder/js/finder.js?b0b050708b2289022423e09adb1ec45a:76
    EventListener.handleEvent* http://localhost:8888/newfolder/joomla40/media/com_finder/js/finder.js?b0b050708b2289022423e09adb1ec45a:83
    <anonymous> http://localhost:8888/newfolder/joomla40/media/com_finder/js/finder.js?b0b050708b2289022423e09adb1ec45a:84

````

### Expected result AFTER applying this Pull Request
No more Uncaught Error
