### PR TITLE
[4.0] Modal close rtl

### DIFF
--- a/administrator/templates/atum/scss/template-rtl.scss
+++ b/administrator/templates/atum/scss/template-rtl.scss
@@ -211,3 +211,9 @@ ul {
 .btn-group > .btn-group:not(:first-child) {
   @include border-end-radius(0);
 }
+
+.modal-header {
+  .btn-close {
+    margin: -.5rem auto -.5rem -.5rem;
+  }
+}


### PR DESCRIPTION
Apply PR
rebuild css

The modal close X is now correctly in the top left and with correct margins

![image](https://user-images.githubusercontent.com/1296369/105625502-ae87d000-5e21-11eb-82e4-c7421a3ea674.png)
