### PR TITLE
[4.0] Use email field type for password reset

### DIFF
--- a/components/com_users/forms/reset_request.xml
+++ b/components/com_users/forms/reset_request.xml
@@ -3,12 +3,12 @@
 	<fieldset name="default" label="COM_USERS_RESET_REQUEST_LABEL">
 		<field
 			name="email"
-			type="text"
+			type="email"
 			label="COM_USERS_FIELD_PASSWORD_RESET_LABEL"
-			class="validate-username"
-			filter="email"
 			required="true"
 			size="30"
+			validate="email"
+			autocomplete="email"
 		/>
 
 		<field


### PR DESCRIPTION
Pull Request for Issue #31891 .

### Summary of Changes
Fix email field type

### Testing Instructions
Go to the reset password field and enter a name and hit submit

### Actual result BEFORE applying this Pull Request
![image](https://user-images.githubusercontent.com/1986000/104042485-7900a700-51d2-11eb-95b0-7106729efcbf.png)

### Expected result AFTER applying this Pull Request
![image](https://user-images.githubusercontent.com/1986000/104042501-7dc55b00-51d2-11eb-8182-bacedb121765.png)

### Documentation Changes Required
No
