### PR TITLE
[4.0] Remove jQuery from password field

### DIFF
--- a/build/media_source/system/js/fields/passwordview.es6.js
+++ b/build/media_source/system/js/fields/passwordview.es6.js
@@ -7,6 +7,22 @@
 
   document.addEventListener('DOMContentLoaded', () => {
     [].slice.call(document.querySelectorAll('input[type="password"]')).forEach((input) => {
+      const lockButton = input.parentNode.querySelector('.input-password-lock');
+
+      if (lockButton) {
+        lockButton.addEventListener('click', () => {
+          if (input.disabled) {
+            lockButton.innerHTML = Joomla.Text._('JCANCEL');
+            input.disabled = false;
+            return;
+          }
+
+          lockButton.innerHTML = Joomla.Text._('JMODIFY');
+          input.disabled = true;
+          input.value = '';
+        });
+      }
+
       const toggleButton = input.parentNode.querySelector('.input-password-toggle');
 
       if (!toggleButton) {

--- a/layouts/joomla/form/field/password.php
+++ b/layouts/joomla/form/field/password.php
@@ -74,35 +74,11 @@ Text::script('JFIELD_PASSWORD_INDICATE_INCOMPLETE');
 Text::script('JFIELD_PASSWORD_INDICATE_COMPLETE');
 Text::script('JSHOWPASSWORD');
 Text::script('JHIDEPASSWORD');
-
-// TODO: Remove this jQuery dependency and move the lock functionality to the password view script
-\Joomla\CMS\HTML\HTMLHelper::_('jquery.framework');
+Text::script('JMODIFY');
+Text::script('JCANCEL');
 
 if ($lock)
 {
-	// Load script on document load.
-	$document->addScriptDeclaration(
-			"
-		jQuery(document).ready(function() {
-			jQuery('#" . $id ."_lock').on('click', function() {
-				var lockButton = jQuery(this);
-				var passwordInput = jQuery('#" . $id . "');
-				var lock = lockButton.hasClass('active');
-
-				if (lock === true) {
-					lockButton.html('" . Text::_('JMODIFY', true) . "');
-					passwordInput.attr('disabled', true);
-					passwordInput.val('');
-				}
-				else
-				{
-					lockButton.html('" . Text::_('JCANCEL', true) . "');
-					passwordInput.attr('disabled', false);
-				}
-			});
-		});"
-	);
-
 	$disabled = true;
 	$hint = str_repeat('*', strlen($value));
 	$value = '';
@@ -182,7 +158,9 @@ if ($rules && !empty($description))
 				<span class="sr-only"><?php echo Text::_('JSHOWPASSWORD'); ?></span>
 			</button>
 			<?php if ($lock): ?>
-				<button type="button" id="<?php echo $id; ?>_lock" class="btn btn-info" data-toggle="button"><?php echo Text::_('JMODIFY'); ?></button>
+				<button type="button" id="<?php echo $id; ?>_lock" class="btn btn-info input-password-lock" data-toggle="button">
+					<?php echo Text::_('JMODIFY'); ?>
+				</button>
 			<?php endif; ?>
 		</span>
 	</div>


### PR DESCRIPTION
Pull Request to remove jQuery, as introduced in #31672.

### Summary of Changes
Changes the password field lock functionality to plain vanilla. It also doesn't depend on the Bootstrap class "active" but on the disabled state.

### Testing Instructions
- Open the back end global configuration
- Click on the Server tab
- Modify the password

### Actual result BEFORE applying this Pull Request
Password can be changed.

### Expected result AFTER applying this Pull Request
Password can be changed.