### PR TITLE
[4.0] [PHP 8] Fix PHP error "array_merge() does not accept unknown named parameters" for com_finder

### DIFF
--- a/components/com_finder/src/Model/SearchModel.php
+++ b/components/com_finder/src/Model/SearchModel.php
@@ -286,7 +286,7 @@ class SearchModel extends ListModel
 			return $query;
 		}
 
-		$included = call_user_func_array('array_merge', $this->includedTerms);
+		$included = call_user_func_array('array_merge', array_values($this->includedTerms));
 		$query->join('INNER', $this->_db->quoteName('#__finder_links_terms') . ' AS m ON m.link_id = l.link_id')
 			->where('m.term_id IN (' . implode(',', $included) . ')');
 


### PR DESCRIPTION
Pull Request for Issue #32370 .

### Summary of Changes

Use `array_values` to fix the array_merge call on PHP 8.

The same fix has been made at other places by other contributors.

Since com_finder was nearly completely rewritten in J4, this PR is made for the 4.0-dev branch and not for staging. In staging I don't see that part of code like it is here.

Thanks @breebee for reporting the issue and proposing the right fix.

### Testing Instructions

Have a current 4.0-dev branch or latest 4.0 nightly or latest Beta installation on a server with PHP version 8.

Have a smart search module on the site. If you don't have that because it's a new installation, just install "Sample Data Blog".

In Global Configuration in admin, switch on "Debug System" to see PHP errors and set error reporting to "Maximum".

Use the smart search module on the site.

### Actual result BEFORE applying this Pull Request

![2021-02-10_01](https://user-images.githubusercontent.com/7413183/107485821-92579300-6b84-11eb-9927-40ca639efaf5.png)

### Expected result AFTER applying this Pull Request

![2021-02-10_02](https://user-images.githubusercontent.com/7413183/107485832-971c4700-6b84-11eb-9edb-92b1a9cf9d2e.png)

### Documentation Changes Required

None.