### PR TITLE
[4.0] Remove icon/class in modal footer

### DIFF
--- a/administrator/components/com_cpanel/tmpl/cpanel/default.php
+++ b/administrator/components/com_cpanel/tmpl/cpanel/default.php
@@ -41,9 +41,9 @@ echo HTMLHelper::_(
 		'url'         => Route::_('index.php?option=com_cpanel&task=addModule&function=jSelectModuleType&position=' . $this->escape($this->position)),
 		'bodyHeight'  => '70',
 		'modalWidth'  => '80',
-		'footer'      => '<button type="button" class="button-cancel btn btn-sm btn-danger" data-bs-dismiss="modal" data-bs-target="#closeBtn"><span class="icon-times" aria-hidden="true"></span>'
+		'footer'      => '<button type="button" class="button-cancel btn btn-danger" data-bs-dismiss="modal" data-bs-target="#closeBtn">'
 			. Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>'
-			. '<button type="button" class="button-save btn btn-sm btn-success hidden" data-bs-target="#saveBtn"><span class="icon-copy" aria-hidden="true"></span>'
+			. '<button type="button" class="button-save btn btn-success hidden" data-bs-target="#saveBtn">'
 			. Text::_('JSAVE') . '</button>',
 	)
 );


### PR DESCRIPTION
### Summary of Changes
This PR removes icon/class in modal footer to be consistent with other modals.

This PR does not fix the hover color/order in #29560.

### Testing Instructions
Go to Home Dashboard.
Scroll to the bottom.
Click `Add module to the dashboard`.


### Actual result BEFORE applying this Pull Request
Icon in button.


### Expected result AFTER applying this Pull Request
No icon in button.
