### PR TITLE
Fix select Group Parent on group creation error

### DIFF
--- a/administrator/components/com_users/models/fields/groupparent.php
+++ b/administrator/components/com_users/models/fields/groupparent.php
@@ -75,7 +75,7 @@ class JFormFieldGroupParent extends JFormFieldList
 		}
 
 		// We should not remove any groups when we are creating a new group
-		if (!is_null($currentGroupId))
+		if ($currentGroupId !== null && $currentGroupId !== 0)
 		{
 			// Prevent parenting direct children and children of children of this item.
 			$options = $this->cleanOptionsChildrenByFather($options, $currentGroupId);


### PR DESCRIPTION
Pull Request for Issue #32305 .

### Summary of Changes
This small PR solves the issue https://github.com/joomla/joomla-cms/issues/32305. I use same code with what we are having on Joomla 4 to allow selecting Group Parent when there is error with creating a new user group


### Testing Instructions
1. Create New User Group. In the Group Title, enter Registered, in Group Parent, select Public (so that you can error when trying to save the user group)
2. Before patch, on error screen, you won't be able to choose user groups anymore
3. After path, you can choose user group you want for Group Parent.