### PR TITLE
[4.0] make the Bootstrap build script v10 compatible

### DIFF
--- a/build/build-modules-js/build-bootstrap-js.es6.js
+++ b/build/build-modules-js/build-bootstrap-js.es6.js
@@ -1,5 +1,5 @@
 const {
-  readdir, readFile, rename, writeFile, rm,
+  readdir, readFile, rename, writeFile, unlink,
 } = require('fs').promises;
 const { resolve } = require('path');
 const { minify } = require('terser');
@@ -119,7 +119,7 @@ const buildLegacy = async () => {
 
   try {
     await build(resolve(inputFolder, 'index.es6.js'));
-    await rm(resolve(outputFolder, 'index.es6.js'));
+    await unlink(resolve(outputFolder, 'index.es6.js'));
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error(error);


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/32135 .

### Summary of Changes

Replace `rm` which is new and requires nodejs v14 to `unlink`

### Testing Instructions

run `npm install` and check that the `media/vendor/bootstrap/js` has all the needed files there (the `rm` was removing a file `index.es6.js`


### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Documentation Changes Required

