### PR TITLE
[4.0] Cassiopea: xtd Status icons and Clear button colors

### DIFF
--- a/templates/cassiopeia/scss/blocks/_icons.scss
+++ b/templates/cassiopeia/scss/blocks/_icons.scss
@@ -1,11 +1,4 @@
 // Icons
-.#{$jicon-css-prefix}::before {
-  content: "\e008";
-}
-
-.#{$jicon-css-prefix}::before {
-  content: "\f125";
-}
 
 .#{$jicon-css-prefix}-white {
   color: $white;
@@ -15,6 +8,61 @@
   &::before {
     min-width: 16px;
   }
+}
+
+.tbody-icon {
+  padding: 0 3px;
+  text-align: center;
+  background-color: transparent;
+  border: 0;
+
+  [class^="#{$jicon-css-prefix}-"],
+  [class*=" #{$jicon-css-prefix}-"],
+  [class^="#{$fa-css-prefix}-"],
+  [class*=" #{$fa-css-prefix}-"] {
+    width: 26px;
+    height: 26px;
+    font-size: 1.1rem;
+    line-height: 22px;
+    color: $gray-400;
+    border: 2px solid var(--border);
+    border-radius: 50%;
+  }
+
+  .#{$jicon-css-prefix}-publish,
+  .#{$jicon-css-prefix}-check,
+  .#{$fa-css-prefix}-check {
+    color: $success;
+    border-color: $success;
+  }
+
+  .#{$jicon-css-prefix}-checkedout,
+  .#{$jicon-css-prefix}-lock,
+  .#{$fa-css-prefix}-lock {
+    width: auto;
+    height: auto;
+    font-size: 1.2rem;
+    line-height: 1rem;
+    color: $gray-700;
+    border: 0;
+  }
+
+  &.home-disabled,
+  &.featured-disabled,
+  &.color-featured-disabled,
+  &.#{$jicon-css-prefix}-star-disabled,
+  &.#{$fa-css-prefix}-star-disabled {
+    cursor: not-allowed;
+    opacity: 1;
+  }
+}
+
+.tbody-icon .icon-delete,
+.tbody-icon .fa-delete,
+.tbody-icon .icon-times,
+.tbody-icon .fa-times {
+  color: $danger;
+  border-color: $danger;
 }
 
 // WebAuthn

--- a/templates/cassiopeia/scss/system/searchtools/searchtools.scss
+++ b/templates/cassiopeia/scss/system/searchtools/searchtools.scss
@@ -12,6 +12,11 @@
       margin: 4px 0;
       margin-inline-end: 8px;
     }
+
+    .js-stools-btn-clear {
+      background-color: #30638d;
+      border: 0;
+    }
   }
 
   .ordering-select {

--- a/templates/cassiopeia/scss/system/searchtools/searchtools.scss
+++ b/templates/cassiopeia/scss/system/searchtools/searchtools.scss
@@ -14,7 +14,7 @@
     }
 
     .js-stools-btn-clear {
-      background-color: #30638d;
+      background-color: $cyan;
       border: 0;
     }
   }

--- a/templates/cassiopeia/scss/tools/variables/_variables.scss
+++ b/templates/cassiopeia/scss/tools/variables/_variables.scss
@@ -147,8 +147,8 @@ $h5-font-size:                        .9286rem;
 $h6-font-size:                        .8571rem;
 
 // Icons
-$jicon-css-prefix:                    icon;
-$fa-css-prefix:                       fa;
+$jicon-css-prefix:                    icon !default;
+$fa-css-prefix:                       fa !default;
 
 // Tables
 $table-bg:                            transparent !default;


### PR DESCRIPTION
### Summary of Changes
Normalizes _icons.scss on the model of atum
Color searchtools Clear button to distinguish from Filter Options button when Filers are active


### Testing Instructions
Edit an article in frontend.
Select CMS Content xtds +> Article, Contact, Menu
Pop up displays.


### Actual result BEFORE applying this Pull Request
The Status icons are all black.
The Clear button gets the same color when Filters are active

![xtd_articles_before](https://user-images.githubusercontent.com/869724/104577201-7b8f5080-5659-11eb-8181-328393eccc3b.gif)



### Expected result AFTER applying this Pull Request

Status icons are Green when item is published, Red when unpublished.
Clear button is differentiated when Filter is active.

![xtd_articles](https://user-images.githubusercontent.com/869724/104577332-a679a480-5659-11eb-825b-b189750afc09.gif)


### Documentation Changes Required

None