### PR TITLE
[4] Rename and namespace Joomla Commands

### DIFF
--- a/libraries/src/Console/AddUserCommand.php
+++ b/libraries/src/Console/AddUserCommand.php
@@ -34,7 +34,7 @@ class AddUserCommand extends AbstractCommand
 	 * @var    string
 	 * @since  4.0.0
 	 */
-	protected static $defaultName = 'user:add';
+	protected static $defaultName = 'joomla:user:add';
 
 	/**
 	 * SymfonyStyle Object

--- a/libraries/src/Console/AddUserToGroupCommand.php
+++ b/libraries/src/Console/AddUserToGroupCommand.php
@@ -36,7 +36,7 @@ class AddUserToGroupCommand extends AbstractCommand
 	 * @var    string
 	 * @since  4.0.0
 	 */
-	protected static $defaultName = 'user:addtogroup';
+	protected static $defaultName = 'joomla:user:addtogroup';
 
 	/**
 	 * SymfonyStyle Object

--- a/libraries/src/Console/ChangeUserPasswordCommand.php
+++ b/libraries/src/Console/ChangeUserPasswordCommand.php
@@ -31,7 +31,7 @@ class ChangeUserPasswordCommand extends AbstractCommand
 	 * @var    string
 	 * @since  4.0.0
 	 */
-	protected static $defaultName = 'user:reset-password';
+	protected static $defaultName = 'joomla:user:reset-password';
 
 	/**
 	 * SymfonyStyle Object

--- a/libraries/src/Console/CheckJoomlaUpdatesCommand.php
+++ b/libraries/src/Console/CheckJoomlaUpdatesCommand.php
@@ -29,7 +29,7 @@ class CheckJoomlaUpdatesCommand extends AbstractCommand
 	 * @var    string
 	 * @since  4.0
 	 */
-	protected static $defaultName = 'core:check-updates';
+	protected static $defaultName = 'joomla:updates:check';
 
 	/**
 	 * Stores the Update Information

--- a/libraries/src/Console/CheckUpdatesCommand.php
+++ b/libraries/src/Console/CheckUpdatesCommand.php
@@ -30,7 +30,7 @@ class CheckUpdatesCommand extends AbstractCommand
 	 * @var    string
 	 * @since  4.0.0
 	 */
-	protected static $defaultName = 'update:extensions:check';
+	protected static $defaultName = 'joomla:extensions:checkupdates';
 
 	/**
 	 * Internal function to execute the command.

--- a/libraries/src/Console/CleanCacheCommand.php
+++ b/libraries/src/Console/CleanCacheCommand.php
@@ -29,7 +29,7 @@ class CleanCacheCommand extends AbstractCommand
 	 * @var    string
 	 * @since  4.0.0
 	 */
-	protected static $defaultName = 'cache:clean';
+	protected static $defaultName = 'joomla:cache:clean';
 
 	/**
 	 * Internal function to execute the command.

--- a/libraries/src/Console/DeleteUserCommand.php
+++ b/libraries/src/Console/DeleteUserCommand.php
@@ -35,7 +35,7 @@ class DeleteUserCommand extends AbstractCommand
 	 * @var    string
 	 * @since  4.0.0
 	 */
-	protected static $defaultName = 'user:delete';
+	protected static $defaultName = 'joomla:user:delete';
 
 	/**
 	 * SymfonyStyle Object

--- a/libraries/src/Console/ExtensionInstallCommand.php
+++ b/libraries/src/Console/ExtensionInstallCommand.php
@@ -31,7 +31,7 @@ class ExtensionInstallCommand extends AbstractCommand
 	 * @var    string
 	 * @since  4.0
 	 */
-	protected static $defaultName = 'extension:install';
+	protected static $defaultName = 'joomla:extension:install';
 
 	/**
 	 * Stores the Input Object

--- a/libraries/src/Console/ExtensionRemoveCommand.php
+++ b/libraries/src/Console/ExtensionRemoveCommand.php
@@ -33,7 +33,7 @@ class ExtensionRemoveCommand extends AbstractCommand
 	 * @var    string
 	 * @since  4.0
 	 */
