### PR TITLE
[4.0] Codemirror autorefresh

### DIFF
--- a/build/build-modules-js/init.es6.js
+++ b/build/build-modules-js/init.es6.js
@@ -160,6 +160,7 @@ const copyFiles = (options) => {
 
       concatFiles(
         [
+          'media/vendor/codemirror/addon/display/autorefresh.js',
           'media/vendor/codemirror/addon/display/fullscreen.js',
           'media/vendor/codemirror/addon/display/panel.js',
           'media/vendor/codemirror/addon/edit/closebrackets.js',

--- a/plugins/editors/codemirror/codemirror.php
+++ b/plugins/editors/codemirror/codemirror.php
@@ -161,6 +161,8 @@ class PlgEditorCodemirror extends CMSPlugin
 			$options->autofocus = isset($params['autofocus']) ? (bool) $params['autofocus'] : false;
 			$autofocused = $options->autofocus;
 		}
+		// Set autorefresh to true - fixes issue when editor is not loaded in a focused tab
+		$options->autoRefresh = true;
 
 		$options->lineWrapping = (boolean) $this->params->get('lineWrapping', 1);
 


### PR DESCRIPTION
This PR adds the autorefresh addon for codemirror

To replicate the bug follow the instructions in #31908

Also test in the plugin itself where the editor is loaded on the second tab

Apply pr and nmp i

The editor loads correctly now
