### PR TITLE
[4.0] Remove double variable $spellcheck in field layouts

### DIFF
--- a/layouts/joomla/form/field/email.php
+++ b/layouts/joomla/form/field/email.php
@@ -43,7 +43,6 @@ extract($displayData);
  * @var   boolean  $hasValue        Has this field a value assigned?
  * @var   array    $options         Options available for this field.
  * @var   array    $inputType       Options available for this field.
- * @var   array    $spellcheck      Options available for this field.
  * @var   string   $accept          File types that are accepted.
  * @var   string   $dataAttribute   Miscellaneous data attributes preprocessed for HTML output
  * @var   array    $dataAttributes  Miscellaneous data attribute for eg, data-*.

--- a/layouts/joomla/form/field/file.php
+++ b/layouts/joomla/form/field/file.php
@@ -45,7 +45,6 @@ extract($displayData);
  * @var   boolean  $hasValue        Has this field a value assigned?
  * @var   array    $options         Options available for this field.
  * @var   array    $inputType       Options available for this field.
- * @var   array    $spellcheck      Options available for this field.
  * @var   string   $accept          File types that are accepted.
  * @var   string   $dataAttribute   Miscellaneous data attributes preprocessed for HTML output
  * @var   array    $dataAttributes  Miscellaneous data attribute for eg, data-*

--- a/layouts/joomla/form/field/moduleorder.php
+++ b/layouts/joomla/form/field/moduleorder.php
@@ -43,7 +43,6 @@ extract($displayData);
  * @var   boolean  $hasValue        Has this field a value assigned?
  * @var   array    $options         Options available for this field.
  * @var   array    $inputType       Options available for this field.
- * @var   array    $spellcheck      Options available for this field.
  * @var   string   $accept          File types that are accepted.
  * @var   string   $dataAttribute   Miscellaneous data attributes preprocessed for HTML output
  * @var   array    $dataAttributes  Miscellaneous data attributes for eg, data-*.

--- a/layouts/joomla/form/field/number.php
+++ b/layouts/joomla/form/field/number.php
@@ -40,7 +40,6 @@ extract($displayData);
  * @var   boolean  $hasValue        Has this field a value assigned?
  * @var   array    $options         Options available for this field.
  * @var   array    $inputType       Options available for this field.
- * @var   array    $spellcheck      Options available for this field.
  * @var   string   $accept          File types that are accepted.
  * @var   string   $dataAttribute   Miscellaneous data attributes preprocessed for HTML output
  * @var   array    $dataAttributes  Miscellaneous data attribute for eg, data-*.

--- a/layouts/joomla/form/field/time.php
+++ b/layouts/joomla/form/field/time.php
@@ -42,7 +42,6 @@ extract($displayData);
  * @var   boolean $hasValue       Has this field a value assigned?
  * @var   array   $options        Options available for this field.
  * @var   array   $inputType      Options available for this field.
- * @var   array   $spellcheck     Options available for this field.
  * @var   string  $accept         File types that are accepted.
  * @var   string  $dataAttribute  Miscellaneous data attributes preprocessed for HTML output
  * @var   array   $dataAttributes Miscellaneous data attribute for eg, data-*.


### PR DESCRIPTION
The $spellcheck variable must be declared once and have a boolean type.


### Testing Instructions
code review