### PR TITLE
[4.0] Skip-to plugin major upgrade [a11y]

### DIFF
--- a/administrator/language/en-GB/plg_system_skipto.ini
+++ b/administrator/language/en-GB/plg_system_skipto.ini
@@ -4,13 +4,29 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_SYSTEM_SKIPTO="System - Skip-To Navigation"
-PLG_SYSTEM_SKIPTO_CONTENT="Content"
-PLG_SYSTEM_SKIPTO_PAGE_OUTLINE="Page Outline"
+PLG_SYSTEM_SKIPTO_ACCESS_KEY_NOT_SUPPORTED="The use of Access keys is not supported on this browser."
+PLG_SYSTEM_SKIPTO_HEADING_IMP="Page Outline"
+PLG_SYSTEM_SKIPTO_HEADING_LEVEL="Heading level"
+PLG_SYSTEM_SKIPTO_HEADING_NONE="No headings to skip to"
+PLG_SYSTEM_SKIPTO_LANDMARK_ASIDE="Aside"
+PLG_SYSTEM_SKIPTO_LANDMARK_FOOTER="Footer"
+PLG_SYSTEM_SKIPTO_LANDMARK_FORM="Form"
+PLG_SYSTEM_SKIPTO_LANDMARK_HEADER="Header"
+PLG_SYSTEM_SKIPTO_LANDMARK_IMP="Landmarks"
+PLG_SYSTEM_SKIPTO_LANDMARK_MAIN="Main"
+PLG_SYSTEM_SKIPTO_LANDMARK_NAV="Navigation"
+PLG_SYSTEM_SKIPTO_LANDMARK_NONE="No landmarks to skip to"
+PLG_SYSTEM_SKIPTO_LANDMARK_SEARCH="Search"
+PLG_SYSTEM_SKIPTO_MENU="Landmarks and Page Outline"
 PLG_SYSTEM_SKIPTO_SECTION="Site Section"
 PLG_SYSTEM_SKIPTO_SECTION_ADMIN="Administrator (Backend)"
 PLG_SYSTEM_SKIPTO_SECTION_BOTH="Both"
 PLG_SYSTEM_SKIPTO_SECTION_SITE="Site (Frontend)"
 PLG_SYSTEM_SKIPTO_SKIP_TO="Skip To"
-PLG_SYSTEM_SKIPTO_SKIP_TO_AND_PAGE_OUTLINE="Skip To and Page Outline"
-PLG_SYSTEM_SKIPTO_SKIP_TO_KEYBOARD="Skip To Keyboard Navigation"
+PLG_SYSTEM_SKIPTO_TITLE="Keyboard Navigation"
+; do not translate $key
+PLG_SYSTEM_SKIPTO_TITLE_WITH_ACCCESS_KEY="Keyboard Navigation - Access key is $key"
 PLG_SYSTEM_SKIPTO_XML_DESCRIPTION="The plugin creates a dropdown menu consisting of the links to the important places on a given web page. This makes it easier for keyboard and screen reader users to quickly jump to the desired location by choosing it from the list of options."
+
+
+

--- a/build/build-modules-js/settings.json
+++ b/build/build-modules-js/settings.json
@@ -548,30 +548,21 @@
         "name": "skipto",
         "licenseFilename": "LICENSE.md",
         "js": {
-          "src/js/skipTo.js": "js/skipTo.js",
-          "src/js/dropMenu.js": "js/dropMenu.js"
+          "src/js/skipto.js": "js/skipto.js"
         },
         "css": {
-          "src/css/SkipTo.css": "css/SkipTo.css"
+          "src/css/skipTo.css": "css/skipTo.css"
         },
         "provideAssets": [
           {
             "name": "skipto",
             "type": "style",
-            "uri": "SkipTo.css"
-          },
-          {
-            "name": "skipto.dropmenu",
-            "type": "script",
-            "uri": "dropMenu.js",
-            "attributes": {
-              "defer": true
-            }
+            "uri": "skipTo.css"
           },
           {
             "name": "skipto",
             "type": "script",
-            "uri": "skipTo.js",
+            "uri": "skipto.js",
             "attributes": {
               "defer": true
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10446,9 +10446,9 @@
       }
     },
     "skipto": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/skipto/-/skipto-2.1.1.tgz",
-      "integrity": "sha512-fK4iFyQl3icXU9I7L5A26tU/8dVkCni4Df72L6C0kvzjYwP5nGXqq/3S/TuZM6vBqCtwqKQJabWn0R67oW2fww=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/skipto/-/skipto-3.1.0.tgz",
+      "integrity": "sha512-0VUrBxn7+pHHyLO5PG6YhDFF3aaZl5AoOPAnXRlMSDNHtPT7WbpQTNSCQu5qhjhvfl1S+YWwwzfYdqItv9RzpQ=="
     },
     "slash": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "qrcode-generator": "^1.4.4",
     "roboto-fontface": "^0.10.0",
     "short-and-sweet": "^1.0.2",
