### PR TITLE
[4] remove redundant code in frontend template manager

### DIFF
--- a/components/com_config/src/Model/TemplatesModel.php
+++ b/components/com_config/src/Model/TemplatesModel.php
@@ -46,18 +46,17 @@ class TemplatesModel extends FormModel
 	 * @param   array    $data      An optional array of data for the form to interrogate.
 	 * @param   boolean  $loadData  True if the form is to load its own data (default case), false if not.
 	 *
-	 * @return  JForm|bool    A JForm object on success, false on failure
+	 * @return  Form|bool    A JForm object on success, false on failure
 	 *
 	 * @since   3.2
 	 */
 	public function getForm($data = array(), $loadData = true)
 	{
-		// Get the form.
-		$form = $this->loadForm('com_config.templates', 'templates', array('control' => 'jform', 'load_data' => $loadData));
-
 		try
 		{
-			$form = new Form('com_config.templates');
+			// Get the form.
+			$form = $this->loadForm('com_config.templates', 'templates', array('control' => 'jform', 'load_data' => $loadData));
+			
 			$data = array();
 			$this->preprocessForm($form, $data);
 


### PR DESCRIPTION

### Summary of Changes

remove code smell and correctly load the form for frontend template config
$form was created twice, directly overwriting itself as soon as it was loaded.

### Testing Instructions

Install testing data on Joomla 4
login to FRONTEND 
click "Template Settings" in the right hand side menu

### Actual result BEFORE applying this Pull Request

Page loads

### Expected result AFTER applying this Pull Request

Page loads - but with less code to power it

<img width="682" alt="Screenshot 2021-01-10 at 19 38 00" src="https://user-images.githubusercontent.com/400092/104133414-5c53a300-537b-11eb-96f4-8da4f22592cb.png">


### Documentation Changes Required

none - code review only