### PR TITLE
[4.0] Fix bootstrap.framework

### DIFF
--- a/libraries/src/HTML/Helpers/Bootstrap.php
+++ b/libraries/src/HTML/Helpers/Bootstrap.php
@@ -528,11 +528,15 @@ abstract class Bootstrap
 	 */
 	public static function framework($debug = null) :void
 	{
+		$wa = Factory::getApplication()
+			->getDocument()
+			->getWebAssetManager();
+
 		array_map(
-			function ($script) {
-				HTMLHelper::_('bootstrap.' . $script);
+			function ($script) use ($wa) {
+				$wa->useScript('bootstrap.' . $script);
 			},
-			static::$scripts
+			['alert', 'button', 'carousel', 'collapse', 'dropdown', 'modal', 'popover', 'scrollspy', 'tab', 'toast', 'tooltip']
 		);
 	}
 

--- a/libraries/src/HTML/Helpers/Bootstrap.php
+++ b/libraries/src/HTML/Helpers/Bootstrap.php
@@ -536,7 +536,7 @@ abstract class Bootstrap
 			function ($script) use ($wa) {
 				$wa->useScript('bootstrap.' . $script);
 			},
-			['alert', 'button', 'carousel', 'collapse', 'dropdown', 'modal', 'popover', 'scrollspy', 'tab', 'toast', 'tooltip']
+			['alert', 'button', 'carousel', 'collapse', 'dropdown', 'modal', 'popover', 'scrollspy', 'tab', 'toast']
 		);
 	}
 


### PR DESCRIPTION
### Summary of Changes

Additionally to #32208


### Testing Instructions

call `HTMLHelper::_('bootstrap.framework')`

### Actual result BEFORE applying this Pull Request
error


### Expected result AFTER applying this Pull Request

works

### Documentation Changes Required
none

bip bip @wilsonge @dgrammatiko 
