### PR TITLE
[4.0] Rework tags to have a dedicated interface

### DIFF
--- a/administrator/components/com_banners/src/Table/BannerTable.php
+++ b/administrator/components/com_banners/src/Table/BannerTable.php
@@ -389,6 +389,6 @@ class BannerTable extends Table implements VersionableTableInterface
 	 */
 	public function getTypeAlias()
 	{
-		return 'com_banners.banner';
+		return $this->typeAlias;
 	}
 }

--- a/administrator/components/com_banners/src/Table/ClientTable.php
+++ b/administrator/components/com_banners/src/Table/ClientTable.php
@@ -40,7 +40,7 @@ class ClientTable extends Table implements VersionableTableInterface
 	 */
 	public function __construct(DatabaseDriver $db)
 	{
-		$this->typeAlias        = 'com_banners.client';
+		$this->typeAlias = 'com_banners.client';
 
 		$this->setColumnAlias('published', 'state');
 
@@ -56,7 +56,7 @@ class ClientTable extends Table implements VersionableTableInterface
 	 */
 	public function getTypeAlias()
 	{
-		return 'com_banners.client';
+		return $this->typeAlias;
 	}
 
 	/**

--- a/administrator/components/com_contact/src/Table/ContactTable.php
+++ b/administrator/components/com_contact/src/Table/ContactTable.php
@@ -275,6 +275,6 @@ class ContactTable extends Table implements VersionableTableInterface, TaggableT
 	 */
 	public function getTypeAlias()
 	{
-		return 'com_contact.contact';
+		return $this->typeAlias;
 	}
 }

--- a/administrator/components/com_contact/src/Table/ContactTable.php
+++ b/administrator/components/com_contact/src/Table/ContactTable.php
@@ -16,6 +16,8 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\String\PunycodeHelper;
 use Joomla\CMS\Table\Table;
+use Joomla\CMS\Tag\TaggableTableInterface;
+use Joomla\CMS\Tag\TaggableTableTrait;
 use Joomla\CMS\Versioning\VersionableTableInterface;
 use Joomla\Database\DatabaseDriver;
 use Joomla\String\StringHelper;
@@ -25,8 +27,10 @@ use Joomla\String\StringHelper;
  *
  * @since  1.0
  */
-class ContactTable extends Table implements VersionableTableInterface
+class ContactTable extends Table implements VersionableTableInterface, TaggableTableInterface
 {
+	use TaggableTableTrait;
+
 	/**
 	 * Indicates that columns fully support the NULL value in the database
 	 *

--- a/administrator/components/com_content/src/Model/ArticleModel.php
+++ b/administrator/components/com_content/src/Model/ArticleModel.php
@@ -27,6 +27,7 @@ use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\String\PunycodeHelper;
 use Joomla\CMS\Table\Table;
 use Joomla\CMS\Table\TableInterface;
+use Joomla\CMS\Tag\TaggableTableInterface;
 use Joomla\CMS\UCM\UCMType;
 use Joomla\CMS\Versioning\VersionableModelTrait;
 use Joomla\CMS\Workflow\Workflow;
@@ -260,6 +261,12 @@ class ArticleModel extends AdminModel implements WorkflowModelInterface
 
 			// Set the new category ID
 			$this->table->catid = $categoryId;
+
+			// We don't want to modify tags - so remove the tags helper associated
+			if ($this->table instanceof TaggableTableInterface)
+			{
+				$this->table->clearTagsHelper();
+			}
 
 			// Check the row.
 			if (!$this->table->check())

--- a/administrator/components/com_content/src/Model/ArticleModel.php
+++ b/administrator/components/com_content/src/Model/ArticleModel.php
@@ -262,7 +262,7 @@ class ArticleModel extends AdminModel implements WorkflowModelInterface
 			// Set the new category ID
 			$this->table->catid = $categoryId;
 
-			// We don't want to modify tags - so remove the tags helper associated
+			// We don't want to modify tags - so remove the associated tags helper
 			if ($this->table instanceof TaggableTableInterface)
 			{
 				$this->table->clearTagsHelper();

--- a/administrator/components/com_newsfeeds/src/Table/NewsfeedTable.php
+++ b/administrator/components/com_newsfeeds/src/Table/NewsfeedTable.php
@@ -16,6 +16,8 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\String\PunycodeHelper;
 use Joomla\CMS\Table\Table;
+use Joomla\CMS\Tag\TaggableTableInterface;
+use Joomla\CMS\Tag\TaggableTableTrait;
 use Joomla\CMS\Versioning\VersionableTableInterface;
 use Joomla\Database\DatabaseDriver;
 use Joomla\String\StringHelper;
@@ -25,8 +27,10 @@ use Joomla\String\StringHelper;
  *
  * @since  1.6
  */
-class NewsfeedTable extends Table implements VersionableTableInterface
+class NewsfeedTable extends Table implements VersionableTableInterface, TaggableTableInterface
 {
+	use TaggableTableTrait;
+
 	/**
 	 * Indicates that columns fully support the NULL value in the database
 	 *

--- a/administrator/components/com_newsfeeds/src/Table/NewsfeedTable.php
+++ b/administrator/components/com_newsfeeds/src/Table/NewsfeedTable.php
@@ -210,6 +210,6 @@ class NewsfeedTable extends Table implements VersionableTableInterface, Taggable
 	 */
 	public function getTypeAlias()
 	{
-		return 'com_newsfeeds.newsfeed';
+		return $this->typeAlias;
 	}
 }

--- a/administrator/components/com_tags/src/Table/TagTable.php
+++ b/administrator/components/com_tags/src/Table/TagTable.php
@@ -256,6 +256,6 @@ class TagTable extends Nested implements VersionableTableInterface
 	 */
 	public function getTypeAlias()
 	{
-		return 'com_tags.tag';
+		return $this->typeAlias;
 	}
 }

