### PR TITLE
[4.0] Use a bootstrap global object

### DIFF
--- a/build/.eslintrc
+++ b/build/.eslintrc
@@ -21,7 +21,8 @@
   // Additional global variables your script accesses during execution
   "globals": {
     "Joomla": true,
-	"MediaManager" : true
+	"MediaManager" : true,
+	"bootstrap": true,
   },
   // Rule overrides
   "rules": {

--- a/build/media_source/mod_multilangstatus/js/admin-multilangstatus.es6.js
+++ b/build/media_source/mod_multilangstatus/js/admin-multilangstatus.es6.js
@@ -21,7 +21,7 @@
       document.body.appendChild(clone);
 
       // Modal was moved so it needs to be re initialised
-      Joomla.Bootstrap.Initialise.Modal(clone);
+      Joomla.initialiseModal(clone);
     }
   });
 })();

--- a/build/media_source/system/js/fields/joomla-field-media.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-media.w-c.es6.js
@@ -98,11 +98,10 @@
 
       // Bootstrap modal init
       if (this.modalElement
-        && Joomla.Bootstrap
-        && Joomla.Bootstrap.Instances
-        && Joomla.Bootstrap.Instances.Modal
-        && Joomla.Bootstrap.Instances.Modal.get(this.modalElement) === undefined) {
-        Joomla.Bootstrap.Initialise.Modal(this.modalElement, { isJoomla: true });
+        && bootstrap
+        && bootstrap.Modal
+        && bootstrap.Modal.getInstance(this.modalElement) === undefined) {
+        Joomla.initialiseModal(this.modalElement, { isJoomla: true });
       }
 
       if (this.buttonClearEl) {

--- a/build/media_source/system/js/fields/joomla-field-user.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-user.w-c.es6.js
@@ -55,11 +55,10 @@
 
       // Bootstrap modal init
       if (this.modal
-        && Joomla.Bootstrap
-        && Joomla.Bootstrap.Instances
-        && Joomla.Bootstrap.Instances.Modal
-        && Joomla.Bootstrap.Instances.Modal.get(this.modal) === undefined) {
-        Joomla.Bootstrap.Initialise.Modal(this.modal, { isJoomla: true });
+        && bootstrap
+        && bootstrap.Modal
+        && bootstrap.Modal.getInstance(this.modal) === undefined) {
+        Joomla.initialiseModal(this.modal, { isJoomla: true });
       }
 
       if (this.buttonSelect) {

--- a/build/media_source/vendor/bootstrap/js/alert.es6.js
+++ b/build/media_source/vendor/bootstrap/js/alert.es6.js
@@ -1,25 +1,7 @@
 import Alert from '../../../../../node_modules/bootstrap/js/src/alert';
 
-Joomla = Joomla || {};
-Joomla.Bootstrap = Joomla.Bootstrap || {};
-Joomla.Bootstrap.Initialise = Joomla.Bootstrap.Initialise || {};
-Joomla.Bootstrap.Instances = Joomla.Bootstrap.Instances || {};
-Joomla.Bootstrap.Instances.Alert = new WeakMap();
-
-/**
- * Initialise the Alert iteractivity
- *
- * @param {HTMLElement} el The element that will become an Alert
- */
-Joomla.Bootstrap.Initialise.Alert = (el) => {
-  if (!(el instanceof Element)) {
-    return;
-  }
-  if (Joomla.Bootstrap.Instances.Alert.get(el) && el.dispose) {
-    el.dispose();
-  }
-  Joomla.Bootstrap.Instances.Alert.set(el, new Alert(el));
-};
+window.bootstrap = window.bootstrap || {};
+window.Bootstrap.Alert = Alert;
 
 // Ensure vanilla mode, for consistency of the events
 if (!Object.prototype.hasOwnProperty.call(document.body.dataset, 'bsNoJquery')) {
@@ -32,7 +14,7 @@ const alerts = Joomla.getOptions('bootstrap.alert');
 if (alerts && alerts.length) {
   alerts.forEach((selector) => {
     Array.from(document.querySelectorAll(selector))
-      .map((el) => Joomla.Bootstrap.Initialise.Alert(el));
+      .map((el) => new window.bootstrap.Alert(el));
   });
 }
 

--- a/build/media_source/vendor/bootstrap/js/alert.es6.js
+++ b/build/media_source/vendor/bootstrap/js/alert.es6.js
@@ -1,7 +1,7 @@
 import Alert from '../../../../../node_modules/bootstrap/js/src/alert';
 
 window.bootstrap = window.bootstrap || {};
-window.Bootstrap.Alert = Alert;
+window.bootstrap.Alert = Alert;
 
 // Ensure vanilla mode, for consistency of the events
 if (!Object.prototype.hasOwnProperty.call(document.body.dataset, 'bsNoJquery')) {

--- a/build/media_source/vendor/bootstrap/js/alert.es6.js
+++ b/build/media_source/vendor/bootstrap/js/alert.es6.js
@@ -8,14 +8,16 @@ if (!Object.prototype.hasOwnProperty.call(document.body.dataset, 'bsNoJquery')) 
   document.body.dataset.bsNoJquery = '';
 }
 
-// Get the elements/configurations from the PHP
-const alerts = Joomla.getOptions('bootstrap.alert');
-// Initialise the elements
-if (alerts && alerts.length) {
-  alerts.forEach((selector) => {
-    Array.from(document.querySelectorAll(selector))
-      .map((el) => new window.bootstrap.Alert(el));
-  });
+if (Joomla && Joomla.getOptions) {
+  // Get the elements/configurations from the PHP
+  const alerts = Joomla.getOptions('bootstrap.alert');
+  // Initialise the elements
+  if (alerts && alerts.length) {
+    alerts.forEach((selector) => {
+      Array.from(document.querySelectorAll(selector))
+        .map((el) => new window.bootstrap.Alert(el));
+    });
+  }
 }
 
 export default Alert;

--- a/build/media_source/vendor/bootstrap/js/button.es6.js
+++ b/build/media_source/vendor/bootstrap/js/button.es6.js
@@ -1,25 +1,7 @@
 import Button from '../../../../../node_modules/bootstrap/js/src/button';
 
-Joomla = Joomla || {};
-Joomla.Bootstrap = Joomla.Bootstrap || {};
-Joomla.Bootstrap.Initialise = Joomla.Bootstrap.Initialise || {};
-Joomla.Bootstrap.Instances = Joomla.Bootstrap.Instances || {};
-Joomla.Bootstrap.Instances.Button = new WeakMap();
-
-/**
- * Initialise the Button iteractivity
- *
- * @param {HTMLElement} el The element that will become an Button
- */
-Joomla.Bootstrap.Initialise.Button = (el) => {
-  if (!(el instanceof Element)) {
-    return;
-  }
-  if (Joomla.Bootstrap.Instances.Button.get(el) && el.dispose) {
-    el.dispose();
-  }
-  Joomla.Bootstrap.Instances.Button.set(el, new Button(el));
-};
+window.bootstrap = window.bootstrap || {};
+window.bootstrap.Button = Button;
 
 // Ensure vanilla mode, for consistency of the events
 if (!Object.prototype.hasOwnProperty.call(document.body.dataset, 'bsNoJquery')) {
@@ -32,7 +14,7 @@ const buttons = Joomla.getOptions('bootstrap.button');
 if (buttons && buttons.length) {
   buttons.forEach((selector) => {
     Array.from(document.querySelectorAll(selector))
-      .map((el) => Joomla.Bootstrap.Initialise.Button(el));
+      .map((el) => new window.bootstrap.Button(el));
   });
 }
 

--- a/build/media_source/vendor/bootstrap/js/button.es6.js
+++ b/build/media_source/vendor/bootstrap/js/button.es6.js
@@ -8,14 +8,16 @@ if (!Object.prototype.hasOwnProperty.call(document.body.dataset, 'bsNoJquery')) 
   document.body.dataset.bsNoJquery = '';
 }
 
-// Get the elements/configurations from the PHP
-const buttons = Joomla.getOptions('bootstrap.button');
-// Initialise the elements
-if (buttons && buttons.length) {
-  buttons.forEach((selector) => {
-    Array.from(document.querySelectorAll(selector))
-      .map((el) => new window.bootstrap.Button(el));
-  });
+if (Joomla && Joomla.getOptions) {
+  // Get the elements/configurations from the PHP
+  const buttons = Joomla.getOptions('bootstrap.button');
+  // Initialise the elements
+  if (buttons && buttons.length) {
+    buttons.forEach((selector) => {
+      Array.from(document.querySelectorAll(selector))
+        .map((el) => new window.bootstrap.Button(el));
+    });
+  }
 }
 
 export default Button;

--- a/build/media_source/vendor/bootstrap/js/carousel.es6.js
+++ b/build/media_source/vendor/bootstrap/js/carousel.es6.js
@@ -1,26 +1,7 @@
 import Carousel from '../../../../../node_modules/bootstrap/js/src/carousel';
 
-Joomla = Joomla || {};
-Joomla.Bootstrap = Joomla.Bootstrap || {};
-Joomla.Bootstrap.Initialise = Joomla.Bootstrap.Initialise || {};
-Joomla.Bootstrap.Instances = Joomla.Bootstrap.Instances || {};
-Joomla.Bootstrap.Instances.Carousel = new WeakMap();
-
-/**
- * Initialise the Carousel iteractivity
- *
- * @param {HTMLElement} el The element that will become an Carousel
- * @param {object} options The options for this carousel
- */
-Joomla.Bootstrap.Initialise.Carousel = (el, options) => {
-  if (!(el instanceof Element)) {
-    return;
-  }
-  if (Joomla.Bootstrap.Instances.Carousel.get(el) && el.dispose) {
-    el.dispose();
-  }
-  Joomla.Bootstrap.Instances.Carousel.set(el, new Carousel(el, options));
-};
+window.bootstrap = window.bootstrap || {};
+window.bootstrap.Carousel = Carousel;
 
 // Get the elements/configurations from the PHP
 const carousels = Joomla.getOptions('bootstrap.carousel');
@@ -44,7 +25,7 @@ if (typeof carousels === 'object' && carousels !== null) {
 
     const elements = Array.from(document.querySelectorAll(carousel));
     if (elements.length) {
-      elements.map((el) => Joomla.Bootstrap.Initialise.Carousel(el, options));
+      elements.map((el) => new window.bootstrap.Carousel(el, options));
     }
   });
 }

--- a/build/media_source/vendor/bootstrap/js/carousel.es6.js
+++ b/build/media_source/vendor/bootstrap/js/carousel.es6.js
@@ -3,31 +3,33 @@ import Carousel from '../../../../../node_modules/bootstrap/js/src/carousel';
 window.bootstrap = window.bootstrap || {};
 window.bootstrap.Carousel = Carousel;
 
-// Get the elements/configurations from the PHP
-const carousels = Joomla.getOptions('bootstrap.carousel');
-
-// Force Vanilla mode!
+// Ensure vanilla mode, for consistency of the events
 if (!Object.prototype.hasOwnProperty.call(document.body.dataset, 'bsNoJquery')) {
   document.body.dataset.bsNoJquery = '';
 }
-// Initialise the elements
-if (typeof carousels === 'object' && carousels !== null) {
-  Object.keys(carousels).forEach((carousel) => {
-    const opt = carousels[carousel];
-    const options = {
-      interval: opt.interval ? opt.interval : 5000,
-      keyboard: opt.keyboard ? opt.keyboard : true,
-      pause: opt.pause ? opt.pause : 'hover',
-      slide: opt.slide ? opt.slide : false,
-      wrap: opt.wrap ? opt.wrap : true,
-      touch: opt.touch ? opt.touch : true,
-    };
 
-    const elements = Array.from(document.querySelectorAll(carousel));
-    if (elements.length) {
-      elements.map((el) => new window.bootstrap.Carousel(el, options));
-    }
-  });
+if (Joomla && Joomla.getOptions) {
+  // Get the elements/configurations from the PHP
+  const carousels = Joomla.getOptions('bootstrap.carousel');
+  // Initialise the elements
+  if (typeof carousels === 'object' && carousels !== null) {
+    Object.keys(carousels).forEach((carousel) => {
+      const opt = carousels[carousel];
+      const options = {
+        interval: opt.interval ? opt.interval : 5000,
+        keyboard: opt.keyboard ? opt.keyboard : true,
+        pause: opt.pause ? opt.pause : 'hover',
+        slide: opt.slide ? opt.slide : false,
+        wrap: opt.wrap ? opt.wrap : true,
+        touch: opt.touch ? opt.touch : true,
+      };
+
+      const elements = Array.from(document.querySelectorAll(carousel));
+      if (elements.length) {
+        elements.map((el) => new window.bootstrap.Carousel(el, options));
+      }
+    });
+  }
 }
 
 export default Carousel;

--- a/build/media_source/vendor/bootstrap/js/collapse.es6.js
+++ b/build/media_source/vendor/bootstrap/js/collapse.es6.js
@@ -1,26 +1,7 @@
 import Collapse from '../../../../../node_modules/bootstrap/js/src/collapse';
 
-Joomla = Joomla || {};
-Joomla.Bootstrap = Joomla.Bootstrap || {};
-Joomla.Bootstrap.Initialise = Joomla.Bootstrap.Initialise || {};
-Joomla.Bootstrap.Instances = Joomla.Bootstrap.Instances || {};
-Joomla.Bootstrap.Instances.Collapse = new WeakMap();
-
-/**
- * Initialise the Collapse iteractivity
- *
- * @param {HTMLElement} el The element that will become an collapse
- * @param {object} options The options for this collapse
- */
-Joomla.Bootstrap.Initialise.Collapse = (el, options) => {
-  if (!(el instanceof Element)) {
-    return;
-  }
-  if (Joomla.Bootstrap.Instances.Collapse.get(el) && el.dispose) {
-    el.dispose();
-  }
-  Joomla.Bootstrap.Instances.Collapse.set(el, new Collapse(el, options));
-};
+window.bootstrap = window.bootstrap || {};
+window.bootstrap.Collapse = Collapse;
 
 // Ensure vanilla mode, for consistency of the events
 if (!Object.prototype.hasOwnProperty.call(document.body.dataset, 'bsNoJquery')) {
@@ -43,7 +24,7 @@ if (typeof collapses === 'object' && collapses !== null) {
 
     const elements = Array.from(document.querySelectorAll(collapse));
     if (elements.length) {
-      elements.map((el) => Joomla.Bootstrap.Initialise.Collapse(el, options));
+      elements.map((el) => new window.bootstrap.Collapse(el, options));
     }
   });
 }

--- a/build/media_source/vendor/bootstrap/js/collapse.es6.js
+++ b/build/media_source/vendor/bootstrap/js/collapse.es6.js
@@ -8,10 +8,10 @@ if (!Object.prototype.hasOwnProperty.call(document.body.dataset, 'bsNoJquery')) 
   document.body.dataset.bsNoJquery = '';
 }
 
-// Get the elements/configurations from the PHP
-const collapses = { ...Joomla.getOptions('bootstrap.collapse'), ...Joomla.getOptions('bootstrap.accordion') };
-// Initialise the elements
-if (typeof collapses === 'object' && collapses !== null) {
+if (Joomla && Joomla.getOptions) {
+  // Get the elements/configurations from the PHP
+  const collapses = { ...Joomla.getOptions('bootstrap.collapse'), ...Joomla.getOptions('bootstrap.accordion') };
+  // Initialise the elements
   Object.keys(collapses).forEach((collapse) => {
     const opt = collapses[collapse];
     const options = {

--- a/build/media_source/vendor/bootstrap/js/dropdown.es6.js
+++ b/build/media_source/vendor/bootstrap/js/dropdown.es6.js
@@ -8,22 +8,24 @@ if (!Object.prototype.hasOwnProperty.call(document.body.dataset, 'bsNoJquery')) 
   document.body.dataset.bsNoJquery = '';
 }
 
-// Get the elements/configurations from the PHP
-const dropdowns = Joomla.getOptions('bootstrap.dropdown');
-// Initialise the elements
-if (typeof dropdowns === 'object' && dropdowns !== null) {
-  Object.keys(dropdowns).forEach((dropdown) => {
-    const opt = dropdowns[dropdown];
-    const options = {
-      interval: opt.interval ? opt.interval : 5000,
-      pause: opt.pause ? opt.pause : 'hover',
-    };
+if (Joomla && Joomla.getOptions) {
+  // Get the elements/configurations from the PHP
+  const dropdowns = Joomla.getOptions('bootstrap.dropdown');
+  // Initialise the elements
+  if (typeof dropdowns === 'object' && dropdowns !== null) {
+    Object.keys(dropdowns).forEach((dropdown) => {
+      const opt = dropdowns[dropdown];
+      const options = {
+        interval: opt.interval ? opt.interval : 5000,
+        pause: opt.pause ? opt.pause : 'hover',
+      };
 
-    const elements = Array.from(document.querySelectorAll(dropdown));
-    if (elements.length) {
-      elements.map((el) => new window.bootstrap.Dropdown(el, options));
-    }
-  });
+      const elements = Array.from(document.querySelectorAll(dropdown));
+      if (elements.length) {
+        elements.map((el) => new window.bootstrap.Dropdown(el, options));
+      }
+    });
+  }
 }
 
 export default Dropdown;

--- a/build/media_source/vendor/bootstrap/js/dropdown.es6.js
+++ b/build/media_source/vendor/bootstrap/js/dropdown.es6.js
@@ -1,26 +1,7 @@
 import Dropdown from '../../../../../node_modules/bootstrap/js/src/dropdown';
 
-Joomla = Joomla || {};
-Joomla.Bootstrap = Joomla.Bootstrap || {};
-Joomla.Bootstrap.Initialise = Joomla.Bootstrap.Initialise || {};
-Joomla.Bootstrap.Instances = Joomla.Bootstrap.Instances || {};
-Joomla.Bootstrap.Instances.Dropdown = new WeakMap();
-
-/**
- * Initialise the iteractivity
- *
- * @param {HTMLElement} el The element that will become an dropdown
- * @param {object} options The options for this dropdown
- */
-Joomla.Bootstrap.Initialise.Dropdown = (el, options) => {
-  if (!(el instanceof Element)) {
-    return;
-  }
-  if (Joomla.Bootstrap.Instances.Dropdown.get(el) && el.dispose) {
-    el.dispose();
-  }
-  Joomla.Bootstrap.Instances.Dropdown.set(el, new Dropdown(el, options));
-};
+window.bootstrap = window.bootstrap || {};
+window.bootstrap.Dropdown = Dropdown;
 
 // Ensure vanilla mode, for consistency of the events
 if (!Object.prototype.hasOwnProperty.call(document.body.dataset, 'bsNoJquery')) {
@@ -40,7 +21,7 @@ if (typeof dropdowns === 'object' && dropdowns !== null) {
 
     const elements = Array.from(document.querySelectorAll(dropdown));
     if (elements.length) {
-      elements.map((el) => Joomla.Bootstrap.Initialise.Dropdown(el, options));
+      elements.map((el) => new window.bootstrap.Dropdown(el, options));
     }
   });
 }

--- a/build/media_source/vendor/bootstrap/js/modal.es6.js
+++ b/build/media_source/vendor/bootstrap/js/modal.es6.js
@@ -1,23 +1,21 @@
 import Modal from '../../../../../node_modules/bootstrap/js/src/modal';
 
 Joomla = Joomla || {};
-Joomla.Bootstrap = Joomla.Bootstrap || {};
-Joomla.Bootstrap.Initialise = Joomla.Bootstrap.Initialise || {};
-Joomla.Bootstrap.Instances = Joomla.Bootstrap.Instances || {};
-Joomla.Bootstrap.Instances.Modal = new WeakMap();
+Joomla.Modal = Joomla.Modal || {};
+window.bootstrap = window.bootstrap || {};
+window.bootstrap.Modal = Modal;
 
-Joomla.Bootstrap.Initialise.Modal = (modal, options) => {
+Joomla.initialiseModal = (modal, options) => {
   if (!(modal instanceof Element)) {
     return;
   }
-  if (Joomla.Bootstrap.Instances.Modal.get(modal) && modal.dispose) {
-    modal.dispose();
-  }
-  Joomla.Bootstrap.Instances.Modal.set(modal, new Modal(modal, options));
+
+  // eslint-disable-next-line no-new
+  new window.bootstrap.Modal(modal, options);
 
   // Comply with the Joomla API - Bound element.open/close
-  modal.open = () => { Joomla.Bootstrap.Instances.Modal.get(modal).show(modal); };
-  modal.close = () => { Joomla.Bootstrap.Instances.Modal.get(modal).hide(); };
+  modal.open = () => { window.bootstrap.Modal.getInstance(modal).show(modal); };
+  modal.close = () => { window.bootstrap.Modal.getInstance(modal).hide(); };
 
   // Do some Joomla specific changes
   modal.addEventListener('show.bs.modal', () => {
@@ -145,7 +143,6 @@ const modals = Joomla.getOptions('bootstrap.modal');
 // Initialise the elements
 if (typeof modals === 'object' && modals !== null) {
   Object.keys(modals).forEach((modal) => {
-    const modalEl = document.querySelector(modal);
     const opt = modals[modal];
     const options = {
       backdrop: opt.backdrop ? opt.backdrop : true,
@@ -153,9 +150,8 @@ if (typeof modals === 'object' && modals !== null) {
       focus: opt.focus ? opt.focus : true,
     };
 
-    if (modalEl) {
-      Joomla.Bootstrap.Initialise.Modal(modalEl, options);
-    }
+    Array.from(document.querySelectorAll(modal))
+      .map((modalEl) => Joomla.initialiseModal(modalEl, options));
   });
 }
 

--- a/build/media_source/vendor/bootstrap/js/modal.es6.js
+++ b/build/media_source/vendor/bootstrap/js/modal.es6.js
@@ -138,21 +138,23 @@ if (!Object.prototype.hasOwnProperty.call(document.body.dataset, 'bsNoJquery')) 
   document.body.dataset.bsNoJquery = '';
 }
 
-// Get the elements/configurations from the PHP
-const modals = Joomla.getOptions('bootstrap.modal');
-// Initialise the elements
-if (typeof modals === 'object' && modals !== null) {
-  Object.keys(modals).forEach((modal) => {
-    const opt = modals[modal];
-    const options = {
-      backdrop: opt.backdrop ? opt.backdrop : true,
-      keyboard: opt.keyboard ? opt.keyboard : true,
-      focus: opt.focus ? opt.focus : true,
-    };
+if (Joomla && Joomla.getOptions) {
+  // Get the elements/configurations from the PHP
+  const modals = Joomla.getOptions('bootstrap.modal');
+  // Initialise the elements
+  if (typeof modals === 'object' && modals !== null) {
+    Object.keys(modals).forEach((modal) => {
+      const opt = modals[modal];
+      const options = {
+        backdrop: opt.backdrop ? opt.backdrop : true,
+        keyboard: opt.keyboard ? opt.keyboard : true,
+        focus: opt.focus ? opt.focus : true,
+      };
 
-    Array.from(document.querySelectorAll(modal))
-      .map((modalEl) => Joomla.initialiseModal(modalEl, options));
-  });
+      Array.from(document.querySelectorAll(modal))
+        .map((modalEl) => Joomla.initialiseModal(modalEl, options));
+    });
+  }
 }
 
 export default Modal;

--- a/build/media_source/vendor/bootstrap/js/popover.es6.js
+++ b/build/media_source/vendor/bootstrap/js/popover.es6.js
@@ -1,41 +1,9 @@
 import Popover from '../../../../../node_modules/bootstrap/js/src/popover';
 import Tooltip from '../../../../../node_modules/bootstrap/js/src/tooltip';
 
-Joomla = Joomla || {};
-Joomla.Bootstrap = Joomla.Bootstrap || {};
-Joomla.Bootstrap.Initialise = Joomla.Bootstrap.Initialise || {};
-Joomla.Bootstrap.Instances = Joomla.Bootstrap.Instances || {};
-Joomla.Bootstrap.Instances.Popover = new WeakMap();
-Joomla.Bootstrap.Instances.Tooltip = new WeakMap();
-
-/**
- * Initialise the Popover iteractivity
- *
- * @param {HTMLElement} el The element that will become an popover
- * @param {object} options The options for this popover
- */
-Joomla.Bootstrap.Initialise.Popover = (el, options) => {
-  if (!(el instanceof Element)) {
-    return;
-  }
-  if (Joomla.Bootstrap.Instances.Popover.get(el) && el.dispose) {
-    el.dispose();
-  }
-  Joomla.Bootstrap.Instances.Popover.set(el, new Popover(el, options));
-};
-
-/**
- * Initialise the Tooltip iteractivity
- *
- * @param {HTMLElement} el The element that will become an tooltip
- * @param {object} options The options for this tooltip
- */
-Joomla.Bootstrap.Initialise.Tooltip = (el, options) => {
-  if (Joomla.Bootstrap.Instances.Tooltip.get(el) && el.dispose) {
-    el.dispose();
-  }
-  Joomla.Bootstrap.Instances.Tooltip.set(el, new Tooltip(el, options));
-};
+window.bootstrap = window.bootstrap || {};
+window.bootstrap.Popover = Popover;
+window.bootstrap.Tooltip = Tooltip;
 
 // Ensure vanilla mode, for consistency of the events
 if (!Object.prototype.hasOwnProperty.call(document.body.dataset, 'bsNoJquery')) {
@@ -77,7 +45,7 @@ if (typeof popovers === 'object' && popovers !== null) {
 
     const elements = Array.from(document.querySelectorAll(popover));
     if (elements.length) {
-      elements.map((el) => Joomla.Bootstrap.Initialise.Popover(el, options));
+      elements.map((el) => new window.bootstrap.Popover(el, options));
     }
   });
 }
@@ -113,7 +81,7 @@ if (typeof tooltips === 'object' && tooltips !== null) {
 
     const elements = Array.from(document.querySelectorAll(tooltip));
     if (elements.length) {
-      elements.map((el) => Joomla.Bootstrap.Initialise.Tooltip(el, options));
+      elements.map((el) => new window.bootstrap.Tooltip(el, options));
     }
   });
 }

--- a/build/media_source/vendor/bootstrap/js/popover.es6.js
+++ b/build/media_source/vendor/bootstrap/js/popover.es6.js
@@ -10,80 +10,82 @@ if (!Object.prototype.hasOwnProperty.call(document.body.dataset, 'bsNoJquery')) 
   document.body.dataset.bsNoJquery = '';
 }
 
-// Get the elements/configurations from the PHP
-const tooltips = Joomla.getOptions('bootstrap.tooltip');
-const popovers = Joomla.getOptions('bootstrap.popover');
-// Initialise the elements
-if (typeof popovers === 'object' && popovers !== null) {
-  Object.keys(popovers).forEach((popover) => {
-    const opt = popovers[popover];
-    const options = {
-      animation: opt.animation ? opt.animation : true,
-      container: opt.container ? opt.container : false,
-      content: opt.content ? opt.content : '',
-      delay: opt.delay ? opt.delay : 0,
-      html: opt.html ? opt.html : false,
-      placement: opt.placement ? opt.placement : 'top',
-      selector: opt.selector ? opt.selector : false,
-      title: opt.title ? opt.title : '',
-      trigger: opt.trigger ? opt.trigger : 'click',
-      offset: opt.offset ? opt.offset : 0,
-      fallbackPlacement: opt.fallbackPlacement ? opt.fallbackPlacement : 'flip',
-      boundary: opt.boundary ? opt.boundary : 'scrollParent',
-      customClass: opt.customClass ? opt.customClass : '',
-      sanitize: opt.sanitize ? opt.sanitize : true,
-      sanitizeFn: opt.sanitizeFn ? opt.sanitizeFn : null,
-      popperConfig: opt.popperConfig ? opt.popperConfig : null,
-    };
+if (Joomla && Joomla.getOptions) {
+  // Get the elements/configurations from the PHP
+  const tooltips = Joomla.getOptions('bootstrap.tooltip');
+  const popovers = Joomla.getOptions('bootstrap.popover');
+  // Initialise the elements
+  if (typeof popovers === 'object' && popovers !== null) {
+    Object.keys(popovers).forEach((popover) => {
+      const opt = popovers[popover];
+      const options = {
+        animation: opt.animation ? opt.animation : true,
+        container: opt.container ? opt.container : false,
+        content: opt.content ? opt.content : '',
+        delay: opt.delay ? opt.delay : 0,
+        html: opt.html ? opt.html : false,
+        placement: opt.placement ? opt.placement : 'top',
+        selector: opt.selector ? opt.selector : false,
+        title: opt.title ? opt.title : '',
+        trigger: opt.trigger ? opt.trigger : 'click',
+        offset: opt.offset ? opt.offset : 0,
+        fallbackPlacement: opt.fallbackPlacement ? opt.fallbackPlacement : 'flip',
+        boundary: opt.boundary ? opt.boundary : 'scrollParent',
+        customClass: opt.customClass ? opt.customClass : '',
+        sanitize: opt.sanitize ? opt.sanitize : true,
+        sanitizeFn: opt.sanitizeFn ? opt.sanitizeFn : null,
+        popperConfig: opt.popperConfig ? opt.popperConfig : null,
+      };
 
-    if (opt.template) {
-      options.template = opt.template;
-    }
-    if (opt.allowList) {
-      options.allowList = opt.allowList;
-    }
+      if (opt.template) {
+        options.template = opt.template;
+      }
+      if (opt.allowList) {
+        options.allowList = opt.allowList;
+      }
 
-    const elements = Array.from(document.querySelectorAll(popover));
-    if (elements.length) {
-      elements.map((el) => new window.bootstrap.Popover(el, options));
-    }
-  });
-}
-// Initialise the elements
-if (typeof tooltips === 'object' && tooltips !== null) {
-  Object.keys(tooltips).forEach((tooltip) => {
-    const opt = tooltips[tooltip];
-    const options = {
-      animation: opt.animation ? opt.animation : true,
-      container: opt.container ? opt.container : false,
-      delay: opt.delay ? opt.delay : 0,
-      html: opt.html ? opt.html : false,
-      selector: opt.selector ? opt.selector : false,
-      trigger: opt.trigger ? opt.trigger : 'hover focus',
-      fallbackPlacement: opt.fallbackPlacement ? opt.fallbackPlacement : null,
-      boundary: opt.boundary ? opt.boundary : 'clippingParents',
-      title: opt.title ? opt.title : '',
-      customClass: opt.customClass ? opt.customClass : '',
-      sanitize: opt.sanitize ? opt.sanitize : true,
-      sanitizeFn: opt.sanitizeFn ? opt.sanitizeFn : null,
-      popperConfig: opt.popperConfig ? opt.popperConfig : null,
-    };
+      const elements = Array.from(document.querySelectorAll(popover));
+      if (elements.length) {
+        elements.map((el) => new window.bootstrap.Popover(el, options));
+      }
+    });
+  }
+  // Initialise the elements
+  if (typeof tooltips === 'object' && tooltips !== null) {
+    Object.keys(tooltips).forEach((tooltip) => {
+      const opt = tooltips[tooltip];
+      const options = {
+        animation: opt.animation ? opt.animation : true,
+        container: opt.container ? opt.container : false,
+        delay: opt.delay ? opt.delay : 0,
+        html: opt.html ? opt.html : false,
+        selector: opt.selector ? opt.selector : false,
+        trigger: opt.trigger ? opt.trigger : 'hover focus',
+        fallbackPlacement: opt.fallbackPlacement ? opt.fallbackPlacement : null,
+        boundary: opt.boundary ? opt.boundary : 'clippingParents',
+        title: opt.title ? opt.title : '',
+        customClass: opt.customClass ? opt.customClass : '',
+        sanitize: opt.sanitize ? opt.sanitize : true,
+        sanitizeFn: opt.sanitizeFn ? opt.sanitizeFn : null,
+        popperConfig: opt.popperConfig ? opt.popperConfig : null,
+      };
 
-    if (opt.placement) {
-      options.placement = opt.placement;
-    }
-    if (opt.template) {
-      options.template = opt.template;
-    }
-    if (opt.allowList) {
-      options.allowList = opt.allowList;
-    }
+      if (opt.placement) {
+        options.placement = opt.placement;
+      }
+      if (opt.template) {
+        options.template = opt.template;
+      }
+      if (opt.allowList) {
+        options.allowList = opt.allowList;
+      }
 
-    const elements = Array.from(document.querySelectorAll(tooltip));
-    if (elements.length) {
-      elements.map((el) => new window.bootstrap.Tooltip(el, options));
-    }
-  });
+      const elements = Array.from(document.querySelectorAll(tooltip));
+      if (elements.length) {
+        elements.map((el) => new window.bootstrap.Tooltip(el, options));
+      }
+    });
+  }
 }
 
 export { Tooltip, Popover };

--- a/build/media_source/vendor/bootstrap/js/scrollspy.es6.js
+++ b/build/media_source/vendor/bootstrap/js/scrollspy.es6.js
@@ -1,26 +1,7 @@
 import Scrollspy from '../../../../../node_modules/bootstrap/js/src/scrollspy';
 
-Joomla = Joomla || {};
-Joomla.Bootstrap = Joomla.Bootstrap || {};
-Joomla.Bootstrap.Initialise = Joomla.Bootstrap.Initialise || {};
-Joomla.Bootstrap.Instances = Joomla.Bootstrap.Instances || {};
-Joomla.Bootstrap.Instances.Scrollspy = new WeakMap();
-
-/**
- * Initialise the Scrollspy iteractivity
- *
- * @param {HTMLElement} el The element that will become a scrollspy
- * @param {object} options The options for this scrollspy
- */
-Joomla.Bootstrap.Initialise.Scrollspy = (el, options) => {
-  if (!(el instanceof Element)) {
-    return;
-  }
-  if (Joomla.Bootstrap.Instances.Scrollspy.get(el) && el.dispose) {
-    el.dispose();
-  }
-  Joomla.Bootstrap.Instances.Scrollspy.set(el, new Scrollspy(el, options));
-};
+window.bootstrap = window.bootstrap || {};
+window.bootstrap.Scrollspy = Scrollspy;
 
 // Ensure vanilla mode, for consistency of the events
 if (!Object.prototype.hasOwnProperty.call(document.body.dataset, 'bsNoJquery')) {
@@ -44,7 +25,7 @@ if (typeof scrollspys === 'object' && scrollspys !== null) {
 
     const elements = Array.from(document.querySelectorAll(scrollspy));
     if (elements.length) {
-      elements.map((el) => Joomla.Bootstrap.Initialise.Scrollspy(el, options));
+      elements.map((el) => new window.bootstrap.Scrollspy(el, options));
     }
   });
 }

--- a/build/media_source/vendor/bootstrap/js/scrollspy.es6.js
+++ b/build/media_source/vendor/bootstrap/js/scrollspy.es6.js
@@ -8,26 +8,28 @@ if (!Object.prototype.hasOwnProperty.call(document.body.dataset, 'bsNoJquery')) 
   document.body.dataset.bsNoJquery = '';
 }
 
-// Get the elements/configurations from the PHP
-const scrollspys = Joomla.getOptions('bootstrap.scrollspy');
-// Initialise the elements
-if (typeof scrollspys === 'object' && scrollspys !== null) {
-  Object.keys(scrollspys).forEach((scrollspy) => {
-    const opt = scrollspys[scrollspy];
-    const options = {
-      offset: opt.offset ? opt.offset : 10,
-      method: opt.method ? opt.method : 'auto',
-    };
+if (Joomla && Joomla.getOptions) {
+  // Get the elements/configurations from the PHP
+  const scrollspys = Joomla.getOptions('bootstrap.scrollspy');
+  // Initialise the elements
+  if (typeof scrollspys === 'object' && scrollspys !== null) {
+    Object.keys(scrollspys).forEach((scrollspy) => {
+      const opt = scrollspys[scrollspy];
+      const options = {
+        offset: opt.offset ? opt.offset : 10,
+        method: opt.method ? opt.method : 'auto',
+      };
 
-    if (opt.target) {
-      options.target = opt.target;
-    }
+      if (opt.target) {
+        options.target = opt.target;
+      }
 
-    const elements = Array.from(document.querySelectorAll(scrollspy));
-    if (elements.length) {
-      elements.map((el) => new window.bootstrap.Scrollspy(el, options));
-    }
-  });
+      const elements = Array.from(document.querySelectorAll(scrollspy));
+      if (elements.length) {
+        elements.map((el) => new window.bootstrap.Scrollspy(el, options));
+      }
+    });
+  }
 }
 
 export default Scrollspy;

--- a/build/media_source/vendor/bootstrap/js/tab.es6.js
+++ b/build/media_source/vendor/bootstrap/js/tab.es6.js
@@ -1,10 +1,7 @@
 import Tab from '../../../../../node_modules/bootstrap/js/src/tab';
 
-Joomla = Joomla || {};
-Joomla.Bootstrap = Joomla.Bootstrap || {};
-Joomla.Bootstrap.Initialise = Joomla.Bootstrap.Initialise || {};
-Joomla.Bootstrap.Instances = Joomla.Bootstrap.Instances || {};
-Joomla.Bootstrap.Instances.Tab = new WeakMap();
+window.bootstrap = window.bootstrap || {};
+window.bootstrap.Tab = Tab;
 
 /**
  * Initialise the Tabs interactivity
@@ -12,7 +9,7 @@ Joomla.Bootstrap.Instances.Tab = new WeakMap();
  * @param {HTMLElement} el The element that will become an collapse
  * @param {object} options The options for this collapse
  */
-Joomla.Bootstrap.Initialise.Tab = (el, options) => {
+Joomla.initialiseTabs = (el, options) => {
   if (!(el instanceof Element) && options.isJoomla) {
     const nSelector = el.split('.')[1];
     if (!nSelector) {
@@ -57,25 +54,16 @@ Joomla.Bootstrap.Initialise.Tab = (el, options) => {
             li.appendChild(link);
 
             ul.appendChild(li);
+
+            // eslint-disable-next-line no-new
+            new window.bootstrap.Tab(li);
           }
         });
       }
-
-      if (Joomla.Bootstrap.Instances.Tab.get(tab) && tab.dispose) {
-        tab.dispose();
-      }
-
-      Joomla.Bootstrap.Instances.Tab.set(tab, new Tab(tab));
     }
   } else {
-    if (!(el instanceof Element)) {
-      return;
-    }
-    if (Joomla.Bootstrap.Instances.Tab.get(el) && el.dispose) {
-      el.dispose();
-    }
-
-    Joomla.Bootstrap.Instances.Tab.set(el, new Tab(el, options));
+    Array.from(document.querySelectorAll(`${el} a`))
+      .map((tab) => new window.bootstrap.Tab(tab, options));
   }
 };
 
@@ -88,9 +76,7 @@ if (!Object.prototype.hasOwnProperty.call(document.body.dataset, 'bsNoJquery')) 
 const tabs = Joomla.getOptions('bootstrap.tabs');
 // Initialise the elements
 if (typeof tabs === 'object' && tabs !== null) {
-  Object.keys(tabs).forEach((tab) => {
-    Joomla.Bootstrap.Initialise.Tab(tab, tabs[tab]);
-  });
+  Object.keys(tabs).map((tab) => Joomla.initialiseTabs(tab, tabs[tab]));
 }
 
 export default Tab;

--- a/build/media_source/vendor/bootstrap/js/tab.es6.js
+++ b/build/media_source/vendor/bootstrap/js/tab.es6.js
@@ -1,5 +1,6 @@
 import Tab from '../../../../../node_modules/bootstrap/js/src/tab';
 
+window.Joomla = window.Joomla || {};
 window.bootstrap = window.bootstrap || {};
 window.bootstrap.Tab = Tab;
 
@@ -67,16 +68,18 @@ Joomla.initialiseTabs = (el, options) => {
   }
 };
 
-// Ensure vanilla mode, for consistency of the events
-if (!Object.prototype.hasOwnProperty.call(document.body.dataset, 'bsNoJquery')) {
-  document.body.dataset.bsNoJquery = '';
-}
+if (Joomla && Joomla.getOptions) {
+  // Ensure vanilla mode, for consistency of the events
+  if (!Object.prototype.hasOwnProperty.call(document.body.dataset, 'bsNoJquery')) {
+    document.body.dataset.bsNoJquery = '';
+  }
 
-// Get the elements/configurations from the PHP
-const tabs = Joomla.getOptions('bootstrap.tabs');
-// Initialise the elements
-if (typeof tabs === 'object' && tabs !== null) {
-  Object.keys(tabs).map((tab) => Joomla.initialiseTabs(tab, tabs[tab]));
+  // Get the elements/configurations from the PHP
+  const tabs = Joomla.getOptions('bootstrap.tabs');
+  // Initialise the elements
+  if (typeof tabs === 'object' && tabs !== null) {
+    Object.keys(tabs).map((tab) => Joomla.initialiseTabs(tab, tabs[tab]));
+  }
 }
 
 export default Tab;

--- a/build/media_source/vendor/bootstrap/js/toast.es6.js
+++ b/build/media_source/vendor/bootstrap/js/toast.es6.js
@@ -1,26 +1,7 @@
 import Toast from '../../../../../node_modules/bootstrap/js/src/toast';
 
-Joomla = Joomla || {};
-Joomla.Bootstrap = Joomla.Bootstrap || {};
-Joomla.Bootstrap.Initialise = Joomla.Bootstrap.Initialise || {};
-Joomla.Bootstrap.Instances = Joomla.Bootstrap.Instances || {};
-Joomla.Bootstrap.Instances.Toast = new WeakMap();
-
-/**
- * Initialise the iteractivity
- *
- * @param {HTMLElement} el The element that will become an toast
- * @param {object} options The options for this toast
- */
-Joomla.Bootstrap.Initialise.Toast = (el, options) => {
-  if (!(el instanceof Element)) {
-    return;
-  }
-  if (Joomla.Bootstrap.Instances.Toast.get(el) && el.dispose) {
-    el.dispose();
-  }
-  Joomla.Bootstrap.Instances.Toast.set(el, new Toast(el, options));
-};
+window.bootstrap = window.bootstrap || {};
+window.bootstrap.Toast = Toast;
 
 // Ensure vanilla mode, for consistency of the events
 if (!Object.prototype.hasOwnProperty.call(document.body.dataset, 'bsNoJquery')) {
@@ -41,7 +22,7 @@ if (typeof toasts === 'object' && toasts !== null) {
 
     const elements = Array.from(document.querySelectorAll(toast));
     if (elements.length) {
-      elements.map((el) => Joomla.Bootstrap.Initialise.Toast(el, options));
+      elements.map((el) => new window.bootstrap.Toast(el, options));
     }
   });
 }

--- a/build/media_source/vendor/bootstrap/js/toast.es6.js
+++ b/build/media_source/vendor/bootstrap/js/toast.es6.js
@@ -8,23 +8,25 @@ if (!Object.prototype.hasOwnProperty.call(document.body.dataset, 'bsNoJquery')) 
   document.body.dataset.bsNoJquery = '';
 }
 
-// Get the elements/configurations from the PHP
-const toasts = Joomla.getOptions('bootstrap.toast');
-// Initialise the elements
-if (typeof toasts === 'object' && toasts !== null) {
-  Object.keys(toasts).forEach((toast) => {
-    const opt = toasts[toast];
-    const options = {
-      animation: opt.animation ? opt.animation : true,
-      autohide: opt.autohide ? opt.autohide : true,
-      delay: opt.delay ? opt.delay : 5000,
-    };
+if (Joomla && Joomla.getOptions) {
+  // Get the elements/configurations from the PHP
+  const toasts = Joomla.getOptions('bootstrap.toast');
+  // Initialise the elements
+  if (typeof toasts === 'object' && toasts !== null) {
+    Object.keys(toasts).forEach((toast) => {
+      const opt = toasts[toast];
+      const options = {
+        animation: opt.animation ? opt.animation : true,
+        autohide: opt.autohide ? opt.autohide : true,
+        delay: opt.delay ? opt.delay : 5000,
+      };
 
-    const elements = Array.from(document.querySelectorAll(toast));
-    if (elements.length) {
-      elements.map((el) => new window.bootstrap.Toast(el, options));
-    }
-  });
+      const elements = Array.from(document.querySelectorAll(toast));
+      if (elements.length) {
+        elements.map((el) => new window.bootstrap.Toast(el, options));
+      }
+    });
+  }
 }
 
 export default Toast;

--- a/libraries/src/HTML/Helpers/Bootstrap.php
+++ b/libraries/src/HTML/Helpers/Bootstrap.php
@@ -524,7 +524,6 @@ abstract class Bootstrap
 						]
 					]
 				)
-				->useScript('bootstrap.' . $script . '.ES6')
 
 				// Register the ES5 script with attributes: nomodule, defer
 				->registerScript(
@@ -538,6 +537,9 @@ abstract class Bootstrap
 						]
 					]
 				)
