### PR TITLE
[4.0] sass deprecations

### DIFF
--- a/administrator/templates/atum/scss/_variables.scss
+++ b/administrator/templates/atum/scss/_variables.scss
@@ -19,7 +19,7 @@ $light-blue:                       #2a69b8; //is the atum-link-color
 $focusshadow:                      0 0 0 .2rem #eaeaea;
 
 // BS Colours
-$blue:                             hsl(213, 63, 44%); // base color for calculation, Primary-color
+$blue:                             hsl(213, 63%, 44%); // base color for calculation, Primary-color
 $indigo:                           #0377be; //used in bootstrap
 $purple:                           #6f42c1; //used in bootstrap
 $pink:                             #971250; //used in bootstrap
@@ -81,15 +81,15 @@ $colors: (
   atum-link-color:                 $light-blue,
   atum-link-hover-color:           darken($light-blue, 20%),
   atum-contrast:                   $light-blue,
-  atum-bg-dark-5:                  adjust-color($base-color, $hue: -6%, $saturation: -85%, $lightness: +65.1%),
-  atum-bg-dark-10:                 adjust-color($base-color, $hue: -6%, $saturation: -80%, $lightness: +59.4%),
-  atum-bg-dark-20:                 adjust-color($base-color, $hue: -6%, $saturation: -75%, $lightness: +47.3%),
-  atum-bg-dark-30:                 adjust-color($base-color, $hue: -5%, $saturation: -55%, $lightness: +34.3%),
-  atum-bg-dark-40:                 adjust-color($base-color, $hue: -3%, $saturation: -40%, $lightness: +21.4%),
-  atum-bg-dark-50:                 adjust-color($base-color, $hue: -1%, $saturation: -15%, $lightness: +10%),
-  atum-bg-dark-70:                 adjust-color($base-color, $hue: +4%, $lightness: -6%),
-  atum-bg-dark-80:                 adjust-color($base-color, $hue: +7%, $lightness: -11.5%),
-  atum-bg-dark-90:                 adjust-color($base-color, $hue: +10%, $saturation: -1%, $lightness: -17%)
+  atum-bg-dark-5:                  adjust-color($base-color, $hue: -6, $saturation: -85%, $lightness: +65.1%),
+  atum-bg-dark-10:                 adjust-color($base-color, $hue: -6, $saturation: -80%, $lightness: +59.4%),
+  atum-bg-dark-20:                 adjust-color($base-color, $hue: -6, $saturation: -75%, $lightness: +47.3%),
+  atum-bg-dark-30:                 adjust-color($base-color, $hue: -5, $saturation: -55%, $lightness: +34.3%),
+  atum-bg-dark-40:                 adjust-color($base-color, $hue: -3, $saturation: -40%, $lightness: +21.4%),
+  atum-bg-dark-50:                 adjust-color($base-color, $hue: -1, $saturation: -15%, $lightness: +10%),
+  atum-bg-dark-70:                 adjust-color($base-color, $hue: +4, $lightness: -6%),
+  atum-bg-dark-80:                 adjust-color($base-color, $hue: +7, $lightness: -11.5%),
+  atum-bg-dark-90:                 adjust-color($base-color, $hue: +10, $saturation: -1%, $lightness: -17%)
 );
 
 // Alerts


### PR DESCRIPTION
https://sass-lang.com/documentation/breaking-changes/color-units

Compiling the scss with this updated version produced a lot of deprecation warnings.

After updating the variables with their recommendations there are no more deprecation warnings.

I ran a diff between the template.css before and after and there were no changes so the changes have no impact.

Pull Request for Issue #32111 
