### PR TITLE
[4.0] Setup legacy CLI app with proper dispatcher and container

### DIFF
--- a/libraries/src/Application/CliApplication.php
+++ b/libraries/src/Application/CliApplication.php
@@ -116,16 +116,25 @@ abstract class CliApplication extends AbstractApplication implements DispatcherA
 
 		$container = $container ?: Factory::getContainer();
 		$this->setContainer($container);
+		$this->setDispatcher($dispatcher ?: $container->get(\Joomla\Event\DispatcherInterface::class));
+
+		if (!$container->has('session'))
+		{
+			$container->alias('session', 'session.cli')
+				->alias('JSession', 'session.cli')
+				->alias(\Joomla\CMS\Session\Session::class, 'session.cli')
+				->alias(\Joomla\Session\Session::class, 'session.cli')
+				->alias(\Joomla\Session\SessionInterface::class, 'session.cli');
+		}
+
+		\JLoader::register('JNamespacePsr4Map', JPATH_LIBRARIES . '/namespacemap.php');
+		$extensionLoader = new \JNamespacePsr4Map;
+		$extensionLoader->load();
 
 		$this->input    = new \Joomla\CMS\Input\Cli;
 		$this->language = Factory::getLanguage();
 		$this->output   = $output ?: new Stdout;
 		$this->cliInput = $cliInput ?: new CliInput;
-
-		if ($dispatcher)
-		{
-			$this->setDispatcher($dispatcher);
-		}
 
 		parent::__construct($config);
 


### PR DESCRIPTION
### Summary of Changes
The CLI app gets deprecated by the new Console app. Still a lot of extensions rely on it. To be as much backwards compatible as possible, some setup work is needed. This pr adds the functionality to load the extensions namespace map, and setup properly the dispatcher and some session variables, copied from the console app.

### Testing Instructions
- Copy the discover app from here https://github.com/Digital-Peak/DPDocker/blob/master/webserver/scripts/discoverapp.php to the joomla root.
- Remove the lines 25 to 37 in the file discoverapp.php of your joomal root
- Link an extension with a symlink
- Execute `php discoverapp.php` in your Joomla root folder

### Actual result BEFORE applying this Pull Request
It crashes and the extension doesn't get installed.

### Expected result AFTER applying this Pull Request
The extension is installed.