### PR TITLE
[4.0] Modify layout for tags using BS5

### DIFF
--- a/layouts/joomla/content/tags.php
+++ b/layouts/joomla/content/tags.php
@@ -22,7 +22,7 @@ $authorised = Factory::getUser()->getAuthorisedViewLevels();
 		<?php foreach ($displayData as $i => $tag) : ?>
 			<?php if (in_array($tag->access, $authorised)) : ?>
 				<?php $tagParams = new Registry($tag->params); ?>
-				<?php $link_class = $tagParams->get('tag_link_class', 'badge bg-info'); ?>
+				<?php $link_class = $tagParams->get('tag_link_class', 'btn btn-info btn-sm'); ?>
 				<li class="list-inline-item tag-<?php echo $tag->tag_id; ?> tag-list<?php echo $i; ?>" itemprop="keywords">
 					<a href="<?php echo Route::_(RouteHelper::getTagRoute($tag->tag_id . ':' . $tag->alias)); ?>" class="<?php echo $link_class; ?>">
 						<?php echo $this->escape($tag->title); ?>

--- a/templates/cassiopeia/scss/blocks/_tags.scss
+++ b/templates/cassiopeia/scss/blocks/_tags.scss
@@ -1,0 +1,15 @@
+// Tags
+
+.tags {
+  .list-inline-item {
+    margin-bottom: .5rem;
+  }
+  a.btn {
+    font-weight: 700;
+  }
+}
+
+.tag {
+  display: inline-block;
+  padding: .5rem 0;
+}

--- a/templates/cassiopeia/scss/template.scss
+++ b/templates/cassiopeia/scss/template.scss
@@ -27,6 +27,7 @@
 @import "blocks/modifiers";
 @import "blocks/utilities";
 @import "blocks/legacy";
+@import "blocks/tags";
 @import "blocks/css-grid"; // Last to allow fallback
 
 // Vendor overrides


### PR DESCRIPTION
### Summary of Changes (modified)
Changed class badge for tags and use now btn classes as explained in the BS5 documentation:
https://getbootstrap.com/docs/5.0/components/buttons/#button-tags

Tweak some css for tags on articles and on popular tags module

Thanks to @chmst for the help ;-)

### Testing Instructions
Install blog example data. Run npm

### Actual result BEFORE applying this Pull Request
Tags are too close to each other, they are underlined, on hover the colour of the text is too dark...


### Expected result AFTER applying this Pull Request
Tags look good

![grafik](https://user-images.githubusercontent.com/9153168/105579255-b3974180-5d85-11eb-9a53-cfa6baecdc17.png)

![grafik](https://user-images.githubusercontent.com/9153168/105579267-c7db3e80-5d85-11eb-83ef-8432e820cbc7.png)

