### PR TITLE
[4.0][plugin][content][pagenavigation] fix wrong sql on order by

### DIFF
--- a/plugins/content/pagenavigation/pagenavigation.php
+++ b/plugins/content/pagenavigation/pagenavigation.php
@@ -89,7 +89,7 @@ class PlgContentPagenavigation extends CMSPlugin
 				{
 					// Use created if modified is not set
 					case 'modified':
-						$orderby = $db->quoteName('a.modified') . ' IS NULL THEN ' .
+						$orderby = 'CASE WHEN ' .  $db->quoteName('a.modified') . ' IS NULL THEN ' .
 						$db->quoteName('a.created') . ' ELSE ' . $db->quoteName('a.modified') . ' END';
 						break;
 

--- a/plugins/content/pagenavigation/pagenavigation.php
+++ b/plugins/content/pagenavigation/pagenavigation.php
@@ -90,7 +90,7 @@ class PlgContentPagenavigation extends CMSPlugin
 					// Use created if modified is not set
 					case 'modified':
 						$orderby = 'CASE WHEN ' . $db->quoteName('a.modified') . ' IS NULL THEN ' .
-						$db->quoteName('a.created') . ' ELSE ' . $db->quoteName('a.modified') . ' END';
+							$db->quoteName('a.created') . ' ELSE ' . $db->quoteName('a.modified') . ' END';
 						break;
 
 					// Use created if publish_up is not set

--- a/plugins/content/pagenavigation/pagenavigation.php
+++ b/plugins/content/pagenavigation/pagenavigation.php
@@ -89,7 +89,7 @@ class PlgContentPagenavigation extends CMSPlugin
 				{
 					// Use created if modified is not set
 					case 'modified':
-						$orderby = 'CASE WHEN ' .  $db->quoteName('a.modified') . ' IS NULL THEN ' .
+						$orderby = 'CASE WHEN ' . $db->quoteName('a.modified') . ' IS NULL THEN ' .
 						$db->quoteName('a.created') . ' ELSE ' . $db->quoteName('a.modified') . ' END';
 						break;
 


### PR DESCRIPTION
Pull Request for Issue #31803 .

### Summary of Changes
fixed the missed `CASE`


### Testing Instructions
1 create a category blog menu
2 create an article and put in on the category blog menu made in step 1
3 set article global options->shared->Date for Ordering to Modified
4 goto frontend of site, select category blog menu made in step 1 then select article made in step 2


### Actual result BEFORE applying this Pull Request
Article can be viewed ok


### Expected result AFTER applying this Pull Request
ERROR 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'THEN a.created ELSE a.modified END DESC' at line 5




