### PR TITLE
[4.0] Aria controls [a11y]

### DIFF
--- a/administrator/components/com_admin/tmpl/help/default.php
+++ b/administrator/components/com_admin/tmpl/help/default.php
@@ -20,7 +20,7 @@ use Joomla\CMS\Router\Route;
 <form action="<?php echo Route::_('index.php?option=com_admin&amp;view=help'); ?>" method="post" name="adminForm" id="adminForm">
 	<div class="row mt-sm-3">
 		<div id="sidebar" class="col-md-3">
-			<button class="btn btn-sm btn-secondary my-2 options-menu d-md-none" type="button" data-toggle="collapse" data-target=".sidebar-nav" aria-controls="sidebar-nav" aria-expanded="false">
+			<button class="btn btn-sm btn-secondary my-2 options-menu d-md-none" type="button" data-toggle="collapse" data-target=".sidebar-nav" aria-controls="help-index" aria-expanded="false">
 				 <span class="icon-align-justify" aria-hidden="true"></span>
 				 <?php echo Text::_('JTOGGLE_SIDEBAR_MENU'); ?>
 			</button>

--- a/administrator/components/com_config/tmpl/application/default.php
+++ b/administrator/components/com_config/tmpl/application/default.php
@@ -32,7 +32,7 @@ Text::script('MESSAGE');
 				<span class="icon-align-justify" aria-hidden="true"></span>
 				<?php echo Text::_('JTOGGLE_SIDEBAR_MENU'); ?>
 			</button>
-			<div class="sidebar-nav bg-light p-2 my-2">
+			<div id="sidebar-nav" class="sidebar-nav bg-light p-2 my-2">
 				<?php echo $this->loadTemplate('navigation'); ?>
 			</div>
 		</div>

--- a/administrator/components/com_config/tmpl/component/default.php
+++ b/administrator/components/com_config/tmpl/component/default.php
@@ -47,7 +47,7 @@ $xml = $this->form->getXml();
 				 <span class="icon-align-justify" aria-hidden="true"></span>
 				 <?php echo Text::_('JTOGGLE_SIDEBAR_MENU'); ?>
 			</button>
-			<div class="sidebar-nav bg-light p-2 my-2">
+			<div id="sidebar-nav" class="sidebar-nav bg-light p-2 my-2">
 				<?php echo $this->loadTemplate('navigation'); ?>
 			</div>
 		</div>


### PR DESCRIPTION
Aria controls is used for some toggle buttons in mobile views as below
![image](https://user-images.githubusercontent.com/1296369/105233416-bc0f3280-5b61-11eb-8eca-b74aea403359.png)
![image](https://user-images.githubusercontent.com/1296369/105233461-ca5d4e80-5b61-11eb-9223-fc4938e103ae.png)

It is used to identify what the button controls. In these examples its the list of components and help items.

For it to work correctly then it must control an id and not a class.

This PR corrects a copy paste error to ensure that there is always a matching id