### PR TITLE
[4.0] Cover cases where the image can't be parsed

### DIFF
--- a/libraries/src/Image/Exception/UnparsableImageException.php
+++ b/libraries/src/Image/Exception/UnparsableImageException.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * @package     Joomla.Platform
+ * @subpackage  Image
+ *
+ * @copyright   (C) 2020 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\CMS\Image\Exception;
+
+\defined('JPATH_PLATFORM') or die;
+
+/**
+ * Exception thrown when an image has no known properties.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class UnparsableImageException extends \RuntimeException
+{
+}

--- a/libraries/src/Image/Image.php
+++ b/libraries/src/Image/Image.php
@@ -186,7 +186,7 @@ class Image
 
 		if (!$info)
 		{
-			throw new \RuntimeException('Unable to get properties for the image.');
+			throw new Exception\UnparsableImageException('Unable to get properties for the image.');
 		}
 
 		// Build the response object.

--- a/plugins/filesystem/local/src/Adapter/LocalAdapter.php
+++ b/plugins/filesystem/local/src/Adapter/LocalAdapter.php
@@ -18,6 +18,7 @@ use Joomla\CMS\Filesystem\Folder;
 use Joomla\CMS\Filesystem\Path;
 use Joomla\CMS\Helper\MediaHelper;
 use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Image\Exception\UnparsableImageException;
 use Joomla\CMS\Image\Image;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\String\PunycodeHelper;
@@ -352,12 +353,19 @@ class LocalAdapter implements AdapterInterface
 		if (MediaHelper::isImage($obj->name))
 		{
 			// Get the image properties
-			$props       = Image::getImageFileProperties($path);
-			$obj->width  = $props->width;
-			$obj->height = $props->height;
+			try
+			{
+				$props       = Image::getImageFileProperties($path);
+				$obj->width  = $props->width;
+				$obj->height = $props->height;
 
-			// Todo : Change this path to an actual thumbnail path
-			$obj->thumb_path = $this->getUrl($obj->path);
+				// Todo : Change this path to an actual thumbnail path
+				$obj->thumb_path = $this->getUrl($obj->path);
+			}
+			catch (UnparsableImageException $e)
+			{
+				// Ignore the exception - it's an image that we don't know how to parse right now
+			}
 		}
 
 		return $obj;


### PR DESCRIPTION
Pull Request for Issue #31837 .

### Summary of Changes
Create a custom exception that we can catch to cover cases where images can't be parsed

### Testing Instructions
Add an XCF image into your images folder (e.g. https://stendhalgame.org/wiki/File:Sample-column.xcf) that can't be parsed by PHP. Note you can't do this through image manager upload. 

### Actual result BEFORE applying this Pull Request
No images in the folder will load

### Expected result AFTER applying this Pull Request
Images load

### Documentation Changes Required
None