--- a/administrator/components/com_users/src/Table/NoteTable.php
+++ b/administrator/components/com_users/src/Table/NoteTable.php
@@ -126,6 +126,6 @@ class NoteTable extends Table implements VersionableTableInterface
 	 */
 	public function getTypeAlias()
 	{
-		return 'com_users.note';
+		return $this->typeAlias;
 	}
 }

--- a/libraries/src/Event/Model/BeforeBatchCopy.php
+++ b/libraries/src/Event/Model/BeforeBatchCopy.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  (C) 2020 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\CMS\Event\Model;
+
+\defined('JPATH_PLATFORM') or die;
+
+use BadMethodCallException;
+use Joomla\CMS\Event\AbstractImmutableEvent;
+
+/**
+ * Event class for modifying batch copy data
+ *
+ * @since  4.0.0
+ */
+class BeforeBatchCopy extends AbstractImmutableEvent
+{
+	/**
+	 * Constructor.
+	 *
+	 * @param   string  $name       The event name.
+	 * @param   array   $arguments  The event arguments.
+	 *
+	 * @throws  BadMethodCallException
+	 *
+	 * @since   4.0.0
+	 */
+	public function __construct($name, array $arguments = array())
+	{
+		if (!\array_key_exists('sourceTable', $arguments))
+		{
+			throw new BadMethodCallException("Argument 'sourceTable' is required for event $name");
+		}
+
+		if (!\array_key_exists('updatedTable', $arguments))
+		{
+			throw new BadMethodCallException("Argument 'updatedTable' is required for event $name");
+		}
+
+		parent::__construct($name, $arguments);
+	}
+}

