### PR TITLE
[4.0] RTL: Correcting target blank icon placement

### DIFF
--- a/administrator/templates/atum/scss/template-rtl.scss
+++ b/administrator/templates/atum/scss/template-rtl.scss
@@ -232,3 +232,18 @@ ul {
 .btn-group > .btn-group:not(:first-child) {
   @include border-right-radius(0);
 }
+
+// Target blank icon
+a[target=_blank] {
+  &::before {
+    content: "";
+  }
+
+  &::after {
+    padding-left: 3px;
+    font-family: "Font Awesome 5 Free";
+    font-size: 14px;
+    font-weight: 900;
+    content: "";
+  }
+}


### PR DESCRIPTION
### Summary of Changes
RTL: the target blank icon should be placed before the link, i.e. to the right of it.
Using `::after` instead of `::before` solves the issue


### Testing Instructions
Display admin login in LTR (admin default language set to en-GB). 
Switch default admin language to fa-IR, logout.

Note: Do not bother about the strings which will anyway display in English as they do not exist yet in fa-IR

### Actual result BEFORE applying this Pull Request

LTR
<img width="1021" alt="target_before" src="https://user-images.githubusercontent.com/869724/105464076-46a27f80-5c91-11eb-9ca6-22b29b4c2113.png">

RTL

<img width="906" alt="Screen Shot 2021-01-22 at 09 11 31" src="https://user-images.githubusercontent.com/869724/105464435-e4964a00-5c91-11eb-9b89-abb49a1d0bb8.png">


### Expected result AFTER applying this Pull Request
RTL

<img width="867" alt="target_after" src="https://user-images.githubusercontent.com/869724/105464223-7c476880-5c91-11eb-9d04-5397f62d91ee.png">



### Documentation Changes Required

