### PR TITLE
[4.0] RTL: wrong float in Associations manager

### DIFF
--- a/administrator/components/com_associations/tmpl/associations/default.php
+++ b/administrator/components/com_associations/tmpl/associations/default.php
@@ -106,7 +106,7 @@ Text::script('COM_ASSOCIATIONS_PURGE_CONFIRM_PROMPT', true);
 									</td>
 								<?php endif; ?>
 								<th scope="row" class="has-context">
-									<div class="float-start break-word">
+									<div class="break-word">
 										<?php if (isset($item->level)) : ?>
 											<?php echo LayoutHelper::render('joomla.html.treeprefix', array('level' => $item->level)); ?>
 										<?php endif; ?>


### PR DESCRIPTION
### Summary of Changes
as title says, useless float for the title column


### Testing Instructions
Clean install with at least 2 languages including Persian. Set the site as multilingual by installing sample data
Set Persian as default admin language
Load com_associations => articles
Look at the Title column


### Actual result BEFORE applying this Pull Request

<img width="1031" alt="Screen Shot 2021-01-24 at 07 15 36" src="https://user-images.githubusercontent.com/869724/105622835-023fec80-5e15-11eb-87c7-6be1dfd0a952.png">


### Expected result AFTER applying this Pull Request

<img width="1053" alt="Screen Shot 2021-01-24 at 07 16 44" src="https://user-images.githubusercontent.com/869724/105622840-0b30be00-5e15-11eb-802b-9b5c65cb8cc7.png">


