### PR TITLE
s/deletion/uninstall

### DIFF
--- a/administrator/language/en-GB/plg_extension_namespacemap.ini
+++ b/administrator/language/en-GB/plg_extension_namespacemap.ini
@@ -4,4 +4,4 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_EXTENSION_NAMESPACEMAP="Extension - Namespace Updater"
-PLG_EXTENSION_NAMESPACEMAP_XML_DESCRIPTION="Automatically builds and updates the <strong>administrator/cache/autoload_psr4.php</strong> file that is used to autoload extensions.<br><strong>Warning! This plugin must be enabled</strong> as it runs on extension install, update and deletion."
+PLG_EXTENSION_NAMESPACEMAP_XML_DESCRIPTION="Automatically builds and updates the <strong>administrator/cache/autoload_psr4.php</strong> file that is used to autoload extensions.<br><strong>Warning! This plugin must be enabled</strong> as it runs on extension install, update and uninstall."

--- a/administrator/language/en-GB/plg_extension_namespacemap.sys.ini
+++ b/administrator/language/en-GB/plg_extension_namespacemap.sys.ini
@@ -4,4 +4,4 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_EXTENSION_NAMESPACEMAP="Extension - Namespace Updater"
-PLG_EXTENSION_NAMESPACEMAP_XML_DESCRIPTION="Automatically builds and updates the <strong>administrator/cache/autoload_psr4.php</strong> file that is used to autoload extensions.<br><strong>Warning! This plugin must be enabled</strong> as it runs on extension install, update and deletion."
+PLG_EXTENSION_NAMESPACEMAP_XML_DESCRIPTION="Automatically builds and updates the <strong>administrator/cache/autoload_psr4.php</strong> file that is used to autoload extensions.<br><strong>Warning! This plugin must be enabled</strong> as it runs on extension install, update and uninstall."


### PR DESCRIPTION
### Summary of Changes

Change the word deletion to be uninstall

There is no concept of "deleting" or "deletion" of a plugin or extension in Joomla. 

It is consistently referred to as "Uninstalling" or "Uninstall" throughout Joomla 

<img width="613" alt="Screenshot 2021-01-10 at 17 35 36" src="https://user-images.githubusercontent.com/400092/104130730-425d9480-536a-11eb-8335-c60627e05518.png">


### Testing Instructions

Text change only
