### PR TITLE
[4.0] Hard coded spaces

### DIFF
--- a/layouts/joomla/content/language.php
+++ b/layouts/joomla/content/language.php
@@ -20,7 +20,7 @@ if ($item->language === '*')
 }
 elseif ($item->language_image)
 {
-	echo HTMLHelper::_('image', 'mod_languages/' . $item->language_image . '.gif', '', null, true) . '&nbsp;' . htmlspecialchars($item->language_title, ENT_COMPAT, 'UTF-8');
+	echo HTMLHelper::_('image', 'mod_languages/' . $item->language_image . '.gif', '', array('class' => 'me-1'), true) . htmlspecialchars($item->language_title, ENT_COMPAT, 'UTF-8');
 }
 elseif ($item->language_title)
 {


### PR DESCRIPTION
It's 2021 and we really should be using css and not spaces for layout. This example PR is for the language layout and replaces the hard coded space with the correct css class of me-1. (because of the new BS5 classes this is RTL aware)

![image](https://user-images.githubusercontent.com/1296369/106658290-026a8580-6595-11eb-95b7-32e2eb60887e.png)


If accepted there are plenty of places to update