+
+				->useScript('core')
+				->useScript('bootstrap.' . $script . '.ES6')
 				->useScript('bootstrap.legacy');
 
 			array_push(static::$loadedScripts, $script);


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Use a global object named `bootstrap` instead of the `Joomla.Bootstrap`

## WHY?

This is my fault, let me explain: Joomla has 2 instances (tabs and modals) where it kinda uses it's own constructor (eg some specific tasks executed before initialising the interactive elements). When I was implementing this JS part of BS5 I thought a `Joomla` registry was a good idea. **Never ever ship code that was a nice idea**. The problem is that Bootstrap documentation in such case is referring to objects that don't actually exist in the document. **I'm sorry, this was a terrible idea**


### Testing Instructions
Check the dropdowns in the dashdoard
Check the modals in the Article Edit
Check the Accordion in the Menu edit (select new component)
Check the tabs in the tinyMCE plugin (set0... )

### Actual result BEFORE applying this Pull Request
Bootstrap docs don't actually reflect the methods of the interactive components


### Expected result AFTER applying this Pull Request
Code is the same but the Bootstrap docs reflect exactly what exists in our codebase

### Example of the code that reflects BS docs
![Screenshot 2021-01-25 at 18 31 58](https://user-images.githubusercontent.com/3889375/105746049-3fa09900-5f3f-11eb-8386-89354115f25b.png)
![Screenshot 2021-01-25 at 18 36 40](https://user-images.githubusercontent.com/3889375/105746059-416a5c80-5f3f-11eb-9ee6-d9ab1160a2aa.png)
![Screenshot 2021-01-25 at 18 39 41](https://user-images.githubusercontent.com/3889375/105746062-4202f300-5f3f-11eb-8e72-865de12ad599.png)


### Documentation Changes Required
The Bootstrap Docs **is** our documentation but we still need to document the Bootstrap.php methods 

@wilsonge sorry mate for the mess, this needs to be merged ASAP