### PR TITLE
[4] add missing and fix wrong includes in com_finder, and remove unset on undefined var

### DIFF
--- a/administrator/components/com_finder/src/Indexer/Adapter.php
+++ b/administrator/components/com_finder/src/Indexer/Adapter.php
@@ -11,6 +11,7 @@ namespace Joomla\Component\Finder\Administrator\Indexer;
 
 \defined('_JEXEC') or die;
 
+use Exception;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\Database\DatabaseInterface;

--- a/administrator/components/com_finder/src/Indexer/Helper.php
+++ b/administrator/components/com_finder/src/Indexer/Helper.php
@@ -11,6 +11,7 @@ namespace Joomla\Component\Finder\Administrator\Indexer;
 
 \defined('_JEXEC') or die;
 
+use Exception;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Multilanguage;

--- a/administrator/components/com_finder/src/Indexer/Indexer.php
+++ b/administrator/components/com_finder/src/Indexer/Indexer.php
@@ -11,6 +11,7 @@ namespace Joomla\Component\Finder\Administrator\Indexer;
 
 \defined('_JEXEC') or die;
 
+use Exception;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Filesystem\File;
@@ -20,7 +21,6 @@ use Joomla\CMS\Profiler\Profiler;
 use Joomla\Database\ParameterType;
 use Joomla\Database\QueryInterface;
 use Joomla\String\StringHelper;
-use Exception;
 
 /**
  * Main indexer class for the Finder indexer package.

--- a/administrator/components/com_finder/src/Indexer/Indexer.php
+++ b/administrator/components/com_finder/src/Indexer/Indexer.php
@@ -18,7 +18,9 @@ use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Profiler\Profiler;
 use Joomla\Database\ParameterType;
+use Joomla\Database\QueryInterface;
 use Joomla\String\StringHelper;
+use Exception;
 
 /**
  * Main indexer class for the Finder indexer package.
@@ -102,7 +104,7 @@ class Indexer
 	/**
 	 * Reusable Query Template. To be used with clone.
 	 *
-	 * @var    Joomla\Database\QueryInterface
+	 * @var    QueryInterface
 	 * @since  3.8.0
 	 */
 	protected $addTokensToDbQueryTemplate;
@@ -834,7 +836,7 @@ class Indexer
 				// Parse, tokenise and add tokens to the database.
 				$count = $this->tokenizeToDbShort($string, $context, $lang, $format, $count);
 
-				unset($string, $tokens);
+				unset($string);
 			}
 
 			return $count;

--- a/administrator/components/com_finder/src/Indexer/Query.php
+++ b/administrator/components/com_finder/src/Indexer/Query.php
@@ -11,6 +11,7 @@ namespace Joomla\Component\Finder\Administrator\Indexer;
 
 \defined('_JEXEC') or die;
 
+use Exception;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;

--- a/administrator/components/com_finder/src/Model/FilterModel.php
+++ b/administrator/components/com_finder/src/Model/FilterModel.php
@@ -14,6 +14,7 @@ namespace Joomla\Component\Finder\Administrator\Model;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\MVC\Model\AdminModel;
+use Joomla\Component\Finder\Administrator\Table\FilterTable;
 
 /**
  * Filter model class for Finder.
@@ -56,7 +57,7 @@ class FilterModel extends AdminModel
 	/**
 	 * Method to get the filter data.
 	 *
-	 * @return  \Joomla\Component\Finder\Administrator\Table\Filter|boolean  The filter data or false on a failure.
+	 * @return  FilterTable|boolean  The filter data or false on a failure.
 	 *
 	 * @since   2.5
 	 */


### PR DESCRIPTION
Code review

Add missing includes for docblock type hints

Correct incorrect type hint and include that too (FilterTable)

Remote `$tokens` from the `unset` as `$tokens` is not even set in this method and undefined at this time and place. 