### PR TITLE
[4.0] Correcting WebAuthn display in login menu item

### DIFF
--- a/administrator/modules/mod_login/tmpl/default.php
+++ b/administrator/modules/mod_login/tmpl/default.php
@@ -112,6 +112,8 @@ Text::script('JHIDEPASSWORD');
 					<span class="<?php echo $button['icon'] ?>"></span>
 				<?php elseif (!empty($button['image'])): ?>
 					<?php echo $button['image']; ?>
+				<?php elseif (!empty($button['svg'])): ?>
+					<?php echo $button['svg']; ?>
 				<?php endif; ?>
 				<?php echo Text::_($button['label']) ?>
 			</button>

--- a/components/com_users/tmpl/login/default_login.php
+++ b/components/com_users/tmpl/login/default_login.php
@@ -79,7 +79,7 @@ $usersConfig = ComponentHelper::getParams('com_users');
 				<div class="com-users-login__submit control-group">
 					<div class="controls">
 						<button type="button"
-								class="btn btn-secondary <?php echo $button['class'] ?? '' ?>"
+								class="btn btn-secondary w-100 <?php echo $button['class'] ?? '' ?>"
 								<?php foreach ($dataAttributeKeys as $key): ?>
 								<?php echo $key ?>="<?php echo $button[$key] ?>"
 								<?php endforeach; ?>
@@ -92,11 +92,7 @@ $usersConfig = ComponentHelper::getParams('com_users');
 							<?php if (!empty($button['icon'])): ?>
 								<span class="<?php echo $button['icon'] ?>"></span>
 							<?php elseif (!empty($button['image'])): ?>
-								<?php echo HTMLHelper::_('image', $button['image'], Text::_($button['tooltip'] ?? ''), [
-									'class' => 'icon',
-								], true) ?>
-							<?php elseif (!empty($button['svg'])): ?>
-								<?php echo $button['svg']; ?>
+								<?php echo $button['image']; ?>
 							<?php endif; ?>
 							<?php echo Text::_($button['label']) ?>
 						</button>

--- a/components/com_users/tmpl/login/default_login.php
+++ b/components/com_users/tmpl/login/default_login.php
@@ -93,6 +93,8 @@ $usersConfig = ComponentHelper::getParams('com_users');
 								<span class="<?php echo $button['icon'] ?>"></span>
 							<?php elseif (!empty($button['image'])): ?>
 								<?php echo $button['image']; ?>
+							<?php elseif (!empty($button['svg'])): ?>
+								<?php echo $button['svg']; ?>
 							<?php endif; ?>
 							<?php echo Text::_($button['label']) ?>
 						</button>

--- a/components/com_users/tmpl/login/default_login.php
+++ b/components/com_users/tmpl/login/default_login.php
@@ -92,7 +92,9 @@ $usersConfig = ComponentHelper::getParams('com_users');
 							<?php if (!empty($button['icon'])): ?>
 								<span class="<?php echo $button['icon'] ?>"></span>
 							<?php elseif (!empty($button['image'])): ?>
-								<?php echo $button['image']; ?>
+								<?php echo HTMLHelper::_('image', $button['image'], Text::_($button['tooltip'] ?? ''), [
+									'class' => 'icon',
+								], true) ?>
 							<?php elseif (!empty($button['svg'])): ?>
 								<?php echo $button['svg']; ?>
 							<?php endif; ?>

--- a/modules/mod_login/tmpl/default.php
+++ b/modules/mod_login/tmpl/default.php
@@ -120,6 +120,8 @@ Text::script('JHIDEPASSWORD');
 						<span class="<?php echo $button['icon'] ?>"></span>
 					<?php elseif (!empty($button['image'])): ?>
 						<?php echo $button['image']; ?>
+					<?php elseif (!empty($button['svg'])): ?>
+						<?php echo $button['svg']; ?>
 					<?php endif; ?>
 					<?php echo Text::_($button['label']) ?>
 				</button>

--- a/plugins/system/webauthn/src/PluginTraits/AdditionalLoginButtons.php
+++ b/plugins/system/webauthn/src/PluginTraits/AdditionalLoginButtons.php
@@ -162,7 +162,7 @@ trait AdditionalLoginButtons
 				'id'                 => $randomId,
 				'data-webauthn-form' => $form,
 				'data-webauthn-url'  => $url,
-				'image'              => $image,
+				'svg'                => $image,
 				'class'              => 'plg_system_webauthn_login_button',
 			],
 		];


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/32182

### Summary of Changes
https://github.com/joomla/joomla-cms/pull/31545 forgot to modify com_users login default_login tmpl and login modules


### Testing Instructions
Set webautn to display when login.
Create a login menu item.


### Actual result BEFORE applying this Pull Request

<img width="1256" alt="Screen Shot 2021-01-29 at 18 03 20" src="https://user-images.githubusercontent.com/869724/106304982-5e16d500-625c-11eb-8986-441f7887e7c4.png">

### Expected result AFTER applying this Pull Request

<img width="1057" alt="Screen Shot 2021-01-30 at 10 08 50" src="https://user-images.githubusercontent.com/869724/106352802-38cea900-62e6-11eb-96d0-f0721c99ce77.png">


### Note

This PR does not solve the tooltip display in the menu as well as in the login module
`PLG_SYSTEM_WEBAUTHN_LOGIN_DESC="Login without a password using the W3C Web Authentication (WebAuthn) standard in compatible browsers. You need to have already set up WebAuthn authentication in your user profile."`


