### PR TITLE
[4.0] Cleanup Image tests

### DIFF
--- a/tests/Unit/Libraries/Cms/Image/ImageTest.php
+++ b/tests/Unit/Libraries/Cms/Image/ImageTest.php
@@ -28,6 +28,41 @@ class ImageTest extends UnitTestCase
 	protected $instance;
 
 	/**
+	 * @var    string  The testing jpg image unique name.
+	 *
+	 * @since  4.0.0
+	 */
+	protected $testFile;
+
+	/**
+	 * @var    string  The testing gif image unique name.
+	 *
+	 * @since  4.0.0
+	 */
+	protected $testFileGif;
+
+	/**
+	 * @var    string  The testing png image unique name.
+	 *
+	 * @since  4.0.0
+	 */
+	protected $testFilePng;
+
+	/**
+	 * @var    string  The testing bmp image unique name.
+	 *
+	 * @since  4.0.0
+	 */
+	protected $testFileBmp;
+
+	/**
+	 * @var    string  The testing webp image unique name.
+	 *
+	 * @since  4.0.0
+	 */
+	protected $testFileWebp;
+
+	/**
 	 * Setup for testing.
 	 *
 	 * @return  void
@@ -172,7 +207,7 @@ class ImageTest extends UnitTestCase
 	 *
 	 * @return  void
 	 *
-	 * @covers  Joomla\CMS\Image\Image::__construct
+	 * @covers  \Joomla\CMS\Image\Image::__construct
 	 *
 	 * @since   4.0.0
 	 */
@@ -181,17 +216,17 @@ class ImageTest extends UnitTestCase
 		// Create a 10x10 image handle.
 		$testImageHandle = imagecreatetruecolor(10, 10);
 
-		// Create a new ImageInspector object from the handle.
-		$testImage = new ImageInspector($testImageHandle);
+		// Create a new Image object from the handle.
+		$testImage = new Image($testImageHandle);
 
-		// Verify that the handle created is the same one in the ImageInspector.
-		$this->assertSame($testImageHandle, $testImage->getClassProperty('handle'));
+		// Verify that the handle created is the same one in the Image.
+		$this->assertSame($testImageHandle, TestHelper::getValue($testImage, 'handle'));
 
-		// Create a new ImageInspector with no handle.
-		$testImage2 = new ImageInspector;
+		// Create a new Image with no handle.
+		$testImage2 = new Image;
 
