### PR TITLE
[4.0] Cassiopeia - Correct code in error.php

### DIFF
--- a/templates/cassiopeia/error.php
+++ b/templates/cassiopeia/error.php
@@ -67,11 +67,11 @@ $this->addHeadLink(HTMLHelper::_('image', 'favicon.ico', '', [], true, 1), 'alte
 $this->addHeadLink(HTMLHelper::_('image', 'joomla-favicon-pinned.svg', '', [], true, 1), 'mask-icon', 'rel', ['color' => '#000']);
 
 // Logo file or site title param
-if ($this->params->get('logoFile'))
+if ($params->get('logoFile'))
 {
 	$logo = '<img src="' . Uri::root() . htmlspecialchars($params->get('logoFile'), ENT_QUOTES) . '" alt="' . $sitename . '">';
 }
-elseif ($this->params->get('siteTitle'))
+elseif ($params->get('siteTitle'))
 {
 	$logo = '<span title="' . $sitename . '">' . htmlspecialchars($params->get('siteTitle'), ENT_COMPAT, 'UTF-8') . '</span>';
 }


### PR DESCRIPTION
Pull Request for Issue #32097 .

### Summary of Changes
Removed a $this in the code. In the error.php the parameters are called with $params and not with $this->params

### Testing Instructions
Go to the template configuration and write a title as alternative to logo. Call a page that doesn't exists. (see comments and screenshots on the issue #32097 )


### Actual result BEFORE applying this Pull Request
The title is not showed, you still see the standard Cassiopeia logo.


### Expected result AFTER applying this Pull Request
You see the title of the page.


### Documentation Changes Required

