### PR TITLE
[4.0] Fix WebComponent dependencies, and attributes rendering

### DIFF
--- a/build/build-modules-js/settings.json
+++ b/build/build-modules-js/settings.json
@@ -334,7 +334,6 @@
               "type": "module"
             },
             "dependencies": [
-              "wcpolyfill",
               "webcomponent.joomla-alert-legacy"
             ]
           },
@@ -363,7 +362,6 @@
               "type": "module"
             },
             "dependencies": [
-              "wcpolyfill",
               "webcomponent.joomla-tab-legacy"
             ]
           }

--- a/build/build-modules-js/settings.json
+++ b/build/build-modules-js/settings.json
@@ -482,7 +482,8 @@
             "type": "script",
             "uri": "webcomponents-sd-ce-pf.js",
             "attributes": {
-              "nomodule": ""
+              "nomodule": true,
+              "defer": true
             },
             "dependencies": ["core"]
           }

--- a/build/build-modules-js/settings.json
+++ b/build/build-modules-js/settings.json
@@ -315,19 +315,57 @@
             "uri": "joomla-alert.min.css"
           },
           {
+            "name": "webcomponent.joomla-alert-legacy",
+            "type": "script",
+            "uri": "joomla-alert-es5.min.js",
+            "attributes": {
+              "nomodule": true,
+              "defer": true
+            },
+            "dependencies": [
+              "wcpolyfill"
+            ]
+          },
+          {
+            "name": "webcomponent.joomla-alert",
+            "type": "script",
+            "uri": "joomla-alert.min.js",
+            "attributes": {
+              "type": "module"
+            },
+            "dependencies": [
+              "wcpolyfill",
+              "webcomponent.joomla-alert-legacy"
+            ]
+          },
+          {
             "name": "webcomponent.joomla-tab",
             "type": "style",
             "uri": "joomla-tab.min.css"
           },
           {
-            "name": "webcomponent.joomla-alert",
+            "name": "webcomponent.joomla-tab-legacy",
             "type": "script",
-            "uri": "joomla-alert.min.js"
+            "uri": "joomla-tab-es5.min.js",
+            "attributes": {
+              "nomodule": true,
+              "defer": true
+            },
+            "dependencies": [
+              "wcpolyfill"
+            ]
           },
           {
             "name": "webcomponent.joomla-tab",
             "type": "script",
-            "uri": "joomla-tab.min.js"
+            "uri": "joomla-tab.min.js",
+            "attributes": {
+              "type": "module"
+            },
+            "dependencies": [
+              "wcpolyfill",
+              "webcomponent.joomla-tab-legacy"
+            ]
           }
         ],
         "dependencies": [],

--- a/build/media_source/system/joomla.asset.json
+++ b/build/media_source/system/joomla.asset.json
@@ -467,58 +467,6 @@
         "wcpolyfill",
         "webcomponent.toolbar-button-legacy"
       ]
-    },
-    {
-      "name": "webcomponent.joomla-alert",
-      "type": "style",
-      "uri": "vendor/joomla-custom-elements/joomla-alert.min.css"
-    },
-    {
-      "name": "webcomponent.joomla-alert-legacy",
-      "type": "script",
-      "uri": "vendor/joomla-custom-elements/joomla-alert-es5.min.js",
-      "attributes": {
-        "nomodule": "",
-        "defer": true
-      }
-    },
-    {
-      "name": "webcomponent.joomla-alert",
-      "type": "script",
-      "uri": "vendor/joomla-custom-elements/joomla-alert.min.js",
-      "attributes": {
-        "type": "module"
-      },
-      "dependencies": [
-        "wcpolyfill",
-        "webcomponent.joomla-alert-legacy"
-      ]
-    },
-    {
-      "name": "webcomponent.joomla-tab",
-      "type": "style",
-      "uri": "vendor/joomla-custom-elements/joomla-tab.min.css"
-    },
-    {
-      "name": "webcomponent.joomla-tab-legacy",
-      "type": "script",
-      "uri": "vendor/joomla-custom-elements/joomla-tab-es5.min.js",
-      "attributes": {
-        "nomodule": "",
-        "defer": true
-      }
-    },
-    {
-      "name": "webcomponent.joomla-tab",
-      "type": "script",
-      "uri": "vendor/joomla-custom-elements/joomla-tab.min.js",
-      "attributes": {
-        "type": "module"
-      },
-      "dependencies": [
-        "wcpolyfill",
-        "webcomponent.joomla-tab-legacy"
-      ]
     }
   ]
 }

