### PR TITLE
[4.0] Fix wrong redirect for com_config Close button

### DIFF
--- a/administrator/components/com_config/src/Controller/ComponentController.php
+++ b/administrator/components/com_config/src/Controller/ComponentController.php
@@ -201,7 +201,23 @@ class ComponentController extends FormController
 		// Clear session data.
 		$this->app->setUserState("$this->option.edit.$this->context.$component.data", null);
 
-		$this->setRedirect(Route::_('index.php?option=' . $component, false));
+		// Calculate redirect URL
+		$returnUri = $this->input->post->get('return', null, 'base64');
+
+		$redirect = 'index.php?option=' . $component;
+
+		if (!empty($returnUri))
+		{
+			$redirect = base64_decode($returnUri);
+		}
+
+		// Don't redirect to an external URL.
+		if (!Uri::isInternal($redirect))
+		{
+			$redirect = Uri::base();
+		}
+
+		$this->setRedirect(Route::_($redirect, false));
 
 		return true;
 	}


### PR DESCRIPTION
Pull Request for Issue #32128.

### Summary of Changes
This simple PR fixes wrong redirect URL issue when users click on Close button on component configuration screen. See https://github.com/joomla/joomla-cms/issues/32128 for detailed issue description.

### Testing Instructions

1. Login to administrator area of your site.
2. Access to Components -> Contacts -> Categories
3. Click on Options button in the toolbar
4. On the next screen, click on Close button:

- Before patch: You are being redirected back to contacts list - which is wrong (index.php?option=com_contact)
- After patch: You are being redirected back to the original page which you click on Options button (index.php?option=com_categories&view=categories&extension=com_contact)