### PR TITLE
[4.0] Fix merge conflict from PR 31672

### DIFF
--- a/administrator/components/com_config/forms/application.xml
+++ b/administrator/components/com_config/forms/application.xml
@@ -202,6 +202,7 @@
 			filter="raw"
 			autocomplete="off"
 			size="30"
+			hiddenDescription="true"
 			lock="true"
 		/>
 

--- a/layouts/joomla/form/field/password.php
+++ b/layouts/joomla/form/field/password.php
@@ -176,13 +176,14 @@ if ($rules && !empty($description))
 			id="<?php echo $id; ?>"
 			value="<?php echo htmlspecialchars($value, ENT_COMPAT, 'UTF-8'); ?>"
 			<?php echo implode(' ', $attributes); ?>>
-		<?php if ($lock): ?>
-			<span class="input-group-append">
-				<button type="button" class="btn btn-secondary input-password-toggle">
-					<span class="icon-eye icon-fw" aria-hidden="true"></span>
-					<span class="sr-only"><?php echo Text::_('JSHOWPASSWORD'); ?></span>
-				</button>
-			</span>
-		<?php endif; ?>
+		<span class="input-group-append">
+			<button type="button" class="btn btn-secondary input-password-toggle">
+				<span class="icon-eye icon-fw" aria-hidden="true"></span>
+				<span class="sr-only"><?php echo Text::_('JSHOWPASSWORD'); ?></span>
+			</button>
+			<?php if ($lock): ?>
+				<button type="button" id="<?php echo $id; ?>_lock" class="btn btn-info" data-toggle="button"><?php echo JText::_('JMODIFY'); ?></button>
+			<?php endif; ?>
+		</span>
 	</div>
 </div>

--- a/layouts/joomla/form/field/password.php
+++ b/layouts/joomla/form/field/password.php
@@ -182,7 +182,7 @@ if ($rules && !empty($description))
 				<span class="sr-only"><?php echo Text::_('JSHOWPASSWORD'); ?></span>
 			</button>
 			<?php if ($lock): ?>
-				<button type="button" id="<?php echo $id; ?>_lock" class="btn btn-info" data-toggle="button"><?php echo JText::_('JMODIFY'); ?></button>
+				<button type="button" id="<?php echo $id; ?>_lock" class="btn btn-info" data-toggle="button"><?php echo Text::_('JMODIFY'); ?></button>
 			<?php endif; ?>
 		</span>
 	</div>

--- a/layouts/joomla/form/field/password.php
+++ b/layouts/joomla/form/field/password.php
@@ -158,7 +158,6 @@ if ($rules && !empty($description))
 	}
 }
 ?>
-<<<<<<< HEAD
 <?php if (!empty($description)) : ?>
 	<div id="<?php echo $name . '-desc'; ?>" class="small text-muted">
 		<?php if ($rules) : ?>
@@ -177,27 +176,13 @@ if ($rules && !empty($description))
 			id="<?php echo $id; ?>"
 			value="<?php echo htmlspecialchars($value, ENT_COMPAT, 'UTF-8'); ?>"
 			<?php echo implode(' ', $attributes); ?>>
-		<span class="input-group-append">
-			<button type="button" class="btn btn-secondary input-password-toggle">
-				<span class="icon-eye icon-fw" aria-hidden="true"></span>
-				<span class="sr-only"><?php echo Text::_('JSHOWPASSWORD'); ?></span>
-			</button>
-		</span>
+		<?php if ($lock): ?>
+			<span class="input-group-append">
+				<button type="button" class="btn btn-secondary input-password-toggle">
+					<span class="icon-eye icon-fw" aria-hidden="true"></span>
+					<span class="sr-only"><?php echo Text::_('JSHOWPASSWORD'); ?></span>
+				</button>
+			</span>
+		<?php endif; ?>
 	</div>
 </div>
-=======
-<?php if ($lock): ?>
-    <span class="input-append">
-<?php endif; ?>
-<input
-    type="password"
-    name="<?php echo $name; ?>"
-    id="<?php echo $id; ?>"
-    value="<?php echo htmlspecialchars($value, ENT_COMPAT, 'UTF-8'); ?>"
-    <?php echo implode(' ', $attributes); ?>
-/>
-<?php if ($lock): ?>
-    <button type="button" id="<?php echo $id; ?>_lock" class="btn btn-info" data-toggle="button"><?php echo JText::_('JMODIFY'); ?></button>
-    </span>
-<?php endif; ?>
->>>>>>> 3.10-dev


### PR DESCRIPTION
Pull Request for [https://github.com/joomla/joomla-cms/commit/8cfeec1aef7d7a25a6c872721198e4e7f4fddcf6#commitcomment-45729579](https://github.com/joomla/joomla-cms/commit/8cfeec1aef7d7a25a6c872721198e4e7f4fddcf6#commitcomment-45729579).

### Summary of Changes

Solve the merge conflict we currently have in the 4.0-dev branch here:

https://github.com/joomla/joomla-cms/blob/4.0-dev/layouts/joomla/form/field/password.php#L161-L203

### Testing Instructions

1. Start a new installation on current 4.0-dev or latest 4.0 nightly build. Select language and site name and go to the next step for entering super user data and do not continue after that.
Result: The form shows a merge conflict, see section "Actual result BEFORE applying this Pull Request" below.
2. Apply the patch of this PR.
3. Start again the new installation.
Result: The form doesn't show a merge conflict. The installation succeeds.
4. Test PR #31672 again as described there, but this time on the 4.0-dev or latest 4.0 nightly build with the patch of this PR applied.
Result: See section "Expected result AFTER applying this Pull Request" below.

### Actual result BEFORE applying this Pull Request

Drone PHP CS fails in the 4.0-dev branch at the file modified by this PR here.

New installation: The form shows a merge conflict
![2021-01-07_1](https://user-images.githubusercontent.com/7413183/103904738-f7d7e000-50fd-11eb-8df0-04ef71d5f96f.png)

### Expected result AFTER applying this Pull Request

Drone PHP CS is successful for this PR here.

New installation: The form doesn't show a merge conflict
![2021-01-07_3](https://user-images.githubusercontent.com/7413183/103904478-9b74c080-50fd-11eb-8c52-14baa42d0877.png)

The change from PR #31672 works on 4.0, too.

Eg for database password in Global Configuration, Server tab:
![2021-01-07_2](https://user-images.githubusercontent.com/7413183/103903276-fc02fe00-50fb-11eb-804c-258a64e74251.png)

### Documentation Changes Required

None.