### PR TITLE
[4.0] RTL input groups rounded corners

### DIFF
--- a/administrator/templates/atum/scss/vendor/bootstrap/_bootstrap-rtl.scss
+++ b/administrator/templates/atum/scss/vendor/bootstrap/_bootstrap-rtl.scss
@@ -142,3 +142,35 @@
   padding-left: 0 !important;
 }
 
+
+.input-group {
+  &:not(.has-validation) {
+    > :not(:last-child):not(.dropdown-toggle):not(.dropdown-menu),
+    > .dropdown-toggle:nth-last-child(n + 3) {
+      @include border-end-radius($border-radius);
+    }
+  }
+
+  &.has-validation {
+    > :nth-last-child(n + 3):not(.dropdown-toggle):not(.dropdown-menu),
+    > .dropdown-toggle:nth-last-child(n + 4) {
+      @include border-end-radius(0);
+    }
+  }
+  $validation-messages: "";
+  @each $state in map-keys($form-validation-states) {
+    $validation-messages: $validation-messages + ":not(." + unquote($state) + "-tooltip)" + ":not(." + unquote($state) + "-feedback)";
+  }
+
+  > :not(:first-child):not(.dropdown-menu)#{$validation-messages} {
+    margin-left: -$input-border-width;
+    @include border-start-radius(0);
+    @include border-end-radius(0);
+  }
+
+  > :last-child:not(.dropdown-menu)#{$validation-messages} {
+    margin-left: -$input-border-width;
+    @include border-start-radius($border-radius);
+    @include border-end-radius(0);
+  }
+}


### PR DESCRIPTION
Since the BS5 upgrade some of the rounded corners are incorrect. I have put the corrections in the vendor/bootstrap/_bootstrap-rtl.scss that @infograf768 created.

The existing rounded corners code in the template-rtl.scss file may or may not be needed I didnt check.

scss really isnt my thing

## Before
![chrome_2021-01-27_22-22-14](https://user-images.githubusercontent.com/1296369/106062940-5f76bf00-60ef-11eb-8e56-fefa5ff75114.png)

![chrome_2021-01-27_22-22-54](https://user-images.githubusercontent.com/1296369/106062942-5f76bf00-60ef-11eb-9317-898abbcfbfa1.png)

![chrome_2021-01-27_22-23-36](https://user-images.githubusercontent.com/1296369/106062943-600f5580-60ef-11eb-9613-be39b4409465.png)

## After
![chrome_2021-01-27_22-26-02](https://user-images.githubusercontent.com/1296369/106062938-5ede2880-60ef-11eb-839a-4f74d2c3813e.png)

![chrome_2021-01-27_22-25-34](https://user-images.githubusercontent.com/1296369/106062946-600f5580-60ef-11eb-8b79-ed20c940f482.png)

![chrome_2021-01-27_22-25-03](https://user-images.githubusercontent.com/1296369/106062945-600f5580-60ef-11eb-8cfe-b1c8e500360d.png)

