### PR TITLE
[4] phpmailerException - add missing include exception and alias it.

### DIFF
--- a/plugins/system/privacyconsent/privacyconsent.php
+++ b/plugins/system/privacyconsent/privacyconsent.php
@@ -27,6 +27,7 @@ use Joomla\Component\Messages\Administrator\Model\MessageModel;
 use Joomla\Database\Exception\ExecutionFailureException;
 use Joomla\Database\ParameterType;
 use Joomla\Utilities\ArrayHelper;
+use PHPMailer\PHPMailer\Exception as phpmailerException;
 
 /**
  * An example custom privacyconsent plugin.


### PR DESCRIPTION
Core review 

add missing include and alias 

`use PHPMailer\PHPMailer\Exception as phpmailerException;`

which is used, and currently undefined, here: 

https://github.com/joomla/joomla-cms/blob/413e89168df9b0b2d9ddb5b7d8715e00817227c4/plugins/system/privacyconsent/privacyconsent.php#L643