### PR TITLE
Let's use original assets from parent template

### DIFF
--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -465,7 +465,7 @@ abstract class HTMLHelper
 
 							if (empty($found))
 							{
-								$found = static::addFileToBuffer("$templaPath/$template->parent/$folder/$file", $ext, $debugMode);
+								$found = static::addFileToBuffer(JPATH_THEMES . "/$template->parent/$folder/$file", $ext, $debugMode);
 							}
 						}
 						else


### PR DESCRIPTION
Cannot use the asset's heritage of a parent folder without make a copy of all assets in /media/templates/<application>/<parent_template>

### Summary of Changes

Change the path to use the asset's heritage of a parent template

### Testing Instructions

- Create a simple sub template with only an xml file
- Try to run the website with this subtemplate

### Actual result BEFORE applying this Pull Request
- The assets of the parent are not loaded

### Expected result AFTER applying this Pull Request
- The assets are corretly loaded

### Documentation Changes Required

