### PR TITLE
[4.0] add missing interactivity

### DIFF
--- a/administrator/templates/atum/index.php
+++ b/administrator/templates/atum/index.php
@@ -126,6 +126,7 @@ Text::script('TPL_ATUM_MORE_ELEMENTS');
 <div id="wrapper" class="d-flex wrapper<?php echo $hiddenMenu ? '0' : ''; ?>">
 	<?php // Sidebar ?>
 	<?php if (!$hiddenMenu) : ?>
+	<?php HTMLHelper::_('bootstrap.collapse', '.toggler-burger'); ?>
 		<button class="navbar-toggler toggler-burger collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#sidebar-wrapper" aria-controls="sidebar-wrapper" aria-expanded="false" aria-label="<?php echo Text::_('JTOGGLE_SIDEBAR_MENU'); ?>">
 			<span class="navbar-toggler-icon"></span>
 		</button>
@@ -147,6 +148,7 @@ Text::script('TPL_ATUM_MORE_ELEMENTS');
 	<div class="container-fluid container-main">
 		<?php if (!$cpanel) : ?>
 			<?php // Subheader ?>
+			<?php HTMLHelper::_('bootstrap.collapse', '.toggler-toolbar'); ?>
 			<button class="navbar-toggler toggler-toolbar toggler-burger collapsed" type="button" data-bs-toggle="collapse" data-bs-target=".subhead" aria-controls="subhead" aria-expanded="false" aria-label="<?php echo Text::_('TPL_ATUM_TOOLBAR'); ?>">
 				<span class="toggler-toolbar-icon"></span>
 			</button>


### PR DESCRIPTION
Pull Request for Issue #32161 and #32162 .

### Summary of Changes



### Testing Instructions
Resize the browser to mobile size and try the bottom menu toggler
![Screenshot 2021-01-26 at 15 05 00](https://user-images.githubusercontent.com/3889375/105855350-47684800-5fe8-11eb-9340-35d2cb5662d7.png)


Try to edit an article and try the gears button on the top (mobile size again)

### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Documentation Changes Required

