### PR TITLE
[4.0][CLI] handle exception from cli

### DIFF
--- a/cli/joomla.php
+++ b/cli/joomla.php
@@ -74,14 +74,14 @@ $container->alias('session', 'session.cli')
 $app = \Joomla\CMS\Factory::getContainer()->get(\Joomla\Console\Application::class);
 \Joomla\CMS\Factory::$application = $app;
 
-try 
+try
 {
- 	$app->execute();
+	$app->execute();
 }
 catch (Exception $error)
-{ 
+{
 	echo $error->getMessage() . PHP_EOL;
-	
+
 	if (JDEBUG)
 	{
 		echo $error->getTraceAsString() . PHP_EOL;

--- a/cli/joomla.php
+++ b/cli/joomla.php
@@ -73,4 +73,19 @@ $container->alias('session', 'session.cli')
 
 $app = \Joomla\CMS\Factory::getContainer()->get(\Joomla\Console\Application::class);
 \Joomla\CMS\Factory::$application = $app;
-$app->execute();
+
+try 
+{
+ 	$app->execute();
+}
+catch (Exception $error)
+{ 
+	echo $error->getMessage() . PHP_EOL;
+	
+	if (JDEBUG)
+	{
+		echo $error->getTraceAsString() . PHP_EOL;
+	}
+
+	exit;
+}


### PR DESCRIPTION
Pull Request for Issue #31984 .

### Summary of Changes

handled exception from CLI

### Testing Instructions
Install Joomla 4 perfectly.
Edit /configuration.php and change your database host to an invalid value, while there check debug=false and error_reporting = none (it would have been default).

Now run php cli/joomla.php


### Actual result BEFORE applying this Pull Request

![image](https://user-images.githubusercontent.com/181681/105018854-c5a37800-5a45-11eb-9a6e-171f674a863a.png)


### Expected result AFTER applying this Pull Request

Exception is caught and rendered nicely with the message "Could not connect to database: php_network_getaddresses: getaddrinfo failed: nodename nor servname provided, or not known""
Expect no stack trace
Expect no debug information



