### PR TITLE
[4.0] Remove sampledata images

### DIFF
--- a/build/build.php
+++ b/build/build.php
@@ -91,6 +91,8 @@ function clean_checkout(string $dir)
 
 	// testing sampledata
 	system('rm -rf plugins/sampledata/testing');
+	system('rm -rf images/sampledata/parks');
+	system('rm -rf images/sampledata/fruitshop');
 
 	// paragonie/random_compat
 	system('rm -rf libraries/vendor/paragonie/random_compat/other');


### PR DESCRIPTION
Add the sampledata parks and fruitshops image folders to the list of things not to be included in a build

This means they are still available for use in the sampledata testing plugin as that is only available in git clones