-		// Verify that there is no handle in the ImageInspector.
-		$this->assertNull($testImage2->getClassProperty('handle'));
+		// Verify that there is no handle in the Image.
+		$this->assertNull(TestHelper::getValue($testImage2, 'handle'));
 	}
 
 	/**
@@ -204,21 +239,19 @@ class ImageTest extends UnitTestCase
 	 *
 	 * @return  void
 	 *
-	 * @covers  Joomla\CMS\Image\Image::loadFile
+	 * @covers  \Joomla\CMS\Image\Image::loadFile
 	 *
 	 * @since   4.0.0
 	 */
 	public function testloadFile()
 	{
-		// Get a new Image inspector.
-		$image = new ImageInspector;
-		$image->loadFile($this->testFile);
+		$this->instance->loadFile($this->testFile);
 
 		// Verify that the cropped image is the correct size.
-		$this->assertEquals(341, imagesy($image->getClassProperty('handle')));
-		$this->assertEquals(500, imagesx($image->getClassProperty('handle')));
+		$this->assertEquals(341, imagesy(TestHelper::getValue($this->instance, 'handle')));
+		$this->assertEquals(500, imagesx(TestHelper::getValue($this->instance, 'handle')));
 
-		$this->assertEquals($this->testFile, $image->getPath());
+		$this->assertEquals($this->testFile, $this->instance->getPath());
 	}
 
 	/**
@@ -231,21 +264,19 @@ class ImageTest extends UnitTestCase
 	 *
 	 * @return  void
 	 *
-	 * @covers  Joomla\CMS\Image\Image::loadFile
+	 * @covers  \Joomla\CMS\Image\Image::loadFile
 	 *
 	 * @since   4.0.0
 	 */
 	public function testloadFileGif()
 	{
-		// Get a new Image inspector.
-		$image = new ImageInspector;
-		$image->loadFile($this->testFileGif);
+		$this->instance->loadFile($this->testFileGif);
 
 		// Verify that the cropped image is the correct size.
-		$this->assertEquals(341, imagesy($image->getClassProperty('handle')));
-		$this->assertEquals(500, imagesx($image->getClassProperty('handle')));
+		$this->assertEquals(341, imagesy(TestHelper::getValue($this->instance, 'handle')));
+		$this->assertEquals(500, imagesx(TestHelper::getValue($this->instance, 'handle')));
 
-		$this->assertEquals($this->testFileGif, $image->getPath());
+		$this->assertEquals($this->testFileGif, $this->instance->getPath());
 	}
 
 	/**
@@ -258,21 +289,19 @@ class ImageTest extends UnitTestCase
 	 *
 	 * @return  void
 	 *
-	 * @covers  Joomla\CMS\Image\Image::loadFile
+	 * @covers  \Joomla\CMS\Image\Image::loadFile
 	 *
 	 * @since   4.0.0
 	 */
 	public function testloadFilePng()
 	{
-		// Get a new Image inspector.
-		$image = new ImageInspector;
-		$image->loadFile($this->testFilePng);
+		$this->instance->loadFile($this->testFilePng);
 
 		// Verify that the cropped image is the correct size.
-		$this->assertEquals(341, imagesy($image->getClassProperty('handle')));
-		$this->assertEquals(500, imagesx($image->getClassProperty('handle')));
+		$this->assertEquals(341, imagesy(TestHelper::getValue($this->instance, 'handle')));
+		$this->assertEquals(500, imagesx(TestHelper::getValue($this->instance, 'handle')));
 
-		$this->assertEquals($this->testFilePng, $image->getPath());
+		$this->assertEquals($this->testFilePng, $this->instance->getPath());
 	}
 
 	/**
@@ -285,21 +314,19 @@ class ImageTest extends UnitTestCase
 	 *
 	 * @return  void
 	 *
-	 * @covers  Joomla\CMS\Image\Image::loadFile
+	 * @covers  \Joomla\CMS\Image\Image::loadFile
 	 *
 	 * @since   4.0.0
 	 */
 	public function testloadFileWebp()
 	{
-		// Get a new Image inspector.
-		$image = new ImageInspector;
-		$image->loadFile($this->testFileWebp);
+		$this->instance->loadFile($this->testFileWebp);
 
 		// Verify that the cropped image is the correct size.
-		$this->assertEquals(341, imagesy($image->getClassProperty('handle')));
-		$this->assertEquals(500, imagesx($image->getClassProperty('handle')));
+		$this->assertEquals(341, imagesy(TestHelper::getValue($this->instance, 'handle')));
+		$this->assertEquals(500, imagesx(TestHelper::getValue($this->instance, 'handle')));
 
-		$this->assertEquals($this->testFileWebp, $image->getPath());
+		$this->assertEquals($this->testFileWebp, $this->instance->getPath());
 	}
 
 	/**
@@ -309,16 +336,14 @@ class ImageTest extends UnitTestCase
 	 *
 	 * @return  void
 	 *
-	 * @covers  Joomla\CMS\Image\Image::loadFile
+	 * @covers  \Joomla\CMS\Image\Image::loadFile
 	 * @since   4.0.0
 	 */
 	public function testloadFileBmp()
 	{
 		$this->expectException(\InvalidArgumentException::class);
 
-		// Get a new Image inspector.
-		$image = new ImageInspector;
-		$image->loadFile($this->testFileBmp);
+		$this->instance->loadFile($this->testFileBmp);
 	}
 
 	/**
@@ -328,16 +353,14 @@ class ImageTest extends UnitTestCase
 	 *
 	 * @return  void
 	 *
-	 * @covers  Joomla\CMS\Image\Image::loadFile
+	 * @covers  \Joomla\CMS\Image\Image::loadFile
 	 * @since   4.0.0
 	 */
 	public function testloadFileWithInvalidFile()
 	{
 		$this->expectException(\InvalidArgumentException::class);
 
-		// Get a new Image inspector.
-		$image = new ImageInspector;
-		$image->loadFile('bogus_file');
+		$this->instance->loadFile('bogus_file');
 	}
 
 	/**
@@ -347,27 +370,26 @@ class ImageTest extends UnitTestCase
 	 *
 	 * @return  void
 	 *
-	 * @covers  Joomla\CMS\Image\Image::resize
+	 * @covers  \Joomla\CMS\Image\Image::resize
 	 *
 	 * @since   4.0.0
 	 */
 	public function testResize()
 	{
 		// Get a new Image inspector.
-		$image = new ImageInspector;
-		$image->loadFile($this->testFile);
+		$this->instance->loadFile($this->testFile);
 
-		$image->resize(1000, 682, false);
-
-		// Verify that the resized image is the correct size.
-		$this->assertEquals(682, imagesy($image->getClassProperty('handle')));
-		$this->assertEquals(1000, imagesx($image->getClassProperty('handle')));
-
-		$image->resize(1000, 682, false, ImageInspector::SCALE_FIT);
+		$this->instance->resize(1000, 682, false);
 
 		// Verify that the resized image is the correct size.
-		$this->assertEquals(682, imagesy($image->getClassProperty('handle')));
-		$this->assertEquals(1000, imagesx($image->getClassProperty('handle')));
+		$this->assertEquals(682, imagesy(TestHelper::getValue($this->instance, 'handle')));
+		$this->assertEquals(1000, imagesx(TestHelper::getValue($this->instance, 'handle')));
+
+		$this->instance->resize(1000, 682, false, Image::SCALE_FIT);
+
+		// Verify that the resized image is the correct size.
+		$this->assertEquals(682, imagesy(TestHelper::getValue($this->instance, 'handle')));
+		$this->assertEquals(1000, imagesx(TestHelper::getValue($this->instance, 'handle')));
 	}
 
 	/**
@@ -378,7 +400,7 @@ class ImageTest extends UnitTestCase
 	 *
 	 * @return  void
 	 *
-	 * @covers  Joomla\CMS\Image\Image::resize
+	 * @covers  \Joomla\CMS\Image\Image::resize
 	 *
 	 * @since   4.0.0
 	 */
@@ -390,13 +412,13 @@ class ImageTest extends UnitTestCase
 		// Set black to be transparent in the image.
 		imagecolortransparent($transparentImage, imagecolorallocate($transparentImage, 0, 0, 0));
 
-		$image = new ImageInspector($transparentImage);
+		$image = new Image($transparentImage);
 
 		$image->resize(5, 5, false);
 
 		// Verify that the resized image is the correct size.
-		$this->assertEquals(5, imagesy($image->getClassProperty('handle')));
-		$this->assertEquals(5, imagesx($image->getClassProperty('handle')));
+		$this->assertEquals(5, imagesy(TestHelper::getValue($image, 'handle')));
+		$this->assertEquals(5, imagesx(TestHelper::getValue($image, 'handle')));
 
 		$this->assertTrue($image->isTransparent());
 	}
@@ -408,7 +430,7 @@ class ImageTest extends UnitTestCase
 	 *
 	 * @return  void
 	 *
-	 * @covers  Joomla\CMS\Image\Image::resize
+	 * @covers  \Joomla\CMS\Image\Image::resize
 	 *
 	 * @since   4.0.0
 	 */
