### PR TITLE
[4.0] Allow 3rd party scss compiling scripts to coexist with own build tools

### DIFF
--- a/build/build-modules-js/compilecss.es6.js
+++ b/build/build-modules-js/compilecss.es6.js
@@ -57,7 +57,7 @@ module.exports.compile = (options, path) => {
                 // Don't take files with "_" but "file" has the full path, so check via match
                 if (file.match(/\.scss$/)) {
                   // Bail out for non Joomla convention folders, eg: scss
-                  if (!(file.match(/\/templates\/scss\//) || file.match(/\\templates\\scss\\/))) {
+                  if (!(file.match(/\/scss\//) || file.match(/\\scss\\/))) {
                     return;
                   }
                   // Ignore files starting with _

--- a/build/build-modules-js/compilecss.es6.js
+++ b/build/build-modules-js/compilecss.es6.js
@@ -57,7 +57,7 @@ module.exports.compile = (options, path) => {
                 // Don't take files with "_" but "file" has the full path, so check via match
                 if (file.match(/\.scss$/)) {
                   // Bail out for non Joomla convention folders, eg: scss
-                  if (!file.match(/\/template(s)?\/scss\//) || !file.match(/\\template(s)?\\scss\\/)) {
+                  if (!(file.match(/\/templates\/scss\//) || file.match(/\\templates\\scss\\/))) {
                     return;
                   }
                   // Ignore files starting with _

--- a/build/build-modules-js/compilecss.es6.js
+++ b/build/build-modules-js/compilecss.es6.js
@@ -57,7 +57,7 @@ module.exports.compile = (options, path) => {
                 // Don't take files with "_" but "file" has the full path, so check via match
                 if (file.match(/\.scss$/)) {
                   // Bail out for non Joomla convention folders, eg: scss
-                  if (file.match(/\/template(s)?\/scss\//) || file.match(/\\template(s)?\\scss\\/)) {
+                  if (!file.match(/\/template(s)?\/scss\//) || !file.match(/\\template(s)?\\scss\\/)) {
                     return;
                   }
                   // Ignore files starting with _

--- a/build/build-modules-js/compilecss.es6.js
+++ b/build/build-modules-js/compilecss.es6.js
@@ -56,6 +56,11 @@ module.exports.compile = (options, path) => {
               (file) => {
                 // Don't take files with "_" but "file" has the full path, so check via match
                 if (file.match(/\.scss$/)) {
+                  // Bail out for non Joomla convention folders, eg: scss
+                  if (file.match(/\/template(s)?\/scss\//) || file.match(/\\template(s)?\\scss\\/)) {
+                    return;
+                  }
+                  // Ignore files starting with _
                   if (!file.match(/(\/|\\)_[^/\\]+$/)) {
                     files.push(file);
                   }


### PR DESCRIPTION
Pull Request for Issue #31852 .

### Summary of Changes
Templates scss files that are inside a folder `scss` **will** use the repos built tools. Other folder names are free to use their own scripts 

### Testing Instructions



### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Documentation Changes Required

