### PR TITLE
[4.0] Backend: Make new modules cards clickable

### DIFF
--- a/administrator/components/com_modules/tmpl/select/default.php
+++ b/administrator/components/com_modules/tmpl/select/default.php
@@ -67,7 +67,7 @@ endif;
 							<?php echo $desc; ?>
 						</p>
 					</div>
-					<a href="<?php echo Route::_($link); ?>" class="btn btn-primary <?php echo $function ? ' select-link" data-function="' . $this->escape($function) : ''; ?>" aria-label="<?php echo Text::sprintf('COM_MODULES_SELECT_MODULE', $name); ?>">
+					<a href="<?php echo Route::_($link); ?>" class="btn btn-primary stretched-link <?php echo $function ? ' select-link" data-function="' . $this->escape($function) : ''; ?>" aria-label="<?php echo Text::sprintf('COM_MODULES_SELECT_MODULE', $name); ?>">
 						<?php echo Text::_('JSELECT'); ?>
 					</a>
 				</div>


### PR DESCRIPTION
### Summary of Changes
Add class "stretched-link" to the buttons on new modules cards to make the whole card clickable.

### Testing Instructions
Go to Content -> Site (or Administrator) Modules -> New

### Actual result BEFORE applying this Pull Request
The cards have a hover effect but are not clickable. You can only click on the select button to create a new module.

### Expected result AFTER applying this Pull Request
The whole cards are clickable.

![grafik](https://user-images.githubusercontent.com/9153168/107063247-6fbb2800-67da-11eb-9238-2ad1482401d9.png)