@@ -416,10 +438,7 @@ class ImageTest extends UnitTestCase
 	{
 		$this->expectException(\LogicException::class);
 
-		// Get a new Image inspector.
-		$image = new ImageInspector;
-
-		$image->resize(1000, 682, false);
+		$this->instance->resize(1000, 682, false);
 	}
 
 	/**
@@ -431,21 +450,19 @@ class ImageTest extends UnitTestCase
 	 */
 	public function testCropResize()
 	{
-		// Get a new Image inspector.
-		$image = new ImageInspector;
-		$image->loadFile($this->testFile);
+		$this->instance->loadFile($this->testFile);
 
-		$image->cropResize(500 * 2, 341 * 2, false);
+		$this->instance->cropResize(500 * 2, 341 * 2, false);
 
 		// Verify that the cropped resized image is the correct size.
-		$this->assertEquals(341 * 2, imagesy($image->getClassProperty('handle')));
-		$this->assertEquals(500 * 2, imagesx($image->getClassProperty('handle')));
+		$this->assertEquals(341 * 2, imagesy(TestHelper::getValue($this->instance, 'handle')));
+		$this->assertEquals(500 * 2, imagesx(TestHelper::getValue($this->instance, 'handle')));
 
-		$image->cropResize(500 * 3, 341 * 2, false);
+		$this->instance->cropResize(500 * 3, 341 * 2, false);
 
 		// Verify that the cropped resized image is the correct size.
-		$this->assertEquals(341 * 2, imagesy($image->getClassProperty('handle')));
-		$this->assertEquals(500 * 3, imagesx($image->getClassProperty('handle')));
+		$this->assertEquals(341 * 2, imagesy(TestHelper::getValue($this->instance, 'handle')));
+		$this->assertEquals(500 * 3, imagesx(TestHelper::getValue($this->instance, 'handle')));
 	}
 
 	/**
@@ -454,7 +471,7 @@ class ImageTest extends UnitTestCase
 	 *
 	 * @return  void
 	 *
-	 * @covers  Joomla\CMS\Image\Image::toFile
+	 * @covers  \Joomla\CMS\Image\Image::toFile
 	 *
 	 * @since   4.0.0
 	 */
@@ -464,8 +481,7 @@ class ImageTest extends UnitTestCase
 
 		$outFileGif = __DIR__ . '/tmp/out.gif';
 
-		$image = new ImageInspector;
-		$image->toFile($outFileGif, IMAGETYPE_GIF);
+		$this->instance->toFile($outFileGif, IMAGETYPE_GIF);
 	}
 
 	/**
@@ -479,7 +495,7 @@ class ImageTest extends UnitTestCase
 	 *
 	 * @return  void
 	 *
-	 * @covers  Joomla\CMS\Image\Image::toFile
+	 * @covers  \Joomla\CMS\Image\Image::toFile
 	 *
 	 * @since   4.0.0
 	 */
