### PR TITLE
[4.0] Normalizing contacts filters in backend and xtd modal

### DIFF
--- a/administrator/components/com_contact/forms/filter_contacts.xml
+++ b/administrator/components/com_contact/forms/filter_contacts.xml
@@ -38,12 +38,13 @@
 			name="category_id"
 			type="category"
 			label="JCATEGORY"
+			multiple="true"
 			extension="com_contact"
-			published="0,1,2"
+			layout="joomla.form.field.list-fancy-select"
+			hint="JOPTION_SELECT_CATEGORY"
 			onchange="this.form.submit();"
-			>
-			<option value="">JOPTION_SELECT_CATEGORY</option>
-		</field>
+			published="0,1,2"
+		/>
 
 		<field
 			name="access"

--- a/components/com_contact/forms/filter_contacts.xml
+++ b/components/com_contact/forms/filter_contacts.xml
@@ -24,14 +24,14 @@
 		<field
 			name="category_id"
 			type="category"
-			label="JOPTION_FILTER_CATEGORY"
-			description="JOPTION_FILTER_CATEGORY_DESC"
+			label="JCATEGORY"
+			multiple="true"
 			extension="com_contact"
-			published="0,1,2"
+			layout="joomla.form.field.list-fancy-select"
+			hint="JOPTION_SELECT_CATEGORY"
 			onchange="this.form.submit();"
-			>
-			<option value="">JOPTION_SELECT_CATEGORY</option>
-		</field>
+			published="0,1,2"
+		/>
 
 		<field
 			name="access"
@@ -57,13 +57,13 @@
 		<field
 			name="tag"
 			type="tag"
-			label="JOPTION_FILTER_TAG"
-			description="JOPTION_FILTER_TAG_DESC"
+			label="JTAG"
+			multiple="true"
 			mode="nested"
+			custom="false"
+			hint="JOPTION_SELECT_TAG"
 			onchange="this.form.submit();"
-			>
-			<option value="">JOPTION_SELECT_TAG</option>
-		</field>
+		/>
 
 		<field
 			name="level"

--- a/components/com_content/forms/filter_articles.xml
+++ b/components/com_content/forms/filter_articles.xml
@@ -82,13 +82,14 @@
 		<field
 			name="tag"
 			type="tag"
-			label="JOPTION_FILTER_TAG"
-			description="JOPTION_FILTER_TAG_DESC"
+			label="JTAG"
 			multiple="true"
-			class="multipleTags"
 			mode="nested"
+			custom="false"
+			hint="JOPTION_SELECT_TAG"
 			onchange="this.form.submit();"
 		/>
+
 	</fields>
 	<fields name="list">
 		<field


### PR DESCRIPTION
### Summary of Changes
Allow and correct display of multiple choice for contacts categories and tags, normalizing filters as done for articles.
_EDIT : also corrects hint for article xtd tags filter to use "- Select Tag -" instead of "Type or select some tags"_

### Important
The display in frontend xtd is corrected by https://github.com/joomla/joomla-cms/pull/31799


### Testing Instructions
Create some contacts categories and contacts in each.
Create some tags and assign one or multiple tags to the contacts created.
1. Display the Contacts Manager in backend and test filtering by category.
2. Edit an article in backend AND frontend and use CMS Content => Contacts dropdown to display the modal where to choose a contact to insert. Test filtering by category(ies) and Tag(s)

### Actual result BEFORE applying this Pull Request
Impossible to filter by multiple categories in front as in backend (Manager and xtd)
Wrong field display for category as well as multiple tags in the xtd.

manager

<img width="1025" alt="Screen Shot 2020-12-30 at 11 19 51" src="https://user-images.githubusercontent.com/869724/103345270-3da6ff80-4a91-11eb-972d-7b4782cc6dc2.png">

xtd (frontend)

<img width="1126" alt="Screen Shot 2020-12-30 at 11 24 00" src="https://user-images.githubusercontent.com/869724/103345394-92e31100-4a91-11eb-8a0b-4c654e53e83b.png">


### Expected result AFTER applying this Pull Request and also https://github.com/joomla/joomla-cms/pull/31799
Manager

<img width="943" alt="Screen Shot 2020-12-30 at 11 04 38" src="https://user-images.githubusercontent.com/869724/103344440-e2740d80-4a8e-11eb-9a71-eaa9bb2fbb23.png">

xtd (frontend)

<img width="1138" alt="Screen Shot 2020-12-30 at 11 06 32" src="https://user-images.githubusercontent.com/869724/103344515-1a7b5080-4a8f-11eb-9f22-179f4377fdab.png">



