### PR TITLE
[4.0] Workflow missing scope [a11y]

### DIFF
--- a/administrator/components/com_workflow/tmpl/workflows/default.php
+++ b/administrator/components/com_workflow/tmpl/workflows/default.php
@@ -78,7 +78,7 @@ $userId = $user->id;
 								<th scope="col" class="w-1 text-center">
 									<?php echo HTMLHelper::_('searchtools.sort', 'JSTATUS', 'w.published', $listDirn, $listOrder); ?>
 								</th>
-								<th>
+								<th scope="col">
 									<?php echo HTMLHelper::_('searchtools.sort', 'COM_WORKFLOW_NAME', 'w.title', $listDirn, $listOrder); ?>
 								</th>
 								<th scope="col" class="w-10 text-center d-none d-md-table-cell">


### PR DESCRIPTION
all th elements in this table should have a scope attribute. These cells should contain a scope attribute to identify their association with td elements.

The name column was missing this attribute.

There is no visual change
