### PR TITLE
[4] Prevent User Enumeration using WebAuthn

### DIFF
--- a/plugins/system/webauthn/src/CredentialRepository.php
+++ b/plugins/system/webauthn/src/CredentialRepository.php
@@ -23,6 +23,7 @@ use Joomla\Registry\Registry;
 use JsonException;
 use RuntimeException;
 use Throwable;
+use Webauthn\PublicKeyCredentialDescriptor;
 use Webauthn\PublicKeyCredentialSource;
 use Webauthn\PublicKeyCredentialSourceRepository;
 use Webauthn\PublicKeyCredentialUserEntity;
@@ -484,5 +485,17 @@ class CredentialRepository implements PublicKeyCredentialSourceRepository
 		}
 
 		return $secret;
+	}
+
+	public function getFakePublicKeyCredentialDescriptor(string $username): PublicKeyCredentialDescriptor
+	{
+		$key = $this->getEncryptionKey();
+		$username = hash_hmac('sha256', $username, $key, false);
+
+		return new PublicKeyCredentialDescriptor(
+			'public-key',
+			$username,
+			[]
+		);
 	}
 }


### PR DESCRIPTION
 - On 18th June 2020 I reported this to the Joomla Security Strike Team. 
 - I asked for an update today, and was told it was confirmed but no action has been taken
 - I have been repeatedly told that Joomla 4 has not been released and therefore the JSST are not interested in Joomla 4 security issues being reported in private and they are to be done in the public tracker. 
 - I tried to explain the problem and the solution today, in brief, but the @zero-24 was not understanding

So here is the proposed fix. 

The problem is, with WebAuthn, it is possible to Enumerate users that exist and have WebAuthn enabled by simply going to /administrator/index.php login page, providing a username and clicking "Web Authentication"

This makes an Ajax call to check if that user exists and if they have WebAuthn enabled. 

If the username doesn't exist, if there is an exception thrown, or if the username exists and they don't have WebAuthn enabled, then the Ajax returns `false` and the user gets a message:

<img width="886" alt="Screenshot 2021-01-12 at 23 03 57" src="https://user-images.githubusercontent.com/400092/104385087-7e3f5800-552a-11eb-9533-be00cc8c6471.png">


if the username exists and the user has WebAuthn enabled then the Ajax return a challenge - which is a json string like this example below, and the browser prompts for the user to use their WebAuthn device (fingerprint, yubikey etc) 

```
{"challenge":"-XGWsHC2uM52C5Rgu6uiDFGmxjQL9DnIf_7o3QxIqTo","rpId":"aec9d095825e.ngrok.io","userVerification":"preferred","allowCredentials":[{"type":"public-key","id":"OGJkYzAxMjQ4YWEwYjZjY2E5MWQ3ZGUyZjFmNTM2OGM1YWFiZTJiMGIwNTk1NTY5ZGViZDEwMTY3OTM3NmI0Yw"}],"timeout":60000}
```

Therefore it is possible to Enumerate users based on the response to the Ajax call. (and its possible, after obtaining the CSRF token, to send CURL requests to the Ajax endpoint millions of times a min with different usernames) to quickly check millions of usernames 

Ironically, the users with WebAuthn enabled on their account are probably more security minded (power users, or with Super Admin rights) and therefore identifying their usernames is a nice thing for hackers... although probably useless, as the accounts are secured by webauthn - doh! 

### Summary of Changes

The result of the changes is that a challenge is returned from all attempts to use Web Authentication button to login to Joomla.

If the user has previously registered a WebAuthn device, then the challenge returned is a valid challenge and that user can go on to authenticate as normal by using their device.

if the username doesn't exist, or is a valid user without WebAuthn set up on their account, a challenge is returned that is valid enough for the browser to prompt for a WebAuthn device, but not valid enough that providing a device will authenticate the session. Its a fake challenge that prevents a Timing Vector and User Enumeration. 

### Testing Instructions

VISIT YOUR SITE OVER HTTPS

Enable WebAuthn on USERNAME-WITH-WEBAUTH
DONT Enable WebAuthn on USERNAME-WITHOUT-WEBAUTH
Logout.

On the login page enter username USERNAME-WITHOUT-WEBAUTH and click Web Authentication Button  - you should be prompted to provide a WebAuthn Device press by your browser - press/use any webauthn device - note that you are rightly rejected access

**Note that the fake challenge json is different based on the username provided and is indistinguishable from a genuine challenge.**

<img width="460" alt="Screenshot 2021-01-12 at 22 57 13" src="https://user-images.githubusercontent.com/400092/104384610-a8dce100-5529-11eb-8b4a-15214e0f2a2f.png">


On the login page enter username USERNAME-WITH-WEBAUTH and click Web Authentication Button  - you should be prompted to provide a WebAuthn Device press by your browser - press/use your registered webauthn device - note that you are rightly GRANTED access and the page reloads and you are logged in. 

### Documentation Changes Required

None


// Paging @nikosdion as the only one who might be able to review this on a technical level. 