### PR TITLE
[4] ob_end_clean raises a notice if the included layout file did something stupid

### DIFF
--- a/libraries/src/Layout/FileLayout.php
+++ b/libraries/src/Layout/FileLayout.php
@@ -127,9 +127,10 @@ class FileLayout extends BaseLayout
 		ob_start();
 		include $path;
 		$layoutOutput .= ob_get_contents();
+
 		if (ob_get_length())
 		{
-		ob_end_clean();
+			ob_end_clean();
 		}
 
 		return $layoutOutput;

--- a/libraries/src/Layout/FileLayout.php
+++ b/libraries/src/Layout/FileLayout.php
@@ -127,7 +127,10 @@ class FileLayout extends BaseLayout
 		ob_start();
 		include $path;
 		$layoutOutput .= ob_get_contents();
+		if (ob_get_length())
+		{
 		ob_end_clean();
+		}
 
 		return $layoutOutput;
 	}


### PR DESCRIPTION
### Summary of Changes

ob_end_clean raises a notice if the included layout file did something stupid (like running `ob_get_clean()` !!!) 

```
Notice: ob_end_clean(): failed to delete buffer. No buffer to delete in
/home/path/public_html/libraries/src/Layout/FileLayout.php
```

Battle tested code should check if a buffer exists before attempting to clear it, if by blindly clearing a non-existent buffer then raises a PHP Notice/Error/Warning/Fatal. 

### Testing Instructions

Install JEvents 3.6.12 on Joomla 4 beta 6

Visit https://example.com/administrator/index.php?option=com_jevents&task=params.edit

note that the file administrator/components/com_jevents/layouts/joomla/system/message.php is included by `include $path;` and message.php runs a `ob_get_clean()` within in.

**This is probably a bug in JEvents** because the `ob_get_clean` should be two lines higher so it doesn't get run in Joomla 4 - **but still Joomla should handle cleaning of output buffers better and never show Notices to the screen.** 

### Actual result BEFORE applying this Pull Request

```
Notice: ob_end_clean(): failed to delete buffer. No buffer to delete in
/home/path/public_html/libraries/src/Layout/FileLayout.php
```

### Expected result AFTER applying this Pull Request

No errors

### Documentation Changes Required

// @GeraintEdwards 