### PR TITLE
Fix issue #32210

### DIFF
--- a/components/com_users/controllers/user.php
+++ b/components/com_users/controllers/user.php
@@ -232,8 +232,9 @@ class UsersControllerUser extends UsersController
 	{
 		// Get the ItemID of the page to redirect after logout
 		$app    = JFactory::getApplication();
-		$itemid = $app->getMenu()->getActive()->params->get('logout');
-
+		$active = $app->getMenu()->getActive();
+		$itemid = $active ? $active->getParams()->get('logout') : 0;
+		
 		// Get the language of the page when multilang is on
 		if (JLanguageMultilang::isEnabled())
 		{


### PR DESCRIPTION
Pull Request for Issue #32210.

### Summary of Changes
Added code to check to make sure menu item is active before getting redirect menu item from menu parameters to avoid fatal error on menulogout method. 

I could not re-procedure the issue as mentioned in https://github.com/joomla/joomla-cms/issues/32210. However, we can see that fatal error by access to direct link http://localhost/joomla/index.php/component/users?task=user.menulogout

### Testing Instructions

1. Login
2. Access to this link http://localhost/joomla/index.php/component/users?task=user.menulogout (direct link to trigger menulogout  method in users controller
3. Before patch: You get fatal error.
4. Apply patch: You are being logged out.
