### PR TITLE
[4.0] Fix pre tag display in blog/featured layouts.

### DIFF
--- a/templates/cassiopeia/scss/blocks/_modifiers.scss
+++ b/templates/cassiopeia/scss/blocks/_modifiers.scss
@@ -115,6 +115,7 @@
   display: flex;
   flex-direction: column;
   padding: 0 ($cassiopeia-grid-gutter / 2) $cassiopeia-grid-gutter;
+  overflow: hidden;
 
   .boxed & {
     background-color: $white;


### PR DESCRIPTION
Pull Request for Issue #32296.

This is an alternative solution to #32322. You'll need NPM to test this PR!

### Summary of Changes

Added an `overflow:hidden` so that blog item divs don't expand with `<pre>` tags inside their content.

### Testing Instructions

1. Create an article. In the content, add a HTML `<pre>` tag with at least one very long line inside it.
2. Mark the article as featured and add it to a category.
3. Look at the article in frontend in the following views:
  - single article
  - category blog
  - featured blog

### Actual result BEFORE applying this Pull Request

The pre tag destroys the blog layouts (but is correctly displayed in single article view). 

![Screenshot_2021-02-06 actual](https://user-images.githubusercontent.com/1410135/107126012-841c2500-68ad-11eb-883d-b199a1047f86.png)

### Expected result AFTER applying this Pull Request

The pre tag gets a vertical scrollbar and is displayed inside the limits of the article.

![Screenshot_2021-02-06 expected](https://user-images.githubusercontent.com/1410135/107126015-87afac00-68ad-11eb-9dbc-a263317e82f2.png)


### Documentation Changes Required

None