### PR TITLE
[4.0] TinyMCE help

### DIFF
--- a/plugins/editors/tinymce/src/Field/TinymcebuilderField.php
+++ b/plugins/editors/tinymce/src/Field/TinymcebuilderField.php
@@ -83,6 +83,7 @@ class TinymcebuilderField extends FormField
 			'format' => array('label' => 'Format'),
 			'table'  => array('label' => 'Table'),
 			'tools'  => array('label' => 'Tools'),
+			'help'   => array('label' => 'Help'),
 		);
 
 		$data['menus']         = $menus;

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -988,6 +988,7 @@ class PlgEditorTinymce extends CMSPlugin
 			'template'       => array('label' => 'Insert template', 'plugin' => 'template'),
 			'searchreplace'  => array('label' => 'Find and replace', 'plugin' => 'searchreplace'),
 			'insertdatetime' => array('label' => 'Insert date/time', 'plugin' => 'insertdatetime'),
+			'help'           => array('label' => 'Help', 'plugin' => 'help'),
 			// 'spellchecker'   => array('label' => 'Spellcheck', 'plugin' => 'spellchecker'),
 		];
 
@@ -1017,7 +1018,7 @@ class PlgEditorTinymce extends CMSPlugin
 		];
 
 		$preset['medium'] = array(
-			'menu' => array('edit', 'insert', 'view', 'format', 'table', 'tools'),
+			'menu' => array('edit', 'insert', 'view', 'format', 'table', 'tools', 'help'),
 			'toolbar1' => array(
 				'bold', 'italic', 'underline', 'strikethrough', '|',
 				'alignleft', 'aligncenter', 'alignright', 'alignjustify', '|',
@@ -1034,7 +1035,7 @@ class PlgEditorTinymce extends CMSPlugin
 		);
 
 		$preset['advanced'] = array(
-			'menu'     => array('edit', 'insert', 'view', 'format', 'table', 'tools'),
+			'menu'     => array('edit', 'insert', 'view', 'format', 'table', 'tools', 'help'),
 			'toolbar1' => array(
 				'bold', 'italic', 'underline', 'strikethrough', '|',
 				'alignleft', 'aligncenter', 'alignright', 'alignjustify', '|',


### PR DESCRIPTION
This PR reveals many of the hidden secrets in tinymce by enabling the help functionality which shows the hotkeys etc

There are several things to do to test.

In the plugin go to set 1 and press the clear button and then load the medium preset
In the plugin go to set 0 and press the clear button and then load the advanced preset
(this is to emulate a clean install)
You will now see a help item on the toolbar as shown below
![image](https://user-images.githubusercontent.com/1296369/103483377-c3eb7a80-4dde-11eb-8371-4d71a975e7cc.png)

Check that you can click on the help and remove it by dragging it off the tinymce panel
Check that you can click on the help in the available menus and buttons panel and add it by dragging it to the tinymce panel

Check that you can click on the help button in the available menus and buttons panel and add it by dragging it to the tinymce panel
![image](https://user-images.githubusercontent.com/1296369/103483432-1c227c80-4ddf-11eb-9602-ca668efe7a18.png)

When you have finished - save the plugin and open a new article.
You will now see the help menu item and if you added it the help button.

Check that the help is displayed as below
![help](https://user-images.githubusercontent.com/1296369/103483479-74f21500-4ddf-11eb-9183-9b25b6d8deea.gif)

The help pages can be further customised but that is beyond the scope of this PR. If you are interested you can find further information at https://www.tiny.cloud/docs/plugins/opensource/help/
