### PR TITLE
Fix published attribute for Tag field

### DIFF
--- a/libraries/src/Form/Field/TagField.php
+++ b/libraries/src/Form/Field/TagField.php
@@ -116,7 +116,7 @@ class TagField extends \JFormFieldList
 	 */
 	protected function getOptions()
 	{
-		$published = (string) $this->element['published'] ?: [0, 1];
+		$published = (string) $this->element['published'] ?: array(0, 1);
 		$app       = Factory::getApplication();
 		$tag       = $app->getLanguage()->getTag();
 

--- a/libraries/src/Form/Field/TagField.php
+++ b/libraries/src/Form/Field/TagField.php
@@ -116,7 +116,7 @@ class TagField extends \JFormFieldList
 	 */
 	protected function getOptions()
 	{
-		$published = $this->element['published'] ?: array(0, 1);
+		$published = (string) $this->element['published'] ?: [0, 1];
 		$app       = Factory::getApplication();
 		$tag       = $app->getLanguage()->getTag();
 


### PR DESCRIPTION
Pull Request for Issue #32065 .

### Summary of Changes
This simple PR fixes small issue with published attribute of Tag Field Type. According to our documentation, when published set to 1, only published tags should be displayed. As of right now, it always display both published and unpublished tags.

### Testing Instructions
1. Create some tags (some published tags and some unpublished tags)
2. Modify this file https://github.com/joomla/joomla-cms/blob/staging/administrator/components/com_contact/models/forms/contact.xml#L235, add published="1" after that line.
3. Create new contact:

- Before patch: Both unpublished tags and published tags are being displayed
- After patch: Only published tags are being displayed.