### PR TITLE
[4.0] Fix sitename added to breadcrumb in tag view

### DIFF
--- a/components/com_tags/src/View/Tag/HtmlView.php
+++ b/components/com_tags/src/View/Tag/HtmlView.php
@@ -12,7 +12,6 @@ namespace Joomla\Component\Tags\Site\View\Tag;
 \defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
-use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Plugin\PluginHelper;

--- a/components/com_tags/src/View/Tag/HtmlView.php
+++ b/components/com_tags/src/View/Tag/HtmlView.php
@@ -320,21 +320,8 @@ class HtmlView extends BaseHtmlView
 			}
 		}
 
-		if (empty($title))
-		{
-			$title = $app->get('sitename');
-		}
-		elseif ($app->get('sitename_pagetitles', 0) == 1)
-		{
-			$title = Text::sprintf('JPAGETITLE', $app->get('sitename'), $title);
-		}
-		elseif ($app->get('sitename_pagetitles', 0) == 2)
-		{
-			$title = Text::sprintf('JPAGETITLE', $title, $app->get('sitename'));
-		}
-
-		$this->document->setTitle($title);
-
+		$this->setDocumentTitle($title);
+		
 		$pathway->addItem($title);
 
 		foreach ($this->item as $itemElement)

--- a/components/com_tags/src/View/Tag/HtmlView.php
+++ b/components/com_tags/src/View/Tag/HtmlView.php
@@ -321,7 +321,6 @@ class HtmlView extends BaseHtmlView
 		}
 
 		$this->setDocumentTitle($title);
-		
 		$pathway->addItem($title);
 
 		foreach ($this->item as $itemElement)


### PR DESCRIPTION
Pull Request for Issue #32253.

### Summary of Changes
This PR fixed issue https://github.com/joomla/joomla-cms/issues/32253. It also uses build-in **setDocumentTitle** method from HtmlView class to set page title instead of calculating and setting page title manually in the view

### Testing Instructions
1. In Global Configuration -> SEO set "Site Name in Page Titles" = BEFORE
2. Create a menu item to link to Tagged Items menu item type of Tags component
3. Go to frontend of your site, access to that menu item, look at the last item in breadcrumb

- Before patch: It contains site name
- After patch: It does not contain site name anymore
