### PR TITLE
$nowDate has to be quoted for the query to work (#32016)

### DIFF
--- a/components/com_content/src/Model/ArticlesModel.php
+++ b/components/com_content/src/Model/ArticlesModel.php
@@ -572,8 +572,7 @@ class ArticlesModel extends ListModel
 				$relativeDate = (int) $this->getState('filter.relative_date', 0);
 				$query->where(
 					$db->quoteName($dateField) . ' IS NOT NULL AND '
-					. $db->quoteName($dateField) . ' >= ' . $query->dateAdd(':relativeNowDate ', -1 * $relativeDate, 'DAY')
-					->bind(':relativeNowDate ', $nowDate)
+					. $db->quoteName($dateField) . ' >= ' . $query->dateAdd($db->quote($nowDate), -1 * $relativeDate, 'DAY')
 				);
 				break;
 

--- a/components/com_content/src/Model/ArticlesModel.php
+++ b/components/com_content/src/Model/ArticlesModel.php
@@ -572,7 +572,7 @@ class ArticlesModel extends ListModel
 				$relativeDate = (int) $this->getState('filter.relative_date', 0);
 				$query->where(
 					$db->quoteName($dateField) . ' IS NOT NULL AND '
-					. $db->quoteName($dateField) . ' >= ' . $query->dateAdd($nowDate, -1 * $relativeDate, 'DAY')
+					. $db->quoteName($dateField) . ' >= ' . $query->dateAdd($db->quote($nowDate), -1 * $relativeDate, 'DAY')
 				);
 				break;
 

--- a/components/com_content/src/Model/ArticlesModel.php
+++ b/components/com_content/src/Model/ArticlesModel.php
@@ -572,7 +572,8 @@ class ArticlesModel extends ListModel
 				$relativeDate = (int) $this->getState('filter.relative_date', 0);
 				$query->where(
 					$db->quoteName($dateField) . ' IS NOT NULL AND '
-					. $db->quoteName($dateField) . ' >= ' . $query->dateAdd($db->quote($nowDate), -1 * $relativeDate, 'DAY')
+					. $db->quoteName($dateField) . ' >= ' . $query->dateAdd(':relativeNowDate ', -1 * $relativeDate, 'DAY')
+					->bind(':relativeNowDate ', $nowDate)
 				);
 				break;
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
The database query with relative date fails because the $nowDate is not 'quoted'.


### Testing Instructions
Create new module instance of mod_articles_category and set filter to relative date.


### Actual result BEFORE applying this Pull Request
The Query fails and the frontend shows an error:
```
Warning: Invalid argument supplied for foreach() in /Users/marcorensch/Sites/joomla4b5/components/com_content/src/Model/ArticlesModel.php on line 713

Warning: Invalid argument supplied for foreach() in /Users/marcorensch/Sites/joomla4b5/modules/mod_articles_category/src/Helper/ArticlesCategoryHelper.php on line 257
```


### Expected result AFTER applying this Pull Request
The query runs and the searched articles gets loaded.


### Documentation Changes Required
The $nowDate was already quoted in Joomla 3.x, but was not initially set in J4 because in line 298/299 /378/379/538/539 $nowDate is used with bind which does not have to be 'quoted'. The easiest & cleanest way is to 'quote' $nowDate directly in the relative query.
