### PR TITLE
[4.0] TinyMCE quickbars

### DIFF
--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -581,7 +581,7 @@ class PlgEditorTinymce extends CMSPlugin
 				// Quickbars
 				'quickbars_image_toolbar'     => false,
 				'quickbars_insert_toolbar'    => false,
-				'quickbars_selection_toolbar' => 'bold italic | H2 H3 | link blockquote',
+				'quickbars_selection_toolbar' => 'bold italic underline | H2 H3 | link blockquote',
 
 				// Cleanup/Output
 				'inline_styles'    => true,

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -404,6 +404,7 @@ class PlgEditorTinymce extends CMSPlugin
 			'autolink',
 			'lists',
 			'importcss',
+			'quickbars',
 		);
 
 		// Allowed elements
@@ -576,6 +577,11 @@ class PlgEditorTinymce extends CMSPlugin
 				'toolbar' => empty($toolbar) ? null  : 'jxtdbuttons ' . implode(' ', $toolbar),
 
 				'plugins'  => implode(',', array_unique($plugins)),
+
+				// Quickbars
+				'quickbars_image_toolbar'     => false,
+				'quickbars_insert_toolbar'    => false,
+				'quickbars_selection_toolbar' => 'bold italic | H2 H3 | link blockquote',
 
 				// Cleanup/Output
 				'inline_styles'    => true,


### PR DESCRIPTION
Shown when text is selected, providing formatting buttons such as: bold, italic, and link.

![image](https://user-images.githubusercontent.com/1296369/104037024-11dff400-51cc-11eb-89ab-9e803696be50.png)

To test just apply the pr and in the editor select some text. 