### PR TITLE
[4.0] Add collapse for the burger

### DIFF
--- a/templates/cassiopeia/error.php
+++ b/templates/cassiopeia/error.php
@@ -117,6 +117,7 @@ $this->setMetaData('viewport', 'width=device-width, initial-scale=1');
 			<div class="grid-child container-nav">
 				<?php if ($this->countModules('menu')) : ?>
 					<nav class="navbar navbar-expand-md">
+						<?php HTMLHelper::_('bootstrap.collapse', '.navbar-toggler'); ?>
 						<button class="navbar-toggler navbar-toggler-right" type="button" data-bs-toggle="collapse" data-bs-target="#navbar" aria-controls="navbar" aria-expanded="false" aria-label="<?php echo Text::_('TPL_CASSIOPEIA_TOGGLE'); ?>">
 							<span class="icon-menu" aria-hidden="true"></span>
 						</button>

--- a/templates/cassiopeia/index.php
+++ b/templates/cassiopeia/index.php
@@ -129,6 +129,7 @@ $stickyHeader = $this->params->get('stickyHeader') ? 'position-sticky sticky-top
 			<div class="grid-child container-nav">
 				<?php if ($this->countModules('menu')) : ?>
 					<nav class="navbar navbar-expand-md">
+						<?php HTMLHelper::_('bootstrap.collapse', '.navbar-toggler'); ?>
 						<button class="navbar-toggler navbar-toggler-right" type="button" data-bs-toggle="collapse" data-bs-target="#navbar" aria-controls="navbar" aria-expanded="false" aria-label="<?php echo Text::_('TPL_CASSIOPEIA_TOGGLE'); ?>">
 							<span class="icon-menu" aria-hidden="true"></span>
 						</button>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Burger menu fix for Cassiopeia


### Testing Instructions
Go to the home of your testing site
Resize the browser to mobile size and check the burger icon interactivity

![Screenshot 2021-01-26 at 16 36 22](https://user-images.githubusercontent.com/3889375/105867146-0a568280-5ff5-11eb-99f4-6c8ee9d36b97.png)



### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Documentation Changes Required

