### PR TITLE
[4.0] Remove header page title css

### DIFF
--- a/administrator/templates/atum/scss/template-rtl.scss
+++ b/administrator/templates/atum/scss/template-rtl.scss
@@ -30,16 +30,6 @@ ul {
 
 // Header
 .header {
-  .page-title {
-    [class^="#{$jicon-css-prefix}-"],
-    [class*=" #{$jicon-css-prefix}-"],
-    [class^="#{$fa-css-prefix}-"],
-    [class*=" #{$fa-css-prefix}-"] {
-      margin-right: 0;
-      margin-left: 15px;
-    }
-  }
-
   .logo svg,
   .logo img {
     margin-right: .8rem;


### PR DESCRIPTION
This css should have been removed a long time ago when @ciar4n changed the _header.scss in  #28589

