### PR TITLE
[4.0] Left align ID column

### DIFF
--- a/administrator/components/com_csp/tmpl/reports/default.php
+++ b/administrator/components/com_csp/tmpl/reports/default.php
@@ -128,7 +128,7 @@ $saveOrder = $listOrder == 'a.id';
 									<td class="d-none d-md-table-cell">
 										<?php echo $item->created > 0 ? HTMLHelper::_('date', $item->created, Text::_('DATE_FORMAT_LC4')) : '-'; ?>
 									</td>
-									<td class="text-center d-none d-md-table-cell">
+									<td class="d-none d-md-table-cell">
 										<?php echo $item->id; ?>
 									</td>
 								</tr>

--- a/administrator/components/com_menus/tmpl/menus/default.php
+++ b/administrator/components/com_menus/tmpl/menus/default.php
@@ -225,7 +225,7 @@ $wa->useScript('com_menus.admin-menus');
 											); ?>
 									<?php endif; ?>
 								</td>
-								<td class="d-none d-lg-table-cell text-center">
+								<td class="d-none d-lg-table-cell">
 									<?php echo $item->id; ?>
 								</td>
 							</tr>


### PR DESCRIPTION
### Summary of Changes
To be consistent with the ID column in other sections, make the following be left-aligned.


### Testing Instructions
Code review.

or

Go to Menus > Manage
See ID column.

Go to System > Content Security Policy
Enable it to see entries.
See ID  column.


### Actual result BEFORE applying this Pull Request
ID column is centered.


### Expected result AFTER applying this Pull Request
ID column is left-aligned.