### PR TITLE
[4.0] Minor Cleanup of workflow code

### DIFF
--- a/administrator/components/com_workflow/src/View/Stages/HtmlView.php
+++ b/administrator/components/com_workflow/src/View/Stages/HtmlView.php
@@ -145,7 +145,7 @@ class HtmlView extends BaseHtmlView
 		if (!empty($this->stages))
 		{
 			$extension = Factory::getApplication()->input->getCmd('extension');
-			$workflow  = new Workflow(['extension' => $extension]);
+			$workflow  = new Workflow($extension);
 		}
 
 		$this->addToolbar();

--- a/libraries/src/MVC/Model/WorkflowBehaviorTrait.php
+++ b/libraries/src/MVC/Model/WorkflowBehaviorTrait.php
@@ -77,7 +77,7 @@ trait WorkflowBehaviorTrait
 			$this->section = array_shift($parts);
 		}
 
-		$this->workflow = new Workflow(['extension' => $extension]);
+		$this->workflow = new Workflow($extension);
 
 		$params = ComponentHelper::getParams($this->extension);
 

--- a/libraries/src/Workflow/Workflow.php
+++ b/libraries/src/Workflow/Workflow.php
@@ -111,14 +111,21 @@ class Workflow
 	public function __construct(array $options, ?CMSApplication $app = null, ?DatabaseDriver $db = null)
 	{
 		// Required options
+		if (!array_key_exists('extension', $options))
+		{
+			throw new \InvalidArgumentException('Missing argument \'extension\' for Workflow');
+		}
+
 		$this->extension = $options['extension'];
 
 		// Default some optional options
-		$this->options['access']     = true;
-		$this->options['published']  = true;
-		$this->options['countItems'] = false;
+		$defaultOptions = [
+			'access'     => true,
+			'published'  => true,
+			'countItems' => false,
+		];
 
-		$this->setOptions($options);
+		$this->setOptions(array_merge($defaultOptions, $this->options));
 
 		// Initialise default objects if none have been provided
 		$this->app = $app ?: Factory::getApplication();

--- a/libraries/src/Workflow/Workflow.php
+++ b/libraries/src/Workflow/Workflow.php
@@ -44,14 +44,6 @@ class Workflow
 	protected $extension = null;
 
 	/**
-	 * Workflow options
-	 *
-	 * @var    array
-	 * @since  4.0.0
-	 */
-	protected $options = [];
-
-	/**
 	 * Application Object
 	 *
 	 * @var    CMSApplication
@@ -102,30 +94,15 @@ class Workflow
 	/**
 	 * Class constructor
 	 *
-	 * @param   array            $options  Array of options
-	 * @param   ?CMSApplication  $app      Application Object
-	 * @param   ?DatabaseDriver  $db       Database Driver Object
+	 * @param   string           $extension  The extension name
+	 * @param   ?CMSApplication  $app        Application Object
+	 * @param   ?DatabaseDriver  $db         Database Driver Object
 	 *
 	 * @since   4.0.0
 	 */
-	public function __construct(array $options, ?CMSApplication $app = null, ?DatabaseDriver $db = null)
+	public function __construct(string $extension, ?CMSApplication $app = null, ?DatabaseDriver $db = null)
 	{
-		// Required options
-		if (!array_key_exists('extension', $options))
-		{
-			throw new \InvalidArgumentException('Missing argument \'extension\' for Workflow');
-		}
-
-		$this->extension = $options['extension'];
-
-		// Default some optional options
-		$defaultOptions = [
-			'access'     => true,
-			'published'  => true,
-			'countItems' => false,
-		];
-
-		$this->setOptions(array_merge($defaultOptions, $this->options));
+		$this->extension = $extension;
 
 		// Initialise default objects if none have been provided
 		$this->app = $app ?: Factory::getApplication();
@@ -586,32 +563,5 @@ class Workflow
 			->bind(':extension', $this->extension);
 
 		return $this->db->setQuery($query)->loadObject();
-	}
-
-	/**
-	 * Allows to set some optional options, eg. if the access level should be considered.
-	 *
-	 * @param   array  $options  The new options
-	 *
-	 * @return  void
-	 *
-	 * @since  4.0.0
-	 */
-	public function setOptions(array $options): void
-	{
-		if (isset($options['access']))
-		{
-			$this->options['access'] = (bool) $options['access'];
-		}
-
-		if (isset($options['published']))
-		{
-			$this->options['published'] = (bool) $options['published'];
-		}
-
-		if (isset($options['countItems']))
-		{
-			$this->options['countItems'] = (bool) $options['countItems'];
-		}
 	}
 }

--- a/plugins/sampledata/multilang/multilang.php
+++ b/plugins/sampledata/multilang/multilang.php
@@ -1160,7 +1160,7 @@ class PlgSampledataMultilang extends CMSPlugin
 			return false;
 		}
 
-		$workflow = new Workflow(['extension' => 'com_content.article']);
+		$workflow = new Workflow('com_content.article');
 
 		try
 		{


### PR DESCRIPTION
### Summary of Changes
- Allows injection of the CMSApplication + DatabaseDriver classes into the Workflow class (this is to allow future unit testing of the class).
- Cleanup constructor - the options array (and setOptions method) weren't used by the class anymore - they've been removed in the large refactor. It now just requires a string of the extension name.

### Testing Instructions
Workflow related functionalities unchanged. Install sample data and create and modify workflows 

### Documentation Changes Required
Possibly. Not sure whether the documentation covers the constructor. It's likely it only covers using the trait.
