### PR TITLE
Replace icon tag by icon info

### DIFF
--- a/components/com_contact/tmpl/contact/default.php
+++ b/components/com_contact/tmpl/contact/default.php
@@ -154,7 +154,7 @@ $canEdit = $canDo->get('core.edit') || ($canDo->get('core.edit.own') && $this->i
 			<dl class="dl-horizontal">
 				<dt>
 					<?php if (!$this->params->get('marker_misc')) : ?>
-						<span class="icon-tags" aria-hidden="true"></span>
+						<span class="icon-info-circle" aria-hidden="true"></span>
 						<span class="visually-hidden"><?php echo Text::_('COM_CONTACT_OTHER_INFORMATION'); ?></span>
 					<?php else : ?>
 						<span class="<?php echo $this->params->get('marker_class'); ?>">


### PR DESCRIPTION
Pull Request for Issue #32246 .

### Summary of Changes
Replace icon tag by icon-info-circle in miscellaneous information. 


### Testing Instructions
see #32246


### Actual result BEFORE applying this Pull Request
In single contact view, miscellaneous information has icon-tag. This is misleading. As it is hard to find an icon representign misc information,  I suggest icon-info-circle. 

### Expected result AFTER applying this Pull Request
![grafik](https://user-images.githubusercontent.com/1035262/107159630-adae7c80-6991-11eb-9425-d81c2309fc1e.png)



### Documentation Changes Required
screen 
