### PR TITLE
[4.0] RTL: bootstrap5 rtl overrides (Atum)

### DIFF
--- a/administrator/templates/atum/scss/template-rtl.scss
+++ b/administrator/templates/atum/scss/template-rtl.scss
@@ -1,14 +1,11 @@
 @import "template";
+@import "vendor/bootstrap/bootstrap-rtl";
 
 // Global
 dl,
 ol,
 ul {
   padding-right: 0;
-}
-
-.close {
-  float: left;
 }
 
 .dropdown-menu-end {
@@ -106,26 +103,6 @@ ul {
   }
 }
 
-.ms-auto {
-  margin-right: auto !important;
-  margin-left: 0 !important;
-}
-
-.me-auto {
-  margin-right: 0 !important;
-  margin-left: auto !important;
-}
-
-.ms-2 {
-  margin-right: .5rem;
-  margin-left: 0 !important;
-}
-
-.me-2 {
-  margin-right: 0 !important;
-  margin-left: .5rem;
-}
-
 .field-calendar {
   float: none;
 }
@@ -136,15 +113,6 @@ ul {
 
 .field-user-wrapper {
   float: none;
-}
-
-// Bootstrap overrides
-.text-start {
-  text-align: right !important;
-}
-
-.text-end {
-  text-align: left !important;
 }
 
 // System panel
@@ -210,10 +178,4 @@ ul {
 .btn-group > .btn:not(:first-child),
 .btn-group > .btn-group:not(:first-child) {
   @include border-end-radius(0);
-}
-
-.modal-header {
-  .btn-close {
-    margin: -.5rem auto -.5rem -.5rem;
-  }
 }

--- a/administrator/templates/atum/scss/vendor/bootstrap/_bootstrap-rtl.scss
+++ b/administrator/templates/atum/scss/vendor/bootstrap/_bootstrap-rtl.scss
@@ -1,0 +1,144 @@
+// Bootstrap rtl overrides
+
+.float-start {
+  float: right !important;
+}
+
+.float-end {
+  float: left !important;
+}
+
+.modal-header {
+  .btn-close {
+    margin: -.5rem auto -.5rem -.5rem;
+  }
+}
+
+.text-start {
+  text-align: right !important;
+}
+
+.text-end {
+  text-align: left !important;
+}
+
+.me-0 {
+  margin-right: auto !important;
+  margin-left: 0 !important;
+}
+
+.me-1 {
+  margin-right: auto !important;
+  margin-left: .25rem !important;
+}
+
+.me-2 {
+  margin-right: auto !important;
+  margin-left: .5rem !important;
+}
+
+.me-3 {
+  margin-right: auto !important;
+  margin-left: 1rem !important;
+}
+
+.me-4 {
+  margin-right: auto !important;
+  margin-left: 1.5rem !important;
+}
+
+.me-5 {
+  margin-right: auto !important;
+  margin-left: 3rem !important;
+}
+
+.me-auto {
+  margin-right: 0 !important;
+  margin-left: auto !important;
+}
+
+.ms-0 {
+  margin-right: 0 !important;
+  margin-left: auto !important;
+}
+
+.ms-1 {
+  margin-right: .25rem !important;
+  margin-left: auto !important;
+}
+
+.ms-2 {
+  margin-right: .5rem !important;
+  margin-left: auto !important;
+}
+
+.ms-3 {
+  margin-right: 1rem !important;
+  margin-left: auto !important;
+}
+
+.ms-4 {
+  margin-right: 1.5rem !important;
+  margin-left: auto !important;
+}
+
+.ms-5 {
+  margin-right: 3rem !important;
+  margin-left: auto !important;
+}
+
+.ms-auto {
+  margin-right: 0 !important;
+  margin-left: auto !important;
+}
+
+.pe-0 {
+  padding-right: 0 !important;
+  padding-left: 0 !important;
+}
+.pe-1 {
+  padding-right: 0 !important;
+  padding-left: .25rem !important;
+}
+.pe-2 {
+  padding-right: 0 !important;
+  padding-left: .5rem !important;
+}
+.pe-3 {
+  padding-right: 0 !important;
+  padding-left: 1rem !important;
+}
+.pe-4 {
+  padding-right: 0 !important;
+  padding-left: 1.5rem !important;
+}
+.pe-5 {
+  padding-right: 0 !important;
+  padding-left: 3rem !important;
+}
+
+.ps-0 {
+  padding-right: 0 !important;
+  padding-left: 0 !important;
+}
+.ps-1 {
+  padding-right: .25rem !important;
+  padding-left: 0 !important;
+}
+.ps-2 {
+  padding-right: .5rem !important;
+  padding-left: 0 !important;
+}
+.ps-3 {
+  padding-right: 1rem !important;
+  padding-left: 0 !important;
+}
+.ps-4 {
+  padding-right: 1.5rem !important;
+  padding-left: 0 !important;
+}
+.ps-5 {
+  padding-right: 3rem !important;
+  padding-left: 0 !important;
+}
+


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/32113

### Summary of Changes
Created a new `_bootstrap-rtl.scss` file loaded by `template-rtl.scss` in Atum
Moved the bootstrap specific classes from `template-rtl.scss` to the new file.
Added necessary rtl bootstrap5 classes in this new file. Some are not yet used in core but may be in the future.
This may not be exhaustive. If necessary, some classes may be added in the file. For example for `@media` twists.


### Testing Instructions
patch 
run npm ci
Install Persian fa-IR language and switch to Persian in back-end.
test multiple aspects of the admin UI.


### Actual result BEFORE applying this Pull Request
An example of the corrected results in admin template editing=>description tab:

Reference: LTR

<img width="1233" alt="Screen Shot 2021-01-26 at 09 58 44" src="https://user-images.githubusercontent.com/869724/105823174-1c1c3380-5fbd-11eb-9430-4a5231f2825c.png">


RTL:

<img width="1239" alt="Screen Shot 2021-01-26 at 09 57 21" src="https://user-images.githubusercontent.com/869724/105823008-f2fba300-5fbc-11eb-828e-4d8f965dcc5e.png">


### Expected result AFTER applying this Pull Request
<img width="1247" alt="Screen Shot 2021-01-26 at 09 53 46" src="https://user-images.githubusercontent.com/869724/105822514-723ca700-5fbc-11eb-91e7-db1901edbcde.png">



### NOTE
This could be an example to follow for Cassiopea

@drmenzelit @brianteeman @chmst 

