### PR TITLE
[4.0][WIP] Add fix to to repeatable fields plugin migration

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -252,6 +252,9 @@ class JoomlaInstallerScript
 			return;
 		}
 
+		// Ensure the FieldsHelper class is loaded for the Repeatable fields plugin we're about to remove
+		\JLoader::register('FieldsHelper', JPATH_ADMINISTRATOR . '/components/com_fields/helpers/fields.php');
+
 		try
 		{
 			$db->transactionStart();


### PR DESCRIPTION
Pull Request for Issue #30556 .

### Summary of Changes
WIP on fixing the release blocker above

### Testing Instructions
Create A repeatable article field in 3.10 and run the migration to 4.x following the instructions in https://www.joomla.org/announcements/release-news/5833-joomla-4-0-0-beta7-and-joomla-3-10-alpha5.html. Before patch fatal error. After the patch field migrated

### Documentation Changes Required
None
