### PR TITLE
[4.0] com_users webauthn svg

### DIFF
--- a/components/com_users/tmpl/login/default_login.php
+++ b/components/com_users/tmpl/login/default_login.php
@@ -95,6 +95,8 @@ $usersConfig = ComponentHelper::getParams('com_users');
 								<?php echo HTMLHelper::_('image', $button['image'], Text::_($button['tooltip'] ?? ''), [
 									'class' => 'icon',
 								], true) ?>
+							<?php elseif (!empty($button['svg'])): ?>
+								<?php echo $button['svg']; ?>
 							<?php endif; ?>
 							<?php echo Text::_($button['label']) ?>
 						</button>


### PR DESCRIPTION
The code that was added to the login module to support the svg icon for webauthn was missing for the users component

### Testing Instructions
Compare the login module and the user login menu item in the front end on a site with https


### Actual result BEFORE applying this Pull Request
![image](https://user-images.githubusercontent.com/1296369/103445499-a1d1eb00-4c6c-11eb-846d-042f5b1031fc.png)



### Expected result AFTER applying this Pull Request

![image](https://user-images.githubusercontent.com/1296369/103445488-86ff7680-4c6c-11eb-9742-765585114906.png)
