### PR TITLE
[4.0] External link icon placement

### DIFF
--- a/administrator/templates/atum/scss/blocks/_global.scss
+++ b/administrator/templates/atum/scss/blocks/_global.scss
@@ -166,8 +166,9 @@ body .container-main {
   text-align: end !important;
 }
 
-// extern links with icons
+// external links with icons
 a[target="_blank"]::before {
+  display: inline-block;
   padding-right: 3px;
   font-family: "Font Awesome 5 Free";
   font-size: 14px;

--- a/administrator/templates/atum/scss/blocks/_global.scss
+++ b/administrator/templates/atum/scss/blocks/_global.scss
@@ -169,7 +169,7 @@ body .container-main {
 // external links with icons
 a[target="_blank"]::before {
   display: inline-block;
-  padding-right: 3px;
+  padding-inline-end: 3px;
   font-family: "Font Awesome 5 Free";
   font-size: 14px;
   font-weight: 900;


### PR DESCRIPTION
As identified by @infograf768 the placement of the icon to indicate an external link is incorrect in RTL.

Unlike his proposal which creates additional css just for the RTL to wap the class from ::before to ::after this PR does it the correct way.

The icon is still ::before the beginning of the text and now correctly identifies the direction.

No need for a separate class in the css at all. ;)

PR #32101 should be reverted and this used instead as its the correct semantic way