### PR TITLE
[4.0] [RTL] Adding specific bootstrap-rtl.scss to Cassiopea

### DIFF
--- a/templates/cassiopeia/scss/template-rtl.scss
+++ b/templates/cassiopeia/scss/template-rtl.scss
@@ -1,4 +1,5 @@
 @import "template";
+@import "vendor/bootstrap/bootstrap-rtl";
 
 body,
 .dropdown-item {
@@ -55,11 +56,6 @@ body,
       margin-left: 1.55em;
     }
   }
-}
-
-.me-2 {
-  margin-right: 0 !important;
-  margin-left: .5rem;
 }
 
 // SearchTools rounded corners

--- a/templates/cassiopeia/scss/vendor/bootstrap/_bootstrap-rtl.scss
+++ b/templates/cassiopeia/scss/vendor/bootstrap/_bootstrap-rtl.scss
@@ -1,0 +1,196 @@
+// Bootstrap rtl overrides
+
+.float-start {
+  float: right !important;
+}
+
+.float-end {
+  float: left !important;
+}
+
+.modal-header {
+  .btn-close {
+    margin: -.5rem auto -.5rem -.5rem;
+  }
+}
+
+.text-start {
+  text-align: right !important;
+}
+
+.text-end {
+  text-align: left !important;
+}
+
+.me-0 {
+  margin-right: auto !important;
+  margin-left: 0 !important;
+}
+
+.me-1 {
+  margin-right: auto !important;
+  margin-left: .25rem !important;
+}
+
+.me-2 {
+  margin-right: auto !important;
+  margin-left: .5rem !important;
+}
+
+.me-3 {
+  margin-right: auto !important;
+  margin-left: 1rem !important;
+}
+
+.me-4 {
+  margin-right: auto !important;
+  margin-left: 1.5rem !important;
+}
+
+.me-5 {
+  margin-right: auto !important;
+  margin-left: 3rem !important;
+}
+
+.me-auto {
+  margin-right: 0 !important;
+  margin-left: auto !important;
+}
+
+.ms-0 {
+  margin-right: 0 !important;
+  margin-left: auto !important;
+}
+
+.ms-1 {
+  margin-right: .25rem !important;
+  margin-left: auto !important;
+}
+
+.ms-2 {
+  margin-right: .5rem !important;
+  margin-left: auto !important;
+}
+
+.ms-3 {
+  margin-right: 1rem !important;
+  margin-left: auto !important;
+}
+
+.ms-4 {
+  margin-right: 1.5rem !important;
+  margin-left: auto !important;
+}
+
+.ms-5 {
+  margin-right: 3rem !important;
+  margin-left: auto !important;
+}
+
+.ms-auto {
+  margin-right: auto !important;
+  margin-left: 0 !important;
+}
+
+.pe-0 {
+  padding-right: 0 !important;
+  padding-left: 0 !important;
+}
+.pe-1 {
+  padding-right: 0 !important;
+  padding-left: .25rem !important;
+}
+.pe-2 {
+  padding-right: 0 !important;
+  padding-left: .5rem !important;
+}
+.pe-3 {
+  padding-right: 0 !important;
+  padding-left: 1rem !important;
+}
+.pe-4 {
+  padding-right: 0 !important;
+  padding-left: 1.5rem !important;
+}
+.pe-5 {
+  padding-right: 0 !important;
+  padding-left: 3rem !important;
+}
+
+.ps-0 {
+  padding-right: 0 !important;
+  padding-left: 0 !important;
+}
+.ps-1 {
+  padding-right: .25rem !important;
+  padding-left: 0 !important;
+}
+.ps-2 {
+  padding-right: .5rem !important;
+  padding-left: 0 !important;
+}
+.ps-3 {
+  padding-right: 1rem !important;
+  padding-left: 0 !important;
+}
+.ps-4 {
+  padding-right: 1.5rem !important;
+  padding-left: 0 !important;
+}
+.ps-5 {
+  padding-right: 3rem !important;
+  padding-left: 0 !important;
+}
+
+
+.input-group {
+  &:not(.has-validation) {
+    > :not(:last-child):not(.dropdown-toggle):not(.dropdown-menu),
+    > .dropdown-toggle:nth-last-child(n + 3) {
+      @include border-end-radius($border-radius);
+    }
+  }
+
+  &.has-validation {
+    > :nth-last-child(n + 3):not(.dropdown-toggle):not(.dropdown-menu),
+    > .dropdown-toggle:nth-last-child(n + 4) {
+      @include border-end-radius(0);
+    }
+  }
+  $validation-messages: "";
+  @each $state in map-keys($form-validation-states) {
+    $validation-messages: $validation-messages + ":not(." + unquote($state) + "-tooltip)" + ":not(." + unquote($state) + "-feedback)";
+  }
+
+  > :not(:first-child):not(.dropdown-menu)#{$validation-messages} {
+    margin-left: -$input-border-width;
+    @include border-start-radius(0);
+    @include border-end-radius(0);
+  }
+
+  > :last-child:not(.dropdown-menu)#{$validation-messages} {
+    margin-left: -$input-border-width;
+    @include border-start-radius($border-radius);
+    @include border-end-radius(0);
+  }
+}
+
+.breadcrumb-item {
+  // The separator between breadcrumbs (by default, a forward-slash: "/")
+  + .breadcrumb-item {
+    padding-right: $breadcrumb-item-padding-x;
+    padding-left: 0 !important;
+
+    &::before {
+      float: right; // Suppress inline spacings and underlining of the separator
+      padding-left: $breadcrumb-item-padding-x;
+      padding-right: 0 !important;
+      color: $breadcrumb-divider-color;
+      content: var(--#{$variable-prefix}breadcrumb-divider, escape-svg($breadcrumb-divider)) #{"/* rtl:"} var(--#{$variable-prefix}breadcrumb-divider, escape-svg($breadcrumb-divider-flipped)) #{"*/"};
+    }
+  }
+
+  &.active {
+    color: $breadcrumb-active-color;
+  }
+}

--- a/templates/cassiopeia/scss/vendor/bootstrap/_bootstrap-rtl.scss
+++ b/templates/cassiopeia/scss/vendor/bootstrap/_bootstrap-rtl.scss
@@ -183,8 +183,8 @@
 
     &::before {
       float: right; // Suppress inline spacings and underlining of the separator
-      padding-left: $breadcrumb-item-padding-x;
       padding-right: 0 !important;
+      padding-left: $breadcrumb-item-padding-x;
       color: $breadcrumb-divider-color;
       content: var(--#{$variable-prefix}breadcrumb-divider, escape-svg($breadcrumb-divider)) #{"/* rtl:"} var(--#{$variable-prefix}breadcrumb-divider, escape-svg($breadcrumb-divider-flipped)) #{"*/"};
     }


### PR DESCRIPTION
### Summary of Changes
As title says. Adds boostrap5 overrides for Cassiopea as was done for Atum (https://github.com/joomla/joomla-cms/pull/32166 )
This corrects Breadcrumbs as well as Rounded corners (https://github.com/joomla/joomla-cms/pull/32177) and more in modals.


### Testing Instructions
Install Persian language. Make it default language in frontend.
Switch to Persian in back-end and install the blog sample data.
Load frrontend
Check Breadcrumbs path
Check input groups rounded corners (in login form but also in the xtd modals)
Check the "X" close button in xtd modals.


### Actual result BEFORE applying this Pull Request
<img width="370" alt="Screen Shot 2021-02-04 at 08 27 45" src="https://user-images.githubusercontent.com/869724/106859209-faa8ff00-66c2-11eb-88df-c65713de18e7.png">

<img width="290" alt="Screen Shot 2021-02-04 at 09 14 16" src="https://user-images.githubusercontent.com/869724/106867853-617fe580-66ce-11eb-923f-a647e2472081.png">

<img width="1102" alt="Screen Shot 2021-02-04 at 10 00 50" src="https://user-images.githubusercontent.com/869724/106869385-28e10b80-66d0-11eb-81ed-1ec3ccd9a7fd.png">


### Expected result AFTER applying this Pull Request
<img width="1174" alt="Screen Shot 2021-02-04 at 09 22 23" src="https://user-images.githubusercontent.com/869724/106868050-968c3800-66ce-11eb-8024-b3c5a536300f.png">

<img width="290" alt="Screen Shot 2021-02-04 at 09 22 33" src="https://user-images.githubusercontent.com/869724/106868075-9d1aaf80-66ce-11eb-85e3-92874746209c.png">

<img width="308" alt="Screen Shot 2021-02-04 at 09 53 42" src="https://user-images.githubusercontent.com/869724/106868308-ebc84980-66ce-11eb-97c9-b99c839d9f81.png">

<img width="1139" alt="Screen Shot 2021-02-04 at 09 57 20" src="https://user-images.githubusercontent.com/869724/106869368-22eb2a80-66d0-11eb-9b5e-c83566b15502.png">


### Note
As in https://github.com/joomla/joomla-cms/pull/32177 , I have not deleted the input group classes present in template-rtl.scss

The star icon, part of login form, may still need a tweak `.input-group-text` should have no border radius