### PR TITLE
[4.0] Actions menu icon width

### DIFF
--- a/administrator/templates/atum/scss/blocks/_toolbar.scss
+++ b/administrator/templates/atum/scss/blocks/_toolbar.scss
@@ -20,10 +20,6 @@
     box-shadow: none;
   }
 
-  .btn-group > joomla-toolbar-button {
-    margin-inline-start: 0;
-  }
-
   joomla-toolbar-button,
   .btn-group {
     margin-inline-start: .75rem;
@@ -34,9 +30,12 @@
   }
 
   joomla-toolbar-button {
+
     .btn > span,
     .dropdown-item > span {
       margin-inline-end: .5rem;
+      width: 1.25em;
+      text-align: center;
     }
   }
 


### PR DESCRIPTION
Due to the different width of the icons the icon and subsequent text are not aligned vertically

This PR applies a width and align center to the icons in the actions dropdown menu.

Pull Request for Issue #32213

As this is an scss change you need to apply patch and then npm i

### Before
![image](https://user-images.githubusercontent.com/1296369/106368854-dd7fd380-6344-11eb-90fc-46fef6997394.png)

![image](https://user-images.githubusercontent.com/1296369/106368856-df499700-6344-11eb-8cf3-fccbd2e5a947.png)

### After
![image](https://user-images.githubusercontent.com/1296369/106648694-8702d700-6588-11eb-8287-75181d2e59d8.png)

![image](https://user-images.githubusercontent.com/1296369/106648824-aef23a80-6588-11eb-911a-5d706788dd94.png)