@@ -487,7 +503,7 @@ class ImageTest extends UnitTestCase
 	{
 		$outFileGif = __DIR__ . '/tmp/out-' . rand() . '.gif';
 
-		$image = new ImageInspector($this->testFile);
+		$image = new Image($this->testFile);
 		$image->toFile($outFileGif, IMAGETYPE_GIF);
 
 		$a = Image::getImageFileProperties($this->testFile);
@@ -519,7 +535,7 @@ class ImageTest extends UnitTestCase
 	 *
 	 * @return  void
 	 *
-	 * @covers  Joomla\CMS\Image\Image::toFile
+	 * @covers  \Joomla\CMS\Image\Image::toFile
 	 *
 	 * @since   4.0.0
 	 */
@@ -527,7 +543,7 @@ class ImageTest extends UnitTestCase
 	{
 		$outFilePng = __DIR__ . '/tmp/out-' . rand() . '.png';
 
-		$image = new ImageInspector($this->testFile);
+		$image = new Image($this->testFile);
 		$image->toFile($outFilePng, IMAGETYPE_PNG);
 
 		$a = Image::getImageFileProperties($this->testFile);
@@ -559,7 +575,7 @@ class ImageTest extends UnitTestCase
 	 *
 	 * @return  void
 	 *
-	 * @covers  Joomla\CMS\Image\Image::toFile
+	 * @covers  \Joomla\CMS\Image\Image::toFile
 	 *
 	 * @since   4.0.0
 	 */
@@ -568,7 +584,7 @@ class ImageTest extends UnitTestCase
 		// Write the file out to a JPG.
 		$outFileJpg = __DIR__ . '/tmp/out-' . rand() . '.jpg';
 
-		$image = new ImageInspector($this->testFile);
+		$image = new Image($this->testFile);
 		$image->toFile($outFileJpg, IMAGETYPE_JPEG);
 
 		// Get the file properties for both input and output.
@@ -599,7 +615,7 @@ class ImageTest extends UnitTestCase
 	 *
 	 * @return  void
 	 *
-	 * @covers  Joomla\CMS\Image\Image::toFile
+	 * @covers  \Joomla\CMS\Image\Image::toFile
 	 *
 	 * @since   4.0.0
 	 */
@@ -607,7 +623,7 @@ class ImageTest extends UnitTestCase
 	{
 		$outFileWebp = __DIR__ . '/tmp/out-' . rand() . '.webp';
 
-		$image = new ImageInspector($this->testFile);
+		$image = new Image($this->testFile);
 		$image->toFile($outFileWebp, IMAGETYPE_WEBP);
 
 		$a = Image::getImageFileProperties($this->testFile);
@@ -639,7 +655,7 @@ class ImageTest extends UnitTestCase
 	 *
 	 * @return  void
 	 *
-	 * @covers  Joomla\CMS\Image\Image::toFile
+	 * @covers  \Joomla\CMS\Image\Image::toFile
 	 *
 	 * @since   4.0.0
 	 */
@@ -648,7 +664,7 @@ class ImageTest extends UnitTestCase
 		// Write the file out to a JPG.
 		$outFileDefault = __DIR__ . '/tmp/out-' . rand() . '.default';
 
-		$image = new ImageInspector($this->testFile);
+		$image = new Image($this->testFile);
 		$image->toFile($outFileDefault);
 
 		// Get the file properties for both input and output.
@@ -673,7 +689,7 @@ class ImageTest extends UnitTestCase
 	 *
 	 * @return  void
 	 *
-	 * @covers  Joomla\CMS\Image\Image::getFilterInstance
+	 * @covers  \Joomla\CMS\Image\Image::getFilterInstance
 	 *
 	 * @since   4.0.0
 	 */
@@ -695,7 +711,7 @@ class ImageTest extends UnitTestCase
 	 *
 	 * @return  void
 	 *
-	 * @covers  Joomla\CMS\Image\Image::getHeight
+	 * @covers  \Joomla\CMS\Image\Image::getHeight
 	 *
 	 * @since   4.0.0
 	 */
@@ -704,13 +720,12 @@ class ImageTest extends UnitTestCase
 		// Create a 108x42 image handle and add no transparency.
 		$imageHandle = imagecreatetruecolor(108, 42);
 
-		// Create a new ImageInspector object from the image handle.
-		$image = new ImageInspector($imageHandle);
+		// Create a new Image object from the image handle.
+		$image = new Image($imageHandle);
 
-		$this->assertequals(
+		$this->assertEquals(
 			42,
-			$image->getHeight(),
-			'Line: ' . __LINE__
+			$image->getHeight()
 		);
 	}
 
@@ -719,7 +734,7 @@ class ImageTest extends UnitTestCase
 	 *
 	 * @return  void
 	 *
-	 * @covers  Joomla\CMS\Image\Image::getHeight
+	 * @covers  \Joomla\CMS\Image\Image::getHeight
 	 *
 	 * @since   4.0.0
 	 */
@@ -727,10 +742,7 @@ class ImageTest extends UnitTestCase
 	{
 		$this->expectException(\LogicException::class);
 
-		// Create a new Image object without loading an image.
-		$image = new Image;
-
-		$image->getHeight();
+		$this->instance->getHeight();
 	}
 
 	/**
@@ -740,7 +752,7 @@ class ImageTest extends UnitTestCase
 	 *
 	 * @return  void
 	 *
-	 * @covers  Joomla\CMS\Image\Image::getWidth
+	 * @covers  \Joomla\CMS\Image\Image::getWidth
 	 *
 	 * @since   4.0.0
 	 */
@@ -749,13 +761,12 @@ class ImageTest extends UnitTestCase
 		// Create a 108x42 image handle and add no transparency.
 		$imageHandle = imagecreatetruecolor(108, 42);
 
-		// Create a new ImageInspector object from the image handle.
-		$image = new ImageInspector($imageHandle);
+		// Create a new Image object from the image handle.
+		$image = new Image($imageHandle);
 
 		$this->assertEquals(
 			108,
-			$image->getWidth(),
-			'Line: ' . __LINE__
+			$image->getWidth()
 		);
 	}
 
@@ -764,7 +775,7 @@ class ImageTest extends UnitTestCase
 	 *
 	 * @return  void
 	 *
-	 * @covers  Joomla\CMS\Image\Image::getWidth
+	 * @covers  \Joomla\CMS\Image\Image::getWidth
 	 *
 	 * @since   4.0.0
 	 */
@@ -772,10 +783,7 @@ class ImageTest extends UnitTestCase
 	{
 		$this->expectException(\LogicException::class);
 
-		// Create a new Image object without loading an image.
-		$image = new Image;
-
-		$image->getWidth();
+		$this->instance->getWidth();
 	}
 
 	/**
@@ -783,7 +791,7 @@ class ImageTest extends UnitTestCase
 	 *
 	 * @return  void
 	 *
-	 * @covers  Joomla\CMS\Image\Image::getImageFileProperties
+	 * @covers  \Joomla\CMS\Image\Image::getImageFileProperties
 	 *
 	 * @since   4.0.0
 	 */
@@ -799,16 +807,15 @@ class ImageTest extends UnitTestCase
 	 *
 	 * @return  void
 	 *
+	 * @covers  \Joomla\CMS\Image\Image::generateThumbs
+	 *
 	 * @since   1.1.3
 	 */
 	public function testGenerateThumbsWithoutLoadedImage()
 	{
 		$this->expectException(\LogicException::class);
 
-		// Create a new Image object without loading an image.
-		$image = new Image;
-
-		$thumbs = $image->generateThumbs('50x38');
+		$thumbs = $this->instance->generateThumbs('50x38');
 	}
 
 	/**
@@ -816,17 +823,17 @@ class ImageTest extends UnitTestCase
 	 *
 	 * @return  void
 	 *
+	 * @covers  \Joomla\CMS\Image\Image::generateThumbs
+	 *
 	 * @since   1.1.3
 	 */
 	public function testGenerateThumbsWithInvalidSize()
 	{
 		$this->expectException(\InvalidArgumentException::class);
 
-		// Create a new Image object without loading an image.
-		$image = new Image;
-		$image->loadFile($this->testFile);
+		$this->instance->loadFile($this->testFile);
 
-		$thumbs = $image->generateThumbs('50*38');
+		$thumbs = $this->instance->generateThumbs('50*38');
 	}
 
 	/**
@@ -834,15 +841,15 @@ class ImageTest extends UnitTestCase
 	 *
 	 * @return  void
 	 *
+	 * @covers  \Joomla\CMS\Image\Image::generateThumbs
+	 *
 	 * @since   1.1.3
 	 */
 	public function testGenerateThumbs()
 	{
-		// Get a new Image inspector.
-		$image = new ImageInspector;
-		$image->loadFile($this->testFile);
+		$this->instance->loadFile($this->testFile);
 
-		$thumbs = $image->generateThumbs('50x38');
+		$thumbs = $this->instance->generateThumbs('50x38');
 
 		// Verify that the resized image is the correct size.
 		$this->assertEquals(
@@ -854,7 +861,7 @@ class ImageTest extends UnitTestCase
 			imagesx(TestHelper::getValue($thumbs[0], 'handle'))
 		);
 
-		$thumbs = $image->generateThumbs('50x38', ImageInspector::CROP);
+		$thumbs = $this->instance->generateThumbs('50x38', Image::CROP);
 
 		// Verify that the resized image is the correct size.
 		$this->assertEquals(
@@ -866,7 +873,7 @@ class ImageTest extends UnitTestCase
 			imagesx(TestHelper::getValue($thumbs[0], 'handle'))
 		);
 
-		$thumbs = $image->generateThumbs('50x38', ImageInspector::CROP_RESIZE);
+		$thumbs = $this->instance->generateThumbs('50x38', Image::CROP_RESIZE);
 
 		// Verify that the resized image is the correct size.
 		$this->assertEquals(
@@ -884,16 +891,15 @@ class ImageTest extends UnitTestCase
 	 *
 	 * @return  void
 	 *
+	 * @covers  \Joomla\CMS\Image\Image::createThumbs
+	 *
 	 * @since   1.1.3
 	 */
 	public function testCreateThumbsWithoutLoadedImage()
 	{
 		$this->expectException(\LogicException::class);
 
-		// Create a new Image object without loading an image.
-		$image = new Image;
-
-		$thumbs = $image->createThumbs('50x38');
+		$thumbs = $this->instance->createThumbs('50x38');
 	}
 
 	/**
@@ -901,17 +907,16 @@ class ImageTest extends UnitTestCase
 	 *
 	 * @return  void
 	 *
+	 * @covers  \Joomla\CMS\Image\Image::createThumbs
+	 *
 	 * @since   1.1.3
 	 */
 	public function testGenerateThumbsWithInvalidFolder()
 	{
 		$this->expectException(\InvalidArgumentException::class);
 
-		// Create a new Image object without loading an image.
-		$image = new Image;
-		$image->loadFile($this->testFile);
-
-		$thumbs = $image->createThumbs('50x38', Image::SCALE_INSIDE, '/foo/bar');
+		$this->instance->loadFile($this->testFile);
+		$this->instance->createThumbs('50x38', Image::SCALE_INSIDE, '/foo/bar');
 	}
 
 	/**
@@ -919,15 +924,15 @@ class ImageTest extends UnitTestCase
 	 *
 	 * @return  void
 	 *
+	 * @covers  \Joomla\CMS\Image\Image::createThumbs
+	 *
 	 * @since   1.1.3
 	 */
 	public function testCreateThumbs()
 	{
-		// Get a new Image inspector.
-		$image = new ImageInspector;
-		$image->loadFile($this->testFile);
+		$this->instance->loadFile($this->testFile);
 
-		$thumbs = $image->createThumbs('50x38', ImageInspector::CROP);
+		$thumbs = $this->instance->createThumbs('50x38', Image::CROP);
 		$outFileGif = TestHelper::getValue($thumbs[0], 'path');
 
 		$a = Image::getImageFileProperties($this->testFile);
@@ -950,7 +955,7 @@ class ImageTest extends UnitTestCase
 	 *
 	 * @return  void
 	 *
-	 * @covers  Joomla\CMS\Image\Image::isTransparent
+	 * @covers  \Joomla\CMS\Image\Image::isTransparent
 	 *
 	 * @since   4.0.0
 	 */
@@ -958,10 +963,7 @@ class ImageTest extends UnitTestCase
 	{
 		$this->expectException(\LogicException::class);
 
-		// Create a new Image object without loading an image.
-		$image = new Image;
-
-		$image->isTransparent();
+		$this->instance->isTransparent();
 	}
 
 	/**
@@ -971,7 +973,7 @@ class ImageTest extends UnitTestCase
 	 *
 	 * @return  void
 	 *
-	 * @covers  Joomla\CMS\Image\Image::isTransparent
+	 * @covers  \Joomla\CMS\Image\Image::isTransparent
 	 *
 	 * @since   4.0.0
 	 */
@@ -983,8 +985,8 @@ class ImageTest extends UnitTestCase
 		// Set black to be transparent in the image.
 		imagecolortransparent($transparentImage, imagecolorallocate($transparentImage, 0, 0, 0));
 
-		// Create a new ImageInspector object from the image handle.
-		$transparent = new ImageInspector($transparentImage);
+		// Create a new Image object from the image handle.
+		$transparent = new Image($transparentImage);
 
 		// Assert that the image has transparency.
 		$this->assertTrue(($transparent->isTransparent()));
@@ -997,7 +999,7 @@ class ImageTest extends UnitTestCase
 	 *
 	 * @return  void
 	 *
-	 * @covers  Joomla\CMS\Image\Image::isTransparent
+	 * @covers  \Joomla\CMS\Image\Image::isTransparent
 	 *
 	 * @since   4.0.0
 	 */
@@ -1006,8 +1008,8 @@ class ImageTest extends UnitTestCase
 		// Create a 10x10 image handle and add no transparency.
 		$opaqueImage = imagecreatetruecolor(10, 10);
 
-		// Create a new ImageInspector object from the image handle.
-		$opaque = new ImageInspector($opaqueImage);
+		// Create a new Image object from the image handle.
+		$opaque = new Image($opaqueImage);
 
 		// Assert that the image does not have transparency.
 		$this->assertFalse(($opaque->isTransparent()));
@@ -1018,7 +1020,7 @@ class ImageTest extends UnitTestCase
 	 *
 	 * @return  void
 	 *
-	 * @covers  Joomla\CMS\Image\Image::crop
+	 * @covers  \Joomla\CMS\Image\Image::crop
 	 *
 	 * @since   4.0.0
 	 */
@@ -1054,7 +1056,7 @@ class ImageTest extends UnitTestCase
 	 *
 	 * @dataProvider getCropData
 	 *
-	 * @covers  Joomla\CMS\Image\Image::crop
+	 * @covers  \Joomla\CMS\Image\Image::crop
 	 *
 	 * @since   4.0.0
 	 */
@@ -1093,8 +1095,8 @@ class ImageTest extends UnitTestCase
 		// Draw a white rectangle one pixel inside the crop area.
 		imagefilledrectangle($imageHandle, ($cropLeft + 1), ($cropTop + 1), ($cropLeft + $cropWidth - 2), ($cropTop + $cropHeight - 2), $white);
 
-		// Create a new ImageInspector from the image handle.
-		$image = new ImageInspector($imageHandle);
+		// Create a new Image from the image handle.
+		$image = new Image($imageHandle);
 
 		// Crop the image to specifications.
 		$image->crop($cropWidth, $cropHeight, $actualCropLeft, $actualCropTop, false);
@@ -1102,52 +1104,52 @@ class ImageTest extends UnitTestCase
 		// Verify that the cropped image is the correct size.
 		$this->assertEquals(
 			$cropHeight,
-			imagesy($image->getClassProperty('handle'))
+			imagesy(TestHelper::getValue($image, 'handle'))
 		);
 		$this->assertEquals(
 			$cropWidth,
-			imagesx($image->getClassProperty('handle'))
+			imagesx(TestHelper::getValue($image, 'handle'))
 		);
 
 		// Validate the correct pixels for the corners.
 		// Top/Left
 		$this->assertEquals(
 			$red,
-			imagecolorat($image->getClassProperty('handle'), 0, 0)
+			imagecolorat(TestHelper::getValue($image, 'handle'), 0, 0)
 		);
 		$this->assertEquals(
 			$white,
-			imagecolorat($image->getClassProperty('handle'), 1, 1)
+			imagecolorat(TestHelper::getValue($image, 'handle'), 1, 1)
 		);
 
 		// Top/Right
 		$this->assertEquals(
 			$red,
-			imagecolorat($image->getClassProperty('handle'), 0, ($cropHeight - 1))
+			imagecolorat(TestHelper::getValue($image, 'handle'), 0, ($cropHeight - 1))
 		);
 		$this->assertEquals(
 			$white,
-			imagecolorat($image->getClassProperty('handle'), 1, ($cropHeight - 2))
+			imagecolorat(TestHelper::getValue($image, 'handle'), 1, ($cropHeight - 2))
 		);
 
 		// Bottom/Left
 		$this->assertEquals(
 			$red,
-			imagecolorat($image->getClassProperty('handle'), ($cropWidth - 1), 0)
+			imagecolorat(TestHelper::getValue($image, 'handle'), ($cropWidth - 1), 0)
 		);
 		$this->assertEquals(
 			$white,
-			imagecolorat($image->getClassProperty('handle'), ($cropWidth - 2), 1)
+			imagecolorat(TestHelper::getValue($image, 'handle'), ($cropWidth - 2), 1)
 		);
 
 		// Bottom/Right
 		$this->assertEquals(
 			$red,
-			imagecolorat($image->getClassProperty('handle'), ($cropWidth - 1), ($cropHeight - 1))
+			imagecolorat(TestHelper::getValue($image, 'handle'), ($cropWidth - 1), ($cropHeight - 1))
 		);
 		$this->assertEquals(
 			$white,
-			imagecolorat($image->getClassProperty('handle'), ($cropWidth - 2), ($cropHeight - 2))
+			imagecolorat(TestHelper::getValue($image, 'handle'), ($cropWidth - 2), ($cropHeight - 2))
 		);
 	}
 
@@ -1156,7 +1158,7 @@ class ImageTest extends UnitTestCase
 	 *
 	 * @return  void
 	 *
-	 * @covers  Joomla\CMS\Image\Image::rotate
+	 * @covers  \Joomla\CMS\Image\Image::rotate
 	 *
 	 * @since   4.0.0
 	 */
@@ -1164,10 +1166,7 @@ class ImageTest extends UnitTestCase
 	{
 		$this->expectException(\LogicException::class);
 
-		// Create a new Image object without loading an image.
-		$image = new Image;
-
-		$image->rotate(90);
+		$this->instance->rotate(90);
 	}
 
 	/**
@@ -1179,7 +1178,7 @@ class ImageTest extends UnitTestCase
 	 *
 	 * @return  void
 	 *
-	 * @covers  Joomla\CMS\Image\Image::rotate
+	 * @covers  \Joomla\CMS\Image\Image::rotate
 	 *
 	 * @since   4.0.0
 	 */
@@ -1198,8 +1197,8 @@ class ImageTest extends UnitTestCase
 		// Draw a white vertical line in the middle of the image.
 		imageline($imageHandle, 50, 5, 50, 95, $white);
 
-		// Create a new ImageInspector from the image handle.
-		$image = new ImageInspector($imageHandle);
+		// Create a new Image from the image handle.
+		$image = new Image($imageHandle);
 
 		// Crop the image to specifications.
 		$image->rotate(90, -1, false);
@@ -1208,21 +1207,21 @@ class ImageTest extends UnitTestCase
 		// Red line.
 		$this->assertEquals(
 			$red,
-			imagecolorat($image->getClassProperty('handle'), 50, 5)
+			imagecolorat(TestHelper::getValue($image, 'handle'), 50, 5)
 		);
 		$this->assertEquals(
 			$red,
-			imagecolorat($image->getClassProperty('handle'), 50, 95)
+			imagecolorat(TestHelper::getValue($image, 'handle'), 50, 95)
 		);
 
 		// White line.
 		$this->assertEquals(
 			$white,
-			imagecolorat($image->getClassProperty('handle'), 5, 50)
+			imagecolorat(TestHelper::getValue($image, 'handle'), 5, 50)
 		);
 		$this->assertEquals(
 			$white,
-			imagecolorat($image->getClassProperty('handle'), 95, 50)
+			imagecolorat(TestHelper::getValue($image, 'handle'), 95, 50)
 		);
 	}
 
@@ -1231,7 +1230,7 @@ class ImageTest extends UnitTestCase
 	 *
 	 * @return  void
 	 *
-	 * @covers  Joomla\CMS\Image\Image::filter
+	 * @covers  \Joomla\CMS\Image\Image::filter
 	 *
 	 * @since   4.0.0
 	 */
@@ -1259,7 +1258,7 @@ class ImageTest extends UnitTestCase
 	 *
 	 * @return  void
 	 *
-	 * @covers  Joomla\CMS\Image\Image::filter
+	 * @covers  \Joomla\CMS\Image\Image::filter
 	 *
 	 * @since   4.0.0
 	 */
@@ -1278,7 +1277,7 @@ class ImageTest extends UnitTestCase
 	 *
 	 * @return  void
 	 *
-	 * @covers  Joomla\CMS\Image\Image::filter
+	 * @covers  \Joomla\CMS\Image\Image::filter
 	 *
 	 * @since   4.0.0
 	 */
@@ -1286,8 +1285,7 @@ class ImageTest extends UnitTestCase
 	{
 		$this->expectException(\RuntimeException::class);
 
-		// Create a new ImageInspector object.
-		$image = new ImageInspector(imagecreatetruecolor(10, 10));
+		$image = new Image(imagecreatetruecolor(10, 10));
 
 		$image->filter('foobar');
 	}
@@ -1307,7 +1305,7 @@ class ImageTest extends UnitTestCase
 	 *
 	 * @dataProvider getPrepareDimensionsData
 	 *
-	 * @covers  Joomla\CMS\Image\Image::prepareDimensions
+	 * @covers  \Joomla\CMS\Image\Image::prepareDimensions
 	 *
 	 * @since   4.0.0
 	 */
@@ -1316,10 +1314,10 @@ class ImageTest extends UnitTestCase
 		// Create a image handle of the correct size.
 		$imageHandle = imagecreatetruecolor($imageWidth, $imageHeight);
 
-		// Create a new ImageInspector from the image handle.
-		$image = new ImageInspector($imageHandle);
+		// Create a new Image from the image handle.
+		$image = new Image($imageHandle);
 
-		$dimensions = $image->prepareDimensions($inputWidth, $inputHeight, $inputScale);
+		$dimensions = TestHelper::invoke($image, 'prepareDimensions', [$inputWidth, $inputHeight, $inputScale]);
 
 		// Validate the correct response.
 		$this->assertEquals($expectedHeight, $dimensions->height);
@@ -1331,7 +1329,7 @@ class ImageTest extends UnitTestCase
 	 *
 	 * @return  void
 	 *
-	 * @covers  Joomla\CMS\Image\Image::prepareDimensions
+	 * @covers  \Joomla\CMS\Image\Image::prepareDimensions
 	 *
 	 * @since   4.0.0
 	 */
@@ -1342,10 +1340,9 @@ class ImageTest extends UnitTestCase
 		// Create a image handle of the correct size.
 		$imageHandle = imagecreatetruecolor(100, 100);
 
-		// Create a new ImageInspector from the image handle.
-		$image = new ImageInspector($imageHandle);
+		$image = new Image($imageHandle);
 
-		$dimensions = $image->prepareDimensions(123, 456, 42);
+		$dimensions = TestHelper::invoke($image, 'prepareDimensions', [123, 456, 42]);
 	}
 
 	/**
@@ -1362,7 +1359,7 @@ class ImageTest extends UnitTestCase
 	 *
 	 * @dataProvider getSanitizeDimensionData
 	 *
-	 * @covers  Joomla\CMS\Image\Image::sanitizeHeight
+	 * @covers  \Joomla\CMS\Image\Image::sanitizeHeight
 	 *
 	 * @since   4.0.0
 	 */
@@ -1371,13 +1368,12 @@ class ImageTest extends UnitTestCase
 		// Create a image handle of the correct size.
 		$imageHandle = imagecreatetruecolor($imageWidth, $imageHeight);
 
-		// Create a new ImageInspector from the image handle.
-		$image = new ImageInspector($imageHandle);
+		$image = new Image($imageHandle);
 
 		// Validate the correct response.
 		$this->assertEquals(
 			$expectedHeight,
-			$image->sanitizeHeight($inputHeight, $inputWidth)
+			TestHelper::invoke($image, 'sanitizeHeight', [$inputHeight, $inputWidth])
 		);
 	}
 
@@ -1395,7 +1391,7 @@ class ImageTest extends UnitTestCase
 	 *
 	 * @dataProvider getSanitizeDimensionData
 	 *
-	 * @covers  Joomla\CMS\Image\Image::sanitizeWidth
+	 * @covers  \Joomla\CMS\Image\Image::sanitizeWidth
 	 *
 	 * @since   4.0.0
 	 */
@@ -1404,13 +1400,12 @@ class ImageTest extends UnitTestCase
 		// Create a image handle of the correct size.
 		$imageHandle = imagecreatetruecolor($imageWidth, $imageHeight);
 
-		// Create a new ImageInspector from the image handle.
-		$image = new ImageInspector($imageHandle);
+		$image = new Image($imageHandle);
 
 		// Validate the correct response.
 		$this->assertEquals(
 			$expectedWidth,
-			$image->sanitizeWidth($inputWidth, $inputHeight)
+			TestHelper::invoke($image, 'sanitizeWidth', [$inputWidth, $inputHeight])
 		);
 	}
 
