### PR TITLE
[4] Remove unreachable code in cli CodeStyle.php

### DIFF
--- a/libraries/src/Application/CLI/ColorStyle.php
+++ b/libraries/src/Application/CLI/ColorStyle.php
@@ -209,8 +209,6 @@ final class ColorStyle
 
 				default:
 					throw new \RuntimeException('Invalid option: ' . $subParts[0]);
-
-					break;
 			}
 		}
 


### PR DESCRIPTION
Code review.

`break;` after throwing an exception is not required and is unreachable code. 