### PR TITLE
[4.0] Fix movecopy JS in field list

### DIFF
--- a/administrator/components/com_fields/tmpl/fields/default_batch_body.php
+++ b/administrator/components/com_fields/tmpl/fields/default_batch_body.php
@@ -15,6 +15,7 @@ use Joomla\CMS\Layout\LayoutHelper;
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('com_fields.admin-fields-batch');
+$wa->useScript('joomla.batch-copymove');
 
 $context   = $this->escape($this->state->get('filter.context'));
 ?>

--- a/administrator/components/com_menus/tmpl/items/default_batch_body.php
+++ b/administrator/components/com_menus/tmpl/items/default_batch_body.php
@@ -26,6 +26,7 @@ if ($clientId == 1)
 	/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 	$wa = $this->document->getWebAssetManager();
 	$wa->useScript('com_menus.batch-body');
+	$wa->useScript('joomla.batch-copymove');
 }
 ?>
 <div class="container">

--- a/administrator/components/com_modules/tmpl/modules/default_batch_body.php
+++ b/administrator/components/com_modules/tmpl/modules/default_batch_body.php
@@ -33,7 +33,8 @@ Text::script('JGLOBAL_SELECT_PRESS_TO_SELECT');
 
 $this->document->getWebAssetManager()
 	->usePreset('choicesjs')
-	->useScript('webcomponent.field-fancy-select');
+	->useScript('webcomponent.field-fancy-select')
+	->useScript('joomla.batch-copymove');
 
 ?>
 

--- a/administrator/components/com_users/tmpl/users/default_batch_body.php
+++ b/administrator/components/com_users/tmpl/users/default_batch_body.php
@@ -25,6 +25,10 @@ $resetOptions = array(
 	HTMLHelper::_('select.option', 'no', Text::_('JNO'))
 );
 
+/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+$wa = Factory::getApplication()->getDocument()->getWebAssetManager();
+$wa->useScript('joomla.batch-copymove');
+
 ?>
 
 <div class="container">

--- a/administrator/components/com_users/tmpl/users/default_batch_body.php
+++ b/administrator/components/com_users/tmpl/users/default_batch_body.php
@@ -26,7 +26,7 @@ $resetOptions = array(
 );
 
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
-$wa = Factory::getApplication()->getDocument()->getWebAssetManager();
+$wa = $this->document->getWebAssetManager();
 $wa->useScript('joomla.batch-copymove');
 
 ?>

--- a/build/media_source/layouts/js/joomla/html/batch/batch-copymove.es6.js
+++ b/build/media_source/layouts/js/joomla/html/batch/batch-copymove.es6.js
@@ -8,6 +8,7 @@
     const batchCategory = document.getElementById('batch-category-id');
     const batchMenu = document.getElementById('batch-menu-id');
     const batchPosition = document.getElementById('batch-position-id');
+    const batchGroup = document.getElementById('batch-group-id');
     const batchCopyMove = document.getElementById('batch-copy-move');
     let batchSelector;
 
@@ -30,6 +31,10 @@
 
     if (batchPosition) {
       batchSelector = batchPosition;
+    }
+
+    if (batchGroup) {
+      batchSelector = batchGroup;
     }
 
     if (batchCopyMove) {

--- a/build/media_source/system/joomla.asset.json
+++ b/build/media_source/system/joomla.asset.json
@@ -188,9 +188,9 @@
       }
     },
     {
-      "name": "joomla.batch-language",
+      "name": "joomla.batch-copymove",
       "type": "script",
-      "uri": "layouts/joomla/html/batch/batch-language.min.js",
+      "uri": "layouts/joomla/html/batch/batch-copymove.min.js",
       "attributes": {
         "defer": true
       }

--- a/layouts/joomla/html/batch/adminlanguage.php
+++ b/layouts/joomla/html/batch/adminlanguage.php
@@ -9,7 +9,6 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 

--- a/layouts/joomla/html/batch/adminlanguage.php
+++ b/layouts/joomla/html/batch/adminlanguage.php
@@ -13,10 +13,6 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
-$wa = Factory::getApplication()->getDocument()->getWebAssetManager();
-$wa->useScript('joomla.batch-language');
-
 ?>
 <label id="batch-language-lbl" for="batch-language-id">
 	<?php echo Text::_('JLIB_HTML_BATCH_LANGUAGE_LABEL'); ?>

--- a/layouts/joomla/html/batch/item.php
+++ b/layouts/joomla/html/batch/item.php
@@ -29,7 +29,7 @@ $options = array(
 
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = Factory::getApplication()->getDocument()->getWebAssetManager();
-$wa->useScript('joomla.batch-language');
+$wa->useScript('joomla.batch-copymove');
 
 ?>
 <label id="batch-choose-action-lbl" for="batch-category-id">

--- a/layouts/joomla/html/batch/language.php
+++ b/layouts/joomla/html/batch/language.php
@@ -9,7 +9,6 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 

--- a/layouts/joomla/html/batch/language.php
+++ b/layouts/joomla/html/batch/language.php
@@ -13,10 +13,6 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
-$wa = Factory::getApplication()->getDocument()->getWebAssetManager();
-$wa->useScript('joomla.batch-language');
-
 ?>
 <label id="batch-language-lbl" for="batch-language-id">
 	<?php echo Text::_('JLIB_HTML_BATCH_LANGUAGE_LABEL'); ?>


### PR DESCRIPTION
Pull Request for Issue #31741  .

### Summary of Changes
Fix movecopy JS in field list
Rename movecopy JS to "movecopy" instead of "language"
Update webassets (remove from language add to movecopy)


### Testing Instructions
In general follow: #31741 but as this also renames the file and loads it on a different place, go through all "move & copy" batch functions and test if they still work


### Actual result BEFORE applying this Pull Request
Javascript error


### Expected result AFTER applying this Pull Request
No Javascript error


