### PR TITLE
[4] return built in constants instead of hand typed integers

### DIFF
--- a/libraries/src/Console/AddUserCommand.php
+++ b/libraries/src/Console/AddUserCommand.php
@@ -14,6 +14,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\User\User;
 use Joomla\Console\Command\AbstractCommand;
 use Joomla\Filter\InputFilter;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\InvalidOptionException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -119,7 +120,7 @@ class AddUserCommand extends AbstractCommand
 		{
 			$this->ioStyle->error("'" . $this->userGroups[1] . "' user group doesn't exist!");
 
-			return 1;
+			return Command::FAILURE;
 		}
 
 		// Get filter to remove invalid characters
@@ -154,7 +155,7 @@ class AddUserCommand extends AbstractCommand
 
 		$this->ioStyle->success("User created!");
 
-		return 0;
+		return Command::SUCCESS;
 	}
 
 	/**

--- a/libraries/src/Console/AddUserToGroupCommand.php
+++ b/libraries/src/Console/AddUserToGroupCommand.php
@@ -15,6 +15,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\User\User;
 use Joomla\CMS\User\UserHelper;
 use Joomla\Console\Command\AbstractCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\InvalidOptionException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -92,7 +93,7 @@ class AddUserToGroupCommand extends AbstractCommand
 		{
 			$this->ioStyle->error("The user " . $this->username . " does not exist!");
 
-			return 1;
+			return Command::FAILURE;
 		}
 
 		// Fetch user
@@ -121,11 +122,11 @@ class AddUserToGroupCommand extends AbstractCommand
 			{
 				$this->ioStyle->error("Can't add '" . $user->username . "' to group '" . $result . "'!");
 
-				return 1;
+				return Command::FAILURE;
 			}
 		}
 
-		return 0;
+		return Command::SUCCESS;
 	}
 
 

--- a/libraries/src/Console/ChangeUserPasswordCommand.php
+++ b/libraries/src/Console/ChangeUserPasswordCommand.php
@@ -13,6 +13,7 @@ namespace Joomla\CMS\Console;
 use Joomla\CMS\User\User;
 use Joomla\CMS\User\UserHelper;
 use Joomla\Console\Command\AbstractCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -87,7 +88,7 @@ class ChangeUserPasswordCommand extends AbstractCommand
 		{
 			$this->ioStyle->error("The user " . $this->username . " does not exist!");
 
-			return 1;
+			return Command::FAILURE;
 		}
 
 		$user = User::getInstance($userId);
@@ -99,12 +100,12 @@ class ChangeUserPasswordCommand extends AbstractCommand
 		{
 			$this->ioStyle->error($user->getError());
 
-			return 1;
+			return Command::FAILURE;
 		}
 
 		$this->ioStyle->success("Password changed!");
 
-		return 0;
+		return Command::SUCCESS;
 	}
 
 	/**

--- a/libraries/src/Console/CheckJoomlaUpdatesCommand.php
+++ b/libraries/src/Console/CheckJoomlaUpdatesCommand.php
@@ -12,6 +12,7 @@ namespace Joomla\CMS\Console;
 
 use Joomla\Component\Joomlaupdate\Administrator\Model\UpdateModel;
 use Joomla\Console\Command\AbstractCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
@@ -131,7 +132,7 @@ class CheckJoomlaUpdatesCommand extends AbstractCommand
 		{
 			$symfonyStyle->success('You already have the latest Joomla version ' . $data['latest']);
 
-			return 0;
+			return Command::SUCCESS;
 		}
 
 		$symfonyStyle->note('New Joomla Version ' . $data['latest'] . ' is available.');
@@ -141,6 +142,6 @@ class CheckJoomlaUpdatesCommand extends AbstractCommand
 			$symfonyStyle->warning('We cannot find an update URL');
 		}
 
-		return 0;
+		return Command::SUCCESS;
 	}
 }

--- a/libraries/src/Console/CheckUpdatesCommand.php
+++ b/libraries/src/Console/CheckUpdatesCommand.php
@@ -13,6 +13,7 @@ namespace Joomla\CMS\Console;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Updater\Updater;
 use Joomla\Console\Command\AbstractCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
@@ -58,7 +59,7 @@ class CheckUpdatesCommand extends AbstractCommand
 
 		$symfonyStyle->success('Finished fetching updates');
 
-		return 0;
+		return Command::SUCCESS;
 	}
 
 	/**

--- a/libraries/src/Console/CleanCacheCommand.php
+++ b/libraries/src/Console/CleanCacheCommand.php
@@ -12,6 +12,7 @@ namespace Joomla\CMS\Console;
 
 use Joomla\CMS\Factory;
 use Joomla\Console\Command\AbstractCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
@@ -51,7 +52,7 @@ class CleanCacheCommand extends AbstractCommand
 
 		$symfonyStyle->success('Cache cleaned');
 
-		return 0;
+		return Command::SUCCESS;
 	}
 
 	/**

--- a/libraries/src/Console/DeleteUserCommand.php
+++ b/libraries/src/Console/DeleteUserCommand.php
@@ -16,6 +16,7 @@ use Joomla\CMS\User\User;
 use Joomla\CMS\User\UserHelper;
 use Joomla\Console\Command\AbstractCommand;
 use Joomla\Database\ParameterType;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -83,14 +84,14 @@ class DeleteUserCommand extends AbstractCommand
 		{
 			$this->ioStyle->error($this->username . ' does not exist!');
 
-			return 1;
+			return Command::FAILURE;
 		}
 
 		if ($input->isInteractive() && !$this->ioStyle->confirm('Are you sure you want to delete this user?', false))
 		{
 			$this->ioStyle->note('User not deleted');
 
-			return 0;
+			return Command::SUCCESS;
 		}
 
 		$groups = UserHelper::getUserGroups($userId);
@@ -133,12 +134,12 @@ class DeleteUserCommand extends AbstractCommand
 		{
 			$this->ioStyle->error("Can't remove " . $this->username . ' form usertable');
 
-			return 1;
+			return Command::FAILURE;
 		}
 
 		$this->ioStyle->success('User ' . $this->username . ' deleted!');
 
-		return 0;
+		return Command::SUCCESS;
 	}
 
 	/**

--- a/libraries/src/Console/ExtensionsListCommand.php
+++ b/libraries/src/Console/ExtensionsListCommand.php
@@ -12,6 +12,7 @@ namespace Joomla\CMS\Console;
 
 use Joomla\Console\Command\AbstractCommand;
 use Joomla\Database\DatabaseInterface;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -246,7 +247,7 @@ class ExtensionsListCommand extends AbstractCommand
 		{
 			$this->ioStyle->error("Cannot find extensions of the type '$type' specified.");
 
-			return 0;
+			return Command::SUCCESS;
 		}
 
 		$extensions = $this->getExtensionsNameAndId($extensions);
@@ -254,6 +255,6 @@ class ExtensionsListCommand extends AbstractCommand
 		$this->ioStyle->title('Installed extensions.');
 		$this->ioStyle->table(['Name', 'Extension ID', 'Version', 'Type', 'Active'], $extensions);
 
-		return 0;
+		return Command::SUCCESS;
 	}
 }

--- a/libraries/src/Console/FinderIndexCommand.php
+++ b/libraries/src/Console/FinderIndexCommand.php
@@ -16,6 +16,7 @@ use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\Component\Finder\Administrator\Indexer\Indexer;
 use Joomla\Console\Command\AbstractCommand;
 use Joomla\Database\DatabaseInterface;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -220,7 +221,7 @@ EOF;
 
 		$this->ioStyle->newline(1);
 
-		return 0;
+		return Command::SUCCESS;
 	}
 
 	/**

--- a/libraries/src/Console/GetConfigurationCommand.php
+++ b/libraries/src/Console/GetConfigurationCommand.php
@@ -366,6 +366,6 @@ class GetConfigurationCommand extends AbstractCommand
 			return self::CONFIG_GET_SUCCESSFUL;
 		}
 
-		return self::CONFIG_GET_FAILED;
+		return self::CONFIG_GET_OPTION_NOT_FOUND;
 	}
 }

--- a/libraries/src/Console/ListUserCommand.php
+++ b/libraries/src/Console/ListUserCommand.php
@@ -12,6 +12,7 @@ namespace Joomla\CMS\Console;
 
 use Joomla\CMS\Factory;
 use Joomla\Console\Command\AbstractCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
@@ -86,7 +87,7 @@ class ListUserCommand extends AbstractCommand
 
 		$this->ioStyle->table(['id', 'username', 'name', 'email', 'blocked', 'groups'], $users);
 
-		return 0;
+		return Command::SUCCESS;
 	}
 
 	/**

--- a/libraries/src/Console/RemoveOldFilesCommand.php
+++ b/libraries/src/Console/RemoveOldFilesCommand.php
@@ -11,6 +11,7 @@ namespace Joomla\CMS\Console;
 \defined('JPATH_PLATFORM') or die;
 
 use Joomla\Console\Command\AbstractCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
@@ -53,7 +54,7 @@ class RemoveOldFilesCommand extends AbstractCommand
 
 		$symfonyStyle->success('Files removed');
 
-		return 0;
+		return Command::SUCCESS;
 	}
 
 	/**

--- a/libraries/src/Console/RemoveUserFromGroupCommand.php
+++ b/libraries/src/Console/RemoveUserFromGroupCommand.php
@@ -15,6 +15,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\User\User;
 use Joomla\CMS\User\UserHelper;
 use Joomla\Console\Command\AbstractCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\InvalidOptionException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -134,7 +135,7 @@ class RemoveUserFromGroupCommand extends AbstractCommand
 						. $result . " needs at least one active user!"
 					);
 
-					return 1;
+					return Command::FAILURE;
 				}
 			}
 
@@ -142,20 +143,20 @@ class RemoveUserFromGroupCommand extends AbstractCommand
 			{
 				$this->ioStyle->error("Can't remove '" . $user->username . "' from group '" . $result . "'! Every user needs at least one group");
 
-				return 1;
+				return Command::FAILURE;
 			}
 
 			if (!UserHelper::removeUserFromGroup($user->id, $userGroup))
 			{
 				$this->ioStyle->error("Can't remove '" . $user->username . "' from group '" . $result . "'!");
 
-				return 1;
+				return Command::FAILURE;
 			}
 
 			$this->ioStyle->success("Removed '" . $user->username . "' from group '" . $result . "'!");
 		}
 
-		return 0;
+		return Command::SUCCESS;
 	}
 
 	/**

--- a/libraries/src/Console/SessionGcCommand.php
+++ b/libraries/src/Console/SessionGcCommand.php
@@ -14,6 +14,7 @@ use Joomla\Console\Command\AbstractCommand;
 use Joomla\DI\ContainerAwareInterface;
 use Joomla\DI\ContainerAwareTrait;
 use Joomla\Session\SessionInterface;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -63,12 +64,12 @@ class SessionGcCommand extends AbstractCommand implements ContainerAwareInterfac
 		{
 			$symfonyStyle->error('Garbage collection was not completed. Either the operation failed or it is not supported on your platform.');
 
-			return 1;
+			return Command::FAILURE;
 		}
 
 		$symfonyStyle->success('Garbage collection completed.');
 
-		return 0;
+		return Command::SUCCESS;
 	}
 
 	/**

--- a/libraries/src/Console/SessionMetadataGcCommand.php
+++ b/libraries/src/Console/SessionMetadataGcCommand.php
@@ -13,6 +13,7 @@ namespace Joomla\CMS\Console;
 use Joomla\CMS\Session\MetadataManager;
 use Joomla\Console\Command\AbstractCommand;
 use Joomla\Session\SessionInterface;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
@@ -86,7 +87,7 @@ class SessionMetadataGcCommand extends AbstractCommand
 
 		$symfonyStyle->success('Metadata garbage collection completed.');
 
-		return 0;
+		return Command::FAILURE;
 	}
 
 	/**


### PR DESCRIPTION
### Summary of Changes

Symfony provides `Command::SUCCESS` and `Command::FAILURE` return statuses

This PR replaces hand typed integers with those constants

AND Bonus: Fixes typo in `CONFIG_GET_OPTION_NOT_FOUND` in libraries/src/Console/GetConfigurationCommand.php

**The Command::SUCCESS and Command::FAILURE constants were introduced in Symfony 5.1.**


### Testing Instructions

run commands 

### Actual result BEFORE applying this Pull Request

All commands work and return exit codes appropriate to their exit status

### Expected result AFTER applying this Pull Request

All commands work and return exit codes appropriate to their exit status while reusing built in Class Constants provided by `\Symfony\Component\Console\Command\Command`

### Documentation Changes Required

None