### PR TITLE
[4.0] Removing three strings which are not supposed to be translated.

### DIFF
--- a/administrator/components/com_config/forms/application.xml
+++ b/administrator/components/com_config/forms/application.xml
@@ -344,8 +344,9 @@
 		<field
 			name="cors_allow_origin"
 			type="text"
-			label="COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_ORIGIN_LABEL"
+			label="Access-Control-Allow-Origin"
 			description="COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_ORIGIN_DESC"
+			translate_label="false"
 			default="*"
 			showon="cors:1"
 		/>
@@ -353,8 +354,9 @@
 		<field
 			name="cors_allow_headers"
 			type="text"
-			label="COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_HEADERS_LABEL"
+			label="Access-Control-Allow-Headers"
 			description="COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_HEADERS_DESC"
+			translate_label="false"
 			default="Content-Type,X-Joomla-Token"
 			showon="cors:1"
 		/>
@@ -362,8 +364,9 @@
 		<field
 			name="cors_allow_methods"
 			type="text"
-			label="COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_METHODS_LABEL"
+			label="Access-Control-Allow-Methods"
 			description="COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_METHODS_DESC"
+			translate_label="false"
 			showon="cors:1"
 		/>
 	</fieldset>

--- a/administrator/language/en-GB/com_config.ini
+++ b/administrator/language/en-GB/com_config.ini
@@ -230,9 +230,6 @@ JLIB_RULES_SETTING_NOTES_COM_CONFIG="If you change the setting, it will apply to
 
 COM_CONFIG_WEBSERVICES_SETTINGS="Webservices"
 COM_CONFIG_FIELD_WEBSERVICES_CORSOFFF_LABEL="Enable CORS"
-COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_ORIGIN_LABEL="Access-Control-Allow-Origin"
 COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_ORIGIN_DESC="Specifies the origin allowed to access webservices on this site,sent back in response to a preflight request. Default: * (=all)."
-COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_HEADERS_LABEL="Access-Control-Allow-Headers"
 COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_HEADERS_DESC="Specifies the header(s) sent back in response to a preflight request. Default: Content-Type,X-Joomla-Token"
-COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_METHODS_LABEL="Access-Control-Allow-Methods"
 COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_METHODS_DESC="Specifies the webservice method(s) allowed to access on this site, sent back in response to a preflight request. Default: all methods available for the requested route."


### PR DESCRIPTION
https://github.com/joomla/joomla-cms/pull/31379 introduced three new language strings. But the strings are technical terms which are not supposed to be translated:
````
COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_ORIGIN_LABEL="Access-Control-Allow-Origin"
COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_HEADERS_LABEL="Access-Control-Allow-Headers"
COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_METHODS_LABEL="Access-Control-Allow-Methods"
````

### Summary of Changes
This PR removes the strings and "hardcodes" the label to the term. It also adjusts the form XML so it doesn't try to translate the string.


### Testing Instructions
Go to global configuration -> server tab. Enable "CORS" and then check the labels of the three "Access-Control-Allow-..." parameters


### Actual result BEFORE applying this Pull Request
Strings are translated to the technical term


### Expected result AFTER applying this Pull Request
Strings are not translated.
But actually no difference to before the PR.


### Documentation Changes Required
None
