### PR TITLE
[4.0] Atum rtl unused

### DIFF
--- a/administrator/templates/atum/scss/template-rtl.scss
+++ b/administrator/templates/atum/scss/template-rtl.scss
@@ -54,14 +54,6 @@ ul {
   margin-left: 0;
 }
 
-.menu-toggle-icon::before {
-  content: "\f054";
-
-  .closed & {
-    content: "\f053";
-  }
-}
-
 // Status
 .status {
   margin-right: 250px;


### PR DESCRIPTION
Removes an unused class from the RTL scss.

Code review
