### PR TITLE
[4.0] RTL: wrong float-start in fields groups and Useless float-start in com_templates

### DIFF
--- a/administrator/components/com_fields/tmpl/groups/default.php
+++ b/administrator/components/com_fields/tmpl/groups/default.php
@@ -118,7 +118,7 @@ $context = $this->escape($this->state->get('filter.context'));
 										<?php echo HTMLHelper::_('jgrid.published', $item->state, $i, 'groups.', $canChange, 'cb'); ?>
 									</td>
 									<th scope="row">
-										<div class="float-start break-word">
+										<div class="break-word">
 											<?php if ($item->checked_out) : ?>
 												<?php echo HTMLHelper::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, 'groups.', $canCheckin); ?>
 											<?php endif; ?>

--- a/administrator/components/com_templates/src/Service/HTML/Templates.php
+++ b/administrator/components/com_templates/src/Service/HTML/Templates.php
@@ -49,7 +49,7 @@ class Templates
 
 			if (file_exists($preview))
 			{
-				$html = '<button type="button" data-bs-target="#' . $template . '-Modal" class="thumbnail float-start" data-bs-toggle="modal" title="'. Text::_('COM_TEMPLATES_CLICK_TO_ENLARGE') . '">' . $html . '</button>';
+				$html = '<button type="button" data-bs-target="#' . $template . '-Modal" class="thumbnail" data-bs-toggle="modal" title="'. Text::_('COM_TEMPLATES_CLICK_TO_ENLARGE') . '">' . $html . '</button>';
 			}
 		}
 

--- a/administrator/components/com_templates/tmpl/template/default_description.php
+++ b/administrator/components/com_templates/tmpl/template/default_description.php
@@ -17,7 +17,7 @@ use Joomla\Component\Templates\Administrator\Helper\TemplatesHelper;
 ?>
 
 <div class="clearfix">
-	<div class="float-start me-3 text-center">
+	<div class="me-3 text-center">
 		<?php echo HTMLHelper::_('templates.thumb', $this->template->element, $this->template->client_id); ?>
 		<?php echo HTMLHelper::_('templates.thumbModal', $this->template->element, $this->template->client_id); ?>
 	</div>

--- a/administrator/components/com_templates/tmpl/template/default_description.php
+++ b/administrator/components/com_templates/tmpl/template/default_description.php
@@ -17,7 +17,7 @@ use Joomla\Component\Templates\Administrator\Helper\TemplatesHelper;
 ?>
 
 <div class="clearfix">
-	<div class="me-3 text-center">
+	<div class="float-start me-3 text-center">
 		<?php echo HTMLHelper::_('templates.thumb', $this->template->element, $this->template->client_id); ?>
 		<?php echo HTMLHelper::_('templates.thumbModal', $this->template->element, $this->template->client_id); ?>
 	</div>


### PR DESCRIPTION
### Summary of Changes
take off float-start class when unnecessary


### Testing Instructions
Create a field group for articles
install Persian. Switch admin to Persian language
go to `administrator/index.php?option=com_fields&view=groups&context=com_content.article`

As for com_templates, go to
`administrator/index.php?option=com_templates&view=templates&client_id=0`
Look at the thumb


### Actual result BEFORE applying this Pull Request

fields groups:

<img width="1098" alt="fieldsgroupstitlebefore" src="https://user-images.githubusercontent.com/869724/105626752-26f68d00-5e32-11eb-8588-99c1f2baed6f.png">



### Expected result AFTER applying this Pull Request

<img width="1098" alt="fieldsgroupstitleafter" src="https://user-images.githubusercontent.com/869724/105626754-2c53d780-5e32-11eb-94e6-dde59c372494.png">

for the template no change

<img width="1090" alt="Screen Shot 2021-01-24 at 11 09 40" src="https://user-images.githubusercontent.com/869724/105627075-bef57600-5e34-11eb-8edb-32d3b6f4504d.png">


### Documentation Changes Required