-	protected static $defaultName = 'extension:remove';
+	protected static $defaultName = 'joomla:extension:remove';
 
 	/**
 	 * @var InputInterface
@@ -123,12 +123,12 @@ class ExtensionRemoveCommand extends AbstractCommand
 		$this->addArgument(
 			'extensionId',
 			InputArgument::REQUIRED,
-			'ID of extension to be removed (run extension:list command to check)'
+			'ID of extension to be removed (run joomla:extension:list command to check)'
 		);
 
 		$help = "<info>%command.name%</info> is used to uninstall extensions.
 		\nThe command requires one argument, the ID of the extension to uninstall.
-		\nYou may find this ID by running the <info>extension:list</info> command.
+		\nYou may find this ID by running the <info>joomla:extension:list</info> command.
 		\nUsage: <info>php %command.full_name% <extension_id></info>";
 
 		$this->setDescription('Remove an extension');

--- a/libraries/src/Console/ExtensionsListCommand.php
+++ b/libraries/src/Console/ExtensionsListCommand.php
@@ -30,7 +30,7 @@ class ExtensionsListCommand extends AbstractCommand
 	 * @var    string
 	 * @since  4.0
 	 */
-	protected static $defaultName = 'extension:list';
+	protected static $defaultName = 'joomla:extension:list';
 
 	/**
 	 * Stores the installed Extensions

--- a/libraries/src/Console/FinderIndexCommand.php
+++ b/libraries/src/Console/FinderIndexCommand.php
@@ -35,7 +35,7 @@ class FinderIndexCommand extends AbstractCommand
 	 * @var    string
 	 * @since  4.0.0
 	 */
-	protected static $defaultName = 'finder:index';
+	protected static $defaultName = 'joomla:finder:index';
 
 	/**
 	 * Stores the Input Object

--- a/libraries/src/Console/GetConfigurationCommand.php
+++ b/libraries/src/Console/GetConfigurationCommand.php
@@ -30,7 +30,7 @@ class GetConfigurationCommand extends AbstractCommand
 	 * @var    string
 	 * @since  4.0
 	 */
-	protected static $defaultName = 'config:get';
+	protected static $defaultName = 'joomla:config:get';
 
 	/**
 	 * Stores the Input Object

--- a/libraries/src/Console/ListUserCommand.php
+++ b/libraries/src/Console/ListUserCommand.php
@@ -29,7 +29,7 @@ class ListUserCommand extends AbstractCommand
 	 * @var    string
 	 * @since  4.0.0
 	 */
-	protected static $defaultName = 'user:list';
+	protected static $defaultName = 'joomla:user:list';
 
 	/**
 	 * SymfonyStyle Object

--- a/libraries/src/Console/RemoveOldFilesCommand.php
+++ b/libraries/src/Console/RemoveOldFilesCommand.php
@@ -28,7 +28,7 @@ class RemoveOldFilesCommand extends AbstractCommand
 	 * @var    string
 	 * @since  4.0.0
 	 */
-	protected static $defaultName = 'update:joomla:remove-old-files';
+	protected static $defaultName = 'joomla:update:cleanup';
 
 	/**
 	 * Internal function to execute the command.

--- a/libraries/src/Console/RemoveUserFromGroupCommand.php
+++ b/libraries/src/Console/RemoveUserFromGroupCommand.php
@@ -36,7 +36,7 @@ class RemoveUserFromGroupCommand extends AbstractCommand
 	 * @var    string
 	 * @since  4.0.0
 	 */
-	protected static $defaultName = 'user:removefromgroup';
+	protected static $defaultName = 'joomla:user:removefromgroup';
 
 	/**
 	 * SymfonyStyle Object

--- a/libraries/src/Console/SessionGcCommand.php
+++ b/libraries/src/Console/SessionGcCommand.php
@@ -34,7 +34,7 @@ class SessionGcCommand extends AbstractCommand implements ContainerAwareInterfac
 	 * @var    string
 	 * @since  4.0.0
 	 */
-	protected static $defaultName = 'session:gc';
+	protected static $defaultName = 'joomla:session:gc';
 
 	/**
 	 * Internal function to execute the command.

--- a/libraries/src/Console/SessionMetadataGcCommand.php
+++ b/libraries/src/Console/SessionMetadataGcCommand.php
@@ -30,7 +30,7 @@ class SessionMetadataGcCommand extends AbstractCommand
 	 * @var    string
 	 * @since  4.0.0
 	 */
