### PR TITLE
Action logs fix for media manager upload urls

### DIFF
--- a/administrator/components/com_actionlogs/helpers/actionlogs.php
+++ b/administrator/components/com_actionlogs/helpers/actionlogs.php
@@ -245,14 +245,14 @@ class ActionlogsHelper
 	 * @param   string   $component
 	 * @param   string   $contentType
 	 * @param   integer  $id
-	 * @param   JObject  $object
 	 * @param   string   $urlVar
+	 * @param   JObject  $object
 	 *
 	 * @return  string  Link to the content item
 	 *
 	 * @since   3.9.0
 	 */
-	public static function getContentTypeLink($component, $contentType, $id, $object, $urlVar = 'id')
+	public static function getContentTypeLink($component, $contentType, $id, $urlVar = 'id', $object = null)
 	{
 		// Try to find the component helper.
 		$eName = str_replace('com_', '', $component);

--- a/administrator/components/com_actionlogs/helpers/actionlogs.php
+++ b/administrator/components/com_actionlogs/helpers/actionlogs.php
@@ -245,13 +245,14 @@ class ActionlogsHelper
 	 * @param   string   $component
 	 * @param   string   $contentType
 	 * @param   integer  $id
+	 * @param   JObject  $object
 	 * @param   string   $urlVar
 	 *
 	 * @return  string  Link to the content item
 	 *
 	 * @since   3.9.0
 	 */
-	public static function getContentTypeLink($component, $contentType, $id, $urlVar = 'id')
+	public static function getContentTypeLink($component, $contentType, $id, $object, $urlVar = 'id')
 	{
 		// Try to find the component helper.
 		$eName = str_replace('com_', '', $component);
@@ -266,7 +267,7 @@ class ActionlogsHelper
 
 			if (class_exists($cName) && is_callable(array($cName, 'getContentTypeLink')))
 			{
-				return $cName::getContentTypeLink($contentType, $id);
+				return $cName::getContentTypeLink($contentType, $id, $object);
 			}
 		}
 

--- a/administrator/components/com_media/helpers/media.php
+++ b/administrator/components/com_media/helpers/media.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Object\CMSObject;
+
 /**
  * Media helper class.
  *
@@ -196,5 +198,41 @@ abstract class MediaHelper
 		$mediaHelper = new JHelperMedia;
 
 		return $mediaHelper->countFiles($dir);
+	}
+
+	/**
+	 * Generates the URL to the object in the action logs component
+	 *
+	 * @param   string     $contentType  The content type
+	 * @param   integer    $id           The integer id
+	 * @param   CMSObject  $mediaObject  The media object being uploaded
+	 *
+	 * @return  string  The link for the action log
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public static function getContentTypeLink($contentType, $id, CMSObject $mediaObject)
+	{
+		if ($contentType === 'com_media.file')
+		{
+			return '';
+		}
+
+		$link         = 'index.php?option=com_media&view=media';
+		$uploadedPath = substr($mediaObject->get('filepath'), strlen(COM_MEDIA_BASE) + 1);
+
+		// Now remove the filename
+		$uploadedBasePath = substr_replace(
+			$uploadedPath ,
+			'',
+			(strlen(DIRECTORY_SEPARATOR . $mediaObject->get('name')) * -1)
+		);
+
+		if (!empty($uploadedBasePath))
+		{
+			$link = $link . '&folder=' . $uploadedBasePath;
+		}
+
+		return $link;
 	}
 }

--- a/administrator/components/com_media/helpers/media.php
+++ b/administrator/components/com_media/helpers/media.php
@@ -223,7 +223,7 @@ abstract class MediaHelper
 
 		// Now remove the filename
 		$uploadedBasePath = substr_replace(
-			$uploadedPath ,
+			$uploadedPath,
 			'',
 			(strlen(DIRECTORY_SEPARATOR . $mediaObject->get('name')) * -1)
 		);

--- a/plugins/actionlog/joomla/joomla.php
+++ b/plugins/actionlog/joomla/joomla.php
@@ -119,7 +119,7 @@ class PlgActionlogJoomla extends ActionLogPlugin
 			'type'     => $params->text_prefix . '_TYPE_' . $params->type_title,
 			'id'       => $id,
 			'title'    => $article->get($params->title_holder),
-			'itemlink' => ActionlogsHelper::getContentTypeLink($option, $contentType, $id, $article, $params->id_holder),
+			'itemlink' => ActionlogsHelper::getContentTypeLink($option, $contentType, $id, $params->id_holder, $article),
 		);
 
 		$this->addLog(array($message), $messageLanguageKey, $context);
@@ -268,7 +268,7 @@ class PlgActionlogJoomla extends ActionLogPlugin
 				'type'        => $params->text_prefix . '_TYPE_' . $params->type_title,
 				'id'          => $pk,
 				'title'       => $items[$pk]->{$params->title_holder},
-				'itemlink'    => ActionlogsHelper::getContentTypeLink($option, $contentType, $pk, null, $params->id_holder)
+				'itemlink'    => ActionlogsHelper::getContentTypeLink($option, $contentType, $pk, $params->id_holder, null)
 			);
 
 			$messages[] = $message;
@@ -528,7 +528,7 @@ class PlgActionlogJoomla extends ActionLogPlugin
 			'id'             => $table->get($params->id_holder),
 			'title'          => $table->get($params->title_holder),
 			'extension_name' => $table->get($params->title_holder),
-			'itemlink'       => ActionlogsHelper::getContentTypeLink($option, $contentType, $table->get($params->id_holder), $table, $params->id_holder)
+			'itemlink'       => ActionlogsHelper::getContentTypeLink($option, $contentType, $table->get($params->id_holder), $params->id_holder, $article)
 		);
 
 		$this->addLog(array($message), $messageLanguageKey, $context);

--- a/plugins/actionlog/joomla/joomla.php
+++ b/plugins/actionlog/joomla/joomla.php
@@ -119,7 +119,7 @@ class PlgActionlogJoomla extends ActionLogPlugin
 			'type'     => $params->text_prefix . '_TYPE_' . $params->type_title,
 			'id'       => $id,
 			'title'    => $article->get($params->title_holder),
-			'itemlink' => ActionlogsHelper::getContentTypeLink($option, $contentType, $id, $params->id_holder)
+			'itemlink' => ActionlogsHelper::getContentTypeLink($option, $contentType, $id, $article, $params->id_holder),
 		);
 
 		$this->addLog(array($message), $messageLanguageKey, $context);
@@ -268,7 +268,7 @@ class PlgActionlogJoomla extends ActionLogPlugin
 				'type'        => $params->text_prefix . '_TYPE_' . $params->type_title,
 				'id'          => $pk,
 				'title'       => $items[$pk]->{$params->title_holder},
-				'itemlink'    => ActionlogsHelper::getContentTypeLink($option, $contentType, $pk, $params->id_holder)
+				'itemlink'    => ActionlogsHelper::getContentTypeLink($option, $contentType, $pk, null, $params->id_holder)
 			);
 
 			$messages[] = $message;
@@ -528,7 +528,7 @@ class PlgActionlogJoomla extends ActionLogPlugin
 			'id'             => $table->get($params->id_holder),
 			'title'          => $table->get($params->title_holder),
 			'extension_name' => $table->get($params->title_holder),
-			'itemlink'       => ActionlogsHelper::getContentTypeLink($option, $contentType, $table->get($params->id_holder), $params->id_holder)
+			'itemlink'       => ActionlogsHelper::getContentTypeLink($option, $contentType, $table->get($params->id_holder), $table, $params->id_holder)
 		);
 
 		$this->addLog(array($message), $messageLanguageKey, $context);


### PR DESCRIPTION
Pull Request for Issue #30951 .

### Summary of Changes
Fixes URLs generated in the action logs plugin from the media component. Involves passing the JObject generated by a component back through however - as the id of the media (always 0) is completely useless as the current parameter.

### Testing Instructions
Upload an item into the media manager. Before the patch the link on the file name uploaded will be invalid. After patching the link will correctly take you to the folder of the uploaded item.

### Documentation Changes Required
None
