### PR TITLE
[4.0] Fixing series of Docblocks and mapped class inheritances

### DIFF
--- a/libraries/src/Adapter/Adapter.php
+++ b/libraries/src/Adapter/Adapter.php
@@ -58,7 +58,7 @@ class Adapter extends CMSObject
 	/**
 	 * Database Connector Object
 	 *
-	 * @var    \JDatabaseDriver
+	 * @var    \Joomla\Database\DatabaseDriver
 	 * @since  1.6
 	 */
 	protected $_db;
@@ -84,7 +84,7 @@ class Adapter extends CMSObject
 	/**
 	 * Get the database connector object
 	 *
-	 * @return  \JDatabaseDriver  Database connector object
+	 * @return  \Joomla\Database\DatabaseDriver  Database connector object
 	 *
 	 * @since   1.6
 	 */

--- a/libraries/src/Installer/Adapter/ComponentAdapter.php
+++ b/libraries/src/Installer/Adapter/ComponentAdapter.php
@@ -1270,7 +1270,7 @@ class ComponentAdapter extends InstallerAdapter
 	{
 		$db = $this->parent->getDbo();
 
-		/** @var  \JTableMenu  $table */
+		/** @var  \Joomla\CMS\Table\Menu  $table */
 		$table = Table::getInstance('menu');
 
 		// Get the ids of the menu items
@@ -1530,7 +1530,7 @@ class ComponentAdapter extends InstallerAdapter
 	{
 		$db = $this->parent->getDbo();
 
-		/** @var  \JTableMenu  $table */
+		/** @var  \Joomla\CMS\Table\Menu  $table */
 		$table  = Table::getInstance('menu');
 
 		try
@@ -1584,7 +1584,7 @@ class ComponentAdapter extends InstallerAdapter
 			}
 			else
 			{
-				/** @var  \JTableMenu $temporaryTable */
+				/** @var  \Joomla\CMS\Table\Menu $temporaryTable */
 				$temporaryTable = Table::getInstance('menu');
 				$temporaryTable->delete($menu_id, true);
 				$temporaryTable->load($parentId);

--- a/libraries/src/Installer/Installer.php
+++ b/libraries/src/Installer/Installer.php
@@ -10,6 +10,7 @@ namespace Joomla\CMS\Installer;
 
 \defined('JPATH_PLATFORM') or die;
 
+use Joomla\CMS\Adapter\Adapter;
 use Joomla\CMS\Application\ApplicationHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Filesystem\File;
@@ -24,14 +25,12 @@ use Joomla\Database\DatabaseDriver;
 use Joomla\Database\Exception\ExecutionFailureException;
 use Joomla\Database\ParameterType;
 
-\JLoader::import('joomla.base.adapter');
-
 /**
  * Joomla base installer class
  *
  * @since  3.1
  */
-class Installer extends \JAdapter
+class Installer extends Adapter
 {
 	/**
 	 * Array of paths needed by the installer

--- a/libraries/src/MVC/View/CategoryView.php
+++ b/libraries/src/MVC/View/CategoryView.php
@@ -10,6 +10,7 @@ namespace Joomla\CMS\MVC\View;
 
 \defined('JPATH_PLATFORM') or die;
 
+use Joomla\CMS\Categories\CategoryNode;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Helper\TagsHelper;
 use Joomla\CMS\Language\Text;
@@ -42,7 +43,7 @@ class CategoryView extends HtmlView
 	/**
 	 * The category model object for this category
 	 *
-	 * @var    \JModelCategory
+	 * @var    CategoryNode
 	 * @since  3.2
 	 */
 	protected $category;

--- a/libraries/src/MVC/View/ListView.php
+++ b/libraries/src/MVC/View/ListView.php
@@ -37,7 +37,7 @@ class ListView extends HtmlView
 	/**
 	 * The pagination object
 	 *
-	 * @var  \JPagination
+	 * @var  \Joomla\CMS\Pagination\Pagination
 	 */
 	protected $pagination;
 
@@ -58,7 +58,7 @@ class ListView extends HtmlView
 	/**
 	 * Form object for search filters
 	 *
-	 * @var  \JForm
+	 * @var  \Joomla\CMS\Form\Form
 	 */
 	public $filterForm;
 

--- a/libraries/src/Updater/UpdateAdapter.php
+++ b/libraries/src/Updater/UpdateAdapter.php
@@ -10,6 +10,7 @@ namespace Joomla\CMS\Updater;
 
 \defined('JPATH_PLATFORM') or die;
 
+use Joomla\CMS\Adapter\AdapterInstance;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Http\HttpFactory;
 use Joomla\CMS\Language\Text;
@@ -18,14 +19,12 @@ use Joomla\CMS\Version;
 use Joomla\Database\ParameterType;
 use Joomla\Registry\Registry;
 
-\JLoader::import('joomla.base.adapterinstance');
-
 /**
  * UpdateAdapter class.
  *
  * @since  1.7.0
  */
-abstract class UpdateAdapter extends \JAdapterInstance
+abstract class UpdateAdapter extends AdapterInstance
 {
 	/**
 	 * Resource handle for the XML Parser

--- a/libraries/src/Updater/Updater.php
+++ b/libraries/src/Updater/Updater.php
@@ -10,18 +10,17 @@ namespace Joomla\CMS\Updater;
 
 \defined('JPATH_PLATFORM') or die;
 
+use Joomla\CMS\Adapter\Adapter;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Table\Table;
 use Joomla\Database\ParameterType;
-
-\JLoader::import('joomla.base.adapter');
 
 /**
  * Updater Class
  *
  * @since  1.7.0
  */
-class Updater extends \JAdapter
+class Updater extends Adapter
 {
 	/**
 	 * Development snapshots, nightly builds, pre-release versions and so on


### PR DESCRIPTION
I ran https://psalm.dev/ over our codebase and fixed a few of the reported issues. This replaces the old class names with the new namespaced ones in a few docblocks and also changes the parent classes from a few classes from the old (mapped) names to the new namespaced ones.