### PR TITLE
[4.0] Introduce a new render

### DIFF
--- a/layouts/joomla/toolbar/modal.php
+++ b/layouts/joomla/toolbar/modal.php
@@ -33,7 +33,7 @@ $icon     = isset($displayData['icon']) ? $displayData['icon'] : 'icon-download'
 $text     = isset($displayData['text']) ? $displayData['text'] : '';
 
 // Enqueue the modal at the body bottom
-Factory::getDocument()->setBodyBottom(
+Factory::getDocument()->enqueueBodyEnd(
 	HTMLHelper::_('bootstrap.renderModal',
 		'modal_' . $selector,
 		[

--- a/layouts/joomla/toolbar/modal.php
+++ b/layouts/joomla/toolbar/modal.php
@@ -59,7 +59,7 @@ Factory::getDocument()->appendBodyEnd(
 		class="btn btn-primary"
 		type="button"
 		data-toggle="modal"
-		onclick="document.getElementById('modal_<?php echo $selector; ?>').open();">
+		data-target="#modal_<?php echo $selector; ?>">
 		<span class="<?php echo $icon; ?>" aria-hidden="true"></span>
 		<?php echo $text; ?>
 	</button>

--- a/layouts/joomla/toolbar/modal.php
+++ b/layouts/joomla/toolbar/modal.php
@@ -33,7 +33,7 @@ $icon     = isset($displayData['icon']) ? $displayData['icon'] : 'icon-download'
 $text     = isset($displayData['text']) ? $displayData['text'] : '';
 
 // Enqueue the modal at the body bottom
-Factory::getDocument()->enqueueBodyEnd(
+Factory::getDocument()->appendBodyEnd(
 	HTMLHelper::_('bootstrap.renderModal',
 		'modal_' . $selector,
 		[

--- a/layouts/joomla/toolbar/modal.php
+++ b/layouts/joomla/toolbar/modal.php
@@ -31,38 +31,36 @@ $id       = isset($displayData['id']) ? $displayData['id'] : '';
 $class    = isset($displayData['class']) ? $displayData['class'] : 'btn btn-primary';
 $icon     = isset($displayData['icon']) ? $displayData['icon'] : 'icon-download';
 $text     = isset($displayData['text']) ? $displayData['text'] : '';
-?>
 
-<!-- Render the button -->
+// Enqueue the modal at the body bottom
+Factory::getDocument()->setBodyBottom(
+	HTMLHelper::_('bootstrap.renderModal',
+		'modal_' . $selector,
+		[
+			'url'         => $displayData['doTask'],
+			'title'       => $text,
+			'height'      => '100%',
+			'width'       => '100%',
+			'modalWidth'  => 80,
+			'bodyHeight'  => 60,
+			'closeButton' => true,
+			'footer'      => '<button class="btn btn-secondary" data-bs-dismiss="modal" type="button"'
+							. ' onclick="window.parent.Joomla.Modal.getCurrent().close();">'
+							. Text::_('COM_BANNERS_CANCEL') . '</button>'
+							. '<button class="btn btn-success" type="button"'
+							. ' onclick="Joomla.iframeButtonClick({iframeSelector: \'#modal_downloadModal\', buttonSelector: \'#exportBtn\'})">'
+							. Text::_('COM_BANNERS_TRACKS_EXPORT') . '</button>',
+		]
+	)
+);
+?>
 <joomla-toolbar-button<?php echo $id; ?>>
 	<button
 		class="btn btn-primary"
 		type="button"
-		onclick="document.getElementById('modal_<?php echo $selector; ?>').open(); document.body.appendChild(document.getElementById('modal_<?php echo $selector; ?>'));"
-		data-toggle="modal">
+		data-toggle="modal"
+		onclick="document.getElementById('modal_<?php echo $selector; ?>').open();">
 		<span class="<?php echo $icon; ?>" aria-hidden="true"></span>
 		<?php echo $text; ?>
 	</button>
 </joomla-toolbar-button>
-
-<!-- Render the modal -->
-<?php
-echo HTMLHelper::_('bootstrap.renderModal',
-	'modal_' . $selector,
-	[
-		'url'         => $displayData['doTask'],
-		'title'       => $text,
-		'height'      => '100%',
-		'width'       => '100%',
-		'modalWidth'  => 80,
-		'bodyHeight'  => 60,
-		'closeButton' => true,
-		'footer'      => '<button class="btn btn-secondary" data-dismiss="modal" type="button"'
-						. ' onclick="window.parent.Joomla.Modal.getCurrent().close();">'
-						. Text::_('COM_BANNERS_CANCEL') . '</button>'
-						. '<button class="btn btn-success" type="button"'
-						. ' onclick="Joomla.iframeButtonClick({iframeSelector: \'#modal_downloadModal\', buttonSelector: \'#exportBtn\'})">'
-						. Text::_('COM_BANNERS_TRACKS_EXPORT') . '</button>',
-	]
-);
-

--- a/layouts/joomla/toolbar/versions.php
+++ b/layouts/joomla/toolbar/versions.php
@@ -62,7 +62,7 @@ Factory::getDocument()->appendBodyEnd(
 		class="btn btn-primary"
 		type="button"
 		data-toggle="modal"
-		data-target="#versionsModal"
+		data-target="#versionsModal">
 		<span class="icon-code-branch" aria-hidden="true"></span>
 		<?php echo $title; ?>
 	</button>

--- a/layouts/joomla/toolbar/versions.php
+++ b/layouts/joomla/toolbar/versions.php
@@ -31,7 +31,7 @@ Factory::getDocument()->getWebAssetManager()
 	->useScript('webcomponent.toolbar-button');
 
 // Enqueue the modal at the body bottom
-Factory::getDocument()->setBodyBottom(
+Factory::getDocument()->enqueueBodyEnd(
 	HTMLHelper::_(
 		'bootstrap.renderModal',
 		'versionsModal',

--- a/layouts/joomla/toolbar/versions.php
+++ b/layouts/joomla/toolbar/versions.php
@@ -30,27 +30,30 @@ Factory::getDocument()->getWebAssetManager()
 	->useScript('core')
 	->useScript('webcomponent.toolbar-button');
 
-echo HTMLHelper::_(
-	'bootstrap.renderModal',
-	'versionsModal',
-	array(
-		'url'    => 'index.php?' . http_build_query(
-			[
-				'option' => 'com_contenthistory',
-				'view' => 'history',
-				'layout' => 'modal',
-				'tmpl' => 'component',
-				'item_id' => $itemId,
-				Session::getFormToken() => 1
-			]
-		),
-		'title'  => $title,
-		'height' => '100%',
-		'width'  => '100%',
-		'modalWidth'  => '80',
-		'bodyHeight'  => '60',
-		'footer' => '<button type="button" class="btn btn-secondary" data-dismiss="modal" aria-hidden="true">'
-			. Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>'
+// Enqueue the modal at the body bottom
+Factory::getDocument()->setBodyBottom(
+	HTMLHelper::_(
+		'bootstrap.renderModal',
+		'versionsModal',
+		[
+			'url'        => 'index.php?' . http_build_query(
+				[
+					'option' => 'com_contenthistory',
+					'view' => 'history',
+					'layout' => 'modal',
+					'tmpl' => 'component',
+					'item_id' => $itemId,
+					Session::getFormToken() => 1
+				]
+			),
+			'title'       => $title,
+			'height'      => '100%',
+			'width'       => '100%',
+			'modalWidth'  => '80',
+			'bodyHeight'  => '60',
+			'footer'      => '<button type="button" class="btn btn-secondary" data-dismiss="modal" aria-hidden="true">'
+							. Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>'
+		]
 	)
 );
 ?>
@@ -58,8 +61,7 @@ echo HTMLHelper::_(
 	<button
 		class="btn btn-primary"
 		type="button"
-		onclick="document.getElementById('versionsModal').open()"
-		data-toggle="modal">
+		onclick="document.getElementById('versionsModal').open()">
 		<span class="icon-code-branch" aria-hidden="true"></span>
 		<?php echo $title; ?>
 	</button>

--- a/layouts/joomla/toolbar/versions.php
+++ b/layouts/joomla/toolbar/versions.php
@@ -31,7 +31,7 @@ Factory::getDocument()->getWebAssetManager()
 	->useScript('webcomponent.toolbar-button');
 
 // Enqueue the modal at the body bottom
-Factory::getDocument()->enqueueBodyEnd(
+Factory::getDocument()->appendBodyEnd(
 	HTMLHelper::_(
 		'bootstrap.renderModal',
 		'versionsModal',

--- a/layouts/joomla/toolbar/versions.php
+++ b/layouts/joomla/toolbar/versions.php
@@ -61,7 +61,8 @@ Factory::getDocument()->appendBodyEnd(
 	<button
 		class="btn btn-primary"
 		type="button"
-		onclick="document.getElementById('versionsModal').open()">
+		data-toggle="modal"
+		data-target="#versionsModal"
 		<span class="icon-code-branch" aria-hidden="true"></span>
 		<?php echo $title; ?>
 	</button>

--- a/libraries/src/Document/Document.php
+++ b/libraries/src/Document/Document.php
@@ -263,12 +263,12 @@ class Document
 	protected $webAssetManager = null;
 
 	/**
-	 * Body bottom que
+	 * Body bottom HTML chunks
 	 *
 	 * @var    array
 	 * @since  __DEPLOY_VERSION__
 	 */
-	protected $bodyEndQueue = [];
+	protected $bodyEndChunks = [];
 
 	/**
 	 * Class constructor.
@@ -398,9 +398,9 @@ class Document
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function enqueueBodyEnd($content): Document
+	public function appendBodyEnd($content): Document
 	{
-		$this->bodyEndQueue[] = $content;
+		$this->bodyEndChunks[] = $content;
 
 		return $this;
 	}
@@ -414,9 +414,9 @@ class Document
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function setBodyEndQueue($content): Document
+	public function setBodyEndChunks($content): Document
 	{
-		$this->bodyEndQueue = $content;
+		$this->bodyEndChunks = $content;
 
 		return $this;
 	}
@@ -428,9 +428,9 @@ class Document
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function getBodyEndQueue(): array
+	public function getBodyEndChunks(): array
 	{
-		return $this->bodyEndQueue;
+		return $this->bodyEndChunks;
 	}
 
 	/**

--- a/libraries/src/Document/Document.php
+++ b/libraries/src/Document/Document.php
@@ -268,7 +268,7 @@ class Document
 	 * @var    array
 	 * @since  __DEPLOY_VERSION__
 	 */
-	protected $bodyBottom = [];
+	protected $bodyEndQue = [];
 
 	/**
 	 * Class constructor.
@@ -390,7 +390,7 @@ class Document
 	}
 
 	/**
-	 * Set the bodyBottom queue
+	 * Enqueue HTML to be placed at the body end
 	 *
 	 * @param   string  $content  The content to be enqueued
 	 *
@@ -398,23 +398,39 @@ class Document
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function setBodyBottom($content): Document
+	public function enqueueBodyEnd($content): Document
 	{
-		$this->bodyBottom[] = $content;
+		$this->bodyEndQue[] = $content;
 
 		return $this;
 	}
 
 	/**
-	 * Get the $bodyBottom queue
+	 * Set the bodyBottom queue
 	 *
-	 * @return  array
+	 * @param   array  $content  The content to be enqueued
+	 *
+	 * @return  Document instance of $this to allow chaining
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function getBodyBottom(): array
+	public function setBodyEndHTML($content): Document
 	{
-		return $this->bodyBottom;
+		$this->bodyEndQue = $content;
+
+		return $this;
+	}
+
+	/**
+	 * Get the queue for the chunks to be placed at the end of the body
+	 *
+	 * @return  array  The array of the HTML chunks
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getBodyEndHTML(): array
+	{
+		return $this->bodyEndQue;
 	}
 
 	/**

--- a/libraries/src/Document/Document.php
+++ b/libraries/src/Document/Document.php
@@ -268,7 +268,7 @@ class Document
 	 * @var    array
 	 * @since  __DEPLOY_VERSION__
 	 */
-	protected $bodyEndQue = [];
+	protected $bodyEndQueue = [];
 
 	/**
 	 * Class constructor.
@@ -400,13 +400,13 @@ class Document
 	 */
 	public function enqueueBodyEnd($content): Document
 	{
-		$this->bodyEndQue[] = $content;
+		$this->bodyEndQueue[] = $content;
 
 		return $this;
 	}
 
 	/**
-	 * Set the bodyBottom queue
+	 * Set the queue for the chunks to be placed at the end of the body
 	 *
 	 * @param   array  $content  The content to be enqueued
 	 *
@@ -414,9 +414,9 @@ class Document
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function setBodyEndHTML($content): Document
+	public function setBodyEndQueue($content): Document
 	{
-		$this->bodyEndQue = $content;
+		$this->bodyEndQueue = $content;
 
 		return $this;
 	}
@@ -428,9 +428,9 @@ class Document
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function getBodyEndHTML(): array
+	public function getBodyEndQueue(): array
 	{
-		return $this->bodyEndQue;
+		return $this->bodyEndQueue;
 	}
 
 	/**

--- a/libraries/src/Document/Document.php
+++ b/libraries/src/Document/Document.php
@@ -263,6 +263,14 @@ class Document
 	protected $webAssetManager = null;
 
 	/**
+	 * Body bottom que
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $bodyBottom = [];
+
+	/**
 	 * Class constructor.
 	 *
 	 * @param   array  $options  Associative array of options
@@ -379,6 +387,34 @@ class Document
 		$this->factory = $factory;
 
 		return $this;
+	}
+
+	/**
+	 * Set the bodyBottom queue
+	 *
+	 * @param   string  $content  The content to be enqueued
+	 *
+	 * @return  Document instance of $this to allow chaining
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function setBodyBottom($content): Document
+	{
+		$this->bodyBottom[] = $content;
+
+		return $this;
+	}
+
+	/**
+	 * Get the $bodyBottom queue
+	 *
+	 * @return  array
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getBodyBottom(): array
+	{
+		return $this->bodyBottom;
 	}
 
 	/**

--- a/libraries/src/Document/HtmlDocument.php
+++ b/libraries/src/Document/HtmlDocument.php
@@ -880,7 +880,8 @@ class HtmlDocument extends Document
 			if (!$hasBodyEnd)
 			{
 				$this->_template    = str_replace('</body>', '<jdoc:include type="bodyend" /></body>', $this->_template);
-				$template_tags_last = ['<jdoc:include type="bodyend" />' => ['type' => 'bodyend', 'name' => '', 'attribs' => []]] + $template_tags_last;
+				$template_tags_last = ['<jdoc:include type="bodyend" />' => ['type' => 'bodyend', 'name' => '', 'attribs' => []]]
+					+ $template_tags_last;
 			}
 
 			$this->_template_tags = $template_tags_first + $messages + array_reverse($template_tags_last);

--- a/libraries/src/Document/HtmlDocument.php
+++ b/libraries/src/Document/HtmlDocument.php
@@ -895,7 +895,7 @@ class HtmlDocument extends Document
 			$with[] = $this->getBuffer($args['type'], $args['name'], $args['attribs']);
 		}
 
-		$bodyBottom = $this->getBuffer('bodybottom', '', ['type' => 'bodybottom']);
+		$bodyBottom = $this->getBuffer('bodyend', '', []);
 
 		return str_replace($replace, $with, $this->_template) . $bodyBottom;
 	}

--- a/libraries/src/Document/HtmlDocument.php
+++ b/libraries/src/Document/HtmlDocument.php
@@ -895,6 +895,8 @@ class HtmlDocument extends Document
 			$with[] = $this->getBuffer($args['type'], $args['name'], $args['attribs']);
 		}
 
-		return str_replace($replace, $with, $this->_template);
+		$bodyBottom = $this->getBuffer('bodybottom', '', ['type' => 'bodybottom']);
+
+		return str_replace($replace, $with, $this->_template) . $bodyBottom;
 	}
 }

--- a/libraries/src/Document/HtmlDocument.php
+++ b/libraries/src/Document/HtmlDocument.php
@@ -879,7 +879,7 @@ class HtmlDocument extends Document
 
 			if (!$hasBodyEnd)
 			{
-				$this->_template = str_replace('</body>', '<jdoc:include type="bodyend" /></body>', $this->_template);
+				$this->_template    = str_replace('</body>', '<jdoc:include type="bodyend" /></body>', $this->_template);
 				$template_tags_last = ['<jdoc:include type="bodyend" />' => ['type' => 'bodyend', 'name' => '', 'attribs' => []]] + $template_tags_last;
 			}
 

--- a/libraries/src/Document/HtmlDocument.php
+++ b/libraries/src/Document/HtmlDocument.php
@@ -841,8 +841,8 @@ class HtmlDocument extends Document
 	 */
 	protected function _parseTemplate()
 	{
-		$matches         = [];
-		$this->_template = str_replace('</body>', '<jdoc:include type="bodyend" /></body>', $this->_template);
+		$matches    = [];
+		$hasBodyEnd = false;
 
 		if (preg_match_all('#<jdoc:include\ type="([^"]+)"(.*)\/>#iU', $this->_template, $matches))
 		{
@@ -870,6 +870,17 @@ class HtmlDocument extends Document
 				{
 					$template_tags_last[$matches[0][$i]] = ['type' => $type, 'name' => $name, 'attribs' => $attribs];
 				}
+
+				if ($type === 'bodyend')
+				{
+					$hasBodyEnd = true;
+				}
+			}
+
+			if (!$hasBodyEnd)
+			{
+				$this->_template = str_replace('</body>', '<jdoc:include type="bodyend" /></body>', $this->_template);
+				$template_tags_last = ['<jdoc:include type="bodyend" />' => ['type' => 'bodyend', 'name' => '', 'attribs' => []]] + $template_tags_last;
 			}
 
 			$this->_template_tags = $template_tags_first + $messages + array_reverse($template_tags_last);

--- a/libraries/src/Document/HtmlDocument.php
+++ b/libraries/src/Document/HtmlDocument.php
@@ -895,8 +895,6 @@ class HtmlDocument extends Document
 			$with[] = $this->getBuffer($args['type'], $args['name'], $args['attribs']);
 		}
 
-		$bodyBottom = $this->getBuffer('bodyend', '', []);
-
-		return str_replace($replace, $with, $this->_template) . $bodyBottom;
+		return str_replace($replace, $with, $this->_template) . $this->getBuffer('bodyend', '', []);
 	}
 }

--- a/libraries/src/Document/HtmlDocument.php
+++ b/libraries/src/Document/HtmlDocument.php
@@ -841,20 +841,21 @@ class HtmlDocument extends Document
 	 */
 	protected function _parseTemplate()
 	{
-		$matches = array();
+		$matches         = [];
+		$this->_template = str_replace('</body>', '<jdoc:include type="bodyend" /></body>', $this->_template);
 
 		if (preg_match_all('#<jdoc:include\ type="([^"]+)"(.*)\/>#iU', $this->_template, $matches))
 		{
-			$messages = [];
+			$messages            = [];
 			$template_tags_first = [];
-			$template_tags_last = [];
+			$template_tags_last  = [];
 
 			// Step through the jdocs in reverse order.
 			for ($i = \count($matches[0]) - 1; $i >= 0; $i--)
 			{
-				$type = $matches[1][$i];
+				$type    = $matches[1][$i];
 				$attribs = empty($matches[2][$i]) ? array() : Utility::parseAttributes($matches[2][$i]);
-				$name = $attribs['name'] ?? null;
+				$name    = $attribs['name'] ?? null;
 
 				// Separate buffers to be executed first and last
 				if ($type === 'module' || $type === 'modules')
@@ -892,9 +893,9 @@ class HtmlDocument extends Document
 		foreach ($this->_template_tags as $jdoc => $args)
 		{
 			$replace[] = $jdoc;
-			$with[] = $this->getBuffer($args['type'], $args['name'], $args['attribs']);
+			$with[]    = $this->getBuffer($args['type'], $args['name'], $args['attribs']);
 		}
 
-		return str_replace($replace, $with, $this->_template) . $this->getBuffer('bodyend', '', []);
+		return str_replace($replace, $with, $this->_template);
 	}
 }

--- a/libraries/src/Document/Renderer/Html/BodybottomRenderer.php
+++ b/libraries/src/Document/Renderer/Html/BodybottomRenderer.php
@@ -2,7 +2,7 @@
 /**
  * Joomla! Content Management System
  *
- * @copyright  (C) 2015 Open Source Matters, Inc. <https://www.joomla.org>
+ * @copyright  (C) 2021 Open Source Matters, Inc. <https://www.joomla.org>
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/libraries/src/Document/Renderer/Html/BodybottomRenderer.php
+++ b/libraries/src/Document/Renderer/Html/BodybottomRenderer.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  (C) 2015 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Document\Renderer\Html;
+
+\defined('JPATH_PLATFORM') or die;
+
+use Joomla\CMS\Document\DocumentRenderer;
+use Joomla\CMS\Factory;
+
+/**
+ * HTML document renderer for the body bottom queue
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class BodybottomRenderer extends DocumentRenderer
+{
+	/**
+	 * Renders the body bottom queue and returns it as a string
+	 *
+	 * @param   string  $name     Not used.
+	 * @param   array   $params   Associative array of values
+	 * @param   string  $content  Not used.
+	 *
+	 * @return  string  The output of the script
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function render($name, $params = array(), $content = null)
+	{
+		$buffer  = '';
+		$content = Factory::getDocument()->getBodyBottom();
+
+		foreach ($content as $key => $value)
+		{
+			$buffer .= $value;
+		}
+
+		return $buffer;
+	}
+}

--- a/libraries/src/Document/Renderer/Html/BodyendRenderer.php
+++ b/libraries/src/Document/Renderer/Html/BodyendRenderer.php
@@ -34,7 +34,7 @@ class BodyendRenderer extends DocumentRenderer
 	public function render($name, $params = array(), $content = null)
 	{
 		$buffer  = '';
-		$content = Factory::getDocument()->getBodyEndQueue();
+		$content = Factory::getDocument()->getBodyEndChunks();
 
 		foreach ($content as $key => $value)
 		{

--- a/libraries/src/Document/Renderer/Html/BodyendRenderer.php
+++ b/libraries/src/Document/Renderer/Html/BodyendRenderer.php
@@ -34,7 +34,7 @@ class BodyendRenderer extends DocumentRenderer
 	public function render($name, $params = array(), $content = null)
 	{
 		$buffer  = '';
-		$content = Factory::getDocument()->getBodyEndHTML();
+		$content = Factory::getDocument()->getBodyEndQueue();
 
 		foreach ($content as $key => $value)
 		{

--- a/libraries/src/Document/Renderer/Html/BodyendRenderer.php
+++ b/libraries/src/Document/Renderer/Html/BodyendRenderer.php
@@ -18,7 +18,7 @@ use Joomla\CMS\Factory;
  *
  * @since  __DEPLOY_VERSION__
  */
-class BodybottomRenderer extends DocumentRenderer
+class BodyendRenderer extends DocumentRenderer
 {
 	/**
 	 * Renders the body bottom queue and returns it as a string
@@ -34,7 +34,7 @@ class BodybottomRenderer extends DocumentRenderer
 	public function render($name, $params = array(), $content = null)
 	{
 		$buffer  = '';
-		$content = Factory::getDocument()->getBodyBottom();
+		$content = Factory::getDocument()->getBodyEndHTML();
 
 		foreach ($content as $key => $value)
 		{

--- a/libraries/src/Document/Renderer/Html/BodyendRenderer.php
+++ b/libraries/src/Document/Renderer/Html/BodyendRenderer.php
@@ -33,14 +33,6 @@ class BodyendRenderer extends DocumentRenderer
 	 */
 	public function render($name, $params = array(), $content = null)
 	{
-		$buffer  = '';
-		$content = Factory::getDocument()->getBodyEndChunks();
-
-		foreach ($content as $key => $value)
-		{
-			$buffer .= $value;
-		}
-
-		return $buffer;
+		return implode('', Factory::getDocument()->getBodyEndChunks());
 	}
 }

--- a/libraries/src/Toolbar/Button/PopupButton.php
+++ b/libraries/src/Toolbar/Button/PopupButton.php
@@ -147,7 +147,7 @@ class PopupButton extends ToolbarButton
 				$params['footer'] = $footer;
 			}
 
-			Factory::getDocument()->setBodyBottom(HTMLHelper::_('bootstrap.renderModal', $selector, $params));
+			Factory::getDocument()->enqueueBodyEnd(HTMLHelper::_('bootstrap.renderModal', $selector, $params));
 		}
 
 		// If an $onClose event is passed, add it to the modal JS object

--- a/libraries/src/Toolbar/Button/PopupButton.php
+++ b/libraries/src/Toolbar/Button/PopupButton.php
@@ -147,7 +147,7 @@ class PopupButton extends ToolbarButton
 				$params['footer'] = $footer;
 			}
 
-			Factory::getDocument()->enqueueBodyEnd(HTMLHelper::_('bootstrap.renderModal', $selector, $params));
+			Factory::getDocument()->appendBodyEnd(HTMLHelper::_('bootstrap.renderModal', $selector, $params));
 		}
 
 		// If an $onClose event is passed, add it to the modal JS object

--- a/libraries/src/Toolbar/Button/PopupButton.php
+++ b/libraries/src/Toolbar/Button/PopupButton.php
@@ -138,31 +138,16 @@ class PopupButton extends ToolbarButton
 			$params['bodyHeight'] = $options['bodyHeight'] ?? null;
 			$params['modalWidth'] = $options['modalWidth'] ?? null;
 
-			// Place modal div and scripts in a new div
-			$html[] = '<div class="btn-group" style="width: 0; margin: 0; padding: 0;">';
-
+			// Enqueue the modal HTML to be rendered at the body bottom
 			$selector = $options['selector'];
-
-			$footer = $this->getFooter();
+			$footer   = $this->getFooter();
 
 			if ($footer !== null)
 			{
 				$params['footer'] = $footer;
 			}
 
-			$html[] = HTMLHelper::_('bootstrap.renderModal', $selector, $params);
-
-			$html[] = '</div>';
-
-			// We have to move the modal, otherwise we get problems with the backdrop
-			// TODO: There should be a better workaround than this
-			Factory::getDocument()->addScriptDeclaration(
-				<<<JS
-window.addEventListener('DOMContentLoaded', function() {
-	document.body.appendChild(document.getElementById('{$options['selector']}'));
-});
-JS
-			);
+			Factory::getDocument()->setBodyBottom(HTMLHelper::_('bootstrap.renderModal', $selector, $params));
 		}
 
 		// If an $onClose event is passed, add it to the modal JS object


### PR DESCRIPTION

Pull Request for pending todos 

### Summary of Changes

- Create a new renderer bodybottom which renders just before the closing body tag
- Add a new private variable to the Document
- Add setter/getter for the previous private variable

- Fix the @todos for the toolbar modals

### Testing Instructions

Apply patch, and check that the modals in the Article Edit form (both the Versions and Preview) are still functional


### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Documentation Changes Required


@wilsonge although the problem was pretty obvious in the BS5 transition this solution and the shenanigans (the ability to enqueue html for the bottom of the page) should be pretty valid for J4 regardless of the BS5 decision