-    "skipto": "^2.1.1",
+    "skipto": "^3.1.0",
     "tinymce": "^5.6.1",
     "vue": "^2.6.12",
     "vue-focus-lock": "^1.3.2",

--- a/plugins/system/skipto/skipto.php
+++ b/plugins/system/skipto/skipto.php
@@ -61,15 +61,30 @@ class PlgSystemSkipto extends CMSPlugin
 			[
 				'settings' => [
 					'skipTo' => [
-						'buttonDivRole'  => 'navigation',
-						'buttonDivLabel' => Text::_('PLG_SYSTEM_SKIPTO_SKIP_TO_KEYBOARD'),
-						'buttonLabel'    => Text::_('PLG_SYSTEM_SKIPTO_SKIP_TO'),
-						'buttonDivTitle' => '',
-						'menuLabel'      => Text::_('PLG_SYSTEM_SKIPTO_SKIP_TO_AND_PAGE_OUTLINE'),
-						'landmarksLabel' => Text::_('PLG_SYSTEM_SKIPTO_SKIP_TO'),
-						'headingsLabel'	 => Text::_('PLG_SYSTEM_SKIPTO_PAGE_OUTLINE'),
-						// The following string begins with a space
-						'contentLabel'   => ' ' . Text::_('PLG_SYSTEM_SKIPTO_CONTENT'),
+						'colorTheme'                  => 'joomla',
+					//	'displayOption'               => 'popup',
+						'accesskey'                   => '9',
+						'customClass'                 => 'joomla',
+						'enableActions'               => false,
+						'enableHeadingLevelShortcuts' => false,
+						'headings'                    => 'h1, h2, h3',
+						'landmarks'                   => 'main, nav, search, aside, header, footer, form',
+						'accesskeyNotSupported'       => Text::_('PLG_SYSTEM_SKIPTO_ACCESS_KEY_NOT_SUPPORTED'),
+						'asideLabel'                  => Text::_('PLG_SYSTEM_SKIPTO_LANDMARK_ASIDE'),
+						'buttonLabel'                 => Text::_('PLG_SYSTEM_SKIPTO_SKIP_TO'),
+						'buttonTitle'                 => Text::_('PLG_SYSTEM_SKIPTO_TITLE'),
+						'buttonTitleWithAccesskey'    => Text::_('PLG_SYSTEM_SKIPTO_TITLE_WITH_ACCCESS_KEY'),
+						'footerLabel'                 => Text::_('PLG_SYSTEM_SKIPTO_LANDMARK_FOOTER'),
+						'formLabel'                   => Text::_('PLG_SYSTEM_SKIPTO_LANDMARK_FORM'),
+						'headerLabel'                 => Text::_('PLG_SYSTEM_SKIPTO_LANDMARK_HEADER'),
+						'headingImportantGroupLabel'  => Text::_('PLG_SYSTEM_SKIPTO_HEADING_IMP'),
+						'headingLevelLabel'           => Text::_('PLG_SYSTEM_SKIPTO_HEADING_LEVEL'),
+						'landmarkImportantGroupLabel' => Text::_('PLG_SYSTEM_SKIPTO_LANDMARK_IMP'),
+						'mainLabel'                   => Text::_('PLG_SYSTEM_SKIPTO_LANDMARK_MAIN'),
+						'msgNoHeadingsFound'          => Text::_('PLG_SYSTEM_SKIPTO_HEADING_NONE'),
+						'msgNoLandmarksFound'         => Text::_('PLG_SYSTEM_SKIPTO_LANDMARK_NONE'),
+						'navLabel'                    => Text::_('PLG_SYSTEM_SKIPTO_LANDMARK_NAV'),
+						'searchLabel'                 => Text::_('PLG_SYSTEM_SKIPTO_LANDMARK_SEARCH'),
 					]
 				]
 			]
