### PR TITLE
Make sure the sendmail endpoint can only be called via post

### DIFF
--- a/administrator/components/com_config/controller/application/sendtestmail.php
+++ b/administrator/components/com_config/controller/application/sendtestmail.php
@@ -30,7 +30,7 @@ class ConfigControllerApplicationSendtestmail extends JControllerBase
 		$this->app->sendHeaders();
 
 		// Check if user token is valid.
-		if (!JSession::checkToken('get'))
+		if (!JSession::checkToken())
 		{
 			$this->app->enqueueMessage(JText::_('JINVALID_TOKEN'), 'error');
 			echo new JResponseJson;


### PR DESCRIPTION
Pull Request for an Issue reported by @PhilETaylor to the JSST. The JSST decided to patch this in the public tracker hence here the PR.

### Summary of Changes

Make sure the sendmail endpoint can only be called via post

### Testing Instructions

- Make sure the sendmail test button works
- apply this patch
- Make sure the sendmail test button still works

### Actual result BEFORE applying this Pull Request

The sendmail test button works

### Expected result AFTER applying this Pull Request

The sendmail test button still works

### Documentation Changes Required

none