--- a/libraries/src/Event/Model/BeforeBatchCopy.php
+++ b/libraries/src/Event/Model/BeforeBatchCopy.php
@@ -16,7 +16,7 @@ use Joomla\CMS\Event\AbstractImmutableEvent;
 /**
  * Event class for modifying batch copy data
  *
- * @since  4.0.0
+ * @since  __DEPLOY_VERSION__
  */
 class BeforeBatchCopy extends AbstractImmutableEvent
 {
@@ -28,18 +28,13 @@ class BeforeBatchCopy extends AbstractImmutableEvent
 	 *
 	 * @throws  BadMethodCallException
 	 *
-	 * @since   4.0.0
+	 * @since   __DEPLOY_VERSION__
 	 */
 	public function __construct($name, array $arguments = array())
 	{
-		if (!\array_key_exists('sourceTable', $arguments))
+		if (!\array_key_exists('src', $arguments))
 		{
-			throw new BadMethodCallException("Argument 'sourceTable' is required for event $name");
-		}
-
-		if (!\array_key_exists('updatedTable', $arguments))
-		{
-			throw new BadMethodCallException("Argument 'updatedTable' is required for event $name");
+			throw new BadMethodCallException("Argument 'src' is required for event $name");
 		}
 
 		parent::__construct($name, $arguments);

--- a/libraries/src/Event/Model/BeforeBatchEvent.php
+++ b/libraries/src/Event/Model/BeforeBatchEvent.php
@@ -14,11 +14,11 @@ use BadMethodCallException;
 use Joomla\CMS\Event\AbstractImmutableEvent;
 
 /**
- * Event class for modifying batch copy data
+ * Event class for modifying a table object before a batch event is applied
  *
  * @since  __DEPLOY_VERSION__
  */
-class BeforeBatchCopy extends AbstractImmutableEvent
+class BeforeBatchEvent extends AbstractImmutableEvent
 {
 	/**
 	 * Constructor.
@@ -35,6 +35,11 @@ class BeforeBatchCopy extends AbstractImmutableEvent
 		if (!\array_key_exists('src', $arguments))
 		{
 			throw new BadMethodCallException("Argument 'src' is required for event $name");
+		}
+
+		if (!\array_key_exists('type', $arguments))
+		{
+			throw new BadMethodCallException("Argument 'type' is required for event $name");
 		}
 
 		parent::__construct($name, $arguments);

--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -1542,7 +1542,7 @@ abstract class AdminModel extends FormModel
 		{
 			$this->table->load((int) $pk);
 
-			// We don't want to modify tags on reorder, not removing the tagsHelper removes all tags associated
+			// We don't want to modify tags on reorder, not removing the tagsHelper removes all associated tags
 			if ($this->table instanceof TaggableTableInterface)
 			{
 				$this->table->clearTagsHelper();

--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -11,6 +11,7 @@ namespace Joomla\CMS\MVC\Model;
 \defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Component\ComponentHelper;
+use Joomla\CMS\Event\Model\BeforeBatchCopy;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\FormFactoryInterface;
 use Joomla\CMS\Language\Associations;
@@ -512,7 +513,11 @@ abstract class AdminModel extends FormModel
 			// New category ID
 			$this->table->catid = $categoryId;
 
-			Factory::getApplication()->triggerEvent($this->event_before_batch_copy, array($contexts, $originalTable, $this->table));
+			$event = new BeforeBatchCopy(
+				$this->event_before_batch_copy,
+				['sourceTable' => $originalTable, 'updatedTable' => $this->table]
+			);
+			Factory::getApplication()->triggerEvent($this->event_before_batch_copy, $event);
 
 			// TODO: Deal with ordering?
 			// $this->table->ordering = 1;

--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -460,8 +460,6 @@ abstract class AdminModel extends FormModel
 			// Pop the first ID off the stack
 			$pk = array_shift($pks);
 
-			$originalTable = clone $this->table;
-
 			$this->table->reset();
 
 			// Check that the row actually exists
@@ -515,7 +513,7 @@ abstract class AdminModel extends FormModel
 
 			$event = new BeforeBatchCopy(
 				$this->event_before_batch_copy,
-				['sourceTable' => $originalTable, 'updatedTable' => $this->table]
+				['src' => $this->table]
 			);
 			Factory::getApplication()->triggerEvent($this->event_before_batch_copy, $event);
 

--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -701,7 +701,7 @@ abstract class AdminModel extends FormModel
 			// Set the new category ID
 			$this->table->catid = $categoryId;
 
-			// We don't want to modify tags - so remove the tags helper associated
+			// We don't want to modify tags - so remove the associated tags helper
 			if ($this->table instanceof TaggableTableInterface)
 			{
 				$this->table->clearTagsHelper();

--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -620,7 +620,7 @@ abstract class AdminModel extends FormModel
 				$this->table->load($pk);
 				$this->table->language = $value;
 
-				// We don't want to modify tags - so remove the tags helper associated
+				// We don't want to modify tags - so remove the associated tags helper
 				if ($this->table instanceof TaggableTableInterface)
 				{
 					$this->table->clearTagsHelper();

--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -401,7 +401,7 @@ abstract class AdminModel extends FormModel
 				$this->table->load($pk);
 				$this->table->access = (int) $value;
 
-				// We don't want to modify tags - so remove the tags helper associated
+				// We don't want to modify tags - so remove the associated tags helper
 				if ($this->table instanceof TaggableTableInterface)
 				{
 					$this->table->clearTagsHelper();

--- a/libraries/src/Table/Category.php
+++ b/libraries/src/Table/Category.php
@@ -14,6 +14,8 @@ use Joomla\CMS\Access\Rules;
 use Joomla\CMS\Application\ApplicationHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Tag\TaggableTableInterface;
+use Joomla\CMS\Tag\TaggableTableTrait;
 use Joomla\CMS\Versioning\VersionableTableInterface;
 use Joomla\Database\DatabaseDriver;
 use Joomla\Database\ParameterType;
@@ -24,8 +26,10 @@ use Joomla\Registry\Registry;
  *
  * @since  1.5
  */
-class Category extends Nested implements VersionableTableInterface
+class Category extends Nested implements VersionableTableInterface, TaggableTableInterface
 {
+	use TaggableTableTrait;
+
 	/**
 	 * Indicates that columns fully support the NULL value in the database
 	 *

--- a/libraries/src/Table/Category.php
+++ b/libraries/src/Table/Category.php
@@ -47,6 +47,8 @@ class Category extends Nested implements VersionableTableInterface, TaggableTabl
 	 */
 	public function __construct(DatabaseDriver $db)
 	{
+		// @deprecated This format was used by tags and versioning before 4.0 before the introduction of the
+		//             getTypeAlias function. This notation with the {} will be removed in Joomla 5
 		$this->typeAlias = '{extension}.category';
 		parent::__construct('#__categories', 'id', $db);
 		$this->access = (int) Factory::getApplication()->get('access');

--- a/libraries/src/Table/Content.php
+++ b/libraries/src/Table/Content.php
@@ -49,6 +49,7 @@ class Content extends Table implements VersionableTableInterface, TaggableTableI
 	public function __construct(DatabaseDriver $db)
 	{
 		$this->typeAlias = 'com_content.article';
+
 		parent::__construct('#__content', 'id', $db);
 
 		// Set the alias since the column is called state
@@ -393,7 +394,7 @@ class Content extends Table implements VersionableTableInterface, TaggableTableI
 	}
 
 	/**
-	 * Get the type alias for the history table
+	 * Get the type alias for UCM features
 	 *
 	 * @return  string  The alias as described above
 	 *
@@ -401,6 +402,6 @@ class Content extends Table implements VersionableTableInterface, TaggableTableI
 	 */
 	public function getTypeAlias()
 	{
-		return 'com_content.article';
+		return $this->typeAlias;
 	}
 }

--- a/libraries/src/Table/Content.php
+++ b/libraries/src/Table/Content.php
@@ -14,6 +14,8 @@ use Joomla\CMS\Access\Rules;
 use Joomla\CMS\Application\ApplicationHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Tag\TaggableTableInterface;
+use Joomla\CMS\Tag\TaggableTableTrait;
 use Joomla\CMS\Versioning\VersionableTableInterface;
 use Joomla\Database\DatabaseDriver;
 use Joomla\Database\ParameterType;
@@ -25,8 +27,10 @@ use Joomla\String\StringHelper;
  *
  * @since  1.5
  */
-class Content extends Table implements VersionableTableInterface
+class Content extends Table implements VersionableTableInterface, TaggableTableInterface
 {
+	use TaggableTableTrait;
+
 	/**
 	 * Indicates that columns fully support the NULL value in the database
 	 *

--- a/libraries/src/Tag/TaggableTableInterface.php
+++ b/libraries/src/Tag/TaggableTableInterface.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  (C) 2020 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Tag;
+
+\defined('JPATH_PLATFORM') or die;
+
+use Joomla\CMS\Helper\TagsHelper;
+use Joomla\CMS\Table\TableInterface;
+
+/**
+ * Interface for a taggable Table class
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+interface TaggableTableInterface extends TableInterface
+{
+	/**
+	 * Get the type alias for the tags mapping table
+	 *
+	 * The type alias generally is the internal component name with the
+	 * content type. Ex.: com_content.article
+	 *
+	 * @return  string  The alias as described above
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getTypeAlias();
+
+	/**
+	 * Get the tags helper
+	 *
+	 * @return  ?TagsHelper  The tags helper object
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getTagsHelper(): ?TagsHelper;
+
+	/**
+	 * Set the tags helper
+	 *
+	 * @string   TagsHelper  $tagsHelper  The tags helper object
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function setTagsHelper(TagsHelper $tagsHelper): void;
+
+	/**
+	 * Clears a set tags helper
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function clearTagsHelper(): void;
+}

--- a/libraries/src/Tag/TaggableTableInterface.php
+++ b/libraries/src/Tag/TaggableTableInterface.php
@@ -44,7 +44,9 @@ interface TaggableTableInterface extends TableInterface
 	/**
 	 * Set the tags helper
 	 *
-	 * @string   TagsHelper  $tagsHelper  The tags helper object
+	 * @param   TagsHelper  $tagsHelper  The tags helper object
+	 *
+	 * @return  void
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */

--- a/libraries/src/Tag/TaggableTableTrait.php
+++ b/libraries/src/Tag/TaggableTableTrait.php
@@ -26,6 +26,8 @@ trait TaggableTableTrait
 	 *
 	 * @var    TagsHelper
 	 * @since  __DEPLOY_VERSION__
+	 * @note   The tags helper property is set to public for backwards compatibility for Joomla 4.0. It will be made a
+	 *         protected property in Joomla 5.0
 	 */
 	public $tagsHelper;
 

--- a/libraries/src/Tag/TaggableTableTrait.php
+++ b/libraries/src/Tag/TaggableTableTrait.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  (C) 2020 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Tag;
+
+\defined('JPATH_PLATFORM') or die;
+
+use Joomla\CMS\Helper\TagsHelper;
+use Joomla\CMS\Language\Text;
+use Joomla\CMS\Router\Route;
+
+/**
+ * Defines the trait for a Taggable Table Class.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+trait TaggableTableTrait
+{
+	/**
+	 * The tags helper property
+	 *
+	 * @var    TagsHelper
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public $tagsHelper;
+
+	/**
+	 * Get the tags helper
+	 *
+	 * @return  TagsHelper  The tags helper object
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getTagsHelper(): ?TagsHelper
+	{
+		return $this->tagsHelper;
+	}
+
+	/**
+	 * Set the tags helper
+	 *
+	 * @param   TagsHelper   $tagsHelper  The tags helper to be set
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function setTagsHelper(TagsHelper $tagsHelper): void
+	{
+		$this->tagsHelper = $tagsHelper;
+	}
+
+	/**
+	 * Clears the tags helper
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function clearTagsHelper(): void
+	{
+		$this->tagsHelper = null;
+	}
+}

--- a/plugins/behaviour/taggable/taggable.php
+++ b/plugins/behaviour/taggable/taggable.php
@@ -359,7 +359,7 @@ class PlgBehaviourTaggable extends CMSPlugin
 	 * Internal method
 	 * Parses a TypeAlias of the form "{variableName}.type", replacing {variableName} with table-instance variables variableName
 	 *
-	 * @param   TableInterface  $table  The table
+	 * @param   TaggableTableInterface  $table  The table
 	 *
 	 * @return  string
 	 *
@@ -367,14 +367,14 @@ class PlgBehaviourTaggable extends CMSPlugin
 	 *
 	 * @internal
 	 */
-	protected function parseTypeAlias(TableInterface &$table)
+	protected function parseTypeAlias(TaggableTableInterface &$table)
 	{
 		return preg_replace_callback('/{([^}]+)}/',
 			function ($matches) use ($table)
 			{
 				return $table->{$matches[1]};
 			},
-			$table->typeAlias
+			$table->getTypeAlias()
 		);
 	}
 }

--- a/plugins/behaviour/taggable/taggable.php
+++ b/plugins/behaviour/taggable/taggable.php
@@ -334,11 +334,11 @@ class PlgBehaviourTaggable extends CMSPlugin
 	public function onBeforeBatchCopy(CmsEvent\Model\BeforeBatchCopy $event)
 	{
 		/** @var TableInterface $oldTable */
-		$oldTable = $event['sourceTable'];
+		$sourceTable = $event['src'];
 
-		/** @var TableInterface $updatedTable */
-		$updatedTable = $event['updatedTable'];
-
-		$updatedTable->newTags = $oldTable->tagsHelper->tags;
+		if ($sourceTable instanceof TaggableTableInterface)
+		{
+			$sourceTable->newTags = $sourceTable->tagsHelper->tags;
+		}
 	}
 }

--- a/plugins/behaviour/taggable/taggable.php
+++ b/plugins/behaviour/taggable/taggable.php
@@ -325,20 +325,33 @@ class PlgBehaviourTaggable extends CMSPlugin
 	/**
 	 * Runs when an existing table object has been loaded
 	 *
-	 * @param   CmsEvent\Model\BeforeBatchCopy  $event  The event to handle
+	 * @param   CmsEvent\Model\BeforeBatchEvent $event The event to handle
 	 *
 	 * @return  void
 	 *
 	 * @since   4.0.0
 	 */
-	public function onBeforeBatchCopy(CmsEvent\Model\BeforeBatchCopy $event)
+	public function onBeforeBatch(CmsEvent\Model\BeforeBatchEvent $event)
 	{
 		/** @var TableInterface $oldTable */
 		$sourceTable = $event['src'];
 
-		if ($sourceTable instanceof TaggableTableInterface)
+		if (!($sourceTable instanceof TaggableTableInterface))
+		{
+			return;
+		}
+
+		if ($event['type'] === 'copy')
 		{
 			$sourceTable->newTags = $sourceTable->getTagsHelper()->tags;
+		}
+		else
+		{
+			/**
+			 * All other batch actions we don't want the tags to be modified so clear the helper - that way no actions
+			 * will be performed on store
+			 */
+			$sourceTable->clearTagsHelper();
 		}
 	}
 }

--- a/plugins/behaviour/taggable/taggable.php
+++ b/plugins/behaviour/taggable/taggable.php
@@ -338,7 +338,7 @@ class PlgBehaviourTaggable extends CMSPlugin
 
 		if ($sourceTable instanceof TaggableTableInterface)
 		{
-			$sourceTable->newTags = $sourceTable->tagsHelper->tags;
+			$sourceTable->newTags = $sourceTable->getTagsHelper()->tags;
 		}
 	}
 }