@@ -78,15 +93,15 @@ class PlgSystemSkipto extends CMSPlugin
 		/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 		$wa = $document->getWebAssetManager();
 		$wa->useStyle('skipto')
-			->useScript('skipto.dropmenu')
 			->useScript('skipto')
 			->addInlineScript(
 				'document.addEventListener(\'DOMContentLoaded\', function() {'
-				. 'window.SkipToConfig = Joomla.getOptions(\'skipto-settings\');'
-				. 'window.skipToMenuInit();});',
+				. 'window.SkipToConfig = Joomla.getOptions(\'skipto-settings\');});',
 				[],
 				['type' => 'module'],
 				['skipto']
 			);
 	}
 }
+
+//useStyle('skipto')

--- a/plugins/system/skipto/skipto.php
+++ b/plugins/system/skipto/skipto.php
@@ -53,8 +53,7 @@ class PlgSystemSkipto extends CMSPlugin
 		}
 
 		// Are we in a modal?
-		$input   = Factory::getApplication()->input;
-		if ($input->get('tmpl', '', 'cmd') === 'component')
+		if ($this->app->input->get('tmpl', '', 'cmd') === 'component')
 		{
 			return;
 		}

--- a/plugins/system/skipto/skipto.php
+++ b/plugins/system/skipto/skipto.php
@@ -62,7 +62,7 @@ class PlgSystemSkipto extends CMSPlugin
 				'settings' => [
 					'skipTo' => [
 						'colorTheme'                  => 'joomla',
-					//	'displayOption'               => 'popup',
+						'displayOption'               => 'popup',
 						'accesskey'                   => '9',
 						'customClass'                 => 'joomla',
 						'enableActions'               => false,
@@ -103,5 +103,3 @@ class PlgSystemSkipto extends CMSPlugin
 			);
 	}
 }
-
-//useStyle('skipto')

--- a/plugins/system/skipto/skipto.php
+++ b/plugins/system/skipto/skipto.php
@@ -55,7 +55,7 @@ class PlgSystemSkipto extends CMSPlugin
 		// Load language file.
 		$this->loadLanguage();
 
-		// Add strings for translations in JavaScript.
+		// Add strings for translations in JavaScript and other plugin settings.
 		$document->addScriptOptions(
 			'skipto-settings',
 			[

--- a/plugins/system/skipto/skipto.php
+++ b/plugins/system/skipto/skipto.php
@@ -52,6 +52,13 @@ class PlgSystemSkipto extends CMSPlugin
 			return;
 		}
 
+		// Are we in a modal?
+		$input   = Factory::getApplication()->input;
+		if ($input->get('tmpl', '', 'cmd') === 'component')
+		{
+			return;
+		}
+
 		// Load language file.
 		$this->loadLanguage();
 


### PR DESCRIPTION
This is a draft PR to give a heads up about this new version especially as there are new language strings.

Amongst other things it addresses @infograf768 comments about not everything be translatable and an old comment from @clodder about the dropdown script which is no longer being used.

In the process of creating this PR I discovered a few bugs in the upstream code (pr submitted) and that there github is ahead of the release on npm yet with a lower package number.

As a result this PR is not completed and its not working (hence its a draft).

This release is much much better under the hood. I have only implemented some of the features (ie not the important and all distinction) as they're more suitable to a content rich site than an admin ui.

For now you can only do a code review. As soon as I get a response to https://github.com/paypal/skipto/issues/68 I will be able to complete the release

More information http://paypal.github.io/skipto/
