### PR TITLE
[4] Cleanup of switch and remove unreachable code

### DIFF
--- a/administrator/components/com_postinstall/src/Controller/MessageController.php
+++ b/administrator/components/com_postinstall/src/Controller/MessageController.php
@@ -99,8 +99,6 @@ class MessageController extends BaseController
 
 				return;
 
-				break;
-
 			case 'action':
 				$helper = new PostinstallHelper;
 				$file = $helper->parsePath($item->action_file);
@@ -111,10 +109,6 @@ class MessageController extends BaseController
 
 					call_user_func($item->action);
 				}
-				break;
-
-			case 'message':
-			default:
 				break;
 		}
 


### PR DESCRIPTION
Code review

Remove `break` which is unreachable after a `return`

Remove redundant `case` and `default`

