### PR TITLE
[4.0] svg logo [a11y]

### DIFF
--- a/build/media_source/templates/atum/js/template.es6.js
+++ b/build/media_source/templates/atum/js/template.es6.js
@@ -103,6 +103,10 @@
             svg.setAttribute('viewBox', `0 0 ${svg.getAttribute('height')} ${svg.getAttribute('width')}`);
           }
 
+          // SVG needs to have a role of presentation and focusable set to false
+          svg.setAttribute('role', 'presentation');
+          svg.setAttribute('focusable', 'false');
+
           // Replace image with new SVG
           img.parentElement.replaceChild(svg, img);
         },


### PR DESCRIPTION
Due to some "bugs" in some screenreaders and browsers and how they handle svg it is recommended to set them to focusable=false and ensure they have the correct role.

Because of the way we handle svg logos in the template this has to be done in the js and not the svg file itself.

The only way to really test after applying the PR and npm i is to view the source. If successable the svg will have the role and focusable attributes as below

![image](https://user-images.githubusercontent.com/1296369/106354732-d5e01080-62eb-11eb-8a29-18785abd72e9.png)