--- a/build/media_source/system/joomla.asset.json
+++ b/build/media_source/system/joomla.asset.json
@@ -200,9 +200,13 @@
       "type": "script",
       "uri": "system/fields/joomla-field-fancy-select-es5.min.js",
       "attributes": {
-        "nomodule": "",
+        "nomodule": true,
         "defer": true
-      }
+      },
+      "dependencies": [
+        "wcpolyfill",
+        "choicesjs"
+      ]
     },
     {
       "name": "webcomponent.field-fancy-select",
@@ -212,7 +216,6 @@
         "type": "module"
       },
       "dependencies": [
-        "wcpolyfill",
         "choicesjs",
         "webcomponent.field-fancy-select-legacy"
       ]
@@ -232,9 +235,12 @@
       "type": "script",
       "uri": "system/fields/joomla-image-select-es5.min.js",
       "attributes": {
-        "nomodule": "",
+        "nomodule": true,
         "defer": true
-      }
+      },
+      "dependencies": [
+        "wcpolyfill"
+      ]
     },
     {
       "name": "webcomponent.image-select",
@@ -244,7 +250,6 @@
         "type": "module"
       },
       "dependencies": [
-        "wcpolyfill",
         "webcomponent.image-select-legacy"
       ]
     },
@@ -253,9 +258,12 @@
       "type": "script",
       "uri": "system/fields/joomla-field-media-es5.min.js",
       "attributes": {
-        "nomodule": "",
+        "nomodule": true,
         "defer": true
-      }
+      },
+      "dependencies": [
+        "wcpolyfill"
+      ]
     },
     {
       "name": "webcomponent.field-media",
@@ -265,7 +273,6 @@
         "type": "module"
       },
       "dependencies": [
-        "wcpolyfill",
         "webcomponent.field-media-legacy"
       ]
     },
@@ -274,9 +281,12 @@
       "type": "script",
       "uri": "system/fields/joomla-field-module-order-es5.min.js",
       "attributes": {
-        "nomodule": "",
+        "nomodule": true,
         "defer": true
-      }
+      },
+      "dependencies": [
+        "wcpolyfill"
+      ]
     },
     {
       "name": "webcomponent.field-module-order",
@@ -286,7 +296,6 @@
         "type": "module"
       },
       "dependencies": [
-        "wcpolyfill",
         "webcomponent.field-module-order-legacy"
       ]
     },
@@ -300,9 +309,12 @@
       "type": "script",
       "uri": "system/fields/joomla-field-permissions-es5.min.js",
       "attributes": {
-        "nomodule": "",
+        "nomodule": true,
         "defer": true
-      }
+      },
+      "dependencies": [
+        "wcpolyfill"
+      ]
     },
     {
       "name": "webcomponent.field-permissions",
@@ -312,7 +324,6 @@
         "type": "module"
       },
       "dependencies": [
-        "wcpolyfill",
         "webcomponent.field-permissions-legacy"
       ]
     },
@@ -321,9 +332,12 @@
       "type": "script",
       "uri": "system/fields/joomla-field-send-test-mail-es5.min.js",
       "attributes": {
-        "nomodule": "",
+        "nomodule": true,
         "defer": true
-      }
+      },
+      "dependencies": [
+        "wcpolyfill"
+      ]
     },
     {
       "name": "webcomponent.field-send-test-mail",
@@ -333,7 +347,6 @@
         "type": "module"
       },
       "dependencies": [
-        "wcpolyfill",
         "webcomponent.field-send-test-mail-legacy"
       ]
     },
