### PR TITLE
Optimize the code introduced with PR 32006 to rename incorrectly cased files on update

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -2692,8 +2692,10 @@ class JoomlaInstallerScript
 			if ($newBasename !== $expectedBasename)
 			{
 				// Rename the file.
-				rename(JPATH_ROOT . $old, JPATH_ROOT . $old . '.tmp');
-				rename(JPATH_ROOT . $old . '.tmp', JPATH_ROOT . $expected);
+				if (rename(JPATH_ROOT . $old, JPATH_ROOT . $old . '.tmp'))
+				{
+					rename(JPATH_ROOT . $old . '.tmp', JPATH_ROOT . $expected);
+				}
 
 				continue;
 			}
@@ -2708,8 +2710,10 @@ class JoomlaInstallerScript
 					if (!in_array($expectedBasename, scandir(dirname($newRealpath))))
 					{
 						// Rename the file.
-						rename(JPATH_ROOT . $old, JPATH_ROOT . $old . '.tmp');
-						rename(JPATH_ROOT . $old . '.tmp', JPATH_ROOT . $expected);
+						if (rename(JPATH_ROOT . $old, JPATH_ROOT . $old . '.tmp'))
+						{
+							rename(JPATH_ROOT . $old . '.tmp', JPATH_ROOT . $expected);
+						}
 					}
 				}
 				else

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -2668,14 +2668,14 @@ class JoomlaInstallerScript
 	protected function fixFilenameCasing()
 	{
 		$files = array(
-			'libraries/src/Filesystem/Support/Stringcontroller.php' => 'libraries/src/Filesystem/Support/StringController.php',
-			'libraries/vendor/paragonie/sodium_compat/src/Core/Xsalsa20.php' => 'libraries/vendor/paragonie/sodium_compat/src/Core/XSalsa20.php',
-			'media/mod_languages/images/si_LK.gif' => 'media/mod_languages/images/si_lk.gif',
+			'/libraries/src/Filesystem/Support/Stringcontroller.php' => '/libraries/src/Filesystem/Support/StringController.php',
+			'/libraries/vendor/paragonie/sodium_compat/src/Core/Xsalsa20.php' => '/libraries/vendor/paragonie/sodium_compat/src/Core/XSalsa20.php',
+			'/media/mod_languages/images/si_LK.gif' => '/media/mod_languages/images/si_lk.gif',
 		);
 
 		foreach ($files as $old => $expected)
 		{
-			$oldRealpath = realpath(JPATH_ROOT . '/' . $old);
+			$oldRealpath = realpath(JPATH_ROOT . $old);
 
 			// On Unix without incorrectly cased file.
 			if ($oldRealpath === false)
@@ -2684,7 +2684,7 @@ class JoomlaInstallerScript
 			}
 
 			$oldBasename      = basename($oldRealpath);
-			$newRealpath      = realpath(JPATH_ROOT . '/' . $expected);
+			$newRealpath      = realpath(JPATH_ROOT . $expected);
 			$newBasename      = basename($newRealpath);
 			$expectedBasename = basename($expected);
 
@@ -2692,8 +2692,8 @@ class JoomlaInstallerScript
 			if ($newBasename !== $expectedBasename)
 			{
 				// Rename the file.
-				rename(JPATH_ROOT . '/' . $old, JPATH_ROOT . '/' . $old . '.tmp');
-				rename(JPATH_ROOT . '/' . $old . '.tmp', JPATH_ROOT . '/' . $expected);
+				rename(JPATH_ROOT . $old, JPATH_ROOT . $old . '.tmp');
+				rename(JPATH_ROOT . $old . '.tmp', JPATH_ROOT . $expected);
 
 				continue;
 			}
@@ -2708,14 +2708,14 @@ class JoomlaInstallerScript
 					if (!in_array($expectedBasename, scandir(dirname($newRealpath))))
 					{
 						// Rename the file.
-						rename(JPATH_ROOT . '/' . $old, JPATH_ROOT . '/' . $old . '.tmp');
-						rename(JPATH_ROOT . '/' . $old . '.tmp', JPATH_ROOT . '/' . $expected);
+						rename(JPATH_ROOT . $old, JPATH_ROOT . $old . '.tmp');
+						rename(JPATH_ROOT . $old . '.tmp', JPATH_ROOT . $expected);
 					}
 				}
 				else
 				{
 					// On Unix with both files: Delete the incorrectly cased file.
-					unlink(JPATH_ROOT . '/' . $old);
+					unlink(JPATH_ROOT . $old);
 				}
 			}
 		}

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -2692,10 +2692,8 @@ class JoomlaInstallerScript
 			if ($newBasename !== $expectedBasename)
 			{
 				// Rename the file.
-				if (rename(JPATH_ROOT . $old, JPATH_ROOT . $old . '.tmp'))
-				{
-					rename(JPATH_ROOT . $old . '.tmp', JPATH_ROOT . $expected);
-				}
+				rename(JPATH_ROOT . $old, JPATH_ROOT . $old . '.tmp');
+				rename(JPATH_ROOT . $old . '.tmp', JPATH_ROOT . $expected);
 
 				continue;
 			}
@@ -2710,10 +2708,8 @@ class JoomlaInstallerScript
 					if (!in_array($expectedBasename, scandir(dirname($newRealpath))))
 					{
 						// Rename the file.
-						if (rename(JPATH_ROOT . $old, JPATH_ROOT . $old . '.tmp'))
-						{
-							rename(JPATH_ROOT . $old . '.tmp', JPATH_ROOT . $expected);
-						}
+						rename(JPATH_ROOT . $old, JPATH_ROOT . $old . '.tmp');
+						rename(JPATH_ROOT . $old . '.tmp', JPATH_ROOT . $expected);
 					}
 				}
 				else


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This Pull Request (PR) simplifies the code in the new function `fixFilenameCasing` which has been added to `script.php` with PR #32006 by using old and new paths which begin with a slash, so it doesn't need to prepend the slash every time we use it.

This makes it also consistent with the calling function `deleteUnexistingFiles`, where the paths of files and folders to be removed also are paths starting with a slash.

### Testing Instructions

Check that the testing instructions from PR #32006 still work on a current staging or latest 3.9.x nightly build after the patch of this PR here has been applied.

Use the [update package built by drone for this PR](https://ci.joomla.org/artifacts/joomla/joomla-cms/staging/32176/downloads/39683/Joomla_3.9.25-dev+pr.32176-Development-Update_Package.zip) for Update.

### Actual result BEFORE applying this Pull Request

Works as described in the testing instructions of PR #32006 .

### Expected result AFTER applying this Pull Request

Still works as described in the testing instructions of PR #32006 .

### Documentation Changes Required

No.