### PR TITLE
[4] Add dry-run and verbose/debug modes to update:joomla:remove-old-files cmd

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -6272,12 +6272,12 @@ class JoomlaInstallerScript
 			}
 		}
 
-		if ($supressOutput === false && \count($status['folders_errors']))
+		if ($suppressOutput === false && \count($status['folders_errors']))
 		{
 			echo implode('<br/>', $status['folders_errors']);
 		}
 
-		if ($supressOutput === false && \count($status['files_errors']))
+		if ($suppressOutput === false && \count($status['files_errors']))
 		{
 			echo implode('<br/>', $status['files_errors']);
 		}

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -468,11 +468,11 @@ class JoomlaInstallerScript
 	 * Delete files that should not exist
 	 *
 	 * @param bool  $dryRun          If set to true, will not actually delete files, but just report their status for use in CLI
-	 * @param bool  $supressOutput   Set to true to supress echoing any errors, and just return the $status array
+	 * @param bool  $suppressOutput   Set to true to supress echoing any errors, and just return the $status array
 	 *
 	 * @return  array
 	 */
-	public function deleteUnexistingFiles($dryRun = false, $supressOutput = false)
+	public function deleteUnexistingFiles($dryRun = false, $suppressOutput = false)
 	{
 		$status = [
 			'files_exist'     =>[],

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -475,14 +475,14 @@ class JoomlaInstallerScript
 	public function deleteUnexistingFiles($dryRun = false, $suppressOutput = false)
 	{
 		$status = [
-			'files_exist'     =>[],
-			'folders_exist'   =>[],
-			'files_deleted'   =>[],
-			'folders_deleted' =>[],
-			'files_errors'    =>[],
-			'folders_errors'  =>[],
-			'folders_checked' =>[],
-			'files_checked'   =>[],
+			'files_exist'     => [],
+			'folders_exist'   => [],
+			'files_deleted'   => [],
+			'folders_deleted' => [],
+			'files_errors'    => [],
+			'folders_errors'  => [],
+			'folders_checked' => [],
+			'files_checked'   => [],
 		];
 
 		$files = array(
@@ -6237,14 +6237,15 @@ class JoomlaInstallerScript
 			{
 				$status['files_exist'][] = $file;
 
-				if ($dryRun === false){
+				if ($dryRun === false)
+				{
 					if (File::delete(JPATH_ROOT . $file))
 					{
 						$status['files_deleted'][] = $file;
 					}
 					else
 					{
-						$status['files_errors'][] = Text::sprintf('FILES_JOOMLA_ERROR_FILE_FOLDER', $file) ;
+						$status['files_errors'][] = Text::sprintf('FILES_JOOMLA_ERROR_FILE_FOLDER', $file);
 					}
 				}
 			}
@@ -6256,7 +6257,8 @@ class JoomlaInstallerScript
 			{
 				$status['folders_exist'][] = $folder;
 
-				if ($dryRun === false){
+				if ($dryRun === false)
+				{
 					// TODO There is an issue while deleting folders using the ftp mode
 					if (Folder::delete(JPATH_ROOT . $folder))
 					{
@@ -6264,7 +6266,7 @@ class JoomlaInstallerScript
 					}
 					else
 					{
-						$status['folders_errors'][] = Text::sprintf('FILES_JOOMLA_ERROR_FILE_FOLDER', $folder) ;
+						$status['folders_errors'][] = Text::sprintf('FILES_JOOMLA_ERROR_FILE_FOLDER', $folder);
 					}
 				}
 			}

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -467,10 +467,24 @@ class JoomlaInstallerScript
 	/**
 	 * Delete files that should not exist
 	 *
-	 * @return  void
+	 * @param bool  $dryRun          If set to true, will not actually delete files, but just report their status for use in CLI
+	 * @param bool  $supressOutput   Set to true to supress echoing any errors, and just return the $status array
+	 *
+	 * @return  array
 	 */
-	public function deleteUnexistingFiles()
+	public function deleteUnexistingFiles($dryRun = false, $supressOutput = false)
 	{
+		$status = [
+			'files_exist'     =>[],
+			'folders_exist'   =>[],
+			'files_deleted'   =>[],
+			'folders_deleted' =>[],
+			'files_errors'    =>[],
+			'folders_errors'  =>[],
+			'folders_checked' =>[],
+			'files_checked'   =>[],
+		];
+
 		$files = array(
 			// Joomla 4.0 Beta 1
 			'/administrator/components/com_actionlogs/actionlogs.php',
@@ -5026,7 +5040,6 @@ class JoomlaInstallerScript
 			'/templates/cassiopeia/scss/vendor/bootstrap/_card.scss',
 		);
 
-		// TODO There is an issue while deleting folders using the ftp mode
 		$folders = array(
 			// Joomla 4.0 Beta 1
 			'/templates/system/images',
@@ -6215,21 +6228,59 @@ class JoomlaInstallerScript
 			'/plugins/content/imagelazyload',
 		);
 
+		$status['files_checked'] = $files;
+		$status['folders_checked'] = $folders;
+
 		foreach ($files as $file)
 		{
-			if (File::exists(JPATH_ROOT . $file) && !File::delete(JPATH_ROOT . $file))
+			if ($fileExists = File::exists(JPATH_ROOT . $file))
 			{
-				echo Text::sprintf('FILES_JOOMLA_ERROR_FILE_FOLDER', $file) . '<br>';
+				$status['files_exist'][] = $file;
+
+				if ($dryRun === false){
+					if (File::delete(JPATH_ROOT . $file))
+					{
+						$status['files_deleted'][] = $file;
+					}
+					else
+					{
+						$status['files_errors'][] = Text::sprintf('FILES_JOOMLA_ERROR_FILE_FOLDER', $file) ;
+					}
+				}
 			}
 		}
 
 		foreach ($folders as $folder)
 		{
-			if (Folder::exists(JPATH_ROOT . $folder) && !Folder::delete(JPATH_ROOT . $folder))
+			if ($folderExists = Folder::exists(JPATH_ROOT . $folder))
 			{
-				echo Text::sprintf('FILES_JOOMLA_ERROR_FILE_FOLDER', $folder) . '<br>';
+				$status['folders_exist'][] = $folder;
+
+				if ($dryRun === false){
+					// TODO There is an issue while deleting folders using the ftp mode
+					if (Folder::delete(JPATH_ROOT . $folder))
+					{
+						$status['folders_deleted'][] = $folder;
+					}
+					else
+					{
+						$status['folders_errors'][] = Text::sprintf('FILES_JOOMLA_ERROR_FILE_FOLDER', $folder) ;
+					}
+				}
 			}
 		}
+
+		if ($supressOutput === false && \count($status['folders_errors']))
+		{
+			echo implode('<br/>', $status['folders_errors']);
+		}
+
+		if ($supressOutput === false && \count($status['files_errors']))
+		{
+			echo implode('<br/>', $status['files_errors']);
+		}
+
+		return $status;
 	}
 
 	/**

--- a/libraries/src/Console/RemoveOldFilesCommand.php
+++ b/libraries/src/Console/RemoveOldFilesCommand.php
@@ -35,8 +35,8 @@ class RemoveOldFilesCommand extends AbstractCommand
 	/**
 	 * Internal function to execute the command.
 	 *
-	 * @param  InputInterface  $input   The input to inject into the command.
-	 * @param  OutputInterface $output  The output to inject into the command.
+	 * @param   InputInterface  $input   The input to inject into the command.
+	 * @param   OutputInterface $output  The output to inject into the command.
 	 *
 	 * @return  integer  The command exit code
 	 *
@@ -60,6 +60,7 @@ class RemoveOldFilesCommand extends AbstractCommand
 			foreach ($status['files_checked'] as $file)
 			{
 				$exists = in_array($file, array_values($status['files_exist']));
+
 				if ($exists)
 				{
 					$symfonyStyle->writeln('<error>File Checked & Exists</error> - ' . $file, OutputInterface::VERBOSITY_VERY_VERBOSE);
@@ -73,6 +74,7 @@ class RemoveOldFilesCommand extends AbstractCommand
 			foreach ($status['folders_checked'] as $folder)
 			{
 				$exists = in_array($folder, array_values($status['folders_exist']));
+
 				if ($exists)
 				{
 					$symfonyStyle->writeln('<error>Folder Checked & Exists</error> - ' . $folder, OutputInterface::VERBOSITY_VERY_VERBOSE);
@@ -84,38 +86,44 @@ class RemoveOldFilesCommand extends AbstractCommand
 			}
 		}
 
-		if ($dryRun===false)
+		if ($dryRun === false)
 		{
-			foreach ($status['files_deleted'] as $file) {
+			foreach ($status['files_deleted'] as $file)
+			{
 				$symfonyStyle->writeln('<comment>File Deleted = ' . $file . '</comment>', OutputInterface::VERBOSITY_VERBOSE);
 			}
 
-			foreach ($status['files_errors'] as $error) {
+			foreach ($status['files_errors'] as $error)
+			{
 				$symfonyStyle->error($error);
 			}
 
-			foreach ($status['folders_deleted'] as $folder) {
+			foreach ($status['folders_deleted'] as $folder)
+			{
 				$symfonyStyle->writeln('<comment>Folder Deleted = ' . $folder . '</comment>', OutputInterface::VERBOSITY_VERBOSE);
 			}
 
-			foreach ($status['folders_errors'] as $error) {
+			foreach ($status['folders_errors'] as $error)
+			{
 				$symfonyStyle->error($error);
 			}
 		}
 
-		$symfonyStyle->success(sprintf(
-			$dryRun ? '%s Files checked and %s would be deleted' : '%s Files checked and %s deleted',
-			\count($status['files_checked']),
-			($dryRun ? \count($status['files_exist']) : \count($status['files_deleted'])
+		$symfonyStyle->success(
+			sprintf(
+				$dryRun ? '%s Files checked and %s would be deleted' : '%s Files checked and %s deleted',
+				\count($status['files_checked']),
+				($dryRun ? \count($status['files_exist']) : \count($status['files_deleted']))
 			)
-		));
+		);
 
-		$symfonyStyle->success(sprintf(
-			$dryRun ? '%s Folders checked and %s would be deleted' : '%s Folders checked and %s deleted',
-			\count($status['folders_checked']),
-			($dryRun ? \count($status['folders_exist']) : \count($status['folders_deleted'])
+		$symfonyStyle->success(
+			sprintf(
+				$dryRun ? '%s Folders checked and %s would be deleted' : '%s Folders checked and %s deleted',
+				\count($status['folders_checked']),
+				($dryRun ? \count($status['folders_exist']) : \count($status['folders_deleted']))
 			)
-		));
+		);
 
 		return Command::SUCCESS;
 	}

--- a/libraries/src/Console/RemoveOldFilesCommand.php
+++ b/libraries/src/Console/RemoveOldFilesCommand.php
@@ -11,7 +11,9 @@ namespace Joomla\CMS\Console;
 \defined('JPATH_PLATFORM') or die;
 
 use Joomla\Console\Command\AbstractCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
@@ -33,8 +35,8 @@ class RemoveOldFilesCommand extends AbstractCommand
 	/**
 	 * Internal function to execute the command.
 	 *
-	 * @param   InputInterface   $input   The input to inject into the command.
-	 * @param   OutputInterface  $output  The output to inject into the command.
+	 * @param  InputInterface  $input   The input to inject into the command.
+	 * @param  OutputInterface $output  The output to inject into the command.
 	 *
 	 * @return  integer  The command exit code
 	 *
@@ -44,16 +46,78 @@ class RemoveOldFilesCommand extends AbstractCommand
 	{
 		$symfonyStyle = new SymfonyStyle($input, $output);
 
-		$symfonyStyle->title('Removing Old Files');
+		$dryRun = $input->getOption('dry-run');
+
+		$symfonyStyle->title('Removing Unneeded Files & Folders' . ($dryRun ? ' - Dry Run' : ''));
 
 		// We need the update script
 		\JLoader::register('JoomlaInstallerScript', JPATH_ADMINISTRATOR . '/components/com_admin/script.php');
 
-		(new \JoomlaInstallerScript)->deleteUnexistingFiles();
+		$status = (new \JoomlaInstallerScript)->deleteUnexistingFiles($dryRun, true);
 
-		$symfonyStyle->success('Files removed');
+		if ($output->isVeryVerbose()||$output->isDebug())
+		{
+			foreach ($status['files_checked'] as $file)
+			{
+				$exists = in_array($file, array_values($status['files_exist']));
+				if ($exists)
+				{
+					$symfonyStyle->writeln('<error>File Checked & Exists</error> - ' . $file, OutputInterface::VERBOSITY_VERY_VERBOSE);
+				}
+				else
+				{
+					$symfonyStyle->writeln('<info>File Checked & Doesn\'t Exist</info> - ' . $file, OutputInterface::VERBOSITY_DEBUG);
+				}
+			}
 
-		return 0;
+			foreach ($status['folders_checked'] as $folder)
+			{
+				$exists = in_array($file, array_values($status['folders_exist']));
+				if ($exists)
+				{
+					$symfonyStyle->writeln('<error>Folder Checked & Exists</error> - ' . $folder, OutputInterface::VERBOSITY_VERY_VERBOSE);
+				}
+				else
+				{
+					$symfonyStyle->writeln('<info>Folder Checked & Doesn\'t Exist</info> - ' . $folder, OutputInterface::VERBOSITY_DEBUG);
+				}
+			}
+		}
+
+		if ($dryRun===false)
+		{
+			foreach ($status['files_deleted'] as $file) {
+				$symfonyStyle->writeln('<comment>File Deleted = ' . $file . '</comment>', OutputInterface::VERBOSITY_VERBOSE);
+			}
+
+			foreach ($status['files_errors'] as $error) {
+				$symfonyStyle->error($error);
+			}
+
+			foreach ($status['folders_deleted'] as $folder) {
+				$symfonyStyle->writeln('<comment>Folder Deleted = ' . $folder . '</comment>', OutputInterface::VERBOSITY_VERBOSE);
+			}
+
+			foreach ($status['folders_errors'] as $error) {
+				$symfonyStyle->error($error);
+			}
+		}
+
+		$symfonyStyle->success(sprintf(
+			$dryRun ? '%s Files checked and %s would be deleted' : '%s Files checked and %s deleted',
+			\count($status['files_checked']),
+			($dryRun ? \count($status['files_exist']) : \count($status['files_deleted'])
+			)
+		));
+
+		$symfonyStyle->success(sprintf(
+			$dryRun ? '%s Folders checked and %s would be deleted' : '%s Folders checked and %s deleted',
+			\count($status['folders_checked']),
+			($dryRun ? \count($status['folders_exist']) : \count($status['folders_deleted'])
+			)
+		));
+
+		return Command::SUCCESS;
 	}
 
 	/**
@@ -69,6 +133,7 @@ class RemoveOldFilesCommand extends AbstractCommand
 		\nUsage: <info>php %command.full_name%</info>";
 
 		$this->setDescription('Remove old system files');
+		$this->addOption('dry-run', null, InputOption::VALUE_NONE, 'Executes a dry run without deleting anything');
 		$this->setHelp($help);
 	}
 }

--- a/libraries/src/Console/RemoveOldFilesCommand.php
+++ b/libraries/src/Console/RemoveOldFilesCommand.php
@@ -72,7 +72,7 @@ class RemoveOldFilesCommand extends AbstractCommand
 
 			foreach ($status['folders_checked'] as $folder)
 			{
-				$exists = in_array($file, array_values($status['folders_exist']));
+				$exists = in_array($folder, array_values($status['folders_exist']));
 				if ($exists)
 				{
 					$symfonyStyle->writeln('<error>Folder Checked & Exists</error> - ' . $folder, OutputInterface::VERBOSITY_VERY_VERBOSE);


### PR DESCRIPTION
Closes #31901 replaces #31914

### Summary of Changes

Improvements to the `update:joomla:remove-old-files` CLI Command

 - Adds an option for `--dry-run`
 - Adds an output change for very verbose mode `-vv`
 - Adds an output change for debug mode `-vvv`


`--dry-run` option is a standard for all Symfony based commands that do destructive things. 

`-v` `-vv` `-vvv` options are a standard Symfony command option for increasing the verbosity to assist with debugging and gathering additional information from a command.

Also See https://github.com/joomla/joomla-cms/pull/31941 for a proposal to rename this command to `Joomla:update:cleanup` but this PR can be applied without that one. 

### Testing Instructions

run these commands to create yourself some folders and files to then go on to delete with the CLI from this PR:

```
touch administrator/components/com_actionlogs/actionlogs.php
touch administrator/components/com_actionlogs/controller.php
mkdir -p templates/system/images
mkdir -p templates/system/html
mkdir -p templates/protostar/less
mkdir -p templates/protostar/language/en-GB
mkdir -p templates/protostar/language
mkdir -p templates/protostar/js
mkdir -p templates/protostar/img
mkdir -p templates/protostar/images/system
```

Apply PR. 

Run these commands as a test of each new feature:


This command should show s summary, but not delete anything:
`php cli/joomla.php update:joomla:remove-old-files --dry-run`

<img width="859" alt="Screenshot 2021-01-09 at 15 54 48" src="https://user-images.githubusercontent.com/400092/104096215-04da0800-5293-11eb-94f6-0a839a621f63.png">

-- 

This command should show what files and folders will be deleted
` php cli/joomla.php update:joomla:remove-old-files --dry-run -vv`

<img width="856" alt="Screenshot 2021-01-09 at 15 56 24" src="https://user-images.githubusercontent.com/400092/104096249-3f43a500-5293-11eb-9ed1-6f7ef37aa6d9.png">

-- 

This command should show what files and folders are checked and what will be deleted (output is huge, so screenshots below are snipped to show important bits)
` php cli/joomla.php update:joomla:remove-old-files --dry-run -vvv`

<img width="705" alt="Screenshot 2021-01-09 at 15 57 42" src="https://user-images.githubusercontent.com/400092/104096275-6dc18000-5293-11eb-8e7f-fbcabf785561.png">

<img width="878" alt="Screenshot 2021-01-09 at 15 57 53" src="https://user-images.githubusercontent.com/400092/104096276-72863400-5293-11eb-89a8-d9e01b1229bd.png">

-- 

You can then set up your folders/files with the test script above, and run any of these commands to ACTUALLY DELETE the files and folders. 

`php cli/joomla.php update:joomla:remove-old-files`

<img width="855" alt="Screenshot 2021-01-09 at 15 58 42" src="https://user-images.githubusercontent.com/400092/104096291-8fbb0280-5293-11eb-88aa-2f5a71452cfc.png">

`php cli/joomla.php update:joomla:remove-old-files -vv`

<img width="853" alt="Screenshot 2021-01-09 at 16 00 27" src="https://user-images.githubusercontent.com/400092/104096360-cee95380-5293-11eb-97c0-a37e556c9f5a.png">

and lastly `php cli/joomla.php update:joomla:remove-old-files -vvv` but Im not going to show that output as its huge and meant for debugging. 


### Actual result BEFORE applying this Pull Request


<img width="871" alt="Screenshot 2021-01-09 at 16 02 23" src="https://user-images.githubusercontent.com/400092/104097259-12dc5880-5294-11eb-80c6-fcef1f3198af.png">

### Expected result AFTER applying this Pull Request

As explained above

### Documentation Changes Required