### PR DESCRIPTION
Pull Request for Issue #31127 (and addresses comments made in the original PR https://github.com/joomla/joomla-cms/pull/31793) .

I don't like making b/c breaks in functionality this late into the J4 development. But I think this is required before we start wrapping ourselves in circles with workarounds in batch funtionality.

### Summary of Changes
Reworks some of tags onto an interface (partly stolen from @Hackwar 's work in https://github.com/joomla/joomla-cms/pull/24551 but without some of the larger changes) like we already did with versions.

There's also a new plugin event specifically for batch events that will allow us to to transformations of objects on the data being created. I chose to have a plugin here as the newTag property is kinda internal to the taggable plugin. Whereas the other batch methods can simply use the interface and don't really have any tags logic (other than using for the interface methods)

The new `TaggableTableInterface` should also allow us to cleanup any other interactions (such as the existing saveorder code).

### Testing Instructions
Test tags functionality in all components (articles, categories, contact and newsfeeds). Confirm assigning, removing tags to all these things work. Confirm all still work

Test batch moving items to a new category or language. Before patch tags would get lost, after patch they don't.

Test batch copying items. Before patch tags are not preserved after patch they are.

### Documentation Changes Required
Interface and trait needs to be documented. We also should backport them as empty back to the 3.10 release like we did with the versioning
