### PR TITLE
[4] Fix default value type does not match the given type

### DIFF
--- a/libraries/src/Toolbar/ToolbarHelper.php
+++ b/libraries/src/Toolbar/ToolbarHelper.php
@@ -598,7 +598,7 @@ abstract class ToolbarHelper
 	 *
 	 * @since   1.5
 	 */
-	public static function preferences($component, $height = '550', $width = '875', $alt = 'JToolbar_Options', $path = '')
+	public static function preferences($component, $height = 550, $width = 875, $alt = 'JToolbar_Options', $path = '')
 	{
 		$component = urlencode($component);
 		$path = urlencode($path);


### PR DESCRIPTION
Even though they are unused, the docblock states they should be integers, not strings. 

Code review.


` * @param   integer  $height     The height of the popup. [UNUSED]`

` * @param   integer  $width      The width of the popup. [UNUSED]`