### PR TITLE
Build - Don't create HTML report for a single test run

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -39,8 +39,8 @@
 	</testsuites>
 
 	<logging>
-		<log type="coverage-html" target="build/coverage" title="Joomla-CMS" charset="UTF-8" yui="true" highlight="true"
-			lowUpperBound="35" highLowerBound="70" />
+		<!-- log type="coverage-html" target="build/coverage" title="Joomla-CMS" charset="UTF-8" yui="true" highlight="true"
+			lowUpperBound="35" highLowerBound="70" / -->
 		<log type="coverage-clover" target="build/logs/clover.xml" />
 		<log type="junit" target="build/logs/junit.xml" logIncompleteSkipped="false" />
 	</logging>


### PR DESCRIPTION
### Summary of Changes

Don't generate HTML coverage report

### Testing Instructions

Code review

### Actual result BEFORE applying this Pull Request

Some tests fail with

```text
Generating code coverage report in HTML format ...count(): Parameter must be an array or an object that implements Countable
```

### Expected result AFTER applying this Pull Request

The error is gone

### Documentation Changes Required

No