### PR TITLE
[4.0] Associations style

### DIFF
--- a/administrator/components/com_menus/tmpl/items/default.php
+++ b/administrator/components/com_menus/tmpl/items/default.php
@@ -82,7 +82,7 @@ $assoc   = Associations::isEnabled() && $this->state->get('filter.client_id') ==
 								</th>
 							<?php endif; ?>
 							<?php if ($assoc) : ?>
-								<th scope="col" class="w-10 d-none d-md-table-cell text-center">
+								<th scope="col" class="w-10 d-none d-md-table-cell">
 									<?php echo HTMLHelper::_('searchtools.sort', 'COM_MENUS_HEADING_ASSOCIATION', 'association', $listDirn, $listOrder); ?>
 								</th>
 							<?php endif; ?>
@@ -242,7 +242,7 @@ $assoc   = Associations::isEnabled() && $this->state->get('filter.client_id') ==
 									</td>
 								<?php endif; ?>
 								<?php if ($assoc) : ?>
-									<td class="small d-none d-md-table-cell text-center">
+									<td class="small d-none d-md-table-cell">
 										<?php if ($item->association) : ?>
 											<?php echo HTMLHelper::_('menus.association', $item->id); ?>
 										<?php endif; ?>

--- a/administrator/components/com_newsfeeds/tmpl/newsfeeds/default.php
+++ b/administrator/components/com_newsfeeds/tmpl/newsfeeds/default.php
@@ -73,7 +73,7 @@ if ($saveOrder && !empty($this->items))
 									<?php echo HTMLHelper::_('searchtools.sort', 'COM_NEWSFEEDS_CACHE_TIME_HEADING', 'a.cache_time', $listDirn, $listOrder); ?>
 								</th>
 								<?php if ($assoc) : ?>
-								<th scope="col" class="w-10 d-none d-md-table-cell text-center">
+								<th scope="col" class="w-10 d-none d-md-table-cell">
 									<?php echo HTMLHelper::_('searchtools.sort', 'COM_NEWSFEEDS_HEADING_ASSOCIATION', 'association', $listDirn, $listOrder); ?>
 								</th>
 								<?php endif; ?>
@@ -151,7 +151,7 @@ if ($saveOrder && !empty($this->items))
 									<?php echo (int) $item->cache_time; ?>
 								</td>
 								<?php if ($assoc) : ?>
-								<td class="d-none d-md-table-cell text-center">
+								<td class="d-none d-md-table-cell">
 									<?php if ($item->association) : ?>
 										<?php echo HTMLHelper::_('newsfeedsadministrator.association', $item->id); ?>
 									<?php endif; ?>

--- a/administrator/templates/atum/scss/blocks/_global.scss
+++ b/administrator/templates/atum/scss/blocks/_global.scss
@@ -159,6 +159,7 @@ body .container-main {
 .item-associations li {
   display: inline-block;
   list-style: none;
+  margin-bottom: 3px;
 }
 
 // Quickicon specific

--- a/administrator/templates/atum/scss/blocks/_global.scss
+++ b/administrator/templates/atum/scss/blocks/_global.scss
@@ -158,8 +158,8 @@ body .container-main {
 
 .item-associations li {
   display: inline-block;
-  list-style: none;
   margin-bottom: 3px;
+  list-style: none;
 }
 
 // Quickicon specific


### PR DESCRIPTION
For consistency all the associations buttons are now not center aligned.

A margin bottom has also been applied to the buttons to ensure equal distribution when the buttons wrap.

To test you need a multilingual site with more than two languages AND rebuild the css with npm i

### Before Menu Items
![image](https://user-images.githubusercontent.com/1296369/106385385-fed5d380-63c7-11eb-95b8-60062e419f29.png)

### Before Articles
![image](https://user-images.githubusercontent.com/1296369/106385363-d9e16080-63c7-11eb-9da6-7cb4b6dac061.png)

### After Menu Items
![image](https://user-images.githubusercontent.com/1296369/106385319-a0a8f080-63c7-11eb-972a-87301e815cb4.png)

### After Articles
![image](https://user-images.githubusercontent.com/1296369/106385331-b4545700-63c7-11eb-8e53-bc3249f60f27.png)
