### PR TITLE
[4.0] correction for 31832

### DIFF
--- a/administrator/components/com_menus/presets/system.xml
+++ b/administrator/components/com_menus/presets/system.xml
@@ -264,7 +264,7 @@
 	</menuitem>
 
 	<menuitem
-		title="MOD_MENU_ACCESS_HEADLINE"
+		title="MOD_MENU_ACCESS"
 		type="heading"
 		icon="key"
 		>

--- a/administrator/language/en-GB/mod_menu.ini
+++ b/administrator/language/en-GB/mod_menu.ini
@@ -4,8 +4,8 @@
 ; Note : All ini files need to be saved as UTF-8
 
 MOD_MENU="Administrator Menu"
+MOD_MENU_ACCESS="User Permissions"
 MOD_MENU_ACCESS_GROUPS="Groups"
-MOD_MENU_ACCESS_HEADLINE="User Permissions"
 MOD_MENU_ACCESS_LEVELS="Access Levels"
 MOD_MENU_ACCESS_SETTINGS="Settings"
 MOD_MENU_ACCESS_TEXT_FILTERS="Text Filters"


### PR DESCRIPTION
There was no need to change the language key. It was consistent with all the similar strings which followed a set structure. (and if changed it should have been _HEADING not _HEADLINE)

All that was needed was to change the value of the string