### PR TITLE
[4.0] Use setDocumentTitle to set document title for com_content

### DIFF
--- a/components/com_content/src/View/Archive/HtmlView.php
+++ b/components/com_content/src/View/Archive/HtmlView.php
@@ -228,13 +228,9 @@ class HtmlView extends BaseHtmlView
 	 */
 	protected function _prepareDocument()
 	{
-		$app   = Factory::getApplication();
-		$menus = $app->getMenu();
-		$title = null;
-
 		// Because the application sets a default page title,
 		// we need to get it from the menu item itself
-		$menu = $menus->getActive();
+		$menu = Factory::getApplication()->getMenu()->getActive();
 
 		if ($menu)
 		{
@@ -245,22 +241,7 @@ class HtmlView extends BaseHtmlView
 			$this->params->def('page_heading', Text::_('JGLOBAL_ARTICLES'));
 		}
 
-		$title = $this->params->get('page_title', '');
-
-		if (empty($title))
-		{
-			$title = $app->get('sitename');
-		}
-		elseif ($app->get('sitename_pagetitles', 0) == 1)
-		{
-			$title = Text::sprintf('JPAGETITLE', $app->get('sitename'), $title);
-		}
-		elseif ($app->get('sitename_pagetitles', 0) == 2)
-		{
-			$title = Text::sprintf('JPAGETITLE', $title, $app->get('sitename'));
-		}
-
-		$this->document->setTitle($title);
+		$this->setDocumentTitle($this->params->get('page_title', ''));
 
 		if ($this->params->get('menu-meta_description'))
 		{

--- a/components/com_content/src/View/Article/HtmlView.php
+++ b/components/com_content/src/View/Article/HtmlView.php
@@ -268,15 +268,13 @@ class HtmlView extends BaseHtmlView
 	protected function _prepareDocument()
 	{
 		$app     = Factory::getApplication();
-		$menus   = $app->getMenu();
 		$pathway = $app->getPathway();
-		$title   = null;
 
 		/**
 		 * Because the application sets a default page title,
 		 * we need to get it from the menu item itself
 		 */
-		$menu = $menus->getActive();
+		$menu = $app->getMenu()->getActive();
 
 		if ($menu)
 		{
@@ -316,26 +314,12 @@ class HtmlView extends BaseHtmlView
 			}
 		}
 
-		// Check for empty title and add site name if param is set
-		if (empty($title))
-		{
-			$title = $app->get('sitename');
-		}
-		elseif ($app->get('sitename_pagetitles', 0) == 1)
-		{
-			$title = Text::sprintf('JPAGETITLE', $app->get('sitename'), $title);
-		}
-		elseif ($app->get('sitename_pagetitles', 0) == 2)
-		{
-			$title = Text::sprintf('JPAGETITLE', $title, $app->get('sitename'));
-		}
-
 		if (empty($title))
 		{
 			$title = $this->item->title;
 		}
 
-		$this->document->setTitle($title);
+		$this->setDocumentTitle($title);
 
 		if ($this->item->metadesc)
 		{

--- a/components/com_content/src/View/Category/HtmlView.php
+++ b/components/com_content/src/View/Category/HtmlView.php
@@ -150,7 +150,6 @@ class HtmlView extends CategoryView
 
 		// Because the application sets a default page title,
 		// we need to get it from the menu item itself
-		$app    = Factory::getApplication();
 		$active = $app->getMenu()->getActive();
 
 		if ($active
@@ -169,24 +168,12 @@ class HtmlView extends CategoryView
 			$this->params->set('page_title', $title);
 		}
 
-		// Check for empty title and add site name if param is set
-		if (empty($title))
-		{
-			$title = $app->get('sitename');
-		}
-		elseif ($app->get('sitename_pagetitles', 0) == 1)
-		{
-			$title = Text::sprintf('JPAGETITLE', $app->get('sitename'), $title);
-		}
-		elseif ($app->get('sitename_pagetitles', 0) == 2)
-		{
-			$title = Text::sprintf('JPAGETITLE', $title, $app->get('sitename'));
-		}
-
 		if (empty($title))
 		{
 			$title = $this->category->title;
 		}
+
+		$this->setDocumentTitle($title);
 
 		$this->document->setTitle($title);
 

--- a/components/com_content/src/View/Featured/HtmlView.php
+++ b/components/com_content/src/View/Featured/HtmlView.php
@@ -215,13 +215,9 @@ class HtmlView extends BaseHtmlView
 	 */
 	protected function _prepareDocument()
 	{
-		$app   = Factory::getApplication();
-		$menus = $app->getMenu();
-		$title = null;
-
 		// Because the application sets a default page title,
 		// we need to get it from the menu item itself
-		$menu = $menus->getActive();
+		$menu = Factory::getApplication()->getMenu()->getActive();
 
 		if ($menu)
 		{
@@ -232,22 +228,7 @@ class HtmlView extends BaseHtmlView
 			$this->params->def('page_heading', Text::_('JGLOBAL_ARTICLES'));
 		}
 
-		$title = $this->params->get('page_title', '');
-
-		if (empty($title))
-		{
-			$title = $app->get('sitename');
-		}
-		elseif ($app->get('sitename_pagetitles', 0) == 1)
-		{
-			$title = Text::sprintf('JPAGETITLE', $app->get('sitename'), $title);
-		}
-		elseif ($app->get('sitename_pagetitles', 0) == 2)
-		{
-			$title = Text::sprintf('JPAGETITLE', $title, $app->get('sitename'));
-		}
-
-		$this->document->setTitle($title);
+		$this->setDocumentTitle($this->params->get('page_title', ''));
 
 		if ($this->params->get('menu-meta_description'))
 		{

--- a/components/com_content/src/View/Form/HtmlView.php
+++ b/components/com_content/src/View/Form/HtmlView.php
@@ -193,12 +193,10 @@ class HtmlView extends BaseHtmlView
 	protected function _prepareDocument()
 	{
 		$app   = Factory::getApplication();
-		$menus = $app->getMenu();
-		$title = null;
 
 		// Because the application sets a default page title,
 		// we need to get it from the menu item itself
-		$menu = $menus->getActive();
+		$menu = $app->getMenu()->getActive();
 
 		if ($menu)
 		{
@@ -211,19 +209,9 @@ class HtmlView extends BaseHtmlView
 
 		$title = $this->params->def('page_title', Text::_('COM_CONTENT_FORM_EDIT_ARTICLE'));
 
-		if ($app->get('sitename_pagetitles', 0) == 1)
-		{
-			$title = Text::sprintf('JPAGETITLE', $app->get('sitename'), $title);
-		}
-		elseif ($app->get('sitename_pagetitles', 0) == 2)
-		{
-			$title = Text::sprintf('JPAGETITLE', $title, $app->get('sitename'));
-		}
+		$this->setDocumentTitle($title);
 
-		$this->document->setTitle($title);
-
-		$pathway = $app->getPathway();
-		$pathway->addItem($title, '');
+		$app->getPathway()->addItem($title);
 
 		if ($this->params->get('menu-meta_description'))
 		{


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Same with other similar PRs, this PR modifies com_content code to use setDocumentTitle  method from HtmlView class to set document title instead of using the same repeating code on all views.


### Testing Instructions
Create menu items to link to link to the follow menu item types of com_content:
- Archived Articles
- Category Blog
- Categories List
- Create Article
- Featured Articles
- Single Articles

Then access to these menu items, make sure browser page title is the same before and after patch.