### PR TITLE
[4] correct single line comment style

### DIFF
--- a/administrator/index.php
+++ b/administrator/index.php
@@ -6,13 +6,9 @@
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-/**
- * NOTE: This file should remain compatible with PHP 5.2 to allow us to run our PHP minimum check and show a friendly error message
- */
+// NOTE: This file should remain compatible with PHP 5.2 to allow us to run our PHP minimum check and show a friendly error message
 
-/**
- * Define the application's minimum supported PHP version as a constant so it can be referenced within the application.
- */
+// Define the application's minimum supported PHP version as a constant so it can be referenced within the application.
 define('JOOMLA_MINIMUM_PHP', '7.2.5');
 
 if (version_compare(PHP_VERSION, JOOMLA_MINIMUM_PHP, '<'))

--- a/api/index.php
+++ b/api/index.php
@@ -6,13 +6,9 @@
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-/**
- * NOTE: This file should remain compatible with PHP 5.2 to allow us to run our PHP minimum check and show a friendly error message
- */
+// NOTE: This file should remain compatible with PHP 5.2 to allow us to run our PHP minimum check and show a friendly error message
 
-/**
- * Define the application's minimum supported PHP version as a constant so it can be referenced within the application.
- */
+// Define the application's minimum supported PHP version as a constant so it can be referenced within the application.
 define('JOOMLA_MINIMUM_PHP', '7.2.5');
 
 if (version_compare(PHP_VERSION, JOOMLA_MINIMUM_PHP, '<'))

--- a/cli/joomla.php
+++ b/cli/joomla.php
@@ -9,9 +9,7 @@
 // We are a valid entry point.
 const _JEXEC = 1;
 
-/**
- * Define the application's minimum supported PHP version as a constant so it can be referenced within the application.
- */
+// Define the application's minimum supported PHP version as a constant so it can be referenced within the application.
 const JOOMLA_MINIMUM_PHP = '7.2.5';
 
 if (version_compare(PHP_VERSION, JOOMLA_MINIMUM_PHP, '<'))

--- a/index.php
+++ b/index.php
@@ -6,13 +6,9 @@
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-/**
- * NOTE: This file should remain compatible with PHP 5.2 to allow us to run our PHP minimum check and show a friendly error message
- */
+// NOTE: This file should remain compatible with PHP 5.2 to allow us to run our PHP minimum check and show a friendly error message
 
-/**
- * Define the application's minimum supported PHP version as a constant so it can be referenced within the application.
- */
+// Define the application's minimum supported PHP version as a constant so it can be referenced within the application.
 define('JOOMLA_MINIMUM_PHP', '7.2.5');
 
 if (version_compare(PHP_VERSION, JOOMLA_MINIMUM_PHP, '<'))


### PR DESCRIPTION
### Summary of Changes

change `/** */` syntax to `//` to comply with https://developer.joomla.org/coding-standards/inline-code-comments.html for single line comments

No code changes. 