### PR TITLE
[4.0] RTL help and options button

### DIFF
--- a/administrator/templates/atum/scss/vendor/bootstrap/_bootstrap-rtl.scss
+++ b/administrator/templates/atum/scss/vendor/bootstrap/_bootstrap-rtl.scss
@@ -88,8 +88,8 @@
 }
 
 .ms-auto {
-  margin-right: 0 !important;
-  margin-left: auto !important;
+  margin-right: auto !important;
+  margin-left: 0 !important;
 }
 
 .pe-0 {


### PR DESCRIPTION
Looks like the values for the rtl settings were the wrong way around

## Before
![image](https://user-images.githubusercontent.com/1296369/106068066-d87a1480-60f7-11eb-9110-7a98ca6287a1.png)

## After
![image](https://user-images.githubusercontent.com/1296369/106068031-c4ceae00-60f7-11eb-80ab-1fdde7df5667.png)