@@ -1424,19 +1419,16 @@ class ImageTest extends UnitTestCase
 	 *
 	 * @dataProvider getSanitizeOffsetData
 	 *
-	 * @covers  Joomla\CMS\Image\Image::sanitizeOffset
+	 * @covers  \Joomla\CMS\Image\Image::sanitizeOffset
 	 *
 	 * @since   4.0.0
 	 */
 	public function testSanitizeOffset($input, $expected)
 	{
-		// Create a new ImageInspector.
-		$image = new ImageInspector;
-
 		// Validate the correct response.
 		$this->assertEquals(
 			$expected,
-			$image->sanitizeOffset($input)
+			TestHelper::invoke($this->instance, 'sanitizeOffset', [$input])
 		);
 	}
 
@@ -1445,7 +1437,7 @@ class ImageTest extends UnitTestCase
 	 *
 	 * @return  void
 	 *
-	 * @covers  Joomla\CMS\Image\Image::destroy
+	 * @covers  \Joomla\CMS\Image\Image::destroy
 	 *
 	 * @since   4.0.0
 	 */

--- a/tests/Unit/Libraries/Cms/Image/ImageTest.php
+++ b/tests/Unit/Libraries/Cms/Image/ImageTest.php
@@ -1317,7 +1317,7 @@ class ImageTest extends UnitTestCase
 		// Create a new Image from the image handle.
 		$image = new Image($imageHandle);
 
