### PR TITLE
[4.0] Validate URL for Iframe Wrapper menu item type

### DIFF
--- a/components/com_wrapper/tmpl/wrapper/default.xml
+++ b/components/com_wrapper/tmpl/wrapper/default.xml
@@ -15,7 +15,8 @@
 
 			<field
 				name="url"
-				type="text"
+				type="url"
+				validate="url"
 				label="COM_WRAPPER_FIELD_URL_LABEL"
 				size="30"
 				required="true"

--- a/components/com_wrapper/tmpl/wrapper/default.xml
+++ b/components/com_wrapper/tmpl/wrapper/default.xml
@@ -16,10 +16,10 @@
 			<field
 				name="url"
 				type="url"
-				validate="url"
 				label="COM_WRAPPER_FIELD_URL_LABEL"
 				size="30"
 				required="true"
+				validate="url"
 			/>
 		</fieldset>
 		<!-- Add fields to the parameters object for the layout. -->

--- a/components/com_wrapper/tmpl/wrapper/default.xml
+++ b/components/com_wrapper/tmpl/wrapper/default.xml
@@ -19,6 +19,7 @@
 				label="COM_WRAPPER_FIELD_URL_LABEL"
 				size="30"
 				required="true"
+				filter="url"
 				validate="url"
 			/>
 		</fieldset>


### PR DESCRIPTION
Pull Request for Issue #32245 (part).

### Summary of Changes
This small PR change field type of the url field type to url, also add validate="url" to make sure a valid URL needs to be saved before the menu item can be saved.


### Testing Instructions
1. Create a menu item of Iframe Wrapper menu item type
2. Before patch: You can enter anything into URL
3. After patch: Only valid URL is accepted