### PR TITLE
[4.0] Stop tabs shifting and fix contrast issue

### DIFF
--- a/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-tab.scss
+++ b/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-tab.scss
@@ -136,12 +136,12 @@ joomla-tab {
       position: relative;
       display: block;
       padding: .75em 1em;
+      margin: -1px 0;
       color: var(--atum-special-color);
       text-decoration: none;
       border-top: 1px solid #fff;
       border-bottom: 1px solid $gray-300;
       box-shadow: none;
-      margin: -1px 0;
 
       &[active],
       &:hover {

--- a/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-tab.scss
+++ b/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-tab.scss
@@ -57,7 +57,7 @@ joomla-tab {
         margin: -1px;
         background-color: $white;
         background-image: none;
-        border: 2px solid var(--bluegray);
+        border: 1px solid var(--bluegray);
         border-bottom: solid 1px #fff;
         border-radius: 0;
         box-shadow: none;

--- a/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-tab.scss
+++ b/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-tab.scss
@@ -160,7 +160,7 @@ joomla-tab {
         }
 
         .text-muted {
-          color: var(--atum-text-light)!important;
+          color: var(--atum-text-light) !important;
         }
       }
     }

--- a/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-tab.scss
+++ b/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-tab.scss
@@ -138,9 +138,10 @@ joomla-tab {
       padding: .75em 1em;
       color: var(--atum-special-color);
       text-decoration: none;
-      border: 0;
+      border-top: 1px solid #fff;
       border-bottom: 1px solid $gray-300;
       box-shadow: none;
+      margin: -1px 0;
 
       &[active],
       &:hover {

--- a/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-tab.scss
+++ b/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-tab.scss
@@ -139,7 +139,7 @@ joomla-tab {
       margin: -1px 0;
       color: var(--atum-special-color);
       text-decoration: none;
-      border-top: 1px solid #fff;
+      border-top: 1px solid transparent;
       border-bottom: 1px solid $gray-300;
       box-shadow: none;
 

--- a/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-tab.scss
+++ b/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-tab.scss
@@ -158,6 +158,10 @@ joomla-tab {
           height: auto;
           background-color: var(--atum-bg-dark);
         }
+
+        .text-muted {
+          color: var(--atum-text-light)!important;
+        }
       }
     }
 


### PR DESCRIPTION
Apply pr and rebuild css with npm i and test the TWO issues

### Before
![before](https://user-images.githubusercontent.com/1296369/106442817-a5c37980-6473-11eb-8565-704996354696.gif)

### After
![after](https://user-images.githubusercontent.com/1296369/106442854-b4aa2c00-6473-11eb-9c64-8ef5882abf20.gif)

### Before
![image](https://user-images.githubusercontent.com/1296369/106400767-716e9f80-6418-11eb-9ae6-d5c9136d9af7.png)

### After
![image](https://user-images.githubusercontent.com/1296369/106400757-6287ed00-6418-11eb-81bf-29f4323a55dd.png)
