### PR TITLE
Fix PHP CS errors introduced with PR 31672

### DIFF
--- a/layouts/joomla/form/field/password.php
+++ b/layouts/joomla/form/field/password.php
@@ -112,16 +112,16 @@ $attributes = array(
 
 ?>
 <?php if ($lock): ?>
-    <span class="input-append">
+	<span class="input-append">
 <?php endif; ?>
 <input
-    type="password"
-    name="<?php echo $name; ?>"
-    id="<?php echo $id; ?>"
-    value="<?php echo htmlspecialchars($value, ENT_COMPAT, 'UTF-8'); ?>"
-    <?php echo implode(' ', $attributes); ?>
+	type="password"
+	name="<?php echo $name; ?>"
+	id="<?php echo $id; ?>"
+	value="<?php echo htmlspecialchars($value, ENT_COMPAT, 'UTF-8'); ?>"
+	<?php echo implode(' ', $attributes); ?>
 />
 <?php if ($lock): ?>
-    <button type="button" id="<?php echo $id; ?>_lock" class="btn btn-info" data-toggle="button"><?php echo JText::_('JMODIFY'); ?></button>
-    </span>
+	<button type="button" id="<?php echo $id; ?>_lock" class="btn btn-info" data-toggle="button"><?php echo JText::_('JMODIFY'); ?></button>
+	</span>
 <?php endif; ?>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Use tabs and not spaces for indentation in PHP files.

### Testing Instructions

Code review + check that PHP CS succeeds in Drone tests.

### Actual result BEFORE applying this Pull Request

Spaces used for indentation at the end of file `layouts/joomla/form/field/password.php`.

PHP CS fails in Drone tests.

### Expected result AFTER applying this Pull Request

Tabs used for indentation at the end of file `layouts/joomla/form/field/password.php`.

PHP CS succeeds in Drone tests.

### Documentation Changes Required

None.