@@ -347,9 +360,12 @@
       "type": "script",
       "uri": "system/fields/joomla-field-simple-color-es5.min.js",
       "attributes": {
-        "nomodule": "",
+        "nomodule": true,
         "defer": true
-      }
+      },
+      "dependencies": [
+        "wcpolyfill"
+      ]
     },
     {
       "name": "webcomponent.field-simple-color",
@@ -359,7 +375,6 @@
         "type": "module"
       },
       "dependencies": [
-        "wcpolyfill",
         "webcomponent.field-simple-color-legacy"
       ]
     },
@@ -368,9 +383,12 @@
       "type": "script",
       "uri": "system/fields/joomla-field-subform-es5.min.js",
       "attributes": {
-        "nomodule": "",
+        "nomodule": true,
         "defer": true
-      }
+      },
+      "dependencies": [
+        "wcpolyfill"
+      ]
     },
     {
       "name": "webcomponent.field-subform",
@@ -380,7 +398,6 @@
         "type": "module"
       },
       "dependencies": [
-        "wcpolyfill",
         "webcomponent.field-subform-legacy"
       ]
     },
@@ -389,9 +406,12 @@
       "type": "script",
       "uri": "system/fields/joomla-field-user-es5.min.js",
       "attributes": {
-        "nomodule": "",
+        "nomodule": true,
         "defer": true
-      }
+      },
+      "dependencies": [
+        "wcpolyfill"
+      ]
     },
     {
       "name": "webcomponent.field-user",
@@ -401,7 +421,6 @@
         "type": "module"
       },
       "dependencies": [
-        "wcpolyfill",
         "webcomponent.field-user-legacy"
       ]
     },
@@ -410,9 +429,12 @@
       "type": "script",
       "uri": "system/joomla-core-loader-es5.min.js",
       "attributes": {
-        "nomodule": "",
+        "nomodule": true,
         "defer": true
-      }
+      },
+      "dependencies": [
+        "wcpolyfill"
+      ]
     },
     {
       "name": "webcomponent.core-loader",
@@ -422,7 +444,6 @@
         "type": "module"
       },
       "dependencies": [
-        "wcpolyfill",
         "webcomponent.core-loader-legacy"
       ]
     },
@@ -431,9 +452,12 @@
       "type": "script",
       "uri": "system/joomla-hidden-mail-es5.min.js",
       "attributes": {
-        "nomodule": "",
+        "nomodule": true,
         "defer": true
-      }
+      },
+      "dependencies": [
+        "wcpolyfill"
+      ]
     },
     {
       "name": "webcomponent.hidden-mail",
@@ -443,7 +467,6 @@
         "type": "module"
       },
       "dependencies": [
-        "wcpolyfill",
         "webcomponent.hidden-mail-legacy"
       ]
     },
@@ -452,9 +475,12 @@
       "type": "script",
       "uri": "system/joomla-toolbar-button-es5.min.js",
       "attributes": {
-        "nomodule": "",
+        "nomodule": true,
         "defer": true
-      }
+      },
+      "dependencies": [
+        "wcpolyfill"
+      ]
     },
     {
       "name": "webcomponent.toolbar-button",
@@ -464,7 +490,6 @@
         "type": "module"
       },
       "dependencies": [
-        "wcpolyfill",
         "webcomponent.toolbar-button-legacy"
       ]
     }

--- a/libraries/src/Document/Renderer/Html/ScriptsRenderer.php
+++ b/libraries/src/Document/Renderer/Html/ScriptsRenderer.php
@@ -291,7 +291,7 @@ class ScriptsRenderer extends DocumentRenderer
 		$buffer = '';
 
 		$defaultJsMimes         = array('text/javascript', 'application/javascript', 'text/x-javascript', 'application/x-javascript');
-		$html5NoValueAttributes = array('defer', 'async');
+		$html5NoValueAttributes = array('defer', 'async', 'nomodule');
 
 		foreach ($attributes as $attrib => $value)
 		{
@@ -307,19 +307,22 @@ class ScriptsRenderer extends DocumentRenderer
 				continue;
 			}
 
