### PR TITLE
Fix categories list on batch process categories

### DIFF
--- a/administrator/components/com_categories/views/categories/tmpl/default_batch_body.php
+++ b/administrator/components/com_categories/views/categories/tmpl/default_batch_body.php
@@ -39,7 +39,7 @@ $extension = $this->escape($this->state->get('filter.extension'));
 					<div id="batch-choose-action" class="combo controls">
 						<select name="batch[category_id]" id="batch-category-id">
 							<option value=""><?php echo JText::_('JLIB_HTML_BATCH_NO_CATEGORY') ?></option>
-							<?php echo JHtml::_('select.options', JHtml::_('category.categories', $extension, array('filter.published' => $published))); ?>
+							<?php echo JHtml::_('select.options', JHtml::_('category.categories', $extension, array('filter.published' => $this->state->get('filter.published')))); ?>
 						</select>
 					</div>
 				</div>


### PR DESCRIPTION
Pull Request for Issue #32233

### Summary of Changes
Instead of passing $published (which is casted to integer before), we pass the un-casting value  $this->state->get('filter.published') to JHtmlCategory::categories method to get correct list of categories when no status is selected on Select Status filter dropdown on Categories management screen.

### Testing Instructions
1. Access to Categories Management screen
2. Check on the checkbox next to one category 
3. Press Batch button in the toolbar

Before patch: Only unpublished category is displayed in the popup
After patch: All categories are being displayed

