### PR TITLE
[4.0] Fix saving template options from frontend

### DIFF
--- a/components/com_config/src/Model/TemplatesModel.php
+++ b/components/com_config/src/Model/TemplatesModel.php
@@ -55,7 +55,7 @@ class TemplatesModel extends FormModel
 		try
 		{
 			// Get the form.
-			$form = $this->loadForm('com_config.templates', 'templates', array('control' => 'jform', 'load_data' => $loadData));
+			$form = $this->loadForm('com_config.templates', 'templates', array('load_data' => $loadData));
 
 			$data = array();
 			$this->preprocessForm($form, $data);


### PR DESCRIPTION
Pull Request for Issue #32254.

### Summary of Changes
The Style controller expects to receive data directly from params input name, so I modified code to remove jform from name of the input (same as how it works in Joomla 3) to have template options save properly


### Testing Instructions
1. Follow instructions at https://github.com/joomla/joomla-cms/issues/32254 , confirm the issue
2. Apply patch, confirm the issue is fixed.