### PR TITLE
[4.0] rules field inline style

### DIFF
--- a/layouts/joomla/form/field/rules.php
+++ b/layouts/joomla/form/field/rules.php
@@ -105,15 +105,15 @@ $ajaxUri = Route::_('index.php?option=com_config&task=application.store&format=j
 				<table class="table respTable">
 					<thead>
 						<tr>
-							<th style="width: 30%" class="actions" id="actions-th<?php echo $group->value; ?>">
+							<th class="actions w-30" id="actions-th<?php echo $group->value; ?>">
 								<span class="acl-action"><?php echo Text::_('JLIB_RULES_ACTION'); ?></span>
 							</th>
 
-							<th style="width: 40%" class="settings" id="settings-th<?php echo $group->value; ?>">
+							<th class="settings w-40" id="settings-th<?php echo $group->value; ?>">
 								<span class="acl-action"><?php echo Text::_('JLIB_RULES_SELECT_SETTING'); ?></span>
 							</th>
 
-							<th style="width: 30%" id="aclaction-th<?php echo $group->value; ?>">
+							<th class="w-30" id="aclaction-th<?php echo $group->value; ?>">
 								<span class="acl-action"><?php echo Text::_('JLIB_RULES_CALCULATED_SETTING'); ?></span>
 							</th>
 						</tr>


### PR DESCRIPTION
This PR replaces the inline styles used for the permissions with classes. This replacement was done everywhere but it looks like the change was missed here.

There is no visible change as the widths are the same
