### PR TITLE
[4.0] Fix edit account URI fragment

### DIFF
--- a/administrator/modules/mod_user/tmpl/default.php
+++ b/administrator/modules/mod_user/tmpl/default.php
@@ -37,7 +37,7 @@ $hideLinks = $app->input->getBool('hidemainmenu');
 			<?php echo Text::sprintf('MOD_USER_TITLE', $user->name); ?>
 		</div>
 		<?php $uri   = Uri::getInstance(); ?>
-		<?php $route = 'index.php?option=com_admin&task=profile.edit&id=' . $user->id . '&return=' . base64_encode($uri) . '#details'; ?>
+		<?php $route = 'index.php?option=com_admin&task=profile.edit&id=' . $user->id . '&return=' . base64_encode($uri) . '#attrib-user_details'; ?>
 		<a class="dropdown-item" href="<?php echo Route::_($route); ?>">
 			<span class="icon-user icon-fw" aria-hidden="true"></span>
 			<?php echo Text::_('MOD_USER_EDIT_ACCOUNT'); ?>


### PR DESCRIPTION
### Summary of Changes

Fix the URI fragment for the `Edit Account` so that it always opens the first tab

### Testing Instructions

1. Open the User Menu (top right)
2. Click `Edit Account`
3. Navigate to any tab...e.g `Joomla API Token`
4. Click `Close` in the toolbar
5. Re-do steps 1 and 2

### Actual result BEFORE applying this Pull Request

The tab which was opened as last before the last closing is shown, e.g. Joomla API Token view

### Expected result AFTER applying this Pull Request

My Profile Details view is shown
