### PR TITLE
[4.0] Menu list readability [a11y]

### DIFF
--- a/administrator/components/com_menus/tmpl/items/default.php
+++ b/administrator/components/com_menus/tmpl/items/default.php
@@ -178,23 +178,27 @@ $assoc   = Associations::isEnabled() && $this->state->get('filter.client_id') ==
 									<?php else : ?>
 										<?php echo $this->escape($item->title); ?>
 									<?php endif; ?>
-									<span class="small">
-									<?php if ($item->type != 'url') : ?>
-										<?php if (empty($item->note)) : ?>
-											<?php echo Text::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->alias)); ?>
-										<?php else : ?>
-											<?php echo Text::sprintf('JGLOBAL_LIST_ALIAS_NOTE', $this->escape($item->alias), $this->escape($item->note)); ?>
-										<?php endif; ?>
-									<?php elseif ($item->type == 'url' && $item->note) : ?>
-										<?php echo Text::sprintf('JGLOBAL_LIST_NOTE', $this->escape($item->note)); ?>
-									<?php endif; ?>
-									</span>
 									<?php echo HTMLHelper::_('menus.visibility', $item->params); ?>
+									<div>
+										<?php echo $prefix; ?>
+										<span class="small">
+										<?php if ($item->type != 'url') : ?>
+											<?php if (empty($item->note)) : ?>
+												<?php echo Text::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->alias)); ?>
+											<?php else : ?>
+												<?php echo Text::sprintf('JGLOBAL_LIST_ALIAS_NOTE', $this->escape($item->alias), $this->escape($item->note)); ?>
+											<?php endif; ?>
+										<?php elseif ($item->type == 'url' && $item->note) : ?>
+											<?php echo Text::sprintf('JGLOBAL_LIST_NOTE', $this->escape($item->note)); ?>
+										<?php endif; ?>
+										</span>
+									</div>
 									<div title="<?php echo $this->escape($item->path); ?>">
 										<?php echo $prefix; ?>
 										<span class="small"
 											  title="<?php echo isset($item->item_type_desc) ? htmlspecialchars($this->escape($item->item_type_desc), ENT_COMPAT, 'UTF-8') : ''; ?>">
-											<?php echo $this->escape($item->item_type); ?></span>
+											<?php echo $this->escape($item->item_type); ?>
+										</span>
 									</div>
 									<?php if ($item->type === 'component' && !$item->enabled) : ?>
 										<div>

--- a/administrator/components/com_menus/tmpl/items/modal.php
+++ b/administrator/components/com_menus/tmpl/items/modal.php
@@ -118,17 +118,22 @@ if (!empty($editor))
 							<?php else : ?>
 								<?php echo $this->escape($item->title); ?>
 							<?php endif; ?>
-							<span class="small">
+							<?php echo HTMLHelper::_('menus.visibility', $item->params); ?>
+							<div>
+								<?php echo $prefix; ?>
+								<span class="small">
 								<?php if (empty($item->note)) : ?>
 									<?php echo Text::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->alias)); ?>
 								<?php else : ?>
 									<?php echo Text::sprintf('JGLOBAL_LIST_ALIAS_NOTE', $this->escape($item->alias), $this->escape($item->note)); ?>
 								<?php endif; ?>
-							</span>
+								</span>
+							</div>
 							<div title="<?php echo $this->escape($item->path); ?>">
 								<?php echo $prefix; ?>
 								<span class="small" title="<?php echo isset($item->item_type_desc) ? htmlspecialchars($this->escape($item->item_type_desc), ENT_COMPAT, 'UTF-8') : ''; ?>">
-									<?php echo $this->escape($item->item_type); ?></span>
+									<?php echo $this->escape($item->item_type); ?>
+								</span>
 							</div>
 							<?php if ($item->type === 'component' && !$item->enabled) : ?>
 								<div>


### PR DESCRIPTION
For com_content we changed the list view so that the title, alias and category were all on separate lines as it was felt that this improved readability and clarity which is a benefit for everyone but especially for those with cognitive issues

This PR does the same for menu items.

### Before
![image](https://user-images.githubusercontent.com/1296369/103592669-8a546580-4eeb-11eb-94e3-9d8fe8ee8af6.png)

### After
![image](https://user-images.githubusercontent.com/1296369/103592648-7d377680-4eeb-11eb-9be2-f40b176514c2.png)
