### PR TITLE
[4.0] Media field: Uncaught TypeError: MediaXTDElements is undefined

### DIFF
--- a/build/media_source/system/js/fields/joomla-image-select.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-image-select.w-c.es6.js
@@ -375,7 +375,7 @@
   if (window.jQuery) {
     const MediaXTDElements = Joomla.getOptions('xtdImageModal');
 
-    if (MediaXTDElements.length) {
+    if (MediaXTDElements) {
       MediaXTDElements.forEach((element) => {
         window.jQuery(`#${element}`).on('show.bs.modal', (ev) => {
           const addData = ev.target.querySelector('joomla-field-mediamore');


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/31816

### Summary of Changes
`.length` is unecessary in the js


### Testing Instructions
Create a category blog menu item.
Look at console.


### Actual result BEFORE applying this Pull Request
```
Uncaught TypeError: MediaXTDElements is undefined
    <anonymous> http://localhost:8888/newfolder/joomla40/media/system/js/fields/joomla-image-select.js:401
    <anonymous> http://localhost:8888/newfolder/joomla40/media/system/js/fields/joomla-image-select.js:413
joomla-image-select.js:401:9
```


### Expected result AFTER applying this Pull Request
No more uncaught error.


### Explanation
The error will not show when the Editor is one of the fields loaded in the page (which ever it is), because the image XTD is available through the CMS Content => Image.
Blog, for example, has no Editor, but contains some media fields.

