### PR TITLE
Fix batch menu items

### DIFF
--- a/administrator/components/com_menus/views/items/tmpl/default_batch_body.php
+++ b/administrator/components/com_menus/views/items/tmpl/default_batch_body.php
@@ -63,7 +63,7 @@ endif;
 						<option value=""><?php echo JText::_('JLIB_HTML_BATCH_NO_CATEGORY'); ?></option>
 						<?php
 						$opts     = array(
-							'published' => $published,
+							'published' => $this->state->get('filter.published'),
 							'checkacl'  => (int) $this->state->get('menutypeid'),
 							'clientid'  => (int) $clientId,
 						);


### PR DESCRIPTION
Pull Request for Issue #32375.

### Summary of Changes
This small PR fixes #32375.


### Testing Instructions
1. Access to Menus -> Main Menu
2. Select some menu items, then press Batch button in the toolbar
3. Before patch: On then popup, you only see unpublished menu item
4. After patch: Both published and unpublished menu items are being displayed