### PR TITLE
[3.10] Make sure the message is more clear for 3.x extensions

### DIFF
--- a/administrator/language/en-GB/en-GB.com_joomlaupdate.ini
+++ b/administrator/language/en-GB/en-GB.com_joomlaupdate.ini
@@ -59,7 +59,7 @@ COM_JOOMLAUPDATE_VIEW_DEFAULT_EXTENSIONS_PROBABLY_COMPATIBLE_NOTES="<p>The exten
 COM_JOOMLAUPDATE_VIEW_DEFAULT_EXTENSIONS_REQUIRING_UPDATES_TO_BE_COMPATIBLE="Update Required"
 COM_JOOMLAUPDATE_VIEW_DEFAULT_EXTENSIONS_REQUIRING_UPDATES_TO_BE_COMPATIBLE_NOTES="<p>Please update these extensions before updating Joomla.</p><p id='updateorangewarning' class='hidden'>Please take extra care if this updated version of the extension is not also listed as compatible with your current version of Joomla.</p>"
 COM_JOOMLAUPDATE_VIEW_DEFAULT_EXTENSIONS_UPDATE_SERVER_OFFERS_NO_COMPATIBLE_VERSION="Update Information Unavailable"
-COM_JOOMLAUPDATE_VIEW_DEFAULT_EXTENSIONS_UPDATE_SERVER_OFFERS_NO_COMPATIBLE_VERSION_NOTES="Extension does not offer an compatible version for the selected target version of Joomla. This could mean the extension does not use the Joomla update system or the developer has not provided compatibility information for this Joomla version yet."
+COM_JOOMLAUPDATE_VIEW_DEFAULT_EXTENSIONS_UPDATE_SERVER_OFFERS_NO_COMPATIBLE_VERSION_NOTES="Extension does not offer a compatible version for the selected target version of Joomla. This could mean the extension does not use the Joomla update system or the developer has not provided compatibility information for this Joomla version yet."
 COM_JOOMLAUPDATE_VIEW_DEFAULT_SHOW_LESS_EXTENSION_COMPATIBILITY_INFORMATION="[ Less Detail %s ]"
 COM_JOOMLAUPDATE_VIEW_DEFAULT_SHOW_MORE_EXTENSION_COMPATIBILITY_INFORMATION="[ More Detail %s ]"
 COM_JOOMLAUPDATE_VIEW_DEFAULT_EXTENSION_COMPATIBLE="Compatible"

--- a/administrator/language/en-GB/en-GB.com_joomlaupdate.ini
+++ b/administrator/language/en-GB/en-GB.com_joomlaupdate.ini
@@ -59,7 +59,7 @@ COM_JOOMLAUPDATE_VIEW_DEFAULT_EXTENSIONS_PROBABLY_COMPATIBLE_NOTES="<p>The exten
 COM_JOOMLAUPDATE_VIEW_DEFAULT_EXTENSIONS_REQUIRING_UPDATES_TO_BE_COMPATIBLE="Update Required"
 COM_JOOMLAUPDATE_VIEW_DEFAULT_EXTENSIONS_REQUIRING_UPDATES_TO_BE_COMPATIBLE_NOTES="<p>Please update these extensions before updating Joomla.</p><p id='updateorangewarning' class='hidden'>Please take extra care if this updated version of the extension is not also listed as compatible with your current version of Joomla.</p>"
 COM_JOOMLAUPDATE_VIEW_DEFAULT_EXTENSIONS_UPDATE_SERVER_OFFERS_NO_COMPATIBLE_VERSION="Update Information Unavailable"
-COM_JOOMLAUPDATE_VIEW_DEFAULT_EXTENSIONS_UPDATE_SERVER_OFFERS_NO_COMPATIBLE_VERSION_NOTES="Extension does not use the Joomla update system or the developer has provided no compatibility information."
+COM_JOOMLAUPDATE_VIEW_DEFAULT_EXTENSIONS_UPDATE_SERVER_OFFERS_NO_COMPATIBLE_VERSION_NOTES="Extension does not offer an compatible version for the selected target version of Joomla. This could mean the extension does not use the Joomla update system or the developer has not provided compatibility information for this Joomla version yet."
 COM_JOOMLAUPDATE_VIEW_DEFAULT_SHOW_LESS_EXTENSION_COMPATIBILITY_INFORMATION="[ Less Detail %s ]"
 COM_JOOMLAUPDATE_VIEW_DEFAULT_SHOW_MORE_EXTENSION_COMPATIBILITY_INFORMATION="[ More Detail %s ]"
 COM_JOOMLAUPDATE_VIEW_DEFAULT_EXTENSION_COMPATIBLE="Compatible"


### PR DESCRIPTION
Pull Request for Issue #31292

### Summary of Changes

Clarify the message about extensions that do not offer an compatible version for the selected target version of Joomla. Maybe @brianteeman can check that my english is not making it even worse?

### Testing Instructions

- install 3.10
- install: http://www.crosborne.co.uk/index.php/downloads?download=4 (or any 3.x only extension)
- set the update server (Compontents -> Joomla Update -> Options -> Updatererver: Custom; Mimimum stability: Development -> URL: https://update.joomla.org/core/test/310to4_list.xml)
- Notice the message
- apply the patch
- notice the changed message

### Actual result BEFORE applying this Pull Request

![image](https://user-images.githubusercontent.com/2596554/104973464-1343c480-59f5-11eb-8c4d-25185454a845.png)

### Expected result AFTER applying this Pull Request

![image](https://user-images.githubusercontent.com/2596554/104973390-dd064500-59f4-11eb-9160-9805f97c2f0f.png)

### Documentation Changes Required

We should make clear in the docs that any 3.x only extension is going to be listed there as expected.