### PR TITLE
[4] Remove return after an exception (copy and paste legacy issue)

### DIFF
--- a/components/com_users/src/Controller/RegistrationController.php
+++ b/components/com_users/src/Controller/RegistrationController.php
@@ -50,8 +50,6 @@ class RegistrationController extends BaseController
 		if ($uParams->get('useractivation') == 0 || $uParams->get('allowUserRegistration') == 0)
 		{
 			throw new \Exception(Text::_('JLIB_APPLICATION_ERROR_ACCESS_FORBIDDEN'), 403);
-
-			return false;
 		}
 
 		/** @var \Joomla\Component\Users\Site\Model\RegistrationModel $model */
@@ -62,8 +60,6 @@ class RegistrationController extends BaseController
 		if ($token === null || strlen($token) !== 32)
 		{
 			throw new \Exception(Text::_('JINVALID_TOKEN'), 403);
-
-			return false;
 		}
 
 		// Get the User ID
@@ -72,8 +68,6 @@ class RegistrationController extends BaseController
 		if (!$userIdToActivate)
 		{
 			throw new \Exception(Text::_('COM_USERS_ACTIVATION_TOKEN_NOT_FOUND'), 403);
-
-			return false;
 		}
 
 		// Get the user we want to activate
@@ -179,8 +173,6 @@ class RegistrationController extends BaseController
 		if (!$form)
 		{
 			throw new \Exception($model->getError(), 500);
-
-			return false;
 		}
 
 		$data = $model->validate($form, $requestData);


### PR DESCRIPTION
### Summary of Changes

On code review.

Before Joomla 4 this was a `JError::raiseError(...)` call and not an `Exception` so the `return` made sense then

Now we throw `Exception` there is no way to reach the `return false;` and therefore its redundant unreachable code

