### PR TITLE
[4.0] Remove RTL specific css

### DIFF
--- a/administrator/templates/atum/scss/vendor/bootstrap/_dropdown.scss
+++ b/administrator/templates/atum/scss/vendor/bootstrap/_dropdown.scss
@@ -7,10 +7,7 @@
 
   joomla-toolbar-button {
     border: 0;
-
-    [dir=rtl] & {
-      text-align: right;
-    }
+    text-align: start;
   }
 }
 


### PR DESCRIPTION
With this PR we remove the need for an RTL specific class

It's my belief that with the correct css we can avoid a lot of RTL overrides

After the PR there is no visible change

### LTR
![image](https://user-images.githubusercontent.com/1296369/105577925-81c9af00-5d74-11eb-91ac-49c200903a62.png)

### RTL
![image](https://user-images.githubusercontent.com/1296369/105577930-85f5cc80-5d74-11eb-92ee-4546deabbcdb.png)
