### PR TITLE
[4.0] Showon init only once, public method Joomla.Showon.initialise()

### DIFF
--- a/build/media_source/system/js/showon.es6.js
+++ b/build/media_source/system/js/showon.es6.js
@@ -29,6 +29,12 @@
       if (this.showonFields.length) {
         // @todo refactor this, dry
         this.showonFields.forEach((field) => {
+          // Set up only once
+          if (field.hasAttribute('data-showon-initialised')) {
+            return;
+          }
+          field.setAttribute('data-showon-initialised', '');
+
           const jsondata = field.getAttribute('data-showon') || '';
           const showonData = JSON.parse(jsondata);
           let localFields;
@@ -204,12 +210,20 @@
     }
   }
 
+  // Provide a public API
+  window.Joomla = window.Joomla || {};
+
+  if (!Joomla.Showon) {
+    Joomla.Showon = {
+      initilise: (container) => new Showon(container)
+    }
+  }
+
   /**
    * Initialize 'showon' feature at an initial page load
    */
   document.addEventListener('DOMContentLoaded', () => {
-    // eslint-disable-next-line no-new
-    new Showon(document);
+    Joomla.Showon.initilise(document);
   });
 
   /**
@@ -229,7 +243,6 @@
       });
     }
 
-    // eslint-disable-next-line no-new
-    new Showon(target);
+    Joomla.Showon.initilise(target);
   });
 })(document);

--- a/build/media_source/system/js/showon.es6.js
+++ b/build/media_source/system/js/showon.es6.js
@@ -215,8 +215,8 @@
 
   if (!Joomla.Showon) {
     Joomla.Showon = {
-      initialise: (container) => new Showon(container)
-    }
+      initialise: (container) => new Showon(container),
+    };
   }
 
   /**

--- a/build/media_source/system/js/showon.es6.js
+++ b/build/media_source/system/js/showon.es6.js
@@ -215,7 +215,7 @@
 
   if (!Joomla.Showon) {
     Joomla.Showon = {
-      initilise: (container) => new Showon(container)
+      initialise: (container) => new Showon(container)
     }
   }
 
@@ -223,7 +223,7 @@
    * Initialize 'showon' feature at an initial page load
    */
   document.addEventListener('DOMContentLoaded', () => {
-    Joomla.Showon.initilise(document);
+    Joomla.Showon.initialise(document);
   });
 
   /**
@@ -243,6 +243,6 @@
       });
     }
 
-    Joomla.Showon.initilise(target);
+    Joomla.Showon.initialise(target);
   });
 })(document);


### PR DESCRIPTION
### Summary of Changes
Same as #32061
The code make sure that showon initialised only once, no mater how often Joomla.Showon.initilise was called.
Also add public `Joomla.Showon.initilise` (to be in sync with 3.10)

### Testing Instructions

Apply path, run `npm install`
Make sure `showon` still works.

Example, go to global config change "Debug Language" on/off, should downup/hides "Language Display" field.
Also the field "Language Display"  will have extra attribute `data-showon-initialised`


### Actual result BEFORE applying this Pull Request
showon works,
the showon field do not have `data-showon-initialised`



### Expected result AFTER applying this Pull Request
showon works,
the showon field do have `data-showon-initialised` attribute




