### PR TITLE
[4.0]Use form-select instead of form-control for states select

### DIFF
--- a/libraries/src/HTML/Helpers/Grid.php
+++ b/libraries/src/HTML/Helpers/Grid.php
@@ -236,7 +236,7 @@ abstract class Grid
 			$state,
 			'filter_state',
 			array(
-				'list.attr' => 'class="form-control" size="1" onchange="Joomla.submitform();"',
+				'list.attr' => 'class="form-select" size="1" onchange="Joomla.submitform();"',
 				'list.select' => $filterState,
 				'option.key' => null,
 			)


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Method state in Joomla\CMS\HTML\Helpers\Grid class generate states dropdown (select element), so it should use form-select class instead of form-control (bootstrap 5). I found this small issue while testing my extensions in latest Joomla 4 nightly build


### Testing Instructions
Code review.
