### PR TITLE
[4.0] Fix associations modal

### DIFF
--- a/build/media_source/vendor/bootstrap/js/modal.es6.js
+++ b/build/media_source/vendor/bootstrap/js/modal.es6.js
@@ -46,8 +46,8 @@ Joomla.initialiseModal = (modal, options) => {
         idFieldArr[0] = idFieldArr[0].replace(/&quot;/g, '"');
 
         if (!document.getElementById(idFieldArr[1])) {
-          // eslint-disable-next-line no-new-func
-          el = new Function(idFieldArr[0]); // This is UNSAFE!!!!
+          // eslint-disable-next-line no-eval
+          el = eval(idFieldArr[0]); // This is UNSAFE!!!!
         } else {
           el = document.getElementById(idFieldArr[1]).value;
         }


### PR DESCRIPTION
### Summary of Changes
Assocations modal current doesn't evaluate the forced language when trying to select a counterpart language for an (e.g. article).

@dgrammatiko I'm well aware this seems sub-optimal (security etc) - but definitely fixes the issue in chrome (and is the original code we had in bootstrap-init.js from https://github.com/joomla/joomla-cms/pull/21176). Where does this code come from in J3 btw? I'm so confused :D 

### Testing Instructions
Load an article in com_assocations and try and select a counterpart language. Before patch no articles show to select. After patch they do.

### Documentation Changes Required
None