### PR TITLE
[4.0] Add missing change events

### DIFF
--- a/build/media_source/system/js/fields/joomla-field-media.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-media.w-c.es6.js
@@ -152,6 +152,11 @@
     setValue(value) {
       this.inputElement.value = value;
       this.updatePreview();
+
+      this.dispatchEvent(new CustomEvent('change', {
+        detail: { value },
+        bubbles: true,
+      }));
     }
 
     clearValue() {

--- a/build/media_source/system/js/fields/joomla-field-simple-color.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-simple-color.w-c.es6.js
@@ -365,6 +365,11 @@
       this.icon.setAttribute('class', clss);
       this.icon.style.backgroundColor = bgcolor;
 
+      this.dispatchEvent(new CustomEvent('change', {
+        detail: { value: color },
+        bubbles: true,
+      }));
+
       // Hide the panel
       this.hide();
 

--- a/build/media_source/system/js/fields/joomla-field-user.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-user.w-c.es6.js
@@ -140,7 +140,10 @@
       this.input.setAttribute('value', value);
       this.inputName.setAttribute('value', name || value);
       // trigger change event
-      this.input.dispatchEvent(new Event('change'));
+      this.dispatchEvent(new CustomEvent('change', {
+        detail: { value, name },
+        bubbles: true,
+      }));
     }
   }
 


### PR DESCRIPTION
Pull Request for Issue #21354 .

### Summary of Changes
Add missing change events for the fields `media`, `user` and `simple color`


### Testing Instructions
in your browser console (assuming Chrome) Selecet the HTML element for the field (eg `joomla-field-simple-color`) and in the console copy paste `$0.addEventListener('change', (ev) => console.log(ev));` Then select a color. Observe the console. Repeat for the other 2 fields


### Actual result BEFORE applying this Pull Request

No event triggered

### Expected result AFTER applying this Pull Request

Change Event triggered on each change

### Documentation Changes Required

