### PR TITLE
Set result description even if introtext or fulltext is missing

### DIFF
--- a/components/com_finder/views/search/tmpl/default_result.php
+++ b/components/com_finder/views/search/tmpl/default_result.php
@@ -24,7 +24,7 @@ if ($show_description)
 	$pad_length  = $term_length < $desc_length ? (int) floor(($desc_length - $term_length) / 2) : 0;
 
 	// Make sure we highlight term both in introtext and fulltext
-	if (!empty($this->result->summary) && !empty($this->result->body))
+	if (!empty($this->result->summary) || !empty($this->result->body))
 	{
 		$full_description = FinderIndexerHelper::parse($this->result->summary . $this->result->body);
 	}


### PR DESCRIPTION
Pull Request for Issue [#31848]

### Summary of Changes

The given code expects introtext AND fulltext both be present for a result description to be presented in search results. My patch loosens this requirement.

### Testing Instructions

1. create an article with the title "Hello finder", without introtext but with fulltext that contains several random sentences and the word "foobar"
2. call php cli/finder_indexer.php
3. search for "foobar"

### Actual result BEFORE applying this Pull Request

Title of the article without description text.

### Expected result AFTER applying this Pull Request

Title of the article with description text.

### Documentation Changes Required

Nothing I know of.