### PR TITLE
[4.0] Mail Templates mobile

### DIFF
--- a/administrator/components/com_mails/tmpl/templates/default.php
+++ b/administrator/components/com_mails/tmpl/templates/default.php
@@ -42,10 +42,10 @@ $listDirn = $this->escape($this->state->get('list.direction'));
 								<th scope="col" class="w-15 d-none d-md-table-cell">
 									<?php echo HTMLHelper::_('searchtools.sort', 'COM_MAILS_HEADING_COMPONENT', 'a.component', $listDirn, $listOrder); ?>
 								</th>
-								<th scope="col" class="w-10 d-md-table-cell">
+								<th scope="col" class="w-10 d-none d-md-table-cell">
 									<?php echo Text::_('COM_MAILS_HEADING_TEMPLATES_FOR_LANGUAGES'); ?>
 								</th>
-								<th scope="col" class="w-10 d-md-table-cell">
+								<th scope="col" class="w-10 d-none d-md-table-cell">
 									<?php echo Text::_('COM_MAILS_HEADING_NO_TEMPLATES_FOR_LANGUAGES'); ?>
 								</th>
 								<th scope="col" class="w-30 d-none d-md-table-cell">
@@ -83,7 +83,7 @@ $listDirn = $this->escape($this->state->get('list.direction'));
 								<td class="d-none d-md-table-cell">
 									<?php echo Text::_($component); ?>
 								</td>
-								<td class="d-md-table-cell">
+								<td class="d-none d-md-table-cell">
 									<?php foreach ($this->languages as $language) : ?>
 										<?php if (in_array($language->lang_code, $item->languages)) : ?>
 											<?php if ($language->image) : ?>
@@ -94,7 +94,7 @@ $listDirn = $this->escape($this->state->get('list.direction'));
 										<?php endif; ?>
 									<?php endforeach; ?>
 								</td>
-								<td class="d-md-table-cell">
+								<td class="d-none d-md-table-cell">
 									<?php foreach ($this->languages as $language) : ?>
 										<?php if (!in_array($language->lang_code, $item->languages)) : ?>
 											<?php if ($language->image) : ?>


### PR DESCRIPTION
Pull Request for Issue #30950

Simple PR to hide two columns from the mobile view. The mobile view can never contain everything and the two columns removed are just alternative ways to create/edit templates per language

### Before
![image](https://user-images.githubusercontent.com/1296369/103444971-67654f80-4c66-11eb-903e-8d87ee6cf61b.png)

### After
![image](https://user-images.githubusercontent.com/1296369/103444967-54eb1600-4c66-11eb-96a9-3203640526d1.png)
