### PR TITLE
[4.0] Output correct error message for com_messages

### DIFF
--- a/administrator/components/com_messages/src/Model/MessageModel.php
+++ b/administrator/components/com_messages/src/Model/MessageModel.php
@@ -136,7 +136,7 @@ class MessageModel extends AdminModel
 				// Invalid message_id returns 0
 				if ($this->item->user_id_to === '0')
 				{
-					$this->setError(JText::_('JERROR_ALERTNOAUTHOR'));
+					$this->setError(Text::_('JERROR_ALERTNOAUTHOR'));
 
 					return false;
 				}

--- a/administrator/components/com_messages/src/View/Message/HtmlView.php
+++ b/administrator/components/com_messages/src/View/Message/HtmlView.php
@@ -66,6 +66,10 @@ class HtmlView extends BaseHtmlView
 		{
 			throw new GenericDataException(implode("\n", $errors), 500);
 		}
+		elseif ($this->getLayout() != 'edit' && empty($this->item->message_id))
+		{
+			throw new GenericDataException(Text::_('JERROR_ALERTNOAUTHOR'));
+		}
 
 		parent::display($tpl);
 		$this->addToolbar();

--- a/administrator/components/com_messages/src/View/Message/HtmlView.php
+++ b/administrator/components/com_messages/src/View/Message/HtmlView.php
@@ -68,7 +68,7 @@ class HtmlView extends BaseHtmlView
 		}
 		elseif ($this->getLayout() != 'edit' && empty($this->item->message_id))
 		{
-			throw new GenericDataException(Text::_('JERROR_ALERTNOAUTHOR'));
+			throw new GenericDataException(Text::_('JERROR_ALERTNOAUTHOR'), 403);
 		}
 
 		parent::display($tpl);

--- a/administrator/components/com_messages/src/View/Message/HtmlView.php
+++ b/administrator/components/com_messages/src/View/Message/HtmlView.php
@@ -66,7 +66,7 @@ class HtmlView extends BaseHtmlView
 		{
 			throw new GenericDataException(implode("\n", $errors), 500);
 		}
-		elseif ($this->getLayout() != 'edit' && empty($this->item->message_id))
+		elseif ($this->getLayout() !== 'edit' && empty($this->item->message_id))
 		{
 			throw new GenericDataException(Text::_('JERROR_ALERTNOAUTHOR'), 403);
 		}


### PR DESCRIPTION
Pull Request for Issue #29534 .

### Summary of Changes
Give a correct error message when calling a message with wrong ID


### Testing Instructions
See #29534


### Actual result BEFORE applying this Pull Request
PHP error


### Expected result AFTER applying this Pull Request
Regular error

