### PR TITLE
[4.0] cassiopeia chrome fix [a11y]

### DIFF
--- a/templates/cassiopeia/html/layouts/chromes/card.php
+++ b/templates/cassiopeia/html/layouts/chromes/card.php
@@ -28,16 +28,21 @@ $headerClass            = htmlspecialchars($params->get('header_class', ''), ENT
 $headerAttribs          = [];
 $headerAttribs['class'] = $headerClass;
 
-if ($module->showtitle) :
-	$moduleAttribs['aria-labelledby'] = 'mod-' . $module->id;
-	$headerAttribs['id']             = 'mod-' . $module->id;
-
-	if ($headerClass !== 'card-title') :
-		$headerAttribs['class'] = 'card-header ' . $headerClass;
-	endif;
-else:
-	$moduleAttribs['aria-label'] = $module->title;
+// Only output a header class if it is not card-title
+if ($headerClass !== 'card-title') :
+	$headerAttribs['class'] = 'card-header ' . $headerClass;
 endif;
+
+// Only add aria if the moduleTag is not a div
+if ($moduleTag !== 'div')
+{
+	if ($module->showtitle) :
+		$moduleAttribs['aria-labelledby'] = 'mod-' . $module->id;
+		$headerAttribs['id']              = 'mod-' . $module->id;
+	else:
+		$moduleAttribs['aria-label'] = $module->title;
+	endif;
+}
 
 $header = '<' . $headerTag . ' ' . ArrayHelper::toString($headerAttribs) . '>' . $module->title . '</' . $headerTag . '>';
 ?>

--- a/templates/cassiopeia/html/layouts/chromes/noCard.php
+++ b/templates/cassiopeia/html/layouts/chromes/noCard.php
@@ -26,14 +26,23 @@ $moduleAttribs['class'] = $module->position . ' no-card ' . htmlspecialchars($pa
 $headerTag              = htmlspecialchars($params->get('header_tag', 'h3'), ENT_QUOTES, 'UTF-8');
 $headerClass            = htmlspecialchars($params->get('header_class', ''), ENT_QUOTES, 'UTF-8');
 $headerAttribs          = [];
-$headerAttribs['class'] = $headerClass;
 
-if ($module->showtitle) :
-	$moduleAttribs['aria-labelledby'] = 'mod-' . $module->id;
-	$headerAttribs['id']             = 'mod-' . $module->id;
-else:
-	$moduleAttribs['aria-label'] = $module->title;
-endif;
+// Only output a header class if one is set
+if ($headerClass !== '')
+{
+	$headerAttribs['class'] = $headerClass;
+}
+
+// Only add aria if the moduleTag is not a div
+if ($moduleTag !== 'div')
+{
+	if ($module->showtitle) :
+		$moduleAttribs['aria-labelledby'] = 'mod-' . $module->id;
+		$headerAttribs['id']              = 'mod-' . $module->id;
+	else:
+		$moduleAttribs['aria-label'] = $module->title;
+	endif;
+}
 
 $header = '<' . $headerTag . ' ' . ArrayHelper::toString($headerAttribs) . '>' . $module->title . '</' . $headerTag . '>';
 ?>


### PR DESCRIPTION
Continuation of #31772 this time for the two cassiopeia module chromes card and nocard

With this PR the aria values are only added if the module is NOT a div ie its a section etc

Fixes issues created by #31609
