### PR TITLE
[4.0] breadcrumbs html_entities

### DIFF
--- a/modules/mod_breadcrumbs/tmpl/default.php
+++ b/modules/mod_breadcrumbs/tmpl/default.php
@@ -48,7 +48,7 @@ use Joomla\CMS\Router\Route;
 		foreach ($list as $key => $item) :
 			if ($key !== $last_item_key) :
 				if (!empty($item->link)) :
-					$breadcrumbItem = '<a itemprop="item" href="' . Route::_($item->link) . '" class="pathway"><span itemprop="name">' . $item->name . '</span></a>';
+					$breadcrumbItem = '<a itemprop="item" href="' . Route::_($item->link) . '" class="pathway"><span itemprop="name">' . html_entity_decode($item->name, ENT_QUOTES, 'UTF-8') . '</span></a>';
 				else :
 					$breadcrumbItem = '<span itemprop="name">' . $item->name . '</span>';
 				endif;
@@ -57,7 +57,7 @@ use Joomla\CMS\Router\Route;
 					<meta itemprop="position" content="<?php echo $key + 1; ?>">
 				</li>
 			<?php elseif ($show_last) :
-				$breadcrumbItem = '<span itemprop="name">' . $item->name . '</span>';
+				$breadcrumbItem = '<span itemprop="name">' . html_entity_decode($item->name, ENT_QUOTES, 'UTF-8') . '</span>';
 				// Render last item if required. ?>
 				<li aria-current="page" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem" class="mod-breadcrumbs__item breadcrumb-item active"><?php echo $breadcrumbItem; ?>
 					<meta itemprop="position" content="<?php echo $key + 1; ?>">


### PR DESCRIPTION
Simple PR for #32265

htmlentities are stored in the database by com_finder. This ensures that the breadcrumbs module will display them correctly