### PR TITLE
[4.0] PHP support status.

### DIFF
--- a/plugins/quickicon/phpversioncheck/phpversioncheck.php
+++ b/plugins/quickicon/phpversioncheck/phpversioncheck.php
@@ -123,6 +123,10 @@ class PlgQuickiconPhpVersionCheck extends CMSPlugin
 				'security' => '2021-11-28',
 				'eos'      => '2022-11-28',
 			),
+			'8.0' => array(
+				'security' => '2022-11-26',
+				'eos'      => '2023-11-26'
+			)
 		);
 
 		// Fill our return array with default values

--- a/plugins/quickicon/phpversioncheck/phpversioncheck.php
+++ b/plugins/quickicon/phpversioncheck/phpversioncheck.php
@@ -125,8 +125,8 @@ class PlgQuickiconPhpVersionCheck extends CMSPlugin
 			),
 			'8.0' => array(
 				'security' => '2022-11-26',
-				'eos'      => '2023-11-26'
-			)
+				'eos'      => '2023-11-26',
+			),
 		);
 
 		// Fill our return array with default values


### PR DESCRIPTION
Updates the php version check plugin to make it aware of php 8.0

Code review

PS should we still be recommending 7.3? @wilsonge 
