### PR TITLE
[4.0] Don't attempt to open an empty path

### DIFF
--- a/libraries/src/Filter/InputFilter.php
+++ b/libraries/src/Filter/InputFilter.php
@@ -298,7 +298,7 @@ class InputFilter extends BaseInputFilter
 					|| $options['shorttag_in_content'] || $options['phar_stub_in_content']
 					|| ($options['fobidden_ext_in_content'] && !empty($options['forbidden_extensions'])))
 				{
-					$fp = @fopen($tempName, 'r');
+					$fp = strlen($tempName) ? @fopen($tempName, 'r') : false;
 
 					if ($fp !== false)
 					{


### PR DESCRIPTION
Pull Request for Issue #32277 .

### Summary of Changes
Check that we have a `$tempName` because fopen('') throws an error on PHP 8


### Testing Instructions
Described in #32277 - I have also added a component that can be installed to easily test this happening.
[com_uploadtest.zip](https://github.com/joomla/joomla-cms/files/5957839/com_uploadtest.zip)

- Install com_uploadtest.zip
- Go to Components - Upload Test
- Don't select a file
- Press Send


### Actual result BEFORE applying this Pull Request
An error has occurred.

    0 Path cannot be empty 


### Expected result AFTER applying this Pull Request
Successful redirect with 'No file was sent' message.


### Documentation Changes Required
None
