### PR TITLE
[4.0] Banner TracksExport modal

### DIFF
--- a/administrator/components/com_banners/tmpl/tracks/default.php
+++ b/administrator/components/com_banners/tmpl/tracks/default.php
@@ -89,19 +89,6 @@ $listDirn   = $this->escape($this->state->get('list.direction'));
 				<?php echo HTMLHelper::_(
 					'bootstrap.renderModal',
 					'downloadModal',
-					[
-						'title'       => Text::_('COM_BANNERS_TRACKS_DOWNLOAD'),
-						'url'         => Route::_('index.php?option=com_banners&amp;view=download&amp;tmpl=component'),
-						'height'      => '370px',
-						'width'       => '300px',
-						'modalWidth'  => '40',
-						'footer'      => '<button type="button" class="btn" data-dismiss="modal"'
-								. ' onclick="Joomla.iframeButtonClick({iframeSelector: \'#downloadModal\', buttonSelector: \'#closeBtn\'})">'
-								. Text::_('COM_BANNERS_CANCEL') . '</button>'
-								. '<button type="button" class="btn btn-success"'
-								. ' onclick="Joomla.iframeButtonClick({iframeSelector: \'#downloadModal\', buttonSelector: \'#exportBtn\'})">'
-								. Text::_('COM_BANNERS_TRACKS_EXPORT') . '</button>',
-					]
 				); ?>
 				<input type="hidden" name="task" value="">
 				<input type="hidden" name="boxchecked" value="0">

--- a/administrator/components/com_banners/tmpl/tracks/default.php
+++ b/administrator/components/com_banners/tmpl/tracks/default.php
@@ -88,7 +88,7 @@ $listDirn   = $this->escape($this->state->get('list.direction'));
 				<?php // Load the export form ?>
 				<?php echo HTMLHelper::_(
 					'bootstrap.renderModal',
-					'downloadModal',
+					'downloadModal'
 				); ?>
 				<input type="hidden" name="task" value="">
 				<input type="hidden" name="boxchecked" value="0">

--- a/layouts/joomla/toolbar/modal.php
+++ b/layouts/joomla/toolbar/modal.php
@@ -57,9 +57,9 @@ echo HTMLHelper::_('bootstrap.renderModal',
 		'modalWidth'  => 80,
 		'bodyHeight'  => 60,
 		'closeButton' => true,
-		'footer'      => '<a class="btn btn-secondary" data-dismiss="modal" type="button"'
+		'footer'      => '<button class="btn btn-secondary" data-dismiss="modal" type="button"'
 						. ' onclick="window.parent.Joomla.Modal.getCurrent().close();">'
-						. Text::_('COM_BANNERS_CANCEL') . '</a>'
+						. Text::_('COM_BANNERS_CANCEL') . '</button>'
 						. '<button class="btn btn-success" type="button"'
 						. ' onclick="Joomla.iframeButtonClick({iframeSelector: \'#modal_downloadModal\', buttonSelector: \'#exportBtn\'})">'
 						. Text::_('COM_BANNERS_TRACKS_EXPORT') . '</button>',


### PR DESCRIPTION
Pull Request for Issue #31926  .

### Summary of Changes
The modal was rendering with an `a` instead of a `button`

In investigating this I found that the modal was not using the code in the view but the code in a layout. 

This PR removes the unused code in the view and corrects the link in the layout.

I do not really understand why this is a layout


### Testing Instructions
Apply the pr and check that the export tracks modal still works
View the source and check that the cancel button is using `button` markup