-			// B/C: If defer and async is false or empty don't render the attribute.
-			if (\in_array($attrib, array('defer', 'async')) && !$value)
+			// B/C: If defer and async is false or empty don't render the attribute. Also skip if value is bool:false.
+			if (\in_array($attrib, array('defer', 'async')) && !$value || $value === false)
 			{
 				continue;
 			}
+
+			// NoValue attribute, if it have bool:true
+			$isNoValueAttrib = $value === true || \in_array($attrib, $html5NoValueAttributes);
 
 			// Don't add type attribute if document is HTML5 and it's a default mime type. 'mime' is for B/C.
 			if ($attrib === 'mime')
 			{
 				$attrib = 'type';
 			}
-			// B/C defer and async can be set to yes when using the old method.
-			elseif (\in_array($attrib, array('defer', 'async')) && $value === true)
+			// NoValue attribute in non HTML5 should contain a value, set it equal to attribute name.
+			elseif ($isNoValueAttrib)
 			{
 				$value = $attrib;
 			}
@@ -327,7 +330,7 @@ class ScriptsRenderer extends DocumentRenderer
 			// Add attribute to script tag output.
 			$buffer .= ' ' . htmlspecialchars($attrib, ENT_COMPAT, 'UTF-8');
 
-			if (!($this->_doc->isHtml5() && \in_array($attrib, $html5NoValueAttributes)))
+			if (!($this->_doc->isHtml5() && $isNoValueAttrib))
 			{
 				// Json encode value if it's an array.
 				$value = !is_scalar($value) ? json_encode($value) : $value;

--- a/libraries/src/Document/Renderer/Html/StylesRenderer.php
+++ b/libraries/src/Document/Renderer/Html/StylesRenderer.php
@@ -299,19 +299,36 @@ class StylesRenderer extends DocumentRenderer
 				continue;
 			}
 
+			// Skip the attribute if value is bool:false.
+			if ($value === false)
+			{
+				continue;
+			}
+
+			// NoValue attribute, if it have bool:true
+			$isNoValueAttrib = $value === true;
+
 			// Don't add type attribute if document is HTML5 and it's a default mime type. 'mime' is for B/C.
 			if ($attrib === 'mime')
 			{
 				$attrib = 'type';
 			}
+			// NoValue attribute in non HTML5 should contain a value, set it equal to attribute name.
+			elseif ($isNoValueAttrib)
+			{
+				$value = $attrib;
+			}
 
 			// Add attribute to script tag output.
 			$buffer .= ' ' . htmlspecialchars($attrib, ENT_COMPAT, 'UTF-8');
 
-			// Json encode value if it's an array.
-			$value = !is_scalar($value) ? json_encode($value) : $value;
+			if (!($this->_doc->isHtml5() && $isNoValueAttrib))
+			{
+				// Json encode value if it's an array.
+				$value = !is_scalar($value) ? json_encode($value) : $value;
 
-			$buffer .= '="' . htmlspecialchars($value, ENT_COMPAT, 'UTF-8') . '"';
+				$buffer .= '="' . htmlspecialchars($value, ENT_COMPAT, 'UTF-8') . '"';
+			}
 		}
 
 		return $buffer;


### PR DESCRIPTION
### Summary of Changes
Fix WebComponent dependencies after merging #32171
And joomla-alert and joomla-tabs was duplicated in a "system" asset, however it is a "vendor" asset.

Also I have fixed "no value attributes" rendering, it should be good to test in 1 pr.

### Testing Instructions

Apply patch, run `npm install`,
Open backend, and check for page source code where a scripts is rendered.

Look for example for `joomla-alert-legacy.js`


### Actual result BEFORE applying this Pull Request

`joomla-alert-legacy.js` goes before `webcomponents-sd-ce-pf.js`
"nomodule" atribute rendered as `nomodule=""`

### Expected result AFTER applying this Pull Request

`joomla-alert-legacy.js` goes after `webcomponents-sd-ce-pf.js`
"nomodule" attribute rendered as `nomodule`


### Documentation Changes Required
none

bip bip @dgrammatiko @wilsonge 