### PR TITLE
[4.0] Fix the no jQuery mode

### DIFF
--- a/build/build-modules-js/build-bootstrap-js.es6.js
+++ b/build/build-modules-js/build-bootstrap-js.es6.js
@@ -59,6 +59,7 @@ const build = async () => {
         'node_modules/bootstrap/js/src/dom/manipulator.js',
         'node_modules/bootstrap/js/src/dom/selector-engine.js',
         'node_modules/bootstrap/js/src/util/index.js',
+        'build/media_source/vendor/bootstrap/js/nojquerymode.es6.js',
       ],
     },
   });

--- a/build/media_source/vendor/bootstrap/js/alert.es6.js
+++ b/build/media_source/vendor/bootstrap/js/alert.es6.js
@@ -1,14 +1,10 @@
+import nojQueryMode from './nojquerymode.es6';
 import Alert from '../../../../../node_modules/bootstrap/js/src/alert';
 
 window.bootstrap = window.bootstrap || {};
 window.bootstrap.Alert = Alert;
 
-// Ensure vanilla mode, for consistency of the events
-if (!Object.prototype.hasOwnProperty.call(document.body.dataset, 'bsNoJquery')) {
-  document.body.dataset.bsNoJquery = '';
-}
-
-if (Joomla && Joomla.getOptions) {
+if (nojQueryMode && Joomla && Joomla.getOptions) {
   // Get the elements/configurations from the PHP
   const alerts = Joomla.getOptions('bootstrap.alert');
   // Initialise the elements

--- a/build/media_source/vendor/bootstrap/js/button.es6.js
+++ b/build/media_source/vendor/bootstrap/js/button.es6.js
@@ -1,14 +1,10 @@
+import nojQueryMode from './nojquerymode.es6';
 import Button from '../../../../../node_modules/bootstrap/js/src/button';
 
 window.bootstrap = window.bootstrap || {};
 window.bootstrap.Button = Button;
 
-// Ensure vanilla mode, for consistency of the events
-if (!Object.prototype.hasOwnProperty.call(document.body.dataset, 'bsNoJquery')) {
-  document.body.dataset.bsNoJquery = '';
-}
-
-if (Joomla && Joomla.getOptions) {
+if (nojQueryMode && Joomla && Joomla.getOptions) {
   // Get the elements/configurations from the PHP
   const buttons = Joomla.getOptions('bootstrap.button');
   // Initialise the elements

--- a/build/media_source/vendor/bootstrap/js/carousel.es6.js
+++ b/build/media_source/vendor/bootstrap/js/carousel.es6.js
@@ -1,14 +1,10 @@
+import nojQueryMode from './nojquerymode.es6';
 import Carousel from '../../../../../node_modules/bootstrap/js/src/carousel';
 
 window.bootstrap = window.bootstrap || {};
 window.bootstrap.Carousel = Carousel;
 
-// Ensure vanilla mode, for consistency of the events
-if (!Object.prototype.hasOwnProperty.call(document.body.dataset, 'bsNoJquery')) {
-  document.body.dataset.bsNoJquery = '';
-}
-
-if (Joomla && Joomla.getOptions) {
+if (nojQueryMode && Joomla && Joomla.getOptions) {
   // Get the elements/configurations from the PHP
   const carousels = Joomla.getOptions('bootstrap.carousel');
   // Initialise the elements

--- a/build/media_source/vendor/bootstrap/js/collapse.es6.js
+++ b/build/media_source/vendor/bootstrap/js/collapse.es6.js
@@ -1,14 +1,10 @@
+import nojQueryMode from './nojquerymode.es6';
 import Collapse from '../../../../../node_modules/bootstrap/js/src/collapse';
 
 window.bootstrap = window.bootstrap || {};
 window.bootstrap.Collapse = Collapse;
 
-// Ensure vanilla mode, for consistency of the events
-if (!Object.prototype.hasOwnProperty.call(document.body.dataset, 'bsNoJquery')) {
-  document.body.dataset.bsNoJquery = '';
-}
-
-if (Joomla && Joomla.getOptions) {
+if (nojQueryMode && Joomla && Joomla.getOptions) {
   // Get the elements/configurations from the PHP
   const collapses = { ...Joomla.getOptions('bootstrap.collapse'), ...Joomla.getOptions('bootstrap.accordion') };
   // Initialise the elements

--- a/build/media_source/vendor/bootstrap/js/dropdown.es6.js
+++ b/build/media_source/vendor/bootstrap/js/dropdown.es6.js
@@ -1,14 +1,10 @@
+import nojQueryMode from './nojquerymode.es6';
 import Dropdown from '../../../../../node_modules/bootstrap/js/src/dropdown';
 
 window.bootstrap = window.bootstrap || {};
 window.bootstrap.Dropdown = Dropdown;
 
-// Ensure vanilla mode, for consistency of the events
-if (!Object.prototype.hasOwnProperty.call(document.body.dataset, 'bsNoJquery')) {
-  document.body.dataset.bsNoJquery = '';
-}
-
-if (Joomla && Joomla.getOptions) {
+if (nojQueryMode && Joomla && Joomla.getOptions) {
   // Get the elements/configurations from the PHP
   const dropdowns = Joomla.getOptions('bootstrap.dropdown');
   // Initialise the elements

--- a/build/media_source/vendor/bootstrap/js/modal.es6.js
+++ b/build/media_source/vendor/bootstrap/js/modal.es6.js
@@ -1,3 +1,4 @@
+import nojQueryMode from './nojquerymode.es6';
 import Modal from '../../../../../node_modules/bootstrap/js/src/modal';
 
 Joomla = Joomla || {};
@@ -133,12 +134,7 @@ Joomla.iframeButtonClick = (options) => {
   }
 };
 
-// Ensure vanilla mode, for consistency of the events
-if (!Object.prototype.hasOwnProperty.call(document.body.dataset, 'bsNoJquery')) {
-  document.body.dataset.bsNoJquery = '';
-}
-
-if (Joomla && Joomla.getOptions) {
+if (nojQueryMode && Joomla && Joomla.getOptions) {
   // Get the elements/configurations from the PHP
   const modals = Joomla.getOptions('bootstrap.modal');
   // Initialise the elements

--- a/build/media_source/vendor/bootstrap/js/nojquerymode.es6.js
+++ b/build/media_source/vendor/bootstrap/js/nojquerymode.es6.js
@@ -1,0 +1,7 @@
+// Ensure vanilla mode, for consistency of the events
+if (!Object.prototype.hasOwnProperty.call(document.body.dataset, 'bsNoJquery')) {
+  document.body.dataset.bsNoJquery = '';
+}
+const nojQueryMode = true;
+
+export default nojQueryMode;

--- a/build/media_source/vendor/bootstrap/js/popover.es6.js
+++ b/build/media_source/vendor/bootstrap/js/popover.es6.js
@@ -1,3 +1,4 @@
+import nojQueryMode from './nojquerymode.es6';
 import Popover from '../../../../../node_modules/bootstrap/js/src/popover';
 import Tooltip from '../../../../../node_modules/bootstrap/js/src/tooltip';
 
@@ -5,12 +6,7 @@ window.bootstrap = window.bootstrap || {};
 window.bootstrap.Popover = Popover;
 window.bootstrap.Tooltip = Tooltip;
 
-// Ensure vanilla mode, for consistency of the events
-if (!Object.prototype.hasOwnProperty.call(document.body.dataset, 'bsNoJquery')) {
-  document.body.dataset.bsNoJquery = '';
-}
-
-if (Joomla && Joomla.getOptions) {
+if (nojQueryMode && Joomla && Joomla.getOptions) {
   // Get the elements/configurations from the PHP
   const tooltips = Joomla.getOptions('bootstrap.tooltip');
   const popovers = Joomla.getOptions('bootstrap.popover');

--- a/build/media_source/vendor/bootstrap/js/scrollspy.es6.js
+++ b/build/media_source/vendor/bootstrap/js/scrollspy.es6.js
@@ -1,14 +1,10 @@
+import nojQueryMode from './nojquerymode.es6';
 import Scrollspy from '../../../../../node_modules/bootstrap/js/src/scrollspy';
 
 window.bootstrap = window.bootstrap || {};
 window.bootstrap.Scrollspy = Scrollspy;
 
-// Ensure vanilla mode, for consistency of the events
-if (!Object.prototype.hasOwnProperty.call(document.body.dataset, 'bsNoJquery')) {
-  document.body.dataset.bsNoJquery = '';
-}
-
-if (Joomla && Joomla.getOptions) {
+if (nojQueryMode && Joomla && Joomla.getOptions) {
   // Get the elements/configurations from the PHP
   const scrollspys = Joomla.getOptions('bootstrap.scrollspy');
   // Initialise the elements

--- a/build/media_source/vendor/bootstrap/js/tab.es6.js
+++ b/build/media_source/vendor/bootstrap/js/tab.es6.js
@@ -1,3 +1,4 @@
+import nojQueryMode from './nojquerymode.es6';
 import Tab from '../../../../../node_modules/bootstrap/js/src/tab';
 
 window.Joomla = window.Joomla || {};
@@ -68,7 +69,7 @@ Joomla.initialiseTabs = (el, options) => {
   }
 };
 
-if (Joomla && Joomla.getOptions) {
+if (nojQueryMode && Joomla && Joomla.getOptions) {
   // Ensure vanilla mode, for consistency of the events
   if (!Object.prototype.hasOwnProperty.call(document.body.dataset, 'bsNoJquery')) {
     document.body.dataset.bsNoJquery = '';

--- a/build/media_source/vendor/bootstrap/js/tab.es6.js
+++ b/build/media_source/vendor/bootstrap/js/tab.es6.js
@@ -70,11 +70,6 @@ Joomla.initialiseTabs = (el, options) => {
 };
 
 if (nojQueryMode && Joomla && Joomla.getOptions) {
-  // Ensure vanilla mode, for consistency of the events
-  if (!Object.prototype.hasOwnProperty.call(document.body.dataset, 'bsNoJquery')) {
-    document.body.dataset.bsNoJquery = '';
-  }
-
   // Get the elements/configurations from the PHP
   const tabs = Joomla.getOptions('bootstrap.tabs');
   // Initialise the elements

--- a/build/media_source/vendor/bootstrap/js/toast.es6.js
+++ b/build/media_source/vendor/bootstrap/js/toast.es6.js
@@ -1,14 +1,10 @@
+import nojQueryMode from './nojquerymode.es6';
 import Toast from '../../../../../node_modules/bootstrap/js/src/toast';
 
 window.bootstrap = window.bootstrap || {};
 window.bootstrap.Toast = Toast;
 
-// Ensure vanilla mode, for consistency of the events
-if (!Object.prototype.hasOwnProperty.call(document.body.dataset, 'bsNoJquery')) {
-  document.body.dataset.bsNoJquery = '';
-}
-
-if (Joomla && Joomla.getOptions) {
+if (nojQueryMode && Joomla && Joomla.getOptions) {
   // Get the elements/configurations from the PHP
   const toasts = Joomla.getOptions('bootstrap.toast');
   // Initialise the elements


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
- DRY code, reduced some repeated code for the jQuery mode
- Ensure that the vanilla mode for the events is called before instantiating any component


### Testing Instructions
- Apply the PR
- Edit `administrator/templates/atum/joomla.asset.json` and add `"jquery"` after line 48
- Goto administrator dashboard  open the browser's console in the and paste: 
```js
jQuery
x = document.querySelector('.dropdown-toggle')
jQuery(x).dropdown()
```
You should see an error: `Uncaught TypeError: jQuery(...).dropdown is not a function`
The test is successful

### Actual result BEFORE applying this Pull Request
The first component could be instantiated using the jQuery methods


### Expected result AFTER applying this Pull Request
No component could be instantiated using the jQuery methods


### Documentation Changes Required

There is documentation here: https://github.com/joomla/joomla-cms/discussions/32239
