### PR TITLE
[4.0] Pre-update Check

### DIFF
--- a/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_preupdatecheck.php
+++ b/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_preupdatecheck.php
@@ -208,7 +208,8 @@ $compatibilityTypes = array(
 		<h3>
 			<?php echo Text::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_EXTENSIONS'); ?>
 		</h3>
-		<div class="alert alert-no-items">
+		<div class="alert alert-info">
+			<span class="icon-info-circle" aria-hidden="true"></span><span class="visually-hidden"><?php echo Text::_('INFO'); ?></span>
 			<?php echo Text::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_EXTENSIONS_NONE'); ?>
 		</div>
 	</div>


### PR DESCRIPTION
In the joomla-update component there is a non existent class. Additionally the mark is not consistent with similar messages

To test set the update server to custom and the url to https://update.joomla.org/core/nightlies/next_major_list.xml

Assuming you have no extensions installed you will see the following message
![image](https://user-images.githubusercontent.com/1296369/107714947-1ebd9f00-6cc6-11eb-8231-0224e16ed6cd.png)

Apply the PR and you will see the following improved message
![image](https://user-images.githubusercontent.com/1296369/107714927-106f8300-6cc6-11eb-9249-37de7dc03fbd.png)
