### PR TITLE
[4.0] Updated switcher.php layout and its corresponding scss files

### DIFF
--- a/administrator/templates/atum/scss/blocks/_form.scss
+++ b/administrator/templates/atum/scss/blocks/_form.scss
@@ -57,12 +57,6 @@
 
 }
 
-.control-group {
-  .switcher__legend {
-    font-size: $label-font-size;
-  }
-}
-
 .spacer {
   hr {
     width: 380px;
@@ -149,12 +143,6 @@ legend {
 .container-popup [id="filter[search]-desc"] {
   top: 100%;
   bottom: auto;
-}
-
-.switcher__legend {
-  margin-bottom: 0;
-  font-size: $label-font-size;
-  color: var(--atum-special-color);
 }
 
 .input-group-append {

--- a/build/media_source/system/scss/fields/switcher.scss
+++ b/build/media_source/system/scss/fields/switcher.scss
@@ -100,10 +100,3 @@ $switcher-height: 28px;
 .switcher input ~ input:checked ~ .toggle-outside .toggle-inside {
   left: ($switcher-width / 2) - 1;
 }
-
-.switcher__legend {
-  padding: 5px 0;
-  margin-bottom: 1rem;
-  font-size: 1rem;
-  font-weight: 400;
-}

--- a/layouts/joomla/form/field/radio/switcher.php
+++ b/layouts/joomla/form/field/radio/switcher.php
@@ -68,7 +68,7 @@ $attr .= $dataAttribute;
 
 ?>
 <fieldset <?php echo $attr; ?>>
-	<legend class="switcher__legend visually-hidden">
+	<legend class="visually-hidden">
 		<?php echo $label; ?>
 	</legend>
 	<div class="switcher<?php echo ($readonly || $disabled ? ' disabled' : ''); ?>">


### PR DESCRIPTION
### Summary of Changes
Since the `<legend>` added to the switch field type is set to use `visually-hidden` class, with the self explanatory function, all the additional styling is redundant, hence we clean it up.

Pull Request for Issue https://github.com/joomla/joomla-cms/pull/32367#issuecomment-776805109 .

### Testing Instructions

Simplest way to test:
* go to `System` - `Site Template Styles` - `Cassiopeia`
* go to `Advanced` tab and inspect the `<legend>` element of the setting called `Layout`
* the `.switcher__legend` class should have no style before merging the #32367 into the 4.0 branch


### Actual result BEFORE applying this Pull Request
### Expected result AFTER applying this Pull Request
No visual or functional change is expected since the target element uses the `.visually-hidden` class


### Documentation Changes Required
No
