### PR TITLE
[4.0] Move gzip command to work on windows

### DIFF
--- a/build/build.js
+++ b/build/build.js
@@ -3,14 +3,14 @@
  *
  * To get the complete functional media folder please run
  *
- * npm install
+ * npm ci
  *
  * For dedicated tasks, please run:
  * node build.js --build-pages  === will create the error pages (for incomplete repo build PHP+NPM)
  * node build.js --copy-assets  === will clean the media/vendor folder and then will populate the folder from node_modules
  * node build.js --compile-js   === will transpile ES6 files and also uglify the ES6,ES5 files
  * node build.js --compile-css  === will compile all the scss defined files and also create a minified version of the css
- *
+ * node build.js --gzip  === will create gzip files for all the minified stylesheets and scripts.'
  */
 
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -24,6 +24,7 @@ const compileCSS = require('./build-modules-js/compilecss.es6.js');
 const compileJS = require('./build-modules-js/compilejs.es6.js');
 const minifyVendor = require('./build-modules-js/javascript/minify-vendor.es6.js');
 const watch = require('./build-modules-js/watch.es6.js');
+const { gzipFiles } = require('./build-modules-js/gzip-assets.es6');
 
 // The settings
 const options = require('../package.json');
@@ -42,6 +43,7 @@ Program
   .option('--compile-js, --compile-js path', 'Handles ES6, ES5 and web component scripts')
   .option('--compile-css, --compile-css path', 'Compiles all the scss files to css')
   .option('--watch', 'Watch file changes and re-compile (ATM only works for the js in the media_source).')
+  .option('--gzip', 'Precompress all the minified stylesheets and scripts.')
   .on('--help', () => {
     // eslint-disable-next-line no-console
     console.log(`Version: ${options.version}`);
@@ -101,4 +103,9 @@ if (Program.compileJs) {
 // Compress/transpile the javascript files
 if (Program.watch) {
   watch.run();
+}
+
+// Compress/transpile the javascript files
+if (Program.gzip) {
+  gzipFiles();
 }

--- a/build/build.js
+++ b/build/build.js
@@ -105,7 +105,7 @@ if (Program.watch) {
   watch.run();
 }
 
-// Compress/transpile the javascript files
+// Gzip js/css files
 if (Program.gzip) {
   gzipFiles();
 }

--- a/build/build.js
+++ b/build/build.js
@@ -43,7 +43,7 @@ Program
   .option('--compile-js, --compile-js path', 'Handles ES6, ES5 and web component scripts')
   .option('--compile-css, --compile-css path', 'Compiles all the scss files to css')
   .option('--watch', 'Watch file changes and re-compile (ATM only works for the js in the media_source).')
-  .option('--gzip', 'Precompress all the minified stylesheets and scripts.')
+  .option('--gzip', 'Compress all the minified stylesheets and scripts.')
   .on('--help', () => {
     // eslint-disable-next-line no-console
     console.log(`Version: ${options.version}`);

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "install": "node build/build.js --copy-assets && node build/build.js --build-pages",
     "postinstall": "node build/build.js --compile-js && node build/build.js --compile-css && npm run build:com_media",
     "update": "node build/build.js --copy-assets && node build/build.js --build-pages && node build/build.js --compile-js && node build/build.js --compile-css",
-    "gzip": "node -e 'require(\"./build/build-modules-js/gzip-assets.es6.js\").gzipFiles()'",
+    "gzip": "node build/build.js --gzip",
     "watch:com_media": "cross-env NODE_ENV=development webpack --progress --hide-modules --watch --config administrator/components/com_media/webpack.config.js",
     "dev:com_media": "cross-env NODE_ENV=development webpack --progress --hide-modules --config administrator/components/com_media/webpack.config.js",
     "build:com_media": "cross-env NODE_ENV=production webpack --progress --hide-modules --config administrator/components/com_media/webpack.config.js"


### PR DESCRIPTION
Successor PR to https://github.com/joomla/joomla-cms/pull/31692 which doesn't work on Mac

There is a node command to gzip the assets

`npm run gzip`

When testing on windows it doesn't work although does on Mac

After applying this PR then running the same command and it will work. (note it will appear to hang at the end - just be patient its slow)