### PR TITLE
[4.0] Fix stats-message.js, should append message instead of insert

### DIFF
--- a/build/media_source/plg_system_stats/js/stats-message.es6.js
+++ b/build/media_source/plg_system_stats/js/stats-message.es6.js
@@ -71,7 +71,7 @@ Joomla = window.Joomla || {};
         try {
           const json = JSON.parse(response);
           if (json && json.html) {
-            messageContainer.innerHTML = json.html;
+            messageContainer.insertAdjacentHTML('beforeend', json.html);
             messageContainer.querySelector('.js-pstats-alert').classList.remove('hidden');
             initStatsEvents(getJson);
           }


### PR DESCRIPTION
Pull Request for Issue #31985 .

### Summary of Changes

stats-message.js should append message instead of insert


### Testing Instructions
Run `npm install` and please look #31985 for details


### Actual result BEFORE applying this Pull Request

Only 1 message visible


### Expected result AFTER applying this Pull Request

All messages visible

