### PR TITLE
[4.0] Cassiopeia image select

### DIFF
--- a/templates/cassiopeia/scss/template.scss
+++ b/templates/cassiopeia/scss/template.scss
@@ -35,6 +35,7 @@
 @import "vendor/bootstrap/custom-forms";
 @import "vendor/bootstrap/collapse";
 @import "vendor/bootstrap/dropdown";
+@import "vendor/bootstrap/forms";
 @import "vendor/bootstrap/lists";
 @import "vendor/bootstrap/modal";
 @import "vendor/bootstrap/nav";

--- a/templates/cassiopeia/scss/vendor/bootstrap/_forms.scss
+++ b/templates/cassiopeia/scss/vendor/bootstrap/_forms.scss
@@ -1,0 +1,14 @@
+.field-media-wrapper {
+  display: block;
+  width: 100%;
+  max-width: calc(50vw - 5rem);
+
+  .field-media-preview {
+    width: 100%;
+    max-width: none;
+  }
+
+  @include media-breakpoint-down(md) {
+    min-width: 100%;
+  }
+}


### PR DESCRIPTION
Adds the same scss that is used in the backend for the image select field so that it is styled correctly.

To test dont forget to run npm

### Before
![image](https://user-images.githubusercontent.com/1296369/103134452-322a9180-46a9-11eb-9317-6cbaf73c73d1.png)

### After
![image](https://user-images.githubusercontent.com/1296369/103134444-250da280-46a9-11eb-8960-61c09bf62c60.png)
