### PR TITLE
[4.0] Disable accessibility plugin in modal

### DIFF
--- a/plugins/system/accessibility/accessibility.php
+++ b/plugins/system/accessibility/accessibility.php
@@ -52,6 +52,13 @@ class PlgSystemAccessibility extends CMSPlugin
 			return;
 		}
 
+		// Are we in a modal?
+		$input   = Factory::getApplication()->input;
+		if ($input->get('tmpl', '', 'cmd') === 'component')
+		{
+			return;
+		}
+
 		// Load language file.
 		$this->loadLanguage();
 

--- a/plugins/system/accessibility/accessibility.php
+++ b/plugins/system/accessibility/accessibility.php
@@ -53,8 +53,7 @@ class PlgSystemAccessibility extends CMSPlugin
 		}
 
 		// Are we in a modal?
-		$input   = Factory::getApplication()->input;
-		if ($input->get('tmpl', '', 'cmd') === 'component')
+		if ($this->app->input->get('tmpl', '', 'cmd') === 'component')
 		{
 			return;
 		}


### PR DESCRIPTION
To test enable the system accessibility plugin
In an article in the images & links tab click on select to open the modal

### Before
![image](https://user-images.githubusercontent.com/1296369/103640431-ec42b880-4f47-11eb-9084-790f7e035d80.png)

### After
![image](https://user-images.githubusercontent.com/1296369/103640400-da611580-4f47-11eb-8df6-aa546d0129cf.png)

In the new skipto plugin I will apply the same fix and that will address #30691 