-	protected static $defaultName = 'session:metadata:gc';
+	protected static $defaultName = 'joomla:session:metadatagc';
 
 	/**
 	 * The session metadata manager.

--- a/libraries/src/Console/SetConfigurationCommand.php
+++ b/libraries/src/Console/SetConfigurationCommand.php
@@ -34,7 +34,7 @@ class SetConfigurationCommand extends AbstractCommand
 	 * @var    string
 	 * @since  4.0
 	 */
-	protected static $defaultName = 'config:set';
+	protected static $defaultName = 'joomla:config:set';
 
 	/**
 	 * Stores the Input Object

--- a/libraries/src/Console/SiteDownCommand.php
+++ b/libraries/src/Console/SiteDownCommand.php
@@ -29,7 +29,7 @@ class SiteDownCommand extends AbstractCommand
 	 * @var    string
 	 * @since  4.0
 	 */
-	protected static $defaultName = 'site:down';
+	protected static $defaultName = 'joomla:site:down';
 
 	/**
 	 * SymfonyStyle Object
@@ -39,13 +39,13 @@ class SiteDownCommand extends AbstractCommand
 	private $ioStyle;
 
 	/**
-	 * Return code if site:down failed
+	 * Return code if joomla:site:down failed
 	 * @since 4.0
 	 */
 	const SITE_DOWN_FAILED = 1;
 
 	/**
-	 * Return code if site:down was successful
+	 * Return code if joomla:site:down was successful
 	 * @since 4.0
 	 */
 	const SITE_DOWN_SUCCESSFUL = 0;

--- a/libraries/src/Console/SiteUpCommand.php
+++ b/libraries/src/Console/SiteUpCommand.php
@@ -29,7 +29,7 @@ class SiteUpCommand extends AbstractCommand
 	 * @var    string
 	 * @since  4.0
 	 */
-	protected static $defaultName = 'site:up';
+	protected static $defaultName = 'joomla:site:up';
 
 	/**
 	 * SymfonyStyle Object
@@ -39,13 +39,13 @@ class SiteUpCommand extends AbstractCommand
 	private $ioStyle;
 
 	/**
-	 * Return code if site:up failed
+	 * Return code if joomla:site:up failed
 	 * @since 4.0
 	 */
 	const SITE_UP_FAILED = 1;
 
 	/**
-	 * Return code if site:up was successful
+	 * Return code if joomla:site:up was successful
 	 * @since 4.0
 	 */
 	const SITE_UP_SUCCESSFUL = 0;

--- a/libraries/src/Console/UpdateCoreCommand.php
+++ b/libraries/src/Console/UpdateCoreCommand.php
@@ -34,7 +34,7 @@ class UpdateCoreCommand extends AbstractCommand
 	 * @var    string
 	 * @since  4.0
 	 */
-	protected static $defaultName = 'core:update';
+	protected static $defaultName = 'joomla:update:install';
 
 	/**
 	 * Stores the Input Object


### PR DESCRIPTION
**A decision is needed asap - as a release blocker - because if this is not merged before Joomla 4.0.0 is released, then its a b/c change and will not be worth doing in the future when Joomla 4.1 is released.** 

### Summary of Changes

prefix all Joomla internal commands with `joomla:` to correctly namespace them from other commands.

Out of the box this doesn't seem to make much sense, however as the community add more and more commands, the name spacing and naming convention of commands can, and will, get messy. This has already played out in other projects with commands. 

### Testing Instructions

`php cli/joomla.php list`

note that `database:import/export` is not covered by this PR as that is a library of its own. 

### Actual result BEFORE applying this Pull Request

<img width="910" alt="Screenshot 2021-01-09 at 13 06 35" src="https://user-images.githubusercontent.com/400092/104092385-86be3700-527b-11eb-8c79-c094fb241503.png">

### Expected result AFTER applying this Pull Request

<img width="903" alt="Screenshot 2021-01-09 at 13 06 49" src="https://user-images.githubusercontent.com/400092/104092390-8de54500-527b-11eb-8b8f-9bac86150b78.png">

And after installing extensions with other commands you can see why this is much neater and makes sense to do:


<img width="889" alt="Screenshot 2021-01-09 at 13 11 33" src="https://user-images.githubusercontent.com/400092/104092490-398e9500-527c-11eb-88c0-b9c24bda2ba3.png">



### Documentation Changes Required

