### PR TITLE
[4.0] Move image box in media manager to bottom

### DIFF
--- a/administrator/components/com_media/tmpl/file/default.php
+++ b/administrator/components/com_media/tmpl/file/default.php
@@ -57,8 +57,8 @@ $this->useCoreUI = true;
 	<?php $fieldSets = $form->getFieldsets(); ?>
 	<?php if ($fieldSets) : ?>
 		<?php echo HTMLHelper::_('uitab.startTabSet', 'myTab', array('active' => 'attrib-' . reset($fieldSets)->name)); ?>
-		<?php echo '<div id="media-manager-edit-container" class="media-manager-edit d-flex justify-content-around col-md-9 p-4"></div>'; ?>
 		<?php echo LayoutHelper::render('joomla.edit.params', $this); ?>
+		<?php echo '<div id="media-manager-edit-container" class="media-manager-edit d-flex justify-content-around col-md-9 p-4"></div>'; ?>
 		<?php echo HTMLHelper::_('uitab.endTabSet'); ?>
 	<?php endif; ?>
 	</form>

--- a/build/media_source/com_media/js/edit-images.es6.js
+++ b/build/media_source/com_media/js/edit-images.es6.js
@@ -91,7 +91,7 @@ Joomla.MediaManager = Joomla.MediaManager || {};
       // Move the container to the correct tab
       const mediaContainer = document.getElementById('media-manager-edit-container');
       const tab = document.getElementById(link.id.replace('tab-', ''));
-      tab.insertAdjacentElement('afterbegin', mediaContainer);
+      tab.insertAdjacentElement('beforeend', mediaContainer);
 
       activate(link.id.replace('tab-attrib-', ''), data);
     });
@@ -278,7 +278,7 @@ Joomla.MediaManager = Joomla.MediaManager || {};
 
           // Move the container to the correct tab
           const tab = document.getElementById(target.id.replace('tab-', ''));
-          tab.insertAdjacentElement('afterbegin', container);
+          tab.insertAdjacentElement('beforeend', container);
 
           activate(target.id.replace('tab-attrib-', ''), data);
         });


### PR DESCRIPTION
Pull Request for Issue #31820 and #29156 .

### Summary of Changes
Currently rotating and resizing an image let the box jump, based on the height. This PR moves the image below the parameters so there is no jumping.


### Testing Instructions
Edit an image in the media manager


### Actual result BEFORE applying this Pull Request
Jumping because the image is above the parameters


### Expected result AFTER applying this Pull Request
No jumping because the image is below the parameters.
