### PR TITLE
Fix CSS build script to avoid multiple min files (Windows machine)

### DIFF
--- a/build/build-modules-js/compilecss.es6.js
+++ b/build/build-modules-js/compilecss.es6.js
@@ -66,7 +66,7 @@ module.exports.compile = (options, path) => {
                     Fs.copyFileSync(file, file.replace('/build/media_source/', '/media/').replace('\\build\\media_source\\', '\\media\\'));
                   }
                 }
-                if (file.match(/\.css/) && !file.match(/\/template(s)?\//)) {
+                if (file.match(/\.css/) && !(file.match(/\/template(s)?\//) || file.match(/\\template(s)?\\/))) {
                   // CSS file, we will copy the file and then minify it in place
                   // Ensure that the directories exist or create them
                   FsExtra.mkdirsSync(Path.dirname(file).replace('/build/media_source/', '/media/').replace('\\build\\media_source\\', '\\media\\'), {});


### PR DESCRIPTION
Pull Request for Issue #31790 .

### Summary of Changes
Improve build script for windows machines.


### Testing Instructions
See #31790 by using a windows machine


### Actual result BEFORE applying this Pull Request
a lot of ```min.min...min.css``` files


### Expected result AFTER applying this Pull Request
only filename.min.css files

@dgrammatiko I changed your suggestion a bit, but perhaps I'm wrong?

