### PR TITLE
[4.0] Password hint

### DIFF
--- a/layouts/joomla/form/field/password.php
+++ b/layouts/joomla/form/field/password.php
@@ -104,12 +104,12 @@ if ($lock)
 	);
 
 	$disabled = true;
-	$hint = str_repeat('*', strlen($value));
+	$hint = str_repeat('&#x2022;', strlen($value));
 	$value = '';
 }
 
 $attributes = array(
-	strlen($hint) ? 'placeholder="' . htmlspecialchars($hint, ENT_COMPAT, 'UTF-8') . '"' : '',
+	strlen($hint) ? 'placeholder="' . $hint . '"' : '',
 	!empty($autocomplete) ? 'autocomplete="' . $autocomplete . '"' : '',
 	!empty($class) ? 'class="form-control ' . $class . '"' : 'class="form-control"',
 	!empty($description) ? 'aria-describedby="' . $name . '-desc"' : '',


### PR DESCRIPTION
A recent PR introduced the use of a placeholder as an indicator on the password field as a pseudo mask character.

The place holder text used was a string of *

However the browsers now use a bullet character and not an asterisk

This simple pr corrects that.

NOTE: because the symbol being emulated by this password placeholder is generated by the browser it is not possible to 100% match on all browsers. Images below are from chrome on windows 10

### Before
![pw2](https://user-images.githubusercontent.com/1296369/104288251-755d7080-54af-11eb-89dc-44f3b362fe4b.gif)


### After
![pw](https://user-images.githubusercontent.com/1296369/104288059-35968900-54af-11eb-92e2-e6e4f1c7cf2e.gif)
