### PR TITLE
[4] Remove return after an exception (copy and paste legacy issue)

### DIFF
--- a/administrator/components/com_contenthistory/src/View/Preview/HtmlView.php
+++ b/administrator/components/com_contenthistory/src/View/Preview/HtmlView.php
@@ -56,8 +56,6 @@ class HtmlView extends BaseHtmlView
 			Factory::getLanguage()->load('com_content', JPATH_SITE, null, true);
 
 			throw new \Exception(Text::_('COM_CONTENT_ERROR_ARTICLE_NOT_FOUND'), 404);
-
-			return false;
 		}
 
 		// Check for errors.


### PR DESCRIPTION
### Summary of Changes

On code review.

Before Joomla 4 this was a `JError::raiseError(...)` call and not an `Exception` so the `return` made sense then

Now we throw `Exception` there is no way to reach the `return false;` and therefore its redundant unreachable code
