### PR TITLE
[4.0] com_associations: normalizing columns width

### DIFF
--- a/administrator/components/com_associations/tmpl/associations/default.php
+++ b/administrator/components/com_associations/tmpl/associations/default.php
@@ -71,7 +71,7 @@ Text::script('COM_ASSOCIATIONS_PURGE_CONFIRM_PROMPT', true);
 								<th scope="col" class="w-15">
 									<?php echo Text::_('JGRID_HEADING_LANGUAGE'); ?>
 								</th>
-								<th scope="col" class="w-5">
+								<th scope="col" class="w-15">
 									<?php echo Text::_('COM_ASSOCIATIONS_HEADING_ASSOCIATION'); ?>
 								</th>
 								<th scope="col" class="w-15">


### PR DESCRIPTION
### Summary of Changes
`Associations` and `Not Associated` columns should have same default width
Although `w-5` may look fine in en-GB as the title of the column is relatively long, it does not work nicely in Persian.

### Testing Instructions
Create a multilingual site with multiple languages and associate a few articles
Load  Multilingual Associations component
Switch to Persian admin language.


### Actual result BEFORE applying this Pull Request

Reference for en-GB

<img width="1162" alt="Screen Shot 2021-02-01 at 12 18 12" src="https://user-images.githubusercontent.com/869724/106452043-a534de00-6487-11eb-8c34-c0f58fd147df.png">

Persian 

<img width="1153" alt="Screen Shot 2021-02-01 at 11 59 48" src="https://user-images.githubusercontent.com/869724/106451147-6c483980-6486-11eb-8399-139cdc3185db.png">


### Expected result AFTER applying this Pull Request
<img width="1151" alt="Screen Shot 2021-02-01 at 12 00 13" src="https://user-images.githubusercontent.com/869724/106451184-79fdbf00-6486-11eb-8abb-1b128e2a9c2f.png">

