### PR TITLE
[4.0] Fix wrong link to category on user action log

### DIFF
--- a/administrator/components/com_categories/src/Controller/CategoryController.php
+++ b/administrator/components/com_categories/src/Controller/CategoryController.php
@@ -153,6 +153,18 @@ class CategoryController extends FormController
 	protected function getRedirectToItemAppend($recordId = null, $urlVar = 'id')
 	{
 		$append = parent::getRedirectToItemAppend($recordId);
+
+		// In case edit category, we should get extension of that category in database instead of getting from request
+		if ($recordId > 0)
+		{
+			$table = $this->getModel('Category')->getTable();
+
+			if ($table->load($recordId))
+			{
+				$this->extension = $table->extension;
+			}
+		}
+
 		$append .= '&extension=' . $this->extension;
 
 		return $append;

--- a/administrator/components/com_categories/src/Controller/CategoryController.php
+++ b/administrator/components/com_categories/src/Controller/CategoryController.php
@@ -154,8 +154,8 @@ class CategoryController extends FormController
 	{
 		$append = parent::getRedirectToItemAppend($recordId);
 
-		// In case edit category, we should get extension of that category in database instead of getting from request
-		if ($recordId > 0)
+		// In case extension is not passed in the URL, get it directly from category instead of default to com_content
+		if (!$this->input->exists('extension') && $recordId > 0)
 		{
 			$table = $this->getModel('Category')->getTable();
 

--- a/plugins/actionlog/joomla/joomla.php
+++ b/plugins/actionlog/joomla/joomla.php
@@ -96,13 +96,6 @@ class PlgActionlogJoomla extends ActionLogPlugin
 			$context = $this->contextAliases[$context];
 		}
 
-		$option = $this->app->input->getCmd('option');
-
-		if (!$this->checkLoggable($option))
-		{
-			return;
-		}
-
 		$params = ActionlogsHelper::getLogContentTypeParams($context);
 
 		// Not found a valid content type, don't process further
@@ -111,7 +104,12 @@ class PlgActionlogJoomla extends ActionLogPlugin
 			return;
 		}
 
-		list(, $contentType) = explode('.', $params->type_alias);
+		list($option, $contentType) = explode('.', $params->type_alias);
+
+		if (!$this->checkLoggable($option))
+		{
+			return;
+		}
 
 		if ($isNew)
 		{


### PR DESCRIPTION
Pull Request for Issue #32264 .

### Summary of Changes
Instead of getting $option directly from request (which is wrong in case category is created from add article/add contact... screen), we can just get $option (component) from type_alias(com_content.article, com_categories.category....) of the content type. 

This solve error in case the content type is created using a different component (like category is created from com_contact or com_content) as shown in the issue https://github.com/joomla/joomla-cms/issues/32264

### Testing Instructions
1. Follow instructions at https://github.com/joomla/joomla-cms/issues/32264 to see the issue
2. Apply patch, confirm the issue fixed


### Actual result BEFORE applying this Pull Request
The link to category is wrong


### Expected result AFTER applying this Pull Request
The link to category is right

### Documentation Changes Required
If this change is accepted, similar change should be done to other methods in the plugin like onContentAfterDelete, onContentChangeState....
