### PR TITLE
[4] fix Notice: Only variables should be passed by reference

### DIFF
--- a/libraries/src/MVC/Controller/BaseController.php
+++ b/libraries/src/MVC/Controller/BaseController.php
@@ -280,7 +280,8 @@ class BaseController implements ControllerInterface
 
 		if (\is_array($command))
 		{
-			$command = $filter->clean(array_pop(array_keys($command)), 'cmd');
+			$keys = array_keys($command);
+			$command = $filter->clean(array_pop($keys), 'cmd');
 		}
 		else
 		{


### PR DESCRIPTION
Code review

Test case: https://3v4l.org/OQacn

```php
<?php
$command = ['one'=>1,"two"=>2,"three"=>3];
$keys = array_keys($command);

// Raises a notice
var_dump(array_pop(array_keys($command)));

echo "\n\n\n\n";

var_dump(array_pop($keys));
```


