### PR TITLE
s/JNamespaceMap/JNamespacePsr4Map

### DIFF
--- a/libraries/namespacemap.php
+++ b/libraries/namespacemap.php
@@ -12,7 +12,7 @@ use Joomla\CMS\Filesystem\File;
 use Joomla\CMS\Filesystem\Folder;
 
 /**
- * Class JNamespaceMap
+ * Class JNamespacePsr4Map
  *
  * @since  4.0.0
  */


### PR DESCRIPTION
s/JNamespaceMap/JNamespacePsr4Map

To be clear, this is code comments only, not a class name change, the class is already called `JNamespacePsr4Map` and the Class comment was wrong. 