### PR TITLE
[4.0] Set sidebar countModule content aware

### DIFF
--- a/templates/cassiopeia/index.php
+++ b/templates/cassiopeia/index.php
@@ -125,9 +125,9 @@ $stickyHeader = $this->params->get('stickyHeader') ? 'position-sticky sticky-top
 				<?php endif; ?>
 			</div>
 		</div>
-		<?php if ($this->countModules('menu') || $this->countModules('search')) : ?>
+		<?php if ($this->countModules('menu', true) || $this->countModules('search', true)) : ?>
 			<div class="grid-child container-nav">
-				<?php if ($this->countModules('menu')) : ?>
+				<?php if ($this->countModules('menu', true)) : ?>
 					<nav class="navbar navbar-expand-md">
 						<?php HTMLHelper::_('bootstrap.collapse', '.navbar-toggler'); ?>
 						<button class="navbar-toggler navbar-toggler-right" type="button" data-bs-toggle="collapse" data-bs-target="#navbar" aria-controls="navbar" aria-expanded="false" aria-label="<?php echo Text::_('TPL_CASSIOPEIA_TOGGLE'); ?>">
@@ -138,7 +138,7 @@ $stickyHeader = $this->params->get('stickyHeader') ? 'position-sticky sticky-top
 						</div>
 					</nav>
 				<?php endif; ?>
-				<?php if ($this->countModules('search')) : ?>
+				<?php if ($this->countModules('search', true)) : ?>
 					<div class="container-search">
 						<jdoc:include type="modules" name="search" style="none" />
 					</div>
@@ -147,19 +147,19 @@ $stickyHeader = $this->params->get('stickyHeader') ? 'position-sticky sticky-top
 		<?php endif; ?>
 	</header>
 
-	<?php if ($this->countModules('banner')) : ?>
+	<?php if ($this->countModules('banner', true)) : ?>
 		<div class="container-banner full-width">
 			<jdoc:include type="modules" name="banner" style="none" />
 		</div>
 	<?php endif; ?>
 
-	<?php if ($this->countModules('top-a')) : ?>
+	<?php if ($this->countModules('top-a', true)) : ?>
 	<div class="grid-child container-top-a">
 		<jdoc:include type="modules" name="top-a" style="card" />
 	</div>
 	<?php endif; ?>
 
-	<?php if ($this->countModules('top-b')) : ?>
+	<?php if ($this->countModules('top-b', true)) : ?>
 	<div class="grid-child container-top-b">
 		<jdoc:include type="modules" name="top-b" style="card" />
 	</div>
@@ -187,19 +187,19 @@ $stickyHeader = $this->params->get('stickyHeader') ? 'position-sticky sticky-top
 	</div>
 	<?php endif; ?>
 
-	<?php if ($this->countModules('bottom-a')) : ?>
+	<?php if ($this->countModules('bottom-a', true)) : ?>
 	<div class="grid-child container-bottom-a">
 		<jdoc:include type="modules" name="bottom-a" style="card" />
 	</div>
 	<?php endif; ?>
 
-	<?php if ($this->countModules('bottom-b')) : ?>
+	<?php if ($this->countModules('bottom-b', true)) : ?>
 	<div class="grid-child container-bottom-b">
 		<jdoc:include type="modules" name="bottom-b" style="card" />
 	</div>
 	<?php endif; ?>
 
-	<?php if ($this->countModules('footer')) : ?>
+	<?php if ($this->countModules('footer', true)) : ?>
 	<footer class="container-footer footer full-width">
 		<div class="grid-child">
 			<jdoc:include type="modules" name="footer" style="none" />

--- a/templates/cassiopeia/index.php
+++ b/templates/cassiopeia/index.php
@@ -79,12 +79,12 @@ else
 
 $hasClass = '';
 
-if ($this->countModules('sidebar-left'))
+if ($this->countModules('sidebar-left', true))
 {
 	$hasClass .= ' has-sidebar-left';
 }
 
-if ($this->countModules('sidebar-right'))
+if ($this->countModules('sidebar-right', true))
 {
 	$hasClass .= ' has-sidebar-right';
 }
@@ -165,7 +165,7 @@ $stickyHeader = $this->params->get('stickyHeader') ? 'position-sticky sticky-top
 	</div>
 	<?php endif; ?>
 
-	<?php if ($this->countModules('sidebar-left')) : ?>
+	<?php if ($this->countModules('sidebar-left', true)) : ?>
 	<div class="grid-child container-sidebar-left">
 		<jdoc:include type="modules" name="sidebar-left" style="card" />
 	</div>
@@ -181,7 +181,7 @@ $stickyHeader = $this->params->get('stickyHeader') ? 'position-sticky sticky-top
 		<jdoc:include type="modules" name="main-bottom" style="card" />
 	</div>
 
-	<?php if ($this->countModules('sidebar-right')) : ?>
+	<?php if ($this->countModules('sidebar-right', true)) : ?>
 	<div class="grid-child container-sidebar-right">
 		<jdoc:include type="modules" name="sidebar-right" style="card" />
 	</div>


### PR DESCRIPTION
Pull Request for Issue #32224 .

### Summary of Changes
Makes sidebar-* countModules content-aware


### Testing Instructions
1. Enable only the Tag Similar module in either sidebar position
2. Open an article with no similar tags

### Before
Blank space in sidebar position


### After
No blank space in sidebar position


### Documentation Changes Required

