### PR TITLE
[4.0] Cassiopeia: Wrap preformatted text blocks

### DIFF
--- a/templates/cassiopeia/scss/blocks/_global.scss
+++ b/templates/cassiopeia/scss/blocks/_global.scss
@@ -166,6 +166,17 @@ figcaption {
   color: $gray-600;
 }
 
+pre,
+code {
+  white-space: pre-wrap;
+}
+
+pre {
+  code {
+    white-space: pre-wrap;
+  }
+}
+
 .mod-menu {
   flex-direction: column;
 }


### PR DESCRIPTION
Pull Request for Issue #32296  .

### Summary of Changes
Added white-space: pre-wrap for pre + code blocks


### Testing Instructions
Run npm 

Add some text in a pre or pre + code block in an article.


### Actual result BEFORE applying this Pull Request
The pre block doesn't fit in the content, it gets a horizontal scroll bar:

![grafik](https://user-images.githubusercontent.com/9153168/107069660-8c5b5e00-67e2-11eb-95c6-df40cbf082ad.png)



### Expected result AFTER applying this Pull Request
The pre block adapts to the width of the content:

![grafik](https://user-images.githubusercontent.com/9153168/107069686-97ae8980-67e2-11eb-83d4-108d953da45e.png)


