### PR TITLE
[4] Remove unset call as $xml is not set when here

### DIFF
--- a/libraries/src/Installer/InstallerHelper.php
+++ b/libraries/src/Installer/InstallerHelper.php
@@ -285,9 +285,6 @@ abstract class InstallerHelper
 
 		Log::add(Text::_('JLIB_INSTALLER_ERROR_NOTFINDJOOMLAXMLSETUPFILE'), Log::WARNING, 'jerror');
 
-		// Free up memory.
-		unset($xml);
-
 		return false;
 	}
 


### PR DESCRIPTION
Remove unset call as $xml is not set when here

Code review. 

`$xml` is only set in the nested foreach statement, and already unset before the return and continue within that. 

