### PR TITLE
[4.0] Repair alignment of search icon after BS5 merge

### DIFF
--- a/templates/cassiopeia/scss/vendor/_awesomplete.scss
+++ b/templates/cassiopeia/scss/vendor/_awesomplete.scss
@@ -7,7 +7,7 @@
       @include border-end-radius(0);
     }
   }
-  .input-group-append button {
+  button {
     display: flex;
     align-items: center;
     .icon-search {


### PR DESCRIPTION
### Summary of Changes
Small change in css because of BS5


### Testing Instructions
Create a search module in the sidebar.
Install patch, run npm


### Actual result BEFORE applying this Pull Request
The search icon is not aligned to the word search
![grafik](https://user-images.githubusercontent.com/9153168/105576709-f7ce1600-5d74-11eb-8d92-33bd5e5584be.png)



### Expected result AFTER applying this Pull Request
The icon and word are aligned
![grafik](https://user-images.githubusercontent.com/9153168/105576705-f270cb80-5d74-11eb-8442-90283fa6d8f4.png)


