### PR TITLE
[4.0] Simplify error messages

### DIFF
--- a/administrator/components/com_menus/src/Helper/MenusHelper.php
+++ b/administrator/components/com_menus/src/Helper/MenusHelper.php
@@ -587,19 +587,19 @@ class MenusHelper extends ContentHelper
 
 			if (!$table->bind($record))
 			{
-				throw new \Exception('Bind failed: ' . $table->getError());
+				throw new \Exception($table->getError());
 			}
 
 			$table->setLocation($item->getParent()->id, 'last-child');
 
 			if (!$table->check())
 			{
-				throw new \Exception('Check failed: ' . $table->getError());
+				throw new \Exception($table->getError());
 			}
 
 			if (!$table->store())
 			{
-				throw new \Exception('Saved failed: ' . $table->getError());
+				throw new \Exception($table->getError());
 			}
 
 			$item->id = $table->get('id');


### PR DESCRIPTION
Building on the idea from #32263 and  #32268

### Summary of Changes

"No need for a user to see technical terms when something goes wrong if the message is good enough without"

On Code Review only. 

These were not even translatable. 