### PR TITLE
[4] Security. Uncouple the length of a placeholder mask from the actual password length.

### DIFF
--- a/layouts/joomla/form/field/password.php
+++ b/layouts/joomla/form/field/password.php
@@ -81,7 +81,7 @@ if ($lock)
 	Text::script('JCANCEL');
 
 	$disabled = true;
-	$hint = str_repeat('&#x2022;', strlen($value));
+	$hint = str_repeat('&#x2022;', 10);
 	$value = '';
 }
 


### PR DESCRIPTION
### Summary of Changes

Currently in Joomla 4, the Password field (used for fields like the Joomla Global Configuration Database Password) uses a mask and doesn't show the actual password. (Because `$lock` is set) 

The placeholder is a set of bullets (used to be asterisks) 

The placeholder and mask is currently the same length as the REAL PASSWORD therefore giving away too much information about the real value of the password. 

This PR changes this behaviour to set a standard (plucked out of the air) 10 bullets mask/placeholder so that the real length of the underlying password is not leaked to the viewer.


### Testing Instructions

Check Joomla Global Configuration -> Database password - Note the number of bullets equals the number of chars in your REAL database password
Apply PR
Check Joomla Global Configuration -> Database password - Note the number of bullets equals 10.

### Actual result BEFORE applying this Pull Request

The length of the real password was leaked to the user interface when the password field locked specifically to hide such password. 

### Expected result AFTER applying this Pull Request

10 bullet length placeholder/hint regardless of the length of the underlying password. 

### Documentation Changes Required

None.