### PR TITLE
[4.0] Update buttons.php layout to latest Bootstrap 5 markup, also added LEGEND markup

### DIFF
--- a/layouts/joomla/form/field/radio/buttons.php
+++ b/layouts/joomla/form/field/radio/buttons.php
@@ -48,6 +48,10 @@ $isBtnYesNo  = strpos(trim($class), 'btn-group-yesno') !== false;
 $classToggle = $isBtnGroup ? ' class="btn-check"' : '';
 $btnClass    = $isBtnGroup ? 'btn btn-outline-secondary' : 'form-check';
 
+// make sure both `btn-group` and `btn-group-yesno` class attribute values
+// both use same `btn-group` class, the .btn-group-yesno class does not exist
+$class = $isBtnYesNo ? str_replace('-yesno','', $class) : $class;
+
 // Add the attributes of the fieldset in an array
 $attribs = ['class="' . trim(
 		$class . ' radio' . ($readonly || $disabled ? ' disabled' : '') . ($readonly ? ' readonly' : '')

--- a/layouts/joomla/form/field/radio/buttons.php
+++ b/layouts/joomla/form/field/radio/buttons.php
@@ -48,10 +48,6 @@ $isBtnYesNo  = strpos(trim($class), 'btn-group-yesno') !== false;
 $classToggle = $isBtnGroup ? ' class="btn-check"' : '';
 $btnClass    = $isBtnGroup ? 'btn btn-outline-secondary' : 'form-check';
 
-// make sure both `btn-group` and `btn-group-yesno` class attribute values
-// both use same `btn-group` class, the .btn-group-yesno class does not exist
-$class = $isBtnYesNo ? str_replace('-yesno', '', $class) : $class;
-
 // Add the attributes of the fieldset in an array
 $attribs = ['class="' . trim(
 		$class . ' radio' . ($readonly || $disabled ? ' disabled' : '') . ($readonly ? ' readonly' : '')
@@ -83,6 +79,9 @@ if ($dataAttribute)
 }
 ?>
 <fieldset id="<?php echo $id; ?>" >
+	<legend class="radio__legend visually-hidden">
+		<?php echo $label; ?>
+	</legend>
 	<div <?php echo implode(' ', $attribs); ?>>
 		<?php foreach ($options as $i => $option) : ?>
 			<?php

--- a/layouts/joomla/form/field/radio/buttons.php
+++ b/layouts/joomla/form/field/radio/buttons.php
@@ -50,7 +50,7 @@ $btnClass    = $isBtnGroup ? 'btn btn-outline-secondary' : 'form-check';
 
 // make sure both `btn-group` and `btn-group-yesno` class attribute values
 // both use same `btn-group` class, the .btn-group-yesno class does not exist
-$class = $isBtnYesNo ? str_replace('-yesno','', $class) : $class;
+$class = $isBtnYesNo ? str_replace('-yesno', '', $class) : $class;
 
 // Add the attributes of the fieldset in an array
 $attribs = ['class="' . trim(

--- a/layouts/joomla/form/field/radio/buttons.php
+++ b/layouts/joomla/form/field/radio/buttons.php
@@ -79,7 +79,7 @@ if ($dataAttribute)
 }
 ?>
 <fieldset id="<?php echo $id; ?>" >
-	<legend class="radio__legend visually-hidden">
+	<legend class="visually-hidden">
 		<?php echo $label; ?>
 	</legend>
 	<div <?php echo implode(' ', $attribs); ?>>

--- a/layouts/joomla/form/field/radio/buttons.php
+++ b/layouts/joomla/form/field/radio/buttons.php
@@ -104,7 +104,6 @@ if ($dataAttribute)
 				$optionClass = trim($optionClass . ' ' . $disabled);
 			}
 			$checked     = ((string) $option->value === $value) ? 'checked="checked"' : '';
-			$optionClass .= $checked ? ' active' : '';
 
 			// Initialize some JavaScript option attributes.
 			$onclick    = !empty($option->onclick) ? 'onclick="' . $option->onclick . '"' : '';
@@ -116,8 +115,8 @@ if ($dataAttribute)
 			<?php if ($required) : ?>
 				<?php $attributes[] = 'required'; ?>
 			<?php endif; ?>
+			<input<?php echo $classToggle; ?> type="radio" id="<?php echo $oid; ?>" name="<?php echo $name; ?>" value="<?php echo $ovalue; ?>" <?php echo implode(' ', $attributes); ?>>
 			<label for="<?php echo $oid; ?>" class="<?php echo trim($optionClass . ' ' . $style); ?>">
-				<input<?php echo $classToggle; ?> type="radio" id="<?php echo $oid; ?>" name="<?php echo $name; ?>" value="<?php echo $ovalue; ?>" <?php echo implode(' ', $attributes); ?>>
 				<?php echo $option->text; ?>
 			</label>
 		<?php endforeach; ?>


### PR DESCRIPTION
### Summary of Changes
Updated layout file according to Bootstrap 5 new markup
* the `active` class no longer required for the `<label>` element
* the `<input>` is no longer inside the `<label>` element
* the new markup requires no `bootstrap.Button` plugin functionality anymore, everything is pure CSS

Details on the updated markup
https://getbootstrap.com/docs/5.0/components/button-group/#checkbox-and-radio-button-groups

Pull Request for Issues #32366 and #32275.

### Testing Instructions
* Open `site/templates/cassiopeia/templateDetails.xml`
* Create a new field inside the `<fieldset name="advanced">`, here a quick example

```xml
<field
  name="my-radio"
  type="Radio"
  default="0"
  class="btn-group"
  label="Radio Test">
  <option value="0">Disabled</option>
  <option value="1">Enabled</option>
</field>
```
* Login to `site/administrator` 
* go to `System` -> `Site Template Styles` -> `Cassiopeia`
* Check the new `Radio Test`, it should work perfect

### Actual result BEFORE applying this Pull Request
The layout won't work with the new Bootstrap 5 CSS and Markup. The JavaScript for radio / checkboxes toggling has been deprecated in favor of a more traditional markup and adjusted CSS.

### Expected result AFTER applying this Pull Request
If instructed as above. or in any case of a `Radio` field used with `class="btn-group"` attribute, the radio input works properly in the sense that showcases the correct chosen option on any user selection.

### Notice
Due to the radio/checkboxes toggle functionality being deprecated in Bootstrap 5 (but replaced with a new CSS + Markup solution) we might need to check for any redundant JavaScript related.

### Documentation Changes Required
None