### PR TITLE
[4] Remove unreachable code in webauthn trait

### DIFF
--- a/plugins/system/webauthn/src/PluginTraits/AjaxHandler.php
+++ b/plugins/system/webauthn/src/PluginTraits/AjaxHandler.php
@@ -150,7 +150,6 @@ trait AjaxHandler
 					$app->redirect($result);
 
 					return;
-					break;
 
 				default:
 					Joomla::log('system', "Callback complete, returning JSON.");


### PR DESCRIPTION
on code review.

`break;` is not needed and is `unreachable code` and should be removed 