### PR TITLE
Fix Privacy Request Email Data Export Error

### DIFF
--- a/administrator/components/com_privacy/views/request/view.html.php
+++ b/administrator/components/com_privacy/views/request/view.html.php
@@ -147,7 +147,10 @@ class PrivacyViewRequest extends JViewLegacy
 						if (JFactory::getConfig()->get('mailonline', 1))
 						{
 							JToolbarHelper::link(
-								JRoute::_('index.php?option=com_privacy&task=request.emailexport&id=' . (int) $this->item->id . $return . '&' . JSession::getFormToken() . '=1'),
+								JRoute::_(
+									'index.php?option=com_privacy&task=request.emailexport&id=' . (int) $this->item->id . $return
+									. '&' . JSession::getFormToken() . '=1'
+								),
 								'COM_PRIVACY_ACTION_EMAIL_EXPORT_DATA',
 								'mail'
 							);

--- a/administrator/components/com_privacy/views/request/view.html.php
+++ b/administrator/components/com_privacy/views/request/view.html.php
@@ -147,7 +147,7 @@ class PrivacyViewRequest extends JViewLegacy
 						if (JFactory::getConfig()->get('mailonline', 1))
 						{
 							JToolbarHelper::link(
-								JRoute::_('index.php?option=com_privacy&task=request.emailexport&id=' . (int) $this->item->id . $return),
+								JRoute::_('index.php?option=com_privacy&task=request.emailexport&id=' . (int) $this->item->id . $return . '&' . JSession::getFormToken() . '=1'),
 								'COM_PRIVACY_ACTION_EMAIL_EXPORT_DATA',
 								'mail'
 							);


### PR DESCRIPTION
Pull Request for Issue #32272 .

### Summary of Changes
The emailexport method of PrivacyControllerRequest controller check form token from GET ( see https://github.com/joomla/joomla-cms/blob/staging/administrator/components/com_privacy/controllers/request.php#L139 ), however, the form token is not passed in the URL and it causes the error below when the button is pressed:

> The security token did not match. The request was aborted to prevent any security breach. Please try again

This simple PR just fixes that error.

### Testing Instructions

1. Code review.
2. Real test: See comment https://github.com/joomla/joomla-cms/pull/32299#issuecomment-773364992 below.

### Actual result BEFORE applying this Pull Request

See issue #32272 : Error "The security token did not match. The request was aborted to prevent any security breach. Please try again"

### Expected result AFTER applying this Pull Request

No error will be shown. The data is exported and emailed.

### Documentation Changes Required

None.