-		$dimensions = TestHelper::invoke($image, 'prepareDimensions', [$inputWidth, $inputHeight, $inputScale]);
+		$dimensions = TestHelper::invoke($image, 'prepareDimensions', $inputWidth, $inputHeight, $inputScale);
 
 		// Validate the correct response.
 		$this->assertEquals($expectedHeight, $dimensions->height);
@@ -1342,7 +1342,7 @@ class ImageTest extends UnitTestCase
 
 		$image = new Image($imageHandle);
 
-		$dimensions = TestHelper::invoke($image, 'prepareDimensions', [123, 456, 42]);
+		$dimensions = TestHelper::invoke($image, 'prepareDimensions', 123, 456, 42);
 	}
 
 	/**
@@ -1373,7 +1373,7 @@ class ImageTest extends UnitTestCase
 		// Validate the correct response.
 		$this->assertEquals(
 			$expectedHeight,
-			TestHelper::invoke($image, 'sanitizeHeight', [$inputHeight, $inputWidth])
+			TestHelper::invoke($image, 'sanitizeHeight', $inputHeight, $inputWidth)
 		);
 	}
 
@@ -1405,7 +1405,7 @@ class ImageTest extends UnitTestCase
 		// Validate the correct response.
 		$this->assertEquals(
 			$expectedWidth,
-			TestHelper::invoke($image, 'sanitizeWidth', [$inputWidth, $inputHeight])
+			TestHelper::invoke($image, 'sanitizeWidth', $inputWidth, $inputHeight)
 		);
 	}
 
@@ -1428,7 +1428,7 @@ class ImageTest extends UnitTestCase
 		// Validate the correct response.
 		$this->assertEquals(
 			$expected,
-			TestHelper::invoke($this->instance, 'sanitizeOffset', [$input])
+			TestHelper::invoke($this->instance, 'sanitizeOffset', $input)
 		);
 	}
 

--- a/tests/Unit/Libraries/Cms/Image/ImageTest.php
+++ b/tests/Unit/Libraries/Cms/Image/ImageTest.php
@@ -695,13 +695,13 @@ class ImageTest extends UnitTestCase
 	 */
 	public function testGetFilterInstance()
 	{
-		// Create a new ImageInspector object.
-		$image = new ImageInspector(imagecreatetruecolor(1, 1));
+		// Create a new Image object.
+		$image = new Image(imagecreatetruecolor(1, 1));
 
 		// Get the filter instance.
-		$filter = $image->getFilterInstance('inspector');
+		$filter = TestHelper::invoke($image, 'getFilterInstance', 'brightness');
 
-		$this->assertInstanceOf('\\Joomla\\CMS\\Image\\Filter\\Inspector', $filter);
+		$this->assertInstanceOf('\\Joomla\\CMS\\Image\\Filter\\Brightness', $filter);
 	}
 
 	/**

--- a/tests/Unit/Libraries/Cms/Image/stubs/ImageInspector.php
+++ b/tests/Unit/Libraries/Cms/Image/stubs/ImageInspector.php
@@ -22,49 +22,6 @@ class ImageInspector extends Image
 	public $mockFilter;
 
 	/**
-	 * Method for inspecting protected variables.
-	 *
-	 * @param   string  $name  The name of the property.
-	 *
-	 * @return  mixed  The value of the class variable.
-	 *
-	 * @since   4.0.0
-	 */
-	public function getClassProperty($name)
-	{
-		if (property_exists($this, $name))
-		{
-			return $this->$name;
-		}
-		else
-		{
-			throw new \Exception('Undefined or private property: ' . __CLASS__ . '::' . $name);
-		}
-	}
-
-	/**
-	 * Method for setting protected variables.
-	 *
-	 * @param   string  $name   The name of the property.
-	 * @param   mixed   $value  The value of the property.
-	 *
-	 * @return  void
-	 *
-	 * @since   4.0.0
-	 */
-	public function setClassProperty($name, $value)
-	{
-		if (property_exists($this, $name))
-		{
-			$this->$name = $value;
-		}
-		else
-		{
-			throw new \Exception('Undefined or private property: ' . __CLASS__ . '::' . $name);
-		}
-	}
-
-	/**
 	 * Allows public access to protected method.
 	 *
 	 * @param   string  $type  The image filter type to get.
@@ -84,65 +41,5 @@ class ImageInspector extends Image
 		{
 			return parent::getFilterInstance($type);
 		}
-	}
-
-	/**
-	 * Allows public access to protected method.
-	 *
-	 * @param   mixed    $width        The width of the resized image in pixels or a percentage.
-	 * @param   mixed    $height       The height of the resized image in pixels or a percentage.
-	 * @param   integer  $scaleMethod  The method to use for scaling
-	 *
-	 * @return  object
-	 *
-	 * @since   4.0.0
-	 */
-	public function prepareDimensions($width, $height, $scaleMethod)
-	{
-		return parent::prepareDimensions($width, $height, $scaleMethod);
-	}
-
-	/**
-	 * Allows public access to protected method.
-	 *
-	 * @param   mixed  $height  The input height value to sanitize.
-	 * @param   mixed  $width   The input width value for reference.
-	 *
-	 * @return  integer
-	 *
-	 * @since   4.0.0
-	 */
-	public function sanitizeHeight($height, $width)
-	{
-		return parent::sanitizeHeight($height, $width);
-	}
-
-	/**
-	 * Allows public access to protected method.
-	 *
-	 * @param   mixed  $offset  An offset value.
-	 *
-	 * @return  integer
-	 *
-	 * @since   4.0.0
-	 */
-	public function sanitizeOffset($offset)
-	{
-		return parent::sanitizeOffset($offset);
-	}
-
-	/**
-	 * Allows public access to protected method.
-	 *
-	 * @param   mixed  $width   The input width value to sanitize.
-	 * @param   mixed  $height  The input height value for reference.
-	 *
-	 * @return  integer
-	 *
-	 * @since   4.0.0
-	 */
-	public function sanitizeWidth($width, $height)
-	{
-		return parent::sanitizeWidth($width, $height);
 	}
 }


### PR DESCRIPTION
Major cleanup based on test reviews I was doing as part of https://github.com/joomla/joomla-cms/pull/31804

I've tried to keep the tests as similar as I can (although I'm very unsure why we're testing some of the protected methods). But the main aim is to reduce the amount of image instances we are creating unnecessarily and remove dependencies on the ImageInspector. There are two instances left in tests directly related to test the filter function which I still need to figure out but will be PR'd independently of this


## Testing
Testing is purely on code review + Drone passing as this is only touching the tests