### PR TITLE
[4.0] Articles - Categories H tags

### DIFF
--- a/modules/mod_articles_categories/tmpl/default_items.php
+++ b/modules/mod_articles_categories/tmpl/default_items.php
@@ -21,14 +21,12 @@ $id     = $input->getInt('id');
 
 foreach ($list as $item) : ?>
 	<li<?php if ($id == $item->id && in_array($view, array('category', 'categories')) && $option == 'com_content') echo ' class="active"'; ?>> <?php $levelup = $item->level - $startLevel - 1; ?>
-		<h<?php echo $params->get('item_heading') + $levelup; ?>>
 		<a href="<?php echo Route::_(RouteHelper::getCategoryRoute($item->id, $item->language)); ?>">
 		<?php echo $item->title; ?>
 			<?php if ($params->get('numitems')) : ?>
 				(<?php echo $item->numitems; ?>)
 			<?php endif; ?>
 		</a>
-		</h<?php echo $params->get('item_heading') + $levelup; ?>>
 
 		<?php if ($params->get('show_description', 0)) : ?>
 			<?php echo HTMLHelper::_('content.prepare', $item->description, $item->getParams(), 'mod_articles_categories.content'); ?>


### PR DESCRIPTION
We do not need H tags in nested ul items

Pull Request for Issue #31942 .

### Summary of Changes
I removed the lines of code that generate H tags.


### Testing Instructions
create nested categories of content like:
![image](https://user-images.githubusercontent.com/906604/104105652-e6ced080-52af-11eb-9b40-0d920d7cd02c.png)

_Is can be usefully import Sample Data and then move the category._

Create a module of Articles - Categories with these settings:
![image](https://user-images.githubusercontent.com/906604/104105672-0239db80-52b0-11eb-83a1-484422b9306e.png)


### Actual result BEFORE applying this Pull Request

![image](https://user-images.githubusercontent.com/906604/104105681-1978c900-52b0-11eb-9cae-aa324f09fc1f.png)


### Expected result AFTER applying this Pull Request

![image](https://user-images.githubusercontent.com/906604/104105677-0e259d80-52b0-11eb-92af-8ca3e1416da5.png)


### Documentation Changes Required

NO
