### PR TITLE
[4.0] Support namespace module for com_ajax

### DIFF
--- a/components/com_ajax/ajax.php
+++ b/components/com_ajax/ajax.php
@@ -118,7 +118,6 @@ elseif ($input->get('module'))
 				try
 				{
 					$results = call_user_func($class . '::' . $method . 'Ajax');
-
 				}
 				catch (Exception $e)
 				{


### PR DESCRIPTION
Pull Request for Issue #32136 .

### Summary of Changes
Modify com_ajax to support namespace module.

### Testing Instructions
1. Create an instance of module Articles - Categories, make sure it is enabled on all pages. Publish the module
2. Modify the file modules/mod_articles_categories/src/Helper/ArticlesCategoriesHelper.php, add a simple method for testing com_ajax
```php
public static function getDataAjax()
{
	$data = ['test'];

	return $data;
}
```
3. Access to this URL to trigger com_ajax for the module

http://localhost/joomla4/index.php?option=com_ajax&module=articles_categories&method=getData&format=json

4. Before patch, you will get this error
{"success":false,"message":"The file at mod_articles_categories\/helper.php does not exist.","messages":null,"data":null}

5. After patch, you will get this success response:
{"success":true,"message":null,"messages":null,"data":["test"]}

You can install the modified mod_articles_categories.zip which I attached here so that you don't have do the step #2 (modify code)
[mod_articles_categories.zip](https://github.com/joomla/joomla-cms/files/5919797/mod_articles_categories.zip)
