### PR TITLE
[4.0] Subform instead of SubForm

### DIFF
--- a/libraries/src/Form/FormField.php
+++ b/libraries/src/Form/FormField.php
@@ -1241,7 +1241,7 @@ abstract class FormField
 		if ($valid !== false && $this instanceof SubformField)
 		{
 			// Load the subform validation rule.
-			$rule = FormHelper::loadRuleType('SubForm');
+			$rule = FormHelper::loadRuleType('Subform');
 
 			try
 			{


### PR DESCRIPTION
### Summary of Changes
- See changed code. Typo corrected.

### Testing Instructions
- https://github.com/joomla/joomla-cms/pull/32217 must be fixed/merged first.

- Go to `administrator/index.php?option=com_config&view=component&component=com_users`
- Tabulator `Email Domain Options`
- Add a subform row, fill it
- Click on `Save`

### Actual result BEFORE applying this Pull Request
- Error `Call to a member function test() on bool`, `JROOT/libraries/src/Form/FormField.php:1249 `
- This happens in all extensions with a subform via JForm.

### Expected result AFTER applying this Pull Request
- Saving without error
- Subform field correctly saved and displayed with newly created row

