### PR TITLE
[4.0] Accessibility plugin language

### DIFF
--- a/plugins/system/accessibility/accessibility.php
+++ b/plugins/system/accessibility/accessibility.php
@@ -64,6 +64,9 @@ class PlgSystemAccessibility extends CMSPlugin
 		// Determine if it is an LTR or RTL language
 		$direction = Factory::getLanguage()->isRTL() ? 'right' : 'left';
 
+		// Detect the current active language
+		$lang = Factory::getLanguage()->getTag();
+
 		/**
 		* Add strings for translations in Javascript.
 		* Reference  https://ranbuch.github.io/accessibility/
@@ -99,6 +102,8 @@ class PlgSystemAccessibility extends CMSPlugin
 					'enabled' => true,
 					'helpTitles' => true,
 				],
+				'textToSpeechLang' => [$lang],
+				'speechToTextLang' => [$lang],
 			]
 		);
 


### PR DESCRIPTION
Adds support for different voices as requested

Pull Request for Issue #32381

The available languages are dependant on your browser. I have tested it with en-GB, en-US, fr-FR and de-DE on chrome for windows and all are available. And when I am using a non supported langauge it defaults to en-US (tested with persian)